### PR TITLE
fix: expose File

### DIFF
--- a/js/dom_types.ts
+++ b/js/dom_types.ts
@@ -196,12 +196,14 @@ export interface CustomEvent extends Event {
   ): void;
 }
 
-/* TODO(ry) Re-expose this interface. There is currently some interference
- * between deno's File and this one.
- */
 export interface DomFile extends Blob {
   readonly lastModified: number;
   readonly name: string;
+}
+
+export interface DomFileConstructor {
+  new (bits: BlobPart[], filename: string, options?: FilePropertyBag): DomFile;
+  prototype: DomFile;
 }
 
 export interface FilePropertyBag extends BlobPropertyBag {

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -13,6 +13,7 @@ import * as consoleTypes from "./console";
 import * as customEvent from "./custom_event";
 import * as deno from "./deno";
 import * as domTypes from "./dom_types";
+import * as domFile from "./dom_file";
 import * as event from "./event";
 import * as eventTarget from "./event_target";
 import * as formData from "./form_data";
@@ -74,11 +75,8 @@ window.location = (undefined as unknown) as domTypes.Location;
 window.Blob = blob.DenoBlob;
 export type Blob = blob.DenoBlob;
 
-// TODO(ry) Do not export a class implementing the DOM, export the DOM
-// interface. See this comment for implementation hint:
-// https://github.com/denoland/deno/pull/1396#discussion_r243711502
-// window.File = file.DenoFile;
-// export type File = file.DenoFile;
+window.File = domFile.DenoFile as domTypes.DomFileConstructor;
+export type File = domTypes.DomFile;
 
 window.CustomEventInit = customEvent.CustomEventInit;
 export type CustomEventInit = customEvent.CustomEventInit;

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -18,7 +18,7 @@ import "./event_target_test.ts";
 import "./fetch_test.ts";
 // TODO The global "File" has been temporarily disabled. See the note in
 // js/globals.ts
-// import "./file_test.ts";
+import "./file_test.ts";
 import "./files_test.ts";
 import "./form_data_test.ts";
 import "./globals_test.ts";

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -16,8 +16,6 @@ import "./dir_test.ts";
 import "./event_test.ts";
 import "./event_target_test.ts";
 import "./fetch_test.ts";
-// TODO The global "File" has been temporarily disabled. See the note in
-// js/globals.ts
 import "./file_test.ts";
 import "./files_test.ts";
 import "./form_data_test.ts";


### PR DESCRIPTION
This PR exposes `File` again, and addresses the TODO comments created in #1396. It also restores `//js/file_test.ts`.

cc @ry, @kitsonk 
