### PR TITLE
Upgrade JS deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.3.1",
     "tslint-no-circular-imports": "^0.5.0",
-    "typescript": "3.0.1"
+    "typescript": "3.0.3"
   }
 }


### PR DESCRIPTION
Upgrades TS to 3.0.3 to help #729 
Also upgrades minor versions of other JS deps. I wasn't able to upgrade rollup without a build failure - so that was left out.

Tests failing locally - this may need to wait for #889 to land.

cc @kitsonk 