### PR TITLE
Implement Deno.chown API for Unix/Linux

### DIFF
--- a/cli/BUILD.gn
+++ b/cli/BUILD.gn
@@ -54,6 +54,7 @@ ts_sources = [
   "../js/buffer.ts",
   "../js/build.ts",
   "../js/chmod.ts",
+  "../js/chown.ts",
   "../js/colors.ts",
   "../js/compiler.ts",
   "../js/console.ts",

--- a/cli/errors.rs
+++ b/cli/errors.rs
@@ -186,6 +186,12 @@ impl From<UnixError> for DenoError {
           Errno::EINVAL.desc().to_owned(),
         ),
       },
+      UnixError::Sys(Errno::ENOENT) => Self {
+        repr: Repr::Simple(
+          ErrorKind::NotFound,
+          Errno::ENOENT.desc().to_owned(),
+        ),
+      },
       UnixError::Sys(err) => Self {
         repr: Repr::Simple(ErrorKind::UnixError, err.desc().to_owned()),
       },

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -15,6 +15,8 @@ use std::os::unix::fs::DirBuilderExt;
 #[cfg(any(unix))]
 use std::os::unix::fs::PermissionsExt;
 
+#[cfg(not(unix))]
+use crate::errors;
 use crate::errors::DenoResult;
 
 pub fn write_file<T: AsRef<[u8]>>(

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -9,11 +9,7 @@ use rand;
 use rand::Rng;
 
 #[cfg(unix)]
-use nix::unistd::chown as unix_chown;
-#[cfg(unix)]
-use nix::unistd::Gid;
-#[cfg(unix)]
-use nix::unistd::Uid;
+use nix::unistd::{chown as unix_chown, Gid, Uid};
 #[cfg(any(unix))]
 use std::os::unix::fs::DirBuilderExt;
 #[cfg(any(unix))]

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -126,5 +126,5 @@ pub fn chown(path: &str, uid: u32, gid: u32) -> DenoResult<()> {
 pub fn chown(_path: &str, _uid: u32, _gid: u32) -> DenoResult<()> {
   // Noop
   // TODO: implement chown for Windows
-  Ok(())
+  errors::op_not_implemented()
 }

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -15,8 +15,6 @@ use std::os::unix::fs::DirBuilderExt;
 #[cfg(any(unix))]
 use std::os::unix::fs::PermissionsExt;
 
-#[cfg(not(unix))]
-use crate::errors;
 use crate::errors::DenoResult;
 
 pub fn write_file<T: AsRef<[u8]>>(
@@ -128,5 +126,6 @@ pub fn chown(path: &str, uid: u32, gid: u32) -> DenoResult<()> {
 pub fn chown(_path: &str, _uid: u32, _gid: u32) -> DenoResult<()> {
   // Noop
   // TODO: implement chown for Windows
-  errors::op_not_implemented()
+  use crate::errors;
+  Err(errors::op_not_implemented())
 }

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -127,7 +127,7 @@ pub fn chown(path: &str, uid: u32, gid: u32) -> DenoResult<()> {
 }
 
 #[cfg(not(unix))]
-pub fn chown(path: &str, uid: u32, gid: u32) -> DenoResult<()> {
+pub fn chown(_path: &str, _uid: u32, _gid: u32) -> DenoResult<()> {
   // Noop
   // TODO: implement chown for Windows
   Ok(())

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -2,6 +2,7 @@ union Any {
   Accept,
   Chdir,
   Chmod,
+  Chown,
   Close,
   CompilerConfig,
   CompilerConfigRes,
@@ -341,6 +342,12 @@ table Mkdir {
 table Chmod {
   path: string;
   mode: uint; // Specified by https://godoc.org/os#FileMode
+}
+
+table Chown {
+  path: string;
+  uid: uint;
+  gid: uint;  // Specified by https://godoc.org/os#Chown
 }
 
 table Remove {

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -871,7 +871,7 @@ fn op_chmod(
 }
 
 fn op_chown(
-  _state: &ThreadSafeState,
+  state: &ThreadSafeState,
   base: &msg::Base<'_>,
   data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
@@ -880,6 +880,10 @@ fn op_chown(
   let path = String::from(inner.path().unwrap());
   let uid = inner.uid();
   let gid = inner.gid();
+
+  if let Err(e) = state.check_write(&path) {
+    return odd_future(e);
+  }
 
   debug!("op_chown {}", &path);
   match deno_fs::chown(&path, uid, gid) {

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -186,6 +186,7 @@ pub fn op_selector_std(inner_type: msg::Any) -> Option<OpCreator> {
     msg::Any::Accept => Some(op_accept),
     msg::Any::Chdir => Some(op_chdir),
     msg::Any::Chmod => Some(op_chmod),
+    msg::Any::Chown => Some(op_chown),
     msg::Any::Close => Some(op_close),
     msg::Any::CopyFile => Some(op_copy_file),
     msg::Any::Cwd => Some(op_cwd),
@@ -867,6 +868,24 @@ fn op_chmod(
     }
     Ok(empty_buf())
   })
+}
+
+fn op_chown(
+  _state: &ThreadSafeState,
+  base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> Box<OpWithError> {
+  assert!(data.is_none());
+  let inner = base.inner_as_chown().unwrap();
+  let path = String::from(inner.path().unwrap());
+  let uid = inner.uid();
+  let gid = inner.gid();
+
+  debug!("op_chown {}", &path);
+  match deno_fs::chown(&path, uid, gid) {
+    Ok(_) => ok_future(empty_buf()),
+    Err(e) => odd_future(e),
+  }
 }
 
 fn op_open(

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -885,11 +885,13 @@ fn op_chown(
     return odd_future(e);
   }
 
-  debug!("op_chown {}", &path);
-  match deno_fs::chown(&path, uid, gid) {
-    Ok(_) => ok_future(empty_buf()),
-    Err(e) => odd_future(e),
-  }
+  blocking(base.sync(), move || {
+    debug!("op_chown {}", &path);
+    match deno_fs::chown(&path, uid, gid) {
+      Ok(_) => Ok(empty_buf()),
+      Err(e) => Err(e),
+    }
+  })
 }
 
 fn op_open(

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -885,11 +885,13 @@ fn op_chown(
     return odd_future(e);
   }
 
-  debug!("op_chown {}", &path);
-  match deno_fs::chown(&path, uid, gid) {
-    Ok(_) => ok_future(empty_buf()),
-    Err(e) => odd_future(e),
-  }
+  blocking(base.sync(), move || {
+    debug!("op_chown {}", &path);
+    match deno_fs::chown(&path, uid, gid) {
+      Ok(_) => ok_future(empty_buf()),
+      Err(e) => odd_future(e),
+    }
+  })
 }
 
 fn op_open(

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -885,13 +885,11 @@ fn op_chown(
     return odd_future(e);
   }
 
-  blocking(base.sync(), move || {
-    debug!("op_chown {}", &path);
-    match deno_fs::chown(&path, uid, gid) {
-      Ok(_) => ok_future(empty_buf()),
-      Err(e) => odd_future(e),
-    }
-  })
+  debug!("op_chown {}", &path);
+  match deno_fs::chown(&path, uid, gid) {
+    Ok(_) => ok_future(empty_buf()),
+    Err(e) => odd_future(e),
+  }
 }
 
 fn op_open(

--- a/js/chown.ts
+++ b/js/chown.ts
@@ -15,7 +15,7 @@ function req(
 }
 
 /**
- * Change owner of a regular file or directory synchronously, Unix only at the moment
+ * Change owner of a regular file or directory synchronously. Unix only at the moment.
  * @param path path to the file
  * @param uid user id of the new owner
  * @param gid group id of the new owner
@@ -25,7 +25,7 @@ export function chownSync(path: string, uid: number, gid: number): void {
 }
 
 /**
- * Change owner of a regular file or directory asynchronously, Unix only at the moment
+ * Change owner of a regular file or directory asynchronously. Unix only at the moment.
  * @param path path to the file
  * @param uid user id of the new owner
  * @param gid group id of the new owner

--- a/js/chown.ts
+++ b/js/chown.ts
@@ -1,0 +1,39 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import * as flatbuffers from "./flatbuffers";
+import * as msg from "gen/cli/msg_generated";
+import * as dispatch from "./dispatch";
+
+function req(
+  path: string,
+  uid: number,
+  gid: number
+): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
+  const builder = flatbuffers.createBuilder();
+  const path_ = builder.createString(path);
+  const inner = msg.Chown.createChown(builder, path_, uid, gid);
+  return [builder, msg.Any.Chown, inner];
+}
+
+/**
+ * Change owner of a regular file or directory synchronously, Unix only at the moment
+ * @param path path to the file
+ * @param uid user id of the new owner
+ * @param gid group id of the new owner
+ */
+export function chownSync(path: string, uid: number, gid: number): void {
+  dispatch.sendSync(...req(path, uid, gid));
+}
+
+/**
+ * Change owner of a regular file or directory asynchronously, Unix only at the moment
+ * @param path path to the file
+ * @param uid user id of the new owner
+ * @param gid group id of the new owner
+ */
+export async function chown(
+  path: string,
+  uid: number,
+  gid: number
+): Promise<void> {
+  await dispatch.sendAsync(...req(path, uid, gid));
+}

--- a/js/chown_test.ts
+++ b/js/chown_test.ts
@@ -1,0 +1,97 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { testPerm, assertEquals } from "./test_util.ts";
+
+// chown on Windows is noop for now, so ignore its testing on Windows
+if (Deno.build.os !== "win") {
+  // default user ID and group ID of the current process
+  const uid = Deno.build.os === "mac" ? 501 : 1000;
+  const gid = Deno.build.os === "mac" ? 20 : 1000;
+
+  testPerm({ write: true }, function chownSyncFileNotExist(): void {
+    const filePath = Deno.makeTempDirSync() + "/chown_test_file.txt";
+    try {
+      Deno.chownSync(filePath, uid, gid);
+    } catch (e) {
+      assertEquals(e.kind, Deno.ErrorKind.NotFound);
+      assertEquals(e.name, "NotFound");
+    }
+  });
+
+  testPerm({ write: true }, async function chownFileNotExist(): Promise<void> {
+    const filePath = (await Deno.makeTempDir()) + "/chown_test_file.txt";
+    try {
+      await Deno.chown(filePath, uid, gid);
+    } catch (e) {
+      assertEquals(e.kind, Deno.ErrorKind.NotFound);
+      assertEquals(e.name, "NotFound");
+    }
+  });
+
+  testPerm({ write: true }, function chownSyncPermissionDenied(): void {
+    const enc = new TextEncoder();
+    const dirPath = Deno.makeTempDirSync();
+    const filePath = dirPath + "/chown_test_file.txt";
+    const fileData = enc.encode("Hello");
+    Deno.writeFileSync(filePath, fileData);
+
+    try {
+      // try changing the file's owner to root
+      Deno.chownSync(filePath, 0, 0);
+    } catch (e) {
+      assertEquals(e.kind, Deno.ErrorKind.PermissionDenied);
+      assertEquals(e.name, "PermissionDenied");
+    }
+    Deno.removeSync(dirPath, { recursive: true });
+  });
+
+  testPerm({ write: true }, async function chownPermissionDenied(): Promise<
+    void
+  > {
+    const enc = new TextEncoder();
+    const dirPath = await Deno.makeTempDir();
+    const filePath = dirPath + "/chown_test_file.txt";
+    const fileData = enc.encode("Hello");
+    await Deno.writeFile(filePath, fileData);
+
+    try {
+      // try changing the file's owner to root
+      await Deno.chown(filePath, 0, 0);
+    } catch (e) {
+      assertEquals(e.kind, Deno.ErrorKind.PermissionDenied);
+      assertEquals(e.name, "PermissionDenied");
+    }
+    await Deno.remove(dirPath, { recursive: true });
+  });
+
+  testPerm({ write: true }, function chownSyncSucceed(): void {
+    // TODO: when a file's owner is actually being changed,
+    // chown only succeeds if run under priviledged user (root)
+    // The test script has no such priviledge, so need to find a better way to test this case
+    const enc = new TextEncoder();
+    const dirPath = Deno.makeTempDirSync();
+    const filePath = dirPath + "/chown_test_file.txt";
+    const fileData = enc.encode("Hello");
+    Deno.writeFileSync(filePath, fileData);
+
+    // the test script creates this file with the same uid and gid,
+    // here chown is a noop so it succeeds under non-priviledged user
+    Deno.chownSync(filePath, uid, gid);
+
+    Deno.removeSync(dirPath, { recursive: true });
+  });
+
+  testPerm({ write: true }, async function chownSucceed(): Promise<void> {
+    // TODO: same as chownSyncSucceed
+    const enc = new TextEncoder();
+    const dirPath = await Deno.makeTempDir();
+    const filePath = dirPath + "/chown_test_file.txt";
+    const fileData = enc.encode("Hello");
+    await Deno.writeFile(filePath, fileData);
+
+    // the test script creates this file with the same uid and gid,
+    // here chown is a noop so it succeeds under non-priviledged user
+    await Deno.chown(filePath, uid, gid);
+
+    Deno.removeSync(dirPath, { recursive: true });
+  });
+}

--- a/js/chown_test.ts
+++ b/js/chown_test.ts
@@ -3,7 +3,7 @@ import { testPerm, assertEquals } from "./test_util.ts";
 
 // chown on Windows is noop for now, so ignore its testing on Windows
 if (Deno.build.os !== "win") {
-  async function getUidAndGid() {
+  async function getUidAndGid(): Promise<{ uid: number; gid: number }> {
     // get the user ID and group ID of the current process
     const uidProc = Deno.run({
       stdout: "piped",

--- a/js/chown_test.ts
+++ b/js/chown_test.ts
@@ -26,6 +26,16 @@ if (Deno.build.os !== "win") {
     return { uid, gid };
   }
 
+  testPerm({}, async function chownNoWritePermission(): Promise<void> {
+    const filePath = "chown_test_file.txt";
+    try {
+      await Deno.chown(filePath, 1000, 1000);
+    } catch (e) {
+      assertEquals(e.kind, Deno.ErrorKind.PermissionDenied);
+      assertEquals(e.name, "PermissionDenied");
+    }
+  });
+
   testPerm(
     { run: true, write: true },
     async function chownSyncFileNotExist(): Promise<void> {

--- a/js/chown_test.ts
+++ b/js/chown_test.ts
@@ -3,29 +3,58 @@ import { testPerm, assertEquals } from "./test_util.ts";
 
 // chown on Windows is noop for now, so ignore its testing on Windows
 if (Deno.build.os !== "win") {
-  // default user ID and group ID of the current process
-  const uid = Deno.build.os === "mac" ? 501 : 1000;
-  const gid = Deno.build.os === "mac" ? 20 : 1000;
+  async function getUidAndGid() {
+    // get the user ID and group ID of the current process
+    const uid_proc = Deno.run({
+      stdout: "piped",
+      args: ["python", "-c", "import os; print(os.getuid())"]
+    });
+    const gid_proc = Deno.run({
+      stdout: "piped",
+      args: ["python", "-c", "import os; print(os.getgid())"]
+    });
 
-  testPerm({ write: true }, function chownSyncFileNotExist(): void {
-    const filePath = Deno.makeTempDirSync() + "/chown_test_file.txt";
-    try {
-      Deno.chownSync(filePath, uid, gid);
-    } catch (e) {
-      assertEquals(e.kind, Deno.ErrorKind.NotFound);
-      assertEquals(e.name, "NotFound");
-    }
-  });
+    assertEquals((await uid_proc.status()).code, 0);
+    assertEquals((await gid_proc.status()).code, 0);
+    const uid = parseInt(
+      new TextDecoder("utf-8").decode(await uid_proc.output())
+    );
+    const gid = parseInt(
+      new TextDecoder("utf-8").decode(await gid_proc.output())
+    );
 
-  testPerm({ write: true }, async function chownFileNotExist(): Promise<void> {
-    const filePath = (await Deno.makeTempDir()) + "/chown_test_file.txt";
-    try {
-      await Deno.chown(filePath, uid, gid);
-    } catch (e) {
-      assertEquals(e.kind, Deno.ErrorKind.NotFound);
-      assertEquals(e.name, "NotFound");
+    return { uid, gid };
+  }
+
+  testPerm(
+    { run: true, write: true },
+    async function chownSyncFileNotExist(): Promise<void> {
+      const { uid, gid } = await getUidAndGid();
+      const filePath = Deno.makeTempDirSync() + "/chown_test_file.txt";
+
+      try {
+        Deno.chownSync(filePath, uid, gid);
+      } catch (e) {
+        assertEquals(e.kind, Deno.ErrorKind.NotFound);
+        assertEquals(e.name, "NotFound");
+      }
     }
-  });
+  );
+
+  testPerm(
+    { run: true, write: true },
+    async function chownFileNotExist(): Promise<void> {
+      const { uid, gid } = await getUidAndGid();
+      const filePath = (await Deno.makeTempDir()) + "/chown_test_file.txt";
+
+      try {
+        await Deno.chown(filePath, uid, gid);
+      } catch (e) {
+        assertEquals(e.kind, Deno.ErrorKind.NotFound);
+        assertEquals(e.name, "NotFound");
+      }
+    }
+  );
 
   testPerm({ write: true }, function chownSyncPermissionDenied(): void {
     const enc = new TextEncoder();
@@ -63,25 +92,34 @@ if (Deno.build.os !== "win") {
     await Deno.remove(dirPath, { recursive: true });
   });
 
-  testPerm({ write: true }, function chownSyncSucceed(): void {
-    // TODO: when a file's owner is actually being changed,
-    // chown only succeeds if run under priviledged user (root)
-    // The test script has no such priviledge, so need to find a better way to test this case
-    const enc = new TextEncoder();
-    const dirPath = Deno.makeTempDirSync();
-    const filePath = dirPath + "/chown_test_file.txt";
-    const fileData = enc.encode("Hello");
-    Deno.writeFileSync(filePath, fileData);
+  testPerm(
+    { run: true, write: true },
+    async function chownSyncSucceed(): Promise<void> {
+      // TODO: when a file's owner is actually being changed,
+      // chown only succeeds if run under priviledged user (root)
+      // The test script has no such priviledge, so need to find a better way to test this case
+      const { uid, gid } = await getUidAndGid();
 
-    // the test script creates this file with the same uid and gid,
-    // here chown is a noop so it succeeds under non-priviledged user
-    Deno.chownSync(filePath, uid, gid);
+      const enc = new TextEncoder();
+      const dirPath = Deno.makeTempDirSync();
+      const filePath = dirPath + "/chown_test_file.txt";
+      const fileData = enc.encode("Hello");
+      Deno.writeFileSync(filePath, fileData);
 
-    Deno.removeSync(dirPath, { recursive: true });
-  });
+      // the test script creates this file with the same uid and gid,
+      // here chown is a noop so it succeeds under non-priviledged user
+      Deno.chownSync(filePath, uid, gid);
 
-  testPerm({ write: true }, async function chownSucceed(): Promise<void> {
+      Deno.removeSync(dirPath, { recursive: true });
+    }
+  );
+
+  testPerm({ run: true, write: true }, async function chownSucceed(): Promise<
+    void
+  > {
     // TODO: same as chownSyncSucceed
+    const { uid, gid } = await getUidAndGid();
+
     const enc = new TextEncoder();
     const dirPath = await Deno.makeTempDir();
     const filePath = dirPath + "/chown_test_file.txt";

--- a/js/chown_test.ts
+++ b/js/chown_test.ts
@@ -5,22 +5,22 @@ import { testPerm, assertEquals } from "./test_util.ts";
 if (Deno.build.os !== "win") {
   async function getUidAndGid() {
     // get the user ID and group ID of the current process
-    const uid_proc = Deno.run({
+    const uidProc = Deno.run({
       stdout: "piped",
       args: ["python", "-c", "import os; print(os.getuid())"]
     });
-    const gid_proc = Deno.run({
+    const gidProc = Deno.run({
       stdout: "piped",
       args: ["python", "-c", "import os; print(os.getgid())"]
     });
 
-    assertEquals((await uid_proc.status()).code, 0);
-    assertEquals((await gid_proc.status()).code, 0);
+    assertEquals((await uidProc.status()).code, 0);
+    assertEquals((await gidProc.status()).code, 0);
     const uid = parseInt(
-      new TextDecoder("utf-8").decode(await uid_proc.output())
+      new TextDecoder("utf-8").decode(await uidProc.output())
     );
     const gid = parseInt(
-      new TextDecoder("utf-8").decode(await gid_proc.output())
+      new TextDecoder("utf-8").decode(await gidProc.output())
     );
 
     return { uid, gid };

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -46,6 +46,7 @@ export {
   MakeTempDirOptions
 } from "./make_temp_dir";
 export { chmodSync, chmod } from "./chmod";
+export { chownSync, chown } from "./chown";
 export { utimeSync, utime } from "./utime";
 export { removeSync, remove, RemoveOption } from "./remove";
 export { renameSync, rename } from "./rename";

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -8,6 +8,7 @@ import "./body_test.ts";
 import "./buffer_test.ts";
 import "./build_test.ts";
 import "./chmod_test.ts";
+import "./chown_test.ts";
 import "./console_test.ts";
 import "./copy_file_test.ts";
 import "./custom_event_test.ts";


### PR DESCRIPTION
Make the syscall using `nix` crate in Rust. Implement for Unix/Linux first, since `chown` in Windows is a no-op.
Prior art:
Node: `fs.chown(path, uid, gid, callback)`, `fs.chownSync(path, uid, gid)`
Python: `os.chown(path, uid, gid)`
Go: `func Chown(name string, uid, gid int) error`
C: `int chown(const char *pathname, uid_t owner, gid_t group)`

