### PR TITLE
Upgrade hyper-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ dirs = "1.0.3"
 flatbuffers = { path = "third_party/flatbuffers/rust/flatbuffers/" }
 futures = "0.1.23"
 hyper = "0.12.9"
-hyper-rustls = "0.14.0"
+# The current version of hyper-rustls, 0.14.0, depends on tokio-core, which is
+# deprecated.
+hyper-rustls = { git = "https://github.com/ctz/hyper-rustls.git" }
 libc = "0.2.42"
 log = "0.4.4"
 rand = "0.4.3"

--- a/build_extra/rust/BUILD.gn
+++ b/build_extra/rust/BUILD.gn
@@ -426,23 +426,6 @@ rust_crate("hyper") {
   ]
 }
 
-rust_crate("tokio_core") {
-  source_root = "$registry_github/tokio-core-0.1.17/src/lib.rs"
-  extern = [
-    ":mio",
-    ":futures",
-    ":tokio",
-    ":tokio_executor",
-    ":tokio_reactor",
-    ":tokio_timer",
-    ":tokio_io",
-    ":log",
-    ":iovec",
-    ":bytes",
-    ":scoped_tls",
-  ]
-}
-
 rust_crate("h2") {
   source_root = "$registry_github/h2-0.1.12/src/lib.rs"
   extern = [
@@ -659,14 +642,14 @@ rust_crate("tokio_current_thread") {
 }
 
 rust_crate("hyper_rustls") {
-  source_root = "$registry_github/hyper-rustls-0.14.0/src/lib.rs"
+  source_root =
+      "$crates/git/checkouts/hyper-rustls-d4ca51501db57c63/2c536d5/src/lib.rs"
   extern = [
     ":ct_logs",
     ":futures",
     ":http",
     ":hyper",
     ":rustls",
-    ":tokio_core",
     ":tokio_io",
     ":tokio_rustls",
     ":tokio_tcp",


### PR DESCRIPTION
This removes tokio-core, which was deprecated.

<!--

Thank you for your pull request. Before submitting, please make sure the following is done.

1. Ensure ./tools/test.py passes.
2. Format your code with ./tools/format.py
3. Make sure ./tools/lint.py passes.

-->
