### PR TITLE
Remove from test_cc SnapshotterInitializesCorrectly

### DIFF
--- a/libdeno/deno.h
+++ b/libdeno/deno.h
@@ -36,6 +36,9 @@ typedef struct {
   deno_recv_cb recv_cb;    // Maps to libdeno.send() calls.
 } deno_config;
 
+// Create a new deno isolate.
+// Warning: If config.will_snapshot is set, deno_get_snapshot() must be called
+// or an error will result.
 Deno* deno_new(deno_config config);
 
 // Generate a snapshot. The resulting buf can be used with deno_new.

--- a/libdeno/libdeno_test.cc
+++ b/libdeno/libdeno_test.cc
@@ -14,11 +14,6 @@ TEST(LibDenoTest, InitializesCorrectlyWithoutSnapshot) {
   deno_delete(d);
 }
 
-TEST(LibDenoTest, SnapshotterInitializesCorrectly) {
-  Deno* d = deno_new(deno_config{1, empty, empty, nullptr});
-  deno_delete(d);
-}
-
 TEST(LibDenoTest, Snapshotter) {
   Deno* d1 = deno_new(deno_config{1, empty, empty, nullptr});
   EXPECT_TRUE(deno_execute(d1, nullptr, "a.js", "a = 1 + 2"));


### PR DESCRIPTION
Unfortunately V8 has a debug-only assert that checks
that a SnapshotCreator actually created a snapshot:
https://github.com/denoland/deno_third_party/blob/7d8c9aa769778140e1619f545e706bf34545509e/v8/src/api.cc#L571

This was not being triggered in Linux & Mac debug builds
because we were using the prebuilt release V8 build.
It was being triggered in Windows debug build because there is
a prebuilt v8_debug.lib. However the Windows error went unnoticed.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
