### PR TITLE
Use tslint-config-prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ts-node": "^7.0.1",
     "ts-simple-ast": "17.1.0",
     "tslint": "^5.10.0",
+    "tslint-config-prettier": "^1.15.0",
     "tslint-eslint-rules": "^5.3.1",
     "tslint-no-circular-imports": "^0.5.0",
     "typescript": "3.1.3"

--- a/tslint.json
+++ b/tslint.json
@@ -63,5 +63,5 @@
       "allow-trailing-underscore"
     ]
   },
-  "extends": ["tslint-no-circular-imports"]
+  "extends": ["tslint-no-circular-imports", "tslint-config-prettier"]
 }


### PR DESCRIPTION
The modules `tslint-config-prettier` will ensure the `tslint` will ignore anything that Prettier will handle, thereby removing the need to disable `tslint` just because of Prettier formatting.

This requires an updated to `third_party`.