### PR TITLE
Set up git pre-commit hook and format the code automatically

### DIFF
--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Copyright 2018 the Deno authors. All rights reserved. MIT license.
+# The script for git pre-commit hook.
+# This script formats the source code and adds them back to staging.
+staged=$(git diff --cached --name-only --diff-filter=ACM | tr '\n' ' ')
+[ -z "$staged" ] && exit 0
+echo Formatting files
+./tools/format.py
+echo "$staged" | xargs git add
+exit 0

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -6,11 +6,13 @@ from util import shell_quote
 import os
 import re
 import sys
+import shutil
 from distutils.spawn import find_executable
 
 
 def main():
     enable_ansi_colors()
+    set_up_git_hooks()
 
     os.chdir(root_path)
 
@@ -47,6 +49,12 @@ def write_lastchange():
     #    sys.executable, "build/util/lastchange.py", "-o",
     #    "build/util/LASTCHANGE", "--source-dir", root_path, "--filter="
     # ])
+
+
+def set_up_git_hooks():
+    pre_commit_src = os.path.join(root_path, 'tools', 'pre-commit.sh')
+    pre_commit = os.path.join(root_path, '.git', 'hooks', 'pre-commit')
+    shutil.copy2(pre_commit_src, pre_commit)
 
 
 # If this text is found in args.gn, we assume it hasn't been hand edited.


### PR DESCRIPTION
Related to #363 (but not a direct solution)

This PR sets up `.git/hooks/pre-commit` from `//tools/setup.py` and it runs `//tools/format.py` at `git commit` and adds back the change to the staging of commit. With this change, committed files should be always formatted and it prevents unformatted codes to appear in future pull requests.


