### PR TITLE
Revert json ops

### DIFF
--- a/cli/deno_error.rs
+++ b/cli/deno_error.rs
@@ -205,18 +205,6 @@ impl GetErrorKind for ReadlineError {
   }
 }
 
-impl GetErrorKind for serde_json::error::Error {
-  fn kind(&self) -> ErrorKind {
-    use serde_json::error::*;
-    match self.classify() {
-      Category::Io => ErrorKind::InvalidInput,
-      Category::Syntax => ErrorKind::InvalidInput,
-      Category::Data => ErrorKind::InvalidData,
-      Category::Eof => ErrorKind::UnexpectedEof,
-    }
-  }
-}
-
 #[cfg(unix)]
 mod unix {
   use super::{ErrorKind, GetErrorKind};
@@ -263,11 +251,6 @@ impl GetErrorKind for dyn AnyError {
       .or_else(|| self.downcast_ref::<uri::InvalidUri>().map(Get::kind))
       .or_else(|| self.downcast_ref::<url::ParseError>().map(Get::kind))
       .or_else(|| self.downcast_ref::<ReadlineError>().map(Get::kind))
-      .or_else(|| {
-        self
-          .downcast_ref::<serde_json::error::Error>()
-          .map(Get::kind)
-      })
       .or_else(|| unix_error_kind(self))
       .unwrap_or_else(|| {
         panic!("Can't get ErrorKind for {:?}", self);

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -32,6 +32,7 @@ mod http_body;
 mod http_util;
 mod import_map;
 pub mod msg;
+pub mod msg_util;
 pub mod ops;
 pub mod permissions;
 mod progress;

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -1,14 +1,23 @@
 union Any {
   Accept,
+  ApplySourceMap,
+  Cache,
   Chdir,
   Chmod,
   Chown,
+  Close,
   CopyFile,
   CreateWorker,
   CreateWorkerRes,
   Cwd,
   CwdRes,
   Dial,
+  Fetch,
+  FetchSourceFile,
+  FetchSourceFileRes,
+  FetchRes,
+  FormatError,
+  FormatErrorRes,
   GetRandomValues,
   GlobalTimer,
   GlobalTimerRes,
@@ -29,6 +38,8 @@ union Any {
   NewConn,
   Now,
   NowRes,
+  Open,
+  OpenRes,
   PermissionRevoke,
   Permissions,
   PermissionsRes,
@@ -204,6 +215,33 @@ table WorkerPostMessage {
   // data passed thru the zero-copy data parameter.
 }
 
+table FetchSourceFile {
+  specifier: string;
+  referrer: string;
+}
+
+table FetchSourceFileRes {
+  // If it's a non-http module, moduleName and filename will be the same.
+  // For http modules, module_name is its resolved http URL, and filename
+  // is the location of the locally downloaded source code.
+  module_name: string;
+  filename: string;
+  media_type: MediaType;
+  data: [ubyte];
+}
+
+table ApplySourceMap {
+  filename: string;
+  line: int;
+  column: int;
+}
+
+table Cache {
+  extension: string;
+  module_id: string;
+  contents: string;
+}
+
 table Chdir {
   directory: string;
 }
@@ -234,6 +272,29 @@ table PermissionsRes {
   net: bool;
   env: bool;
   hrtime: bool;
+}
+
+// Note this represents The WHOLE header of an http message, not just the key
+// value pairs. That means it includes method and url for Requests and status
+// for responses. This is why it is singular "Header" instead of "Headers".
+table HttpHeader {
+  is_request: bool;
+  // Request only:
+  method: string;
+  url: string;
+  // Response only:
+  status: uint16;
+  // Both:
+  fields: [KeyValue];
+}
+
+table Fetch {
+  header: HttpHeader;
+}
+
+table FetchRes {
+  header: HttpHeader;
+  body_rid: uint32;
 }
 
 table MakeTempDir {
@@ -355,6 +416,16 @@ table Truncate {
   len: uint;
 }
 
+table Open {
+  filename: string;
+  perm: uint;
+  mode: string;
+}
+
+table OpenRes {
+  rid: uint32;
+}
+
 table Read {
   rid: uint32;
   // (ptr, len) is passed as second parameter to Deno.core.send().
@@ -371,6 +442,10 @@ table Write {
 
 table WriteRes {
   nbyte: uint;
+}
+
+table Close {
+  rid: uint32;
 }
 
 table Kill {

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -1,14 +1,37 @@
 union Any {
+  Accept,
   Chdir,
   Chmod,
   Chown,
   CopyFile,
+  CreateWorker,
+  CreateWorkerRes,
   Cwd,
   CwdRes,
+  Dial,
+  GetRandomValues,
+  GlobalTimer,
+  GlobalTimerRes,
+  GlobalTimerStop,
+  HostGetMessage,
+  HostGetMessageRes,
+  HostGetWorkerClosed,
+  HostPostMessage,
+  Kill,
   Link,
+  Listen,
+  ListenRes,
   MakeTempDir,
   MakeTempDirRes,
+  Metrics,
+  MetricsRes,
   Mkdir,
+  NewConn,
+  Now,
+  NowRes,
+  PermissionRevoke,
+  Permissions,
+  PermissionsRes,
   Read,
   ReadDir,
   ReadDirRes,
@@ -17,11 +40,25 @@ union Any {
   ReadlinkRes,
   Remove,
   Rename,
+  ReplReadline,
+  ReplReadlineRes,
+  ReplStart,
+  ReplStartRes,
+  Resources,
+  ResourcesRes,
+  Run,
+  RunRes,
+  RunStatus,
+  RunStatusRes,
   Seek,
+  Shutdown,
   Stat,
   StatRes,
   Symlink,
   Truncate,
+  WorkerGetMessage,
+  WorkerGetMessageRes,
+  WorkerPostMessage,
   Write,
   WriteRes,
 }
@@ -122,13 +159,81 @@ table FormatErrorRes {
   error: string;
 }
 
+// Create worker as host
+table CreateWorker {
+  specifier: string;
+  include_deno_namespace: bool;
+  has_source_code: bool;
+  source_code: string;
+}
+
+table CreateWorkerRes {
+  rid: uint32;
+}
+
+table HostGetWorkerClosed {
+  rid: uint32;
+}
+
+// Get message from guest worker as host
+table HostGetMessage {
+  rid: uint32;
+}
+
+table HostGetMessageRes {
+  data: [ubyte];
+}
+
+// Post message to guest worker as host
+table HostPostMessage {
+  rid: uint32;
+  // data passed thru the zero-copy data parameter.
+}
+
+// Get message from host as guest worker
+table WorkerGetMessage {
+  unused: int8;
+}
+
+table WorkerGetMessageRes {
+  data: [ubyte];
+}
+
+// Post message to host as guest worker
+table WorkerPostMessage {
+  // data passed thru the zero-copy data parameter.
+}
+
 table Chdir {
   directory: string;
 }
 
+table GlobalTimer {
+  timeout: int;
+}
+
+table GlobalTimerRes { }
+
+table GlobalTimerStop { }
+
 table KeyValue {
   key: string;
   value: string;
+}
+
+table Permissions {}
+
+table PermissionRevoke {
+  permission: string;
+}
+
+table PermissionsRes {
+  run: bool;
+  read: bool;
+  write: bool;
+  net: bool;
+  env: bool;
+  hrtime: bool;
 }
 
 table MakeTempDir {
@@ -189,6 +294,35 @@ table ReadlinkRes {
   path: string;
 }
 
+table ReplStart {
+  history_file: string;
+  // TODO add config
+}
+
+table ReplStartRes {
+  rid: uint32;
+}
+
+table ReplReadline {
+  rid: uint32;
+  prompt: string;
+}
+
+table ReplReadlineRes {
+  line: string;
+}
+
+table Resources {}
+
+table Resource {
+  rid: uint32;
+  repr: string;
+}
+
+table ResourcesRes {
+  resources: [Resource];
+}
+
 table Symlink {
   oldname: string;
   newname: string;
@@ -239,10 +373,99 @@ table WriteRes {
   nbyte: uint;
 }
 
+table Kill {
+  pid: int32;
+  signo: int32;
+}
+
+table Shutdown {
+  rid: uint32;
+  how: uint;
+}
+
+table Listen {
+  network: string;
+  address: string;
+}
+
+table ListenRes {
+  rid: uint32;
+}
+
+table Accept {
+  rid: uint32;
+}
+
+table Dial {
+  network: string;
+  address: string;
+}
+
+// Response to Accept and Dial.
+table NewConn {
+  rid: uint32;
+  remote_addr: string;
+  local_addr: string;
+}
+
+table Metrics {}
+
+table MetricsRes {
+  ops_dispatched: uint64;
+  ops_completed: uint64;
+  bytes_sent_control: uint64;
+  bytes_sent_data: uint64;
+  bytes_received: uint64;
+}
+
+enum ProcessStdio: byte { Inherit, Piped, Null }
+
+table Run {
+  args: [string];
+  cwd: string;
+  env: [KeyValue];
+  stdin: ProcessStdio;
+  stdout: ProcessStdio;
+  stderr: ProcessStdio;
+  stdin_rid: uint32;
+  stdout_rid: uint32;
+  stderr_rid: uint32;
+}
+
+table RunRes {
+  rid: uint32;
+  pid: uint32;
+  // The following stdio rids are only valid if "Piped" was specified for the
+  // corresponding stdio stream. The caller MUST issue a close op for all valid
+  // stdio streams.
+  stdin_rid: uint32;
+  stdout_rid: uint32;
+  stderr_rid: uint32;
+}
+
+table RunStatus {
+  rid: uint32;
+}
+
+table RunStatusRes {
+  got_signal: bool;
+  exit_code: int;
+  exit_signal: int;
+}
+
+table Now {}
+
+table NowRes {
+  seconds: uint64;
+  subsec_nanos: uint32;
+}
+
 table Seek {
   rid: uint32;
   offset: int;
   whence: uint;
 }
+
+table GetRandomValues {}
 
 root_type Base;

--- a/cli/msg.fbs
+++ b/cli/msg.fbs
@@ -62,11 +62,16 @@ union Any {
   RunStatus,
   RunStatusRes,
   Seek,
+  SetEnv,
   Shutdown,
+  Start,
+  StartRes,
   Stat,
   StatRes,
   Symlink,
   Truncate,
+  HomeDir,
+  HomeDirRes,
   WorkerGetMessage,
   WorkerGetMessageRes,
   WorkerPostMessage,
@@ -162,6 +167,25 @@ table Base {
   inner: Any;
 }
 
+table Start {
+  unused: int8;
+}
+
+table StartRes {
+  cwd: string;
+  pid: uint32;
+  argv: [string];
+  main_module: string; // Absolute URL.
+  debug_flag: bool;
+  deps_flag: bool;
+  types_flag: bool;
+  version_flag: bool;
+  deno_version: string;
+  v8_version: string;
+  no_color: bool;
+  xeval_delim: string;
+}
+
 table FormatError {
   error: string;
 }
@@ -253,6 +277,11 @@ table GlobalTimer {
 table GlobalTimerRes { }
 
 table GlobalTimerStop { }
+
+table SetEnv {
+  key: string;
+  value: string;
+}
 
 table KeyValue {
   key: string;
@@ -414,6 +443,12 @@ table StatRes {
 table Truncate {
   name: string;
   len: uint;
+}
+
+table HomeDir {}
+
+table HomeDirRes {
+  path: string;
 }
 
 table Open {

--- a/cli/msg.rs
+++ b/cli/msg.rs
@@ -1,8 +1,22 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 #![allow(dead_code)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::all, clippy::pedantic))]
+use crate::state;
 use flatbuffers;
+use std::sync::atomic::Ordering;
 
 // GN_OUT_DIR is set either by build.rs (for the Cargo build), or by
 // build_extra/rust/run.py (for the GN+Ninja build).
 include!(concat!(env!("GN_OUT_DIR"), "/gen/cli/msg_generated.rs"));
+
+impl<'a> From<&'a state::Metrics> for MetricsResArgs {
+  fn from(m: &'a state::Metrics) -> Self {
+    MetricsResArgs {
+      ops_dispatched: m.ops_dispatched.load(Ordering::SeqCst) as u64,
+      ops_completed: m.ops_completed.load(Ordering::SeqCst) as u64,
+      bytes_sent_control: m.bytes_sent_control.load(Ordering::SeqCst) as u64,
+      bytes_sent_data: m.bytes_sent_data.load(Ordering::SeqCst) as u64,
+      bytes_received: m.bytes_received.load(Ordering::SeqCst) as u64,
+    }
+  }
+}

--- a/cli/msg_util.rs
+++ b/cli/msg_util.rs
@@ -1,0 +1,124 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+// Helpers for serialization.
+use crate::msg;
+use deno::ErrBox;
+use flatbuffers;
+use http::header::HeaderName;
+use http::uri::Uri;
+use http::Method;
+use hyper::header::HeaderMap;
+use hyper::header::HeaderValue;
+use hyper::Body;
+use hyper::Request;
+use hyper::Response;
+use std::str::FromStr;
+
+type Headers = HeaderMap<HeaderValue>;
+
+pub fn serialize_key_value<'bldr>(
+  builder: &mut flatbuffers::FlatBufferBuilder<'bldr>,
+  key: &str,
+  value: &str,
+) -> flatbuffers::WIPOffset<msg::KeyValue<'bldr>> {
+  let key = builder.create_string(&key);
+  let value = builder.create_string(&value);
+  msg::KeyValue::create(
+    builder,
+    &msg::KeyValueArgs {
+      key: Some(key),
+      value: Some(value),
+    },
+  )
+}
+
+pub fn serialize_request_header<'bldr>(
+  builder: &mut flatbuffers::FlatBufferBuilder<'bldr>,
+  r: &Request<Body>,
+) -> flatbuffers::WIPOffset<msg::HttpHeader<'bldr>> {
+  let method = builder.create_string(r.method().as_str());
+  let url = builder.create_string(r.uri().to_string().as_ref());
+
+  let mut fields = Vec::new();
+  for (key, val) in r.headers().iter() {
+    let kv = serialize_key_value(builder, key.as_ref(), val.to_str().unwrap());
+    fields.push(kv);
+  }
+  let fields = builder.create_vector(fields.as_ref());
+
+  msg::HttpHeader::create(
+    builder,
+    &msg::HttpHeaderArgs {
+      is_request: true,
+      method: Some(method),
+      url: Some(url),
+      fields: Some(fields),
+      ..Default::default()
+    },
+  )
+}
+
+pub fn serialize_fields<'bldr>(
+  builder: &mut flatbuffers::FlatBufferBuilder<'bldr>,
+  headers: &Headers,
+) -> flatbuffers::WIPOffset<
+  flatbuffers::Vector<
+    'bldr,
+    flatbuffers::ForwardsUOffset<msg::KeyValue<'bldr>>,
+  >,
+> {
+  let mut fields = Vec::new();
+  for (key, val) in headers.iter() {
+    let kv = serialize_key_value(builder, key.as_ref(), val.to_str().unwrap());
+    fields.push(kv);
+  }
+  builder.create_vector(fields.as_ref())
+}
+
+// Not to be confused with serialize_response which has nothing to do with HTTP.
+pub fn serialize_http_response<'bldr>(
+  builder: &mut flatbuffers::FlatBufferBuilder<'bldr>,
+  r: &Response<Body>,
+) -> flatbuffers::WIPOffset<msg::HttpHeader<'bldr>> {
+  let status = r.status().as_u16();
+  let fields = serialize_fields(builder, r.headers());
+  msg::HttpHeader::create(
+    builder,
+    &msg::HttpHeaderArgs {
+      is_request: false,
+      status,
+      fields: Some(fields),
+      ..Default::default()
+    },
+  )
+}
+
+pub fn deserialize_request(
+  header_msg: msg::HttpHeader<'_>,
+  body: Body,
+) -> Result<Request<Body>, ErrBox> {
+  let mut r = Request::new(body);
+
+  assert!(header_msg.is_request());
+
+  let u = header_msg.url().unwrap();
+  let u = Uri::from_str(u).map_err(ErrBox::from)?;
+  *r.uri_mut() = u;
+
+  if let Some(method) = header_msg.method() {
+    let method = Method::from_str(method).unwrap();
+    *r.method_mut() = method;
+  }
+
+  if let Some(fields) = header_msg.fields() {
+    let headers = r.headers_mut();
+    for i in 0..fields.len() {
+      let kv = fields.get(i);
+      let key = kv.key().unwrap();
+      let name = HeaderName::from_bytes(key.as_bytes()).unwrap();
+      let value = kv.value().unwrap();
+      let v = HeaderValue::from_str(value).unwrap();
+      headers.insert(name, v);
+    }
+  }
+  Ok(r)
+}

--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -1,68 +1,86 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use super::dispatch_json::{Deserialize, JsonOp, Value};
+use super::dispatch_flatbuffers::serialize_response;
+use super::utils::*;
+use crate::deno_error;
+use crate::msg;
 use crate::state::ThreadSafeState;
 use crate::tokio_util;
 use deno::*;
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct CacheArgs {
-  module_id: String,
-  contents: String,
-  extension: String,
-}
+use flatbuffers::FlatBufferBuilder;
+use futures::Future;
 
 pub fn op_cache(
   state: &ThreadSafeState,
-  args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  let args: CacheArgs = serde_json::from_value(args)?;
+  base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> CliOpResult {
+  assert!(data.is_none());
+  let inner = base.inner_as_cache().unwrap();
+  let extension = inner.extension().unwrap();
+  // TODO: rename to something with 'url'
+  let module_id = inner.module_id().unwrap();
+  let contents = inner.contents().unwrap();
 
-  let module_specifier = ModuleSpecifier::resolve_url(&args.module_id)
+  let module_specifier = ModuleSpecifier::resolve_url(module_id)
     .expect("Should be valid module specifier");
 
   state.ts_compiler.cache_compiler_output(
     &module_specifier,
-    &args.extension,
-    &args.contents,
+    extension,
+    contents,
   )?;
 
-  Ok(JsonOp::Sync(json!({})))
-}
-
-#[derive(Deserialize)]
-struct FetchSourceFileArgs {
-  specifier: String,
-  referrer: String,
+  ok_buf(empty_buf())
 }
 
 pub fn op_fetch_source_file(
   state: &ThreadSafeState,
-  args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  let args: FetchSourceFileArgs = serde_json::from_value(args)?;
+  base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> CliOpResult {
+  if !base.sync() {
+    return Err(deno_error::no_async_support());
+  }
+  assert!(data.is_none());
+  let inner = base.inner_as_fetch_source_file().unwrap();
+  let cmd_id = base.cmd_id();
+  let specifier = inner.specifier().unwrap();
+  let referrer = inner.referrer().unwrap();
 
   // TODO(ry) Maybe a security hole. Only the compiler worker should have access
   // to this. Need a test to demonstrate the hole.
   let is_dyn_import = false;
 
   let resolved_specifier =
-    state.resolve(&args.specifier, &args.referrer, false, is_dyn_import)?;
+    state.resolve(specifier, referrer, false, is_dyn_import)?;
 
   let fut = state
     .file_fetcher
-    .fetch_source_file_async(&resolved_specifier);
+    .fetch_source_file_async(&resolved_specifier)
+    .and_then(move |out| {
+      let builder = &mut FlatBufferBuilder::new();
+      let data_off = builder.create_vector(out.source_code.as_slice());
+      let msg_args = msg::FetchSourceFileResArgs {
+        module_name: Some(builder.create_string(&out.url.to_string())),
+        filename: Some(builder.create_string(&out.filename.to_str().unwrap())),
+        media_type: out.media_type,
+        data: Some(data_off),
+      };
+      let inner = msg::FetchSourceFileRes::create(builder, &msg_args);
+      Ok(serialize_response(
+        cmd_id,
+        builder,
+        msg::BaseArgs {
+          inner: Some(inner.as_union_value()),
+          inner_type: msg::Any::FetchSourceFileRes,
+          ..Default::default()
+        },
+      ))
+    });
 
   // WARNING: Here we use tokio_util::block_on() which starts a new Tokio
   // runtime for executing the future. This is so we don't inadvernently run
   // out of threads in the main runtime.
-  let out = tokio_util::block_on(fut)?;
-  Ok(JsonOp::Sync(json!({
-    "moduleName": out.url.to_string(),
-    "filename": out.filename.to_str().unwrap(),
-    "mediaType": out.media_type as i32,
-    "sourceCode": String::from_utf8(out.source_code).unwrap(),
-  })))
+  let result_buf = tokio_util::block_on(fut)?;
+  Ok(Op::Sync(result_buf))
 }

--- a/cli/ops/dispatch_flatbuffers.rs
+++ b/cli/ops/dispatch_flatbuffers.rs
@@ -6,7 +6,10 @@ use deno::*;
 use flatbuffers::FlatBufferBuilder;
 use hyper::rt::Future;
 
-use super::files::{op_read, op_write};
+use super::compiler::{op_cache, op_fetch_source_file};
+use super::errors::{op_apply_source_map, op_format_error};
+use super::fetch::op_fetch;
+use super::files::{op_close, op_open, op_read, op_seek, op_write};
 use super::fs::{
   op_chdir, op_chmod, op_chown, op_copy_file, op_cwd, op_link,
   op_make_temp_dir, op_mkdir, op_read_dir, op_read_link, op_remove, op_rename,
@@ -139,13 +142,19 @@ pub fn serialize_response(
 pub fn op_selector_std(inner_type: msg::Any) -> Option<CliDispatchFn> {
   match inner_type {
     msg::Any::Accept => Some(op_accept),
+    msg::Any::ApplySourceMap => Some(op_apply_source_map),
+    msg::Any::Cache => Some(op_cache),
     msg::Any::Chdir => Some(op_chdir),
     msg::Any::Chmod => Some(op_chmod),
     msg::Any::Chown => Some(op_chown),
+    msg::Any::Close => Some(op_close),
     msg::Any::CopyFile => Some(op_copy_file),
     msg::Any::CreateWorker => Some(op_create_worker),
     msg::Any::Cwd => Some(op_cwd),
     msg::Any::Dial => Some(op_dial),
+    msg::Any::Fetch => Some(op_fetch),
+    msg::Any::FetchSourceFile => Some(op_fetch_source_file),
+    msg::Any::FormatError => Some(op_format_error),
     msg::Any::GetRandomValues => Some(op_get_random_values),
     msg::Any::GlobalTimer => Some(op_global_timer),
     msg::Any::GlobalTimerStop => Some(op_global_timer_stop),
@@ -159,6 +168,7 @@ pub fn op_selector_std(inner_type: msg::Any) -> Option<CliDispatchFn> {
     msg::Any::Metrics => Some(op_metrics),
     msg::Any::Mkdir => Some(op_mkdir),
     msg::Any::Now => Some(op_now),
+    msg::Any::Open => Some(op_open),
     msg::Any::PermissionRevoke => Some(op_revoke_permission),
     msg::Any::Permissions => Some(op_permissions),
     msg::Any::Read => Some(op_read),
@@ -171,6 +181,7 @@ pub fn op_selector_std(inner_type: msg::Any) -> Option<CliDispatchFn> {
     msg::Any::Resources => Some(op_resources),
     msg::Any::Run => Some(op_run),
     msg::Any::RunStatus => Some(op_run_status),
+    msg::Any::Seek => Some(op_seek),
     msg::Any::Shutdown => Some(op_shutdown),
     msg::Any::Stat => Some(op_stat),
     msg::Any::Symlink => Some(op_symlink),

--- a/cli/ops/dispatch_flatbuffers.rs
+++ b/cli/ops/dispatch_flatbuffers.rs
@@ -12,6 +12,19 @@ use super::fs::{
   op_make_temp_dir, op_mkdir, op_read_dir, op_read_link, op_remove, op_rename,
   op_stat, op_symlink, op_truncate,
 };
+use super::metrics::op_metrics;
+use super::net::{op_accept, op_dial, op_listen, op_shutdown};
+use super::performance::op_now;
+use super::permissions::{op_permissions, op_revoke_permission};
+use super::process::{op_kill, op_run, op_run_status};
+use super::random::op_get_random_values;
+use super::repl::{op_repl_readline, op_repl_start};
+use super::resources::op_resources;
+use super::timers::{op_global_timer, op_global_timer_stop};
+use super::workers::{
+  op_create_worker, op_host_get_message, op_host_get_worker_closed,
+  op_host_post_message, op_worker_get_message, op_worker_post_message,
+};
 
 type CliDispatchFn = fn(
   state: &ThreadSafeState,
@@ -125,23 +138,49 @@ pub fn serialize_response(
 /// Standard ops set for most isolates
 pub fn op_selector_std(inner_type: msg::Any) -> Option<CliDispatchFn> {
   match inner_type {
+    msg::Any::Accept => Some(op_accept),
     msg::Any::Chdir => Some(op_chdir),
     msg::Any::Chmod => Some(op_chmod),
     msg::Any::Chown => Some(op_chown),
     msg::Any::CopyFile => Some(op_copy_file),
+    msg::Any::CreateWorker => Some(op_create_worker),
     msg::Any::Cwd => Some(op_cwd),
+    msg::Any::Dial => Some(op_dial),
+    msg::Any::GetRandomValues => Some(op_get_random_values),
+    msg::Any::GlobalTimer => Some(op_global_timer),
+    msg::Any::GlobalTimerStop => Some(op_global_timer_stop),
+    msg::Any::HostGetMessage => Some(op_host_get_message),
+    msg::Any::HostGetWorkerClosed => Some(op_host_get_worker_closed),
+    msg::Any::HostPostMessage => Some(op_host_post_message),
+    msg::Any::Kill => Some(op_kill),
     msg::Any::Link => Some(op_link),
+    msg::Any::Listen => Some(op_listen),
     msg::Any::MakeTempDir => Some(op_make_temp_dir),
+    msg::Any::Metrics => Some(op_metrics),
     msg::Any::Mkdir => Some(op_mkdir),
+    msg::Any::Now => Some(op_now),
+    msg::Any::PermissionRevoke => Some(op_revoke_permission),
+    msg::Any::Permissions => Some(op_permissions),
     msg::Any::Read => Some(op_read),
     msg::Any::ReadDir => Some(op_read_dir),
     msg::Any::Readlink => Some(op_read_link),
     msg::Any::Remove => Some(op_remove),
     msg::Any::Rename => Some(op_rename),
+    msg::Any::ReplReadline => Some(op_repl_readline),
+    msg::Any::ReplStart => Some(op_repl_start),
+    msg::Any::Resources => Some(op_resources),
+    msg::Any::Run => Some(op_run),
+    msg::Any::RunStatus => Some(op_run_status),
+    msg::Any::Shutdown => Some(op_shutdown),
     msg::Any::Stat => Some(op_stat),
     msg::Any::Symlink => Some(op_symlink),
     msg::Any::Truncate => Some(op_truncate),
     msg::Any::Write => Some(op_write),
+
+    // TODO(ry) split these out so that only the appropriate Workers can access
+    // them.
+    msg::Any::WorkerGetMessage => Some(op_worker_get_message),
+    msg::Any::WorkerPostMessage => Some(op_worker_post_message),
 
     _ => None,
   }

--- a/cli/ops/dispatch_flatbuffers.rs
+++ b/cli/ops/dispatch_flatbuffers.rs
@@ -17,6 +17,7 @@ use super::fs::{
 };
 use super::metrics::op_metrics;
 use super::net::{op_accept, op_dial, op_listen, op_shutdown};
+use super::os::{op_home_dir, op_set_env, op_start};
 use super::performance::op_now;
 use super::permissions::{op_permissions, op_revoke_permission};
 use super::process::{op_kill, op_run, op_run_status};
@@ -182,10 +183,13 @@ pub fn op_selector_std(inner_type: msg::Any) -> Option<CliDispatchFn> {
     msg::Any::Run => Some(op_run),
     msg::Any::RunStatus => Some(op_run_status),
     msg::Any::Seek => Some(op_seek),
+    msg::Any::SetEnv => Some(op_set_env),
     msg::Any::Shutdown => Some(op_shutdown),
+    msg::Any::Start => Some(op_start),
     msg::Any::Stat => Some(op_stat),
     msg::Any::Symlink => Some(op_symlink),
     msg::Any::Truncate => Some(op_truncate),
+    msg::Any::HomeDir => Some(op_home_dir),
     msg::Any::Write => Some(op_write),
 
     // TODO(ry) split these out so that only the appropriate Workers can access

--- a/cli/ops/errors.rs
+++ b/cli/ops/errors.rs
@@ -1,56 +1,88 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use super::dispatch_json::{Deserialize, JsonOp, Value};
+use super::dispatch_flatbuffers::serialize_response;
+use super::utils::*;
+use crate::deno_error;
 use crate::fmt_errors::JSError;
+use crate::msg;
 use crate::source_maps::get_orig_position;
 use crate::source_maps::CachedMaps;
 use crate::state::ThreadSafeState;
 use deno::*;
+use flatbuffers::FlatBufferBuilder;
 use std::collections::HashMap;
-
-#[derive(Deserialize)]
-struct FormatErrorArgs {
-  error: String,
-}
 
 pub fn op_format_error(
   state: &ThreadSafeState,
-  args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  let args: FormatErrorArgs = serde_json::from_value(args)?;
-  let error = JSError::from_json(&args.error, &state.ts_compiler);
+  base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> CliOpResult {
+  assert!(data.is_none());
+  let inner = base.inner_as_format_error().unwrap();
+  let json_str = inner.error().unwrap();
+  let error = JSError::from_json(json_str, &state.ts_compiler);
+  let error_string = error.to_string();
 
-  Ok(JsonOp::Sync(json!({
-    "error": error.to_string(),
-  })))
-}
+  let mut builder = FlatBufferBuilder::new();
+  let new_error = builder.create_string(&error_string);
 
-#[derive(Deserialize)]
-struct ApplySourceMap {
-  filename: String,
-  line: i32,
-  column: i32,
+  let inner = msg::FormatErrorRes::create(
+    &mut builder,
+    &msg::FormatErrorResArgs {
+      error: Some(new_error),
+    },
+  );
+
+  let response_buf = serialize_response(
+    base.cmd_id(),
+    &mut builder,
+    msg::BaseArgs {
+      inner_type: msg::Any::FormatErrorRes,
+      inner: Some(inner.as_union_value()),
+      ..Default::default()
+    },
+  );
+
+  ok_buf(response_buf)
 }
 
 pub fn op_apply_source_map(
   state: &ThreadSafeState,
-  args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  let args: ApplySourceMap = serde_json::from_value(args)?;
+  base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> CliOpResult {
+  if !base.sync() {
+    return Err(deno_error::no_async_support());
+  }
+  assert!(data.is_none());
+  let inner = base.inner_as_apply_source_map().unwrap();
+  let cmd_id = base.cmd_id();
+  let filename = inner.filename().unwrap();
+  let line = inner.line();
+  let column = inner.column();
 
   let mut mappings_map: CachedMaps = HashMap::new();
   let (orig_filename, orig_line, orig_column) = get_orig_position(
-    args.filename,
-    args.line.into(),
-    args.column.into(),
+    filename.to_owned(),
+    line.into(),
+    column.into(),
     &mut mappings_map,
     &state.ts_compiler,
   );
 
-  Ok(JsonOp::Sync(json!({
-    "filename": orig_filename.to_string(),
-    "line": orig_line as u32,
-    "column": orig_column as u32,
-  })))
+  let builder = &mut FlatBufferBuilder::new();
+  let msg_args = msg::ApplySourceMapArgs {
+    filename: Some(builder.create_string(&orig_filename)),
+    line: orig_line as i32,
+    column: orig_column as i32,
+  };
+  let res_inner = msg::ApplySourceMap::create(builder, &msg_args);
+  ok_buf(serialize_response(
+    cmd_id,
+    builder,
+    msg::BaseArgs {
+      inner: Some(res_inner.as_union_value()),
+      inner_type: msg::Any::ApplySourceMap,
+      ..Default::default()
+    },
+  ))
 }

--- a/cli/ops/fetch.rs
+++ b/cli/ops/fetch.rs
@@ -1,57 +1,38 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use super::dispatch_json::{Deserialize, JsonOp, Value};
+use super::dispatch_flatbuffers::serialize_response;
+use super::utils::CliOpResult;
 use crate::http_util;
+use crate::msg;
+use crate::msg_util;
 use crate::resources;
 use crate::state::ThreadSafeState;
 use deno::*;
-use http::header::HeaderName;
-use http::uri::Uri;
-use http::Method;
+use flatbuffers::FlatBufferBuilder;
 use hyper;
-use hyper::header::HeaderValue;
 use hyper::rt::Future;
-use hyper::Request;
 use std;
 use std::convert::From;
-use std::str::FromStr;
-
-#[derive(Deserialize)]
-struct FetchArgs {
-  method: Option<String>,
-  url: String,
-  headers: Vec<(String, String)>,
-}
 
 pub fn op_fetch(
   state: &ThreadSafeState,
-  args: Value,
+  base: &msg::Base<'_>,
   data: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  let args: FetchArgs = serde_json::from_value(args)?;
-  let url = args.url;
+) -> CliOpResult {
+  let inner = base.inner_as_fetch().unwrap();
+  let cmd_id = base.cmd_id();
+
+  let header = inner.header().unwrap();
+  assert!(header.is_request());
+  let url = header.url().unwrap();
 
   let body = match data {
     None => hyper::Body::empty(),
     Some(buf) => hyper::Body::from(Vec::from(&*buf)),
   };
 
-  let mut req = Request::new(body);
-  let uri = Uri::from_str(&url).map_err(ErrBox::from)?;
-  *req.uri_mut() = uri;
+  let req = msg_util::deserialize_request(header, body)?;
 
-  if let Some(method) = args.method {
-    let method = Method::from_str(&method).unwrap();
-    *req.method_mut() = method;
-  }
-
-  let headers = req.headers_mut();
-  for header_pair in args.headers {
-    let name = HeaderName::from_bytes(header_pair.0.as_bytes()).unwrap();
-    let v = HeaderValue::from_str(&header_pair.1).unwrap();
-    headers.insert(name, v);
-  }
-
-  let url_ = url::Url::parse(&url).map_err(ErrBox::from)?;
+  let url_ = url::Url::parse(url).map_err(ErrBox::from)?;
   state.check_net_url(&url_)?;
 
   let client = http_util::get_client();
@@ -61,22 +42,32 @@ pub fn op_fetch(
     .request(req)
     .map_err(ErrBox::from)
     .and_then(move |res| {
-      let status = res.status().as_u16();
-      let mut res_headers = Vec::new();
-      for (key, val) in res.headers().iter() {
-        res_headers.push((key.to_string(), val.to_str().unwrap().to_owned()));
-      }
+      let builder = &mut FlatBufferBuilder::new();
+      let header_off = msg_util::serialize_http_response(builder, &res);
       let body = res.into_body();
       let body_resource = resources::add_hyper_body(body);
+      let inner = msg::FetchRes::create(
+        builder,
+        &msg::FetchResArgs {
+          header: Some(header_off),
+          body_rid: body_resource.rid,
+        },
+      );
 
-      let json_res = json!({
-        "bodyRid": body_resource.rid,
-        "status": status,
-        "headers": res_headers
-      });
-
-      futures::future::ok(json_res)
+      Ok(serialize_response(
+        cmd_id,
+        builder,
+        msg::BaseArgs {
+          inner: Some(inner.as_union_value()),
+          inner_type: msg::Any::FetchRes,
+          ..Default::default()
+        },
+      ))
     });
-
-  Ok(JsonOp::Async(Box::new(future)))
+  if base.sync() {
+    let result_buf = future.wait()?;
+    Ok(Op::Sync(result_buf))
+  } else {
+    Ok(Op::Async(Box::new(future)))
+  }
 }

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -45,29 +45,6 @@ pub const OP_OPEN: OpId = 15;
 pub const OP_CLOSE: OpId = 16;
 pub const OP_SEEK: OpId = 17;
 pub const OP_FETCH: OpId = 18;
-pub const OP_METRICS: OpId = 19;
-pub const OP_REPL_START: OpId = 20;
-pub const OP_REPL_READLINE: OpId = 21;
-pub const OP_ACCEPT: OpId = 22;
-pub const OP_DIAL: OpId = 23;
-pub const OP_SHUTDOWN: OpId = 24;
-pub const OP_LISTEN: OpId = 25;
-pub const OP_RESOURCES: OpId = 26;
-pub const OP_GET_RANDOM_VALUES: OpId = 27;
-pub const OP_GLOBAL_TIMER_STOP: OpId = 28;
-pub const OP_GLOBAL_TIMER: OpId = 29;
-pub const OP_NOW: OpId = 30;
-pub const OP_PERMISSIONS: OpId = 31;
-pub const OP_REVOKE_PERMISSION: OpId = 32;
-pub const OP_CREATE_WORKER: OpId = 33;
-pub const OP_HOST_GET_WORKER_CLOSED: OpId = 34;
-pub const OP_HOST_POST_MESSAGE: OpId = 35;
-pub const OP_HOST_GET_MESSAGE: OpId = 36;
-pub const OP_WORKER_POST_MESSAGE: OpId = 37;
-pub const OP_WORKER_GET_MESSAGE: OpId = 38;
-pub const OP_RUN: OpId = 39;
-pub const OP_RUN_STATUS: OpId = 40;
-pub const OP_KILL: OpId = 41;
 
 pub fn dispatch(
   state: &ThreadSafeState,
@@ -135,112 +112,8 @@ pub fn dispatch(
     OP_SEEK => {
       dispatch_json::dispatch(files::op_seek, state, control, zero_copy)
     }
-    OP_METRICS => {
-      dispatch_json::dispatch(metrics::op_metrics, state, control, zero_copy)
-    }
     OP_FETCH => {
       dispatch_json::dispatch(fetch::op_fetch, state, control, zero_copy)
-    }
-    OP_REPL_START => {
-      dispatch_json::dispatch(repl::op_repl_start, state, control, zero_copy)
-    }
-    OP_REPL_READLINE => {
-      dispatch_json::dispatch(repl::op_repl_readline, state, control, zero_copy)
-    }
-    OP_ACCEPT => {
-      dispatch_json::dispatch(net::op_accept, state, control, zero_copy)
-    }
-    OP_DIAL => dispatch_json::dispatch(net::op_dial, state, control, zero_copy),
-    OP_SHUTDOWN => {
-      dispatch_json::dispatch(net::op_shutdown, state, control, zero_copy)
-    }
-    OP_LISTEN => {
-      dispatch_json::dispatch(net::op_listen, state, control, zero_copy)
-    }
-    OP_RESOURCES => dispatch_json::dispatch(
-      resources::op_resources,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_GET_RANDOM_VALUES => dispatch_json::dispatch(
-      random::op_get_random_values,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_GLOBAL_TIMER_STOP => dispatch_json::dispatch(
-      timers::op_global_timer_stop,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_GLOBAL_TIMER => dispatch_json::dispatch(
-      timers::op_global_timer,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_NOW => {
-      dispatch_json::dispatch(performance::op_now, state, control, zero_copy)
-    }
-    OP_PERMISSIONS => dispatch_json::dispatch(
-      permissions::op_permissions,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_REVOKE_PERMISSION => dispatch_json::dispatch(
-      permissions::op_revoke_permission,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_CREATE_WORKER => dispatch_json::dispatch(
-      workers::op_create_worker,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_HOST_GET_WORKER_CLOSED => dispatch_json::dispatch(
-      workers::op_host_get_worker_closed,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_HOST_POST_MESSAGE => dispatch_json::dispatch(
-      workers::op_host_post_message,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_HOST_GET_MESSAGE => dispatch_json::dispatch(
-      workers::op_host_get_message,
-      state,
-      control,
-      zero_copy,
-    ),
-    // TODO: make sure these two ops are only accessible to appropriate Workers
-    OP_WORKER_POST_MESSAGE => dispatch_json::dispatch(
-      workers::op_worker_post_message,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_WORKER_GET_MESSAGE => dispatch_json::dispatch(
-      workers::op_worker_get_message,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_RUN => {
-      dispatch_json::dispatch(process::op_run, state, control, zero_copy)
-    }
-    OP_RUN_STATUS => {
-      dispatch_json::dispatch(process::op_run_status, state, control, zero_copy)
-    }
-    OP_KILL => {
-      dispatch_json::dispatch(process::op_kill, state, control, zero_copy)
     }
     OP_FLATBUFFER => dispatch_flatbuffers::dispatch(state, control, zero_copy),
     _ => panic!("bad op_id"),

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -34,9 +34,6 @@ pub const OP_IS_TTY: OpId = 4;
 pub const OP_ENV: OpId = 5;
 pub const OP_EXEC_PATH: OpId = 6;
 pub const OP_UTIME: OpId = 7;
-pub const OP_SET_ENV: OpId = 8;
-pub const OP_HOME_DIR: OpId = 9;
-pub const OP_START: OpId = 10;
 
 pub fn dispatch(
   state: &ThreadSafeState,
@@ -62,17 +59,8 @@ pub fn dispatch(
     OP_EXEC_PATH => {
       dispatch_json::dispatch(os::op_exec_path, state, control, zero_copy)
     }
-    OP_HOME_DIR => {
-      dispatch_json::dispatch(os::op_home_dir, state, control, zero_copy)
-    }
     OP_UTIME => {
       dispatch_json::dispatch(fs::op_utime, state, control, zero_copy)
-    }
-    OP_SET_ENV => {
-      dispatch_json::dispatch(os::op_set_env, state, control, zero_copy)
-    }
-    OP_START => {
-      dispatch_json::dispatch(os::op_start, state, control, zero_copy)
     }
     OP_FLATBUFFER => dispatch_flatbuffers::dispatch(state, control, zero_copy),
     _ => panic!("bad op_id"),

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -37,14 +37,6 @@ pub const OP_UTIME: OpId = 7;
 pub const OP_SET_ENV: OpId = 8;
 pub const OP_HOME_DIR: OpId = 9;
 pub const OP_START: OpId = 10;
-pub const OP_APPLY_SOURCE_MAP: OpId = 11;
-pub const OP_FORMAT_ERROR: OpId = 12;
-pub const OP_CACHE: OpId = 13;
-pub const OP_FETCH_SOURCE_FILE: OpId = 14;
-pub const OP_OPEN: OpId = 15;
-pub const OP_CLOSE: OpId = 16;
-pub const OP_SEEK: OpId = 17;
-pub const OP_FETCH: OpId = 18;
 
 pub fn dispatch(
   state: &ThreadSafeState,
@@ -81,39 +73,6 @@ pub fn dispatch(
     }
     OP_START => {
       dispatch_json::dispatch(os::op_start, state, control, zero_copy)
-    }
-    OP_APPLY_SOURCE_MAP => dispatch_json::dispatch(
-      errors::op_apply_source_map,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_FORMAT_ERROR => dispatch_json::dispatch(
-      errors::op_format_error,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_CACHE => {
-      dispatch_json::dispatch(compiler::op_cache, state, control, zero_copy)
-    }
-    OP_FETCH_SOURCE_FILE => dispatch_json::dispatch(
-      compiler::op_fetch_source_file,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_OPEN => {
-      dispatch_json::dispatch(files::op_open, state, control, zero_copy)
-    }
-    OP_CLOSE => {
-      dispatch_json::dispatch(files::op_close, state, control, zero_copy)
-    }
-    OP_SEEK => {
-      dispatch_json::dispatch(files::op_seek, state, control, zero_copy)
-    }
-    OP_FETCH => {
-      dispatch_json::dispatch(fetch::op_fetch, state, control, zero_copy)
     }
     OP_FLATBUFFER => dispatch_flatbuffers::dispatch(state, control, zero_copy),
     _ => panic!("bad op_id"),

--- a/cli/ops/os.rs
+++ b/cli/ops/os.rs
@@ -1,11 +1,15 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+use super::dispatch_flatbuffers::serialize_response;
 use super::dispatch_json::{Deserialize, JsonOp, Value};
+use super::utils::*;
 use crate::ansi;
 use crate::fs as deno_fs;
+use crate::msg;
 use crate::state::ThreadSafeState;
 use crate::version;
 use atty;
 use deno::*;
+use flatbuffers::FlatBufferBuilder;
 use log;
 use std::collections::HashMap;
 use std::env;
@@ -13,38 +17,97 @@ use url::Url;
 
 pub fn op_start(
   state: &ThreadSafeState,
-  _args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  Ok(JsonOp::Sync(json!({
-    "cwd": deno_fs::normalize_path(&env::current_dir().unwrap()),
-    "pid": std::process::id(),
-    "argv": state.argv,
-    "mainModule": state.main_module().map(|x| x.as_str().to_string()),
-    "debugFlag": state
-      .flags
-      .log_level
-      .map_or(false, |l| l == log::Level::Debug),
-    "versionFlag": state.flags.version,
-    "v8Version": version::v8(),
-    "denoVersion": version::DENO,
-    "noColor": !ansi::use_color(),
-    "xevalDelim": state.flags.xeval_delim.clone(),
-  })))
+  base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> CliOpResult {
+  assert!(data.is_none());
+  let mut builder = FlatBufferBuilder::new();
+
+  let state = state;
+  let argv = state.argv.iter().map(String::as_str).collect::<Vec<_>>();
+  let argv_off = builder.create_vector_of_strings(argv.as_slice());
+
+  let cwd_path = env::current_dir().unwrap();
+  let cwd_off =
+    builder.create_string(deno_fs::normalize_path(cwd_path.as_ref()).as_ref());
+
+  let v8_version = version::v8();
+  let v8_version_off = builder.create_string(v8_version);
+
+  let deno_version = version::DENO;
+  let deno_version_off = builder.create_string(deno_version);
+
+  let main_module = state
+    .main_module()
+    .map(|m| builder.create_string(&m.to_string()));
+
+  let xeval_delim = state
+    .flags
+    .xeval_delim
+    .clone()
+    .map(|m| builder.create_string(&m));
+
+  let debug_flag = state
+    .flags
+    .log_level
+    .map_or(false, |l| l == log::Level::Debug);
+
+  let inner = msg::StartRes::create(
+    &mut builder,
+    &msg::StartResArgs {
+      cwd: Some(cwd_off),
+      pid: std::process::id(),
+      argv: Some(argv_off),
+      main_module,
+      debug_flag,
+      version_flag: state.flags.version,
+      v8_version: Some(v8_version_off),
+      deno_version: Some(deno_version_off),
+      no_color: !ansi::use_color(),
+      xeval_delim,
+      ..Default::default()
+    },
+  );
+
+  ok_buf(serialize_response(
+    base.cmd_id(),
+    &mut builder,
+    msg::BaseArgs {
+      inner_type: msg::Any::StartRes,
+      inner: Some(inner.as_union_value()),
+      ..Default::default()
+    },
+  ))
 }
 
 pub fn op_home_dir(
   state: &ThreadSafeState,
-  _args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
+  base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> CliOpResult {
+  assert!(data.is_none());
+  let cmd_id = base.cmd_id();
+
   state.check_env()?;
+
+  let builder = &mut FlatBufferBuilder::new();
   let path = dirs::home_dir()
     .unwrap_or_default()
     .into_os_string()
     .into_string()
     .unwrap_or_default();
-  Ok(JsonOp::Sync(json!(path)))
+  let path = Some(builder.create_string(&path));
+  let inner = msg::HomeDirRes::create(builder, &msg::HomeDirResArgs { path });
+
+  ok_buf(serialize_response(
+    cmd_id,
+    builder,
+    msg::BaseArgs {
+      inner: Some(inner.as_union_value()),
+      inner_type: msg::Any::HomeDirRes,
+      ..Default::default()
+    },
+  ))
 }
 
 pub fn op_exec_path(
@@ -61,21 +124,18 @@ pub fn op_exec_path(
   Ok(JsonOp::Sync(json!(path)))
 }
 
-#[derive(Deserialize)]
-struct SetEnv {
-  key: String,
-  value: String,
-}
-
 pub fn op_set_env(
   state: &ThreadSafeState,
-  args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  let args: SetEnv = serde_json::from_value(args)?;
+  base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> CliOpResult {
+  assert!(data.is_none());
+  let inner = base.inner_as_set_env().unwrap();
+  let key = inner.key().unwrap();
+  let value = inner.value().unwrap();
   state.check_env()?;
-  env::set_var(args.key, args.value);
-  Ok(JsonOp::Sync(json!({})))
+  env::set_var(key, value);
+  ok_buf(empty_buf())
 }
 
 pub fn op_env(

--- a/cli/ops/permissions.rs
+++ b/cli/ops/permissions.rs
@@ -1,35 +1,50 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use super::dispatch_json::{Deserialize, JsonOp, Value};
+use super::dispatch_flatbuffers::serialize_response;
+use super::utils::*;
+use crate::msg;
 use crate::state::ThreadSafeState;
 use deno::*;
+use flatbuffers::FlatBufferBuilder;
 
 pub fn op_permissions(
   state: &ThreadSafeState,
-  _args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  Ok(JsonOp::Sync(json!({
-    "run": state.permissions.allows_run(),
-    "read": state.permissions.allows_read(),
-    "write": state.permissions.allows_write(),
-    "net": state.permissions.allows_net(),
-    "env": state.permissions.allows_env(),
-    "hrtime": state.permissions.allows_hrtime(),
-  })))
-}
-
-#[derive(Deserialize)]
-struct RevokePermissionArgs {
-  permission: String,
+  base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> CliOpResult {
+  assert!(data.is_none());
+  let cmd_id = base.cmd_id();
+  let builder = &mut FlatBufferBuilder::new();
+  let inner = msg::PermissionsRes::create(
+    builder,
+    &msg::PermissionsResArgs {
+      run: state.permissions.allows_run(),
+      read: state.permissions.allows_read(),
+      write: state.permissions.allows_write(),
+      net: state.permissions.allows_net(),
+      env: state.permissions.allows_env(),
+      hrtime: state.permissions.allows_hrtime(),
+    },
+  );
+  let response_buf = serialize_response(
+    cmd_id,
+    builder,
+    msg::BaseArgs {
+      inner: Some(inner.as_union_value()),
+      inner_type: msg::Any::PermissionsRes,
+      ..Default::default()
+    },
+  );
+  ok_buf(response_buf)
 }
 
 pub fn op_revoke_permission(
   state: &ThreadSafeState,
-  args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  let args: RevokePermissionArgs = serde_json::from_value(args)?;
-  let permission = args.permission.as_ref();
+  base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> CliOpResult {
+  assert!(data.is_none());
+  let inner = base.inner_as_permission_revoke().unwrap();
+  let permission = inner.permission().unwrap();
   match permission {
     "run" => state.permissions.revoke_run(),
     "read" => state.permissions.revoke_read(),
@@ -39,6 +54,5 @@ pub fn op_revoke_permission(
     "hrtime" => state.permissions.revoke_hrtime(),
     _ => Ok(()),
   }?;
-
-  Ok(JsonOp::Sync(json!({})))
+  ok_buf(empty_buf())
 }

--- a/cli/ops/random.rs
+++ b/cli/ops/random.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use super::dispatch_json::{JsonOp, Value};
+use super::utils::*;
+use crate::msg;
 use crate::state::ThreadSafeState;
 use deno::*;
 use rand::thread_rng;
@@ -7,18 +8,16 @@ use rand::Rng;
 
 pub fn op_get_random_values(
   state: &ThreadSafeState,
-  _args: Value,
-  zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  assert!(zero_copy.is_some());
-
+  _base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> CliOpResult {
   if let Some(ref seeded_rng) = state.seeded_rng {
     let mut rng = seeded_rng.lock().unwrap();
-    rng.fill(&mut zero_copy.unwrap()[..]);
+    rng.fill(&mut data.unwrap()[..]);
   } else {
     let mut rng = thread_rng();
-    rng.fill(&mut zero_copy.unwrap()[..]);
+    rng.fill(&mut data.unwrap()[..]);
   }
 
-  Ok(JsonOp::Sync(json!({})))
+  ok_buf(empty_buf())
 }

--- a/cli/ops/resources.rs
+++ b/cli/ops/resources.rs
@@ -1,14 +1,54 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use super::dispatch_json::{JsonOp, Value};
+use super::dispatch_flatbuffers::serialize_response;
+use super::utils::ok_buf;
+use super::utils::CliOpResult;
+use crate::msg;
 use crate::resources::table_entries;
 use crate::state::ThreadSafeState;
 use deno::*;
+use flatbuffers::FlatBufferBuilder;
 
 pub fn op_resources(
   _state: &ThreadSafeState,
-  _args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
+  base: &msg::Base<'_>,
+  data: Option<PinnedBuf>,
+) -> CliOpResult {
+  assert!(data.is_none());
+  let cmd_id = base.cmd_id();
+
+  let builder = &mut FlatBufferBuilder::new();
   let serialized_resources = table_entries();
-  Ok(JsonOp::Sync(json!(serialized_resources)))
+
+  let res: Vec<_> = serialized_resources
+    .iter()
+    .map(|(key, value)| {
+      let repr = builder.create_string(value);
+
+      msg::Resource::create(
+        builder,
+        &msg::ResourceArgs {
+          rid: *key,
+          repr: Some(repr),
+        },
+      )
+    })
+    .collect();
+
+  let resources = builder.create_vector(&res);
+  let inner = msg::ResourcesRes::create(
+    builder,
+    &msg::ResourcesResArgs {
+      resources: Some(resources),
+    },
+  );
+
+  ok_buf(serialize_response(
+    cmd_id,
+    builder,
+    msg::BaseArgs {
+      inner: Some(inner.as_union_value()),
+      inner_type: msg::Any::ResourcesRes,
+      ..Default::default()
+    },
+  ))
 }

--- a/js/dispatch.ts
+++ b/js/dispatch.ts
@@ -15,14 +15,6 @@ export const OP_UTIME = 7;
 export const OP_SET_ENV = 8;
 export const OP_HOME_DIR = 9;
 export const OP_START = 10;
-export const OP_APPLY_SOURCE_MAP = 11;
-export const OP_FORMAT_ERROR = 12;
-export const OP_CACHE = 13;
-export const OP_FETCH_SOURCE_FILE = 14;
-export const OP_OPEN = 15;
-export const OP_CLOSE = 16;
-export const OP_SEEK = 17;
-export const OP_FETCH = 18;
 
 export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
   switch (opId) {
@@ -33,17 +25,10 @@ export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
     case OP_READ:
       minimal.asyncMsgFromRust(opId, ui8);
       break;
-    case OP_EXIT:
-    case OP_IS_TTY:
-    case OP_ENV:
-    case OP_EXEC_PATH:
     case OP_UTIME:
-    case OP_OPEN:
-    case OP_SEEK:
-    case OP_FETCH:
       json.asyncMsgFromRust(opId, ui8);
       break;
     default:
-      throw Error("bad async opId");
+      throw Error("bad opId");
   }
 }

--- a/js/dispatch.ts
+++ b/js/dispatch.ts
@@ -23,29 +23,6 @@ export const OP_OPEN = 15;
 export const OP_CLOSE = 16;
 export const OP_SEEK = 17;
 export const OP_FETCH = 18;
-export const OP_METRICS = 19;
-export const OP_REPL_START = 20;
-export const OP_REPL_READLINE = 21;
-export const OP_ACCEPT = 22;
-export const OP_DIAL = 23;
-export const OP_SHUTDOWN = 24;
-export const OP_LISTEN = 25;
-export const OP_RESOURCES = 26;
-export const OP_GET_RANDOM_VALUES = 27;
-export const OP_GLOBAL_TIMER_STOP = 28;
-export const OP_GLOBAL_TIMER = 29;
-export const OP_NOW = 30;
-export const OP_PERMISSIONS = 31;
-export const OP_REVOKE_PERMISSION = 32;
-export const OP_CREATE_WORKER = 33;
-export const OP_HOST_GET_WORKER_CLOSED = 34;
-export const OP_HOST_POST_MESSAGE = 35;
-export const OP_HOST_GET_MESSAGE = 36;
-export const OP_WORKER_POST_MESSAGE = 37;
-export const OP_WORKER_GET_MESSAGE = 38;
-export const OP_RUN = 39;
-export const OP_RUN_STATUS = 40;
-export const OP_KILL = 41;
 
 export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
   switch (opId) {
@@ -64,15 +41,6 @@ export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
     case OP_OPEN:
     case OP_SEEK:
     case OP_FETCH:
-    case OP_REPL_START:
-    case OP_REPL_READLINE:
-    case OP_ACCEPT:
-    case OP_DIAL:
-    case OP_GLOBAL_TIMER:
-    case OP_HOST_GET_WORKER_CLOSED:
-    case OP_HOST_GET_MESSAGE:
-    case OP_WORKER_GET_MESSAGE:
-    case OP_RUN_STATUS:
       json.asyncMsgFromRust(opId, ui8);
       break;
     default:

--- a/js/dispatch.ts
+++ b/js/dispatch.ts
@@ -12,9 +12,6 @@ export const OP_IS_TTY = 4;
 export const OP_ENV = 5;
 export const OP_EXEC_PATH = 6;
 export const OP_UTIME = 7;
-export const OP_SET_ENV = 8;
-export const OP_HOME_DIR = 9;
-export const OP_START = 10;
 
 export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
   switch (opId) {

--- a/js/format_error.ts
+++ b/js/format_error.ts
@@ -1,9 +1,17 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import * as dispatch from "./dispatch";
-import { sendSync } from "./dispatch_json";
+import { sendSync, msg, flatbuffers } from "./dispatch_flatbuffers";
+import { assert } from "./util";
 
-// TODO(bartlomieju): move to `repl.ts`?
 export function formatError(errString: string): string {
-  const res = sendSync(dispatch.OP_FORMAT_ERROR, { error: errString });
-  return res.error;
+  const builder = flatbuffers.createBuilder();
+  const errString_ = builder.createString(errString);
+  const offset = msg.FormatError.createFormatError(builder, errString_);
+  const baseRes = sendSync(builder, msg.Any.FormatError, offset);
+  assert(baseRes != null);
+  assert(msg.Any.FormatErrorRes === baseRes!.innerType());
+  const formatErrorResMsg = new msg.FormatErrorRes();
+  assert(baseRes!.inner(formatErrorResMsg) != null);
+  const formattedError = formatErrorResMsg.error();
+  assert(formatError != null);
+  return formattedError!;
 }

--- a/js/get_random_values.ts
+++ b/js/get_random_values.ts
@@ -1,7 +1,14 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import * as dispatch from "./dispatch";
-import { sendSync } from "./dispatch_json";
+import { sendSync, msg, flatbuffers } from "./dispatch_flatbuffers";
 import { assert } from "./util";
+
+function req(
+  typedArray: ArrayBufferView
+): [flatbuffers.Builder, msg.Any, flatbuffers.Offset, ArrayBufferView] {
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.GetRandomValues.createGetRandomValues(builder);
+  return [builder, msg.Any.GetRandomValues, inner, typedArray];
+}
 
 /** Synchronously collects cryptographically secure random values. The
  * underlying CSPRNG in use is Rust's `rand::rngs::ThreadRng`.
@@ -21,11 +28,6 @@ export function getRandomValues<
 >(typedArray: T): T {
   assert(typedArray !== null, "Input must not be null");
   assert(typedArray.length <= 65536, "Input must not be longer than 65536");
-  const ui8 = new Uint8Array(
-    typedArray.buffer,
-    typedArray.byteOffset,
-    typedArray.byteLength
-  );
-  sendSync(dispatch.OP_GET_RANDOM_VALUES, {}, ui8);
+  sendSync(...req(typedArray as ArrayBufferView));
   return typedArray;
 }

--- a/js/main.ts
+++ b/js/main.ts
@@ -22,12 +22,12 @@ export default function denoMain(
   preserveDenoNamespace: boolean = true,
   name?: string
 ): void {
-  const s = os.start(preserveDenoNamespace, name);
+  const startResMsg = os.start(preserveDenoNamespace, name);
 
-  setVersions(s.denoVersion, s.v8Version);
+  setVersions(startResMsg.denoVersion()!, startResMsg.v8Version()!);
 
   // handle `--version`
-  if (s.versionFlag) {
+  if (startResMsg.versionFlag()) {
     console.log("deno:", deno.version.deno);
     console.log("v8:", deno.version.v8);
     console.log("typescript:", deno.version.typescript);
@@ -36,22 +36,24 @@ export default function denoMain(
 
   setPrepareStackTrace(Error);
 
-  if (s.mainModule) {
-    assert(s.mainModule.length > 0);
-    setLocation(s.mainModule);
+  const mainModule = startResMsg.mainModule();
+  if (mainModule) {
+    assert(mainModule.length > 0);
+    setLocation(mainModule);
   }
 
-  log("cwd", s.cwd);
+  const cwd = startResMsg.cwd();
+  log("cwd", cwd);
 
-  for (let i = 1; i < s.argv.length; i++) {
-    args.push(s.argv[i]);
+  for (let i = 1; i < startResMsg.argvLength(); i++) {
+    args.push(startResMsg.argv(i));
   }
   log("args", args);
   Object.freeze(args);
 
   if (window["_xevalWrapper"] !== undefined) {
-    xevalMain(window["_xevalWrapper"] as XevalFunc, s.xevalDelim);
-  } else if (!s.mainModule) {
+    xevalMain(window["_xevalWrapper"] as XevalFunc, startResMsg.xevalDelim());
+  } else if (!mainModule) {
     replLoop();
   }
 }

--- a/js/os.ts
+++ b/js/os.ts
@@ -1,7 +1,8 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { core } from "./core";
 import * as dispatch from "./dispatch";
-import { sendSync } from "./dispatch_json";
+import { sendSync, msg, flatbuffers } from "./dispatch_flatbuffers";
+import * as dispatchJson from "./dispatch_json";
 import { assert } from "./util";
 import * as util from "./util";
 import { window } from "./window";
@@ -23,17 +24,21 @@ function setGlobals(pid_: number, noColor_: boolean): void {
  *       console.log(Deno.isTTY().stdout);
  */
 export function isTTY(): { stdin: boolean; stdout: boolean; stderr: boolean } {
-  return sendSync(dispatch.OP_IS_TTY);
+  return dispatchJson.sendSync(dispatch.OP_IS_TTY);
 }
 
 /** Exit the Deno process with optional exit code. */
 export function exit(code = 0): never {
-  sendSync(dispatch.OP_EXIT, { code });
+  dispatchJson.sendSync(dispatch.OP_EXIT, { code });
   return util.unreachable();
 }
 
 function setEnv(key: string, value: string): void {
-  sendSync(dispatch.OP_SET_ENV, { key, value });
+  const builder = flatbuffers.createBuilder();
+  const key_ = builder.createString(key);
+  const value_ = builder.createString(value);
+  const inner = msg.SetEnv.createSetEnv(builder, key_, value_);
+  sendSync(builder, msg.Any.SetEnv, inner);
 }
 
 /** Returns a snapshot of the environment variables at invocation. Mutating a
@@ -48,7 +53,7 @@ function setEnv(key: string, value: string): void {
  *       console.log(myEnv.TEST_VAR == newEnv.TEST_VAR);
  */
 export function env(): { [index: string]: string } {
-  const env = sendSync(dispatch.OP_ENV);
+  const env = dispatchJson.sendSync(dispatch.OP_ENV);
   return new Proxy(env, {
     set(obj, prop: string, value: string): boolean {
       setEnv(prop, value);
@@ -57,35 +62,35 @@ export function env(): { [index: string]: string } {
   });
 }
 
-interface Start {
-  cwd: string;
-  pid: number;
-  argv: string[];
-  mainModule: string; // Absolute URL.
-  debugFlag: boolean;
-  depsFlag: boolean;
-  typesFlag: boolean;
-  versionFlag: boolean;
-  denoVersion: string;
-  v8Version: string;
-  noColor: boolean;
-  xevalDelim: string;
+/** Send to the privileged side that we have setup and are ready. */
+function sendStart(): msg.StartRes {
+  const builder = flatbuffers.createBuilder();
+  const startOffset = msg.Start.createStart(builder, 0 /* unused */);
+  const baseRes = sendSync(builder, msg.Any.Start, startOffset);
+  assert(baseRes != null);
+  assert(msg.Any.StartRes === baseRes!.innerType());
+  const startResMsg = new msg.StartRes();
+  assert(baseRes!.inner(startResMsg) != null);
+  return startResMsg;
 }
 
 // This function bootstraps an environment within Deno, it is shared both by
 // the runtime and the compiler environments.
 // @internal
-export function start(preserveDenoNamespace = true, source?: string): Start {
+export function start(
+  preserveDenoNamespace = true,
+  source?: string
+): msg.StartRes {
   core.setAsyncHandler(dispatch.asyncMsgFromRust);
 
   // First we send an empty `Start` message to let the privileged side know we
   // are ready. The response should be a `StartRes` message containing the CLI
   // args and other info.
-  const s = sendSync(dispatch.OP_START);
+  const startResMsg = sendStart();
 
-  util.setLogDebug(s.debugFlag, source);
+  util.setLogDebug(startResMsg.debugFlag(), source);
 
-  setGlobals(s.pid, s.noColor);
+  setGlobals(startResMsg.pid(), startResMsg.noColor());
 
   if (preserveDenoNamespace) {
     util.immutableDefine(window, "Deno", window.Deno);
@@ -100,7 +105,7 @@ export function start(preserveDenoNamespace = true, source?: string): Start {
     assert(window.Deno === undefined);
   }
 
-  return s;
+  return startResMsg;
 }
 
 /**
@@ -108,10 +113,18 @@ export function start(preserveDenoNamespace = true, source?: string): Start {
  * Requires the `--allow-env` flag.
  */
 export function homeDir(): string {
-  const path = sendSync(dispatch.OP_HOME_DIR);
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.HomeDir.createHomeDir(builder);
+  const baseRes = sendSync(builder, msg.Any.HomeDir, inner)!;
+  assert(msg.Any.HomeDirRes === baseRes.innerType());
+  const res = new msg.HomeDirRes();
+  assert(baseRes.inner(res) != null);
+  const path = res.path();
+
   if (!path) {
     throw new Error("Could not get home directory.");
   }
+
   return path;
 }
 
@@ -120,5 +133,5 @@ export function homeDir(): string {
  * Requires the `--allow-env` flag.
  */
 export function execPath(): string {
-  return sendSync(dispatch.OP_EXEC_PATH);
+  return dispatchJson.sendSync(dispatch.OP_EXEC_PATH);
 }

--- a/js/performance.ts
+++ b/js/performance.ts
@@ -1,11 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import * as dispatch from "./dispatch";
-import { sendSync } from "./dispatch_json";
-
-interface NowResponse {
-  seconds: number;
-  subsecNanos: number;
-}
+import { sendSync, msg, flatbuffers } from "./dispatch_flatbuffers";
+import { assert } from "./util";
 
 export class Performance {
   /** Returns a current time from Deno's start in milliseconds.
@@ -16,7 +11,12 @@ export class Performance {
    *       console.log(`${t} ms since start!`);
    */
   now(): number {
-    const res = sendSync(dispatch.OP_NOW) as NowResponse;
-    return res.seconds * 1e3 + res.subsecNanos / 1e6;
+    const builder = flatbuffers.createBuilder();
+    const inner = msg.Now.createNow(builder);
+    const baseRes = sendSync(builder, msg.Any.Now, inner)!;
+    assert(msg.Any.NowRes === baseRes.innerType());
+    const res = new msg.NowRes();
+    assert(baseRes.inner(res) != null);
+    return res.seconds().toFloat64() * 1e3 + res.subsecNanos() / 1e6;
   }
 }

--- a/js/permissions.ts
+++ b/js/permissions.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import * as dispatch from "./dispatch";
-import { sendSync } from "./dispatch_json";
+import { sendSync, msg, flatbuffers } from "./dispatch_flatbuffers";
+import { assert } from "./util";
 
 /** Permissions as granted by the caller */
 export interface Permissions {
@@ -15,6 +15,23 @@ export interface Permissions {
 
 export type Permission = keyof Permissions;
 
+function getReq(): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.Permissions.createPermissions(builder);
+  return [builder, msg.Any.Permissions, inner];
+}
+
+function createPermissions(inner: msg.PermissionsRes): Permissions {
+  return {
+    read: inner.read(),
+    write: inner.write(),
+    net: inner.net(),
+    env: inner.env(),
+    run: inner.run(),
+    hrtime: inner.hrtime()
+  };
+}
+
 /** Inspect granted permissions for the current program.
  *
  *       if (Deno.permissions().read) {
@@ -23,7 +40,24 @@ export type Permission = keyof Permissions;
  *       }
  */
 export function permissions(): Permissions {
-  return sendSync(dispatch.OP_PERMISSIONS) as Permissions;
+  const baseRes = sendSync(...getReq())!;
+  assert(msg.Any.PermissionsRes === baseRes.innerType());
+  const res = new msg.PermissionsRes();
+  assert(baseRes.inner(res) != null);
+  // TypeScript cannot track assertion above, therefore not null assertion
+  return createPermissions(res);
+}
+
+function revokeReq(
+  permission: string
+): [flatbuffers.Builder, msg.Any, flatbuffers.Offset] {
+  const builder = flatbuffers.createBuilder();
+  const permission_ = builder.createString(permission);
+  const inner = msg.PermissionRevoke.createPermissionRevoke(
+    builder,
+    permission_
+  );
+  return [builder, msg.Any.PermissionRevoke, inner];
 }
 
 /** Revoke a permission. When the permission was already revoked nothing changes
@@ -35,5 +69,5 @@ export function permissions(): Permissions {
  *       Deno.readFile("example.test"); // -> error or permission prompt
  */
 export function revokePermission(permission: Permission): void {
-  sendSync(dispatch.OP_REVOKE_PERMISSION, { permission });
+  sendSync(...revokeReq(permission));
 }

--- a/js/process.ts
+++ b/js/process.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./dispatch_json";
-import * as dispatch from "./dispatch";
+import { sendSync, sendAsync, msg, flatbuffers } from "./dispatch_flatbuffers";
+
 import { File, close } from "./files";
 import { ReadCloser, WriteCloser } from "./io";
 import { readAll } from "./buffer";
@@ -31,22 +31,21 @@ export interface RunOptions {
   stdin?: ProcessStdio | number;
 }
 
-interface RunStatusResponse {
-  gotSignal: boolean;
-  exitCode: number;
-  exitSignal: number;
-}
-
 async function runStatus(rid: number): Promise<ProcessStatus> {
-  const res = (await sendAsync(dispatch.OP_RUN_STATUS, {
-    rid
-  })) as RunStatusResponse;
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.RunStatus.createRunStatus(builder, rid);
 
-  if (res.gotSignal) {
-    const signal = res.exitSignal;
+  const baseRes = await sendAsync(builder, msg.Any.RunStatus, inner);
+  assert(baseRes != null);
+  assert(msg.Any.RunStatusRes === baseRes!.innerType());
+  const res = new msg.RunStatusRes();
+  assert(baseRes!.inner(res) != null);
+
+  if (res.gotSignal()) {
+    const signal = res.exitSignal();
     return { signal, success: false };
   } else {
-    const code = res.exitCode;
+    const code = res.exitCode();
     return { code, success: code === 0 };
   }
 }
@@ -57,7 +56,9 @@ async function runStatus(rid: number): Promise<ProcessStatus> {
  * Requires the `--allow-run` flag.
  */
 export function kill(pid: number, signo: number): void {
-  sendSync(dispatch.OP_KILL, { pid, signo });
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.Kill.createKill(builder, pid, signo);
+  sendSync(builder, msg.Any.Kill, inner);
 }
 
 export class Process {
@@ -68,20 +69,20 @@ export class Process {
   readonly stderr?: ReadCloser;
 
   // @internal
-  constructor(res: RunResponse) {
-    this.rid = res.rid;
-    this.pid = res.pid;
+  constructor(res: msg.RunRes) {
+    this.rid = res.rid();
+    this.pid = res.pid();
 
-    if (res.stdinRid && res.stdinRid > 0) {
-      this.stdin = new File(res.stdinRid);
+    if (res.stdinRid() > 0) {
+      this.stdin = new File(res.stdinRid());
     }
 
-    if (res.stdoutRid && res.stdoutRid > 0) {
-      this.stdout = new File(res.stdoutRid);
+    if (res.stdoutRid() > 0) {
+      this.stdout = new File(res.stdoutRid());
     }
 
-    if (res.stderrRid && res.stderrRid > 0) {
-      this.stderr = new File(res.stderrRid);
+    if (res.stderrRid() > 0) {
+      this.stderr = new File(res.stderrRid());
     }
   }
 
@@ -134,13 +135,14 @@ export interface ProcessStatus {
   signal?: number; // TODO: Make this a string, e.g. 'SIGTERM'.
 }
 
-// TODO: this method is only used to validate proper option, probably can be renamed
-function stdioMap(s: string): string {
+function stdioMap(s: ProcessStdio): msg.ProcessStdio {
   switch (s) {
     case "inherit":
+      return msg.ProcessStdio.Inherit;
     case "piped":
+      return msg.ProcessStdio.Piped;
     case "null":
-      return s;
+      return msg.ProcessStdio.Null;
     default:
       return unreachable();
   }
@@ -150,13 +152,6 @@ function isRid(arg: unknown): arg is number {
   return !isNaN(arg as number);
 }
 
-interface RunResponse {
-  rid: number;
-  pid: number;
-  stdinRid: number | null;
-  stdoutRid: number | null;
-  stderrRid: number | null;
-}
 /**
  * Spawns new subprocess.
  *
@@ -171,56 +166,71 @@ interface RunResponse {
  * they can be set to either `ProcessStdio` or `rid` of open file.
  */
 export function run(opt: RunOptions): Process {
-  assert(opt.args.length > 0);
-  let env: Array<[string, string]> = [];
+  const builder = flatbuffers.createBuilder();
+  const argsOffset = msg.Run.createArgsVector(
+    builder,
+    opt.args.map((a): number => builder.createString(a))
+  );
+  const cwdOffset = opt.cwd == null ? 0 : builder.createString(opt.cwd);
+  const kvOffset: flatbuffers.Offset[] = [];
   if (opt.env) {
-    env = Array.from(Object.entries(opt.env));
+    for (const [key, val] of Object.entries(opt.env)) {
+      const keyOffset = builder.createString(key);
+      const valOffset = builder.createString(String(val));
+      kvOffset.push(msg.KeyValue.createKeyValue(builder, keyOffset, valOffset));
+    }
   }
+  const envOffset = msg.Run.createEnvVector(builder, kvOffset);
 
-  let stdin = stdioMap("inherit");
-  let stdout = stdioMap("inherit");
-  let stderr = stdioMap("inherit");
-  let stdinRid = 0;
-  let stdoutRid = 0;
-  let stderrRid = 0;
+  let stdInOffset = stdioMap("inherit");
+  let stdOutOffset = stdioMap("inherit");
+  let stdErrOffset = stdioMap("inherit");
+  let stdinRidOffset = 0;
+  let stdoutRidOffset = 0;
+  let stderrRidOffset = 0;
 
   if (opt.stdin) {
     if (isRid(opt.stdin)) {
-      stdinRid = opt.stdin;
+      stdinRidOffset = opt.stdin;
     } else {
-      stdin = stdioMap(opt.stdin);
+      stdInOffset = stdioMap(opt.stdin);
     }
   }
 
   if (opt.stdout) {
     if (isRid(opt.stdout)) {
-      stdoutRid = opt.stdout;
+      stdoutRidOffset = opt.stdout;
     } else {
-      stdout = stdioMap(opt.stdout);
+      stdOutOffset = stdioMap(opt.stdout);
     }
   }
 
   if (opt.stderr) {
     if (isRid(opt.stderr)) {
-      stderrRid = opt.stderr;
+      stderrRidOffset = opt.stderr;
     } else {
-      stderr = stdioMap(opt.stderr);
+      stdErrOffset = stdioMap(opt.stderr);
     }
   }
 
-  const req = {
-    args: opt.args.map(String),
-    cwd: opt.cwd,
-    env,
-    stdin,
-    stdout,
-    stderr,
-    stdinRid,
-    stdoutRid,
-    stderrRid
-  };
+  const inner = msg.Run.createRun(
+    builder,
+    argsOffset,
+    cwdOffset,
+    envOffset,
+    stdInOffset,
+    stdOutOffset,
+    stdErrOffset,
+    stdinRidOffset,
+    stdoutRidOffset,
+    stderrRidOffset
+  );
+  const baseRes = sendSync(builder, msg.Any.Run, inner);
+  assert(baseRes != null);
+  assert(msg.Any.RunRes === baseRes!.innerType());
+  const res = new msg.RunRes();
+  assert(baseRes!.inner(res) != null);
 
-  const res = sendSync(dispatch.OP_RUN, req) as RunResponse;
   return new Process(res);
 }
 

--- a/js/timers.ts
+++ b/js/timers.ts
@@ -1,8 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { assert } from "./util";
+import { sendAsync, sendSync, msg, flatbuffers } from "./dispatch_flatbuffers";
 import { window } from "./window";
-import * as dispatch from "./dispatch";
-import { sendSync, sendAsync } from "./dispatch_json";
 
 interface Timer {
   id: number;
@@ -38,8 +37,11 @@ function getTime(): number {
 }
 
 function clearGlobalTimeout(): void {
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.GlobalTimerStop.createGlobalTimerStop(builder);
   globalTimeoutDue = null;
-  sendSync(dispatch.OP_GLOBAL_TIMER_STOP);
+  let res = sendSync(builder, msg.Any.GlobalTimerStop, inner);
+  assert(res == null);
 }
 
 async function setGlobalTimeout(due: number, now: number): Promise<void> {
@@ -50,8 +52,12 @@ async function setGlobalTimeout(due: number, now: number): Promise<void> {
   assert(timeout >= 0);
 
   // Send message to the backend.
+  const builder = flatbuffers.createBuilder();
+  msg.GlobalTimer.startGlobalTimer(builder);
+  msg.GlobalTimer.addTimeout(builder, timeout);
+  const inner = msg.GlobalTimer.endGlobalTimer(builder);
   globalTimeoutDue = due;
-  await sendAsync(dispatch.OP_GLOBAL_TIMER, { timeout });
+  await sendAsync(builder, msg.Any.GlobalTimer, inner);
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   fireTimers();
 }

--- a/js/workers.ts
+++ b/js/workers.ts
@@ -1,8 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as dispatch from "./dispatch";
-import { sendAsync, sendSync } from "./dispatch_json";
-import { log } from "./util";
+import { sendAsync, sendSync, msg, flatbuffers } from "./dispatch_flatbuffers";
+import { assert, log } from "./util";
 import { TextDecoder, TextEncoder } from "./text_encoding";
 import { window } from "./window";
 import { blobURLMap } from "./url";
@@ -27,28 +26,61 @@ function createWorker(
   hasSourceCode: boolean,
   sourceCode: Uint8Array
 ): number {
-  return sendSync(dispatch.OP_CREATE_WORKER, {
-    specifier,
+  const builder = flatbuffers.createBuilder();
+  const specifier_ = builder.createString(specifier);
+  const sourceCode_ = builder.createString(sourceCode);
+  const inner = msg.CreateWorker.createCreateWorker(
+    builder,
+    specifier_,
     includeDenoNamespace,
     hasSourceCode,
-    sourceCode: new TextDecoder().decode(sourceCode)
-  });
+    sourceCode_
+  );
+  const baseRes = sendSync(builder, msg.Any.CreateWorker, inner);
+  assert(baseRes != null);
+  assert(
+    msg.Any.CreateWorkerRes === baseRes!.innerType(),
+    `base.innerType() unexpectedly is ${baseRes!.innerType()}`
+  );
+  const res = new msg.CreateWorkerRes();
+  assert(baseRes!.inner(res) != null);
+  return res.rid();
 }
 
 async function hostGetWorkerClosed(rid: number): Promise<void> {
-  await sendAsync(dispatch.OP_HOST_GET_WORKER_CLOSED, { rid });
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.HostGetWorkerClosed.createHostGetWorkerClosed(builder, rid);
+  await sendAsync(builder, msg.Any.HostGetWorkerClosed, inner);
 }
 
 function hostPostMessage(rid: number, data: any): void {
   const dataIntArray = encodeMessage(data);
-  sendSync(dispatch.OP_HOST_POST_MESSAGE, { rid }, dataIntArray);
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.HostPostMessage.createHostPostMessage(builder, rid);
+  const baseRes = sendSync(
+    builder,
+    msg.Any.HostPostMessage,
+    inner,
+    dataIntArray
+  );
+  assert(baseRes != null);
 }
 
 async function hostGetMessage(rid: number): Promise<any> {
-  const res = await sendAsync(dispatch.OP_HOST_GET_MESSAGE, { rid });
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.HostGetMessage.createHostGetMessage(builder, rid);
+  const baseRes = await sendAsync(builder, msg.Any.HostGetMessage, inner);
+  assert(baseRes != null);
+  assert(
+    msg.Any.HostGetMessageRes === baseRes!.innerType(),
+    `base.innerType() unexpectedly is ${baseRes!.innerType()}`
+  );
+  const res = new msg.HostGetMessageRes();
+  assert(baseRes!.inner(res) != null);
 
-  if (res.data != null) {
-    return decodeMessage(new Uint8Array(res.data));
+  const dataArray = res.dataArray();
+  if (dataArray != null) {
+    return decodeMessage(dataArray);
   } else {
     return null;
   }
@@ -59,15 +91,36 @@ export let onmessage: (e: { data: any }) => void = (): void => {};
 
 export function postMessage(data: any): void {
   const dataIntArray = encodeMessage(data);
-  sendSync(dispatch.OP_WORKER_POST_MESSAGE, {}, dataIntArray);
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.WorkerPostMessage.createWorkerPostMessage(builder);
+  const baseRes = sendSync(
+    builder,
+    msg.Any.WorkerPostMessage,
+    inner,
+    dataIntArray
+  );
+  assert(baseRes != null);
 }
 
 export async function getMessage(): Promise<any> {
   log("getMessage");
-  const res = await sendAsync(dispatch.OP_WORKER_GET_MESSAGE);
+  const builder = flatbuffers.createBuilder();
+  const inner = msg.WorkerGetMessage.createWorkerGetMessage(
+    builder,
+    0 /* unused */
+  );
+  const baseRes = await sendAsync(builder, msg.Any.WorkerGetMessage, inner);
+  assert(baseRes != null);
+  assert(
+    msg.Any.WorkerGetMessageRes === baseRes!.innerType(),
+    `base.innerType() unexpectedly is ${baseRes!.innerType()}`
+  );
+  const res = new msg.WorkerGetMessageRes();
+  assert(baseRes!.inner(res) != null);
 
-  if (res.data != null) {
-    return decodeMessage(new Uint8Array(res.data));
+  const dataArray = res.dataArray();
+  if (dataArray != null) {
+    return decodeMessage(dataArray);
   } else {
     return null;
   }

--- a/tests/error_004_missing_module.ts.out
+++ b/tests/error_004_missing_module.ts.out
@@ -1,12 +1,12 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts"
-[WILDCARD] js/dispatch_json.ts:[WILDCARD]
+[WILDCARD] js/dispatch_flatbuffers.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
-    at toDenoError (js/dispatch_json.ts:[WILDCARD])
-    at sendSync$1 (js/dispatch_json.ts:[WILDCARD])
+    at maybeError (js/dispatch_flatbuffers.ts:[WILDCARD])
+    at maybeThrowError (js/dispatch_flatbuffers.ts:[WILDCARD])
+    at sendSync (js/dispatch_flatbuffers.ts:[WILDCARD])
     at fetchSourceFile (js/compiler.ts:[WILDCARD])
     at _resolveModule (js/compiler.ts:[WILDCARD])
     at js/compiler.ts:[WILDCARD]
     at resolveModuleNames (js/compiler.ts:[WILDCARD])
     at resolveModuleNamesWorker ([WILDCARD]typescript.js:[WILDCARD])
     at resolveModuleNamesReusingOldState ([WILDCARD]typescript.js:[WILDCARD])
-    at processImportedModules ([WILDCARD]typescript.js:[WILDCARD])

--- a/tests/error_005_missing_dynamic_import.ts.out
+++ b/tests/error_005_missing_dynamic_import.ts.out
@@ -1,11 +1,11 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts"
-[WILDCARD] js/dispatch_json.ts:[WILDCARD]
+[WILDCARD] js/dispatch_flatbuffers.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
-    at toDenoError (js/dispatch_json.ts:[WILDCARD])
-    at sendSync$1 (js/dispatch_json.ts:[WILDCARD])
+    at maybeError (js/dispatch_flatbuffers.ts:[WILDCARD])
+    at maybeThrowError (js/dispatch_flatbuffers.ts:[WILDCARD])
+    at sendSync (js/dispatch_flatbuffers.ts:[WILDCARD])
     at fetchSourceFile (js/compiler.ts:[WILDCARD])
     at _resolveModule (js/compiler.ts:[WILDCARD])
     at js/compiler.ts:[WILDCARD]
     at resolveModuleNamesWorker ([WILDCARD])
     at resolveModuleNamesReusingOldState ([WILDCARD]typescript.js:[WILDCARD])
-    at processImportedModules ([WILDCARD]typescript.js:[WILDCARD])

--- a/tests/error_006_import_ext_failure.ts.out
+++ b/tests/error_006_import_ext_failure.ts.out
@@ -1,11 +1,11 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/non-existent"
-[WILDCARD] js/dispatch_json.ts:[WILDCARD]
+[WILDCARD] js/dispatch_flatbuffers.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
-    at toDenoError (js/dispatch_json.ts:[WILDCARD])
-    at sendSync$1 (js/dispatch_json.ts:[WILDCARD])
+    at maybeError (js/dispatch_flatbuffers.ts:[WILDCARD])
+    at maybeThrowError (js/dispatch_flatbuffers.ts:[WILDCARD])
+    at sendSync (js/dispatch_flatbuffers.ts:[WILDCARD])
     at fetchSourceFile (js/compiler.ts:[WILDCARD])
     at _resolveModule (js/compiler.ts:[WILDCARD])
     at js/compiler.ts:[WILDCARD]
     at resolveModuleNamesWorker ([WILDCARD])
     at resolveModuleNamesReusingOldState ([WILDCARD]typescript.js:[WILDCARD])
-    at processImportedModules ([WILDCARD]typescript.js:[WILDCARD])

--- a/tests/error_011_bad_module_specifier.ts.out
+++ b/tests/error_011_bad_module_specifier.ts.out
@@ -1,11 +1,12 @@
 [WILDCARD]error: Uncaught ImportPrefixMissing: relative import path "bad-module.ts" not prefixed with / or ./ or ../
-[WILDCARD] js/dispatch_json.ts:[WILDCARD]
+[WILDCARD] js/dispatch_flatbuffers.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
-    at toDenoError (js/dispatch_json.ts:[WILDCARD])
-    at sendSync$1 (js/dispatch_json.ts:[WILDCARD])
+    at maybeError (js/dispatch_flatbuffers.ts:[WILDCARD])
+    at maybeThrowError (js/dispatch_flatbuffers.ts:[WILDCARD])
+    at sendSync (js/dispatch_flatbuffers.ts:[WILDCARD])
     at fetchSourceFile (js/compiler.ts:[WILDCARD])
     at _resolveModule (js/compiler.ts:[WILDCARD])
     at js/compiler.ts:[WILDCARD]
-    at resolveModuleNamesWorker ([WILDCARD])
+    at resolveModuleNames (js/compiler.ts:[WILDCARD])
+    at resolveModuleNamesWorker ([WILDCARD]typescript.js:[WILDCARD])
     at resolveModuleNamesReusingOldState ([WILDCARD]typescript.js:[WILDCARD])
-    at processImportedModules ([WILDCARD]typescript.js:[WILDCARD])

--- a/tests/error_012_bad_dynamic_import_specifier.ts.out
+++ b/tests/error_012_bad_dynamic_import_specifier.ts.out
@@ -1,11 +1,12 @@
 [WILDCARD]error: Uncaught ImportPrefixMissing: relative import path "bad-module.ts" not prefixed with / or ./ or ../
-[WILDCARD] js/dispatch_json.ts:[WILDCARD]
+[WILDCARD] js/dispatch_flatbuffers.ts:[WILDCARD]
     at DenoError (js/errors.ts:[WILDCARD])
-    at toDenoError (js/dispatch_json.ts:[WILDCARD])
-    at sendSync$1 (js/dispatch_json.ts:[WILDCARD])
+    at maybeError (js/dispatch_flatbuffers.ts:[WILDCARD])
+    at maybeThrowError (js/dispatch_flatbuffers.ts:[WILDCARD])
+    at sendSync (js/dispatch_flatbuffers.ts:[WILDCARD])
     at fetchSourceFile (js/compiler.ts:[WILDCARD])
     at _resolveModule (js/compiler.ts:[WILDCARD])
     at js/compiler.ts:[WILDCARD]
+    at resolveModuleNames (js/compiler.ts:[WILDCARD])
     at resolveModuleNamesWorker ([WILDCARD])
     at resolveModuleNamesReusingOldState ([WILDCARD]typescript.js:[WILDCARD])
-    at processImportedModules ([WILDCARD]typescript.js:[WILDCARD])


### PR DESCRIPTION
We're experiencing odd benchmarks and errors as a result of the recent ops moving to JSON. They're odd because node and hyper benchmarks are being negatively effected along with deno.

It's disconcerting that the errors below did not cause the tests to fail. 

[Errors are seen during the benchmarks](https://travis-ci.com/denoland/deno/jobs/227948237):
```
Compile file:///home/travis/build/denoland/deno/tools/deno_tcp.ts
Listening on 127.0.0.1:4544
Listening on 127.0.0.1:4545
error: Uncaught RangeError: start offset of Int32Array should be a multiple of 4
► js/dispatch_minimal.ts:44:17
    at asyncMsgFromRust (js/dispatch_minimal.ts:44:17)
    at asyncMsgFromRust$3 (js/dispatch.ts:57:7)
    at handleAsyncMsgFromRust (shared_queue.js:171:9)
Compile file:///home/travis/build/denoland/deno/js/deps/https/deno.land/std/http/http_bench.ts
http://127.0.0.1:4546/
Listening on http://127.0.0.1:4548
Compile file:///home/travis/build/denoland/deno/tools/deno_http_proxy.ts
Proxy listening on http://127.0.0.1:4547/
error: Uncaught RangeError: start offset of Int32Array should be a multiple of 4
► js/dispatch_minimal.ts:44:17
    at asyncMsgFromRust (js/dispatch_minimal.ts:44:17)
    at asyncMsgFromRust$3 (js/dispatch.ts:57:7)
    at handleAsyncMsgFromRust (shared_queue.js:171:9)
Listening on http://127.0.0.1:4550
Compile file:///home/travis/build/denoland/deno/tools/deno_tcp_proxy.ts
Proxy listening on http://127.0.0.1:4549/
single-thread
http_bench.js start
listening http://127.0.0.1:4544/ rid = 3
unexpected err Connection reset by peer (os error 104)
unexpected err Connection reset by peer (os error 104)
unexpected err Connection reset by peer (os error 104)
unexpected err Connection reset by peer (os error 104)
unexpected err Connection reset by peer (os error 104)
unexpected err Connection reset by peer (os error 104)
unexpected err Connection reset by peer (os error 104)
unexpected err Connection reset by peer (os error 104)
```
cc @bartlomieju 