### PR TITLE
Avoid crashing on direct run of non-existent module

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 use hyper;
+use msg::enum_name_error_kind;
 pub use msg::ErrorKind;
 use std;
 use std::fmt;
@@ -88,6 +89,10 @@ impl DenoError {
         }
       }
     }
+  }
+
+  pub fn kind_str(&self) -> &str {
+    enum_name_error_kind(self.kind())
   }
 }
 

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -255,8 +255,8 @@ impl Isolate {
 
   /// Executes the provided JavaScript module.
   pub fn execute_mod(&self, js_filename: &str) -> Result<(), JSError> {
-    let out =
-      code_fetch_and_maybe_compile(&self.state, js_filename, ".").unwrap();
+    let out = code_fetch_and_maybe_compile(&self.state, js_filename, ".")
+      .map_err(JSError::from)?;
 
     let filename = CString::new(out.filename.clone()).unwrap();
     let filename_ptr = filename.as_ptr() as *const i8;

--- a/tests/run_not_found.out
+++ b/tests/run_not_found.out
@@ -1,0 +1,1 @@
+NotFound: Cannot resolve module "./not-a-valid-remote-module.ts" from "."

--- a/tests/run_not_found.test
+++ b/tests/run_not_found.test
@@ -1,0 +1,4 @@
+args: ./not-a-valid-remote-module.ts --reload
+check_stderr: true
+exit_code: 1
+output: tests/run_not_found.out


### PR DESCRIPTION
Before:
```
$ deno ./not-a-valid-remote-module.ts
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: DenoError { repr: Simple(NotFound, "Cannot resolve module \"./not-a-valid-remote-module.ts\" from \".\"") }', libcore\result.rs:1009:5
```
After:
```
$ deno ./not-a-valid-remote-module.ts
NotFound: Cannot resolve module "./not-a-valid-remote-module.ts" from "."
```