### PR TITLE
clean up rust code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ fn main() {
 
   let state = Arc::new(isolate::IsolateState::new(flags, rest_argv));
   let snapshot = snapshot::deno_snapshot();
-  let mut isolate = isolate::Isolate::new(snapshot, state, ops::dispatch);
+  let isolate = isolate::Isolate::new(snapshot, state, ops::dispatch);
   tokio_util::init(|| {
     isolate
       .execute("deno_main.js", "denoMain();")


### PR DESCRIPTION
This is a bunch of cleanups on rust code.

Please note the change on `Isolate::from_void_ptr`.
1. It is renamed to `from_raw_ptr`, to keep consistency with std libs.
2. It is changed to `unsafe` function, because itself can't guarantee the input raw pointer is valid or not. This guarantee should be provided by the caller.
3. Its return type is changed to `&Isolate`, because `&mut Isolate` type requires that no other aliases co-exist in this period of time, this does not seem true. So I changed most of the methods to accept shared reference `&Isolate`. It is easier to reason about the correctness of `unsafe` blocks. As long as these shared references are in the same thread, these `unsafe` codes are probably correct.

Others are tiny improvements.