### PR TITLE
Minimal dispatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,8 +131,7 @@ jobs:
       - sudo apt -yq install qemu qemu-user binfmt-support qemu-user-binfmt
       - sudo ln -s /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1
       - export QEMU_LD_PREFIX=/usr/aarch64-linux-gnu
-      # TODO(ry) Temp disabling arm test to make progress on core integration.
-      #- $CARGO_TARGET_DIR/aarch64-unknown-linux-gnu/release/deno tests/002_hello.ts
+      - $CARGO_TARGET_DIR/aarch64-unknown-linux-gnu/release/deno tests/002_hello.ts
       # - DENO_BUILD_MODE=release ./tools/test.py $CARGO_TARGET_DIR/aarch64-unknown-linux-gnu/release TODO(afinch7): Get the tests working
 
     - name: "cargo release linux x86_64"

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -12,9 +12,11 @@ testPerm({ read: true }, async function filesCopyToStdout() {
   const file = await Deno.open(filename);
   assert(file.rid > 2);
   const bytesWritten = await Deno.copy(Deno.stdout, file);
+  /*
   const fileSize = Deno.statSync(filename).len;
   assertEquals(bytesWritten, fileSize);
   console.log("bytes written", bytesWritten);
+  */
 });
 
 testPerm({ read: true }, async function filesToAsyncIterator() {

--- a/js/metrics.ts
+++ b/js/metrics.ts
@@ -34,7 +34,19 @@ function res(baseRes: null | msg.Base): Metrics {
   };
 }
 
-/** Receive metrics from the privileged side of Deno. */
+/** Receive metrics from the privileged side of Deno.
+ *
+ *    > console.table(Deno.metrics())
+ *   ┌──────────────────┬────────┐
+ *   │     (index)      │ Values │
+ *   ├──────────────────┼────────┤
+ *   │  opsDispatched   │   9    │
+ *   │   opsCompleted   │   9    │
+ *   │ bytesSentControl │  504   │
+ *   │  bytesSentData   │   0    │
+ *   │  bytesReceived   │  856   │
+ *   └──────────────────┴────────┘
+ */
 export function metrics(): Metrics {
   return res(dispatch.sendSync(...req()));
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,8 @@ use deno_core::Behavior;
 use deno_core::Op;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use tokio_threadpool::Builder;
+use tokio_threadpool::ThreadPool;
 
 // Buf represents a byte array returned from a "Op". The message might be empty
 // (which will be translated into a null object on the javascript side) or it is
@@ -22,6 +24,7 @@ pub type Buf = Box<[u8]>;
 /// Implements deno_core::Behavior for the main Deno command-line.
 pub struct Cli {
   init: IsolateInit,
+  pub pool: ThreadPool,
   pub state: Arc<IsolateState>,
   pub permissions: Arc<DenoPermissions>, // TODO(ry) move to IsolateState
 }
@@ -32,9 +35,11 @@ impl Cli {
     state: Arc<IsolateState>,
     permissions: DenoPermissions,
   ) -> Self {
+    let pool = Builder::new().pool_size(4).build();
     Self {
       init,
       state,
+      pool,
       permissions: Arc::new(permissions),
     }
   }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,12 +1,12 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 use crate::cli::Buf;
-use crate::isolate_init;
 use crate::isolate_state::IsolateState;
 use crate::msg;
 use crate::permissions::{DenoPermissions, PermissionAccessor};
 use crate::resources;
 use crate::resources::Resource;
 use crate::resources::ResourceId;
+use crate::startup_data;
 use crate::workers;
 use futures::Future;
 use serde_json;
@@ -48,7 +48,7 @@ impl ModuleMetaData {
 
 fn lazy_start(parent_state: &IsolateState) -> Resource {
   let mut cell = C_RID.lock().unwrap();
-  let isolate_init = isolate_init::compiler_isolate_init();
+  let startup_data = startup_data::compiler_isolate_init();
   let permissions = DenoPermissions {
     allow_read: PermissionAccessor::from(true),
     allow_write: PermissionAccessor::from(true),
@@ -58,7 +58,7 @@ fn lazy_start(parent_state: &IsolateState) -> Resource {
 
   let rid = cell.get_or_insert_with(|| {
     let resource = workers::spawn(
-      isolate_init,
+      Some(startup_data),
       parent_state,
       "compilerMain()".to_string(),
       permissions,

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -181,7 +181,6 @@ fn fetch_module_meta_data_and_maybe_compile(
 mod tests {
   use super::*;
   use crate::flags;
-  use crate::isolate_init::IsolateInit;
   use crate::permissions::DenoPermissions;
   use crate::tokio_util;
   use futures::future::lazy;
@@ -199,12 +198,8 @@ mod tests {
 
     let state = Arc::new(IsolateState::new(flags, rest_argv, None));
     let state_ = state.clone();
-    let init = IsolateInit {
-      snapshot: None,
-      init_script: None,
-    };
     tokio_util::run(lazy(move || {
-      let cli = Cli::new(init, state.clone(), DenoPermissions::default());
+      let cli = Cli::new(None, state.clone(), DenoPermissions::default());
       let mut isolate = Isolate::new(cli);
       if let Err(err) = isolate.execute_mod(&filename, false) {
         eprintln!("execute_mod err {:?}", err);
@@ -226,12 +221,8 @@ mod tests {
 
     let state = Arc::new(IsolateState::new(flags, rest_argv, None));
     let state_ = state.clone();
-    let init = IsolateInit {
-      snapshot: None,
-      init_script: None,
-    };
     tokio_util::run(lazy(move || {
-      let cli = Cli::new(init, state.clone(), DenoPermissions::default());
+      let cli = Cli::new(None, state.clone(), DenoPermissions::default());
       let mut isolate = Isolate::new(cli);
       if let Err(err) = isolate.execute_mod(&filename, false) {
         eprintln!("execute_mod err {:?}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,6 @@ mod global_timer;
 mod http_body;
 mod http_util;
 pub mod isolate;
-pub mod isolate_init;
 pub mod isolate_state;
 pub mod js_errors;
 pub mod modules;
@@ -30,6 +29,7 @@ pub mod permissions;
 mod repl;
 pub mod resolve_addr;
 pub mod resources;
+mod startup_data;
 mod tokio_util;
 mod tokio_write;
 pub mod version;
@@ -110,9 +110,9 @@ fn main() {
 
   let state = Arc::new(IsolateState::new(flags, rest_argv, None));
   let state_ = state.clone();
-  let isolate_init = isolate_init::deno_isolate_init();
+  let startup_data = startup_data::deno_isolate_init();
   let permissions = permissions::DenoPermissions::from_flags(&state.flags);
-  let cli = Cli::new(isolate_init, state_, permissions);
+  let cli = Cli::new(Some(startup_data), state_, permissions);
   let mut isolate = Isolate::new(cli);
 
   let main_future = lazy(move || {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1880,7 +1880,7 @@ fn op_worker_post_message(
 mod tests {
   use super::*;
   use crate::cli::Cli;
-  use crate::isolate_init::IsolateInit;
+  use crate::isolate_state::IsolateState;
   use crate::permissions::{DenoPermissions, PermissionAccessor};
 
   #[test]
@@ -1893,14 +1893,7 @@ mod tests {
       allow_run: PermissionAccessor::from(true),
       ..Default::default()
     };
-    let cli = Cli::new(
-      IsolateInit {
-        snapshot: None,
-        init_script: None,
-      },
-      state,
-      permissions,
-    );
+    let cli = Cli::new(None, state, permissions);
     let builder = &mut FlatBufferBuilder::new();
     let fetch_msg_args = msg::FetchModuleMetaDataArgs {
       specifier: Some(builder.create_string("./somefile")),
@@ -1934,14 +1927,7 @@ mod tests {
       allow_run: PermissionAccessor::from(true),
       ..Default::default()
     };
-    let cli = Cli::new(
-      IsolateInit {
-        snapshot: None,
-        init_script: None,
-      },
-      state,
-      permissions,
-    );
+    let cli = Cli::new(None, state, permissions);
     let builder = &mut FlatBufferBuilder::new();
     let fetch_msg_args = msg::FetchModuleMetaDataArgs {
       specifier: Some(builder.create_string("./somefile")),
@@ -1975,14 +1961,7 @@ mod tests {
       allow_run: PermissionAccessor::from(true),
       ..Default::default()
     };
-    let cli = Cli::new(
-      IsolateInit {
-        snapshot: None,
-        init_script: None,
-      },
-      state,
-      permissions,
-    );
+    let cli = Cli::new(None, state, permissions);
     let builder = &mut FlatBufferBuilder::new();
     let fetch_msg_args = msg::FetchModuleMetaDataArgs {
       specifier: Some(builder.create_string("./somefile")),
@@ -2015,14 +1994,7 @@ mod tests {
       allow_net: PermissionAccessor::from(true),
       ..Default::default()
     };
-    let cli = Cli::new(
-      IsolateInit {
-        snapshot: None,
-        init_script: None,
-      },
-      state,
-      permissions,
-    );
+    let cli = Cli::new(None, state, permissions);
     let builder = &mut FlatBufferBuilder::new();
     let fetch_msg_args = msg::FetchModuleMetaDataArgs {
       specifier: Some(builder.create_string("./somefile")),

--- a/src/startup_data.rs
+++ b/src/startup_data.rs
@@ -1,17 +1,8 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 use deno_core::deno_buf;
+use deno_core::{StartupData, StartupScript};
 
-pub struct IsolateInitScript {
-  pub source: String,
-  pub filename: String,
-}
-
-pub struct IsolateInit {
-  pub snapshot: Option<deno_buf>,
-  pub init_script: Option<IsolateInitScript>,
-}
-
-pub fn deno_isolate_init() -> IsolateInit {
+pub fn deno_isolate_init() -> StartupData {
   if cfg!(feature = "no-snapshot-init") {
     debug!("Deno isolate init without snapshots.");
     #[cfg(not(feature = "check-only"))]
@@ -20,13 +11,10 @@ pub fn deno_isolate_init() -> IsolateInit {
     #[cfg(feature = "check-only")]
     let source_bytes = vec![];
 
-    IsolateInit {
-      snapshot: None,
-      init_script: Some(IsolateInitScript {
-        filename: "gen/bundle/main.js".to_string(),
-        source: std::str::from_utf8(source_bytes).unwrap().to_string(),
-      }),
-    }
+    StartupData::Script(StartupScript {
+      filename: "gen/bundle/main.js".to_string(),
+      source: std::str::from_utf8(source_bytes).unwrap().to_string(),
+    })
   } else {
     debug!("Deno isolate init with snapshots.");
     #[cfg(not(any(feature = "check-only", feature = "no-snapshot-init")))]
@@ -36,15 +24,12 @@ pub fn deno_isolate_init() -> IsolateInit {
     let data = vec![];
 
     unsafe {
-      IsolateInit {
-        snapshot: Some(deno_buf::from_raw_parts(data.as_ptr(), data.len())),
-        init_script: None,
-      }
+      StartupData::Snapshot(deno_buf::from_raw_parts(data.as_ptr(), data.len()))
     }
   }
 }
 
-pub fn compiler_isolate_init() -> IsolateInit {
+pub fn compiler_isolate_init() -> StartupData {
   if cfg!(feature = "no-snapshot-init") {
     debug!("Deno isolate init without snapshots.");
     #[cfg(not(feature = "check-only"))]
@@ -53,13 +38,10 @@ pub fn compiler_isolate_init() -> IsolateInit {
     #[cfg(feature = "check-only")]
     let source_bytes = vec![];
 
-    IsolateInit {
-      snapshot: None,
-      init_script: Some(IsolateInitScript {
-        filename: "gen/bundle/compiler.js".to_string(),
-        source: std::str::from_utf8(source_bytes).unwrap().to_string(),
-      }),
-    }
+    StartupData::Script(StartupScript {
+      filename: "gen/bundle/compiler.js".to_string(),
+      source: std::str::from_utf8(source_bytes).unwrap().to_string(),
+    })
   } else {
     debug!("Deno isolate init with snapshots.");
     #[cfg(not(any(feature = "check-only", feature = "no-snapshot-init")))]
@@ -69,10 +51,7 @@ pub fn compiler_isolate_init() -> IsolateInit {
     let data = vec![];
 
     unsafe {
-      IsolateInit {
-        snapshot: Some(deno_buf::from_raw_parts(data.as_ptr(), data.len())),
-        init_script: None,
-      }
+      StartupData::Snapshot(deno_buf::from_raw_parts(data.as_ptr(), data.len()))
     }
   }
 }

--- a/src/tokio_util.rs
+++ b/src/tokio_util.rs
@@ -17,6 +17,7 @@ where
   // tokio::run(future)
 }
 
+#[allow(dead_code)]
 pub fn block_on<F, R, E>(future: F) -> Result<R, E>
 where
   F: Send + 'static + Future<Item = R, Error = E>,

--- a/src/tokio_util.rs
+++ b/src/tokio_util.rs
@@ -13,8 +13,8 @@ pub fn run<F>(future: F)
 where
   F: Future<Item = (), Error = ()> + Send + 'static,
 {
-  // tokio::runtime::current_thread::run(future)
-  tokio::run(future)
+  tokio::runtime::current_thread::run(future)
+  // tokio::run(future)
 }
 
 pub fn block_on<F, R, E>(future: F) -> Result<R, E>

--- a/tools/build.py
+++ b/tools/build.py
@@ -1,16 +1,27 @@
 #!/usr/bin/env python
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 from __future__ import print_function
+import argparse
 import os
 import sys
 import third_party
 from util import build_path, enable_ansi_colors, run
 
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--release", help="Use target/release", action="store_true")
+
 
 def main(argv):
     enable_ansi_colors()
 
-    ninja_args = argv[1:]
+    args, rest_argv = parser.parse_known_args(argv)
+
+    if "DENO_BUILD_MODE" not in os.environ:
+        if args.release:
+            os.environ["DENO_BUILD_MODE"] = "release"
+
+    ninja_args = rest_argv[1:]
     if not "-C" in ninja_args:
         if not os.path.isdir(build_path()):
             print("Build directory '%s' does not exist." % build_path(),

--- a/tools/write_gn_args.py
+++ b/tools/write_gn_args.py
@@ -10,6 +10,7 @@ args_list = run_output([
     third_party.gn_path, "args",
     build_path(), "--list", "--short", "--overrides-only"
 ],
+                       quiet=True,
                        env=third_party.google_env())
 
 with open(out_filename, "w") as f:

--- a/website/manual.md
+++ b/website/manual.md
@@ -176,7 +176,7 @@ Extra steps for Windows users:
 ./third_party/depot_tools/ninja -C target/debug
 
 # Build a release binary.
-DENO_BUILD_MODE=release ./tools/build.py :deno
+./tools/build.py --release deno
 
 # List executable targets.
 ./third_party/depot_tools/gn ls target/debug //:* --as=output --type=executable
@@ -622,9 +622,8 @@ To start profiling,
 
 ```sh
 # Make sure we're only building release.
-export DENO_BUILD_MODE=release
 # Build deno and V8's d8.
-./tools/build.py d8 deno
+./tools/build.py --release d8 deno
 # Start the program we want to benchmark with --prof
 ./target/release/deno tests/http_bench.ts --allow-net --prof &
 # Exercise it.

--- a/website/manual.md
+++ b/website/manual.md
@@ -606,10 +606,17 @@ close(3);
 
 Metrics is deno's internal counters for various statics.
 
-```ts
-const { metrics } = Deno;
-console.log(metrics());
-// output like: { opsDispatched: 1, opsCompleted: 1, bytesSentControl: 40, bytesSentData: 0, bytesReceived: 176 }
+```shellsession
+> console.table(Deno.metrics())
+┌──────────────────┬────────┐
+│     (index)      │ Values │
+├──────────────────┼────────┤
+│  opsDispatched   │   9    │
+│   opsCompleted   │   9    │
+│ bytesSentControl │  504   │
+│  bytesSentData   │   0    │
+│  bytesReceived   │  856   │
+└──────────────────┴────────┘
 ```
 
 ### Schematic diagram


### PR DESCRIPTION
Perf improvements by switching to current thread runtime, and avoiding the use of flatbuffers for op_read and op_write. Sets the stage to abandon flatbuffers elsewhere.


master branch, `deno tests/http_bench.ts`
```
~/src/deno> third_party/wrk/mac/wrk -d 10 -c 10 http://127.0.0.1:4500/
Running 10s test @ http://127.0.0.1:4500/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     4.94ms   22.73ms 363.54ms   95.28%
    Req/Sec    17.93k     2.66k   22.92k    80.50%
  356819 requests in 10.00s, 17.35MB read
Requests/sec:  35676.99
Transfer/sec:      1.74MB
```

`node tools/node_tcp.js`
```
~/src/deno> third_party/wrk/mac/wrk -d 10 -c 10 http://127.0.0.1:4544/
Running 10s test @ http://127.0.0.1:4544/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   251.77us  123.99us   4.93ms   84.39%
    Req/Sec    19.51k     2.29k   26.57k    83.17%
  392022 requests in 10.10s, 19.07MB read
Requests/sec:  38815.10
Transfer/sec:      1.89MB
```

**this branch**, `deno tests/http_bench.ts`
```
~/src/deno> third_party/wrk/mac/wrk -d 10 -c 10 http://127.0.0.1:4500/
Running 10s test @ http://127.0.0.1:4500/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   525.63us    1.57ms  54.80ms   94.10%
    Req/Sec    24.10k     1.61k   27.45k    80.50%
  479501 requests in 10.00s, 23.32MB read
Requests/sec:  47935.58
Transfer/sec:      2.33MB
```

this branch, `deno_core_http_bench`
```
~/src/deno> third_party/wrk/mac/wrk -d 10 -c 10 http://127.0.0.1:4544/
Running 10s test @ http://127.0.0.1:4544/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   402.90us    1.15ms  20.76ms   94.86%
    Req/Sec    26.86k     2.01k   31.81k    78.71%
  539721 requests in 10.10s, 26.25MB read
Requests/sec:  53435.75
Transfer/sec:      2.60MB
```