### PR TITLE
fix: make --importmap flag global

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -100,16 +100,6 @@ fn add_run_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
       Arg::with_name("no-fetch")
         .long("no-fetch")
         .help("Do not download remote modules"),
-    ).arg(
-      Arg::with_name("importmap")
-        .long("importmap")
-        .value_name("FILE")
-        .help("Load import map file")
-        .long_help(
-          "Load import map file
-Specification: https://wicg.github.io/import-maps/
-Examples: https://github.com/WICG/import-maps#the-import-map",
-        ).takes_value(true),
     )
 }
 
@@ -160,6 +150,18 @@ To get help on the another subcommands (run in this case):
         .long("config")
         .value_name("FILE")
         .help("Load compiler configuration file")
+        .takes_value(true)
+        .global(true),
+    ).arg(
+      Arg::with_name("importmap")
+        .long("importmap")
+        .value_name("FILE")
+        .help("Load import map file")
+        .long_help(
+          "Load import map file
+Specification: https://wicg.github.io/import-maps/
+Examples: https://github.com/WICG/import-maps#the-import-map",
+        )
         .takes_value(true)
         .global(true),
     ).arg(
@@ -1347,6 +1349,22 @@ mod tests {
       }
     );
     assert_eq!(subcommand, DenoSubcommand::Run);
+    assert_eq!(argv, svec!["deno", "script.ts"]);
+
+    let (flags, subcommand, argv) = flags_from_vec(svec![
+      "deno",
+      "fetch",
+      "--importmap=importmap.json",
+      "script.ts"
+    ]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        import_map_path: Some("importmap.json".to_owned()),
+        ..DenoFlags::default()
+      }
+    );
+    assert_eq!(subcommand, DenoSubcommand::Fetch);
     assert_eq!(argv, svec!["deno", "script.ts"]);
   }
 

--- a/tests/036_import_map_fetch.test
+++ b/tests/036_import_map_fetch.test
@@ -1,0 +1,2 @@
+args: fetch --reload --importmap=tests/importmaps/import_map.json tests/importmaps/test.ts
+output: tests/036_import_map_fetch.out


### PR DESCRIPTION
Fixes #2685 

I exposed `--importmap` flag as global, so it can be used with all subcommands. 