### PR TITLE
Minor optimization to repl.ts

### DIFF
--- a/js/repl.ts
+++ b/js/repl.ts
@@ -124,7 +124,7 @@ function parenthesesAreOpen(code: string): boolean {
     if (bracePosition % 2 === 0) {
       stack.push(bracePosition + 1); // push next expected brace position
     } else {
-      if (stack.length === 0 || stack.pop() !== bracePosition) {
+      if (stack.pop() !== bracePosition) {
         return false;
       }
     }


### PR DESCRIPTION
`stack.pop()` will return `undefined` if `stack` is empty, so the `stack.length === 0` check is unnecessary.

This is a minor optimization to `parenthesesAreOpen()` that was pointed out in `https://codereview.stackexchange.com/a/46039/148556` (which the original author of `parenthesesAreOpen()` drew inspiration from.
