### PR TITLE
Make mode always u32 and switch to has_mode for StatRes fbs

### DIFF
--- a/js/mkdir_test.ts
+++ b/js/mkdir_test.ts
@@ -13,7 +13,8 @@ testPerm({ write: true }, function mkdirSyncMode() {
   const path = deno.makeTempDirSync() + "/dir/subdir";
   deno.mkdirSync(path, 0o755); // no perm for x
   const pathInfo = deno.statSync(path);
-  if (pathInfo.mode !== null) { // Skip windows
+  if (pathInfo.mode !== null) {
+    // Skip windows
     assertEqual(pathInfo.mode & 0o777, 0o755);
   }
 });

--- a/js/stat.ts
+++ b/js/stat.ts
@@ -43,6 +43,7 @@ export class FileInfo {
     const modified = this._msg.modified().toFloat64();
     const accessed = this._msg.accessed().toFloat64();
     const created = this._msg.created().toFloat64();
+    const hasMode = this._msg.hasMode();
     const mode = this._msg.mode(); // negative for invalid mode (Windows)
 
     this._isFile = this._msg.isFile();
@@ -51,8 +52,8 @@ export class FileInfo {
     this.modified = modified ? modified : null;
     this.accessed = accessed ? accessed : null;
     this.created = created ? created : null;
-    // null if invalid mode (Windows)
-    this.mode = mode >= 0 ? mode & 0o7777 : null;
+    // null on Windows
+    this.mode = hasMode ? mode : null;
   }
 
   /**

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -154,8 +154,7 @@ fn parse_core_args(args: Vec<String>) -> (Vec<String>, Vec<String>) {
       }
 
       true
-    })
-    .collect();
+    }).collect();
 
   // Replace args being sent to V8
   for idx in 0..args.len() {
@@ -222,7 +221,6 @@ pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
       let cstr = CStr::from_ptr(*ptr as *const i8);
       let slice = cstr.to_str().unwrap();
       slice.to_string()
-    })
-    .chain(rest.into_iter())
+    }).chain(rest.into_iter())
     .collect()
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -154,7 +154,8 @@ fn parse_core_args(args: Vec<String>) -> (Vec<String>, Vec<String>) {
       }
 
       true
-    }).collect();
+    })
+    .collect();
 
   // Replace args being sent to V8
   for idx in 0..args.len() {
@@ -221,6 +222,7 @@ pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
       let cstr = CStr::from_ptr(*ptr as *const i8);
       let slice = cstr.to_str().unwrap();
       slice.to_string()
-    }).chain(rest.into_iter())
+    })
+    .chain(rest.into_iter())
     .collect()
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -80,7 +80,7 @@ pub fn mkdir(path: &Path, perm: u32) -> std::io::Result<()> {
 #[cfg(any(unix))]
 fn set_dir_permission(builder: &mut DirBuilder, perm: u32) {
   debug!("set dir perm to {}", perm);
-  builder.mode(perm);
+  builder.mode(perm & 0o777);
 }
 
 #[cfg(not(any(unix)))]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -288,7 +288,8 @@ fn handle_env(d: *const DenoC, base: &msg::Base) -> Box<Op> {
           ..Default::default()
         },
       )
-    }).collect();
+    })
+    .collect();
   let tables = builder.create_vector(&vars);
   let msg = msg::EnvironRes::create(
     builder,
@@ -401,7 +402,8 @@ where
     .and_then(|_| {
       cb();
       Ok(())
-    }).select(cancel_rx)
+    })
+    .select(cancel_rx)
     .map(|_| ())
     .map_err(|_| ());
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -288,8 +288,7 @@ fn handle_env(d: *const DenoC, base: &msg::Base) -> Box<Op> {
           ..Default::default()
         },
       )
-    })
-    .collect();
+    }).collect();
   let tables = builder.create_vector(&vars);
   let msg = msg::EnvironRes::create(
     builder,
@@ -402,8 +401,7 @@ where
     .and_then(|_| {
       cb();
       Ok(())
-    })
-    .select(cancel_rx)
+    }).select(cancel_rx)
     .map(|_| ())
     .map_err(|_| ());
 
@@ -533,13 +531,13 @@ macro_rules! to_seconds {
 }
 
 #[cfg(any(unix))]
-fn get_mode(perm: fs::Permissions) -> i32 {
-  (perm.mode() as i32)
+fn get_mode(perm: fs::Permissions) -> u32 {
+  perm.mode()
 }
 
 #[cfg(not(any(unix)))]
-fn get_mode(_perm: fs::Permissions) -> i32 {
-  -1
+fn get_mode(_perm: fs::Permissions) -> u32 {
+  0
 }
 
 fn handle_stat(_d: *const DenoC, base: &msg::Base) -> Box<Op> {
@@ -568,6 +566,7 @@ fn handle_stat(_d: *const DenoC, base: &msg::Base) -> Box<Op> {
         accessed: to_seconds!(metadata.accessed()),
         created: to_seconds!(metadata.created()),
         mode: get_mode(metadata.permissions()),
+        has_mode: cfg!(target_family = "unix"),
         ..Default::default()
       },
     );

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -212,8 +212,8 @@ table StatRes {
   modified:ulong;
   accessed:ulong;
   created:ulong;
-  mode: int = -1;
-  // negative mode for invalid (Windows); default to invalid
+  mode: uint;
+  has_mode: bool; // false on windows
 }
 
 root_type Base;


### PR DESCRIPTION
Using `int` as mode is a mistake (based on Go's [FileMode](https://golang.org/pkg/os/#FileMode)). Switch back to `uint` and uses `has_mode` to represent non-unix case