### PR TITLE
Port writeFileSync to write_file.ts, add writeFile and tests

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -8,11 +8,11 @@ export {
   makeTempDirSync,
   renameSync,
   statSync,
-  lstatSync,
-  writeFileSync
+  lstatSync
 } from "./os";
 export { mkdirSync, mkdir } from "./mkdir";
 export { readFileSync, readFile } from "./read_file";
+export { writeFileSync, writeFile } from "./write_file";
 export { ErrorKind, DenoError } from "./errors";
 export { libdeno } from "./libdeno";
 export const argv: string[] = [];

--- a/js/os.ts
+++ b/js/os.ts
@@ -275,38 +275,6 @@ function statSyncInner(filename: string, lstat: boolean): FileInfo {
 }
 
 /**
- * Write a new file.
- *     import { writeFileSync } from "deno";
- *
- *     const encoder = new TextEncoder("utf-8");
- *     const data = encoder.encode("Hello world\n");
- *     writeFileSync("hello.txt", data);
- */
-export function writeFileSync(
-  filename: string,
-  data: Uint8Array,
-  perm = 0o666
-): void {
-  /* Ideally we could write:
-  const res = sendSync({
-    command: fbs.Command.WRITE_FILE_SYNC,
-    writeFileSyncFilename: filename,
-    writeFileSyncData: data,
-    writeFileSyncPerm: perm
-  });
-  */
-  const builder = new flatbuffers.Builder();
-  const filename_ = builder.createString(filename);
-  const dataOffset = fbs.WriteFileSync.createDataVector(builder, data);
-  fbs.WriteFileSync.startWriteFileSync(builder);
-  fbs.WriteFileSync.addFilename(builder, filename_);
-  fbs.WriteFileSync.addData(builder, dataOffset);
-  fbs.WriteFileSync.addPerm(builder, perm);
-  const msg = fbs.WriteFileSync.endWriteFileSync(builder);
-  sendSync(builder, fbs.Any.WriteFileSync, msg);
-}
-
-/**
  * Renames (moves) oldpath to newpath.
  *     import { renameSync } from "deno";
  *     const oldpath = 'from/path';

--- a/js/os_test.ts
+++ b/js/os_test.ts
@@ -85,35 +85,6 @@ test(async function lstatSyncNotFound() {
   assertEqual(badInfo, undefined);
 });
 
-testPerm({ write: true }, function writeFileSyncSuccess() {
-  const enc = new TextEncoder();
-  const data = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test.txt";
-  deno.writeFileSync(filename, data, 0o666);
-  const dataRead = deno.readFileSync(filename);
-  const dec = new TextDecoder("utf-8");
-  const actual = dec.decode(dataRead);
-  assertEqual("Hello", actual);
-});
-
-// For this test to pass we need --allow-write permission.
-// Otherwise it will fail with deno.PermissionDenied instead of deno.NotFound.
-testPerm({ write: true }, function writeFileSyncFail() {
-  const enc = new TextEncoder();
-  const data = enc.encode("Hello");
-  const filename = "/baddir/test.txt";
-  // The following should fail because /baddir doesn't exist (hopefully).
-  let caughtError = false;
-  try {
-    deno.writeFileSync(filename, data);
-  } catch (e) {
-    caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.NotFound);
-    assertEqual(e.name, "NotFound");
-  }
-  assert(caughtError);
-});
-
 testPerm({ write: true }, function makeTempDirSync() {
   const dir1 = deno.makeTempDirSync({ prefix: "hello", suffix: "world" });
   const dir2 = deno.makeTempDirSync({ prefix: "hello", suffix: "world" });

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -6,4 +6,5 @@ import "./console_test.ts";
 import "./fetch_test.ts";
 import "./os_test.ts";
 import "./read_file_test.ts";
+import "./write_file_test.ts";
 import "./mkdir_test.ts";

--- a/js/write_file.ts
+++ b/js/write_file.ts
@@ -1,0 +1,52 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import * as fbs from "gen/msg_generated";
+import { flatbuffers } from "flatbuffers";
+import * as dispatch from "./dispatch";
+
+/**
+ * Write a new file, with given filename and data synchronously.
+ *     import { writeFileSync } from "deno";
+ *
+ *     const encoder = new TextEncoder("utf-8");
+ *     const data = encoder.encode("Hello world\n");
+ *     writeFileSync("hello.txt", data);
+ */
+export function writeFileSync(
+  filename: string,
+  data: Uint8Array,
+  perm = 0o666
+): void {
+  dispatch.sendSync(...req(filename, data, perm));
+}
+
+/**
+ * Write a new file, with given filename and data.
+ *     import { writeFile } from "deno";
+ *
+ *     const encoder = new TextEncoder("utf-8");
+ *     const data = encoder.encode("Hello world\n");
+ *     await writeFile("hello.txt", data);
+ */
+export async function writeFile(
+  filename: string,
+  data: Uint8Array,
+  perm = 0o666
+): Promise<void> {
+  await dispatch.sendAsync(...req(filename, data, perm));
+}
+
+function req(
+  filename: string,
+  data: Uint8Array,
+  perm: number
+): [flatbuffers.Builder, fbs.Any, flatbuffers.Offset] {
+  const builder = new flatbuffers.Builder();
+  const filename_ = builder.createString(filename);
+  const dataOffset = fbs.WriteFile.createDataVector(builder, data);
+  fbs.WriteFile.startWriteFile(builder);
+  fbs.WriteFile.addFilename(builder, filename_);
+  fbs.WriteFile.addData(builder, dataOffset);
+  fbs.WriteFile.addPerm(builder, perm);
+  const msg = fbs.WriteFile.endWriteFile(builder);
+  return [builder, fbs.Any.WriteFile, msg];
+}

--- a/js/write_file.ts
+++ b/js/write_file.ts
@@ -5,6 +5,7 @@ import * as dispatch from "./dispatch";
 
 /**
  * Write a new file, with given filename and data synchronously.
+ *
  *     import { writeFileSync } from "deno";
  *
  *     const encoder = new TextEncoder("utf-8");
@@ -21,6 +22,7 @@ export function writeFileSync(
 
 /**
  * Write a new file, with given filename and data.
+ *
  *     import { writeFile } from "deno";
  *
  *     const encoder = new TextEncoder("utf-8");

--- a/js/write_file_test.ts
+++ b/js/write_file_test.ts
@@ -33,7 +33,7 @@ testPerm({ write: false }, function writeFileSyncPerm() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
   const filename = "/baddir/test.txt";
-  // The following should fail because /baddir doesn't exist (hopefully).
+  // The following should fail due to no write permission
   let caughtError = false;
   try {
     deno.writeFileSync(filename, data);
@@ -56,7 +56,7 @@ testPerm({ write: true }, async function writeFileSuccess() {
   assertEqual("Hello", actual);
 });
 
-testPerm({ write: true }, async function writeFileFail() {
+testPerm({ write: true }, async function writeFileNotFound() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
   const filename = "/baddir/test.txt";
@@ -76,7 +76,7 @@ testPerm({ write: false }, async function writeFilePerm() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
   const filename = "/baddir/test.txt";
-  // The following should fail because /baddir doesn't exist (hopefully).
+  // The following should fail due to no write permission
   let caughtError = false;
   try {
     await deno.writeFile(filename, data);

--- a/js/write_file_test.ts
+++ b/js/write_file_test.ts
@@ -1,0 +1,89 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import { testPerm, assert, assertEqual } from "./test_util.ts";
+import * as deno from "deno";
+
+testPerm({ write: true }, function writeFileSyncSuccess() {
+  const enc = new TextEncoder();
+  const data = enc.encode("Hello");
+  const filename = deno.makeTempDirSync() + "/test.txt";
+  deno.writeFileSync(filename, data, 0o666);
+  const dataRead = deno.readFileSync(filename);
+  const dec = new TextDecoder("utf-8");
+  const actual = dec.decode(dataRead);
+  assertEqual("Hello", actual);
+});
+
+testPerm({ write: true }, function writeFileSyncFail() {
+  const enc = new TextEncoder();
+  const data = enc.encode("Hello");
+  const filename = "/baddir/test.txt";
+  // The following should fail because /baddir doesn't exist (hopefully).
+  let caughtError = false;
+  try {
+    deno.writeFileSync(filename, data);
+  } catch (e) {
+    caughtError = true;
+    assertEqual(e.kind, deno.ErrorKind.NotFound);
+    assertEqual(e.name, "NotFound");
+  }
+  assert(caughtError);
+});
+
+testPerm({ write: false }, function writeFileSyncPerm() {
+  const enc = new TextEncoder();
+  const data = enc.encode("Hello");
+  const filename = "/baddir/test.txt";
+  // The following should fail because /baddir doesn't exist (hopefully).
+  let caughtError = false;
+  try {
+    deno.writeFileSync(filename, data);
+  } catch (e) {
+    caughtError = true;
+    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.name, "PermissionDenied");
+  }
+  assert(caughtError);
+});
+
+testPerm({ write: true }, async function writeFileSuccess() {
+  const enc = new TextEncoder();
+  const data = enc.encode("Hello");
+  const filename = deno.makeTempDirSync() + "/test.txt";
+  await deno.writeFile(filename, data, 0o666);
+  const dataRead = deno.readFileSync(filename);
+  const dec = new TextDecoder("utf-8");
+  const actual = dec.decode(dataRead);
+  assertEqual("Hello", actual);
+});
+
+testPerm({ write: true }, async function writeFileFail() {
+  const enc = new TextEncoder();
+  const data = enc.encode("Hello");
+  const filename = "/baddir/test.txt";
+  // The following should fail because /baddir doesn't exist (hopefully).
+  let caughtError = false;
+  try {
+    await deno.writeFile(filename, data);
+  } catch (e) {
+    caughtError = true;
+    assertEqual(e.kind, deno.ErrorKind.NotFound);
+    assertEqual(e.name, "NotFound");
+  }
+  assert(caughtError);
+});
+
+testPerm({ write: false }, async function writeFilePerm() {
+  const enc = new TextEncoder();
+  const data = enc.encode("Hello");
+  const filename = "/baddir/test.txt";
+  // The following should fail because /baddir doesn't exist (hopefully).
+  let caughtError = false;
+  try {
+    await deno.writeFile(filename, data);
+  } catch (e) {
+    caughtError = true;
+    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.name, "PermissionDenied");
+  }
+  assert(caughtError);
+});

--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -118,7 +118,7 @@ impl DenoDir {
         Some(ref parent) => fs::create_dir_all(parent),
         None => Ok(()),
       }?;
-      deno_fs::write_file_sync(&p, source.as_bytes())?;
+      deno_fs::write_file(&p, source.as_bytes(), 0o666)?;
       source
     } else {
       let source = fs::read_to_string(&p)?;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,5 +1,5 @@
 use std;
-use std::fs::{create_dir, File};
+use std::fs::{create_dir, File, OpenOptions};
 use std::io::ErrorKind;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -7,9 +7,36 @@ use std::path::{Path, PathBuf};
 use rand;
 use rand::Rng;
 
-pub fn write_file_sync(path: &Path, content: &[u8]) -> std::io::Result<()> {
-  let mut f = File::create(path)?;
-  f.write_all(content)
+#[cfg(any(unix))]
+use std::os::unix::fs::PermissionsExt;
+
+pub fn write_file(
+  filename: &Path,
+  data: &[u8],
+  perm: u32,
+) -> std::io::Result<()> {
+  let is_append = perm & (1 << 31) != 0;
+  let mut file = OpenOptions::new()
+            .read(false)
+            .write(true)
+            .append(is_append)
+            .truncate(!is_append)
+            .create(true)
+            .open(filename)?;
+  
+  set_permissions(&mut file, perm)?;
+  file.write_all(data)
+}
+
+#[cfg(any(unix))]
+fn set_permissions(file: &mut File, perm: u32) -> std::io::Result<()> {
+  debug!("set file perm to {}", perm);
+  file.set_permissions(PermissionsExt::from_mode(perm & 0o777))
+}
+#[cfg(not(any(unix)))]
+fn set_permissions(_file: &mut File, _perm: u32) -> std::io::Result<()> {
+  // NOOP on windows
+  Ok(())
 }
 
 pub fn make_temp_dir(

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -17,13 +17,13 @@ pub fn write_file(
 ) -> std::io::Result<()> {
   let is_append = perm & (1 << 31) != 0;
   let mut file = OpenOptions::new()
-            .read(false)
-            .write(true)
-            .append(is_append)
-            .truncate(!is_append)
-            .create(true)
-            .open(filename)?;
-  
+    .read(false)
+    .write(true)
+    .append(is_append)
+    .truncate(!is_append)
+    .create(true)
+    .open(filename)?;
+
   set_permissions(&mut file, perm)?;
   file.write_all(data)
 }

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -17,11 +17,11 @@ union Any {
   Mkdir,
   ReadFile,
   ReadFileRes,
+  WriteFile,
   RenameSync,
   StatSync,
   StatSyncRes,
   SetEnv,
-  WriteFileSync,
 }
 
 enum ErrorKind: byte {
@@ -181,6 +181,13 @@ table ReadFileRes {
   data: [ubyte];
 }
 
+table WriteFile {
+  filename: string;
+  data: [ubyte];
+  perm: uint;
+  // perm specified by https://godoc.org/os#FileMode
+}
+
 table RenameSync {
   oldpath: string;
   newpath: string;
@@ -198,13 +205,6 @@ table StatSyncRes {
   modified:ulong;
   accessed:ulong;
   created:ulong;
-}
-
-table WriteFileSync {
-  filename: string;
-  data: [ubyte];
-  perm: uint;
-  // perm specified by https://godoc.org/os#FileMode
 }
 
 root_type Base;


### PR DESCRIPTION
Based on #567 (fixed, rebased and reformatted to match master requirements)

- [x] Move writeFileSync to `write_file.ts`
- [x] Create (async) `writeFile`
- [x] Add tests for `writeFile`
