### PR TITLE
Use max-width over max-device-width

### DIFF
--- a/website/style.css
+++ b/website/style.css
@@ -140,7 +140,7 @@ header h1 {
   margin: 8px 0;
 }
 
-@media only screen and (max-device-width: 480px) {
+@media only screen and (max-width: 480px) {
   body {
     margin: 0;
   }


### PR DESCRIPTION
Using max-width because this applies the mobile styles to narrow windows
on larger devices as well as full with windows on narrow devices.

# Before

![Screenshot 2019-10-15 at 21 47 38](https://user-images.githubusercontent.com/440503/66869996-6d570e00-ef98-11e9-8629-a018cf2e0d89.png)

# After

![Screenshot 2019-10-15 at 21 48 02](https://user-images.githubusercontent.com/440503/66870022-7516b280-ef98-11e9-926b-85c90c9854a7.png)

