### PR TITLE
text_encoding web compatibility

### DIFF
--- a/js/text_encoding.ts
+++ b/js/text_encoding.ts
@@ -442,6 +442,9 @@ export class TextDecoder {
 
     return codePointsToString(output);
   }
+  get [Symbol.toStringTag]() {
+    return "TextDecoder";
+  }
 }
 
 export class TextEncoder {
@@ -466,5 +469,8 @@ export class TextEncoder {
     }
 
     return new Uint8Array(output);
+  }
+  get [Symbol.toStringTag]() {
+    return "TextEncoder";
   }
 }

--- a/js/text_encoding_test.ts
+++ b/js/text_encoding_test.ts
@@ -91,3 +91,11 @@ test(function textDecoderSharedInt32Array() {
   const actual = decoder.decode(i32);
   assertEquals(actual, "ABCDEFGH");
 });
+
+test(function toStringShouldBeWebCompatibility() {
+  const encoder = new TextEncoder();
+  assertEquals(encoder.toString(), "[object TextEncoder]");
+
+  const decoder = new TextDecoder();
+  assertEquals(decoder.toString(), "[object TextDecoder]");
+});


### PR DESCRIPTION
make `new TextDecoder().toString()` web compatibility

Chrome:

```ts
"[object TextDecoder]"
```

Firefox:

```ts
"[object TextDecoder]"
```

Safari:

```ts
"[object TextDecoder]"
```