### PR TITLE
Updated some type assertions to work with other libc implementations.

### DIFF
--- a/src/flags.rs
+++ b/src/flags.rs
@@ -3,7 +3,7 @@ use crate::libdeno;
 
 use getopts;
 use getopts::Options;
-use libc::c_int;
+use libc::{c_int, c_char};
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::mem;
@@ -343,7 +343,7 @@ pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
     .collect::<Vec<_>>();
   let mut c_argv = raw_argv
     .iter_mut()
-    .map(|arg| arg.as_mut_ptr() as *mut i8)
+    .map(|arg| arg.as_mut_ptr() as *mut c_char)
     .collect::<Vec<_>>();
 
   // Store the length of the c_argv array in a local variable. We'll pass
@@ -360,7 +360,7 @@ pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
   c_argv
     .iter()
     .map(|ptr| unsafe {
-      let cstr = CStr::from_ptr(*ptr as *const i8);
+      let cstr = CStr::from_ptr(*ptr as *const c_char);
       let slice = cstr.to_str().unwrap();
       slice.to_string()
     }).chain(rest.into_iter())

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -3,7 +3,8 @@ use crate::libdeno;
 
 use getopts;
 use getopts::Options;
-use libc::{c_int, c_char};
+use libc::c_char;
+use libc::c_int;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::mem;

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -287,10 +287,10 @@ impl Isolate {
     source: String,
   ) -> Result<libdeno::deno_mod, JSError> {
     let name_ = CString::new(name.clone()).unwrap();
-    let name_ptr = name_.as_ptr() as *const i8;
+    let name_ptr = name_.as_ptr() as *const c_char;
 
     let source_ = CString::new(source.clone()).unwrap();
-    let source_ptr = source_.as_ptr() as *const i8;
+    let source_ptr = source_.as_ptr() as *const c_char;
 
     let id = unsafe {
       libdeno::deno_mod_new(self.libdeno_isolate, name_ptr, source_ptr)


### PR DESCRIPTION
Some implementations of libc use unsigned int for plain `char` values. This behavior is already correctly represented by the rust libc crate, so the rust compiler will catch this type mismatch and fail with other platforms cross compile and native toolchains.

I found this problem when compiling with the `aarch64-unknown-linux-gnu` target. I have confirmed this to also be a problem with the native compilers/toolchains on a raspberry pi running arm64 debian.

My understanding of rust's `as` statement is that it only serves as a type assertion, so it shouldn't have any affect on the function of deno as a whole. I may be wrong about this since i'm relatively new to rust though.