### PR TITLE
Separate behavior for the compiler isolate

### DIFF
--- a/cli/cli_behavior.rs
+++ b/cli/cli_behavior.rs
@@ -2,10 +2,9 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
-use crate::errors::DenoResult;
 use crate::isolate_state::IsolateState;
+use crate::isolate_state::IsolateStateContainer;
 use crate::ops;
-use crate::permissions::DenoPermissions;
 use deno_core::deno_buf;
 use deno_core::deno_mod;
 use deno_core::Behavior;
@@ -15,52 +14,24 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 /// Implements deno_core::Behavior for the main Deno command-line.
-pub struct Cli {
+pub struct CliBehavior {
   startup_data: Option<StartupData>,
   pub state: Arc<IsolateState>,
-  pub permissions: Arc<DenoPermissions>, // TODO(ry) move to IsolateState
 }
 
-impl Cli {
+impl CliBehavior {
   pub fn new(
     startup_data: Option<StartupData>,
     state: Arc<IsolateState>,
-    permissions: DenoPermissions,
   ) -> Self {
     Self {
       startup_data,
       state,
-      permissions: Arc::new(permissions),
     }
-  }
-
-  #[inline]
-  pub fn check_read(&self, filename: &str) -> DenoResult<()> {
-    self.permissions.check_read(filename)
-  }
-
-  #[inline]
-  pub fn check_write(&self, filename: &str) -> DenoResult<()> {
-    self.permissions.check_write(filename)
-  }
-
-  #[inline]
-  pub fn check_env(&self) -> DenoResult<()> {
-    self.permissions.check_env()
-  }
-
-  #[inline]
-  pub fn check_net(&self, filename: &str) -> DenoResult<()> {
-    self.permissions.check_net(filename)
-  }
-
-  #[inline]
-  pub fn check_run(&self) -> DenoResult<()> {
-    self.permissions.check_run()
   }
 }
 
-impl Behavior for Cli {
+impl Behavior for CliBehavior {
   fn startup_data(&mut self) -> Option<StartupData> {
     self.startup_data.take()
   }
@@ -80,6 +51,18 @@ impl Behavior for Cli {
     control: &[u8],
     zero_copy: deno_buf,
   ) -> (bool, Box<Op>) {
-    ops::dispatch(self, control, zero_copy)
+    ops::dispatch_cli(self, control, zero_copy)
+  }
+}
+
+impl IsolateStateContainer for CliBehavior {
+  fn state(&self) -> Arc<IsolateState> {
+    self.state.clone()
+  }
+}
+
+impl IsolateStateContainer for &CliBehavior {
+  fn state(&self) -> Arc<IsolateState> {
+    self.state.clone()
   }
 }

--- a/cli/cli_behavior.rs
+++ b/cli/cli_behavior.rs
@@ -1,7 +1,4 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-#![allow(unused_variables)]
-#![allow(dead_code)]
-
 use crate::isolate_state::IsolateState;
 use crate::isolate_state::IsolateStateContainer;
 use crate::ops;

--- a/cli/compiler.rs
+++ b/cli/compiler.rs
@@ -1,20 +1,85 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 use crate::isolate_state::IsolateState;
+use crate::isolate_state::{IsolateStateContainer, WorkerChannels};
 use crate::msg;
-use crate::permissions::{DenoPermissions, PermissionAccessor};
+use crate::ops;
 use crate::resources;
 use crate::resources::Resource;
 use crate::resources::ResourceId;
 use crate::startup_data;
 use crate::workers;
+use crate::workers::WorkerBehavior;
+use deno_core::deno_buf;
+use deno_core::deno_mod;
+use deno_core::Behavior;
 use deno_core::Buf;
+use deno_core::Op;
+use deno_core::StartupData;
 use futures::Future;
 use serde_json;
 use std::str;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::sync::Mutex;
 
 lazy_static! {
   static ref C_RID: Mutex<Option<ResourceId>> = Mutex::new(None);
+}
+
+pub struct CompilerBehavior {
+  pub state: Arc<IsolateState>,
+}
+
+impl CompilerBehavior {
+  pub fn new(state: Arc<IsolateState>) -> Self {
+    Self { state }
+  }
+}
+
+impl Behavior for CompilerBehavior {
+  fn startup_data(&mut self) -> Option<StartupData> {
+    Some(startup_data::compiler_isolate_init())
+  }
+
+  fn resolve(&mut self, specifier: &str, referrer: deno_mod) -> deno_mod {
+    self
+      .state
+      .metrics
+      .resolve_count
+      .fetch_add(1, Ordering::Relaxed);
+    let mut modules = self.state.modules.lock().unwrap();
+    modules.resolve_cb(&self.state.dir, specifier, referrer)
+  }
+
+  fn dispatch(
+    &mut self,
+    control: &[u8],
+    zero_copy: deno_buf,
+  ) -> (bool, Box<Op>) {
+    ops::dispatch_compiler(self, control, zero_copy)
+  }
+}
+
+impl IsolateStateContainer for CompilerBehavior {
+  fn state(&self) -> Arc<IsolateState> {
+    self.state.clone()
+  }
+}
+
+impl IsolateStateContainer for &CompilerBehavior {
+  fn state(&self) -> Arc<IsolateState> {
+    self.state.clone()
+  }
+}
+
+impl WorkerBehavior for CompilerBehavior {
+  fn set_internal_channels(&mut self, worker_channels: WorkerChannels) {
+    self.state = Arc::new(IsolateState::new(
+      self.state.flags.clone(),
+      self.state.argv.clone(),
+      Some(worker_channels),
+    ));
+  }
 }
 
 // This corresponds to JS ModuleMetaData.
@@ -46,22 +111,16 @@ impl ModuleMetaData {
   }
 }
 
-fn lazy_start(parent_state: &IsolateState) -> Resource {
+fn lazy_start(parent_state: Arc<IsolateState>) -> Resource {
   let mut cell = C_RID.lock().unwrap();
-  let startup_data = startup_data::compiler_isolate_init();
-  let permissions = DenoPermissions {
-    allow_read: PermissionAccessor::from(true),
-    allow_write: PermissionAccessor::from(true),
-    allow_net: PermissionAccessor::from(true),
-    ..Default::default()
-  };
-
   let rid = cell.get_or_insert_with(|| {
     let resource = workers::spawn(
-      Some(startup_data),
-      parent_state,
+      CompilerBehavior::new(Arc::new(IsolateState::new(
+        parent_state.flags.clone(),
+        parent_state.argv.clone(),
+        None,
+      ))),
       "compilerMain()".to_string(),
-      permissions,
     );
     resource.rid
   });
@@ -78,7 +137,7 @@ fn req(specifier: &str, referrer: &str) -> Buf {
 }
 
 pub fn compile_sync(
-  parent_state: &IsolateState,
+  parent_state: Arc<IsolateState>,
   specifier: &str,
   referrer: &str,
   module_meta_data: &ModuleMetaData,
@@ -140,7 +199,12 @@ mod tests {
       maybe_source_map: None,
     };
 
-    out = compile_sync(&IsolateState::mock(), specifier, &referrer, &mut out);
+    out = compile_sync(
+      Arc::new(IsolateState::mock()),
+      specifier,
+      &referrer,
+      &mut out,
+    );
     assert!(
       out
         .maybe_output_code

--- a/cli/errors.rs
+++ b/cli/errors.rs
@@ -179,6 +179,10 @@ pub fn permission_denied() -> DenoError {
   )
 }
 
+pub fn op_not_implemented() -> DenoError {
+  new(ErrorKind::BadResource, String::from("op not implemented"))
+}
+
 #[derive(Debug)]
 pub enum RustOrJsError {
   Rust(DenoError),

--- a/cli/isolate_state.rs
+++ b/cli/isolate_state.rs
@@ -5,6 +5,7 @@ use crate::flags;
 use crate::global_timer::GlobalTimer;
 use crate::modules::Modules;
 use crate::permissions::DenoPermissions;
+use deno_core::deno_mod;
 use deno_core::Buf;
 use futures::sync::mpsc as async_mpsc;
 use std;
@@ -143,3 +144,16 @@ impl IsolateState {
 pub trait IsolateStateContainer {
   fn state(&self) -> Arc<IsolateState>;
 }
+
+/// Provides state_resolve function for IsolateStateContainer implementors
+pub trait IsolateStateModuleResolution: IsolateStateContainer {
+  fn state_resolve(&mut self, specifier: &str, referrer: deno_mod) -> deno_mod {
+    let state = self.state();
+    state.metrics.resolve_count.fetch_add(1, Ordering::Relaxed);
+    let mut modules = state.modules.lock().unwrap();
+    modules.resolve_cb(&state.dir, specifier, referrer)
+  }
+}
+
+// Auto implementation for all IsolateStateContainer implementors
+impl<T> IsolateStateModuleResolution for T where T: IsolateStateContainer {}

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -9,7 +9,7 @@ extern crate futures;
 extern crate serde_json;
 
 mod ansi;
-pub mod cli;
+pub mod cli_behavior;
 pub mod compiler;
 pub mod deno_dir;
 pub mod errors;
@@ -35,7 +35,7 @@ mod tokio_write;
 pub mod version;
 pub mod workers;
 
-use crate::cli::Cli;
+use crate::cli_behavior::CliBehavior;
 use crate::errors::RustOrJsError;
 use crate::isolate::Isolate;
 use crate::isolate_state::IsolateState;
@@ -111,8 +111,7 @@ fn main() {
   let state = Arc::new(IsolateState::new(flags, rest_argv, None));
   let state_ = state.clone();
   let startup_data = startup_data::deno_isolate_init();
-  let permissions = permissions::DenoPermissions::from_flags(&state.flags);
-  let cli = Cli::new(Some(startup_data), state_, permissions);
+  let cli = CliBehavior::new(Some(startup_data), state_);
   let mut isolate = Isolate::new(cli);
 
   let main_future = lazy(move || {

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -1,8 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 use atty;
 use crate::ansi;
-use crate::cli_behavior::CliBehavior;
-use crate::compiler::CompilerBehavior;
 use crate::errors;
 use crate::errors::{op_not_implemented, DenoError, DenoResult, ErrorKind};
 use crate::fs as deno_fs;
@@ -74,22 +72,6 @@ fn empty_buf() -> Buf {
 /// This functions invoked every time libdeno.send() is called.
 /// control corresponds to the first argument of libdeno.send().
 /// data corresponds to the second argument of libdeno.send().
-pub fn dispatch_cli(
-  cli: &CliBehavior,
-  control: &[u8],
-  zero_copy: deno_buf,
-) -> (bool, Box<Op>) {
-  dispatch_all(Box::new(cli), control, zero_copy, op_selector_std)
-}
-
-pub fn dispatch_compiler(
-  compiler: &CompilerBehavior,
-  control: &[u8],
-  zero_copy: deno_buf,
-) -> (bool, Box<Op>) {
-  dispatch_all(Box::new(compiler), control, zero_copy, op_selector_compiler)
-}
-
 pub fn dispatch_all(
   sc: Box<&IsolateStateContainer>,
   control: &[u8],

--- a/src/cli_behavior.rs
+++ b/src/cli_behavior.rs
@@ -1,0 +1,73 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+#![allow(unused_variables)]
+#![allow(dead_code)]
+
+use crate::isolate_state::IsolateStateContainer;
+use crate::isolate_state::IsolateState;
+use crate::ops;
+use deno_core::deno_buf;
+use deno_core::deno_mod;
+use deno_core::Behavior;
+use deno_core::Op;
+use deno_core::StartupData;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+// Buf represents a byte array returned from a "Op". The message might be empty
+// (which will be translated into a null object on the javascript side) or it is
+// a heap allocated opaque sequence of bytes.  Usually a flatbuffer message.
+pub type Buf = Box<[u8]>;
+
+/// Implements deno_core::Behavior for the main Deno command-line.
+pub struct CliBehavior {
+  startup_data: Option<StartupData>,
+  pub state: Arc<IsolateState>,
+}
+
+impl CliBehavior {
+  pub fn new(
+    startup_data: Option<StartupData>,
+    state: Arc<IsolateState>,
+  ) -> Self {
+    Self {
+      startup_data,
+      state,
+    }
+  }
+}
+
+impl Behavior for CliBehavior {
+  fn startup_data(&mut self) -> Option<StartupData> {
+    self.startup_data.take()
+  }
+
+  fn resolve(&mut self, specifier: &str, referrer: deno_mod) -> deno_mod {
+    self
+      .state
+      .metrics
+      .resolve_count
+      .fetch_add(1, Ordering::Relaxed);
+    let mut modules = self.state.modules.lock().unwrap();
+    modules.resolve_cb(&self.state.dir, specifier, referrer)
+  }
+
+  fn dispatch(
+    &mut self,
+    control: &[u8],
+    zero_copy: deno_buf,
+  ) -> (bool, Box<Op>) {
+    ops::dispatch_cli(self, control, zero_copy)
+  }
+}
+
+impl IsolateStateContainer for CliBehavior {
+  fn state(&self) -> Arc<IsolateState> {
+    self.state.clone()
+  }
+}
+
+impl IsolateStateContainer for &CliBehavior {
+  fn state(&self) -> Arc<IsolateState> {
+    self.state.clone()
+  }
+}


### PR DESCRIPTION
The primary goal was to create a separate `Behavior` implementation for the compiler isolate, so permissions could be moved back to `IsolateState`. It ended up turning into a ton of refactors and cleanups.