### PR TITLE
Use https for the demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ scripts to be executed._
 Try it:
 
 ```
-> deno http://deno.land/thumb.ts
+> deno https://deno.land/thumb.ts
 ```
 
 See also [deno_install](https://github.com/denoland/deno_install).


### PR DESCRIPTION
Without HTTPS it might be possible for a MITM to inject arbitrary code into the "thumb.ts" response which Deno would then execute.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
