### PR TITLE
Fix the 2nd example in deno.land

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -108,7 +108,7 @@ href="https://github.com/denoland/deno_install/blob/master/install.ps1">https://
 
       <p>Or a more complex one:</p>
 
-      <pre><code class="typescript language-typescript">import { serve } from "https://deno.land/std@v0.2.10/http/server.ts";
+      <pre><code class="typescript language-typescript">import { serve } from "https://deno.land/std@v0.3.2/http/server.ts";
 const s = serve("0.0.0.0:8000");
 
 async function main() {


### PR DESCRIPTION
As reported in gitter, the 2nd example in https://deno.land/ doesn't work with the latest release of deno because of the removal of 'deno' builtin module. This PR updates deno_std's version in import path and fixes the above problem.
