### PR TITLE
clippy fixes

### DIFF
--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -946,12 +946,10 @@ fn filter_shebang(code: String) -> String {
     return code;
   }
   match code.find('\n') {
-    None => {
-      return String::from("");
-    }
+    None => String::from(""),
     Some(i) => {
       let (_, rest) = code.split_at(i);
-      return String::from(rest);
+      String::from(rest)
     }
   }
 }

--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -945,12 +945,11 @@ fn filter_shebang(code: String) -> String {
   if !code.starts_with("#!") {
     return code;
   }
-  match code.find('\n') {
-    None => String::from(""),
-    Some(i) => {
-      let (_, rest) = code.split_at(i);
-      String::from(rest)
-    }
+  if let Some(i) = code.find('\n') {
+    let (_, rest) = code.split_at(i);
+    String::from(rest)
+  } else {
+    String::from("")
   }
 }
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -287,12 +287,17 @@ pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
   // Store the length of the c_argv array in a local variable. We'll pass
   // a pointer to this local variable to deno_set_v8_flags(), which then
   // updates its value.
+  #[cfg_attr(
+    feature = "cargo-clippy",
+    allow(cast_possible_truncation, cast_possible_wrap)
+  )]
   let mut c_argv_len = c_argv.len() as c_int;
   // Let v8 parse the arguments it recognizes and remove them from c_argv.
   unsafe {
     libdeno::deno_set_v8_flags(&mut c_argv_len, c_argv.as_mut_ptr());
   };
   // If c_argv_len was updated we have to change the length of c_argv to match.
+  #[cfg_attr(feature = "cargo-clippy", allow(cast_sign_loss))]
   c_argv.truncate(c_argv_len as usize);
   // Copy the modified arguments list into a proper rust vec and return it.
   c_argv

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -101,7 +101,7 @@ fn set_recognized_flags(
           flags.types = true;
         }
 
-        if matches.free.len() > 0 {
+        if !matches.free.is_empty() {
           rest.extend(matches.free);
         }
       }

--- a/src/http_body.rs
+++ b/src/http_body.rs
@@ -10,7 +10,7 @@ use std::io;
 use std::io::Read;
 use tokio::io::AsyncRead;
 
-/// Wraps hyper::Body so that it can be exposed as an AsyncRead and integrated
+/// Wraps `hyper::Body` so that it can be exposed as an `AsyncRead` and integrated
 /// into resources more easily.
 pub struct HttpBody {
   body: Body,
@@ -19,8 +19,8 @@ pub struct HttpBody {
 }
 
 impl HttpBody {
-  pub fn from(body: Body) -> HttpBody {
-    HttpBody {
+  pub fn from(body: Body) -> Self {
+    Self {
       body,
       chunk: None,
       pos: 0,
@@ -36,30 +36,27 @@ impl Read for HttpBody {
 
 impl AsyncRead for HttpBody {
   fn poll_read(&mut self, buf: &mut [u8]) -> Poll<usize, io::Error> {
-    match self.chunk.take() {
-      Some(chunk) => {
-        debug!(
-          "HttpBody Fake Read buf {} chunk {} pos {}",
-          buf.len(),
-          chunk.len(),
-          self.pos
-        );
-        let n = min(buf.len(), chunk.len() - self.pos);
-        {
-          let rest = &chunk[self.pos..];
-          buf[..n].clone_from_slice(&rest[..n]);
-        }
-        self.pos += n;
-        if self.pos == chunk.len() {
-          self.pos = 0;
-        } else {
-          self.chunk = Some(chunk);
-        }
-        return Ok(Async::Ready(n));
+    if let Some(chunk) = self.chunk.take() {
+      debug!(
+        "HttpBody Fake Read buf {} chunk {} pos {}",
+        buf.len(),
+        chunk.len(),
+        self.pos
+      );
+      let n = min(buf.len(), chunk.len() - self.pos);
+      {
+        let rest = &chunk[self.pos..];
+        buf[..n].clone_from_slice(&rest[..n]);
       }
-      None => {
-        assert_eq!(self.pos, 0);
+      self.pos += n;
+      if self.pos == chunk.len() {
+        self.pos = 0;
+      } else {
+        self.chunk = Some(chunk);
       }
+      return Ok(Async::Ready(n));
+    } else {
+      assert_eq!(self.pos, 0);
     }
 
     let p = self.body.poll_data();

--- a/src/http_util.rs
+++ b/src/http_util.rs
@@ -27,7 +27,7 @@ pub fn get_client() -> Client<Connector, hyper::Body> {
 }
 
 /// Construct the next uri based on base uri and location header fragment
-/// See https://tools.ietf.org/html/rfc3986#section-4.2
+/// See <https://tools.ietf.org/html/rfc3986#section-4.2>
 fn resolve_uri_from_location(base_uri: &Uri, location: &str) -> Uri {
   if location.starts_with("http://") || location.starts_with("https://") {
     // absolute uri

--- a/src/http_util.rs
+++ b/src/http_util.rs
@@ -31,25 +31,25 @@ pub fn get_client() -> Client<Connector, hyper::Body> {
 fn resolve_uri_from_location(base_uri: &Uri, location: &str) -> Uri {
   if location.starts_with("http://") || location.starts_with("https://") {
     // absolute uri
-    return location
+    location
       .parse::<Uri>()
-      .expect("provided redirect url should be a valid url");
+      .expect("provided redirect url should be a valid url")
   } else if location.starts_with("//") {
     // "//" authority path-abempty
-    return format!("{}:{}", base_uri.scheme_part().unwrap().as_str(), location)
+    format!("{}:{}", base_uri.scheme_part().unwrap().as_str(), location)
       .parse::<Uri>()
-      .expect("provided redirect url should be a valid url");
-  } else if location.starts_with("/") {
+      .expect("provided redirect url should be a valid url")
+  } else if location.starts_with('/') {
     // path-absolute
     let mut new_uri_parts = base_uri.clone().into_parts();
     new_uri_parts.path_and_query = Some(location.parse().unwrap());
-    return Uri::from_parts(new_uri_parts).unwrap();
+    Uri::from_parts(new_uri_parts).unwrap()
   } else {
     // assuming path-noscheme | path-empty
     let mut new_uri_parts = base_uri.clone().into_parts();
     new_uri_parts.path_and_query =
       Some(format!("{}/{}", base_uri.path(), location).parse().unwrap());
-    return Uri::from_parts(new_uri_parts).unwrap();
+    Uri::from_parts(new_uri_parts).unwrap()
   }
 }
 

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -68,7 +68,7 @@ pub struct IsolateState {
 impl IsolateState {
   pub fn new(flags: flags::DenoFlags, argv_rest: Vec<String>) -> Self {
     let custom_root = env::var("DENO_DIR").map(|s| s.into()).ok();
-    IsolateState {
+    Self {
       dir: deno_dir::DenoDir::new(flags.reload, custom_root).unwrap(),
       argv: argv_rest,
       permissions: DenoPermissions::new(&flags),

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -152,7 +152,7 @@ impl Isolate {
       tx,
       ntasks: 0,
       timeout_due: None,
-      state: state,
+      state,
     }
   }
 

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -20,7 +20,7 @@ pub struct deno_buf {
 
 impl deno_buf {
   pub fn empty() -> Self {
-    deno_buf {
+    Self {
       alloc_ptr: null_mut(),
       alloc_len: 0,
       data_ptr: null_mut(),

--- a/src/msg_util.rs
+++ b/src/msg_util.rs
@@ -26,7 +26,6 @@ pub fn serialize_key_value<'bldr>(
     &msg::KeyValueArgs {
       key: Some(key),
       value: Some(value),
-      ..Default::default()
     },
   )
 }
@@ -71,7 +70,7 @@ pub fn serialize_fields<'bldr>(
     let kv = serialize_key_value(builder, key.as_ref(), val.to_str().unwrap());
     fields.push(kv);
   }
-  return builder.create_vector(fields.as_ref());
+  builder.create_vector(fields.as_ref())
 }
 
 // Not to be confused with serialize_response which has nothing to do with HTTP.
@@ -98,7 +97,7 @@ pub fn deserialize_request(
 ) -> Request<Body> {
   let mut r = Request::new(body);
 
-  assert!(header_msg.is_request() == true);
+  assert!(header_msg.is_request());
 
   let url = header_msg.url().unwrap();
   let uri = Uri::from_str(url).unwrap();

--- a/src/msg_util.rs
+++ b/src/msg_util.rs
@@ -99,9 +99,9 @@ pub fn deserialize_request(
 
   assert!(header_msg.is_request());
 
-  let url = header_msg.url().unwrap();
-  let uri = Uri::from_str(url).unwrap();
-  *r.uri_mut() = uri;
+  let u = header_msg.url().unwrap();
+  let u = Uri::from_str(u).unwrap();
+  *r.uri_mut() = u;
 
   if let Some(method) = header_msg.method() {
     let method = Method::from_str(method).unwrap();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -400,7 +400,7 @@ fn op_fetch(
   assert!(header.is_request());
   let url = header.url().unwrap();
 
-  let body = if data.len() == 0 {
+  let body = if data.is_empty() {
     hyper::Body::empty()
   } else {
     hyper::Body::from(Vec::from(data))
@@ -429,7 +429,6 @@ fn op_fetch(
           &msg::FetchResArgs {
             header: Some(header_off),
             body_rid: body_resource.rid,
-            ..Default::default()
           },
         );
 
@@ -1469,7 +1468,6 @@ fn op_run_status(
         got_signal,
         exit_code: code.unwrap_or(-1),
         exit_signal: signal.unwrap_or(-1),
-        ..Default::default()
       },
     );
     Ok(serialize_response(

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -330,7 +330,7 @@ fn op_set_timeout(
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_set_timeout().unwrap();
-  // FIXME why is timeout a double if it's cast immediately to i64?
+  // FIXME why is timeout a double if it's cast immediately to i64/u64??
   let val = inner.timeout() as i64;
   isolate.timeout_due = if val >= 0 {
     Some(Instant::now() + Duration::from_millis(val as u64))
@@ -1376,19 +1376,19 @@ fn op_run(
   let args = inner.args().unwrap();
   let cwd = inner.cwd();
 
-  let mut cmd = Command::new(args.get(0));
+  let mut c = Command::new(args.get(0));
   (1..args.len()).for_each(|i| {
     let arg = args.get(i);
-    cmd.arg(arg);
+    c.arg(arg);
   });
-  cwd.map(|d| cmd.current_dir(d));
+  cwd.map(|d| c.current_dir(d));
 
-  cmd.stdin(subprocess_stdio_map(inner.stdin()));
-  cmd.stdout(subprocess_stdio_map(inner.stdout()));
-  cmd.stderr(subprocess_stdio_map(inner.stderr()));
+  c.stdin(subprocess_stdio_map(inner.stdin()));
+  c.stdout(subprocess_stdio_map(inner.stdout()));
+  c.stderr(subprocess_stdio_map(inner.stderr()));
 
   // Spawn the command.
-  let child = match cmd.spawn_async() {
+  let child = match c.spawn_async() {
     Ok(v) => v,
     Err(err) => {
       return odd_future(err.into());

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -66,7 +66,7 @@ enum Repr {
   TcpStream(tokio::net::TcpStream),
   HttpBody(HttpBody),
   Repl(Repl),
-  Child(tokio_process::Child),
+  Child(Box<tokio_process::Child>),
   ChildStdin(tokio_process::ChildStdin),
   ChildStdout(tokio_process::ChildStdout),
   ChildStderr(tokio_process::ChildStderr),
@@ -298,10 +298,10 @@ pub fn add_child(mut c: tokio_process::Child) -> ChildResources {
     resources.stderr_rid = Some(rid);
   }
 
-  let r = tg.insert(child_rid, Repr::Child(c));
+  let r = tg.insert(child_rid, Repr::Child(Box::new(c)));
   assert!(r.is_none());
 
-  return resources;
+  resources
 }
 
 pub struct ChildStatus {

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -66,6 +66,9 @@ enum Repr {
   TcpStream(tokio::net::TcpStream),
   HttpBody(HttpBody),
   Repl(Repl),
+  // Enum size is bounded by the largest variant.
+  // Use `Box` around large `Child` struct.
+  // https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
   Child(Box<tokio_process::Child>),
   ChildStdin(tokio_process::ChildStdin),
   ChildStdout(tokio_process::ChildStdout),

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -258,6 +258,7 @@ pub fn add_repl(repl: Repl) -> Resource {
   Resource { rid }
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(stutter))]
 pub struct ChildResources {
   pub child_rid: ResourceId,
   pub stdin_rid: Option<ResourceId>,


### PR DESCRIPTION
Note: `Repr::Child` moved to `Box` due to `large_enum_variant` lint
https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant