### PR TITLE
Use shallow submodules, don't clone Typescript recursively

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -94,7 +94,7 @@ install:
   # Clone the third_party submodule.
   - ps: |-
       try {
-        Exec { & git submodule update --init --force --depth 1 }
+        Exec { & git submodule update --init --force --depth 1 --jobs 4 }
       } catch {
         # Git will fail if the `third_party` directory was restored from cache,
         # but the `.git/modules` directory wasn't. Rebuild it from scratch.

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,5 @@
 [submodule "typescript"]
 	path = deno_typescript/typescript
 	url = https://github.com/microsoft/TypeScript.git
+	fetchRecurseSubmodules = false
+	shallow = true


### PR DESCRIPTION
This should shave off just under 3 minutes from Travis CI build time.

Edit: Travis doesn't work; we can't control how Travis clones submodules (it always uses --recursive); we also can't run `git submodule update --init` manually because it would happen after restoring the caches, which includes some directories under //third_party, which then makes `git submodule update` fail.
But at least appveyor & local can be faster.