### PR TITLE
[WIP] Traditional flag parsing and eval flag

### DIFF
--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -234,7 +234,10 @@ impl DenoDir {
         let r = Url::from_directory_path(&containing_file);
         // TODO(ry) Properly handle error.
         if r.is_err() {
-          error!("Url::from_directory_path error {}", containing_file);
+          error!(
+            "Url::from_directory_path error {}",
+            containing_file
+          );
         }
         let base = r.unwrap();
         base.join(module_specifier)?
@@ -262,7 +265,10 @@ impl DenoDir {
       }
     }
 
-    debug!("module_name: {}, filename: {}", module_name, filename);
+    debug!(
+      "module_name: {}, filename: {}",
+      module_name, filename
+    );
     Ok((module_name, filename))
   }
 }
@@ -329,7 +335,10 @@ fn test_code_cache() {
   let r = deno_dir.code_cache(filename, source_code, output_code);
   r.expect("code_cache error");
   assert!(cache_path.exists());
-  assert_eq!(output_code, fs::read_file_sync_string(&cache_path).unwrap());
+  assert_eq!(
+    output_code,
+    fs::read_file_sync_string(&cache_path).unwrap()
+  );
 }
 
 // https://github.com/denoland/deno/blob/golang/deno_dir.go#L25-L30
@@ -363,7 +372,7 @@ fn test_source_code_hash() {
 // `Url::from_file_path()` fails if the input path isn't an absolute path.
 #[cfg(test)]
 macro_rules! add_root {
-  ($path:expr) => {
+  ($path: expr) => {
     if cfg!(target_os = "windows") {
       concat!("C:", $path)
     } else {
@@ -399,8 +408,17 @@ fn test_src_file_to_url() {
   let (_temp_dir, deno_dir) = test_setup();
   assert_eq!("hello", deno_dir.src_file_to_url("hello"));
   assert_eq!("/hello", deno_dir.src_file_to_url("/hello"));
-  let x = String::from(deno_dir.deps.join("hello/world.txt").to_str().unwrap());
-  assert_eq!("http://hello/world.txt", deno_dir.src_file_to_url(x));
+  let x = String::from(
+    deno_dir
+      .deps
+      .join("hello/world.txt")
+      .to_str()
+      .unwrap(),
+  );
+  assert_eq!(
+    "http://hello/world.txt",
+    deno_dir.src_file_to_url(x)
+  );
 }
 
 // https://github.com/denoland/deno/blob/golang/os_test.go#L16-L87

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -229,23 +229,6 @@ fn test_set_flags_6() {
   );
 }
 
-#[test]
-fn test_set_flags_7() {
-  let (flags, rest) = set_flags(svec!["deno", "-h", "--", "-r", "-e"]);
-  assert!(rest == svec!["deno", "-r", "-e"]);
-  assert!(
-    flags == DenoFlags {
-      help: true,
-      log_debug: false,
-      version: false,
-      reload: false,
-      allow_write: false,
-      allow_net: false,
-      eval: vec![],
-    }
-  );
-}
-
 // Returns args passed to V8, followed by args passed to JS
 // TODO Rename to v8_set_flags_preprocess
 fn parse_core_args(args: Vec<String>) -> (Vec<String>, Vec<String>) {

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -145,6 +145,61 @@ fn test_set_flags_3() {
   );
 }
 
+#[test]
+fn test_set_flags_4() {
+  let (flags, rest) = set_flags(svec!["deno", "-Dr", "script.ts", "--allow-write"]);
+  assert!(rest == svec!["deno", "script.ts"]);
+  assert!(
+    flags == DenoFlags {
+      help: false,
+      log_debug: true,
+      version: false,
+      reload: true,
+      allow_write: true,
+      allow_net: false,
+      eval: None,
+    }
+  );
+}
+
+#[test]
+fn test_set_flags_5() {
+  let (flags, rest) = set_flags(svec!["deno", "-D", "-e", "console.log('Hello, World')"]);
+  assert!(rest == svec!["deno"]);
+  assert!(
+    flags == DenoFlags {
+      help: false,
+      log_debug: true,
+      version: false,
+      reload: false,
+      allow_write: false,
+      allow_net: false,
+      eval: Some("console.log('Hello, World')".to_owned()),
+    }
+  );
+}
+
+#[test]
+fn test_set_flags_6() {
+  let (flags, rest) = set_flags(svec![
+    "deno",
+    "-Dreconsole.error('ERROR: Oh no!')",
+    "script.ts"
+  ]);
+  assert!(rest == svec!["deno", "script.ts"]);
+  assert!(
+    flags == DenoFlags {
+      help: false,
+      log_debug: true,
+      version: false,
+      reload: true,
+      allow_write: false,
+      allow_net: false,
+      eval: Some("console.error('ERROR: Oh no!')".to_owned()),
+    }
+  );
+}
+
 // Returns args passed to V8, followed by args passed to JS
 // TODO Rename to v8_set_flags_preprocess
 fn parse_core_args(args: Vec<String>) -> (Vec<String>, Vec<String>) {

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -68,7 +68,7 @@ pub fn set_flags(args: Vec<String>) -> (DenoFlags, Vec<String>) {
         "--allow-write" => flags.allow_write = true,
         "--allow-net" => flags.allow_net = true,
         "--" => break,
-        _ => rest.push(a.clone()), // maybe complain here about an unknown arg?
+        _ => unimplemented!(),
       }
     } else if a.len() > 1 && &a[0..1] == "-" {
       let mut iter = a.chars().skip(1); // skip the "-"

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -81,7 +81,9 @@ pub fn set_flags(args: Vec<String>) -> (DenoFlags, Vec<String>) {
           'e' => {
             let chars_left = iter.count();
             if chars_left != 0 {
-              flags.eval.push(a[a.len() - chars_left..].to_owned());
+              flags
+                .eval
+                .push(a[a.len() - chars_left..].to_owned());
             } else if let Some(e) = arg_iter.next() {
               flags.eval.push(e.clone())
             } else {
@@ -138,7 +140,12 @@ fn test_set_flags_2() {
 
 #[test]
 fn test_set_flags_3() {
-  let (flags, rest) = set_flags(svec!["deno", "-r", "script.ts", "--allow-write"]);
+  let (flags, rest) = set_flags(svec![
+    "deno",
+    "-r",
+    "script.ts",
+    "--allow-write"
+  ]);
   assert!(rest == svec!["deno", "script.ts"]);
   assert!(
     flags == DenoFlags {
@@ -155,7 +162,12 @@ fn test_set_flags_3() {
 
 #[test]
 fn test_set_flags_4() {
-  let (flags, rest) = set_flags(svec!["deno", "-Dr", "script.ts", "--allow-write"]);
+  let (flags, rest) = set_flags(svec![
+    "deno",
+    "-Dr",
+    "script.ts",
+    "--allow-write"
+  ]);
   assert!(rest == svec!["deno", "script.ts"]);
   assert!(
     flags == DenoFlags {
@@ -188,7 +200,10 @@ fn test_set_flags_5() {
       reload: false,
       allow_write: false,
       allow_net: false,
-      eval: svec!["console.log('Hello, World')", "console.log('second e')"],
+      eval: svec![
+        "console.log('Hello, World')",
+        "console.log('second e')"
+      ],
     }
   );
 }
@@ -252,7 +267,10 @@ fn parse_core_args(args: Vec<String>) -> (Vec<String>, Vec<String>) {
   // Replace args being sent to V8
   for idx in 0..args.len() {
     if args[idx] == "--v8-options" {
-      mem::swap(args.get_mut(idx).unwrap(), &mut String::from("--help"));
+      mem::swap(
+        args.get_mut(idx).unwrap(),
+        &mut String::from("--help"),
+      );
     }
   }
 
@@ -261,14 +279,29 @@ fn parse_core_args(args: Vec<String>) -> (Vec<String>, Vec<String>) {
 
 #[test]
 fn test_parse_core_args_1() {
-  let js_args = parse_core_args(vec!["deno".to_string(), "--v8-options".to_string()]);
-  assert!(js_args == (vec!["deno".to_string(), "--help".to_string()], vec![]));
+  let js_args = parse_core_args(vec![
+    "deno".to_string(),
+    "--v8-options".to_string(),
+  ]);
+  assert!(
+    js_args
+      == (
+        vec!["deno".to_string(), "--help".to_string()],
+        vec![]
+      )
+  );
 }
 
 #[test]
 fn test_parse_core_args_2() {
   let js_args = parse_core_args(vec!["deno".to_string(), "--help".to_string()]);
-  assert!(js_args == (vec!["deno".to_string()], vec!["--help".to_string()]));
+  assert!(
+    js_args
+      == (
+        vec!["deno".to_string()],
+        vec!["--help".to_string()]
+      )
+  );
 }
 
 // Pass the command line arguments to v8.
@@ -280,7 +313,11 @@ pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
   let (argv, rest) = parse_core_args(args);
   let mut argv = argv
     .iter()
-    .map(|arg| CString::new(arg.as_str()).unwrap().into_bytes_with_nul())
+    .map(|arg| {
+      CString::new(arg.as_str())
+        .unwrap()
+        .into_bytes_with_nul()
+    })
     .collect::<Vec<_>>();
 
   // Make a new array, that can be modified by V8::SetFlagsFromCommandLine(),

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -200,6 +200,23 @@ fn test_set_flags_6() {
   );
 }
 
+#[test]
+fn test_set_flags_7() {
+  let (flags, rest) = set_flags(svec!["deno", "-h", "--", "-r", "-e"]);
+  assert!(rest == svec!["deno", "-r", "-e"]);
+  assert!(
+    flags == DenoFlags {
+      help: true,
+      log_debug: false,
+      version: false,
+      reload: false,
+      allow_write: false,
+      allow_net: false,
+      eval: None,
+    }
+  );
+}
+
 // Returns args passed to V8, followed by args passed to JS
 // TODO Rename to v8_set_flags_preprocess
 fn parse_core_args(args: Vec<String>) -> (Vec<String>, Vec<String>) {

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -33,7 +33,7 @@ pub fn print_usage() {
 -e or --eval [SCRIPT]  Evaluate a script from the command line, may be passed multiple times.
 -r or --reload         Reload cached remote resources.
 -D or --log-debug      Log debug output.
---help                 Print this message.
+-h or --help           Print this message.
 --v8-options           Print V8 command line options."
   );
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -25,10 +25,7 @@ pub fn write_file_sync(path: &Path, content: &[u8]) -> std::io::Result<()> {
 
 pub fn mkdir(path: &Path) -> std::io::Result<()> {
   debug!("mkdir -p {}", path.display());
-  assert!(
-    path.has_root(),
-    "non-has_root not yet implemented"
-  );
+  assert!(path.has_root(), "non-has_root not yet implemented");
   std::fs::create_dir_all(path).or_else(|err| {
     if err.kind() == std::io::ErrorKind::AlreadyExists {
       Ok(())

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -25,7 +25,10 @@ pub fn write_file_sync(path: &Path, content: &[u8]) -> std::io::Result<()> {
 
 pub fn mkdir(path: &Path) -> std::io::Result<()> {
   debug!("mkdir -p {}", path.display());
-  assert!(path.has_root(), "non-has_root not yet implemented");
+  assert!(
+    path.has_root(),
+    "non-has_root not yet implemented"
+  );
   std::fs::create_dir_all(path).or_else(|err| {
     if err.kind() == std::io::ErrorKind::AlreadyExists {
       Ok(())

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -33,12 +33,7 @@ pub extern "C" fn msg_from_js(d: *const DenoC, buf: deno_buf) {
       let msg = msg::CodeFetch::init_from_table(base.msg().unwrap());
       let module_specifier = msg.module_specifier().unwrap();
       let containing_file = msg.containing_file().unwrap();
-      handle_code_fetch(
-        d,
-        &mut builder,
-        module_specifier,
-        containing_file,
-      )
+      handle_code_fetch(d, &mut builder, module_specifier, containing_file)
     }
     msg::Any::CodeCache => {
       // TODO base.msg_as_CodeCache();
@@ -46,13 +41,7 @@ pub extern "C" fn msg_from_js(d: *const DenoC, buf: deno_buf) {
       let filename = msg.filename().unwrap();
       let source_code = msg.source_code().unwrap();
       let output_code = msg.output_code().unwrap();
-      handle_code_cache(
-        d,
-        &mut builder,
-        filename,
-        source_code,
-        output_code,
-      )
+      handle_code_cache(d, &mut builder, filename, source_code, output_code)
     }
     msg::Any::FetchReq => {
       // TODO base.msg_as_FetchReq();
@@ -63,13 +52,7 @@ pub extern "C" fn msg_from_js(d: *const DenoC, buf: deno_buf) {
     msg::Any::TimerStart => {
       // TODO base.msg_as_TimerStart();
       let msg = msg::TimerStart::init_from_table(base.msg().unwrap());
-      handle_timer_start(
-        d,
-        &mut builder,
-        msg.id(),
-        msg.interval(),
-        msg.delay(),
-      )
+      handle_timer_start(d, &mut builder, msg.id(), msg.interval(), msg.delay())
     }
     msg::Any::TimerClear => {
       // TODO base.msg_as_TimerClear();
@@ -140,11 +123,7 @@ fn handle_start(
 ) -> HandlerResult {
   let deno = from_c(d);
 
-  let argv = deno
-    .argv
-    .iter()
-    .map(|s| s.as_str())
-    .collect::<Vec<_>>();
+  let argv = deno.argv.iter().map(|s| s.as_str()).collect::<Vec<_>>();
   let argv_off = builder.create_vector_of_strings(argv.as_slice());
 
   let cwd_path = std::env::current_dir().unwrap();
@@ -209,10 +188,7 @@ fn handle_code_fetch(
 ) -> HandlerResult {
   let deno = from_c(d);
 
-  assert!(
-    deno.dir.root.join("gen") == deno.dir.gen,
-    "Sanity check"
-  );
+  assert!(deno.dir.root.join("gen") == deno.dir.gen, "Sanity check");
 
   let out = deno
     .dir

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,16 +66,10 @@ impl Deno {
     deno_box
   }
 
-  fn execute(
-    &mut self,
-    js_filename: &str,
-    js_source: &str,
-  ) -> Result<(), DenoException> {
+  fn execute(&mut self, js_filename: &str, js_source: &str) -> Result<(), DenoException> {
     let filename = CString::new(js_filename).unwrap();
     let source = CString::new(js_source).unwrap();
-    let r = unsafe {
-      binding::deno_execute(self.ptr, filename.as_ptr(), source.as_ptr())
-    };
+    let r = unsafe { binding::deno_execute(self.ptr, filename.as_ptr(), source.as_ptr()) };
     if r == 0 {
       let ptr = unsafe { binding::deno_last_exception(self.ptr) };
       let cstr = unsafe { CStr::from_ptr(ptr) };
@@ -146,6 +140,13 @@ fn main() {
   } else {
     log::LevelFilter::Info
   });
+
+  if let Some(e) = d.flags.eval.clone() {
+    d.execute("<anonymous>", &e).unwrap_or_else(|err| {
+      error!("{}", err);
+      std::process::exit(1);
+    });
+  }
 
   d.execute("deno_main.js", "denoMain();")
     .unwrap_or_else(|err| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ fn main() {
     log::LevelFilter::Info
   });
 
-  if let Some(e) = d.flags.eval.clone() {
+  for e in d.flags.eval.clone() {
     d.execute("<anonymous>", &e).unwrap_or_else(|err| {
       error!("{}", err);
       std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,10 +104,7 @@ fn test_c_to_rust() {
   let d = Deno::new(argv);
   let d2 = from_c(d.ptr);
   assert!(d.ptr == d2.ptr);
-  assert!(
-    d.dir.root.join("gen") == d.dir.gen,
-    "Sanity check"
-  );
+  assert!(d.dir.root.join("gen") == d.dir.gen, "Sanity check");
 }
 
 static LOGGER: Logger = Logger;

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,10 +66,16 @@ impl Deno {
     deno_box
   }
 
-  fn execute(&mut self, js_filename: &str, js_source: &str) -> Result<(), DenoException> {
+  fn execute(
+    &mut self,
+    js_filename: &str,
+    js_source: &str,
+  ) -> Result<(), DenoException> {
     let filename = CString::new(js_filename).unwrap();
     let source = CString::new(js_source).unwrap();
-    let r = unsafe { binding::deno_execute(self.ptr, filename.as_ptr(), source.as_ptr()) };
+    let r = unsafe {
+      binding::deno_execute(self.ptr, filename.as_ptr(), source.as_ptr())
+    };
     if r == 0 {
       let ptr = unsafe { binding::deno_last_exception(self.ptr) };
       let cstr = unsafe { CStr::from_ptr(ptr) };
@@ -98,7 +104,10 @@ fn test_c_to_rust() {
   let d = Deno::new(argv);
   let d2 = from_c(d.ptr);
   assert!(d.ptr == d2.ptr);
-  assert!(d.dir.root.join("gen") == d.dir.gen, "Sanity check");
+  assert!(
+    d.dir.root.join("gen") == d.dir.gen,
+    "Sanity check"
+  );
 }
 
 static LOGGER: Logger = Logger;
@@ -142,10 +151,11 @@ fn main() {
   });
 
   for e in d.flags.eval.clone() {
-    d.execute("<anonymous>", &e).unwrap_or_else(|err| {
-      error!("{}", err);
-      std::process::exit(1);
-    });
+    d.execute("<anonymous>", &e)
+      .unwrap_or_else(|err| {
+        error!("{}", err);
+        std::process::exit(1);
+      });
   }
 
   d.execute("deno_main.js", "denoMain();")


### PR DESCRIPTION
## Additions
This PR reworks flag parsing to be a bit more user-friendly, by implementing more traditional rules.

following capabilities are added:

- same argument short flags (i.e. `deno -rD` is legal,  and it is equivalent to `deno -r -D`, or `deno --reload --log-debug`)
- The special flag, `--`,  will immediately stop flag parsing
- short flag arguments may be in the same argv argument as the flag itself (i.e `deno -e'console.log("test")'` is the same as `deno -e 'console.log("test")'`)

This PR also adds the `-e` (`--eval`) flag, which can be passed a string to evaluate.

## Not Implemented

So far, no there is no error handling in the `set_flags` function, I've just left `unimplemented!()` where there should probably be some sort of error message or something in the future.

Evaluation is also not fully supported, each instance of `-e` is evaluated in a loop in the `main` function but what operations it can actually perform are _extremely_ limited, because it is run before `denoMain()`.

Deno still complains if it's missing an input file, even if one or more `-e` flags were provided

## Questions

I have a few questions about what error handling and the eval flag before they are implemented.

Should the error handling be done completely in the main set_flags function. So set_flags doesn't return and error, but instead prints an error message, or should it just return a `Result`.

Is eval practical at this point? I think it's a really helpful thing to have, and helps when just trying out deno, but is it worth it to change `denoMain()`, or use some other method to get it working properly?