### PR TITLE
Provide option to delete Deno namespace in worker

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -196,8 +196,10 @@ fn create_worker_and_state(
       s.status(status, msg).expect("shell problem");
     }
   });
+  // TODO(kevinkassimo): maybe make include_deno_namespace also configurable?
   let state =
-    ThreadSafeState::new(flags, argv, ops::op_selector_std, progress).unwrap();
+    ThreadSafeState::new(flags, argv, ops::op_selector_std, progress, true)
+      .unwrap();
   let worker = Worker::new(
     "main".to_string(),
     startup_data::deno_isolate_init(),

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -204,6 +204,7 @@ table FormatErrorRes {
 // Create worker as host
 table CreateWorker {
   specifier: string;
+  include_deno_namespace: bool;
 }
 
 table CreateWorkerRes {

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -84,6 +84,8 @@ pub struct State {
   pub js_compiler: JsCompiler,
   pub json_compiler: JsonCompiler,
   pub ts_compiler: TsCompiler,
+
+  pub include_deno_namespace: bool,
 }
 
 impl Clone for ThreadSafeState {
@@ -151,6 +153,7 @@ impl ThreadSafeState {
     argv_rest: Vec<String>,
     dispatch_selector: ops::OpSelector,
     progress: Progress,
+    include_deno_namespace: bool,
   ) -> Result<Self, ErrBox> {
     let custom_root = env::var("DENO_DIR").map(String::into).ok();
 
@@ -223,6 +226,7 @@ impl ThreadSafeState {
       ts_compiler,
       js_compiler: JsCompiler {},
       json_compiler: JsonCompiler {},
+      include_deno_namespace,
     };
 
     Ok(ThreadSafeState(Arc::new(state)))
@@ -302,6 +306,7 @@ impl ThreadSafeState {
       argv,
       ops::op_selector_std,
       Progress::new(),
+      true,
     )
     .unwrap()
   }

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -126,6 +126,7 @@ mod tests {
       argv,
       op_selector_std,
       Progress::new(),
+      true,
     )
     .unwrap();
     let state_ = state.clone();
@@ -155,6 +156,7 @@ mod tests {
       argv,
       op_selector_std,
       Progress::new(),
+      true,
     )
     .unwrap();
     let state_ = state.clone();
@@ -182,7 +184,7 @@ mod tests {
     let mut flags = flags::DenoFlags::default();
     flags.reload = true;
     let state =
-      ThreadSafeState::new(flags, argv, op_selector_std, Progress::new())
+      ThreadSafeState::new(flags, argv, op_selector_std, Progress::new(), true)
         .unwrap();
     let state_ = state.clone();
     tokio_util::run(lazy(move || {

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -29,8 +29,12 @@ SharedQueue Binary Layout
   const INDEX_RECORDS = 3 + MAX_RECORDS;
   const HEAD_INIT = 4 * INDEX_RECORDS;
 
+  // Available on start due to bindings.
   const Deno = window[GLOBAL_NAMESPACE];
   const core = Deno[CORE_NAMESPACE];
+  // Warning: DO NOT use window.Deno after this point.
+  // It is possible that the Deno namespace has been deleted.
+  // Use the above local Deno and core variable instead.
 
   let sharedBytes;
   let shared32;
@@ -165,7 +169,7 @@ SharedQueue Binary Layout
     const success = push(control);
     // If successful, don't use first argument of core.send.
     const arg0 = success ? null : control;
-    return window.Deno.core.send(arg0, zeroCopy);
+    return Deno.core.send(arg0, zeroCopy);
   }
 
   const denoCore = {

--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -25,7 +25,7 @@ const console = new Console(core.print);
 window.console = console;
 window.workerMain = workerMain;
 export default function denoMain(): void {
-  os.start("TS");
+  os.start(true, "TS");
 }
 
 const ASSETS = "$asset$";

--- a/js/core.ts
+++ b/js/core.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { window } from "./window";
 
+// This allows us to access core in API even if we
+// dispose window.Deno
 export const core = window.Deno.core as DenoCore;

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -32,7 +32,6 @@ import * as request from "./request";
 // These imports are not exposed and therefore are fine to just import the
 // symbols required.
 import { core } from "./core";
-import { immutableDefine } from "./util";
 
 // During the build process, augmentations to the variable `window` in this
 // file are tracked and created as part of default library that is built into
@@ -71,7 +70,7 @@ window.window = window;
 // This is the Deno namespace, it is handled differently from other window
 // properties when building the runtime type library, as the whole module
 // is flattened into a single namespace.
-immutableDefine(window, "Deno", deno);
+window.Deno = deno;
 Object.freeze(window.Deno);
 
 // Globally available functions and object instances.

--- a/js/main.ts
+++ b/js/main.ts
@@ -18,8 +18,11 @@ import { setLocation } from "./location";
 // builtin modules
 import * as deno from "./deno";
 
-export default function denoMain(name?: string): void {
-  const startResMsg = os.start(name);
+export default function denoMain(
+  preserveDenoNamespace: boolean = true,
+  name?: string
+): void {
+  const startResMsg = os.start(preserveDenoNamespace, name);
 
   setVersions(startResMsg.denoVersion()!, startResMsg.v8Version()!);
 

--- a/js/workers.ts
+++ b/js/workers.ts
@@ -161,10 +161,8 @@ export interface Worker {
 export interface WorkerOptions {}
 
 export interface DenoWorkerOptions extends WorkerOptions {
-  deno?: {
-    // TODO(kevinkassimo): maybe just name this option "sandbox"?
-    noDenoNamespace?: boolean;
-  };
+  // TODO(kevinkassimo): maybe just name this option "sandbox"?
+  noDenoNamespace?: boolean;
 }
 
 export class WorkerImpl implements Worker {
@@ -177,7 +175,7 @@ export class WorkerImpl implements Worker {
 
   constructor(specifier: string, options?: DenoWorkerOptions) {
     let includeDenoNamespace = true;
-    if (options && options.deno && options.deno.noDenoNamespace) {
+    if (options && options.noDenoNamespace) {
       includeDenoNamespace = false;
     }
     this.rid = createWorker(specifier, includeDenoNamespace);

--- a/js/workers.ts
+++ b/js/workers.ts
@@ -160,8 +160,11 @@ export interface Worker {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface WorkerOptions {}
 
+/** Extended Deno Worker initialization options.
+ * `noDenoNamespace` hides global `window.Deno` namespace for
+ * spawned worker and nested workers spawned by it (default: false).
+ */
 export interface DenoWorkerOptions extends WorkerOptions {
-  // TODO(kevinkassimo): maybe just name this option "sandbox"?
   noDenoNamespace?: boolean;
 }
 

--- a/tests/039_worker_deno_ns.test
+++ b/tests/039_worker_deno_ns.test
@@ -1,0 +1,2 @@
+args: run --reload tests/039_worker_deno_ns.ts
+output: tests/039_worker_deno_ns.ts.out

--- a/tests/039_worker_deno_ns.ts
+++ b/tests/039_worker_deno_ns.ts
@@ -1,0 +1,25 @@
+const w1 = new Worker("./tests/039_worker_deno_ns/has_ns.ts");
+const w2 = new Worker("./tests/039_worker_deno_ns/no_ns.ts", {
+  deno: { noDenoNamespace: true }
+});
+let w1MsgCount = 0;
+let w2MsgCount = 0;
+w1.onmessage = (msg): void => {
+  console.log(msg.data);
+  w1MsgCount++;
+  if (w1MsgCount === 1) {
+    w1.postMessage("CONTINUE");
+  } else {
+    w2.postMessage("START");
+  }
+};
+w2.onmessage = (msg): void => {
+  console.log(msg.data);
+  w2MsgCount++;
+  if (w2MsgCount === 1) {
+    w2.postMessage("CONTINUE");
+  } else {
+    Deno.exit(0);
+  }
+};
+w1.postMessage("START");

--- a/tests/039_worker_deno_ns.ts
+++ b/tests/039_worker_deno_ns.ts
@@ -1,6 +1,6 @@
 const w1 = new Worker("./tests/039_worker_deno_ns/has_ns.ts");
 const w2 = new Worker("./tests/039_worker_deno_ns/no_ns.ts", {
-  deno: { noDenoNamespace: true }
+  noDenoNamespace: true
 });
 let w1MsgCount = 0;
 let w2MsgCount = 0;

--- a/tests/039_worker_deno_ns.ts.out
+++ b/tests/039_worker_deno_ns.ts.out
@@ -1,0 +1,4 @@
+has_ns.ts: is window.Deno available: true
+[SPAWNED BY has_ns.ts] maybe_ns.ts: is window.Deno available: true
+no_ns.ts: is window.Deno available: false
+[SPAWNED BY no_ns.ts] maybe_ns.ts: is window.Deno available: false

--- a/tests/039_worker_deno_ns/has_ns.ts
+++ b/tests/039_worker_deno_ns/has_ns.ts
@@ -1,0 +1,10 @@
+onmessage = (msg): void => {
+  if (msg.data === "START") {
+    postMessage("has_ns.ts: is window.Deno available: " + !!window.Deno);
+  } else {
+    const worker = new Worker("./tests/039_worker_deno_ns/maybe_ns.ts");
+    worker.onmessage = (msg): void => {
+      postMessage("[SPAWNED BY has_ns.ts] " + msg.data);
+    };
+  }
+};

--- a/tests/039_worker_deno_ns/maybe_ns.ts
+++ b/tests/039_worker_deno_ns/maybe_ns.ts
@@ -1,0 +1,1 @@
+postMessage("maybe_ns.ts: is window.Deno available: " + !!window.Deno);

--- a/tests/039_worker_deno_ns/no_ns.ts
+++ b/tests/039_worker_deno_ns/no_ns.ts
@@ -1,0 +1,10 @@
+onmessage = (msg): void => {
+  if (msg.data === "START") {
+    postMessage("no_ns.ts: is window.Deno available: " + !!window.Deno);
+  } else {
+    const worker = new Worker("./tests/039_worker_deno_ns/maybe_ns.ts");
+    worker.onmessage = (msg): void => {
+      postMessage("[SPAWNED BY no_ns.ts] " + msg.data);
+    };
+  }
+};


### PR DESCRIPTION
Add an option to `Worker` creation such that worker could be sandboxed (no access to `window.Deno` namespace)

The condition is propagated (e.g. if a sandboxed worker tries to create another worker, it will always also be sandboxed)

This is achieved by adding a condition to per worker/isolate `State` and calling `denoMain()` with param whether to preserve or delete `window.Deno`

(The locations where things are attached/bounded to `Deno` or `Deno.core` is growing more nebulous. Maybe we need better comments for it)

~~Tests needed. Will try to add them after first-round review (to ensure no leaking of the namespace through other channels)~~ Added