### PR TITLE
Print error message and exit instead of panic for invalid tsconfig

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -113,10 +113,17 @@ fn create_worker_and_state(
       s.status(status, msg).expect("shell problem");
     }
   });
-  // TODO(kevinkassimo): maybe make include_deno_namespace also configurable?
-  let state =
-    ThreadSafeState::new(flags, argv, ops::op_selector_std, progress, true)
-      .unwrap();
+  let state = {
+    // TODO(kevinkassimo): maybe make include_deno_namespace also configurable?
+    let maybe_state =
+      ThreadSafeState::new(flags, argv, ops::op_selector_std, progress, true);
+    if let Err(e) = maybe_state {
+      // Just exit, as this is only called on Deno startup.
+      eprintln!("Failed to start Deno: {}", &e);
+      std::process::exit(1);
+    }
+    maybe_state.unwrap()
+  };
   let worker = Worker::new(
     "main".to_string(),
     startup_data::deno_isolate_init(),


### PR DESCRIPTION
For a bad tsconfig (invalid syntax, or with comments, this feature need to be supported later in a different PR),

Before:
```
$ deno --allow-net --config tsconfig.json server.ts
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ErrBox(DenoError { kind: InvalidInput, msg: "Compiler config is not a valid JSON" })', src/libcore/result.rs:999:5
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

After:
```
$ deno --allow-net --config tsconfig.json server.ts
Failed to start Deno: Compiler config is not a valid JSON
```