### PR TITLE
Utilise internal names for snapshot bundles

### DIFF
--- a/cli/source_maps.rs
+++ b/cli/source_maps.rs
@@ -407,7 +407,7 @@ mod tests {
     assert_eq!(actual.message, "TypeError: baz");
     // Because this is accessing the live bundle, this test might be more fragile
     assert_eq!(actual.frames.len(), 1);
-    assert!(actual.frames[0].script_name.ends_with("js/window.ts"));
+    assert!(actual.frames[0].script_name.ends_with("/window.ts"));
   }
 
   #[test]


### PR DESCRIPTION
This PR fixes the problem since moving to `deno_typescript` for bundling where the module specifiers were fully qualified filenames of the system where they were built, which wasn't a good situation.  This ensure that the bundle and source map are built in a way where any of the internal modules are represented in a consistent internal way.  For example for `deno run tests/error_004_missing_module.ts` we get the following error:

```
error: Uncaught NotFound: Cannot resolve module "file:///Users/kkelly/github/deno/tests/bad-module.ts"
► $deno$/dispatch_json.ts:40:11
    at DenoError ($deno$/errors.ts:20:5)
    at unwrapResponse ($deno$/dispatch_json.ts:40:11)
    at sendSync ($deno$/dispatch_json.ts:67:10)
    at fetchSourceFiles ($deno$/compiler.ts:145:15)
    at _resolveModules ($deno$/compiler.ts:278:25)
    at resolveModuleNames ($deno$/compiler.ts:423:17)
    at resolveModuleNamesWorker (typescript.js:91510:127)
    at resolveModuleNamesReusingOldState (typescript.js:91756:24)
    at processImportedModules (typescript.js:93095:35)
    at findSourceFile (typescript.js:92896:17)
```