### PR TITLE
fmt_test: resolve absolute path issue of fmt testing

### DIFF
--- a/tools/fmt_test.py
+++ b/tools/fmt_test.py
@@ -23,17 +23,12 @@ class TestFmt(DenoTestCase):
             # fetch it instead through tools/http_server.py.
             deno_dir = d
 
-            # TODO(kt3k) Below can be run([deno_exe, "fmt", dst], ...)
-            # once the following issue is addressed:
-            # https://github.com/denoland/deno_std/issues/330
-            result = run_output([
-                os.path.join(root_path, self.deno_exe), "fmt",
-                "badly_formatted.js"
-            ],
-                                cwd=d,
-                                merge_env={"DENO_DIR": deno_dir},
-                                exit_on_fail=True,
-                                quiet=True)
+            result = run_output(
+                [os.path.join(root_path, self.deno_exe), "fmt", dst],
+                cwd=d,
+                merge_env={"DENO_DIR": deno_dir},
+                exit_on_fail=True,
+                quiet=True)
             self.assertEqual(result.code, 0)
             with open(fixed_filename) as f:
                 expected = f.read()


### PR DESCRIPTION
This PR resolves a TODO comment in `//tools/fmt_test.py`

`deno fmt` used to has a bug about handling of absolute paths. Now it was fixed at https://github.com/denoland/deno_std/pull/438, and we can use absolute paths in arguments.
