### PR TITLE
Implement closeRead/closeWrite using TcpStream::shutdown

### DIFF
--- a/js/net.ts
+++ b/js/net.ts
@@ -12,10 +12,7 @@ export type Network = "tcp";
 // export type Network = "tcp" | "tcp4" | "tcp6" | "unix" | "unixpacket";
 
 // TODO Support finding network from Addr, see https://golang.org/pkg/net/#Addr
-export interface Addr {
-  network: Network;
-  address: string;
-}
+export type Addr = string;
 
 /** A Listener is a generic network listener for stream-oriented protocols. */
 export interface Listener {
@@ -31,11 +28,7 @@ export interface Listener {
 }
 
 class ListenerImpl implements Listener {
-  private addr_: Addr;
-
-  constructor(readonly fd: number, network: Network, address: string) {
-    this.addr_ = Object.freeze({ network, address });
-  }
+  constructor(readonly fd: number) {}
 
   async accept(): Promise<Conn> {
     const builder = new flatbuffers.Builder();
@@ -55,7 +48,7 @@ class ListenerImpl implements Listener {
   }
 
   addr(): Addr {
-    return this.addr_;
+    return notImplemented();
   }
 }
 
@@ -148,7 +141,7 @@ export function listen(network: Network, address: string): Listener {
   assert(msg.Any.ListenRes === baseRes!.innerType());
   const res = new msg.ListenRes();
   assert(baseRes!.inner(res) != null);
-  return new ListenerImpl(res.rid(), network, address);
+  return new ListenerImpl(res.rid());
 }
 
 /** Dial connects to the address on the named network.

--- a/js/net.ts
+++ b/js/net.ts
@@ -103,7 +103,7 @@ class ConnImpl implements Conn {
 }
 
 enum ShutdownMode {
-  // See https://linux.die.net/man/2/shutdown
+  // See http://man7.org/linux/man-pages/man2/shutdown.2.html
   // Corresponding to SHUT_RD, SHUT_WR, SHUT_RDWR
   Read = 0,
   Write,

--- a/js/net.ts
+++ b/js/net.ts
@@ -82,7 +82,6 @@ class ConnImpl implements Conn {
    * Most callers should just use close().
    */
   closeRead(): void {
-    // TODO(ry) Connect to AsyncWrite::shutdown in resources.rs
     shutdown(this.fd, ShutdownMode.Read);
   }
 
@@ -90,7 +89,6 @@ class ConnImpl implements Conn {
    * connection. Most callers should just use close().
    */
   closeWrite(): void {
-    // TODO(ry) Connect to AsyncWrite::shutdown in resources.rs
     shutdown(this.fd, ShutdownMode.Write);
   }
 }

--- a/js/net_test.ts
+++ b/js/net_test.ts
@@ -36,7 +36,7 @@ testPerm({ net: true }, async function netDialListen() {
   conn.close();
 });
 
-testPerm({ net: true }, async function netConnCloseRead() {
+testPerm({ net: true }, async function netCloseReadSuccess() {
   const addr = "127.0.0.1:4500";
   const listener = deno.listen("tcp", addr);
   const closeDeferred = deferred();
@@ -64,7 +64,7 @@ testPerm({ net: true }, async function netConnCloseRead() {
   conn.close();
 });
 
-testPerm({ net: true }, async function netConnDupCloseReadFailure() {
+testPerm({ net: true }, async function netDoubleCloseRead() {
   const addr = "127.0.0.1:4500";
   const listener = deno.listen("tcp", addr);
   const closeDeferred = deferred();
@@ -90,7 +90,7 @@ testPerm({ net: true }, async function netConnDupCloseReadFailure() {
   conn.close();
 });
 
-testPerm({ net: true }, async function netConnCloseWrite() {
+testPerm({ net: true }, async function netCloseWriteSuccess() {
   const addr = "127.0.0.1:4500";
   const listener = deno.listen("tcp", addr);
   const closeDeferred = deferred();
@@ -123,7 +123,7 @@ testPerm({ net: true }, async function netConnCloseWrite() {
   conn.close();
 });
 
-testPerm({ net: true }, async function netConnDupCloseWriteFailure() {
+testPerm({ net: true }, async function netDoubleCloseWrite() {
   const addr = "127.0.0.1:4500";
   const listener = deno.listen("tcp", addr);
   const closeDeferred = deferred();

--- a/js/net_test.ts
+++ b/js/net_test.ts
@@ -1,7 +1,8 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 
 import * as deno from "deno";
-import { testPerm, assert, assertEqual, deferred } from "./test_util.ts";
+import { testPerm, assert, assertEqual } from "./test_util.ts";
+import { deferred } from "./util.ts";
 
 testPerm({ net: true }, function netListenClose() {
   const listener = deno.listen("tcp", "127.0.0.1:4500");

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -49,26 +49,6 @@ export function test(fn: testing.TestFunction) {
   testPerm({ write: false, net: false, env: false }, fn);
 }
 
-interface Deferred {
-  promise: Promise<void>;
-  resolve: Function;
-  reject: Function;
-}
-
-export function deferred(): Deferred {
-  let resolve: Function | undefined;
-  let reject: Function | undefined;
-  const promise = new Promise<void>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return {
-    promise,
-    resolve: resolve!,
-    reject: reject!
-  };
-}
-
 test(function permSerialization() {
   for (const write of [true, false]) {
     for (const net of [true, false]) {

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -49,6 +49,26 @@ export function test(fn: testing.TestFunction) {
   testPerm({ write: false, net: false, env: false }, fn);
 }
 
+interface Deferred {
+  promise: Promise<void>;
+  resolve: Function;
+  reject: Function;
+}
+
+export function deferred(): Deferred {
+  let resolve: Function | undefined;
+  let reject: Function | undefined;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return {
+    promise,
+    resolve: resolve!,
+    reject: reject!
+  };
+}
+
 test(function permSerialization() {
   for (const write of [true, false]) {
     for (const net of [true, false]) {

--- a/js/testing/testing.ts
+++ b/js/testing/testing.ts
@@ -57,12 +57,11 @@ const FG_RED = "\x1b[31m";
 const FG_GREEN = "\x1b[32m";
 
 function red_failed() {
-  return FG_RED + "FAILED" + RESET
+  return FG_RED + "FAILED" + RESET;
 }
 
-
 function green_ok() {
-  return FG_GREEN + "ok" + RESET
+  return FG_GREEN + "ok" + RESET;
 }
 
 async function runTests() {
@@ -96,8 +95,8 @@ async function runTests() {
   const result = failed > 0 ? red_failed() : green_ok();
   console.log(
     `\ntest result: ${result}. ${passed} passed; ${failed} failed; ` +
-    `${ignored} ignored; ${measured} measured; ${filtered} filtered out\n`);
-
+      `${ignored} ignored; ${measured} measured; ${filtered} filtered out\n`
+  );
 
   if (failed === 0) {
     // All good.

--- a/js/util.ts
+++ b/js/util.ts
@@ -101,3 +101,29 @@ export function containsOnlyASCII(str: string): boolean {
   }
   return /^[\x00-\x7F]*$/.test(str);
 }
+
+// @internal
+export interface Deferred {
+  promise: Promise<void>;
+  resolve: Function;
+  reject: Function;
+}
+
+/**
+ * Create a wrapper around a promise that could be
+ * resolved externally.
+ * @internal
+ */
+export function deferred(): Deferred {
+  let resolve: Function | undefined;
+  let reject: Function | undefined;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return {
+    promise,
+    resolve: resolve!,
+    reject: reject!
+  };
+}

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -35,6 +35,7 @@ union Any {
   Write,
   WriteRes,
   Close,
+  Shutdown,
   Listen,
   ListenRes,
   Accept,
@@ -288,6 +289,11 @@ table WriteRes {
 
 table Close {
   rid: int;
+}
+
+table Shutdown {
+  rid: int;
+  is_write: bool;
 }
 
 table Listen {

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -293,7 +293,7 @@ table Close {
 
 table Shutdown {
   rid: int;
-  is_write: bool;
+  how: uint;
 }
 
 table Listen {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -9,6 +9,8 @@ use isolate::Isolate;
 use isolate::IsolateState;
 use isolate::Op;
 use msg;
+use resources;
+use resources::Resource;
 use tokio_util;
 
 use flatbuffers::FlatBufferBuilder;
@@ -19,7 +21,6 @@ use hyper;
 use hyper::rt::{Future, Stream};
 use hyper::Client;
 use remove_dir_all::remove_dir_all;
-use resources;
 use std;
 use std::fs;
 use std::net::{Shutdown, SocketAddr};
@@ -636,7 +637,8 @@ fn op_shutdown(
         _ => unimplemented!(),
       };
       blocking!(base.sync(), || {
-        resource.shutdown_on(shutdown_mode)?;
+        // Use UFCS for disambiguation
+        Resource::shutdown(&mut resource, shutdown_mode)?;
         Ok(empty_buf())
       })
     }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -82,8 +82,7 @@ impl Resource {
     assert!(r.is_some());
   }
 
-  // no collision with unimplemented shutdown
-  pub fn shutdown_on(&mut self, how: Shutdown) -> Result<(), DenoError> {
+  pub fn shutdown(&mut self, how: Shutdown) -> Result<(), DenoError> {
     let mut table = RESOURCE_TABLE.lock().unwrap();
     let maybe_repr = table.get_mut(&self.rid);
     match maybe_repr {


### PR DESCRIPTION
Attempt to implement `closeRead/closeWrite`
Simulated [`shutdown(2)`](http://man7.org/linux/man-pages/man2/shutdown.2.html) interface.

Also briefly implemented `Conn.addr()`