### PR TITLE
Make build and setup python 3 syntax compatible

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python
 # Copyright 2018 the Deno authors. All rights reserved. MIT license.
+from __future__ import print_function
 import os
 import sys
 from os.path import join
 import third_party
 from util import root_path, run, run_output, build_path
 
+
+if sys.version_info[0] > 2:
+    print("Deno build script requires python 2.")
+    sys.exit(1)
+
 third_party.fix_symlinks()
 
-print "DENO_BUILD_PATH:", build_path()
+print("DENO_BUILD_PATH:", build_path())
 if not os.path.isdir(build_path()):
-    print "DENO_BUILD_PATH does not exist. Run tools/setup.py"
+    print("DENO_BUILD_PATH does not exist. Run tools/setup.py")
     sys.exit(1)
 os.chdir(build_path())
 

--- a/tools/check_output_test.py
+++ b/tools/check_output_test.py
@@ -4,6 +4,7 @@
 # .out file which specifies what the stdout should be.
 #
 # Usage: check_output_test.py [path to deno executable]
+from __future__ import print_function
 import os
 import sys
 import subprocess
@@ -26,18 +27,18 @@ def check_output_test(deno_exe_filename):
         with open(out_abs, 'r') as f:
             expected_out = f.read()
         cmd = [deno_exe_filename, script_abs]
-        print " ".join(cmd)
+        print(" ".join(cmd))
         try:
             actual_out = subprocess.check_output(cmd, universal_newlines=True)
         except subprocess.CalledProcessError as e:
-            print "Got non-zero exit code. Output:"
-            print e.output
+            print("Got non-zero exit code. Output:")
+            print(e.output)
             sys.exit(1)
 
         if expected_out != actual_out:
-            print "Expected output does not match actual."
-            print "Expected: " + expected_out
-            print "Actual:   " + actual_out
+            print("Expected output does not match actual.")
+            print("Expected: " + expected_out)
+            print("Actual:   " + actual_out)
             sys.exit(1)
 
 

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import third_party
 from util import run, build_path, build_mode
 import os
 import distutils.spawn
+import sys
+
+if sys.version_info[0] > 2:
+    print("Deno setup script requires python 2.")
+    sys.exit(1)
 
 third_party.fix_symlinks()
 third_party.download_gn()
@@ -17,7 +23,7 @@ def get_gn_args():
     elif build_mode() == "debug":
         pass
     else:
-        print "Bad mode {}. Use 'release' or 'debug' (default)" % build_mode()
+        print("Bad mode {}. Use 'release' or 'debug' (default)" % build_mode())
         sys.exit(1)
     if "DENO_BUILD_ARGS" in os.environ:
         out += os.environ["DENO_BUILD_ARGS"].split()
@@ -27,7 +33,7 @@ def get_gn_args():
     if ccache_path:
         out += [r'cc_wrapper="%s"' % ccache_path]
 
-    print "DENO_BUILD_ARGS:", out
+    print("DENO_BUILD_ARGS:", out)
 
     return out
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Runs the full test suite.
 # Usage: ./tools/test.py out/Debug
+from __future__ import print_function
 import os
 import sys
 from check_output_test import check_output_test
@@ -9,14 +10,14 @@ from util import executable_suffix, run
 
 def check_exists(filename):
     if not os.path.exists(filename):
-        print "Required target doesn't exist:", filename
-        print "Build target :all"
+        print("Required target doesn't exist:", filename)
+        print("Build target :all")
         sys.exit(1)
 
 
 def main(argv):
     if len(argv) != 2:
-        print "Usage: tools/test.py [build dir]"
+        print("Usage: tools/test.py [build dir]")
         sys.exit(1)
     build_dir = argv[1]
 

--- a/tools/util.py
+++ b/tools/util.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Ryan Dahl <ry@tinyclouds.org>
 # All rights reserved. MIT License.
+from __future__ import print_function
 import os
 import shutil
 import stat
@@ -22,7 +23,7 @@ def make_env(merge_env={}, env=None):
 def run(args, quiet=False, cwd=None, env=None, merge_env={}):
     args[0] = os.path.normpath(args[0])
     if not quiet:
-        print " ".join(args)
+        print(" ".join(args))
     env = make_env(env=env, merge_env=merge_env)
     shell = os.name == "nt"  # Run through shell to make .bat/.cmd files work.
     rc = subprocess.call(args, cwd=cwd, env=env, shell=shell)
@@ -33,7 +34,7 @@ def run(args, quiet=False, cwd=None, env=None, merge_env={}):
 def run_output(args, quiet=False, cwd=None, env=None, merge_env={}):
     args[0] = os.path.normpath(args[0])
     if not quiet:
-        print " ".join(args)
+        print(" ".join(args))
     env = make_env(env=env, merge_env=merge_env)
     shell = os.name == "nt"  # Run through shell to make .bat/.cmd files work.
     return subprocess.check_output(args, cwd=cwd, env=env, shell=shell)


### PR DESCRIPTION
Both should **not** be run on python 3 however since v8 build scripts require python 2 (for now?).
This exits with status 1 with a message stating this, rather than a syntax error.

Note: I used [futurize](http://python-future.org/) to insert `__future__` import and update prints.

xlink: #464