### PR TITLE
CI: don't build while linting and try to publish in forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,7 @@ jobs:
         run: cargo clippy --all-targets --release --locked -- -D clippy::all
 
       - name: Build
+        if: matrix.kind != 'lint'
         run: cargo build --release --locked --all-targets
 
       - name: Test
@@ -110,7 +111,7 @@ jobs:
         run: python ./tools/benchmark.py target/release
 
       - name: Post Benchmarks
-        if: matrix.kind == 'bench' && github.ref == 'refs/heads/master'
+        if: matrix.kind == 'bench' && github.ref == 'refs/heads/master' && github.repository == 'denoland/deno'
         env:
           DENOBOT_PAT: ${{ secrets.DENOBOT_PAT }}
         run: |
@@ -132,20 +133,20 @@ jobs:
           cat /proc/meminfo
 
       - name: Pre-release (linux)
-        if: startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.os, 'ubuntu') && matrix.kind != 'lint'
         run: gzip -c target/release/deno > target/release/deno_linux_x64.gz
 
       - name: Pre-release (mac)
-        if: startsWith(matrix.os, 'macOS')
+        if: startsWith(matrix.os, 'macOS') && matrix.kind != 'lint'
         run: gzip -c target/release/deno > target/release/deno_osx_x64.gz
 
       - name: Pre-release (windows)
-        if: startsWith(matrix.os, 'windows')
+        if: startsWith(matrix.os, 'windows') && matrix.kind != 'lint'
         run: PowerShell -Command "& {Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno_win_x64.zip}"
 
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: matrix.kind == 'test' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.kind == 'test' && startsWith(github.ref, 'refs/tags/') && github.repository == 'denoland/deno'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This PR fixes 2 smaller issues with the gh action CI:
* don't try (and fail) to publish (benchmarks or releases on tag pushes) when running in a fork (reported by @nayeemrmn in gitter)
* don't build in the lint job (could safe some time to get faster linting results)