### PR TITLE
Added readfileStr, readfileStrSync

### DIFF
--- a/js/deno.ts
+++ b/js/deno.ts
@@ -41,7 +41,12 @@ export {
 export { chmodSync, chmod } from "./chmod";
 export { removeSync, remove, RemoveOption } from "./remove";
 export { renameSync, rename } from "./rename";
-export { readFileSync, readFile } from "./read_file";
+export {
+  readFileSync,
+  readFile,
+  readFileStrSync,
+  readFileStr
+} from "./read_file";
 export { readDirSync, readDir } from "./read_dir";
 export { copyFileSync, copyFile } from "./copy_file";
 export { readlinkSync, readlink } from "./read_link";

--- a/js/read_file.ts
+++ b/js/read_file.ts
@@ -3,6 +3,7 @@ import * as msg from "gen/msg_generated";
 import * as flatbuffers from "./flatbuffers";
 import { assert } from "./util";
 import * as dispatch from "./dispatch";
+import { TextDecoder } from "./text_encoding";
 
 function req(
   filename: string

--- a/js/read_file.ts
+++ b/js/read_file.ts
@@ -35,6 +35,17 @@ export function readFileSync(filename: string): Uint8Array {
   return res(dispatch.sendSync(...req(filename)));
 }
 
+/**
+ * Read file synchronously and output it as a string.
+ *
+ * @param filename File to read
+ * @param encoding Encoding of the file
+ */
+export function readFileStrSync(filename: string, encoding: string): string {
+  const decoder = new TextDecoder(encoding);
+  return decoder.decode(readFileSync(filename));
+}
+
 /** Read the entire contents of a file.
  *
  *       const decoder = new TextDecoder("utf-8");
@@ -43,4 +54,18 @@ export function readFileSync(filename: string): Uint8Array {
  */
 export async function readFile(filename: string): Promise<Uint8Array> {
   return res(await dispatch.sendAsync(...req(filename)));
+}
+
+/**
+ * Read file and output it as a string.
+ *
+ * @param filename File to read
+ * @param encoding Encoding of the file
+ */
+export async function readFileStr(
+  filename: string,
+  encoding: string
+): Promise<string> {
+  const decoder = new TextDecoder(encoding);
+  return decoder.decode(await readFile(filename));
 }

--- a/js/read_file_test.ts
+++ b/js/read_file_test.ts
@@ -10,6 +10,14 @@ testPerm({ read: true }, function readFileSyncSuccess() {
   assertEquals(pkg.name, "deno");
 });
 
+testPerm({ read: true }, function readFileStrSyncSuccess() {
+  const json = Deno.readFileStrSync("package.json", "utf-8");
+  assert(json.length > 0);
+  assert(typeof json === "string");
+  const pkg = JSON.parse(json);
+  assertEquals(pkg.name, "deno");
+});
+
 testPerm({ read: false }, function readFileSyncPerm() {
   let caughtError = false;
   try {
@@ -40,6 +48,14 @@ testPerm({ read: true }, async function readFileSuccess() {
   assert(data.byteLength > 0);
   const decoder = new TextDecoder("utf-8");
   const json = decoder.decode(data);
+  const pkg = JSON.parse(json);
+  assertEquals(pkg.name, "deno");
+});
+
+testPerm({ read: true }, async function readFileSuccess() {
+  const json = await Deno.readFileStr("package.json", "utf-8");
+  assert(json.length > 0);
+  assert(typeof json === "string");
   const pkg = JSON.parse(json);
   assertEquals(pkg.name, "deno");
 });


### PR DESCRIPTION
Added a little shortcut for the readfile
```ts
export function readFileStrSync(filename: string, encoding: string): string {
  const decoder = new TextDecoder(encoding);
  return decoder.decode(readFileSync(filename));
}
```

Easier to use. Or i can do the same as node does and change the signature as:
```ts
export function readFileSync(filename: string, encoding?: string): Uint8Array | string {
```

I prefer a clear separation personnaly. Your thoughts?