### PR TITLE
Remove duplicated links in website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -83,22 +83,6 @@
         </tr>
       </table>
 
-      <p>
-        <a href="https://github.com/denoland/deno/blob/master/Docs.md">
-          Documentation
-        </a>
-      </p>
-      <p>
-        <a href="typedoc/index.html">
-          API Reference
-        </a>
-      </p>
-      <p>
-        <a href="https://github.com/denolib/awesome-deno">
-          Other Deno resources.
-        </a>
-      </p>
-
       <h2 id="install"><a href="#install">#</a>Install</h2>
 
       <p id="install-shell"><a href="#install-shell">#</a>With Shell</p>


### PR DESCRIPTION
The links were duplicated at top and in `Dig in` section

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
