### PR TITLE
refactor: use Url in deno dir

### DIFF
--- a/cli/compiler.rs
+++ b/cli/compiler.rs
@@ -249,7 +249,7 @@ mod tests {
     tokio_util::init(|| {
       let specifier = "./tests/002_hello.ts";
       use deno::ModuleSpecifier;
-      let module_name = ModuleSpecifier::resolve_root(specifier)
+      let module_name = ModuleSpecifier::resolve_url_or_path(specifier)
         .unwrap()
         .to_string();
 
@@ -296,7 +296,7 @@ mod tests {
   fn test_bundle_async() {
     let specifier = "./tests/002_hello.ts";
     use deno::ModuleSpecifier;
-    let module_name = ModuleSpecifier::resolve_root(specifier)
+    let module_name = ModuleSpecifier::resolve_url_or_path(specifier)
       .unwrap()
       .to_string();
 

--- a/cli/deno_error.rs
+++ b/cli/deno_error.rs
@@ -110,7 +110,8 @@ impl DenoError {
         use ModuleResolutionError::*;
         match err {
           InvalidUrl(err) | InvalidBaseUrl(err) => Self::url_error_kind(err),
-          ImportPathPrefixMissing => ErrorKind::ImportPathPrefixMissing,
+          InvalidPath => ErrorKind::InvalidPath,
+          ImportPrefixMissing => ErrorKind::ImportPrefixMissing,
         }
       }
       Repr::Diagnostic(ref _err) => ErrorKind::Diagnostic,

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -630,7 +630,9 @@ pub enum DenoSubcommand {
 
 fn get_default_bundle_filename(source_file: &str) -> String {
   use deno::ModuleSpecifier;
-  let url = ModuleSpecifier::resolve_root(source_file).unwrap().to_url();
+  let url = ModuleSpecifier::resolve_url_or_path(source_file)
+    .unwrap()
+    .to_url();
   let path_segments = url.path_segments().unwrap();
   let last = path_segments.last().unwrap();
   String::from(last.trim_end_matches(".ts").trim_end_matches(".js"))

--- a/cli/import_map.rs
+++ b/cli/import_map.rs
@@ -178,9 +178,7 @@ impl ImportMap {
         continue;
       }
 
-      let normalized_address = ModuleSpecifier::resolve(&url_string, ".")
-        .expect("Address should be valid module specifier");
-      normalized_addresses.push(normalized_address);
+      normalized_addresses.push(url.into());
     }
 
     normalized_addresses

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -143,6 +143,7 @@ enum ErrorKind: byte {
   NoSyncSupport,
   ImportMapError,
   ImportPrefixMissing,
+  DenoDirError,
 
   // other kinds
   Diagnostic,

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -102,6 +102,7 @@ enum ErrorKind: byte {
   WouldBlock,
   InvalidInput,
   InvalidData,
+  InvalidPath,
   TimedOut,
   Interrupted,
   WriteZero,
@@ -141,7 +142,7 @@ enum ErrorKind: byte {
   NoAsyncSupport,
   NoSyncSupport,
   ImportMapError,
-  ImportPathPrefixMissing,
+  ImportPrefixMissing,
 
   // other kinds
   Diagnostic,

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -2053,7 +2053,7 @@ fn op_create_worker(
   err_check(worker.execute("denoMain()"));
   err_check(worker.execute("workerMain()"));
 
-  let module_specifier = ModuleSpecifier::resolve_root(specifier)?;
+  let module_specifier = ModuleSpecifier::resolve_url_or_path(specifier)?;
 
   let op =
     worker

--- a/cli/ops.rs
+++ b/cli/ops.rs
@@ -481,8 +481,12 @@ fn op_cache(
   // cache path. In the future, checksums will not be used in the cache
   // filenames and this requirement can be removed. See
   // https://github.com/denoland/deno/issues/2057
+  let module_specifier = ModuleSpecifier::resolve_url(module_id)
+    .expect("Should be valid module specifier");
   let module_meta_data =
-    state.dir.fetch_module_meta_data(module_id, true, true)?;
+    state
+      .dir
+      .fetch_module_meta_data(&module_specifier, true, true)?;
 
   let (js_cache_path, source_map_path) = state.dir.cache_path(
     &PathBuf::from(&module_meta_data.filename),
@@ -525,11 +529,8 @@ fn op_fetch_module_meta_data(
 
   let fut = state
     .dir
-    .fetch_module_meta_data_async(
-      &resolved_specifier.to_string(),
-      use_cache,
-      no_fetch,
-    ).and_then(move |out| {
+    .fetch_module_meta_data_async(&resolved_specifier, use_cache, no_fetch)
+    .and_then(move |out| {
       let builder = &mut FlatBufferBuilder::new();
       let data_off = builder.create_vector(out.source_code.as_slice());
       let msg_args = msg::FetchModuleMetaDataResArgs {

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -126,11 +126,8 @@ pub fn fetch_module_meta_data_and_maybe_compile_async(
 
   state_
     .dir
-    .fetch_module_meta_data_async(
-      &module_specifier.to_string(),
-      use_cache,
-      no_fetch,
-    ).and_then(move |out| {
+    .fetch_module_meta_data_async(&module_specifier, use_cache, no_fetch)
+    .and_then(move |out| {
       if out.media_type == msg::MediaType::TypeScript
         && !out.has_output_code_and_source_map()
       {

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -170,7 +170,8 @@ impl Loader for ThreadSafeState {
       }
     }
 
-    ModuleSpecifier::resolve(specifier, referrer).map_err(DenoError::from)
+    ModuleSpecifier::resolve_import(specifier, referrer)
+      .map_err(DenoError::from)
   }
 
   /// Given an absolute url, load its source code.
@@ -252,7 +253,7 @@ impl ThreadSafeState {
       None
     } else {
       let root_specifier = argv_rest[1].clone();
-      match ModuleSpecifier::resolve_root(&root_specifier) {
+      match ModuleSpecifier::resolve_url_or_path(&root_specifier) {
         Ok(specifier) => Some(specifier),
         Err(e) => {
           // TODO: handle unresolvable specifier

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -141,7 +141,7 @@ mod tests {
   #[test]
   fn execute_mod_esm_imports_a() {
     let module_specifier =
-      ModuleSpecifier::resolve_root("tests/esm_imports_a.js").unwrap();
+      ModuleSpecifier::resolve_url_or_path("tests/esm_imports_a.js").unwrap();
     let argv = vec![String::from("./deno"), module_specifier.to_string()];
     let state = ThreadSafeState::new(
       flags::DenoFlags::default(),
@@ -169,7 +169,7 @@ mod tests {
   #[test]
   fn execute_mod_circular() {
     let module_specifier =
-      ModuleSpecifier::resolve_root("tests/circular1.js").unwrap();
+      ModuleSpecifier::resolve_url_or_path("tests/circular1.js").unwrap();
     let argv = vec![String::from("./deno"), module_specifier.to_string()];
     let state = ThreadSafeState::new(
       flags::DenoFlags::default(),
@@ -197,7 +197,7 @@ mod tests {
   #[test]
   fn execute_006_url_imports() {
     let module_specifier =
-      ModuleSpecifier::resolve_root("tests/006_url_imports.ts").unwrap();
+      ModuleSpecifier::resolve_url_or_path("tests/006_url_imports.ts").unwrap();
     let argv = vec![String::from("deno"), module_specifier.to_string()];
     let mut flags = flags::DenoFlags::default();
     flags.reload = true;
@@ -327,7 +327,7 @@ mod tests {
       // "foo" is not a valid module specifier so this should return an error.
       let mut worker = create_test_worker();
       let module_specifier =
-        ModuleSpecifier::resolve_root("does-not-exist").unwrap();
+        ModuleSpecifier::resolve_url_or_path("does-not-exist").unwrap();
       let result = worker.execute_mod_async(&module_specifier, false).wait();
       assert!(result.is_err());
     })
@@ -340,7 +340,7 @@ mod tests {
       // tests).
       let mut worker = create_test_worker();
       let module_specifier =
-        ModuleSpecifier::resolve_root("./tests/002_hello.ts").unwrap();
+        ModuleSpecifier::resolve_url_or_path("./tests/002_hello.ts").unwrap();
       let result = worker.execute_mod_async(&module_specifier, false).wait();
       assert!(result.is_ok());
     })

--- a/core/module_specifier.rs
+++ b/core/module_specifier.rs
@@ -180,6 +180,41 @@ mod tests {
   fn test_resolve_import() {
     let tests = vec![
       (
+        "./005_more_imports.ts",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        "http://deno.land/core/tests/005_more_imports.ts",
+      ),
+      (
+        "../005_more_imports.ts",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        "http://deno.land/core/005_more_imports.ts",
+      ),
+      (
+        "http://deno.land/core/tests/005_more_imports.ts",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        "http://deno.land/core/tests/005_more_imports.ts",
+      ),
+      (
+        "data:text/javascript,export default 'grapes';",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        "data:text/javascript,export default 'grapes';",
+      ),
+      (
+        "blob:https://whatwg.org/d0360e2f-caee-469f-9a2f-87d5b0456f6f",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        "blob:https://whatwg.org/d0360e2f-caee-469f-9a2f-87d5b0456f6f",
+      ),
+      (
+        "javascript:export default 'artichokes';",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        "javascript:export default 'artichokes';",
+      ),
+      (
+        "data:text/plain,export default 'kale';",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        "data:text/plain,export default 'kale';",
+      ),
+      (
         "/dev/core/tests/005_more_imports.ts",
         "file:///home/yeti",
         "file:///dev/core/tests/005_more_imports.ts",
@@ -223,6 +258,31 @@ mod tests {
 
     let tests = vec![
       (
+        "005_more_imports.ts",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        ImportPrefixMissing,
+      ),
+      (
+        ".tomato",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        ImportPrefixMissing,
+      ),
+      (
+        "..zucchini.mjs",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        ImportPrefixMissing,
+      ),
+      (
+        r".\yam.es",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        ImportPrefixMissing,
+      ),
+      (
+        r"..\yam.es",
+        "http://deno.land/core/tests/006_url_imports.ts",
+        ImportPrefixMissing,
+      ),
+      (
         "https://eggplant:b/c",
         "http://deno.land/core/tests/006_url_imports.ts",
         InvalidUrl(InvalidPort),
@@ -248,7 +308,16 @@ mod tests {
   #[test]
   fn test_resolve_url_or_path() {
     // Absolute URL.
-    let mut tests: Vec<(&str, String)> = vec![];
+    let mut tests: Vec<(&str, String)> = vec![
+      (
+        "http://deno.land/core/tests/006_url_imports.ts",
+        "http://deno.land/core/tests/006_url_imports.ts".to_string(),
+      ),
+      (
+        "https://deno.land/core/tests/006_url_imports.ts",
+        "https://deno.land/core/tests/006_url_imports.ts".to_string(),
+      ),
+    ];
 
     // The local path tests assume that the cwd is the deno repo root.
     let cwd = current_dir().unwrap();

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -643,11 +643,11 @@ mod tests {
 
       eprintln!(">> RESOLVING, S: {}, R: {}", specifier, referrer);
 
-      let output_specifier = match ModuleSpecifier::resolve(specifier, referrer)
-      {
-        Ok(specifier) => specifier,
-        Err(_e) => return Err(MockError::ResolveErr),
-      };
+      let output_specifier =
+        match ModuleSpecifier::resolve_import(specifier, referrer) {
+          Ok(specifier) => specifier,
+          Err(..) => return Err(MockError::ResolveErr),
+        };
 
       if mock_source_code(&output_specifier.to_string()).is_some() {
         Ok(output_specifier)

--- a/tests/error_011_bad_module_specifier.ts.out
+++ b/tests/error_011_bad_module_specifier.ts.out
@@ -1,4 +1,4 @@
-[WILDCARD]error: Uncaught ImportPathPrefixMissing: relative import path not prefixed with / or ./ or ../
+[WILDCARD]error: Uncaught ImportPrefixMissing: relative import path not prefixed with / or ./ or ../
 [WILDCARD] js/errors.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
     at maybeError (js/errors.ts:[WILDCARD])

--- a/tests/error_012_bad_dynamic_import_specifier.ts.out
+++ b/tests/error_012_bad_dynamic_import_specifier.ts.out
@@ -7,5 +7,6 @@
     at fetchModuleMetaData (js/compiler.ts:[WILDCARD])
     at _resolveModule (js/compiler.ts:[WILDCARD])
     at js/compiler.ts:[WILDCARD]
+    at resolveModuleNames (js/compiler.ts:[WILDCARD])
     at resolveModuleNamesWorker ([WILDCARD])
     at resolveModuleNamesReusingOldState ([WILDCARD]typescript.js:[WILDCARD])

--- a/tests/error_012_bad_dynamic_import_specifier.ts.out
+++ b/tests/error_012_bad_dynamic_import_specifier.ts.out
@@ -1,4 +1,4 @@
-[WILDCARD]error: Uncaught ImportPathPrefixMissing: relative import path not prefixed with / or ./ or ../
+[WILDCARD]error: Uncaught ImportPrefixMissing: relative import path not prefixed with / or ./ or ../
 [WILDCARD] js/errors.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
     at maybeError (js/errors.ts:[WILDCARD])


### PR DESCRIPTION
Follow-up to #2559 (and blocked by it)

Use `Url` instead of `String` for specifiers in `//cli/deno_dir.rs`