### PR TITLE
Implemented deno.env and refactored flags.rs

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -1,6 +1,7 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 // Public deno module.
 export {
+  env,
   exit,
   FileInfo,
   makeTempDirSync,

--- a/js/os_test.ts
+++ b/js/os_test.ts
@@ -2,6 +2,27 @@
 import { test, testPerm, assert, assertEqual } from "./test_util.ts";
 import * as deno from "deno";
 
+testPerm({ env: true }, async function envSuccess() {
+  const env = deno.env();
+  assert(env !== null);
+  env.test_var = "Hello World";
+  const newEnv = deno.env();
+  assertEqual(env.test_var, newEnv.test_var);
+});
+
+test(async function envFailure() {
+  let caughtError = false;
+  try {
+    const env = deno.env();
+  } catch (err) {
+    caughtError = true;
+    // TODO assert(err instanceof deno.PermissionDenied).
+    assertEqual(err.name, "deno.PermissionDenied");
+  }
+
+  assert(caughtError);
+});
+
 // TODO Add tests for modified, accessed, and created fields once there is a way
 // to create temp files.
 test(async function statSyncSuccess() {

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -17,23 +17,26 @@ testing.setFilter(deno.argv[1]);
 interface DenoPermissions {
   write?: boolean;
   net?: boolean;
+  env?: boolean;
 }
 
 function permToString(perms: DenoPermissions): string {
   const w = perms.write ? 1 : 0;
   const n = perms.net ? 1 : 0;
-  return `permW${w}N${n}`;
+  const e = perms.env ? 1 : 0;
+  return `permW${w}N${n}E${e}`;
 }
 
 function permFromString(s: string): DenoPermissions {
-  const re = /^permW([01])N([01])$/;
+  const re = /^permW([01])N([01])E([01])$/;
   const found = s.match(re);
   if (!found) {
     throw Error("Not a permission string");
   }
   return {
     write: Boolean(Number(found[1])),
-    net: Boolean(Number(found[2]))
+    net: Boolean(Number(found[2])),
+    env: Boolean(Number(found[3])),
   };
 }
 
@@ -43,14 +46,16 @@ export function testPerm(perms: DenoPermissions, fn: testing.TestFunction) {
 }
 
 export function test(fn: testing.TestFunction) {
-  testPerm({ write: false, net: false }, fn);
+  testPerm({ write: false, net: false, env: false }, fn);
 }
 
 test(function permSerialization() {
-  for (let write of [true, false]) {
-    for (let net of [true, false]) {
-      let perms: DenoPermissions = { write, net };
-      testing.assertEqual(perms, permFromString(permToString(perms)));
+  for (const write of [true, false]) {
+    for (const net of [true, false]) {
+      for (const env of [true, false]) {
+        const perms: DenoPermissions = { write, net, env };
+        testing.assertEqual(perms, permFromString(permToString(perms)));
+      }
     }
   }
 });

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -10,6 +10,8 @@ union Any {
   TimerStart,
   TimerReady,
   TimerClear,
+  Environ,
+  EnvironRes,
   FetchReq,
   FetchRes,
   MakeTempDir,
@@ -18,6 +20,7 @@ union Any {
   ReadFileSyncRes,
   StatSync,
   StatSyncRes,
+  SetEnv,
   WriteFileSync,
 }
 
@@ -122,6 +125,22 @@ table TimerReady {
 
 table TimerClear {
   id: uint;
+}
+
+table Environ {}
+
+table SetEnv {
+    key: string;
+    value: string;
+}
+
+table EnvironRes {
+    map: [EnvPair];
+}
+
+table EnvPair {
+    key: string;
+    value: string;
 }
 
 table FetchReq {

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -10,12 +10,14 @@ import sys
 # tests by the special string. permW0N0 means allow-write but not allow-net.
 # See js/test_util.ts for more details.
 def unit_tests(deno_exe):
-    run([deno_exe, "js/unit_tests.ts", "permW0N0"])
-    run([deno_exe, "js/unit_tests.ts", "permW1N0", "--allow-write"])
-    run([deno_exe, "js/unit_tests.ts", "permW0N1", "--allow-net"])
+    run([deno_exe, "js/unit_tests.ts", "permW0N0E0"])
+    run([deno_exe, "js/unit_tests.ts", "permW1N0E0", "--allow-write"])
+    run([deno_exe, "js/unit_tests.ts", "permW0N1E0", "--allow-net"])
+    run([deno_exe, "js/unit_tests.ts", "permW0N0E1", "--allow-env"])
     run([
-        deno_exe, "js/unit_tests.ts", "permW1N1", "--allow-write",
-        "--allow-net"
+        deno_exe, "js/unit_tests.ts", "permW1N1E1", "--allow-write",
+        "--allow-net",
+        "--allow-env",
     ])
 
 


### PR DESCRIPTION
Resolves #631 

* **Node:** [`process.env`](https://nodejs.org/api/process.html#process_process_env) returns an object that allows you to mutate environment variables with objects setters. This implementation copies that.

* **Rust:** [`env::vars`](https://doc.rust-lang.org/std/env/fn.vars.html) returns an iterator of key-value pair, for getting single environment variables rust has [`env::var`](https://doc.rust-lang.org/std/env/fn.var.html) and  [`env::set_var`](https://doc.rust-lang.org/std/env/fn.set_var.html) for getting and setting single variables.

* **Go:** [`os.Environ`](https://golang.org/pkg/os/#Environ) returns a list of strings in the `key=value` format.

* **Ruby:** [`ENV`](https://ruby-doc.org/core-2.1.4/ENV.html) is a class with various methods for getting, setting, converting into an iterator, arrays, etc.

* **Python:** [`os.environ`](https://docs.python.org/2/library/os.html#os.environ) is similar to Node's a approach of having a singleton dict with getters and setter for manipulating environment variables.

This PR as makes a small refactor to `flags.rs` to reduce LoC and to print better error messages by using `assert_eq!(x, y)` macro instead of `assert!(x == y)`.