### PR TITLE
Fix: deno --v8-options does not print v8 options

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -2,7 +2,6 @@
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
 // Creates vector of strings, Vec<String>
-#[cfg(test)]
 macro_rules! svec {
     ($($x:expr),*) => (vec![$($x.to_string()),*]);
 }
@@ -23,7 +22,6 @@ pub struct DenoFlags {
   pub allow_run: bool,
   pub allow_high_precision: bool,
   pub no_prompts: bool,
-  pub v8_help: bool,
   pub v8_flags: Option<Vec<String>>,
 }
 
@@ -245,15 +243,17 @@ pub fn parse_flags(matches: ArgMatches) -> DenoFlags {
     flags.no_prompts = true;
   }
   if matches.is_present("v8-options") {
-    flags.v8_help = true;
+    let v8_flags = svec!["deno", "--help"];
+    flags.v8_flags = Some(v8_flags);
   }
   if matches.is_present("v8-flags") {
-    let v8_flags: Vec<String> = matches
+    let mut v8_flags: Vec<String> = matches
       .values_of("v8-flags")
       .unwrap()
       .map(String::from)
       .collect();
 
+    v8_flags.insert(0, "deno".to_string());
     flags.v8_flags = Some(v8_flags);
   }
 
@@ -408,7 +408,7 @@ mod tests {
     assert_eq!(
       flags,
       DenoFlags {
-        v8_help: true,
+        v8_flags: Some(svec!["deno", "--help"]),
         ..DenoFlags::default()
       }
     );
@@ -420,7 +420,7 @@ mod tests {
     assert_eq!(
       flags,
       DenoFlags {
-        v8_flags: Some(svec!["--expose-gc", "--gc-stats=1"]),
+        v8_flags: Some(svec!["deno", "--expose-gc", "--gc-stats=1"]),
         ..DenoFlags::default()
       }
     );

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -258,11 +258,6 @@ fn main() {
   let args: Vec<String> = env::args().collect();
   let (flags, subcommand, argv) = flags::flags_from_vec(args);
 
-  if flags.v8_help {
-    // show v8 help and exit
-    v8_set_flags(vec!["--help".to_string()]);
-  }
-
   if let Some(ref v8_flags) = flags.v8_flags {
     v8_set_flags(v8_flags.clone());
   }

--- a/tests/v8_flags.js
+++ b/tests/v8_flags.js
@@ -1,0 +1,1 @@
+console.log(typeof gc);

--- a/tests/v8_flags.js.out
+++ b/tests/v8_flags.js.out
@@ -1,0 +1,1 @@
+function

--- a/tests/v8_flags.test
+++ b/tests/v8_flags.test
@@ -1,0 +1,2 @@
+args: --v8-flags=--expose-gc tests/v8_flags.js
+output: tests/v8_flags.js.out

--- a/tests/v8_help.out
+++ b/tests/v8_help.out
@@ -1,0 +1,1 @@
+[WILDCARD]

--- a/tests/v8_help.out
+++ b/tests/v8_help.out
@@ -1,1 +1,3 @@
 [WILDCARD]
+Synopsis:
+[WILDCARD]d8[WILDCARD]

--- a/tests/v8_help.test
+++ b/tests/v8_help.test
@@ -1,0 +1,2 @@
+args: --v8-options
+output: tests/v8_help.out


### PR DESCRIPTION
This PR fixes #2272

I've added two simple integration tests to make sure this issue never returns. 

CC @piscisaureus @kevinkassimo 