### PR TITLE
Nit on readDir entry mode

### DIFF
--- a/js/read_dir_test.ts
+++ b/js/read_dir_test.ts
@@ -14,6 +14,7 @@ function assertSameContent(files: FileInfo[]) {
 
     if (file.name === "002_hello.ts") {
       assertEqual(file.path, `tests/${file.name}`);
+      assertEqual(file.mode!, deno.statSync(`tests/${file.name}`).mode!);
       counter++;
     }
   }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -945,6 +945,8 @@ fn op_read_dir(
             created: to_seconds!(metadata.created()),
             name: Some(name),
             path: Some(path),
+            mode: get_mode(&metadata.permissions()),
+            has_mode: cfg!(target_family = "unix"),
             ..Default::default()
           },
         )


### PR DESCRIPTION
Closes #1317 
+ Make sure `deno.readDir` entries contains mode (I gave up with adding path/name for `deno.stat`)