### PR TITLE
 [WIP] fix: whitelist symlink permission check

### DIFF
--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -900,7 +900,11 @@ pub fn resolve_path(path: &str) -> Result<(PathBuf, String), DenoError> {
   let url = resolve_file_url(path.to_string(), ".".to_string())
     .map_err(DenoError::from)?;
   let path = url.to_file_path().unwrap();
-  let path_string = path.to_str().unwrap().to_string();
+  let mut path_string = path.to_str().unwrap().to_string();
+  // Remove trailing slash.
+  if path_string.len() > 1 && path_string.ends_with('/') {
+    path_string.pop();
+  }
   Ok((path, path_string))
 }
 

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -295,11 +295,7 @@ fn resolve_paths(paths: Vec<String>) -> Vec<String> {
       eprintln!("Unrecognized path to whitelist: {}", pathstr);
       continue;
     }
-    let mut full_path = result.unwrap().1;
-    // Remove trailing slash.
-    if full_path.len() > 1 && full_path.ends_with('/') {
-      full_path.pop();
-    }
+    let full_path = result.unwrap().1;
     out.push(full_path);
   }
   out

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -136,6 +136,7 @@ enum ErrorKind: byte {
   OpNotAvaiable,
   WorkerInitFailed,
   UnixError,
+  CircularSymlink,
 }
 
 table Cwd {}

--- a/tools/complex_permissions_test.py
+++ b/tools/complex_permissions_test.py
@@ -98,9 +98,8 @@ class Prompt(object):
                       test_type)
             wrap_test(test_name_base + "_no_prefix", self.test_no_prefix,
                       test_type)
-            if os.name != "nt":
-                wrap_test(test_name_base + "_symlink", self.test_symlink,
-                          test_type)
+            wrap_test(test_name_base + "_symlink", self.test_symlink,
+                      test_type)
         wrap_test(test_name_base + "_allow_localhost_4545",
                   self.test_allow_localhost_4545)
         wrap_test(test_name_base + "_allow_deno_land",


### PR DESCRIPTION
Based on #2317.

Try read given path to ensure that if it is a symlink, the target must be on the whitelist.

We have to be careful with some of the cases to decide whether we should attempt permission checks that follow the symlinks (potential TOCTOU issues)