### PR TITLE
add helper to turn deno.Reader into async iterator

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -7,7 +7,7 @@ export { chdir, cwd } from "./dir";
 export { File, open, stdin, stdout, stderr, read, write, close } from "./files";
 export {
   copy,
-  readerIterator,
+  toAsyncIterator,
   ReadResult,
   Reader,
   Writer,

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -7,6 +7,7 @@ export { chdir, cwd } from "./dir";
 export { File, open, stdin, stdout, stderr, read, write, close } from "./files";
 export {
   copy,
+  readerIterator,
   ReadResult,
   Reader,
   Writer,

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -21,12 +21,11 @@ test(async function filesCopyToStdout() {
 test(async function filesToAsyncIterator() {
   const filename = "tests/hello.txt";
   const file = await deno.open(filename);
-  const fileSize = deno.statSync(filename).len;
 
   let totalSize = 0;
   for await (const buf of deno.toAsyncIterator(file)) {
     totalSize += buf.byteLength;
   }
 
-  assertEqual(totalSize, fileSize);
+  assertEqual(totalSize, 12);
 });

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -17,3 +17,16 @@ test(async function filesCopyToStdout() {
   assertEqual(bytesWritten, fileSize);
   console.log("bytes written", bytesWritten);
 });
+
+test(async function filesToAsyncIterator() {
+  const filename = 'tests/hello.txt';
+  const file = await deno.open(filename);
+  const fileSize = deno.statSync(filename).len;
+
+  let totalSize = 0;
+  for await (const buf of deno.toAsyncIterator(file)) {
+    totalSize += buf.byteLength;
+  }
+
+  assertEqual(totalSize, fileSize);
+});

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -19,7 +19,7 @@ test(async function filesCopyToStdout() {
 });
 
 test(async function filesToAsyncIterator() {
-  const filename = 'tests/hello.txt';
+  const filename = "tests/hello.txt";
   const file = await deno.open(filename);
   const fileSize = deno.statSync(filename).len;
 

--- a/js/io.ts
+++ b/js/io.ts
@@ -15,7 +15,7 @@ export interface Reader {
    * of bytes read (`0` <= `n` <= `p.byteLength`) and any error encountered.
    * Even if `read()` returns `n` < `p.byteLength`, it may use all of `p` as
    * scratch space during the call. If some data is available but not
-   * `p.byteLength`  , `read()` conventionally returns what is available
+   * `p.byteLength` bytes, `read()` conventionally returns what is available
    * instead of waiting for more.
    *
    * When `read()` encounters an error or end-of-file condition after
@@ -123,7 +123,7 @@ export async function copy(dst: Writer, src: Reader): Promise<number> {
  *        console.log(chunk)
  *    }
  */
-export function readerIterator(
+export function toAsyncIterator(
   r: Reader
 ): AsyncIterableIterator<ArrayBufferView> {
   const b = new Uint8Array(1024);


### PR DESCRIPTION
@ry it implements functionality you asked for. I agree with @kitsonk we should name it `toAsyncIterator`. Let me know if you want any changes.