### PR TITLE
v0.2.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "deno"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 # crates.
 [package]
 name = "deno"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2018"
 
 [dependencies]

--- a/Releases.md
+++ b/Releases.md
@@ -6,6 +6,18 @@ https://github.com/denoland/deno/releases
 We also have a one-line install commands at
 https://github.com/denoland/deno_install
 
+### v0.2.11 / 2019.02.08
+
+- Add deps to --info output (#1720)
+- Add --allow-read (#1689)
+- Add deno.isTTY() (#1622)
+- Add emojis to permission prompts (#1684)
+- Add basic WebAssembly support (#1677)
+- Add `NO_COLOR` support https://no-color.org/ (#1716)
+- Add color exceptions (#1698)
+- Fix: do not load cache files when recompile flag is set (#1695)
+- Upgrade V8 to 7.4.98 (#1640)
+
 ### v0.2.10 / 2019.02.02
 
 - Add --fmt (#1646)


### PR DESCRIPTION
https://github.com/denoland/deno/pull/1716 should land first.