### PR TITLE
io: change Reader interface

### DIFF
--- a/js/buffer_test.ts
+++ b/js/buffer_test.ts
@@ -60,10 +60,10 @@ async function empty(buf: Buffer, s: string, fub: Uint8Array): Promise<void> {
   check(buf, s);
   while (true) {
     const r = await buf.read(fub);
-    if (r.nread == 0) {
+    if (r === Deno.EOF) {
       break;
     }
-    s = s.slice(r.nread);
+    s = s.slice(r);
     check(buf, s);
   }
   check(buf, "");
@@ -126,8 +126,7 @@ test(async function bufferReadEmptyAtEOF(): Promise<void> {
   let buf = new Buffer();
   const zeroLengthTmp = new Uint8Array(0);
   let result = await buf.read(zeroLengthTmp);
-  assertEquals(result.nread, 0);
-  assertEquals(result.eof, false);
+  assertEquals(result, 0);
 });
 
 test(async function bufferLargeByteWrites(): Promise<void> {
@@ -217,7 +216,8 @@ test(async function bufferTestGrow(): Promise<void> {
     for (let growLen of [0, 100, 1000, 10000, 100000]) {
       const buf = new Buffer(xBytes.buffer as ArrayBuffer);
       // If we read, this affects buf.off, which is good to test.
-      const { nread } = await buf.read(tmp);
+      const result = await buf.read(tmp);
+      const nread = result === Deno.EOF ? 0 : result;
       buf.grow(growLen);
       const yBytes = repeat("y", growLen);
       await buf.write(yBytes);

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -20,9 +20,9 @@ export {
   OpenMode
 } from "./files";
 export {
+  EOF,
   copy,
   toAsyncIterator,
-  ReadResult,
   SeekMode,
   Reader,
   SyncReader,

--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -218,7 +218,7 @@ class Body implements domTypes.Body, domTypes.ReadableStream, io.ReadCloser {
     return decoder.decode(ab);
   }
 
-  read(p: Uint8Array): Promise<io.ReadResult> {
+  read(p: Uint8Array): Promise<number | io.EOF> {
     return read(this.rid, p);
   }
 

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -39,15 +39,16 @@ test(async function readerToAsyncIterator(): Promise<void> {
 
     constructor(private readonly s: string) {}
 
-    async read(p: Uint8Array): Promise<Deno.ReadResult> {
+    async read(p: Uint8Array): Promise<number | Deno.EOF> {
       const n = Math.min(p.byteLength, this.buf.byteLength - this.offset);
       p.set(this.buf.slice(this.offset, this.offset + n));
       this.offset += n;
 
-      return {
-        nread: n,
-        eof: this.offset === this.buf.byteLength
-      };
+      if (n === 0) {
+        return Deno.EOF;
+      }
+
+      return n;
     }
   }
 
@@ -228,7 +229,7 @@ testPerm(
     const buf = new Uint8Array(20);
     await file.seek(0, Deno.SeekMode.SEEK_START);
     const result = await file.read(buf);
-    assertEquals(result.nread, 13);
+    assertEquals(result, 13);
     file.close();
 
     await Deno.remove(tempDir, { recursive: true });

--- a/js/io.ts
+++ b/js/io.ts
@@ -3,11 +3,8 @@
 // Documentation liberally lifted from them too.
 // Thank you! We love Go!
 
-// The bytes read during an I/O call and a boolean indicating EOF.
-export interface ReadResult {
-  nread: number;
-  eof: boolean;
-}
+export const EOF: unique symbol = Symbol("EOF");
+export type EOF = typeof EOF;
 
 // Seek whence values.
 // https://golang.org/pkg/io/#pkg-constants
@@ -21,36 +18,27 @@ export enum SeekMode {
 // https://golang.org/pkg/io/#Reader
 export interface Reader {
   /** Reads up to p.byteLength bytes into `p`. It resolves to the number
-   * of bytes read (`0` <= `n` <= `p.byteLength`) and any error encountered.
+   * of bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error encountered.
    * Even if `read()` returns `n` < `p.byteLength`, it may use all of `p` as
    * scratch space during the call. If some data is available but not
    * `p.byteLength` bytes, `read()` conventionally returns what is available
    * instead of waiting for more.
    *
-   * When `read()` encounters an error or end-of-file condition after
-   * successfully reading `n` > `0` bytes, it returns the number of bytes read.
-   * It may return the (non-nil) error from the same call or return the error
-   * (and `n` == `0`) from a subsequent call. An instance of this general case
-   * is that a `Reader` returning a non-zero number of bytes at the end of the
-   * input stream may return either `err` == `EOF` or `err` == `null`. The next
-   * `read()` should return `0`, `EOF`.
+   * When `read()` encounters end-of-file condition, it returns EOF symbol.
+   *
+   * When `read()` encounters an error, it rejects with an error.
    *
    * Callers should always process the `n` > `0` bytes returned before
-   * considering the `EOF`. Doing so correctly handles I/O errors that happen
-   * after reading some bytes and also both of the allowed `EOF` behaviors.
-   *
-   * Implementations of `read()` are discouraged from returning a zero byte
-   * count with a `null` error, except when `p.byteLength` == `0`. Callers
-   * should treat a return of `0` and `null` as indicating that nothing
-   * happened; in particular it does not indicate `EOF`.
+   * considering the EOF. Doing so correctly handles I/O errors that happen
+   * after reading some bytes and also both of the allowed EOF behaviors.
    *
    * Implementations must not retain `p`.
    */
-  read(p: Uint8Array): Promise<ReadResult>;
+  read(p: Uint8Array): Promise<number | EOF>;
 }
 
 export interface SyncReader {
-  readSync(p: Uint8Array): ReadResult;
+  readSync(p: Uint8Array): number | EOF;
 }
 
 // Writer is the interface that wraps the basic write() method.
@@ -128,10 +116,11 @@ export async function copy(dst: Writer, src: Reader): Promise<number> {
   let gotEOF = false;
   while (gotEOF === false) {
     const result = await src.read(b);
-    if (result.eof) {
+    if (result === EOF) {
       gotEOF = true;
+    } else {
+      n += await dst.write(b.subarray(0, result));
     }
-    n += await dst.write(b.subarray(0, result.nread));
   }
   return n;
 }
@@ -146,7 +135,7 @@ export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array> {
   const b = new Uint8Array(1024);
   // Keep track if end-of-file has been reached, then
   // signal that iterator is done during subsequent next()
-  // call. This is required because `r` can return a `ReadResult`
+  // call. This is required because `r` can return a `number | EOF`
   // with data read and EOF reached. But if iterator returns
   // `done` then `value` is discarded.
   //
@@ -164,10 +153,13 @@ export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array> {
       }
 
       const result = await r.read(b);
-      sawEof = result.eof;
+      if (result === EOF) {
+        sawEof = true;
+        return { value: new Uint8Array(), done: true };
+      }
 
       return {
-        value: b.subarray(0, result.nread),
+        value: b.subarray(0, result),
         done: false
       };
     }

--- a/js/io.ts
+++ b/js/io.ts
@@ -3,7 +3,10 @@
 // Documentation liberally lifted from them too.
 // Thank you! We love Go!
 
-export const EOF: unique symbol = Symbol("EOF");
+// TODO(kt3k): EOF should be `unique symbol` type.
+// That might require some changes of ts_library_builder.
+// See #2591 for more details.
+export const EOF: "EOF" = "EOF";
 export type EOF = typeof EOF;
 
 // Seek whence values.

--- a/js/io.ts
+++ b/js/io.ts
@@ -6,8 +6,8 @@
 // TODO(kt3k): EOF should be `unique symbol` type.
 // That might require some changes of ts_library_builder.
 // See #2591 for more details.
-export const EOF: "EOF" = "EOF";
-export type EOF = typeof EOF;
+export const EOF: null = null;
+export type EOF = null;
 
 // Seek whence values.
 // https://golang.org/pkg/io/#pkg-constants

--- a/js/net.ts
+++ b/js/net.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { ReadResult, Reader, Writer, Closer } from "./io";
+import { EOF, Reader, Writer, Closer } from "./io";
 import * as msg from "gen/cli/msg_generated";
 import { assert, notImplemented } from "./util";
 import * as dispatch from "./dispatch";
@@ -55,7 +55,7 @@ class ConnImpl implements Conn {
     return write(this.rid, p);
   }
 
-  read(p: Uint8Array): Promise<ReadResult> {
+  read(p: Uint8Array): Promise<number | EOF> {
     return read(this.rid, p);
   }
 

--- a/js/net_test.ts
+++ b/js/net_test.ts
@@ -53,20 +53,16 @@ testPerm({ net: true }, async function netDialListen(): Promise<void> {
   const conn = await Deno.dial("tcp", "127.0.0.1:4500");
   const buf = new Uint8Array(1024);
   const readResult = await conn.read(buf);
-  assertEquals(3, readResult.nread);
+  assertEquals(3, readResult);
   assertEquals(1, buf[0]);
   assertEquals(2, buf[1]);
   assertEquals(3, buf[2]);
   assert(conn.rid > 0);
 
-  // TODO Currently ReadResult does not properly transmit EOF in the same call.
-  // it requires a second call to get the EOF. Either ReadResult to be an
-  // integer in which 0 signifies EOF or the handler should be modified so that
-  // EOF is properly transmitted.
-  assertEquals(false, readResult.eof);
+  assert(readResult !== Deno.EOF);
 
   const readResult2 = await conn.read(buf);
-  assertEquals(true, readResult2.eof);
+  assertEquals(Deno.EOF, readResult2);
 
   listener.close();
   conn.close();
@@ -85,20 +81,16 @@ testPerm({ net: true }, async function netListenAsyncIterator(): Promise<void> {
   const conn = await Deno.dial("tcp", "127.0.0.1:4500");
   const buf = new Uint8Array(1024);
   const readResult = await conn.read(buf);
-  assertEquals(3, readResult.nread);
+  assertEquals(3, readResult);
   assertEquals(1, buf[0]);
   assertEquals(2, buf[1]);
   assertEquals(3, buf[2]);
   assert(conn.rid > 0);
 
-  // TODO Currently ReadResult does not properly transmit EOF in the same call.
-  // it requires a second call to get the EOF. Either ReadResult to be an
-  // integer in which 0 signifies EOF or the handler should be modified so that
-  // EOF is properly transmitted.
-  assertEquals(false, readResult.eof);
+  assert(readResult !== Deno.EOF);
 
   const readResult2 = await conn.read(buf);
-  assertEquals(true, readResult2.eof);
+  assertEquals(Deno.EOF, readResult2);
 
   listener.close();
   conn.close();
@@ -116,7 +108,7 @@ testPerm({ net: true }, async function netCloseReadSuccess() {
     await conn.write(new Uint8Array([1, 2, 3]));
     const buf = new Uint8Array(1024);
     const readResult = await conn.read(buf);
-    assertEquals(3, readResult.nread);
+    assertEquals(3, readResult);
     assertEquals(4, buf[0]);
     assertEquals(5, buf[1]);
     assertEquals(6, buf[2]);
@@ -128,8 +120,7 @@ testPerm({ net: true }, async function netCloseReadSuccess() {
   closeReadDeferred.resolve();
   const buf = new Uint8Array(1024);
   const readResult = await conn.read(buf);
-  assertEquals(0, readResult.nread); // No error, read nothing
-  assertEquals(true, readResult.eof); // with immediate EOF
+  assertEquals(Deno.EOF, readResult); // with immediate EOF
   // Ensure closeRead does not impact write
   await conn.write(new Uint8Array([4, 5, 6]));
   await closeDeferred.promise;
@@ -181,7 +172,7 @@ testPerm({ net: true }, async function netCloseWriteSuccess() {
   const buf = new Uint8Array(1024);
   // Check read not impacted
   const readResult = await conn.read(buf);
-  assertEquals(3, readResult.nread);
+  assertEquals(3, readResult);
   assertEquals(1, buf[0]);
   assertEquals(2, buf[1]);
   assertEquals(3, buf[2]);

--- a/js/process_test.ts
+++ b/js/process_test.ts
@@ -156,13 +156,14 @@ testPerm({ run: true }, async function runStdoutPiped(): Promise<void> {
 
   const data = new Uint8Array(10);
   let r = await p.stdout.read(data);
-  assertEquals(r.nread, 5);
-  assertEquals(r.eof, false);
-  const s = new TextDecoder().decode(data.subarray(0, r.nread));
+  if (r === Deno.EOF) {
+    throw new Error("p.stdout.read(...) should not be EOF");
+  }
+  assertEquals(r, 5);
+  const s = new TextDecoder().decode(data.subarray(0, r));
   assertEquals(s, "hello");
   r = await p.stdout.read(data);
-  assertEquals(r.nread, 0);
-  assertEquals(r.eof, true);
+  assertEquals(r, Deno.EOF);
   p.stdout.close();
 
   const status = await p.status();
@@ -182,13 +183,14 @@ testPerm({ run: true }, async function runStderrPiped(): Promise<void> {
 
   const data = new Uint8Array(10);
   let r = await p.stderr.read(data);
-  assertEquals(r.nread, 5);
-  assertEquals(r.eof, false);
-  const s = new TextDecoder().decode(data.subarray(0, r.nread));
+  if (r === Deno.EOF) {
+    throw new Error("p.stderr.read should not return EOF here");
+  }
+  assertEquals(r, 5);
+  const s = new TextDecoder().decode(data.subarray(0, r));
   assertEquals(s, "hello");
   r = await p.stderr.read(data);
-  assertEquals(r.nread, 0);
-  assertEquals(r.eof, true);
+  assertEquals(r, Deno.EOF);
   p.stderr.close();
 
   const status = await p.status();
@@ -306,8 +308,7 @@ testPerm({ run: true }, async function runClose(): Promise<void> {
 
   const data = new Uint8Array(10);
   let r = await p.stderr.read(data);
-  assertEquals(r.nread, 0);
-  assertEquals(r.eof, true);
+  assertEquals(r, Deno.EOF);
 });
 
 test(function signalNumbers(): void {

--- a/tools/deno_http_proxy.ts
+++ b/tools/deno_http_proxy.ts
@@ -21,10 +21,6 @@ async function proxyRequest(req: ServerRequest) {
     method: req.method,
     headers: req.headers
   });
-  // TODO(kt3k): lib.deno_runtime.d.ts has 2 EOF types: Deno.EOF and io.EOF.
-  // They are identical symbols, and should be compatible. However typescript
-  // recognizes they are different types and the below call doesn't compile.
-  // @ts-ignore
   req.respond(resp);
 }
 

--- a/tools/deno_http_proxy.ts
+++ b/tools/deno_http_proxy.ts
@@ -21,6 +21,7 @@ async function proxyRequest(req: ServerRequest) {
     method: req.method,
     headers: req.headers
   });
+  // @ts-ignore
   req.respond(resp);
 }
 

--- a/tools/deno_http_proxy.ts
+++ b/tools/deno_http_proxy.ts
@@ -21,6 +21,9 @@ async function proxyRequest(req: ServerRequest) {
     method: req.method,
     headers: req.headers
   });
+  // TODO(kt3k): lib.deno_runtime.d.ts has 2 EOF types: Deno.EOF and io.EOF.
+  // They are identical symbols, and should be compatible. However typescript
+  // recognizes they are different types and the below call doesn't compile.
   // @ts-ignore
   req.respond(resp);
 }

--- a/tools/deno_tcp.ts
+++ b/tools/deno_tcp.ts
@@ -13,7 +13,7 @@ async function handle(conn: Deno.Conn): Promise<void> {
   try {
     while (true) {
       const r = await conn.read(buffer);
-      if (r.eof) {
+      if (r === Deno.EOF) {
         break;
       }
       await conn.write(response);


### PR DESCRIPTION
This PR changes the Reader interface from:
```ts
export interface Reader {
  read(p: Uint8Array): Promise<ReadResult>;
}
```
to:
```ts
export interface Reader {
  read(p: Uint8Array): Promise<number | EOF>;
}
```

I introduced `EOF` symbol according to @bartlomieju's [comment](https://github.com/denoland/deno/issues/2384#issuecomment-502394163) and the discussion in https://github.com/denoland/deno_std/pull/444

---
closes #2384 