### PR TITLE
feat: top level namespace for ops registry

### DIFF
--- a/core/examples/http_bench.js
+++ b/core/examples/http_bench.js
@@ -119,7 +119,7 @@ let ops;
 
 async function main() {
   Deno.core.setAsyncHandler(handleAsyncMsgFromRust);
-  ops = Deno.core.ops();
+  ops = Deno.core.ops()["http_bench"];
 
   Deno.core.print("http_bench.js start\n");
 

--- a/core/examples/http_bench.rs
+++ b/core/examples/http_bench.rs
@@ -152,11 +152,12 @@ fn main() {
     });
 
     let mut isolate = deno::Isolate::new(startup_data, false);
-    isolate.register_op("listen", http_op(op_listen));
-    isolate.register_op("accept", http_op(op_accept));
-    isolate.register_op("read", http_op(op_read));
-    isolate.register_op("write", http_op(op_write));
-    isolate.register_op("close", http_op(op_close));
+    let namespace = "http_bench";
+    isolate.register_op(namespace, "listen", http_op(op_listen));
+    isolate.register_op(namespace, "accept", http_op(op_accept));
+    isolate.register_op(namespace, "read", http_op(op_read));
+    isolate.register_op(namespace, "write", http_op(op_write));
+    isolate.register_op(namespace, "close", http_op(op_close));
 
     isolate.then(|r| {
       js_check(r);

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -250,7 +250,7 @@ impl Isolate {
   ///
   /// Ops added using this method are only usable if `dispatch` is not set
   /// (using `set_dispatch` method).
-  pub fn register_op<F>(&mut self, name: &str, op: F) -> OpId
+  pub fn register_op<F>(&mut self, namespace: &str, name: &str, op: F) -> OpId
   where
     F: Fn(&[u8], Option<PinnedBuf>) -> CoreOp + Send + Sync + 'static,
   {
@@ -258,7 +258,7 @@ impl Isolate {
       self.dispatch.is_none(),
       "set_dispatch should not be used in conjunction with register_op"
     );
-    self.op_registry.register(name, op)
+    self.op_registry.register(namespace, name, op)
   }
 
   pub fn set_dyn_import<F>(&mut self, f: F)


### PR DESCRIPTION
This isn't really needed, but I think that it's a nice feature, and should eliminate the need to worry about overlap in registered op names. I know something similar could be achieved with code like this
```
fn init(i: Isolate, n: &str) {
  i.register_op(format!({}_{}, n, "someOpName"), op_some_op_name);
}
```
but I think that it would be better if we standardized on something more like this
```
fn init(i: Isolate, n: &str) {
  i.register_op(n, "someOpName", op_some_op_name);
}
```
On the js side things are pretty simple. `Deno.core.ops()["someOp"]` becomes `Deno.core.ops()["someNamespace"]["someOp"]` and this should leave plenty of room for namespace aliases.
```
ns = Deno.core.ops()["someNamespace"]; 
someOpId = ns["someOp"]
```

cc @ry @bartlomieju 