### PR TITLE
fix: use int instead of double for timeout type.

### DIFF
--- a/js/timers.ts
+++ b/js/timers.ts
@@ -25,6 +25,9 @@ interface Timer {
 const EPOCH = Date.now();
 const APOCALYPSE = 2 ** 32 - 2;
 
+// Timeout values > TIMEOUT_MAX are set to 1.
+const TIMEOUT_MAX = 2 ** 31 - 1;
+
 let globalTimeoutDue: number | null = null;
 
 let nextTimerId = 1;
@@ -50,6 +53,7 @@ function setGlobalTimeout(due: number | null, now: number) {
     timeout = due - now;
     assert(timeout >= 0);
   }
+
   // Send message to the backend.
   const builder = flatbuffers.createBuilder();
   msg.SetTimeout.startSetTimeout(builder);
@@ -181,7 +185,15 @@ function setTimer(
   // and INT32_MAX. Any other value will cause the timer to fire immediately.
   // We emulate this behavior.
   const now = getTime();
+  if (delay > TIMEOUT_MAX) {
+    console.warn(
+      `${delay} does not fit into a 32-bit signed integer.
+Timeout duration was set to 1.`
+    );
+    delay = 1;
+  }
   delay = Math.max(0, delay | 0);
+
   // Create a new, unscheduled timer object.
   const timer = {
     id: nextTimerId++,

--- a/js/timers.ts
+++ b/js/timers.ts
@@ -187,8 +187,9 @@ function setTimer(
   const now = getTime();
   if (delay > TIMEOUT_MAX) {
     console.warn(
-      `${delay} does not fit into a 32-bit signed integer.
-Timeout duration was set to 1.`
+      `${delay} does not fit into` +
+        " a 32-bit signed integer." +
+        "\nTimeout duration was set to 1."
     );
     delay = 1;
   }

--- a/js/timers_test.ts
+++ b/js/timers_test.ts
@@ -155,3 +155,12 @@ test(async function intervalCancelInvalidSilentFail() {
   // Should silently fail (no panic)
   clearInterval(2147483647);
 });
+
+test(async function fireCallbackImmediatelyWhenDelayOverMaxValue() {
+  let count = 0;
+  setTimeout(() => {
+    count++;
+  }, 2 ** 31);
+  await waitForMs(1);
+  assertEqual(count, 1);
+});

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -177,7 +177,7 @@ table Chdir {
 }
 
 table SetTimeout {
-  timeout: double;
+  timeout: int;
 }
 
 table Exit {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -331,8 +331,7 @@ fn op_set_timeout(
 ) -> Box<Op> {
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_set_timeout().unwrap();
-  // FIXME why is timeout a double if it's cast immediately to i64/u64??
-  let val = inner.timeout() as i64;
+  let val = inner.timeout();
   let timeout_due = if val >= 0 {
     Some(Instant::now() + Duration::from_millis(val as u64))
   } else {


### PR DESCRIPTION
<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->

Hi :) I found FIXME comment in ops.rs. I think it is better to use `int` instead of `double` for timeout type in flatbuffer. Because delay is rounded by typescript side like following. If not, please reject this PR.

https://github.com/denoland/deno/blob/master/js/timers.ts#L180-L184