### PR TITLE
Update to TypeScript 3.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.3.1",
     "tslint-no-circular-imports": "^0.5.0",
-    "typescript": "3.1.3"
+    "typescript": "3.1.6"
   }
 }


### PR DESCRIPTION
This updates to the latest patch release of TypeScript which fixes several defects, none known to effect Deno, but still good to have less potential userland defects.