### PR TITLE
Fix race condition in build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -234,6 +234,10 @@ bundle("compiler_bundle") {
   deps = [
     ":deno_runtime_declaration",
     ":msg_ts",
+    ":write_gn_args",
+  ]
+  data = [
+    "$target_gen_dir/gn_args.txt",
   ]
 }
 


### PR DESCRIPTION
This fixes the race condition in build introduced in #1845 

compiler_bundle doesn't use `gen/gn_args.txt` but depends on it because `rollup.config.js` reads it. This patch adds `:write_gn_args` to compiler_bundle's dependencies.

example build failure: https://ci.appveyor.com/project/deno/deno/builds/22764022