### PR TITLE
fix urlSearchParams custom symbol iterator

### DIFF
--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -12,13 +12,8 @@ export class URLSearchParams {
       return;
     }
 
-    if (Array.isArray(init)) {
+    if (Array.isArray(init) || isIterable(init)) {
       this._handleArrayInitialization(init);
-      return;
-    }
-
-    if (isIterable(init)) {
-      this.params = [...init];
       return;
     }
 
@@ -285,7 +280,9 @@ export class URLSearchParams {
     }
   }
 
-  private _handleArrayInitialization(init: string[][]): void {
+  private _handleArrayInitialization(
+    init: string[][] | Iterable<[string, string]>
+  ): void {
     // Overload: sequence<sequence<USVString>>
     for (const tuple of init) {
       // If pair does not contain exactly two items, then throw a TypeError.

--- a/js/url_search_params_test.ts
+++ b/js/url_search_params_test.ts
@@ -227,3 +227,12 @@ test(function urlSearchParamsCustomSymbolIterator(): void {
   const params1 = new URLSearchParams((params as unknown) as string[][]);
   assertEquals(params1.get("a"), "b");
 });
+
+test(function urlSearchParamsCustomSymbolIteratorWithNonStringParams(): void {
+  const params = {};
+  params[Symbol.iterator] = function*(): IterableIterator<[number, number]> {
+    yield [1, 2];
+  };
+  const params1 = new URLSearchParams((params as unknown) as string[][]);
+  assertEquals(params1.get("1"), "2");
+});


### PR DESCRIPTION
Previous pr #2512 has a bug, I mistakenly assign the deconstructed `init` directly to `params`.
