### PR TITLE
Fix typo in style guide relating to format script

### DIFF
--- a/website/style_guide.md
+++ b/website/style_guide.md
@@ -39,7 +39,7 @@ Example: Instead of `file-server.ts` use `file_server.ts`.
 ## Format code using prettier.
 
 More specifically, code should be wrapped at 80 columns and use 2-space
-indentation and use camel-case. Use `//format.ts` to invoke prettier.
+indentation and use camel-case. Use `./format.ts` to invoke prettier.
 
 ## Exported functions: max 2 args, put the rest into an options object.
 


### PR DESCRIPTION
<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
Fix a small typo in the style guide which relates to the instructions on how to run prettier 