### PR TITLE
Cleanups for runtime lib declarations.

### DIFF
--- a/js/io.ts
+++ b/js/io.ts
@@ -116,12 +116,11 @@ export async function copy(dst: Writer, src: Reader): Promise<number> {
   return n;
 }
 
-/**
- * Turns `r` into async iterator.
+/** Turns `r` into async iterator.
  *
- *    for await (const chunk of readerIterator(reader)) {
- *        console.log(chunk)
- *    }
+ *      for await (const chunk of readerIterator(reader)) {
+ *          console.log(chunk)
+ *      }
  */
 export function toAsyncIterator(
   r: Reader

--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -45,4 +45,5 @@ interface Libdeno {
 }
 
 const window = globalEval("this");
+// @internal
 export const libdeno = window.libdeno as Libdeno;

--- a/js/resources.ts
+++ b/js/resources.ts
@@ -4,7 +4,12 @@ import * as flatbuffers from "./flatbuffers";
 import { assert } from "./util";
 import * as dispatch from "./dispatch";
 
-export function resources(): { [key: number]: string } {
+export type ResourceMap = { [rid: number]: string };
+
+/** Returns a map of open _file like_ resource ids along with their string
+ * representation.
+ */
+export function resources(): ResourceMap {
   const builder = flatbuffers.createBuilder();
   msg.Resources.startResources(builder);
   const inner = msg.Resource.endResource(builder);
@@ -14,7 +19,7 @@ export function resources(): { [key: number]: string } {
   const res = new msg.ResourcesRes();
   assert(baseRes!.inner(res) !== null);
 
-  const resources: { [key: number]: string } = {};
+  const resources = {} as ResourceMap;
 
   for (let i = 0; i < res.resourcesLength(); i++) {
     const item = res.resources(i)!;


### PR DESCRIPTION
I noticed some items were appearing in the `lib.deno_runtime.d.ts` that we didn't expect or in ways we didn't want.  This PR cleans those up.
