### PR TITLE
Revert "Use -O3 instead of -O (#2070)"

### DIFF
--- a/build_extra/rust/rust.gni
+++ b/build_extra/rust/rust.gni
@@ -253,10 +253,7 @@ template("_rust_crate") {
       args += [ "-g" ]
     }
     if (is_official_build) {
-      args += [
-        "-C",
-        "opt-level=3",
-      ]
+      args += [ "-O" ]
     }
     if (is_test) {
       args += [ "--test" ]


### PR DESCRIPTION
It didn't deliver the expected performance improvements, so let's go
back and use Rust defaults again.

This reverts commit 4232c89c9eb18b32a6e87bfbb46c8d5862f52fb3.

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
