### PR TITLE
Add rust_treat_warnings_as_errors build arg

### DIFF
--- a/.gn
+++ b/.gn
@@ -30,6 +30,7 @@ default_args = {
   is_component_build = false
   symbol_level = 1
   treat_warnings_as_errors = false
+  rust_treat_warnings_as_errors = false
 
   # https://cs.chromium.org/chromium/src/docs/ccache_mac.md
   clang_use_chrome_plugins = false

--- a/build_extra/rust/rust.gni
+++ b/build_extra/rust/rust.gni
@@ -1,6 +1,9 @@
 declare_args() {
   # Absolute path of rust build files.
   rust_build = "//build_extra/rust/"
+
+  # treat the warnings in rust files as errors
+  rust_treat_warnings_as_errors = true
 }
 
 if (is_win) {
@@ -64,13 +67,15 @@ template("run_rustc") {
     outputs = []
     script = "//tools/run_rustc.py"
 
-    # TODO: We want to apply "-Dwarnings" only when treat_warnings_as_errors is not false
-    # https://github.com/denoland/deno/pull/379
     args = [
       rebase_path(source_root, root_build_dir),
       "--crate-name=$crate_name",
       "--crate-type=$crate_type",
     ]
+
+    if (rust_treat_warnings_as_errors) {
+      args += [ "-Dwarnings" ]
+    }
 
     if (!is_win) {
       args += [ "--color=always" ]


### PR DESCRIPTION
This PR resolves a TODO comment created in #379.

Since the build arg `treat_warnings_as_errors` is declared in [a BUILD.gn file](https://github.com/denoland/deno_third_party/blob/221e8d5662be4d7524e31bb7b647623f46ad53ce/v8/build/config/compiler/BUILD.gn#L44) (not a .gni file), I think it's not possible to reuse this arg in deno's .gn/.gni files. (If the arg were declared in `.gni` file, we could import and use it.)

So I suggest to introduce a new build arg `rust_treat_warnings_as_errors` for controlling the same thing as `treat_warnings_as_errors` for rust compilation.