### PR TITLE
Add warning about only supporting Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ You probably want
 [ccache](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/ccache)
 installed too.
 
+**Note:** the Python scripts in `./tools` only supports Python 2, since V8's build process doesn't support Python 3 (See [this](https://github.com/denoland/deno/issues/464#issuecomment-411795578))
+
 To build:
 
     # Fetch deps.


### PR DESCRIPTION
It seems a lot of new contributors, myself included, have made the mistake of first attempting to use Python 3 to build deno.