### PR TITLE
check the arguments number of `URLSearchParams`

### DIFF
--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -1,4 +1,4 @@
-import { requiredArguments } from './util';
+import { requiredArguments } from "./util";
 
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 export class URLSearchParams {
@@ -48,7 +48,7 @@ export class URLSearchParams {
    *       searchParams.append('name', 'second');
    */
   append(name: string, value: string): void {
-    requiredArguments('URLSearchParams.append', arguments.length, 2);
+    requiredArguments("URLSearchParams.append", arguments.length, 2);
     this.params.push([String(name), value]);
   }
 
@@ -58,7 +58,7 @@ export class URLSearchParams {
    *       searchParams.delete('name');
    */
   delete(name: string): void {
-    requiredArguments('URLSearchParams.delete', arguments.length, 1);
+    requiredArguments("URLSearchParams.delete", arguments.length, 1);
     name = String(name);
     let i = 0;
     while (i < this.params.length) {
@@ -76,7 +76,7 @@ export class URLSearchParams {
    *       searchParams.getAll('name');
    */
   getAll(name: string): string[] {
-    requiredArguments('URLSearchParams.getAll', arguments.length, 1);
+    requiredArguments("URLSearchParams.getAll", arguments.length, 1);
     name = String(name);
     const values = [];
     for (const entry of this.params) {
@@ -93,7 +93,7 @@ export class URLSearchParams {
    *       searchParams.get('name');
    */
   get(name: string): string | null {
-    requiredArguments('URLSearchParams.get', arguments.length, 1);
+    requiredArguments("URLSearchParams.get", arguments.length, 1);
     name = String(name);
     for (const entry of this.params) {
       if (entry[0] === name) {
@@ -110,7 +110,7 @@ export class URLSearchParams {
    *       searchParams.has('name');
    */
   has(name: string): boolean {
-    requiredArguments('URLSearchParams.has', arguments.length, 1);
+    requiredArguments("URLSearchParams.has", arguments.length, 1);
     name = String(name);
     return this.params.some(entry => entry[0] === name);
   }
@@ -123,7 +123,7 @@ export class URLSearchParams {
    *       searchParams.set('name', 'value');
    */
   set(name: string, value: string): void {
-    requiredArguments('URLSearchParams.set', arguments.length, 2);
+    requiredArguments("URLSearchParams.set", arguments.length, 2);
 
     // If there are any name-value pairs whose name is name, in list,
     // set the value of the first such name-value pair to value
@@ -178,7 +178,7 @@ export class URLSearchParams {
     // tslint:disable-next-line:no-any
     thisArg?: any
   ) {
-    requiredArguments('URLSearchParams.forEach', arguments.length, 1);
+    requiredArguments("URLSearchParams.forEach", arguments.length, 1);
 
     if (typeof thisArg !== "undefined") {
       callbackfn = callbackfn.bind(thisArg);

--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -1,3 +1,5 @@
+import { requiredArguments } from './util';
+
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 export class URLSearchParams {
   private params: Array<[string, string]> = [];
@@ -46,14 +48,7 @@ export class URLSearchParams {
    *       searchParams.append('name', 'second');
    */
   append(name: string, value: string): void {
-    if (arguments.length < 2) {
-      // tslint:disable-next-line:max-line-length
-      const errMsg = `URLSearchParams.append requires at least 2 arguments, but only ${
-        arguments.length
-      } present`;
-      throw new TypeError(errMsg);
-    }
-
+    requiredArguments('URLSearchParams.append', arguments.length, 2);
     this.params.push([String(name), value]);
   }
 
@@ -63,14 +58,7 @@ export class URLSearchParams {
    *       searchParams.delete('name');
    */
   delete(name: string): void {
-    if (arguments.length < 1) {
-      // tslint:disable-next-line:max-line-length
-      const errMsg = `URLSearchParams.delete requires at least 1 argument, but only ${
-        arguments.length
-      } present`;
-      throw new TypeError(errMsg);
-    }
-
+    requiredArguments('URLSearchParams.delete', arguments.length, 1);
     name = String(name);
     let i = 0;
     while (i < this.params.length) {
@@ -88,14 +76,7 @@ export class URLSearchParams {
    *       searchParams.getAll('name');
    */
   getAll(name: string): string[] {
-    if (arguments.length < 1) {
-      // tslint:disable-next-line:max-line-length
-      const errMsg = `URLSearchParams.getAll requires at least 1 argument, but only ${
-        arguments.length
-      } present`;
-      throw new TypeError(errMsg);
-    }
-
+    requiredArguments('URLSearchParams.getAll', arguments.length, 1);
     name = String(name);
     const values = [];
     for (const entry of this.params) {
@@ -112,14 +93,7 @@ export class URLSearchParams {
    *       searchParams.get('name');
    */
   get(name: string): string | null {
-    if (arguments.length < 1) {
-      // tslint:disable-next-line:max-line-length
-      const errMsg = `URLSearchParams.get requires at least 1 argument, but only ${
-        arguments.length
-      } present`;
-      throw new TypeError(errMsg);
-    }
-
+    requiredArguments('URLSearchParams.get', arguments.length, 1);
     name = String(name);
     for (const entry of this.params) {
       if (entry[0] === name) {
@@ -136,14 +110,7 @@ export class URLSearchParams {
    *       searchParams.has('name');
    */
   has(name: string): boolean {
-    if (arguments.length < 1) {
-      // tslint:disable-next-line:max-line-length
-      const errMsg = `URLSearchParams.has requires at least 1 argument, but only ${
-        arguments.length
-      } present`;
-      throw new TypeError(errMsg);
-    }
-
+    requiredArguments('URLSearchParams.has', arguments.length, 1);
     name = String(name);
     return this.params.some(entry => entry[0] === name);
   }
@@ -156,13 +123,7 @@ export class URLSearchParams {
    *       searchParams.set('name', 'value');
    */
   set(name: string, value: string): void {
-    if (arguments.length < 2) {
-      // tslint:disable-next-line:max-line-length
-      const errMsg = `URLSearchParams.set requires at least 2 arguments, but only ${
-        arguments.length
-      } present`;
-      throw new TypeError(errMsg);
-    }
+    requiredArguments('URLSearchParams.set', arguments.length, 2);
 
     // If there are any name-value pairs whose name is name, in list,
     // set the value of the first such name-value pair to value
@@ -217,17 +178,12 @@ export class URLSearchParams {
     // tslint:disable-next-line:no-any
     thisArg?: any
   ) {
-    if (arguments.length < 1) {
-      // tslint:disable-next-line:max-line-length
-      const errMsg = `URLSearchParams.forEach requires at least 1 argument, but only ${
-        arguments.length
-      } present`;
-      throw new TypeError(errMsg);
-    }
+    requiredArguments('URLSearchParams.forEach', arguments.length, 1);
 
     if (typeof thisArg !== "undefined") {
       callbackfn = callbackfn.bind(thisArg);
     }
+
     for (const [key, value] of this.entries()) {
       callbackfn(value, key, this);
     }

--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -46,6 +46,14 @@ export class URLSearchParams {
    *       searchParams.append('name', 'second');
    */
   append(name: string, value: string): void {
+    if (arguments.length < 2) {
+      // tslint:disable-next-line:max-line-length
+      const errMsg = `URLSearchParams.append requires at least 2 arguments, but only ${
+        arguments.length
+      } present`;
+      throw new TypeError(errMsg);
+    }
+
     this.params.push([name, value]);
   }
 
@@ -55,6 +63,14 @@ export class URLSearchParams {
    *       searchParams.delete('name');
    */
   delete(name: string): void {
+    if (arguments.length < 1) {
+      // tslint:disable-next-line:max-line-length
+      const errMsg = `URLSearchParams.delete requires at least 1 argument, but only ${
+        arguments.length
+      } present`;
+      throw new TypeError(errMsg);
+    }
+
     let i = 0;
     while (i < this.params.length) {
       if (this.params[i][0] === name) {
@@ -71,6 +87,14 @@ export class URLSearchParams {
    *       searchParams.getAll('name');
    */
   getAll(name: string): string[] {
+    if (arguments.length < 1) {
+      // tslint:disable-next-line:max-line-length
+      const errMsg = `URLSearchParams.getAll requires at least 1 argument, but only ${
+        arguments.length
+      } present`;
+      throw new TypeError(errMsg);
+    }
+
     const values = [];
     for (const entry of this.params) {
       if (entry[0] === name) {
@@ -86,6 +110,14 @@ export class URLSearchParams {
    *       searchParams.get('name');
    */
   get(name: string): string | null {
+    if (arguments.length < 1) {
+      // tslint:disable-next-line:max-line-length
+      const errMsg = `URLSearchParams.get requires at least 1 argument, but only ${
+        arguments.length
+      } present`;
+      throw new TypeError(errMsg);
+    }
+
     for (const entry of this.params) {
       if (entry[0] === name) {
         return entry[1];
@@ -101,6 +133,14 @@ export class URLSearchParams {
    *       searchParams.has('name');
    */
   has(name: string): boolean {
+    if (arguments.length < 1) {
+      // tslint:disable-next-line:max-line-length
+      const errMsg = `URLSearchParams.has requires at least 1 argument, but only ${
+        arguments.length
+      } present`;
+      throw new TypeError(errMsg);
+    }
+
     return this.params.some(entry => entry[0] === name);
   }
 
@@ -112,6 +152,14 @@ export class URLSearchParams {
    *       searchParams.set('name', 'value');
    */
   set(name: string, value: string): void {
+    if (arguments.length < 2) {
+      // tslint:disable-next-line:max-line-length
+      const errMsg = `URLSearchParams.set requires at least 2 arguments, but only ${
+        arguments.length
+      } present`;
+      throw new TypeError(errMsg);
+    }
+
     // If there are any name-value pairs whose name is name, in list,
     // set the value of the first such name-value pair to value
     // and remove the others.
@@ -122,12 +170,13 @@ export class URLSearchParams {
         if (!found) {
           this.params[i][1] = value;
           found = true;
+          i++;
         } else {
           this.params.splice(i, 1);
-          continue;
         }
+      } else {
+        i++;
       }
-      i++;
     }
 
     // Otherwise, append a new name-value pair whose name is name
@@ -163,6 +212,14 @@ export class URLSearchParams {
     // tslint:disable-next-line:no-any
     thisArg?: any
   ) {
+    if (arguments.length < 1) {
+      // tslint:disable-next-line:max-line-length
+      const errMsg = `URLSearchParams.forEach requires at least 1 argument, but only ${
+        arguments.length
+      } present`;
+      throw new TypeError(errMsg);
+    }
+
     if (typeof thisArg !== "undefined") {
       callbackfn = callbackfn.bind(thisArg);
     }

--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -54,7 +54,7 @@ export class URLSearchParams {
       throw new TypeError(errMsg);
     }
 
-    this.params.push([name, value]);
+    this.params.push([String(name), value]);
   }
 
   /** Deletes the given search parameter and its associated value,
@@ -71,6 +71,7 @@ export class URLSearchParams {
       throw new TypeError(errMsg);
     }
 
+    name = String(name);
     let i = 0;
     while (i < this.params.length) {
       if (this.params[i][0] === name) {
@@ -95,6 +96,7 @@ export class URLSearchParams {
       throw new TypeError(errMsg);
     }
 
+    name = String(name);
     const values = [];
     for (const entry of this.params) {
       if (entry[0] === name) {
@@ -118,6 +120,7 @@ export class URLSearchParams {
       throw new TypeError(errMsg);
     }
 
+    name = String(name);
     for (const entry of this.params) {
       if (entry[0] === name) {
         return entry[1];
@@ -141,6 +144,7 @@ export class URLSearchParams {
       throw new TypeError(errMsg);
     }
 
+    name = String(name);
     return this.params.some(entry => entry[0] === name);
   }
 
@@ -163,6 +167,7 @@ export class URLSearchParams {
     // If there are any name-value pairs whose name is name, in list,
     // set the value of the first such name-value pair to value
     // and remove the others.
+    name = String(name);
     let found = false;
     let i = 0;
     while (i < this.params.length) {

--- a/js/url_search_params_test.ts
+++ b/js/url_search_params_test.ts
@@ -138,3 +138,41 @@ test(function urlSearchParamsShouldThrowTypeError() {
 
   assertEqual(hasThrown, 2);
 });
+
+test(function urlSearchParamsAppendArgumentsCheck() {
+  const methodRequireOneParam = ["delete", "getAll", "get", "has", "forEach"];
+
+  const methodRequireTwoParams = ["append", "set"];
+
+  methodRequireOneParam.concat(methodRequireTwoParams).forEach(method => {
+    const searchParams = new URLSearchParams();
+    let hasThrown = 0;
+    try {
+      searchParams[method]();
+      hasThrown = 1;
+    } catch (err) {
+      if (err instanceof TypeError) {
+        hasThrown = 2;
+      } else {
+        hasThrown = 3;
+      }
+    }
+    assertEqual(hasThrown, 2);
+  });
+
+  methodRequireTwoParams.forEach(method => {
+    const searchParams = new URLSearchParams();
+    let hasThrown = 0;
+    try {
+      searchParams[method]("foo");
+      hasThrown = 1;
+    } catch (err) {
+      if (err instanceof TypeError) {
+        hasThrown = 2;
+      } else {
+        hasThrown = 3;
+      }
+    }
+    assertEqual(hasThrown, 2);
+  });
+});

--- a/js/util.ts
+++ b/js/util.ts
@@ -137,3 +137,12 @@ export function isTypedArray(x: unknown): x is TypedArray {
 export function isObject(o: unknown): o is object {
   return o != null && typeof o === "object";
 }
+
+// @internal
+export function requiredArguments(name: string, length: number, required: number): void {
+  if (length < required) {
+    const errMsg = `${name} requires at least ${required} argument${
+      required === 1 ? '' : 's'}, but only ${length} present`;
+    throw new TypeError(errMsg);
+  }
+}

--- a/js/util.ts
+++ b/js/util.ts
@@ -139,10 +139,15 @@ export function isObject(o: unknown): o is object {
 }
 
 // @internal
-export function requiredArguments(name: string, length: number, required: number): void {
+export function requiredArguments(
+  name: string,
+  length: number,
+  required: number
+): void {
   if (length < required) {
     const errMsg = `${name} requires at least ${required} argument${
-      required === 1 ? '' : 's'}, but only ${length} present`;
+      required === 1 ? "" : "s"
+    }, but only ${length} present`;
     throw new TypeError(errMsg);
   }
 }


### PR DESCRIPTION
`URLSearchParams` did not check the number of arguments passed, thereby causing some bugs.

When we use TypeScript, the tsc compiler will do parameter checking for us, but many times we write code in JavaScript.

```ts
let s = new URLSearchParams()
s.append()

// before
s.toString() === "undefined=undefined"

// after fix
// TypeError: URLSearchParams.append requires at least 2 arguments, but only 0 present
```

-------------

In addition, the first argument should be converted to `string` type

```ts
let s = new URLSearchParams()

// the `String` wrapper
s.set(new String("foo"), "bar")

// When calling `toString`, the keys and values are converted to strings
s.toString() === "foo=bar"

// but...

// before
s.has('foo') === false
s.get('foo') === null

// after fix
s.has('foo') === true
s.get('foo') === "bar"
```