### PR TITLE
Update instructions on using ./tools/format.py in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ submodule. However, you need to install separately:
     # Format code.
     ./tools/format.py
 
+Before running `./tools/format.py`, make sure you have `yapf` installed for the
+current Python and `rustfmt` for Rust. They can be installed by:
+
+    pip install yapf
+    rustup component add rustfmt-preview
+
 Other useful commands:
 
     # Call ninja manually.


### PR DESCRIPTION
A quick README update on installing dependent packages before running `./tools/format.py`. Feel free to close this PR if we feel that's too trivial/there's no need to include it. Thanks!