### PR TITLE
Better REPL multiline support

### DIFF
--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -9,6 +9,12 @@ export type PromiseRejectEvent =
   | "ResolveAfterResolved"
   | "RejectAfterResolved";
 
+interface EvalErrorInfo {
+  isNativeError: boolean;
+  isCompileError: boolean;
+  thrown: any; // tslint:disable-line:no-any
+}
+
 interface Libdeno {
   recv(cb: MessageCallback): void;
 
@@ -19,7 +25,7 @@ interface Libdeno {
   shared: ArrayBuffer;
 
   /* tslint:disable-next-line:no-any */
-  eval(code: string): any[];
+  eval(code: string): [any, EvalErrorInfo | null];
 
   setGlobalErrorHandler: (
     handler: (

--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -18,6 +18,9 @@ interface Libdeno {
 
   shared: ArrayBuffer;
 
+  /* tslint:disable-next-line:no-any */
+  eval(code: string): any[];
+
   setGlobalErrorHandler: (
     handler: (
       message: string,

--- a/js/repl.ts
+++ b/js/repl.ts
@@ -85,14 +85,15 @@ export async function replLoop(): Promise<void> {
 function evaluate(code: string): void {
   try {
     // TODO: use sandbox in the future
-    const [result, err, isNativeError] = libdeno.eval(code);
-    if (err === null) {
+    const [result, errInfo] = libdeno.eval(code);
+    if (!errInfo) {
       console.log(result);
     } else {
-      if (isNativeError) {
-        console.error(err.message);
+      if (errInfo.isNativeError) {
+        console.error((errInfo.thrown as Error).message);
       } else {
-        console.error("Thrown:", err);
+        // TODO: make Node-like multiline support a separate PR
+        console.error("Thrown:", errInfo.thrown);
       }
     }
   } catch (err) {

--- a/js/repl.ts
+++ b/js/repl.ts
@@ -70,7 +70,7 @@ export async function replLoop(): Promise<void> {
       }
       while (!evaluate(code)) {
         code += "\n";
-        code += await readline(rid, "... ");
+        code += await readline(rid, "  ");
       }
     } catch (err) {
       if (err.message === "EOF") {

--- a/js/repl.ts
+++ b/js/repl.ts
@@ -7,6 +7,7 @@ import { close } from "./files";
 import * as dispatch from "./dispatch";
 import { exit } from "./os";
 import { globalEval } from "./global_eval";
+import { libdeno } from "./libdeno";
 
 const window = globalEval("this");
 
@@ -83,8 +84,17 @@ export async function replLoop(): Promise<void> {
 
 function evaluate(code: string): void {
   try {
-    const result = eval.call(window, code); // FIXME use a new scope.
-    console.log(result);
+    // TODO: use sandbox in the future
+    const [result, err, isNativeError] = libdeno.eval(code);
+    if (err === null) {
+      console.log(result);
+    } else {
+      if (isNativeError) {
+        console.error(err.message);
+      } else {
+        console.error("Thrown:", err);
+      }
+    }
   } catch (err) {
     if (err instanceof Error) {
       console.error(`${err.constructor.name}: ${err.message}`);

--- a/js/repl.ts
+++ b/js/repl.ts
@@ -69,6 +69,7 @@ export async function replLoop(): Promise<void> {
         break;
       }
       while (!evaluate(code)) {
+        code += "\n";
         code += await readline(rid, "... ");
       }
     } catch (err) {

--- a/libdeno/internal.h
+++ b/libdeno/internal.h
@@ -59,6 +59,7 @@ class DenoIsolate {
   v8::StartupData snapshot_;
   v8::Persistent<v8::ArrayBuffer> global_import_buf_;
   v8::Persistent<v8::ArrayBuffer> shared_ab_;
+  v8::Persistent<v8::Context> repl_context_;
 };
 
 class UserDataScope {
@@ -88,9 +89,14 @@ void Recv(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Send(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Shared(v8::Local<v8::Name> property,
             const v8::PropertyCallbackInfo<v8::Value>& info);
+void ExecuteInThisContext(const v8::FunctionCallbackInfo<v8::Value>& args);
 static intptr_t external_references[] = {
-    reinterpret_cast<intptr_t>(Print), reinterpret_cast<intptr_t>(Recv),
-    reinterpret_cast<intptr_t>(Send), reinterpret_cast<intptr_t>(Shared), 0};
+    reinterpret_cast<intptr_t>(Print),
+    reinterpret_cast<intptr_t>(Recv),
+    reinterpret_cast<intptr_t>(Send),
+    reinterpret_cast<intptr_t>(Shared),
+    reinterpret_cast<intptr_t>(ExecuteInThisContext),
+    0};
 
 static const deno_buf empty_buf = {nullptr, 0, nullptr, 0};
 

--- a/libdeno/internal.h
+++ b/libdeno/internal.h
@@ -89,14 +89,11 @@ void Recv(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Send(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Shared(v8::Local<v8::Name> property,
             const v8::PropertyCallbackInfo<v8::Value>& info);
-void ExecuteInThisContext(const v8::FunctionCallbackInfo<v8::Value>& args);
+void Eval(const v8::FunctionCallbackInfo<v8::Value>& args);
 static intptr_t external_references[] = {
-    reinterpret_cast<intptr_t>(Print),
-    reinterpret_cast<intptr_t>(Recv),
-    reinterpret_cast<intptr_t>(Send),
-    reinterpret_cast<intptr_t>(Shared),
-    reinterpret_cast<intptr_t>(ExecuteInThisContext),
-    0};
+    reinterpret_cast<intptr_t>(Print), reinterpret_cast<intptr_t>(Recv),
+    reinterpret_cast<intptr_t>(Send),  reinterpret_cast<intptr_t>(Shared),
+    reinterpret_cast<intptr_t>(Eval),  0};
 
 static const deno_buf empty_buf = {nullptr, 0, nullptr, 0};
 

--- a/libdeno/libdeno_test.cc
+++ b/libdeno/libdeno_test.cc
@@ -253,14 +253,14 @@ TEST(LibDenoTest, Shared) {
   deno_delete(d);
 }
 
-TEST(LibDenoTest, ExecuteInThisContext) {
+TEST(LibDenoTest, LibDenoEval) {
   Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
-  EXPECT_TRUE(deno_execute(d, nullptr, "a.js", "ExecuteInThisContext();"));
+  EXPECT_TRUE(deno_execute(d, nullptr, "a.js", "LibDenoEval();"));
   deno_delete(d);
 }
 
-TEST(LibDenoTest, ExecuteInThisContextError) {
+TEST(LibDenoTest, LibDenoEvalError) {
   Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
-  EXPECT_TRUE(deno_execute(d, nullptr, "a.js", "ExecuteInThisContextError();"));
+  EXPECT_TRUE(deno_execute(d, nullptr, "a.js", "LibDenoEvalError();"));
   deno_delete(d);
 }

--- a/libdeno/libdeno_test.cc
+++ b/libdeno/libdeno_test.cc
@@ -252,3 +252,15 @@ TEST(LibDenoTest, Shared) {
   EXPECT_EQ(s[2], 44);
   deno_delete(d);
 }
+
+TEST(LibDenoTest, ExecuteInThisContext) {
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
+  EXPECT_TRUE(deno_execute(d, nullptr, "a.js", "ExecuteInThisContext();"));
+  deno_delete(d);
+}
+
+TEST(LibDenoTest, ExecuteInThisContextError) {
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
+  EXPECT_TRUE(deno_execute(d, nullptr, "a.js", "ExecuteInThisContextError();"));
+  deno_delete(d);
+}

--- a/libdeno/libdeno_test.js
+++ b/libdeno/libdeno_test.js
@@ -146,3 +146,34 @@ global.Shared = () => {
   ui8[1] = 43;
   ui8[2] = 44;
 };
+
+global.ExecuteInThisContext = () => {
+  const [result, err] = libdeno.eval("let a = 1; a");
+  assert(result === 1);
+  assert(!err);
+  const [result2, err2] = libdeno.eval("a = a + 1; a");
+  assert(result2 === 2);
+  assert(!err2);
+};
+
+global.ExecuteInThisContextError = () => {
+  const [result, err, isNativeError] = libdeno.eval("not_a_variable");
+  assert(!result);
+  assert(!!err);
+  assert(err.message === "ReferenceError: not_a_variable is not defined");
+  assert(isNativeError);
+
+  const [result2, err2, isNativeError2] = libdeno.eval("throw 1");
+  assert(!result2);
+  assert(!!err2);
+  console.log(err2);
+  assert(err2 === 1);
+  assert(!isNativeError2); // not a native error
+
+  const [result3, err3, isNativeError3] =
+    libdeno.eval("class AError extends Error {}; throw new AError('e')");
+  assert(!result3);
+  assert(!!err3);
+  assert(err3.message === "Error: e");
+  assert(isNativeError3); // extend from native error, still native error
+};

--- a/tools/repl_test.py
+++ b/tools/repl_test.py
@@ -77,6 +77,11 @@ class Repl(object):
         assertEqual(out, '')
         assertEqual(err, 'SyntaxError: Unexpected end of input\n')
         assertEqual(code, 0)
+        # ensure '{' is not mistakenly recognized...
+        out, err, code = self.input("'{'")
+        assertEqual(out, '{\n')
+        assertEqual(err, '')
+        assertEqual(code, 0)
 
     def test_reference_error(self):
         out, err, code = self.input("not_a_variable")

--- a/tools/repl_test.py
+++ b/tools/repl_test.py
@@ -115,6 +115,12 @@ class Repl(object):
         assertEqual(err, '')
         assertEqual(code, 0)
 
+    def test_lexical_scoped_variable(self):
+        out, err, code = self.input("let a = 123;", "a")
+        assertEqual(out, 'undefined\n123\n')
+        assertEqual(err, '')
+        assertEqual(code, 0)
+
 
 def assertEqual(left, right):
     if left != right:

--- a/tools/repl_test.py
+++ b/tools/repl_test.py
@@ -72,6 +72,11 @@ class Repl(object):
         assertEqual(out, '3\n')
         assertEqual(err, '')
         assertEqual(code, 0)
+        # ensure eval("{") is not mistakenly recognized...
+        out, err, code = self.input("eval('{')")
+        assertEqual(out, '')
+        assertEqual(err, 'SyntaxError: Unexpected end of input\n')
+        assertEqual(code, 0)
 
     def test_reference_error(self):
         out, err, code = self.input("not_a_variable")


### PR DESCRIPTION
__This is built on top of #1407__

This PR uses compilation SyntaxError for multiline support. This is similar to the Node approach.
Before:
```
> if (true) {
  console.log('Hi')
  }
Hi
undefined
> eval("{")
SyntaxError: Unexpected end of input
> "{"
  "}"
SyntaxError: Unexpected string
>
```
After:
```
> if (true) {
... console.log('Hi')
... }
Hi
undefined
> eval("{")
SyntaxError: Unexpected end of input
> "{"
{
> "}"
}
>
```