### PR TITLE
Don't test resolve_from_cwd_absolute() on Windows

### DIFF
--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -182,13 +182,11 @@ mod tests {
     assert_eq!(resolve_from_cwd("a/..").unwrap().0, cwd);
   }
 
+  // TODO: Get a good expected value here for Windows.
+  #[cfg(not(windows))]
   #[test]
   fn resolve_from_cwd_absolute() {
-    let expected = if cfg!(windows) {
-      Path::new("C:\\a")
-    } else {
-      Path::new("/a")
-    };
+    let expected = Path::new("/a");
     assert_eq!(resolve_from_cwd("/a").unwrap().0, expected);
   }
 }


### PR DESCRIPTION
```
---- fs::tests::resolve_from_cwd_absolute stdout ----
thread 'fs::tests::resolve_from_cwd_absolute' panicked at 'assertion failed: (left == right)
left: "D:\\a",
right: "C:\\a"', cli\fs.rs:192:5
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace.
```

Unless there's a way of getting the proper Window path prefix?

cc @bartlomieju @lucacasonato