### PR TITLE
Implemented deno.statSync

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -1,5 +1,13 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 // Public deno module.
-export { exit, makeTempDirSync, readFileSync, writeFileSync } from "./os";
+export {
+  exit,
+  FileInfo,
+  makeTempDirSync,
+  readFileSync,
+  statSync,
+  lStatSync,
+  writeFileSync
+} from "./os";
 export { libdeno } from "./libdeno";
 export const argv: string[] = [];

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -13,6 +13,70 @@ test(async function tests_test() {
   assert(true);
 });
 
+// TODO Add tests for modified, accessed, and created fields once there is a way
+// to create temp files.
+test(async function statSyncSuccess() {
+  const packageInfo = deno.statSync("package.json");
+  assert(packageInfo.isFile());
+  assert(!packageInfo.isSymlink());
+
+  const testingInfo = deno.statSync("testing");
+  assert(testingInfo.isDirectory());
+  assert(!testingInfo.isSymlink());
+
+  const srcInfo = deno.statSync("src");
+  assert(srcInfo.isDirectory());
+  assert(!srcInfo.isSymlink());
+})
+
+test(async function statSyncNotFound() {
+  let caughtError = false;
+  let badInfo;
+
+  try {
+    badInfo = deno.statSync("bad_file_name");
+  } catch (err) {
+    caughtError = true;
+    // TODO assert(err instanceof deno.NotFound).
+    assert(err);
+    assertEqual(err.name, "deno.NotFound");
+  }
+
+  assert(caughtError);
+  assertEqual(badInfo, undefined);
+});
+
+test(async function lStatSyncSuccess() {
+  const packageInfo = deno.lStatSync("package.json");
+  assert(packageInfo.isFile());
+  assert(!packageInfo.isSymlink());
+
+  const testingInfo = deno.lStatSync("testing");
+  assert(!testingInfo.isDirectory());
+  assert(testingInfo.isSymlink());
+
+  const srcInfo = deno.lStatSync("src");
+  assert(srcInfo.isDirectory());
+  assert(!srcInfo.isSymlink());
+})
+
+test(async function lStatSyncNotFound() {
+  let caughtError = false;
+  let badInfo;
+
+  try {
+    badInfo = deno.lStatSync("bad_file_name");
+  } catch (err) {
+    caughtError = true;
+    // TODO assert(err instanceof deno.NotFound).
+    assert(err);
+    assertEqual(err.name, "deno.NotFound");
+  }
+
+  assert(caughtError);
+  assertEqual(badInfo, undefined);
+});
+
 test(async function tests_readFileSync() {
   const data = deno.readFileSync("package.json");
   if (!data.byteLength) {

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -16,6 +16,8 @@ union Any {
   MakeTempDirRes,
   ReadFileSync,
   ReadFileSyncRes,
+  StatSync,
+  StatSyncRes,
   WriteFileSync,
 }
 
@@ -151,6 +153,20 @@ table ReadFileSync {
 
 table ReadFileSyncRes {
   data: [ubyte];
+}
+
+table StatSync {
+  filename: string;
+  lstat: bool;
+}
+
+table StatSyncRes {
+  is_file: bool;
+  is_symlink: bool;
+  len: ulong;
+  modified:ulong;
+  accessed:ulong;
+  created:ulong;
 }
 
 table WriteFileSync {


### PR DESCRIPTION
This is essentially a basic version Rust's `Metadata`, currently it only contains cross platform functionality, but could be expanded to optionally include platform specific metadata.