### PR TITLE
Remove custom panic handler.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,14 +77,6 @@ fn print_err_and_exit(err: js_errors::JSError) {
 }
 
 fn main() {
-  // Rust does not die on panic by default. And -Cpanic=abort is broken.
-  // https://github.com/rust-lang/cargo/issues/2738
-  // Therefore this hack.
-  std::panic::set_hook(Box::new(|panic_info| {
-    eprintln!("{}", panic_info.to_string());
-    std::process::abort();
-  }));
-
   log::set_logger(&LOGGER).unwrap();
   let args = env::args().collect();
   let (flags, rest_argv, usage_string) =


### PR DESCRIPTION
This was introduced because Tokio would swallow panics. This is still
the case, but this panic handler causes more problems than it solves.
It requires people to know how to use debuggers to inspect stacktraces.

TODO:
- Fix Tokio to not swallow errors.
- Be very careful in the intrim that we do not introduce broken tests
  due to this unfortunate "feature" of tokio.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->

Fixes #1075