### PR TITLE
Add application/x-typescript mime type support

### DIFF
--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -794,7 +794,8 @@ fn map_content_type(path: &Path, content_type: Option<&str>) -> msg::MediaType {
         "application/typescript"
         | "text/typescript"
         | "video/vnd.dlna.mpeg-tts"
-        | "video/mp2t" => msg::MediaType::TypeScript,
+        | "video/mp2t"
+        | "application/x-typescript" => msg::MediaType::TypeScript,
         "application/javascript"
         | "text/javascript"
         | "application/ecmascript"
@@ -855,6 +856,10 @@ fn test_map_content_type() {
   );
   assert_eq!(
     map_content_type(Path::new("foo/bar"), Some("video/mp2t")),
+    msg::MediaType::TypeScript
+  );
+  assert_eq!(
+    map_content_type(Path::new("foo/bar"), Some("application/x-typescript")),
     msg::MediaType::TypeScript
   );
   assert_eq!(

--- a/tests/019_media_types.ts
+++ b/tests/019_media_types.ts
@@ -6,6 +6,7 @@
 import { loaded as loadedTs1 } from "http://localhost:4545/tests/subdir/mt_text_typescript.t1.ts";
 import { loaded as loadedTs2 } from "http://localhost:4545/tests/subdir/mt_video_vdn.t2.ts";
 import { loaded as loadedTs3 } from "http://localhost:4545/tests/subdir/mt_video_mp2t.t3.ts";
+import { loaded as loadedTs4 } from "http://localhost:4545/tests/subdir/mt_application_x_typescript.t4.ts";
 import { loaded as loadedJs1 } from "http://localhost:4545/tests/subdir/mt_text_javascript.j1.js";
 import { loaded as loadedJs2 } from "http://localhost:4545/tests/subdir/mt_application_ecmascript.j2.js";
 import { loaded as loadedJs3 } from "http://localhost:4545/tests/subdir/mt_text_ecmascript.j3.js";
@@ -16,6 +17,7 @@ console.log(
   loadedTs1,
   loadedTs2,
   loadedTs3,
+  loadedTs4,
   loadedJs1,
   loadedJs2,
   loadedJs3,

--- a/tests/019_media_types.ts.out
+++ b/tests/019_media_types.ts.out
@@ -1,8 +1,9 @@
 Downloading http://localhost:4545/tests/subdir/mt_text_typescript.t1.ts
 Downloading http://localhost:4545/tests/subdir/mt_video_vdn.t2.ts
 Downloading http://localhost:4545/tests/subdir/mt_video_mp2t.t3.ts
+Downloading http://localhost:4545/tests/subdir/mt_application_x_typescript.t4.ts
 Downloading http://localhost:4545/tests/subdir/mt_text_javascript.j1.js
 Downloading http://localhost:4545/tests/subdir/mt_application_ecmascript.j2.js
 Downloading http://localhost:4545/tests/subdir/mt_text_ecmascript.j3.js
 Downloading http://localhost:4545/tests/subdir/mt_application_x_javascript.j4.js
-success true true true true true true true
+success true true true true true true true true

--- a/tests/subdir/mt_application_x_typescript.t4.ts
+++ b/tests/subdir/mt_application_x_typescript.t4.ts
@@ -1,0 +1,1 @@
+export const loaded = true;

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -22,6 +22,8 @@ class ContentTypeHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
             return "video/vnd.dlna.mpeg-tts"
         if ".t3." in path:
             return "video/mp2t"
+        if ".t4." in path:
+            return "application/x-typescript"
         if ".j1." in path:
             return "text/javascript"
         if ".j2." in path:


### PR DESCRIPTION
E.g. `deno http://deno.land/thumb.ts` does not work after MIME type enforcement PR, as it is served with MIME type `application/x-typescript`.