### PR TITLE
Inject typescript version from package.json during build through env! (`deno -v`)

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -4,6 +4,7 @@ use std::ffi::CStr;
 
 // This is the source of truth for the Deno version. Ignore the value in Cargo.toml.
 const DENO_VERSION: &str = "0.1.8";
+const TYPESCRIPT_VERSION: &'static str = env!("TYPESCRIPT_VERSION");
 
 pub fn print_version() {
   let v = unsafe { libdeno::deno_v8_version() };
@@ -11,4 +12,5 @@ pub fn print_version() {
   let version = c_str.to_str().unwrap();
   println!("deno: {}", DENO_VERSION);
   println!("v8: {}", version);
+  println!("typescript: {}", TYPESCRIPT_VERSION);
 }

--- a/tools/build.py
+++ b/tools/build.py
@@ -4,7 +4,8 @@ from __future__ import print_function
 import os
 import sys
 import third_party
-from util import build_path, enable_ansi_colors, run
+from util import build_path, enable_ansi_colors, run, make_env
+import package_json
 
 enable_ansi_colors()
 
@@ -18,6 +19,10 @@ if not "-C" in ninja_args:
         sys.exit(1)
     ninja_args = ["-C", build_path()] + ninja_args
 
+package_json_env = {
+    "TYPESCRIPT_VERSION": package_json.get_typescript_version()
+}
+
 run([third_party.ninja_path] + ninja_args,
-    env=third_party.google_env(),
+    env=make_env(package_json_env, third_party.google_env()),
     quiet=True)

--- a/tools/deno_dir_test.py
+++ b/tools/deno_dir_test.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from util import rmtree, run
 
+
 def deno_dir_test(deno_exe, deno_dir):
     assert os.path.isfile(deno_exe)
 
@@ -29,13 +30,14 @@ def deno_dir_test(deno_exe, deno_dir):
     rmtree(deno_dir)
 
     if old_deno_dir is not None:
-      os.environ["DENO_DIR"] = old_deno_dir
+        os.environ["DENO_DIR"] = old_deno_dir
 
 
 def run_deno(deno_exe, deno_dir=None):
     cmd = [deno_exe, "tests/002_hello.ts"]
     deno_dir_env = {"DENO_DIR": deno_dir} if deno_dir is not None else None
     run(cmd, quiet=True, env=deno_dir_env)
+
 
 def main(argv):
     if len(sys.argv) != 3:

--- a/tools/package_json.py
+++ b/tools/package_json.py
@@ -1,0 +1,10 @@
+import json
+import os
+
+root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+
+def get_typescript_version():
+    with open(os.path.join(root_path, 'package.json')) as f:
+        package_json_data = json.load(f)
+        return package_json_data["devDependencies"]["typescript"]

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -4,6 +4,7 @@ import sys
 import subprocess
 import re
 
+
 def run_unit_test2(cmd):
     process = subprocess.Popen(
         cmd,
@@ -25,6 +26,7 @@ def run_unit_test2(cmd):
     errcode = process.returncode
     if errcode != 0:
         sys.exit(errcode)
+
 
 def run_unit_test(deno_exe, permStr, flags=[]):
     cmd = [deno_exe, "--reload", "js/unit_tests.ts", permStr] + flags
@@ -48,9 +50,7 @@ def unit_tests(deno_exe):
     # These are not strictly unit tests for Deno, but for ts_library_builder.
     # They run under Node, but use the same //js/testing/ library.
     run_unit_test2([
-        "node",
-        "./node_modules/.bin/ts-node",
-        "--project",
+        "node", "./node_modules/.bin/ts-node", "--project",
         "tools/ts_library_builder/tsconfig.json",
         "tools/ts_library_builder/test.ts"
     ])


### PR DESCRIPTION
Closes #993 

Instead of adding new bindings or change `msg.Start` formats (which requires us to run `isolate.execute("deno_main.js", "denoMain();")`), we should be able to inject the version during compilation from `package.json`