### PR TITLE
console.log print error stack & reorganize implementation into functions

### DIFF
--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -91,3 +91,17 @@ test(function consoleTestStringifyCircular() {
     "Console { printFunc: [Function], debug: [Function: log], info: [Function: log], error: [Function: warn] }"
   );
 });
+
+test(function consoleTestError() {
+  class MyError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = "MyError";
+    }
+  }
+  try {
+    throw new MyError("This is an error");
+  } catch (e) {
+    assertEqual(stringify(e).split("\n")[0], "MyError: This is an error");
+  }
+});


### PR DESCRIPTION
Closes #684 , print out `error.stack` when encountering object as instance of `Error`  (since #676 is closed for now)

(Would attempt handling more special types and add print indentation once #826 lands. Would import code heavily from #676)