### PR TITLE
Fix a bug that copyFile reports different error codes

### DIFF
--- a/js/copy_file_test.ts
+++ b/js/copy_file_test.ts
@@ -43,15 +43,8 @@ testPerm({ write: true }, function copyFileSyncFailure() {
     err = e;
   }
   assert(!!err);
-  if (deno.platform.os === "win") {
-    assertEqual(err.kind, deno.ErrorKind.NotFound);
-    assertEqual(err.name, "NotFound");
-  } else {
-    // On *nix, Rust deem non-existent path as invalid input
-    // See https://github.com/rust-lang/rust/issues/54800
-    assertEqual(err.kind, deno.ErrorKind.InvalidInput);
-    assertEqual(err.name, "InvalidInput");
-  }
+  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.name, "NotFound");
 });
 
 testPerm({ write: true }, function copyFileSyncOverwrite() {
@@ -104,15 +97,8 @@ testPerm({ write: true }, async function copyFileFailure() {
     err = e;
   }
   assert(!!err);
-  if (deno.platform.os === "win") {
-    assertEqual(err.kind, deno.ErrorKind.NotFound);
-    assertEqual(err.name, "NotFound");
-  } else {
-    // On *nix, Rust deem non-existent path as invalid input
-    // See https://github.com/rust-lang/rust/issues/54800
-    assertEqual(err.kind, deno.ErrorKind.InvalidInput);
-    assertEqual(err.name, "InvalidInput");
-  }
+  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.name, "NotFound");
 });
 
 testPerm({ write: true }, async function copyFileOverwrite() {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -811,6 +811,16 @@ fn op_copy_file(
 
   debug!("op_copy_file {} {}", from.display(), to.display());
   blocking!(base.sync(), || {
+    // On *nix, Rust deem non-existent path as invalid input
+    // See https://github.com/rust-lang/rust/issues/54800
+    // Once the issue is reolved, we should remove this workaround.
+    if cfg!(unix) && !from.is_file() {
+      return Err(errors::new(
+          ErrorKind::NotFound,
+          "File not found".to_string(),
+      ));
+    }
+
     fs::copy(&from, &to)?;
     Ok(empty_buf())
   })


### PR DESCRIPTION
This is a workaroud. Once the issue is resolved in Rust side, we should
remove it.

Fixes #895

<!--

Thank you for your pull request. Before submitting, please make sure the following is done.

1. Ensure ./tools/test.py passes.
2. Format your code with ./tools/format.py
3. Make sure ./tools/lint.py passes.

And please read: https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md

-->
