### PR TITLE
Snapshot improvements

### DIFF
--- a/cli/cli_behavior.rs
+++ b/cli/cli_behavior.rs
@@ -4,24 +4,16 @@ use crate::ops;
 use deno::deno_buf;
 use deno::Behavior;
 use deno::Op;
-use deno::StartupData;
 use std::sync::Arc;
 
 /// Implements deno::Behavior for the main Deno command-line.
 pub struct CliBehavior {
-  startup_data: Option<StartupData>,
   pub state: Arc<IsolateState>,
 }
 
 impl CliBehavior {
-  pub fn new(
-    startup_data: Option<StartupData>,
-    state: Arc<IsolateState>,
-  ) -> Self {
-    Self {
-      startup_data,
-      state,
-    }
+  pub fn new(state: Arc<IsolateState>) -> Self {
+    Self { state }
   }
 }
 
@@ -38,10 +30,6 @@ impl IsolateStateContainer for CliBehavior {
 }
 
 impl Behavior for CliBehavior {
-  fn startup_data(&mut self) -> Option<StartupData> {
-    self.startup_data.take()
-  }
-
   fn dispatch(
     &mut self,
     control: &[u8],

--- a/cli/compiler.rs
+++ b/cli/compiler.rs
@@ -143,7 +143,7 @@ fn lazy_start(parent_state: Arc<IsolateState>) -> ResourceId {
   cell
     .get_or_insert_with(|| {
       let worker_result = workers::spawn(
-        Some(startup_data::compiler_isolate_init()),
+        startup_data::compiler_isolate_init(),
         CompilerBehavior::new(
           parent_state.flags.clone(),
           parent_state.argv.clone(),

--- a/cli/compiler.rs
+++ b/cli/compiler.rs
@@ -17,7 +17,6 @@ use deno::Behavior;
 use deno::Buf;
 use deno::JSError;
 use deno::Op;
-use deno::StartupData;
 use futures::future::*;
 use futures::sync::oneshot;
 use futures::Future;
@@ -70,10 +69,6 @@ impl IsolateStateContainer for &CompilerBehavior {
 }
 
 impl Behavior for CompilerBehavior {
-  fn startup_data(&mut self) -> Option<StartupData> {
-    Some(startup_data::compiler_isolate_init())
-  }
-
   fn dispatch(
     &mut self,
     control: &[u8],
@@ -148,6 +143,7 @@ fn lazy_start(parent_state: Arc<IsolateState>) -> ResourceId {
   cell
     .get_or_insert_with(|| {
       let worker_result = workers::spawn(
+        Some(startup_data::compiler_isolate_init()),
         CompilerBehavior::new(
           parent_state.flags.clone(),
           parent_state.argv.clone(),

--- a/cli/isolate.rs
+++ b/cli/isolate.rs
@@ -13,6 +13,7 @@ use deno;
 use deno::deno_mod;
 use deno::Behavior;
 use deno::JSError;
+use deno::StartupData;
 use futures::future::Either;
 use futures::Async;
 use futures::Future;
@@ -32,10 +33,10 @@ pub struct Isolate<B: Behavior> {
 }
 
 impl<B: DenoBehavior> Isolate<B> {
-  pub fn new(behavior: B) -> Isolate<B> {
+  pub fn new(startup_data: Option<StartupData>, behavior: B) -> Isolate<B> {
     let state = behavior.state().clone();
     Self {
-      inner: CoreIsolate::new(behavior),
+      inner: CoreIsolate::new(startup_data, behavior),
       state,
     }
   }
@@ -270,8 +271,8 @@ mod tests {
     let state = Arc::new(IsolateState::new(flags, rest_argv, None, false));
     let state_ = state.clone();
     tokio_util::run(lazy(move || {
-      let cli = CliBehavior::new(None, state.clone());
-      let mut isolate = Isolate::new(cli);
+      let cli = CliBehavior::new(state.clone());
+      let mut isolate = Isolate::new(None, cli);
       if let Err(err) = isolate.execute_mod(&filename, false) {
         eprintln!("execute_mod err {:?}", err);
       }
@@ -293,8 +294,8 @@ mod tests {
     let state = Arc::new(IsolateState::new(flags, rest_argv, None, false));
     let state_ = state.clone();
     tokio_util::run(lazy(move || {
-      let cli = CliBehavior::new(None, state.clone());
-      let mut isolate = Isolate::new(cli);
+      let cli = CliBehavior::new(state.clone());
+      let mut isolate = Isolate::new(None, cli);
       if let Err(err) = isolate.execute_mod(&filename, false) {
         eprintln!("execute_mod err {:?}", err);
       }

--- a/cli/isolate.rs
+++ b/cli/isolate.rs
@@ -33,7 +33,7 @@ pub struct Isolate<B: Behavior> {
 }
 
 impl<B: DenoBehavior> Isolate<B> {
-  pub fn new(startup_data: Option<StartupData>, behavior: B) -> Isolate<B> {
+  pub fn new(startup_data: StartupData, behavior: B) -> Isolate<B> {
     let state = behavior.state().clone();
     Self {
       inner: CoreIsolate::new(startup_data, behavior),
@@ -272,7 +272,7 @@ mod tests {
     let state_ = state.clone();
     tokio_util::run(lazy(move || {
       let cli = CliBehavior::new(state.clone());
-      let mut isolate = Isolate::new(None, cli);
+      let mut isolate = Isolate::new(StartupData::None, cli);
       if let Err(err) = isolate.execute_mod(&filename, false) {
         eprintln!("execute_mod err {:?}", err);
       }
@@ -295,7 +295,7 @@ mod tests {
     let state_ = state.clone();
     tokio_util::run(lazy(move || {
       let cli = CliBehavior::new(state.clone());
-      let mut isolate = Isolate::new(None, cli);
+      let mut isolate = Isolate::new(StartupData::None, cli);
       if let Err(err) = isolate.execute_mod(&filename, false) {
         eprintln!("execute_mod err {:?}", err);
       }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -107,9 +107,8 @@ fn main() {
 
   let state = Arc::new(IsolateState::new(flags, rest_argv, None, false));
   let state_ = state.clone();
-  let startup_data = startup_data::deno_isolate_init();
   let cli = CliBehavior::new(state_);
-  let mut isolate = Isolate::new(Some(startup_data), cli);
+  let mut isolate = Isolate::new(startup_data::deno_isolate_init(), cli);
 
   let main_future = lazy(move || {
     // Setup runtime.

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -108,8 +108,8 @@ fn main() {
   let state = Arc::new(IsolateState::new(flags, rest_argv, None, false));
   let state_ = state.clone();
   let startup_data = startup_data::deno_isolate_init();
-  let cli = CliBehavior::new(Some(startup_data), state_);
-  let mut isolate = Isolate::new(cli);
+  let cli = CliBehavior::new(state_);
+  let mut isolate = Isolate::new(Some(startup_data), cli);
 
   let main_future = lazy(move || {
     // Setup runtime.

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -1843,7 +1843,7 @@ fn op_create_worker(
       parent_state.argv.clone(),
     );
     match workers::spawn(
-      Some(startup_data::deno_isolate_init()),
+      startup_data::deno_isolate_init(),
       behavior,
       &format!("USER-WORKER-{}", specifier),
       workers::WorkerInit::Module(specifier.to_string()),

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -15,6 +15,7 @@ use crate::resolve_addr::resolve_addr;
 use crate::resources;
 use crate::resources::table_entries;
 use crate::resources::Resource;
+use crate::startup_data;
 use crate::tokio_util;
 use crate::tokio_write;
 use crate::version;
@@ -1842,6 +1843,7 @@ fn op_create_worker(
       parent_state.argv.clone(),
     );
     match workers::spawn(
+      Some(startup_data::deno_isolate_init()),
       behavior,
       &format!("USER-WORKER-{}", specifier),
       workers::WorkerInit::Module(specifier.to_string()),

--- a/cli/startup_data.rs
+++ b/cli/startup_data.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use deno::deno_buf;
+use deno::deno_snapshot;
 use deno::{Script, StartupData};
 
 pub fn deno_isolate_init() -> StartupData {
@@ -24,7 +24,10 @@ pub fn deno_isolate_init() -> StartupData {
     let data = vec![];
 
     unsafe {
-      StartupData::Snapshot(deno_buf::from_raw_parts(data.as_ptr(), data.len()))
+      StartupData::Snapshot(deno_snapshot::from_raw_parts(
+        data.as_ptr(),
+        data.len(),
+      ))
     }
   }
 }
@@ -55,7 +58,10 @@ pub fn compiler_isolate_init() -> StartupData {
     let data = vec![];
 
     unsafe {
-      StartupData::Snapshot(deno_buf::from_raw_parts(data.as_ptr(), data.len()))
+      StartupData::Snapshot(deno_snapshot::from_raw_parts(
+        data.as_ptr(),
+        data.len(),
+      ))
     }
   }
 }

--- a/cli/startup_data.rs
+++ b/cli/startup_data.rs
@@ -1,8 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use deno::deno_snapshot;
 use deno::{Script, StartupData};
 
-pub fn deno_isolate_init() -> StartupData {
+pub fn deno_isolate_init() -> StartupData<'static> {
   if cfg!(feature = "no-snapshot-init") {
     debug!("Deno isolate init without snapshots.");
     #[cfg(not(feature = "check-only"))]
@@ -23,16 +22,11 @@ pub fn deno_isolate_init() -> StartupData {
     #[cfg(any(feature = "check-only", feature = "no-snapshot-init"))]
     let data = vec![];
 
-    unsafe {
-      StartupData::Snapshot(deno_snapshot::from_raw_parts(
-        data.as_ptr(),
-        data.len(),
-      ))
-    }
+    StartupData::Snapshot(data)
   }
 }
 
-pub fn compiler_isolate_init() -> StartupData {
+pub fn compiler_isolate_init() -> StartupData<'static> {
   if cfg!(feature = "no-snapshot-init") {
     debug!("Compiler isolate init without snapshots.");
     #[cfg(not(feature = "check-only"))]
@@ -57,11 +51,6 @@ pub fn compiler_isolate_init() -> StartupData {
     #[cfg(any(feature = "check-only", feature = "no-snapshot-init"))]
     let data = vec![];
 
-    unsafe {
-      StartupData::Snapshot(deno_snapshot::from_raw_parts(
-        data.as_ptr(),
-        data.len(),
-      ))
-    }
+    StartupData::Snapshot(data)
   }
 }

--- a/cli/startup_data.rs
+++ b/cli/startup_data.rs
@@ -11,8 +11,8 @@ pub fn deno_isolate_init() -> StartupData<'static> {
     let source_bytes = vec![];
 
     StartupData::Script(Script {
-      filename: "gen/cli/bundle/main.js".to_string(),
-      source: std::str::from_utf8(&source_bytes[..]).unwrap().to_string(),
+      filename: "gen/cli/bundle/main.js",
+      source: std::str::from_utf8(&source_bytes[..]).unwrap(),
     })
   } else {
     debug!("Deno isolate init with snapshots.");
@@ -38,8 +38,8 @@ pub fn compiler_isolate_init() -> StartupData<'static> {
     let source_bytes = vec![];
 
     StartupData::Script(Script {
-      filename: "gen/cli/bundle/compiler.js".to_string(),
-      source: std::str::from_utf8(&source_bytes[..]).unwrap().to_string(),
+      filename: "gen/cli/bundle/compiler.js",
+      source: std::str::from_utf8(&source_bytes[..]).unwrap(),
     })
   } else {
     debug!("Deno isolate init with snapshots.");

--- a/cli/workers.rs
+++ b/cli/workers.rs
@@ -78,7 +78,7 @@ pub struct Worker<B: WorkerBehavior> {
 }
 
 impl<B: WorkerBehavior> Worker<B> {
-  pub fn new(startup_data: Option<StartupData>, mut behavior: B) -> Self {
+  pub fn new(startup_data: StartupData, mut behavior: B) -> Self {
     let (worker_in_tx, worker_in_rx) = mpsc::channel::<Buf>(1);
     let (worker_out_tx, worker_out_rx) = mpsc::channel::<Buf>(1);
 
@@ -124,7 +124,7 @@ pub enum WorkerInit {
 }
 
 pub fn spawn<B: WorkerBehavior + 'static>(
-  startup_data: Option<StartupData>,
+  startup_data: StartupData,
   behavior: B,
   worker_debug_name: &str,
   init: WorkerInit,
@@ -177,7 +177,7 @@ mod tests {
   fn test_spawn() {
     tokio_util::init(|| {
       let worker_result = spawn(
-        Some(startup_data::compiler_isolate_init()),
+        startup_data::compiler_isolate_init(),
         CompilerBehavior::new(
           IsolateState::mock().flags.clone(),
           IsolateState::mock().argv.clone(),
@@ -240,7 +240,7 @@ mod tests {
   fn removed_from_resource_table_on_close() {
     tokio_util::init(|| {
       let worker_result = spawn(
-        Some(startup_data::compiler_isolate_init()),
+        startup_data::compiler_isolate_init(),
         CompilerBehavior::new(
           IsolateState::mock().flags.clone(),
           IsolateState::mock().argv.clone(),

--- a/core/http_bench.rs
+++ b/core/http_bench.rs
@@ -162,10 +162,10 @@ fn main() {
 
     let js_source = include_str!("http_bench.js");
 
-    let startup_data = Some(StartupData::Script(Script {
+    let startup_data = StartupData::Script(Script {
       source: js_source.to_string(),
       filename: "http_bench.js".to_string(),
-    }));
+    });
 
     let isolate = deno::Isolate::new(startup_data, HttpBench());
 

--- a/core/http_bench.rs
+++ b/core/http_bench.rs
@@ -99,15 +99,6 @@ pub type HttpBenchOp = dyn Future<Item = i32, Error = std::io::Error> + Send;
 struct HttpBench();
 
 impl Behavior for HttpBench {
-  fn startup_data(&mut self) -> Option<StartupData> {
-    let js_source = include_str!("http_bench.js");
-
-    Some(StartupData::Script(Script {
-      source: js_source.to_string(),
-      filename: "http_bench.js".to_string(),
-    }))
-  }
-
   fn dispatch(
     &mut self,
     control: &[u8],
@@ -168,7 +159,15 @@ fn main() {
     // TODO currently isolate.execute() must be run inside tokio, hence the
     // lazy(). It would be nice to not have that contraint. Probably requires
     // using v8::MicrotasksPolicy::kExplicit
-    let isolate = deno::Isolate::new(HttpBench());
+
+    let js_source = include_str!("http_bench.js");
+
+    let startup_data = Some(StartupData::Script(Script {
+      source: js_source.to_string(),
+      filename: "http_bench.js".to_string(),
+    }));
+
+    let isolate = deno::Isolate::new(startup_data, HttpBench());
 
     isolate.then(|r| {
       js_check(r);

--- a/core/http_bench.rs
+++ b/core/http_bench.rs
@@ -163,8 +163,8 @@ fn main() {
     let js_source = include_str!("http_bench.js");
 
     let startup_data = StartupData::Script(Script {
-      source: js_source.to_string(),
-      filename: "http_bench.js".to_string(),
+      source: js_source,
+      filename: "http_bench.js",
     });
 
     let isolate = deno::Isolate::new(startup_data, HttpBench());

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -8,6 +8,7 @@ use crate::js_errors::JSError;
 use crate::libdeno;
 use crate::libdeno::deno_buf;
 use crate::libdeno::deno_mod;
+use crate::libdeno::deno_snapshot;
 use crate::shared_queue::SharedQueue;
 use crate::shared_queue::RECOMMENDED_SIZE;
 use futures::Async;
@@ -58,7 +59,7 @@ pub struct Script {
 /// in the form of the StartupScript struct.
 pub enum StartupData {
   Script(Script),
-  Snapshot(deno_buf),
+  Snapshot(deno_snapshot),
 }
 
 /// Defines the behavior of an Isolate.
@@ -127,7 +128,7 @@ impl<B: Behavior> Isolate<B> {
       will_snapshot: 0,
       load_snapshot: match startup_snapshot {
         Some(s) => s,
-        None => libdeno::deno_buf::empty(),
+        None => libdeno::deno_snapshot::empty(),
       },
       shared: shared.as_deno_buf(),
       recv_cb: Self::pre_dispatch,

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -51,16 +51,16 @@ impl Future for PendingOp {
 }
 
 /// Stores a script used to initalize a Isolate
-pub struct Script {
-  pub source: String,
-  pub filename: String,
+pub struct Script<'a> {
+  pub source: &'a str,
+  pub filename: &'a str,
 }
 
 /// Represents data used to initialize isolate at startup
 /// either a binary snapshot or a javascript source file
 /// in the form of the StartupScript struct.
 pub enum StartupData<'a> {
-  Script(Script),
+  Script(Script<'a>),
   Snapshot(&'a [u8]),
   None,
 }
@@ -149,9 +149,7 @@ impl<B: Behavior> Isolate<B> {
 
     // If we want to use execute this has to happen here sadly.
     if let Some(s) = startup_script {
-      core_isolate
-        .execute(s.filename.as_str(), s.source.as_str())
-        .unwrap()
+      core_isolate.execute(s.filename, s.source).unwrap()
     };
 
     core_isolate

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -16,6 +16,7 @@ pub use crate::isolate::*;
 pub use crate::js_errors::*;
 pub use crate::libdeno::deno_buf;
 pub use crate::libdeno::deno_mod;
+pub use crate::libdeno::deno_snapshot;
 pub use crate::modules::*;
 
 pub fn v8_version() -> &'static str {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -16,7 +16,6 @@ pub use crate::isolate::*;
 pub use crate::js_errors::*;
 pub use crate::libdeno::deno_buf;
 pub use crate::libdeno::deno_mod;
-pub use crate::libdeno::deno_snapshot;
 pub use crate::modules::*;
 
 pub fn v8_version() -> &'static str {

--- a/core/libdeno.rs
+++ b/core/libdeno.rs
@@ -108,6 +108,34 @@ impl AsMut<[u8]> for deno_buf {
   }
 }
 
+#[repr(C)]
+pub struct deno_snapshot {
+  data_ptr: *const u8,
+  data_len: usize,
+}
+
+/// `deno_snapshot` can not clone, and there is no interior mutability.
+/// This type satisfies Send bound.
+unsafe impl Send for deno_snapshot {}
+
+impl deno_snapshot {
+  #[inline]
+  pub fn empty() -> Self {
+    Self {
+      data_ptr: null(),
+      data_len: 0,
+    }
+  }
+
+  #[inline]
+  pub unsafe fn from_raw_parts(ptr: *const u8, len: usize) -> Self {
+    Self {
+      data_ptr: ptr,
+      data_len: len,
+    }
+  }
+}
+
 #[allow(non_camel_case_types)]
 type deno_recv_cb = unsafe extern "C" fn(
   user_data: *mut c_void,
@@ -128,7 +156,7 @@ type deno_resolve_cb = unsafe extern "C" fn(
 #[repr(C)]
 pub struct deno_config {
   pub will_snapshot: c_int,
-  pub load_snapshot: deno_buf,
+  pub load_snapshot: deno_snapshot,
   pub shared: deno_buf,
   pub recv_cb: deno_recv_cb,
 }

--- a/core/libdeno.rs
+++ b/core/libdeno.rs
@@ -110,8 +110,8 @@ impl AsMut<[u8]> for deno_buf {
 
 #[repr(C)]
 pub struct deno_snapshot {
-  data_ptr: *const u8,
-  data_len: usize,
+  pub data_ptr: *const u8,
+  pub data_len: usize,
 }
 
 /// `deno_snapshot` can not clone, and there is no interior mutability.
@@ -133,6 +133,13 @@ impl deno_snapshot {
       data_ptr: ptr,
       data_len: len,
     }
+  }
+}
+
+// TODO Does this make sense?
+impl Drop for deno_snapshot {
+  fn drop(&mut self) {
+    unsafe { deno_snapshot_delete(self) }
   }
 }
 
@@ -242,4 +249,9 @@ extern "C" {
     user_data: *const c_void,
     id: deno_mod,
   );
+
+  pub fn deno_snapshot_new(i: *const isolate) -> deno_snapshot;
+
+  #[allow(dead_code)]
+  pub fn deno_snapshot_delete(s: &mut deno_snapshot);
 }

--- a/core/libdeno.rs
+++ b/core/libdeno.rs
@@ -120,6 +120,9 @@ pub struct deno_snapshot<'a> {
 /// This type satisfies Send bound.
 unsafe impl Send for deno_snapshot<'_> {}
 
+// TODO(ry) Snapshot1 and Snapshot2 are not very good names and need to be
+// reconsidered. The entire snapshotting interface is still under construction.
+
 /// The type returned from deno_snapshot_new. Needs to be dropped.
 pub type Snapshot1<'a> = deno_snapshot<'a>;
 

--- a/core/libdeno/api.cc
+++ b/core/libdeno/api.cc
@@ -93,7 +93,7 @@ void deno_unlock(Deno* d_) {
   d->locker_ = nullptr;
 }
 
-deno_snapshot deno_get_snapshot(Deno* d_) {
+deno_snapshot deno_snapshot_new(Deno* d_) {
   auto* d = unwrap(d_);
   CHECK_NOT_NULL(d->snapshot_creator_);
   d->ClearModules();

--- a/core/libdeno/api.cc
+++ b/core/libdeno/api.cc
@@ -93,7 +93,7 @@ void deno_unlock(Deno* d_) {
   d->locker_ = nullptr;
 }
 
-deno_buf deno_get_snapshot(Deno* d_) {
+deno_snapshot deno_get_snapshot(Deno* d_) {
   auto* d = unwrap(d_);
   CHECK_NOT_NULL(d->snapshot_creator_);
   d->ClearModules();
@@ -101,8 +101,12 @@ deno_buf deno_get_snapshot(Deno* d_) {
 
   auto blob = d->snapshot_creator_->CreateBlob(
       v8::SnapshotCreator::FunctionCodeHandling::kKeep);
-  return {nullptr, 0, reinterpret_cast<uint8_t*>(const_cast<char*>(blob.data)),
-          blob.raw_size, 0};
+  return {reinterpret_cast<uint8_t*>(const_cast<char*>(blob.data)),
+          blob.raw_size};
+}
+
+void deno_snapshot_delete(deno_snapshot snapshot) {
+  delete[] snapshot.data_ptr;
 }
 
 static std::unique_ptr<v8::Platform> platform;

--- a/core/libdeno/deno.h
+++ b/core/libdeno/deno.h
@@ -36,14 +36,14 @@ const char* deno_v8_version();
 void deno_set_v8_flags(int* argc, char** argv);
 
 typedef struct {
-  int will_snapshot;            // Default 0. If calling deno_get_snapshot 1.
+  int will_snapshot;            // Default 0. If calling deno_snapshot_new 1.
   deno_snapshot load_snapshot;  // A startup snapshot to use.
   deno_buf shared;              // Shared buffer to be mapped to libdeno.shared
   deno_recv_cb recv_cb;         // Maps to libdeno.send() calls.
 } deno_config;
 
 // Create a new deno isolate.
-// Warning: If config.will_snapshot is set, deno_get_snapshot() must be called
+// Warning: If config.will_snapshot is set, deno_snapshot_new() must be called
 // or an error will result.
 Deno* deno_new(deno_config config);
 void deno_delete(Deno* d);
@@ -53,9 +53,9 @@ void deno_delete(Deno* d);
 // When calling this function, the caller must have created the isolate "d" with
 // "will_snapshot" set to 1.
 // The caller must free the returned data with deno_snapshot_delete().
-deno_snapshot deno_get_snapshot(Deno* d);
+deno_snapshot deno_snapshot_new(Deno* d);
 
-// Only for use with data returned from deno_get_snapshot.
+// Only for use with data returned from deno_snapshot_new.
 void deno_snapshot_delete(deno_snapshot);
 
 void deno_lock(Deno* d);

--- a/core/libdeno/internal.h
+++ b/core/libdeno/internal.h
@@ -169,6 +169,7 @@ static intptr_t external_references[] = {
     0};
 
 static const deno_buf empty_buf = {nullptr, 0, nullptr, 0, 0};
+static const deno_snapshot empty_snapshot = {nullptr, 0};
 
 Deno* NewFromSnapshot(void* user_data, deno_recv_cb cb);
 

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -13,7 +13,7 @@ TEST(LibDenoTest, Snapshotter) {
   Deno* d1 = deno_new(deno_config{1, empty_snapshot, empty, nullptr});
   deno_execute(d1, nullptr, "a.js", "a = 1 + 2");
   EXPECT_EQ(nullptr, deno_last_exception(d1));
-  deno_snapshot test_snapshot = deno_get_snapshot(d1);
+  deno_snapshot test_snapshot = deno_snapshot_new(d1);
   deno_delete(d1);
 
   Deno* d2 = deno_new(deno_config{0, test_snapshot, empty, nullptr});

--- a/core/libdeno/modules_test.cc
+++ b/core/libdeno/modules_test.cc
@@ -13,7 +13,7 @@ void recv_cb(void* user_data, deno_buf buf, deno_buf zero_copy_buf) {
 
 TEST(ModulesTest, Resolution) {
   exec_count = 0;  // Reset
-  Deno* d = deno_new(deno_config{0, empty, empty, recv_cb});
+  Deno* d = deno_new(deno_config{0, empty_snapshot, empty, recv_cb});
   EXPECT_EQ(0, exec_count);
 
   static deno_mod a = deno_mod_new(d, true, "a.js",
@@ -66,7 +66,7 @@ TEST(ModulesTest, Resolution) {
 
 TEST(ModulesTest, ResolutionError) {
   exec_count = 0;  // Reset
-  Deno* d = deno_new(deno_config{0, empty, empty, recv_cb});
+  Deno* d = deno_new(deno_config{0, empty_snapshot, empty, recv_cb});
   EXPECT_EQ(0, exec_count);
 
   static deno_mod a = deno_mod_new(d, true, "a.js",
@@ -99,7 +99,7 @@ TEST(ModulesTest, ResolutionError) {
 
 TEST(ModulesTest, ImportMetaUrl) {
   exec_count = 0;  // Reset
-  Deno* d = deno_new(deno_config{0, empty, empty, recv_cb});
+  Deno* d = deno_new(deno_config{0, empty_snapshot, empty, recv_cb});
   EXPECT_EQ(0, exec_count);
 
   static deno_mod a =
@@ -119,7 +119,7 @@ TEST(ModulesTest, ImportMetaUrl) {
 }
 
 TEST(ModulesTest, ImportMetaMain) {
-  Deno* d = deno_new(deno_config{0, empty, empty, recv_cb});
+  Deno* d = deno_new(deno_config{0, empty_snapshot, empty, recv_cb});
 
   const char* throw_not_main_src = "if (!import.meta.main) throw 'err'";
   static deno_mod throw_not_main =

--- a/core/libdeno/snapshot_creator.cc
+++ b/core/libdeno/snapshot_creator.cc
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  auto snapshot = deno_get_snapshot(d);
+  auto snapshot = deno_snapshot_new(d);
 
   std::ofstream file_(snapshot_out_bin, std::ios::binary);
   file_.write(reinterpret_cast<char*>(snapshot.data_ptr), snapshot.data_len);

--- a/core/libdeno/snapshot_creator.cc
+++ b/core/libdeno/snapshot_creator.cc
@@ -8,8 +8,6 @@
 #include "third_party/v8/include/v8.h"
 #include "third_party/v8/src/base/logging.h"
 
-namespace deno {}  // namespace deno
-
 int main(int argc, char** argv) {
   const char* snapshot_out_bin = argv[1];
   const char* js_fn = argv[2];
@@ -23,7 +21,7 @@ int main(int argc, char** argv) {
   CHECK(deno::ReadFileToString(js_fn, &js_source));
 
   deno_init();
-  deno_config config = {1, deno::empty_buf, deno::empty_buf, nullptr};
+  deno_config config = {1, deno::empty_snapshot, deno::empty_buf, nullptr};
   Deno* d = deno_new(config);
 
   deno_execute(d, nullptr, js_fn, js_source.c_str());
@@ -40,7 +38,7 @@ int main(int argc, char** argv) {
   file_.write(reinterpret_cast<char*>(snapshot.data_ptr), snapshot.data_len);
   file_.close();
 
-  delete[] snapshot.data_ptr;
+  deno_snapshot_delete(snapshot);
   deno_delete(d);
 
   return file_.bad();

--- a/core/libdeno/test.cc
+++ b/core/libdeno/test.cc
@@ -3,7 +3,7 @@
 #include <string>
 #include "file_util.h"
 
-deno_buf snapshot = {nullptr, 0, nullptr, 0, 0};
+deno_snapshot snapshot = {nullptr, 0};
 
 int main(int argc, char** argv) {
   // Locate the snapshot.

--- a/core/libdeno/test.h
+++ b/core/libdeno/test.h
@@ -5,7 +5,8 @@
 #include "deno.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-extern deno_buf snapshot;  // Loaded in libdeno/test.cc
+extern deno_snapshot snapshot;  // Loaded in libdeno/test.cc
 const deno_buf empty = {nullptr, 0, nullptr, 0, 0};
+const deno_snapshot empty_snapshot = {nullptr, 0};
 
 #endif  // TEST_H_


### PR DESCRIPTION
First pass at simplifying the snapshot interfaces

* Moves how snapshots are supplied to the Isolate. Previously they were given by Behavior::startup_data() but it was only called once at startup. It makes more sense (and simplifies Behavior) to pass it to the constructor of Isolate.
* Adds new libdeno type `deno_snapshot` instead of overloading `deno_buf`.
* Adds new libdeno method to delete snapshot `deno_snapshot_delete`
* Renames `deno_get_snapshot` to `deno_snapshot_new`
* Makes StartupData hold references to snapshots. This was implicit when it previously held a `deno_buf` but is made explicit now. Note that `include_bytes!()` returns a `&'static [u8]` and we want to avoid copying that.

