### PR TITLE
Remove Deno.platform

### DIFF
--- a/js/build.ts
+++ b/js/build.ts
@@ -25,6 +25,3 @@ export function setBuildInfo(os: OperatingSystem, arch: Arch): void {
 
   Object.freeze(build);
 }
-
-// TODO(kevinkassimo): deprecate Deno.platform
-export const platform = build;

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -86,7 +86,7 @@ export {
   Signal
 } from "./process.ts";
 export { inspect, customInspect } from "./console.ts";
-export { build, platform, OperatingSystem, Arch } from "./build.ts";
+export { build, OperatingSystem, Arch } from "./build.ts";
 export { version } from "./version.ts";
 export const args: string[] = [];
 

--- a/js/lib.deno_runtime.d.ts
+++ b/js/lib.deno_runtime.d.ts
@@ -1198,7 +1198,6 @@ declare namespace Deno {
     os: OperatingSystem;
   }
   export const build: BuildInfo;
-  export const platform: BuildInfo;
 
   // @url js/version.d.ts
 

--- a/js/process_test.ts
+++ b/js/process_test.ts
@@ -312,15 +312,15 @@ testPerm({ run: true }, async function runClose(): Promise<void> {
 });
 
 test(function signalNumbers(): void {
-  if (Deno.platform.os === "mac") {
+  if (Deno.build.os === "mac") {
     assertEquals(Deno.Signal.SIGSTOP, 17);
-  } else if (Deno.platform.os === "linux") {
+  } else if (Deno.build.os === "linux") {
     assertEquals(Deno.Signal.SIGSTOP, 19);
   }
 });
 
 // Ignore signal tests on windows for now...
-if (Deno.platform.os !== "win") {
+if (Deno.build.os !== "win") {
   test(function killPermissions(): void {
     let caughtError = false;
     try {

--- a/js/symlink.ts
+++ b/js/symlink.ts
@@ -2,7 +2,7 @@
 import { sendSync, sendAsync } from "./dispatch_json.ts";
 import * as dispatch from "./dispatch.ts";
 import * as util from "./util.ts";
-import { platform } from "./build.ts";
+import { build } from "./build.ts";
 
 /** Synchronously creates `newname` as a symbolic link to `oldname`. The type
  * argument can be set to `dir` or `file` and is only available on Windows
@@ -15,7 +15,7 @@ export function symlinkSync(
   newname: string,
   type?: string
 ): void {
-  if (platform.os === "win" && type) {
+  if (build.os === "win" && type) {
     return util.notImplemented();
   }
   sendSync(dispatch.OP_SYMLINK, { oldname, newname });
@@ -32,7 +32,7 @@ export async function symlink(
   newname: string,
   type?: string
 ): Promise<void> {
-  if (platform.os === "win" && type) {
+  if (build.os === "win" && type) {
     return util.notImplemented();
   }
   await sendAsync(dispatch.OP_SYMLINK, { oldname, newname });

--- a/js/symlink_test.ts
+++ b/js/symlink_test.ts
@@ -14,7 +14,7 @@ testPerm({ read: true, write: true }, function symlinkSyncSuccess(): void {
     errOnWindows = e;
   }
   if (errOnWindows) {
-    assertEquals(Deno.platform.os, "win");
+    assertEquals(Deno.build.os, "win");
     assertEquals(errOnWindows.kind, Deno.ErrorKind.Other);
     assertEquals(errOnWindows.message, "Not implemented");
   } else {
@@ -49,7 +49,7 @@ testPerm({ write: true }, function symlinkSyncNotImplemented(): void {
     err = e;
   }
   if (err) {
-    assertEquals(Deno.platform.os, "win");
+    assertEquals(Deno.build.os, "win");
     assertEquals(err.message, "Not implemented");
   }
 });


### PR DESCRIPTION
Similar to https://github.com/denoland/deno_std/pull/590, this PR removes Deno.platform and replaces its usages with Deno.build.