### PR TITLE
fix timer's params length

### DIFF
--- a/js/timers.ts
+++ b/js/timers.ts
@@ -229,7 +229,7 @@ function setTimer(
 /** Sets a timer which executes a function once after the timer expires. */
 export function setTimeout(
   cb: (...args: Args) => void,
-  delay: number,
+  delay: number = 0,
   ...args: Args
 ): number {
   // @ts-ignore
@@ -240,7 +240,7 @@ export function setTimeout(
 /** Repeatedly calls a function , with a fixed time delay between each call. */
 export function setInterval(
   cb: (...args: Args) => void,
-  delay: number,
+  delay: number = 0,
   ...args: Args
 ): number {
   // @ts-ignore
@@ -261,10 +261,16 @@ function clearTimer(id: number): void {
   idMap.delete(timer.id);
 }
 
-export function clearTimeout(id: number): void {
+export function clearTimeout(id: number = 0): void {
+  if (id === 0) {
+    return;
+  }
   clearTimer(id);
 }
 
-export function clearInterval(id: number): void {
+export function clearInterval(id: number = 0): void {
+  if (id === 0) {
+    return;
+  }
   clearTimer(id);
 }

--- a/js/timers_test.ts
+++ b/js/timers_test.ts
@@ -249,6 +249,13 @@ test(function testFunctionName(): void {
   assertEquals(clearInterval.name, "clearInterval");
 });
 
+test(function testFunctionParamsLength(): void {
+  assertEquals(setTimeout.length, 1);
+  assertEquals(setInterval.length, 1);
+  assertEquals(clearTimeout.length, 0);
+  assertEquals(clearInterval.length, 0);
+});
+
 test(function clearTimeoutAndClearIntervalNotBeEquals(): void {
   assertNotEquals(clearTimeout, clearInterval);
 });


### PR DESCRIPTION
make web compatible

 length  |chrome | firefox
-|-| -|
`setTimeout.length` | 1 | 1
`setInterval.length` | 1 | 1
`clearTimeout.length` | 0 | 0
`clearInterval.length` | 0 | 0