### PR TITLE
Increase the size of the shared buffer

### DIFF
--- a/core/shared_queue.rs
+++ b/core/shared_queue.rs
@@ -32,7 +32,7 @@ const INDEX_RECORDS: usize = 3 + MAX_RECORDS;
 /// Byte offset of where the records begin. Also where the head starts.
 const HEAD_INIT: usize = 4 * INDEX_RECORDS;
 /// A rough guess at how big we should make the shared buffer in bytes.
-pub const RECOMMENDED_SIZE: usize = 128 * MAX_RECORDS;
+pub const RECOMMENDED_SIZE: usize = 256 * MAX_RECORDS;
 
 pub struct SharedQueue {
   bytes: Vec<u8>,

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -201,4 +201,5 @@ if __name__ == '__main__':
     if len(sys.argv) < 2:
         print "Usage ./tools/http_benchmark.py target/debug/deno"
         sys.exit(1)
+    deno_tcp(sys.argv[1])
     deno_http(sys.argv[1])


### PR DESCRIPTION
This seems to provide a decent performance lift across the board, but not enough to make back the performance lost in #2452