### PR TITLE
core: remove support for moving deno_buf ownership from C++ to JavaScript

### DIFF
--- a/core/libdeno.rs
+++ b/core/libdeno.rs
@@ -19,16 +19,9 @@ pub struct isolate {
   _unused: [u8; 0],
 }
 
-/// If "alloc_ptr" is not null, this type represents a buffer which is created
-/// in C side, and then passed to Rust side by `deno_recv_cb`. Finally it should
-/// be moved back to C side by `deno_respond`. If it is not passed to
-/// `deno_respond` in the end, it will be leaked.
-///
-/// If "alloc_ptr" is null, this type represents a borrowed slice.
+/// This type represents a borrowed slice.
 #[repr(C)]
 pub struct deno_buf {
-  alloc_ptr: *const u8,
-  alloc_len: usize,
   data_ptr: *const u8,
   data_len: usize,
 }
@@ -41,8 +34,6 @@ impl deno_buf {
   #[inline]
   pub fn empty() -> Self {
     Self {
-      alloc_ptr: null(),
-      alloc_len: 0,
       data_ptr: null(),
       data_len: 0,
     }
@@ -51,8 +42,6 @@ impl deno_buf {
   #[inline]
   pub unsafe fn from_raw_parts(ptr: *const u8, len: usize) -> Self {
     Self {
-      alloc_ptr: null(),
-      alloc_len: 0,
       data_ptr: ptr,
       data_len: len,
     }
@@ -64,8 +53,6 @@ impl<'a> From<&'a [u8]> for deno_buf {
   #[inline]
   fn from(x: &'a [u8]) -> Self {
     Self {
-      alloc_ptr: null(),
-      alloc_len: 0,
       data_ptr: x.as_ref().as_ptr(),
       data_len: x.len(),
     }

--- a/core/libdeno/binding.cc
+++ b/core/libdeno/binding.cc
@@ -167,57 +167,33 @@ v8::Local<v8::Uint8Array> ImportBuf(DenoIsolate* d, deno_buf buf) {
     return v8::Local<v8::Uint8Array>();
   }
 
-  if (buf.alloc_ptr == nullptr) {
-    // If alloc_ptr isn't set, we memcpy.
-    // This is currently used for flatbuffers created in Rust.
-
-    // To avoid excessively allocating new ArrayBuffers, we try to reuse a
-    // single global ArrayBuffer. The caveat is that users must extract data
-    // from it before the next tick. We only do this for ArrayBuffers less than
-    // 1024 bytes.
-    v8::Local<v8::ArrayBuffer> ab;
-    void* data;
-    if (buf.data_len > GLOBAL_IMPORT_BUF_SIZE) {
-      // Simple case. We allocate a new ArrayBuffer for this.
-      ab = v8::ArrayBuffer::New(d->isolate_, buf.data_len);
-      data = ab->GetContents().Data();
-    } else {
-      // Fast case. We reuse the global ArrayBuffer.
-      if (d->global_import_buf_.IsEmpty()) {
-        // Lazily initialize it.
-        DCHECK_NULL(d->global_import_buf_ptr_);
-        ab = v8::ArrayBuffer::New(d->isolate_, GLOBAL_IMPORT_BUF_SIZE);
-        d->global_import_buf_.Reset(d->isolate_, ab);
-        d->global_import_buf_ptr_ = ab->GetContents().Data();
-      } else {
-        DCHECK(d->global_import_buf_ptr_);
-        ab = d->global_import_buf_.Get(d->isolate_);
-      }
-      data = d->global_import_buf_ptr_;
-    }
-    memcpy(data, buf.data_ptr, buf.data_len);
-    auto view = v8::Uint8Array::New(ab, 0, buf.data_len);
-    return view;
+  // To avoid excessively allocating new ArrayBuffers, we try to reuse a single
+  // global ArrayBuffer. The caveat is that users must extract data from it
+  // before the next tick. We only do this for ArrayBuffers less than 1024
+  // bytes.
+  v8::Local<v8::ArrayBuffer> ab;
+  void* data;
+  if (buf.data_len > GLOBAL_IMPORT_BUF_SIZE) {
+    // Simple case. We allocate a new ArrayBuffer for this.
+    ab = v8::ArrayBuffer::New(d->isolate_, buf.data_len);
+    data = ab->GetContents().Data();
   } else {
-    auto ab = v8::ArrayBuffer::New(
-        d->isolate_, reinterpret_cast<void*>(buf.alloc_ptr), buf.alloc_len,
-        v8::ArrayBufferCreationMode::kInternalized);
-    auto view =
-        v8::Uint8Array::New(ab, buf.data_ptr - buf.alloc_ptr, buf.data_len);
-    return view;
+    // Fast case. We reuse the global ArrayBuffer.
+    if (d->global_import_buf_.IsEmpty()) {
+      // Lazily initialize it.
+      DCHECK_NULL(d->global_import_buf_ptr_);
+      ab = v8::ArrayBuffer::New(d->isolate_, GLOBAL_IMPORT_BUF_SIZE);
+      d->global_import_buf_.Reset(d->isolate_, ab);
+      d->global_import_buf_ptr_ = ab->GetContents().Data();
+    } else {
+      DCHECK(d->global_import_buf_ptr_);
+      ab = d->global_import_buf_.Get(d->isolate_);
+    }
+    data = d->global_import_buf_ptr_;
   }
-}
-
-static deno_buf GetContents(v8::Isolate* isolate,
-                            v8::Local<v8::ArrayBufferView> view) {
-  auto ab = view->Buffer();
-  auto contents = ab->GetContents();
-  deno_buf buf;
-  buf.alloc_ptr = reinterpret_cast<uint8_t*>(contents.Data());
-  buf.alloc_len = contents.ByteLength();
-  buf.data_ptr = buf.alloc_ptr + view->ByteOffset();
-  buf.data_len = view->ByteLength();
-  return buf;
+  memcpy(data, buf.data_ptr, buf.data_len);
+  auto view = v8::Uint8Array::New(ab, 0, buf.data_len);
+  return view;
 }
 
 // Sets the recv_ callback.
@@ -247,13 +223,12 @@ void Send(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
   v8::HandleScope handle_scope(isolate);
 
-  deno_buf control = {nullptr, 0u, nullptr, 0u};
-  if (args.Length() > 0) {
-    v8::Local<v8::Value> control_v = args[0];
-    if (control_v->IsArrayBufferView()) {
-      control =
-          GetContents(isolate, v8::Local<v8::ArrayBufferView>::Cast(control_v));
-    }
+  deno_buf control = {nullptr, 0};
+  if (args[0]->IsArrayBufferView()) {
+    auto view = v8::Local<v8::ArrayBufferView>::Cast(args[0]);
+    auto data =
+        reinterpret_cast<uint8_t*>(view->Buffer()->GetContents().Data());
+    control = {data + view->ByteOffset(), view->ByteLength()};
   }
 
   PinnedBuf zero_copy =

--- a/core/libdeno/deno.h
+++ b/core/libdeno/deno.h
@@ -17,10 +17,8 @@ typedef deno::PinnedBuf::Raw deno_pinned_buf;
 
 // Data that gets transmitted.
 typedef struct {
-  uint8_t* alloc_ptr;  // Start of memory allocation (from `new uint8_t[len]`).
-  size_t alloc_len;    // Length of the memory allocation.
-  uint8_t* data_ptr;   // Start of logical contents (within the allocation).
-  size_t data_len;     // Length of logical contents.
+  uint8_t* data_ptr;
+  size_t data_len;
 } deno_buf;
 
 typedef struct {

--- a/core/libdeno/internal.h
+++ b/core/libdeno/internal.h
@@ -157,7 +157,7 @@ static intptr_t external_references[] = {
     reinterpret_cast<intptr_t>(MessageCallback),
     0};
 
-static const deno_buf empty_buf = {nullptr, 0, nullptr, 0};
+static const deno_buf empty_buf = {nullptr, 0};
 static const deno_snapshot empty_snapshot = {nullptr, 0};
 
 Deno* NewFromSnapshot(void* user_data, deno_recv_cb cb);

--- a/core/libdeno/test.h
+++ b/core/libdeno/test.h
@@ -6,7 +6,7 @@
 #include "testing/gtest/include/gtest/gtest.h"
 
 extern deno_snapshot snapshot;  // Loaded in libdeno/test.cc
-const deno_buf empty = {nullptr, 0, nullptr, 0};
+const deno_buf empty = {nullptr, 0};
 const deno_snapshot empty_snapshot = {nullptr, 0};
 
 #endif  // TEST_H_


### PR DESCRIPTION
The functionality hasn't been in use for a long time. Without this feature,
the `alloc_ptr` and `alloc_len` fields are no longer necessary.
