### PR TITLE
Avoid memory leak

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -190,6 +190,8 @@ impl Isolate {
 
   pub fn respond(&mut self, req_id: i32, buf: Buf) {
     self.state.metrics_op_completed(buf.len());
+    // deno_respond will memcpy the buf into V8's heap,
+    // so borrowing a reference here is sufficient.
     unsafe {
       libdeno::deno_respond(
         self.libdeno_isolate,

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -190,15 +190,12 @@ impl Isolate {
 
   pub fn respond(&mut self, req_id: i32, buf: Buf) {
     self.state.metrics_op_completed(buf.len());
-
-    // TODO(zero-copy) Use Buf::leak(buf) to leak the heap allocated buf. And
-    // don't do the memcpy in ImportBuf() (in libdeno/binding.cc)
     unsafe {
       libdeno::deno_respond(
         self.libdeno_isolate,
         self.as_void_ptr(),
         req_id,
-        buf.into(),
+        buf.as_ref().into(),
       )
     }
   }
@@ -268,20 +265,6 @@ impl Isolate {
 impl Drop for Isolate {
   fn drop(&mut self) {
     unsafe { libdeno::deno_delete(self.libdeno_isolate) }
-  }
-}
-
-/// Converts Rust Buf to libdeno `deno_buf`.
-impl From<Buf> for libdeno::deno_buf {
-  fn from(x: Buf) -> Self {
-    let len = x.len();
-    let ptr = Box::into_raw(x);
-    Self {
-      alloc_ptr: std::ptr::null_mut(),
-      alloc_len: 0,
-      data_ptr: ptr as *mut u8,
-      data_len: len,
-    }
   }
 }
 

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -41,7 +41,6 @@ impl<'a> From<&'a [u8]> for deno_buf {
   }
 }
 
-
 type DenoRecvCb = unsafe extern "C" fn(
   user_data: *mut c_void,
   req_id: i32,

--- a/src/libdeno.rs
+++ b/src/libdeno.rs
@@ -29,6 +29,19 @@ impl deno_buf {
   }
 }
 
+/// Converts Rust &Buf to libdeno `deno_buf`.
+impl<'a> From<&'a [u8]> for deno_buf {
+  fn from(x: &'a [u8]) -> Self {
+    Self {
+      alloc_ptr: std::ptr::null_mut(),
+      alloc_len: 0,
+      data_ptr: x.as_ref().as_ptr() as *mut u8,
+      data_len: x.len(),
+    }
+  }
+}
+
+
 type DenoRecvCb = unsafe extern "C" fn(
   user_data: *mut c_void,
   req_id: i32,


### PR DESCRIPTION
Fix #1263

It is hard to achieve zero-copy when passing message between Rust and C, because we can't assume they use the same allocator. There is only one case that zero-copy is easy:
```
1. Create buffer in Rust
2. Call function in C
    1. Pass borrowed pointer to C
    2. C only need to use this buffer in a limited time span
3.  The buffer is destroyed in Rust
```
I think deno is not as simple as this. Zero-copy will cost significant API complexity.