### PR TITLE
fix code sample in Docs

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -66,7 +66,7 @@ The copy here is actually zero-copy. That is, it reads data from the socket and
 writes it back to it without ever calling a memcpy() or similar.
 
 ```ts
-import { listen, accept, copy } from "deno";
+import { listen, copy } from "deno";
 const listener = listen("tcp", ":8080");
 while (true) {
   const conn = await listener.accept();


### PR DESCRIPTION
When I run this example, I get the following error:

```
server.ts:1:18 - error TS2305: Module '"deno"' has no exported member 'accept'.

1 import { listen, accept, copy } from "deno";
                   ~~~~~~
```

`accept()` is a method of `listener`. 

```ts
/** A Listener is a generic network listener for stream-oriented protocols. */
export interface Listener {
  /** Waits for and resolves to the next connection to the `Listener`. */
  accept(): Promise<Conn>;  // <--- HERE

  /** Close closes the listener. Any pending accept promises will be rejected
   * with errors.
   */
  close(): void;

  /** Return the address of the `Listener`. */
  addr(): Addr;
}
```