### PR TITLE
readme: fix formatting error

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@
 - No `package.json`. No npm. Not explicitly compatible with Node.
 
 - Imports reference source code URLs only.
-  `import { test } from "https://unpkg.com/deno_testing@0.0.5/testing.ts" import { log } from "./util.ts"`
+
+  ```typescript
+  import { test } from "https://unpkg.com/deno_testing@0.0.5/testing.ts";
+  import { log } from "./util.ts";
+  ```
+
   Remote code is fetched and cached on first execution, and never updated until
   the code is run with the `--reload` flag. (So, this will still work on an
   airplane. See `~/.deno/src` for details on the cache.)


### PR DESCRIPTION
Prettier kinda butchered it the other day.
It turns that, prior to running prettier, the readme contained a mixture of tabs and spaces.
Prettier interpreted that a little different than the github renderer.
I guess that's a prettier bug -- but let's just not mix tabs and spaces ;)

<!--

Thank you for your pull request. Before submitting, please make sure the following is done.

1. Ensure ./tools/test.py passes.
2. Format your code with ./tools/format.py
3. Make sure ./tools/lint.py passes.

-->
