### PR TITLE
win: fix stderr output issue

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,10 +22,6 @@ environment:
   #   -mx=1 : Fast compression.
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -t7z -snl -mtc -mx=1
 
-  # Disable python stdout buffering, so test output shows up in the build log in
-  # realtime, rather than all at once when the test runner exits.
-  PYTHONUNBUFFERED: 1
-
   # Define some PowerShell helper functions which are used in the scripts below.
   # They're defined in an environment variable to reduce noise in the build log.
   PS_UTILS: |-

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <iostream>
 #include <string>
 
 #include "third_party/v8/include/libplatform/libplatform.h"
@@ -132,7 +133,7 @@ void HandleException(v8::Local<v8::Context> context,
   if (d != nullptr) {
     d->last_exception = exception_str;
   } else {
-    printf("Pre-Deno Exception %s\n", exception_str.c_str());
+    std::cerr << "Pre-Deno Exception " << exception_str << std::endl;
     exit(1);
   }
 }
@@ -159,9 +160,8 @@ void Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
   bool is_err =
       args.Length() >= 2 ? args[1]->BooleanValue(context).ToChecked() : false;
   const char* cstr = ToCString(str);
-  auto stream = is_err ? stderr : stdout;
-  fprintf(stream, "%s\n", cstr);
-  fflush(stream);
+  auto& stream = is_err ? std::cerr : std::cout;
+  stream << cstr << std::endl;
 }
 
 static v8::Local<v8::Uint8Array> ImportBuf(v8::Isolate* isolate, deno_buf buf) {

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -11,14 +11,6 @@
 #include "deno.h"
 #include "internal.h"
 
-void hexdump(const uint8_t* buf, size_t len) {
-  for (size_t i = 0; i < len; ++i) {
-    char ch = buf[i];
-    printf("%02x ", ch & 0xff);
-  }
-  printf("\n");
-}
-
 namespace deno {
 
 Deno* FromIsolate(v8::Isolate* isolate) {
@@ -145,20 +137,6 @@ void HandleException(v8::Local<v8::Context> context,
   }
 }
 
-/*
-bool AbortOnUncaughtExceptionCallback(v8::Isolate* isolate) {
-  return true;
-}
-
-void MessageCallback2(Local<Message> message, v8::Local<v8::Value> data) {
-  printf("MessageCallback2\n\n");
-}
-
-void FatalErrorCallback2(const char* location, const char* message) {
-  printf("FatalErrorCallback2\n");
-}
-*/
-
 void ExitOnPromiseRejectCallback(
     v8::PromiseRejectMessage promise_reject_message) {
   auto* isolate = v8::Isolate::GetCurrent();
@@ -244,7 +222,7 @@ void Send(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Locker locker(d->isolate);
   v8::EscapableHandleScope handle_scope(isolate);
 
-  CHECK_EQ(d->currentArgs, nullptr); // libdeno.send re-entry forbidden.
+  CHECK_EQ(d->currentArgs, nullptr);  // libdeno.send re-entry forbidden.
   int32_t req_id = d->next_req_id++;
 
   v8::Local<v8::Value> control_v = args[0];


### PR DESCRIPTION
This partially fixes the windows issue where every character printed through deno.print() ends up on a new line. There are still too many empty lines written to the appveyor build log, but that seems to be be caused by powershell and the way appveyor uses it, which I will fix in a later PR.

<!--

Thank you for your pull request. Before submitting, please make sure the following is done.

1. Ensure ./tools/test.py passes.
2. Format your code with ./tools/format.py
3. Make sure ./tools/lint.py passes.

-->
