### PR TITLE
Add -glldb to clang flags for libdeno

### DIFF
--- a/libdeno/BUILD.gn
+++ b/libdeno/BUILD.gn
@@ -15,6 +15,7 @@ config("deno_config") {
     cflags += [
       "-fcolor-diagnostics",
       "-fansi-escape-codes",
+      "-glldb",
     ]
   }
 

--- a/libdeno/BUILD.gn
+++ b/libdeno/BUILD.gn
@@ -15,8 +15,10 @@ config("deno_config") {
     cflags += [
       "-fcolor-diagnostics",
       "-fansi-escape-codes",
-      "-glldb",
     ]
+    if (is_debug) {
+      cflags += [ "-glldb" ]
+    }
   }
 
   if (is_win) {


### PR DESCRIPTION
Closes #1445 

For example, in `deno_new`, before:
```
Target 0: (deno) stopped.
(lldb) fr v
(lldb) fr v d
error: no variable named 'd' found in this frame
(lldb) ta v
error: no debug information for frame 0
```
After:
```
(lldb) fr v
(deno_config) config = {
  will_snapshot = 0
  load_snapshot = (alloc_ptr = 0x0000000000000000, alloc_len = 0, data_ptr = "\x01", data_len = 19512816)
  shared = (alloc_ptr = 0x0000000000000000, alloc_len = 0, data_ptr = 0x0000000000000000, data_len = 0)
  recv_cb = 0x0000000101dc2280 (deno`deno_bin::isolate::pre_dispatch::hfd6312a487ade99e at isolate.rs:319)
}
(v8::Isolate::CreateParams) params = {
  entry_hook = 0x0000000000000000
  code_event_handler = 0x0000000000000000
  constraints = {
    max_semi_space_size_in_kb_ = 0
    max_old_space_size_ = 0
    max_executable_size_ = 4385243184
    stack_limit_ = 0x0000000000000000
    code_range_size_ = 0
    max_zone_pool_size_ = 0
  }
  snapshot_blob = 0x000000010510b858
  counter_lookup_callback = 0x0000000000000000
  create_histogram_callback = 0x0000000000000000
  add_histogram_sample_callback = 0x0000000000000000
  array_buffer_allocator = 0x000000010510b880
  external_references = 0x00000001037ac980
  allow_atomics_wait = true
  only_terminate_in_safe_scope = false
}
(v8::Locker) locker = (has_lock_ = true, top_level_ = true, isolate_ = 0x0000000000000020)
(deno::DenoIsolate *) d = 0x000000010510b7a0
(v8::Isolate *) isolate = 0x0000000106000000
(v8::Isolate::Scope) isolate_scope = (isolate_ = 0x0000000106000000)
(lldb) fr v d
(deno::DenoIsolate *) d = 0x000000010510b7a0
(lldb) ta v
Global variables for /Users/kevinqian/Desktop/Programming/Deno/deno/target/debug/gen/libdeno/libdeno_jumbo_1.cc in ./target/debug/deno:
(const std::__1::piecewise_construct_t) std::__1::piecewise_construct = {}
(const int) kApiSystemPointerSize = 8
(std::__1::vector<deno::InternalFieldData *, std::__1::allocator<deno::InternalFieldData *> >) deno::deserialized_data = size=0 {}
(intptr_t [6]) deno::external_references = ([0] = 4295652208, [1] = 4295652688, [2] = 4295653168, [3] = 4295654512, [4] = 4295655392, [5] = 0)
```