### PR TITLE
Added `rid` to `Conn` interface

### DIFF
--- a/js/net.ts
+++ b/js/net.ts
@@ -57,6 +57,8 @@ export interface Conn extends Reader, Writer, Closer {
   localAddr: string;
   /** The remote address of the connection. */
   remoteAddr: string;
+  /** The resource ID of the connection. */
+  rid: number;
   /** Shuts down (`shutdown(2)`) the reading side of the TCP connection. Most
    * callers should just use `close()`.
    */

--- a/js/net_test.ts
+++ b/js/net_test.ts
@@ -22,6 +22,7 @@ testPerm({ net: true }, async function netDialListen() {
   assertEqual(1, buf[0]);
   assertEqual(2, buf[1]);
   assertEqual(3, buf[2]);
+  assert(conn.rid > 0);
 
   // TODO Currently ReadResult does not properly transmit EOF in the same call.
   // it requires a second call to get the EOF. Either ReadResult to be an


### PR DESCRIPTION
Adds the `rid` property to `Conn` to allow access to the resource ID of the incoming connection.