### PR TITLE
Add Deno.kill(pid, signo) and process.kill(signo) (Unix only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/BUILD.gn
+++ b/cli/BUILD.gn
@@ -42,6 +42,9 @@ main_extern = [
 if (is_win) {
   main_extern += [ "$rust_build:winapi" ]
 }
+if (is_posix) {
+  main_extern += [ "$rust_build:nix" ]
+}
 
 ts_sources = [
   "../js/assets.ts",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,3 +50,6 @@ url = "1.7.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.7"
+
+[target.'cfg(unix)'.dependencies]
+nix = "0.11.0"

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -9,6 +9,8 @@ extern crate futures;
 extern crate serde_json;
 extern crate clap;
 extern crate deno;
+#[cfg(unix)]
+extern crate nix;
 
 mod ansi;
 pub mod compiler;
@@ -27,6 +29,7 @@ pub mod permissions;
 mod repl;
 pub mod resolve_addr;
 pub mod resources;
+mod signal;
 mod startup_data;
 pub mod state;
 mod tokio_util;

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -21,6 +21,7 @@ union Any {
   GlobalTimerStop,
   IsTTY,
   IsTTYRes,
+  Kill,
   Link,
   Listen,
   ListenRes,
@@ -129,7 +130,8 @@ enum ErrorKind: byte {
   InvalidUri,
   InvalidSeekMode,
   OpNotAvaiable,
-  WorkerInitFailed
+  WorkerInitFailed,
+  UnixError,
 }
 
 table Cwd {}
@@ -451,6 +453,11 @@ table WriteRes {
 
 table Close {
   rid: uint32;
+}
+
+table Kill {
+  pid: int32;
+  signo: int32;
 }
 
 table Shutdown {

--- a/cli/signal.rs
+++ b/cli/signal.rs
@@ -3,10 +3,11 @@ use nix::sys::signal::{kill as unix_kill, Signal};
 #[cfg(unix)]
 use nix::unistd::Pid;
 
-use crate::errors::{DenoError, DenoResult};
+use crate::errors::DenoResult;
 
 #[cfg(unix)]
 pub fn kill(pid: i32, signo: i32) -> DenoResult<()> {
+  use crate::errors::DenoError;
   let sig = Signal::from_c_int(signo)?;
   unix_kill(Pid::from_raw(pid), Option::Some(sig)).map_err(DenoError::from)
 }

--- a/cli/signal.rs
+++ b/cli/signal.rs
@@ -1,0 +1,19 @@
+#[cfg(unix)]
+use nix::sys::signal::{kill as unix_kill, Signal};
+#[cfg(unix)]
+use nix::unistd::Pid;
+
+use crate::errors::{DenoError, DenoResult};
+
+#[cfg(unix)]
+pub fn kill(pid: i32, signo: i32) -> DenoResult<()> {
+  let sig = Signal::from_c_int(signo)?;
+  unix_kill(Pid::from_raw(pid), Option::Some(sig)).map_err(DenoError::from)
+}
+
+#[cfg(not(unix))]
+pub fn kill(_pid: i32, _signal: i32) -> DenoResult<()> {
+  // NOOP
+  // TODO: implement this for windows
+  Ok(())
+}

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -68,7 +68,14 @@ export { FileInfo } from "./file_info";
 export { connect, dial, listen, Listener, Conn } from "./net";
 export { metrics, Metrics } from "./metrics";
 export { resources } from "./resources";
-export { run, RunOptions, Process, ProcessStatus } from "./process";
+export {
+  kill,
+  run,
+  RunOptions,
+  Process,
+  ProcessStatus,
+  Signal
+} from "./process";
 export { inspect } from "./console";
 export { build, platform, OperatingSystem, Arch } from "./build";
 export { version } from "./version";

--- a/js/process.ts
+++ b/js/process.ts
@@ -51,6 +51,16 @@ async function runStatus(rid: number): Promise<ProcessStatus> {
   }
 }
 
+/** Send a signal to process under given PID. Unix only at this moment.
+ * If pid is negative, the signal will be sent to the process group identified
+ * by -pid.
+ */
+export function kill(pid: number, signo: number): void {
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.Kill.createKill(builder, pid, signo);
+  dispatch.sendSync(builder, msg.Any.Kill, inner);
+}
+
 export class Process {
   readonly rid: number;
   readonly pid: number;
@@ -112,6 +122,10 @@ export class Process {
 
   close(): void {
     close(this.rid);
+  }
+
+  kill(signo: number) {
+    kill(this.pid, signo);
   }
 }
 
@@ -178,4 +192,38 @@ export function run(opt: RunOptions): Process {
   assert(baseRes!.inner(res) != null);
 
   return new Process(res);
+}
+
+export enum Signal {
+  SIGHUP = 1,
+  SIGINT,
+  SIGQUIT,
+  SIGILL,
+  SIGTRAP,
+  SIGABRT,
+  SIGBUS,
+  SIGFPE,
+  SIGKILL,
+  SIGUSR1,
+  SIGSEGV,
+  SIGUSR2,
+  SIGPIPE,
+  SIGALRM,
+  SIGTERM,
+  SIGSTKFLT,
+  SIGCHLD,
+  SIGCONT,
+  SIGSTOP,
+  SIGTSTP,
+  SIGTTIN,
+  SIGTTOU,
+  SIGURG,
+  SIGXCPU,
+  SIGXFSZ,
+  SIGVTALRM,
+  SIGPROF,
+  SIGWINCH,
+  SIGIO,
+  SIGPWR,
+  SIGSYS
 }

--- a/js/process.ts
+++ b/js/process.ts
@@ -124,7 +124,7 @@ export class Process {
     close(this.rid);
   }
 
-  kill(signo: number) {
+  kill(signo: number): void {
     kill(this.pid, signo);
   }
 }

--- a/js/process.ts
+++ b/js/process.ts
@@ -7,6 +7,7 @@ import { File, close } from "./files";
 import { ReadCloser, WriteCloser } from "./io";
 import { readAll } from "./buffer";
 import { assert, unreachable } from "./util";
+import { platform } from "./build";
 
 /** How to handle subprocess stdio.
  *
@@ -194,36 +195,76 @@ export function run(opt: RunOptions): Process {
   return new Process(res);
 }
 
-export enum Signal {
+// From `kill -l`
+enum LinuxSignal {
   SIGHUP = 1,
-  SIGINT,
-  SIGQUIT,
-  SIGILL,
-  SIGTRAP,
-  SIGABRT,
-  SIGBUS,
-  SIGFPE,
-  SIGKILL,
-  SIGUSR1,
-  SIGSEGV,
-  SIGUSR2,
-  SIGPIPE,
-  SIGALRM,
-  SIGTERM,
-  SIGSTKFLT,
-  SIGCHLD,
-  SIGCONT,
-  SIGSTOP,
-  SIGTSTP,
-  SIGTTIN,
-  SIGTTOU,
-  SIGURG,
-  SIGXCPU,
-  SIGXFSZ,
-  SIGVTALRM,
-  SIGPROF,
-  SIGWINCH,
-  SIGIO,
-  SIGPWR,
-  SIGSYS
+  SIGINT = 2,
+  SIGQUIT = 3,
+  SIGILL = 4,
+  SIGTRAP = 5,
+  SIGABRT = 6,
+  SIGBUS = 7,
+  SIGFPE = 8,
+  SIGKILL = 9,
+  SIGUSR1 = 10,
+  SIGSEGV = 11,
+  SIGUSR2 = 12,
+  SIGPIPE = 13,
+  SIGALRM = 14,
+  SIGTERM = 15,
+  SIGSTKFLT = 16,
+  SIGCHLD = 17,
+  SIGCONT = 18,
+  SIGSTOP = 19,
+  SIGTSTP = 20,
+  SIGTTIN = 21,
+  SIGTTOU = 22,
+  SIGURG = 23,
+  SIGXCPU = 24,
+  SIGXFSZ = 25,
+  SIGVTALRM = 26,
+  SIGPROF = 27,
+  SIGWINCH = 28,
+  SIGIO = 29,
+  SIGPWR = 30,
+  SIGSYS = 31
 }
+
+// From `kill -l`
+enum MacOSSignal {
+  SIGHUP = 1,
+  SIGINT = 2,
+  SIGQUIT = 3,
+  SIGILL = 4,
+  SIGTRAP = 5,
+  SIGABRT = 6,
+  SIGEMT = 7,
+  SIGFPE = 8,
+  SIGKILL = 9,
+  SIGBUS = 10,
+  SIGSEGV = 11,
+  SIGSYS = 12,
+  SIGPIPE = 13,
+  SIGALRM = 14,
+  SIGTERM = 15,
+  SIGURG = 16,
+  SIGSTOP = 17,
+  SIGTSTP = 18,
+  SIGCONT = 19,
+  SIGCHLD = 20,
+  SIGTTIN = 21,
+  SIGTTOU = 22,
+  SIGIO = 23,
+  SIGXCPU = 24,
+  SIGXFSZ = 25,
+  SIGVTALRM = 26,
+  SIGPROF = 27,
+  SIGWINCH = 28,
+  SIGINFO = 29,
+  SIGUSR1 = 30,
+  SIGUSR2 = 31
+}
+
+/** Signals numbers. This is platform dependent.
+ */
+export const Signal = platform.os === "mac" ? MacOSSignal : LinuxSignal;

--- a/js/process_test.ts
+++ b/js/process_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, testPerm, assert, assertEquals } from "./test_util.ts";
-const { run, DenoError, ErrorKind } = Deno;
+const { kill, run, DenoError, ErrorKind } = Deno;
 
 test(function runPermissions(): void {
   let caughtError = false;
@@ -223,3 +223,61 @@ testPerm({ run: true }, async function runEnv(): Promise<void> {
   assertEquals(s, "01234567");
   p.close();
 });
+
+testPerm({ run: true }, async function runClose() {
+  const p = run({
+    args: [
+      "python",
+      "-c",
+      "from time import sleep; import sys; sleep(10000); sys.stderr.write('error')"
+    ],
+    stderr: "piped"
+  });
+  assert(!p.stdin);
+  assert(!p.stdout);
+
+  p.close();
+
+  const data = new Uint8Array(10);
+  let r = await p.stderr.read(data);
+  assertEquals(r.nread, 0);
+  assertEquals(r.eof, true);
+});
+
+// Ignore signal tests on windows for now...
+if (Deno.platform.os !== "win") {
+  testPerm({ run: true }, async function killSuccess() {
+    const p = run({
+      args: ["python", "-c", "from time import sleep; sleep(10000)"]
+    });
+
+    assertEquals(Deno.Signal.SIGINT, 2);
+    kill(p.pid, Deno.Signal.SIGINT);
+    const status = await p.status();
+
+    assertEquals(status.success, false);
+    assertEquals(status.code, undefined);
+    assertEquals(status.signal, Deno.Signal.SIGINT);
+  });
+
+  testPerm({ run: true }, async function killFailed() {
+    const p = run({
+      args: ["python", "-c", "from time import sleep; sleep(10000)"]
+    });
+    assert(!p.stdin);
+    assert(!p.stdout);
+
+    let err;
+    try {
+      kill(p.pid, 12345);
+    } catch (e) {
+      err = e;
+    }
+
+    assert(!!err);
+    assertEquals(err.kind, Deno.ErrorKind.InvalidInput);
+    assertEquals(err.name, "InvalidInput");
+
+    p.close();
+  });
+}

--- a/js/process_test.ts
+++ b/js/process_test.ts
@@ -244,6 +244,14 @@ testPerm({ run: true }, async function runClose(): Promise<void> {
   assertEquals(r.eof, true);
 });
 
+test(function signalNumbers(): void {
+  if (Deno.platform.os === "mac") {
+    assertEquals(Deno.Signal.SIGSTOP, 17);
+  } else if (Deno.platform.os === "linux") {
+    assertEquals(Deno.Signal.SIGSTOP, 19);
+  }
+});
+
 // Ignore signal tests on windows for now...
 if (Deno.platform.os !== "win") {
   testPerm({ run: true }, async function killSuccess(): Promise<void> {

--- a/js/process_test.ts
+++ b/js/process_test.ts
@@ -224,7 +224,7 @@ testPerm({ run: true }, async function runEnv(): Promise<void> {
   p.close();
 });
 
-testPerm({ run: true }, async function runClose() {
+testPerm({ run: true }, async function runClose(): Promise<void> {
   const p = run({
     args: [
       "python",
@@ -246,7 +246,7 @@ testPerm({ run: true }, async function runClose() {
 
 // Ignore signal tests on windows for now...
 if (Deno.platform.os !== "win") {
-  testPerm({ run: true }, async function killSuccess() {
+  testPerm({ run: true }, async function killSuccess(): Promise<void> {
     const p = run({
       args: ["python", "-c", "from time import sleep; sleep(10000)"]
     });
@@ -260,7 +260,7 @@ if (Deno.platform.os !== "win") {
     assertEquals(status.signal, Deno.Signal.SIGINT);
   });
 
-  testPerm({ run: true }, async function killFailed() {
+  testPerm({ run: true }, async function killFailed(): Promise<void> {
     const p = run({
       args: ["python", "-c", "from time import sleep; sleep(10000)"]
     });


### PR DESCRIPTION
Implemented for Unix only first.

+ Node: [`process.kill(pid[, signal])`](https://nodejs.org/api/process.html#process_process_kill_pid_signal)
+ Python: [`os.kill(pid, sig)`](https://docs.python.org/2/library/os.html#os.kill)
+ C: [`int kill(pid_t pid, int sig)`](http://man7.org/linux/man-pages/man2/kill.2.html)
+ Go: [`os.FindProcess` + `func (p *Process) Signal(sig Signal) error`](https://golang.org/pkg/os/#Process.Signal)

Also add a test to verify if process gets killed on `close` is working fine. If it works, then we might want to close #1494 