### PR TITLE
Replaced read_file_sync{_string} with std::fs::read{_to_string}

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,22 +1,7 @@
 use std;
 use std::fs::File;
-use std::io::Read;
 use std::io::Write;
 use std::path::Path;
-
-pub fn read_file_sync(path: &Path) -> std::io::Result<Vec<u8>> {
-  File::open(path).and_then(|mut f| {
-    let mut buffer = Vec::new();
-    f.read_to_end(&mut buffer)?;
-    Ok(buffer)
-  })
-}
-
-pub fn read_file_sync_string(path: &Path) -> std::io::Result<String> {
-  let vec = read_file_sync(path)?;
-  String::from_utf8(vec)
-    .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))
-}
 
 pub fn write_file_sync(path: &Path, content: &[u8]) -> std::io::Result<()> {
   let mut f = File::create(path)?;


### PR DESCRIPTION
The std version is generally better as it will preallocate the Vec/String based on file size leading to faster reads. This will bump the minimum needed rustc version to 1.26.0, though I couldn't find any documentation on whether deno has a minimum version to support other than stable.