### PR TITLE
Revise build instructions for windows

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -328,11 +328,17 @@ Extra steps for Mac users:
 Extra steps for Windows users:
 
 1. Add `python.exe` to `PATH` (e.g. `set PATH=%PATH%;C:\Python27\python.exe`)
-2. Get [VS Community 2017](https://www.visualstudio.com/downloads/). Make sure
-   to select the option to install C++ tools and the Windows SDK.
-3. Enable `Debugging Tools for Windows`. Go to `Control Panel` ->
-   `Windows 10 SDK` -> Right-Click -> `Change` -> `Change` ->
-   `Check Debugging Tools for Windows` -> `Change` -> `Finish`.
+2. Get [VS Community 2017](https://www.visualstudio.com/downloads/) with
+   `Desktop development with C++` toolkit and make sure to select the following
+   required tools listed below along with all C++ tools.
+   - Windows 10 SDK >= 10.0.17134
+   - Visual C++ ATL for x86 and x64
+   - Visual C++ MFC for x86 and x64
+   - C++ profiling tools
+3. Enable `Debugging Tools for Windows`. Go to `Control Panel` → `Programs` →
+   `Programs and Features` → Select
+   `Windows Software Development Kit - Windows 10` → `Change` → `Change` → Check
+   `Debugging Tools For Windows` → `Change` -> `Finish`.
 
 ### Build:
 


### PR DESCRIPTION
<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->

Listing precisely about the tools and features that are required for windows build in **Docs.md file.**
Some of the tools can easily be missed out while installing Visual Studio which are essential for
the third parties build like [Chromium](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/windows_build_instructions.md#setting-up-windows).
We need to mention all of them in the **Build Instructions (for advanced users only)** section of the Docs.md file.

Also, correcting the **enable debugging setting** location.