### PR TITLE
Replace macros to check nullptr

### DIFF
--- a/libdeno/api.cc
+++ b/libdeno/api.cc
@@ -79,7 +79,7 @@ deno::DenoIsolate* unwrap(Deno* d_) {
 
 deno_buf deno_get_snapshot(Deno* d_) {
   auto* d = unwrap(d_);
-  CHECK_NE(d->snapshot_creator_, nullptr);
+  CHECK_NOT_NULL(d->snapshot_creator_);
   d->ClearModules();
   d->context_.Reset();
 

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -20,7 +20,7 @@ std::vector<InternalFieldData*> deserialized_data;
 
 void DeserializeInternalFields(v8::Local<v8::Object> holder, int index,
                                v8::StartupData payload, void* data) {
-  DCHECK_EQ(data, nullptr);
+  DCHECK_NULL(data);
   if (payload.raw_size == 0) {
     holder->SetAlignedPointerInInternalField(index, nullptr);
     return;
@@ -33,7 +33,7 @@ void DeserializeInternalFields(v8::Local<v8::Object> holder, int index,
 
 v8::StartupData SerializeInternalFields(v8::Local<v8::Object> holder, int index,
                                         void* data) {
-  DCHECK_EQ(data, nullptr);
+  DCHECK_NULL(data);
   InternalFieldData* embedder_field = static_cast<InternalFieldData*>(
       holder->GetAlignedPointerFromInternalField(index));
   if (embedder_field == nullptr) return {nullptr, 0};
@@ -139,7 +139,7 @@ v8::Local<v8::Uint8Array> ImportBuf(DenoIsolate* d, deno_buf buf) {
       // Fast case. We reuse the global ArrayBuffer.
       if (d->global_import_buf_.IsEmpty()) {
         // Lazily initialize it.
-        DCHECK_EQ(d->global_import_buf_ptr_, nullptr);
+        DCHECK_NULL(d->global_import_buf_ptr_);
         ab = v8::ArrayBuffer::New(d->isolate_, GLOBAL_IMPORT_BUF_SIZE);
         d->global_import_buf_.Reset(d->isolate_, ab);
         d->global_import_buf_ptr_ = ab->GetContents().Data();
@@ -202,7 +202,7 @@ void Send(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Locker locker(d->isolate_);
   v8::HandleScope handle_scope(isolate);
 
-  CHECK_EQ(d->current_args_, nullptr);  // libdeno.send re-entry forbidden.
+  CHECK_NULL(d->current_args_);  // libdeno.send re-entry forbidden.
   int32_t req_id = d->next_req_id_++;
 
   v8::Local<v8::Value> control_v = args[0];
@@ -220,7 +220,7 @@ void Send(const v8::FunctionCallbackInfo<v8::Value>& args) {
     CHECK_EQ(args.Length(), 1);
   }
 
-  DCHECK_EQ(d->current_args_, nullptr);
+  DCHECK_NULL(d->current_args_);
   d->current_args_ = &args;
 
   d->recv_cb_(d->user_data_, req_id, control, data);

--- a/libdeno/exceptions.cc
+++ b/libdeno/exceptions.cc
@@ -155,7 +155,7 @@ void HandleException(v8::Local<v8::Context> context,
   v8::Isolate* isolate = context->GetIsolate();
   DenoIsolate* d = DenoIsolate::FromIsolate(isolate);
   std::string json_str = EncodeExceptionAsJSON(context, exception);
-  CHECK(d != nullptr);
+  CHECK_NOT_NULL(d);
   d->last_exception_ = json_str;
 }
 
@@ -164,7 +164,7 @@ void HandleExceptionMessage(v8::Local<v8::Context> context,
   v8::Isolate* isolate = context->GetIsolate();
   DenoIsolate* d = DenoIsolate::FromIsolate(isolate);
   std::string json_str = EncodeMessageAsJSON(context, message);
-  CHECK(d != nullptr);
+  CHECK_NOT_NULL(d);
   d->last_exception_ = json_str;
 }
 

--- a/libdeno/modules.cc
+++ b/libdeno/modules.cc
@@ -70,7 +70,7 @@ v8::MaybeLocal<v8::Module> ResolveCallback(Local<Context> context,
 
   deno_mod referrer_id = referrer->GetIdentityHash();
   auto* referrer_info = d->GetModuleInfo(referrer_id);
-  CHECK_NE(referrer_info, nullptr);
+  CHECK_NOT_NULL(referrer_info);
 
   for (int i = 0; i < referrer->GetModuleRequestsLength(); i++) {
     Local<String> req = referrer->GetModuleRequest(i);
@@ -158,7 +158,7 @@ void deno_mod_instantiate(Deno* d_, void* user_data, deno_mod id,
 
   v8::TryCatch try_catch(isolate);
   {
-    CHECK_EQ(nullptr, d->resolve_cb_);
+    CHECK_NULL(d->resolve_cb_);
     d->resolve_cb_ = cb;
     {
       auto* info = d->GetModuleInfo(id);

--- a/libdeno/snapshot_creator.cc
+++ b/libdeno/snapshot_creator.cc
@@ -16,8 +16,8 @@ int main(int argc, char** argv) {
 
   deno_set_v8_flags(&argc, argv);
 
-  CHECK_NE(js_fn, nullptr);
-  CHECK_NE(snapshot_out_bin, nullptr);
+  CHECK_NOT_NULL(js_fn);
+  CHECK_NOT_NULL(snapshot_out_bin);
 
   std::string js_source;
   CHECK(deno::ReadFileToString(js_fn, &js_source));


### PR DESCRIPTION
This replaces `CHECK_EQ`/`CHECK_NE` with `CHECK_NULL`/`CHECK_NOT_NULL` to check nullptr.
These macros are implemented in V8.
Refs: https://github.com/denoland/deno_third_party/blob/master/v8/src/base/logging.h#L312

<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->
