### PR TITLE
Add osx to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: c++
+os:
+  - linux
+  - osx
 env:
   global:
   - CARGO_PATH=$HOME/.cargo/
@@ -23,6 +26,9 @@ install: |
   if [ $? != 0 ]; then
     curl -sSf https://sh.rustup.rs | sh -s -- -y
   fi
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    brew install ccache && export PATH="/usr/local/opt/ccache/libexec:$PATH";
+  fi
 before_script:
 - ccache -s
 - "./tools/setup.py"
@@ -32,12 +38,12 @@ script:
 - "./tools/test.py $DENO_BUILD_PATH"
 before_deploy: |
   # gzip and name release to denote platform
-  gzip -c $DENO_BUILD_PATH/deno > $DENO_BUILD_PATH/deno_linux_x64.gz
+  gzip -c $DENO_BUILD_PATH/deno > $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz
 deploy:
   provider: releases
   api_key:
     secure: RIwv515oDcPAlEvt7uG8FeSFi6Tz6ODJUOXcFj6FYUPszxJ7Cg1kBLKln+fNW5OeOc52VsaZb/vPZ85skyEM6zk2ijL9FcSnnfNEm548w77iH6G0sk09NgBTy6KRXES6NZHD9jN1YTWYkT2G1NQi7mLqxR8a8pnWTbeK5HhtSWGsZPtXqf5iQbvnWsmKA0/w+FIgKupU0xe/qsYjh0eMLYpZDUWoKO0VxBKJ/ix5Uz91aJTjMIcHHij+ALg4pk+FkDotdyx39XB9b25KDxGuaI7NxWjSPzDxs/ZBHP6QYDLO0ti93ftvLAxRoBKPFoZrXqAu3KG9anr9WvxE40DO9OdV0VX2ZUatMUQm3DpSheN8ml2sErFqjIInqlpkdOVDYORz7FikPxkb9DKt+iuyFfxPRa4YWJv2tg8+Hy/nRCQw69OoKqrSNJ8KJDB3OjYbRBtdHz79RLJhTsGZla6RiyXfM7crR7CbFjbwdbW3Pt60t24fhvXQ0SwR0QTgzS/ieYEQHq/9GtSQA/Tn4kdIkyN6BdOMrQd/aUtgKmNdqbSlfmWGNyNZIxHdB+3RrTNT1tagkRI4UHEUfEujpIdYKwLjv0Xmi/VtTM+zOSkzHsIWGPfHBmIGnXfAItUHqivQYJ15E+dzg3T1CEbBxkDQtvwien9Fa8/pBsMkyovl8ps=
-  file: "$DENO_BUILD_PATH/deno_linux_x64.gz"
+  file: "$DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
   on:
     tags: true
     repo: denoland/deno


### PR DESCRIPTION
Unfortunately this times-out on osx...

I am not sure what can be done to speed up the build script.
I tried with -j8 and without -j. They didn't seem to make much difference.

https://travis-ci.org/hayd/deno/jobs/419484578
It got _seemingly_ close to:
```
[907/1054] CXX obj/third_party/v8/v8_base/liftoff-assembler.o
```
Note: Machine seems to be the [same size as linux](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system).

#563