### PR TITLE
minor cleanup

### DIFF
--- a/gclient_config.py
+++ b/gclient_config.py
@@ -31,12 +31,6 @@ solutions = [
     },
     {
         'url':
-        'https://chromium.googlesource.com/chromium/src/third_party/zlib@39b4a6260702da4c089eca57136abf40a39667e9',
-        'name':
-        'zlib'
-    },
-    {
-        'url':
         'https://github.com/cpplint/cpplint.git@a33992f68f36fcaa6d0f531a25012a4c474d3542',
         'name':
         'cpplint'

--- a/website/manual.md
+++ b/website/manual.md
@@ -229,12 +229,11 @@ git submodule update
 # Skip downloading binary build tools and point the build
 # to the system provided ones (for packagers of deno ...).
 export DENO_BUILD_ARGS="clang_base_path=/usr clang_use_chrome_plugins=false"
-export DENO_NO_BINARY_DOWNLOAD=1
-DENO_GN_PATH=/usr/bin/gn DENO_NINJA_PATH=/usr/bin/ninja cargo build
+DENO_NO_BINARY_DOWNLOAD=1 DENO_GN_PATH=/usr/bin/gn cargo build
 ```
 
 Environment variables: `DENO_BUILD_MODE`, `DENO_BUILD_PATH`, `DENO_BUILD_ARGS`,
-`DENO_DIR`, `DENO_GN_PATH`, `DENO_NINJA_PATH`, `DENO_NO_BINARY_DOWNLOAD`.
+`DENO_DIR`, `DENO_GN_PATH`, `DENO_NO_BINARY_DOWNLOAD`.
 
 ## API reference
 


### PR DESCRIPTION
This PR:
* removes the mention of `DENO_NINJA_PATH` from the manual since it got removed in #2950 because it was dead code after the `./tools/build.py`removal
* removes `zlib` from `gclient_config.py`(likely forgotten in #2958)