### PR TITLE
doc: update TS and V8 version in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## A secure TypeScript runtime built on V8
 
-- Supports TypeScript 3.0 out of the box. Uses V8 7.0. That is, it's very modern
+- Supports TypeScript 3.1 out of the box. Uses V8 7.1. That is, it's very modern
   JavaScript.
 
 - No `package.json`. No npm. Not explicitly compatible with Node.


### PR DESCRIPTION
As the readme is the first thing I read when arriving on the repo, I think it should reflect the current state of deno. Maybe we would rather change the phrasing so we don't have to change it every time we update the dependencies - or we can make the change in the same commit as the version bump.

Refs: https://github.com/denoland/deno/pull/980
Refs: https://github.com/denoland/deno/pull/1041

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
