### PR TITLE
Refactor zero-copy buffers for performance and to prevent memory leaks 

### DIFF
--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -23,11 +23,11 @@ use crate::tokio_write;
 use crate::version;
 use crate::worker::root_specifier_to_url;
 use crate::worker::Worker;
-use deno::deno_buf;
 use deno::js_check;
 use deno::Buf;
 use deno::JSError;
 use deno::Op;
+use deno::PinnedBuf;
 use flatbuffers::FlatBufferBuilder;
 use futures;
 use futures::Async;
@@ -64,7 +64,7 @@ pub type OpWithError = dyn Future<Item = Buf, Error = DenoError> + Send;
 // TODO Ideally we wouldn't have to box the OpWithError being returned.
 // The box is just to make it easier to get a prototype refactor working.
 type OpCreator =
-  fn(state: &ThreadSafeState, base: &msg::Base<'_>, data: deno_buf)
+  fn(state: &ThreadSafeState, base: &msg::Base<'_>, data: Option<PinnedBuf>)
     -> Box<OpWithError>;
 
 pub type OpSelector = fn(inner_type: msg::Any) -> Option<OpCreator>;
@@ -81,11 +81,11 @@ fn empty_buf() -> Buf {
 pub fn dispatch_all(
   state: &ThreadSafeState,
   control: &[u8],
-  zero_copy: deno_buf,
+  zero_copy: Option<PinnedBuf>,
   op_selector: OpSelector,
 ) -> (bool, Box<Op>) {
   let bytes_sent_control = control.len();
-  let bytes_sent_zero_copy = zero_copy.len();
+  let bytes_sent_zero_copy = zero_copy.as_ref().map(|b| b.len()).unwrap_or(0);
   let base = msg::get_root_as_base(&control);
   let is_sync = base.sync();
   let inner_type = base.inner_type();
@@ -226,9 +226,9 @@ pub fn op_selector_std(inner_type: msg::Any) -> Option<OpCreator> {
 fn op_now(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let seconds = state.start_time.elapsed().as_secs();
   let mut subsec_nanos = state.start_time.elapsed().subsec_nanos();
   let reduced_time_precision = 2_000_000; // 2ms in nanoseconds
@@ -262,7 +262,7 @@ fn op_now(
 fn op_is_tty(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  _data: deno_buf,
+  _data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
   let builder = &mut FlatBufferBuilder::new();
   let inner = msg::IsTTYRes::create(
@@ -287,7 +287,7 @@ fn op_is_tty(
 fn op_exit(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  _data: deno_buf,
+  _data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
   let inner = base.inner_as_exit().unwrap();
   std::process::exit(inner.code())
@@ -296,9 +296,9 @@ fn op_exit(
 fn op_start(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let mut builder = FlatBufferBuilder::new();
 
   let state = state;
@@ -351,9 +351,9 @@ fn op_start(
 fn op_format_error(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_format_error().unwrap();
   let orig_error = String::from(inner.error().unwrap());
 
@@ -410,9 +410,9 @@ pub fn odd_future(err: DenoError) -> Box<OpWithError> {
 fn op_fetch_module_meta_data(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_fetch_module_meta_data().unwrap();
   let cmd_id = base.cmd_id();
   let specifier = inner.specifier().unwrap();
@@ -452,9 +452,9 @@ fn op_fetch_module_meta_data(
 fn op_compiler_config(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_compiler_config().unwrap();
   let cmd_id = base.cmd_id();
   let compiler_type = inner.compiler_type().unwrap();
@@ -486,9 +486,9 @@ fn op_compiler_config(
 fn op_chdir(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_chdir().unwrap();
   let directory = inner.directory().unwrap();
   Box::new(futures::future::result(|| -> OpResult {
@@ -500,10 +500,10 @@ fn op_chdir(
 fn op_global_timer_stop(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
   assert!(base.sync());
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let state = state;
   let mut t = state.global_timer.lock().unwrap();
   t.cancel();
@@ -513,10 +513,10 @@ fn op_global_timer_stop(
 fn op_global_timer(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
   assert!(!base.sync());
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_global_timer().unwrap();
   let val = inner.timeout();
@@ -546,9 +546,9 @@ fn op_global_timer(
 fn op_set_env(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_set_env().unwrap();
   let key = inner.key().unwrap();
   let value = inner.value().unwrap();
@@ -562,9 +562,9 @@ fn op_set_env(
 fn op_env(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
 
   if let Err(e) = state.check_env() {
@@ -594,9 +594,9 @@ fn op_env(
 fn op_permissions(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
   let builder = &mut FlatBufferBuilder::new();
   let inner = msg::PermissionsRes::create(
@@ -624,9 +624,9 @@ fn op_permissions(
 fn op_revoke_permission(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_permission_revoke().unwrap();
   let permission = inner.permission().unwrap();
   let result = match permission {
@@ -647,7 +647,7 @@ fn op_revoke_permission(
 fn op_fetch(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
   let inner = base.inner_as_fetch().unwrap();
   let cmd_id = base.cmd_id();
@@ -656,10 +656,9 @@ fn op_fetch(
   assert!(header.is_request());
   let url = header.url().unwrap();
 
-  let body = if data.is_empty() {
-    hyper::Body::empty()
-  } else {
-    hyper::Body::from(Vec::from(&*data))
+  let body = match data {
+    None => hyper::Body::empty(),
+    Some(buf) => hyper::Body::from(Vec::from(&*buf)),
   };
 
   let maybe_req = msg_util::deserialize_request(header, body);
@@ -734,9 +733,9 @@ where
 fn op_make_temp_dir(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let base = Box::new(*base);
   let inner = base.inner_as_make_temp_dir().unwrap();
   let cmd_id = base.cmd_id();
@@ -783,9 +782,9 @@ fn op_make_temp_dir(
 fn op_mkdir(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_mkdir().unwrap();
   let path = String::from(inner.path().unwrap());
   let recursive = inner.recursive();
@@ -805,9 +804,9 @@ fn op_mkdir(
 fn op_chmod(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_chmod().unwrap();
   let _mode = inner.mode();
   let path = String::from(inner.path().unwrap());
@@ -844,9 +843,9 @@ fn op_chmod(
 fn op_open(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_open().unwrap();
   let filename_str = inner.filename().unwrap();
@@ -934,9 +933,9 @@ fn op_open(
 fn op_close(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_close().unwrap();
   let rid = inner.rid();
   match resources::lookup(rid) {
@@ -951,9 +950,9 @@ fn op_close(
 fn op_kill(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_kill().unwrap();
   let pid = inner.pid();
   let signo = inner.signo();
@@ -966,9 +965,9 @@ fn op_kill(
 fn op_shutdown(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_shutdown().unwrap();
   let rid = inner.rid();
   let how = inner.how();
@@ -992,7 +991,7 @@ fn op_shutdown(
 fn op_read(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_read().unwrap();
@@ -1001,7 +1000,7 @@ fn op_read(
   match resources::lookup(rid) {
     None => odd_future(errors::bad_resource()),
     Some(resource) => {
-      let op = tokio::io::read(resource, data)
+      let op = tokio::io::read(resource, data.unwrap())
         .map_err(DenoError::from)
         .and_then(move |(_resource, _buf, nread)| {
           let builder = &mut FlatBufferBuilder::new();
@@ -1030,7 +1029,7 @@ fn op_read(
 fn op_write(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_write().unwrap();
@@ -1039,7 +1038,7 @@ fn op_write(
   match resources::lookup(rid) {
     None => odd_future(errors::bad_resource()),
     Some(resource) => {
-      let op = tokio_write::write(resource, data)
+      let op = tokio_write::write(resource, data.unwrap())
         .map_err(DenoError::from)
         .and_then(move |(_resource, _buf, nwritten)| {
           let builder = &mut FlatBufferBuilder::new();
@@ -1067,9 +1066,9 @@ fn op_write(
 fn op_seek(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let _cmd_id = base.cmd_id();
   let inner = base.inner_as_seek().unwrap();
   let rid = inner.rid();
@@ -1089,9 +1088,9 @@ fn op_seek(
 fn op_remove(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_remove().unwrap();
   let path_ = inner.path().unwrap();
   let path = PathBuf::from(path_);
@@ -1118,9 +1117,9 @@ fn op_remove(
 fn op_copy_file(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_copy_file().unwrap();
   let from_ = inner.from().unwrap();
   let from = PathBuf::from(from_);
@@ -1174,9 +1173,9 @@ fn get_mode(_perm: &fs::Permissions) -> u32 {
 fn op_cwd(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
   Box::new(futures::future::result(|| -> OpResult {
     let path = std::env::current_dir()?;
@@ -1200,9 +1199,9 @@ fn op_cwd(
 fn op_stat(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_stat().unwrap();
   let cmd_id = base.cmd_id();
   let filename_ = inner.filename().unwrap();
@@ -1252,9 +1251,9 @@ fn op_stat(
 fn op_read_dir(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_read_dir().unwrap();
   let cmd_id = base.cmd_id();
   let path = String::from(inner.path().unwrap());
@@ -1313,9 +1312,9 @@ fn op_read_dir(
 fn op_rename(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_rename().unwrap();
   let oldpath = PathBuf::from(inner.oldpath().unwrap());
   let newpath_ = inner.newpath().unwrap();
@@ -1333,9 +1332,9 @@ fn op_rename(
 fn op_link(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_link().unwrap();
   let oldname = PathBuf::from(inner.oldname().unwrap());
   let newname_ = inner.newname().unwrap();
@@ -1355,9 +1354,9 @@ fn op_link(
 fn op_symlink(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_symlink().unwrap();
   let oldname = PathBuf::from(inner.oldname().unwrap());
   let newname_ = inner.newname().unwrap();
@@ -1384,9 +1383,9 @@ fn op_symlink(
 fn op_read_link(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_readlink().unwrap();
   let cmd_id = base.cmd_id();
   let name_ = inner.name().unwrap();
@@ -1422,9 +1421,9 @@ fn op_read_link(
 fn op_repl_start(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_repl_start().unwrap();
   let cmd_id = base.cmd_id();
   let history_file = String::from(inner.history_file().unwrap());
@@ -1453,9 +1452,9 @@ fn op_repl_start(
 fn op_repl_readline(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_repl_readline().unwrap();
   let cmd_id = base.cmd_id();
   let rid = inner.rid();
@@ -1489,9 +1488,9 @@ fn op_repl_readline(
 fn op_truncate(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
 
   let inner = base.inner_as_truncate().unwrap();
   let filename = String::from(inner.name().unwrap());
@@ -1512,9 +1511,9 @@ fn op_truncate(
 fn op_utime(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
 
   let inner = base.inner_as_utime().unwrap();
   let filename = String::from(inner.filename().unwrap());
@@ -1535,9 +1534,9 @@ fn op_utime(
 fn op_listen(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   if let Err(e) = state.check_net("listen") {
     return odd_future(e);
   }
@@ -1597,9 +1596,9 @@ fn new_conn(cmd_id: u32, tcp_stream: TcpStream) -> OpResult {
 fn op_accept(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   if let Err(e) = state.check_net("accept") {
     return odd_future(e);
   }
@@ -1623,9 +1622,9 @@ fn op_accept(
 fn op_dial(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   if let Err(e) = state.check_net("dial") {
     return odd_future(e);
   }
@@ -1649,9 +1648,9 @@ fn op_dial(
 fn op_metrics(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
 
   let builder = &mut FlatBufferBuilder::new();
@@ -1673,9 +1672,9 @@ fn op_metrics(
 fn op_resources(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
 
   let builder = &mut FlatBufferBuilder::new();
@@ -1725,7 +1724,7 @@ fn subprocess_stdio_map(v: msg::ProcessStdio) -> std::process::Stdio {
 fn op_run(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
   assert!(base.sync());
   let cmd_id = base.cmd_id();
@@ -1734,7 +1733,7 @@ fn op_run(
     return odd_future(e);
   }
 
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let inner = base.inner_as_run().unwrap();
   let args = inner.args().unwrap();
   let env = inner.env().unwrap();
@@ -1798,9 +1797,9 @@ fn op_run(
 fn op_run_status(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_run_status().unwrap();
   let rid = inner.rid();
@@ -1871,9 +1870,9 @@ impl Future for GetMessageFuture {
 fn op_worker_get_message(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
 
   let op = GetMessageFuture {
@@ -1906,11 +1905,11 @@ fn op_worker_get_message(
 fn op_worker_post_message(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
   let cmd_id = base.cmd_id();
 
-  let d = Vec::from(data.as_ref()).into_boxed_slice();
+  let d = Vec::from(data.unwrap().as_ref()).into_boxed_slice();
 
   let tx = {
     let wc = state.worker_channels.lock().unwrap();
@@ -1936,9 +1935,9 @@ fn op_worker_post_message(
 fn op_create_worker(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_create_worker().unwrap();
   let specifier = inner.specifier().unwrap();
@@ -1995,9 +1994,9 @@ fn op_create_worker(
 fn op_host_get_worker_closed(
   state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_host_get_worker_closed().unwrap();
   let rid = inner.rid();
@@ -2026,9 +2025,9 @@ fn op_host_get_worker_closed(
 fn op_host_get_message(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
-  assert_eq!(data.len(), 0);
+  assert!(data.is_none());
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_host_get_message().unwrap();
   let rid = inner.rid();
@@ -2060,13 +2059,13 @@ fn op_host_get_message(
 fn op_host_post_message(
   _state: &ThreadSafeState,
   base: &msg::Base<'_>,
-  data: deno_buf,
+  data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_host_post_message().unwrap();
   let rid = inner.rid();
 
-  let d = Vec::from(data.as_ref()).into_boxed_slice();
+  let d = Vec::from(data.unwrap().as_ref()).into_boxed_slice();
 
   let op = resources::post_message_to_worker(rid, d);
   let op = op.map_err(|e| errors::new(ErrorKind::Other, e.to_string()));

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -8,9 +8,9 @@ use crate::permissions::DenoPermissions;
 use crate::resources;
 use crate::resources::ResourceId;
 use crate::worker::Worker;
-use deno::deno_buf;
 use deno::Buf;
 use deno::Op;
+use deno::PinnedBuf;
 use futures::future::Shared;
 use std;
 use std::collections::HashMap;
@@ -84,7 +84,7 @@ impl ThreadSafeState {
   pub fn dispatch(
     &self,
     control: &[u8],
-    zero_copy: deno_buf,
+    zero_copy: Option<PinnedBuf>,
   ) -> (bool, Box<Op>) {
     ops::dispatch_all(self, control, zero_copy, self.dispatch_selector)
   }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -16,6 +16,7 @@ pub use crate::isolate::*;
 pub use crate::js_errors::*;
 pub use crate::libdeno::deno_buf;
 pub use crate::libdeno::deno_mod;
+pub use crate::libdeno::PinnedBuf;
 pub use crate::modules::*;
 
 pub fn v8_version() -> &'static str {

--- a/core/libdeno/BUILD.gn
+++ b/core/libdeno/BUILD.gn
@@ -46,6 +46,7 @@ v8_source_set("libdeno") {
   sources = [
     "api.cc",
     "binding.cc",
+    "buffer.h",
     "deno.h",
     "exceptions.cc",
     "exceptions.h",

--- a/core/libdeno/api.cc
+++ b/core/libdeno/api.cc
@@ -46,7 +46,7 @@ Deno* deno_new(deno_config config) {
   }
   deno::DenoIsolate* d = new deno::DenoIsolate(config);
   v8::Isolate::CreateParams params;
-  params.array_buffer_allocator = d->array_buffer_allocator_;
+  params.array_buffer_allocator = &deno::ArrayBufferAllocator::global();
   params.external_references = deno::external_references;
 
   if (config.load_snapshot.data_ptr) {
@@ -148,12 +148,9 @@ void deno_execute(Deno* d_, void* user_data, const char* js_filename,
   deno::Execute(context, js_filename, js_source);
 }
 
-void deno_zero_copy_release(Deno* d_, size_t zero_copy_id) {
-  auto* d = unwrap(d_);
-  v8::Isolate::Scope isolate_scope(d->isolate_);
-  v8::Locker locker(d->isolate_);
-  v8::HandleScope handle_scope(d->isolate_);
-  d->DeleteZeroCopyRef(zero_copy_id);
+void deno_pinned_buf_delete(deno_pinned_buf* buf) {
+  // The PinnedBuf destructor implicitly releases the ArrayBuffer reference.
+  auto _ = deno::PinnedBuf(*buf);
 }
 
 void deno_respond(Deno* d_, void* user_data, deno_buf buf) {
@@ -161,7 +158,6 @@ void deno_respond(Deno* d_, void* user_data, deno_buf buf) {
   if (d->current_args_ != nullptr) {
     // Synchronous response.
     if (buf.data_ptr != nullptr) {
-      DCHECK_EQ(buf.zero_copy_id, 0);
       auto ab = deno::ImportBuf(d, buf);
       d->current_args_->GetReturnValue().Set(ab);
     }
@@ -189,9 +185,6 @@ void deno_respond(Deno* d_, void* user_data, deno_buf buf) {
   v8::Local<v8::Value> args[1];
   int argc = 0;
 
-  // You cannot use zero_copy_buf with deno_respond(). Use
-  // deno_zero_copy_release() instead.
-  DCHECK_EQ(buf.zero_copy_id, 0);
   if (buf.data_ptr != nullptr) {
     args[0] = deno::ImportBuf(d, buf);
     argc = 1;

--- a/core/libdeno/buffer.h
+++ b/core/libdeno/buffer.h
@@ -1,0 +1,140 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+#ifndef BUFFER_H_
+#define BUFFER_H_
+
+// Cpplint bans the use of <mutex> because it duplicates functionality in
+// chromium //base. However Deno doensn't use that, so suppress that lint.
+#include <memory>
+#include <mutex>  // NOLINT
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "third_party/v8/include/v8.h"
+#include "third_party/v8/src/base/logging.h"
+
+namespace deno {
+
+class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
+ public:
+  static ArrayBufferAllocator& global() {
+    static ArrayBufferAllocator global_instance;
+    return global_instance;
+  }
+
+  void* Allocate(size_t length) override { return new uint8_t[length](); }
+
+  void* AllocateUninitialized(size_t length) override {
+    return new uint8_t[length];
+  }
+
+  void Free(void* data, size_t length) override { Unref(data); }
+
+ private:
+  friend class PinnedBuf;
+
+  void Ref(void* data) {
+    std::lock_guard<std::mutex> lock(ref_count_map_mutex_);
+    // Note:
+    //  - `unordered_map::insert(make_pair(key, value))` returns the existing
+    //    item if the key, already exists in the map, otherwise it creates an
+    //    new entry with `value`.
+    //  - Buffers not in the map have an implicit reference count of one.
+    auto entry = ref_count_map_.insert(std::make_pair(data, 1)).first;
+    ++entry->second;
+  }
+
+  void Unref(void* data) {
+    {
+      std::lock_guard<std::mutex> lock(ref_count_map_mutex_);
+      auto entry = ref_count_map_.find(data);
+      if (entry == ref_count_map_.end()) {
+        // Buffers not in the map have an implicit ref count of one. After
+        // dereferencing there are no references left, so we delete the buffer.
+      } else if (--entry->second == 0) {
+        // The reference count went to zero, so erase the map entry and free the
+        // buffer.
+        ref_count_map_.erase(entry);
+      } else {
+        // After decreasing the reference count the buffer still has references
+        // left, so we leave the pin in place.
+        return;
+      }
+      delete[] reinterpret_cast<uint8_t*>(data);
+    }
+  }
+
+ private:
+  ArrayBufferAllocator() {}
+
+  ~ArrayBufferAllocator() {
+    // TODO(pisciaureus): Enable this check. It currently fails sometimes
+    // because the compiler worker isolate never actually exits, so when the
+    // process exits this isolate still holds on to some buffers.
+    // CHECK(ref_count_map_.empty());
+  }
+
+  std::unordered_map<void*, size_t> ref_count_map_;
+  std::mutex ref_count_map_mutex_;
+};
+
+class PinnedBuf {
+  struct Unref {
+    // This callback gets called from the Pin destructor.
+    void operator()(void* ptr) { ArrayBufferAllocator::global().Unref(ptr); }
+  };
+  // The Pin is a unique (non-copyable) smart pointer which automatically
+  // unrefs the referenced ArrayBuffer in its destructor.
+  using Pin = std::unique_ptr<void, Unref>;
+
+  uint8_t* data_ptr_;
+  size_t data_len_;
+  Pin pin_;
+
+ public:
+  // PinnedBuf::Raw is a POD struct with the same memory layout as the PinBuf
+  // itself. It is used to move a PinnedBuf between C and Rust.
+  struct Raw {
+    uint8_t* data_ptr;
+    size_t data_len;
+    void* pin;
+  };
+
+  PinnedBuf() : data_ptr_(nullptr), data_len_(0), pin_() {}
+
+  explicit PinnedBuf(v8::Local<v8::ArrayBufferView> view) {
+    auto buf = view->Buffer()->GetContents().Data();
+    ArrayBufferAllocator::global().Ref(buf);
+
+    data_ptr_ = reinterpret_cast<uint8_t*>(buf) + view->ByteOffset();
+    data_len_ = view->ByteLength();
+    pin_ = Pin(buf);
+  }
+
+  // This constructor recreates a PinnedBuf that has previously been converted
+  // to a PinnedBuf::Raw using the IntoRaw() method. This is a move operation;
+  // the Raw struct is emptied in the process.
+  explicit PinnedBuf(Raw raw)
+      : data_ptr_(raw.data_ptr), data_len_(raw.data_len), pin_(raw.pin) {
+    raw.data_ptr = nullptr;
+    raw.data_len = 0;
+    raw.pin = nullptr;
+  }
+
+  // The IntoRaw() method converts the PinnedBuf to a PinnedBuf::Raw so it's
+  // ownership can be moved to Rust. The source PinnedBuf is emptied in the
+  // process, but the pinned ArrayBuffer is not dereferenced. In order to not
+  // leak it, the raw struct must eventually be turned back into a PinnedBuf
+  // using the constructor above.
+  Raw IntoRaw() {
+    Raw raw{
+        .data_ptr = data_ptr_, .data_len = data_len_, .pin = pin_.release()};
+    data_ptr_ = nullptr;
+    data_len_ = 0;
+    return raw;
+  }
+};
+
+}  // namespace deno
+
+#endif  // BUFFER_H_

--- a/core/libdeno/internal.h
+++ b/core/libdeno/internal.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "buffer.h"
 #include "deno.h"
 #include "third_party/v8/include/v8.h"
 #include "third_party/v8/src/base/logging.h"
@@ -36,11 +38,9 @@ class DenoIsolate {
         snapshot_creator_(nullptr),
         global_import_buf_ptr_(nullptr),
         recv_cb_(config.recv_cb),
-        next_zero_copy_id_(1),  // zero_copy_id must not be zero.
         user_data_(nullptr),
         resolve_cb_(nullptr),
         has_snapshotted_(false) {
-    array_buffer_allocator_ = v8::ArrayBuffer::Allocator::NewDefaultAllocator();
     if (config.load_snapshot.data_ptr) {
       snapshot_.data =
           reinterpret_cast<const char*>(config.load_snapshot.data_ptr);
@@ -65,7 +65,6 @@ class DenoIsolate {
     } else {
       isolate_->Dispose();
     }
-    delete array_buffer_allocator_;
   }
 
   static inline DenoIsolate* FromIsolate(v8::Isolate* isolate) {
@@ -89,31 +88,13 @@ class DenoIsolate {
     }
   }
 
-  void DeleteZeroCopyRef(size_t zero_copy_id) {
-    DCHECK_NE(zero_copy_id, 0);
-    // Delete persistent reference to data ArrayBuffer.
-    auto it = zero_copy_map_.find(zero_copy_id);
-    if (it != zero_copy_map_.end()) {
-      it->second.Reset();
-      zero_copy_map_.erase(it);
-    }
-  }
-
-  void AddZeroCopyRef(size_t zero_copy_id, v8::Local<v8::Value> zero_copy_v) {
-    zero_copy_map_.emplace(std::piecewise_construct,
-                           std::make_tuple(zero_copy_id),
-                           std::make_tuple(isolate_, zero_copy_v));
-  }
-
   v8::Isolate* isolate_;
   v8::Locker* locker_;
-  v8::ArrayBuffer::Allocator* array_buffer_allocator_;
   deno_buf shared_;
   const v8::FunctionCallbackInfo<v8::Value>* current_args_;
   v8::SnapshotCreator* snapshot_creator_;
   void* global_import_buf_ptr_;
   deno_recv_cb recv_cb_;
-  size_t next_zero_copy_id_;
   void* user_data_;
 
   std::map<deno_mod, ModuleInfo> mods_;
@@ -121,7 +102,6 @@ class DenoIsolate {
   deno_resolve_cb resolve_cb_;
 
   v8::Persistent<v8::Context> context_;
-  std::map<size_t, v8::Persistent<v8::Value>> zero_copy_map_;
   std::map<int, v8::Persistent<v8::Value>> pending_promise_map_;
   std::string last_exception_;
   v8::Persistent<v8::Function> recv_;
@@ -177,7 +157,7 @@ static intptr_t external_references[] = {
     reinterpret_cast<intptr_t>(MessageCallback),
     0};
 
-static const deno_buf empty_buf = {nullptr, 0, nullptr, 0, 0};
+static const deno_buf empty_buf = {nullptr, 0, nullptr, 0};
 static const deno_snapshot empty_snapshot = {nullptr, 0};
 
 Deno* NewFromSnapshot(void* user_data, deno_recv_cb cb);

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -54,17 +54,6 @@ deno_buf strbuf(const char* str) {
   return buf;
 }
 
-// Same as strbuf but with null alloc_ptr.
-deno_buf StrBufNullAllocPtr(const char* str) {
-  auto len = strlen(str);
-  deno_buf buf;
-  buf.alloc_ptr = nullptr;
-  buf.alloc_len = 0;
-  buf.data_ptr = reinterpret_cast<uint8_t*>(strdup(str));
-  buf.data_len = len;
-  return buf;
-}
-
 void assert_null(deno_buf b) {
   EXPECT_EQ(b.alloc_ptr, nullptr);
   EXPECT_EQ(b.alloc_len, 0u);

--- a/core/libdeno/modules_test.cc
+++ b/core/libdeno/modules_test.cc
@@ -1,13 +1,14 @@
-// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 #include "test.h"
 
 static int exec_count = 0;
-void recv_cb(void* user_data, deno_buf buf, deno_buf zero_copy_buf) {
+void recv_cb(void* user_data, deno_buf buf, deno_pinned_buf zero_copy_buf) {
   // We use this to check that scripts have executed.
   EXPECT_EQ(1u, buf.data_len);
   EXPECT_EQ(buf.data_ptr[0], 4);
-  EXPECT_EQ(zero_copy_buf.zero_copy_id, 0u);
   EXPECT_EQ(zero_copy_buf.data_ptr, nullptr);
+  EXPECT_EQ(zero_copy_buf.data_len, 0u);
+  EXPECT_EQ(zero_copy_buf.pin, nullptr);
   exec_count++;
 }
 

--- a/core/libdeno/test.h
+++ b/core/libdeno/test.h
@@ -6,7 +6,7 @@
 #include "testing/gtest/include/gtest/gtest.h"
 
 extern deno_snapshot snapshot;  // Loaded in libdeno/test.cc
-const deno_buf empty = {nullptr, 0, nullptr, 0, 0};
+const deno_buf empty = {nullptr, 0, nullptr, 0};
 const deno_snapshot empty_snapshot = {nullptr, 0};
 
 #endif  // TEST_H_


### PR DESCRIPTION
* In order to prevent ArrayBuffers from getting garbage collected by V8,
  we used to store a v8::Persistent<ArrayBuffer> in a map. This patch
  introduces a custom ArrayBuffer allocator which doesn't use Persistent
  handles, but instead stores a pointer to the actual ArrayBuffer data
  alongside with a reference count. Since creating Persistent handles
  has quite a bit of overhead, this change significantly increases
  performance. Various HTTP server benchmarks report about 5-10% more
  requests per second than before.

* Previously the Persistent handle that prevented garbage collection had
  to be released manually, and this wasn't always done, which was
  causing memory leaks. This has been resolved by introducing a new
  `PinnedBuf` type in both Rust and C++ that automatically re-enables
  garbage collection when it goes out of scope.

* Zero-copy buffers are now correctly wrapped in an Option if there is a
  possibility that they're not present. This clears up a correctness
  issue where we were creating zero-length slices from a null pointer,
  which is against the rules.