### PR TITLE
Fix JSON Modules

### DIFF
--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -137,6 +137,7 @@ export class Compiler
   private readonly _options: ts.CompilerOptions = {
     allowJs: true,
     checkJs: true,
+    esModuleInterop: true,
     module: ts.ModuleKind.ESNext,
     outDir: "$deno$",
     resolveJsonModule: true,

--- a/js/compiler_test.ts
+++ b/js/compiler_test.ts
@@ -506,6 +506,7 @@ test(function compilerGetCompilationSettings() {
   const expectedKeys = [
     "allowJs",
     "checkJs",
+    "esModuleInterop",
     "module",
     "outDir",
     "resolveJsonModule",

--- a/tests/020_json_modules.ts
+++ b/tests/020_json_modules.ts
@@ -1,3 +1,2 @@
-import * as config from "./subdir/config.json";
-// TODO Shouldn't need 'default'
-console.log(JSON.stringify(config["default"]));
+import config from "./subdir/config.json";
+console.log(JSON.stringify(config));


### PR DESCRIPTION
Because ESM does not support `export =` assignments, nor allow "spreading" of exports, JSON modules when targeting ESM need to use a `export default`.  From a type checking perspective, though, TypeScript assumes JSON modules will be an `export =` affair, even when targeting ESM as the output.  This means we to add the `esModuleInterop` flag to the compiler options.  This doesn't change the emit, but allows TypeScript to assume that the default import of a module is the same as the namespace import.

This does mean that to properly import JSON modules, we have no option but to deal with the default import, so instead of:

```ts
import * as config from "./config.json";
```

Only the following is supported:

```ts
import config from "./config.json";
```

~This currently includes #1512 as well, which I will rebase when that is merged.~

Rebased and ready. @ry 