### PR TITLE
Fix Appveyor's sccache --stop-server problem

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,7 @@ clone_folder: C:\deno
 clone_depth: 1
 
 environment:
+  SCCACHE_IDLE_TIMEOUT: 0
   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
   DENO_BUILD_MODE: release
   DENO_BUILD_PATH: $(APPVEYOR_BUILD_FOLDER)\target\release


### PR DESCRIPTION
The problem is seen here: https://ci.appveyor.com/project/deno/deno/builds/27283032

```
sccache --stop-server
Stopping sccache server...
sccache : error: couldn't connect to server
At line:1 char:1
+ sccache --stop-server
+ ~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (error: couldn't connect to server:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError

caused by:
No connection could be made because the target machine actively refused it.
 (os error 10061)
Command executed with exception:  (os error 10061)
```

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
