### PR TITLE
Windows libdeno.print() improvements

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -341,18 +341,6 @@ function stringifyWithQuotes(
   }
 }
 
-// Returns true when the console is collapsed.
-function isCollapsed(
-  collapsedAt: number | null | undefined,
-  indentLevel: number | null | undefined
-) {
-  if (collapsedAt == null || indentLevel == null) {
-    return false;
-  }
-
-  return collapsedAt <= indentLevel;
-}
-
 /** TODO Do not expose this from "deno" namespace.
  * @internal
  */
@@ -464,22 +452,23 @@ export function stringifyArgs(
   }
 
   const { collapsedAt, indentLevel } = options;
-  if (
-    !isCollapsed(collapsedAt, indentLevel) &&
-    indentLevel != null &&
-    indentLevel > 0
-  ) {
-    const groupIndent = " ".repeat(indentLevel);
-    if (str.indexOf("\n") !== -1) {
-      str = str.replace(/\n/g, `\n${groupIndent}`);
+  const isCollapsed =
+    collapsedAt != null && indentLevel != null && collapsedAt <= indentLevel;
+  if (!isCollapsed) {
+    if (indentLevel != null && indentLevel > 0) {
+      const groupIndent = " ".repeat(indentLevel);
+      if (str.indexOf("\n") !== -1) {
+        str = str.replace(/\n/g, `\n${groupIndent}`);
+      }
+      str = groupIndent + str;
     }
-    str = groupIndent + str;
+    str += "\n";
   }
 
   return str;
 }
 
-type PrintFunc = (x: string, isErr?: boolean, printsNewline?: boolean) => void;
+type PrintFunc = (x: string, isErr?: boolean) => void;
 
 const countMap = new Map<string, number>();
 const timerMap = new Map<string, number>();
@@ -500,8 +489,7 @@ export class Console {
         indentLevel: this.indentLevel,
         collapsedAt: this.collapsedAt
       }),
-      false,
-      !isCollapsed(this.collapsedAt, this.indentLevel)
+      false
     );
   };
 
@@ -522,8 +510,7 @@ export class Console {
         indentLevel: this.indentLevel,
         collapsedAt: this.collapsedAt
       }),
-      true,
-      !isCollapsed(this.collapsedAt, this.indentLevel)
+      true
     );
   };
 

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -1,24 +1,16 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test, assertEqual, assert } from "./test_util.ts";
+import { assert, assertEqual, test } from "./test_util.ts";
 
 // Some of these APIs aren't exposed in the types and so we have to cast to any
 // in order to "trick" TypeScript.
 // tslint:disable-next-line:no-any
-const {
-  Console,
-  libdeno,
-  stringifyArgs,
-  inspect,
-  readAll,
-  write,
-  stdout
-} = Deno as any;
+const { Console, libdeno, stringifyArgs, inspect, write, stdout } = Deno as any;
 
 const console = new Console(libdeno.print);
 
 // tslint:disable-next-line:no-any
 function stringify(...args: any[]): string {
-  return stringifyArgs(args);
+  return stringifyArgs(args).replace(/\n$/, "");
 }
 
 test(function consoleTestAssertShouldNotThrowError() {
@@ -139,16 +131,16 @@ test(function consoleTestStringifyWithDepth() {
   const nestedObj: any = { a: { b: { c: { d: { e: { f: 42 } } } } } };
   assertEqual(
     stringifyArgs([nestedObj], { depth: 3 }),
-    "{ a: { b: { c: [Object] } } }"
+    "{ a: { b: { c: [Object] } } }\n"
   );
   assertEqual(
     stringifyArgs([nestedObj], { depth: 4 }),
-    "{ a: { b: { c: { d: [Object] } } } }"
+    "{ a: { b: { c: { d: [Object] } } } }\n"
   );
-  assertEqual(stringifyArgs([nestedObj], { depth: 0 }), "[Object]");
+  assertEqual(stringifyArgs([nestedObj], { depth: 0 }), "[Object]\n");
   assertEqual(
     stringifyArgs([nestedObj], { depth: null }),
-    "{ a: { b: { c: { d: [Object] } } } }"
+    "{ a: { b: { c: { d: [Object] } } } }\n"
   );
   // test inspect is working the same way
   assertEqual(

--- a/libdeno/binding.cc
+++ b/libdeno/binding.cc
@@ -96,13 +96,8 @@ void Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::String::Utf8Value str(isolate, args[0]);
   bool is_err =
       args.Length() >= 2 ? args[1]->BooleanValue(context).ToChecked() : false;
-  bool prints_newline =
-      args.Length() >= 3 ? args[2]->BooleanValue(context).ToChecked() : true;
   FILE* file = is_err ? stderr : stdout;
   fwrite(*str, sizeof(**str), str.length(), file);
-  if (prints_newline) {
-    fprintf(file, "\n");
-  }
   fflush(file);
 }
 


### PR DESCRIPTION
Note that emoji are still not supported, due limitations of the Windows console.