### PR TITLE
Only emit declarations for generated files

### DIFF
--- a/js/tsconfig.generated.json
+++ b/js/tsconfig.generated.json
@@ -7,6 +7,7 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true
   },
   "files": [
     "../node_modules/typescript/lib/lib.esnext.d.ts",

--- a/js/tsconfig.generated.json
+++ b/js/tsconfig.generated.json
@@ -6,7 +6,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true
   },
   "files": [


### PR DESCRIPTION
I forgot this was a _thing_ until I was reviewing stuff.

`--emitDeclarationOnly` causes just the `.d.ts` files to be output, which are the only things we are inlining in the `assets.ts` anyways.  So slightly more efficient and slightly safer that unused code is not generated during the build.
