### PR TITLE
chore(gn): remove unnecessary build option

### DIFF
--- a/build_extra/flatbuffers/BUILD.gn
+++ b/build_extra/flatbuffers/BUILD.gn
@@ -13,11 +13,6 @@ config("flatbuffers_config") {
     cflags = [
       "-Wno-exit-time-destructors",
       "-Wno-header-hygiene",
-
-      # TODO: rust branch of flatbuffers has this warning.
-      # This should be removed when the branch fixed.
-      "-Wno-return-type",
-
       "-fcolor-diagnostics",
       "-fansi-escape-codes",
     ]


### PR DESCRIPTION
This PR removes an old workaround which seems now unnecessary.