### PR TITLE
Avoid fetch segfault on empty Uri

### DIFF
--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -47,6 +47,17 @@ testPerm({ net: true }, async function responseClone() {
   }
 });
 
+testPerm({ net: true }, async function fetchEmptyInvalid() {
+  let err;
+  try {
+    await fetch("");
+  } catch (err_) {
+    err = err_;
+  }
+  assertEqual(err.kind, deno.ErrorKind.InvalidUri);
+  assertEqual(err.name, "InvalidUri");
+});
+
 // TODO(ry) The following tests work but are flaky. There's a race condition
 // somewhere. Here is what one of these flaky failures looks like:
 //

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -106,6 +106,9 @@ enum ErrorKind: byte {
   HttpParse,
   HttpOther,
   TooLarge,
+
+  // custom errors
+  InvalidUri,
 }
 
 table Cwd {}

--- a/src/msg_util.rs
+++ b/src/msg_util.rs
@@ -1,5 +1,7 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 // Helpers for serialization.
+use errors;
+use errors::DenoResult;
 use flatbuffers;
 use http::header::HeaderName;
 use http::uri::Uri;
@@ -94,13 +96,14 @@ pub fn serialize_http_response<'bldr>(
 pub fn deserialize_request(
   header_msg: msg::HttpHeader,
   body: Body,
-) -> Request<Body> {
+) -> DenoResult<Request<Body>> {
   let mut r = Request::new(body);
 
   assert!(header_msg.is_request());
 
   let u = header_msg.url().unwrap();
-  let u = Uri::from_str(u).unwrap();
+  let u = Uri::from_str(u)
+    .map_err(|e| errors::new(msg::ErrorKind::InvalidUri, e.to_string()))?;
   *r.uri_mut() = u;
 
   if let Some(method) = header_msg.method() {
@@ -119,5 +122,5 @@ pub fn deserialize_request(
       headers.insert(name, v);
     }
   }
-  r
+  Ok(r)
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -408,7 +408,11 @@ fn op_fetch(
     hyper::Body::from(Vec::from(&*data))
   };
 
-  let req = msg_util::deserialize_request(header, body);
+  let maybe_req = msg_util::deserialize_request(header, body);
+  if let Err(e) = maybe_req {
+    return odd_future(e);
+  }
+  let req = maybe_req.unwrap();
 
   if let Err(e) = state.check_net(url) {
     return odd_future(e);


### PR DESCRIPTION
Closes #1392 
Don't unwrap prematurely.
