### PR TITLE
Add argument type checks

### DIFF
--- a/js/read_file.ts
+++ b/js/read_file.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import * as msg from "gen/msg_generated";
 import * as flatbuffers from "./flatbuffers";
-import { assert } from "./util";
+import { assert, validateArgumentType } from "./util";
 import * as dispatch from "./dispatch";
 
 /** Read the entire contents of a file synchronously.
@@ -11,6 +11,7 @@ import * as dispatch from "./dispatch";
  *       console.log(decoder.decode(data));
  */
 export function readFileSync(filename: string): Uint8Array {
+  validateArgumentType(filename, "string", "filename", "readFileSync");
   return res(dispatch.sendSync(...req(filename)));
 }
 
@@ -21,6 +22,7 @@ export function readFileSync(filename: string): Uint8Array {
  *       console.log(decoder.decode(data));
  */
 export async function readFile(filename: string): Promise<Uint8Array> {
+  validateArgumentType(filename, "string", "filename", "readFile");
   return res(await dispatch.sendAsync(...req(filename)));
 }
 

--- a/js/read_file_test.ts
+++ b/js/read_file_test.ts
@@ -35,6 +35,18 @@ testPerm({ read: true }, function readFileSyncNotFound() {
   assert(data === undefined);
 });
 
+testPerm({ read: true }, function readFileSyncBadArgument() {
+  let err;
+  try {
+    // @ts-ignore
+    Deno.readFileSync(123);
+  } catch (e) {
+    err = e;
+  }
+  assert(!!err);
+  assert(err instanceof TypeError);
+});
+
 testPerm({ read: true }, async function readFileSuccess() {
   const data = await Deno.readFile("package.json");
   assert(data.byteLength > 0);
@@ -54,4 +66,16 @@ testPerm({ read: false }, async function readFilePerm() {
     assertEqual(e.name, "PermissionDenied");
   }
   assert(caughtError);
+});
+
+testPerm({ read: true }, async function readFileBadArgument() {
+  let err;
+  try {
+    // @ts-ignore
+    await Deno.readFile(123);
+  } catch (e) {
+    err = e;
+  }
+  assert(!!err);
+  assert(err instanceof TypeError);
 });

--- a/js/util.ts
+++ b/js/util.ts
@@ -133,6 +133,55 @@ export function requiredArguments(
   }
 }
 
+function isArgumentOfType(
+  value: any, // tslint:disable-line:no-any
+  type: string | Function
+): boolean {
+  if (typeof type === "string") {
+    return typeof value === type;
+  } else {
+    return value instanceof type;
+  }
+}
+
+function stringifyType(
+  type: string | Function | Array<string | Function>
+): string {
+  if (Array.isArray(type)) {
+    return type.map(stringifyType).join(" | ");
+  } else if (typeof type === "string") {
+    return type;
+  } else {
+    return type.name;
+  }
+}
+
+// @internal
+export function validateArgumentType(
+  value: any, // tslint:disable-line:no-any
+  type: string | Function | Array<string | Function>,
+  name: string,
+  source?: string // name of the function
+): void {
+  let isValidArgument = false;
+  if (Array.isArray(type)) {
+    for (const sig of type) {
+      if (isArgumentOfType(value, sig)) {
+        isValidArgument = true;
+        break;
+      }
+    }
+  } else {
+    isValidArgument = isArgumentOfType(value, type);
+  }
+  if (!isValidArgument) {
+    const errString = `Argument "${name}" should have type ${stringifyType(
+      type
+    )}${source ? ` in "${source}"` : ""}`;
+    throw new TypeError(errString);
+  }
+}
+
 // Returns values from a WeakMap to emulate private properties in JavaScript
 export function getPrivateValue<
   K extends object,


### PR DESCRIPTION
Add argument type checks (for JS).
e.g.
```
> Deno.readFileSync()
Uncaught TypeError: Argument "filename" should have type string in "readFileSync"
    at validateArgumentType (deno/js/util.ts:181:11)
    at readFileSync (deno/js/read_file.ts:14:3)
    at <unknown>:1:6
    at evaluate (deno/js/repl.ts:137:37)
    at replLoop (deno/js/repl.ts:110:13)
```

Would work on adding to other exported functions if this approach is okay.