### PR TITLE
Remove dispatch optimization

### DIFF
--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -268,8 +268,6 @@ impl Isolate {
     control_argv0: deno_buf,
     zero_copy_buf: deno_pinned_buf,
   ) {
-    // The user called Deno.core.send()
-
     let isolate = unsafe { Isolate::from_raw_ptr(user_data) };
 
     let op = if let Some(ref f) = isolate.dispatch {
@@ -278,9 +276,7 @@ impl Isolate {
       panic!("isolate.dispatch not set")
     };
 
-    // At this point the SharedQueue should be empty.
-    assert_eq!(isolate.shared.size(), 0);
-
+    debug_assert_eq!(isolate.shared.size(), 0);
     match op {
       Op::Sync(buf) => {
         // For sync messages, we always return the response via Deno.core.send's

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -268,30 +268,14 @@ impl Isolate {
     control_argv0: deno_buf,
     zero_copy_buf: deno_pinned_buf,
   ) {
-    let isolate = unsafe { Isolate::from_raw_ptr(user_data) };
-    let control_shared = isolate.shared.shift();
+    // The user called Deno.core.send()
 
-    let op = if control_argv0.len() > 0 {
-      // The user called Deno.core.send(control)
-      if let Some(ref f) = isolate.dispatch {
-        f(control_argv0.as_ref(), PinnedBuf::new(zero_copy_buf))
-      } else {
-        panic!("isolate.dispatch not set")
-      }
-    } else if let Some(c) = control_shared {
-      // The user called Deno.sharedQueue.push(control)
-      if let Some(ref f) = isolate.dispatch {
-        f(&c, PinnedBuf::new(zero_copy_buf))
-      } else {
-        panic!("isolate.dispatch not set")
-      }
+    let isolate = unsafe { Isolate::from_raw_ptr(user_data) };
+
+    let op = if let Some(ref f) = isolate.dispatch {
+      f(control_argv0.as_ref(), PinnedBuf::new(zero_copy_buf))
     } else {
-      // The sharedQueue is empty. The shouldn't happen usually, but it's also
-      // not technically a failure.
-      #[cfg(test)]
-      unreachable!();
-      #[cfg(not(test))]
-      return;
+      panic!("isolate.dispatch not set")
     };
 
     // At this point the SharedQueue should be empty.
@@ -868,43 +852,6 @@ pub mod tests {
       assert_eq!(dispatch_count.load(Ordering::Relaxed), 2);
       // We are idle, so the next poll should be the last.
       assert_eq!(Async::Ready(()), isolate.poll().unwrap());
-    });
-  }
-
-  #[test]
-  fn test_shared() {
-    run_in_task(|| {
-      let (mut isolate, dispatch_count) = setup(Mode::AsyncImmediate);
-
-      js_check(isolate.execute(
-        "setup2.js",
-        r#"
-        let nrecv = 0;
-        Deno.core.setAsyncHandler((buf) => {
-          assert(buf.byteLength === 1);
-          assert(buf[0] === 43);
-          nrecv++;
-        });
-        "#,
-      ));
-      assert_eq!(dispatch_count.load(Ordering::Relaxed), 0);
-
-      js_check(isolate.execute(
-        "send1.js",
-        r#"
-        let control = new Uint8Array([42]);
-        Deno.core.sharedQueue.push(control);
-        Deno.core.send();
-        assert(nrecv === 0);
-
-        Deno.core.sharedQueue.push(control);
-        Deno.core.send();
-        assert(nrecv === 0);
-        "#,
-      ));
-      assert_eq!(dispatch_count.load(Ordering::Relaxed), 2);
-      assert_eq!(Async::Ready(()), isolate.poll().unwrap());
-      js_check(isolate.execute("send1.js", "assert(nrecv === 2);"));
     });
   }
 

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -165,11 +165,7 @@ SharedQueue Binary Layout
 
   function dispatch(control, zeroCopy = null) {
     maybeInit();
-    // First try to push control to shared.
-    const success = push(control);
-    // If successful, don't use first argument of core.send.
-    const arg0 = success ? null : control;
-    return Deno.core.send(arg0, zeroCopy);
+    return Deno.core.send(control, zeroCopy);
   }
 
   const denoCore = {

--- a/core/shared_queue.rs
+++ b/core/shared_queue.rs
@@ -103,6 +103,7 @@ impl SharedQueue {
     s[INDEX_OFFSETS + index] = end as u32;
   }
 
+  #[cfg(test)]
   fn get_end(&self, index: usize) -> Option<usize> {
     if index < self.num_records() {
       let s = self.as_u32_slice();
@@ -112,6 +113,7 @@ impl SharedQueue {
     }
   }
 
+  #[cfg(test)]
   fn get_offset(&self, index: usize) -> Option<usize> {
     if index < self.num_records() {
       Some(if index == 0 {
@@ -126,6 +128,7 @@ impl SharedQueue {
   }
 
   /// Returns none if empty.
+  #[cfg(test)]
   pub fn shift(&mut self) -> Option<&[u8]> {
     let u32_slice = self.as_u32_slice();
     let i = u32_slice[INDEX_NUM_SHIFTED_OFF] as usize;


### PR DESCRIPTION
Deno.core.dispatch() used to push the "control" buf onto the shared
array buffer before calling into V8, with the idea that it was one less
argument to parse. Turns out there is no more overhead passing the
control ArrayBuffer directly over. Furthermore this optimization was
making the refactors outlined in #2730 more complex. Therefore it is
being removed.

benchmark results are unchanged:

**this branch**
```
~/src/deno> wrk -d 30s --latency http://127.0.0.1:4500
Running 30s test @ http://127.0.0.1:4500
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   392.64us    2.76ms  88.67ms   98.88%
    Req/Sec    21.34k     1.56k   24.37k    86.50%
  Latency Distribution
     50%  197.00us
     75%  242.00us
     90%  310.00us
     99%    3.38ms
  1274182 requests in 30.01s, 61.97MB read
Requests/sec:  42457.87
Transfer/sec:      2.07MB
```

**deno v0.13**
```
~/src/deno> wrk -d 30s --latency http://127.0.0.1:4500
Running 30s test @ http://127.0.0.1:4500
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   269.44us  427.67us   7.88ms   97.32%
    Req/Sec    21.17k     1.12k   24.37k    78.17%
  Latency Distribution
     50%  199.00us
     75%  248.00us
     90%  315.00us
     99%    2.93ms
  1264226 requests in 30.01s, 61.49MB read
Requests/sec:  42127.59
Transfer/sec:      2.05MB
```