### PR TITLE
feat: parallelize downloads from TS compiler

### DIFF
--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -69,6 +69,59 @@ pub fn op_fetch_source_file(
 }
 
 #[derive(Deserialize)]
+struct FetchSourceFilesArgs {
+  specifiers: Vec<String>,
+  referrer: String,
+}
+
+pub fn op_fetch_source_files(
+  state: &ThreadSafeState,
+  args: Value,
+  _zero_copy: Option<PinnedBuf>,
+) -> Result<JsonOp, ErrBox> {
+  let args: FetchSourceFilesArgs = serde_json::from_value(args)?;
+
+  // TODO(ry) Maybe a security hole. Only the compiler worker should have access
+  // to this. Need a test to demonstrate the hole.
+  let is_dyn_import = false;
+
+  let mut resolved_specifiers = vec![];
+
+  for specifier in &args.specifiers {
+    let resolved_specifier =
+      state.resolve(specifier, &args.referrer, false, is_dyn_import)?;
+    resolved_specifiers.push(resolved_specifier);
+  }
+
+  let mut futures = vec![];
+
+  for resolved_specifier in resolved_specifiers {
+    let fut = state
+      .file_fetcher
+      .fetch_source_file_async(&resolved_specifier);
+    futures.push(fut);
+  }
+
+  // WARNING: Here we use tokio_util::block_on() which starts a new Tokio
+  // runtime for executing the future. This is so we don't inadvernently run
+  // out of threads in the main runtime.
+  let files = tokio_util::block_on(futures::future::join_all(futures))?;
+  let res: Vec<serde_json::value::Value> = files
+    .into_iter()
+    .map(|file| {
+      json!({
+        "moduleName": file.url.to_string(),
+        "filename": file.filename.to_str().unwrap(),
+        "mediaType": file.media_type as i32,
+        "sourceCode": String::from_utf8(file.source_code).unwrap(),
+      })
+    })
+    .collect();
+
+  Ok(JsonOp::Sync(json!(res)))
+}
+
+#[derive(Deserialize)]
 struct FetchAssetArgs {
   name: String,
 }

--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -33,42 +33,6 @@ pub fn op_cache(
 }
 
 #[derive(Deserialize)]
-struct FetchSourceFileArgs {
-  specifier: String,
-  referrer: String,
-}
-
-pub fn op_fetch_source_file(
-  state: &ThreadSafeState,
-  args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  let args: FetchSourceFileArgs = serde_json::from_value(args)?;
-
-  // TODO(ry) Maybe a security hole. Only the compiler worker should have access
-  // to this. Need a test to demonstrate the hole.
-  let is_dyn_import = false;
-
-  let resolved_specifier =
-    state.resolve(&args.specifier, &args.referrer, false, is_dyn_import)?;
-
-  let fut = state
-    .file_fetcher
-    .fetch_source_file_async(&resolved_specifier);
-
-  // WARNING: Here we use tokio_util::block_on() which starts a new Tokio
-  // runtime for executing the future. This is so we don't inadvernently run
-  // out of threads in the main runtime.
-  let out = tokio_util::block_on(fut)?;
-  Ok(JsonOp::Sync(json!({
-    "moduleName": out.url.to_string(),
-    "filename": out.filename.to_str().unwrap(),
-    "mediaType": out.media_type as i32,
-    "sourceCode": String::from_utf8(out.source_code).unwrap(),
-  })))
-}
-
-#[derive(Deserialize)]
 struct FetchSourceFilesArgs {
   specifiers: Vec<String>,
   referrer: String,

--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -49,17 +49,10 @@ pub fn op_fetch_source_files(
   // to this. Need a test to demonstrate the hole.
   let is_dyn_import = false;
 
-  let mut resolved_specifiers = vec![];
-
+  let mut futures = vec![];
   for specifier in &args.specifiers {
     let resolved_specifier =
       state.resolve(specifier, &args.referrer, false, is_dyn_import)?;
-    resolved_specifiers.push(resolved_specifier);
-  }
-
-  let mut futures = vec![];
-
-  for resolved_specifier in resolved_specifiers {
     let fut = state
       .file_fetcher
       .fetch_source_file_async(&resolved_specifier);
@@ -67,7 +60,7 @@ pub fn op_fetch_source_files(
   }
 
   // WARNING: Here we use tokio_util::block_on() which starts a new Tokio
-  // runtime for executing the future. This is so we don't inadvernently run
+  // runtime for executing the future. This is so we don't inadvertently run
   // out of threads in the main runtime.
   let files = tokio_util::block_on(futures::future::join_all(futures))?;
   let res: Vec<serde_json::value::Value> = files

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -37,7 +37,7 @@ pub const OP_START: OpId = 10;
 pub const OP_APPLY_SOURCE_MAP: OpId = 11;
 pub const OP_FORMAT_ERROR: OpId = 12;
 pub const OP_CACHE: OpId = 13;
-pub const OP_FETCH_SOURCE_FILE: OpId = 14;
+pub const OP_FETCH_SOURCE_FILES: OpId = 14;
 pub const OP_OPEN: OpId = 15;
 pub const OP_CLOSE: OpId = 16;
 pub const OP_SEEK: OpId = 17;
@@ -81,7 +81,6 @@ pub const OP_TRUNCATE: OpId = 54;
 pub const OP_MAKE_TEMP_DIR: OpId = 55;
 pub const OP_CWD: OpId = 56;
 pub const OP_FETCH_ASSET: OpId = 57;
-pub const OP_FETCH_SOURCE_FILES: OpId = 58;
 
 pub fn dispatch(
   state: &ThreadSafeState,
@@ -134,8 +133,8 @@ pub fn dispatch(
     OP_CACHE => {
       dispatch_json::dispatch(compiler::op_cache, state, control, zero_copy)
     }
-    OP_FETCH_SOURCE_FILE => dispatch_json::dispatch(
-      compiler::op_fetch_source_file,
+    OP_FETCH_SOURCE_FILES => dispatch_json::dispatch(
+      compiler::op_fetch_source_files,
       state,
       control,
       zero_copy,
@@ -297,12 +296,6 @@ pub fn dispatch(
     OP_CWD => dispatch_json::dispatch(fs::op_cwd, state, control, zero_copy),
     OP_FETCH_ASSET => dispatch_json::dispatch(
       compiler::op_fetch_asset,
-      state,
-      control,
-      zero_copy,
-    ),
-    OP_FETCH_SOURCE_FILES => dispatch_json::dispatch(
-      compiler::op_fetch_source_files,
       state,
       control,
       zero_copy,

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -81,6 +81,7 @@ pub const OP_TRUNCATE: OpId = 54;
 pub const OP_MAKE_TEMP_DIR: OpId = 55;
 pub const OP_CWD: OpId = 56;
 pub const OP_FETCH_ASSET: OpId = 57;
+pub const OP_FETCH_SOURCE_FILES: OpId = 58;
 
 pub fn dispatch(
   state: &ThreadSafeState,
@@ -296,6 +297,12 @@ pub fn dispatch(
     OP_CWD => dispatch_json::dispatch(fs::op_cwd, state, control, zero_copy),
     OP_FETCH_ASSET => dispatch_json::dispatch(
       compiler::op_fetch_asset,
+      state,
+      control,
+      zero_copy,
+    ),
+    OP_FETCH_SOURCE_FILES => dispatch_json::dispatch(
+      compiler::op_fetch_source_files,
       state,
       control,
       zero_copy,

--- a/js/dispatch.ts
+++ b/js/dispatch.ts
@@ -60,6 +60,7 @@ export const OP_TRUNCATE = 54;
 export const OP_MAKE_TEMP_DIR = 55;
 export const OP_CWD = 56;
 export const OP_FETCH_ASSET = 57;
+export const OP_FETCH_SOURCE_FILES = 58;
 
 export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
   switch (opId) {

--- a/js/dispatch.ts
+++ b/js/dispatch.ts
@@ -16,7 +16,7 @@ export const OP_START = 10;
 export const OP_APPLY_SOURCE_MAP = 11;
 export const OP_FORMAT_ERROR = 12;
 export const OP_CACHE = 13;
-export const OP_FETCH_SOURCE_FILE = 14;
+export const OP_FETCH_SOURCE_FILES = 14;
 export const OP_OPEN = 15;
 export const OP_CLOSE = 16;
 export const OP_SEEK = 17;
@@ -60,7 +60,6 @@ export const OP_TRUNCATE = 54;
 export const OP_MAKE_TEMP_DIR = 55;
 export const OP_CWD = 56;
 export const OP_FETCH_ASSET = 57;
-export const OP_FETCH_SOURCE_FILES = 58;
 
 export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
   switch (opId) {

--- a/tests/error_004_missing_module.ts.out
+++ b/tests/error_004_missing_module.ts.out
@@ -3,10 +3,10 @@
     at DenoError ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendSync[WILDCARD] ([WILDCARD]dispatch_json.ts:[WILDCARD])
-    at fetchSourceFile ([WILDCARD]compiler.ts:[WILDCARD])
-    at _resolveModule ([WILDCARD]compiler.ts:[WILDCARD])
-    at [WILDCARD]compiler.ts:[WILDCARD]
+    at fetchSourceFiles ([WILDCARD]compiler.ts:[WILDCARD])
+    at _resolveModules ([WILDCARD]compiler.ts:[WILDCARD])
     at resolveModuleNames ([WILDCARD]compiler.ts:[WILDCARD])
     at resolveModuleNamesWorker ([WILDCARD]typescript.js:[WILDCARD])
     at resolveModuleNamesReusingOldState ([WILDCARD]typescript.js:[WILDCARD])
     at processImportedModules ([WILDCARD]typescript.js:[WILDCARD])
+    at findSourceFile ([WILDCARD]typescript.js:[WILDCARD])

--- a/tests/error_005_missing_dynamic_import.ts.out
+++ b/tests/error_005_missing_dynamic_import.ts.out
@@ -3,9 +3,10 @@
     at DenoError ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendSync[WILDCARD] ([WILDCARD]dispatch_json.ts:[WILDCARD])
-    at fetchSourceFile ([WILDCARD]compiler.ts:[WILDCARD])
-    at _resolveModule ([WILDCARD]compiler.ts:[WILDCARD])
+    at fetchSourceFiles ([WILDCARD]compiler.ts:[WILDCARD])
+    at _resolveModules ([WILDCARD]compiler.ts:[WILDCARD])
     at [WILDCARD]compiler.ts:[WILDCARD]
     at resolveModuleNamesWorker ([WILDCARD])
     at resolveModuleNamesReusingOldState ([WILDCARD]typescript.js:[WILDCARD])
     at processImportedModules ([WILDCARD]typescript.js:[WILDCARD])
+    at findSourceFile ([WILDCARD]typescript.js:[WILDCARD])

--- a/tests/error_006_import_ext_failure.ts.out
+++ b/tests/error_006_import_ext_failure.ts.out
@@ -3,9 +3,10 @@
     at DenoError ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendSync[WILDCARD] ([WILDCARD]dispatch_json.ts:[WILDCARD])
-    at fetchSourceFile ([WILDCARD]compiler.ts:[WILDCARD])
-    at _resolveModule ([WILDCARD]compiler.ts:[WILDCARD])
+    at fetchSourceFiles ([WILDCARD]compiler.ts:[WILDCARD])
+    at _resolveModules ([WILDCARD]compiler.ts:[WILDCARD])
     at [WILDCARD]compiler.ts:[WILDCARD]
     at resolveModuleNamesWorker ([WILDCARD])
     at resolveModuleNamesReusingOldState ([WILDCARD]typescript.js:[WILDCARD])
     at processImportedModules ([WILDCARD]typescript.js:[WILDCARD])
+    at findSourceFile ([WILDCARD]typescript.js:[WILDCARD])

--- a/tests/error_011_bad_module_specifier.ts.out
+++ b/tests/error_011_bad_module_specifier.ts.out
@@ -3,9 +3,10 @@
     at DenoError ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendSync[WILDCARD] ([WILDCARD]dispatch_json.ts:[WILDCARD])
-    at fetchSourceFile ([WILDCARD]compiler.ts:[WILDCARD])
-    at _resolveModule ([WILDCARD]compiler.ts:[WILDCARD])
+    at fetchSourceFiles ([WILDCARD]compiler.ts:[WILDCARD])
+    at _resolveModules ([WILDCARD]compiler.ts:[WILDCARD])
     at [WILDCARD]compiler.ts:[WILDCARD]
     at resolveModuleNamesWorker ([WILDCARD])
     at resolveModuleNamesReusingOldState ([WILDCARD]typescript.js:[WILDCARD])
     at processImportedModules ([WILDCARD]typescript.js:[WILDCARD])
+    at findSourceFile ([WILDCARD]typescript.js:[WILDCARD])

--- a/tests/error_012_bad_dynamic_import_specifier.ts.out
+++ b/tests/error_012_bad_dynamic_import_specifier.ts.out
@@ -3,9 +3,10 @@
     at DenoError ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendSync[WILDCARD] ([WILDCARD]dispatch_json.ts:[WILDCARD])
-    at fetchSourceFile ([WILDCARD]compiler.ts:[WILDCARD])
-    at _resolveModule ([WILDCARD]compiler.ts:[WILDCARD])
+    at fetchSourceFiles ([WILDCARD]compiler.ts:[WILDCARD])
+    at _resolveModules ([WILDCARD]compiler.ts:[WILDCARD])
     at [WILDCARD]compiler.ts:[WILDCARD]
     at resolveModuleNamesWorker ([WILDCARD])
     at resolveModuleNamesReusingOldState ([WILDCARD]typescript.js:[WILDCARD])
     at processImportedModules ([WILDCARD]typescript.js:[WILDCARD])
+    at findSourceFile ([WILDCARD]typescript.js:[WILDCARD])


### PR DESCRIPTION
Fixes #2626

A small change to the compiler that requests all imports from a file at once instead of doing N round trips. Still needs a bit of cleanup.

`master`
```
$ time deno -r fetch https://deno.land/std/testing/runner.ts
Download https://deno.land/std/testing/runner.ts
Compile https://deno.land/std/testing/runner.ts
Download https://deno.land/std/flags/mod.ts
Download https://deno.land/std/fs/mod.ts
Download https://deno.land/std/testing/mod.ts
Download https://deno.land/std/fs/empty_dir.ts
Download https://deno.land/std/fs/ensure_dir.ts
Download https://deno.land/std/fs/ensure_file.ts
Download https://deno.land/std/fs/ensure_link.ts
Download https://deno.land/std/fs/ensure_symlink.ts
Download https://deno.land/std/fs/exists.ts
Download https://deno.land/std/fs/glob.ts
Download https://deno.land/std/fs/globrex.ts
Download https://deno.land/std/fs/move.ts
Download https://deno.land/std/fs/copy.ts
Download https://deno.land/std/fs/read_file_str.ts
Download https://deno.land/std/fs/write_file_str.ts
Download https://deno.land/std/fs/read_json.ts
Download https://deno.land/std/fs/write_json.ts
Download https://deno.land/std/fs/walk.ts
Download https://deno.land/std/fs/eol.ts
Download https://deno.land/std/fs/utils.ts
Download https://deno.land/std/fs/path/mod.ts
Download https://deno.land/std/fs/path/win32.ts
Download https://deno.land/std/fs/path/posix.ts
Download https://deno.land/std/fs/path/constants.ts
Download https://deno.land/std/fs/path/interface.ts
Download https://deno.land/std/fs/path/utils.ts
Download https://deno.land/std/testing/asserts.ts
Download https://deno.land/std/fmt/colors.ts
Download https://deno.land/std/testing/diff.ts
Download https://deno.land/std/testing/format.ts

real	0m4.273s
user	0m2.615s
sys	0m0.310s
```

`this PR`
```
$ time target/release/deno -r fetch https://deno.land/std/testing/runner.ts
Download https://deno.land/std/testing/runner.ts
Compile https://deno.land/std/testing/runner.ts
Download https://deno.land/std/flags/mod.ts
Download https://deno.land/std/fs/mod.ts
Download https://deno.land/std/testing/mod.ts
Download https://deno.land/std/fs/empty_dir.ts
Download https://deno.land/std/fs/ensure_dir.ts
Download https://deno.land/std/fs/ensure_file.ts
Download https://deno.land/std/fs/ensure_link.ts
Download https://deno.land/std/fs/ensure_symlink.ts
Download https://deno.land/std/fs/exists.ts
Download https://deno.land/std/fs/glob.ts
Download https://deno.land/std/fs/globrex.ts
Download https://deno.land/std/fs/move.ts
Download https://deno.land/std/fs/copy.ts
Download https://deno.land/std/fs/read_file_str.ts
Download https://deno.land/std/fs/write_file_str.ts
Download https://deno.land/std/fs/read_json.ts
Download https://deno.land/std/fs/write_json.ts
Download https://deno.land/std/fs/walk.ts
Download https://deno.land/std/fs/eol.ts
Download https://deno.land/std/fs/utils.ts
Download https://deno.land/std/fs/path/mod.ts
Download https://deno.land/std/fs/path/win32.ts
Download https://deno.land/std/fs/path/posix.ts
Download https://deno.land/std/fs/path/constants.ts
Download https://deno.land/std/fs/path/interface.ts
Download https://deno.land/std/fs/path/utils.ts
Download https://deno.land/std/testing/asserts.ts
Download https://deno.land/std/fmt/colors.ts
Download https://deno.land/std/testing/diff.ts
Download https://deno.land/std/testing/format.ts

real	0m2.259s
user	0m2.494s
sys	0m0.250s
```

CC @ry @kitsonk 