### PR TITLE
chore: bump deno_std deps

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 
 macro_rules! std_url {
   ($x:expr) => {
-    concat!("https://deno.land/std@06958a4/", $x)
+    concat!("https://deno.land/std@17a214b/", $x)
   };
 }
 


### PR DESCRIPTION
This PR bumps deno_std dependencies of `cli` crate to version with updated test runner (denoland/deno_std#604)

Closes #2948 