### PR TITLE
Fix for tests in #2675

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
   - CARGO_HOME=$TRAVIS_BUILD_DIR/third_party/rust_crates/
   - RUSTUP_HOME=$HOME/.rustup/
   - RUST_BACKTRACE=full
-  - CARGO_TARGET_DIR=$HOME/target
   - PATH=$TRAVIS_BUILD_DIR/third_party/llvm-build/Release+Asserts/bin:$CARGO_HOME/bin:$PATH
   - PYTHONPATH=third_party/python_packages
   - RUSTC_WRAPPER=sccache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "cargo_gn"
 version = "0.0.13"
-source = "git+https://github.com/afinch7/cargo_gn?branch=ninja_env#fe11059d112acc5ca3a1688233507d25d322669d"
+source = "git+https://github.com/afinch7/cargo_gn?branch=ninja_env#7639477242cbe35d2cb37a317b0ce8e2f063f246"
 
 [[package]]
 name = "cc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,8 +113,8 @@ dependencies = [
 
 [[package]]
 name = "cargo_gn"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.0.13"
+source = "git+https://github.com/afinch7/cargo_gn?branch=ninja_env#fe11059d112acc5ca3a1688233507d25d322669d"
 
 [[package]]
 name = "cc"
@@ -204,7 +204,7 @@ dependencies = [
 name = "deno"
 version = "0.12.0"
 dependencies = [
- "cargo_gn 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_gn 0.0.13 (git+https://github.com/afinch7/cargo_gn?branch=ninja_env)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -221,7 +221,7 @@ version = "0.12.0"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo_gn 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_gn 0.0.13 (git+https://github.com/afinch7/cargo_gn?branch=ninja_env)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deno 0.12.0",
  "dirs 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1564,7 +1564,7 @@ dependencies = [
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-"checksum cargo_gn 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "a34c50fb2ca26fb832617113c1123284ff4641be3407f60c4619876024606c5a"
+"checksum cargo_gn 0.0.13 (git+https://github.com/afinch7/cargo_gn?branch=ninja_env)" = "<none>"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,8 +113,8 @@ dependencies = [
 
 [[package]]
 name = "cargo_gn"
-version = "0.0.10"
-source = "git+https://github.com/denoland/cargo_gn#5565d5dfa977942dda29eb829ee451fd2acca2bc"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
@@ -204,7 +204,7 @@ dependencies = [
 name = "deno"
 version = "0.12.0"
 dependencies = [
- "cargo_gn 0.0.10 (git+https://github.com/denoland/cargo_gn)",
+ "cargo_gn 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -221,7 +221,7 @@ version = "0.12.0"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo_gn 0.0.10 (git+https://github.com/denoland/cargo_gn)",
+ "cargo_gn 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deno 0.12.0",
  "dirs 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1564,7 +1564,7 @@ dependencies = [
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-"checksum cargo_gn 0.0.10 (git+https://github.com/denoland/cargo_gn)" = "<none>"
+"checksum cargo_gn 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "a34c50fb2ca26fb832617113c1123284ff4641be3407f60c4619876024606c5a"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "cargo_gn"
 version = "0.0.13"
-source = "git+https://github.com/afinch7/cargo_gn?branch=ninja_env#7639477242cbe35d2cb37a317b0ce8e2f063f246"
+source = "git+https://github.com/denoland/cargo_gn#c2cb9d3913fde7a9aee794bd4de2c7109a3c2617"
 
 [[package]]
 name = "cc"
@@ -204,7 +204,7 @@ dependencies = [
 name = "deno"
 version = "0.12.0"
 dependencies = [
- "cargo_gn 0.0.13 (git+https://github.com/afinch7/cargo_gn?branch=ninja_env)",
+ "cargo_gn 0.0.13 (git+https://github.com/denoland/cargo_gn)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -221,7 +221,7 @@ version = "0.12.0"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo_gn 0.0.13 (git+https://github.com/afinch7/cargo_gn?branch=ninja_env)",
+ "cargo_gn 0.0.13 (git+https://github.com/denoland/cargo_gn)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deno 0.12.0",
  "dirs 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1564,7 +1564,7 @@ dependencies = [
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-"checksum cargo_gn 0.0.13 (git+https://github.com/afinch7/cargo_gn?branch=ninja_env)" = "<none>"
+"checksum cargo_gn 0.0.13 (git+https://github.com/denoland/cargo_gn)" = "<none>"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -61,7 +61,7 @@ fwdansi = "1.0.1"
 nix = "0.13.x"
 
 [build-dependencies]
-cargo_gn = { git = "https://github.com/afinch7/cargo_gn", branch = "ninja_env" }
+cargo_gn = { git = "https://github.com/denoland/cargo_gn" }
 # To avoid building V8 twice, we make sure that the core crate is built before
 # cli starts building.
 deno = { path = "../core" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -61,7 +61,7 @@ fwdansi = "1.0.1"
 nix = "0.13.x"
 
 [build-dependencies]
-cargo_gn = "0.0.12"
+cargo_gn = { git = "https://github.com/afinch7/cargo_gn", branch = "ninja_env" }
 # To avoid building V8 twice, we make sure that the core crate is built before
 # cli starts building.
 deno = { path = "../core" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -61,7 +61,7 @@ fwdansi = "1.0.1"
 nix = "0.13.x"
 
 [build-dependencies]
-cargo_gn = { git = "https://github.com/denoland/cargo_gn" }
+cargo_gn = "0.0.12"
 # To avoid building V8 twice, we make sure that the core crate is built before
 # cli starts building.
 deno = { path = "../core" }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -4,6 +4,6 @@ include!("../tools/build_common.rs");
 
 fn main() {
   // TODO(ry) When running "cargo check" only build "msg_rs"
-  setup();
-  cargo_gn::build("cli:deno_deps");
+  let (_, ninja_env) = setup();
+  cargo_gn::build("cli:deno_deps", ninja_env);
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,5 +34,5 @@ path = "examples/http_bench.rs"
 tokio = "0.1.18"
 
 [build-dependencies]
-cargo_gn = "0.0.12"
+cargo_gn = { git = "https://github.com/afinch7/cargo_gn", branch = "ninja_env" }
 which = "2.0.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,5 +34,5 @@ path = "examples/http_bench.rs"
 tokio = "0.1.18"
 
 [build-dependencies]
-cargo_gn = { git = "https://github.com/afinch7/cargo_gn", branch = "ninja_env" }
+cargo_gn = { git = "https://github.com/denoland/cargo_gn" }
 which = "2.0.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,5 +34,5 @@ path = "examples/http_bench.rs"
 tokio = "0.1.18"
 
 [build-dependencies]
-cargo_gn = { git = "https://github.com/denoland/cargo_gn" }
+cargo_gn = "0.0.12"
 which = "2.0.1"

--- a/core/build.rs
+++ b/core/build.rs
@@ -2,8 +2,8 @@
 // Run "cargo build -vv" if you want to see gn output.
 include!("../tools/build_common.rs");
 fn main() {
-  let gn_out_path = setup();
-  cargo_gn::build("core:deno_core_deps");
+  let (gn_out_path, ninja_env) = setup();
+  cargo_gn::build("core:deno_core_deps", ninja_env);
 
   let d = gn_out_path.join("obj/core/libdeno/");
   println!("cargo:rustc-link-search=native={}", d.display());

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -58,25 +58,36 @@ def import_data_from_gh_pages():
         write_json(all_data_file, [])  # writes empty json data
 
 
+def is_gn_build(build_dir):
+    # TODO(afinch7) maybe find a better check for this?
+    return os.path.exists(
+        os.path.join(build_dir, "cli_test" + executable_suffix))
+
+
 def get_binary_sizes(build_dir):
+    path_prefix = "gn_out/gen"
+    if is_gn_build(build_dir):
+        path_prefix = "gen"
+
     path_dict = {
         "deno":
         os.path.join(build_dir, "deno" + executable_suffix),
         "main.js":
-        os.path.join(build_dir, "gen/cli/bundle/main.js"),
+        os.path.join(build_dir, path_prefix + "/cli/bundle/main.js"),
         "main.js.map":
-        os.path.join(build_dir, "gen/cli/bundle/main.js.map"),
+        os.path.join(build_dir, path_prefix + "/cli/bundle/main.js.map"),
         "compiler.js":
-        os.path.join(build_dir, "gen/cli/bundle/compiler.js"),
+        os.path.join(build_dir, path_prefix + "/cli/bundle/compiler.js"),
         "compiler.js.map":
-        os.path.join(build_dir, "gen/cli/bundle/compiler.js.map"),
+        os.path.join(build_dir, path_prefix + "/cli/bundle/compiler.js.map"),
         "snapshot_deno.bin":
-        os.path.join(build_dir, "gen/cli/snapshot_deno.bin"),
+        os.path.join(build_dir, path_prefix + "/cli/snapshot_deno.bin"),
         "snapshot_compiler.bin":
-        os.path.join(build_dir, "gen/cli/snapshot_compiler.bin")
+        os.path.join(build_dir, path_prefix + "/cli/snapshot_compiler.bin")
     }
     sizes = {}
     for name, path in path_dict.items():
+        print path
         assert os.path.exists(path)
         sizes[name] = os.path.getsize(path)
     return sizes

--- a/tools/build_common.rs
+++ b/tools/build_common.rs
@@ -35,7 +35,8 @@ fn setup() -> PathBuf {
   match which("sccache") {
     Ok(sccache_path) => {
       gn_args.push(("cc_wapper".to_string(), format!("{:?}", sccache_path)));
-      gn_args.push(("rustc_wrapper".to_string(), format!("{:?}", sccache_path)));
+      gn_args
+        .push(("rustc_wrapper".to_string(), format!("{:?}", sccache_path)));
     }
     Err(_) => {}
   }

--- a/tools/build_common.rs
+++ b/tools/build_common.rs
@@ -17,7 +17,7 @@ fn binary_downloads() {
 
 // This is essentially a re-write of the original tools/setup.py
 // but in rust.
-fn setup() -> (PathBuf, cargo_gn::NinjaEnv) {
+fn setup() -> (PathBuf, Option<cargo_gn::NinjaEnv>) {
   let is_debug = cargo_gn::is_debug();
   let mut gn_args: cargo_gn::GnArgs = Vec::new();
   if is_debug {
@@ -55,8 +55,8 @@ fn setup() -> (PathBuf, cargo_gn::NinjaEnv) {
     .canonicalize()
     .unwrap();
 
-  let ninja_env: cargo_gn::NinjaEnv = if !cfg!(target_os = "windows") {
-    Vec::new()
+  let ninja_env: Option<cargo_gn::NinjaEnv> = if !cfg!(target_os = "windows") {
+    None
   } else {
     // Windows needs special configuration. This is similar to the function of
     // python_env() in //tools/util.py.
@@ -84,7 +84,7 @@ fn setup() -> (PathBuf, cargo_gn::NinjaEnv) {
     env.push(("PYTHONPATH".to_string(), python_path.join(";")));
     env.push(("PATH".to_string(), path + &orig_path));
     env.push(("DEPOT_TOOLS_WIN_TOOLCHAIN".to_string(), "0".to_string()));
-    env
+    Some(env)
   };
 
   (cargo_gn::maybe_gen("..", gn_args), ninja_env)


### PR DESCRIPTION
This patch mainly removes `CARGO_TARGET_DIR` from the travis config. This should allow tests to run successfully in the travis cargo build.

ref #2675 