### PR TITLE
feat: Deno.deps API

### DIFF
--- a/cli/ops/deps.rs
+++ b/cli/ops/deps.rs
@@ -1,0 +1,42 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+use super::dispatch_json::{Deserialize, JsonOp, Value};
+use crate::state::ThreadSafeState;
+use futures::Future;
+use deno::*;
+
+#[derive(Deserialize)]
+struct DepsArgs {
+  url: String,
+}
+
+pub fn op_deps(
+  state: &ThreadSafeState,
+  args: Value,
+  _zero_copy: Option<PinnedBuf>,
+) -> Result<JsonOp, ErrBox> {
+  let args: DepsArgs = serde_json::from_value(args)?;
+
+  let state_ = state.clone();
+  let module_specifier = ModuleSpecifier::resolve_url_or_path(&args.url)?;
+  let module_specifier_ = module_specifier.clone();
+
+  let fut = state_
+    .file_fetcher
+    .fetch_source_file_async(&module_specifier)
+    .and_then(move |_out| {
+      state_
+        .fetch_compiled_module(&module_specifier_)
+        .and_then(move |compiled| {
+          let modules = state_.modules.lock().unwrap();
+
+          let deps_json_string = match modules.deps(&compiled.name.to_string()) {
+            None => "".to_string(),
+            Some(deps) => deps.to_json_object(),
+          };
+
+          futures::future::ok(json!(deps_json_string))
+        })
+    });
+
+  Ok(JsonOp::Async(Box::new(fut)))
+}

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -3,6 +3,7 @@ use crate::state::ThreadSafeState;
 use deno::*;
 
 mod compiler;
+mod deps;
 mod dispatch_json;
 mod dispatch_minimal;
 mod errors;
@@ -83,6 +84,7 @@ pub const OP_MAKE_TEMP_DIR: OpId = 55;
 pub const OP_CWD: OpId = 56;
 pub const OP_FETCH_ASSET: OpId = 57;
 pub const OP_DIAL_TLS: OpId = 58;
+pub const OP_DEPS: OpId = 59;
 
 pub fn dispatch(
   state: &ThreadSafeState,
@@ -304,6 +306,9 @@ pub fn dispatch(
     ),
     OP_DIAL_TLS => {
       dispatch_json::dispatch(tls::op_dial_tls, state, control, zero_copy)
+    }
+    OP_DEPS => {
+      dispatch_json::dispatch(deps::op_deps, state, control, zero_copy)
     }
     _ => panic!("bad op_id"),
   };

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -556,6 +556,22 @@ impl Deps {
 
     format!("[\"{}\",{}]", self.name, children)
   }
+
+  pub fn to_json_object(&self) -> String {
+    let mut children = "[".to_string();
+
+    if let Some(ref deps) = self.deps {
+      for d in deps {
+        children.push_str(&d.to_json_object());
+        if !d.is_last {
+          children.push_str(",");
+        }
+      }
+    }
+    children.push_str("]");
+
+    format!("{{\"name\": \"{}\", \"deps\": {}}}", self.name, children)
+  }
 }
 
 impl fmt::Display for Deps {

--- a/js/deno.ts
+++ b/js/deno.ts
@@ -53,6 +53,7 @@ export {
 } from "./make_temp_dir.ts";
 export { chmodSync, chmod } from "./chmod.ts";
 export { chownSync, chown } from "./chown.ts";
+export { deps } from "./deps.ts";
 export { utimeSync, utime } from "./utime.ts";
 export { removeSync, remove, RemoveOption } from "./remove.ts";
 export { renameSync, rename } from "./rename.ts";

--- a/js/deps.ts
+++ b/js/deps.ts
@@ -1,0 +1,12 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { sendAsync } from "./dispatch_json.ts";
+import * as dispatch from "./dispatch.ts";
+
+interface DepsRes {
+  name: string;
+  deps: [DepsRes]
+}
+
+export async function deps(url: string): Promise<DepsRes> {
+  return await sendAsync(dispatch.OP_DEPS, { url });
+}

--- a/js/dispatch.ts
+++ b/js/dispatch.ts
@@ -61,6 +61,7 @@ export const OP_MAKE_TEMP_DIR = 55;
 export const OP_CWD = 56;
 export const OP_FETCH_ASSET = 57;
 export const OP_DIAL_TLS = 58;
+export const OP_DEPS = 59;
 
 export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
   switch (opId) {
@@ -99,6 +100,7 @@ export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
     case OP_TRUNCATE:
     case OP_MAKE_TEMP_DIR:
     case OP_DIAL_TLS:
+    case OP_DEPS:
       json.asyncMsgFromRust(opId, ui8);
       break;
     default:

--- a/js/lib.deno_runtime.d.ts
+++ b/js/lib.deno_runtime.d.ts
@@ -464,6 +464,14 @@ declare namespace Deno {
    */
   export function chown(path: string, uid: number, gid: number): Promise<void>;
 
+  // @url js/deps.d.ts
+  interface DepsRes {
+    name: string;
+    deps: [DepsRes]
+  }
+
+  export function deps(url: string): Promise<DepsRes>;
+
   // @url js/utime.d.ts
 
   /** Synchronously changes the access and modification times of a file system

--- a/test.js
+++ b/test.js
@@ -1,0 +1,3 @@
+// await import("https://deno.land/std/examples/catj.ts");
+const deps = await Deno.deps("https://deno.land/std/examples/catj.ts");
+console.log(deps);


### PR DESCRIPTION
So this PR is meant to resolve #2096

## Talking points

What kind of API we want to provide? 

If API was to expose only dependencies of current program then it would look like `Deno.deps()` and it would return the dependency tree of main module. TBH I don't think it's really useful.

If we want to expose API to get dependencies of any file `Deno.deps(url)` then there are a few things to settle on:
- IMHO it should be done by TS compiler - `Modules` struct from `//core/modules.rs` has `deps` API but it requires modules to be loaded into V8 to use, I believe it's better to use TS compiler's ability to statically analyze code to retrieve dependency graph
- `deno info` works by loading and executing module to retrieve it's dependency graph, if we move this logic into TS compiler then we could abstract this operation and share it with `Deno.deps` API