### PR TITLE
Add build platform enum

### DIFF
--- a/js/build.ts
+++ b/js/build.ts
@@ -7,11 +7,19 @@ export interface BuildInfo {
   arch: "x64";
 
   /** The operating system platform. */
-  os: "mac" | "win" | "linux";
+  os: BuildPlatform;
 
   /** The GN build arguments */
   gnArgs: string;
 }
+
+/** The operating system platform. */
+export enum BuildPlatform {
+  mac = "mac",
+  win = "win",
+  linux = "linux"
+}
+
 
 // 'build' is injected by rollup.config.js at compile time.
 export const build: BuildInfo = {

--- a/js/build.ts
+++ b/js/build.ts
@@ -7,14 +7,14 @@ export interface BuildInfo {
   arch: "x64";
 
   /** The operating system platform. */
-  os: OperatingSystem;
+  os: OSType;
 
   /** The GN build arguments */
   gnArgs: string;
 }
 
 /** The operating system platform. */
-export enum OperatingSystem {
+export enum OSType {
   mac = "mac",
   win = "win",
   linux = "linux"

--- a/js/build.ts
+++ b/js/build.ts
@@ -7,19 +7,18 @@ export interface BuildInfo {
   arch: "x64";
 
   /** The operating system platform. */
-  os: BuildPlatform;
+  os: OperatingSystem;
 
   /** The GN build arguments */
   gnArgs: string;
 }
 
 /** The operating system platform. */
-export enum BuildPlatform {
+export enum OperatingSystem {
   mac = "mac",
   win = "win",
   linux = "linux"
 }
-
 
 // 'build' is injected by rollup.config.js at compile time.
 export const build: BuildInfo = {

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -63,7 +63,7 @@ export { metrics, Metrics } from "./metrics";
 export { resources } from "./resources";
 export { run, RunOptions, Process, ProcessStatus } from "./process";
 export { inspect } from "./console";
-export { build, platform } from "./build";
+export { build, platform, OperatingSystem } from "./build";
 export { version } from "./version";
 export const args: string[] = [];
 

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -63,7 +63,7 @@ export { metrics, Metrics } from "./metrics";
 export { resources } from "./resources";
 export { run, RunOptions, Process, ProcessStatus } from "./process";
 export { inspect } from "./console";
-export { build, platform, OperatingSystem } from "./build";
+export { build, platform, OSType } from "./build";
 export { version } from "./version";
 export const args: string[] = [];
 


### PR DESCRIPTION
added an enum for the build platform and exported it to be exposed to user. And make it consistent for any other plaform update. To be used like:

```ts
if(Deno.plaform == BuildPlatform.win) {
```