### PR TITLE
Change usage example script extension from .js to .ts

### DIFF
--- a/src/flags.rs
+++ b/src/flags.rs
@@ -23,7 +23,7 @@ pub struct DenoFlags {
 
 pub fn print_usage() {
   println!(
-    "Usage: deno script.js
+    "Usage: deno script.ts
 
 --allow-write      Allow file system write access.
 --allow-net        Allow network access.


### PR DESCRIPTION
This caused me a half-second's confusion when I first tried running Deno -- *I thought this would run TypeScript directly, but it's asking for a JavaScript file?* It looks like `.ts` examples are used elsewhere in this file's own tests, and the README, so maybe this could be switched to match.