### PR TITLE
Multiple headers

### DIFF
--- a/js/headers_test.ts
+++ b/js/headers_test.ts
@@ -329,3 +329,41 @@ test(function toStringShouldBeWebCompatibility(): void {
   const headers = new Headers();
   assertEquals(headers.toString(), "[object Headers]");
 });
+
+test(function headersShouldAllowDuplicateNames(): void {
+  let headers = new Headers();
+  assertEquals(headers.has("cookie"), false);
+  assertEquals(headers.get("cookie"), null);
+
+  headers.set("Cookie", "hey=kid");
+  assertEquals(headers.get("cookie"), "hey=kid");
+  assertEquals(headers.has("cookie"), true);
+
+  headers.append("Cookie", "you=want");
+  assertEquals(headers.get("cookie"), "hey=kid, you=want");
+  assertEquals(headers.has("cookie"), true);
+
+  headers.append("Cookie", "a=job");
+  assertEquals(headers.get("cookie"), "hey=kid, you=want, a=job");
+  assertEquals(headers.has("cookie"), true);
+
+  headers.delete("Cookie");
+  assertEquals(headers.has("cookie"), false);
+  assertEquals(headers.get("cookie"), null);
+
+  headers.set("Cookie", "i=want");
+  assertEquals(headers.get("cookie"), "i=want");
+  assertEquals(headers.has("cookie"), true);
+
+  headers.set("Cookie", "those=pictures");
+  assertEquals(headers.get("cookie"), "those=pictures");
+  assertEquals(headers.has("cookie"), true);
+
+  headers.append("Cookie", "of=spiderman");
+  assertEquals(headers.get("cookie"), "those=pictures, of=spiderman");
+  assertEquals(headers.has("cookie"), true);
+
+  headers.delete("Cookie");
+  assertEquals(headers.has("cookie"), false);
+  assertEquals(headers.get("cookie"), null);
+});


### PR DESCRIPTION
First see this [issue](https://github.com/denoland/deno_std/issues/379) and the original [PR in deno_std](https://github.com/denoland/deno_std/pull/466).
This implementation of `Headers` supports duplicate keys, which are described in [section 4.2](https://tools.ietf.org/html/rfc2616#section-4.2) by RFC 2616, and preserves the order in which headers are applied. These are the notable weaknesses of the `Map` type representation currently in use.

This implementation is largely informed both by [golang](https://github.com/golang/go/blob/master/src/net/http/header.go), and the description of a [headers list](https://fetch.spec.whatwg.org/#headers-class) in the spec referenced throughout the original class.

I'd appreciate some feedback as to whether this is a worthwhile direction for the `Headers` to take, and the significance of its relationship to `domIterableMixin`. I'm also curious where I can go for information about local development; I'm able to run `./tools/test.py` but it's evident that I'm not running them against my changes. 