### PR TITLE
fmt: use --write option of prettier/main.ts

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -448,6 +448,8 @@ pub fn flags_from_vec(
         .collect();
       argv.extend(files);
 
+      argv.push("--write".to_string());
+
       DenoSubcommand::Run
     }
     ("info", Some(info_match)) => {
@@ -726,7 +728,13 @@ mod tests {
     assert_eq!(subcommand, DenoSubcommand::Run);
     assert_eq!(
       argv,
-      svec!["deno", PRETTIER_URL, "script_1.ts", "script_2.ts"]
+      svec![
+        "deno",
+        PRETTIER_URL,
+        "script_1.ts",
+        "script_2.ts",
+        "--write"
+      ]
     );
   }
 

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -448,6 +448,7 @@ pub fn flags_from_vec(
         .collect();
       argv.extend(files);
 
+      // `deno fmt` writes to the files by default
       argv.push("--write".to_string());
 
       DenoSubcommand::Run


### PR DESCRIPTION
This PR is the first step for addressing #2090 (Please see [the comment](https://github.com/denoland/deno/issues/2090#issuecomment-492897028) for the plans). 

This maps `deno fmt` to `deno run https://deno.land/std/prettier/main.ts --write`. This doesn't make any effect at this point, but this prepares for the change in std https://github.com/denoland/deno_std/pull/332. When this change released we can merge https://github.com/denoland/deno_std/pull/332.