### PR TITLE
Fixed chart width to responsive

### DIFF
--- a/website/all_benchmark.html
+++ b/website/all_benchmark.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2018 the Deno authors. All rights reserved. MIT license. -->
+<!-- Copyright 2018-2019 the Deno authors. All rights reserved. MIT license. -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/website/app.js
+++ b/website/app.js
@@ -135,11 +135,6 @@ function generate(
   // @ts-ignore
   c3.generate({
     bindto: id,
-    size: {
-      height: 300,
-      // @ts-ignore
-      width: window.chartWidth || 375 // TODO: do not use global variable
-    },
     data: {
       columns,
       onclick

--- a/website/style.css
+++ b/website/style.css
@@ -13,6 +13,8 @@ main {
 }
 svg {
   margin: 0px auto;
+  width: 100%;
+  height: 300px;
 }
 
 a {


### PR DESCRIPTION
On the mobile device, the chart is pulled out of the screen.
So I changed the responsive width.

before:
<img width="375" alt="2019-02-04 3 35 12" src="https://user-images.githubusercontent.com/301613/52193494-bba50080-2892-11e9-8f5d-867bc705e820.png">

after:
<img width="375" alt="2019-02-04 3 42 49" src="https://user-images.githubusercontent.com/301613/52193647-8cdb5a00-2893-11e9-9f93-bd96884f4cf3.png">

