### PR TITLE
WIP: build as rust crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@
 [package]
 name = "deno"
 version = "0.0.0"
+build = "build.rs"
 
 [dependencies]
 dirs = "1.0.4"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,29 @@
+use std::env;
+use std::process::Command;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+
+    // ./third_party/depot_tools/gn gen $OUT_DIR
+    let gn_status = Command::new("./third_party/depot_tools/gn")
+        .args(&["gen", &out_dir])
+        .status()
+        .expect("Failed to execute GN.");
+
+    if !gn_status.success() {
+        println!("Failed to generate GN build configuration.");
+        std::process::exit(-1);
+    }
+
+
+    // DENO_BUILD_PATH=$OUT_DIR python ./tools/build.py
+    let py_status = Command::new("python")
+        .env("DENO_BUILD_PATH", out_dir)
+        .arg("./tools/build.py")
+        .arg("libdeno")
+        .status()
+        .expect("Failed to build Deno.\nMake sure you have `python` in your PATH.");
+    if !py_status.success() {
+        std::process::exit(-1);
+    }
+}

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -26,6 +26,7 @@ type DenoRecvCb = unsafe extern "C" fn(
   data_buf: deno_buf,
 );
 
+#[link(name = "libdeno", kind = "static")]
 extern "C" {
   pub fn deno_init();
   pub fn deno_v8_version() -> *const c_char;


### PR DESCRIPTION
Started from #724, and #695.

I've got `libdeno` to compile, but build fails on:
```
 --> src/main.rs:7:1
  |
7 | extern crate msg_rs as msg;
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate

error: aborting due to previous error
```

AFAIK we need to incorporate compilation of `msg.fbs` into `crate build` process.

CC @ry 