### PR TITLE
Allow terminating an Isolate from another thread.

### DIFF
--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -755,16 +755,16 @@ mod tests {
     });
 
     let t2 = std::thread::spawn(move || {
-      // run an infinte loop
+      // run an infinite loop
       let res = isolate.execute(
-        "infinte_loop.js",
+        "infinite_loop.js",
         r#"
           let i = 0;
           while (true) { i++; }
         "#,
       );
 
-      // execute() terminated which means terminate_execution() was successful.
+      // execute() terminated, which means terminate_execution() was successful.
       tx.send(true).ok();
 
       if let Err(e) = res {

--- a/core/libdeno.rs
+++ b/core/libdeno.rs
@@ -155,6 +155,7 @@ extern "C" {
     js_filename: *const c_char,
     js_source: *const c_char,
   );
+  pub fn deno_terminate_execution(i: *const isolate);
 
   // Modules
 

--- a/libdeno/exceptions.cc
+++ b/libdeno/exceptions.cc
@@ -174,6 +174,15 @@ std::string EncodeExceptionAsJSON(v8::Local<v8::Context> context,
 void HandleException(v8::Local<v8::Context> context,
                      v8::Local<v8::Value> exception) {
   v8::Isolate* isolate = context->GetIsolate();
+
+  // TerminateExecution was called
+  if (isolate->IsExecutionTerminating()) {
+    isolate->CancelTerminateExecution();
+
+    // exception is the null value
+    exception = v8::Exception::Error(v8_str("execution terminated"));
+  }
+
   DenoIsolate* d = DenoIsolate::FromIsolate(isolate);
   std::string json_str = EncodeExceptionAsJSON(context, exception);
   CHECK_NOT_NULL(d);

--- a/libdeno/exceptions.cc
+++ b/libdeno/exceptions.cc
@@ -177,10 +177,20 @@ void HandleException(v8::Local<v8::Context> context,
 
   // TerminateExecution was called
   if (isolate->IsExecutionTerminating()) {
+    // cancel exception termination so that the exception can be created
     isolate->CancelTerminateExecution();
 
-    // exception is the null value
-    exception = v8::Exception::Error(v8_str("execution terminated"));
+    // maybe make a new exception object
+    if (exception->IsNullOrUndefined()) {
+      exception = v8::Exception::Error(v8_str("execution terminated"));
+    }
+
+    // handle the exception as if it is a regular exception
+    HandleException(context, exception);
+
+    // re-enable exception termination
+    isolate->TerminateExecution();
+    return;
   }
 
   DenoIsolate* d = DenoIsolate::FromIsolate(isolate);
@@ -192,6 +202,13 @@ void HandleException(v8::Local<v8::Context> context,
 void HandleExceptionMessage(v8::Local<v8::Context> context,
                             v8::Local<v8::Message> message) {
   v8::Isolate* isolate = context->GetIsolate();
+
+  // TerminateExecution was called
+  if (isolate->IsExecutionTerminating()) {
+    HandleException(context, v8::Undefined(isolate));
+    return;
+  }
+
   DenoIsolate* d = DenoIsolate::FromIsolate(isolate);
   std::string json_str = EncodeMessageAsJSON(context, message);
   CHECK_NOT_NULL(d);


### PR DESCRIPTION
This allows users of deno core to forcefully terminate the execution of any script by calling `terminate_execution()` from a different thread. This is also an API required to implement the Web Worker `Worker.prototype.terminate()` function.

Note: I'm not entirely sure about calling the _thread safe_ isolate handle `SharedIsolate`.  (update: renamed to `IsolateHandle`)
