### PR TITLE
feat(website/benchmark): enable zoom of charts

### DIFF
--- a/website/app.ts
+++ b/website/app.ts
@@ -127,6 +127,7 @@ export function formatReqSec(reqPerSec) {
  * @param {function} onclick action on clicking nodes of chart
  * @param {string} yLabel label of y axis
  * @param {function} yTickFormat formatter of y axis ticks
+ * @param {boolean} zoomEnabled enables the zoom feature
  */
 function generate(
   id,
@@ -134,7 +135,8 @@ function generate(
   columns,
   onclick,
   yLabel = "",
-  yTickFormat = null
+  yTickFormat = null,
+  zoomEnabled = true
 ) {
   const yAxis = {
     padding: { bottom: 0 },
@@ -173,6 +175,9 @@ function generate(
         categories
       },
       y: yAxis
+    },
+    zoom: {
+      enabled: zoomEnabled
     }
   });
 }


### PR DESCRIPTION
This enables the zooming of charts of the benchmark page by mouse wheel (scrolling) event. It's a little slow when showing all benchmark data, but it still works.

closes #2666 
