### PR TITLE
Add missing deps to cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,15 @@ name = "deno"
 version = "0.0.0"
 
 [dependencies]
-url = "1.7.1"
+dirs = "1.0.3"
+flatbuffers = { path = "third_party/flatbuffers/rust/flatbuffers/" }
+futures = "0.1.23"
+hyper = "0.12.8"
+hyper-rustls = "0.14.0"
 libc = "0.2.42"
 log = "0.4.3"
 rand = "0.4.2"
+ring = "0.13.2"
 tempfile = "3"
 tokio = "0.1"
-hyper = "0.12.8"
-hyper-rustls = "0.14.0"
-flatbuffers = { path = "third_party/flatbuffers/rust/flatbuffers/" }
-dirs = "1.0.3"
+url = "1.7.1"


### PR DESCRIPTION
We're using ring and futures directly, so they should be listed in cargo.toml.

<!--

Thank you for your pull request. Before submitting, please make sure the following is done.

1. Ensure ./tools/test.py passes.
2. Format your code with ./tools/format.py
3. Make sure ./tools/lint.py passes.

-->
