### PR TITLE
Loader improvements

### DIFF
--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -2067,7 +2067,7 @@ fn op_create_worker(
     // TODO(ry) Use execute_mod_async here.
     let result = worker.execute_mod(&specifier_url, false);
     match result {
-      Ok(worker) => {
+      Ok(()) => {
         let mut workers_tl = parent_state.workers.lock().unwrap();
         workers_tl.insert(rid, worker.shared());
         let builder = &mut FlatBufferBuilder::new();
@@ -2085,10 +2085,8 @@ fn op_create_worker(
           },
         ))
       }
-      Err((errors::RustOrJsError::Js(_), _worker)) => {
-        Err(errors::worker_init_failed())
-      }
-      Err((errors::RustOrJsError::Rust(err), _worker)) => Err(err),
+      Err(errors::RustOrJsError::Js(_)) => Err(errors::worker_init_failed()),
+      Err(errors::RustOrJsError::Rust(err)) => Err(err),
     }
   }()))
 }


### PR DESCRIPTION
This patch makes it so that RecursiveLoad doesn't own the Isolate, so `Worker::execute_mod_async` does not take ownership anymore.

Previously Worker implemented Loader, but now ThreadSafeState does.

This is necessary preparation work for dynamic import (https://github.com/denoland/deno/issues/1789) and import maps (https://github.com/denoland/deno/issues/1921)