### PR TITLE
Add optional param `isErr` to `libdeno.print` for printing to stderr

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -108,7 +108,7 @@ export function stringifyArgs(args: any[]): string {
   return out.join(" ");
 }
 
-type PrintFunc = (x: string) => void;
+type PrintFunc = (x: string, isErr?: boolean) => void;
 
 export class Console {
   constructor(private printFunc: PrintFunc) {}
@@ -123,8 +123,7 @@ export class Console {
 
   // tslint:disable-next-line:no-any
   warn(...args: any[]): void {
-    // TODO Log to stderr.
-    this.printFunc(stringifyArgs(args));
+    this.printFunc(stringifyArgs(args), true);
   }
 
   error = this.warn;

--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -8,7 +8,7 @@ interface Libdeno {
 
   send(msg: ArrayBufferView): null | Uint8Array;
 
-  print(x: string): void;
+  print(x: string, isErr?: boolean): void;
 
   setGlobalErrorHandler: (
     handler: (

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -141,13 +141,19 @@ void ExitOnPromiseRejectCallback(
 }
 
 void Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK_EQ(args.Length(), 1);
+  CHECK_GE(args.Length(), 1);
+  CHECK_LE(args.Length(), 2);
   auto* isolate = args.GetIsolate();
+  Deno* d = static_cast<Deno*>(isolate->GetData(0));
+  auto context = d->context.Get(d->isolate);
   v8::HandleScope handle_scope(isolate);
   v8::String::Utf8Value str(isolate, args[0]);
+  bool is_err =
+      args.Length() >= 2 ? args[1]->BooleanValue(context).ToChecked() : false;
   const char* cstr = ToCString(str);
-  printf("%s\n", cstr);
-  fflush(stdout);
+  auto stream = is_err ? stderr : stdout;
+  fprintf(stream, "%s\n", cstr);
+  fflush(stream);
 }
 
 static v8::Local<v8::Uint8Array> ImportBuf(v8::Isolate* isolate, deno_buf buf) {

--- a/libdeno/libdeno_test.js
+++ b/libdeno/libdeno_test.js
@@ -124,7 +124,7 @@ global.SnapshotBug = () => {
 
 global.GlobalErrorHandling = () => {
   libdeno.setGlobalErrorHandler((message, source, line, col, error) => {
-    libdeno.print(`line ${line} col ${col}`);
+    libdeno.print(`line ${line} col ${col}`, true);
     assert("ReferenceError: notdefined is not defined" === message);
     assert(source === "helloworld.js");
     assert(line === 3);


### PR DESCRIPTION
`libdeno.print(x: string, isErr?: boolean)`.

If `isErr` is `true`, print to stderr. Otherwise, print to stdout.