### PR TITLE
Avoid show confusing lines in gen/bundle/main.js that throws error

### DIFF
--- a/src/js_errors.rs
+++ b/src/js_errors.rs
@@ -75,28 +75,31 @@ impl ToString for StackFrame {
 
 impl ToString for JSError {
   fn to_string(&self) -> String {
-    // TODO use fewer clones.
     // TODO Improve the formatting of these error messages.
     let mut s = String::new();
 
     if self.script_resource_name.is_some() {
-      s.push_str(&self.script_resource_name.clone().unwrap());
-    }
-    if self.line_number.is_some() {
-      s.push_str(&format!(
-        ":{}:{}",
-        self.line_number.unwrap(),
-        self.start_column.unwrap()
-      ));
-      assert!(self.start_column.is_some());
-    }
-    if self.source_line.is_some() {
-      s.push_str("\n");
-      s.push_str(&self.source_line.clone().unwrap());
-      s.push_str("\n\n");
+      let script_resource_name = self.script_resource_name.as_ref().unwrap();
+      // Avoid showing internal code from gen/bundle/main.js
+      if script_resource_name != "gen/bundle/main.js" {
+        s.push_str(script_resource_name);
+        if self.line_number.is_some() {
+          s.push_str(&format!(
+            ":{}:{}",
+            self.line_number.unwrap(),
+            self.start_column.unwrap()
+          ));
+          assert!(self.start_column.is_some());
+        }
+        if self.source_line.is_some() {
+          s.push_str("\n");
+          s.push_str(self.source_line.as_ref().unwrap());
+          s.push_str("\n\n");
+        }
+      }
     }
 
-    s.push_str(&self.message.clone());
+    s.push_str(&self.message);
 
     for frame in &self.frames {
       s.push_str("\n");

--- a/tests/error_004_missing_module.ts.out
+++ b/tests/error_004_missing_module.ts.out
@@ -1,4 +1,5 @@
-[WILDCARD]NotFound: Cannot resolve module "bad-module.ts" from "[WILDCARD]/tests/error_004_missing_module.ts"
+Compiling [WILDCARD]tests/error_004_missing_module.ts
+NotFound: Cannot resolve module "bad-module.ts" from "[WILDCARD]/tests/error_004_missing_module.ts"
     at DenoError ([WILDCARD]/js/errors.ts:[WILDCARD])
     at maybeError ([WILDCARD]/js/errors.ts:[WILDCARD])
     at maybeThrowError ([WILDCARD]/js/errors.ts:[WILDCARD])

--- a/tests/error_006_import_ext_failure.ts.out
+++ b/tests/error_006_import_ext_failure.ts.out
@@ -1,4 +1,5 @@
-[WILDCARD]NotFound: Cannot resolve module "./non-existent" from "[WILDCARD]/tests/error_006_import_ext_failure.ts"
+Compiling [WILDCARD]tests/error_006_import_ext_failure.ts
+NotFound: Cannot resolve module "./non-existent" from "[WILDCARD]/tests/error_006_import_ext_failure.ts"
     at DenoError ([WILDCARD]/js/errors.ts:[WILDCARD])
     at maybeError ([WILDCARD]/js/errors.ts:[WILDCARD])
     at maybeThrowError ([WILDCARD]/js/errors.ts:[WILDCARD])


### PR DESCRIPTION
Avoid show confusing lines in gen/bundle/main.js that throws error.
Also uses `as_ref` avoid some unneeded `clone`s.

For a file `bad_import.ts`:
```ts
import "non-existent.txt";
```
Run `deno bad_import.ts`:
Before:
```
gen/bundle/main.js:4339:17
          return new DenoError(kind, base.error());

NotFound: Cannot resolve module "non-existent.txt" from "/Users/kevinqian/Desktop/Programming/Deno/test/bad_import.ts"
    at DenoError (deno/js/errors.ts:19:5)
    at maybeError (deno/js/errors.ts:38:12)
    at maybeThrowError (deno/js/errors.ts:26:15)
    at sendSync (deno/js/dispatch.ts:67:5)
    at codeFetch (deno/js/os.ts:46:19)
    at resolveModule (deno/js/compiler.ts:357:38)
    at moduleNames.map.name (deno/js/compiler.ts:519:31)
    at resolveModuleNames (deno/js/compiler.ts:511:24)
    at compilerHost.resolveModuleNames (deno/third_party/node_modules/typescript/lib/typescript.js:32750:71)
    at resolveModuleNamesWorker (deno/third_party/node_modules/typescript/lib/typescript.js:20688:69)
```
After:
```
NotFound: Cannot resolve module "non-existent.txt" from "/Users/kevinqian/Desktop/Programming/Deno/test/bad_import.ts"
    at DenoError (deno/js/errors.ts:19:5)
    at maybeError (deno/js/errors.ts:38:12)
    at maybeThrowError (deno/js/errors.ts:26:15)
    at sendSync (deno/js/dispatch.ts:67:5)
    at codeFetch (deno/js/os.ts:46:19)
    at resolveModule (deno/js/compiler.ts:357:38)
    at moduleNames.map.name (deno/js/compiler.ts:519:31)
    at resolveModuleNames (deno/js/compiler.ts:511:24)
    at compilerHost.resolveModuleNames (deno/third_party/node_modules/typescript/lib/typescript.js:32750:71)
    at resolveModuleNamesWorker (deno/third_party/node_modules/typescript/lib/typescript.js:20688:69)
```