### PR TITLE
REPL shouldn't crash when it gets SIGINT

### DIFF
--- a/cli/deno_error.rs
+++ b/cli/deno_error.rs
@@ -192,6 +192,7 @@ impl GetErrorKind for ReadlineError {
     match self {
       Io(err) => GetErrorKind::kind(err),
       Eof => ErrorKind::UnexpectedEof,
+      Interrupted => ErrorKind::Interrupted,
       #[cfg(unix)]
       Errno(err) => err.kind(),
       _ => unimplemented!(),


### PR DESCRIPTION
Fixes #2653 

I wasn't able to come up with a good test for this. tools/repl_test.py, I discovered isn't really testing the REPL exactly because the stdio pipes it sets up are not TTYs. So the test behavior is different than a real REPL session. I will address this later.