### PR TITLE
Fix permission check for net

### DIFF
--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -1629,7 +1629,7 @@ fn op_listen(
   let address = inner.address().unwrap();
   let resolved_address = match resolve_addr(address).wait() {
     Err(err) => return odd_future(DenoError::from(err)),
-    Ok(v) => v
+    Ok(v) => v,
   };
 
   if let Err(e) = state.check_net(&resolved_address.to_string()) {
@@ -1723,10 +1723,9 @@ fn op_dial(
     return odd_future(e);
   }
 
-  let op =
-    TcpStream::connect(&resolved_address)
-      .map_err(DenoError::from)
-      .and_then(move |tcp_stream| new_conn(cmd_id, tcp_stream));
+  let op = TcpStream::connect(&resolved_address)
+    .map_err(DenoError::from)
+    .and_then(move |tcp_stream| new_conn(cmd_id, tcp_stream));
   Box::new(op)
 }
 

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -1681,7 +1681,7 @@ fn new_conn(cmd_id: u32, tcp_stream: TcpStream) -> OpResult {
 }
 
 fn op_accept(
-  state: &ThreadSafeState,
+  _state: &ThreadSafeState,
   base: &msg::Base<'_>,
   data: Option<PinnedBuf>,
 ) -> Box<OpWithError> {
@@ -1695,7 +1695,7 @@ fn op_accept(
     Some(server_resource) => {
       let op = tokio_util::accept(server_resource)
         .map_err(DenoError::from)
-        .and_then(move |(tcp_stream, socket_addr)| {
+        .and_then(move |(tcp_stream, _socket_addr)| {
           new_conn(cmd_id, tcp_stream)
         });
       Box::new(op)

--- a/tools/complex_permissions_test.py
+++ b/tools/complex_permissions_test.py
@@ -81,22 +81,23 @@ class Prompt(object):
         self.run(["--allow-read"], ["read", "package.json"], b'')
 
     def test(self):
-        # for test_type in ["read", "write"]:
-        # test_name_base = "test_" + test_type
-        # wrap_test(test_name_base + "_inside_project_dir",
-        #           self.test_inside_project_dir, test_type)
-        # wrap_test(test_name_base + "_outside_tests_dir",
-        #           self.test_outside_test_dir, test_type)
-        # wrap_test(test_name_base + "_inside_tests_dir",
-        #           self.test_inside_test_dir, test_type)
-        # wrap_test(test_name_base + "_outside_tests_and_js_dir",
-        #           self.test_outside_test_and_js_dir, test_type)
-        # wrap_test(test_name_base + "_inside_tests_and_js_dir",
-        #           self.test_inside_test_and_js_dir, test_type)
-        # wrap_test(test_name_base + "_relative", self.test_relative,
-        #           test_type)
-        # wrap_test(test_name_base + "_no_prefix", self.test_no_prefix,
-        #           test_type)
+        for test_type in ["read", "write"]:
+            test_name_base = "test_" + test_type
+            wrap_test(test_name_base + "_inside_project_dir",
+                      self.test_inside_project_dir, test_type)
+            wrap_test(test_name_base + "_outside_tests_dir",
+                      self.test_outside_test_dir, test_type)
+            wrap_test(test_name_base + "_inside_tests_dir",
+                      self.test_inside_test_dir, test_type)
+            wrap_test(test_name_base + "_outside_tests_and_js_dir",
+                      self.test_outside_test_and_js_dir, test_type)
+            wrap_test(test_name_base + "_inside_tests_and_js_dir",
+                      self.test_inside_test_and_js_dir, test_type)
+            wrap_test(test_name_base + "_relative", self.test_relative,
+                      test_type)
+            wrap_test(test_name_base + "_no_prefix", self.test_no_prefix,
+                      test_type)
+
         test_name = "net_fetch"
         test_name_base = "test_" + test_name
         wrap_test(test_name_base + "_allow_localhost_4545",

--- a/tools/complex_permissions_test.ts
+++ b/tools/complex_permissions_test.ts
@@ -11,8 +11,23 @@ const test: (args: string[]) => void = {
       (file): any => writeFileSync(file, new Uint8Array(), { append: true })
     );
   },
-  net: (hosts: string[]): void => {
+  net_fetch: (hosts: string[]): void => {
     hosts.forEach((host): any => fetch(host));
+  },
+  net_listen: (hosts: string[]): void => {
+    hosts.forEach(
+      (host): any => {
+        const listener = Deno.listen("tcp", host);
+        listener.close();
+      }
+    );
+  },
+  net_dial: async (hosts: string[]): Promise<void> => {
+    for (const host of hosts) {
+      console.log("host in dial:", host);
+      const listener = await Deno.dial("tcp", host);
+      listener.close();
+    }
   }
 }[name];
 


### PR DESCRIPTION
Closes #2371

It turns out we were checking for "listen", "dial" and "accept" addresses in net permissions 😅 

I removed check in `op_accept` because we need to first issue `op_listen` and there is already check there.