### PR TITLE
Hide line with value zero

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ export function createExecTimeColumns(data) {
     ...data.map(d => {
       const benchmark = d.benchmark[name];
       const meanValue = benchmark ? benchmark.mean : 0;
-      return meanValue || 0;
+      return (meanValue || 0) == 0 ? null : meanValue || 0;
     })
   ]);
 }
@@ -44,9 +44,11 @@ export function createBinarySizeColumns(data) {
           return name === "deno" ? binarySizeData : 0;
         default:
           if (!binarySizeData) {
-            return 0;
+            return null;
           }
-          return binarySizeData[name] || 0;
+          return (binarySizeData[name] || 0) == 0
+            ? null
+            : binarySizeData[name] || 0;
       }
     })
   ]);
@@ -59,9 +61,11 @@ export function createThreadCountColumns(data) {
     ...data.map(d => {
       const threadCountData = d["thread_count"];
       if (!threadCountData) {
-        return 0;
+        return null;
       }
-      return threadCountData[name] || 0;
+      return (threadCountData[name] || 0) == 0
+        ? null
+        : threadCountData[name] || 0;
     })
   ]);
 }
@@ -73,9 +77,11 @@ export function createSyscallCountColumns(data) {
     ...data.map(d => {
       const syscallCountData = d["syscall_count"];
       if (!syscallCountData) {
-        return 0;
+        return null;
       }
-      return syscallCountData[name] || 0;
+      return (syscallCountData[name] || 0) == 0
+        ? null
+        : syscallCountData[name] || 0;
     })
   ]);
 }
@@ -148,7 +154,7 @@ export async function main() {
         categories: sha1List
       },
       y: {
-        label: "seconds",
+        label: "seconds"
       }
     }
   });


### PR DESCRIPTION
This is a continuation of the previous PR #840 

> There are some benchmarks that show up as zero values. So it looks like something was very zero and then jumped.

![1](https://user-images.githubusercontent.com/22411349/46191036-923bfd00-c313-11e8-832a-fce2a587ed86.png)
![2](https://user-images.githubusercontent.com/22411349/46191037-923bfd00-c313-11e8-957d-02a74dd6b1a3.png)
![3](https://user-images.githubusercontent.com/22411349/46191039-92d49380-c313-11e8-9b3c-039f24e28dde.png)
