### PR TITLE
[flags] Add shorthand flag `-A[wne]` for `--allow-*` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@
   serialized messages defined in this
   [flatbuffer](https://github.com/denoland/deno/blob/master/src/msg.fbs). This makes it
   easy to audit.
-	To enable write access explicitly use `--allow-write` and `--allow-net` for
-  network access.
+
+  The following flags are used to explicitly enable different type of accesses:
+  * `--allow-write`: enable write access.
+  * `--allow-net`: enable network access.
+  * `--allow-env`: enable access to environment variables.
+
+  You can also use `-A[wne]` as shorthand to enable corresponding write, network and env access.
 
 * Single executable:
 	```

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -108,6 +108,20 @@ fn test_set_flags_3() {
   );
 }
 
+#[test]
+fn test_set_flags_4() {
+  let (flags, rest) =
+    set_flags(svec!["deno", "-Awn", "script.ts", "--allow-env"]);
+  assert_eq!(rest, svec!["deno", "script.ts"]);
+  assert_eq!(flags, DenoFlags {
+      allow_write: true,
+      allow_net: true,
+      allow_env: true,
+      ..DenoFlags::default()
+    }
+  );
+}
+
 // Returns args passed to V8, followed by args passed to JS
 // TODO Rename to v8_set_flags_preprocess
 fn parse_core_args(args: Vec<String>) -> (Vec<String>, Vec<String>) {

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -29,6 +29,7 @@ pub fn print_usage() {
 --allow-write      Allow file system write access.
 --allow-net        Allow network access.
 --allow-env        Allow environment access.
+-A[wne]            Short hand of --allow-* flags.
 -v or --version    Print the version.
 -r or --reload     Reload cached remote resources.
 -D or --log-debug  Log debug output.
@@ -50,7 +51,21 @@ pub fn set_flags(args: Vec<String>) -> (DenoFlags, Vec<String>) {
       "--allow-env" => flags.allow_env = true,
       "--allow-write" => flags.allow_write = true,
       "--allow-net" => flags.allow_net = true,
-      _ => rest.push(a.clone()),
+      _ => {
+        // Check for shorthand
+        if a.starts_with("-A") {
+          for c in (&a[2..]).chars() {
+            match c {
+              'e' => flags.allow_env = true,
+              'w' => flags.allow_write = true,
+              'n' => flags.allow_net = true,
+              _ => (),
+             }
+          }
+        } else {
+          rest.push(a.clone());
+        }
+      },
     }
   }
 


### PR DESCRIPTION
Add `-A[wne]` as shorthand for `--allow-*` flags; reduces a lot of typing. I would admit that this might make developers paying less attention to access control, but as a tradeoff it would still bring about much more convenience.