### PR TITLE
Add ASCII support to TextDecoder

### DIFF
--- a/js/text_encoding_test.ts
+++ b/js/text_encoding_test.ts
@@ -48,6 +48,23 @@ test(function textDecoder2() {
   assertEqual(decoder.decode(fixture), "𝓽𝓮𝔁𝓽");
 });
 
+test(function textDecoderASCII() {
+  const fixture = new Uint8Array([0x89, 0x95, 0x9f, 0xbf]);
+  const decoder = new TextDecoder("ascii");
+  assertEqual(decoder.decode(fixture), "‰•Ÿ¿");
+});
+
+test(function textDecoderErrorEncoding() {
+  let didThrow = false;
+  try {
+    const decoder = new TextDecoder("foo");
+  } catch (e) {
+    didThrow = true;
+    assertEqual(e.message, "The encoding label provided ('foo') is invalid.");
+  }
+  assert(didThrow);
+});
+
 test(function textEncoder() {
   const fixture = "������";
   const encoder = new TextEncoder();


### PR DESCRIPTION
Fixes #1288 

This adds support for single byte decoders and the code point encodings for `windows-1252` which is a superset of `ascii` and `us-ascii` and `latin1` plus a few others.  It also makes it easier to add extra decoders in the future if required.