### PR TITLE
Remove replacements hack in deno_typescript

### DIFF
--- a/cli/ops/os.rs
+++ b/cli/ops/os.rs
@@ -11,6 +11,16 @@ use std::collections::HashMap;
 use std::env;
 use url::Url;
 
+/// BUILD_OS and BUILD_ARCH match the values in Deno.build. See js/build.ts.
+#[cfg(target_os = "macos")]
+static BUILD_OS: &str = "mac";
+#[cfg(target_os = "linux")]
+static BUILD_OS: &str = "linux";
+#[cfg(target_os = "windows")]
+static BUILD_OS: &str = "win";
+#[cfg(target_arch = "x86_64")]
+static BUILD_ARCH: &str = "x64";
+
 pub fn op_start(
   state: &ThreadSafeState,
   _args: Value,
@@ -31,6 +41,8 @@ pub fn op_start(
     "tsVersion": version::typescript(),
     "noColor": !ansi::use_color(),
     "xevalDelim": state.flags.xeval_delim.clone(),
+    "os": BUILD_OS,
+    "arch": BUILD_ARCH,
   })))
 }
 

--- a/deno_typescript/compiler_main.js
+++ b/deno_typescript/compiler_main.js
@@ -3,14 +3,9 @@
 
 const ASSETS = "$asset$";
 
-let replacements;
-
-function main(configText, rootNames, replacements_) {
+function main(configText, rootNames) {
   println(`>>> ts version ${ts.version}`);
   println(`>>> rootNames ${rootNames}`);
-
-  replacements = replacements_;
-  println(`>>> replacements ${JSON.stringify(replacements)}`);
 
   const host = new Host();
 
@@ -146,12 +141,6 @@ class Host {
     // TODO(ry) A terrible hack. Please remove ASAP.
     if (fileName.endsWith("typescript.d.ts")) {
       sourceCode = sourceCode.replace("export = ts;", "");
-    }
-
-    // TODO(ry) A terrible hack. Please remove ASAP.
-    for (let key of Object.keys(replacements)) {
-      let val = replacements[key];
-      sourceCode = sourceCode.replace(key, val);
     }
 
     let sourceFile = ts.createSourceFile(fileName, sourceCode, languageVersion);

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -12,7 +12,6 @@ use deno::ModuleSpecifier;
 use deno::StartupData;
 pub use ops::EmitResult;
 use ops::WrittenFile;
-use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -78,12 +77,8 @@ impl TSIsolate {
     root_names: Vec<String>,
   ) -> Result<Arc<Mutex<TSState>>, ErrBox> {
     let root_names_json = serde_json::json!(root_names).to_string();
-    let source = &format!(
-      "main({:?}, {}, {})",
-      config_json.to_string(),
-      root_names_json,
-      preprocessor_replacements_json()
-    );
+    let source =
+      &format!("main({:?}, {})", config_json.to_string(), root_names_json);
     self.isolate.execute("<anon>", source)?;
     Ok(self.state.clone())
   }
@@ -268,21 +263,4 @@ pub fn trace_serializer() {
   let r =
     deno::v8_set_flags(vec![dummy.clone(), "--trace-serializer".to_string()]);
   assert_eq!(r, vec![dummy]);
-}
-
-fn preprocessor_replacements_json() -> String {
-  /// BUILD_OS and BUILD_ARCH match the values in Deno.build. See js/build.ts.
-  #[cfg(target_os = "macos")]
-  static BUILD_OS: &str = "mac";
-  #[cfg(target_os = "linux")]
-  static BUILD_OS: &str = "linux";
-  #[cfg(target_os = "windows")]
-  static BUILD_OS: &str = "win";
-  #[cfg(target_arch = "x86_64")]
-  static BUILD_ARCH: &str = "x64";
-
-  let mut replacements = HashMap::new();
-  replacements.insert("DENO_REPLACE_OS", BUILD_OS);
-  replacements.insert("DENO_REPLACE_ARCH", BUILD_ARCH);
-  serde_json::json!(replacements).to_string()
 }

--- a/js/build.ts
+++ b/js/build.ts
@@ -14,14 +14,17 @@ export interface BuildInfo {
   os: OperatingSystem;
 }
 
-// 'build' is injected by rollup.config.js at compile time.
 export const build: BuildInfo = {
-  // These string will be replaced by rollup
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  arch: `DENO_REPLACE_ARCH` as any,
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  os: `DENO_REPLACE_OS` as any
+  arch: "" as Arch,
+  os: "" as OperatingSystem
 };
+
+export function setBuildInfo(os: OperatingSystem, arch: Arch): void {
+  build.os = os;
+  build.arch = arch;
+
+  Object.freeze(build);
+}
 
 // TODO(kevinkassimo): deprecate Deno.platform
 export const platform = build;

--- a/js/main.ts
+++ b/js/main.ts
@@ -11,11 +11,13 @@ import { setVersions } from "./version.ts";
 import { window } from "./window.ts";
 import { setLocation } from "./location.ts";
 import { setBuildInfo } from "./build.ts";
+import { setSignals } from "./process.ts";
 
 function denoMain(preserveDenoNamespace: boolean = true, name?: string): void {
   const s = os.start(preserveDenoNamespace, name);
 
   setBuildInfo(s.os, s.arch);
+  setSignals();
   setVersions(s.denoVersion, s.v8Version, s.tsVersion);
 
   setPrepareStackTrace(Error);

--- a/js/main.ts
+++ b/js/main.ts
@@ -10,10 +10,12 @@ import { xevalMain, XevalFunc } from "./xeval.ts";
 import { setVersions } from "./version.ts";
 import { window } from "./window.ts";
 import { setLocation } from "./location.ts";
+import { setBuildInfo } from "./build.ts";
 
 function denoMain(preserveDenoNamespace: boolean = true, name?: string): void {
   const s = os.start(preserveDenoNamespace, name);
 
+  setBuildInfo(s.os, s.arch);
   setVersions(s.denoVersion, s.v8Version, s.tsVersion);
 
   setPrepareStackTrace(Error);

--- a/js/os.ts
+++ b/js/os.ts
@@ -5,6 +5,7 @@ import { sendSync } from "./dispatch_json.ts";
 import { assert } from "./util.ts";
 import * as util from "./util.ts";
 import { window } from "./window.ts";
+import { OperatingSystem, Arch } from "./build.ts";
 
 // builtin modules
 import { _setGlobals } from "./deno.ts";
@@ -62,6 +63,8 @@ interface Start {
   tsVersion: string;
   noColor: boolean;
   xevalDelim: string;
+  os: OperatingSystem;
+  arch: Arch;
 }
 
 // This function bootstraps an environment within Deno, it is shared both by

--- a/js/process.ts
+++ b/js/process.ts
@@ -5,7 +5,7 @@ import { File, close } from "./files.ts";
 import { ReadCloser, WriteCloser } from "./io.ts";
 import { readAll } from "./buffer.ts";
 import { assert, unreachable } from "./util.ts";
-import { platform } from "./build.ts";
+import { build } from "./build.ts";
 
 /** How to handle subprocess stdio.
  *
@@ -296,4 +296,12 @@ enum MacOSSignal {
 
 /** Signals numbers. This is platform dependent.
  */
-export const Signal = platform.os === "mac" ? MacOSSignal : LinuxSignal;
+export const Signal = {};
+
+export function setSignals(): void {
+  if (build.os === "mac") {
+    Object.assign(Signal, MacOSSignal);
+  } else {
+    Object.assign(Signal, LinuxSignal);
+  }
+}


### PR DESCRIPTION
This PR adds OS and Arch info to op_start message and remove `replacements` hack in deno_typescript.