### PR TITLE
[WIP] Add build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@
 [package]
 name = "deno"
 version = "0.0.0"
+build = "build.rs"
 
 [dependencies]
 url = "1.7.1"
@@ -17,4 +18,5 @@ tokio = "0.1"
 hyper = "0.12.8"
 hyper-rustls = "0.14.0"
 flatbuffers = { path = "third_party/flatbuffers/rust/flatbuffers/" }
+futures = "0.1"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,28 @@
+use std::env;
+use std::process::Command;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+
+    // ./third_party/depot_tools/gn gen $OUT_DIR
+    let gn_status = Command::new("./third_party/depot_tools/gn")
+        .args(&["gen", &out_dir])
+        .status()
+        .expect("Failed to execute GN.");
+
+    if !gn_status.success() {
+        println!("Failed to generate GN build configuration.");
+        std::process::exit(-1);
+    }
+
+    // DENO_BUILD_PATH=$OUT_DIR python ./tools/build.py
+    let py_status = Command::new("python")
+        .env("DENO_BUILD_PATH", out_dir)
+        .arg("./tools/build.py")
+        .status()
+        .expect("Failed to build Deno.\nMake sure you have `python` in your PATH.");
+
+    if !py_status.success() {
+        std::process::exit(-1);
+    }
+}


### PR DESCRIPTION
This patch aims to add build.rs so that we can use Cargo to build Deno.

When I run `cargo build`, cargo downloads and compiles all the rust dependencies and then complains about `msg_generated`, and exits with a non-zero exit code.
 
As previously discussed with Ryan there seem to be two approaches to solve this issue:

1) Telling Cargo that we don't want it to run `rustc` on `src/main.rs`
2) Only build libdeno and generate assets like flatbuffer codes and typescript bundle.

Fixes #695