### PR TITLE
fix: [tls] op_dial_tls is not registerd and broken

### DIFF
--- a/cli/js/tls_test.ts
+++ b/cli/js/tls_test.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, testPerm, assert, assertEquals } from "./test_util.ts";
-
+import { BufWriter, BufReader } from "../../std/io/bufio.ts";
+import { TextProtoReader } from "../../std/textproto/mod.ts";
+import { runIfMain } from "../../std/testing/mod.ts";
 // TODO(ry) The tests in this file use github.com:443, but it would be better to
 // not rely on an internet connection and rather use a localhost TLS server.
 
@@ -18,8 +20,28 @@ test(async function dialTLSNoPerm(): Promise<void> {
 testPerm({ net: true }, async function dialTLSBasic(): Promise<void> {
   const conn = await Deno.dialTLS({ hostname: "github.com", port: 443 });
   assert(conn.rid > 0);
-  const body = new TextEncoder().encode("GET / HTTP/1.0\r\n\r\n");
-  const writeResult = await conn.write(body);
+  const w = new BufWriter(conn);
+  const r = new BufReader(conn);
+  let body = "GET / HTTP/1.1\r\n";
+  body += "Host: github.com\r\n";
+  body += "\r\n";
+  const writeResult = await w.write(new TextEncoder().encode(body));
   assertEquals(body.length, writeResult);
+  await w.flush();
+  const tpr = new TextProtoReader(r);
+  const statusLine = await tpr.readLine();
+  assert(!!statusLine, "line must be read: " + statusLine);
+  const m = statusLine.match(/^(.+?) (.+?) (.+?)$/);
+  assert(m !== null, "must be matched");
+  const [_, proto, status, ok] = m;
+  assertEquals(proto, "HTTP/1.1");
+  assertEquals(status, "200");
+  assertEquals(ok, "OK");
+  const headers = await tpr.readMIMEHeader();
+  const contentLength = parseInt(headers.get("content-length"));
+  const bodyBuf = new Uint8Array(contentLength);
+  await r.readFull(bodyBuf);
   conn.close();
 });
+
+runIfMain(import.meta);

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -20,4 +20,5 @@ pub mod random;
 pub mod repl;
 pub mod resources;
 pub mod timers;
+pub mod tls;
 pub mod workers;

--- a/cli/ops/net.rs
+++ b/cli/ops/net.rs
@@ -18,7 +18,6 @@ use tokio::net::TcpStream;
 pub fn init(i: &mut Isolate, s: &ThreadSafeState) {
   i.register_op("accept", s.core_op(json_op(s.stateful_op(op_accept))));
   i.register_op("dial", s.core_op(json_op(s.stateful_op(op_dial))));
-  i.register_op("dial_tls", s.core_op(json_op(s.stateful_op(op_dial))));
   i.register_op("shutdown", s.core_op(json_op(s.stateful_op(op_shutdown))));
   i.register_op("listen", s.core_op(json_op(s.stateful_op(op_listen))));
 }

--- a/cli/ops/tls.rs
+++ b/cli/ops/tls.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 use super::dispatch_json::{Deserialize, JsonOp, Value};
+use crate::ops::json_op;
 use crate::resolve_addr::resolve_addr;
 use crate::resources;
 use crate::state::ThreadSafeState;
@@ -19,6 +20,9 @@ use webpki_roots;
 struct DialTLSArgs {
   hostname: String,
   port: u16,
+}
+pub fn init(i: &mut Isolate, s: &ThreadSafeState) {
+  i.register_op("dial_tls", s.core_op(json_op(s.stateful_op(op_dial_tls))));
 }
 
 pub fn op_dial_tls(

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -39,6 +39,7 @@ impl Worker {
       ops::fs::init(&mut i, &state);
       ops::io::init(&mut i, &state);
       ops::net::init(&mut i, &state);
+      ops::tls::init(&mut i, &state);
       ops::os::init(&mut i, &state);
       ops::permissions::init(&mut i, &state);
       ops::process::init(&mut i, &state);


### PR DESCRIPTION
- `dialTLS` was broken on 97d8498d
  - Or broken from v0.20.0? v0.19.0's  `dialTLS` works fine.
- added more accurate test.