### PR TITLE
[WIP] Web API: EventTarget

### DIFF
--- a/js/dom_types.ts
+++ b/js/dom_types.ts
@@ -41,9 +41,6 @@ type ReferrerPolicy =
   | "unsafe-url";
 export type BlobPart = BufferSource | Blob | string;
 export type FormDataEntryValue = DomFile | string;
-export type EventListenerOrEventListenerObject =
-  | EventListener
-  | EventListenerObject;
 
 export interface DomIterable<K, V> {
   keys(): IterableIterator<K>;
@@ -70,13 +67,13 @@ interface AbortSignalEventMap {
 export interface EventTarget {
   addEventListener(
     type: string,
-    listener: EventListenerOrEventListenerObject | null,
+    callback: EventListener | null,
     options?: boolean | AddEventListenerOptions
   ): void;
-  dispatchEvent(evt: Event): boolean;
+  dispatchEvent(event: Event): boolean;
   removeEventListener(
     type: string,
-    listener?: EventListenerOrEventListenerObject | null,
+    callback?: EventListener | null,
     options?: EventListenerOptions | boolean
   ): void;
 }
@@ -135,7 +132,9 @@ export interface URLSearchParams {
 }
 
 export interface EventListener {
-  (evt: Event): void;
+  handleEvent(event: Event): void;
+  readonly callback: EventListener | null;
+  readonly options: boolean | AddEventListenerOptions;
 }
 
 export interface EventInit {
@@ -167,11 +166,11 @@ export interface EventPath {
 
 export interface Event {
   readonly type: string;
-  readonly target: EventTarget | null;
-  readonly currentTarget: EventTarget | null;
+  target: EventTarget | null;
+  currentTarget: EventTarget | null;
   composedPath(): EventPath[];
 
-  readonly eventPhase: number;
+  eventPhase: number;
 
   stopPropagation(): void;
   stopImmediatePropagation(): void;
@@ -182,8 +181,16 @@ export interface Event {
   readonly defaultPrevented: boolean;
   readonly composed: boolean;
 
-  readonly isTrusted: boolean;
+  isTrusted: boolean;
   readonly timeStamp: Date;
+
+  dispatched: boolean;
+  readonly initialized: boolean;
+  inPassiveListener: boolean;
+  cancelBubble: boolean;
+  cancelBubbleImmediately: boolean;
+  path: EventPath[];
+  relatedTarget: EventTarget | null;
 }
 
 export interface CustomEvent extends Event {
@@ -215,12 +222,12 @@ interface ProgressEvent extends Event {
 }
 
 export interface EventListenerOptions {
-  capture?: boolean;
+  capture: boolean;
 }
 
 export interface AddEventListenerOptions extends EventListenerOptions {
-  once?: boolean;
-  passive?: boolean;
+  once: boolean;
+  passive: boolean;
 }
 
 interface AbortSignal extends EventTarget {
@@ -233,7 +240,7 @@ interface AbortSignal extends EventTarget {
   ): void;
   addEventListener(
     type: string,
-    listener: EventListenerOrEventListenerObject,
+    listener: EventListener,
     options?: boolean | AddEventListenerOptions
   ): void;
   removeEventListener<K extends keyof AbortSignalEventMap>(
@@ -243,7 +250,7 @@ interface AbortSignal extends EventTarget {
   ): void;
   removeEventListener(
     type: string,
-    listener: EventListenerOrEventListenerObject,
+    listener: EventListener,
     options?: boolean | EventListenerOptions
   ): void;
 }
@@ -252,10 +259,6 @@ export interface ReadableStream {
   readonly locked: boolean;
   cancel(): Promise<void>;
   getReader(): ReadableStreamReader;
-}
-
-export interface EventListenerObject {
-  handleEvent(evt: Event): void;
 }
 
 export interface ReadableStreamReader {

--- a/js/event.ts
+++ b/js/event.ts
@@ -21,7 +21,7 @@ export class EventInit implements domTypes.EventInit {
 export class Event implements domTypes.Event {
   // Each event has the following associated flags
   private _canceledFlag = false;
-  private dispatchedFlag = false;
+  private _dispatchedFlag = false;
   private _initializedFlag = false;
   private _inPassiveListenerFlag = false;
   private _stopImmediatePropagationFlag = false;
@@ -42,6 +42,7 @@ export class Event implements domTypes.Event {
       currentTarget: null,
       eventPhase: domTypes.EventPhase.NONE,
       isTrusted: false,
+      relatedTarget: null,
       target: null,
       timeStamp: Date.now()
     });
@@ -55,8 +56,16 @@ export class Event implements domTypes.Event {
     return this._stopPropagationFlag;
   }
 
+  set cancelBubble(value: boolean) {
+    this._stopPropagationFlag = value;
+  }
+
   get cancelBubbleImmediately(): boolean {
     return this._stopImmediatePropagationFlag;
+  }
+
+  set cancelBubbleImmediately(value: boolean) {
+    this._stopImmediatePropagationFlag = value;
   }
 
   get cancelable(): boolean {
@@ -71,28 +80,123 @@ export class Event implements domTypes.Event {
     return getPrivateValue(this, eventAttributes, "currentTarget");
   }
 
+  set currentTarget(value: domTypes.EventTarget) {
+    eventAttributes.set(this, {
+      type: this.type,
+      bubbles: this.bubbles,
+      cancelable: this.cancelable,
+      composed: this.composed,
+      currentTarget: value,
+      eventPhase: this.eventPhase,
+      isTrusted: this.isTrusted,
+      relatedTarget: this.relatedTarget,
+      target: this.target,
+      timeStamp: this.timeStamp
+    });
+  }
+
   get defaultPrevented(): boolean {
     return this._canceledFlag;
   }
 
   get dispatched(): boolean {
-    return this.dispatchedFlag;
+    return this._dispatchedFlag;
+  }
+
+  set dispatched(value: boolean) {
+    this._dispatchedFlag = value;
   }
 
   get eventPhase(): number {
     return getPrivateValue(this, eventAttributes, "eventPhase");
   }
 
+  set eventPhase(value: number) {
+    eventAttributes.set(this, {
+      type: this.type,
+      bubbles: this.bubbles,
+      cancelable: this.cancelable,
+      composed: this.composed,
+      currentTarget: this.currentTarget,
+      eventPhase: value,
+      isTrusted: this.isTrusted,
+      relatedTarget: this.relatedTarget,
+      target: this.target,
+      timeStamp: this.timeStamp
+    });
+  }
+
   get initialized(): boolean {
     return this._initializedFlag;
+  }
+
+  set inPassiveListener(value: boolean) {
+    this._inPassiveListenerFlag = value;
   }
 
   get isTrusted(): boolean {
     return getPrivateValue(this, eventAttributes, "isTrusted");
   }
 
+  set isTrusted(value: boolean) {
+    eventAttributes.set(this, {
+      type: this.type,
+      bubbles: this.bubbles,
+      cancelable: this.cancelable,
+      composed: this.composed,
+      currentTarget: this.currentTarget,
+      eventPhase: this.eventPhase,
+      isTrusted: value,
+      relatedTarget: this.relatedTarget,
+      target: this.target,
+      timeStamp: this.timeStamp
+    });
+  }
+
+  get path(): domTypes.EventPath[] {
+    return this._path;
+  }
+
+  set path(value: domTypes.EventPath[]) {
+    this._path = value;
+  }
+
+  get relatedTarget(): domTypes.EventTarget {
+    return getPrivateValue(this, eventAttributes, "relatedTarget");
+  }
+
+  set relatedTarget(value: domTypes.EventTarget) {
+    eventAttributes.set(this, {
+      type: this.type,
+      bubbles: this.bubbles,
+      cancelable: this.cancelable,
+      composed: this.composed,
+      currentTarget: this.currentTarget,
+      eventPhase: this.eventPhase,
+      isTrusted: this.isTrusted,
+      relatedTarget: value,
+      target: this.target,
+      timeStamp: this.timeStamp
+    });
+  }
+
   get target(): domTypes.EventTarget {
     return getPrivateValue(this, eventAttributes, "target");
+  }
+
+  set target(value: domTypes.EventTarget) {
+    eventAttributes.set(this, {
+      type: this.type,
+      bubbles: this.bubbles,
+      cancelable: this.cancelable,
+      composed: this.composed,
+      currentTarget: this.currentTarget,
+      eventPhase: this.eventPhase,
+      isTrusted: this.isTrusted,
+      relatedTarget: this.relatedTarget,
+      target: value,
+      timeStamp: this.timeStamp
+    });
   }
 
   get timeStamp(): Date {
@@ -257,6 +361,7 @@ Reflect.defineProperty(Event.prototype, "currentTarget", { enumerable: true });
 Reflect.defineProperty(Event.prototype, "defaultPrevented", {
   enumerable: true
 });
+Reflect.defineProperty(Event.prototype, "dispatched", { enumerable: true });
 Reflect.defineProperty(Event.prototype, "eventPhase", { enumerable: true });
 Reflect.defineProperty(Event.prototype, "isTrusted", { enumerable: true });
 Reflect.defineProperty(Event.prototype, "target", { enumerable: true });

--- a/js/event_target.ts
+++ b/js/event_target.ts
@@ -1,56 +1,611 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import * as domTypes from "./dom_types";
+import { DenoError, ErrorKind } from "./errors";
 import { requiredArguments } from "./util";
 
-/* TODO: This is an incomplete implementation to provide functionality
- * for Event. A proper spec is still required for a proper Web API.
- */
+export class EventListenerOptions implements domTypes.EventListenerOptions {
+  _capture = false;
+
+  constructor({ capture = false } = {}) {
+    this._capture = capture;
+  }
+
+  get capture(): boolean {
+    return this._capture;
+  }
+}
+
+export class AddEventListenerOptions extends EventListenerOptions
+  implements domTypes.AddEventListenerOptions {
+  _passive = false;
+  _once = false;
+
+  constructor({ capture = false, passive = false, once = false } = {}) {
+    super({ capture });
+    this._passive = passive;
+    this._once = once;
+  }
+
+  get passive(): boolean {
+    return this._passive;
+  }
+
+  get once(): boolean {
+    return this._once;
+  }
+}
+
+export class EventListener implements domTypes.EventListener {
+  allEvents: domTypes.Event[] = [];
+  atEvents: domTypes.Event[] = [];
+  bubbledEvents: domTypes.Event[] = [];
+  capturedEvents: domTypes.Event[] = [];
+
+  private _callback: domTypes.EventListener | null = null;
+  private _options: boolean | domTypes.AddEventListenerOptions = false;
+
+  public handleEvent(event: domTypes.Event): void {
+    this.allEvents.push(event);
+
+    switch (event.eventPhase) {
+      case domTypes.EventPhase.CAPTURING_PHASE:
+        this.capturedEvents.push(event);
+        break;
+      case domTypes.EventPhase.AT_TARGET:
+        this.atEvents.push(event);
+        break;
+      case domTypes.EventPhase.BUBBLING_PHASE:
+        this.bubbledEvents.push(event);
+        break;
+      default:
+        throw new Error("Unspecified event phase");
+    }
+  }
+
+  get callback(): domTypes.EventListener | null {
+    return this._callback;
+  }
+
+  get options(): boolean | domTypes.AddEventListenerOptions {
+    return this._options;
+  }
+}
+
 export class EventTarget implements domTypes.EventTarget {
-  public listeners: {
-    [type in string]: domTypes.EventListenerOrEventListenerObject[]
-  } = {};
+  public listeners: { [type in string]: domTypes.EventListener[] } = {};
+
+  private _hasActivationBehavior = false;
 
   public addEventListener(
     type: string,
-    listener: domTypes.EventListenerOrEventListenerObject | null,
-    _options?: boolean | domTypes.AddEventListenerOptions
+    callback: domTypes.EventListener | null,
+    options?: boolean | domTypes.AddEventListenerOptions
   ): void {
     requiredArguments("EventTarget.addEventListener", arguments.length, 2);
-    if (!this.listeners.hasOwnProperty(type)) {
+
+    options = this._normalizeEventHandlerOptions(options, [
+      "capture",
+      "once",
+      "passive"
+    ]);
+
+    if (callback === null) {
+      return;
+    }
+
+    if (!this.listeners[type]) {
       this.listeners[type] = [];
     }
-    if (listener !== null) {
-      this.listeners[type].push(listener);
+
+    for (let i = 0; i < this.listeners[type].length; ++i) {
+      const listener = this.listeners[type][i];
+      if (
+        listener.options.capture === options.capture &&
+        listener.callback === callback
+      ) {
+        return;
+      }
     }
+
+    this.listeners[type].push({ callback, options });
   }
 
   public removeEventListener(
     type: string,
-    callback: domTypes.EventListenerOrEventListenerObject | null,
-    _options?: domTypes.EventListenerOptions | boolean
+    callback: domTypes.EventListener | null,
+    options?: domTypes.EventListenerOptions | boolean
   ): void {
     requiredArguments("EventTarget.removeEventListener", arguments.length, 2);
-    if (this.listeners.hasOwnProperty(type) && callback !== null) {
-      this.listeners[type] = this.listeners[type].filter(
-        listener => listener !== callback
+
+    if (callback === undefined || callback === null) {
+      callback = null;
+    } else if (typeof callback !== "object" && typeof callback !== "function") {
+      throw new TypeError(
+        "Only undefined, null, an object, or a function are allowed for the callback parameter"
       );
+    }
+
+    options = this._normalizeEventHandlerOptions(options, ["capture"]);
+
+    if (callback === null) {
+      // Optimization, not in the spec.
+      return;
+    }
+
+    if (!this.listeners[type]) {
+      return;
+    }
+
+    for (let i = 0; i < this.listeners[type].length; ++i) {
+      const listener = this.listeners[type][i];
+      if (
+        listener.callback === callback &&
+        listener.options.capture === options.capture
+      ) {
+        this.listeners[type].splice(i, 1);
+        break;
+      }
     }
   }
 
   public dispatchEvent(event: domTypes.Event): boolean {
     requiredArguments("EventTarget.dispatchEvent", arguments.length, 1);
-    if (!this.listeners.hasOwnProperty(event.type)) {
-      return true;
-    }
-    const stack = this.listeners[event.type].slice();
 
-    for (const stackElement of stack) {
-      if ((stackElement as domTypes.EventListenerObject).handleEvent) {
-        (stackElement as domTypes.EventListenerObject).handleEvent(event);
-      } else {
-        (stackElement as domTypes.EventListener).call(this, event);
+    if (event.dispatched || !event.initialized) {
+      throw new DenoError(
+        ErrorKind.InvalidData,
+        "Tried to dispatch an uninitialized event"
+      );
+    }
+
+    if (event.eventPhase !== domTypes.EventPhase.NONE) {
+      throw new DenoError(
+        ErrorKind.InvalidData,
+        "Tried to dispatch a dispatching event"
+      );
+    }
+
+    event.isTrusted = false;
+
+    return this._dispatch(event);
+  }
+
+  // https://dom.spec.whatwg.org/#concept-event-dispatch
+  _dispatch(eventImpl: domTypes.Event, targetOverride?: domTypes.EventTarget) {
+    let targetImpl = this;
+    let clearTargets = false;
+    let activationTarget = null;
+
+    eventImpl.dispatched = true;
+
+    targetOverride = targetOverride || targetImpl;
+    let relatedTarget = retarget(eventImpl.relatedTarget, targetImpl);
+
+    if (
+      targetImpl !== relatedTarget ||
+      targetImpl === eventImpl.relatedTarget
+    ) {
+      const touchTargets: domTypes.EventTarget[] = [];
+
+      this._appendToEventPath(
+        eventImpl,
+        targetImpl,
+        targetOverride,
+        relatedTarget,
+        touchTargets,
+        false
+      );
+
+      const isActivationEvent = eventImpl.type === "click";
+
+      if (isActivationEvent && targetImpl._hasActivationBehavior) {
+        activationTarget = targetImpl;
+      }
+
+      let slotInClosedTree = false;
+      let slotable =
+        isSlotable(targetImpl) && targetImpl._assignedSlot ? targetImpl : null;
+      let parent = getEventTargetParent(targetImpl, eventImpl);
+
+      // Populate event path
+      // https://dom.spec.whatwg.org/#event-path
+      while (parent !== null) {
+        if (slotable !== null) {
+          if (parent.localName !== "slot") {
+            throw new Error("Internal Error: Expected parent to be a Slot");
+          }
+
+          slotable = null;
+
+          const parentRoot = getRoot(parent);
+          if (isShadowRoot(parentRoot) && parentRoot.mode === "closed") {
+            slotInClosedTree = true;
+          }
+        }
+
+        if (isSlotable(parent) && parent._assignedSlot) {
+          slotable = parent;
+        }
+
+        relatedTarget = retarget(eventImpl.relatedTarget, parent);
+
+        if (
+          (isNode(parent) &&
+            isShadowInclusiveAncestor(getRoot(targetImpl), parent)) ||
+          parent.constructor.name === "Window"
+        ) {
+          if (
+            isActivationEvent &&
+            eventImpl.bubbles &&
+            activationTarget === null &&
+            parent._hasActivationBehavior
+          ) {
+            activationTarget = parent;
+          }
+
+          this._appendToEventPath(
+            eventImpl,
+            parent,
+            null,
+            relatedTarget,
+            touchTargets,
+            slotInClosedTree
+          );
+        } else if (parent === relatedTarget) {
+          parent = null;
+        } else {
+          targetImpl = parent;
+
+          if (
+            isActivationEvent &&
+            activationTarget === null &&
+            targetImpl._hasActivationBehavior
+          ) {
+            activationTarget = targetImpl;
+          }
+
+          this._appendToEventPath(
+            eventImpl,
+            parent,
+            targetImpl,
+            relatedTarget,
+            touchTargets,
+            slotInClosedTree
+          );
+        }
+
+        if (parent !== null) {
+          parent = getEventTargetParent(parent, eventImpl);
+        }
+
+        slotInClosedTree = false;
+      }
+
+      let clearTargetsTupleIndex = -1;
+      for (
+        let i = eventImpl.path.length - 1;
+        i >= 0 && clearTargetsTupleIndex === -1;
+        i--
+      ) {
+        if (eventImpl.path[i].target !== null) {
+          clearTargetsTupleIndex = i;
+        }
+      }
+      const clearTargetsTuple = eventImpl.path[clearTargetsTupleIndex];
+
+      clearTargets =
+        (isNode(clearTargetsTuple.target) &&
+          isShadowRoot(getRoot(clearTargetsTuple.target))) ||
+        (isNode(clearTargetsTuple.relatedTarget) &&
+          isShadowRoot(getRoot(clearTargetsTuple.relatedTarget)));
+
+      eventImpl.eventPhase = domTypes.EventPhase.CAPTURING_PHASE;
+
+      if (
+        activationTarget !== null &&
+        activationTarget._legacyPreActivationBehavior
+      ) {
+        activationTarget._legacyPreActivationBehavior();
+      }
+
+      for (let i = eventImpl.path.length - 1; i >= 0; --i) {
+        const tuple = eventImpl.path[i];
+
+        if (tuple.target === null) {
+          this._invokeEventListeners(tuple, eventImpl);
+        }
+      }
+
+      for (let i = 0; i < eventImpl.path.length; i++) {
+        const tuple = eventImpl.path[i];
+
+        if (tuple.target !== null) {
+          eventImpl.eventPhase = domTypes.EventPhase.AT_TARGET;
+        } else {
+          eventImpl.eventPhase = domTypes.EventPhase.BUBBLING_PHASE;
+        }
+
+        if (
+          (eventImpl.eventPhase === domTypes.EventPhase.BUBBLING_PHASE &&
+            eventImpl.bubbles) ||
+          eventImpl.eventPhase === domTypes.EventPhase.AT_TARGET
+        ) {
+          this._invokeEventListeners(tuple, eventImpl);
+        }
       }
     }
-    return !event.defaultPrevented;
+
+    eventImpl.eventPhase = domTypes.EventPhase.NONE;
+
+    eventImpl.currentTarget = null;
+    eventImpl.path = [];
+    eventImpl.dispatched = false;
+    eventImpl.cancelBubble = false;
+    eventImpl.cancelBubbleImmediately = false;
+
+    if (clearTargets) {
+      eventImpl.target = null;
+      eventImpl.relatedTarget = null;
+    }
+
+    if (activationTarget !== null) {
+      if (!eventImpl.defaultPrevented) {
+        activationTarget._activationBehavior();
+      } else if (activationTarget._legacyCanceledActivationBehavior) {
+        activationTarget._legacyCanceledActivationBehavior();
+      }
+    }
+
+    return !eventImpl.defaultPrevented;
+  }
+
+  // https://dom.spec.whatwg.org/#concept-event-listener-invoke
+  _invokeEventListeners(
+    tuple: {
+      item: domTypes.EventTarget;
+      relatedTarget: domTypes.EventTarget;
+    },
+    eventImpl: domTypes.Event
+  ) {
+    const tupleIndex = eventImpl.path.indexOf(tuple);
+    for (let i = tupleIndex; i >= 0; i--) {
+      const t = eventImpl.path[i];
+      if (t.target) {
+        eventImpl.target = t.target;
+        break;
+      }
+    }
+
+    eventImpl.relatedTarget = tuple.relatedTarget;
+
+    if (eventImpl.cancelBubble) {
+      return;
+    }
+
+    eventImpl.currentTarget = tuple.item;
+
+    const listeners = tuple.item.listeners;
+    this._innerInvokeEventListeners(eventImpl, listeners);
+  }
+
+  // https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke
+  _innerInvokeEventListeners(
+    eventImpl: domTypes.Event,
+    listeners: { [type in string]: domTypes.EventListener[] }
+  ) {
+    let found = false;
+
+    const { type } = eventImpl;
+
+    if (!listeners || !listeners[type]) {
+      return found;
+    }
+
+    // Copy event listeners before iterating since the list can be modified during the iteration.
+    const handlers = listeners[type].slice();
+
+    for (let i = 0; i < handlers.length; i++) {
+      const listener = handlers[i];
+      const { capture, once, passive } = listener.options;
+
+      // Check if the event listener has been removed since the listeners has been cloned.
+      if (!listeners[type].includes(listener)) {
+        continue;
+      }
+
+      found = true;
+
+      if (
+        (eventImpl.eventPhase === domTypes.EventPhase.CAPTURING_PHASE &&
+          !capture) ||
+        (eventImpl.eventPhase === domTypes.EventPhase.BUBBLING_PHASE && capture)
+      ) {
+        continue;
+      }
+
+      if (once) {
+        listeners[type].splice(listeners[type].indexOf(listener), 1);
+      }
+
+      if (passive) {
+        eventImpl.inPassiveListener = true;
+      }
+
+      try {
+        if (typeof listener.callback === "object") {
+          if (typeof listener.callback.handleEvent === "function") {
+            listener.callback.handleEvent(eventImpl);
+          }
+        } else {
+          listener.callback.call(eventImpl.currentTarget, eventImpl);
+        }
+      } catch (error) {
+        throw new DenoError(ErrorKind.Interrupted, error.message);
+      }
+
+      eventImpl.inPassiveListener = false;
+
+      if (eventImpl.cancelBubbleImmediately) {
+        return found;
+      }
+    }
+
+    return found;
+  }
+
+  _normalizeEventHandlerOptions(
+    options: boolean | object | undefined,
+    defaultBoolKeys: string[]
+  ): domTypes.EventListenerOptions | domTypes.AddEventListenerOptions {
+    const returnValue:
+      | domTypes.EventListenerOptions
+      | domTypes.AddEventListenerOptions = {
+      capture: false,
+      passive: false,
+      once: false
+    };
+
+    if (
+      typeof options === "boolean" ||
+      options === null ||
+      typeof options === "undefined"
+    ) {
+      returnValue.capture = Boolean(options);
+      return returnValue;
+    }
+
+    if (typeof options !== "object") {
+      returnValue.capture = Boolean(options);
+      defaultBoolKeys = defaultBoolKeys.filter((k: string) => k !== "capture");
+    }
+
+    for (const key of defaultBoolKeys) {
+      returnValue[key] = Boolean(options[key]);
+    }
+
+    return returnValue;
+  }
+
+  // https://dom.spec.whatwg.org/#concept-event-path-append
+  _appendToEventPath(
+    eventImpl: domTypes.Event,
+    target: domTypes.EventTarget,
+    targetOverride: domTypes.EventTarget | null,
+    relatedTarget: domTypes.EventTarget,
+    touchTargets: domTypes.EventTarget[],
+    slotInClosedTree: boolean
+  ) {
+    const itemInShadowTree = isNode(target) && isShadowRoot(getRoot(target));
+    const rootOfClosedTree = isShadowRoot(target) && target.mode === "closed";
+
+    eventImpl.path.push({
+      item: target,
+      itemInShadowTree,
+      target: targetOverride,
+      relatedTarget,
+      touchTargetList: touchTargets,
+      rootOfClosedTree,
+      slotInClosedTree
+    });
   }
 }
+
+// https://dom.spec.whatwg.org/#node
+enum NODE_TYPE {
+  ELEMENT_NODE = 1,
+  TEXT_NODE = 3,
+  DOCUMENT_FRAGMENT_NODE = 11
+}
+
+function isNode(nodeImpl: domTypes.EventTarget | null) {
+  return Boolean(nodeImpl && "nodeType" in nodeImpl);
+}
+
+function isShadowRoot(nodeImpl: domTypes.EventTarget | null) {
+  return Boolean(
+    nodeImpl &&
+      nodeImpl.nodeType === NODE_TYPE.DOCUMENT_FRAGMENT_NODE &&
+      "host" in nodeImpl
+  );
+}
+
+function isSlotable(nodeImpl: domTypes.EventTarget | null) {
+  return (
+    nodeImpl &&
+    (nodeImpl.nodeType === NODE_TYPE.ELEMENT_NODE ||
+      nodeImpl.nodeType === NODE_TYPE.TEXT_NODE)
+  );
+}
+
+// https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor
+function isShadowInclusiveAncestor(
+  ancestor: domTypes.EventTarget,
+  node: domTypes.EventTarget
+) {
+  while (isNode(node)) {
+    if (node === ancestor) {
+      return true;
+    }
+
+    if (isShadowRoot(node)) {
+      node = node.host;
+    } else {
+      node = domSymbolTree.parent(node);
+    }
+  }
+
+  return false;
+}
+
+// https://dom.spec.whatwg.org/#retarget
+function retarget(a: domTypes.EventTarget | null, b: domTypes.EventTarget) {
+  while (true) {
+    if (!isNode(a)) {
+      return a;
+    }
+
+    const aRoot = getRoot(a);
+    if (
+      !isShadowRoot(aRoot) ||
+      (isNode(b) && isShadowInclusiveAncestor(aRoot, b))
+    ) {
+      return a;
+    }
+
+    a = getRoot(a).host;
+  }
+}
+
+// https://dom.spec.whatwg.org/#get-the-parent
+function getEventTargetParent(
+  eventTarget: domTypes.EventTarget,
+  event: domTypes.Event
+) {
+  return eventTarget._getTheParent ? eventTarget._getTheParent(event) : null;
+}
+
+function getRoot(node: domTypes.EventTarget | null) {
+  let root;
+
+  for (const ancestor of domSymbolTree.ancestorsIterator(node)) {
+    root = ancestor;
+  }
+
+  return root;
+}
+
+/** Built-in objects providing `get` methods for our
+ * interceptable JavaScript operations.
+ */
+Reflect.defineProperty(EventTarget.prototype, "listeners", {
+  enumerable: true
+});
+Reflect.defineProperty(EventTarget.prototype, "addEventListener", {
+  enumerable: true
+});
+Reflect.defineProperty(EventTarget.prototype, "removeEventListener", {
+  enumerable: true
+});
+Reflect.defineProperty(EventTarget.prototype, "dispatchEvent", {
+  enumerable: true
+});


### PR DESCRIPTION
This PR implements the [EventTarget](https://dom.spec.whatwg.org/#eventtarget) Web API spec.

I'm still stuck on this but wanted some initial eyes because I feel like a lot of the dispatching work that has to be done specifically relating to the Shadow DOM or `Window` seems unnecessary in the context of Deno. If I can make those assumptions that this stuff will always be a non-issue than this simplifies the implementation quite a bit.

@ztplz I know you were planning on working on an implementation of `EventTarget` would this be a good base for you to take over the line?