### PR TITLE
Fix broken anchor link in manual

### DIFF
--- a/website/manual.md
+++ b/website/manual.md
@@ -776,7 +776,7 @@ tabs.
 
 It is a good practice to use `import.meta.main` idiom for an entry point for
 executable file. See
-[Testing if current file is the main program](#testing-if-current-file-is-the-main-program)
+[Testing if current file is the main program](#testingifcurrentfileisthemainprogram)
 section.
 
 Example:


### PR DESCRIPTION
Seems Showdown renders element IDs in all lowercase.

Could there exist some strategy that allows Showdown to render the anchor link destination URLs? That would be ideal.