### PR TITLE
Implement non-blocking ops

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -13,9 +13,9 @@ use std::os::unix::fs::DirBuilderExt;
 #[cfg(any(unix))]
 use std::os::unix::fs::PermissionsExt;
 
-pub fn write_file(
+pub fn write_file<T: AsRef<[u8]>>(
   filename: &Path,
-  data: &[u8],
+  data: T,
   perm: u32,
 ) -> std::io::Result<()> {
   let is_append = perm & (1 << 31) != 0;
@@ -28,7 +28,7 @@ pub fn write_file(
     .open(filename)?;
 
   set_permissions(&mut file, perm)?;
-  file.write_all(data)
+  file.write_all(data.as_ref())
 }
 
 #[cfg(any(unix))]

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 use tokio;
+use tokio_threadpool::ThreadPool;
 use tokio_util;
 
 // Buf represents a byte array returned from a "Op".
@@ -58,6 +59,7 @@ pub struct Isolate {
 // inside IsolateState.
 #[cfg_attr(feature = "cargo-clippy", allow(stutter))]
 pub struct IsolateState {
+  pub thread_pool: ThreadPool,
   pub dir: deno_dir::DenoDir,
   pub argv: Vec<String>,
   pub permissions: DenoPermissions,
@@ -69,6 +71,7 @@ impl IsolateState {
   pub fn new(flags: flags::DenoFlags, argv_rest: Vec<String>) -> Self {
     let custom_root = env::var("DENO_DIR").map(|s| s.into()).ok();
     Self {
+      thread_pool: ThreadPool::new(),
       dir: deno_dir::DenoDir::new(flags.reload, custom_root).unwrap(),
       argv: argv_rest,
       permissions: DenoPermissions::new(&flags),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -479,8 +479,9 @@ where
   }
 }
 
-/// `futures::future::poll_fn` only support `F: FnMut()->Poll<T, T>`
-/// However, we require that `F: FnOnce()->Poll<T, T>`
+/// `futures::future::poll_fn` only support `F: FnMut()->Poll<T, E>`
+/// However, we require that `F: FnOnce()->Poll<T, E>`.
+/// Therefore, we created our version of `poll_fn`.
 fn poll_fn<T, E, F>(f: F) -> PollFn<F>
 where
   F: FnOnce() -> Poll<T, E>,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -16,8 +16,7 @@ use version;
 
 use flatbuffers::FlatBufferBuilder;
 use futures;
-use futures::future::poll_fn;
-use futures::Poll;
+use futures::lazy;
 use hyper;
 use hyper::rt::Future;
 use remove_dir_all::remove_dir_all;
@@ -41,7 +40,7 @@ use tokio;
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio_process::CommandExt;
-use tokio_threadpool;
+use tokio_threadpool::ThreadPool;
 
 type OpResult = DenoResult<Buf>;
 
@@ -236,11 +235,13 @@ fn serialize_response(
   data.into()
 }
 
+#[inline]
 fn ok_future(buf: Buf) -> Box<Op> {
   Box::new(futures::future::ok(buf))
 }
 
 // Shout out to Earl Sweatshirt.
+#[inline]
 fn odd_future(err: DenoError) -> Box<Op> {
   Box::new(futures::future::err(err))
 }
@@ -445,36 +446,16 @@ fn op_fetch(
   Box::new(future)
 }
 
-// This is just type conversion. Implement From trait?
-// See https://github.com/tokio-rs/tokio/blob/ffd73a64e7ec497622b7f939e38017afe7124dc4/tokio-fs/src/lib.rs#L76-L85
-fn convert_blocking<F>(f: F) -> Poll<Buf, DenoError>
+fn blocking<F>(is_sync: bool, thread_pool: &ThreadPool, f: F) -> Box<Op>
 where
-  F: FnOnce() -> DenoResult<Buf>,
+  F: 'static + Send + FnOnce() -> DenoResult<Buf>,
 {
-  use futures::Async::*;
-  match tokio_threadpool::blocking(f) {
-    Ok(Ready(Ok(v))) => Ok(v.into()),
-    Ok(Ready(Err(err))) => Err(err),
-    Ok(NotReady) => Ok(NotReady),
-    Err(_err) => panic!("blocking error"),
+  if is_sync {
+    Box::new(futures::future::result(f()))
+  } else {
+    let h = thread_pool.spawn_handle(lazy(move || f()));
+    Box::new(h)
   }
-}
-
-// TODO Do not use macro for the blocking function.. We should instead be able
-// to do this with a normal function, but there seems to some type system
-// issues. The type of this function should be something like this:
-//   fn blocking<F>(is_sync: bool, f: F) -> Box<Op>
-//   where F: FnOnce() -> DenoResult<Buf>
-macro_rules! blocking {
-  ($is_sync:expr, $fn:expr) => {
-    if $is_sync {
-      // If synchronous, execute the function immediately on the main thread.
-      Box::new(futures::future::result($fn()))
-    } else {
-      // Otherwise dispatch to thread pool.
-      Box::new(poll_fn(move || convert_blocking($fn)))
-    }
-  };
 }
 
 fn op_make_temp_dir(
@@ -496,7 +477,7 @@ fn op_make_temp_dir(
   let prefix = inner.prefix().map(String::from);
   let suffix = inner.suffix().map(String::from);
 
-  blocking!(base.sync(), || -> OpResult {
+  blocking(base.sync(), &state.thread_pool, move || -> OpResult {
     // TODO(piscisaureus): use byte vector for paths, not a string.
     // See https://github.com/denoland/deno/issues/627.
     // We can't assume that paths are always valid utf8 strings.
@@ -539,7 +520,7 @@ fn op_mkdir(
   if let Err(e) = state.check_write(&path) {
     return odd_future(e);
   }
-  blocking!(base.sync(), || {
+  blocking(base.sync(), &state.thread_pool, move || {
     debug!("op_mkdir {}", path);
     deno_fs::mkdir(Path::new(&path), mode)?;
     Ok(empty_buf())
@@ -560,7 +541,7 @@ fn op_chmod(
     return odd_future(e);
   }
 
-  blocking!(base.sync(), || {
+  blocking(base.sync(), &state.thread_pool, move || {
     debug!("op_chmod {}", &path);
     let path = PathBuf::from(&path);
     // Still check file/dir exists on windows
@@ -628,7 +609,7 @@ fn op_close(
 }
 
 fn op_shutdown(
-  _state: &IsolateState,
+  state: &IsolateState,
   base: &msg::Base,
   data: libdeno::deno_buf,
 ) -> Box<Op> {
@@ -644,7 +625,7 @@ fn op_shutdown(
         1 => Shutdown::Write,
         _ => unimplemented!(),
       };
-      blocking!(base.sync(), || {
+      blocking(base.sync(), &state.thread_pool, move || {
         // Use UFCS for disambiguation
         Resource::shutdown(&mut resource, shutdown_mode)?;
         Ok(empty_buf())
@@ -743,7 +724,7 @@ fn op_remove(
     return odd_future(e);
   }
 
-  blocking!(base.sync(), || {
+  blocking(base.sync(), &state.thread_pool, move || {
     debug!("op_remove {}", path.display());
     let metadata = fs::metadata(&path)?;
     if metadata.is_file() {
@@ -759,7 +740,7 @@ fn op_remove(
 
 // Prototype https://github.com/denoland/deno/blob/golang/os.go#L171-L184
 fn op_read_file(
-  _config: &IsolateState,
+  state: &IsolateState,
   base: &msg::Base,
   data: libdeno::deno_buf,
 ) -> Box<Op> {
@@ -768,7 +749,7 @@ fn op_read_file(
   let cmd_id = base.cmd_id();
   let filename = PathBuf::from(inner.filename().unwrap());
   debug!("op_read_file {}", filename.display());
-  blocking!(base.sync(), || {
+  blocking(base.sync(), &state.thread_pool, move || {
     let vec = fs::read(&filename)?;
     // Build the response message. memcpy data into inner.
     // TODO(ry) zero-copy.
@@ -808,7 +789,7 @@ fn op_copy_file(
   }
 
   debug!("op_copy_file {} {}", from.display(), to.display());
-  blocking!(base.sync(), || {
+  blocking(base.sync(), &state.thread_pool, move || {
     // On *nix, Rust deem non-existent path as invalid input
     // See https://github.com/rust-lang/rust/issues/54800
     // Once the issue is reolved, we should remove this workaround.
@@ -871,7 +852,7 @@ fn op_cwd(
 }
 
 fn op_stat(
-  _config: &IsolateState,
+  state: &IsolateState,
   base: &msg::Base,
   data: libdeno::deno_buf,
 ) -> Box<Op> {
@@ -881,7 +862,7 @@ fn op_stat(
   let filename = PathBuf::from(inner.filename().unwrap());
   let lstat = inner.lstat();
 
-  blocking!(base.sync(), || {
+  blocking(base.sync(), &state.thread_pool, move || {
     let builder = &mut FlatBufferBuilder::new();
     debug!("op_stat {} {}", filename.display(), lstat);
     let metadata = if lstat {
@@ -918,7 +899,7 @@ fn op_stat(
 }
 
 fn op_read_dir(
-  _state: &IsolateState,
+  state: &IsolateState,
   base: &msg::Base,
   data: libdeno::deno_buf,
 ) -> Box<Op> {
@@ -927,7 +908,7 @@ fn op_read_dir(
   let cmd_id = base.cmd_id();
   let path = String::from(inner.path().unwrap());
 
-  blocking!(base.sync(), || -> OpResult {
+  blocking(base.sync(), &state.thread_pool, move || -> OpResult {
     debug!("op_read_dir {}", path);
     let builder = &mut FlatBufferBuilder::new();
     let entries: Vec<_> = fs::read_dir(Path::new(&path))?
@@ -986,9 +967,9 @@ fn op_write_file(
     return odd_future(e);
   }
 
-  blocking!(base.sync(), || -> OpResult {
+  blocking(base.sync(), &state.thread_pool, move || -> OpResult {
     debug!("op_write_file {} {}", filename, data.len());
-    deno_fs::write_file(Path::new(&filename), &data, perm)?;
+    deno_fs::write_file(Path::new(&filename), data, perm)?;
     Ok(empty_buf())
   })
 }
@@ -1006,7 +987,7 @@ fn op_rename(
   if let Err(e) = state.check_write(&newpath_) {
     return odd_future(e);
   }
-  blocking!(base.sync(), || -> OpResult {
+  blocking(base.sync(), &state.thread_pool, move || -> OpResult {
     debug!("op_rename {} {}", oldpath.display(), newpath.display());
     fs::rename(&oldpath, &newpath)?;
     Ok(empty_buf())
@@ -1034,7 +1015,7 @@ fn op_symlink(
       "Not implemented".to_string(),
     ));
   }
-  blocking!(base.sync(), || -> OpResult {
+  blocking(base.sync(), &state.thread_pool, move || -> OpResult {
     debug!("op_symlink {} {}", oldname.display(), newname.display());
     #[cfg(any(unix))]
     std::os::unix::fs::symlink(&oldname, &newname)?;
@@ -1043,7 +1024,7 @@ fn op_symlink(
 }
 
 fn op_read_link(
-  _state: &IsolateState,
+  state: &IsolateState,
   base: &msg::Base,
   data: libdeno::deno_buf,
 ) -> Box<Op> {
@@ -1052,7 +1033,7 @@ fn op_read_link(
   let cmd_id = base.cmd_id();
   let name = PathBuf::from(inner.name().unwrap());
 
-  blocking!(base.sync(), || -> OpResult {
+  blocking(base.sync(), &state.thread_pool, move || -> OpResult {
     debug!("op_read_link {}", name.display());
     let path = fs::read_link(&name)?;
     let builder = &mut FlatBufferBuilder::new();
@@ -1107,7 +1088,7 @@ fn op_repl_start(
 }
 
 fn op_repl_readline(
-  _state: &IsolateState,
+  state: &IsolateState,
   base: &msg::Base,
   data: libdeno::deno_buf,
 ) -> Box<Op> {
@@ -1121,7 +1102,7 @@ fn op_repl_readline(
   // Ignore this clippy warning until this issue is addressed:
   // https://github.com/rust-lang-nursery/rust-clippy/issues/1684
   #[cfg_attr(feature = "cargo-clippy", allow(redundant_closure_call))]
-  blocking!(base.sync(), || -> OpResult {
+  blocking(base.sync(), &state.thread_pool, move || -> OpResult {
     let line = resources::readline(rid, &prompt)?;
 
     let builder = &mut FlatBufferBuilder::new();
@@ -1159,7 +1140,7 @@ fn op_truncate(
     return odd_future(e);
   }
 
-  blocking!(base.sync(), || {
+  blocking(base.sync(), &state.thread_pool, move || {
     debug!("op_truncate {} {}", filename, len);
     let f = fs::OpenOptions::new().write(true).open(&filename)?;
     f.set_len(u64::from(len))?;


### PR DESCRIPTION
Spawn the operation to thread pool when `is_sync` is false.

At present, all the operations are sync, even the `is_sync`'s value is false. The `blocking!` macro does not dispatch the task to background thread. Please note that `tokio_threadpool::blocking` does not spawn, it only marks the operation is `blocking`. We have to call `Threadpool::spawn_handle` to do this.

### Unresolved questions

* Is the function name `blocking` appropriate?

