### PR TITLE
Reenable copyFile tests

### DIFF
--- a/js/copy_file_test.ts
+++ b/js/copy_file_test.ts
@@ -31,7 +31,6 @@ testPerm({ write: true }, function copyFileSyncSuccess() {
   assertSameContent(fromFilename, toFilename);
 });
 
-/* Test is incorrect. TODO: fix this test.
 testPerm({ write: true }, function copyFileSyncFailure() {
   const tempDir = deno.makeTempDirSync();
   const fromFilename = tempDir + "/from.txt";
@@ -44,11 +43,16 @@ testPerm({ write: true }, function copyFileSyncFailure() {
     err = e;
   }
   assert(!!err);
-  // Rust deem non-existent path as invalid input
-  assertEqual(err.kind, deno.ErrorKind.InvalidInput);
-  assertEqual(err.name, "InvalidInput");
+  if (deno.platform.os === "win") {
+    assertEqual(err.kind, deno.ErrorKind.NotFound);
+    assertEqual(err.name, "NotFound");
+  } else {
+    // On *nix, Rust deem non-existent path as invalid input
+    // See https://github.com/rust-lang/rust/issues/54800
+    assertEqual(err.kind, deno.ErrorKind.InvalidInput);
+    assertEqual(err.name, "InvalidInput");
+  }
 });
-*/
 
 testPerm({ write: true }, function copyFileSyncOverwrite() {
   const tempDir = deno.makeTempDirSync();
@@ -88,7 +92,6 @@ testPerm({ write: true }, async function copyFileSuccess() {
   assertSameContent(fromFilename, toFilename);
 });
 
-/* Test is incorrect. TODO: fix this test.
 testPerm({ write: true }, async function copyFileFailure() {
   const tempDir = deno.makeTempDirSync();
   const fromFilename = tempDir + "/from.txt";
@@ -101,11 +104,16 @@ testPerm({ write: true }, async function copyFileFailure() {
     err = e;
   }
   assert(!!err);
-  // Rust deem non-existent path as invalid input
-  assertEqual(err.kind, deno.ErrorKind.InvalidInput);
-  assertEqual(err.name, "InvalidInput");
+  if (deno.platform.os === "win") {
+    assertEqual(err.kind, deno.ErrorKind.NotFound);
+    assertEqual(err.name, "NotFound");
+  } else {
+    // On *nix, Rust deem non-existent path as invalid input
+    // See https://github.com/rust-lang/rust/issues/54800
+    assertEqual(err.kind, deno.ErrorKind.InvalidInput);
+    assertEqual(err.name, "InvalidInput");
+  }
 });
-*/
 
 testPerm({ write: true }, async function copyFileOverwrite() {
   const tempDir = deno.makeTempDirSync();


### PR DESCRIPTION
Disabled in #885 .
Relevant Rust issue: rust-lang/rust#54800

`ErrorKind.InvalidInput` is the expected ErrorKind on *nix, as shown below from Rust's libstd source:
https://github.com/rust-lang/rust/blob/5597ee8a6483238421750fce4eb7031b12852428/src/libstd/sys/unix/fs.rs#L837-L842
```rust
if !from.is_file() {
  return Err(Error::new(ErrorKind::InvalidInput,
    "the source path is not an existing regular file"))
}
```

However, based on @piscisaureus 's feedback, on windows this would actually be a `ErrorKind.NotFound`. Rust's [doc](https://doc.rust-lang.org/std/fs/fn.copy.html#errors) is kind of unclear on this.

For now, check based on platform.
(I feel we probably will need to address uniform ErrorKind cross platform at some point)

