### PR TITLE
Add ability to unit test based on permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # deno
 
-| **Linux** | **Windows** |
+| **Linux & Mac** | **Windows** |
 |:---------------:|:-----------:|
 | [![Travis](https://travis-ci.com/denoland/deno.svg?branch=master)](https://travis-ci.com/denoland/deno) | [![Appveyor](https://ci.appveyor.com/api/projects/status/yel7wtcqwoy0to8x?branch=master&svg=true)](https://ci.appveyor.com/project/deno/deno) |
 

--- a/js/compiler_test.ts
+++ b/js/compiler_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
-import { test, assert, assertEqual } from "./testing/testing.ts";
+import { test, assert, assertEqual } from "./test_util.ts";
 import * as compiler from "compiler";
 import * as ts from "typescript";
 

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 
-import { test, assert, assertEqual } from "./testing/testing.ts";
+import { test, assert, assertEqual } from "./test_util.ts";
 import { stringifyArgs } from "./console.ts";
 
 // tslint:disable-next-line:no-any

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -2,3 +2,4 @@
 // Public deno module.
 export { exit, readFileSync, writeFileSync } from "./os";
 export { libdeno } from "./libdeno";
+export const argv: string[] = [];

--- a/js/main.ts
+++ b/js/main.ts
@@ -7,6 +7,7 @@ import { DenoCompiler } from "./compiler";
 import { libdeno } from "./libdeno";
 import * as timers from "./timers";
 import { onFetchRes } from "./fetch";
+import { argv } from "./deno";
 
 function startMsg(cmdId: number): Uint8Array {
   const builder = new flatbuffers.Builder();
@@ -85,13 +86,14 @@ export default function denoMain() {
   const cwd = startResMsg.cwd();
   log("cwd", cwd);
 
-  const argv: string[] = [];
-  for (let i = 0; i < startResMsg.argvLength(); i++) {
+  // TODO handle shebang.
+  for (let i = 1; i < startResMsg.argvLength(); i++) {
     argv.push(startResMsg.argv(i));
   }
   log("argv", argv);
+  Object.freeze(argv);
 
-  const inputFn = argv[1];
+  const inputFn = argv[0];
   if (!inputFn) {
     console.log("No input script specified.");
     os.exit(1);

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -1,0 +1,70 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+//
+// We want to test many ops in deno which have different behavior depending on
+// the permissions set. These tests can specify which permissions they expect,
+// which appends a special string like "permW1N0" to the end of the test name.
+// Here we run several copies of deno with different permissions, filtering the
+// tests by the special string. permW0N0 means allow-write but not allow-net.
+// See tools/unit_tests.py for more details.
+
+import * as deno from "deno";
+import * as testing from "./testing/testing.ts";
+export { assert, assertEqual } from "./testing/testing.ts";
+
+// testing.setFilter must be run before any tests are defined.
+const permFilter = deno.argv[1];
+permFromString(permFilter);
+testing.setFilter(permFilter);
+
+interface DenoPermissions {
+  write?: boolean;
+  net?: boolean;
+}
+
+function permToString(perms: DenoPermissions): string {
+  const w = perms.write ? 1 : 0;
+  const n = perms.net ? 1 : 0;
+  return `permW${w}N${n}`;
+}
+
+function permFromString(s: string): DenoPermissions {
+  const re = /^permW([01])N([01])$/;
+  const found = s.match(re);
+  if (!found) {
+    throw Error("Not a permission string");
+  }
+  return {
+    write: Boolean(Number(found[1])),
+    net: Boolean(Number(found[2]))
+  };
+}
+
+export function testPerm(perms: DenoPermissions, fn: testing.TestFunction) {
+  const name = `${fn.name}_${permToString(perms)}`;
+  testing.test({ fn, name });
+}
+
+export function test(fn: testing.TestFunction) {
+  testPerm({ write: false, net: false }, fn);
+}
+
+test(function permSerialization() {
+  for (let write of [true, false]) {
+    for (let net of [true, false]) {
+      let perms: DenoPermissions = { write, net };
+      testing.assertEqual(perms, permFromString(permToString(perms)));
+    }
+  }
+});
+
+// To better catch internal errors, permFromString should throw if it gets an
+// invalid permission string.
+test(function permFromStringThrows() {
+  let threw = false;
+  try {
+    permFromString("bad");
+  } catch (e) {
+    threw = true;
+  }
+  testing.assert(threw);
+});

--- a/js/testing/testing.ts
+++ b/js/testing/testing.ts
@@ -24,21 +24,13 @@ export interface TestDefinition {
 
 export const exitOnFail = true;
 
-/* A subset of the tests can be ran by providing a filter expression.
- * In Node.js the filter is specified on the command line:
- *
- *   ts-node test_node log        # all tests with 'log' in the name
- *   ts-node test_node ^util      # tests starting with 'util'
- *
- * In the browser, the filter is specified as part of the url:
- *
- *   http://localhost:9876/test.html#script=some/script.js&filter=log
- *   http://localhost:9876/test.html#script=some/script.js&filter=^util
- */
-let filterExpr: string = null;
-
-const filterRegExp = filterExpr ? new RegExp(filterExpr, "i") : null;
+let filterRegExp: RegExp | null;
 const tests: TestDefinition[] = [];
+
+// Must be called before any test() that needs to be filtered.
+export function setFilter(s: string): void {
+  filterRegExp = new RegExp(s, "i");
+}
 
 export function test(t: TestDefinition | TestFunction): void {
   const fn: TestFunction = typeof t === "function" ? t : t.fn;

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -14,6 +14,7 @@ PORT = 4545
 def serve_forever():
     os.chdir(root_path)  # Hopefully the main thread doesn't also chdir.
     Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
+    SocketServer.TCPServer.allow_reuse_address = True
     httpd = SocketServer.TCPServer(("", PORT), Handler)
     print "Deno test server http://localhost:%d/" % PORT
     httpd.serve_forever()

--- a/tools/test.py
+++ b/tools/test.py
@@ -5,6 +5,7 @@ import os
 import sys
 from check_output_test import check_output_test
 from util import executable_suffix, run, build_path
+from unit_tests import unit_tests
 from util_test import util_test
 import subprocess
 import http_server
@@ -41,7 +42,7 @@ def main(argv):
 
     deno_exe = os.path.join(build_dir, "deno" + executable_suffix)
     check_exists(deno_exe)
-    run([deno_exe, "js/unit_tests.ts", "--allow-write"])
+    unit_tests(deno_exe)
 
     check_exists(deno_exe)
     check_output_test(deno_exe)

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+from util import run
+import sys
+
+
+# We want to test many ops in deno which have different behavior depending on
+# the permissions set. These tests can specify which permissions they expect,
+# which appends a special string like "permW1N0" to the end of the test name.
+# Here we run several copies of deno with different permissions, filtering the
+# tests by the special string. permW0N0 means allow-write but not allow-net.
+# See js/test_util.ts for more details.
+def unit_tests(deno_exe):
+    run([deno_exe, "js/unit_tests.ts", "permW0N0"])
+    run([deno_exe, "js/unit_tests.ts", "permW1N0", "--allow-write"])
+    run([deno_exe, "js/unit_tests.ts", "permW0N1", "--allow-net"])
+    run([
+        deno_exe, "js/unit_tests.ts", "permW1N1", "--allow-write",
+        "--allow-net"
+    ])
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print "Usage ./tools/unit_tests.py out/debug/deno"
+        sys.exit(1)
+    unit_tests(sys.argv[1])


### PR DESCRIPTION
Also exposes `deno.argv`

Example:
```typescript
testPerm({ net: true }, async function tests_fetch() {
  const response = await fetch("http://localhost:4545/package.json");
  const json = await response.json();
  assertEqual(json.name, "deno");
});
```
Currently in the stdout you will see many lines like this:
```
DONE. Test passed: 0, failed: 0

DONE. Test passed: 0, failed: 0

DONE. Test passed: 0, failed: 0

DONE. Test passed: 0, failed: 0

DONE. Test passed: 0, failed: 0

DONE. Test passed: 0, failed: 0

DONE. Test passed: 0, failed: 0
```
This is caused by #587