### PR TITLE
Add `toString` for CallSite of eval origin

### DIFF
--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -17,5 +17,5 @@ import "./symlink_test.ts";
 import "./platform_test.ts";
 import "./text_encoding_test.ts";
 import "./trace_test.ts";
-
+import "./v8_source_maps_test.ts";
 import "../website/app_test.js";

--- a/js/v8_source_maps.ts
+++ b/js/v8_source_maps.ts
@@ -88,6 +88,7 @@ export function wrapCallSite(frame: CallSite): CallSite {
     origin = mapEvalOrigin(origin);
     frame = cloneCallSite(frame);
     frame.getEvalOrigin = () => origin;
+    frame.toString = () => CallSiteToString(frame);
     return frame;
   }
 

--- a/js/v8_source_maps_test.ts
+++ b/js/v8_source_maps_test.ts
@@ -1,0 +1,14 @@
+import { test, assert, assertEqual } from "./test_util.ts";
+
+test(function evalErrorFormatted() {
+  let err;
+  try {
+    eval("boom");
+  } catch (e) {
+    err = e;
+  }
+  assert(!!err);
+  // tslint:disable-next-line:no-unused-expression
+  err.stack; // This would crash if err.stack is malformed
+  assertEqual(err.name, "ReferenceError");
+});

--- a/js/v8_source_maps_test.ts
+++ b/js/v8_source_maps_test.ts
@@ -1,5 +1,8 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
 import { test, assert, assertEqual } from "./test_util.ts";
 
+// This test demonstrates a bug:
+// https://github.com/denoland/deno/issues/808
 test(function evalErrorFormatted() {
   let err;
   try {


### PR DESCRIPTION
Closes #808 .

Explicitly add `.toString()` for frame of eval origin.

Example: when running
```ts
eval("boom");
```
Before fix:
```
=====Error inside of prepareStackTrace====
TypeError: CallSite method toString expects CallSite as receiver
    at Object.toString (<anonymous>)
    at stack.map (gen/bundle/main.js:127367:77)
    at Array.map (<anonymous>)
    at prepareStackTrace$1 (gen/bundle/main.js:127367:28)
    at Function.prepareStackTraceWrapper (gen/bundle/main.js:127355:18)
    at onGlobalError (gen/bundle/main.js:127917:25)
=====Original error=======================
ERROR RS -
```
After fix:
```
ReferenceError: boom is not defined
    at eval (eval at <anonymous> (/Users/kevinqian/Desktop/Programming/Deno/deno/test3.ts), <anonymous>:1:1)
    at eval (file:///Users/kevinqian/Desktop/Programming/Deno/deno/test3.ts:1:1)
    at DenoCompiler.eval [as _globalEval] (<anonymous>)
    at DenoCompiler._gatherDependencies (deno/js/compiler.ts:212:10)
    at DenoCompiler.run (deno/js/compiler.ts:557:12)
    at denoMain (deno/js/main.ts:71:12)
    at deno_main.js:1:1
```