### PR TITLE
[WIP] add console.table()

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -473,6 +473,16 @@ export class Console {
 
     this.info(`${label}: ${duration}ms`);
   };
+
+  /** Writes the properties of the supplied `obj` to stdout */
+  // tslint:disable-next-line:no-any
+  table = (obj: any, options: ConsoleOptions = {}) => {
+    let rows = Object.entries(obj).map(([key, val]) => {
+      return `| ${key} | ${val} |`;
+    });
+    rows = ["| (index) | value |"].concat(rows);
+    this.printFunc(stringifyArgs([rows.join("\n")], options));
+  };
 }
 
 /**


### PR DESCRIPTION
<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
Associated to #1351 
Make the `console.table()` implementation follow the [whatwg#table](https://console.spec.whatwg.org/#table).
Trying to reproduce `console.table()` of chrome devtools.


TODO:
- [x] object, instance and array to table string
<img width="253" alt="screen shot 2018-12-21 at 22 35 37" src="https://user-images.githubusercontent.com/4220570/50344998-c6b90100-0570-11e9-98ac-d3cabc7dd8a4.png">

- [ ] write test
- [ ] format table
- [ ] ./tools/test.py
- [ ] ./tools/format.py
- [ ] ./tools/lint.py