### PR TITLE
[manual] fixing unused decoder

### DIFF
--- a/website/manual.md
+++ b/website/manual.md
@@ -409,7 +409,7 @@ async function main() {
 
   if (code === 0) {
     const rawOutput = await p.output();
-    Deno.stdout.write(rawOutput);
+    await Deno.stdout.write(rawOutput);
   } else {
     const rawError = await p.stderrOutput();
     const errorString = decoder.decode(rawError);

--- a/website/manual.md
+++ b/website/manual.md
@@ -412,7 +412,7 @@ async function main() {
     Deno.stdout.write(rawOutput);
   } else {
     const rawError = await p.stderrOutput();
-    const errorString = new TextDecoder().decode(rawError);
+    const errorString = decoder.decode(rawError);
     console.log(errorString);
   }
 


### PR DESCRIPTION
Just found an mistake in an example.