### PR TITLE
Ignore type parameter on non-Windows platforms in symlink

### DIFF
--- a/js/symlink.ts
+++ b/js/symlink.ts
@@ -3,6 +3,7 @@ import * as msg from "gen/cli/msg_generated";
 import * as flatbuffers from "./flatbuffers";
 import * as dispatch from "./dispatch";
 import * as util from "./util";
+import { platform } from "./deno";
 
 function req(
   oldname: string,
@@ -10,7 +11,7 @@ function req(
   type?: string
 ): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
   // TODO Use type for Windows.
-  if (type) {
+  if (platform.os === "win" && type) {
     return util.notImplemented();
   }
   const builder = flatbuffers.createBuilder();

--- a/js/symlink.ts
+++ b/js/symlink.ts
@@ -3,14 +3,13 @@ import * as msg from "gen/cli/msg_generated";
 import * as flatbuffers from "./flatbuffers";
 import * as dispatch from "./dispatch";
 import * as util from "./util";
-import { platform } from "./deno";
+import { platform } from "./build";
 
 function req(
   oldname: string,
   newname: string,
   type?: string
 ): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
-  // TODO Use type for Windows.
   if (platform.os === "win" && type) {
     return util.notImplemented();
   }

--- a/js/symlink_test.ts
+++ b/js/symlink_test.ts
@@ -14,6 +14,7 @@ testPerm({ read: true, write: true }, function symlinkSyncSuccess(): void {
     errOnWindows = e;
   }
   if (errOnWindows) {
+    assertEquals(Deno.platform.os, "win");
     assertEquals(errOnWindows.kind, Deno.ErrorKind.Other);
     assertEquals(errOnWindows.message, "Not implemented");
   } else {
@@ -36,6 +37,7 @@ test(function symlinkSyncPerm(): void {
 });
 
 // Just for now, until we implement symlink for Windows.
+// Symlink with type should succeed on other platforms with type ignored
 testPerm({ write: true }, function symlinkSyncNotImplemented(): void {
   let err;
   try {
@@ -43,7 +45,10 @@ testPerm({ write: true }, function symlinkSyncNotImplemented(): void {
   } catch (e) {
     err = e;
   }
-  assertEquals(err.message, "Not implemented");
+  if (err) {
+    assertEquals(Deno.platform.os, "win");
+    assertEquals(err.message, "Not implemented");
+  }
 });
 
 testPerm({ read: true, write: true }, async function symlinkSuccess(): Promise<


### PR DESCRIPTION
Quick fix of [issue 2169](https://github.com/denoland/deno/issues/2169): the `type` parameter in symlink is ignored for non-Windows platforms.
