### PR TITLE
Changed link reference in install instructions

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -86,10 +86,10 @@
 
       <p>Mac or Linux</p>
       <pre>curl -fL <a
-href="https://github.com/denoland/deno_install/blob/master/install.sh">https://deno.land/x/install/install.sh</a> | sh</pre>
+href="https://deno.land/x/install/install.sh">https://deno.land/x/install/install.sh</a> | sh</pre>
       <p>Windows (PowerShell)</p>
       <pre>iex (iwr <a
-href="https://github.com/denoland/deno_install/blob/master/install.ps1">https://deno.land/x/install/install.ps1</a>)</pre>
+href="https://deno.land/x/install/install.ps1">https://deno.land/x/install/install.ps1</a>)</pre>
 
       <h2 id="example">Example <a href="#example">#</a></h2>
 


### PR DESCRIPTION
The href values were different than the displayed url. This might cause confusions, even if there is a redirection in place.