### PR TITLE
Fix expected dyn before `AnyError` trait

### DIFF
--- a/core/any_error.rs
+++ b/core/any_error.rs
@@ -43,7 +43,7 @@ impl AsRef<dyn AnyError> for ErrBox {
 }
 
 impl Deref for ErrBox {
-  type Target = Box<AnyError>;
+  type Target = Box<dyn AnyError>;
   fn deref(&self) -> &Self::Target {
     &self.0
   }


### PR DESCRIPTION
This isn't a problem of rust stable, but it causes issues on nightly.