### PR TITLE
Optimization: Reduce ImporBuf ArrayBuffer allocations

### DIFF
--- a/libdeno/internal.h
+++ b/libdeno/internal.h
@@ -16,6 +16,10 @@ struct deno_s {
   v8::Persistent<v8::Function> global_error_handler;
   v8::Persistent<v8::Function> promise_reject_handler;
   v8::Persistent<v8::Function> promise_error_examiner;
+
+  v8::Persistent<v8::ArrayBuffer> global_import_buf;
+  void* global_import_buf_ptr;
+
   int32_t pending_promise_events;
   v8::Persistent<v8::Context> context;
   v8::Persistent<v8::Map> async_data_map;

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -10,15 +10,21 @@ ADDR = "127.0.0.1:4544"
 DURATION = "10s"
 
 
-def http_benchmark(deno_exe):
+def deno_http_benchmark(deno_exe):
     deno_cmd = [deno_exe, "--allow-net", "tests/http_bench.ts", ADDR]
-    node_cmd = ["node", "tools/node_http.js", ADDR.split(":")[1]]
-
     print "http_benchmark testing DENO."
-    deno_rps = run(deno_cmd)
+    return run(deno_cmd)
 
+
+def node_http_benchmark(deno_exe):
+    node_cmd = ["node", "tools/node_http.js", ADDR.split(":")[1]]
     print "http_benchmark testing NODE."
-    node_rps = run(node_cmd)
+    return run(node_cmd)
+
+
+def http_benchmark(deno_exe):
+    deno_rps = deno_http_benchmark(deno_exe)
+    node_rps = node_http_benchmark(deno_exe)
 
     return {"deno": deno_rps, "node": node_rps}
 
@@ -46,4 +52,4 @@ if __name__ == '__main__':
     if len(sys.argv) < 2:
         print "Usage ./tools/tcp_http_benchmark.py out/debug/deno"
         sys.exit(1)
-    http_benchmark(sys.argv[1])
+    deno_http_benchmark(sys.argv[1])


### PR DESCRIPTION
Better at http benchmark:
```
~/src/deno> ./tools/http_benchmark.py out/before/deno
http_benchmark testing DENO.
Listening on 127.0.0.1:4544
third_party/wrk/mac/wrk -d 10s http://127.0.0.1:4544/
Running 10s test @ http://127.0.0.1:4544/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   790.69us    1.22ms  23.65ms   95.58%
    Req/Sec     8.25k     1.10k    9.80k    88.50%
  164125 requests in 10.00s, 7.98MB read
Requests/sec:  16407.65
Transfer/sec:    817.18KB

~/src/deno> ./tools/http_benchmark.py out/after/deno
http_benchmark testing DENO.
Listening on 127.0.0.1:4544
third_party/wrk/mac/wrk -d 10s http://127.0.0.1:4544/
Running 10s test @ http://127.0.0.1:4544/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   640.84us    0.91ms  24.95ms   97.02%
    Req/Sec     9.03k     1.05k   10.16k    94.00%
  179642 requests in 10.00s, 8.74MB read
Requests/sec:  17962.53
Transfer/sec:      0.87MB
```
But worse at throughput benchmark (???)
```
~/src/deno> ./tools/throughput_benchmark.py out/before/deno 1000
listening on 127.0.0.1:4544
head -c 1048576000 /dev/zero | nc 127.0.0.1 4544
17.5132410526 seconds

~/src/deno> ./tools/throughput_benchmark.py out/after/deno 1000
listening on 127.0.0.1:4544
head -c 1048576000 /dev/zero | nc 127.0.0.1 4544
21.8031110764 seconds
```