### PR TITLE
refactor: remove calls to tokio_util::block_on

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -656,50 +656,46 @@ mod tests {
   use crate::fs as deno_fs;
   use crate::tokio_util;
   use deno::ModuleSpecifier;
+  use futures::future::lazy;
   use std::path::PathBuf;
   use tempfile::TempDir;
 
-  impl TsCompiler {
-    fn compile_sync(
-      self: &Self,
-      state: ThreadSafeState,
-      source_file: &SourceFile,
-    ) -> Result<CompiledModule, ErrBox> {
-      tokio_util::block_on(self.compile_async(state, source_file))
-    }
-  }
-
   #[test]
-  fn test_compile_sync() {
-    tokio_util::init(|| {
-      let p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .join("tests/002_hello.ts")
-        .to_owned();
-      let specifier =
-        ModuleSpecifier::resolve_url_or_path(p.to_str().unwrap()).unwrap();
+  fn test_compile_async() {
+    let p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+      .parent()
+      .unwrap()
+      .join("tests/002_hello.ts")
+      .to_owned();
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path(p.to_str().unwrap()).unwrap();
 
-      let out = SourceFile {
-        url: specifier.as_url().clone(),
-        filename: PathBuf::from(p.to_str().unwrap().to_string()),
-        media_type: msg::MediaType::TypeScript,
-        source_code: include_bytes!("../tests/002_hello.ts").to_vec(),
-      };
+    let out = SourceFile {
+      url: specifier.as_url().clone(),
+      filename: PathBuf::from(p.to_str().unwrap().to_string()),
+      media_type: msg::MediaType::TypeScript,
+      source_code: include_bytes!("../tests/002_hello.ts").to_vec(),
+    };
 
-      let mock_state = ThreadSafeState::mock(vec![
-        String::from("deno"),
-        String::from("hello.js"),
-      ]);
-      let compiled = mock_state
+    let mock_state = ThreadSafeState::mock(vec![
+      String::from("deno"),
+      String::from("hello.js"),
+    ]);
+
+    tokio_util::run(lazy(move || {
+      mock_state
         .ts_compiler
-        .compile_sync(mock_state.clone(), &out)
-        .unwrap();
-      assert!(compiled
-        .code
-        .as_bytes()
-        .starts_with("console.log(\"Hello World\");".as_bytes()));
-    })
+        .compile_async(mock_state.clone(), &out)
+        .then(|result| {
+          assert!(result.is_ok());
+          assert!(result
+            .unwrap()
+            .code
+            .as_bytes()
+            .starts_with("console.log(\"Hello World\");".as_bytes()));
+          Ok(())
+        })
+    }))
   }
 
   #[test]
@@ -719,12 +715,20 @@ mod tests {
       p.to_string_lossy().into(),
       String::from("$deno$/bundle.js"),
     ]);
-    let out = state.ts_compiler.bundle_async(
-      state.clone(),
-      module_name,
-      String::from("$deno$/bundle.js"),
-    );
-    assert!(tokio_util::block_on(out).is_ok());
+
+    tokio_util::run(lazy(move || {
+      state
+        .ts_compiler
+        .bundle_async(
+          state.clone(),
+          module_name,
+          String::from("$deno$/bundle.js"),
+        )
+        .then(|result| {
+          assert!(result.is_ok());
+          Ok(())
+        })
+    }))
   }
 
   #[test]

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -139,22 +139,22 @@ mod tests {
   use super::*;
   use crate::tokio_util;
 
-  pub fn fetch_string_once_sync(url: &Url) -> Result<FetchOnceResult, ErrBox> {
-    tokio_util::block_on(fetch_string_once(url))
-  }
-
   #[test]
   fn test_fetch_sync_string() {
     let http_server_guard = crate::test_util::http_server();
     // Relies on external http server. See tools/http_server.py
     let url = Url::parse("http://127.0.0.1:4545/package.json").unwrap();
-    tokio_util::init(|| match fetch_string_once_sync(&url).unwrap() {
-      FetchOnceResult::Code(code, maybe_content_type) => {
+
+    let fut = fetch_string_once(&url).then(|result| match result {
+      Ok(FetchOnceResult::Code(code, maybe_content_type)) => {
         assert!(!code.is_empty());
         assert_eq!(maybe_content_type, Some("application/json".to_string()));
+        Ok(())
       }
-      _ => unreachable!(),
+      _ => panic!(),
     });
+
+    tokio_util::run(fut);
     drop(http_server_guard);
   }
 
@@ -165,10 +165,15 @@ mod tests {
     let url = Url::parse("http://127.0.0.1:4546/package.json").unwrap();
     // Dns resolver substitutes `127.0.0.1` with `localhost`
     let target_url = Url::parse("http://localhost:4545/package.json").unwrap();
-    tokio_util::init(|| {
-      let result = fetch_string_once_sync(&url).unwrap();
-      assert_eq!(result, FetchOnceResult::Redirect(target_url));
+    let fut = fetch_string_once(&url).then(move |result| match result {
+      Ok(FetchOnceResult::Redirect(url)) => {
+        assert_eq!(url, target_url);
+        Ok(())
+      }
+      _ => panic!(),
     });
+
+    tokio_util::run(fut);
     drop(http_server_guard);
   }
 


### PR DESCRIPTION
Removes as many calls to `tokio_util::block_on` as possible