### PR TITLE
fix `FormData` name

### DIFF
--- a/js/form_data.ts
+++ b/js/form_data.ts
@@ -100,8 +100,8 @@ class FormDataBase {
 }
 
 // tslint:disable-next-line:variable-name
-export const FormData = DomIterableMixin<
+export class FormData extends DomIterableMixin<
   string,
   domTypes.FormDataEntryValue,
   typeof FormDataBase
->(FormDataBase, dataSymbol);
+>(FormDataBase, dataSymbol) {}

--- a/js/form_data_test.ts
+++ b/js/form_data_test.ts
@@ -1,6 +1,10 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 import { test, assert, assertEqual } from "./test_util.ts";
 
+test(function formDataHasCorrectNameProp() {
+  assertEqual(FormData.name, "FormData");
+});
+
 test(function formDataParamsAppendSuccess() {
   const formData = new FormData();
   formData.append("a", "true");


### PR DESCRIPTION
in repl:

```js
> FormData.name
FormDataBase
> new FormData
FormDataBase {}
```

----------

`FormData` is exported with [an assignment statement](https://github.com/denoland/deno/blob/c6e2fffc1388cdb4411d6c2cff36c4febb7c75d5/js/form_data.ts#L102-L107), it causes the wrong `name` in `DomIterableMixin`.

https://github.com/denoland/deno/blob/c6e2fffc1388cdb4411d6c2cff36c4febb7c75d5/js/mixins/dom_iterable.ts#L68-L72

--------

In `Headers`, the name is correct, it uses inheritance instead of assignment. https://github.com/denoland/deno/blob/c6e2fffc1388cdb4411d6c2cff36c4febb7c75d5/js/headers.ts#L113-L119