### PR TITLE
Improve global types

### DIFF
--- a/js/globals.ts
+++ b/js/globals.ts
@@ -9,8 +9,20 @@ import { globalEval } from "./global-eval";
 
 declare global {
   interface Window {
-    console: Console;
     define: Readonly<unknown>;
+
+    clearTimeout: typeof clearTimeout;
+    clearInterval: typeof clearInterval;
+    setTimeout: typeof setTimeout;
+    setInterval: typeof setInterval;
+
+    console: typeof console;
+    window: typeof window;
+
+    fetch: typeof fetch;
+
+    TextEncoder: typeof TextEncoder;
+    TextDecoder: typeof TextDecoder;
   }
 
   const clearTimeout: typeof timers.clearTimer;
@@ -24,8 +36,8 @@ declare global {
   const fetch: typeof fetch_.fetch;
 
   // tslint:disable:variable-name
-  let TextEncoder: typeof textEncoding.TextEncoder;
-  let TextDecoder: typeof textEncoding.TextDecoder;
+  const TextEncoder: typeof textEncoding.TextEncoder;
+  const TextDecoder: typeof textEncoding.TextDecoder;
   // tslint:enable:variable-name
 }
 


### PR DESCRIPTION
This patch adjusts the type definition of `Window` interface.

FYI; Currently there is no way in typescript to avoid this duplication.

See:
https://github.com/Microsoft/TypeScript/issues/14052
https://github.com/Microsoft/TypeScript/issues/10050