### PR TITLE
Use python2 binary

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -77,7 +77,7 @@ fn main() {
   }
 
   if !gn_out_path.join("build.ninja").exists() {
-    let status = Command::new("python")
+    let status = Command::new("python2")
       .env("DENO_BUILD_PATH", &gn_out_dir)
       .env("DENO_BUILD_MODE", &gn_mode)
       .arg("./tools/setup.py")
@@ -86,7 +86,7 @@ fn main() {
     assert!(status.success());
   }
 
-  let status = Command::new("python")
+  let status = Command::new("python2")
     .env("DENO_BUILD_PATH", &gn_out_dir)
     .env("DENO_BUILD_MODE", &gn_mode)
     .arg("./tools/build.py")

--- a/tools/third_party.py
+++ b/tools/third_party.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 # This script contains helper functions to work with the third_party subrepo.
 
@@ -232,7 +232,7 @@ def download_from_google_storage(item, bucket):
         sha1_file = "v8/buildtools/linux64/%s.sha1" % item
 
     run([
-        "python",
+        sys.executable,
         tp('depot_tools/download_from_google_storage.py'),
         '--platform=' + sys.platform,
         '--no_auth',
@@ -255,13 +255,13 @@ def download_clang_format():
 
 # Download clang by calling the clang update script.
 def download_clang():
-    run(['python', tp('v8/tools/clang/scripts/update.py')], env=google_env())
+    run([sys.executable, tp('v8/tools/clang/scripts/update.py')], env=google_env())
 
 
 def maybe_download_sysroot():
     if sys.platform.startswith('linux'):
         run([
-            'python',
+            sys.executable,
             os.path.join(root_path,
                          'build/linux/sysroot_scripts/install-sysroot.py'),
             '--arch=amd64'


### PR DESCRIPTION
On e.g. Arch Linux, `python` symlinks to `python3`, but the scripts contained in deno are all legacy python.