### PR TITLE
Revert "Use the same parse processing at contractor of URL with sette…

### DIFF
--- a/js/url.ts
+++ b/js/url.ts
@@ -7,7 +7,7 @@ interface URLParts {
   password: string;
   hostname: string;
   port: string;
-  pathname: string;
+  path: string;
   query: string;
   hash: string;
 }
@@ -15,7 +15,7 @@ interface URLParts {
 const patterns = {
   protocol: "(?:([^:/?#]+):)",
   authority: "(?://([^/?#]*))",
-  pathname: "([^?#]*)",
+  path: "([^?#]*)",
   query: "(\\?[^#]*)",
   hash: "(#.*)",
 
@@ -25,7 +25,7 @@ const patterns = {
 };
 
 const urlRegExp = new RegExp(
-  `^${patterns.protocol}?${patterns.authority}?${patterns.pathname}${
+  `^${patterns.protocol}?${patterns.authority}?${patterns.path}${
     patterns.query
   }?${patterns.hash}?`
 );
@@ -39,17 +39,6 @@ const searchParamsMethods: Array<keyof urlSearchParams.URLSearchParams> = [
   "delete",
   "set"
 ];
-
-const initializedURLParts = {
-  protocol: "",
-  username: "",
-  password: "",
-  hostname: "",
-  port: "",
-  pathname: "",
-  query: "",
-  hash: ""
-};
 
 function parse(url: string): URLParts | undefined {
   const urlMatch = urlRegExp.exec(url);
@@ -65,7 +54,7 @@ function parse(url: string): URLParts | undefined {
         password: authorityMatch[2] || "",
         hostname: authorityMatch[3] || "",
         port: authorityMatch[4] || "",
-        pathname: urlMatch[3] || "",
+        path: urlMatch[3] || "",
         query: urlMatch[4] || "",
         hash: urlMatch[5] || ""
       };
@@ -166,7 +155,7 @@ export class URL {
   }
 
   get pathname(): string {
-    return this._parts.pathname ? this._parts.pathname : "/";
+    return this._parts.path ? this._parts.path : "/";
   }
 
   set pathname(value: string) {
@@ -174,8 +163,8 @@ export class URL {
     if (!value || value.charAt(0) !== "/") {
       value = `/${value}`;
     }
-    // pathnames can contain % unescaped
-    this._parts.pathname = escape(value).replace(/%25/g, "%");
+    // paths can contain % unescaped
+    this._parts.path = escape(value).replace(/%25/g, "%");
   }
 
   get port(): string {
@@ -229,15 +218,6 @@ export class URL {
     return this._searchParams;
   }
 
-  get query(): string {
-    return this._parts.query;
-  }
-
-  set query(value: string) {
-    value = String(value);
-    this._parts.query = value;
-  }
-
   constructor(url: string, base?: string | URL) {
     let baseParts: URLParts | undefined;
     if (base) {
@@ -254,24 +234,17 @@ export class URL {
 
     if (urlParts.protocol) {
       this._parts = urlParts;
-      this.protocol = urlParts.protocol;
-      this.username = urlParts.username;
-      this.password = urlParts.password;
-      this.hostname = urlParts.hostname;
-      this.port = urlParts.port;
-      this.pathname = urlParts.pathname;
-      this.query = urlParts.query;
-      this.hash = urlParts.hash;
     } else if (baseParts) {
-      this._parts = initializedURLParts;
-      this.protocol = baseParts.protocol;
-      this.username = baseParts.username;
-      this.password = baseParts.password;
-      this.hostname = baseParts.hostname;
-      this.port = baseParts.port;
-      this.pathname = urlParts.pathname || baseParts.pathname;
-      this.query = urlParts.query || baseParts.query;
-      this.hash = urlParts.hash;
+      this._parts = {
+        protocol: baseParts.protocol,
+        username: baseParts.username,
+        password: baseParts.password,
+        hostname: baseParts.hostname,
+        port: baseParts.port,
+        path: urlParts.path || baseParts.path,
+        query: urlParts.query || baseParts.query,
+        hash: urlParts.hash
+      };
     } else {
       throw new TypeError("URL requires a base URL.");
     }

--- a/js/url_test.ts
+++ b/js/url_test.ts
@@ -31,19 +31,6 @@ test(function urlParsing() {
   );
 });
 
-test(function constractorParsing() {
-  const url = new URL("http://どめいん.com/ぱす?きー=ばりゅー#はっしゅ");
-  const { host, pathname, search, hash } = url;
-  url.host = "どめいん.com";
-  url.pathname = "/ぱす";
-  url.search = "?きー=ばりゅー";
-  url.hash = "#はっしゅ";
-  assertEqual(host, url.host);
-  assertEqual(pathname, url.pathname);
-  assertEqual(search, url.search);
-  assertEqual(hash, url.hash);
-});
-
 test(function urlModifications() {
   const url = new URL(
     "https://foo:bar@baz.qat:8000/qux/quux?foo=bar&baz=12#qat"


### PR DESCRIPTION
…rs (#1549)"

Right now every instance of URL which has a basePath passed will share
the same instance of parts, so a change to one of them will change them
all.

https://github.com/denoland/deno/pull/1549#issuecomment-455896081

This reverts commit 9e1f5ccb8b06c01c1330ed38aeba83cfc51f5387.

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
