### PR TITLE
Decode main.js.map during snapshotting.

### DIFF
--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -368,6 +368,7 @@ export class DenoCompiler
   private _setupSourceMaps(): void {
     sourceMaps.install({
       installPrepareStackTrace: true,
+
       getGeneratedContents: (fileName: string): string | RawSourceMap => {
         this._log("compiler.getGeneratedContents", fileName);
         if (fileName === "gen/bundle/main.js") {
@@ -387,6 +388,11 @@ export class DenoCompiler
         }
       }
     });
+    // Pre-compute source maps for main.js.map. This will happen at compile-time
+    // as long as Compiler is instanciated before the snapshot is created..
+    const consumer = sourceMaps.loadConsumer("gen/bundle/main.js");
+    assert(consumer != null);
+    consumer!.computeColumnSpans();
   }
 
   private constructor() {

--- a/js/main.ts
+++ b/js/main.ts
@@ -10,6 +10,10 @@ import { sendSync, handleAsyncMsgFromRust } from "./dispatch";
 import { promiseErrorExaminer, promiseRejectHandler } from "./promise_util";
 import { version } from "typescript";
 
+// Instantiate compiler at the top-level so it decodes source maps for the main
+// bundle during snapshot.
+const compiler = DenoCompiler.instance();
+
 function sendStart(): msg.StartRes {
   const builder = flatbuffers.createBuilder();
   msg.Start.startStart(builder);
@@ -43,7 +47,6 @@ export default function denoMain() {
   libdeno.setGlobalErrorHandler(onGlobalError);
   libdeno.setPromiseRejectHandler(promiseRejectHandler);
   libdeno.setPromiseErrorExaminer(promiseErrorExaminer);
-  const compiler = DenoCompiler.instance();
 
   // First we send an empty "Start" message to let the privileged side know we
   // are ready. The response should be a "StartRes" message containing the CLI

--- a/js/v8_source_maps.ts
+++ b/js/v8_source_maps.ts
@@ -186,7 +186,7 @@ function CallSiteToString(frame: CallSite): string {
 // Regex for detecting source maps
 const reSourceMap = /^data:application\/json[^,]+base64,/;
 
-function loadConsumer(source: string): SourceMapConsumer | null {
+export function loadConsumer(source: string): SourceMapConsumer | null {
   let consumer = consumers.get(source);
   if (consumer == null) {
     const code = getGeneratedContents(source);
@@ -210,8 +210,8 @@ function loadConsumer(source: string): SourceMapConsumer | null {
       sourceMapData = arrayToStr(ui8);
       sourceMappingURL = source;
     } else {
-      // Support source map URLs relative to the source URL
-      //sourceMappingURL = supportRelativeURL(source, sourceMappingURL);
+      // TODO Support source map URLs relative to the source URL
+      // sourceMappingURL = supportRelativeURL(source, sourceMappingURL);
       sourceMapData = getGeneratedContents(sourceMappingURL);
     }
 
@@ -219,7 +219,6 @@ function loadConsumer(source: string): SourceMapConsumer | null {
       typeof sourceMapData === "string"
         ? JSON.parse(sourceMapData)
         : sourceMapData;
-    //console.log("sourceMapData", sourceMapData);
     consumer = new SourceMapConsumer(rawSourceMap);
     consumers.set(source, consumer);
   }
@@ -242,7 +241,7 @@ function retrieveSourceMapURL(fileData: string): string | null {
   return lastMatch[1];
 }
 
-function mapSourcePosition(position: Position): MappedPosition {
+export function mapSourcePosition(position: Position): MappedPosition {
   const consumer = loadConsumer(position.source);
   if (consumer == null) {
     return position;

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -521,13 +521,6 @@ void InitializeContext(v8::Isolate* isolate, v8::Local<v8::Context> context,
             .FromJust());
 
   {
-    auto source = deno::v8_str(js_source);
-    CHECK(
-        deno_val->Set(context, deno::v8_str("mainSource"), source).FromJust());
-
-    bool r = deno::ExecuteV8StringSource(context, js_filename, source);
-    CHECK(r);
-
     if (source_map != nullptr) {
       v8::TryCatch try_catch(isolate);
       v8::ScriptOrigin origin(v8_str("set_source_map.js"));
@@ -551,6 +544,13 @@ void InitializeContext(v8::Isolate* isolate, v8::Local<v8::Context> context,
                       source_map_obj.ToLocalChecked())
                 .FromJust());
     }
+
+    auto source = deno::v8_str(js_source);
+    CHECK(
+        deno_val->Set(context, deno::v8_str("mainSource"), source).FromJust());
+
+    bool r = deno::ExecuteV8StringSource(context, js_filename, source);
+    CHECK(r);
   }
 }
 


### PR DESCRIPTION
Fixes #1087

Pro:
time ./out/debug/deno tests/error_001.ts  3.0s -> 0.4s

Con:
time ./tool/build.py snapshot              33s -> 1m52s
out/debug/gen/snapshot_deno.bin            39M -> 121M

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
