### PR TITLE
Declare globals explicitly in lib.deno_runtime.d.ts

### DIFF
--- a/js/body_test.ts
+++ b/js/body_test.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, testPerm, assertEquals, assert } from "./test_util.ts";
+import * as domTypes from "./dom_types.ts";
 
 // just a hack to get a body object
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/js/lib.deno_runtime.d.ts
+++ b/js/lib.deno_runtime.d.ts
@@ -6,1350 +6,1541 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 
-declare namespace Deno {
-  // @url js/os.d.ts
+// This makes it so that `declare`d variables aren't global by default.
+export {};
 
-  /** The current process id of the runtime. */
-  export let pid: number;
-  /** Reflects the NO_COLOR environment variable: https://no-color.org/ */
-  export let noColor: boolean;
-  /** Check if running in terminal.
-   *
-   *       console.log(Deno.isTTY().stdout);
-   */
-  export function isTTY(): {
-    stdin: boolean;
-    stdout: boolean;
-    stderr: boolean;
-  };
-  /** Exit the Deno process with optional exit code. */
-  export function exit(code?: number): never;
-  /** Returns a snapshot of the environment variables at invocation. Mutating a
-   * property in the object will set that variable in the environment for
-   * the process. The environment object will only accept `string`s
-   * as values.
-   *
-   *       const myEnv = Deno.env();
-   *       console.log(myEnv.SHELL);
-   *       myEnv.TEST_VAR = "HELLO";
-   *       const newEnv = Deno.env();
-   *       console.log(myEnv.TEST_VAR == newEnv.TEST_VAR);
-   */
-  export function env(): {
-    [index: string]: string;
-  };
-  /**
-   * Returns the current user's home directory.
-   * Requires the `--allow-env` flag.
-   */
-  export function homeDir(): string;
-  /**
-   * Returns the path to the current deno executable.
-   * Requires the `--allow-env` flag.
-   */
-  export function execPath(): string;
+declare global {
+  export namespace Deno {
+    // @url js/os.d.ts
 
-  // @url js/dir.d.ts
-
-  /**
-   * `cwd()` Return a string representing the current working directory.
-   * If the current directory can be reached via multiple paths
-   * (due to symbolic links), `cwd()` may return
-   * any one of them.
-   * throws `NotFound` exception if directory not available
-   */
-  export function cwd(): string;
-  /**
-   * `chdir()` Change the current working directory to path.
-   * throws `NotFound` exception if directory not available
-   */
-  export function chdir(directory: string): void;
-
-  // @url js/io.d.ts
-
-  export const EOF: null;
-  export type EOF = null;
-  export enum SeekMode {
-    SEEK_START = 0,
-    SEEK_CURRENT = 1,
-    SEEK_END = 2
-  }
-  export interface Reader {
-    /** Reads up to p.byteLength bytes into `p`. It resolves to the number
-     * of bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error encountered.
-     * Even if `read()` returns `n` < `p.byteLength`, it may use all of `p` as
-     * scratch space during the call. If some data is available but not
-     * `p.byteLength` bytes, `read()` conventionally returns what is available
-     * instead of waiting for more.
+    /** The current process id of the runtime. */
+    export let pid: number;
+    /** Reflects the NO_COLOR environment variable: https://no-color.org/ */
+    export let noColor: boolean;
+    /** Check if running in terminal.
      *
-     * When `read()` encounters end-of-file condition, it returns EOF symbol.
-     *
-     * When `read()` encounters an error, it rejects with an error.
-     *
-     * Callers should always process the `n` > `0` bytes returned before
-     * considering the EOF. Doing so correctly handles I/O errors that happen
-     * after reading some bytes and also both of the allowed EOF behaviors.
-     *
-     * Implementations must not retain `p`.
+     *       console.log(Deno.isTTY().stdout);
      */
-    read(p: Uint8Array): Promise<number | EOF>;
-  }
-  export interface SyncReader {
-    readSync(p: Uint8Array): number | EOF;
-  }
-  export interface Writer {
-    /** Writes `p.byteLength` bytes from `p` to the underlying data
-     * stream. It resolves to the number of bytes written from `p` (`0` <= `n` <=
-     * `p.byteLength`) and any error encountered that caused the write to stop
-     * early. `write()` must return a non-null error if it returns `n` <
-     * `p.byteLength`. write() must not modify the slice data, even temporarily.
-     *
-     * Implementations must not retain `p`.
-     */
-    write(p: Uint8Array): Promise<number>;
-  }
-  export interface SyncWriter {
-    writeSync(p: Uint8Array): number;
-  }
-  export interface Closer {
-    close(): void;
-  }
-  export interface Seeker {
-    /** Seek sets the offset for the next `read()` or `write()` to offset,
-     * interpreted according to `whence`: `SeekStart` means relative to the start
-     * of the file, `SeekCurrent` means relative to the current offset, and
-     * `SeekEnd` means relative to the end. Seek returns the new offset relative
-     * to the start of the file and an error, if any.
-     *
-     * Seeking to an offset before the start of the file is an error. Seeking to
-     * any positive offset is legal, but the behavior of subsequent I/O operations
-     * on the underlying object is implementation-dependent.
-     */
-    seek(offset: number, whence: SeekMode): Promise<void>;
-  }
-  export interface SyncSeeker {
-    seekSync(offset: number, whence: SeekMode): void;
-  }
-  export interface ReadCloser extends Reader, Closer {}
-  export interface WriteCloser extends Writer, Closer {}
-  export interface ReadSeeker extends Reader, Seeker {}
-  export interface WriteSeeker extends Writer, Seeker {}
-  export interface ReadWriteCloser extends Reader, Writer, Closer {}
-  export interface ReadWriteSeeker extends Reader, Writer, Seeker {}
-  /** Copies from `src` to `dst` until either `EOF` is reached on `src`
-   * or an error occurs. It returns the number of bytes copied and the first
-   * error encountered while copying, if any.
-   *
-   * Because `copy()` is defined to read from `src` until `EOF`, it does not
-   * treat an `EOF` from `read()` as an error to be reported.
-   */
-  export function copy(dst: Writer, src: Reader): Promise<number>;
-  /** Turns `r` into async iterator.
-   *
-   *      for await (const chunk of toAsyncIterator(reader)) {
-   *          console.log(chunk)
-   *      }
-   */
-  export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array>;
-
-  // @url js/files.d.ts
-
-  /** Open a file and return an instance of the `File` object
-   *  synchronously.
-   *
-   *       const file = Deno.openSync("/foo/bar.txt");
-   */
-  export function openSync(filename: string, mode?: OpenMode): File;
-  /** Open a file and return an instance of the `File` object.
-   *
-   *       (async () => {
-   *         const file = await Deno.open("/foo/bar.txt");
-   *       })();
-   */
-  export function open(filename: string, mode?: OpenMode): Promise<File>;
-  /** Read synchronously from a file ID into an array buffer.
-   *
-   * Return `number | EOF` for the operation.
-   *
-   *      const file = Deno.openSync("/foo/bar.txt");
-   *      const buf = new Uint8Array(100);
-   *      const nread = Deno.readSync(file.rid, buf);
-   *      const text = new TextDecoder().decode(buf);
-   *
-   */
-  export function readSync(rid: number, p: Uint8Array): number | EOF;
-  /** Read from a file ID into an array buffer.
-   *
-   * Resolves with the `number | EOF` for the operation.
-   *
-   *       (async () => {
-   *         const file = await Deno.open("/foo/bar.txt");
-   *         const buf = new Uint8Array(100);
-   *         const nread = await Deno.read(file.rid, buf);
-   *         const text = new TextDecoder().decode(buf);
-   *       })();
-   */
-  export function read(rid: number, p: Uint8Array): Promise<number | EOF>;
-  /** Write synchronously to the file ID the contents of the array buffer.
-   *
-   * Resolves with the number of bytes written.
-   *
-   *       const encoder = new TextEncoder();
-   *       const data = encoder.encode("Hello world\n");
-   *       const file = Deno.openSync("/foo/bar.txt");
-   *       Deno.writeSync(file.rid, data);
-   */
-  export function writeSync(rid: number, p: Uint8Array): number;
-  /** Write to the file ID the contents of the array buffer.
-   *
-   * Resolves with the number of bytes written.
-   *
-   *      (async () => {
-   *        const encoder = new TextEncoder();
-   *        const data = encoder.encode("Hello world\n");
-   *        const file = await Deno.open("/foo/bar.txt");
-   *        await Deno.write(file.rid, data);
-   *      })();
-   *
-   */
-  export function write(rid: number, p: Uint8Array): Promise<number>;
-  /** Seek a file ID synchronously to the given offset under mode given by `whence`.
-   *
-   *       const file = Deno.openSync("/foo/bar.txt");
-   *       Deno.seekSync(file.rid, 0, 0);
-   */
-  export function seekSync(rid: number, offset: number, whence: SeekMode): void;
-  /** Seek a file ID to the given offset under mode given by `whence`.
-   *
-   *      (async () => {
-   *        const file = await Deno.open("/foo/bar.txt");
-   *        await Deno.seek(file.rid, 0, 0);
-   *      })();
-   */
-  export function seek(
-    rid: number,
-    offset: number,
-    whence: SeekMode
-  ): Promise<void>;
-  /** Close the file ID. */
-  export function close(rid: number): void;
-  /** The Deno abstraction for reading and writing files. */
-  export class File
-    implements
-      Reader,
-      SyncReader,
-      Writer,
-      SyncWriter,
-      Seeker,
-      SyncSeeker,
-      Closer {
-    readonly rid: number;
-    constructor(rid: number);
-    write(p: Uint8Array): Promise<number>;
-    writeSync(p: Uint8Array): number;
-    read(p: Uint8Array): Promise<number | EOF>;
-    readSync(p: Uint8Array): number | EOF;
-    seek(offset: number, whence: SeekMode): Promise<void>;
-    seekSync(offset: number, whence: SeekMode): void;
-    close(): void;
-  }
-  /** An instance of `File` for stdin. */
-  export const stdin: File;
-  /** An instance of `File` for stdout. */
-  export const stdout: File;
-  /** An instance of `File` for stderr. */
-  export const stderr: File;
-  export type OpenMode =
-    | "r"
-    /** Read-write. Start at beginning of file. */
-    | "r+"
-    /** Write-only. Opens and truncates existing file or creates new one for
-     * writing only.
-     */
-    | "w"
-    /** Read-write. Opens and truncates existing file or creates new one for
-     * writing and reading.
-     */
-    | "w+"
-    /** Write-only. Opens existing file or creates new one. Each write appends
-     * content to the end of file.
-     */
-    | "a"
-    /** Read-write. Behaves like "a" and allows to read from file. */
-    | "a+"
-    /** Write-only. Exclusive create - creates new file only if one doesn't exist
-     * already.
-     */
-    | "x"
-    /** Read-write. Behaves like `x` and allows to read from file. */
-    | "x+";
-
-  // @url js/buffer.d.ts
-
-  /** A Buffer is a variable-sized buffer of bytes with read() and write()
-   * methods. Based on https://golang.org/pkg/bytes/#Buffer
-   */
-  export class Buffer implements Reader, SyncReader, Writer, SyncWriter {
-    private buf;
-    private off;
-    constructor(ab?: ArrayBuffer);
-    /** bytes() returns a slice holding the unread portion of the buffer.
-     * The slice is valid for use only until the next buffer modification (that
-     * is, only until the next call to a method like read(), write(), reset(), or
-     * truncate()). The slice aliases the buffer content at least until the next
-     * buffer modification, so immediate changes to the slice will affect the
-     * result of future reads.
-     */
-    bytes(): Uint8Array;
-    /** toString() returns the contents of the unread portion of the buffer
-     * as a string. Warning - if multibyte characters are present when data is
-     * flowing through the buffer, this method may result in incorrect strings
-     * due to a character being split.
-     */
-    toString(): string;
-    /** empty() returns whether the unread portion of the buffer is empty. */
-    empty(): boolean;
-    /** length is a getter that returns the number of bytes of the unread
-     * portion of the buffer
-     */
-    readonly length: number;
-    /** Returns the capacity of the buffer's underlying byte slice, that is,
-     * the total space allocated for the buffer's data.
-     */
-    readonly capacity: number;
-    /** truncate() discards all but the first n unread bytes from the buffer but
-     * continues to use the same allocated storage.  It throws if n is negative or
-     * greater than the length of the buffer.
-     */
-    truncate(n: number): void;
-    /** reset() resets the buffer to be empty, but it retains the underlying
-     * storage for use by future writes. reset() is the same as truncate(0)
-     */
-    reset(): void;
-    /** _tryGrowByReslice() is a version of grow for the fast-case
-     * where the internal buffer only needs to be resliced. It returns the index
-     * where bytes should be written and whether it succeeded.
-     * It returns -1 if a reslice was not needed.
-     */
-    private _tryGrowByReslice;
-    private _reslice;
-    /** readSync() reads the next len(p) bytes from the buffer or until the buffer
-     * is drained. The return value n is the number of bytes read. If the
-     * buffer has no data to return, eof in the response will be true.
-     */
-    readSync(p: Uint8Array): number | EOF;
-    read(p: Uint8Array): Promise<number | EOF>;
-    writeSync(p: Uint8Array): number;
-    write(p: Uint8Array): Promise<number>;
-    /** _grow() grows the buffer to guarantee space for n more bytes.
-     * It returns the index where bytes should be written.
-     * If the buffer can't grow it will throw with ErrTooLarge.
-     */
-    private _grow;
-    /** grow() grows the buffer's capacity, if necessary, to guarantee space for
-     * another n bytes. After grow(n), at least n bytes can be written to the
-     * buffer without another allocation. If n is negative, grow() will panic. If
-     * the buffer can't grow it will throw ErrTooLarge.
-     * Based on https://golang.org/pkg/bytes/#Buffer.Grow
-     */
-    grow(n: number): void;
-    /** readFrom() reads data from r until EOF and appends it to the buffer,
-     * growing the buffer as needed. It returns the number of bytes read. If the
-     * buffer becomes too large, readFrom will panic with ErrTooLarge.
-     * Based on https://golang.org/pkg/bytes/#Buffer.ReadFrom
-     */
-    readFrom(r: Reader): Promise<number>;
-    /** Sync version of `readFrom`
-     */
-    readFromSync(r: SyncReader): number;
-  }
-  /** Read `r` until EOF and return the content as `Uint8Array`.
-   */
-  export function readAll(r: Reader): Promise<Uint8Array>;
-  /** Read synchronously `r` until EOF and return the content as `Uint8Array`.
-   */
-  export function readAllSync(r: SyncReader): Uint8Array;
-  /** Write all the content of `arr` to `w`.
-   */
-  export function writeAll(w: Writer, arr: Uint8Array): Promise<void>;
-  /** Write synchronously all the content of `arr` to `w`.
-   */
-  export function writeAllSync(w: SyncWriter, arr: Uint8Array): void;
-
-  // @url js/mkdir.d.ts
-
-  /** Creates a new directory with the specified path synchronously.
-   * If `recursive` is set to true, nested directories will be created (also known
-   * as "mkdir -p").
-   * `mode` sets permission bits (before umask) on UNIX and does nothing on
-   * Windows.
-   *
-   *       Deno.mkdirSync("new_dir");
-   *       Deno.mkdirSync("nested/directories", true);
-   */
-  export function mkdirSync(
-    path: string,
-    recursive?: boolean,
-    mode?: number
-  ): void;
-  /** Creates a new directory with the specified path.
-   * If `recursive` is set to true, nested directories will be created (also known
-   * as "mkdir -p").
-   * `mode` sets permission bits (before umask) on UNIX and does nothing on
-   * Windows.
-   *
-   *       await Deno.mkdir("new_dir");
-   *       await Deno.mkdir("nested/directories", true);
-   */
-  export function mkdir(
-    path: string,
-    recursive?: boolean,
-    mode?: number
-  ): Promise<void>;
-
-  // @url js/make_temp_dir.d.ts
-
-  export interface MakeTempDirOptions {
-    dir?: string;
-    prefix?: string;
-    suffix?: string;
-  }
-  /** makeTempDirSync is the synchronous version of `makeTempDir`.
-   *
-   *       const tempDirName0 = Deno.makeTempDirSync();
-   *       const tempDirName1 = Deno.makeTempDirSync({ prefix: 'my_temp' });
-   */
-  export function makeTempDirSync(options?: MakeTempDirOptions): string;
-  /** makeTempDir creates a new temporary directory in the directory `dir`, its
-   * name beginning with `prefix` and ending with `suffix`.
-   * It returns the full path to the newly created directory.
-   * If `dir` is unspecified, tempDir uses the default directory for temporary
-   * files. Multiple programs calling tempDir simultaneously will not choose the
-   * same directory. It is the caller's responsibility to remove the directory
-   * when no longer needed.
-   *
-   *       const tempDirName0 = await Deno.makeTempDir();
-   *       const tempDirName1 = await Deno.makeTempDir({ prefix: 'my_temp' });
-   */
-  export function makeTempDir(options?: MakeTempDirOptions): Promise<string>;
-
-  // @url js/chmod.d.ts
-
-  /** Changes the permission of a specific file/directory of specified path
-   * synchronously.
-   *
-   *       Deno.chmodSync("/path/to/file", 0o666);
-   */
-  export function chmodSync(path: string, mode: number): void;
-  /** Changes the permission of a specific file/directory of specified path.
-   *
-   *       await Deno.chmod("/path/to/file", 0o666);
-   */
-  export function chmod(path: string, mode: number): Promise<void>;
-
-  // @url js/chown.d.ts
-
-  /**
-   * Change owner of a regular file or directory synchronously. Unix only at the moment.
-   * @param path path to the file
-   * @param uid user id of the new owner
-   * @param gid group id of the new owner
-   */
-  export function chownSync(path: string, uid: number, gid: number): void;
-  /**
-   * Change owner of a regular file or directory asynchronously. Unix only at the moment.
-   * @param path path to the file
-   * @param uid user id of the new owner
-   * @param gid group id of the new owner
-   */
-  export function chown(path: string, uid: number, gid: number): Promise<void>;
-
-  // @url js/utime.d.ts
-
-  /** Synchronously changes the access and modification times of a file system
-   * object referenced by `filename`. Given times are either in seconds
-   * (Unix epoch time) or as `Date` objects.
-   *
-   *       Deno.utimeSync("myfile.txt", 1556495550, new Date());
-   */
-  export function utimeSync(
-    filename: string,
-    atime: number | Date,
-    mtime: number | Date
-  ): void;
-  /** Changes the access and modification times of a file system object
-   * referenced by `filename`. Given times are either in seconds
-   * (Unix epoch time) or as `Date` objects.
-   *
-   *       await Deno.utime("myfile.txt", 1556495550, new Date());
-   */
-  export function utime(
-    filename: string,
-    atime: number | Date,
-    mtime: number | Date
-  ): Promise<void>;
-
-  // @url js/remove.d.ts
-
-  export interface RemoveOption {
-    recursive?: boolean;
-  }
-  /** Removes the named file or directory synchronously. Would throw
-   * error if permission denied, not found, or directory not empty if `recursive`
-   * set to false.
-   * `recursive` is set to false by default.
-   *
-   *       Deno.removeSync("/path/to/dir/or/file", {recursive: false});
-   */
-  export function removeSync(path: string, options?: RemoveOption): void;
-  /** Removes the named file or directory. Would throw error if
-   * permission denied, not found, or directory not empty if `recursive` set
-   * to false.
-   * `recursive` is set to false by default.
-   *
-   *       await Deno.remove("/path/to/dir/or/file", {recursive: false});
-   */
-  export function remove(path: string, options?: RemoveOption): Promise<void>;
-
-  // @url js/rename.d.ts
-
-  /** Synchronously renames (moves) `oldpath` to `newpath`. If `newpath` already
-   * exists and is not a directory, `renameSync()` replaces it. OS-specific
-   * restrictions may apply when `oldpath` and `newpath` are in different
-   * directories.
-   *
-   *       Deno.renameSync("old/path", "new/path");
-   */
-  export function renameSync(oldpath: string, newpath: string): void;
-  /** Renames (moves) `oldpath` to `newpath`. If `newpath` already exists and is
-   * not a directory, `rename()` replaces it. OS-specific restrictions may apply
-   * when `oldpath` and `newpath` are in different directories.
-   *
-   *       await Deno.rename("old/path", "new/path");
-   */
-  export function rename(oldpath: string, newpath: string): Promise<void>;
-
-  // @url js/read_file.d.ts
-
-  /** Read the entire contents of a file synchronously.
-   *
-   *       const decoder = new TextDecoder("utf-8");
-   *       const data = Deno.readFileSync("hello.txt");
-   *       console.log(decoder.decode(data));
-   */
-  export function readFileSync(filename: string): Uint8Array;
-  /** Read the entire contents of a file.
-   *
-   *       const decoder = new TextDecoder("utf-8");
-   *       const data = await Deno.readFile("hello.txt");
-   *       console.log(decoder.decode(data));
-   */
-  export function readFile(filename: string): Promise<Uint8Array>;
-
-  // @url js/file_info.d.ts
-
-  /** A FileInfo describes a file and is returned by `stat`, `lstat`,
-   * `statSync`, `lstatSync`.
-   */
-  export interface FileInfo {
-    /** The size of the file, in bytes. */
-    len: number;
-    /** The last modification time of the file. This corresponds to the `mtime`
-     * field from `stat` on Unix and `ftLastWriteTime` on Windows. This may not
-     * be available on all platforms.
-     */
-    modified: number | null;
-    /** The last access time of the file. This corresponds to the `atime`
-     * field from `stat` on Unix and `ftLastAccessTime` on Windows. This may not
-     * be available on all platforms.
-     */
-    accessed: number | null;
-    /** The last access time of the file. This corresponds to the `birthtime`
-     * field from `stat` on Unix and `ftCreationTime` on Windows. This may not
-     * be available on all platforms.
-     */
-    created: number | null;
-    /** The underlying raw st_mode bits that contain the standard Unix permissions
-     * for this file/directory. TODO Match behavior with Go on windows for mode.
-     */
-    mode: number | null;
-    /** The file or directory name. */
-    name: string | null;
-    /** Returns whether this is info for a regular file. This result is mutually
-     * exclusive to `FileInfo.isDirectory` and `FileInfo.isSymlink`.
-     */
-    isFile(): boolean;
-    /** Returns whether this is info for a regular directory. This result is
-     * mutually exclusive to `FileInfo.isFile` and `FileInfo.isSymlink`.
-     */
-    isDirectory(): boolean;
-    /** Returns whether this is info for a symlink. This result is
-     * mutually exclusive to `FileInfo.isFile` and `FileInfo.isDirectory`.
-     */
-    isSymlink(): boolean;
-  }
-
-  // @url js/read_dir.d.ts
-
-  /** Reads the directory given by path and returns a list of file info
-   * synchronously.
-   *
-   *       const files = Deno.readDirSync("/");
-   */
-  export function readDirSync(path: string): FileInfo[];
-  /** Reads the directory given by path and returns a list of file info.
-   *
-   *       const files = await Deno.readDir("/");
-   */
-  export function readDir(path: string): Promise<FileInfo[]>;
-
-  // @url js/copy_file.d.ts
-
-  /** Copies the contents of a file to another by name synchronously.
-   * Creates a new file if target does not exists, and if target exists,
-   * overwrites original content of the target file.
-   *
-   * It would also copy the permission of the original file
-   * to the destination.
-   *
-   *       Deno.copyFileSync("from.txt", "to.txt");
-   */
-  export function copyFileSync(from: string, to: string): void;
-  /** Copies the contents of a file to another by name.
-   *
-   * Creates a new file if target does not exists, and if target exists,
-   * overwrites original content of the target file.
-   *
-   * It would also copy the permission of the original file
-   * to the destination.
-   *
-   *       await Deno.copyFile("from.txt", "to.txt");
-   */
-  export function copyFile(from: string, to: string): Promise<void>;
-
-  // @url js/read_link.d.ts
-
-  /** Returns the destination of the named symbolic link synchronously.
-   *
-   *       const targetPath = Deno.readlinkSync("symlink/path");
-   */
-  export function readlinkSync(name: string): string;
-  /** Returns the destination of the named symbolic link.
-   *
-   *       const targetPath = await Deno.readlink("symlink/path");
-   */
-  export function readlink(name: string): Promise<string>;
-
-  // @url js/stat.d.ts
-
-  interface StatResponse {
-    isFile: boolean;
-    isSymlink: boolean;
-    len: number;
-    modified: number;
-    accessed: number;
-    created: number;
-    mode: number;
-    hasMode: boolean;
-    name: string | null;
-  }
-  /** Queries the file system for information on the path provided. If the given
-   * path is a symlink information about the symlink will be returned.
-   *
-   *       const fileInfo = await Deno.lstat("hello.txt");
-   *       assert(fileInfo.isFile());
-   */
-  export function lstat(filename: string): Promise<FileInfo>;
-  /** Queries the file system for information on the path provided synchronously.
-   * If the given path is a symlink information about the symlink will be
-   * returned.
-   *
-   *       const fileInfo = Deno.lstatSync("hello.txt");
-   *       assert(fileInfo.isFile());
-   */
-  export function lstatSync(filename: string): FileInfo;
-  /** Queries the file system for information on the path provided. `stat` Will
-   * always follow symlinks.
-   *
-   *       const fileInfo = await Deno.stat("hello.txt");
-   *       assert(fileInfo.isFile());
-   */
-  export function stat(filename: string): Promise<FileInfo>;
-  /** Queries the file system for information on the path provided synchronously.
-   * `statSync` Will always follow symlinks.
-   *
-   *       const fileInfo = Deno.statSync("hello.txt");
-   *       assert(fileInfo.isFile());
-   */
-  export function statSync(filename: string): FileInfo;
-
-  // @url js/link.d.ts
-
-  /** Synchronously creates `newname` as a hard link to `oldname`.
-   *
-   *       Deno.linkSync("old/name", "new/name");
-   */
-  export function linkSync(oldname: string, newname: string): void;
-  /** Creates `newname` as a hard link to `oldname`.
-   *
-   *       await Deno.link("old/name", "new/name");
-   */
-  export function link(oldname: string, newname: string): Promise<void>;
-
-  // @url js/symlink.d.ts
-
-  /** Synchronously creates `newname` as a symbolic link to `oldname`. The type
-   * argument can be set to `dir` or `file` and is only available on Windows
-   * (ignored on other platforms).
-   *
-   *       Deno.symlinkSync("old/name", "new/name");
-   */
-  export function symlinkSync(
-    oldname: string,
-    newname: string,
-    type?: string
-  ): void;
-  /** Creates `newname` as a symbolic link to `oldname`. The type argument can be
-   * set to `dir` or `file` and is only available on Windows (ignored on other
-   * platforms).
-   *
-   *       await Deno.symlink("old/name", "new/name");
-   */
-  export function symlink(
-    oldname: string,
-    newname: string,
-    type?: string
-  ): Promise<void>;
-
-  // @url js/write_file.d.ts
-
-  /** Options for writing to a file.
-   * `perm` would change the file's permission if set.
-   * `create` decides if the file should be created if not exists (default: true)
-   * `append` decides if the file should be appended (default: false)
-   */
-  export interface WriteFileOptions {
-    perm?: number;
-    create?: boolean;
-    append?: boolean;
-  }
-  /** Write a new file, with given filename and data synchronously.
-   *
-   *       const encoder = new TextEncoder();
-   *       const data = encoder.encode("Hello world\n");
-   *       Deno.writeFileSync("hello.txt", data);
-   */
-  export function writeFileSync(
-    filename: string,
-    data: Uint8Array,
-    options?: WriteFileOptions
-  ): void;
-  /** Write a new file, with given filename and data.
-   *
-   *       const encoder = new TextEncoder();
-   *       const data = encoder.encode("Hello world\n");
-   *       await Deno.writeFile("hello.txt", data);
-   */
-  export function writeFile(
-    filename: string,
-    data: Uint8Array,
-    options?: WriteFileOptions
-  ): Promise<void>;
-
-  // @url js/error_stack.d.ts
-
-  interface Location {
-    /** The full url for the module, e.g. `file://some/file.ts` or
-     * `https://some/file.ts`. */
-    filename: string;
-    /** The line number in the file.  It is assumed to be 1-indexed. */
-    line: number;
-    /** The column number in the file.  It is assumed to be 1-indexed. */
-    column: number;
-  }
-  /** Given a current location in a module, lookup the source location and
-   * return it.
-   *
-   * When Deno transpiles code, it keep source maps of the transpiled code.  This
-   * function can be used to lookup the original location.  This is automatically
-   * done when accessing the `.stack` of an error, or when an uncaught error is
-   * logged.  This function can be used to perform the lookup for creating better
-   * error handling.
-   *
-   * **Note:** `line` and `column` are 1 indexed, which matches display
-   * expectations, but is not typical of most index numbers in Deno.
-   *
-   * An example:
-   *
-   *       const orig = Deno.applySourceMap({
-   *         location: "file://my/module.ts",
-   *         line: 5,
-   *         column: 15
-   *       });
-   *       console.log(`${orig.filename}:${orig.line}:${orig.column}`);
-   *
-   */
-  export function applySourceMap(location: Location): Location;
-
-  // @url js/errors.d.ts
-
-  /** A Deno specific error.  The `kind` property is set to a specific error code
-   * which can be used to in application logic.
-   *
-   *       try {
-   *         somethingThatMightThrow();
-   *       } catch (e) {
-   *         if (
-   *           e instanceof Deno.DenoError &&
-   *           e.kind === Deno.ErrorKind.Overflow
-   *         ) {
-   *           console.error("Overflow error!");
-   *         }
-   *       }
-   *
-   */
-  export class DenoError<T extends ErrorKind> extends Error {
-    readonly kind: T;
-    constructor(kind: T, msg: string);
-  }
-  export enum ErrorKind {
-    NoError = 0,
-    NotFound = 1,
-    PermissionDenied = 2,
-    ConnectionRefused = 3,
-    ConnectionReset = 4,
-    ConnectionAborted = 5,
-    NotConnected = 6,
-    AddrInUse = 7,
-    AddrNotAvailable = 8,
-    BrokenPipe = 9,
-    AlreadyExists = 10,
-    WouldBlock = 11,
-    InvalidInput = 12,
-    InvalidData = 13,
-    TimedOut = 14,
-    Interrupted = 15,
-    WriteZero = 16,
-    Other = 17,
-    UnexpectedEof = 18,
-    BadResource = 19,
-    CommandFailed = 20,
-    EmptyHost = 21,
-    IdnaError = 22,
-    InvalidPort = 23,
-    InvalidIpv4Address = 24,
-    InvalidIpv6Address = 25,
-    InvalidDomainCharacter = 26,
-    RelativeUrlWithoutBase = 27,
-    RelativeUrlWithCannotBeABaseBase = 28,
-    SetHostOnCannotBeABaseUrl = 29,
-    Overflow = 30,
-    HttpUser = 31,
-    HttpClosed = 32,
-    HttpCanceled = 33,
-    HttpParse = 34,
-    HttpOther = 35,
-    TooLarge = 36,
-    InvalidUri = 37,
-    InvalidSeekMode = 38,
-    OpNotAvailable = 39,
-    WorkerInitFailed = 40,
-    UnixError = 41,
-    NoAsyncSupport = 42,
-    NoSyncSupport = 43,
-    ImportMapError = 44,
-    InvalidPath = 45,
-    ImportPrefixMissing = 46,
-    UnsupportedFetchScheme = 47,
-    TooManyRedirects = 48,
-    Diagnostic = 49,
-    JSError = 50
-  }
-
-  // @url js/permissions.d.ts
-
-  /** Permissions as granted by the caller */
-  export interface Permissions {
-    read: boolean;
-    write: boolean;
-    net: boolean;
-    env: boolean;
-    run: boolean;
-    hrtime: boolean;
-  }
-  export type Permission = keyof Permissions;
-  /** Inspect granted permissions for the current program.
-   *
-   *       if (Deno.permissions().read) {
-   *         const file = await Deno.readFile("example.test");
-   *         // ...
-   *       }
-   */
-  export function permissions(): Permissions;
-  /** Revoke a permission. When the permission was already revoked nothing changes
-   *
-   *       if (Deno.permissions().read) {
-   *         const file = await Deno.readFile("example.test");
-   *         Deno.revokePermission('read');
-   *       }
-   *       Deno.readFile("example.test"); // -> error or permission prompt
-   */
-  export function revokePermission(permission: Permission): void;
-
-  // @url js/truncate.d.ts
-
-  /** Truncates or extends the specified file synchronously, updating the size of
-   * this file to become size.
-   *
-   *       Deno.truncateSync("hello.txt", 10);
-   */
-  export function truncateSync(name: string, len?: number): void;
-  /**
-   * Truncates or extends the specified file, updating the size of this file to
-   * become size.
-   *
-   *       await Deno.truncate("hello.txt", 10);
-   */
-  export function truncate(name: string, len?: number): Promise<void>;
-
-  // @url js/net.d.ts
-
-  type Network = "tcp";
-  interface Addr {
-    network: Network;
-    address: string;
-  }
-  /** A Listener is a generic network listener for stream-oriented protocols. */
-  export interface Listener extends AsyncIterator<Conn> {
-    /** Waits for and resolves to the next connection to the `Listener`. */
-    accept(): Promise<Conn>;
-    /** Close closes the listener. Any pending accept promises will be rejected
-     * with errors.
-     */
-    close(): void;
-    /** Return the address of the `Listener`. */
-    addr(): Addr;
-    [Symbol.asyncIterator](): AsyncIterator<Conn>;
-  }
-  export interface Conn extends Reader, Writer, Closer {
-    /** The local address of the connection. */
-    localAddr: string;
-    /** The remote address of the connection. */
-    remoteAddr: string;
-    /** The resource ID of the connection. */
-    rid: number;
-    /** Shuts down (`shutdown(2)`) the reading side of the TCP connection. Most
-     * callers should just use `close()`.
-     */
-    closeRead(): void;
-    /** Shuts down (`shutdown(2)`) the writing side of the TCP connection. Most
-     * callers should just use `close()`.
-     */
-    closeWrite(): void;
-  }
-  /** Listen announces on the local network address.
-   *
-   * The network must be `tcp`, `tcp4`, `tcp6`, `unix` or `unixpacket`.
-   *
-   * For TCP networks, if the host in the address parameter is empty or a literal
-   * unspecified IP address, `listen()` listens on all available unicast and
-   * anycast IP addresses of the local system. To only use IPv4, use network
-   * `tcp4`. The address can use a host name, but this is not recommended,
-   * because it will create a listener for at most one of the host's IP
-   * addresses. If the port in the address parameter is empty or `0`, as in
-   * `127.0.0.1:` or `[::1]:0`, a port number is automatically chosen. The
-   * `addr()` method of `Listener` can be used to discover the chosen port.
-   *
-   * See `dial()` for a description of the network and address parameters.
-   */
-  export function listen(network: Network, address: string): Listener;
-  /** Dial connects to the address on the named network.
-   *
-   * Supported networks are only `tcp` currently.
-   *
-   * TODO: `tcp4` (IPv4-only), `tcp6` (IPv6-only), `udp`, `udp4` (IPv4-only),
-   * `udp6` (IPv6-only), `ip`, `ip4` (IPv4-only), `ip6` (IPv6-only), `unix`,
-   * `unixgram` and `unixpacket`.
-   *
-   * For TCP and UDP networks, the address has the form `host:port`. The host must
-   * be a literal IP address, or a host name that can be resolved to IP addresses.
-   * The port must be a literal port number or a service name. If the host is a
-   * literal IPv6 address it must be enclosed in square brackets, as in
-   * `[2001:db8::1]:80` or `[fe80::1%zone]:80`. The zone specifies the scope of
-   * the literal IPv6 address as defined in RFC 4007. The functions JoinHostPort
-   * and SplitHostPort manipulate a pair of host and port in this form. When using
-   * TCP, and the host resolves to multiple IP addresses, Dial will try each IP
-   * address in order until one succeeds.
-   *
-   * Examples:
-   *
-   *     dial("tcp", "golang.org:http")
-   *     dial("tcp", "192.0.2.1:http")
-   *     dial("tcp", "198.51.100.1:80")
-   *     dial("udp", "[2001:db8::1]:domain")
-   *     dial("udp", "[fe80::1%lo0]:53")
-   *     dial("tcp", ":80")
-   */
-  export function dial(network: Network, address: string): Promise<Conn>;
-  /** **RESERVED** */
-  export function connect(_network: Network, _address: string): Promise<Conn>;
-
-  // @url js/metrics.d.ts
-
-  export interface Metrics {
-    opsDispatched: number;
-    opsCompleted: number;
-    bytesSentControl: number;
-    bytesSentData: number;
-    bytesReceived: number;
-  }
-  /** Receive metrics from the privileged side of Deno.
-   *
-   *      > console.table(Deno.metrics())
-   *      ┌──────────────────┬────────┐
-   *      │     (index)      │ Values │
-   *      ├──────────────────┼────────┤
-   *      │  opsDispatched   │   9    │
-   *      │   opsCompleted   │   9    │
-   *      │ bytesSentControl │  504   │
-   *      │  bytesSentData   │   0    │
-   *      │  bytesReceived   │  856   │
-   *      └──────────────────┴────────┘
-   */
-  export function metrics(): Metrics;
-
-  // @url js/resources.d.ts
-
-  interface ResourceMap {
-    [rid: number]: string;
-  }
-  /** Returns a map of open _file like_ resource ids along with their string
-   * representation.
-   */
-  export function resources(): ResourceMap;
-
-  // @url js/process.d.ts
-
-  /** How to handle subprocess stdio.
-   *
-   * "inherit" The default if unspecified. The child inherits from the
-   * corresponding parent descriptor.
-   *
-   * "piped"  A new pipe should be arranged to connect the parent and child
-   * subprocesses.
-   *
-   * "null" This stream will be ignored. This is the equivalent of attaching the
-   * stream to /dev/null.
-   */
-  type ProcessStdio = "inherit" | "piped" | "null";
-  export interface RunOptions {
-    args: string[];
-    cwd?: string;
-    env?: {
-      [key: string]: string;
+    export function isTTY(): {
+      stdin: boolean;
+      stdout: boolean;
+      stderr: boolean;
     };
-    stdout?: ProcessStdio | number;
-    stderr?: ProcessStdio | number;
-    stdin?: ProcessStdio | number;
-  }
-  /** Send a signal to process under given PID. Unix only at this moment.
-   * If pid is negative, the signal will be sent to the process group identified
-   * by -pid.
-   * Requires the `--allow-run` flag.
-   */
-  export function kill(pid: number, signo: number): void;
-  export class Process {
-    readonly rid: number;
-    readonly pid: number;
-    readonly stdin?: WriteCloser;
-    readonly stdout?: ReadCloser;
-    readonly stderr?: ReadCloser;
-    status(): Promise<ProcessStatus>;
-    /** Buffer the stdout and return it as Uint8Array after EOF.
-     * You must set stdout to "piped" when creating the process.
-     * This calls close() on stdout after its done.
+    /** Exit the Deno process with optional exit code. */
+    export function exit(code?: number): never;
+    /** Returns a snapshot of the environment variables at invocation. Mutating a
+     * property in the object will set that variable in the environment for
+     * the process. The environment object will only accept `string`s
+     * as values.
+     *
+     *       const myEnv = Deno.env();
+     *       console.log(myEnv.SHELL);
+     *       myEnv.TEST_VAR = "HELLO";
+     *       const newEnv = Deno.env();
+     *       console.log(myEnv.TEST_VAR == newEnv.TEST_VAR);
      */
-    output(): Promise<Uint8Array>;
-    /** Buffer the stderr and return it as Uint8Array after EOF.
-     * You must set stderr to "piped" when creating the process.
-     * This calls close() on stderr after its done.
+    export function env(): {
+      [index: string]: string;
+    };
+    /**
+     * Returns the current user's home directory.
+     * Requires the `--allow-env` flag.
      */
-    stderrOutput(): Promise<Uint8Array>;
-    close(): void;
-    kill(signo: number): void;
+    export function homeDir(): string;
+    /**
+     * Returns the path to the current deno executable.
+     * Requires the `--allow-env` flag.
+     */
+    export function execPath(): string;
+
+    // @url js/dir.d.ts
+
+    /**
+     * `cwd()` Return a string representing the current working directory.
+     * If the current directory can be reached via multiple paths
+     * (due to symbolic links), `cwd()` may return
+     * any one of them.
+     * throws `NotFound` exception if directory not available
+     */
+    export function cwd(): string;
+    /**
+     * `chdir()` Change the current working directory to path.
+     * throws `NotFound` exception if directory not available
+     */
+    export function chdir(directory: string): void;
+
+    // @url js/io.d.ts
+
+    export const EOF: null;
+    export type EOF = null;
+    export enum SeekMode {
+      SEEK_START = 0,
+      SEEK_CURRENT = 1,
+      SEEK_END = 2
+    }
+    export interface Reader {
+      /** Reads up to p.byteLength bytes into `p`. It resolves to the number
+       * of bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error encountered.
+       * Even if `read()` returns `n` < `p.byteLength`, it may use all of `p` as
+       * scratch space during the call. If some data is available but not
+       * `p.byteLength` bytes, `read()` conventionally returns what is available
+       * instead of waiting for more.
+       *
+       * When `read()` encounters end-of-file condition, it returns EOF symbol.
+       *
+       * When `read()` encounters an error, it rejects with an error.
+       *
+       * Callers should always process the `n` > `0` bytes returned before
+       * considering the EOF. Doing so correctly handles I/O errors that happen
+       * after reading some bytes and also both of the allowed EOF behaviors.
+       *
+       * Implementations must not retain `p`.
+       */
+      read(p: Uint8Array): Promise<number | EOF>;
+    }
+    export interface SyncReader {
+      readSync(p: Uint8Array): number | EOF;
+    }
+    export interface Writer {
+      /** Writes `p.byteLength` bytes from `p` to the underlying data
+       * stream. It resolves to the number of bytes written from `p` (`0` <= `n` <=
+       * `p.byteLength`) and any error encountered that caused the write to stop
+       * early. `write()` must return a non-null error if it returns `n` <
+       * `p.byteLength`. write() must not modify the slice data, even temporarily.
+       *
+       * Implementations must not retain `p`.
+       */
+      write(p: Uint8Array): Promise<number>;
+    }
+    export interface SyncWriter {
+      writeSync(p: Uint8Array): number;
+    }
+    export interface Closer {
+      close(): void;
+    }
+    export interface Seeker {
+      /** Seek sets the offset for the next `read()` or `write()` to offset,
+       * interpreted according to `whence`: `SeekStart` means relative to the start
+       * of the file, `SeekCurrent` means relative to the current offset, and
+       * `SeekEnd` means relative to the end. Seek returns the new offset relative
+       * to the start of the file and an error, if any.
+       *
+       * Seeking to an offset before the start of the file is an error. Seeking to
+       * any positive offset is legal, but the behavior of subsequent I/O operations
+       * on the underlying object is implementation-dependent.
+       */
+      seek(offset: number, whence: SeekMode): Promise<void>;
+    }
+    export interface SyncSeeker {
+      seekSync(offset: number, whence: SeekMode): void;
+    }
+    export interface ReadCloser extends Reader, Closer {}
+    export interface WriteCloser extends Writer, Closer {}
+    export interface ReadSeeker extends Reader, Seeker {}
+    export interface WriteSeeker extends Writer, Seeker {}
+    export interface ReadWriteCloser extends Reader, Writer, Closer {}
+    export interface ReadWriteSeeker extends Reader, Writer, Seeker {}
+    /** Copies from `src` to `dst` until either `EOF` is reached on `src`
+     * or an error occurs. It returns the number of bytes copied and the first
+     * error encountered while copying, if any.
+     *
+     * Because `copy()` is defined to read from `src` until `EOF`, it does not
+     * treat an `EOF` from `read()` as an error to be reported.
+     */
+    export function copy(dst: Writer, src: Reader): Promise<number>;
+    /** Turns `r` into async iterator.
+     *
+     *      for await (const chunk of toAsyncIterator(reader)) {
+     *          console.log(chunk)
+     *      }
+     */
+    export function toAsyncIterator(
+      r: Reader
+    ): AsyncIterableIterator<Uint8Array>;
+
+    // @url js/files.d.ts
+
+    /** Open a file and return an instance of the `File` object
+     *  synchronously.
+     *
+     *       const file = Deno.openSync("/foo/bar.txt");
+     */
+    export function openSync(filename: string, mode?: OpenMode): File;
+    /** Open a file and return an instance of the `File` object.
+     *
+     *       (async () => {
+     *         const file = await Deno.open("/foo/bar.txt");
+     *       })();
+     */
+    export function open(filename: string, mode?: OpenMode): Promise<File>;
+    /** Read synchronously from a file ID into an array buffer.
+     *
+     * Return `number | EOF` for the operation.
+     *
+     *      const file = Deno.openSync("/foo/bar.txt");
+     *      const buf = new Uint8Array(100);
+     *      const nread = Deno.readSync(file.rid, buf);
+     *      const text = new TextDecoder().decode(buf);
+     *
+     */
+    export function readSync(rid: number, p: Uint8Array): number | EOF;
+    /** Read from a file ID into an array buffer.
+     *
+     * Resolves with the `number | EOF` for the operation.
+     *
+     *       (async () => {
+     *         const file = await Deno.open("/foo/bar.txt");
+     *         const buf = new Uint8Array(100);
+     *         const nread = await Deno.read(file.rid, buf);
+     *         const text = new TextDecoder().decode(buf);
+     *       })();
+     */
+    export function read(rid: number, p: Uint8Array): Promise<number | EOF>;
+    /** Write synchronously to the file ID the contents of the array buffer.
+     *
+     * Resolves with the number of bytes written.
+     *
+     *       const encoder = new TextEncoder();
+     *       const data = encoder.encode("Hello world\n");
+     *       const file = Deno.openSync("/foo/bar.txt");
+     *       Deno.writeSync(file.rid, data);
+     */
+    export function writeSync(rid: number, p: Uint8Array): number;
+    /** Write to the file ID the contents of the array buffer.
+     *
+     * Resolves with the number of bytes written.
+     *
+     *      (async () => {
+     *        const encoder = new TextEncoder();
+     *        const data = encoder.encode("Hello world\n");
+     *        const file = await Deno.open("/foo/bar.txt");
+     *        await Deno.write(file.rid, data);
+     *      })();
+     *
+     */
+    export function write(rid: number, p: Uint8Array): Promise<number>;
+    /** Seek a file ID synchronously to the given offset under mode given by `whence`.
+     *
+     *       const file = Deno.openSync("/foo/bar.txt");
+     *       Deno.seekSync(file.rid, 0, 0);
+     */
+    export function seekSync(
+      rid: number,
+      offset: number,
+      whence: SeekMode
+    ): void;
+    /** Seek a file ID to the given offset under mode given by `whence`.
+     *
+     *      (async () => {
+     *        const file = await Deno.open("/foo/bar.txt");
+     *        await Deno.seek(file.rid, 0, 0);
+     *      })();
+     */
+    export function seek(
+      rid: number,
+      offset: number,
+      whence: SeekMode
+    ): Promise<void>;
+    /** Close the file ID. */
+    export function close(rid: number): void;
+    /** The Deno abstraction for reading and writing files. */
+    export class File
+      implements
+        Reader,
+        SyncReader,
+        Writer,
+        SyncWriter,
+        Seeker,
+        SyncSeeker,
+        Closer {
+      readonly rid: number;
+      constructor(rid: number);
+      write(p: Uint8Array): Promise<number>;
+      writeSync(p: Uint8Array): number;
+      read(p: Uint8Array): Promise<number | EOF>;
+      readSync(p: Uint8Array): number | EOF;
+      seek(offset: number, whence: SeekMode): Promise<void>;
+      seekSync(offset: number, whence: SeekMode): void;
+      close(): void;
+    }
+    /** An instance of `File` for stdin. */
+    export const stdin: File;
+    /** An instance of `File` for stdout. */
+    export const stdout: File;
+    /** An instance of `File` for stderr. */
+    export const stderr: File;
+    export type OpenMode =
+      | "r"
+      /** Read-write. Start at beginning of file. */
+      | "r+"
+      /** Write-only. Opens and truncates existing file or creates new one for
+       * writing only.
+       */
+      | "w"
+      /** Read-write. Opens and truncates existing file or creates new one for
+       * writing and reading.
+       */
+      | "w+"
+      /** Write-only. Opens existing file or creates new one. Each write appends
+       * content to the end of file.
+       */
+      | "a"
+      /** Read-write. Behaves like "a" and allows to read from file. */
+      | "a+"
+      /** Write-only. Exclusive create - creates new file only if one doesn't exist
+       * already.
+       */
+      | "x"
+      /** Read-write. Behaves like `x` and allows to read from file. */
+      | "x+";
+
+    // @url js/buffer.d.ts
+
+    /** A Buffer is a variable-sized buffer of bytes with read() and write()
+     * methods. Based on https://golang.org/pkg/bytes/#Buffer
+     */
+    export class Buffer implements Reader, SyncReader, Writer, SyncWriter {
+      private buf;
+      private off;
+      constructor(ab?: ArrayBuffer);
+      /** bytes() returns a slice holding the unread portion of the buffer.
+       * The slice is valid for use only until the next buffer modification (that
+       * is, only until the next call to a method like read(), write(), reset(), or
+       * truncate()). The slice aliases the buffer content at least until the next
+       * buffer modification, so immediate changes to the slice will affect the
+       * result of future reads.
+       */
+      bytes(): Uint8Array;
+      /** toString() returns the contents of the unread portion of the buffer
+       * as a string. Warning - if multibyte characters are present when data is
+       * flowing through the buffer, this method may result in incorrect strings
+       * due to a character being split.
+       */
+      toString(): string;
+      /** empty() returns whether the unread portion of the buffer is empty. */
+      empty(): boolean;
+      /** length is a getter that returns the number of bytes of the unread
+       * portion of the buffer
+       */
+      readonly length: number;
+      /** Returns the capacity of the buffer's underlying byte slice, that is,
+       * the total space allocated for the buffer's data.
+       */
+      readonly capacity: number;
+      /** truncate() discards all but the first n unread bytes from the buffer but
+       * continues to use the same allocated storage.  It throws if n is negative or
+       * greater than the length of the buffer.
+       */
+      truncate(n: number): void;
+      /** reset() resets the buffer to be empty, but it retains the underlying
+       * storage for use by future writes. reset() is the same as truncate(0)
+       */
+      reset(): void;
+      /** _tryGrowByReslice() is a version of grow for the fast-case
+       * where the internal buffer only needs to be resliced. It returns the index
+       * where bytes should be written and whether it succeeded.
+       * It returns -1 if a reslice was not needed.
+       */
+      private _tryGrowByReslice;
+      private _reslice;
+      /** readSync() reads the next len(p) bytes from the buffer or until the buffer
+       * is drained. The return value n is the number of bytes read. If the
+       * buffer has no data to return, eof in the response will be true.
+       */
+      readSync(p: Uint8Array): number | EOF;
+      read(p: Uint8Array): Promise<number | EOF>;
+      writeSync(p: Uint8Array): number;
+      write(p: Uint8Array): Promise<number>;
+      /** _grow() grows the buffer to guarantee space for n more bytes.
+       * It returns the index where bytes should be written.
+       * If the buffer can't grow it will throw with ErrTooLarge.
+       */
+      private _grow;
+      /** grow() grows the buffer's capacity, if necessary, to guarantee space for
+       * another n bytes. After grow(n), at least n bytes can be written to the
+       * buffer without another allocation. If n is negative, grow() will panic. If
+       * the buffer can't grow it will throw ErrTooLarge.
+       * Based on https://golang.org/pkg/bytes/#Buffer.Grow
+       */
+      grow(n: number): void;
+      /** readFrom() reads data from r until EOF and appends it to the buffer,
+       * growing the buffer as needed. It returns the number of bytes read. If the
+       * buffer becomes too large, readFrom will panic with ErrTooLarge.
+       * Based on https://golang.org/pkg/bytes/#Buffer.ReadFrom
+       */
+      readFrom(r: Reader): Promise<number>;
+      /** Sync version of `readFrom`
+       */
+      readFromSync(r: SyncReader): number;
+    }
+    /** Read `r` until EOF and return the content as `Uint8Array`.
+     */
+    export function readAll(r: Reader): Promise<Uint8Array>;
+    /** Read synchronously `r` until EOF and return the content as `Uint8Array`.
+     */
+    export function readAllSync(r: SyncReader): Uint8Array;
+    /** Write all the content of `arr` to `w`.
+     */
+    export function writeAll(w: Writer, arr: Uint8Array): Promise<void>;
+    /** Write synchronously all the content of `arr` to `w`.
+     */
+    export function writeAllSync(w: SyncWriter, arr: Uint8Array): void;
+
+    // @url js/mkdir.d.ts
+
+    /** Creates a new directory with the specified path synchronously.
+     * If `recursive` is set to true, nested directories will be created (also known
+     * as "mkdir -p").
+     * `mode` sets permission bits (before umask) on UNIX and does nothing on
+     * Windows.
+     *
+     *       Deno.mkdirSync("new_dir");
+     *       Deno.mkdirSync("nested/directories", true);
+     */
+    export function mkdirSync(
+      path: string,
+      recursive?: boolean,
+      mode?: number
+    ): void;
+    /** Creates a new directory with the specified path.
+     * If `recursive` is set to true, nested directories will be created (also known
+     * as "mkdir -p").
+     * `mode` sets permission bits (before umask) on UNIX and does nothing on
+     * Windows.
+     *
+     *       await Deno.mkdir("new_dir");
+     *       await Deno.mkdir("nested/directories", true);
+     */
+    export function mkdir(
+      path: string,
+      recursive?: boolean,
+      mode?: number
+    ): Promise<void>;
+
+    // @url js/make_temp_dir.d.ts
+
+    export interface MakeTempDirOptions {
+      dir?: string;
+      prefix?: string;
+      suffix?: string;
+    }
+    /** makeTempDirSync is the synchronous version of `makeTempDir`.
+     *
+     *       const tempDirName0 = Deno.makeTempDirSync();
+     *       const tempDirName1 = Deno.makeTempDirSync({ prefix: 'my_temp' });
+     */
+    export function makeTempDirSync(options?: MakeTempDirOptions): string;
+    /** makeTempDir creates a new temporary directory in the directory `dir`, its
+     * name beginning with `prefix` and ending with `suffix`.
+     * It returns the full path to the newly created directory.
+     * If `dir` is unspecified, tempDir uses the default directory for temporary
+     * files. Multiple programs calling tempDir simultaneously will not choose the
+     * same directory. It is the caller's responsibility to remove the directory
+     * when no longer needed.
+     *
+     *       const tempDirName0 = await Deno.makeTempDir();
+     *       const tempDirName1 = await Deno.makeTempDir({ prefix: 'my_temp' });
+     */
+    export function makeTempDir(options?: MakeTempDirOptions): Promise<string>;
+
+    // @url js/chmod.d.ts
+
+    /** Changes the permission of a specific file/directory of specified path
+     * synchronously.
+     *
+     *       Deno.chmodSync("/path/to/file", 0o666);
+     */
+    export function chmodSync(path: string, mode: number): void;
+    /** Changes the permission of a specific file/directory of specified path.
+     *
+     *       await Deno.chmod("/path/to/file", 0o666);
+     */
+    export function chmod(path: string, mode: number): Promise<void>;
+
+    // @url js/chown.d.ts
+
+    /**
+     * Change owner of a regular file or directory synchronously. Unix only at the moment.
+     * @param path path to the file
+     * @param uid user id of the new owner
+     * @param gid group id of the new owner
+     */
+    export function chownSync(path: string, uid: number, gid: number): void;
+    /**
+     * Change owner of a regular file or directory asynchronously. Unix only at the moment.
+     * @param path path to the file
+     * @param uid user id of the new owner
+     * @param gid group id of the new owner
+     */
+    export function chown(
+      path: string,
+      uid: number,
+      gid: number
+    ): Promise<void>;
+
+    // @url js/utime.d.ts
+
+    /** Synchronously changes the access and modification times of a file system
+     * object referenced by `filename`. Given times are either in seconds
+     * (Unix epoch time) or as `Date` objects.
+     *
+     *       Deno.utimeSync("myfile.txt", 1556495550, new Date());
+     */
+    export function utimeSync(
+      filename: string,
+      atime: number | Date,
+      mtime: number | Date
+    ): void;
+    /** Changes the access and modification times of a file system object
+     * referenced by `filename`. Given times are either in seconds
+     * (Unix epoch time) or as `Date` objects.
+     *
+     *       await Deno.utime("myfile.txt", 1556495550, new Date());
+     */
+    export function utime(
+      filename: string,
+      atime: number | Date,
+      mtime: number | Date
+    ): Promise<void>;
+
+    // @url js/remove.d.ts
+
+    export interface RemoveOption {
+      recursive?: boolean;
+    }
+    /** Removes the named file or directory synchronously. Would throw
+     * error if permission denied, not found, or directory not empty if `recursive`
+     * set to false.
+     * `recursive` is set to false by default.
+     *
+     *       Deno.removeSync("/path/to/dir/or/file", {recursive: false});
+     */
+    export function removeSync(path: string, options?: RemoveOption): void;
+    /** Removes the named file or directory. Would throw error if
+     * permission denied, not found, or directory not empty if `recursive` set
+     * to false.
+     * `recursive` is set to false by default.
+     *
+     *       await Deno.remove("/path/to/dir/or/file", {recursive: false});
+     */
+    export function remove(path: string, options?: RemoveOption): Promise<void>;
+
+    // @url js/rename.d.ts
+
+    /** Synchronously renames (moves) `oldpath` to `newpath`. If `newpath` already
+     * exists and is not a directory, `renameSync()` replaces it. OS-specific
+     * restrictions may apply when `oldpath` and `newpath` are in different
+     * directories.
+     *
+     *       Deno.renameSync("old/path", "new/path");
+     */
+    export function renameSync(oldpath: string, newpath: string): void;
+    /** Renames (moves) `oldpath` to `newpath`. If `newpath` already exists and is
+     * not a directory, `rename()` replaces it. OS-specific restrictions may apply
+     * when `oldpath` and `newpath` are in different directories.
+     *
+     *       await Deno.rename("old/path", "new/path");
+     */
+    export function rename(oldpath: string, newpath: string): Promise<void>;
+
+    // @url js/read_file.d.ts
+
+    /** Read the entire contents of a file synchronously.
+     *
+     *       const decoder = new TextDecoder("utf-8");
+     *       const data = Deno.readFileSync("hello.txt");
+     *       console.log(decoder.decode(data));
+     */
+    export function readFileSync(filename: string): Uint8Array;
+    /** Read the entire contents of a file.
+     *
+     *       const decoder = new TextDecoder("utf-8");
+     *       const data = await Deno.readFile("hello.txt");
+     *       console.log(decoder.decode(data));
+     */
+    export function readFile(filename: string): Promise<Uint8Array>;
+
+    // @url js/file_info.d.ts
+
+    /** A FileInfo describes a file and is returned by `stat`, `lstat`,
+     * `statSync`, `lstatSync`.
+     */
+    export interface FileInfo {
+      /** The size of the file, in bytes. */
+      len: number;
+      /** The last modification time of the file. This corresponds to the `mtime`
+       * field from `stat` on Unix and `ftLastWriteTime` on Windows. This may not
+       * be available on all platforms.
+       */
+      modified: number | null;
+      /** The last access time of the file. This corresponds to the `atime`
+       * field from `stat` on Unix and `ftLastAccessTime` on Windows. This may not
+       * be available on all platforms.
+       */
+      accessed: number | null;
+      /** The last access time of the file. This corresponds to the `birthtime`
+       * field from `stat` on Unix and `ftCreationTime` on Windows. This may not
+       * be available on all platforms.
+       */
+      created: number | null;
+      /** The underlying raw st_mode bits that contain the standard Unix permissions
+       * for this file/directory. TODO Match behavior with Go on windows for mode.
+       */
+      mode: number | null;
+      /** The file or directory name. */
+      name: string | null;
+      /** Returns whether this is info for a regular file. This result is mutually
+       * exclusive to `FileInfo.isDirectory` and `FileInfo.isSymlink`.
+       */
+      isFile(): boolean;
+      /** Returns whether this is info for a regular directory. This result is
+       * mutually exclusive to `FileInfo.isFile` and `FileInfo.isSymlink`.
+       */
+      isDirectory(): boolean;
+      /** Returns whether this is info for a symlink. This result is
+       * mutually exclusive to `FileInfo.isFile` and `FileInfo.isDirectory`.
+       */
+      isSymlink(): boolean;
+    }
+
+    // @url js/read_dir.d.ts
+
+    /** Reads the directory given by path and returns a list of file info
+     * synchronously.
+     *
+     *       const files = Deno.readDirSync("/");
+     */
+    export function readDirSync(path: string): FileInfo[];
+    /** Reads the directory given by path and returns a list of file info.
+     *
+     *       const files = await Deno.readDir("/");
+     */
+    export function readDir(path: string): Promise<FileInfo[]>;
+
+    // @url js/copy_file.d.ts
+
+    /** Copies the contents of a file to another by name synchronously.
+     * Creates a new file if target does not exists, and if target exists,
+     * overwrites original content of the target file.
+     *
+     * It would also copy the permission of the original file
+     * to the destination.
+     *
+     *       Deno.copyFileSync("from.txt", "to.txt");
+     */
+    export function copyFileSync(from: string, to: string): void;
+    /** Copies the contents of a file to another by name.
+     *
+     * Creates a new file if target does not exists, and if target exists,
+     * overwrites original content of the target file.
+     *
+     * It would also copy the permission of the original file
+     * to the destination.
+     *
+     *       await Deno.copyFile("from.txt", "to.txt");
+     */
+    export function copyFile(from: string, to: string): Promise<void>;
+
+    // @url js/read_link.d.ts
+
+    /** Returns the destination of the named symbolic link synchronously.
+     *
+     *       const targetPath = Deno.readlinkSync("symlink/path");
+     */
+    export function readlinkSync(name: string): string;
+    /** Returns the destination of the named symbolic link.
+     *
+     *       const targetPath = await Deno.readlink("symlink/path");
+     */
+    export function readlink(name: string): Promise<string>;
+
+    // @url js/stat.d.ts
+
+    interface StatResponse {
+      isFile: boolean;
+      isSymlink: boolean;
+      len: number;
+      modified: number;
+      accessed: number;
+      created: number;
+      mode: number;
+      hasMode: boolean;
+      name: string | null;
+    }
+    /** Queries the file system for information on the path provided. If the given
+     * path is a symlink information about the symlink will be returned.
+     *
+     *       const fileInfo = await Deno.lstat("hello.txt");
+     *       assert(fileInfo.isFile());
+     */
+    export function lstat(filename: string): Promise<FileInfo>;
+    /** Queries the file system for information on the path provided synchronously.
+     * If the given path is a symlink information about the symlink will be
+     * returned.
+     *
+     *       const fileInfo = Deno.lstatSync("hello.txt");
+     *       assert(fileInfo.isFile());
+     */
+    export function lstatSync(filename: string): FileInfo;
+    /** Queries the file system for information on the path provided. `stat` Will
+     * always follow symlinks.
+     *
+     *       const fileInfo = await Deno.stat("hello.txt");
+     *       assert(fileInfo.isFile());
+     */
+    export function stat(filename: string): Promise<FileInfo>;
+    /** Queries the file system for information on the path provided synchronously.
+     * `statSync` Will always follow symlinks.
+     *
+     *       const fileInfo = Deno.statSync("hello.txt");
+     *       assert(fileInfo.isFile());
+     */
+    export function statSync(filename: string): FileInfo;
+
+    // @url js/link.d.ts
+
+    /** Synchronously creates `newname` as a hard link to `oldname`.
+     *
+     *       Deno.linkSync("old/name", "new/name");
+     */
+    export function linkSync(oldname: string, newname: string): void;
+    /** Creates `newname` as a hard link to `oldname`.
+     *
+     *       await Deno.link("old/name", "new/name");
+     */
+    export function link(oldname: string, newname: string): Promise<void>;
+
+    // @url js/symlink.d.ts
+
+    /** Synchronously creates `newname` as a symbolic link to `oldname`. The type
+     * argument can be set to `dir` or `file` and is only available on Windows
+     * (ignored on other platforms).
+     *
+     *       Deno.symlinkSync("old/name", "new/name");
+     */
+    export function symlinkSync(
+      oldname: string,
+      newname: string,
+      type?: string
+    ): void;
+    /** Creates `newname` as a symbolic link to `oldname`. The type argument can be
+     * set to `dir` or `file` and is only available on Windows (ignored on other
+     * platforms).
+     *
+     *       await Deno.symlink("old/name", "new/name");
+     */
+    export function symlink(
+      oldname: string,
+      newname: string,
+      type?: string
+    ): Promise<void>;
+
+    // @url js/write_file.d.ts
+
+    /** Options for writing to a file.
+     * `perm` would change the file's permission if set.
+     * `create` decides if the file should be created if not exists (default: true)
+     * `append` decides if the file should be appended (default: false)
+     */
+    export interface WriteFileOptions {
+      perm?: number;
+      create?: boolean;
+      append?: boolean;
+    }
+    /** Write a new file, with given filename and data synchronously.
+     *
+     *       const encoder = new TextEncoder();
+     *       const data = encoder.encode("Hello world\n");
+     *       Deno.writeFileSync("hello.txt", data);
+     */
+    export function writeFileSync(
+      filename: string,
+      data: Uint8Array,
+      options?: WriteFileOptions
+    ): void;
+    /** Write a new file, with given filename and data.
+     *
+     *       const encoder = new TextEncoder();
+     *       const data = encoder.encode("Hello world\n");
+     *       await Deno.writeFile("hello.txt", data);
+     */
+    export function writeFile(
+      filename: string,
+      data: Uint8Array,
+      options?: WriteFileOptions
+    ): Promise<void>;
+
+    // @url js/error_stack.d.ts
+
+    interface Location {
+      /** The full url for the module, e.g. `file://some/file.ts` or
+       * `https://some/file.ts`. */
+      filename: string;
+      /** The line number in the file.  It is assumed to be 1-indexed. */
+      line: number;
+      /** The column number in the file.  It is assumed to be 1-indexed. */
+      column: number;
+    }
+    /** Given a current location in a module, lookup the source location and
+     * return it.
+     *
+     * When Deno transpiles code, it keep source maps of the transpiled code.  This
+     * function can be used to lookup the original location.  This is automatically
+     * done when accessing the `.stack` of an error, or when an uncaught error is
+     * logged.  This function can be used to perform the lookup for creating better
+     * error handling.
+     *
+     * **Note:** `line` and `column` are 1 indexed, which matches display
+     * expectations, but is not typical of most index numbers in Deno.
+     *
+     * An example:
+     *
+     *       const orig = Deno.applySourceMap({
+     *         location: "file://my/module.ts",
+     *         line: 5,
+     *         column: 15
+     *       });
+     *       console.log(`${orig.filename}:${orig.line}:${orig.column}`);
+     *
+     */
+    export function applySourceMap(location: Location): Location;
+
+    // @url js/errors.d.ts
+
+    /** A Deno specific error.  The `kind` property is set to a specific error code
+     * which can be used to in application logic.
+     *
+     *       try {
+     *         somethingThatMightThrow();
+     *       } catch (e) {
+     *         if (
+     *           e instanceof Deno.DenoError &&
+     *           e.kind === Deno.ErrorKind.Overflow
+     *         ) {
+     *           console.error("Overflow error!");
+     *         }
+     *       }
+     *
+     */
+    export class DenoError<T extends ErrorKind> extends Error {
+      readonly kind: T;
+      constructor(kind: T, msg: string);
+    }
+    export enum ErrorKind {
+      NoError = 0,
+      NotFound = 1,
+      PermissionDenied = 2,
+      ConnectionRefused = 3,
+      ConnectionReset = 4,
+      ConnectionAborted = 5,
+      NotConnected = 6,
+      AddrInUse = 7,
+      AddrNotAvailable = 8,
+      BrokenPipe = 9,
+      AlreadyExists = 10,
+      WouldBlock = 11,
+      InvalidInput = 12,
+      InvalidData = 13,
+      TimedOut = 14,
+      Interrupted = 15,
+      WriteZero = 16,
+      Other = 17,
+      UnexpectedEof = 18,
+      BadResource = 19,
+      CommandFailed = 20,
+      EmptyHost = 21,
+      IdnaError = 22,
+      InvalidPort = 23,
+      InvalidIpv4Address = 24,
+      InvalidIpv6Address = 25,
+      InvalidDomainCharacter = 26,
+      RelativeUrlWithoutBase = 27,
+      RelativeUrlWithCannotBeABaseBase = 28,
+      SetHostOnCannotBeABaseUrl = 29,
+      Overflow = 30,
+      HttpUser = 31,
+      HttpClosed = 32,
+      HttpCanceled = 33,
+      HttpParse = 34,
+      HttpOther = 35,
+      TooLarge = 36,
+      InvalidUri = 37,
+      InvalidSeekMode = 38,
+      OpNotAvailable = 39,
+      WorkerInitFailed = 40,
+      UnixError = 41,
+      NoAsyncSupport = 42,
+      NoSyncSupport = 43,
+      ImportMapError = 44,
+      InvalidPath = 45,
+      ImportPrefixMissing = 46,
+      UnsupportedFetchScheme = 47,
+      TooManyRedirects = 48,
+      Diagnostic = 49,
+      JSError = 50
+    }
+
+    // @url js/permissions.d.ts
+
+    /** Permissions as granted by the caller */
+    export interface Permissions {
+      read: boolean;
+      write: boolean;
+      net: boolean;
+      env: boolean;
+      run: boolean;
+      hrtime: boolean;
+    }
+    export type Permission = keyof Permissions;
+    /** Inspect granted permissions for the current program.
+     *
+     *       if (Deno.permissions().read) {
+     *         const file = await Deno.readFile("example.test");
+     *         // ...
+     *       }
+     */
+    export function permissions(): Permissions;
+    /** Revoke a permission. When the permission was already revoked nothing changes
+     *
+     *       if (Deno.permissions().read) {
+     *         const file = await Deno.readFile("example.test");
+     *         Deno.revokePermission('read');
+     *       }
+     *       Deno.readFile("example.test"); // -> error or permission prompt
+     */
+    export function revokePermission(permission: Permission): void;
+
+    // @url js/truncate.d.ts
+
+    /** Truncates or extends the specified file synchronously, updating the size of
+     * this file to become size.
+     *
+     *       Deno.truncateSync("hello.txt", 10);
+     */
+    export function truncateSync(name: string, len?: number): void;
+    /**
+     * Truncates or extends the specified file, updating the size of this file to
+     * become size.
+     *
+     *       await Deno.truncate("hello.txt", 10);
+     */
+    export function truncate(name: string, len?: number): Promise<void>;
+
+    // @url js/net.d.ts
+
+    type Network = "tcp";
+    interface Addr {
+      network: Network;
+      address: string;
+    }
+    /** A Listener is a generic network listener for stream-oriented protocols. */
+    export interface Listener extends AsyncIterator<Conn> {
+      /** Waits for and resolves to the next connection to the `Listener`. */
+      accept(): Promise<Conn>;
+      /** Close closes the listener. Any pending accept promises will be rejected
+       * with errors.
+       */
+      close(): void;
+      /** Return the address of the `Listener`. */
+      addr(): Addr;
+      [Symbol.asyncIterator](): AsyncIterator<Conn>;
+    }
+    export interface Conn extends Reader, Writer, Closer {
+      /** The local address of the connection. */
+      localAddr: string;
+      /** The remote address of the connection. */
+      remoteAddr: string;
+      /** The resource ID of the connection. */
+      rid: number;
+      /** Shuts down (`shutdown(2)`) the reading side of the TCP connection. Most
+       * callers should just use `close()`.
+       */
+      closeRead(): void;
+      /** Shuts down (`shutdown(2)`) the writing side of the TCP connection. Most
+       * callers should just use `close()`.
+       */
+      closeWrite(): void;
+    }
+    /** Listen announces on the local network address.
+     *
+     * The network must be `tcp`, `tcp4`, `tcp6`, `unix` or `unixpacket`.
+     *
+     * For TCP networks, if the host in the address parameter is empty or a literal
+     * unspecified IP address, `listen()` listens on all available unicast and
+     * anycast IP addresses of the local system. To only use IPv4, use network
+     * `tcp4`. The address can use a host name, but this is not recommended,
+     * because it will create a listener for at most one of the host's IP
+     * addresses. If the port in the address parameter is empty or `0`, as in
+     * `127.0.0.1:` or `[::1]:0`, a port number is automatically chosen. The
+     * `addr()` method of `Listener` can be used to discover the chosen port.
+     *
+     * See `dial()` for a description of the network and address parameters.
+     */
+    export function listen(network: Network, address: string): Listener;
+    /** Dial connects to the address on the named network.
+     *
+     * Supported networks are only `tcp` currently.
+     *
+     * TODO: `tcp4` (IPv4-only), `tcp6` (IPv6-only), `udp`, `udp4` (IPv4-only),
+     * `udp6` (IPv6-only), `ip`, `ip4` (IPv4-only), `ip6` (IPv6-only), `unix`,
+     * `unixgram` and `unixpacket`.
+     *
+     * For TCP and UDP networks, the address has the form `host:port`. The host must
+     * be a literal IP address, or a host name that can be resolved to IP addresses.
+     * The port must be a literal port number or a service name. If the host is a
+     * literal IPv6 address it must be enclosed in square brackets, as in
+     * `[2001:db8::1]:80` or `[fe80::1%zone]:80`. The zone specifies the scope of
+     * the literal IPv6 address as defined in RFC 4007. The functions JoinHostPort
+     * and SplitHostPort manipulate a pair of host and port in this form. When using
+     * TCP, and the host resolves to multiple IP addresses, Dial will try each IP
+     * address in order until one succeeds.
+     *
+     * Examples:
+     *
+     *     dial("tcp", "golang.org:http")
+     *     dial("tcp", "192.0.2.1:http")
+     *     dial("tcp", "198.51.100.1:80")
+     *     dial("udp", "[2001:db8::1]:domain")
+     *     dial("udp", "[fe80::1%lo0]:53")
+     *     dial("tcp", ":80")
+     */
+    export function dial(network: Network, address: string): Promise<Conn>;
+    /** **RESERVED** */
+    export function connect(_network: Network, _address: string): Promise<Conn>;
+
+    // @url js/metrics.d.ts
+
+    export interface Metrics {
+      opsDispatched: number;
+      opsCompleted: number;
+      bytesSentControl: number;
+      bytesSentData: number;
+      bytesReceived: number;
+    }
+    /** Receive metrics from the privileged side of Deno.
+     *
+     *      > console.table(Deno.metrics())
+     *      ┌──────────────────┬────────┐
+     *      │     (index)      │ Values │
+     *      ├──────────────────┼────────┤
+     *      │  opsDispatched   │   9    │
+     *      │   opsCompleted   │   9    │
+     *      │ bytesSentControl │  504   │
+     *      │  bytesSentData   │   0    │
+     *      │  bytesReceived   │  856   │
+     *      └──────────────────┴────────┘
+     */
+    export function metrics(): Metrics;
+
+    // @url js/resources.d.ts
+
+    interface ResourceMap {
+      [rid: number]: string;
+    }
+    /** Returns a map of open _file like_ resource ids along with their string
+     * representation.
+     */
+    export function resources(): ResourceMap;
+
+    // @url js/process.d.ts
+
+    /** How to handle subprocess stdio.
+     *
+     * "inherit" The default if unspecified. The child inherits from the
+     * corresponding parent descriptor.
+     *
+     * "piped"  A new pipe should be arranged to connect the parent and child
+     * subprocesses.
+     *
+     * "null" This stream will be ignored. This is the equivalent of attaching the
+     * stream to /dev/null.
+     */
+    type ProcessStdio = "inherit" | "piped" | "null";
+    export interface RunOptions {
+      args: string[];
+      cwd?: string;
+      env?: {
+        [key: string]: string;
+      };
+      stdout?: ProcessStdio | number;
+      stderr?: ProcessStdio | number;
+      stdin?: ProcessStdio | number;
+    }
+    /** Send a signal to process under given PID. Unix only at this moment.
+     * If pid is negative, the signal will be sent to the process group identified
+     * by -pid.
+     * Requires the `--allow-run` flag.
+     */
+    export function kill(pid: number, signo: number): void;
+    export class Process {
+      readonly rid: number;
+      readonly pid: number;
+      readonly stdin?: WriteCloser;
+      readonly stdout?: ReadCloser;
+      readonly stderr?: ReadCloser;
+      status(): Promise<ProcessStatus>;
+      /** Buffer the stdout and return it as Uint8Array after EOF.
+       * You must set stdout to "piped" when creating the process.
+       * This calls close() on stdout after its done.
+       */
+      output(): Promise<Uint8Array>;
+      /** Buffer the stderr and return it as Uint8Array after EOF.
+       * You must set stderr to "piped" when creating the process.
+       * This calls close() on stderr after its done.
+       */
+      stderrOutput(): Promise<Uint8Array>;
+      close(): void;
+      kill(signo: number): void;
+    }
+    export interface ProcessStatus {
+      success: boolean;
+      code?: number;
+      signal?: number;
+    }
+    /**
+     * Spawns new subprocess.
+     *
+     * Subprocess uses same working directory as parent process unless `opt.cwd`
+     * is specified.
+     *
+     * Environmental variables for subprocess can be specified using `opt.env`
+     * mapping.
+     *
+     * By default subprocess inherits stdio of parent process. To change that
+     * `opt.stdout`, `opt.stderr` and `opt.stdin` can be specified independently -
+     * they can be set to either `ProcessStdio` or `rid` of open file.
+     */
+    export function run(opt: RunOptions): Process;
+    enum LinuxSignal {
+      SIGHUP = 1,
+      SIGINT = 2,
+      SIGQUIT = 3,
+      SIGILL = 4,
+      SIGTRAP = 5,
+      SIGABRT = 6,
+      SIGBUS = 7,
+      SIGFPE = 8,
+      SIGKILL = 9,
+      SIGUSR1 = 10,
+      SIGSEGV = 11,
+      SIGUSR2 = 12,
+      SIGPIPE = 13,
+      SIGALRM = 14,
+      SIGTERM = 15,
+      SIGSTKFLT = 16,
+      SIGCHLD = 17,
+      SIGCONT = 18,
+      SIGSTOP = 19,
+      SIGTSTP = 20,
+      SIGTTIN = 21,
+      SIGTTOU = 22,
+      SIGURG = 23,
+      SIGXCPU = 24,
+      SIGXFSZ = 25,
+      SIGVTALRM = 26,
+      SIGPROF = 27,
+      SIGWINCH = 28,
+      SIGIO = 29,
+      SIGPWR = 30,
+      SIGSYS = 31
+    }
+    enum MacOSSignal {
+      SIGHUP = 1,
+      SIGINT = 2,
+      SIGQUIT = 3,
+      SIGILL = 4,
+      SIGTRAP = 5,
+      SIGABRT = 6,
+      SIGEMT = 7,
+      SIGFPE = 8,
+      SIGKILL = 9,
+      SIGBUS = 10,
+      SIGSEGV = 11,
+      SIGSYS = 12,
+      SIGPIPE = 13,
+      SIGALRM = 14,
+      SIGTERM = 15,
+      SIGURG = 16,
+      SIGSTOP = 17,
+      SIGTSTP = 18,
+      SIGCONT = 19,
+      SIGCHLD = 20,
+      SIGTTIN = 21,
+      SIGTTOU = 22,
+      SIGIO = 23,
+      SIGXCPU = 24,
+      SIGXFSZ = 25,
+      SIGVTALRM = 26,
+      SIGPROF = 27,
+      SIGWINCH = 28,
+      SIGINFO = 29,
+      SIGUSR1 = 30,
+      SIGUSR2 = 31
+    }
+    /** Signals numbers. This is platform dependent.
+     */
+    export const Signal: typeof MacOSSignal | typeof LinuxSignal;
+    export {};
+
+    // @url js/console.d.ts
+
+    type ConsoleOptions = Partial<{
+      showHidden: boolean;
+      depth: number;
+      colors: boolean;
+      indentLevel: number;
+    }>;
+    /** A symbol which can be used as a key for a custom method which will be called
+     * when `Deno.inspect()` is called, or when the object is logged to the console.
+     */
+    export const customInspect: unique symbol;
+    /**
+     * `inspect()` converts input into string that has the same format
+     * as printed by `console.log(...)`;
+     */
+    export function inspect(value: unknown, options?: ConsoleOptions): string;
+
+    // @url js/build.d.ts
+
+    export type OperatingSystem = "mac" | "win" | "linux";
+    export type Arch = "x64" | "arm64";
+    /** Build related information */
+    interface BuildInfo {
+      /** The CPU architecture. */
+      arch: Arch;
+      /** The operating system. */
+      os: OperatingSystem;
+    }
+    export const build: BuildInfo;
+    export const platform: BuildInfo;
+
+    // @url js/version.d.ts
+
+    interface Version {
+      deno: string;
+      v8: string;
+      typescript: string;
+    }
+    export const version: Version;
+    export {};
+
+    // @url js/deno.d.ts
+
+    export const args: string[];
   }
-  export interface ProcessStatus {
-    success: boolean;
-    code?: number;
-    signal?: number;
+
+  // @url js/globals.ts
+
+  export interface Window {
+    window: Window;
+    atob: typeof textEncoding.atob;
+    btoa: typeof textEncoding.btoa;
+    fetch: typeof fetchTypes.fetch;
+    clearTimeout: typeof timers.clearTimeout;
+    clearInterval: typeof timers.clearInterval;
+    console: consoleTypes.Console;
+    setTimeout: typeof timers.setTimeout;
+    setInterval: typeof timers.setInterval;
+    location: domTypes.Location;
+    onload: Function | undefined;
+    crypto: Crypto;
+    Blob: typeof blob.DenoBlob;
+    File: domTypes.DomFileConstructor;
+    CustomEventInit: typeof customEvent.CustomEventInit;
+    CustomEvent: typeof customEvent.CustomEvent;
+    EventInit: typeof event.EventInit;
+    Event: typeof event.Event;
+    EventListener: typeof eventTarget.EventListener;
+    EventTarget: typeof eventTarget.EventTarget;
+    URL: typeof url.URL;
+    URLSearchParams: typeof urlSearchParams.URLSearchParams;
+    Headers: domTypes.HeadersConstructor;
+    FormData: domTypes.FormDataConstructor;
+    TextEncoder: typeof textEncoding.TextEncoder;
+    TextDecoder: typeof textEncoding.TextDecoder;
+    Request: domTypes.RequestConstructor;
+    Response: typeof fetchTypes.Response;
+    performance: performanceUtil.Performance;
+    onmessage: (e: { data: any }) => void;
+    workerMain: typeof workers.workerMain;
+    workerClose: typeof workers.workerClose;
+    postMessage: typeof workers.postMessage;
+    Worker: typeof workers.WorkerImpl;
+    addEventListener: (
+      type: string,
+      callback: (event: domTypes.Event) => void | null,
+      options?: boolean | domTypes.AddEventListenerOptions | undefined
+    ) => void;
+    dispatchEvent: (event: domTypes.Event) => boolean;
+    removeEventListener: (
+      type: string,
+      callback: (event: domTypes.Event) => void | null,
+      options?: boolean | domTypes.EventListenerOptions | undefined
+    ) => void;
+    queueMicrotask: (task: () => void) => void;
+    Deno: typeof Deno;
   }
-  /**
-   * Spawns new subprocess.
-   *
-   * Subprocess uses same working directory as parent process unless `opt.cwd`
-   * is specified.
-   *
-   * Environmental variables for subprocess can be specified using `opt.env`
-   * mapping.
-   *
-   * By default subprocess inherits stdio of parent process. To change that
-   * `opt.stdout`, `opt.stderr` and `opt.stdin` can be specified independently -
-   * they can be set to either `ProcessStdio` or `rid` of open file.
-   */
-  export function run(opt: RunOptions): Process;
-  enum LinuxSignal {
-    SIGHUP = 1,
-    SIGINT = 2,
-    SIGQUIT = 3,
-    SIGILL = 4,
-    SIGTRAP = 5,
-    SIGABRT = 6,
-    SIGBUS = 7,
-    SIGFPE = 8,
-    SIGKILL = 9,
-    SIGUSR1 = 10,
-    SIGSEGV = 11,
-    SIGUSR2 = 12,
-    SIGPIPE = 13,
-    SIGALRM = 14,
-    SIGTERM = 15,
-    SIGSTKFLT = 16,
-    SIGCHLD = 17,
-    SIGCONT = 18,
-    SIGSTOP = 19,
-    SIGTSTP = 20,
-    SIGTTIN = 21,
-    SIGTTOU = 22,
-    SIGURG = 23,
-    SIGXCPU = 24,
-    SIGXFSZ = 25,
-    SIGVTALRM = 26,
-    SIGPROF = 27,
-    SIGWINCH = 28,
-    SIGIO = 29,
-    SIGPWR = 30,
-    SIGSYS = 31
-  }
-  enum MacOSSignal {
-    SIGHUP = 1,
-    SIGINT = 2,
-    SIGQUIT = 3,
-    SIGILL = 4,
-    SIGTRAP = 5,
-    SIGABRT = 6,
-    SIGEMT = 7,
-    SIGFPE = 8,
-    SIGKILL = 9,
-    SIGBUS = 10,
-    SIGSEGV = 11,
-    SIGSYS = 12,
-    SIGPIPE = 13,
-    SIGALRM = 14,
-    SIGTERM = 15,
-    SIGURG = 16,
-    SIGSTOP = 17,
-    SIGTSTP = 18,
-    SIGCONT = 19,
-    SIGCHLD = 20,
-    SIGTTIN = 21,
-    SIGTTOU = 22,
-    SIGIO = 23,
-    SIGXCPU = 24,
-    SIGXFSZ = 25,
-    SIGVTALRM = 26,
-    SIGPROF = 27,
-    SIGWINCH = 28,
-    SIGINFO = 29,
-    SIGUSR1 = 30,
-    SIGUSR2 = 31
-  }
-  /** Signals numbers. This is platform dependent.
-   */
-  export const Signal: typeof MacOSSignal | typeof LinuxSignal;
-  export {};
 
-  // @url js/console.d.ts
-
-  type ConsoleOptions = Partial<{
-    showHidden: boolean;
-    depth: number;
-    colors: boolean;
-    indentLevel: number;
-  }>;
-  /** A symbol which can be used as a key for a custom method which will be called
-   * when `Deno.inspect()` is called, or when the object is logged to the console.
-   */
-  export const customInspect: unique symbol;
-  /**
-   * `inspect()` converts input into string that has the same format
-   * as printed by `console.log(...)`;
-   */
-  export function inspect(value: unknown, options?: ConsoleOptions): string;
-
-  // @url js/build.d.ts
-
-  export type OperatingSystem = "mac" | "win" | "linux";
-  export type Arch = "x64" | "arm64";
-  /** Build related information */
-  interface BuildInfo {
-    /** The CPU architecture. */
-    arch: Arch;
-    /** The operating system. */
-    os: OperatingSystem;
-  }
-  export const build: BuildInfo;
-  export const platform: BuildInfo;
-
-  // @url js/version.d.ts
-
-  interface Version {
-    deno: string;
-    v8: string;
-    typescript: string;
-  }
-  export const version: Version;
-  export {};
-
-  // @url js/deno.d.ts
-
-  export const args: string[];
-}
-
-// @url js/globals.ts
-
-declare interface Window {
-  window: Window;
-  atob: typeof textEncoding.atob;
-  btoa: typeof textEncoding.btoa;
-  fetch: typeof fetchTypes.fetch;
-  clearTimeout: typeof timers.clearTimeout;
-  clearInterval: typeof timers.clearInterval;
-  console: consoleTypes.Console;
-  setTimeout: typeof timers.setTimeout;
-  setInterval: typeof timers.setInterval;
-  location: domTypes.Location;
-  onload: Function | undefined;
-  crypto: Crypto;
-  Blob: typeof blob.DenoBlob;
-  File: domTypes.DomFileConstructor;
-  CustomEventInit: typeof customEvent.CustomEventInit;
-  CustomEvent: typeof customEvent.CustomEvent;
-  EventInit: typeof event.EventInit;
-  Event: typeof event.Event;
-  EventListener: typeof eventTarget.EventListener;
-  EventTarget: typeof eventTarget.EventTarget;
-  URL: typeof url.URL;
-  URLSearchParams: typeof urlSearchParams.URLSearchParams;
-  Headers: domTypes.HeadersConstructor;
-  FormData: domTypes.FormDataConstructor;
-  TextEncoder: typeof textEncoding.TextEncoder;
-  TextDecoder: typeof textEncoding.TextDecoder;
-  Request: domTypes.RequestConstructor;
-  Response: typeof fetchTypes.Response;
-  performance: performanceUtil.Performance;
-  onmessage: (e: { data: any }) => void;
-  workerMain: typeof workers.workerMain;
-  workerClose: typeof workers.workerClose;
-  postMessage: typeof workers.postMessage;
-  Worker: typeof workers.WorkerImpl;
-  addEventListener: (
+  export const window: Window;
+  export const atob: typeof textEncoding.atob;
+  export const btoa: typeof textEncoding.btoa;
+  export const fetch: typeof fetchTypes.fetch;
+  export const clearTimeout: typeof timers.clearTimeout;
+  export const clearInterval: typeof timers.clearInterval;
+  export const console: consoleTypes.Console;
+  export const setTimeout: typeof timers.setTimeout;
+  export const setInterval: typeof timers.setInterval;
+  export const location: domTypes.Location;
+  export const onload: Function | undefined;
+  export const crypto: Crypto;
+  export const Blob: typeof blob.DenoBlob;
+  export const File: domTypes.DomFileConstructor;
+  export const CustomEventInit: typeof customEvent.CustomEventInit;
+  export const CustomEvent: typeof customEvent.CustomEvent;
+  export const EventInit: typeof event.EventInit;
+  export const Event: typeof event.Event;
+  export const EventListener: typeof eventTarget.EventListener;
+  export const EventTarget: typeof eventTarget.EventTarget;
+  export const URL: typeof url.URL;
+  export const URLSearchParams: typeof urlSearchParams.URLSearchParams;
+  export const Headers: domTypes.HeadersConstructor;
+  export const FormData: domTypes.FormDataConstructor;
+  export const TextEncoder: typeof textEncoding.TextEncoder;
+  export const TextDecoder: typeof textEncoding.TextDecoder;
+  export const Request: domTypes.RequestConstructor;
+  export const Response: typeof fetchTypes.Response;
+  export const performance: performanceUtil.Performance;
+  export let onmessage: (e: { data: any }) => void;
+  export const workerMain: typeof workers.workerMain;
+  export const workerClose: typeof workers.workerClose;
+  export const postMessage: typeof workers.postMessage;
+  export const Worker: typeof workers.WorkerImpl;
+  export const addEventListener: (
     type: string,
     callback: (event: domTypes.Event) => void | null,
     options?: boolean | domTypes.AddEventListenerOptions | undefined
   ) => void;
-  dispatchEvent: (event: domTypes.Event) => boolean;
-  removeEventListener: (
+  export const dispatchEvent: (event: domTypes.Event) => boolean;
+  export const removeEventListener: (
     type: string,
     callback: (event: domTypes.Event) => void | null,
     options?: boolean | domTypes.EventListenerOptions | undefined
   ) => void;
-  queueMicrotask: (task: () => void) => void;
-  Deno: typeof Deno;
-}
 
-declare const window: Window;
-declare const atob: typeof textEncoding.atob;
-declare const btoa: typeof textEncoding.btoa;
-declare const fetch: typeof fetchTypes.fetch;
-declare const clearTimeout: typeof timers.clearTimeout;
-declare const clearInterval: typeof timers.clearInterval;
-declare const console: consoleTypes.Console;
-declare const setTimeout: typeof timers.setTimeout;
-declare const setInterval: typeof timers.setInterval;
-declare const location: domTypes.Location;
-declare const onload: Function | undefined;
-declare const crypto: Crypto;
-declare const Blob: typeof blob.DenoBlob;
-declare const File: domTypes.DomFileConstructor;
-declare const CustomEventInit: typeof customEvent.CustomEventInit;
-declare const CustomEvent: typeof customEvent.CustomEvent;
-declare const EventInit: typeof event.EventInit;
-declare const Event: typeof event.Event;
-declare const EventListener: typeof eventTarget.EventListener;
-declare const EventTarget: typeof eventTarget.EventTarget;
-declare const URL: typeof url.URL;
-declare const URLSearchParams: typeof urlSearchParams.URLSearchParams;
-declare const Headers: domTypes.HeadersConstructor;
-declare const FormData: domTypes.FormDataConstructor;
-declare const TextEncoder: typeof textEncoding.TextEncoder;
-declare const TextDecoder: typeof textEncoding.TextDecoder;
-declare const Request: domTypes.RequestConstructor;
-declare const Response: typeof fetchTypes.Response;
-declare const performance: performanceUtil.Performance;
-declare let onmessage: (e: { data: any }) => void;
-declare const workerMain: typeof workers.workerMain;
-declare const workerClose: typeof workers.workerClose;
-declare const postMessage: typeof workers.postMessage;
-declare const Worker: typeof workers.WorkerImpl;
-declare const addEventListener: (
-  type: string,
-  callback: (event: domTypes.Event) => void | null,
-  options?: boolean | domTypes.AddEventListenerOptions | undefined
-) => void;
-declare const dispatchEvent: (event: domTypes.Event) => boolean;
-declare const removeEventListener: (
-  type: string,
-  callback: (event: domTypes.Event) => void | null,
-  options?: boolean | domTypes.EventListenerOptions | undefined
-) => void;
+  export type Blob = blob.DenoBlob;
+  export type File = domTypes.DomFile;
+  export type CustomEventInit = customEvent.CustomEventInit;
+  export type CustomEvent = customEvent.CustomEvent;
+  export type EventInit = event.EventInit;
+  export type Event = event.Event;
+  export type EventListener = eventTarget.EventListener;
+  export type EventTarget = eventTarget.EventTarget;
+  export type URL = url.URL;
+  export type URLSearchParams = urlSearchParams.URLSearchParams;
+  export type Headers = domTypes.Headers;
+  export type FormData = domTypes.FormData;
+  export type TextEncoder = textEncoding.TextEncoder;
+  export type TextDecoder = textEncoding.TextDecoder;
+  export type Request = domTypes.Request;
+  export type Response = domTypes.Response;
+  export type Worker = workers.Worker;
 
-declare type Blob = blob.DenoBlob;
-declare type File = domTypes.DomFile;
-declare type CustomEventInit = customEvent.CustomEventInit;
-declare type CustomEvent = customEvent.CustomEvent;
-declare type EventInit = event.EventInit;
-declare type Event = event.Event;
-declare type EventListener = eventTarget.EventListener;
-declare type EventTarget = eventTarget.EventTarget;
-declare type URL = url.URL;
-declare type URLSearchParams = urlSearchParams.URLSearchParams;
-declare type Headers = domTypes.Headers;
-declare type FormData = domTypes.FormData;
-declare type TextEncoder = textEncoding.TextEncoder;
-declare type TextDecoder = textEncoding.TextDecoder;
-declare type Request = domTypes.Request;
-declare type Response = domTypes.Response;
-declare type Worker = workers.Worker;
+  export interface ImportMeta {
+    url: string;
+    main: boolean;
+  }
 
-declare interface ImportMeta {
-  url: string;
-  main: boolean;
-}
+  export interface Crypto {
+    readonly subtle: null;
+    getRandomValues: <
+      T extends
+        | Int8Array
+        | Uint8Array
+        | Uint8ClampedArray
+        | Int16Array
+        | Uint16Array
+        | Int32Array
+        | Uint32Array
+    >(
+      typedArray: T
+    ) => T;
+  }
 
-declare interface Crypto {
-  readonly subtle: null;
-  getRandomValues: <
-    T extends
-      | Int8Array
-      | Uint8Array
-      | Uint8ClampedArray
-      | Int16Array
-      | Uint16Array
-      | Int32Array
-      | Uint32Array
-  >(
-    typedArray: T
-  ) => T;
+  // @url js/lib.web_assembly.d.ts
+
+  // This follows the WebIDL at: https://webassembly.github.io/spec/js-api/
+  // And follow on WebIDL at: https://webassembly.github.io/spec/web-api/
+
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+
+  export namespace WebAssembly {
+    interface WebAssemblyInstantiatedSource {
+      module: Module;
+      instance: Instance;
+    }
+
+    /** Compiles a `WebAssembly.Module` from WebAssembly binary code.  This
+     * function is useful if it is necessary to a compile a module before it can
+     * be instantiated (otherwise, the `WebAssembly.instantiate()` function
+     * should be used). */
+    function compile(bufferSource: domTypes.BufferSource): Promise<Module>;
+
+    /** Compiles a `WebAssembly.Module` directly from a streamed underlying
+     * source. This function is useful if it is necessary to a compile a module
+     * before it can be instantiated (otherwise, the
+     * `WebAssembly.instantiateStreaming()` function should be used). */
+    function compileStreaming(
+      source: Promise<domTypes.Response>
+    ): Promise<Module>;
+
+    /** Takes the WebAssembly binary code, in the form of a typed array or
+     * `ArrayBuffer`, and performs both compilation and instantiation in one step.
+     * The returned `Promise` resolves to both a compiled `WebAssembly.Module` and
+     * its first `WebAssembly.Instance`. */
+    function instantiate(
+      bufferSource: domTypes.BufferSource,
+      importObject?: object
+    ): Promise<WebAssemblyInstantiatedSource>;
+
+    /** Takes an already-compiled `WebAssembly.Module` and returns a `Promise`
+     * that resolves to an `Instance` of that `Module`. This overload is useful if
+     * the `Module` has already been compiled. */
+    function instantiate(
+      module: Module,
+      importObject?: object
+    ): Promise<Instance>;
+
+    /** Compiles and instantiates a WebAssembly module directly from a streamed
+     * underlying source. This is the most efficient, optimized way to load wasm
+     * code. */
+    function instantiateStreaming(
+      source: Promise<domTypes.Response>,
+      importObject?: object
+    ): Promise<WebAssemblyInstantiatedSource>;
+
+    /** Validates a given typed array of WebAssembly binary code, returning
+     * whether the bytes form a valid wasm module (`true`) or not (`false`). */
+    function validate(bufferSource: domTypes.BufferSource): boolean;
+
+    type ImportExportKind = "function" | "table" | "memory" | "global";
+
+    interface ModuleExportDescriptor {
+      name: string;
+      kind: ImportExportKind;
+    }
+    interface ModuleImportDescriptor {
+      module: string;
+      name: string;
+      kind: ImportExportKind;
+    }
+
+    class Module {
+      constructor(bufferSource: domTypes.BufferSource);
+
+      /** Given a `Module` and string, returns a copy of the contents of all
+       * custom sections in the module with the given string name. */
+      static customSections(
+        moduleObject: Module,
+        sectionName: string
+      ): ArrayBuffer;
+
+      /** Given a `Module`, returns an array containing descriptions of all the
+       * declared exports. */
+      static exports(moduleObject: Module): ModuleExportDescriptor[];
+
+      /** Given a `Module`, returns an array containing descriptions of all the
+       * declared imports. */
+      static imports(moduleObject: Module): ModuleImportDescriptor[];
+    }
+
+    class Instance<T extends object = { [key: string]: any }> {
+      constructor(module: Module, importObject?: object);
+
+      /** An object containing as its members all the functions exported from the
+       * WebAssembly module instance, to allow them to be accessed and used by
+       * JavaScript. */
+      readonly exports: T;
+    }
+
+    interface MemoryDescriptor {
+      initial: number;
+      maximum?: number;
+    }
+
+    class Memory {
+      constructor(descriptor: MemoryDescriptor);
+
+      /** An accessor property that returns the buffer contained in the memory. */
+      readonly buffer: ArrayBuffer;
+
+      /** Increases the size of the memory instance by a specified number of
+       * WebAssembly pages (each one is 64KB in size). */
+      grow(delta: number): number;
+    }
+
+    type TableKind = "anyfunc";
+
+    interface TableDescriptor {
+      element: TableKind;
+      initial: number;
+      maximum?: number;
+    }
+
+    class Table {
+      constructor(descriptor: TableDescriptor);
+
+      /** Returns the length of the table, i.e. the number of elements. */
+      readonly length: number;
+
+      /** Accessor function — gets the element stored at a given index. */
+      get(index: number): (...args: any[]) => any;
+
+      /** Increases the size of the Table instance by a specified number of
+       * elements. */
+      grow(delta: number): number;
+
+      /** Sets an element stored at a given index to a given value. */
+      set(index: number, value: (...args: any[]) => any): void;
+    }
+
+    interface GlobalDescriptor {
+      value: string;
+      mutable?: boolean;
+    }
+
+    /** Represents a global variable instance, accessible from both JavaScript and
+     * importable/exportable across one or more `WebAssembly.Module` instances.
+     * This allows dynamic linking of multiple modules. */
+    class Global {
+      constructor(descriptor: GlobalDescriptor, value?: any);
+
+      /** Old-style method that returns the value contained inside the global
+       * variable. */
+      valueOf(): any;
+
+      /** The value contained inside the global variable — this can be used to
+       * directly set and get the global's value. */
+      value: any;
+    }
+
+    /** Indicates an error during WebAssembly decoding or validation */
+    class CompileError extends Error {
+      constructor(message: string, fileName?: string, lineNumber?: string);
+    }
+
+    /** Indicates an error during module instantiation (besides traps from the
+     * start function). */
+    class LinkError extends Error {
+      constructor(message: string, fileName?: string, lineNumber?: string);
+    }
+
+    /** Is thrown whenever WebAssembly specifies a trap. */
+    class RuntimeError extends Error {
+      constructor(message: string, fileName?: string, lineNumber?: string);
+    }
+  }
+
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 }
 
 declare namespace domTypes {
@@ -2593,179 +2784,3 @@ declare namespace performanceUtil {
     now(): number;
   }
 }
-
-// @url js/lib.web_assembly.d.ts
-
-// This follows the WebIDL at: https://webassembly.github.io/spec/js-api/
-// And follow on WebIDL at: https://webassembly.github.io/spec/web-api/
-
-/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */
-
-declare namespace WebAssembly {
-  interface WebAssemblyInstantiatedSource {
-    module: Module;
-    instance: Instance;
-  }
-
-  /** Compiles a `WebAssembly.Module` from WebAssembly binary code.  This
-   * function is useful if it is necessary to a compile a module before it can
-   * be instantiated (otherwise, the `WebAssembly.instantiate()` function
-   * should be used). */
-  function compile(bufferSource: domTypes.BufferSource): Promise<Module>;
-
-  /** Compiles a `WebAssembly.Module` directly from a streamed underlying
-   * source. This function is useful if it is necessary to a compile a module
-   * before it can be instantiated (otherwise, the
-   * `WebAssembly.instantiateStreaming()` function should be used). */
-  function compileStreaming(
-    source: Promise<domTypes.Response>
-  ): Promise<Module>;
-
-  /** Takes the WebAssembly binary code, in the form of a typed array or
-   * `ArrayBuffer`, and performs both compilation and instantiation in one step.
-   * The returned `Promise` resolves to both a compiled `WebAssembly.Module` and
-   * its first `WebAssembly.Instance`. */
-  function instantiate(
-    bufferSource: domTypes.BufferSource,
-    importObject?: object
-  ): Promise<WebAssemblyInstantiatedSource>;
-
-  /** Takes an already-compiled `WebAssembly.Module` and returns a `Promise`
-   * that resolves to an `Instance` of that `Module`. This overload is useful if
-   * the `Module` has already been compiled. */
-  function instantiate(
-    module: Module,
-    importObject?: object
-  ): Promise<Instance>;
-
-  /** Compiles and instantiates a WebAssembly module directly from a streamed
-   * underlying source. This is the most efficient, optimized way to load wasm
-   * code. */
-  function instantiateStreaming(
-    source: Promise<domTypes.Response>,
-    importObject?: object
-  ): Promise<WebAssemblyInstantiatedSource>;
-
-  /** Validates a given typed array of WebAssembly binary code, returning
-   * whether the bytes form a valid wasm module (`true`) or not (`false`). */
-  function validate(bufferSource: domTypes.BufferSource): boolean;
-
-  type ImportExportKind = "function" | "table" | "memory" | "global";
-
-  interface ModuleExportDescriptor {
-    name: string;
-    kind: ImportExportKind;
-  }
-  interface ModuleImportDescriptor {
-    module: string;
-    name: string;
-    kind: ImportExportKind;
-  }
-
-  class Module {
-    constructor(bufferSource: domTypes.BufferSource);
-
-    /** Given a `Module` and string, returns a copy of the contents of all
-     * custom sections in the module with the given string name. */
-    static customSections(
-      moduleObject: Module,
-      sectionName: string
-    ): ArrayBuffer;
-
-    /** Given a `Module`, returns an array containing descriptions of all the
-     * declared exports. */
-    static exports(moduleObject: Module): ModuleExportDescriptor[];
-
-    /** Given a `Module`, returns an array containing descriptions of all the
-     * declared imports. */
-    static imports(moduleObject: Module): ModuleImportDescriptor[];
-  }
-
-  class Instance<T extends object = { [key: string]: any }> {
-    constructor(module: Module, importObject?: object);
-
-    /** An object containing as its members all the functions exported from the
-     * WebAssembly module instance, to allow them to be accessed and used by
-     * JavaScript. */
-    readonly exports: T;
-  }
-
-  interface MemoryDescriptor {
-    initial: number;
-    maximum?: number;
-  }
-
-  class Memory {
-    constructor(descriptor: MemoryDescriptor);
-
-    /** An accessor property that returns the buffer contained in the memory. */
-    readonly buffer: ArrayBuffer;
-
-    /** Increases the size of the memory instance by a specified number of
-     * WebAssembly pages (each one is 64KB in size). */
-    grow(delta: number): number;
-  }
-
-  type TableKind = "anyfunc";
-
-  interface TableDescriptor {
-    element: TableKind;
-    initial: number;
-    maximum?: number;
-  }
-
-  class Table {
-    constructor(descriptor: TableDescriptor);
-
-    /** Returns the length of the table, i.e. the number of elements. */
-    readonly length: number;
-
-    /** Accessor function — gets the element stored at a given index. */
-    get(index: number): (...args: any[]) => any;
-
-    /** Increases the size of the Table instance by a specified number of
-     * elements. */
-    grow(delta: number): number;
-
-    /** Sets an element stored at a given index to a given value. */
-    set(index: number, value: (...args: any[]) => any): void;
-  }
-
-  interface GlobalDescriptor {
-    value: string;
-    mutable?: boolean;
-  }
-
-  /** Represents a global variable instance, accessible from both JavaScript and
-   * importable/exportable across one or more `WebAssembly.Module` instances.
-   * This allows dynamic linking of multiple modules. */
-  class Global {
-    constructor(descriptor: GlobalDescriptor, value?: any);
-
-    /** Old-style method that returns the value contained inside the global
-     * variable. */
-    valueOf(): any;
-
-    /** The value contained inside the global variable — this can be used to
-     * directly set and get the global's value. */
-    value: any;
-  }
-
-  /** Indicates an error during WebAssembly decoding or validation */
-  class CompileError extends Error {
-    constructor(message: string, fileName?: string, lineNumber?: string);
-  }
-
-  /** Indicates an error during module instantiation (besides traps from the
-   * start function). */
-  class LinkError extends Error {
-    constructor(message: string, fileName?: string, lineNumber?: string);
-  }
-
-  /** Is thrown whenever WebAssembly specifies a trap. */
-  class RuntimeError extends Error {
-    constructor(message: string, fileName?: string, lineNumber?: string);
-  }
-}
-
-/* eslint-enable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */

--- a/tests/types.out
+++ b/tests/types.out
@@ -1,14 +1,9 @@
-// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-[WILDCARD]
-
-declare namespace Deno {
-[WILDCARD]
-}
-[WILDCARD]
-declare interface Window {
-[WILDCARD]
-  Deno: typeof Deno;
-}
-
-declare const window: Window;
-[WILDCARD]
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.[WILDCARD]
+declare global {
+  export namespace Deno {[WILDCARD]
+  }[WILDCARD]
+  export interface Window {[WILDCARD]
+    Deno: typeof Deno;[WILDCARD]
+  }[WILDCARD]
+  export const window: Window;[WILDCARD]
+}[WILDCARD]


### PR DESCRIPTION
Fixes #2888.

I added `export {};` (see comment and https://github.com/Microsoft/TypeScript/issues/19545). Everything global is in a `declare global {}` block.

@ry Not sure how I'd test this.