### PR TITLE
chore: bump test runner

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -682,7 +682,7 @@ const PRETTIER_URL: &str = "https://deno.land/std@v0.11/prettier/main.ts";
 /// Used for `deno install...` subcommand
 const INSTALLER_URL: &str = "https://deno.land/std@v0.11/installer/mod.ts";
 /// Used for `deno test...` subcommand
-const TEST_RUNNER_URL: &str = "https://deno.land/std@15afc61/testing/runner.ts";
+const TEST_RUNNER_URL: &str = "https://deno.land/std@4531fa8/testing/runner.ts";
 
 /// These are currently handled subcommands.
 /// There is no "Help" subcommand because it's handled by `clap::App` itself.


### PR DESCRIPTION
This PR bumps test runner URL to latest revision (https://github.com/denoland/deno_std/commit/4531fa81597c346fd291c1d1a2063789369fb84d)
so the problem described in denoland/deno_std#568 no longer occurs