### PR TITLE
resources op

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -102,6 +102,7 @@ ts_sources = [
   "js/read_link.ts",
   "js/remove.ts",
   "js/rename.ts",
+  "js/resources.ts",
   "js/stat.ts",
   "js/symlink.ts",
   "js/text_encoding.ts",

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -38,6 +38,7 @@ export { truncateSync, truncate } from "./truncate";
 export { FileInfo } from "./file_info";
 export { connect, dial, listen, Listener, Conn } from "./net";
 export { metrics } from "./metrics";
+export { resources } from "./resources";
 export const args: string[] = [];
 
 // Provide the compiler API in an obfuscated way

--- a/js/resources.ts
+++ b/js/resources.ts
@@ -1,0 +1,41 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import * as msg from "gen/msg_generated";
+import * as flatbuffers from "./flatbuffers";
+import { assert } from "./util";
+import * as dispatch from "./dispatch";
+
+interface Resource {
+  rid: number;
+  repr: string;
+}
+
+export function resources(): Resource[] {
+  return res(dispatch.sendSync(...req()));
+}
+
+function req(): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
+  const builder = flatbuffers.createBuilder();
+  msg.Resources.startResources(builder);
+  const inner = msg.Resource.endResource(builder);
+  return [builder, msg.Any.Resources, inner];
+}
+
+function res(baseRes: null | msg.Base): Resource[] {
+  assert(baseRes !== null);
+  assert(msg.Any.ResourcesRes === baseRes!.innerType());
+  const res = new msg.ResourcesRes();
+  assert(baseRes!.inner(res) !== null);
+
+  const resources: Resource[] = [];
+
+  for (let i = 0; i < res.resourcesLength(); i++) {
+    const item = res.resources(i)!;
+
+    resources.push({
+        rid: item.rid()!,
+        repr: item.repr()!,
+    });
+  }
+
+  return resources;
+}

--- a/js/resources.ts
+++ b/js/resources.ts
@@ -32,8 +32,8 @@ function res(baseRes: null | msg.Base): Resource[] {
     const item = res.resources(i)!;
 
     resources.push({
-        rid: item.rid()!,
-        repr: item.repr()!,
+      rid: item.rid()!,
+      repr: item.repr()!
     });
   }
 

--- a/js/resources.ts
+++ b/js/resources.ts
@@ -37,5 +37,5 @@ function res(baseRes: null | msg.Base): Resource[] {
     });
   }
 
-  return resources;
+  return resources.sort((a, b) => a.rid - b.rid);
 }

--- a/js/resources_test.ts
+++ b/js/resources_test.ts
@@ -2,7 +2,7 @@
 import { test, testPerm, assert, assertEqual } from "./test_util.ts";
 import * as deno from "deno";
 
-test(function stdioResources() {
+test(function resourcesStdio() {
   const res = deno.resources();
 
   assertEqual(res[0], "stdin");
@@ -10,7 +10,7 @@ test(function stdioResources() {
   assertEqual(res[2], "stderr");
 });
 
-testPerm({ net: true }, async function netResources() {
+testPerm({ net: true }, async function resourcesNet() {
   const addr = "127.0.0.1:4500";
   const listener = deno.listen("tcp", addr);
 
@@ -31,9 +31,9 @@ testPerm({ net: true }, async function netResources() {
   conn.close();
 });
 
-test(function fileResources() {
+test(async function resourcesFile() {
   const resourcesBefore = deno.resources();
-  deno.open("package.json");
+  await deno.open("tests/hello.txt");
   const resourcesAfter = deno.resources();
 
   // check that exactly one new resource (file) was added
@@ -41,8 +41,8 @@ test(function fileResources() {
     Object.keys(resourcesAfter).length,
     Object.keys(resourcesBefore).length + 1
   );
-  const newRid = Object.keys(resourcesAfter).find(key => {
-    return !resourcesBefore.hasOwnProperty(key);
+  const newRid = Object.keys(resourcesAfter).find(rid => {
+    return !resourcesBefore.hasOwnProperty(rid);
   });
   assertEqual(resourcesAfter[newRid], "fsFile");
 });

--- a/js/resources_test.ts
+++ b/js/resources_test.ts
@@ -13,23 +13,17 @@ test(function resourcesStdio() {
 testPerm({ net: true }, async function resourcesNet() {
   const addr = "127.0.0.1:4501";
   const listener = deno.listen("tcp", addr);
-  let counter = 0;
 
-  listener.accept().then(async conn => {
-    const res = deno.resources();
-    // besides 3 stdio resources, we should have additional 3 from listen(), accept() and dial()
-    assertEqual(Object.keys(res).length, 6);
-    assertEqual(Object.values(res).filter(r => r === "tcpListener").length, 1);
-    assertEqual(Object.values(res).filter(r => r === "tcpStream").length, 2);
+  const dialerConn = await deno.dial("tcp", addr);
+  const listenerConn = await listener.accept();
 
-    conn.close();
-    listener.close();
-    counter++;
-  });
+  const res = deno.resources();
+  assertEqual(Object.values(res).filter(r => r === "tcpListener").length, 1);
+  assertEqual(Object.values(res).filter(r => r === "tcpStream").length, 2);
 
-  const conn = await deno.dial("tcp", addr);
-  conn.close();
-  assertEqual(counter, 1);
+  listenerConn.close();
+  dialerConn.close();
+  listener.close();
 });
 
 test(async function resourcesFile() {

--- a/js/resources_test.ts
+++ b/js/resources_test.ts
@@ -1,0 +1,32 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import { test, testPerm, assert, assertEqual } from "./test_util.ts";
+import * as deno from "deno";
+
+testPerm({ net: true }, async function resources() {
+  const res = deno.resources();
+  console.log('resources', res)
+  // there should be only stdio
+  assertEqual(res.length, 3);
+
+  const stdio = [{rid: 0, repr: "stdin"}, {rid: 1, repr: "stdout"}, {rid: 2, repr: "stderr"}];
+
+  stdio.forEach((stdioItem) => {
+    const found = res.find(resItem => resItem.rid === stdioItem.rid && resItem.repr === stdioItem.repr);
+    assert(!!found);
+  });
+
+  const addr = "127.0.0.1:4500";
+  const listener = deno.listen("tcp", addr);
+  listener.accept().then(async conn => {
+    // TODO: this is failing, we have 6 resources open intead of 4
+    const res1 = deno.resources();
+    console.log('resources', res1)
+    // there should be only stdio
+    assertEqual(res1.length, 4);
+    conn.close();
+  });
+
+  const conn = await deno.dial("tcp", addr);
+  const buf = new Uint8Array(1024);
+  await conn.read(buf);
+});

--- a/js/resources_test.ts
+++ b/js/resources_test.ts
@@ -11,7 +11,7 @@ test(function resourcesStdio() {
 });
 
 testPerm({ net: true }, async function resourcesNet() {
-  const addr = "127.0.0.1:4500";
+  const addr = "127.0.0.1:4501";
   const listener = deno.listen("tcp", addr);
 
   listener.accept().then(async conn => {

--- a/js/resources_test.ts
+++ b/js/resources_test.ts
@@ -5,7 +5,6 @@ import * as deno from "deno";
 test(function stdioResources() {
   const res = deno.resources();
 
-  assertEqual(Object.keys(res).length, 3);
   assertEqual(res[0], "stdin");
   assertEqual(res[1], "stdout");
   assertEqual(res[2], "stderr");
@@ -33,8 +32,17 @@ testPerm({ net: true }, async function netResources() {
 });
 
 test(function fileResources() {
+  const resourcesBefore = deno.resources();
   deno.open("package.json");
-  const res = deno.resources();
-  console.log(res);
-  assertEqual(Object.values(res).filter(r => r === "fsFile").length, 1);
+  const resourcesAfter = deno.resources();
+
+  // check that exactly one new resource (file) was added
+  assertEqual(
+    Object.keys(resourcesAfter).length,
+    Object.keys(resourcesBefore).length + 1
+  );
+  const newRid = Object.keys(resourcesAfter).find(key => {
+    return !resourcesBefore.hasOwnProperty(key);
+  });
+  assertEqual(resourcesAfter[newRid], "fsFile");
 });

--- a/js/resources_test.ts
+++ b/js/resources_test.ts
@@ -27,11 +27,13 @@ testPerm({ net: true }, async function netResources() {
     assertEqual(res.filter(r => r.repr === "tcpStream").length, 2);
 
     conn.close();
+    listener.close();
   });
 
   const conn = await deno.dial("tcp", addr);
   const buf = new Uint8Array(1024);
   await conn.read(buf);
+  conn.close();
 });
 
 test(function fileResources() {

--- a/js/resources_test.ts
+++ b/js/resources_test.ts
@@ -5,14 +5,10 @@ import * as deno from "deno";
 test(function stdioResources() {
   const res = deno.resources();
 
-  assertEqual(res[0].rid, 0);
-  assertEqual(res[0].repr, "stdin");
-
-  assertEqual(res[1].rid, 1);
-  assertEqual(res[1].repr, "stdout");
-
-  assertEqual(res[2].rid, 2);
-  assertEqual(res[2].repr, "stderr");
+  assertEqual(Object.keys(res).length, 3);
+  assertEqual(res[0], "stdin");
+  assertEqual(res[1], "stdout");
+  assertEqual(res[2], "stderr");
 });
 
 testPerm({ net: true }, async function netResources() {
@@ -22,9 +18,9 @@ testPerm({ net: true }, async function netResources() {
   listener.accept().then(async conn => {
     const res = deno.resources();
     // besides 3 stdio resources, we should have additional 3 from listen(), accept() and dial()
-    assertEqual(res.length, 6);
-    assertEqual(res.filter(r => r.repr === "tcpListener").length, 1);
-    assertEqual(res.filter(r => r.repr === "tcpStream").length, 2);
+    assertEqual(Object.keys(res).length, 6);
+    assertEqual(Object.values(res).filter(r => r === "tcpListener").length, 1);
+    assertEqual(Object.values(res).filter(r => r === "tcpStream").length, 2);
 
     conn.close();
     listener.close();
@@ -37,7 +33,8 @@ testPerm({ net: true }, async function netResources() {
 });
 
 test(function fileResources() {
-  deno.readFileSync("package.json");
+  deno.open("package.json");
   const res = deno.resources();
-  assertEqual(res.filter(r => r.repr === "fsFile").length, 1);
+  console.log(res);
+  assertEqual(Object.values(res).filter(r => r === "fsFile").length, 1);
 });

--- a/js/resources_test.ts
+++ b/js/resources_test.ts
@@ -13,6 +13,7 @@ test(function resourcesStdio() {
 testPerm({ net: true }, async function resourcesNet() {
   const addr = "127.0.0.1:4501";
   const listener = deno.listen("tcp", addr);
+  let counter = 0;
 
   listener.accept().then(async conn => {
     const res = deno.resources();
@@ -23,12 +24,12 @@ testPerm({ net: true }, async function resourcesNet() {
 
     conn.close();
     listener.close();
+    counter++;
   });
 
   const conn = await deno.dial("tcp", addr);
-  const buf = new Uint8Array(1024);
-  await conn.read(buf);
   conn.close();
+  assertEqual(counter, 1);
 });
 
 test(async function resourcesFile() {

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -22,6 +22,7 @@ import "./read_dir_test.ts";
 import "./read_file_test.ts";
 import "./read_link_test.ts";
 import "./rename_test.ts";
+import "./resources_test.ts";
 import "./stat_test.ts";
 import "./symlink_test.ts";
 import "./text_encoding_test.ts";

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -24,6 +24,8 @@ union Any {
   Rename,
   Readlink,
   ReadlinkRes,
+  Resources,
+  ResourcesRes,
   Symlink,
   Stat,
   StatRes,
@@ -268,6 +270,17 @@ table Readlink {
 
 table ReadlinkRes {
   path: string;
+}
+
+table Resources {}
+
+table Resource {
+  rid: int;
+  repr: string;
+}
+
+table ResourcesRes {
+  resources: [Resource];
 }
 
 table Symlink {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -19,6 +19,7 @@ use futures::Poll;
 use hyper;
 use hyper::rt::{Future, Stream};
 use remove_dir_all::remove_dir_all;
+use resources::get_resource_table_entries;
 use std;
 use std::fs;
 use std::net::{Shutdown, SocketAddr};
@@ -94,6 +95,7 @@ pub fn dispatch(
       msg::Any::Read => op_read,
       msg::Any::Remove => op_remove,
       msg::Any::Rename => op_rename,
+      msg::Any::Resources => op_resources,
       msg::Any::SetEnv => op_set_env,
       msg::Any::Shutdown => op_shutdown,
       msg::Any::Start => op_start,
@@ -1284,6 +1286,52 @@ fn op_metrics(
     msg::BaseArgs {
       inner: Some(inner.as_union_value()),
       inner_type: msg::Any::MetricsRes,
+      ..Default::default()
+    },
+  ))
+}
+
+fn op_resources(
+  _state: Arc<IsolateState>,
+  base: &msg::Base,
+  data: &'static mut [u8],
+) -> Box<Op> {
+  assert_eq!(data.len(), 0);
+  let cmd_id = base.cmd_id();
+
+  let builder = &mut FlatBufferBuilder::new();
+  let serialized_resources = get_resource_table_entries();
+
+  let res: Vec<_> = serialized_resources.iter()
+    .map(|key| {
+      // TODO: use actual repr of resource
+      let value = builder.create_string("foobar");
+
+      msg::Resource::create(
+        builder,
+        &msg::ResourceArgs {
+          rid: key.clone(),
+          repr: Some(value),
+          ..Default::default()
+        },
+      )
+    }).collect();
+
+  let resources = builder.create_vector(&res);
+  let inner = msg::ResourcesRes::create(
+    builder,
+    &msg::ResourcesResArgs {
+      resources: Some(resources),
+      ..Default::default()
+    },
+  );
+
+  ok_future(serialize_response(
+    cmd_id,
+    builder,
+    msg::BaseArgs {
+      inner: Some(inner.as_union_value()),
+      inner_type: msg::Any::ResourcesRes,
       ..Default::default()
     },
   ))

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1303,15 +1303,14 @@ fn op_resources(
   let serialized_resources = get_resource_table_entries();
 
   let res: Vec<_> = serialized_resources.iter()
-    .map(|key| {
-      // TODO: use actual repr of resource
-      let value = builder.create_string("foobar");
+    .map(|(key, value)| {
+      let s_value = builder.create_string(value);
 
       msg::Resource::create(
         builder,
         &msg::ResourceArgs {
           rid: key.clone(),
-          repr: Some(value),
+          repr: Some(s_value),
           ..Default::default()
         },
       )

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1304,13 +1304,13 @@ fn op_resources(
 
   let res: Vec<_> = serialized_resources.iter()
     .map(|(key, value)| {
-      let s_value = builder.create_string(value);
+      let repr = builder.create_string(value);
 
       msg::Resource::create(
         builder,
         &msg::ResourceArgs {
           rid: key.clone(),
-          repr: Some(s_value),
+          repr: Some(repr),
           ..Default::default()
         },
       )

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -19,7 +19,7 @@ use futures::Poll;
 use hyper;
 use hyper::rt::{Future, Stream};
 use remove_dir_all::remove_dir_all;
-use resources::get_resource_table_entries;
+use resources::table_entries;
 use std;
 use std::fs;
 use std::net::{Shutdown, SocketAddr};
@@ -1300,7 +1300,7 @@ fn op_resources(
   let cmd_id = base.cmd_id();
 
   let builder = &mut FlatBufferBuilder::new();
-  let serialized_resources = get_resource_table_entries();
+  let serialized_resources = table_entries();
 
   let res: Vec<_> = serialized_resources
     .iter()

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1302,7 +1302,8 @@ fn op_resources(
   let builder = &mut FlatBufferBuilder::new();
   let serialized_resources = get_resource_table_entries();
 
-  let res: Vec<_> = serialized_resources.iter()
+  let res: Vec<_> = serialized_resources
+    .iter()
     .map(|(key, value)| {
       let repr = builder.create_string(value);
 

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -74,7 +74,7 @@ fn inspect_repr(repr: &Repr) -> String {
     Repr::Stdin(_) => "stdin",
     Repr::Stdout(_) => "stdout",
     Repr::Stderr(_) => "stderr",
-    Repr::FsFile(_) => "fsfile",
+    Repr::FsFile(_) => "fsFile",
     Repr::TcpListener(_) => "tcpListener",
     Repr::TcpStream(_) => "tcpStream",
   };

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -61,27 +61,26 @@ enum Repr {
 pub fn get_resource_table_entries() -> Vec<(i32, String)> {
   let table = RESOURCE_TABLE.lock().unwrap();
 
-  let tuples = table.iter()
-    .map(|(key, value)| {
-      (key.clone(), inspect_repr(&value))
-    }).collect();
+  let tuples = table
+    .iter()
+    .map(|(key, value)| (key.clone(), inspect_repr(&value)))
+    .collect();
 
   tuples
 }
 
 fn inspect_repr(repr: &Repr) -> String {
-    let h_repr = match repr {
-        Repr::Stdin(_) => "stdin",
-        Repr::Stdout(_) => "stdout",
-        Repr::Stderr(_) => "stderr",
-        Repr::FsFile(_) => "fsfile",
-        Repr::TcpListener(_) => "tcpListener",
-        Repr::TcpStream(_) => "tcpStream",
-    };
+  let h_repr = match repr {
+    Repr::Stdin(_) => "stdin",
+    Repr::Stdout(_) => "stdout",
+    Repr::Stderr(_) => "stderr",
+    Repr::FsFile(_) => "fsfile",
+    Repr::TcpListener(_) => "tcpListener",
+    Repr::TcpStream(_) => "tcpStream",
+  };
 
   String::from(h_repr)
 }
-
 
 // Abstract async file interface.
 // Ideally in unix, if Resource represents an OS rid, it will be the same.

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -58,7 +58,7 @@ enum Repr {
   TcpStream(tokio::net::TcpStream),
 }
 
-pub fn get_resource_table_entries() -> HashMap<ResourceId, String> {
+pub fn get_resource_table_entries() -> Vec<(i32, String)> {
   let table = RESOURCE_TABLE.lock().unwrap();
 
   let tuples = table.iter()

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -16,7 +16,6 @@ use tokio_write;
 
 use futures;
 use futures::future::{Either, FutureResult};
-use futures::Future;
 use futures::Poll;
 use std;
 use std::collections::HashMap;

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -58,16 +58,30 @@ enum Repr {
   TcpStream(tokio::net::TcpStream),
 }
 
-pub fn get_resource_table_entries() -> Vec<i32> {
+pub fn get_resource_table_entries() -> HashMap<ResourceId, String> {
   let table = RESOURCE_TABLE.lock().unwrap();
 
-  let serialized_resources: Vec<i32> = table.iter()
-    .map(|(key, _value)| {
-        key.clone()
+  let tuples = table.iter()
+    .map(|(key, value)| {
+      (key.clone(), inspect_repr(&value))
     }).collect();
 
-  serialized_resources
+  tuples
 }
+
+fn inspect_repr(repr: &Repr) -> String {
+    let h_repr = match repr {
+        Repr::Stdin(_) => "stdin",
+        Repr::Stdout(_) => "stdout",
+        Repr::Stderr(_) => "stderr",
+        Repr::FsFile(_) => "fsfile",
+        Repr::TcpListener(_) => "tcpListener",
+        Repr::TcpStream(_) => "tcpStream",
+    };
+
+  String::from(h_repr)
+}
+
 
 // Abstract async file interface.
 // Ideally in unix, if Resource represents an OS rid, it will be the same.

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -58,6 +58,17 @@ enum Repr {
   TcpStream(tokio::net::TcpStream),
 }
 
+pub fn get_resource_table_entries() -> Vec<i32> {
+  let table = RESOURCE_TABLE.lock().unwrap();
+
+  let serialized_resources: Vec<i32> = table.iter()
+    .map(|(key, _value)| {
+        key.clone()
+    }).collect();
+
+  serialized_resources
+}
+
 // Abstract async file interface.
 // Ideally in unix, if Resource represents an OS rid, it will be the same.
 #[derive(Debug)]

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -58,7 +58,7 @@ enum Repr {
   TcpStream(tokio::net::TcpStream),
 }
 
-pub fn get_resource_table_entries() -> Vec<(i32, String)> {
+pub fn table_entries() -> Vec<(i32, String)> {
   let table = RESOURCE_TABLE.lock().unwrap();
 
   let tuples = table
@@ -70,9 +70,13 @@ pub fn get_resource_table_entries() -> Vec<(i32, String)> {
 }
 
 #[test]
-fn test_get_resource_table_entries() {
-  assert_eq!(get_resource_table_entries().len(), 3);
-  // TODO: add asserts for add_fs_file, add_tcp_listener, add_tcp_stream
+fn test_table_entries() {
+  let mut entries = table_entries();
+  entries.sort();
+  assert_eq!(entries.len(), 3);
+  assert_eq!(entries[0], (0, String::from("stdin")));
+  assert_eq!(entries[1], (1, String::from("stdout")));
+  assert_eq!(entries[2], (2, String::from("stderr")));
 }
 
 fn inspect_repr(repr: &Repr) -> String {

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -16,6 +16,7 @@ use tokio_write;
 
 use futures;
 use futures::future::{Either, FutureResult};
+use futures::Future;
 use futures::Poll;
 use std;
 use std::collections::HashMap;
@@ -67,6 +68,12 @@ pub fn get_resource_table_entries() -> Vec<(i32, String)> {
     .collect();
 
   tuples
+}
+
+#[test]
+fn test_get_resource_table_entries() {
+  assert_eq!(get_resource_table_entries().len(), 3);
+  // TODO: add asserts for add_fs_file, add_tcp_listener, add_tcp_stream
 }
 
 fn inspect_repr(repr: &Repr) -> String {

--- a/tests/hello.txt
+++ b/tests/hello.txt
@@ -1,0 +1,1 @@
+Hello world!


### PR DESCRIPTION
Ref #1117 

Todo:
- [x] return sensible text representation of `Resource`
- [x] tests