### PR TITLE
tools/third_party: download gn from CIPD

### DIFF
--- a/gclient_config.py
+++ b/gclient_config.py
@@ -24,7 +24,7 @@ solutions = [{
     }
 }, {
     'url':
-    'https://chromium.googlesource.com/chromium/tools/depot_tools@40bacee96a94600ad2179d69a8025469d119960f',
+    'https://chromium.googlesource.com/chromium/tools/depot_tools@efce0d1b7657c440c90f0f4bce614b96672b9e0b',
     'name':
     'depot_tools'
 }, {

--- a/tools/third_party.py
+++ b/tools/third_party.py
@@ -210,7 +210,7 @@ def download_from_google_storage(item, bucket):
 
 
 # Download the given item from Chrome Infrastructure Package Deployment.
-def download_from_cipd(item, deps_name):
+def download_from_cipd(item, version):
     if sys.platform == 'win32':
         root_dir = "v8/buildtools/win"
         item += "windows-amd64"
@@ -231,16 +231,11 @@ def download_from_cipd(item, deps_name):
         ],
             env=google_env())
 
-    # read CIPD version from the DEPS file
-    deps = open(tp('v8/DEPS'), 'rb').read()
-    regex = r"'" + re.escape(deps_name) + r"': '(git_revision:[0-9a-f]{40})'"
-    version = re.search(regex, deps).group(1)
-
     run([
         tp('depot_tools/cipd'),
         'install',
         item,
-        version,
+        'git_revision:' + version,
         '-root',
         tp(root_dir),
     ],
@@ -249,7 +244,7 @@ def download_from_cipd(item, deps_name):
 
 # Download gn from Google storage.
 def download_gn():
-    download_from_cipd('gn/gn/', 'gn_version')
+    download_from_cipd('gn/gn/', '152c5144ceed9592c20f0c8fd55769646077569b')
 
 
 # Download clang-format from Google storage.


### PR DESCRIPTION
This PR switches the download method of the `gn` binary in `tools/third_party` from the deprecated (and now for `gn` removed )`download_from_google_storage` to a `CIPD` based installation.

Refs: #2907 

This requires a update of `depot_tools` in `deno_third_party` to a more recent version and with this https://github.com/denoland/deno_third_party/commit/f8757afb7368b2f6a518ebedde728f819e7c59d0 should be reverted.