### PR TITLE
Added compodoc for better documentation

### DIFF
--- a/tools/docs.py
+++ b/tools/docs.py
@@ -5,7 +5,8 @@ import tempfile
 from util import run, root_path
 
 target_path = os.path.join(root_path, "target/")
-
+tsconfig_path = os.path.join(root_path, "tsconfig.docs.json")
+print(tsconfig_path)
 os.chdir(root_path)
 
 # Builds into target/doc
@@ -15,12 +16,9 @@ run(["cargo", "doc", "--no-deps", "-vv"])
 # We want to run typedoc on that declaration file only.
 os.chdir(os.path.join(target_path, "debug/gen/lib/"))
 
-# You must have typedoc installed seprately.
-# TODO Replace typedoc with something else ASAP. It's very awful.
+# You must have compodoc installed seprately.
+# TODO Replace compodoc with something else ASAP. It's very awful.
 run([
-    "typedoc", "lib.deno_runtime.d.ts", "--out",
-    os.path.join(target_path, "typedoc"), "--entryPoint", "\"deno\"",
-    "--ignoreCompilerErrors", "--includeDeclarations", "--excludeExternals",
-    "--excludePrivate", "--excludeProtected", "--mode", "file", "--name",
-    "deno", "--theme", "minimal", "--readme", "none"
-])
+    "compodoc", "-p", tsconfig_path, "--output",
+    os.path.join(target_path, "compodoc")
+], None, root_path)

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig",
+  "include": [
+    "js/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*_test.ts"
+  ]
+}


### PR DESCRIPTION
Hi @ry,

Thanks for creating beautiful language. I am big fan of you. :)

This PR is to add better documentation for TypeScript file. TypeDoc is does not look nice. I used compodoc from my Angular.io projects. It looks nice and clean. I tried to find some other tools to generate doc very specific to typescript. I didn't found. Please check the PR and check the output. If  it look nice i can customise more to get better output. Please refer to below given details.

Running App:
https://denolang-docs.herokuapp.com/

How to run in local:
Pre-Requisite: nodejs npm, compodoc, lite-server
```bash
npm install -g compodoc lite-server
```
Run:
```bash
compodoc -p tsconfig.docs.json --theme stripe
```
Output:
```bash 
cd documentation &&  lite-server
```
Using docs.py:
```bash
python2 tools/docs.py
cd target/compodoc &&  lite-server
```
