### PR TITLE
Add JSDoc to deno_typescript

### DIFF
--- a/deno_typescript/amd_runtime.js
+++ b/deno_typescript/amd_runtime.js
@@ -1,20 +1,34 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+
 // A very very basic AMD preamble to support the output of TypeScript outFile
 // bundles.
-let require, define;
+
+/**
+ * @type {(name: string) => any}
+ */
+let require;
+
+/**
+ * @type {(name: string, deps: ReadonlyArray<string>, factory: (...deps: any[]) => void) => void}
+ */
+let define;
 
 (function() {
+  /**
+   * @type {Map<string, { name: string, exports: any }>}
+   */
   const modules = new Map();
 
-  function println(first, ...s) {
-    Deno.core.print(first + " " + s.map(JSON.stringify).join(" ") + "\n");
-  }
-
+  /**
+   * @param {string} name
+   */
   function createOrLoadModule(name) {
-    if (!modules.has(name)) {
-      const m = { name, exports: {} };
+    let m = modules.get(name);
+    if (!m) {
+      m = { name, exports: {} };
       modules.set(name, m);
     }
-    return modules.get(name);
+    return m;
   }
 
   require = name => {

--- a/deno_typescript/globals.d.ts
+++ b/deno_typescript/globals.d.ts
@@ -1,0 +1,13 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+
+// This scopes the `ts` namespace globally, which is where it exists at runtime
+// when building Deno, but the `typescript/lib/typescript.d.ts` is defined as a
+// module
+
+import * as _ts from "typescript";
+
+declare global {
+  namespace ts {
+    export = _ts;
+  }
+}

--- a/deno_typescript/jsconfig.json
+++ b/deno_typescript/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext"
+  }
+}


### PR DESCRIPTION
This PR adds JSDoc to the JavaScript in `deno_typescript`, which can be used with VSCode to help ensure the type safety of the JavaScript code without it being written in TypeScript.  This is a stepping stone to potentially shared parts between `deno_typescript` and the Deno runtime compiler.