### PR TITLE
Optimization: eager syscalls 

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -172,7 +172,7 @@ impl Isolate {
 
   pub fn respond(&mut self, req_id: i32, buf: Buf) {
     self.state.metrics_op_completed(buf.len() as u64);
-    
+
     // TODO(zero-copy) Use Buf::leak(buf) to leak the heap allocated buf. And
     // don't do the memcpy in ImportBuf() (in libdeno/binding.cc)
     unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod libdeno;
 pub mod ops;
 mod resources;
 mod tokio_util;
+mod tokio_write;
 mod version;
 
 use std::env;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -665,7 +665,7 @@ fn op_read(
   match resources::lookup(rid) {
     None => odd_future(errors::bad_resource()),
     Some(resource) => {
-      let op = tokio_io::io::read(resource, data)
+      let op = resources::eager_read(resource, data)
         .map_err(|err| DenoError::from(err))
         .and_then(move |(_resource, _buf, nread)| {
           let builder = &mut FlatBufferBuilder::new();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -12,7 +12,6 @@ use msg;
 use resources;
 use resources::Resource;
 use tokio_util;
-use tokio_write;
 use version;
 
 use flatbuffers::FlatBufferBuilder;
@@ -704,7 +703,7 @@ fn op_write(
   match resources::lookup(rid) {
     None => odd_future(errors::bad_resource()),
     Some(resource) => {
-      let op = tokio_write::write(resource, data)
+      let op = resources::eager_write(resource, data)
         .map_err(|err| DenoError::from(err))
         .and_then(move |(_resource, _buf, nwritten)| {
           let builder = &mut FlatBufferBuilder::new();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -12,6 +12,7 @@ use msg;
 use resources;
 use resources::Resource;
 use tokio_util;
+use tokio_write;
 use version;
 
 use flatbuffers::FlatBufferBuilder;
@@ -36,7 +37,6 @@ use std::time::{Duration, Instant};
 use tokio;
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
-use tokio_io;
 use tokio_threadpool;
 
 type OpResult = DenoResult<Buf>;
@@ -704,15 +704,14 @@ fn op_write(
   match resources::lookup(rid) {
     None => odd_future(errors::bad_resource()),
     Some(resource) => {
-      let len = data.len();
-      let op = tokio_io::io::write_all(resource, data)
+      let op = tokio_write::write(resource, data)
         .map_err(|err| DenoError::from(err))
-        .and_then(move |(_resource, _buf)| {
+        .and_then(move |(_resource, _buf, nwritten)| {
           let builder = &mut FlatBufferBuilder::new();
           let inner = msg::WriteRes::create(
             builder,
             &msg::WriteResArgs {
-              nbyte: len as u32,
+              nbyte: nwritten as u32,
               ..Default::default()
             },
           );

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -11,7 +11,6 @@ use isolate::Op;
 use msg;
 use resources;
 use resources::Resource;
-use tokio_util;
 use version;
 
 use flatbuffers::FlatBufferBuilder;
@@ -1186,7 +1185,7 @@ fn op_accept(
   match resources::lookup(server_rid) {
     None => odd_future(errors::bad_resource()),
     Some(server_resource) => {
-      let op = tokio_util::accept(server_resource)
+      let op = resources::eager_accept(server_resource)
         .map_err(|err| DenoError::from(err))
         .and_then(move |(tcp_stream, _socket_addr)| {
           new_conn(cmd_id, tcp_stream)

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -11,6 +11,8 @@
 use errors::DenoError;
 
 use futures;
+use futures::future::Either;
+use futures::future::FutureResult;
 use futures::Poll;
 use std;
 use std::collections::HashMap;
@@ -23,6 +25,7 @@ use std::sync::Mutex;
 use tokio;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
+use tokio_io;
 
 pub type ResourceId = i32; // Sometimes referred to RID.
 
@@ -187,4 +190,54 @@ pub fn add_tcp_stream(stream: tokio::net::TcpStream) -> Resource {
 pub fn lookup(rid: ResourceId) -> Option<Resource> {
   let table = RESOURCE_TABLE.lock().unwrap();
   table.get(&rid).map(|_| Resource { rid })
+}
+
+type EagerRead<R, T> =
+  Either<tokio_io::io::Read<R, T>, FutureResult<(R, T, usize), std::io::Error>>;
+
+#[cfg(windows)]
+#[allow(unused_mut)]
+pub fn eager_read<T>(resource: Resource, mut buf: T) -> EagerRead<Resource, T>
+where
+  T: AsMut<[u8]>,
+{
+  Either::A(tokio_io::io::read(resource, buf)).into()
+}
+
+// This is an optimization that Tokio should do.
+// Attempt to call read() on the main thread.
+#[cfg(not(windows))]
+pub fn eager_read<T>(resource: Resource, mut buf: T) -> EagerRead<Resource, T>
+where
+  T: AsMut<[u8]>,
+{
+  let mut table = RESOURCE_TABLE.lock().unwrap();
+  let maybe_repr = table.get_mut(&resource.rid);
+  match maybe_repr {
+    None => panic!("bad rid"),
+    Some(repr) => match repr {
+      Repr::TcpStream(ref mut tcp_stream) => {
+        // Unforunately we can't just call read() on tokio::net::TcpStream
+        use std::os::unix::io::AsRawFd;
+        use std::os::unix::io::FromRawFd;
+        use std::os::unix::io::IntoRawFd;
+        let mut std_tcp_stream =
+          unsafe { std::net::TcpStream::from_raw_fd(tcp_stream.as_raw_fd()) };
+        let read_result = std_tcp_stream.read(buf.as_mut());
+        // std_tcp_stream will close when it gets dropped. Thus...
+        let _ = std_tcp_stream.into_raw_fd();
+        match read_result {
+          Ok(nread) => Either::B(futures::future::ok((resource, buf, nread))),
+          Err(err) => {
+            if err.kind() == std::io::ErrorKind::WouldBlock {
+              Either::A(tokio_io::io::read(resource, buf))
+            } else {
+              Either::B(futures::future::err(err))
+            }
+          }
+        }
+      }
+      _ => Either::A(tokio_io::io::read(resource, buf)),
+    },
+  }
 }

--- a/src/tokio_write.rs
+++ b/src/tokio_write.rs
@@ -1,0 +1,61 @@
+// TODO Submit this file upstream into tokio-io/src/io/write.rs
+use std::io;
+use std::mem;
+
+use futures::{Future, Poll};
+use tokio::io::AsyncWrite;
+
+/// A future used to write some data to a stream.
+///
+/// This is created by the [`write`] top-level method.
+///
+/// [`write`]: fn.write.html
+#[derive(Debug)]
+pub struct Write<A, T> {
+  state: State<A, T>,
+}
+
+#[derive(Debug)]
+enum State<A, T> {
+  Pending { a: A, buf: T },
+  Empty,
+}
+
+/// Creates a future that will write some of the buffer `buf` to
+/// the stream `a` provided.
+///
+/// Any error which happens during writing will cause both the stream and the
+/// buffer to get destroyed.
+pub fn write<A, T>(a: A, buf: T) -> Write<A, T>
+where
+  A: AsyncWrite,
+  T: AsRef<[u8]>,
+{
+  Write {
+    state: State::Pending { a: a, buf: buf },
+  }
+}
+
+impl<A, T> Future for Write<A, T>
+where
+  A: AsyncWrite,
+  T: AsRef<[u8]>,
+{
+  type Item = (A, T, usize);
+  type Error = io::Error;
+
+  fn poll(&mut self) -> Poll<(A, T, usize), io::Error> {
+    let nwritten = match self.state {
+      State::Pending {
+        ref mut a,
+        ref mut buf,
+      } => try_ready!(a.poll_write(buf.as_ref())),
+      State::Empty => panic!("poll a Read after it's done"),
+    };
+
+    match mem::replace(&mut self.state, State::Empty) {
+      State::Pending { a, buf } => Ok((a, buf, nwritten).into()),
+      State::Empty => panic!("invalid internal state"),
+    }
+  }
+}


### PR DESCRIPTION
TCP sockets should attempt the non-blocking read/write/accept in the main thread.

```
gpu ~/src/deno> ./profile_http.sh out/before/deno
Listening on 127.0.0.1:4500
Running 10s test @ http://localhost:4500/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   438.95us  432.04us   8.14ms   96.14%
    Req/Sec    13.12k     1.43k   15.13k    93.00%
  260978 requests in 10.01s, 12.69MB read
Requests/sec:  26080.64
Transfer/sec:      1.27MB

gpu ~/src/deno> ./profile_http.sh out/eager_read_only/deno
Listening on 127.0.0.1:4500
Running 10s test @ http://localhost:4500/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   396.49us  413.72us   8.73ms   96.20%
    Req/Sec    14.73k     1.31k   15.51k    96.00%
  293044 requests in 10.00s, 14.25MB read
Requests/sec:  29299.82
Transfer/sec:      1.43MB

gpu ~/src/deno> ./profile_http.sh out/eager_read_write/deno
Listening on 127.0.0.1:4500
Running 10s test @ http://localhost:4500/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   334.21us  447.99us  12.23ms   95.24%
    Req/Sec    19.28k     2.32k   21.70k    93.50%
  383787 requests in 10.01s, 18.67MB read
Requests/sec:  38352.23
Transfer/sec:      1.87MB

gpu ~/src/deno> ./profile_http.sh out/eager_read_write_accept/deno
Listening on 127.0.0.1:4500
Running 10s test @ http://localhost:4500/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   329.35us  452.19us  12.23ms   95.00%
    Req/Sec    19.94k     2.53k   22.16k    95.50%
  396920 requests in 10.00s, 19.31MB read
Requests/sec:  39686.59
Transfer/sec:      1.93MB
```