### PR TITLE
Handle Location header relative URI

### DIFF
--- a/src/http_util.rs
+++ b/src/http_util.rs
@@ -26,34 +26,30 @@ pub fn get_client() -> Client<Connector, hyper::Body> {
   Client::builder().build(c)
 }
 
-// Construct the next uri based on base uri and location header fragment
-// https://tools.ietf.org/html/rfc3986#section-4.2
-fn maybe_uri_from_location(base_uri: &Uri, location: &str) -> Option<Uri> {
+/// Construct the next uri based on base uri and location header fragment
+/// See https://tools.ietf.org/html/rfc3986#section-4.2
+fn resolve_uri_from_location(base_uri: &Uri, location: &str) -> Uri {
   if location.starts_with("http://") || location.starts_with("https://") {
     // absolute uri
-    return Some(
-      location
-        .parse::<Uri>()
-        .expect("provided redirect url should be a valid url"),
-    );
+    return location
+      .parse::<Uri>()
+      .expect("provided redirect url should be a valid url");
   } else if location.starts_with("//") {
     // "//" authority path-abempty
-    return Some(
-      format!("{}:{}", base_uri.scheme_part().unwrap().as_str(), location)
-        .parse::<Uri>()
-        .expect("provided redirect url should be a valid url"),
-    );
+    return format!("{}:{}", base_uri.scheme_part().unwrap().as_str(), location)
+      .parse::<Uri>()
+      .expect("provided redirect url should be a valid url");
   } else if location.starts_with("/") {
     // path-absolute
     let mut new_uri_parts = base_uri.clone().into_parts();
     new_uri_parts.path_and_query = Some(location.parse().unwrap());
-    return Uri::from_parts(new_uri_parts).ok();
+    return Uri::from_parts(new_uri_parts).unwrap();
   } else {
     // assuming path-noscheme | path-empty
     let mut new_uri_parts = base_uri.clone().into_parts();
     new_uri_parts.path_and_query =
       Some(format!("{}/{}", base_uri.path(), location).parse().unwrap());
-    return Uri::from_parts(new_uri_parts).ok();
+    return Uri::from_parts(new_uri_parts).unwrap();
   }
 }
 
@@ -64,8 +60,7 @@ pub fn fetch_sync_string(module_name: &str) -> DenoResult<(String, String)> {
   let client = get_client();
   // TODO(kevinkassimo): consider set a max redirection counter
   // to avoid bouncing between 2 or more urls
-  let fetch_future = loop_fn((client, Some(url)), |(client, maybe_url)| {
-    let url = maybe_url.expect("target url should not be None");
+  let fetch_future = loop_fn((client, url), |(client, url)| {
     client
       .get(url.clone())
       .map_err(DenoError::from)
@@ -79,8 +74,8 @@ pub fn fetch_sync_string(module_name: &str) -> DenoResult<(String, String)> {
             .unwrap()
             .to_string();
           debug!("Redirecting to {}...", &location_string);
-          let maybe_new_url = maybe_uri_from_location(&url, &location_string);
-          return Ok(Loop::Continue((client, maybe_new_url)));
+          let new_url = resolve_uri_from_location(&url, &location_string);
+          return Ok(Loop::Continue((client, new_url)));
         }
         if !response.status().is_success() {
           return Err(errors::new(
@@ -133,47 +128,39 @@ fn test_fetch_sync_string_with_redirect() {
 }
 
 #[test]
-fn test_maybe_uri_from_location_full_1() {
+fn test_resolve_uri_from_location_full_1() {
   let url = "http://deno.land".parse::<Uri>().unwrap();
-  let maybe_new_uri = maybe_uri_from_location(&url, "http://golang.org");
-  assert!(maybe_new_uri.is_some());
-  assert_eq!(maybe_new_uri.unwrap().host().unwrap(), "golang.org");
+  let new_uri = resolve_uri_from_location(&url, "http://golang.org");
+  assert_eq!(new_uri.host().unwrap(), "golang.org");
 }
 
 #[test]
-fn test_maybe_uri_from_location_full_2() {
+fn test_resolve_uri_from_location_full_2() {
   let url = "https://deno.land".parse::<Uri>().unwrap();
-  let maybe_new_uri = maybe_uri_from_location(&url, "https://golang.org");
-  assert!(maybe_new_uri.is_some());
-  assert_eq!(maybe_new_uri.unwrap().host().unwrap(), "golang.org");
+  let new_uri = resolve_uri_from_location(&url, "https://golang.org");
+  assert_eq!(new_uri.host().unwrap(), "golang.org");
 }
 
 #[test]
-fn test_maybe_uri_from_location_relative_1() {
+fn test_resolve_uri_from_location_relative_1() {
   let url = "http://deno.land/x".parse::<Uri>().unwrap();
-  let maybe_new_uri = maybe_uri_from_location(&url, "//rust-lang.org/en-US");
-  assert!(maybe_new_uri.is_some());
-  let new_uri = maybe_new_uri.unwrap();
+  let new_uri = resolve_uri_from_location(&url, "//rust-lang.org/en-US");
   assert_eq!(new_uri.host().unwrap(), "rust-lang.org");
   assert_eq!(new_uri.path(), "/en-US");
 }
 
 #[test]
-fn test_maybe_uri_from_location_relative_2() {
+fn test_resolve_uri_from_location_relative_2() {
   let url = "http://deno.land/x".parse::<Uri>().unwrap();
-  let maybe_new_uri = maybe_uri_from_location(&url, "/y");
-  assert!(maybe_new_uri.is_some());
-  let new_uri = maybe_new_uri.unwrap();
+  let new_uri = resolve_uri_from_location(&url, "/y");
   assert_eq!(new_uri.host().unwrap(), "deno.land");
   assert_eq!(new_uri.path(), "/y");
 }
 
 #[test]
-fn test_maybe_uri_from_location_relative_3() {
+fn test_resolve_uri_from_location_relative_3() {
   let url = "http://deno.land/x".parse::<Uri>().unwrap();
-  let maybe_new_uri = maybe_uri_from_location(&url, "z");
-  assert!(maybe_new_uri.is_some());
-  let new_uri = maybe_new_uri.unwrap();
+  let new_uri = resolve_uri_from_location(&url, "z");
   assert_eq!(new_uri.host().unwrap(), "deno.land");
   assert_eq!(new_uri.path(), "/x/z");
 }


### PR DESCRIPTION
This addresses 1st part of problem for #1239 (the location header in the sample given was `/dyo@0.0.2?module`, not a full path)
+ Handle `Location` header that contains [relative URI](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location#Directives)

Refs:
https://tools.ietf.org/html/rfc7231#page-68
https://tools.ietf.org/html/rfc3986#section-4.2
https://tools.ietf.org/html/rfc3986#section-3.3