### PR TITLE
Fix travis release builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,8 @@ jobs:
       deploy:
         provider: releases
         skip_cleanup: true
-        api_key: $GITHUB_RELEASE_KEY
-        #api_key:
-        #  secure: nm/XSUqQkucsgrTqHhZvVzzGrNsiagQyvy4ozqIcuI9BIENJ7upV2HKy0q+lE0j3iwTLXEVFEQ40hnG166nVTgVjIpxoGcVZvMTqAQFus9gVzbA71fAfAQL+nVlIRsdrSJOvsz1BHLKUgZ7UwyciApduaBDgm+mwXtMty5SHDotTc6mX4bz4UceMG4W7WXFcrWwWz+oFz9r8rYW1aKXcCQOms8eshbCtA3LzJtzUIN9NCE+bWf7QGRtz65aKy26MA/mTEAivQQ/J3ueXn4BzulpATHaSwOy5bvc2HGq5YjVJk1RQI7wqr4ONAtFWyMNAxB4JJ+g1XcN6oscoelpQgVWM2GxEblOZ+HSZAhpYiUuCQiKVe4eF238VQpn0BKw1dPEj1UWf5DHUMdcDFxeBfv1vIge5qhb+fpJTGKXfy91+DlwzM+JMBwqkXnuPFoPbh1lDLDKWB8UPGt07o+Y6tdZytr82kCoMaaHFqAVXYb0iBvG0Bw3WfzpwUsURGU08rw1pFnofnC74IyHGbcJ/+u39GzWTlCNGKce7OgEn16MzGe8QzpVmnO5+WX/uBhDHUyvDZkZHGZWHi19gQaUqDlZ4F3lSe4LMgpjEN23Ovv4AWT8bD2lbVr0XhsMlrcMw5n+RhjNDgadDw3dV9F2MHlZBpp1kYNaVqDkv5nIltYA=
+        api_key:
+          secure: nm/XSUqQkucsgrTqHhZvVzzGrNsiagQyvy4ozqIcuI9BIENJ7upV2HKy0q+lE0j3iwTLXEVFEQ40hnG166nVTgVjIpxoGcVZvMTqAQFus9gVzbA71fAfAQL+nVlIRsdrSJOvsz1BHLKUgZ7UwyciApduaBDgm+mwXtMty5SHDotTc6mX4bz4UceMG4W7WXFcrWwWz+oFz9r8rYW1aKXcCQOms8eshbCtA3LzJtzUIN9NCE+bWf7QGRtz65aKy26MA/mTEAivQQ/J3ueXn4BzulpATHaSwOy5bvc2HGq5YjVJk1RQI7wqr4ONAtFWyMNAxB4JJ+g1XcN6oscoelpQgVWM2GxEblOZ+HSZAhpYiUuCQiKVe4eF238VQpn0BKw1dPEj1UWf5DHUMdcDFxeBfv1vIge5qhb+fpJTGKXfy91+DlwzM+JMBwqkXnuPFoPbh1lDLDKWB8UPGt07o+Y6tdZytr82kCoMaaHFqAVXYb0iBvG0Bw3WfzpwUsURGU08rw1pFnofnC74IyHGbcJ/+u39GzWTlCNGKce7OgEn16MzGe8QzpVmnO5+WX/uBhDHUyvDZkZHGZWHi19gQaUqDlZ4F3lSe4LMgpjEN23Ovv4AWT8bD2lbVr0XhsMlrcMw5n+RhjNDgadDw3dV9F2MHlZBpp1kYNaVqDkv5nIltYA=
         file: "$DENO_BUILD_PATH/deno_linux_x64.gz"
-        #on:
-        #  repo: denoland/deno
+        on:
+          repo: denoland/deno

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,9 @@ jobs:
       deploy:
         provider: releases
         skip_cleanup: true
-        api_key:
-          secure: nm/XSUqQkucsgrTqHhZvVzzGrNsiagQyvy4ozqIcuI9BIENJ7upV2HKy0q+lE0j3iwTLXEVFEQ40hnG166nVTgVjIpxoGcVZvMTqAQFus9gVzbA71fAfAQL+nVlIRsdrSJOvsz1BHLKUgZ7UwyciApduaBDgm+mwXtMty5SHDotTc6mX4bz4UceMG4W7WXFcrWwWz+oFz9r8rYW1aKXcCQOms8eshbCtA3LzJtzUIN9NCE+bWf7QGRtz65aKy26MA/mTEAivQQ/J3ueXn4BzulpATHaSwOy5bvc2HGq5YjVJk1RQI7wqr4ONAtFWyMNAxB4JJ+g1XcN6oscoelpQgVWM2GxEblOZ+HSZAhpYiUuCQiKVe4eF238VQpn0BKw1dPEj1UWf5DHUMdcDFxeBfv1vIge5qhb+fpJTGKXfy91+DlwzM+JMBwqkXnuPFoPbh1lDLDKWB8UPGt07o+Y6tdZytr82kCoMaaHFqAVXYb0iBvG0Bw3WfzpwUsURGU08rw1pFnofnC74IyHGbcJ/+u39GzWTlCNGKce7OgEn16MzGe8QzpVmnO5+WX/uBhDHUyvDZkZHGZWHi19gQaUqDlZ4F3lSe4LMgpjEN23Ovv4AWT8bD2lbVr0XhsMlrcMw5n+RhjNDgadDw3dV9F2MHlZBpp1kYNaVqDkv5nIltYA=
+        api_key: $GITHUB_RELEASE_KEY
+        #api_key:
+        #  secure: nm/XSUqQkucsgrTqHhZvVzzGrNsiagQyvy4ozqIcuI9BIENJ7upV2HKy0q+lE0j3iwTLXEVFEQ40hnG166nVTgVjIpxoGcVZvMTqAQFus9gVzbA71fAfAQL+nVlIRsdrSJOvsz1BHLKUgZ7UwyciApduaBDgm+mwXtMty5SHDotTc6mX4bz4UceMG4W7WXFcrWwWz+oFz9r8rYW1aKXcCQOms8eshbCtA3LzJtzUIN9NCE+bWf7QGRtz65aKy26MA/mTEAivQQ/J3ueXn4BzulpATHaSwOy5bvc2HGq5YjVJk1RQI7wqr4ONAtFWyMNAxB4JJ+g1XcN6oscoelpQgVWM2GxEblOZ+HSZAhpYiUuCQiKVe4eF238VQpn0BKw1dPEj1UWf5DHUMdcDFxeBfv1vIge5qhb+fpJTGKXfy91+DlwzM+JMBwqkXnuPFoPbh1lDLDKWB8UPGt07o+Y6tdZytr82kCoMaaHFqAVXYb0iBvG0Bw3WfzpwUsURGU08rw1pFnofnC74IyHGbcJ/+u39GzWTlCNGKce7OgEn16MzGe8QzpVmnO5+WX/uBhDHUyvDZkZHGZWHi19gQaUqDlZ4F3lSe4LMgpjEN23Ovv4AWT8bD2lbVr0XhsMlrcMw5n+RhjNDgadDw3dV9F2MHlZBpp1kYNaVqDkv5nIltYA=
         file: "$DENO_BUILD_PATH/deno_linux_x64.gz"
-        on:
-          repo: denoland/deno
+        #on:
+        #  repo: denoland/deno

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
           DENO_BUILD_MODE=release \
           ./tools/build.py -j2
         # test release binary
-        env DENO_BUILD_MODE=release ./tools/tests.py
+        env DENO_BUILD_MODE=release ./tools/test.py
       before_deploy: |
         # gzip and name release to denote platform
         gzip -c $DENO_BUILD_PATH/deno > $DENO_BUILD_PATH/deno_linux_x64.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ jobs:
     - stage: test
 
     - stage: release
-      if: tag IS present
       script: |
         # build release binary
         env DENO_BUILD_ARGS="use_custom_libcxx=false use_sysroot=false" \
@@ -66,5 +65,4 @@ jobs:
           secure: nm/XSUqQkucsgrTqHhZvVzzGrNsiagQyvy4ozqIcuI9BIENJ7upV2HKy0q+lE0j3iwTLXEVFEQ40hnG166nVTgVjIpxoGcVZvMTqAQFus9gVzbA71fAfAQL+nVlIRsdrSJOvsz1BHLKUgZ7UwyciApduaBDgm+mwXtMty5SHDotTc6mX4bz4UceMG4W7WXFcrWwWz+oFz9r8rYW1aKXcCQOms8eshbCtA3LzJtzUIN9NCE+bWf7QGRtz65aKy26MA/mTEAivQQ/J3ueXn4BzulpATHaSwOy5bvc2HGq5YjVJk1RQI7wqr4ONAtFWyMNAxB4JJ+g1XcN6oscoelpQgVWM2GxEblOZ+HSZAhpYiUuCQiKVe4eF238VQpn0BKw1dPEj1UWf5DHUMdcDFxeBfv1vIge5qhb+fpJTGKXfy91+DlwzM+JMBwqkXnuPFoPbh1lDLDKWB8UPGt07o+Y6tdZytr82kCoMaaHFqAVXYb0iBvG0Bw3WfzpwUsURGU08rw1pFnofnC74IyHGbcJ/+u39GzWTlCNGKce7OgEn16MzGe8QzpVmnO5+WX/uBhDHUyvDZkZHGZWHi19gQaUqDlZ4F3lSe4LMgpjEN23Ovv4AWT8bD2lbVr0XhsMlrcMw5n+RhjNDgadDw3dV9F2MHlZBpp1kYNaVqDkv5nIltYA=
         file: "$DENO_BUILD_PATH/deno_linux_x64.gz"
         on:
-          tags: true
           repo: denoland/deno


### PR DESCRIPTION
Sorry about that 😩 
- fixed misnamed test script
- removed tag restriction (the `branches: only: master` restriction is still there, carried over from the [original travis config](https://github.com/denoland/deno/blob/e41ee9bf4c76ffadaca41ca8443f076e228f1c6b/.travis.yml) )

tested in my fork: https://travis-ci.com/bobheadxi/deno/builds/82211942 with 
948b8ab
the release: https://github.com/bobheadxi/deno/releases/tag/untagged-9b2b03e4d9244f023331

Related: #501 