### PR TITLE
Use sourcemapFile to reroot sourcemap sources

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -264,6 +264,8 @@ run_node("bundle") {
     rebase_path("js/main.ts", root_build_dir),
     "-o",
     rebase_path(out_dir + "main.js", root_build_dir),
+    "--sourcemapFile",
+    rebase_path("."),
     "--silent",
     "--environment",
     "BASEPATH:" + rebase_path(".", root_build_dir),


### PR DESCRIPTION
While it isn't perfect (.e.g. something like `$deno$/js/main.ts`), outside of actually re-writing the source-map, this is what we can get:

```
$ ./out/debug/deno ./tests/008_stack_trace.ts
Error: exception from mod1
    at Object.throwsError (file:///Users/kkelly/github/deno/tests/subdir/mod1.ts:16:9)
    at foo (file:///Users/kkelly/github/deno/tests/008_stack_trace.ts:4:3)
    at eval (file:///Users/kkelly/github/deno/tests/008_stack_trace.ts:7:1)
    at localDefine (deno/js/runtime.ts:157:5)
    at eval (/Users/kkelly/github/deno/tests/008_stack_trace.ts, <anonymous>)
    at eval (<anonymous>)
    at execute (deno/js/runtime.ts:219:3)
    at FileModule.compileAndRun (deno/js/runtime.ts:114:5)
    at denoMain (deno/js/main.ts:56:7)
    at deno_main.js:1:1
```

Resolves #461 