### PR TITLE
fix: support relative path for whitelisting

### DIFF
--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -896,6 +896,14 @@ pub fn resolve_file_url(
   Ok(j)
 }
 
+pub fn resolve_path(path: &str) -> Result<(PathBuf, String), DenoError> {
+  let url = resolve_file_url(path.to_string(), ".".to_string())
+    .map_err(DenoError::from)?;
+  let path = url.to_file_path().unwrap();
+  let path_string = path.to_str().unwrap().to_string();
+  Ok((path, path_string))
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -2,7 +2,7 @@
 use atty;
 use crate::ansi;
 use crate::compiler::get_compiler_config;
-use crate::deno_dir;
+use crate::deno_dir::resolve_path;
 use crate::dispatch_minimal::dispatch_minimal;
 use crate::dispatch_minimal::parse_min_record;
 use crate::errors;
@@ -239,14 +239,6 @@ pub fn op_selector_std(inner_type: msg::Any) -> Option<OpCreator> {
 
     _ => None,
   }
-}
-
-fn resolve_path(path: &str) -> Result<(PathBuf, String), DenoError> {
-  let url = deno_dir::resolve_file_url(path.to_string(), ".".to_string())
-    .map_err(DenoError::from)?;
-  let path = url.to_file_path().unwrap();
-  let path_string = path.to_str().unwrap().to_string();
-  Ok((path, path_string))
 }
 
 // Returns a milliseconds and nanoseconds subsec

--- a/tools/complex_permissions_test.py
+++ b/tools/complex_permissions_test.py
@@ -92,6 +92,10 @@ class Prompt(object):
                       self.test_outside_test_and_js_dir, test_type)
             wrap_test(test_name_base + "_inside_tests_and_js_dir",
                       self.test_inside_test_and_js_dir, test_type)
+            wrap_test(test_name_base + "_relative", self.test_relative,
+                      test_type)
+            wrap_test(test_name_base + "_no_prefix", self.test_no_prefix,
+                      test_type)
         wrap_test(test_name_base + "_allow_localhost_4545",
                   self.test_allow_localhost_4545)
         wrap_test(test_name_base + "_allow_deno_land",
@@ -178,6 +182,30 @@ class Prompt(object):
         assert code == 0
         assert not PROMPT_PATTERN in stderr
         assert not PERMISSION_DENIED_PATTERN in stderr
+
+    def test_relative(self, test_type):
+        # Save and restore curdir
+        saved_curdir = os.getcwd()
+        os.chdir(root_path)
+        code, _stdout, stderr = self.run(
+            ["--no-prompt", "--allow-" + test_type + "=" + "./tests"],
+            [test_type, "tests/subdir/config.json"], b'')
+        assert code == 0
+        assert not PROMPT_PATTERN in stderr
+        assert not PERMISSION_DENIED_PATTERN in stderr
+        os.chdir(saved_curdir)
+
+    def test_no_prefix(self, test_type):
+        # Save and restore curdir
+        saved_curdir = os.getcwd()
+        os.chdir(root_path)
+        code, _stdout, stderr = self.run(
+            ["--no-prompt", "--allow-" + test_type + "=" + "tests"],
+            [test_type, "tests/subdir/config.json"], b'')
+        assert code == 0
+        assert not PROMPT_PATTERN in stderr
+        assert not PERMISSION_DENIED_PATTERN in stderr
+        os.chdir(saved_curdir)
 
 
 def complex_permissions_test(deno_exe):


### PR DESCRIPTION
Using ~~`std::fs::canonicalize`~~ `resolve_path` to expand path to full existing path, such that
later attempt to loop-pop and compare path segment would work.

Update: use `resolve_path` instead of `canonicalize`, since allowing a path that will exist in the future does not seem to have actual negative security implications.
