### PR TITLE
fix console.log when error has been caught

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -4,8 +4,6 @@ import { TypedArray } from "./types";
 import { TextEncoder } from "./text_encoding";
 import { File, stdout } from "./files";
 import { cliTable } from "./console_table";
-import { formatError } from "./format_error";
-import { core } from "./core";
 
 type ConsoleContext = Set<unknown>;
 type ConsoleOptions = Partial<{
@@ -323,8 +321,7 @@ function createObjectString(
   ...args: [ConsoleContext, number, number]
 ): string {
   if (value instanceof Error) {
-    const errorJSON = core.errorToJSON(value);
-    return formatError(errorJSON);
+    return String(value.stack);
   } else if (Array.isArray(value)) {
     return createArrayString(value, ...args);
   } else if (value instanceof Number) {

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -254,7 +254,7 @@ test(function consoleTestError() {
   } catch (e) {
     assert(
       stringify(e)
-        .split("\n")[3]
+        .split("\n")[0]  // error has been caught
         .includes("MyError: This is an error")
     );
   }
@@ -581,5 +581,23 @@ test(function consoleTable() {
   mockConsole((console, out) => {
     console.table("test");
     assertEquals(out.toString(), "test\n");
+  });
+});
+
+// console.log(Error) test
+test(function consoleLogShouldNotThrowError() {
+  let result = 0;
+  try {
+    console.log(new Error("foo"));
+    result = 1;
+  } catch (e) {
+    result = 2;
+  }
+  assertEquals(result, 1);
+
+  // output errors to the console should not include "Uncaught"
+  mockConsole((console, out) => {
+    console.log(new Error("foo"));
+    assertEquals(out.toString().includes("Uncaught"), false);
   });
 });

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -254,7 +254,7 @@ test(function consoleTestError() {
   } catch (e) {
     assert(
       stringify(e)
-        .split("\n")[0]  // error has been caught
+        .split("\n")[0] // error has been caught
         .includes("MyError: This is an error")
     );
   }


### PR DESCRIPTION
If the error has been caught, just output Error's stackTrace.

code:

```ts
console.log(new Error('hello'))
```

current behavior:

```plain
<unknown>:1:12
console.log(new Error('hello'))
            ^
Uncaught Error: hello
    at <unknown>:1:13
    at evaluate (deno/js/repl.ts:93:34)
    at replLoop (deno/js/repl.ts:151:13)
```

after fixed:

```plain
Error: hello
    at <unknown>:1:13
    at evaluate (gen/bundle/main.js:9888:38)
    at replLoop (gen/bundle/main.js:9937:19)
```

-----

If the error is uncaught, still the current behavior.

```ts
throw new Error('hello')
```

output:

```plain
<unknown>:1:6
throw new Error('hello')
      ^
Uncaught Error: hello
    at <unknown>:1:7
    at evaluate (deno/js/repl.ts:93:34)
    at replLoop (deno/js/repl.ts:151:13)
```