### PR TITLE
[WIP] Implementation of create file

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -4,7 +4,7 @@
 /// <amd-module name="deno"/>
 export { env, exit } from "./os";
 export { chdir, cwd } from "./dir";
-export { File, open, stdin, stdout, stderr, read, write, close } from "./files";
+export { File, OpenMode, open, stdin, stdout, stderr, read, write, close } from "./files";
 export {
   copy,
   toAsyncIterator,

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -6,7 +6,6 @@ export { env, exit } from "./os";
 export { chdir, cwd } from "./dir";
 export {
   File,
-  OpenMode,
   open,
   stdin,
   stdout,

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -4,16 +4,7 @@
 /// <amd-module name="deno"/>
 export { env, exit } from "./os";
 export { chdir, cwd } from "./dir";
-export {
-  File,
-  open,
-  stdin,
-  stdout,
-  stderr,
-  read,
-  write,
-  close
-} from "./files";
+export { File, open, stdin, stdout, stderr, read, write, close } from "./files";
 export {
   copy,
   toAsyncIterator,

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -4,7 +4,17 @@
 /// <amd-module name="deno"/>
 export { env, exit } from "./os";
 export { chdir, cwd } from "./dir";
-export { File, OpenMode, open, stdin, stdout, stderr, read, write, close } from "./files";
+export {
+  File,
+  OpenMode,
+  open,
+  stdin,
+  stdout,
+  stderr,
+  read,
+  write,
+  close
+} from "./files";
 export {
   copy,
   toAsyncIterator,

--- a/js/files.ts
+++ b/js/files.ts
@@ -29,51 +29,30 @@ export const stdout = new File(1);
 /** An instance of `File` for stderr. */
 export const stderr = new File(2);
 
-export enum OpenMode {
-  /** Read-only, default mode.
-   * Starts at beginning of file.
-   */
-  Read = "r",
-  /** Read-write
-   * Start at beginning of file.
-   */
-  ReadWrite = "r+",
-  /** Write-only
-   * Opens and truncates existing file or creates new one
-   * for writing only.
-   */
-  Write = "w",
-  /** Write-read
-   * Opens and truncates existing file or creates new one
-   * for writing and reading.
-   */
-  WriteRead = "w+",
-  /** Append-only
-   * Opens existing file or creates new one.
-   * Each write appends content to file and doesn't overwrite
-   * already existing content.
-   */
-  Append = "a",
-  /** Append-read
-   * Behaves like `OpenMode.Append` and allows to read from file.
-   */
-  AppendRead = "a+",
-  /** Exclusive create
-   * Creates new file only if one doesn't exist already.
-   * Allows to write to file.
-   */
-  ExclusiveCreate = "x",
-  /** Exclusive create - read
-   * Behaves like `OpenMode.ExclusiveCreate` and allows to read from file.
-   */
-  ExclusiveCreateRead = "x+"
-}
+type OpenMode =
+  /** Read-only, default mode. Starts at beginning of file. */
+  "r" |
+  /** Read-write. Start at beginning of file. */
+  "r+" |
+  /** Write-only. Opens and truncates existing file or creates new one for writing only. */
+  "w" |
+  /** Read-write. Opens and truncates existing file or creates new one for writing and reading. */
+  "w+" |
+  /** Write-only. Opens existing file or creates new one. Each write appends content to the end of file. */
+  "a" |
+  /** Read-write. Behaves like "a" and allows to read from file. */
+  "a+" |
+  /** Write-only. Exclusive create - creates new file only if one doesn't exist already */
+  "x" |
+  /** Read-write. Behaves like `x` and allows to read from file. */
+  "x+";
+
 
 /** A factory function for creating instances of `File` associated with the
  * supplied file name.
  */
 export function create(filename: string): Promise<File> {
-  return open(filename, OpenMode.WriteRead);
+  return open(filename, "w+");
 }
 
 /** Open a file and return an instance of the `File` object.
@@ -85,7 +64,7 @@ export function create(filename: string): Promise<File> {
  */
 export async function open(
   filename: string,
-  mode: OpenMode = OpenMode.Read
+  mode: OpenMode = "r"
 ): Promise<File> {
   const builder = flatbuffers.createBuilder();
   const filename_ = builder.createString(filename);

--- a/js/files.ts
+++ b/js/files.ts
@@ -29,14 +29,51 @@ export const stdout = new File(1);
 /** An instance of `File` for stderr. */
 export const stderr = new File(2);
 
-// TODO This is just a placeholder - not final API.
-export type OpenMode = "r" | "w" | "w+" | "x";
+export enum OpenMode {
+  /** Read-only, default mode.
+   * Starts at beginning of file.
+   */
+  Read = "r",
+  /** Read-write
+   * Start at beginning of file.
+   */
+  ReadWrite = "r+",
+  /** Write-only
+   * Opens and truncates existing file or creates new one
+   * for writing only.
+   */
+  Write = "w",
+  /** Write-read
+   * Opens and truncates existing file or creates new one
+   * for writing and reading.
+   */
+  WriteRead = "w+",
+  /** Append-only
+   * Opens existing file or creates new one.
+   * Each write appends content to file and doesn't overwrite
+   * already existing content.
+   */
+  Append = "a",
+  /** Append-read
+   * Behaves like `OpenMode.Append` and allows to read from file.
+   */
+  AppendRead = "a+",
+  /** Exclusive create
+   * Creates new file only if one doesn't exist already.
+   * Allows to write to file.
+   */
+  ExclusiveCreate = "x",
+  /** Exclusive create - read
+   * Behaves like `OpenMode.ExclusiveCreate` and allows to read from file.
+   */
+  ExclusiveCreateRead = "x+"
+}
 
 /** A factory function for creating instances of `File` associated with the
  * supplied file name.
  */
 export function create(filename: string): Promise<File> {
-  return open(filename, "x");
+  return open(filename, OpenMode.ExclusiveCreate);
 }
 
 /** Open a file and return an instance of the `File` object.
@@ -48,7 +85,7 @@ export function create(filename: string): Promise<File> {
  */
 export async function open(
   filename: string,
-  mode: OpenMode = "r"
+  mode: OpenMode = OpenMode.Read
 ): Promise<File> {
   const builder = flatbuffers.createBuilder();
   const filename_ = builder.createString(filename);

--- a/js/files.ts
+++ b/js/files.ts
@@ -29,24 +29,25 @@ export const stdout = new File(1);
 /** An instance of `File` for stderr. */
 export const stderr = new File(2);
 
+// tslint:disable:max-line-length
 type OpenMode =
   /** Read-only, default mode. Starts at beginning of file. */
-  "r" |
+  | "r"
   /** Read-write. Start at beginning of file. */
-  "r+" |
+  | "r+"
   /** Write-only. Opens and truncates existing file or creates new one for writing only. */
-  "w" |
+  | "w"
   /** Read-write. Opens and truncates existing file or creates new one for writing and reading. */
-  "w+" |
+  | "w+"
   /** Write-only. Opens existing file or creates new one. Each write appends content to the end of file. */
-  "a" |
+  | "a"
   /** Read-write. Behaves like "a" and allows to read from file. */
-  "a+" |
+  | "a+"
   /** Write-only. Exclusive create - creates new file only if one doesn't exist already */
-  "x" |
+  | "x"
   /** Read-write. Behaves like `x` and allows to read from file. */
-  "x+";
-
+  | "x+";
+// tslint:enable:max-line-length
 
 /** A factory function for creating instances of `File` associated with the
  * supplied file name.

--- a/js/files.ts
+++ b/js/files.ts
@@ -52,8 +52,10 @@ export async function open(
 ): Promise<File> {
   const builder = flatbuffers.createBuilder();
   const filename_ = builder.createString(filename);
+  const mode_ = builder.createString(mode);
   msg.Open.startOpen(builder);
   msg.Open.addFilename(builder, filename_);
+  msg.Open.addMode(builder, mode_);
   const inner = msg.Open.endOpen(builder);
   const baseRes = await dispatch.sendAsync(builder, msg.Any.Open, inner);
   assert(baseRes != null);

--- a/js/files.ts
+++ b/js/files.ts
@@ -29,25 +29,31 @@ export const stdout = new File(1);
 /** An instance of `File` for stderr. */
 export const stderr = new File(2);
 
-// tslint:disable:max-line-length
 type OpenMode =
-  /** Read-only, default mode. Starts at beginning of file. */
+  /** Read-only. Default. Starts at beginning of file. */
   | "r"
   /** Read-write. Start at beginning of file. */
   | "r+"
-  /** Write-only. Opens and truncates existing file or creates new one for writing only. */
+  /** Write-only. Opens and truncates existing file or creates new one for
+   * writing only.
+   */
   | "w"
-  /** Read-write. Opens and truncates existing file or creates new one for writing and reading. */
+  /** Read-write. Opens and truncates existing file or creates new one for
+   * writing and reading.
+   */
   | "w+"
-  /** Write-only. Opens existing file or creates new one. Each write appends content to the end of file. */
+  /** Write-only. Opens existing file or creates new one. Each write appends
+   * content to the end of file.
+   */
   | "a"
   /** Read-write. Behaves like "a" and allows to read from file. */
   | "a+"
-  /** Write-only. Exclusive create - creates new file only if one doesn't exist already */
+  /** Write-only. Exclusive create - creates new file only if one doesn't exist
+   * already.
+   */
   | "x"
   /** Read-write. Behaves like `x` and allows to read from file. */
   | "x+";
-// tslint:enable:max-line-length
 
 /** A factory function for creating instances of `File` associated with the
  * supplied file name.

--- a/js/files.ts
+++ b/js/files.ts
@@ -73,7 +73,7 @@ export enum OpenMode {
  * supplied file name.
  */
 export function create(filename: string): Promise<File> {
-  return open(filename, OpenMode.ExclusiveCreate);
+  return open(filename, OpenMode.WriteRead);
 }
 
 /** Open a file and return an instance of the `File` object.

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -33,7 +33,7 @@ test(async function filesToAsyncIterator() {
 testPerm({ write: true }, async function createFile() {
   const tempDir = await deno.makeTempDir();
   const filename = tempDir + "/test.txt";
-  let f = await deno.open(filename, deno.OpenMode.Write);
+  let f = await deno.open(filename, "w");
   let fileInfo = deno.statSync(filename);
   assert(fileInfo.isFile());
   assert(fileInfo.len === 0);
@@ -54,7 +54,7 @@ testPerm({ write: true }, async function openModeWrite() {
   const filename = tempDir + "hello.txt";
   const data = encoder.encode("Hello world!\n");
 
-  let file = await deno.open(filename, deno.OpenMode.Write);
+  let file = await deno.open(filename, "w");
   // assert file was created
   let fileInfo = deno.statSync(filename);
   assert(fileInfo.isFile());
@@ -71,11 +71,11 @@ testPerm({ write: true }, async function openModeWrite() {
   } catch (e) {
     thrown = true;
   } finally {
-    assert(thrown, "OpenMode.Write shouldn't allow to read file");
+    assert(thrown, "'w' mode shouldn't allow to read file");
   }
   file.close();
   // assert that existing file is truncated on open
-  file = await deno.open(filename, deno.OpenMode.Write);
+  file = await deno.open(filename, "w");
   file.close();
   const fileSize = deno.statSync(filename).len;
   assertEqual(fileSize, 0);
@@ -88,7 +88,7 @@ testPerm({ write: true }, async function openModeWriteRead() {
   const filename = tempDir + "hello.txt";
   const data = encoder.encode("Hello world!\n");
 
-  let file = await deno.open(filename, deno.OpenMode.WriteRead);
+  let file = await deno.open(filename, "w+");
   // assert file was created
   let fileInfo = deno.statSync(filename);
   assert(fileInfo.isFile());

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 import * as deno from "deno";
-import { test, assert, assertEqual } from "./test_util.ts";
+import { test, testPerm, assert, assertEqual } from "./test_util.ts";
 
 test(function filesStdioFileDescriptors() {
   assertEqual(deno.stdin.rid, 0);
@@ -28,4 +28,23 @@ test(async function filesToAsyncIterator() {
   }
 
   assertEqual(totalSize, 12);
+});
+
+testPerm({write: true}, async function createFile() {
+  const tempDir = await deno.makeTempDir();
+  const filename = tempDir + "/test.txt";
+  // TODO: replace with OpenMode enum
+  let f = await deno.open(filename, 'w');
+  let fileInfo = deno.statSync(filename);
+  assert(fileInfo.isFile());
+  assert(fileInfo.len === 0);
+  const enc = new TextEncoder();
+  const data = enc.encode("Hello");
+  await f.write(data);
+  fileInfo = deno.statSync(filename);
+  assert(fileInfo.len === 5);
+  f.close();
+
+  // TODO: test different modes
+  await deno.removeAll(tempDir);
 });

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -30,11 +30,11 @@ test(async function filesToAsyncIterator() {
   assertEqual(totalSize, 12);
 });
 
-testPerm({write: true}, async function createFile() {
+testPerm({ write: true }, async function createFile() {
   const tempDir = await deno.makeTempDir();
   const filename = tempDir + "/test.txt";
   // TODO: replace with OpenMode enum
-  let f = await deno.open(filename, 'w');
+  let f = await deno.open(filename, "w");
   let fileInfo = deno.statSync(filename);
   assert(fileInfo.isFile());
   assert(fileInfo.len === 0);

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -34,7 +34,7 @@ testPerm({ write: true }, async function createFile() {
   const tempDir = await deno.makeTempDir();
   const filename = tempDir + "/test.txt";
   // TODO: replace with OpenMode enum
-  let f = await deno.open(filename, "w");
+  let f = await deno.open(filename, deno.OpenMode.Write);
   let fileInfo = deno.statSync(filename);
   assert(fileInfo.isFile());
   assert(fileInfo.len === 0);

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -349,6 +349,7 @@ table Truncate {
 table Open {
   filename: string;
   perm: uint;
+  mode: string;
 }
 
 table OpenRes {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -593,12 +593,39 @@ fn op_open(
 
   let mut open_options = tokio::fs::OpenOptions::new();
 
-  open_options
-    .create(mode == "w" || mode == "w+")
-    .create_new(mode == "x")
-    .read(true)
-    .write(mode == "w" || mode == "w+" || mode == "x")
-    .truncate(mode == "w+");
+  match mode {
+    "r" => {
+      open_options.read(true);
+    }
+    "r+" => {
+      open_options.read(true).write(true);
+    }
+    "w" => {
+      open_options.create(true).write(true).truncate(true);
+    }
+    "w+" => {
+      open_options
+        .read(true)
+        .create(true)
+        .write(true)
+        .truncate(true);
+    }
+    "a" => {
+      open_options.create(true).append(true);
+    }
+    "a+" => {
+      open_options.read(true).create(true).append(true);
+    }
+    "x" => {
+      open_options.create_new(true).write(true);
+    }
+    "x+" => {
+      open_options.create_new(true).read(true).write(true);
+    }
+    &_ => {
+      panic!("Unknown file open mode.");
+    }
+  }
 
   let op = open_options
     .open(filename)

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -591,12 +591,16 @@ fn op_open(
   //  let perm = inner.perm();
   let mode = inner.mode().unwrap();
 
-  let op = tokio::fs::OpenOptions::new()
+  let mut open_options = tokio::fs::OpenOptions::new();
+
+  open_options
     .create(mode == "w" || mode == "w+")
     .create_new(mode == "x")
     .read(true)
     .write(mode == "w" || mode == "w+" || mode == "x")
-    .truncate(mode == "w+")
+    .truncate(mode == "w+");
+
+  let op = open_options
     .open(filename)
     .map_err(DenoError::from)
     .and_then(move |fs_file| -> OpResult {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -588,9 +588,16 @@ fn op_open(
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_open().unwrap();
   let filename = PathBuf::from(inner.filename().unwrap());
-  // TODO let perm = inner.perm();
+  //  let perm = inner.perm();
+  let mode = inner.mode().unwrap();
 
-  let op = tokio::fs::File::open(filename)
+  let op = tokio::fs::OpenOptions::new()
+    .create(mode == "w" || mode == "w+")
+    .create_new(mode == "x")
+    .read(true)
+    .write(mode == "w" || mode == "w+" || mode == "x")
+    .truncate(mode == "w+")
+    .open(filename)
     .map_err(DenoError::from)
     .and_then(move |fs_file| -> OpResult {
       let resource = resources::add_fs_file(fs_file);


### PR DESCRIPTION
Trying to implement simple logger in deno I found that creating a file is still impossible.

I saw work done in #908, but I turns out we can simply use `tokio::fs::OpenOptions` to configure what mode we want to open file in.

This is very rough minimal implementation that still needs a lot of work.

TODO:
- [x] settle on `OpenMode`s and implement as `enum` in `files.ts`
- [x] factor out setup code of `tokio::fs::OpenOptions` in `ops.ts`
- [x] tests