### PR TITLE
Implemented deno.readDirSync

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -6,6 +6,7 @@ export { mkdirSync, mkdir } from "./mkdir";
 export { makeTempDirSync, makeTempDir } from "./make_temp_dir";
 export { removeSync, remove, removeAllSync, removeAll } from "./remove";
 export { readFileSync, readFile } from "./read_file";
+export { readDirSync, readDir } from "./read_dir";
 export { renameSync, rename } from "./rename";
 export { FileInfo, statSync, lstatSync, stat, lstat } from "./stat";
 export { symlinkSync, symlink } from "./symlink";

--- a/js/read_dir.ts
+++ b/js/read_dir.ts
@@ -1,0 +1,55 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import * as fbs from "gen/msg_generated";
+import { flatbuffers } from "flatbuffers";
+import * as dispatch from "./dispatch";
+import { FileInfo } from "./stat";
+import { assert } from "./util";
+
+/**
+ * Queries the file system for information on the path provided.
+ * `stat` Will always follow symlinks.
+ *
+ *     import { stat } from "deno";
+ *     const fileInfo = await deno.stat("hello.txt");
+ *     assert(fileInfo.isFile());
+ */
+export async function readDir(filename: string): Promise<FileInfo[]> {
+  return res(await dispatch.sendAsync(...req(filename)));
+}
+
+/**
+ * Queries the file system for information on the path provided synchronously.
+ * `statSync` Will always follow symlinks.
+ *
+ *     import { statSync } from "deno";
+ *     const fileInfo = deno.statSync("hello.txt");
+ *     assert(fileInfo.isFile());
+ */
+export function readDirSync(filename: string): FileInfo[] {
+  return res(dispatch.sendSync(...req(filename)));
+}
+
+function req(
+  filename: string,
+): [flatbuffers.Builder, fbs.Any, flatbuffers.Offset] {
+  const builder = new flatbuffers.Builder();
+  const filename_ = builder.createString(filename);
+  fbs.ReadDir.startReadDir(builder);
+  fbs.ReadDir.addFilename(builder, filename_);
+  const msg = fbs.ReadDir.endReadDir(builder);
+  return [builder, fbs.Any.ReadDir, msg];
+}
+
+function res(baseRes: null | fbs.Base): FileInfo[] {
+  assert(baseRes != null);
+  assert(fbs.Any.ReadDirRes === baseRes!.msgType());
+  const res = new fbs.ReadDirRes();
+  assert(baseRes!.msg(res) != null);
+  const fileInfos: FileInfo[] = [];
+
+  for (let i = 0; i < res.entriesLength(); i++) {
+    fileInfos.push(new FileInfo(res.entries(i)!));
+  }
+
+  return fileInfos;
+}

--- a/js/read_dir_test.ts
+++ b/js/read_dir_test.ts
@@ -1,0 +1,49 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import { test, testPerm, assert, assertEqual } from "./test_util.ts";
+import * as deno from "deno";
+
+testPerm({ write: true }, async function readDirSuccess() {
+  const dirName = deno.makeTempDirSync();
+  const enc = new TextEncoder();
+  const data = enc.encode("Hello");
+  deno.writeFileSync(`${dirName}/test.txt`, data, 0o666);
+  deno.writeFileSync(`${dirName}/test.rs`, data, 0o666);
+
+  const entries = deno.readDirSync(dirName);
+  assertEqual(entries.length, 2);
+
+  for (const entry of entries) {
+    assert(entry.isFile());
+    assert(entry.name === "test.txt" || entry.name === "test.rs");
+    assert(
+      entry.path === `${dirName}/test.txt` ||
+      entry.path === `${dirName}/test.rs`
+    );
+  }
+});
+
+test(async function readDirSyncNotADir() {
+  let caughtError = false;
+
+  try {
+    const src = deno.readDirSync("Cargo.toml");
+  } catch (err) {
+    caughtError = true;
+    assertEqual(err.kind, deno.ErrorKind.Other);
+  }
+
+  assert(caughtError);
+});
+
+test(async function readDirSyncNotFound() {
+  let caughtError = false;
+
+  try {
+    const src = deno.readDirSync("bad_dir_name");
+  } catch (err) {
+    caughtError = true;
+    assertEqual(err.kind, deno.ErrorKind.NotFound);
+  }
+
+  assert(caughtError);
+});

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -5,6 +5,7 @@ import "./compiler_test.ts";
 import "./console_test.ts";
 import "./fetch_test.ts";
 import "./os_test.ts";
+import "./read_dir_test.ts";
 import "./read_file_test.ts";
 import "./write_file_test.ts";
 import "./mkdir_test.ts";

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -16,6 +16,8 @@ union Any {
   MakeTempDirRes,
   Mkdir,
   Remove,
+  ReadDir,
+  ReadDirRes,
   ReadFile,
   ReadFileRes,
   WriteFile,
@@ -206,12 +208,26 @@ table Symlink {
   newname: string;
 }
 
+table ReadDir {
+  filename: string;
+}
+
+table ReadDirRes {
+  entries: [FileInfo];
+}
+
 table Stat {
   filename: string;
   lstat: bool;
 }
 
 table StatRes {
+  // Workaround for codegen issues. Without the array Flatbuffers will not
+  // declare a lifetime for StatRes that FileInfo requires.
+  info: [FileInfo];
+}
+
+table FileInfo {
   is_file: bool;
   is_symlink: bool;
   len: ulong;
@@ -220,6 +236,8 @@ table StatRes {
   created:ulong;
   mode: uint;
   has_mode: bool; // false on windows
+  name: string;
+  path: string;
 }
 
 root_type Base;


### PR DESCRIPTION
* **Node:** [`fs.readdirSync`](https://nodejs.org/api/fs.html#fs_fs_readdirsync_path_options) returns a list of paths of entries in the path.

* **Rust:** [`fs::read_dir`](https://doc.rust-lang.org/std/fs/fn.read_dir.html) returns an iterator of [`DirEntry`](https://doc.rust-lang.org/std/fs/struct.DirEntry.html)s.

* **Go:** [`ioutil.ReadDir`](https://golang.org/pkg/io/ioutil/#ReadDir) returns a list of [`os.FileInfo`](https://golang.org/pkg/os/#FileInfo)s.

* **Ruby:** [`Dir`](https://ruby-doc.org/core-2.5.1/Dir.html) is a class with various methods for general directory operations such as changing directories. `Dir["dir/"]` returns a array of strings matching the path. This also accepts a general glob pattern as opposed to a strict path.

* **Python:** [`os.listdir`](https://docs.python.org/2/library/os.html#os.listdir) returns an list of paths in arbitrary order.