### PR TITLE
Fix issue with lib builder when flattening

### DIFF
--- a/tools/ts_library_builder/ast_util.ts
+++ b/tools/ts_library_builder/ast_util.ts
@@ -75,12 +75,22 @@ export function checkDiagnostics(project: Project, onlyFor?: string[]) {
     })
     .map(diagnostic => diagnostic.compilerObject);
 
+  logDiagnostics(diagnostics);
+
   if (diagnostics.length) {
-    console.log(
-      ts.formatDiagnosticsWithColorAndContext(diagnostics, formatDiagnosticHost)
-    );
     process.exit(1);
   }
+}
+
+function createDeclarationError(
+  msg: string,
+  declaration: ImportDeclaration | ExportDeclaration
+): Error {
+  return new Error(
+    `${msg}\n` +
+      `  In: "${declaration.getSourceFile().getFilePath()}"\n` +
+      `  Text: "${declaration.getText()}"`
+  );
 }
 
 export interface FlattenNamespaceOptions {
@@ -151,7 +161,12 @@ export function flattenNamespace({
   }
 
   sourceFile.getExportDeclarations().forEach(exportDeclaration => {
-    processSourceFile(exportDeclaration.getModuleSpecifierSourceFileOrThrow());
+    const exportedSourceFile = exportDeclaration.getModuleSpecifierSourceFile();
+    if (exportedSourceFile) {
+      processSourceFile(exportedSourceFile);
+    } else {
+      throw createDeclarationError("Missing source file.", exportDeclaration);
+    }
     exportDeclaration.remove();
   });
 
@@ -254,9 +269,19 @@ export function loadFiles(project: Project, filePaths: string[]) {
   }
 }
 
+/** Log diagnostics to the console with colour. */
+export function logDiagnostics(diagnostics: ts.Diagnostic[]): void {
+  if (diagnostics.length) {
+    console.log(
+      ts.formatDiagnosticsWithColorAndContext(diagnostics, formatDiagnosticHost)
+    );
+  }
+}
+
 export interface NamespaceSourceFileOptions {
   debug?: boolean;
   namespace?: string;
+  namespaces: Set<string>;
   rootPath: string;
   sourceFileMap: Map<SourceFile, string>;
 }
@@ -267,7 +292,13 @@ export interface NamespaceSourceFileOptions {
  */
 export function namespaceSourceFile(
   sourceFile: SourceFile,
-  { debug, namespace, rootPath, sourceFileMap }: NamespaceSourceFileOptions
+  {
+    debug,
+    namespace,
+    namespaces,
+    rootPath,
+    sourceFileMap
+  }: NamespaceSourceFileOptions
 ): string {
   if (sourceFileMap.has(sourceFile)) {
     return "";
@@ -300,22 +331,42 @@ export function namespaceSourceFile(
 
   const output = sourceFile
     .getImportDeclarations()
+    .filter(declaration => {
+      const dsf = declaration.getModuleSpecifierSourceFile();
+      if (dsf == null) {
+        try {
+          const namespaceName = declaration
+            .getNamespaceImportOrThrow()
+            .getText();
+          if (!namespaces.has(namespaceName)) {
+            throw createDeclarationError(
+              "Already defined source file under different namespace.",
+              declaration
+            );
+          }
+        } catch (e) {
+          throw createDeclarationError(
+            "Unsupported import clause.",
+            declaration
+          );
+        }
+        declaration.remove();
+      }
+      return dsf;
+    })
     .map(declaration => {
       if (
         declaration.getNamedImports().length ||
         !declaration.getNamespaceImport()
       ) {
-        throw new Error(
-          "Unsupported import clause.\n" +
-            `  In: "${declaration.getSourceFile().getFilePath()}"\n` +
-            `  Text: "${declaration.getText()}"`
-        );
+        throw createDeclarationError("Unsupported import clause.", declaration);
       }
       const text = namespaceSourceFile(
         declaration.getModuleSpecifierSourceFileOrThrow(),
         {
           debug,
           namespace: declaration.getNamespaceImportOrThrow().getText(),
+          namespaces,
           rootPath,
           sourceFileMap
         }
@@ -327,6 +378,8 @@ export function namespaceSourceFile(
   sourceFile
     .getExportDeclarations()
     .forEach(declaration => declaration.remove());
+
+  namespaces.add(namespace);
 
   return `${output}
     ${globalNamespaceText || ""}

--- a/tools/ts_library_builder/test.ts
+++ b/tools/ts_library_builder/test.ts
@@ -128,7 +128,10 @@ test(function buildLibraryMerge() {
   });
 
   assert(targetSourceFile.getNamespace("moduleC") != null);
-  assertEqual(targetSourceFile.getNamespaces().length, 1);
+  assert(targetSourceFile.getNamespace("moduleD") != null);
+  assert(targetSourceFile.getNamespace("moduleE") != null);
+  assert(targetSourceFile.getNamespace("moduleF") != null);
+  assertEqual(targetSourceFile.getNamespaces().length, 4);
   assert(targetSourceFile.getInterface("FooBar") != null);
   assertEqual(targetSourceFile.getInterfaces().length, 1);
   const variableDeclarations = targetSourceFile.getVariableDeclarations();
@@ -138,7 +141,15 @@ test(function buildLibraryMerge() {
     variableDeclarations[2].getType().getText(),
     `typeof moduleC.qat`
   );
-  assertEqual(variableDeclarations.length, 3);
+  assertEqual(
+    variableDeclarations[3].getType().getText(),
+    `typeof moduleE.process`
+  );
+  assertEqual(
+    variableDeclarations[4].getType().getText(),
+    `typeof moduleD.reprocess`
+  );
+  assertEqual(variableDeclarations.length, 5);
 });
 
 // TODO author unit tests for `ast_util.ts`

--- a/tools/ts_library_builder/testdata/globals.ts
+++ b/tools/ts_library_builder/testdata/globals.ts
@@ -1,6 +1,10 @@
 import * as moduleC from "./moduleC";
+import * as moduleD from "./moduleD";
+import * as moduleE from "./moduleE";
 
 // tslint:disable-next-line:no-any
 const foobarbaz: any = {};
 foobarbaz.bar = new moduleC.Bar();
 foobarbaz.qat = moduleC.qat;
+foobarbaz.process = moduleE.process;
+foobarbaz.reprocess = moduleD.reprocess;

--- a/tools/ts_library_builder/testdata/moduleD.ts
+++ b/tools/ts_library_builder/testdata/moduleD.ts
@@ -1,0 +1,5 @@
+import * as moduleF from "./moduleF";
+
+export function reprocess(value: typeof moduleF.key) {
+  console.log(value);
+}

--- a/tools/ts_library_builder/testdata/moduleE.ts
+++ b/tools/ts_library_builder/testdata/moduleE.ts
@@ -1,0 +1,5 @@
+import * as moduleF from "./moduleF";
+
+export function process(value: typeof moduleF.key) {
+  console.log(value);
+}

--- a/tools/ts_library_builder/testdata/moduleF.ts
+++ b/tools/ts_library_builder/testdata/moduleF.ts
@@ -1,0 +1,1 @@
+export const key = "value";


### PR DESCRIPTION
This fixes an issue with the library builder when flattening a module where if another module had imported it already and it was part of the output, it would error not being able to find the source file.  Now, it will only error if the namespace of the module being imported differs from a previous version, which is unsupported.
