### PR TITLE
Make `window` compatible with ts 3.6

### DIFF
--- a/cli/tests/types.out
+++ b/cli/tests/types.out
@@ -10,5 +10,5 @@ declare interface Window {
   Deno: typeof Deno;
 }
 
-declare const window: Window;
+declare const window: Window & typeof globalThis;
 [WILDCARD]

--- a/js/globals_test.ts
+++ b/js/globals_test.ts
@@ -14,7 +14,6 @@ test(function windowWindowExists(): void {
 });
 
 test(function globalThisEqualsWindow(): void {
-  // @ts-ignore (TypeScript thinks globalThis and window don't match)
   assert(globalThis === window);
 });
 

--- a/js/lib.deno_runtime.d.ts
+++ b/js/lib.deno_runtime.d.ts
@@ -1217,7 +1217,7 @@ declare namespace Deno {
 // @url js/globals.ts
 
 declare interface Window {
-  window: Window;
+  window: Window & typeof globalThis;
   atob: typeof textEncoding.atob;
   btoa: typeof textEncoding.btoa;
   fetch: typeof fetchTypes.fetch;
@@ -1263,7 +1263,7 @@ declare interface Window {
   Deno: typeof Deno;
 }
 
-declare const window: Window;
+declare const window: Window & typeof globalThis;
 declare const atob: typeof textEncoding.atob;
 declare const btoa: typeof textEncoding.btoa;
 declare const fetch: typeof fetchTypes.fetch;


### PR DESCRIPTION
see https://github.com/microsoft/TypeScript/pull/32335

https://devblogs.microsoft.com/typescript/announcing-typescript-3-6/#dom-updates

> The global `window` is no longer defined as type `Window` – instead, it is defined as type `Window & typeof globalThis`. In some cases, it may be better to refer to its type as `typeof window`.

fixed #2669