### PR TITLE
Remove v8::Locker from deno_respond

### DIFF
--- a/core/libdeno/api.cc
+++ b/core/libdeno/api.cc
@@ -173,7 +173,6 @@ void deno_respond(Deno* d_, void* user_data, deno_buf buf) {
 
   // Asynchronous response.
   deno::UserDataScope user_data_scope(d, user_data);
-  v8::Locker locker(d->isolate_);
   v8::Isolate::Scope isolate_scope(d->isolate_);
   v8::HandleScope handle_scope(d->isolate_);
 


### PR DESCRIPTION
This looks unnecessary, but I'm not 100% sure.
