### PR TITLE
refactor(webapp): stop hard coding benchmark column names

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 ## About benchmark data
 
-The benchmark chart supposes `//website/data.json` has the signature of
+The benchmark chart supposes `//website/data.json` has the type
 `BenchmarkData[]` where `BenchmarkData` is defined like the below:
 
 ```typescript
@@ -16,9 +16,17 @@ interface ExecTimeData {
 interface BenchmarkData {
   created_at: string;
   sha1: string;
-  binary_size?: number;
   benchmark: {
     [key: string]: ExecTimeData;
+  };
+  binarySizeData: {
+    [key: string]: number;
+  };
+  threadCountData: {
+    [key: string]: number;
+  };
+  syscallCountData: {
+    [key: string]: number;
   };
 }
 ```

--- a/website/app.js
+++ b/website/app.js
@@ -16,13 +16,8 @@ export function getTravisData() {
     .then(data => data.builds.reverse());
 }
 
-const benchmarkNames = [
-  "hello",
-  "relative_import",
-  "cold_hello",
-  "cold_relative_import"
-];
 export function createExecTimeColumns(data) {
+  const benchmarkNames = Object.keys(data[data.length - 1].benchmark);
   return benchmarkNames.map(name => [
     name,
     ...data.map(d => {
@@ -33,8 +28,9 @@ export function createExecTimeColumns(data) {
   ]);
 }
 
-const binarySizeNames = ["deno", "main.js", "main.js.map", "snapshot_deno.bin"];
 export function createBinarySizeColumns(data) {
+  const propName = "binary_size";
+  const binarySizeNames = Object.keys(data[data.length - 1][propName]);
   return binarySizeNames.map(name => [
     name,
     ...data.map(d => {
@@ -52,12 +48,13 @@ export function createBinarySizeColumns(data) {
   ]);
 }
 
-const threadCountNames = ["set_timeout", "fetch_deps"];
 export function createThreadCountColumns(data) {
+  const propName = "thread_count";
+  const threadCountNames = Object.keys(data[data.length - 1][propName]);
   return threadCountNames.map(name => [
     name,
     ...data.map(d => {
-      const threadCountData = d["thread_count"];
+      const threadCountData = d[propName];
       if (!threadCountData) {
         return null;
       }
@@ -66,12 +63,13 @@ export function createThreadCountColumns(data) {
   ]);
 }
 
-const syscallCountNames = ["hello", "fetch_deps"];
 export function createSyscallCountColumns(data) {
+  const propName = "syscall_count";
+  const syscallCountNames = Object.keys(data[data.length - 1][propName]);
   return syscallCountNames.map(name => [
     name,
     ...data.map(d => {
-      const syscallCountData = d["syscall_count"];
+      const syscallCountData = d[propName];
       if (!syscallCountData) {
         return null;
       }
@@ -80,13 +78,8 @@ export function createSyscallCountColumns(data) {
   ]);
 }
 
-const travisCompileTimeNames = ["duration_time"];
 function createTravisCompileTimeColumns(data) {
-  const columnsData = travisCompileTimeNames.map(name => [
-    name,
-    ...data.map(d => d.duration)
-  ]);
-  return columnsData;
+  return [["duration_time", ...data.map(d => d.duration)]];
 }
 
 export function createSha1List(data) {

--- a/website/app_test.js
+++ b/website/app_test.js
@@ -83,21 +83,31 @@ const irregularData = [
   {
     created_at: "2018-01-01T01:00:00Z",
     sha1: "123",
+    benchmark: {},
     binary_size: {},
-    benchmark: {
-      hello: {},
-      relative_import: {},
-      cold_hello: {},
-      cold_relative_import: {}
-    },
     thread_count: {},
     syscall_count: {}
   },
   {
     created_at: "2018-02-01T01:00:00Z",
     sha1: "456",
-    binary_size: 100000000,
-    benchmark: {}
+    benchmark: {
+      hello: {},
+      relative_import: {},
+      cold_hello: {},
+      cold_relative_import: {}
+    },
+    binary_size: {
+      deno: 1
+    },
+    thread_count: {
+      set_timeout: 5,
+      fetch_deps: 7
+    },
+    syscall_count: {
+      hello: 700,
+      fetch_deps: 800
+    }
   }
 ];
 
@@ -133,12 +143,7 @@ test(function createBinarySizeColumnsRegularData() {
 
 test(function createBinarySizeColumnsIrregularData() {
   const columns = createBinarySizeColumns(irregularData);
-  assertEqual(columns, [
-    ["deno", null, 100000000],
-    ["main.js", null, 0],
-    ["main.js.map", null, 0],
-    ["snapshot_deno.bin", null, 0]
-  ]);
+  assertEqual(columns, [["deno", null, 1]]);
 });
 
 test(function createThreadCountColumnsRegularData() {
@@ -148,10 +153,7 @@ test(function createThreadCountColumnsRegularData() {
 
 test(function createThreadCountColumnsIrregularData() {
   const columns = createThreadCountColumns(irregularData);
-  assertEqual(columns, [
-    ["set_timeout", null, null],
-    ["fetch_deps", null, null]
-  ]);
+  assertEqual(columns, [["set_timeout", null, 5], ["fetch_deps", null, 7]]);
 });
 
 test(function createSyscallCountColumnsRegularData() {
@@ -161,7 +163,7 @@ test(function createSyscallCountColumnsRegularData() {
 
 test(function createSyscallCountColumnsIrregularData() {
   const columns = createSyscallCountColumns(irregularData);
-  assertEqual(columns, [["hello", null, null], ["fetch_deps", null, null]]);
+  assertEqual(columns, [["hello", null, 700], ["fetch_deps", null, 800]]);
 });
 
 test(function createSha1ListRegularData() {


### PR DESCRIPTION
This PR implements the improvement of the benchmark viewer script which is suggested in https://github.com/denoland/deno/pull/889#issuecomment-426691747.

Now `//webapp/app.js` guesses the column names for each benchmark from the last record in the data. Now we can add a new column by just modifying `//tools/benchmark.py`.

(I chose `the last record` for guessing the column name because this would be convenient if we want to stop seeing some of the columns. In that case we can just remove the column from the latest benchmark data and the column disappears in the page.)
