### PR TITLE
Show backtrace using backtrace crate

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -62,6 +62,7 @@ main_extern = [
   "$rust_build:url",
   "$rust_build:remove_dir_all",
   "$rust_build:dirs",
+  "$rust_build:backtrace",
   "//build_extra/flatbuffers/rust:flatbuffers",
   ":msg_rs",
 ]

--- a/build_extra/rust/BUILD.gn
+++ b/build_extra/rust/BUILD.gn
@@ -114,6 +114,7 @@ rust_crate("winapi") {
     "cfg",
     "cfgmgr32",
     "combaseapi",
+    "dbghelp",
     "errhandlingapi",
     "excpt",
     "fileapi",
@@ -919,4 +920,30 @@ rust_crate("parking_lot_core") {
 rust_crate("lock_api") {
   source_root = "$registry_github/lock_api-0.1.3/src/lib.rs"
   extern = [ ":scopeguard" ]
+}
+
+rust_crate("backtrace_sys") {
+  source_root = "$registry_github/backtrace-sys-0.1.24/src/lib.rs"
+  extern = [ ":libc" ]
+}
+
+rust_crate("rustc_demangle") {
+  source_root = "$registry_github/rustc-demangle-0.1.9/src/lib.rs"
+  extern = []
+}
+
+rust_crate("backtrace") {
+  source_root = "$registry_github/backtrace-0.3.9/src/lib.rs"
+  features = [
+    "libunwind",
+    "libbacktrace",
+    "coresymbolication",
+    "dladdr",
+    "dbghelp",
+  ]
+  extern = [
+    ":libc",
+    ":cfg_if",
+    ":rustc_demangle",
+  ]
 }


### PR DESCRIPTION
Trying to close #1075

Without `RUST_BACKTRACE` (with manually introduced panic):
```
PANIC occurred: "BOOM"
   at file '../../src/flags.rs' line 88 column 22
note: Run with `RUST_BACKTRACE=1` for a backtrace.
Abort trap: 6
```

With `RUST_BACKTRACE=1` (somehow very slow...):
```
PANIC occurred: "BOOM"
   at file '../../src/flags.rs' line 88 column 22
Generating backtrace (this may take a while)...
stack backtrace:
   0:        0x106747684 - backtrace::backtrace::trace::h7521a6f8a16644a2
   1:        0x106741d1c - backtrace::capture::Backtrace::new_unresolved::h3c59519b6e970ab4
   2:        0x106741c7e - backtrace::capture::Backtrace::new::h92da90e18a74c240
   3:        0x106dd3f8e - deno_bin::main::{{closure}}::h56f17ed2946f3e90
                        at ../../src/main.rs:75
   4:        0x105397fb8 - std::panicking::rust_panic_with_hook::h4cb31c29ed859698
   5:        0x106756677 - std::panicking::begin_panic::h795f5ce9987d7001
   6:        0x106dbad0f - deno_bin::flags::set_flags::h3f0965e25312cff7
                        at ../../src/flags.rs:88
   7:        0x106dd39e9 - deno_bin::main::hca0fdc99db1f89a0
                        at ../../src/main.rs:83
   8:        0x106c58691 - std::rt::lang_start::{{closure}}::h396d38ba250525b2
                        at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
   9:        0x105397937 - std::panicking::try::do_call::hdc4508fe181791f6
  10:        0x1053a428e - ___rust_maybe_catch_panic
  11:        0x105371e4c - std::rt::lang_start_internal::h6d6c64041629047f
  12:        0x106c58671 - std::rt::lang_start::h50f3d8bf0b40c17d
                        at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  13:        0x106ddd781 - _main
Abort trap: 6
```