### PR TITLE
chore: bump test runner version

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -682,7 +682,7 @@ const PRETTIER_URL: &str = "https://deno.land/std@v0.11/prettier/main.ts";
 /// Used for `deno install...` subcommand
 const INSTALLER_URL: &str = "https://deno.land/std@v0.11/installer/mod.ts";
 /// Used for `deno test...` subcommand
-const TEST_RUNNER_URL: &str = "https://deno.land/std@c44e536/testing/runner.ts";
+const TEST_RUNNER_URL: &str = "https://deno.land/std@15afc61/testing/runner.ts";
 
 /// These are currently handled subcommands.
 /// There is no "Help" subcommand because it's handled by `clap::App` itself.

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1753,7 +1753,13 @@ mod tests {
       "some_dir/",
       "**/*_test.ts"
     ]);
-    assert_eq!(flags, DenoFlags::default());
+    assert_eq!(
+      flags,
+      DenoFlags {
+        allow_read: true,
+        ..DenoFlags::default()
+      }
+    );
     assert_eq!(subcommand, DenoSubcommand::Run);
     assert_eq!(
       argv,

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1743,4 +1743,27 @@ mod tests {
     assert_eq!(subcommand, DenoSubcommand::Run);
     assert_eq!(argv, svec!["deno", "script.ts"])
   }
+
+  #[test]
+  fn test_flags_from_vec_36() {
+    let (flags, subcommand, argv) = flags_from_vec(svec![
+      "deno",
+      "test",
+      "--exclude",
+      "some_dir/",
+      "**/*_test.ts"
+    ]);
+    assert_eq!(flags, DenoFlags::default());
+    assert_eq!(subcommand, DenoSubcommand::Run);
+    assert_eq!(
+      argv,
+      svec![
+        "deno",
+        TEST_RUNNER_URL,
+        "--exclude",
+        "some_dir/",
+        "**/*_test.ts"
+      ]
+    )
+  }
 }


### PR DESCRIPTION
Because denoland/deno_std#564 landed after #2783 

CC @ry

~~Let's not merge it yet, there are still some quirks I'll try to resolve tonight~~

Seems ok