### PR TITLE
chore: Refactor unit tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -218,7 +218,7 @@ after_test:
   # listed explicitly in cli\BUILD.gn. This is not an air-tight check.
   # TODO: make rollup or another bundler write a depfile.
   - ps: |-
-      $ignore = "test_util.ts", "unit_tests.ts", "*_test.ts"
+      $ignore = "test_util.ts", "unit_tests.ts", "unit_test_runner.ts", "*_test.ts"
       Get-ChildItem "js" -File -Force -Name                               |
         where   { $name = $_; -not ($ignore | where { $name -like $_ }) } |
         where   { -not (Select-String -Pattern $_ -Path cli\BUILD.gn `

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -52,11 +52,23 @@ function permissionsMatch(
   return true;
 }
 
-export const permissionCombinations: Set<string> = new Set([]);
+export const permissionCombinations: Map<string, Deno.Permissions> = new Map();
+
+function permToString(perms: Deno.Permissions): string {
+  const r = perms.read ? 1 : 0;
+  const w = perms.write ? 1 : 0;
+  const n = perms.net ? 1 : 0;
+  const e = perms.env ? 1 : 0;
+  const u = perms.run ? 1 : 0;
+  const h = perms.highPrecision ? 1 : 0;
+  return `permR${r}W${w}N${n}E${e}U${u}H${h}`;
+}
 
 function registerPermCombination(perms: Deno.Permissions): void {
-  // TODO: poor-man's set of unique objects, to be refactored
-  permissionCombinations.add(JSON.stringify(perms));
+  const key = permToString(perms);
+  if (!permissionCombinations.has(key)) {
+    permissionCombinations.set(key, perms);
+  }
 }
 
 function normalizeTestPermissions(perms: TestPermissions): Deno.Permissions {

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -26,32 +26,6 @@ interface DenoPermissions {
   highPrecision?: boolean;
 }
 
-function permToString(perms: DenoPermissions): string {
-  const r = perms.read ? 1 : 0;
-  const w = perms.write ? 1 : 0;
-  const n = perms.net ? 1 : 0;
-  const e = perms.env ? 1 : 0;
-  const u = perms.run ? 1 : 0;
-  const h = perms.highPrecision ? 1 : 0;
-  return `permR${r}W${w}N${n}E${e}U${u}H${h}`;
-}
-
-function permFromString(s: string): DenoPermissions {
-  const re = /^permR([01])W([01])N([01])E([01])U([01])H([01])$/;
-  const found = s.match(re);
-  if (!found) {
-    throw Error("Not a permission string");
-  }
-  return {
-    read: Boolean(Number(found[1])),
-    write: Boolean(Number(found[2])),
-    net: Boolean(Number(found[3])),
-    env: Boolean(Number(found[4])),
-    run: Boolean(Number(found[5])),
-    highPrecision: Boolean(Number(found[6]))
-  };
-}
-
 const processPerms = Deno.permissions();
 
 function permissionsMatch(
@@ -86,8 +60,7 @@ export function testPerm(
     return;
   }
 
-  const name = `${fn.name}_${permToString(perms)}`;
-  testing.test({ fn, name });
+  testing.test(fn);
 }
 
 export function test(fn: testing.TestFunction): void {
@@ -104,31 +77,7 @@ export function test(fn: testing.TestFunction): void {
   );
 }
 
-test(function permSerialization(): void {
-  for (const write of [true, false]) {
-    for (const net of [true, false]) {
-      for (const env of [true, false]) {
-        for (const run of [true, false]) {
-          for (const read of [true, false]) {
-            for (const highPrecision of [true, false]) {
-              const perms: DenoPermissions = {
-                write,
-                net,
-                env,
-                run,
-                read,
-                highPrecision
-              };
-              assertEquals(perms, permFromString(permToString(perms)));
-            }
-          }
-        }
-      }
-    }
-  }
-});
-
-test(function permsMatchesOk(): void {
+test(function permissionsMatches(): void {
   assert(
     permissionsMatch(
       {
@@ -207,15 +156,4 @@ test(function permsMatchesOk(): void {
       }
     )
   );
-});
-// To better catch internal errors, permFromString should throw if it gets an
-// invalid permission string.
-test(function permFromStringThrows(): void {
-  let threw = false;
-  try {
-    permFromString("bad");
-  } catch (e) {
-    threw = true;
-  }
-  assert(threw);
 });

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -54,6 +54,11 @@ function permissionsMatch(
 
 export const permissionCombinations: Set<string> = new Set([]);
 
+function registerPermCombination(perms: Deno.Permissions): void {
+  // TODO: poor-man's set of unique objects, to be refactored
+  permissionCombinations.add(JSON.stringify(perms));
+}
+
 function normalizeTestPermissions(perms: TestPermissions): Deno.Permissions {
   const normalizedPerms = {
     read: !!perms.read,
@@ -66,11 +71,6 @@ function normalizeTestPermissions(perms: TestPermissions): Deno.Permissions {
 
   registerPermCombination(normalizedPerms);
   return normalizedPerms;
-}
-
-function registerPermCombination(perms: Deno.Permissions): void {
-  // TODO: poor-man's set of unique objects, to be refactored
-  permissionCombinations.add(JSON.stringify(perms));
 }
 
 export function testPerm(

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -222,7 +222,7 @@ test(function permissionsMatches(): void {
   );
 });
 
-testPerm({ read: true }, async function parsingUnitTestOutput(): void {
+testPerm({ read: true }, async function parsingUnitTestOutput(): Promise<void> {
   const cwd = Deno.cwd();
   const testDataPath = `${cwd}/tools/testdata/`;
 

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -111,7 +111,7 @@ function extractNumber(re: RegExp, str: string): number | undefined {
 export function parseUnitTestOutput(
   rawOutput: Uint8Array,
   print: boolean
-): { actual?: number; expected?: number } {
+): { actual?: number; expected?: number; resultOutput?: string } {
   const decoder = new TextDecoder();
   const output = decoder.decode(rawOutput);
 
@@ -138,7 +138,7 @@ export function parseUnitTestOutput(
     actual = extractNumber(/(\d+) passed/, result);
   }
 
-  return { actual, expected };
+  return { actual, expected, resultOutput: result };
 }
 
 test(function permissionsMatches(): void {
@@ -222,7 +222,7 @@ test(function permissionsMatches(): void {
   );
 });
 
-testPerm({ read: true }, async function parsingUnitTestOutput() {
+testPerm({ read: true }, async function parsingUnitTestOutput(): void {
   const cwd = Deno.cwd();
   const testDataPath = `${cwd}/tools/testdata/`;
 

--- a/js/unit_test_runner.ts
+++ b/js/unit_test_runner.ts
@@ -1,8 +1,12 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+// TODO(bartlomieju): enable linter
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
 import "./unit_tests.ts";
 
 import { permissionCombinations } from "./test_util.ts";
 
-async function main() {
+async function main(): Promise<void> {
   console.log(
     "discovered permission combinations:",
     permissionCombinations.size

--- a/js/unit_test_runner.ts
+++ b/js/unit_test_runner.ts
@@ -1,0 +1,42 @@
+import "./unit_tests.ts";
+
+import { permissionCombinations } from "./test_util.ts";
+
+async function main() {
+  console.log(
+    "discovered permission combinations:",
+    permissionCombinations.size
+  );
+
+  for (let comb of permissionCombinations) {
+    comb = JSON.parse(comb);
+    console.log("perm comb", comb);
+
+    const permFlags = Object.keys(comb)
+      .map(permName => {
+        if (comb[permName]) {
+          const snakeCase = permName.replace(
+            /\.?([A-Z])/g,
+            (x, y) => `-${y.toLowerCase()}`
+          );
+          return `--allow-${snakeCase}`;
+        }
+      })
+      .filter(el => !!el);
+
+    console.log("permFlags", permFlags);
+
+    const args = [Deno.execPath, "run", ...permFlags, "js/unit_tests.ts"];
+
+    console.log("args", args);
+
+    const p = Deno.run({
+      args,
+      stdout: "inherit"
+    });
+    const status = await p.status();
+    console.log("status ", status);
+  }
+}
+
+main();

--- a/js/unit_test_runner.ts
+++ b/js/unit_test_runner.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env deno run --reload --allow-run
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import "./unit_tests.ts";
-import { permissionCombinations } from "./test_util.ts";
+import { permissionCombinations, parseUnitTestOutput } from "./test_util.ts";
 
 function permsToCliFlags(perms: Deno.Permissions): string[] {
   return Object.keys(perms)
@@ -27,43 +27,6 @@ function fmtPerms(perms: Deno.Permissions): string {
   }
 
   return fmt;
-}
-
-function parseUnitTestOutput(
-  rawOutput: Uint8Array,
-  print: boolean
-): { actual: number; expected: number } {
-  const decoder = new TextDecoder();
-  const output = decoder.decode(rawOutput);
-
-  let expected = null,
-    actual = null,
-    result = null;
-
-  for (const line of output.split("\n")) {
-    if (!expected) {
-      // expect "running 30 tests"
-      const match = line.match(/running (\d+) tests/);
-      expected = Number.parseInt(match[1]);
-    } else if (line.indexOf("test result:") !== -1) {
-      result = line;
-    }
-
-    if (print) {
-      console.log(line);
-    }
-  }
-
-  // Check that the number of expected tests equals what was reported at the
-  // bottom.
-  if (result) {
-    // result should be a string like this:
-    // "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; ..."
-    const match = result.match(/(\d+) passed/);
-    actual = Number.parseInt(match[1]);
-  }
-
-  return { actual, expected };
 }
 
 async function main(): Promise<void> {

--- a/js/unit_test_runner.ts
+++ b/js/unit_test_runner.ts
@@ -29,7 +29,10 @@ function fmtPerms(perms: Deno.Permissions): string {
   return fmt;
 }
 
-function parseUnitTestOutput(rawOutput: Uint8Array, print: boolean) {
+function parseUnitTestOutput(
+  rawOutput: Uint8Array,
+  print: boolean
+): { actual: number; expected: number } {
   const decoder = new TextDecoder();
   const output = decoder.decode(rawOutput);
 

--- a/js/unit_test_runner.ts
+++ b/js/unit_test_runner.ts
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
       args,
       stdout: "piped"
     });
-    
+
     const { actual, expected, resultOutput } = parseUnitTestOutput(
       await p.output(),
       true

--- a/js/unit_test_runner.ts
+++ b/js/unit_test_runner.ts
@@ -29,6 +29,40 @@ function fmtPerms(perms: Deno.Permissions): string {
   return fmt;
 }
 
+function parseUnitTestOutput(rawOutput: Uint8Array, print: boolean) {
+  const decoder = new TextDecoder();
+  const output = decoder.decode(rawOutput);
+
+  let expected = null,
+    actual = null,
+    result = null;
+
+  for (const line of output.split("\n")) {
+    if (!expected) {
+      // expect "running 30 tests"
+      const match = line.match(/running (\d+) tests/);
+      expected = Number.parseInt(match[1]);
+    } else if (line.indexOf("test result:") !== -1) {
+      result = line;
+    }
+
+    if (print) {
+      console.log(line);
+    }
+  }
+
+  // Check that the number of expected tests equals what was reported at the
+  // bottom.
+  if (result) {
+    // result should be a string like this:
+    // "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; ..."
+    const match = result.match(/(\d+) passed/);
+    actual = Number.parseInt(match[1]);
+  }
+
+  return { actual, expected };
+}
+
 async function main(): Promise<void> {
   console.log(
     "Discovered permission combinations for tests:",
@@ -55,11 +89,20 @@ async function main(): Promise<void> {
 
     const p = Deno.run({
       args,
-      stdout: "inherit"
+      stdout: "piped"
     });
 
-    const { code } = await p.status();
-    testResults.push(code);
+    await p.status();
+    const { actual, expected } = parseUnitTestOutput(await p.output(), true);
+
+    if (!actual && !expected) {
+      console.error("Bad js/unit_test.ts output");
+      testResults.push(1);
+    } else if (expected !== actual) {
+      testResults.push(1);
+    } else {
+      testResults.push(0);
+    }
   }
 
   // if any run tests returned non-zero status then whole test

--- a/js/unit_test_runner.ts
+++ b/js/unit_test_runner.ts
@@ -11,12 +11,12 @@ function permsToCliFlags(perms: Deno.Permissions): string[] {
 
         const cliFlag = key.replace(
           /\.?([A-Z])/g,
-          (x, y) => `-${y.toLowerCase()}`
+          (x, y): string => `-${y.toLowerCase()}`
         );
         return `--allow-${cliFlag}`;
       }
     )
-    .filter(e => e.length);
+    .filter((e): boolean => e.length > 0);
 }
 
 function fmtPerms(perms: Deno.Permissions): string {

--- a/js/unit_test_runner.ts
+++ b/js/unit_test_runner.ts
@@ -1,7 +1,6 @@
+#!/usr/bin/env deno run --reload --allow-run
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-
 import "./unit_tests.ts";
-
 import { permissionCombinations } from "./test_util.ts";
 
 function permsToCliFlags(perms: Deno.Permissions): string[] {
@@ -46,7 +45,13 @@ async function main(): Promise<void> {
     console.log(`Running tests for: ${fmtPerms(perms)}`);
     const cliPerms = permsToCliFlags(perms);
     // run subsequent tests using same deno executable
-    const args = [Deno.execPath, "run", ...cliPerms, "js/unit_tests.ts"];
+    const args = [
+      Deno.execPath,
+      "run",
+      "--no-prompt",
+      ...cliPerms,
+      "js/unit_tests.ts"
+    ];
 
     const p = Deno.run({
       args,

--- a/js/unit_test_runner.ts
+++ b/js/unit_test_runner.ts
@@ -58,8 +58,7 @@ async function main(): Promise<void> {
       args,
       stdout: "piped"
     });
-
-    await p.status();
+    
     const { actual, expected, resultOutput } = parseUnitTestOutput(
       await p.output(),
       true

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -50,4 +50,11 @@ import "./version_test.ts";
 
 import "../website/app_test.js";
 
-import "./deps/https/deno.land/std/testing/main.ts";
+import { runIfMain } from "./deps/https/deno.land/std/testing/mod.ts";
+
+async function main() {
+  // Testing entire test suite serially
+  runIfMain(import.meta);
+}
+
+main();

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -52,7 +52,7 @@ import "../website/app_test.js";
 
 import { runIfMain } from "./deps/https/deno.land/std/testing/mod.ts";
 
-async function main() {
+async function main(): Promise<void> {
   // Testing entire test suite serially
   runIfMain(import.meta);
 }

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -3,7 +3,7 @@
 import util
 import sys
 import subprocess
-import re
+import itertools
 
 
 def run_unit_test2(cmd):
@@ -18,46 +18,42 @@ def run_unit_test2(cmd):
     errcode = process.returncode
     if errcode != 0:
         sys.exit(errcode)
-    # To avoid the case where we silently filter out all tests.
-    assert expected > 0
+
     if actual == None and expected == None:
         raise AssertionError("Bad js/unit_test.ts output")
     if expected != actual:
         print "expected", expected, "actual", actual
         raise AssertionError("expected tests did not equal actual")
+
     process.wait()
     errcode = process.returncode
     if errcode != 0:
         sys.exit(errcode)
 
 
-def run_unit_test(deno_exe, permStr, flags=None):
+def run_unit_test(deno_exe, flags=None):
     if flags is None:
         flags = []
-    cmd = [deno_exe, "run"] + flags + ["js/unit_tests.ts", permStr]
+    cmd = [deno_exe, "run"] + flags + ["js/unit_tests.ts"]
+    print "Running unit tests for permissions: {}".format(flags)
     run_unit_test2(cmd)
 
 
-# We want to test many ops in deno which have different behavior depending on
-# the permissions set. These tests can specify which permissions they expect,
-# which appends a special string like "permW1N0" to the end of the test name.
-# Here we run several copies of deno with different permissions, filtering the
-# tests by the special string. permW1N0 means allow-write but not allow-net.
-# See js/test_util.ts for more details.
+perms = [
+    "--allow-read", "--allow-write", "--allow-net", "--allow-run",
+    "--allow-env", "--allow-high-precision"
+]
+
+
 def unit_tests(deno_exe):
-    run_unit_test(deno_exe, "permR0W0N0E0U0H0", ["--reload"])
-    run_unit_test(deno_exe, "permR1W0N0E0U0H0", ["--allow-read"])
-    run_unit_test(deno_exe, "permR0W1N0E0U0H0", ["--allow-write"])
-    run_unit_test(deno_exe, "permR0W0N1E0U0H0", ["--allow-net"])
-    run_unit_test(deno_exe, "permR1W1N0E0U0H0",
-                  ["--allow-read", "--allow-write"])
-    run_unit_test(deno_exe, "permR0W0N0E1U0H0", ["--allow-env"])
-    run_unit_test(deno_exe, "permR0W0N0E0U0H1", ["--allow-high-precision"])
-    run_unit_test(deno_exe, "permR0W0N0E0U1H0", ["--allow-run"])
-    run_unit_test(deno_exe, "permR0W1N0E0U1H0",
-                  ["--allow-run", "--allow-write"])
-    # TODO We might accidentally miss some. We should be smarter about which we
-    # run. Maybe we can use the "filtered out" number to check this.
+    run_unit_test(deno_exe, [])
+
+    for i in range(len(perms)):
+        combinations = itertools.combinations(perms, i + 1)
+
+        for test_perms in combinations:
+            test_perms = list(test_perms)
+            run_unit_test(deno_exe, test_perms)
 
 
 if __name__ == '__main__':

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -7,7 +7,7 @@ import itertools
 import http_server
 
 
-def run_unit_test2(cmd):
+def run_unit_test(cmd):
     process = subprocess.Popen(
         cmd,
         bufsize=1,
@@ -20,11 +20,11 @@ def run_unit_test2(cmd):
     if errcode != 0:
         sys.exit(errcode)
 
-    if actual == None and expected == None:
-        raise AssertionError("Bad js/unit_test.ts output")
-    if expected != actual:
-        print "expected", expected, "actual", actual
-        raise AssertionError("expected tests did not equal actual")
+    # if actual == None and expected == None:
+    #     raise AssertionError("Bad js/unit_test.ts output")
+    # if expected != actual:
+    #     print "expected", expected, "actual", actual
+    #     raise AssertionError("expected tests did not equal actual")
 
     process.wait()
     errcode = process.returncode
@@ -32,29 +32,10 @@ def run_unit_test2(cmd):
         sys.exit(errcode)
 
 
-def run_unit_test(deno_exe, flags=None):
-    if flags is None:
-        flags = []
-    cmd = [deno_exe, "run"] + flags + ["js/unit_tests.ts"]
-    print "Running unit tests for permissions: {}".format(flags)
-    run_unit_test2(cmd)
-
-
-perms = [
-    "--allow-read", "--allow-write", "--allow-net", "--allow-run",
-    "--allow-env", "--allow-high-precision"
-]
-
-
 def unit_tests(deno_exe):
-    run_unit_test(deno_exe, [])
-
-    for i in range(len(perms)):
-        combinations = itertools.combinations(perms, i + 1)
-
-        for test_perms in combinations:
-            test_perms = list(test_perms)
-            run_unit_test(deno_exe, test_perms)
+    flags = ["--reload", "--allow-run"]
+    cmd = [deno_exe, "run"] + flags + ["js/unit_test_runner.ts"]
+    run_unit_test(cmd)
 
 
 if __name__ == '__main__':

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -14,7 +14,7 @@ def run_unit_test(cmd):
         universal_newlines=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
-    (actual, expected) = util.parse_unit_test_output(process.stdout, True)
+    util.parse_unit_test_output(process.stdout, True)
     process.wait()
     errcode = process.returncode
     if errcode != 0:

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -4,6 +4,7 @@ import util
 import sys
 import subprocess
 import itertools
+import http_server
 
 
 def run_unit_test2(cmd):
@@ -60,4 +61,6 @@ if __name__ == '__main__':
     if len(sys.argv) < 2:
         print "Usage ./tools/unit_tests.py target/debug/deno"
         sys.exit(1)
+
+    http_server.spawn()
     unit_tests(sys.argv[1])

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import util
 import sys
 import subprocess
 import http_server
 
 
-def run_unit_test(cmd):
+def unit_tests(deno_exe):
+    cmd = [
+        deno_exe, "run", "--reload", "--allow-run", "js/unit_test_runner.ts"
+    ]
     process = subprocess.Popen(
         cmd, bufsize=1, universal_newlines=True, stderr=subprocess.STDOUT)
 
@@ -14,11 +16,6 @@ def run_unit_test(cmd):
     errcode = process.returncode
     if errcode != 0:
         sys.exit(errcode)
-
-
-def unit_tests(deno_exe):
-    run_unit_test(
-        [deno_exe, "run", "--reload", "--allow-run", "js/unit_test_runner.ts"])
 
 
 if __name__ == '__main__':

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -3,7 +3,6 @@
 import util
 import sys
 import subprocess
-import itertools
 import http_server
 
 
@@ -33,9 +32,8 @@ def run_unit_test(cmd):
 
 
 def unit_tests(deno_exe):
-    flags = ["--reload", "--allow-run"]
-    cmd = [deno_exe, "run"] + flags + ["js/unit_test_runner.ts"]
-    run_unit_test(cmd)
+    run_unit_test(
+        [deno_exe, "run", "--reload", "--allow-run", "js/unit_test_runner.ts"])
 
 
 if __name__ == '__main__':

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -8,22 +8,7 @@ import http_server
 
 def run_unit_test(cmd):
     process = subprocess.Popen(
-        cmd,
-        bufsize=1,
-        universal_newlines=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT)
-    util.parse_unit_test_output(process.stdout, True)
-    process.wait()
-    errcode = process.returncode
-    if errcode != 0:
-        sys.exit(errcode)
-
-    # if actual == None and expected == None:
-    #     raise AssertionError("Bad js/unit_test.ts output")
-    # if expected != actual:
-    #     print "expected", expected, "actual", actual
-    #     raise AssertionError("expected tests did not equal actual")
+        cmd, bufsize=1, universal_newlines=True, stderr=subprocess.STDOUT)
 
     process.wait()
     errcode = process.returncode

--- a/tools/util.py
+++ b/tools/util.py
@@ -329,28 +329,6 @@ def enable_ansi_colors_win10():
     return True
 
 
-def parse_unit_test_output(output, print_to_stdout):
-    expected = None
-    actual = None
-    result = None
-    for line in iter(output.readline, ''):
-        if expected is None:
-            # expect "running 30 tests"
-            expected = extract_number(r'running (\d+) tests', line)
-        elif "test result:" in line:
-            result = line
-        if print_to_stdout:
-            sys.stdout.write(line)
-            sys.stdout.flush()
-    # Check that the number of expected tests equals what was reported at the
-    # bottom.
-    if result:
-        # result should be a string like this:
-        # "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; ..."
-        actual = extract_number(r'(\d+) passed', result)
-    return (actual, expected)
-
-
 def extract_number(pattern, string):
     matches = re.findall(pattern, string)
     if len(matches) != 1:

--- a/tools/util_test.py
+++ b/tools/util_test.py
@@ -48,37 +48,6 @@ def shell_quote_win_test():
         'a"b""c\\d\\"e\\\\')
 
 
-def parse_unit_test_output_test():
-    print "Testing util.parse_unit_test_output()..."
-    # This is an example of a successful unit test output.
-    output = open(
-        os.path.join(util.root_path, "tools/testdata/unit_test_output1.txt"))
-    (actual, expected) = util.parse_unit_test_output(output, False)
-    assert actual == 96
-    assert expected == 96
-
-    # This is an example of a silently dying unit test.
-    output = open(
-        os.path.join(util.root_path, "tools/testdata/unit_test_output2.txt"))
-    (actual, expected) = util.parse_unit_test_output(output, False)
-    assert actual == None
-    assert expected == 96
-
-    # This is an example of compiling before successful unit tests.
-    output = open(
-        os.path.join(util.root_path, "tools/testdata/unit_test_output3.txt"))
-    (actual, expected) = util.parse_unit_test_output(output, False)
-    assert actual == 96
-    assert expected == 96
-
-    # Check what happens on empty output.
-    from StringIO import StringIO
-    output = StringIO("\n\n\n")
-    (actual, expected) = util.parse_unit_test_output(output, False)
-    assert actual == None
-    assert expected == None
-
-
 def parse_wrk_output_test():
     print "Testing util.parse_wrk_output_test()..."
     f = open(os.path.join(util.root_path, "tools/testdata/wrk1.txt"))
@@ -101,7 +70,6 @@ def util_test():
     pattern_match_test()
     parse_exit_code_test()
     shell_quote_win_test()
-    parse_unit_test_output_test()
     parse_wrk_output_test()
 
 


### PR DESCRIPTION
This PR tries to resolve issue #2103.

In the first pass I've changed the behavior of Python script to run unit tests with every possible combination of permissions. This ensures that no test is skipped but requires to spawn separate Deno process for each combination even if there are no tests to run. This approach is really suboptimal. 

My next step will be to first run a process to discover all tests and establish which perm combinations are used in test cases and then spawn new processes only for those combinations.  

By the way, I think that this combination technique might be useful for users as well. Maybe we should consider implementing it in standard library? Eg. in deno-postgres I need to run tests once with `--allow-env` flag and second time without it, I'd be neat if this was built in without need to port this behavior.

CC @ry