### PR TITLE
[WIP] Configure compiler with tsconfig.json

### DIFF
--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -522,9 +522,7 @@ export class DenoCompiler
       configurationText
     );
     if (error) {
-      console.warn(
-        this._ts.formatDiagnosticsWithColorAndContext([error], this)
-      );
+      console.log(this._ts.formatDiagnosticsWithColorAndContext([error], this));
       this._os.exit(1);
     }
     const { options, errors } = this._ts.convertCompilerOptionsFromJson(
@@ -532,7 +530,7 @@ export class DenoCompiler
       deno.cwd()
     );
     if (errors.length) {
-      console.warn(this._ts.formatDiagnosticsWithColorAndContext(errors, this));
+      console.log(this._ts.formatDiagnosticsWithColorAndContext(errors, this));
       this._os.exit(1);
     }
     const ignoredOptions: string[] = [];

--- a/js/main.ts
+++ b/js/main.ts
@@ -7,7 +7,7 @@ import { DenoCompiler } from "./compiler";
 import { libdeno } from "./libdeno";
 import { args } from "./deno";
 import { sendSync, handleAsyncMsgFromRust } from "./dispatch";
-import { readFile } from "./read_file";
+import { readFileSync } from "./read_file";
 import { promiseErrorExaminer, promiseRejectHandler } from "./promise_util";
 import { version } from "typescript";
 import { TextDecoder } from "text-encoding";
@@ -41,7 +41,7 @@ function onGlobalError(
 }
 
 /* tslint:disable-next-line:no-default-export */
-export default async function denoMain() {
+export default function denoMain() {
   libdeno.recv(handleAsyncMsgFromRust);
   libdeno.setGlobalErrorHandler(onGlobalError);
   libdeno.setPromiseRejectHandler(promiseRejectHandler);
@@ -92,7 +92,7 @@ export default async function denoMain() {
   if (tsconfigFilename) {
     try {
       const decoder = new TextDecoder("utf-8");
-      const tsconfigJson = decoder.decode(await readFile(tsconfigFilename));
+      const tsconfigJson = decoder.decode(readFileSync(tsconfigFilename));
       const ignoredOptions = compiler.configure(tsconfigJson);
       if (ignoredOptions) {
         console.warn(

--- a/js/main.ts
+++ b/js/main.ts
@@ -103,9 +103,7 @@ export default function denoMain() {
       }
     } catch (e) {
       if (e instanceof DenoError && e.kind === msg.ErrorKind.NotFound) {
-        console.error(
-          `Specified configuration "${tsconfigFilename}" not found.`
-        );
+        console.log(`Specified configuration "${tsconfigFilename}" not found.`);
         os.exit(1);
       } else {
         throw e;

--- a/js/main.ts
+++ b/js/main.ts
@@ -103,7 +103,10 @@ export default async function denoMain() {
       }
     } catch (e) {
       if (e instanceof DenoError && e.kind === msg.ErrorKind.NotFound) {
-        log("No tsconfig.json.");
+        console.error(
+          `Specified configuration "${tsconfigFilename}" not found.`
+        );
+        os.exit(1);
       } else {
         throw e;
       }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -256,9 +256,11 @@ export default function makeConfig(commandOptions) {
           // rollup requires them to be explicitly defined to make them available in the
           // bundle
           [typescriptPath]: [
+            "convertCompilerOptionsFromJson",
             "createLanguageService",
             "formatDiagnosticsWithColorAndContext",
             "ModuleKind",
+            "parseConfigFileTextToJson",
             "ScriptKind",
             "ScriptSnapshot",
             "ScriptTarget",

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -26,6 +26,7 @@ pub struct DenoFlags {
   pub allow_net: bool,
   pub allow_env: bool,
   pub types_flag: bool,
+  pub maybe_config: Option<String>,
 }
 
 pub fn process(flags: &DenoFlags, usage_string: &str) {
@@ -71,6 +72,7 @@ pub fn set_flags(
   opts.optflag("r", "reload", "Reload cached remote resources.");
   opts.optflag("", "v8-options", "Print V8 command line options.");
   opts.optflag("", "types", "Print runtime TypeScript declarations.");
+  opts.optopt("c", "config", "Specify a tsconfig.json file.", "FILE");
 
   let mut flags = DenoFlags::default();
 
@@ -108,6 +110,7 @@ pub fn set_flags(
   if matches.opt_present("types") {
     flags.types_flag = true;
   }
+  flags.maybe_config = matches.opt_str("c");
 
   let rest: Vec<_> = matches.free.to_vec();
   Ok((flags, rest, get_usage(&opts)))
@@ -180,6 +183,20 @@ fn test_set_flags_5() {
     flags,
     DenoFlags {
       types_flag: true,
+      ..DenoFlags::default()
+    }
+  )
+}
+
+#[test]
+fn test_set_flags_6() {
+  let (flags, rest, _) =
+    set_flags(svec!["deno", "--config", "foobar.json"]).unwrap();
+  assert_eq!(rest, svec!["deno"]);
+  assert_eq!(
+    flags,
+    DenoFlags {
+      maybe_config: Some("foobar.json".to_string()),
       ..DenoFlags::default()
     }
   )

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -132,6 +132,7 @@ table StartRes {
   recompile_flag: bool;
   types_flag: bool;
   version_flag: bool;
+  config_file: string;
   deno_version: string;
   v8_version: string;
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -181,6 +181,11 @@ fn op_start(
   let cwd_off =
     builder.create_string(deno_fs::normalize_path(cwd_path.as_ref()).as_ref());
 
+  let config_file_off = builder.create_string(match state.flags.maybe_config {
+    Some(ref config_file) => &config_file,
+    None => "",
+  });
+
   let v8_version = version::get_v8_version();
   let v8_version_off = builder.create_string(v8_version);
 
@@ -196,6 +201,7 @@ fn op_start(
       recompile_flag: state.flags.recompile,
       types_flag: state.flags.types_flag,
       version_flag: state.flags.version,
+      config_file: Some(config_file_off),
       v8_version: Some(v8_version_off),
       deno_version: Some(deno_version_off),
       ..Default::default()

--- a/tests/config_bad.out
+++ b/tests/config_bad.out
@@ -1,0 +1,2 @@
+[91merror[0m[90m TS5023: [0mUnknown compiler option 'badOption'.
+

--- a/tests/config_bad.test
+++ b/tests/config_bad.test
@@ -1,0 +1,3 @@
+args: --config tests/configs/tsconfig_bad.json tests/fixtures/hello_world.js --recompile
+output: tests/config_bad.out
+exit_code: 1

--- a/tests/config_checkjs.out
+++ b/tests/config_checkjs.out
@@ -1,0 +1,5 @@
+[96m[WILDCARD]/tests/fixtures/loose.js[0m:[93m2[0m:[93m1[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'Date'.
+
+[7m2[0m timeStamp = Date.now();
+[7m [0m [91m~~~~~~~~~[0m
+

--- a/tests/config_checkjs.test
+++ b/tests/config_checkjs.test
@@ -1,0 +1,3 @@
+args: tests/fixtures/loose.js --recompile
+output: tests/config_checkjs.out
+exit_code: 1

--- a/tests/config_ignored.out
+++ b/tests/config_ignored.out
@@ -1,0 +1,1 @@
+Hello world!

--- a/tests/config_ignored.test
+++ b/tests/config_ignored.test
@@ -1,0 +1,2 @@
+args: -c tests/configs/tsconfig_ignored.json tests/fixtures/hello_world.js --recompile
+output: tests/config_ignored.out

--- a/tests/config_missing.out
+++ b/tests/config_missing.out
@@ -1,0 +1,1 @@
+Specified configuration "missing.json" not found.

--- a/tests/config_missing.test
+++ b/tests/config_missing.test
@@ -1,0 +1,3 @@
+args: --config missing.json tests/fixtures/hello_world.js
+output: tests/config_missing.out
+exit_code: 1

--- a/tests/config_nocheckjs.out
+++ b/tests/config_nocheckjs.out
@@ -1,0 +1,1 @@
+timeStamp [WILDCARD]

--- a/tests/config_nocheckjs.test
+++ b/tests/config_nocheckjs.test
@@ -1,0 +1,2 @@
+args: --config tests/configs/tsconfig_nocheckjs.json tests/fixtures/loose.js --recompile
+output: tests/config_nocheckjs.out

--- a/tests/config_notstrict.out
+++ b/tests/config_notstrict.out
@@ -1,0 +1,7 @@
+TypeError: Cannot read property 'foo' of undefined
+    at eval ([WILDCARD]/tests/fixtures/loose.ts:[WILDCARD])
+    at DenoCompiler.eval [as _globalEval] (<anonymous>)
+    at DenoCompiler._gatherDependencies (deno/js/compiler.ts:[WILDCARD])
+    at DenoCompiler.run (deno/js/compiler.ts:[WILDCARD])
+    at denoMain (deno/js/main.ts:[WILDCARD])
+    at deno_main.js:1:1

--- a/tests/config_notstrict.test
+++ b/tests/config_notstrict.test
@@ -1,0 +1,3 @@
+args: tests/fixtures/loose.ts --recompile
+output: tests/config_notstrict.out
+exit_code: 1

--- a/tests/config_strict.out
+++ b/tests/config_strict.out
@@ -1,0 +1,5 @@
+[96m[WILDCARD]/tests/fixtures/loose.ts[0m:[93m3[0m:[93m13[0m - [91merror[0m[90m TS2532: [0mObject is possibly 'undefined'.
+
+[7m3[0m console.log(map.get("foo").foo);
+[7m [0m [91m            ~~~~~~~~~~~~~~[0m
+

--- a/tests/config_strict.test
+++ b/tests/config_strict.test
@@ -1,0 +1,3 @@
+args: --config tests/configs/tsconfig_strict.json tests/fixtures/loose.ts --recompile
+output: tests/config_strict.out
+exit_code: 1

--- a/tests/configs/tsconfig_bad.json
+++ b/tests/configs/tsconfig_bad.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "badOption": false
+  }
+}

--- a/tests/configs/tsconfig_ignored.json
+++ b/tests/configs/tsconfig_ignored.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5"
+  }
+}

--- a/tests/configs/tsconfig_nocheckjs.json
+++ b/tests/configs/tsconfig_nocheckjs.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "checkJs": false
+  }
+}

--- a/tests/configs/tsconfig_strict.json
+++ b/tests/configs/tsconfig_strict.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/tests/fixtures/hello_world.js
+++ b/tests/fixtures/hello_world.js
@@ -1,0 +1,1 @@
+console.log("Hello world!");

--- a/tests/fixtures/loose.js
+++ b/tests/fixtures/loose.js
@@ -1,0 +1,3 @@
+let timeStamp = new Date();
+timeStamp = Date.now();
+console.log("timeStamp", timeStamp);

--- a/tests/fixtures/loose.ts
+++ b/tests/fixtures/loose.ts
@@ -1,0 +1,3 @@
+const map = new Map<string, { foo: number }>();
+
+console.log(map.get("foo").foo);


### PR DESCRIPTION
Fixes #51 

This PR add support for configuring the compiler via a tsconfig JSON via specified via the `-c` or `--config` command line arguments.

The tsconfig is read in and processed so that any options in the `compilerOptions` values that would interfere with Deno or are meaningless in a Deno context are ignored.  A warning will be logged to the console indicating any ignored options.

Example of the flag usage and output:

```
$ ./out/debug/deno tests/002_hello.ts
Hello World
$ ./out/debug/deno tests/002_hello.ts --config tsconfig.json
Unsupported compiler options in: "tsconfig.json"
  The following options were ignored:
    baseUrl, module, moduleResolution, noLib, paths, pretty, types
Hello World
$ ./out/debug/deno tests/002_hello.ts --config bad.json
Specified configuration "bad.json" not found.
```

I think it is functionally complete but does not have all the tests.