### PR TITLE
Minor tweaks:

### DIFF
--- a/cli/startup_data.rs
+++ b/cli/startup_data.rs
@@ -1,56 +1,61 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use deno::{Script, StartupData};
+#[cfg(feature = "no-snapshot-init")]
+use deno::Script;
 
+use deno::StartupData;
+
+#[cfg(feature = "no-snapshot-init")]
 pub fn deno_isolate_init() -> StartupData<'static> {
-  if cfg!(feature = "no-snapshot-init") {
-    debug!("Deno isolate init without snapshots.");
-    #[cfg(not(feature = "check-only"))]
-    let source_bytes =
-      include_bytes!(concat!(env!("GN_OUT_DIR"), "/gen/cli/bundle/main.js"));
-    #[cfg(feature = "check-only")]
-    let source_bytes = b"";
+  debug!("Deno isolate init without snapshots.");
+  #[cfg(not(feature = "check-only"))]
+  let source =
+    include_str!(concat!(env!("GN_OUT_DIR"), "/gen/cli/bundle/main.js"));
+  #[cfg(feature = "check-only")]
+  let source = "";
 
-    StartupData::Script(Script {
-      filename: "gen/cli/bundle/main.js",
-      source: std::str::from_utf8(&source_bytes[..]).unwrap(),
-    })
-  } else {
-    debug!("Deno isolate init with snapshots.");
-    #[cfg(not(any(feature = "check-only", feature = "no-snapshot-init")))]
-    let data =
-      include_bytes!(concat!(env!("GN_OUT_DIR"), "/gen/cli/snapshot_deno.bin"));
-    #[cfg(any(feature = "check-only", feature = "no-snapshot-init"))]
-    let data = b"";
-
-    StartupData::Snapshot(data)
-  }
+  StartupData::Script(Script {
+    filename: "gen/cli/bundle/main.js",
+    source,
+  })
 }
 
+#[cfg(not(feature = "no-snapshot-init"))]
+pub fn deno_isolate_init() -> StartupData<'static> {
+  debug!("Deno isolate init with snapshots.");
+  #[cfg(not(feature = "check-only"))]
+  let data =
+    include_bytes!(concat!(env!("GN_OUT_DIR"), "/gen/cli/snapshot_deno.bin"));
+  #[cfg(feature = "check-only")]
+  let data = b"";
+
+  StartupData::Snapshot(data)
+}
+
+#[cfg(feature = "no-snapshot-init")]
 pub fn compiler_isolate_init() -> StartupData<'static> {
-  if cfg!(feature = "no-snapshot-init") {
-    debug!("Compiler isolate init without snapshots.");
-    #[cfg(not(feature = "check-only"))]
-    let source_bytes = include_bytes!(concat!(
-      env!("GN_OUT_DIR"),
-      "/gen/cli/bundle/compiler.js"
-    ));
-    #[cfg(feature = "check-only")]
-    let source_bytes = b"";
+  debug!("Compiler isolate init without snapshots.");
+  #[cfg(not(feature = "check-only"))]
+  let source =
+    include_str!(concat!(env!("GN_OUT_DIR"), "/gen/cli/bundle/compiler.js"));
+  #[cfg(feature = "check-only")]
+  let source = "";
 
-    StartupData::Script(Script {
-      filename: "gen/cli/bundle/compiler.js",
-      source: std::str::from_utf8(&source_bytes[..]).unwrap(),
-    })
-  } else {
-    debug!("Deno isolate init with snapshots.");
-    #[cfg(not(any(feature = "check-only", feature = "no-snapshot-init")))]
-    let data = include_bytes!(concat!(
-      env!("GN_OUT_DIR"),
-      "/gen/cli/snapshot_compiler.bin"
-    ));
-    #[cfg(any(feature = "check-only", feature = "no-snapshot-init"))]
-    let data = b"";
+  StartupData::Script(Script {
+    filename: "gen/cli/bundle/compiler.js",
+    source,
+  })
+}
 
-    StartupData::Snapshot(data)
-  }
+#[cfg(not(feature = "no-snapshot-init"))]
+pub fn compiler_isolate_init() -> StartupData<'static> {
+  debug!("Deno isolate init with snapshots.");
+  #[cfg(not(feature = "check-only"))]
+  let data = include_bytes!(concat!(
+    env!("GN_OUT_DIR"),
+    "/gen/cli/snapshot_compiler.bin"
+  ));
+  #[cfg(feature = "check-only")]
+  let data = b"";
+
+  StartupData::Snapshot(data)
 }

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -25,7 +25,7 @@ use libc::c_void;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::ptr::null;
-use std::sync::{Arc, Mutex, Once, ONCE_INIT};
+use std::sync::{Arc, Mutex, Once};
 
 pub type Buf = Box<[u8]>;
 
@@ -55,8 +55,8 @@ struct OwnedScript {
   pub filename: String,
 }
 
-impl<'a> From<Script<'a>> for OwnedScript {
-  fn from(s: Script<'a>) -> OwnedScript {
+impl From<Script<'_>> for OwnedScript {
+  fn from(s: Script) -> OwnedScript {
     OwnedScript {
       source: s.source.to_string(),
       filename: s.filename.to_string(),
@@ -133,10 +133,10 @@ impl Drop for Isolate {
   }
 }
 
-static DENO_INIT: Once = ONCE_INIT;
+static DENO_INIT: Once = Once::new();
 
 impl Isolate {
-  /// startup_data defines the snapshot or script used at startup to initalize
+  /// startup_data defines the snapshot or script used at startup to initialize
   /// the isolate.
   pub fn new(startup_data: StartupData, will_snapshot: bool) -> Self {
     DENO_INIT.call_once(|| {
@@ -157,7 +157,7 @@ impl Isolate {
 
     let mut startup_script: Option<OwnedScript> = None;
 
-    // Seperate into Option values for each startup type
+    // Separate into Option values for each startup type
     match startup_data {
       StartupData::Script(d) => {
         startup_script = Some(d.into());


### PR DESCRIPTION
1. Separate Snapshot and Script StartupData functions based on cfg "no-snapshot-init"
2. Replace deprecated Once::ONCE_INIT with Once::new (https://github.com/rust-lang/rust/pull/61757)
3. Elide lifetime
4. Fix typos

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
