### PR TITLE
mkdir should return an error if a file with the given path exists

### DIFF
--- a/js/mkdir_test.ts
+++ b/js/mkdir_test.ts
@@ -7,6 +7,20 @@ testPerm({ write: true }, function mkdirSyncSuccess() {
   deno.mkdirSync(path);
   const pathInfo = deno.statSync(path);
   assert(pathInfo.isDirectory());
+  deno.mkdirSync(path);
+});
+
+testPerm({ write: true }, function mkdirSyncFail() {
+  let caughtError = false;
+  const path = deno.makeTempDirSync() + "/file.txt";
+  deno.writeFileSync(path, new Uint8Array(0));
+  try {
+    deno.mkdirSync(path);
+  } catch (err) {
+    caughtError = true;
+    assertEqual(err.kind, deno.ErrorKind.AlreadyExists);
+  }
+  assert(caughtError);
 });
 
 testPerm({ write: true }, function mkdirSyncMode() {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -72,10 +72,7 @@ pub fn mkdir(path: &Path, perm: u32) -> std::io::Result<()> {
   let mut builder = DirBuilder::new();
   builder.recursive(true);
   set_dir_permission(&mut builder, perm);
-  builder.create(path).or_else(|err| match err.kind() {
-    std::io::ErrorKind::AlreadyExists => Ok(()),
-    _ => Err(err),
-  })
+  builder.create(path)
 }
 
 #[cfg(any(unix))]


### PR DESCRIPTION
The return value from builder.create is fine. If a folder with
that path already exists, then create returns Ok, because we are in
recursive mode. But if it is a file that already exists on that path,
then we should not swallow the error but return it.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
