### PR TITLE
Add env option to run api

### DIFF
--- a/js/process_test.ts
+++ b/js/process_test.ts
@@ -186,3 +186,22 @@ testPerm({ run: true }, async function runOutput() {
   assertEqual(s, "hello");
   p.close();
 });
+
+testPerm({ run: true }, async function runEnv() {
+  const p = run({
+    args: [
+      "python",
+      "-c",
+      "import os, sys; sys.stdout.write(os.environ.get('FOO', '') + os.environ.get('BAR', ''))"
+    ],
+    env: {
+      FOO: "0123",
+      BAR: "4567"
+    },
+    stdout: "piped"
+  });
+  const output = await p.output();
+  const s = new TextDecoder().decode(output);
+  assertEqual(s, "01234567");
+  p.close();
+});

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -464,6 +464,7 @@ enum ProcessStdio: byte { Inherit, Piped, Null }
 table Run {
   args: [string];
   cwd: string;
+  env: [KeyValue];
   stdin: ProcessStdio;
   stdout: ProcessStdio;
   stderr: ProcessStdio;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1559,6 +1559,7 @@ fn op_run(
   assert_eq!(data.len(), 0);
   let inner = base.inner_as_run().unwrap();
   let args = inner.args().unwrap();
+  let env = inner.env().unwrap();
   let cwd = inner.cwd();
 
   let mut c = Command::new(args.get(0));
@@ -1567,6 +1568,10 @@ fn op_run(
     c.arg(arg);
   });
   cwd.map(|d| c.current_dir(d));
+  (0..env.len()).for_each(|i| {
+    let entry = env.get(i);
+    c.env(entry.key().unwrap(), entry.value().unwrap());
+  });
 
   c.stdin(subprocess_stdio_map(inner.stdin()));
   c.stdout(subprocess_stdio_map(inner.stdout()));


### PR DESCRIPTION
This PR adds `env` option to `run` API. When `env` object is specified, the key-value pairs are added to env variables of subprocesses.

---
This PR addresses [this comment](https://github.com/denoland/deno/pull/1732#discussion_r255624078), though format.ts itself is now reverted.