### PR TITLE
doc: Remove TS and V8 versions from README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## A secure TypeScript runtime built on V8
 
-- Supports TypeScript 3.2 out of the box. Uses V8 7.1. That is, it's very modern
-  JavaScript.
+- Supports TypeScript out of the box. Uses a recent version of V8. That is,
+  it's very modern JavaScript.
 
 - No `package.json`. No npm. Not explicitly compatible with Node.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## A secure TypeScript runtime built on V8
 
-- Supports TypeScript out of the box. Uses a recent version of V8. That is,
-  it's very modern JavaScript.
+- Supports TypeScript out of the box. Uses a recent version of V8. That is, it's
+  very modern JavaScript.
 
 - No `package.json`. No npm. Not explicitly compatible with Node.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## A secure TypeScript runtime built on V8
 
-- Supports TypeScript 3.1 out of the box. Uses V8 7.1. That is, it's very modern
+- Supports TypeScript 3.2 out of the box. Uses V8 7.1. That is, it's very modern
   JavaScript.
 
 - No `package.json`. No npm. Not explicitly compatible with Node.


### PR DESCRIPTION
Since we now use TypeScript 3.2.1
