### PR TITLE
Make isObject function more specific

### DIFF
--- a/js/util.ts
+++ b/js/util.ts
@@ -135,5 +135,5 @@ export function isTypedArray(x: unknown): x is TypedArray {
 // Returns whether o is an object, not null, and not a function.
 // @internal
 export function isObject(o: unknown): o is object {
-  return o != null && typeof o === "object";
+  return typeof o === "object" && o !== null;
 }


### PR DESCRIPTION
<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
It's a so little PR that just make `isObject` function more specific and logically by using strict equal.

If `o` is `undefined`, `typeof o === Object` returns false so didn't effect the results.