### PR TITLE
Rename deno.argv, libdeno::DenoC and deno_set_flags 

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -13,4 +13,4 @@ export { writeFileSync, writeFile } from "./write_file";
 export { ErrorKind, DenoError } from "./errors";
 export { libdeno } from "./libdeno";
 export { arch, platform } from "./platform";
-export const argv: string[] = [];
+export const args: string[] = [];

--- a/js/main.ts
+++ b/js/main.ts
@@ -5,7 +5,7 @@ import { assert, log, setLogDebug } from "./util";
 import * as os from "./os";
 import { DenoCompiler } from "./compiler";
 import { libdeno } from "./libdeno";
-import { argv } from "./deno";
+import { args } from "./deno";
 import { sendSync, handleAsyncMsgFromRust } from "./dispatch";
 
 function sendStart(): fbs.StartRes {
@@ -39,7 +39,7 @@ export default function denoMain() {
 
   // First we send an empty "Start" message to let the privlaged side know we
   // are ready. The response should be a "StartRes" message containing the CLI
-  // argv and other info.
+  // args and other info.
   const startResMsg = sendStart();
 
   setLogDebug(startResMsg.debugFlag());
@@ -49,12 +49,12 @@ export default function denoMain() {
 
   // TODO handle shebang.
   for (let i = 1; i < startResMsg.argvLength(); i++) {
-    argv.push(startResMsg.argv(i));
+    args.push(startResMsg.argv(i));
   }
-  log("argv", argv);
-  Object.freeze(argv);
+  log("args", args);
+  Object.freeze(args);
 
-  const inputFn = argv[0];
+  const inputFn = args[0];
   if (!inputFn) {
     console.log("No input script specified.");
     os.exit(1);

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -12,7 +12,7 @@ import * as testing from "./testing/testing.ts";
 export { assert, assertEqual } from "./testing/testing.ts";
 
 // testing.setFilter must be run before any tests are defined.
-testing.setFilter(deno.argv[1]);
+testing.setFilter(deno.args[1]);
 
 interface DenoPermissions {
   write?: boolean;

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -393,7 +393,7 @@ void* deno_get_data(Deno* d) { return d->data; }
 
 const char* deno_v8_version() { return v8::V8::GetVersion(); }
 
-void deno_set_flags(int* argc, char** argv) {
+void deno_set_v8_flags(int* argc, char** argv) {
   v8::V8::SetFlagsFromCommandLine(argc, argv, true);
 }
 

--- a/libdeno/deno.h
+++ b/libdeno/deno.h
@@ -26,7 +26,7 @@ typedef void (*deno_recv_cb)(Deno* d, deno_buf buf);
 
 void deno_init();
 const char* deno_v8_version();
-void deno_set_flags(int* argc, char** argv);
+void deno_set_v8_flags(int* argc, char** argv);
 
 Deno* deno_new(void* data, deno_recv_cb cb);
 void deno_delete(Deno* d);

--- a/libdeno/test.cc
+++ b/libdeno/test.cc
@@ -5,6 +5,6 @@
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   deno_init();
-  deno_set_flags(&argc, argv);
+  deno_set_v8_flags(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -189,7 +189,7 @@ fn test_parse_core_args_2() {
 // Pass the command line arguments to v8.
 // Returns a vector of command line arguments that v8 did not understand.
 pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
-  // deno_set_flags(int* argc, char** argv) mutates argc and argv to remove
+  // deno_set_v8_flags(int* argc, char** argv) mutates argc and argv to remove
   // flags that v8 understands.
   // First parse core args, then converto to a vector of C strings.
   let (argv, rest) = parse_core_args(args);
@@ -205,13 +205,12 @@ pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
     .map(|arg| arg.as_mut_ptr() as *mut i8)
     .collect::<Vec<_>>();
   // Store the length of the argv array in a local variable. We'll pass a
-  // pointer to this local variable to deno_set_flags(), which then
+  // pointer to this local variable to deno_set_v8_flags(), which then
   // updates its value.
   let mut c_argc = c_argv.len() as c_int;
   // Let v8 parse the arguments it recognizes and remove them from c_argv.
   unsafe {
-    // TODO(ry) Rename deno_set_flags to deno_set_v8_flags().
-    libdeno::deno_set_flags(&mut c_argc, c_argv.as_mut_ptr());
+    libdeno::deno_set_v8_flags(&mut c_argc, c_argv.as_mut_ptr());
   };
   // If c_argc was updated we have to change the length of c_argv to match.
   c_argv.truncate(c_argc as usize);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -629,7 +629,7 @@ fn handle_timer_start(i: *const isolate, base: &msg::Base) -> Box<Op> {
   let future = {
     let (delay_task, cancel_delay) = set_timeout(
       move || {
-        remove_timer(d, timer_id);
+        remove_timer(i, timer_id);
       },
       delay,
     );

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -10,7 +10,7 @@ use hyper::rt::{Future, Stream};
 use hyper::Client;
 use isolate::from_c;
 use libdeno;
-use libdeno::{deno_buf, isolate};
+use libdeno::{deno_buf, isolate_ptr};
 use msg;
 use remove_dir_all::remove_dir_all;
 use std;
@@ -36,9 +36,9 @@ type OpResult = DenoResult<Buf>;
 
 // TODO Ideally we wouldn't have to box the Op being returned.
 // The box is just to make it easier to get a prototype refactor working.
-type Handler = fn(d: *const isolate, base: &msg::Base) -> Box<Op>;
+type Handler = fn(d: *const isolate_ptr, base: &msg::Base) -> Box<Op>;
 
-pub extern "C" fn msg_from_js(d: *const isolate, buf: deno_buf) {
+pub extern "C" fn msg_from_js(d: *const isolate_ptr, buf: deno_buf) {
   let bytes = unsafe { std::slice::from_raw_parts(buf.data_ptr, buf.data_len) };
   let base = msg::get_root_as_base(bytes);
   let msg_type = base.msg_type();
@@ -150,12 +150,12 @@ fn not_implemented() -> DenoError {
   ))
 }
 
-fn handle_exit(_d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_exit(_d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_exit().unwrap();
   std::process::exit(msg.code())
 }
 
-fn handle_start(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_start(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let isolate = from_c(d);
   let mut builder = FlatBufferBuilder::new();
 
@@ -211,7 +211,7 @@ fn odd_future(err: DenoError) -> Box<Op> {
 }
 
 // https://github.com/denoland/isolate/blob/golang/os.go#L100-L154
-fn handle_code_fetch(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_code_fetch(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_code_fetch().unwrap();
   let cmd_id = base.cmd_id();
   let module_specifier = msg.module_specifier().unwrap();
@@ -253,7 +253,7 @@ fn handle_code_fetch(d: *const isolate, base: &msg::Base) -> Box<Op> {
 }
 
 // https://github.com/denoland/isolate/blob/golang/os.go#L156-L169
-fn handle_code_cache(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_code_cache(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_code_cache().unwrap();
   let filename = msg.filename().unwrap();
   let source_code = msg.source_code().unwrap();
@@ -265,7 +265,7 @@ fn handle_code_cache(d: *const isolate, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_set_env(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_set_env(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_set_env().unwrap();
   let key = msg.key().unwrap();
   let value = msg.value().unwrap();
@@ -279,7 +279,7 @@ fn handle_set_env(d: *const isolate, base: &msg::Base) -> Box<Op> {
   ok_future(None)
 }
 
-fn handle_env(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_env(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let isolate = from_c(d);
   let cmd_id = base.cmd_id();
   if !isolate.flags.allow_env {
@@ -320,7 +320,7 @@ fn handle_env(d: *const isolate, base: &msg::Base) -> Box<Op> {
   ))
 }
 
-fn handle_fetch_req(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_fetch_req(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_fetch_req().unwrap();
   let cmd_id = base.cmd_id();
   let id = msg.id();
@@ -420,7 +420,7 @@ where
   (delay_task, cancel_tx)
 }
 
-fn handle_make_temp_dir(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_make_temp_dir(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let base = Box::new(*base);
   let msg = base.msg_as_make_temp_dir().unwrap();
   let cmd_id = base.cmd_id();
@@ -475,7 +475,7 @@ fn handle_mkdir(d: *const isolate, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_remove(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_remove(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_remove().unwrap();
   let path = msg.path().unwrap();
   let recursive = msg.recursive();
@@ -502,7 +502,7 @@ fn handle_remove(d: *const isolate, base: &msg::Base) -> Box<Op> {
 }
 
 // Prototype https://github.com/denoland/isolate/blob/golang/os.go#L171-L184
-fn handle_read_file(_d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_read_file(_d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_read_file().unwrap();
   let cmd_id = base.cmd_id();
   let filename = String::from(msg.filename().unwrap());
@@ -552,7 +552,7 @@ fn get_mode(_perm: fs::Permissions) -> u32 {
   0
 }
 
-fn handle_stat(_d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_stat(_d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_stat().unwrap();
   let cmd_id = base.cmd_id();
   let filename = String::from(msg.filename().unwrap());
@@ -595,7 +595,7 @@ fn handle_stat(_d: *const isolate, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_write_file(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_write_file(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_write_file().unwrap();
   let filename = String::from(msg.filename().unwrap());
   let data = msg.data().unwrap();
@@ -612,13 +612,13 @@ fn handle_write_file(d: *const isolate, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn remove_timer(d: *const isolate, timer_id: u32) {
+fn remove_timer(d: *const isolate_ptr, timer_id: u32) {
   let isolate = from_c(d);
   isolate.timers.remove(&timer_id);
 }
 
 // Prototype: https://github.com/ry/isolate/blob/golang/timers.go#L25-L39
-fn handle_timer_start(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_timer_start(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   debug!("handle_timer_start");
   let msg = base.msg_as_timer_start().unwrap();
   let cmd_id = base.cmd_id();
@@ -659,14 +659,14 @@ fn handle_timer_start(d: *const isolate, base: &msg::Base) -> Box<Op> {
 }
 
 // Prototype: https://github.com/ry/isolate/blob/golang/timers.go#L40-L43
-fn handle_timer_clear(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_timer_clear(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_timer_clear().unwrap();
   debug!("handle_timer_clear");
   remove_timer(d, msg.id());
   ok_future(None)
 }
 
-fn handle_rename(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_rename(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let isolate = from_c(d);
   if !isolate.flags.allow_write {
     return odd_future(permission_denied());
@@ -681,7 +681,7 @@ fn handle_rename(d: *const isolate, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_symlink(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_symlink(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let deno = from_c(d);
   if !deno.flags.allow_write {
     return odd_future(permission_denied());

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -10,7 +10,7 @@ use hyper::rt::{Future, Stream};
 use hyper::Client;
 use isolate::from_c;
 use libdeno;
-use libdeno::{deno_buf, DenoC};
+use libdeno::{deno_buf, isolate};
 use msg;
 use remove_dir_all::remove_dir_all;
 use std;
@@ -36,9 +36,9 @@ type OpResult = DenoResult<Buf>;
 
 // TODO Ideally we wouldn't have to box the Op being returned.
 // The box is just to make it easier to get a prototype refactor working.
-type Handler = fn(d: *const DenoC, base: &msg::Base) -> Box<Op>;
+type Handler = fn(d: *const isolate, base: &msg::Base) -> Box<Op>;
 
-pub extern "C" fn msg_from_js(d: *const DenoC, buf: deno_buf) {
+pub extern "C" fn msg_from_js(d: *const isolate, buf: deno_buf) {
   let bytes = unsafe { std::slice::from_raw_parts(buf.data_ptr, buf.data_len) };
   let base = msg::get_root_as_base(bytes);
   let msg_type = base.msg_type();
@@ -150,12 +150,12 @@ fn not_implemented() -> DenoError {
   ))
 }
 
-fn handle_exit(_d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_exit(_d: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_exit().unwrap();
   std::process::exit(msg.code())
 }
 
-fn handle_start(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_start(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let isolate = from_c(d);
   let mut builder = FlatBufferBuilder::new();
 
@@ -211,7 +211,7 @@ fn odd_future(err: DenoError) -> Box<Op> {
 }
 
 // https://github.com/denoland/isolate/blob/golang/os.go#L100-L154
-fn handle_code_fetch(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_code_fetch(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_code_fetch().unwrap();
   let cmd_id = base.cmd_id();
   let module_specifier = msg.module_specifier().unwrap();
@@ -253,7 +253,7 @@ fn handle_code_fetch(d: *const DenoC, base: &msg::Base) -> Box<Op> {
 }
 
 // https://github.com/denoland/isolate/blob/golang/os.go#L156-L169
-fn handle_code_cache(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_code_cache(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_code_cache().unwrap();
   let filename = msg.filename().unwrap();
   let source_code = msg.source_code().unwrap();
@@ -265,7 +265,7 @@ fn handle_code_cache(d: *const DenoC, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_set_env(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_set_env(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_set_env().unwrap();
   let key = msg.key().unwrap();
   let value = msg.value().unwrap();
@@ -279,7 +279,7 @@ fn handle_set_env(d: *const DenoC, base: &msg::Base) -> Box<Op> {
   ok_future(None)
 }
 
-fn handle_env(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_env(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let isolate = from_c(d);
   let cmd_id = base.cmd_id();
   if !isolate.flags.allow_env {
@@ -320,7 +320,7 @@ fn handle_env(d: *const DenoC, base: &msg::Base) -> Box<Op> {
   ))
 }
 
-fn handle_fetch_req(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_fetch_req(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_fetch_req().unwrap();
   let cmd_id = base.cmd_id();
   let id = msg.id();
@@ -420,7 +420,7 @@ where
   (delay_task, cancel_tx)
 }
 
-fn handle_make_temp_dir(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_make_temp_dir(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let base = Box::new(*base);
   let msg = base.msg_as_make_temp_dir().unwrap();
   let cmd_id = base.cmd_id();
@@ -459,7 +459,7 @@ fn handle_make_temp_dir(d: *const DenoC, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_mkdir(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_mkdir(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_mkdir().unwrap();
   let mode = msg.mode();
   let path = msg.path().unwrap();
@@ -475,7 +475,7 @@ fn handle_mkdir(d: *const DenoC, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_remove(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_remove(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_remove().unwrap();
   let path = msg.path().unwrap();
   let recursive = msg.recursive();
@@ -502,7 +502,7 @@ fn handle_remove(d: *const DenoC, base: &msg::Base) -> Box<Op> {
 }
 
 // Prototype https://github.com/denoland/isolate/blob/golang/os.go#L171-L184
-fn handle_read_file(_d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_read_file(_d: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_read_file().unwrap();
   let cmd_id = base.cmd_id();
   let filename = String::from(msg.filename().unwrap());
@@ -552,7 +552,7 @@ fn get_mode(_perm: fs::Permissions) -> u32 {
   0
 }
 
-fn handle_stat(_d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_stat(_d: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_stat().unwrap();
   let cmd_id = base.cmd_id();
   let filename = String::from(msg.filename().unwrap());
@@ -595,7 +595,7 @@ fn handle_stat(_d: *const DenoC, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_write_file(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_write_file(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_write_file().unwrap();
   let filename = String::from(msg.filename().unwrap());
   let data = msg.data().unwrap();
@@ -612,14 +612,13 @@ fn handle_write_file(d: *const DenoC, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-// TODO(ry) Use Isolate instead of DenoC as first arg.
-fn remove_timer(d: *const DenoC, timer_id: u32) {
+fn remove_timer(d: *const isolate, timer_id: u32) {
   let isolate = from_c(d);
   isolate.timers.remove(&timer_id);
 }
 
 // Prototype: https://github.com/ry/isolate/blob/golang/timers.go#L25-L39
-fn handle_timer_start(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_timer_start(d: *const isolate, base: &msg::Base) -> Box<Op> {
   debug!("handle_timer_start");
   let msg = base.msg_as_timer_start().unwrap();
   let cmd_id = base.cmd_id();
@@ -660,14 +659,14 @@ fn handle_timer_start(d: *const DenoC, base: &msg::Base) -> Box<Op> {
 }
 
 // Prototype: https://github.com/ry/isolate/blob/golang/timers.go#L40-L43
-fn handle_timer_clear(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_timer_clear(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_timer_clear().unwrap();
   debug!("handle_timer_clear");
   remove_timer(d, msg.id());
   ok_future(None)
 }
 
-fn handle_rename(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_rename(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let isolate = from_c(d);
   if !isolate.flags.allow_write {
     return odd_future(permission_denied());
@@ -682,7 +681,7 @@ fn handle_rename(d: *const DenoC, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_symlink(d: *const DenoC, base: &msg::Base) -> Box<Op> {
+fn handle_symlink(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let deno = from_c(d);
   if !deno.flags.allow_write {
     return odd_future(permission_denied());

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -36,9 +36,9 @@ type OpResult = DenoResult<Buf>;
 
 // TODO Ideally we wouldn't have to box the Op being returned.
 // The box is just to make it easier to get a prototype refactor working.
-type Handler = fn(d: *const isolate, base: &msg::Base) -> Box<Op>;
+type Handler = fn(i: *const isolate, base: &msg::Base) -> Box<Op>;
 
-pub extern "C" fn msg_from_js(d: *const isolate, buf: deno_buf) {
+pub extern "C" fn msg_from_js(i: *const isolate, buf: deno_buf) {
   let bytes = unsafe { std::slice::from_raw_parts(buf.data_ptr, buf.data_len) };
   let base = msg::get_root_as_base(bytes);
   let msg_type = base.msg_type();
@@ -67,7 +67,7 @@ pub extern "C" fn msg_from_js(d: *const isolate, buf: deno_buf) {
     )),
   };
 
-  let future = handler(d, &base);
+  let future = handler(i, &base);
   let future = future.or_else(move |err| {
     // No matter whether we got an Err or Ok, we want a serialized message to
     // send back. So transform the DenoError into a deno_buf.
@@ -84,7 +84,7 @@ pub extern "C" fn msg_from_js(d: *const isolate, buf: deno_buf) {
     ))
   });
 
-  let isolate = from_c(d);
+  let isolate = from_c(i);
   if base.sync() {
     // Execute future synchronously.
     // println!("sync handler {}", msg::enum_name_any(msg_type));
@@ -94,7 +94,7 @@ pub extern "C" fn msg_from_js(d: *const isolate, buf: deno_buf) {
       Some(box_u8) => {
         let buf = deno_buf_from(box_u8);
         // Set the synchronous response, the value returned from isolate.send().
-        unsafe { libdeno::deno_set_response(d, buf) }
+        unsafe { libdeno::deno_set_response(i, buf) }
       }
     }
   } else {
@@ -118,7 +118,7 @@ pub extern "C" fn msg_from_js(d: *const isolate, buf: deno_buf) {
         }
       };
       // TODO(ry) make this thread safe.
-      unsafe { libdeno::deno_send(d, buf) };
+      unsafe { libdeno::deno_send(i, buf) };
       Ok(())
     });
     isolate.rt.spawn(future);
@@ -150,13 +150,13 @@ fn not_implemented() -> DenoError {
   ))
 }
 
-fn handle_exit(_d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_exit(_i: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_exit().unwrap();
   std::process::exit(msg.code())
 }
 
-fn handle_start(d: *const isolate, base: &msg::Base) -> Box<Op> {
-  let isolate = from_c(d);
+fn handle_start(i: *const isolate, base: &msg::Base) -> Box<Op> {
+  let isolate = from_c(i);
   let mut builder = FlatBufferBuilder::new();
 
   let argv = isolate.argv.iter().map(|s| s.as_str()).collect::<Vec<_>>();
@@ -211,12 +211,12 @@ fn odd_future(err: DenoError) -> Box<Op> {
 }
 
 // https://github.com/denoland/isolate/blob/golang/os.go#L100-L154
-fn handle_code_fetch(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_code_fetch(i: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_code_fetch().unwrap();
   let cmd_id = base.cmd_id();
   let module_specifier = msg.module_specifier().unwrap();
   let containing_file = msg.containing_file().unwrap();
-  let isolate = from_c(d);
+  let isolate = from_c(i);
 
   assert_eq!(
     isolate.dir.root.join("gen"),
@@ -253,24 +253,24 @@ fn handle_code_fetch(d: *const isolate, base: &msg::Base) -> Box<Op> {
 }
 
 // https://github.com/denoland/isolate/blob/golang/os.go#L156-L169
-fn handle_code_cache(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_code_cache(i: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_code_cache().unwrap();
   let filename = msg.filename().unwrap();
   let source_code = msg.source_code().unwrap();
   let output_code = msg.output_code().unwrap();
   Box::new(futures::future::result(|| -> OpResult {
-    let isolate = from_c(d);
+    let isolate = from_c(i);
     isolate.dir.code_cache(filename, source_code, output_code)?;
     Ok(None)
   }()))
 }
 
-fn handle_set_env(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_set_env(i: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_set_env().unwrap();
   let key = msg.key().unwrap();
   let value = msg.value().unwrap();
 
-  let isolate = from_c(d);
+  let isolate = from_c(i);
   if !isolate.flags.allow_env {
     return odd_future(permission_denied());
   }
@@ -279,8 +279,8 @@ fn handle_set_env(d: *const isolate, base: &msg::Base) -> Box<Op> {
   ok_future(None)
 }
 
-fn handle_env(d: *const isolate, base: &msg::Base) -> Box<Op> {
-  let isolate = from_c(d);
+fn handle_env(i: *const isolate, base: &msg::Base) -> Box<Op> {
+  let isolate = from_c(i);
   let cmd_id = base.cmd_id();
   if !isolate.flags.allow_env {
     return odd_future(permission_denied());
@@ -320,12 +320,12 @@ fn handle_env(d: *const isolate, base: &msg::Base) -> Box<Op> {
   ))
 }
 
-fn handle_fetch_req(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_fetch_req(i: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_fetch_req().unwrap();
   let cmd_id = base.cmd_id();
   let id = msg.id();
   let url = msg.url().unwrap();
-  let isolate = from_c(d);
+  let isolate = from_c(i);
 
   if !isolate.flags.allow_net {
     return odd_future(permission_denied());
@@ -420,7 +420,7 @@ where
   (delay_task, cancel_tx)
 }
 
-fn handle_make_temp_dir(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_make_temp_dir(i: *const isolate, base: &msg::Base) -> Box<Op> {
   let base = Box::new(*base);
   let msg = base.msg_as_make_temp_dir().unwrap();
   let cmd_id = base.cmd_id();
@@ -428,7 +428,7 @@ fn handle_make_temp_dir(d: *const isolate, base: &msg::Base) -> Box<Op> {
   let prefix = msg.prefix();
   let suffix = msg.suffix();
 
-  let isolate = from_c(d);
+  let isolate = from_c(i);
   if !isolate.flags.allow_write {
     return odd_future(permission_denied());
   }
@@ -459,11 +459,11 @@ fn handle_make_temp_dir(d: *const isolate, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_mkdir(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_mkdir(i: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_mkdir().unwrap();
   let mode = msg.mode();
   let path = msg.path().unwrap();
-  let isolate = from_c(d);
+  let isolate = from_c(i);
   if !isolate.flags.allow_write {
     return odd_future(permission_denied());
   }
@@ -475,11 +475,11 @@ fn handle_mkdir(d: *const isolate, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_remove(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_remove(i: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_remove().unwrap();
   let path = msg.path().unwrap();
   let recursive = msg.recursive();
-  let isolate = from_c(d);
+  let isolate = from_c(i);
   if !isolate.flags.allow_write {
     return odd_future(permission_denied());
   }
@@ -502,7 +502,7 @@ fn handle_remove(d: *const isolate, base: &msg::Base) -> Box<Op> {
 }
 
 // Prototype https://github.com/denoland/isolate/blob/golang/os.go#L171-L184
-fn handle_read_file(_d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_read_file(_i: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_read_file().unwrap();
   let cmd_id = base.cmd_id();
   let filename = String::from(msg.filename().unwrap());
@@ -552,7 +552,7 @@ fn get_mode(_perm: fs::Permissions) -> u32 {
   0
 }
 
-fn handle_stat(_d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_stat(_i: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_stat().unwrap();
   let cmd_id = base.cmd_id();
   let filename = String::from(msg.filename().unwrap());
@@ -595,13 +595,13 @@ fn handle_stat(_d: *const isolate, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_write_file(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_write_file(i: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_write_file().unwrap();
   let filename = String::from(msg.filename().unwrap());
   let data = msg.data().unwrap();
   let perm = msg.perm();
 
-  let isolate = from_c(d);
+  let isolate = from_c(i);
   if !isolate.flags.allow_write {
     return odd_future(permission_denied());
   }
@@ -612,19 +612,19 @@ fn handle_write_file(d: *const isolate, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn remove_timer(d: *const isolate, timer_id: u32) {
-  let isolate = from_c(d);
+fn remove_timer(i: *const isolate, timer_id: u32) {
+  let isolate = from_c(i);
   isolate.timers.remove(&timer_id);
 }
 
 // Prototype: https://github.com/ry/isolate/blob/golang/timers.go#L25-L39
-fn handle_timer_start(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_timer_start(i: *const isolate, base: &msg::Base) -> Box<Op> {
   debug!("handle_timer_start");
   let msg = base.msg_as_timer_start().unwrap();
   let cmd_id = base.cmd_id();
   let timer_id = msg.id();
   let delay = msg.delay();
-  let isolate = from_c(d);
+  let isolate = from_c(i);
 
   let future = {
     let (delay_task, cancel_delay) = set_timeout(
@@ -659,15 +659,15 @@ fn handle_timer_start(d: *const isolate, base: &msg::Base) -> Box<Op> {
 }
 
 // Prototype: https://github.com/ry/isolate/blob/golang/timers.go#L40-L43
-fn handle_timer_clear(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_timer_clear(i: *const isolate, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_timer_clear().unwrap();
   debug!("handle_timer_clear");
-  remove_timer(d, msg.id());
+  remove_timer(i, msg.id());
   ok_future(None)
 }
 
-fn handle_rename(d: *const isolate, base: &msg::Base) -> Box<Op> {
-  let isolate = from_c(d);
+fn handle_rename(i: *const isolate, base: &msg::Base) -> Box<Op> {
+  let isolate = from_c(i);
   if !isolate.flags.allow_write {
     return odd_future(permission_denied());
   }
@@ -681,8 +681,8 @@ fn handle_rename(d: *const isolate, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_symlink(d: *const isolate, base: &msg::Base) -> Box<Op> {
-  let deno = from_c(d);
+fn handle_symlink(i: *const isolate, base: &msg::Base) -> Box<Op> {
+  let deno = from_c(i);
   if !deno.flags.allow_write {
     return odd_future(permission_denied());
   }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -459,7 +459,7 @@ fn handle_make_temp_dir(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   }()))
 }
 
-fn handle_mkdir(d: *const isolate, base: &msg::Base) -> Box<Op> {
+fn handle_mkdir(d: *const isolate_ptr, base: &msg::Base) -> Box<Op> {
   let msg = base.msg_as_mkdir().unwrap();
   let mode = msg.mode();
   let path = msg.path().unwrap();

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -14,7 +14,7 @@ use tokio;
 type DenoException<'a> = &'a str;
 
 pub struct Isolate {
-  pub ptr: *const libdeno::DenoC,
+  pub ptr: *const libdeno::isolate,
   pub dir: deno_dir::DenoDir,
   pub rt: tokio::runtime::current_thread::Runtime,
   pub timers: HashMap<u32, futures::sync::oneshot::Sender<()>>,
@@ -33,7 +33,7 @@ impl Isolate {
     let (flags, argv_rest) = flags::set_flags(argv);
 
     let mut deno_box = Box::new(Isolate {
-      ptr: 0 as *const libdeno::DenoC,
+      ptr: 0 as *const libdeno::isolate,
       dir: deno_dir::DenoDir::new(flags.reload, None).unwrap(),
       rt: tokio::runtime::current_thread::Runtime::new().unwrap(),
       timers: HashMap::new(),
@@ -76,7 +76,7 @@ impl Drop for Isolate {
   }
 }
 
-pub fn from_c<'a>(d: *const libdeno::DenoC) -> &'a mut Isolate {
+pub fn from_c<'a>(d: *const libdeno::isolate) -> &'a mut Isolate {
   let ptr = unsafe { libdeno::deno_get_data(d) };
   let ptr = ptr as *mut Isolate;
   let isolate_box = unsafe { Box::from_raw(ptr) };

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -14,7 +14,7 @@ use tokio;
 type DenoException<'a> = &'a str;
 
 pub struct Isolate {
-  pub ptr: *const libdeno::isolate_ptr,
+  pub ptr: *const libdeno::isolate,
   pub dir: deno_dir::DenoDir,
   pub rt: tokio::runtime::current_thread::Runtime,
   pub timers: HashMap<u32, futures::sync::oneshot::Sender<()>>,
@@ -33,7 +33,7 @@ impl Isolate {
     let (flags, argv_rest) = flags::set_flags(argv);
 
     let mut deno_box = Box::new(Isolate {
-      ptr: 0 as *const libdeno::isolate_ptr,
+      ptr: 0 as *const libdeno::isolate,
       dir: deno_dir::DenoDir::new(flags.reload, None).unwrap(),
       rt: tokio::runtime::current_thread::Runtime::new().unwrap(),
       timers: HashMap::new(),
@@ -76,7 +76,7 @@ impl Drop for Isolate {
   }
 }
 
-pub fn from_c<'a>(d: *const libdeno::isolate_ptr) -> &'a mut Isolate {
+pub fn from_c<'a>(d: *const libdeno::isolate) -> &'a mut Isolate {
   let ptr = unsafe { libdeno::deno_get_data(d) };
   let ptr = ptr as *mut Isolate;
   let isolate_box = unsafe { Box::from_raw(ptr) };

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -14,7 +14,7 @@ use tokio;
 type DenoException<'a> = &'a str;
 
 pub struct Isolate {
-  pub ptr: *const libdeno::isolate,
+  pub ptr: *const libdeno::isolate_ptr,
   pub dir: deno_dir::DenoDir,
   pub rt: tokio::runtime::current_thread::Runtime,
   pub timers: HashMap<u32, futures::sync::oneshot::Sender<()>>,
@@ -33,7 +33,7 @@ impl Isolate {
     let (flags, argv_rest) = flags::set_flags(argv);
 
     let mut deno_box = Box::new(Isolate {
-      ptr: 0 as *const libdeno::isolate,
+      ptr: 0 as *const libdeno::isolate_ptr,
       dir: deno_dir::DenoDir::new(flags.reload, None).unwrap(),
       rt: tokio::runtime::current_thread::Runtime::new().unwrap(),
       timers: HashMap::new(),
@@ -76,7 +76,7 @@ impl Drop for Isolate {
   }
 }
 
-pub fn from_c<'a>(d: *const libdeno::isolate) -> &'a mut Isolate {
+pub fn from_c<'a>(d: *const libdeno::isolate_ptr) -> &'a mut Isolate {
   let ptr = unsafe { libdeno::deno_get_data(d) };
   let ptr = ptr as *mut Isolate;
   let isolate_box = unsafe { Box::from_raw(ptr) };

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -76,8 +76,8 @@ impl Drop for Isolate {
   }
 }
 
-pub fn from_c<'a>(d: *const libdeno::isolate) -> &'a mut Isolate {
-  let ptr = unsafe { libdeno::deno_get_data(d) };
+pub fn from_c<'a>(i: *const libdeno::isolate) -> &'a mut Isolate {
+  let ptr = unsafe { libdeno::deno_get_data(i) };
   let ptr = ptr as *mut Isolate;
   let isolate_box = unsafe { Box::from_raw(ptr) };
   Box::leak(isolate_box)

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -6,7 +6,7 @@ use libc::c_int;
 use libc::c_void;
 
 #[repr(C)]
-pub struct DenoC {
+pub struct isolate {
   _unused: [u8; 0],
 }
 
@@ -19,20 +19,20 @@ pub struct deno_buf {
   pub data_len: usize,
 }
 
-type DenoRecvCb = unsafe extern "C" fn(d: *const DenoC, buf: deno_buf);
+type DenoRecvCb = unsafe extern "C" fn(d: *const isolate, buf: deno_buf);
 
 extern "C" {
   pub fn deno_init();
   pub fn deno_v8_version() -> *const c_char;
-  pub fn deno_set_flags(argc: *mut c_int, argv: *mut *mut c_char);
-  pub fn deno_new(data: *const c_void, cb: DenoRecvCb) -> *const DenoC;
-  pub fn deno_delete(d: *const DenoC);
-  pub fn deno_last_exception(d: *const DenoC) -> *const c_char;
-  pub fn deno_get_data(d: *const DenoC) -> *const c_void;
-  pub fn deno_set_response(d: *const DenoC, buf: deno_buf);
-  pub fn deno_send(d: *const DenoC, buf: deno_buf);
+  pub fn deno_set_v8_flags(argc: *mut c_int, argv: *mut *mut c_char);
+  pub fn deno_new(data: *const c_void, cb: DenoRecvCb) -> *const isolate;
+  pub fn deno_delete(d: *const isolate);
+  pub fn deno_last_exception(d: *const isolate) -> *const c_char;
+  pub fn deno_get_data(d: *const isolate) -> *const c_void;
+  pub fn deno_set_response(d: *const isolate, buf: deno_buf);
+  pub fn deno_send(d: *const isolate, buf: deno_buf);
   pub fn deno_execute(
-    d: *const DenoC,
+    d: *const isolate,
     js_filename: *const c_char,
     js_source: *const c_char,
   ) -> c_int;

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -6,7 +6,7 @@ use libc::c_int;
 use libc::c_void;
 
 #[repr(C)]
-pub struct isolate {
+pub struct isolate_ptr {
   _unused: [u8; 0],
 }
 
@@ -19,20 +19,20 @@ pub struct deno_buf {
   pub data_len: usize,
 }
 
-type DenoRecvCb = unsafe extern "C" fn(d: *const isolate, buf: deno_buf);
+type DenoRecvCb = unsafe extern "C" fn(d: *const isolate_ptr, buf: deno_buf);
 
 extern "C" {
   pub fn deno_init();
   pub fn deno_v8_version() -> *const c_char;
   pub fn deno_set_v8_flags(argc: *mut c_int, argv: *mut *mut c_char);
-  pub fn deno_new(data: *const c_void, cb: DenoRecvCb) -> *const isolate;
-  pub fn deno_delete(d: *const isolate);
-  pub fn deno_last_exception(d: *const isolate) -> *const c_char;
-  pub fn deno_get_data(d: *const isolate) -> *const c_void;
-  pub fn deno_set_response(d: *const isolate, buf: deno_buf);
-  pub fn deno_send(d: *const isolate, buf: deno_buf);
+  pub fn deno_new(data: *const c_void, cb: DenoRecvCb) -> *const isolate_ptr;
+  pub fn deno_delete(d: *const isolate_ptr);
+  pub fn deno_last_exception(d: *const isolate_ptr) -> *const c_char;
+  pub fn deno_get_data(d: *const isolate_ptr) -> *const c_void;
+  pub fn deno_set_response(d: *const isolate_ptr, buf: deno_buf);
+  pub fn deno_send(d: *const isolate_ptr, buf: deno_buf);
   pub fn deno_execute(
-    d: *const isolate,
+    d: *const isolate_ptr,
     js_filename: *const c_char,
     js_source: *const c_char,
   ) -> c_int;

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -6,7 +6,7 @@ use libc::c_int;
 use libc::c_void;
 
 #[repr(C)]
-pub struct isolate_ptr {
+pub struct isolate {
   _unused: [u8; 0],
 }
 
@@ -19,20 +19,20 @@ pub struct deno_buf {
   pub data_len: usize,
 }
 
-type DenoRecvCb = unsafe extern "C" fn(d: *const isolate_ptr, buf: deno_buf);
+type DenoRecvCb = unsafe extern "C" fn(d: *const isolate, buf: deno_buf);
 
 extern "C" {
   pub fn deno_init();
   pub fn deno_v8_version() -> *const c_char;
   pub fn deno_set_v8_flags(argc: *mut c_int, argv: *mut *mut c_char);
-  pub fn deno_new(data: *const c_void, cb: DenoRecvCb) -> *const isolate_ptr;
-  pub fn deno_delete(d: *const isolate_ptr);
-  pub fn deno_last_exception(d: *const isolate_ptr) -> *const c_char;
-  pub fn deno_get_data(d: *const isolate_ptr) -> *const c_void;
-  pub fn deno_set_response(d: *const isolate_ptr, buf: deno_buf);
-  pub fn deno_send(d: *const isolate_ptr, buf: deno_buf);
+  pub fn deno_new(data: *const c_void, cb: DenoRecvCb) -> *const isolate;
+  pub fn deno_delete(i: *const isolate);
+  pub fn deno_last_exception(i: *const isolate) -> *const c_char;
+  pub fn deno_get_data(i: *const isolate) -> *const c_void;
+  pub fn deno_set_response(i: *const isolate, buf: deno_buf);
+  pub fn deno_send(i: *const isolate, buf: deno_buf);
   pub fn deno_execute(
-    d: *const isolate_ptr,
+    i: *const isolate,
     js_filename: *const c_char,
     js_source: *const c_char,
   ) -> c_int;


### PR DESCRIPTION
<!--

Thank you for your pull request. Before submitting, please make sure the following is done.

1. Ensure ./tools/test.py passes.
2. Format your code with ./tools/format.py
3. Make sure ./tools/lint.py passes.

-->
#793   rename deno.argv to deno.args
#792   rename libdeno::DenoC to libdeno::isolate
#791   rename deno_set_flags to deno_set_v8_flags 
