### PR TITLE
Fix broken link to API reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ more specifics.
 
 [Install](https://github.com/denoland/deno_install)
 
-[API Reference](https://deno.land/typedoc)
+[API Reference](https://deno.land/typedoc/)
 
 [Style Guide](https://deno.land/style_guide.html)
 


### PR DESCRIPTION
Add missing trailing slash
https://deno.land/typedoc returns 404
https://deno.land/typedoc/ works nicely

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
