### PR TITLE
Add linux-only thread count benchmark for `004_set_timeout.ts`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ matrix:
   include:
   - os: linux
     env: BENCHMARK=1
+    sudo: required
   - os: osx
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ matrix:
   include:
   - os: linux
     env: BENCHMARK=1
+    sudo: required
   - os: osx
 env:
   global:
@@ -38,6 +39,11 @@ install:
       cargo install hyperfine
     fi
     hyperfine --version
+    if [ ! $(which strace) ]; then
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        sudo apt-get install strace
+      fi
+    fi
   fi
 - |-
   # Install ccache (OS X only).

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ matrix:
   include:
   - os: linux
     env: BENCHMARK=1
-    sudo: required
   - os: osx
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,6 @@ install:
       cargo install hyperfine
     fi
     hyperfine --version
-    if [ ! $(which strace) ]; then
-      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        sudo apt-get install strace
-      fi
-    fi
   fi
 - |-
   # Install ccache (OS X only).

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -45,16 +45,6 @@ def import_data_from_gh_pages():
         write_json(data_file, [])  # writes empty json data
 
 
-def get_build_dir_from_argv(argv):
-    if len(argv) == 2:
-        return sys.argv[1]
-    elif len(argv) == 1:
-        return build_path()
-    else:
-        print "Usage: tools/benchmark.py [build_dir]"
-        sys.exit(1)
-
-
 # run strace with test_args and record times a syscall record appears in out file
 # based on syscall_line_matcher. Should be reusable
 def count_strace_syscall(syscall_name, syscall_line_matcher, test_args):
@@ -64,21 +54,23 @@ def count_strace_syscall(syscall_name, syscall_line_matcher, test_args):
     return len(filter(syscall_line_matcher, f))
 
 
-def run_thread_count_tests(deno_path):
-    thread_count_args_map = {
-        "set_timeout": ["tests/004_set_timeout.ts", "--reload"]
-    }
+def run_thread_count_benchmark(deno_path):
     thread_count_map = {}
-    for name, test_args in thread_count_args_map.items():
-        count = count_strace_syscall(
-            "clone", lambda line: "clone(" in line,
-            [deno_path] + test_args) + 1  # main thread
-        thread_count_map[name] = count
+    thread_count_map["set_timeout"] = count_strace_syscall(
+        "clone", lambda line: "clone(" in line,
+        [deno_path, "tests/004_set_timeout.ts", "--reload"]) + 1
     return thread_count_map
 
 
 def main(argv):
-    build_dir = get_build_dir_from_argv(argv)
+    if len(argv) == 2:
+        build_dir = sys.argv[1]
+    elif len(argv) == 1:
+        build_dir = build_path()
+    else:
+        print "Usage: tools/benchmark.py [build_dir]"
+        sys.exit(1)
+
     deno_path = os.path.join(build_dir, "deno")
     benchmark_file = os.path.join(build_dir, "benchmark.json")
 
@@ -109,7 +101,7 @@ def main(argv):
 
     if "linux" in sys.platform:
         # Thread count test, only on linux
-        new_data["thread_count"] = run_thread_count_tests(deno_path)
+        new_data["thread_count"] = run_thread_count_benchmark(deno_path)
 
     all_data.append(new_data)
     write_json(data_file, all_data)

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -44,6 +44,7 @@ def import_data_from_gh_pages():
     except:
         write_json(data_file, [])  # writes empty json data
 
+
 def get_build_dir_from_argv(argv):
     if len(argv) == 2:
         return sys.argv[1]
@@ -53,13 +54,15 @@ def get_build_dir_from_argv(argv):
         print "Usage: tools/benchmark.py [build_dir]"
         sys.exit(1)
 
+
 # run strace with test_args and record times a syscall record appears in out file
 # based on syscall_line_matcher. Should be reusable
 def count_strace_syscall(syscall_name, syscall_line_matcher, test_args):
     f = tempfile.NamedTemporaryFile()
-    run(["strace", "-f", "-o", f.name, "-e",
-        "trace=" + syscall_name] + test_args)
+    run(["strace", "-f", "-o", f.name, "-e", "trace=" + syscall_name] +
+        test_args)
     return len(filter(syscall_line_matcher, f))
+
 
 def run_thread_count_tests(deno_path):
     thread_count_args_map = {
@@ -67,10 +70,12 @@ def run_thread_count_tests(deno_path):
     }
     thread_count_map = {}
     for name, test_args in thread_count_args_map.items():
-        count = count_strace_syscall("clone", lambda line: "clone(" in line,
-            [deno_path] + test_args) + 1 # main thread
+        count = count_strace_syscall(
+            "clone", lambda line: "clone(" in line,
+            [deno_path] + test_args) + 1  # main thread
         thread_count_map[name] = count
     return thread_count_map
+
 
 def main(argv):
     build_dir = get_build_dir_from_argv(argv)

--- a/tools/benchmark_test.py
+++ b/tools/benchmark_test.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import sys
+import os
+from util import build_path
+from benchmark import get_build_dir_from_argv, run_thread_count_tests
+
+def main(argv):
+  build_dir = get_build_dir_from_argv(argv)
+  deno_path = os.path.join(build_dir, "deno")
+
+  if "linux" in sys.platform:
+    thread_count_dict = run_thread_count_tests(deno_path)
+    assert "set_timeout" in thread_count_dict
+    assert thread_count_dict["set_timeout"] > 1
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/tools/benchmark_test.py
+++ b/tools/benchmark_test.py
@@ -1,20 +1,10 @@
-#!/usr/bin/env python
-# Copyright 2018 the Deno authors. All rights reserved. MIT license.
 import sys
 import os
-from util import build_path
-from benchmark import get_build_dir_from_argv, run_thread_count_tests
+from benchmark import run_thread_count_benchmark
 
 
-def main(argv):
-    build_dir = get_build_dir_from_argv(argv)
-    deno_path = os.path.join(build_dir, "deno")
-
+def benchmark_test(deno_path):
     if "linux" in sys.platform:
-        thread_count_dict = run_thread_count_tests(deno_path)
+        thread_count_dict = run_thread_count_benchmark(deno_path)
         assert "set_timeout" in thread_count_dict
         assert thread_count_dict["set_timeout"] > 1
-
-
-if __name__ == '__main__':
-    main(sys.argv)

--- a/tools/benchmark_test.py
+++ b/tools/benchmark_test.py
@@ -5,14 +5,16 @@ import os
 from util import build_path
 from benchmark import get_build_dir_from_argv, run_thread_count_tests
 
-def main(argv):
-  build_dir = get_build_dir_from_argv(argv)
-  deno_path = os.path.join(build_dir, "deno")
 
-  if "linux" in sys.platform:
-    thread_count_dict = run_thread_count_tests(deno_path)
-    assert "set_timeout" in thread_count_dict
-    assert thread_count_dict["set_timeout"] > 1
+def main(argv):
+    build_dir = get_build_dir_from_argv(argv)
+    deno_path = os.path.join(build_dir, "deno")
+
+    if "linux" in sys.platform:
+        thread_count_dict = run_thread_count_tests(deno_path)
+        assert "set_timeout" in thread_count_dict
+        assert thread_count_dict["set_timeout"] > 1
+
 
 if __name__ == '__main__':
     main(sys.argv)

--- a/tools/test.py
+++ b/tools/test.py
@@ -8,6 +8,7 @@ from setup_test import setup_test
 from util import executable_suffix, run, build_path
 from unit_tests import unit_tests
 from util_test import util_test
+from benchmark_test import benchmark_test
 import subprocess
 import http_server
 
@@ -52,6 +53,9 @@ def main(argv):
     deno_ns_exe = os.path.join(build_dir, "deno_ns" + executable_suffix)
     check_exists(deno_ns_exe)
     check_output_test(deno_ns_exe)
+
+    check_exists(deno_exe)
+    benchmark_test(deno_exe)
 
 
 if __name__ == '__main__':

--- a/tools/test.py
+++ b/tools/test.py
@@ -31,9 +31,15 @@ def main(argv):
 
     http_server.spawn()
 
+    deno_exe = os.path.join(build_dir, "deno" + executable_suffix)
+    check_exists(deno_exe)
+    deno_ns_exe = os.path.join(build_dir, "deno_ns" + executable_suffix)
+    check_exists(deno_ns_exe)
+
     # Internal tools testing
     setup_test()
     util_test()
+    benchmark_test(deno_exe)
 
     test_cc = os.path.join(build_dir, "test_cc" + executable_suffix)
     check_exists(test_cc)
@@ -43,19 +49,10 @@ def main(argv):
     check_exists(test_rs)
     run([test_rs])
 
-    deno_exe = os.path.join(build_dir, "deno" + executable_suffix)
-    check_exists(deno_exe)
     unit_tests(deno_exe)
 
-    check_exists(deno_exe)
     check_output_test(deno_exe)
-
-    deno_ns_exe = os.path.join(build_dir, "deno_ns" + executable_suffix)
-    check_exists(deno_ns_exe)
     check_output_test(deno_ns_exe)
-
-    check_exists(deno_exe)
-    benchmark_test(deno_exe)
 
 
 if __name__ == '__main__':

--- a/website/app.js
+++ b/website/app.js
@@ -42,6 +42,17 @@ export async function main() {
   const binarySizeColumns = createBinarySizeColumns(data);
   const sha1List = createSha1List(data);
 
+  const threadCountColumns = threadCountNames.map(name => [
+    name,
+    ...data.map(d => {
+      const threadCountData = d["thread_count"];
+      if (!threadCountData) {
+        return 0;
+      }
+      return threadCountData[name] || 0;
+    })
+  ]);
+
   c3.generate({
     bindto: "#exec-time-chart",
     data: { columns: execTimeColumns },

--- a/website/app.js
+++ b/website/app.js
@@ -20,6 +20,20 @@ export function createBinarySizeColumns(data) {
   return [["binary_size", ...data.map(d => d.binary_size || 0)]];
 }
 
+const threadCountNames = ["set_timeout"];
+export function createThreadCountColumns(data) {
+  return threadCountNames.map(name => [
+    name,
+    ...data.map(d => {
+      const threadCountData = d["thread_count"];
+      if (!threadCountData) {
+        return 0;
+      }
+      return threadCountData[name] || 0;
+    })
+  ]);
+}
+
 export function createSha1List(data) {
   return data.map(d => d.sha1);
 }
@@ -40,18 +54,8 @@ export async function main() {
 
   const execTimeColumns = createExecTimeColumns(data);
   const binarySizeColumns = createBinarySizeColumns(data);
+  const threadCountColumns = createThreadCountColumns(data);
   const sha1List = createSha1List(data);
-
-  const threadCountColumns = threadCountNames.map(name => [
-    name,
-    ...data.map(d => {
-      const threadCountData = d["thread_count"];
-      if (!threadCountData) {
-        return 0;
-      }
-      return threadCountData[name] || 0;
-    })
-  ]);
 
   c3.generate({
     bindto: "#exec-time-chart",
@@ -76,6 +80,17 @@ export async function main() {
         tick: {
           format: d => formatBytes(d)
         }
+      }
+    }
+  });
+
+  c3.generate({
+    bindto: "#thread-count-chart",
+    data: { columns: threadCountColumns },
+    axis: {
+      x: {
+        type: "category",
+        categories: sha1List
       }
     }
   });

--- a/website/app_test.js
+++ b/website/app_test.js
@@ -1,9 +1,10 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 
-import { test, testPerm, assertEqual } from "../js/test_util.ts";
+import { test, assertEqual } from "../js/test_util.ts";
 import {
   createBinarySizeColumns,
   createExecTimeColumns,
+  createThreadCountColumns,
   createSha1List,
   formatBytes
 } from "./app.js";
@@ -20,6 +21,9 @@ const regularData = [
       relative_import: {
         mean: 0.06
       }
+    },
+    thread_count: {
+      set_timeout: 4
     }
   },
   {
@@ -33,6 +37,9 @@ const regularData = [
       relative_import: {
         mean: 0.065
       }
+    },
+    thread_count: {
+      set_timeout: 5
     }
   }
 ];
@@ -44,7 +51,8 @@ const irregularData = [
     benchmark: {
       hello: {},
       relative_import: {}
-    }
+    },
+    thread_count: {}
   },
   {
     created_at: "2018-02-01T01:00:00Z",
@@ -74,6 +82,16 @@ test(function createBinarySizeColumnsRegularData() {
 test(function createBinarySizeColumnsIrregularData() {
   const columns = createBinarySizeColumns(irregularData);
   assertEqual(columns, [["binary_size", 0, 0]]);
+});
+
+test(function createThreadCountColumnsRegularData() {
+  const columns = createThreadCountColumns(regularData);
+  assertEqual(columns, [["set_timeout", 4, 5]]);
+});
+
+test(function createThreadCountColumnsIrregularData() {
+  const columns = createThreadCountColumns(irregularData);
+  assertEqual(columns, [["set_timeout", 0, 0]]);
 });
 
 test(function createSha1ListRegularData() {

--- a/website/index.html
+++ b/website/index.html
@@ -9,6 +9,8 @@
   <div id="exec-time-chart"></div>
   <h2>Binary size chart</h2>
   <div id="binary-size-chart"></div>
+  <h2>Thread count chart</h2>
+  <div id="thread-count-chart"></div>
   <script src="https://unpkg.com/d3@5.7.0/dist/d3.min.js"></script>
   <script src="https://unpkg.com/c3@0.6.7/c3.min.js"></script>
   <script type="module">


### PR DESCRIPTION
For #786

Only works on linux. Relies on `strace` and observes count of `clone()` calls.
(If needed, could also add `dtruss` based observation for macos upon request)

![thread](https://user-images.githubusercontent.com/15007517/45940643-0cc0f180-bf8f-11e8-9d03-1b8349e78c2c.png)
