### PR TITLE
Move Platform from types to platform

### DIFF
--- a/js/platform.ts
+++ b/js/platform.ts
@@ -1,3 +1,20 @@
-import { Platform } from "./types";
+// Do not add unsupported platforms.
+export interface Platform {
+  /**
+   * The operating system CPU architecture
+   */
+  arch: "x64";
+
+  /**
+   * The operating system platform
+   */
+  os: "mac" | "win" | "linux";
+}
+
 // 'platform' is  injected by rollup.config.js at compile time.
-export const platform: Platform = {};
+export const platform: Platform = {
+  // tslint:disable:no-any
+  arch: "" as any,
+  os: "" as any
+  // tslint:disable:any
+};

--- a/js/read_link_test.ts
+++ b/js/read_link_test.ts
@@ -9,7 +9,7 @@ testPerm({ write: true }, function readlinkSyncSuccess() {
   deno.mkdirSync(target);
   // TODO Add test for Windows once symlink is implemented for Windows.
   // See https://github.com/denoland/deno/issues/815.
-  if (deno.platform !== "win32") {
+  if (deno.platform.os !== "win") {
     deno.symlinkSync(target, symlink);
     const targetPath = deno.readlinkSync(symlink);
     assertEqual(targetPath, target);
@@ -36,7 +36,7 @@ testPerm({ write: true }, async function readlinkSuccess() {
   deno.mkdirSync(target);
   // TODO Add test for Windows once symlink is implemented for Windows.
   // See https://github.com/denoland/deno/issues/815.
-  if (deno.platform !== "win32") {
+  if (deno.platform.os !== "win") {
     deno.symlinkSync(target, symlink);
     const targetPath = await deno.readlink(symlink);
     assertEqual(targetPath, target);

--- a/js/types.ts
+++ b/js/types.ts
@@ -151,9 +151,3 @@ declare global {
     stackTraceLimit: number;
   }
 }
-
-// Do not add unsupported platforms.
-export interface Platform {
-  arch?: "x64";
-  os?: "mac" | "win" | "linux";
-}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -108,9 +108,10 @@ function platform({ include, exclude } = {}) {
         // Adapted from https://github.com/rollup/rollup-plugin-inject/blob/master/src/index.js
         const arch = archNodeToDeno[process.arch];
         const os = osNodeToDeno[process.platform];
+        // We do not have to worry about the interface here, because this is just to generate
+        // the actual runtime code, not any type information integrated into Deno
         const magicString = new MagicString(`
-import { Platform } from "./types";
-export const platform: Platform = { arch: "${arch}", os:"${os}" };`);
+export const platform = { arch: "${arch}", os:"${os}" };`);
         return {
           code: magicString.toString(),
           map: magicString.generateMap()


### PR DESCRIPTION
This fixes an issue with flattening types for #729 but also makes much more sense that `platform.ts` owns the types since they aren't used anywhere else in Deno.

Generally we should try to keep types close to the code instead of abstracting them out.