### PR TITLE
Replace mutex by atomics

### DIFF
--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -387,8 +387,8 @@ pub struct CodeFetchOutput {
 #[cfg(test)]
 pub fn test_setup() -> (TempDir, DenoDir) {
   let temp_dir = TempDir::new().expect("tempdir fail");
-  let deno_dir =
-    DenoDir::new(false, Some(temp_dir.path())).expect("setup fail");
+  let deno_dir = DenoDir::new(false, Some(temp_dir.path().to_path_buf()))
+    .expect("setup fail");
   (temp_dir, deno_dir)
 }
 

--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -41,16 +41,13 @@ impl DenoDir {
   // https://github.com/denoland/deno/blob/golang/deno_dir.go#L99-L111
   pub fn new(
     reload: bool,
-    custom_root: Option<&Path>,
+    custom_root: Option<PathBuf>,
   ) -> std::io::Result<Self> {
     // Only setup once.
     let home_dir = dirs::home_dir().expect("Could not get home directory.");
     let default = home_dir.join(".deno");
 
-    let root: PathBuf = match custom_root {
-      None => default,
-      Some(path) => path.to_path_buf(),
-    };
+    let root: PathBuf = custom_root.unwrap_or(default);
     let gen = root.as_path().join("gen");
     let deps = root.as_path().join("deps");
     let deps_http = deps.join("http");

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -130,15 +130,6 @@ pub struct Metrics {
 
 static DENO_INIT: std::sync::Once = std::sync::ONCE_INIT;
 
-fn empty() -> libdeno::deno_buf {
-  libdeno::deno_buf {
-    alloc_ptr: std::ptr::null_mut(),
-    alloc_len: 0,
-    data_ptr: std::ptr::null_mut(),
-    data_len: 0,
-  }
-}
-
 impl Isolate {
   pub fn new(
     snapshot: libdeno::deno_buf,
@@ -148,7 +139,7 @@ impl Isolate {
     DENO_INIT.call_once(|| {
       unsafe { libdeno::deno_init() };
     });
-    let shared = empty(); // TODO Use shared for message passing.
+    let shared = libdeno::deno_buf::empty(); // TODO Use shared for message passing.
     let libdeno_isolate =
       unsafe { libdeno::deno_new(snapshot, shared, pre_dispatch) };
     // This channel handles sending async messages back to the runtime.
@@ -392,7 +383,7 @@ mod tests {
     let (flags, rest_argv, _) = flags::set_flags(argv).unwrap();
 
     let state = Arc::new(IsolateState::new(flags, rest_argv));
-    let snapshot = unsafe { crate::snapshot::deno_snapshot.clone() };
+    let snapshot = libdeno::deno_buf::empty();
     let mut isolate = Isolate::new(snapshot, state, dispatch_sync);
     tokio_util::init(|| {
       isolate
@@ -434,7 +425,7 @@ mod tests {
     let argv = vec![String::from("./deno"), String::from("hello.js")];
     let (flags, rest_argv, _) = flags::set_flags(argv).unwrap();
     let state = Arc::new(IsolateState::new(flags, rest_argv));
-    let snapshot = unsafe { crate::snapshot::deno_snapshot.clone() };
+    let snapshot = libdeno::deno_buf::empty();
     let mut isolate = Isolate::new(snapshot, state, metrics_dispatch_sync);
     tokio_util::init(|| {
       // Verify that metrics have been properly initialized.
@@ -471,7 +462,7 @@ mod tests {
     let argv = vec![String::from("./deno"), String::from("hello.js")];
     let (flags, rest_argv, _) = flags::set_flags(argv).unwrap();
     let state = Arc::new(IsolateState::new(flags, rest_argv));
-    let snapshot = unsafe { crate::snapshot::deno_snapshot.clone() };
+    let snapshot = libdeno::deno_buf::empty();
     let mut isolate = Isolate::new(snapshot, state, metrics_dispatch_async);
     tokio_util::init(|| {
       // Verify that metrics have been properly initialized.

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -140,10 +140,11 @@ fn empty() -> libdeno::deno_buf {
 }
 
 impl Isolate {
-  pub fn new(dispatch: Dispatch, state: Arc<IsolateState>) -> Self {
+  pub fn new(state: Arc<IsolateState>) -> Self {
     DENO_INIT.call_once(|| {
       unsafe { libdeno::deno_init() };
     });
+    let dispatch = super::ops::dispatch;
     let shared = empty(); // TODO Use shared for message passing.
     let snapshot = unsafe { super::snapshot::deno_snapshot.clone() };
     let libdeno_isolate =

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -17,6 +17,17 @@ pub struct deno_buf {
   pub data_len: usize,
 }
 
+impl deno_buf {
+  pub fn empty() -> Self {
+    deno_buf {
+      alloc_ptr: std::ptr::null_mut(),
+      alloc_len: 0,
+      data_ptr: std::ptr::null_mut(),
+      data_len: 0,
+    }
+  }
+}
+
 type DenoRecvCb = unsafe extern "C" fn(
   user_data: *mut c_void,
   req_id: i32,

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -2,6 +2,7 @@
 use libc::c_char;
 use libc::c_int;
 use libc::c_void;
+use std::ptr::null_mut;
 
 #[repr(C)]
 pub struct isolate {
@@ -20,9 +21,9 @@ pub struct deno_buf {
 impl deno_buf {
   pub fn empty() -> Self {
     deno_buf {
-      alloc_ptr: std::ptr::null_mut(),
+      alloc_ptr: null_mut(),
       alloc_len: 0,
-      data_ptr: std::ptr::null_mut(),
+      data_ptr: null_mut(),
       data_len: 0,
     }
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ pub mod version;
 mod eager_unix;
 
 use std::env;
+use std::sync::Arc;
 
 static LOGGER: Logger = Logger;
 
@@ -95,12 +96,9 @@ fn main() {
     log::LevelFilter::Info
   });
 
-  let mut isolate = isolate::Isolate::new(
-    unsafe { snapshot::deno_snapshot.clone() },
-    flags,
-    rest_argv,
-    ops::dispatch,
-  );
+  let state = Arc::new(isolate::IsolateState::new(flags, rest_argv));
+
+  let mut isolate = isolate::Isolate::new(ops::dispatch, state);
   tokio_util::init(|| {
     isolate
       .execute("deno_main.js", "denoMain();")

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,8 +97,8 @@ fn main() {
   });
 
   let state = Arc::new(isolate::IsolateState::new(flags, rest_argv));
-
-  let mut isolate = isolate::Isolate::new(state, ops::dispatch);
+  let snapshot = unsafe { snapshot::deno_snapshot.clone() };
+  let mut isolate = isolate::Isolate::new(snapshot, state, ops::dispatch);
   tokio_util::init(|| {
     isolate
       .execute("deno_main.js", "denoMain();")

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ fn main() {
 
   let state = Arc::new(isolate::IsolateState::new(flags, rest_argv));
 
-  let mut isolate = isolate::Isolate::new(ops::dispatch, state);
+  let mut isolate = isolate::Isolate::new(state);
   tokio_util::init(|| {
     isolate
       .execute("deno_main.js", "denoMain();")

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ fn main() {
 
   let state = Arc::new(isolate::IsolateState::new(flags, rest_argv));
 
-  let mut isolate = isolate::Isolate::new(state);
+  let mut isolate = isolate::Isolate::new(state, ops::dispatch);
   tokio_util::init(|| {
     isolate
       .execute("deno_main.js", "denoMain();")

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -2,6 +2,20 @@
 #![allow(dead_code)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy, pedantic))]
 use flatbuffers;
+use std::sync::atomic::Ordering;
+
 // GN_OUT_DIR is set either by build.rs (for the Cargo build), or by
 // build_extra/rust/run.py (for the GN+Ninja build).
 include!(concat!(env!("GN_OUT_DIR"), "/gen/msg_generated.rs"));
+
+impl<'a> From<&'a super::isolate::Metrics> for MetricsResArgs {
+  fn from(m: &'a super::isolate::Metrics) -> Self {
+    MetricsResArgs {
+      ops_dispatched: m.ops_dispatched.load(Ordering::SeqCst) as u64,
+      ops_completed: m.ops_completed.load(Ordering::SeqCst) as u64,
+      bytes_sent_control: m.bytes_sent_control.load(Ordering::SeqCst) as u64,
+      bytes_sent_data: m.bytes_sent_data.load(Ordering::SeqCst) as u64,
+      bytes_received: m.bytes_received.load(Ordering::SeqCst) as u64,
+    }
+  }
+}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -23,6 +23,7 @@ use remove_dir_all::remove_dir_all;
 use repl;
 use resources::table_entries;
 use std;
+use std::convert::From;
 use std::fs;
 use std::net::{Shutdown, SocketAddr};
 #[cfg(unix)]
@@ -1291,18 +1292,10 @@ fn op_metrics(
   assert_eq!(data.len(), 0);
   let cmd_id = base.cmd_id();
 
-  let metrics = state.metrics.lock().unwrap();
-
   let builder = &mut FlatBufferBuilder::new();
   let inner = msg::MetricsRes::create(
     builder,
-    &msg::MetricsResArgs {
-      ops_dispatched: metrics.ops_dispatched,
-      ops_completed: metrics.ops_completed,
-      bytes_sent_control: metrics.bytes_sent_control,
-      bytes_sent_data: metrics.bytes_sent_data,
-      bytes_received: metrics.bytes_received,
-    },
+    &msg::MetricsResArgs::from(&state.metrics),
   );
   ok_future(serialize_response(
     cmd_id,

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -5,40 +5,41 @@ use flags::DenoFlags;
 use errors::permission_denied;
 use errors::DenoResult;
 use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg_attr(feature = "cargo-clippy", allow(stutter))]
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default)]
 pub struct DenoPermissions {
-  pub allow_write: bool,
-  pub allow_net: bool,
-  pub allow_env: bool,
-  pub allow_run: bool,
+  pub allow_write: AtomicBool,
+  pub allow_net: AtomicBool,
+  pub allow_env: AtomicBool,
+  pub allow_run: AtomicBool,
 }
 
 impl DenoPermissions {
   pub fn new(flags: &DenoFlags) -> Self {
     Self {
-      allow_write: flags.allow_write,
-      allow_env: flags.allow_env,
-      allow_net: flags.allow_net,
-      allow_run: flags.allow_run,
+      allow_write: AtomicBool::new(flags.allow_write),
+      allow_env: AtomicBool::new(flags.allow_env),
+      allow_net: AtomicBool::new(flags.allow_net),
+      allow_run: AtomicBool::new(flags.allow_run),
     }
   }
 
-  pub fn check_run(&mut self) -> DenoResult<()> {
-    if self.allow_run {
+  pub fn check_run(&self) -> DenoResult<()> {
+    if self.allow_run.load(Ordering::SeqCst) {
       return Ok(());
     };
     // TODO get location (where access occurred)
     let r = permission_prompt("Deno requests access to run a subprocess.");
     if r.is_ok() {
-      self.allow_run = true;
+      self.allow_run.store(true, Ordering::SeqCst);
     }
     r
   }
 
-  pub fn check_write(&mut self, filename: &str) -> DenoResult<()> {
-    if self.allow_write {
+  pub fn check_write(&self, filename: &str) -> DenoResult<()> {
+    if self.allow_write.load(Ordering::SeqCst) {
       return Ok(());
     };
     // TODO get location (where access occurred)
@@ -47,13 +48,13 @@ impl DenoPermissions {
       filename
     ));;
     if r.is_ok() {
-      self.allow_write = true;
+      self.allow_write.store(true, Ordering::SeqCst);
     }
     r
   }
 
-  pub fn check_net(&mut self, domain_name: &str) -> DenoResult<()> {
-    if self.allow_net {
+  pub fn check_net(&self, domain_name: &str) -> DenoResult<()> {
+    if self.allow_net.load(Ordering::SeqCst) {
       return Ok(());
     };
     // TODO get location (where access occurred)
@@ -62,20 +63,20 @@ impl DenoPermissions {
       domain_name
     ));
     if r.is_ok() {
-      self.allow_net = true;
+      self.allow_net.store(true, Ordering::SeqCst);
     }
     r
   }
 
-  pub fn check_env(&mut self) -> DenoResult<()> {
-    if self.allow_env {
+  pub fn check_env(&self) -> DenoResult<()> {
+    if self.allow_env.load(Ordering::SeqCst) {
       return Ok(());
     };
     // TODO get location (where access occurred)
     let r =
       permission_prompt(&"Deno requests access to environment variables.");
     if r.is_ok() {
-      self.allow_env = true;
+      self.allow_env.store(true, Ordering::SeqCst);
     }
     r
   }


### PR DESCRIPTION
Hi Deno team,

Thank you for creating such an amazing project. It's my pleasure to participate in.

This PR is basically trying to remove `Mutex`es from `IsolateState`.

1. Use `AtomicBool` in `DenoPermissions`, so we don't have to use `Mutex` around `DenoPermissions`.

2. Use `AtomicUsize` in `Metrics`, so we don't have to use `Mutex` around `Metrics`.
  Please note that `AtomicU64` type is still unstable, I guess `AtomicUsize` is suitable for this situation.

3. Move `mpsc::Sender<(i32, Buf)>` outside of `IsolateState`.
    * In general, we always clone a new `Sender` and move it to new thread.  `Mutex<Sender<_>>` is unidiomatic in Rust.
    * And also, I don't feel the `Option` is useful here.

4. Refine the construction of `Isolate` and `IsolateState` instances.
  The command line arguments actually only useful to `IsolateState`. It makes no sense to accept them in `Isolate::new` function. The new process is that: a) create a `IsolateState` from command line options  b) create a `Isolate` from `IsolateState`.

Hopefully this change can make Deno slightly faster, but I don't have concrete profile numbers.

And another question, I can't build debug version on my machine, only release build succeeded.
So `./tools/test.py` command fails to run on my machine. I'm using Win10's Linux subsystem.