### PR TITLE
Fix a binary size regression

### DIFF
--- a/.gn
+++ b/.gn
@@ -32,10 +32,6 @@ default_args = {
   treat_warnings_as_errors = false
   rust_treat_warnings_as_errors = true
 
-  # Enable Jumbo build by default
-  # https://chromium.googlesource.com/chromium/src/+/master/docs/jumbo.md
-  use_jumbo_build = true
-
   # https://cs.chromium.org/chromium/src/docs/ccache_mac.md
   clang_use_chrome_plugins = false
 

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -104,7 +104,9 @@ def generate_gn_args(mode):
     if mode == "release":
         out += ["is_official_build=true"]
     elif mode == "debug":
-        pass
+        # Enable Jumbo build by default in debug mode for faster build.
+        # https://chromium.googlesource.com/chromium/src/+/master/docs/jumbo.md
+        out += ["use_jumbo_build=true"]
     else:
         print "Bad mode {}. Use 'release' or 'debug' (default)" % mode
         sys.exit(1)


### PR DESCRIPTION
This patch changes Jumbo build to use only in debug mode.

Refs: https://github.com/denoland/deno/commit/dc8841d8a98122d762ec21ed119dbcc2f78e7300#commitcomment-30907372

<!--

Thank you for your pull request. Before submitting, please make sure the following is done.

1. Ensure ./tools/test.py passes.
2. Format your code with ./tools/format.py
3. Make sure ./tools/lint.py passes.

And please read: https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md

-->
