### PR TITLE
make `Headers` follow spec

### DIFF
--- a/js/headers.ts
+++ b/js/headers.ts
@@ -31,10 +31,11 @@ class HeadersBase {
   // https://github.com/bitinn/node-fetch/blob/master/src/headers.js
   // Copyright (c) 2016 David Frank. MIT License.
   private _validateName(name: string) {
-    if (invalidTokenRegex.test(name)) {
+    if (invalidTokenRegex.test(name) || name === "") {
       throw new TypeError(`${name} is not a legal HTTP header name`);
     }
   }
+
   private _validateValue(value: string) {
     if (invalidHeaderCharRegex.test(value)) {
       throw new TypeError(`${value} is not a legal HTTP header value`);

--- a/js/headers.ts
+++ b/js/headers.ts
@@ -51,8 +51,17 @@ class HeadersBase {
     } else {
       this[headerMap] = new Map();
       if (Array.isArray(init)) {
-        for (const [rawName, rawValue] of init) {
-          const [name, value] = this._normalizeParams(rawName, rawValue);
+        for (const tuple of init) {
+          // If header does not contain exactly two items,
+          // then throw a TypeError.
+          // ref: https://fetch.spec.whatwg.org/#concept-headers-fill
+          if (tuple.length !== 2) {
+            // tslint:disable:max-line-length
+            // prettier-ignore
+            throw new TypeError("Failed to construct 'Headers'; Each header pair must be an iterable [name, value] tuple");
+          }
+
+          const [name, value] = this._normalizeParams(tuple[0], tuple[1]);
           this._validateName(name);
           this._validateValue(value);
           const existingValue = this[headerMap].get(name);

--- a/js/headers_test.ts
+++ b/js/headers_test.ts
@@ -224,7 +224,12 @@ test(function headerIllegalReject() {
   } catch (e) {
     errorCount++;
   }
-  assertEqual(errorCount, 8);
+  try {
+    headers.set("", "ok");
+  } catch (e) {
+    errorCount++;
+  }
+  assertEqual(errorCount, 9);
   // 'o k' is valid value but invalid name
   new Headers({ "He-y": "o k" });
 });

--- a/js/headers_test.ts
+++ b/js/headers_test.ts
@@ -229,6 +229,24 @@ test(function headerIllegalReject() {
   new Headers({ "He-y": "o k" });
 });
 
+// If pair does not contain exactly two items,then throw a TypeError.
+test(function headerParamsShouldThrowTypeError() {
+  let hasThrown = 0;
+
+  try {
+    new Headers([["1"]]);
+    hasThrown = 1;
+  } catch (err) {
+    if (err instanceof TypeError) {
+      hasThrown = 2;
+    } else {
+      hasThrown = 3;
+    }
+  }
+
+  assertEqual(hasThrown, 2);
+});
+
 test(function headerParamsArgumentsCheck() {
   const methodRequireOneParam = ["delete", "get", "has", "forEach"];
 

--- a/js/headers_test.ts
+++ b/js/headers_test.ts
@@ -239,7 +239,7 @@ test(function headerParamsShouldThrowTypeError() {
   let hasThrown = 0;
 
   try {
-    new Headers([["1"]]);
+    new Headers(([["1"]] as unknown) as Array<[string, string]>);
     hasThrown = 1;
   } catch (err) {
     if (err instanceof TypeError) {


### PR DESCRIPTION
make `Headers` follow spec.

## 1. constructor with array

https://fetch.spec.whatwg.org/#concept-headers-fill

> If header does not contain exactly two items, then throw a TypeError.

When the element in a two-dimensional array is not exactly  two, throw a TypeError.

**Browser Compatibility:**

Firefox:

```js
new Headers([[]])
// TypeError: Headers require name/value tuples when being initialized by a sequence.

new Headers([['foo']])
// TypeError: Headers require name/value tuples when being initialized by a sequence. 

new Headers([['foo', 'bar']])
// Headers {  }

new Headers([['foo', 'bar', 'hello']])
// TypeError: Headers require name/value tuples when being initialized by a sequence.
```

Chrome:

```js
new Headers([[]])
// TypeError: Failed to construct 'Headers': Invalid value

new Headers([['foo']])
// TypeError: Failed to construct 'Headers': Invalid value

new Headers([['foo', 'bar']])
// Headers {}

new Headers([['foo', 'bar', 'hello']])
// TypeError: Failed to construct 'Headers': Invalid value
```

## 2. header-name can not by empty string

https://tools.ietf.org/html/rfc7230#section-3.2

```
header-field   = field-name ":" OWS field-value OWS

field-name     = token
field-value    = *( field-content / obs-fold )
field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
field-vchar    = VCHAR / obs-text

obs-fold       = CRLF 1*( SP / HTAB )
               ; obsolete line folding
               ; see Section 3.2.4
```

**Browser Compatibility:**

Firefox:

```js
let headers = new Headers();
headers.set('', 'foo');  // TypeError:  is an invalid header name.
```

Chrome:

```js
let headers = new Headers();
headers.set('', 'foo');  // TypeError: Failed to execute 'set' on 'Headers': Invalid name
```

