### PR TITLE
Enable jumbo build in release.

### DIFF
--- a/.gn
+++ b/.gn
@@ -34,6 +34,10 @@ default_args = {
   # Works in other configurations.
   is_component_build = false
 
+  # Enable Jumbo build by default in debug mode for faster build.
+  # https://chromium.googlesource.com/chromium/src/+/master/docs/jumbo.md
+  use_jumbo_build = true
+
   symbol_level = 1
   treat_warnings_as_errors = true
   rust_treat_warnings_as_errors = true

--- a/.gn
+++ b/.gn
@@ -34,7 +34,7 @@ default_args = {
   # Works in other configurations.
   is_component_build = false
 
-  # Enable Jumbo build by default in debug mode for faster build.
+  # Enable Jumbo build for a faster build.
   # https://chromium.googlesource.com/chromium/src/+/master/docs/jumbo.md
   use_jumbo_build = true
 

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -107,9 +107,7 @@ def generate_gn_args(mode):
     if mode == "release":
         out += ["is_official_build=true"]
     elif mode == "debug":
-        # Enable Jumbo build by default in debug mode for faster build.
-        # https://chromium.googlesource.com/chromium/src/+/master/docs/jumbo.md
-        out += ["use_jumbo_build=true"]
+        out += ["is_debug=true"]
     else:
         print "Bad mode {}. Use 'release' or 'debug' (default)" % mode
         sys.exit(1)


### PR DESCRIPTION
Although this results in slightly larger executable sizes, we've decided
that the improvement in build time (especially on Windows) is worth it.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
