### PR TITLE
perf: less aggresive dyn import polling

### DIFF
--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -645,7 +645,9 @@ impl Future for Isolate {
 
     loop {
       // If there are any pending dyn_import futures, do those first.
-      self.poll_dyn_imports()?;
+      if !self.pending_dyn_imports.is_empty() {
+        self.poll_dyn_imports()?;
+      }
 
       // Now handle actual ops.
       self.have_unpolled_ops = false;


### PR DESCRIPTION
Yesterday when checking out benchmarks for #2793 I found something interesting on flamegraph:
<img width="1156" alt="Zrzut ekranu 2019-09-4 o 13 50 24" src="https://user-images.githubusercontent.com/13602871/64252427-3282a480-cf1b-11e9-8c6e-1962a87de0dc.png">

Circled flame is `poll_dyn_imports`. That was very surprising because `tools/deno_tcp.ts` doesn't have any dynamic imports. 

Small change introduced in this PR caused following benchmarks:
**`master` release build**
```
third_party/wrk/mac/wrk -d 10s --latency http://127.0.0.1:4544
Running 10s test @ http://127.0.0.1:4544
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   214.73us  507.96us  16.78ms   95.77%
    Req/Sec    36.46k     3.35k   40.69k    77.23%
  Latency Distribution
     50%  117.00us
     75%  128.00us
     90%  180.00us
     99%    2.82ms
  732851 requests in 10.10s, 35.64MB read
Requests/sec:  72545.46
Transfer/sec:      3.53MB
```

**`this PR` release build**
```
third_party/wrk/mac/wrk -d 10s --latency http://127.0.0.1:4544
Running 10s test @ http://127.0.0.1:4544
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   198.69us  441.42us   9.57ms   95.62%
    Req/Sec    38.96k     3.90k   44.34k    81.68%
  Latency Distribution
     50%  107.00us
     75%  119.00us
     90%  180.00us
     99%    2.68ms
  783008 requests in 10.10s, 38.08MB read
Requests/sec:  77513.84
Transfer/sec:      3.77MB
```

**`master` debug build**
```
test @ http://127.0.0.1:4544
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   797.56us  693.39us  14.69ms   97.73%
    Req/Sec     6.86k   683.54     7.47k    91.09%
  Latency Distribution
     50%  686.00us
     75%  717.00us
     90%  801.00us
     99%    4.34ms
  137990 requests in 10.10s, 6.71MB read
Requests/sec:  13659.89
Transfer/sec:    680.33KB
```

**`this PR` debug build**
```
third_party/wrk/mac/wrk -d 10s --latency http://127.0.0.1:4544
Running 10s test @ http://127.0.0.1:4544
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   768.40us  703.67us  14.71ms   97.67%
    Req/Sec     7.18k   656.85     7.78k    90.10%
  Latency Distribution
     50%  657.00us
     75%  683.00us
     90%  770.00us
     99%    4.47ms
  144414 requests in 10.10s, 7.02MB read
Requests/sec:  14296.96
Transfer/sec:    712.06KB
```

That's ~5% req/sec gain with simple if. CC @ry @piscisaureus 