### PR TITLE
Support CheckJS

### DIFF
--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -133,6 +133,7 @@ export class DenoCompiler
   // arguments
   private readonly _options: Readonly<ts.CompilerOptions> = {
     allowJs: true,
+    checkJs: true,
     module: ts.ModuleKind.AMD,
     outDir: "$deno$",
     // TODO https://github.com/denoland/deno/issues/23

--- a/tests/error_008_checkjs.js
+++ b/tests/error_008_checkjs.js
@@ -1,0 +1,6 @@
+// console.log intentionally misspelled to trigger a type error
+consol.log("hello world!");
+
+// the following error should be ignored and not output to the console
+// @ts-ignore
+const foo = new Foo();

--- a/tests/error_008_checkjs.js.out
+++ b/tests/error_008_checkjs.js.out
@@ -1,0 +1,10 @@
+[96m[WILDCARD]/tests/error_008_checkjs.js[WILDCARD] - [91merror[0m[90m TS2552: [0mCannot find name 'consol'. Did you mean 'console'?
+
+[WILDCARD] consol.log("hello world!");
+[WILDCARD]~~~~~~[0m
+
+  [96m$asset$/lib.deno_runtime.d.ts[WILDCARD]
+[WILDCARD]declare const console: console_.Console;
+[WILDCARD]~~~~~~~[0m
+[WILDCARD]'console' is declared here.
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "allowUnreachableCode": false,
     "baseUrl": ".",
+    "checkJs": true,
     "module": "esnext",
     "moduleResolution": "node",
     "noImplicitReturns": true,

--- a/website/app.js
+++ b/website/app.js
@@ -154,10 +154,12 @@ function gen2(
     };
   }
 
+  // @ts-ignore
   c3.generate({
     bindto: id,
     size: {
       height: 300,
+      // @ts-ignore
       width: window.chartWidth || 375 // TODO: do not use global variable
     },
     data: {
@@ -201,6 +203,7 @@ export async function drawChartsFromBenchmarkData(dataUrl) {
   const sha1ShortList = sha1List.map(sha1 => sha1.substring(0, 6));
 
   const viewCommitOnClick = _sha1List => d => {
+    // @ts-ignore
     window.open(
       `https://github.com/denoland/deno/commit/${_sha1List[d["index"]]}`
     );
@@ -230,6 +233,7 @@ export async function drawChartsFromBenchmarkData(dataUrl) {
  */
 export async function drawChartsFromTravisData() {
   const viewPullRequestOnClick = _prNumberList => d => {
+    // @ts-ignore
     window.open(
       `https://github.com/denoland/deno/pull/${_prNumberList[d["index"]]}`
     );


### PR DESCRIPTION
Fixes #976 

This PR enables the `--checkJs` TypeScript compiler option.  This means that JavaScript will be type checked and users can supply JSDoc type annotations that will be enforced by Deno, reporting type issues when running programmes.  This means all JavaScript will be compared to the built in type library and ensure the JavaScript programmes utilise Deno APIs with type safety.  The way JavaScript is checked by the TypeScript compiler is very loose, but allows users to incrementally "opt-in" using the JSDoc annotations.

The feature is [described here](https://github.com/Microsoft/TypeScript/wiki/Type-Checking-JavaScript-Files).

While the pragma of `// @ts-ignore` and `// @ts-nocheck` work in Deno, it is not recommended they be used as they are simply ignoring a problem that might not _yet_ be a runtime exception, but could/should be.  My recommendation is that if there is any JavaScript that _should_ work but fails because of a type error, we look at addressing why that is the case versus just _ignoring_ it.