### PR TITLE
fix: #2033 shared queue push bug

### DIFF
--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -1,5 +1,25 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
+function debug(...msg) {
+  // console.log("js:shared_queue:", ...msg)
+}
+
+/*
+SharedQueue Binary Layout
++-------------------------------+-------------------------------+
+|                        NUM_RECORDS (32)                       |
++---------------------------------------------------------------+
+|                        NUM_SHIFTED_OFF (32)                   |
++---------------------------------------------------------------+
+|                        HEAD (32)                              |
++---------------------------------------------------------------+
+|                        OFFSETS (32)                           |
++---------------------------------------------------------------+
+|                        RECORD_ENDS (*MAX_RECORDS)           ...
++---------------------------------------------------------------+
+|                        RECORDS (*MAX_RECORDS)               ...
++---------------------------------------------------------------+
+ */
 (window => {
   const GLOBAL_NAMESPACE = "Deno";
   const CORE_NAMESPACE = "core";
@@ -24,6 +44,7 @@
   }
 
   function reset() {
+    debug("reset");
     shared32[INDEX_NUM_RECORDS] = 0;
     shared32[INDEX_NUM_SHIFTED_OFF] = 0;
     shared32[INDEX_HEAD] = HEAD_INIT;
@@ -41,6 +62,10 @@
     return shared32[INDEX_NUM_RECORDS] - shared32[INDEX_NUM_SHIFTED_OFF];
   }
 
+  function numShiftedOff() {
+    return shared32[INDEX_NUM_SHIFTED_OFF];
+  }
+
   function setEnd(index, end) {
     shared32[INDEX_OFFSETS + index] = end;
   }
@@ -55,7 +80,7 @@
 
   function getOffset(index) {
     if (index < numRecords()) {
-      if (index == 0) {
+      if (index === 0) {
         return HEAD_INIT;
       } else {
         return shared32[INDEX_OFFSETS + index - 1];
@@ -69,41 +94,51 @@
     let off = head();
     let end = off + buf.byteLength;
     let index = numRecords();
-    if (end > shared32.byteLength) {
-      console.log("shared_queue.ts push fail");
+    if (end > shared32.byteLength || size() >= MAX_RECORDS) {
+      debug("push fail");
       return false;
     }
     setEnd(index, end);
-    assert(end - off == buf.byteLength);
+    assert(end - off === buf.byteLength);
     sharedBytes.set(buf, off);
     shared32[INDEX_NUM_RECORDS] += 1;
     shared32[INDEX_HEAD] = end;
+    debug(`push: num_records=${numRecords()}, index_head=${head()}`);
     return true;
   }
 
   /// Returns null if empty.
   function shift() {
     let i = shared32[INDEX_NUM_SHIFTED_OFF];
-    if (size() == 0) {
-      assert(i == 0);
+    debug(`shift:begin: num_records=${numRecords()}, shifted_off=${i}`);
+    if (size() === 0) {
+      assert(i === 0);
       return null;
     }
 
     let off = getOffset(i);
     let end = getEnd(i);
 
+    debug(`shift:going off=${off}, end=${end}, ablen=${sharedBytes.length}`);
     if (size() > 1) {
+      debug(`shift:incr size=${size()}, num_shifted_off=${numShiftedOff()}`);
       shared32[INDEX_NUM_SHIFTED_OFF] += 1;
+      debug(`shift:done num_shifted_off=${numShiftedOff()}`);
     } else {
+      debug(`shift: size=${size()}. will reset`);
       reset();
     }
 
     assert(off != null);
     assert(end != null);
+    debug(
+      `shift: num_records=${numRecords()}, num_shifted_off=${numShiftedOff()}`
+    );
     return sharedBytes.subarray(off, end);
   }
 
   let asyncHandler;
+
   function setAsyncHandler(cb) {
     assert(asyncHandler == null);
     asyncHandler = cb;
@@ -123,6 +158,7 @@
     assert(shared.byteLength > 0);
     assert(sharedBytes == null);
     assert(shared32 == null);
+    debug(`init: ${shared.byteLength}`);
     sharedBytes = new Uint8Array(shared);
     shared32 = new Int32Array(shared);
     // Callers should not call Deno.core.recv, use setAsyncHandler.

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -1,9 +1,4 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-
-function debug(...msg) {
-  // console.log("js:shared_queue:", ...msg)
-}
-
 /*
 SharedQueue Binary Layout
 +-------------------------------+-------------------------------+
@@ -21,6 +16,12 @@ SharedQueue Binary Layout
 +---------------------------------------------------------------+
  */
 (window => {
+  function debug(...msg) {
+    if (!window) {
+      // TODO: never reach. we need macro like debug! for rust...
+      console.log("js:shared_queue:", ...msg);
+    }
+  }
   const GLOBAL_NAMESPACE = "Deno";
   const CORE_NAMESPACE = "core";
   const MAX_RECORDS = 100;


### PR DESCRIPTION
- fixed  #2033 
- I finally found `SharedQueue` (js, also rust) wrongly push record item though it has full records according to MAX_RECORDS size.
- shifting operation to SharedQueue that pushed more than MAX_RECORDS will cause obtaining wrong subarray of shared bytes. 
- That is why deserialized flatbuffers message has `cmd_id=0`
- **NOTE: this fixing seriously degrade benchmarks**

- benchmark comparison between https://deno.land/std/http/http_bench.ts is below

**deno@v0.3.8 (ended with error #2033 )**
```
 ➜  wrk -t12 -c400 -d30s http://127.0.0.1:4500
Running 30s test @ http://127.0.0.1:4500
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    18.86ms    3.58ms  62.30ms   86.99%
    Req/Sec     1.67k   203.47     2.77k    89.08%
  597492 requests in 30.02s, 28.49MB read
  Socket errors: connect 0, read 383, write 0, timeout 0
Requests/sec:  19904.28
Transfer/sec:      0.95MB
```

**this PR (no error after benching)**

```
➜  wrk -t12 -c400 -d30s http://127.0.0.1:4500
Running 30s test @ http://127.0.0.1:4500
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    99.21ms   12.93ms 262.61ms   84.30%
    Req/Sec   315.41     45.03   564.00     87.41%
  112963 requests in 30.10s, 5.39MB read
  Socket errors: connect 0, read 451, write 0, timeout 0
Requests/sec:   3753.16
Transfer/sec:    183.26KB
```

I don't fully understand how SharedQueue is needed, `MAX_RECORDS` seems to be small for intensive use cases...? 