### PR TITLE
Use system rustfmt instead of fixed binary

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -162,8 +162,9 @@ install:
           "$env:RUSTUP_HOME\tmp",
           "$env:RUSTUP_HOME\toolchains\stable-x86_64-pc-windows-msvc\share\doc"
         )
-        Exec { rustup component add clippy }
       }
+      Exec { rustup component add clippy }
+      Exec { rustup component add rustfmt }
 
   # Log installed Node.js version + processor architecture.
   - node -p "`Node ${process.version} ${process.arch}`"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,9 @@ install:
     curl -sSf https://sh.rustup.rs | sh -s -- -y \
       --default-toolchain $RUST_VERSION
     rustup default $RUST_VERSION
-    rustup component add clippy
   fi
+  rustup component add clippy
+  rustup component add rustfmt
   rustc --version
   cargo --version
 - |-

--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -96,7 +96,8 @@ impl CompilerConfig {
         DenoError::new(
           ErrorKind::InvalidInput,
           "Compiler config is not a valid JSON".to_string(),
-        ).into(),
+        )
+        .into(),
       ),
     }
   }
@@ -153,15 +154,15 @@ fn req(
 ) -> Buf {
   let j = match (compiler_config.path, compiler_config.content) {
     (Some(config_path), Some(config_data)) => json!({
-        "rootNames": root_names,
-        "bundle": bundle,
-        "configPath": config_path,
-        "config": str::from_utf8(&config_data).unwrap(),
-      }),
+      "rootNames": root_names,
+      "bundle": bundle,
+      "configPath": config_path,
+      "config": str::from_utf8(&config_data).unwrap(),
+    }),
     _ => json!({
-        "rootNames": root_names,
-        "bundle": bundle,
-      }),
+      "rootNames": root_names,
+      "bundle": bundle,
+    }),
   };
 
   j.to_string().into_boxed_str().into_boxed_bytes()
@@ -410,7 +411,8 @@ impl TsCompiler {
         }
 
         Ok(())
-      }).and_then(move |_| {
+      })
+      .and_then(move |_| {
         // if we are this far it means compilation was successful and we can
         // load compiled filed from disk
         state_
@@ -420,12 +422,14 @@ impl TsCompiler {
             // TODO: this situation shouldn't happen
             panic!("Expected to find compiled file: {}", e)
           })
-      }).and_then(move |compiled_module| {
+      })
+      .and_then(move |compiled_module| {
         // Explicit drop to keep reference alive until future completes.
         drop(compiling_job);
 
         Ok(compiled_module)
-      }).then(move |r| {
+      })
+      .then(move |r| {
         debug!(">>>>> compile_sync END");
         // TODO(ry) do this in worker's destructor.
         // resource.close();
@@ -685,12 +689,10 @@ mod tests {
         .ts_compiler
         .compile_sync(mock_state.clone(), &out)
         .unwrap();
-      assert!(
-        compiled
-          .code
-          .as_bytes()
-          .starts_with("console.log(\"Hello World\");".as_bytes())
-      );
+      assert!(compiled
+        .code
+        .as_bytes()
+        .starts_with("console.log(\"Hello World\");".as_bytes()));
     })
   }
 

--- a/cli/dispatch_minimal.rs
+++ b/cli/dispatch_minimal.rs
@@ -137,7 +137,9 @@ mod ops {
     debug!("read rid={}", rid);
     let zero_copy = match zero_copy {
       None => {
-        return Box::new(futures::future::err(deno_error::no_buffer_specified()))
+        return Box::new(
+          futures::future::err(deno_error::no_buffer_specified()),
+        )
       }
       Some(buf) => buf,
     };
@@ -155,7 +157,9 @@ mod ops {
     debug!("write rid={}", rid);
     let zero_copy = match zero_copy {
       None => {
-        return Box::new(futures::future::err(deno_error::no_buffer_specified()))
+        return Box::new(
+          futures::future::err(deno_error::no_buffer_specified()),
+        )
       }
       Some(buf) => buf,
     };

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -135,14 +135,16 @@ impl SourceFileFetcher {
         &module_url,
         self.use_disk_cache,
         self.no_remote_fetch,
-      ).then(move |result| {
+      )
+      .then(move |result| {
         let mut out = result.map_err(|err| {
           if err.kind() == ErrorKind::NotFound {
             // For NotFound, change the message to something better.
             DenoError::new(
               ErrorKind::NotFound,
               format!("Cannot resolve module \"{}\"", module_url.to_string()),
-            ).into()
+            )
+            .into()
           } else {
             err
           }
@@ -329,7 +331,8 @@ impl SourceFileFetcher {
             "cannot find remote file '{}' in cache",
             module_url.to_string()
           ),
-        ).into(),
+        )
+        .into(),
       ));
     }
 
@@ -353,7 +356,8 @@ impl SourceFileFetcher {
               &module_url,
               None,
               Some(new_module_url.to_string()),
-            ).unwrap();
+            )
+            .unwrap();
 
           // Explicit drop to keep reference alive until future completes.
           drop(download_job);
@@ -373,7 +377,8 @@ impl SourceFileFetcher {
               &module_url,
               maybe_content_type.clone(),
               None,
-            ).unwrap();
+            )
+            .unwrap();
 
           dir.save_source_code(&module_url, &source).unwrap();
 
@@ -651,7 +656,8 @@ mod tests {
       Progress::new(),
       true,
       false,
-    ).expect("setup fail")
+    )
+    .expect("setup fail")
   }
 
   fn test_setup() -> (TempDir, SourceFileFetcher) {
@@ -771,11 +777,9 @@ mod tests {
       // If get_source_file does not call remote, this should be JavaScript
       // as we modified before! (we do not overwrite .headers.json due to no http fetch)
       assert_eq!(&(r3.media_type), &msg::MediaType::Json);
-      assert!(
-        fs::read_to_string(&headers_file_name)
-          .unwrap()
-          .contains("application/json")
-      );
+      assert!(fs::read_to_string(&headers_file_name)
+        .unwrap()
+        .contains("application/json"));
 
       // let's create fresh instance of DenoDir (simulating another freshh Deno process)
       // and don't use cache
@@ -865,7 +869,8 @@ mod tests {
     tokio_util::init(|| {
       let specifier = ModuleSpecifier::resolve_url(
         "http://localhost:4545/tests/subdir/mismatch_ext.ts",
-      ).unwrap();
+      )
+      .unwrap();
       let headers_file_name = fetcher.deps_cache.location.join(
         fetcher.deps_cache.get_cache_filename_with_extension(
           specifier.as_url(),

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1,11 +1,11 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+use crate::fs as deno_fs;
 use clap::App;
 use clap::AppSettings;
 use clap::Arg;
 use clap::ArgMatches;
 use clap::Shell;
 use clap::SubCommand;
-use crate::fs as deno_fs;
 use deno::ModuleSpecifier;
 use log::Level;
 use std;
@@ -61,7 +61,8 @@ fn add_run_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         .use_delimiter(true)
         .require_equals(true)
         .help("Allow file system read access"),
-    ).arg(
+    )
+    .arg(
       Arg::with_name("allow-write")
         .long("allow-write")
         .min_values(0)
@@ -69,7 +70,8 @@ fn add_run_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         .use_delimiter(true)
         .require_equals(true)
         .help("Allow file system write access"),
-    ).arg(
+    )
+    .arg(
       Arg::with_name("allow-net")
         .long("allow-net")
         .min_values(0)
@@ -77,28 +79,34 @@ fn add_run_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         .use_delimiter(true)
         .require_equals(true)
         .help("Allow network access"),
-    ).arg(
+    )
+    .arg(
       Arg::with_name("allow-env")
         .long("allow-env")
         .help("Allow environment access"),
-    ).arg(
+    )
+    .arg(
       Arg::with_name("allow-run")
         .long("allow-run")
         .help("Allow running subprocesses"),
-    ).arg(
+    )
+    .arg(
       Arg::with_name("allow-hrtime")
         .long("allow-hrtime")
         .help("Allow high resolution time measurement"),
-    ).arg(
+    )
+    .arg(
       Arg::with_name("allow-all")
         .short("A")
         .long("allow-all")
         .help("Allow all permissions"),
-    ).arg(
+    )
+    .arg(
       Arg::with_name("no-prompt")
         .long("no-prompt")
         .help("Do not use prompts"),
-    ).arg(
+    )
+    .arg(
       Arg::with_name("no-fetch")
         .long("no-fetch")
         .help("Do not download remote modules"),

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -69,7 +69,8 @@ pub fn make_temp_dir(
   let mut buf: PathBuf = match dir {
     Some(ref p) => p.to_path_buf(),
     None => std::env::temp_dir(),
-  }.join("_");
+  }
+  .join("_");
   let mut rng = rand::thread_rng();
   loop {
     let unique = rng.gen::<u32>();

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -170,12 +170,14 @@ pub fn fetch_string(
             DenoError::new(
               deno_error::ErrorKind::NotFound,
               "module not found".to_string(),
-            ).into(),
+            )
+            .into(),
           );
         }
         Ok(Loop::Break(response))
       })
-  }).and_then(|response| {
+  })
+  .and_then(|response| {
     let content_type = response
       .headers()
       .get(CONTENT_TYPE)
@@ -186,7 +188,8 @@ pub fn fetch_string(
       .map(|body| String::from_utf8(body.to_vec()).unwrap())
       .map_err(ErrBox::from);
     body.join(future::ok(content_type))
-  }).and_then(|(body_string, maybe_content_type)| {
+  })
+  .and_then(|(body_string, maybe_content_type)| {
     future::ok((body_string, maybe_content_type.unwrap()))
   })
 }

--- a/cli/import_map.rs
+++ b/cli/import_map.rs
@@ -488,22 +488,20 @@ mod tests {
 
     // invalid schema: 'imports' is non-object
     for non_object in non_object_strings.to_vec() {
-      assert!(
-        ImportMap::from_json(
-          base_url,
-          &format!("{{\"imports\": {}}}", non_object),
-        ).is_err()
-      );
+      assert!(ImportMap::from_json(
+        base_url,
+        &format!("{{\"imports\": {}}}", non_object),
+      )
+      .is_err());
     }
 
     // invalid schema: 'scopes' is non-object
     for non_object in non_object_strings.to_vec() {
-      assert!(
-        ImportMap::from_json(
-          base_url,
-          &format!("{{\"scopes\": {}}}", non_object),
-        ).is_err()
-      );
+      assert!(ImportMap::from_json(
+        base_url,
+        &format!("{{\"scopes\": {}}}", non_object),
+      )
+      .is_err());
     }
   }
 
@@ -756,11 +754,9 @@ mod tests {
     let import_map =
       ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
         .unwrap();
-    assert!(
-      import_map
-        .scopes
-        .contains_key("https://base.example/path1/path2/foo")
-    );
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo"));
 
     // Should work with ./, ../, and / prefixes..
     let json_map = r#"{
@@ -773,16 +769,12 @@ mod tests {
     let import_map =
       ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
         .unwrap();
-    assert!(
-      import_map
-        .scopes
-        .contains_key("https://base.example/path1/path2/foo")
-    );
-    assert!(
-      import_map
-        .scopes
-        .contains_key("https://base.example/path1/foo")
-    );
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo"));
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/foo"));
     assert!(import_map.scopes.contains_key("https://base.example/foo"));
 
     // Should work with /s, ?s, and #s..
@@ -794,11 +786,9 @@ mod tests {
     let import_map =
       ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
         .unwrap();
-    assert!(
-      import_map
-        .scopes
-        .contains_key("https://base.example/path1/path2/foo/bar?baz#qux")
-    );
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo/bar?baz#qux"));
 
     // Should work with an empty string scope key..
     let json_map = r#"{
@@ -809,11 +799,9 @@ mod tests {
     let import_map =
       ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
         .unwrap();
-    assert!(
-      import_map
-        .scopes
-        .contains_key("https://base.example/path1/path2/path3")
-    );
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/path3"));
 
     // Should work with / suffixes..
     let json_map = r#"{
@@ -828,21 +816,15 @@ mod tests {
     let import_map =
       ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
         .unwrap();
-    assert!(
-      import_map
-        .scopes
-        .contains_key("https://base.example/path1/path2/foo/")
-    );
-    assert!(
-      import_map
-        .scopes
-        .contains_key("https://base.example/path1/path2/foo/")
-    );
-    assert!(
-      import_map
-        .scopes
-        .contains_key("https://base.example/path1/foo/")
-    );
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo/"));
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo/"));
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/foo/"));
     assert!(import_map.scopes.contains_key("https://base.example/foo/"));
     assert!(import_map.scopes.contains_key("https://base.example/foo//"));
 
@@ -857,11 +839,9 @@ mod tests {
     let import_map =
       ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
         .unwrap();
-    assert!(
-      import_map
-        .scopes
-        .contains_key("https://base.example/path1/path2/foo//")
-    );
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo//"));
     assert_eq!(import_map.scopes.len(), 1);
   }
 
@@ -909,11 +889,9 @@ mod tests {
       ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
         .unwrap();
     // tricky case! remember we have a base URL
-    assert!(
-      import_map
-        .scopes
-        .contains_key("https://base.example/path1/path2/example.org")
-    );
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/example.org"));
     assert!(import_map.scopes.contains_key("https://example.com///"));
     assert!(import_map.scopes.contains_key("https://example.net/"));
     assert!(import_map.scopes.contains_key("https://example.com/foo/"));
@@ -1245,7 +1223,8 @@ mod tests {
       let import_map = ImportMap::from_json(
         "https://base.example/path1/path2/path3",
         &json_map.to_string(),
-      ).unwrap();
+      )
+      .unwrap();
 
       assert!(import_map.imports.get("foo").unwrap().is_empty());
     }
@@ -1370,21 +1349,15 @@ mod tests {
     assert!(import_map.resolve("%2E/foo", referrer_url).is_err());
     assert!(import_map.resolve("%2E%2Efoo", referrer_url).is_err());
     assert!(import_map.resolve(".%2Efoo", referrer_url).is_err());
-    assert!(
-      import_map
-        .resolve("https://ex ample.org", referrer_url)
-        .is_err()
-    );
-    assert!(
-      import_map
-        .resolve("https://example.org:deno", referrer_url)
-        .is_err()
-    );
-    assert!(
-      import_map
-        .resolve("https://[example.org]", referrer_url)
-        .is_err()
-    );
+    assert!(import_map
+      .resolve("https://ex ample.org", referrer_url)
+      .is_err());
+    assert!(import_map
+      .resolve("https://example.org:deno", referrer_url)
+      .is_err());
+    assert!(import_map
+      .resolve("https://[example.org]", referrer_url)
+      .is_err());
   }
 
   #[test]
@@ -1512,11 +1485,9 @@ mod tests {
     );
 
     // Should fail for attempting to get a submodule of something not declared with a trailing slash.
-    assert!(
-      import_map
-        .resolve("not-a-package/foo", referrer_url)
-        .is_err()
-    );
+    assert!(import_map
+      .resolve("not-a-package/foo", referrer_url)
+      .is_err());
   }
 
   #[test]
@@ -1575,28 +1546,20 @@ mod tests {
     );
 
     // Should fail for URLs that remap to empty arrays.
-    assert!(
-      import_map
-        .resolve("https://example.com/lib/no.mjs", referrer_url)
-        .is_err()
-    );
+    assert!(import_map
+      .resolve("https://example.com/lib/no.mjs", referrer_url)
+      .is_err());
     assert!(import_map.resolve("/lib/no.mjs", referrer_url).is_err());
     assert!(import_map.resolve("../lib/no.mjs", referrer_url).is_err());
-    assert!(
-      import_map
-        .resolve("https://example.com/app/dotrelative/no.mjs", referrer_url)
-        .is_err()
-    );
-    assert!(
-      import_map
-        .resolve("/app/dotrelative/no.mjs", referrer_url)
-        .is_err()
-    );
-    assert!(
-      import_map
-        .resolve("../app/dotrelative/no.mjs", referrer_url)
-        .is_err()
-    );
+    assert!(import_map
+      .resolve("https://example.com/app/dotrelative/no.mjs", referrer_url)
+      .is_err());
+    assert!(import_map
+      .resolve("/app/dotrelative/no.mjs", referrer_url)
+      .is_err());
+    assert!(import_map
+      .resolve("../app/dotrelative/no.mjs", referrer_url)
+      .is_err());
 
     // Should remap URLs that are just composed from / and ..
     assert_resolve(

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -131,7 +131,8 @@ pub fn print_file_info(
           debug!("compiler error exiting!");
           eprintln!("\n{}", e.to_string());
           std::process::exit(1);
-        }).and_then(move |compiled| {
+        })
+        .and_then(move |compiled| {
           if out.media_type == msg::MediaType::TypeScript
             || (out.media_type == msg::MediaType::JavaScript
               && state_.ts_compiler.compile_js)
@@ -236,7 +237,8 @@ fn fetch_or_info_command(
         } else {
           future::Either::B(future::ok(worker))
         }
-      }).and_then(|worker| {
+      })
+      .and_then(|worker| {
         worker.then(|result| {
           js_check(result);
           Ok(())
@@ -290,7 +292,8 @@ fn xeval_command(flags: DenoFlags, argv: Vec<String>) {
       .then(|result| {
         js_check(result);
         Ok(())
-      }).map_err(print_err_and_exit)
+      })
+      .map_err(print_err_and_exit)
   });
   tokio_util::run(main_future);
 }
@@ -309,7 +312,8 @@ fn bundle_command(flags: DenoFlags, argv: Vec<String>) {
       debug!("diagnostics returned, exiting!");
       eprintln!("");
       print_err_and_exit(err);
-    }).and_then(move |_| {
+    })
+    .and_then(move |_| {
       debug!(">>>>> bundle_async END");
       Ok(())
     });
@@ -327,7 +331,8 @@ fn run_repl(flags: DenoFlags, argv: Vec<String>) {
       .then(|result| {
         js_check(result);
         Ok(())
-      }).map_err(|(err, _worker): (ErrBox, Worker)| print_err_and_exit(err))
+      })
+      .map_err(|(err, _worker): (ErrBox, Worker)| print_err_and_exit(err))
   });
   tokio_util::run(main_future);
 }
@@ -351,7 +356,8 @@ fn run_script(flags: DenoFlags, argv: Vec<String>) {
           js_check(result);
           Ok(())
         })
-      }).map_err(print_err_and_exit)
+      })
+      .map_err(print_err_and_exit)
   });
 
   if use_current_thread {

--- a/cli/msg.rs
+++ b/cli/msg.rs
@@ -1,9 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 #![allow(dead_code)]
-#![cfg_attr(
-  feature = "cargo-clippy",
-  allow(clippy::all, clippy::pedantic)
-)]
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::all, clippy::pedantic))]
 use crate::state;
 use flatbuffers;
 use std::sync::atomic::Ordering;

--- a/cli/permissions.rs
+++ b/cli/permissions.rs
@@ -1,8 +1,8 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use ansi_term::Style;
-use atty;
 use crate::deno_error::permission_denied;
 use crate::flags::DenoFlags;
+use ansi_term::Style;
+use atty;
 use deno::ErrBox;
 use log;
 use std::collections::HashSet;

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -68,7 +68,9 @@ impl Repl {
     self
       .editor
       .load_history(&self.history_file.to_str().unwrap())
-      .map_err(|e| debug!("Unable to load history file: {:?} {}", self.history_file, e))
+      .map_err(|e| {
+        debug!("Unable to load history file: {:?} {}", self.history_file, e)
+      })
       // ignore this error (e.g. it occurs on first load)
       .unwrap_or(())
   }
@@ -91,7 +93,8 @@ impl Repl {
       .map(|line| {
         self.editor.add_history_entry(line.clone());
         line
-      }).map_err(ErrBox::from)
+      })
+      .map_err(ErrBox::from)
     // Forward error to TS side for processing
   }
 }

--- a/cli/resources.rs
+++ b/cli/resources.rs
@@ -543,7 +543,8 @@ pub fn seek(
         deno_error::DenoError::new(
           deno_error::ErrorKind::InvalidSeekMode,
           format!("Invalid seek mode: {}", whence),
-        ).into(),
+        )
+        .into(),
       ));
     }
   };

--- a/cli/shell.rs
+++ b/cli/shell.rs
@@ -342,18 +342,18 @@ impl ShellOut {
           None => write!(stream, " ")?,
         }
       } /*
-      ShellOut::Write(ref mut w) => {
-        if justified {
-          write!(w, "{:>12}", status)?;
-        } else {
-          write!(w, "{}", status)?;
+        ShellOut::Write(ref mut w) => {
+          if justified {
+            write!(w, "{:>12}", status)?;
+          } else {
+            write!(w, "{}", status)?;
+          }
+          match message {
+            Some(message) => writeln!(w, " {}", message)?,
+            None => write!(w, " ")?,
+          }
         }
-        match message {
-          Some(message) => writeln!(w, " {}", message)?,
-          None => write!(w, " ")?,
-        }
-      }
-      */
+        */
     }
     Ok(())
   }
@@ -479,12 +479,10 @@ mod imp {
   }
 }
 
-#[cfg(
-  any(
-    all(unix, not(any(target_os = "linux", target_os = "macos"))),
-    windows
-  )
-)]
+#[cfg(any(
+  all(unix, not(any(target_os = "linux", target_os = "macos"))),
+  windows
+))]
 fn default_err_erase_line(shell: &mut Shell) {
   if let Some(max_width) = imp::stderr_width() {
     let blank = " ".repeat(max_width);

--- a/cli/source_maps.rs
+++ b/cli/source_maps.rs
@@ -78,13 +78,15 @@ fn builtin_source_map(script_name: &str) -> Option<Vec<u8>> {
       include_bytes!(concat!(
         env!("GN_OUT_DIR"),
         "/gen/cli/bundle/main.js.map"
-      )).to_vec(),
+      ))
+      .to_vec(),
     ),
     "gen/cli/bundle/compiler.js" => Some(
       include_bytes!(concat!(
         env!("GN_OUT_DIR"),
         "/gen/cli/bundle/compiler.js.map"
-      )).to_vec(),
+      ))
+      .to_vec(),
     ),
     _ => None,
   }

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -302,7 +302,8 @@ impl ThreadSafeState {
       argv,
       ops::op_selector_std,
       Progress::new(),
-    ).unwrap()
+    )
+    .unwrap()
   }
 
   pub fn metrics_op_dispatched(

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -126,7 +126,8 @@ mod tests {
       argv,
       op_selector_std,
       Progress::new(),
-    ).unwrap();
+    )
+    .unwrap();
     let state_ = state.clone();
     tokio_util::run(lazy(move || {
       let mut worker =
@@ -154,7 +155,8 @@ mod tests {
       argv,
       op_selector_std,
       Progress::new(),
-    ).unwrap();
+    )
+    .unwrap();
     let state_ = state.clone();
     tokio_util::run(lazy(move || {
       let mut worker =
@@ -283,7 +285,8 @@ mod tests {
           println!("workers.rs after resource close");
           r.unwrap();
           Ok(())
-        }).shared();
+        })
+        .shared();
 
       let worker_future_ = worker_future.clone();
       tokio::spawn(lazy(move || worker_future_.then(|_| Ok(()))));

--- a/core/examples/http_bench.rs
+++ b/core/examples/http_bench.rs
@@ -149,11 +149,13 @@ fn dispatch(control: &[u8], zero_copy_buf: Option<PinnedBuf>) -> CoreOp {
       .and_then(move |result| {
         record_a.result = result;
         Ok(record_a)
-      }).or_else(|err| -> Result<Record, ()> {
+      })
+      .or_else(|err| -> Result<Record, ()> {
         eprintln!("unexpected err {}", err);
         record_b.result = -1;
         Ok(record_b)
-      }).then(|result| -> Result<Buf, ()> {
+      })
+      .then(|result| -> Result<Buf, ()> {
         let record = result.unwrap();
         Ok(record.into())
       }),
@@ -234,7 +236,8 @@ fn op_accept(listener_rid: i32) -> Box<HttpBenchOp> {
         Some(Repr::TcpListener(ref mut listener)) => listener.poll_accept(),
         _ => panic!("bad rid {}", listener_rid),
       }
-    }).and_then(move |(stream, addr)| {
+    })
+    .and_then(move |(stream, addr)| {
       debug!("accept success {}", addr);
       let rid = new_rid();
 
@@ -283,7 +286,8 @@ fn op_read(rid: i32, zero_copy_buf: Option<PinnedBuf>) -> Box<HttpBenchOp> {
         }
         _ => panic!("bad rid"),
       }
-    }).and_then(move |nread| {
+    })
+    .and_then(move |nread| {
       debug!("read success {}", nread);
       Ok(nread as i32)
     }),
@@ -303,7 +307,8 @@ fn op_write(rid: i32, zero_copy_buf: Option<PinnedBuf>) -> Box<HttpBenchOp> {
         }
         _ => panic!("bad rid"),
       }
-    }).and_then(move |nwritten| {
+    })
+    .and_then(move |nwritten| {
       debug!("write success {}", nwritten);
       Ok(nwritten as i32)
     }),

--- a/core/flags.rs
+++ b/core/flags.rs
@@ -39,5 +39,6 @@ pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
       let cstr = CStr::from_ptr(*ptr as *const c_char);
       let slice = cstr.to_str().unwrap();
       slice.to_string()
-    }).collect()
+    })
+    .collect()
 }

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -792,7 +792,8 @@ pub mod tests {
         let control = new Uint8Array([42]);
         Deno.core.send(control);
       "#,
-      ).unwrap();
+      )
+      .unwrap();
     assert_eq!(dispatch_count.load(Ordering::Relaxed), 0);
 
     let imports = isolate.mod_get_imports(mod_a);

--- a/core/js_errors.rs
+++ b/core/js_errors.rs
@@ -310,7 +310,8 @@ mod tests {
         "isConstructor":false,
         "isWasm":false
       }"#,
-    ).unwrap();
+    )
+    .unwrap();
     let r = StackFrame::from_json_value(&v);
     assert_eq!(
       r,
@@ -334,7 +335,8 @@ mod tests {
         "line": 2,
         "column": 11
       }"#,
-    ).unwrap();
+    )
+    .unwrap();
     let r = StackFrame::from_json_value(&v);
     assert!(r.is_some());
     let f = r.unwrap();

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -384,7 +384,8 @@ impl Modules {
         if !i.has_child(&child_name) {
           i.children.push(child_name.to_string());
         }
-      }).is_some()
+      })
+      .is_some()
   }
 
   pub fn register(&mut self, id: deno_mod, name: &str) {

--- a/tools/format.py
+++ b/tools/format.py
@@ -61,7 +61,7 @@ def clang_format():
 def rustfmt():
     print "rustfmt"
     qrun([
-        "third_party/rustfmt/" + platform() + "/rustfmt",
+        "rustfmt",
         "--config-path",
         rustfmt_config,
     ] + find_exts(["cli", "core", "tools"], [".rs"]))

--- a/tools/gn.rs
+++ b/tools/gn.rs
@@ -97,7 +97,8 @@ impl Build {
         "third_party/python_packages/win32",
         "third_party/python_packages/win32/lib",
         "third_party/python_packages/Pythonwin",
-      ].into_iter()
+      ]
+      .into_iter()
       .map(|p| self.root.join(p).into_os_string().into_string().unwrap())
       .collect();
       let orig_path = String::from(";")


### PR DESCRIPTION
I think that rustfmt is more stable now, so we can relax our constraints. If we run into version incompatibility problems [again](https://github.com/denoland/deno/pull/1029), then we should move the binaries into prebuilt instead of third_party.