### PR TITLE
fix: deno version panic

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -300,7 +300,7 @@ fn main() {
     DenoSubcommand::Repl => run_repl(flags, argv),
     DenoSubcommand::Run => run_script(flags, argv),
     DenoSubcommand::Types => types_command(),
-    DenoSubcommand::Version => run_script(flags, argv),
+    DenoSubcommand::Version => run_repl(flags, argv),
     DenoSubcommand::Xeval => xeval_command(flags, argv),
   }
 }

--- a/tests/version.out
+++ b/tests/version.out
@@ -1,0 +1,3 @@
+deno:[WILDCARD]
+v8:[WILDCARD]
+typescript:[WILDCARD]

--- a/tests/version.test
+++ b/tests/version.test
@@ -1,0 +1,2 @@
+args: version
+output: tests/version.out


### PR DESCRIPTION
I've broken `deno version` with #2215. There was panic related to lack of main module for `run_script` function

This PR fixes it and adds integration test to make sure it doesn't happen again