### PR TITLE
Correct golang prototype dates

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -280,7 +280,7 @@ This is already working.
 When the rewrite is at feature parity with the Go prototype, we will release
 binaries for people to try.
 
-### v0.0.0 / 2018.09.32 / Golang Prototype
+### v0.0.0 / 2018.05.14 - 2018.06.22 / Golang Prototype
 
 https://github.com/denoland/deno/tree/golang
 


### PR DESCRIPTION
Go prototype seems to have [started on 14 May](https://github.com/denoland/deno/commit/f7c5e19081920f59ce2006d3255a58fb611b6a17) and been [removed on 22 Jun](https://github.com/denoland/deno/pull/276).