### PR TITLE
Sorting non-existent params removes ? from URL

### DIFF
--- a/js/url.ts
+++ b/js/url.ts
@@ -80,6 +80,10 @@ export class URL {
       /* eslint-enable */
     }
     this._searchParams = searchParams;
+
+    // convert to `any` that has avoided the private limit
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this._searchParams as any).url = this;
   }
 
   get hash(): string {

--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -54,6 +54,7 @@ export class URLSearchParams {
   append(name: string, value: string): void {
     requiredArguments("URLSearchParams.append", arguments.length, 2);
     this.params.push([String(name), String(value)]);
+    this.updateSteps();
   }
 
   /** Deletes the given search parameter and its associated value,
@@ -156,6 +157,8 @@ export class URLSearchParams {
     if (!found) {
       this.append(name, value);
     }
+
+    this.updateSteps();
   }
 
   /** Sort all key/value pairs contained in this object in place and
@@ -168,6 +171,7 @@ export class URLSearchParams {
     this.params = this.params.sort(
       (a, b): number => (a[0] === b[0] ? 0 : a[0] > b[0] ? 1 : -1)
     );
+    this.updateSteps();
   }
 
   /** Calls a function for each element contained in this object in

--- a/js/url_test.ts
+++ b/js/url_test.ts
@@ -157,3 +157,11 @@ test(function removingNonExistentParamRemovesQuestionMarkFromURL(): void {
   assertEquals(url.href, "http://example.com/");
   assertEquals(url.search, "");
 });
+
+test(function sortingNonExistentParamRemovesQuestionMarkFromURL(): void {
+  const url = new URL("http://example.com/?");
+  assertEquals(url.href, "http://example.com/?");
+  url.searchParams.sort();
+  assertEquals(url.href, "http://example.com/");
+  assertEquals(url.search, "");
+});


### PR DESCRIPTION
```ts
const url = new URL("http://example.com/?")
url.searchParams.sort()

// current
url.href === "http://example.com/?"
url.search === "?"

// after fixed
url.href === "http://example.com/"
url.search === ""
```