### PR TITLE
Cleanup Deno namespace

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -366,7 +366,9 @@ function isCollapsed(
   return collapsedAt <= indentLevel;
 }
 
-/** TODO Do not expose this from "deno" namespace. */
+/** TODO Do not expose this from "deno" namespace.
+ * @internal
+ */
 export function stringifyArgs(
   // tslint:disable-next-line:no-any
   args: any[],
@@ -501,6 +503,7 @@ const timerMap = new Map<string, number>();
 export class Console {
   indentLevel: number;
   collapsedAt: number | null;
+  /** @internal */
   constructor(private printFunc: PrintFunc) {
     this.indentLevel = 0;
     this.collapsedAt = null;

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual, assert } from "./test_util.ts";
 
-const { Console, libdeno, stringifyArgs, inspect, write, stdout } = Deno;
+// Some of these APIs aren't exposed in the types and so we have to cast to any
+// in order to "trick" TypeScript.
+// tslint:disable-next-line:no-any
+const { Console, libdeno, stringifyArgs, inspect, write, stdout } = Deno as any;
 
 const console = new Console(libdeno.print);
 

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -31,9 +31,13 @@ export {
 } from "./io";
 export { Buffer, readAll } from "./buffer";
 export { mkdirSync, mkdir } from "./mkdir";
-export { makeTempDirSync, makeTempDir } from "./make_temp_dir";
+export {
+  makeTempDirSync,
+  makeTempDir,
+  MakeTempDirOptions
+} from "./make_temp_dir";
 export { chmodSync, chmod } from "./chmod";
-export { removeSync, remove } from "./remove";
+export { removeSync, remove, RemoveOption } from "./remove";
 export { renameSync, rename } from "./rename";
 export { readFileSync, readFile } from "./read_file";
 export { readDirSync, readDir } from "./read_dir";
@@ -41,22 +45,25 @@ export { copyFileSync, copyFile } from "./copy_file";
 export { readlinkSync, readlink } from "./read_link";
 export { statSync, lstatSync, stat, lstat } from "./stat";
 export { symlinkSync, symlink } from "./symlink";
-export { writeFileSync, writeFile } from "./write_file";
+export { writeFileSync, writeFile, WriteFileOptions } from "./write_file";
 export { ErrorKind, DenoError } from "./errors";
 export { libdeno } from "./libdeno";
 export { platform } from "./platform";
 export { truncateSync, truncate } from "./truncate";
 export { FileInfo } from "./file_info";
 export { connect, dial, listen, Listener, Conn } from "./net";
-export { metrics } from "./metrics";
+export { metrics, Metrics } from "./metrics";
 export { resources } from "./resources";
 export { run, RunOptions, Process, ProcessStatus } from "./process";
 export { inspect } from "./console";
 export const args: string[] = [];
 
 // TODO Don't expose Console nor stringifyArgs.
+/** @internal */
 export { Console, stringifyArgs } from "./console";
 // TODO Don't expose DomIterableMixin.
+/** @internal */
 export { DomIterableMixin } from "./mixins/dom_iterable";
 // TODO Don't expose deferred.
+/** @internal */
 export { deferred } from "./util";

--- a/js/files.ts
+++ b/js/files.ts
@@ -57,6 +57,7 @@ export type OpenMode =
 
 /** A factory function for creating instances of `File` associated with the
  * supplied file name.
+ * @internal
  */
 export function create(filename: string): Promise<File> {
   return open(filename, "w+");

--- a/js/metrics.ts
+++ b/js/metrics.ts
@@ -4,7 +4,7 @@ import * as flatbuffers from "./flatbuffers";
 import { assert } from "./util";
 import * as dispatch from "./dispatch";
 
-interface Metrics {
+export interface Metrics {
   opsDispatched: number;
   opsCompleted: number;
   bytesSentControl: number;

--- a/js/mixins/dom_iterable_test.ts
+++ b/js/mixins/dom_iterable_test.ts
@@ -17,10 +17,10 @@ function setup() {
 
   return {
     Base,
-    DomIterable: Deno.DomIterableMixin<string, number, typeof Base>(
-      Base,
-      dataSymbol
-    )
+    // This is using an internal API we don't want published as types, so having
+    // to cast to any to "trick" TypeScript
+    // tslint:disable-next-line:no-any
+    DomIterable: (Deno as any).DomIterableMixin(Base, dataSymbol)
   };
 }
 

--- a/js/os.ts
+++ b/js/os.ts
@@ -12,6 +12,7 @@ export let pid: number;
 /** Reflects the NO_COLOR environment variable: https://no-color.org/ */
 export let noColor: boolean;
 
+/** @internal */
 export function setGlobals(pid_: number, noColor_: boolean): void {
   assert(!pid);
   pid = pid_;


### PR DESCRIPTION
This PR cleans up the Deno namespace where we were unintentionally leaking some non-sensical things that were really internal.

The one thing it does not do, is that the `console.ts` types leak into the Deno namespace because the `inspect()` function exists in `console.ts`, so when the namespace is flattened, all of the types are brought in, because the library builder isn't capable of tree shaking unused types.  The best solution to this is to split `inspect()` out to different module, but if agreed it is probably best to do that as a seperate PR.
