### PR TITLE
Fix bundle hashing.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -152,7 +152,7 @@ source_set("snapshot") {
   # header file that contains the the sha256 hash of the snapshot.
   if (cc_wrapper != "" && cc_wrapper != "ccache") {
     hash_h = "$target_gen_dir/bundle/hash.h"
-    inputs = [
+    data = [
       hash_h,
     ]
     deps += [ ":bundle_hash_h" ]


### PR DESCRIPTION
Across several PRs we are experiencing AppVeyor failure. It appears to be due to the bundle not rebuilding...  I believe this fixes it.

Examples of the failures we're seeing:

https://github.com/denoland/deno/pull/1056
```
C:/deno/js/file_test.ts:5:20 - error TS2552: Cannot find name 'File'. Did you mean 'file'?
5   const file = new File(arg1, "name");
                     ~~~~
```
https://github.com/denoland/deno/pull/1088
```
C:/deno/js/chmod_test.ts:18:8 - error TS2339: Property 'chmodSync' does not exist on type 'typeof import("deno")'.
18   deno.chmodSync(filename, 0o777);
          ~~~~~~~~~
```
