### PR TITLE
Add fetch_deps to syscall count.

### DIFF
--- a/website/app.js
+++ b/website/app.js
@@ -66,7 +66,7 @@ export function createThreadCountColumns(data) {
   ]);
 }
 
-const syscallCountNames = ["hello"];
+const syscallCountNames = ["hello", "fetch_deps"];
 export function createSyscallCountColumns(data) {
   return syscallCountNames.map(name => [
     name,


### PR DESCRIPTION
The benchmark was added in b7fd6e but was not surfaced in the UI.

TODO: The tests should have failed and caught this situation.