### PR TITLE
core: Remove await from write in http_bench

### DIFF
--- a/core/examples/http_bench.js
+++ b/core/examples/http_bench.js
@@ -114,10 +114,10 @@ async function serve(rid) {
       break;
     }
 
-    const nwritten = await write(rid, responseBuf);
-    if (nwritten < 0) {
-      break;
-    }
+    // TODO(ry) asynchronously write the response. This is cheating a bit,
+    // because writes could be done out of order. This is temporary - we're just
+    // evaluating the performance penalty of having the await here.
+    write(rid, responseBuf);
   }
   close(rid);
 }


### PR DESCRIPTION
This is to evaluate the performance impact of this change.

This branch
```
> wrk -d 30 http://127.0.0.1:4544/
Running 30s test @ http://127.0.0.1:4544/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   232.04us   52.17us   4.61ms   93.34%
    Req/Sec    20.95k   768.85    22.06k    90.86%
  1254273 requests in 30.10s, 61.00MB read
Requests/sec:  41671.13
Transfer/sec:      2.03MB
```

master branch
```
> wrk -d 30 http://127.0.0.1:4544/
Running 30s test @ http://127.0.0.1:4544/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   199.30us   42.40us   3.50ms   89.39%
    Req/Sec    23.76k     1.30k   26.05k    81.23%
  1422840 requests in 30.10s, 69.20MB read
Requests/sec:  47272.11
Transfer/sec:      2.30MB
```