### PR TITLE
feat: Minimal op registration in isolate

### DIFF
--- a/core/examples/http_bench.js
+++ b/core/examples/http_bench.js
@@ -1,6 +1,7 @@
 // This is not a real HTTP server. We read blindly one time into 'requestBuf',
 // then write this fixed 'responseBuf'. The point of this benchmark is to
 // exercise the event loop in a simple yet semi-realistic way.
+Deno.core.refreshOpsMap();
 const OP_LISTEN = Deno.core.opsMap["listen"];
 const OP_ACCEPT = Deno.core.opsMap["accept"];
 const OP_READ = Deno.core.opsMap["read"];

--- a/core/examples/http_bench.js
+++ b/core/examples/http_bench.js
@@ -75,12 +75,12 @@ function handleAsyncMsgFromRust(opId, buf) {
 
 /** Listens on 0.0.0.0:4500, returns rid. */
 function listen() {
-  return sendSync(Deno.core.ops.get("listen"), -1);
+  return sendSync(ops["listen"], -1);
 }
 
 /** Accepts a connection, returns rid. */
 async function accept(rid) {
-  return await sendAsync(Deno.core.ops.get("accept"), rid);
+  return await sendAsync(ops["accept"], rid);
 }
 
 /**
@@ -88,16 +88,16 @@ async function accept(rid) {
  * Returns bytes read.
  */
 async function read(rid, data) {
-  return await sendAsync(Deno.core.ops.get("read"), rid, data);
+  return await sendAsync(ops["read"], rid, data);
 }
 
 /** Writes a fixed HTTP response to the socket rid. Returns bytes written. */
 async function write(rid, data) {
-  return await sendAsync(Deno.core.ops.get("write"), rid, data);
+  return await sendAsync(ops["write"], rid, data);
 }
 
 function close(rid) {
-  return sendSync(Deno.core.ops.get("close"), rid);
+  return sendSync(ops["close"], rid);
 }
 
 async function serve(rid) {
@@ -115,9 +115,11 @@ async function serve(rid) {
   close(rid);
 }
 
+let ops;
+
 async function main() {
   Deno.core.setAsyncHandler(handleAsyncMsgFromRust);
-  Deno.core.ops.init();
+  ops = Deno.core.ops();
 
   Deno.core.print("http_bench.js start\n");
 

--- a/core/examples/http_bench.js
+++ b/core/examples/http_bench.js
@@ -75,12 +75,12 @@ function handleAsyncMsgFromRust(opId, buf) {
 
 /** Listens on 0.0.0.0:4500, returns rid. */
 function listen() {
-  return sendSync(Deno.core.ops["listen"], -1);
+  return sendSync(Deno.core.ops.get("listen"), -1);
 }
 
 /** Accepts a connection, returns rid. */
 async function accept(rid) {
-  return await sendAsync(Deno.core.ops["accept"], rid);
+  return await sendAsync(Deno.core.ops.get("accept"), rid);
 }
 
 /**
@@ -88,16 +88,16 @@ async function accept(rid) {
  * Returns bytes read.
  */
 async function read(rid, data) {
-  return await sendAsync(Deno.core.ops["read"], rid, data);
+  return await sendAsync(Deno.core.ops.get("read"), rid, data);
 }
 
 /** Writes a fixed HTTP response to the socket rid. Returns bytes written. */
 async function write(rid, data) {
-  return await sendAsync(Deno.core.ops["write"], rid, data);
+  return await sendAsync(Deno.core.ops.get("write"), rid, data);
 }
 
 function close(rid) {
-  return sendSync(Deno.core.ops["close"], rid);
+  return sendSync(Deno.core.ops.get("close"), rid);
 }
 
 async function serve(rid) {
@@ -117,7 +117,7 @@ async function serve(rid) {
 
 async function main() {
   Deno.core.setAsyncHandler(handleAsyncMsgFromRust);
-  Deno.core.initOps();
+  Deno.core.ops.init();
 
   Deno.core.print("http_bench.js start\n");
 

--- a/core/examples/http_bench.js
+++ b/core/examples/http_bench.js
@@ -164,7 +164,7 @@ async function main() {
     const op = opRegistry.get(name);
 
     if (!op) {
-      continue;
+      throw new Error(`Unknown op: ${name}`);
     }
 
     op.setOpId(opId);

--- a/core/examples/http_bench.js
+++ b/core/examples/http_bench.js
@@ -150,6 +150,8 @@ async function serve(rid) {
 
 async function main() {
   Deno.core.setAsyncHandler(HttpOp.handleAsyncMsgFromRust);
+  // Initialize ops by getting their ids from Rust
+  // and assign id for each of our ops.
   const opsMap = Deno.core.getOps();
   for (const [name, opId] of Object.entries(opsMap)) {
     const op = registry[name];

--- a/core/examples/http_bench.js
+++ b/core/examples/http_bench.js
@@ -1,19 +1,7 @@
 // This is not a real HTTP server. We read blindly one time into 'requestBuf',
 // then write this fixed 'responseBuf'. The point of this benchmark is to
 // exercise the event loop in a simple yet semi-realistic way.
-class Op {
-  constructor(name) {
-    this.name = name;
-    this.opId = 0;
-    Deno.core.registerOp(this);
-  }
-
-  setOpId(opId) {
-    this.opId = opId;
-  }
-}
-
-class HttpOp extends Op {
+class HttpOp extends Deno.core.Op {
   static handleAsyncMsgFromRust(opId, buf) {
     const record = recordFromBuf(buf);
     const { promiseId, result } = record;

--- a/core/examples/http_bench.js
+++ b/core/examples/http_bench.js
@@ -38,13 +38,11 @@ class Op {
     p.resolve(record);
   }
 
-  /** Returns i32 number */
   static sendSync(opId, arg, zeroCopy) {
     const buf = send(0, opId, arg, zeroCopy);
     return recordFromBuf(buf);
   }
 
-  /** Returns Promise<number> */
   static sendAsync(opId, arg, zeroCopy = null) {
     const promiseId = nextPromiseId++;
     const p = createResolvable();
@@ -55,11 +53,13 @@ class Op {
 }
 
 class HttpOp extends Op {
+  /** Returns i32 number */
   sendSync(arg, zeroCopy = null) {
     const res = HttpOp.sendSync(this.opId, arg, zeroCopy);
     return res.result;
   }
 
+  /** Returns Promise<number> */
   async sendAsync(arg, zeroCopy = null) {
     const res = await HttpOp.sendAsync(this.opId, arg, zeroCopy);
     return res.result;

--- a/core/examples/http_bench.js
+++ b/core/examples/http_bench.js
@@ -3,19 +3,7 @@
 // exercise the event loop in a simple yet semi-realistic way.
 const registry = {};
 
-function initOps(opsMap) {
-  for (const [name, opId] of Object.entries(opsMap)) {
-    const op = registry[name];
-
-    if (!op) {
-      continue;
-    }
-
-    op.setOpId(opId);
-  }
-}
-
-class Op {
+class HttpOp {
   constructor(name) {
     if (typeof registry[name] !== "undefined") {
       throw new Error(`Duplicate op: ${name}`);
@@ -50,9 +38,7 @@ class Op {
     send(promiseId, opId, arg, zeroCopy);
     return p;
   }
-}
 
-class HttpOp extends Op {
   /** Returns i32 number */
   sendSync(arg, zeroCopy = null) {
     const res = HttpOp.sendSync(this.opId, arg, zeroCopy);
@@ -163,8 +149,18 @@ async function serve(rid) {
 }
 
 async function main() {
-  Deno.core.setAsyncHandler(Op.handleAsyncMsgFromRust);
-  initOps(Deno.core.getOps());
+  Deno.core.setAsyncHandler(HttpOp.handleAsyncMsgFromRust);
+  const opsMap = Deno.core.getOps();
+  for (const [name, opId] of Object.entries(opsMap)) {
+    const op = registry[name];
+
+    if (!op) {
+      continue;
+    }
+
+    op.setOpId(opId);
+  }
+
   Deno.core.print("http_bench.js start\n");
 
   const listenerRid = listen();

--- a/core/examples/http_bench.js
+++ b/core/examples/http_bench.js
@@ -1,11 +1,12 @@
 // This is not a real HTTP server. We read blindly one time into 'requestBuf',
 // then write this fixed 'responseBuf'. The point of this benchmark is to
 // exercise the event loop in a simple yet semi-realistic way.
+// TODO: sync these ops via `Deno.core.ops`;
 const OP_LISTEN = 1;
 const OP_ACCEPT = 2;
 const OP_READ = 3;
 const OP_WRITE = 4;
-const OP_CLOSE = 5;
+const OP_CLOSE = 0;
 const requestBuf = new Uint8Array(64 * 1024);
 const responseBuf = new Uint8Array(
   "HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\nHello World\n"

--- a/core/examples/http_bench.rs
+++ b/core/examples/http_bench.rs
@@ -36,12 +36,6 @@ impl log::Log for Logger {
   fn flush(&self) {}
 }
 
-const OP_LISTEN: OpId = 1;
-const OP_ACCEPT: OpId = 2;
-const OP_READ: OpId = 3;
-const OP_WRITE: OpId = 4;
-const OP_CLOSE: OpId = 5;
-
 #[derive(Clone, Debug, PartialEq)]
 pub struct Record {
   pub promise_id: i32,
@@ -106,65 +100,46 @@ fn test_record_from() {
 
 pub type HttpBenchOp = dyn Future<Item = i32, Error = std::io::Error> + Send;
 
-fn dispatch(
-  op_id: OpId,
-  control: &[u8],
+pub type HttpBenchOpHandler = fn(
+  is_sync: bool,
+  record: Record,
   zero_copy_buf: Option<PinnedBuf>,
-) -> CoreOp {
-  let record = Record::from(control);
-  let is_sync = record.promise_id == 0;
-  let http_bench_op = match op_id {
-    OP_LISTEN => {
-      assert!(is_sync);
-      op_listen()
-    }
-    OP_CLOSE => {
-      assert!(is_sync);
-      let rid = record.arg;
-      op_close(rid)
-    }
-    OP_ACCEPT => {
-      assert!(!is_sync);
-      let listener_rid = record.arg;
-      op_accept(listener_rid)
-    }
-    OP_READ => {
-      assert!(!is_sync);
-      let rid = record.arg;
-      op_read(rid, zero_copy_buf)
-    }
-    OP_WRITE => {
-      assert!(!is_sync);
-      let rid = record.arg;
-      op_write(rid, zero_copy_buf)
-    }
-    _ => panic!("bad op {}", op_id),
-  };
-  let mut record_a = record.clone();
-  let mut record_b = record.clone();
+) -> Box<HttpBenchOp>;
 
-  let fut = Box::new(
-    http_bench_op
-      .and_then(move |result| {
-        record_a.result = result;
-        Ok(record_a)
-      })
-      .or_else(|err| -> Result<Record, ()> {
-        eprintln!("unexpected err {}", err);
-        record_b.result = -1;
-        Ok(record_b)
-      })
-      .then(|result| -> Result<Buf, ()> {
-        let record = result.unwrap();
-        Ok(record.into())
-      }),
-  );
+fn serialize_http_bench_op(handler: HttpBenchOpHandler) -> Box<CoreOpHandler> {
+  let serialized_op =
+    move |control: &[u8], zero_copy_buf: Option<PinnedBuf>| -> CoreOp {
+      let record = Record::from(control);
+      let is_sync = record.promise_id == 0;
+      let op = handler(is_sync, record.clone(), zero_copy_buf);
 
-  if is_sync {
-    Op::Sync(fut.wait().unwrap())
-  } else {
-    Op::Async(fut)
-  }
+      let mut record_a = record.clone();
+      let mut record_b = record.clone();
+
+      let fut = Box::new(
+        op.and_then(move |result| {
+          record_a.result = result;
+          Ok(record_a)
+        })
+        .or_else(|err| -> Result<Record, ()> {
+          eprintln!("unexpected err {}", err);
+          record_b.result = -1;
+          Ok(record_b)
+        })
+        .then(|result| -> Result<Buf, ()> {
+          let record = result.unwrap();
+          Ok(record.into())
+        }),
+      );
+
+      if is_sync {
+        Op::Sync(fut.wait().unwrap())
+      } else {
+        Op::Async(fut)
+      }
+    };
+
+  Box::new(serialized_op)
 }
 
 fn main() {
@@ -181,7 +156,11 @@ fn main() {
     });
 
     let mut isolate = deno::Isolate::new(startup_data, false);
-    isolate.set_dispatch(dispatch);
+    isolate.register_op("close", serialize_http_bench_op(op_close));
+    isolate.register_op("listen", serialize_http_bench_op(op_listen));
+    isolate.register_op("accept", serialize_http_bench_op(op_accept));
+    isolate.register_op("read", serialize_http_bench_op(op_read));
+    isolate.register_op("write", serialize_http_bench_op(op_write));
 
     isolate.then(|r| {
       js_check(r);
@@ -225,7 +204,13 @@ fn new_rid() -> i32 {
   rid as i32
 }
 
-fn op_accept(listener_rid: i32) -> Box<HttpBenchOp> {
+fn op_accept(
+  is_sync: bool,
+  record: Record,
+  _zero_copy_buf: Option<PinnedBuf>,
+) -> Box<HttpBenchOp> {
+  assert!(!is_sync);
+  let listener_rid = record.arg;
   debug!("accept {}", listener_rid);
   Box::new(
     futures::future::poll_fn(move || {
@@ -248,9 +233,13 @@ fn op_accept(listener_rid: i32) -> Box<HttpBenchOp> {
   )
 }
 
-fn op_listen() -> Box<HttpBenchOp> {
+fn op_listen(
+  is_sync: bool,
+  _record: Record,
+  _zero_copy_buf: Option<PinnedBuf>,
+) -> Box<HttpBenchOp> {
+  assert!(is_sync);
   debug!("listen");
-
   Box::new(lazy(move || {
     let addr = "127.0.0.1:4544".parse::<SocketAddr>().unwrap();
     let listener = tokio::net::TcpListener::bind(&addr).unwrap();
@@ -262,8 +251,14 @@ fn op_listen() -> Box<HttpBenchOp> {
   }))
 }
 
-fn op_close(rid: i32) -> Box<HttpBenchOp> {
+fn op_close(
+  is_sync: bool,
+  record: Record,
+  _zero_copy_buf: Option<PinnedBuf>,
+) -> Box<HttpBenchOp> {
+  assert!(is_sync);
   debug!("close");
+  let rid = record.arg;
   Box::new(lazy(move || {
     let mut table = RESOURCE_TABLE.lock().unwrap();
     let r = table.remove(&rid);
@@ -272,7 +267,13 @@ fn op_close(rid: i32) -> Box<HttpBenchOp> {
   }))
 }
 
-fn op_read(rid: i32, zero_copy_buf: Option<PinnedBuf>) -> Box<HttpBenchOp> {
+fn op_read(
+  is_sync: bool,
+  record: Record,
+  zero_copy_buf: Option<PinnedBuf>,
+) -> Box<HttpBenchOp> {
+  assert!(!is_sync);
+  let rid = record.arg;
   debug!("read rid={}", rid);
   let mut zero_copy_buf = zero_copy_buf.unwrap();
   Box::new(
@@ -293,7 +294,13 @@ fn op_read(rid: i32, zero_copy_buf: Option<PinnedBuf>) -> Box<HttpBenchOp> {
   )
 }
 
-fn op_write(rid: i32, zero_copy_buf: Option<PinnedBuf>) -> Box<HttpBenchOp> {
+fn op_write(
+  is_sync: bool,
+  record: Record,
+  zero_copy_buf: Option<PinnedBuf>,
+) -> Box<HttpBenchOp> {
+  assert!(!is_sync);
+  let rid = record.arg;
   debug!("write rid={}", rid);
   let zero_copy_buf = zero_copy_buf.unwrap();
   Box::new(

--- a/core/examples/http_bench.rs
+++ b/core/examples/http_bench.rs
@@ -156,11 +156,11 @@ fn main() {
     });
 
     let mut isolate = deno::Isolate::new(startup_data, false);
-    isolate.register_op("close", serialize_http_bench_op(op_close));
     isolate.register_op("listen", serialize_http_bench_op(op_listen));
     isolate.register_op("accept", serialize_http_bench_op(op_accept));
     isolate.register_op("read", serialize_http_bench_op(op_read));
     isolate.register_op("write", serialize_http_bench_op(op_write));
+    isolate.register_op("close", serialize_http_bench_op(op_close));
 
     isolate.then(|r| {
       js_check(r);

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -250,7 +250,10 @@ impl Isolate {
   ///
   /// Ops added using this method are only usable if `dispatch` is not set
   /// (using `set_dispatch` method).
-  pub fn register_op(&mut self, name: &str, op: Box<CoreOpHandler>) -> OpId {
+  pub fn register_op<F>(&mut self, name: &str, op: F) -> OpId
+  where
+    F: Fn(&[u8], Option<PinnedBuf>) -> CoreOp + Send + Sync + 'static,
+  {
     assert!(
       self.dispatch.is_none(),
       "set_dispatch should not be used in conjunction with register_op"

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -234,6 +234,9 @@ impl Isolate {
   /// Defines the how Deno.core.dispatch() acts.
   /// Called whenever Deno.core.dispatch() is called in JavaScript. zero_copy_buf
   /// corresponds to the second argument of Deno.core.dispatch().
+  ///
+  /// If this method is used then ops registered using `op_register` function are
+  /// ignored and all dispatching must be handled manually in provided callback.
   pub fn set_dispatch<F>(&mut self, f: F)
   where
     F: Fn(OpId, &[u8], Option<PinnedBuf>) -> CoreOp + Send + Sync + 'static,
@@ -251,6 +254,10 @@ impl Isolate {
     control: &[u8],
     zero_copy_buf: Option<PinnedBuf>,
   ) -> CoreOp {
+    // TODO: see TODO in `core/ops.rs` to handle this op via public API
+    // Op with id 0 has special meaning - it's special op that is
+    // always provided to retrieve op id map.
+    // Op id map consists of name to `OpId` mappings.
     if op_id == 0 {
       let op_map = self.op_registry.get_op_map();
       let op_map_json = serde_json::to_string(&op_map).unwrap();

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -245,7 +245,7 @@ impl Isolate {
     self.op_registry.register_op(name, op)
   }
 
-  pub fn call_op(
+  fn call_op(
     &self,
     op_id: OpId,
     control: &[u8],
@@ -334,6 +334,7 @@ impl Isolate {
     let isolate = unsafe { Isolate::from_raw_ptr(user_data) };
 
     let op = if let Some(ref f) = isolate.dispatch {
+      assert!(op_id != 0);
       f(op_id, control_buf.as_ref(), PinnedBuf::new(zero_copy_buf))
     } else {
       isolate.call_op(

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -13,11 +13,10 @@ use crate::libdeno::deno_buf;
 use crate::libdeno::deno_dyn_import_id;
 use crate::libdeno::deno_mod;
 use crate::libdeno::deno_pinned_buf;
-use crate::libdeno::OpId;
 use crate::libdeno::PinnedBuf;
 use crate::libdeno::Snapshot1;
 use crate::libdeno::Snapshot2;
-use crate::ops::OpRegistry;
+use crate::ops::*;
 use crate::shared_queue::SharedQueue;
 use crate::shared_queue::RECOMMENDED_SIZE;
 use futures::stream::FuturesUnordered;
@@ -35,28 +34,8 @@ use std::fmt;
 use std::ptr::null;
 use std::sync::{Arc, Mutex, Once};
 
-pub type Buf = Box<[u8]>;
-
-pub type OpAsyncFuture<E> = Box<dyn Future<Item = Buf, Error = E> + Send>;
-
-type PendingOpFuture =
-  Box<dyn Future<Item = (OpId, Buf), Error = CoreError> + Send>;
-
-pub enum Op<E> {
-  Sync(Buf),
-  Async(OpAsyncFuture<E>),
-}
-
-pub type CoreError = ();
-
-pub type CoreOp = Op<CoreError>;
-
-pub type OpResult<E> = Result<Op<E>, E>;
-
 /// Args: op_id, control_buf, zero_copy_buf
 type CoreDispatchFn = dyn Fn(OpId, &[u8], Option<PinnedBuf>) -> CoreOp;
-/// Main type describing op
-pub type CoreOpHandler = dyn Fn(&[u8], Option<PinnedBuf>) -> CoreOp;
 
 /// Stores a script used to initalize a Isolate
 pub struct Script<'a> {

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -258,7 +258,7 @@ impl Isolate {
       self.dispatch.is_none(),
       "set_dispatch should not be used in conjunction with register_op"
     );
-    self.op_registry.register_op(name, op)
+    self.op_registry.register(name, op)
   }
 
   pub fn set_dyn_import<F>(&mut self, f: F)
@@ -339,7 +339,7 @@ impl Isolate {
       );
       f(op_id, control_buf.as_ref(), PinnedBuf::new(zero_copy_buf))
     } else {
-      isolate.op_registry.call_op(
+      isolate.op_registry.call(
         op_id,
         control_buf.as_ref(),
         PinnedBuf::new(zero_copy_buf),

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -333,7 +333,10 @@ impl Isolate {
     let isolate = unsafe { Isolate::from_raw_ptr(user_data) };
 
     let op = if let Some(ref f) = isolate.dispatch {
-      assert!(op_id != 0);
+      assert!(
+        op_id != 0,
+        "op_id 0 is a special value that shouldn't be used with dispatch"
+      );
       f(op_id, control_buf.as_ref(), PinnedBuf::new(zero_copy_buf))
     } else {
       isolate.op_registry.call_op(

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -237,6 +237,7 @@ impl Isolate {
   ///
   /// If this method is used then ops registered using `op_register` function are
   /// ignored and all dispatching must be handled manually in provided callback.
+  // TODO: we want to deprecate and remove this API and move to `register_op` API
   pub fn set_dispatch<F>(&mut self, f: F)
   where
     F: Fn(OpId, &[u8], Option<PinnedBuf>) -> CoreOp + Send + Sync + 'static,
@@ -250,6 +251,10 @@ impl Isolate {
   /// Ops added using this method are only usable if `dispatch` is not set
   /// (using `set_dispatch` method).
   pub fn register_op(&mut self, name: &str, op: Box<CoreOpHandler>) -> OpId {
+    assert!(
+      self.dispatch.is_none(),
+      "set_dispatch should not be used in conjunction with register_op"
+    );
     self.op_registry.register_op(name, op)
   }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -23,6 +23,7 @@ pub use crate::libdeno::OpId;
 pub use crate::libdeno::PinnedBuf;
 pub use crate::module_specifier::*;
 pub use crate::modules::*;
+pub use crate::ops::*;
 
 pub fn v8_version() -> &'static str {
   use std::ffi::CStr;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -11,6 +11,7 @@ mod js_errors;
 mod libdeno;
 mod module_specifier;
 mod modules;
+mod ops;
 mod shared_queue;
 
 pub use crate::any_error::*;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -40,7 +40,7 @@ impl OpRegistry {
     let mut registry = Self::default();
     // TODO: We should register actual "get_op_map" op here, but I couldn't
     // get past borrow checker when I wanted to do:
-    //    registry.register_op("get_op_map", Box::new(self.op_noop));
+    //    registry.register_op("get_op_map", Box::new(registry.op_noop));
 
     // Add single noop symbolizing "get_op_map" function. The actual
     // handling is done in `isolate.rs`.
@@ -72,8 +72,14 @@ impl OpRegistry {
 }
 
 #[test]
-fn test_register_op() {
+fn test_op_registry() {
   let mut op_registry = OpRegistry::new();
   let op_id = op_registry.register_op("test", Box::new(op_noop));
   assert!(op_id != 0);
+
+  let mut expected_map = HashMap::new();
+  expected_map.insert("get_op_map", 0);
+  expected_map.insert("test", 1);
+  let op_map = op_registry.get_op_map();
+  assert_eq!(op_map, expected_map);
 }

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -66,11 +66,11 @@ impl OpRegistry {
   ) -> OpId {
     let op_id = self.ops.len() as u32;
 
-    self
-      .op_map
-      .entry(name.to_string())
-      .and_modify(|_| panic!("Op already registered {}", op_id))
-      .or_insert(op_id);
+    let existing = self.op_map.insert(name.to_string(), op_id);
+    assert!(
+      existing.is_none(),
+      format!("Op already registered: {}", name)
+    );
 
     self.ops.push(serialized_op);
     op_id

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -1,0 +1,35 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+use crate::CoreOpHandler;
+#[allow(dead_code)]
+use crate::OpId;
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct OpRegistry {
+  pub ops: Vec<Box<CoreOpHandler>>,
+  pub phone_book: HashMap<String, OpId>,
+}
+
+impl OpRegistry {
+  #[allow(dead_code)]
+  pub fn get_op_map(&self) -> HashMap<String, OpId> {
+    self.phone_book.clone()
+  }
+
+  pub fn register_op(
+    &mut self,
+    name: &str,
+    serialized_op: Box<CoreOpHandler>,
+  ) -> OpId {
+    let op_id = self.ops.len() as u32;
+
+    self
+      .phone_book
+      .entry(name.to_string())
+      .and_modify(|_| panic!("Op already registered {}", op_id))
+      .or_insert(op_id);
+
+    self.ops.push(serialized_op);
+    op_id
+  }
+}

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -31,36 +31,21 @@ pub struct OpRegistry {
   pub op_map: HashMap<String, OpId>,
 }
 
-fn op_noop(_control: &[u8], _zero_copy_buf: Option<PinnedBuf>) -> CoreOp {
-  Op::Sync(Box::new([]))
-}
-
-fn op_get_op_map(op_registry: &OpRegistry) -> CoreOp {
-  let op_map = op_registry.get_op_map();
-  let op_map_json = serde_json::to_string(&op_map).unwrap();
-  let buf = op_map_json.as_bytes().to_owned().into_boxed_slice();
-  Op::Sync(buf)
-}
-
 impl OpRegistry {
   pub fn new() -> Self {
     let mut registry = Self::default();
-    // Add single noop symbolizing "get_op_map" function. The actual
-    // handling is done in `call_op` method.
-    let op_id = registry.register_op("get_op_map", Box::new(op_noop));
+    let op_id = registry.register_op("get_op_map", |_, _| {
+      // get_op_map is a special op which is handled in call_op.
+      unreachable!()
+    });
     assert_eq!(op_id, 0);
     registry
   }
 
-  pub fn get_op_map(&self) -> HashMap<String, OpId> {
-    self.op_map.clone()
-  }
-
-  pub fn register_op(
-    &mut self,
-    name: &str,
-    serialized_op: Box<CoreOpHandler>,
-  ) -> OpId {
+  pub fn register_op<F>(&mut self, name: &str, op: F) -> OpId
+  where
+    F: Fn(&[u8], Option<PinnedBuf>) -> CoreOp + Send + Sync + 'static,
+  {
     let op_id = self.ops.len() as u32;
 
     let existing = self.op_map.insert(name.to_string(), op_id);
@@ -69,8 +54,13 @@ impl OpRegistry {
       format!("Op already registered: {}", name)
     );
 
-    self.ops.push(serialized_op);
+    self.ops.push(Box::new(op));
     op_id
+  }
+
+  fn json_map(&self) -> Buf {
+    let op_map_json = serde_json::to_string(&self.op_map).unwrap();
+    op_map_json.as_bytes().to_owned().into_boxed_slice()
   }
 
   pub fn call_op(
@@ -79,11 +69,11 @@ impl OpRegistry {
     control: &[u8],
     zero_copy_buf: Option<PinnedBuf>,
   ) -> CoreOp {
-    // Op with id 0 has special meaning - it's a special op that is
-    // always provided to retrieve op id map.
-    // Op id map consists of name to `OpId` mappings.
+    // Op with id 0 has special meaning - it's a special op that is always
+    // provided to retrieve op id map. The map consists of name to `OpId`
+    // mappings.
     if op_id == 0 {
-      return op_get_op_map(self);
+      return Op::Sync(self.json_map());
     }
 
     let op_handler = &*self.ops.get(op_id as usize).expect("Op not found!");
@@ -93,21 +83,29 @@ impl OpRegistry {
 
 #[test]
 fn test_op_registry() {
+  use std::sync::atomic;
+  use std::sync::Arc;
   let mut op_registry = OpRegistry::new();
-  let op_id = op_registry.register_op("test", Box::new(op_noop));
-  assert!(op_id != 0);
+
+  let c = Arc::new(atomic::AtomicUsize::new(0));
+  let c_ = c.clone();
+
+  let test_id = op_registry.register_op("test", move |_, _| {
+    c_.fetch_add(1, atomic::Ordering::SeqCst);
+    CoreOp::Sync(Box::new([]))
+  });
+  assert!(test_id != 0);
 
   let mut expected_map = HashMap::new();
   expected_map.insert("get_op_map".to_string(), 0);
   expected_map.insert("test".to_string(), 1);
-  let op_map = op_registry.get_op_map();
-  assert_eq!(op_map, expected_map);
+  assert_eq!(op_registry.op_map, expected_map);
 
-  let res = op_registry.call_op(1, &[], None);
-  match res {
-    Op::Sync(buf) => {
-      assert_eq!(buf.len(), 0);
-    }
-    _ => panic!(),
+  let res = op_registry.call_op(test_id, &[], None);
+  if let Op::Sync(buf) = res {
+    assert_eq!(buf.len(), 0);
+  } else {
+    unreachable!();
   }
+  assert_eq!(c.load(atomic::Ordering::SeqCst), 1);
 }

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -53,10 +53,7 @@ impl OpRegistry {
   }
 
   pub fn get_op_map(&self) -> HashMap<String, OpId> {
-    let mut op_map = self.op_map.clone();
-    // Don't send "get_op_map" to JS, if JS encounters unknown op it should throw.
-    op_map.remove("get_op_map");
-    op_map
+    self.op_map.clone()
   }
 
   pub fn register_op(
@@ -101,6 +98,7 @@ fn test_op_registry() {
   assert!(op_id != 0);
 
   let mut expected_map = HashMap::new();
+  expected_map.insert("get_op_map".to_string(), 0);
   expected_map.insert("test".to_string(), 1);
   let op_map = op_registry.get_op_map();
   assert_eq!(op_map, expected_map);

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -1,6 +1,9 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+use crate::CoreOp;
 use crate::CoreOpHandler;
+use crate::Op;
 use crate::OpId;
+use crate::PinnedBuf;
 use std::collections::HashMap;
 
 #[derive(Default)]
@@ -9,8 +12,18 @@ pub struct OpRegistry {
   pub phone_book: HashMap<String, OpId>,
 }
 
+fn get_op_map(_control: &[u8], _zero_copy_buf: Option<PinnedBuf>) -> CoreOp {
+  Op::Sync(Box::new([]))
+}
+
 impl OpRegistry {
-  #[allow(dead_code)]
+  pub fn new() -> Self {
+    // TODO: this is make shift fix for get op map
+    let mut registry = Self::default();
+    registry.register_op("get_op_map", Box::new(get_op_map));
+    registry
+  }
+
   pub fn get_op_map(&self) -> HashMap<String, OpId> {
     self.phone_book.clone()
   }

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -98,11 +98,16 @@ fn test_op_registry() {
   assert!(op_id != 0);
 
   let mut expected_map = HashMap::new();
-  expected_map.insert("get_op_map", 0);
-  expected_map.insert("test", 1);
+  expected_map.insert("get_op_map".to_string(), 0);
+  expected_map.insert("test".to_string(), 1);
   let op_map = op_registry.get_op_map();
   assert_eq!(op_map, expected_map);
 
-  let res = op_registry.call_op(1, [], None);
-  assert_eq!(op_map, Op::Sync(Box::new([])));
+  let res = op_registry.call_op(1, &[], None);
+  match res {
+    Op::Sync(buf) => {
+      assert_eq!(buf.len(), 0);
+    }
+    _ => panic!(),
+  }
 }

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -39,7 +39,7 @@ fn op_get_op_map(op_registry: &OpRegistry) -> CoreOp {
   let op_map = op_registry.get_op_map();
   let op_map_json = serde_json::to_string(&op_map).unwrap();
   let buf = op_map_json.as_bytes().to_owned().into_boxed_slice();
-  return Op::Sync(buf);
+  Op::Sync(buf)
 }
 
 impl OpRegistry {

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 use crate::CoreOpHandler;
-#[allow(dead_code)]
 use crate::OpId;
 use std::collections::HashMap;
 

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -1,10 +1,29 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use crate::CoreOp;
-use crate::CoreOpHandler;
-use crate::Op;
-use crate::OpId;
+pub use crate::libdeno::OpId;
 use crate::PinnedBuf;
+use futures::Future;
 use std::collections::HashMap;
+
+pub type Buf = Box<[u8]>;
+
+pub type OpAsyncFuture<E> = Box<dyn Future<Item = Buf, Error = E> + Send>;
+
+pub(crate) type PendingOpFuture =
+  Box<dyn Future<Item = (OpId, Buf), Error = CoreError> + Send>;
+
+pub type OpResult<E> = Result<Op<E>, E>;
+
+pub enum Op<E> {
+  Sync(Buf),
+  Async(OpAsyncFuture<E>),
+}
+
+pub type CoreError = ();
+
+pub type CoreOp = Op<CoreError>;
+
+/// Main type describing op
+pub type CoreOpHandler = dyn Fn(&[u8], Option<PinnedBuf>) -> CoreOp;
 
 #[derive(Default)]
 pub struct OpRegistry {

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -53,7 +53,10 @@ impl OpRegistry {
   }
 
   pub fn get_op_map(&self) -> HashMap<String, OpId> {
-    self.op_map.clone()
+    let mut op_map = self.op_map.clone();
+    // Don't send "get_op_map" to JS, if JS encounters unknown op it should throw.
+    op_map.remove("get_op_map");
+    op_map
   }
 
   pub fn register_op(
@@ -98,7 +101,6 @@ fn test_op_registry() {
   assert!(op_id != 0);
 
   let mut expected_map = HashMap::new();
-  expected_map.insert("get_op_map".to_string(), 0);
   expected_map.insert("test".to_string(), 1);
   let op_map = op_registry.get_op_map();
   assert_eq!(op_map, expected_map);

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 #[derive(Default)]
 pub struct OpRegistry {
   pub ops: Vec<Box<CoreOpHandler>>,
-  pub phone_book: HashMap<String, OpId>,
+  pub op_map: HashMap<String, OpId>,
 }
 
 fn get_op_map(_control: &[u8], _zero_copy_buf: Option<PinnedBuf>) -> CoreOp {
@@ -25,7 +25,7 @@ impl OpRegistry {
   }
 
   pub fn get_op_map(&self) -> HashMap<String, OpId> {
-    self.phone_book.clone()
+    self.op_map.clone()
   }
 
   pub fn register_op(
@@ -36,7 +36,7 @@ impl OpRegistry {
     let op_id = self.ops.len() as u32;
 
     self
-      .phone_book
+      .op_map
       .entry(name.to_string())
       .and_modify(|_| panic!("Op already registered {}", op_id))
       .or_insert(op_id);

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -178,9 +178,11 @@ SharedQueue Binary Layout
     return Deno.core.send(opId, control, zeroCopy);
   }
 
-  const opsMapBytes = dispatch(0, []);
-  const opsMapJson = String.fromCharCode.apply(null, opsMapBytes);
-  const opsMap = JSON.parse(opsMapJson);
+  function refreshOpsMap() {
+    const opsMapBytes = dispatch(0, []);
+    const opsMapJson = String.fromCharCode.apply(null, opsMapBytes);
+    Deno.core.opsMap = JSON.parse(opsMapJson);
+  }
 
   const denoCore = {
     setAsyncHandler,
@@ -194,7 +196,8 @@ SharedQueue Binary Layout
       reset,
       shift
     },
-    opsMap
+    opsMap: {},
+    refreshOpsMap
   };
 
   assert(window[GLOBAL_NAMESPACE] != null);

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -39,6 +39,7 @@ SharedQueue Binary Layout
   let sharedBytes;
   let shared32;
   let initialized = false;
+  let opsMap = {};
 
   function maybeInit() {
     if (!initialized) {
@@ -58,10 +59,12 @@ SharedQueue Binary Layout
     Deno.core.recv(handleAsyncMsgFromRust);
   }
 
-  function getOps() {
+  function initOps() {
     const opsMapBytes = Deno.core.send(0, new Uint8Array([]), null);
     const opsMapJson = String.fromCharCode.apply(null, opsMapBytes);
-    return JSON.parse(opsMapJson);
+    for (const [key, value] of Object.entries(JSON.parse(opsMapJson))) {
+      opsMap[key] = value;
+    }
   }
 
   function assert(cond) {
@@ -195,7 +198,8 @@ SharedQueue Binary Layout
       reset,
       shift
     },
-    getOps
+    initOps,
+    ops: opsMap
   };
 
   assert(window[GLOBAL_NAMESPACE] != null);

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -39,7 +39,6 @@ SharedQueue Binary Layout
   let sharedBytes;
   let shared32;
   let initialized = false;
-  let opsMap = {};
 
   function maybeInit() {
     if (!initialized) {
@@ -59,22 +58,11 @@ SharedQueue Binary Layout
     Deno.core.recv(handleAsyncMsgFromRust);
   }
 
-  function initOps() {
+  function ops() {
+    // op id 0 is a special value to retreive the map of registered ops.
     const opsMapBytes = Deno.core.send(0, new Uint8Array([]), null);
     const opsMapJson = String.fromCharCode.apply(null, opsMapBytes);
-    opsMap = JSON.parse(opsMapJson);
-  }
-
-  function getOpId(name) {
-    const opId = opsMap[name];
-
-    if (!opId) {
-      throw new Error(
-        `Unknown op: "${key}". Did you forget to initialize ops with Deno.core.ops.init()?`
-      );
-    }
-
-    return opId;
+    return JSON.parse(opsMapJson);
   }
 
   function assert(cond) {
@@ -208,10 +196,7 @@ SharedQueue Binary Layout
       reset,
       shift
     },
-    ops: {
-      init: initOps,
-      get: getOpId
-    }
+    ops
   };
 
   assert(window[GLOBAL_NAMESPACE] != null);

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -39,7 +39,7 @@ SharedQueue Binary Layout
   let sharedBytes;
   let shared32;
   let initialized = false;
-  let opsMap = {};
+  const opsMap = {};
 
   function maybeInit() {
     if (!initialized) {
@@ -66,6 +66,23 @@ SharedQueue Binary Layout
       opsMap[key] = value;
     }
   }
+
+  const opsMapProxy = new Proxy(opsMap, {
+    get(target, key) {
+      const opId = target[key];
+
+      if (!opId) {
+        throw new Error(
+          `Unknown op: "${key}". Did you forget to initialize ops with Deno.core.initOps()?`
+        );
+      }
+
+      return opId;
+    },
+    set() {
+      throw new Error("Setting op id is not allowed.");
+    }
+  });
 
   function assert(cond) {
     if (!cond) {
@@ -199,7 +216,7 @@ SharedQueue Binary Layout
       shift
     },
     initOps,
-    ops: opsMap
+    ops: opsMapProxy
   };
 
   assert(window[GLOBAL_NAMESPACE] != null);

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -178,6 +178,10 @@ SharedQueue Binary Layout
     return Deno.core.send(opId, control, zeroCopy);
   }
 
+  const opsMapBytes = dispatch(0, []);
+  const opsMapJson = String.fromCharCode.apply(null, opsMapBytes);
+  const opsMap = JSON.parse(opsMapJson);
+
   const denoCore = {
     setAsyncHandler,
     dispatch,
@@ -189,7 +193,8 @@ SharedQueue Binary Layout
       push,
       reset,
       shift
-    }
+    },
+    opsMap
   };
 
   assert(window[GLOBAL_NAMESPACE] != null);

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -191,14 +191,16 @@ SharedQueue Binary Layout
   function handleAsyncMsgFromRust(opId, buf) {
     if (buf) {
       // This is the overflow_response case of deno::Isolate::poll().
-      opsCb[opId](opId, buf);
+      const cb = asyncHandler ? asyncHandler : opsCb[opId];
+      cb(opId, buf);
     } else {
       while (true) {
         const opIdBuf = shift();
         if (opIdBuf == null) {
           break;
         }
-        opsCb[opIdBuf[0]](...opIdBuf);
+        const cb = asyncHandler ? asyncHandler : opsCb[opIdBuf[0]];
+        cb(...opIdBuf);
       }
     }
   }

--- a/core/shared_queue.rs
+++ b/core/shared_queue.rs
@@ -196,7 +196,7 @@ impl SharedQueue {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::isolate::Buf;
+  use crate::ops::Buf;
 
   #[test]
   fn basic() {

--- a/deno_typescript/lib.deno_core.d.ts
+++ b/deno_typescript/lib.deno_core.d.ts
@@ -58,8 +58,7 @@ declare interface DenoCore {
     shift(): Uint8Array | null;
   };
 
-  Op: typeof Op;
-  initOps(): void;
+  getOps(): Record<string, number>;
 
   recv(cb: MessageCallback): void;
 

--- a/deno_typescript/lib.deno_core.d.ts
+++ b/deno_typescript/lib.deno_core.d.ts
@@ -37,8 +37,9 @@ declare interface DenoCore {
     shift(): Uint8Array | null;
   };
 
-  refreshOpsMap(): void;
-  opsMap: Record<string, number>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerOp(op: any): void;
+  initOps(): void;
 
   recv(cb: MessageCallback): void;
 

--- a/deno_typescript/lib.deno_core.d.ts
+++ b/deno_typescript/lib.deno_core.d.ts
@@ -20,6 +20,27 @@ interface EvalErrorInfo {
   thrown: any;
 }
 
+declare type OpId = number;
+
+declare class Op {
+  name: string;
+  opId: OpId;
+
+  constructor(name: string);
+
+  setOpId(opId: Opid): void;
+
+  static handleAsyncMsgFromRust(opId: OpId, buf: Uint8Array): void;
+
+  static sendSync(opId: OpId, control: Uint8Array, zeroCopy?: Uint8Array): void;
+
+  static sendAsync(
+    opId: OpId,
+    control: Uint8Array,
+    zeroCopy?: Uint8Array
+  ): void;
+}
+
 declare interface DenoCore {
   print(s: string, isErr?: boolean);
   dispatch(
@@ -37,8 +58,7 @@ declare interface DenoCore {
     shift(): Uint8Array | null;
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  registerOp(op: any): void;
+  Op: Op;
   initOps(): void;
 
   recv(cb: MessageCallback): void;

--- a/deno_typescript/lib.deno_core.d.ts
+++ b/deno_typescript/lib.deno_core.d.ts
@@ -37,6 +37,7 @@ declare interface DenoCore {
     shift(): Uint8Array | null;
   };
 
+  refreshOpsMap(): void;
   opsMap: Record<string, number>;
 
   recv(cb: MessageCallback): void;

--- a/deno_typescript/lib.deno_core.d.ts
+++ b/deno_typescript/lib.deno_core.d.ts
@@ -37,6 +37,8 @@ declare interface DenoCore {
     shift(): Uint8Array | null;
   };
 
+  opsMap: Record<string, number>;
+
   recv(cb: MessageCallback): void;
 
   send(

--- a/deno_typescript/lib.deno_core.d.ts
+++ b/deno_typescript/lib.deno_core.d.ts
@@ -37,7 +37,8 @@ declare interface DenoCore {
     shift(): Uint8Array | null;
   };
 
-  getOps(): Record<string, number>;
+  initOps(): void;
+  ops: Record<string, number>;
 
   recv(cb: MessageCallback): void;
 

--- a/deno_typescript/lib.deno_core.d.ts
+++ b/deno_typescript/lib.deno_core.d.ts
@@ -20,27 +20,6 @@ interface EvalErrorInfo {
   thrown: any;
 }
 
-declare type OpId = number;
-
-declare class Op {
-  name: string;
-  opId: OpId;
-
-  constructor(name: string);
-
-  setOpId(opId: OpId): void;
-
-  static handleAsyncMsgFromRust(opId: OpId, buf: Uint8Array): void;
-
-  static sendSync(opId: OpId, control: Uint8Array, zeroCopy?: Uint8Array): void;
-
-  static sendAsync(
-    opId: OpId,
-    control: Uint8Array,
-    zeroCopy?: Uint8Array
-  ): void;
-}
-
 declare interface DenoCore {
   print(s: string, isErr?: boolean);
   dispatch(

--- a/deno_typescript/lib.deno_core.d.ts
+++ b/deno_typescript/lib.deno_core.d.ts
@@ -28,7 +28,7 @@ declare class Op {
 
   constructor(name: string);
 
-  setOpId(opId: Opid): void;
+  setOpId(opId: OpId): void;
 
   static handleAsyncMsgFromRust(opId: OpId, buf: Uint8Array): void;
 
@@ -58,7 +58,7 @@ declare interface DenoCore {
     shift(): Uint8Array | null;
   };
 
-  Op: Op;
+  Op: typeof Op;
   initOps(): void;
 
   recv(cb: MessageCallback): void;

--- a/deno_typescript/lib.deno_core.d.ts
+++ b/deno_typescript/lib.deno_core.d.ts
@@ -37,8 +37,10 @@ declare interface DenoCore {
     shift(): Uint8Array | null;
   };
 
-  initOps(): void;
-  ops: Record<string, number>;
+  ops: {
+    init(): void;
+    get(name: string): number;
+  };
 
   recv(cb: MessageCallback): void;
 


### PR DESCRIPTION
Towards #2987 

This PR introduces `OpRegistry` structure in `Isolate`.

`OpRegistry` collects `OpHandlers` which are functions returning `CoreOp`.

This can be safely introduced to work with `deno_cli` because if you set dispatch manually via `set_dispatch` then ops registered on isolate are ignored.

~~I still have to get op id forwarding to JS.~~

CC @ry @piscisaureus 