### PR TITLE
WIP async stack traces ...

### DIFF
--- a/core/libdeno/api.cc
+++ b/core/libdeno/api.cc
@@ -120,8 +120,8 @@ void deno_init() {
     // remove this to make it work asynchronously too. But that requires getting
     // PumpMessageLoop and RunMicrotasks setup correctly.
     // See https://github.com/denoland/deno/issues/2544
-    const char* argv[2] = {"", "--no-wasm-async-compilation"};
-    int argc = 2;
+    const char* argv[3] = {"", "--no-wasm-async-compilation", "--async-stack-traces"};
+    int argc = 3;
     v8::V8::SetFlagsFromCommandLine(&argc, const_cast<char**>(argv), false);
   }
 }

--- a/core/libdeno/binding.cc
+++ b/core/libdeno/binding.cc
@@ -69,6 +69,12 @@ void PromiseRejectCallback(v8::PromiseRejectMessage promise_reject_message) {
 
   v8::Context::Scope context_scope(context);
 
+  auto message = v8::Exception::CreateMessage(isolate, error);
+  auto stack_trace = message->GetStackTrace();
+  uint32_t count = static_cast<uint32_t>(stack_trace->GetFrameCount());
+  printf("FRAME COUNT %d\n", count);
+
+
   int promise_id = promise->GetIdentityHash();
   switch (promise_reject_message.GetEvent()) {
     case v8::kPromiseRejectWithNoHandler:

--- a/core/libdeno/libdeno_test.cc
+++ b/core/libdeno/libdeno_test.cc
@@ -281,3 +281,24 @@ TEST(LibDenoTest, WasmInstantiate) {
 
   deno_delete(d);
 }
+
+/*
+
+ To run this test:
+
+ ./tools/build.py libdeno_test && ./target/debug/libdeno_test
+ --gtest_filter=LibDenoTest.AsyncException
+
+*/
+TEST(LibDenoTest, AsyncException) {
+  Deno* d = deno_new(deno_config{0, snapshot, empty, nullptr, nullptr});
+  EXPECT_EQ(deno_last_exception(d), nullptr);
+  deno_execute(d, nullptr, "a.js", "AsyncException()");
+
+  deno_check_promise_errors(d);
+
+  // Note that there is only one frame in the JSON output....
+  printf("deno_last_exception %s\n", deno_last_exception(d));
+
+  deno_delete(d);
+}

--- a/core/libdeno/libdeno_test.js
+++ b/core/libdeno/libdeno_test.js
@@ -253,3 +253,13 @@ global.WasmInstantiate = () => {
     Deno.core.send(new Uint8Array([42]));
   })();
 };
+
+global.AsyncException = () => {
+  (async () => {
+    await Promise.resolve().then(() => {
+      const error = new Error;
+      Deno.core.print(error.stack + "\n");
+      throw error;
+    });
+  })()
+};


### PR DESCRIPTION
cc @nayeem-rahman 

```
> ./tools/build.py libdeno_test && ./target/debug/libdeno_test --gtest_filter=LibDenoTest.AsyncException
ninja: Entering directory `/Users/rld/src/deno/target/debug'
[2/2] LINK ./libdeno_test
Note: Google Test filter = LibDenoTest.AsyncException
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from LibDenoTest
[ RUN      ] LibDenoTest.AsyncException
Error
    at /Users/rld/src/deno/core/libdeno/libdeno_test.js:260:21
    at async /Users/rld/src/deno/core/libdeno/libdeno_test.js:259:5
deno_last_exception (null)
deno_last_exception {"message":"Uncaught Error","sourceLine":"","lineNumber":0,"startPosition":-1,"endPosition":-1,"errorLevel":8,"startColumn":-1,"endColumn":-1,"isSharedCrossOrigin":true,"isOpaque":false,"frames":[{"line":260,"column":21,"scriptName":"/Users/rld/src/deno/core/libdeno/libdeno_test.js","isEval":false,"isConstructor":false,"isWasm":false}]}
[       OK ] LibDenoTest.AsyncException (80 ms)
[----------] 1 test from LibDenoTest (80 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (80 ms total)
[  PASSED  ] 1 test.
```


Other places to look
* `isolate_->SetPromiseRejectCallback()` https://github.com/denoland/deno/blob/deec1b9b97011d1a0ef7312c0a3efde21186b82d/core/libdeno/binding.cc#L562