### PR TITLE
Gave ability to zoom website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://unpkg.com/c3@0.6.7/c3.min.css" />
     <link rel="stylesheet" href="style.css" />
     <meta
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
+      content="width=device-width, initial-scale=1.0"
       name="viewport"
     />
   </head>


### PR DESCRIPTION
Please, let's not block users from scaling the website, especially critical on mobile devices in terms of accessibility.
[Never use maximum-scale=1.0](https://a11yproject.com/posts/never-use-maximum-scale/)
[Interfering with a user agent's ability to zoom](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html#failure)
So, I've removed `maximum-scale=1.0` and `user-scalable=0` from `index.html`.
`all_benchmark.html` already has only `width=device-width, initial-scale=1.0` as expected.