### PR TITLE
Add CustomInspect for Headers

### DIFF
--- a/cli/js/headers.ts
+++ b/cli/js/headers.ts
@@ -2,6 +2,7 @@
 import * as domTypes from "./dom_types.ts";
 import { DomIterableMixin } from "./mixins/dom_iterable.ts";
 import { requiredArguments } from "./util.ts";
+import { customInspect } from "./console.ts";
 
 // From node-fetch
 // Copyright (c) 2016 David Frank. MIT License.
@@ -83,6 +84,18 @@ class HeadersBase {
         }
       }
     }
+  }
+
+  [customInspect](): string {
+    let headerSize = this[headerMap].size;
+    let output = "";
+    this[headerMap].forEach((value, key) => {
+      const prefix = headerSize === this[headerMap].size ? " " : "";
+      const postfix = headerSize === 1 ? " " : ", ";
+      output = output + `${prefix}${key}: ${value}${postfix}`;
+      headerSize--;
+    });
+    return `Headers {${output}}`;
   }
 
   // ref: https://fetch.spec.whatwg.org/#concept-headers-append

--- a/cli/js/headers_test.ts
+++ b/cli/js/headers_test.ts
@@ -1,5 +1,9 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assert, assertEquals } from "./test_util.ts";
+const {
+  stringifyArgs
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} = Deno as any;
 
 // Logic heavily copied from web-platform-tests, make
 // sure pass mostly header basic test
@@ -328,4 +332,26 @@ test(function headerParamsArgumentsCheck(): void {
 test(function toStringShouldBeWebCompatibility(): void {
   const headers = new Headers();
   assertEquals(headers.toString(), "[object Headers]");
+});
+
+function stringify(...args: unknown[]): string {
+  return stringifyArgs(args).replace(/\n$/, "");
+}
+
+test(function customInspectReturnsCorrectHeadersFormat(): void {
+  const blankHeaders = new Headers();
+  assertEquals(stringify(blankHeaders), "Headers {}");
+  const singleHeader = new Headers([["Content-Type", "application/json"]]);
+  assertEquals(
+    stringify(singleHeader),
+    "Headers { content-type: application/json }"
+  );
+  const multiParamHeader = new Headers([
+    ["Content-Type", "application/json"],
+    ["Content-Length", "1337"]
+  ]);
+  assertEquals(
+    stringify(multiParamHeader),
+    "Headers { content-type: application/json, content-length: 1337 }"
+  );
 });


### PR DESCRIPTION
Fixes: https://github.com/denoland/deno_std/issues/543

cli/js/headers.ts
- Adds an implementation of CustomInspect for the Headers class
- Worth noting due to implementation of the Headers class the contents of headersMap have lowercase keys, although this matches the specification as header keys are case agnostic, it does seem to not match behaviour of other implementations in other languages I have seen, would require some rewriting of Headers.ts

cli/js/headers_test.ts
- Adds a test to ensure that the output matches expectations