### PR TITLE
Separate internal tools tests (setup, util, benchmark) into a new script

### DIFF
--- a/tools/internal_tests.py
+++ b/tools/internal_tests.py
@@ -1,0 +1,23 @@
+from setup_test import setup_test
+from util_test import util_test
+from benchmark_test import benchmark_test
+from util import build_path, executable_suffix
+import sys
+import os
+
+def internal_tests(build_dir, deno_exe):
+  setup_test()
+  util_test()
+  benchmark_test(build_dir, deno_exe)
+
+def main():
+    import http_server
+    http_server.spawn()
+
+    build_dir = build_path()
+    deno_exe = os.path.join(build_dir, "deno" + executable_suffix)
+
+    internal_tests(build_dir, deno_exe)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test.py
+++ b/tools/test.py
@@ -5,12 +5,10 @@
 import os
 import sys
 from integration_tests import integration_tests
+from internal_tests import internal_tests
 from deno_dir_test import deno_dir_test
-from setup_test import setup_test
 from util import build_path, enable_ansi_colors, executable_suffix, run, rmtree
 from unit_tests import unit_tests
-from util_test import util_test
-from benchmark_test import benchmark_test
 from repl_test import repl_tests
 from prefetch_test import prefetch_test
 from fmt_test import fmt_test
@@ -47,9 +45,7 @@ def main(argv):
     check_exists(deno_exe)
 
     # Internal tools testing
-    setup_test()
-    util_test()
-    benchmark_test(build_dir, deno_exe)
+    internal_tests(build_dir, deno_exe)
 
     test_cc = os.path.join(build_dir, "test_cc" + executable_suffix)
     check_exists(test_cc)


### PR DESCRIPTION
Similar to #1671. Reasons: it'll be easier to run only internal tests, not all tests.