### PR TITLE
Fix multiple error messages for a missing file

### DIFF
--- a/cli/state.rs
+++ b/cli/state.rs
@@ -181,10 +181,7 @@ impl Loader for ThreadSafeState {
     self.metrics.resolve_count.fetch_add(1, Ordering::SeqCst);
     Box::new(
       fetch_module_meta_data_and_maybe_compile_async(self, module_specifier)
-        .map_err(|err| {
-          eprintln!("{}", err);
-          err
-        }).map(|module_meta_data| deno::SourceCodeInfo {
+        .map(|module_meta_data| deno::SourceCodeInfo {
           // Real module name, might be different from initial URL
           // due to redirections.
           code: module_meta_data.js_source(),

--- a/tests/error_013_missing_script.out
+++ b/tests/error_013_missing_script.out
@@ -1,0 +1,1 @@
+Cannot resolve module "[WILDCARD]missing_file_name"

--- a/tests/error_013_missing_script.test
+++ b/tests/error_013_missing_script.test
@@ -1,0 +1,4 @@
+args: run --reload missing_file_name
+check_stderr: true
+exit_code: 1
+output: tests/error_013_missing_script.out


### PR DESCRIPTION
Deno prints the error message twice if it can't find the script to run. This patch fixes it.
