### PR TITLE
Remove unused msg.fbs table `WriteFileSync`

### DIFF
--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -253,13 +253,6 @@ table Truncate {
   len: uint;
 }
 
-table WriteFileSync {
-  filename: string;
-  data: [ubyte];
-  perm: uint;
-  // perm specified by https://godoc.org/os#FileMode
-}
-
 table Open {
   filename: string;
   perm: uint;


### PR DESCRIPTION
Removed table WriteFileSync { ... } from msg.fbs since I could not found where it is used. It was introduced in #846, probably due to a rebase/merge error.