### PR TITLE
fix: debug logging in runtime/compiler

### DIFF
--- a/js/util.ts
+++ b/js/util.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { TypedArray } from "./types.ts";
 import { window } from "./window.ts";
-const { console } = window;
 
 let logDebug = false;
 let logSource = "JS";
@@ -20,7 +19,9 @@ export function setLogDebug(debug: boolean, source?: string): void {
  */
 export function log(...args: unknown[]): void {
   if (logDebug) {
-    console.log(`DEBUG ${logSource} -`, ...args);
+    // if we destructure `console` off `window` too early, we don't bind to
+    // the right console, therefore we don't log anything out.
+    window.console.log(`DEBUG ${logSource} -`, ...args);
   }
 }
 


### PR DESCRIPTION
Fixes #2908 

Both debug logging in the runtime and the compiler were broken do to the `util.ts` binding to the `compiler` too early.  It was done as the modules are instantiated but at that point the runtime `console` instance won't be created.  So this patch restores the functionality that has been broken since we removed rollup.
