### PR TITLE
Set globals on compiler startup

### DIFF
--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -540,5 +540,6 @@ window.compilerMain = function compilerMain() {
 
 /* tslint:disable-next-line:no-default-export */
 export default function denoMain() {
-  os.start("TS");
+  const startResMsg = os.start("TS");
+  os.setGlobals(startResMsg.pid(), startResMsg.noColor());
 }

--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -6,6 +6,7 @@ import { Console } from "./console";
 import { globalEval } from "./global_eval";
 import { libdeno } from "./libdeno";
 import * as os from "./os";
+import { args } from "./deno";
 import { TextDecoder, TextEncoder } from "./text_encoding";
 import { clearTimer, setTimeout } from "./timers";
 import { postMessage, workerClose, workerMain } from "./workers";
@@ -541,5 +542,12 @@ window.compilerMain = function compilerMain() {
 /* tslint:disable-next-line:no-default-export */
 export default function denoMain() {
   const startResMsg = os.start("TS");
+
   os.setGlobals(startResMsg.pid(), startResMsg.noColor());
+
+  for (let i = 1; i < startResMsg.argvLength(); i++) {
+    args.push(startResMsg.argv(i));
+  }
+  log("args", args);
+  Object.freeze(args);
 }


### PR DESCRIPTION
Come up when working on #1730. It turns out when compiler starts it doesn't call `os.setGlobals`.

~~I wonder if this bit from `denoMain` should be added as well:~~ 
```ts
  for (let i = 1; i < startResMsg.argvLength(); i++) {
    args.push(startResMsg.argv(i));
  }
  log("args", args);
  Object.freeze(args);
```

EDIT: `deno.args` was not set in worker as well.