### PR TITLE
Implement `Body.formData` for fetch

### DIFF
--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -129,6 +129,7 @@ class Body implements domTypes.Body, domTypes.ReadableStream, io.ReadCloser {
         const headerText = bodyPart.slice(0, headerOctetSeperatorIndex);
         const octets = bodyPart.slice(headerOctetSeperatorIndex + 4);
 
+        // TODO: use textproto.readMIMEHeader from deno_std
         const rawHeaders = headerText.split("\r\n");
         for (const rawHeader of rawHeaders) {
           const sepIndex = rawHeader.indexOf(":");

--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -58,6 +58,30 @@ testPerm({ net: true }, async function fetchEmptyInvalid() {
   assertEqual(err.name, "InvalidUri");
 });
 
+testPerm({ net: true }, async function fetchMultipartFormDataSuccess() {
+  const response = await fetch(
+    "http://localhost:4545/tests/subdir/multipart_form_data.txt"
+  );
+  const formData = await response.formData();
+  assert(formData.has("field_1"));
+  assertEqual(formData.get("field_1").toString(), "value_1 \r\n");
+  assert(formData.has("field_2"));
+  const file = formData.get("field_2") as File;
+  assertEqual(file.name, "file.js");
+  // Currently we cannot read from file...
+});
+
+testPerm({ net: true }, async function fetchURLEncodedFormDataSuccess() {
+  const response = await fetch(
+    "http://localhost:4545/tests/subdir/form_urlencoded.txt"
+  );
+  const formData = await response.formData();
+  assert(formData.has("field_1"));
+  assertEqual(formData.get("field_1").toString(), "Hi");
+  assert(formData.has("field_2"));
+  assertEqual(formData.get("field_2").toString(), "<Deno>");
+});
+
 // TODO(ry) The following tests work but are flaky. There's a race condition
 // somewhere. Here is what one of these flaky failures looks like:
 //

--- a/tests/subdir/form_urlencoded.txt
+++ b/tests/subdir/form_urlencoded.txt
@@ -1,0 +1,1 @@
+field_1=Hi&field_2=%3CDeno%3E

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -32,6 +32,10 @@ class ContentTypeHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
             return "text/ecmascript"
         if ".j4." in path:
             return "application/x-javascript"
+        if "multipart_form_data" in path:
+            return "multipart/form-data;boundary=boundary"
+        if "form_urlencoded" in path:
+            return "application/x-www-form-urlencoded"
         return SimpleHTTPServer.SimpleHTTPRequestHandler.guess_type(self, path)
 
 

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -23,19 +23,19 @@ class ContentTypeHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                              'multipart/form-data;boundary=boundary')
             self.end_headers()
             self.wfile.write(
-                bytes(
-                    'Preamble\r\n'
-                    '--boundary\t \r\n'
-                    'Content-Disposition: form-data; name="field_1"\r\n'
-                    '\r\n'
-                    'value_1 \r\n'
-                    '\r\n--boundary\r\n'
-                    'Content-Disposition: form-data; name="field_2"; filename="file.js"\r\n'
-                    'Content-Type: text/javascript\r\n'
-                    '\r\n'
-                    'console.log("Hi")'
-                    '\r\n--boundary--\r\n'
-                    'Epilogue'))
+                bytes('Preamble\r\n'
+                      '--boundary\t \r\n'
+                      'Content-Disposition: form-data; name="field_1"\r\n'
+                      '\r\n'
+                      'value_1 \r\n'
+                      '\r\n--boundary\r\n'
+                      'Content-Disposition: form-data; name="field_2"; '
+                      'filename="file.js"\r\n'
+                      'Content-Type: text/javascript\r\n'
+                      '\r\n'
+                      'console.log("Hi")'
+                      '\r\n--boundary--\r\n'
+                      'Epilogue'))
             return
         return SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET(self)
 

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -15,6 +15,30 @@ REDIRECT_PORT = 4546
 
 
 class ContentTypeHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if "multipart_form_data.txt" in self.path:
+            self.protocol_version = 'HTTP/1.1'
+            self.send_response(200, 'OK')
+            self.send_header('Content-type',
+                             'multipart/form-data;boundary=boundary')
+            self.end_headers()
+            self.wfile.write(
+                bytes(
+                    'Preamble\r\n'
+                    '--boundary\t \r\n'
+                    'Content-Disposition: form-data; name="field_1"\r\n'
+                    '\r\n'
+                    'value_1 \r\n'
+                    '\r\n--boundary\r\n'
+                    'Content-Disposition: form-data; name="field_2"; filename="file.js"\r\n'
+                    'Content-Type: text/javascript\r\n'
+                    '\r\n'
+                    'console.log("Hi")'
+                    '\r\n--boundary--\r\n'
+                    'Epilogue'))
+            return
+        return SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET(self)
+
     def guess_type(self, path):
         if ".t1." in path:
             return "text/typescript"
@@ -32,8 +56,6 @@ class ContentTypeHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
             return "text/ecmascript"
         if ".j4." in path:
             return "application/x-javascript"
-        if "multipart_form_data" in path:
-            return "multipart/form-data;boundary=boundary"
         if "form_urlencoded" in path:
             return "application/x-www-form-urlencoded"
         return SimpleHTTPServer.SimpleHTTPRequestHandler.guess_type(self, path)


### PR DESCRIPTION
Based mostly on https://fetch.spec.whatwg.org/#body-mixin

`node-fetch` did not implement this. `whatwg-fetch` implements `application/x-www-form-urlencoded` but not `multipart/form-data`.

~~TODO: Debug, format code, add tests~~