### PR TITLE
feat: expose Console on global object [don't merge]

### DIFF
--- a/js/console.ts
+++ b/js/console.ts
@@ -492,7 +492,6 @@ export class Console {
   indentLevel: number;
   [isConsoleInstance]: boolean = false;
 
-  /** @internal */
   constructor(private printFunc: PrintFunc) {
     this.indentLevel = 0;
     this[isConsoleInstance] = true;

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -80,6 +80,7 @@ window.fetch = fetchTypes.fetch;
 window.clearTimeout = timers.clearTimeout;
 window.clearInterval = timers.clearInterval;
 window.console = new consoleTypes.Console(core.print);
+window.Console = consoleTypes.Console;
 window.setTimeout = timers.setTimeout;
 window.setInterval = timers.setInterval;
 window.location = (undefined as unknown) as domTypes.Location;

--- a/js/globals_test.ts
+++ b/js/globals_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test, assert } from "./test_util.ts";
+import {test, assert, assertArrayContains, assertEquals} from "./test_util.ts";
 
 test(function globalThisExists(): void {
   assert(globalThis != null);
@@ -102,4 +102,25 @@ test(async function windowQueueMicrotask(): Promise<void> {
   setTimeout(resolve2!, 0);
   await p1;
   await p2;
+});
+
+test(function consoleAssignToWindow(): void {
+  const originalConsole = window.console;
+  const captured: Array<[string, boolean]> = [];
+  const capturingConsole = new Console((x: string, isErr?: boolean): void => {
+    captured.push([x, !!isErr]);
+  });
+
+  window.console = capturingConsole;
+  console.log("this is log");
+  console.error("this is error");
+  window.console = originalConsole;
+
+  assertEquals(
+    JSON.stringify([
+      ["this is log\n", false],
+      ["this is error\n", true],
+    ]),
+    JSON.stringify(captured)
+  );
 });

--- a/js/globals_test.ts
+++ b/js/globals_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import {test, assert, assertArrayContains, assertEquals} from "./test_util.ts";
+import { test, assert, assertEquals } from "./test_util.ts";
 
 test(function globalThisExists(): void {
   assert(globalThis != null);
@@ -107,9 +107,11 @@ test(async function windowQueueMicrotask(): Promise<void> {
 test(function consoleAssignToWindow(): void {
   const originalConsole = window.console;
   const captured: Array<[string, boolean]> = [];
-  const capturingConsole = new Console((x: string, isErr?: boolean): void => {
-    captured.push([x, !!isErr]);
-  });
+  const capturingConsole = new Console(
+    (x: string, isErr?: boolean): void => {
+      captured.push([x, !!isErr]);
+    }
+  );
 
   window.console = capturingConsole;
   console.log("this is log");
@@ -117,10 +119,7 @@ test(function consoleAssignToWindow(): void {
   window.console = originalConsole;
 
   assertEquals(
-    JSON.stringify([
-      ["this is log\n", false],
-      ["this is error\n", true],
-    ]),
+    JSON.stringify([["this is log\n", false], ["this is error\n", true]]),
     JSON.stringify(captured)
   );
 });

--- a/js/lib.deno_runtime.d.ts
+++ b/js/lib.deno_runtime.d.ts
@@ -1274,6 +1274,7 @@ declare const fetch: typeof fetchTypes.fetch;
 declare const clearTimeout: typeof timers.clearTimeout;
 declare const clearInterval: typeof timers.clearInterval;
 declare const console: consoleTypes.Console;
+declare const Console: typeof consoleTypes.Console;
 declare const setTimeout: typeof timers.setTimeout;
 declare const setInterval: typeof timers.setInterval;
 declare const location: domTypes.Location;
@@ -1314,6 +1315,7 @@ declare const removeEventListener: (
 ) => void;
 
 declare type Blob = blob.DenoBlob;
+declare type Console = typeof consoleTypes.Console;
 declare type File = domTypes.DomFile;
 declare type CustomEventInit = customEvent.CustomEventInit;
 declare type CustomEvent = customEvent.CustomEvent;
@@ -1957,7 +1959,9 @@ declare namespace consoleTypes {
     static kClearScreenDown: string;
   }
   const isConsoleInstance: unique symbol;
+  type PrintFunc = (x: string, isErr?: boolean) => void;
   export class Console {
+    constructor(printFunc: PrintFunc);
     private printFunc;
     indentLevel: number;
     [isConsoleInstance]: boolean;

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -19,6 +19,7 @@ export {
   assertNotEquals,
   assertStrictEq,
   assertStrContains,
+  assertArrayContains,
   unreachable
 } from "./deps/https/deno.land/std/testing/asserts.ts";
 

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -19,7 +19,6 @@ export {
   assertNotEquals,
   assertStrictEq,
   assertStrContains,
-  assertArrayContains,
   unreachable
 } from "./deps/https/deno.land/std/testing/asserts.ts";
 


### PR DESCRIPTION
It's useful to export `Console` from `Deno` object. Obvious example would be creating "capturing" console for testing module. Unfortunately I hit problem with types in TS which I can't figure on my own.

Currently experiencing this problem:
```ts
const fakeConsole = new Deno.Console(fakePrint);
window.console = fakeConsole;
```

```ts
error TS2741: Property '[isConsoleInstance]' is missing in type 'Deno.Console' but required in type 'consoleTypes.Console'.

► file:///Users/biwanczuk/dev/deno_std/testing/mod.ts:63:3

63   window.console = fakeConsole;
     ~~~~~~~~~~~~~~

  '[isConsoleInstance]' is declared here.

    ► $asset$/lib.deno_runtime.d.ts:2037:5

    2037     [isConsoleInstance]: boolean;
             ~~~~~~~~~~~~~~~~~~~
```

From `lib.deno_runtime.d.ts`:
```ts
declare interface Window {
   ...
   console: consoleTypes.Console;
   ...
}
```
Inside `Console` there is `isConsoleInstance` which is a unique symbol. This causes that `Deno.Console.isConsoleInstance` is a different symbol than `consoleTypes.Console.isConsoleInstance`.

I believe the problem lies in a way we generated our declaration file, but I'm not sure. Calling @kitsonk for help on this one.