### PR TITLE
Travis changes, publish from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ cache:
    - $CARGO_PATH
    - $RUSTUP_PATH
    - $DENO_BUILD_PATH
-   - third_party/v8/build/linux/debian_sid_amd64-sysroot/
-   - third_party/v8/third_party/llvm-build/
+   - third_party
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,24 +49,22 @@ jobs:
 
     - stage: release
       if: tag IS present
-      script: true # skip script
-      before_deploy: |
+      script: |
         # build release binary
         env DENO_BUILD_ARGS="use_custom_libcxx=false use_sysroot=false" \
           DENO_BUILD_MODE=release \
           ./tools/build.py -j2
-
         # test release binary
         env DENO_BUILD_MODE=release ./tools/tests.py
-
+      before_deploy: |
         # gzip and name release to denote platform
-        gzip -c $DENO_BUILD_PATH/deno > $DENO_BUILD_PATH/deno-linux.gz
+        gzip -c $DENO_BUILD_PATH/deno > $DENO_BUILD_PATH/deno_linux_x64.gz
       deploy:
         provider: releases
         skip_cleanup: true
         api_key:
           secure: nm/XSUqQkucsgrTqHhZvVzzGrNsiagQyvy4ozqIcuI9BIENJ7upV2HKy0q+lE0j3iwTLXEVFEQ40hnG166nVTgVjIpxoGcVZvMTqAQFus9gVzbA71fAfAQL+nVlIRsdrSJOvsz1BHLKUgZ7UwyciApduaBDgm+mwXtMty5SHDotTc6mX4bz4UceMG4W7WXFcrWwWz+oFz9r8rYW1aKXcCQOms8eshbCtA3LzJtzUIN9NCE+bWf7QGRtz65aKy26MA/mTEAivQQ/J3ueXn4BzulpATHaSwOy5bvc2HGq5YjVJk1RQI7wqr4ONAtFWyMNAxB4JJ+g1XcN6oscoelpQgVWM2GxEblOZ+HSZAhpYiUuCQiKVe4eF238VQpn0BKw1dPEj1UWf5DHUMdcDFxeBfv1vIge5qhb+fpJTGKXfy91+DlwzM+JMBwqkXnuPFoPbh1lDLDKWB8UPGt07o+Y6tdZytr82kCoMaaHFqAVXYb0iBvG0Bw3WfzpwUsURGU08rw1pFnofnC74IyHGbcJ/+u39GzWTlCNGKce7OgEn16MzGe8QzpVmnO5+WX/uBhDHUyvDZkZHGZWHi19gQaUqDlZ4F3lSe4LMgpjEN23Ovv4AWT8bD2lbVr0XhsMlrcMw5n+RhjNDgadDw3dV9F2MHlZBpp1kYNaVqDkv5nIltYA=
-        file: "$DENO_BUILD_PATH/deno-linux.gz"
+        file: "$DENO_BUILD_PATH/deno_linux_x64.gz"
         on:
           tags: true
           repo: denoland/deno

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   include:
-    - stage: precache and build
+    - stage: precache
       before_install: |
         # Install Rust.
         # TODO(ry) Include rustc in third_party https://github.com/denoland/deno/issues/386
@@ -42,13 +42,13 @@ jobs:
         - export CCACHE_SLOPPINESS=time_macros
         - ccache -s
         - ./tools/setup.py
-        # Travis hangs without -j2 argument to ninja.
-        - ./tools/build.py -j2
 
     - stage: lint
       script: ./tools/lint.py
 
     - stage: test
+      # Travis hangs without -j2 argument to ninja.
+      before_script: ./tools/build.py -j2
       script: ./tools/test.py $DENO_BUILD_PATH
 
     - stage: release

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,16 +51,22 @@ jobs:
       if: tag IS present
       script: true # skip script
       before_deploy: |
+        # build release binary
         env DENO_BUILD_ARGS="use_custom_libcxx=false use_sysroot=false" \
           DENO_BUILD_MODE=release \
           ./tools/build.py -j2
-          cp $DENO_BUILD_PATH/deno $DENO_BUILD_PATH/deno-linux
+
+        # test release binary
+        env DENO_BUILD_MODE=release ./tools/tests.py
+
+        # gzip and name release to denote platform
+        gzip -c $DENO_BUILD_PATH/deno > $DENO_BUILD_PATH/deno-linux.gz
       deploy:
         provider: releases
         skip_cleanup: true
         api_key:
           secure: nm/XSUqQkucsgrTqHhZvVzzGrNsiagQyvy4ozqIcuI9BIENJ7upV2HKy0q+lE0j3iwTLXEVFEQ40hnG166nVTgVjIpxoGcVZvMTqAQFus9gVzbA71fAfAQL+nVlIRsdrSJOvsz1BHLKUgZ7UwyciApduaBDgm+mwXtMty5SHDotTc6mX4bz4UceMG4W7WXFcrWwWz+oFz9r8rYW1aKXcCQOms8eshbCtA3LzJtzUIN9NCE+bWf7QGRtz65aKy26MA/mTEAivQQ/J3ueXn4BzulpATHaSwOy5bvc2HGq5YjVJk1RQI7wqr4ONAtFWyMNAxB4JJ+g1XcN6oscoelpQgVWM2GxEblOZ+HSZAhpYiUuCQiKVe4eF238VQpn0BKw1dPEj1UWf5DHUMdcDFxeBfv1vIge5qhb+fpJTGKXfy91+DlwzM+JMBwqkXnuPFoPbh1lDLDKWB8UPGt07o+Y6tdZytr82kCoMaaHFqAVXYb0iBvG0Bw3WfzpwUsURGU08rw1pFnofnC74IyHGbcJ/+u39GzWTlCNGKce7OgEn16MzGe8QzpVmnO5+WX/uBhDHUyvDZkZHGZWHi19gQaUqDlZ4F3lSe4LMgpjEN23Ovv4AWT8bD2lbVr0XhsMlrcMw5n+RhjNDgadDw3dV9F2MHlZBpp1kYNaVqDkv5nIltYA=
-        file: "$DENO_BUILD_PATH/deno-linux"
+        file: "$DENO_BUILD_PATH/deno-linux.gz"
         on:
           tags: true
           repo: denoland/deno

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,9 @@ jobs:
       deploy:
         provider: releases
         skip_cleanup: true
-        api_key: $GITHUB_RELEASE_KEY
+        api_key:
+          secure: nm/XSUqQkucsgrTqHhZvVzzGrNsiagQyvy4ozqIcuI9BIENJ7upV2HKy0q+lE0j3iwTLXEVFEQ40hnG166nVTgVjIpxoGcVZvMTqAQFus9gVzbA71fAfAQL+nVlIRsdrSJOvsz1BHLKUgZ7UwyciApduaBDgm+mwXtMty5SHDotTc6mX4bz4UceMG4W7WXFcrWwWz+oFz9r8rYW1aKXcCQOms8eshbCtA3LzJtzUIN9NCE+bWf7QGRtz65aKy26MA/mTEAivQQ/J3ueXn4BzulpATHaSwOy5bvc2HGq5YjVJk1RQI7wqr4ONAtFWyMNAxB4JJ+g1XcN6oscoelpQgVWM2GxEblOZ+HSZAhpYiUuCQiKVe4eF238VQpn0BKw1dPEj1UWf5DHUMdcDFxeBfv1vIge5qhb+fpJTGKXfy91+DlwzM+JMBwqkXnuPFoPbh1lDLDKWB8UPGt07o+Y6tdZytr82kCoMaaHFqAVXYb0iBvG0Bw3WfzpwUsURGU08rw1pFnofnC74IyHGbcJ/+u39GzWTlCNGKce7OgEn16MzGe8QzpVmnO5+WX/uBhDHUyvDZkZHGZWHi19gQaUqDlZ4F3lSe4LMgpjEN23Ovv4AWT8bD2lbVr0XhsMlrcMw5n+RhjNDgadDw3dV9F2MHlZBpp1kYNaVqDkv5nIltYA=
         file: "$DENO_BUILD_PATH/deno"
         on:
           tags: true
+          repo: denoland/deno

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,33 +25,30 @@ cache:
   directories:
    - $CARGO_PATH
    - $RUSTUP_PATH
-   - $DENO_BUILD_PATH
-   - third_party
+   - third_party/v8/build/linux/debian_sid_amd64-sysroot/
+   - third_party/v8/third_party/llvm-build/
+
+install: |
+  # Install Rust.
+  # TODO(ry) Include rustc in third_party https://github.com/denoland/deno/issues/386
+  rustc --version
+  if [ $? != 0 ]; then
+    curl -sSf https://sh.rustup.rs | sh -s -- -y
+  fi
+before_script:
+  - ccache -s
+  - ./tools/setup.py
+script:
+  - ./tools/lint.py
+  - ./tools/build.py -j2
+  - ./tools/test.py $DENO_BUILD_PATH
 
 jobs:
   include:
-    - stage: precache
-      before_script: |
-        # Install Rust.
-        # TODO(ry) Include rustc in third_party https://github.com/denoland/deno/issues/386
-        rustc --version
-        if [ $? != 0 ]; then
-          curl -sSf https://sh.rustup.rs | sh -s -- -y
-        fi
-      script:
-        - ccache -s
-        - ./tools/setup.py
-
-    - stage: lint
-      script: ./tools/lint.py
-
     - stage: test
-      # Travis hangs without -j2 argument to ninja.
-      before_script: ./tools/build.py -j2
-      script: ./tools/test.py $DENO_BUILD_PATH
 
     - stage: release
-      script: true
+      script: true # skip script
       before_deploy: |
         env DENO_BUILD_ARGS="use_custom_libcxx=false use_sysroot=false" \
           DENO_BUILD_MODE=release \

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,5 @@ jobs:
         skip_cleanup: true
         api_key: $GITHUB_RELEASE_KEY
         file: "$DENO_BUILD_PATH/deno"
+        on:
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   include:
     - stage: precache
-      before_install: |
+      before_script: |
         # Install Rust.
         # TODO(ry) Include rustc in third_party https://github.com/denoland/deno/issues/386
         export PATH=$CARGO_PATH/bin:$PATH
@@ -35,7 +35,7 @@ jobs:
         if [ $? != 0 ]; then
           curl -sSf https://sh.rustup.rs | sh -s -- -y
         fi
-      install:
+      script:
         # ccache needs the custom LLVM to be in PATH and other variables.
         - export PATH=`pwd`/third_party/llvm-build/Release+Asserts/bin:$PATH
         - export CCACHE_CPP2=yes
@@ -52,6 +52,7 @@ jobs:
       script: ./tools/test.py $DENO_BUILD_PATH
 
     - stage: release
+      script: true
       before_deploy: |
         env DENO_BUILD_ARGS="use_custom_libcxx=false use_sysroot=false" \
           DENO_BUILD_PATH=$HOME/out/release \

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: c++
+
 branches:
   only:
   - master
+
 cache:
   ccache: true
   directories:
@@ -9,6 +11,7 @@ cache:
    - $RUSTUP_PATH
    - third_party/v8/build/linux/debian_sid_amd64-sysroot/
    - third_party/v8/third_party/llvm-build/
+
 env:
   global:
     - CARGO_PATH=$HOME/.cargo/
@@ -20,23 +23,42 @@ env:
     - DENO_BUILD_ARGS="is_debug=false use_allocator=\"none\" use_custom_libcxx=false use_sysroot=false"
     - DENO_BUILD_PATH=$HOME/out/Default
     - DENO_BUILD_MODE=debug
-before_install: |
-  # Install Rust.
-  # TODO(ry) Include rustc in third_party https://github.com/denoland/deno/issues/386
-  export PATH=$CARGO_PATH/bin:$PATH
-  rustc --version
-  if [ $? != 0 ]; then
-    curl -sSf https://sh.rustup.rs | sh -s -- -y
-  fi
-install:
- # ccache needs the custom LLVM to be in PATH and other variables.
- - export PATH=`pwd`/third_party/llvm-build/Release+Asserts/bin:$PATH
- - export CCACHE_CPP2=yes
- - export CCACHE_SLOPPINESS=time_macros
- - ccache -s
- - ./tools/setup.py
- # Travis hangs without -j2 argument to ninja.
- - ./tools/build.py -j2
-script:
- - ./tools/lint.py
- - ./tools/test.py $DENO_BUILD_PATH
+
+jobs:
+  include:
+    - stage: precache and build
+      before_install: |
+        # Install Rust.
+        # TODO(ry) Include rustc in third_party https://github.com/denoland/deno/issues/386
+        export PATH=$CARGO_PATH/bin:$PATH
+        rustc --version
+        if [ $? != 0 ]; then
+          curl -sSf https://sh.rustup.rs | sh -s -- -y
+        fi
+      install:
+        # ccache needs the custom LLVM to be in PATH and other variables.
+        - export PATH=`pwd`/third_party/llvm-build/Release+Asserts/bin:$PATH
+        - export CCACHE_CPP2=yes
+        - export CCACHE_SLOPPINESS=time_macros
+        - ccache -s
+        - ./tools/setup.py
+        # Travis hangs without -j2 argument to ninja.
+        - ./tools/build.py -j2
+
+    - stage: lint
+      script: ./tools/lint.py
+
+    - stage: test
+      script: ./tools/test.py $DENO_BUILD_PATH
+
+    - stage: release
+      before_deploy: |
+        env DENO_BUILD_ARGS="use_custom_libcxx=false use_sysroot=false" \
+          DENO_BUILD_PATH=$HOME/out/release \
+          DENO_BUILD_MODE=release \
+          ./tools/build.py -j2
+      deploy:
+        provider: releases
+        skip_cleanup: true
+        api_key: $GITHUB_RELEASE_KEY
+        file: "$HOME/out/release/deno"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,6 @@ branches:
   only:
   - master
 
-cache:
-  ccache: true
-  directories:
-   - $CARGO_PATH
-   - $RUSTUP_PATH
-   - third_party/v8/build/linux/debian_sid_amd64-sysroot/
-   - third_party/v8/third_party/llvm-build/
-
 env:
   global:
     - CARGO_PATH=$HOME/.cargo/
@@ -23,6 +15,15 @@ env:
     - DENO_BUILD_ARGS="is_debug=false use_allocator=\"none\" use_custom_libcxx=false use_sysroot=false"
     - DENO_BUILD_PATH=$HOME/out/Default
     - DENO_BUILD_MODE=debug
+
+cache:
+  ccache: true
+  directories:
+   - $CARGO_PATH
+   - $RUSTUP_PATH
+   - $DENO_BUILD_PATH
+   - third_party/v8/build/linux/debian_sid_amd64-sysroot/
+   - third_party/v8/third_party/llvm-build/
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ env:
     - DENO_BUILD_ARGS="is_debug=false use_allocator=\"none\" use_custom_libcxx=false use_sysroot=false"
     - DENO_BUILD_PATH=$HOME/out/Default
     - DENO_BUILD_MODE=debug
+    # ccache needs the custom LLVM to be in PATH and other variables.
+    - PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_PATH/bin:$PATH
+    - CCACHE_CPP2=yes
+    - CCACHE_SLOPPINESS=time_macros
 
 cache:
   ccache: true
@@ -30,16 +34,11 @@ jobs:
       before_script: |
         # Install Rust.
         # TODO(ry) Include rustc in third_party https://github.com/denoland/deno/issues/386
-        export PATH=$CARGO_PATH/bin:$PATH
         rustc --version
         if [ $? != 0 ]; then
           curl -sSf https://sh.rustup.rs | sh -s -- -y
         fi
       script:
-        # ccache needs the custom LLVM to be in PATH and other variables.
-        - export PATH=`pwd`/third_party/llvm-build/Release+Asserts/bin:$PATH
-        - export CCACHE_CPP2=yes
-        - export CCACHE_SLOPPINESS=time_macros
         - ccache -s
         - ./tools/setup.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,10 @@ jobs:
       script: true
       before_deploy: |
         env DENO_BUILD_ARGS="use_custom_libcxx=false use_sysroot=false" \
-          DENO_BUILD_PATH=$HOME/out/release \
           DENO_BUILD_MODE=release \
           ./tools/build.py -j2
       deploy:
         provider: releases
         skip_cleanup: true
         api_key: $GITHUB_RELEASE_KEY
-        file: "$HOME/out/release/deno"
+        file: "$DENO_BUILD_PATH/deno"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ jobs:
     - stage: test
 
     - stage: release
+      if: tag IS present
       script: true # skip script
       before_deploy: |
         env DENO_BUILD_ARGS="use_custom_libcxx=false use_sysroot=false" \

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,13 @@ jobs:
         env DENO_BUILD_ARGS="use_custom_libcxx=false use_sysroot=false" \
           DENO_BUILD_MODE=release \
           ./tools/build.py -j2
+          cp $DENO_BUILD_PATH/deno $DENO_BUILD_PATH/deno-linux
       deploy:
         provider: releases
         skip_cleanup: true
         api_key:
           secure: nm/XSUqQkucsgrTqHhZvVzzGrNsiagQyvy4ozqIcuI9BIENJ7upV2HKy0q+lE0j3iwTLXEVFEQ40hnG166nVTgVjIpxoGcVZvMTqAQFus9gVzbA71fAfAQL+nVlIRsdrSJOvsz1BHLKUgZ7UwyciApduaBDgm+mwXtMty5SHDotTc6mX4bz4UceMG4W7WXFcrWwWz+oFz9r8rYW1aKXcCQOms8eshbCtA3LzJtzUIN9NCE+bWf7QGRtz65aKy26MA/mTEAivQQ/J3ueXn4BzulpATHaSwOy5bvc2HGq5YjVJk1RQI7wqr4ONAtFWyMNAxB4JJ+g1XcN6oscoelpQgVWM2GxEblOZ+HSZAhpYiUuCQiKVe4eF238VQpn0BKw1dPEj1UWf5DHUMdcDFxeBfv1vIge5qhb+fpJTGKXfy91+DlwzM+JMBwqkXnuPFoPbh1lDLDKWB8UPGt07o+Y6tdZytr82kCoMaaHFqAVXYb0iBvG0Bw3WfzpwUsURGU08rw1pFnofnC74IyHGbcJ/+u39GzWTlCNGKce7OgEn16MzGe8QzpVmnO5+WX/uBhDHUyvDZkZHGZWHi19gQaUqDlZ4F3lSe4LMgpjEN23Ovv4AWT8bD2lbVr0XhsMlrcMw5n+RhjNDgadDw3dV9F2MHlZBpp1kYNaVqDkv5nIltYA=
-        file: "$DENO_BUILD_PATH/deno"
+        file: "$DENO_BUILD_PATH/deno-linux"
         on:
           tags: true
           repo: denoland/deno


### PR DESCRIPTION
this is an alternative take on #485 

- splits CI into precache, lint, test, and release stages. matrix expansions can apply these stages further down the line for different platforms, etc. https://docs.travis-ci.com/user/build-stages/matrix-expansion/
- no conditions are set on the `release` stage yet, but that can be added https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#conditional-stages

See https://travis-ci.com/bobheadxi/deno

~I'm not completely familiar with the deno build scripts yet so this is still pretty wip, am attempting to publish to my fork currently - any feedback would be appreciated and i'd be happy to make any changes requested~

Release: https://github.com/bobheadxi/deno/releases
