### PR TITLE
Add back typescript version number and add Deno.version object.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -109,6 +109,7 @@ ts_sources = [
   "js/workers.ts",
   "js/write_file.ts",
   "js/performance.ts",
+  "js/version.ts",
   "tsconfig.json",
 
   # Listing package.json and yarn.lock as sources ensures the bundle is rebuilt

--- a/js/const.d.ts
+++ b/js/const.d.ts
@@ -1,2 +1,0 @@
-// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-declare var TS_VERSION: string;

--- a/js/const.d.ts
+++ b/js/const.d.ts
@@ -1,0 +1,2 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+declare var TS_VERSION: string;

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -56,6 +56,7 @@ export { metrics, Metrics } from "./metrics";
 export { resources } from "./resources";
 export { run, RunOptions, Process, ProcessStatus } from "./process";
 export { inspect } from "./console";
+export { version } from "./version";
 export const args: string[] = [];
 
 // TODO Don't expose Console nor stringifyArgs.

--- a/js/main.ts
+++ b/js/main.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 // tslint:disable-next-line:no-reference
 /// <reference path="./plugins.d.ts" />
-/// <reference path="./const.d.ts" />
 
 import "./globals";
 
@@ -10,6 +9,7 @@ import * as os from "./os";
 import { libdeno } from "./libdeno";
 import { args } from "./deno";
 import { replLoop } from "./repl";
+import { version } from "./version";
 
 // builtin modules
 import * as deno from "./deno";
@@ -25,11 +25,14 @@ export default function denoMain() {
   libdeno.builtinModules["deno"] = deno;
   Object.freeze(libdeno.builtinModules);
 
+  version.deno = startResMsg.denoVersion();
+  version.v8 = startResMsg.v8Version();
+
   // handle `--version`
   if (startResMsg.versionFlag()) {
-    console.log("deno:", startResMsg.denoVersion());
-    console.log("v8:", startResMsg.v8Version());
-    console.log("typescript:", TS_VERSION);
+    console.log("deno:", version.deno);
+    console.log("v8:", version.v8);
+    console.log("typescript:", version.typescript);
     os.exit(0);
   }
 

--- a/js/main.ts
+++ b/js/main.ts
@@ -9,7 +9,7 @@ import * as os from "./os";
 import { libdeno } from "./libdeno";
 import { args } from "./deno";
 import { replLoop } from "./repl";
-import { version } from "./version";
+import { setVersions } from "./version";
 
 // builtin modules
 import * as deno from "./deno";
@@ -25,14 +25,13 @@ export default function denoMain() {
   libdeno.builtinModules["deno"] = deno;
   Object.freeze(libdeno.builtinModules);
 
-  version.deno = startResMsg.denoVersion();
-  version.v8 = startResMsg.v8Version();
+  setVersions(startResMsg.denoVersion()!, startResMsg.v8Version()!);
 
   // handle `--version`
   if (startResMsg.versionFlag()) {
-    console.log("deno:", version.deno);
-    console.log("v8:", version.v8);
-    console.log("typescript:", version.typescript);
+    console.log("deno:", deno.version.deno);
+    console.log("v8:", deno.version.v8);
+    console.log("typescript:", deno.version.typescript);
     os.exit(0);
   }
 

--- a/js/main.ts
+++ b/js/main.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 // tslint:disable-next-line:no-reference
 /// <reference path="./plugins.d.ts" />
+/// <reference path="./const.d.ts" />
 
 import "./globals";
 
@@ -28,8 +29,7 @@ export default function denoMain() {
   if (startResMsg.versionFlag()) {
     console.log("deno:", startResMsg.denoVersion());
     console.log("v8:", startResMsg.v8Version());
-    // TODO figure out a way to restore functionality
-    // console.log("typescript:", version);
+    console.log("typescript:", TS_VERSION);
     os.exit(0);
   }
 

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -44,6 +44,7 @@ import "./url_test.ts";
 import "./url_search_params_test.ts";
 import "./write_file_test.ts";
 import "./performance_test.ts";
+import "./version_test.ts";
 
 import "../website/app_test.js";
 

--- a/js/version.ts
+++ b/js/version.ts
@@ -1,14 +1,14 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 interface Version {
-  deno: string | null;
-  v8: string | null;
+  deno: string;
+  v8: string;
   typescript: string;
 }
 
 export const version: Version = {
-  deno: null,
-  v8: null,
-  typescript: "TS_VERSION"
+  deno: "",
+  v8: "",
+  typescript: "TS_VERSION" // This string will be replaced by rollup
 };
 
 /**

--- a/js/version.ts
+++ b/js/version.ts
@@ -1,7 +1,4 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-// tslint:disable-next-line:no-reference
-/// <reference path="./const.d.ts" />
-
 interface Version {
   deno: string | null;
   v8: string | null;
@@ -13,3 +10,13 @@ export const version: Version = {
   v8: null,
   typescript: TS_VERSION
 };
+
+/**
+ * Sets the deno and v8 versions and freezes the version object.
+ */
+export function setVersions(denoVersion: string, v8Version: string): void {
+  version.deno = denoVersion;
+  version.v8 = v8Version;
+
+  Object.freeze(version);
+}

--- a/js/version.ts
+++ b/js/version.ts
@@ -13,6 +13,7 @@ export const version: Version = {
 
 /**
  * Sets the deno and v8 versions and freezes the version object.
+ * @internal
  */
 export function setVersions(denoVersion: string, v8Version: string): void {
   version.deno = denoVersion;

--- a/js/version.ts
+++ b/js/version.ts
@@ -8,7 +8,7 @@ interface Version {
 export const version: Version = {
   deno: null,
   v8: null,
-  typescript: TS_VERSION
+  typescript: "TS_VERSION"
 };
 
 /**

--- a/js/version.ts
+++ b/js/version.ts
@@ -1,0 +1,15 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+// tslint:disable-next-line:no-reference
+/// <reference path="./const.d.ts" />
+
+interface Version {
+  deno: string | null;
+  v8: string | null;
+  typescript: string;
+}
+
+export const version: Version = {
+  deno: null,
+  v8: null,
+  typescript: TS_VERSION
+};

--- a/js/version_test.ts
+++ b/js/version_test.ts
@@ -1,7 +1,8 @@
-import { test, assertEqual, assert } from "./test_util.ts";
+import { test, assert } from "./test_util.ts";
 
 test(function version() {
-  assert(typeof Deno.version.deno === "string");
-  assert(typeof Deno.version.v8 === "string");
-  assert(typeof Deno.version.typescript === "string");
+  const pattern = /^\d+\.\d+\.\d+$/;
+  assert(pattern.test(Deno.version.deno));
+  assert(pattern.test(Deno.version.v8));
+  assert(pattern.test(Deno.version.typescript));
 });

--- a/js/version_test.ts
+++ b/js/version_test.ts
@@ -1,0 +1,7 @@
+import { test, assertEqual, assert } from "./test_util.ts";
+
+test(function version() {
+  assert(typeof Deno.version.deno === "string");
+  assert(typeof Deno.version.v8 === "string");
+  assert(typeof Deno.version.typescript === "string");
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-node-globals": "^1.2.1",
     "rollup-plugin-node-resolve": "^3.3.0",
+    "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-string": "^2.0.2",
     "rollup-plugin-typescript2": "^0.16.1",
     "rollup-pluginutils": "^2.3.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -228,7 +228,7 @@ export default function makeConfig(commandOptions) {
 
       // replace strings
       replace({
-        TS_VERSION: `"${typescript.version}"`
+        TS_VERSION: typescript.version
       }),
 
       // would prefer to use `rollup-plugin-virtual` to inject the empty module, but there

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,6 +9,7 @@ import globals from "rollup-plugin-node-globals";
 import nodeResolve from "rollup-plugin-node-resolve";
 import typescriptPlugin from "rollup-plugin-typescript2";
 import { createFilter } from "rollup-pluginutils";
+import replace from "rollup-plugin-replace";
 import typescript from "typescript";
 import MagicString from "magic-string";
 
@@ -223,6 +224,11 @@ export default function makeConfig(commandOptions) {
       // inject platform and arch from Node
       platform({
         include: [platformPath]
+      }),
+
+      // replace strings
+      replace({
+        TS_VERSION: `"${typescript.version}"`
       }),
 
       // would prefer to use `rollup-plugin-virtual` to inject the empty module, but there


### PR DESCRIPTION
This is a continuation of #1676. This adds back the printing of typescript version number.
This also addresses [the comment](https://github.com/denoland/deno/pull/1676#discussion_r253894585):

> t would be good to have access to the versions in the runtime environment - maybe that can be done as part of this work... `deno.version.v8` for example would be nice to have.

This PR uses rollup-plugin-replace for embedding typescript version in the bundle.

---
depends on https://github.com/denoland/deno_third_party/pull/33
