### PR TITLE
Reduce dependency on tokio_util::block_on and clean up

### DIFF
--- a/cli/compiler.rs
+++ b/cli/compiler.rs
@@ -142,11 +142,18 @@ pub fn compile_async(
         }
       }
 
-      let r = state
-        .dir
-        .fetch_module_meta_data(&module_name, ".", true, true);
-      let module_meta_data_after_compile = r.unwrap();
-
+      Ok(())
+    }).and_then(move |_| {
+      state.dir.fetch_module_meta_data_async(
+        &module_name,
+        ".",
+        true,
+        true,
+      ).map_err(|e| {
+        // TODO(95th) Instead of panicking, We could translate this error to Diagnostic.
+        panic!("{}", e)
+      })
+    }).and_then(move |module_meta_data_after_compile| {
       // Explicit drop to keep reference alive until future completes.
       drop(compiling_job);
 

--- a/cli/js_errors.rs
+++ b/cli/js_errors.rs
@@ -137,10 +137,10 @@ impl SourceMap {
   }
 }
 
-fn frame_apply_source_map(
+fn frame_apply_source_map<G: SourceMapGetter>(
   frame: &StackFrame,
   mappings_map: &mut CachedMaps,
-  getter: &dyn SourceMapGetter,
+  getter: &G,
 ) -> StackFrame {
   let maybe_sm = get_mappings(frame.script_name.as_ref(), mappings_map, getter);
   let frame_pos = (
@@ -181,9 +181,9 @@ fn frame_apply_source_map(
   }
 }
 
-pub fn apply_source_map(
+pub fn apply_source_map<G: SourceMapGetter>(
   js_error: &JSError,
-  getter: &dyn SourceMapGetter,
+  getter: &G,
 ) -> JSError {
   let mut mappings_map: CachedMaps = HashMap::new();
   let mut frames = Vec::<StackFrame>::new();
@@ -232,9 +232,9 @@ fn builtin_source_map(script_name: &str) -> Option<Vec<u8>> {
   }
 }
 
-fn parse_map_string(
+fn parse_map_string<G: SourceMapGetter>(
   script_name: &str,
-  getter: &dyn SourceMapGetter,
+  getter: &G,
 ) -> Option<SourceMap> {
   builtin_source_map(script_name)
     .or_else(|| getter.get_source_map(script_name))
@@ -243,10 +243,10 @@ fn parse_map_string(
     })
 }
 
-fn get_mappings<'a>(
+fn get_mappings<'a, G: SourceMapGetter>(
   script_name: &str,
   mappings_map: &'a mut CachedMaps,
-  getter: &dyn SourceMapGetter,
+  getter: &G,
 ) -> &'a Option<SourceMap> {
   mappings_map
     .entry(script_name.to_string())

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -51,6 +51,7 @@ use flags::DenoFlags;
 use flags::DenoSubcommand;
 use futures::lazy;
 use futures::Future;
+use futures::future;
 use log::{LevelFilter, Metadata, Record};
 use std::env;
 
@@ -92,53 +93,55 @@ where
   }
 }
 
-pub fn print_file_info(worker: &Worker, url: &str) {
-  let maybe_out =
-    state::fetch_module_meta_data_and_maybe_compile(&worker.state, url, ".");
-  if let Err(err) = maybe_out {
-    println!("{}", err);
-    return;
-  }
-  let out = maybe_out.unwrap();
+pub fn print_file_info(
+  worker: Worker,
+  url: &str,
+) -> impl Future<Item = Worker, Error = ()> {
+  worker::fetch_module_meta_data_and_maybe_compile_async(
+    &worker.state,
+    url,
+    ".",
+  ).and_then(move |out| {
+    println!("{} {}", ansi::bold("local:".to_string()), &(out.filename));
 
-  println!("{} {}", ansi::bold("local:".to_string()), &(out.filename));
-
-  println!(
-    "{} {}",
-    ansi::bold("type:".to_string()),
-    msg::enum_name_media_type(out.media_type)
-  );
-
-  if out.maybe_output_code_filename.is_some() {
     println!(
       "{} {}",
-      ansi::bold("compiled:".to_string()),
-      out.maybe_output_code_filename.as_ref().unwrap(),
+      ansi::bold("type:".to_string()),
+      msg::enum_name_media_type(out.media_type)
     );
-  }
 
-  if out.maybe_source_map_filename.is_some() {
-    println!(
-      "{} {}",
-      ansi::bold("map:".to_string()),
-      out.maybe_source_map_filename.as_ref().unwrap()
-    );
-  }
-
-  let modules = worker.modules.lock().unwrap();
-  if let Some(deps) = modules.deps(&out.module_name) {
-    println!("{}{}", ansi::bold("deps:\n".to_string()), deps.name);
-    if let Some(ref depsdeps) = deps.deps {
-      for d in depsdeps {
-        println!("{}", d);
-      }
+    if out.maybe_output_code_filename.is_some() {
+      println!(
+        "{} {}",
+        ansi::bold("compiled:".to_string()),
+        out.maybe_output_code_filename.as_ref().unwrap(),
+      );
     }
-  } else {
-    println!(
-      "{} cannot retrieve full dependency graph",
-      ansi::bold("deps:".to_string()),
-    );
-  }
+
+    if out.maybe_source_map_filename.is_some() {
+      println!(
+        "{} {}",
+        ansi::bold("map:".to_string()),
+        out.maybe_source_map_filename.as_ref().unwrap()
+      );
+    }
+
+	let modules = worker.modules.lock().unwrap();
+    if let Some(deps) = worker.modules.deps(&out.module_name) {
+      println!("{}{}", ansi::bold("deps:\n".to_string()), deps.name);
+      if let Some(ref depsdeps) = deps.deps {
+        for d in depsdeps {
+          println!("{}", d);
+        }
+      }
+    } else {
+      println!(
+        "{} cannot retrieve full dependency graph",
+        ansi::bold("deps:".to_string()),
+      );
+    }
+    Ok(worker)
+  }).map_err(|err| println!("{}", err))
 }
 
 fn create_worker_and_state(
@@ -195,8 +198,11 @@ fn fetch_or_info_command(
       .execute_mod_async(&main_url, true)
       .and_then(move |()| {
         if print_info {
-          print_file_info(&worker, &main_module);
+          future::Either::A(print_file_info(worker, &main_module))
+        } else {
+          future::Either::B(future::ok(worker))
         }
+      }).and_then(|worker| {
         worker.then(|result| {
           js_check(result);
           Ok(())

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -103,7 +103,7 @@ impl ThreadSafeState {
   }
 }
 
-fn fetch_module_meta_data_and_maybe_compile_async(
+pub fn fetch_module_meta_data_and_maybe_compile_async(
   state: &ThreadSafeState,
   specifier: &str,
   referrer: &str,


### PR DESCRIPTION
Reduce `block_on` dependencies and some clean up
1. Use static dispatch for `SourceMapGetter` by making methods generic.
2. `execute_mod` is no longer used except 3 tests. Its usage in `ops.rs` has been replaced with `execute_mod_async`
3. `fetch_module_meta_data_and_maybe_compile` has been removed and its usage in `main.rs` has been replaced with `fetch_module_meta_data_and_maybe_compile_async`

Also, Isolate's `terminate_execution` test seems flaky.. It failed once or twice for me but passed in the next runs.
