### PR TITLE
Make ReadFile operation zero copy

### DIFF
--- a/js/read_file.ts
+++ b/js/read_file.ts
@@ -15,7 +15,7 @@ import { open } from "./files";
  */
 export function readFileSync(filename: string): Uint8Array {
   const buf = prepared_buf(filename);
-  if (buf.length == 0) {
+  if (buf.length === 0) {
     return buf;
   }
   const builder = flatbuffers.createBuilder();
@@ -36,7 +36,7 @@ export function readFileSync(filename: string): Uint8Array {
  */
 export async function readFile(filename: string): Promise<Uint8Array> {
   const buf = prepared_buf(filename);
-  if (buf.length == 0) {
+  if (buf.length === 0) {
     return buf;
   }
   const file = await open(filename, "r");

--- a/js/read_file.ts
+++ b/js/read_file.ts
@@ -1,8 +1,10 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 import * as msg from "gen/msg_generated";
 import * as flatbuffers from "./flatbuffers";
-import { assert } from "./util";
 import * as dispatch from "./dispatch";
+import { assert } from "./util";
+import { statSync } from "./stat";
+import { open } from "./files";
 
 /** Read the entire contents of a file synchronously.
  *
@@ -12,7 +14,17 @@ import * as dispatch from "./dispatch";
  *       console.log(decoder.decode(data));
  */
 export function readFileSync(filename: string): Uint8Array {
-  return res(dispatch.sendSync(...req(filename)));
+  const buf = prepared_buf(filename);
+  if (buf.length == 0) {
+    return buf;
+  }
+  const builder = flatbuffers.createBuilder();
+  const filename_ = builder.createString(filename);
+  msg.ReadFile.startReadFile(builder);
+  msg.ReadFile.addFilename(builder, filename_);
+  const inner = msg.ReadFile.endReadFile(builder);
+  dispatch.sendSync(builder, msg.Any.ReadFile, inner, buf);
+  return buf;
 }
 
 /** Read the entire contents of a file.
@@ -23,26 +35,17 @@ export function readFileSync(filename: string): Uint8Array {
  *       console.log(decoder.decode(data));
  */
 export async function readFile(filename: string): Promise<Uint8Array> {
-  return res(await dispatch.sendAsync(...req(filename)));
+  const buf = prepared_buf(filename);
+  if (buf.length == 0) {
+    return buf;
+  }
+  const file = await open(filename, "r");
+  await file.read(buf);
+  return buf;
 }
 
-function req(
-  filename: string
-): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
-  const builder = flatbuffers.createBuilder();
-  const filename_ = builder.createString(filename);
-  msg.ReadFile.startReadFile(builder);
-  msg.ReadFile.addFilename(builder, filename_);
-  const inner = msg.ReadFile.endReadFile(builder);
-  return [builder, msg.Any.ReadFile, inner];
-}
-
-function res(baseRes: null | msg.Base): Uint8Array {
-  assert(baseRes != null);
-  assert(msg.Any.ReadFileRes === baseRes!.innerType());
-  const inner = new msg.ReadFileRes();
-  assert(baseRes!.inner(inner) != null);
-  const dataArray = inner.dataArray();
-  assert(dataArray != null);
-  return new Uint8Array(dataArray!);
+function prepared_buf(filename: string): Uint8Array {
+  const fileInfo = statSync(filename);
+  assert(fileInfo.isFile(), "invalid file: " + filename);
+  return new Uint8Array(fileInfo.len);
 }

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -16,7 +16,6 @@ union Any {
   Chmod,
   Remove,
   ReadFile,
-  ReadFileRes,
   ReadDir,
   ReadDirRes,
   WriteFile,
@@ -249,10 +248,6 @@ table Remove {
 
 table ReadFile {
   filename: string;
-}
-
-table ReadFileRes {
-  data: [ubyte];
 }
 
 table ReadDir {


### PR DESCRIPTION
Resolve a TODO item in source code.

Before:
1. Read to Vec
2. Serialize to FlatBuffer
3. Clone to Buf
4. Clone to Javascript's Uint8Array

After:
1. Read file length
2. Allocate Uint8Array in Javascript
3. Read to Uint8Array

This way minimized memory copy but added a syscall. I guess it is faster, because `std::fs::read()` in [Rust's standard library](https://doc.rust-lang.org/src/std/fs.rs.html#265-270) chose the same strategy.