### PR TITLE
refactor: use Path/PathBuf in deno dir

### DIFF
--- a/cli/compiler.rs
+++ b/cli/compiler.rs
@@ -11,22 +11,22 @@ use crate::worker::Worker;
 use deno::Buf;
 use futures::Future;
 use futures::Stream;
+use std::path::PathBuf;
 use std::str;
 use std::sync::atomic::Ordering;
 
 // This corresponds to JS ModuleMetaData.
 // TODO Rename one or the other so they correspond.
-// TODO(bartlomieju): update file name fields to PathBuf
 #[derive(Debug, Clone)]
 pub struct ModuleMetaData {
   pub module_name: String,
   pub module_redirect_source_name: Option<String>, // source of redirect
-  pub filename: String,
+  pub filename: PathBuf,
   pub media_type: msg::MediaType,
   pub source_code: Vec<u8>,
-  pub maybe_output_code_filename: Option<String>,
+  pub maybe_output_code_filename: Option<PathBuf>,
   pub maybe_output_code: Option<Vec<u8>>,
-  pub maybe_source_map_filename: Option<String>,
+  pub maybe_source_map_filename: Option<PathBuf>,
   pub maybe_source_map: Option<Vec<u8>>,
 }
 
@@ -256,7 +256,7 @@ mod tests {
       let mut out = ModuleMetaData {
         module_name,
         module_redirect_source_name: None,
-        filename: "/tests/002_hello.ts".to_owned(),
+        filename: PathBuf::from("/tests/002_hello.ts"),
         media_type: msg::MediaType::TypeScript,
         source_code: include_bytes!("../tests/002_hello.ts").to_vec(),
         maybe_output_code_filename: None,

--- a/cli/compiler.rs
+++ b/cli/compiler.rs
@@ -16,6 +16,7 @@ use std::sync::atomic::Ordering;
 
 // This corresponds to JS ModuleMetaData.
 // TODO Rename one or the other so they correspond.
+// TODO(bartlomieju): update file name fields to PathBuf
 #[derive(Debug, Clone)]
 pub struct ModuleMetaData {
   pub module_name: String,

--- a/cli/compiler.rs
+++ b/cli/compiler.rs
@@ -9,7 +9,6 @@ use crate::state::*;
 use crate::tokio_util;
 use crate::worker::Worker;
 use deno::Buf;
-use deno::ModuleSpecifier;
 use futures::Future;
 use futures::Stream;
 use std::str;
@@ -213,11 +212,9 @@ pub fn compile_async(
 
       Ok(())
     }).and_then(move |_| {
-    // TODO(bartlomieju): module specifier should exist on `ModuleMetaData` struct
-    let module_specifier = ModuleSpecifier::resolve(&module_name, ".").expect("Failed to resolve specifier");
-
       state.dir.fetch_module_meta_data_async(
-        &module_specifier,
+        &module_name,
+        ".",
         true,
         true,
       ).map_err(|e| {

--- a/cli/compiler.rs
+++ b/cli/compiler.rs
@@ -9,6 +9,7 @@ use crate::state::*;
 use crate::tokio_util;
 use crate::worker::Worker;
 use deno::Buf;
+use deno::ModuleSpecifier;
 use futures::Future;
 use futures::Stream;
 use std::str;
@@ -212,9 +213,11 @@ pub fn compile_async(
 
       Ok(())
     }).and_then(move |_| {
+    // TODO(bartlomieju): module specifier should exist on `ModuleMetaData` struct
+    let module_specifier = ModuleSpecifier::resolve(&module_name, ".").expect("Failed to resolve specifier");
+
       state.dir.fetch_module_meta_data_async(
-        &module_name,
-        ".",
+        &module_specifier,
         true,
         true,
       ).map_err(|e| {

--- a/cli/compiler.rs
+++ b/cli/compiler.rs
@@ -215,7 +215,6 @@ pub fn compile_async(
     }).and_then(move |_| {
       state.dir.fetch_module_meta_data_async(
         &module_name,
-        ".",
         true,
         true,
       ).map_err(|e| {

--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -746,7 +746,7 @@ fn fetch_local_source(
   }
   // No redirect needed or end of redirects.
   // We can try read the file
-  let source_code = match fs::read(filepath.clone()) {
+  let source_code = match fs::read(filepath) {
     Err(e) => {
       if e.kind() == std::io::ErrorKind::NotFound {
         return Ok(None);

--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -868,19 +868,9 @@ fn save_source_code_headers(
   }
 }
 
-// TODO(bartlomieju): this method should be removed, it doesn't belong to deno_dir.rs
-// as it's called by function that just want to resolve relative or absolute path
-// with respect to current working dir
-pub fn resolve_path(path: &str) -> Result<(PathBuf, String), DenoError> {
-  let url = resolve_file_url(path.to_string(), ".".to_string())
-    .map_err(DenoError::from)?;
-  let path = url.to_file_path().unwrap();
-  let path_string = path.to_str().unwrap().to_string();
-  Ok((path, path_string))
-}
-
-// TODO(bartlomieju): replaces `resolve_path`
-pub fn resolve_from_cwd(path: &str) -> Result<PathBuf, DenoError> {
+// TODO(bartlomieju): this method should be moved, it doesn't belong to deno_dir.rs
+//  it's a general utility
+pub fn resolve_from_cwd(path: &str) -> Result<(PathBuf, String), DenoError> {
   let candidate_path = Path::new(path);
 
   let resolved_path = if candidate_path.is_absolute() {
@@ -890,7 +880,10 @@ pub fn resolve_from_cwd(path: &str) -> Result<PathBuf, DenoError> {
     cwd.join(path)
   };
 
-  resolved_path.canonicalize().map_err(DenoError::from)
+  let path = resolved_path.canonicalize().map_err(DenoError::from)?;
+  let path_string = path.to_str().unwrap().to_string();
+
+  Ok((path, path_string))
 }
 
 pub fn resolve_file_url(

--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -798,9 +798,7 @@ static MIME_TYPE: &'static str = "mime_type";
 static REDIRECT_TO: &'static str = "redirect_to";
 
 fn source_code_headers_filename(filepath: PathBuf) -> PathBuf {
-  let mut headers_path = filepath.clone();
-  headers_path.push(".headers.json");
-  headers_path
+  PathBuf::from([filepath.to_str().unwrap(), ".headers.json"].concat())
 }
 
 /// Get header metadata associated with a single source code file.
@@ -1520,8 +1518,7 @@ mod tests {
     let (_temp_dir, deno_dir) = test_setup();
     let cwd = std::env::current_dir().unwrap();
     let module_name = "http://example.com/mt_text_typescript.t1.ts"; // not used
-    let mut filepath = cwd.clone();
-    filepath.push("/tests/subdir/mt_text_typescript.t1.ts");
+    let filepath = cwd.join("tests/subdir/mt_text_typescript.t1.ts");
 
     let result = fetch_local_source(&deno_dir, module_name, filepath, None);
     assert!(result.is_ok());
@@ -1535,7 +1532,7 @@ mod tests {
     let (_temp_dir, deno_dir) = test_setup();
 
     let cwd = std::env::current_dir().unwrap();
-    let cwd_string = format!("file://{}/", cwd.to_str().unwrap());
+    let cwd_string = String::from(cwd.to_str().unwrap()) + "/";
 
     tokio_util::init(|| {
       // Test failure case.
@@ -1558,7 +1555,7 @@ mod tests {
     let (_temp_dir, deno_dir) = test_setup();
 
     let cwd = std::env::current_dir().unwrap();
-    let cwd_string = format!("file://{}/", cwd.to_str().unwrap());
+    let cwd_string = String::from(cwd.to_str().unwrap()) + "/";
 
     tokio_util::init(|| {
       // Test failure case.

--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -147,7 +147,10 @@ impl DenoDir {
 
     let specifier = specifier.to_string();
     let referrer = referrer.to_string();
+    // TODO: url resolution should happen here
+    // let module_name = ...
 
+    // TODO: this should return only deps filepath for given module URL
     let result = self.resolve_module(&specifier, &referrer);
     if let Err(err) = result {
       return Either::A(futures::future::err(DenoError::from(err)));
@@ -250,6 +253,7 @@ impl DenoDir {
   }
 
   // Prototype: https://github.com/denoland/deno/blob/golang/os.go#L56-L68
+  // TODO: this method should take deps filepath and return URL for module
   fn src_file_to_url(self: &Self, filename: &str) -> String {
     let filename_path = Path::new(filename);
     if filename_path.starts_with(&self.deps) {
@@ -298,6 +302,9 @@ impl DenoDir {
     resolve_file_url(specifier, referrer)
   }
 
+  // TODO(bartlomieju): this method should return only `local filepath`
+  //  it should be called with already resolved URLs
+  // TODO(bartlomieju): rename to url_to_deps_path
   /// Returns (module name, local filename)
   pub fn resolve_module(
     self: &Self,
@@ -880,10 +887,9 @@ pub fn resolve_from_cwd(path: &str) -> Result<(PathBuf, String), DenoError> {
     cwd.join(path)
   };
 
-  let path = resolved_path.canonicalize().map_err(DenoError::from)?;
-  let path_string = path.to_str().unwrap().to_string();
+  let path_string = resolved_path.to_str().unwrap().to_string();
 
-  Ok((path, path_string))
+  Ok((resolved_path, path_string))
 }
 
 pub fn resolve_file_url(

--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -11,7 +11,6 @@ use crate::progress::Progress;
 use crate::source_maps::SourceMapGetter;
 use crate::tokio_util;
 use crate::version;
-use deno::ModuleSpecifier;
 use dirs;
 use futures::future::{loop_fn, Either, Loop};
 use futures::Future;
@@ -150,15 +149,18 @@ impl DenoDir {
 
   pub fn fetch_module_meta_data_async(
     self: &Self,
-    specifier: &ModuleSpecifier,
+    specifier: &str,
+    referrer: &str,
     use_cache: bool,
     no_fetch: bool,
   ) -> impl Future<Item = ModuleMetaData, Error = deno_error::DenoError> {
-    debug!("fetch_module_meta_data. specifier {}", specifier);
+    debug!(
+      "fetch_module_meta_data. specifier {} referrer {}",
+      specifier, referrer
+    );
 
     let specifier = specifier.to_string();
-    // TODO: referrer is always "."
-    let referrer = ".".to_string();
+    let referrer = referrer.to_string();
 
     let result = self.resolve_module(&specifier, &referrer);
     if let Err(err) = result {
@@ -255,14 +257,10 @@ impl DenoDir {
     use_cache: bool,
     no_fetch: bool,
   ) -> Result<ModuleMetaData, deno_error::DenoError> {
-    // TODO(bartlomieju): change signature of this function
-    let module_specifier = ModuleSpecifier::resolve(specifier, referrer)?;
-
-    tokio_util::block_on(self.fetch_module_meta_data_async(
-      &module_specifier,
-      use_cache,
-      no_fetch,
-    ))
+    tokio_util::block_on(
+      self
+        .fetch_module_meta_data_async(specifier, referrer, use_cache, no_fetch),
+    )
   }
 
   // Prototype: https://github.com/denoland/deno/blob/golang/os.go#L56-L68
@@ -1542,7 +1540,7 @@ mod tests {
     tokio_util::init(|| {
       // Test failure case.
       let specifier = "hello.ts";
-      let referrer = file_url!("/baddir/badfile.ts");
+      let referrer = add_root!("/baddir/badfile.ts");
       let r = deno_dir.fetch_module_meta_data(specifier, referrer, true, false);
       assert!(r.is_err());
 
@@ -1550,7 +1548,6 @@ mod tests {
       let specifier = "./js/main.ts";
       let referrer = cwd_string.as_str();
       let r = deno_dir.fetch_module_meta_data(specifier, referrer, true, false);
-      println!("{:?} {:?}", r, referrer);
       assert!(r.is_ok());
     })
   }

--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -219,10 +219,8 @@ impl DenoDir {
           Ok((output_code, source_map)) => {
             out.maybe_output_code = Some(output_code);
             out.maybe_source_map = Some(source_map);
-            out.maybe_output_code_filename =
-              Some(output_code_filename.to_str().unwrap().to_string());
-            out.maybe_source_map_filename =
-              Some(output_source_map_filename.to_str().unwrap().to_string());
+            out.maybe_output_code_filename = Some(output_code_filename);
+            out.maybe_source_map_filename = Some(output_source_map_filename);
             Ok(out)
           }
         }
@@ -628,9 +626,6 @@ fn fetch_remote_source_async(
           }
           FetchOnceResult::Code(source, maybe_content_type) => {
             // We land on the code.
-            // TODO: replace with `PathBuf`
-            let filename = filepath.to_str().unwrap().to_string();
-
             match filepath.parent() {
               Some(ref parent) => fs::create_dir_all(parent),
               None => Ok(()),
@@ -663,7 +658,7 @@ fn fetch_remote_source_async(
             Ok(Loop::Break(Some(ModuleMetaData {
               module_name: module_name.to_string(),
               module_redirect_source_name: maybe_initial_module_name,
-              filename: filename.to_string(),
+              filename: filepath.clone(),
               media_type: map_content_type(
                 filepath.as_path(),
                 maybe_content_type.as_ref().map(String::as_str),
@@ -758,7 +753,7 @@ fn fetch_local_source(
   Ok(Some(ModuleMetaData {
     module_name: module_name.to_string(),
     module_redirect_source_name: module_initial_source_name,
-    filename: filepath.to_str().unwrap().to_string(),
+    filename: filepath.to_owned(),
     media_type: map_content_type(
       &filepath,
       source_code_headers.mime_type.as_ref().map(String::as_str),

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -394,7 +394,7 @@ fn resolve_paths(paths: Vec<String>) -> Vec<String> {
       eprintln!("Unrecognized path to whitelist: {}", pathstr);
       continue;
     }
-    let mut full_path = result.unwrap().to_str().unwrap().to_string();
+    let mut full_path = result.unwrap().1;
     // Remove trailing slash.
     if full_path.len() > 1 && full_path.ends_with('/') {
       full_path.pop();
@@ -1060,21 +1060,20 @@ mod tests {
   fn test_flags_from_vec_19() {
     use tempfile::TempDir;
     let temp_dir = TempDir::new().expect("tempdir fail");
-    let temp_dir_path =
+    let (_, temp_dir_path) =
       deno_dir::resolve_from_cwd(temp_dir.path().to_str().unwrap()).unwrap();
-    let temp_dir_str = temp_dir_path.to_str().unwrap();
 
     let (flags, subcommand, argv) = flags_from_vec(svec![
       "deno",
       "run",
-      format!("--allow-read={}", temp_dir_str),
+      format!("--allow-read={}", &temp_dir_path),
       "script.ts"
     ]);
     assert_eq!(
       flags,
       DenoFlags {
         allow_read: false,
-        read_whitelist: svec![temp_dir_str],
+        read_whitelist: svec![&temp_dir_path],
         ..DenoFlags::default()
       }
     );
@@ -1086,21 +1085,20 @@ mod tests {
   fn test_flags_from_vec_20() {
     use tempfile::TempDir;
     let temp_dir = TempDir::new().expect("tempdir fail");
-    let temp_dir_path =
+    let (_, temp_dir_path) =
       deno_dir::resolve_from_cwd(temp_dir.path().to_str().unwrap()).unwrap();
-    let temp_dir_str = temp_dir_path.to_str().unwrap();
 
     let (flags, subcommand, argv) = flags_from_vec(svec![
       "deno",
       "run",
-      format!("--allow-write={}", temp_dir_str),
+      format!("--allow-write={}", &temp_dir_path),
       "script.ts"
     ]);
     assert_eq!(
       flags,
       DenoFlags {
         allow_write: false,
-        write_whitelist: svec![temp_dir_str],
+        write_whitelist: svec![&temp_dir_path],
         ..DenoFlags::default()
       }
     );

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -389,12 +389,12 @@ To change installation directory use -d/--dir flag
 fn resolve_paths(paths: Vec<String>) -> Vec<String> {
   let mut out: Vec<String> = vec![];
   for pathstr in paths.iter() {
-    let result = deno_dir::resolve_path(pathstr);
+    let result = deno_dir::resolve_from_cwd(pathstr);
     if result.is_err() {
       eprintln!("Unrecognized path to whitelist: {}", pathstr);
       continue;
     }
-    let mut full_path = result.unwrap().1;
+    let mut full_path = result.unwrap().to_str().unwrap().to_string();
     // Remove trailing slash.
     if full_path.len() > 1 && full_path.ends_with('/') {
       full_path.pop();
@@ -1060,20 +1060,21 @@ mod tests {
   fn test_flags_from_vec_19() {
     use tempfile::TempDir;
     let temp_dir = TempDir::new().expect("tempdir fail");
-    let (_, temp_dir_path) =
-      deno_dir::resolve_path(temp_dir.path().to_str().unwrap()).unwrap();
+    let temp_dir_path =
+      deno_dir::resolve_from_cwd(temp_dir.path().to_str().unwrap()).unwrap();
+    let temp_dir_str = temp_dir_path.to_str().unwrap();
 
     let (flags, subcommand, argv) = flags_from_vec(svec![
       "deno",
       "run",
-      format!("--allow-read={}", &temp_dir_path),
+      format!("--allow-read={}", temp_dir_str),
       "script.ts"
     ]);
     assert_eq!(
       flags,
       DenoFlags {
         allow_read: false,
-        read_whitelist: svec![&temp_dir_path],
+        read_whitelist: svec![temp_dir_str],
         ..DenoFlags::default()
       }
     );
@@ -1085,20 +1086,21 @@ mod tests {
   fn test_flags_from_vec_20() {
     use tempfile::TempDir;
     let temp_dir = TempDir::new().expect("tempdir fail");
-    let (_, temp_dir_path) =
-      deno_dir::resolve_path(temp_dir.path().to_str().unwrap()).unwrap();
+    let temp_dir_path =
+      deno_dir::resolve_from_cwd(temp_dir.path().to_str().unwrap()).unwrap();
+    let temp_dir_str = temp_dir_path.to_str().unwrap();
 
     let (flags, subcommand, argv) = flags_from_vec(svec![
       "deno",
       "run",
-      format!("--allow-write={}", &temp_dir_path),
+      format!("--allow-write={}", temp_dir_str),
       "script.ts"
     ]);
     assert_eq!(
       flags,
       DenoFlags {
         allow_write: false,
-        write_whitelist: svec![&temp_dir_path],
+        write_whitelist: svec![temp_dir_str],
         ..DenoFlags::default()
       }
     );

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -105,7 +105,11 @@ pub fn print_file_info(
     &worker.state,
     module_specifier,
   ).and_then(move |out| {
-    println!("{} {}", ansi::bold("local:".to_string()), &(out.filename));
+    println!(
+      "{} {}",
+      ansi::bold("local:".to_string()),
+      out.filename.to_str().unwrap()
+    );
 
     println!(
       "{} {}",
@@ -117,7 +121,7 @@ pub fn print_file_info(
       println!(
         "{} {}",
         ansi::bold("compiled:".to_string()),
-        out.maybe_output_code_filename.as_ref().unwrap(),
+        out.maybe_output_code_filename.unwrap().to_str().unwrap(),
       );
     }
 
@@ -125,7 +129,7 @@ pub fn print_file_info(
       println!(
         "{} {}",
         ansi::bold("map:".to_string()),
-        out.maybe_source_map_filename.as_ref().unwrap()
+        out.maybe_source_map_filename.unwrap().to_str().unwrap()
       );
     }
 

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -458,6 +458,7 @@ fn op_cache(
   assert!(data.is_none());
   let inner = base.inner_as_cache().unwrap();
   let extension = inner.extension().unwrap();
+  // TODO: rename to something with 'url'
   let module_id = inner.module_id().unwrap();
   let contents = inner.contents().unwrap();
 
@@ -468,9 +469,8 @@ fn op_cache(
   // cache path. In the future, checksums will not be used in the cache
   // filenames and this requirement can be removed. See
   // https://github.com/denoland/deno/issues/2057
-  let module_meta_data = state
-    .dir
-    .fetch_module_meta_data(module_id, ".", true, true)?;
+  let module_meta_data =
+    state.dir.fetch_module_meta_data(module_id, true, true)?;
 
   let (js_cache_path, source_map_path) = state.dir.cache_path(
     &PathBuf::from(&module_meta_data.filename),
@@ -515,7 +515,6 @@ fn op_fetch_module_meta_data(
     .dir
     .fetch_module_meta_data_async(
       &resolved_specifier.to_string(),
-      referrer,
       use_cache,
       no_fetch,
     ).and_then(move |out| {

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -513,8 +513,12 @@ fn op_fetch_module_meta_data(
 
   let fut = state
     .dir
-    .fetch_module_meta_data_async(&resolved_specifier, use_cache, no_fetch)
-    .and_then(move |out| {
+    .fetch_module_meta_data_async(
+      &resolved_specifier.to_string(),
+      referrer,
+      use_cache,
+      no_fetch,
+    ).and_then(move |out| {
       let builder = &mut FlatBufferBuilder::new();
       let data_off = builder.create_vector(out.source_code.as_slice());
       let msg_args = msg::FetchModuleMetaDataResArgs {

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -472,9 +472,10 @@ fn op_cache(
     .dir
     .fetch_module_meta_data(module_id, ".", true, true)?;
 
-  let (js_cache_path, source_map_path) = state
-    .dir
-    .cache_path(&module_meta_data.filename, &module_meta_data.source_code);
+  let (js_cache_path, source_map_path) = state.dir.cache_path(
+    &PathBuf::from(&module_meta_data.filename),
+    &module_meta_data.source_code,
+  );
 
   if extension == ".map" {
     debug!("cache {:?}", source_map_path);

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -522,7 +522,7 @@ fn op_fetch_module_meta_data(
       let data_off = builder.create_vector(out.source_code.as_slice());
       let msg_args = msg::FetchModuleMetaDataResArgs {
         module_name: Some(builder.create_string(&out.module_name)),
-        filename: Some(builder.create_string(&out.filename)),
+        filename: Some(builder.create_string(&out.filename.to_str().unwrap())),
         media_type: out.media_type,
         data: Some(data_off),
       };

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -512,12 +512,8 @@ fn op_fetch_module_meta_data(
 
   let fut = state
     .dir
-    .fetch_module_meta_data_async(
-      &resolved_specifier.to_string(),
-      referrer,
-      use_cache,
-      no_fetch,
-    ).and_then(move |out| {
+    .fetch_module_meta_data_async(&resolved_specifier, use_cache, no_fetch)
+    .and_then(move |out| {
       let builder = &mut FlatBufferBuilder::new();
       let data_off = builder.create_vector(out.source_code.as_slice());
       let msg_args = msg::FetchModuleMetaDataResArgs {

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 use atty;
 use crate::ansi;
-use crate::deno_dir::resolve_path;
+use crate::deno_dir::resolve_from_cwd;
 use crate::deno_error;
 use crate::deno_error::err_check;
 use crate::deno_error::DenoError;
@@ -847,7 +847,7 @@ fn op_mkdir(
 ) -> CliOpResult {
   assert!(data.is_none());
   let inner = base.inner_as_mkdir().unwrap();
-  let (path, path_) = resolve_path(inner.path().unwrap())?;
+  let (path, path_) = resolve_from_cwd(inner.path().unwrap())?;
   let recursive = inner.recursive();
   let mode = inner.mode();
 
@@ -868,7 +868,7 @@ fn op_chmod(
   assert!(data.is_none());
   let inner = base.inner_as_chmod().unwrap();
   let _mode = inner.mode();
-  let (path, path_) = resolve_path(inner.path().unwrap())?;
+  let (path, path_) = resolve_from_cwd(inner.path().unwrap())?;
 
   state.check_write(&path_)?;
 
@@ -916,7 +916,7 @@ fn op_open(
   assert!(data.is_none());
   let cmd_id = base.cmd_id();
   let inner = base.inner_as_open().unwrap();
-  let (filename, filename_) = resolve_path(inner.filename().unwrap())?;
+  let (filename, filename_) = resolve_from_cwd(inner.filename().unwrap())?;
   let mode = inner.mode().unwrap();
 
   let mut open_options = tokio::fs::OpenOptions::new();
@@ -1168,7 +1168,7 @@ fn op_remove(
 ) -> CliOpResult {
   assert!(data.is_none());
   let inner = base.inner_as_remove().unwrap();
-  let (path, path_) = resolve_path(inner.path().unwrap())?;
+  let (path, path_) = resolve_from_cwd(inner.path().unwrap())?;
   let recursive = inner.recursive();
 
   state.check_write(&path_)?;
@@ -1194,8 +1194,8 @@ fn op_copy_file(
 ) -> CliOpResult {
   assert!(data.is_none());
   let inner = base.inner_as_copy_file().unwrap();
-  let (from, from_) = resolve_path(inner.from().unwrap())?;
-  let (to, to_) = resolve_path(inner.to().unwrap())?;
+  let (from, from_) = resolve_from_cwd(inner.from().unwrap())?;
+  let (to, to_) = resolve_from_cwd(inner.to().unwrap())?;
 
   state.check_read(&from_)?;
   state.check_write(&to_)?;
@@ -1269,7 +1269,7 @@ fn op_stat(
   assert!(data.is_none());
   let inner = base.inner_as_stat().unwrap();
   let cmd_id = base.cmd_id();
-  let (filename, filename_) = resolve_path(inner.filename().unwrap())?;
+  let (filename, filename_) = resolve_from_cwd(inner.filename().unwrap())?;
   let lstat = inner.lstat();
 
   state.check_read(&filename_)?;
@@ -1318,7 +1318,7 @@ fn op_read_dir(
   assert!(data.is_none());
   let inner = base.inner_as_read_dir().unwrap();
   let cmd_id = base.cmd_id();
-  let (path, path_) = resolve_path(inner.path().unwrap())?;
+  let (path, path_) = resolve_from_cwd(inner.path().unwrap())?;
 
   state.check_read(&path_)?;
 
@@ -1374,8 +1374,8 @@ fn op_rename(
 ) -> CliOpResult {
   assert!(data.is_none());
   let inner = base.inner_as_rename().unwrap();
-  let (oldpath, _) = resolve_path(inner.oldpath().unwrap())?;
-  let (newpath, newpath_) = resolve_path(inner.newpath().unwrap())?;
+  let (oldpath, _) = resolve_from_cwd(inner.oldpath().unwrap())?;
+  let (newpath, newpath_) = resolve_from_cwd(inner.newpath().unwrap())?;
 
   state.check_write(&newpath_)?;
 
@@ -1393,8 +1393,8 @@ fn op_link(
 ) -> CliOpResult {
   assert!(data.is_none());
   let inner = base.inner_as_link().unwrap();
-  let (oldname, _) = resolve_path(inner.oldname().unwrap())?;
-  let (newname, newname_) = resolve_path(inner.newname().unwrap())?;
+  let (oldname, _) = resolve_from_cwd(inner.oldname().unwrap())?;
+  let (newname, newname_) = resolve_from_cwd(inner.newname().unwrap())?;
 
   state.check_write(&newname_)?;
 
@@ -1412,8 +1412,8 @@ fn op_symlink(
 ) -> CliOpResult {
   assert!(data.is_none());
   let inner = base.inner_as_symlink().unwrap();
-  let (oldname, _) = resolve_path(inner.oldname().unwrap())?;
-  let (newname, newname_) = resolve_path(inner.newname().unwrap())?;
+  let (oldname, _) = resolve_from_cwd(inner.oldname().unwrap())?;
+  let (newname, newname_) = resolve_from_cwd(inner.newname().unwrap())?;
 
   state.check_write(&newname_)?;
   // TODO Use type for Windows.
@@ -1439,7 +1439,7 @@ fn op_read_link(
   assert!(data.is_none());
   let inner = base.inner_as_readlink().unwrap();
   let cmd_id = base.cmd_id();
-  let (name, name_) = resolve_path(inner.name().unwrap())?;
+  let (name, name_) = resolve_from_cwd(inner.name().unwrap())?;
 
   state.check_read(&name_)?;
 
@@ -1541,7 +1541,7 @@ fn op_truncate(
   assert!(data.is_none());
 
   let inner = base.inner_as_truncate().unwrap();
-  let (filename, filename_) = resolve_path(inner.name().unwrap())?;
+  let (filename, filename_) = resolve_from_cwd(inner.name().unwrap())?;
   let len = inner.len();
 
   state.check_write(&filename_)?;

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -128,7 +128,6 @@ pub fn fetch_module_meta_data_and_maybe_compile_async(
     .dir
     .fetch_module_meta_data_async(
       &module_specifier.to_string(),
-      ".",
       use_cache,
       no_fetch,
     ).and_then(move |out| {

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -126,12 +126,8 @@ pub fn fetch_module_meta_data_and_maybe_compile_async(
 
   state_
     .dir
-    .fetch_module_meta_data_async(
-      &module_specifier.to_string(),
-      ".",
-      use_cache,
-      no_fetch,
-    ).and_then(move |out| {
+    .fetch_module_meta_data_async(&module_specifier, use_cache, no_fetch)
+    .and_then(move |out| {
       if out.media_type == msg::MediaType::TypeScript
         && !out.has_output_code_and_source_map()
       {

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -126,8 +126,12 @@ pub fn fetch_module_meta_data_and_maybe_compile_async(
 
   state_
     .dir
-    .fetch_module_meta_data_async(&module_specifier, use_cache, no_fetch)
-    .and_then(move |out| {
+    .fetch_module_meta_data_async(
+      &module_specifier.to_string(),
+      ".",
+      use_cache,
+      no_fetch,
+    ).and_then(move |out| {
       if out.media_type == msg::MediaType::TypeScript
         && !out.has_output_code_and_source_map()
       {

--- a/tests/error_004_missing_module.ts.out
+++ b/tests/error_004_missing_module.ts.out
@@ -1,4 +1,4 @@
-[WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts" from "[WILDCARD]tests/error_004_missing_module.ts"
+[WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts"
 [WILDCARD] js/errors.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
     at maybeError (js/errors.ts:[WILDCARD])

--- a/tests/error_005_missing_dynamic_import.ts.out
+++ b/tests/error_005_missing_dynamic_import.ts.out
@@ -1,4 +1,4 @@
-[WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts" from "[WILDCARD]tests/error_005_missing_dynamic_import.ts"
+[WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts"
 [WILDCARD] js/errors.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
     at maybeError (js/errors.ts:[WILDCARD])

--- a/tests/error_006_import_ext_failure.ts.out
+++ b/tests/error_006_import_ext_failure.ts.out
@@ -1,4 +1,4 @@
-[WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/non-existent" from "[WILDCARD]tests/error_006_import_ext_failure.ts"
+[WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/non-existent"
 [WILDCARD] js/errors.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
     at maybeError (js/errors.ts:[WILDCARD])


### PR DESCRIPTION
This is preliminary work towards #2057 

Refactoring `//cli/deno_dir.rs` to use more concrete types, because there is a hell lot of `&str` arguments