### PR TITLE
ci: add timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     name: ${{ matrix.kind }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: [macOS-10.14, windows-2016, ubuntu-16.04]


### PR DESCRIPTION
I managed to somehow hang CI and jobs been running for more than 3 hours. 

This PR adds 60 minutes timeout to CI