### PR TITLE
Don't use absolute paths in build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -333,7 +333,7 @@ after_test:
 
   # If this build is going to be deployed, build a zip file.
   - ps: |-
-      if ($env:APPVEYOR_REPO_TAG) {
+      if ($env:APPVEYOR_REPO_TAG -eq "true") {
         Compress-Archive -CompressionLevel Optimal -Force `
           -Path "$env:DENO_BUILD_PATH\deno.exe" `
           -DestinationPath "$env:APPVEYOR_BUILD_FOLDER\$env:RELEASE_ARTIFACT"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -331,6 +331,22 @@ after_test:
         throw "Build should be up-to-date but isnt't."
       }
 
+  # Verify that generated ninja files do not use absolute path names.
+  # If they do, it makes ccache/sccache much less effective.
+  - ps: |-
+      $trap = "NO_ABS_PATH_PLS"
+      $dir = "$env:APPVEYOR_BUILD_FOLDER\out\$trap"
+      Exec { gn gen $dir | Out-Null }
+      $files = Get-Tree $dir -File -Force -Recurse | where Extension -ne ".dll"
+      Select-String $trap -Path $files -SimpleMatch | tee -Variable line_matches
+      if ($line_matches) {
+        $ctx = $line_matches.Line                                          |
+          Select-String "[^\s;,]*[\s=]*[^\s;,=]*$trap[^\s;,]*" -AllMatches |
+          foreach { $_.Matches.Value -replace '\$(.)', '$1' }              |
+          sort -Unique
+        throw @("Absolute path(s) found in build script:") + $ctx -join "`n  "
+      }
+
   # If this build is going to be deployed, build a zip file.
   - ps: |-
       if ($env:APPVEYOR_REPO_TAG -eq "true") {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -243,9 +243,8 @@ run_node("bundle") {
 
 source_set("libdeno_nosnapshot") {
   bundle_outputs = get_target_outputs(":bundle")
-  bundle_location = rebase_path(bundle_outputs[0])
-  bundle_rel_location = rebase_path(bundle_outputs[0], root_build_dir)
-  bundle_map_location = rebase_path(bundle_outputs[1])
+  bundle_location = rebase_path(bundle_outputs[0], root_build_dir)
+  bundle_map_location = rebase_path(bundle_outputs[1], root_build_dir)
   inputs = bundle_outputs
   sources = [
     "libdeno/from_filesystem.cc",
@@ -257,7 +256,6 @@ source_set("libdeno_nosnapshot") {
   configs += [ ":deno_config" ]
   defines = [
     "BUNDLE_LOCATION=\"$bundle_location\"",
-    "BUNDLE_REL_LOCATION=\"$bundle_rel_location\"",
     "BUNDLE_MAP_LOCATION=\"$bundle_map_location\"",
   ]
 }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -189,9 +189,9 @@ run_node("gen_declarations") {
     "-p",
     rebase_path("js/tsconfig.generated.json", root_build_dir),
     "--baseUrl",
-    rebase_path(root_build_dir),
+    rebase_path(root_build_dir, root_build_dir),
     "--outDir",
-    rebase_path(out_dir),
+    rebase_path(out_dir, root_build_dir),
   ]
 }
 

--- a/libdeno/file_util.cc
+++ b/libdeno/file_util.cc
@@ -1,9 +1,20 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 #include <inttypes.h>
+#include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <fstream>
 #include <iterator>
 #include <string>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 #include "file_util.h"
 
@@ -26,6 +37,54 @@ std::string Basename(std::string const& filename) {
     }
   }
   return filename;
+}
+
+// Returns the directory component from a filename. The returned path always
+// ends with a slash. This function does not understand Windows drive letters.
+std::string Dirname(std::string const& filename) {
+  for (auto it = filename.rbegin(); it != filename.rend(); ++it) {
+    char ch = *it;
+    if (ch == '\\' || ch == '/') {
+      return std::string(filename.begin(), it.base());
+    }
+  }
+  return std::string("./");
+}
+
+// Returns the full path the currently running executable.
+// This implementation is very basic. Caveats:
+//   * OS X: fails if buffer is too small, does not retry with a bigger buffer.
+//   * Windows: ANSI only, no unicode. Fails if path is longer than 260 chars.
+bool ExePath(std::string* path) {
+#ifdef _WIN32
+  // Windows only.
+  char exe_buf[MAX_PATH];
+  DWORD len = GetModuleFileNameA(NULL, exe_buf, sizeof exe_buf);
+  if (len == 0 || len == sizeof exe_buf) {
+    return false;
+  }
+#else
+#ifdef __APPLE__
+  // OS X only.
+  char link_buf[PATH_MAX * 2];  // Exe may be longer than MAX_PATH, says Apple.
+  uint32_t len = sizeof link_buf;
+  if (_NSGetExecutablePath(link_buf, &len) < 0) {
+    return false;
+  }
+#else
+  // Linux only.
+  static const char* link_buf = "/proc/self/exe";
+#endif
+  // Linux and OS X.
+  char exe_buf[PATH_MAX];
+  char* r = realpath(link_buf, exe_buf);
+  if (r == NULL) {
+    return false;
+  }
+#endif
+  // All platforms.
+  path->assign(exe_buf);
+  return true;
 }
 
 }  // namespace deno

--- a/libdeno/file_util.h
+++ b/libdeno/file_util.h
@@ -7,6 +7,8 @@
 namespace deno {
 bool ReadFileToString(const char* fn, std::string* contents);
 std::string Basename(std::string const& filename);
+std::string Dirname(std::string const& filename);
+bool ExePath(std::string* path);
 }  // namespace deno
 
 #endif  // FILE_UTIL_H_

--- a/libdeno/file_util_test.cc
+++ b/libdeno/file_util_test.cc
@@ -11,11 +11,36 @@ TEST(FileUtilTest, ReadFileToStringFileNotExist) {
 TEST(FileUtilTest, Basename) {
   EXPECT_EQ("foo.txt", deno::Basename("foo.txt"));
   EXPECT_EQ("foo.txt", deno::Basename("/foo.txt"));
+  EXPECT_EQ("", deno::Basename("/foo/"));
+  EXPECT_EQ("", deno::Basename("foo/"));
   EXPECT_EQ("", deno::Basename("/"));
   EXPECT_EQ("foo.txt", deno::Basename(".\\foo.txt"));
   EXPECT_EQ("foo.txt", deno::Basename("/home/ryan/foo.txt"));
   EXPECT_EQ("foo.txt", deno::Basename("C:\\home\\ryan\\foo.txt"));
 }
 
-// TODO(ry) success unit test. Needs a tempfile or fixture.
-// TEST(FileUtilTest, ReadFileToStringSuccess) { }
+TEST(FileUtilTest, Dirname) {
+  EXPECT_EQ("home/dank/", deno::Dirname("home/dank/memes.gif"));
+  EXPECT_EQ("/home/dank/", deno::Dirname("/home/dank/memes.gif"));
+  EXPECT_EQ("/home/dank/", deno::Dirname("/home/dank/"));
+  EXPECT_EQ("home/dank/", deno::Dirname("home/dank/memes.gif"));
+  EXPECT_EQ("/", deno::Dirname("/"));
+  EXPECT_EQ(".\\", deno::Dirname(".\\memes.gif"));
+  EXPECT_EQ("c:\\", deno::Dirname("c:\\stuff"));
+  EXPECT_EQ("./", deno::Dirname("nothing"));
+  EXPECT_EQ("./", deno::Dirname(""));
+}
+
+TEST(FileUtilTest, ExePath) {
+  std::string exe_path;
+  EXPECT_TRUE(deno::ExePath(&exe_path));
+  // Path is absolute.
+  EXPECT_TRUE(exe_path.find("/") == 0 || exe_path.find(":\\") == 1);
+  // FIlename is the name of the test binary.
+  std::string exe_filename = deno::Basename(exe_path);
+  EXPECT_EQ(exe_filename.find("test_cc"), 0);
+  // Path exists (also tests ReadFileToString).
+  std::string contents;
+  EXPECT_TRUE(deno::ReadFileToString(exe_path.c_str(), &contents));
+  EXPECT_NE(contents.find("Inception :)"), std::string::npos);
+}

--- a/tools/format.py
+++ b/tools/format.py
@@ -13,7 +13,7 @@ rustfmt_config = os.path.join(tools_path, "rustfmt.toml")
 os.chdir(root_path)
 
 run([clang_format_path, "-i", "-style", "Google"] +
-    find_exts("src", ".cc", ".h"))
+    find_exts("libdeno", ".cc", ".h"))
 
 for fn in ["BUILD.gn", ".gn"] + find_exts("build_extra", ".gn", ".gni"):
     run(["third_party/depot_tools/gn", "format", fn], env=google_env())

--- a/tslint.json
+++ b/tslint.json
@@ -64,7 +64,5 @@
       "allow-trailing-underscore"
     ]
   },
-  "extends": [
-    "tslint-no-circular-imports"
-  ]
+  "extends": ["tslint-no-circular-imports"]
 }


### PR DESCRIPTION
* Free minor fix pack included.
* Using absolute paths in the build inhibits reuse of ccache'd object code.
* Example of the CI "abs path" alarm going off: https://ci.appveyor.com/project/deno/deno/build/621.master#L738