### PR TITLE
Avoid crashing on ES module resolution when module not found

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -403,8 +403,15 @@ extern "C" fn resolve_cb(
   debug!("module_resolve callback {} {}", specifier, referrer);
   let isolate = unsafe { Isolate::from_raw_ptr(user_data) };
 
-  let out =
-    code_fetch_and_maybe_compile(&isolate.state, specifier, referrer).unwrap();
+  let maybe_out =
+    code_fetch_and_maybe_compile(&isolate.state, specifier, referrer);
+
+  if maybe_out.is_err() {
+    // Resolution failure
+    return;
+  }
+
+  let out = maybe_out.unwrap();
 
   let filename = CString::new(out.filename.clone()).unwrap();
   let filename_ptr = filename.as_ptr() as *const i8;

--- a/tests/error_009_missing_js_module.js
+++ b/tests/error_009_missing_js_module.js
@@ -1,0 +1,1 @@
+import "./bad-module.js";

--- a/tests/error_009_missing_js_module.js.out
+++ b/tests/error_009_missing_js_module.js.out
@@ -1,0 +1,1 @@
+NotFound: Cannot resolve module "./bad-module.js" from "[WILDCARD]/tests/error_009_missing_js_module.js"

--- a/tests/error_009_missing_js_module.test
+++ b/tests/error_009_missing_js_module.test
@@ -1,0 +1,4 @@
+args: tests/error_009_missing_js_module.js
+check_stderr: true
+exit_code: 1
+output: tests/error_009_missing_js_module.js.out


### PR DESCRIPTION
Closes #1545 .

See discussion https://github.com/denoland/deno/issues/1545#issuecomment-455383259

Ideally, could improve error message by providing more accurate location of `import` statement (using [`GetModuleRequestsLength()`](https://denolib.github.io/v8-docs/classv8_1_1Module.html#a323acfb19889ba4e16b81f1c3d89c2b9) and [`GetModuleRequestLocation()`](https://denolib.github.io/v8-docs/classv8_1_1Module.html#a95b5467ac9bcfc120470b6944c7da111)) (However, exception value cannot be directly modified and thus we might need to introduce custom location to `EncodeExceptionAsJSON`, which is out of scope of this PR and might not be very useful)
