### PR TITLE
clearTimeout should convert to number

### DIFF
--- a/js/timers.ts
+++ b/js/timers.ts
@@ -250,6 +250,7 @@ export function setInterval(
 
 /** Clears a previously set timer by id. AKA clearTimeout and clearInterval. */
 export function clearTimer(id: number): void {
+  id = Number(id);
   const timer = idMap.get(id);
   if (timer === undefined) {
     // Timer doesn't exist any more or never existed. This is not an error.

--- a/js/timers_test.ts
+++ b/js/timers_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test, assertEquals } from "./test_util.ts";
+import { test, assert, assertEquals } from "./test_util.ts";
 
 function deferred(): {
   promise: Promise<{}>;
@@ -230,4 +230,16 @@ test(async function timeoutBindThis(): Promise<void> {
       assertEquals(hasThrown, 2);
     }
   );
+});
+
+test(async function clearTimeoutShouldConvertToNumber(): Promise<void> {
+  let called = false;
+  const obj = {
+    valueOf(): number {
+      called = true;
+      return 1;
+    }
+  };
+  clearTimeout((obj as unknown) as number);
+  assert(called);
 });


### PR DESCRIPTION
call `clearTimeout(obj)`, the param `obj` should convert to number. if `obj` has `valueOf` method, it will be called.

```js
clearTimeout({
    valueOf() {
        console.log('be called')
    }
})
```