### PR TITLE
Don't print new line if progress bar was not used

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -138,11 +138,15 @@ fn create_worker_and_state(
 ) -> (Worker, ThreadSafeState) {
   let progress = Progress::new();
   progress.set_callback(|done, completed, total, msg| {
-    if done {
-      eprintln!("");
-    } else {
+    if !done {
       eprint!("\r[{}/{}] {}", completed, total, msg);
       eprint!("\x1B[K"); // Clear to end of line.
+      return;
+    }
+
+    // print empty line only if progress bar was used
+    if done && total > 0 {
+      eprintln!();
     }
   });
   let state = ThreadSafeState::new(flags, argv, ops::op_selector_std, progress);


### PR DESCRIPTION
Closes #2345

@ry additionally I'd like to suggest that `ProgressBar.done` resets progress bar's state - that way when we land `import()` and `Deno.deps` it should work properly out-of-the-box. 