### PR TITLE
clarify Travis benchmark chart units

### DIFF
--- a/website/app.js
+++ b/website/app.js
@@ -247,7 +247,7 @@ export async function drawChartsFromTravisData() {
     prNumberList,
     travisCompileTimeColumns,
     viewPullRequestOnClick(prNumberList),
-    "time",
+    "minutes",
     formatSecsAsMins
   );
 }


### PR DESCRIPTION
Currently, the Travis chart displays "time" as the y-label of the graph, when in fact the unit is in minutes. (makes this consistent with other y-labels being "seconds")

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
