### PR TITLE
Rename powershell highlighting to shell

### DIFF
--- a/website/manual.md
+++ b/website/manual.md
@@ -101,7 +101,7 @@ curl -fsSL https://deno.land/x/install/install.sh | sh
 
 Using PowerShell:
 
-```powershell
+```shell
 iwr https://deno.land/x/install/install.ps1 -useb | iex
 ```
 


### PR DESCRIPTION
In the previous commit(https://github.com/denoland/deno/pull/1780#issuecomment-464067615), we removed support for PowerShell highlighting, which made the style ugly:

<img width="500" alt="" src="https://user-images.githubusercontent.com/359395/61435610-73bef500-a96b-11e9-98f5-4a151434a9cb.png">

In the manual, we used jsut only one PowerShell code `iwr https://deno.land/x/install/install.ps1 -useb | iex`, so we can change the highlight name from `powershell` to `shell`. It can implement the exact same highlighting style without loading an extra 6kb(ziped 2.93kb) js file.