### PR TITLE
manual - update run example

### DIFF
--- a/js/process.ts
+++ b/js/process.ts
@@ -8,7 +8,7 @@ import { ReadCloser, WriteCloser } from "./io";
 import { readAll } from "./buffer";
 import { assert, unreachable } from "./util";
 
-/** How to handle subsubprocess stdio.
+/** How to handle subprocess stdio.
  *
  * "inherit" The default if unspecified. The child inherits from the
  * corresponding parent descriptor.
@@ -101,6 +101,18 @@ function stdioMap(s: ProcessStdio): msg.ProcessStdio {
   }
 }
 
+/**
+ * Spawns new subprocess.
+ *
+ * Subprocess uses same working directory as parent process unless `opt.cwd`
+ * is specified.
+ *
+ * Environmental variables for subprocess can be specified using `opt.env`
+ * mapping.
+ *
+ * By default subprocess inherits stdio of parent process. To change that
+ * `opt.stdout`, `opt.stderr` and `opt.stdin` can be specified independently.
+ */
 export function run(opt: RunOptions): Process {
   const builder = flatbuffers.createBuilder();
   const argsOffset = msg.Run.createArgsVector(

--- a/website/manual.md
+++ b/website/manual.md
@@ -312,44 +312,44 @@ file_server --reload
 
 ### Run subprocess
 
-```
+[API Reference](https://deno.land/typedoc/index.html#run)
+
+Example:
+
+```ts
 const p = Deno.run({
-    args: ["deno", "--allow-read", "https://deno.land/x/examples/cat.ts", "README.md"],
+  args: ["deno", "https://deno.land/welcome.ts"]
 });
 
 // start subprocess
 await p.status();
 ```
 
-When this program is started, the user is prompted for permission to run
-subprocess:
+Run it:
 
 ```
-> deno https://deno.land/x/examples/subprocess_simple.ts
-⚠️  Deno requests access to run a subprocess. Grant? [yN] y
-```
-
-For security reasons, deno does not allow programs to run subprocess without
-explicit permission. To avoid the console prompt, use a command-line flag:
-
-```
-> deno https://deno.land/x/examples/subprocess_simple.ts --allow-run
+> deno --allow-run https://deno.land/x/examples/subprocess_simple.ts
+Welcome to Deno 🦕
 ```
 
 By default when you use `deno.run()` subprocess inherits `stdin`, `stdout` and
 `stdout` of parent process. If you want to communicate with started subprocess
 you can use `"piped"` option.
 
-```
+```ts
 const decoder = new TextDecoder();
 
-const filesToCat = Deno.args.slice(1);
-const subprocessArgs = ["deno", "--allow-read", "https://deno.land/x/examples/cat.ts", ...filesToCat];
+const fileNames = Deno.args.slice(1);
 
 const p = Deno.run({
-  subprocessArgs,
+  args: [
+    "deno",
+    "--allow-read",
+    "https://deno.land/x/examples/cat.ts",
+    ...fileNames
+  ],
   stdout: "piped",
-  stderr: "piped",
+  stderr: "piped"
 });
 
 const { code } = await p.status();

--- a/website/manual.md
+++ b/website/manual.md
@@ -318,7 +318,7 @@ Example:
 
 ```ts
 const p = Deno.run({
-  args: [ "echo", "hello" ]
+  args: ["echo", "hello"]
 });
 
 // start subprocess
@@ -354,15 +354,9 @@ const p = Deno.run({
 
 const { code } = await p.status();
 
-if (code === 0) {
-  const rawOutput = await p.output();
-  const output = decoder.decode(rawOutput);
-  console.log(output);
-} else {
-  const rawErr = await Deno.readAll(p.stderr);
-  const err = decoder.decode(rawErr);
-  console.log(err);
-}
+const rawOutput = await p.output();
+const output = decoder.decode(rawOutput);
+console.log(output);
 
 Deno.exit(code);
 ```

--- a/website/manual.md
+++ b/website/manual.md
@@ -318,7 +318,7 @@ Example:
 
 ```ts
 const p = Deno.run({
-  args: ["deno", "https://deno.land/welcome.ts"]
+  args: [ "echo", "hello" ]
 });
 
 // start subprocess
@@ -329,7 +329,7 @@ Run it:
 
 ```
 > deno --allow-run https://deno.land/x/examples/subprocess_simple.ts
-Welcome to Deno 🦕
+hello
 ```
 
 By default when you use `deno.run()` subprocess inherits `stdin`, `stdout` and
@@ -355,7 +355,7 @@ const p = Deno.run({
 const { code } = await p.status();
 
 if (code === 0) {
-  const rawOutput = await Deno.readAll(p.stdout);
+  const rawOutput = await p.output();
   const output = decoder.decode(rawOutput);
   console.log(output);
 } else {

--- a/website/manual.md
+++ b/website/manual.md
@@ -317,18 +317,23 @@ file_server --reload
 Example:
 
 ```ts
-const p = Deno.run({
-  args: ["echo", "hello"]
-});
+async function main() {
+  // create subprocess
+  const p = Deno.run({
+    args: ["echo", "hello"]
+  });
 
-// start subprocess
-await p.status();
+  // await its completion
+  await p.status();
+}
+
+main();
 ```
 
 Run it:
 
 ```
-> deno --allow-run https://deno.land/x/examples/subprocess_simple.ts
+> deno --allow-run ./subprocess_simple.ts
 hello
 ```
 
@@ -337,37 +342,40 @@ By default when you use `deno.run()` subprocess inherits `stdin`, `stdout` and
 you can use `"piped"` option.
 
 ```ts
-const decoder = new TextDecoder();
+async function main() {
+  const decoder = new TextDecoder();
 
-const fileNames = Deno.args.slice(1);
+  const fileNames = Deno.args.slice(1);
 
-const p = Deno.run({
-  args: [
-    "deno",
-    "--allow-read",
-    "https://deno.land/x/examples/cat.ts",
-    ...fileNames
-  ],
-  stdout: "piped",
-  stderr: "piped"
-});
+  const p = Deno.run({
+    args: [
+      "deno",
+      "--allow-read",
+      "https://deno.land/x/examples/cat.ts",
+      ...fileNames
+    ],
+    stdout: "piped",
+    stderr: "piped"
+  });
 
-const { code } = await p.status();
+  const { code } = await p.status();
 
-const rawOutput = await p.output();
-const output = decoder.decode(rawOutput);
-console.log(output);
+  const rawOutput = await p.output();
+  Deno.stdout.write(rawOutput);
 
-Deno.exit(code);
+  Deno.exit(code);
+}
+
+main();
 ```
 
 When you run it:
 
 ```
-> deno https://deno.land/x/examples/subprocess.ts --allow-run <somefile>
+> deno ./subprocess.ts --allow-run <somefile>
 [file content]
 
-> deno https://deno.land/x/examples/subprocess.ts --allow-run non_existent_file.md
+> deno ./subprocess.ts --allow-run non_existent_file.md
 
 Uncaught NotFound: No such file or directory (os error 2)
     at DenoError (deno/js/errors.ts:19:5)


### PR DESCRIPTION
Adds coloring to TypeScript examples introduced in #1791 and removes permission prompt explained earlier.

I'm creating it as draft PR pending merge of denoland/deno_std#196

CC @ry 