### PR TITLE
feat: add console.dirxml

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -526,6 +526,18 @@ export class Console {
     this.printFunc(stringifyArgs([obj], options) + "\n", false);
   };
 
+  /** From MDN:
+   * Displays an interactive tree of the descendant elements of
+   * the specified XML/HTML element. If it is not possible to display
+   * as an element the JavaScript Object view is shown instead.
+   * The output is presented as a hierarchical listing of expandable
+   * nodes that let you see the contents of child nodes.
+   *
+   * Since we write to stdout, we can't display anything interactive
+   * we just fall back to `console.dir`.
+   */
+  dirxml = this.dir;
+
   /** Writes the arguments to stdout */
   warn = (...args: unknown[]): void => {
     this.printFunc(

--- a/js/console_test.ts
+++ b/js/console_test.ts
@@ -150,7 +150,7 @@ test(function consoleTestStringifyCircular(): void {
   assertEquals(stringify(JSON), "{}");
   assertEquals(
     stringify(console),
-    "{ printFunc, log, debug, info, dir, warn, error, assert, count, countReset, table, time, timeLog, timeEnd, group, groupCollapsed, groupEnd, clear, trace, indentLevel }"
+    "{ printFunc, log, debug, info, dir, dirxml, warn, error, assert, count, countReset, table, time, timeLog, timeEnd, group, groupCollapsed, groupEnd, clear, trace, indentLevel }"
   );
   // test inspect is working the same
   assertEquals(inspect(nestedObj), nestedObjExpected);
@@ -320,6 +320,7 @@ test(function consoleTestClear(): void {
 test(function consoleDetachedLog(): void {
   const log = console.log;
   const dir = console.dir;
+  const dirxml = console.dirxml;
   const debug = console.debug;
   const info = console.info;
   const warn = console.warn;
@@ -336,6 +337,7 @@ test(function consoleDetachedLog(): void {
   const consoleClear = console.clear;
   log("Hello world");
   dir("Hello world");
+  dirxml("Hello world");
   debug("Hello world");
   info("Hello world");
   warn("Hello world");
@@ -665,6 +667,22 @@ test(function consoleDir(): void {
     (console, out): void => {
       console.dir("DIR", { indentLevel: 2 });
       assertEquals(out.toString(), "  DIR\n");
+    }
+  );
+});
+
+// console.dir test
+test(function consoleDirXml(): void {
+  mockConsole(
+    (console, out): void => {
+      console.dirxml("DIRXML");
+      assertEquals(out.toString(), "DIRXML\n");
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.dirxml("DIRXML", { indentLevel: 2 });
+      assertEquals(out.toString(), "  DIRXML\n");
     }
   );
 });


### PR DESCRIPTION
This PR adds `console.dirxml` method which is an alias for `dir` as described [in this comment](https://github.com/denoland/deno/issues/1351#issuecomment-525684984).

Effectively this PR closes #1351