### PR TITLE
Check `Event` constructor params

### DIFF
--- a/js/event.ts
+++ b/js/event.ts
@@ -31,6 +31,7 @@ export class Event implements domTypes.Event {
   private _path: domTypes.EventPath[] = [];
 
   constructor(type: string, eventInitDict: domTypes.EventInit = {}) {
+    requiredArguments("Event", arguments.length, 1);
     this._initializedFlag = true;
     eventAttributes.set(this, {
       type,

--- a/js/event.ts
+++ b/js/event.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import * as domTypes from "./dom_types";
-import { getPrivateValue } from "./util";
+import { getPrivateValue, requiredArguments } from "./util";
 
 // WeakMaps are recommended for private attributes (see MDN link below)
 // https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/Guides/Contributor_s_Guide/Private_Properties#Using_WeakMaps
@@ -32,6 +32,7 @@ export class Event implements domTypes.Event {
 
   constructor(type: string, eventInitDict: domTypes.EventInit = {}) {
     requiredArguments("Event", arguments.length, 1);
+    type = String(type);
     this._initializedFlag = true;
     eventAttributes.set(this, {
       type,

--- a/js/event_test.ts
+++ b/js/event_test.ts
@@ -68,3 +68,15 @@ test(function eventPreventDefaultSuccess() {
   cancelableEvent.preventDefault();
   assertEquals(cancelableEvent.defaultPrevented, true);
 });
+
+test(function eventInitializedWithNonStringType() {
+  const type = undefined;
+  const event = new Event(type);
+
+  assertEquals(event.isTrusted, false);
+  assertEquals(event.target, null);
+  assertEquals(event.currentTarget, null);
+  assertEquals(event.type, "undefined");
+  assertEquals(event.bubbles, false);
+  assertEquals(event.cancelable, false);
+});


### PR DESCRIPTION
fix 2 bugs:

1. `Event` requires at least 1 argument
2. Convert the parameter `type` to string

-----------

Chrome:

```ts
const event = new Event()
// TypeError: Failed to construct 'Event': 1 argument required, but only 0 present.
```

Firefox:

```ts
const event = new Event()
// TypeError: Event requires at least 1 argument, but only 0 were passed
```

Deno(Before fixed):

```ts
const event = new Event()
event.type === undefined
```

after fixed:

```ts
const event = new Event()
// TypeError: Event requires at least 1 argument, but only 0 present
```

---- 

Before fixed:

```ts
const event = new Event(null)
event.type === null  // true
```

After fixed:

```ts
const event = new Event(null)
event.type === null    // false
event.type === "null"  // true
```