### PR TITLE
Hide compiler module

### DIFF
--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -1,7 +1,7 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
-/// <amd-module name="compiler"/>
 import * as ts from "typescript";
 import { assetSourceCode } from "./assets";
+// tslint:disable-next-line:no-circular-imports
 import * as deno from "./deno";
 import { globalEval } from "./global_eval";
 import { libdeno } from "./libdeno";
@@ -648,7 +648,7 @@ export class DenoCompiler
     this._log("resolveModuleNames()", { moduleNames, containingFile });
     return moduleNames.map(name => {
       let resolvedFileName;
-      if (name === "deno" || name === "compiler") {
+      if (name === "deno") {
         // builtin modules are part of `globals.d.ts`
         resolvedFileName = this._resolveModuleName("globals.d.ts", ASSETS);
       } else if (name === "typescript") {
@@ -683,8 +683,7 @@ export class DenoCompiler
   // tslint:disable-next-line:no-any
   private static _builtins: { [mid: string]: any } = {
     typescript: ts,
-    deno,
-    compiler: { DenoCompiler, ModuleMetaData }
+    deno
   };
 
   private static _instance: DenoCompiler | undefined;

--- a/js/compiler_test.ts
+++ b/js/compiler_test.ts
@@ -1,12 +1,12 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 import { test, assert, assertEqual } from "./test_util.ts";
-import * as compiler from "compiler";
+import * as deno from "deno";
 import * as ts from "typescript";
 
 // We use a silly amount of `any` in these tests...
 // tslint:disable:no-any
 
-const { DenoCompiler } = compiler;
+const { DenoCompiler } = (deno as any)._compiler;
 
 interface ModuleInfo {
   moduleName: string | null;
@@ -42,8 +42,8 @@ function mockModuleInfo(
 }
 
 // Some fixtures we will us in testing
-const fooBarTsSource = `import * as compiler from "compiler";
-console.log(compiler);
+const fooBarTsSource = `import * as deno from "deno";
+console.log(deno);
 export const foo = "bar";
 `;
 
@@ -81,13 +81,13 @@ const modBModuleInfo = mockModuleInfo(
 
 // TODO(#23) Remove source map strings from fooBarTsOutput.
 // tslint:disable:max-line-length
-const fooBarTsOutput = `define(["require", "exports", "compiler"], function (require, exports, compiler) {
+const fooBarTsOutput = `define(["require", "exports", "deno"], function (require, exports, deno) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
-    console.log(compiler);
+    console.log(deno);
     exports.foo = "bar";
 });
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYmFyLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZmlsZTovLy9yb290L3Byb2plY3QvZm9vL2Jhci50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOzs7SUFDQSxPQUFPLENBQUMsR0FBRyxDQUFDLFFBQVEsQ0FBQyxDQUFDO0lBQ1QsUUFBQSxHQUFHLEdBQUcsS0FBSyxDQUFDIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0ICogYXMgY29tcGlsZXIgZnJvbSBcImNvbXBpbGVyXCI7XG5jb25zb2xlLmxvZyhjb21waWxlcik7XG5leHBvcnQgY29uc3QgZm9vID0gXCJiYXJcIjtcbiJdfQ==
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYmFyLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZmlsZTovLy9yb290L3Byb2plY3QvZm9vL2Jhci50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOzs7SUFDQSxPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ0wsUUFBQSxHQUFHLEdBQUcsS0FBSyxDQUFDIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0ICogYXMgZGVubyBmcm9tIFwiZGVub1wiO1xuY29uc29sZS5sb2coZGVubyk7XG5leHBvcnQgY29uc3QgZm9vID0gXCJiYXJcIjtcbiJdfQ==
 //# sourceURL=/root/project/foo/bar.ts`;
 
 // TODO(#23) Remove source map strings from fooBazTsOutput.
@@ -159,7 +159,7 @@ let codeFetchStack: Array<{
 }> = [];
 
 let mockDepsStack: string[][] = [];
-let mockFactoryStack: compiler.AmdFactory[] = [];
+let mockFactoryStack: any[] = [];
 
 function globalEvalMock(x: string): void {
   globalEvalStack.push(x);
@@ -247,7 +247,7 @@ const serviceMock = {
     );
   }
 };
-const windowMock: { define?: compiler.AmdDefine } = {};
+const windowMock: { define?: any } = {};
 const mocks = {
   _globalEval: globalEvalMock,
   _log: logMock,
@@ -300,12 +300,12 @@ test(function compilerRun() {
   // equal to `deno foo/bar.ts`
   setup();
   let factoryRun = false;
-  mockDepsStack.push(["require", "exports", "compiler"]);
-  mockFactoryStack.push((_require, _exports, _compiler) => {
+  mockDepsStack.push(["require", "exports", "deno"]);
+  mockFactoryStack.push((_require, _exports, _deno) => {
     factoryRun = true;
     assertEqual(typeof _require, "function");
     assertEqual(typeof _exports, "object");
-    assert(_compiler === compiler);
+    assert(_deno === deno);
     _exports.foo = "bar";
   });
   const moduleMetaData = compilerInstance.run("foo/bar.ts", "/root/project");
@@ -337,8 +337,8 @@ test(function compilerRunMultiModule() {
     factoryStack.push("baz");
     assertEqual(_bar.foo, "bar");
   };
-  const barDeps = ["require", "exports", "compiler"];
-  const barFactory = (_require, _exports, _compiler) => {
+  const barDeps = ["require", "exports", "deno"];
+  const barFactory = (_require, _exports, _deno) => {
     factoryStack.push("bar");
     _exports.foo = "bar";
   };
@@ -411,7 +411,7 @@ test(function compilerGetModuleDependencies() {
   const bazFactory = () => {
     throw new Error("Unexpected factory call");
   };
-  const barDeps = ["require", "exports", "compiler"];
+  const barDeps = ["require", "exports", "deno"];
   const barFactory = () => {
     throw new Error("Unexpected factory call");
   };

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -23,3 +23,8 @@ export { truncateSync, truncate } from "./truncate";
 export { FileInfo } from "./file_info";
 export { connect, dial, listen, Listener, Conn } from "./net";
 export const args: string[] = [];
+
+// Provide the compiler API in an obfuscated way
+import * as compiler from "./compiler";
+// @internal
+export const _compiler = compiler;

--- a/js/tsconfig.declarations.json
+++ b/js/tsconfig.declarations.json
@@ -13,7 +13,6 @@
   },
   "files": [
     "../node_modules/typescript/lib/lib.esnext.d.ts",
-    "./compiler.ts",
     "./deno.ts",
     "./globals.ts"
   ]


### PR DESCRIPTION
Resolves #876 

This only exposes the compiler module to userland via an "undocumented" `_compiler` property of the Deno module.
