### PR TITLE
chore: make tests quieter

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -196,7 +196,7 @@ build_script:
 test_script:
   - python tools\lint.py
   - python tools\test_format.py
-  - ps: Exec { & python tools\test.py -v --build-dir $env:DENO_BUILD_PATH }
+  - ps: Exec { & python tools\test.py --build-dir $env:DENO_BUILD_PATH }
 
 after_test:
   # Delete the the rollup cache, which is unreliable, so that it doesn't get

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ script:
 - ./tools/lint.py
 - ./tools/test_format.py
 - ./tools/build.py -C target/release
-- DENO_BUILD_MODE=release ./tools/test.py -v
+- DENO_BUILD_MODE=release ./tools/test.py
 
 jobs:
   fast_finish: true

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -11,7 +11,7 @@ import sys
 import json
 import time
 import shutil
-from util import run, run_output, root_path, build_path, executable_suffix
+from util import root_path, run, run_output, build_path, executable_suffix
 import tempfile
 import http_server
 import throughput_benchmark
@@ -212,7 +212,8 @@ def main(argv):
         print "Usage: tools/benchmark.py [build_dir]"
         sys.exit(1)
 
-    sha1 = run_output(["git", "rev-parse", "HEAD"]).strip()
+    sha1 = run_output(["git", "rev-parse", "HEAD"],
+                      exit_on_fail=True).out.strip()
     http_server.spawn()
 
     deno_exe = os.path.join(build_dir, "deno")

--- a/tools/deno_dir_test.py
+++ b/tools/deno_dir_test.py
@@ -5,7 +5,7 @@
 import os
 
 from test_util import DenoTestCase, run_tests
-from util import mkdtemp, rmtree, run
+from util import mkdtemp, rmtree, run_output
 
 
 class TestDenoDir(DenoTestCase):
@@ -38,7 +38,8 @@ class TestDenoDir(DenoTestCase):
     def run_deno(self, deno_dir=None):
         cmd = [self.deno_exe, "run", "tests/002_hello.ts"]
         deno_dir_env = {"DENO_DIR": deno_dir} if deno_dir is not None else None
-        run(cmd, quiet=True, env=deno_dir_env)
+        res = run_output(cmd, quiet=True, env=deno_dir_env)
+        self.assertEqual(res.code, 0)
 
 
 if __name__ == '__main__':

--- a/tools/fetch_test.py
+++ b/tools/fetch_test.py
@@ -12,11 +12,10 @@ from util import mkdtemp, tests_path, run_output
 class TestFetch(DenoTestCase):
     def test_fetch(self):
         deno_dir = mkdtemp()
-        quiet = sys.argv.count('-v') < 2 and not '-vv' in sys.argv
         try:
             t = os.path.join(tests_path, "006_url_imports.ts")
             result = run_output([self.deno_exe, "fetch", t],
-                                quiet=quiet,
+                                quiet=True,
                                 merge_env={"DENO_DIR": deno_dir})
             self.assertEqual(result.out, "")
             self.assertEqual(result.code, 0)

--- a/tools/fetch_test.py
+++ b/tools/fetch_test.py
@@ -2,20 +2,24 @@
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import os
 import shutil
+import sys
 
 import http_server
 from test_util import DenoTestCase, run_tests
 from util import mkdtemp, tests_path, run_output
 
 
-class FetchTest(DenoTestCase):
+class TestFetch(DenoTestCase):
     def test_fetch(self):
         deno_dir = mkdtemp()
+        quiet = sys.argv.count('-v') < 2 and not '-vv' in sys.argv
         try:
             t = os.path.join(tests_path, "006_url_imports.ts")
-            output = run_output([self.deno_exe, "fetch", t],
+            result = run_output([self.deno_exe, "fetch", t],
+                                quiet=quiet,
                                 merge_env={"DENO_DIR": deno_dir})
-            assert output == ""
+            self.assertEqual(result.out, "")
+            self.assertEqual(result.code, 0)
             # Check that we actually did the prefetch.
             os.path.exists(
                 os.path.join(

--- a/tools/fmt_test.py
+++ b/tools/fmt_test.py
@@ -4,10 +4,10 @@ import os
 import shutil
 
 from test_util import DenoTestCase, run_tests
-from util import mkdtemp, root_path, tests_path, run
+from util import mkdtemp, root_path, tests_path, run_output
 
 
-class FmtTest(DenoTestCase):
+class TestFmt(DenoTestCase):
     def test_fmt(self):
         d = mkdtemp()
         try:
@@ -26,12 +26,15 @@ class FmtTest(DenoTestCase):
             # TODO(kt3k) Below can be run([deno_exe, "fmt", dst], ...)
             # once the following issue is addressed:
             # https://github.com/denoland/deno_std/issues/330
-            run([
+            result = run_output([
                 os.path.join(root_path, self.deno_exe), "fmt",
                 "badly_formatted.js"
             ],
-                cwd=d,
-                merge_env={"DENO_DIR": deno_dir})
+                                cwd=d,
+                                merge_env={"DENO_DIR": deno_dir},
+                                exit_on_fail=True,
+                                quiet=True)
+            self.assertEqual(result.code, 0)
             with open(fixed_filename) as f:
                 expected = f.read()
             with open(dst) as f:

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -17,7 +17,7 @@ REDIRECT_PORT = 4546
 ANOTHER_REDIRECT_PORT = 4547
 DOUBLE_REDIRECTS_PORT = 4548
 
-QUIET = '-vv' not in sys.argv and sys.argv.count('-v') < 2
+QUIET = '-v' not in sys.argv and '--verbose' not in sys.argv
 
 
 class QuietSimpleHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -17,8 +17,17 @@ REDIRECT_PORT = 4546
 ANOTHER_REDIRECT_PORT = 4547
 DOUBLE_REDIRECTS_PORT = 4548
 
+QUIET = '-vv' not in sys.argv and sys.argv.count('-v') < 2
 
-class ContentTypeHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+
+class QuietSimpleHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    def log_request(self, code='-', size='-'):
+        if not QUIET:
+            SimpleHTTPServer.SimpleHTTPRequestHandler.log_request(
+                self, code, size)
+
+
+class ContentTypeHandler(QuietSimpleHTTPRequestHandler):
     def do_GET(self):
         if "multipart_form_data.txt" in self.path:
             self.protocol_version = 'HTTP/1.1'
@@ -102,7 +111,8 @@ def server():
     })
     SocketServer.TCPServer.allow_reuse_address = True
     s = SocketServer.TCPServer(("", PORT), Handler)
-    print "Deno test server http://localhost:%d/" % PORT
+    if not QUIET:
+        print "Deno test server http://localhost:%d/" % PORT
     return RunningServer(s, start(s))
 
 
@@ -110,7 +120,7 @@ def base_redirect_server(host_port, target_port, extra_path_segment=""):
     os.chdir(root_path)
     target_host = "http://localhost:%d" % target_port
 
-    class RedirectHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    class RedirectHandler(QuietSimpleHTTPRequestHandler):
         def do_GET(self):
             self.send_response(301)
             self.send_header('Location',
@@ -120,8 +130,9 @@ def base_redirect_server(host_port, target_port, extra_path_segment=""):
     Handler = RedirectHandler
     SocketServer.TCPServer.allow_reuse_address = True
     s = SocketServer.TCPServer(("", host_port), Handler)
-    print "redirect server http://localhost:%d/ -> http://localhost:%d/" % (
-        host_port, target_port)
+    if not QUIET:
+        print "redirect server http://localhost:%d/ -> http://localhost:%d/" % (
+            host_port, target_port)
     return RunningServer(s, start(s))
 
 
@@ -153,7 +164,8 @@ def start(s):
 def spawn():
     servers = (server(), redirect_server(), another_redirect_server(),
                double_redirects_server())
-    sleep(1)  # TODO I'm too lazy to figure out how to do this properly.
+    while any(not s.thread.is_alive() for s in servers):
+        sleep(0.01)
     try:
         yield
     finally:

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import third_party
-from util import build_mode, build_path, enable_ansi_colors, root_path, run
-from util import shell_quote, run_output
+from util import (build_mode, build_path, enable_ansi_colors, root_path, run,
+                  shell_quote)
 import os
 import re
 import sys

--- a/tools/test.py
+++ b/tools/test.py
@@ -6,8 +6,8 @@ import os
 
 from benchmark_test import TestBenchmark
 from deno_dir_test import TestDenoDir
-from fetch_test import FetchTest
-from fmt_test import FmtTest
+from fetch_test import TestFetch
+from fmt_test import TestFmt
 from integration_tests import TestIntegrations
 from repl_test import TestRepl
 from setup_test import TestSetup
@@ -21,7 +21,7 @@ from complex_permissions_test import complex_permissions_tests
 
 import http_server
 from util import (enable_ansi_colors, build_path, RESET, FG_RED, FG_GREEN,
-                  executable_suffix, run, run_output, rmtree, tests_path)
+                  executable_suffix, rmtree, tests_path)
 from test_util import parse_test_args, run_tests
 
 
@@ -40,8 +40,8 @@ def main():
         TestUtil,
         TestTarget,
         JsUnitTests,
-        FetchTest,
-        FmtTest,
+        TestFetch,
+        TestFmt,
         TestIntegrations,
         TestRepl,
         TestDenoDir,

--- a/tools/test_format.py
+++ b/tools/test_format.py
@@ -9,11 +9,11 @@ import subprocess
 
 def main():
     util.run([sys.executable, "tools/format.py"])
-    output = util.run_output(
+    result = util.run_output(
         ["git", "status", "-uno", "--porcelain", "--ignore-submodules"])
-    if len(output) > 0:
+    if len(result.out) > 0:
         print "Run tools/format.py "
-        print output
+        print result.out
         sys.exit(1)
 
 

--- a/tools/test_format.py
+++ b/tools/test_format.py
@@ -10,8 +10,9 @@ import subprocess
 def main():
     util.run([sys.executable, "tools/format.py"])
     result = util.run_output(
-        ["git", "status", "-uno", "--porcelain", "--ignore-submodules"])
-    if len(result.out) > 0:
+        ["git", "status", "-uno", "--porcelain", "--ignore-submodules"],
+        exit_on_fail=True)
+    if result.out:
         print "Run tools/format.py "
         print result.out
         sys.exit(1)

--- a/tools/test_util.py
+++ b/tools/test_util.py
@@ -25,13 +25,11 @@ class DenoTestCase(unittest.TestCase):
 class ColorTextTestResult(unittest.TextTestResult):
     @contextlib.contextmanager
     def color(self, code):
-        if self.showAll:
-            self.stream.write(code)
+        self.stream.write(code)
         try:
             yield
         finally:
-            if self.showAll:
-                self.stream.write(RESET)
+            self.stream.write(RESET)
 
     def getDescription(self, test):
         name = str(test)
@@ -135,7 +133,7 @@ def run_tests(test_cases=None):
         suite = unittest.TestSuite(filtered_tests)
 
     runner = ColorTextTestRunner(
-        verbosity=args.verbose + 1, failfast=args.failfast)
+        verbosity=args.verbose + 2, failfast=args.failfast)
 
     result = runner.run(suite)
     if not result.wasSuccessful():

--- a/tools/test_util.py
+++ b/tools/test_util.py
@@ -3,12 +3,13 @@
 # Runs the full test suite.
 # Usage: ./tools/test.py out/Debug
 import argparse
+import contextlib
 import os
 import sys
 import unittest
 
 from util import (enable_ansi_colors, build_path, RESET, FG_RED, FG_GREEN,
-                  executable_suffix, run, run_output, rmtree, tests_path)
+                  executable_suffix, rmtree, tests_path)
 
 
 class DenoTestCase(unittest.TestCase):
@@ -22,6 +23,16 @@ class DenoTestCase(unittest.TestCase):
 
 # overload the test result class
 class ColorTextTestResult(unittest.TextTestResult):
+    @contextlib.contextmanager
+    def color(self, code):
+        if self.showAll:
+            self.stream.write(code)
+        try:
+            yield
+        finally:
+            if self.showAll:
+                self.stream.write(RESET)
+
     def getDescription(self, test):
         name = str(test)
         if name.startswith("test_"):
@@ -29,25 +40,16 @@ class ColorTextTestResult(unittest.TextTestResult):
         return name
 
     def addSuccess(self, test):
-        if self.showAll:
-            self.stream.write(FG_GREEN)
-        super(ColorTextTestResult, self).addSuccess(test)
-        if self.showAll:
-            self.stream.write(RESET)
+        with self.color(FG_GREEN):
+            super(ColorTextTestResult, self).addSuccess(test)
 
     def addError(self, test, err):
-        if self.showAll:
-            self.stream.write(FG_RED)
-        super(ColorTextTestResult, self).addError(test, err)
-        if self.showAll:
-            self.stream.write(RESET)
+        with self.color(FG_RED):
+            super(ColorTextTestResult, self).addError(test, err)
 
     def addFailure(self, test, err):
-        if self.showAll:
-            self.stream.write(FG_RED)
-        super(ColorTextTestResult, self).addFailure(test, err)
-        if self.showAll:
-            self.stream.write(RESET)
+        with self.color(FG_RED):
+            super(ColorTextTestResult, self).addFailure(test, err)
 
 
 class ColorTextTestRunner(unittest.TextTestRunner):

--- a/tools/write_gn_args.py
+++ b/tools/write_gn_args.py
@@ -11,7 +11,8 @@ args_list = run_output([
     build_path(), "--list", "--short", "--overrides-only"
 ],
                        quiet=True,
-                       env=third_party.google_env())
+                       env=third_party.google_env(),
+                       exit_on_fail=True).out
 
 with open(out_filename, "w") as f:
     f.write(args_list)


### PR DESCRIPTION
Don't mix http request logging in with the tests output.
Don't print that the file servers are starting unless -vv flag is passed.

Capture the output of run with run_output which returns stdout, stderr and exit_code.
Test against exit_code rather than relying on sys.exit.

cc @bartlomieju @ry 

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
