### PR TITLE
Update `deno -h` output in manual

### DIFF
--- a/website/manual.md
+++ b/website/manual.md
@@ -535,26 +535,27 @@ if (import.meta.main) {
 
 ```shellsession
 $ deno -h
-deno
+deno 
 
 USAGE:
-    deno_dev [FLAGS] [OPTIONS] [SUBCOMMAND]
+    deno [FLAGS] [OPTIONS] [SUBCOMMAND]
 
 FLAGS:
-    -A, --allow-all      Allow all permissions
-        --allow-env      Allow environment access
-        --allow-net      Allow network access
-        --allow-read     Allow file system read access
-        --allow-run      Allow running subprocesses
-        --allow-write    Allow file system write access
-    -h, --help           Prints help information
-    -D, --log-debug      Log debug output
-        --no-prompt      Do not use prompts
-        --prefetch       Prefetch the dependencies
-    -r, --reload         Reload source code cache (recompile TypeScript)
-        --types          Print runtime TypeScript declarations
-        --v8-options     Print V8 command line options
-    -v, --version        Print the version
+    -A, --allow-all               Allow all permissions
+        --allow-env               Allow environment access
+        --allow-high-precision    Allow high precision time measurement
+        --allow-net               Allow network access
+        --allow-read              Allow file system read access
+        --allow-run               Allow running subprocesses
+        --allow-write             Allow file system write access
+    -h, --help                    Prints help information
+    -D, --log-debug               Log debug output
+        --no-prompt               Do not use prompts
+        --prefetch                Prefetch the dependencies
+    -r, --reload                  Reload source code cache (recompile TypeScript)
+        --types                   Print runtime TypeScript declarations
+        --v8-options              Print V8 command line options
+    -v, --version                 Print the version
 
 OPTIONS:
         --v8-flags=<v8-flags>    Set V8 command line options

--- a/website/manual.md
+++ b/website/manual.md
@@ -535,7 +535,7 @@ if (import.meta.main) {
 
 ```shellsession
 $ deno -h
-deno 
+deno
 
 USAGE:
     deno [FLAGS] [OPTIONS] [SUBCOMMAND]


### PR DESCRIPTION
- `deno` instead of `deno_dev`
- add `--allow-high-precision`