### PR TITLE
Remove the 'static lifetime bound in ops.rs

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,19 +1,9 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 use libdeno::deno_buf;
-use std;
 
 pub fn deno_snapshot() -> deno_buf {
   let data =
     include_bytes!(concat!(env!("GN_OUT_DIR"), "/gen/snapshot_deno.bin"));
-  let ptr = data.as_ptr();
-  // TODO The cast is not necessary here. deno_buf specifies mutable
-  // pointers when it doesn't necessarally need mutable. So maybe the deno_buf
-  // type should be broken into a mutable and non-mutable version?
-  let ptr_mut = ptr as *mut u8;
-  deno_buf {
-    alloc_ptr: std::ptr::null_mut(),
-    alloc_len: 0,
-    data_ptr: ptr_mut,
-    data_len: data.len(),
-  }
+
+  unsafe { deno_buf::from_raw_parts(data.as_ptr(), data.len()) }
 }


### PR DESCRIPTION
The main purpose of this PR is to remove the `'static` lifetime bound in
```rust
type OpCreator =
  fn(state: &Arc<IsolateState>, base: &msg::Base, data: &'static mut [u8])
    -> Box<Op>;
```

The reason is simple: it is plain wrong, the `data` is actually not `'static`. It is created when the message is sent from C side, and will be recycled when the message is responded. It violates the definition of `'static` lifetime.

If someone save this pointer somewhere else, and reuse it later again, uninitialized memory could be accessed. This kind of memory unsafety does not happen yet because the logic is carefully organized in this project. Lifetime constraints are maintained by code convention. It could be more robust if we can express this constraint by Rust's type system.

Basic idea: tie buffer's lifetime to an object's lifetime, a.k.a, RAII. The type `deno_buf` is pretty suitable for this job.