### PR TITLE
Add benchmark tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@ Cargo.lock
 yarn.lock
 # npm deps
 node_modules
+# editor files
 .idea
-
 # RLS generated files
 /target/
+# benchmark temp files
+/benchmark.json
+/gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 .idea
 # RLS generated files
 /target/
-# benchmark temp files
-/benchmark.json
+# export dir for gh-pages
 /gh-pages
+# temp benchmark data
+/website/data.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ after_success:
 # TODO: Include hyperfine in //third_party
 - cargo install hyperfine
 - ./tools/benchmark.py $DENO_BUILD_PATH
+# export website assets for deployment
 - cp website/*.* gh-pages/
 before_deploy: |
   # gzip and name release to denote platform

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 - "./tools/build.py -j2"
 - "./tools/test.py $DENO_BUILD_PATH"
 after_success:
-# benchmark
+# TODO: Include hyperfine in //third_party
 - cargo install hyperfine
 - ./tools/benchmark.py $DENO_BUILD_PATH
 - cp website/*.* gh-pages/

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,23 @@ script:
 - bash -c "sleep 2100; pkill ninja" &
 - "./tools/build.py -j2"
 - "./tools/test.py $DENO_BUILD_PATH"
+after_success:
+# benchmark
+- cargo install hyperfine
+- ./tools/benchmark.py $DENO_BUILD_PATH
+- cp website/*.* gh-pages/
 before_deploy: |
   # gzip and name release to denote platform
   gzip -c $DENO_BUILD_PATH/deno > $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz
 deploy:
-  provider: releases
+- provider: pages
+  local-dir: gh-pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: true
+  on:
+    branch: master
+- provider: releases
   api_key:
     secure: RIwv515oDcPAlEvt7uG8FeSFi6Tz6ODJUOXcFj6FYUPszxJ7Cg1kBLKln+fNW5OeOc52VsaZb/vPZ85skyEM6zk2ijL9FcSnnfNEm548w77iH6G0sk09NgBTy6KRXES6NZHD9jN1YTWYkT2G1NQi7mLqxR8a8pnWTbeK5HhtSWGsZPtXqf5iQbvnWsmKA0/w+FIgKupU0xe/qsYjh0eMLYpZDUWoKO0VxBKJ/ix5Uz91aJTjMIcHHij+ALg4pk+FkDotdyx39XB9b25KDxGuaI7NxWjSPzDxs/ZBHP6QYDLO0ti93ftvLAxRoBKPFoZrXqAu3KG9anr9WvxE40DO9OdV0VX2ZUatMUQm3DpSheN8ml2sErFqjIInqlpkdOVDYORz7FikPxkb9DKt+iuyFfxPRa4YWJv2tg8+Hy/nRCQw69OoKqrSNJ8KJDB3OjYbRBtdHz79RLJhTsGZla6RiyXfM7crR7CbFjbwdbW3Pt60t24fhvXQ0SwR0QTgzS/ieYEQHq/9GtSQA/Tn4kdIkyN6BdOMrQd/aUtgKmNdqbSlfmWGNyNZIxHdB+3RrTNT1tagkRI4UHEUfEujpIdYKwLjv0Xmi/VtTM+zOSkzHsIWGPfHBmIGnXfAItUHqivQYJ15E+dzg3T1CEbBxkDQtvwien9Fa8/pBsMkyovl8ps=
   file: "$DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# Performs benchmark, and append data to //gh-pages/data.json.
+
+import os
+import sys
+import json
+import time
+from util import run, run_output, root_path, build_path
+
+benchmark_types = ["hello", "relative_import"]
+benchmark_files = ["tests/002_hello.ts", "tests/003_relative_import.ts"]
+
+data_file = "gh-pages/data.json"
+benchmark_file = "benchmark.json"
+
+
+def read_json(filename):
+    with open(filename) as json_file:
+        return json.load(json_file)
+
+
+def write_json(filename, data):
+    with open(filename, 'w') as outfile:
+        json.dump(data, outfile)
+
+
+def prepare_gh_pages_dir():
+    if os.path.exists("gh-pages"):
+        return
+    try:
+        run([
+            "git", "clone", "--depth", "1", "-b", "gh-pages",
+            "https://github.com/denoland/deno.git", "gh-pages"
+        ])
+    except:
+        os.mkdir("gh-pages")
+        with open("gh-pages/data.json", "w") as f:
+            f.write("[]")  # writes empty json data
+
+
+def main(argv):
+    if len(argv) == 2:
+        build_dir = sys.argv[1]
+    elif len(argv) == 1:
+        build_dir = build_path()
+    else:
+        print "Usage: tools/benchmark.py [build_dir]"
+        sys.exit(1)
+
+    os.chdir(root_path)
+    prepare_gh_pages_dir()
+    run(["hyperfine", "--export-json", benchmark_file, "--warmup", "3"] + [
+        os.path.join(build_dir, "deno") + " " + file
+        for file in benchmark_files
+    ])
+    all_data = read_json(data_file)
+    benchmark_data = read_json(benchmark_file)
+    sha1 = run_output(["git", "rev-parse", "HEAD"]).strip()
+    new_data = {
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "sha1": sha1,
+        "benchmark": {}
+    }
+    for type, data in zip(benchmark_types, benchmark_data["results"]):
+        new_data["benchmark"][type] = {
+            "mean": data["mean"],
+            "stddev": data["stddev"],
+            "user": data["user"],
+            "system": data["system"],
+            "min": data["min"],
+            "max": data["max"]
+        }
+    all_data.append(new_data)
+    write_json(data_file, all_data)
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/tools/format.py
+++ b/tools/format.py
@@ -29,7 +29,7 @@ for fn in ["BUILD.gn", ".gn"] + find_exts("build_extra", ".gn", ".gni"):
 run(["yapf", "-i"] + glob("tools/*.py") + find_exts("build_extra", ".py"))
 
 run(["node", prettier, "--write"] + find_exts("js/", ".js", ".ts") +
-    find_exts("tests/", ".js", ".ts") +
+    find_exts("tests/", ".js", ".ts") + find_exts("website/", ".js", ".ts") +
     ["rollup.config.js", "tsconfig.json", "tslint.json"])
 
 # Requires rustfmt 0.8.2 (flags were different in previous versions)

--- a/website/app.js
+++ b/website/app.js
@@ -1,12 +1,12 @@
-const benchmarkTypes = ["hello", "relative_import"];
+const benchmarkNames = ["hello", "relative_import"];
 
 (async () => {
   const data = await (await fetch("./data.json")).json();
 
-  const benchmarkColumns = benchmarkTypes.map(type => [
-    type,
+  const benchmarkColumns = benchmarkNames.map(name => [
+    name,
     ...data.map(d => {
-      const benchmark = d.benchmark[type];
+      const benchmark = d.benchmark[name];
       return benchmark ? benchmark.mean : 0;
     })
   ]);

--- a/website/app.js
+++ b/website/app.js
@@ -1,0 +1,26 @@
+const benchmarkTypes = ["hello", "relative_import"];
+
+(async () => {
+  const data = await (await fetch("./data.json")).json();
+
+  const benchmarkColumns = benchmarkTypes.map(type => [
+    type,
+    ...data.map(d => {
+      const benchmark = d.benchmark[type];
+      return benchmark ? benchmark.mean : 0;
+    })
+  ]);
+
+  const sha1List = data.map(d => d.sha1);
+
+  c3.generate({
+    bindto: "#benchmark-chart",
+    data: { columns: benchmarkColumns },
+    axis: {
+      x: {
+        type: "category",
+        categories: sha1List
+      }
+    }
+  });
+})();

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>deno benchmark</title>
+  <link rel="stylesheet" href="https://unpkg.com/c3@0.6.7/c3.min.css">
+</head>
+<body>
+  <div id="benchmark-chart"></div>
+  <script src="https://unpkg.com/d3@5.7.0/dist/d3.min.js"></script>
+  <script src="https://unpkg.com/c3@0.6.7/c3.min.js"></script>
+  <script src="./app.js"></script>
+</body>
+</html>
+


### PR DESCRIPTION
This PR tries to address #373.

- This uses [hyperfine](https://github.com/sharkdp/hyperfine) for benchmarking tool.
- This solution uses `gh-pages` for static hosting of web site, and stores benchmark data in a json file `//data.json` in gh-pages branch.
- Added `//tools/benchmark.py`, which performs benchmarks, downloads gh-pages branch and append data to `//gh-pages/data.json`.
- Added `//website/` directory which contains the frontend resources to show the chart of benchmarked data. (The page uses `d3` and `c3` for showing the chart.)
- Added `provider: pages` in deployment of travis. This deploys `//gh-pages/` directory to `gh-pages` branch.
  - This requires `$GITHUB_TOKEN` env var set appropriately in travis.

The demo is available [here](https://kt3k.github.io/deno/), which I tested in my fork.

<img width="1353" alt="2018-09-21 10 49 57" src="https://user-images.githubusercontent.com/613956/45855674-29410c00-bd8c-11e8-9192-a8f820caeb75.png">

---
notes:
- This uses a single json file as a database. I think this scales up to a few thousand data, but probably it needs to be replaced with more serious db tools like sqlite or online db solutions after thousands of commits.