### PR TITLE
v0.1.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 # crates.
 [package]
 name = "deno"
-version = "0.1.11"
+version = "0.1.12"
 
 [dependencies]
 atty = "0.2.11"

--- a/src/version.rs
+++ b/src/version.rs
@@ -2,7 +2,8 @@
 use libdeno;
 use std::ffi::CStr;
 
-pub const DENO: &str = "0.1.11";
+// TODO Extract this version string from Cargo.toml.
+pub const DENO: &str = "0.1.12";
 
 pub fn v8() -> &'static str {
   let version = unsafe { libdeno::deno_v8_version() };


### PR DESCRIPTION
- Update to TypeScript 3.1.6 (#1177)
- Fixes Headers type not available. (#1175)
- Reader/Writer to use Uint8Array not ArrayBufferView (#1171)
- Fixes importing modules starting with 'http'. (#1167)
- build: Use target/ instead of out/ (#1153)
- Support repl multiline input (#1165)

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
