### PR TITLE
[WIP] TS Compiler Options

### DIFF
--- a/js/main.ts
+++ b/js/main.ts
@@ -43,7 +43,6 @@ export default function denoMain() {
   libdeno.setGlobalErrorHandler(onGlobalError);
   libdeno.setPromiseRejectHandler(promiseRejectHandler);
   libdeno.setPromiseErrorExaminer(promiseErrorExaminer);
-  const compiler = DenoCompiler.instance();
 
   // First we send an empty "Start" message to let the privileged side know we
   // are ready. The response should be a "StartRes" message containing the CLI
@@ -51,6 +50,10 @@ export default function denoMain() {
   const startResMsg = sendStart();
 
   setLogDebug(startResMsg.debugFlag());
+
+  const compiler = DenoCompiler.instance({
+    strict: startResMsg.strictFlag()
+  });
 
   // handle `--types`
   if (startResMsg.typesFlag()) {

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -17,15 +17,16 @@ macro_rules! svec {
 
 #[derive(Debug, PartialEq, Default)]
 pub struct DenoFlags {
+  pub allow_env: bool,
+  pub allow_net: bool,
+  pub allow_write: bool,
   pub help: bool,
   pub log_debug: bool,
-  pub version: bool,
-  pub reload: bool,
   pub recompile: bool,
-  pub allow_write: bool,
-  pub allow_net: bool,
-  pub allow_env: bool,
+  pub reload: bool,
+  pub strict: bool,
   pub types_flag: bool,
+  pub version: bool,
 }
 
 pub fn process(flags: &DenoFlags, usage_string: String) {
@@ -70,6 +71,7 @@ pub fn set_flags(
   opts.optflag("r", "reload", "Reload cached remote resources.");
   opts.optflag("", "v8-options", "Print V8 command line options.");
   opts.optflag("", "types", "Print runtime TypeScript declarations.");
+  opts.optflag("s", "strict", "Evaluate TypeScript in strict mode.");
 
   let mut flags = DenoFlags::default();
 
@@ -80,32 +82,38 @@ pub fn set_flags(
     }
   };
 
+  if matches.opt_present("allow-env") {
+    flags.allow_env = true;
+  }
+  if matches.opt_present("allow-net") {
+    flags.allow_net = true;
+  }
+  if matches.opt_present("allow-write") {
+    flags.allow_write = true;
+  }
   if matches.opt_present("help") {
     flags.help = true;
   }
   if matches.opt_present("log-debug") {
     flags.log_debug = true;
   }
-  if matches.opt_present("version") {
-    flags.version = true;
+  if matches.opt_present("recompile") {
+    flags.recompile = true;
   }
   if matches.opt_present("reload") {
     flags.reload = true;
   }
-  if matches.opt_present("recompile") {
-    flags.recompile = true;
-  }
-  if matches.opt_present("allow-write") {
-    flags.allow_write = true;
-  }
-  if matches.opt_present("allow-net") {
-    flags.allow_net = true;
-  }
-  if matches.opt_present("allow-env") {
-    flags.allow_env = true;
+  if matches.opt_present("strict") {
+    flags.strict = true;
   }
   if matches.opt_present("types") {
     flags.types_flag = true;
+  }
+  if matches.opt_present("strict") {
+    flags.strict = true;
+  }
+  if matches.opt_present("version") {
+    flags.version = true;
   }
 
   let rest: Vec<_> = matches.free.iter().map(|s| s.clone()).collect();
@@ -179,6 +187,19 @@ fn test_set_flags_5() {
     flags,
     DenoFlags {
       types_flag: true,
+      ..DenoFlags::default()
+    }
+  )
+}
+
+#[test]
+fn test_set_flags_6() {
+  let (flags, rest, _) = set_flags(svec!["deno", "--strict"]).unwrap();
+  assert_eq!(rest, svec!["deno"]);
+  assert_eq!(
+    flags,
+    DenoFlags {
+      strict: true,
       ..DenoFlags::default()
     }
   )

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -123,15 +123,16 @@ table Start {
 }
 
 table StartRes {
-  cwd: string;
   argv: [string];
+  cwd: string;
   debug_flag: bool;
+  deno_version: string;
   deps_flag: bool;
   recompile_flag: bool;
+  strict_flag: bool;
   types_flag: bool;
-  version_flag: bool;
-  deno_version: string;
   v8_version: string;
+  version_flag: bool;
 }
 
 table CodeFetch {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -187,14 +187,15 @@ fn op_start(
   let inner = msg::StartRes::create(
     &mut builder,
     &msg::StartResArgs {
-      cwd: Some(cwd_off),
       argv: Some(argv_off),
+      cwd: Some(cwd_off),
       debug_flag: state.flags.log_debug,
-      recompile_flag: state.flags.recompile,
-      types_flag: state.flags.types_flag,
-      version_flag: state.flags.version,
-      v8_version: Some(v8_version_off),
       deno_version: Some(deno_version_off),
+      recompile_flag: state.flags.recompile,
+      strict_flag: state.flags.strict,
+      types_flag: state.flags.types_flag,
+      v8_version: Some(v8_version_off),
+      version_flag: state.flags.version,
       ..Default::default()
     },
   );

--- a/tests/flags/README.md
+++ b/tests/flags/README.md
@@ -1,0 +1,19 @@
+# Flag Tests
+
+Tests located in sub-directories of this one will be executed by passing the
+specified flags to Deno on the command line. Multiple flags are denoted by an
+`_` in the directory name.
+
+For example if a test was named `tests/flags/foo/test.ts` with a corresponding
+`tests/flags/foo/test.ts.out` the command line to Deno would be:
+
+```
+$ deno --foo tests/flags/foo/test.ts
+```
+
+If the test was named `tests/flags/foo_bar/test.ts` with a corresponding
+`tests/flags/foo_bar/test.ts.out` the command line to Deno would be:
+
+```
+$ deno --foo --bar tests/flags/foo_bar/test.ts
+```

--- a/tests/flags/strict/error_maybe_undefined.ts
+++ b/tests/flags/strict/error_maybe_undefined.ts
@@ -1,0 +1,5 @@
+const map = new Map<string, { bar: string }>();
+
+if (map.get("foo").bar) {
+  console.log("maybe undefined");
+}

--- a/tests/flags/strict/error_maybe_undefined.ts.out
+++ b/tests/flags/strict/error_maybe_undefined.ts.out
@@ -1,0 +1,5 @@
+[96m[WILDCARD]/tests/flags/strict/error_maybe_undefined.ts[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS2532: [0mObject is possibly 'undefined'.
+
+[7m3[0m if (map.get("foo").bar) {
+[7m [0m [91m    ~~~~~~~~~~~~~~[0m
+

--- a/tools/flag_output_tests.py
+++ b/tools/flag_output_tests.py
@@ -27,7 +27,8 @@ def flag_output_tests(deno_executable):
             if filename.endswith(".out")
         ])
         assert len(outs) > 0
-        tests = [(os.path.splitext(filename)[0], filename) for filename in outs]
+        tests = [(os.path.splitext(filename)[0], filename)
+                 for filename in outs]
         for (script, out_filename) in tests:
             script_abs = os.path.join(tests_path, script)
             out_abs = os.path.join(tests_path, out_filename)
@@ -39,7 +40,8 @@ def flag_output_tests(deno_executable):
             print " ".join(cmd)
             actual_code = 0
             try:
-                actual_out = subprocess.check_output(cmd, universal_newlines=True)
+                actual_out = subprocess.check_output(
+                    cmd, universal_newlines=True)
             except subprocess.CalledProcessError as e:
                 actual_code = e.returncode
                 actual_out = e.output
@@ -62,7 +64,7 @@ def flag_output_tests(deno_executable):
                 sys.exit(1)
 
 
-def main (argv):
+def main(argv):
     flag_output_tests(argv[1])
 
 

--- a/tools/flag_output_tests.py
+++ b/tools/flag_output_tests.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# Copyright 2018 the Deno authors. All rights reserved. MIT license.
+# Given a deno executable, this script executes several integration tests also
+# passing command line flags to the deno executable based on the path of the
+# test case.
+#
+# Usage: flag_output_tests.py [path to deno executable]
+import os
+import sys
+import subprocess
+from util import pattern_match, parse_exit_code
+
+root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+flags_path = os.path.join(root_path, "tests", "flags")
+
+
+def flag_output_tests(deno_executable):
+    assert os.path.isfile(deno_executable)
+    switch_dirs = sorted([
+        filename for filename in os.listdir(flags_path)
+        if os.path.isdir(os.path.join(flags_path, filename))
+    ])
+    for switch_dir in switch_dirs:
+        tests_path = os.path.join(flags_path, switch_dir)
+        outs = sorted([
+            filename for filename in os.listdir(tests_path)
+            if filename.endswith(".out")
+        ])
+        assert len(outs) > 0
+        tests = [(os.path.splitext(filename)[0], filename) for filename in outs]
+        for (script, out_filename) in tests:
+            script_abs = os.path.join(tests_path, script)
+            out_abs = os.path.join(tests_path, out_filename)
+            with open(out_abs, 'r') as f:
+                expected_out = f.read()
+            flags = ["--" + flag for flag in switch_dir.split("_")]
+            cmd = [deno_executable, script_abs, "--reload"] + flags
+            expected_code = parse_exit_code(script)
+            print " ".join(cmd)
+            actual_code = 0
+            try:
+                actual_out = subprocess.check_output(cmd, universal_newlines=True)
+            except subprocess.CalledProcessError as e:
+                actual_code = e.returncode
+                actual_out = e.output
+                if expected_code == 0:
+                    print "Expected success but got error. Output:"
+                    print actual_out
+                    sys.exit(1)
+
+            if expected_code != actual_code:
+                print "Expected exit code %d but got %d" % (expected_code,
+                                                            actual_code)
+                print "Output:"
+                print actual_out
+                sys.exit(1)
+
+            if pattern_match(expected_out, actual_out) != True:
+                print "Expected output does not match actual."
+                print "Expected: " + expected_out
+                print "Actual:   " + actual_out
+                sys.exit(1)
+
+
+def main (argv):
+    flag_output_tests(argv[1])
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tools/test.py
+++ b/tools/test.py
@@ -5,6 +5,7 @@
 import os
 import sys
 from check_output_test import check_output_test
+from flag_output_tests import flag_output_tests
 from deno_dir_test import deno_dir_test
 from setup_test import setup_test
 from util import build_path, enable_ansi_colors, executable_suffix, run, rmtree
@@ -59,6 +60,8 @@ def main(argv):
     unit_tests(deno_exe)
 
     check_output_test(deno_exe)
+
+    flag_output_tests(deno_exe)
 
     # TODO We currently skip testing the prompt in Windows completely.
     # Windows does not support the pty module used for testing the permission


### PR DESCRIPTION
Fixes #51 

Based on my thoughts in #51, I have done a WIP.  This currently adds the infrastructure to take additional command line flags and pass them to the TypeScript compiler.  This WIP adds the options `--strict` along with some additional test infrastructure for automating testing of various flags.

Thoughts and feedback on the approach are welcomed.