### PR TITLE
core: refactor to use Shared trait

### DIFF
--- a/core/http_bench.rs
+++ b/core/http_bench.rs
@@ -57,10 +57,10 @@ fn main() {
 
   let args: Vec<String> = env::args().collect();
   if args.len() > 1 && args[1] == "--multi-thread" {
-    debug!("multi-thread");
+    println!("multi-thread");
     tokio::run(main_future);
   } else {
-    debug!("single-thread");
+    println!("single-thread");
     tokio::runtime::current_thread::run(main_future);
   }
 }

--- a/core/http_bench.rs
+++ b/core/http_bench.rs
@@ -40,7 +40,7 @@ fn main() {
   let js_source = include_str!("http_bench.js");
 
   let main_future = lazy(move || {
-    let isolate = deno_core::Isolate::new(SharedSimple::new(), recv_cb);
+    let isolate = deno_core::Isolate::new(SharedSimple::new(), recv_cb, None);
 
     let (setup_filename, setup_source) = SharedSimple::js();
     js_check(isolate.execute(setup_filename, setup_source));

--- a/core/shared.rs
+++ b/core/shared.rs
@@ -1,49 +1,25 @@
-use crate::libdeno::deno_buf;
-use std::mem;
+use crate::deno_buf;
+use crate::shared_simple::SharedSimpleRecord;
 
-// TODO this is where we abstract flatbuffers at.
-// TODO make these constants private to this file.
-const INDEX_NUM_RECORDS: usize = 0;
-const INDEX_RECORDS: usize = 1;
-pub const RECORD_OFFSET_PROMISE_ID: usize = 0;
-pub const RECORD_OFFSET_OP: usize = 1;
-pub const RECORD_OFFSET_ARG: usize = 2;
-pub const RECORD_OFFSET_RESULT: usize = 3;
-const RECORD_SIZE: usize = 4;
-const NUM_RECORDS: usize = 100;
+/// Represents a shared buffer that can be accessed by JS.
+pub trait Shared<Record = SharedSimpleRecord> {
+  fn as_deno_buf(&self) -> deno_buf;
 
-/// Represents the shared buffer between JS and Rust.
-/// Used for FFI.
-pub struct Shared(Vec<i32>);
+  /// Returns static JS code which implements Deno.shared
+  /// This will be executed and available to Isolates before
+  /// other code is run.
+  fn js() -> (&'static str, &'static str);
 
-impl Shared {
-  pub fn new() -> Shared {
-    let mut vec = Vec::<i32>::new();
-    vec.resize(INDEX_RECORDS + RECORD_SIZE * NUM_RECORDS, 0);
-    Shared(vec)
-  }
+  /// Pushes a record onto the stack. Returns false if no room.
+  fn push(&mut self, record: &Record) -> bool;
 
-  pub fn set_record(&mut self, i: usize, off: usize, value: i32) {
-    assert!(i < NUM_RECORDS);
-    self.0[INDEX_RECORDS + RECORD_SIZE * i + off] = value;
-  }
+  /// Returns the last element of the stack if any.
+  fn pop(&mut self) -> Option<Record>;
 
-  pub fn get_record(&self, i: usize, off: usize) -> i32 {
-    assert!(i < NUM_RECORDS);
-    return self.0[INDEX_RECORDS + RECORD_SIZE * i + off];
-  }
+  /// Removes all records.
+  /// Also resets the next().
+  fn reset(&mut self);
 
-  pub fn set_num_records(&mut self, num_records: i32) {
-    self.0[INDEX_NUM_RECORDS] = num_records;
-  }
-
-  pub fn get_num_records(&self) -> i32 {
-    return self.0[INDEX_NUM_RECORDS];
-  }
-
-  pub fn as_deno_buf(&mut self) -> deno_buf {
-    let ptr = self.0.as_mut_ptr() as *mut u8;
-    let len = mem::size_of::<i32>() * self.0.len();
-    unsafe { deno_buf::from_raw_parts(ptr, len) }
-  }
+  /// Returns number of elements.
+  fn len(&self) -> usize;
 }

--- a/core/shared_simple.js
+++ b/core/shared_simple.js
@@ -1,0 +1,50 @@
+(function() {
+  const INDEX_LEN = 0;
+  const NUM_RECORDS = 128;
+  const RECORD_SIZE = 4;
+  const shared32 = new Int32Array(libdeno.shared);
+  const global = this;
+
+  if (!global["Deno"]) {
+    global["Deno"] = {};
+  }
+
+  function idx(i, off) {
+    return 1 + i * RECORD_SIZE + off;
+  }
+
+  Deno.sharedSimple = {
+    push: (promiseId, opId, arg, result) => {
+      if (shared32[INDEX_LEN] >= NUM_RECORDS) {
+        return false;
+      }
+      const i = shared32[INDEX_LEN]++;
+      shared32[idx(i, 0)] = promiseId;
+      shared32[idx(i, 1)] = opId;
+      shared32[idx(i, 2)] = arg;
+      shared32[idx(i, 3)] = result;
+      return true;
+    },
+
+    pop: () => {
+      if (shared32[INDEX_LEN] == 0) {
+        return null;
+      }
+      const i = --shared32[INDEX_LEN];
+      return {
+        promiseId: shared32[idx(i, 0)],
+        opId: shared32[idx(i, 1)],
+        arg: shared32[idx(i, 2)],
+        result: shared32[idx(i, 3)]
+      };
+    },
+
+    reset: () => {
+      shared32[INDEX_LEN] = 0;
+    },
+
+    size: () => {
+      return shared32[INDEX_LEN];
+    }
+  };
+})();

--- a/core/shared_simple.rs
+++ b/core/shared_simple.rs
@@ -1,0 +1,161 @@
+use crate::deno_buf;
+use crate::shared::Shared;
+use std::mem;
+
+// Used for Default
+const INDEX_LEN: usize = 0;
+const NUM_RECORDS: usize = 128;
+const RECORD_SIZE: usize = 4; // num i32 in SharedSimpleRecord
+
+#[derive(Default, Clone, PartialEq, Debug)]
+pub struct SharedSimpleRecord {
+  pub promise_id: i32,
+  pub op_id: i32,
+  pub arg: i32,
+  pub result: i32,
+}
+
+/// Represents the shared buffer between JS and Rust.
+/// Used for FFI.
+pub struct SharedSimple(Vec<i32>);
+
+impl SharedSimple {
+  pub fn new() -> SharedSimple {
+    let mut vec = Vec::<i32>::new();
+    let n = 1 + 4 * NUM_RECORDS;
+    vec.resize(n, 0);
+    vec[INDEX_LEN] = 0;
+    SharedSimple(vec)
+  }
+}
+
+fn idx(i: usize, off: usize) -> usize {
+  1 + i * RECORD_SIZE + off
+}
+
+impl Shared<SharedSimpleRecord> for SharedSimple {
+  fn as_deno_buf(&self) -> deno_buf {
+    let ptr = self.0.as_ptr() as *const u8;
+    let len = mem::size_of::<i32>() * self.0.len();
+    unsafe { deno_buf::from_raw_parts(ptr, len) }
+  }
+
+  fn js() -> (&'static str, &'static str) {
+    ("core/shared_simple.js", include_str!("shared_simple.js"))
+  }
+
+  fn push(&mut self, record: &SharedSimpleRecord) -> bool {
+    debug!("push {:?}", record);
+    let i = self.len();
+    if i >= NUM_RECORDS {
+      return false;
+    }
+    self.0[idx(i, 0)] = record.promise_id;
+    self.0[idx(i, 1)] = record.op_id;
+    self.0[idx(i, 2)] = record.arg;
+    self.0[idx(i, 3)] = record.result;
+    self.0[INDEX_LEN] += 1;
+    true
+  }
+
+  /// Gets an element.
+  fn pop(&mut self) -> Option<SharedSimpleRecord> {
+    if self.len() == 0 {
+      return None;
+    }
+    self.0[INDEX_LEN] -= 1;
+    let i = self.len();
+
+    Some(SharedSimpleRecord {
+      promise_id: self.0[idx(i, 0)],
+      op_id: self.0[idx(i, 1)],
+      arg: self.0[idx(i, 2)],
+      result: self.0[idx(i, 3)],
+    })
+  }
+
+  fn reset(&mut self) {
+    self.0[INDEX_LEN] = 0;
+  }
+
+  /// Returns number of elements.
+  fn len(&self) -> usize {
+    self.0[INDEX_LEN] as usize
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::Isolate;
+  use crate::JSError;
+
+  fn inc_counter(isolate: &mut Isolate, zero_copy_buf: deno_buf) {
+    assert_eq!(zero_copy_buf.len(), 0);
+    isolate.test_send_counter += 1; // TODO ideally store this in isolate.state?
+  }
+
+  fn js_check(r: Result<(), JSError>) {
+    if let Err(e) = r {
+      panic!(e.to_string());
+    }
+  }
+
+  #[test]
+  fn test_execute() {
+    let shared = SharedSimple::new();
+    let mut isolate = Isolate::new(shared, inc_counter);
+    let (setup_filename, setup_source) = SharedSimple::js();
+    js_check(isolate.execute(setup_filename, setup_source));
+    js_check(isolate.execute("x.js", "Deno.sharedSimple.push(1, 2, 3, 4)"));
+    assert_eq!(isolate.shared.len(), 1);
+    js_check(isolate.execute("x.js", "Deno.sharedSimple.push(-1, -2, -3, -4)"));
+    assert_eq!(isolate.shared.len(), 2);
+    assert_eq!(
+      isolate.shared.pop().unwrap(),
+      SharedSimpleRecord {
+        promise_id: -1,
+        op_id: -2,
+        arg: -3,
+        result: -4
+      }
+    );
+    assert_eq!(isolate.shared.len(), 1);
+    assert_eq!(
+      isolate.shared.pop().unwrap(),
+      SharedSimpleRecord {
+        promise_id: 1,
+        op_id: 2,
+        arg: 3,
+        result: 4
+      }
+    );
+    assert_eq!(isolate.shared.len(), 0);
+
+    js_check(isolate.execute("x.js", "Deno.sharedSimple.push(1, 2, 3, 4)"));
+    assert_eq!(isolate.shared.len(), 1);
+    js_check(isolate.execute("x.js", "Deno.sharedSimple.push(-1, -2, -3, -4)"));
+
+    js_check(isolate.execute(
+      "x.js",
+      r#"
+        let r = Deno.sharedSimple.pop();
+        if (r.promiseId != -1) throw "err";
+        if (r.opId != -2) throw "err";
+        if (r.arg != -3) throw "err";
+        if (r.result != -4) throw "err";
+      "#,
+    ));
+
+    js_check(isolate.execute(
+      "x.js",
+      r#"
+        if (Deno.sharedSimple.size() != 1) throw "err";
+      "#,
+    ));
+
+    js_check(isolate.execute("x.js", "Deno.sharedSimple.reset()"));
+    assert_eq!(isolate.shared.len(), 0);
+    assert_eq!(isolate.test_send_counter, 0);
+  }
+}

--- a/core/shared_simple.rs
+++ b/core/shared_simple.rs
@@ -104,7 +104,7 @@ mod tests {
   #[test]
   fn test_execute() {
     let shared = SharedSimple::new();
-    let mut isolate = Isolate::new(shared, inc_counter);
+    let mut isolate = Isolate::new(shared, inc_counter, None);
     let (setup_filename, setup_source) = SharedSimple::js();
     js_check(isolate.execute(setup_filename, setup_source));
     js_check(isolate.execute("x.js", "Deno.sharedSimple.push(1, 2, 3, 4)"));


### PR DESCRIPTION
Introduces the Shared trait which abstracts access to the shared buffer. SharedSimple as a very basic implementation of this which is used in deno_core_http_bench

