### PR TITLE
Ensure DENO_DIR when saving the REPL history

### DIFF
--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -2,6 +2,7 @@
 use crate::deno_dir::DenoDir;
 use deno::ErrBox;
 use rustyline;
+use std::fs;
 use std::path::PathBuf;
 
 #[cfg(not(windows))]
@@ -76,14 +77,7 @@ impl Repl {
   }
 
   fn save_history(&mut self) -> Result<(), ErrBox> {
-    if !self.history_dir_exists() {
-      eprintln!(
-        "Unable to save REPL history: {:?} directory does not exist",
-        self.history_file
-      );
-      return Ok(());
-    }
-
+    fs::create_dir_all(self.history_file.parent().unwrap())?;
     self
       .editor
       .save_history(&self.history_file.to_str().unwrap())
@@ -92,14 +86,6 @@ impl Repl {
         eprintln!("Unable to save REPL history: {:?} {}", self.history_file, e);
         ErrBox::from(e)
       })
-  }
-
-  fn history_dir_exists(&self) -> bool {
-    self
-      .history_file
-      .parent()
-      .map(|ref p| p.exists())
-      .unwrap_or(false)
   }
 
   pub fn readline(&mut self, prompt: &str) -> Result<String, ErrBox> {

--- a/tools/repl_test.py
+++ b/tools/repl_test.py
@@ -150,11 +150,11 @@ class TestRepl(DenoTestCase):
         new_env = os.environ.copy()
         new_env["DENO_DIR"] = deno_dir
         out, err, code = self.input("1", exit=False, env=new_env)
+        self.assertTrue(os.path.isdir(deno_dir))
+        shutil.rmtree(deno_dir)
         self.assertEqual(out, "1\n")
         self.assertEqual(err, "")
         self.assertEqual(code, 0)
-        self.assertTrue(os.path.isdir(deno_dir))
-        shutil.rmtree(deno_dir)
 
     def test_save_last_eval(self):
         out, err, code = self.input("1", "_")

--- a/tools/repl_test.py
+++ b/tools/repl_test.py
@@ -1,5 +1,6 @@
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import os
+import shutil
 from subprocess import CalledProcessError, PIPE, Popen
 import sys
 import time
@@ -145,12 +146,15 @@ class TestRepl(DenoTestCase):
         self.assertEqual(code, 0)
 
     def test_missing_deno_dir(self):
+        deno_dir = "nonexistent"
         new_env = os.environ.copy()
-        new_env["DENO_DIR"] = os.path.abspath("doesnt_exist")
-        out, err, code = self.input("'noop'", exit=False, env=new_env)
-        self.assertEqual(out, "noop\n")
-        self.assertTrue(err.startswith("Unable to save REPL history:"))
+        new_env["DENO_DIR"] = deno_dir
+        out, err, code = self.input("1", exit=False, env=new_env)
+        self.assertEqual(out, "1\n")
+        self.assertEqual(err, "")
         self.assertEqual(code, 0)
+        self.assertTrue(os.path.isdir(deno_dir))
+        shutil.rmtree(deno_dir)
 
     def test_save_last_eval(self):
         out, err, code = self.input("1", "_")


### PR DESCRIPTION
Fixes #3104.

I still think it should be an entry in `DenoDir`, though.