### PR TITLE
Initial implementation of general user land signal handling (unix only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "utime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/BUILD.gn
+++ b/cli/BUILD.gn
@@ -60,7 +60,10 @@ if (is_win) {
   ]
 }
 if (is_posix) {
-  main_extern_rlib += [ "nix" ]
+  main_extern_rlib += [
+    "nix",
+    "tokio_signal",
+  ]
 }
 
 ts_sources = [
@@ -121,6 +124,7 @@ ts_sources = [
   "../js/repl.ts",
   "../js/request.ts",
   "../js/resources.ts",
+  "../js/sigaction.ts",
   "../js/stat.ts",
   "../js/symlink.ts",
   "../js/text_encoding.ts",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -59,3 +59,4 @@ fwdansi = "1.0.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.14.1"
+tokio-signal = "0.2.7"

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -83,6 +83,12 @@ union Any {
   WorkerPostMessage,
   Write,
   WriteRes,
+
+  SignalListen,
+  SignalListenRes,
+
+  SignalPoll,
+  SignalPollRes,
 }
 
 enum ErrorKind: byte {
@@ -606,5 +612,21 @@ table Seek {
 }
 
 table GetRandomValues {}
+
+table SignalListen {
+  signo: int;
+}
+
+table SignalListenRes {
+  rid: uint32;
+}
+
+table SignalPoll {
+  rid: uint32;
+}
+
+table SignalPollRes {
+  signo: int;
+}
 
 root_type Base;

--- a/cli/resources.rs
+++ b/cli/resources.rs
@@ -261,15 +261,13 @@ impl Future for Resource {
       None => panic!("bad rid"),
       Some(repr) => match repr {
         Repr::SignalStream(ref mut s) => match s.poll() {
-          Ok(Async::Ready(Some(signo))) => return Ok(Async::Ready(signo)),
-          Ok(Async::Ready(None)) => {
-            return Err(Error::new(
-              std::io::ErrorKind::Other,
-              "Signal listen stopped.",
-            ))
-          }
-          Ok(Async::NotReady) => return Ok(Async::NotReady),
-          Err(err) => return Err(err),
+          Ok(Async::Ready(Some(signo))) => Ok(Async::Ready(signo)),
+          Ok(Async::Ready(None)) => Err(Error::new(
+            std::io::ErrorKind::Other,
+            "Signal listen stopped.",
+          )),
+          Ok(Async::NotReady) => Ok(Async::NotReady),
+          Err(err) => Err(err),
         },
         _ => panic!("Cannot poll as future"),
       },

--- a/cli/resources.rs
+++ b/cli/resources.rs
@@ -387,7 +387,9 @@ pub fn add_signal_stream(signo: i32) -> Resource {
   let mut tg = RESOURCE_TABLE.lock().unwrap();
   let r = tg.insert(
     rid,
-    Repr::SignalStream(Box::new(TokioSignal::new(signo).flatten_stream())),
+    // Need to wait, since sigmask might have not been set
+    // if just flatten stream.
+    Repr::SignalStream(Box::new(TokioSignal::new(signo).wait().unwrap())),
   );
   assert!(r.is_none());
   Resource { rid }

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -57,14 +57,14 @@ impl Future for AsyncType<CoreOpAsyncFuture> {
   fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
     match self {
       AsyncType::Required(ref mut r) => match r.poll() {
-        Ok(Ready(buf)) => return Ok(Ready(AsyncType::Required(buf))),
-        Ok(NotReady) => return Ok(NotReady),
-        Err(e) => return Err(e),
+        Ok(Ready(buf)) => Ok(Ready(AsyncType::Required(buf))),
+        Ok(NotReady) => Ok(NotReady),
+        Err(_) => Err(()),
       },
       AsyncType::Optional(ref mut r) => match r.poll() {
-        Ok(Ready(buf)) => return Ok(Ready(AsyncType::Optional(buf))),
-        Ok(NotReady) => return Ok(NotReady),
-        Err(e) => return Err(e),
+        Ok(Ready(buf)) => Ok(Ready(AsyncType::Optional(buf))),
+        Ok(NotReady) => Ok(NotReady),
+        Err(_) => Err(()),
       },
     }
   }

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -41,7 +41,7 @@ pub enum Op<E> {
 
 pub type CoreError = ();
 
-type CoreOpAsyncFuture = OpAsyncFuture<CoreError>;
+pub type CoreOpAsyncFuture = OpAsyncFuture<CoreError>;
 
 pub type CoreOp = Op<CoreError>;
 

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -79,6 +79,7 @@ export {
   ProcessStatus,
   Signal
 } from "./process";
+export { sigaction } from "./sigaction";
 export { inspect } from "./console";
 export { build, platform, OperatingSystem, Arch } from "./build";
 export { version } from "./version";

--- a/js/sigaction.ts
+++ b/js/sigaction.ts
@@ -1,0 +1,73 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import * as msg from "gen/cli/msg_generated";
+import * as flatbuffers from "./flatbuffers";
+import * as dispatch from "./dispatch";
+import { assert } from "./util";
+
+function reqListen(
+  signo: number
+): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.SignalListen.createSignalListen(builder, signo);
+  return [builder, msg.Any.SignalListen, inner];
+}
+
+function resListen(baseRes: null | msg.Base): number {
+  assert(baseRes !== null);
+  assert(msg.Any.SignalListenRes === baseRes!.innerType());
+  const res = new msg.SignalListenRes();
+  assert(baseRes!.inner(res) !== null);
+  const rid = res.rid();
+  assert(rid !== null);
+  return rid!;
+}
+
+function reqPoll(
+  rid: number
+): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.SignalPoll.createSignalPoll(builder, rid);
+  return [builder, msg.Any.SignalPoll, inner];
+}
+
+function resPoll(baseRes: null | msg.Base): number {
+  assert(baseRes !== null);
+  assert(msg.Any.SignalPollRes === baseRes!.innerType());
+  const res = new msg.SignalPollRes();
+  assert(baseRes!.inner(res) !== null);
+  const signo = res.signo();
+  assert(signo !== null);
+  return signo!;
+}
+
+type SignalHandler = () => void;
+
+interface SignalInfo {
+  rid: number;
+  handlers: SignalHandler[];
+}
+
+const handlerMap = new Map<number, SignalInfo>();
+
+async function startSignalLoop(rid: number): void {
+  while (true) {
+    const signo = resPoll(await dispatch.sendAsync(...reqPoll(rid)));
+    const signalInfo = handlerMap.get(signo);
+    assert(!!signalInfo);
+    signalInfo!.handlers.forEach((h: SignalHandler): void => h());
+  }
+}
+
+/** Register a handler for a given signal.
+ * Could be called multiple times to register extra handlers for the
+ * same signal.
+ */
+export function sigaction(signo: number, handler: SignalHandler): void {
+  if (!handlerMap.has(signo)) {
+    // register handler;
+    const rid = resListen(dispatch.sendSync(...reqListen(signo)));
+    handlerMap.set(signo, { rid, handlers: [] });
+    startSignalLoop(rid);
+  }
+  handlerMap.get(signo)!.handlers.push(handler);
+}

--- a/js/sigaction.ts
+++ b/js/sigaction.ts
@@ -2,7 +2,8 @@
 import * as msg from "gen/cli/msg_generated";
 import * as flatbuffers from "./flatbuffers";
 import * as dispatch from "./dispatch";
-import { assert } from "./util";
+import { assert, notImplemented } from "./util";
+import { build } from "./build";
 
 function reqListen(
   signo: number
@@ -49,7 +50,7 @@ interface SignalInfo {
 
 const handlerMap = new Map<number, SignalInfo>();
 
-async function startSignalLoop(rid: number): void {
+async function startSignalLoop(rid: number): Promise<void> {
   while (true) {
     const signo = resPoll(await dispatch.sendAsync(...reqPoll(rid)));
     const signalInfo = handlerMap.get(signo);
@@ -63,6 +64,10 @@ async function startSignalLoop(rid: number): void {
  * same signal.
  */
 export function sigaction(signo: number, handler: SignalHandler): void {
+  if (build.os === "win") {
+    notImplemented();
+  }
+
   if (!handlerMap.has(signo)) {
     // register handler;
     const rid = resListen(dispatch.sendSync(...reqListen(signo)));

--- a/js/sigaction_test.ts
+++ b/js/sigaction_test.ts
@@ -1,0 +1,39 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { testPerm, assertEquals, deferred } from "./test_util.ts";
+
+// Ignore signal tests on windows for now...
+if (Deno.platform.os !== "win") {
+  testPerm({ run: true, net: true }, async function sigactionTest(): Promise<
+    void
+  > {
+    const d = deferred();
+    let signalCaughtCount = 0;
+    Deno.sigaction(
+      Deno.Signal.SIGUSR1,
+      (): void => {
+        signalCaughtCount++;
+      }
+    );
+
+    Deno.sigaction(
+      Deno.Signal.SIGUSR1,
+      (): void => {
+        signalCaughtCount++;
+        d.resolve();
+      }
+    );
+
+    // Since signal listening is optional, Deno would exit
+    // immediately once there is no required tasks.
+    // To prevent this during testing, listen on a port
+    // for no reason such that we have required task
+    // to prevent exit.
+    const l = Deno.listen("tcp", "localhost:4999");
+
+    Deno.kill(Deno.pid, Deno.Signal.SIGUSR1);
+    await d;
+    assertEquals(signalCaughtCount, 2);
+
+    l.close();
+  });
+}

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -19,6 +19,7 @@ export {
   assertStrictEq,
   assertStrContains
 } from "./deps/https/deno.land/std/testing/asserts.ts";
+export { deferred } from "./deps/https/deno.land/std/util/async.ts";
 
 interface TestPermissions {
   read?: boolean;

--- a/js/unit_test_runner.ts
+++ b/js/unit_test_runner.ts
@@ -65,8 +65,14 @@ async function main(): Promise<void> {
       stdout: "piped"
     });
 
+    const output = await p.output();
+
+    if (cliPerms.length === 1 && cliPerms[0] === "--allow-run") {
+      console.log(">>>", new TextDecoder().decode(output));
+    }
+
     const { actual, expected, resultOutput } = parseUnitTestOutput(
-      await p.output(),
+      output,
       true
     );
 

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -38,6 +38,7 @@ import "./read_link_test.ts";
 import "./rename_test.ts";
 import "./request_test.ts";
 import "./resources_test.ts";
+import "./sigaction_test.ts";
 import "./stat_test.ts";
 import "./symlink_test.ts";
 import "./text_encoding_test.ts";


### PR DESCRIPTION
Implement general signal handling `sigaction(signo, handler)`.

Try it out by pressing Ctrl-C when running this script (wait for TS compiler to finish compile first, since it is not immune to SIGINT):
```ts
Deno.sigaction(Deno.Signal.SIGINT, () => {
  console.log(">> SIGINT caught (1)");
});

Deno.sigaction(Deno.Signal.SIGINT, () => {
  console.log(">> SIGINT caught (2)");
});

console.log("sigaction() DEMO starts");

setTimeout(() => {
  console.log("DONE");
}, 5000)
```

Notice that signal handler would not block script from exiting after timeout, and multiple handlers could be registered.

Achieved by implementing optional Op type which does not prevent process exit.

Code is hacked up so needs much polishing after confirming the approach. API design feedback also needed.

~~Tests needed.~~ Added basic unit test