### PR TITLE
Use multimap with Persistent module handle to avoid IdentityHash collision

### DIFF
--- a/libdeno/internal.h
+++ b/libdeno/internal.h
@@ -56,8 +56,9 @@ class DenoIsolate {
   int32_t next_req_id_;
   void* user_data_;
 
-  // identity hash -> filename
-  std::map<int, std::string> module_filename_map_;
+  // identity hash -> filename, module (avoid hash collision)
+  std::multimap<int, std::pair<std::string, v8::Persistent<v8::Module>>>
+      module_info_map_;
   // filename -> Module
   std::map<std::string, v8::Persistent<v8::Module>> module_map_;
   // Set by deno_resolve_ok


### PR DESCRIPTION
Avoids possible identity hash collision by making the map a multimap and keep a persistent handle for the module to compare.

This construct is also [seen in Node](https://github.com/nodejs/node/blob/0043c6f5482993f7d91d6a78edeb310147895fb5/src/module_wrap.cc#L74-L83).

(Tried running this on top of the ESM PR, and seems fine with module resolutions)
(The O(1000) comments seems valid (tested myself), but considering the hash is [an int](https://denolib.github.io/v8-docs/classv8_1_1Module.html#aa2966a54ccb783a91ab494407782e9e3), the collision chance should still be quite high...)