### PR TITLE
fix url `set` and `constructor`

### DIFF
--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -122,13 +122,12 @@ export class URLSearchParams {
         if (!found) {
           this.params[i][1] = value;
           found = true;
-          i++;
         } else {
           this.params.splice(i, 1);
+          continue;
         }
-      } else {
-        i++;
       }
+      i++;
     }
 
     // Otherwise, append a new name-value pair whose name is name

--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -24,6 +24,12 @@ export class URLSearchParams {
     } else if (Array.isArray(init)) {
       // Overload: sequence<sequence<USVString>>
       for (const tuple of init) {
+        // If pair does not contain exactly two items, then throw a TypeError.
+        if (tuple.length !== 2) {
+          const errMsg =
+            "Each query pair must be an iterable [name, value] tuple";
+          throw new TypeError(errMsg);
+        }
         this.append(tuple[0], tuple[1]);
       }
     } else if (Object(init) === init) {
@@ -106,8 +112,30 @@ export class URLSearchParams {
    *       searchParams.set('name', 'value');
    */
   set(name: string, value: string): void {
-    this.delete(name);
-    this.append(name, value);
+    // If there are any name-value pairs whose name is name, in list,
+    // set the value of the first such name-value pair to value
+    // and remove the others.
+    let found = false;
+    let i = 0;
+    while (i < this.params.length) {
+      if (this.params[i][0] === name) {
+        if (!found) {
+          this.params[i][1] = value;
+          found = true;
+          i++;
+        } else {
+          this.params.splice(i, 1);
+        }
+      } else {
+        i++;
+      }
+    }
+
+    // Otherwise, append a new name-value pair whose name is name
+    // and value is value, to list.
+    if (!found) {
+      this.append(name, value);
+    }
   }
 
   /** Sort all key/value pairs contained in this object in place and

--- a/js/url_search_params_test.ts
+++ b/js/url_search_params_test.ts
@@ -59,11 +59,18 @@ test(function urlSearchParamsHasSuccess() {
   assert(!searchParams.has("c"));
 });
 
-test(function urlSearchParamsSetSuccess() {
+test(function urlSearchParamsSetReplaceFirstAndRemoveOthers() {
   const init = "a=54&b=true&a=true";
   const searchParams = new URLSearchParams(init);
   searchParams.set("a", "false");
-  assertEqual(searchParams.toString(), "b=true&a=false");
+  assertEqual(searchParams.toString(), "a=false&b=true");
+});
+
+test(function urlSearchParamsSetAppendNew() {
+  const init = "a=54&b=true&a=true";
+  const searchParams = new URLSearchParams(init);
+  searchParams.set("c", "foo");
+  assertEqual(searchParams.toString(), "a=54&b=true&a=true&c=foo");
 });
 
 test(function urlSearchParamsSortSuccess() {
@@ -111,4 +118,23 @@ test(function urlSearchParamsMissingPair() {
   const init = "c=4&&a=54&";
   const searchParams = new URLSearchParams(init);
   assertEqual(searchParams.toString(), "c=4&a=54");
+});
+
+// If pair does not contain exactly two items, then throw a TypeError.
+// ref https://url.spec.whatwg.org/#interface-urlsearchparams
+test(function urlSearchParamsShouldThrowTypeError() {
+  let hasThrown = 0;
+
+  try {
+    new URLSearchParams([["1"]]);
+    hasThrown = 1;
+  } catch (err) {
+    if (err instanceof TypeError) {
+      hasThrown = 2;
+    } else {
+      hasThrown = 3;
+    }
+  }
+
+  assertEqual(hasThrown, 2);
 });


### PR DESCRIPTION
I fixed 2 functions of URL to make it more compliant with the whatwg specification.

**`constructor`**

spec:

> 1. ...
> 1. If init is a sequence, then for each pair in init:
>    1. **If pair does not contain exactly two items, then throw a TypeError.**
>    2. Append a new name-value pair whose name is pair’s first item, and value is pair’s second item, to query’s list.
> 3. ...

before:

```js
const searchParams = new URLSearchParams([["foo"]])
searchParams.toString() === "foo=undefined"
```

after:

```js
const searchParams = new URLSearchParams([["foo"]])
// throw TypeError
```

------

**`set`**

spec:

> 1. If there are any name-value pairs whose name is name, in list, **set the value of the first such name-value pair to value** and remove the others. 
> 2. Otherwise, append a new name-value pair whose name is name and value is value, to list.
> 3. ...


before:

```js
const searchParams = new URLSearchParams("a=1&b=2&a=3")
searchParams.set("a", "false");

// before
searchParams.toString() === "b=2&a=false"

// after
searchParams.toString() === "a=false&b=2"
```

cc @kitsonk 
