### PR TITLE
Make Deno/Deno.core not deletable/writable

### DIFF
--- a/js/globals.ts
+++ b/js/globals.ts
@@ -5,7 +5,7 @@
 // library.
 
 // Modules which will make up part of the global public API surface should be
-// imported as namespaces, so when the runtime tpye library is generated they
+// imported as namespaces, so when the runtime type library is generated they
 // can be expressed as a namespace in the type library.
 import { window } from "./window";
 import * as blob from "./blob";
@@ -29,6 +29,7 @@ import * as performanceUtil from "./performance";
 // These imports are not exposed and therefore are fine to just import the
 // symbols required.
 import { core } from "./core";
+import { immutableDefine } from "./util";
 
 // During the build process, augmentations to the variable `window` in this
 // file are tracked and created as part of default library that is built into
@@ -44,7 +45,7 @@ window.window = window;
 // This is the Deno namespace, it is handled differently from other window
 // properties when building the runtime type library, as the whole module
 // is flattened into a single namespace.
-window.Deno = deno;
+immutableDefine(window, "Deno", deno);
 Object.freeze(window.Deno);
 
 // ref https://console.spec.whatwg.org/#console-namespace

--- a/js/globals_test.ts
+++ b/js/globals_test.ts
@@ -33,3 +33,47 @@ test(function DenoNamespaceIsFrozen() {
 test(function webAssemblyExists() {
   assert(typeof WebAssembly.compile === "function");
 });
+
+test(function DenoNamespaceImmutable() {
+  const denoCopy = window.Deno;
+  try {
+    // @ts-ignore
+    Deno = 1;
+  } catch {}
+  assert(denoCopy === Deno);
+  try {
+    // @ts-ignore
+    window.Deno = 1;
+  } catch {}
+  assert(denoCopy === Deno);
+  try {
+    delete window.Deno;
+  } catch {}
+  assert(denoCopy === Deno);
+
+  const { readFile } = Deno;
+  try {
+    // @ts-ignore
+    Deno.readFile = 1;
+  } catch {}
+  assert(readFile === Deno.readFile);
+  try {
+    delete window.Deno.readFile;
+  } catch {}
+  assert(readFile === Deno.readFile);
+
+  // @ts-ignore
+  const { print } = Deno.core;
+  try {
+    // @ts-ignore
+    Deno.core.print = 1;
+  } catch {}
+  // @ts-ignore
+  assert(print === Deno.core.print);
+  try {
+    // @ts-ignore
+    delete Deno.core.print;
+  } catch {}
+  // @ts-ignore
+  assert(print === Deno.core.print);
+});

--- a/js/main.ts
+++ b/js/main.ts
@@ -11,7 +11,6 @@ import { args } from "./deno";
 import { replLoop } from "./repl";
 import { setVersions } from "./version";
 import { setLocation } from "./location";
-import { window } from "./window";
 
 // builtin modules
 import * as deno from "./deno";
@@ -20,10 +19,6 @@ import * as deno from "./deno";
 import libDts from "gen/cli/lib/lib.deno_runtime.d.ts!string";
 
 export default function denoMain(name?: string): void {
-  // Deno.core could ONLY be safely frozen here (not in globals.ts)
-  // since shared_queue.js will modify core properties.
-  Object.freeze(window.Deno.core);
-
   const startResMsg = os.start(name);
 
   setVersions(startResMsg.denoVersion()!, startResMsg.v8Version()!);

--- a/js/main.ts
+++ b/js/main.ts
@@ -11,6 +11,7 @@ import { args } from "./deno";
 import { replLoop } from "./repl";
 import { setVersions } from "./version";
 import { setLocation } from "./location";
+import { window } from "./window";
 
 // builtin modules
 import * as deno from "./deno";
@@ -19,6 +20,10 @@ import * as deno from "./deno";
 import libDts from "gen/cli/lib/lib.deno_runtime.d.ts!string";
 
 export default function denoMain(name?: string): void {
+  // Deno.core could ONLY be safely frozen here (not in globals.ts)
+  // since shared_queue.js will modify core properties.
+  Object.freeze(window.Deno.core);
+
   const startResMsg = os.start(name);
 
   setVersions(startResMsg.denoVersion()!, startResMsg.v8Version()!);

--- a/js/os.ts
+++ b/js/os.ts
@@ -6,6 +6,7 @@ import * as flatbuffers from "./flatbuffers";
 import { TextDecoder } from "./text_encoding";
 import { assert } from "./util";
 import * as util from "./util";
+import { window } from "./window";
 
 /** The current process id of the runtime. */
 export let pid: number;
@@ -167,6 +168,10 @@ export function start(source?: string): msg.StartRes {
   util.setLogDebug(startResMsg.debugFlag(), source);
 
   setGlobals(startResMsg.pid(), startResMsg.noColor(), startResMsg.execPath()!);
+
+  // Deno.core could ONLY be safely frozen here (not in globals.ts)
+  // since shared_queue.js will modify core properties.
+  Object.freeze(window.Deno.core);
 
   return startResMsg;
 }

--- a/js/util.ts
+++ b/js/util.ts
@@ -131,6 +131,21 @@ export function requiredArguments(
   }
 }
 
+// @internal
+export function immutableDefine(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  o: any,
+  p: string | number | symbol,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any
+): void {
+  Object.defineProperty(o, p, {
+    value,
+    configurable: false,
+    writable: false
+  });
+}
+
 // Returns values from a WeakMap to emulate private properties in JavaScript
 export function getPrivateValue<
   K extends object,


### PR DESCRIPTION
before: 
```
> Deno = 1
1
panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`', ../../core/isolate.rs:468:7
Abort trap: 6

> delete window.Deno
true
panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`', ../../core/isolate.rs:468:7
Abort trap: 6

> Deno.core.send = 1
1
panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`', ../../core/isolate.rs:468:7
Abort trap: 6

> delete Deno.core.send
true
panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`', ../../core/isolate.rs:468:7
Abort trap: 6
```

after:
```
> Deno = 1
1
> delete window.Deno
false
> Deno.core.send = 1
1
> delete Deno.core.send
false
> Deno
{ args, noColor, pid, env, exit, isTTY, execPath, chdir, cwd, File, open, openSync, stdin, stdout, stderr, read, readSync, write, writeSync, seek, seekSync, close, copy, toAsyncIterator, SeekMode, Buffer, readAll, readAllSync, mkdirSync, mkdir, makeTempDirSync, makeTempDir, chmodSync, chmod, removeSync, remove, renameSync, rename, readFileSync, readFile, readDirSync, readDir, copyFileSync, copyFile, readlinkSync, readlink, statSync, lstatSync, stat, lstat, linkSync, link, symlinkSync, symlink, writeFileSync, writeFile, ErrorKind, DenoError, permissions, revokePermission, truncateSync, truncate, connect, dial, listen, metrics, resources, run, Process, inspect, build, platform, version, core, Console, stringifyArgs, DomIterableMixin }
> Deno.core.send
[Function]
>
```