### PR TITLE
Local filenames starting with 'http' shouldn't be remote.

### DIFF
--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -753,10 +753,30 @@ fn test_resolve_module_6() {
   assert_eq!(filename, expected_filename);
 }
 
+#[test]
+fn test_resolve_module_7() {
+  std::panic::set_hook(Box::new(|panic_info| {
+    eprintln!("{}", panic_info.to_string());
+    std::process::abort();
+  }));
+  let (_temp_dir, deno_dir) = test_setup();
+
+  let module_specifier = "http_test.ts";
+  let containing_file = add_root!("/Users/rld/src/deno_net/");
+  let expected_module_name = "/Users/rld/src/deno_net/http_test.ts";
+  let expected_filename = "/Users/rld/src/deno_net/http_test.ts";
+
+  let (module_name, filename) = deno_dir
+    .resolve_module(module_specifier, containing_file)
+    .unwrap();
+  assert_eq!(module_name, expected_module_name);
+  assert_eq!(filename, expected_filename);
+}
+
 const ASSET_PREFIX: &str = "/$asset$/";
 
 fn is_remote(module_name: &str) -> bool {
-  module_name.starts_with("http")
+  module_name.starts_with("http://") || module_name.starts_with("https://")
 }
 
 fn parse_local_or_remote(p: &str) -> Result<url::Url, url::ParseError> {

--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -755,16 +755,12 @@ fn test_resolve_module_6() {
 
 #[test]
 fn test_resolve_module_7() {
-  std::panic::set_hook(Box::new(|panic_info| {
-    eprintln!("{}", panic_info.to_string());
-    std::process::abort();
-  }));
   let (_temp_dir, deno_dir) = test_setup();
 
   let module_specifier = "http_test.ts";
   let containing_file = add_root!("/Users/rld/src/deno_net/");
-  let expected_module_name = "/Users/rld/src/deno_net/http_test.ts";
-  let expected_filename = "/Users/rld/src/deno_net/http_test.ts";
+  let expected_module_name = add_root!("/Users/rld/src/deno_net/http_test.ts");
+  let expected_filename = add_root!("/Users/rld/src/deno_net/http_test.ts");
 
   let (module_name, filename) = deno_dir
     .resolve_module(module_specifier, containing_file)


### PR DESCRIPTION
"http_test.ts" was being marked as a remote module specifier.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
