### PR TITLE
Rename source url to script name

### DIFF
--- a/src/js_errors.rs
+++ b/src/js_errors.rs
@@ -31,8 +31,8 @@ type CachedMaps = HashMap<String, Option<SourceMap>>;
 
 #[derive(Debug, PartialEq)]
 pub struct StackFrame {
-  pub line: u32,          // zero indexed
-  pub column: u32,        // zero indexed
+  pub line: u32,   // zero indexed
+  pub column: u32, // zero indexed
   pub script_name: String,
   pub function_name: String,
   pub is_eval: bool,
@@ -151,7 +151,8 @@ impl StackFrame {
     mappings_map: &mut CachedMaps,
     getter: &SourceMapGetter,
   ) -> StackFrame {
-    let maybe_sm = get_mappings(self.script_name.as_ref(), mappings_map, getter);
+    let maybe_sm =
+      get_mappings(self.script_name.as_ref(), mappings_map, getter);
     let frame_pos = (self.script_name.to_owned(), self.line, self.column);
     let (script_name, line, column) = match maybe_sm {
       None => frame_pos,

--- a/src/js_errors.rs
+++ b/src/js_errors.rs
@@ -33,7 +33,7 @@ type CachedMaps = HashMap<String, Option<SourceMap>>;
 pub struct StackFrame {
   pub line: u32,          // zero indexed
   pub column: u32,        // zero indexed
-  pub source_url: String, // TODO rename to 'script_name'
+  pub script_name: String,
   pub function_name: String,
   pub is_eval: bool,
   pub is_constructor: bool,
@@ -53,12 +53,12 @@ impl ToString for StackFrame {
     if self.function_name.len() > 0 {
       format!(
         "    at {} ({}:{}:{})",
-        self.function_name, self.source_url, line, column
+        self.function_name, self.script_name, line, column
       )
     } else if self.is_eval {
-      format!("    at eval ({}:{}:{})", self.source_url, line, column)
+      format!("    at eval ({}:{}:{})", self.script_name, line, column)
     } else {
-      format!("    at {}:{}:{}", self.source_url, line, column)
+      format!("    at {}:{}:{}", self.script_name, line, column)
     }
   }
 }
@@ -138,7 +138,7 @@ impl StackFrame {
     Some(StackFrame {
       line: line - 1,
       column: column - 1,
-      source_url: script_name,
+      script_name: script_name,
       function_name,
       is_eval,
       is_constructor,
@@ -151,9 +151,9 @@ impl StackFrame {
     mappings_map: &mut CachedMaps,
     getter: &SourceMapGetter,
   ) -> StackFrame {
-    let maybe_sm = get_mappings(self.source_url.as_ref(), mappings_map, getter);
-    let frame_pos = (self.source_url.to_owned(), self.line, self.column);
-    let (source_url, line, column) = match maybe_sm {
+    let maybe_sm = get_mappings(self.script_name.as_ref(), mappings_map, getter);
+    let frame_pos = (self.script_name.to_owned(), self.line, self.column);
+    let (script_name, line, column) = match maybe_sm {
       None => frame_pos,
       Some(sm) => match sm.mappings.original_location_for(
         self.line,
@@ -176,7 +176,7 @@ impl StackFrame {
     };
 
     StackFrame {
-      source_url,
+      script_name,
       function_name: self.function_name.clone(),
       line,
       column,
@@ -272,16 +272,16 @@ impl JSError {
 }
 
 fn parse_map_string(
-  source_url: &str,
+  script_name: &str,
   getter: &SourceMapGetter,
 ) -> Option<SourceMap> {
-  match source_url {
+  match script_name {
     "gen/bundle/main.js" => {
       let s =
         include_str!(concat!(env!("GN_OUT_DIR"), "/gen/bundle/main.js.map"));
       SourceMap::from_json(s)
     }
-    _ => match getter.get_source_map(source_url) {
+    _ => match getter.get_source_map(script_name) {
       None => None,
       Some(raw_source_map) => SourceMap::from_json(&raw_source_map),
     },
@@ -289,13 +289,13 @@ fn parse_map_string(
 }
 
 fn get_mappings<'a>(
-  source_url: &str,
+  script_name: &str,
   mappings_map: &'a mut CachedMaps,
   getter: &SourceMapGetter,
 ) -> &'a Option<SourceMap> {
   mappings_map
-    .entry(source_url.to_string())
-    .or_insert_with(|| parse_map_string(source_url, getter))
+    .entry(script_name.to_string())
+    .or_insert_with(|| parse_map_string(script_name, getter))
 }
 
 #[cfg(test)]
@@ -309,7 +309,7 @@ mod tests {
         StackFrame {
           line: 4,
           column: 16,
-          source_url: "foo_bar.ts".to_string(),
+          script_name: "foo_bar.ts".to_string(),
           function_name: "foo".to_string(),
           is_eval: false,
           is_constructor: false,
@@ -318,7 +318,7 @@ mod tests {
         StackFrame {
           line: 5,
           column: 20,
-          source_url: "bar_baz.ts".to_string(),
+          script_name: "bar_baz.ts".to_string(),
           function_name: "qat".to_string(),
           is_eval: false,
           is_constructor: false,
@@ -327,7 +327,7 @@ mod tests {
         StackFrame {
           line: 1,
           column: 1,
-          source_url: "deno_main.js".to_string(),
+          script_name: "deno_main.js".to_string(),
           function_name: "".to_string(),
           is_eval: false,
           is_constructor: false,
@@ -369,7 +369,7 @@ mod tests {
       Some(StackFrame {
         line: 1,
         column: 10,
-        source_url: "/Users/rld/src/deno/tests/error_001.ts".to_string(),
+        script_name: "/Users/rld/src/deno/tests/error_001.ts".to_string(),
         function_name: "foo".to_string(),
         is_eval: true,
         is_constructor: false,
@@ -392,7 +392,7 @@ mod tests {
     let f = r.unwrap();
     assert_eq!(f.line, 1);
     assert_eq!(f.column, 10);
-    assert_eq!(f.source_url, "/Users/rld/src/deno/tests/error_001.ts");
+    assert_eq!(f.script_name, "/Users/rld/src/deno/tests/error_001.ts");
   }
 
   #[test]
@@ -429,7 +429,7 @@ mod tests {
       StackFrame {
         line: 1,
         column: 10,
-        source_url: "/Users/rld/src/deno/tests/error_001.ts".to_string(),
+        script_name: "/Users/rld/src/deno/tests/error_001.ts".to_string(),
         function_name: "foo".to_string(),
         is_eval: true,
         is_constructor: false,
@@ -462,7 +462,7 @@ mod tests {
         StackFrame {
           line: 5,
           column: 12,
-          source_url: "foo_bar.ts".to_string(),
+          script_name: "foo_bar.ts".to_string(),
           function_name: "foo".to_string(),
           is_eval: false,
           is_constructor: false,
@@ -471,7 +471,7 @@ mod tests {
         StackFrame {
           line: 4,
           column: 14,
-          source_url: "bar_baz.ts".to_string(),
+          script_name: "bar_baz.ts".to_string(),
           function_name: "qat".to_string(),
           is_eval: false,
           is_constructor: false,
@@ -480,7 +480,7 @@ mod tests {
         StackFrame {
           line: 1,
           column: 1,
-          source_url: "deno_main.js".to_string(),
+          script_name: "deno_main.js".to_string(),
           function_name: "".to_string(),
           is_eval: false,
           is_constructor: false,
@@ -499,7 +499,7 @@ mod tests {
       frames: vec![StackFrame {
         line: 11,
         column: 12,
-        source_url: "gen/bundle/main.js".to_string(),
+        script_name: "gen/bundle/main.js".to_string(),
         function_name: "setLogDebug".to_string(),
         is_eval: false,
         is_constructor: false,
@@ -512,7 +512,7 @@ mod tests {
     assert_eq!(actual.frames.len(), 1);
     assert_eq!(actual.frames[0].line, 15);
     assert_eq!(actual.frames[0].column, 16);
-    assert_eq!(actual.frames[0].source_url, "deno/js/util.ts");
+    assert_eq!(actual.frames[0].script_name, "deno/js/util.ts");
   }
 
   #[test]


### PR DESCRIPTION
I renamed follow to `// TODO rename to 'script_name'`.

- [x] ./tools/test.py
- [x] ./tools/format.py
- [x] ./tools/lint.py