### PR TITLE
build improvements for packagers of deno

### DIFF
--- a/tools/prebuilt.py
+++ b/tools/prebuilt.py
@@ -18,23 +18,22 @@ def download_prebuilt(sha1_file):
         env=google_env())
 
 
-def load_sccache():
+def get_platform_path(tool):
     if sys.platform == 'win32':
-        p = "prebuilt/win/sccache.exe"
+        return "prebuilt/win/" + tool + ".exe"
     elif sys.platform.startswith('linux'):
-        p = "prebuilt/linux64/sccache"
+        return "prebuilt/linux64/" + tool
     elif sys.platform == 'darwin':
-        p = "prebuilt/mac/sccache"
+        return "prebuilt/mac/" + tool
+
+
+def load_sccache():
+    p = get_platform_path("sccache")
     download_prebuilt(p + ".sha1")
     return os.path.join(root_path, p)
 
 
 def load_hyperfine():
-    if sys.platform == 'win32':
-        p = "prebuilt/win/hyperfine.exe"
-    elif sys.platform.startswith('linux'):
-        p = "prebuilt/linux64/hyperfine"
-    elif sys.platform == 'darwin':
-        p = "prebuilt/mac/hyperfine"
+    p = get_platform_path("hyperfine")
     download_prebuilt(p + ".sha1")
     return os.path.join(root_path, p)

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -31,6 +31,7 @@ def main():
         third_party.download_clang_format()
         third_party.download_clang()
         third_party.maybe_download_sysroot()
+        prebuilt.load_sccache()
 
     write_lastchange()
 
@@ -125,7 +126,7 @@ def generate_gn_args(mode):
     if "DENO_BUILD_ARGS" in os.environ:
         out += os.environ["DENO_BUILD_ARGS"].split()
 
-    cacher = prebuilt.load_sccache()
+    cacher = os.path.join(root_path, prebuilt.get_platform_path("sccache"))
     if not os.path.exists(cacher):
         cacher = find_executable("sccache") or find_executable("ccache")
 

--- a/tools/third_party.py
+++ b/tools/third_party.py
@@ -24,9 +24,16 @@ third_party_path = tp()
 depot_tools_path = tp("depot_tools")
 rust_crates_path = tp("rust_crates")
 python_packages_path = tp("python_packages")
-gn_path = tp(depot_tools_path, "gn")
 clang_format_path = tp(depot_tools_path, "clang-format")
-ninja_path = tp(depot_tools_path, "ninja")
+
+if "DENO_GN_PATH" in os.environ:
+    gn_path = os.environ["DENO_GN_PATH"]
+else:
+    gn_path = tp(depot_tools_path, "gn")
+if "DENO_NINJA_PATH" in os.environ:
+    ninja_path = os.environ["DENO_NINJA_PATH"]
+else:
+    ninja_path = tp(depot_tools_path, "ninja")
 
 python_site_env = None
 

--- a/website/manual.md
+++ b/website/manual.md
@@ -205,10 +205,16 @@ Extra steps for Windows users:
 
 # Update third_party modules
 git submodule update
+
+# Skip downloading binary build tools and point the build
+# to the system provided ones (for packagers of deno ...).
+./tools/setup.py --no-binary-download
+export DENO_BUILD_ARGS="clang_base_path=/usr clang_use_chrome_plugins=false"
+DENO_GN_PATH=/usr/bin/gn DENO_NINJA_PATH=/usr/bin/ninja ./tools/build.py
 ```
 
 Environment variables: `DENO_BUILD_MODE`, `DENO_BUILD_PATH`, `DENO_BUILD_ARGS`,
-`DENO_DIR`.
+`DENO_DIR`, `DENO_GN_PATH`, `DENO_NINJA_PATH`.
 
 ## API reference
 


### PR DESCRIPTION
This PR adds some improvements to the build tooling of `deno` which could be useful for packagers of deno. These ideas came up during the creating of the homebrew formula in https://github.com/Homebrew/homebrew-core/pull/35645. With is being merged the homebrew formula could make use of your build scripts (`tools/setup.py` and `tools/build.py`) and be even more simple as shown in this gist: https://gist.github.com/chrmoritz/3dfc9fa7acc720cf5e1289e51662f69c#file-deno-rb-L40-L46

Refs: #1474

The first commit https://github.com/denoland/deno/pull/2423/commits/4205d062f08b4c892bfbcdb185e48de38c7f124a to `./tools/third_party.py` simply adds the option to override the default `gn_path` and `ninja_path` by setting the newly added `DENO_GN_PATH` and `DENO_NINJA_PATH` environment variables. (This is useful when not using the prebuilt binaries of both tools and instead pointing the build system to the system provided ones.)

The second commit https://github.com/denoland/deno/pull/2423/commits/d7bb9bb85a232b454ece7cdc702134afd6c26f90 fixes `./tools/setup.py`'s `--no-binary-download` option to also disable the download of the `sccache` binary. To make it work I had to refactor the `./tools/prebuilt.py` a bit to separate the getting the platform specific path to the binary from actually downloading said binary.