### PR TITLE
Apply DenoError TooLarge

### DIFF
--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -6,6 +6,7 @@
 import { Reader, Writer, ReadResult } from "./io";
 import { assert } from "./util";
 import { TextDecoder } from "./text_encoding";
+import { DenoError, ErrorKind } from "./errors";
 
 // MIN_READ is the minimum ArrayBuffer size passed to a read call by
 // buffer.ReadFrom. As long as the Buffer has at least MIN_READ bytes beyond
@@ -170,7 +171,10 @@ export class Buffer implements Reader, Writer {
       // don't spend all our time copying.
       copyBytes(this.buf, this.buf.subarray(this.off));
     } else if (c > MAX_SIZE - c - n) {
-      throw Error("ErrTooLarge"); // TODO DenoError(TooLarge)
+      throw new DenoError(
+        ErrorKind.TooLarge,
+        "The buffer can't grow because it becomes too large"
+      );
     } else {
       // Not enough space anywhere, we need to allocate.
       const buf = new Uint8Array(2 * c + n);

--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -173,7 +173,7 @@ export class Buffer implements Reader, Writer {
     } else if (c > MAX_SIZE - c - n) {
       throw new DenoError(
         ErrorKind.TooLarge,
-        "The buffer can't grow because it becomes too large"
+        "The buffer cannot be grown beyond the maximum size."
       );
     } else {
       // Not enough space anywhere, we need to allocate.

--- a/js/buffer_test.ts
+++ b/js/buffer_test.ts
@@ -1,9 +1,9 @@
 import { Buffer, readAll } from "deno";
+import * as deno from "deno";
 // This code has been ported almost directly from Go's src/bytes/buffer_test.go
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.
 // https://github.com/golang/go/blob/master/LICENSE
 import { assert, assertEqual, test } from "./test_util.ts";
-import { stringifyArgs } from "./console.ts";
 // N controls how many iterations of certain checks are performed.
 const N = 100;
 let testBytes: Uint8Array | null;
@@ -63,10 +63,6 @@ async function empty(buf: Buffer, s: string, fub: Uint8Array): Promise<void> {
     check(buf, s);
   }
   check(buf, "");
-}
-
-function stringify(...args: any[]): string {
-  return stringifyArgs(args);
 }
 
 test(function bufferNewBuffer() {
@@ -141,14 +137,16 @@ test(async function bufferTooLargeByteWrites() {
   const xBytes = repeat("x", 0);
   const buf = new Buffer(xBytes.buffer as ArrayBuffer);
   const { nread, eof } = await buf.read(tmp);
+
+  let err;
   try {
     buf.grow(growLen);
   } catch (e) {
-    assertEqual(
-      stringify(e).split("\n")[0],
-      "TooLarge: The buffer can't grow because it becomes too large"
-    );
+    err = e;
   }
+
+  assertEqual(err.kind, deno.ErrorKind.TooLarge);
+  assertEqual(err.name, "TooLarge");
 });
 
 test(async function bufferLargeByteReads() {

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -105,6 +105,7 @@ enum ErrorKind: byte {
   HttpCanceled,
   HttpParse,
   HttpOther,
+  TooLarge,
 }
 
 table Cwd {}


### PR DESCRIPTION
I've modified error type in `js/buffer.ts` to DenoError  from Error, so added enum type to `msg.fbs`.