### PR TITLE
feat: add debug info to ModuleResolutionError

### DIFF
--- a/cli/deno_error.rs
+++ b/cli/deno_error.rs
@@ -118,8 +118,8 @@ impl GetErrorKind for ModuleResolutionError {
     use ModuleResolutionError::*;
     match self {
       InvalidUrl(ref err) | InvalidBaseUrl(ref err) => err.kind(),
-      InvalidPath(ref _p) => ErrorKind::InvalidPath,
-      ImportPrefixMissing => ErrorKind::ImportPrefixMissing,
+      InvalidPath(_) => ErrorKind::InvalidPath,
+      ImportPrefixMissing(_) => ErrorKind::ImportPrefixMissing,
     }
   }
 }

--- a/cli/deno_error.rs
+++ b/cli/deno_error.rs
@@ -118,7 +118,7 @@ impl GetErrorKind for ModuleResolutionError {
     use ModuleResolutionError::*;
     match self {
       InvalidUrl(ref err) | InvalidBaseUrl(ref err) => err.kind(),
-      InvalidPath => ErrorKind::InvalidPath,
+      InvalidPath(ref _p) => ErrorKind::InvalidPath,
       ImportPrefixMissing => ErrorKind::ImportPrefixMissing,
     }
   }

--- a/core/module_specifier.rs
+++ b/core/module_specifier.rs
@@ -413,7 +413,7 @@ mod tests {
     ];
     if cfg!(target_os = "windows") {
       let p = r"\\.\c:/stuff/deno/script.ts";
-      tests.push((p.clone(), InvalidPath(PathBuf::from(p))));
+      tests.push((p, InvalidPath(PathBuf::from(p))));
     }
 
     for (specifier, expected_err) in tests {

--- a/tests/error_011_bad_module_specifier.ts.out
+++ b/tests/error_011_bad_module_specifier.ts.out
@@ -1,4 +1,4 @@
-[WILDCARD]error: Uncaught ImportPrefixMissing: relative import path not prefixed with / or ./ or ../
+[WILDCARD]error: Uncaught ImportPrefixMissing: relative import path "bad-module.ts" not prefixed with / or ./ or ../
 [WILDCARD] js/errors.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
     at maybeError (js/errors.ts:[WILDCARD])

--- a/tests/error_012_bad_dynamic_import_specifier.ts.out
+++ b/tests/error_012_bad_dynamic_import_specifier.ts.out
@@ -1,4 +1,4 @@
-[WILDCARD]error: Uncaught ImportPrefixMissing: relative import path not prefixed with / or ./ or ../
+[WILDCARD]error: Uncaught ImportPrefixMissing: relative import path "bad-module.ts" not prefixed with / or ./ or ../
 [WILDCARD] js/errors.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
     at maybeError (js/errors.ts:[WILDCARD])


### PR DESCRIPTION
A little ergonomic change, with it should be easier to spot bad imports.

Before:
```
Compile file:///Users/biwanczuk/dev/deno/tests/error_011_bad_module_specifier.ts
error: Uncaught ImportPrefixMissing: relative import path not prefixed with / or ./ or ../
...snip...
```

After:
```
Compile file:///Users/biwanczuk/dev/deno/tests/error_011_bad_module_specifier.ts
error: Uncaught ImportPrefixMissing: relative import path "bad-module.rs" not prefixed with / or ./ or ../
...snip...
```

Also closes #2402