### PR TITLE
Kill all pending accepts when TCP listener is closed

### DIFF
--- a/js/net_test.ts
+++ b/js/net_test.ts
@@ -4,8 +4,22 @@ import { testPerm, assert, assertEqual } from "./test_util.ts";
 import { deferred } from "deno";
 
 testPerm({ net: true }, function netListenClose() {
-  const listener = deno.listen("tcp", "127.0.0.1:4500");
+  const listener = deno.listen("tcp", "127.0.0.1:4502");
   listener.close();
+});
+
+testPerm({ net: true }, async function netCloseWhileAccept() {
+  const listener = deno.listen("tcp", "127.0.0.1:4501");
+  const p = listener.accept();
+  listener.close();
+  let err: Error;
+  try {
+    await p;
+  } catch (e) {
+    err = e;
+  }
+  assert(!!err);
+  assertEqual(err.message, "Listener has been closed");
 });
 
 testPerm({ net: true }, async function netDialListen() {

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -200,9 +200,7 @@ impl Resource {
     let r = table.remove(&self.rid);
     assert!(r.is_some());
     // If TcpListener, we must kill all pending accepts!
-    if let Repr::TcpListener(l, m) = r.unwrap() {
-      // Drop first
-      std::mem::drop(l);
+    if let Repr::TcpListener(_, m) = r.unwrap() {
       // Call notify on each task, so that they would error out
       for (_, t) in m {
         t.notify();

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -87,11 +87,12 @@ enum Repr {
   Stdout(tokio::fs::File),
   Stderr(tokio::io::Stderr),
   FsFile(tokio::fs::File),
-  // Since TcpListener might be closed while there are pending accept tasks,
-  // we need to track these task so that when the listener is closed,
-  // pending tasks could be notified and die.
-  // The tasks are indexed, so they could be removed when accept completed.
-  TcpListener(tokio::net::TcpListener, HashMap<usize, futures::task::Task>),
+  // Since TcpListener might be closed while there is a pending accept task,
+  // we need to track the task so that when the listener is closed,
+  // this pending task could be notified and die.
+  // Currently TcpListener itself does not take care of this issue.
+  // See: https://github.com/tokio-rs/tokio/issues/846
+  TcpListener(tokio::net::TcpListener, Option<futures::task::Task>),
   TcpStream(tokio::net::TcpStream),
   HttpBody(HttpBody),
   Repl(Repl),
@@ -152,7 +153,7 @@ fn inspect_repr(repr: &Repr) -> String {
 
 // Abstract async file interface.
 // Ideally in unix, if Resource represents an OS rid, it will be the same.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Resource {
   pub rid: ResourceId,
 }
@@ -174,22 +175,35 @@ impl Resource {
     }
   }
 
-  /// Track pending tasks with task_id as identifier (for TcpListener resource)
-  /// Insert the task into map for tracking
-  pub fn track_task(&mut self, task_id: usize) {
+  /// Track the current task (for TcpListener resource).
+  /// Throws an error if another task is already tracked.
+  pub fn track_task(&mut self) -> Result<(), std::io::Error> {
     let mut table = RESOURCE_TABLE.lock().unwrap();
-    // Only register if is TcpListener
-    if let Some(Repr::TcpListener(_, m)) = table.get_mut(&self.rid) {
-      m.insert(task_id, futures::task::current());
+    // Only track if is TcpListener.
+    if let Some(Repr::TcpListener(_, t)) = table.get_mut(&self.rid) {
+      // Currently, we only allow tracking a single accept task for a listener.
+      // This might be changed in the future with multiple workers.
+      // Caveat: TcpListener by itself also only tracks an accept task at a time.
+      // See https://github.com/tokio-rs/tokio/issues/846#issuecomment-454208883
+      if t.is_some() {
+        return Err(std::io::Error::new(
+          std::io::ErrorKind::Other,
+          "Another accept task is ongoing",
+        ));
+      }
+      t.replace(futures::task::current());
     }
+    Ok(())
   }
 
-  /// Remove a task from tracking (for TcpListener resource)
-  /// Happens when the task is done and thus no further tracking is needed
-  pub fn untrack_task(&mut self, task_id: usize) {
+  /// Stop tracking a task (for TcpListener resource).
+  /// Happens when the task is done and thus no further tracking is needed.
+  pub fn untrack_task(&mut self) {
     let mut table = RESOURCE_TABLE.lock().unwrap();
-    if let Some(Repr::TcpListener(_, m)) = table.get_mut(&self.rid) {
-      m.remove(&task_id);
+    // Only untrack if is TcpListener.
+    if let Some(Repr::TcpListener(_, t)) = table.get_mut(&self.rid) {
+      assert!(t.is_some());
+      t.take();
     }
   }
 
@@ -200,11 +214,9 @@ impl Resource {
     let r = table.remove(&self.rid);
     assert!(r.is_some());
     // If TcpListener, we must kill all pending accepts!
-    if let Repr::TcpListener(_, m) = r.unwrap() {
-      // Call notify on each task, so that they would error out
-      for (_, t) in m {
-        t.notify();
-      }
+    if let Repr::TcpListener(_, Some(t)) = r.unwrap() {
+      // Call notify on the tracked task, so that they would error out.
+      t.notify();
     }
   }
 
@@ -297,7 +309,7 @@ pub fn add_fs_file(fs_file: tokio::fs::File) -> Resource {
 pub fn add_tcp_listener(listener: tokio::net::TcpListener) -> Resource {
   let rid = new_rid();
   let mut tg = RESOURCE_TABLE.lock().unwrap();
-  let r = tg.insert(rid, Repr::TcpListener(listener, HashMap::new()));
+  let r = tg.insert(rid, Repr::TcpListener(listener, None));
   assert!(r.is_none());
   Resource { rid }
 }

--- a/src/tokio_util.rs
+++ b/src/tokio_util.rs
@@ -85,7 +85,10 @@ impl Future for Accept {
           r.track_task(self.task_id);
           return Ok(futures::prelude::Async::NotReady);
         }
-        Err(e) => return Err(From::from(e)),
+        Err(e) => {
+          r.untrack_task(self.task_id);
+          return Err(From::from(e));
+        }
       },
       AcceptState::Empty => panic!("poll Accept after it's done"),
     };

--- a/src/tokio_util.rs
+++ b/src/tokio_util.rs
@@ -11,13 +11,6 @@ use tokio;
 use tokio::net::TcpStream;
 use tokio_executor;
 
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
-lazy_static! {
-  // Keep unique such that no collisions in TcpListener accept task map
-  static ref NEXT_ACCEPT_ID: AtomicUsize = AtomicUsize::new(0);
-}
-
 pub fn block_on<F, R, E>(future: F) -> Result<R, E>
 where
   F: Send + 'static + Future<Item = R, Error = E>,
@@ -52,7 +45,6 @@ enum AcceptState {
 pub fn accept(r: Resource) -> Accept {
   Accept {
     state: AcceptState::Pending(r),
-    task_id: NEXT_ACCEPT_ID.fetch_add(1, Ordering::SeqCst),
   }
 }
 
@@ -63,7 +55,6 @@ pub fn accept(r: Resource) -> Accept {
 #[derive(Debug)]
 pub struct Accept {
   state: AcceptState,
-  task_id: usize,
 }
 
 impl Future for Accept {
@@ -73,20 +64,21 @@ impl Future for Accept {
   fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
     let (stream, addr) = match self.state {
       // Similar to try_ready!, but also track/untrack accept task
-      // in TcpListener resource
-      // In this way, when the listener is closed, the task could be
-      // notified to error out (instead of stuck forever)
+      // in TcpListener resource.
+      // In this way, when the listener is closed, the task can be
+      // notified to error out (instead of stuck forever).
       AcceptState::Pending(ref mut r) => match r.poll_accept() {
         Ok(futures::prelude::Async::Ready(t)) => {
-          r.untrack_task(self.task_id);
+          r.untrack_task();
           t
         }
         Ok(futures::prelude::Async::NotReady) => {
-          r.track_task(self.task_id);
+          // Would error out if another accept task is being tracked.
+          r.track_task()?;
           return Ok(futures::prelude::Async::NotReady);
         }
         Err(e) => {
-          r.untrack_task(self.task_id);
+          r.untrack_task();
           return Err(From::from(e));
         }
       },


### PR DESCRIPTION
Closes #1516 .

Keep track of the pending accept task and notify it when the corresponding `TcpListener` from `ResourceTable` is dropped.

Before: Hangs forever
After:
```
Other: Listener has been closed
    at DenoError (deno/js/errors.ts:19:5)
    at maybeError (deno/js/errors.ts:38:12)
    at handleAsyncMsgFromRust (deno/js/dispatch.ts:27:17)
```
and dies. This error could be caught.

This is a first-pass implementation (so might not be the best solution). I'm slightly worried about the performance implication of adding 2 `ResourceTable` locks.
(Benchmark from Travis seems no change though)