### PR TITLE
Rename ansi2colors

### DIFF
--- a/cli/colors.rs
+++ b/cli/colors.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-// TODO(ry) Rename this file to colors.rs
 // TODO(ry) Replace ansi_term with termcolor.
 use ansi_term::Color::Black;
 use ansi_term::Color::Fixed;

--- a/cli/deno_error.rs
+++ b/cli/deno_error.rs
@@ -299,7 +299,7 @@ impl GetErrorKind for dyn AnyError {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::ansi::strip_ansi_codes;
+  use crate::colors::strip_ansi_codes;
   use crate::diagnostics::Diagnostic;
   use crate::diagnostics::DiagnosticCategory;
   use crate::diagnostics::DiagnosticItem;

--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -191,7 +191,8 @@ impl DisplayFormatter for DiagnosticItem {
       _ => "".to_string(),
     };
 
-    let code = colors::bold(format!(" TS{}", self.code.to_string())).to_string();
+    let code =
+      colors::bold(format!(" TS{}", self.code.to_string())).to_string();
 
     format!("{}{}: ", category, code)
   }

--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 //! This module encodes TypeScript errors (diagnostics) into Rust structs and
 //! contains code for printing them to the console.
-use crate::ansi;
+use crate::colors;
 use crate::fmt_errors::format_maybe_source_line;
 use crate::fmt_errors::format_maybe_source_name;
 use crate::fmt_errors::DisplayFormatter;
@@ -183,7 +183,7 @@ impl DisplayFormatter for DiagnosticItem {
   fn format_category_and_code(&self) -> String {
     let category = match self.category {
       DiagnosticCategory::Error => {
-        format!("{}", ansi::red_bold("error".to_string()))
+        format!("{}", colors::red_bold("error".to_string()))
       }
       DiagnosticCategory::Warning => "warn".to_string(),
       DiagnosticCategory::Debug => "debug".to_string(),
@@ -191,7 +191,7 @@ impl DisplayFormatter for DiagnosticItem {
       _ => "".to_string(),
     };
 
-    let code = ansi::bold(format!(" TS{}", self.code.to_string())).to_string();
+    let code = colors::bold(format!(" TS{}", self.code.to_string())).to_string();
 
     format!("{}{}: ", category, code)
   }
@@ -340,7 +340,7 @@ impl From<i64> for DiagnosticCategory {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::ansi::strip_ansi_codes;
+  use crate::colors::strip_ansi_codes;
 
   fn diagnostic1() -> Diagnostic {
     Diagnostic {

--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 //! This mod provides DenoError to unify errors across Deno.
-use crate::ansi;
+use crate::colors;
 use crate::source_maps::apply_source_map;
 use crate::source_maps::SourceMapGetter;
 use deno::ErrBox;
@@ -20,9 +20,9 @@ pub trait DisplayFormatter {
 }
 
 fn format_source_name(script_name: String, line: i64, column: i64) -> String {
-  let script_name_c = ansi::cyan(script_name);
-  let line_c = ansi::yellow((1 + line).to_string());
-  let column_c = ansi::yellow((1 + column).to_string());
+  let script_name_c = colors::cyan(script_name);
+  let line_c = colors::yellow((1 + line).to_string());
+  let column_c = colors::yellow((1 + column).to_string());
   format!("{}:{}:{}", script_name_c, line_c, column_c,)
 }
 
@@ -65,10 +65,10 @@ pub fn format_maybe_source_line(
   assert!(start_column.is_some());
   assert!(end_column.is_some());
   let line = (1 + line_number.unwrap()).to_string();
-  let line_color = ansi::black_on_white(line.to_string());
+  let line_color = colors::black_on_white(line.to_string());
   let line_len = line.clone().len();
   let line_padding =
-    ansi::black_on_white(format!("{:indent$}", "", indent = line_len))
+    colors::black_on_white(format!("{:indent$}", "", indent = line_len))
       .to_string();
   let mut s = String::new();
   let start_column = start_column.unwrap();
@@ -89,9 +89,9 @@ pub fn format_maybe_source_line(
     }
   }
   let color_underline = if is_error {
-    ansi::red(s).to_string()
+    colors::red(s).to_string()
   } else {
-    ansi::cyan(s).to_string()
+    colors::cyan(s).to_string()
   };
 
   let indent = format!("{:indent$}", "", indent = level);
@@ -104,13 +104,13 @@ pub fn format_maybe_source_line(
 
 /// Format a message to preface with `error: ` with ansi codes for red.
 pub fn format_error_message(msg: String) -> String {
-  let preamble = ansi::red("error:".to_string());
+  let preamble = colors::red("error:".to_string());
   format!("{} {}", preamble, msg)
 }
 
 fn format_stack_frame(frame: &StackFrame) -> String {
   // Note when we print to string, we change from 0-indexed to 1-indexed.
-  let function_name = ansi::italic_bold(frame.function_name.clone());
+  let function_name = colors::italic_bold(frame.function_name.clone());
   let source_loc =
     format_source_name(frame.script_name.clone(), frame.line, frame.column);
 
@@ -159,7 +159,7 @@ impl DisplayFormatter for JSError {
   fn format_message(&self, _level: usize) -> String {
     format!(
       "{}{}",
-      ansi::red_bold("error: ".to_string()),
+      colors::red_bold("error: ".to_string()),
       self.0.message.clone()
     )
   }
@@ -218,7 +218,7 @@ impl Error for JSError {}
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::ansi::strip_ansi_codes;
+  use crate::colors::strip_ansi_codes;
 
   fn error1() -> V8Exception {
     V8Exception {

--- a/cli/integration_tests.rs
+++ b/cli/integration_tests.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use crate::ansi::strip_ansi_codes;
+use crate::colors::strip_ansi_codes;
 use os_pipe::pipe;
 use std::env;
 use std::io::Read;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -21,7 +21,7 @@ extern crate url;
 #[cfg(test)]
 mod integration_tests;
 
-mod ansi;
+mod colors;
 mod assets;
 pub mod compilers;
 pub mod deno_dir;
@@ -142,17 +142,17 @@ fn print_cache_info(worker: Worker) {
 
   println!(
     "{} {:?}",
-    ansi::bold("DENO_DIR location:".to_string()),
+    colors::bold("DENO_DIR location:".to_string()),
     state.dir.root
   );
   println!(
     "{} {:?}",
-    ansi::bold("Remote modules cache:".to_string()),
+    colors::bold("Remote modules cache:".to_string()),
     state.dir.deps_cache.location
   );
   println!(
     "{} {:?}",
-    ansi::bold("TypeScript compiler cache:".to_string()),
+    colors::bold("TypeScript compiler cache:".to_string()),
     state.dir.gen_cache.location
   );
 }
@@ -171,13 +171,13 @@ pub fn print_file_info(
     .and_then(|out| {
       println!(
         "{} {}",
-        ansi::bold("local:".to_string()),
+        colors::bold("local:".to_string()),
         out.filename.to_str().unwrap()
       );
 
       println!(
         "{} {}",
-        ansi::bold("type:".to_string()),
+        colors::bold("type:".to_string()),
         msg::enum_name_media_type(out.media_type)
       );
 
@@ -201,7 +201,7 @@ pub fn print_file_info(
 
             println!(
               "{} {}",
-              ansi::bold("compiled:".to_string()),
+              colors::bold("compiled:".to_string()),
               compiled_source_file.filename.to_str().unwrap(),
             );
           }
@@ -213,7 +213,7 @@ pub fn print_file_info(
           {
             println!(
               "{} {}",
-              ansi::bold("map:".to_string()),
+              colors::bold("map:".to_string()),
               source_map.filename.to_str().unwrap()
             );
           }
@@ -221,7 +221,7 @@ pub fn print_file_info(
           if let Some(deps) =
             worker.state.modules.lock().unwrap().deps(&compiled.name)
           {
-            println!("{}{}", ansi::bold("deps:\n".to_string()), deps.name);
+            println!("{}{}", colors::bold("deps:\n".to_string()), deps.name);
             if let Some(ref depsdeps) = deps.deps {
               for d in depsdeps {
                 println!("{}", d);
@@ -230,7 +230,7 @@ pub fn print_file_info(
           } else {
             println!(
               "{} cannot retrieve full dependency graph",
-              ansi::bold("deps:".to_string()),
+              colors::bold("deps:".to_string()),
             );
           }
           Ok(worker)

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -21,8 +21,8 @@ extern crate url;
 #[cfg(test)]
 mod integration_tests;
 
-mod colors;
 mod assets;
+mod colors;
 pub mod compilers;
 pub mod deno_dir;
 pub mod deno_error;

--- a/cli/ops/os.rs
+++ b/cli/ops/os.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 use super::dispatch_json::{Deserialize, JsonOp, Value};
-use crate::ansi;
+use crate::colors;
 use crate::fs as deno_fs;
 use crate::state::ThreadSafeState;
 use crate::version;
@@ -39,7 +39,7 @@ pub fn op_start(
     "v8Version": version::v8(),
     "denoVersion": version::DENO,
     "tsVersion": version::typescript(),
-    "noColor": !ansi::use_color(),
+    "noColor": !colors::use_color(),
     "xevalDelim": state.flags.xeval_delim.clone(),
     "os": BUILD_OS,
     "arch": BUILD_ARCH,


### PR DESCRIPTION
`````
diff --git a/cli/ansi.rs b/cli/colors.rs
--- a/cli/ansi.rs
+++ b/cli/colors.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-// TODO(ry) Rename this file to colors.rs
 // TODO(ry) Replace ansi_term with termcolor.
 use ansi_term::Color::Black;
 use ansi_term::Color::Fixed;
`````