### PR TITLE
Remove DenoSubcommand::Install

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -693,7 +693,6 @@ pub enum DenoSubcommand {
   Eval,
   Fetch,
   Info,
-  Install,
   Repl,
   Run,
   Types,
@@ -830,7 +829,7 @@ pub fn flags_from_vec(
               .collect();
             argv.extend(flags);
           }
-          DenoSubcommand::Install
+          DenoSubcommand::Run
         }
         _ => unreachable!(),
       }
@@ -1553,7 +1552,7 @@ mod tests {
         ..DenoFlags::default()
       }
     );
-    assert_eq!(subcommand, DenoSubcommand::Install);
+    assert_eq!(subcommand, DenoSubcommand::Run);
     assert_eq!(
       argv,
       svec![
@@ -1583,7 +1582,7 @@ mod tests {
         ..DenoFlags::default()
       }
     );
-    assert_eq!(subcommand, DenoSubcommand::Install);
+    assert_eq!(subcommand, DenoSubcommand::Run);
     assert_eq!(
       argv,
       svec![
@@ -1617,7 +1616,7 @@ mod tests {
         ..DenoFlags::default()
       }
     );
-    assert_eq!(subcommand, DenoSubcommand::Install);
+    assert_eq!(subcommand, DenoSubcommand::Run);
     assert_eq!(
       argv,
       svec![

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -421,7 +421,6 @@ fn main() {
     DenoSubcommand::Eval => eval_command(flags, argv),
     DenoSubcommand::Fetch => fetch_command(flags, argv),
     DenoSubcommand::Info => info_command(flags, argv),
-    DenoSubcommand::Install => run_script(flags, argv),
     DenoSubcommand::Repl => run_repl(flags, argv),
     DenoSubcommand::Run => run_script(flags, argv),
     DenoSubcommand::Types => types_command(),


### PR DESCRIPTION
Like how `fmt` and `test` are already handled, `install` should reduce to `run` at the arg parsing stage.