### PR TITLE
Support cargo build on OSX/Linux

### DIFF
--- a/.gn
+++ b/.gn
@@ -30,6 +30,10 @@ default_args = {
   # for now. See http://clang.llvm.org/docs/ControlFlowIntegrity.html
   is_cfi = false
 
+  # To link properly with Cargo built objects, we need to build libc++ and
+  # include it in deno_deps.
+  use_custom_libcxx = true
+
   is_component_build = false
   symbol_level = 1
   treat_warnings_as_errors = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - RUSTUP_HOME=$HOME/.rustup/
   - RUST_BACKTRACE=1
   - HOMEBREW_PATH=$HOME/homebrew/
-  - DENO_BUILD_ARGS="use_custom_libcxx=false use_sysroot=false"
+  - DENO_BUILD_ARGS="use_sysroot=false"
   - DENO_BUILD_PATH=$HOME/out/Default
   - CARGO_TARGET_DIR=$HOME/target
   - DENO_BUILD_MODE=release
@@ -92,6 +92,7 @@ script:
 - bash -c "sleep 2100; pkill ninja; pkill cargo" &
 - ./tools/build.py -j2
 - RUSTC_WRAPPER=sccache cargo check -j2 --release
+- RUSTC_WRAPPER=sccache cargo build -j2 --release
 - ./tools/test.py $DENO_BUILD_PATH
 after_script:
 - ccache --show-stats

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -212,6 +212,13 @@ v8_executable("test_cc") {
   configs = [ ":deno_config" ]
 }
 
+v8_deps = [
+  "third_party/v8:v8",
+  "third_party/v8:v8_libbase",
+  "third_party/v8:v8_libplatform",
+  "third_party/v8:v8_libsampler",
+]
+
 # Only functionality needed for libdeno_test and snapshot_creator
 # In particular no flatbuffers, no assets, no rust, no msg handlers.
 # Because snapshots are slow, it's important that snapshot_creator's
@@ -225,19 +232,19 @@ static_library("libdeno") {
     "libdeno/file_util.h",
     "libdeno/internal.h",
   ]
-  public_deps = [
-    "third_party/v8:v8_monolith",
-  ]
+  public_deps = v8_deps
   configs += [ ":deno_config" ]
 }
 
 static_library("deno_deps") {
   complete_static_lib = true
   public_deps = [
-    ":libdeno",
-    ":msg_rs",
-    ":snapshot",
-  ]
+                  ":libdeno",
+                  ":msg_rs",
+                  ":snapshot",
+                  "//build/win:default_exe_manifest",
+                  "//buildtools/third_party/libc++:libc++",
+                ] + v8_deps
   configs += [ ":deno_config" ]
 }
 


### PR DESCRIPTION
@piscisaureus Needs windows support. `use_custom_libcxx = true` fails on appveyor. 