### PR TITLE
fix --v8-options

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -230,7 +230,8 @@ pub fn set_flags(
 
   if matches.is_present("v8-options") {
     // display v8 help and exit
-    v8_set_flags(vec!["deno".to_string(), "--help".to_string()]);
+    // TODO(bartlomieju): this relies on `v8_set_flags` to swap `--v8-options` to help
+    v8_set_flags(vec!["deno".to_string(), "--v8-options".to_string()]);
   }
 
   if matches.is_present("v8-flags") {


### PR DESCRIPTION
Fixes #2092 

@ry are you very attached to `v8_set_flags` in the current form? I'd prefer to remove `v8_set_flags_preprocess` it does some magic that is not needed anymore.
