### PR TITLE
Better build instructions for all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,14 @@ submodule. However, you need to install separately:
 1. [Rust](https://www.rust-lang.org/en-US/install.html)
 2. [Node](http://nodejs.org/)
 3. Python 2. [Not 3](https://github.com/denoland/deno/issues/464#issuecomment-411795578).
-4. [ccache](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/ccache) (Optional but helpful for speeding up rebuilds of V8.)
-.
+4. [ccache](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/ccache) (Optional but helpful for speeding up rebuilds of V8.).
+5. Extra steps for Windows users:
+   1. Add `python.exe` to `PATH`. E.g. `set PATH=%PATH%;C:\Python27\python.exe`
+   2. Get [VS Community 2017](https://www.visualstudio.com/downloads/), make sure to select the option to install C++ tools and the Windows SDK
+   3. Enable `Debugging Tools for Windows`, Goto Control Panel -> Windows 10 SDK -> Right-Click -> Change -> Change -> Check Debugging Tools for Windows -> Change -> Finish
 
-To build:
+
+#### To build:
 
     # Fetch deps.
     git clone --recurse-submodules https://github.com/denoland/deno.git


### PR DESCRIPTION
This should close issue [#802](https://github.com/denoland/deno/issues/802)
I have added in-detail build instructions for Windows users specially. For OSX and Linux I have copied from VSCode. This will help new people to test out the project and not get stuck like I had.