### PR TITLE
doc: fix list style

### DIFF
--- a/website/style_guide.md
+++ b/website/style_guide.md
@@ -59,8 +59,8 @@ When designing function interfaces, stick to the following rules.
    Other arguments can be objects, but they must be distinguishable from a
    'plain' Object runtime, by having either:
 
-   - a distinguishing prototype (e.g. `Array`, `Map`, `Date`, `class MyThing`)
-   - a well-known symbol property (e.g. an iterable with `Symbol.iterator`).
+    - a distinguishing prototype (e.g. `Array`, `Map`, `Date`, `class MyThing`)
+    - a well-known symbol property (e.g. an iterable with `Symbol.iterator`).
 
    This allows the API to evolve in a backwards compatible way, even when the
    position of the options object changes.


### PR DESCRIPTION
When indenting with less than 4 spaces, it will be treated as a new list by md.

<img width="1159" alt="图片" src="https://user-images.githubusercontent.com/359395/63821401-7b68b500-c97f-11e9-9184-103dbde6ac3c.png">

after fixed:

![](https://user-images.githubusercontent.com/359395/63821437-99361a00-c97f-11e9-95f1-0219d0eb4659.png)
