### PR TITLE
Add dyn to areas of core.

### DIFF
--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -94,7 +94,7 @@ impl Repl {
       .editor
       .readline(&prompt)
       .map(|line| {
-        self.editor.add_history_entry(line.as_ref());
+        self.editor.add_history_entry(line.clone());
         line
       }).map_err(|e| deno_error(ErrorKind::Other, e.description().to_string()))
     // Forward error to TS side for processing

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -76,10 +76,10 @@ pub enum StartupData<'a> {
 
 pub type OpResult<E> = Result<Op<E>, E>;
 
-type CoreDispatchFn = Fn(&[u8], Option<PinnedBuf>) -> CoreOp;
+type CoreDispatchFn = dyn Fn(&[u8], Option<PinnedBuf>) -> CoreOp;
 
 pub type DynImportFuture = Box<dyn Future<Item = deno_mod, Error = ()> + Send>;
-type DynImportFn = Fn(&str, &str) -> DynImportFuture;
+type DynImportFn = dyn Fn(&str, &str) -> DynImportFuture;
 
 /// Wraps DynImportFuture to include the deno_dyn_import_id, so that it doesn't
 /// need to be exposed.

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -597,7 +597,7 @@ mod tests {
   }
 
   impl Error for MockError {
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
       unimplemented!()
     }
   }


### PR DESCRIPTION
Nightly Rust complains with the following:

```
error: trait objects without an explicit `dyn` are deprecated
  --> ../../core/isolate.rs:71:19
   |
71 | type DispatchFn = Fn(&[u8], Option<PinnedBuf>) -> Op;
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Fn(&[u8], Option<PinnedBuf>) -> Op`
   |
   = note: `-D bare-trait-objects` implied by `-D warnings`

error: trait objects without an explicit `dyn` are deprecated
  --> ../../core/isolate.rs:74:20
   |
74 | type DynImportFn = Fn(&str, &str) -> DynImportFuture;
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Fn(&str, &str) -> DynImportFuture`

error: trait objects without an explicit `dyn` are deprecated
   --> ../../core/modules.rs:598:32
    |
598 |     fn cause(&self) -> Option<&Error> {
    |                                ^^^^^ help: use `dyn`: `dyn Error`

error: aborting due to 3 previous errors
```

This patch fixes it and should be supported by earlier versions of Rust.  (I had to update to a recent version of nightly because master has something that is triggering a bug in RLS, updating to a more recent version of nightly fixed that).

