### PR TITLE
Update 0.16 release notes

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -30,6 +30,7 @@ In deno_std:
   (denoland/deno_std#558)
 - fix: refactor 'assertEquals' (denoland/deno_std#560)
 - fix: test all text functions in colors module (denoland/deno_std#553)
+- fix: move colors module into fmt module (denoland/deno_std#571)
 
 ### v0.15.0 / 2019.08.13
 


### PR DESCRIPTION
Adds note about colors module location change in deno_std

As a side note, I'd be interested to hear why this change was made.
