### PR TITLE
Add default-run (+ clean up old references)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "main.rs"
 name = "deno_cli"
 version = "0.17.0"
 edition = "2018"
+default-run = "deno"
 
 [dependencies]
 deno = { path = "../core" }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,6 @@
   "files": [
     "js/lib.web_assembly.d.ts",
     "js/lib.deno_runtime.d.ts",
-    "core/core.d.ts",
-    "core/libdeno/libdeno.d.ts",
     "js/main.ts",
     "js/compiler.ts"
   ]

--- a/website/manual.md
+++ b/website/manual.md
@@ -160,7 +160,7 @@ cargo build -vv
 ./target/debug/deno tests/002_hello.ts
 
 # Test.
-CARGO_TEST=1 ./tools/test.py
+./tools/test.py
 
 # Format code.
 ./tools/format.py


### PR DESCRIPTION
Since we can use `cargo run` now, this removes the need for `--bin deno`.