### PR TITLE
[WIP] Capability to test deno CLI flags

### DIFF
--- a/tests/flags/README.md
+++ b/tests/flags/README.md
@@ -1,0 +1,19 @@
+# Flag Tests
+
+Tests located in sub-directories of this one will be executed by passing the
+specified flags to Deno on the command line. Multiple flags are denoted by an
+`_` in the directory name.
+
+For example if a test was named `tests/flags/foo/test.ts` with a corresponding
+`tests/flags/foo/test.ts.out` the command line to Deno would be:
+
+```
+$ deno --foo tests/flags/foo/test.ts
+```
+
+If the test was named `tests/flags/foo_bar/test.ts` with a corresponding
+`tests/flags/foo_bar/test.ts.out` the command line to Deno would be:
+
+```
+$ deno --foo --bar tests/flags/foo_bar/test.ts
+```

--- a/tests/flags/types/blank.ts
+++ b/tests/flags/types/blank.ts
@@ -1,0 +1,2 @@
+// Intentional blank to just support the ability to pass the `--types` flag to
+// Deno on the command line

--- a/tests/flags/types/blank.ts.out
+++ b/tests/flags/types/blank.ts.out
@@ -1,0 +1,15 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+
+/// <reference no-default-lib="true" />
+/// <reference lib="esnext" />
+[WILDCARD]
+declare module "deno" {
+[WILDCARD]
+}
+
+declare interface Window {
+[WILDCARD]
+}
+
+declare const window: Window;
+[WILDCARD]

--- a/tools/flag_output_tests.py
+++ b/tools/flag_output_tests.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# Copyright 2018 the Deno authors. All rights reserved. MIT license.
+# Given a deno executable, this script executes several integration tests also
+# passing command line flags to the deno executable based on the path of the
+# test case.
+#
+# Usage: flag_output_tests.py [path to deno executable]
+import os
+import sys
+import subprocess
+from util import pattern_match, parse_exit_code
+
+root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+flags_path = os.path.join(root_path, "tests", "flags")
+
+
+def flag_output_tests(deno_executable):
+    assert os.path.isfile(deno_executable)
+    switch_dirs = sorted([
+        filename for filename in os.listdir(flags_path)
+        if os.path.isdir(os.path.join(flags_path, filename))
+    ])
+    for switch_dir in switch_dirs:
+        tests_path = os.path.join(flags_path, switch_dir)
+        outs = sorted([
+            filename for filename in os.listdir(tests_path)
+            if filename.endswith(".out")
+        ])
+        assert len(outs) > 0
+        tests = [(os.path.splitext(filename)[0], filename)
+                 for filename in outs]
+        for (script, out_filename) in tests:
+            script_abs = os.path.join(tests_path, script)
+            out_abs = os.path.join(tests_path, out_filename)
+            with open(out_abs, 'r') as f:
+                expected_out = f.read()
+            flags = ["--" + flag for flag in switch_dir.split("_")]
+            cmd = [deno_executable, script_abs, "--reload"] + flags
+            expected_code = parse_exit_code(script)
+            print " ".join(cmd)
+            actual_code = 0
+            try:
+                actual_out = subprocess.check_output(
+                    cmd, universal_newlines=True)
+            except subprocess.CalledProcessError as e:
+                actual_code = e.returncode
+                actual_out = e.output
+                if expected_code == 0:
+                    print "Expected success but got error. Output:"
+                    print actual_out
+                    sys.exit(1)
+
+            if expected_code != actual_code:
+                print "Expected exit code %d but got %d" % (expected_code,
+                                                            actual_code)
+                print "Output:"
+                print actual_out
+                sys.exit(1)
+
+            if pattern_match(expected_out, actual_out) != True:
+                print "Expected output does not match actual."
+                print "Expected: " + expected_out
+                print "Actual:   " + actual_out
+                sys.exit(1)
+
+
+def main(argv):
+    flag_output_tests(argv[1])
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tools/test.py
+++ b/tools/test.py
@@ -5,6 +5,7 @@
 import os
 import sys
 from check_output_test import check_output_test
+from flag_output_tests import flag_output_tests
 from deno_dir_test import deno_dir_test
 from setup_test import setup_test
 from util import build_path, enable_ansi_colors, executable_suffix, run, rmtree
@@ -59,6 +60,8 @@ def main(argv):
     unit_tests(deno_exe)
 
     check_output_test(deno_exe)
+
+    flag_output_tests(deno_exe)
 
     # TODO We currently skip testing the prompt in Windows completely.
     # Windows does not support the pty module used for testing the permission


### PR DESCRIPTION
This PR adds the capability to run rests that pass additional CLI arguments to Deno during the integration test.

I broke this out from another PR where we will be using a different approach to deliver it, therefore not requiring this functionality immediately.

Test and test output pairs located in a subdirectory of the `tests/flags` directory will be executed with the additional flags.  For example if a test pair were located in `tests/flags/foo` the test would be run with `deno tests/flags/foo/test.ts --reload --foo`.

If the sub directory of `flags` contains an `_`, this will be used to split up multiple flags.  If the test were in `tests/flags/foo_bar` the test would be run with `deno tests/flags/foo_bar/test.ts --reload --foo --bar`.
