### PR TITLE
fix: clippy warnings with clippy 0.0.212 (3bda548f 2019-02-03)

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -25,7 +25,7 @@ pub fn strip_ansi_codes(s: &str) -> Cow<str> {
 }
 
 pub fn use_color() -> bool {
-  *NO_COLOR == false
+  !(*NO_COLOR)
 }
 
 pub fn red_bold(s: String) -> impl fmt::Display {

--- a/src/js_errors.rs
+++ b/src/js_errors.rs
@@ -115,7 +115,7 @@ impl fmt::Display for JSError {
               s.push(' ');
             }
           }
-          write!(f, "{}\n", ansi::red_bold(s))?;
+          writeln!(f, "{}", ansi::red_bold(s))?;
         }
       }
     }
@@ -193,7 +193,7 @@ impl StackFrame {
     Some(StackFrame {
       line: line - 1,
       column: column - 1,
-      script_name: script_name,
+      script_name,
       function_name,
       is_eval,
       is_constructor,
@@ -227,8 +227,8 @@ impl StackFrame {
             let orig_source = sm.sources[original.source as usize].clone();
             (
               orig_source,
-              original.original_line as i64,
-              original.original_column as i64,
+              i64::from(original.original_line),
+              i64::from(original.original_column),
             )
           }
         },

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -184,11 +184,11 @@ fn op_now(
   assert_eq!(data.len(), 0);
   let start = SystemTime::now();
   let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
-  let time = since_the_epoch.as_secs() as u64 * 1000
-    + since_the_epoch.subsec_millis() as u64;
+  let time = since_the_epoch.as_secs() * 1000
+    + u64::from(since_the_epoch.subsec_millis());
 
   let builder = &mut FlatBufferBuilder::new();
-  let inner = msg::NowRes::create(builder, &msg::NowResArgs { time: time });
+  let inner = msg::NowRes::create(builder, &msg::NowResArgs { time });
   ok_future(serialize_response(
     base.cmd_id(),
     builder,
@@ -327,7 +327,6 @@ fn op_code_fetch(
       filename: Some(builder.create_string(&out.filename)),
       media_type: out.media_type,
       source_code: Some(builder.create_string(&out.source_code)),
-      ..Default::default()
     };
     let inner = msg::CodeFetchRes::create(builder, &msg_args);
     Ok(serialize_response(
@@ -622,9 +621,15 @@ fn op_chmod(
     #[cfg(any(unix))]
     {
       // We need to use underscore to compile in Windows.
-      #[cfg_attr(feature = "cargo-clippy", allow(used_underscore_binding))]
+      #[cfg_attr(
+        feature = "cargo-clippy",
+        allow(clippy::used_underscore_binding)
+      )]
       let mut permissions = _metadata.permissions();
-      #[cfg_attr(feature = "cargo-clippy", allow(used_underscore_binding))]
+      #[cfg_attr(
+        feature = "cargo-clippy",
+        allow(clippy::used_underscore_binding)
+      )]
       permissions.set_mode(_mode);
       fs::set_permissions(&path, permissions)?;
     }


### PR DESCRIPTION
<!--
https://github.com/denoland/deno/blob/master/.github/CONTRIBUTING.md
-->

I found some clippy warnings with v0.0.212.
I fixed these warnings.

<details>
<summary>clippy messages</summary>
warning: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
   --> src/js_errors.rs:118:11
    |
118 |           write!(f, "{}\n", ansi::red_bold(s))?;
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(clippy::write_with_newline)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#write_with_newline

warning: redundant field names in struct initialization
   --> src/js_errors.rs:196:7
    |
196 |       script_name: script_name,
    |       ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `script_name`
    |
    = note: #[warn(clippy::redundant_field_names)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/ops.rs:191:63
    |
191 |   let inner = msg::NowRes::create(builder, &msg::NowResArgs { time: time });
    |                                                               ^^^^^^^^^^ help: replace it with: `time`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: lint name `used_underscore_binding` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
   --> src/ops.rs:625:50
    |
625 |       #[cfg_attr(feature = "cargo-clippy", allow(used_underscore_binding))]
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^ help: change it to: `clippy::used_underscore_binding`
    |
    = note: #[warn(renamed_and_removed_lints)] on by default

warning: lint name `used_underscore_binding` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
   --> src/ops.rs:627:50
    |
627 |       #[cfg_attr(feature = "cargo-clippy", allow(used_underscore_binding))]
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^ help: change it to: `clippy::used_underscore_binding`

warning: lint name `used_underscore_binding` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
   --> src/ops.rs:625:50
    |
625 |       #[cfg_attr(feature = "cargo-clippy", allow(used_underscore_binding))]
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^ help: change it to: `clippy::used_underscore_binding`

warning: equality checks against false can be replaced by a negation
  --> src/ansi.rs:28:3
   |
28 |   *NO_COLOR == false
   |   ^^^^^^^^^^^^^^^^^^ help: try simplifying it as shown: `!(*NO_COLOR)`
   |
   = note: #[warn(clippy::bool_comparison)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_comparison

warning: casting u32 to i64 may become silently lossy if types change
   --> src/js_errors.rs:230:15
    |
230 |               original.original_line as i64,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `i64::from(original.original_line)`
    |
    = note: #[warn(clippy::cast_lossless)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_lossless

warning: casting u32 to i64 may become silently lossy if types change
   --> src/js_errors.rs:231:15
    |
231 |               original.original_column as i64,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `i64::from(original.original_column)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_lossless

warning: casting u32 to u64 may become silently lossy if types change
   --> src/ops.rs:188:7
    |
188 |     + since_the_epoch.subsec_millis() as u64;
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u64::from(since_the_epoch.subsec_millis())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_lossless

warning: struct update has no effect, all the fields in the struct have already been specified
   --> src/ops.rs:330:9
    |
330 |       ..Default::default()
    |         ^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(clippy::needless_update)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_update
</details>
