### PR TITLE
Remove race condition from netCloseReadSuccess test

### DIFF
--- a/js/net_test.ts
+++ b/js/net_test.ts
@@ -41,7 +41,9 @@ testPerm({ net: true }, async function netCloseReadSuccess() {
   const addr = "127.0.0.1:4500";
   const listener = deno.listen("tcp", addr);
   const closeDeferred = deferred();
+  const closeReadDeferred = deferred();
   listener.accept().then(async conn => {
+    await closeReadDeferred.promise;
     await conn.write(new Uint8Array([1, 2, 3]));
     const buf = new Uint8Array(1024);
     const readResult = await conn.read(buf);
@@ -54,6 +56,7 @@ testPerm({ net: true }, async function netCloseReadSuccess() {
   });
   const conn = await deno.dial("tcp", addr);
   conn.closeRead(); // closing read
+  closeReadDeferred.resolve();
   const buf = new Uint8Array(1024);
   const readResult = await conn.read(buf);
   assertEqual(0, readResult.nread); // No error, read nothing


### PR DESCRIPTION
Realized there is a race condition for `netCloseReadSuccess` test from previous travis failure.

Ensure that listener side write only happens after the `conn.closeRead` is called.