### PR TITLE
Fix import map panics, use import map's location as its base URL

### DIFF
--- a/cli/import_map.rs
+++ b/cli/import_map.rs
@@ -473,6 +473,15 @@ mod tests {
   use super::*;
 
   #[test]
+  fn load_nonexistent() {
+    let file_path = "nonexistent_import_map.json";
+    let file_url = ModuleSpecifier::resolve_url_or_path(file_path)
+      .unwrap()
+      .to_string();
+    assert!(ImportMap::load(&file_url, file_path).is_err());
+  }
+
+  #[test]
   fn from_json_1() {
     let base_url = "https://deno.land";
 

--- a/cli/import_map.rs
+++ b/cli/import_map.rs
@@ -46,9 +46,9 @@ pub struct ImportMap {
 }
 
 impl ImportMap {
-  pub fn load(base_url: &str, file_name: &str) -> Result<Self, ErrBox> {
-    let cwd = std::env::current_dir().unwrap();
-    let resolved_path = cwd.join(file_name);
+  pub fn load(file_path: &str) -> Result<Self, ErrBox> {
+    let file_url = ModuleSpecifier::resolve_url_or_path(file_path)?.to_string();
+    let resolved_path = std::env::current_dir().unwrap().join(file_path);
     debug!(
       "Attempt to load import map: {}",
       resolved_path.to_str().unwrap()
@@ -66,7 +66,8 @@ impl ImportMap {
         .as_str(),
       )
     })?;
-    ImportMap::from_json(base_url, &json_string).map_err(ErrBox::from)
+    // The URL of the import map is the base URL for its values.
+    ImportMap::from_json(&file_url, &json_string).map_err(ErrBox::from)
   }
 
   pub fn from_json(
@@ -482,10 +483,7 @@ mod tests {
   #[test]
   fn load_nonexistent() {
     let file_path = "nonexistent_import_map.json";
-    let file_url = ModuleSpecifier::resolve_url_or_path(file_path)
-      .unwrap()
-      .to_string();
-    assert!(ImportMap::load(&file_url, file_path).is_err());
+    assert!(ImportMap::load(file_path).is_err());
   }
 
   #[test]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -115,6 +115,7 @@ fn create_worker_and_state(
   // TODO(kevinkassimo): maybe make include_deno_namespace also configurable?
   let state =
     ThreadSafeState::new(flags, argv, ops::op_selector_std, progress, true)
+      .map_err(print_err_and_exit)
       .unwrap();
   let worker = Worker::new(
     "main".to_string(),

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -380,3 +380,17 @@ fn thread_safe() {
     String::from("hello.js"),
   ]));
 }
+
+#[test]
+fn import_map_given_for_repl() {
+  let _result = ThreadSafeState::new(
+    flags::DenoFlags {
+      import_map_path: Some("import_map.json".to_string()),
+      ..flags::DenoFlags::default()
+    },
+    vec![String::from("./deno")],
+    ops::op_selector_std,
+    Progress::new(),
+    true,
+  );
+}

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -200,14 +200,7 @@ impl ThreadSafeState {
 
     let import_map: Option<ImportMap> = match &flags.import_map_path {
       None => None,
-      Some(file_name) => {
-        let base_url = match &main_module {
-          Some(module_specifier) => module_specifier.clone(),
-          None => unreachable!(),
-        };
-        let import_map = ImportMap::load(&base_url.to_string(), file_name)?;
-        Some(import_map)
-      }
+      Some(file_path) => Some(ImportMap::load(file_path)?),
     };
 
     let mut seeded_rng = None;


### PR DESCRIPTION
Fixes #2769

Panics when
- [x] One is specified for REPL mode. [cli/state.rs#L198](https://github.com/denoland/deno/blob/9bd473d8ac9228e483bd26028dbe7ba88e971c08/cli/state.rs#L198)
- [x] It doesn't exist or can't be read. [cli/import_map.rs#L58](https://github.com/denoland/deno/blob/9bd473d8ac9228e483bd26028dbe7ba88e971c08/cli/import_map.rs#L58)
- [x] Any other `ImportMapError` occurs like parse failure, etc. These properly propagate to main.rs but get unwrapped there. [cli/main.rs#L200](https://github.com/denoland/deno/blob/9bd473d8ac9228e483bd26028dbe7ba88e971c08/cli/main.rs#L119)

Also:
- [x] Use import map's location as its base URL.
- [x] Add tests.