### PR TITLE
travis: allow cache to be saved when build takes too long

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_script:
 - "./tools/setup.py"
 script:
 - "./tools/lint.py"
+- bash -c "sleep 2100; pkill ninja" &
 - "./tools/build.py -j2"
 - "./tools/test.py $DENO_BUILD_PATH"
 before_deploy: |


### PR DESCRIPTION
Kill Ninja after 35 minutes to prevent Travis from cancelling the build
due to time-out. This allows the cache to be saved, so the build can
complete when it is attempted again.

Land on approval.