### PR TITLE
Basic support of let/const in REPL

### DIFF
--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -9,6 +9,16 @@ export type PromiseRejectEvent =
   | "ResolveAfterResolved"
   | "RejectAfterResolved";
 
+interface EvalErrorInfo {
+  // Is the object thrown a native Error?
+  isNativeError: boolean;
+  // Was the error happened during compilation?
+  isCompileError: boolean;
+  // The actual thrown entity
+  // (might be an Error or anything else thrown by the user)
+  thrown: any; // tslint:disable-line:no-any
+}
+
 interface Libdeno {
   recv(cb: MessageCallback): void;
 
@@ -17,6 +27,15 @@ interface Libdeno {
   print(x: string, isErr?: boolean): void;
 
   shared: ArrayBuffer;
+
+  /** Evaluate provided code in the current context.
+   * It differs from eval(...) in that it does not create a new context.
+   * Returns an array: [output, errInfo].
+   * If an error occurs, `output` becomes null and `errInfo` is non-null.
+   */
+  eval(
+    code: string
+  ): [any, EvalErrorInfo | null] /* tslint:disable-line:no-any */;
 
   builtinModules: { [s: string]: object };
 

--- a/js/repl.ts
+++ b/js/repl.ts
@@ -7,6 +7,7 @@ import { close } from "./files";
 import * as dispatch from "./dispatch";
 import { exit } from "./os";
 import { globalEval } from "./global_eval";
+import { libdeno } from "./libdeno";
 
 const window = globalEval("this");
 
@@ -83,8 +84,18 @@ export async function replLoop(): Promise<void> {
 
 function evaluate(code: string): void {
   try {
-    const result = eval.call(window, code); // FIXME use a new scope.
-    console.log(result);
+    // TODO: use sandbox in the future
+    const [result, errInfo] = libdeno.eval(code);
+    if (!errInfo) {
+      console.log(result);
+    } else {
+      if (errInfo.isNativeError) {
+        console.error((errInfo.thrown as Error).message);
+      } else {
+        // TODO: make Node-like multiline support a separate PR
+        console.error("Thrown:", errInfo.thrown);
+      }
+    }
   } catch (err) {
     if (err instanceof Error) {
       console.error(`${err.constructor.name}: ${err.message}`);

--- a/libdeno/internal.h
+++ b/libdeno/internal.h
@@ -113,6 +113,7 @@ void Recv(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Send(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Shared(v8::Local<v8::Name> property,
             const v8::PropertyCallbackInfo<v8::Value>& info);
+void Eval(const v8::FunctionCallbackInfo<v8::Value>& args);
 void BuiltinModules(v8::Local<v8::Name> property,
                     const v8::PropertyCallbackInfo<v8::Value>& info);
 static intptr_t external_references[] = {
@@ -120,6 +121,7 @@ static intptr_t external_references[] = {
     reinterpret_cast<intptr_t>(Recv),
     reinterpret_cast<intptr_t>(Send),
     reinterpret_cast<intptr_t>(Shared),
+    reinterpret_cast<intptr_t>(Eval),
     reinterpret_cast<intptr_t>(BuiltinModules),
     0};
 

--- a/libdeno/libdeno_test.cc
+++ b/libdeno/libdeno_test.cc
@@ -322,6 +322,18 @@ TEST(LibDenoTest, ModuleSnapshot) {
   delete[] test_snapshot.data_ptr;
 }
 
+TEST(LibDenoTest, LibDenoEval) {
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr, nullptr});
+  EXPECT_TRUE(deno_execute(d, nullptr, "a.js", "LibDenoEval();"));
+  deno_delete(d);
+}
+
+TEST(LibDenoTest, LibDenoEvalError) {
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr, nullptr});
+  EXPECT_TRUE(deno_execute(d, nullptr, "a.js", "LibDenoEvalError();"));
+  deno_delete(d);
+}
+
 TEST(LibDenoTest, BuiltinModules) {
   static int count = 0;
   auto resolve_cb = [](void* user_data, const char* specifier,

--- a/libdeno/libdeno_test.js
+++ b/libdeno/libdeno_test.js
@@ -146,3 +146,50 @@ global.Shared = () => {
   ui8[1] = 43;
   ui8[2] = 44;
 };
+
+global.LibDenoEval = () => {
+  const [result, errInfo] = libdeno.eval("let a = 1; a");
+  assert(result === 1);
+  assert(!errInfo);
+  const [result2, errInfo2] = libdeno.eval("a = a + 1; a");
+  assert(result2 === 2);
+  assert(!errInfo2);
+};
+
+global.LibDenoEvalError = () => {
+  const [result, errInfo] = libdeno.eval("not_a_variable");
+  assert(!result);
+  assert(!!errInfo);
+  assert(errInfo.isNativeError); // is a native error (ReferenceError)
+  assert(!errInfo.isCompileError); // is NOT a compilation error
+  assert(errInfo.thrown.message === "ReferenceError: not_a_variable is not defined");
+
+  const [result2, errInfo2] = libdeno.eval("throw 1");
+  assert(!result2);
+  assert(!!errInfo2);
+  assert(!errInfo2.isNativeError); // is NOT a native error
+  assert(!errInfo2.isCompileError); // is NOT a compilation error
+  assert(errInfo2.thrown === 1);
+
+  const [result3, errInfo3] =
+    libdeno.eval("class AError extends Error {}; throw new AError('e')");
+  assert(!result3);
+  assert(!!errInfo3);
+  assert(errInfo3.isNativeError); // extend from native error, still native error
+  assert(!errInfo3.isCompileError); // is NOT a compilation error
+  assert(errInfo3.thrown.message === "Error: e");
+
+  const [result4, errInfo4] = libdeno.eval("{");
+  assert(!result4);
+  assert(!!errInfo4);
+  assert(errInfo4.isNativeError); // is a native error (SyntaxError)
+  assert(errInfo4.isCompileError); // is a compilation error! (braces not closed)
+  assert(errInfo4.thrown.message === "SyntaxError: Unexpected end of input");
+
+  const [result5, errInfo5] = libdeno.eval("eval('{')");
+  assert(!result5);
+  assert(!!errInfo5);
+  assert(errInfo5.isNativeError); // is a native error (SyntaxError)
+  assert(!errInfo5.isCompileError); // is NOT a compilation error! (just eval)
+  assert(errInfo5.thrown.message === "SyntaxError: Unexpected end of input");
+};

--- a/tools/repl_test.py
+++ b/tools/repl_test.py
@@ -115,6 +115,12 @@ class Repl(object):
         assertEqual(err, '')
         assertEqual(code, 0)
 
+    def test_lexical_scoped_variable(self):
+        out, err, code = self.input("let a = 123;", "a")
+        assertEqual(out, 'undefined\n123\n')
+        assertEqual(err, '')
+        assertEqual(code, 0)
+
 
 def assertEqual(left, right):
     if left != right:


### PR DESCRIPTION
Closes #1159 

This is a simplified version of #1334 which works well
```
$ ./target/debug/deno
> a
ReferenceError: a is not defined
> let a = 1
undefined
> a += 1
2
> const b = 2
undefined
> b += 1
TypeError: Assignment to constant variable.
> throw new Error("Hello")
Error: Hello
> throw {}
Thrown: {}
```

(If this looks fine, would be great to be included in v0.2.4)