### PR TITLE
benchmark: track the binary size

### DIFF
--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -66,6 +66,7 @@ def main(argv):
     new_data = {
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "sha1": sha1,
+        "binary_size": os.path.getsize(deno_path),
         "benchmark": {}
     }
     for [[name, _], data] in zip(benchmarks, benchmark_data["results"]):

--- a/website/README.md
+++ b/website/README.md
@@ -4,20 +4,20 @@ The benchmark chart supposes `//website/data.json` has the signature of `Benchma
 
 ```typescript
 interface ExecTimeData {
-    mean: number
-    stddev: number
-    user: number
-    system: number
-    min: number
-    max: number
+  mean: number
+  stddev: number
+  user: number
+  system: number
+  min: number
+  max: number
 }
 
 interface BenchmarkData {
-    created_at: string,
-    sha1: string,
-    binary_size?: number,
-    benchmark: {
-        [key: string]: ExecTimeData
-    }
+  created_at: string,
+  sha1: string,
+  binary_size?: number,
+  benchmark: {
+    [key: string]: ExecTimeData
+  }
 }
 ```

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,23 @@
+## About benchmark data
+
+The benchmark chart supposes `//website/data.json` has the signature of `BenchmarkData[]` where `BenchmarkData` is defined like the below:
+
+```typescript
+interface ExecTimeData {
+    mean: number
+    stddev: number
+    user: number
+    system: number
+    min: number
+    max: number
+}
+
+interface BenchmarkData {
+    created_at: string,
+    sha1: string,
+    binary_size?: number,
+    benchmark: {
+        [key: string]: ExecTimeData
+    }
+}
+```

--- a/website/app.js
+++ b/website/app.js
@@ -11,7 +11,7 @@ const benchmarkNames = ["hello", "relative_import"];
     })
   ]);
 
-  const binarySizeList = data.map(d => d.binary_size || 0)
+  const binarySizeList = data.map(d => d.binary_size || 0);
   const sha1List = data.map(d => d.sha1);
 
   c3.generate({
@@ -27,16 +27,16 @@ const benchmarkNames = ["hello", "relative_import"];
 
   c3.generate({
     bindto: "#binary-size-chart",
-    data: { columns: [['binary_size', ...binarySizeList]] },
+    data: { columns: [["binary_size", ...binarySizeList]] },
     axis: {
       x: {
         type: "category",
         categories: sha1List
       },
       y: {
-	tick: {
-	  format: d => formatBytes(d)
-	}
+        tick: {
+          format: d => formatBytes(d)
+        }
       }
     }
   });
@@ -44,5 +44,11 @@ const benchmarkNames = ["hello", "relative_import"];
 
 // Formats the byte sizes e.g. 19000 -> 18.55KB
 // Copied from https://stackoverflow.com/a/18650828
-function formatBytes(a,b){if(0==a)return"0 Bytes";var c=1024,d=b||2,e=["Bytes","KB","MB","GB","TB","PB","EB","ZB","YB"],f=Math.floor(Math.log(a)/Math.log(c));return parseFloat((a/Math.pow(c,f)).toFixed(d))+" "+e[f]}
-
+function formatBytes(a, b) {
+  if (0 == a) return "0 Bytes";
+  var c = 1024,
+    d = b || 2,
+    e = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"],
+    f = Math.floor(Math.log(a) / Math.log(c));
+  return parseFloat((a / Math.pow(c, f)).toFixed(d)) + " " + e[f];
+}

--- a/website/app.js
+++ b/website/app.js
@@ -3,7 +3,7 @@ const benchmarkNames = ["hello", "relative_import"];
 (async () => {
   const data = await (await fetch("./data.json")).json();
 
-  const benchmarkColumns = benchmarkNames.map(name => [
+  const execTimeColumns = benchmarkNames.map(name => [
     name,
     ...data.map(d => {
       const benchmark = d.benchmark[name];
@@ -11,11 +11,12 @@ const benchmarkNames = ["hello", "relative_import"];
     })
   ]);
 
+  const binarySizeList = data.map(d => d.binary_size || 0)
   const sha1List = data.map(d => d.sha1);
 
   c3.generate({
-    bindto: "#benchmark-chart",
-    data: { columns: benchmarkColumns },
+    bindto: "#exec-time-chart",
+    data: { columns: execTimeColumns },
     axis: {
       x: {
         type: "category",
@@ -23,4 +24,25 @@ const benchmarkNames = ["hello", "relative_import"];
       }
     }
   });
+
+  c3.generate({
+    bindto: "#binary-size-chart",
+    data: { columns: [['binary_size', ...binarySizeList]] },
+    axis: {
+      x: {
+        type: "category",
+        categories: sha1List
+      },
+      y: {
+	tick: {
+	  format: d => formatBytes(d)
+	}
+      }
+    }
+  });
 })();
+
+// Formats the byte sizes e.g. 19000 -> 18.55KB
+// Copied from https://stackoverflow.com/a/18650828
+function formatBytes(a,b){if(0==a)return"0 Bytes";var c=1024,d=b||2,e=["Bytes","KB","MB","GB","TB","PB","EB","ZB","YB"],f=Math.floor(Math.log(a)/Math.log(c));return parseFloat((a/Math.pow(c,f)).toFixed(d))+" "+e[f]}
+

--- a/website/index.html
+++ b/website/index.html
@@ -5,7 +5,10 @@
   <link rel="stylesheet" href="https://unpkg.com/c3@0.6.7/c3.min.css">
 </head>
 <body>
-  <div id="benchmark-chart"></div>
+  <h2>Execution time chart</h2>
+  <div id="exec-time-chart"></div>
+  <h2>Binary size chart</h2>
+  <div id="binary-size-chart"></div>
   <script src="https://unpkg.com/d3@5.7.0/dist/d3.min.js"></script>
   <script src="https://unpkg.com/c3@0.6.7/c3.min.js"></script>
   <script src="./app.js"></script>


### PR DESCRIPTION
This change tries to close #785.

This starts the tracking of binary sizes of `out/release/deno` in travis.

This can be tested locally by running `./tools/benchmark.py`, `./tools/http_server.py`, and visiting `http://localhost:4545/website`.

The above steps should show the page like the below:

<img width="1361" alt="2018-09-23 18 02 13" src="https://user-images.githubusercontent.com/613956/45926299-52b09200-bf5c-11e8-991c-988e11ec0f5a.png">
