### PR TITLE
Reader/Writer should use Uint8Array not ArrayBufferView

### DIFF
--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -127,10 +127,7 @@ export class Buffer implements Reader, Writer {
    * is drained. The return value n is the number of bytes read. If the
    * buffer has no data to return, eof in the response will be true.
    */
-  async read(p: ArrayBufferView): Promise<ReadResult> {
-    if (!(p instanceof Uint8Array)) {
-      throw Error("Only Uint8Array supported");
-    }
+  async read(p: Uint8Array): Promise<ReadResult> {
     if (this.empty()) {
       // Buffer is empty, reset to recover space.
       this.reset();
@@ -146,11 +143,8 @@ export class Buffer implements Reader, Writer {
     return { nread, eof: false };
   }
 
-  async write(p: ArrayBufferView): Promise<number> {
+  async write(p: Uint8Array): Promise<number> {
     const m = this._grow(p.byteLength);
-    if (!(p instanceof Uint8Array)) {
-      throw Error("Only Uint8Array supported");
-    }
     return copyBytes(this.buf, p, m);
   }
 

--- a/js/files.ts
+++ b/js/files.ts
@@ -9,11 +9,11 @@ import * as flatbuffers from "./flatbuffers";
 export class File implements Reader, Writer, Closer {
   constructor(readonly rid: number) {}
 
-  write(p: ArrayBufferView): Promise<number> {
+  write(p: Uint8Array): Promise<number> {
     return write(this.rid, p);
   }
 
-  read(p: ArrayBufferView): Promise<ReadResult> {
+  read(p: Uint8Array): Promise<ReadResult> {
     return read(this.rid, p);
   }
 
@@ -68,10 +68,7 @@ export async function open(
  *
  * Resolves with the `ReadResult` for the operation.
  */
-export async function read(
-  rid: number,
-  p: ArrayBufferView
-): Promise<ReadResult> {
+export async function read(rid: number, p: Uint8Array): Promise<ReadResult> {
   const builder = flatbuffers.createBuilder();
   msg.Read.startRead(builder);
   msg.Read.addRid(builder, rid);
@@ -88,7 +85,7 @@ export async function read(
  *
  * Resolves with the number of bytes written.
  */
-export async function write(rid: number, p: ArrayBufferView): Promise<number> {
+export async function write(rid: number, p: Uint8Array): Promise<number> {
   const builder = flatbuffers.createBuilder();
   msg.Write.startWrite(builder);
   msg.Write.addRid(builder, rid);

--- a/js/io.ts
+++ b/js/io.ts
@@ -37,7 +37,7 @@ export interface Reader {
    *
    * Implementations must not retain `p`.
    */
-  read(p: ArrayBufferView): Promise<ReadResult>;
+  read(p: Uint8Array): Promise<ReadResult>;
 }
 
 // Writer is the interface that wraps the basic write() method.
@@ -51,7 +51,7 @@ export interface Writer {
    *
    * Implementations must not retain `p`.
    */
-  write(p: ArrayBufferView): Promise<number>;
+  write(p: Uint8Array): Promise<number>;
 }
 
 // https://golang.org/pkg/io/#Closer
@@ -123,9 +123,7 @@ export async function copy(dst: Writer, src: Reader): Promise<number> {
  *        console.log(chunk)
  *    }
  */
-export function toAsyncIterator(
-  r: Reader
-): AsyncIterableIterator<ArrayBufferView> {
+export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array> {
   const b = new Uint8Array(1024);
 
   return {
@@ -133,7 +131,7 @@ export function toAsyncIterator(
       return this;
     },
 
-    async next(): Promise<IteratorResult<ArrayBufferView>> {
+    async next(): Promise<IteratorResult<Uint8Array>> {
       const result = await r.read(b);
       return {
         value: b.subarray(0, result.nread),

--- a/js/net.ts
+++ b/js/net.ts
@@ -74,11 +74,11 @@ class ConnImpl implements Conn {
     readonly localAddr: string
   ) {}
 
-  write(p: ArrayBufferView): Promise<number> {
+  write(p: Uint8Array): Promise<number> {
     return write(this.rid, p);
   }
 
-  read(p: ArrayBufferView): Promise<ReadResult> {
+  read(p: Uint8Array): Promise<ReadResult> {
     return read(this.rid, p);
   }
 


### PR DESCRIPTION
Because many Reader/Writer implementations (e.g. bufio) assume their able to use subarray() with byte indexes and often ask for byte values, it makes sense to simply restrict all implementations to Uint8Array.