### PR TITLE
set setTimeout callback's `this` to window object

### DIFF
--- a/js/timers.ts
+++ b/js/timers.ts
@@ -3,6 +3,7 @@ import { assert } from "./util";
 import * as msg from "gen/cli/msg_generated";
 import * as flatbuffers from "./flatbuffers";
 import { sendAsync, sendSync } from "./dispatch";
+import { window } from "./window";
 
 interface Timer {
   id: number;
@@ -186,8 +187,8 @@ function setTimer(
   args: Args,
   repeat: boolean
 ): number {
-  // If any `args` were provided (which is uncommon), bind them to the callback.
-  const callback: () => void = args.length === 0 ? cb : cb.bind(null, ...args);
+  // Bind `args` to the callback and bind `this` to window(global).
+  const callback: () => void = cb.bind(window, ...args);
   // In the browser, the delay value must be coercible to an integer between 0
   // and INT32_MAX. Any other value will cause the timer to fire immediately.
   // We emulate this behavior.

--- a/js/timers_test.ts
+++ b/js/timers_test.ts
@@ -165,3 +165,15 @@ test(async function fireCallbackImmediatelyWhenDelayOverMaxValue(): Promise<
   await waitForMs(1);
   assertEquals(count, 1);
 });
+
+test(async function timeoutCallbackThis(): Promise<void> {
+  const { promise, resolve } = deferred();
+  const obj = {
+    foo(): void {
+      assertEquals(this, window);
+      resolve();
+    }
+  };
+  setTimeout(obj.foo, 1);
+  await promise;
+});


### PR DESCRIPTION
ref: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Explanation

> **Note**: The default `this` value of a `setTimeout` callback will still be the `window` object, and not `undefined`, **even in strict mode**.
