### PR TITLE
Mark APIs at internal and include JSDoc in types

### DIFF
--- a/js/assets.ts
+++ b/js/assets.ts
@@ -46,7 +46,7 @@ import textEncodingDts from "/third_party/node_modules/@types/text-encoding/inde
 import typescriptDts from "/third_party/node_modules/typescript/lib/typescript.d.ts!string";
 // tslint:enable:max-line-length
 
-// prettier-ignore
+// @internal
 export const assetSourceCode: { [key: string]: string } = {
   // Generated library
   "globals.d.ts": globalsDts,
@@ -85,5 +85,5 @@ export const assetSourceCode: { [key: string]: string } = {
   "fetch-types.d.ts": fetchTypesDts,
   "flatbuffers.d.ts": flatbuffersDts,
   "text-encoding.d.ts": textEncodingDts,
-  "typescript.d.ts": typescriptDts,
+  "typescript.d.ts": typescriptDts
 };

--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -50,6 +50,7 @@ type OutputCode = string;
 /**
  * Abstraction of the APIs required from the `os` module so they can be
  * easily mocked.
+ * @internal
  */
 export interface Os {
   codeCache: typeof os.codeCache;
@@ -60,6 +61,7 @@ export interface Os {
 /**
  * Abstraction of the APIs required from the `typescript` module so they can
  * be easily mocked.
+ * @internal
  */
 export interface Ts {
   createLanguageService: typeof ts.createLanguageService;

--- a/js/compiler_test.ts
+++ b/js/compiler_test.ts
@@ -177,7 +177,7 @@ function globalEvalMock(x: string): void {
 function logMock(...args: any[]): void {
   logStack.push(args);
 }
-const osMock: compiler.Os = {
+const osMock = {
   codeCache(fileName: string, sourceCode: string, outputCode: string): void {
     codeCacheStack.push({ fileName, sourceCode, outputCode });
     if (fileName in moduleCache) {
@@ -205,7 +205,7 @@ const osMock: compiler.Os = {
     throw new Error(`os.exit(${code})`);
   }
 };
-const tsMock: compiler.Ts = {
+const tsMock = {
   createLanguageService(host: ts.LanguageServiceHost): ts.LanguageService {
     return {} as ts.LanguageService;
   },

--- a/js/errors.ts
+++ b/js/errors.ts
@@ -1,5 +1,6 @@
 import { deno as fbs } from "gen/msg_generated";
 
+// @internal
 export class DenoError<T extends fbs.ErrorKind> extends Error {
   constructor(readonly kind: T, msg: string) {
     super(msg);
@@ -7,6 +8,7 @@ export class DenoError<T extends fbs.ErrorKind> extends Error {
   }
 }
 
+// @internal
 export function maybeThrowError(base: fbs.Base): void {
   const kind = base.errorKind();
   if (kind !== fbs.ErrorKind.NoError) {

--- a/js/fbs_util.ts
+++ b/js/fbs_util.ts
@@ -4,6 +4,7 @@ import { flatbuffers } from "flatbuffers";
 import { maybeThrowError } from "./errors";
 import { deno as fbs } from "gen/msg_generated";
 
+// @internal
 export function send(
   builder: flatbuffers.Builder,
   msgType: fbs.Any,

--- a/js/global-eval.ts
+++ b/js/global-eval.ts
@@ -1,6 +1,10 @@
-// If you use the eval function indirectly, by invoking it via a reference
-// other than eval, as of ECMAScript 5 it works in the global scope rather than
-// the local scope. This means, for instance, that function declarations create
-// global functions, and that the code being evaluated doesn't have access to
-// local variables within the scope where it's being called.
+/**
+ * If you use the eval function indirectly, by invoking it via a reference
+ * other than eval, as of ECMAScript 5 it works in the global scope rather than
+ * the local scope. This means, for instance, that function declarations create
+ * global functions, and that the code being evaluated doesn't have access to
+ * local variables within the scope where it's being called.
+ *
+ * @internal
+ */
 export const globalEval = eval;

--- a/js/tsconfig.generated.json
+++ b/js/tsconfig.generated.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "module": "amd",
+    "removeComments": false,
     "stripInternal": true
   },
   "files": [

--- a/js/util.ts
+++ b/js/util.ts
@@ -3,11 +3,15 @@ import { TypedArray } from "./types";
 
 let logDebug = false;
 
+// @internal
 export function setLogDebug(debug: boolean): void {
   logDebug = debug;
 }
 
-// Debug logging for deno. Enable with the --DEBUG command line flag.
+/**
+ * Debug logging for deno. Enable with the `--DEBUG` command line flag.
+ * @internal
+ */
 // tslint:disable-next-line:no-any
 export function log(...args: any[]): void {
   if (logDebug) {
@@ -15,41 +19,51 @@ export function log(...args: any[]): void {
   }
 }
 
+// @internal
 export function assert(cond: boolean, msg = "assert") {
   if (!cond) {
     throw Error(msg);
   }
 }
 
+// @internal
 export function typedArrayToArrayBuffer(ta: TypedArray): ArrayBuffer {
   const ab = ta.buffer.slice(ta.byteOffset, ta.byteOffset + ta.byteLength);
   return ab as ArrayBuffer;
 }
 
+// @internal
 export function arrayToStr(ui8: Uint8Array): string {
   return String.fromCharCode(...ui8);
 }
 
-// A `Resolvable` is a Promise with the `reject` and `resolve` functions
-// placed as methods on the promise object itself. It allows you to do:
-//
-//   const p = createResolvable<number>();
-//   ...
-//   p.resolve(42);
-//
-// It'd be prettier to make Resolvable a class that inherits from Promise,
-// rather than an interface. This is possible in ES2016, however typescript
-// produces broken code when targeting ES5 code.
-// See https://github.com/Microsoft/TypeScript/issues/15202
-// At the time of writing, the github issue is closed but the problem remains.
+/**
+ * A `Resolvable` is a Promise with the `reject` and `resolve` functions
+ * placed as methods on the promise object itself. It allows you to do:
+ *
+ *     const p = createResolvable<number>();
+ *     ...
+ *     p.resolve(42);
+ *
+ * It'd be prettier to make Resolvable a class that inherits from Promise,
+ * rather than an interface. This is possible in ES2016, however typescript
+ * produces broken code when targeting ES5 code.
+ * See https://github.com/Microsoft/TypeScript/issues/15202
+ * At the time of writing, the github issue is closed but the problem remains.
+ *
+ * @internal
+ */
+
 export interface ResolvableMethods<T> {
   resolve: (value?: T | PromiseLike<T>) => void;
   // tslint:disable-next-line:no-any
   reject: (reason?: any) => void;
 }
 
+// @internal
 export type Resolvable<T> = Promise<T> & ResolvableMethods<T>;
 
+// @internal
 export function createResolvable<T>(): Resolvable<T> {
   let methods: ResolvableMethods<T>;
   const promise = new Promise<T>((resolve, reject) => {
@@ -60,10 +74,12 @@ export function createResolvable<T>(): Resolvable<T> {
   return Object.assign(promise, methods!) as Resolvable<T>;
 }
 
+// @internal
 export function notImplemented(): never {
   throw new Error("Not implemented");
 }
 
+// @internal
 export function unreachable(): never {
   throw new Error("Code not reachable");
 }

--- a/js/v8_source_maps.ts
+++ b/js/v8_source_maps.ts
@@ -26,6 +26,7 @@ type GetGeneratedContentsCallback = (fileName: string) => string | RawSourceMap;
 
 let getGeneratedContents: GetGeneratedContentsCallback;
 
+// @internal
 export function install(options: Options) {
   getGeneratedContents = options.getGeneratedContents;
   if (options.installPrepareStackTrace) {
@@ -33,6 +34,7 @@ export function install(options: Options) {
   }
 }
 
+// @internal
 export function prepareStackTraceWrapper(
   error: Error,
   stack: CallSite[]
@@ -48,6 +50,7 @@ export function prepareStackTraceWrapper(
   }
 }
 
+// @internal
 export function prepareStackTrace(error: Error, stack: CallSite[]): string {
   const frames = stack.map(
     (frame: CallSite) => `\n    at ${wrapCallSite(frame).toString()}`
@@ -55,6 +58,7 @@ export function prepareStackTrace(error: Error, stack: CallSite[]): string {
   return error.toString() + frames.join("");
 }
 
+// @internal
 export function wrapCallSite(frame: CallSite): CallSite {
   if (frame.isNative()) {
     return frame;

--- a/tests/error_003_typescript.ts.out
+++ b/tests/error_003_typescript.ts.out
@@ -4,7 +4,7 @@
 [30;47m [0m [91m~~~~~~[0m
 
   [96m$asset$/globals.d.ts[WILDCARD]
-    [30;47m[WILDCARD][0m         const console: Console;
-    [30;47m   [0m [96m              ~~~~~~~[0m
-    'console' is declared here.
+[WILDCARD]const console: Console;
+[WILDCARD]~~~~~~~[0m
+[WILDCARD]'console' is declared here.
 


### PR DESCRIPTION
This PR is another step towards #632.  It marks a lot of the APIs that were leaking into `globals.d.ts` as `@internal` so they are stripped out.  It also includes the JSDoc as part of the `globals.d.ts` so it can be more easily be useful in an editor.

There are a couple challenges which appear to be issues with TypeScript, which I will raise seperate issues for:
* When all exports of a module are marked as `@internal` and the types are emitted as a bundle, the bundle still contains an empty namespace/module.
* Other modules are not properly elided when there are no dependencies elsewhere in the output.  So while we have no dependency now on the bundled types for `msg_generated` it still exists in the bundle, and we cannot mark all of its exports as `@internal`.
