### PR TITLE
Implement seek syscall

### DIFF
--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -66,6 +66,7 @@ union Any {
   NowRes,
   IsTTY,
   IsTTYRes,
+  Seek,
 }
 
 enum ErrorKind: byte {
@@ -504,6 +505,11 @@ table IsTTYRes {
   stdin: bool;
   stdout: bool;
   stderr: bool;
+}
+
+table Seek {
+  rid: uint32;
+  offset: uint64;
 }
 
 root_type Base;


### PR DESCRIPTION
Closes #1304 

It's been laying around for some time and failing with:
```
error[E0507]: cannot move out of borrowed content
   --> ../../src/resources.rs:577:9
    |
577 |         f.seek(SeekFrom::Start(offset))
    |         ^ cannot move out of borrowed content

```

Help appreciated, I'm not good with Rust