### PR TITLE
Replace indirect eval with globalThis

### DIFF
--- a/js/window.ts
+++ b/js/window.ts
@@ -1,10 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
-// (0, eval) is indirect eval.
 // See the links below for details:
 // - https://stackoverflow.com/a/14120023
 // - https://tc39.github.io/ecma262/#sec-performeval (spec)
-export const window = (0, eval)("this");
-// TODO: The above should be replaced with globalThis
-// when the globalThis proposal goes to stage 4
-// See https://github.com/tc39/proposal-global
+export const window = globalThis;

--- a/js/window.ts
+++ b/js/window.ts
@@ -1,6 +1,3 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
-// See the links below for details:
-// - https://stackoverflow.com/a/14120023
-// - https://tc39.github.io/ecma262/#sec-performeval (spec)
-export const window = globalThis;
+export const window = globalThis as any;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "rollup-pluginutils": "2.4.1",
     "ts-morph": "1.3.0",
     "ts-node": "8.0.2",
-    "typescript": "3.4.1"
+    "typescript": "3.4.5"
   }
 }


### PR DESCRIPTION
Revisiting one of the TO-DOs to replace indirect eval with `globalThis`.

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
