### PR TITLE
Implement stdinReadline

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -8,6 +8,7 @@ export {
   makeTempDirSync,
   mkdirSync,
   readFileSync,
+  stdinReadlineSync,
   renameSync,
   statSync,
   lstatSync,

--- a/js/os.ts
+++ b/js/os.ts
@@ -146,6 +146,32 @@ export function readFileSync(filename: string): Uint8Array {
   return new Uint8Array(dataArray!);
 }
 
+/**
+ * Read a line from stdin.
+ *     import { stdinReadlineSync } from "deno";
+ *
+ *     stdinReadlineSync();
+ */
+export function stdinReadlineSync(): Uint8Array {
+  /* Ideally we could write:
+  const res = send({
+    command: fbs.Command.STDIN_READ_UNTIL_SYNC,
+    until: 10,
+  });
+  */
+  const builder = new flatbuffers.Builder();
+  fbs.StdinReadUntilSync.startStdinReadUntilSync(builder);
+  fbs.StdinReadUntilSync.addUntil(builder, 10);  // '\n'
+  const msg = fbs.StdinReadUntilSync.endStdinReadUntilSync(builder);
+  const baseRes = send(builder, fbs.Any.StdinReadUntilSync, msg);
+  assert(fbs.Any.StdinReadUntilSyncRes === baseRes!.msgType());
+  const res = new fbs.StdinReadUntilSyncRes();
+  assert(baseRes!.msg(res) != null);
+  const dataArray = res.dataArray();
+  assert(dataArray != null);
+  return new Uint8Array(dataArray!);
+}
+
 function createEnv(_msg: fbs.EnvironRes): { [index: string]: string } {
   const env: { [index: string]: string } = {};
 

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -19,6 +19,8 @@ union Any {
   MkdirSync,
   ReadFileSync,
   ReadFileSyncRes,
+  StdinReadUntilSync,
+  StdinReadUntilSyncRes,
   RenameSync,
   StatSync,
   StatSyncRes,
@@ -179,6 +181,14 @@ table ReadFileSync {
 }
 
 table ReadFileSyncRes {
+  data: [ubyte];
+}
+
+table StdinReadUntilSync {
+  until: ubyte;
+}
+
+table StdinReadUntilSyncRes {
   data: [ubyte];
 }
 


### PR DESCRIPTION
Prior art:

Go:
```
reader := bufio.NewReader(os.Stdin)
text, _ := reader.ReadLine()
```

Node:
```
var readline = require('readline');
var rl = readline.createInterface({
  input: process.stdin,
  output: process.stdout,
  terminal: false
});

rl.on('line', function(line){
    console.log(line);
})
```
see https://stackoverflow.com/a/20087094/1240268

Python: [`sys.stdin.readline()`](https://docs.python.org/3/tutorial/inputoutput.html#methods-of-file-objects)

Rust: [`pub fn read_line(&self, buf: &mut String) -> Result<usize>`](https://doc.rust-lang.org/std/io/struct.Stdin.html#method.read_line)

---

This allows one to define an iterator of lines, and to write a simple REPL...

_It's unclear if it's preferable/additional to have a read nbytes and read everything (maybe these can have the same back-end api as read(n) and read(0). I attempted this, but it's not included here._

I am not sure how to test this...