### PR TITLE
Feature/add permission whitelist doc

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -191,6 +191,9 @@ ability to spawn subprocesses.
   # run program with permission to read from disk and listen to network
   deno run --allow-net --allow-read https://deno.land/std/http/file_server.ts
 
+  # run program with permission to read whitelist files from disk and listen to nework
+  deno run --allow-net --allow-read=$(pwd) https://deno.land/std/http/file_server.ts 
+
   # run program with all permissions
   deno run -A https://deno.land/std/http/file_server.ts
 ",

--- a/website/manual.md
+++ b/website/manual.md
@@ -357,6 +357,37 @@ And if you ever want to upgrade to the latest published version:
 $ file_server --reload
 ```
 
+### Permissions whitelist
+
+deno also provides permissions whitelist.
+
+This is an example to restrict File system access by whitelist.
+
+```shellsession
+$ deno run --allow-read=/usr https://deno.land/std/examples/cat.ts /etc/passwd
+⚠️  Deno requests read access to "/etc/passwd". Grant? [a/y/n/d (a = allow always, y = allow once, n = deny once, d = deny always)]
+```
+
+You can grant read permission under `/etc` dir
+
+```shellsession
+$ deno run --allow-read=/etc https://deno.land/std/examples/cat.ts /etc/passwd
+```
+
+`--allow-write` works same as `--allow-read`.
+
+This is an example to restrict host.
+
+```ts
+(async () => {
+  const result = await fetch("https://deno.land/std/examples/echo_server.ts");
+})();
+```
+
+```shellsession
+$ deno run --allow-net=deno.land allow-net-whitelist-example.ts
+```
+
 ### Run subprocess
 
 [API Reference](https://deno.land/typedoc/index.html#run)


### PR DESCRIPTION
<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->

## Overview
fix #2316 

## Note
I couldn't find appropriate example code about `--allow-net` in deno_std.
So, is it ok to add example code to deno_std?