### PR TITLE
Inject deno.arch/deno.platform from Node's process.arch/process.platform through rollup

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -71,6 +71,7 @@ ts_sources = [
   "js/make_temp_dir.ts",
   "js/mock_builtin.js",
   "js/os.ts",
+  "js/platform.ts",
   "js/plugins.d.ts",
   "js/read_file.ts",
   "js/remove.ts",

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -12,4 +12,5 @@ export { symlinkSync, symlink } from "./symlink";
 export { writeFileSync, writeFile } from "./write_file";
 export { ErrorKind, DenoError } from "./errors";
 export { libdeno } from "./libdeno";
+export { arch, platform } from "./platform";
 export const argv: string[] = [];

--- a/js/platform.ts
+++ b/js/platform.ts
@@ -1,3 +1,5 @@
 // Dummy. Injected in rollup.config.js
-export const arch = "";
-export const platform = "";
+import { DenoArch, DenoPlatform } from "./types";
+
+export const arch: DenoArch = "unknown";
+export const platform: DenoPlatform = "unknown";

--- a/js/platform.ts
+++ b/js/platform.ts
@@ -1,0 +1,3 @@
+// Dummy. Injected in rollup.config.js
+export const arch = "";
+export const platform = "";

--- a/js/platform_test.ts
+++ b/js/platform_test.ts
@@ -1,0 +1,9 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import { test, assert } from "./test_util.ts";
+import * as deno from "deno";
+
+test(function injectPlatformSuccess() {
+  // Make sure they exists and not empty (transformed)
+  assert(!!deno.arch);
+  assert(!!deno.platform);
+});

--- a/js/platform_test.ts
+++ b/js/platform_test.ts
@@ -2,8 +2,8 @@
 import { test, assert } from "./test_util.ts";
 import * as deno from "deno";
 
-test(function injectPlatformSuccess() {
-  // Make sure they exists and not empty (transformed)
-  assert(!!deno.arch);
-  assert(!!deno.platform);
+test(function transformPlatformSuccess() {
+  // Make sure they are transformed
+  assert(deno.arch !== "unknown");
+  assert(deno.platform !== "unknown");
 });

--- a/js/types.ts
+++ b/js/types.ts
@@ -151,3 +151,29 @@ declare global {
     stackTraceLimit: number;
   }
 }
+
+// Based on Node's arch
+export type DenoArch =
+  | "arm"
+  | "arm64"
+  | "ia32"
+  | "mips"
+  | "mipsel"
+  | "ppc"
+  | "ppc64"
+  | "s390"
+  | "s390x"
+  | "x32"
+  | "x64"
+  | "unknown";
+
+export type DenoPlatform =
+  | "aix"
+  | "darwin"
+  | "freebsd"
+  | "linux"
+  | "openbsd"
+  | "sunos"
+  | "win32"
+  | "android"
+  | "unknown";

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -14,3 +14,4 @@ import "./rename_test.ts";
 import "./blob_test.ts";
 import "./timers_test.ts";
 import "./symlink_test.ts";
+import "./platform_test.ts";

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@types/text-encoding": "0.0.33",
     "base64-js": "^1.3.0",
     "flatbuffers": "^1.9.0",
+    "magic-string": "^0.22.5",
     "prettier": "^1.14.0",
     "rollup": "^0.63.2",
     "rollup-plugin-alias": "^1.4.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import typescriptPlugin from "rollup-plugin-typescript2";
 import { createFilter } from "rollup-pluginutils";
 import typescript from "typescript";
+import MagicString from "magic-string";
 
 const mockPath = path.join(__dirname, "js", "mock_builtin.js");
 const platformPath = path.join(__dirname, "js", "platform.ts");
@@ -95,12 +96,15 @@ function platform({ include, exclude } = {}) {
      */
     transform(_code, id) {
       if (filter(id)) {
+        // Adapted from https://github.com/rollup/rollup-plugin-inject/blob/master/src/index.js
+        const magicString = new MagicString(`
+import { DenoArch, DenoPlatform } from "./types";
+export const arch: DenoArch = "${process.arch}";
+export const platform: DenoPlatform = "${process.platform}";`);
         // arch and platform comes from Node
         return {
-          code: `export const arch = "${process.arch}";
-          export const platform = "${process.platform}";
-          `,
-          map: { mappings: "" }
+          code: magicString.toString(),
+          map: magicString.generateMap()
         };
       }
     }


### PR DESCRIPTION
Related to #771 .
Now `deno.arch` and `deno.platform` becomes exactly the same as Node's [`process.arch`](https://nodejs.org/api/process.html#process_process_arch) and [`process.platform`](https://nodejs.org/api/process.html#process_process_platform). Injected compile-time in `rollup.config.js`.

(I am not familiar with rollup but a brief examination of its documentation seems justifying this solution, though might not be the best . Manually tested and working locally. Hard to create test for it though...)

@kitsonk 