### PR TITLE
improve file_info.ts

### DIFF
--- a/js/file_info.ts
+++ b/js/file_info.ts
@@ -5,8 +5,6 @@ import * as msg from "gen/msg_generated";
  * `statSync`, `lstatSync`.
  */
 export interface FileInfo {
-  readonly _isFile: boolean;
-  readonly _isSymlink: boolean;
   /** The size of the file, in bytes. */
   len: number;
   /** The last modification time of the file. This corresponds to the `mtime`
@@ -53,8 +51,8 @@ export interface FileInfo {
 
 // @internal
 export class FileInfoImpl implements FileInfo {
-  readonly _isFile: boolean;
-  readonly _isSymlink: boolean;
+  private readonly _isFile: boolean;
+  private readonly _isSymlink: boolean;
   len: number;
   modified: number | null;
   accessed: number | null;


### PR DESCRIPTION
<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
`_isFile` and `_isSymlink` don't need to export,  remove them from `FIleInfo` and mark them `private readonly` in `FileInfoImpl`.