### PR TITLE
fix typo in permissions explanation

### DIFF
--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -4,7 +4,7 @@
 // the permissions set. These tests can specify which permissions they expect,
 // which appends a special string like "permW1N0" to the end of the test name.
 // Here we run several copies of deno with different permissions, filtering the
-// tests by the special string. permW0N0 means allow-write but not allow-net.
+// tests by the special string. permW1N0 means allow-write but not allow-net.
 // See tools/unit_tests.py for more details.
 
 import * as testing from "./deps/https/deno.land/std/testing/mod.ts";

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -42,7 +42,7 @@ def run_unit_test(deno_exe, permStr, flags=None):
 # the permissions set. These tests can specify which permissions they expect,
 # which appends a special string like "permW1N0" to the end of the test name.
 # Here we run several copies of deno with different permissions, filtering the
-# tests by the special string. permW0N0 means allow-write but not allow-net.
+# tests by the special string. permW1N0 means allow-write but not allow-net.
 # See js/test_util.ts for more details.
 def unit_tests(deno_exe):
     run_unit_test(deno_exe, "permR0W0N0E0U0H0", ["--reload"])


### PR DESCRIPTION
Simple typo correction in two files.