### PR TITLE
[console] Use constructor.name to print out function type

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -23,11 +23,13 @@ function stringify(ctx: ConsoleContext, value: any): string {
     case "symbol":
       return String(value);
     case "function":
+      // Might be Function/AsyncFunction/GeneratorFunction
+      const cstrName = value.__proto__.constructor.name;
       if (value.name && value.name !== "anonymous") {
         // from MDN spec
-        return `[Function: ${value.name}]`;
+        return `[${cstrName}: ${value.name}]`;
       }
-      return "[Function]";
+      return `[${cstrName}]`;
     case "object":
       if (value === null) {
         return "null";

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -80,6 +80,10 @@ test(function consoleTestStringifyCircular() {
   assertEqual(stringify(function f() {}), "[Function: f]");
   assertEqual(stringify(async function af() {}), "[AsyncFunction: af]");
   assertEqual(stringify(function* gf() {}), "[GeneratorFunction: gf]");
+  assertEqual(
+    stringify(async function* agf() {}),
+    "[AsyncGeneratorFunction: agf]"
+  );
   assertEqual(stringify(nestedObj), nestedObjExpected);
   assertEqual(stringify(JSON), "{}");
   assertEqual(

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -43,6 +43,8 @@ test(function consoleTestStringifyCircular() {
     bool: true,
     str: "a",
     method() {},
+    async asyncMethod() {},
+    *generatorMethod() {},
     un: undefined,
     nu: null,
     arrowFunc: () => {},
@@ -66,7 +68,7 @@ test(function consoleTestStringifyCircular() {
 
   nestedObj.o = circularObj;
 
-  const nestedObjExpected = `{ num: 1, bool: true, str: "a", method: [Function: method], un: undefined, nu: null, arrowFunc: [Function: arrowFunc], extendedClass: Extended { a: 1, b: 2 }, nFunc: [Function], extendedCstr: [Function: Extended], o: { num: 2, bool: false, str: "b", method: [Function: method], un: undefined, nu: null, nested: [Circular], emptyObj: {}, arr: [ 1, "s", false, null, [Circular] ], baseClass: Base { a: 1 } } }`;
+  const nestedObjExpected = `{ num: 1, bool: true, str: "a", method: [Function: method], asyncMethod: [AsyncFunction: asyncMethod], generatorMethod: [GeneratorFunction: generatorMethod], un: undefined, nu: null, arrowFunc: [Function: arrowFunc], extendedClass: Extended { a: 1, b: 2 }, nFunc: [Function], extendedCstr: [Function: Extended], o: { num: 2, bool: false, str: "b", method: [Function: method], un: undefined, nu: null, nested: [Circular], emptyObj: {}, arr: [ 1, "s", false, null, [Circular] ], baseClass: Base { a: 1 } } }`;
 
   assertEqual(stringify(1), "1");
   assertEqual(stringify("s"), "s");
@@ -76,6 +78,8 @@ test(function consoleTestStringifyCircular() {
   assertEqual(stringify(undefined), "undefined");
   assertEqual(stringify(new Extended()), "Extended { a: 1, b: 2 }");
   assertEqual(stringify(function f() {}), "[Function: f]");
+  assertEqual(stringify(async function af() {}), "[AsyncFunction: af]");
+  assertEqual(stringify(function* gf() {}), "[GeneratorFunction: gf]");
   assertEqual(stringify(nestedObj), nestedObjExpected);
   assertEqual(stringify(JSON), "{}");
   assertEqual(


### PR DESCRIPTION
Switch to `.__proto__.constructor.name` to print out more accurate function type (`Function/AsyncFunction/GeneratorFunction`)