### PR TITLE
Enforce env permission on homeDir() and execPath

### DIFF
--- a/js/os_test.ts
+++ b/js/os_test.ts
@@ -39,6 +39,26 @@ test(function osIsTTYSmoke(): void {
   console.log(Deno.isTTY());
 });
 
-test(function homeDir(): void {
+testPerm({ env: true }, function homeDir(): void {
   assertNotEquals(Deno.homeDir(), "");
+});
+
+testPerm({ env: false }, function homeDirPerm(): void {
+  let caughtError = false;
+  try {
+    Deno.homeDir();
+  } catch (err) {
+    caughtError = true;
+    assertEquals(err.kind, Deno.ErrorKind.PermissionDenied);
+    assertEquals(err.name, "PermissionDenied");
+  }
+  assert(caughtError);
+});
+
+testPerm({ env: true }, function execPath(): void {
+  assertNotEquals(Deno.execPath, "");
+});
+
+testPerm({ env: false }, function execPathPerm(): void {
+  assertEquals(Deno.execPath, "");
 });

--- a/tools/target_test.py
+++ b/tools/target_test.py
@@ -55,7 +55,10 @@ class TestTarget(DenoTestCase):
         assert result.out.strip() == "noColor false"
 
     def test_exec_path(self):
-        cmd = [self.deno_exe, "run", "--allow-run", "tests/exec_path.ts"]
+        cmd = [
+            self.deno_exe, "run", "--allow-run", "--allow-env",
+            "tests/exec_path.ts"
+        ]
         result = run_output(cmd, quiet=True)
         print "exec_path", result.code
         print result.out

--- a/tools/unit_tests.py
+++ b/tools/unit_tests.py
@@ -10,7 +10,7 @@ from test_util import DenoTestCase, run_tests
 class JsUnitTests(DenoTestCase):
     def test_unit_test_runner(self):
         cmd = [
-            self.deno_exe, "run", "--reload", "--allow-run",
+            self.deno_exe, "run", "--reload", "--allow-run", "--allow-env",
             "js/unit_test_runner.ts"
         ]
         process = subprocess.Popen(


### PR DESCRIPTION
Closes #2713 .

Turning on `allow_env` check for `Deno.homeDir()`.
Also set `Deno.execPath` to empty string if `env` is not turned on.
