### PR TITLE
Handle promise reject handler added later issue

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -90,6 +90,7 @@ ts_sources = [
   "js/os.ts",
   "js/platform.ts",
   "js/plugins.d.ts",
+  "js/promise_util.ts",
   "js/read_dir.ts",
   "js/read_file.ts",
   "js/read_link.ts",

--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -37,7 +37,7 @@ interface Libdeno {
     ) => void
   ) => void;
 
-  setPromiseExaminer: (handler: () => void) => number;
+  setPromiseErrorExaminer: (handler: () => void) => number;
 
   constants: {
     promiseRejectEvents: PromiseRejectEvents;

--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -3,6 +3,11 @@ import { globalEval } from "./global_eval";
 
 // The libdeno functions are moved so that users can't access them.
 type MessageCallback = (msg: Uint8Array) => void;
+export type PromiseRejectEvent =
+  | "RejectWithNoHandler"
+  | "HandlerAddedAfterReject"
+  | "ResolveAfterResolved"
+  | "RejectAfterResolved";
 
 interface Libdeno {
   recv(cb: MessageCallback): void;
@@ -24,7 +29,7 @@ interface Libdeno {
   setPromiseRejectHandler: (
     handler: (
       error: Error | string,
-      event: number,
+      event: PromiseRejectEvent,
       /* tslint:disable-next-line:no-any */
       promise: Promise<any>
     ) => void
@@ -34,12 +39,6 @@ interface Libdeno {
 
   mainSource: string;
   mainSourceMap: RawSourceMap;
-
-  // Promise Reject Events
-  kPromiseRejectWithNoHandler: number;
-  kPromiseHandlerAddedAfterReject: number;
-  kPromiseResolveAfterResolved: number;
-  kPromiseRejectAfterResolved: number;
 }
 
 const window = globalEval("this");

--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -3,6 +3,14 @@ import { globalEval } from "./global_eval";
 
 // The libdeno functions are moved so that users can't access them.
 type MessageCallback = (msg: Uint8Array) => void;
+
+interface PromiseRejectEvents {
+  kPromiseRejectWithNoHandler: number;
+  kPromiseHandlerAddedAfterReject: number;
+  kPromiseResolveAfterResolved: number;
+  kPromiseRejectAfterResolved: number;
+}
+
 interface Libdeno {
   recv(cb: MessageCallback): void;
 
@@ -19,6 +27,21 @@ interface Libdeno {
       error: Error
     ) => void
   ) => void;
+
+  setPromiseRejectHandler: (
+    handler: (
+      error: Error,
+      event: number,
+      /* tslint:disable-next-line:no-any */
+      promise: Promise<any>
+    ) => void
+  ) => void;
+
+  setPromiseExaminer: (handler: () => void) => number;
+
+  constants: {
+    promiseRejectEvents: PromiseRejectEvents;
+  };
 
   mainSource: string;
   mainSourceMap: RawSourceMap;

--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -4,13 +4,6 @@ import { globalEval } from "./global_eval";
 // The libdeno functions are moved so that users can't access them.
 type MessageCallback = (msg: Uint8Array) => void;
 
-interface PromiseRejectEvents {
-  kPromiseRejectWithNoHandler: number;
-  kPromiseHandlerAddedAfterReject: number;
-  kPromiseResolveAfterResolved: number;
-  kPromiseRejectAfterResolved: number;
-}
-
 interface Libdeno {
   recv(cb: MessageCallback): void;
 
@@ -30,21 +23,23 @@ interface Libdeno {
 
   setPromiseRejectHandler: (
     handler: (
-      error: Error,
+      error: Error | string,
       event: number,
       /* tslint:disable-next-line:no-any */
       promise: Promise<any>
     ) => void
   ) => void;
 
-  setPromiseErrorExaminer: (handler: () => void) => number;
-
-  constants: {
-    promiseRejectEvents: PromiseRejectEvents;
-  };
+  setPromiseErrorExaminer: (handler: () => boolean) => void;
 
   mainSource: string;
   mainSourceMap: RawSourceMap;
+
+  // Promise Reject Events
+  kPromiseRejectWithNoHandler: number;
+  kPromiseHandlerAddedAfterReject: number;
+  kPromiseResolveAfterResolved: number;
+  kPromiseRejectAfterResolved: number;
 }
 
 const window = globalEval("this");

--- a/js/main.ts
+++ b/js/main.ts
@@ -7,6 +7,7 @@ import { DenoCompiler } from "./compiler";
 import { libdeno } from "./libdeno";
 import { args } from "./deno";
 import { sendSync, handleAsyncMsgFromRust } from "./dispatch";
+import { promiseExaminer, promiseRejectHandler } from "./promise_util";
 
 function sendStart(): msg.StartRes {
   const builder = new flatbuffers.Builder();
@@ -39,6 +40,8 @@ function onGlobalError(
 export default function denoMain() {
   libdeno.recv(handleAsyncMsgFromRust);
   libdeno.setGlobalErrorHandler(onGlobalError);
+  libdeno.setPromiseRejectHandler(promiseRejectHandler);
+  libdeno.setPromiseExaminer(promiseExaminer);
   const compiler = DenoCompiler.instance();
 
   // First we send an empty "Start" message to let the privileged side know we

--- a/js/main.ts
+++ b/js/main.ts
@@ -7,7 +7,7 @@ import { DenoCompiler } from "./compiler";
 import { libdeno } from "./libdeno";
 import { args } from "./deno";
 import { sendSync, handleAsyncMsgFromRust } from "./dispatch";
-import { promiseExaminer, promiseRejectHandler } from "./promise_util";
+import { promiseErrorExaminer, promiseRejectHandler } from "./promise_util";
 
 function sendStart(): msg.StartRes {
   const builder = new flatbuffers.Builder();
@@ -41,7 +41,7 @@ export default function denoMain() {
   libdeno.recv(handleAsyncMsgFromRust);
   libdeno.setGlobalErrorHandler(onGlobalError);
   libdeno.setPromiseRejectHandler(promiseRejectHandler);
-  libdeno.setPromiseExaminer(promiseExaminer);
+  libdeno.setPromiseErrorExaminer(promiseErrorExaminer);
   const compiler = DenoCompiler.instance();
 
   // First we send an empty "Start" message to let the privileged side know we

--- a/js/promise_util.ts
+++ b/js/promise_util.ts
@@ -31,7 +31,7 @@ export function promiseRejectHandler(
 }
 
 // Return 0 when continue, 1 to die
-export function promiseExaminer(): number {
+export function promiseErrorExaminer(): number {
   if (otherPromiseErrorMap.size > 0) {
     for (const msg of otherPromiseErrorMap.values()) {
       console.log(msg);

--- a/js/promise_util.ts
+++ b/js/promise_util.ts
@@ -1,0 +1,49 @@
+import { libdeno } from "./libdeno";
+
+const promiseRejectEvents = libdeno.constants.promiseRejectEvents;
+
+/* tslint:disable-next-line:no-any */
+const promiseRejectMap = new Map<Promise<any>, string>();
+/* tslint:disable-next-line:no-any */
+const otherPromiseErrorMap = new Map<Promise<any>, string>();
+
+export function promiseRejectHandler(
+  /* tslint:disable-next-line:no-any */
+  error: any,
+  event: number,
+  /* tslint:disable-next-line:no-any */
+  promise: Promise<any>
+) {
+  switch (event) {
+    case promiseRejectEvents.kPromiseRejectWithNoHandler:
+      promiseRejectMap.set(
+        promise,
+        error.stack || "PromiseRejectWithNoHandler"
+      );
+      break;
+    case promiseRejectEvents.kPromiseHandlerAddedAfterReject:
+      promiseRejectMap.delete(promise);
+      break;
+    default:
+      // error is string here
+      otherPromiseErrorMap.set(promise, `Promise error: ${error}`);
+  }
+}
+
+// Return 0 when continue, 1 to die
+export function promiseExaminer(): number {
+  if (otherPromiseErrorMap.size > 0) {
+    for (const msg of otherPromiseErrorMap.values()) {
+      console.log(msg);
+    }
+    otherPromiseErrorMap.clear();
+  }
+  if (promiseRejectMap.size > 0) {
+    for (const msg of promiseRejectMap.values()) {
+      console.log(msg);
+    }
+    promiseRejectMap.clear();
+    return 1;
+  }
+  return 0;
+}

--- a/js/promise_util.ts
+++ b/js/promise_util.ts
@@ -1,4 +1,4 @@
-import { libdeno } from "./libdeno";
+import { PromiseRejectEvent } from "./libdeno";
 
 /* tslint:disable-next-line:no-any */
 const rejectMap = new Map<Promise<any>, string>();
@@ -10,18 +10,15 @@ const otherErrorMap = new Map<Promise<any>, string>();
 
 export function promiseRejectHandler(
   error: Error | string,
-  event: number,
+  event: PromiseRejectEvent,
   /* tslint:disable-next-line:no-any */
   promise: Promise<any>
 ) {
   switch (event) {
-    case libdeno.kPromiseRejectWithNoHandler:
-      rejectMap.set(
-        promise,
-        (error as Error).stack || "PromiseRejectWithNoHandler"
-      );
+    case "RejectWithNoHandler":
+      rejectMap.set(promise, (error as Error).stack || "RejectWithNoHandler");
       break;
-    case libdeno.kPromiseHandlerAddedAfterReject:
+    case "HandlerAddedAfterReject":
       rejectMap.delete(promise);
       break;
     default:

--- a/libdeno/deno.h
+++ b/libdeno/deno.h
@@ -59,6 +59,8 @@ int deno_execute(Deno* d, void* user_data, const char* js_filename,
 // libdeno.recv() callback. Check deno_last_exception() for exception text.
 int deno_respond(Deno* d, void* user_data, int32_t req_id, deno_buf buf);
 
+void deno_check_promise_reject_events(Deno* d);
+
 const char* deno_last_exception(Deno* d);
 
 void deno_terminate_execution(Deno* d);

--- a/libdeno/deno.h
+++ b/libdeno/deno.h
@@ -59,7 +59,7 @@ int deno_execute(Deno* d, void* user_data, const char* js_filename,
 // libdeno.recv() callback. Check deno_last_exception() for exception text.
 int deno_respond(Deno* d, void* user_data, int32_t req_id, deno_buf buf);
 
-void deno_check_promise_reject_events(Deno* d);
+void deno_check_promise_errors(Deno* d);
 
 const char* deno_last_exception(Deno* d);
 

--- a/libdeno/internal.h
+++ b/libdeno/internal.h
@@ -15,7 +15,7 @@ struct deno_s {
   v8::Persistent<v8::Function> recv;
   v8::Persistent<v8::Function> global_error_handler;
   v8::Persistent<v8::Function> promise_reject_handler;
-  v8::Persistent<v8::Function> promise_examiner;
+  v8::Persistent<v8::Function> promise_error_examiner;
   int32_t pending_promise_events;
   v8::Persistent<v8::Context> context;
   v8::Persistent<v8::Map> async_data_map;
@@ -36,14 +36,14 @@ void Recv(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Send(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SetGlobalErrorHandler(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SetPromiseRejectHandler(const v8::FunctionCallbackInfo<v8::Value>& args);
-void SetPromiseExaminer(const v8::FunctionCallbackInfo<v8::Value>& args);
+void SetPromiseErrorExaminer(const v8::FunctionCallbackInfo<v8::Value>& args);
 static intptr_t external_references[] = {
     reinterpret_cast<intptr_t>(Print),
     reinterpret_cast<intptr_t>(Recv),
     reinterpret_cast<intptr_t>(Send),
     reinterpret_cast<intptr_t>(SetGlobalErrorHandler),
     reinterpret_cast<intptr_t>(SetPromiseRejectHandler),
-    reinterpret_cast<intptr_t>(SetPromiseExaminer),
+    reinterpret_cast<intptr_t>(SetPromiseErrorExaminer),
     0};
 
 Deno* NewFromSnapshot(void* user_data, deno_recv_cb cb);

--- a/libdeno/internal.h
+++ b/libdeno/internal.h
@@ -14,6 +14,9 @@ struct deno_s {
   std::string last_exception;
   v8::Persistent<v8::Function> recv;
   v8::Persistent<v8::Function> global_error_handler;
+  v8::Persistent<v8::Function> promise_reject_handler;
+  v8::Persistent<v8::Function> promise_examiner;
+  int32_t pending_promise_events;
   v8::Persistent<v8::Context> context;
   v8::Persistent<v8::Map> async_data_map;
   deno_recv_cb cb;
@@ -32,10 +35,16 @@ void Print(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Recv(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Send(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SetGlobalErrorHandler(const v8::FunctionCallbackInfo<v8::Value>& args);
+void SetPromiseRejectHandler(const v8::FunctionCallbackInfo<v8::Value>& args);
+void SetPromiseExaminer(const v8::FunctionCallbackInfo<v8::Value>& args);
 static intptr_t external_references[] = {
-    reinterpret_cast<intptr_t>(Print), reinterpret_cast<intptr_t>(Recv),
+    reinterpret_cast<intptr_t>(Print),
+    reinterpret_cast<intptr_t>(Recv),
     reinterpret_cast<intptr_t>(Send),
-    reinterpret_cast<intptr_t>(SetGlobalErrorHandler), 0};
+    reinterpret_cast<intptr_t>(SetGlobalErrorHandler),
+    reinterpret_cast<intptr_t>(SetPromiseRejectHandler),
+    reinterpret_cast<intptr_t>(SetPromiseExaminer),
+    0};
 
 Deno* NewFromSnapshot(void* user_data, deno_recv_cb cb);
 

--- a/libdeno/libdeno_test.cc
+++ b/libdeno/libdeno_test.cc
@@ -193,3 +193,15 @@ TEST(LibDenoTest, DataBuf) {
   EXPECT_EQ(data_buf_copy.data_ptr[1], 8);
   deno_delete(d);
 }
+
+TEST(LibDenoTest, PromiseRejectCatchHandling) {
+  static int count = 0;
+  Deno* d = deno_new([](auto _, int req_id, auto buf, auto data_buf) {
+    // If no error, nothing should be sent, and count should not increment
+    count++;
+  });
+  EXPECT_TRUE(deno_execute(d, nullptr, "a.js", "PromiseRejectCatchHandling()"));
+
+  EXPECT_EQ(count, 0);
+  deno_delete(d);
+}

--- a/libdeno/libdeno_test.js
+++ b/libdeno/libdeno_test.js
@@ -148,12 +148,12 @@ global.PromiseRejectCatchHandling = () => {
   });
   libdeno.setPromiseRejectHandler((error, event, promise) => {
     count++;
-    if (event === libdeno.constants.promiseRejectEvents.kPromiseRejectWithNoHandler) {
+    if (event === libdeno.kPromiseRejectWithNoHandler) {
       assertOrSend(error instanceof Error);
       assertOrSend(error.message === "message");
       assertOrSend(count === 1);
       promiseRef = promise;
-    } else if (event === libdeno.constants.promiseRejectEvents.kPromiseHandlerAddedAfterReject) {
+    } else if (event === libdeno.kPromiseHandlerAddedAfterReject) {
       assertOrSend(count === 2);
       assertOrSend(promiseRef === promise);
     }

--- a/libdeno/libdeno_test.js
+++ b/libdeno/libdeno_test.js
@@ -133,3 +133,43 @@ global.DataBuf = () => {
   b[0] = 9;
   b[1] = 8;
 };
+
+global.PromiseRejectCatchHandling = () => {
+  let count = 0;
+  let promiseRef = null;
+  // When we have an error, libdeno sends something
+  function assertOrSend(cond) {
+    if (!cond) {
+      libdeno.send(new Uint8Array([42]));
+    }
+  }
+  libdeno.setPromiseExaminer(() => {
+    assertOrSend(count === 2);
+  });
+  libdeno.setPromiseRejectHandler((error, event, promise) => {
+    count++;
+    if (event === libdeno.constants.promiseRejectEvents.kPromiseRejectWithNoHandler) {
+      assertOrSend(error instanceof Error);
+      assertOrSend(error.message === "message");
+      assertOrSend(count === 1);
+      promiseRef = promise;
+    } else if (event === libdeno.constants.promiseRejectEvents.kPromiseHandlerAddedAfterReject) {
+      assertOrSend(count === 2);
+      assertOrSend(promiseRef === promise);
+    }
+    // Should never reach 3!
+    assertOrSend(count !== 3);
+  });
+
+  async function fn() {
+    throw new Error("message");
+  }
+
+  (async () => {
+    try {
+      await fn();
+    } catch (e) {
+      assertOrSend(count === 2);
+    }
+  })();
+}

--- a/libdeno/libdeno_test.js
+++ b/libdeno/libdeno_test.js
@@ -148,12 +148,12 @@ global.PromiseRejectCatchHandling = () => {
   });
   libdeno.setPromiseRejectHandler((error, event, promise) => {
     count++;
-    if (event === libdeno.kPromiseRejectWithNoHandler) {
+    if (event === "RejectWithNoHandler") {
       assertOrSend(error instanceof Error);
       assertOrSend(error.message === "message");
       assertOrSend(count === 1);
       promiseRef = promise;
-    } else if (event === libdeno.kPromiseHandlerAddedAfterReject) {
+    } else if (event === "HandlerAddedAfterReject") {
       assertOrSend(count === 2);
       assertOrSend(promiseRef === promise);
     }

--- a/libdeno/libdeno_test.js
+++ b/libdeno/libdeno_test.js
@@ -143,7 +143,7 @@ global.PromiseRejectCatchHandling = () => {
       libdeno.send(new Uint8Array([42]));
     }
   }
-  libdeno.setPromiseExaminer(() => {
+  libdeno.setPromiseErrorExaminer(() => {
     assertOrSend(count === 2);
   });
   libdeno.setPromiseRejectHandler((error, event, promise) => {

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -166,6 +166,12 @@ impl Isolate {
     }
   }
 
+  fn check_promise_reject_events(&self) {
+    unsafe {
+      libdeno::deno_check_promise_reject_events(self.libdeno_isolate);
+    }
+  }
+
   // TODO Use Park abstraction? Note at time of writing Tokio default runtime
   // does not have new_with_park().
   pub fn event_loop(&mut self) {
@@ -176,7 +182,10 @@ impl Isolate {
         Err(mpsc::RecvTimeoutError::Timeout) => self.timeout(),
         Err(e) => panic!("recv_deadline() failed: {:?}", e),
       }
+      self.check_promise_reject_events();
     }
+    // Check on done
+    self.check_promise_reject_events();
   }
 
   fn ntasks_increment(&mut self) {

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -166,9 +166,9 @@ impl Isolate {
     }
   }
 
-  fn check_promise_reject_events(&self) {
+  fn check_promise_errors(&self) {
     unsafe {
-      libdeno::deno_check_promise_reject_events(self.libdeno_isolate);
+      libdeno::deno_check_promise_errors(self.libdeno_isolate);
     }
   }
 
@@ -182,10 +182,10 @@ impl Isolate {
         Err(mpsc::RecvTimeoutError::Timeout) => self.timeout(),
         Err(e) => panic!("recv_deadline() failed: {:?}", e),
       }
-      self.check_promise_reject_events();
+      self.check_promise_errors();
     }
     // Check on done
-    self.check_promise_reject_events();
+    self.check_promise_errors();
   }
 
   fn ntasks_increment(&mut self) {

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -33,7 +33,7 @@ extern "C" {
   pub fn deno_new(cb: DenoRecvCb) -> *const isolate;
   pub fn deno_delete(i: *const isolate);
   pub fn deno_last_exception(i: *const isolate) -> *const c_char;
-  pub fn deno_check_promise_reject_events(i: *const isolate);
+  pub fn deno_check_promise_errors(i: *const isolate);
   pub fn deno_respond(
     i: *const isolate,
     user_data: *mut c_void,

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -33,6 +33,7 @@ extern "C" {
   pub fn deno_new(cb: DenoRecvCb) -> *const isolate;
   pub fn deno_delete(i: *const isolate);
   pub fn deno_last_exception(i: *const isolate) -> *const c_char;
+  pub fn deno_check_promise_reject_events(i: *const isolate);
   pub fn deno_respond(
     i: *const isolate,
     user_data: *mut c_void,

--- a/tests/018_async_catch.ts
+++ b/tests/018_async_catch.ts
@@ -1,0 +1,14 @@
+async function fn() {
+  throw new Error("message");
+}
+async function call() {
+  try {
+    console.log("before await fn()");
+    await fn();
+    console.log("after await fn()");
+  } catch (error) {
+    console.log("catch");
+  }
+  console.log("after try-catch");
+}
+call().catch(() => console.log("outer catch"));

--- a/tests/018_async_catch.ts.out
+++ b/tests/018_async_catch.ts.out
@@ -1,0 +1,3 @@
+before await fn()
+catch
+after try-catch

--- a/tests/async_error.ts.out
+++ b/tests/async_error.ts.out
@@ -1,5 +1,6 @@
 hello
 before error
+world
 Error: error
     at foo ([WILDCARD]tests/async_error.ts:4:9)
     at eval ([WILDCARD]tests/async_error.ts:7:1)


### PR DESCRIPTION
Closes #936
Rationale see #936 comments (handler implementation moved to TS side).

v8 [emits `kPromiseHandlerAddedAfterReject`](https://v8.paulfryzel.com/docs/master/classv8_1_1_isolate.html#a702f0ba4e5dee8a98aeb92239d58784e) when a catch block is found in async function, that cancels a previous `kPromiseRejectWithNoHandler`. Postpone error handling and exit to the end of each event loop cycle. `tests/async_error.ts.out` actually now matches that running under Node. ("world" is printed first: error handling only happens after script running to its end)

An alternative C++ only implementation could be found [here](https://github.com/kevinkassimo/deno/commit/a60f3d45df162e3e1dd9481ff93af175c55aab29)