### PR TITLE
fix: edge case in toAsyncIterator

### DIFF
--- a/js/io.ts
+++ b/js/io.ts
@@ -168,7 +168,7 @@ export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array> {
 
       return {
         value: b.subarray(0, result.nread),
-        done: false,
+        done: false
       };
     }
   };

--- a/js/io.ts
+++ b/js/io.ts
@@ -144,6 +144,14 @@ export async function copy(dst: Writer, src: Reader): Promise<number> {
  */
 export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array> {
   const b = new Uint8Array(1024);
+  // Keep track if end-of-file has been reached, then
+  // signal that iterator is done during subsequent next()
+  // call. This is required because `r` can return a `ReadResult`
+  // with data read and EOF reached. But if iterator returns
+  // `done` then `value` is discarded.
+  //
+  // See https://github.com/denoland/deno/issues/2330 for reference.
+  let sawEof = false;
 
   return {
     [Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array> {
@@ -151,10 +159,16 @@ export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array> {
     },
 
     async next(): Promise<IteratorResult<Uint8Array>> {
+      if (sawEof) {
+        return { value: new Uint8Array(), done: true };
+      }
+
       const result = await r.read(b);
+      sawEof = result.eof;
+
       return {
         value: b.subarray(0, result.nread),
-        done: result.eof
+        done: false,
       };
     }
   };


### PR DESCRIPTION
This PR fixes issue from #2330, where `toAsyncIterator` returned no chunks, because `reader` returned data and EOF in single call.