### PR TITLE
Rename types according to Rust naming guidelines

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -48,8 +48,7 @@ type OpResult = DenoResult<Buf>;
 // TODO Ideally we wouldn't have to box the Op being returned.
 // The box is just to make it easier to get a prototype refactor working.
 type OpCreator =
-  fn(state: &IsolateState, base: &msg::Base, data: libdeno::deno_buf)
-    -> Box<Op>;
+  fn(state: &IsolateState, base: &msg::Base, data: libdeno::DenoBuf) -> Box<Op>;
 
 #[inline]
 fn empty_buf() -> Buf {
@@ -62,8 +61,8 @@ fn empty_buf() -> Buf {
 /// data corresponds to the second argument of libdeno.send().
 pub fn dispatch(
   isolate: &Isolate,
-  control: libdeno::deno_buf,
-  data: libdeno::deno_buf,
+  control: libdeno::DenoBuf,
+  data: libdeno::DenoBuf,
 ) -> (bool, Box<Op>) {
   let base = msg::get_root_as_base(&control);
   let is_sync = base.sync();
@@ -127,7 +126,7 @@ pub fn dispatch(
     op.or_else(move |err: DenoError| -> DenoResult<Buf> {
       debug!("op err {}", err);
       // No matter whether we got an Err or Ok, we want a serialized message to
-      // send back. So transform the DenoError into a deno_buf.
+      // send back. So transform the DenoError into a DenoBuf.
       let builder = &mut FlatBufferBuilder::new();
       let errmsg_offset = builder.create_string(&format!("{}", err));
       Ok(serialize_response(
@@ -170,7 +169,7 @@ pub fn dispatch(
 fn op_exit(
   _config: &IsolateState,
   base: &msg::Base,
-  _data: libdeno::deno_buf,
+  _data: libdeno::DenoBuf,
 ) -> Box<Op> {
   let inner = base.inner_as_exit().unwrap();
   std::process::exit(inner.code())
@@ -179,7 +178,7 @@ fn op_exit(
 fn op_start(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let mut builder = FlatBufferBuilder::new();
@@ -249,7 +248,7 @@ fn odd_future(err: DenoError) -> Box<Op> {
 fn op_code_fetch(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_code_fetch().unwrap();
@@ -292,7 +291,7 @@ fn op_code_fetch(
 fn op_code_cache(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_code_cache().unwrap();
@@ -311,7 +310,7 @@ fn op_code_cache(
 fn op_chdir(
   _state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_chdir().unwrap();
@@ -325,7 +324,7 @@ fn op_chdir(
 fn op_set_timeout(
   isolate: &Isolate,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_set_timeout().unwrap();
@@ -343,7 +342,7 @@ fn op_set_timeout(
 fn op_set_env(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_set_env().unwrap();
@@ -359,7 +358,7 @@ fn op_set_env(
 fn op_env(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let cmd_id = base.cmd_id();
@@ -391,7 +390,7 @@ fn op_env(
 fn op_fetch(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   let inner = base.inner_as_fetch().unwrap();
   let cmd_id = base.cmd_id();
@@ -480,7 +479,7 @@ macro_rules! blocking {
 fn op_make_temp_dir(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let base = Box::new(*base);
@@ -529,7 +528,7 @@ fn op_make_temp_dir(
 fn op_mkdir(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_mkdir().unwrap();
@@ -549,7 +548,7 @@ fn op_mkdir(
 fn op_chmod(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_chmod().unwrap();
@@ -582,7 +581,7 @@ fn op_chmod(
 fn op_open(
   _state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let cmd_id = base.cmd_id();
@@ -613,7 +612,7 @@ fn op_open(
 fn op_close(
   _state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_close().unwrap();
@@ -630,7 +629,7 @@ fn op_close(
 fn op_shutdown(
   _state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_shutdown().unwrap();
@@ -656,7 +655,7 @@ fn op_shutdown(
 fn op_read(
   _state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_read().unwrap();
@@ -694,7 +693,7 @@ fn op_read(
 fn op_write(
   _state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_write().unwrap();
@@ -731,7 +730,7 @@ fn op_write(
 fn op_remove(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_remove().unwrap();
@@ -761,7 +760,7 @@ fn op_remove(
 fn op_read_file(
   _config: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_read_file().unwrap();
@@ -795,7 +794,7 @@ fn op_read_file(
 fn op_copy_file(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_copy_file().unwrap();
@@ -847,7 +846,7 @@ fn get_mode(_perm: &fs::Permissions) -> u32 {
 fn op_cwd(
   _state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let cmd_id = base.cmd_id();
@@ -873,7 +872,7 @@ fn op_cwd(
 fn op_stat(
   _config: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_stat().unwrap();
@@ -920,7 +919,7 @@ fn op_stat(
 fn op_read_dir(
   _state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_read_dir().unwrap();
@@ -976,7 +975,7 @@ fn op_read_dir(
 fn op_write_file(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   let inner = base.inner_as_write_file().unwrap();
   let filename = String::from(inner.filename().unwrap());
@@ -996,7 +995,7 @@ fn op_write_file(
 fn op_rename(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_rename().unwrap();
@@ -1016,7 +1015,7 @@ fn op_rename(
 fn op_symlink(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_symlink().unwrap();
@@ -1045,7 +1044,7 @@ fn op_symlink(
 fn op_read_link(
   _state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_readlink().unwrap();
@@ -1078,7 +1077,7 @@ fn op_read_link(
 fn op_repl_start(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_repl_start().unwrap();
@@ -1109,7 +1108,7 @@ fn op_repl_start(
 fn op_repl_readline(
   _state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_repl_readline().unwrap();
@@ -1147,7 +1146,7 @@ fn op_repl_readline(
 fn op_truncate(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
 
@@ -1170,7 +1169,7 @@ fn op_truncate(
 fn op_listen(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   if let Err(e) = state.check_net("listen") {
@@ -1236,7 +1235,7 @@ fn new_conn(cmd_id: u32, tcp_stream: TcpStream) -> OpResult {
 fn op_accept(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   if let Err(e) = state.check_net("accept") {
@@ -1262,7 +1261,7 @@ fn op_accept(
 fn op_dial(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   if let Err(e) = state.check_net("dial") {
@@ -1286,7 +1285,7 @@ fn op_dial(
 fn op_metrics(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let cmd_id = base.cmd_id();
@@ -1310,7 +1309,7 @@ fn op_metrics(
 fn op_resources(
   _state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let cmd_id = base.cmd_id();
@@ -1362,7 +1361,7 @@ fn subprocess_stdio_map(v: msg::ProcessStdio) -> std::process::Stdio {
 fn op_run(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert!(base.sync());
   let cmd_id = base.cmd_id();
@@ -1430,7 +1429,7 @@ fn op_run(
 fn op_run_status(
   state: &IsolateState,
   base: &msg::Base,
-  data: libdeno::deno_buf,
+  data: libdeno::DenoBuf,
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let cmd_id = base.cmd_id();

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,9 +1,9 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
-use libdeno::deno_buf;
+use libdeno::DenoBuf;
 
-pub fn deno_snapshot() -> deno_buf {
+pub fn deno_snapshot() -> DenoBuf {
   let data =
     include_bytes!(concat!(env!("GN_OUT_DIR"), "/gen/snapshot_deno.bin"));
 
-  unsafe { deno_buf::from_raw_parts(data.as_ptr(), data.len()) }
+  unsafe { DenoBuf::from_raw_parts(data.as_ptr(), data.len()) }
 }


### PR DESCRIPTION
According to https://rust-lang-nursery.github.io/api-guidelines/naming.html, types should be named as `UpperCamelCase` in Rust. Most of the code is compliant with the standard, except 3 of them.