### PR TITLE
perf: use BTreeMap for ResourceTable

### DIFF
--- a/cli/resources.rs
+++ b/cli/resources.rs
@@ -24,7 +24,7 @@ use futures::Sink;
 use futures::Stream;
 use hyper;
 use std;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::{Error, Read, Seek, SeekFrom, Write};
 use std::net::{Shutdown, SocketAddr};
 use std::process::ExitStatus;
@@ -41,7 +41,7 @@ pub type ResourceId = u32; // Sometimes referred to RID.
 
 // These store Deno's file descriptors. These are not necessarily the operating
 // system ones.
-type ResourceTable = HashMap<ResourceId, Repr>;
+type ResourceTable = BTreeMap<ResourceId, Repr>;
 
 #[cfg(not(windows))]
 use std::os::unix::io::FromRawFd;
@@ -56,7 +56,7 @@ lazy_static! {
   // Starts at 3 because stdio is [0-2].
   static ref NEXT_RID: AtomicUsize = AtomicUsize::new(3);
   static ref RESOURCE_TABLE: Mutex<ResourceTable> = Mutex::new({
-    let mut m = HashMap::new();
+    let mut m = BTreeMap::new();
     // TODO Load these lazily during lookup?
     m.insert(0, Repr::Stdin(tokio::io::stdin()));
 


### PR DESCRIPTION
This is just an experiment, but after profiling `deno_tcp` I managed to shave of 2% by using `BTreeMap` instead of `HashMap` for `ResourceTable`.

Before:
![Zrzut ekranu 2019-08-4 o 14 42 15](https://user-images.githubusercontent.com/13602871/62423818-4c378e80-b6c6-11e9-951b-4c9cce379ce2.png)
![Zrzut ekranu 2019-08-4 o 14 44 29](https://user-images.githubusercontent.com/13602871/62423823-670a0300-b6c6-11e9-9638-f1358ec1c746.png)


After:
![Zrzut ekranu 2019-08-4 o 14 42 33](https://user-images.githubusercontent.com/13602871/62423821-50fc4280-b6c6-11e9-9ae2-358744c81a83.png)
![Zrzut ekranu 2019-08-4 o 14 44 34](https://user-images.githubusercontent.com/13602871/62423827-6c674d80-b6c6-11e9-995b-5869624505a8.png)
