### PR TITLE
Use tagged version of prettier in CLI

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -398,7 +398,7 @@ pub fn parse_flags(matches: ArgMatches) -> DenoFlags {
 }
 
 /// Used for `deno fmt <files>...` subcommand
-const PRETTIER_URL: &str = "https://deno.land/std/prettier/main.ts";
+const PRETTIER_URL: &str = "https://deno.land/std@20190520/prettier/main.ts";
 
 /// These are currently handled subcommands.
 /// There is no "Help" subcommand because it's handled by `clap::App` itself.

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -398,7 +398,7 @@ pub fn parse_flags(matches: ArgMatches) -> DenoFlags {
 }
 
 /// Used for `deno fmt <files>...` subcommand
-const PRETTIER_URL: &str = "https://deno.land/std@20190520/prettier/main.ts";
+const PRETTIER_URL: &str = "https://deno.land/std@v0.5.0/prettier/main.ts";
 
 /// These are currently handled subcommands.
 /// There is no "Help" subcommand because it's handled by `clap::App` itself.


### PR DESCRIPTION
Until now we've been using untagged URL to Prettier (used in `deno fmt`). 

This is not safe because because there may be changes that are not compatible with installed version of Deno on `master` branch of deno_std.

This PR fixes this, I used latest available tag for deno_std.

I believe this is related to #2382