### PR TITLE
Exclude .png files from git auto-EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Use Unix line endings in all text files.
 * text=auto eol=lf
+*.png -text
 
 # Tell git which symlinks point to files, and which ones point to directories.
 # This is revelevant for Windows only, and requires git >= 2.19.2 to work.


### PR DESCRIPTION
Fix #1995 for users with the old git version.
Make it explicit for git, that it should not treat png files as text files and so it won't try to fix EOL in images.

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
