### PR TITLE
Drop assert!() from untrack_task()

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -202,7 +202,8 @@ impl Resource {
     let mut table = RESOURCE_TABLE.lock().unwrap();
     // Only untrack if is TcpListener.
     if let Some(Repr::TcpListener(_, t)) = table.get_mut(&self.rid) {
-      assert!(t.is_some());
+      // DO NOT assert is_some here.
+      // See reasoning in Accept::poll().
       t.take();
     }
   }

--- a/src/tokio_util.rs
+++ b/src/tokio_util.rs
@@ -69,6 +69,10 @@ impl Future for Accept {
       // notified to error out (instead of stuck forever).
       AcceptState::Pending(ref mut r) => match r.poll_accept() {
         Ok(futures::prelude::Async::Ready(t)) => {
+          // Notice: it is possible to be Ready on the first poll.
+          // When eager accept fails due to WouldBlock,
+          // a next poll() might still be immediately Ready.
+          // See https://github.com/denoland/deno/issues/1756.
           r.untrack_task();
           t
         }


### PR DESCRIPTION
Closes #1756
See reasoning of this patch in #1756.
