### PR TITLE
v0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 # crates.
 [package]
 name = "deno"
-version = "0.2.2"
+version = "0.2.3"
 
 [dependencies]
 atty = "=0.2.11"


### PR DESCRIPTION
- console.assert should not throw error (#1335)
- Support more modes in deno.open (#1282, #1336)
- Simplify code fetch logic (#1322)
- readDir entry mode (#1326)
- Use stderr for exceptions (#1303)
- console.log formatting improvements (#1327, #1299)
- Expose TooLarge error code for buffers (#1298)
