### PR TITLE
perf: remove double resource lookup for read/write ops

### DIFF
--- a/cli/ops/io.rs
+++ b/cli/ops/io.rs
@@ -17,8 +17,8 @@ pub fn op_read(rid: i32, zero_copy: Option<PinnedBuf>) -> Box<MinimalOp> {
   let resource = Resource { rid: rid as u32 };
   Box::new(
     tokio::io::read(resource, zero_copy)
-    .map_err(ErrBox::from)
-    .and_then(move |(_resource, _buf, nread)| Ok(nread as i32)),
+      .map_err(ErrBox::from)
+      .and_then(move |(_resource, _buf, nread)| Ok(nread as i32)),
   )
 }
 


### PR DESCRIPTION
This is just an experiment but it seems like a waste of cycles to perform double resource lookup for each read/write operation. 