### PR TITLE
Do not close file on invalid seek mode

### DIFF
--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -198,4 +198,10 @@ testPerm({ read: true }, async function seekMode() {
   assert(!!err);
   assertEquals(err.kind, Deno.ErrorKind.InvalidSeekMode);
   assertEquals(err.name, "InvalidSeekMode");
+
+  // We should still be able to read the file
+  // since it is still open.
+  let buf = new Uint8Array(1);
+  await file.read(buf); // "H"
+  assertEquals(new TextDecoder().decode(buf), "H");
 });


### PR DESCRIPTION
Since invalid seek mode generates errors that could be caught, we should not unexpectedly close the file. Previously we return too early before reinserting the resource back to the resource table on error, causing the file to be closed on dropping of the fd. 
