### PR TITLE
Cleanup DenoCompiler API

### DIFF
--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -114,16 +114,6 @@ export class ModuleMetaData implements ts.IScriptSnapshot {
 }
 
 /**
- * The required minimal API to allow formatting of TypeScript compiler
- * diagnostics.
- */
-const formatDiagnosticsHost: ts.FormatDiagnosticsHost = {
-  getCurrentDirectory: () => ".",
-  getCanonicalFileName: (fileName: string) => fileName,
-  getNewLine: () => EOL
-};
-
-/**
  * Throw a module resolution error, when a module is unsuccessfully resolved.
  */
 function throwResolutionError(
@@ -142,7 +132,8 @@ function throwResolutionError(
  * with Deno specific APIs to provide an interface for compiling and running
  * TypeScript and JavaScript modules.
  */
-export class DenoCompiler implements ts.LanguageServiceHost {
+export class DenoCompiler
+  implements ts.LanguageServiceHost, ts.FormatDiagnosticsHost {
   // Modules are usually referenced by their ModuleSpecifier and ContainingFile,
   // and keeping a map of the resolved module file name allows more efficient
   // future resolution
@@ -370,7 +361,7 @@ export class DenoCompiler implements ts.LanguageServiceHost {
     if (diagnostics.length > 0) {
       const errMsg = this._ts.formatDiagnosticsWithColorAndContext(
         diagnostics,
-        formatDiagnosticsHost
+        this
       );
       console.log(errMsg);
       // All TypeScript errors are terminal for deno
@@ -597,6 +588,11 @@ export class DenoCompiler implements ts.LanguageServiceHost {
   }
 
   // TypeScript Language Service API
+
+  getCanonicalFileName(fileName: string): string {
+    this._log("getCanonicalFileName", fileName);
+    return fileName;
+  }
 
   getCompilationSettings(): ts.CompilerOptions {
     this._log("getCompilationSettings()");

--- a/tests/error_004_missing_module.ts.out
+++ b/tests/error_004_missing_module.ts.out
@@ -2,7 +2,7 @@ Error: Cannot resolve module "bad-module.ts" from "[WILDCARD]error_004_missing_m
   os.codeFetch message: [WILDCARD] (os error 2)
     at throwResolutionError (deno/js/compiler.ts:[WILDCARD])
     at DenoCompiler.resolveModule (deno/js/compiler.ts:[WILDCARD])
-    at DenoCompiler.resolveModuleName (deno/js/compiler.ts:[WILDCARD])
+    at DenoCompiler._resolveModuleName (deno/js/compiler.ts:[WILDCARD])
     at moduleNames.map.name (deno/js/compiler.ts:[WILDCARD])
     at Array.map (<anonymous>)
     at DenoCompiler.resolveModuleNames (deno/js/compiler.ts:[WILDCARD])

--- a/tests/error_005_missing_dynamic_import.ts.out
+++ b/tests/error_005_missing_dynamic_import.ts.out
@@ -2,7 +2,7 @@ Error: Cannot resolve module "bad-module.ts" from "[WILDCARD]deno/tests/error_00
   os.codeFetch message: [WILDCARD] (os error 2)
     at throwResolutionError (deno/js/compiler.ts:[WILDCARD])
     at DenoCompiler.resolveModule (deno/js/compiler.ts:[WILDCARD])
-    at DenoCompiler.resolveModuleName (deno/js/compiler.ts:[WILDCARD])
+    at DenoCompiler._resolveModuleName (deno/js/compiler.ts:[WILDCARD])
     at moduleNames.map.name (deno/js/compiler.ts:[WILDCARD])
     at Array.map (<anonymous>)
     at DenoCompiler.resolveModuleNames (deno/js/compiler.ts:[WILDCARD])


### PR DESCRIPTION
This PR does some cleanup of the `DenoCompiler` API:

* Combines the Format Diagnostic Host into the DenoCompiler
* Takes `makeDefine`, `resolveFileName`, `resolveModuleName`, and `setModuleName` private as they really shouldn't be part of the public API.
