### PR TITLE
Remove DENO_BUILD_MODE environment variable

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,6 @@ clone_depth: 1
 
 environment:
   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  DENO_BUILD_MODE: release
   DENO_BUILD_PATH: $(APPVEYOR_BUILD_FOLDER)\out\release
   DENO_THIRD_PARTY_PATH: $(APPVEYOR_BUILD_FOLDER)\third_party
   MTIME_CACHE_DB: $(APPVEYOR_BUILD_FOLDER)\mtime_cache.xml
@@ -347,7 +346,7 @@ before_build:
   - ps: Start-TraceFilesNeeded $env:DENO_BUILD_PATH -Recurse
 
   # Download clang and gn, generate ninja files.
-  - python tools\setup.py
+  - python tools\setup.py --release
   - ps: Set-FilesNeeded -Auto -Reason "Setup finished"
 
   # Mark files that are produced during the build, and are known to ninja, as
@@ -359,7 +358,7 @@ before_build:
       Set-FilesNeeded -Auto -Path $outputs -Reason "Build dependency graph"
 
 build_script:
-  - python tools\build.py
+  - python tools\build.py --release
   - ps: Set-FilesNeeded -Auto -Reason "Build finished"
 
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
   - HOMEBREW_PATH=$HOME/homebrew/
   - DENO_BUILD_ARGS="use_custom_libcxx=false use_sysroot=false"
   - DENO_BUILD_PATH=$HOME/out/Default
-  - DENO_BUILD_MODE=release
   - PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH
   - CCACHE_CPP2=yes
   - CCACHE_SLOPPINESS=time_macros
@@ -83,11 +82,11 @@ install:
   rm -rf "$RUSTUP_HOME"toolchains/*/etc
   rm -rf "$RUSTUP_HOME"toolchains/*/share
 before_script:
-- ./tools/setup.py
+- ./tools/setup.py --release
 script:
 - ./tools/lint.py
 - bash -c "sleep 2100; pkill ninja" &
-- ./tools/build.py -j2
+- ./tools/build.py --release -j2
 - ./tools/test.py $DENO_BUILD_PATH
 after_script:
 - ccache --show-stats

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Other useful commands:
     # Call ninja manually.
     ./third_party/depot_tools/ninja -C out/debug
     # Build a release binary.
-    DENO_BUILD_MODE=release ./tools/build.py :deno
+    ./tools/build.py --release :deno
     # List executable targets.
     ./third_party/depot_tools/gn ls out/debug //:* --as=output --type=executable
     # List build configuation.
@@ -152,7 +152,7 @@ Other useful commands:
     ./third_party/depot_tools/gn desc out/debug/ :deno
     ./third_party/depot_tools/gn help
 
-Env vars: `DENO_BUILD_MODE`, `DENO_BUILD_PATH`, `DENO_BUILD_ARGS`, `DENO_DIR`.
+Env vars: `DENO_BUILD_PATH`, `DENO_BUILD_ARGS`, `DENO_DIR`.
 
 ## Contributing
 

--- a/tools/build.py
+++ b/tools/build.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright 2018 the Deno authors. All rights reserved. MIT license.
 from __future__ import print_function
+import argparse
 import os
 import sys
 import third_party
@@ -10,13 +11,27 @@ enable_ansi_colors()
 
 third_party.fix_symlinks()
 
-ninja_args = sys.argv[1:]
-if not "-C" in ninja_args:
-    if not os.path.isdir(build_path()):
-        print("Build directory '%s' does not exist." % build_path(),
+parser = argparse.ArgumentParser()
+build_option_group = parser.add_mutually_exclusive_group()
+build_option_group.add_argument("--debug", action="store_true")
+build_option_group.add_argument("--release", action="store_true")
+# This makes -C option not allow to use --debug or --release together.
+build_option_group.add_argument("-C", action="store", nargs=1, metavar="path")
+build_option, ninja_args = parser.parse_known_args()
+
+if build_option.C != None:
+    ninja_args += ["-C"] + build_option.C
+else:
+    if build_option.release:
+        build_mode = "release"
+    else:
+        build_mode = "debug"
+
+    if not os.path.isdir(build_path(build_mode)):
+        print("Build directory '%s' does not exist." % build_path(build_mode),
               "Run tools/setup.py")
         sys.exit(1)
-    ninja_args = ["-C", build_path()] + ninja_args
+    ninja_args += ["-C", build_path(build_mode)]
 
 run([third_party.ninja_path] + ninja_args,
     env=third_party.google_env(),

--- a/tools/testdata/travis_benchmark.json
+++ b/tools/testdata/travis_benchmark.json
@@ -62,7 +62,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -85,7 +85,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -100,7 +99,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "errored",
       "started_at": "2018-10-16T06:02:26Z",
@@ -170,7 +169,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -193,7 +192,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -208,7 +206,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-16T01:24:11Z",
@@ -278,7 +276,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -301,7 +299,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -316,7 +313,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-16T01:14:08Z",
@@ -386,7 +383,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -409,7 +406,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -424,7 +420,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-16T00:54:22Z",
@@ -494,7 +490,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "$DENO_BUILD_PATH/deno -v",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
@@ -518,7 +514,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -533,7 +528,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-16T00:22:14Z",
@@ -603,7 +598,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./out/Default/deno -v",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
@@ -627,7 +622,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -642,7 +636,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "failed",
       "started_at": "2018-10-16T00:11:05Z",
@@ -712,7 +706,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./out/release/deno -v",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
@@ -736,7 +730,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -751,7 +744,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "failed",
       "started_at": "2018-10-16T00:02:53Z",
@@ -821,7 +814,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -844,7 +837,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -859,7 +851,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T23:56:19Z",
@@ -929,7 +921,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -952,7 +944,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -967,7 +958,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T23:39:18Z",
@@ -1037,7 +1028,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -1060,7 +1051,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -1075,7 +1065,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T22:55:48Z",
@@ -1145,7 +1135,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -1168,7 +1158,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -1183,7 +1172,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T22:36:34Z",
@@ -1253,7 +1242,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -1276,7 +1265,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -1291,7 +1279,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "errored",
       "started_at": "2018-10-15T22:03:14Z",
@@ -1361,7 +1349,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -1384,7 +1372,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -1399,7 +1386,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "errored",
       "started_at": "2018-10-15T21:03:30Z",
@@ -1469,7 +1456,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -1492,7 +1479,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -1507,7 +1493,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T18:41:34Z",
@@ -1577,7 +1563,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -1600,7 +1586,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -1615,7 +1600,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T17:33:47Z",
@@ -1685,7 +1670,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -1708,7 +1693,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -1723,7 +1707,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T16:43:54Z",
@@ -1793,7 +1777,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -1816,7 +1800,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -1831,7 +1814,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "failed",
       "started_at": "2018-10-15T14:59:30Z",
@@ -1901,7 +1884,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -1924,7 +1907,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -1939,7 +1921,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "failed",
       "started_at": "2018-10-15T14:49:22Z",
@@ -2009,7 +1991,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -2032,7 +2014,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -2047,7 +2028,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "errored",
       "started_at": "2018-10-15T14:14:16Z",
@@ -2117,7 +2098,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -2140,7 +2121,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -2155,7 +2135,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "errored",
       "started_at": "2018-10-15T14:07:57Z",
@@ -2225,7 +2205,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -2248,7 +2228,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -2263,7 +2242,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T12:54:45Z",
@@ -2333,7 +2312,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -2356,7 +2335,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -2371,7 +2349,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T11:33:43Z",
@@ -2441,7 +2419,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -2464,7 +2442,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -2479,7 +2456,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T11:13:31Z",
@@ -2549,7 +2526,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -2572,7 +2549,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -2587,7 +2563,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T01:03:58Z",
@@ -2657,7 +2633,7 @@
         "script": [
           "./tools/lint.py",
           "bash -c \"sleep 2100; pkill ninja\" \u0026",
-          "./tools/build.py -j2",
+          "./tools/build.py --release -j2",
           "./tools/test.py $DENO_BUILD_PATH"
         ],
         ".result": "configured",
@@ -2680,7 +2656,6 @@
           "HOMEBREW_PATH=$HOME/homebrew/",
           "DENO_BUILD_ARGS=\"use_custom_libcxx=false use_sysroot=false\"",
           "DENO_BUILD_PATH=$HOME/out/Default",
-          "DENO_BUILD_MODE=release",
           "PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH",
           "CCACHE_CPP2=yes",
           "CCACHE_SLOPPINESS=time_macros",
@@ -2695,7 +2670,7 @@
         "before_deploy": [
           "gzip -c $DENO_BUILD_PATH/deno \u003e $DENO_BUILD_PATH/deno_${TRAVIS_OS_NAME}_x64.gz"
         ],
-        "before_script": ["./tools/setup.py"]
+        "before_script": ["./tools/setup.py --release"]
       },
       "state": "passed",
       "started_at": "2018-10-15T00:34:50Z",

--- a/tools/util.py
+++ b/tools/util.py
@@ -140,19 +140,12 @@ def rmtree(directory):
     shutil.rmtree(directory, onerror=rm_readonly)
 
 
-def build_mode(default="debug"):
-    if "DENO_BUILD_MODE" in os.environ:
-        return os.environ["DENO_BUILD_MODE"]
-    else:
-        return default
-
-
 # E.G. "out/debug"
-def build_path():
+def build_path(build_mode="debug"):
     if "DENO_BUILD_PATH" in os.environ:
         return os.environ["DENO_BUILD_PATH"]
     else:
-        return os.path.join(root_path, "out", build_mode())
+        return os.path.join(root_path, "out", build_mode)
 
 
 # Returns True if the expected matches the actual output, allowing variation


### PR DESCRIPTION
After this patch, we can use the command as follows:
  #### For debug build (default)
  `$ ./tools/build.py` or `$ ./tools/build.py --debug`
  #### For release build
  `$ ./tools/build.py --release`

Fixes #1004.

<!--

Thank you for your pull request. Before submitting, please make sure the following is done.

1. Ensure ./tools/test.py passes.
2. Format your code with ./tools/format.py
3. Make sure ./tools/lint.py passes.

And please read: https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md

-->
