### PR TITLE
build: remove gn option 'symbol_level=1'

### DIFF
--- a/.gn
+++ b/.gn
@@ -28,7 +28,6 @@ default_args = {
   is_cfi = false
 
   is_component_build = false
-  symbol_level = 1
   treat_warnings_as_errors = false
   rust_treat_warnings_as_errors = false
 


### PR DESCRIPTION
With the default setting, the debug build produces much more useful
debug information.