### PR TITLE
Add `deno.platform()` for os/family check

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -71,6 +71,7 @@ ts_sources = [
   "js/make_temp_dir.ts",
   "js/mock_builtin.js",
   "js/os.ts",
+  "js/platform.ts",
   "js/plugins.d.ts",
   "js/read_file.ts",
   "js/remove.ts",

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -9,6 +9,7 @@ export { readFileSync, readFile } from "./read_file";
 export { renameSync, rename } from "./rename";
 export { FileInfo, statSync, lstatSync, stat, lstat } from "./stat";
 export { writeFileSync, writeFile } from "./write_file";
+export { PlatformInfo, platform, platformSync } from "./platform";
 export { ErrorKind, DenoError } from "./errors";
 export { libdeno } from "./libdeno";
 export const argv: string[] = [];

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -10,7 +10,7 @@ export { renameSync, rename } from "./rename";
 export { FileInfo, statSync, lstatSync, stat, lstat } from "./stat";
 export { symlinkSync, symlink } from "./symlink";
 export { writeFileSync, writeFile } from "./write_file";
-export { PlatformInfo, platform, platformSync } from "./platform";
+export { PlatformInfo, platform } from "./platform";
 export { ErrorKind, DenoError } from "./errors";
 export { libdeno } from "./libdeno";
 export const argv: string[] = [];

--- a/js/platform.ts
+++ b/js/platform.ts
@@ -9,24 +9,34 @@ export interface PlatformInfo {
   family: string;
 }
 
+let cachedPlatformInfo: PlatformInfo | null = null;
+
 /**
- * Retrieves information about the current platform synchronously.
+ * Retrieves information (os, os family) about the current
+ * platform synchronously.
  *
  *     import { platformSync } from "deno";
  *     const platform = deno.platformSync();
  */
 export function platformSync(): PlatformInfo {
-  return res(dispatch.sendSync(...req()));
+  if (!cachedPlatformInfo) {
+    cachedPlatformInfo = res(dispatch.sendSync(...req()));
+  }
+  return cachedPlatformInfo!;
 }
 
 /**
- * Creates a new directory with the specified path and permission.
+ * Retrieves information (os, os family) about the current
+ * platform.
  *
  *     import { platform } from "deno";
  *     const platform = await deno.platform();
  */
 export async function platform(): Promise<PlatformInfo> {
-  return res(await dispatch.sendAsync(...req()));
+  if (!cachedPlatformInfo) {
+    cachedPlatformInfo = res(await dispatch.sendAsync(...req()));
+  }
+  return cachedPlatformInfo!;
 }
 
 function req(): [flatbuffers.Builder, fbs.Any, flatbuffers.Offset] {

--- a/js/platform.ts
+++ b/js/platform.ts
@@ -13,28 +13,14 @@ let cachedPlatformInfo: PlatformInfo | null = null;
 
 /**
  * Retrieves information (os, os family) about the current
- * platform synchronously.
- *
- *     import { platformSync } from "deno";
- *     const platform = deno.platformSync();
- */
-export function platformSync(): PlatformInfo {
-  if (!cachedPlatformInfo) {
-    cachedPlatformInfo = Object.freeze(res(dispatch.sendSync(...req())));
-  }
-  return cachedPlatformInfo!;
-}
-
-/**
- * Retrieves information (os, os family) about the current
- * platform.
+ * platform (synchronously).
  *
  *     import { platform } from "deno";
- *     const platform = await deno.platform();
+ *     const plat = platform();
  */
-export async function platform(): Promise<PlatformInfo> {
+export function platform(): PlatformInfo {
   if (!cachedPlatformInfo) {
-    cachedPlatformInfo = Object.freeze(res(await dispatch.sendAsync(...req())));
+    cachedPlatformInfo = Object.freeze(res(dispatch.sendSync(...req())));
   }
   return cachedPlatformInfo!;
 }

--- a/js/platform.ts
+++ b/js/platform.ts
@@ -17,6 +17,9 @@ let cachedPlatformInfo: PlatformInfo | null = null;
  *
  *     import { platform } from "deno";
  *     const plat = platform();
+ *     // On Linux, would print "linux" and "unix"
+ *     // On Windows, would print "windows" and "windows"
+ *     console.log(plat.os, plat.family)
  */
 export function platform(): PlatformInfo {
   if (!cachedPlatformInfo) {

--- a/js/platform.ts
+++ b/js/platform.ts
@@ -1,0 +1,52 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import * as fbs from "gen/msg_generated";
+import { flatbuffers } from "flatbuffers";
+import { assert } from "./util";
+import * as dispatch from "./dispatch";
+
+export interface PlatformInfo {
+  os: string;
+  family: string;
+  endian: string;
+}
+
+/**
+ * Retrieves information about the current platform synchronously.
+ *
+ *     import { platformSync } from "deno";
+ *     const platform = deno.platformSync();
+ */
+export function platformSync(): PlatformInfo {
+  return res(dispatch.sendSync(...req()));
+}
+
+/**
+ * Creates a new directory with the specified path and permission.
+ *
+ *     import { platform } from "deno";
+ *     const platform = await deno.platform();
+ */
+export async function platform(): Promise<PlatformInfo> {
+  return res(await dispatch.sendAsync(...req()));
+}
+
+function req(): [flatbuffers.Builder, fbs.Any, flatbuffers.Offset] {
+  const builder = new flatbuffers.Builder();
+  fbs.Platform.startPlatform(builder);
+  const msg = fbs.Platform.endPlatform(builder);
+  return [builder, fbs.Any.Platform, msg];
+}
+
+function res(baseRes: null | fbs.Base): PlatformInfo {
+  assert(baseRes != null);
+  assert(fbs.Any.PlatformRes === baseRes!.msgType());
+  const msg = new fbs.PlatformRes();
+  assert(baseRes!.msg(msg) != null);
+  const os = msg.os()!;
+  const family = msg.family()!;
+  const endian = msg.endian()!;
+  assert(os != null);
+  assert(family != null);
+  assert(endian != null);
+  return { os, family, endian };
+}

--- a/js/platform.ts
+++ b/js/platform.ts
@@ -20,7 +20,7 @@ let cachedPlatformInfo: PlatformInfo | null = null;
  */
 export function platformSync(): PlatformInfo {
   if (!cachedPlatformInfo) {
-    cachedPlatformInfo = res(dispatch.sendSync(...req()));
+    cachedPlatformInfo = Object.freeze(res(dispatch.sendSync(...req())));
   }
   return cachedPlatformInfo!;
 }
@@ -34,7 +34,7 @@ export function platformSync(): PlatformInfo {
  */
 export async function platform(): Promise<PlatformInfo> {
   if (!cachedPlatformInfo) {
-    cachedPlatformInfo = res(await dispatch.sendAsync(...req()));
+    cachedPlatformInfo = Object.freeze(res(await dispatch.sendAsync(...req())));
   }
   return cachedPlatformInfo!;
 }

--- a/js/platform.ts
+++ b/js/platform.ts
@@ -7,7 +7,6 @@ import * as dispatch from "./dispatch";
 export interface PlatformInfo {
   os: string;
   family: string;
-  endian: string;
 }
 
 /**
@@ -44,9 +43,7 @@ function res(baseRes: null | fbs.Base): PlatformInfo {
   assert(baseRes!.msg(msg) != null);
   const os = msg.os()!;
   const family = msg.family()!;
-  const endian = msg.endian()!;
   assert(os != null);
   assert(family != null);
-  assert(endian != null);
-  return { os, family, endian };
+  return { os, family };
 }

--- a/js/platform_test.ts
+++ b/js/platform_test.ts
@@ -1,0 +1,27 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import { test, assert } from "./test_util.ts";
+import * as deno from "deno";
+
+test(function platformSyncSuccess() {
+  const plat = deno.platformSync();
+  assert(!!plat.os);
+  assert(!!plat.family);
+  assert(!!plat.endian);
+  if (plat.os === "windows") {
+    assert(plat.family === "windows");
+  } else if (plat.os === "macos" || plat.os === "linux") {
+    assert(plat.family === "unix");
+  }
+});
+
+test(async function platformSuccess() {
+  const plat = await deno.platform();
+  assert(!!plat.os);
+  assert(!!plat.family);
+  assert(!!plat.endian);
+  if (plat.os === "windows") {
+    assert(plat.family === "windows");
+  } else if (plat.os === "macos" || plat.os === "linux") {
+    assert(plat.family === "unix");
+  }
+});

--- a/js/platform_test.ts
+++ b/js/platform_test.ts
@@ -6,7 +6,6 @@ test(function platformSyncSuccess() {
   const plat = deno.platformSync();
   assert(!!plat.os);
   assert(!!plat.family);
-  assert(!!plat.endian);
   if (plat.os === "windows") {
     assert(plat.family === "windows");
   } else if (plat.os === "macos" || plat.os === "linux") {
@@ -18,7 +17,6 @@ test(async function platformSuccess() {
   const plat = await deno.platform();
   assert(!!plat.os);
   assert(!!plat.family);
-  assert(!!plat.endian);
   if (plat.os === "windows") {
     assert(plat.family === "windows");
   } else if (plat.os === "macos" || plat.os === "linux") {

--- a/js/platform_test.ts
+++ b/js/platform_test.ts
@@ -2,19 +2,8 @@
 import { test, assert } from "./test_util.ts";
 import * as deno from "deno";
 
-test(function platformSyncSuccess() {
-  const plat = deno.platformSync();
-  assert(!!plat.os);
-  assert(!!plat.family);
-  if (plat.os === "windows") {
-    assert(plat.family === "windows");
-  } else if (plat.os === "macos" || plat.os === "linux") {
-    assert(plat.family === "unix");
-  }
-});
-
-test(async function platformSuccess() {
-  const plat = await deno.platform();
+test(function platformSuccess() {
+  const plat = deno.platform();
   assert(!!plat.os);
   assert(!!plat.family);
   if (plat.os === "windows") {

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -13,3 +13,4 @@ import "./stat_test.ts";
 import "./rename_test.ts";
 import "./blob_test.ts";
 import "./timers_test.ts";
+import "./platform_test.ts";

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -12,6 +12,7 @@ use isolate::from_c;
 use libdeno;
 use libdeno::{deno_buf, DenoC};
 use msg;
+use platform;
 use remove_dir_all::remove_dir_all;
 use std;
 use std::fs;
@@ -59,6 +60,7 @@ pub extern "C" fn msg_from_js(d: *const DenoC, buf: deno_buf) {
     msg::Any::SetEnv => handle_set_env,
     msg::Any::Stat => handle_stat,
     msg::Any::WriteFile => handle_write_file,
+    msg::Any::Platform => handle_platform,
     msg::Any::Exit => handle_exit,
     _ => panic!(format!(
       "Unhandled message {}",
@@ -671,5 +673,35 @@ fn handle_rename(d: *const DenoC, base: &msg::Base) -> Box<Op> {
     debug!("handle_rename {} {}", oldpath, newpath);
     fs::rename(Path::new(&oldpath), Path::new(&newpath))?;
     Ok(None)
+  }()))
+}
+
+fn handle_platform(_d: *const DenoC, base: &msg::Base) -> Box<Op> {
+  let cmd_id = base.cmd_id();
+  Box::new(futures::future::result(|| -> OpResult {
+    debug!("handle_platform");
+    let platform_ = platform::get_platform();
+    let builder = &mut FlatBufferBuilder::new();
+    let os = builder.create_string(platform_.os.as_str());
+    let family = builder.create_string(platform_.family.as_str());
+    let endian = builder.create_string(platform_.endian.as_str());
+    let msg = msg::PlatformRes::create(
+      builder,
+      &msg::PlatformResArgs {
+        os: Some(os),
+        family: Some(family),
+        endian: Some(endian),
+        ..Default::default()
+      },
+    );
+    Ok(serialize_response(
+      cmd_id,
+      builder,
+      msg::BaseArgs {
+        msg: Some(msg.as_union_value()),
+        msg_type: msg::Any::PlatformRes,
+        ..Default::default()
+      },
+    ))
   }()))
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -148,7 +148,7 @@ fn permission_denied() -> DenoError {
 fn not_implemented() -> DenoError {
   DenoError::from(std::io::Error::new(
     std::io::ErrorKind::Other,
-    "Not implemented"
+    "Not implemented",
   ))
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -684,13 +684,11 @@ fn handle_platform(_d: *const DenoC, base: &msg::Base) -> Box<Op> {
     let builder = &mut FlatBufferBuilder::new();
     let os = builder.create_string(platform_.os.as_str());
     let family = builder.create_string(platform_.family.as_str());
-    let endian = builder.create_string(platform_.endian.as_str());
     let msg = msg::PlatformRes::create(
       builder,
       &msg::PlatformResArgs {
         os: Some(os),
         family: Some(family),
-        endian: Some(endian),
         ..Default::default()
       },
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ pub mod handlers;
 mod isolate;
 mod libdeno;
 mod net;
+mod platform;
 mod version;
 
 use isolate::Isolate;

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -223,7 +223,6 @@ table Platform {}
 table PlatformRes {
   os: string;
   family: string;
-  endian: string;
 }
 
 root_type Base;

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -23,6 +23,8 @@ union Any {
   Stat,
   StatRes,
   SetEnv,
+  Platform,
+  PlatformRes,
 }
 
 enum ErrorKind: byte {
@@ -214,6 +216,14 @@ table StatRes {
   created:ulong;
   mode: uint;
   has_mode: bool; // false on windows
+}
+
+table Platform {}
+
+table PlatformRes {
+  os: string;
+  family: string;
+  endian: string;
 }
 
 root_type Base;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -2,7 +2,6 @@
 pub struct Platform {
   pub os: String,
   pub family: String,
-  pub endian: String,
 }
 
 // OS
@@ -96,22 +95,9 @@ fn get_family() -> String {
   "other".to_string()
 }
 
-// ENDIAN
-
-#[cfg(target_endian = "big")]
-fn get_endian() -> String {
-  "big".to_string()
-}
-
-#[cfg(target_endian = "little")]
-fn get_endian() -> String {
-  "little".to_string()
-}
-
 pub fn get_platform() -> Platform {
   Platform {
     os: get_os(),
     family: get_family(),
-    endian: get_endian(),
   }
 }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,117 @@
+// See https://doc.rust-lang.org/reference/attributes.html
+pub struct Platform {
+  pub os: String,
+  pub family: String,
+  pub endian: String,
+}
+
+// OS
+
+#[cfg(target_os = "windows")]
+fn get_os() -> String {
+  "windows".to_string()
+}
+
+#[cfg(target_os = "macos")]
+fn get_os() -> String {
+  "macos".to_string()
+}
+
+#[cfg(target_os = "ios")]
+fn get_os() -> String {
+  "ios".to_string()
+}
+
+#[cfg(target_os = "linux")]
+fn get_os() -> String {
+  "linux".to_string()
+}
+
+#[cfg(target_os = "android")]
+fn get_os() -> String {
+  "android".to_string()
+}
+
+#[cfg(target_os = "freebsd")]
+fn get_os() -> String {
+  "freebsd".to_string()
+}
+
+#[cfg(target_os = "dragonfly")]
+fn get_os() -> String {
+  "dragonfly".to_string()
+}
+
+#[cfg(target_os = "bitrig")]
+fn get_os() -> String {
+  "bitrig".to_string()
+}
+
+#[cfg(target_os = "openbsd")]
+fn get_os() -> String {
+  "openbsd".to_string()
+}
+
+#[cfg(target_os = "netbsd")]
+fn get_os() -> String {
+  "netbsd".to_string()
+}
+
+#[cfg(
+  not(
+    any(
+      target_os = "windows",
+      target_os = "macos",
+      target_os = "ios",
+      target_os = "linux",
+      target_os = "android",
+      target_os = "freebsd",
+      target_os = "dragonfly",
+      target_os = "bitrig",
+      target_os = "openbsd",
+      target_os = "netbsd"
+    )
+  )
+)]
+fn get_os() -> String {
+  // In case of new OS, e.g. fuschia
+  "other".to_string()
+}
+
+// FAMILY
+
+#[cfg(target_family = "windows")]
+fn get_family() -> String {
+  "windows".to_string()
+}
+
+#[cfg(target_family = "unix")]
+fn get_family() -> String {
+  "unix".to_string()
+}
+
+#[cfg(not(any(target_family = "windows", target_family = "unix")))]
+fn get_family() -> String {
+  // In case
+  "other".to_string()
+}
+
+// ENDIAN
+
+#[cfg(target_endian = "big")]
+fn get_endian() -> String {
+  "big".to_string()
+}
+
+#[cfg(target_endian = "little")]
+fn get_endian() -> String {
+  "little".to_string()
+}
+
+pub fn get_platform() -> Platform {
+  Platform {
+    os: get_os(),
+    family: get_family(),
+    endian: get_endian(),
+  }
+}


### PR DESCRIPTION
This PR implements basic OS info detection. Based on Rust `cfg` macro. See [conditional compilation](https://doc.rust-lang.org/reference/attributes.html#conditional-compilation) (It turns out the list might not be complete, check [`librustc-target` source](https://github.com/rust-lang/rust/tree/master/src/librustc_target/spec).

Use case: e.g. for `Blob` for converting line endings to native (CRLF vs LF).

Python: [`platform` library](https://docs.python.org/2/library/platform.html)
Go: [`runtime.GOOS`](https://golang.org/pkg/runtime/#GOOS)
Rust: use [`cfg` macro](https://doc.rust-lang.org/std/macro.cfg.html)
Node: [`process.platform`](https://nodejs.org/api/process.html#process_process_platform)