### PR TITLE
Remove deno_core_http_bench from core/Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,6 @@ dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,18 +8,9 @@ edition = "2018"
 [lib]
 path = "lib.rs"
 
-[[bin]]
-name = "deno_core_http_bench"
-path = "http_bench.rs"
-required-features = ["bin-dependencies"]
-
-[features]
-bin-dependencies = ["tokio"]
-
 [dependencies]
 futures = "0.1.25"
 lazy_static = "1.3.0"
 libc = "0.2.51"
 log = "0.4.6"
 serde_json = "1.0.39"
-tokio = { version = "0.1.18", optional = true }


### PR DESCRIPTION
So we don't have to have an optional tokio dependency. We build
deno_core_http_bench using GN anyway.

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
