### PR TITLE
Introduce old program

### DIFF
--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -256,6 +256,7 @@ pub fn get_asset(name: &str) -> Option<&'static str> {
     "lib.es2019.symbol.d.ts" => inc!("lib.es2019.symbol.d.ts"),
     "lib.esnext.bigint.d.ts" => inc!("lib.esnext.bigint.d.ts"),
     "lib.esnext.intl.d.ts" => inc!("lib.esnext.intl.d.ts"),
+    "main.ts" => Some("export {};\n\nDeno;\n"),
     _ => None,
   }
 }


### PR DESCRIPTION
@ry @bartlomieju the discussion of how to [warm up the compiler](https://github.com/denoland/deno/issues/2789#issuecomment-527203962) for snapshotting has been an objective for a while to see if it improves the performance.  This PR is an example of how we can do that, the problem I have is that it requires loading all of the assets from Rust, which requires a couple of ops to be available while snapshotting and that is where my brain stopped quickly working.

Sharing so we can see if there would be an easy way to solve this.  Once we have generated an `oldProgram`, when we kick off the compiler, it will already have all the supporting libs in memory and parsed.