### PR TITLE
Remove some non-standard web API constructors

### DIFF
--- a/js/custom_event.ts
+++ b/js/custom_event.ts
@@ -7,22 +7,6 @@ import { getPrivateValue, requiredArguments } from "./util.ts";
 // https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/Guides/Contributor_s_Guide/Private_Properties#Using_WeakMaps
 export const customEventAttributes = new WeakMap();
 
-export class CustomEventInit extends event.EventInit
-  implements domTypes.CustomEventInit {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  detail: any;
-
-  constructor({
-    bubbles = false,
-    cancelable = false,
-    composed = false,
-    detail = null
-  }: domTypes.CustomEventInit) {
-    super({ bubbles, cancelable, composed });
-    this.detail = detail;
-  }
-}
-
 export class CustomEvent extends event.Event implements domTypes.CustomEvent {
   constructor(
     type: string,

--- a/js/custom_event_test.ts
+++ b/js/custom_event_test.ts
@@ -4,12 +4,12 @@ import { test, assertEquals } from "./test_util.ts";
 test(function customEventInitializedWithDetail(): void {
   const type = "touchstart";
   const detail = { message: "hello" };
-  const customEventDict = new CustomEventInit({
+  const customEventInit = {
     bubbles: true,
     cancelable: true,
     detail
-  });
-  const event = new CustomEvent(type, customEventDict);
+  } as CustomEventInit;
+  const event = new CustomEvent(type, customEventInit);
 
   assertEquals(event.bubbles, true);
   assertEquals(event.cancelable, true);

--- a/js/event.ts
+++ b/js/event.ts
@@ -10,18 +10,6 @@ function isTrusted(this: Event): boolean {
   return getPrivateValue(this, eventAttributes, "isTrusted");
 }
 
-export class EventInit implements domTypes.EventInit {
-  bubbles = false;
-  cancelable = false;
-  composed = false;
-
-  constructor({ bubbles = false, cancelable = false, composed = false } = {}) {
-    this.bubbles = bubbles;
-    this.cancelable = cancelable;
-    this.composed = composed;
-  }
-}
-
 export class Event implements domTypes.Event {
   // The default value is `false`.
   // Use `defineProperty` to define on each instance, NOT on the prototype.

--- a/js/event_target.ts
+++ b/js/event_target.ts
@@ -21,84 +21,6 @@ function getEventTargetParent(
   return null;
 }
 
-export class EventListenerOptions implements domTypes.EventListenerOptions {
-  _capture = false;
-
-  constructor({ capture = false } = {}) {
-    this._capture = capture;
-  }
-
-  get capture(): boolean {
-    return this._capture;
-  }
-}
-
-export class AddEventListenerOptions extends EventListenerOptions
-  implements domTypes.AddEventListenerOptions {
-  _passive = false;
-  _once = false;
-
-  constructor({ capture = false, passive = false, once = false } = {}) {
-    super({ capture });
-    this._passive = passive;
-    this._once = once;
-  }
-
-  get passive(): boolean {
-    return this._passive;
-  }
-
-  get once(): boolean {
-    return this._once;
-  }
-}
-
-export class EventListener implements domTypes.EventListener {
-  allEvents: domTypes.Event[] = [];
-  atEvents: domTypes.Event[] = [];
-  bubbledEvents: domTypes.Event[] = [];
-  capturedEvents: domTypes.Event[] = [];
-
-  private _callback: (event: domTypes.Event) => void | null;
-  private _options: boolean | domTypes.AddEventListenerOptions = false;
-
-  constructor(
-    callback: (event: domTypes.Event) => void | null,
-    options: boolean | domTypes.AddEventListenerOptions
-  ) {
-    this._callback = callback;
-    this._options = options;
-  }
-
-  public handleEvent(event: domTypes.Event): void {
-    this.allEvents.push(event);
-
-    switch (event.eventPhase) {
-      case domTypes.EventPhase.CAPTURING_PHASE:
-        this.capturedEvents.push(event);
-        break;
-      case domTypes.EventPhase.AT_TARGET:
-        this.atEvents.push(event);
-        break;
-      case domTypes.EventPhase.BUBBLING_PHASE:
-        this.bubbledEvents.push(event);
-        break;
-      default:
-        throw new Error("Unspecified event phase");
-    }
-
-    this._callback(event);
-  }
-
-  get callback(): (event: domTypes.Event) => void | null {
-    return this._callback;
-  }
-
-  get options(): domTypes.AddEventListenerOptions | boolean {
-    return this._options;
-  }
-}
-
 export const eventTargetAssignedSlot: unique symbol = Symbol();
 export const eventTargetHasActivationBehavior: unique symbol = Symbol();
 
@@ -148,7 +70,14 @@ export class EventTarget implements domTypes.EventTarget {
       }
     }
 
-    listeners[type].push(new EventListener(callback, normalizedOptions));
+    const eventTarget = this;
+    listeners[type].push({
+      callback,
+      options: normalizedOptions,
+      handleEvent(event: domTypes.Event): void {
+        this.callback.call(eventTarget, event);
+      }
+    } as domTypes.EventListener);
   }
 
   public removeEventListener(
@@ -487,7 +416,7 @@ const eventTargetHelpers = {
       }
 
       try {
-        if (listener.callback && typeof listener.handleEvent === "function") {
+        if (listener.callback) {
           listener.handleEvent(eventImpl);
         }
       } catch (error) {

--- a/js/event_target.ts
+++ b/js/event_target.ts
@@ -70,6 +70,7 @@ export class EventTarget implements domTypes.EventTarget {
       }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const eventTarget = this;
     listeners[type].push({
       callback,

--- a/js/event_test.ts
+++ b/js/event_test.ts
@@ -15,8 +15,8 @@ test(function eventInitializedWithType(): void {
 
 test(function eventInitializedWithTypeAndDict(): void {
   const init = "submit";
-  const eventInitDict = new EventInit({ bubbles: true, cancelable: true });
-  const event = new Event(init, eventInitDict);
+  const eventInit = { bubbles: true, cancelable: true } as EventInit;
+  const event = new Event(init, eventInit);
 
   assertEquals(event.isTrusted, false);
   assertEquals(event.target, null);
@@ -62,8 +62,8 @@ test(function eventPreventDefaultSuccess(): void {
   event.preventDefault();
   assertEquals(event.defaultPrevented, false);
 
-  const eventInitDict = new EventInit({ bubbles: true, cancelable: true });
-  const cancelableEvent = new Event(type, eventInitDict);
+  const eventInit = { bubbles: true, cancelable: true } as EventInit;
+  const cancelableEvent = new Event(type, eventInit);
   assertEquals(cancelableEvent.defaultPrevented, false);
   cancelableEvent.preventDefault();
   assertEquals(cancelableEvent.defaultPrevented, true);

--- a/js/globals.ts
+++ b/js/globals.ts
@@ -97,29 +97,26 @@ window.crypto = (csprng as unknown) as Crypto;
 // We have to export the type aliases, so that TypeScript _knows_ they are
 // being used, which it cannot statically determine within this module.
 window.Blob = blob.DenoBlob;
-export type Blob = blob.DenoBlob;
+export type Blob = domTypes.Blob;
 
 export type Body = domTypes.Body;
 
 window.File = domFile.DenoFile as domTypes.DomFileConstructor;
 export type File = domTypes.DomFile;
 
-window.CustomEventInit = customEvent.CustomEventInit;
-export type CustomEventInit = customEvent.CustomEventInit;
+export type CustomEventInit = domTypes.CustomEventInit;
 window.CustomEvent = customEvent.CustomEvent;
-export type CustomEvent = customEvent.CustomEvent;
-window.EventInit = event.EventInit;
-export type EventInit = event.EventInit;
+export type CustomEvent = domTypes.CustomEvent;
+export type EventInit = domTypes.EventInit;
 window.Event = event.Event;
-export type Event = event.Event;
-window.EventListener = eventTarget.EventListener;
-export type EventListener = eventTarget.EventListener;
+export type Event = domTypes.Event;
+export type EventListener = domTypes.EventListener;
 window.EventTarget = eventTarget.EventTarget;
-export type EventTarget = eventTarget.EventTarget;
+export type EventTarget = domTypes.EventTarget;
 window.URL = url.URL;
 export type URL = url.URL;
 window.URLSearchParams = urlSearchParams.URLSearchParams;
-export type URLSearchParams = urlSearchParams.URLSearchParams;
+export type URLSearchParams = domTypes.URLSearchParams;
 
 // Using the `as` keyword to use standard compliant interfaces as the Deno
 // implementations contain some implementation details we wouldn't want to

--- a/js/lib.deno_runtime.d.ts
+++ b/js/lib.deno_runtime.d.ts
@@ -1231,11 +1231,8 @@ declare interface Window {
   crypto: Crypto;
   Blob: typeof blob.DenoBlob;
   File: domTypes.DomFileConstructor;
-  CustomEventInit: typeof customEvent.CustomEventInit;
   CustomEvent: typeof customEvent.CustomEvent;
-  EventInit: typeof event.EventInit;
   Event: typeof event.Event;
-  EventListener: typeof eventTarget.EventListener;
   EventTarget: typeof eventTarget.EventTarget;
   URL: typeof url.URL;
   URLSearchParams: typeof urlSearchParams.URLSearchParams;
@@ -1312,17 +1309,17 @@ declare const removeEventListener: (
   options?: boolean | domTypes.EventListenerOptions | undefined
 ) => void;
 
-declare type Blob = blob.DenoBlob;
+declare type Blob = domTypes.Blob;
 declare type Body = domTypes.Body;
 declare type File = domTypes.DomFile;
-declare type CustomEventInit = customEvent.CustomEventInit;
-declare type CustomEvent = customEvent.CustomEvent;
-declare type EventInit = event.EventInit;
-declare type Event = event.Event;
-declare type EventListener = eventTarget.EventListener;
-declare type EventTarget = eventTarget.EventTarget;
+declare type CustomEventInit = domTypes.CustomEventInit;
+declare type CustomEvent = domTypes.CustomEvent;
+declare type EventInit = domTypes.EventInit;
+declare type Event = domTypes.Event;
+declare type EventListener = domTypes.EventListener;
+declare type EventTarget = domTypes.EventTarget;
 declare type URL = url.URL;
-declare type URLSearchParams = urlSearchParams.URLSearchParams;
+declare type URLSearchParams = domTypes.URLSearchParams;
 declare type Headers = domTypes.Headers;
 declare type FormData = domTypes.FormData;
 declare type TextEncoder = textEncoding.TextEncoder;


### PR DESCRIPTION
This removes the `EventListener`, `EventInit` and `CustomEventInit` constructors from the userland globals. The type exports stay.

I removed the internal classes as well. `EventListener`'s implementation seemed to be doing some bookkeeping on handled events but that's not being used anywhere so I assume it's old debug stuff. The other two are completely redundant.