### PR TITLE
Enable ansi colors on windows

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -34,6 +34,13 @@ config("deno_config") {
   if (is_win) {
     libs = [ "userenv.lib" ]
   }
+
+  if (is_clang) {
+    cflags = [
+      "-fcolor-diagnostics",
+      "-fansi-escape-codes",
+    ]
+  }
 }
 
 main_extern = [

--- a/build_extra/flatbuffers/BUILD.gn
+++ b/build_extra/flatbuffers/BUILD.gn
@@ -17,6 +17,9 @@ config("flatbuffers_config") {
       # TODO: rust branch of flatbuffers has this warning.
       # This should be removed when the branch fixed.
       "-Wno-return-type",
+
+      "-fcolor-diagnostics",
+      "-fansi-escape-codes",
     ]
   }
 }

--- a/build_extra/rust/rust.gni
+++ b/build_extra/rust/rust.gni
@@ -85,9 +85,7 @@ template("run_rustc") {
       args += [ "-Dwarnings" ]
     }
 
-    if (!is_win) {
-      args += [ "--color=always" ]
-    }
+    args += [ "--color=always" ]
 
     if (!defined(crate_version)) {
       crate_name_and_version = crate_name

--- a/tools/build.py
+++ b/tools/build.py
@@ -4,7 +4,9 @@ from __future__ import print_function
 import os
 import sys
 import third_party
-from util import build_path, run
+from util import build_path, enable_ansi_colors, run
+
+enable_ansi_colors()
 
 third_party.fix_symlinks()
 

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -2,7 +2,9 @@
 # Does google-lint on c++ files and ts-lint on typescript files
 
 import os
-from util import run
+from util import enable_ansi_colors, run
+
+enable_ansi_colors()
 
 root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 third_party_path = os.path.join(root_path, "third_party")

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import third_party
-from util import run, root_path, build_path, build_mode
+from util import build_mode, build_path, enable_ansi_colors, root_path, run
 import os
 import re
 import sys
@@ -8,6 +8,8 @@ from distutils.spawn import find_executable
 
 
 def main():
+    enable_ansi_colors()
+
     os.chdir(root_path)
 
     third_party.fix_symlinks()

--- a/tools/sync_third_party.py
+++ b/tools/sync_third_party.py
@@ -5,6 +5,9 @@
 # find . -type f | grep -v "\.git" | xargs -I% git add -f --no-warn-embedded-repo "%"
 
 import third_party
+import util
+
+util.enable_ansi_colors()
 
 third_party.fix_symlinks()
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -5,7 +5,7 @@ import os
 import sys
 from check_output_test import check_output_test
 from setup_test import setup_test
-from util import executable_suffix, run, build_path
+from util import build_path, enable_ansi_colors, executable_suffix, run
 from unit_tests import unit_tests
 from util_test import util_test
 import subprocess
@@ -27,6 +27,8 @@ def main(argv):
     else:
         print "Usage: tools/test.py [build_dir]"
         sys.exit(1)
+
+    enable_ansi_colors()
 
     http_server.spawn()
 


### PR DESCRIPTION
On windows 10, ansi escape codes are now properly interpreted rather than displayed as gibberish.
Also enable color output from rustc and clang.

For other tools, color output cannot be enabled, either because they ignore the flags to force enable color output (test_rs, gtest, lld-link) or have no such option in the first place (ninja, gn).

Fixes: #624 

