### PR TITLE
test: add proxy tests

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -62,7 +62,9 @@ pub struct DenoFlags {
 
 static ENV_VARIABLES_HELP: &str = "ENVIRONMENT VARIABLES:
     DENO_DIR        Set deno's base directory
-    NO_COLOR        Set to disable color";
+    NO_COLOR        Set to disable color
+    HTTP_PROXY      Set proxy address for HTTP requests (module downloads, fetch)
+    HTTPS_PROXY     Set proxy address for HTTPS requests (module downloads, fetch)";
 
 fn add_run_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
   app

--- a/cli/tests/045_proxy_client.ts
+++ b/cli/tests/045_proxy_client.ts
@@ -3,8 +3,9 @@ async function main(): Promise<void> {
   const res = await fetch("http://deno.land/welcome.ts");
   console.log(`Response http: ${await res.text()}`);
 
-  const res1 = await fetch("https://deno.land/welcome.ts");
-  console.log(`Response https: ${await res1.text()}`);
+  // TODO:
+  // const res1 = await fetch("https://deno.land/welcome.ts");
+  // console.log(`Response https: ${await res1.text()}`);
 }
 
 main();

--- a/cli/tests/045_proxy_client.ts
+++ b/cli/tests/045_proxy_client.ts
@@ -2,10 +2,6 @@
 async function main(): Promise<void> {
   const res = await fetch("http://deno.land/welcome.ts");
   console.log(`Response http: ${await res.text()}`);
-
-  // TODO:
-  // const res1 = await fetch("https://deno.land/welcome.ts");
-  // console.log(`Response https: ${await res1.text()}`);
 }
 
 main();

--- a/cli/tests/045_proxy_client.ts
+++ b/cli/tests/045_proxy_client.ts
@@ -1,0 +1,10 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+async function main(): Promise<void> {
+  const res = await fetch("http://deno.land/welcome.ts");
+  console.log(`Response http: ${await res.text()}`);
+
+  const res1 = await fetch("https://deno.land/welcome.ts");
+  console.log(`Response https: ${await res1.text()}`);
+}
+
+main();

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -60,7 +60,6 @@ async function testModuleDownload(): Promise<void> {
     }
   });
 
-  await http.status();
   const httpStatus = await http.status();
   assertEquals(httpStatus.code, 0);
   http.close();

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../js/deps/https/deno.land/std/http/server.ts";
 import { assertEquals } from "../../js/deps/https/deno.land/std/testing/asserts.ts";
 
-const addr = Deno.args[1] || "127.0.0.1:4500";
+const addr = Deno.args[1] || "127.0.0.1:4555";
 
 async function proxyServer(): Promise<void> {
   const server = serve(addr);

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../js/deps/https/deno.land/std/http/server.ts";
 import { assertEquals } from "../../js/deps/https/deno.land/std/testing/asserts.ts";
 
-const addr = Deno.args[1] || "0.0.0.0:4555";
+const addr = Deno.args[1] || "127.0.0.1:4555";
 
 async function proxyServer(): Promise<void> {
   const server = serve(addr);

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../js/deps/https/deno.land/std/http/server.ts";
 import { assertEquals } from "../../js/deps/https/deno.land/std/testing/asserts.ts";
 
-const addr = Deno.args[1] || "127.0.0.1:4555";
+const addr = Deno.args[1] || "0.0.0.0:4555";
 
 async function proxyServer(): Promise<void> {
   const server = serve(addr);

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -1,0 +1,52 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import {
+  serve,
+  ServerRequest
+} from "../../js/deps/https/deno.land/std/http/server.ts";
+
+const addr = Deno.args[1] || "127.0.0.1:4500";
+
+async function proxyServer() {
+  const server = serve(addr);
+
+  console.log(`Proxy listening on http://${addr}/`);
+  for await (const req of server) {
+    proxyRequest(req);
+  }
+}
+
+async function proxyRequest(req: ServerRequest): Promise<void> {
+  console.log(`Proxying request to: ${req.url}`);
+  const resp = await fetch(req.url, {
+    method: req.method,
+    headers: req.headers
+  });
+  req.respond(resp);
+}
+
+async function main(): Promise<void> {
+  proxyServer();
+
+  const c = Deno.run({
+    args: [
+      Deno.execPath(),
+      "--no-prompt",
+      "--allow-net",
+      "cli/tests/045_proxy_client.ts"
+    ],
+    stdout: "piped",
+    env: {
+      HTTP_PROXY: `http://${addr}`,
+      HTTPS_PROXY: `http://${addr}`
+    }
+  });
+
+  console.log("before status");
+  await c.status();
+  console.log("AFTER status");
+  const clientOutput = await c.output();
+  console.log("Client output", clientOutput);
+  c.close();
+}
+
+main();

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -3,10 +3,9 @@ import {
   serve,
   ServerRequest
 } from "../../js/deps/https/deno.land/std/http/server.ts";
-import { assertEquals } from "../../js/deps/https/deno.land/std/testing/asserts";
+import { assertEquals } from "../../js/deps/https/deno.land/std/testing/asserts.ts";
 
 const addr = Deno.args[1] || "127.0.0.1:4500";
-const decoder = new TextDecoder();
 
 async function proxyServer() {
   const server = serve(addr);
@@ -37,8 +36,7 @@ async function testFetch() {
     ],
     stdout: "piped",
     env: {
-      HTTP_PROXY: `http://${addr}`,
-      HTTPS_PROXY: `http://${addr}`
+      HTTP_PROXY: `http://${addr}`
     }
   });
 
@@ -66,26 +64,6 @@ async function testModuleDownload() {
   const httpStatus = await http.status();
   assertEquals(httpStatus.code, 0);
   http.close();
-
-  // TODO:
-  // const https = Deno.run({
-  //   args: [
-  //     Deno.execPath(),
-  //     "--no-prompt",
-  //     "--reload",
-  //     "fetch",
-  //     "https://deno.land/welcome.ts"
-  //   ],
-  //   stdout: "piped",
-  //   env: {
-  //     HTTPS_PROXY: `http://${addr}`
-  //   }
-  // });
-  //
-  // await https.status();
-  // const httpsStatus = await https.status();
-  // assertEquals(httpsStatus.code, 0);
-  // https.close();
 }
 
 async function main(): Promise<void> {

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -7,7 +7,7 @@ import { assertEquals } from "../../js/deps/https/deno.land/std/testing/asserts.
 
 const addr = Deno.args[1] || "127.0.0.1:4500";
 
-async function proxyServer() {
+async function proxyServer(): Promise<void> {
   const server = serve(addr);
 
   console.log(`Proxy server listening on http://${addr}/`);
@@ -25,7 +25,7 @@ async function proxyRequest(req: ServerRequest): Promise<void> {
   req.respond(resp);
 }
 
-async function testFetch() {
+async function testFetch(): Promise<void> {
   const c = Deno.run({
     args: [
       Deno.execPath(),
@@ -45,7 +45,7 @@ async function testFetch() {
   c.close();
 }
 
-async function testModuleDownload() {
+async function testModuleDownload(): Promise<void> {
   const http = Deno.run({
     args: [
       Deno.execPath(),

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -32,7 +32,7 @@ async function testFetch(): Promise<void> {
       "--no-prompt",
       "--reload",
       "--allow-net",
-      "cli/tests/045_proxy_client.ts"
+      "045_proxy_client.ts"
     ],
     stdout: "piped",
     env: {

--- a/cli/tests/045_proxy_test.ts.out
+++ b/cli/tests/045_proxy_test.ts.out
@@ -1,5 +1,3 @@
 Proxy server listening on http://127.0.0.1:4500/
 Proxy request to: http://deno.land/welcome.ts
-Proxy request to: https://deno.land/welcome.ts
 Proxy request to: http://deno.land/welcome.ts
-Proxy request to: https://deno.land/welcome.ts

--- a/cli/tests/045_proxy_test.ts.out
+++ b/cli/tests/045_proxy_test.ts.out
@@ -1,5 +1,5 @@
-Proxy listening on http://127.0.0.1:4500/
-Proxying request to: http://deno.land/welcome.ts
-Proxying request to: deno.land:443
-Response http: console.log("Welcome to Deno 🦕");
-Response https: console.log("Welcome to Deno 🦕");
+Proxy server listening on http://127.0.0.1:4500/
+Proxy request to: http://deno.land/welcome.ts
+Proxy request to: https://deno.land/welcome.ts
+Proxy request to: http://deno.land/welcome.ts
+Proxy request to: https://deno.land/welcome.ts

--- a/cli/tests/045_proxy_test.ts.out
+++ b/cli/tests/045_proxy_test.ts.out
@@ -1,3 +1,3 @@
-Proxy server listening on http://127.0.0.1:4500/
+Proxy server listening on [WILDCARD]
 Proxy request to: http://deno.land/welcome.ts
 Proxy request to: http://deno.land/welcome.ts

--- a/cli/tests/045_proxy_test.ts.out
+++ b/cli/tests/045_proxy_test.ts.out
@@ -1,0 +1,5 @@
+Proxy listening on http://127.0.0.1:4500/
+Proxying request to: http://deno.land/welcome.ts
+Proxying request to: deno.land:443
+Response http: console.log("Welcome to Deno 🦕");
+Response https: console.log("Welcome to Deno 🦕");

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -304,6 +304,12 @@ itest!(_042_dyn_import_evalcontext {
   output: "042_dyn_import_evalcontext.ts.out",
 });
 
+itest!(_045_proxy {
+  args: "run --allow-read --reload 045_proxy_test.ts",
+  output: "tests/045_proxy_test.ts.out",
+  check_stderr: true,
+});
+
 itest!(async_error {
   exit_code: 1,
   args: "run --reload async_error.ts",

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -305,7 +305,7 @@ itest!(_042_dyn_import_evalcontext {
 });
 
 itest!(_045_proxy {
-  args: "run --allow-net --allow-env --reload 045_proxy_test.ts",
+  args: "run --allow-net --allow-env --allow-run --reload 045_proxy_test.ts",
   output: "tests/045_proxy_test.ts.out",
 });
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -305,9 +305,8 @@ itest!(_042_dyn_import_evalcontext {
 });
 
 itest!(_045_proxy {
-  args: "run --allow-read --reload 045_proxy_test.ts",
+  args: "run --allow-net --allow-env --reload 045_proxy_test.ts",
   output: "tests/045_proxy_test.ts.out",
-  check_stderr: true,
 });
 
 itest!(async_error {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -306,7 +306,7 @@ itest!(_042_dyn_import_evalcontext {
 
 itest!(_045_proxy {
   args: "run --allow-net --allow-env --allow-run --reload 045_proxy_test.ts",
-  output: "tests/045_proxy_test.ts.out",
+  output: "045_proxy_test.ts.out",
 });
 
 itest!(async_error {

--- a/website/manual.md
+++ b/website/manual.md
@@ -712,6 +712,8 @@ SUBCOMMANDS:
 ENVIRONMENT VARIABLES:
     DENO_DIR        Set deno's base directory
     NO_COLOR        Set to disable color
+    HTTP_PROXY      Set proxy address for HTTP requests (module downloads, fetch)
+    HTTPS_PROXY     Set proxy address for HTTPS requests (module downloads, fetch)
 ```
 
 ### Environmental variables

--- a/website/manual.md
+++ b/website/manual.md
@@ -876,13 +876,11 @@ $ deno install awesome_cli https://example.com/awesome/cli.ts
 
 ## Proxies
 
-Deno supports proxies.
+Deno supports proxies for module downloads and `fetch` API.
 
-`HTTP_PROXY` and `HTTPS_PROXY` environmental variables are used to configure
-them.
+Proxy configuration is read from environmental variables: `HTTP_PROXY` and `HTTPS_PROXY`. 
 
-For Windows if environmental variables are not found Deno will fall back to
-reading proxies from registry.
+In case of Windows if environmental variables are not found Deno falls back to reading proxies from registry.
 
 ## Import maps
 

--- a/website/manual.md
+++ b/website/manual.md
@@ -878,9 +878,11 @@ $ deno install awesome_cli https://example.com/awesome/cli.ts
 
 Deno supports proxies for module downloads and `fetch` API.
 
-Proxy configuration is read from environmental variables: `HTTP_PROXY` and `HTTPS_PROXY`. 
+Proxy configuration is read from environmental variables: `HTTP_PROXY` and
+`HTTPS_PROXY`.
 
-In case of Windows if environmental variables are not found Deno falls back to reading proxies from registry.
+In case of Windows if environmental variables are not found Deno falls back to
+reading proxies from registry.
 
 ## Import maps
 


### PR DESCRIPTION
Closes #2873 

- `http`
   - [x] `fetch`
   - [x] module fetching
- [x] update `manual.html`

EDIT:
I removed todo to test `https` proxy as we don't support `https` very well in `deno_std` server.
Eg, for example proxying request to `https://deno.land/welcome.ts:
```
deno_dev -A cli/tests/045_proxy_test.ts
Proxy server listening on http://127.0.0.1:4500/
CONNECT deno.land:443 HTTP/1.1
Proxy request to: deno.land:443
url deno.land:443
url_ deno.land:443 deno.land
error: Uncaught HttpOther: deno.land:443: URL scheme is not allowed
► file:///Users/biwanczuk/dev/deno/js/dispatch_json.ts:40:11
    at DenoError (file:///Users/biwanczuk/dev/deno/js/errors.ts:20:5)
    at unwrapResponse (file:///Users/biwanczuk/dev/deno/js/dispatch_json.ts:40:11)
    at sendAsync (file:///Users/biwanczuk/dev/deno/js/dispatch_json.ts:85:10)
```
We should be proxying to `https://deno.land/welcome.ts` but we receive `deno.land:443` url in `ServerRequest`. Correct me if I'm wrong and it can be somehow done