### PR TITLE
output correct non-ASCII characters on Windows PowerShell

### DIFF
--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -14,7 +14,6 @@
 #define GLOBAL_IMPORT_BUF_SIZE 1024
 
 #ifdef _WIN32
-#include <malloc.h>
 #include <wchar.h>
 #include <windows.h>
 #endif

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -13,7 +13,7 @@
 
 #define GLOBAL_IMPORT_BUF_SIZE 1024
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <malloc.h>
 #include <wchar.h>
 #include <windows.h>


### PR DESCRIPTION
example file:

```js
console.log("hello")
console.log("你好")      // Chinese
console.log("こんにちは") // Japanese
console.log("Привет")    // Russian
```

in PowerShell:

![](https://user-images.githubusercontent.com/359395/50868121-08f39680-13e9-11e9-89ec-307955a74975.png)

when using a Linux-like environment on Windows like git bash, MinGW64, can output the correct result.

![](https://user-images.githubusercontent.com/359395/50868599-33465380-13eb-11e9-9319-3917eb96cea2.png)
