### PR TITLE
Revert "Remove symbol_level=1 override (#1532)"

### DIFF
--- a/.gn
+++ b/.gn
@@ -38,6 +38,7 @@ default_args = {
   # https://chromium.googlesource.com/chromium/src/+/master/docs/jumbo.md
   use_jumbo_build = true
 
+  symbol_level = 1
   treat_warnings_as_errors = true
   rust_treat_warnings_as_errors = true
 


### PR DESCRIPTION
This doubled the size of the Linux release binary.

This reverts commit 0afc698d251214be5a3fb081a96b1957a182828e.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
