### PR TITLE
Fix iterators on UrlSearchParams

### DIFF
--- a/js/dom_types.ts
+++ b/js/dom_types.ts
@@ -100,7 +100,7 @@ export interface ProgressEventInit extends EventInit {
   total?: number;
 }
 
-export interface URLSearchParams {
+export interface URLSearchParams extends DomIterable<string, string> {
   /**
    * Appends a specified key/value pair as a new search parameter.
    */
@@ -142,7 +142,7 @@ export interface URLSearchParams {
    * and invokes the given function.
    */
   forEach(
-    callbackfn: (value: string, key: string, parent: URLSearchParams) => void,
+    callbackfn: (value: string, key: string, parent: this) => void,
     thisArg?: any
   ): void;
 }

--- a/js/lib.deno_runtime.d.ts
+++ b/js/lib.deno_runtime.d.ts
@@ -1459,7 +1459,7 @@ declare namespace domTypes {
     loaded?: number;
     total?: number;
   }
-  export interface URLSearchParams {
+  export interface URLSearchParams extends DomIterable<string, string> {
     /**
      * Appends a specified key/value pair as a new search parameter.
      */
@@ -1501,7 +1501,7 @@ declare namespace domTypes {
      * and invokes the given function.
      */
     forEach(
-      callbackfn: (value: string, key: string, parent: URLSearchParams) => void,
+      callbackfn: (value: string, key: string, parent: this) => void,
       thisArg?: any
     ): void;
   }
@@ -2495,7 +2495,7 @@ declare namespace urlSearchParams {
      *
      */
     forEach(
-      callbackfn: (value: string, key: string, parent: URLSearchParams) => void,
+      callbackfn: (value: string, key: string, parent: this) => void,
       thisArg?: any
     ): void;
     /** Returns an iterator allowing to go through all keys contained
@@ -2505,7 +2505,7 @@ declare namespace urlSearchParams {
      *         console.log(key);
      *       }
      */
-    keys(): Iterable<string>;
+    keys(): IterableIterator<string>;
     /** Returns an iterator allowing to go through all values contained
      * in this object.
      *
@@ -2513,7 +2513,7 @@ declare namespace urlSearchParams {
      *         console.log(value);
      *       }
      */
-    values(): Iterable<string>;
+    values(): IterableIterator<string>;
     /** Returns an iterator allowing to go through all key/value
      * pairs contained in this object.
      *
@@ -2521,7 +2521,7 @@ declare namespace urlSearchParams {
      *         console.log(key, value);
      *       }
      */
-    entries(): Iterable<[string, string]>;
+    entries(): IterableIterator<[string, string]>;
     /** Returns an iterator allowing to go through all key/value
      * pairs contained in this object.
      *
@@ -2529,7 +2529,7 @@ declare namespace urlSearchParams {
      *         console.log(key, value);
      *       }
      */
-    [Symbol.iterator](): Iterable<[string, string]>;
+    [Symbol.iterator](): IterableIterator<[string, string]>;
     /** Returns a query string suitable for use in a URL.
      *
      *        searchParams.toString();

--- a/js/url_search_params.ts
+++ b/js/url_search_params.ts
@@ -184,7 +184,7 @@ export class URLSearchParams {
    *
    */
   forEach(
-    callbackfn: (value: string, key: string, parent: URLSearchParams) => void,
+    callbackfn: (value: string, key: string, parent: this) => void,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     thisArg?: any
   ): void {
@@ -206,7 +206,7 @@ export class URLSearchParams {
    *         console.log(key);
    *       }
    */
-  *keys(): Iterable<string> {
+  *keys(): IterableIterator<string> {
     for (const entry of this.params) {
       yield entry[0];
     }
@@ -219,7 +219,7 @@ export class URLSearchParams {
    *         console.log(value);
    *       }
    */
-  *values(): Iterable<string> {
+  *values(): IterableIterator<string> {
     for (const entry of this.params) {
       yield entry[1];
     }
@@ -232,7 +232,7 @@ export class URLSearchParams {
    *         console.log(key, value);
    *       }
    */
-  *entries(): Iterable<[string, string]> {
+  *entries(): IterableIterator<[string, string]> {
     yield* this.params;
   }
 
@@ -243,7 +243,7 @@ export class URLSearchParams {
    *         console.log(key, value);
    *       }
    */
-  *[Symbol.iterator](): Iterable<[string, string]> {
+  *[Symbol.iterator](): IterableIterator<[string, string]> {
     yield* this.params;
   }
 


### PR DESCRIPTION
With #2970 we introduced a regression with the `UrlSearchParams` lost their DOM iterator capabilities.  This reintroduces them (as well as fixes a couple other related things so that there is assignability between the "abstract" DOM types and the implementation version.