### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -182,14 +182,14 @@ impl DenoDir {
         let path = Path::new(&filename);
         (fs::read_to_string(path)?, map_content_type(path, None))
       };
-      return Ok(CodeFetchOutput {
+      Ok(CodeFetchOutput {
         module_name: module_name.to_string(),
         filename: filename.to_string(),
         media_type,
         source_code,
         maybe_output_code: None,
         maybe_source_map: None,
-      });
+      })
     };
     let default_attempt = use_extension("");
     if default_attempt.is_ok() {
@@ -307,7 +307,7 @@ impl DenoDir {
       || Path::new(&module_specifier).is_absolute()
     {
       parse_local_or_remote(&module_specifier)?
-    } else if containing_file.ends_with("/") {
+    } else if containing_file.ends_with('/') {
       let r = Url::from_directory_path(&containing_file);
       // TODO(ry) Properly handle error.
       if r.is_err() {
@@ -329,13 +329,13 @@ impl DenoDir {
       "https" => {
         module_name = j.to_string();
         filename = deno_fs::normalize_path(
-          get_cache_filename(self.deps_https.as_path(), j).as_ref(),
+          get_cache_filename(self.deps_https.as_path(), &j).as_ref(),
         )
       }
       "http" => {
         module_name = j.to_string();
         filename = deno_fs::normalize_path(
-          get_cache_filename(self.deps_http.as_path(), j).as_ref(),
+          get_cache_filename(self.deps_http.as_path(), &j).as_ref(),
         )
       }
       // TODO(kevinkassimo): change this to support other protocols than http
@@ -347,7 +347,7 @@ impl DenoDir {
   }
 }
 
-fn get_cache_filename(basedir: &Path, url: Url) -> PathBuf {
+fn get_cache_filename(basedir: &Path, url: &Url) -> PathBuf {
   let host = url.host_str().unwrap();
   let host_port = match url.port() {
     // Windows doesn't support ":" in filenames, so we represent port using a
@@ -368,7 +368,7 @@ fn get_cache_filename(basedir: &Path, url: Url) -> PathBuf {
 fn test_get_cache_filename() {
   let url = Url::parse("http://example.com:1234/path/to/file.ts").unwrap();
   let basedir = Path::new("/cache/dir/");
-  let cache_file = get_cache_filename(&basedir, url);
+  let cache_file = get_cache_filename(&basedir, &url);
   assert_eq!(
     cache_file,
     Path::new("/cache/dir/example.com_PORT1234/path/to/file.ts")
@@ -814,7 +814,7 @@ fn map_content_type(path: &Path, content_type: Option<&str>) -> msg::MediaType {
       // sometimes there is additional data after the media type in
       // Content-Type so we have to do a bit of manipulation so we are only
       // dealing with the actual media type
-      let ct_vector: Vec<&str> = content_type.split(";").collect();
+      let ct_vector: Vec<&str> = content_type.split(';').collect();
       let ct: &str = ct_vector.first().unwrap();
       match ct.to_lowercase().as_ref() {
         "application/typescript"

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -220,11 +220,6 @@ fn v8_set_flags_preprocess(args: Vec<String>) -> (Vec<String>, Vec<String>) {
       mem::swap(a, &mut String::from("--help"));
     }
   }
-  // for idx in 0..args.len() {
-  //   if args[idx] == "--v8-options" {
-  //     mem::swap(args.get_mut(idx).unwrap(), &mut String::from("--help"));
-  //   }
-  // }
   (args, rest)
 }
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -28,16 +28,17 @@ pub struct DenoFlags {
   pub types_flag: bool,
 }
 
-pub fn process(flags: &DenoFlags, usage_string: String) {
+pub fn process(flags: &DenoFlags, usage_string: &str) {
   if flags.help {
     println!("{}", &usage_string);
     exit(0);
   }
 
-  let mut log_level = log::LevelFilter::Info;
-  if flags.log_debug {
-    log_level = log::LevelFilter::Debug;
-  }
+  let log_level = if flags.log_debug {
+    log::LevelFilter::Debug
+  } else {
+    log::LevelFilter::Info
+  };
   log::set_max_level(log_level);
 }
 
@@ -108,8 +109,8 @@ pub fn set_flags(
     flags.types_flag = true;
   }
 
-  let rest: Vec<_> = matches.free.iter().map(|s| s.clone()).collect();
-  return Ok((flags, rest, get_usage(&opts)));
+  let rest: Vec<_> = matches.free.to_vec();
+  Ok((flags, rest, get_usage(&opts)))
 }
 
 #[test]
@@ -214,12 +215,16 @@ fn v8_set_flags_preprocess(args: Vec<String>) -> (Vec<String>, Vec<String>) {
     }).collect();
 
   // Replace args being sent to V8
-  for idx in 0..args.len() {
-    if args[idx] == "--v8-options" {
-      mem::swap(args.get_mut(idx).unwrap(), &mut String::from("--help"));
+  for mut a in &mut args {
+    if a == "--v8-options" {
+      mem::swap(a, &mut String::from("--help"));
     }
   }
-
+  // for idx in 0..args.len() {
+  //   if args[idx] == "--v8-options" {
+  //     mem::swap(args.get_mut(idx).unwrap(), &mut String::from("--help"));
+  //   }
+  // }
   (args, rest)
 }
 

--- a/src/http_util.rs
+++ b/src/http_util.rs
@@ -37,7 +37,7 @@ pub fn fetch_sync_string(module_name: &str) -> DenoResult<(String, String)> {
     let url = maybe_url.expect("target url should not be None");
     client
       .get(url)
-      .map_err(|err| DenoError::from(err))
+      .map_err(DenoError::from)
       .and_then(|response| {
         if response.status().is_redirection() {
           let new_url_string = response
@@ -72,7 +72,7 @@ pub fn fetch_sync_string(module_name: &str) -> DenoResult<(String, String)> {
       .into_body()
       .concat2()
       .map(|body| String::from_utf8(body.to_vec()).unwrap())
-      .map_err(|err| DenoError::from(err));
+      .map_err(DenoError::from);
     body.join(future::ok(content_type))
   }).and_then(|(body_string, maybe_content_type)| {
     future::ok((body_string, maybe_content_type.unwrap()))

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -226,9 +226,9 @@ impl Isolate {
 
   fn timeout(&mut self) {
     let dummy_buf = libdeno::deno_buf {
-      alloc_ptr: 0 as *mut u8,
+      alloc_ptr: std::ptr::null_mut(),
       alloc_len: 0,
-      data_ptr: 0 as *mut u8,
+      data_ptr: std::ptr::null_mut(),
       data_len: 0,
     };
     unsafe {
@@ -265,11 +265,11 @@ impl Isolate {
 
   fn ntasks_increment(&mut self) {
     assert!(self.ntasks >= 0);
-    self.ntasks = self.ntasks + 1;
+    self.ntasks += 1;
   }
 
   fn ntasks_decrement(&mut self) {
-    self.ntasks = self.ntasks - 1;
+    self.ntasks -= 1;
     assert!(self.ntasks >= 0);
   }
 
@@ -290,7 +290,7 @@ impl From<Buf> for libdeno::deno_buf {
     let len = x.len();
     let ptr = Box::into_raw(x);
     libdeno::deno_buf {
-      alloc_ptr: 0 as *mut u8,
+      alloc_ptr: std::ptr::null_mut(),
       alloc_len: 0,
       data_ptr: ptr as *mut u8,
       data_len: len,

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn main() {
       std::process::exit(1)
     });
   let mut isolate = isolate::Isolate::new(flags, rest_argv, ops::dispatch);
-  flags::process(&isolate.state.flags, usage_string);
+  flags::process(&isolate.state.flags, &usage_string);
   tokio_util::init(|| {
     isolate
       .execute("deno_main.js", "denoMain();")

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,5 +1,6 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
+#![cfg_attr(feature = "cargo-clippy", allow(clippy))]
 use flatbuffers;
 // GN_OUT_DIR is set either by build.rs (for the Cargo build), or by
 // build_extra/rust/run.py (for the GN+Ninja build).

--- a/src/msg_util.rs
+++ b/src/msg_util.rs
@@ -15,7 +15,6 @@ pub fn serialize_key_value<'bldr>(
     &msg::KeyValueArgs {
       key: Some(key),
       value: Some(value),
-      ..Default::default()
     },
   )
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1125,6 +1125,9 @@ fn op_listen(
   assert_eq!(network, "tcp");
   let address = inner.address().unwrap();
 
+  // Ignore this clippy warning until this issue is addressed:
+  // https://github.com/rust-lang-nursery/rust-clippy/issues/1684
+  #[cfg_attr(feature = "cargo-clippy", allow(redundant_closure_call))]
   Box::new(futures::future::result((move || {
     // TODO properly parse addr
     let addr = SocketAddr::from_str(address).unwrap();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -42,7 +42,7 @@ type OpResult = DenoResult<Buf>;
 // TODO Ideally we wouldn't have to box the Op being returned.
 // The box is just to make it easier to get a prototype refactor working.
 type OpCreator =
-  fn(state: Arc<IsolateState>, base: &msg::Base, data: &'static mut [u8])
+  fn(state: &Arc<IsolateState>, base: &msg::Base, data: &'static mut [u8])
     -> Box<Op>;
 
 // Hopefully Rust optimizes this away.
@@ -110,7 +110,7 @@ pub fn dispatch(
         msg::enum_name_any(inner_type)
       )),
     };
-    op_creator(isolate.state.clone(), &base, data)
+    op_creator(&isolate.state.clone(), &base, data)
   };
 
   let boxed_op = Box::new(
@@ -154,11 +154,11 @@ pub fn dispatch(
     msg::enum_name_any(inner_type),
     base.sync()
   );
-  return (base.sync(), boxed_op);
+  (base.sync(), boxed_op)
 }
 
 fn op_exit(
-  _config: Arc<IsolateState>,
+  _config: &Arc<IsolateState>,
   base: &msg::Base,
   _data: &'static mut [u8],
 ) -> Box<Op> {
@@ -167,7 +167,7 @@ fn op_exit(
 }
 
 fn op_start(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -238,7 +238,7 @@ fn odd_future(err: DenoError) -> Box<Op> {
 
 // https://github.com/denoland/deno/blob/golang/os.go#L100-L154
 fn op_code_fetch(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -281,7 +281,7 @@ fn op_code_fetch(
 
 // https://github.com/denoland/deno/blob/golang/os.go#L156-L169
 fn op_code_cache(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -300,7 +300,7 @@ fn op_code_cache(
 }
 
 fn op_chdir(
-  _state: Arc<IsolateState>,
+  _state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -308,7 +308,7 @@ fn op_chdir(
   let inner = base.inner_as_chdir().unwrap();
   let directory = inner.directory().unwrap();
   Box::new(futures::future::result(|| -> OpResult {
-    let _result = std::env::set_current_dir(&directory)?;
+    std::env::set_current_dir(&directory)?;
     Ok(empty_buf())
   }()))
 }
@@ -330,7 +330,7 @@ fn op_set_timeout(
 }
 
 fn op_set_env(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -346,7 +346,7 @@ fn op_set_env(
 }
 
 fn op_env(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -364,10 +364,7 @@ fn op_env(
   let tables = builder.create_vector(&vars);
   let inner = msg::EnvironRes::create(
     builder,
-    &msg::EnvironResArgs {
-      map: Some(tables),
-      ..Default::default()
-    },
+    &msg::EnvironResArgs { map: Some(tables) },
   );
   ok_future(serialize_response(
     cmd_id,
@@ -381,7 +378,7 @@ fn op_env(
 }
 
 fn op_fetch(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -400,7 +397,7 @@ fn op_fetch(
 
   debug!("Before fetch {}", url);
   let future = client.get(url).and_then(move |res| {
-    let status = res.status().as_u16() as i32;
+    let status = i32::from(res.status().as_u16());
     debug!("fetch {}", status);
 
     let headers = {
@@ -445,7 +442,6 @@ fn op_fetch(
           body: Some(body_off),
           header_key: Some(header_keys_off),
           header_value: Some(header_values_off),
-          ..Default::default()
         },
       );
 
@@ -474,7 +470,7 @@ where
     Ok(Ready(Ok(v))) => Ok(v.into()),
     Ok(Ready(Err(err))) => Err(err),
     Ok(NotReady) => Ok(NotReady),
-    Err(_) => panic!("blocking error"),
+    Err(_err) => panic!("blocking error"),
   }
 }
 
@@ -496,7 +492,7 @@ macro_rules! blocking {
 }
 
 fn op_make_temp_dir(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -530,7 +526,6 @@ fn op_make_temp_dir(
       builder,
       &msg::MakeTempDirResArgs {
         path: Some(path_off),
-        ..Default::default()
       },
     );
     Ok(serialize_response(
@@ -546,7 +541,7 @@ fn op_make_temp_dir(
 }
 
 fn op_mkdir(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -566,7 +561,7 @@ fn op_mkdir(
 }
 
 fn op_chmod(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -596,7 +591,7 @@ fn op_chmod(
 }
 
 fn op_open(
-  _state: Arc<IsolateState>,
+  _state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -607,17 +602,12 @@ fn op_open(
   // TODO let perm = inner.perm();
 
   let op = tokio::fs::File::open(filename)
-    .map_err(|err| DenoError::from(err))
+    .map_err(DenoError::from)
     .and_then(move |fs_file| -> OpResult {
       let resource = resources::add_fs_file(fs_file);
       let builder = &mut FlatBufferBuilder::new();
-      let inner = msg::OpenRes::create(
-        builder,
-        &msg::OpenResArgs {
-          rid: resource.rid,
-          ..Default::default()
-        },
-      );
+      let inner =
+        msg::OpenRes::create(builder, &msg::OpenResArgs { rid: resource.rid });
       Ok(serialize_response(
         cmd_id,
         builder,
@@ -632,7 +622,7 @@ fn op_open(
 }
 
 fn op_close(
-  _state: Arc<IsolateState>,
+  _state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -649,7 +639,7 @@ fn op_close(
 }
 
 fn op_shutdown(
-  _state: Arc<IsolateState>,
+  _state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -675,7 +665,7 @@ fn op_shutdown(
 }
 
 fn op_read(
-  _state: Arc<IsolateState>,
+  _state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -687,7 +677,7 @@ fn op_read(
     None => odd_future(errors::bad_resource()),
     Some(resource) => {
       let op = resources::eager_read(resource, data)
-        .map_err(|err| DenoError::from(err))
+        .map_err(DenoError::from)
         .and_then(move |(_resource, _buf, nread)| {
           let builder = &mut FlatBufferBuilder::new();
           let inner = msg::ReadRes::create(
@@ -695,7 +685,6 @@ fn op_read(
             &msg::ReadResArgs {
               nread: nread as u32,
               eof: nread == 0,
-              ..Default::default()
             },
           );
           Ok(serialize_response(
@@ -714,7 +703,7 @@ fn op_read(
 }
 
 fn op_write(
-  _state: Arc<IsolateState>,
+  _state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -726,14 +715,13 @@ fn op_write(
     None => odd_future(errors::bad_resource()),
     Some(resource) => {
       let op = resources::eager_write(resource, data)
-        .map_err(|err| DenoError::from(err))
+        .map_err(DenoError::from)
         .and_then(move |(_resource, _buf, nwritten)| {
           let builder = &mut FlatBufferBuilder::new();
           let inner = msg::WriteRes::create(
             builder,
             &msg::WriteResArgs {
               nbyte: nwritten as u32,
-              ..Default::default()
             },
           );
           Ok(serialize_response(
@@ -752,7 +740,7 @@ fn op_write(
 }
 
 fn op_remove(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -771,12 +759,10 @@ fn op_remove(
     let metadata = fs::metadata(&path)?;
     if metadata.is_file() {
       fs::remove_file(&path)?;
+    } else if recursive {
+      remove_dir_all(&path)?;
     } else {
-      if recursive {
-        remove_dir_all(&path)?;
-      } else {
-        fs::remove_dir(&path)?;
-      }
+      fs::remove_dir(&path)?;
     }
     Ok(empty_buf())
   })
@@ -784,7 +770,7 @@ fn op_remove(
 
 // Prototype https://github.com/denoland/deno/blob/golang/os.go#L171-L184
 fn op_read_file(
-  _config: Arc<IsolateState>,
+  _config: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -803,7 +789,6 @@ fn op_read_file(
       builder,
       &msg::ReadFileResArgs {
         data: Some(data_off),
-        ..Default::default()
       },
     );
     Ok(serialize_response(
@@ -819,7 +804,7 @@ fn op_read_file(
 }
 
 fn op_copy_file(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -861,17 +846,17 @@ macro_rules! to_seconds {
 }
 
 #[cfg(any(unix))]
-fn get_mode(perm: fs::Permissions) -> u32 {
+fn get_mode(perm: &fs::Permissions) -> u32 {
   perm.mode()
 }
 
 #[cfg(not(any(unix)))]
-fn get_mode(_perm: fs::Permissions) -> u32 {
+fn get_mode(_perm: &fs::Permissions) -> u32 {
   0
 }
 
 fn op_cwd(
-  _state: Arc<IsolateState>,
+  _state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -882,13 +867,8 @@ fn op_cwd(
     let builder = &mut FlatBufferBuilder::new();
     let cwd =
       builder.create_string(&path.into_os_string().into_string().unwrap());
-    let inner = msg::CwdRes::create(
-      builder,
-      &msg::CwdResArgs {
-        cwd: Some(cwd),
-        ..Default::default()
-      },
-    );
+    let inner =
+      msg::CwdRes::create(builder, &msg::CwdResArgs { cwd: Some(cwd) });
     Ok(serialize_response(
       cmd_id,
       builder,
@@ -902,7 +882,7 @@ fn op_cwd(
 }
 
 fn op_stat(
-  _config: Arc<IsolateState>,
+  _config: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -930,7 +910,7 @@ fn op_stat(
         modified: to_seconds!(metadata.modified()),
         accessed: to_seconds!(metadata.accessed()),
         created: to_seconds!(metadata.created()),
-        mode: get_mode(metadata.permissions()),
+        mode: get_mode(&metadata.permissions()),
         has_mode: cfg!(target_family = "unix"),
         ..Default::default()
       },
@@ -949,7 +929,7 @@ fn op_stat(
 }
 
 fn op_read_dir(
-  _state: Arc<IsolateState>,
+  _state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -990,7 +970,6 @@ fn op_read_dir(
       builder,
       &msg::ReadDirResArgs {
         entries: Some(entries),
-        ..Default::default()
       },
     );
     Ok(serialize_response(
@@ -1006,7 +985,7 @@ fn op_read_dir(
 }
 
 fn op_write_file(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -1026,7 +1005,7 @@ fn op_write_file(
 }
 
 fn op_rename(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -1046,7 +1025,7 @@ fn op_rename(
 }
 
 fn op_symlink(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -1075,7 +1054,7 @@ fn op_symlink(
 }
 
 fn op_read_link(
-  _state: Arc<IsolateState>,
+  _state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -1093,7 +1072,6 @@ fn op_read_link(
       builder,
       &msg::ReadlinkResArgs {
         path: Some(path_off),
-        ..Default::default()
       },
     );
     Ok(serialize_response(
@@ -1109,7 +1087,7 @@ fn op_read_link(
 }
 
 fn op_truncate(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -1126,13 +1104,13 @@ fn op_truncate(
   blocking!(base.sync(), || {
     debug!("op_truncate {} {}", filename, len);
     let f = fs::OpenOptions::new().write(true).open(&filename)?;
-    f.set_len(len as u64)?;
+    f.set_len(u64::from(len))?;
     Ok(empty_buf())
   })
 }
 
 fn op_listen(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -1157,10 +1135,7 @@ fn op_listen(
     let builder = &mut FlatBufferBuilder::new();
     let inner = msg::ListenRes::create(
       builder,
-      &msg::ListenResArgs {
-        rid: resource.rid,
-        ..Default::default()
-      },
+      &msg::ListenResArgs { rid: resource.rid },
     );
     Ok(serialize_response(
       cmd_id,
@@ -1198,7 +1173,7 @@ fn new_conn(cmd_id: u32, tcp_stream: TcpStream) -> OpResult {
 }
 
 fn op_accept(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -1214,7 +1189,7 @@ fn op_accept(
     None => odd_future(errors::bad_resource()),
     Some(server_resource) => {
       let op = resources::eager_accept(server_resource)
-        .map_err(|err| DenoError::from(err))
+        .map_err(DenoError::from)
         .and_then(move |(tcp_stream, _socket_addr)| {
           new_conn(cmd_id, tcp_stream)
         });
@@ -1224,7 +1199,7 @@ fn op_accept(
 }
 
 fn op_dial(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -1248,7 +1223,7 @@ fn op_dial(
 }
 
 fn op_metrics(
-  state: Arc<IsolateState>,
+  state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -1266,7 +1241,6 @@ fn op_metrics(
       bytes_sent_control: metrics.bytes_sent_control,
       bytes_sent_data: metrics.bytes_sent_data,
       bytes_received: metrics.bytes_received,
-      ..Default::default()
     },
   );
   ok_future(serialize_response(
@@ -1281,7 +1255,7 @@ fn op_metrics(
 }
 
 fn op_resources(
-  _state: Arc<IsolateState>,
+  _state: &Arc<IsolateState>,
   base: &msg::Base,
   data: &'static mut [u8],
 ) -> Box<Op> {
@@ -1299,9 +1273,8 @@ fn op_resources(
       msg::Resource::create(
         builder,
         &msg::ResourceArgs {
-          rid: key.clone(),
+          rid: *key,
           repr: Some(repr),
-          ..Default::default()
         },
       )
     }).collect();
@@ -1311,7 +1284,6 @@ fn op_resources(
     builder,
     &msg::ResourcesResArgs {
       resources: Some(resources),
-      ..Default::default()
     },
   );
 

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -27,7 +27,7 @@ impl DenoPermissions {
       return Ok(());
     };
     // TODO get location (where access occurred)
-    let r = permission_prompt(format!(
+    let r = permission_prompt(&format!(
       "Deno requests write access to \"{}\".",
       filename
     ));;
@@ -42,7 +42,7 @@ impl DenoPermissions {
       return Ok(());
     };
     // TODO get location (where access occurred)
-    let r = permission_prompt(format!(
+    let r = permission_prompt(&format!(
       "Deno requests network access to \"{}\".",
       domain_name
     ));
@@ -57,9 +57,8 @@ impl DenoPermissions {
       return Ok(());
     };
     // TODO get location (where access occurred)
-    let r = permission_prompt(
-      "Deno requests access to environment variables.".to_string(),
-    );
+    let r =
+      permission_prompt(&"Deno requests access to environment variables.");
     if r.is_ok() {
       self.allow_env = true;
     }
@@ -67,7 +66,7 @@ impl DenoPermissions {
   }
 }
 
-fn permission_prompt(message: String) -> DenoResult<()> {
+fn permission_prompt(message: &str) -> DenoResult<()> {
   if !atty::is(atty::Stream::Stdin) || !atty::is(atty::Stream::Stderr) {
     return Err(permission_denied());
   };

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -61,12 +61,10 @@ enum Repr {
 pub fn table_entries() -> Vec<(i32, String)> {
   let table = RESOURCE_TABLE.lock().unwrap();
 
-  let tuples = table
+  table
     .iter()
-    .map(|(key, value)| (key.clone(), inspect_repr(&value)))
-    .collect();
-
-  tuples
+    .map(|(key, value)| (*key, inspect_repr(&value)))
+    .collect()
 }
 
 #[test]
@@ -128,7 +126,7 @@ impl Resource {
       None => panic!("bad rid"),
       Some(repr) => match repr {
         Repr::TcpStream(ref mut f) => {
-          TcpStream::shutdown(f, how).map_err(|err| DenoError::from(err))
+          TcpStream::shutdown(f, how).map_err(DenoError::from)
         }
         _ => panic!("Cannot shutdown"),
       },

--- a/src/tokio_write.rs
+++ b/src/tokio_write.rs
@@ -32,7 +32,7 @@ where
   T: AsRef<[u8]>,
 {
   Write {
-    state: State::Pending { a: a, buf: buf },
+    state: State::Pending { a, buf },
   }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -8,6 +8,5 @@ pub const DENO_VERSION: &str = "0.1.10";
 pub fn get_v8_version() -> &'static str {
   let v = unsafe { libdeno::deno_v8_version() };
   let c_str = unsafe { CStr::from_ptr(v) };
-  let version = c_str.to_str().unwrap();
-  version
+  c_str.to_str().unwrap()
 }


### PR DESCRIPTION
Run with:
``$ DENO_BUILD_PATH=`pwd`/out/debug cargo clippy``

There's still one ~remaining~ suppressed (due to https://github.com/rust-lang-nursery/rust-clippy/issues/1684)

https://github.com/rust-lang-nursery/rust-clippy
