### PR TITLE
Add yarn.lock to third_party

### DIFF
--- a/tools/third_party.py
+++ b/tools/third_party.py
@@ -69,7 +69,7 @@ def fix_symlinks():
 
 # Run Yarn to install JavaScript dependencies.
 def run_yarn():
-    run(["yarn", "--no-lockfile"], cwd=third_party_path)
+    run(["yarn", "install"], cwd=third_party_path)
 
 
 # Run Cargo to install Rust dependencies.


### PR DESCRIPTION
Prevents upgrades with running tools/sync_third_party.py

@piscisaureus I consider this a stop gap solution until we completely generate tp.