### PR TITLE
docs/typo: readerIterator -> toAsyncIterator as exported

### DIFF
--- a/js/io.ts
+++ b/js/io.ts
@@ -119,7 +119,7 @@ export async function copy(dst: Writer, src: Reader): Promise<number> {
 
 /** Turns `r` into async iterator.
  *
- *      for await (const chunk of readerIterator(reader)) {
+ *      for await (const chunk of toAsyncIterator(reader)) {
  *          console.log(chunk)
  *      }
  */


### PR DESCRIPTION
<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->

This corrects a docs typo in the toAsyncIterator example.