### PR TITLE
Fix mac debug build.

### DIFF
--- a/build_extra/rust/BUILD.gn
+++ b/build_extra/rust/BUILD.gn
@@ -726,7 +726,7 @@ rust_crate("dirs") {
 
 ring_root = "$registry_github/ring-0.13.2/"
 
-component("ring_primitives") {
+static_library("ring_primitives") {
   sources = [
     "$ring_root/crypto/constant_time_test.c",
     "$ring_root/crypto/cpu-aarch64-linux.c",


### PR DESCRIPTION
Debug build are component builds now, and linking isn't done properly
when ring_primitives is a component.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
