### PR TITLE
Bundle most types into globals.d.ts

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -186,23 +186,23 @@ executable("snapshot_creator") {
 run_node("gen_declarations") {
   out_dir = target_gen_dir
   sources = [
+    "js/assets.ts",
     "js/compiler.ts",
     "js/console.ts",
     "js/deno.ts",
+    "js/fetch.ts",
+    "js/global-eval.ts",
     "js/globals.ts",
     "js/os.ts",
+    "js/text_encoding.ts",
     "js/timers.ts",
     "js/tsconfig.generated.json",
+    "js/types.ts",
     "js/util.ts",
+    "js/v8_source_maps.ts"
   ]
   outputs = [
-    out_dir + "/js/compiler.d.ts",
-    out_dir + "/js/console.d.ts",
-    out_dir + "/js/deno.d.ts",
-    out_dir + "/js/globals.d.ts",
-    out_dir + "/js/os.d.ts",
-    out_dir + "/js/timers.d.ts",
-    out_dir + "/js/util.d.ts",
+    "$out_dir/types/globals.d.ts",
   ]
   deps = [
     ":msg_ts",
@@ -213,8 +213,8 @@ run_node("gen_declarations") {
     rebase_path("js/tsconfig.generated.json", root_build_dir),
     "--baseUrl",
     rebase_path(root_build_dir, root_build_dir),
-    "--outDir",
-    rebase_path(out_dir, root_build_dir),
+    "--outFile",
+    rebase_path("$out_dir/types/globals.js", root_build_dir),
   ]
 }
 
@@ -233,7 +233,7 @@ run_node("bundle") {
     "js/plugins.d.ts",
     "js/text_encoding.ts",
     "js/timers.ts",
-    "js/types.d.ts",
+    "js/types.ts",
     "js/util.ts",
     "js/v8_source_maps.ts",
     "rollup.config.js",

--- a/js/assets.ts
+++ b/js/assets.ts
@@ -1,21 +1,13 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 
 // tslint:disable-next-line:no-reference
-/// <reference path="plugins.d.ts" />
+/// <reference path="./plugins.d.ts" />
 
 // There is a rollup plugin that will inline any module ending with `!string`
 // tslint:disable:max-line-length
 
 // Generated definitions
-import compilerDts from "gen/js/compiler.d.ts!string";
-import consoleDts from "gen/js/console.d.ts!string";
-import denoDts from "gen/js/deno.d.ts!string";
-import libdenoDts from "gen/js/libdeno.d.ts!string";
-import globalsDts from "gen/js/globals.d.ts!string";
-import osDts from "gen/js/os.d.ts!string";
-import fetchDts from "gen/js/fetch.d.ts!string";
-import timersDts from "gen/js/timers.d.ts!string";
-import utilDts from "gen/js/util.d.ts!string";
+import globalsDts from "gen/types/globals.d.ts!string";
 
 // Static libraries
 import libEs2015Dts from "/third_party/node_modules/typescript/lib/lib.es2015.d.ts!string";
@@ -49,24 +41,16 @@ import libEsnextSymbolDts from "/third_party/node_modules/typescript/lib/lib.esn
 import libGlobalsDts from "/js/lib.globals.d.ts!string";
 
 // Static definitions
-import typescriptDts from "/third_party/node_modules/typescript/lib/typescript.d.ts!string";
-import typesDts from "/js/types.d.ts!string";
 import fetchTypesDts from "/js/fetch_types.d.ts!string";
+import flatbuffersDts from "/third_party/node_modules/@types/flatbuffers/index.d.ts!string";
+import textEncodingDts from "/third_party/node_modules/@types/text-encoding/index.d.ts!string";
+import typescriptDts from "/third_party/node_modules/typescript/lib/typescript.d.ts!string";
 // tslint:enable:max-line-length
 
 // prettier-ignore
 export const assetSourceCode: { [key: string]: string } = {
   // Generated definitions
-  "compiler.d.ts": compilerDts,
-  "console.d.ts": consoleDts,
-  "deno.d.ts": denoDts,
-  "libdeno.d.ts": libdenoDts,
   "globals.d.ts": globalsDts,
-  "os.d.ts": osDts,
-  "fetch.d.ts": fetchDts,
-  "fetch_types.d.ts": fetchTypesDts,
-  "timers.d.ts": timersDts,
-  "util.d.ts": utilDts,
 
   // Static libraries
   "lib.es2015.collection.d.ts": libEs2015CollectionDts,
@@ -100,9 +84,8 @@ export const assetSourceCode: { [key: string]: string } = {
   "lib.globals.d.ts": libGlobalsDts,
 
   // Static definitions
+  "fetch-types.d.ts": fetchTypesDts,
+  "flatbuffers.d.ts": flatbuffersDts,
+  "text-encoding.d.ts": textEncodingDts,
   "typescript.d.ts": typescriptDts,
-  "types.d.ts": typesDts,
-
-  // TODO Remove.
-  "msg_generated.d.ts": "",
 };

--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -1,4 +1,5 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
+/// <amd-module name="compiler"/>
 import * as ts from "typescript";
 import { assetSourceCode } from "./assets";
 import * as deno from "./deno";
@@ -669,10 +670,9 @@ export class DenoCompiler implements ts.LanguageServiceHost {
     this._log("resolveModuleNames()", { moduleNames, containingFile });
     return moduleNames.map(name => {
       let resolvedFileName;
-      if (name === "deno") {
-        resolvedFileName = this.resolveModuleName("deno.d.ts", ASSETS);
-      } else if (name === "compiler") {
-        resolvedFileName = this.resolveModuleName("compiler.d.ts", ASSETS);
+      if (name === "deno" || name === "compiler") {
+        // builtin modules are part of `globals.d.ts`
+        resolvedFileName = this.resolveModuleName("globals.d.ts", ASSETS);
       } else if (name === "typescript") {
         resolvedFileName = this.resolveModuleName("typescript.d.ts", ASSETS);
       } else {

--- a/js/compiler_test.ts
+++ b/js/compiler_test.ts
@@ -474,7 +474,7 @@ test(function compilerFileExists() {
     "/root/project"
   );
   assert(compilerInstance.fileExists(moduleMetaData.fileName));
-  assert(compilerInstance.fileExists("$asset$/compiler.d.ts"));
+  assert(compilerInstance.fileExists("$asset$/globals.d.ts"));
   assertEqual(
     compilerInstance.fileExists("/root/project/unknown-module.ts"),
     false
@@ -493,7 +493,7 @@ test(function compilerResolveModuleNames() {
     ["/root/project/foo/bar.ts", false],
     ["/root/project/foo/baz.ts", false],
     ["$asset$/lib.globals.d.ts", true],
-    ["$asset$/deno.d.ts", true]
+    ["$asset$/globals.d.ts", true]
   ];
   for (let i = 0; i < results.length; i++) {
     const result = results[i];

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -1,5 +1,6 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 // Public deno module.
+/// <amd-module name="deno"/>
 export {
   env,
   exit,

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -2,7 +2,7 @@
 
 import { Console } from "./console";
 import * as timers from "./timers";
-import { TextDecoder, TextEncoder } from "./text_encoding";
+import * as textEncoding from "./text_encoding";
 import * as fetch_ from "./fetch";
 import { libdeno } from "./libdeno";
 import { globalEval } from "./global-eval";
@@ -24,8 +24,8 @@ declare global {
   const fetch: typeof fetch_.fetch;
 
   // tslint:disable:variable-name
-  let TextEncoder: TextEncoder;
-  let TextDecoder: TextDecoder;
+  let TextEncoder: typeof textEncoding.TextEncoder;
+  let TextDecoder: typeof textEncoding.TextDecoder;
   // tslint:enable:variable-name
 }
 
@@ -41,7 +41,7 @@ window.clearTimeout = timers.clearTimer;
 window.clearInterval = timers.clearTimer;
 
 window.console = new Console(libdeno.print);
-window.TextEncoder = TextEncoder;
-window.TextDecoder = TextDecoder;
+window.TextEncoder = textEncoding.TextEncoder;
+window.TextDecoder = textEncoding.TextDecoder;
 
 window.fetch = fetch_.fetch;

--- a/js/lib.globals.d.ts
+++ b/js/lib.globals.d.ts
@@ -2,4 +2,4 @@
 // This file contains the default TypeScript libraries for the deno runtime.
 /// <reference no-default-lib="true"/>
 /// <reference lib="esnext" />
-import "gen/js/globals";
+/// <reference path="globals.d.ts"/>

--- a/js/os.ts
+++ b/js/os.ts
@@ -128,8 +128,8 @@ export function readFileSync(filename: string): Uint8Array {
   return new Uint8Array(dataArray!);
 }
 
-function createEnv(_msg: fbs.EnvironRes): { [index:string]: string } {
-  const env: { [index:string]: string } = {};
+function createEnv(_msg: fbs.EnvironRes): { [index: string]: string } {
+  const env: { [index: string]: string } = {};
 
   for (let i = 0; i < _msg.mapLength(); i++) {
     const item = _msg.map(i)!;
@@ -169,7 +169,7 @@ function setEnv(key: string, value: string): void {
  *     const newEnv = deno.env();
  *     console.log(env.TEST_VAR == newEnv.TEST_VAR);
  */
-export function env(): { [index:string]: string } {
+export function env(): { [index: string]: string } {
   /* Ideally we could write
   const res = send({
     command: fbs.Command.ENV,

--- a/js/tsconfig.generated.json
+++ b/js/tsconfig.generated.json
@@ -7,6 +7,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
+    "module": "amd",
     "stripInternal": true
   },
   "files": [

--- a/js/types.ts
+++ b/js/types.ts
@@ -8,6 +8,7 @@ export interface ModuleInfo {
   outputCode: string | null;
 }
 
+// tslint:disable:max-line-length
 // Following definitions adapted from:
 //   https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts
 // Type definitions for Node.js 10.3.x
@@ -36,11 +37,13 @@ export interface ModuleInfo {
 //                 Alexander T. <https://github.com/a-tarasyuk>
 //                 Lishude <https://github.com/islishude>
 //                 Andrew Makarov <https://github.com/r3nya>
+// tslint:enable:max-line-length
 
 export interface CallSite {
   /**
    * Value of "this"
    */
+  // tslint:disable-next-line:no-any
   getThis(): any;
 
   /**
@@ -133,13 +136,16 @@ declare global {
   // Declare "static" methods in Error
   interface ErrorConstructor {
     /** Create .stack property on a target object */
-    captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
+    captureStackTrace(targetObject: object, constructorOpt?: Function): void;
 
+    // tslint:disable:max-line-length
     /**
      * Optional override for formatting stack traces
      *
      * @see https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
      */
+    // tslint:enable:max-line-length
+    // tslint:disable-next-line:no-any
     prepareStackTrace?: (err: Error, stackTraces: CallSite[]) => any;
 
     stackTraceLimit: number;

--- a/tests/error_003_typescript.ts.out
+++ b/tests/error_003_typescript.ts.out
@@ -4,7 +4,7 @@
 [30;47m [0m [91m~~~~~~[0m
 
   [96m$asset$/globals.d.ts[WILDCARD]
-    [30;47m[WILDCARD][0m     const console: Console;
-    [30;47m  [0m [96m          ~~~~~~~[0m
+    [30;47m[WILDCARD][0m         const console: Console;
+    [30;47m   [0m [96m              ~~~~~~~[0m
     'console' is declared here.
 


### PR DESCRIPTION
Refs: #632 

This PR is a step towards generating a single definition file for all types in deno.

For the dynamically generated types files, they are now bundled into a single file and inlined in the `assets["globals.d.ts"]` object.  There are still 3 external type files that are not part of the bundle:

- `typescript.d.ts` - Likely should always be inlined directly.
- `text-encoding.d.ts` - This is the types for a node module import that we need the types for.  It maybe difficult to inline.
- `fetch_types.d.ts` - These types are written as ambient/global types.  Further changes in another PR to make this into a UMD/modular definition file could be done so that it can be renamed `fetch_types.ts` and then bundled like other modules.
