### PR TITLE
Propagate Url::to_file_path() errors instead of panicking

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -722,16 +722,13 @@ mod tests {
   }
 
   #[test]
-  fn test_invalid_fetch_local_file() {
+  #[cfg(windows)]
+  fn test_fetch_local_file_windows_hang() {
     let (_temp_dir, fetcher) = test_setup();
     let u = Url::parse("file:///etc/passwd").unwrap();
     let r = fetcher.fetch_local_file(&u);
-    if cfg!(target_os = "windows") {
-      let err = r.unwrap_err();
-      assert_eq!(err.kind(), ErrorKind::InvalidPath);
-    } else {
-      assert!(r.is_ok());
-    }
+    let err = r.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidPath);
   }
 
   #[test]

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -722,10 +722,17 @@ mod tests {
   }
 
   #[test]
-  fn test_fetch_local_file_panic() {
+  fn test_fetch_local_file_no_panic() {
     let (_temp_dir, fetcher) = test_setup();
-    let u = Url::parse("file:///etc/passwd").unwrap();
-    let _ = fetcher.fetch_local_file(&u);
+    if cfg!(windows) {
+      // Should fail: missing drive letter.
+      let u = Url::parse("file:///etc/passwd").unwrap();
+      fetcher.fetch_local_file(&u).unwrap_err();
+    } else {
+      // Should fail: local network paths are not supported on unix.
+      let u = Url::parse("file://server/etc/passwd").unwrap();
+      fetcher.fetch_local_file(&u).unwrap_err();
+    }
   }
 
   #[test]

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -722,13 +722,10 @@ mod tests {
   }
 
   #[test]
-  #[cfg(windows)]
-  fn test_fetch_local_file_windows_hang() {
+  fn test_fetch_local_file_panic() {
     let (_temp_dir, fetcher) = test_setup();
     let u = Url::parse("file:///etc/passwd").unwrap();
-    let r = fetcher.fetch_local_file(&u);
-    let err = r.unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::InvalidPath);
+    let _ = fetcher.fetch_local_file(&u);
   }
 
   #[test]

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -722,6 +722,19 @@ mod tests {
   }
 
   #[test]
+  fn test_invalid_fetch_local_file() {
+    let (_temp_dir, fetcher) = test_setup();
+    let u = Url::parse("file:///etc/passwd").unwrap();
+    let r = fetcher.fetch_local_file(&u);
+    if cfg!(target_os = "windows") {
+      let err = r.unwrap_err();
+      assert_eq!(err.kind(), ErrorKind::InvalidPath);
+    } else {
+      assert!(r.is_ok());
+    }
+  }
+
+  #[test]
   fn test_get_source_code_1() {
     let (temp_dir, fetcher) = test_setup();
     // http_util::fetch_sync_string requires tokio

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -213,7 +213,12 @@ impl SourceFileFetcher {
     self: &Self,
     module_url: &Url,
   ) -> Result<SourceFile, ErrBox> {
-    let filepath = module_url.to_file_path().expect("File URL expected");
+    let filepath = module_url.to_file_path().map_err(|()| {
+      ErrBox::from(DenoError::new(
+        ErrorKind::InvalidPath,
+        "File URL contains invalid path".to_owned(),
+      ))
+    })?;
 
     let source_code = match fs::read(filepath.clone()) {
       Ok(c) => c,


### PR DESCRIPTION
<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
