### PR TITLE
Refactor CLI entry point

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -21,7 +21,6 @@ pub struct DenoFlags {
   pub allow_run: bool,
   pub allow_high_precision: bool,
   pub no_prompts: bool,
-  pub types: bool,
   pub prefetch: bool,
 }
 
@@ -67,9 +66,6 @@ impl<'a> From<ArgMatches<'a>> for DenoFlags {
     }
     if matches.is_present("no-prompt") {
       flags.no_prompts = true;
-    }
-    if matches.is_present("types") {
-      flags.types = true;
     }
     if matches.is_present("prefetch") {
       flags.prefetch = true;
@@ -150,13 +146,12 @@ pub fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
         .require_equals(true)
         .help("Set V8 command line options"),
     ).arg(
-      Arg::with_name("types")
-        .long("types")
-        .help("Print runtime TypeScript declarations"),
-    ).arg(
       Arg::with_name("prefetch")
         .long("prefetch")
         .help("Prefetch the dependencies"),
+    ).subcommand(
+      SubCommand::with_name("types")
+        .about("Print runtime TypeScript declarations"),
     ).subcommand(
       SubCommand::with_name("info")
         .setting(AppSettings::DisableVersion)
@@ -270,18 +265,6 @@ mod tests {
         ..DenoFlags::default()
       }
     );
-  }
-
-  #[test]
-  fn test_set_flags_5() {
-    let flags = flags_from_vec(svec!["deno", "--types"]);
-    assert_eq!(
-      flags,
-      DenoFlags {
-        types: true,
-        ..DenoFlags::default()
-      }
-    )
   }
 
   #[test]

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -95,7 +95,7 @@ static ENV_VARIABLES_HELP: &str = "ENVIRONMENT VARIABLES:
     DENO_DIR        Set deno's base directory
     NO_COLOR        Set to disable color";
 
-fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
+pub fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
   App::new("deno")
     .bin_name("deno")
     .global_settings(&[AppSettings::ColorNever])
@@ -198,46 +198,7 @@ fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
 }
 
 #[cfg_attr(feature = "cargo-clippy", allow(stutter))]
-pub fn set_flags(
-  args: Vec<String>,
-) -> Result<(DenoFlags, Vec<String>), String> {
-  let mut rest_argv: Vec<String> = vec!["deno".to_string()];
-  let cli_app = create_cli_app();
-  let matches = cli_app.get_matches_from(args);
-
-  match matches.subcommand() {
-    ("eval", Some(info_match)) => {
-      let code: &str = info_match.value_of("code").unwrap();
-      rest_argv.extend(vec![code.to_string()]);
-    }
-    ("info", Some(info_match)) => {
-      let file: &str = info_match.value_of("file").unwrap();
-      rest_argv.extend(vec![file.to_string()]);
-    }
-    ("fmt", Some(fmt_match)) => {
-      let files: Vec<String> = fmt_match
-        .values_of("files")
-        .unwrap()
-        .map(String::from)
-        .collect();
-      rest_argv.extend(files);
-    }
-    (script, Some(script_match)) => {
-      rest_argv.extend(vec![script.to_string()]);
-      // check if there are any extra arguments that should
-      // be passed to script
-      if script_match.is_present("") {
-        let script_args: Vec<String> = script_match
-          .values_of("")
-          .unwrap()
-          .map(String::from)
-          .collect();
-        rest_argv.extend(script_args);
-      }
-    }
-    _ => {}
-  }
-
+pub fn set_flags(matches: ArgMatches) -> Result<DenoFlags, String> {
   if matches.is_present("v8-options") {
     // display v8 help and exit
     // TODO(bartlomieju): this relies on `v8_set_flags` to swap `--v8-options` to help
@@ -256,138 +217,137 @@ pub fn set_flags(
   }
 
   let flags = DenoFlags::from(matches);
-  Ok((flags, rest_argv))
+  Ok(flags)
 }
 
-#[test]
-fn test_set_flags_1() {
-  let (flags, rest) = set_flags(svec!["deno", "--version"]).unwrap();
-  assert_eq!(rest, svec!["deno"]);
-  assert_eq!(
-    flags,
-    DenoFlags {
-      version: true,
-      ..DenoFlags::default()
-    }
-  );
-}
+#[cfg(test)]
+mod tests {
+  use super::*;
 
-#[test]
-fn test_set_flags_2() {
-  let (flags, rest) =
-    set_flags(svec!["deno", "-r", "-D", "script.ts"]).unwrap();
-  assert_eq!(rest, svec!["deno", "script.ts"]);
-  assert_eq!(
-    flags,
-    DenoFlags {
-      log_debug: true,
-      reload: true,
-      ..DenoFlags::default()
-    }
-  );
-}
+  fn flags_from_vec(args: Vec<String>) -> DenoFlags {
+    let cli_app = create_cli_app();
+    let matches = cli_app.get_matches_from(args);
+    set_flags(matches).unwrap()
+  }
 
-#[test]
-fn test_set_flags_3() {
-  let (flags, rest) =
-    set_flags(svec!["deno", "-r", "--allow-write", "script.ts"]).unwrap();
-  assert_eq!(rest, svec!["deno", "script.ts"]);
-  assert_eq!(
-    flags,
-    DenoFlags {
-      reload: true,
-      allow_write: true,
-      ..DenoFlags::default()
-    }
-  );
-}
+  #[test]
+  fn test_set_flags_1() {
+    let flags = flags_from_vec(svec!["deno", "--version"]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        version: true,
+        ..DenoFlags::default()
+      }
+    );
+  }
 
-#[test]
-fn test_set_flags_4() {
-  let (flags, rest) =
-    set_flags(svec!["deno", "-Dr", "--allow-write", "script.ts"]).unwrap();
-  assert_eq!(rest, svec!["deno", "script.ts"]);
-  assert_eq!(
-    flags,
-    DenoFlags {
-      log_debug: true,
-      reload: true,
-      allow_write: true,
-      ..DenoFlags::default()
-    }
-  );
-}
+  #[test]
+  fn test_set_flags_2() {
+    let flags = flags_from_vec(svec!["deno", "-r", "-D", "script.ts"]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        log_debug: true,
+        reload: true,
+        ..DenoFlags::default()
+      }
+    );
+  }
 
-#[test]
-fn test_set_flags_5() {
-  let (flags, rest) = set_flags(svec!["deno", "--types"]).unwrap();
-  assert_eq!(rest, svec!["deno"]);
-  assert_eq!(
-    flags,
-    DenoFlags {
-      types: true,
-      ..DenoFlags::default()
-    }
-  )
-}
+  #[test]
+  fn test_set_flags_3() {
+    let flags =
+      flags_from_vec(svec!["deno", "-r", "--allow-write", "script.ts"]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        reload: true,
+        allow_write: true,
+        ..DenoFlags::default()
+      }
+    );
+  }
 
-#[test]
-fn test_set_flags_6() {
-  let (flags, rest) =
-    set_flags(svec!["deno", "--allow-net", "gist.ts", "--title", "X"]).unwrap();
-  assert_eq!(rest, svec!["deno", "gist.ts", "--title", "X"]);
-  assert_eq!(
-    flags,
-    DenoFlags {
-      allow_net: true,
-      ..DenoFlags::default()
-    }
-  )
-}
+  #[test]
+  fn test_set_flags_4() {
+    let flags =
+      flags_from_vec(svec!["deno", "-Dr", "--allow-write", "script.ts"]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        log_debug: true,
+        reload: true,
+        allow_write: true,
+        ..DenoFlags::default()
+      }
+    );
+  }
 
-#[test]
-fn test_set_flags_7() {
-  let (flags, rest) =
-    set_flags(svec!["deno", "--allow-all", "gist.ts"]).unwrap();
-  assert_eq!(rest, svec!["deno", "gist.ts"]);
-  assert_eq!(
-    flags,
-    DenoFlags {
-      allow_net: true,
-      allow_env: true,
-      allow_run: true,
-      allow_read: true,
-      allow_write: true,
-      allow_high_precision: true,
-      ..DenoFlags::default()
-    }
-  )
-}
+  #[test]
+  fn test_set_flags_5() {
+    let flags = flags_from_vec(svec!["deno", "--types"]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        types: true,
+        ..DenoFlags::default()
+      }
+    )
+  }
 
-#[test]
-fn test_set_flags_8() {
-  let (flags, rest) =
-    set_flags(svec!["deno", "--allow-read", "gist.ts"]).unwrap();
-  assert_eq!(rest, svec!["deno", "gist.ts"]);
-  assert_eq!(
-    flags,
-    DenoFlags {
-      allow_read: true,
-      ..DenoFlags::default()
-    }
-  )
-}
+  #[test]
+  fn test_set_flags_6() {
+    let flags =
+      flags_from_vec(svec!["deno", "--allow-net", "gist.ts", "--title", "X"]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        allow_net: true,
+        ..DenoFlags::default()
+      }
+    )
+  }
 
-#[test]
-fn test_set_flags_9() {
-  let (flags, rest) =
-    set_flags(svec!["deno", "--allow-high-precision", "script.ts"]).unwrap();
-  assert_eq!(rest, svec!["deno", "script.ts"]);
-  assert_eq!(
-    flags,
-    DenoFlags {
-      allow_high_precision: true,
-      ..DenoFlags::default()
-    }
-  )
+  #[test]
+  fn test_set_flags_7() {
+    let flags = flags_from_vec(svec!["deno", "--allow-all", "gist.ts"]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        allow_net: true,
+        allow_env: true,
+        allow_run: true,
+        allow_read: true,
+        allow_write: true,
+        allow_high_precision: true,
+        ..DenoFlags::default()
+      }
+    )
+  }
+
+  #[test]
+  fn test_set_flags_8() {
+    let flags = flags_from_vec(svec!["deno", "--allow-read", "gist.ts"]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        allow_read: true,
+        ..DenoFlags::default()
+      }
+    )
+  }
+
+  #[test]
+  fn test_set_flags_9() {
+    let flags =
+      flags_from_vec(svec!["deno", "--allow-high-precision", "script.ts"]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        allow_high_precision: true,
+        ..DenoFlags::default()
+      }
+    )
+  }
 }

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -23,9 +23,6 @@ pub struct DenoFlags {
   pub no_prompts: bool,
   pub types: bool,
   pub prefetch: bool,
-  pub info: bool,
-  pub fmt: bool,
-  pub eval: bool,
 }
 
 impl<'a> From<ArgMatches<'a>> for DenoFlags {
@@ -76,15 +73,6 @@ impl<'a> From<ArgMatches<'a>> for DenoFlags {
     }
     if matches.is_present("prefetch") {
       flags.prefetch = true;
-    }
-    if matches.is_present("info") {
-      flags.info = true;
-    }
-    if matches.is_present("fmt") {
-      flags.fmt = true;
-    }
-    if matches.is_present("eval") {
-      flags.eval = true;
     }
 
     flags

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -21,7 +21,6 @@ pub struct DenoFlags {
   pub allow_run: bool,
   pub allow_high_precision: bool,
   pub no_prompts: bool,
-  pub prefetch: bool,
 }
 
 impl<'a> From<ArgMatches<'a>> for DenoFlags {
@@ -66,9 +65,6 @@ impl<'a> From<ArgMatches<'a>> for DenoFlags {
     }
     if matches.is_present("no-prompt") {
       flags.no_prompts = true;
-    }
-    if matches.is_present("prefetch") {
-      flags.prefetch = true;
     }
 
     flags
@@ -145,12 +141,14 @@ pub fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
         .takes_value(true)
         .require_equals(true)
         .help("Set V8 command line options"),
-    ).arg(
-      Arg::with_name("prefetch")
-        .long("prefetch")
-        .help("Prefetch the dependencies"),
+    ).subcommand(
+      SubCommand::with_name("prefetch")
+        .setting(AppSettings::DisableVersion)
+        .about("Prefetch the dependencies")
+        .arg(Arg::with_name("file").takes_value(true).required(true)),
     ).subcommand(
       SubCommand::with_name("types")
+        .setting(AppSettings::DisableVersion)
         .about("Print runtime TypeScript declarations"),
     ).subcommand(
       SubCommand::with_name("info")

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -333,4 +333,25 @@ mod tests {
       }
     )
   }
+
+  #[test]
+  fn test_set_flags_10() {
+    // notice that flags passed after script name will not
+    // be parsed to DenoFlags but instead forwarded to
+    // script args as Deno.args
+    let flags = flags_from_vec(svec![
+      "deno",
+      "--allow-write",
+      "script.ts",
+      "-D",
+      "--allow-net"
+    ]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        allow_write: true,
+        ..DenoFlags::default()
+      }
+    )
+  }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -147,10 +147,7 @@ fn types_command() {
   ));
   let content_bytes = std::fs::read(p).unwrap();
   let content = std::str::from_utf8(&content_bytes[..]).unwrap();
-
   println!("{}", content);
-
-  std::process::exit(0);
 }
 
 fn prefetch_or_info_command(

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -126,7 +126,7 @@ pub fn print_file_info(worker: &Worker, url: &str) {
   }
 }
 
-fn get_worker_and_state(
+fn create_worker_and_state(
   flags: DenoFlags,
   argv: Vec<String>,
 ) -> (Worker, ThreadSafeState) {
@@ -158,7 +158,7 @@ fn prefetch_or_info_command(
   argv: Vec<String>,
   print_info: bool,
 ) {
-  let (mut worker, state) = get_worker_and_state(flags, argv);
+  let (mut worker, state) = create_worker_and_state(flags, argv);
 
   let main_module = state.main_module().unwrap();
   let main_future = lazy(move || {
@@ -184,7 +184,7 @@ fn prefetch_or_info_command(
 }
 
 fn eval_command(flags: DenoFlags, argv: Vec<String>) {
-  let (mut worker, state) = get_worker_and_state(flags, argv);
+  let (mut worker, state) = create_worker_and_state(flags, argv);
   // Wrap provided script in async function so asynchronous methods
   // work. This is required until top-level await is not supported.
   let js_source = format!(
@@ -210,7 +210,7 @@ fn eval_command(flags: DenoFlags, argv: Vec<String>) {
 }
 
 fn run_repl(flags: DenoFlags, argv: Vec<String>) {
-  let (mut worker, _state) = get_worker_and_state(flags, argv);
+  let (mut worker, _state) = create_worker_and_state(flags, argv);
 
   // REPL situation.
   let main_future = lazy(move || {
@@ -228,7 +228,7 @@ fn run_repl(flags: DenoFlags, argv: Vec<String>) {
 }
 
 fn run_script(flags: DenoFlags, argv: Vec<String>) {
-  let (mut worker, state) = get_worker_and_state(flags, argv);
+  let (mut worker, state) = create_worker_and_state(flags, argv);
 
   let main_module = state.main_module().unwrap();
   // Normal situation of executing a module.
@@ -291,8 +291,8 @@ fn main() {
     ("types", Some(_)) => {
       types_command();
     }
-    ("eval", Some(info_match)) => {
-      let code: &str = info_match.value_of("code").unwrap();
+    ("eval", Some(eval_match)) => {
+      let code: &str = eval_match.value_of("code").unwrap();
       argv.extend(vec![code.to_string()]);
       eval_command(flags, argv);
     }
@@ -301,8 +301,8 @@ fn main() {
       argv.extend(vec![file.to_string()]);
       prefetch_or_info_command(flags, argv, true);
     }
-    ("prefetch", Some(info_match)) => {
-      let file: &str = info_match.value_of("file").unwrap();
+    ("prefetch", Some(prefetch_match)) => {
+      let file: &str = prefetch_match.value_of("file").unwrap();
       argv.extend(vec![file.to_string()]);
       prefetch_or_info_command(flags, argv, false);
     }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -270,8 +270,7 @@ fn main() {
 
   if flags.v8_help {
     // show v8 help and exit
-    // TODO(bartlomieju): this relies on `v8_set_flags` to swap `--v8-options` for "--help"
-    v8_set_flags(vec!["--v8-options".to_string()]);
+    v8_set_flags(vec!["--help".to_string()]);
   }
 
   match &flags.v8_flags {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -38,6 +38,7 @@ use crate::errors::RustOrJsError;
 use crate::state::ThreadSafeState;
 use crate::worker::root_specifier_to_url;
 use crate::worker::Worker;
+use flags::{create_cli_app, DenoFlags};
 use futures::lazy;
 use futures::Future;
 use log::{LevelFilter, Metadata, Record};
@@ -123,66 +124,102 @@ pub fn print_file_info(worker: &Worker, url: &str) {
   }
 }
 
-fn main() {
-  #[cfg(windows)]
-  ansi_term::enable_ansi_support().ok(); // For Windows 10
-
-  log::set_logger(&LOGGER).unwrap();
-  let args = env::args().collect();
-  let (mut flags, mut rest_argv) =
-    flags::set_flags(args).unwrap_or_else(|err| {
-      eprintln!("{}", err);
-      std::process::exit(1)
-    });
-
-  log::set_max_level(if flags.log_debug {
-    LevelFilter::Debug
-  } else {
-    LevelFilter::Warn
-  });
-
-  if flags.fmt {
-    rest_argv.insert(1, "https://deno.land/std/prettier/main.ts".to_string());
-    flags.allow_read = true;
-    flags.allow_write = true;
-  }
-
-  let should_prefetch = flags.prefetch || flags.info;
-  let should_display_info = flags.info;
-
+fn get_worker_and_state(
+  flags: DenoFlags,
+  rest_argv: Vec<String>,
+) -> (Worker, ThreadSafeState) {
   let state = ThreadSafeState::new(flags, rest_argv, ops::op_selector_std);
-  let mut worker = Worker::new(
+  let worker = Worker::new(
     "main".to_string(),
     startup_data::deno_isolate_init(),
     state.clone(),
   );
 
-  // TODO(ry) somehow combine the two branches below. They're very similar but
-  // it's difficult to get the types to workout.
+  (worker, state)
+}
 
-  if state.flags.eval {
+fn info_command(flags: DenoFlags, argv: Vec<String>) {
+  let should_display_info = flags.info;
+  let (mut worker, state) = get_worker_and_state(flags, argv);
+
+  if let Some(main_module) = state.main_module() {
     let main_future = lazy(move || {
+      // Setup runtime.
       js_check(worker.execute("denoMain()"));
-      // Wrap provided script in async function so asynchronous methods
-      // work. This is required until top-level await is not supported.
-      let js_source = format!(
-        "async function _topLevelWrapper(){{
-          {}
-        }}
-        _topLevelWrapper();
-        ",
-        &state.argv[1]
-      );
-      // ATM imports in `deno eval` are not allowed
-      // TODO Support ES modules once Worker supports evaluating anonymous modules.
-      js_check(worker.execute(&js_source));
-      worker.then(|result| {
-        js_check(result);
-        Ok(())
-      })
+      debug!("main_module {}", main_module);
+
+      let main_url = root_specifier_to_url(&main_module).unwrap();
+
+      worker
+        .execute_mod_async(&main_url, true)
+        .and_then(move |worker| {
+          if should_display_info {
+            // Display file info and exit. Do not run file
+            print_file_info(&worker, &main_module);
+            std::process::exit(0);
+          }
+
+          worker.then(|result| {
+            js_check(result);
+            Ok(())
+          })
+        }).map_err(|(err, _worker)| print_err_and_exit(err))
     });
     tokio_util::run(main_future);
-  } else if let Some(main_module) = state.main_module() {
+  }
+}
+
+fn eval_command(flags: DenoFlags, argv: Vec<String>) {
+  let (mut worker, state) = get_worker_and_state(flags, argv);
+  // Wrap provided script in async function so asynchronous methods
+  // work. This is required until top-level await is not supported.
+  let js_source = format!(
+    "async function _topLevelWrapper(){{
+        {}
+      }}
+      _topLevelWrapper();
+      ",
+    &state.argv[1]
+  );
+
+  let main_future = lazy(move || {
+    js_check(worker.execute("denoMain()"));
+    // ATM imports in `deno eval` are not allowed
+    // TODO Support ES modules once Worker supports evaluating anonymous modules.
+    js_check(worker.execute(&js_source));
+    worker.then(|result| {
+      js_check(result);
+      Ok(())
+    })
+  });
+  tokio_util::run(main_future);
+}
+
+fn run_repl(flags: DenoFlags, argv: Vec<String>) {
+  let (mut worker, _state) = get_worker_and_state(flags, argv);
+
+  // REPL situation.
+  let main_future = lazy(move || {
+    // Setup runtime.
+    js_check(worker.execute("denoMain()"));
+    worker
+      .then(|result| {
+        js_check(result);
+        Ok(())
+      }).map_err(|(err, _worker): (RustOrJsError, Worker)| {
+        print_err_and_exit(err)
+      })
+  });
+  tokio_util::run(main_future);
+}
+
+fn run_script(flags: DenoFlags, argv: Vec<String>) {
+  let should_prefetch = flags.prefetch || flags.info;
+  let should_display_info = flags.info;
+
+  let (mut worker, state) = get_worker_and_state(flags, argv);
+
+  if let Some(main_module) = state.main_module() {
     // Normal situation of executing a module.
 
     let main_future = lazy(move || {
@@ -208,18 +245,73 @@ fn main() {
     });
     tokio_util::run(main_future);
   } else {
-    // REPL situation.
-    let main_future = lazy(move || {
-      // Setup runtime.
-      js_check(worker.execute("denoMain()"));
-      worker
-        .then(|result| {
-          js_check(result);
-          Ok(())
-        }).map_err(|(err, _worker): (RustOrJsError, Worker)| {
-          print_err_and_exit(err)
-        })
-    });
-    tokio_util::run(main_future);
+    panic!("unreachable");
+  }
+}
+
+fn fmt_command(mut flags: DenoFlags, mut argv: Vec<String>) {
+  argv.insert(1, "https://deno.land/std/prettier/main.ts".to_string());
+  flags.allow_read = true;
+  flags.allow_write = true;
+  run_script(flags, argv);
+}
+
+fn main() {
+  #[cfg(windows)]
+  ansi_term::enable_ansi_support().ok(); // For Windows 10
+
+  log::set_logger(&LOGGER).unwrap();
+  let args: Vec<String> = env::args().collect();
+  let cli_app = create_cli_app();
+  let matches = cli_app.get_matches_from(args);
+  let flags = flags::set_flags(matches.clone()).unwrap_or_else(|err| {
+    eprintln!("{}", err);
+    std::process::exit(1)
+  });
+
+  log::set_max_level(if flags.log_debug {
+    LevelFilter::Debug
+  } else {
+    LevelFilter::Warn
+  });
+
+  let mut rest_argv: Vec<String> = vec!["deno".to_string()];
+  match matches.subcommand() {
+    ("eval", Some(info_match)) => {
+      let code: &str = info_match.value_of("code").unwrap();
+      rest_argv.extend(vec![code.to_string()]);
+      eval_command(flags, rest_argv);
+    }
+    ("info", Some(info_match)) => {
+      let file: &str = info_match.value_of("file").unwrap();
+      rest_argv.extend(vec![file.to_string()]);
+      info_command(flags, rest_argv);
+    }
+    ("fmt", Some(fmt_match)) => {
+      let files: Vec<String> = fmt_match
+        .values_of("files")
+        .unwrap()
+        .map(String::from)
+        .collect();
+      rest_argv.extend(files);
+      fmt_command(flags, rest_argv);
+    }
+    (script, Some(script_match)) => {
+      rest_argv.extend(vec![script.to_string()]);
+      // check if there are any extra arguments that should
+      // be passed to script
+      if script_match.is_present("") {
+        let script_args: Vec<String> = script_match
+          .values_of("")
+          .unwrap()
+          .map(String::from)
+          .collect();
+        rest_argv.extend(script_args);
+      }
+      run_script(flags, rest_argv);
+    }
+    _ => {
+      run_repl(flags, rest_argv);
+    }
   }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -43,6 +43,7 @@ use futures::lazy;
 use futures::Future;
 use log::{LevelFilter, Metadata, Record};
 use std::env;
+use std::path::Path;
 
 static LOGGER: Logger = Logger;
 
@@ -136,6 +137,19 @@ fn get_worker_and_state(
   );
 
   (worker, state)
+}
+
+fn types_command() {
+  let p = Path::new(concat!(
+    env!("GN_OUT_DIR"),
+    "/gen/cli/lib/lib.deno_runtime.d.ts"
+  ));
+  let content_bytes = std::fs::read(p).unwrap();
+  let content = std::str::from_utf8(&content_bytes[..]).unwrap();
+
+  println!("{}", content);
+
+  std::process::exit(0);
 }
 
 fn info_command(flags: DenoFlags, argv: Vec<String>) {
@@ -260,6 +274,9 @@ fn main() {
 
   let mut rest_argv: Vec<String> = vec!["deno".to_string()];
   match matches.subcommand() {
+    ("types", Some(_)) => {
+      types_command();
+    }
     ("eval", Some(info_match)) => {
       let code: &str = info_match.value_of("code").unwrap();
       rest_argv.extend(vec![code.to_string()]);

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -321,7 +321,6 @@ fn op_start(
       argv: Some(argv_off),
       main_module,
       debug_flag: state.flags.log_debug,
-      types_flag: state.flags.types,
       version_flag: state.flags.version,
       v8_version: Some(v8_version_off),
       deno_version: Some(deno_version_off),

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -158,9 +158,11 @@ impl ThreadSafeState {
   #[cfg(test)]
   pub fn mock() -> ThreadSafeState {
     let argv = vec![String::from("./deno"), String::from("hello.js")];
-    // For debugging: argv.push_back(String::from("-D"));
-    let (flags, rest_argv) = flags::set_flags(argv).unwrap();
-    ThreadSafeState::new(flags, rest_argv, ops::op_selector_std)
+    ThreadSafeState::new(
+      flags::DenoFlags::default(),
+      argv,
+      ops::op_selector_std,
+    )
   }
 
   pub fn metrics_op_dispatched(

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -267,9 +267,8 @@ mod tests {
     let js_url = Url::from_file_path(filename).unwrap();
 
     let argv = vec![String::from("./deno"), js_url.to_string()];
-    let (flags, rest_argv) = flags::set_flags(argv).unwrap();
-
-    let state = ThreadSafeState::new(flags, rest_argv, op_selector_std);
+    let state =
+      ThreadSafeState::new(flags::DenoFlags::default(), argv, op_selector_std);
     let state_ = state.clone();
     tokio_util::run(lazy(move || {
       let worker = Worker::new("TEST".to_string(), StartupData::None, state);
@@ -294,9 +293,8 @@ mod tests {
     let js_url = Url::from_file_path(filename).unwrap();
 
     let argv = vec![String::from("./deno"), js_url.to_string()];
-    let (flags, rest_argv) = flags::set_flags(argv).unwrap();
-
-    let state = ThreadSafeState::new(flags, rest_argv, op_selector_std);
+    let state =
+      ThreadSafeState::new(flags::DenoFlags::default(), argv, op_selector_std);
     let state_ = state.clone();
     tokio_util::run(lazy(move || {
       let worker = Worker::new("TEST".to_string(), StartupData::None, state);

--- a/core/examples/http_bench.rs
+++ b/core/examples/http_bench.rs
@@ -191,6 +191,7 @@ fn main() {
   });
 
   let args: Vec<String> = env::args().collect();
+  // NOTE: `--help` arg will display V8 help and exit
   let args = deno::v8_set_flags(args);
 
   log::set_logger(&LOGGER).unwrap();

--- a/core/flags.rs
+++ b/core/flags.rs
@@ -5,17 +5,13 @@ use libc::c_char;
 use libc::c_int;
 use std::ffi::CStr;
 use std::ffi::CString;
-use std::mem;
 use std::vec::Vec;
 
 /// Pass the command line arguments to v8.
 /// Returns a vector of command line arguments that V8 did not understand.
-/// Translates --v8-options into a --help flag for V8.
 pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
   // deno_set_v8_flags(int* argc, char** argv) mutates argc and argv to remove
   // flags that v8 understands.
-  // First parse core args, then convert to a vector of C strings.
-  let (args, rest) = v8_set_flags_preprocess(args);
 
   // Make a new array, that can be modified by V8::SetFlagsFromCommandLine(),
   // containing mutable raw pointers to the individual command line args.
@@ -43,42 +39,5 @@ pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
       let cstr = CStr::from_ptr(*ptr as *const c_char);
       let slice = cstr.to_str().unwrap();
       slice.to_string()
-    }).chain(rest.into_iter())
-    .collect()
-}
-
-// Returns args passed to V8, followed by args passed to JS
-fn v8_set_flags_preprocess(args: Vec<String>) -> (Vec<String>, Vec<String>) {
-  let (rest, mut v8_args) =
-    args.into_iter().partition(|ref a| a.as_str() == "--help");
-
-  // Replace args being sent to V8
-  for a in &mut v8_args {
-    if a == "--v8-options" {
-      mem::swap(a, &mut String::from("--help"));
-    }
-  }
-  (v8_args, rest)
-}
-
-#[test]
-fn test_v8_set_flags_preprocess_1() {
-  let js_args = v8_set_flags_preprocess(vec![
-    "deno".to_string(),
-    "--v8-options".to_string(),
-  ]);
-  assert_eq!(
-    js_args,
-    (vec!["deno".to_string(), "--help".to_string()], vec![])
-  );
-}
-
-#[test]
-fn test_v8_set_flags_preprocess_2() {
-  let js_args =
-    v8_set_flags_preprocess(vec!["deno".to_string(), "--help".to_string()]);
-  assert_eq!(
-    js_args,
-    (vec!["deno".to_string()], vec!["--help".to_string()])
-  );
+    }).collect()
 }

--- a/js/main.ts
+++ b/js/main.ts
@@ -15,9 +15,6 @@ import { setLocation } from "./location";
 // builtin modules
 import * as deno from "./deno";
 
-// TODO(kitsonk) remove with `--types` below
-import libDts from "gen/cli/lib/lib.deno_runtime.d.ts!string";
-
 export default function denoMain(name?: string): void {
   const startResMsg = os.start(name);
 
@@ -28,13 +25,6 @@ export default function denoMain(name?: string): void {
     console.log("deno:", deno.version.deno);
     console.log("v8:", deno.version.v8);
     console.log("typescript:", deno.version.typescript);
-    os.exit(0);
-  }
-
-  // handle `--types`
-  // TODO(kitsonk) move to Rust fetching from compiler
-  if (startResMsg.typesFlag()) {
-    console.log(libDts);
     os.exit(0);
   }
 

--- a/tests/types.test
+++ b/tests/types.test
@@ -1,2 +1,2 @@
-args: --types
+args: types
 output: tests/types.out

--- a/tools/docs.py
+++ b/tools/docs.py
@@ -11,7 +11,7 @@ os.chdir(root_path)
 # Builds into target/doc
 run(["cargo", "doc", "--all", "--no-deps", "-vv"])
 
-# 'deno --types' is stored in target/debug/gen/cli/lib/lib.deno_runtime.d.ts
+# 'deno types' is stored in target/debug/gen/cli/lib/lib.deno_runtime.d.ts
 # We want to run typedoc on that declaration file only.
 os.chdir(os.path.join(target_path, "debug/gen/cli/lib/"))
 

--- a/tools/prefetch_test.py
+++ b/tools/prefetch_test.py
@@ -13,7 +13,7 @@ def prefetch_test(deno_exe):
     deno_dir = mkdtemp()
     try:
         t = os.path.join(tests_path, "006_url_imports.ts")
-        output = run_output([deno_exe, "--prefetch", t],
+        output = run_output([deno_exe, "prefetch", t],
                             merge_env={"DENO_DIR": deno_dir})
         assert output == ""
         # Check that we actually did the prefetch.

--- a/website/manual.md
+++ b/website/manual.md
@@ -206,13 +206,13 @@ Environment variables: `DENO_BUILD_MODE`, `DENO_BUILD_PATH`, `DENO_BUILD_ARGS`,
 
 ## API reference
 
-### deno --types
+### deno types
 
 To get an exact reference of deno's runtime API, run the following in the
 command line:
 
 ```shellsession
-$ deno --types
+$ deno types
 ```
 
 [This is what the output looks like.](https://gist.github.com/ry/46da4724168cdefa763e13207d27ede5)
@@ -551,9 +551,7 @@ FLAGS:
     -h, --help                    Prints help information
     -D, --log-debug               Log debug output
         --no-prompt               Do not use prompts
-        --prefetch                Prefetch the dependencies
     -r, --reload                  Reload source code cache (recompile TypeScript)
-        --types                   Print runtime TypeScript declarations
         --v8-options              Print V8 command line options
     -v, --version                 Print the version
 
@@ -565,6 +563,8 @@ SUBCOMMANDS:
     eval        Eval script
     fmt         Format files
     info        Show source file related info
+    prefetch    Prefetch the dependencies
+    types       Print runtime TypeScript declarations
 
 ENVIRONMENT VARIABLES:
     DENO_DIR        Set deno's base directory
@@ -606,7 +606,7 @@ Particularly useful ones:
 |                       Scheduler | Tokio                            |
 | Userland: libc++ / glib / boost | deno_std                         |
 |                 /proc/\$\$/stat | [Deno.metrics()](#metrics)       |
-|                       man pages | deno --types                     |
+|                       man pages | deno types                       |
 
 #### Resources
 


### PR DESCRIPTION
This PR refactors `main.rs` to use dedicated functions for different `deno <subcommand>`, as [discussed](https://github.com/denoland/deno/pull/2084#discussion_r275699462) in #2084

EDIT: This PR should be blocked by #2113 

EDIT2: As suggested by @kevinkassimo in #2102 and changed `--types` and `--prefetch` to respective subcommands:
```
deno --types -> deno types
deno --prefetch -> deno prefetch
```