### PR TITLE
v0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 # crates.
 [package]
 name = "deno"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 atty = "=0.2.11"

--- a/src/version.rs
+++ b/src/version.rs
@@ -3,7 +3,7 @@ use libdeno;
 use std::ffi::CStr;
 
 // TODO Extract this version string from Cargo.toml.
-pub const DENO: &str = "0.2.1";
+pub const DENO: &str = "0.2.2";
 
 pub fn v8() -> &'static str {
   let version = unsafe { libdeno::deno_v8_version() };


### PR DESCRIPTION
- Don't crash when .mime file not exist in cache (#1291)
- Process source maps in Rust instead of JS (#1280)
- Use alternate TextEncoder/TextDecoder implementation (#1281)
- Upgrade flatbuffers to 80d148
- Fix memory leaks (#1265, #1275)
