### PR TITLE
ops/fetch: implement Response.statusText

### DIFF
--- a/cli/ops/fetch.rs
+++ b/cli/ops/fetch.rs
@@ -50,7 +50,7 @@ pub fn op_fetch(
   }
   debug!("Before fetch {}", url);
   let future = request.send().map_err(ErrBox::from).and_then(move |res| {
-    let status = res.status().as_u16();
+    let status = res.status();
     let mut res_headers = Vec::new();
     for (key, val) in res.headers().iter() {
       res_headers.push((key.to_string(), val.to_str().unwrap().to_owned()));
@@ -61,7 +61,8 @@ pub fn op_fetch(
 
     let json_res = json!({
       "bodyRid": body_resource.rid,
-      "status": status,
+      "status": status.as_u16(),
+      "statusText": status.canonical_reason().unwrap_or(""),
       "headers": res_headers
     });
 

--- a/js/fetch.ts
+++ b/js/fetch.ts
@@ -243,7 +243,6 @@ class Body implements domTypes.Body, domTypes.ReadableStream, io.ReadCloser {
 }
 
 export class Response implements domTypes.Response {
-  statusText = "FIXME"; // TODO
   readonly type = "basic"; // TODO
   readonly redirected: boolean;
   headers: domTypes.Headers;
@@ -254,6 +253,7 @@ export class Response implements domTypes.Response {
   constructor(
     readonly url: string,
     readonly status: number,
+    readonly statusText: string,
     headersList: Array<[string, string]>,
     rid: number,
     redirected_: boolean,
@@ -313,6 +313,7 @@ export class Response implements domTypes.Response {
     return new Response(
       this.url,
       this.status,
+      this.statusText,
       headersList,
       -1,
       this.redirected,
@@ -324,6 +325,7 @@ export class Response implements domTypes.Response {
 interface FetchResponse {
   bodyRid: number;
   status: number;
+  statusText: string;
   headers: Array<[string, string]>;
 }
 
@@ -422,6 +424,7 @@ export async function fetch(
     const response = new Response(
       url,
       fetchResponse.status,
+      fetchResponse.statusText,
       fetchResponse.headers,
       fetchResponse.bodyRid,
       redirected

--- a/js/fetch_test.ts
+++ b/js/fetch_test.ts
@@ -107,6 +107,7 @@ testPerm(
 testPerm({ net: true }, async function fetchWithRedirection(): Promise<void> {
   const response = await fetch("http://localhost:4546/"); // will redirect to http://localhost:4545/
   assertEquals(response.status, 200);
+  assertEquals(response.statusText, "OK");
   assertEquals(response.url, "http://localhost:4545/");
   const body = await response.text();
   assert(body.includes("<title>Directory listing for /</title>"));
@@ -117,6 +118,7 @@ testPerm({ net: true }, async function fetchWithRelativeRedirection(): Promise<
 > {
   const response = await fetch("http://localhost:4545/tests"); // will redirect to /tests/
   assertEquals(response.status, 200);
+  assertEquals(response.statusText, "OK");
   const body = await response.text();
   assert(body.includes("<title>Directory listing for /tests/</title>"));
 });


### PR DESCRIPTION
This PR implements Response.statusText field of fetch API. (Addresses a TODO in //js/fetch.ts)