### PR TITLE
changes to accomodate pyenv to have a project specific python2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ node_modules
 /website/data.json
 /website/recent.json
 /js/gen
+
+# ignore the pyenv (local) version file
+.python-version

--- a/website/manual.md
+++ b/website/manual.md
@@ -119,6 +119,15 @@ deno https://deno.land/welcome.ts
 # Fetch deps.
 git clone --recurse-submodules https://github.com/denoland/deno.git
 cd deno
+# Check your python
+python -V  # 2.7?
+
+# If you don't have python2 _and_ you have pyenv, you can install python2 in a project specific way
+type pyenv | grep function  # pyenv is a function
+pyenv install 2.7.15
+pyenv local 2.7.15
+python -V # 2.7.15
+
 ./tools/setup.py
 
 # You may need to ensure that sccache is running.
@@ -147,6 +156,10 @@ submodule. However, you need to install separately:
 2. [Node](https://nodejs.org/)
 3. Python 2.
    [Not 3](https://github.com/denoland/deno/issues/464#issuecomment-411795578).
+
+   Note that [pyenv](https://github.com/pyenv/pyenv) can be useful to deploy a
+   python2, especially in those situations where the default python in now
+   python3 such as Ubuntu 18.10 and above. See more below.
 
 Extra steps for Mac users:
 


### PR DESCRIPTION
<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
I read the contributing stuff, I'm making a documentation suggestion so thankfully I can't break anything substantive.

Some context: Ubuntu 18.10 install python3 as the standard python. This breaks the build directions in website/manual.md. I wanted to see if I could still build deno and I use pyenv rather than apt-get to manage python version. So I managed to install a "project local" python2 and successfully build. I added a few sentences on how to do it in the manual build section.

pyenv creates a $GITROOT/.python-version to "remember" which python is configured, e.g.

```bash
cat .python-version 
2.7.15
```
This probably shouldn't be checked in, so I added it to .gitignore.

Also note that pyenv only supports linux and osx, not windows. You've been pretty good about describing all three platforms equally. So you might want to handle this "pyenv hack" in a different way. Maybe a note at the bottom. Or skip it altogether. That's fine. I did some work and didn't want to waste it. Up to you.