### PR TITLE
do not export `isConsoleInstance`

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -486,7 +486,7 @@ type PrintFunc = (x: string, isErr?: boolean) => void;
 
 const countMap = new Map<string, number>();
 const timerMap = new Map<string, number>();
-export const isConsoleInstance = Symbol("isConsoleInstance");
+const isConsoleInstance = Symbol("isConsoleInstance");
 
 export class Console {
   indentLevel: number;

--- a/js/lib.deno_runtime.d.ts
+++ b/js/lib.deno_runtime.d.ts
@@ -1176,7 +1176,6 @@ declare namespace Deno {
     colors: boolean;
     indentLevel: number;
   }>;
-  export const isConsoleInstance: unique symbol;
   /** A symbol which can be used as a key for a custom method which will be called
    * when `Deno.inspect()` is called, or when the object is logged to the console.
    */

--- a/js/lib.deno_runtime.d.ts
+++ b/js/lib.deno_runtime.d.ts
@@ -1957,7 +1957,7 @@ declare namespace consoleTypes {
     static kClear: string;
     static kClearScreenDown: string;
   }
-  export const isConsoleInstance: unique symbol;
+  const isConsoleInstance: unique symbol;
   export class Console {
     private printFunc;
     indentLevel: number;


### PR DESCRIPTION
I saw in the typedoc that [`isConsoleInstance`](https://deno.land/typedoc/index.html#isconsoleinstance) should not be exported, it is only used inside console.ts.

