### PR TITLE
print string with NULL '\0'

### DIFF
--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -205,7 +205,6 @@ void Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::String::Utf8Value str(isolate, args[0]);
   bool is_err =
       args.Length() >= 2 ? args[1]->BooleanValue(context).ToChecked() : false;
-  // const char* cstr = ToCString(str);
   FILE* file = is_err ? stderr : stdout;
   fwrite(*str, sizeof(**str), str.length(), file);
   fprintf(file, "\n");

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -209,6 +209,7 @@ void Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
   FILE* file = is_err ? stderr : stdout;
   fwrite(*str, sizeof(**str), str.length(), file);
   fprintf(file, "\n");
+  fflush(file);
 }
 
 v8::Local<v8::Uint8Array> ImportBuf(DenoIsolate* d, deno_buf buf) {

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -205,9 +205,10 @@ void Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::String::Utf8Value str(isolate, args[0]);
   bool is_err =
       args.Length() >= 2 ? args[1]->BooleanValue(context).ToChecked() : false;
-  const char* cstr = ToCString(str);
-  auto& stream = is_err ? std::cerr : std::cout;
-  stream << cstr << std::endl;
+  // const char* cstr = ToCString(str);
+  FILE* file = is_err ? stderr : stdout;
+  fwrite(*str, sizeof(**str), str.length(), file);
+  fprintf(file, "\n");
 }
 
 v8::Local<v8::Uint8Array> ImportBuf(DenoIsolate* d, deno_buf buf) {


### PR DESCRIPTION
The current deno does not correctly output a string containing a null '\0' character.

```js
> str = "foo\0bar";
foo
> str.length 
7
> console.log('foo\0bar')
foo
```

when output a string, deno converts the js-string to a C-string: `const char* cstr = ToCString(str)`. the C-string is an array of characters terminated by `NULL` character `'\0'`, but js-string did not. when we output a js-string, we can NOT convert it to c-string.

Firefox:

```js
console.log('foo\0bar');    // foo�bar
```

Chrome:

```js
console.log('foo\0bar');    // foo bar
```

Node.js

```js
console.log('foo\0bar');    // foo bar
```
