### PR TITLE
Move deno_std to a more convenient location.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 	path = core/libdeno/build
 	url = https://github.com/denoland/chromium_build.git
 [submodule "deno_std"]
-	path = js/deps/https/deno.land/std
+	path = std
 	url = https://github.com/denoland/deno_std.git
 [submodule "deno_third_party"]
 	path = third_party

--- a/cli/tests/034_onload/imported.ts
+++ b/cli/tests/034_onload/imported.ts
@@ -1,4 +1,4 @@
-import { assert } from "../../../js/deps/https/deno.land/std/testing/asserts.ts";
+import { assert } from "../../../std/testing/asserts.ts";
 import "./nest_imported.ts";
 
 const handler = (e: Event): void => {

--- a/cli/tests/034_onload/main.ts
+++ b/cli/tests/034_onload/main.ts
@@ -1,4 +1,4 @@
-import { assert } from "../../../js/deps/https/deno.land/std/testing/asserts.ts";
+import { assert } from "../../../std/testing/asserts.ts";
 import "./imported.ts";
 
 const eventHandler = (e: Event): void => {

--- a/cli/tests/034_onload/nest_imported.ts
+++ b/cli/tests/034_onload/nest_imported.ts
@@ -1,4 +1,4 @@
-import { assert } from "../../../js/deps/https/deno.land/std/testing/asserts.ts";
+import { assert } from "../../../std/testing/asserts.ts";
 
 const handler = (e: Event): void => {
   assert(!e.cancelable);

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -1,9 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import {
-  serve,
-  ServerRequest
-} from "../../js/deps/https/deno.land/std/http/server.ts";
-import { assertEquals } from "../../js/deps/https/deno.land/std/testing/asserts.ts";
+import { serve, ServerRequest } from "../../std/http/server.ts";
+import { assertEquals } from "../../std/testing/asserts.ts";
 
 const addr = Deno.args[1] || "127.0.0.1:4555";
 

--- a/cli/tests/fetch_deps.ts
+++ b/cli/tests/fetch_deps.ts
@@ -1,5 +1,5 @@
 // Run ./tools/http_server.py too in order for this test to run.
-import { assert } from "../js/deps/https/deno.land/std/testing/asserts.ts";
+import { assert } from "../std/testing/asserts.ts";
 
 // TODO Top level await https://github.com/denoland/deno/issues/471
 async function main(): Promise<void> {

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 description = "Provides snapshots for the deno CLI"
 repository = "https://github.com/denoland/deno"
 exclude = [
-  "deps/https/deno.land/std/fs/testdata/0-link.ts",
-  "deps/https/deno.land/std/fs/testdata/copy_dir_link_file/0.txt",
+  "std/fs/testdata/0-link.ts",
+  "std/fs/testdata/copy_dir_link_file/0.txt",
 ]
 
 [lib]

--- a/js/test_util.ts
+++ b/js/test_util.ts
@@ -7,11 +7,8 @@
 // tests by the special string. permW1N0 means allow-write but not allow-net.
 // See tools/unit_tests.py for more details.
 
-import * as testing from "./deps/https/deno.land/std/testing/mod.ts";
-import {
-  assert,
-  assertEquals
-} from "./deps/https/deno.land/std/testing/asserts.ts";
+import * as testing from "../std/testing/mod.ts";
+import { assert, assertEquals } from "../std/testing/asserts.ts";
 export {
   assert,
   assertThrows,
@@ -21,7 +18,7 @@ export {
   assertStrictEq,
   assertStrContains,
   unreachable
-} from "./deps/https/deno.land/std/testing/asserts.ts";
+} from "../std/testing/asserts.ts";
 
 interface TestPermissions {
   read?: boolean;

--- a/js/unit_tests.ts
+++ b/js/unit_tests.ts
@@ -55,7 +55,7 @@ import "./version_test.ts";
 
 import "../website/app_test.ts";
 
-import { runIfMain } from "./deps/https/deno.land/std/testing/mod.ts";
+import { runIfMain } from "../std/testing/mod.ts";
 
 async function main(): Promise<void> {
   // Testing entire test suite serially

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -211,8 +211,8 @@ def run_http(build_dir, new_data):
 
 def bundle_benchmark(deno_exe):
     bundles = {
-        "file_server": "./js/deps/https/deno.land/std/http/file_server.ts",
-        "gist": "./js/deps/https/deno.land/std/examples/gist.ts",
+        "file_server": "./std/http/file_server.ts",
+        "gist": "./std/examples/gist.ts",
     }
 
     sizes = {}

--- a/tools/deno_http_proxy.ts
+++ b/tools/deno_http_proxy.ts
@@ -1,8 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import {
-  serve,
-  ServerRequest
-} from "../js/deps/https/deno.land/std/http/server.ts";
+import { serve, ServerRequest } from "../std/http/server.ts";
 
 const addr = Deno.args[1] || "127.0.0.1:4500";
 const originAddr = Deno.args[2] || "127.0.0.1:4501";

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -55,8 +55,7 @@ def deno_tcp_current_thread(deno_exe):
 def deno_http(deno_exe):
     port = get_port()
     deno_cmd = [
-        deno_exe, "run", "--allow-net",
-        "js/deps/https/deno.land/std/http/http_bench.ts",
+        deno_exe, "run", "--allow-net", "std/http/http_bench.ts",
         server_addr(port)
     ]
     print "http_benchmark testing DENO using net/http."

--- a/website/app_test.ts
+++ b/website/app_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
 import { test, assertEquals } from "../js/test_util.ts";
-import { runIfMain } from "../js/deps/https/deno.land/std/testing/mod.ts";
+import { runIfMain } from "../std/testing/mod.ts";
 import {
   BenchmarkRun,
   createBinarySizeColumns,


### PR DESCRIPTION
//js/deps/https/deno.land/std -> //std

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
