### PR TITLE
Improve DenoCompiler.makeDefine and localRequire

### DIFF
--- a/js/compiler_test.ts
+++ b/js/compiler_test.ts
@@ -108,6 +108,12 @@ const moduleMap: {
       "/root/project/foo/bar.ts",
       fooBarTsSource,
       fooBarTsOutput
+    ),
+    "./qat.ts": mockModuleInfo(
+      "foo/qat",
+      "/root/project/foo/qat.ts",
+      "export const foo = 'bar'",
+      null
     )
   }
 };
@@ -274,6 +280,33 @@ test(function compilerMakeDefine() {
 // TODO testMakeDefineExternalModule - testing that make define properly runs
 // external modules, this is implicitly tested though in
 // `compilerRunMultiModule`
+
+test(function compilerLocalRequire() {
+  const moduleMetaData = new ModuleMetaData(
+    "/root/project/foo/baz.ts",
+    fooBazTsSource,
+    fooBazTsOutput
+  );
+  const localDefine = compilerInstance.makeDefine(moduleMetaData);
+  let requireCallbackCalled = false;
+  localDefine(
+    ["require", "exports"],
+    (_require, _exports, _compiler): void => {
+      assertEqual(typeof _require, "function");
+      _require(
+        ["./qat.ts"],
+        _qat => {
+          requireCallbackCalled = true;
+          assert(_qat);
+        },
+        () => {
+          throw new Error("Should not error");
+        }
+      );
+    }
+  );
+  assert(requireCallbackCalled, "Factory expected to be called");
+});
 
 test(function compilerRun() {
   // equal to `deno foo/bar.ts`

--- a/tests/error_005_missing_dynamic_import.ts
+++ b/tests/error_005_missing_dynamic_import.ts
@@ -1,0 +1,3 @@
+(async () => {
+  const badModule = await import("bad-module.ts");
+})();

--- a/tests/error_005_missing_dynamic_import.ts.out
+++ b/tests/error_005_missing_dynamic_import.ts.out
@@ -1,0 +1,12 @@
+Error: Cannot resolve module "bad-module.ts" from "[WILDCARD]deno/tests/error_005_missing_dynamic_import.ts".
+  os.codeFetch message: [WILDCARD] (os error 2)
+    at throwResolutionError (deno/js/compiler.ts:[WILDCARD])
+    at DenoCompiler.resolveModule (deno/js/compiler.ts:[WILDCARD])
+    at DenoCompiler.resolveModuleName (deno/js/compiler.ts:[WILDCARD])
+    at moduleNames.map.name (deno/js/compiler.ts:[WILDCARD])
+    at Array.map (<anonymous>)
+    at DenoCompiler.resolveModuleNames (deno/js/compiler.ts:[WILDCARD])
+    at Object.compilerHost.resolveModuleNames (deno/third_party/node_modules/typescript/lib/typescript.js:[WILDCARD])
+    at resolveModuleNamesWorker (deno/third_party/node_modules/typescript/lib/typescript.js:[WILDCARD])
+    at resolveModuleNamesReusingOldState (deno/third_party/node_modules/typescript/lib/typescript.js:[WILDCARD])
+    at processImportedModules (deno/third_party/node_modules/typescript/lib/typescript.js:[WILDCARD])


### PR DESCRIPTION
Fixes #579 

It is likely that `resolveDependencies` is just temporary location until #581 lands and there is a cleaner API for resolving dependencies and instantiating the modules.