### PR TITLE
Use `@internal` with js/timers.ts

### DIFF
--- a/js/assets.ts
+++ b/js/assets.ts
@@ -94,7 +94,4 @@ export const assetSourceCode: { [key: string]: string } = {
   // Static definitions
   "typescript.d.ts": typescriptDts,
   "types.d.ts": typesDts,
-
-  // TODO(ry) Remove the following when possible. It's a workaround.
-  "msg_generated.d.ts": "",
 };

--- a/js/timers.ts
+++ b/js/timers.ts
@@ -21,6 +21,7 @@ interface Timer {
 
 const timers = new Map<number, Timer>();
 
+/** @internal */
 export function onMessage(msg: fbs.TimerReady) {
   const timerReadyId = msg.id();
   const timerReadyDone = msg.done();

--- a/js/tsconfig.generated.json
+++ b/js/tsconfig.generated.json
@@ -6,7 +6,8 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "stripInternal": true
   },
   "files": [
     "../node_modules/typescript/lib/lib.esnext.d.ts",


### PR DESCRIPTION
Resolves #510 

Actually looking into more, it certainly seems like `timers.ts` only exports `onMessage` for testing purposes and therefore can be marked internal, which then elides the `gen/msg_generated` import.