### PR TITLE
[WIP] Add --depfile flag and functionality

### DIFF
--- a/js/main.ts
+++ b/js/main.ts
@@ -79,10 +79,23 @@ export default function denoMain() {
   log("argv", argv);
   Object.freeze(argv);
 
-  const inputFn = argv[0];
-  if (!inputFn) {
-    console.log("No input script specified.");
-    os.exit(1);
+  let inputFn = argv[0];
+
+  if (startResMsg.depfileFlag() && argv.length > 1) {
+    inputFn = argv[1];
+    // TODO: should probably be a function
+    const deps = compiler.placeholderTODO(inputFn, `${cwd}/`);
+    const output: string[] = [];
+    for (const moduleFileName in deps) {
+      const moduleDependencies = deps[moduleFileName] || [];
+      output.push(`${moduleFileName}: ${moduleDependencies.join(" ")}`);
+    }
+    const enc = new TextEncoder();
+    const data = enc.encode(output.join("\n"));
+    const filename = argv[0];
+    os.writeFileSync(filename, data);
+    log(`saved dependency in ${filename}`);
+    os.exit(0);
   }
 
   const printDeps = startResMsg.depsFlag();
@@ -91,6 +104,11 @@ export default function denoMain() {
       console.log(dep);
     }
     os.exit(0);
+  }
+
+  if (!inputFn) {
+    console.log("No input script specified.");
+    os.exit(1);
   }
 
   compiler.run(inputFn, `${cwd}/`);

--- a/js/main.ts
+++ b/js/main.ts
@@ -84,11 +84,11 @@ export default function denoMain() {
   if (startResMsg.depfileFlag() && argv.length > 1) {
     inputFn = argv[1];
     // TODO: should probably be a function
-    const deps = compiler.placeholderTODO(inputFn, `${cwd}/`);
+    const deps = compiler.gatherDependenciesMap(inputFn, `${cwd}/`);
     const output: string[] = [];
-    for (const moduleFileName in deps) {
-      const moduleDependencies = deps[moduleFileName] || [];
-      output.push(`${moduleFileName}: ${moduleDependencies.join(" ")}`);
+    for (const [, moduleMetaData] of deps) {
+      const dependencies = moduleMetaData.deps || [];
+      output.push(`${moduleMetaData.fileName}: ${dependencies.join(" ")}`);
     }
     const enc = new TextEncoder();
     const data = enc.encode(output.join("\n"));

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -22,6 +22,7 @@ pub struct DenoFlags {
   pub allow_net: bool,
   pub allow_env: bool,
   pub deps_flag: bool,
+  pub depfile_flag: bool,
 }
 
 pub fn print_usage() {
@@ -35,7 +36,8 @@ pub fn print_usage() {
 -D or --log-debug  Log debug output.
 -h or --help       Print this message.
 --v8-options       Print V8 command line options.
---deps             Print module dependencies."
+--deps             Print module dependencies.
+--depfile          Outputs module dependencies to a file specified as argument."
   );
 }
 
@@ -56,6 +58,7 @@ pub fn set_flags(args: Vec<String>) -> (DenoFlags, Vec<String>) {
         "--allow-net" => flags.allow_net = true,
         "--allow-env" => flags.allow_env = true,
         "--deps" => flags.deps_flag = true,
+        "--depfile" => flags.depfile_flag = true,
         "--" => break,
         _ => unimplemented!(),
       }
@@ -137,6 +140,20 @@ fn test_set_flags_4() {
       ..DenoFlags::default()
     }
   );
+}
+
+#[test]
+fn test_set_flags_5() {
+  let (flags, rest) = 
+    set_flags(svec!["deno", "--depfile", "deps.d", "script.ts"]);
+    assert_eq!(rest, svec!["deno", "deps.d", "script.ts"]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        depfile_flag: true,
+        ..DenoFlags::default()
+      }
+    );
 }
 
 // Returns args passed to V8, followed by args passed to JS

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -117,6 +117,7 @@ fn handle_start(
       argv: Some(argv_off),
       debug_flag: deno.flags.log_debug,
       deps_flag: deno.flags.deps_flag,
+      depfile_flag: deno.flags.depfile_flag,
       ..Default::default()
     },
   );

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -88,6 +88,7 @@ table StartRes {
   argv: [string];
   debug_flag: bool;
   deps_flag: bool;
+  depfile_flag: bool;
 }
 
 table CodeFetch {


### PR DESCRIPTION
This is a somewhat naive attempt at making this API work:
```
> deno --depfile ./blah.d tests/https_imports.ts
> cat blah.d

tests/https_import.ts: /Users/rld/.deno/deps/gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts

/Users/rld/.deno/deps/gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts:
```
courtesy of @ry [here](https://github.com/denoland/deno/pull/665)

So far the code will allow this:
```
➜  my-deno git:(add-depfile-flag-and-functionality) ✗ ./out/debug/deno --depfile /home/mirko/Desktop/test_deps_dump.d tests/https_import.ts --allow-write
➜  my-deno git:(add-depfile-flag-and-functionality) ✗ cat /home/mirko/Desktop/test_deps_dump.d 
/home/mirko/.deno/deps/gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts: require exports
/home/mirko/code/my-deno/tests/https_import.ts: require exports /home/mirko/.deno/deps/gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts
```

There is several things I would love to get some help with:
1. I feel like I've put too much code in `denoMain.ts` but I wasn't sure where to extract it into function.
2. I made this dummy `placeholderTODO` method on the compiler class which is basically the same as `getModuleDependencies` but returns different things. I had an idea to modify `getModuleDependencies` so it returns `Array<ModuleMetaData>` but I wouldn't want to do a thing like that without consulting.
3. This is probably due to me not understanding the internals of the resolver. But every module has a dependency of `require` and `exports` which makes sense but doesn't really look great here. 

As always any and all advice would be greatly appreciated.

@kitsonk 
