### PR TITLE
Fixed copyright of types output

### DIFF
--- a/tests/types.out
+++ b/tests/types.out
@@ -1,4 +1,4 @@
-// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />

--- a/tools/ts_library_builder/build_library.ts
+++ b/tools/ts_library_builder/build_library.ts
@@ -58,7 +58,7 @@ const { ModuleKind, ModuleResolutionKind, ScriptTarget } = ts;
  * A preamble which is appended to the start of the library.
  */
 // tslint:disable-next-line:max-line-length
-const libPreamble = `// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+const libPreamble = `// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />


### PR DESCRIPTION
Fix copyright from the output of the types flag

before :
```
$ deno --types
// Copyright 2018 the Deno authors. All rights reserved. MIT license.

/// <reference no-default-lib="true" />
/// <reference lib="esnext" />
```

after :
```
$ deno --types
// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.

/// <reference no-default-lib="true" />
/// <reference lib="esnext" />
```