### PR TITLE
Type alias enum variants

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,4 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+#![feature(type_alias_enum_variants)]
+
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]


### PR DESCRIPTION
I am getting about 5 errors like the below when I try to build master with Rust nightly.  I don't know if it was expected to use the experimental feature, but the PR allows me to build:

```
error: enum variants on type aliases are experimental
  --> ../../cli/ops/dispatch_json.rs:70:7
   |
70 |       CoreOp::Sync(serialize_result(promise_id, Ok(sync_value)))
   |       ^^^^^^^^^^^^
   |
   = help: add `#![feature(type_alias_enum_variants)]` to the crate attributes to enable
```