### PR TITLE
Fix broken link to `src/msg.fbs` in `manual.html`

### DIFF
--- a/website/manual.md
+++ b/website/manual.md
@@ -50,7 +50,7 @@ Deno provides <a href="https://github.com/denoland/deno_std">a set of reviewed
 - File system and network access can be controlled in order to run sandboxed
   code. Access between V8 (unprivileged) and Rust (privileged) is only done via
   serialized messages defined in this
-  [flatbuffer](https://github.com/denoland/deno/blob/master/src/msg.fbs). This
+  [flatbuffer](https://github.com/denoland/deno/blob/master/cli/msg.fbs). This
   makes it easy to audit. For example, to enable write access use the flag
   `--allow-write` or for network access `--allow-net`.
 


### PR DESCRIPTION
This fixes a broken link on `manual.html`, see diff.