### PR TITLE
Remove top-level await support from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@
 
 * Always dies on uncaught errors.
 
-* Supports top-level `await`.
-
 * Aims to be browser compatible.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 * Always dies on uncaught errors.
 
-* Aims to support top-level `await`.
+* [Aims to support top-level `await`.](https://github.com/denoland/deno/issues/471)
 
 * Aims to be browser compatible.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@
 
 * Always dies on uncaught errors.
 
+* Aims to support top-level `await`.
+
 * Aims to be browser compatible.
 
 ## Install


### PR DESCRIPTION
Top-level await is not implemented, so perhaps we should remove from the README?

See the Top-level await issue: https://github.com/denoland/deno/issues/471