### PR TITLE
Add --info flag to display file info (compiled code/source map)

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -24,7 +24,9 @@ pub struct CodeFetchOutput {
   pub filename: String,
   pub media_type: msg::MediaType,
   pub source_code: String,
+  pub maybe_output_code_filename: Option<String>,
   pub maybe_output_code: Option<String>,
+  pub maybe_source_map_filename: Option<String>,
   pub maybe_source_map: Option<String>,
 }
 
@@ -70,7 +72,9 @@ impl CodeFetchOutput {
           filename,
           media_type: msg::MediaType::JavaScript, // TODO
           source_code,
+          maybe_output_code_filename: None,
           maybe_output_code,
+          maybe_source_map_filename: None,
           maybe_source_map,
         })
       }

--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -180,7 +180,9 @@ impl DenoDir {
         filename: filename.to_string(),
         media_type: map_content_type(&p, Some(&content_type)),
         source_code: source,
+        maybe_output_code_filename: None,
         maybe_output_code: None,
+        maybe_source_map_filename: None,
         maybe_source_map: None,
       }));
     } else {
@@ -219,7 +221,9 @@ impl DenoDir {
       filename: filename.to_string(),
       media_type: map_content_type(&p, maybe_content_type_str),
       source_code,
+      maybe_output_code_filename: None,
       maybe_output_code: None,
+      maybe_source_map_filename: None,
       maybe_source_map: None,
     }))
   }
@@ -307,6 +311,8 @@ impl DenoDir {
       return Ok(out);
     }
 
+    let (output_code_filename, output_source_map_filename) =
+      self.cache_path(&out.filename, &out.source_code);
     let result =
       self.load_cache(out.filename.as_str(), out.source_code.as_str());
     match result {
@@ -322,7 +328,13 @@ impl DenoDir {
         filename: out.filename,
         media_type: out.media_type,
         source_code: out.source_code,
+        maybe_output_code_filename: output_code_filename
+          .to_str()
+          .map(|s| s.to_string()),
         maybe_output_code: Some(output_code),
+        maybe_source_map_filename: output_source_map_filename
+          .to_str()
+          .map(|s| s.to_string()),
         maybe_source_map: Some(source_map),
       }),
     }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -29,6 +29,7 @@ pub struct DenoFlags {
   pub allow_run: bool,
   pub types: bool,
   pub prefetch: bool,
+  pub info: bool,
 }
 
 pub fn get_usage(opts: &Options) -> String {
@@ -111,6 +112,9 @@ fn set_recognized_flags(
         if matches.opt_present("prefetch") {
           flags.prefetch = true;
         }
+        if matches.opt_present("info") {
+          flags.info = true;
+        }
 
         if !matches.free.is_empty() {
           rest.extend(matches.free);
@@ -147,6 +151,7 @@ pub fn set_flags(
   opts.optflag("", "v8-options", "Print V8 command line options.");
   opts.optflag("", "types", "Print runtime TypeScript declarations.");
   opts.optflag("", "prefetch", "Prefetch the dependencies.");
+  opts.optflag("I", "info", "Show source file related info");
 
   let mut flags = DenoFlags::default();
 

--- a/tools/file_info_test.py
+++ b/tools/file_info_test.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import os
+import sys
+from util import tests_path, run, run_output, build_path, green_ok
+import tempfile
+import shutil
+import re
+
+
+def file_info_test(deno_exe):
+    sys.stdout.write("file_info_test...")
+    sys.stdout.flush()
+
+    # On Windows, set the base directory that mkdtemp() uses explicitly. If not,
+    # it'll use the short (8.3) path to the temp dir, which triggers the error
+    # 'TS5009: Cannot find the common subdirectory path for the input files.'
+    temp_dir = os.environ["TEMP"] if os.name == 'nt' else None
+    deno_dir = tempfile.mkdtemp(dir=temp_dir)
+    try:
+        t = "https://deno.land/thumb.ts"
+        run([deno_exe, t],
+            merge_env={"DENO_DIR": deno_dir})
+        output = run_output([deno_exe, "--info", t],
+                            merge_env={"DENO_DIR": deno_dir})
+        cache_location = os.path.join(deno_dir,
+                         "deps/https/deno.land/thumb.ts")
+        assert cache_location in output
+        assert "TypeScript" in output
+        # actual source map name changes with path
+        compiled_code = re.search(
+            'compiled javascript:([^\n]*)\n', output).group(1)
+        assert compiled_code + ".map" in output
+    finally:
+        shutil.rmtree(deno_dir)
+
+    print green_ok()
+
+
+if __name__ == "__main__":
+    file_info_test(sys.argv[1])

--- a/tools/test.py
+++ b/tools/test.py
@@ -13,6 +13,7 @@ from util_test import util_test
 from benchmark_test import benchmark_test
 from repl_test import repl_tests
 from prefetch_test import prefetch_test
+from file_info_test import file_info_test
 import subprocess
 import http_server
 
@@ -61,6 +62,8 @@ def main(argv):
     unit_tests(deno_exe)
 
     prefetch_test(deno_exe)
+
+    file_info_test(deno_exe)
 
     integration_tests(deno_exe)
 


### PR DESCRIPTION
```
$ ./target/debug/deno -I https://deno.land/thumb.ts
local filename: /Users/kevinqian/.deno/deps/https/deno.land/thumb.ts
media type: TypeScript
compiled javascript: /Users/kevinqian/.deno/gen/5532f1efea8d099e8204df3327c55b50367a8a7a.js
source map: /Users/kevinqian/.deno/gen/5532f1efea8d099e8204df3327c55b50367a8a7a.js.map
```