### PR TITLE
Allow inspection and revocation of permissions

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -91,6 +91,7 @@ ts_sources = [
   "js/mock_builtin.js",
   "js/net.ts",
   "js/os.ts",
+  "js/permissions.ts",
   "js/platform.ts",
   "js/plugins.d.ts",
   "js/process.ts",

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -50,6 +50,12 @@ export { symlinkSync, symlink } from "./symlink";
 export { writeFileSync, writeFile, WriteFileOptions } from "./write_file";
 export { ErrorKind, DenoError } from "./errors";
 export { libdeno } from "./libdeno";
+export {
+  permissions,
+  revokePermission,
+  Permission,
+  Permissions
+} from "./permissions";
 export { platform } from "./platform";
 export { truncateSync, truncate } from "./truncate";
 export { FileInfo } from "./file_info";

--- a/js/permissions.ts
+++ b/js/permissions.ts
@@ -4,7 +4,7 @@ import * as flatbuffers from "./flatbuffers";
 import * as dispatch from "./dispatch";
 import { assert } from "./util";
 
-// Permissions as granted by the caller
+/** Permissions as granted by the caller */
 export type Permissions = {
   read: boolean;
   write: boolean;
@@ -17,7 +17,13 @@ export type Permissions = {
 
 export type Permission = keyof Permissions;
 
-// Inspect granted permissions for the current program.
+/** Inspect granted permissions for the current program.
+ *
+ *       if (Deno.permissions().read) {
+ *         const file = await Deno.readFile("example.test");
+ *         // ...
+ *       }
+ */
 export function permissions(): Permissions {
   const baseRes = dispatch.sendSync(...getReq())!;
   assert(msg.Any.PermissionsRes === baseRes.innerType());
@@ -27,7 +33,14 @@ export function permissions(): Permissions {
   return createPermissions(res);
 }
 
-// Revoke a permission. When the permission was already revoked nothing changes
+/** Revoke a permission. When the permission was already revoked nothing changes
+ *
+ *       if (Deno.permissions().read) {
+ *         const file = await Deno.readFile("example.test");
+ *         Deno.revokePermission('read');
+ *       }
+ *       Deno.readFile("example.test"); // -> error or permission prompt
+ */
 export function revokePermission(permission: Permission): void {
   dispatch.sendSync(...revokeReq(permission));
 }

--- a/js/permissions.ts
+++ b/js/permissions.ts
@@ -1,0 +1,59 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import * as msg from "gen/msg_generated";
+import * as flatbuffers from "./flatbuffers";
+import * as dispatch from "./dispatch";
+import { assert } from "./util";
+
+
+// Keep in sync with src/permissions.rs
+export type Permissions = {
+  read: boolean;
+  write: boolean;
+  net: boolean;
+  env: boolean;
+  run: boolean;
+}
+
+export type Permission = keyof Permissions;
+
+export function permissions(): Permissions {
+  const baseRes = dispatch.sendSync(...getReq())!;
+  assert(msg.Any.PermissionsRes === baseRes.innerType());
+  const res = new msg.PermissionsRes();
+  assert(baseRes.inner(res) != null);
+  // TypeScript cannot track assertion above, therefore not null assertion
+  return createPermissions(res);
+}
+
+export function revokePermission(permission: Permission): void {
+  dispatch.sendSync(...revokeReq(permission));
+}
+
+function createPermissions(inner: msg.PermissionsRes): Permissions {
+  return {
+    read: inner.read(),
+    write: inner.write(),
+    net: inner.net(),
+    env: inner.env(),
+    run: inner.run(),
+  };
+}
+
+function getReq(
+): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
+  const builder = flatbuffers.createBuilder();
+  msg.Permissions.startPermissions(builder);
+  const inner = msg.Permissions.endPermissions(builder);
+  return [builder, msg.Any.Permissions, inner];
+}
+
+function revokeReq(
+  permission: string,
+): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
+  const builder = flatbuffers.createBuilder();
+  const permission_ = builder.createString(permission);
+  msg.PermissionRevoke.startPermissionRevoke(builder);
+  msg.PermissionRevoke.addPermission(builder, permission_);
+  const inner = msg.PermissionRevoke.endPermissionRevoke(builder);
+  return [builder, msg.Any.PermissionRevoke, inner];
+}

--- a/js/permissions.ts
+++ b/js/permissions.ts
@@ -4,7 +4,6 @@ import * as flatbuffers from "./flatbuffers";
 import * as dispatch from "./dispatch";
 import { assert } from "./util";
 
-
 // Keep in sync with src/permissions.rs
 export type Permissions = {
   read: boolean;
@@ -12,7 +11,7 @@ export type Permissions = {
   net: boolean;
   env: boolean;
   run: boolean;
-}
+};
 
 export type Permission = keyof Permissions;
 
@@ -35,12 +34,11 @@ function createPermissions(inner: msg.PermissionsRes): Permissions {
     write: inner.write(),
     net: inner.net(),
     env: inner.env(),
-    run: inner.run(),
+    run: inner.run()
   };
 }
 
-function getReq(
-): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
+function getReq(): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
   const builder = flatbuffers.createBuilder();
   msg.Permissions.startPermissions(builder);
   const inner = msg.Permissions.endPermissions(builder);
@@ -48,7 +46,7 @@ function getReq(
 }
 
 function revokeReq(
-  permission: string,
+  permission: string
 ): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
   const builder = flatbuffers.createBuilder();
   const permission_ = builder.createString(permission);

--- a/js/permissions.ts
+++ b/js/permissions.ts
@@ -4,17 +4,20 @@ import * as flatbuffers from "./flatbuffers";
 import * as dispatch from "./dispatch";
 import { assert } from "./util";
 
-// Keep in sync with src/permissions.rs
+// Permissions as granted by the caller
 export type Permissions = {
   read: boolean;
   write: boolean;
   net: boolean;
   env: boolean;
   run: boolean;
+
+  // NOTE: Keep in sync with src/permissions.rs
 };
 
 export type Permission = keyof Permissions;
 
+// Inspect granted permissions for the current program.
 export function permissions(): Permissions {
   const baseRes = dispatch.sendSync(...getReq())!;
   assert(msg.Any.PermissionsRes === baseRes.innerType());
@@ -24,6 +27,7 @@ export function permissions(): Permissions {
   return createPermissions(res);
 }
 
+// Revoke a permission. When the permission was already revoked nothing changes
 export function revokePermission(permission: Permission): void {
   dispatch.sendSync(...revokeReq(permission));
 }

--- a/js/permissions_test.ts
+++ b/js/permissions_test.ts
@@ -2,20 +2,20 @@
 import { testPerm, assert, assertEqual } from "./test_util.ts";
 import { Permission } from "deno";
 
-const perms: Permission[] = ["run", "read", "write", "net", "env"];
+const knownPermissions: Permission[] = ["run", "read", "write", "net", "env"];
 
-for (let grant of perms) {
+for (let grant of knownPermissions) {
   testPerm({ [grant]: true }, function envGranted() {
     const perms = Deno.permissions();
     assert(perms !== null);
-    for (let perm of Object.keys(perms)) {
+    for (const perm in perms) {
       assertEqual(perms[perm], perm === grant);
     }
 
     Deno.revokePermission(grant);
 
     const revoked = Deno.permissions();
-    for (let perm of Object.keys(revoked)) {
+    for (const perm in revoked) {
       assertEqual(revoked[perm], false);
     }
   });

--- a/js/permissions_test.ts
+++ b/js/permissions_test.ts
@@ -2,17 +2,10 @@
 import { testPerm, assert, assertEqual } from "./test_util.ts";
 import { Permission } from "deno";
 
-const perms: Permission[] = [
-  "run",
-  "read",
-  "write",
-  "net",
-  "env",
-];
+const perms: Permission[] = ["run", "read", "write", "net", "env"];
 
 for (let grant of perms) {
   testPerm({ [grant]: true }, function envGranted() {
-
     const perms = Deno.permissions();
     assert(perms !== null);
     for (let perm of Object.keys(perms)) {

--- a/js/permissions_test.ts
+++ b/js/permissions_test.ts
@@ -1,0 +1,29 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { testPerm, assert, assertEqual } from "./test_util.ts";
+import { Permission } from "deno";
+
+const perms: Permission[] = [
+  "run",
+  "read",
+  "write",
+  "net",
+  "env",
+];
+
+for (let grant of perms) {
+  testPerm({ [grant]: true }, function envGranted() {
+
+    const perms = Deno.permissions();
+    assert(perms !== null);
+    for (let perm of Object.keys(perms)) {
+      assertEqual(perms[perm], perm === grant);
+    }
+
+    Deno.revokePermission(grant);
+
+    const revoked = Deno.permissions();
+    for (let perm of Object.keys(revoked)) {
+      assertEqual(revoked[perm], false);
+    }
+  });
+}

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -45,6 +45,7 @@ import "./url_test.ts";
 import "./url_search_params_test.ts";
 import "./write_file_test.ts";
 import "./performance_test.ts";
+import "./permissions_test.ts";
 import "./version_test.ts";
 
 import "../website/app_test.js";

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -12,6 +12,9 @@ union Any {
   Exit,
   Environ,
   EnvironRes,
+  Permissions,
+  PermissionRevoke,
+  PermissionsRes,
   Fetch,
   FetchRes,
   MakeTempDir,
@@ -229,6 +232,20 @@ table EnvironRes {
 table KeyValue {
   key: string;
   value: string;
+}
+
+table Permissions {}
+
+table PermissionRevoke {
+  permission: string;
+}
+
+table PermissionsRes {
+  run: bool;
+  read: bool;
+  write: bool;
+  net: bool;
+  env: bool;
 }
 
 // Note this represents The WHOLE header of an http message, not just the key

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
+use atty;
 use crate::ansi;
 use crate::errors;
 use crate::errors::{permission_denied, DenoError, DenoResult, ErrorKind};
@@ -21,7 +22,6 @@ use crate::resources::table_entries;
 use crate::resources::Resource;
 use crate::tokio_util;
 use crate::version;
-use atty;
 use deno_core::JSError;
 use flatbuffers::FlatBufferBuilder;
 use futures;
@@ -57,11 +57,9 @@ type OpResult = DenoResult<Buf>;
 
 // TODO Ideally we wouldn't have to box the Op being returned.
 // The box is just to make it easier to get a prototype refactor working.
-type OpCreator = fn(
-  isolate: &Isolate,
-  base: &msg::Base<'_>,
-  data: libdeno::deno_buf,
-) -> Box<Op>;
+type OpCreator =
+  fn(isolate: &Isolate, base: &msg::Base<'_>, data: libdeno::deno_buf)
+    -> Box<Op>;
 
 #[inline]
 fn empty_buf() -> Buf {
@@ -158,8 +156,7 @@ pub fn dispatch(
           ..Default::default()
         },
       ))
-    })
-    .and_then(move |buf: Buf| -> DenoResult<Buf> {
+    }).and_then(move |buf: Buf| -> DenoResult<Buf> {
       // Handle empty responses. For sync responses we just want
       // to send null. For async we want to send a small message
       // with the cmd_id.
@@ -1220,8 +1217,7 @@ fn op_read_dir(
             has_mode: cfg!(target_family = "unix"),
           },
         )
-      })
-      .collect();
+      }).collect();
 
     let entries = builder.create_vector(&entries);
     let inner = msg::ReadDirRes::create(
@@ -1610,8 +1606,7 @@ fn op_resources(
           repr: Some(repr),
         },
       )
-    })
-    .collect();
+    }).collect();
 
   let resources = builder.create_vector(&res);
   let inner = msg::ResourcesRes::create(
@@ -1894,8 +1889,7 @@ mod tests {
       &isolate,
       &final_msg,
       libdeno::deno_buf::empty(),
-    )
-    .wait();
+    ).wait();
     match fetch_result {
       Ok(_) => assert!(true),
       Err(e) => assert_eq!(e.to_string(), permission_denied().to_string()),
@@ -1933,8 +1927,7 @@ mod tests {
       &isolate,
       &final_msg,
       libdeno::deno_buf::empty(),
-    )
-    .wait();
+    ).wait();
     match fetch_result {
       Ok(_) => assert!(true),
       Err(e) => assert_eq!(e.to_string(), permission_denied().to_string()),
@@ -1972,8 +1965,7 @@ mod tests {
       &isolate,
       &final_msg,
       libdeno::deno_buf::empty(),
-    )
-    .wait();
+    ).wait();
     match fetch_result {
       Ok(_) => assert!(true),
       Err(e) => assert!(e.to_string() != permission_denied().to_string()),

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -3,15 +3,16 @@ use atty;
 
 use crate::flags::DenoFlags;
 
-use ansi_term::Style;
 use crate::errors::permission_denied;
 use crate::errors::DenoResult;
+use ansi_term::Style;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg_attr(feature = "cargo-clippy", allow(stutter))]
 #[derive(Debug, Default)]
 pub struct DenoPermissions {
+  // Keep in sync with src/permissions.ts
   pub allow_read: AtomicBool,
   pub allow_write: AtomicBool,
   pub allow_net: AtomicBool,
@@ -89,6 +90,51 @@ impl DenoPermissions {
       self.allow_env.store(true, Ordering::SeqCst);
     }
     r
+  }
+
+  pub fn allows_run(&self) -> bool {
+    return self.allow_run.load(Ordering::SeqCst);
+  }
+
+  pub fn allows_read(&self) -> bool {
+    return self.allow_read.load(Ordering::SeqCst);
+  }
+
+  pub fn allows_write(&self) -> bool {
+    return self.allow_write.load(Ordering::SeqCst);
+  }
+
+  pub fn allows_net(&self) -> bool {
+    return self.allow_net.load(Ordering::SeqCst);
+  }
+
+  pub fn allows_env(&self) -> bool {
+    return self.allow_env.load(Ordering::SeqCst);
+  }
+
+  pub fn revoke_run(&self) -> DenoResult<()> {
+    self.allow_run.store(false, Ordering::SeqCst);
+    return Ok(());
+  }
+
+  pub fn revoke_read(&self) -> DenoResult<()> {
+    self.allow_read.store(false, Ordering::SeqCst);
+    return Ok(());
+  }
+
+  pub fn revoke_write(&self) -> DenoResult<()> {
+    self.allow_write.store(false, Ordering::SeqCst);
+    return Ok(());
+  }
+
+  pub fn revoke_net(&self) -> DenoResult<()> {
+    self.allow_net.store(false, Ordering::SeqCst);
+    return Ok(());
+  }
+
+  pub fn revoke_env(&self) -> DenoResult<()> {
+    self.allow_env.store(false, Ordering::SeqCst);
+    return Ok(());
   }
 
   pub fn default() -> Self {

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -3,9 +3,9 @@ use atty;
 
 use crate::flags::DenoFlags;
 
+use ansi_term::Style;
 use crate::errors::permission_denied;
 use crate::errors::DenoResult;
-use ansi_term::Style;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/website/manual.md
+++ b/website/manual.md
@@ -286,6 +286,35 @@ It's worth noting that like the `cat.ts` example, the `copy()` function here
 also does not make unnecessary memory copies. It receives a packet from the
 kernel and sends back, without further complexity.
 
+### Inspecting and revoking permissions
+
+Sometimes a program may want to revoke previously granted permissions. When a
+program, at a later stage, needs those permissions, a new prompt will be
+presented to the user.
+
+```ts
+const { permissions, revokePermission, open, remove } = Deno;
+
+(async () => {
+  // lookup a permission
+  if (!permissions().write) {
+    throw new Error("need write permission");
+  }
+
+  const log = await open("request.log", "a+");
+
+  // revoke some permissions
+  revokePermission("read");
+  revokePermission("write");
+
+  // use the log file
+  await log.write(encoder.encode("hello\n"));
+
+  // this will prompt for the write permission or fail.
+  await remove("request.log");
+})();
+```
+
 ### File server
 
 This one serves a local directory in HTTP.


### PR DESCRIPTION
This patch allows deno scripts to revoke permissions granted by the user.  When the script, at a later stage, needs those permissions, a new prompt will be presented to the user.

The main use-case for this feature is to allow trusted _bootstrap_ code to run with raised privileges without granting all permissions to untrusted code following the bootstrap fase.