### PR TITLE
Fix test of unbuffered_stderr

### DIFF
--- a/tests/unbuffered_stderr.ts.out
+++ b/tests/unbuffered_stderr.ts.out
@@ -1,1 +1,2 @@
-[WILDCARD]x
+Compiling [WILDCARD].ts
+x


### PR DESCRIPTION
As reported in gitter, if the path of working directory includes `x`, the `[WILDCARD]x` matches to unexpected part of output and the test fails.

This changes the matching pattern to more specific one.
