### PR TITLE
Use the same parse processing in contractor of URL with setters

### DIFF
--- a/js/url.ts
+++ b/js/url.ts
@@ -218,6 +218,15 @@ export class URL {
     return this._searchParams;
   }
 
+  get query(): string {
+    return this._parts.query;
+  }
+
+  set query(value: string) {
+    value = String(value);
+    this._parts.query = value;
+  }
+
   constructor(url: string, base?: string | URL) {
     let baseParts: URLParts | undefined;
     if (base) {

--- a/js/url.ts
+++ b/js/url.ts
@@ -7,7 +7,7 @@ interface URLParts {
   password: string;
   hostname: string;
   port: string;
-  path: string;
+  pathname: string;
   query: string;
   hash: string;
 }
@@ -15,7 +15,7 @@ interface URLParts {
 const patterns = {
   protocol: "(?:([^:/?#]+):)",
   authority: "(?://([^/?#]*))",
-  path: "([^?#]*)",
+  pathname: "([^?#]*)",
   query: "(\\?[^#]*)",
   hash: "(#.*)",
 
@@ -25,7 +25,7 @@ const patterns = {
 };
 
 const urlRegExp = new RegExp(
-  `^${patterns.protocol}?${patterns.authority}?${patterns.path}${
+  `^${patterns.protocol}?${patterns.authority}?${patterns.pathname}${
     patterns.query
   }?${patterns.hash}?`
 );
@@ -54,7 +54,7 @@ function parse(url: string): URLParts | undefined {
         password: authorityMatch[2] || "",
         hostname: authorityMatch[3] || "",
         port: authorityMatch[4] || "",
-        path: urlMatch[3] || "",
+        pathname: urlMatch[3] || "",
         query: urlMatch[4] || "",
         hash: urlMatch[5] || ""
       };
@@ -155,7 +155,7 @@ export class URL {
   }
 
   get pathname(): string {
-    return this._parts.path ? this._parts.path : "/";
+    return this._parts.pathname ? this._parts.pathname : "/";
   }
 
   set pathname(value: string) {
@@ -163,8 +163,8 @@ export class URL {
     if (!value || value.charAt(0) !== "/") {
       value = `/${value}`;
     }
-    // paths can contain % unescaped
-    this._parts.path = escape(value).replace(/%25/g, "%");
+    // pathnames can contain % unescaped
+    this._parts.pathname = escape(value).replace(/%25/g, "%");
   }
 
   get port(): string {
@@ -241,7 +241,7 @@ export class URL {
         password: baseParts.password,
         hostname: baseParts.hostname,
         port: baseParts.port,
-        path: urlParts.path || baseParts.path,
+        pathname: urlParts.pathname || baseParts.pathname,
         query: urlParts.query || baseParts.query,
         hash: urlParts.hash
       };

--- a/js/url.ts
+++ b/js/url.ts
@@ -40,6 +40,17 @@ const searchParamsMethods: Array<keyof urlSearchParams.URLSearchParams> = [
   "set"
 ];
 
+const initializedURLParts = {
+  protocol: "",
+  username: "",
+  password: "",
+  hostname: "",
+  port: "",
+  pathname: "",
+  query: "",
+  hash: ""
+};
+
 function parse(url: string): URLParts | undefined {
   const urlMatch = urlRegExp.exec(url);
   if (urlMatch) {
@@ -243,17 +254,24 @@ export class URL {
 
     if (urlParts.protocol) {
       this._parts = urlParts;
+      this.protocol = urlParts.protocol;
+      this.username = urlParts.username;
+      this.password = urlParts.password;
+      this.hostname = urlParts.hostname;
+      this.port = urlParts.port;
+      this.pathname = urlParts.pathname;
+      this.query = urlParts.query;
+      this.hash = urlParts.hash;
     } else if (baseParts) {
-      this._parts = {
-        protocol: baseParts.protocol,
-        username: baseParts.username,
-        password: baseParts.password,
-        hostname: baseParts.hostname,
-        port: baseParts.port,
-        pathname: urlParts.pathname || baseParts.pathname,
-        query: urlParts.query || baseParts.query,
-        hash: urlParts.hash
-      };
+      this._parts = initializedURLParts;
+      this.protocol = baseParts.protocol;
+      this.username = baseParts.username;
+      this.password = baseParts.password;
+      this.hostname = baseParts.hostname;
+      this.port = baseParts.port;
+      this.pathname = urlParts.pathname || baseParts.pathname;
+      this.query = urlParts.query || baseParts.query;
+      this.hash = urlParts.hash;
     } else {
       throw new TypeError("URL requires a base URL.");
     }


### PR DESCRIPTION
#### Problem this patch fixes
Currently, contractor of URL does not use the same parse processing with when the setters in the Class and it makes inconsistent behaviour. See the code below and this patch is to fix the issue.

There is more missing implementation around ASCII encoding at URL and I'm working on it based on this patch. Let me know if you have any question.

#### Code to reproduce
```js
const url = new URL('http://example.com/パス');
console.log(url.pathname);
// => /パス

url.pathname = 'パス';
console.log(url.pathname);
// => /%u30D1%u30B9
```