### PR TITLE
More permissions prompt options

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -3,7 +3,7 @@ use crate::isolate::Buf;
 use crate::isolate::IsolateState;
 use crate::isolate_init;
 use crate::msg;
-use crate::permissions::DenoPermissions;
+use crate::permissions::{DenoPermissions, PermissionAccessor};
 use crate::resources;
 use crate::resources::Resource;
 use crate::resources::ResourceId;
@@ -12,7 +12,6 @@ use crate::workers;
 use futures::Future;
 use serde_json;
 use std::str;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -53,11 +52,9 @@ fn lazy_start(parent_state: &Arc<IsolateState>) -> Resource {
   let mut cell = C_RID.lock().unwrap();
   let isolate_init = isolate_init::compiler_isolate_init();
   let permissions = DenoPermissions {
-    allow_read: AtomicBool::new(true),
-    allow_write: AtomicBool::new(true),
-    allow_env: AtomicBool::new(false),
-    allow_net: AtomicBool::new(true),
-    allow_run: AtomicBool::new(false),
+    allow_read: PermissionAccessor::from(true),
+    allow_write: PermissionAccessor::from(true),
+    allow_net: PermissionAccessor::from(true),
     ..Default::default()
   };
   let rid = cell.get_or_insert_with(|| {

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -6,6 +6,7 @@ use crate::flags::DenoFlags;
 use ansi_term::Style;
 use crate::errors::permission_denied;
 use crate::errors::DenoResult;
+use std::fmt;
 use std::io;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -33,6 +34,16 @@ impl From<bool> for PermissionAccessorState {
     match val {
       true => PermissionAccessorState::Allow,
       false => PermissionAccessorState::Ask,
+    }
+  }
+}
+
+impl fmt::Display for PermissionAccessorState {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      PermissionAccessorState::Allow => f.pad("Allow"),
+      PermissionAccessorState::Ask => f.pad("Ask"),
+      PermissionAccessorState::Deny => f.pad("Deny"),
     }
   }
 }
@@ -159,7 +170,7 @@ impl DenoPermissions {
       {
         Err(e) => Err(e),
         Ok(v) => {
-          self.allow_run.update_with_prompt_result(&v);
+          self.allow_read.update_with_prompt_result(&v);
           v.check()?;
           Ok(())
         }
@@ -176,7 +187,7 @@ impl DenoPermissions {
       {
         Err(e) => Err(e),
         Ok(v) => {
-          self.allow_run.update_with_prompt_result(&v);
+          self.allow_write.update_with_prompt_result(&v);
           v.check()?;
           Ok(())
         }
@@ -193,7 +204,7 @@ impl DenoPermissions {
       ) {
         Err(e) => Err(e),
         Ok(v) => {
-          self.allow_run.update_with_prompt_result(&v);
+          self.allow_net.update_with_prompt_result(&v);
           v.check()?;
           Ok(())
         }
@@ -209,7 +220,7 @@ impl DenoPermissions {
         match self.try_permissions_prompt("access to environment variables") {
           Err(e) => Err(e),
           Ok(v) => {
-            self.allow_run.update_with_prompt_result(&v);
+            self.allow_env.update_with_prompt_result(&v);
             v.check()?;
             Ok(())
           }
@@ -293,6 +304,17 @@ impl PromptResult {
       PromptResult::DenyOnce => Err(permission_denied()),
       PromptResult::DenyAlways => Err(permission_denied()),
       _ => Ok(()),
+    }
+  }
+}
+
+impl fmt::Display for PromptResult {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      PromptResult::AllowAlways => f.pad("AllowAlways"),
+      PromptResult::AllowOnce => f.pad("AllowOnce"),
+      PromptResult::DenyOnce => f.pad("DenyOnce"),
+      PromptResult::DenyAlways => f.pad("DenyAlways"),
     }
   }
 }

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -7,178 +7,315 @@ use ansi_term::Style;
 use crate::errors::permission_denied;
 use crate::errors::DenoResult;
 use std::io;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// Tri-state value for storing permission state
+pub enum PermissionAccessorState {
+  Allow = 0,
+  Ask = 1,
+  Deny = 2,
+}
+
+impl From<usize> for PermissionAccessorState {
+  fn from(val: usize) -> Self {
+    match val {
+      0 => PermissionAccessorState::Allow,
+      1 => PermissionAccessorState::Ask,
+      2 => PermissionAccessorState::Deny,
+      _ => unreachable!(),
+    }
+  }
+}
+
+impl From<bool> for PermissionAccessorState {
+  fn from(val: bool) -> Self {
+    match val {
+      true => PermissionAccessorState::Allow,
+      false => PermissionAccessorState::Ask,
+    }
+  }
+}
+
+#[derive(Debug)]
+pub struct PermissionAccessor {
+  state: Arc<AtomicUsize>,
+}
+
+impl PermissionAccessor {
+  pub fn new(state: PermissionAccessorState) -> Self {
+    Self {
+      state: Arc::new(AtomicUsize::new(state as usize)),
+    }
+  }
+
+  pub fn is_allow(&self) -> bool {
+    match self.get_state() {
+      PermissionAccessorState::Allow => true,
+      _ => false,
+    }
+  }
+
+  /// If the state is "Allow" walk it back to the default "Ask"
+  /// Don't do anything if state is "Deny"
+  pub fn revoke(&self) {
+    if self.is_allow() {
+      self.ask();
+    }
+  }
+
+  pub fn allow(&self) {
+    self.set_state(PermissionAccessorState::Allow)
+  }
+
+  pub fn ask(&self) {
+    self.set_state(PermissionAccessorState::Ask)
+  }
+
+  pub fn deny(&self) {
+    self.set_state(PermissionAccessorState::Deny)
+  }
+
+  /// Update this accessors state based on a PromptResult value
+  /// This will only update the state if the PromptResult value
+  /// is one of the "Always" values
+  pub fn update_with_prompt_result(&self, prompt_result: &PromptResult) {
+    match prompt_result {
+      PromptResult::AllowAlways => self.allow(),
+      PromptResult::DenyAlways => self.deny(),
+      _ => {}
+    }
+  }
+
+  #[inline]
+  pub fn get_state(&self) -> PermissionAccessorState {
+    self.state.load(Ordering::SeqCst).into()
+  }
+  fn set_state(&self, state: PermissionAccessorState) {
+    self.state.store(state as usize, Ordering::SeqCst)
+  }
+}
+
+impl From<bool> for PermissionAccessor {
+  fn from(val: bool) -> Self {
+    Self::new(PermissionAccessorState::from(val))
+  }
+}
+
+impl Default for PermissionAccessor {
+  fn default() -> Self {
+    Self {
+      state: Arc::new(AtomicUsize::new(PermissionAccessorState::Ask as usize)),
+    }
+  }
+}
 
 #[cfg_attr(feature = "cargo-clippy", allow(stutter))]
 #[derive(Debug, Default)]
 pub struct DenoPermissions {
   // Keep in sync with src/permissions.ts
-  pub allow_read: AtomicBool,
-  pub allow_write: AtomicBool,
-  pub allow_net: AtomicBool,
-  pub allow_env: AtomicBool,
-  pub allow_run: AtomicBool,
+  pub allow_read: PermissionAccessor,
+  pub allow_write: PermissionAccessor,
+  pub allow_net: PermissionAccessor,
+  pub allow_env: PermissionAccessor,
+  pub allow_run: PermissionAccessor,
   pub no_prompts: AtomicBool,
 }
 
 impl DenoPermissions {
   pub fn from_flags(flags: &DenoFlags) -> Self {
     Self {
-      allow_read: AtomicBool::new(flags.allow_read),
-      allow_write: AtomicBool::new(flags.allow_write),
-      allow_env: AtomicBool::new(flags.allow_env),
-      allow_net: AtomicBool::new(flags.allow_net),
-      allow_run: AtomicBool::new(flags.allow_run),
+      allow_read: PermissionAccessor::from(flags.allow_read),
+      allow_write: PermissionAccessor::from(flags.allow_write),
+      allow_env: PermissionAccessor::from(flags.allow_env),
+      allow_net: PermissionAccessor::from(flags.allow_net),
+      allow_run: PermissionAccessor::from(flags.allow_run),
       no_prompts: AtomicBool::new(flags.no_prompts),
     }
   }
 
   pub fn check_run(&self) -> DenoResult<()> {
-    if self.allow_run.load(Ordering::SeqCst) {
-      return Ok(());
-    };
-    // TODO get location (where access occurred)
-    let r = self.try_permissions_prompt("access to run a subprocess");
-    if r.is_ok() {
-      self.allow_run.store(true, Ordering::SeqCst);
+    match self.allow_run.get_state() {
+      PermissionAccessorState::Allow => Ok(()),
+      PermissionAccessorState::Ask => {
+        match self.try_permissions_prompt("access to run a subprocess") {
+          Err(e) => Err(e),
+          Ok(v) => {
+            self.allow_run.update_with_prompt_result(&v);
+            v.check()?;
+            Ok(())
+          }
+        }
+      }
+      PermissionAccessorState::Deny => Err(permission_denied()),
     }
-    r
   }
 
   pub fn check_read(&self, filename: &str) -> DenoResult<()> {
-    if self.allow_read.load(Ordering::SeqCst) {
-      return Ok(());
-    };
-    // TODO get location (where access occurred)
-    let r =
-      self.try_permissions_prompt(&format!("read access to \"{}\"", filename));;
-    if r.is_ok() {
-      self.allow_read.store(true, Ordering::SeqCst);
+    match self.allow_read.get_state() {
+      PermissionAccessorState::Allow => Ok(()),
+      PermissionAccessorState::Ask => match self
+        .try_permissions_prompt(&format!("read access to \"{}\"", filename))
+      {
+        Err(e) => Err(e),
+        Ok(v) => {
+          self.allow_run.update_with_prompt_result(&v);
+          v.check()?;
+          Ok(())
+        }
+      },
+      PermissionAccessorState::Deny => Err(permission_denied()),
     }
-    r
   }
 
   pub fn check_write(&self, filename: &str) -> DenoResult<()> {
-    if self.allow_write.load(Ordering::SeqCst) {
-      return Ok(());
-    };
-    // TODO get location (where access occurred)
-    let r =
-      self.try_permissions_prompt(&format!("write access to \"{}\"", filename));;
-    if r.is_ok() {
-      self.allow_write.store(true, Ordering::SeqCst);
+    match self.allow_write.get_state() {
+      PermissionAccessorState::Allow => Ok(()),
+      PermissionAccessorState::Ask => match self
+        .try_permissions_prompt(&format!("write access to \"{}\"", filename))
+      {
+        Err(e) => Err(e),
+        Ok(v) => {
+          self.allow_run.update_with_prompt_result(&v);
+          v.check()?;
+          Ok(())
+        }
+      },
+      PermissionAccessorState::Deny => Err(permission_denied()),
     }
-    r
   }
 
   pub fn check_net(&self, domain_name: &str) -> DenoResult<()> {
-    if self.allow_net.load(Ordering::SeqCst) {
-      return Ok(());
-    };
-    // TODO get location (where access occurred)
-    let r = self.try_permissions_prompt(&format!(
-      "network access to \"{}\"",
-      domain_name
-    ));
-    if r.is_ok() {
-      self.allow_net.store(true, Ordering::SeqCst);
+    match self.allow_net.get_state() {
+      PermissionAccessorState::Allow => Ok(()),
+      PermissionAccessorState::Ask => match self.try_permissions_prompt(
+        &format!("network access to \"{}\"", domain_name),
+      ) {
+        Err(e) => Err(e),
+        Ok(v) => {
+          self.allow_run.update_with_prompt_result(&v);
+          v.check()?;
+          Ok(())
+        }
+      },
+      PermissionAccessorState::Deny => Err(permission_denied()),
     }
-    r
   }
 
   pub fn check_env(&self) -> DenoResult<()> {
-    if self.allow_env.load(Ordering::SeqCst) {
-      return Ok(());
-    };
-    // TODO get location (where access occurred)
-    let r = self.try_permissions_prompt(&"access to environment variables");
-    if r.is_ok() {
-      self.allow_env.store(true, Ordering::SeqCst);
+    match self.allow_env.get_state() {
+      PermissionAccessorState::Allow => Ok(()),
+      PermissionAccessorState::Ask => {
+        match self.try_permissions_prompt("access to environment variables") {
+          Err(e) => Err(e),
+          Ok(v) => {
+            self.allow_run.update_with_prompt_result(&v);
+            v.check()?;
+            Ok(())
+          }
+        }
+      }
+      PermissionAccessorState::Deny => Err(permission_denied()),
     }
-    r
   }
 
   /// Try to present the user with a permission prompt
   /// will error with permission_denied if no_prompts is enabled
-  fn try_permissions_prompt(&self, message: &str) -> DenoResult<()> {
+  fn try_permissions_prompt(&self, message: &str) -> DenoResult<PromptResult> {
     if self.no_prompts.load(Ordering::SeqCst) {
       return Err(permission_denied());
     }
+    if !atty::is(atty::Stream::Stdin) || !atty::is(atty::Stream::Stderr) {
+      return Err(permission_denied());
+    };
     permission_prompt(message)
   }
 
   pub fn allows_run(&self) -> bool {
-    return self.allow_run.load(Ordering::SeqCst);
+    return self.allow_run.is_allow();
   }
 
   pub fn allows_read(&self) -> bool {
-    return self.allow_read.load(Ordering::SeqCst);
+    return self.allow_read.is_allow();
   }
 
   pub fn allows_write(&self) -> bool {
-    return self.allow_write.load(Ordering::SeqCst);
+    return self.allow_write.is_allow();
   }
 
   pub fn allows_net(&self) -> bool {
-    return self.allow_net.load(Ordering::SeqCst);
+    return self.allow_net.is_allow();
   }
 
   pub fn allows_env(&self) -> bool {
-    return self.allow_env.load(Ordering::SeqCst);
+    return self.allow_env.is_allow();
   }
 
   pub fn revoke_run(&self) -> DenoResult<()> {
-    self.allow_run.store(false, Ordering::SeqCst);
+    self.allow_run.revoke();
     return Ok(());
   }
 
   pub fn revoke_read(&self) -> DenoResult<()> {
-    self.allow_read.store(false, Ordering::SeqCst);
+    self.allow_read.revoke();
     return Ok(());
   }
 
   pub fn revoke_write(&self) -> DenoResult<()> {
-    self.allow_write.store(false, Ordering::SeqCst);
+    self.allow_write.revoke();
     return Ok(());
   }
 
   pub fn revoke_net(&self) -> DenoResult<()> {
-    self.allow_net.store(false, Ordering::SeqCst);
+    self.allow_net.revoke();
     return Ok(());
   }
 
   pub fn revoke_env(&self) -> DenoResult<()> {
-    self.allow_env.store(false, Ordering::SeqCst);
+    self.allow_env.revoke();
     return Ok(());
   }
+}
 
-  pub fn default() -> Self {
-    Self {
-      allow_read: AtomicBool::new(false),
-      allow_write: AtomicBool::new(false),
-      allow_env: AtomicBool::new(false),
-      allow_net: AtomicBool::new(false),
-      allow_run: AtomicBool::new(false),
-      ..Default::default()
+/// Quad-state value for representing user input on permission prompt
+#[derive(Debug, Clone)]
+pub enum PromptResult {
+  AllowAlways = 0,
+  AllowOnce = 1,
+  DenyOnce = 2,
+  DenyAlways = 3,
+}
+
+impl PromptResult {
+  /// If value is any form of deny this will error with permission_denied
+  pub fn check(&self) -> DenoResult<()> {
+    match self {
+      PromptResult::DenyOnce => Err(permission_denied()),
+      PromptResult::DenyAlways => Err(permission_denied()),
+      _ => Ok(()),
     }
   }
 }
 
-fn permission_prompt(message: &str) -> DenoResult<()> {
-  if !atty::is(atty::Stream::Stdin) || !atty::is(atty::Stream::Stderr) {
-    return Err(permission_denied());
-  };
-  let msg = format!("⚠️  Deno requests {}. Grant? [yN] ", message);
+fn permission_prompt(message: &str) -> DenoResult<PromptResult> {
+  let msg = format!("⚠️  Deno requests {}. Grant? [a/y/n/d (a = allow always, y = allow once, n = deny once, d = deny always)] ", message);
   // print to stderr so that if deno is > to a file this is still displayed.
   eprint!("{}", Style::new().bold().paint(msg));
-  let mut input = String::new();
-  let stdin = io::stdin();
-  let _nread = stdin.read_line(&mut input)?;
-  let ch = input.chars().next().unwrap();
-  let is_yes = ch == 'y' || ch == 'Y';
-  if is_yes {
-    Ok(())
-  } else {
-    Err(permission_denied())
+  loop {
+    let mut input = String::new();
+    let stdin = io::stdin();
+    let _nread = stdin.read_line(&mut input)?;
+    let ch = input.chars().next().unwrap();
+    match ch.to_ascii_lowercase() {
+      'a' => return Ok(PromptResult::AllowAlways),
+      'y' => return Ok(PromptResult::AllowOnce),
+      'n' => return Ok(PromptResult::DenyOnce),
+      'd' => return Ok(PromptResult::DenyAlways),
+      _ => {
+        // If we don't get a recognized option try again.
+        let msg_again = format!("Unrecognized option '{}' [a/y/n/d (a = allow always, y = allow once, n = deny once, d = deny always)] ", ch);
+        eprint!("{}", Style::new().bold().paint(msg_again));
+      }
+    };
   }
 }

--- a/tools/permission_prompt_test.py
+++ b/tools/permission_prompt_test.py
@@ -12,6 +12,10 @@ from util import build_path, executable_suffix, green_ok, red_failed
 
 PERMISSIONS_PROMPT_TEST_TS = "tools/permission_prompt_test.ts"
 
+PROMPT_PATTERN = b'⚠️'
+FIRST_CHECK_FAILED_PATTERN = b'First check failed'
+PERMISSION_DENIED_PATTERN = b'PermissionDenied: permission denied'
+
 
 # This function is copied from:
 # https://gist.github.com/hayd/4f46a68fc697ba8888a7b517a414583e
@@ -97,84 +101,84 @@ class Prompt(object):
         code, stdout, stderr = self.run("needs" + test_type.capitalize(), b'',
                                         ["--allow-" + test_type])
         assert code == 0
-        assert not b'⚠️  Deno requests' in stderr
-        assert not b'First check failed' in stdout
-        assert not b'PermissionDenied: permission denied' in stderr
+        assert not PROMPT_PATTERN in stderr
+        assert not FIRST_CHECK_FAILED_PATTERN in stdout
+        assert not PERMISSION_DENIED_PATTERN in stderr
 
     def test_yes_yes(self, test_type):
         code, stdout, stderr = self.run("needs" + test_type.capitalize(),
                                         b'y\ny\n')
         assert code == 0
-        assert b'⚠️  Deno requests' in stderr
-        assert not b'First check failed' in stdout
-        assert not b'PermissionDenied: permission denied' in stderr
+        assert PROMPT_PATTERN in stderr
+        assert not FIRST_CHECK_FAILED_PATTERN in stdout
+        assert not PERMISSION_DENIED_PATTERN in stderr
 
     def test_yes_no(self, test_type):
         code, stdout, stderr = self.run("needs" + test_type.capitalize(),
                                         b'y\nn\n')
         assert code == 1
-        assert b'⚠️  Deno requests' in stderr
-        assert not b'First check failed' in stdout
-        assert b'PermissionDenied: permission denied' in stderr
+        assert PROMPT_PATTERN in stderr
+        assert not FIRST_CHECK_FAILED_PATTERN in stdout
+        assert PERMISSION_DENIED_PATTERN in stderr
 
     def test_no_no(self, test_type):
         code, stdout, stderr = self.run("needs" + test_type.capitalize(),
                                         b'n\nn\n')
         assert code == 1
-        assert b'⚠️  Deno requests' in stderr
-        assert b'First check failed' in stdout
-        assert b'PermissionDenied: permission denied' in stderr
+        assert PROMPT_PATTERN in stderr
+        assert FIRST_CHECK_FAILED_PATTERN in stdout
+        assert PERMISSION_DENIED_PATTERN in stderr
 
     def test_no_yes(self, test_type):
         code, stdout, stderr = self.run("needs" + test_type.capitalize(),
                                         b'n\ny\n')
         assert code == 0
 
-        assert b'⚠️  Deno requests' in stderr
-        assert b'First check failed' in stdout
-        assert not b'PermissionDenied: permission denied' in stderr
+        assert PROMPT_PATTERN in stderr
+        assert FIRST_CHECK_FAILED_PATTERN in stdout
+        assert not PERMISSION_DENIED_PATTERN in stderr
 
     def test_allow(self, test_type):
         code, stdout, stderr = self.run("needs" + test_type.capitalize(),
                                         b'a\n')
         assert code == 0
-        assert b'⚠️  Deno requests' in stderr
-        assert not b'First check failed' in stdout
-        assert not b'PermissionDenied: permission denied' in stderr
+        assert PROMPT_PATTERN in stderr
+        assert not FIRST_CHECK_FAILED_PATTERN in stdout
+        assert not PERMISSION_DENIED_PATTERN in stderr
 
     def test_deny(self, test_type):
         code, stdout, stderr = self.run("needs" + test_type.capitalize(),
                                         b'd\n')
         assert code == 1
-        assert b'⚠️  Deno requests' in stderr
-        assert b'First check failed' in stdout
-        assert b'PermissionDenied: permission denied' in stderr
+        assert PROMPT_PATTERN in stderr
+        assert FIRST_CHECK_FAILED_PATTERN in stdout
+        assert PERMISSION_DENIED_PATTERN in stderr
 
     def test_unrecognized_option(self, test_type):
         code, stdout, stderr = self.run("needs" + test_type.capitalize(),
                                         b'e\na\n')
         assert code == 0
-        assert b'⚠️  Deno requests' in stderr
-        assert not b'First check failed' in stdout
-        assert not b'PermissionDenied: permission denied' in stderr
+        assert PROMPT_PATTERN in stderr
+        assert not FIRST_CHECK_FAILED_PATTERN in stdout
+        assert not PERMISSION_DENIED_PATTERN in stderr
         assert b'Unrecognized option' in stderr
 
     def test_no_prompt(self, test_type):
         code, stdout, stderr = self.run("needs" + test_type.capitalize(), b'',
                                         ["--no-prompt"])
         assert code == 1
-        assert not b'⚠️  Deno requests' in stderr
-        assert b'First check failed' in stdout
-        assert b'PermissionDenied: permission denied' in stderr
+        assert not PROMPT_PATTERN in stderr
+        assert FIRST_CHECK_FAILED_PATTERN in stdout
+        assert PERMISSION_DENIED_PATTERN in stderr
 
     def test_no_prompt_allow(self, test_type):
         code, stdout, stderr = self.run(
             "needs" + test_type.capitalize(), b'',
             ["--no-prompt", "--allow-" + test_type])
         assert code == 0
-        assert not b'⚠️  Deno requests' in stderr
-        assert not b'First check failed' in stdout
-        assert not b'PermissionDenied: permission denied' in stderr
+        assert not PROMPT_PATTERN in stderr
+        assert not FIRST_CHECK_FAILED_PATTERN in stdout
+        assert not PERMISSION_DENIED_PATTERN in stderr
 
 
 def permission_prompt_test(deno_exe):

--- a/tools/permission_prompt_test.py
+++ b/tools/permission_prompt_test.py
@@ -6,8 +6,9 @@ import pty
 import select
 import subprocess
 import sys
+import time
 
-from util import build_path, executable_suffix, green_ok
+from util import build_path, executable_suffix, green_ok, red_failed
 
 PERMISSIONS_PROMPT_TEST_TS = "tools/permission_prompt_test.ts"
 
@@ -15,7 +16,7 @@ PERMISSIONS_PROMPT_TEST_TS = "tools/permission_prompt_test.ts"
 # This function is copied from:
 # https://gist.github.com/hayd/4f46a68fc697ba8888a7b517a414583e
 # https://stackoverflow.com/q/52954248/1240268
-def tty_capture(cmd, bytes_input):
+def tty_capture(cmd, bytes_input, timeout=5):
     """Capture the output of cmd with bytes_input to stdin,
     with stdin, stdout and stderr as TTYs."""
     mo, so = pty.openpty()  # provide tty to enable line-buffering
@@ -23,21 +24,23 @@ def tty_capture(cmd, bytes_input):
     mi, si = pty.openpty()
     fdmap = {mo: 'stdout', me: 'stderr', mi: 'stdin'}
 
+    timeout_exact = time.time() + timeout
     p = subprocess.Popen(
         cmd, bufsize=1, stdin=si, stdout=so, stderr=se, close_fds=True)
     os.write(mi, bytes_input)
 
-    timeout = .04  # seconds
+    select_timeout = .04  #seconds
     res = {'stdout': b'', 'stderr': b''}
     while True:
-        ready, _, _ = select.select([mo, me], [], [], timeout)
+        ready, _, _ = select.select([mo, me], [], [], select_timeout)
         if ready:
             for fd in ready:
                 data = os.read(fd, 512)
                 if not data:
                     break
                 res[fdmap[fd]] += data
-        elif p.poll() is not None:  # select timed-out
+        elif p.poll() is not None or time.time(
+        ) > timeout_exact:  # select timed-out
             break  # p exited
     for fd in [si, so, se, mi, mo, me]:
         os.close(fd)  # can't do it sooner: it leads to errno.EIO error
@@ -45,10 +48,14 @@ def tty_capture(cmd, bytes_input):
     return p.returncode, res['stdout'], res['stderr']
 
 
-def wrap_test(test_method, test_name):
+def wrap_test(test_name, test_method, *argv):
     sys.stdout.write(test_name + " ... ")
-    test_method()
-    print green_ok()
+    try:
+        test_method(*argv)
+        print green_ok()
+    except AssertionError:
+        print red_failed()
+        raise
 
 
 class Prompt(object):
@@ -70,36 +77,21 @@ class Prompt(object):
     def test(self):
         for test_type in self.test_types:
             test_name_base = "test_" + test_type
-            sys.stdout.write(test_name_base + "_allow_flag" + " ... ")
-            self.test_allow_flag(test_type)
-            print green_ok()
-            sys.stdout.write(test_name_base + "_yes_yes" + " ... ")
-            self.test_yes_yes(test_type)
-            print green_ok()
-            sys.stdout.write(test_name_base + "_yes_no" + " ... ")
-            self.test_yes_no(test_type)
-            print green_ok()
-            sys.stdout.write(test_name_base + "_no_no" + " ... ")
-            self.test_no_no(test_type)
-            print green_ok()
-            sys.stdout.write(test_name_base + "_no_yes" + " ... ")
-            self.test_no_yes(test_type)
-            print green_ok()
-            sys.stdout.write(test_name_base + "_allow" + " ... ")
-            self.test_allow(test_type)
-            print green_ok()
-            sys.stdout.write(test_name_base + "_deny" + " ... ")
-            self.test_deny(test_type)
-            print green_ok()
-            sys.stdout.write(test_name_base + "_unrecognized_option" + " ... ")
-            self.test_unrecognized_option(test_type)
-            print green_ok()
-            sys.stdout.write(test_name_base + "_no_prompt" + " ... ")
-            self.test_no_prompt(test_type)
-            print green_ok()
-            sys.stdout.write(test_name_base + "_no_prompt_allow" + " ... ")
-            self.test_no_prompt_allow(test_type)
-            print green_ok()
+            wrap_test(test_name_base + "_allow_flag", self.test_allow_flag,
+                      test_type)
+            wrap_test(test_name_base + "_yes_yes", self.test_yes_yes,
+                      test_type)
+            wrap_test(test_name_base + "_yes_no", self.test_yes_no, test_type)
+            wrap_test(test_name_base + "_no_no", self.test_no_no, test_type)
+            wrap_test(test_name_base + "_no_yes", self.test_no_yes, test_type)
+            wrap_test(test_name_base + "_allow", self.test_allow, test_type)
+            wrap_test(test_name_base + "_deny", self.test_deny, test_type)
+            wrap_test(test_name_base + "_unrecognized_option",
+                      self.test_unrecognized_option, test_type)
+            wrap_test(test_name_base + "_no_prompt", self.test_no_prompt,
+                      test_type)
+            wrap_test(test_name_base + "_no_prompt_allow",
+                      self.test_no_prompt_allow, test_type)
 
     def test_allow_flag(self, test_type):
         code, stdout, stderr = self.run("needs" + test_type.capitalize(), b'',

--- a/tools/permission_prompt_test.py
+++ b/tools/permission_prompt_test.py
@@ -51,6 +51,7 @@ def tty_capture(cmd, bytes_input, timeout=5):
     p.wait()
     return p.returncode, res['stdout'], res['stderr']
 
+
 # Wraps a test in debug printouts
 # so we have visual indicator of what test failed
 def wrap_test(test_name, test_method, *argv):

--- a/tools/permission_prompt_test.py
+++ b/tools/permission_prompt_test.py
@@ -5,8 +5,9 @@ import os
 import pty
 import select
 import subprocess
+import sys
 
-from util import build_path, executable_suffix
+from util import build_path, executable_suffix, green_ok
 
 PERMISSIONS_PROMPT_TEST_TS = "tools/permission_prompt_test.ts"
 
@@ -44,6 +45,12 @@ def tty_capture(cmd, bytes_input):
     return p.returncode, res['stdout'], res['stderr']
 
 
+def wrap_test(test_method, test_name):
+    sys.stdout.write(test_name + " ... ")
+    test_method()
+    print green_ok()
+
+
 class Prompt(object):
     def __init__(self, deno_exe):
         self.deno_exe = deno_exe
@@ -78,6 +85,7 @@ class Prompt(object):
         self.run('needsWrite', b'', allow_write=True)
 
     def test_read_yes(self):
+        sys.stdout.write("test_read_yes ...")
         code, stdout, stderr = self.run('needsRead', b'y\n')
         assert code == 0
         assert stdout == b''
@@ -170,7 +178,7 @@ class Prompt(object):
         assert b'PermissionDenied: permission denied' in stderr
 
     def test_run_yes(self):
-        code, stdout, stderr = self.run('needsRun', b'y\n')
+        code, stdout, stderr = self.run('needsRun', b'a\n')
         assert code == 0
         assert stdout == b'hello'
         assert b'⚠️  Deno requests access to run' in stderr
@@ -195,30 +203,31 @@ class Prompt(object):
 
 def permission_prompt_test(deno_exe):
     p = Prompt(deno_exe)
-    p.warm_up()
-    p.test_read_yes()
-    p.test_read_arg()
-    p.test_read_no()
-    p.test_read_no_prompt()
-    p.test_write_yes()
-    p.test_write_arg()
-    p.test_write_no()
-    p.test_write_no_prompt()
-    p.test_env_yes()
-    p.test_env_arg()
-    p.test_env_no()
-    p.test_env_no_prompt()
-    p.test_net_yes()
-    p.test_net_arg()
-    p.test_net_no()
-    p.test_net_no_prompt()
-    p.test_run_yes()
-    p.test_run_arg()
-    p.test_run_no()
-    p.test_run_no_prompt()
+    wrap_test(p.warm_up, "warm_up")
+    wrap_test(p.test_read_yes, "read_yes")
+    wrap_test(p.test_read_arg, "read_arg")
+    wrap_test(p.test_read_no, "read_no")
+    wrap_test(p.test_read_no_prompt, "read_no_prompts")
+    wrap_test(p.test_write_yes, "write_yes")
+    wrap_test(p.test_write_arg, "write_arg")
+    wrap_test(p.test_write_no, "write_no")
+    wrap_test(p.test_write_no_prompt, "write_no_prompts")
+    wrap_test(p.test_env_yes, "env_yes")
+    wrap_test(p.test_env_arg, "env_arg")
+    wrap_test(p.test_env_no, "env_no")
+    wrap_test(p.test_env_no_prompt, "env_no_prompts")
+    wrap_test(p.test_net_yes, "net_yes")
+    wrap_test(p.test_net_arg, "net_arg")
+    wrap_test(p.test_net_no, "net_no")
+    wrap_test(p.test_net_no_prompt, "net_no_prompts")
+    wrap_test(p.test_run_yes, "run_yes")
+    wrap_test(p.test_run_arg, "run_arg")
+    wrap_test(p.test_run_no, "run_no")
+    wrap_test(p.test_run_no_prompt, "run_no_prompts")
 
 
 def main():
+    print "Permissions prompt tests"
     deno_exe = os.path.join(build_path(), "deno" + executable_suffix)
     permission_prompt_test(deno_exe)
 

--- a/tools/permission_prompt_test.ts
+++ b/tools/permission_prompt_test.ts
@@ -35,7 +35,7 @@ const test = {
     }
     listen("tcp", "127.0.0.1:4541");
   },
-  needsRun: async () => {
+  needsRun: () => {
     try {
       const process = run({
         args: [

--- a/tools/permission_prompt_test.ts
+++ b/tools/permission_prompt_test.ts
@@ -1,13 +1,15 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 const { args, listen, env, exit, makeTempDirSync, readFileSync, run } = Deno;
 
+const firstCheckFailedMessage = "First check failed";
+
 const name = args[1];
 const test = {
   needsRead: async () => {
     try {
       readFileSync("package.json");
     } catch (e) {
-      console.log("First check failed");
+      console.log(firstCheckFailedMessage);
     }
     readFileSync("package.json");
   },
@@ -15,7 +17,7 @@ const test = {
     try {
       makeTempDirSync();
     } catch (e) {
-      console.log("First check failed");
+      console.log(firstCheckFailedMessage);
     }
     makeTempDirSync();
   },
@@ -23,7 +25,7 @@ const test = {
     try {
       env().home;
     } catch (e) {
-      console.log("First check failed");
+      console.log(firstCheckFailedMessage);
     }
     env().home;
   },
@@ -31,7 +33,7 @@ const test = {
     try {
       listen("tcp", "127.0.0.1:4540");
     } catch (e) {
-      console.log("First check failed");
+      console.log(firstCheckFailedMessage);
     }
     listen("tcp", "127.0.0.1:4541");
   },
@@ -45,7 +47,7 @@ const test = {
         ]
       });
     } catch (e) {
-      console.log("First check failed");
+      console.log(firstCheckFailedMessage);
     }
     const process = run({
       args: [

--- a/tools/permission_prompt_test.ts
+++ b/tools/permission_prompt_test.ts
@@ -1,21 +1,52 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-const { args, listen, env, exit, makeTempDirSync, readFile, run } = Deno;
+const { args, listen, env, exit, makeTempDirSync, readFileSync, run } = Deno;
 
 const name = args[1];
 const test = {
-  needsRead: () => {
-    readFile("package.json");
+  needsRead: async () => {
+    try {
+      readFileSync("package.json");
+    } catch (e) {
+      console.log("First check failed");
+    }
+    readFileSync("package.json");
   },
   needsWrite: () => {
+    try {
+      makeTempDirSync();
+    } catch (e) {
+      console.log("First check failed");
+    }
     makeTempDirSync();
   },
   needsEnv: () => {
+    try {
+      env().home;
+    } catch (e) {
+      console.log("First check failed");
+    }
     env().home;
   },
   needsNet: () => {
-    listen("tcp", "127.0.0.1:4540");
+    try {
+      listen("tcp", "127.0.0.1:4540");
+    } catch (e) {
+      console.log("First check failed");
+    }
+    listen("tcp", "127.0.0.1:4541");
   },
   needsRun: async () => {
+    try {
+      const process = run({
+        args: [
+          "python",
+          "-c",
+          "import sys; sys.stdout.write('hello'); sys.stdout.flush()"
+        ]
+      });
+    } catch (e) {
+      console.log("First check failed");
+    }
     const process = run({
       args: [
         "python",
@@ -23,7 +54,6 @@ const test = {
         "import sys; sys.stdout.write('hello'); sys.stdout.flush()"
       ]
     });
-    await process.status();
   }
 }[name];
 


### PR DESCRIPTION
Added some new permissions prompt options, and gave better names to existing options. The existing options when you receive a permission prompt are: y for allow always(I thought this meant yes once for some time) and n for no once(give the program a permission denied error this time). This change adds two new options and renames the existing allow always option the new set of options are:

* a/A for allow always for this permission type
* y/Y for allow once
* n/N for deny once
* d/D for deny always for this permission type

It might also make sense to remove the revoke commands, since this solves the same problems in a way that doesn't conflict with `--no-prompt`. 