### PR TITLE
jsdoc style guide update

### DIFF
--- a/website/style_guide.md
+++ b/website/style_guide.md
@@ -231,7 +231,7 @@ For example:
 Do not document function arguments unless they are non-obvious of their intent
 (though if they are non-obvious intent, the API should be considered anyways).
 Therefore `@param` should generally not be used. If `@param` is used, it should
-not include the `type` as Typescript is already strong typed.
+not include the `type` as Typescript is already strongly typed.
 
 ```ts
 /**

--- a/website/style_guide.md
+++ b/website/style_guide.md
@@ -230,7 +230,15 @@ For example:
 
 Do not document function arguments unless they are non-obvious of their intent
 (though if they are non-obvious intent, the API should be considered anyways).
-Therefore `@param` should generally not be used.
+Therefore `@param` should generally not be used. If `@param` is used, it
+should not include the `type` as Typescript is already strong typed.
+
+```ts
+/**
+ * Function with non obvious param
+ * @param foo Description of non obvious parameter
+ */
+```
 
 Vertical spacing should be minimized whenever possible. Therefore single line
 comments should be written as:

--- a/website/style_guide.md
+++ b/website/style_guide.md
@@ -230,8 +230,8 @@ For example:
 
 Do not document function arguments unless they are non-obvious of their intent
 (though if they are non-obvious intent, the API should be considered anyways).
-Therefore `@param` should generally not be used. If `@param` is used, it
-should not include the `type` as Typescript is already strong typed.
+Therefore `@param` should generally not be used. If `@param` is used, it should
+not include the `type` as Typescript is already strong typed.
 
 ```ts
 /**


### PR DESCRIPTION
As discussed in https://github.com/denoland/deno_std/pull/271#discussion_r265366006

Jsdoc style guide is updated to tell people to not use the typing in the jsdoc param.

cc @kitsonk 