### PR TITLE
Implement `deno.trace()`

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -80,6 +80,7 @@ ts_sources = [
   "js/symlink.ts",
   "js/text_encoding.ts",
   "js/timers.ts",
+  "js/trace.ts",
   "js/types.ts",
   "js/util.ts",
   "js/v8_source_maps.ts",

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -13,4 +13,5 @@ export { writeFileSync, writeFile } from "./write_file";
 export { ErrorKind, DenoError } from "./errors";
 export { libdeno } from "./libdeno";
 export { arch, platform } from "./platform";
+export { trace } from "./trace";
 export const argv: string[] = [];

--- a/js/trace.ts
+++ b/js/trace.ts
@@ -1,8 +1,7 @@
-import { startTrace, endTrace } from "./dispatch";
+import { TraceInfo, pushTraceStack, popTraceStack } from "./dispatch";
 
 /**
  * Trace operations executed inside a given function or promise.
- * Behavior of nested trace() is undefined.
  * Notice: To capture every operations in asynchronous deno.* calls,
  * you might want to put them in functions instead of directly invoking.
  *
@@ -11,17 +10,17 @@ import { startTrace, endTrace } from "./dispatch";
  *     const ops = await trace(async () => {
  *       await mkdir("my_dir");
  *     });
- *     // ops becomes ["Mkdir"]
+ *     // ops becomes [{ sync: false, name: "Mkdir" }]
  */
 export async function trace(
   // tslint:disable-next-line:no-any
   fnOrPromise: Function | Promise<any>
-): Promise<string[]> {
-  startTrace();
+): Promise<TraceInfo[]> {
+  pushTraceStack();
   if (typeof fnOrPromise === "function") {
     await fnOrPromise();
   } else {
     await fnOrPromise;
   }
-  return endTrace();
+  return popTraceStack();
 }

--- a/js/trace.ts
+++ b/js/trace.ts
@@ -1,8 +1,62 @@
-import { TraceInfo, pushTraceStack, popTraceStack } from "./dispatch";
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import * as fbs from "gen/msg_generated";
+
+export interface TraceInfo {
+  sync: boolean; // is synchronous call
+  name: string; // name of operation
+}
+
+interface TraceListStackNode {
+  list: TraceInfo[];
+  prevStackNode: TraceListStackNode | null;
+}
+
+let currTraceListStackNode: TraceListStackNode | null = null;
+
+// Push a new list to trace stack
+export function pushTraceStack(): void {
+  if (currTraceListStackNode === null) {
+    currTraceListStackNode = { list: [], prevStackNode: null };
+  } else {
+    const newStack = { list: [], prevStackNode: currTraceListStackNode };
+    currTraceListStackNode = newStack;
+  }
+}
+
+// Pop from trace stack and (if possible) concat to parent trace stack node
+export function popTraceStack(): TraceInfo[] {
+  if (currTraceListStackNode === null) {
+    throw new Error("trace list stack should not be empty");
+  }
+  const resultList = currTraceListStackNode!.list;
+  if (!!currTraceListStackNode!.prevStackNode) {
+    const prevStackNode = currTraceListStackNode!.prevStackNode!;
+    // concat inner results to outer stack
+    prevStackNode.list = prevStackNode.list.concat(resultList);
+    currTraceListStackNode = prevStackNode;
+  } else {
+    currTraceListStackNode = null;
+  }
+  return resultList;
+}
+
+// Push to trace stack if we are tracing
+export function maybePushTrace(op: fbs.Any, sync: boolean): void {
+  if (currTraceListStackNode === null) {
+    return; // no trace requested
+  }
+  // Freeze the object, avoid tampering
+  currTraceListStackNode!.list.push(
+    Object.freeze({
+      sync,
+      name: fbs.Any[op] // convert to enum names
+    })
+  );
+}
 
 /**
  * Trace operations executed inside a given function or promise.
- * Notice: To capture every operations in asynchronous deno.* calls,
+ * Notice: To capture every operation in asynchronous deno.* calls,
  * you might want to put them in functions instead of directly invoking.
  *
  *     import { trace, mkdir } from "deno";

--- a/js/trace.ts
+++ b/js/trace.ts
@@ -1,0 +1,27 @@
+import { startTrace, endTrace } from "./dispatch";
+
+/**
+ * Trace operations executed inside a given function or promise.
+ * Behavior of nested trace() is undefined.
+ * Notice: To capture every operations in asynchronous deno.* calls,
+ * you might want to put them in functions instead of directly invoking.
+ *
+ *     import { trace, mkdir } from "deno";
+ *
+ *     const ops = await trace(async () => {
+ *       await mkdir("my_dir");
+ *     });
+ *     // ops becomes ["Mkdir"]
+ */
+export async function trace(
+  // tslint:disable-next-line:no-any
+  fnOrPromise: Function | Promise<any>
+): Promise<string[]> {
+  startTrace();
+  if (typeof fnOrPromise === "function") {
+    await fnOrPromise();
+  } else {
+    await fnOrPromise;
+  }
+  return endTrace();
+}

--- a/js/trace_test.ts
+++ b/js/trace_test.ts
@@ -1,0 +1,45 @@
+import { testPerm, assertEqual } from "./test_util.ts";
+import * as deno from "deno";
+
+testPerm({ write: true }, async function traceFunctionSuccess() {
+  const ops = await deno.trace(async () => {
+    const enc = new TextEncoder();
+    const data = enc.encode("Hello");
+    // Mixing sync and async calls
+    const filename = deno.makeTempDirSync() + "/test.txt";
+    await deno.writeFile(filename, data, 0o666);
+    await deno.removeSync(filename);
+  });
+  assertEqual(ops.length, 3);
+  assertEqual(ops[0], "MakeTempDir");
+  assertEqual(ops[1], "WriteFile");
+  assertEqual(ops[2], "Remove");
+});
+
+testPerm({ write: true }, async function tracePromiseSuccess() {
+  // Ensure we don't miss any send actions
+  // (new Promise(fn), fn runs synchronously)
+  const asyncFunction = async () => {
+    const enc = new TextEncoder();
+    const data = enc.encode("Hello");
+    // Mixing sync and async calls
+    const filename = deno.makeTempDirSync() + "/test.txt";
+    await deno.writeFile(filename, data, 0o666);
+    await deno.removeSync(filename);
+  };
+  const promise = Promise.resolve().then(asyncFunction);
+  const ops = await deno.trace(promise);
+  assertEqual(ops.length, 3);
+  assertEqual(ops[0], "MakeTempDir");
+  assertEqual(ops[1], "WriteFile");
+  assertEqual(ops[2], "Remove");
+});
+
+testPerm({ write: true }, async function traceRepeatSuccess() {
+  const ops1 = await deno.trace(async () => await deno.makeTempDir());
+  assertEqual(ops1.length, 1);
+  assertEqual(ops1[0], "MakeTempDir");
+  const ops2 = await deno.trace(async () => await deno.statSync("."));
+  assertEqual(ops2.length, 1);
+  assertEqual(ops2[0], "Stat");
+});

--- a/js/trace_test.ts
+++ b/js/trace_test.ts
@@ -11,9 +11,12 @@ testPerm({ write: true }, async function traceFunctionSuccess() {
     await deno.removeSync(filename);
   });
   assertEqual(ops.length, 3);
-  assertEqual(ops[0], "MakeTempDir");
-  assertEqual(ops[1], "WriteFile");
-  assertEqual(ops[2], "Remove");
+  assertEqual(ops[0].name, "MakeTempDir");
+  assertEqual(ops[0].sync, true);
+  assertEqual(ops[1].name, "WriteFile");
+  assertEqual(ops[1].sync, false);
+  assertEqual(ops[2].name, "Remove");
+  assertEqual(ops[2].sync, true);
 });
 
 testPerm({ write: true }, async function tracePromiseSuccess() {
@@ -30,16 +33,66 @@ testPerm({ write: true }, async function tracePromiseSuccess() {
   const promise = Promise.resolve().then(asyncFunction);
   const ops = await deno.trace(promise);
   assertEqual(ops.length, 3);
-  assertEqual(ops[0], "MakeTempDir");
-  assertEqual(ops[1], "WriteFile");
-  assertEqual(ops[2], "Remove");
+  assertEqual(ops[0].name, "MakeTempDir");
+  assertEqual(ops[0].sync, true);
+  assertEqual(ops[1].name, "WriteFile");
+  assertEqual(ops[1].sync, false);
+  assertEqual(ops[2].name, "Remove");
+  assertEqual(ops[2].sync, true);
 });
 
 testPerm({ write: true }, async function traceRepeatSuccess() {
   const ops1 = await deno.trace(async () => await deno.makeTempDir());
   assertEqual(ops1.length, 1);
-  assertEqual(ops1[0], "MakeTempDir");
+  assertEqual(ops1[0].name, "MakeTempDir");
+  assertEqual(ops1[0].sync, false);
   const ops2 = await deno.trace(async () => await deno.statSync("."));
   assertEqual(ops2.length, 1);
-  assertEqual(ops2[0], "Stat");
+  assertEqual(ops2[0].name, "Stat");
+  assertEqual(ops2[0].sync, true);
+});
+
+testPerm({ write: true }, async function traceIdempotence() {
+  let ops1, ops2, ops3;
+  ops1 = await deno.trace(async () => {
+    const filename = (await deno.makeTempDir()) + "/test.txt";
+    ops2 = await deno.trace(async () => {
+      const enc = new TextEncoder();
+      const data = enc.encode("Hello");
+      deno.writeFileSync(filename, data, 0o666);
+      ops3 = await deno.trace(async () => {
+        await deno.remove(filename);
+      });
+      await deno.makeTempDir();
+    });
+  });
+
+  // Flatten the calls
+  assertEqual(ops1.length, 4);
+  assertEqual(ops1[0].name, "MakeTempDir");
+  assertEqual(ops1[0].sync, false);
+  assertEqual(ops1[1].name, "WriteFile");
+  assertEqual(ops1[1].sync, true);
+  assertEqual(ops1[2].name, "Remove");
+  assertEqual(ops1[2].sync, false);
+  assertEqual(ops1[3].name, "MakeTempDir");
+  assertEqual(ops1[3].sync, false);
+
+  assertEqual(ops2.length, 3);
+  assertEqual(ops2[0].name, "WriteFile");
+  assertEqual(ops2[0].sync, true);
+  assertEqual(ops2[1].name, "Remove");
+  assertEqual(ops2[1].sync, false);
+  assertEqual(ops2[2].name, "MakeTempDir");
+  assertEqual(ops2[2].sync, false);
+
+  assertEqual(ops3.length, 1);
+  assertEqual(ops3[0].name, "Remove");
+  assertEqual(ops3[0].sync, false);
+
+  // Expect top-level repeat still works after all the nestings
+  const ops4 = await deno.trace(async () => await deno.statSync("."));
+  assertEqual(ops4.length, 1);
+  assertEqual(ops4[0].name, "Stat");
+  assertEqual(ops4[0].sync, true);
 });

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -16,3 +16,4 @@ import "./timers_test.ts";
 import "./symlink_test.ts";
 import "./platform_test.ts";
 import "./text_encoding_test.ts";
+import "./trace_test.ts";


### PR DESCRIPTION
Closes #788 .
Implements `deno.trace(fnOrPromise: Function | Promise<any>): Promise<string[]>`.
Notice that for calls such as `deno.mkdir()`, we should place it inside an async function for tracing (to avoid missing the first message due to the syntactical nature of `async/await`), such as `await deno.trace(async () => await deno.mkdir("my_dir"))`
Nested `trace` calls would have the inner trace result flattened and concat to the outer one. See `traceIdempotent` test for details
