### PR TITLE
cli: --current-thread flag to use tokio::runtime::current_thread

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -162,7 +162,7 @@ To get help on the another subcommands (run in this case):
         .global(true),
     )
     .arg(
-      Arg::with_name("current_thread")
+      Arg::with_name("current-thread")
         .long("current-thread")
         .global(true)
         .help("Use tokio::runtime::current_thread"),

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -43,6 +43,8 @@ pub struct DenoFlags {
   pub v8_flags: Option<Vec<String>>,
   pub xeval_replvar: Option<String>,
   pub xeval_delim: Option<String>,
+  // Use tokio::runtime::current_thread
+  pub current_thread: bool,
 }
 
 static ENV_VARIABLES_HELP: &str = "ENVIRONMENT VARIABLES:
@@ -158,6 +160,12 @@ To get help on the another subcommands (run in this case):
         .help("Load compiler configuration file")
         .takes_value(true)
         .global(true),
+    )
+    .arg(
+      Arg::with_name("current_thread")
+        .long("current-thread")
+        .global(true)
+        .help("Use tokio::runtime::current_thread"),
     ).arg(
       Arg::with_name("importmap")
         .long("importmap")
@@ -443,6 +451,9 @@ pub fn parse_flags(
 ) -> DenoFlags {
   let mut flags = maybe_flags.unwrap_or_default();
 
+  if matches.is_present("current-thread") {
+    flags.current_thread = true;
+  }
   if matches.is_present("log-level") {
     flags.log_level = match matches.value_of("log-level").unwrap() {
       "debug" => Some(Level::Debug),
@@ -1614,6 +1625,21 @@ mod tests {
       flags,
       DenoFlags {
         no_fetch: true,
+        ..DenoFlags::default()
+      }
+    );
+    assert_eq!(subcommand, DenoSubcommand::Run);
+    assert_eq!(argv, svec!["deno", "script.ts"])
+  }
+
+  #[test]
+  fn test_flags_from_vec_35() {
+    let (flags, subcommand, argv) =
+      flags_from_vec(svec!["deno", "--current-thread", "script.ts"]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        current_thread: true,
         ..DenoFlags::default()
       }
     );

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -329,6 +329,7 @@ fn run_repl(flags: DenoFlags, argv: Vec<String>) {
 }
 
 fn run_script(flags: DenoFlags, argv: Vec<String>) {
+  let use_current_thread = flags.current_thread;
   let (mut worker, state) = create_worker_and_state(flags, argv);
 
   let main_module = state.main_module().unwrap();
@@ -348,7 +349,12 @@ fn run_script(flags: DenoFlags, argv: Vec<String>) {
         })
       }).map_err(print_err_and_exit)
   });
-  tokio_util::run(main_future);
+
+  if use_current_thread {
+    tokio_util::run_on_current_thread(main_future);
+  } else {
+    tokio_util::run(main_future);
+  }
 }
 
 fn main() {

--- a/cli/tokio_util.rs
+++ b/cli/tokio_util.rs
@@ -26,6 +26,13 @@ where
   rt.block_on_all(future).unwrap();
 }
 
+pub fn run_on_current_thread<F>(future: F)
+where
+  F: Future<Item = (), Error = ()> + Send + 'static,
+{
+  tokio::runtime::current_thread::run(future);
+}
+
 /// THIS IS A HACK AND SHOULD BE AVOIDED.
 ///
 /// This creates a new tokio runtime, with many new threads, to execute the

--- a/tests/037_current_thread.test
+++ b/tests/037_current_thread.test
@@ -1,0 +1,2 @@
+args: run --current-thread --reload tests/034_onload/main.ts
+output: tests/034_onload.out

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -32,6 +32,13 @@ def deno_tcp(deno_exe):
     return run(deno_cmd, addr)
 
 
+def deno_tcp_current_thread(deno_exe):
+    addr = get_addr()
+    deno_cmd = [deno_exe, "run", "--current-thread", "--allow-net", "tools/deno_tcp.ts", addr]
+    print "http_benchmark testing DENO."
+    return run(deno_cmd, addr)
+
+
 def deno_http(deno_exe):
     addr = get_addr()
     deno_cmd = [
@@ -146,6 +153,7 @@ def http_benchmark(build_dir):
     return {
         # "deno_tcp" was once called "deno"
         "deno_tcp": deno_tcp(deno_exe),
+        "deno_tcp_current_thread": deno_tcp_current_thread(deno_exe),
         # "deno_http" was once called "deno_net_http"
         "deno_http": deno_http(deno_exe),
         "deno_proxy": deno_http_proxy(deno_exe, hyper_hello_exe),

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -35,8 +35,8 @@ def deno_tcp(deno_exe):
 def deno_tcp_current_thread(deno_exe):
     addr = get_addr()
     deno_cmd = [
-        deno_exe, "run", "--current-thread",
-        "--allow-net", "tools/deno_tcp.ts", addr
+        deno_exe, "run", "--current-thread", "--allow-net",
+        "tools/deno_tcp.ts", addr
     ]
     print "http_benchmark testing DENO."
     return run(deno_cmd, addr)

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -34,7 +34,10 @@ def deno_tcp(deno_exe):
 
 def deno_tcp_current_thread(deno_exe):
     addr = get_addr()
-    deno_cmd = [deno_exe, "run", "--current-thread", "--allow-net", "tools/deno_tcp.ts", addr]
+    deno_cmd = [
+        deno_exe, "run", "--current-thread",
+        "--allow-net", "tools/deno_tcp.ts", addr
+    ]
     print "http_benchmark testing DENO."
     return run(deno_cmd, addr)
 


### PR DESCRIPTION
This PR adds `--current-thread` flag that can be used to run Deno using `tokio::runtime::current_thread` instead of thread pool runtime.

Currently it is only used when running scripts (so eval, etc. will still use thread pool runtime).

I also added HTTP benchmark so we can see the difference.

CC @ry