### PR TITLE
Update to TypeScript 3.5.1

### DIFF
--- a/js/assets.ts
+++ b/js/assets.ts
@@ -34,8 +34,12 @@ import libEs2018PromiseDts from "/third_party/node_modules/typescript/lib/lib.es
 import libEs2018RegexpDts from "/third_party/node_modules/typescript/lib/lib.es2018.regexp.d.ts!string";
 import libEs2019Dts from "/third_party/node_modules/typescript/lib/lib.es2019.d.ts!string";
 import libEs2019ArrayDts from "/third_party/node_modules/typescript/lib/lib.es2019.array.d.ts!string";
+import libEs2019ObjectDts from "/third_party/node_modules/typescript/lib/lib.es2019.object.d.ts!string";
 import libEs2019StringDts from "/third_party/node_modules/typescript/lib/lib.es2019.string.d.ts!string";
 import libEs2019SymbolDts from "/third_party/node_modules/typescript/lib/lib.es2019.symbol.d.ts!string";
+import libEs2020Dts from "/third_party/node_modules/typescript/lib/lib.es2020.d.ts!string";
+import libEs2020String from "/third_party/node_modules/typescript/lib/lib.es2020.string.d.ts!string";
+import libEs2020SymbolWellknownDts from "/third_party/node_modules/typescript/lib/lib.es2020.symbol.wellknown.d.ts!string";
 import libEs5Dts from "/third_party/node_modules/typescript/lib/lib.es5.d.ts!string";
 import libEsnextArrayDts from "/third_party/node_modules/typescript/lib/lib.esnext.array.d.ts!string";
 import libEsnextAsynciterablesDts from "/third_party/node_modules/typescript/lib/lib.esnext.asynciterable.d.ts!string";
@@ -71,8 +75,12 @@ const defaultAssets: { [key: string]: string } = {
   "lib.es2018.regexp.d.ts": libEs2018RegexpDts,
   "lib.es2019.d.ts": libEs2019Dts,
   "lib.es2019.array.d.ts": libEs2019ArrayDts,
+  "lib.es2019.object.d.ts": libEs2019ObjectDts,
   "lib.es2019.string.d.ts": libEs2019StringDts,
   "lib.es2019.symbol.d.ts": libEs2019SymbolDts,
+  "lib.es2020.d.ts": libEs2020Dts,
+  "lib.es2020.string.d.ts": libEs2020String,
+  "lib.es2020.symbol.wellknown.d.ts": libEs2020SymbolWellknownDts,
   "lib.es5.d.ts": libEs5Dts,
   "lib.esnext.d.ts": libEsnextDts,
   "lib.esnext.array.d.ts": libEsnextArrayDts,

--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -389,7 +389,6 @@ window.compilerMain = function compilerMain(): void {
       .concat(emitResult.diagnostics)
       .filter(
         ({ code }): boolean => {
-          if (code === 2649) return false;
           // TS2691: An import path cannot end with a '.ts' extension. Consider
           // importing 'bad-module' instead.
           if (code === 2691) return false;

--- a/js/console.ts
+++ b/js/console.ts
@@ -612,7 +612,8 @@ export class Console {
       stringifyValue(value)
     ];
 
-    let resultData: { [key: string]: unknown };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let resultData: any;
     const isSet = data instanceof Set;
     const isMap = data instanceof Map;
     const valuesKey = "Values";

--- a/js/unit_test_runner.ts
+++ b/js/unit_test_runner.ts
@@ -3,6 +3,12 @@
 import "./unit_tests.ts";
 import { permissionCombinations, parseUnitTestOutput } from "./test_util.ts";
 
+interface TestResult {
+  perms: string;
+  output: string;
+  result: number;
+}
+
 function permsToCliFlags(perms: Deno.Permissions): string[] {
   return Object.keys(perms)
     .map(
@@ -39,7 +45,7 @@ async function main(): Promise<void> {
     console.log("\t" + fmtPerms(perms));
   }
 
-  const testResults = new Set();
+  const testResults = new Set<TestResult>();
 
   for (const perms of permissionCombinations.values()) {
     const permsFmt = fmtPerms(perms);
@@ -84,10 +90,10 @@ async function main(): Promise<void> {
   // run should fail
   let testsFailed = false;
 
-  for (const testResult of testResults.values()) {
+  for (const testResult of testResults) {
     console.log(`Summary for ${testResult.perms}`);
     console.log(testResult.output + "\n");
-    testsFailed = testsFailed || testResult.result;
+    testsFailed = testsFailed || Boolean(testResult.result);
   }
 
   if (testsFailed) {

--- a/js/url.ts
+++ b/js/url.ts
@@ -71,12 +71,13 @@ export class URL {
     const searchParams = new urlSearchParams.URLSearchParams(this.search);
 
     for (const methodName of searchParamsMethods) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      /* eslint-disable @typescript-eslint/no-explicit-any */
       const method: (...args: any[]) => any = searchParams[methodName];
-      searchParams[methodName] = (...args: unknown[]): void => {
+      searchParams[methodName] = (...args: unknown[]): any => {
         method.apply(searchParams, args);
         this.search = searchParams.toString();
       };
+      /* eslint-enable */
     }
     this._searchParams = searchParams;
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "rollup-pluginutils": "2.4.1",
     "ts-morph": "1.3.0",
     "ts-node": "8.0.2",
-    "typescript": "3.4.1"
+    "typescript": "3.5.1"
   }
 }

--- a/tools/ts_library_builder/build_library.ts
+++ b/tools/ts_library_builder/build_library.ts
@@ -210,16 +210,6 @@ export function prepareFileForMerge({
     true
   );
 
-  // `globalThis` accesses the global scope and is defined here:
-  // https://github.com/tc39/proposal-global
-  addVariableDeclaration(
-    targetSourceFile,
-    "globalThis",
-    interfaceName,
-    true,
-    true
-  );
-
   // Add self reference to the global variable
   addInterfaceProperty(interfaceDeclaration, globalVarName, interfaceName);
 

--- a/tools/ts_library_builder/test.ts
+++ b/tools/ts_library_builder/test.ts
@@ -173,25 +173,24 @@ function buildLibraryMerge(): void {
   assert.equal(targetSourceFile.getInterfaces().length, 2);
   const variableDeclarations = targetSourceFile.getVariableDeclarations();
   assert.equal(variableDeclarations[0].getType().getText(), `FooBar`);
-  assert.equal(variableDeclarations[1].getType().getText(), `FooBar`);
-  assert.equal(variableDeclarations[2].getType().getText(), `moduleC.Bar`);
+  assert.equal(variableDeclarations[1].getType().getText(), `moduleC.Bar`);
   assert.equal(
-    variableDeclarations[3].getType().getText(),
+    variableDeclarations[2].getType().getText(),
     `typeof moduleC.qat`
   );
   assert.equal(
-    variableDeclarations[4].getType().getText(),
+    variableDeclarations[3].getType().getText(),
     `typeof moduleE.process`
   );
   assert.equal(
-    variableDeclarations[5].getType().getText(),
+    variableDeclarations[4].getType().getText(),
     `typeof moduleD.reprocess`
   );
   assert.equal(
-    variableDeclarations[6].getType().getText(),
+    variableDeclarations[5].getType().getText(),
     `typeof moduleC.Bar`
   );
-  assert.equal(variableDeclarations.length, 7);
+  assert.equal(variableDeclarations.length, 6);
   const typeAliases = targetSourceFile.getTypeAliases();
   assert.equal(typeAliases[0].getName(), "Bar");
   assert.equal(typeAliases[0].getType().getText(), "moduleC.Bar");


### PR DESCRIPTION
There were some minor changes because type analysis was more precise than previous versions and `globalThis` needed to be removed from the runtime type library, because it is provided by TypeScript itself.