### PR TITLE
Add fetch local file

### DIFF
--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -422,9 +422,9 @@ export async function fetch(
         e instanceof DenoError &&
         (e as DenoError<ErrorKind.NotFound>).kind === ErrorKind.NotFound
       ) {
-        return new Response(404, [], new msg.FetchRes().bodyRid);
+        return new Response(404, [], new msg.FetchRes().bodyRid());
       } else {
-        return new Response(500, [], new msg.FetchRes().bodyRid);
+        return new Response(500, [], new msg.FetchRes().bodyRid());
       }
     }
   }

--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -12,7 +12,7 @@ import { read, close } from "./files";
 import { Buffer } from "./buffer";
 import { FormData } from "./form_data";
 import { URLSearchParams } from "./url_search_params";
-import { openSync } from "./files";
+import { open } from "./files";
 import { DenoError, ErrorKind } from "./errors";
 
 function getHeaderValueParams(value: string): Map<string, string> {
@@ -411,7 +411,7 @@ export async function fetch(
   const m = url.match(/file:\/\/\/(.*)/i);
   if (m && m[0]) {
     try {
-      const f = openSync(m[1]);
+      const f = await open(m[1]);
       const headers: [string, string][] = [];
       // TODO : Add return type. Using Deno_std media_types module
       const response = new Response(200, headers, f.rid);

--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -413,8 +413,7 @@ export async function fetch(
     try {
       const f = openSync(m[1]);
       const headers: [string, string][] = [];
-      // headers.push(["content-type", contentType(extname(m[1])) || "text/plain"])
-      headers.push(["content-type", "text/plain"]);
+      // TODO : Add return type. Using Deno_std media_types module
       const response = new Response(200, headers, f.rid);
       return response;
     } catch (e) {

--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -422,9 +422,9 @@ export async function fetch(
         e instanceof DenoError &&
         (e as DenoError<ErrorKind.NotFound>).kind === ErrorKind.NotFound
       ) {
-        return new Response(404, [], new msg.FetchRes().bodyRid());
+        return new Response(404, [], -1);
       } else {
-        return new Response(500, [], new msg.FetchRes().bodyRid());
+        return new Response(500, [], -1);
       }
     }
   }

--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -413,7 +413,7 @@ export async function fetch(
   if (m && m[0]) {
     try {
       const f = await open(m[1]);
-      const headers: [string, string][] = [];
+      const headers: Array<[string, string]> = [];
       // TODO : Add return type. Using Deno_std media_types module
       const response = new Response(200, headers, f.rid);
       return response;

--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -408,7 +408,8 @@ export async function fetch(
   }
 
   // Fetching a local file
-  const m = url.match(/file:\/\/\/(.*)/i);
+  // See RFC8089 : https://tools.ietf.org/html/rfc8089
+  const m = url.match(/file:\/{1,5}(.*)/i);
   if (m && m[0]) {
     try {
       const f = await open(m[1]);

--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -422,9 +422,9 @@ export async function fetch(
         e instanceof DenoError &&
         (e as DenoError<ErrorKind.NotFound>).kind === ErrorKind.NotFound
       ) {
-        return new Response(404, [], 0);
+        return new Response(404, [], new msg.FetchRes().bodyRid);
       } else {
-        return new Response(500, [], 0);
+        return new Response(500, [], new msg.FetchRes().bodyRid);
       }
     }
   }

--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -159,7 +159,7 @@ testPerm({ net: true }, async function fetchInitBlobBody(): Promise<void> {
   assert(response.headers.get("content-type").startsWith("text/javascript"));
 });
 
-testPerm({ read: true }, async function fetchLocalFile() {
+testPerm({ read: true }, async function fetchLocalFile(): void {
   const res = await fetch("file:///./js/fetch.ts");
   const text = await res.text();
   const decoder = new TextDecoder("utf-8");

--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -159,6 +159,17 @@ testPerm({ net: true }, async function fetchInitBlobBody(): Promise<void> {
   assert(response.headers.get("content-type").startsWith("text/javascript"));
 });
 
+testPerm({ read: true }, async function fetchLocalFile() {
+  const res = await fetch("file:///./js/fetch.ts");
+  const text = await res.text();
+  const decoder = new TextDecoder("utf-8");
+  const data = decoder.decode(Deno.readFileSync("./js/fetch.ts"));
+  assertEquals(text, data);
+  assert(res.headers.get("content-type").startsWith("text/plain"));
+  const resNotFound = await fetch("file:///./js/NotExistingFile.ts");
+  assertEquals(resNotFound.status, 404);
+});
+
 // TODO(ry) The following tests work but are flaky. There's a race condition
 // somewhere. Here is what one of these flaky failures looks like:
 //

--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -165,7 +165,6 @@ testPerm({ read: true }, async function fetchLocalFile() {
   const decoder = new TextDecoder("utf-8");
   const data = decoder.decode(Deno.readFileSync("./js/fetch.ts"));
   assertEquals(text, data);
-  assert(res.headers.get("content-type").startsWith("text/plain"));
   const resNotFound = await fetch("file:///./js/NotExistingFile.ts");
   assertEquals(resNotFound.status, 404);
 });

--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -167,6 +167,7 @@ testPerm({ read: true }, async function fetchLocalFile(): Promise<void> {
   assertEquals(text, data);
   const resNotFound = await fetch("file:///./js/NotExistingFile.ts");
   assertEquals(resNotFound.status, 404);
+  assertEquals(await resNotFound.text(), "");
 });
 
 // TODO(ry) The following tests work but are flaky. There's a race condition

--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -159,7 +159,7 @@ testPerm({ net: true }, async function fetchInitBlobBody(): Promise<void> {
   assert(response.headers.get("content-type").startsWith("text/javascript"));
 });
 
-testPerm({ read: true }, async function fetchLocalFile(): void {
+testPerm({ read: true }, async function fetchLocalFile(): Promise<void> {
   const res = await fetch("file:///./js/fetch.ts");
   const text = await res.text();
   const decoder = new TextDecoder("utf-8");

--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -170,6 +170,19 @@ testPerm({ read: true }, async function fetchLocalFile(): Promise<void> {
   assertEquals(await resNotFound.text(), "");
 });
 
+testPerm({}, async function fetchLocalNoPerm(): Promise<void> {
+  let hasThrown = false;
+  let _err;
+  try {
+    await fetch("file:///./js/fetch.ts");
+  } catch (e) {
+    _err = e;
+    hasThrown = true;
+  }
+  assertEquals(_err.kind, Deno.ErrorKind.PermissionDenied);
+  assert(hasThrown);
+});
+
 // TODO(ry) The following tests work but are flaky. There's a race condition
 // somewhere. Here is what one of these flaky failures looks like:
 //


### PR DESCRIPTION
This fixes https://github.com/denoland/deno/issues/2150

I have 2 questions:
Here : https://github.com/denoland/deno/compare/master...zekth:fetch_local?expand=1#diff-cee0e68f0ac7840274b5171cf4df9dbeR410 i need to handle the `content-type` but it's in deno_std atm. Any idea? Also, how could i get the content-lenght?