### PR TITLE
Moved console tests to own file

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -13,7 +13,7 @@ function getClassInstanceName(instance: any): string {
 }
 
 // tslint:disable-next-line:no-any
-export function stringify(ctx: ConsoleContext, value: any): string {
+function stringify(ctx: ConsoleContext, value: any): string {
   switch (typeof value) {
     case "string":
       return value;
@@ -95,7 +95,7 @@ function stringifyWithQuotes(ctx: ConsoleContext, value: any): string {
 }
 
 // tslint:disable-next-line:no-any
-function stringifyArgs(args: any[]): string {
+export function stringifyArgs(args: any[]): string {
   const out: string[] = [];
   for (const a of args) {
     if (typeof a === "string") {

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -1,0 +1,82 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+
+import { test, assert, assertEqual } from "./testing/testing.ts";
+import { stringifyArgs } from "./console.ts";
+
+// tslint:disable-next-line:no-any
+function stringify(...args: any[]): string {
+  return stringifyArgs(args);
+}
+
+test(function consoleTestAssert() {
+  console.assert(true);
+
+  let hasThrown = false;
+  try {
+    console.assert(false);
+  } catch {
+    hasThrown = true;
+  }
+  assertEqual(hasThrown, true);
+});
+
+test(function consoleTestStringifyComplexObjects() {
+  assertEqual(stringify("foo"), "foo");
+  assertEqual(stringify(["foo", "bar"]), `[ "foo", "bar" ]`);
+  assertEqual(stringify({ foo: "bar" }), `{ foo: "bar" }`);
+});
+
+test(function consoleTestStringifyCircular() {
+  class Base {
+    a = 1;
+    m1() {}
+  }
+
+  class Extended extends Base {
+    b = 2;
+    m2() {}
+  }
+
+  // tslint:disable-next-line:no-any
+  const nestedObj: any = {
+    num: 1,
+    bool: true,
+    str: "a",
+    method() {},
+    un: undefined,
+    nu: null,
+    arrowFunc: () => {},
+    extendedClass: new Extended(),
+    nFunc: new Function(),
+    extendedCstr: Extended
+  };
+
+  const circularObj = {
+    num: 2,
+    bool: false,
+    str: "b",
+    method() {},
+    un: undefined,
+    nu: null,
+    nested: nestedObj,
+    emptyObj: {},
+    arr: [1, "s", false, null, nestedObj],
+    baseClass: new Base()
+  };
+
+  nestedObj.o = circularObj;
+
+  const nestedObjExpected = `{ num: 1, bool: true, str: "a", method: [Function: method], un: undefined, nu: null, arrowFunc: [Function: arrowFunc], extendedClass: Extended { a: 1, b: 2 }, nFunc: [Function], extendedCstr: [Function: Extended], o: { num: 2, bool: false, str: "b", method: [Function: method], un: undefined, nu: null, nested: [Circular], emptyObj: {}, arr: [ 1, "s", false, null, [Circular] ], baseClass: Base { a: 1 } } }`;
+
+  assertEqual(stringify(1), "1");
+  assertEqual(stringify("s"), "s");
+  assertEqual(stringify(false), "false");
+  assertEqual(stringify(Symbol(1)), "Symbol(1)");
+  assertEqual(stringify(null), "null");
+  assertEqual(stringify(undefined), "undefined");
+  assertEqual(stringify(new Extended()), "Extended { a: 1, b: 2 }");
+  assertEqual(stringify(function f() {}), "[Function: f]");
+  assertEqual(stringify(nestedObj), nestedObjExpected);
+  assertEqual(stringify(JSON), "{}");
+  assertEqual(stringify(console), "Console { printFunc: [Function], debug: [Function: log], info: [Function: log], error: [Function: warn] }");
+});

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -5,90 +5,13 @@
 
 import { test, assert, assertEqual } from "./testing/testing.ts";
 import { readFileSync } from "deno";
-import { stringify } from "./console.ts";
 import * as deno from "deno";
 
 import "./compiler_test.ts";
+import "./console_test.ts";
 
 test(async function tests_test() {
   assert(true);
-});
-
-test(function tests_console_assert() {
-  console.assert(true);
-
-  let hasThrown = false;
-  try {
-    console.assert(false);
-  } catch {
-    hasThrown = true;
-  }
-  assertEqual(hasThrown, true);
-});
-
-test(function tests_console_stringify_complex_objects() {
-  // tslint:disable:no-any
-  assertEqual("foo", stringify(new Set<any>(), "foo"));
-  assertEqual(`[ "foo", "bar" ]`, stringify(new Set<any>(), ["foo", "bar"]));
-  assertEqual(`{ foo: "bar" }`, stringify(new Set<any>(), { foo: "bar" }));
-  // tslint:enable:no-any
-});
-
-test(function tests_console_stringify_circular() {
-  class Base {
-    a = 1;
-    m1() {}
-  }
-
-  class Extended extends Base {
-    b = 2;
-    m2() {}
-  }
-
-  // tslint:disable-next-line:no-any
-  const nestedObj: any = {
-    num: 1,
-    bool: true,
-    str: "a",
-    method() {},
-    un: undefined,
-    nu: null,
-    arrowFunc: () => {},
-    extendedClass: new Extended(),
-    nFunc: new Function(),
-    extendedCstr: Extended
-  };
-
-  const circularObj = {
-    num: 2,
-    bool: false,
-    str: "b",
-    method() {},
-    un: undefined,
-    nu: null,
-    nested: nestedObj,
-    emptyObj: {},
-    arr: [1, "s", false, null, nestedObj],
-    baseClass: new Base()
-  };
-
-  nestedObj.o = circularObj;
-
-  try {
-    console.log(1);
-    console.log("s");
-    console.log(false);
-    console.log(Symbol(1));
-    console.log(null);
-    console.log(undefined);
-    console.log(new Extended());
-    console.log(function f() {});
-    console.log(nestedObj);
-    console.log(JSON);
-    console.log(console);
-  } catch {
-    throw new Error("Expected no crash on circular object");
-  }
 });
 
 test(async function tests_readFileSync() {


### PR DESCRIPTION
Switched circular test to use stringify with assertEqual. Also `testStringify` function that matches `console.log`'s arguments to reduce code reuse.