### PR TITLE
Separate source maps from output code

### DIFF
--- a/js/os.ts
+++ b/js/os.ts
@@ -11,6 +11,7 @@ interface CodeInfo {
   mediaType: msg.MediaType;
   sourceCode: string | undefined;
   outputCode: string | undefined;
+  sourceMap: string | undefined;
 }
 
 /** Exit the Deno process with optional exit code. */
@@ -52,7 +53,8 @@ export function codeFetch(
     filename: codeFetchRes.filename() || undefined,
     mediaType: codeFetchRes.mediaType(),
     sourceCode: codeFetchRes.sourceCode() || undefined,
-    outputCode: codeFetchRes.outputCode() || undefined
+    outputCode: codeFetchRes.outputCode() || undefined,
+    sourceMap: codeFetchRes.sourceMap() || undefined
   };
 }
 
@@ -60,17 +62,20 @@ export function codeFetch(
 export function codeCache(
   filename: string,
   sourceCode: string,
-  outputCode: string
+  outputCode: string,
+  sourceMap: string
 ): void {
   util.log("os.ts codeCache", filename, sourceCode, outputCode);
   const builder = flatbuffers.createBuilder();
   const filename_ = builder.createString(filename);
   const sourceCode_ = builder.createString(sourceCode);
   const outputCode_ = builder.createString(outputCode);
+  const sourceMap_ = builder.createString(sourceMap);
   msg.CodeCache.startCodeCache(builder);
   msg.CodeCache.addFilename(builder, filename_);
   msg.CodeCache.addSourceCode(builder, sourceCode_);
   msg.CodeCache.addOutputCode(builder, outputCode_);
+  msg.CodeCache.addSourceMap(builder, sourceMap_);
   const inner = msg.CodeCache.endCodeCache(builder);
   const baseRes = sendSync(builder, msg.Any.CodeCache, inner);
   assert(baseRes == null); // Expect null or error.

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -146,14 +146,18 @@ table CodeFetchRes {
   module_name: string;
   filename: string;
   media_type: MediaType;
+  // TODO These should be [ubyte].
+  // See: https://github.com/denoland/deno/issues/1113
   source_code: string;
   output_code: string; // Non-empty only if cached.
+  source_map: string; // Non-empty only if cached.
 }
 
 table CodeCache {
   filename: string;
   source_code: string;
   output_code: string;
+  source_map: string;
 }
 
 table Chdir {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -257,12 +257,12 @@ fn op_code_fetch(
       source_code: Some(builder.create_string(&out.source_code)),
       ..Default::default()
     };
-    match out.maybe_output_code {
-      Some(ref output_code) => {
-        msg_args.output_code = Some(builder.create_string(output_code));
-      }
-      _ => (),
-    };
+    if let Some(ref output_code) = out.maybe_output_code {
+      msg_args.output_code = Some(builder.create_string(output_code));
+    }
+    if let Some(ref source_map) = out.maybe_source_map {
+      msg_args.source_map = Some(builder.create_string(source_map));
+    }
     let inner = msg::CodeFetchRes::create(builder, &msg_args);
     Ok(serialize_response(
       cmd_id,
@@ -287,8 +287,11 @@ fn op_code_cache(
   let filename = inner.filename().unwrap();
   let source_code = inner.source_code().unwrap();
   let output_code = inner.output_code().unwrap();
+  let source_map = inner.source_map().unwrap();
   Box::new(futures::future::result(|| -> OpResult {
-    state.dir.code_cache(filename, source_code, output_code)?;
+    state
+      .dir
+      .code_cache(filename, source_code, output_code, source_map)?;
     Ok(empty_buf())
   }()))
 }


### PR DESCRIPTION
Fixes #24

Separates the source maps to a distinct cache file and deals with them independently.

This appears to be functionality complete, but wanted to get an initial review before I write all the tests for it.