### PR TITLE
Implement deno.renameSync

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -8,6 +8,7 @@ export {
   makeTempDirSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   statSync,
   lStatSync,
   writeFileSync

--- a/js/os.ts
+++ b/js/os.ts
@@ -336,3 +336,29 @@ export function writeFileSync(
   const msg = fbs.WriteFileSync.endWriteFileSync(builder);
   send(builder, fbs.Any.WriteFileSync, msg);
 }
+
+/**
+ * Renames (moves) oldpath to newpath.
+ *     import { renameSync } from "deno";
+ *     const oldpath = 'from/path';
+ *     const newpath = 'to/path';
+ *
+ *     renameSync(oldpath, newpath);
+ */
+export function renameSync(oldpath: string, newpath: string): void {
+  /* Ideally we could write:
+  const res = send({
+    command: fbs.Command.RENAME_SYNC,
+    renameOldPath: oldpath,
+    renameNewPath: newpath
+  });
+  */
+  const builder = new flatbuffers.Builder();
+  const _oldpath = builder.createString(oldpath);
+  const _newpath = builder.createString(newpath);
+  fbs.RenameSync.startRenameSync(builder);
+  fbs.RenameSync.addOldpath(builder, _oldpath);
+  fbs.RenameSync.addNewpath(builder, _newpath);
+  const msg = fbs.RenameSync.endRenameSync(builder);
+  send(builder, fbs.Any.RenameSync, msg);
+}

--- a/js/os_test.ts
+++ b/js/os_test.ts
@@ -204,3 +204,41 @@ testPerm({ write: false }, function mkdDirSyncPerm() {
   assertEqual(err.name, "deno.PermissionDenied");
 });
 
+testPerm({ write: true }, function renameSync() {
+  const testDir = deno.makeTempDirSync() + "/test-rename";
+  const oldpath = testDir + "/oldpath"
+  const newpath = testDir + "/newpath"
+  deno.mkdirSync(oldpath);
+  deno.renameSync(oldpath, newpath);
+  const newPathInfo = deno.statSync(newpath);
+  assert(newPathInfo.isDirectory());
+
+  let caughtErr = false;
+  let oldPathInfo;
+
+  try {
+    oldPathInfo = deno.statSync(oldpath);
+  } catch (err) {
+    caughtErr = true;
+    // TODO assert(err instanceof deno.NotFound).
+    assert(err);
+    assertEqual(err.name, "deno.NotFound");
+  }
+
+  assert(caughtErr);
+  assertEqual(oldPathInfo, undefined);
+});
+
+test(function renameSyncPerm() {
+  let err;
+  try {
+    const oldpath = "/oldbaddir";
+    const newpath = "/newbaddir";
+    deno.renameSync(oldpath, newpath);
+  } catch (err_) {
+    err = err_;
+  }
+  // TODO assert(err instanceof deno.PermissionDenied).
+  assert(err);
+  assertEqual(err.name, "deno.PermissionDenied");
+});

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -19,6 +19,7 @@ union Any {
   MkdirSync,
   ReadFileSync,
   ReadFileSyncRes,
+  RenameSync,
   StatSync,
   StatSyncRes,
   SetEnv,
@@ -179,6 +180,11 @@ table ReadFileSync {
 
 table ReadFileSyncRes {
   data: [ubyte];
+}
+
+table RenameSync {
+  oldpath: string;
+  newpath: string;
 }
 
 table StatSync {


### PR DESCRIPTION
Prior art:

Go: [`func Rename(oldpath, newpath string) error`](https://golang.org/pkg/os/#Rename)

Node: [`fs.rename(oldPath, newPath, callback)`](https://nodejs.org/api/fs.html#fs_fs_rename_oldpath_newpath_callback)

Python: [`os.rename(src, dst, *, src_dir_fd=None, dst_dir_fd=None)`](https://docs.python.org/3/library/os.html#os.rename)

Rust: [`pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()>`](https://doc.rust-lang.org/std/fs/fn.rename.html)