### PR TITLE
Travis: branches only master prevents building tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: c++
-branches:
-  only:
-  - master
 env:
   global:
   - CARGO_PATH=$HOME/.cargo/


### PR DESCRIPTION
It appears there's no way to whitelist tags in addition to master, so we
can just build all for now.
https://github.com/travis-ci/travis-ci/issues/2111