### PR TITLE
Embed typescript version in rust

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -399,18 +399,9 @@ fn run_script(flags: DenoFlags, argv: Vec<String>) {
 }
 
 fn version_command() {
-  // The TypeScript version is only available in JS at the moment.
-  // TODO: Rewrite if this changes.
-  eval_command(
-    DenoFlags::default(),
-    vec![
-      "eval".to_string(),
-      "console.log(\"deno:\", Deno.version.deno);
-       console.log(\"v8:\", Deno.version.v8);
-       console.log(\"typescript:\", Deno.version.typescript);"
-        .to_string(),
-    ],
-  );
+  println!("deno: {}", version::DENO);
+  println!("v8: {}", version::v8());
+  println!("typescript: {}", version::typescript());
 }
 
 fn main() {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -398,6 +398,21 @@ fn run_script(flags: DenoFlags, argv: Vec<String>) {
   }
 }
 
+fn version_command() {
+  // The TypeScript version is only available in JS at the moment.
+  // TODO: Rewrite if this changes.
+  eval_command(
+    DenoFlags::default(),
+    vec![
+      "eval".to_string(),
+      "console.log(\"deno:\", Deno.version.deno);
+       console.log(\"v8:\", Deno.version.v8);
+       console.log(\"typescript:\", Deno.version.typescript);"
+        .to_string(),
+    ],
+  );
+}
+
 fn main() {
   #[cfg(windows)]
   ansi_term::enable_ansi_support().ok(); // For Windows 10
@@ -425,7 +440,7 @@ fn main() {
     DenoSubcommand::Repl => run_repl(flags, argv),
     DenoSubcommand::Run => run_script(flags, argv),
     DenoSubcommand::Types => types_command(),
-    DenoSubcommand::Version => run_repl(flags, argv),
+    DenoSubcommand::Version => version_command(),
     DenoSubcommand::Xeval => xeval_command(flags, argv),
   }
 }

--- a/cli/ops/os.rs
+++ b/cli/ops/os.rs
@@ -28,6 +28,7 @@ pub fn op_start(
     "versionFlag": state.flags.version,
     "v8Version": version::v8(),
     "denoVersion": version::DENO,
+    "tsVersion": version::typescript(),
     "noColor": !ansi::use_color(),
     "xevalDelim": state.flags.xeval_delim.clone(),
   })))

--- a/cli/version.rs
+++ b/cli/version.rs
@@ -1,6 +1,17 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+use serde_json;
 pub const DENO: &str = env!("CARGO_PKG_VERSION");
 
 pub fn v8() -> &'static str {
   deno::v8_version()
+}
+
+pub fn typescript() -> String {
+  // TODO: By using include_str! we are including the package.json into
+  // the deno binary using serde to decode it at runtime. This is suboptimal
+  // in space and time. We need to extract the TypeScript version at compile
+  // time instead. This will be easier after #2608.
+  let data = include_str!("../node_modules/typescript/package.json");
+  let pkg: serde_json::Value = serde_json::from_str(data).unwrap();
+  pkg["version"].as_str().unwrap().to_string()
 }

--- a/deno_typescript/compiler_main.js
+++ b/deno_typescript/compiler_main.js
@@ -10,7 +10,6 @@ function main(configText, rootNames, replacements_) {
   println(`>>> rootNames ${rootNames}`);
 
   replacements = replacements_;
-  replacements["DENO_REPLACE_TS_VERSION"] = ts.version;
   println(`>>> replacements ${JSON.stringify(replacements)}`);
 
   const host = new Host();

--- a/js/main.ts
+++ b/js/main.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-
 import "./globals.ts";
 
 import { assert, log } from "./util.ts";
@@ -13,19 +12,13 @@ import { window } from "./window.ts";
 import { setLocation } from "./location.ts";
 import * as Deno from "./deno.ts";
 
-function denoMain(preserveDenoNamespace: boolean = true, name?: string): void {
+export default function denoMain(
+  preserveDenoNamespace: boolean = true,
+  name?: string
+): void {
   const s = os.start(preserveDenoNamespace, name);
 
   setVersions(s.denoVersion, s.v8Version);
-
-  // handle `--version`
-  if (s.versionFlag) {
-    const { console } = window;
-    console.log("deno:", Deno.version.deno);
-    console.log("v8:", Deno.version.v8);
-    console.log("typescript:", Deno.version.typescript);
-    os.exit(0);
-  }
 
   setPrepareStackTrace(Error);
 

--- a/js/main.ts
+++ b/js/main.ts
@@ -10,15 +10,11 @@ import { xevalMain, XevalFunc } from "./xeval.ts";
 import { setVersions } from "./version.ts";
 import { window } from "./window.ts";
 import { setLocation } from "./location.ts";
-import * as Deno from "./deno.ts";
 
-export default function denoMain(
-  preserveDenoNamespace: boolean = true,
-  name?: string
-): void {
+function denoMain(preserveDenoNamespace: boolean = true, name?: string): void {
   const s = os.start(preserveDenoNamespace, name);
 
-  setVersions(s.denoVersion, s.v8Version);
+  setVersions(s.denoVersion, s.v8Version, s.tsVersion);
 
   setPrepareStackTrace(Error);
 

--- a/js/os.ts
+++ b/js/os.ts
@@ -59,6 +59,7 @@ interface Start {
   versionFlag: boolean;
   denoVersion: string;
   v8Version: string;
+  tsVersion: string;
   noColor: boolean;
   xevalDelim: string;
 }

--- a/js/version.ts
+++ b/js/version.ts
@@ -8,17 +8,21 @@ interface Version {
 export const version: Version = {
   deno: "",
   v8: "",
-  // This string will be replaced by rollup
-  typescript: `DENO_REPLACE_TS_VERSION`
+  typescript: ""
 };
 
 /**
- * Sets the deno and v8 versions and freezes the version object.
+ * Sets the deno, v8, and typescript versions and freezes the version object.
  * @internal
  */
-export function setVersions(denoVersion: string, v8Version: string): void {
+export function setVersions(
+  denoVersion: string,
+  v8Version: string,
+  tsVersion: string
+): void {
   version.deno = denoVersion;
   version.v8 = v8Version;
+  version.typescript = tsVersion;
 
   Object.freeze(version);
 }


### PR DESCRIPTION
This PR is continued from #2848.

This change embeds `package.json` of typescript to rust and extracts `version` field of it.