### PR TITLE
http benchmarks with unique ports

### DIFF
--- a/tools/deno_http_proxy.ts
+++ b/tools/deno_http_proxy.ts
@@ -9,7 +9,7 @@ const originAddr = Deno.args[2] || "127.0.0.1:4501";
 const server = serve(addr);
 
 async function main(): Promise<void> {
-  console.log(`http://${addr}/`);
+  console.log(`Proxy listening on http://${addr}/`);
   for await (const req of server) {
     proxyRequest(req);
   }

--- a/tools/deno_tcp_proxy.ts
+++ b/tools/deno_tcp_proxy.ts
@@ -19,7 +19,7 @@ async function handle(conn: Deno.Conn): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  console.log("Listening on", addr);
+  console.log(`Proxy listening on http://${addr}/`);
   while (true) {
     const conn = await listener.accept();
     handle(conn);

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -151,7 +151,7 @@ def run(server_cmd, merge_env=None, origin_cmd=None):
 
     server = subprocess.Popen(server_cmd, env=env)
 
-    time.sleep(15)  # wait for server to wake up. TODO racy.
+    time.sleep(5)  # wait for server to wake up. TODO racy.
 
     try:
         cmd = "third_party/wrk/%s/wrk -d %s http://%s/" % (util.platform(),

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -142,7 +142,7 @@ def run(server_cmd, merge_env=None, origin_cmd=None):
 
     # Wait for port 4544 to become available.
     # TODO Need to use SO_REUSEPORT with tokio::net::TcpListener.
-    time.sleep(5)
+    time.sleep(10)
 
     origin = None
     if origin_cmd is not None:
@@ -162,6 +162,7 @@ def run(server_cmd, merge_env=None, origin_cmd=None):
         print output
         return stats
     finally:
+        print "Stopping server"
         server.kill()
         if origin is not None:
             print "Stopping origin server"

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -12,25 +12,36 @@ import subprocess
 #   "deno_tcp" was once called "deno"
 #   "deno_http" was once called "deno_net_http"
 
-ADDR = "127.0.0.1:4544"
-ORIGIN_ADDR = "127.0.0.1:4545"
 DURATION = "10s"
+
+LAST_PORT = 4544
+
+
+def get_addr(port=None):
+    global LAST_PORT
+    if port is None:
+        port = LAST_PORT
+        LAST_PORT = LAST_PORT + 1
+    return ("127.0.0.1:%d" % (port))
 
 
 def deno_tcp(deno_exe):
-    deno_cmd = [deno_exe, "run", "--allow-net", "tools/deno_tcp.ts", ADDR]
+    addr = get_addr()
+    deno_cmd = [deno_exe, "run", "--allow-net", "tools/deno_tcp.ts", addr]
     print "http_benchmark testing DENO."
-    return run(deno_cmd)
+    return run(deno_cmd, addr)
 
 
 def deno_http(deno_exe):
+    addr = get_addr()
     deno_cmd = [
         deno_exe, "run", "--allow-net",
-        "js/deps/https/deno.land/std/http/http_bench.ts", ADDR
+        "js/deps/https/deno.land/std/http/http_bench.ts", addr
     ]
     print "http_benchmark testing DENO using net/http."
     return run(
         deno_cmd,
+        addr,
         merge_env={
             # Load from //js/deps/https/deno.land/net/ submodule.
             "DENO_DIR": os.path.join(util.root_path, "js")
@@ -38,75 +49,94 @@ def deno_http(deno_exe):
 
 
 def deno_tcp_proxy(deno_exe, hyper_hello_exe):
+    addr = get_addr()
+    origin_addr = get_addr()
     deno_cmd = [
-        deno_exe, "run", "--allow-net", "tools/deno_tcp_proxy.ts", ADDR,
-        ORIGIN_ADDR
+        deno_exe, "run", "--allow-net", "tools/deno_tcp_proxy.ts", addr,
+        origin_addr
     ]
     print "http_proxy_benchmark testing DENO using net/tcp."
     return run(
         deno_cmd,
+        addr,
         merge_env={"DENO_DIR": os.path.join(util.root_path, "js")},
-        origin_cmd=http_proxy_origin(hyper_hello_exe))
+        origin_cmd=http_proxy_origin(hyper_hello_exe, origin_addr))
 
 
 def deno_http_proxy(deno_exe, hyper_hello_exe):
+    addr = get_addr()
+    origin_addr = get_addr()
     deno_cmd = [
-        deno_exe, "run", "--allow-net", "tools/deno_http_proxy.ts", ADDR,
-        ORIGIN_ADDR
+        deno_exe, "run", "--allow-net", "tools/deno_http_proxy.ts", addr,
+        origin_addr
     ]
     print "http_proxy_benchmark testing DENO using net/http."
     return run(
         deno_cmd,
+        addr,
         merge_env={"DENO_DIR": os.path.join(util.root_path, "js")},
-        origin_cmd=http_proxy_origin(hyper_hello_exe))
+        origin_cmd=http_proxy_origin(hyper_hello_exe, origin_addr))
 
 
 def deno_core_single(exe):
     print "http_benchmark testing deno_core_single"
-    return run([exe, "--single-thread"])
+    return run([exe, "--single-thread"], "127.0.0.1:4544")
 
 
 def deno_core_multi(exe):
     print "http_benchmark testing deno_core_multi"
-    return run([exe, "--multi-thread"])
+    return run([exe, "--multi-thread"], "127.0.0.1:4544")
 
 
 def node_http():
-    node_cmd = ["node", "tools/node_http.js", ADDR.split(":")[1]]
+    addr = get_addr()
+    node_cmd = ["node", "tools/node_http.js", addr.split(":")[1]]
     print "http_benchmark testing NODE."
-    return run(node_cmd)
+    return run(node_cmd, addr)
 
 
 def node_http_proxy(hyper_hello_exe):
-    node_cmd = ["node", "tools/node_http_proxy.js", ADDR.split(":")[1]]
+    addr = get_addr()
+    origin_addr = get_addr()
+    node_cmd = [
+        "node", "tools/node_http_proxy.js",
+        addr.split(":")[1],
+        origin_addr.split(":")[1]
+    ]
     print "http_proxy_benchmark testing NODE."
-    return run(node_cmd, None, http_proxy_origin(hyper_hello_exe))
+    return run(node_cmd, addr, None,
+               http_proxy_origin(hyper_hello_exe, origin_addr))
 
 
 def node_tcp_proxy(hyper_hello_exe):
+    addr = get_addr()
+    origin_addr = get_addr()
     node_cmd = [
         "node", "tools/node_tcp_proxy.js",
-        ADDR.split(":")[1],
-        ORIGIN_ADDR.split(":")[1]
+        addr.split(":")[1],
+        origin_addr.split(":")[1]
     ]
     print "http_proxy_benchmark testing NODE tcp."
-    return run(node_cmd, None, http_proxy_origin(hyper_hello_exe))
+    return run(node_cmd, addr, None,
+               http_proxy_origin(hyper_hello_exe, origin_addr))
 
 
 def node_tcp():
-    node_cmd = ["node", "tools/node_tcp.js", ADDR.split(":")[1]]
+    addr = get_addr()
+    node_cmd = ["node", "tools/node_tcp.js", addr.split(":")[1]]
     print "http_benchmark testing node_tcp.js"
-    return run(node_cmd)
+    return run(node_cmd, addr)
 
 
-def http_proxy_origin(hyper_hello_exe):
-    return [hyper_hello_exe, ORIGIN_ADDR.split(":")[1]]
+def http_proxy_origin(hyper_hello_exe, addr):
+    return [hyper_hello_exe, addr.split(":")[1]]
 
 
 def hyper_http(hyper_hello_exe):
-    hyper_cmd = [hyper_hello_exe, ADDR.split(":")[1]]
+    addr = get_addr()
+    hyper_cmd = [hyper_hello_exe, addr.split(":")[1]]
     print "http_benchmark testing RUST hyper."
-    return run(hyper_cmd)
+    return run(hyper_cmd, addr)
 
 
 def http_benchmark(build_dir):
@@ -131,7 +161,8 @@ def http_benchmark(build_dir):
     }
 
 
-def run(server_cmd, merge_env=None, origin_cmd=None):
+def run(server_cmd, addr, merge_env=None, origin_cmd=None):
+
     # Run deno echo server in the background.
     if merge_env is None:
         env = None
@@ -142,30 +173,27 @@ def run(server_cmd, merge_env=None, origin_cmd=None):
 
     # Wait for port 4544 to become available.
     # TODO Need to use SO_REUSEPORT with tokio::net::TcpListener.
-    time.sleep(10)
+    time.sleep(5)
 
     origin = None
     if origin_cmd is not None:
-        print "Starting origin server"
         origin = subprocess.Popen(origin_cmd, env=env)
 
     server = subprocess.Popen(server_cmd, env=env)
 
-    time.sleep(5)  # wait for server to wake up. TODO racy.
+    time.sleep(10)  # wait for server to wake up. TODO racy.
 
     try:
         cmd = "third_party/wrk/%s/wrk -d %s http://%s/" % (util.platform(),
-                                                           DURATION, ADDR)
+                                                           DURATION, addr)
         print cmd
         output = subprocess.check_output(cmd, shell=True)
         stats = util.parse_wrk_output(output)
         print output
         return stats
     finally:
-        print "Stopping server"
         server.kill()
         if origin is not None:
-            print "Stopping origin server"
             origin.kill()
 
 


### PR DESCRIPTION
@ry this makes the tcp proxy benchmarks work (#2464), but it's a little bit heavy handed. I've been looking through build logs and it seems like there have been sporadic errors caused by ports not being free —even with the 5s sleep.