### PR TITLE
Signals handling [WIP]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/BUILD.gn
+++ b/core/BUILD.gn
@@ -23,6 +23,7 @@ main_extern_rlib = [
   "libc",
   "serde_json",
   "log",
+  "tokio_signal"
 ]
 
 rust_rlib("deno") {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = "1.3.0"
 libc = "0.2.55"
 log = "0.4.6"
 serde_json = "1.0.39"
+tokio-signal = "0.2.7"
 
 [[example]]
 name = "deno_core_http_bench"

--- a/core/libdeno.rs
+++ b/core/libdeno.rs
@@ -261,6 +261,7 @@ extern "C" {
     js_source: *const c_char,
   );
   pub fn deno_terminate_execution(i: *const isolate);
+  pub fn deno_print_stack_trace(i: *const isolate);
 
   // Modules
 
@@ -296,4 +297,5 @@ extern "C" {
 
   #[allow(dead_code)]
   pub fn deno_snapshot_delete(s: &mut deno_snapshot);
+
 }

--- a/core/libdeno/api.cc
+++ b/core/libdeno/api.cc
@@ -243,4 +243,11 @@ void deno_terminate_execution(Deno* d_) {
   deno::DenoIsolate* d = reinterpret_cast<deno::DenoIsolate*>(d_);
   d->isolate_->TerminateExecution();
 }
+
+void deno_print_stack_trace(Deno * d_){
+  deno::DenoIsolate* d = reinterpret_cast<deno::DenoIsolate*>(d_);
+  auto* isolate = d->isolate_;
+  CHECK_NOT_NULL(isolate);
+  deno::ThrowInvalidArgument(isolate);
+}
 }

--- a/core/libdeno/binding.cc
+++ b/core/libdeno/binding.cc
@@ -375,7 +375,12 @@ void EvalContext(const v8::FunctionCallbackInfo<v8::Value>& args) {
   auto context = d->context_.Get(isolate);
   v8::Context::Scope context_scope(context);
 
-  CHECK(args[0]->IsString());
+  if (!(args[0]->IsString()))
+  {
+    ThrowInvalidArgument(isolate);
+    return;
+  }
+
   auto source = args[0].As<v8::String>();
 
   auto output = v8::Array::New(isolate, 2);

--- a/core/libdeno/binding.cc
+++ b/core/libdeno/binding.cc
@@ -98,7 +98,7 @@ void PromiseRejectCallback(v8::PromiseRejectMessage promise_reject_message) {
 void Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
   auto* isolate = args.GetIsolate();
   int argsLen = args.Length();
-  if(argsLen < 1 || argsLen > 2){
+  if (argsLen < 1 || argsLen > 2) {
     ThrowInvalidArgument(isolate);
   }
   DenoIsolate* d = DenoIsolate::FromIsolate(isolate);
@@ -377,8 +377,7 @@ void EvalContext(const v8::FunctionCallbackInfo<v8::Value>& args) {
   auto context = d->context_.Get(isolate);
   v8::Context::Scope context_scope(context);
 
-  if (!(args[0]->IsString()))
-  {
+  if (!(args[0]->IsString())) {
     ThrowInvalidArgument(isolate);
     return;
   }

--- a/core/libdeno/binding.cc
+++ b/core/libdeno/binding.cc
@@ -96,9 +96,11 @@ void PromiseRejectCallback(v8::PromiseRejectMessage promise_reject_message) {
 }
 
 void Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK_GE(args.Length(), 1);
-  CHECK_LE(args.Length(), 3);
   auto* isolate = args.GetIsolate();
+  int argsLen = args.Length();
+  if(argsLen < 1 || argsLen > 2){
+    ThrowInvalidArgument(isolate);
+  }
   DenoIsolate* d = DenoIsolate::FromIsolate(isolate);
   auto context = d->context_.Get(d->isolate_);
   v8::HandleScope handle_scope(isolate);

--- a/core/libdeno/binding.cc
+++ b/core/libdeno/binding.cc
@@ -222,7 +222,7 @@ void Send(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   DenoIsolate* d = DenoIsolate::FromIsolate(isolate);
   DCHECK_EQ(d->isolate_, isolate);
-
+  
   v8::HandleScope handle_scope(isolate);
 
   deno_buf control = {nullptr, 0};

--- a/core/libdeno/exceptions.cc
+++ b/core/libdeno/exceptions.cc
@@ -214,4 +214,9 @@ void HandleExceptionMessage(v8::Local<v8::Context> context,
   CHECK_NOT_NULL(d);
   d->last_exception_ = json_str;
 }
+
+void ThrowInvalidArgument(v8::Isolate *isolate){
+      isolate->ThrowException(v8::Exception::TypeError(v8_str("Invalid Argument")));
+}
+
 }  // namespace deno

--- a/core/libdeno/exceptions.cc
+++ b/core/libdeno/exceptions.cc
@@ -215,8 +215,8 @@ void HandleExceptionMessage(v8::Local<v8::Context> context,
   d->last_exception_ = json_str;
 }
 
-void ThrowInvalidArgument(v8::Isolate *isolate){
-      isolate->ThrowException(v8::Exception::TypeError(v8_str("Invalid Argument")));
+void ThrowInvalidArgument(v8::Isolate* isolate) {
+  isolate->ThrowException(v8::Exception::TypeError(v8_str("Invalid Argument")));
 }
 
 }  // namespace deno

--- a/core/libdeno/exceptions.h
+++ b/core/libdeno/exceptions.h
@@ -18,6 +18,8 @@ void HandleException(v8::Local<v8::Context> context,
 
 void HandleExceptionMessage(v8::Local<v8::Context> context,
                             v8::Local<v8::Message> message);
+
+void ThrowInvalidArgument(v8::Isolate* isolate);
 }  // namespace deno
 
 #endif  // EXCEPTIONS_H_

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -235,6 +235,13 @@ TEST(LibDenoTest, LibDenoEvalContextError) {
   deno_delete(d);
 }
 
+TEST(LibDenoTest, LibDenoEvalContextInvalidArgument){
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
+  deno_execute(d, nullptr, "a.js", "LibDenoEvalContextInvalidArgument();");
+  EXPECT_EQ(nullptr, deno_last_exception(d));
+  deno_delete(d);
+}
+
 TEST(LibDenoTest, SharedAtomics) {
   int32_t s[] = {0, 1, 2};
   deno_buf shared = {reinterpret_cast<uint8_t*>(s), sizeof s};

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -236,14 +236,14 @@ TEST(LibDenoTest, LibDenoEvalContextError) {
 }
 
 TEST(LibDenoTest, LibDenoEvalContextInvalidArgument) {
-  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr, nullptr});
   deno_execute(d, nullptr, "a.js", "LibDenoEvalContextInvalidArgument();");
   EXPECT_EQ(nullptr, deno_last_exception(d));
   deno_delete(d);
 }
 
 TEST(LibDenoTest, LibDenoPrintInvalidArgument) {
-  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr, nullptr});
   deno_execute(d, nullptr, "a.js", "LibDenoPrintInvalidArgument();");
   EXPECT_EQ(nullptr, deno_last_exception(d));
   deno_delete(d);

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -235,14 +235,14 @@ TEST(LibDenoTest, LibDenoEvalContextError) {
   deno_delete(d);
 }
 
-TEST(LibDenoTest, LibDenoEvalContextInvalidArgument){
+TEST(LibDenoTest, LibDenoEvalContextInvalidArgument) {
   Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
   deno_execute(d, nullptr, "a.js", "LibDenoEvalContextInvalidArgument();");
   EXPECT_EQ(nullptr, deno_last_exception(d));
   deno_delete(d);
 }
 
-TEST(LibDenoTest, LibDenoPrintInvalidArgument){
+TEST(LibDenoTest, LibDenoPrintInvalidArgument) {
   Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
   deno_execute(d, nullptr, "a.js", "LibDenoPrintInvalidArgument();");
   EXPECT_EQ(nullptr, deno_last_exception(d));

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -242,6 +242,13 @@ TEST(LibDenoTest, LibDenoEvalContextInvalidArgument){
   deno_delete(d);
 }
 
+TEST(LibDenoTest, LibDenoPrintInvalidArgument){
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr});
+  deno_execute(d, nullptr, "a.js", "LibDenoPrintInvalidArgument();");
+  EXPECT_EQ(nullptr, deno_last_exception(d));
+  deno_delete(d);
+}
+
 TEST(LibDenoTest, SharedAtomics) {
   int32_t s[] = {0, 1, 2};
   deno_buf shared = {reinterpret_cast<uint8_t*>(s), sizeof s};

--- a/core/libdeno/libdeno_test.js
+++ b/core/libdeno/libdeno_test.js
@@ -203,7 +203,7 @@ global.LibDenoEvalContextInvalidArgument = () => {
     assert(e instanceof TypeError);
     assert(e.message === "Invalid Argument");
   }
-}
+};
 
 global.LibDenoPrintInvalidArgument = () => {
   try {
@@ -218,4 +218,4 @@ global.LibDenoPrintInvalidArgument = () => {
     assert(e instanceof TypeError);
     assert(e.message === "Invalid Argument");
   }
-}
+};

--- a/core/libdeno/libdeno_test.js
+++ b/core/libdeno/libdeno_test.js
@@ -195,3 +195,12 @@ global.LibDenoEvalContextError = () => {
   assert(!errInfo5.isCompileError); // is NOT a compilation error! (just eval)
   assert(errInfo5.thrown.message === "Unexpected end of input");
 };
+
+global.LibDenoEvalContextInvalidArgument = () => {
+  try{
+    Deno.core.evalContext();
+  }catch(e){
+    assert(e instanceof TypeError);
+    assert(e.message === "Invalid Argument");
+  }
+}

--- a/core/libdeno/libdeno_test.js
+++ b/core/libdeno/libdeno_test.js
@@ -197,9 +197,24 @@ global.LibDenoEvalContextError = () => {
 };
 
 global.LibDenoEvalContextInvalidArgument = () => {
-  try{
+  try {
     Deno.core.evalContext();
-  }catch(e){
+  } catch (e) {
+    assert(e instanceof TypeError);
+    assert(e.message === "Invalid Argument");
+  }
+}
+
+global.LibDenoPrintInvalidArgument = () => {
+  try {
+    Deno.core.print();
+  } catch (e) {
+    assert(e instanceof TypeError);
+    assert(e.message === "Invalid Argument");
+  }
+  try {
+    Deno.core.print(2, 3, 4);
+  } catch (e) {
     assert(e instanceof TypeError);
     assert(e.message === "Invalid Argument");
   }


### PR DESCRIPTION
I attempted to fix [#1725](https://github.com/denoland/deno/issues/1725).

For a good starting point, I choose to put ctrl-c signal stream in core/Isolate.rs and then I just tried to print something when a signal is captured, and to print something else otherwise - and that worked. Later I tried to just throw error in isolate when in case of ctrl-c signal and it produces an error

    ...
    hello
    ...
    ...
    ^C
    
    #
    # Fatal error in ../../third_party/v8/src/isolate.h, line 516
    # Debug check failed: (isolate) != nullptr.
    #
    #
    #
    #FailureMessage Object: 0x7f351b3ced00
    ==== C stack trace ===============================
        ./target/debug/deno(+0x425b393) [0x559c832e3393]
    ...

so it seems like isolate is gone while method `deno_print_stack_trace(Deno  * d_) `is called. I tested it with very simple script `setInterval(()=>console.log("hello"), 1000);`

I don't have an idea how to fix that. Anyone has?
