### PR TITLE
Add Deno.core.setGCObserver() for callbacks invoked on GC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,5 +132,5 @@ jobs:
       - third_party/depot_tools/gn gen target/debug
       - export ASAN_OPTIONS=detect_leaks=1
       - ./tools/build.py test_cc
-      - ./target/debug/test_cc
+      - ./target/debug/test_cc --expose-gc
 

--- a/core/libdeno/api.cc
+++ b/core/libdeno/api.cc
@@ -71,6 +71,11 @@ Deno* deno_new(deno_config config) {
       deno::InitializeContext(isolate, context);
     }
     d->context_.Reset(isolate, context);
+
+    d->gc_observer_private_symbol_.Reset(
+        isolate,
+        v8::Private::New(isolate, v8::String::NewFromUtf8(
+                                      isolate, "deno:gc_observer:symbol")));
   }
 
   return reinterpret_cast<Deno*>(d);

--- a/core/libdeno/internal.h
+++ b/core/libdeno/internal.h
@@ -155,6 +155,7 @@ void Recv(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Send(const v8::FunctionCallbackInfo<v8::Value>& args);
 void EvalContext(const v8::FunctionCallbackInfo<v8::Value>& args);
 void ErrorToJSON(const v8::FunctionCallbackInfo<v8::Value>& args);
+void SetGCObserver(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Shared(v8::Local<v8::Name> property,
             const v8::PropertyCallbackInfo<v8::Value>& info);
 void MessageCallback(v8::Local<v8::Message> message, v8::Local<v8::Value> data);
@@ -164,6 +165,7 @@ static intptr_t external_references[] = {
     reinterpret_cast<intptr_t>(Send),
     reinterpret_cast<intptr_t>(EvalContext),
     reinterpret_cast<intptr_t>(ErrorToJSON),
+    reinterpret_cast<intptr_t>(SetGCObserver),
     reinterpret_cast<intptr_t>(Shared),
     reinterpret_cast<intptr_t>(MessageCallback),
     0};

--- a/core/libdeno/internal.h
+++ b/core/libdeno/internal.h
@@ -113,6 +113,7 @@ class DenoIsolate {
   deno_resolve_cb resolve_cb_;
 
   v8::Persistent<v8::Context> context_;
+  v8::Persistent<v8::Private> gc_observer_private_symbol_;
   std::map<size_t, v8::Persistent<v8::Value>> zero_copy_map_;
   std::map<int, v8::Persistent<v8::Value>> pending_promise_map_;
   std::string last_exception_;

--- a/core/libdeno/libdeno.d.ts
+++ b/core/libdeno/libdeno.d.ts
@@ -37,4 +37,7 @@ declare interface DenoCore {
   evalContext(code: string): [any, EvalErrorInfo | null];
 
   errorToJSON: (e: Error) => string;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setGCObserver: <T>(o: T, callback: (o: T) => void) => T;
 }

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -315,6 +315,13 @@ TEST(LibDenoTest, LibDenoEvalContextError) {
   deno_delete(d);
 }
 
+TEST(LibDenoTest, LibDenoGCObserver) {
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
+  deno_execute(d, nullptr, "a.js", "LibDenoGCObserver();");
+  EXPECT_EQ(nullptr, deno_last_exception(d));
+  deno_delete(d);
+}
+
 TEST(LibDenoTest, SharedAtomics) {
   int32_t s[] = {0, 1, 2};
   deno_buf shared = {nullptr, 0, reinterpret_cast<uint8_t*>(s), sizeof s, 0};

--- a/tools/test.py
+++ b/tools/test.py
@@ -76,7 +76,7 @@ def main(argv):
 
     test_cc = os.path.join(build_dir, "test_cc" + executable_suffix)
     check_exists(test_cc)
-    run([test_cc])
+    run([test_cc, "--expose-gc"])
 
     test_rs = os.path.join(build_dir, "test_rs" + executable_suffix)
     check_exists(test_rs)


### PR DESCRIPTION
`Deno.core.setGCObserver(target, handler)` sets `handler: (target) => void` to be invoked on `target` immediately before being GC-ed e.g. to clear up open resources such as connections.

Sample usage (as shown in libdeno tests):
```js
  // Simulating a connection goes out of scope
  // for auto closing.
  let isClosed = false;
  let ID = 12345;
  const fakeClose = id => {
    if (id === ID) {
      isClosed = true;
    }
  };
  class FakeConn {
    constructor(rid) {
      this.rid = rid;
    }
    close() {
      Deno.core.print("Closing fake connection\n");
      fakeClose(this.rid);
    }
  }
  // IIFE. Simply using scope might not work.
  (() => {
    const conn = new FakeConn(12345);
    Deno.core.setGCObserver(conn, c => {
      Deno.core.print("Destroy callback invoked 3\n");
      c.close();
    });
  })();
  // Guarantee GC.
  gc();
  assert(isClosed);
```