### PR TITLE
Export missing io types from deno

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -3,7 +3,10 @@
 /// <amd-module name="deno"/>
 export { env, exit } from "./os";
 export { File, open, stdin, stdout, stderr, read, write, close } from "./files";
-export { copy, Reader, Writer } from "./io";
+export {
+	copy, ReadResult, Reader, Writer, Closer, Seeker, ReaderCloser,
+	WriteCloser, ReadSeeker, WriteSeeker, ReadWriteCloser, ReadWriteSeeker,
+} from "./io";
 export { mkdirSync, mkdir } from "./mkdir";
 export { makeTempDirSync, makeTempDir } from "./make_temp_dir";
 export { removeSync, remove, removeAllSync, removeAll } from "./remove";


### PR DESCRIPTION
There are many essential interfaces in io.ts that I don't see any way to access in scripts. This change exports them all such that they can be accessed as:

```typescript
import { ReadSeeker, Closer, ReadResult, ... } from "deno";
```

The Seeker interface mentions the constants `SeekStart`, `SeekCurrent` and `SeekEnd`, which I believe should also be defined and exported, but I'm not sure what the correct values would be.

One test failed, but it doesn't appear to have anything to do with the changes:

```
test netDoubleCloseRead_permW0N1E0
Error
    at Object.assert (file:///home/ns/git/deno/js/testing/util.ts:35:11)
    at netDoubleCloseRead (file:///home/ns/git/deno/js/net_test.ts:89:3)
```