### PR TITLE
removes ? from URL when deleting all params

### DIFF
--- a/js/url.ts
+++ b/js/url.ts
@@ -8,7 +8,7 @@ interface URLParts {
   hostname: string;
   port: string;
   path: string;
-  query: string;
+  query: string | null;
   hash: string;
 }
 
@@ -64,7 +64,7 @@ function parse(url: string): URLParts | undefined {
 }
 
 export class URL {
-  private _parts: URLParts;
+  _parts: URLParts;
   private _searchParams!: urlSearchParams.URLSearchParams;
 
   private _updateSearchParams(): void {
@@ -192,15 +192,26 @@ export class URL {
   }
 
   get search(): string {
+    if (this._parts.query === null || this._parts.query === "") {
+      return "";
+    }
+
     return this._parts.query;
   }
 
   set search(value: string) {
     value = String(value);
-    if (value.charAt(0) !== "?") {
-      value = `?${value}`;
+    let query: string | null;
+
+    if (value === "") {
+      query = null;
+    } else if (value.charAt(0) !== "?") {
+      query = `?${value}`;
+    } else {
+      query = value;
     }
-    this._parts.query = value;
+
+    this._parts.query = query;
     this._updateSearchParams();
   }
 

--- a/js/url.ts
+++ b/js/url.ts
@@ -64,7 +64,7 @@ function parse(url: string): URLParts | undefined {
 }
 
 export class URL {
-  _parts: URLParts;
+  private _parts: URLParts;
   private _searchParams!: urlSearchParams.URLSearchParams;
 
   private _updateSearchParams(): void {

--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -1,8 +1,10 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { URL } from "./url";
 import { requiredArguments } from "./util";
 
 export class URLSearchParams {
   private params: Array<[string, string]> = [];
+  private url: URL | null = null;
 
   constructor(init: string | string[][] | Record<string, string> = "") {
     if (typeof init === "string") {
@@ -22,6 +24,19 @@ export class URLSearchParams {
     // Overload: record<USVString, USVString>
     for (const key of Object.keys(init)) {
       this.append(key, init[key]);
+    }
+  }
+
+  private updateSteps(): void {
+    if (this.url === null) {
+      return;
+    }
+
+    let query = this.toString();
+    if (query === "") {
+      this.url._parts.query = null;
+    } else {
+      this.url._parts.query = query;
     }
   }
 
@@ -51,6 +66,7 @@ export class URLSearchParams {
         i++;
       }
     }
+    this.updateSteps();
   }
 
   /** Returns all the values associated with a given search parameter

--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -32,12 +32,13 @@ export class URLSearchParams {
       return;
     }
 
-    let query = this.toString();
+    let query: string | null = this.toString();
     if (query === "") {
-      this.url._parts.query = null;
-    } else {
-      this.url._parts.query = query;
+      query = null;
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.url as any)._parts.query = query;
   }
 
   /** Appends a specified key/value pair as a new search parameter.

--- a/js/url_test.ts
+++ b/js/url_test.ts
@@ -141,3 +141,19 @@ test(function urlBaseString(): void {
   );
   assertEquals(url.href, "https://foo:bar@baz.qat:8000/foo/bar?baz=foo#qux");
 });
+
+test(function deletingAllParamsRemovesQuestionMarkFromURL(): void {
+  const url = new URL("http://example.com/?param1&param2");
+  url.searchParams.delete("param1");
+  url.searchParams.delete("param2");
+  assertEquals(url.href, "http://example.com/");
+  assertEquals(url.search, "");
+});
+
+test(function removingNonExistentParamRemovesQuestionMarkFromURL(): void {
+  const url = new URL("http://example.com/?");
+  assertEquals(url.href, "http://example.com/?");
+  url.searchParams.delete("param1");
+  assertEquals(url.href, "http://example.com/");
+  assertEquals(url.search, "");
+});


### PR DESCRIPTION
wpt: https://github.com/web-platform-tests/wpt/blob/master/url/urlsearchparams-delete.any.js#L32-L45

```ts
const url = new URL('http://example.com/?');
url.href === 'http://example.com/?'
//                               ↑
//                              HERE(with ?)

// Removing non-existent param
url.searchParams.delete('param1'); 
url.href === 'http://example.com/'
//                               ↑
//                              HERE(without ?)
```