### PR TITLE
Replace panic with error on windows for op_symlink

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -2,8 +2,7 @@
 
 use errors;
 use errors::permission_denied;
-use errors::DenoError;
-use errors::DenoResult;
+use errors::{DenoError, DenoResult, ErrorKind};
 use fs as deno_fs;
 use isolate::Buf;
 use isolate::Isolate;
@@ -967,7 +966,10 @@ fn op_symlink(
   }
   // TODO Use type for Windows.
   if cfg!(windows) {
-    panic!("symlink for windows is not yet implemented")
+    return odd_future(errors::new(
+      ErrorKind::Other,
+      "symlink for windows is not yet implemented".to_string(),
+    ));
   }
 
   let inner = base.inner_as_symlink().unwrap();


### PR DESCRIPTION
This would cause test.py to die halfway, due to https://github.com/denoland/deno/commit/cfa54cabbdaca48d7623cd5fd5aada59b5e02040 , and the assumption below in symlink tests:
https://github.com/denoland/deno/blob/5f14ec486c6a6edf0cee2643b4dbebd5b86cc884/js/symlink_test.ts#L12-L16

It is not previous detected on AppVeyor, as #919 would cause the tests to silently die halfway. I only noticed this by applying #911 patch that somehow mysteriously fix test running for release build.
