### PR TITLE
Move registry to main repo

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -1,8 +1,6 @@
 # Deno Module Registry
 
-`https://deno.land/x/` is a service that provides URL redirection.
-The intention is to provide a short URLs for use in code.
+`https://deno.land/x/` is a service that provides URL redirection. The intention
+is to provide a short URLs for use in code.
 
 Example: `https://deno.land/x/net@d9ab8eb/http.ts`
-
-

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,0 +1,8 @@
+# Deno Module Registry
+
+`https://deno.land/x/` is a service that provides URL redirection.
+The intention is to provide a short URLs for use in code.
+
+Example: `https://deno.land/x/net@d9ab8eb/http.ts`
+
+

--- a/registry/deploy_registry.sh
+++ b/registry/deploy_registry.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# TODO Port this to python once its working properly.
+
+set -e
+
+cd "$(dirname "$0")"
+
+sam package --template-file template.yaml \
+  --output-template-file packaged.yaml --s3-bucket deno.land
+
+sam deploy --template-file packaged.yaml \
+  --stack-name denoland4  --capabilities CAPABILITY_IAM
+
+echo "Manually update lambda https://console.aws.amazon.com/lambda/home?region=us-east-1"

--- a/registry/packaged.yaml
+++ b/registry/packaged.yaml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: deno.land/x redirect server.
+Globals:
+  Function:
+    Timeout: 3
+Outputs:
+  DenoLandApi:
+    Description: API Gateway endpoint URL for Prod stage for Hello World function
+    Value:
+      Fn::Sub: https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/
+  DenoLandFunction:
+    Description: Hello World Lambda Function ARN
+    Value:
+      Fn::GetAtt:
+      - DenoLandFunction
+      - Arn
+  DenoLandFunctionIamRole:
+    Description: Implicit IAM Role created for Hello World function
+    Value:
+      Fn::GetAtt:
+      - DenoLandFunctionRole
+      - Arn
+Resources:
+  DenoLandFunction:
+    Properties:
+      CodeUri: s3://deno.land/8b58bc3c5643f8da2d4dac6a98688e4a
+      Events:
+        DenoLand:
+          Properties:
+            Method: get
+            Path: /x
+          Type: Api
+      Handler: app.lambdaHandler
+      Runtime: nodejs8.10
+    Type: AWS::Serverless::Function
+Transform: AWS::Serverless-2016-10-31

--- a/registry/src/app.js
+++ b/registry/src/app.js
@@ -1,0 +1,111 @@
+// TODO Cron job to update the database with current values.
+const DATABASE = require("./database.json");
+const { assert } = console;
+
+const notFound = {
+  status: "404",
+  headers: {
+    "Content-Type": [
+      {
+        key: "Content-Type",
+        value: "text/plain"
+      }
+    ]
+  },
+  body: "Not Found\r\n"
+};
+
+function proxy(pathname) {
+  if (!pathname.startsWith("/x/")) {
+    return null;
+  }
+
+  const i = pathname.indexOf("/", 3);
+  const rest = pathname.slice(i + 1);
+  const nameBranch = pathname.slice(3, i);
+  let [name, branch] = nameBranch.split("@", 2);
+  const urlPattern = DATABASE[name];
+
+  if (!branch) {
+    branch = "master";
+  }
+
+  if (!urlPattern) {
+    return null;
+  }
+
+  const url = urlPattern.replace("${b}", branch);
+  assert(url.endsWith("/"));
+  assert(!rest.startsWith("/"));
+  return url + rest;
+}
+exports.proxy = proxy;
+
+const docs = `
+  <h1>deno.land packages</h1>
+  <p>
+    This is a URL redirection service for Deno scripts.
+    The basic format is
+    <code>https://deno.land/x/NAME@BRANCH/SCRIPT.ts</code>
+    If you leave out the branch, it will default to master.
+  </p>
+  <p>
+    To add a package send a pull request to
+    <code>https://github.com/denoland/registry/blob/master/x/database.json</code>
+  </p>
+`;
+
+function indexPage() {
+  let body = `<!DOCTYPE html><html>${docs}<ul>`;
+
+  for (let name in DATABASE) {
+    const url = DATABASE[name];
+    body += `<li>https://deno.land/x/${name}/  &rarr;  ${url} </li>\n`;
+  }
+
+  body += "</ul></html>";
+  return {
+    status: "200",
+    body,
+    headers: {
+      "Content-Type": [
+        {
+          key: "Content-Type",
+          value: "text/html"
+        }
+      ]
+    }
+  };
+}
+exports.indexPage = indexPage;
+
+exports.lambdaHandler = (event, context, callback) => {
+  console.log("Received event:", JSON.stringify(event, null, 2));
+  const pathname = event.Records[0].cf.request.uri;
+  console.log("pathname", pathname);
+
+  if (pathname === "/x/" || pathname === "/x" || pathname === "/x/index.html") {
+    callback(null, indexPage());
+    return;
+  }
+
+  const l = proxy(pathname);
+  if (!l) {
+    callback(null, notFound);
+    return;
+  }
+
+  console.log("redirect", pathname, l);
+  const response = {
+    status: "302",
+    headers: {
+      location: [
+        {
+          key: "Location",
+          value: l
+        }
+      ]
+    }
+  };
+  callback(null, response);
+};

--- a/registry/src/database.json
+++ b/registry/src/database.json
@@ -1,0 +1,12 @@
+{
+  "net": "https://raw.githubusercontent.com/denoland/deno_net/${b}/",
+  "examples": "https://raw.githubusercontent.com/denoland/deno_examples/${b}/",
+  "install": "https://raw.githubusercontent.com/denoland/deno_install/${b}/",
+  "parseargs": "https://raw.githubusercontent.com/bartlomieju/parseargs/${b}/",
+  "leftspread":
+    "https://gist.githubusercontent.com/piscisaureus/a4fa24a16eb12663472a62cc2b0b602f/raw/${b}/leftspread.d.ts",
+  "testing": "https://raw.githubusercontent.com/denoland/deno/${b}/js/testing/",
+  "dotenv": "https://raw.githubusercontent.com/pietvanzoen/deno-dotenv/${b}/",
+  "path": "https://raw.githubusercontent.com/zhmushan/deno_path/${b}/",
+  "colors": "https://raw.githubusercontent.com/kitsonk/colors/${b}/"
+}

--- a/registry/src/database.json
+++ b/registry/src/database.json
@@ -3,8 +3,7 @@
   "examples": "https://raw.githubusercontent.com/denoland/deno_examples/${b}/",
   "install": "https://raw.githubusercontent.com/denoland/deno_install/${b}/",
   "parseargs": "https://raw.githubusercontent.com/bartlomieju/parseargs/${b}/",
-  "leftspread":
-    "https://gist.githubusercontent.com/piscisaureus/a4fa24a16eb12663472a62cc2b0b602f/raw/${b}/leftspread.d.ts",
+  "leftspread": "https://gist.githubusercontent.com/piscisaureus/a4fa24a16eb12663472a62cc2b0b602f/raw/${b}/leftspread.d.ts",
   "testing": "https://raw.githubusercontent.com/denoland/deno/${b}/js/testing/",
   "dotenv": "https://raw.githubusercontent.com/pietvanzoen/deno-dotenv/${b}/",
   "path": "https://raw.githubusercontent.com/zhmushan/deno_path/${b}/",

--- a/registry/src/test.js
+++ b/registry/src/test.js
@@ -18,6 +18,6 @@ assert.equal(
 
 // Just check that indexPage() doesn't crash and the body looks like html.
 const r = indexPage();
-assert(r.body.match(/html/i)); 
+assert(r.body.match(/html/i));
 
 console.log("ok");

--- a/registry/src/test.js
+++ b/registry/src/test.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const { proxy, indexPage } = require("./app");
+const assert = require("assert");
+
+assert.equal(
+  proxy("/x/net/main.js"),
+  "https://raw.githubusercontent.com/denoland/deno_net/master/main.js"
+);
+assert.equal(
+  proxy("/x/net/foo/bar.js"),
+  "https://raw.githubusercontent.com/denoland/deno_net/master/foo/bar.js"
+);
+assert.equal(
+  proxy("/x/net@v0.1.2/foo/bar.js"),
+  "https://raw.githubusercontent.com/denoland/deno_net/v0.1.2/foo/bar.js"
+);
+
+// Just check that indexPage() doesn't crash and the body looks like html.
+const r = indexPage();
+assert(r.body.match(/html/i)); 
+
+console.log("ok");

--- a/registry/template.yaml
+++ b/registry/template.yaml
@@ -1,0 +1,34 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: deno.land/x redirect server.
+Globals:
+    Function:
+        Timeout: 3
+
+Resources:
+    DenoLandFunction:
+        Type: AWS::Serverless::Function
+        Properties:
+            CodeUri: src/
+            Handler: app.lambdaHandler
+            Runtime: nodejs8.10
+            Events:
+                DenoLand:
+                    Type: Api
+                    Properties:
+                        Path: /x
+                        Method: get
+
+Outputs:
+
+    DenoLandApi:
+      Description: "API Gateway endpoint URL for Prod stage for Hello World function"
+      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+
+    DenoLandFunction:
+      Description: "Hello World Lambda Function ARN"
+      Value: !GetAtt DenoLandFunction.Arn
+
+    DenoLandFunctionIamRole:
+      Description: "Implicit IAM Role created for Hello World function"
+      Value: !GetAtt DenoLandFunctionRole.Arn

--- a/tools/format.py
+++ b/tools/format.py
@@ -39,7 +39,7 @@ qrun(
 print "prettier"
 qrun(["node", prettier, "--write", "--loglevel=error"] + ["rollup.config.js"] +
      glob("*.json") + glob("*.md") +
-     find_exts([".github", "js", "tests", "tools", "website"],
+     find_exts([".github", "js", "tests", "tools", "website", "registry"],
                [".js", ".json", ".ts", ".md"],
                skip=["tools/clang"]))
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -74,6 +74,9 @@ def main(argv):
 
     deno_dir_test(deno_exe, deno_dir)
 
+    # Test for the registry AWS lambda function.
+    run(["node", "registry/src/test.js"])
+
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))


### PR DESCRIPTION
Was at https://github.com/denoland/registry
Aside from having it in a more central place, it opens the possibility of iterating over the distributed modules for tests (at some point)