### PR TITLE
Update @typescript-eslint/* to v2.1.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": "./tsconfig.json"
+    "project": "./tsconfig.json",
+    "createDefaultProgram": true
   },
   "plugins": ["@typescript-eslint"],
   "extends": [
@@ -11,7 +12,10 @@
     "prettier/@typescript-eslint"
   ],
   "rules": {
-    "@typescript-eslint/array-type": ["error", "array-simple"],
+    "@typescript-eslint/array-type": [
+      "error",
+      { "default": "array-simple" }
+    ],
     "@typescript-eslint/explicit-member-accessibility": ["off"],
     "@typescript-eslint/no-non-null-assertion": ["off"],
     "@typescript-eslint/no-use-before-define": ["off"],
@@ -19,6 +23,17 @@
     "@typescript-eslint/no-unused-vars": [
       "error",
       { "argsIgnorePattern": "^_" }
-    ]
-  }
+    ],
+    "@typescript-eslint/ban-ts-ignore": ["off"],
+    "@typescript-eslint/no-empty-function": ["off"],
+    "@typescript-eslint/explicit-function-return-type": ["off"]
+  },
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": ["error"]
+      }
+    }
+  ]
 }

--- a/core/libdeno/libdeno_test.js
+++ b/core/libdeno/libdeno_test.js
@@ -3,6 +3,7 @@
 // A simple runtime that doesn't involve typescript or protobufs to test
 // libdeno. Invoked by libdeno_test.cc
 
+// eslint-disable-next-line @typescript-eslint/no-this-alias
 const global = this;
 
 function assert(cond) {

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -48,7 +48,7 @@ SharedQueue Binary Layout
   }
 
   function init() {
-    let shared = Deno.core.shared;
+    const shared = Deno.core.shared;
     assert(shared.byteLength > 0);
     assert(sharedBytes == null);
     assert(shared32 == null);
@@ -113,9 +113,9 @@ SharedQueue Binary Layout
   }
 
   function push(opId, buf) {
-    let off = head();
-    let end = off + buf.byteLength;
-    let index = numRecords();
+    const off = head();
+    const end = off + buf.byteLength;
+    const index = numRecords();
     if (end > shared32.byteLength || index >= MAX_RECORDS) {
       // console.log("shared_queue.js push fail");
       return false;
@@ -130,7 +130,7 @@ SharedQueue Binary Layout
 
   /// Returns null if empty.
   function shift() {
-    let i = shared32[INDEX_NUM_SHIFTED_OFF];
+    const i = shared32[INDEX_NUM_SHIFTED_OFF];
     if (size() == 0) {
       assert(i == 0);
       return null;
@@ -164,7 +164,7 @@ SharedQueue Binary Layout
       asyncHandler(opId, buf);
     } else {
       while (true) {
-        let opIdBuf = shift();
+        const opIdBuf = shift();
         if (opIdBuf == null) {
           break;
         }

--- a/core/shared_queue_test.js
+++ b/core/shared_queue_test.js
@@ -25,11 +25,11 @@ function fullRecords(q) {
 function main() {
   const q = Deno.core.sharedQueue;
 
-  let h = q.head();
+  const h = q.head();
   assert(h > 0);
 
   let r = new Uint8Array([1, 2, 3, 4, 5]);
-  let len = r.byteLength + h;
+  const len = r.byteLength + h;
   assert(q.push(99, r));
   assert(q.head() == len);
 

--- a/js/base64.ts
+++ b/js/base64.ts
@@ -5,7 +5,7 @@ const lookup: string[] = [];
 const revLookup: number[] = [];
 
 const code = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-for (var i = 0, len = code.length; i < len; ++i) {
+for (let i = 0, len = code.length; i < len; ++i) {
   lookup[i] = code[i];
   revLookup[code.charCodeAt(i)] = i;
 }
@@ -16,7 +16,7 @@ revLookup["-".charCodeAt(0)] = 62;
 revLookup["_".charCodeAt(0)] = 63;
 
 function getLens(b64: string): [number, number] {
-  var len = b64.length;
+  const len = b64.length;
 
   if (len % 4 > 0) {
     throw new Error("Invalid string. Length must be a multiple of 4");
@@ -24,19 +24,19 @@ function getLens(b64: string): [number, number] {
 
   // Trim off extra bytes after placeholder bytes are found
   // See: https://github.com/beatgammit/base64-js/issues/42
-  var validLen = b64.indexOf("=");
+  let validLen = b64.indexOf("=");
   if (validLen === -1) validLen = len;
 
-  var placeHoldersLen = validLen === len ? 0 : 4 - (validLen % 4);
+  const placeHoldersLen = validLen === len ? 0 : 4 - (validLen % 4);
 
   return [validLen, placeHoldersLen];
 }
 
 // base64 is 4/3 + up to two characters of the original data
 export function byteLength(b64: string): number {
-  var lens = getLens(b64);
-  var validLen = lens[0];
-  var placeHoldersLen = lens[1];
+  const lens = getLens(b64);
+  const validLen = lens[0];
+  const placeHoldersLen = lens[1];
   return ((validLen + placeHoldersLen) * 3) / 4 - placeHoldersLen;
 }
 
@@ -49,19 +49,20 @@ function _byteLength(
 }
 
 export function toByteArray(b64: string): Uint8Array {
-  var tmp;
-  var lens = getLens(b64);
-  var validLen = lens[0];
-  var placeHoldersLen = lens[1];
+  let tmp;
+  const lens = getLens(b64);
+  const validLen = lens[0];
+  const placeHoldersLen = lens[1];
 
-  var arr = new Uint8Array(_byteLength(b64, validLen, placeHoldersLen));
+  const arr = new Uint8Array(_byteLength(b64, validLen, placeHoldersLen));
 
-  var curByte = 0;
+  let curByte = 0;
 
   // if there are placeholders, only get up to the last complete 4 chars
-  var len = placeHoldersLen > 0 ? validLen - 4 : validLen;
+  const len = placeHoldersLen > 0 ? validLen - 4 : validLen;
 
-  for (var i = 0; i < len; i += 4) {
+  let i;
+  for (i = 0; i < len; i += 4) {
     tmp =
       (revLookup[b64.charCodeAt(i)] << 18) |
       (revLookup[b64.charCodeAt(i + 1)] << 12) |
@@ -101,9 +102,9 @@ function tripletToBase64(num: number): string {
 }
 
 function encodeChunk(uint8: Uint8Array, start: number, end: number): string {
-  var tmp;
-  var output = [];
-  for (var i = start; i < end; i += 3) {
+  let tmp;
+  const output = [];
+  for (let i = start; i < end; i += 3) {
     tmp =
       ((uint8[i] << 16) & 0xff0000) +
       ((uint8[i + 1] << 8) & 0xff00) +
@@ -114,14 +115,14 @@ function encodeChunk(uint8: Uint8Array, start: number, end: number): string {
 }
 
 export function fromByteArray(uint8: Uint8Array): string {
-  var tmp;
-  var len = uint8.length;
-  var extraBytes = len % 3; // if we have 1 byte left, pad 2 bytes
-  var parts = [];
-  var maxChunkLength = 16383; // must be multiple of 3
+  let tmp;
+  const len = uint8.length;
+  const extraBytes = len % 3; // if we have 1 byte left, pad 2 bytes
+  const parts = [];
+  const maxChunkLength = 16383; // must be multiple of 3
 
   // go through the array every three bytes, we'll deal with trailing stuff later
-  for (var i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {
+  for (let i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {
     parts.push(
       encodeChunk(
         uint8,

--- a/js/blob.ts
+++ b/js/blob.ts
@@ -7,7 +7,7 @@ import { build } from "./build.ts";
 export const bytesSymbol = Symbol("bytes");
 
 function convertLineEndingsToNative(s: string): string {
-  let nativeLineEnd = build.os == "win" ? "\r\n" : "\n";
+  const nativeLineEnd = build.os == "win" ? "\r\n" : "\n";
 
   let position = 0;
 
@@ -19,7 +19,7 @@ function convertLineEndingsToNative(s: string): string {
   let result = token;
 
   while (position < s.length) {
-    let c = s.charAt(position);
+    const c = s.charAt(position);
     if (c == "\r") {
       result += nativeLineEnd;
       position++;

--- a/js/blob_test.ts
+++ b/js/blob_test.ts
@@ -54,7 +54,7 @@ test(function nativeEndLine(): void {
   const options: object = {
     ending: "native"
   };
-  let blob = new Blob(["Hello\nWorld"], options);
+  const blob = new Blob(["Hello\nWorld"], options);
 
   assertEquals(blob.size, Deno.build.os === "win" ? 12 : 11);
 });

--- a/js/buffer_test.ts
+++ b/js/buffer_test.ts
@@ -45,7 +45,7 @@ async function fillBytes(
 ): Promise<string> {
   check(buf, s);
   for (; n > 0; n--) {
-    let m = await buf.write(fub);
+    const m = await buf.write(fub);
     assertEquals(m, fub.byteLength);
     const decoder = new TextDecoder();
     s += decoder.decode(fub);
@@ -84,7 +84,7 @@ test(function bufferNewBuffer(): void {
 
 test(async function bufferBasicOperations(): Promise<void> {
   init();
-  let buf = new Buffer();
+  const buf = new Buffer();
   for (let i = 0; i < 5; i++) {
     check(buf, "");
 
@@ -123,9 +123,9 @@ test(async function bufferBasicOperations(): Promise<void> {
 test(async function bufferReadEmptyAtEOF(): Promise<void> {
   // check that EOF of 'buf' is not reached (even though it's empty) if
   // results are written to buffer that has 0 length (ie. it can't store any data)
-  let buf = new Buffer();
+  const buf = new Buffer();
   const zeroLengthTmp = new Uint8Array(0);
-  let result = await buf.read(zeroLengthTmp);
+  const result = await buf.read(zeroLengthTmp);
   assertEquals(result, 0);
 });
 
@@ -211,9 +211,9 @@ test(async function bufferReadFromSync(): Promise<void> {
 
 test(async function bufferTestGrow(): Promise<void> {
   const tmp = new Uint8Array(72);
-  for (let startLen of [0, 100, 1000, 10000, 100000]) {
+  for (const startLen of [0, 100, 1000, 10000, 100000]) {
     const xBytes = repeat("x", startLen);
-    for (let growLen of [0, 100, 1000, 10000, 100000]) {
+    for (const growLen of [0, 100, 1000, 10000, 100000]) {
       const buf = new Buffer(xBytes.buffer as ArrayBuffer);
       // If we read, this affects buf.off, which is good to test.
       const result = await buf.read(tmp);

--- a/js/colors.ts
+++ b/js/colors.ts
@@ -11,7 +11,7 @@ interface Code {
   regexp: RegExp;
 }
 
-let enabled = !noColor;
+const enabled = !noColor;
 
 function code(open: number, close: number): Code {
   return {

--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -61,8 +61,7 @@ interface ConfigureResponse {
 
 /** Options that either do nothing in Deno, or would cause undesired behavior
  * if modified. */
-// TODO(#2878): The type should be ReadonlyArray<string>
-const ignoredCompilerOptions: string[] = [
+const ignoredCompilerOptions: readonly string[] = [
   "allowSyntheticDefaultImports",
   "baseUrl",
   "build",
@@ -416,7 +415,7 @@ class Host implements ts.CompilerHost {
     data: string,
     writeByteOrderMark: boolean,
     onError?: (message: string) => void,
-    sourceFiles?: ts.SourceFile[] // TODO(#2878): The type should be ReadonlyArray<ts.SourceFile>
+    sourceFiles?: readonly ts.SourceFile[]
   ): void {
     util.log("writeFile", fileName);
     try {

--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -61,6 +61,7 @@ interface ConfigureResponse {
 
 /** Options that either do nothing in Deno, or would cause undesired behavior
  * if modified. */
+// TODO(#2878): The type should be ReadonlyArray<string>
 const ignoredCompilerOptions: string[] = [
   "allowSyntheticDefaultImports",
   "baseUrl",
@@ -415,7 +416,7 @@ class Host implements ts.CompilerHost {
     data: string,
     writeByteOrderMark: boolean,
     onError?: (message: string) => void,
-    sourceFiles?: ts.SourceFile[]
+    sourceFiles?: ts.SourceFile[] // TODO(#2878): The type should be ReadonlyArray<ts.SourceFile>
   ): void {
     util.log("writeFile", fileName);
     try {

--- a/js/compiler.ts
+++ b/js/compiler.ts
@@ -61,7 +61,7 @@ interface ConfigureResponse {
 
 /** Options that either do nothing in Deno, or would cause undesired behavior
  * if modified. */
-const ignoredCompilerOptions: ReadonlyArray<string> = [
+const ignoredCompilerOptions: string[] = [
   "allowSyntheticDefaultImports",
   "baseUrl",
   "build",
@@ -415,7 +415,7 @@ class Host implements ts.CompilerHost {
     data: string,
     writeByteOrderMark: boolean,
     onError?: (message: string) => void,
-    sourceFiles?: ReadonlyArray<ts.SourceFile>
+    sourceFiles?: ts.SourceFile[]
   ): void {
     util.log("writeFile", fileName);
     try {

--- a/js/console.ts
+++ b/js/console.ts
@@ -490,7 +490,7 @@ const isConsoleInstance = Symbol("isConsoleInstance");
 
 export class Console {
   indentLevel: number;
-  [isConsoleInstance]: boolean = false;
+  [isConsoleInstance] = false;
 
   /** @internal */
   constructor(private printFunc: PrintFunc) {
@@ -501,7 +501,7 @@ export class Console {
     // For historical web-compatibility reasons, the namespace object for
     // console must have as its [[Prototype]] an empty object, created as if
     // by ObjectCreate(%ObjectPrototype%), instead of %ObjectPrototype%.
-    let console = Object.create({}) as Console;
+    const console = Object.create({}) as Console;
     Object.assign(console, this);
     return console;
   }

--- a/js/diagnostics.ts
+++ b/js/diagnostics.ts
@@ -204,7 +204,7 @@ function parseRelatedInformation(
 export function fromTypeScriptDiagnostic(
   diagnostics: readonly ts.Diagnostic[]
 ): Diagnostic {
-  let items: DiagnosticItem[] = [];
+  const items: DiagnosticItem[] = [];
   for (const sourceDiagnostic of diagnostics) {
     const item: DiagnosticItem = parseDiagnostic(sourceDiagnostic);
     if (sourceDiagnostic.relatedInformation) {

--- a/js/dom_util.ts
+++ b/js/dom_util.ts
@@ -50,7 +50,7 @@ export function isShadowInclusiveAncestor(
 export function getRoot(
   node: domTypes.EventTarget | null
 ): domTypes.EventTarget | null {
-  let root = node;
+  const root = node;
 
   // for (const ancestor of domSymbolTree.ancestorsIterator(node)) {
   //   root = ancestor;

--- a/js/files.ts
+++ b/js/files.ts
@@ -115,7 +115,7 @@ export function writeSync(rid: number, p: Uint8Array): number {
  *
  */
 export async function write(rid: number, p: Uint8Array): Promise<number> {
-  let result = await sendAsyncMinimal(dispatch.OP_WRITE, rid, p);
+  const result = await sendAsyncMinimal(dispatch.OP_WRITE, rid, p);
   if (result < 0) {
     throw new Error("write error");
   } else {

--- a/js/files_test.ts
+++ b/js/files_test.ts
@@ -323,7 +323,7 @@ testPerm({ read: true }, async function seekMode(): Promise<void> {
 
   // We should still be able to read the file
   // since it is still open.
-  let buf = new Uint8Array(1);
+  const buf = new Uint8Array(1);
   await file.read(buf); // "H"
   assertEquals(new TextDecoder().decode(buf), "H");
 });

--- a/js/io.ts
+++ b/js/io.ts
@@ -6,7 +6,7 @@
 // TODO(kt3k): EOF should be `unique symbol` type.
 // That might require some changes of ts_library_builder.
 // See #2591 for more details.
-export const EOF: null = null;
+export const EOF = null;
 export type EOF = null;
 
 // Seek whence values.

--- a/js/main.ts
+++ b/js/main.ts
@@ -13,7 +13,7 @@ import { setLocation } from "./location.ts";
 import { setBuildInfo } from "./build.ts";
 import { setSignals } from "./process.ts";
 
-function denoMain(preserveDenoNamespace: boolean = true, name?: string): void {
+function denoMain(preserveDenoNamespace = true, name?: string): void {
   const s = os.start(preserveDenoNamespace, name);
 
   setBuildInfo(s.os, s.arch);

--- a/js/permissions_test.ts
+++ b/js/permissions_test.ts
@@ -10,7 +10,7 @@ const knownPermissions: Deno.Permission[] = [
   "hrtime"
 ];
 
-for (let grant of knownPermissions) {
+for (const grant of knownPermissions) {
   testPerm({ [grant]: true }, function envGranted(): void {
     const perms = Deno.permissions();
     assert(perms !== null);

--- a/js/process_test.ts
+++ b/js/process_test.ts
@@ -44,10 +44,10 @@ testPerm({ run: true }, async function runSuccess(): Promise<void> {
 testPerm({ run: true }, async function runCommandFailedWithCode(): Promise<
   void
 > {
-  let p = run({
+  const p = run({
     args: ["python", "-c", "import sys;sys.exit(41 + 1)"]
   });
-  let status = await p.status();
+  const status = await p.status();
   assertEquals(status.success, false);
   assertEquals(status.code, 42);
   assertEquals(status.signal, undefined);
@@ -133,8 +133,8 @@ testPerm({ run: true }, async function runStdinPiped(): Promise<void> {
   assert(!p.stdout);
   assert(!p.stderr);
 
-  let msg = new TextEncoder().encode("hello");
-  let n = await p.stdin.write(msg);
+  const msg = new TextEncoder().encode("hello");
+  const n = await p.stdin.write(msg);
   assertEquals(n, msg.byteLength);
 
   p.stdin.close();
@@ -307,7 +307,7 @@ testPerm({ run: true }, async function runClose(): Promise<void> {
   p.close();
 
   const data = new Uint8Array(10);
-  let r = await p.stderr.read(data);
+  const r = await p.stderr.read(data);
   assertEquals(r, Deno.EOF);
 });
 

--- a/js/request.ts
+++ b/js/request.ts
@@ -138,7 +138,7 @@ export class Request extends body.Body implements domTypes.Request {
       headersList.push(header);
     }
 
-    let body2 = this._bodySource;
+    const body2 = this._bodySource;
 
     const cloned = new Request(this.url, {
       body: body2,

--- a/js/text_encoding.ts
+++ b/js/text_encoding.ts
@@ -481,7 +481,7 @@ export class TextEncoder {
         break;
       }
       if (Array.isArray(result)) {
-        output.push.apply(output, result);
+        output.push(...result);
       } else {
         output.push(result);
       }

--- a/js/text_encoding_test.ts
+++ b/js/text_encoding_test.ts
@@ -24,8 +24,8 @@ test(function atobWithAsciiWhitespace(): void {
                 d29ybGQ=`
   ];
 
-  for (let encoded of encodedList) {
-    let decoded = atob(encoded);
+  for (const encoded of encodedList) {
+    const decoded = atob(encoded);
     assertEquals(decoded, "hello world");
   }
 });

--- a/js/timers.ts
+++ b/js/timers.ts
@@ -48,7 +48,7 @@ async function setGlobalTimeout(due: number, now: number): Promise<void> {
   // Since JS and Rust don't use the same clock, pass the time to rust as a
   // relative time value. On the Rust side we'll turn that into an absolute
   // value again.
-  let timeout = due - now;
+  const timeout = due - now;
   assert(timeout >= 0);
 
   // Send message to the backend.
@@ -229,7 +229,7 @@ function setTimer(
 /** Sets a timer which executes a function once after the timer expires. */
 export function setTimeout(
   cb: (...args: Args) => void,
-  delay: number = 0,
+  delay = 0,
   ...args: Args
 ): number {
   checkBigInt(delay);
@@ -241,7 +241,7 @@ export function setTimeout(
 /** Repeatedly calls a function , with a fixed time delay between each call. */
 export function setInterval(
   cb: (...args: Args) => void,
-  delay: number = 0,
+  delay = 0,
   ...args: Args
 ): number {
   checkBigInt(delay);
@@ -263,7 +263,7 @@ function clearTimer(id: number): void {
   idMap.delete(timer.id);
 }
 
-export function clearTimeout(id: number = 0): void {
+export function clearTimeout(id = 0): void {
   checkBigInt(id);
   if (id === 0) {
     return;
@@ -271,7 +271,7 @@ export function clearTimeout(id: number = 0): void {
   clearTimer(id);
 }
 
-export function clearInterval(id: number = 0): void {
+export function clearInterval(id = 0): void {
   checkBigInt(id);
   if (id === 0) {
     return;

--- a/js/workers.ts
+++ b/js/workers.ts
@@ -55,7 +55,7 @@ async function hostGetMessage(rid: number): Promise<any> {
 }
 
 // Stuff for workers
-export let onmessage: (e: { data: any }) => void = (): void => {};
+export const onmessage: (e: { data: any }) => void = (): void => {};
 
 export function postMessage(data: any): void {
   const dataIntArray = encodeMessage(data);
@@ -122,7 +122,7 @@ export interface DenoWorkerOptions extends WorkerOptions {
 
 export class WorkerImpl implements Worker {
   private readonly rid: number;
-  private isClosing: boolean = false;
+  private isClosing = false;
   private readonly isClosedPromise: Promise<void>;
   public onerror?: () => void;
   public onmessage?: (data: any) => void;

--- a/js/xeval.ts
+++ b/js/xeval.ts
@@ -48,7 +48,7 @@ async function* chunks(
   let inspectIndex = 0;
   let matchIndex = 0;
   while (true) {
-    let result = await reader.read(inspectArr);
+    const result = await reader.read(inspectArr);
     if (result === EOF) {
       // Yield last chunk.
       const lastChunk = inputBuffer.toString();
@@ -59,7 +59,7 @@ async function* chunks(
       // Discard all remaining and silently fail.
       return;
     }
-    let sliceRead = inspectArr.subarray(0, result as number);
+    const sliceRead = inspectArr.subarray(0, result as number);
     await writeAll(inputBuffer, sliceRead);
 
     let sliceToProcess = inputBuffer.bytes();

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "deno",
   "devDependencies": {
     "@types/prettier": "1.16.1",
-    "@typescript-eslint/eslint-plugin": "1.6.0",
-    "@typescript-eslint/parser": "1.6.0",
+    "@typescript-eslint/eslint-plugin": "2.1.0",
+    "@typescript-eslint/parser": "2.1.0",
     "eslint": "5.15.1",
     "eslint-config-prettier": "4.1.0",
     "magic-string": "0.25.2",

--- a/tests/subdir/redirects/redirect4.ts
+++ b/tests/subdir/redirects/redirect4.ts
@@ -1,2 +1,2 @@
 import { redirect } from "./redirect1.ts";
-export const value: string = `4 imports ${redirect}`;
+export const value = `4 imports ${redirect}`;

--- a/tests/wasm_async.js
+++ b/tests/wasm_async.js
@@ -16,8 +16,8 @@ const bytes = new Uint8Array([
 ]);
 
 async function main() {
-  let wasm = await WebAssembly.instantiate(bytes);
-  let result = wasm.instance.exports.add(1, 3);
+  const wasm = await WebAssembly.instantiate(bytes);
+  const result = wasm.instance.exports.add(1, 3);
   console.log("1 + 3 =", result);
   if (result != 4) {
     throw Error("bad");

--- a/tests/workers_round_robin_bench.ts
+++ b/tests/workers_round_robin_bench.ts
@@ -38,7 +38,7 @@ function handleAsyncMsgFromWorker(
 
 async function main(): Promise<void> {
   const workers: Array<[Map<number, Resolvable<string>>, Worker]> = [];
-  for (var i = 1; i <= workerCount; ++i) {
+  for (let i = 1; i <= workerCount; ++i) {
     const worker = new Worker("./subdir/bench_worker.ts");
     const promise = new Promise(
       (resolve): void => {

--- a/tests/workers_startup_bench.ts
+++ b/tests/workers_startup_bench.ts
@@ -3,7 +3,7 @@ const workerCount = 50;
 
 async function bench(): Promise<void> {
   const workers: Worker[] = [];
-  for (var i = 1; i <= workerCount; ++i) {
+  for (let i = 1; i <= workerCount; ++i) {
     const worker = new Worker("./subdir/bench_worker.ts");
     const promise = new Promise(
       (resolve): void => {


### PR DESCRIPTION
This PR updates `@typescript-eslint` toolchains to v2.1.0. This removes the below warning from `./tools/lint.py`:

```
WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.
```

depends on https://github.com/denoland/deno_third_party/pull/50