### PR TITLE
Split up tools/sync_third_party

### DIFF
--- a/tools/sync_gclient.py
+++ b/tools/sync_gclient.py
@@ -1,17 +1,13 @@
 #!/usr/bin/env python
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-# Run this script if you are changing Deno's dependencies.
+# Run this script if you are changing //gclient_config.py
 # To update the deno_third_party git repo after running this, try the following:
 # cd third_party
-# find . -type f | grep -v "\.git" | \
+# find v8 -type f | grep -v "\.git" | \
 #   xargs -I% git add -f --no-warn-embedded-repo "%"
 
 import third_party
 import util
 
 util.enable_ansi_colors()
-
-third_party.run_yarn()
-third_party.run_cargo()
-third_party.run_pip()
 third_party.run_gclient_sync()

--- a/tools/sync_node_modules.py
+++ b/tools/sync_node_modules.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+# Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import third_party
+import util
+util.enable_ansi_colors()
+third_party.run_yarn()

--- a/tools/sync_python_modules.py
+++ b/tools/sync_python_modules.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+# Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import third_party
+import util
+util.enable_ansi_colors()
+third_party.run_pip()

--- a/tools/sync_rust_crates.py
+++ b/tools/sync_rust_crates.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+# There is a magic tool which has no documentation. It is used to update rust
+# crates in third_party. https://github.com/piscisaureus/gnargo
+import third_party
+import util
+util.enable_ansi_colors()
+third_party.run_cargo()


### PR DESCRIPTION
This is just encoding my actual workflow; not suggesting that this
workflow is ideal. Previously I would edit sync_third_party.py each time
I ran it.

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
