### PR TITLE
Fix passing Isolate between c and rust 

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -131,7 +131,7 @@ void deno_set_callback(Deno* deno, deno_sub_cb cb);
 // Get error text with deno_last_exception().
 // 0 = success, non-zero = failure.
 // TODO(ry) Currently the return code has opposite semantics.
-int deno_execute(Deno* d, const char* js_filename, const char* js_source);
+int deno_execute(Deno* d, void* user_data, const char* js_filename, const char* js_source);
 
 // This call doesn't go into JS. This is thread-safe.
 // TODO(ry) Currently this is called deno_pub. It should be renamed.

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -4,8 +4,18 @@
 export { env, exit } from "./os";
 export { File, open, stdin, stdout, stderr, read, write, close } from "./files";
 export {
-	copy, ReadResult, Reader, Writer, Closer, Seeker, ReaderCloser,
-	WriteCloser, ReadSeeker, WriteSeeker, ReadWriteCloser, ReadWriteSeeker,
+  copy,
+  ReadResult,
+  Reader,
+  Writer,
+  Closer,
+  Seeker,
+  ReaderCloser,
+  WriteCloser,
+  ReadSeeker,
+  WriteSeeker,
+  ReadWriteCloser,
+  ReadWriteSeeker
 } from "./io";
 export { mkdirSync, mkdir } from "./mkdir";
 export { makeTempDirSync, makeTempDir } from "./make_temp_dir";

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -413,7 +413,7 @@ void deno_init() {
   v8::V8::Initialize();
 }
 
-void* deno_get_data(Deno* d) { return d->data; }
+void* deno_get_data(Deno* d) { return d->user_data; }
 
 const char* deno_v8_version() { return v8::V8::GetVersion(); }
 

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -243,7 +243,7 @@ void Send(const v8::FunctionCallbackInfo<v8::Value>& args) {
   DCHECK_EQ(d->currentArgs, nullptr);
   d->currentArgs = &args;
 
-  d->cb(d, req_id, control, data);
+  d->cb(d->user_data, req_id, control, data);
 
   if (d->currentArgs == nullptr) {
     // This indicates that deno_repond() was called already.
@@ -429,11 +429,6 @@ void deno_init() {
   auto* p = v8::platform::CreateDefaultPlatform();
   v8::V8::InitializePlatform(p);
   v8::V8::Initialize();
-}
-
-void* deno_get_data(const Deno* d) {
-  CHECK(d->user_data != nullptr);
-  return d->user_data;
 }
 
 const char* deno_v8_version() { return v8::V8::GetVersion(); }

--- a/libdeno/deno.h
+++ b/libdeno/deno.h
@@ -30,7 +30,7 @@ void deno_init();
 const char* deno_v8_version();
 void deno_set_v8_flags(int* argc, char** argv);
 
-Deno* deno_new(void* user_data, deno_recv_cb cb);
+Deno* deno_new(deno_recv_cb cb);
 void deno_delete(Deno* d);
 
 // Returns the void* user_data provided in deno_new.
@@ -39,7 +39,8 @@ void* deno_get_data(Deno*);
 // Returns false on error.
 // Get error text with deno_last_exception().
 // 0 = fail, 1 = success
-int deno_execute(Deno* d, const char* js_filename, const char* js_source);
+int deno_execute(Deno* d, void* user_data, const char* js_filename,
+                 const char* js_source);
 
 // deno_respond sends up to one message back for every deno_recv_cb made.
 //
@@ -59,7 +60,7 @@ int deno_execute(Deno* d, const char* js_filename, const char* js_source);
 //
 // A non-zero return value, means a JS exception was encountered during the
 // libdeno.recv() callback. Check deno_last_exception() for exception text.
-int deno_respond(Deno* d, int32_t req_id, deno_buf buf);
+int deno_respond(Deno* d, void* user_data, int32_t req_id, deno_buf buf);
 
 const char* deno_last_exception(Deno* d);
 

--- a/libdeno/deno.h
+++ b/libdeno/deno.h
@@ -23,8 +23,8 @@ typedef struct deno_s Deno;
 // A callback to receive a message from a libdeno.send() javascript call.
 // control_buf is valid for only for the lifetime of this callback.
 // data_buf is valid until deno_respond() is called.
-typedef void (*deno_recv_cb)(Deno* d, int32_t req_id, deno_buf control_buf,
-                             deno_buf data_buf);
+typedef void (*deno_recv_cb)(void* user_data, int32_t req_id,
+                             deno_buf control_buf, deno_buf data_buf);
 
 void deno_init();
 const char* deno_v8_version();
@@ -32,9 +32,6 @@ void deno_set_v8_flags(int* argc, char** argv);
 
 Deno* deno_new(deno_recv_cb cb);
 void deno_delete(Deno* d);
-
-// Returns the void* user_data provided in deno_new.
-void* deno_get_data(Deno*);
 
 // Returns false on error.
 // Get error text with deno_last_exception().

--- a/libdeno/deno.h
+++ b/libdeno/deno.h
@@ -30,10 +30,10 @@ void deno_init();
 const char* deno_v8_version();
 void deno_set_v8_flags(int* argc, char** argv);
 
-Deno* deno_new(void* data, deno_recv_cb cb);
+Deno* deno_new(void* user_data, deno_recv_cb cb);
 void deno_delete(Deno* d);
 
-// Returns the void* data provided in deno_new.
+// Returns the void* user_data provided in deno_new.
 void* deno_get_data(Deno*);
 
 // Returns false on error.

--- a/libdeno/from_filesystem.cc
+++ b/libdeno/from_filesystem.cc
@@ -14,7 +14,7 @@
 
 namespace deno {
 
-Deno* NewFromFileSystem(void* data, deno_recv_cb cb) {
+Deno* NewFromFileSystem(void* user_data, deno_recv_cb cb) {
   std::string exe_path;
   CHECK(deno::ExePath(&exe_path));
   std::string exe_dir = deno::Dirname(exe_path);  // Always ends with a slash.
@@ -30,7 +30,7 @@ Deno* NewFromFileSystem(void* data, deno_recv_cb cb) {
   Deno* d = new Deno;
   d->currentArgs = nullptr;
   d->cb = cb;
-  d->data = data;
+  d->user_data = user_data;
   v8::Isolate::CreateParams params;
   params.array_buffer_allocator =
       v8::ArrayBuffer::Allocator::NewDefaultAllocator();
@@ -55,7 +55,7 @@ Deno* NewFromFileSystem(void* data, deno_recv_cb cb) {
 }  // namespace deno
 
 extern "C" {
-Deno* deno_new(void* data, deno_recv_cb cb) {
-  return deno::NewFromFileSystem(data, cb);
+Deno* deno_new(void* user_data, deno_recv_cb cb) {
+  return deno::NewFromFileSystem(user_data, cb);
 }
 }

--- a/libdeno/from_filesystem.cc
+++ b/libdeno/from_filesystem.cc
@@ -14,7 +14,7 @@
 
 namespace deno {
 
-Deno* NewFromFileSystem(void* user_data, deno_recv_cb cb) {
+Deno* NewFromFileSystem(deno_recv_cb cb) {
   std::string exe_path;
   CHECK(deno::ExePath(&exe_path));
   std::string exe_dir = deno::Dirname(exe_path);  // Always ends with a slash.
@@ -30,7 +30,7 @@ Deno* NewFromFileSystem(void* user_data, deno_recv_cb cb) {
   Deno* d = new Deno;
   d->currentArgs = nullptr;
   d->cb = cb;
-  d->user_data = user_data;
+  d->user_data = nullptr;
   v8::Isolate::CreateParams params;
   params.array_buffer_allocator =
       v8::ArrayBuffer::Allocator::NewDefaultAllocator();
@@ -55,7 +55,5 @@ Deno* NewFromFileSystem(void* user_data, deno_recv_cb cb) {
 }  // namespace deno
 
 extern "C" {
-Deno* deno_new(void* user_data, deno_recv_cb cb) {
-  return deno::NewFromFileSystem(user_data, cb);
-}
+Deno* deno_new(deno_recv_cb cb) { return deno::NewFromFileSystem(cb); }
 }

--- a/libdeno/from_snapshot.cc
+++ b/libdeno/from_snapshot.cc
@@ -43,11 +43,11 @@ void DeserializeInternalFields(v8::Local<v8::Object> holder, int index,
   deserialized_data.push_back(embedder_field);
 }
 
-Deno* NewFromSnapshot(void* data, deno_recv_cb cb) {
+Deno* NewFromSnapshot(void* user_data, deno_recv_cb cb) {
   Deno* d = new Deno;
   d->currentArgs = nullptr;
   d->cb = cb;
-  d->data = data;
+  d->user_data = user_data;
   v8::Isolate::CreateParams params;
   params.array_buffer_allocator =
       v8::ArrayBuffer::Allocator::NewDefaultAllocator();
@@ -80,7 +80,7 @@ Deno* NewFromSnapshot(void* data, deno_recv_cb cb) {
 }  // namespace deno
 
 extern "C" {
-Deno* deno_new(void* data, deno_recv_cb cb) {
-  return deno::NewFromSnapshot(data, cb);
+Deno* deno_new(void* user_data, deno_recv_cb cb) {
+  return deno::NewFromSnapshot(user_data, cb);
 }
 }

--- a/libdeno/from_snapshot.cc
+++ b/libdeno/from_snapshot.cc
@@ -43,11 +43,11 @@ void DeserializeInternalFields(v8::Local<v8::Object> holder, int index,
   deserialized_data.push_back(embedder_field);
 }
 
-Deno* NewFromSnapshot(void* user_data, deno_recv_cb cb) {
+Deno* NewFromSnapshot(deno_recv_cb cb) {
   Deno* d = new Deno;
   d->currentArgs = nullptr;
   d->cb = cb;
-  d->user_data = user_data;
+  d->user_data = nullptr;
   v8::Isolate::CreateParams params;
   params.array_buffer_allocator =
       v8::ArrayBuffer::Allocator::NewDefaultAllocator();
@@ -80,7 +80,5 @@ Deno* NewFromSnapshot(void* user_data, deno_recv_cb cb) {
 }  // namespace deno
 
 extern "C" {
-Deno* deno_new(void* user_data, deno_recv_cb cb) {
-  return deno::NewFromSnapshot(user_data, cb);
-}
+Deno* deno_new(deno_recv_cb cb) { return deno::NewFromSnapshot(cb); }
 }

--- a/libdeno/internal.h
+++ b/libdeno/internal.h
@@ -18,7 +18,7 @@ struct deno_s {
   v8::Persistent<v8::Map> async_data_map;
   deno_recv_cb cb;
   int32_t next_req_id;
-  void* data;
+  void* user_data;
 };
 }
 
@@ -37,7 +37,7 @@ static intptr_t external_references[] = {
     reinterpret_cast<intptr_t>(Send),
     reinterpret_cast<intptr_t>(SetGlobalErrorHandler), 0};
 
-Deno* NewFromSnapshot(void* data, deno_recv_cb cb);
+Deno* NewFromSnapshot(void* user_data, deno_recv_cb cb);
 
 void InitializeContext(v8::Isolate* isolate, v8::Local<v8::Context> context,
                        const char* js_filename, const std::string& js_source,

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -102,10 +102,7 @@ impl Isolate {
     });
 
     (*isolate).libdeno_isolate = unsafe {
-      libdeno::deno_new(
-        isolate.as_ref() as *const _ as *const c_void,
-        pre_dispatch,
-      )
+      libdeno::deno_new(isolate.as_mut() as *mut _ as *mut c_void, pre_dispatch)
     };
 
     isolate

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -44,12 +44,7 @@ pub struct Isolate {
   libdeno_isolate: *const libdeno::isolate,
   dispatch: Dispatch,
   rx: mpsc::Receiver<(i32, Buf)>,
-  // Although Isolate is only accessed on the main thread, we use an atomic
-  // variable here to workaround an issue probably caused by our poor usage
-  // of Box::leak in Isolate::from_c()
-  // https://github.com/denoland/deno/issues/919
-  // ntasks ought to be i32.
-  ntasks: atomic::AtomicIsize,
+  ntasks: i32,
   pub timeout_due: Option<Instant>,
   pub state: Arc<IsolateState>,
 }
@@ -91,7 +86,7 @@ impl Isolate {
       libdeno_isolate: 0 as *const libdeno::isolate,
       dispatch,
       rx,
-      ntasks: atomic::AtomicIsize::new(0),
+      ntasks: 0,
       timeout_due: None,
       state: Arc::new(IsolateState {
         dir: deno_dir::DenoDir::new(flags.reload, None).unwrap(),
@@ -195,18 +190,17 @@ impl Isolate {
   }
 
   fn ntasks_increment(&mut self) {
-    let previous_ntasks = self.ntasks.fetch_add(1, atomic::Ordering::SeqCst);
-    assert!(previous_ntasks >= 0);
+    assert!(self.ntasks >= 0);
+    self.ntasks = self.ntasks + 1;
   }
 
   fn ntasks_decrement(&mut self) {
-    let previous_ntasks = self.ntasks.fetch_sub(1, atomic::Ordering::SeqCst);
-    assert!(previous_ntasks >= 1);
+    self.ntasks = self.ntasks - 1;
+    assert!(self.ntasks >= 0);
   }
 
   fn is_idle(&self) -> bool {
-    let n = self.ntasks.load(atomic::Ordering::SeqCst);
-    n == 0 && self.timeout_due.is_none()
+    self.ntasks == 0 && self.timeout_due.is_none()
   }
 }
 

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -100,8 +100,8 @@ impl Isolate {
     self as *mut _ as *mut c_void
   }
 
-  pub fn from_c<'a>(d: *const libdeno::isolate) -> &'a mut Isolate {
-    let ptr = unsafe { libdeno::deno_get_data(d) } as *mut _;
+  pub fn from_void_ptr<'a>(ptr: *mut c_void) -> &'a mut Isolate {
+    let ptr = ptr as *mut _;
     unsafe { &mut *ptr }
   }
 
@@ -236,7 +236,7 @@ impl From<Buf> for libdeno::deno_buf {
 
 // Dereferences the C pointer into the Rust Isolate object.
 extern "C" fn pre_dispatch(
-  d: *const libdeno::isolate,
+  user_data: *mut c_void,
   req_id: i32,
   control_buf: libdeno::deno_buf,
   data_buf: libdeno::deno_buf,
@@ -256,7 +256,7 @@ extern "C" fn pre_dispatch(
     )
   };
 
-  let isolate = Isolate::from_c(d);
+  let isolate = Isolate::from_void_ptr(user_data);
   let dispatch = isolate.dispatch;
   let (is_sync, op) = dispatch(isolate, control_slice, data_slice);
 

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -30,13 +30,19 @@ extern "C" {
   pub fn deno_init();
   pub fn deno_v8_version() -> *const c_char;
   pub fn deno_set_v8_flags(argc: *mut c_int, argv: *mut *mut c_char);
-  pub fn deno_new(user_data: *mut c_void, cb: DenoRecvCb) -> *const isolate;
+  pub fn deno_new(cb: DenoRecvCb) -> *const isolate;
   pub fn deno_delete(i: *const isolate);
   pub fn deno_last_exception(i: *const isolate) -> *const c_char;
   pub fn deno_get_data(i: *const isolate) -> *mut c_void;
-  pub fn deno_respond(i: *const isolate, req_id: i32, buf: deno_buf);
+  pub fn deno_respond(
+    i: *const isolate,
+    user_data: *mut c_void,
+    req_id: i32,
+    buf: deno_buf,
+  );
   pub fn deno_execute(
     i: *const isolate,
+    user_data: *mut c_void,
     js_filename: *const c_char,
     js_source: *const c_char,
   ) -> c_int;

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -20,7 +20,7 @@ pub struct deno_buf {
 }
 
 type DenoRecvCb = unsafe extern "C" fn(
-  d: *const isolate,
+  user_data: *mut c_void,
   req_id: i32,
   buf: deno_buf,
   data_buf: deno_buf,
@@ -33,7 +33,6 @@ extern "C" {
   pub fn deno_new(cb: DenoRecvCb) -> *const isolate;
   pub fn deno_delete(i: *const isolate);
   pub fn deno_last_exception(i: *const isolate) -> *const c_char;
-  pub fn deno_get_data(i: *const isolate) -> *mut c_void;
   pub fn deno_respond(
     i: *const isolate,
     user_data: *mut c_void,

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -30,10 +30,10 @@ extern "C" {
   pub fn deno_init();
   pub fn deno_v8_version() -> *const c_char;
   pub fn deno_set_v8_flags(argc: *mut c_int, argv: *mut *mut c_char);
-  pub fn deno_new(data: *const c_void, cb: DenoRecvCb) -> *const isolate;
+  pub fn deno_new(user_data: *mut c_void, cb: DenoRecvCb) -> *const isolate;
   pub fn deno_delete(i: *const isolate);
   pub fn deno_last_exception(i: *const isolate) -> *const c_char;
-  pub fn deno_get_data(i: *const isolate) -> *const c_void;
+  pub fn deno_get_data(i: *const isolate) -> *mut c_void;
   pub fn deno_respond(i: *const isolate, req_id: i32, buf: deno_buf);
   pub fn deno_execute(
     i: *const isolate,


### PR DESCRIPTION
I'm not super sure about the rename from `data` to `isolate_data`, it is still very ambiguous. 
Maybe it should be `callback_data` or `user_data` or `embedder_data` instead.