### PR TITLE
Add `seek` and implement `Seeker` on `File`

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -11,6 +11,7 @@ export {
   stderr,
   read,
   write,
+  seek,
   close,
   OpenMode
 } from "./files";
@@ -18,6 +19,7 @@ export {
   copy,
   toAsyncIterator,
   ReadResult,
+  SeekMode,
   Reader,
   Writer,
   Closer,

--- a/js/files.ts
+++ b/js/files.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { Reader, Writer, Seeker, Closer, ReadResult } from "./io";
+import { Reader, Writer, Seeker, Closer, ReadResult, SeekMode } from "./io";
 import * as dispatch from "./dispatch";
 import * as msg from "gen/msg_generated";
 import { assert } from "./util";
@@ -17,7 +17,7 @@ export class File implements Reader, Writer, Seeker, Closer {
     return read(this.rid, p);
   }
 
-  seek(offset: number, whence: number): Promise<void> {
+  seek(offset: number, whence: SeekMode): Promise<void> {
     return seek(this.rid, offset, whence);
   }
 
@@ -133,7 +133,7 @@ export async function write(rid: number, p: Uint8Array): Promise<number> {
 export async function seek(
   rid: number,
   offset: number,
-  whence: number
+  whence: SeekMode
 ): Promise<void> {
   const builder = flatbuffers.createBuilder();
   msg.Seek.startSeek(builder);

--- a/js/files.ts
+++ b/js/files.ts
@@ -1,12 +1,12 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { Reader, Writer, Closer, ReadResult } from "./io";
+import { Reader, Writer, Seeker, Closer, ReadResult } from "./io";
 import * as dispatch from "./dispatch";
 import * as msg from "gen/msg_generated";
 import { assert } from "./util";
 import * as flatbuffers from "./flatbuffers";
 
 /** The Deno abstraction for reading and writing files. */
-export class File implements Reader, Writer, Closer {
+export class File implements Reader, Writer, Seeker, Closer {
   constructor(readonly rid: number) {}
 
   write(p: Uint8Array): Promise<number> {
@@ -15,6 +15,10 @@ export class File implements Reader, Writer, Closer {
 
   read(p: Uint8Array): Promise<ReadResult> {
     return read(this.rid, p);
+  }
+
+  seek(offset: number, whence: number): Promise<void> {
+    return seek(this.rid, offset, whence);
   }
 
   close(): void {
@@ -121,6 +125,23 @@ export async function write(rid: number, p: Uint8Array): Promise<number> {
   const res = new msg.WriteRes();
   assert(baseRes!.inner(res) != null);
   return res.nbyte();
+}
+
+/** Seek a file ID to the given offset under mode given by `whence`.
+ *
+ */
+export async function seek(
+  rid: number,
+  offset: number,
+  whence: number
+): Promise<void> {
+  const builder = flatbuffers.createBuilder();
+  msg.Seek.startSeek(builder);
+  msg.Seek.addRid(builder, rid);
+  msg.Seek.addOffset(builder, offset);
+  msg.Seek.addWhence(builder, whence);
+  const inner = msg.Seek.endSeek(builder);
+  await dispatch.sendAsync(builder, msg.Any.Seek, inner);
 }
 
 /** Close the file ID. */

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -153,3 +153,53 @@ testPerm({ read: true, write: true }, async function openModeWriteRead() {
 
   await Deno.remove(tempDir, { recursive: true });
 });
+
+testPerm({ read: true }, async function seekStart() {
+  const filename = "tests/hello.txt";
+  const file = await Deno.open(filename);
+  // Deliberately move 1 step forward
+  await file.read(new Uint8Array(1)); // "H"
+  // Skipping "Hello "
+  await file.seek(6, Deno.SeekMode.SEEK_START);
+  const buf = new Uint8Array(6);
+  await file.read(buf);
+  const decoded = new TextDecoder().decode(buf);
+  assertEqual(decoded, "world!");
+});
+
+testPerm({ read: true }, async function seekCurrent() {
+  const filename = "tests/hello.txt";
+  const file = await Deno.open(filename);
+  // Deliberately move 1 step forward
+  await file.read(new Uint8Array(1)); // "H"
+  // Skipping "ello "
+  await file.seek(5, Deno.SeekMode.SEEK_CURRENT);
+  const buf = new Uint8Array(6);
+  await file.read(buf);
+  const decoded = new TextDecoder().decode(buf);
+  assertEqual(decoded, "world!");
+});
+
+testPerm({ read: true }, async function seekEnd() {
+  const filename = "tests/hello.txt";
+  const file = await Deno.open(filename);
+  await file.seek(-6, Deno.SeekMode.SEEK_END);
+  const buf = new Uint8Array(6);
+  await file.read(buf);
+  const decoded = new TextDecoder().decode(buf);
+  assertEqual(decoded, "world!");
+});
+
+testPerm({ read: true }, async function seekMode() {
+  const filename = "tests/hello.txt";
+  const file = await Deno.open(filename);
+  let err;
+  try {
+    await file.seek(1, -1);
+  } catch (e) {
+    err = e;
+  }
+  assert(!!err);
+  assertEqual(err.kind, Deno.ErrorKind.InvalidSeekMode);
+  assertEqual(err.name, "InvalidSeekMode");
+});

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -141,15 +141,11 @@ testPerm({ read: true, write: true }, async function openModeWriteRead() {
   fileInfo = Deno.statSync(filename);
   assertEqual(fileInfo.len, 13);
 
-  // TODO: this test is not working, I expect because
-  //  file handle points to the end of file, but ATM
-  //  deno has no seek implementation on Rust side
-  // assert file can be read
-  // const buf = new Uint8Array(20);
-  // const result = await file.read(buf);
-  // console.log(result.eof, result.nread);
-  // assertEqual(result.nread, 13);
-  // file.close();
+  const buf = new Uint8Array(20);
+  await file.seek(0, Deno.SeekMode.SEEK_START);
+  const result = await file.read(buf);
+  assertEqual(result.nread, 13);
+  file.close();
 
   await Deno.remove(tempDir, { recursive: true });
 });

--- a/js/io.ts
+++ b/js/io.ts
@@ -9,6 +9,14 @@ export interface ReadResult {
   eof: boolean;
 }
 
+// Seek whence values.
+// https://golang.org/pkg/io/#pkg-constants
+export enum SeekMode {
+  SEEK_START = 0,
+  SEEK_CURRENT = 1,
+  SEEK_END = 2
+}
+
 // Reader is the interface that wraps the basic read() method.
 // https://golang.org/pkg/io/#Reader
 export interface Reader {

--- a/js/io.ts
+++ b/js/io.ts
@@ -82,7 +82,7 @@ export interface Seeker {
    * any positive offset is legal, but the behavior of subsequent I/O operations
    * on the underlying object is implementation-dependent.
    */
-  seek(offset: number, whence: number): Promise<void>;
+  seek(offset: number, whence: SeekMode): Promise<void>;
 }
 
 // https://golang.org/pkg/io/#ReadCloser

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -66,6 +66,7 @@ union Any {
   NowRes,
   IsTTY,
   IsTTYRes,
+  Seek,
 }
 
 enum ErrorKind: byte {
@@ -504,6 +505,11 @@ table IsTTYRes {
   stdin: bool;
   stdout: bool;
   stderr: bool;
+}
+
+table Seek {
+  rid: uint32;
+  offset: uint64;
 }
 
 root_type Base;

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -119,6 +119,7 @@ enum ErrorKind: byte {
 
   // custom errors
   InvalidUri,
+  InvalidSeekMode,
 }
 
 table Cwd {}
@@ -509,7 +510,8 @@ table IsTTYRes {
 
 table Seek {
   rid: uint32;
-  offset: uint64;
+  offset: int;
+  whence: uint;
 }
 
 root_type Base;

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -86,9 +86,7 @@ enum Repr {
   Stdin(tokio::io::Stdin),
   Stdout(tokio::fs::File),
   Stderr(tokio::io::Stderr),
-  // TODO(kevinkassimo): remove Option after tokio seek PR lands:
-  // https://github.com/tokio-rs/tokio/pull/785
-  FsFile(Option<tokio::fs::File>),
+  FsFile(tokio::fs::File),
   // Since TcpListener might be closed while there is a pending accept task,
   // we need to track the task so that when the listener is closed,
   // this pending task could be notified and die.
@@ -251,13 +249,7 @@ impl AsyncRead for Resource {
     match maybe_repr {
       None => panic!("bad rid"),
       Some(repr) => match repr {
-        Repr::FsFile(ref mut maybe_f) => {
-          if let Some(f) = maybe_f {
-            return f.poll_read(buf);
-          } else {
-            panic!("Cannot read");
-          }
-        }
+        Repr::FsFile(ref mut f) => f.poll_read(buf),
         Repr::Stdin(ref mut f) => f.poll_read(buf),
         Repr::TcpStream(ref mut f) => f.poll_read(buf),
         Repr::HttpBody(ref mut f) => f.poll_read(buf),
@@ -286,13 +278,7 @@ impl AsyncWrite for Resource {
     match maybe_repr {
       None => panic!("bad rid"),
       Some(repr) => match repr {
-        Repr::FsFile(ref mut maybe_f) => {
-          if let Some(f) = maybe_f {
-            return f.poll_write(buf);
-          } else {
-            panic!("Cannot write");
-          }
-        }
+        Repr::FsFile(ref mut f) => f.poll_write(buf),
         Repr::Stdout(ref mut f) => f.poll_write(buf),
         Repr::Stderr(ref mut f) => f.poll_write(buf),
         Repr::TcpStream(ref mut f) => f.poll_write(buf),
@@ -315,7 +301,7 @@ fn new_rid() -> ResourceId {
 pub fn add_fs_file(fs_file: tokio::fs::File) -> Resource {
   let rid = new_rid();
   let mut tg = RESOURCE_TABLE.lock().unwrap();
-  match tg.insert(rid, Repr::FsFile(Some(fs_file))) {
+  match tg.insert(rid, Repr::FsFile(fs_file)) {
     Some(_) => panic!("There is already a file with that rid"),
     None => Resource { rid },
   }
@@ -580,37 +566,61 @@ pub fn eager_accept(resource: Resource) -> EagerAccept {
   }
 }
 
-pub fn seek(resource: Resource, offset: i32, whence: u32) -> DenoResult<u64> {
+// TODO(kevinkassimo): revamp this after the following lands:
+// https://github.com/tokio-rs/tokio/pull/785
+pub fn seek(
+  resource: Resource,
+  offset: i32,
+  whence: u32,
+) -> Box<dyn Future<Item = (), Error = DenoError> + Send> {
   let mut table = RESOURCE_TABLE.lock().unwrap();
-  let maybe_repr = table.get_mut(&resource.rid);
+  // We take ownership of File here.
+  // It is put back below while still holding the lock.
+  let maybe_repr = table.remove(&resource.rid);
   match maybe_repr {
     None => panic!("bad rid"),
-    Some(repr) => match repr {
-      Repr::FsFile(ref mut maybe_f) => {
-        let seek_from = match whence {
-          0 => SeekFrom::Start(offset as u64),
-          1 => SeekFrom::Current(offset as i64),
-          2 => SeekFrom::End(offset as i64),
-          _ => {
-            return Err(errors::new(
-              errors::ErrorKind::InvalidSeekMode,
-              format!("Invalid seek mode: {}", whence),
-            ));
-          }
-        };
-        // TODO(kevinkassimo): revamp this after the following lands:
-        // https://github.com/tokio-rs/tokio/pull/785
-        if maybe_f.is_some() {
-          let f = maybe_f.take().unwrap();
-          let mut std_file = f.into_std();
-          let result = std_file.seek(seek_from).map_err(DenoError::from);
-          maybe_f.replace(tokio_fs::File::from_std(std_file));
-          return result;
-        } else {
-          panic!("cannot seek");
+    Some(Repr::FsFile(f)) => {
+      let seek_from = match whence {
+        0 => SeekFrom::Start(offset as u64),
+        1 => SeekFrom::Current(offset as i64),
+        2 => SeekFrom::End(offset as i64),
+        _ => {
+          return Box::new(futures::future::err(errors::new(
+            errors::ErrorKind::InvalidSeekMode,
+            format!("Invalid seek mode: {}", whence),
+          )));
         }
+      };
+      // Trait Clone not implemented on tokio::fs::File,
+      // so convert to std File first.
+      let std_file = f.into_std();
+      // Create a copy and immediately put back.
+      // We don't want to block other resource ops.
+      // try_clone() would yield a copy containing the same
+      // underlying fd, so operations on the copy would also
+      // affect the one in resource table, and we don't need
+      // to write back.
+      let maybe_std_file_copy = std_file.try_clone();
+      // Insert the entry back with the same rid.
+      table.insert(
+        resource.rid,
+        Repr::FsFile(tokio_fs::File::from_std(std_file)),
+      );
+      if maybe_std_file_copy.is_err() {
+        return Box::new(futures::future::err(DenoError::from(
+          maybe_std_file_copy.unwrap_err(),
+        )));
       }
-      _ => panic!("cannot seek"),
-    },
+      let mut std_file_copy = maybe_std_file_copy.unwrap();
+      return Box::new(futures::future::lazy(move || {
+        let result = std_file_copy
+          .seek(seek_from)
+          .map(|_| {
+            return ();
+          }).map_err(DenoError::from);
+        futures::future::result(result)
+      }));
+    }
+    _ => panic!("cannot seek"),
   }
 }


### PR DESCRIPTION
Based on #1794 .
Closes #1304 .

#1794 fails due to that `seek` takes the ownership of the original tokio File.

This patch contains a special hack that circumvents the current tokio seek problem.

tokio `seek` is implemented to take ownership of the original File and emit a new one in its future, which conflicts with the design of ResourceTable.

~~To avoid the problem, the current hack makes the `FsFile` resource an `Option` which we could `take` the value ownership out of it. We then convert the tokio File into a Rust std File, perform the seek, and then put it back into the resource.~~
The hack is simplified. See comments in the code.

We might be able to drop this hack after tokio-rs/tokio#785 lands.
