### PR TITLE
Build fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /out/
 *.pyc
 gclient_config.py_entries
+Cargo.lock
 # npm deps
 node_modules
 

--- a/.gn
+++ b/.gn
@@ -23,6 +23,10 @@ default_args = {
   use_ozone = false
   use_udev = false
 
+  # TODO(ry) We may want to turn on CFI at some point. Disabling for simplicity
+  # for now. See http://clang.llvm.org/docs/ControlFlowIntegrity.html
+  is_cfi = false
+
   is_component_build = false
   symbol_level = 1
   treat_warnings_as_errors = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ branches:
 cache:
   ccache: true
   directories:
-   - $DENO_BUILD_PATH
    - $CARGO_PATH
    - $RUSTUP_PATH
+   - third_party/v8/build/linux/debian_sid_amd64-sysroot/
+   - third_party/v8/third_party/llvm-build/
 env:
   global:
     - CARGO_PATH=$HOME/.cargo/

--- a/gclient_config.py
+++ b/gclient_config.py
@@ -9,6 +9,7 @@ solutions = [{
         'v8/tools/swarming_client': None,
         'v8/third_party/instrumented_libraries': None,
         'v8/third_party/android_tools': None,
+        'v8/third_party/depot_tools': None,
         'v8/test/wasm-js': None,
         'v8/test/benchmarks/data': None,
         'v8/test/mozilla/data': None,


### PR DESCRIPTION
Fixes @Pato91's [Linux/release issue](https://github.com/denoland/deno/issues/438#issuecomment-410939516).

Removes the redundant `//third_party/v8/third_party/depot_tools`. People may have to run setup.py after this commit.