### PR TITLE
Remove Config struct from core

### DIFF
--- a/core/examples/http_bench.rs
+++ b/core/examples/http_bench.rs
@@ -179,9 +179,8 @@ fn main() {
       filename: "http_bench.js",
     });
 
-    let mut config = deno::Config::default();
-    config.dispatch(dispatch);
-    let isolate = deno::Isolate::new(startup_data, config);
+    let mut isolate = deno::Isolate::new(startup_data, false);
+    isolate.set_dispatch(dispatch);
 
     isolate.then(|r| {
       js_check(r);

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -90,7 +90,6 @@ pub struct Isolate {
   shared_libdeno_isolate: Arc<Mutex<Option<*const libdeno::isolate>>>,
   dispatch: Option<Arc<DispatchFn>>,
   dyn_import: Option<Arc<DynImportFn>>,
-  pub will_snapshot: bool,
   needs_init: bool,
   shared: SharedQueue,
   pending_ops: FuturesUnordered<OpAsyncFuture>,
@@ -157,7 +156,6 @@ impl Isolate {
       needs_init,
       pending_ops: FuturesUnordered::new(),
       have_unpolled_ops: false,
-      will_snapshot,
       pending_dyn_imports: FuturesUnordered::new(),
     };
 


### PR DESCRIPTION
It's unnecessary indirection and is preventing the ability to easily
pass isolate references into the dispatch and dyn_import closures.

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
