### PR TITLE
Add libdeno.builtinModules

### DIFF
--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -18,6 +18,8 @@ interface Libdeno {
 
   shared: ArrayBuffer;
 
+  builtinModules: { [s: string]: object };
+
   setGlobalErrorHandler: (
     handler: (
       message: string,

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -323,6 +323,23 @@ void Send(const v8::FunctionCallbackInfo<v8::Value>& args) {
   }
 }
 
+v8::Local<v8::Object> DenoIsolate::GetBuiltinModules() {
+  v8::EscapableHandleScope handle_scope(isolate_);
+  if (builtin_modules_.IsEmpty()) {
+    builtin_modules_.Reset(isolate_, v8::Object::New(isolate_));
+  }
+  return handle_scope.Escape(builtin_modules_.Get(isolate_));
+}
+
+void BuiltinModules(v8::Local<v8::Name> property,
+                    const v8::PropertyCallbackInfo<v8::Value>& info) {
+  v8::Isolate* isolate = info.GetIsolate();
+  DenoIsolate* d = FromIsolate(isolate);
+  DCHECK_EQ(d->isolate_, isolate);
+  v8::Locker locker(d->isolate_);
+  info.GetReturnValue().Set(d->GetBuiltinModules());
+}
+
 void Shared(v8::Local<v8::Name> property,
             const v8::PropertyCallbackInfo<v8::Value>& info) {
   v8::Isolate* isolate = info.GetIsolate();
@@ -408,6 +425,44 @@ v8::MaybeLocal<v8::Module> ResolveCallback(v8::Local<v8::Context> context,
   v8::EscapableHandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(context);
 
+  v8::String::Utf8Value specifier_utf8val(isolate, specifier);
+  const char* specifier_cstr = ToCString(specifier_utf8val);
+
+  auto builtin_modules = d->GetBuiltinModules();
+  bool has_builtin = builtin_modules->Has(context, specifier).ToChecked();
+
+  // printf("has_builtin %s %d\n", specifier_cstr, has_builtin);
+  if (has_builtin) {
+    auto val = builtin_modules->Get(context, specifier).ToLocalChecked();
+    CHECK(val->IsObject());
+    auto obj = val->ToObject(isolate);
+
+    std::string src = "let globalEval = eval\nlet g = globalEval('this');\n";
+    auto names = obj->GetOwnPropertyNames(context).ToLocalChecked();
+    for (uint32_t i = 0; i < names->Length(); i++) {
+      auto name = names->Get(context, i).ToLocalChecked();
+      v8::String::Utf8Value name_utf8val(isolate, name);
+      const char* name_cstr = ToCString(name_utf8val);
+      // TODO use format string.
+      src.append("export const ");
+      src.append(name_cstr);
+      src.append(" = g.libdeno.builtinModules.");
+      src.append(specifier_cstr);
+      src.append(".");
+      src.append(name_cstr);
+      src.append(";\n");
+    }
+
+    // printf("src\n####\n%s\n###\n", src.c_str());
+    auto src_ = v8_str(src.c_str(), true);
+
+    auto module = CompileModule(context, specifier_cstr, src_).ToLocalChecked();
+    auto maybe_ok = module->InstantiateModule(context, ResolveCallback);
+    CHECK(!maybe_ok.IsNothing());
+
+    return handle_scope.Escape(module);
+  }
+
   int ref_id = referrer->GetIdentityHash();
   std::string referrer_filename = d->module_filename_map_[ref_id];
 
@@ -431,6 +486,7 @@ v8::MaybeLocal<v8::Module> ResolveCallback(v8::Local<v8::Context> context,
 void DenoIsolate::ResolveOk(const char* filename, const char* source) {
   CHECK(resolve_module_.IsEmpty());
   auto count = module_map_.count(filename);
+  // printf("DenoIsolate::ResolveOk <<%s>> <<%s>>\n", filename, source);
   if (count == 1) {
     auto module = module_map_[filename].Get(isolate_);
     resolve_module_.Reset(isolate_, module);
@@ -439,7 +495,7 @@ void DenoIsolate::ResolveOk(const char* filename, const char* source) {
     v8::HandleScope handle_scope(isolate_);
     auto context = context_.Get(isolate_);
     v8::TryCatch try_catch(isolate_);
-    auto maybe_module = CompileModule(context, filename, v8_str(source));
+    auto maybe_module = CompileModule(context, filename, v8_str(source, true));
     if (maybe_module.IsEmpty()) {
       DCHECK(try_catch.HasCaught());
       HandleException(context, try_catch.Exception());
@@ -545,6 +601,11 @@ void InitializeContext(v8::Isolate* isolate, v8::Local<v8::Context> context) {
 
   CHECK(deno_val->SetAccessor(context, deno::v8_str("shared"), Shared)
             .FromJust());
+
+  CHECK(
+      deno_val
+          ->SetAccessor(context, deno::v8_str("builtinModules"), BuiltinModules)
+          .FromJust());
 }
 
 void DenoIsolate::AddIsolate(v8::Isolate* isolate) {

--- a/libdeno/internal.h
+++ b/libdeno/internal.h
@@ -45,6 +45,8 @@ class DenoIsolate {
   void ResolveOk(const char* filename, const char* source);
   void ClearModules();
 
+  v8::Local<v8::Object> GetBuiltinModules();
+
   v8::Isolate* isolate_;
   v8::ArrayBuffer::Allocator* array_buffer_allocator_;
   deno_buf shared_;
@@ -62,6 +64,8 @@ class DenoIsolate {
   std::map<std::string, v8::Persistent<v8::Module>> module_map_;
   // Set by deno_resolve_ok
   v8::Persistent<v8::Module> resolve_module_;
+
+  v8::Persistent<v8::Object> builtin_modules_;
 
   v8::Persistent<v8::Context> context_;
   std::map<int32_t, v8::Persistent<v8::Value>> async_data_map_;
@@ -108,9 +112,15 @@ void Recv(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Send(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Shared(v8::Local<v8::Name> property,
             const v8::PropertyCallbackInfo<v8::Value>& info);
+void BuiltinModules(v8::Local<v8::Name> property,
+                    const v8::PropertyCallbackInfo<v8::Value>& info);
 static intptr_t external_references[] = {
-    reinterpret_cast<intptr_t>(Print), reinterpret_cast<intptr_t>(Recv),
-    reinterpret_cast<intptr_t>(Send), reinterpret_cast<intptr_t>(Shared), 0};
+    reinterpret_cast<intptr_t>(Print),
+    reinterpret_cast<intptr_t>(Recv),
+    reinterpret_cast<intptr_t>(Send),
+    reinterpret_cast<intptr_t>(Shared),
+    reinterpret_cast<intptr_t>(BuiltinModules),
+    0};
 
 static const deno_buf empty_buf = {nullptr, 0, nullptr, 0};
 


### PR DESCRIPTION
This is needed to support builtin modules like

    import { open } from "deno"


This is part of the Native ES modules PR #1460 ... But I think it will be easier to review and land separately.