### PR TITLE
Fix test js_error_apply_source_map_2

### DIFF
--- a/src/js_errors.rs
+++ b/src/js_errors.rs
@@ -518,7 +518,7 @@ mod tests {
     assert_eq!(actual.frames.len(), 1);
     assert_eq!(actual.frames[0].line, 15);
     assert_eq!(actual.frames[0].column, 16);
-    assert_eq!(actual.frames[0].script_name, "deno/js/util.ts");
+    assert!(actual.frames[0].script_name.ends_with("js/util.ts"));
   }
 
   #[test]


### PR DESCRIPTION
If the project is checked out into a directory not called "deno" this
test fails.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
