### PR TITLE
fix: run blocking function on a different task

### DIFF
--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -793,9 +793,10 @@ where
     let result_buf = f()?;
     Ok(Op::Sync(result_buf))
   } else {
-    Ok(Op::Async(Box::new(tokio_util::poll_fn(move || {
-      convert_blocking(f)
-    }))))
+    Ok(Op::Async(Box::new(futures::sync::oneshot::spawn(
+      tokio_util::poll_fn(move || convert_blocking(f)),
+      &tokio_executor::DefaultExecutor::current(),
+    ))))
   }
 }
 


### PR DESCRIPTION
This avoids freezing the current task if the fn blocks indefinitely

### Context:

I'm adding ops to Deno for filesystem watching. 

Unfortunately, the cross-platform rust crate for this (rust notify) currently exposes a non-futures API for receiving events. I noticed in test cases that while it is blocking, timers no longer fire.

Example (https://github.com/jcao219/deno/blob/pr-add-watch/js/watch_fs_test.ts):

```ts
test(async function watcherClosedWhileWatching(): Promise<void> {
  const watcher = Deno.watch([]);
  const promise = watcher.next();
  setTimeout((): void => watcher.close(), 10); // Never fires...
  const { value, done } = await promise;
  assert(done);
  assertStrictEq(value.eventType, "watcherClosed");
  assertStrictEq(value.source, null);
  assertStrictEq(value.destination, null);
});
```

This change fixes the issue.
