### PR TITLE
v0.1.10

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -3,7 +3,7 @@ use libdeno;
 use std::ffi::CStr;
 
 // This is the source of truth for the Deno version. Ignore the value in Cargo.toml.
-pub const DENO_VERSION: &str = "0.1.9";
+pub const DENO_VERSION: &str = "0.1.10";
 
 pub fn get_v8_version() -> &'static str {
   let v = unsafe { libdeno::deno_v8_version() };


### PR DESCRIPTION
- Add URLSearchParams (#1049)
- Implement clone for FetchResponse (#1054)
- Use content-type headers when importing from URLs. (#1020)
- Use checkJs option, JavaScript will be type checked and users can
  supply JSDoc type annotations that will be enforced by Deno (#1068)
- Add separate http/https cache dirs to DENO_DIR (#971)
- Support https in fetch. (#1100)
- Add chmod/chmodSync on unix (#1088)
- Remove broken features: --deps and trace() (#1103)
- Ergonomics: Prompt TTY for permission escalation (#1081)

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
