### PR TITLE
Fix #404 (change :test_cc to v8_executable)

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -75,7 +75,7 @@ rust_test("test_rs") {
   ]
 }
 
-executable("test_cc") {
+v8_executable("test_cc") {
   testonly = true
   sources = [
     "src/flatbuffer_builder_test.cc",
@@ -86,7 +86,7 @@ executable("test_cc") {
     ":deno_flatbuffer_builder",
     "//testing/gtest:gtest",
   ]
-  configs += [ ":deno_config" ]
+  configs = [ ":deno_config" ]
 }
 
 static_library("libdeno") {


### PR DESCRIPTION
This resolves #404.

- The warnings seem caused by the difference of `-fvisibility` settings of linked targets.
  - https://stackoverflow.com/questions/9894961/strange-warnings-from-the-linker-ld
- BUILDCONFIG.gn sets the default as `-fvisibility=hidden` (in posix env) 
  - https://github.com/denoland/deno_third_party/blob/2dde8457b037a399f07106ccfc34382a80c469bb/v8/build/config/BUILDCONFIG.gn#L543-L548
- v8 targets override it with `-fvisibility=default` (in posix env)
  - https://github.com/denoland/deno_third_party/blob/2dde8457b037a399f07106ccfc34382a80c469bb/v8/gni/v8.gni#L116-L119
- `:test_cc` is declared as `executable` and it uses `-fvisibility=hidden` and other targets like `deno_base_test` or `deno_flatbuffer_builder` are declared as `v8_source_set` and they use `-fvisibility=default`. This seem causing the above warnings.

This PR changes `:test_cc` to v8_executable.