### PR TITLE
feat: expose writeAll() and writeAllSync()

### DIFF
--- a/js/buffer.ts
+++ b/js/buffer.ts
@@ -274,3 +274,21 @@ export function readAllSync(r: SyncReader): Uint8Array {
   buf.readFromSync(r);
   return buf.bytes();
 }
+
+/** Write all the content of `arr` to `w`.
+ */
+export async function writeAll(w: Writer, arr: Uint8Array): Promise<void> {
+  let nwritten = 0;
+  while (nwritten < arr.length) {
+    nwritten += await w.write(arr.subarray(nwritten));
+  }
+}
+
+/** Write synchronously all the content of `arr` to `w`.
+ */
+export function writeAllSync(w: SyncWriter, arr: Uint8Array): void {
+  let nwritten = 0;
+  while (nwritten < arr.length) {
+    nwritten += w.writeSync(arr.subarray(nwritten));
+  }
+}

--- a/js/buffer_test.ts
+++ b/js/buffer_test.ts
@@ -5,7 +5,7 @@
 // https://github.com/golang/go/blob/master/LICENSE
 import { assertEquals, test } from "./test_util.ts";
 
-const { Buffer, readAll, readAllSync } = Deno;
+const { Buffer, readAll, readAllSync, writeAll, writeAllSync } = Deno;
 type Buffer = Deno.Buffer;
 
 // N controls how many iterations of certain checks are performed.
@@ -248,6 +248,28 @@ test(function testReadAllSync(): void {
   init();
   const reader = new Buffer(testBytes.buffer as ArrayBuffer);
   const actualBytes = readAllSync(reader);
+  assertEquals(testBytes.byteLength, actualBytes.byteLength);
+  for (let i = 0; i < testBytes.length; ++i) {
+    assertEquals(testBytes[i], actualBytes[i]);
+  }
+});
+
+test(async function testWriteAll(): Promise<void> {
+  init();
+  const writer = new Buffer();
+  await writeAll(writer, testBytes);
+  const actualBytes = writer.bytes();
+  assertEquals(testBytes.byteLength, actualBytes.byteLength);
+  for (let i = 0; i < testBytes.length; ++i) {
+    assertEquals(testBytes[i], actualBytes[i]);
+  }
+});
+
+test(function testWriteAllSync(): void {
+  init();
+  const writer = new Buffer();
+  writeAllSync(writer, testBytes);
+  const actualBytes = writer.bytes();
   assertEquals(testBytes.byteLength, actualBytes.byteLength);
   for (let i = 0; i < testBytes.length; ++i) {
     assertEquals(testBytes[i], actualBytes[i]);

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -38,7 +38,7 @@ export {
   ReadWriteCloser,
   ReadWriteSeeker
 } from "./io";
-export { Buffer, readAll, readAllSync } from "./buffer";
+export { Buffer, readAll, readAllSync, writeAll, writeAllSync } from "./buffer";
 export { mkdirSync, mkdir } from "./mkdir";
 export {
   makeTempDirSync,

--- a/js/write_file.ts
+++ b/js/write_file.ts
@@ -2,6 +2,7 @@
 import { stat, statSync } from "./stat";
 import { open, openSync } from "./files";
 import { chmod, chmodSync } from "./chmod";
+import { writeAll, writeAllSync } from "./buffer";
 
 /** Options for writing to a file.
  * `perm` would change the file's permission if set.
@@ -40,7 +41,7 @@ export function writeFileSync(
     chmodSync(filename, options.perm);
   }
 
-  file.writeSync(data);
+  writeAllSync(file, data);
   file.close();
 }
 
@@ -70,6 +71,6 @@ export async function writeFile(
     await chmod(filename, options.perm);
   }
 
-  await file.write(data);
+  await writeAll(file, data);
   file.close();
 }

--- a/js/xeval.ts
+++ b/js/xeval.ts
@@ -1,21 +1,9 @@
-import { Buffer } from "./buffer";
+import { Buffer, writeAll } from "./buffer";
 import { stdin } from "./files";
 import { TextEncoder, TextDecoder } from "./text_encoding";
 import { Reader, EOF } from "./io";
 
 export type XevalFunc = (v: string) => void;
-
-async function writeAll(buffer: Buffer, arr: Uint8Array): Promise<void> {
-  let bytesWritten = 0;
-  while (bytesWritten < arr.length) {
-    try {
-      const nwritten = await buffer.write(arr.subarray(bytesWritten));
-      bytesWritten += nwritten;
-    } catch {
-      return;
-    }
-  }
-}
 
 // TODO(kevinkassimo): Move this utility to deno_std.
 // Import from there once doable.


### PR DESCRIPTION
Symmetric with `readAll()` and `readAllSync()`. Also used in `xeval`.
Also correct usage in `writeFile()`/`writeFileSync()`.