### PR TITLE
Rename CLI flags to subcommands

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -34,7 +34,6 @@ pub fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
     .global_settings(&[AppSettings::ColorNever])
     .settings(&[
       AppSettings::AllowExternalSubcommands,
-      AppSettings::DisableHelpSubcommand,
     ]).after_help(ENV_VARIABLES_HELP)
     .arg(
       Arg::with_name("version")

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -35,8 +35,7 @@ pub fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
     .settings(&[
       AppSettings::AllowExternalSubcommands,
       AppSettings::DisableVersion,
-    ])
-    .after_help(ENV_VARIABLES_HELP)
+    ]).after_help(ENV_VARIABLES_HELP)
     .arg(
       Arg::with_name("allow-read")
         .long("allow-read")
@@ -91,10 +90,8 @@ pub fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
         .use_delimiter(true)
         .require_equals(true)
         .help("Set V8 command line options"),
-    ).subcommand(
-      SubCommand::with_name("version")
-        .about("Print the version"),
-    ).subcommand(
+    ).subcommand(SubCommand::with_name("version").about("Print the version"))
+    .subcommand(
       SubCommand::with_name("fetch")
         .setting(AppSettings::DisableVersion)
         .about("Fetch the dependencies")

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -34,13 +34,10 @@ pub fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
     .global_settings(&[AppSettings::ColorNever])
     .settings(&[
       AppSettings::AllowExternalSubcommands,
-    ]).after_help(ENV_VARIABLES_HELP)
+      AppSettings::DisableVersion,
+    ])
+    .after_help(ENV_VARIABLES_HELP)
     .arg(
-      Arg::with_name("version")
-        .short("v")
-        .long("version")
-        .help("Print the version"),
-    ).arg(
       Arg::with_name("allow-read")
         .long("allow-read")
         .help("Allow file system read access"),
@@ -94,6 +91,9 @@ pub fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
         .use_delimiter(true)
         .require_equals(true)
         .help("Set V8 command line options"),
+    ).subcommand(
+      SubCommand::with_name("version")
+        .about("Print the version"),
     ).subcommand(
       SubCommand::with_name("fetch")
         .setting(AppSettings::DisableVersion)
@@ -204,7 +204,7 @@ mod tests {
 
   #[test]
   fn test_set_flags_1() {
-    let flags = flags_from_vec(svec!["deno", "--version"]);
+    let flags = flags_from_vec(svec!["deno", "version"]);
     assert_eq!(
       flags,
       DenoFlags {

--- a/website/manual.md
+++ b/website/manual.md
@@ -553,7 +553,6 @@ FLAGS:
         --no-prompt               Do not use prompts
     -r, --reload                  Reload source code cache (recompile TypeScript)
         --v8-options              Print V8 command line options
-    -v, --version                 Print the version
 
 OPTIONS:
         --v8-flags=<v8-flags>    Set V8 command line options
@@ -566,6 +565,7 @@ SUBCOMMANDS:
     help        Prints this message or the help of the given subcommand(s)
     info        Show source file related info
     types       Print runtime TypeScript declarations
+    version     Print the version
 
 ENVIRONMENT VARIABLES:
     DENO_DIR        Set deno's base directory

--- a/website/manual.md
+++ b/website/manual.md
@@ -563,6 +563,7 @@ SUBCOMMANDS:
     eval        Eval script
     fetch       Fetch the dependencies
     fmt         Format files
+    help        Prints this message or the help of the given subcommand(s)
     info        Show source file related info
     types       Print runtime TypeScript declarations
 


### PR DESCRIPTION
This PR changes CLI flags `--help` and `--version` to subcommands.

* Changes to `deno --version`:
It has been renamed to `deno version` subcommand, so effectively you no longer can do `deno --version some_file.ts`
```shellsession
$ deno version
deno: 0.3.9
v8: 7.4.238
typescript: 3.4.1
```

* Changes to `deno --help`:
Deno still has `deno --help` and `deno -h`. Additionally a new subcommand `deno help` is present which can be used two-fold:
```shellsession
$ deno help // works just like deno -h
deno

USAGE:
    deno [FLAGS] [OPTIONS] [SUBCOMMAND]
...

$ deno help <subcommand> // display help for subcommand

$ deno help eval
Eval script

USAGE:
    deno eval <code>

FLAGS:
    -h, --help    Prints help information

ARGS:
    <code>
```

@ry if #2189 is a go, I'll add it to this PR as well