### PR TITLE
Fix indentation for .py files in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ indent_style = space
 indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4


### PR DESCRIPTION
Indentation in 🐍 files should be 4 spaces, not 2