### PR TITLE
feat: show only 20 benchmark data in inde.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules
 /gh-pages
 # temp benchmark data
 /website/data.json
+/website/recent.json

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -25,7 +25,8 @@ exec_time_benchmarks = [
 ]
 
 gh_pages_data_file = "gh-pages/data.json"
-data_file = "website/data.json"
+all_data_file = "website/data.json"  # Includes all benchmark data.
+recent_data_file = "website/recent.json"  # Includes recent 20 benchmark data.
 
 
 def read_json(filename):
@@ -39,16 +40,16 @@ def write_json(filename, data):
 
 
 def import_data_from_gh_pages():
-    if os.path.exists(data_file):
+    if os.path.exists(all_data_file):
         return
     try:
         run([
             "git", "clone", "--depth", "1", "-b", "gh-pages",
             "https://github.com/denoland/deno.git", "gh-pages"
         ])
-        shutil.copy(gh_pages_data_file, data_file)
+        shutil.copy(gh_pages_data_file, all_data_file)
     except:
-        write_json(data_file, [])  # writes empty json data
+        write_json(all_data_file, [])  # writes empty json data
 
 
 def get_binary_sizes(build_dir):
@@ -157,7 +158,7 @@ def main(argv):
     run(["hyperfine", "--export-json", benchmark_file, "--warmup", "3"] + [
         deno_path + " " + " ".join(args) for [_, args] in exec_time_benchmarks
     ])
-    all_data = read_json(data_file)
+    all_data = read_json(all_data_file)
     benchmark_data = read_json(benchmark_file)
     sha1 = run_output(["git", "rev-parse", "HEAD"]).strip()
     new_data = {
@@ -191,7 +192,8 @@ def main(argv):
         new_data["syscall_count"] = run_syscall_count_benchmark(deno_path)
 
     all_data.append(new_data)
-    write_json(data_file, all_data)
+    write_json(all_data_file, all_data)
+    write_json(recent_data_file, all_data[-20:])
 
 
 if __name__ == '__main__':

--- a/website/all_benchmark.html
+++ b/website/all_benchmark.html
@@ -1,0 +1,47 @@
+<!-- Copyright 2018 the Deno authors. All rights reserved. MIT license. -->
+<!DOCTYPE html>
+<html>
+<head>
+  <title>all benchmark data | deno</title>
+  <link rel="stylesheet" href="https://unpkg.com/c3@0.6.7/c3.min.css">
+  <link rel="stylesheet" href="style.css">
+  <meta content='width=device-width, initial-scale=1.0' name='viewport' />
+</head>
+<body>
+  <main>
+    <h1>all benchmark data</h1>
+
+    <p><a href="./">back</a>
+
+    <h2>Execution time</h2>
+    <div id="exec-time-chart"></div>
+
+    <h2>Throughput</h2>
+    <div id="throughput-chart"></div>
+
+    <h2>Req/Sec</h2>
+    <div id="req-per-sec-chart"></div>
+
+    <h2>Executable size</h2>
+    <div id="binary-size-chart"></div>
+
+    <h2>Thread count</h2>
+    <div id="thread-count-chart"></div>
+
+    <h2>Syscall count</h2>
+    <div id="syscall-count-chart"></div>
+
+    <h2>Travis</h2>
+    <div id="travis-compile-time-chart"></div>
+  </main>
+  <script src="https://unpkg.com/d3@5.7.0/dist/d3.min.js"></script>
+  <script src="https://unpkg.com/c3@0.6.7/c3.min.js"></script>
+
+  <script type="module">
+  import { drawCharts } from "./app.js";
+  window.chartWidth = 800
+  drawCharts("./data.json");
+  </script>
+</body>
+</html>
+

--- a/website/app.js
+++ b/website/app.js
@@ -124,12 +124,17 @@ export function formatBytes(a, b) {
   return parseFloat((a / Math.pow(c, f)).toFixed(d)) + " " + e[f];
 }
 
+/**
+ * @param {string} id The id of dom element
+ * @param {any[][]} columns The columns data
+ * @param {string[]} categories The sha1 hashes (which work as x-axis values)
+ */
 function gen2(id, categories, columns, onclick) {
   c3.generate({
     bindto: id,
     size: {
       height: 300,
-      width: 375
+      width: window.chartWidth || 375 // TODO: do not use global variable
     },
     data: {
       columns,
@@ -154,16 +159,19 @@ export function formatSeconds(t) {
   return a < 30 ? `${min} min` : `${min + 1} min`;
 }
 
-export function main() {
-  drawChartsFromBenchmarkData();
+/**
+ * @param dataUrl The url of benchramk data json.
+ */
+export function drawCharts(dataUrl) {
+  drawChartsFromBenchmarkData(dataUrl);
   drawChartsFromTravisData();
 }
 
 /**
  * Draws the charts from the benchmark data stored in gh-pages branch.
  */
-export async function drawChartsFromBenchmarkData() {
-  const data = await getJson("./data.json");
+export async function drawChartsFromBenchmarkData(dataUrl) {
+  const data = await getJson(dataUrl);
 
   const execTimeColumns = createExecTimeColumns(data);
   const throughputColumns = createThroughputColumns(data);

--- a/website/index.html
+++ b/website/index.html
@@ -48,13 +48,17 @@
     <h2>Travis</h2>
     How long for Travis CI to return a green status for pull requests.
     <div id="travis-compile-time-chart"></div>
+
+    <h2>References</h2>
+    <p> <a href="./all_benchmark.html">All benchmark data</a>
+
   </main>
   <script src="https://unpkg.com/d3@5.7.0/dist/d3.min.js"></script>
   <script src="https://unpkg.com/c3@0.6.7/c3.min.js"></script>
 
   <script type="module">
-  import { main } from "./app.js";
-  main();
+  import { drawCharts } from "./app.js";
+  drawCharts("./recent.json");
   </script>
 </body>
 </html>


### PR DESCRIPTION
This PR tries to solve #1027.

- Creates `//website/recent.json` which includes only recent 20 benchmark data.
- Loads `recent.json` in `//website/index.html` instead of `data.json` (all data)
- Created a new page `/website/all_benchmark.html` which shows the all benchmark data.

index.html
<img width="537" alt="2018-10-20 16 57 06" src="https://user-images.githubusercontent.com/613956/47253123-29672100-d48a-11e8-8fbc-79e27f61ed2e.png">

all_benchmark.html
<img width="938" alt="2018-10-20 16 57 20" src="https://user-images.githubusercontent.com/613956/47253128-3421b600-d48a-11e8-8e00-4ad4c4417735.png">


---
resolves #1027