### PR TITLE
Changed tools/lint.py to lint the entire js and tests directories.

### DIFF
--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -67,7 +67,7 @@ test(function consoleTestStringifyCircular() {
   };
 
   nestedObj.o = circularObj;
-
+  // tslint:disable-next-line:max-line-length  
   const nestedObjExpected = `{ num: 1, bool: true, str: "a", method: [Function: method], asyncMethod: [AsyncFunction: asyncMethod], generatorMethod: [GeneratorFunction: generatorMethod], un: undefined, nu: null, arrowFunc: [Function: arrowFunc], extendedClass: Extended { a: 1, b: 2 }, nFunc: [Function], extendedCstr: [Function: Extended], o: { num: 2, bool: false, str: "b", method: [Function: method], un: undefined, nu: null, nested: [Circular], emptyObj: [object], arr: [object], baseClass: [object] } }`;
 
   assertEqual(stringify(1), "1");
@@ -88,11 +88,13 @@ test(function consoleTestStringifyCircular() {
   assertEqual(stringify(JSON), "{}");
   assertEqual(
     stringify(console),
+    // tslint:disable-next-line:max-line-length
     "Console { printFunc: [Function], log: [Function], debug: [Function], info: [Function], dir: [Function], warn: [Function], error: [Function], assert: [Function] }"
   );
 });
 
 test(function consoleTestStringifyWithDepth() {
+  // tslint:disable-next-line:no-any  
   const nestedObj: any = { a: { b: { c: { d: { e: { f: 42 } } } } } };
   assertEqual(
     stringifyArgs([nestedObj], { depth: 3 }),

--- a/js/make_temp_dir_test.ts
+++ b/js/make_temp_dir_test.ts
@@ -6,7 +6,7 @@ testPerm({ write: true }, function makeTempDirSyncSuccess() {
   const dir1 = deno.makeTempDirSync({ prefix: "hello", suffix: "world" });
   const dir2 = deno.makeTempDirSync({ prefix: "hello", suffix: "world" });
   // Check that both dirs are different.
-  assert(dir1 != dir2);
+  assert(dir1 !== dir2);
   for (const dir of [dir1, dir2]) {
     // Check that the prefix and suffix are applied.
     const lastPart = dir.replace(/^.*[\\\/]/, "");
@@ -44,7 +44,7 @@ testPerm({ write: true }, async function makeTempDirSuccess() {
   const dir1 = await deno.makeTempDir({ prefix: "hello", suffix: "world" });
   const dir2 = await deno.makeTempDir({ prefix: "hello", suffix: "world" });
   // Check that both dirs are different.
-  assert(dir1 != dir2);
+  assert(dir1 !== dir2);
   for (const dir of [dir1, dir2]) {
     // Check that the prefix and suffix are applied.
     const lastPart = dir.replace(/^.*[\\\/]/, "");

--- a/js/net_test.ts
+++ b/js/net_test.ts
@@ -9,7 +9,7 @@ testPerm({ net: true }, function netListenClose() {
 });
 
 testPerm({ net: true }, async function netDialListen() {
-  let addr = "127.0.0.1:4500";
+  const addr = "127.0.0.1:4500";
   const listener = deno.listen("tcp", addr);
   listener.accept().then(async conn => {
     await conn.write(new Uint8Array([1, 2, 3]));

--- a/js/read_dir_test.ts
+++ b/js/read_dir_test.ts
@@ -7,7 +7,7 @@ function assertSameContent(files: FileInfo[]) {
   let counter = 0;
 
   for (const file of files) {
-    if (file.name == "subdir") {
+    if (file.name === "subdir") {
       assert(file.isDirectory());
       counter++;
     }

--- a/js/timers_test.ts
+++ b/js/timers_test.ts
@@ -32,7 +32,7 @@ test(async function timeoutSuccess() {
 });
 
 test(async function timeoutArgs() {
-  let arg = 1;
+  const arg = 1;
   await new Promise((resolve, reject) => {
     setTimeout(
       (a, b, c) => {

--- a/tests/010_set_interval.ts
+++ b/tests/010_set_interval.ts
@@ -1,7 +1,7 @@
-const id = setInterval(function() {
+const id = setInterval(() => {
   console.log("test");
 }, 200);
 
-setTimeout(function() {
+setTimeout(() => {
   clearInterval(id);
 }, 500);

--- a/tests/cat.ts
+++ b/tests/cat.ts
@@ -2,8 +2,8 @@ import { stdout, open, copy, args } from "deno";
 
 async function main() {
   for (let i = 1; i < args.length; i++) {
-    let filename = args[i];
-    let file = await open(filename);
+    const filename = args[i];
+    const file = await open(filename);
     await copy(stdout, file);
   }
 }

--- a/tests/https_import.ts
+++ b/tests/https_import.ts
@@ -1,5 +1,6 @@
 // TODO Use https://localhost:4555/ but we need more infrastructure to
 // support verifying self-signed certificates.
+// tslint:disable-next-line:max-line-length
 import { printHello } from "https://gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts";
 
 printHello();

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -17,4 +17,4 @@ run([
     "python", cpplint, "--filter=-build/include_subdir", "--repository=src",
     "--extensions=cc,h", "--recursive", "src/."
 ])
-run(["node", tslint, "-p", ".", "--exclude", "**/gen/**/*.ts"])
+run(["node", tslint, "js/**/*.ts", "tests/**/*.ts", "--exclude", "**/gen/**/*.ts"])

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -17,4 +17,6 @@ run([
     "python", cpplint, "--filter=-build/include_subdir", "--repository=src",
     "--extensions=cc,h", "--recursive", "src/."
 ])
-run(["node", tslint, "js/**/*.ts", "tests/**/*.ts", "--exclude", "**/gen/**/*.ts"])
+
+run(["node", tslint, "-p", ".", "--exclude", "**/gen/**/*.ts"])
+run(["node", tslint, "./js/**/*_test.ts", "./tests/**/*.ts", "--exclude", "**/gen/**/*.ts"])


### PR DESCRIPTION
Fixes #897 
This change will lint the entire js and tests directories and their sub directories. Currently it was pointing at tsconfig and would only lint files that were part of js/main.ts or node_modules/typescript/lib/lib.esnext.d.ts and their dependencies

After this change ./tools/lint.py will fail as the test files were not previously linted and some of them will now fail lint. Fixing these newly found test format issues should probably be opened as part of another PR.

<!--

Thank you for your pull request. Before submitting, please make sure the following is done.

1. Ensure ./tools/test.py passes.
2. Format your code with ./tools/format.py
3. Make sure ./tools/lint.py passes.

-->
