### PR TITLE
Add atob/btoa based on base64-js

### DIFF
--- a/js/errors.ts
+++ b/js/errors.ts
@@ -25,10 +25,3 @@ export function maybeError(base: fbs.Base): null | DenoError<fbs.ErrorKind> {
     return new DenoError(kind, base.error()!);
   }
 }
-
-export class InvalidCharacterError extends Error {
-  constructor(msg: string) {
-    super(msg);
-    this.name = "InvalidCharacterError";
-  }
-}

--- a/js/errors.ts
+++ b/js/errors.ts
@@ -25,3 +25,10 @@ export function maybeError(base: fbs.Base): null | DenoError<fbs.ErrorKind> {
     return new DenoError(kind, base.error()!);
   }
 }
+
+export class InvalidCharacterError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "InvalidCharacterError";
+  }
+}

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -25,6 +25,8 @@ declare global {
 
     TextEncoder: typeof TextEncoder;
     TextDecoder: typeof TextDecoder;
+    atob: typeof atob;
+    btoa: typeof btoa;
 
     Headers: typeof Headers;
     Blob: typeof Blob;
@@ -43,6 +45,8 @@ declare global {
   // tslint:disable:variable-name
   const TextEncoder: typeof textEncoding.TextEncoder;
   const TextDecoder: typeof textEncoding.TextDecoder;
+  const atob: typeof textEncoding.atob;
+  const btoa: typeof textEncoding.btoa;
   const Headers: typeof DenoHeaders;
   const Blob: typeof DenoBlob;
   // tslint:enable:variable-name
@@ -62,6 +66,8 @@ window.clearInterval = timers.clearTimer;
 window.console = new Console(libdeno.print);
 window.TextEncoder = textEncoding.TextEncoder;
 window.TextDecoder = textEncoding.TextDecoder;
+window.atob = textEncoding.atob;
+window.btoa = textEncoding.btoa;
 
 window.fetch = fetch_.fetch;
 

--- a/js/text_encoding.ts
+++ b/js/text_encoding.ts
@@ -29,20 +29,13 @@ export function btoa(s: string): string {
     const charCode = s[i].charCodeAt(0);
     if (charCode > 0xff) {
       throw new InvalidCharacterError(
-        "'btoa' failed: The string to be encoded contains " +
-          "characters outside of the Latin1 range."
+        "The string to be encoded contains characters " +
+          "outside of the Latin1 range."
       );
     }
     byteArray.push(charCode);
   }
-  let result;
-  try {
-    result = base64.fromByteArray(Uint8Array.from(byteArray));
-  } catch (_) {
-    throw new InvalidCharacterError(
-      "The string to be decoded is not correctly encoded"
-    );
-  }
+  const result = base64.fromByteArray(Uint8Array.from(byteArray));
   return result;
 }
 

--- a/js/text_encoding.ts
+++ b/js/text_encoding.ts
@@ -1,6 +1,6 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 import * as base64 from "base64-js";
-import { InvalidCharacterError } from "./errors";
+import { DenoError, ErrorKind } from "./errors";
 
 export function atob(s: string): string {
   const rem = s.length % 4;
@@ -12,7 +12,8 @@ export function atob(s: string): string {
   try {
     byteArray = base64.toByteArray(s);
   } catch (_) {
-    throw new InvalidCharacterError(
+    throw new DenoError(
+      ErrorKind.InvalidInput,
       "The string to be decoded is not correctly encoded"
     );
   }
@@ -28,7 +29,8 @@ export function btoa(s: string): string {
   for (let i = 0; i < s.length; i++) {
     const charCode = s[i].charCodeAt(0);
     if (charCode > 0xff) {
-      throw new InvalidCharacterError(
+      throw new DenoError(
+        ErrorKind.InvalidInput,
         "The string to be encoded contains characters " +
           "outside of the Latin1 range."
       );

--- a/js/text_encoding.ts
+++ b/js/text_encoding.ts
@@ -1,4 +1,50 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import * as base64 from "base64-js";
+import { InvalidCharacterError } from "./errors";
+
+export function atob(s: string): string {
+  const rem = s.length % 4;
+  // base64-js requires length exactly times of 4
+  if (rem > 0) {
+    s = s.padEnd(s.length + (4 - rem), "=");
+  }
+  let byteArray;
+  try {
+    byteArray = base64.toByteArray(s);
+  } catch (_) {
+    throw new InvalidCharacterError(
+      "The string to be decoded is not correctly encoded"
+    );
+  }
+  let result = "";
+  for (let i = 0; i < byteArray.length; i++) {
+    result += String.fromCharCode(byteArray[i]);
+  }
+  return result;
+}
+
+export function btoa(s: string): string {
+  const byteArray = [];
+  for (let i = 0; i < s.length; i++) {
+    const charCode = s[i].charCodeAt(0);
+    if (charCode > 0xff) {
+      throw new InvalidCharacterError(
+        "'btoa' failed: The string to be encoded contains " +
+          "characters outside of the Latin1 range."
+      );
+    }
+    byteArray.push(charCode);
+  }
+  let result;
+  try {
+    result = base64.fromByteArray(Uint8Array.from(byteArray));
+  } catch (_) {
+    throw new InvalidCharacterError(
+      "The string to be decoded is not correctly encoded"
+    );
+  }
+  return result;
+}
 
 // @types/text-encoding relies on lib.dom.d.ts for some interfaces. We do not
 // want to include lib.dom.d.ts (due to size) into deno's global type scope.

--- a/js/text_encoding_test.ts
+++ b/js/text_encoding_test.ts
@@ -22,5 +22,5 @@ test(function btoaFailed() {
     err = e;
   }
   assert(!!err);
-  assertEqual(err.name, "InvalidCharacterError");
+  assertEqual(err.name, "InvalidInput");
 });

--- a/js/text_encoding_test.ts
+++ b/js/text_encoding_test.ts
@@ -1,0 +1,26 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import { test, assert, assertEqual } from "./test_util.ts";
+
+test(function atobSuccess() {
+  const text = "hello world";
+  const encoded = btoa(text);
+  assertEqual(encoded, "aGVsbG8gd29ybGQ=");
+});
+
+test(function btoaSuccess() {
+  const encoded = "aGVsbG8gd29ybGQ=";
+  const decoded = atob(encoded);
+  assertEqual(decoded, "hello world");
+});
+
+test(function btoaFailed() {
+  const text = "你好";
+  let err;
+  try {
+    btoa(text);
+  } catch (e) {
+    err = e;
+  }
+  assert(!!err);
+  assertEqual(err.name, "InvalidCharacterError");
+});

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -15,3 +15,4 @@ import "./blob_test.ts";
 import "./timers_test.ts";
 import "./symlink_test.ts";
 import "./platform_test.ts";
+import "./text_encoding_test.ts";


### PR DESCRIPTION
Related to #775 . Uses `base64-js` for implementation (pure JS/TS)

There is still another option: use a [polyfill version](https://github.com/davidchambers/Base64.js/blob/master/base64.js), which might be more lightweighted.