### PR TITLE
trim_left_matches (deprecated) => trim_start_matches

### DIFF
--- a/src/resolve_addr.rs
+++ b/src/resolve_addr.rs
@@ -85,7 +85,7 @@ fn split<'a>(address: &'a str) -> Option<(&'a str, u16)> {
       addr
     };
 
-    let p = p.trim_left_matches(':');
+    let p = p.trim_start_matches(':');
     match p.parse::<u16>() {
       Err(_) => None,
       Ok(port) => Some((addr, port)),


### PR DESCRIPTION
For this on Rust 1.33 (`trim_start_matches` is added on Rust 1.30 so I would assume this patch would build):
```
error: use of deprecated item 'core::str::<impl str>::trim_left_matches': superseded by `trim_start_matches`
  --> ../../src/resolve_addr.rs:88:15
   |
88 |     let p = p.trim_left_matches(':');
   |               ^^^^^^^^^^^^^^^^^
   |
   = note: `-D deprecated` implied by `-D warnings`
```
