### PR TITLE
format: don't format files in third_party

### DIFF
--- a/tools/format.py
+++ b/tools/format.py
@@ -17,33 +17,21 @@ rustfmt_config = os.path.join(tools_path, "rustfmt.toml")
 os.chdir(root_path)
 
 run([clang_format_path, "-i", "-style", "Google"] +
-    find_exts("libdeno", ".cc", ".h"))
+    find_exts(["libdeno"], [".cc", ".h"]))
 
-for fn in ["BUILD.gn", ".gn"] + find_exts("build_extra", ".gn", ".gni"):
+for fn in ["BUILD.gn", ".gn"] + find_exts(["build_extra"], [".gn", ".gni"]):
     run(["third_party/depot_tools/gn", "format", fn], env=google_env())
 
-# We use `glob()` instead of `find_exts()` in the tools directory, because:
-#   * On Windows, `os.walk()` (called by `find_exts()`) follows symlinks.
-#   * The tools directory contains a symlink 'clang', pointing at the directory
-#     'third_party/v8/tools/clang', which contains many .py files.
-#   * These third party python files shouldn't be formatted.
-#   * The tools directory has no subdirectories, so `glob()` is sufficient.
-# TODO(ry) Install yapf in third_party.
-run([sys.executable, "third_party/python_packages/bin/yapf", "-i"] +
-    glob("tools/*.py") + find_exts("build_extra", ".py"),
+run([sys.executable, "third_party/python_packages/bin/yapf", "-i"] + find_exts(
+    ["tools", "build_extra"], [".py"], skip=["tools/clang"]),
     env=python_env())
 
-# yapf: disable
-run(["node", prettier, "--write"] +
-    ["rollup.config.js"] + glob("*.json") + glob("*.md") +
-    find_exts(".github/", ".md") +
-    find_exts("js/", ".js", ".ts", ".md") +
-    find_exts("tests/", ".js", ".ts", ".md") +
-    find_exts("tools/", ".js", ".json", ".ts", ".md") +
-    find_exts("website/", ".js", ".ts", ".md"))
-# yapf: enable
+run(["node", prettier, "--write"] + ["rollup.config.js"] + glob("*.json") +
+    glob("*.md") + find_exts([".github", "js", "tests", "tools", "website"],
+                             [".js", ".json", ".ts", ".md"],
+                             skip=["tools/clang"]))
 
 run([
     "third_party/rustfmt/" + platform() +
     "/rustfmt", "--config-path", rustfmt_config
-] + find_exts("src/", ".rs"))
+] + find_exts(["src"], [".rs"]))

--- a/tools/third_party.py
+++ b/tools/third_party.py
@@ -161,7 +161,6 @@ def run_pip():
         merge_env=pip_env)
 
     # Get yapf.
-    # Install pywin32.
     run([
         sys.executable, "-m", "pip", "install", "--upgrade", "--target",
         python_packages_path, "yapf"

--- a/tools/util.py
+++ b/tools/util.py
@@ -131,15 +131,24 @@ def touch(fname):
 
 
 # Recursive search for files of certain extensions.
-# (Recursive glob doesn't exist in python 2.7.)
-def find_exts(directory, *extensions):
+#   * Recursive glob doesn't exist in python 2.7.
+#   * On windows, `os.walk()` unconditionally follows symlinks.
+#     The `skip`  parameter should be used to avoid recursing through those.
+def find_exts(directories, extensions, skip=[]):
+    assert isinstance(directories, list)
+    assert isinstance(extensions, list)
+    skip = [os.path.normpath(i) for i in skip]
     matches = []
-    for root, dirnames, filenames in os.walk(directory):
-        for filename in filenames:
-            for ext in extensions:
-                if filename.endswith(ext):
-                    matches.append(os.path.join(root, filename))
-                    break
+    for directory in directories:
+        for root, dirnames, filenames in os.walk(directory):
+            if root in skip:
+                dirnames[:] = []  # Don't recurse further into this directory.
+                continue
+            for filename in filenames:
+                for ext in extensions:
+                    if filename.endswith(ext):
+                        matches.append(os.path.join(root, filename))
+                        break
     return matches
 
 


### PR DESCRIPTION
It's annoying, and it also makes appveyor slow because it will re-upload
the third_party cache every time something changes in there.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
