### PR TITLE
libdeno.send(): Use GetContents instead of Externalize

### DIFF
--- a/libdeno/libdeno_test.cc
+++ b/libdeno/libdeno_test.cc
@@ -152,18 +152,6 @@ TEST(LibDenoTest, JSSendArrayBufferViewTypes) {
   deno_delete(d);
 }
 
-TEST(LibDenoTest, JSSendNeutersBuffer) {
-  static int count = 0;
-  Deno* d = deno_new(nullptr, [](auto _, auto buf) {
-    count++;
-    EXPECT_EQ(buf.data_len, 1u);
-    EXPECT_EQ(buf.data_ptr[0], 42);
-  });
-  EXPECT_TRUE(deno_execute(d, "a.js", "JSSendNeutersBuffer()"));
-  EXPECT_EQ(count, 1);
-  deno_delete(d);
-}
-
 TEST(LibDenoTest, TypedArraySnapshots) {
   Deno* d = deno_new(nullptr, nullptr);
   EXPECT_TRUE(deno_execute(d, "a.js", "TypedArraySnapshots()"));

--- a/libdeno/libdeno_test.js
+++ b/libdeno/libdeno_test.js
@@ -103,18 +103,6 @@ global.JSSendArrayBufferViewTypes = () => {
   libdeno.send(dv);
 };
 
-global.JSSendNeutersBuffer = () => {
-  // Buffer should be neutered after transferring it to the native side.
-  const u8 = new Uint8Array([42]);
-  assert(u8.byteLength === 1);
-  assert(u8.buffer.byteLength === 1);
-  assert(u8[0] === 42);
-  const r = libdeno.send(u8);
-  assert(u8.byteLength === 0);
-  assert(u8.buffer.byteLength === 0);
-  assert(u8[0] === undefined);
-};
-
 // The following join has caused SnapshotBug to segfault when using kKeep.
 [].join("");
 


### PR DESCRIPTION
The externalize property is unused. This should be faster.