### PR TITLE
Fix http server example

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -108,7 +108,7 @@ href="https://github.com/denoland/deno_install/blob/master/install.ps1">https://
 
       <p>Or a more complex one:</p>
 
-      <pre><code class="typescript language-typescript">import { serve } from "https://deno.land/std@v0.3.2/http/server.ts";
+      <pre><code class="typescript language-typescript">import { serve } from "https://deno.land/std/http/server.ts";
 
 async function main() {
   const body = new TextEncoder().encode("Hello World\n");


### PR DESCRIPTION
(reopenning #1942 because it was badly rebased and closed, sorry)

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
The old http server code (used in the example on the website) is not working.
I ran into the following error:
```
Uncaught NotFound: Cannot resolve module "deno" from "/root/.deno/deps/https/deno.land/std@v0.2.10/http/server.ts"
    at DenoError (deno/js/errors.ts:22:5)
    at maybeError (deno/js/errors.ts:33:12)
    at maybeThrowError (deno/js/errors.ts:39:15)
    at sendSync (deno/js/dispatch.ts:75:5)
    at fetchModuleMetaData (deno/js/os.ts:80:19)
    at _resolveModule (deno/js/compiler.ts:249:38)
    at resolveModuleNames (deno/js/compiler.ts:479:35)
    at compilerHost.resolveModuleNames (deno/third_party/node_modules/typescript/lib/typescript.js:118650:138)
    at resolveModuleNamesWorker (deno/third_party/node_modules/typescript/lib/typescript.js:86767:127)
    at resolveModuleNamesReusingOldState (deno/third_party/node_modules/typescript/lib/typescript.js:87001:24)
```

Using the latest version, fixed the problem. I think it might be a good idea to keep it that way (always use latest version), or add this test into CI, somehow to pickup the example from the website and try to run it