### PR TITLE
Make stdout unbuffered

### DIFF
--- a/js/testing/testing.ts
+++ b/js/testing/testing.ts
@@ -13,6 +13,7 @@
    limitations under the License.
 */
 
+import { stdout } from "deno";
 export { assert, assertEqual, equal } from "./util";
 
 export type TestFunction = () => void | Promise<void>;
@@ -70,6 +71,11 @@ function green_ok() {
   return FG_GREEN + "ok" + RESET;
 }
 
+// Prints to stdout without newline.
+async function print(s: string): Promise<void> {
+  await stdout.write(new TextEncoder().encode(s));
+}
+
 async function runTests() {
   let passed = 0;
   let failed = 0;
@@ -78,7 +84,7 @@ async function runTests() {
   for (let i = 0; i < tests.length; i++) {
     const { fn, name } = tests[i];
     let result = green_ok();
-    console.log("test", name);
+    print(`test ${name}`);
     try {
       await fn();
       passed++;

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -43,7 +43,6 @@ pub type ResourceId = u32; // Sometimes referred to RID.
 // system ones.
 type ResourceTable = HashMap<ResourceId, Repr>;
 
-
 use std::os::unix::io::FromRawFd;
 
 lazy_static! {

--- a/tools/ts_library_builder/test.ts
+++ b/tools/ts_library_builder/test.ts
@@ -3,7 +3,7 @@
 //  ./node_modules/.bin/ts-node --project tools/ts_library_builder/tsconfig.json tools/ts_library_builder/test.ts
 
 import { Project, ts } from "ts-simple-ast";
-import { assert, assertEqual, test } from "../../js/testing/testing";
+import { assert, assertEqual, test } from "./testing/testing";
 import { flatten, mergeGlobal } from "./build_library";
 import { loadDtsFiles } from "./ast_util";
 

--- a/tools/ts_library_builder/testing/testing.ts
+++ b/tools/ts_library_builder/testing/testing.ts
@@ -13,7 +13,6 @@
    limitations under the License.
 */
 
-import { stdout } from "deno";
 export { assert, assertEqual, equal } from "./util";
 
 export type TestFunction = () => void | Promise<void>;
@@ -73,7 +72,7 @@ function green_ok() {
 
 // Prints to stdout without newline.
 async function print(s: string): Promise<void> {
-  await stdout.write(new TextEncoder().encode(s));
+  process.stdout.write(s);
 }
 
 async function runTests() {

--- a/tools/ts_library_builder/testing/util.ts
+++ b/tools/ts_library_builder/testing/util.ts
@@ -1,0 +1,64 @@
+/*!
+   Copyright 2018 Propel http://propel.site/.  All rights reserved.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+// TODO(ry) Use unknown here for parameters types.
+// tslint:disable-next-line:no-any
+export function assertEqual(actual: any, expected: any, msg?: string) {
+  if (!msg) {
+    msg = `actual: ${actual} expected: ${expected}`;
+  }
+  if (!equal(actual, expected)) {
+    console.error(
+      "assertEqual failed. actual = ",
+      actual,
+      "expected =",
+      expected
+    );
+    throw new Error(msg);
+  }
+}
+
+export function assert(expr: boolean, msg = "") {
+  if (!expr) {
+    throw new Error(msg);
+  }
+}
+
+// TODO(ry) Use unknown here for parameters types.
+// tslint:disable-next-line:no-any
+export function equal(c: any, d: any): boolean {
+  const seen = new Map();
+  return (function compare(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a && typeof a === "object" && b && typeof b === "object") {
+      if (seen.get(a) === b) {
+        return true;
+      }
+      if (Object.keys(a).length !== Object.keys(b).length) {
+        return false;
+      }
+      for (const key in { ...a, ...b }) {
+        if (!compare(a[key], b[key])) {
+          return false;
+        }
+      }
+      seen.set(a, b);
+      return true;
+    }
+    return false;
+  })(c, d);
+}

--- a/tools/ts_library_builder/testing/util_test.ts
+++ b/tools/ts_library_builder/testing/util_test.ts
@@ -1,0 +1,40 @@
+/*!
+   Copyright 2018 Propel http://propel.site/.  All rights reserved.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+import { test } from "./testing.ts";
+import { assert } from "./util.ts";
+import * as util from "./util.ts";
+
+test(async function util_equal() {
+  assert(util.equal("world", "world"));
+  assert(!util.equal("hello", "world"));
+  assert(util.equal(5, 5));
+  assert(!util.equal(5, 6));
+  assert(util.equal(NaN, NaN));
+  assert(util.equal({ hello: "world" }, { hello: "world" }));
+  assert(!util.equal({ world: "hello" }, { hello: "world" }));
+  assert(
+    util.equal(
+      { hello: "world", hi: { there: "everyone" } },
+      { hello: "world", hi: { there: "everyone" } }
+    )
+  );
+  assert(
+    !util.equal(
+      { hello: "world", hi: { there: "everyone" } },
+      { hello: "world", hi: { there: "everyone else" } }
+    )
+  );
+});


### PR DESCRIPTION
This PR fixes #948. Continued from https://github.com/ry/deno/commit/756078733185e9127901c6957a73d0e2c9bdafde.

I copied `//js/testing/*` to `//tools/ts_builder_library/testing/*` (and slightly modified them to work with node.js) because `//js/testing` is not isomorphic anymore (doesn't work in (ts-)node because of `import ... from "deno"` line) and use it in ts_builder_library testing.
