### PR TITLE
bump std/prettier@0.5.0 to std/prettier@0.7.0

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -403,7 +403,7 @@ pub fn parse_flags(matches: ArgMatches) -> DenoFlags {
 }
 
 /// Used for `deno fmt <files>...` subcommand
-const PRETTIER_URL: &str = "https://deno.land/std@v0.5.0/prettier/main.ts";
+const PRETTIER_URL: &str = "https://deno.land/std@v0.7.0/prettier/main.ts";
 
 /// These are currently handled subcommands.
 /// There is no "Help" subcommand because it's handled by `clap::App` itself.


### PR DESCRIPTION
next time release `deno`

we should synchronize the version of `std/prettier`.