### PR TITLE
Avoid search prototype chain

### DIFF
--- a/js/event_target.ts
+++ b/js/event_target.ts
@@ -14,7 +14,7 @@ export class EventTarget implements domTypes.EventTarget {
     listener: domTypes.EventListenerOrEventListenerObject | null,
     _options?: boolean | domTypes.AddEventListenerOptions
   ): void {
-    if (!(type in this.listeners)) {
+    if (!(this.listeners.hasOwnProperty(type))) {
       this.listeners[type] = [];
     }
     if (listener !== null) {
@@ -27,7 +27,7 @@ export class EventTarget implements domTypes.EventTarget {
     callback: domTypes.EventListenerOrEventListenerObject | null,
     _options?: domTypes.EventListenerOptions | boolean
   ): void {
-    if (type in this.listeners && callback !== null) {
+    if (this.listeners.hasOwnProperty(type) && callback !== null) {
       this.listeners[type] = this.listeners[type].filter(
         listener => listener !== callback
       );
@@ -35,7 +35,7 @@ export class EventTarget implements domTypes.EventTarget {
   }
 
   public dispatchEvent(event: domTypes.Event): boolean {
-    if (!(event.type in this.listeners)) {
+    if (!(this.listeners.hasOwnProperty(event.type))) {
       return true;
     }
     const stack = this.listeners[event.type].slice();

--- a/js/event_target.ts
+++ b/js/event_target.ts
@@ -14,7 +14,7 @@ export class EventTarget implements domTypes.EventTarget {
     listener: domTypes.EventListenerOrEventListenerObject | null,
     _options?: boolean | domTypes.AddEventListenerOptions
   ): void {
-    if (!(this.listeners.hasOwnProperty(type))) {
+    if (!this.listeners.hasOwnProperty(type)) {
       this.listeners[type] = [];
     }
     if (listener !== null) {
@@ -35,7 +35,7 @@ export class EventTarget implements domTypes.EventTarget {
   }
 
   public dispatchEvent(event: domTypes.Event): boolean {
-    if (!(this.listeners.hasOwnProperty(event.type))) {
+    if (!this.listeners.hasOwnProperty(event.type)) {
       return true;
     }
     const stack = this.listeners[event.type].slice();

--- a/js/event_target_test.ts
+++ b/js/event_target_test.ts
@@ -64,3 +64,26 @@ test(function removingNullEventListenerShouldSucceed() {
   assertEquals(document.removeEventListener("x", null, true), undefined);
   assertEquals(document.removeEventListener("x", null), undefined);
 });
+
+test(function constructedEventTargetUseObjectPrototype() {
+  const target = new EventTarget();
+  const event = new Event("toString", { bubbles: true, cancelable: false });
+  let callCount = 0;
+
+  function listener(e): void {
+    assertEquals(e, event);
+    ++callCount;
+  }
+
+  target.addEventListener("toString", listener);
+
+  target.dispatchEvent(event);
+  assertEquals(callCount, 1);
+
+  target.dispatchEvent(event);
+  assertEquals(callCount, 2);
+
+  target.removeEventListener("toString", listener);
+  target.dispatchEvent(event);
+  assertEquals(callCount, 2);
+});


### PR DESCRIPTION
The `in` operator returns `true` if the specified property in its **prototype chain**.

```shell
> target.addEventListener("toString",  listener)

Uncaught TypeError: this.listeners[type].push is not a function
    at addEventListener (deno/js/event_target.ts:21:28)
    at <unknown>:1:8
    at evaluate (deno/js/repl.ts:93:34)
    at replLoop (deno/js/repl.ts:151:13)
```