### PR TITLE
Deno.core.evalContext() crashes & Deno.core.print() crashes fix

### DIFF
--- a/core/libdeno/binding.cc
+++ b/core/libdeno/binding.cc
@@ -375,7 +375,12 @@ void EvalContext(const v8::FunctionCallbackInfo<v8::Value>& args) {
   auto context = d->context_.Get(isolate);
   v8::Context::Scope context_scope(context);
 
-  CHECK(args[0]->IsString());
+  if (!(args[0]->IsString()))
+  {
+    ThrowInvalidArgument(isolate);
+    return;
+  }
+
   auto source = args[0].As<v8::String>();
 
   auto output = v8::Array::New(isolate, 2);

--- a/core/libdeno/binding.cc
+++ b/core/libdeno/binding.cc
@@ -98,7 +98,7 @@ void PromiseRejectCallback(v8::PromiseRejectMessage promise_reject_message) {
 void Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
   auto* isolate = args.GetIsolate();
   int argsLen = args.Length();
-  if(argsLen < 1 || argsLen > 2){
+  if (argsLen < 1 || argsLen > 2) {
     ThrowInvalidArgument(isolate);
   }
   DenoIsolate* d = DenoIsolate::FromIsolate(isolate);
@@ -377,8 +377,7 @@ void EvalContext(const v8::FunctionCallbackInfo<v8::Value>& args) {
   auto context = d->context_.Get(isolate);
   v8::Context::Scope context_scope(context);
 
-  if (!(args[0]->IsString()))
-  {
+  if (!(args[0]->IsString())) {
     ThrowInvalidArgument(isolate);
     return;
   }

--- a/core/libdeno/binding.cc
+++ b/core/libdeno/binding.cc
@@ -96,9 +96,11 @@ void PromiseRejectCallback(v8::PromiseRejectMessage promise_reject_message) {
 }
 
 void Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK_GE(args.Length(), 1);
-  CHECK_LE(args.Length(), 3);
   auto* isolate = args.GetIsolate();
+  int argsLen = args.Length();
+  if(argsLen < 1 || argsLen > 2){
+    ThrowInvalidArgument(isolate);
+  }
   DenoIsolate* d = DenoIsolate::FromIsolate(isolate);
   auto context = d->context_.Get(d->isolate_);
   v8::HandleScope handle_scope(isolate);

--- a/core/libdeno/exceptions.cc
+++ b/core/libdeno/exceptions.cc
@@ -214,4 +214,9 @@ void HandleExceptionMessage(v8::Local<v8::Context> context,
   CHECK_NOT_NULL(d);
   d->last_exception_ = json_str;
 }
+
+void ThrowInvalidArgument(v8::Isolate *isolate){
+      isolate->ThrowException(v8::Exception::TypeError(v8_str("Invalid Argument")));
+}
+
 }  // namespace deno

--- a/core/libdeno/exceptions.cc
+++ b/core/libdeno/exceptions.cc
@@ -215,8 +215,8 @@ void HandleExceptionMessage(v8::Local<v8::Context> context,
   d->last_exception_ = json_str;
 }
 
-void ThrowInvalidArgument(v8::Isolate *isolate){
-      isolate->ThrowException(v8::Exception::TypeError(v8_str("Invalid Argument")));
+void ThrowInvalidArgument(v8::Isolate* isolate) {
+  isolate->ThrowException(v8::Exception::TypeError(v8_str("Invalid Argument")));
 }
 
 }  // namespace deno

--- a/core/libdeno/exceptions.h
+++ b/core/libdeno/exceptions.h
@@ -18,6 +18,8 @@ void HandleException(v8::Local<v8::Context> context,
 
 void HandleExceptionMessage(v8::Local<v8::Context> context,
                             v8::Local<v8::Message> message);
+
+void ThrowInvalidArgument(v8::Isolate* isolate);
 }  // namespace deno
 
 #endif  // EXCEPTIONS_H_

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -235,6 +235,13 @@ TEST(LibDenoTest, LibDenoEvalContextError) {
   deno_delete(d);
 }
 
+TEST(LibDenoTest, LibDenoEvalContextInvalidArgument){
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
+  deno_execute(d, nullptr, "a.js", "LibDenoEvalContextInvalidArgument();");
+  EXPECT_EQ(nullptr, deno_last_exception(d));
+  deno_delete(d);
+}
+
 TEST(LibDenoTest, SharedAtomics) {
   int32_t s[] = {0, 1, 2};
   deno_buf shared = {reinterpret_cast<uint8_t*>(s), sizeof s};

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -236,14 +236,14 @@ TEST(LibDenoTest, LibDenoEvalContextError) {
 }
 
 TEST(LibDenoTest, LibDenoEvalContextInvalidArgument) {
-  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr, nullptr});
   deno_execute(d, nullptr, "a.js", "LibDenoEvalContextInvalidArgument();");
   EXPECT_EQ(nullptr, deno_last_exception(d));
   deno_delete(d);
 }
 
 TEST(LibDenoTest, LibDenoPrintInvalidArgument) {
-  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr, nullptr});
   deno_execute(d, nullptr, "a.js", "LibDenoPrintInvalidArgument();");
   EXPECT_EQ(nullptr, deno_last_exception(d));
   deno_delete(d);

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -235,14 +235,14 @@ TEST(LibDenoTest, LibDenoEvalContextError) {
   deno_delete(d);
 }
 
-TEST(LibDenoTest, LibDenoEvalContextInvalidArgument){
+TEST(LibDenoTest, LibDenoEvalContextInvalidArgument) {
   Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
   deno_execute(d, nullptr, "a.js", "LibDenoEvalContextInvalidArgument();");
   EXPECT_EQ(nullptr, deno_last_exception(d));
   deno_delete(d);
 }
 
-TEST(LibDenoTest, LibDenoPrintInvalidArgument){
+TEST(LibDenoTest, LibDenoPrintInvalidArgument) {
   Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
   deno_execute(d, nullptr, "a.js", "LibDenoPrintInvalidArgument();");
   EXPECT_EQ(nullptr, deno_last_exception(d));

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -242,6 +242,13 @@ TEST(LibDenoTest, LibDenoEvalContextInvalidArgument){
   deno_delete(d);
 }
 
+TEST(LibDenoTest, LibDenoPrintInvalidArgument){
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
+  deno_execute(d, nullptr, "a.js", "LibDenoPrintInvalidArgument();");
+  EXPECT_EQ(nullptr, deno_last_exception(d));
+  deno_delete(d);
+}
+
 TEST(LibDenoTest, SharedAtomics) {
   int32_t s[] = {0, 1, 2};
   deno_buf shared = {reinterpret_cast<uint8_t*>(s), sizeof s};

--- a/core/libdeno/libdeno_test.js
+++ b/core/libdeno/libdeno_test.js
@@ -203,7 +203,7 @@ global.LibDenoEvalContextInvalidArgument = () => {
     assert(e instanceof TypeError);
     assert(e.message === "Invalid Argument");
   }
-}
+};
 
 global.LibDenoPrintInvalidArgument = () => {
   try {
@@ -218,4 +218,4 @@ global.LibDenoPrintInvalidArgument = () => {
     assert(e instanceof TypeError);
     assert(e.message === "Invalid Argument");
   }
-}
+};

--- a/core/libdeno/libdeno_test.js
+++ b/core/libdeno/libdeno_test.js
@@ -195,3 +195,12 @@ global.LibDenoEvalContextError = () => {
   assert(!errInfo5.isCompileError); // is NOT a compilation error! (just eval)
   assert(errInfo5.thrown.message === "Unexpected end of input");
 };
+
+global.LibDenoEvalContextInvalidArgument = () => {
+  try{
+    Deno.core.evalContext();
+  }catch(e){
+    assert(e instanceof TypeError);
+    assert(e.message === "Invalid Argument");
+  }
+}

--- a/core/libdeno/libdeno_test.js
+++ b/core/libdeno/libdeno_test.js
@@ -197,9 +197,24 @@ global.LibDenoEvalContextError = () => {
 };
 
 global.LibDenoEvalContextInvalidArgument = () => {
-  try{
+  try {
     Deno.core.evalContext();
-  }catch(e){
+  } catch (e) {
+    assert(e instanceof TypeError);
+    assert(e.message === "Invalid Argument");
+  }
+}
+
+global.LibDenoPrintInvalidArgument = () => {
+  try {
+    Deno.core.print();
+  } catch (e) {
+    assert(e instanceof TypeError);
+    assert(e.message === "Invalid Argument");
+  }
+  try {
+    Deno.core.print(2, 3, 4);
+  } catch (e) {
     assert(e instanceof TypeError);
     assert(e.message === "Invalid Argument");
   }


### PR DESCRIPTION
Regarding [#2457]("https://github.com/denoland/deno/issues/2457") and [#2458]("https://github.com/denoland/deno/issues/2458")

Now it's throwing a catchable error.

```
> Deno.core.evalContext();

Uncaught TypeError: Invalid Argument
    at <unknown>:1:11
    at evaluate (js/repl.ts:87:34)
    at replLoop (js/repl.ts:145:13)

> Deno.core.print();

Uncaught TypeError: Invalid Argument
    at <unknown>:1:11
    at evaluate (js/repl.ts:87:34)
    at replLoop (js/repl.ts:145:13)

```