### PR TITLE
docs(style_guide): fix typo

### DIFF
--- a/website/style_guide.md
+++ b/website/style_guide.md
@@ -174,9 +174,9 @@ limited to closures.
 Bad
 
 ```ts
-export const foo(): string => {
+export const foo = (): string => {
   return "bar";
-}
+};
 ```
 
 Good


### PR DESCRIPTION
Fixes a small syntax error

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
