### PR TITLE
Add link/linkSync fs call for hardlinks

### DIFF
--- a/cli/BUILD.gn
+++ b/cli/BUILD.gn
@@ -72,6 +72,7 @@ ts_sources = [
   "../js/headers.ts",
   "../js/io.ts",
   "../js/lib.web_assembly.d.ts",
+  "../js/link.ts",
   "../js/location.ts",
   "../js/main.ts",
   "../js/make_temp_dir.ts",

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -21,6 +21,7 @@ union Any {
   GlobalTimerStop,
   IsTTY,
   IsTTYRes,
+  Link,
   Listen,
   ListenRes,
   MakeTempDir,
@@ -387,6 +388,11 @@ table ResourcesRes {
 }
 
 table Symlink {
+  oldname: string;
+  newname: string;
+}
+
+table Link {
   oldname: string;
   newname: string;
 }

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -53,6 +53,7 @@ export { readDirSync, readDir } from "./read_dir";
 export { copyFileSync, copyFile } from "./copy_file";
 export { readlinkSync, readlink } from "./read_link";
 export { statSync, lstatSync, stat, lstat } from "./stat";
+export { linkSync, link } from "./link";
 export { symlinkSync, symlink } from "./symlink";
 export { writeFileSync, writeFile, WriteFileOptions } from "./write_file";
 export { ErrorKind, DenoError } from "./errors";

--- a/js/link.ts
+++ b/js/link.ts
@@ -1,0 +1,31 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import * as msg from "gen/cli/msg_generated";
+import * as flatbuffers from "./flatbuffers";
+import * as dispatch from "./dispatch";
+
+function req(
+  oldname: string,
+  newname: string
+): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
+  const builder = flatbuffers.createBuilder();
+  const oldname_ = builder.createString(oldname);
+  const newname_ = builder.createString(newname);
+  const inner = msg.Link.createLink(builder, oldname_, newname_);
+  return [builder, msg.Any.Link, inner];
+}
+
+/** Synchronously creates `newname` as a hard link to `oldname`.
+ *
+ *       Deno.linkSync("old/name", "new/name");
+ */
+export function linkSync(oldname: string, newname: string): void {
+  dispatch.sendSync(...req(oldname, newname));
+}
+
+/** Creates `newname` as a hard link to `oldname`.
+ *
+ *       await Deno.link("old/name", "new/name");
+ */
+export async function link(oldname: string, newname: string): Promise<void> {
+  await dispatch.sendAsync(...req(oldname, newname));
+}

--- a/js/link_test.ts
+++ b/js/link_test.ts
@@ -1,0 +1,104 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { test, testPerm, assert, assertEquals } from "./test_util.ts";
+
+testPerm({ read: true, write: true }, function linkSyncSuccess() {
+  const testDir = Deno.makeTempDirSync();
+  const oldData = "Hardlink";
+  const oldName = testDir + "/oldname";
+  const newName = testDir + "/newname";
+  Deno.writeFileSync(oldName, new TextEncoder().encode(oldData));
+  // Create the hard link.
+  Deno.linkSync(oldName, newName);
+  // We should expect reading the same content.
+  const newData = new TextDecoder().decode(Deno.readFileSync(newName));
+  assertEquals(oldData, newData);
+  // Writing to newname also affects oldname.
+  const newData2 = "Modified";
+  Deno.writeFileSync(newName, new TextEncoder().encode(newData2));
+  assertEquals(newData2, new TextDecoder().decode(Deno.readFileSync(oldName)));
+  // Writing to oldname also affects newname.
+  const newData3 = "ModifiedAgain";
+  Deno.writeFileSync(oldName, new TextEncoder().encode(newData3));
+  assertEquals(newData3, new TextDecoder().decode(Deno.readFileSync(newName)));
+  // Remove oldname. File still accessible through newname.
+  Deno.removeSync(oldName);
+  const newNameStat = Deno.statSync(newName);
+  assert(newNameStat.isFile());
+  assert(!newNameStat.isSymlink()); // Not a symlink.
+  assertEquals(newData3, new TextDecoder().decode(Deno.readFileSync(newName)));
+});
+
+testPerm({ read: true, write: true }, function linkSyncExists() {
+  const testDir = Deno.makeTempDirSync();
+  const oldName = testDir + "/oldname";
+  const newName = testDir + "/newname";
+  Deno.writeFileSync(oldName, new TextEncoder().encode("oldName"));
+  // newname is already created.
+  Deno.writeFileSync(newName, new TextEncoder().encode("newName"));
+
+  let err;
+  try {
+    Deno.linkSync(oldName, newName);
+  } catch (e) {
+    err = e;
+  }
+  assert(!!err);
+  console.log(err);
+  assertEquals(err.kind, Deno.ErrorKind.AlreadyExists);
+  assertEquals(err.name, "AlreadyExists");
+});
+
+testPerm({ read: true, write: true }, function linkSyncNotFound() {
+  const testDir = Deno.makeTempDirSync();
+  const oldName = testDir + "/oldname";
+  const newName = testDir + "/newname";
+
+  let err;
+  try {
+    Deno.linkSync(oldName, newName);
+  } catch (e) {
+    err = e;
+  }
+  assert(!!err);
+  console.log(err);
+  assertEquals(err.kind, Deno.ErrorKind.NotFound);
+  assertEquals(err.name, "NotFound");
+});
+
+test(function linkSyncPerm() {
+  let err;
+  try {
+    Deno.linkSync("oldbaddir", "newbaddir");
+  } catch (e) {
+    err = e;
+  }
+  assertEquals(err.kind, Deno.ErrorKind.PermissionDenied);
+  assertEquals(err.name, "PermissionDenied");
+});
+
+testPerm({ read: true, write: true }, async function linkSuccess() {
+  const testDir = Deno.makeTempDirSync();
+  const oldData = "Hardlink";
+  const oldName = testDir + "/oldname";
+  const newName = testDir + "/newname";
+  Deno.writeFileSync(oldName, new TextEncoder().encode(oldData));
+  // Create the hard link.
+  await Deno.link(oldName, newName);
+  // We should expect reading the same content.
+  const newData = new TextDecoder().decode(Deno.readFileSync(newName));
+  assertEquals(oldData, newData);
+  // Writing to newname also affects oldname.
+  const newData2 = "Modified";
+  Deno.writeFileSync(newName, new TextEncoder().encode(newData2));
+  assertEquals(newData2, new TextDecoder().decode(Deno.readFileSync(oldName)));
+  // Writing to oldname also affects newname.
+  const newData3 = "ModifiedAgain";
+  Deno.writeFileSync(oldName, new TextEncoder().encode(newData3));
+  assertEquals(newData3, new TextDecoder().decode(Deno.readFileSync(newName)));
+  // Remove oldname. File still accessible through newname.
+  Deno.removeSync(oldName);
+  const newNameStat = Deno.statSync(newName);
+  assert(newNameStat.isFile());
+  assert(!newNameStat.isSymlink()); // Not a symlink.
+  assertEquals(newData3, new TextDecoder().decode(Deno.readFileSync(newName)));
+});

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -23,6 +23,7 @@ import "./files_test.ts";
 import "./form_data_test.ts";
 import "./globals_test.ts";
 import "./headers_test.ts";
+import "./link_test.ts";
 import "./location_test.ts";
 import "./make_temp_dir_test.ts";
 import "./metrics_test.ts";


### PR DESCRIPTION
Stumbled upon this, realized that we have never introduced this fs utility.

Prior art:
+ __Node__: [`fs.link(existingPath, newPath, callback)`](https://nodejs.org/dist/latest-v11.x/docs/api/fs.html#fs_fs_link_existingpath_newpath_callback)
+ __C__: [`int link (const char *oldname, const char *newname)`](https://www.gnu.org/software/libc/manual/html_node/Hard-Links.html)
+ __Python__: [`os.link(source, link_name)`](https://docs.python.org/2/library/os.html#os.link)
+ __Rust__: [`pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result<()>`](https://doc.rust-lang.org/std/fs/fn.hard_link.html)

(Debating if we should name it `hardlink` instead for clarify, and potentially renaming `readlink` to `readSymlink`?)
