### PR TITLE
fix: cache paths on Windows are broken

### DIFF
--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -43,7 +43,7 @@ impl DiskCache {
         }
       }
       "file" => {
-        eprintln!("url file path {:?}", url.to_file_path());
+        eprintln!("url file path {:?} {:?}", url.to_file_path(), url);
         let path = url.to_file_path().unwrap();
         let mut path_components = path.components();
 

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -58,7 +58,7 @@ impl DiskCache {
                 let disk = (disk_byte as char).to_string();
                 out.push(disk);
               }
-              _ => {}
+              _ => unreachable!(),
             }
           }
         }

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -47,20 +47,19 @@ impl DiskCache {
         let mut path_components = path.components();
 
         if cfg!(target_os = "windows") {
-          match path_components.next().unwrap() {
-            Component::Prefix(prefix_component) => {
-              // Windows doesn't support ":" in filenames, so we need to extract disk prefix
-              // Example: file:///C:/deno/js/unit_test_runner.ts
-              // it should produce: file\c\deno\js\unit_test_runner.ts
-              match prefix_component.kind() {
-                Prefix::Disk(disk_byte) | Prefix::VerbatimDisk(disk_byte) => {
-                  let disk = (disk_byte as char).to_string();
-                  out.push(disk);
-                }
-                _ => {}
+          if let Component::Prefix(prefix_component) =
+            path_components.next().unwrap()
+          {
+            // Windows doesn't support ":" in filenames, so we need to extract disk prefix
+            // Example: file:///C:/deno/js/unit_test_runner.ts
+            // it should produce: file\c\deno\js\unit_test_runner.ts
+            match prefix_component.kind() {
+              Prefix::Disk(disk_byte) | Prefix::VerbatimDisk(disk_byte) => {
+                let disk = (disk_byte as char).to_string();
+                out.push(disk);
               }
+              _ => {}
             }
-            _ => {}
           }
         }
 

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -43,6 +43,7 @@ impl DiskCache {
         }
       }
       "file" => {
+        eprintln!("url file path {:?}", url.to_file_path());
         let path = url.to_file_path().unwrap();
         let mut path_components = path.components();
 

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -47,7 +47,7 @@ impl DiskCache {
         let mut path_components = path.components();
 
         if cfg!(target_os = "windows") {
-          if let Ok(Component::Prefix(prefix_component)) =
+          if let Some(Component::Prefix(prefix_component)) =
             path_components.next()
           {
             eprintln!("prefix component {:?}", prefix_component);

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -185,7 +185,7 @@ mod tests {
       test_cases.push((
         "file:///D:/std/http/file_server",
         "js",
-        "file/D/a/1/s/format.ts",
+        "file/D/a/1/s/file_server.js",
       ));
     } else {
       test_cases.push((

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -47,9 +47,10 @@ impl DiskCache {
         let mut path_components = path.components();
 
         if cfg!(target_os = "windows") {
-          if let Component::Prefix(prefix_component) =
-            path_components.next().unwrap()
+          if let Ok(Component::Prefix(prefix_component)) =
+            path_components.next()
           {
+            eprintln!("prefix component {:?}", prefix_component);
             // Windows doesn't support ":" in filenames, so we need to extract disk prefix
             // Example: file:///C:/deno/js/unit_test_runner.ts
             // it should produce: file\c\deno\js\unit_test_runner.ts
@@ -60,6 +61,8 @@ impl DiskCache {
               }
               _ => {}
             }
+          } else {
+            eprintln!("no prefix component {:?}", path);
           }
         }
 

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -26,6 +26,7 @@ impl DiskCache {
 
     let scheme = url.scheme();
     out.push(scheme);
+
     match scheme {
       "http" | "https" => {
         let host = url.host_str().unwrap();
@@ -43,7 +44,7 @@ impl DiskCache {
       }
       "file" => {
         let path = url.to_file_path().unwrap();
-
+        let path_ = path.clone();
         let mut path_components = path.components();
 
         if cfg!(target_os = "windows") {
@@ -64,9 +65,20 @@ impl DiskCache {
           }
         }
 
-        out.join(path_components.as_path());
+        // Must be relative, so strip forward slash
+        let mut remaining_components = path_components.as_path();
+        if let Ok(stripped) = remaining_components.strip_prefix("/") {
+          remaining_components = stripped;
+        };
+
+        out = out.join(remaining_components);
       }
-      _ => {}
+      scheme => {
+        unimplemented!(
+          "Don't know how to create cache name for scheme: {}",
+          scheme
+        );
+      }
     };
 
     out

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -185,7 +185,7 @@ mod tests {
       test_cases.push((
         "file:///D:/std/http/file_server",
         "js",
-        "file/D/a/1/s/file_server.js",
+        "file/D/std/http/file_server.js",
       ));
     } else {
       test_cases.push((

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -44,7 +44,6 @@ impl DiskCache {
       }
       "file" => {
         let path = url.to_file_path().unwrap();
-        let path_ = path.clone();
         let mut path_components = path.components();
 
         if cfg!(target_os = "windows") {

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -41,6 +41,8 @@ impl DiskCache {
       _ => {}
     };
 
+    eprintln!("path segments: {:?}", url.path_segments().unwrap());
+
     for path_seg in url.path_segments().unwrap() {
       out.push(path_seg);
     }
@@ -92,7 +94,7 @@ mod tests {
   fn test_get_cache_filename() {
     let cache = DiskCache::new(&PathBuf::from("foo"));
 
-    let test_cases = [
+    let mut test_cases = [
       (
         "http://deno.land/std/http/file_server.ts",
         "http/deno.land/std/http/file_server.ts",
@@ -110,6 +112,15 @@ mod tests {
         "file/std/http/file_server.ts",
       ),
     ];
+
+    if cfg!(target_os = "windows") {
+      test_cases.push(
+        (
+          "file:///D:/a/1/s/format.ts",
+          "file/D/a/1/s/format.ts",
+        ),
+      )
+    }
 
     for test_case in &test_cases {
       assert_eq!(


### PR DESCRIPTION
Cache paths are not properly generated on Windows.

It's broken since v0.13.0.

Ref: 
denoland/deno_std#552
denoland/deno_std#556

Example:
```rust
file:///C:/deno/js/unit_test_runner.ts
// for above URL this cache path should be generated 
file\c\deno\js\unit_test_runner.ts
// this is produced (probably)
C:/deno/js/unit_test_runner.ts
```