### PR TITLE
Add window.queueMicrotask

### DIFF
--- a/core/libdeno/internal.h
+++ b/core/libdeno/internal.h
@@ -156,6 +156,7 @@ void ErrorToJSON(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Shared(v8::Local<v8::Name> property,
             const v8::PropertyCallbackInfo<v8::Value>& info);
 void MessageCallback(v8::Local<v8::Message> message, v8::Local<v8::Value> data);
+void QueueMicrotask(const v8::FunctionCallbackInfo<v8::Value>& args);
 static intptr_t external_references[] = {
     reinterpret_cast<intptr_t>(Print),
     reinterpret_cast<intptr_t>(Recv),
@@ -164,6 +165,7 @@ static intptr_t external_references[] = {
     reinterpret_cast<intptr_t>(ErrorToJSON),
     reinterpret_cast<intptr_t>(Shared),
     reinterpret_cast<intptr_t>(MessageCallback),
+    reinterpret_cast<intptr_t>(QueueMicrotask),
     0};
 
 static const deno_buf empty_buf = {nullptr, 0};

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -89,6 +89,7 @@ window.onload = undefined as undefined | Function;
 // standard https://www.w3.org/TR/WebCryptoAPI/#crypto-interface as it does not
 // yet incorporate the SubtleCrypto interface as its "subtle" property.
 window.crypto = (csprng as unknown) as Crypto;
+// window.queueMicrotask added by hand to self-maintained lib.deno_runtime.d.ts
 
 // When creating the runtime type library, we use modifications to `window` to
 // determine what is in the global namespace.  When we put a class in the

--- a/js/globals_test.ts
+++ b/js/globals_test.ts
@@ -77,3 +77,29 @@ test(function DenoNamespaceImmutable(): void {
   // @ts-ignore
   assert(print === Deno.core.print);
 });
+
+test(async function windowQueueMicrotask(): Promise<void> {
+  let resolve1: () => void | undefined;
+  let resolve2: () => void | undefined;
+  let microtaskDone = false;
+  const p1 = new Promise(
+    (res): void => {
+      resolve1 = (): void => {
+        microtaskDone = true;
+        res();
+      };
+    }
+  );
+  const p2 = new Promise(
+    (res): void => {
+      resolve2 = (): void => {
+        assert(microtaskDone);
+        res();
+      };
+    }
+  );
+  window.queueMicrotask(resolve1!);
+  setTimeout(resolve2!, 0);
+  await p1;
+  await p2;
+});

--- a/js/lib.deno_runtime.d.ts
+++ b/js/lib.deno_runtime.d.ts
@@ -1264,8 +1264,8 @@ declare interface Window {
     callback: (event: domTypes.Event) => void | null,
     options?: boolean | domTypes.EventListenerOptions | undefined
   ) => void;
-  Deno: typeof Deno;
   queueMicrotask: (task: () => void) => void;
+  Deno: typeof Deno;
 }
 
 declare const window: Window;

--- a/js/lib.deno_runtime.d.ts
+++ b/js/lib.deno_runtime.d.ts
@@ -1265,6 +1265,7 @@ declare interface Window {
     options?: boolean | domTypes.EventListenerOptions | undefined
   ) => void;
   Deno: typeof Deno;
+  queueMicrotask: (task: () => void) => void;
 }
 
 declare const window: Window;


### PR DESCRIPTION
Added `window.queueMicrotask` to allow direct push of code to microtask queue (and therefore no need to create Promise objects).

https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask
