### PR TITLE
Nit on console iterable prototypes

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -63,9 +63,12 @@ function createIterableString(
   ctx.add(value);
 
   const entries: string[] = [];
-  for (const el of value) {
-    entries.push(config.entryHandler(el, ctx, level + 1, maxLevel));
-  }
+  // In cases e.g. Uint8Array.prototype
+  try {
+    for (const el of value) {
+      entries.push(config.entryHandler(el, ctx, level + 1, maxLevel));
+    }
+  } catch (e) {}
   ctx.delete(value);
   const iPrefix = `${config.displayName ? config.displayName + " " : ""}`;
   const iContent = entries.length === 0 ? "" : ` ${entries.join(", ")} `;

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -103,6 +103,7 @@ test(function consoleTestStringifyCircular() {
     "[AsyncGeneratorFunction: agf]"
   );
   assertEqual(stringify(new Uint8Array([1, 2, 3])), "Uint8Array [ 1, 2, 3 ]");
+  assertEqual(stringify(Uint8Array.prototype), "TypedArray []");
   assertEqual(
     stringify({ a: { b: { c: { d: new Set([1]) } } } }),
     "{ a: { b: { c: { d: [Set] } } } }"


### PR DESCRIPTION
+ Avoid `Uint8Array.prototype` throwing type error in `console.log`