### PR TITLE
Expand binary size benchmark

### DIFF
--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -10,7 +10,7 @@ import sys
 import json
 import time
 import shutil
-from util import run, run_output, root_path, build_path
+from util import run, run_output, root_path, build_path, executable_suffix
 import tempfile
 import http_server
 
@@ -53,7 +53,7 @@ def import_data_from_gh_pages():
 
 def get_binary_sizes(build_dir):
     path_dict = {
-        "deno": os.path.join(build_dir, "deno"),
+        "deno": os.path.join(build_dir, "deno" + executable_suffix),
         "main.js": os.path.join(build_dir, "gen/bundle/main.js"),
         "main.js.map": os.path.join(build_dir, "gen/bundle/main.js.map"),
         "snapshot_deno.bin": os.path.join(build_dir, "gen/snapshot_deno.bin")

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -14,11 +14,6 @@ from util import run, run_output, root_path, build_path, executable_suffix
 import tempfile
 import http_server
 
-try:
-    http_server.spawn()
-except:
-    "Warning: another http_server instance is running"
-
 # The list of the tuples of the benchmark name and arguments
 exec_time_benchmarks = [("hello", ["tests/002_hello.ts", "--reload"]),
                         ("relative_import",
@@ -133,6 +128,8 @@ def main(argv):
     else:
         print "Usage: tools/benchmark.py [build_dir]"
         sys.exit(1)
+
+    http_server.spawn()
 
     deno_path = os.path.join(build_dir, "deno")
     benchmark_file = os.path.join(build_dir, "benchmark.json")

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -51,6 +51,19 @@ def import_data_from_gh_pages():
         write_json(data_file, [])  # writes empty json data
 
 
+def get_binary_sizes(build_dir):
+    path_dict = {
+        "deno": os.path.join(build_dir, "deno"),
+        "main.js": os.path.join(build_dir, "gen/bundle/main.js"),
+        "main.js.map": os.path.join(build_dir, "gen/bundle/main.js.map"),
+        "snapshot_deno.bin": os.path.join(build_dir, "gen/snapshot_deno.bin")
+    }
+    sizes = {}
+    for name, path in path_dict.items():
+        sizes[name] = os.path.getsize(path)
+    return sizes
+
+
 def get_strace_summary_text(test_args):
     f = tempfile.NamedTemporaryFile()
     run(["strace", "-c", "-f", "-o", f.name] + test_args)
@@ -136,7 +149,7 @@ def main(argv):
     new_data = {
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "sha1": sha1,
-        "binary_size": os.path.getsize(deno_path),
+        "binary_size": {},
         "thread_count": {},
         "syscall_count": {},
         "benchmark": {}
@@ -152,6 +165,7 @@ def main(argv):
             "max": data["max"]
         }
 
+    new_data["binary_size"] = get_binary_sizes(build_dir)
     if "linux" in sys.platform:
         # Thread count test, only on linux
         new_data["thread_count"] = run_thread_count_benchmark(deno_path)

--- a/tools/benchmark_test.py
+++ b/tools/benchmark_test.py
@@ -19,6 +19,14 @@ def strace_parse_test():
         assert summary["total"]["calls"] == 704
 
 
+def binary_size_test(build_dir):
+    binary_size_dict = benchmark.get_binary_sizes(build_dir)
+    assert binary_size_dict["deno"] > 0
+    assert binary_size_dict["main.js"] > 0
+    assert binary_size_dict["main.js.map"] > 0
+    assert binary_size_dict["snapshot_deno.bin"] > 0
+
+
 def thread_count_test(deno_path):
     thread_count_dict = benchmark.run_thread_count_benchmark(deno_path)
     assert "set_timeout" in thread_count_dict
@@ -31,8 +39,9 @@ def syscall_count_test(deno_path):
     assert syscall_count_dict["hello"] > 1
 
 
-def benchmark_test(deno_path):
+def benchmark_test(build_dir, deno_path):
     strace_parse_test()
+    binary_size_test(build_dir)
     if "linux" in sys.platform:
         thread_count_test(deno_path)
         syscall_count_test(deno_path)

--- a/tools/test.py
+++ b/tools/test.py
@@ -31,10 +31,7 @@ def main(argv):
 
     enable_ansi_colors()
 
-    try:
-        http_server.spawn()
-    except:
-        "Warning: another http_server instance is running"
+    http_server.spawn()
 
     deno_exe = os.path.join(build_dir, "deno" + executable_suffix)
     check_exists(deno_exe)

--- a/tools/test.py
+++ b/tools/test.py
@@ -31,7 +31,10 @@ def main(argv):
 
     enable_ansi_colors()
 
-    http_server.spawn()
+    try:
+        http_server.spawn()
+    except:
+        "Warning: another http_server instance is running"
 
     deno_exe = os.path.join(build_dir, "deno" + executable_suffix)
     check_exists(deno_exe)
@@ -41,7 +44,7 @@ def main(argv):
     # Internal tools testing
     setup_test()
     util_test()
-    benchmark_test(deno_exe)
+    benchmark_test(build_dir, deno_exe)
 
     test_cc = os.path.join(build_dir, "test_cc" + executable_suffix)
     check_exists(test_cc)

--- a/website/app.js
+++ b/website/app.js
@@ -16,8 +16,23 @@ export function createExecTimeColumns(data) {
   ]);
 }
 
+const binarySizeNames = ["deno", "main.js", "main.js.map", "snapshot_deno.bin"];
 export function createBinarySizeColumns(data) {
-  return [["binary_size", ...data.map(d => d.binary_size || 0)]];
+  return binarySizeNames.map(name => [
+    name,
+    ...data.map(d => {
+      const binarySizeData = d["binary_size"];
+      switch (typeof binarySizeData) {
+        case "number": // legacy implementation
+          return name === "deno" ? binarySizeData : 0;
+        default:
+          if (!binarySizeData) {
+            return 0;
+          }
+          return binarySizeData[name] || 0;
+      }
+    })
+  ]);
 }
 
 const threadCountNames = ["set_timeout", "fetch_deps"];

--- a/website/app_test.js
+++ b/website/app_test.js
@@ -14,7 +14,12 @@ const regularData = [
   {
     created_at: "2018-01-01T01:00:00Z",
     sha1: "abcdef",
-    binary_size: 100000000,
+    binary_size: {
+      deno: 100000000,
+      "main.js": 90000000,
+      "main.js.map": 80000000,
+      "snapshot_deno.bin": 70000000
+    },
     benchmark: {
       hello: {
         mean: 0.05
@@ -34,7 +39,12 @@ const regularData = [
   {
     created_at: "2018-01-02T01:00:00Z",
     sha1: "012345",
-    binary_size: 110000000,
+    binary_size: {
+      deno: 100000001,
+      "main.js": 90000001,
+      "main.js.map": 80000001,
+      "snapshot_deno.bin": 70000001
+    },
     benchmark: {
       hello: {
         mean: 0.055
@@ -57,6 +67,7 @@ const irregularData = [
   {
     created_at: "2018-01-01T01:00:00Z",
     sha1: "123",
+    binary_size: {},
     benchmark: {
       hello: {},
       relative_import: {}
@@ -67,6 +78,7 @@ const irregularData = [
   {
     created_at: "2018-02-01T01:00:00Z",
     sha1: "456",
+    binary_size: 100000000,
     benchmark: {}
   }
 ];
@@ -86,12 +98,22 @@ test(function createExecTimeColumnsIrregularData() {
 
 test(function createBinarySizeColumnsRegularData() {
   const columns = createBinarySizeColumns(regularData);
-  assertEqual(columns, [["binary_size", 100000000, 110000000]]);
+  assertEqual(columns, [
+    ["deno", 100000000, 100000001],
+    ["main.js", 90000000, 90000001],
+    ["main.js.map", 80000000, 80000001],
+    ["snapshot_deno.bin", 70000000, 70000001]
+  ]);
 });
 
 test(function createBinarySizeColumnsIrregularData() {
   const columns = createBinarySizeColumns(irregularData);
-  assertEqual(columns, [["binary_size", 0, 0]]);
+  assertEqual(columns, [
+    ["deno", 0, 100000000],
+    ["main.js", 0, 0],
+    ["main.js.map", 0, 0],
+    ["snapshot_deno.bin", 0, 0]
+  ]);
 });
 
 test(function createThreadCountColumnsRegularData() {


### PR DESCRIPTION
Closes #818

Adds binary size benchmark for `main.js`, `main.js.map`, `snapshot_deno.bin`, while keeping backward-compatible.

![binary_size](https://user-images.githubusercontent.com/15007517/46036957-b1d8e880-c0bb-11e8-954d-b31a06c20b7c.png)
