### PR TITLE
Revert "use byte array instead of string for code fetch (#1307)"

### DIFF
--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -233,7 +233,6 @@ export class Compiler
       // We query Rust with a CodeFetch message. It will load the sourceCode,
       // and if there is any outputCode cached, will return that as well.
       const fetchResponse = this._os.codeFetch(moduleSpecifier, containingFile);
-      assert(fetchResponse != null, "fetchResponse is null");
       moduleId = fetchResponse.moduleName;
       fileName = fetchResponse.filename;
       mediaType = fetchResponse.mediaType;

--- a/js/os.ts
+++ b/js/os.ts
@@ -4,7 +4,6 @@ import { assert } from "./util";
 import * as util from "./util";
 import * as flatbuffers from "./flatbuffers";
 import { sendSync } from "./dispatch";
-import { TextDecoder } from "./text_encoding";
 
 interface CodeInfo {
   moduleName: string | undefined;
@@ -46,17 +45,13 @@ export function codeFetch(specifier: string, referrer: string): CodeInfo {
   assert(baseRes!.inner(codeFetchRes) != null);
   // flatbuffers returns `null` for an empty value, this does not fit well with
   // idiomatic TypeScript under strict null checks, so converting to `undefined`
-  const sourceCode = codeFetchRes.sourceCodeArray() || undefined;
-  const outputCode = codeFetchRes.outputCodeArray() || undefined;
-  const sourceMap = codeFetchRes.sourceMapArray() || undefined;
-  const decoder = new TextDecoder();
   return {
     moduleName: codeFetchRes.moduleName() || undefined,
     filename: codeFetchRes.filename() || undefined,
     mediaType: codeFetchRes.mediaType(),
-    sourceCode: sourceCode && decoder.decode(sourceCode),
-    outputCode: outputCode && decoder.decode(outputCode),
-    sourceMap: sourceMap && decoder.decode(sourceMap)
+    sourceCode: codeFetchRes.sourceCode() || undefined,
+    outputCode: codeFetchRes.outputCode() || undefined,
+    sourceMap: codeFetchRes.sourceMap() || undefined
   };
 }
 

--- a/src/http_util.rs
+++ b/src/http_util.rs
@@ -55,7 +55,7 @@ fn resolve_uri_from_location(base_uri: &Uri, location: &str) -> Uri {
 
 // The CodeFetch message is used to load HTTP javascript resources and expects a
 // synchronous response, this utility method supports that.
-pub fn fetch_sync_string(module_name: &str) -> DenoResult<(Vec<u8>, String)> {
+pub fn fetch_sync_string(module_name: &str) -> DenoResult<(String, String)> {
   let url = module_name.parse::<Uri>().unwrap();
   let client = get_client();
   // TODO(kevinkassimo): consider set a max redirection counter
@@ -93,11 +93,11 @@ pub fn fetch_sync_string(module_name: &str) -> DenoResult<(Vec<u8>, String)> {
     let body = response
       .into_body()
       .concat2()
-      .map(|body| body.to_vec())
+      .map(|body| String::from_utf8(body.to_vec()).unwrap())
       .map_err(DenoError::from);
     body.join(future::ok(content_type))
-  }).and_then(|(body_bytes, maybe_content_type)| {
-    future::ok((body_bytes, maybe_content_type.unwrap()))
+  }).and_then(|(body_string, maybe_content_type)| {
+    future::ok((body_string, maybe_content_type.unwrap()))
   });
 
   tokio_util::block_on(fetch_future)

--- a/src/js_errors.rs
+++ b/src/js_errors.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 
 pub trait SourceMapGetter {
   /// Returns the raw source map file.
-  fn get_source_map(&self, script_name: &str) -> Option<Vec<u8>>;
+  fn get_source_map(&self, script_name: &str) -> Option<String>;
 }
 
 struct SourceMap {
@@ -287,9 +287,7 @@ fn parse_map_string(
     }
     _ => match getter.get_source_map(script_name) {
       None => None,
-      Some(raw_source_map) => SourceMap::from_json(
-        &String::from_utf8(raw_source_map).expect("SourceMap is not utf-8"),
-      ),
+      Some(raw_source_map) => SourceMap::from_json(&raw_source_map),
     },
   }
 }
@@ -346,13 +344,13 @@ mod tests {
   struct MockSourceMapGetter {}
 
   impl SourceMapGetter for MockSourceMapGetter {
-    fn get_source_map(&self, script_name: &str) -> Option<Vec<u8>> {
-      let s: &[u8] = match script_name {
-        "foo_bar.ts" => br#"{"sources": ["foo_bar.ts"], "mappings":";;;IAIA,OAAO,CAAC,GAAG,CAAC,qBAAqB,EAAE,EAAE,CAAC,OAAO,CAAC,CAAC;IAC/C,OAAO,CAAC,GAAG,CAAC,eAAe,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,WAAW,EAAE,IAAI,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAE3C,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC"}"#,
-        "bar_baz.ts" => br#"{"sources": ["bar_baz.ts"], "mappings":";;;IAEA,CAAC,KAAK,IAAI,EAAE;QACV,MAAM,GAAG,GAAG,sDAAa,OAAO,2BAAC,CAAC;QAClC,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;IACnB,CAAC,CAAC,EAAE,CAAC;IAEQ,QAAA,GAAG,GAAG,KAAK,CAAC;IAEzB,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC"}"#,
+    fn get_source_map(&self, script_name: &str) -> Option<String> {
+      let s = match script_name {
+        "foo_bar.ts" => r#"{"sources": ["foo_bar.ts"], "mappings":";;;IAIA,OAAO,CAAC,GAAG,CAAC,qBAAqB,EAAE,EAAE,CAAC,OAAO,CAAC,CAAC;IAC/C,OAAO,CAAC,GAAG,CAAC,eAAe,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,WAAW,EAAE,IAAI,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAE3C,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC"}"#,
+        "bar_baz.ts" => r#"{"sources": ["bar_baz.ts"], "mappings":";;;IAEA,CAAC,KAAK,IAAI,EAAE;QACV,MAAM,GAAG,GAAG,sDAAa,OAAO,2BAAC,CAAC;QAClC,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;IACnB,CAAC,CAAC,EAAE,CAAC;IAEQ,QAAA,GAAG,GAAG,KAAK,CAAC;IAEzB,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC"}"#,
         _ => return None,
       };
-      Some(s.to_vec())
+      Some(s.to_string())
     }
   }
 

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -160,16 +160,18 @@ table CodeFetchRes {
   module_name: string;
   filename: string;
   media_type: MediaType;
-  source_code: [ubyte];
-  output_code: [ubyte]; // Non-empty only if cached.
-  source_map: [ubyte]; // Non-empty only if cached.
+  // TODO These should be [ubyte].
+  // See: https://github.com/denoland/deno/issues/1113
+  source_code: string;
+  output_code: string; // Non-empty only if cached.
+  source_map: string; // Non-empty only if cached.
 }
 
 table CodeCache {
   filename: string;
-  source_code: [ubyte];
-  output_code: [ubyte];
-  source_map: [ubyte];
+  source_code: string;
+  output_code: string;
+  source_map: string;
 }
 
 table Chdir {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -268,14 +268,14 @@ fn op_code_fetch(
       module_name: Some(builder.create_string(&out.module_name)),
       filename: Some(builder.create_string(&out.filename)),
       media_type: out.media_type,
-      source_code: Some(builder.create_vector(&out.source_code)),
+      source_code: Some(builder.create_string(&out.source_code)),
       ..Default::default()
     };
     if let Some(ref output_code) = out.maybe_output_code {
-      msg_args.output_code = Some(builder.create_vector(output_code));
+      msg_args.output_code = Some(builder.create_string(output_code));
     }
     if let Some(ref source_map) = out.maybe_source_map {
-      msg_args.source_map = Some(builder.create_vector(source_map));
+      msg_args.source_map = Some(builder.create_string(source_map));
     }
     let inner = msg::CodeFetchRes::create(builder, &msg_args);
     Ok(serialize_response(
@@ -305,7 +305,7 @@ fn op_code_cache(
   Box::new(futures::future::result(|| -> OpResult {
     state
       .dir
-      .code_cache(filename, &source_code, &output_code, &source_map)?;
+      .code_cache(filename, source_code, output_code, source_map)?;
     Ok(empty_buf())
   }()))
 }


### PR DESCRIPTION
This reverts commit e976b3e0414dc768624b77e431ee7f55b03b76a4.

There is nothing technically wrong with this commit, but it's adding
complexity to a big refactor (native ES modules #975). Since it's not
necessary and simply a philosophical preference, I will revert for now
and try to bring it back later.

cc @F001 
ref https://github.com/denoland/deno/issues/1307