### PR TITLE
Optimization: Use std::map for tracking zero-copy buffers

### DIFF
--- a/libdeno/internal.h
+++ b/libdeno/internal.h
@@ -2,6 +2,7 @@
 #ifndef INTERNAL_H_
 #define INTERNAL_H_
 
+#include <map>
 #include <string>
 #include "deno.h"
 #include "third_party/v8/include/v8.h"
@@ -22,7 +23,7 @@ struct deno_s {
 
   int32_t pending_promise_events;
   v8::Persistent<v8::Context> context;
-  v8::Persistent<v8::Map> async_data_map;
+  std::map<int32_t, v8::Persistent<v8::Value>*> async_data_map;
   deno_recv_cb cb;
   int32_t next_req_id;
   void* user_data;


### PR DESCRIPTION
Instead of V8 map.

marginal improvements:
```
gpu ~/src/deno> ./tools/throughput_benchmark.py out/before/deno 1000
listening on 127.0.0.1:4544
head -c 1048576000 /dev/zero | nc 127.0.0.1 4544
3.30926418304 seconds

gpu ~/src/deno> ./tools/throughput_benchmark.py out/after/deno 1000
listening on 127.0.0.1:4544
head -c 1048576000 /dev/zero | nc 127.0.0.1 4544
3.25322794914 seconds

gpu ~/src/deno> ./tools/http_benchmark.py out/before/deno
http_benchmark testing DENO.
Listening on 127.0.0.1:4544
third_party/wrk/linux/wrk -d 10s http://127.0.0.1:4544/
Running 10s test @ http://127.0.0.1:4544/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   436.30us  558.79us  13.90ms   96.12%
    Req/Sec    13.83k     1.41k   14.72k    92.50%
  275232 requests in 10.00s, 13.39MB read
Requests/sec:  27520.05
Transfer/sec:      1.34MB

gpu ~/src/deno> ./tools/http_benchmark.py out/after/deno
http_benchmark testing DENO.
Listening on 127.0.0.1:4544
third_party/wrk/linux/wrk -d 10s http://127.0.0.1:4544/
Running 10s test @ http://127.0.0.1:4544/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   417.95us  486.57us  15.07ms   95.92%
    Req/Sec    14.25k     1.67k   15.04k    96.00%
  283590 requests in 10.00s, 13.79MB read
Requests/sec:  28358.23
Transfer/sec:      1.38MB