### PR TITLE
chore: bump deps version on homepage

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -115,7 +115,7 @@ href="https://deno.land/x/install/install.ps1">https://deno.land/x/install/insta
 
       <p>Or a more complex one:</p>
 
-      <pre><code class="typescript language-typescript">import { serve } from "<a href="https://deno.land/std@v0.12/http/server.ts">https://deno.land/std@v0.12/http/server.ts</a>";
+      <pre><code class="typescript language-typescript">import { serve } from "<a href="https://deno.land/std@v0.19.0/http/server.ts">https://deno.land/std@v0.19.0/http/server.ts</a>";
 const body = new TextEncoder().encode("Hello World\n");
 const s = serve(":8000");
 window.onload = async () => {


### PR DESCRIPTION
With recent changes to `Deno.dial` API the example on main page did not work with `v0.19.0` release. 

Also full tag is required (`v0.19.0`, instead of `v0.19`).

