### PR TITLE
Make URLSearchParams compliant with the spec and browser

### DIFF
--- a/js/dom_types.ts
+++ b/js/dom_types.ts
@@ -90,7 +90,7 @@ export interface ProgressEventInit extends EventInit {
   total?: number;
 }
 
-export interface URLSearchParams {
+export interface URLSearchParams extends DomIterable<string, string> {
   /**
    * Appends a specified key/value pair as a new search parameter.
    */
@@ -100,6 +100,11 @@ export interface URLSearchParams {
    * from the list of all search parameters.
    */
   delete(name: string): void;
+  /** Returns an iterator allowing to go through all key/value pairs
+   * contained in this URLSearchParams object. The both the key and
+   * value of each pairs are ByteString objects.
+   */
+  entries(): IterableIterator<[string, string]>;
   /**
    * Returns the first value associated to the given search parameter.
    */
@@ -112,6 +117,10 @@ export interface URLSearchParams {
    * Returns a Boolean indicating if such a search parameter exists.
    */
   has(name: string): boolean;
+  /** Returns an iterator allowing to go through all keys contained in
+   * this URLSearchParams object. The keys are ByteString objects.
+   */
+  keys(): IterableIterator<string>;
   /**
    * Sets the value associated to a given search parameter to the given value.
    * If there were several values, delete the others.
@@ -127,15 +136,24 @@ export interface URLSearchParams {
    * Returns a query string suitable for use in a URL.
    */
   toString(): string;
+  /** Returns an iterator allowing to go through all values contained in
+   * this URLSearchParams object. The values are ByteString objects.
+   */
+  values(): IterableIterator<string>;
   /**
    * Iterates over each name-value pair in the query
    * and invokes the given function.
    */
   forEach(
-    callbackfn: (value: string, key: string, parent: URLSearchParams) => void,
+    callbackfn: (value: string, key: string, parent: this) => void,
     // tslint:disable-next-line:no-any
     thisArg?: any
   ): void;
+}
+
+export interface URLSearchParamsConstructor {
+  new (init?: URLSearchParamsInit): URLSearchParams;
+  prototype: URLSearchParams;
 }
 
 interface EventListener {

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -16,7 +16,7 @@ import * as fetchTypes from "./fetch";
 import * as headers from "./headers";
 import * as textEncoding from "./text_encoding";
 import * as timers from "./timers";
-import * as urlSearchParams from "./url_search_params";
+import { URLSearchParams } from "./url_search_params";
 
 // These imports are not exposed and therefore are fine to just import the
 // symbols required.
@@ -58,8 +58,9 @@ window.Blob = blob.DenoBlob;
 export type Blob = blob.DenoBlob;
 window.File = file.DenoFile;
 export type File = file.DenoFile;
-window.URLSearchParams = urlSearchParams.URLSearchParams;
-export type URLSearchParams = urlSearchParams.URLSearchParams;
+
+window.URLSearchParams = URLSearchParams as domTypes.URLSearchParamsConstructor;
+export { URLSearchParams } from "./url_search_params";
 
 // Using the `as` keyword to use standard compliant interfaces as the Deno
 // implementations contain some implementation details we wouldn't want to


### PR DESCRIPTION
<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
According to [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) `keys`, `values` and `entries` shouldn't  a generator function, and need to return a `Iterator`.
For example:
in chrome and firefox:
``````
var us = new URLSearchParams()
undefined
console.log(us.keys.constructor.name)
Function
undefined
console.log(us.values.constructor.name)
Function
undefined
console.log(us.entries.constructor.name)
Function
``````
