### PR TITLE
feat: auto remove stale compiled version on rerun

### DIFF
--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -102,7 +102,7 @@ impl DenoDir {
     Ok(deno_dir)
   }
 
-  pub fn cache_path_map_meta(
+  pub fn cache_paths(
     self: &Self,
     filename: &str,
   ) -> (PathBuf, PathBuf, PathBuf) {
@@ -119,8 +119,8 @@ impl DenoDir {
     module_meta_data: &ModuleMetaData,
   ) -> std::io::Result<()> {
     let (cache_path, source_map_path, meta_path) =
-      self.cache_path_map_meta(&module_meta_data.filename);
-    let source_code_state = source_code_state_hash(
+      self.cache_paths(&module_meta_data.filename);
+    let version_hash = source_code_version_hash(
       &module_meta_data.source_code,
       version::DENO,
       &self.config,
@@ -143,11 +143,11 @@ impl DenoDir {
         Some(source_map) => fs::write(source_map_path, source_map),
         _ => Ok(()),
       }?;
-      save_compiled_file_metadata(
-        &meta_path,
-        &module_meta_data.filename,
-        &source_code_state,
-      );
+      let compiled_file_metadata = CompiledFileMetadata {
+        source_path: module_meta_data.filename.clone(),
+        version_hash,
+      };
+      compiled_file_metadata.save(&meta_path);
       Ok(())
     }
   }
@@ -227,14 +227,14 @@ impl DenoDir {
           gen.join(cache_key.to_string() + ".meta"),
         );
 
-        let state_hash_to_validate =
-          source_code_state_hash(&out.source_code, version::DENO, &config);
+        let version_hash_to_validate =
+          source_code_version_hash(&out.source_code, version::DENO, &config);
 
         let result = load_cache(
           &output_code_filename,
           &output_source_map_filename,
           &output_meta_filename,
-          state_hash_to_validate,
+          version_hash_to_validate,
         );
         match result {
           Err(err) => {
@@ -487,66 +487,67 @@ fn get_cache_filename(basedir: &Path, url: &Url) -> PathBuf {
 
 /// Information associated with compiled file in cache.
 /// Includes source code path and state hash.
-/// state_hash is used to validate versions of the file
+/// version_hash is used to validate versions of the file
 /// and could be used to remove stale file in cache.
 struct CompiledFileMetadata {
   pub source_path: String,
-  pub state_hash: String,
+  pub version_hash: String,
 }
 
-/// Get compiled file metadata from meta_path.
-/// If operation failed or metadata file is corrupted,
-/// return None.
-fn get_compiled_file_metadata(
-  meta_path: &PathBuf,
-) -> Option<CompiledFileMetadata> {
-  let maybe_metadata_string = fs::read_to_string(meta_path).ok();
-  maybe_metadata_string.as_ref()?;
-  let maybe_metadata_json: serde_json::Result<serde_json::Value> =
-    serde_json::from_str(&maybe_metadata_string.unwrap());
-  if let Ok(metadata_json) = maybe_metadata_json {
-    let source_path = metadata_json["source_path"].as_str().map(String::from);
-    let state_hash = metadata_json["state_hash"].as_str().map(String::from);
-    if source_path.is_none() || state_hash.is_none() {
+static SOURCE_PATH: &'static str = "source_path";
+static VERSION_HASH: &'static str = "version_hash";
+
+impl CompiledFileMetadata {
+  /// Get compiled file metadata from meta_path.
+  /// If operation failed or metadata file is corrupted,
+  /// return None.
+  fn load<P: AsRef<Path>>(meta_path: P) -> Option<CompiledFileMetadata> {
+    let meta_path = meta_path.as_ref();
+    let maybe_metadata_string = fs::read_to_string(meta_path).ok();
+    maybe_metadata_string.as_ref()?;
+    let maybe_metadata_json: serde_json::Result<serde_json::Value> =
+      serde_json::from_str(&maybe_metadata_string.unwrap());
+    if let Ok(metadata_json) = maybe_metadata_json {
+      let source_path = metadata_json[SOURCE_PATH].as_str().map(String::from);
+      let version_hash = metadata_json[VERSION_HASH].as_str().map(String::from);
+      if source_path.is_none() || version_hash.is_none() {
+        return None;
+      }
+      return Some(CompiledFileMetadata {
+        source_path: source_path.unwrap(),
+        version_hash: version_hash.unwrap(),
+      });
+    } else {
       return None;
     }
-    return Some(CompiledFileMetadata {
-      source_path: source_path.unwrap(),
-      state_hash: state_hash.unwrap(),
-    });
-  } else {
-    return None;
   }
-}
 
-/// Save compiled file metadata to meta_path.
-fn save_compiled_file_metadata(
-  meta_path: &PathBuf,
-  source_path: &str,
-  state_hash: &str,
-) {
-  // Remove possibly existing stale meta file.
-  // May not exist. DON'T unwrap.
-  let _ = std::fs::remove_file(&meta_path);
-  let mut value_map = serde_json::map::Map::new();
+  /// Save compiled file metadata to meta_path.
+  fn save<P: AsRef<Path>>(self: &Self, meta_path: P) {
+    let meta_path = meta_path.as_ref();
+    // Remove possibly existing stale meta file.
+    // May not exist. DON'T unwrap.
+    let _ = std::fs::remove_file(&meta_path);
+    let mut value_map = serde_json::map::Map::new();
 
-  value_map.insert("source_path".to_owned(), json!(source_path));
-  value_map.insert("state_hash".to_string(), json!(state_hash));
+    value_map.insert(SOURCE_PATH.to_owned(), json!(&self.source_path));
+    value_map.insert(VERSION_HASH.to_string(), json!(&self.version_hash));
 
-  let _ = serde_json::to_string(&value_map).map(|s| {
-    let _ = deno_fs::write_file(meta_path, s, 0o666);
-  });
+    let _ = serde_json::to_string(&value_map).map(|s| {
+      let _ = deno_fs::write_file(meta_path, s, 0o666);
+    });
+  }
 }
 
 /// Try loading the compiled code and map from the cache.
 /// Also validate the state hash in case source code has changed.
-/// If the state hash does not match,
+/// If the version hash does not match,
 /// try delete all these files and return an error.
 fn load_cache(
   js_filename: &PathBuf,
   map_filename: &PathBuf,
   meta_filename: &PathBuf,
-  state_hash_to_validate: String,
+  version_hash_to_validate: String,
 ) -> Result<(Vec<u8>, Vec<u8>), std::io::Error> {
   debug!(
     "load_cache code: {} map: {} meta: {}",
@@ -557,22 +558,25 @@ fn load_cache(
   let read_output_code = fs::read(&js_filename)?;
   let read_source_map = fs::read(&map_filename)?;
 
-  // Validate metadata and maybe remove.
+  // Validate metadata.
   let mut should_remove_all = false;
-  if let Some(read_metadata) = get_compiled_file_metadata(meta_filename) {
-    if read_metadata.state_hash != state_hash_to_validate {
-      debug!("load_cache metadata state hash does not match");
+  if let Some(read_metadata) = CompiledFileMetadata::load(meta_filename) {
+    if read_metadata.version_hash != version_hash_to_validate {
+      debug!("load_cache metadata version hash does not match");
       should_remove_all = true;
     }
   } else {
     debug!("load_cache metadata load error");
     should_remove_all = true;
   }
+  // The old version is stale or some error occurred.
+  // Try removing all the cached files.
   if should_remove_all {
     let _ = fs::remove_file(&js_filename);
     let _ = fs::remove_file(&map_filename);
     let _ = fs::remove_file(&meta_filename);
-    // This will trigger a not-found error return.
+    // This will trigger a not-found error return
+    // and hint recompilation.
     let _ = fs::read(&js_filename)?;
   }
 
@@ -601,7 +605,7 @@ fn filename_hash(filename: &str) -> String {
 
 /// Emit a SHA1 hash based on source code, deno version and TS config.
 /// Used to check if a recompilation for source code is needed.
-fn source_code_state_hash(
+fn source_code_version_hash(
   source_code: &[u8],
   version: &str,
   config: &[u8],
@@ -1050,7 +1054,7 @@ mod tests {
   }
 
   #[test]
-  fn test_cache_path_map_meta() {
+  fn test_cache_paths() {
     let (temp_dir, deno_dir) = test_setup();
     let filename = "hello.js";
     let hash = filename_hash(filename);
@@ -1060,7 +1064,7 @@ mod tests {
         temp_dir.path().join(format!("gen/{}.js.map", hash)),
         temp_dir.path().join(format!("gen/{}.meta", hash)),
       ),
-      deno_dir.cache_path_map_meta(filename)
+      deno_dir.cache_paths(filename)
     );
   }
 
@@ -1074,9 +1078,10 @@ mod tests {
     let source_map = b"{}";
     let config = b"{}";
     let hash = filename_hash(filename);
-    let state_hash = source_code_state_hash(source_code, version::DENO, config);
+    let version_hash =
+      source_code_version_hash(source_code, version::DENO, config);
     let (cache_path, source_map_path, meta_path) =
-      deno_dir.cache_path_map_meta(filename);
+      deno_dir.cache_paths(filename);
     assert!(cache_path.ends_with(format!("gen/{}.js", hash)));
     assert!(source_map_path.ends_with(format!("gen/{}.js.map", hash)));
     assert!(meta_path.ends_with(format!("gen/{}.meta", hash)));
@@ -1098,31 +1103,31 @@ mod tests {
     assert!(cache_path.exists());
     assert_eq!(output_code[..].to_owned(), fs::read(&cache_path).unwrap());
 
-    let meta = get_compiled_file_metadata(&meta_path);
+    let meta = CompiledFileMetadata::load(&meta_path);
     assert!(meta.is_some());
-    assert_eq!(&state_hash, &meta.unwrap().state_hash);
+    assert_eq!(&version_hash, &meta.unwrap().version_hash);
   }
 
   #[test]
-  fn test_source_code_state_hash() {
+  fn test_source_code_version_hash() {
     assert_eq!(
       "08574f9cdeb94fd3fb9cdc7a20d086daeeb42bca",
-      source_code_state_hash(b"1+2", "0.4.0", b"{}")
+      source_code_version_hash(b"1+2", "0.4.0", b"{}")
     );
     // Different source_code should result in different hash.
     assert_eq!(
       "d8abe2ead44c3ff8650a2855bf1b18e559addd06",
-      source_code_state_hash(b"1", "0.4.0", b"{}")
+      source_code_version_hash(b"1", "0.4.0", b"{}")
     );
     // Different version should result in different hash.
     assert_eq!(
       "d6feffc5024d765d22c94977b4fe5975b59d6367",
-      source_code_state_hash(b"1", "0.1.0", b"{}")
+      source_code_version_hash(b"1", "0.1.0", b"{}")
     );
     // Different config should result in different hash.
     assert_eq!(
       "3b35db249b26a27decd68686f073a58266b2aec2",
-      source_code_state_hash(b"1", "0.4.0", b"{\"compilerOptions\": {}}")
+      source_code_version_hash(b"1", "0.4.0", b"{\"compilerOptions\": {}}")
     );
   }
 

--- a/tools/cache_test.py
+++ b/tools/cache_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import os
+import sys
+from util import mkdtemp, tests_path, run_output, green_ok
+import shutil
+
+
+def cache_purge_stale_test(deno_exe):
+    sys.stdout.write("fetch_test...")
+    sys.stdout.flush()
+
+    deno_dir = mkdtemp()
+    gen_dir = os.path.join(deno_dir, "gen")
+    filename = os.path.join(deno_dir, "test.ts")
+
+    content_v1 = "console.log('HELLO');"
+    content_v2 = "console.log('HELLO WORLD');"
+
+    # Prepare version 1
+    with open(filename, "w+") as f:
+        f.write(content_v1)
+
+    try:
+        # Run version 1, generate compiled files
+        run_output([deno_exe, "run", filename],
+                   merge_env={"DENO_DIR": deno_dir})
+
+        # Read from gen folder
+        files_v1 = [os.path.join(gen_dir, f) for f in os.listdir(gen_dir)]
+        files_v1.sort()
+        assert len(files_v1) == 3
+        gen_js = filter(lambda f: f.endswith(".js"), files_v1)[0]
+        with open(gen_js, "r+") as f:
+            data = f.read()
+            assert "HELLO" in data
+            assert not "HELLO WORLD" in data
+
+        # Prepare version 2
+        with open(filename, "w+") as f:
+            f.write(content_v2)
+
+        # Run version 2, update compiled files
+        run_output([deno_exe, "run", filename],
+                   merge_env={"DENO_DIR": deno_dir})
+
+        # Read from gen folder again
+        files_v2 = [os.path.join(gen_dir, f) for f in os.listdir(gen_dir)]
+        files_v2.sort()
+        assert len(files_v2) == 3
+        # Files should still have the same names
+        assert files_v1 == files_v2
+        # But the compiled content is updated!
+        with open(gen_js, "r+") as f:
+            data = f.read()
+            assert "HELLO WORLD" in data
+
+        print green_ok()
+    finally:
+        shutil.rmtree(deno_dir)
+
+
+def cache_test(deno_exe):
+    cache_purge_stale_test(deno_exe)
+
+
+if __name__ == "__main__":
+    cache_test(sys.argv[1])

--- a/tools/test.py
+++ b/tools/test.py
@@ -14,6 +14,7 @@ from util_test import util_test
 from benchmark_test import benchmark_test
 from repl_test import repl_tests
 from fetch_test import fetch_test
+from cache_test import cache_test
 from fmt_test import fmt_test
 import subprocess
 import http_server
@@ -95,6 +96,7 @@ def main(argv):
     unit_tests(deno_exe)
 
     fetch_test(deno_exe)
+    cache_test(deno_exe)
     fmt_test(deno_exe)
 
     integration_tests(deno_exe)


### PR DESCRIPTION
First step of #2305.

Creates a new meta file that stores code state_hash (digest from
source_code + deno_version + config) and use filename_hash (digest from
just the source path). When the file content is updated, during rerun we
would check the old cached state_hash. If the hash does not match, we
automatically remove the old files.

e.g.
For a file `hello.ts`
```ts
console.log("HELLO");
```
Calling `deno run hello.ts` yields the following cache content:
```sh
$ ls gen
fab19d3c617bf268f68f677fa7ff9e4b5fb48b8f.js
fab19d3c617bf268f68f677fa7ff9e4b5fb48b8f.js.map
fab19d3c617bf268f68f677fa7ff9e4b5fb48b8f.meta
$ cat gen/fab19d3c617bf268f68f677fa7ff9e4b5fb48b8f.js
console.log("HELLO");
//# sourceMappingURL=hello.js.map
//# sourceURL=/Users/kun/Projects/Deno/test/hello.ts
$ cat gen/fab19d3c617bf268f68f677fa7ff9e4b5fb48b8f.meta
{"source_path":"/Users/kun/Projects/Deno/test/hello.ts","state_hash":"17cfdc471944246d87dd49a7315e28e2f4eef145"}
```

Update this file to
```ts
console.log("HELLO WORLD");
```
We get
```sh
$ ls gen
fab19d3c617bf268f68f677fa7ff9e4b5fb48b8f.js
fab19d3c617bf268f68f677fa7ff9e4b5fb48b8f.js.map
fab19d3c617bf268f68f677fa7ff9e4b5fb48b8f.meta
$ cat gen/fab19d3c617bf268f68f677fa7ff9e4b5fb48b8f.js
console.log("HELLO WORLD");
//# sourceMappingURL=hello.js.map
//# sourceURL=/Users/kun/Projects/Deno/test/hello.ts
$ cat gen/fab19d3c617bf268f68f677fa7ff9e4b5fb48b8f.meta
{"source_path":"/Users/kun/Projects/Deno/test/hello.ts","state_hash":"ca58a353e98a585e79d78345fd3bb7fe51a6376d"}
```
Notice that the old files has been completely replaced with new compiled files of exactly the same name, with content and `state_hash` updated.