### PR TITLE
Add deno.Buffer

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -77,6 +77,7 @@ main_extern = [
 ts_sources = [
   "js/assets.ts",
   "js/blob.ts",
+  "js/buffer.ts",
   "js/chmod.ts",
   "js/compiler.ts",
   "js/console.ts",

--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -170,7 +170,7 @@ export class Buffer implements Reader, Writer {
       return i;
     }
     const c = this.capacity;
-    if (n <= parseInt(c / 2) - m) {
+    if (n <= Math.floor(c / 2) - m) {
       // We can slide things down instead of allocating a new
       // ArrayBuffer. We only need m+n <= c to slide, but
       // we instead let capacity get twice as large so we

--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -52,10 +52,10 @@ export class Buffer implements Reader, Writer {
     return this.buf.subarray(this.off);
   }
 
-  /** String returns the contents of the unread portion of the buffer
+  /** toString() returns the contents of the unread portion of the buffer
    * as a string.
    */
-  str(): string {
+  toString(): string {
     const decoder = new TextDecoder();
     return decoder.decode(this.buf.subarray(this.off));
   }

--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -17,7 +17,7 @@ const MIN_READ = 512;
 // `off` is the offset into `dst` where it will at which to begin writing values
 // from `src`.
 // Returns the number of bytes copied.
-function copyBytes(dst: TypedArray, src: TypedArray, off = 0): number {
+function copyBytes(dst: Uint8Array, src: Uint8Array, off = 0): number {
   const r = dst.byteLength - off;
   if (src.byteLength > r) {
     src = src.subarray(0, r);

--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -75,7 +75,7 @@ export class Buffer implements Reader, Writer {
   /** Returns the capacity of the buffer's underlying byte slice, that is,
    * the total space allocated for the buffer's data.
    */
-  get capacity: number {
+  get capacity(): number {
     return this.buf.buffer.byteLength;
   }
 
@@ -130,6 +130,8 @@ export class Buffer implements Reader, Writer {
       // Buffer is empty, reset to recover space.
       this.reset();
       if (p.byteLength === 0) {
+        // TODO This edge case should be tested by porting TestReadEmptyAtEOF
+        // from the Go tests.
         return { nread: 0, eof: false };
       }
       return { nread: 0, eof: true };

--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -1,0 +1,219 @@
+// This code has been ported almost directly from Go's src/bytes/buffer.go
+// Copyright 2009 The Go Authors. All rights reserved. BSD license.
+// https://github.com/golang/go/blob/master/LICENSE
+
+//import * as io from "./io";
+import { Reader, Writer, ReadResult } from "./io";
+import { assert } from "./util";
+import { TypedArray } from "./types";
+import { TextDecoder } from "./text_encoding";
+
+// MIN_READ is the minimum ArrayBuffer size passed to a read call by
+// buffer.ReadFrom. As long as the Buffer has at least MIN_READ bytes beyond
+// what is required to hold the contents of r, readFrom() will not grow the
+// underlying buffer.
+const MIN_READ = 512;
+
+// `off` is the offset into `dst` where it will at which to begin writing values
+// from `src`.
+// Returns the number of bytes copied.
+function copyBytes(dst: TypedArray, src: TypedArray, off = 0): number {
+  const r = dst.byteLength - off;
+  if (src.byteLength > r) {
+    src = src.subarray(0, r);
+  }
+  dst.set(src, off);
+  return src.byteLength;
+}
+
+/** A Buffer is a variable-sized buffer of bytes with read() and write()
+ * methods. Based on https://golang.org/pkg/bytes/#Buffer
+ */
+export class Buffer implements Reader, Writer {
+  private buf: Uint8Array; // contents are the bytes buf[off : len(buf)]
+  private off = 0; // read at buf[off], write at buf[buf.byteLength]
+
+  constructor(ab?: ArrayBuffer) {
+    if (ab == null) {
+      this.buf = new Uint8Array(0);
+    } else {
+      this.buf = new Uint8Array(ab, 0, ab.byteLength);
+    }
+  }
+
+  /** bytes() returns a slice holding the unread portion of the buffer.
+   * The slice is valid for use only until the next buffer modification (that
+   * is, only until the next call to a method like read(), write(), reset(), or
+   * truncate()). The slice aliases the buffer content at least until the next
+   * buffer modification, so immediate changes to the slice will affect the
+   * result of future reads.
+   */
+  bytes(): Uint8Array {
+    return this.buf.subarray(this.off);
+  }
+
+  /** String returns the contents of the unread portion of the buffer
+   * as a string.
+   */
+  str(): string {
+    const decoder = new TextDecoder();
+    return decoder.decode(this.buf.subarray(this.off));
+  }
+
+  /** empty() returns whether the unread portion of the buffer is empty. */
+  empty() {
+    return this.buf.byteLength <= this.off;
+  }
+
+  /** length is a getter that returns the number of bytes of the unread
+   * portion of the buffer
+   */
+  get length() {
+    return this.buf.byteLength - this.off;
+  }
+
+  /** Cap returns the capacity of the buffer's underlying byte slice, that is,
+   * the total space allocated for the buffer's data.
+   */
+  cap(): number {
+    return this.buf.buffer.byteLength;
+  }
+
+  /** truncate() discards all but the first n unread bytes from the buffer but
+   * continues to use the same allocated storage.  It throws if n is negative or
+   * greater than the length of the buffer.
+   */
+  truncate(n: number): void {
+    if (n === 0) {
+      this.reset();
+      return;
+    }
+    if (n < 0 || n > this.length) {
+      throw Error("bytes.Buffer: truncation out of range");
+    }
+    this._reslice(this.off + n);
+  }
+
+  /** reset() resets the buffer to be empty, but it retains the underlying
+   * storage for use by future writes. reset() is the same as truncate(0)
+   */
+  reset() {
+    this._reslice(0);
+    this.off = 0;
+  }
+
+  /** _tryGrowByReslice() is a inlineable version of grow for the fast-case
+   * where the internal buffer only needs to be resliced. It returns the index
+   * where bytes should be written and whether it succeeded.
+   */
+  private _tryGrowByReslice(n: number): [number, boolean] {
+    const l = this.buf.byteLength;
+    if (n <= this.cap() - l) {
+      this._reslice(l + n);
+      return [l, true];
+    }
+    return [0, false];
+  }
+
+  private _reslice(len: number): void {
+    assert(len <= this.buf.buffer.byteLength);
+    this.buf = new Uint8Array(this.buf.buffer, 0, len);
+  }
+
+  /** read() reads the next len(p) bytes from the buffer or until the buffer
+   * is drained. The return value n is the number of bytes read. If the
+   * buffer has no data to return, eof in the response will be true.
+   */
+  async read(p: ArrayBufferView): Promise<ReadResult> {
+    if (this.empty()) {
+      // Buffer is empty, reset to recover space.
+      this.reset();
+      if (p.byteLength === 0) {
+        return { nread: 0, eof: false };
+      }
+      return { nread: 0, eof: true };
+    }
+    const nread = copyBytes(p as TypedArray, this.buf.subarray(this.off));
+    this.off += nread;
+    return { nread, eof: false };
+  }
+
+  async write(p: ArrayBufferView): Promise<number> {
+    const m = this._grow(p.byteLength);
+    return copyBytes(this.buf, p as TypedArray, m);
+  }
+
+  /** _grow() grows the buffer to guarantee space for n more bytes.
+   * It returns the index where bytes should be written.
+   * If the buffer can't grow it will throw with ErrTooLarge.
+   */
+  private _grow(n: number): number {
+    const m = this.length;
+    // If buffer is empty, reset to recover space.
+    if (m === 0 && this.off !== 0) {
+      this.reset();
+    }
+    // Fast: Try to grow by means of a reslice.
+    const [i, ok] = this._tryGrowByReslice(n);
+    if (ok) {
+      return i;
+    }
+    const c = this.cap();
+    if (n <= c / 2 - m) {
+      // We can slide things down instead of allocating a new
+      // ArrayBuffer. We only need m+n <= c to slide, but
+      // we instead let capacity get twice as large so we
+      // don't spend all our time copying.
+      copyBytes(this.buf, this.buf.subarray(this.off));
+    } else if (c > Number.MAX_SAFE_INTEGER - c - n) {
+      throw Error("ErrTooLarge"); // TODO DenoError(TooLarge)
+    } else {
+      // Not enough space anywhere, we need to allocate.
+      const buf = new Uint8Array(2 * c + n);
+      copyBytes(buf, this.buf.subarray(this.off));
+      this.buf = buf;
+    }
+    // Restore this.off and len(this.buf).
+    this.off = 0;
+    this._reslice(m + n);
+    return m;
+  }
+
+  /** grow() grows the buffer's capacity, if necessary, to guarantee space for
+   * another n bytes. After grow(n), at least n bytes can be written to the
+   * buffer without another allocation. If n is negative, grow() will panic. If
+   * the buffer can't grow it will throw ErrTooLarge.
+   * Based on https://golang.org/pkg/bytes/#Buffer.Grow
+   */
+  grow(n: number): void {
+    if (n < 0) {
+      throw Error("Buffer.grow: negative count");
+    }
+    const m = this._grow(n);
+    this._reslice(m);
+  }
+
+  /** readFrom() reads data from r until EOF and appends it to the buffer,
+   * growing the buffer as needed. It returns the number of bytes read. If the
+   * buffer becomes too large, readFrom will panic with ErrTooLarge.
+   * Based on https://golang.org/pkg/bytes/#Buffer.ReadFrom
+   */
+  async readFrom(r: Reader): Promise<number> {
+    let n = 0;
+    while (true) {
+      try {
+        const i = this._grow(MIN_READ);
+        this._reslice(i);
+        const fub = new Uint8Array(this.buf.buffer, i);
+        const { nread, eof } = await r.read(fub);
+        this._reslice(i + nread);
+        n += nread;
+        if (eof) {
+          return n;
+        }
+      } catch (e) {
+        return n;
+      }
+    }
+  }
+}

--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -52,7 +52,9 @@ export class Buffer implements Reader, Writer {
   }
 
   /** toString() returns the contents of the unread portion of the buffer
-   * as a string.
+   * as a string. Warning - if multibyte characters are present when data is
+   * flowing through the buffer, this method may result in incorrect strings
+   * due to a character being split.
    */
   toString(): string {
     const decoder = new TextDecoder();

--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -105,14 +105,15 @@ export class Buffer implements Reader, Writer {
   /** _tryGrowByReslice() is a version of grow for the fast-case
    * where the internal buffer only needs to be resliced. It returns the index
    * where bytes should be written and whether it succeeded.
+   * It returns -1 if a reslice was not needed.
    */
-  private _tryGrowByReslice(n: number): [number, boolean] {
+  private _tryGrowByReslice(n: number): number {
     const l = this.buf.byteLength;
     if (n <= this.capacity - l) {
       this._reslice(l + n);
-      return [l, true];
+      return l;
     }
-    return [0, false];
+    return -1;
   }
 
   private _reslice(len: number): void {
@@ -154,8 +155,8 @@ export class Buffer implements Reader, Writer {
       this.reset();
     }
     // Fast: Try to grow by means of a reslice.
-    const [i, ok] = this._tryGrowByReslice(n);
-    if (ok) {
+    const i = this._tryGrowByReslice(n);
+    if (i >= 0) {
       return i;
     }
     const c = this.capacity;

--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -37,7 +37,7 @@ export class Buffer implements Reader, Writer {
     if (ab == null) {
       this.buf = new Uint8Array(0);
     } else {
-      this.buf = new Uint8Array(ab, 0, ab.byteLength);
+      this.buf = new Uint8Array(ab);
     }
   }
 

--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -72,10 +72,10 @@ export class Buffer implements Reader, Writer {
     return this.buf.byteLength - this.off;
   }
 
-  /** Cap returns the capacity of the buffer's underlying byte slice, that is,
+  /** Returns the capacity of the buffer's underlying byte slice, that is,
    * the total space allocated for the buffer's data.
    */
-  cap(): number {
+  get capacity: number {
     return this.buf.buffer.byteLength;
   }
 
@@ -97,18 +97,18 @@ export class Buffer implements Reader, Writer {
   /** reset() resets the buffer to be empty, but it retains the underlying
    * storage for use by future writes. reset() is the same as truncate(0)
    */
-  reset() {
+  reset(): void {
     this._reslice(0);
     this.off = 0;
   }
 
-  /** _tryGrowByReslice() is a inlineable version of grow for the fast-case
+  /** _tryGrowByReslice() is a version of grow for the fast-case
    * where the internal buffer only needs to be resliced. It returns the index
    * where bytes should be written and whether it succeeded.
    */
   private _tryGrowByReslice(n: number): [number, boolean] {
     const l = this.buf.byteLength;
-    if (n <= this.cap() - l) {
+    if (n <= this.capacity - l) {
       this._reslice(l + n);
       return [l, true];
     }
@@ -158,7 +158,7 @@ export class Buffer implements Reader, Writer {
     if (ok) {
       return i;
     }
-    const c = this.cap();
+    const c = this.capacity;
     if (n <= c / 2 - m) {
       // We can slide things down instead of allocating a new
       // ArrayBuffer. We only need m+n <= c to slide, but

--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -12,6 +12,7 @@ import { TextDecoder } from "./text_encoding";
 // what is required to hold the contents of r, readFrom() will not grow the
 // underlying buffer.
 const MIN_READ = 512;
+const MAX_SIZE = 2 ** 32 - 2;
 
 // `off` is the offset into `dst` where it will at which to begin writing values
 // from `src`.
@@ -175,7 +176,7 @@ export class Buffer implements Reader, Writer {
       // we instead let capacity get twice as large so we
       // don't spend all our time copying.
       copyBytes(this.buf, this.buf.subarray(this.off));
-    } else if (c > Number.UINT32_MAX - 2 - c - n) {
+    } else if (c > MAX_SIZE - c - n) {
       throw Error("ErrTooLarge"); // TODO DenoError(TooLarge)
     } else {
       // Not enough space anywhere, we need to allocate.

--- a/js/buffer_test.ts
+++ b/js/buffer_test.ts
@@ -4,7 +4,7 @@
 import { test, assert, assertEqual } from "./test_util.ts";
 import { Buffer } from "deno";
 
-// const N = 10000;
+// N controls how many iterations of certain checks are performed.
 const N = 100;
 let testBytes: Uint8Array | null;
 let testString: string | null;

--- a/js/buffer_test.ts
+++ b/js/buffer_test.ts
@@ -133,7 +133,7 @@ test(async function bufferLargeByteReads() {
 
 test(function bufferCapWithPreallocatedSlice() {
   const buf = new Buffer(new ArrayBuffer(10));
-  assertEqual(buf.cap(), 10);
+  assertEqual(buf.capacity, 10);
 });
 
 test(async function bufferReadFrom() {

--- a/js/buffer_test.ts
+++ b/js/buffer_test.ts
@@ -1,0 +1,185 @@
+// This code has been ported almost directly from Go's src/bytes/buffer_test.go
+// Copyright 2009 The Go Authors. All rights reserved. BSD license.
+// https://github.com/golang/go/blob/master/LICENSE
+import { test, assert, assertEqual } from "./test_util.ts";
+import { Buffer } from "deno";
+
+// const N = 10000;
+const N = 100;
+let testBytes: Uint8Array | null;
+let testString: string | null;
+
+function init() {
+  if (testBytes == null) {
+    testBytes = new Uint8Array(N);
+    for (let i = 0; i < N; i++) {
+      testBytes[i] = "a".charCodeAt(0) + (i % 26);
+    }
+    const decoder = new TextDecoder();
+    testString = decoder.decode(testBytes);
+  }
+}
+
+function check(buf: Buffer, s: string) {
+  const bytes = buf.bytes();
+  assertEqual(buf.length, bytes.byteLength);
+  const decoder = new TextDecoder();
+  const bytesStr = decoder.decode(bytes);
+  assertEqual(bytesStr, s);
+  assertEqual(buf.length, buf.str().length);
+  assertEqual(buf.length, s.length);
+}
+
+// Fill buf through n writes of byte slice fub.
+// The initial contents of buf corresponds to the string s;
+// the result is the final contents of buf returned as a string.
+async function fillBytes(
+  buf: Buffer,
+  s: string,
+  n: number,
+  fub: Uint8Array
+): Promise<string> {
+  check(buf, s);
+  for (; n > 0; n--) {
+    let m = await buf.write(fub);
+    assertEqual(m, fub.byteLength);
+    const decoder = new TextDecoder();
+    s += decoder.decode(fub);
+    check(buf, s);
+  }
+  return s;
+}
+
+// Empty buf through repeated reads into fub.
+// The initial contents of buf corresponds to the string s.
+async function empty(buf: Buffer, s: string, fub: Uint8Array): Promise<void> {
+  check(buf, s);
+  while (true) {
+    const r = await buf.read(fub);
+    if (r.nread == 0) {
+      break;
+    }
+    s = s.slice(r.nread);
+    check(buf, s);
+  }
+  check(buf, "");
+}
+
+test(function bufferNewBuffer() {
+  init();
+  const buf = new Buffer(testBytes.buffer as ArrayBuffer);
+  check(buf, testString);
+});
+
+test(async function bufferBasicOperations() {
+  init();
+  let buf = new Buffer();
+  for (let i = 0; i < 5; i++) {
+    check(buf, "");
+
+    buf.reset();
+    check(buf, "");
+
+    buf.truncate(0);
+    check(buf, "");
+
+    let n = await buf.write(testBytes.subarray(0, 1));
+    assertEqual(n, 1);
+    check(buf, "a");
+
+    n = await buf.write(testBytes.subarray(1, 2));
+    assertEqual(n, 1);
+    check(buf, "ab");
+
+    n = await buf.write(testBytes.subarray(2, 26));
+    assertEqual(n, 24);
+    check(buf, testString.slice(0, 26));
+
+    buf.truncate(26);
+    check(buf, testString.slice(0, 26));
+
+    buf.truncate(20);
+    check(buf, testString.slice(0, 20));
+
+    await empty(buf, testString.slice(0, 20), new Uint8Array(5));
+    await empty(buf, "", new Uint8Array(100));
+
+    // TODO buf.writeByte()
+    // TODO buf.readByte()
+  }
+});
+
+test(async function bufferLargeByteWrites() {
+  init();
+  const buf = new Buffer();
+  const limit = 9;
+  for (let i = 3; i < limit; i += 3) {
+    const s = await fillBytes(buf, "", 5, testBytes);
+    await empty(buf, s, new Uint8Array(Math.floor(testString.length / i)));
+  }
+  check(buf, "");
+});
+
+test(async function bufferLargeByteReads() {
+  init();
+  const buf = new Buffer();
+  for (let i = 3; i < 30; i += 3) {
+    const n = Math.floor(testBytes.byteLength / i);
+    const s = await fillBytes(buf, "", 5, testBytes.subarray(0, n));
+    await empty(buf, s, new Uint8Array(testString.length));
+  }
+  check(buf, "");
+});
+
+test(function bufferCapWithPreallocatedSlice() {
+  const buf = new Buffer(new ArrayBuffer(10));
+  assertEqual(buf.cap(), 10);
+});
+
+test(async function bufferReadFrom() {
+  init();
+  const buf = new Buffer();
+  for (let i = 3; i < 30; i += 3) {
+    const s = await fillBytes(
+      buf,
+      "",
+      5,
+      testBytes.subarray(0, Math.floor(testBytes.byteLength / i))
+    );
+    const b = new Buffer();
+    await b.readFrom(buf);
+    const fub = new Uint8Array(testString.length);
+    await empty(b, s, fub);
+  }
+});
+
+function repeat(c: string, bytes: number): Uint8Array {
+  assertEqual(c.length, 1);
+  const ui8 = new Uint8Array(bytes);
+  ui8.fill(c.charCodeAt(0));
+  return ui8;
+}
+
+test(async function bufferTestGrow() {
+  const tmp = new Uint8Array(72);
+  for (let startLen of [0, 100, 1000, 10000, 100000]) {
+    const xBytes = repeat("x", startLen);
+    for (let growLen of [0, 100, 1000, 10000, 100000]) {
+      const buf = new Buffer(xBytes.buffer as ArrayBuffer);
+      // If we read, this affects buf.off, which is good to test.
+      const { nread, eof } = await buf.read(tmp);
+      buf.grow(growLen);
+      const yBytes = repeat("y", growLen);
+      await buf.write(yBytes);
+      // Check that buffer has correct data.
+      assertEqual(
+        buf.bytes().subarray(0, startLen - nread),
+        xBytes.subarray(nread)
+      );
+      assertEqual(
+        buf.bytes().subarray(startLen - nread, startLen - nread + growLen),
+        yBytes
+      );
+    }
+  }
+});

--- a/js/buffer_test.ts
+++ b/js/buffer_test.ts
@@ -26,7 +26,7 @@ function check(buf: Buffer, s: string) {
   const decoder = new TextDecoder();
   const bytesStr = decoder.decode(bytes);
   assertEqual(bytesStr, s);
-  assertEqual(buf.length, buf.str().length);
+  assertEqual(buf.length, buf.toString().length);
   assertEqual(buf.length, s.length);
 }
 

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -20,6 +20,7 @@ export {
   ReadWriteCloser,
   ReadWriteSeeker
 } from "./io";
+export { Buffer } from "./buffer";
 export { mkdirSync, mkdir } from "./mkdir";
 export { makeTempDirSync, makeTempDir } from "./make_temp_dir";
 export { chmodSync, chmod } from "./chmod";

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -4,6 +4,7 @@
 // But it can also be run manually: ./out/debug/deno js/unit_tests.ts
 import "../website/app_test.js";
 import "./blob_test.ts";
+import "./buffer_test.ts";
 import "./chmod_test.ts";
 import "./compiler_test.ts";
 import "./console_test.ts";


### PR DESCRIPTION
Do not confuse this with Node's Buffer. This is a direct port of Go's
bytes.ByteBuffer - it allows buffering of Reader objects.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
