### PR TITLE
Add libdeno.setGlobalErrorHandler

### DIFF
--- a/js/globals.ts
+++ b/js/globals.ts
@@ -1,7 +1,6 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 
 import { Console } from "./console";
-import { exit } from "./os";
 import * as timers from "./timers";
 import { TextDecoder, TextEncoder } from "./text_encoding";
 import * as fetch_ from "./fetch";
@@ -12,13 +11,6 @@ declare global {
   interface Window {
     console: Console;
     define: Readonly<unknown>;
-    onerror?: (
-      message: string,
-      source: string,
-      lineno: number,
-      colno: number,
-      error: Error
-    ) => void;
   }
 
   const clearTimeout: typeof timers.clearTimer;
@@ -43,30 +35,12 @@ window.window = window;
 
 window.libdeno = null;
 
-// import "./url";
-
 window.setTimeout = timers.setTimeout;
 window.setInterval = timers.setInterval;
 window.clearTimeout = timers.clearTimer;
 window.clearInterval = timers.clearTimer;
 
 window.console = new Console(libdeno.print);
-// Uncaught exceptions are sent to window.onerror by the privileged binding.
-window.onerror = (
-  message: string,
-  source: string,
-  lineno: number,
-  colno: number,
-  error: Error
-) => {
-  // TODO Currently there is a bug in v8_source_maps.ts that causes a
-  // segfault if it is used within window.onerror. To workaround we
-  // uninstall the Error.prepareStackTrace handler. Users will get unmapped
-  // stack traces on uncaught exceptions until this issue is fixed.
-  //Error.prepareStackTrace = null;
-  console.log(error.stack);
-  exit(1);
-};
 window.TextEncoder = TextEncoder;
 window.TextDecoder = TextDecoder;
 

--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -10,6 +10,16 @@ interface Libdeno {
 
   print(x: string): void;
 
+  setGlobalErrorHandler: (
+    handler: (
+      message: string,
+      source: string,
+      line: number,
+      col: number,
+      error: Error
+    ) => void
+  ) => void;
+
   mainSource: string;
   mainSourceMap: RawSourceMap;
 }

--- a/js/main.ts
+++ b/js/main.ts
@@ -43,9 +43,21 @@ function onMessage(ui8: Uint8Array) {
   }
 }
 
+function onGlobalError(
+  message: string,
+  source: string,
+  lineno: number,
+  colno: number,
+  error: Error
+) {
+  console.log(error.stack);
+  os.exit(1);
+}
+
 /* tslint:disable-next-line:no-default-export */
 export default function denoMain() {
   libdeno.recv(onMessage);
+  libdeno.setGlobalErrorHandler(onGlobalError);
   const compiler = DenoCompiler.instance();
 
   // First we send an empty "Start" message to let the privlaged side know we

--- a/libdeno/internal.h
+++ b/libdeno/internal.h
@@ -13,6 +13,7 @@ struct deno_s {
   const v8::FunctionCallbackInfo<v8::Value>* currentArgs;
   std::string last_exception;
   v8::Persistent<v8::Function> recv;
+  v8::Persistent<v8::Function> global_error_handler;
   v8::Persistent<v8::Context> context;
   deno_recv_cb cb;
   void* data;
@@ -28,9 +29,11 @@ struct InternalFieldData {
 void Print(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Recv(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Send(const v8::FunctionCallbackInfo<v8::Value>& args);
+void SetGlobalErrorHandler(const v8::FunctionCallbackInfo<v8::Value>& args);
 static intptr_t external_references[] = {reinterpret_cast<intptr_t>(Print),
                                          reinterpret_cast<intptr_t>(Recv),
-                                         reinterpret_cast<intptr_t>(Send), 0};
+                                         reinterpret_cast<intptr_t>(Send),
+                                         reinterpret_cast<intptr_t>(SetGlobalErrorHandler), 0};
 
 Deno* NewFromSnapshot(void* data, deno_recv_cb cb);
 

--- a/libdeno/libdeno_test.cc
+++ b/libdeno/libdeno_test.cc
@@ -176,15 +176,21 @@ TEST(LibDenoTest, SnapshotBug) {
   deno_delete(d);
 }
 
-TEST(LibDenoTest, ErrorHandling) {
+TEST(LibDenoTest, GlobalErrorHandling) {
   static int count = 0;
-  Deno* d = deno_new(nullptr, [](auto deno, auto buf) {
+  Deno* d = deno_new(nullptr, [](auto _, auto buf) {
     count++;
     EXPECT_EQ(static_cast<size_t>(1), buf.data_len);
     EXPECT_EQ(buf.data_ptr[0], 42);
   });
-  EXPECT_FALSE(deno_execute(d, "a.js", "ErrorHandling()"));
+  EXPECT_FALSE(deno_execute(d, "a.js", "GlobalErrorHandling()"));
   EXPECT_EQ(count, 1);
+  deno_delete(d);
+}
+
+TEST(LibDenoTest, DoubleGlobalErrorHandlingFails) {
+  Deno* d = deno_new(nullptr, nullptr);
+  EXPECT_FALSE(deno_execute(d, "a.js", "DoubleGlobalErrorHandlingFails()"));
   deno_delete(d);
 }
 

--- a/libdeno/libdeno_test.js
+++ b/libdeno/libdeno_test.js
@@ -122,8 +122,8 @@ global.SnapshotBug = () => {
   assert("1,2,3" === String([1, 2, 3]));
 };
 
-global.ErrorHandling = () => {
-  global.onerror = (message, source, line, col, error) => {
+global.GlobalErrorHandling = () => {
+  libdeno.setGlobalErrorHandler((message, source, line, col, error) => {
     libdeno.print(`line ${line} col ${col}`);
     assert("ReferenceError: notdefined is not defined" === message);
     assert(source === "helloworld.js");
@@ -131,8 +131,13 @@ global.ErrorHandling = () => {
     assert(col === 1);
     assert(error instanceof Error);
     libdeno.send(new Uint8Array([42]));
-  };
+  });
   eval("\n\n notdefined()\n//# sourceURL=helloworld.js");
+};
+
+global.DoubleGlobalErrorHandlingFails = () => {
+  libdeno.setGlobalErrorHandler((message, source, line, col, error) => {});
+  libdeno.setGlobalErrorHandler((message, source, line, col, error) => {});
 };
 
 global.SendNullAllocPtr = () => {


### PR DESCRIPTION
This PR tries to resolve #553.

- I added libdeno.setGlobalErrorHandler and replaced the use of window.onerror with it.
- Updated the test cases of handling of uncaught errors.