### PR TITLE
Fix path normalization in resolve_from_cwd()

### DIFF
--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -167,19 +167,19 @@ mod tests {
   #[test]
   fn resolve_from_cwd_child() {
     let cwd = std::env::current_dir().unwrap();
-    assert!(resolve_from_cwd("a").unwrap().0 == cwd.join("a"));
+    assert_eq!(resolve_from_cwd("a").unwrap().0, cwd.join("a"));
   }
 
   #[test]
   fn resolve_from_cwd_dot() {
     let cwd = std::env::current_dir().unwrap();
-    assert!(resolve_from_cwd(".").unwrap().0 == cwd);
+    assert_eq!(resolve_from_cwd(".").unwrap().0, cwd);
   }
 
   #[test]
   fn resolve_from_cwd_parent() {
     let cwd = std::env::current_dir().unwrap();
-    assert!(resolve_from_cwd("a/..").unwrap().0 == cwd);
+    assert_eq!(resolve_from_cwd("a/..").unwrap().0, cwd);
   }
 
   #[test]
@@ -189,6 +189,6 @@ mod tests {
     } else {
       Path::new("/a")
     };
-    assert!(resolve_from_cwd("/a").unwrap().0 == expected);
+    assert_eq!(resolve_from_cwd("/a").unwrap().0, expected);
   }
 }

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -156,3 +156,31 @@ pub fn resolve_from_cwd(path: &str) -> Result<(PathBuf, String), ErrBox> {
 
   Ok((normalized_path, path_string))
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn resolve_from_cwd_child() {
+    let cwd = std::env::current_dir().unwrap();
+    assert!(resolve_from_cwd("a").unwrap().0 == cwd.join("a"));
+  }
+
+  #[test]
+  fn resolve_from_cwd_dot() {
+    let cwd = std::env::current_dir().unwrap();
+    assert!(resolve_from_cwd(".").unwrap().0 == cwd);
+  }
+
+  #[test]
+  fn resolve_from_cwd_parent() {
+    let cwd = std::env::current_dir().unwrap();
+    assert!(resolve_from_cwd("a/..").unwrap().0 == cwd);
+  }
+
+  #[test]
+  fn resolve_from_cwd_absolute() {
+    assert!(resolve_from_cwd("/a").unwrap().0 == Path::new("/a"));
+  }
+}

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -139,18 +139,21 @@ pub fn resolve_from_cwd(path: &str) -> Result<(PathBuf, String), ErrBox> {
     cwd.join(path)
   };
 
-  // HACK: `Url::from_directory_path` is used here because it normalizes the path.
+  // HACK: `Url::parse` is used here because it normalizes the path.
   // Joining `/dev/deno/" with "./tests" using `PathBuf` yields `/deno/dev/./tests/`.
   // On the other hand joining `/dev/deno/" with "./tests" using `Url` yields "/dev/deno/tests"
   // - and that's what we want.
   // There exists similar method on `PathBuf` - `PathBuf.canonicalize`, but the problem
   // is `canonicalize` resolves symlinks and we don't want that.
-  // We just want o normalize the path...
-  let resolved_url = Url::from_file_path(resolved_path)
-    .expect("PathBuf should be parseable URL");
-  let normalized_path = resolved_url
+  // We just want to normalize the path...
+  // This only works on absolute paths - not worth extracting as a public utility.
+  let resolved_url =
+    Url::from_file_path(resolved_path).expect("Path should be absolute");
+  let normalized_url = Url::parse(resolved_url.as_str())
+    .expect("String from a URL should parse to a URL");
+  let normalized_path = normalized_url
     .to_file_path()
-    .expect("URL from PathBuf should be valid path");
+    .expect("URL from a path should contain a valid path");
 
   let path_string = normalized_path.to_str().unwrap().to_string();
 

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -184,6 +184,11 @@ mod tests {
 
   #[test]
   fn resolve_from_cwd_absolute() {
-    assert!(resolve_from_cwd("/a").unwrap().0 == Path::new("/a"));
+    let expected = if cfg!(windows) {
+      Path::new("C:\\a")
+    } else {
+      Path::new("/a")
+    };
+    assert!(resolve_from_cwd("/a").unwrap().0 == expected);
   }
 }


### PR DESCRIPTION
Fixes #2718.

`test.js`:
```js
Deno.readDirSync("..");
console.log("OK");
```
`deno --no-prompt --allow-read="." test.js`
Before: `OK`
After: `error: Uncaught PermissionDenied: permission denied ...`