### PR TITLE
Improve formatting

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ environment:
   RUSTUP_HOME: $(RUST_DIR)\rustup
   RUST_BACKTRACE: full
   RUSTC_WRAPPER: sccache
+  PYTHONPATH: third_party\python_packages
   SCCACHE_BUCKET: deno-sccache
   AWS_ACCESS_KEY_ID: AKIAIVRN52PLDBP55LBQ
   AWS_SECRET_ACCESS_KEY:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,7 +19,8 @@ Before submitting, please make sure the following is done:
 
 1. There are tests that cover the changes.
 2. Ensure `./tools/test.py` passes.
-3. Format your code with `deno ./tools/format.ts --allow-read --allow-run`.
+3. Format your code with `PYTHONPATH=third_party/python_packages deno ./tools/format.ts --allow-read --allow-run`.
+   <!-- TODO: set PYTHONPATH in format.ts when run API has env option -->
 4. Make sure `./tools/lint.py` passes.
 
 ## Changes to `third_party`

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - RUST_BACKTRACE=full
   - CARGO_TARGET_DIR=$HOME/target
   - PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH
+  - PYTHONPATH=third_party/python_packages
   - RUSTC_WRAPPER=sccache
   - SCCACHE_BUCKET=deno-sccache
   - AWS_ACCESS_KEY_ID=AKIAIVRN52PLDBP55LBQ

--- a/Docs.md
+++ b/Docs.md
@@ -116,7 +116,8 @@ Extra steps for Windows users:
     ./tools/test.py
 
     # Format code.
-    deno ./tools/format.ts --allow-read --allow-run
+    PYTHONPATH=third_party/python_packages deno ./tools/format.ts --allow-read --allow-run
+    <!-- TODO: set PYTHONPATH in format.ts when run API has env option -->
 
 Other useful commands:
 

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -245,8 +245,11 @@ test(function consoleTestError() {
   try {
     throw new MyError("This is an error");
   } catch (e) {
-    assert(stringify(e).split("\n")[3]
-      .includes("MyError: This is an error"));
+    assert(
+      stringify(e)
+        .split("\n")[3]
+        .includes("MyError: This is an error")
+    );
   }
 });
 

--- a/js/repl.ts
+++ b/js/repl.ts
@@ -107,7 +107,8 @@ function evaluate(code: string): void {
   } else {
     if (errInfo.isNativeError) {
       const formattedError = formatError(
-        libdeno.errorToJSON(errInfo.thrown as Error));
+        libdeno.errorToJSON(errInfo.thrown as Error)
+      );
       console.error(formattedError);
     } else {
       console.error("Thrown:", errInfo.thrown);

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -57,15 +57,20 @@ def import_data_from_gh_pages():
 
 def get_binary_sizes(build_dir):
     path_dict = {
-        "deno": os.path.join(build_dir, "deno" + executable_suffix),
-        "main.js": os.path.join(build_dir, "gen/bundle/main.js"),
-        "main.js.map": os.path.join(build_dir, "gen/bundle/main.js.map"),
-        "compiler.js": os.path.join(build_dir, "gen/bundle/compiler.js"),
-        "compiler.js.map": os.path.join(build_dir,
-            "gen/bundle/compiler.js.map"),
-        "snapshot_deno.bin": os.path.join(build_dir, "gen/snapshot_deno.bin"),
-        "snapshot_compiler.bin": os.path.join(build_dir,
-            "gen/snapshot_compiler.bin")
+        "deno":
+        os.path.join(build_dir, "deno" + executable_suffix),
+        "main.js":
+        os.path.join(build_dir, "gen/bundle/main.js"),
+        "main.js.map":
+        os.path.join(build_dir, "gen/bundle/main.js.map"),
+        "compiler.js":
+        os.path.join(build_dir, "gen/bundle/compiler.js"),
+        "compiler.js.map":
+        os.path.join(build_dir, "gen/bundle/compiler.js.map"),
+        "snapshot_deno.bin":
+        os.path.join(build_dir, "gen/snapshot_deno.bin"),
+        "snapshot_compiler.bin":
+        os.path.join(build_dir, "gen/snapshot_compiler.bin")
     }
     sizes = {}
     for name, path in path_dict.items():

--- a/tools/fmt_test.py
+++ b/tools/fmt_test.py
@@ -18,8 +18,7 @@ def fmt_test(deno_exe):
         # Set DENO_DIR to //js/ so we don't have to rely on an intenet
         # connection to download https://deno.land/x/std/prettier/main.ts
         deno_dir = os.path.join(root_path, "js")
-        run(
-            [deno_exe, dst, "--fmt", "--allow-read"],
+        run([deno_exe, dst, "--fmt", "--allow-read"],
             merge_env={"DENO_DIR": deno_dir})
         with open(fixed_filename) as f:
             expected = f.read()

--- a/tools/integration_tests.py
+++ b/tools/integration_tests.py
@@ -45,7 +45,7 @@ def str2bool(v):
         raise ValueError("Bad boolean value")
 
 
-def integration_tests(deno_exe, test_filter = None):
+def integration_tests(deno_exe, test_filter=None):
     assert os.path.isfile(deno_exe)
     tests = sorted([
         filename for filename in os.listdir(tests_path)
@@ -97,11 +97,12 @@ def integration_tests(deno_exe, test_filter = None):
 
         print green_ok()
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--filter", help="Run specific tests")
-    parser.add_argument("--release", help="Use release build of Deno",
-                        action="store_true")
+    parser.add_argument(
+        "--release", help="Use release build of Deno", action="store_true")
     parser.add_argument("--executable", help="Use external executable of Deno")
     args = parser.parse_args()
 

--- a/tools/is_tty_test.py
+++ b/tools/is_tty_test.py
@@ -10,15 +10,18 @@ from permission_prompt_test import tty_capture
 
 IS_TTY_TEST_TS = "tests/is_tty.ts"
 
+
 def is_tty_test(deno_exe):
     cmd = [deno_exe, IS_TTY_TEST_TS]
     code, stdout, _ = tty_capture(cmd, b'')
     assert code == 0
     assert str(stdin.isatty()).lower() in stdout
 
+
 def main():
     deno_exe = os.path.join(build_path(), "deno" + executable_suffix)
     is_tty_test(deno_exe)
+
 
 if __name__ == "__main__":
     main()

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -15,8 +15,8 @@ tslint = os.path.join(third_party_path, "node_modules", "tslint", "bin",
 
 os.chdir(root_path)
 run([
-    "python", cpplint, "--filter=-build/include_subdir", "--repository=libdeno",
-    "--extensions=cc,h", "--recursive", "libdeno"
+    "python", cpplint, "--filter=-build/include_subdir",
+    "--repository=libdeno", "--extensions=cc,h", "--recursive", "libdeno"
 ])
 
 run(["node", tslint, "-p", ".", "--exclude", "**/gen/**/*.ts"])

--- a/tools/permission_prompt_test.ts
+++ b/tools/permission_prompt_test.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { args, listen, env, exit, makeTempDirSync, readFile, run} from "deno";
+import { args, listen, env, exit, makeTempDirSync, readFile, run } from "deno";
 
 const name = args[1];
 const test = {
   needsRead: () => {
-    readFile("package.json")
+    readFile("package.json");
   },
   needsWrite: () => {
     makeTempDirSync();

--- a/tools/test.py
+++ b/tools/test.py
@@ -38,7 +38,6 @@ def test_no_color(deno_exe):
     print green_ok()
 
 
-
 def main(argv):
     if len(argv) == 2:
         build_dir = sys.argv[1]

--- a/tools/third_party.py
+++ b/tools/third_party.py
@@ -255,8 +255,7 @@ def download_clang_format():
 
 # Download clang by calling the clang update script.
 def download_clang():
-    run(['python', tp('v8/tools/clang/scripts/update.py')],
-        env=google_env())
+    run(['python', tp('v8/tools/clang/scripts/update.py')], env=google_env())
 
 
 def maybe_download_sysroot():

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -46,7 +46,8 @@ def unit_tests(deno_exe):
     run_unit_test(deno_exe, "permR0W0N0E0U0")
     run_unit_test(deno_exe, "permR1W0N0E0U0", ["--allow-read"])
     run_unit_test(deno_exe, "permR0W1N0E0U0", ["--allow-write"])
-    run_unit_test(deno_exe, "permR1W1N0E0U0", ["--allow-read", "--allow-write"])
+    run_unit_test(deno_exe, "permR1W1N0E0U0",
+                  ["--allow-read", "--allow-write"])
     run_unit_test(deno_exe, "permR1W0N1E0U0", ["--allow-read", "--allow-net"])
     run_unit_test(deno_exe, "permR0W0N0E1U0", ["--allow-env"])
     run_unit_test(deno_exe, "permR0W0N0E0U1", ["--allow-run"])

--- a/tools/util.py
+++ b/tools/util.py
@@ -383,6 +383,7 @@ def parse_wrk_output(output):
 def platform():
     return {"linux2": "linux", "darwin": "mac", "win32": "win"}[sys.platform]
 
+
 def mkdtemp():
     # On Windows, set the base directory that mkdtemp() uses explicitly. If not,
     # it'll use the short (8.3) path to the temp dir, which triggers the error


### PR DESCRIPTION
This PR fixes several errors about the formatting script and improves the logging when something errors.

- `--allow-read` was necessary for `std/prettier/main.ts`
- yapf has been failing since format.ts was created. (It doesn't find python_packages path in third_party)
- Error code of each formatter was ignored. I changed format.ts to exit with error when one of the formatters exits with non-zero status code.
- I added error logging when one of the formatters failed. This would be useful for debugging the flaky behavior of format.ts in CI. cf #1718 