### PR TITLE
Implemented deno.chmodSync for mac/linux os users.

### DIFF
--- a/js/chmod.ts
+++ b/js/chmod.ts
@@ -1,0 +1,24 @@
+import * as fbs from "gen/msg_generated";
+import { flatbuffers } from "flatbuffers";
+import * as dispatch from "./dispatch";
+/**
+ * Synchronously changes the file permissions.
+ *
+ *     import { chmodSync } from "deno";
+ *     chmodSync(path, mode);
+ */
+export function chmodSync(path: string, mode: number): void {
+  dispatch.sendSync(...req(path, mode));
+}
+function req(
+  path: string,
+  mode: number
+): [flatbuffers.Builder, fbs.Any, flatbuffers.Offset] {
+  const builder = new flatbuffers.Builder();
+  const path_ = builder.createString(path);
+  fbs.Chmod.startChmod(builder);
+  fbs.Chmod.addPath(builder, path_);
+  fbs.Chmod.addMode(builder, mode);
+  const msg = fbs.Chmod.endChmod(builder);
+  return [builder, fbs.Any.Chmod, msg];
+}

--- a/js/chmod_test.ts
+++ b/js/chmod_test.ts
@@ -6,8 +6,10 @@ testPerm({ write: true }, function chmodSyncSuccess() {
   const data = enc.encode("Hello");
   const filename = deno.makeTempDirSync() + "/test.txt";
   deno.writeFileSync(filename, data, 0o666);
+  let fileInfo = deno.statSync(filename);
+  console.log(fileInfo.mode, 0o666); // This is printing 33206 438
   deno.chmodSync(filename, 0o777);
-  const fileInfo = deno.statSync(filename);
+  fileInfo = deno.statSync(filename);
   assertEqual(fileInfo.mode, 0o777);
 });
 testPerm({ write: false }, function chmodSyncPerm() {

--- a/js/chmod_test.ts
+++ b/js/chmod_test.ts
@@ -1,0 +1,23 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import { test, testPerm, assert, assertEqual } from "./test_util.ts";
+import * as deno from "deno";
+testPerm({ write: true }, function chmodSyncSuccess() {
+  const enc = new TextEncoder();
+  const data = enc.encode("Hello");
+  const filename = deno.makeTempDirSync() + "/test.txt";
+  deno.writeFileSync(filename, data, 0o666);
+  deno.chmodSync(filename, 0o777);
+  const fileInfo = deno.statSync(filename);
+  assertEqual(fileInfo.mode, 0o777);
+});
+testPerm({ write: false }, function chmodSyncPerm() {
+  let err;
+  try {
+    const filename = deno.makeTempDirSync() + "/test.txt";
+    deno.chmodSync(filename, 0o777);
+  } catch (e) {
+    err = e;
+  }
+  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.name, "PermissionDenied");
+});

--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -418,10 +418,10 @@ export class DenoCompiler
    */
   compile(moduleMetaData: ModuleMetaData): OutputCode {
     const recompile = !!this.recompile;
-    this._log(
-        "compiler.compile",
-        { filename: moduleMetaData.fileName, recompile }
-    );
+    this._log("compiler.compile", {
+      filename: moduleMetaData.fileName,
+      recompile
+    });
     if (!recompile && moduleMetaData.outputCode) {
       return moduleMetaData.outputCode;
     }

--- a/js/compiler_test.ts
+++ b/js/compiler_test.ts
@@ -461,16 +461,24 @@ test(function compilerGetScriptFileNames() {
 test(function compilerRecompileFlag() {
   setup();
   compilerInstance.run("foo/bar.ts", "/root/project");
-  assertEqual(getEmitOutputStack.length, 1, "Expected only a single emitted file.");
+  assertEqual(
+    getEmitOutputStack.length,
+    1,
+    "Expected only a single emitted file."
+  );
   // running compiler against same file should use cached code
   compilerInstance.run("foo/bar.ts", "/root/project");
-  assertEqual(getEmitOutputStack.length, 1, "Expected only a single emitted file.");
+  assertEqual(
+    getEmitOutputStack.length,
+    1,
+    "Expected only a single emitted file."
+  );
   compilerInstance.recompile = true;
   compilerInstance.run("foo/bar.ts", "/root/project");
   assertEqual(getEmitOutputStack.length, 2, "Expected two emitted file.");
   assert(
-      getEmitOutputStack[0] === getEmitOutputStack[1],
-      "Expected same file to be emitted twice."
+    getEmitOutputStack[0] === getEmitOutputStack[1],
+    "Expected same file to be emitted twice."
   );
   teardown();
 });

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -15,4 +15,5 @@ export { ErrorKind, DenoError } from "./errors";
 export { libdeno } from "./libdeno";
 export { arch, platform } from "./platform";
 export { trace } from "./trace";
+export { chmodSync } from "./chmod";
 export const args: string[] = [];

--- a/js/read_link.ts
+++ b/js/read_link.ts
@@ -24,9 +24,7 @@ export async function readlink(name: string): Promise<string> {
   return res(await dispatch.sendAsync(...req(name)));
 }
 
-function req(
-  name: string
-): [flatbuffers.Builder, fbs.Any, flatbuffers.Offset] {
+function req(name: string): [flatbuffers.Builder, fbs.Any, flatbuffers.Offset] {
   const builder = new flatbuffers.Builder();
   const name_ = builder.createString(name);
   fbs.Readlink.startReadlink(builder);

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -2,6 +2,7 @@
 // This test is executed as part of tools/test.py
 // But it can also be run manually: ./out/debug/deno js/unit_tests.ts
 import "./compiler_test.ts";
+import "./chmod_test.ts";
 import "./console_test.ts";
 import "./fetch_test.ts";
 import "./os_test.ts";

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -551,7 +551,6 @@ macro_rules! to_seconds {
 
 #[cfg(any(unix))]
 fn get_mode(perm: fs::Permissions) -> u32 {
-  println!("{}", prem.mode);
   perm.mode()
 }
 

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -4,6 +4,7 @@ union Any {
   CodeFetch,
   CodeFetchRes,
   CodeCache,
+  Chmod,
   Exit,
   TimerStart,
   TimerReady,
@@ -221,6 +222,12 @@ table Stat {
   filename: string;
   lstat: bool;
 }
+
+table Chmod {
+  path: string;
+  mode: uint32;
+}
+
 
 table StatRes {
   is_file: bool;

--- a/tools/format.py
+++ b/tools/format.py
@@ -26,7 +26,7 @@ for fn in ["BUILD.gn", ".gn"] + find_exts("build_extra", ".gn", ".gni"):
 #   * These third party python files shouldn't be formatted.
 #   * The tools directory has no subdirectories, so `glob()` is sufficient.
 # TODO(ry) Install yapf in third_party.
-# run(["yapf", "-i"] + glob("tools/*.py") + find_exts("build_extra", ".py"))
+run(["yapf", "-i"] + glob("tools/*.py") + find_exts("build_extra", ".py"))
 
 run(["node", prettier, "--write"] + find_exts("js/", ".js", ".ts") +
     find_exts("tests/", ".js", ".ts") + find_exts("website/", ".js", ".ts") +

--- a/tools/format.py
+++ b/tools/format.py
@@ -26,7 +26,7 @@ for fn in ["BUILD.gn", ".gn"] + find_exts("build_extra", ".gn", ".gni"):
 #   * These third party python files shouldn't be formatted.
 #   * The tools directory has no subdirectories, so `glob()` is sufficient.
 # TODO(ry) Install yapf in third_party.
-run(["yapf", "-i"] + glob("tools/*.py") + find_exts("build_extra", ".py"))
+# run(["yapf", "-i"] + glob("tools/*.py") + find_exts("build_extra", ".py"))
 
 run(["node", prettier, "--write"] + find_exts("js/", ".js", ".ts") +
     find_exts("tests/", ".js", ".ts") + find_exts("website/", ".js", ".ts") +


### PR DESCRIPTION
I have implemented chmodSync for mac/linux os.
Prior art:
Go: func Chmod(name string, mode FileMode) error

Node: fs.chmod(file, mode, callback){

Python: os.chmod(path, mode);

pub fn set_permissions<P: AsRef>(path: P, perm: Permissions) -> Result<()>

Permissions struct in Rust doesn't allow anything apart from -r--r--r-- or -rw-rw-rw