### PR TITLE
Rationalise startup for compiler/main

### DIFF
--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -6,7 +6,6 @@ import { Console } from "./console";
 import { globalEval } from "./global_eval";
 import { libdeno } from "./libdeno";
 import * as os from "./os";
-import { args } from "./deno";
 import { TextDecoder, TextEncoder } from "./text_encoding";
 import { clearTimer, setTimeout } from "./timers";
 import { postMessage, workerClose, workerMain } from "./workers";
@@ -542,13 +541,5 @@ window.compilerMain = function compilerMain() {
 
 /* tslint:disable-next-line:no-default-export */
 export default function denoMain() {
-  const startResMsg = os.start("TS");
-
-  os.setGlobals(startResMsg.pid(), startResMsg.noColor());
-
-  for (let i = 1; i < startResMsg.argvLength(); i++) {
-    args.push(startResMsg.argv(i));
-  }
-  log("args", args);
-  Object.freeze(args);
+  os.start("TS");
 }

--- a/js/main.ts
+++ b/js/main.ts
@@ -39,8 +39,6 @@ export default function denoMain() {
     os.exit(0);
   }
 
-  os.setGlobals(startResMsg.pid(), startResMsg.noColor());
-
   const cwd = startResMsg.cwd();
   log("cwd", cwd);
 

--- a/js/os.ts
+++ b/js/os.ts
@@ -192,5 +192,7 @@ export function start(source?: string): msg.StartRes {
 
   util.setLogDebug(startResMsg.debugFlag(), source);
 
+  setGlobals(startResMsg.pid(), startResMsg.noColor());
+
   return startResMsg;
 }


### PR DESCRIPTION
This PR cleans up startup in the compiler and main.  We don't needs `args` in the compiler, but we need a couple other globals in the `deno` API now.
