### PR TITLE
fix: build deno under node_modules folder

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -178,6 +178,7 @@ run_node("deno_runtime_declaration") {
     rebase_path("node_modules/ts-node/dist/bin.js", root_build_dir),
     "--project",
     rebase_path("tools/ts_library_builder/tsconfig.json"),
+    "--skip-ignore",
     rebase_path("tools/ts_library_builder/main.ts", root_build_dir),
     "--basePath",
     rebase_path(".", root_build_dir),


### PR DESCRIPTION
fix issue: 
https://github.com/denoland/deno/issues/1536

refer to: 
https://github.com/TypeStrong/ts-node#cli-and-programmatic-options

ts-node provides CLI option `--skip-ignore` to skip ignore checks (TS_NODE_SKIP_IGNORE, default: false).