### PR TITLE
Bind `this` to console methods

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -181,29 +181,29 @@ export class Console {
   constructor(private printFunc: PrintFunc) {}
 
   // tslint:disable-next-line:no-any
-  log(...args: any[]): void {
+  log = (...args: any[]): void => {
     this.printFunc(stringifyArgs(args));
-  }
+  };
 
   debug = this.log;
   info = this.log;
 
   // tslint:disable-next-line:no-any
-  dir(obj: any, options: ConsoleOptions = {}) {
+  dir = (obj: any, options: ConsoleOptions = {}) => {
     this.printFunc(stringifyArgs([obj], options));
-  }
+  };
 
   // tslint:disable-next-line:no-any
-  warn(...args: any[]): void {
+  warn = (...args: any[]): void => {
     this.printFunc(stringifyArgs(args), true);
-  }
+  };
 
   error = this.warn;
 
   // tslint:disable-next-line:no-any
-  assert(condition: boolean, ...args: any[]): void {
+  assert = (condition: boolean, ...args: any[]): void => {
     if (!condition) {
       throw new Error(`Assertion failed: ${stringifyArgs(args)}`);
     }
-  }
+  };
 }

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -132,18 +132,11 @@ test(function consoleDetachedLog() {
   const warn = console.warn;
   const error = console.error;
   const consoleAssert = console.assert;
-  let caughtError = false;
-  try {
-    log("Hello world");
-    dir("Hello world");
-    debug("Hello world");
-    info("Hello world");
-    warn("Hello world");
-    error("Hello world");
-    consoleAssert(true);
-  } catch (e) {
-    caughtError = e;
-  }
-
-  assert(!caughtError);
+  log("Hello world");
+  dir("Hello world");
+  debug("Hello world");
+  info("Hello world");
+  warn("Hello world");
+  error("Hello world");
+  consoleAssert(true);
 });

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 
-import { test, assertEqual } from "./test_util.ts";
+import { test, assert, assertEqual } from "./test_util.ts";
 import { stringifyArgs } from "./console.ts";
 
 // tslint:disable-next-line:no-any
@@ -88,7 +88,7 @@ test(function consoleTestStringifyCircular() {
   assertEqual(stringify(JSON), "{}");
   assertEqual(
     stringify(console),
-    "Console { printFunc: [Function], debug: [Function: log], info: [Function: log], error: [Function: warn] }"
+    "Console { printFunc: [Function], log: [Function], debug: [Function], info: [Function], dir: [Function], warn: [Function], error: [Function], assert: [Function] }"
   );
 });
 
@@ -121,4 +121,29 @@ test(function consoleTestError() {
   } catch (e) {
     assertEqual(stringify(e).split("\n")[0], "MyError: This is an error");
   }
+});
+
+// Test bound this issue
+test(function consoleDetachedLog() {
+  const log = console.log;
+  const dir = console.dir;
+  const debug = console.debug;
+  const info = console.info;
+  const warn = console.warn;
+  const error = console.error;
+  const consoleAssert = console.assert;
+  let caughtError = false;
+  try {
+    log("Hello world");
+    dir("Hello world");
+    debug("Hello world");
+    info("Hello world");
+    warn("Hello world");
+    error("Hello world");
+    consoleAssert(true);
+  } catch (e) {
+    caughtError = e;
+  }
+
+  assert(!caughtError);
 });


### PR DESCRIPTION
Closes #872 

Explicitly use class assignment syntax + arrow function to bind `this`, ensure `this.printFunc` is defined.
