### PR TITLE
Default base URL path to '/'

### DIFF
--- a/js/url.ts
+++ b/js/url.ts
@@ -333,7 +333,7 @@ export class URL {
         password: baseParts.password,
         hostname: baseParts.hostname,
         port: baseParts.port,
-        path: resolvePathFromBase(urlParts.path, baseParts.path),
+        path: resolvePathFromBase(urlParts.path, baseParts.path || "/"),
         query: urlParts.query,
         hash: urlParts.hash
       };

--- a/js/url_test.ts
+++ b/js/url_test.ts
@@ -152,6 +152,10 @@ test(function urlRelativeWithBase(): void {
   assertEquals(new URL("../b", "file:///a/a/a").href, "file:///a/b");
 });
 
+test(function emptyBasePath(): void {
+  assertEquals(new URL("", "http://example.com").href, "http://example.com/");
+});
+
 test(function deletingAllParamsRemovesQuestionMarkFromURL(): void {
   const url = new URL("http://example.com/?param1&param2");
   url.searchParams.delete("param1");


### PR DESCRIPTION
`resolvePathFromBase()` uses the base URL path with the expectation of this default.