### PR TITLE
Bump to v0.1.3

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -3,7 +3,7 @@ use libdeno;
 use std::ffi::CStr;
 
 // This is the source of truth for the Deno version. Ignore the value in Cargo.toml.
-const DENO_VERSION: &str = "0.1.2";
+const DENO_VERSION: &str = "0.1.3";
 
 pub fn print_version() {
   let v = unsafe { libdeno::deno_v8_version() };


### PR DESCRIPTION
* Fixes module resolution error #645
* Better flag parsing
* lStatSync -> lstatSync
* Added deno.renameSync()
* Added deno.mkdirSync()
* Fix circular dependencies #653
* Added deno.env() and --allow-env