### PR TITLE
fs: add Deno.utime(...)/Deno.utimeSync(...)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "tokio-rustls 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1339,6 +1340,16 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "utime"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1576,7 @@ dependencies = [
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
+"checksum utime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "055058552ca15c566082fc61da433ae678f78986a6f16957e33162d1b218792a"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum vlq 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/build_extra/rust/BUILD.gn
+++ b/build_extra/rust/BUILD.gn
@@ -1714,6 +1714,26 @@ rust_crate("url") {
   ]
 }
 
+rust_crate("utime") {
+  edition = "2015"
+  source_root = "$cargo_home/registry/src/github.com-1ecc6299db9ec823/utime-0.2.1/src/lib.rs"
+
+  if (is_win) {
+    extern = [
+      ":winapi",
+      ":kernel32",
+    ]
+  }
+  if (is_posix) {
+    extern = [ ":libc" ]
+  }
+
+  args = [
+    "--cap-lints",
+    "allow",
+  ]
+}
+
 rust_crate("utf8_ranges") {
   edition = "2015"
   source_root = "$cargo_home/registry/src/github.com-1ecc6299db9ec823/utf8-ranges-1.0.2/src/lib.rs"

--- a/build_extra/rust/BUILD.gn
+++ b/build_extra/rust/BUILD.gn
@@ -1719,11 +1719,15 @@ rust_crate("utime") {
   source_root = "$cargo_home/registry/src/github.com-1ecc6299db9ec823/utime-0.2.1/src/lib.rs"
 
   if (is_win) {
-    extern = [
-      ":winapi",
-      ":kernel32",
+    extern = [ ":kernel32" ]
+    extern_version = [
+      {
+        crate_name = "winapi"
+        crate_version = "0.2.8"
+      },
     ]
   }
+
   if (is_posix) {
     extern = [ ":libc" ]
   }

--- a/cli/BUILD.gn
+++ b/cli/BUILD.gn
@@ -38,6 +38,7 @@ main_extern = [
   "$rust_build:tokio_rustls",
   "$rust_build:tokio_threadpool",
   "$rust_build:url",
+  "$rust_build:utime",
 ]
 if (is_win) {
   main_extern += [ "$rust_build:winapi" ]
@@ -105,6 +106,7 @@ ts_sources = [
   "../js/url.ts",
   "../js/url_search_params.ts",
   "../js/util.ts",
+  "../js/utime.ts",
   "../js/window.ts",
   "../js/workers.ts",
   "../js/write_file.ts",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,6 +47,7 @@ tokio-process = "0.2.3"
 tokio-rustls = "0.9.2"
 tokio-threadpool = "0.1.14"
 url = "1.7.2"
+utime = "0.2.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.7"

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -67,6 +67,7 @@ union Any {
   StatRes,
   Symlink,
   Truncate,
+  Utime,
   CreateWorker,
   CreateWorkerRes,
   HostGetWorkerClosed,
@@ -432,6 +433,12 @@ table StatRes {
 table Truncate {
   name: string;
   len: uint;
+}
+
+table Utime {
+  filename: string;
+  atime: uint64;
+  mtime: uint64;
 }
 
 table Open {

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -46,6 +46,7 @@ export {
   MakeTempDirOptions
 } from "./make_temp_dir";
 export { chmodSync, chmod } from "./chmod";
+export { utimeSync, utime } from "./utime";
 export { removeSync, remove, RemoveOption } from "./remove";
 export { renameSync, rename } from "./rename";
 export { readFileSync, readFile } from "./read_file";

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -40,6 +40,7 @@ import "./timers_test.ts";
 import "./truncate_test.ts";
 import "./url_test.ts";
 import "./url_search_params_test.ts";
+import "./utime_test.ts";
 import "./write_file_test.ts";
 import "./performance_test.ts";
 import "./permissions_test.ts";

--- a/js/util.ts
+++ b/js/util.ts
@@ -192,3 +192,18 @@ export function hasOwnProperty<T>(obj: T, v: PropertyKey): boolean {
   }
   return Object.prototype.hasOwnProperty.call(obj, v);
 }
+
+/**
+ * Split a number into two parts: lower 32 bit and higher 32 bit
+ * (as if the number is represented as uint64.)
+ *
+ * @param n Number to split.
+ * @internal
+ */
+export function splitNumberToParts(n: number): number[] {
+  // JS bitwise operators (OR, SHIFT) operate as if number is uint32.
+  const lower = n | 0;
+  // This is also faster than Math.floor(n / 0x100000000) in V8.
+  const higher = (n - lower) / 0x100000000;
+  return [lower, higher];
+}

--- a/js/utime.ts
+++ b/js/utime.ts
@@ -1,0 +1,52 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import * as msg from "gen/cli/msg_generated";
+import * as flatbuffers from "./flatbuffers";
+import * as dispatch from "./dispatch";
+import * as util from "./util";
+
+function req(
+  filename: string,
+  atime: number | Date,
+  mtime: number | Date
+): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
+  const atimeSec = atime instanceof Date ? Math.floor(+atime / 1000) : atime;
+  const mtimeSec = mtime instanceof Date ? Math.floor(+mtime / 1000) : mtime;
+
+  const builder = flatbuffers.createBuilder();
+  const filename_ = builder.createString(filename);
+  const atimeParts = util.splitNumberToParts(atimeSec);
+  const atimeMS_ = builder.createLong(atimeParts[0], atimeParts[1]);
+  const mtimeParts = util.splitNumberToParts(mtimeSec);
+  const mtimeMS_ = builder.createLong(mtimeParts[0], mtimeParts[1]);
+
+  const inner = msg.Utime.createUtime(builder, filename_, atimeMS_, mtimeMS_);
+  return [builder, msg.Any.Utime, inner];
+}
+
+/** Synchronously changes the access and modification times of a file system
+ * object referenced by `filename`. Given times are either in seconds
+ * (Unix epoch time) or as `Date` objects.
+ *
+ *       Deno.utimeSync("myfile.txt", 1556495550, new Date());
+ */
+export function utimeSync(
+  filename: string,
+  atime: number | Date,
+  mtime: number | Date
+): void {
+  dispatch.sendSync(...req(filename, atime, mtime));
+}
+
+/** Changes the access and modification times of a file system object
+ * referenced by `filename`. Given times are either in seconds
+ * (Unix epoch time) or as `Date` objects.
+ *
+ *       await Deno.utime("myfile.txt", 1556495550, new Date());
+ */
+export async function utime(
+  filename: string,
+  atime: number | Date,
+  mtime: number | Date
+): Promise<void> {
+  await dispatch.sendAsync(...req(filename, atime, mtime));
+}

--- a/js/utime_test.ts
+++ b/js/utime_test.ts
@@ -1,0 +1,181 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { testPerm, assert, assertEquals } from "./test_util.ts";
+
+// Allow 10 second difference.
+// Note this might not be enough for FAT (but we are not testing on such fs).
+function assertFuzzyTimestampEquals(t1: number, t2: number): void {
+  assert(Math.abs(t1 - t2) < 10);
+}
+
+testPerm({ read: true, write: true }, function utimeSyncFileSuccess(): void {
+  const testDir = Deno.makeTempDirSync();
+  const filename = testDir + "/file.txt";
+  Deno.writeFileSync(filename, new TextEncoder().encode("hello"), {
+    perm: 0o666
+  });
+
+  const atime = 1000;
+  const mtime = 50000;
+  Deno.utimeSync(filename, atime, mtime);
+
+  const fileInfo = Deno.statSync(filename);
+  assertFuzzyTimestampEquals(fileInfo.accessed, atime);
+  assertFuzzyTimestampEquals(fileInfo.modified, mtime);
+});
+
+testPerm(
+  { read: true, write: true },
+  function utimeSyncDirectorySuccess(): void {
+    const testDir = Deno.makeTempDirSync();
+
+    const atime = 1000;
+    const mtime = 50000;
+    Deno.utimeSync(testDir, atime, mtime);
+
+    const dirInfo = Deno.statSync(testDir);
+    assertFuzzyTimestampEquals(dirInfo.accessed, atime);
+    assertFuzzyTimestampEquals(dirInfo.modified, mtime);
+  }
+);
+
+testPerm({ read: true, write: true }, function utimeSyncDateSuccess(): void {
+  const testDir = Deno.makeTempDirSync();
+
+  const atime = 1000;
+  const mtime = 50000;
+  Deno.utimeSync(testDir, new Date(atime * 1000), new Date(mtime * 1000));
+
+  const dirInfo = Deno.statSync(testDir);
+  assertFuzzyTimestampEquals(dirInfo.accessed, atime);
+  assertFuzzyTimestampEquals(dirInfo.modified, mtime);
+});
+
+testPerm(
+  { read: true, write: true },
+  function utimeSyncLargeNumberSuccess(): void {
+    const testDir = Deno.makeTempDirSync();
+
+    // There are Rust side caps (might be fs relate),
+    // so JUST make them slightly larger than UINT32_MAX.
+    const atime = 0x100000001;
+    const mtime = 0x100000002;
+    Deno.utimeSync(testDir, atime, mtime);
+
+    const dirInfo = Deno.statSync(testDir);
+    assertFuzzyTimestampEquals(dirInfo.accessed, atime);
+    assertFuzzyTimestampEquals(dirInfo.modified, mtime);
+  }
+);
+
+testPerm({ read: true, write: true }, function utimeSyncNotFound(): void {
+  const atime = 1000;
+  const mtime = 50000;
+
+  let caughtError = false;
+  try {
+    Deno.utimeSync("/baddir", atime, mtime);
+  } catch (e) {
+    caughtError = true;
+    assertEquals(e.kind, Deno.ErrorKind.NotFound);
+    assertEquals(e.name, "NotFound");
+  }
+  assert(caughtError);
+});
+
+testPerm({ read: true, write: false }, function utimeSyncPerm(): void {
+  const atime = 1000;
+  const mtime = 50000;
+
+  let caughtError = false;
+  try {
+    Deno.utimeSync("/some_dir", atime, mtime);
+  } catch (e) {
+    caughtError = true;
+    assertEquals(e.kind, Deno.ErrorKind.PermissionDenied);
+    assertEquals(e.name, "PermissionDenied");
+  }
+  assert(caughtError);
+});
+
+testPerm(
+  { read: true, write: true },
+  async function utimeFileSuccess(): Promise<void> {
+    const testDir = Deno.makeTempDirSync();
+    const filename = testDir + "/file.txt";
+    Deno.writeFileSync(filename, new TextEncoder().encode("hello"), {
+      perm: 0o666
+    });
+
+    const atime = 1000;
+    const mtime = 50000;
+    await Deno.utime(filename, atime, mtime);
+
+    const fileInfo = Deno.statSync(filename);
+    assertFuzzyTimestampEquals(fileInfo.accessed, atime);
+    assertFuzzyTimestampEquals(fileInfo.modified, mtime);
+  }
+);
+
+testPerm(
+  { read: true, write: true },
+  async function utimeDirectorySuccess(): Promise<void> {
+    const testDir = Deno.makeTempDirSync();
+
+    const atime = 1000;
+    const mtime = 50000;
+    await Deno.utime(testDir, atime, mtime);
+
+    const dirInfo = Deno.statSync(testDir);
+    assertFuzzyTimestampEquals(dirInfo.accessed, atime);
+    assertFuzzyTimestampEquals(dirInfo.modified, mtime);
+  }
+);
+
+testPerm(
+  { read: true, write: true },
+  async function utimeDateSuccess(): Promise<void> {
+    const testDir = Deno.makeTempDirSync();
+
+    const atime = 1000;
+    const mtime = 50000;
+    await Deno.utime(testDir, new Date(atime * 1000), new Date(mtime * 1000));
+
+    const dirInfo = Deno.statSync(testDir);
+    assertFuzzyTimestampEquals(dirInfo.accessed, atime);
+    assertFuzzyTimestampEquals(dirInfo.modified, mtime);
+  }
+);
+
+testPerm({ read: true, write: true }, async function utimeNotFound(): Promise<
+  void
+> {
+  const atime = 1000;
+  const mtime = 50000;
+
+  let caughtError = false;
+  try {
+    await Deno.utime("/baddir", atime, mtime);
+  } catch (e) {
+    caughtError = true;
+    assertEquals(e.kind, Deno.ErrorKind.NotFound);
+    assertEquals(e.name, "NotFound");
+  }
+  assert(caughtError);
+});
+
+testPerm({ read: true, write: false }, async function utimeSyncPerm(): Promise<
+  void
+> {
+  const atime = 1000;
+  const mtime = 50000;
+
+  let caughtError = false;
+  try {
+    await Deno.utime("/some_dir", atime, mtime);
+  } catch (e) {
+    caughtError = true;
+    assertEquals(e.kind, Deno.ErrorKind.PermissionDenied);
+    assertEquals(e.name, "PermissionDenied");
+  }
+  assert(caughtError);
+});


### PR DESCRIPTION
Closes #1948.

```ts
function utimeSync(
  filename: string,
  atime: number | Date,
  mtime: number | Date
): void;

async function utime(
  filename: string,
  atime: number | Date,
  mtime: number | Date
): Promise<void>
```

Notice `utime` (instead of `utimes`) means that `atime` and `mtime` have resolution of 1 second (epoch time format). ([Linux manpages](http://man7.org/linux/man-pages/man2/utimes.2.html))

+ Node: [`fs.utimes(path, atime, mtime, callback)`](https://nodejs.org/dist/latest-v12.x/docs/api/fs.html#fs_fs_utimes_path_atime_mtime_callback)
  + Node seems to be [also using resolution of 1 second](https://github.com/nodejs/node/blob/377939eef847d2475768c0db0b3eb1a699f545f1/lib/internal/fs/utils.js#L380-L396), but named as `utimes` (using libuv [`uv_fs_utime`](http://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_utime)).
+ C: [`int utime(const char *filename, const struct utimbuf *times);`](http://man7.org/linux/man-pages/man2/utimes.2.html)
  + `utimbuf` uses resolution of 1 sec
+ Go: [`func Chtimes(name string, atime time.Time, mtime time.Time) error`](https://golang.org/pkg/os/#Chtimes)
+ Python: [`os.utime(path, times=None, *, [ns, ]dir_fd=None, follow_symlinks=True)`](https://docs.python.org/3/library/os.html#os.utime)