### PR TITLE
Fix issue with runtime lib generation

### DIFF
--- a/tools/ts_library_builder/ast_util.ts
+++ b/tools/ts_library_builder/ast_util.ts
@@ -58,6 +58,14 @@ export function addVariableDeclaration(
   });
 }
 
+/** Copy one source file to the end of another source file. */
+export function appendSourceFile(
+  sourceFile: SourceFile,
+  targetSourceFile: SourceFile
+): void {
+  targetSourceFile.addStatements(`\n${sourceFile.print()}`);
+}
+
 /** Check diagnostics, and if any exist, exit the process */
 export function checkDiagnostics(project: Project, onlyFor?: string[]) {
   const program = project.getProgram();

--- a/tools/ts_library_builder/build_library.ts
+++ b/tools/ts_library_builder/build_library.ts
@@ -13,6 +13,7 @@ import {
   addInterfaceProperty,
   addSourceComment,
   addVariableDeclaration,
+  appendSourceFile,
   checkDiagnostics,
   flattenNamespace,
   getSourceComment,
@@ -420,6 +421,16 @@ export function main({
   if (!silent) {
     console.log(`Merged "globals" into global scope.`);
   }
+
+  // Since we flatten the namespaces, we don't attempt to import `text-encoding`
+  // so we then need to concatenate that onto the `libDts` so it can stand on
+  // its own.
+  const textEncodingSourceFile = outputProject.getSourceFileOrThrow(
+    textEncodingFilePath
+  );
+  appendSourceFile(textEncodingSourceFile, libDTs);
+  // Removing it from the project so we know the libDTs can stand on its own.
+  outputProject.removeSourceFile(textEncodingSourceFile);
 
   // Add the preamble
   libDTs.insertStatements(0, libPreamble);


### PR DESCRIPTION
In taking a look at the `--types` output, I discovered an error that was present in the runtime Deno types declaration.  It occurred when we flattened the global namespace into the global scope, instead of a "module".  This mean we no longer imported the `@types/text-encoding`.  When the emitted library was checked for errors, the TypeScript compiler still resolved the `@types/text-encoding`, which doesn't know to do at runtime.  Because of the way we are emitting our code, TypeScript swallows any errors with the default runtime declaration and simply treat anything it can't resolve as `any`.

So this fix a) appends the `@types/text-encoding` types to the default library, so it can actually stand alone and b) change the library builder so that if there is a future regression, it would actually fail to build the library.
