### PR TITLE
forbidden to set `this` for setTimeout

### DIFF
--- a/js/timers.ts
+++ b/js/timers.ts
@@ -181,8 +181,7 @@ function fireTimers(): void {
 
 export type Args = unknown[];
 
-// @internal
-function checkThis<T>(thisArg: T): void {
+function checkThis(thisArg: unknown): void {
   if (thisArg !== null && thisArg !== undefined && thisArg !== window) {
     throw new TypeError("Illegal invocation");
   }

--- a/js/timers.ts
+++ b/js/timers.ts
@@ -181,6 +181,13 @@ function fireTimers(): void {
 
 export type Args = unknown[];
 
+// @internal
+function checkThis<T>(thisArg: T): void {
+  if (thisArg !== null && thisArg !== undefined && thisArg !== window) {
+    throw new TypeError("Illegal invocation");
+  }
+}
+
 function setTimer(
   cb: (...args: Args) => void,
   delay: number,
@@ -226,6 +233,8 @@ export function setTimeout(
   delay: number,
   ...args: Args
 ): number {
+  // @ts-ignore
+  checkThis(this);
   return setTimer(cb, delay, args, false);
 }
 
@@ -235,6 +244,8 @@ export function setInterval(
   delay: number,
   ...args: Args
 ): number {
+  // @ts-ignore
+  checkThis(this);
   return setTimer(cb, delay, args, true);
 }
 

--- a/js/timers_test.ts
+++ b/js/timers_test.ts
@@ -177,3 +177,57 @@ test(async function timeoutCallbackThis(): Promise<void> {
   setTimeout(obj.foo, 1);
   await promise;
 });
+
+test(async function timeoutBindThis(): Promise<void> {
+  function noop(): void {}
+
+  const thisCheckPassed = [null, undefined, window, globalThis];
+
+  const thisCheckFailed = [
+    0,
+    "",
+    true,
+    false,
+    {},
+    [],
+    "foo",
+    (): void => {},
+    Object.prototype
+  ];
+
+  thisCheckPassed.forEach(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (thisArg: any): void => {
+      let hasThrown = 0;
+      try {
+        setTimeout.call(thisArg, noop, 1);
+        hasThrown = 1;
+      } catch (err) {
+        if (err instanceof TypeError) {
+          hasThrown = 2;
+        } else {
+          hasThrown = 3;
+        }
+      }
+      assertEquals(hasThrown, 1);
+    }
+  );
+
+  thisCheckFailed.forEach(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (thisArg: any): void => {
+      let hasThrown = 0;
+      try {
+        setTimeout.call(thisArg, noop, 1);
+        hasThrown = 1;
+      } catch (err) {
+        if (err instanceof TypeError) {
+          hasThrown = 2;
+        } else {
+          hasThrown = 3;
+        }
+      }
+      assertEquals(hasThrown, 2);
+    }
+  );
+});


### PR DESCRIPTION
ref https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Explanation

> There's also **no option** to pass a `thisArg` to `setTimeout` as there is in Array methods like `forEach`, `reduce`, etc. and as shown below, using call to set this **doesn't** work either.

```js
setTimeout.call(myArray, myArray.myMethod, 2000); // error: "NS_ERROR_XPC_BAD_OP_ON_WN_PROTO: Illegal operation on WrappedNative prototype object"
setTimeout.call(myArray, myArray.myMethod, 2500, 2); // same error
```