### PR TITLE
Add error handling to dispatch_minimal::ops::read/write

### DIFF
--- a/cli/dispatch_minimal.rs
+++ b/cli/dispatch_minimal.rs
@@ -133,7 +133,12 @@ mod ops {
 
   pub fn read(rid: i32, zero_copy: Option<PinnedBuf>) -> Box<MinimalOp> {
     debug!("read rid={}", rid);
-    let zero_copy = zero_copy.unwrap();
+    let zero_copy = match zero_copy {
+      None => {
+        return Box::new(futures::future::err(errors::no_buffer_specified()))
+      }
+      Some(buf) => buf,
+    };
     match resources::lookup(rid as u32) {
       None => Box::new(futures::future::err(errors::bad_resource())),
       Some(resource) => Box::new(
@@ -146,7 +151,12 @@ mod ops {
 
   pub fn write(rid: i32, zero_copy: Option<PinnedBuf>) -> Box<MinimalOp> {
     debug!("write rid={}", rid);
-    let zero_copy = zero_copy.unwrap();
+    let zero_copy = match zero_copy {
+      None => {
+        return Box::new(futures::future::err(errors::no_buffer_specified()))
+      }
+      Some(buf) => buf,
+    };
     match resources::lookup(rid as u32) {
       None => Box::new(futures::future::err(errors::bad_resource())),
       Some(resource) => Box::new(

--- a/cli/errors.rs
+++ b/cli/errors.rs
@@ -225,6 +225,10 @@ pub fn worker_init_failed() -> DenoError {
   )
 }
 
+pub fn no_buffer_specified() -> DenoError {
+  new(ErrorKind::InvalidInput, String::from("no buffer specified"))
+}
+
 #[derive(Debug)]
 pub enum RustOrJsError {
   Rust(DenoError),

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -89,6 +89,49 @@ testPerm({ read: false }, async function readPermFailure(): Promise<void> {
   assert(caughtError);
 });
 
+testPerm({ write: true }, async function writeNullBufferFailure(): Promise<
+  void
+> {
+  const tempDir = Deno.makeTempDirSync();
+  const filename = tempDir + "hello.txt";
+  const file = await Deno.open(filename, "w");
+
+  // writing null should throw an error
+  let err;
+  try {
+    await file.write(null);
+  } catch (e) {
+    err = e;
+  }
+  // TODO: Check error kind when dispatch_minimal pipes errors properly
+  assert(!!err);
+
+  file.close();
+  await Deno.remove(tempDir, { recursive: true });
+});
+
+testPerm(
+  { write: true, read: true },
+  async function readNullBufferFailure(): Promise<void> {
+    const tempDir = Deno.makeTempDirSync();
+    const filename = tempDir + "hello.txt";
+    const file = await Deno.open(filename, "w+");
+
+    // reading file into null buffer should throw an error
+    let err;
+    try {
+      await file.read(null);
+    } catch (e) {
+      err = e;
+    }
+    // TODO: Check error kind when dispatch_minimal pipes errors properly
+    assert(!!err);
+
+    file.close();
+    await Deno.remove(tempDir, { recursive: true });
+  }
+);
+
 testPerm(
   { write: false, read: false },
   async function readWritePermFailure(): Promise<void> {


### PR DESCRIPTION
This patch fixes #2341.