### PR TITLE
Fix TypeScript exports in bundle

### DIFF
--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -131,13 +131,6 @@ function throwResolutionError(
   );
 }
 
-// ts.ScriptKind is not available at runtime, so local enum definition
-enum ScriptKind {
-  JS = 1,
-  TS = 3,
-  JSON = 6
-}
-
 /**
  * A singleton class that combines the TypeScript Language Service host API
  * with Deno specific APIs to provide an interface for compiling and running
@@ -613,13 +606,13 @@ export class DenoCompiler implements ts.LanguageServiceHost {
     const suffix = fileName.substr(fileName.lastIndexOf(".") + 1);
     switch (suffix) {
       case "ts":
-        return ScriptKind.TS;
+        return ts.ScriptKind.TS;
       case "js":
-        return ScriptKind.JS;
+        return ts.ScriptKind.JS;
       case "json":
-        return ScriptKind.JSON;
+        return ts.ScriptKind.JSON;
       default:
-        return this._options.allowJs ? ScriptKind.JS : ScriptKind.TS;
+        return this._options.allowJs ? ts.ScriptKind.JS : ts.ScriptKind.TS;
     }
   }
 

--- a/js/compiler_test.ts
+++ b/js/compiler_test.ts
@@ -8,13 +8,6 @@ import * as ts from "typescript";
 
 const { DenoCompiler } = compiler;
 
-// Enums like this don't exist at runtime, so local copy
-enum ScriptKind {
-  JS = 1,
-  TS = 3,
-  JSON = 6
-}
-
 interface ModuleInfo {
   moduleName: string | null;
   filename: string | null;
@@ -466,11 +459,11 @@ test(function compilerGetScriptFileNames() {
 });
 
 test(function compilerGetScriptKind() {
-  assertEqual(compilerInstance.getScriptKind("foo.ts"), ScriptKind.TS);
-  assertEqual(compilerInstance.getScriptKind("foo.d.ts"), ScriptKind.TS);
-  assertEqual(compilerInstance.getScriptKind("foo.js"), ScriptKind.JS);
-  assertEqual(compilerInstance.getScriptKind("foo.json"), ScriptKind.JSON);
-  assertEqual(compilerInstance.getScriptKind("foo.txt"), ScriptKind.JS);
+  assertEqual(compilerInstance.getScriptKind("foo.ts"), ts.ScriptKind.TS);
+  assertEqual(compilerInstance.getScriptKind("foo.d.ts"), ts.ScriptKind.TS);
+  assertEqual(compilerInstance.getScriptKind("foo.js"), ts.ScriptKind.JS);
+  assertEqual(compilerInstance.getScriptKind("foo.json"), ts.ScriptKind.JSON);
+  assertEqual(compilerInstance.getScriptKind("foo.txt"), ts.ScriptKind.JS);
 });
 
 test(function compilerGetScriptVersion() {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -139,11 +139,13 @@ export default function makeConfig(commandOptions) {
       commonjs({
         namedExports: {
           // Static analysis of `typescript.js` does detect the exports properly, therefore
-          // rollup requires them to be explicitly defined to avoid generating warnings
+          // rollup requires them to be explicitly defined to make them available in the
+          // bundle
           [typescriptPath]: [
             "createLanguageService",
             "formatDiagnosticsWithColorAndContext",
             "ModuleKind",
+            "ScriptKind",
             "ScriptSnapshot",
             "ScriptTarget",
             "version"


### PR DESCRIPTION
When working on another PR, I discovered that the reason why some TypeScript functionality wasn't available was because the exports have to be explicit in the bundle.  This PR fixes that.