### PR TITLE
Improve pretty printing of objects

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -19,6 +19,10 @@ type ConsoleOptions = Partial<{
 // Default depth of logging nested objects
 const DEFAULT_MAX_DEPTH = 4;
 
+// Number of elements an object must have before it's displayed in appreviated
+// form.
+const OBJ_ABBREVIATE_SIZE = 5;
+
 // Char codes
 const CHAR_PERCENT = 37; /* % */
 const CHAR_LOWERCASE_S = 115; /* s */
@@ -272,7 +276,6 @@ function createRawObjectString(
   }
   ctx.add(value);
 
-  const entries: string[] = [];
   let baseString = "";
 
   const className = getClassInstanceName(value);
@@ -280,12 +283,19 @@ function createRawObjectString(
   if (className && className !== "Object" && className !== "anonymous") {
     shouldShowClassName = true;
   }
-
-  for (const key of Object.keys(value)) {
-    entries.push(
-      `${key}: ${stringifyWithQuotes(value[key], ctx, level + 1, maxLevel)}`
-    );
-  }
+  const keys = Object.keys(value);
+  const entries: string[] = keys.map(key => {
+    if (keys.length > OBJ_ABBREVIATE_SIZE) {
+      return key;
+    } else {
+      return `${key}: ${stringifyWithQuotes(
+        value[key],
+        ctx,
+        level + 1,
+        maxLevel
+      )}`;
+    }
+  });
 
   ctx.delete(value);
 

--- a/js/console.ts
+++ b/js/console.ts
@@ -23,6 +23,8 @@ const DEFAULT_MAX_DEPTH = 4;
 // form.
 const OBJ_ABBREVIATE_SIZE = 5;
 
+const STR_ABBREVIATE_SIZE = 100;
+
 // Char codes
 const CHAR_PERCENT = 37; /* % */
 const CHAR_LOWERCASE_S = 115; /* s */
@@ -151,7 +153,11 @@ function stringifyWithQuotes(
 ): string {
   switch (typeof value) {
     case "string":
-      return `"${value}"`;
+      const trunc =
+        value.length > STR_ABBREVIATE_SIZE
+          ? value.slice(0, STR_ABBREVIATE_SIZE) + "..."
+          : value;
+      return JSON.stringify(trunc);
     default:
       return stringify(value, ctx, level, maxLevel);
   }

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -31,6 +31,17 @@ test(function consoleTestStringifyComplexObjects() {
   assertEquals(stringify({ foo: "bar" }), `{ foo: "bar" }`);
 });
 
+test(function consoleTestStringifyLongStrings() {
+  const veryLongString = "a".repeat(200);
+  // If we stringify an object containing the long string, it gets abbreviated.
+  let actual = stringify({ veryLongString });
+  assert(actual.includes("..."));
+  assert(actual.length < 200);
+  // However if we stringify the string itself, we get it exactly.
+  actual = stringify(veryLongString);
+  assertEquals(actual, veryLongString);
+});
+
 test(function consoleTestStringifyCircular() {
   class Base {
     a = 1;

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -72,7 +72,7 @@ test(function consoleTestStringifyCircular() {
   };
 
   nestedObj.o = circularObj;
-  const nestedObjExpected = `{ num: 1, bool: true, str: "a", method: [Function: method], asyncMethod: [AsyncFunction: asyncMethod], generatorMethod: [GeneratorFunction: generatorMethod], un: undefined, nu: null, arrowFunc: [Function: arrowFunc], extendedClass: Extended { a: 1, b: 2 }, nFunc: [Function], extendedCstr: [Function: Extended], o: { num: 2, bool: false, str: "b", method: [Function: method], un: undefined, nu: null, nested: [Circular], emptyObj: {}, arr: [ 1, "s", false, null, [Circular] ], baseClass: Base { a: 1 } } }`;
+  const nestedObjExpected = `{ num, bool, str, method, asyncMethod, generatorMethod, un, nu, arrowFunc, extendedClass, nFunc, extendedCstr, o }`;
 
   assertEquals(stringify(1), "1");
   assertEquals(stringify(1n), "1n");
@@ -114,7 +114,7 @@ test(function consoleTestStringifyCircular() {
   assertEquals(stringify(JSON), "{}");
   assertEquals(
     stringify(console),
-    "Console { printFunc: [Function], log: [Function], debug: [Function], info: [Function], dir: [Function], warn: [Function], error: [Function], assert: [Function], count: [Function], countReset: [Function], table: [Function], time: [Function], timeLog: [Function], timeEnd: [Function], group: [Function], groupCollapsed: [Function], groupEnd: [Function], clear: [Function], indentLevel: 0, collapsedAt: null }"
+    "Console { printFunc, log, debug, info, dir, warn, error, assert, count, countReset, table, time, timeLog, timeEnd, group, groupCollapsed, groupEnd, clear, indentLevel, collapsedAt }"
   );
   // test inspect is working the same
   assertEquals(inspect(nestedObj), nestedObjExpected);


### PR DESCRIPTION
If an object has more than 5 elements, it is printed in abbeviated form
displaying only the keys. This is useful in the REPL when inspecting
large objects like the Deno namespace:

```shellsesssion
  > Deno
  { args, noColor, pid, env, exit, isTTY, execPath, chdir, cwd, File,
  open, stdin, stdout, stderr, read, write, seek, close, copy,
  toAsyncIterator, SeekMode, Buffer, readAll, mkdirSync, mkdir,
  makeTempDirSync, makeTempDir, chmodSync, chmod, removeSync, remove,
  renameSync, rename, readFileSync, readFile, readDirSync, readDir,
  copyFileSync, copyFile, readlinkSync, readlink, statSync, lstatSync,
  stat, lstat, symlinkSync, symlink, writeFileSync, writeFile, ErrorKind,
  DenoError, libdeno, permissions, revokePermission, truncateSync,
  truncate, connect, dial, listen, metrics, resources, run, Process,
  inspect, build, platform, version, Console, stringifyArgs,
  DomIterableMixin }
```

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
