### PR TITLE
Upgrade to TypeScript 3.2

### DIFF
--- a/js/assets.ts
+++ b/js/assets.ts
@@ -35,6 +35,7 @@ import libEs2018RegexpDts from "/third_party/node_modules/typescript/lib/lib.es2
 import libEs5Dts from "/third_party/node_modules/typescript/lib/lib.es5.d.ts!string";
 import libEsnextArrayDts from "/third_party/node_modules/typescript/lib/lib.esnext.array.d.ts!string";
 import libEsnextAsynciterablesDts from "/third_party/node_modules/typescript/lib/lib.esnext.asynciterable.d.ts!string";
+import libEsnextBigintDts from "/third_party/node_modules/typescript/lib/lib.esnext.bigint.d.ts!string";
 import libEsnextDts from "/third_party/node_modules/typescript/lib/lib.esnext.d.ts!string";
 import libEsnextIntlDts from "/third_party/node_modules/typescript/lib/lib.esnext.intl.d.ts!string";
 import libEsnextSymbolDts from "/third_party/node_modules/typescript/lib/lib.esnext.symbol.d.ts!string";
@@ -75,6 +76,7 @@ export const assetSourceCode: { [key: string]: string } = {
   "lib.esnext.d.ts": libEsnextDts,
   "lib.esnext.array.d.ts": libEsnextArrayDts,
   "lib.esnext.asynciterable.d.ts": libEsnextAsynciterablesDts,
+  "lib.esnext.bigint.d.ts": libEsnextBigintDts,
   "lib.esnext.intl.d.ts": libEsnextIntlDts,
   "lib.esnext.symbol.d.ts": libEsnextSymbolDts,
 

--- a/js/timers.ts
+++ b/js/timers.ts
@@ -167,7 +167,9 @@ function fireTimers() {
   setGlobalTimeout(nextTimerDue, now);
 }
 
-function setTimer<Args extends Array<unknown>>(
+export type Args = any[]; // tslint:disable-line:no-any
+
+function setTimer(
   cb: (...args: Args) => void,
   delay: number,
   args: Args,
@@ -198,7 +200,7 @@ function setTimer<Args extends Array<unknown>>(
 }
 
 /** Sets a timer which executes a function once after the timer expires. */
-export function setTimeout<Args extends Array<unknown>>(
+export function setTimeout(
   cb: (...args: Args) => void,
   delay: number,
   ...args: Args
@@ -207,7 +209,7 @@ export function setTimeout<Args extends Array<unknown>>(
 }
 
 /** Repeatedly calls a function , with a fixed time delay between each call. */
-export function setInterval<Args extends Array<unknown>>(
+export function setInterval(
   cb: (...args: Args) => void,
   delay: number,
   ...args: Args

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.3.1",
     "tslint-no-circular-imports": "^0.5.0",
-    "typescript": "3.1.6"
+    "typescript": "3.2.1"
   }
 }


### PR DESCRIPTION
Fixes #1242 

Because of the new ability of `.bind` to check assignability, the advanced typing we had for the callbacks for the timers no longer passes the strict checking.  Looking at both `@types/node` and `lib.dom.d.ts`, they use an `any[]` for the callback arguments, so that is best for us to do that here.