### PR TITLE
refactor benchmark results posting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,16 +115,15 @@ jobs:
         env:
           DENOBOT_PAT: ${{ secrets.DENOBOT_PAT }}
         run: |
-          # Note gh-pages branch is cloned into //gh-pages/ by
-          # tools/benchmark.py, hence the following copy is ok:
+          git clone --depth 1 -b gh-pages https://${DENOBOT_PAT}@github.com/denoland/deno.git gh-pages
+          python ./tools/build_benchmark_jsons.py
           cp -r website/* gh-pages/
           cd gh-pages
-          git remote add origin2 https://${DENOBOT_PAT}@github.com/denoland/deno.git
           git config user.email "propelml@gmail.com"
           git config user.name "denobot"
           git add .
           git commit --message "Update benchmarks"
-          git push origin2 gh-pages
+          git push origin gh-pages
 
       - name: Worker info
         if: matrix.kind == 'bench'

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -10,7 +10,6 @@ import os
 import sys
 import json
 import time
-import shutil
 import tempfile
 import subprocess
 from util import build_path, executable_suffix, root_path, run, run_output
@@ -30,10 +29,6 @@ exec_time_benchmarks = [
     ("workers_round_robin", ["tests/workers_round_robin_bench.ts"]),
 ]
 
-gh_pages_data_file = "gh-pages/data.json"
-all_data_file = "website/data.json"  # Includes all benchmark data.
-recent_data_file = "website/recent.json"  # Includes recent 20 benchmark data.
-
 
 def read_json(filename):
     with open(filename) as json_file:
@@ -43,19 +38,6 @@ def read_json(filename):
 def write_json(filename, data):
     with open(filename, 'w') as outfile:
         json.dump(data, outfile)
-
-
-def import_data_from_gh_pages():
-    if os.path.exists(all_data_file):
-        return
-    try:
-        run([
-            "git", "clone", "--depth", "1", "-b", "gh-pages",
-            "https://github.com/denoland/deno.git", "gh-pages"
-        ])
-        shutil.copy(gh_pages_data_file, all_data_file)
-    except ValueError:
-        write_json(all_data_file, [])  # writes empty json data
 
 
 def get_binary_sizes(build_dir):
@@ -246,7 +228,6 @@ def main(argv):
     deno_exe = os.path.join(build_dir, "deno")
 
     os.chdir(root_path)
-    import_data_from_gh_pages()
 
     new_data = {
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -275,11 +256,7 @@ def main(argv):
     print json.dumps(new_data, indent=2)
     print "===== </BENCHMARK RESULTS>"
 
-    all_data = read_json(all_data_file)
-    all_data.append(new_data)
-
-    write_json(all_data_file, all_data)
-    write_json(recent_data_file, all_data[-20:])
+    write_json(os.path.join(build_dir, "bench.json"), new_data)
 
 
 if __name__ == '__main__':

--- a/tools/build_benchmark_jsons.py
+++ b/tools/build_benchmark_jsons.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+from util import build_path
+from benchmark import read_json, write_json
+import os
+
+current_data_file = os.path.join(build_path(), "bench.json")
+gh_pages_data_file = "gh-pages/data.json"
+all_data_file = "website/data.json"  # Includes all benchmark data.
+recent_data_file = "website/recent.json"  # Includes recent 20 benchmark data.
+
+assert os.path.exists(current_data_file)
+assert os.path.exists(gh_pages_data_file)
+
+new_data = read_json(current_data_file)
+all_data = read_json(gh_pages_data_file)
+all_data.append(new_data)
+
+write_json(all_data_file, all_data)
+write_json(recent_data_file, all_data[-20:])


### PR DESCRIPTION
Fixes: #3062
Continuation of: #3071

This PR moves the 'checking out the old historic benchmark data' from `benchmark.py` to a much later point in the gh action script, which should significantly reduce the likelihood of race conditions as described in #3062.

This also moves the merging of new benchmark results into the all `data.json` into a separated file, called in CI directly after checking out `gh-pages` and directly before pushing the new data to it. It should be also slightly more robust against `gh-pages` checkout failures, because it fails now the build instead of silently starting with an empty array in such cases as before.