### PR TITLE
CI: remove appveyor specific code + fix publish benmark results race

### DIFF
--- a/core/build.rs
+++ b/core/build.rs
@@ -51,8 +51,6 @@ mod gn {
       // Tell Cargo when to re-run this file. We do this first, so these directives
       // can take effect even if something goes wrong later in the build process.
       println!("cargo:rerun-if-env-changed=DENO_BUILD_PATH");
-      // TODO: this is obviously not appropriate here.
-      println!("cargo:rerun-if-env-changed=APPVEYOR_REPO_COMMIT");
 
       // This helps Rust source files locate the snapshot, source map etc.
       println!("cargo:rustc-env=GN_OUT_DIR={}", gn_out_dir);

--- a/tools/util.py
+++ b/tools/util.py
@@ -236,9 +236,6 @@ def parse_exit_code(s):
 def enable_ansi_colors():
     if os.name != 'nt':
         return True  # On non-windows platforms this just works.
-    elif "CI" in os.environ:
-        return True  # Ansi escape codes work out of the box on Appveyor.
-
     return enable_ansi_colors_win10()
 
 


### PR DESCRIPTION
This PR:
* removes some no longer needed appveyor specific code paths
* significantly reduces the likelihood for a race condition when 2 concurrent CI jobs try to publish benchmark results, fixes #3062
* makes benchmark result publishing slightly more robust by not silently swallowing `gh-pages` branch checkout failures and starting from new with an empty history (and only run the `gh-pages` checkout on CI)