### PR TITLE
v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 # crates.
 [package]
 name = "deno"
-version = "0.1.12"
+version = "0.2.0"
 
 [dependencies]
 atty = "=0.2.11"

--- a/src/version.rs
+++ b/src/version.rs
@@ -3,7 +3,7 @@ use libdeno;
 use std::ffi::CStr;
 
 // TODO Extract this version string from Cargo.toml.
-pub const DENO: &str = "0.1.12";
+pub const DENO: &str = "0.2.0";
 
 pub fn v8() -> &'static str {
   let version = unsafe { libdeno::deno_v8_version() };


### PR DESCRIPTION
Changes since v0.1.12:
- First pass at running subprocesses (#1156)
- Improve flag parsing (#1200)
- Improve fetch() (#1194 #1188 #1102)
- Support shebang (#1197)

https://github.com/denoland/deno/milestone/2?closed=1