### PR TITLE
Warm up the DenoCompiler

### DIFF
--- a/js/main.ts
+++ b/js/main.ts
@@ -56,11 +56,13 @@ function onGlobalError(
   os.exit(1);
 }
 
+// ensure the compiler instance is created and is part of the snapshot
+const compiler = DenoCompiler.instance();
+
 /* tslint:disable-next-line:no-default-export */
 export default function denoMain() {
   libdeno.recv(onMessage);
   libdeno.setGlobalErrorHandler(onGlobalError);
-  const compiler = DenoCompiler.instance();
 
   // First we send an empty "Start" message to let the privlaged side know we
   // are ready. The response should be a "StartRes" message containing the CLI


### PR DESCRIPTION
In discussion on #693 I realised the `DenoCompiler` instance wasn't created at the point of the snapshot.  So moving it outside of `denoMain` so it is warmed up for the snapshot.  Should result in a minor improvement in performance.