### PR TITLE
Turn off kPromiseResolvedAfterResolved warning

### DIFF
--- a/js/promise_util.ts
+++ b/js/promise_util.ts
@@ -22,6 +22,9 @@ export function promiseRejectHandler(
     case "HandlerAddedAfterReject":
       rejectMap.delete(promise);
       break;
+    case "ResolveAfterResolved":
+      // Should not warn. See #1272
+      break;
     default:
       // error is string here
       otherErrorMap.set(promise, `Promise warning: ${error as string}`);


### PR DESCRIPTION
Closes #1272 . See rationale in the issue

Not quite sure if I should add an output diff test for this.