### PR TITLE
Set url property of fetch's response

### DIFF
--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -244,7 +244,6 @@ class Body implements domTypes.Body, domTypes.ReadableStream, io.ReadCloser {
 }
 
 export class Response implements domTypes.Response {
-  readonly url: string = "";
   statusText = "FIXME"; // TODO
   readonly type = "basic"; // TODO
   readonly redirected: boolean;
@@ -254,6 +253,7 @@ export class Response implements domTypes.Response {
   readonly body: Body;
 
   constructor(
+    readonly url: string,
     readonly status: number,
     headersList: Array<[string, string]>,
     rid: number,
@@ -312,6 +312,7 @@ export class Response implements domTypes.Response {
     }
 
     return new Response(
+      this.url,
       this.status,
       headersList,
       -1,
@@ -458,7 +459,13 @@ export async function fetch(
 
     const headersList = deserializeHeaderFields(header);
 
-    const response = new Response(status, headersList, bodyRid, redirected);
+    const response = new Response(
+      url,
+      status,
+      headersList,
+      bodyRid,
+      redirected
+    );
     if ([301, 302, 303, 307, 308].includes(response.status)) {
       // We're in a redirect status
       switch ((init && init.redirect) || "follow") {

--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -18,6 +18,11 @@ test(async function fetchPerm(): Promise<void> {
   assertEquals(err.name, "PermissionDenied");
 });
 
+testPerm({ net: true }, async function fetchUrl(): Promise<void> {
+  const response = await fetch("http://localhost:4545/package.json");
+  assertEquals(response.url, "http://localhost:4545/package.json");
+});
+
 testPerm({ net: true }, async function fetchHeaders(): Promise<void> {
   const response = await fetch("http://localhost:4545/package.json");
   const headers = response.headers;
@@ -102,6 +107,7 @@ testPerm(
 testPerm({ net: true }, async function fetchWithRedirection(): Promise<void> {
   const response = await fetch("http://localhost:4546/"); // will redirect to http://localhost:4545/
   assertEquals(response.status, 200);
+  assertEquals(response.url, "http://localhost:4545/");
   const body = await response.text();
   assert(body.includes("<title>Directory listing for /</title>"));
 });


### PR DESCRIPTION
This PR sets `url` property of response object.

closes #2781 