### PR TITLE
Fix example code of writeFile

### DIFF
--- a/js/write_file.ts
+++ b/js/write_file.ts
@@ -7,7 +7,7 @@ import * as dispatch from "./dispatch";
  *
  *       import { writeFileSync } from "deno";
  *
- *       const encoder = new TextEncoder("utf-8");
+ *       const encoder = new TextEncoder();
  *       const data = encoder.encode("Hello world\n");
  *       writeFileSync("hello.txt", data);
  */
@@ -23,7 +23,7 @@ export function writeFileSync(
  *
  *       import { writeFile } from "deno";
  *
- *       const encoder = new TextEncoder("utf-8");
+ *       const encoder = new TextEncoder();
  *       const data = encoder.encode("Hello world\n");
  *       await writeFile("hello.txt", data);
  */


### PR DESCRIPTION
According to spec, `TextEncoder()` takes no parameters. However `TextEncoder("utf-8")` is written
in example codes.

### Reference
Spec of TextEncoder: https://www.w3.org/TR/encoding/#interface-textencoder
MDN: https://developer.mozilla.org/ja/docs/Web/API/TextEncoder/TextEncoder#Parameters

### Error

[![Screenshot from Gyazo](https://gyazo.com/f6f4d2f53bed65ecd3636e7ef587a8f4/raw)](https://gyazo.com/f6f4d2f53bed65ecd3636e7ef587a8f4)

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
