### PR TITLE
Remove specific version of std

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -108,7 +108,7 @@ href="https://github.com/denoland/deno_install/blob/master/install.ps1">https://
 
       <p>Or a more complex one:</p>
 
-      <pre><code class="typescript language-typescript">import { serve } from "https://deno.land/std@v0.3.2/http/server.ts";
+      <pre><code class="typescript language-typescript">import { serve } from "https://deno.land/std/http/server.ts";
 const s = serve("0.0.0.0:8000");
 
 async function main() {


### PR DESCRIPTION
<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
Any reason to keep specific version number of `deno_std`?