### PR TITLE
Add Deno global namespace

### DIFF
--- a/js/buffer_test.ts
+++ b/js/buffer_test.ts
@@ -1,11 +1,13 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
-import { Buffer, readAll } from "deno";
-import * as deno from "deno";
 // This code has been ported almost directly from Go's src/bytes/buffer_test.go
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.
 // https://github.com/golang/go/blob/master/LICENSE
 import { assertEqual, test } from "./test_util.ts";
+
+const { Buffer, readAll } = Deno;
+type Buffer = Deno.Buffer;
+
 // N controls how many iterations of certain checks are performed.
 const N = 100;
 let testBytes: Uint8Array | null;
@@ -22,7 +24,7 @@ function init() {
   }
 }
 
-function check(buf: Buffer, s: string) {
+function check(buf: Deno.Buffer, s: string) {
   const bytes = buf.bytes();
   assertEqual(buf.length, bytes.byteLength);
   const decoder = new TextDecoder();
@@ -147,7 +149,7 @@ test(async function bufferTooLargeByteWrites() {
     err = e;
   }
 
-  assertEqual(err.kind, deno.ErrorKind.TooLarge);
+  assertEqual(err.kind, Deno.ErrorKind.TooLarge);
   assertEqual(err.name, "TooLarge");
 });
 

--- a/js/chmod.ts
+++ b/js/chmod.ts
@@ -6,8 +6,7 @@ import * as dispatch from "./dispatch";
 /** Changes the permission of a specific file/directory of specified path
  * synchronously.
  *
- *       import { chmodSync } from "deno";
- *       chmodSync("/path/to/file", 0o666);
+ *       Deno.chmodSync("/path/to/file", 0o666);
  */
 export function chmodSync(path: string, mode: number): void {
   dispatch.sendSync(...req(path, mode));
@@ -15,8 +14,7 @@ export function chmodSync(path: string, mode: number): void {
 
 /** Changes the permission of a specific file/directory of specified path.
  *
- *       import { chmod } from "deno";
- *       await chmod("/path/to/file", 0o666);
+ *       await Deno.chmod("/path/to/file", 0o666);
  */
 export async function chmod(path: string, mode: number): Promise<void> {
   await dispatch.sendAsync(...req(path, mode));

--- a/js/chmod_test.ts
+++ b/js/chmod_test.ts
@@ -1,22 +1,21 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
-const isNotWindows = deno.platform.os !== "win";
+const isNotWindows = Deno.platform.os !== "win";
 
 testPerm({ read: true, write: true }, function chmodSyncSuccess() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const tempDir = deno.makeTempDirSync();
+  const tempDir = Deno.makeTempDirSync();
   const filename = tempDir + "/test.txt";
-  deno.writeFileSync(filename, data, { perm: 0o666 });
+  Deno.writeFileSync(filename, data, { perm: 0o666 });
 
   // On windows no effect, but should not crash
-  deno.chmodSync(filename, 0o777);
+  Deno.chmodSync(filename, 0o777);
 
   // Check success when not on windows
   if (isNotWindows) {
-    const fileInfo = deno.statSync(filename);
+    const fileInfo = Deno.statSync(filename);
     assertEqual(fileInfo.mode & 0o777, 0o777);
   }
 });
@@ -26,22 +25,22 @@ if (isNotWindows) {
   testPerm({ read: true, write: true }, function chmodSyncSymlinkSuccess() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
-    const tempDir = deno.makeTempDirSync();
+    const tempDir = Deno.makeTempDirSync();
 
     const filename = tempDir + "/test.txt";
-    deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { perm: 0o666 });
     const symlinkName = tempDir + "/test_symlink.txt";
-    deno.symlinkSync(filename, symlinkName);
+    Deno.symlinkSync(filename, symlinkName);
 
-    let symlinkInfo = deno.lstatSync(symlinkName);
+    let symlinkInfo = Deno.lstatSync(symlinkName);
     const symlinkMode = symlinkInfo.mode & 0o777; // platform dependent
 
-    deno.chmodSync(symlinkName, 0o777);
+    Deno.chmodSync(symlinkName, 0o777);
 
     // Change actual file mode, not symlink
-    const fileInfo = deno.statSync(filename);
+    const fileInfo = Deno.statSync(filename);
     assertEqual(fileInfo.mode & 0o777, 0o777);
-    symlinkInfo = deno.lstatSync(symlinkName);
+    symlinkInfo = Deno.lstatSync(symlinkName);
     assertEqual(symlinkInfo.mode & 0o777, symlinkMode);
   });
 }
@@ -50,38 +49,38 @@ testPerm({ write: true }, function chmodSyncFailure() {
   let err;
   try {
     const filename = "/badfile.txt";
-    deno.chmodSync(filename, 0o777);
+    Deno.chmodSync(filename, 0o777);
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
 testPerm({ write: false }, function chmodSyncPerm() {
   let err;
   try {
-    deno.chmodSync("/somefile.txt", 0o777);
+    Deno.chmodSync("/somefile.txt", 0o777);
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });
 
 testPerm({ read: true, write: true }, async function chmodSuccess() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const tempDir = deno.makeTempDirSync();
+  const tempDir = Deno.makeTempDirSync();
   const filename = tempDir + "/test.txt";
-  deno.writeFileSync(filename, data, { perm: 0o666 });
+  Deno.writeFileSync(filename, data, { perm: 0o666 });
 
   // On windows no effect, but should not crash
-  await deno.chmod(filename, 0o777);
+  await Deno.chmod(filename, 0o777);
 
   // Check success when not on windows
   if (isNotWindows) {
-    const fileInfo = deno.statSync(filename);
+    const fileInfo = Deno.statSync(filename);
     assertEqual(fileInfo.mode & 0o777, 0o777);
   }
 });
@@ -91,22 +90,22 @@ if (isNotWindows) {
   testPerm({ read: true, write: true }, async function chmodSymlinkSuccess() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
-    const tempDir = deno.makeTempDirSync();
+    const tempDir = Deno.makeTempDirSync();
 
     const filename = tempDir + "/test.txt";
-    deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { perm: 0o666 });
     const symlinkName = tempDir + "/test_symlink.txt";
-    deno.symlinkSync(filename, symlinkName);
+    Deno.symlinkSync(filename, symlinkName);
 
-    let symlinkInfo = deno.lstatSync(symlinkName);
+    let symlinkInfo = Deno.lstatSync(symlinkName);
     const symlinkMode = symlinkInfo.mode & 0o777; // platform dependent
 
-    await deno.chmod(symlinkName, 0o777);
+    await Deno.chmod(symlinkName, 0o777);
 
     // Just change actual file mode, not symlink
-    const fileInfo = deno.statSync(filename);
+    const fileInfo = Deno.statSync(filename);
     assertEqual(fileInfo.mode & 0o777, 0o777);
-    symlinkInfo = deno.lstatSync(symlinkName);
+    symlinkInfo = Deno.lstatSync(symlinkName);
     assertEqual(symlinkInfo.mode & 0o777, symlinkMode);
   });
 }
@@ -115,21 +114,21 @@ testPerm({ write: true }, async function chmodFailure() {
   let err;
   try {
     const filename = "/badfile.txt";
-    await deno.chmod(filename, 0o777);
+    await Deno.chmod(filename, 0o777);
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
 testPerm({ write: false }, async function chmodPerm() {
   let err;
   try {
-    await deno.chmod("/somefile.txt", 0o777);
+    await Deno.chmod("/somefile.txt", 0o777);
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });

--- a/js/compiler_test.ts
+++ b/js/compiler_test.ts
@@ -1,11 +1,10 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 // We use a silly amount of `any` in these tests...
 // tslint:disable:no-any
 
-const { Compiler, jsonEsmTemplate } = (deno as any)._compiler;
+const { Compiler, jsonEsmTemplate } = (Deno as any)._compiler;
 
 interface ModuleInfo {
   moduleName: string | undefined;

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { Console, libdeno, stringifyArgs, inspect, write, stdout } from "deno";
 import { test, assertEqual, assert } from "./test_util.ts";
+
+const { Console, libdeno, stringifyArgs, inspect, write, stdout } = Deno;
 
 const console = new Console(libdeno.print);
 

--- a/js/copy_file.ts
+++ b/js/copy_file.ts
@@ -10,8 +10,7 @@ import * as dispatch from "./dispatch";
  * It would also copy the permission of the original file
  * to the destination.
  *
- *       import { copyFileSync } from "deno";
- *       copyFileSync("from.txt", "to.txt");
+ *       Deno.copyFileSync("from.txt", "to.txt");
  */
 export function copyFileSync(from: string, to: string): void {
   dispatch.sendSync(...req(from, to));
@@ -25,8 +24,7 @@ export function copyFileSync(from: string, to: string): void {
  * It would also copy the permission of the original file
  * to the destination.
  *
- *       import { copyFile } from "deno";
- *       await copyFile("from.txt", "to.txt");
+ *       await Deno.copyFile("from.txt", "to.txt");
  */
 export async function copyFile(from: string, to: string): Promise<void> {
   await dispatch.sendAsync(...req(from, to));

--- a/js/copy_file_test.ts
+++ b/js/copy_file_test.ts
@@ -1,9 +1,8 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 function readFileString(filename: string): string {
-  const dataRead = deno.readFileSync(filename);
+  const dataRead = Deno.readFileSync(filename);
   const dec = new TextDecoder("utf-8");
   return dec.decode(dataRead);
 }
@@ -11,21 +10,21 @@ function readFileString(filename: string): string {
 function writeFileString(filename: string, s: string) {
   const enc = new TextEncoder();
   const data = enc.encode(s);
-  deno.writeFileSync(filename, data, { perm: 0o666 });
+  Deno.writeFileSync(filename, data, { perm: 0o666 });
 }
 
 function assertSameContent(filename1: string, filename2: string) {
-  const data1 = deno.readFileSync(filename1);
-  const data2 = deno.readFileSync(filename2);
+  const data1 = Deno.readFileSync(filename1);
+  const data2 = Deno.readFileSync(filename2);
   assertEqual(data1, data2);
 }
 
 testPerm({ read: true, write: true }, function copyFileSyncSuccess() {
-  const tempDir = deno.makeTempDirSync();
+  const tempDir = Deno.makeTempDirSync();
   const fromFilename = tempDir + "/from.txt";
   const toFilename = tempDir + "/to.txt";
   writeFileString(fromFilename, "Hello world!");
-  deno.copyFileSync(fromFilename, toFilename);
+  Deno.copyFileSync(fromFilename, toFilename);
   // No change to original file
   assertEqual(readFileString(fromFilename), "Hello world!");
   // Original == Dest
@@ -33,28 +32,28 @@ testPerm({ read: true, write: true }, function copyFileSyncSuccess() {
 });
 
 testPerm({ write: true, read: true }, function copyFileSyncFailure() {
-  const tempDir = deno.makeTempDirSync();
+  const tempDir = Deno.makeTempDirSync();
   const fromFilename = tempDir + "/from.txt";
   const toFilename = tempDir + "/to.txt";
   // We skip initial writing here, from.txt does not exist
   let err;
   try {
-    deno.copyFileSync(fromFilename, toFilename);
+    Deno.copyFileSync(fromFilename, toFilename);
   } catch (e) {
     err = e;
   }
   assert(!!err);
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
 testPerm({ write: true, read: false }, function copyFileSyncPerm1() {
   let caughtError = false;
   try {
-    deno.copyFileSync("/from.txt", "/to.txt");
+    Deno.copyFileSync("/from.txt", "/to.txt");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
@@ -63,23 +62,23 @@ testPerm({ write: true, read: false }, function copyFileSyncPerm1() {
 testPerm({ write: false, read: true }, function copyFileSyncPerm2() {
   let caughtError = false;
   try {
-    deno.copyFileSync("/from.txt", "/to.txt");
+    Deno.copyFileSync("/from.txt", "/to.txt");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
 });
 
 testPerm({ read: true, write: true }, function copyFileSyncOverwrite() {
-  const tempDir = deno.makeTempDirSync();
+  const tempDir = Deno.makeTempDirSync();
   const fromFilename = tempDir + "/from.txt";
   const toFilename = tempDir + "/to.txt";
   writeFileString(fromFilename, "Hello world!");
   // Make Dest exist and have different content
   writeFileString(toFilename, "Goodbye!");
-  deno.copyFileSync(fromFilename, toFilename);
+  Deno.copyFileSync(fromFilename, toFilename);
   // No change to original file
   assertEqual(readFileString(fromFilename), "Hello world!");
   // Original == Dest
@@ -87,11 +86,11 @@ testPerm({ read: true, write: true }, function copyFileSyncOverwrite() {
 });
 
 testPerm({ read: true, write: true }, async function copyFileSuccess() {
-  const tempDir = deno.makeTempDirSync();
+  const tempDir = Deno.makeTempDirSync();
   const fromFilename = tempDir + "/from.txt";
   const toFilename = tempDir + "/to.txt";
   writeFileString(fromFilename, "Hello world!");
-  await deno.copyFile(fromFilename, toFilename);
+  await Deno.copyFile(fromFilename, toFilename);
   // No change to original file
   assertEqual(readFileString(fromFilename), "Hello world!");
   // Original == Dest
@@ -99,29 +98,29 @@ testPerm({ read: true, write: true }, async function copyFileSuccess() {
 });
 
 testPerm({ read: true, write: true }, async function copyFileFailure() {
-  const tempDir = deno.makeTempDirSync();
+  const tempDir = Deno.makeTempDirSync();
   const fromFilename = tempDir + "/from.txt";
   const toFilename = tempDir + "/to.txt";
   // We skip initial writing here, from.txt does not exist
   let err;
   try {
-    await deno.copyFile(fromFilename, toFilename);
+    await Deno.copyFile(fromFilename, toFilename);
   } catch (e) {
     err = e;
   }
   assert(!!err);
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
 testPerm({ read: true, write: true }, async function copyFileOverwrite() {
-  const tempDir = deno.makeTempDirSync();
+  const tempDir = Deno.makeTempDirSync();
   const fromFilename = tempDir + "/from.txt";
   const toFilename = tempDir + "/to.txt";
   writeFileString(fromFilename, "Hello world!");
   // Make Dest exist and have different content
   writeFileString(toFilename, "Goodbye!");
-  await deno.copyFile(fromFilename, toFilename);
+  await Deno.copyFile(fromFilename, toFilename);
   // No change to original file
   assertEqual(readFileString(fromFilename), "Hello world!");
   // Original == Dest
@@ -131,10 +130,10 @@ testPerm({ read: true, write: true }, async function copyFileOverwrite() {
 testPerm({ read: false, write: true }, async function copyFilePerm1() {
   let caughtError = false;
   try {
-    await deno.copyFile("/from.txt", "/to.txt");
+    await Deno.copyFile("/from.txt", "/to.txt");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
@@ -143,10 +142,10 @@ testPerm({ read: false, write: true }, async function copyFilePerm1() {
 testPerm({ read: true, write: false }, async function copyFilePerm2() {
   let caughtError = false;
   try {
-    await deno.copyFile("/from.txt", "/to.txt");
+    await Deno.copyFile("/from.txt", "/to.txt");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);

--- a/js/dir_test.ts
+++ b/js/dir_test.ts
@@ -1,52 +1,51 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 test(function dirCwdNotNull() {
-  assert(deno.cwd() != null);
+  assert(Deno.cwd() != null);
 });
 
 testPerm({ write: true }, function dirCwdChdirSuccess() {
-  const initialdir = deno.cwd();
-  const path = deno.makeTempDirSync();
-  deno.chdir(path);
-  const current = deno.cwd();
-  if (deno.platform.os === "mac") {
+  const initialdir = Deno.cwd();
+  const path = Deno.makeTempDirSync();
+  Deno.chdir(path);
+  const current = Deno.cwd();
+  if (Deno.platform.os === "mac") {
     assertEqual(current, "/private" + path);
   } else {
     assertEqual(current, path);
   }
-  deno.chdir(initialdir);
+  Deno.chdir(initialdir);
 });
 
 testPerm({ write: true }, function dirCwdError() {
   // excluding windows since it throws resource busy, while removeSync
-  if (["linux", "mac"].includes(deno.platform.os)) {
-    const initialdir = deno.cwd();
-    const path = deno.makeTempDirSync();
-    deno.chdir(path);
-    deno.removeSync(path);
+  if (["linux", "mac"].includes(Deno.platform.os)) {
+    const initialdir = Deno.cwd();
+    const path = Deno.makeTempDirSync();
+    Deno.chdir(path);
+    Deno.removeSync(path);
     try {
-      deno.cwd();
+      Deno.cwd();
       throw Error("current directory removed, should throw error");
     } catch (err) {
-      if (err instanceof deno.DenoError) {
+      if (err instanceof Deno.DenoError) {
         console.log(err.name === "NotFound");
       } else {
         throw Error("raised different exception");
       }
     }
-    deno.chdir(initialdir);
+    Deno.chdir(initialdir);
   }
 });
 
 testPerm({ write: true }, function dirChdirError() {
-  const path = deno.makeTempDirSync() + "test";
+  const path = Deno.makeTempDirSync() + "test";
   try {
-    deno.chdir(path);
+    Deno.chdir(path);
     throw Error("directory not available, should throw error");
   } catch (err) {
-    if (err instanceof deno.DenoError) {
+    if (err instanceof Deno.DenoError) {
       console.log(err.name === "NotFound");
     } else {
       throw Error("raised different exception");

--- a/js/errors.ts
+++ b/js/errors.ts
@@ -5,14 +5,17 @@ export { ErrorKind } from "gen/msg_generated";
 /** A Deno specific error.  The `kind` property is set to a specific error code
  * which can be used to in application logic.
  *
- *     import { DenoError, ErrorKind } from "deno";
- *     try {
- *       somethingThatMightThrow();
- *     } catch (e) {
- *       if (e instanceof DenoError && e.kind === ErrorKind.Overflow) {
- *         console.error("Overflow error!");
+ *       try {
+ *         somethingThatMightThrow();
+ *       } catch (e) {
+ *         if (
+ *           e instanceof Deno.DenoError &&
+ *           e.kind === Deno.ErrorKind.Overflow
+ *         ) {
+ *           console.error("Overflow error!");
+ *         }
  *       }
- *     }
+ *
  */
 export class DenoError<T extends ErrorKind> extends Error {
   constructor(readonly kind: T, msg: string) {

--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 testPerm({ net: true }, async function fetchJsonSuccess() {
   const response = await fetch("http://localhost:4545/package.json");
@@ -15,7 +14,7 @@ test(async function fetchPerm() {
   } catch (err_) {
     err = err_;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });
 
@@ -54,7 +53,7 @@ testPerm({ net: true }, async function fetchEmptyInvalid() {
   } catch (err_) {
     err = err_;
   }
-  assertEqual(err.kind, deno.ErrorKind.InvalidUri);
+  assertEqual(err.kind, Deno.ErrorKind.InvalidUri);
   assertEqual(err.name, "InvalidUri");
 });
 
@@ -155,9 +154,9 @@ testPerm({ net: true }, async function fetchInitBlobBody() {
 //     at fetchPostBodyString (file
 
 /* 
-function bufferServer(addr: string): deno.Buffer {
-  const listener = deno.listen("tcp", addr);
-  const buf = new deno.Buffer();
+function bufferServer(addr: string): Deno.Buffer {
+  const listener = Deno.listen("tcp", addr);
+  const buf = new Deno.Buffer();
   listener.accept().then(async conn => {
     const p1 = buf.readFrom(conn);
     const p2 = conn.write(

--- a/js/files.ts
+++ b/js/files.ts
@@ -64,9 +64,8 @@ export function create(filename: string): Promise<File> {
 
 /** Open a file and return an instance of the `File` object.
  *
- *       import * as deno from "deno";
  *       (async () => {
- *         const file = await deno.open("/foo/bar.txt");
+ *         const file = await Deno.open("/foo/bar.txt");
  *       })();
  */
 export async function open(

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -10,6 +10,7 @@
 import * as blob from "./blob";
 import * as consoleTypes from "./console";
 import * as customEvent from "./custom_event";
+import * as deno from "./deno";
 import * as domTypes from "./dom_types";
 import * as event from "./event";
 import * as eventTarget from "./event_target";
@@ -40,6 +41,13 @@ declare global {
 export const window = globalEval("this");
 // A self reference to the global object.
 window.window = window;
+
+// This is the Deno namespace, it is handled differently from other window
+// properties when building the runtime type library, as the whole module
+// is flattened into a single namespace.
+
+window.Deno = deno;
+Object.freeze(window.Deno);
 
 // Globally available functions and object instances.
 window.atob = textEncoding.atob;

--- a/js/globals_test.ts
+++ b/js/globals_test.ts
@@ -17,6 +17,18 @@ test(function globalThisEqualsWindow() {
   assert(globalThis === window);
 });
 
+test(function DenoNamespaceExists() {
+  assert(Deno != null);
+});
+
+test(function DenoNamespaceEqualsWindowDeno() {
+  assert(Deno === window.Deno);
+});
+
+test(function DenoNamespaceIsFrozen() {
+  assert(Object.isFrozen(Deno));
+});
+
 test(function webAssemblyExists() {
   assert(typeof WebAssembly.compile === "function");
 });

--- a/js/headers_test.ts
+++ b/js/headers_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 // Logic heavily copied from web-platform-tests, make
 // sure pass mostly header basic test

--- a/js/libdeno.ts
+++ b/js/libdeno.ts
@@ -24,6 +24,7 @@ interface Libdeno {
 
   shared: ArrayBuffer;
 
+  // DEPRECATED
   builtinModules: { [s: string]: object };
 
   /** Evaluate provided code in the current context.

--- a/js/main.ts
+++ b/js/main.ts
@@ -20,6 +20,7 @@ import libDts from "gen/lib/lib.deno_runtime.d.ts!string";
 export default function denoMain() {
   const startResMsg = os.start();
 
+  // TODO(kitsonk) remove when import "deno" no longer supported
   libdeno.builtinModules["deno"] = deno;
   Object.freeze(libdeno.builtinModules);
 

--- a/js/make_temp_dir.ts
+++ b/js/make_temp_dir.ts
@@ -12,9 +12,8 @@ export interface MakeTempDirOptions {
 
 /** makeTempDirSync is the synchronous version of `makeTempDir`.
  *
- *       import { makeTempDirSync } from "deno";
- *       const tempDirName0 = makeTempDirSync();
- *       const tempDirName1 = makeTempDirSync({ prefix: 'my_temp' });
+ *       const tempDirName0 = Deno.makeTempDirSync();
+ *       const tempDirName1 = Deno.makeTempDirSync({ prefix: 'my_temp' });
  */
 export function makeTempDirSync(options: MakeTempDirOptions = {}): string {
   return res(dispatch.sendSync(...req(options)));
@@ -28,9 +27,8 @@ export function makeTempDirSync(options: MakeTempDirOptions = {}): string {
  * same directory. It is the caller's responsibility to remove the directory
  * when no longer needed.
  *
- *       import { makeTempDir } from "deno";
- *       const tempDirName0 = await makeTempDir();
- *       const tempDirName1 = await makeTempDir({ prefix: 'my_temp' });
+ *       const tempDirName0 = await Deno.makeTempDir();
+ *       const tempDirName1 = await Deno.makeTempDir({ prefix: 'my_temp' });
  */
 export async function makeTempDir(
   options: MakeTempDirOptions = {}

--- a/js/make_temp_dir_test.ts
+++ b/js/make_temp_dir_test.ts
@@ -1,10 +1,9 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 testPerm({ write: true }, function makeTempDirSyncSuccess() {
-  const dir1 = deno.makeTempDirSync({ prefix: "hello", suffix: "world" });
-  const dir2 = deno.makeTempDirSync({ prefix: "hello", suffix: "world" });
+  const dir1 = Deno.makeTempDirSync({ prefix: "hello", suffix: "world" });
+  const dir2 = Deno.makeTempDirSync({ prefix: "hello", suffix: "world" });
   // Check that both dirs are different.
   assert(dir1 !== dir2);
   for (const dir of [dir1, dir2]) {
@@ -14,17 +13,17 @@ testPerm({ write: true }, function makeTempDirSyncSuccess() {
     assert(lastPart.endsWith("world"));
   }
   // Check that the `dir` option works.
-  const dir3 = deno.makeTempDirSync({ dir: dir1 });
+  const dir3 = Deno.makeTempDirSync({ dir: dir1 });
   assert(dir3.startsWith(dir1));
   assert(/^[\\\/]/.test(dir3.slice(dir1.length)));
   // Check that creating a temp dir inside a nonexisting directory fails.
   let err;
   try {
-    deno.makeTempDirSync({ dir: "/baddir" });
+    Deno.makeTempDirSync({ dir: "/baddir" });
   } catch (err_) {
     err = err_;
   }
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
@@ -32,17 +31,17 @@ test(function makeTempDirSyncPerm() {
   // makeTempDirSync should require write permissions (for now).
   let err;
   try {
-    deno.makeTempDirSync({ dir: "/baddir" });
+    Deno.makeTempDirSync({ dir: "/baddir" });
   } catch (err_) {
     err = err_;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });
 
 testPerm({ write: true }, async function makeTempDirSuccess() {
-  const dir1 = await deno.makeTempDir({ prefix: "hello", suffix: "world" });
-  const dir2 = await deno.makeTempDir({ prefix: "hello", suffix: "world" });
+  const dir1 = await Deno.makeTempDir({ prefix: "hello", suffix: "world" });
+  const dir2 = await Deno.makeTempDir({ prefix: "hello", suffix: "world" });
   // Check that both dirs are different.
   assert(dir1 !== dir2);
   for (const dir of [dir1, dir2]) {
@@ -52,16 +51,16 @@ testPerm({ write: true }, async function makeTempDirSuccess() {
     assert(lastPart.endsWith("world"));
   }
   // Check that the `dir` option works.
-  const dir3 = await deno.makeTempDir({ dir: dir1 });
+  const dir3 = await Deno.makeTempDir({ dir: dir1 });
   assert(dir3.startsWith(dir1));
   assert(/^[\\\/]/.test(dir3.slice(dir1.length)));
   // Check that creating a temp dir inside a nonexisting directory fails.
   let err;
   try {
-    await deno.makeTempDir({ dir: "/baddir" });
+    await Deno.makeTempDir({ dir: "/baddir" });
   } catch (err_) {
     err = err_;
   }
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });

--- a/js/metrics_test.ts
+++ b/js/metrics_test.ts
@@ -1,9 +1,8 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, testPerm, assert } from "./test_util.ts";
-import * as deno from "deno";
 
 test(async function metrics() {
-  const m1 = deno.metrics();
+  const m1 = Deno.metrics();
   assert(m1.opsDispatched > 0);
   assert(m1.opsCompleted > 0);
   assert(m1.bytesSentControl > 0);
@@ -13,9 +12,9 @@ test(async function metrics() {
   // Write to stdout to ensure a "data" message gets sent instead of just
   // control messages.
   const dataMsg = new Uint8Array([41, 42, 43]);
-  await deno.stdout.write(dataMsg);
+  await Deno.stdout.write(dataMsg);
 
-  const m2 = deno.metrics();
+  const m2 = Deno.metrics();
   assert(m2.opsDispatched > m1.opsDispatched);
   assert(m2.opsCompleted > m1.opsCompleted);
   assert(m2.bytesSentControl > m1.bytesSentControl);
@@ -24,21 +23,21 @@ test(async function metrics() {
 });
 
 testPerm({ write: true }, function metricsUpdatedIfNoResponseSync() {
-  const filename = deno.makeTempDirSync() + "/test.txt";
+  const filename = Deno.makeTempDirSync() + "/test.txt";
 
   const data = new Uint8Array([41, 42, 43]);
-  deno.writeFileSync(filename, data, { perm: 0o666 });
+  Deno.writeFileSync(filename, data, { perm: 0o666 });
 
-  const metrics = deno.metrics();
+  const metrics = Deno.metrics();
   assert(metrics.opsDispatched === metrics.opsCompleted);
 });
 
 testPerm({ write: true }, async function metricsUpdatedIfNoResponseAsync() {
-  const filename = deno.makeTempDirSync() + "/test.txt";
+  const filename = Deno.makeTempDirSync() + "/test.txt";
 
   const data = new Uint8Array([41, 42, 43]);
-  await deno.writeFile(filename, data, { perm: 0o666 });
+  await Deno.writeFile(filename, data, { perm: 0o666 });
 
-  const metrics = deno.metrics();
+  const metrics = Deno.metrics();
   assert(metrics.opsDispatched === metrics.opsCompleted);
 });

--- a/js/mixins/dom_iterable_test.ts
+++ b/js/mixins/dom_iterable_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assert, assertEqual } from "../test_util.ts";
-import { DomIterableMixin } from "deno";
 
 function setup() {
   const dataSymbol = Symbol("data symbol");
@@ -18,7 +17,10 @@ function setup() {
 
   return {
     Base,
-    DomIterable: DomIterableMixin<string, number, typeof Base>(Base, dataSymbol)
+    DomIterable: Deno.DomIterableMixin<string, number, typeof Base>(
+      Base,
+      dataSymbol
+    )
   };
 }
 

--- a/js/mkdir.ts
+++ b/js/mkdir.ts
@@ -9,9 +9,8 @@ import * as dispatch from "./dispatch";
  * `mode` sets permission bits (before umask) on UNIX and does nothing on
  * Windows.
  *
- *       import { mkdirSync } from "deno";
- *       mkdirSync("new_dir");
- *       mkdirSync("nested/directories", true);
+ *       Deno.mkdirSync("new_dir");
+ *       Deno.mkdirSync("nested/directories", true);
  */
 export function mkdirSync(path: string, recursive = false, mode = 0o777): void {
   dispatch.sendSync(...req(path, recursive, mode));
@@ -23,9 +22,8 @@ export function mkdirSync(path: string, recursive = false, mode = 0o777): void {
  * `mode` sets permission bits (before umask) on UNIX and does nothing on
  * Windows.
  *
- *       import { mkdir } from "deno";
- *       await mkdir("new_dir");
- *       await mkdir("nested/directories", true);
+ *       await Deno.mkdir("new_dir");
+ *       await Deno.mkdir("nested/directories", true);
  */
 export async function mkdir(
   path: string,

--- a/js/mkdir_test.ts
+++ b/js/mkdir_test.ts
@@ -1,18 +1,17 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 testPerm({ read: true, write: true }, function mkdirSyncSuccess() {
-  const path = deno.makeTempDirSync() + "/dir";
-  deno.mkdirSync(path);
-  const pathInfo = deno.statSync(path);
+  const path = Deno.makeTempDirSync() + "/dir";
+  Deno.mkdirSync(path);
+  const pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory());
 });
 
 testPerm({ read: true, write: true }, function mkdirSyncMode() {
-  const path = deno.makeTempDirSync() + "/dir";
-  deno.mkdirSync(path, false, 0o755); // no perm for x
-  const pathInfo = deno.statSync(path);
+  const path = Deno.makeTempDirSync() + "/dir";
+  Deno.mkdirSync(path, false, 0o755); // no perm for x
+  const pathInfo = Deno.statSync(path);
   if (pathInfo.mode !== null) {
     // Skip windows
     assertEqual(pathInfo.mode & 0o777, 0o755);
@@ -22,42 +21,42 @@ testPerm({ read: true, write: true }, function mkdirSyncMode() {
 testPerm({ write: false }, function mkdirSyncPerm() {
   let err;
   try {
-    deno.mkdirSync("/baddir");
+    Deno.mkdirSync("/baddir");
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });
 
 testPerm({ read: true, write: true }, async function mkdirSuccess() {
-  const path = deno.makeTempDirSync() + "/dir";
-  await deno.mkdir(path);
-  const pathInfo = deno.statSync(path);
+  const path = Deno.makeTempDirSync() + "/dir";
+  await Deno.mkdir(path);
+  const pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory());
 });
 
 testPerm({ write: true }, function mkdirErrIfExists() {
   let err;
   try {
-    deno.mkdirSync(".");
+    Deno.mkdirSync(".");
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.AlreadyExists);
+  assertEqual(err.kind, Deno.ErrorKind.AlreadyExists);
   assertEqual(err.name, "AlreadyExists");
 });
 
 testPerm({ read: true, write: true }, function mkdirSyncRecursive() {
-  const path = deno.makeTempDirSync() + "/nested/directory";
-  deno.mkdirSync(path, true);
-  const pathInfo = deno.statSync(path);
+  const path = Deno.makeTempDirSync() + "/nested/directory";
+  Deno.mkdirSync(path, true);
+  const pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory());
 });
 
 testPerm({ read: true, write: true }, async function mkdirRecursive() {
-  const path = deno.makeTempDirSync() + "/nested/directory";
-  await deno.mkdir(path, true);
-  const pathInfo = deno.statSync(path);
+  const path = Deno.makeTempDirSync() + "/nested/directory";
+  await Deno.mkdir(path, true);
+  const pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory());
 });

--- a/js/net_test.ts
+++ b/js/net_test.ts
@@ -1,15 +1,13 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import * as deno from "deno";
 import { testPerm, assert, assertEqual } from "./test_util.ts";
-import { deferred } from "deno";
 
 testPerm({ net: true }, function netListenClose() {
-  const listener = deno.listen("tcp", "127.0.0.1:4500");
+  const listener = Deno.listen("tcp", "127.0.0.1:4500");
   listener.close();
 });
 
 testPerm({ net: true }, async function netCloseWhileAccept() {
-  const listener = deno.listen("tcp", ":4501");
+  const listener = Deno.listen("tcp", ":4501");
   const p = listener.accept();
   listener.close();
   let err;
@@ -19,15 +17,15 @@ testPerm({ net: true }, async function netCloseWhileAccept() {
     err = e;
   }
   assert(!!err);
-  assertEqual(err.kind, deno.ErrorKind.Other);
+  assertEqual(err.kind, Deno.ErrorKind.Other);
   assertEqual(err.message, "Listener has been closed");
 });
 
 testPerm({ net: true }, async function netConcurrentAccept() {
-  const listener = deno.listen("tcp", ":4502");
+  const listener = Deno.listen("tcp", ":4502");
   let acceptErrCount = 0;
   const checkErr = e => {
-    assertEqual(e.kind, deno.ErrorKind.Other);
+    assertEqual(e.kind, Deno.ErrorKind.Other);
     if (e.message === "Listener has been closed") {
       assertEqual(acceptErrCount, 1);
     } else if (e.message === "Another accept task is ongoing") {
@@ -45,12 +43,12 @@ testPerm({ net: true }, async function netConcurrentAccept() {
 });
 
 testPerm({ net: true }, async function netDialListen() {
-  const listener = deno.listen("tcp", ":4500");
+  const listener = Deno.listen("tcp", ":4500");
   listener.accept().then(async conn => {
     await conn.write(new Uint8Array([1, 2, 3]));
     conn.close();
   });
-  const conn = await deno.dial("tcp", "127.0.0.1:4500");
+  const conn = await Deno.dial("tcp", "127.0.0.1:4500");
   const buf = new Uint8Array(1024);
   const readResult = await conn.read(buf);
   assertEqual(3, readResult.nread);
@@ -75,7 +73,7 @@ testPerm({ net: true }, async function netDialListen() {
 /* TODO Fix broken test.
 testPerm({ net: true }, async function netCloseReadSuccess() {
   const addr = "127.0.0.1:4500";
-  const listener = deno.listen("tcp", addr);
+  const listener = Deno.listen("tcp", addr);
   const closeDeferred = deferred();
   const closeReadDeferred = deferred();
   listener.accept().then(async conn => {
@@ -90,7 +88,7 @@ testPerm({ net: true }, async function netCloseReadSuccess() {
     conn.close();
     closeDeferred.resolve();
   });
-  const conn = await deno.dial("tcp", addr);
+  const conn = await Deno.dial("tcp", addr);
   conn.closeRead(); // closing read
   closeReadDeferred.resolve();
   const buf = new Uint8Array(1024);
@@ -108,14 +106,14 @@ testPerm({ net: true }, async function netCloseReadSuccess() {
 /* TODO Fix broken test.
 testPerm({ net: true }, async function netDoubleCloseRead() {
   const addr = "127.0.0.1:4500";
-  const listener = deno.listen("tcp", addr);
+  const listener = Deno.listen("tcp", addr);
   const closeDeferred = deferred();
   listener.accept().then(async conn => {
     await conn.write(new Uint8Array([1, 2, 3]));
     await closeDeferred.promise;
     conn.close();
   });
-  const conn = await deno.dial("tcp", addr);
+  const conn = await Deno.dial("tcp", addr);
   conn.closeRead(); // closing read
   let err;
   try {
@@ -125,7 +123,7 @@ testPerm({ net: true }, async function netDoubleCloseRead() {
     err = e;
   }
   assert(!!err);
-  assertEqual(err.kind, deno.ErrorKind.NotConnected);
+  assertEqual(err.kind, Deno.ErrorKind.NotConnected);
   assertEqual(err.name, "NotConnected");
   closeDeferred.resolve();
   listener.close();
@@ -136,14 +134,14 @@ testPerm({ net: true }, async function netDoubleCloseRead() {
 /* TODO Fix broken test.
 testPerm({ net: true }, async function netCloseWriteSuccess() {
   const addr = "127.0.0.1:4500";
-  const listener = deno.listen("tcp", addr);
+  const listener = Deno.listen("tcp", addr);
   const closeDeferred = deferred();
   listener.accept().then(async conn => {
     await conn.write(new Uint8Array([1, 2, 3]));
     await closeDeferred.promise;
     conn.close();
   });
-  const conn = await deno.dial("tcp", addr);
+  const conn = await Deno.dial("tcp", addr);
   conn.closeWrite(); // closing write
   const buf = new Uint8Array(1024);
   // Check read not impacted
@@ -160,7 +158,7 @@ testPerm({ net: true }, async function netCloseWriteSuccess() {
     err = e;
   }
   assert(!!err);
-  assertEqual(err.kind, deno.ErrorKind.BrokenPipe);
+  assertEqual(err.kind, Deno.ErrorKind.BrokenPipe);
   assertEqual(err.name, "BrokenPipe");
   closeDeferred.resolve();
   listener.close();
@@ -171,13 +169,13 @@ testPerm({ net: true }, async function netCloseWriteSuccess() {
 /* TODO Fix broken test.
 testPerm({ net: true }, async function netDoubleCloseWrite() {
   const addr = "127.0.0.1:4500";
-  const listener = deno.listen("tcp", addr);
+  const listener = Deno.listen("tcp", addr);
   const closeDeferred = deferred();
   listener.accept().then(async conn => {
     await closeDeferred.promise;
     conn.close();
   });
-  const conn = await deno.dial("tcp", addr);
+  const conn = await Deno.dial("tcp", addr);
   conn.closeWrite(); // closing write
   let err;
   try {
@@ -187,7 +185,7 @@ testPerm({ net: true }, async function netDoubleCloseWrite() {
     err = e;
   }
   assert(!!err);
-  assertEqual(err.kind, deno.ErrorKind.NotConnected);
+  assertEqual(err.kind, Deno.ErrorKind.NotConnected);
   assertEqual(err.name, "NotConnected");
   closeDeferred.resolve();
   listener.close();

--- a/js/os.ts
+++ b/js/os.ts
@@ -6,10 +6,10 @@ import { libdeno } from "./libdeno";
 import { assert } from "./util";
 import * as util from "./util";
 
-/** process id */
+/** The current process id of the runtime. */
 export let pid: number;
 
-/** Reflects the NO_COLOR enviromental variable: https://no-color.org/ */
+/** Reflects the NO_COLOR environment variable: https://no-color.org/ */
 export let noColor: boolean;
 
 export function setGlobals(pid_: number, noColor_: boolean): void {
@@ -27,8 +27,7 @@ interface CodeInfo {
 
 /** Check if running in terminal.
  *
- *       import { isTTY } from "deno";
- *       console.log(isTTY().stdout);
+ *       console.log(Deno.isTTY().stdout);
  */
 export function isTTY(): { stdin: boolean; stdout: boolean; stderr: boolean } {
   const builder = flatbuffers.createBuilder();
@@ -141,12 +140,10 @@ function setEnv(key: string, value: string): void {
  * the process. The environment object will only accept `string`s
  * as values.
  *
- *       import { env } from "deno";
- *
- *       const myEnv = env();
+ *       const myEnv = Deno.env();
  *       console.log(myEnv.SHELL);
  *       myEnv.TEST_VAR = "HELLO";
- *       const newEnv = env();
+ *       const newEnv = Deno.env();
  *       console.log(myEnv.TEST_VAR == newEnv.TEST_VAR);
  */
 export function env(): { [index: string]: string } {

--- a/js/os_test.ts
+++ b/js/os_test.ts
@@ -1,22 +1,21 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 testPerm({ env: true }, function envSuccess() {
-  const env = deno.env();
+  const env = Deno.env();
   assert(env !== null);
   env.test_var = "Hello World";
-  const newEnv = deno.env();
+  const newEnv = Deno.env();
   assertEqual(env.test_var, newEnv.test_var);
 });
 
 test(function envFailure() {
   let caughtError = false;
   try {
-    const env = deno.env();
+    const env = Deno.env();
   } catch (err) {
     caughtError = true;
-    assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(err.name, "PermissionDenied");
   }
 
@@ -24,11 +23,11 @@ test(function envFailure() {
 });
 
 test(function osPid() {
-  console.log("pid", deno.pid);
-  assert(deno.pid > 0);
+  console.log("pid", Deno.pid);
+  assert(Deno.pid > 0);
 });
 
 // See complete tests in tools/is_tty_test.py
 test(function osIsTTYSmoke() {
-  console.log(deno.isTTY());
+  console.log(Deno.isTTY());
 });

--- a/js/platform_test.ts
+++ b/js/platform_test.ts
@@ -1,11 +1,10 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assert } from "./test_util.ts";
-import * as deno from "deno";
 
 test(function platformTransform() {
   // deno.platform is injected by rollup at compile time. Here
   // we check it has been properly transformed.
-  const { arch, os } = deno.platform;
+  const { arch, os } = Deno.platform;
   assert(arch === "x64");
   assert(os === "mac" || os === "win" || os === "linux");
 });

--- a/js/process_test.ts
+++ b/js/process_test.ts
@@ -1,15 +1,14 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, testPerm, assert, assertEqual } from "./test_util.ts";
-import { run, DenoError, ErrorKind } from "deno";
-import * as deno from "deno";
+const { run, DenoError, ErrorKind } = Deno;
 
 test(function runPermissions() {
   let caughtError = false;
   try {
-    deno.run({ args: ["python", "-c", "print('hello world')"] });
+    Deno.run({ args: ["python", "-c", "print('hello world')"] });
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
@@ -39,7 +38,7 @@ testPerm({ run: true }, async function runCommandFailedWithCode() {
 });
 
 testPerm({ run: true }, async function runCommandFailedWithSignal() {
-  if (deno.platform.os === "win") {
+  if (Deno.platform.os === "win") {
     return; // No signals on windows.
   }
   const p = run({
@@ -66,7 +65,7 @@ testPerm({ run: true }, function runNotFound() {
 
 testPerm({ write: true, run: true }, async function runWithCwdIsAsync() {
   const enc = new TextEncoder();
-  const cwd = deno.makeTempDirSync({ prefix: "deno_command_test" });
+  const cwd = Deno.makeTempDirSync({ prefix: "deno_command_test" });
 
   const exitCodeFile = "deno_was_here";
   const pyProgramFile = "poll_exit.py";
@@ -86,7 +85,7 @@ while True:
     pass
 `;
 
-  deno.writeFileSync(`${cwd}/${pyProgramFile}.py`, enc.encode(pyProgram));
+  Deno.writeFileSync(`${cwd}/${pyProgramFile}.py`, enc.encode(pyProgram));
   const p = run({
     cwd,
     args: ["python", `${pyProgramFile}.py`]
@@ -95,7 +94,7 @@ while True:
   // Write the expected exit code *after* starting python.
   // This is how we verify that `run()` is actually asynchronous.
   const code = 84;
-  deno.writeFileSync(`${cwd}/${exitCodeFile}`, enc.encode(`${code}`));
+  Deno.writeFileSync(`${cwd}/${exitCodeFile}`, enc.encode(`${code}`));
 
   const status = await p.status();
   assertEqual(status.success, false);

--- a/js/read_dir.ts
+++ b/js/read_dir.ts
@@ -8,8 +8,7 @@ import { assert } from "./util";
 /** Reads the directory given by path and returns a list of file info
  * synchronously.
  *
- *       import { readDirSync } from "deno";
- *       const files = readDirSync("/");
+ *       const files = Deno.readDirSync("/");
  */
 export function readDirSync(path: string): FileInfo[] {
   return res(dispatch.sendSync(...req(path)));
@@ -17,8 +16,7 @@ export function readDirSync(path: string): FileInfo[] {
 
 /** Reads the directory given by path and returns a list of file info.
  *
- *       import { readDir } from "deno";
- *       const files = await readDir("/");
+ *       const files = await Deno.readDir("/");
  */
 export async function readDir(path: string): Promise<FileInfo[]> {
   return res(await dispatch.sendAsync(...req(path)));

--- a/js/read_dir_test.ts
+++ b/js/read_dir_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
-import { FileInfo } from "deno";
+
+type FileInfo = Deno.FileInfo;
 
 function assertSameContent(files: FileInfo[]) {
   let counter = 0;
@@ -14,7 +14,7 @@ function assertSameContent(files: FileInfo[]) {
 
     if (file.name === "002_hello.ts") {
       assertEqual(file.path, `tests/${file.name}`);
-      assertEqual(file.mode!, deno.statSync(`tests/${file.name}`).mode!);
+      assertEqual(file.mode!, Deno.statSync(`tests/${file.name}`).mode!);
       counter++;
     }
   }
@@ -23,17 +23,17 @@ function assertSameContent(files: FileInfo[]) {
 }
 
 testPerm({ read: true }, function readDirSyncSuccess() {
-  const files = deno.readDirSync("tests/");
+  const files = Deno.readDirSync("tests/");
   assertSameContent(files);
 });
 
 testPerm({ read: false }, function readDirSyncPerm() {
   let caughtError = false;
   try {
-    const files = deno.readDirSync("tests/");
+    const files = Deno.readDirSync("tests/");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
@@ -44,10 +44,10 @@ testPerm({ read: true }, function readDirSyncNotDir() {
   let src;
 
   try {
-    src = deno.readDirSync("package.json");
+    src = Deno.readDirSync("package.json");
   } catch (err) {
     caughtError = true;
-    assertEqual(err.kind, deno.ErrorKind.Other);
+    assertEqual(err.kind, Deno.ErrorKind.Other);
   }
   assert(caughtError);
   assertEqual(src, undefined);
@@ -58,27 +58,27 @@ testPerm({ read: true }, function readDirSyncNotFound() {
   let src;
 
   try {
-    src = deno.readDirSync("bad_dir_name");
+    src = Deno.readDirSync("bad_dir_name");
   } catch (err) {
     caughtError = true;
-    assertEqual(err.kind, deno.ErrorKind.NotFound);
+    assertEqual(err.kind, Deno.ErrorKind.NotFound);
   }
   assert(caughtError);
   assertEqual(src, undefined);
 });
 
 testPerm({ read: true }, async function readDirSuccess() {
-  const files = await deno.readDir("tests/");
+  const files = await Deno.readDir("tests/");
   assertSameContent(files);
 });
 
 testPerm({ read: false }, async function readDirPerm() {
   let caughtError = false;
   try {
-    const files = await deno.readDir("tests/");
+    const files = await Deno.readDir("tests/");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);

--- a/js/read_file.ts
+++ b/js/read_file.ts
@@ -6,9 +6,8 @@ import * as dispatch from "./dispatch";
 
 /** Read the entire contents of a file synchronously.
  *
- *       import { readFileSync } from "deno";
  *       const decoder = new TextDecoder("utf-8");
- *       const data = readFileSync("hello.txt");
+ *       const data = Deno.readFileSync("hello.txt");
  *       console.log(decoder.decode(data));
  */
 export function readFileSync(filename: string): Uint8Array {
@@ -17,9 +16,8 @@ export function readFileSync(filename: string): Uint8Array {
 
 /** Read the entire contents of a file.
  *
- *       import { readFile } from "deno";
  *       const decoder = new TextDecoder("utf-8");
- *       const data = await readFile("hello.txt");
+ *       const data = await Deno.readFile("hello.txt");
  *       console.log(decoder.decode(data));
  */
 export async function readFile(filename: string): Promise<Uint8Array> {

--- a/js/read_file_test.ts
+++ b/js/read_file_test.ts
@@ -1,9 +1,8 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 testPerm({ read: true }, function readFileSyncSuccess() {
-  const data = deno.readFileSync("package.json");
+  const data = Deno.readFileSync("package.json");
   assert(data.byteLength > 0);
   const decoder = new TextDecoder("utf-8");
   const json = decoder.decode(data);
@@ -14,10 +13,10 @@ testPerm({ read: true }, function readFileSyncSuccess() {
 testPerm({ read: false }, function readFileSyncPerm() {
   let caughtError = false;
   try {
-    const data = deno.readFileSync("package.json");
+    const data = Deno.readFileSync("package.json");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
@@ -27,17 +26,17 @@ testPerm({ read: true }, function readFileSyncNotFound() {
   let caughtError = false;
   let data;
   try {
-    data = deno.readFileSync("bad_filename");
+    data = Deno.readFileSync("bad_filename");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.NotFound);
+    assertEqual(e.kind, Deno.ErrorKind.NotFound);
   }
   assert(caughtError);
   assert(data === undefined);
 });
 
 testPerm({ read: true }, async function readFileSuccess() {
-  const data = await deno.readFile("package.json");
+  const data = await Deno.readFile("package.json");
   assert(data.byteLength > 0);
   const decoder = new TextDecoder("utf-8");
   const json = decoder.decode(data);
@@ -48,10 +47,10 @@ testPerm({ read: true }, async function readFileSuccess() {
 testPerm({ read: false }, async function readFilePerm() {
   let caughtError = false;
   try {
-    await deno.readFile("package.json");
+    await Deno.readFile("package.json");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);

--- a/js/read_link.ts
+++ b/js/read_link.ts
@@ -6,8 +6,7 @@ import * as dispatch from "./dispatch";
 
 /** Returns the destination of the named symbolic link synchronously.
  *
- *       import { readlinkSync } from "deno";
- *       const targetPath = readlinkSync("symlink/path");
+ *       const targetPath = Deno.readlinkSync("symlink/path");
  */
 export function readlinkSync(name: string): string {
   return res(dispatch.sendSync(...req(name)));
@@ -15,8 +14,7 @@ export function readlinkSync(name: string): string {
 
 /** Returns the destination of the named symbolic link.
  *
- *       import { readlink } from "deno";
- *       const targetPath = await readlink("symlink/path");
+ *       const targetPath = await Deno.readlink("symlink/path");
  */
 export async function readlink(name: string): Promise<string> {
   return res(await dispatch.sendAsync(...req(name)));

--- a/js/read_link_test.ts
+++ b/js/read_link_test.ts
@@ -1,17 +1,16 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 testPerm({ write: true, read: true }, function readlinkSyncSuccess() {
-  const testDir = deno.makeTempDirSync();
+  const testDir = Deno.makeTempDirSync();
   const target = testDir + "/target";
   const symlink = testDir + "/symln";
-  deno.mkdirSync(target);
+  Deno.mkdirSync(target);
   // TODO Add test for Windows once symlink is implemented for Windows.
   // See https://github.com/denoland/deno/issues/815.
-  if (deno.platform.os !== "win") {
-    deno.symlinkSync(target, symlink);
-    const targetPath = deno.readlinkSync(symlink);
+  if (Deno.platform.os !== "win") {
+    Deno.symlinkSync(target, symlink);
+    const targetPath = Deno.readlinkSync(symlink);
     assertEqual(targetPath, target);
   }
 });
@@ -19,10 +18,10 @@ testPerm({ write: true, read: true }, function readlinkSyncSuccess() {
 testPerm({ read: false }, async function readlinkSyncPerm() {
   let caughtError = false;
   try {
-    deno.readlinkSync("/symlink");
+    Deno.readlinkSync("/symlink");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
@@ -32,25 +31,25 @@ testPerm({ read: true }, function readlinkSyncNotFound() {
   let caughtError = false;
   let data;
   try {
-    data = deno.readlinkSync("bad_filename");
+    data = Deno.readlinkSync("bad_filename");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.NotFound);
+    assertEqual(e.kind, Deno.ErrorKind.NotFound);
   }
   assert(caughtError);
   assertEqual(data, undefined);
 });
 
 testPerm({ write: true, read: true }, async function readlinkSuccess() {
-  const testDir = deno.makeTempDirSync();
+  const testDir = Deno.makeTempDirSync();
   const target = testDir + "/target";
   const symlink = testDir + "/symln";
-  deno.mkdirSync(target);
+  Deno.mkdirSync(target);
   // TODO Add test for Windows once symlink is implemented for Windows.
   // See https://github.com/denoland/deno/issues/815.
-  if (deno.platform.os !== "win") {
-    deno.symlinkSync(target, symlink);
-    const targetPath = await deno.readlink(symlink);
+  if (Deno.platform.os !== "win") {
+    Deno.symlinkSync(target, symlink);
+    const targetPath = await Deno.readlink(symlink);
     assertEqual(targetPath, target);
   }
 });
@@ -58,10 +57,10 @@ testPerm({ write: true, read: true }, async function readlinkSuccess() {
 testPerm({ read: false }, async function readlinkPerm() {
   let caughtError = false;
   try {
-    await deno.readlink("/symlink");
+    await Deno.readlink("/symlink");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);

--- a/js/remove.ts
+++ b/js/remove.ts
@@ -12,8 +12,7 @@ export interface RemoveOption {
  * set to false.
  * `recursive` is set to false by default.
  *
- *       import { removeSync } from "deno";
- *       removeSync("/path/to/dir/or/file", {recursive: false});
+ *       Deno.removeSync("/path/to/dir/or/file", {recursive: false});
  */
 export function removeSync(path: string, options: RemoveOption = {}): void {
   dispatch.sendSync(...req(path, options));
@@ -24,8 +23,7 @@ export function removeSync(path: string, options: RemoveOption = {}): void {
  * to false.
  * `recursive` is set to false by default.
  *
- *       import { remove } from "deno";
- *       await remove("/path/to/dir/or/file", {recursive: false});
+ *       await Deno.remove("/path/to/dir/or/file", {recursive: false});
  */
 export async function remove(
   path: string,

--- a/js/remove_test.ts
+++ b/js/remove_test.ts
@@ -1,25 +1,24 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 // SYNC
 
 testPerm({ write: true }, function removeSyncDirSuccess() {
   // REMOVE EMPTY DIRECTORY
-  const path = deno.makeTempDirSync() + "/dir/subdir";
-  deno.mkdirSync(path);
-  const pathInfo = deno.statSync(path);
+  const path = Deno.makeTempDirSync() + "/dir/subdir";
+  Deno.mkdirSync(path);
+  const pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory()); // check exist first
-  deno.removeSync(path); // remove
+  Deno.removeSync(path); // remove
   // We then check again after remove
   let err;
   try {
-    deno.statSync(path);
+    Deno.statSync(path);
   } catch (e) {
     err = e;
   }
   // Directory is gone
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
@@ -27,100 +26,100 @@ testPerm({ write: true }, function removeSyncFileSuccess() {
   // REMOVE FILE
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test.txt";
-  deno.writeFileSync(filename, data, { perm: 0o666 });
-  const fileInfo = deno.statSync(filename);
+  const filename = Deno.makeTempDirSync() + "/test.txt";
+  Deno.writeFileSync(filename, data, { perm: 0o666 });
+  const fileInfo = Deno.statSync(filename);
   assert(fileInfo.isFile()); // check exist first
-  deno.removeSync(filename); // remove
+  Deno.removeSync(filename); // remove
   // We then check again after remove
   let err;
   try {
-    deno.statSync(filename);
+    Deno.statSync(filename);
   } catch (e) {
     err = e;
   }
   // File is gone
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
 testPerm({ write: true }, function removeSyncFail() {
   // NON-EMPTY DIRECTORY
-  const path = deno.makeTempDirSync() + "/dir/subdir";
+  const path = Deno.makeTempDirSync() + "/dir/subdir";
   const subPath = path + "/subsubdir";
-  deno.mkdirSync(path);
-  deno.mkdirSync(subPath);
-  const pathInfo = deno.statSync(path);
+  Deno.mkdirSync(path);
+  Deno.mkdirSync(subPath);
+  const pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory()); // check exist first
-  const subPathInfo = deno.statSync(subPath);
+  const subPathInfo = Deno.statSync(subPath);
   assert(subPathInfo.isDirectory()); // check exist first
   let err;
   try {
     // Should not be able to recursively remove
-    deno.removeSync(path);
+    Deno.removeSync(path);
   } catch (e) {
     err = e;
   }
   // TODO(ry) Is Other really the error we should get here? What would Go do?
-  assertEqual(err.kind, deno.ErrorKind.Other);
+  assertEqual(err.kind, Deno.ErrorKind.Other);
   assertEqual(err.name, "Other");
   // NON-EXISTENT DIRECTORY/FILE
   try {
     // Non-existent
-    deno.removeSync("/baddir");
+    Deno.removeSync("/baddir");
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
 testPerm({ write: false }, function removeSyncPerm() {
   let err;
   try {
-    deno.removeSync("/baddir");
+    Deno.removeSync("/baddir");
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });
 
 testPerm({ write: true }, function removeAllSyncDirSuccess() {
   // REMOVE EMPTY DIRECTORY
-  let path = deno.makeTempDirSync() + "/dir/subdir";
-  deno.mkdirSync(path);
-  let pathInfo = deno.statSync(path);
+  let path = Deno.makeTempDirSync() + "/dir/subdir";
+  Deno.mkdirSync(path);
+  let pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory()); // check exist first
-  deno.removeSync(path, { recursive: true }); // remove
+  Deno.removeSync(path, { recursive: true }); // remove
   // We then check again after remove
   let err;
   try {
-    deno.statSync(path);
+    Deno.statSync(path);
   } catch (e) {
     err = e;
   }
   // Directory is gone
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
   // REMOVE NON-EMPTY DIRECTORY
-  path = deno.makeTempDirSync() + "/dir/subdir";
+  path = Deno.makeTempDirSync() + "/dir/subdir";
   const subPath = path + "/subsubdir";
-  deno.mkdirSync(path);
-  deno.mkdirSync(subPath);
-  pathInfo = deno.statSync(path);
+  Deno.mkdirSync(path);
+  Deno.mkdirSync(subPath);
+  pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory()); // check exist first
-  const subPathInfo = deno.statSync(subPath);
+  const subPathInfo = Deno.statSync(subPath);
   assert(subPathInfo.isDirectory()); // check exist first
-  deno.removeSync(path, { recursive: true }); // remove
+  Deno.removeSync(path, { recursive: true }); // remove
   // We then check parent directory again after remove
   try {
-    deno.statSync(path);
+    Deno.statSync(path);
   } catch (e) {
     err = e;
   }
   // Directory is gone
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
@@ -128,20 +127,20 @@ testPerm({ write: true }, function removeAllSyncFileSuccess() {
   // REMOVE FILE
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test.txt";
-  deno.writeFileSync(filename, data, { perm: 0o666 });
-  const fileInfo = deno.statSync(filename);
+  const filename = Deno.makeTempDirSync() + "/test.txt";
+  Deno.writeFileSync(filename, data, { perm: 0o666 });
+  const fileInfo = Deno.statSync(filename);
   assert(fileInfo.isFile()); // check exist first
-  deno.removeSync(filename, { recursive: true }); // remove
+  Deno.removeSync(filename, { recursive: true }); // remove
   // We then check again after remove
   let err;
   try {
-    deno.statSync(filename);
+    Deno.statSync(filename);
   } catch (e) {
     err = e;
   }
   // File is gone
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
@@ -150,22 +149,22 @@ testPerm({ write: true }, function removeAllSyncFail() {
   let err;
   try {
     // Non-existent
-    deno.removeSync("/baddir", { recursive: true });
+    Deno.removeSync("/baddir", { recursive: true });
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
 testPerm({ write: false }, function removeAllSyncPerm() {
   let err;
   try {
-    deno.removeSync("/baddir", { recursive: true });
+    Deno.removeSync("/baddir", { recursive: true });
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });
 
@@ -173,20 +172,20 @@ testPerm({ write: false }, function removeAllSyncPerm() {
 
 testPerm({ write: true }, async function removeDirSuccess() {
   // REMOVE EMPTY DIRECTORY
-  const path = deno.makeTempDirSync() + "/dir/subdir";
-  deno.mkdirSync(path);
-  const pathInfo = deno.statSync(path);
+  const path = Deno.makeTempDirSync() + "/dir/subdir";
+  Deno.mkdirSync(path);
+  const pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory()); // check exist first
-  await deno.remove(path); // remove
+  await Deno.remove(path); // remove
   // We then check again after remove
   let err;
   try {
-    deno.statSync(path);
+    Deno.statSync(path);
   } catch (e) {
     err = e;
   }
   // Directory is gone
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
@@ -194,99 +193,99 @@ testPerm({ write: true }, async function removeFileSuccess() {
   // REMOVE FILE
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test.txt";
-  deno.writeFileSync(filename, data, { perm: 0o666 });
-  const fileInfo = deno.statSync(filename);
+  const filename = Deno.makeTempDirSync() + "/test.txt";
+  Deno.writeFileSync(filename, data, { perm: 0o666 });
+  const fileInfo = Deno.statSync(filename);
   assert(fileInfo.isFile()); // check exist first
-  await deno.remove(filename); // remove
+  await Deno.remove(filename); // remove
   // We then check again after remove
   let err;
   try {
-    deno.statSync(filename);
+    Deno.statSync(filename);
   } catch (e) {
     err = e;
   }
   // File is gone
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
 testPerm({ write: true }, async function removeFail() {
   // NON-EMPTY DIRECTORY
-  const path = deno.makeTempDirSync() + "/dir/subdir";
+  const path = Deno.makeTempDirSync() + "/dir/subdir";
   const subPath = path + "/subsubdir";
-  deno.mkdirSync(path);
-  deno.mkdirSync(subPath);
-  const pathInfo = deno.statSync(path);
+  Deno.mkdirSync(path);
+  Deno.mkdirSync(subPath);
+  const pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory()); // check exist first
-  const subPathInfo = deno.statSync(subPath);
+  const subPathInfo = Deno.statSync(subPath);
   assert(subPathInfo.isDirectory()); // check exist first
   let err;
   try {
     // Should not be able to recursively remove
-    await deno.remove(path);
+    await Deno.remove(path);
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.Other);
+  assertEqual(err.kind, Deno.ErrorKind.Other);
   assertEqual(err.name, "Other");
   // NON-EXISTENT DIRECTORY/FILE
   try {
     // Non-existent
-    await deno.remove("/baddir");
+    await Deno.remove("/baddir");
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
 testPerm({ write: false }, async function removePerm() {
   let err;
   try {
-    await deno.remove("/baddir");
+    await Deno.remove("/baddir");
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });
 
 testPerm({ write: true }, async function removeAllDirSuccess() {
   // REMOVE EMPTY DIRECTORY
-  let path = deno.makeTempDirSync() + "/dir/subdir";
-  deno.mkdirSync(path);
-  let pathInfo = deno.statSync(path);
+  let path = Deno.makeTempDirSync() + "/dir/subdir";
+  Deno.mkdirSync(path);
+  let pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory()); // check exist first
-  await deno.remove(path, { recursive: true }); // remove
+  await Deno.remove(path, { recursive: true }); // remove
   // We then check again after remove
   let err;
   try {
-    deno.statSync(path);
+    Deno.statSync(path);
   } catch (e) {
     err = e;
   }
   // Directory is gone
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
   // REMOVE NON-EMPTY DIRECTORY
-  path = deno.makeTempDirSync() + "/dir/subdir";
+  path = Deno.makeTempDirSync() + "/dir/subdir";
   const subPath = path + "/subsubdir";
-  deno.mkdirSync(path);
-  deno.mkdirSync(subPath);
-  pathInfo = deno.statSync(path);
+  Deno.mkdirSync(path);
+  Deno.mkdirSync(subPath);
+  pathInfo = Deno.statSync(path);
   assert(pathInfo.isDirectory()); // check exist first
-  const subPathInfo = deno.statSync(subPath);
+  const subPathInfo = Deno.statSync(subPath);
   assert(subPathInfo.isDirectory()); // check exist first
-  await deno.remove(path, { recursive: true }); // remove
+  await Deno.remove(path, { recursive: true }); // remove
   // We then check parent directory again after remove
   try {
-    deno.statSync(path);
+    Deno.statSync(path);
   } catch (e) {
     err = e;
   }
   // Directory is gone
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
@@ -294,20 +293,20 @@ testPerm({ write: true }, async function removeAllFileSuccess() {
   // REMOVE FILE
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test.txt";
-  deno.writeFileSync(filename, data, { perm: 0o666 });
-  const fileInfo = deno.statSync(filename);
+  const filename = Deno.makeTempDirSync() + "/test.txt";
+  Deno.writeFileSync(filename, data, { perm: 0o666 });
+  const fileInfo = Deno.statSync(filename);
   assert(fileInfo.isFile()); // check exist first
-  await deno.remove(filename, { recursive: true }); // remove
+  await Deno.remove(filename, { recursive: true }); // remove
   // We then check again after remove
   let err;
   try {
-    deno.statSync(filename);
+    Deno.statSync(filename);
   } catch (e) {
     err = e;
   }
   // File is gone
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
@@ -316,21 +315,21 @@ testPerm({ write: true }, async function removeAllFail() {
   let err;
   try {
     // Non-existent
-    await deno.remove("/baddir", { recursive: true });
+    await Deno.remove("/baddir", { recursive: true });
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.NotFound);
+  assertEqual(err.kind, Deno.ErrorKind.NotFound);
   assertEqual(err.name, "NotFound");
 });
 
 testPerm({ write: false }, async function removeAllPerm() {
   let err;
   try {
-    await deno.remove("/baddir", { recursive: true });
+    await Deno.remove("/baddir", { recursive: true });
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });

--- a/js/rename.ts
+++ b/js/rename.ts
@@ -8,8 +8,7 @@ import * as dispatch from "./dispatch";
  * restrictions may apply when `oldpath` and `newpath` are in different
  * directories.
  *
- *       import { renameSync } from "deno";
- *       renameSync("old/path", "new/path");
+ *       Deno.renameSync("old/path", "new/path");
  */
 export function renameSync(oldpath: string, newpath: string): void {
   dispatch.sendSync(...req(oldpath, newpath));
@@ -19,8 +18,7 @@ export function renameSync(oldpath: string, newpath: string): void {
  * not a directory, `rename()` replaces it. OS-specific restrictions may apply
  * when `oldpath` and `newpath` are in different directories.
  *
- *       import { rename } from "deno";
- *       await rename("old/path", "new/path");
+ *       await Deno.rename("old/path", "new/path");
  */
 export async function rename(oldpath: string, newpath: string): Promise<void> {
   await dispatch.sendAsync(...req(oldpath, newpath));

--- a/js/rename_test.ts
+++ b/js/rename_test.ts
@@ -1,24 +1,23 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 testPerm({ read: true, write: true }, function renameSyncSuccess() {
-  const testDir = deno.makeTempDirSync();
+  const testDir = Deno.makeTempDirSync();
   const oldpath = testDir + "/oldpath";
   const newpath = testDir + "/newpath";
-  deno.mkdirSync(oldpath);
-  deno.renameSync(oldpath, newpath);
-  const newPathInfo = deno.statSync(newpath);
+  Deno.mkdirSync(oldpath);
+  Deno.renameSync(oldpath, newpath);
+  const newPathInfo = Deno.statSync(newpath);
   assert(newPathInfo.isDirectory());
 
   let caughtErr = false;
   let oldPathInfo;
 
   try {
-    oldPathInfo = deno.statSync(oldpath);
+    oldPathInfo = Deno.statSync(oldpath);
   } catch (e) {
     caughtErr = true;
-    assertEqual(e.kind, deno.ErrorKind.NotFound);
+    assertEqual(e.kind, Deno.ErrorKind.NotFound);
   }
   assert(caughtErr);
   assertEqual(oldPathInfo, undefined);
@@ -29,31 +28,31 @@ testPerm({ read: true, write: false }, function renameSyncPerm() {
   try {
     const oldpath = "/oldbaddir";
     const newpath = "/newbaddir";
-    deno.renameSync(oldpath, newpath);
+    Deno.renameSync(oldpath, newpath);
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });
 
 testPerm({ read: true, write: true }, async function renameSuccess() {
-  const testDir = deno.makeTempDirSync();
+  const testDir = Deno.makeTempDirSync();
   const oldpath = testDir + "/oldpath";
   const newpath = testDir + "/newpath";
-  deno.mkdirSync(oldpath);
-  await deno.rename(oldpath, newpath);
-  const newPathInfo = deno.statSync(newpath);
+  Deno.mkdirSync(oldpath);
+  await Deno.rename(oldpath, newpath);
+  const newPathInfo = Deno.statSync(newpath);
   assert(newPathInfo.isDirectory());
 
   let caughtErr = false;
   let oldPathInfo;
 
   try {
-    oldPathInfo = deno.statSync(oldpath);
+    oldPathInfo = Deno.statSync(oldpath);
   } catch (e) {
     caughtErr = true;
-    assertEqual(e.kind, deno.ErrorKind.NotFound);
+    assertEqual(e.kind, Deno.ErrorKind.NotFound);
   }
   assert(caughtErr);
   assertEqual(oldPathInfo, undefined);

--- a/js/repl.ts
+++ b/js/repl.ts
@@ -2,7 +2,6 @@
 import * as msg from "gen/msg_generated";
 import * as flatbuffers from "./flatbuffers";
 import { assert } from "./util";
-import * as deno from "./deno";
 import { close } from "./files";
 import * as dispatch from "./dispatch";
 import { exit } from "./os";
@@ -73,7 +72,6 @@ export async function readline(rid: number, prompt: string): Promise<string> {
 
 // @internal
 export async function replLoop(): Promise<void> {
-  window.deno = deno; // FIXME use a new scope (rather than window).
   Object.defineProperties(window, replCommands);
 
   const historyFile = "deno_history.txt";

--- a/js/resources_test.ts
+++ b/js/resources_test.ts
@@ -1,9 +1,8 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, testPerm, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 test(function resourcesStdio() {
-  const res = deno.resources();
+  const res = Deno.resources();
 
   assertEqual(res[0], "stdin");
   assertEqual(res[1], "stdout");
@@ -12,12 +11,12 @@ test(function resourcesStdio() {
 
 testPerm({ net: true }, async function resourcesNet() {
   const addr = "127.0.0.1:4501";
-  const listener = deno.listen("tcp", addr);
+  const listener = Deno.listen("tcp", addr);
 
-  const dialerConn = await deno.dial("tcp", addr);
+  const dialerConn = await Deno.dial("tcp", addr);
   const listenerConn = await listener.accept();
 
-  const res = deno.resources();
+  const res = Deno.resources();
   assertEqual(Object.values(res).filter(r => r === "tcpListener").length, 1);
   assertEqual(Object.values(res).filter(r => r === "tcpStream").length, 2);
 
@@ -27,9 +26,9 @@ testPerm({ net: true }, async function resourcesNet() {
 });
 
 testPerm({ read: true }, async function resourcesFile() {
-  const resourcesBefore = deno.resources();
-  await deno.open("tests/hello.txt");
-  const resourcesAfter = deno.resources();
+  const resourcesBefore = Deno.resources();
+  await Deno.open("tests/hello.txt");
+  const resourcesAfter = Deno.resources();
 
   // check that exactly one new resource (file) was added
   assertEqual(

--- a/js/stat.ts
+++ b/js/stat.ts
@@ -8,8 +8,7 @@ import { FileInfo, FileInfoImpl } from "./file_info";
 /** Queries the file system for information on the path provided. If the given
  * path is a symlink information about the symlink will be returned.
  *
- *       import { lstat } from "deno";
- *       const fileInfo = await lstat("hello.txt");
+ *       const fileInfo = await Deno.lstat("hello.txt");
  *       assert(fileInfo.isFile());
  */
 export async function lstat(filename: string): Promise<FileInfo> {
@@ -20,8 +19,7 @@ export async function lstat(filename: string): Promise<FileInfo> {
  * If the given path is a symlink information about the symlink will be
  * returned.
  *
- *       import { lstatSync } from "deno";
- *       const fileInfo = lstatSync("hello.txt");
+ *       const fileInfo = Deno.lstatSync("hello.txt");
  *       assert(fileInfo.isFile());
  */
 export function lstatSync(filename: string): FileInfo {
@@ -31,8 +29,7 @@ export function lstatSync(filename: string): FileInfo {
 /** Queries the file system for information on the path provided. `stat` Will
  * always follow symlinks.
  *
- *       import { stat } from "deno";
- *       const fileInfo = await stat("hello.txt");
+ *       const fileInfo = await Deno.stat("hello.txt");
  *       assert(fileInfo.isFile());
  */
 export async function stat(filename: string): Promise<FileInfo> {
@@ -42,8 +39,7 @@ export async function stat(filename: string): Promise<FileInfo> {
 /** Queries the file system for information on the path provided synchronously.
  * `statSync` Will always follow symlinks.
  *
- *       import { statSync } from "deno";
- *       const fileInfo = statSync("hello.txt");
+ *       const fileInfo = Deno.statSync("hello.txt");
  *       assert(fileInfo.isFile());
  */
 export function statSync(filename: string): FileInfo {

--- a/js/stat_test.ts
+++ b/js/stat_test.ts
@@ -1,19 +1,18 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 // TODO Add tests for modified, accessed, and created fields once there is a way
 // to create temp files.
 testPerm({ read: true }, async function statSyncSuccess() {
-  const packageInfo = deno.statSync("package.json");
+  const packageInfo = Deno.statSync("package.json");
   assert(packageInfo.isFile());
   assert(!packageInfo.isSymlink());
 
-  const testingInfo = deno.statSync("testing");
+  const testingInfo = Deno.statSync("testing");
   assert(testingInfo.isDirectory());
   assert(!testingInfo.isSymlink());
 
-  const srcInfo = deno.statSync("src");
+  const srcInfo = Deno.statSync("src");
   assert(srcInfo.isDirectory());
   assert(!srcInfo.isSymlink());
 });
@@ -21,10 +20,10 @@ testPerm({ read: true }, async function statSyncSuccess() {
 testPerm({ read: false }, async function statSyncPerm() {
   let caughtError = false;
   try {
-    deno.statSync("package.json");
+    Deno.statSync("package.json");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
@@ -35,10 +34,10 @@ testPerm({ read: true }, async function statSyncNotFound() {
   let badInfo;
 
   try {
-    badInfo = deno.statSync("bad_file_name");
+    badInfo = Deno.statSync("bad_file_name");
   } catch (err) {
     caughtError = true;
-    assertEqual(err.kind, deno.ErrorKind.NotFound);
+    assertEqual(err.kind, Deno.ErrorKind.NotFound);
     assertEqual(err.name, "NotFound");
   }
 
@@ -47,15 +46,15 @@ testPerm({ read: true }, async function statSyncNotFound() {
 });
 
 testPerm({ read: true }, async function lstatSyncSuccess() {
-  const packageInfo = deno.lstatSync("package.json");
+  const packageInfo = Deno.lstatSync("package.json");
   assert(packageInfo.isFile());
   assert(!packageInfo.isSymlink());
 
-  const testingInfo = deno.lstatSync("testing");
+  const testingInfo = Deno.lstatSync("testing");
   assert(!testingInfo.isDirectory());
   assert(testingInfo.isSymlink());
 
-  const srcInfo = deno.lstatSync("src");
+  const srcInfo = Deno.lstatSync("src");
   assert(srcInfo.isDirectory());
   assert(!srcInfo.isSymlink());
 });
@@ -63,10 +62,10 @@ testPerm({ read: true }, async function lstatSyncSuccess() {
 testPerm({ read: false }, async function lstatSyncPerm() {
   let caughtError = false;
   try {
-    deno.lstatSync("package.json");
+    Deno.lstatSync("package.json");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
@@ -77,10 +76,10 @@ testPerm({ read: true }, async function lstatSyncNotFound() {
   let badInfo;
 
   try {
-    badInfo = deno.lstatSync("bad_file_name");
+    badInfo = Deno.lstatSync("bad_file_name");
   } catch (err) {
     caughtError = true;
-    assertEqual(err.kind, deno.ErrorKind.NotFound);
+    assertEqual(err.kind, Deno.ErrorKind.NotFound);
     assertEqual(err.name, "NotFound");
   }
 
@@ -89,15 +88,15 @@ testPerm({ read: true }, async function lstatSyncNotFound() {
 });
 
 testPerm({ read: true }, async function statSuccess() {
-  const packageInfo = await deno.stat("package.json");
+  const packageInfo = await Deno.stat("package.json");
   assert(packageInfo.isFile());
   assert(!packageInfo.isSymlink());
 
-  const testingInfo = await deno.stat("testing");
+  const testingInfo = await Deno.stat("testing");
   assert(testingInfo.isDirectory());
   assert(!testingInfo.isSymlink());
 
-  const srcInfo = await deno.stat("src");
+  const srcInfo = await Deno.stat("src");
   assert(srcInfo.isDirectory());
   assert(!srcInfo.isSymlink());
 });
@@ -105,10 +104,10 @@ testPerm({ read: true }, async function statSuccess() {
 testPerm({ read: false }, async function statPerm() {
   let caughtError = false;
   try {
-    await deno.stat("package.json");
+    await Deno.stat("package.json");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
@@ -119,10 +118,10 @@ testPerm({ read: true }, async function statNotFound() {
   let badInfo;
 
   try {
-    badInfo = await deno.stat("bad_file_name");
+    badInfo = await Deno.stat("bad_file_name");
   } catch (err) {
     caughtError = true;
-    assertEqual(err.kind, deno.ErrorKind.NotFound);
+    assertEqual(err.kind, Deno.ErrorKind.NotFound);
     assertEqual(err.name, "NotFound");
   }
 
@@ -131,15 +130,15 @@ testPerm({ read: true }, async function statNotFound() {
 });
 
 testPerm({ read: true }, async function lstatSuccess() {
-  const packageInfo = await deno.lstat("package.json");
+  const packageInfo = await Deno.lstat("package.json");
   assert(packageInfo.isFile());
   assert(!packageInfo.isSymlink());
 
-  const testingInfo = await deno.lstat("testing");
+  const testingInfo = await Deno.lstat("testing");
   assert(!testingInfo.isDirectory());
   assert(testingInfo.isSymlink());
 
-  const srcInfo = await deno.lstat("src");
+  const srcInfo = await Deno.lstat("src");
   assert(srcInfo.isDirectory());
   assert(!srcInfo.isSymlink());
 });
@@ -147,10 +146,10 @@ testPerm({ read: true }, async function lstatSuccess() {
 testPerm({ read: false }, async function lstatPerm() {
   let caughtError = false;
   try {
-    await deno.lstat("package.json");
+    await Deno.lstat("package.json");
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
@@ -161,10 +160,10 @@ testPerm({ read: true }, async function lstatNotFound() {
   let badInfo;
 
   try {
-    badInfo = await deno.lstat("bad_file_name");
+    badInfo = await Deno.lstat("bad_file_name");
   } catch (err) {
     caughtError = true;
-    assertEqual(err.kind, deno.ErrorKind.NotFound);
+    assertEqual(err.kind, Deno.ErrorKind.NotFound);
     assertEqual(err.name, "NotFound");
   }
 

--- a/js/symlink.ts
+++ b/js/symlink.ts
@@ -8,8 +8,7 @@ import * as util from "./util";
  * argument can be set to `dir` or `file` and is only available on Windows
  * (ignored on other platforms).
  *
- *       import { symlinkSync } from "deno";
- *       symlinkSync("old/name", "new/name");
+ *       Deno.symlinkSync("old/name", "new/name");
  */
 export function symlinkSync(
   oldname: string,
@@ -23,8 +22,7 @@ export function symlinkSync(
  * set to `dir` or `file` and is only available on Windows (ignored on other
  * platforms).
  *
- *       import { symlink } from "deno";
- *       await symlink("old/name", "new/name");
+ *       await Deno.symlink("old/name", "new/name");
  */
 export async function symlink(
   oldname: string,

--- a/js/symlink_test.ts
+++ b/js/symlink_test.ts
@@ -1,25 +1,24 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 testPerm({ read: true, write: true }, function symlinkSyncSuccess() {
-  const testDir = deno.makeTempDirSync();
+  const testDir = Deno.makeTempDirSync();
   const oldname = testDir + "/oldname";
   const newname = testDir + "/newname";
-  deno.mkdirSync(oldname);
+  Deno.mkdirSync(oldname);
   let errOnWindows;
   // Just for now, until we implement symlink for Windows.
   try {
-    deno.symlinkSync(oldname, newname);
+    Deno.symlinkSync(oldname, newname);
   } catch (e) {
     errOnWindows = e;
   }
   if (errOnWindows) {
-    assertEqual(errOnWindows.kind, deno.ErrorKind.Other);
+    assertEqual(errOnWindows.kind, Deno.ErrorKind.Other);
     assertEqual(errOnWindows.message, "Not implemented");
   } else {
-    const newNameInfoLStat = deno.lstatSync(newname);
-    const newNameInfoStat = deno.statSync(newname);
+    const newNameInfoLStat = Deno.lstatSync(newname);
+    const newNameInfoStat = Deno.statSync(newname);
     assert(newNameInfoLStat.isSymlink());
     assert(newNameInfoStat.isDirectory());
   }
@@ -28,11 +27,11 @@ testPerm({ read: true, write: true }, function symlinkSyncSuccess() {
 test(function symlinkSyncPerm() {
   let err;
   try {
-    deno.symlinkSync("oldbaddir", "newbaddir");
+    Deno.symlinkSync("oldbaddir", "newbaddir");
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });
 
@@ -40,7 +39,7 @@ test(function symlinkSyncPerm() {
 testPerm({ write: true }, function symlinkSyncNotImplemented() {
   let err;
   try {
-    deno.symlinkSync("oldname", "newname", "dir");
+    Deno.symlinkSync("oldname", "newname", "dir");
   } catch (e) {
     err = e;
   }
@@ -48,23 +47,23 @@ testPerm({ write: true }, function symlinkSyncNotImplemented() {
 });
 
 testPerm({ read: true, write: true }, async function symlinkSuccess() {
-  const testDir = deno.makeTempDirSync();
+  const testDir = Deno.makeTempDirSync();
   const oldname = testDir + "/oldname";
   const newname = testDir + "/newname";
-  deno.mkdirSync(oldname);
+  Deno.mkdirSync(oldname);
   let errOnWindows;
   // Just for now, until we implement symlink for Windows.
   try {
-    await deno.symlink(oldname, newname);
+    await Deno.symlink(oldname, newname);
   } catch (e) {
     errOnWindows = e;
   }
   if (errOnWindows) {
-    assertEqual(errOnWindows.kind, deno.ErrorKind.Other);
+    assertEqual(errOnWindows.kind, Deno.ErrorKind.Other);
     assertEqual(errOnWindows.message, "Not implemented");
   } else {
-    const newNameInfoLStat = deno.lstatSync(newname);
-    const newNameInfoStat = deno.statSync(newname);
+    const newNameInfoLStat = Deno.lstatSync(newname);
+    const newNameInfoStat = Deno.statSync(newname);
     assert(newNameInfoLStat.isSymlink());
     assert(newNameInfoStat.isDirectory());
   }

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -7,7 +7,6 @@
 // tests by the special string. permW0N0 means allow-write but not allow-net.
 // See tools/unit_tests.py for more details.
 
-import * as deno from "deno";
 import * as testing from "./deps/https/deno.land/x/std/testing/mod.ts";
 export {
   assert,
@@ -15,7 +14,7 @@ export {
 } from "./deps/https/deno.land/x/std/testing/mod.ts";
 
 // testing.setFilter must be run before any tests are defined.
-testing.setFilter(deno.args[1]);
+testing.setFilter(Deno.args[1]);
 
 interface DenoPermissions {
   read?: boolean;

--- a/js/truncate.ts
+++ b/js/truncate.ts
@@ -6,9 +6,7 @@ import * as dispatch from "./dispatch";
 /** Truncates or extends the specified file synchronously, updating the size of
  * this file to become size.
  *
- *       import { truncateSync } from "deno";
- *
- *       truncateSync("hello.txt", 10);
+ *       Deno.truncateSync("hello.txt", 10);
  */
 export function truncateSync(name: string, len?: number): void {
   dispatch.sendSync(...req(name, len));
@@ -18,9 +16,7 @@ export function truncateSync(name: string, len?: number): void {
  * Truncates or extends the specified file, updating the size of this file to
  * become size.
  *
- *       import { truncate } from "deno";
- *
- *       await truncate("hello.txt", 10);
+ *       await Deno.truncate("hello.txt", 10);
  */
 export async function truncate(name: string, len?: number): Promise<void> {
   await dispatch.sendAsync(...req(name, len));

--- a/js/truncate_test.ts
+++ b/js/truncate_test.ts
@@ -1,16 +1,15 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 function readDataSync(name: string): string {
-  const data = deno.readFileSync(name);
+  const data = Deno.readFileSync(name);
   const decoder = new TextDecoder("utf-8");
   const text = decoder.decode(data);
   return text;
 }
 
 async function readData(name: string): Promise<string> {
-  const data = await deno.readFile(name);
+  const data = await Deno.readFile(name);
   const decoder = new TextDecoder("utf-8");
   const text = decoder.decode(data);
   return text;
@@ -19,55 +18,55 @@ async function readData(name: string): Promise<string> {
 testPerm({ read: true, write: true }, function truncateSyncSuccess() {
   const enc = new TextEncoder();
   const d = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test_truncateSync.txt";
-  deno.writeFileSync(filename, d);
-  deno.truncateSync(filename, 20);
+  const filename = Deno.makeTempDirSync() + "/test_truncateSync.txt";
+  Deno.writeFileSync(filename, d);
+  Deno.truncateSync(filename, 20);
   let data = readDataSync(filename);
   assertEqual(data.length, 20);
-  deno.truncateSync(filename, 5);
+  Deno.truncateSync(filename, 5);
   data = readDataSync(filename);
   assertEqual(data.length, 5);
-  deno.truncateSync(filename, -5);
+  Deno.truncateSync(filename, -5);
   data = readDataSync(filename);
   assertEqual(data.length, 0);
-  deno.removeSync(filename);
+  Deno.removeSync(filename);
 });
 
 testPerm({ read: true, write: true }, async function truncateSuccess() {
   const enc = new TextEncoder();
   const d = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test_truncate.txt";
-  await deno.writeFile(filename, d);
-  await deno.truncate(filename, 20);
+  const filename = Deno.makeTempDirSync() + "/test_truncate.txt";
+  await Deno.writeFile(filename, d);
+  await Deno.truncate(filename, 20);
   let data = await readData(filename);
   assertEqual(data.length, 20);
-  await deno.truncate(filename, 5);
+  await Deno.truncate(filename, 5);
   data = await readData(filename);
   assertEqual(data.length, 5);
-  await deno.truncate(filename, -5);
+  await Deno.truncate(filename, -5);
   data = await readData(filename);
   assertEqual(data.length, 0);
-  await deno.remove(filename);
+  await Deno.remove(filename);
 });
 
 testPerm({ write: false }, function truncateSyncPerm() {
   let err;
   try {
-    deno.mkdirSync("/test_truncateSyncPermission.txt");
+    Deno.mkdirSync("/test_truncateSyncPermission.txt");
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });
 
 testPerm({ write: false }, async function truncatePerm() {
   let err;
   try {
-    await deno.mkdir("/test_truncatePermission.txt");
+    await Deno.mkdir("/test_truncatePermission.txt");
   } catch (e) {
     err = e;
   }
-  assertEqual(err.kind, deno.ErrorKind.PermissionDenied);
+  assertEqual(err.kind, Deno.ErrorKind.PermissionDenied);
   assertEqual(err.name, "PermissionDenied");
 });

--- a/js/write_file.ts
+++ b/js/write_file.ts
@@ -16,11 +16,9 @@ export interface WriteFileOptions {
 
 /** Write a new file, with given filename and data synchronously.
  *
- *       import { writeFileSync } from "deno";
- *
  *       const encoder = new TextEncoder();
  *       const data = encoder.encode("Hello world\n");
- *       writeFileSync("hello.txt", data);
+ *       Deno.writeFileSync("hello.txt", data);
  */
 export function writeFileSync(
   filename: string,
@@ -32,11 +30,9 @@ export function writeFileSync(
 
 /** Write a new file, with given filename and data.
  *
- *       import { writeFile } from "deno";
- *
  *       const encoder = new TextEncoder();
  *       const data = encoder.encode("Hello world\n");
- *       await writeFile("hello.txt", data);
+ *       await Deno.writeFile("hello.txt", data);
  */
 export async function writeFile(
   filename: string,

--- a/js/write_file_test.ts
+++ b/js/write_file_test.ts
@@ -1,13 +1,12 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assert, assertEqual } from "./test_util.ts";
-import * as deno from "deno";
 
 testPerm({ read: true, write: true }, function writeFileSyncSuccess() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test.txt";
-  deno.writeFileSync(filename, data);
-  const dataRead = deno.readFileSync(filename);
+  const filename = Deno.makeTempDirSync() + "/test.txt";
+  Deno.writeFileSync(filename, data);
+  const dataRead = Deno.readFileSync(filename);
   const dec = new TextDecoder("utf-8");
   const actual = dec.decode(dataRead);
   assertEqual("Hello", actual);
@@ -20,10 +19,10 @@ testPerm({ write: true }, function writeFileSyncFail() {
   // The following should fail because /baddir doesn't exist (hopefully).
   let caughtError = false;
   try {
-    deno.writeFileSync(filename, data);
+    Deno.writeFileSync(filename, data);
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.NotFound);
+    assertEqual(e.kind, Deno.ErrorKind.NotFound);
     assertEqual(e.name, "NotFound");
   }
   assert(caughtError);
@@ -36,46 +35,46 @@ testPerm({ write: false }, function writeFileSyncPerm() {
   // The following should fail due to no write permission
   let caughtError = false;
   try {
-    deno.writeFileSync(filename, data);
+    Deno.writeFileSync(filename, data);
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
 });
 
 testPerm({ read: true, write: true }, function writeFileSyncUpdatePerm() {
-  if (deno.platform.os !== "win") {
+  if (Deno.platform.os !== "win") {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
-    const filename = deno.makeTempDirSync() + "/test.txt";
-    deno.writeFileSync(filename, data, { perm: 0o755 });
-    assertEqual(deno.statSync(filename).mode & 0o777, 0o755);
-    deno.writeFileSync(filename, data, { perm: 0o666 });
-    assertEqual(deno.statSync(filename).mode & 0o777, 0o666);
+    const filename = Deno.makeTempDirSync() + "/test.txt";
+    Deno.writeFileSync(filename, data, { perm: 0o755 });
+    assertEqual(Deno.statSync(filename).mode & 0o777, 0o755);
+    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    assertEqual(Deno.statSync(filename).mode & 0o777, 0o666);
   }
 });
 
 testPerm({ read: true, write: true }, function writeFileSyncCreate() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test.txt";
+  const filename = Deno.makeTempDirSync() + "/test.txt";
   let caughtError = false;
   // if create turned off, the file won't be created
   try {
-    deno.writeFileSync(filename, data, { create: false });
+    Deno.writeFileSync(filename, data, { create: false });
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.NotFound);
+    assertEqual(e.kind, Deno.ErrorKind.NotFound);
     assertEqual(e.name, "NotFound");
   }
   assert(caughtError);
 
   // Turn on create, should have no error
-  deno.writeFileSync(filename, data, { create: true });
-  deno.writeFileSync(filename, data, { create: false });
-  const dataRead = deno.readFileSync(filename);
+  Deno.writeFileSync(filename, data, { create: true });
+  Deno.writeFileSync(filename, data, { create: false });
+  const dataRead = Deno.readFileSync(filename);
   const dec = new TextDecoder("utf-8");
   const actual = dec.decode(dataRead);
   assertEqual("Hello", actual);
@@ -84,21 +83,21 @@ testPerm({ read: true, write: true }, function writeFileSyncCreate() {
 testPerm({ read: true, write: true }, function writeFileSyncAppend() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test.txt";
-  deno.writeFileSync(filename, data);
-  deno.writeFileSync(filename, data, { append: true });
-  let dataRead = deno.readFileSync(filename);
+  const filename = Deno.makeTempDirSync() + "/test.txt";
+  Deno.writeFileSync(filename, data);
+  Deno.writeFileSync(filename, data, { append: true });
+  let dataRead = Deno.readFileSync(filename);
   const dec = new TextDecoder("utf-8");
   let actual = dec.decode(dataRead);
   assertEqual("HelloHello", actual);
   // Now attempt overwrite
-  deno.writeFileSync(filename, data, { append: false });
-  dataRead = deno.readFileSync(filename);
+  Deno.writeFileSync(filename, data, { append: false });
+  dataRead = Deno.readFileSync(filename);
   actual = dec.decode(dataRead);
   assertEqual("Hello", actual);
   // append not set should also overwrite
-  deno.writeFileSync(filename, data);
-  dataRead = deno.readFileSync(filename);
+  Deno.writeFileSync(filename, data);
+  dataRead = Deno.readFileSync(filename);
   actual = dec.decode(dataRead);
   assertEqual("Hello", actual);
 });
@@ -106,9 +105,9 @@ testPerm({ read: true, write: true }, function writeFileSyncAppend() {
 testPerm({ read: true, write: true }, async function writeFileSuccess() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test.txt";
-  await deno.writeFile(filename, data);
-  const dataRead = deno.readFileSync(filename);
+  const filename = Deno.makeTempDirSync() + "/test.txt";
+  await Deno.writeFile(filename, data);
+  const dataRead = Deno.readFileSync(filename);
   const dec = new TextDecoder("utf-8");
   const actual = dec.decode(dataRead);
   assertEqual("Hello", actual);
@@ -121,10 +120,10 @@ testPerm({ read: true, write: true }, async function writeFileNotFound() {
   // The following should fail because /baddir doesn't exist (hopefully).
   let caughtError = false;
   try {
-    await deno.writeFile(filename, data);
+    await Deno.writeFile(filename, data);
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.NotFound);
+    assertEqual(e.kind, Deno.ErrorKind.NotFound);
     assertEqual(e.name, "NotFound");
   }
   assert(caughtError);
@@ -137,46 +136,46 @@ testPerm({ read: true, write: false }, async function writeFilePerm() {
   // The following should fail due to no write permission
   let caughtError = false;
   try {
-    await deno.writeFile(filename, data);
+    await Deno.writeFile(filename, data);
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
 });
 
 testPerm({ read: true, write: true }, async function writeFileUpdatePerm() {
-  if (deno.platform.os !== "win") {
+  if (Deno.platform.os !== "win") {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
-    const filename = deno.makeTempDirSync() + "/test.txt";
-    await deno.writeFile(filename, data, { perm: 0o755 });
-    assertEqual(deno.statSync(filename).mode & 0o777, 0o755);
-    await deno.writeFile(filename, data, { perm: 0o666 });
-    assertEqual(deno.statSync(filename).mode & 0o777, 0o666);
+    const filename = Deno.makeTempDirSync() + "/test.txt";
+    await Deno.writeFile(filename, data, { perm: 0o755 });
+    assertEqual(Deno.statSync(filename).mode & 0o777, 0o755);
+    await Deno.writeFile(filename, data, { perm: 0o666 });
+    assertEqual(Deno.statSync(filename).mode & 0o777, 0o666);
   }
 });
 
 testPerm({ read: true, write: true }, async function writeFileCreate() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test.txt";
+  const filename = Deno.makeTempDirSync() + "/test.txt";
   let caughtError = false;
   // if create turned off, the file won't be created
   try {
-    await deno.writeFile(filename, data, { create: false });
+    await Deno.writeFile(filename, data, { create: false });
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.NotFound);
+    assertEqual(e.kind, Deno.ErrorKind.NotFound);
     assertEqual(e.name, "NotFound");
   }
   assert(caughtError);
 
   // Turn on create, should have no error
-  await deno.writeFile(filename, data, { create: true });
-  await deno.writeFile(filename, data, { create: false });
-  const dataRead = deno.readFileSync(filename);
+  await Deno.writeFile(filename, data, { create: true });
+  await Deno.writeFile(filename, data, { create: false });
+  const dataRead = Deno.readFileSync(filename);
   const dec = new TextDecoder("utf-8");
   const actual = dec.decode(dataRead);
   assertEqual("Hello", actual);
@@ -185,21 +184,21 @@ testPerm({ read: true, write: true }, async function writeFileCreate() {
 testPerm({ read: true, write: true }, async function writeFileAppend() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const filename = deno.makeTempDirSync() + "/test.txt";
-  await deno.writeFile(filename, data);
-  await deno.writeFile(filename, data, { append: true });
-  let dataRead = deno.readFileSync(filename);
+  const filename = Deno.makeTempDirSync() + "/test.txt";
+  await Deno.writeFile(filename, data);
+  await Deno.writeFile(filename, data, { append: true });
+  let dataRead = Deno.readFileSync(filename);
   const dec = new TextDecoder("utf-8");
   let actual = dec.decode(dataRead);
   assertEqual("HelloHello", actual);
   // Now attempt overwrite
-  await deno.writeFile(filename, data, { append: false });
-  dataRead = deno.readFileSync(filename);
+  await Deno.writeFile(filename, data, { append: false });
+  dataRead = Deno.readFileSync(filename);
   actual = dec.decode(dataRead);
   assertEqual("Hello", actual);
   // append not set should also overwrite
-  await deno.writeFile(filename, data);
-  dataRead = deno.readFileSync(filename);
+  await Deno.writeFile(filename, data);
+  dataRead = Deno.readFileSync(filename);
   actual = dec.decode(dataRead);
   assertEqual("Hello", actual);
 });

--- a/tests/016_double_await.ts
+++ b/tests/016_double_await.ts
@@ -1,10 +1,8 @@
-import * as deno from "deno";
-
 // This is to test if Deno would die at 2nd await
 // See https://github.com/denoland/deno/issues/919
 (async () => {
-  const currDirInfo = await deno.stat(".");
-  const parentDirInfo = await deno.stat("..");
+  const currDirInfo = await Deno.stat(".");
+  const parentDirInfo = await Deno.stat("..");
   console.log(currDirInfo.isDirectory());
   console.log(parentDirInfo.isFile());
 })();

--- a/tests/cat.ts
+++ b/tests/cat.ts
@@ -1,4 +1,4 @@
-import { stdout, open, copy, args } from "deno";
+const { stdout, open, copy, args } = Deno;
 
 async function main() {
   for (let i = 1; i < args.length; i++) {

--- a/tests/echo_server.ts
+++ b/tests/echo_server.ts
@@ -1,4 +1,4 @@
-import { args, listen, copy } from "deno";
+const { args, listen, copy } = Deno;
 const addr = args[1] || "127.0.0.1:4544";
 const listener = listen("tcp", addr);
 console.log("listening on", addr);

--- a/tests/exit_error42.ts
+++ b/tests/exit_error42.ts
@@ -1,5 +1,3 @@
-import * as deno from "deno";
-
 console.log("before");
-deno.exit(42);
+Deno.exit(42);
 console.log("after");

--- a/tests/http_bench.ts
+++ b/tests/http_bench.ts
@@ -2,14 +2,13 @@
 // TODO Replace this with a real HTTP server once
 // https://github.com/denoland/deno/issues/726 is completed.
 // Note: this is a keep-alive server.
-import * as deno from "deno";
-const addr = deno.args[1] || "127.0.0.1:4500";
-const listener = deno.listen("tcp", addr);
+const addr = Deno.args[1] || "127.0.0.1:4500";
+const listener = Deno.listen("tcp", addr);
 const response = new TextEncoder().encode(
   "HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\nHello World\n"
 );
 
-async function handle(conn: deno.Conn): Promise<void> {
+async function handle(conn: Deno.Conn): Promise<void> {
   const buffer = new Uint8Array(1024);
   try {
     while (true) {

--- a/tests/is_tty.ts
+++ b/tests/is_tty.ts
@@ -1,2 +1,1 @@
-import { isTTY } from "deno";
-console.log(isTTY().stdin);
+console.log(Deno.isTTY().stdin);

--- a/tests/types.out
+++ b/tests/types.out
@@ -2,13 +2,14 @@
 
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
-[WILDCARD]
-declare module "deno" {
+
+declare namespace Deno {
 [WILDCARD]
 }
-
+[WILDCARD]
 declare interface Window {
 [WILDCARD]
+  Deno: typeof Deno;
 }
 
 declare const window: Window;

--- a/tests/unbuffered_stderr.ts
+++ b/tests/unbuffered_stderr.ts
@@ -1,3 +1,3 @@
-import { stderr } from "deno";
+const { stderr } = Deno;
 
 stderr.write(new TextEncoder().encode("x"));

--- a/tests/unbuffered_stdout.ts
+++ b/tests/unbuffered_stdout.ts
@@ -1,3 +1,3 @@
-import { stdout } from "deno";
+const { stdout } = Deno;
 
 stdout.write(new TextEncoder().encode("a"));

--- a/tools/format.ts
+++ b/tools/format.ts
@@ -1,27 +1,26 @@
 #!/usr/bin/env deno --allow-read --allow-run
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import * as deno from "deno";
 import { join } from "../js/deps/https/deno.land/x/std/fs/path.ts";
 import { findFiles, lookupDenoPath } from "./util.ts";
 
 const clangFormat = join("third_party", "depot_tools", "clang-format");
 const gn = join("third_party", "depot_tools", "gn");
 const yapf = join("third_party", "python_packages", "bin", "yapf");
-const rustfmt = join("third_party", "rustfmt", deno.platform.os, "rustfmt");
+const rustfmt = join("third_party", "rustfmt", Deno.platform.os, "rustfmt");
 const rustfmtConfig = ".rustfmt.toml";
 
 const decoder = new TextDecoder();
 
 async function run(...args: string[]): Promise<void> {
-  if (deno.platform.os === "win") {
+  if (Deno.platform.os === "win") {
     args = ["cmd.exe", "/c", ...args];
   }
-  const p = deno.run({ args, stdout: "piped", stderr: "piped" });
+  const p = Deno.run({ args, stdout: "piped", stderr: "piped" });
   const { code } = await p.status();
   if (code !== 0) {
-    console.log(decoder.decode(await deno.readAll(p.stderr)));
-    console.log(decoder.decode(await deno.readAll(p.stdout)));
-    deno.exit(code);
+    console.log(decoder.decode(await Deno.readAll(p.stderr)));
+    console.log(decoder.decode(await Deno.readAll(p.stdout)));
+    Deno.exit(code);
   }
 }
 

--- a/tools/permission_prompt_test.ts
+++ b/tools/permission_prompt_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { args, listen, env, exit, makeTempDirSync, readFile, run } from "deno";
+const { args, listen, env, exit, makeTempDirSync, readFile, run } = Deno;
 
 const name = args[1];
 const test = {

--- a/tools/repl_test.py
+++ b/tools/repl_test.py
@@ -28,7 +28,7 @@ class Repl(object):
                 p.stdin.flush()
                 time.sleep(sleep_)
             if exit_:
-                p.stdin.write(b'deno.exit(0)\n')
+                p.stdin.write(b'Deno.exit(0)\n')
             else:
                 time.sleep(1)  # wait to be killed by js
             out, err = p.communicate()
@@ -73,7 +73,7 @@ class Repl(object):
         assertEqual(code, 0)
 
     def test_function(self):
-        out, err, code = self.input("deno.writeFileSync")
+        out, err, code = self.input("Deno.writeFileSync")
         assertEqual(out, '[Function: writeFileSync]\n')
         assertEqual(err, '')
         assertEqual(code, 0)
@@ -99,7 +99,7 @@ class Repl(object):
 
     def test_set_timeout(self):
         out, err, code = self.input(
-            "setTimeout(() => { console.log('b'); deno.exit(0); }, 10)",
+            "setTimeout(() => { console.log('b'); Deno.exit(0); }, 10)",
             "'a'",
             exit=False)
         assertEqual(out, '1\na\nb\n')

--- a/tools/ts_library_builder/test.ts
+++ b/tools/ts_library_builder/test.ts
@@ -79,14 +79,16 @@ test(function buildLibraryFlatten() {
     debug,
     declarationProject,
     filePath: `${buildPath}/api.d.ts`,
-    namespaceName: `"api"`,
+    moduleName: `"api"`,
+    namespaceName: "Api",
     targetSourceFile
   });
 
   assert(targetSourceFile.getNamespace(`"api"`) != null);
-  assertEqual(targetSourceFile.getNamespaces().length, 1);
-  const namespaceApi = targetSourceFile.getNamespaceOrThrow(`"api"`);
-  const functions = namespaceApi.getFunctions();
+  assert(targetSourceFile.getNamespace("Api") != null);
+  assertEqual(targetSourceFile.getNamespaces().length, 2);
+  const moduleApi = targetSourceFile.getNamespaceOrThrow(`"api"`);
+  const functions = moduleApi.getFunctions();
   assertEqual(functions[0].getName(), "foo");
   assertEqual(
     functions[0]
@@ -104,12 +106,38 @@ test(function buildLibraryFlatten() {
     ""
   );
   assertEqual(functions.length, 2);
-  const classes = namespaceApi.getClasses();
+  const classes = moduleApi.getClasses();
   assertEqual(classes[0].getName(), "Foo");
   assertEqual(classes.length, 1);
-  const variableDeclarations = namespaceApi.getVariableDeclarations();
+  const variableDeclarations = moduleApi.getVariableDeclarations();
   assertEqual(variableDeclarations[0].getName(), "arr");
   assertEqual(variableDeclarations.length, 1);
+
+  const namespaceApi = targetSourceFile.getNamespaceOrThrow(`"api"`);
+  const functionsNs = namespaceApi.getFunctions();
+  assertEqual(functionsNs[0].getName(), "foo");
+  assertEqual(
+    functionsNs[0]
+      .getJsDocs()
+      .map(jsdoc => jsdoc.getInnerText())
+      .join("\n"),
+    "jsdoc for foo"
+  );
+  assertEqual(functionsNs[1].getName(), "bar");
+  assertEqual(
+    functionsNs[1]
+      .getJsDocs()
+      .map(jsdoc => jsdoc.getInnerText())
+      .join("\n"),
+    ""
+  );
+  assertEqual(functionsNs.length, 2);
+  const classesNs = namespaceApi.getClasses();
+  assertEqual(classesNs[0].getName(), "Foo");
+  assertEqual(classesNs.length, 1);
+  const variableDeclarationsNs = namespaceApi.getVariableDeclarations();
+  assertEqual(variableDeclarationsNs[0].getName(), "arr");
+  assertEqual(variableDeclarationsNs.length, 1);
 });
 
 test(function buildLibraryMerge() {

--- a/tools/util.ts
+++ b/tools/util.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { platform, lstatSync, readDirSync } from "deno";
 import { join } from "../js/deps/https/deno.land/x/std/fs/path/mod.ts";
+
+const { platform, lstatSync, readDirSync } = Deno;
 
 export interface FindOptions {
   skip?: string[];

--- a/tools/util_test.ts
+++ b/tools/util_test.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import * as deno from "deno";
 import { assert, testPerm, assertEqual } from "../js/test_util.ts";
 import { findFiles } from "./util.ts";
 
@@ -55,7 +54,7 @@ testPerm({ read: false }, function testFindFilesPerm() {
     const files = findFiles([testDir], [".ts", ".md"]);
   } catch (e) {
     caughtError = true;
-    assertEqual(e.kind, deno.ErrorKind.PermissionDenied);
+    assertEqual(e.kind, Deno.ErrorKind.PermissionDenied);
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);

--- a/website/manual.md
+++ b/website/manual.md
@@ -69,8 +69,8 @@ formatters</a>.
 ### Browser compatibility
 
 The subset of Deno programs which are written completely in JavaScript and do
-not import the special `"deno"` module, ought to also be able to be run in a
-modern web browser without change.
+not use the global `Deno` namespace (or feature test for it), ought to also be
+able to be run in a modern web browser without change.
 
 ## Setup
 
@@ -228,13 +228,11 @@ In this program each command-line argument is assumed to be a filename, the file
 is opened, and printed to stdout.
 
 ```ts
-import * as deno from "deno";
-
 (async () => {
-  for (let i = 1; i < deno.args.length; i++) {
-    let filename = deno.args[i];
-    let file = await deno.open(filename);
-    await deno.copy(deno.stdout, file);
+  for (let i = 1; i < Deno.args.length; i++) {
+    let filename = Deno.args[i];
+    let file = await Deno.open(filename);
+    await Deno.copy(Deno.stdout, file);
     file.close();
   }
 })();
@@ -257,7 +255,7 @@ This is an example of a simple server which accepts connections on port 8080,
 and returns to the client anything it sends.
 
 ```ts
-import { listen, copy } from "deno";
+const { listen, copy } = Deno;
 
 (async () => {
   const addr = "0.0.0.0:8080";


### PR DESCRIPTION
Resolves #1705 

This PR adds the Deno APIs as a global namespace named `Deno`.  For backwards compatibility, the ability to `import * from "deno"` is preserved.  I have tried to convert every test and internal code the references the module to use the namespace instead, but because I didn't break compatibility I am not sure.

On the REPL, `deno` no longer exists, replaced only with `Deno` to align with the regular runtime.

The runtime type library includes both the namespace and module.  This means it duplicates the whole type information.  When we remove the functionality from the runtime, it will be a one line change to the library generator to remove the module definition from the type library.

I marked a `TODO` in a couple places where to remove the `"deno"` module, but there are additional places I know I didn't mark.