### PR TITLE
Fix type directive parsing

### DIFF
--- a/js/type_directives.ts
+++ b/js/type_directives.ts
@@ -39,9 +39,9 @@ const typeDirectiveRegEx = /@deno-types\s*=\s*(["'])((?:(?=(\\?))\3.)*?)\1/gi;
  *      import * as foo from "./foo.js"
  *      export { a, b, c } from "./bar.js"
  *
- * [See Diagram](https://bit.ly/2lK0izL)
+ * [See Diagram](http://bit.ly/2lOsp0K)
  */
-const importExportRegEx = /(?:import|export)\s+(?:[\s\S]*?from\s+)?(["'])((?:(?=(\\?))\3.)*?)\1/;
+const importExportRegEx = /(?:import|export)(?:\s+|\s+[\s\S]*?from\s+)?(["'])((?:(?=(\\?))\3.)*?)\1/;
 
 /** Parses out any Deno type directives that are part of the source code, or
  * returns `undefined` if there are not any.

--- a/tests/type_definitions.ts
+++ b/tests/type_definitions.ts
@@ -3,4 +3,8 @@ import { foo } from "./type_definitions/foo.js";
 // @deno-types="./type_definitions/fizz.d.ts"
 import "./type_definitions/fizz.js";
 
+import * as qat from "./type_definitions/qat.ts";
+
 console.log(foo);
+console.log(fizz);
+console.log(qat.qat);

--- a/tests/type_definitions.ts.out
+++ b/tests/type_definitions.ts.out
@@ -1,1 +1,3 @@
 [WILDCARD]foo
+fizz
+qat

--- a/tests/type_definitions/fizz.d.ts
+++ b/tests/type_definitions/fizz.d.ts
@@ -1,2 +1,2 @@
-/** An exported value. */
-export const fizz: string;
+/** A global value. */
+declare const fizz: string;

--- a/tests/type_definitions/fizz.js
+++ b/tests/type_definitions/fizz.js
@@ -1,1 +1,1 @@
-export const fizz = "fizz";
+globalThis.fizz = "fizz";

--- a/tests/type_definitions/qat.ts
+++ b/tests/type_definitions/qat.ts
@@ -1,0 +1,1 @@
+export const qat = "qat";


### PR DESCRIPTION
This fixes and issue where the regular expression was too greedy when looking for `import` statements.  For example if you had:

```ts
// @deno-types="./foo.d.ts"
import "./foo.js";

import * as bar from "./bar.ts";
```

The regex would cause `./foo.d.ts` to be substituted for `./bar.ts` instead of `./foo.js`.  This fix now properly parses the `import` statements so that `./food.d.ts` would be applied to `./foo.js` as expected.
