### PR TITLE
Add panic handlers again.

### DIFF
--- a/cli/compiler.rs
+++ b/cli/compiler.rs
@@ -111,6 +111,8 @@ fn lazy_start(parent_state: ThreadSafeState) -> ResourceId {
 
       let mut runtime = C_RUNTIME.lock().unwrap();
       runtime.spawn(lazy(move || {
+        tokio_util::abort_on_panic();
+
         worker.then(move |result| -> Result<(), ()> {
           // Close resource so the future created by
           // handle_worker_message_stream exits

--- a/cli/tokio_util.rs
+++ b/cli/tokio_util.rs
@@ -13,8 +13,20 @@ pub fn run<F>(future: F)
 where
   F: Future<Item = (), Error = ()> + Send + 'static,
 {
+  abort_on_panic();
   // tokio::runtime::current_thread::run(future)
   tokio::run(future)
+}
+
+// Tokio swallows panics. In order to actually crash when we panic, we
+// have to set this custom hook.
+// https://github.com/tokio-rs/tokio/issues/495
+// https://github.com/tokio-rs/tokio/issues/209
+pub fn abort_on_panic() {
+  std::panic::set_hook(Box::new(|panic_info| {
+    eprintln!("{}", panic_info.to_string());
+    std::process::abort();
+  }));
 }
 
 pub fn block_on<F, R, E>(future: F) -> Result<R, E>
@@ -40,7 +52,10 @@ where
   let rt = tokio::runtime::Runtime::new().unwrap();
   let mut executor = rt.executor();
   let mut enter = tokio_executor::enter().expect("Multiple executors at once");
-  tokio_executor::with_default(&mut executor, &mut enter, move |_enter| f());
+  tokio_executor::with_default(&mut executor, &mut enter, move |_enter| {
+    abort_on_panic();
+    f()
+  });
 }
 
 #[derive(Debug)]

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -324,7 +324,7 @@ mod tests {
         onmessage = function(e) {
           console.log("msg from main script", e.data);
           if (e.data == "exit") {
-            close();
+            delete window.onmessage;
             return;
           } else {
             console.assert(e.data === "hi");


### PR DESCRIPTION
The tests were silently failing (again) due to this ill conceived tokio feature.

cc @afinch7 this is happening somewhere in the compiler code - I haven't debugged yet.