### PR TITLE
v0.1.9

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -3,7 +3,7 @@ use libdeno;
 use std::ffi::CStr;
 
 // This is the source of truth for the Deno version. Ignore the value in Cargo.toml.
-pub const DENO_VERSION: &str = "0.1.8";
+pub const DENO_VERSION: &str = "0.1.9";
 
 pub fn get_v8_version() -> &'static str {
   let v = unsafe { libdeno::deno_v8_version() };


### PR DESCRIPTION
#1041 should land first.

- Performance and stability improvements on all platforms.
- Add cwd() and chdir() #907
- Specify deno_dir location with env var DENO_DIR #970
- Make fetch() header compliant with the current spec #1019
- Upgrade TypeScript to 3.1.3
- Upgrade V8 to 7.1.302.4


