### PR TITLE
Fix dynamic import base path problem for REPL and eval

### DIFF
--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -9,8 +9,10 @@ use deno::RecursiveLoad;
 use deno::StartupData;
 use futures::Async;
 use futures::Future;
+use std::env;
 use std::sync::Arc;
 use std::sync::Mutex;
+use url::Url;
 
 /// Wraps deno::Isolate to provide source maps, ops for the CLI, and
 /// high-level module loading
@@ -55,9 +57,11 @@ impl Worker {
     Self { isolate, state }
   }
 
-  /// Same as execute2() but the filename defaults to "<anonymous>".
+  /// Same as execute2() but the filename defaults to "$CWD/__anonymous__".
   pub fn execute(&mut self, js_source: &str) -> Result<(), ErrBox> {
-    self.execute2("<anonymous>", js_source)
+    let path = env::current_dir().unwrap().join("__anonymous__");
+    let url = Url::from_file_path(path).unwrap();
+    self.execute2(url.as_str(), js_source)
   }
 
   /// Executes the provided JavaScript source code. The js_filename argument is

--- a/tests/041_dyn_import_eval.out
+++ b/tests/041_dyn_import_eval.out
@@ -1,0 +1,1 @@
+{ isMod4: true }

--- a/tests/041_dyn_import_eval.test
+++ b/tests/041_dyn_import_eval.test
@@ -1,0 +1,2 @@
+args: eval import('./tests/subdir/mod4.js').then(console.log)
+output: tests/041_dyn_import_eval.out

--- a/tests/042_dyn_import_evalcontext.test
+++ b/tests/042_dyn_import_evalcontext.test
@@ -1,0 +1,2 @@
+args: run --reload tests/042_dyn_import_evalcontext.ts
+output: tests/042_dyn_import_evalcontext.ts.out

--- a/tests/042_dyn_import_evalcontext.ts
+++ b/tests/042_dyn_import_evalcontext.ts
@@ -1,0 +1,4 @@
+// @ts-ignore
+Deno.core.evalContext(
+  "(async () => console.log(await import('./tests/subdir/mod4.js')))()"
+);

--- a/tests/042_dyn_import_evalcontext.ts.out
+++ b/tests/042_dyn_import_evalcontext.ts.out
@@ -1,0 +1,1 @@
+{ isMod4: true }

--- a/tools/integration_tests.py
+++ b/tools/integration_tests.py
@@ -60,6 +60,7 @@ class TestIntegrations(DenoTestCase):
         if not args:
             return
 
+        # TODO(kevinkassimo): better args parsing with quotation marks.
         args = args.split(" ")
         check_stderr = str2bool(test.get("check_stderr", "false"))
         stderr = subprocess.STDOUT if check_stderr else open(os.devnull, 'w')


### PR DESCRIPTION
Closes #2756 

Separated into 2 parts, since `<anonymous>` is not known to core crate (while `<unknown>` is known), and that `<>` would be escaped for URL paths and looks ugly, thus replaced with `__anonymous__`.

We do not have a robust way to test REPL directly atm. Instead test on `Deno.core.evalContext` which is used by REPL.