### PR TITLE
Added normalized benchmark graphs

### DIFF
--- a/website/app.ts
+++ b/website/app.ts
@@ -366,7 +366,6 @@ export async function drawChartsFromBenchmarkData(dataUrl) {
 function hideOnRender(elementID) {
   return () => {
     const chart = window["document"].getElementById(elementID);
-    console.log(chart);
     if (!chart.getAttribute("data-inital-hide-done")) {
       chart.setAttribute("data-inital-hide-done", "true");
       chart.classList.add("hidden");

--- a/website/app.ts
+++ b/website/app.ts
@@ -34,21 +34,28 @@ export function createColumns(data, benchmarkName) {
   ]);
 }
 
-export function createNormalizedColumns(data, benchmarkName, baselineVariety) {
+export function createNormalizedColumns(
+  data,
+  benchmarkName,
+  baselineBenchmark,
+  baselineVariety
+) {
   const varieties = getBenchmarkVarieties(data, benchmarkName);
   return varieties.map(variety => [
     variety,
     ...data.map(d => {
-      if (d[benchmarkName] != null) {
-        if (d[benchmarkName][baselineVariety] != null) {
-          const baseline = d[benchmarkName][baselineVariety];
-          if (d[benchmarkName][variety] != null && baseline != 0) {
-            const v = d[benchmarkName][variety];
-            if (benchmarkName == "benchmark") {
-              const meanValue = v ? v.mean : 0;
-              return meanValue || null;
-            } else {
-              return v / baseline;
+      if (d[baselineBenchmark] != null) {
+        if (d[baselineBenchmark][baselineVariety] != null) {
+          const baseline = d[baselineBenchmark][baselineVariety];
+          if (d[benchmarkName] != null) {
+            if (d[benchmarkName][variety] != null && baseline != 0) {
+              const v = d[benchmarkName][variety];
+              if (benchmarkName == "benchmark") {
+                const meanValue = v ? v.mean : 0;
+                return meanValue || null;
+              } else {
+                return v / baseline;
+              }
             }
           }
         }
@@ -71,7 +78,12 @@ export function createProxyColumns(data) {
 }
 
 export function createNormalizedProxyColumns(data) {
-  return createNormalizedColumns(data, "req_per_sec_proxy", "node_proxy_tcp");
+  return createNormalizedColumns(
+    data,
+    "req_per_sec_proxy",
+    "req_per_sec",
+    "hyper"
+  );
 }
 
 export function createReqPerSecColumns(data) {
@@ -79,7 +91,7 @@ export function createReqPerSecColumns(data) {
 }
 
 export function createNormalizedReqPerSecColumns(data) {
-  return createNormalizedColumns(data, "req_per_sec", "hyper");
+  return createNormalizedColumns(data, "req_per_sec", "req_per_sec", "hyper");
 }
 
 export function createMaxLatencyColumns(data) {
@@ -321,13 +333,13 @@ export async function drawChartsFromBenchmarkData(dataUrl) {
   gen(
     "#normalized-req-per-sec-chart",
     normalizedReqPerSecColumns,
-    "%",
+    "% of hyper througput",
     formatPercentage
   );
   gen(
     "#normalized-proxy-req-per-sec-chart",
     normalizedProxyColumns,
-    "%",
+    "% of hyper througput",
     formatPercentage
   );
   gen("#proxy-req-per-sec-chart", proxyColumns, "req/sec");

--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -102,7 +102,7 @@
 
       <div id="req-per-sec-chart"></div>
 
-      <div id="normalized-req-per-sec-chart" hidden></div>
+      <div id="normalized-req-per-sec-chart"></div>
 
       <input type="checkbox" id="req-per-sec-chart-show-normalized" />
       <label for="req-per-sec-chart-show-normalized">Show Normalized</label>
@@ -156,7 +156,7 @@
 
       <div id="proxy-req-per-sec-chart"></div>
 
-      <div id="normalized-proxy-req-per-sec-chart" hidden></div>
+      <div id="normalized-proxy-req-per-sec-chart"></div>
 
       <input type="checkbox" id="proxy-req-per-sec-chart-show-normalized" />
       <label for="proxy-req-per-sec-chart-show-normalized"

--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -102,6 +102,11 @@
 
       <div id="req-per-sec-chart"></div>
 
+      <div id="normalized-req-per-sec-chart" hidden></div>
+
+      <input type="checkbox" id="req-per-sec-chart-show-normalized" />
+      <label for="req-per-sec-chart-show-normalized">Show Normalized</label>
+
       <h3 id="proxy-req-per-sec">
         Proxy Req/Sec <a href="#proxy-eq-per-sec">#</a>
       </h3>
@@ -150,6 +155,13 @@
       </ul>
 
       <div id="proxy-req-per-sec-chart"></div>
+
+      <div id="normalized-proxy-req-per-sec-chart" hidden></div>
+
+      <input type="checkbox" id="proxy-req-per-sec-chart-show-normalized" />
+      <label for="proxy-req-per-sec-chart-show-normalized"
+        >Show Normalized</label
+      >
 
       <h3 id="max-latency">Max Latency <a href="#max-latency">#</a></h3>
 
@@ -234,17 +246,11 @@
 
       <ul>
         <li>
-          <a
-            href="https://deno.land/std/http/file_server.ts"
-            >file_server</a
-          >
+          <a href="https://deno.land/std/http/file_server.ts">file_server</a>
         </li>
 
         <li>
-          <a
-            href="https://deno.land/std/examples/gist.ts"
-            >gist</a
-          >
+          <a href="https://deno.land/std/examples/gist.ts">gist</a>
         </li>
       </ul>
 
@@ -257,7 +263,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
     <script src="app.bundle.js"></script>
     <script>
-    requirejs(['app'], (app) => app.main());
+      requirejs(["app"], app => app.main());
     </script>
   </body>
 </html>

--- a/website/style.css
+++ b/website/style.css
@@ -158,3 +158,7 @@ code {
   border-top-color: #000;
   animation: spinner .6s linear infinite;
 }
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
Closes #2914.

I added a checkbox to switch between normalized and raw data. Both graphs are drawn right away in separate divs, and are then hidden/shown by the checkbox onchange handler. Currently raw is default, but this can easily be changed.