### PR TITLE
Rationalise compiler ops

### DIFF
--- a/src/modules.rs
+++ b/src/modules.rs
@@ -170,7 +170,7 @@ pub fn print_file_info(
   deno_dir: &DenoDir,
   filename: String,
 ) {
-  let maybe_out = deno_dir.code_fetch(&filename, ".");
+  let maybe_out = deno_dir.fetch_module_meta_data(&filename, ".");
   if maybe_out.is_err() {
     println!("{}", maybe_out.unwrap_err());
     return;

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -6,9 +6,8 @@ union Any {
   WorkerGetMessage,
   WorkerGetMessageRes,
   WorkerPostMessage,
-  CodeFetch,
-  CodeFetchRes,
-  CodeCache,
+  FetchModuleMetaData,
+  FetchModuleMetaDataRes,
   SetTimeout,
   Exit,
   Environ,
@@ -186,28 +185,19 @@ table WorkerPostMessage {
   // data passed thru the zero-copy data parameter.
 }
 
-table CodeFetch {
+table FetchModuleMetaData {
   specifier: string;
   referrer: string;
 }
 
-table CodeFetchRes {
+table FetchModuleMetaDataRes {
   // If it's a non-http module, moduleName and filename will be the same.
   // For http modules, moduleName is its resolved http URL, and filename
   // is the location of the locally downloaded source code.
   module_name: string;
   filename: string;
   media_type: MediaType;
-  // TODO These should be [ubyte].
-  // See: https://github.com/denoland/deno/issues/1113
-  source_code: string;
-}
-
-table CodeCache {
-  filename: string;
-  source_code: string;
-  output_code: string;
-  source_map: string;
+  data: [ubyte];
 }
 
 table Chdir {

--- a/tests/error_004_missing_module.ts.out
+++ b/tests/error_004_missing_module.ts.out
@@ -4,7 +4,7 @@ Uncaught NotFound: Cannot resolve module "bad-module.ts" from "[WILDCARD]/tests/
     at maybeError ([WILDCARD]/js/errors.ts:[WILDCARD])
     at maybeThrowError ([WILDCARD]/js/errors.ts:[WILDCARD])
     at sendSync ([WILDCARD]/js/dispatch.ts:[WILDCARD])
-    at codeFetch ([WILDCARD]/js/os.ts:[WILDCARD])
+    at fetchModuleMetaData ([WILDCARD]/js/os.ts:[WILDCARD])
     at _resolveModule ([WILDCARD]/js/compiler.ts:[WILDCARD])
     at resolveModuleNames ([WILDCARD]/js/compiler.ts:[WILDCARD])
     at compilerHost.resolveModuleNames ([WILDCARD]typescript.js:[WILDCARD])

--- a/tests/error_005_missing_dynamic_import.ts.out
+++ b/tests/error_005_missing_dynamic_import.ts.out
@@ -3,7 +3,7 @@
     at maybeError ([WILDCARD]/js/errors.ts:[WILDCARD])
     at maybeThrowError ([WILDCARD]/js/errors.ts:[WILDCARD])
     at sendSync ([WILDCARD]/js/dispatch.ts:[WILDCARD])
-    at codeFetch ([WILDCARD]/js/os.ts:[WILDCARD])
+    at fetchModuleMetaData ([WILDCARD]/js/os.ts:[WILDCARD])
     at _resolveModule ([WILDCARD]/js/compiler.ts:[WILDCARD])
     at resolveModuleNames ([WILDCARD]/js/compiler.ts:[WILDCARD])
     at compilerHost.resolveModuleNames ([WILDCARD])

--- a/tests/error_006_import_ext_failure.ts.out
+++ b/tests/error_006_import_ext_failure.ts.out
@@ -4,7 +4,7 @@ Uncaught NotFound: Cannot resolve module "./non-existent" from "[WILDCARD]/tests
     at maybeError ([WILDCARD]/js/errors.ts:[WILDCARD])
     at maybeThrowError ([WILDCARD]/js/errors.ts:[WILDCARD])
     at sendSync ([WILDCARD]/js/dispatch.ts:[WILDCARD])
-    at codeFetch ([WILDCARD]/js/os.ts:[WILDCARD])
+    at fetchModuleMetaData ([WILDCARD]/js/os.ts:[WILDCARD])
     at _resolveModule ([WILDCARD]/js/compiler.ts:[WILDCARD])
     at resolveModuleNames ([WILDCARD]/js/compiler.ts:[WILDCARD])
     at compilerHost.resolveModuleNames ([WILDCARD])


### PR DESCRIPTION
This PR removes the code cache OP from the runtime and rationalises the response from the compiler.  Currently, the compiler performs a cache op and then returns the full module (including the source code) back to Rust.  Rust already knows the source code and knows it needs to try to cache the result after a compile, so it handles all of this, removing the need for the compiler to perform these actions.

Because I am still a Rust infant, I am sure I made mistakes in the Rust code.  ~I still need to restore the tests and write new ones.~

I made the decision to rename `CodeFetchOutput` to `ModuleMetaData` because that seem better to represent what is happening, as the object doesn't always come from a code fetch and is incrementally enhanced after the compile.