### PR TITLE
fetch: make response.body async iterable

### DIFF
--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -237,6 +237,10 @@ class Body implements domTypes.Body, domTypes.ReadableStream, io.ReadCloser {
   tee(): [domTypes.ReadableStream, domTypes.ReadableStream] {
     return notImplemented();
   }
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array> {
+    return io.toAsyncIterator(this);
+  }
 }
 
 export class Response implements domTypes.Response {

--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -33,6 +33,17 @@ testPerm({ net: true }, async function fetchBlob(): Promise<void> {
   assertEquals(blob.size, Number(headers.get("Content-Length")));
 });
 
+testPerm({ net: true }, async function fetchAsyncIterator(): Promise<void> {
+  const response = await fetch("http://localhost:4545/package.json");
+  const headers = response.headers;
+  let total = 0;
+  for await (const chunk of response.body) {
+    total += chunk.length;
+  }
+
+  assertEquals(total, Number(headers.get("Content-Length")));
+});
+
 testPerm({ net: true }, async function responseClone(): Promise<void> {
   const response = await fetch("http://localhost:4545/package.json");
   const response1 = response.clone();


### PR DESCRIPTION
This PR makes response.body of fetch async iterable.

fixes #2520