### PR TITLE
benchmarks: make latency benchmark less noisy

### DIFF
--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -184,8 +184,8 @@ def run(server_cmd, addr, merge_env=None, origin_cmd=None):
     time.sleep(10)  # wait for server to wake up. TODO racy.
 
     try:
-        cmd = "third_party/wrk/%s/wrk -d %s http://%s/" % (util.platform(),
-                                                           DURATION, addr)
+        cmd = "third_party/wrk/%s/wrk -d %s --latency http://%s/" % (
+            util.platform(), DURATION, addr)
         print cmd
         output = subprocess.check_output(cmd, shell=True)
         stats = util.parse_wrk_output(output)

--- a/tools/testdata/wrk1.txt
+++ b/tools/testdata/wrk1.txt
@@ -3,6 +3,11 @@ Running 10s test @ http://127.0.0.1:4500/
   Thread Stats   Avg      Stdev     Max   +/- Stdev
     Latency     5.08ms    1.37ms  34.96ms   96.63%
     Req/Sec     0.92k    51.83     1.00k    78.50%
+  Latency Distribution
+     50%    1.96ms
+     75%    2.02ms
+     90%    2.43ms
+     99%    6.25ms
   18381 requests in 10.00s, 0.89MB read
   Socket errors: connect 0, read 18381, write 0, timeout 0
 Requests/sec:   1837.86

--- a/tools/testdata/wrk2.txt
+++ b/tools/testdata/wrk2.txt
@@ -3,6 +3,11 @@ Running 10s test @ http://127.0.0.1:4544/
   Thread Stats   Avg      Stdev     Max   +/- Stdev
     Latency   402.90us    1.15ms  1.25us   94.86%
     Req/Sec    26.86k     2.01k   31.81k    78.71%
+  Latency Distribution
+     50%    2.03ms
+     75%    2.10ms
+     90%    2.43ms
+     99%    6.22ms
   539721 requests in 10.10s, 26.25MB read
 Requests/sec:  53435.75
 Transfer/sec:      2.60MB

--- a/tools/testdata/wrk3.txt
+++ b/tools/testdata/wrk3.txt
@@ -3,6 +3,11 @@ Running 10s test @ http://127.0.0.1:4544/
   Thread Stats   Avg      Stdev     Max   +/- Stdev
     Latency    26.55ms  152.26ms   1.63s    97.45%
     Req/Sec    48.26k     3.13k   61.41k    93.00%
+  Latency Distribution
+     50%    1.98ms
+     75%    2.06ms
+     90%    2.47ms
+     99%    6.36ms
   960491 requests in 10.00s, 80.61MB read
 Requests/sec:  96037.58
 Transfer/sec:      8.06MB

--- a/tools/util.py
+++ b/tools/util.py
@@ -384,7 +384,7 @@ def parse_wrk_output(output):
                                                   line)
         if stats['max_latency'] is None:
             stats['max_latency'] = extract_max_latency_in_milliseconds(
-                r'Latency(?:\s+(\d+.\d+)([a-z]+)){3}', line)
+                r'\s+90%(?:\s+(\d+.\d+)([a-z]+))', line)
     return stats
 
 

--- a/tools/util.py
+++ b/tools/util.py
@@ -384,7 +384,7 @@ def parse_wrk_output(output):
                                                   line)
         if stats['max_latency'] is None:
             stats['max_latency'] = extract_max_latency_in_milliseconds(
-                r'\s+90%(?:\s+(\d+.\d+)([a-z]+))', line)
+                r'\s+99%(?:\s+(\d+.\d+)([a-z]+))', line)
     return stats
 
 

--- a/tools/util_test.py
+++ b/tools/util_test.py
@@ -49,17 +49,17 @@ class TestUtil(DenoTestCase):
         f = open(os.path.join(root_path, "tools/testdata/wrk1.txt"))
         stats = parse_wrk_output(f.read())
         assert stats['req_per_sec'] == 1837
-        assert stats['max_latency'] == 2.43
+        assert stats['max_latency'] == 6.25
 
         f2 = open(os.path.join(root_path, "tools/testdata/wrk2.txt"))
         stats2 = parse_wrk_output(f2.read())
         assert stats2['req_per_sec'] == 53435
-        assert stats2['max_latency'] == 2.43
+        assert stats2['max_latency'] == 6.22
 
         f3 = open(os.path.join(root_path, "tools/testdata/wrk3.txt"))
         stats3 = parse_wrk_output(f3.read())
         assert stats3['req_per_sec'] == 96037
-        assert stats3['max_latency'] == 2.47
+        assert stats3['max_latency'] == 6.36
 
 
 if __name__ == '__main__':

--- a/tools/util_test.py
+++ b/tools/util_test.py
@@ -49,17 +49,17 @@ class TestUtil(DenoTestCase):
         f = open(os.path.join(root_path, "tools/testdata/wrk1.txt"))
         stats = parse_wrk_output(f.read())
         assert stats['req_per_sec'] == 1837
-        assert stats['max_latency'] == 34.96
+        assert stats['max_latency'] == 2.43
 
         f2 = open(os.path.join(root_path, "tools/testdata/wrk2.txt"))
         stats2 = parse_wrk_output(f2.read())
         assert stats2['req_per_sec'] == 53435
-        assert stats2['max_latency'] == 0.00125
+        assert stats2['max_latency'] == 2.43
 
         f3 = open(os.path.join(root_path, "tools/testdata/wrk3.txt"))
         stats3 = parse_wrk_output(f3.read())
         assert stats3['req_per_sec'] == 96037
-        assert stats3['max_latency'] == 1630.0
+        assert stats3['max_latency'] == 2.47
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #2566 

With this change we're tracking 90th percentile of latency.

I did not rename stat field (it's still `max_latency`) but if you want it renamed @ry let me know.