### PR TITLE
fix: shared queue requires aligned buffer

### DIFF
--- a/cli/ops/dispatch_json.rs
+++ b/cli/ops/dispatch_json.rs
@@ -37,7 +37,18 @@ fn serialize_result(
     Ok(v) => json!({ "ok": v, "promiseId": promise_id }),
     Err(err) => json!({ "err": json_err(err), "promiseId": promise_id }),
   };
-  let vec = serde_json::to_vec(&value).unwrap();
+  let mut vec = serde_json::to_vec(&value).unwrap();
+
+  debug!("JSON response pre-align, len={}", vec.len());
+  let len = vec.len();
+  let modulo = len % 4;
+
+  if modulo != 0 {
+    let new_len = len + (4 - modulo);
+    vec.resize(new_len, 0);
+  }
+
+  debug!("JSON response post-align, len={}", vec.len());
   vec.into_boxed_slice()
 }
 

--- a/cli/ops/dispatch_json.rs
+++ b/cli/ops/dispatch_json.rs
@@ -46,8 +46,7 @@ fn serialize_result(
   // Pad string with "space" character. Required by shared_queue.
   if modulo != 0 {
     let new_len = len + (4 - modulo);
-    let space_byte = 32;
-    vec.resize(new_len, space_byte);
+    vec.resize(new_len, ' ' as u8);
   }
 
   debug!("JSON response post-align, len={}", vec.len());

--- a/cli/ops/dispatch_json.rs
+++ b/cli/ops/dispatch_json.rs
@@ -38,18 +38,9 @@ fn serialize_result(
     Err(err) => json!({ "err": json_err(err), "promiseId": promise_id }),
   };
   let mut vec = serde_json::to_vec(&value).unwrap();
-
   debug!("JSON response pre-align, len={}", vec.len());
-  let len = vec.len();
-  let modulo = len % 4;
-
-  // Pad string with "space" character. Required by shared_queue.
-  if modulo != 0 {
-    let new_len = len + (4 - modulo);
-    vec.resize(new_len, b' ');
-  }
-
-  debug!("JSON response post-align, len={}", vec.len());
+  // Align to 32bit word, padding with the space character.
+  vec.resize((vec.len() + 3usize) & !3usize, b' ');
   vec.into_boxed_slice()
 }
 

--- a/cli/ops/dispatch_json.rs
+++ b/cli/ops/dispatch_json.rs
@@ -43,9 +43,11 @@ fn serialize_result(
   let len = vec.len();
   let modulo = len % 4;
 
+  // Pad string with "space" character. Required by shared_queue.
   if modulo != 0 {
     let new_len = len + (4 - modulo);
-    vec.resize(new_len, 0);
+    let space_byte = 32;
+    vec.resize(new_len, space_byte);
   }
 
   debug!("JSON response post-align, len={}", vec.len());

--- a/cli/ops/dispatch_json.rs
+++ b/cli/ops/dispatch_json.rs
@@ -46,7 +46,7 @@ fn serialize_result(
   // Pad string with "space" character. Required by shared_queue.
   if modulo != 0 {
     let new_len = len + (4 - modulo);
-    vec.resize(new_len, ' ' as u8);
+    vec.resize(new_len, b' ');
   }
 
   debug!("JSON response post-align, len={}", vec.len());

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -785,12 +785,12 @@ pub mod tests {
         Mode::AsyncImmediate => {
           assert_eq!(control.len(), 1);
           assert_eq!(control[0], 42);
-          let buf = vec![43u8].into_boxed_slice();
+          let buf = vec![43u8, 0, 0, 0].into_boxed_slice();
           Op::Async(Box::new(futures::future::ok(buf)))
         }
         Mode::OverflowReqSync => {
           assert_eq!(control.len(), 100 * 1024 * 1024);
-          let buf = vec![43u8].into_boxed_slice();
+          let buf = vec![43u8, 0, 0, 0].into_boxed_slice();
           Op::Sync(buf)
         }
         Mode::OverflowResSync => {
@@ -804,7 +804,7 @@ pub mod tests {
         }
         Mode::OverflowReqAsync => {
           assert_eq!(control.len(), 100 * 1024 * 1024);
-          let buf = vec![43u8].into_boxed_slice();
+          let buf = vec![43u8, 0, 0, 0].into_boxed_slice();
           Op::Async(Box::new(futures::future::ok(buf)))
         }
         Mode::OverflowResAsync => {
@@ -1211,7 +1211,7 @@ pub mod tests {
         let control = new Uint8Array(100 * 1024 * 1024);
         let response = Deno.core.dispatch(99, control);
         assert(response instanceof Uint8Array);
-        assert(response.length == 1);
+        assert(response.length == 4);
         assert(response[0] == 43);
         assert(asyncRecv == 0);
         "#,
@@ -1251,7 +1251,7 @@ pub mod tests {
         let asyncRecv = 0;
         Deno.core.setAsyncHandler((opId, buf) => {
           assert(opId == 99);
-          assert(buf.byteLength === 1);
+          assert(buf.byteLength === 4);
           assert(buf[0] === 43);
           asyncRecv++;
         });

--- a/core/shared_queue.rs
+++ b/core/shared_queue.rs
@@ -159,6 +159,8 @@ impl SharedQueue {
     Some((op_id, &self.bytes[off..end]))
   }
 
+  /// Because JS-side may cast `record` to Int32Array it is required
+  /// that `record`'s length is divisible by 4.
   pub fn push(&mut self, op_id: OpId, record: &[u8]) -> bool {
     let off = self.head();
     let end = off + record.len();

--- a/core/shared_queue.rs
+++ b/core/shared_queue.rs
@@ -162,6 +162,14 @@ impl SharedQueue {
   pub fn push(&mut self, op_id: OpId, record: &[u8]) -> bool {
     let off = self.head();
     let end = off + record.len();
+    debug!(
+      "rust:shared_queue:pre-push: op={}, off={}, end={}, len={}",
+      op_id,
+      off,
+      end,
+      record.len()
+    );
+    assert_eq!(record.len() % 4, 0);
     let index = self.num_records();
     if end > self.bytes.len() || index >= MAX_RECORDS {
       debug!("WARNING the sharedQueue overflowed");
@@ -195,31 +203,31 @@ mod tests {
     let h = q.head();
     assert!(h > 0);
 
-    let r = vec![1u8, 2, 3, 4, 5].into_boxed_slice();
+    let r = vec![1u8, 2, 3, 4].into_boxed_slice();
     let len = r.len() + h;
     assert!(q.push(0, &r));
     assert_eq!(q.head(), len);
 
-    let r = vec![6, 7].into_boxed_slice();
+    let r = vec![5, 6, 7, 8].into_boxed_slice();
     assert!(q.push(0, &r));
 
-    let r = vec![8, 9, 10, 11].into_boxed_slice();
+    let r = vec![9, 10, 11, 12].into_boxed_slice();
     assert!(q.push(0, &r));
     assert_eq!(q.num_records(), 3);
     assert_eq!(q.size(), 3);
 
     let (_op_id, r) = q.shift().unwrap();
-    assert_eq!(r, vec![1, 2, 3, 4, 5].as_slice());
+    assert_eq!(r, vec![1, 2, 3, 4].as_slice());
     assert_eq!(q.num_records(), 3);
     assert_eq!(q.size(), 2);
 
     let (_op_id, r) = q.shift().unwrap();
-    assert_eq!(r, vec![6, 7].as_slice());
+    assert_eq!(r, vec![5, 6, 7, 8].as_slice());
     assert_eq!(q.num_records(), 3);
     assert_eq!(q.size(), 1);
 
     let (_op_id, r) = q.shift().unwrap();
-    assert_eq!(r, vec![8, 9, 10, 11].as_slice());
+    assert_eq!(r, vec![9, 10, 11, 12].as_slice());
     assert_eq!(q.num_records(), 0);
     assert_eq!(q.size(), 0);
 
@@ -239,21 +247,21 @@ mod tests {
   #[test]
   fn overflow() {
     let mut q = SharedQueue::new(RECOMMENDED_SIZE);
-    assert!(q.push(0, &alloc_buf(RECOMMENDED_SIZE - 1)));
+    assert!(q.push(0, &alloc_buf(RECOMMENDED_SIZE - 4)));
     assert_eq!(q.size(), 1);
-    assert!(!q.push(0, &alloc_buf(2)));
+    assert!(!q.push(0, &alloc_buf(8)));
     assert_eq!(q.size(), 1);
-    assert!(q.push(0, &alloc_buf(1)));
+    assert!(q.push(0, &alloc_buf(4)));
     assert_eq!(q.size(), 2);
 
     let (_op_id, buf) = q.shift().unwrap();
-    assert_eq!(buf.len(), RECOMMENDED_SIZE - 1);
+    assert_eq!(buf.len(), RECOMMENDED_SIZE - 4);
     assert_eq!(q.size(), 1);
 
-    assert!(!q.push(0, &alloc_buf(1)));
+    assert!(!q.push(0, &alloc_buf(4)));
 
     let (_op_id, buf) = q.shift().unwrap();
-    assert_eq!(buf.len(), 1);
+    assert_eq!(buf.len(), 4);
     assert_eq!(q.size(), 0);
   }
 
@@ -261,11 +269,11 @@ mod tests {
   fn full_records() {
     let mut q = SharedQueue::new(RECOMMENDED_SIZE);
     for _ in 0..MAX_RECORDS {
-      assert!(q.push(0, &alloc_buf(1)))
+      assert!(q.push(0, &alloc_buf(4)))
     }
-    assert_eq!(q.push(0, &alloc_buf(1)), false);
+    assert_eq!(q.push(0, &alloc_buf(4)), false);
     // Even if we shift one off, we still cannot push a new record.
     let _ignored = q.shift().unwrap();
-    assert_eq!(q.push(0, &alloc_buf(1)), false);
+    assert_eq!(q.push(0, &alloc_buf(4)), false);
   }
 }

--- a/core/shared_queue.rs
+++ b/core/shared_queue.rs
@@ -276,4 +276,12 @@ mod tests {
     let _ignored = q.shift().unwrap();
     assert_eq!(q.push(0, &alloc_buf(4)), false);
   }
+
+  #[test]
+  #[should_panic]
+  fn bad_buf_length() {
+    let mut q = SharedQueue::new(RECOMMENDED_SIZE);
+    // check that `record` that has length not a multiple of 4 will cause panic
+    q.push(0, &alloc_buf(3));
+  }
 }

--- a/js/dispatch_json.ts
+++ b/js/dispatch_json.ts
@@ -30,7 +30,7 @@ function nextPromiseId(): number {
 }
 
 function decode(ui8: Uint8Array): JsonResponse {
-  let s = new TextDecoder().decode(ui8);
+  const s = new TextDecoder().decode(ui8);
   return JSON.parse(s) as JsonResponse;
 }
 

--- a/js/dispatch_json.ts
+++ b/js/dispatch_json.ts
@@ -30,7 +30,10 @@ function nextPromiseId(): number {
 }
 
 function decode(ui8: Uint8Array): JsonResponse {
-  const s = new TextDecoder().decode(ui8);
+  let s = new TextDecoder().decode(ui8);
+  // TODO: this is make-shift solution
+  const closingBracket = s.lastIndexOf("}");
+  s = s.slice(0, closingBracket + 1);
   return JSON.parse(s) as JsonResponse;
 }
 

--- a/js/dispatch_json.ts
+++ b/js/dispatch_json.ts
@@ -30,10 +30,8 @@ function nextPromiseId(): number {
 }
 
 function decode(ui8: Uint8Array): JsonResponse {
-  // Received JSON string may be padded with "space" characters
-  // at the end, so make sure to trim it before parsing.
   let s = new TextDecoder().decode(ui8);
-  return JSON.parse(s.trimEnd()) as JsonResponse;
+  return JSON.parse(s) as JsonResponse;
 }
 
 function encode(args: object): Uint8Array {

--- a/js/dispatch_json.ts
+++ b/js/dispatch_json.ts
@@ -30,11 +30,10 @@ function nextPromiseId(): number {
 }
 
 function decode(ui8: Uint8Array): JsonResponse {
+  // Received JSON string may be padded with "space" characters
+  // at the end, so make sure to trim it before parsing.
   let s = new TextDecoder().decode(ui8);
-  // TODO: this is make-shift solution
-  const closingBracket = s.lastIndexOf("}");
-  s = s.slice(0, closingBracket + 1);
-  return JSON.parse(s) as JsonResponse;
+  return JSON.parse(s.trimEnd()) as JsonResponse;
 }
 
 function encode(args: object): Uint8Array {

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -28,7 +28,7 @@ def get_addr(port=None):
 def deno_tcp(deno_exe):
     addr = get_addr()
     deno_cmd = [deno_exe, "run", "--allow-net", "tools/deno_tcp.ts", addr]
-    print "http_benchmark testing DENO."
+    print "http_benchmark testing DENO tcp."
     return run(deno_cmd, addr)
 
 
@@ -38,7 +38,7 @@ def deno_tcp_current_thread(deno_exe):
         deno_exe, "run", "--current-thread", "--allow-net",
         "tools/deno_tcp.ts", addr
     ]
-    print "http_benchmark testing DENO."
+    print "http_benchmark testing DENO tcp (single-thread)."
     return run(deno_cmd, addr)
 
 


### PR DESCRIPTION
This PR fixes problem described in #2814, namely: `shared_queue` requires buffers that are aligned to 4-bytes so that `dispatch_minimal` can work (it uses Int32Array, which requires that `byteOffset` of underlying buffer is a multiple of 4)

CC @ry