### PR TITLE
Improve globals for runtime type library

### DIFF
--- a/js/globals.ts
+++ b/js/globals.ts
@@ -1,19 +1,19 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 import * as blob from "./blob";
-import * as console from "./console";
+import * as console_ from "./console";
 import * as fetch_ from "./fetch";
 import { globalEval } from "./global_eval";
 import { libdeno } from "./libdeno";
 import * as textEncoding from "./text_encoding";
 import * as timers from "./timers";
-import * as urlsearchparams from "./url_search_params";
+import * as urlSearchParams from "./url_search_params";
 
 // During the build process, augmentations to the variable `window` in this
 // file are tracked and created as part of default library that is built into
 // deno, we only need to declare the enough to compile deno.
 
 declare global {
-  const console: console.Console;
+  const console: console_.Console;
   const setTimeout: typeof timers.setTimeout;
   // tslint:disable-next-line:variable-name
   const TextEncoder: typeof textEncoding.TextEncoder;
@@ -28,13 +28,13 @@ window.setInterval = timers.setInterval;
 window.clearTimeout = timers.clearTimer;
 window.clearInterval = timers.clearTimer;
 
-window.console = new console.Console(libdeno.print);
+window.console = new console_.Console(libdeno.print);
 window.TextEncoder = textEncoding.TextEncoder;
 window.TextDecoder = textEncoding.TextDecoder;
 window.atob = textEncoding.atob;
 window.btoa = textEncoding.btoa;
 
-window.URLSearchParams = urlsearchparams.URLSearchParams;
+window.URLSearchParams = urlSearchParams.URLSearchParams;
 
 window.fetch = fetch_.fetch;
 

--- a/tests/error_003_typescript.ts.out
+++ b/tests/error_003_typescript.ts.out
@@ -4,7 +4,7 @@
 [WILDCARD]~~~~~~[0m
 
   [96m$asset$/lib.deno_runtime.d.ts[WILDCARD]
-[WILDCARD]const console: console.Console;
+[WILDCARD]declare const console: console_.Console;
 [WILDCARD]~~~~~~~[0m
 [WILDCARD]'console' is declared here.
 

--- a/tools/ts_library_builder/test.ts
+++ b/tools/ts_library_builder/test.ts
@@ -4,7 +4,7 @@
 
 import { Project, ts } from "ts-simple-ast";
 import { assert, assertEqual, test } from "../../js/testing/testing";
-import { flatten, merge } from "./build_library";
+import { flatten, mergeGlobal } from "./build_library";
 import { loadDtsFiles } from "./ast_util";
 
 const { ModuleKind, ModuleResolutionKind, ScriptTarget } = ts;
@@ -116,7 +116,7 @@ test(function buildLibraryMerge() {
     outputSourceFile: targetSourceFile
   } = setupFixtures();
 
-  merge({
+  mergeGlobal({
     basePath,
     declarationProject,
     debug,
@@ -124,31 +124,19 @@ test(function buildLibraryMerge() {
     filePath: `${buildPath}/globals.ts`,
     inputProject,
     interfaceName: "FooBar",
-    namespaceName: `"bazqat"`,
     targetSourceFile
   });
 
-  assert(targetSourceFile.getNamespace(`"bazqat"`) != null);
+  assert(targetSourceFile.getNamespace("moduleC") != null);
   assertEqual(targetSourceFile.getNamespaces().length, 1);
-  const namespaceBazqat = targetSourceFile.getNamespaceOrThrow(`"bazqat"`);
-  assert(namespaceBazqat.getNamespace("global") != null);
-  assert(namespaceBazqat.getNamespace("moduleC") != null);
-  assertEqual(namespaceBazqat.getNamespaces().length, 2);
-  assert(namespaceBazqat.getInterface("FooBar") != null);
-  assertEqual(namespaceBazqat.getInterfaces().length, 1);
-  const globalNamespace = namespaceBazqat.getNamespaceOrThrow("global");
-  const variableDeclarations = globalNamespace.getVariableDeclarations();
-  assertEqual(
-    variableDeclarations[0].getType().getText(),
-    `import("bazqat").FooBar`
-  );
-  assertEqual(
-    variableDeclarations[1].getType().getText(),
-    `import("bazqat").moduleC.Bar`
-  );
+  assert(targetSourceFile.getInterface("FooBar") != null);
+  assertEqual(targetSourceFile.getInterfaces().length, 1);
+  const variableDeclarations = targetSourceFile.getVariableDeclarations();
+  assertEqual(variableDeclarations[0].getType().getText(), `FooBar`);
+  assertEqual(variableDeclarations[1].getType().getText(), `moduleC.Bar`);
   assertEqual(
     variableDeclarations[2].getType().getText(),
-    `typeof import("bazqat").moduleC.qat`
+    `typeof moduleC.qat`
   );
   assertEqual(variableDeclarations.length, 3);
 });


### PR DESCRIPTION
Resolves #994 

I have updated my [gist](https://gist.github.com/kitsonk/6c11763faf833f5cf4ec14f58657d8f8) with the current output of this PR.

Mainly it removes the `"globals"` module and scopes all the variables there to the outer global scope.  Also any modules that are required by `js/globals.ts` that have global scope augmentation are flattened as well.  Any types from required modules of `js/globals.ts` that are not elided are now `declare`d as a global namespace.  This would mean that someone could reference a type in code (e.g. `domTypes.Headers`) but wouldn't be able to import anything.

Just thinking out loud, currently some namespace names are odd because of name collisions.  So `fetch_` and `console_` could be renamed `fetchTypes` and `consoleTypes` so that they are a little bit clearer in intent.