### PR TITLE
perf: Increase copy() buffer to 32k

### DIFF
--- a/js/io.ts
+++ b/js/io.ts
@@ -101,7 +101,7 @@ export interface ReadWriteSeeker extends Reader, Writer, Seeker {}
 // https://golang.org/pkg/io/#Copy
 export async function copy(dst: Writer, src: Reader): Promise<number> {
   let n = 0;
-  const b = new Uint8Array(1024);
+  const b = new Uint8Array(32*1024);
   let gotEOF = false;
   while (gotEOF === false) {
     const result = await src.read(b);


### PR DESCRIPTION
This will improve the threshold benchmark. Using 32k because that's what
Go uses, but we should explore the value in the future.
https://github.com/golang/go/blob/a0d6420d8be2ae7164797051ec74fa2a2df466a1/src/io/io.go#L391

<!--

Thank you for your pull request. Before submitting, please make sure the following is done.

1. Ensure ./tools/test.py passes.
2. Format your code with ./tools/format.py
3. Make sure ./tools/lint.py passes.

-->
