### PR TITLE
Save last execution result in  for REPL

### DIFF
--- a/tools/repl_test.py
+++ b/tools/repl_test.py
@@ -58,6 +58,7 @@ class TestRepl(DenoTestCase):
     def test_help_command(self):
         out, err, code = self.input("help")
         expectedOut = '\n'.join([
+            "_       Print last execution output",
             "exit    Exit the REPL",
             "help    Print this help message",
             "",
@@ -148,6 +149,12 @@ class TestRepl(DenoTestCase):
         out, err, code = self.input("'noop'", exit=False, env=new_env)
         self.assertEqual(out, "noop\n")
         self.assertTrue(err.startswith("Unable to save REPL history:"))
+        self.assertEqual(code, 0)
+
+    def test_save_last_output(self):
+        out, err, code = self.input("1", "_")
+        self.assertEqual(out, '1\n1\n')
+        self.assertEqual(err, '')
         self.assertEqual(code, 0)
 
 


### PR DESCRIPTION
Closes #2839

```bash
$ ./target/debug/deno
> 1 + 2
3
> _
3
> gibberish+-*/
error: Uncaught SyntaxError: Unexpected token '*'
► <unknown>:1:12
    at evaluate (js/repl.ts:78:34)
    at replLoop (js/repl.ts:143:13)
> _
3
>
```

(I'll probably mostly work on just these low-effort tasks recently due to personal business)