### PR TITLE
 Add *nix only `mode` for FileInfo (stat/lstat)

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -1,12 +1,7 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 // Public deno module.
 /// <amd-module name="deno"/>
-export {
-  env,
-  exit,
-  makeTempDirSync,
-  renameSync,
-} from "./os";
+export { env, exit, makeTempDirSync, renameSync } from "./os";
 export { mkdirSync, mkdir } from "./mkdir";
 export { readFileSync, readFile } from "./read_file";
 export { FileInfo, statSync, lstatSync, stat, lstat } from "./stat";

--- a/js/stat.ts
+++ b/js/stat.ts
@@ -31,12 +31,18 @@ export class FileInfo {
    * be available on all platforms.
    */
   created: number | null;
+  /**
+   * The underlying raw st_mode bits that contain the standard Unix permissions
+   * for this file/directory. Not available on Windows.
+   */
+  mode: number | null;
 
   /* @internal */
   constructor(private _msg: fbs.StatRes) {
     const modified = this._msg.modified().toFloat64();
     const accessed = this._msg.accessed().toFloat64();
     const created = this._msg.created().toFloat64();
+    const mode = this._msg.mode(); // negative for invalid mode (Windows)
 
     this._isFile = this._msg.isFile();
     this._isSymlink = this._msg.isSymlink();
@@ -44,6 +50,7 @@ export class FileInfo {
     this.modified = modified ? modified : null;
     this.accessed = accessed ? accessed : null;
     this.created = created ? created : null;
+    this.mode = mode >= 0 ? mode : null; // null if invalid mode (Windows)
   }
 
   /**

--- a/js/stat.ts
+++ b/js/stat.ts
@@ -8,6 +8,7 @@ import { assert } from "./util";
  * A FileInfo describes a file and is returned by `stat`, `lstat`,
  * `statSync`, `lstatSync`.
  */
+// TODO FileInfo should be an interface not a class.
 export class FileInfo {
   private readonly _isFile: boolean;
   private readonly _isSymlink: boolean;
@@ -33,7 +34,7 @@ export class FileInfo {
   created: number | null;
   /**
    * The underlying raw st_mode bits that contain the standard Unix permissions
-   * for this file/directory. Not available on Windows.
+   * for this file/directory. TODO Match behavior with Go on windows for mode.
    */
   mode: number | null;
 

--- a/js/stat_test.ts
+++ b/js/stat_test.ts
@@ -123,4 +123,3 @@ test(async function lstatNotFound() {
   assert(caughtError);
   assertEqual(badInfo, undefined);
 });
-

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -14,12 +14,12 @@ use libdeno::{deno_buf, DenoC};
 use msg;
 use std;
 use std::fs;
+#[cfg(any(unix))]
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
 use std::time::{Duration, Instant};
 use tokio::timer::Delay;
-#[cfg(any(unix))]
-use std::os::unix::fs::PermissionsExt;
 
 // Buf represents a byte array returned from a "Op".
 // The message might be empty (which will be translated into a null object on

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -205,6 +205,8 @@ table StatRes {
   modified:ulong;
   accessed:ulong;
   created:ulong;
+  mode: int = -1;
+  // negative mode for invalid (Windows); default to invalid
 }
 
 root_type Base;


### PR DESCRIPTION
Found it troubling to not expose mode on *nix for implementing mode related controls and tests.

Added `mode` to `FileInfo` and `StatRes`. Used mode `-1` to mark on Windows (would be set to `null` in `FileInfo`).
Might not be the best option though, could consider instead add `has_unix_mode: bool;` to `StatRes` for distinguishing.