### PR TITLE
build: don't clobber rust depfile mtime when fixing its paths

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -310,7 +310,9 @@ build_script:
   # Attempt to work around multiple rustc instances messing with the same file
   # when building in parallel.
   # TODO: fix this properly.
-  - ninja -C out\debug -j 1 build_extra/rust:winapi build_extra/rust:winapi-0.2
+  - ps: ninja -C $env:DENO_BUILD_PATH -j 1
+              build_extra/rust:winapi build_extra/rust:winapi-0.2
+
   - python tools\build.py
   - ps: Set-FilesNeeded -Auto -Reason "Build finished"
 
@@ -321,3 +323,11 @@ test_script:
 after_test:
   # Remove stale files and empty dirs from the build directory.
   - ps: Stop-TraceFilesNeeded
+
+  # Verify that the build is fully up-to-date. Running ninja should be a no-op.
+  # This catches erroneous file cleanup, and incorrectly set up build deps.
+  - ps: |-
+      $out = ninja -C $env:DENO_BUILD_PATH -n -d explain :all
+      if ($out -notcontains "ninja: no work to do.") {
+        throw "Build should be up-to-date but isnt't."
+      }

--- a/tools/run_rustc.py
+++ b/tools/run_rustc.py
@@ -14,6 +14,9 @@ import util
 # Updates the path of the main target in the depfile to the relative path
 # from base_path build_output_path
 def fix_depfile(depfile_path, base_path, build_output_path):
+    # It's important that the fixed-up depfile has the same mtime as before.
+    # Ninja relies on it to decide whether to rebuild the target it belongs to.
+    stat = os.stat(depfile_path)
     with open(depfile_path, "r") as depfile:
         content = depfile.read()
     content_split = content.split(': ', 1)
@@ -21,6 +24,7 @@ def fix_depfile(depfile_path, base_path, build_output_path):
     new_content = "%s: %s" % (target_path, content_split[1])
     with open(depfile_path, "w") as depfile:
         depfile.write(new_content)
+    os.utime(depfile_path, (stat.st_atime, stat.st_mtime))
 
 
 def main():


### PR DESCRIPTION
This avoids ninja unnecessarily rebuilding rust targets.
Add a check for problems like these to be run on appveyor.
(see this: https://ci.appveyor.com/project/deno/deno/build/394.b/try#L1151)