### PR TITLE
Make integration tests standalone

### DIFF
--- a/tools/integration_tests.py
+++ b/tools/integration_tests.py
@@ -89,7 +89,7 @@ def integration_tests(deno_exe, test_filter = None):
 
         print "... " + green_ok()
 
-def main(argv):
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--filter", help="Run specific tests")
     parser.add_argument("--release", help="Use release build of Deno",
@@ -120,4 +120,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    sys.exit(main())

--- a/tools/integration_tests.py
+++ b/tools/integration_tests.py
@@ -97,11 +97,7 @@ def main(argv):
     parser.add_argument("--executable", help="Use external executable of Deno")
     args = parser.parse_args()
 
-    target = None
-    if args.release:
-        target = "release"
-    else:
-        target = "debug"
+    target = "release" if args.release else "debug"
 
     build_dir = None
     if "DENO_BUILD_PATH" in os.environ:

--- a/tools/integration_tests.py
+++ b/tools/integration_tests.py
@@ -91,7 +91,7 @@ def integration_tests(deno_exe, test_filter = None):
 
 def main(argv):
     parser = argparse.ArgumentParser()
-    parser.add_argument("filter", help="Run specific tests")
+    parser.add_argument("--filter", help="Run specific tests")
     parser.add_argument("--release", help="Use release build of Deno",
                         action="store_true")
     parser.add_argument("--executable", help="Use external executable of Deno")
@@ -116,11 +116,7 @@ def main(argv):
 
     http_server.spawn()
 
-    test_filter = None
-    if len(argv) > 1:
-        test_filter = argv[1]
-
-    integration_tests(deno_exe, test_filter)
+    integration_tests(deno_exe, args.filter)
 
 
 if __name__ == "__main__":

--- a/tools/integration_tests.py
+++ b/tools/integration_tests.py
@@ -11,8 +11,9 @@ import os
 import re
 import sys
 import subprocess
-from util import root_path, tests_path, pattern_match, green_ok, red_failed
-
+import http_server
+import argparse
+from util import root_path, tests_path, pattern_match, green_ok, red_failed, rmtree, executable_suffix
 
 def read_test(file_name):
     with open(file_name, "r") as f:
@@ -88,10 +89,39 @@ def integration_tests(deno_exe, test_filter = None):
         print "... " + green_ok()
 
 def main(argv):
-    deno_exe = argv[1]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filter", help="Run specific tests")
+    parser.add_argument("--release", help="Use release build of Deno", action="store_true")
+    parser.add_argument("--executable", help="Use external executable of Deno")
+    args = parser.parse_args()
+
+    target = None
+    if args.release:
+        target = "release"
+    else:
+        target = "debug"
+
+    build_dir = None
+    if "DENO_BUILD_PATH" in os.environ:
+        build_dir = os.environ["DENO_BUILD_PATH"]
+    else:
+        build_dir = os.path.join(root_path, "target", target)
+
+    deno_dir = os.path.join(build_dir, ".deno_test")
+    if os.path.isdir(deno_dir):
+        rmtree(deno_dir)
+    os.environ["DENO_DIR"] = deno_dir
+
+    deno_exe = os.path.join(build_dir, "deno" + executable_suffix)
+    if args.executable:
+        deno_exe = args.executable
+
+    http_server.spawn()
+
     test_filter = None
-    if len(argv) > 2:
-        test_filter = argv[2]
+    if len(argv) > 1:
+        test_filter = argv[1]
+
     integration_tests(deno_exe, test_filter)
 
 

--- a/tools/integration_tests.py
+++ b/tools/integration_tests.py
@@ -13,7 +13,8 @@ import sys
 import subprocess
 import http_server
 import argparse
-from util import root_path, tests_path, pattern_match, green_ok, red_failed, rmtree, executable_suffix
+from util import root_path, tests_path, pattern_match, \
+                 green_ok, red_failed, rmtree, executable_suffix
 
 def read_test(file_name):
     with open(file_name, "r") as f:
@@ -91,7 +92,8 @@ def integration_tests(deno_exe, test_filter = None):
 def main(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("filter", help="Run specific tests")
-    parser.add_argument("--release", help="Use release build of Deno", action="store_true")
+    parser.add_argument("--release", help="Use release build of Deno",
+                        action="store_true")
     parser.add_argument("--executable", help="Use external executable of Deno")
     args = parser.parse_args()
 


### PR DESCRIPTION
Fixes #1642. You can now run:
* `python tools/integration_tests.py`
* `python tools/integration_tests.py --release`
* `python tools/integration_tests.py --executable /path/to/executable`
* `python tools/integration_tests.py error_007`
* `python tools/integration_tests.py error_007 --release`
And many more!