### PR TITLE
Updates to js/* to clean up default library

### DIFF
--- a/js/blob.ts
+++ b/js/blob.ts
@@ -1,15 +1,18 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
-import { Blob, BlobPart, BlobPropertyBag } from "./dom_types";
+import * as domTypes from "./dom_types";
 import { containsOnlyASCII } from "./util";
 
 const bytesSymbol = Symbol("bytes");
 
-export class DenoBlob implements Blob {
+export class DenoBlob implements domTypes.Blob {
   private readonly [bytesSymbol]: Uint8Array;
   readonly size: number = 0;
   readonly type: string = "";
 
-  constructor(blobParts?: BlobPart[], options?: BlobPropertyBag) {
+  constructor(
+    blobParts?: domTypes.BlobPart[],
+    options?: domTypes.BlobPropertyBag
+  ) {
     if (arguments.length === 0) {
       this[bytesSymbol] = new Uint8Array();
       return;
@@ -53,8 +56,8 @@ export class DenoBlob implements Blob {
 }
 
 function processBlobParts(
-  blobParts: BlobPart[],
-  options: BlobPropertyBag
+  blobParts: domTypes.BlobPart[],
+  options: domTypes.BlobPropertyBag
 ): Uint8Array {
   const normalizeLineEndingsToNative = options.ending === "native";
   // ArrayBuffer.transfer is not yet implemented in V8, so we just have to
@@ -77,7 +80,7 @@ function processBlobParts(
 }
 
 function toUint8Arrays(
-  blobParts: BlobPart[],
+  blobParts: domTypes.BlobPart[],
   doNormalizeLineEndingsToNative: boolean
 ): Uint8Array[] {
   const ret: Uint8Array[] = [];

--- a/js/console.ts
+++ b/js/console.ts
@@ -149,6 +149,7 @@ function stringifyWithQuotes(
   }
 }
 
+// @internal
 export function stringifyArgs(
   // tslint:disable-next-line:no-any
   args: any[],
@@ -178,6 +179,7 @@ export function stringifyArgs(
 type PrintFunc = (x: string, isErr?: boolean) => void;
 
 export class Console {
+  // @internal
   constructor(private printFunc: PrintFunc) {}
 
   // tslint:disable-next-line:no-any

--- a/js/errors.ts
+++ b/js/errors.ts
@@ -1,25 +1,25 @@
-import * as msg from "gen/msg_generated";
+import { Base, ErrorKind } from "gen/msg_generated";
 export { ErrorKind } from "gen/msg_generated";
 
-// @internal
-export class DenoError<T extends msg.ErrorKind> extends Error {
-  constructor(readonly kind: T, errStr: string) {
-    super(errStr);
-    this.name = msg.ErrorKind[kind];
+export class DenoError<T extends ErrorKind> extends Error {
+  constructor(readonly kind: T, msg: string) {
+    super(msg);
+    this.name = ErrorKind[kind];
   }
 }
 
 // @internal
-export function maybeThrowError(base: msg.Base): void {
+export function maybeThrowError(base: Base): void {
   const err = maybeError(base);
   if (err != null) {
     throw err;
   }
 }
 
-export function maybeError(base: msg.Base): null | DenoError<msg.ErrorKind> {
+// @internal
+export function maybeError(base: Base): null | DenoError<ErrorKind> {
   const kind = base.errorKind();
-  if (kind === msg.ErrorKind.NoError) {
+  if (kind === ErrorKind.NoError) {
     return null;
   } else {
     return new DenoError(kind, base.error()!);

--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -10,23 +10,15 @@ import {
 import { flatbuffers } from "flatbuffers";
 import { sendAsync } from "./dispatch";
 import * as msg from "gen/msg_generated";
-import {
-  Headers,
-  Request,
-  Response,
-  Blob,
-  RequestInit,
-  HeadersInit,
-  FormData
-} from "./dom_types";
+import * as domTypes from "./dom_types";
 import { TextDecoder } from "./text_encoding";
 import { DenoBlob } from "./blob";
 
 // ref: https://fetch.spec.whatwg.org/#dom-headers
-export class DenoHeaders implements Headers {
+export class DenoHeaders implements domTypes.Headers {
   private headerMap: Map<string, string> = new Map();
 
-  constructor(init?: HeadersInit) {
+  constructor(init?: domTypes.HeadersInit) {
     if (arguments.length === 0 || init === undefined) {
       return;
     }
@@ -95,7 +87,7 @@ export class DenoHeaders implements Headers {
   }
 
   forEach(
-    callbackfn: (value: string, key: string, parent: Headers) => void,
+    callbackfn: (value: string, key: string, parent: domTypes.Headers) => void,
     // tslint:disable-next-line:no-any
     thisArg?: any
   ): void {
@@ -105,7 +97,7 @@ export class DenoHeaders implements Headers {
   }
 }
 
-class FetchResponse implements Response {
+class FetchResponse implements domTypes.Response {
   readonly url: string = "";
   body: null;
   bodyUsed = false; // TODO
@@ -113,7 +105,7 @@ class FetchResponse implements Response {
   readonly type = "basic"; // TODO
   redirected = false; // TODO
   headers: DenoHeaders;
-  readonly trailer: Promise<Headers>;
+  readonly trailer: Promise<domTypes.Headers>;
   //private bodyChunks: Uint8Array[] = [];
   private first = true;
   private bodyWaiter: Resolvable<ArrayBuffer>;
@@ -135,16 +127,16 @@ class FetchResponse implements Response {
     return this.bodyWaiter;
   }
 
-  async blob(): Promise<Blob> {
+  async blob(): Promise<domTypes.Blob> {
     const arrayBuffer = await this.arrayBuffer();
     return new DenoBlob([arrayBuffer], {
       type: this.headers.get("content-type") || ""
     });
   }
 
-  async formData(): Promise<FormData> {
+  async formData(): Promise<domTypes.FormData> {
     notImplemented();
-    return {} as FormData;
+    return {} as domTypes.FormData;
   }
 
   async json(): Promise<object> {
@@ -162,9 +154,9 @@ class FetchResponse implements Response {
     return 200 <= this.status && this.status < 300;
   }
 
-  clone(): Response {
+  clone(): domTypes.Response {
     notImplemented();
-    return {} as Response;
+    return {} as domTypes.Response;
   }
 
   onHeader?: (res: FetchResponse) => void;
@@ -187,9 +179,9 @@ class FetchResponse implements Response {
 }
 
 export async function fetch(
-  input?: Request | string,
-  init?: RequestInit
-): Promise<Response> {
+  input?: domTypes.Request | string,
+  init?: domTypes.RequestInit
+): Promise<domTypes.Response> {
   const url = input as string;
   log("dispatch FETCH_REQ", url);
 

--- a/js/file_info.ts
+++ b/js/file_info.ts
@@ -61,6 +61,7 @@ export interface FileInfo {
   isSymlink(): boolean;
 }
 
+// @internal
 export class FileInfoImpl implements FileInfo {
   readonly _isFile: boolean;
   readonly _isSymlink: boolean;

--- a/js/os.ts
+++ b/js/os.ts
@@ -15,6 +15,7 @@ export function exit(exitCode = 0): never {
   return util.unreachable();
 }
 
+// @internal
 export function codeFetch(
   moduleSpecifier: string,
   containingFile: string
@@ -44,6 +45,7 @@ export function codeFetch(
   };
 }
 
+// @internal
 export function codeCache(
   filename: string,
   sourceCode: string,

--- a/js/trace.ts
+++ b/js/trace.ts
@@ -41,6 +41,7 @@ function popStack(): TraceInfo[] {
 }
 
 // Push to trace stack if we are tracing
+// @internal
 export function maybePushTrace(op: msg.Any, sync: boolean): void {
   if (current === null) {
     return; // no trace requested

--- a/js/types.ts
+++ b/js/types.ts
@@ -1,6 +1,7 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 export type TypedArray = Uint8Array | Float32Array | Int32Array;
 
+// @internal
 export interface ModuleInfo {
   moduleName: string | null;
   filename: string | null;


### PR DESCRIPTION
Refs #632 

In preparation for supporting types, there are several minor "cleanups" of the `js/` modules that are part of the runtime which will make the internal default library "cleaner".