### PR TITLE
event `isTrusted` is enumerable

### DIFF
--- a/js/event.ts
+++ b/js/event.ts
@@ -23,6 +23,8 @@ export class EventInit implements domTypes.EventInit {
 }
 
 export class Event implements domTypes.Event {
+  // The default value is `false`.
+  // Use `defineProperty` to define on each instance, NOT on the prototype.
   isTrusted!: boolean;
   // Each event has the following associated flags
   private _canceledFlag = false;

--- a/js/event.ts
+++ b/js/event.ts
@@ -6,6 +6,10 @@ import { getPrivateValue, requiredArguments } from "./util";
 // https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/Guides/Contributor_s_Guide/Private_Properties#Using_WeakMaps
 export const eventAttributes = new WeakMap();
 
+function isTrusted(this: Event): boolean {
+  return getPrivateValue(this, eventAttributes, "isTrusted");
+}
+
 export class EventInit implements domTypes.EventInit {
   bubbles = false;
   cancelable = false;
@@ -19,6 +23,7 @@ export class EventInit implements domTypes.EventInit {
 }
 
 export class Event implements domTypes.Event {
+  isTrusted!: boolean;
   // Each event has the following associated flags
   private _canceledFlag = false;
   private _dispatchedFlag = false;
@@ -45,6 +50,10 @@ export class Event implements domTypes.Event {
       relatedTarget: null,
       target: null,
       timeStamp: Date.now()
+    });
+    Reflect.defineProperty(this, "isTrusted", {
+      enumerable: true,
+      get: isTrusted
     });
   }
 
@@ -132,25 +141,6 @@ export class Event implements domTypes.Event {
 
   set inPassiveListener(value: boolean) {
     this._inPassiveListenerFlag = value;
-  }
-
-  get isTrusted(): boolean {
-    return getPrivateValue(this, eventAttributes, "isTrusted");
-  }
-
-  set isTrusted(value: boolean) {
-    eventAttributes.set(this, {
-      type: this.type,
-      bubbles: this.bubbles,
-      cancelable: this.cancelable,
-      composed: this.composed,
-      currentTarget: this.currentTarget,
-      eventPhase: this.eventPhase,
-      isTrusted: value,
-      relatedTarget: this.relatedTarget,
-      target: this.target,
-      timeStamp: this.timeStamp
-    });
   }
 
   get path(): domTypes.EventPath[] {
@@ -363,7 +353,6 @@ Reflect.defineProperty(Event.prototype, "defaultPrevented", {
 });
 Reflect.defineProperty(Event.prototype, "dispatched", { enumerable: true });
 Reflect.defineProperty(Event.prototype, "eventPhase", { enumerable: true });
-Reflect.defineProperty(Event.prototype, "isTrusted", { enumerable: true });
 Reflect.defineProperty(Event.prototype, "target", { enumerable: true });
 Reflect.defineProperty(Event.prototype, "timeStamp", { enumerable: true });
 Reflect.defineProperty(Event.prototype, "type", { enumerable: true });

--- a/js/event_target.ts
+++ b/js/event_target.ts
@@ -201,8 +201,6 @@ export class EventTarget implements domTypes.EventTarget {
       );
     }
 
-    event.isTrusted = false;
-
     return this._dispatch(event);
   }
 

--- a/js/event_test.ts
+++ b/js/event_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test, assertEquals } from "./test_util.ts";
+import { test, assertEquals, assertNotEquals } from "./test_util.ts";
 
 test(function eventInitializedWithType(): void {
   const type = "click";
@@ -79,4 +79,17 @@ test(function eventInitializedWithNonStringType(): void {
   assertEquals(event.type, "undefined");
   assertEquals(event.bubbles, false);
   assertEquals(event.cancelable, false);
+});
+
+// ref https://github.com/web-platform-tests/wpt/blob/master/dom/events/Event-isTrusted.any.js
+test(function eventIsTrusted(): void {
+  const desc1 = Object.getOwnPropertyDescriptor(new Event("x"), "isTrusted");
+  assertNotEquals(desc1, undefined);
+  assertEquals(typeof desc1.get, "function");
+
+  const desc2 = Object.getOwnPropertyDescriptor(new Event("x"), "isTrusted");
+  assertNotEquals(desc2, undefined);
+  assertEquals(typeof desc2.get, "function");
+
+  assertEquals(desc1.get, desc2.get);
 });


### PR DESCRIPTION
web-platform-tests: https://github.com/web-platform-tests/wpt/blob/master/dom/events/Event-isTrusted.any.js

------

According to the specification, `isTrusted` is defined on instance, not on the prototype of the class, and `isTrusted` is enumerable.

Also removed the invoked of `event.isTrusted = false` in [`dispatchEvent`](https://github.com/denoland/deno/blob/master/js/event_target.ts#L204).

ref https://dom.spec.whatwg.org/#dom-event-istrusted