### PR TITLE
Move deno module to globals

### DIFF
--- a/js/globals.ts
+++ b/js/globals.ts
@@ -45,7 +45,7 @@ export const window = globalEval("this");
 window.window = window;
 
 // builtin modules
-window.deno = denoModule;
+window.deno = denoModule as any;
 
 // Globally available functions and object instances.
 window.atob = textEncoding.atob;

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -23,6 +23,9 @@ import * as urlSearchParams from "./url_search_params";
 import * as workers from "./workers";
 import * as performanceUtil from "./performance";
 
+// builtin modules
+import * as denoModule from "./deno";
+
 // These imports are not exposed and therefore are fine to just import the
 // symbols required.
 import { globalEval } from "./global_eval";
@@ -40,6 +43,9 @@ declare global {
 export const window = globalEval("this");
 // A self reference to the global object.
 window.window = window;
+
+// builtin modules
+window.deno = denoModule;
 
 // Globally available functions and object instances.
 window.atob = textEncoding.atob;

--- a/js/main.ts
+++ b/js/main.ts
@@ -2,16 +2,13 @@
 // tslint:disable-next-line:no-reference
 /// <reference path="./plugins.d.ts" />
 
-import "./globals";
+import { window } from "./globals";
 
 import { log } from "./util";
 import * as os from "./os";
 import { libdeno } from "./libdeno";
 import { args } from "./deno";
 import { replLoop } from "./repl";
-
-// builtin modules
-import * as deno from "./deno";
 
 // TODO(kitsonk) remove with `--types` below
 import libDts from "gen/lib/lib.deno_runtime.d.ts!string";
@@ -20,7 +17,7 @@ import libDts from "gen/lib/lib.deno_runtime.d.ts!string";
 export default function denoMain() {
   const startResMsg = os.start();
 
-  libdeno.builtinModules["deno"] = deno;
+  libdeno.builtinModules["deno"] = window.deno;
   Object.freeze(libdeno.builtinModules);
 
   // handle `--version`

--- a/tools/format.ts
+++ b/tools/format.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env deno --allow-run
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import * as deno from "deno";
 import { join } from "../js/deps/https/deno.land/x/std/fs/path.ts";
 import { findFiles } from "./util.ts";
 


### PR DESCRIPTION
Fixes #1705. I've added a backwards compatibility, so no user code will be broken.