### PR TITLE
Add globalThis definition to runtime

### DIFF
--- a/js/globals_test.ts
+++ b/js/globals_test.ts
@@ -1,0 +1,17 @@
+import { test, assert } from "./test_util.ts";
+
+test(function globalThisExists() {
+  assert(globalThis != null);
+});
+
+test(function windowExists() {
+  assert(window != null);
+});
+
+test(function windowWindowExists() {
+  assert(window.window === window);
+});
+
+test(function globalThisEqualsWindow() {
+  assert(globalThis === window);
+});

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -18,6 +18,7 @@ import "./fetch_test.ts";
 // import "./file_test.ts";
 import "./files_test.ts";
 import "./form_data_test.ts";
+import "./globals_test.ts";
 import "./headers_test.ts";
 import "./make_temp_dir_test.ts";
 import "./metrics_test.ts";

--- a/tools/ts_library_builder/build_library.ts
+++ b/tools/ts_library_builder/build_library.ts
@@ -156,6 +156,10 @@ export function mergeGlobal({
   // Declare the global variable
   addVariableDeclaration(targetSourceFile, globalVarName, interfaceName, true);
 
+  // `globalThis` accesses the global scope and is defined here:
+  // https://github.com/tc39/proposal-global
+  addVariableDeclaration(targetSourceFile, "globalThis", interfaceName, true);
+
   // Add self reference to the global variable
   addInterfaceProperty(interfaceDeclaration, globalVarName, interfaceName);
 

--- a/tools/ts_library_builder/test.ts
+++ b/tools/ts_library_builder/test.ts
@@ -140,24 +140,25 @@ test(function buildLibraryMerge() {
   assertEqual(targetSourceFile.getInterfaces().length, 1);
   const variableDeclarations = targetSourceFile.getVariableDeclarations();
   assertEqual(variableDeclarations[0].getType().getText(), `FooBar`);
-  assertEqual(variableDeclarations[1].getType().getText(), `moduleC.Bar`);
+  assertEqual(variableDeclarations[1].getType().getText(), `FooBar`);
+  assertEqual(variableDeclarations[2].getType().getText(), `moduleC.Bar`);
   assertEqual(
-    variableDeclarations[2].getType().getText(),
+    variableDeclarations[3].getType().getText(),
     `typeof moduleC.qat`
   );
   assertEqual(
-    variableDeclarations[3].getType().getText(),
+    variableDeclarations[4].getType().getText(),
     `typeof moduleE.process`
   );
   assertEqual(
-    variableDeclarations[4].getType().getText(),
+    variableDeclarations[5].getType().getText(),
     `typeof moduleD.reprocess`
   );
   assertEqual(
-    variableDeclarations[5].getType().getText(),
+    variableDeclarations[6].getType().getText(),
     `typeof moduleC.Bar`
   );
-  assertEqual(variableDeclarations.length, 6);
+  assertEqual(variableDeclarations.length, 7);
   const typeAliases = targetSourceFile.getTypeAliases();
   assertEqual(typeAliases[0].getName(), "Bar");
   assertEqual(typeAliases[0].getType().getText(), "moduleC.Bar");


### PR DESCRIPTION
The `globalThis` proposal has reached Stage 3: https://github.com/tc39/proposal-global and has been in V8 for a while now.

This PR adds it to the runtime type library for Deno so that users can access it.  It shares the same interface as `window` and `globalThis === window` without any additional runtime code to be added.

I tried to replace our use of `globalEval` with `globalThis` in the runtime code, but it appears that when snapshotting, `globalThis` is not available for some reason.
