### PR TITLE
web-compatibility console

### DIFF
--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -10,6 +10,16 @@ function stringify(...args: unknown[]): string {
   return stringifyArgs(args).replace(/\n$/, "");
 }
 
+// test cases from web-platform-tests
+// via https://github.com/web-platform-tests/wpt/blob/master/console/console-is-a-namespace.any.js
+test(function consoleShouldBeANamespace() {
+  const prototype1 = Object.getPrototypeOf(console);
+  const prototype2 = Object.getPrototypeOf(prototype1);
+
+  assertEquals(Object.getOwnPropertyNames(prototype1).length, 0);
+  assertEquals(prototype2, Object.prototype);
+});
+
 test(function consoleTestAssertShouldNotThrowError() {
   console.assert(true);
 
@@ -123,7 +133,7 @@ test(function consoleTestStringifyCircular() {
   assertEquals(stringify(JSON), "{}");
   assertEquals(
     stringify(console),
-    "Console { printFunc, log, debug, info, dir, warn, error, assert, count, countReset, table, time, timeLog, timeEnd, group, groupCollapsed, groupEnd, clear, indentLevel, collapsedAt }"
+    "{ printFunc, log, debug, info, dir, warn, error, assert, count, countReset, table, time, timeLog, timeEnd, group, groupCollapsed, groupEnd, clear, indentLevel, collapsedAt }"
   );
   // test inspect is working the same
   assertEquals(inspect(nestedObj), nestedObjExpected);

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -46,13 +46,20 @@ window.window = window;
 window.Deno = deno;
 Object.freeze(window.Deno);
 
+// ref https://console.spec.whatwg.org/#console-namespace
+// For historical web-compatibility reasons, the namespace object for
+// console must have as its [[Prototype]] an empty object, created as if
+// by ObjectCreate(%ObjectPrototype%), instead of %ObjectPrototype%.
+let console = Object.create({}) as consoleTypes.Console;
+Object.assign(console, new consoleTypes.Console(core.print));
+
 // Globally available functions and object instances.
 window.atob = textEncoding.atob;
 window.btoa = textEncoding.btoa;
 window.fetch = fetchTypes.fetch;
 window.clearTimeout = timers.clearTimer;
 window.clearInterval = timers.clearTimer;
-window.console = new consoleTypes.Console(core.print);
+window.console = console;
 window.setTimeout = timers.setTimeout;
 window.setInterval = timers.setInterval;
 window.location = (undefined as unknown) as domTypes.Location;


### PR DESCRIPTION
- spec https://console.spec.whatwg.org/#console-namespace
- wpt https://github.com/web-platform-tests/wpt/blob/master/console/console-is-a-namespace.any.js

> For historical web-compatibility reasons, the namespace object for `console` must have as its `[[Prototype]]` an empty object, created as if by `ObjectCreate(%ObjectPrototype%)`, instead of `%ObjectPrototype%`.
