### PR TITLE
Record duration of ./tools/test.py (and optionally ./tools/build.py) on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ cache:
   - "$HOMEBREW_PATH"
   - third_party/v8/build/linux/debian_sid_amd64-sysroot/
   - third_party/v8/third_party/llvm-build/
+before_install:
+- |-
+  # Start timer
+  echo "Start travis timer..."
+  SECONDS=0 # clear SECONDS for recording
 install:
 - |-
   # OS X: install a private copy of homebrew.
@@ -64,13 +69,14 @@ before_script:
 script:
 - ./tools/lint.py
 - bash -c "sleep 2100; pkill ninja" &
-- ./tools/build.py -j2
-- ./tools/test.py $DENO_BUILD_PATH
+- TIMEFORMAT="%E" # set time format
+- TRAVIS_BUILD_DURATION=$(time ./tools/build.py -j2 3>&1 1>&2 2>&3) # swap stdout and stderr
+- TEST_DURATION=$(time ./tools/test.py $DENO_BUILD_PATH 3>&1 1>&2 2>&3) # swap stdout and stderr
 after_success:
 - |
   # Run benchmarks and publish the result to github pages.
   if [ $BENCHMARK ]; then
-    ./tools/benchmark.py $DENO_BUILD_PATH &&
+    ./tools/benchmark.py --build_dir=$DENO_BUILD_PATH --travis_duration=$SECONDS --travis_build_duration=$TRAVIS_BUILD_DURATION --test_duration=$TEST_DURATION &&
     cp -r website/* gh-pages/
   fi
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,6 @@ cache:
   - "$HOMEBREW_PATH"
   - third_party/v8/build/linux/debian_sid_amd64-sysroot/
   - third_party/v8/third_party/llvm-build/
-before_install:
-- |-
-  # Start timer
-  echo "Start travis timer..."
-  SECONDS=0 # clear SECONDS for recording
 install:
 - |-
   # OS X: install a private copy of homebrew.
@@ -69,14 +64,13 @@ before_script:
 script:
 - ./tools/lint.py
 - bash -c "sleep 2100; pkill ninja" &
-- TIMEFORMAT="%E" # set time format
-- TRAVIS_BUILD_DURATION=$(time ./tools/build.py -j2 3>&1 1>&2 2>&3) # swap stdout and stderr
-- TEST_DURATION=$(time ./tools/test.py $DENO_BUILD_PATH 3>&1 1>&2 2>&3) # swap stdout and stderr
+- BUILD_DURATION=$(/usr/bin/time -p ./tools/build.py -j2 3>&1 1>&2 2>&3 | awk '/real/ {print $2}') # swap stdout and stderr
+- TEST_DURATION=$(/usr/bin/time -p ./tools/test.py $DENO_BUILD_PATH 3>&1 1>&2 2>&3 | awk '/real/ {print $2}') # swap stdout and stderr
 after_success:
 - |
   # Run benchmarks and publish the result to github pages.
   if [ $BENCHMARK ]; then
-    ./tools/benchmark.py --build_dir=$DENO_BUILD_PATH --travis_duration=$SECONDS --travis_build_duration=$TRAVIS_BUILD_DURATION --test_duration=$TEST_DURATION &&
+    ./tools/benchmark.py --build_dir=$DENO_BUILD_PATH --build_duration=$BUILD_DURATION --test_duration=$TEST_DURATION &&
     cp -r website/* gh-pages/
   fi
 before_deploy:

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -13,6 +13,7 @@ import shutil
 from util import run, run_output, root_path, build_path, executable_suffix
 import tempfile
 import http_server
+import argparse
 
 # The list of the tuples of the benchmark name and arguments
 exec_time_benchmarks = [
@@ -124,13 +125,13 @@ def run_syscall_count_benchmark(deno_path):
 
 
 def main(argv):
-    if len(argv) == 2:
-        build_dir = sys.argv[1]
-    elif len(argv) == 1:
-        build_dir = build_path()
-    else:
-        print "Usage: tools/benchmark.py [build_dir]"
-        sys.exit(1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("build_dir", type=str, default=build_path())
+    parser.add_argument("travis_duration", type=int, default=0)
+    parser.add_argument("travis_build_duration", type=float, default=0)
+    parser.add_argument("test_duration", type=float, default=0)
+    args = parser.parse_args()
+    build_dir = args.build_dir
 
     http_server.spawn()
 
@@ -152,7 +153,12 @@ def main(argv):
         "binary_size": {},
         "thread_count": {},
         "syscall_count": {},
-        "benchmark": {}
+        "benchmark": {},
+        "duration": {
+            "travis": args.travis_duration,
+            "travis_build": args.travis_build_duration,
+            "test": args.test_duration
+        }
     }
     for [[name, _], data] in zip(exec_time_benchmarks,
                                  benchmark_data["results"]):

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -126,12 +126,11 @@ def run_syscall_count_benchmark(deno_path):
 
 def main(argv):
     parser = argparse.ArgumentParser()
-    parser.add_argument("build_dir", type=str, default=build_path())
-    parser.add_argument("travis_duration", type=int, default=0)
-    parser.add_argument("travis_build_duration", type=float, default=0)
-    parser.add_argument("test_duration", type=float, default=0)
-    args = parser.parse_args()
-    build_dir = args.build_dir
+    parser.add_argument("--build_dir", dest="build_dir", type=str, default=build_path())
+    parser.add_argument("--build_duration", dest="build_duration", type=float, default=0)
+    parser.add_argument("--test_duration", dest="test_duration", type=float, default=0)
+    parse_args = parser.parse_args()
+    build_dir = parse_args.build_dir
 
     http_server.spawn()
 
@@ -155,9 +154,8 @@ def main(argv):
         "syscall_count": {},
         "benchmark": {},
         "duration": {
-            "travis": args.travis_duration,
-            "travis_build": args.travis_build_duration,
-            "test": args.test_duration
+            "build": parse_args.build_duration,
+            "test": parse_args.test_duration
         }
     }
     for [[name, _], data] in zip(exec_time_benchmarks,

--- a/website/app.js
+++ b/website/app.js
@@ -21,6 +21,20 @@ export function createExecTimeColumns(data) {
   ]);
 }
 
+const durationNames = ["travis", "travis_build", "test"];
+export function createDurationColumns(data) {
+  return durationNames.map(name => [
+    name,
+    ...data.map(d => {
+      const durationData = d["duration"];
+      if (!durationData) {
+        return 0;
+      }
+      return durationData[name] || 0;
+    })
+  ]);
+}
+
 const binarySizeNames = ["deno", "main.js", "main.js.map", "snapshot_deno.bin"];
 export function createBinarySizeColumns(data) {
   return binarySizeNames.map(name => [
@@ -90,6 +104,7 @@ export async function main() {
   const binarySizeColumns = createBinarySizeColumns(data);
   const threadCountColumns = createThreadCountColumns(data);
   const syscallCountColumns = createSyscallCountColumns(data);
+  const durationColumns = createDurationColumns(data);
   const sha1List = createSha1List(data);
 
   c3.generate({
@@ -133,6 +148,17 @@ export async function main() {
   c3.generate({
     bindto: "#syscall-count-chart",
     data: { columns: syscallCountColumns },
+    axis: {
+      x: {
+        type: "category",
+        categories: sha1List
+      }
+    }
+  });
+
+  c3.generate({
+    bindto: "#duration-chart",
+    data: { columns: durationColumns },
     axis: {
       x: {
         type: "category",

--- a/website/app.js
+++ b/website/app.js
@@ -21,7 +21,7 @@ export function createExecTimeColumns(data) {
   ]);
 }
 
-const durationNames = ["travis", "travis_build", "test"];
+const durationNames = ["build", "test"];
 export function createDurationColumns(data) {
   return durationNames.map(name => [
     name,

--- a/website/app_test.js
+++ b/website/app_test.js
@@ -43,8 +43,7 @@ const regularData = [
       hello: 600
     },
     duration: {
-      travis: 1000,
-      travis_build: 500,
+      build: 500,
       test: 100
     }
   },
@@ -79,8 +78,7 @@ const regularData = [
       hello: 700
     },
     duration: {
-      travis: 1001,
-      travis_build: 501,
+      build: 501,
       test: 101
     }
   }
@@ -172,8 +170,7 @@ test(function createSyscallCountColumnsIrregularData() {
 test(function createDurationColumnsRegularData() {
   const columns = createDurationColumns(regularData);
   assertEqual(columns, [
-    ["travis", 1000, 1001],
-    ["travis_build", 500, 501],
+    ["build", 500, 501],
     ["test", 100, 101]
   ]);
 });
@@ -181,8 +178,7 @@ test(function createDurationColumnsRegularData() {
 test(function createThreadCountColumnsIrregularData() {
   const columns = createDurationColumns(irregularData);
   assertEqual(columns, [
-    ["travis", 0, 0],
-    ["travis_build", 0, 0],
+    ["build", 0, 0],
     ["test", 0, 0]
   ]);
 });

--- a/website/app_test.js
+++ b/website/app_test.js
@@ -6,6 +6,7 @@ import {
   createExecTimeColumns,
   createThreadCountColumns,
   createSyscallCountColumns,
+  createDurationColumns,
   createSha1List,
   formatBytes
 } from "./app.js";
@@ -40,6 +41,11 @@ const regularData = [
     },
     syscall_count: {
       hello: 600
+    },
+    duration: {
+      travis: 1000,
+      travis_build: 500,
+      test: 100
     }
   },
   {
@@ -71,6 +77,11 @@ const regularData = [
     },
     syscall_count: {
       hello: 700
+    },
+    duration: {
+      travis: 1001,
+      travis_build: 501,
+      test: 101
     }
   }
 ];
@@ -87,7 +98,8 @@ const irregularData = [
       cold_relative_import: {}
     },
     thread_count: {},
-    syscall_count: {}
+    syscall_count: {},
+    duration: {}
   },
   {
     created_at: "2018-02-01T01:00:00Z",
@@ -155,6 +167,24 @@ test(function createSyscallCountColumnsRegularData() {
 test(function createSyscallCountColumnsIrregularData() {
   const columns = createSyscallCountColumns(irregularData);
   assertEqual(columns, [["hello", 0, 0]]);
+});
+
+test(function createDurationColumnsRegularData() {
+  const columns = createDurationColumns(regularData);
+  assertEqual(columns, [
+    ["travis", 1000, 1001],
+    ["travis_build", 500, 501],
+    ["test", 100, 101]
+  ]);
+});
+
+test(function createThreadCountColumnsIrregularData() {
+  const columns = createDurationColumns(irregularData);
+  assertEqual(columns, [
+    ["travis", 0, 0],
+    ["travis_build", 0, 0],
+    ["test", 0, 0]
+  ]);
 });
 
 test(function createSha1ListRegularData() {

--- a/website/index.html
+++ b/website/index.html
@@ -13,6 +13,8 @@
   <div id="thread-count-chart"></div>
   <h2>Syscall count</h2>
   <div id="syscall-count-chart"></div>
+  <h2>Duration</h2>
+  <div id="duration-chart"></div>
   <script src="https://unpkg.com/d3@5.7.0/dist/d3.min.js"></script>
   <script src="https://unpkg.com/c3@0.6.7/c3.min.js"></script>
   <script type="module">


### PR DESCRIPTION
Closes #824 

Save duration for running `./tools/test.py`. I also added `./tools/build.py`, but could be removed if not needed.

![duration](https://user-images.githubusercontent.com/15007517/46053106-61cb4780-c0f6-11e8-8019-ee796aae66b3.png)

(`build` time on the image is very short since I have built the binary already)

