### PR TITLE
URLSearchParams: if pair does not contain exactly two items throw a TypeError

### DIFF
--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -280,11 +280,11 @@ export class URLSearchParams {
     // Overload: sequence<sequence<USVString>>
     for (const tuple of init) {
       // If pair does not contain exactly two items, then throw a TypeError.
-      requiredArguments(
-        "URLSearchParams.constructor tuple array argument",
-        tuple.length,
-        2
-      );
+      if (tuple.length !== 2) {
+        throw new TypeError(
+          "URLSearchParams.constructor tuple array argument must only contain pair elements"
+        );
+      }
       this.append(tuple[0], tuple[1]);
     }
   }

--- a/js/url_search_params_test.ts
+++ b/js/url_search_params_test.ts
@@ -147,6 +147,19 @@ test(function urlSearchParamsShouldThrowTypeError(): void {
   }
 
   assertEquals(hasThrown, 2);
+
+  try {
+    new URLSearchParams([["1", "2", "3"]]);
+    hasThrown = 1;
+  } catch (err) {
+    if (err instanceof TypeError) {
+      hasThrown = 2;
+    } else {
+      hasThrown = 3;
+    }
+  }
+
+  assertEquals(hasThrown, 2);
 });
 
 test(function urlSearchParamsAppendArgumentsCheck(): void {


### PR DESCRIPTION
if pair does not contain exactly two items (such as 1 or 3), throw a TypeError.

now

```ts
new URLSearchParams([[1]])       // TypeError
new URLSearchParams([[1, 2]])    // Correctly
new URLSearchParams([[1,2, 3]])  // Correctly
```

Browser behavior

- Firefox: `TypeError: The expression cannot be converted to return the specified type.`
- Chrome: `TypeError: Failed to construct 'URLSearchParams': Sequence initializer must only contain pair elements`
- Safari: `TypeError: Type error`

