### PR TITLE
Support strict mode

### DIFF
--- a/js/main.ts
+++ b/js/main.ts
@@ -72,5 +72,7 @@ export default function denoMain() {
 
   const inputFn = argv[1];
   const mod = runtime.resolveModule(inputFn, `${cwd}/`);
-  mod.compileAndRun();
+  assert(mod != null);
+  // TypeScript does not track assert, therefore not null assertion
+  mod!.compileAndRun();
 }

--- a/js/os.ts
+++ b/js/os.ts
@@ -37,11 +37,14 @@ export function codeFetch(
   fbs.Base.addMsgType(builder, fbs.Any.CodeFetch);
   builder.finish(fbs.Base.endBase(builder));
   const resBuf = libdeno.send(builder.asUint8Array());
+  assert(resBuf != null);
   // Process CodeFetchRes
-  const bb = new flatbuffers.ByteBuffer(new Uint8Array(resBuf));
+  // TypeScript does not track `assert` from a CFA perspective, therefore not
+  // null assertion `!`
+  const bb = new flatbuffers.ByteBuffer(new Uint8Array(resBuf!));
   const baseRes = fbs.Base.getRootAsBase(bb);
   if (fbs.Any.NONE === baseRes.msgType()) {
-    throw Error(baseRes.error());
+    throw Error(baseRes.error()!);
   }
   assert(fbs.Any.CodeFetchRes === baseRes.msgType());
   const codeFetchRes = new fbs.CodeFetchRes();
@@ -80,7 +83,9 @@ export function codeCache(
     const bb = new flatbuffers.ByteBuffer(new Uint8Array(resBuf));
     const baseRes = fbs.Base.getRootAsBase(bb);
     assert(fbs.Any.NONE === baseRes.msgType());
-    throw Error(baseRes.error());
+    // undefined and null are incompatible in strict mode, but at runtime
+    // a null value is fine, therefore not null assertion
+    throw Error(baseRes.error()!);
   }
 }
 
@@ -103,16 +108,20 @@ export function readFileSync(filename: string): Uint8Array {
   builder.finish(fbs.Base.endBase(builder));
   const resBuf = libdeno.send(builder.asUint8Array());
   assert(resBuf != null);
-
-  const bb = new flatbuffers.ByteBuffer(new Uint8Array(resBuf));
+  // TypeScript does not track `assert` from a CFA perspective, therefore not
+  // null assertion `!`
+  const bb = new flatbuffers.ByteBuffer(new Uint8Array(resBuf!));
   const baseRes = fbs.Base.getRootAsBase(bb);
   if (fbs.Any.NONE === baseRes.msgType()) {
-    throw Error(baseRes.error());
+    // undefined and null are incompatible in strict mode, but at runtime
+    // a null value is fine, therefore not null assertion
+    throw Error(baseRes.error()!);
   }
   assert(fbs.Any.ReadFileSyncRes === baseRes.msgType());
   const res = new fbs.ReadFileSyncRes();
   assert(baseRes.msg(res) != null);
-  return new Uint8Array(res.dataArray());
+  // TypeScript cannot track assertion above, therefore not null assertion
+  return new Uint8Array(res.dataArray()!);
 }
 
 export function writeFileSync(

--- a/js/os.ts
+++ b/js/os.ts
@@ -120,8 +120,10 @@ export function readFileSync(filename: string): Uint8Array {
   assert(fbs.Any.ReadFileSyncRes === baseRes.msgType());
   const res = new fbs.ReadFileSyncRes();
   assert(baseRes.msg(res) != null);
+  const dataArray = res.dataArray();
+  assert(dataArray != null);
   // TypeScript cannot track assertion above, therefore not null assertion
-  return new Uint8Array(res.dataArray()!);
+  return new Uint8Array(dataArray!);
 }
 
 export function writeFileSync(

--- a/js/runtime.ts
+++ b/js/runtime.ts
@@ -130,7 +130,7 @@ export function makeDefine(fileName: string): AmdDefine {
     util.assert(currentModule != null);
     const localExports = currentModule!.exports;
     log("localDefine", fileName, deps, localExports);
-    const args = deps.map((dep) => {
+    const args = deps.map(dep => {
       if (dep === "require") {
         return localRequire;
       } else if (dep === "exports") {
@@ -289,7 +289,7 @@ class TypeScriptHost implements ts.LanguageServiceHost {
   getScriptVersion(fileName: string): string {
     util.log("getScriptVersion", fileName);
     const m = FileModule.load(fileName);
-    return m && m.scriptVersion || "";
+    return (m && m.scriptVersion) || "";
   }
 
   getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined {
@@ -344,23 +344,25 @@ class TypeScriptHost implements ts.LanguageServiceHost {
     containingFile: string
   ): ts.ResolvedModule[] {
     //util.log("resolveModuleNames", { moduleNames, reusedNames });
-    return moduleNames.map((name) => {
-      let resolvedFileName;
-      if (name === "deno") {
-        resolvedFileName = resolveModuleName("deno.d.ts", ASSETS);
-      } else if (name === "typescript") {
-        resolvedFileName = resolveModuleName("typescript.d.ts", ASSETS);
-      } else {
-        resolvedFileName = resolveModuleName(name, containingFile);
-      }
-      if (resolvedFileName == null) {
-        return undefined;
-      }
-      // This flags to the compiler to not go looking to transpile functional
-      // code, anything that is in `/$asset$/` is just library code
-      const isExternalLibraryImport = resolvedFileName.startsWith(ASSETS);
-      return { resolvedFileName, isExternalLibraryImport };
-    }).filter((mod) => mod != null) as ts.ResolvedModule[];
+    return moduleNames
+      .map(name => {
+        let resolvedFileName;
+        if (name === "deno") {
+          resolvedFileName = resolveModuleName("deno.d.ts", ASSETS);
+        } else if (name === "typescript") {
+          resolvedFileName = resolveModuleName("typescript.d.ts", ASSETS);
+        } else {
+          resolvedFileName = resolveModuleName(name, containingFile);
+        }
+        if (resolvedFileName == null) {
+          return undefined;
+        }
+        // This flags to the compiler to not go looking to transpile functional
+        // code, anything that is in `/$asset$/` is just library code
+        const isExternalLibraryImport = resolvedFileName.startsWith(ASSETS);
+        return { resolvedFileName, isExternalLibraryImport };
+      })
+      .filter(mod => mod != null) as ts.ResolvedModule[];
   }
 }
 

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -2,10 +2,10 @@
 export type TypedArray = Uint8Array | Float32Array | Int32Array;
 
 export interface ModuleInfo {
-  moduleName?: string;
-  filename?: string;
-  sourceCode?: string;
-  outputCode?: string;
+  moduleName: string | null;
+  filename: string | null;
+  sourceCode: string | null;
+  outputCode: string | null;
 }
 
 // Following definitions adapted from:

--- a/js/util.ts
+++ b/js/util.ts
@@ -49,15 +49,20 @@ export function arrayToStr(ui8: Uint8Array): string {
 // produces broken code when targeting ES5 code.
 // See https://github.com/Microsoft/TypeScript/issues/15202
 // At the time of writing, the github issue is closed but the problem remains.
-export interface Resolvable<T> extends Promise<T> {
+export interface ResolvableMethods<T> {
   resolve: (value?: T | PromiseLike<T>) => void;
   // tslint:disable-next-line:no-any
   reject: (reason?: any) => void;
 }
+
+type Resolvable<T> = Promise<T> & ResolvableMethods<T>;
+
 export function createResolvable<T>(): Resolvable<T> {
-  let methods;
+  let methods: ResolvableMethods<T>;
   const promise = new Promise<T>((resolve, reject) => {
     methods = { resolve, reject };
   });
-  return Object.assign(promise, methods) as Resolvable<T>;
+  // TypeScript doesn't know that the Promise callback occurs synchronously
+  // therefore use of not null assertion (`!`)
+  return Object.assign(promise, methods!) as Resolvable<T>;
 }

--- a/js/v8_source_maps.ts
+++ b/js/v8_source_maps.ts
@@ -40,7 +40,7 @@ export function prepareStackTraceWrapper(
   try {
     return prepareStackTrace(error, stack);
   } catch (prepareStackError) {
-    Error.prepareStackTrace = null;
+    Error.prepareStackTrace = undefined;
     console.log("=====Error inside of prepareStackTrace====");
     console.log(prepareStackError.stack.toString());
     console.log("=====Original error=======================");
@@ -66,8 +66,8 @@ export function wrapCallSite(frame: CallSite): CallSite {
   const source = frame.getFileName() || frame.getScriptNameOrSourceURL();
 
   if (source) {
-    const line = frame.getLineNumber();
-    const column = frame.getColumnNumber() - 1;
+    const line = frame.getLineNumber() || 0;
+    const column = (frame.getColumnNumber() || 1) - 1;
     const position = mapSourcePosition({ source, line, column });
     frame = cloneCallSite(frame);
     frame.getFileName = () => position.source;
@@ -79,7 +79,7 @@ export function wrapCallSite(frame: CallSite): CallSite {
   }
 
   // Code called using eval() needs special handling
-  let origin = frame.isEval() && frame.getEvalOrigin();
+  let origin = frame.isEval() && frame.getEvalOrigin() || undefined;
   if (origin) {
     origin = mapEvalOrigin(origin);
     frame = cloneCallSite(frame);
@@ -115,7 +115,7 @@ function CallSiteToString(frame: CallSite): string {
   } else {
     fileName = frame.getScriptNameOrSourceURL();
     if (!fileName && frame.isEval()) {
-      fileLocation = frame.getEvalOrigin();
+      fileLocation = frame.getEvalOrigin() || "";
       fileLocation += ", "; // Expecting source position to follow.
     }
 
@@ -181,7 +181,7 @@ function CallSiteToString(frame: CallSite): string {
 // Regex for detecting source maps
 const reSourceMap = /^data:application\/json[^,]+base64,/;
 
-function loadConsumer(source: string): SourceMapConsumer {
+function loadConsumer(source: string): SourceMapConsumer | null {
   let consumer = consumers.get(source);
   if (consumer == null) {
     const code = getGeneratedContents(source);
@@ -221,7 +221,7 @@ function loadConsumer(source: string): SourceMapConsumer {
   return consumer;
 }
 
-function retrieveSourceMapURL(fileData: string): string {
+function retrieveSourceMapURL(fileData: string): string | null {
   // Get the URL of the source map
   // tslint:disable-next-line:max-line-length
   const re = /(?:\/\/[@#][ \t]+sourceMappingURL=([^\s'"]+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^\*]+?)[ \t]*(?:\*\/)[ \t]*$)/gm;

--- a/js/v8_source_maps.ts
+++ b/js/v8_source_maps.ts
@@ -79,7 +79,7 @@ export function wrapCallSite(frame: CallSite): CallSite {
   }
 
   // Code called using eval() needs special handling
-  let origin = frame.isEval() && frame.getEvalOrigin() || undefined;
+  let origin = (frame.isEval() && frame.getEvalOrigin()) || undefined;
   if (origin) {
     origin = mapEvalOrigin(origin);
     frame = cloneCallSite(frame);
@@ -162,7 +162,7 @@ function CallSiteToString(frame: CallSite): string {
         line += ` [as ${methodName} ]`;
       }
     } else {
-      line += typeName + "." + (methodName || "<anonymous>");
+      line += `${typeName}.${methodName || "<anonymous>"}`;
     }
   } else if (isConstructor) {
     line += "new " + (functionName || "<anonymous>");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,10 @@
     "baseUrl": ".",
     "module": "esnext",
     "moduleResolution": "node",
-    "noImplicitAny": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noLib": true,
+    "noUnusedLocals": true,
     "paths": {
       "*": ["*", "out/debug/*", "out/default/*", "out/release/*"]
     },
@@ -15,6 +15,7 @@
     "pretty": true,
     "removeComments": true,
     "sourceMap": true,
+    "strict": true,
     "target": "esnext",
     "types": []
   },


### PR DESCRIPTION
Resolves #504 

This PR sets `--strict` when compiling the internal TypeScript for Deno and makes the necessary changes to support that.  There were a couple issues around strict null checking that were fixed, but most were cases where TypeScript could not determine that a value was defined, but it was _known_ to be defined.  In those cases I used the not null assertion operator (`!`) and inserted a comment.  Not all of my assumptions might of been accurate though.