### PR TITLE
Die on panic and clean up helpers in src/errors.rs

### DIFF
--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -67,7 +67,7 @@ test(function consoleTestStringifyCircular() {
   };
 
   nestedObj.o = circularObj;
-  // tslint:disable-next-line:max-line-length  
+  // tslint:disable-next-line:max-line-length
   const nestedObjExpected = `{ num: 1, bool: true, str: "a", method: [Function: method], asyncMethod: [AsyncFunction: asyncMethod], generatorMethod: [GeneratorFunction: generatorMethod], un: undefined, nu: null, arrowFunc: [Function: arrowFunc], extendedClass: Extended { a: 1, b: 2 }, nFunc: [Function], extendedCstr: [Function: Extended], o: { num: 2, bool: false, str: "b", method: [Function: method], un: undefined, nu: null, nested: [Circular], emptyObj: [object], arr: [object], baseClass: [object] } }`;
 
   assertEqual(stringify(1), "1");
@@ -94,7 +94,7 @@ test(function consoleTestStringifyCircular() {
 });
 
 test(function consoleTestStringifyWithDepth() {
-  // tslint:disable-next-line:no-any  
+  // tslint:disable-next-line:no-any
   const nestedObj: any = { a: { b: { c: { d: { e: { f: 42 } } } } } };
   assertEqual(
     stringifyArgs([nestedObj], { depth: 3 }),

--- a/js/testing/testing.ts
+++ b/js/testing/testing.ts
@@ -72,6 +72,7 @@ async function runTests() {
   for (let i = 0; i < tests.length; i++) {
     const { fn, name } = tests[i];
     let result = green_ok();
+    console.log("test", name);
     try {
       await fn();
       passed++;
@@ -83,7 +84,8 @@ async function runTests() {
         break;
       }
     }
-    console.log("test", name, "...", result);
+    // TODO Do this on the same line as test name is printed.
+    console.log("...", result);
   }
 
   // TODO counts for ignored , measured, filtered.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -94,7 +94,7 @@ impl DenoError {
 impl fmt::Display for DenoError {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self.repr {
-      Repr::Simple(_kind, ref _msg) => panic!("todo"),
+      Repr::Simple(_kind, ref err_str) => f.pad(err_str),
       Repr::IoErr(ref err) => err.fmt(f),
       Repr::UrlErr(ref err) => err.fmt(f),
       Repr::HyperErr(ref err) => err.fmt(f),
@@ -109,7 +109,6 @@ impl std::error::Error for DenoError {
       Repr::IoErr(ref err) => err.description(),
       Repr::UrlErr(ref err) => err.description(),
       Repr::HyperErr(ref err) => err.description(),
-      // Repr::Simple(..) => "FIXME",
     }
   }
 
@@ -119,7 +118,6 @@ impl std::error::Error for DenoError {
       Repr::IoErr(ref err) => Some(err),
       Repr::UrlErr(ref err) => Some(err),
       Repr::HyperErr(ref err) => Some(err),
-      // Repr::Simple(..) => None,
     }
   }
 }
@@ -149,4 +147,18 @@ impl From<hyper::Error> for DenoError {
       repr: Repr::HyperErr(err),
     }
   }
+}
+
+pub fn bad_resource() -> DenoError {
+  new(
+    ErrorKind::BadFileDescriptor, // TODO Rename to BadResource
+    String::from("bad resource id"),
+  )
+}
+
+pub fn permission_denied() -> DenoError {
+  new(
+    ErrorKind::PermissionDenied,
+    String::from("permission denied"),
+  )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,18 @@ impl log::Log for Logger {
 }
 
 fn main() {
+  // Rust does not die on panic by default. And -Cpanic=abort is broken.
+  // https://github.com/rust-lang/cargo/issues/2738
+  // Therefore this hack.
+  std::panic::set_hook(Box::new(|panic_info| {
+    if let Some(location) = panic_info.location() {
+      println!("PANIC file '{}' line {}", location.file(), location.line());
+    } else {
+      println!("PANIC occurred but can't get location information...");
+    }
+    std::process::abort();
+  }));
+
   log::set_logger(&LOGGER).unwrap();
   let args = env::args().collect();
   let mut isolate = isolate::Isolate::new(args, ops::dispatch);

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,6 +1,7 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 
 use errors;
+use errors::permission_denied;
 use errors::DenoError;
 use errors::DenoResult;
 use fs as deno_fs;
@@ -149,20 +150,6 @@ pub fn dispatch(
     base.sync()
   );
   return (base.sync(), boxed_op);
-}
-
-fn permission_denied() -> DenoError {
-  DenoError::from(std::io::Error::new(
-    std::io::ErrorKind::PermissionDenied,
-    "permission denied",
-  ))
-}
-
-fn not_implemented() -> DenoError {
-  DenoError::from(std::io::Error::new(
-    std::io::ErrorKind::Other,
-    "Not implemented",
-  ))
 }
 
 fn op_exit(
@@ -603,10 +590,7 @@ fn op_close(
   let inner = base.inner_as_close().unwrap();
   let rid = inner.rid();
   match resources::lookup(rid) {
-    None => odd_future(errors::new(
-      errors::ErrorKind::BadFileDescriptor,
-      String::from("Bad File Descriptor"),
-    )),
+    None => odd_future(errors::bad_resource()),
     Some(mut resource) => {
       resource.close();
       ok_future(empty_buf())
@@ -624,10 +608,7 @@ fn op_read(
   let rid = inner.rid();
 
   match resources::lookup(rid) {
-    None => odd_future(errors::new(
-      errors::ErrorKind::BadFileDescriptor,
-      String::from("Bad File Descriptor"),
-    )),
+    None => odd_future(errors::bad_resource()),
     Some(resource) => {
       let op = tokio_io::io::read(resource, data)
         .map_err(|err| DenoError::from(err))
@@ -666,10 +647,7 @@ fn op_write(
   let rid = inner.rid();
 
   match resources::lookup(rid) {
-    None => odd_future(errors::new(
-      errors::ErrorKind::BadFileDescriptor,
-      String::from("Bad File Descriptor"),
-    )),
+    None => odd_future(errors::bad_resource()),
     Some(resource) => {
       let len = data.len();
       let op = tokio_io::io::write_all(resource, data)
@@ -958,7 +936,7 @@ fn op_symlink(
   }
   // TODO Use type for Windows.
   if cfg!(windows) {
-    return odd_future(not_implemented());
+    panic!("symlink for windows is not yet implemented")
   }
 
   let inner = base.inner_as_symlink().unwrap();
@@ -1109,10 +1087,7 @@ fn op_accept(
   let server_rid = inner.rid();
 
   match resources::lookup(server_rid) {
-    None => odd_future(errors::new(
-      errors::ErrorKind::BadFileDescriptor,
-      String::from("Bad File Descriptor"),
-    )),
+    None => odd_future(errors::bad_resource()),
     Some(server_resource) => {
       let op = tokio_util::accept(server_resource)
         .map_err(|err| DenoError::from(err))

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -19,4 +19,7 @@ run([
 ])
 
 run(["node", tslint, "-p", ".", "--exclude", "**/gen/**/*.ts"])
-run(["node", tslint, "./js/**/*_test.ts", "./tests/**/*.ts", "--exclude", "**/gen/**/*.ts"])
+run([
+    "node", tslint, "./js/**/*_test.ts", "./tests/**/*.ts", "--exclude",
+    "**/gen/**/*.ts"
+])


### PR DESCRIPTION
* Add errors::bad_resource()
* Move permission_denied() to errors.rs
* Make op_symlink's not_implemented() into a runtime panic.