### PR TITLE
v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "deno"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -225,12 +225,12 @@ dependencies = [
 
 [[package]]
 name = "deno_cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ansi_term 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "deno 0.13.0",
+ "deno 0.14.0",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Releases.md
+++ b/Releases.md
@@ -6,6 +6,27 @@ https://github.com/denoland/deno/releases
 We also have one-line install commands at
 https://github.com/denoland/deno_install
 
+### v0.14.0 / 2019.08.09
+
+In deno:
+
+- feat: remove `Deno.build.args` (#2728)
+- feat: support native line ending conversion in the `Blob` constructor (#2695)
+- feat: add option to delete the `Deno` namespace in a worker (#2717)
+- feat: support starting workers using a blob: URL (#2729)
+- feat: make `Deno.execPath()` a function (#2743, #2744)
+- feat: support `await import(...)` syntax for dynamic module imports (#2516)
+- fix: enforce permissions on `Deno.kill()`, `Deno.homeDir()` and
+  `Deno.execPath()` (#2714, #2723)
+- fix: `cargo build` now builds incrementally (#2740)
+- fix: avoid REPL crash when DENO_DIR doesn't exist (#2727)
+- fix: resolve worker module URLs relative to the host main module URL (#2751)
+- doc: improve documentation on using the V8 profiler (#2742)
+
+In deno_std:
+
+- fix: make the 'ws' module (websockets) work again (denoland/deno_std#550)
+
 ### v0.13.0 / 2019.07.31
 
 In deno:
@@ -23,9 +44,9 @@ In deno:
 
 In deno_std:
 
-- fix: Make shebangs Linux compatible (#545)
-- fix: Ignore error of writing responses to aborted requests (#546)
-- fix: use Deno.execPath where possible (#548)
+- fix: Make shebangs Linux compatible (denoland/deno_std#545)
+- fix: Ignore error of writing responses to aborted requests (denoland/deno_std#546)
+- fix: use Deno.execPath where possible (denoland/deno_std#548)
 
 ### v0.12.0 / 2019.07.16
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ path = "main.rs"
 
 [package]
 name = "deno_cli"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2018"
 
 [dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2018"
 description = "A secure JavaScript/TypeScript runtime built with V8, Rust, and Tokio"
 authors = ["The deno authors <bertbelder@nodejs.org>"]


### PR DESCRIPTION
### v0.14.0 / 2019.08.09

In deno:

- feat: remove `Deno.build.args` (#2728)
- feat: support native line ending conversion in the `Blob` constructor (#2695)
- feat: add option to delete the `Deno` namespace in a worker (#2717)
- feat: support starting workers using a blob: URL (#2729)
- feat: make `Deno.execPath()` a function (#2743, #2744)
- feat: support `await import(...)` syntax for dynamic module imports (#2516)
- fix: enforce permissions on `Deno.kill()`, `Deno.homeDir()` and
  `Deno.execPath()` (#2714, #2723)
- fix: `cargo build` now builds incrementally (#2740)
- fix: avoid REPL crash when DENO_DIR doesn't exist (#2727)
- fix: resolve worker module URLs relative to the host main module URL (#2751)
- doc: improve documentation on using the V8 profiler (#2742)

In deno_std:

- fix: make the 'ws' module (websockets) work again (denoland/deno_std#550)