### PR TITLE
Implement deno.symlink()

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -76,6 +76,7 @@ ts_sources = [
   "js/remove.ts",
   "js/rename.ts",
   "js/stat.ts",
+  "js/symlink.ts",
   "js/text_encoding.ts",
   "js/timers.ts",
   "js/types.ts",

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -8,6 +8,7 @@ export { removeSync, remove, removeAllSync, removeAll } from "./remove";
 export { readFileSync, readFile } from "./read_file";
 export { renameSync, rename } from "./rename";
 export { FileInfo, statSync, lstatSync, stat, lstat } from "./stat";
+export { symlinkSync, symlink } from "./symlink";
 export { writeFileSync, writeFile } from "./write_file";
 export { ErrorKind, DenoError } from "./errors";
 export { libdeno } from "./libdeno";

--- a/js/symlink.ts
+++ b/js/symlink.ts
@@ -2,31 +2,49 @@
 import * as fbs from "gen/msg_generated";
 import { flatbuffers } from "flatbuffers";
 import * as dispatch from "./dispatch";
+import * as util from "./util";
 
 /**
  * Synchronously creates newname as a symbolic link to oldname.
+ * The type argument can be set to 'dir' or 'file' and is only
+ * available on Windows (ignored on other platforms).
  *
  *     import { symlinkSync } from "deno";
  *     symlinkSync("old/name", "new/name");
  */
-export function symlinkSync(oldname: string, newname: string): void {
-  dispatch.sendSync(...req(oldname, newname));
+export function symlinkSync(
+  oldname: string,
+  newname: string,
+  type?: string
+): void {
+  dispatch.sendSync(...req(oldname, newname, type));
 }
 
 /**
  * Creates newname as a symbolic link to oldname.
+ * The type argument can be set to 'dir' or 'file' and is only
+ * available on Windows (ignored on other platforms).
  *
  *     import { symlink } from "deno";
  *     await symlink("old/name", "new/name");
  */
-export async function symlink(oldname: string, newname: string): Promise<void> {
-  await dispatch.sendAsync(...req(oldname, newname));
+export async function symlink(
+  oldname: string,
+  newname: string,
+  type?: string
+): Promise<void> {
+  await dispatch.sendAsync(...req(oldname, newname, type));
 }
 
 function req(
   oldname: string,
-  newname: string
+  newname: string,
+  type?: string
 ): [flatbuffers.Builder, fbs.Any, flatbuffers.Offset] {
+  // TODO Use type for Windows.
+  if (type) {
+    return util.notImplemented();
+  }
   const builder = new flatbuffers.Builder();
   const oldname_ = builder.createString(oldname);
   const newname_ = builder.createString(newname);

--- a/js/symlink.ts
+++ b/js/symlink.ts
@@ -1,0 +1,38 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import * as fbs from "gen/msg_generated";
+import { flatbuffers } from "flatbuffers";
+import * as dispatch from "./dispatch";
+
+/**
+ * Synchronously creates newname as a symbolic link to oldname.
+ *
+ *     import { symlinkSync } from "deno";
+ *     symlinkSync("old/name", "new/name");
+ */
+export function symlinkSync(oldname: string, newname: string): void {
+  dispatch.sendSync(...req(oldname, newname));
+}
+
+/**
+ * Creates newname as a symbolic link to oldname.
+ *
+ *     import { symlink } from "deno";
+ *     await symlink("old/name", "new/name");
+ */
+export async function symlink(oldname: string, newname: string): Promise<void> {
+  await dispatch.sendAsync(...req(oldname, newname));
+}
+
+function req(
+  oldname: string,
+  newname: string
+): [flatbuffers.Builder, fbs.Any, flatbuffers.Offset] {
+  const builder = new flatbuffers.Builder();
+  const oldname_ = builder.createString(oldname);
+  const newname_ = builder.createString(newname);
+  fbs.Symlink.startSymlink(builder);
+  fbs.Symlink.addOldname(builder, oldname_);
+  fbs.Symlink.addNewname(builder, newname_);
+  const msg = fbs.Symlink.endSymlink(builder);
+  return [builder, fbs.Any.Symlink, msg];
+}

--- a/js/symlink_test.ts
+++ b/js/symlink_test.ts
@@ -1,0 +1,40 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import { test, testPerm, assert, assertEqual } from "./test_util.ts";
+import * as deno from "deno";
+
+testPerm({ write: true }, function symlinkSyncSuccess() {
+  const testDir = deno.makeTempDirSync() + "/test-symlink-sync";
+  const oldname = testDir + "/oldname";
+  const newname = testDir + "/newname";
+  deno.mkdirSync(oldname);
+  deno.symlinkSync(oldname, newname);
+  const newNameInfoLStat = deno.lstatSync(newname);
+  const newNameInfoStat = deno.statSync(newname);
+  assert(newNameInfoLStat.isSymlink());
+  assert(newNameInfoStat.isDirectory());
+});
+
+testPerm({ write: false }, function symlinkSyncPerm() {
+  let err;
+  try {
+    const oldname = "/oldbaddir";
+    const newname = "/newbaddir";
+    deno.symlinkSync(oldname, newname);
+  } catch (e) {
+    err = e;
+  }
+  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.name, "PermissionDenied");
+});
+
+testPerm({ write: true }, async function symlinkSuccess() {
+  const testDir = deno.makeTempDirSync() + "/test-symlink";
+  const oldname = testDir + "/oldname";
+  const newname = testDir + "/newname";
+  deno.mkdirSync(oldname);
+  await deno.symlink(oldname, newname);
+  const newNameInfoLStat = deno.lstatSync(newname);
+  const newNameInfoStat = deno.statSync(newname);
+  assert(newNameInfoLStat.isSymlink());
+  assert(newNameInfoStat.isDirectory());
+});

--- a/js/symlink_test.ts
+++ b/js/symlink_test.ts
@@ -17,9 +17,7 @@ testPerm({ write: true }, function symlinkSyncSuccess() {
 testPerm({ write: false }, function symlinkSyncPerm() {
   let err;
   try {
-    const oldname = "/oldbaddir";
-    const newname = "/newbaddir";
-    deno.symlinkSync(oldname, newname);
+    deno.symlinkSync("oldbaddir", "newbaddir");
   } catch (e) {
     err = e;
   }

--- a/js/symlink_test.ts
+++ b/js/symlink_test.ts
@@ -16,7 +16,7 @@ testPerm({ write: true }, function symlinkSyncSuccess() {
   }
   if (errOnWindows) {
     assertEqual(errOnWindows.kind, deno.ErrorKind.Other);
-    assertEqual(errOnWindows.msg, "Not implemented");
+    assertEqual(errOnWindows.message, "Not implemented");
   } else {
     const newNameInfoLStat = deno.lstatSync(newname);
     const newNameInfoStat = deno.statSync(newname);
@@ -61,7 +61,7 @@ testPerm({ write: true }, async function symlinkSuccess() {
   }
   if (errOnWindows) {
     assertEqual(errOnWindows.kind, deno.ErrorKind.Other);
-    assertEqual(errOnWindows.msg, "Not implemented");
+    assertEqual(errOnWindows.message, "Not implemented");
   } else {
     const newNameInfoLStat = deno.lstatSync(newname);
     const newNameInfoStat = deno.statSync(newname);

--- a/js/symlink_test.ts
+++ b/js/symlink_test.ts
@@ -7,11 +7,22 @@ testPerm({ write: true }, function symlinkSyncSuccess() {
   const oldname = testDir + "/oldname";
   const newname = testDir + "/newname";
   deno.mkdirSync(oldname);
-  deno.symlinkSync(oldname, newname);
-  const newNameInfoLStat = deno.lstatSync(newname);
-  const newNameInfoStat = deno.statSync(newname);
-  assert(newNameInfoLStat.isSymlink());
-  assert(newNameInfoStat.isDirectory());
+  let errOnWindows;
+  // Just for now, until we implement symlink for Windows.
+  try {
+    deno.symlinkSync(oldname, newname);
+  } catch (e) {
+    errOnWindows = e;
+  }
+  if (errOnWindows) {
+    assertEqual(errOnWindows.kind, deno.ErrorKind.Other);
+    assertEqual(errOnWindows.msg, "Not implemented");
+  } else {
+    const newNameInfoLStat = deno.lstatSync(newname);
+    const newNameInfoStat = deno.statSync(newname);
+    assert(newNameInfoLStat.isSymlink());
+    assert(newNameInfoStat.isDirectory());
+  }
 });
 
 testPerm({ write: false }, function symlinkSyncPerm() {
@@ -25,14 +36,36 @@ testPerm({ write: false }, function symlinkSyncPerm() {
   assertEqual(err.name, "PermissionDenied");
 });
 
+// Just for now, until we implement symlink for Windows.
+testPerm({ write: true }, function symlinkSyncNotImplemented() {
+  let err;
+  try {
+    deno.symlinkSync("oldname", "newname", "dir");
+  } catch (e) {
+    err = e;
+  }
+  assertEqual(err.message, "Not implemented");
+});
+
 testPerm({ write: true }, async function symlinkSuccess() {
   const testDir = deno.makeTempDirSync() + "/test-symlink";
   const oldname = testDir + "/oldname";
   const newname = testDir + "/newname";
   deno.mkdirSync(oldname);
-  await deno.symlink(oldname, newname);
-  const newNameInfoLStat = deno.lstatSync(newname);
-  const newNameInfoStat = deno.statSync(newname);
-  assert(newNameInfoLStat.isSymlink());
-  assert(newNameInfoStat.isDirectory());
+  let errOnWindows;
+  // Just for now, until we implement symlink for Windows.
+  try {
+    await deno.symlink(oldname, newname);
+  } catch (e) {
+    errOnWindows = e;
+  }
+  if (errOnWindows) {
+    assertEqual(errOnWindows.kind, deno.ErrorKind.Other);
+    assertEqual(errOnWindows.msg, "Not implemented");
+  } else {
+    const newNameInfoLStat = deno.lstatSync(newname);
+    const newNameInfoStat = deno.statSync(newname);
+    assert(newNameInfoLStat.isSymlink());
+    assert(newNameInfoStat.isDirectory());
+  }
 });

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -13,3 +13,4 @@ import "./stat_test.ts";
 import "./rename_test.ts";
 import "./blob_test.ts";
 import "./timers_test.ts";
+import "./symlink_test.ts";

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -685,18 +685,20 @@ fn handle_symlink(d: *const DenoC, base: &msg::Base) -> Box<Op> {
   let newname = String::from(msg.newname().unwrap());
   Box::new(futures::future::result(|| -> OpResult {
     debug!("handle_symlink {} {}", oldname, newname);
+    let oldname_ = Path::new(&oldname);
+    let newname_ = Path::new(&newname);
     if cfg!(windows) {
-      let oldname_stat = fs::metadata(oldname)?;
-      if oldname_stat.is_dir() {
+      let metadata = fs::metadata(&oldname_)?;
+      if metadata.is_dir() {
         #[cfg(windows)]
-        std::os::windows::fs::symlink_dir(oldname, newname)?;
+        std::os::windows::fs::symlink_dir(&oldname_, &newname_)?;
       } else {
         #[cfg(windows)]
-        std::os::windows::fs::symlink_file(oldname, newname)?;
+        std::os::windows::fs::symlink_file(&oldname_, &newname_)?;
       }
     } else {
       #[cfg(unix)]
-      std::os::unix::fs::symlink(oldname, newname)?;
+      std::os::unix::fs::symlink(&oldname_, &newname_)?;
     }
     Ok(None)
   }()))

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -696,10 +696,8 @@ fn handle_symlink(d: *const DenoC, base: &msg::Base) -> Box<Op> {
     let newname = String::from(msg.newname().unwrap());
     Box::new(futures::future::result(|| -> OpResult {
       debug!("handle_symlink {} {}", oldname, newname);
-      let oldname_ = Path::new(&oldname);
-      let newname_ = Path::new(&newname);
       #[cfg(any(unix))]
-      std::os::unix::fs::symlink(&oldname_, &newname_)?;
+      std::os::unix::fs::symlink(Path::new(&oldname), Path::new(&newname))?;
       Ok(None)
     }()))
   }

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -20,6 +20,7 @@ union Any {
   ReadFileRes,
   WriteFile,
   Rename,
+  Symlink,
   Stat,
   StatRes,
   SetEnv,
@@ -198,6 +199,11 @@ table WriteFile {
 table Rename {
   oldpath: string;
   newpath: string;
+}
+
+table Symlink {
+  oldname: string;
+  newname: string;
 }
 
 table Stat {


### PR DESCRIPTION
Prior art:

Go: [`func Symlink(oldname, newname string) error`](https://golang.org/pkg/os/#Symlink)

Node: [`fs.symlink(target, path[, type], callback)`](https://nodejs.org/api/fs.html#fs_fs_symlink_target_path_type_callback)

Python: [`os.symlink(src, dst, target_is_directory=False, *, dir_fd=None)`](https://docs.python.org/3/library/os.html#os.symlink)

Rust:
- unix: [`pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result<()>`](https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html)
- windows (dir): [`pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result<()>`](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html)
- windows (file): [`pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result<()>`](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html)

So, on Windows, a symlink represents either a file or a directory meaning we need to explicitly specify the `type` of symlink. So, I followed Go's convention and didn't implement `type` (we encourage simplicity!) and essentially used the same pattern as the [Go's implementation](https://github.com/golang/go/blob/master/src/os/file_windows.go#L355) to handle it internally by getting the `oldname`'s stats and creates the `symlink_dir()` or `symlink_file()` based on that. 
