### PR TITLE
Event's `isTrusted` is a readonly attribute

### DIFF
--- a/js/event.ts
+++ b/js/event.ts
@@ -89,20 +89,6 @@ export class Event implements domTypes.Event {
     return getPrivateValue(this, eventAttributes, "isTrusted");
   }
 
-  set isTrusted(value) {
-    eventAttributes.set(this, {
-      type: this.type,
-      bubbles: this.bubbles,
-      cancelable: this.cancelable,
-      composed: this.composed,
-      currentTarget: this.currentTarget,
-      eventPhase: this.eventPhase,
-      isTrusted: value,
-      target: this.target,
-      timeStamp: this.timeStamp
-    });
-  }
-
   get target(): domTypes.EventTarget {
     return getPrivateValue(this, eventAttributes, "target");
   }


### PR DESCRIPTION
`Event`'s `isTrusted` is a readonly attribute.

ref https://dom.spec.whatwg.org/#interface-event

IDL:

```
[Unforgeable] readonly attribute boolean isTrusted;
```