### PR TITLE
console output with format

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -14,6 +14,16 @@ type ConsoleOptions = Partial<{
 // Default depth of logging nested objects
 const DEFAULT_MAX_DEPTH = 4;
 
+// Char codes
+const CHAR_PERCENT = 37; /* % */
+const CHAR_LOWERCASE_S = 115; /* s */
+const CHAR_LOWERCASE_D = 100; /* d */
+const CHAR_LOWERCASE_I = 105; /* i */
+const CHAR_LOWERCASE_F = 102; /* f */
+const CHAR_LOWERCASE_O = 111; /* o */
+const CHAR_UPPERCASE_O = 79; /* O */
+const CHAR_LOWERCASE_C = 99; /* c */
+
 // tslint:disable-next-line:no-any
 function getClassInstanceName(instance: any): string {
   if (typeof instance !== "object") {
@@ -352,16 +362,16 @@ export function stringifyArgs(
     let lastPos = 0;
 
     for (let i = 0; i < first.length - 1; i++) {
-      if (first.charCodeAt(i) === 37 /* '%' */) {
+      if (first.charCodeAt(i) === CHAR_PERCENT) {
         const nextChar = first.charCodeAt(++i);
         if (a + 1 !== args.length) {
           switch (nextChar) {
-            case 115: // 's'
+            case CHAR_LOWERCASE_S:
               // format as a string
               tempStr = String(args[++a]);
               break;
-            case 100: // 'd'
-            case 105: // 'i'
+            case CHAR_LOWERCASE_D:
+            case CHAR_LOWERCASE_I:
               // format as an integer
               const tempInteger = args[++a];
               if (typeof tempInteger === "bigint") {
@@ -372,7 +382,7 @@ export function stringifyArgs(
                 tempStr = `${parseInt(tempInteger, 10)}`;
               }
               break;
-            case 102: // 'f'
+            case CHAR_LOWERCASE_F:
               // format as a floating point value
               const tempFloat = args[++a];
               if (typeof tempFloat === "symbol") {
@@ -381,8 +391,8 @@ export function stringifyArgs(
                 tempStr = `${parseFloat(tempFloat)}`;
               }
               break;
-            case 111: // 'o'
-            case 79: // 'O'
+            case CHAR_LOWERCASE_O:
+            case CHAR_UPPERCASE_O:
               // format as an object
               tempStr = stringify(
                 args[++a],
@@ -393,11 +403,11 @@ export function stringifyArgs(
                 options.depth != undefined ? options.depth : DEFAULT_MAX_DEPTH
               );
               break;
-            case 37: // '%'
+            case CHAR_PERCENT:
               str += first.slice(lastPos, i);
               lastPos = i + 1;
               continue;
-            case 99: // 'c'
+            case CHAR_LOWERCASE_C:
               // TODO: applies CSS style rules to the output string as specified
               continue;
             default:
@@ -411,7 +421,7 @@ export function stringifyArgs(
 
           str += tempStr;
           lastPos = i + 1;
-        } else if (nextChar === 37 /* '%' */) {
+        } else if (nextChar === CHAR_PERCENT) {
           str += first.slice(lastPos, i);
           lastPos = i + 1;
         }

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -145,6 +145,80 @@ test(function consoleTestStringifyWithDepth() {
   );
 });
 
+test(function consoleTestWithIntegerFormatSpecifier() {
+  assertEqual(stringify("%i"), "%i");
+  assertEqual(stringify("%i", 42.0), "42");
+  assertEqual(stringify("%i", 42), "42");
+  assertEqual(stringify("%i", "42"), "42");
+  assertEqual(stringify("%i", "42.0"), "42");
+  assertEqual(stringify("%i", 1.5), "1");
+  assertEqual(stringify("%i", -0.5), "0");
+  assertEqual(stringify("%i", ""), "NaN");
+  assertEqual(stringify("%i", Symbol()), "NaN");
+  assertEqual(stringify("%i %d", 42, 43), "42 43");
+  assertEqual(stringify("%d %i", 42), "42 %i");
+  assertEqual(stringify("%d", 12345678901234567890123), "1");
+  assertEqual(
+    stringify("%i", 12345678901234567890123n),
+    "12345678901234567890123n"
+  );
+});
+
+test(function consoleTestWithFloatFormatSpecifier() {
+  assertEqual(stringify("%f"), "%f");
+  assertEqual(stringify("%f", 42.0), "42");
+  assertEqual(stringify("%f", 42), "42");
+  assertEqual(stringify("%f", "42"), "42");
+  assertEqual(stringify("%f", "42.0"), "42");
+  assertEqual(stringify("%f", 1.5), "1.5");
+  assertEqual(stringify("%f", -0.5), "-0.5");
+  assertEqual(stringify("%f", Math.PI), "3.141592653589793");
+  assertEqual(stringify("%f", ""), "NaN");
+  assertEqual(stringify("%f", Symbol("foo")), "NaN");
+  assertEqual(stringify("%f", 5n), "5");
+  assertEqual(stringify("%f %f", 42, 43), "42 43");
+  assertEqual(stringify("%f %f", 42), "42 %f");
+});
+
+test(function consoleTestWithStringFormatSpecifier() {
+  assertEqual(stringify("%s"), "%s");
+  assertEqual(stringify("%s", undefined), "undefined");
+  assertEqual(stringify("%s", "foo"), "foo");
+  assertEqual(stringify("%s", 42), "42");
+  assertEqual(stringify("%s", "42"), "42");
+  assertEqual(stringify("%s %s", 42, 43), "42 43");
+  assertEqual(stringify("%s %s", 42), "42 %s");
+  assertEqual(stringify("%s", Symbol("foo")), "Symbol(foo)");
+});
+
+test(function consoleTestWithObjectFormatSpecifier() {
+  assertEqual(stringify("%o"), "%o");
+  assertEqual(stringify("%o", 42), "42");
+  assertEqual(stringify("%o", "foo"), "foo");
+  assertEqual(stringify("o: %o, a: %O", {}, []), "o: {}, a: []");
+  assertEqual(stringify("%o", { a: 42 }), "{ a: 42 }");
+  assertEqual(
+    stringify("%o", { a: { b: { c: { d: new Set([1]) } } } }),
+    "{ a: { b: { c: { d: [Set] } } } }"
+  );
+});
+
+test(function consoleTestWithVariousOrInvalidFormatSpecifier() {
+  assertEqual(stringify("%s:%s"), "%s:%s");
+  assertEqual(stringify("%i:%i"), "%i:%i");
+  assertEqual(stringify("%d:%d"), "%d:%d");
+  assertEqual(stringify("%%s%s", "foo"), "%sfoo");
+  assertEqual(stringify("%s:%s", undefined), "undefined:%s");
+  assertEqual(stringify("%s:%s", "foo", "bar"), "foo:bar");
+  assertEqual(stringify("%s:%s", "foo", "bar", "baz"), "foo:bar baz");
+  assertEqual(stringify("%%%s%%", "hi"), "%hi%");
+  assertEqual(stringify("%d:%d", 12), "12:%d");
+  assertEqual(stringify("%i:%i", 12), "12:%i");
+  assertEqual(stringify("%f:%f", 12), "12:%f");
+  assertEqual(stringify("o: %o, a: %o", {}), "o: {}, a: %o");
+  assertEqual(stringify("abc%", 1), "abc% 1");
+});
+
 test(function consoleTestCallToStringOnLabel() {
   const methods = ["count", "countReset", "time", "timeLog", "timeEnd"];
 


### PR DESCRIPTION
spec: https://console.spec.whatwg.org/#formatter

In the specification, `%i` and `%d` are integer, the behavior of Chrome, Firefox, and Edge is also like this. In Node.js, `%i` is an integer, but `%d` is a number. We use the behavior in the browsers。

in Node.js:

```js
console.log("%i", 1.1)   // 1
console.log("%d", 1.1)   // 1.1
```

in Chrome, Firefox, and Edge:

```js
console.log("%i", 1.1)   // 1
console.log("%d", 1.1)   // 1
```

spec:

> 2. If specifier is `%d` or `%i`:
>         1. If `Type(current)` is `Symbol`, let `converted` be `NaN`
>         2. Otherwise, let `converted` be the result of `Call(%parseInt%, undefined, « current, 10 »)`.

 -------

part of #1351 
