### PR TITLE
v0.1.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 # crates.
 [package]
 name = "deno"
-version = "0.0.0"
+version = "0.1.11"
 
 [dependencies]
 atty = "0.2.11"

--- a/src/version.rs
+++ b/src/version.rs
@@ -2,8 +2,8 @@
 use libdeno;
 use std::ffi::CStr;
 
-// This is the source of truth for the Deno version. Ignore the value in Cargo.toml.
-pub const DENO_VERSION: &str = "0.1.10";
+// Both the verson in Cargo.toml and this string must be kept in sync.
+pub const DENO_VERSION: &str = "0.1.11";
 
 pub fn get_v8_version() -> &'static str {
   let v = unsafe { libdeno::deno_v8_version() };


### PR DESCRIPTION
- Performance and stability improvements on all platforms.
- Add repl (#998)
- Add deno.Buffer (#1121)
- Support cargo check (#1128)
- Upgrade Rust crates and Flatbuffers. (#1145, #1127)
- Add helper to turn deno.Reader into async iterator (#1130)
- Add ability to load JSON as modules (#1065)
- Add deno.resources() (#1119)
- Add application/x-typescript mime type support (#1111)

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
