### PR TITLE
Update to TypeScript 3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "rollup-pluginutils": "2.4.1",
     "ts-morph": "1.3.0",
     "ts-node": "8.0.2",
-    "typescript": "3.2.2"
+    "typescript": "3.3.3333"
   }
 }

--- a/tools/ts_library_builder/build_library.ts
+++ b/tools/ts_library_builder/build_library.ts
@@ -360,9 +360,9 @@ export function main({
       baseUrl: basePath,
       declaration: true,
       emitDeclarationOnly: true,
+      lib: ["esnext"],
       module: ModuleKind.ESNext,
       moduleResolution: ModuleResolutionKind.NodeJs,
-      // noLib: true,
       paths: {
         "*": ["*", `${buildPath}/*`]
       },
@@ -402,8 +402,8 @@ export function main({
   const declarationProject = new Project({
     compilerOptions: {
       baseUrl: basePath,
+      lib: ["esnext"],
       moduleResolution: ModuleResolutionKind.NodeJs,
-      noLib: true,
       paths: {
         "*": ["*", `${buildPath}/*`]
       },
@@ -432,6 +432,7 @@ export function main({
   const outputProject = new Project({
     compilerOptions: {
       baseUrl: buildPath,
+      lib: ["esnext"],
       moduleResolution: ModuleResolutionKind.NodeJs,
       strict: true,
       target: ScriptTarget.ESNext

--- a/tools/ts_library_builder/tsconfig.json
+++ b/tools/ts_library_builder/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["esnext"],
     "moduleResolution": "node",
     "strict": true,
     "target": "esnext"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,11 +4,11 @@
     "allowUnreachableCode": false,
     "baseUrl": ".",
     "checkJs": true,
+    "lib": ["esnext"],
     "module": "esnext",
     "moduleResolution": "node",
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "noLib": true,
     "noUnusedLocals": true,
     "paths": {
       "*": ["*", "target/debug/*", "target/release/*"]
@@ -22,10 +22,5 @@
     "target": "esnext",
     "types": []
   },
-  "files": [
-    "node_modules/typescript/lib/lib.esnext.d.ts",
-    "js/lib.web_assembly.d.ts",
-    "js/main.ts",
-    "js/compiler.ts"
-  ]
+  "files": ["js/lib.web_assembly.d.ts", "js/main.ts", "js/compiler.ts"]
 }


### PR DESCRIPTION
This PR updates Deno to TypeScript 3.3.  There was a change in behaviour between 3.2 and 3.3 that was causing some issues in the upgrading.  Previously `noLib` would allow you to specify the libraries you wanted to include in the `files` and have the references to other libraries to be resolved.  That stopped working in 3.3, which the previous behaviour was unintended.  Now we have to supply the base library (`esnext`) in the `lib` option.  The reason we do this is that it ensure that `dom` and `scripthost` are not loaded which would potentially allow some features that Deno does not support get past the build process of Deno.

