### PR TITLE
op_fetch_module_meta_data should be more async

### DIFF
--- a/cli/tokio_util.rs
+++ b/cli/tokio_util.rs
@@ -11,14 +11,8 @@ use tokio::net::TcpStream;
 use tokio::runtime;
 
 pub fn create_threadpool_runtime() -> tokio::runtime::Runtime {
-  // This code can be simplified once the following PR is landed and
-  // released: https://github.com/tokio-rs/tokio/pull/1055
-  use tokio_threadpool::Builder as ThreadPoolBuilder;
-  let mut threadpool_builder = ThreadPoolBuilder::new();
-  threadpool_builder.panic_handler(|err| std::panic::resume_unwind(err));
-  #[allow(deprecated)]
   runtime::Builder::new()
-    .threadpool_builder(threadpool_builder)
+    .panic_handler(|err| std::panic::resume_unwind(err))
     .build()
     .unwrap()
 }
@@ -32,15 +26,28 @@ where
   rt.block_on_all(future).unwrap();
 }
 
+/// THIS IS A HACK AND SHOULD BE AVOIDED.
+///
+/// This creates a new tokio runtime, with many new threads, to execute the
+/// given future. This is useful when we want to block the main runtime to
+/// resolve a future without worrying that we'll us up all the threads in the
+/// main runtime.
 pub fn block_on<F, R, E>(future: F) -> Result<R, E>
 where
   F: Send + 'static + Future<Item = R, Error = E>,
   R: Send + 'static,
   E: Send + 'static,
 {
-  let (tx, rx) = futures::sync::oneshot::channel();
-  tokio::spawn(future.then(move |r| tx.send(r).map_err(|_| unreachable!())));
-  rx.wait().unwrap()
+  use std::sync::mpsc::channel;
+  use std::thread;
+  let (sender, receiver) = channel();
+  // Create a new runtime to evaluate the future asynchronously.
+  thread::spawn(move || {
+    let mut rt = create_threadpool_runtime();
+    let r = rt.block_on(future);
+    sender.send(r).unwrap();
+  });
+  receiver.recv().unwrap()
 }
 
 // Set the default executor so we can use tokio::spawn(). It's difficult to


### PR DESCRIPTION
This removes a TODO in op_fetch_module_meta_data to make it async instead of sync.

Currently cli_test hangs on execute_006_url_imports. This seems to be similar to the problem encountered in https://github.com/denoland/deno/pull/2380 but it will be easier to debug with this small patch.

cc @afinch7 @bartlomieju 