### PR TITLE
Optimize read and write ops

### DIFF
--- a/cli/BUILD.gn
+++ b/cli/BUILD.gn
@@ -64,6 +64,7 @@ ts_sources = [
   "../js/deno.ts",
   "../js/dir.ts",
   "../js/dispatch.ts",
+  "../js/dispatch_minimal.ts",
   "../js/dom_types.ts",
   "../js/errors.ts",
   "../js/event.ts",

--- a/cli/dispatch_minimal.rs
+++ b/cli/dispatch_minimal.rs
@@ -151,7 +151,7 @@ mod ops {
       None => Box::new(futures::future::err(errors::bad_resource())),
       Some(resource) => Box::new(
         tokio_write::write(resource, zero_copy)
-          .map_err(|err| err.into())
+          .map_err(errors::DenoError::from)
           .and_then(move |(_resource, _buf, nwritten)| Ok(nwritten as i32)),
       ),
     }

--- a/cli/dispatch_minimal.rs
+++ b/cli/dispatch_minimal.rs
@@ -19,6 +19,7 @@ pub fn has_minimal_token(s: &[i32]) -> bool {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
+// This corresponds to RecordMinimal on the TS side.
 struct Record {
   pub promise_id: i32,
   pub op_id: i32,

--- a/cli/dispatch_minimal.rs
+++ b/cli/dispatch_minimal.rs
@@ -1,0 +1,133 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+// Do not add flatbuffer dependencies to this module.
+//! Connects to js/dispatch_minimal.ts sendAsyncMinimal This acts as a faster
+//! alternative to flatbuffers using a very simple list of int32s to lay out
+//! messages. The first i32 is used to determine if a message a flatbuffer
+//! message or a "minimal" message, see `has_minimal_token()`.
+use crate::state::ThreadSafeState;
+use deno::Buf;
+use deno::Op;
+use deno::PinnedBuf;
+use futures::Future;
+
+const DISPATCH_MINIMAL_TOKEN: i32 = 0xCAFE;
+const OP_READ: i32 = 1;
+const OP_WRITE: i32 = 2;
+
+pub fn has_minimal_token(s: &[i32]) -> bool {
+  s[0] == DISPATCH_MINIMAL_TOKEN
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct Record {
+  pub promise_id: i32,
+  pub op_id: i32,
+  pub arg: i32,
+  pub result: i32,
+}
+
+impl Into<Buf> for Record {
+  fn into(self) -> Buf {
+    let vec = vec![
+      DISPATCH_MINIMAL_TOKEN,
+      self.promise_id,
+      self.op_id,
+      self.arg,
+      self.result,
+    ];
+    //let len = vec.len();
+    let buf32 = vec.into_boxed_slice();
+    let ptr = Box::into_raw(buf32) as *mut [u8; 5 * 4];
+    unsafe { Box::from_raw(ptr) }
+  }
+}
+
+impl From<&[i32]> for Record {
+  fn from(s: &[i32]) -> Record {
+    let ptr = s.as_ptr();
+    let ints = unsafe { std::slice::from_raw_parts(ptr, 5) };
+    assert_eq!(ints[0], DISPATCH_MINIMAL_TOKEN);
+    Record {
+      promise_id: ints[1],
+      op_id: ints[2],
+      arg: ints[3],
+      result: ints[4],
+    }
+  }
+}
+
+pub fn dispatch_minimal(
+  state: &ThreadSafeState,
+  control32: &[i32],
+  zero_copy: Option<PinnedBuf>,
+) -> Op {
+  let record = Record::from(control32);
+  let is_sync = record.promise_id == 0;
+  let min_op = match record.op_id {
+    OP_READ => ops::read(record.arg, zero_copy),
+    OP_WRITE => ops::write(record.arg, zero_copy),
+    _ => unimplemented!(),
+  };
+
+  let mut record_a = record.clone();
+  let mut record_b = record.clone();
+  let state = state.clone();
+
+  let fut = Box::new(
+    min_op
+      .and_then(move |result| {
+        record_a.result = result;
+        Ok(record_a)
+      }).or_else(|err| -> Result<Record, ()> {
+        debug!("unexpected err {}", err);
+        record_b.result = -1;
+        Ok(record_b)
+      }).then(move |result| -> Result<Buf, ()> {
+        let record = result.unwrap();
+        let buf: Buf = record.into();
+        state.metrics_op_completed(buf.len());
+        Ok(buf)
+      }),
+  );
+  if is_sync {
+    Op::Sync(fut.wait().unwrap())
+  } else {
+    Op::Async(fut)
+  }
+}
+
+mod ops {
+  use crate::errors;
+  use crate::resources;
+  use crate::tokio_write;
+  use deno::PinnedBuf;
+  use futures::Future;
+
+  type MinimalOp = dyn Future<Item = i32, Error = errors::DenoError> + Send;
+
+  pub fn read(rid: i32, zero_copy: Option<PinnedBuf>) -> Box<MinimalOp> {
+    debug!("read rid={}", rid);
+    let zero_copy = zero_copy.unwrap();
+    match resources::lookup(rid as u32) {
+      None => Box::new(futures::future::err(errors::bad_resource())),
+      Some(resource) => Box::new(
+        tokio::io::read(resource, zero_copy)
+          .map_err(|err| err.into())
+          .and_then(move |(_resource, _buf, nread)| Ok(nread as i32)),
+      ),
+    }
+  }
+
+  pub fn write(rid: i32, zero_copy: Option<PinnedBuf>) -> Box<MinimalOp> {
+    debug!("write rid={}", rid);
+    let zero_copy = zero_copy.unwrap();
+    match resources::lookup(rid as u32) {
+      None => Box::new(futures::future::err(errors::bad_resource())),
+      Some(resource) => Box::new(
+        tokio_write::write(resource, zero_copy)
+          .map_err(|err| err.into())
+          .and_then(move |(_resource, _buf, nwritten)| Ok(nwritten as i32)),
+      ),
+    }
+  }
+}

--- a/cli/dispatch_minimal.rs
+++ b/cli/dispatch_minimal.rs
@@ -87,7 +87,7 @@ fn test_parse_min_record() {
 
 pub fn dispatch_minimal(
   state: &ThreadSafeState,
-  record: Record,
+  mut record: Record,
   zero_copy: Option<PinnedBuf>,
 ) -> Op {
   let is_sync = record.promise_id == 0;
@@ -98,21 +98,20 @@ pub fn dispatch_minimal(
   };
 
   let state = state.clone();
-  let mut record_ = record;
 
   let fut = Box::new(min_op.then(move |result| -> Result<Buf, ()> {
     match result {
       Ok(r) => {
-        record_.result = r;
+        record.result = r;
       }
       Err(err) => {
         // TODO(ry) The dispatch_minimal doesn't properly pipe errors back to
         // the caller.
         debug!("swallowed err {}", err);
-        record_.result = -1;
+        record.result = -1;
       }
     }
-    let buf: Buf = record_.into();
+    let buf: Buf = record.into();
     state.metrics_op_completed(buf.len());
     Ok(buf)
   }));

--- a/cli/dispatch_minimal.rs
+++ b/cli/dispatch_minimal.rs
@@ -35,7 +35,6 @@ impl Into<Buf> for Record {
       self.arg,
       self.result,
     ];
-    //let len = vec.len();
     let buf32 = vec.into_boxed_slice();
     let ptr = Box::into_raw(buf32) as *mut [u8; 5 * 4];
     unsafe { Box::from_raw(ptr) }

--- a/cli/dispatch_minimal.rs
+++ b/cli/dispatch_minimal.rs
@@ -111,7 +111,7 @@ mod ops {
       None => Box::new(futures::future::err(errors::bad_resource())),
       Some(resource) => Box::new(
         tokio::io::read(resource, zero_copy)
-          .map_err(|err| err.into())
+          .map_err(errors::DenoError::from)
           .and_then(move |(_resource, _buf, nread)| Ok(nread as i32)),
       ),
     }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -15,6 +15,7 @@ extern crate nix;
 mod ansi;
 pub mod compiler;
 pub mod deno_dir;
+mod dispatch_minimal;
 pub mod errors;
 pub mod flags;
 mod fs;

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -2,6 +2,8 @@
 use atty;
 use crate::ansi;
 use crate::compiler::get_compiler_config;
+use crate::dispatch_minimal::dispatch_minimal;
+use crate::dispatch_minimal::has_minimal_token;
 use crate::errors;
 use crate::errors::{DenoError, DenoResult, ErrorKind};
 use crate::fs as deno_fs;
@@ -74,10 +76,15 @@ fn empty_buf() -> Buf {
   Box::new([])
 }
 
-/// Processes raw messages from JavaScript.
-/// This functions invoked every time Deno.core.dispatch() is called.
-/// control corresponds to the first argument of Deno.core.dispatch().
-/// data corresponds to the second argument of Deno.core.dispatch().
+fn slice_u8_as_i32(bytes: &[u8]) -> &[i32] {
+  let p = bytes.as_ptr();
+  // Assert pointer is 32 bit aligned before casting.
+  assert_eq!((p as usize) % std::mem::align_of::<i32>(), 0);
+  #[allow(clippy::cast_ptr_alignment)]
+  let p32 = p as *const i32;
+  unsafe { std::slice::from_raw_parts(p32, bytes.len() / 4) }
+}
+
 pub fn dispatch_all(
   state: &ThreadSafeState,
   control: &[u8],
@@ -86,6 +93,27 @@ pub fn dispatch_all(
 ) -> Op {
   let bytes_sent_control = control.len();
   let bytes_sent_zero_copy = zero_copy.as_ref().map(|b| b.len()).unwrap_or(0);
+
+  let control32 = slice_u8_as_i32(control);
+  let op = if has_minimal_token(control32) {
+    dispatch_minimal(state, control32, zero_copy)
+  } else {
+    dispatch_all_legacy(state, control, zero_copy, op_selector)
+  };
+  state.metrics_op_dispatched(bytes_sent_control, bytes_sent_zero_copy);
+  op
+}
+
+/// Processes raw messages from JavaScript.
+/// This functions invoked every time Deno.core.dispatch() is called.
+/// control corresponds to the first argument of Deno.core.dispatch().
+/// data corresponds to the second argument of Deno.core.dispatch().
+pub fn dispatch_all_legacy(
+  state: &ThreadSafeState,
+  control: &[u8],
+  zero_copy: Option<PinnedBuf>,
+  op_selector: OpSelector,
+) -> Op {
   let base = msg::get_root_as_base(&control);
   let is_sync = base.sync();
   let inner_type = base.inner_type();
@@ -99,7 +127,6 @@ pub fn dispatch_all(
   let op: Box<OpWithError> = op_func(state, &base, zero_copy);
 
   let state = state.clone();
-  state.metrics_op_dispatched(bytes_sent_control, bytes_sent_zero_copy);
 
   let fut = Box::new(
     op.or_else(move |err: DenoError| -> Result<Buf, ()> {

--- a/js/dispatch.ts
+++ b/js/dispatch.ts
@@ -70,7 +70,7 @@ function sendInternal(
 
   const response = core.dispatch(
     control,
-    zeroCopy ? ui8FromArrayBufferView(zeroCopy!) : undefined
+    zeroCopy ? ui8FromArrayBufferView(zeroCopy) : undefined
   );
 
   builder.inUse = false;

--- a/js/dispatch.ts
+++ b/js/dispatch.ts
@@ -5,7 +5,7 @@ import * as msg from "gen/cli/msg_generated";
 import * as errors from "./errors";
 import * as util from "./util";
 import {
-  RecordMinimal,
+  Record,
   nextPromiseId,
   recordFromBufMinimal,
   handleAsyncMsgFromRustMinimal
@@ -13,11 +13,11 @@ import {
 
 const promiseTable = new Map<number, util.Resolvable<msg.Base>>();
 
-interface Record extends RecordMinimal {
+interface FlatbufferRecord extends Record {
   base?: msg.Base;
 }
 
-function recordFromBuf(buf: Uint8Array): Record {
+function recordFromBuf(buf: Uint8Array): FlatbufferRecord {
   // assert(buf.byteLength % 4 == 0);
   const buf32 = new Int32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4);
 

--- a/js/dispatch_minimal.ts
+++ b/js/dispatch_minimal.ts
@@ -11,7 +11,7 @@ export function nextPromiseId(): number {
   return _nextPromiseId++;
 }
 
-export interface RecordMinimal {
+export interface Record {
   promiseId: number;
   opId: number;
   arg: number;
@@ -25,7 +25,7 @@ export function hasMinimalToken(i32: Int32Array): boolean {
   return i32[0] == DISPATCH_MINIMAL_TOKEN;
 }
 
-export function recordFromBufMinimal(buf32: Int32Array): null | RecordMinimal {
+export function recordFromBufMinimal(buf32: Int32Array): null | Record {
   if (hasMinimalToken(buf32)) {
     return {
       promiseId: buf32[1],
@@ -47,7 +47,7 @@ util.assert(scratchBytes.byteLength === scratch32.length * 4);
 
 export function handleAsyncMsgFromRustMinimal(
   ui8: Uint8Array,
-  record: RecordMinimal
+  record: Record
 ): void {
   // Fast and new
   util.log("minimal handleAsyncMsgFromRust ", ui8.length);

--- a/js/dispatch_minimal.ts
+++ b/js/dispatch_minimal.ts
@@ -11,7 +11,7 @@ export function nextPromiseId(): number {
   return _nextPromiseId++;
 }
 
-export interface Record {
+export interface RecordMinimal {
   promiseId: number;
   opId: number;
   arg: number;
@@ -25,7 +25,7 @@ export function hasMinimalToken(i32: Int32Array): boolean {
   return i32[0] == DISPATCH_MINIMAL_TOKEN;
 }
 
-export function recordFromBufMinimal(buf32: Int32Array): null | Record {
+export function recordFromBufMinimal(buf32: Int32Array): null | RecordMinimal {
   if (hasMinimalToken(buf32)) {
     return {
       promiseId: buf32[1],
@@ -47,7 +47,7 @@ util.assert(scratchBytes.byteLength === scratch32.length * 4);
 
 export function handleAsyncMsgFromRustMinimal(
   ui8: Uint8Array,
-  record: Record
+  record: RecordMinimal
 ): void {
   // Fast and new
   util.log("minimal handleAsyncMsgFromRust ", ui8.length);

--- a/js/dispatch_minimal.ts
+++ b/js/dispatch_minimal.ts
@@ -68,7 +68,6 @@ export function sendAsyncMinimal(
   scratch32[1] = promiseId;
   scratch32[2] = opId;
   scratch32[3] = arg;
-  // scratch32[4] = -1;
 
   const promise = util.createResolvable<number>();
   promiseTableMin.set(promiseId, promise);

--- a/js/dispatch_minimal.ts
+++ b/js/dispatch_minimal.ts
@@ -1,0 +1,78 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+// Do not add flatbuffer dependencies to this module.
+import * as util from "./util";
+import { core } from "./core";
+
+const DISPATCH_MINIMAL_TOKEN = 0xcafe;
+const promiseTableMin = new Map<number, util.Resolvable<number>>();
+let _nextPromiseId = 0;
+
+export function nextPromiseId(): number {
+  return _nextPromiseId++;
+}
+
+export interface RecordMinimal {
+  promiseId: number;
+  opId: number;
+  arg: number;
+  result: number;
+}
+
+/** Determines if a message has the "minimal" serialization format. If false, it
+ * is flatbuffer encoded.
+ */
+export function hasMinimalToken(i32: Int32Array): boolean {
+  return i32[0] == DISPATCH_MINIMAL_TOKEN;
+}
+
+export function recordFromBufMinimal(buf32: Int32Array): null | RecordMinimal {
+  if (hasMinimalToken(buf32)) {
+    return {
+      promiseId: buf32[1],
+      opId: buf32[2],
+      arg: buf32[3],
+      result: buf32[4]
+    };
+  }
+  return null;
+}
+
+const scratch32 = new Int32Array(5);
+const scratchBytes = new Uint8Array(
+  scratch32.buffer,
+  scratch32.byteOffset,
+  scratch32.byteLength
+);
+util.assert(scratchBytes.byteLength === scratch32.length * 4);
+
+export function handleAsyncMsgFromRustMinimal(
+  ui8: Uint8Array,
+  record: RecordMinimal
+): void {
+  // Fast and new
+  util.log("minimal handleAsyncMsgFromRust ", ui8.length);
+  const { promiseId, result } = record;
+  const promise = promiseTableMin.get(promiseId);
+  promiseTableMin.delete(promiseId);
+  promise!.resolve(result);
+}
+
+export function sendAsyncMinimal(
+  opId: number,
+  arg: number,
+  zeroCopy: Uint8Array
+): Promise<number> {
+  const promiseId = nextPromiseId(); // AKA cmdId
+
+  scratch32[0] = DISPATCH_MINIMAL_TOKEN;
+  scratch32[1] = promiseId;
+  scratch32[2] = opId;
+  scratch32[3] = arg;
+  // scratch32[4] = -1;
+
+  const promise = util.createResolvable<number>();
+  promiseTableMin.set(promiseId, promise);
+
+  core.dispatch(scratchBytes, zeroCopy);
+  return promise;
+}


### PR DESCRIPTION
Essentially side step flatbuffers.

Benching `deno -A tests/http_bench.ts`

this branch:
```
~/src/deno> third_party/wrk/mac/wrk http://127.0.0.1:4500/
Running 10s test @ http://127.0.0.1:4500/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   279.10us  479.38us   8.05ms   96.60%
    Req/Sec    22.82k     1.46k   26.34k    79.21%
  458621 requests in 10.10s, 22.31MB read
Requests/sec:  45403.95
Transfer/sec:      2.21MB
```
master:
```
~/src/deno> third_party/wrk/mac/wrk http://127.0.0.1:4500/
Running 10s test @ http://127.0.0.1:4500/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   380.73us  545.44us   6.88ms   96.20%
    Req/Sec    16.09k     1.70k   18.80k    82.00%
  320396 requests in 10.01s, 15.58MB read
Requests/sec:  32017.73
Transfer/sec:      1.56MB