### PR TITLE
tools: fix cc_wrapper in setup.py

### DIFF
--- a/tools/setup.py
+++ b/tools/setup.py
@@ -127,13 +127,12 @@ def generate_gn_args(mode):
     if "DENO_BUILD_ARGS" in os.environ:
         out += os.environ["DENO_BUILD_ARGS"].split()
 
-    cacher = find_executable("sccache")
-    if not os.path.exists(cacher):
-        cacher = third_party.get_prebuilt_tool_path("sccache")
+    # Check if sccache is in the path, and if so we set cc_wrapper.
+    cc_wrapper = find_executable("sccache")
+    if not cc_wrapper:
+        cc_wrapper = third_party.get_prebuilt_tool_path("sccache")
 
-    # Check if ccache or sccache are in the path, and if so we set cc_wrapper.
-    cc_wrapper = cacher
-    if cc_wrapper:
+    if os.path.exists(cc_wrapper):
         # The gn toolchain does not shell escape cc_wrapper, so do it here.
         out += ['cc_wrapper=%s' % gn_string(shell_quote(cc_wrapper))]
         if os.name == "nt":


### PR DESCRIPTION
Fixes: #3013 

Also make sure that we can still build if `sccache` is neither on the path nor the prebuilt binary was downloaded.