### PR TITLE
Add basic atob/btoa implementation

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -49,6 +49,7 @@ main_extern = [
   "$rust_build:url",
   "$rust_build:remove_dir_all",
   "$rust_build:dirs",
+  "$rust_build:base64",
   "//build_extra/flatbuffers/rust:flatbuffers",
   ":msg_rs",
 ]

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -43,6 +43,8 @@ declare global {
   // tslint:disable:variable-name
   const TextEncoder: typeof textEncoding.TextEncoder;
   const TextDecoder: typeof textEncoding.TextDecoder;
+  const atob: typeof textEncoding.atob;
+  const btoa: typeof textEncoding.btoa;
   const Headers: typeof DenoHeaders;
   const Blob: typeof DenoBlob;
   // tslint:enable:variable-name
@@ -62,6 +64,8 @@ window.clearInterval = timers.clearTimer;
 window.console = new Console(libdeno.print);
 window.TextEncoder = textEncoding.TextEncoder;
 window.TextDecoder = textEncoding.TextDecoder;
+window.atob = textEncoding.atob;
+window.btoa = textEncoding.btoa;
 
 window.fetch = fetch_.fetch;
 

--- a/js/text_encoding.ts
+++ b/js/text_encoding.ts
@@ -1,4 +1,48 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import * as fbs from "gen/msg_generated";
+import { flatbuffers } from "flatbuffers";
+import { assert } from "./util";
+import * as dispatch from "./dispatch";
+
+/**
+ * Decodes a string of data which has been encoded using base-64 encoding.
+ */
+export function atob(s: string): string {
+  // TODO: make exception compliant to standard, InvalidCharacterError
+  // https://html.spec.whatwg.org/multipage/webappapis.html#dom-atob
+  // TODO: encoding! (JS is UTF16/UCS2)
+  const builder = new flatbuffers.Builder();
+  const data = builder.createString(s);
+  fbs.AToB.startAToB(builder);
+  fbs.AToB.addData(builder, data);
+  const sentMsg = fbs.AToB.endAToB(builder);
+  const baseRes = dispatch.sendSync(builder, fbs.Any.AToB, sentMsg);
+  assert(baseRes != null);
+  assert(fbs.Any.AToBRes === baseRes!.msgType());
+  const receivedMsg = new fbs.AToBRes();
+  assert(baseRes!.msg(receivedMsg) != null);
+  return receivedMsg.decoded()!;
+}
+
+/**
+ * Creates a base-64 encoded ASCII string from a string
+ */
+export function btoa(s: string): string {
+  // TODO: make exception compliant to standard, InvalidCharacterError
+  // https://html.spec.whatwg.org/multipage/webappapis.html#dom-btoa
+  // TODO: encoding! (JS is UTF16/UCS2)
+  const builder = new flatbuffers.Builder();
+  const data = builder.createString(s);
+  fbs.BToA.startBToA(builder);
+  fbs.BToA.addData(builder, data);
+  const sentMsg = fbs.BToA.endBToA(builder);
+  const baseRes = dispatch.sendSync(builder, fbs.Any.BToA, sentMsg);
+  assert(baseRes != null);
+  assert(fbs.Any.BToARes === baseRes!.msgType());
+  const receivedMsg = new fbs.BToARes();
+  assert(baseRes!.msg(receivedMsg) != null);
+  return receivedMsg.encoded()!;
+}
 
 // @types/text-encoding relies on lib.dom.d.ts for some interfaces. We do not
 // want to include lib.dom.d.ts (due to size) into deno's global type scope.

--- a/js/text_encoding_test.ts
+++ b/js/text_encoding_test.ts
@@ -1,0 +1,14 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import { test, assertEqual } from "./test_util.ts";
+
+test(function atobSuccess() {
+  const text = "hello world";
+  const encoded = btoa(text);
+  assertEqual(encoded, "aGVsbG8gd29ybGQ=");
+});
+
+test(function btoaSuccess() {
+  const encoded = "aGVsbG8gd29ybGQ=";
+  const decoded = atob(encoded);
+  assertEqual(decoded, "hello world");
+});

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -15,3 +15,4 @@ import "./blob_test.ts";
 import "./timers_test.ts";
 import "./symlink_test.ts";
 import "./platform_test.ts";
+import "./text_encoding_test.ts";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
+extern crate base64;
 extern crate flatbuffers;
 extern crate futures;
 extern crate hyper;

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -24,6 +24,10 @@ union Any {
   Stat,
   StatRes,
   SetEnv,
+  AToB,
+  AToBRes,
+  BToA,
+  BToARes,
 }
 
 enum ErrorKind: byte {
@@ -70,6 +74,9 @@ enum ErrorKind: byte {
   HttpCanceled,
   HttpParse,
   HttpOther,
+
+  // atob/btoa error
+  InvalidCharacterError,
 }
 
 table Base {
@@ -220,6 +227,22 @@ table StatRes {
   created:ulong;
   mode: uint;
   has_mode: bool; // false on windows
+}
+
+table AToB {
+  data: string;
+}
+
+table AToBRes {
+  decoded: string;
+}
+
+table BToA {
+  data: string;
+}
+
+table BToARes {
+  encoded: string;
 }
 
 root_type Base;


### PR DESCRIPTION
- [x] Basic `window.atob()` and `window.btoa()` implementation.

Currently, this implementation does not throw `InvalidCharacterError` for codepoint outside of `0x00`-`0xFF` range. For example, `atob(btoa("你好"))) === "你好"` is supported with this implementation, but in browsers (based on [standard](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#Unicode_Strings)), `btoa("你好")` should throw error.

Would add charcode range checks if necessary for current stage.