### PR TITLE
Revert "Use include_bytes! instead of incbin. (#1182)"

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -146,12 +146,40 @@ rust_executable("deno") {
 }
 
 source_set("snapshot") {
+  sources = [
+    "src/snapshot.cc",
+  ]
+  configs += [ ":deno_config" ]
   inputs = [
     "$target_gen_dir/snapshot_deno.bin",
   ]
   deps = [
     ":create_snapshot_deno",
   ]
+
+  # snapshot.cc doesn't need to depend on libdeno, it just needs deno_buf.
+  include_dirs = [ "libdeno/" ]
+
+  # src/snapshot.cc uses an assembly '.incbin' directive to embed the snapshot.
+  # This causes trouble when using sccache: since the snapshot file is not
+  # inlined by the c preprocessor, sccache doesn't take its contents into
+  # consideration, leading to false-positive cache hits.
+  # Maybe other caching tools have this issue too, but ccache is unaffected.
+  # Therefore, if a cc_wrapper is used that isn't ccache, include a generated
+  # header file that contains the the sha256 hash of the snapshot.
+  if (cc_wrapper != "" && cc_wrapper != "ccache") {
+    hash_h = "$target_gen_dir/bundle/hash.h"
+    inputs += [ hash_h ]
+    deps += [ ":bundle_hash_h" ]
+    if (is_win) {
+      cflags = [ "/FI" + rebase_path(hash_h, target_out_dir) ]
+    } else {
+      cflags = [
+        "-include",
+        rebase_path(hash_h, target_out_dir),
+      ]
+    }
+  }
 }
 
 rust_executable("hyper_hello") {
@@ -281,6 +309,29 @@ run_node("bundle") {
     rebase_path("."),
     "--silent",
   ]
+}
+
+action("bundle_hash_h") {
+  script = "//tools/sha256sum.py"
+  inputs = get_target_outputs(":bundle")
+  outputs = [
+    "$target_gen_dir/bundle/hash.h",
+  ]
+  deps = [
+    ":bundle",
+  ]
+  args = [
+    "--format",
+    "__attribute__((__unused__)) static const int dummy_%s = 0;",
+    "--outfile",
+    rebase_path(outputs[0], root_build_dir),
+  ]
+  foreach(input, inputs) {
+    args += [
+      "--infile",
+      rebase_path(input, root_build_dir),
+    ]
+  }
 }
 
 ts_flatbuffer("msg_ts") {

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -400,8 +400,12 @@ mod tests {
     let argv = vec![String::from("./deno"), String::from("hello.js")];
     let (flags, rest_argv, _) = flags::set_flags(argv).unwrap();
     // TODO Don't use deno_snapshot for these tests.
-    let mut isolate =
-      Isolate::new(snapshot::deno_snapshot(), flags, rest_argv, dispatch_sync);
+    let mut isolate = Isolate::new(
+      unsafe { snapshot::deno_snapshot.clone() },
+      flags,
+      rest_argv,
+      dispatch_sync,
+    );
     tokio_util::init(|| {
       isolate
         .execute(
@@ -443,7 +447,7 @@ mod tests {
     let (flags, rest_argv, _) = flags::set_flags(argv).unwrap();
     // TODO Don't use deno_snapshot for these tests.
     let mut isolate = Isolate::new(
-      snapshot::deno_snapshot(),
+      unsafe { snapshot::deno_snapshot.clone() },
       flags,
       rest_argv,
       metrics_dispatch_sync,
@@ -484,7 +488,7 @@ mod tests {
     let (flags, rest_argv, _) = flags::set_flags(argv).unwrap();
     // TODO Don't use deno_snapshot for these tests.
     let mut isolate = Isolate::new(
-      snapshot::deno_snapshot(),
+      unsafe { snapshot::deno_snapshot.clone() },
       flags,
       rest_argv,
       metrics_dispatch_async,

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ fn main() {
   });
 
   let mut isolate = isolate::Isolate::new(
-    snapshot::deno_snapshot(),
+    unsafe { snapshot::deno_snapshot.clone() },
     flags,
     rest_argv,
     ops::dispatch,

--- a/src/snapshot.cc
+++ b/src/snapshot.cc
@@ -1,0 +1,18 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+
+#include "deno.h"
+
+extern "C" {
+
+extern const char snapshot_start asm("snapshot_start");
+extern const char snapshot_end asm("snapshot_end");
+asm(".data\n"
+    "snapshot_start: .incbin \"gen/snapshot_deno.bin\"\n"
+    "snapshot_end:\n"
+    ".globl snapshot_start;\n"
+    ".globl snapshot_end;");
+extern const deno_buf deno_snapshot = {
+  nullptr, 0, reinterpret_cast<uint8_t*>(const_cast<char*>(&snapshot_start)),
+  static_cast<size_t>(&snapshot_end - &snapshot_start)};
+
+}

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,19 +1,5 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 use libdeno::deno_buf;
-use std;
-
-pub fn deno_snapshot() -> deno_buf {
-  let data =
-    include_bytes!(concat!(env!("GN_OUT_DIR"), "/gen/snapshot_deno.bin"));
-  let ptr = data.as_ptr();
-  // TODO The transmute is not necessary here. deno_buf specifies mutable
-  // pointers when it doesn't necessarally need mutable. So maybe the deno_buf
-  // type should be broken into a mutable and non-mutable version?
-  let ptr_mut = unsafe { std::mem::transmute::<*const u8, *mut u8>(ptr) };
-  deno_buf {
-    alloc_ptr: std::ptr::null_mut(),
-    alloc_len: 0,
-    data_ptr: ptr_mut,
-    data_len: data.len(),
-  }
+extern "C" {
+  pub static deno_snapshot: deno_buf;
 }


### PR DESCRIPTION
Reverting because this is causing Appveyor to be red. However
I hope we can reintroduce include_bytes! soon in a way that
works on windows. Fixes #1208.

This reverts commits 96c3641fffe8509af9351cec4580861e76d89cc9
and 92e404706b0b1a26cdaf6f8cf81aac148292557f.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
