### PR TITLE
Use proper directory for cache files

### DIFF
--- a/src/deno_dir.rs
+++ b/src/deno_dir.rs
@@ -63,7 +63,13 @@ impl DenoDir {
   ) -> std::io::Result<Self> {
     // Only setup once.
     let home_dir = dirs::home_dir().expect("Could not get home directory.");
-    let default = home_dir.join(".deno");
+    let fallback = home_dir.join(".deno");
+    // We use the OS cache dir because all files deno writes are cache files
+    // Once that changes we need to start using different roots if DENO_DIR
+    // is not set, and keep a single one if it is.
+    let default = dirs::cache_dir()
+      .map(|d| d.join("deno"))
+      .unwrap_or(fallback);
 
     let root: PathBuf = custom_root.unwrap_or(default);
     let gen = root.as_path().join("gen");

--- a/website/manual.md
+++ b/website/manual.md
@@ -359,9 +359,15 @@ and yet it accessed the network. The runtime has special access to download
 imports and cache them to disk.
 
 Deno caches remote imports in a special directory specified by the `$DENO_DIR`
-environmental variable. It default to `$HOME/.deno` if `$DENO_DIR` is not
-specified. The next time you run the program, no downloads will be made. If the
-program hasn't changed, it won't be recompiled either.
+environmental variable. It defaults to the system's cache directory if
+`$DENO_DIR` is not specified. The next time you run the program, no downloads
+will be made. If the program hasn't changed, it won't be recompiled either. The
+default directory is:
+
+- On Linux/Redox: `$XDG_CACHE_HOME/deno` or `$HOME/.cache/deno`
+- On Windows: `%LOCALAPPDATA%/deno` (`%LOCALAPPDATA%` = `FOLDERID_LocalAppData`)
+- On macOS: `$HOME/Library/Caches/deno`
+- If something fails, it falls back to `$HOME/.deno`
 
 **But what if `https://deno.land/` goes down?** Relying on external servers is
 convenient for development but brittle in production. Production software should


### PR DESCRIPTION
Operating systems have defined directories for cache files.
That allows them to do smart things such as leaving them out when doing a backup,
or deleting them when disk space gets low.

From the `dirs` docs:


Function name | Value on Linux/Redox | Value on Windows | Value on macOS
-- | -- | -- | --
`cache_dir` | `Some($XDG_CACHE_HOME)` or `Some($HOME/.cache)` | `Some({FOLDERID_LocalAppData})` | `Some($HOME/Library/Caches)`

Also a `%home%\.deno` folder on windows made no sense whatsoever.

Fixes #481
