### PR TITLE
Add back TypeScript version for -v flag using package.json info

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -129,6 +129,11 @@ deno_cargo_info = exec_script("build_extra/rust/get_cargo_info.py",
                               [ rebase_path("Cargo.toml", root_build_dir) ],
                               "json")
 
+# Reads the typescript info from package.json
+deno_ts_info = exec_script("build_extra/rust/get_ts_info.py",
+                           [ rebase_path("package.json", root_build_dir) ],
+                           "json")
+
 rust_executable("deno") {
   source_root = "src/main.rs"
   extern = main_extern
@@ -140,6 +145,12 @@ rust_executable("deno") {
   # TODO integrate this into rust.gni by allowing the rust_executable template
   # to specify a cargo.toml from which it will extract a version.
   crate_version = deno_cargo_info.version
+
+  envs = [ [
+        "TYPESCRIPT_VERSION",
+        deno_ts_info.version,
+      ] ]
+
   inputs = [
     "Cargo.toml",
   ]
@@ -154,6 +165,12 @@ rust_test("test_rs") {
 
   # Extract version from Cargo.toml
   crate_version = deno_cargo_info.version
+
+  envs = [ [
+        "TYPESCRIPT_VERSION",
+        deno_ts_info.version,
+      ] ]
+
   inputs = [
     "Cargo.toml",
   ]

--- a/build_extra/rust/get_ts_info.cmd
+++ b/build_extra/rust/get_ts_info.cmd
@@ -1,0 +1,2 @@
+REM Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+@"%PYTHON_EXE%" "%~dpn0.py" %*

--- a/build_extra/rust/get_ts_info.py
+++ b/build_extra/rust/get_ts_info.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+
+import sys
+import re
+
+# Read the package version from package.json and output as json
+package_json_path = sys.argv[1]
+
+for line in open(package_json_path):
+    match = re.search('"typescript": "(.*)"', line)
+    if match:
+        print('{"version": "' + match.group(1) + '"}')
+        break

--- a/build_extra/rust/run.py
+++ b/build_extra/rust/run.py
@@ -21,5 +21,17 @@ for i, arg in enumerate(args):
         os.environ["CARGO_PKG_VERSION"] = match.group(1)
         del args[i]
         break
+# Set the custom env variables if provided as an argument
+for i, arg in enumerate(args):
+    match = re.search('--custom-envs="?([^"]*)"?', arg)
+    if match:
+        env_vars = match.group(1).split(",")
+        for env_var in env_vars:
+            env_var = env_var.strip()
+            if len(env_var) > 0:
+                env_args = env_var.split("=")
+                os.environ[env_args[0]] = env_args[1]
+        del args[i]
+        break
 
 sys.exit(subprocess.call(args))

--- a/build_extra/rust/rust.gni
+++ b/build_extra/rust/rust.gni
@@ -52,6 +52,7 @@ template("rust_crate") {
                            "crate_version",
                            "deps",
                            "edition",
+                           "envs",
                            "inputs",
                            "features",
                            "is_test",
@@ -203,6 +204,15 @@ template("rust_crate") {
         # This is used to set env variables for Cargo build compatibility
         "--cargo-pkg-version=$crate_version",
       ]
+    }
+
+    if (defined(envs)) {
+      env_vars = "--custom-envs=\""
+      foreach(e, envs) {
+        env_vars += e[0] + "=" + e[1] + ","
+      }
+      env_vars += "\""
+      args += [ env_vars ]
     }
 
     if (is_debug) {

--- a/js/main.ts
+++ b/js/main.ts
@@ -27,8 +27,7 @@ export default function denoMain() {
   if (startResMsg.versionFlag()) {
     console.log("deno:", startResMsg.denoVersion());
     console.log("v8:", startResMsg.v8Version());
-    // TODO figure out a way to restore functionality
-    // console.log("typescript:", version);
+    console.log("typescript:", startResMsg.tsVersion());
     os.exit(0);
   }
 

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -160,6 +160,7 @@ table StartRes {
   version_flag: bool;
   deno_version: string;
   v8_version: string;
+  ts_version: string;
 }
 
 table WorkerGetMessage {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -255,6 +255,9 @@ fn op_start(
   let deno_version = version::DENO;
   let deno_version_off = builder.create_string(deno_version);
 
+  let ts_version = version::TS;
+  let ts_version_off = builder.create_string(ts_version);
+
   let inner = msg::StartRes::create(
     &mut builder,
     &msg::StartResArgs {
@@ -265,6 +268,7 @@ fn op_start(
       types_flag: state.flags.types,
       version_flag: state.flags.version,
       v8_version: Some(v8_version_off),
+      ts_version: Some(ts_version_off),
       deno_version: Some(deno_version_off),
       ..Default::default()
     },

--- a/src/version.rs
+++ b/src/version.rs
@@ -4,6 +4,7 @@ use crate::libdeno;
 use std::ffi::CStr;
 
 pub const DENO: &str = env!("CARGO_PKG_VERSION");
+pub const TS: &str = env!("TYPESCRIPT_VERSION");
 
 pub fn v8() -> &'static str {
   let version = unsafe { libdeno::deno_v8_version() };


### PR DESCRIPTION
Similar to the way we pass `deno` crate version
