### PR TITLE
Move version subcommand handling to main.rs

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -397,6 +397,21 @@ fn run_script(flags: DenoFlags, argv: Vec<String>) {
   }
 }
 
+fn version_command() {
+  // The TypeScript version is only available in JS at the moment.
+  // TODO: Rewrite if this changes.
+  eval_command(
+    DenoFlags::default(),
+    vec![
+      "eval".to_string(),
+      "console.log(\"deno:\", Deno.version.deno);
+       console.log(\"v8:\", Deno.version.v8);
+       console.log(\"typescript:\", Deno.version.typescript);"
+        .to_string(),
+    ],
+  );
+}
+
 fn main() {
   #[cfg(windows)]
   ansi_term::enable_ansi_support().ok(); // For Windows 10
@@ -424,7 +439,7 @@ fn main() {
     DenoSubcommand::Repl => run_repl(flags, argv),
     DenoSubcommand::Run => run_script(flags, argv),
     DenoSubcommand::Types => types_command(),
-    DenoSubcommand::Version => run_repl(flags, argv),
+    DenoSubcommand::Version => version_command(),
     DenoSubcommand::Xeval => xeval_command(flags, argv),
   }
 }

--- a/js/main.ts
+++ b/js/main.ts
@@ -15,9 +15,6 @@ import { setVersions } from "./version";
 import { window } from "./window";
 import { setLocation } from "./location";
 
-// builtin modules
-import * as deno from "./deno";
-
 export default function denoMain(
   preserveDenoNamespace: boolean = true,
   name?: string
@@ -25,14 +22,6 @@ export default function denoMain(
   const s = os.start(preserveDenoNamespace, name);
 
   setVersions(s.denoVersion, s.v8Version);
-
-  // handle `--version`
-  if (s.versionFlag) {
-    console.log("deno:", deno.version.deno);
-    console.log("v8:", deno.version.v8);
-    console.log("typescript:", deno.version.typescript);
-    os.exit(0);
-  }
 
   setPrepareStackTrace(Error);
 


### PR DESCRIPTION
In the `version` subcommand case, we currently start a REPL session and leave detection and handling to an out of place block in `denoMain()`. This gives it a self-contained rust function like the other subcommands have.