### PR TITLE
WIP Update Permissions API

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -54,7 +54,6 @@ pub struct DenoFlags {
   pub allow_env: bool,
   pub allow_run: bool,
   pub allow_hrtime: bool,
-  pub no_prompts: bool,
   pub no_fetch: bool,
   pub seed: Option<u64>,
   pub v8_flags: Option<Vec<String>>,
@@ -117,11 +116,6 @@ fn add_run_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         .short("A")
         .long("allow-all")
         .help("Allow all permissions"),
-    )
-    .arg(
-      Arg::with_name("no-prompt")
-        .long("no-prompt")
-        .help("Do not use prompts"),
     )
     .arg(
       Arg::with_name("no-fetch")
@@ -706,9 +700,6 @@ fn parse_run_args(mut flags: DenoFlags, matches: &ArgMatches) -> DenoFlags {
     flags.allow_read = true;
     flags.allow_write = true;
     flags.allow_hrtime = true;
-  }
-  if matches.is_present("no-prompt") {
-    flags.no_prompts = true;
   }
   if matches.is_present("no-fetch") {
     flags.no_fetch = true;

--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -66,12 +66,7 @@ export { symlinkSync, symlink } from "./symlink.ts";
 export { writeFileSync, writeFile, WriteFileOptions } from "./write_file.ts";
 export { applySourceMap } from "./error_stack.ts";
 export { ErrorKind, DenoError } from "./errors.ts";
-export {
-  permissions,
-  revokePermission,
-  Permission,
-  Permissions
-} from "./permissions.ts";
+export { permissions } from "./permissions.ts";
 export { truncateSync, truncate } from "./truncate.ts";
 export { FileInfo } from "./file_info.ts";
 export { connect, dial, listen, Listener, Conn } from "./net.ts";

--- a/cli/js/dispatch.ts
+++ b/cli/js/dispatch.ts
@@ -36,8 +36,6 @@ export let OP_GET_RANDOM_VALUES: number;
 export let OP_GLOBAL_TIMER_STOP: number;
 export let OP_GLOBAL_TIMER: number;
 export let OP_NOW: number;
-export let OP_PERMISSIONS: number;
-export let OP_REVOKE_PERMISSION: number;
 export let OP_CREATE_WORKER: number;
 export let OP_HOST_GET_WORKER_CLOSED: number;
 export let OP_HOST_POST_MESSAGE: number;
@@ -65,6 +63,9 @@ export let OP_CWD: number;
 export let OP_FETCH_ASSET: number;
 export let OP_DIAL_TLS: number;
 export let OP_HOSTNAME: number;
+export let OP_QUERY_PERMISSION: number;
+export let OP_REQUEST_PERMISSION: number;
+export let OP_REVOKE_PERMISSION: number;
 
 export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
   switch (opId) {
@@ -105,6 +106,9 @@ export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
     case OP_MAKE_TEMP_DIR:
     case OP_DIAL_TLS:
     case OP_FETCH_SOURCE_FILES:
+    case OP_QUERY_PERMISSION:
+    case OP_REQUEST_PERMISSION:
+    case OP_REVOKE_PERMISSION:
       json.asyncMsgFromRust(opId, ui8);
       break;
     default:

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -885,33 +885,30 @@ declare namespace Deno {
   // @url js/permissions.d.ts
 
   /** Permissions as granted by the caller */
-  export interface Permissions {
-    read: boolean;
-    write: boolean;
-    net: boolean;
-    env: boolean;
-    run: boolean;
-    hrtime: boolean;
+  export type PermissionName =
+    | "run"
+    | "read"
+    | "write"
+    | "net"
+    | "env"
+    | "hrtime";
+  export type PermissionState = "granted" | "denied" | "prompt";
+  interface PermissionDescriptor {
+    name: PermissionName;
+    url?: string;
+    path?: string;
   }
-  export type Permission = keyof Permissions;
-  /** Inspect granted permissions for the current program.
-   *
-   *       if (Deno.permissions().read) {
-   *         const file = await Deno.readFile("example.test");
-   *         // ...
-   *       }
-   */
-  export function permissions(): Permissions;
-  /** Revoke a permission. When the permission was already revoked nothing changes
-   *
-   *       if (Deno.permissions().read) {
-   *         const file = await Deno.readFile("example.test");
-   *         Deno.revokePermission('read');
-   *       }
-   *       Deno.readFile("example.test"); // -> error or permission prompt
-   */
-  export function revokePermission(permission: Permission): void;
+  export class Permissions {
+    query(d: PermissionDescriptor): Promise<PermissionStatus>;
+    request(d: PermissionDescriptor): Promise<PermissionStatus>;
+    revoke(d: PermissionDescriptor): Promise<PermissionStatus>;
+  }
+  export const permissions: Permissions;
 
+  export class PermissionStatus {
+    state: PermissionState;
+    constructor(state: PermissionState);
+  }
   // @url js/truncate.d.ts
 
   /** Truncates or extends the specified file synchronously, updating the size of

--- a/cli/js/permissions.ts
+++ b/cli/js/permissions.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import * as dispatch from "./dispatch.ts";
 import { sendSync } from "./dispatch_json.ts";
-import * as eventTarget from "./event_target.ts";
 
 /** Permissions as granted by the caller
  * See: https://w3c.github.io/permissions/#permission-registry
@@ -21,47 +20,43 @@ export type PermissionState = "granted" | "denied" | "prompt";
 /** See: https://w3c.github.io/permissions/#permission-descriptor */
 interface PermissionDescriptor {
   name: PermissionName;
+  url?: string;
+  path?: string;
 }
 
 export class Permissions {
   /**
    */
   async query(desc: PermissionDescriptor): Promise<PermissionStatus> {
-    const { state } = await sendSync(dispatch.OP_QUERY_PERMISSION, {
-      name: desc.name
+    const { state } = sendSync(dispatch.OP_QUERY_PERMISSION, {
+      ...desc
     });
-    return new PermissionStatus(desc, state);
+    return new PermissionStatus(state);
   }
 
   /**
    */
   async revoke(desc: PermissionDescriptor): Promise<PermissionStatus> {
-    const { state } = await sendSync(dispatch.OP_REVOKE_PERMISSION, {
-      name: desc.name
+    const { state } = sendSync(dispatch.OP_REVOKE_PERMISSION, {
+      ...desc
     });
-    return new PermissionStatus(desc, state);
+    return new PermissionStatus(state);
   }
 
   /**
    */
   async request(desc: PermissionDescriptor): Promise<PermissionStatus> {
-    const { state } = await sendSync(dispatch.OP_REQUEST_PERMISSION, {
-      name: desc.name
+    const { state } = sendSync(dispatch.OP_REQUEST_PERMISSION, {
+      ...desc
     });
-    return new PermissionStatus(desc, state);
+    return new PermissionStatus(state);
   }
 }
 
 export const permissions = new Permissions();
 
 /** https://w3c.github.io/permissions/#permissionstatus */
-export class PermissionStatus extends eventTarget.EventTarget {
-  private _desc: PermissionDescriptor;
-  state: PermissionState;
-  constructor(desc: PermissionDescriptor, state: PermissionState) {
-    super();
-    this._desc = desc;
-    this.state = state;
-  }
+export class PermissionStatus {
+  constructor(public state: PermissionState) {}
   // TODO(kt3k): implement onchange handler
 }

--- a/cli/js/permissions.ts
+++ b/cli/js/permissions.ts
@@ -26,29 +26,26 @@ interface PermissionDescriptor {
 
 export class Permissions {
   /**
+   * Queries the permission.
    */
   async query(desc: PermissionDescriptor): Promise<PermissionStatus> {
-    const { state } = sendSync(dispatch.OP_QUERY_PERMISSION, {
-      ...desc
-    });
+    const { state } = sendSync(dispatch.OP_QUERY_PERMISSION, desc);
     return new PermissionStatus(state);
   }
 
   /**
+   * Revokes the permission.
    */
   async revoke(desc: PermissionDescriptor): Promise<PermissionStatus> {
-    const { state } = sendSync(dispatch.OP_REVOKE_PERMISSION, {
-      ...desc
-    });
+    const { state } = sendSync(dispatch.OP_REVOKE_PERMISSION, desc);
     return new PermissionStatus(state);
   }
 
   /**
+   * Requests the permission.
    */
   async request(desc: PermissionDescriptor): Promise<PermissionStatus> {
-    const { state } = sendSync(dispatch.OP_REQUEST_PERMISSION, {
-      ...desc
-    });
+    const { state } = sendSync(dispatch.OP_REQUEST_PERMISSION, desc);
     return new PermissionStatus(state);
   }
 }

--- a/cli/js/permissions.ts
+++ b/cli/js/permissions.ts
@@ -1,39 +1,67 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import * as dispatch from "./dispatch.ts";
 import { sendSync } from "./dispatch_json.ts";
+import * as eventTarget from "./event_target.ts";
 
-/** Permissions as granted by the caller */
-export interface Permissions {
-  read: boolean;
-  write: boolean;
-  net: boolean;
-  env: boolean;
-  run: boolean;
-  hrtime: boolean;
-  // NOTE: Keep in sync with src/permissions.rs
+/** Permissions as granted by the caller
+ * See: https://w3c.github.io/permissions/#permission-registry
+ */
+export type PermissionName =
+  | "read"
+  | "write"
+  | "net"
+  | "env"
+  | "run"
+  | "hrtime";
+// NOTE: Keep in sync with src/permissions.rs
+
+/** https://w3c.github.io/permissions/#status-of-a-permission */
+export type PermissionState = "granted" | "denied" | "prompt";
+
+/** See: https://w3c.github.io/permissions/#permission-descriptor */
+interface PermissionDescriptor {
+  name: PermissionName;
 }
 
-export type Permission = keyof Permissions;
+export class Permissions {
+  /**
+   */
+  async query(desc: PermissionDescriptor): Promise<PermissionStatus> {
+    const { state } = await sendSync(dispatch.OP_QUERY_PERMISSION, {
+      name: desc.name
+    });
+    return new PermissionStatus(desc, state);
+  }
 
-/** Inspect granted permissions for the current program.
- *
- *       if (Deno.permissions().read) {
- *         const file = await Deno.readFile("example.test");
- *         // ...
- *       }
- */
-export function permissions(): Permissions {
-  return sendSync(dispatch.OP_PERMISSIONS) as Permissions;
+  /**
+   */
+  async revoke(desc: PermissionDescriptor): Promise<PermissionStatus> {
+    const { state } = await sendSync(dispatch.OP_REVOKE_PERMISSION, {
+      name: desc.name
+    });
+    return new PermissionStatus(desc, state);
+  }
+
+  /**
+   */
+  async request(desc: PermissionDescriptor): Promise<PermissionStatus> {
+    const { state } = await sendSync(dispatch.OP_REQUEST_PERMISSION, {
+      name: desc.name
+    });
+    return new PermissionStatus(desc, state);
+  }
 }
 
-/** Revoke a permission. When the permission was already revoked nothing changes
- *
- *       if (Deno.permissions().read) {
- *         const file = await Deno.readFile("example.test");
- *         Deno.revokePermission('read');
- *       }
- *       Deno.readFile("example.test"); // -> error or permission prompt
- */
-export function revokePermission(permission: Permission): void {
-  sendSync(dispatch.OP_REVOKE_PERMISSION, { permission });
+export const permissions = new Permissions();
+
+/** https://w3c.github.io/permissions/#permissionstatus */
+export class PermissionStatus extends eventTarget.EventTarget {
+  private _desc: PermissionDescriptor;
+  state: PermissionState;
+  constructor(desc: PermissionDescriptor, state: PermissionState) {
+    super();
+    this._desc = desc;
+    this.state = state;
+  }
+  // TODO(kt3k): implement onchange handler
 }

--- a/cli/js/permissions_test.ts
+++ b/cli/js/permissions_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { testPerm, assert, assertEquals } from "./test_util.ts";
 
-const knownPermissions: Deno.Permission[] = [
+const knownPermissions: Deno.PermissionName[] = [
   "run",
   "read",
   "write",
@@ -11,18 +11,13 @@ const knownPermissions: Deno.Permission[] = [
 ];
 
 for (const grant of knownPermissions) {
-  testPerm({ [grant]: true }, function envGranted(): void {
-    const perms = Deno.permissions();
-    assert(perms !== null);
-    for (const perm in perms) {
-      assertEquals(perms[perm], perm === grant);
-    }
+  testPerm({ [grant]: true }, async function envGranted(): Promise<void> {
+    const status0 = await Deno.permissions.query({ name: grant });
+    assert(status0 != null);
+    assertEquals(status0.state, "granted");
 
-    Deno.revokePermission(grant);
-
-    const revoked = Deno.permissions();
-    for (const perm in revoked) {
-      assertEquals(revoked[perm], false);
-    }
+    const status1 = await Deno.permissions.revoke({ name: grant });
+    assert(status1 != null);
+    assertEquals(status1.state, "prompt");
   });
 }

--- a/cli/js/unit_test_runner.ts
+++ b/cli/js/unit_test_runner.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env -S deno run --reload --allow-run
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import "./unit_tests.ts";
-import { permissionCombinations, parseUnitTestOutput } from "./test_util.ts";
+import {
+  permissionCombinations,
+  parseUnitTestOutput,
+  Permissions
+} from "./test_util.ts";
 
 interface TestResult {
   perms: string;
@@ -9,7 +13,7 @@ interface TestResult {
   result: number;
 }
 
-function permsToCliFlags(perms: Deno.Permissions): string[] {
+function permsToCliFlags(perms: Permissions): string[] {
   return Object.keys(perms)
     .map(
       (key): string => {
@@ -25,7 +29,7 @@ function permsToCliFlags(perms: Deno.Permissions): string[] {
     .filter((e): boolean => e.length > 0);
 }
 
-function fmtPerms(perms: Deno.Permissions): string {
+function fmtPerms(perms: Permissions): string {
   let fmt = permsToCliFlags(perms).join(" ");
 
   if (!fmt) {
@@ -52,13 +56,7 @@ async function main(): Promise<void> {
     console.log(`Running tests for: ${permsFmt}`);
     const cliPerms = permsToCliFlags(perms);
     // run subsequent tests using same deno executable
-    const args = [
-      Deno.execPath(),
-      "run",
-      "--no-prompt",
-      ...cliPerms,
-      "cli/js/unit_tests.ts"
-    ];
+    const args = [Deno.execPath(), "run", ...cliPerms, "cli/js/unit_tests.ts"];
 
     const p = Deno.run({
       args,

--- a/cli/ops/permissions.rs
+++ b/cli/ops/permissions.rs
@@ -31,10 +31,10 @@ fn get_current_permission(
   state: &ThreadSafeState,
   args: &PermissionArgs,
 ) -> Result<permissions::PermissionAccessorState, ErrBox> {
-  Ok(
-    state
-      .permissions
-      .get_permission_state(&args.name, &args.path, &args.url)?,
+  state.permissions.get_permission_state(
+    &args.name,
+    &args.path.as_ref().map(String::as_str),
+    &args.url.as_ref().map(String::as_str),
   )
 }
 
@@ -72,9 +72,9 @@ pub fn op_request_permission(
 
   match name {
     "run" => state.permissions.request_run(),
-    "read" => state.permissions.request_read(path.unwrap().as_ref()),
-    "write" => state.permissions.request_write(path.unwrap().as_ref()),
-    "net" => state.permissions.request_net(url.unwrap().as_ref()),
+    "read" => state.permissions.request_read(&path.map(String::as_str)),
+    "write" => state.permissions.request_write(&path.map(String::as_str)),
+    "net" => state.permissions.request_net(&url.map(String::as_str)),
     "env" => state.permissions.request_env(),
     "hrtime" => state.permissions.request_hrtime(),
     _ => Ok(()),

--- a/cli/ops/permissions.rs
+++ b/cli/ops/permissions.rs
@@ -6,8 +6,12 @@ use deno::*;
 
 pub fn init(i: &mut Isolate, s: &ThreadSafeState) {
   i.register_op(
-    "permissions",
-    s.core_op(json_op(s.stateful_op(op_permissions))),
+    "query_permission",
+    s.core_op(json_op(s.stateful_op(op_query_permission))),
+  );
+  i.register_op(
+    "request_permission",
+    s.core_op(json_op(s.stateful_op(op_request_permission))),
   );
   i.register_op(
     "revoke_permission",
@@ -31,8 +35,42 @@ pub fn op_permissions(
 }
 
 #[derive(Deserialize)]
-struct RevokePermissionArgs {
-  permission: String,
+struct PermissionArgs {
+  name: String,
+  url: Option<String>,
+  path: Option<String>,
+}
+
+pub fn op_query_permission(
+  state: &ThreadSafeState,
+  args: Value,
+  _zero_copy: Option<PinnedBuf>,
+) -> Result<JsonOp, ErrBox> {
+  let args: PermissionArgs = serde_json::from_value(args)?;
+  Ok(JsonOp::Sync(json!({
+    "state": state.permissions.get_permission_string(args.name)?
+  })))
+}
+
+pub fn op_request_permission(
+  state: &ThreadSafeState,
+  value: Value,
+  _zero_copy: Option<PinnedBuf>,
+) -> Result<JsonOp, ErrBox> {
+  let args: PermissionArgs = serde_json::from_value(value)?;
+  let name = args.name.as_ref();
+  match name {
+    "run" => state.permissions.request_run(),
+    "read" => state.permissions.request_read(args.path.unwrap().as_ref()),
+    "write" => state.permissions.request_write(args.path.unwrap().as_ref()),
+    "net" => state.permissions.request_net(args.url.unwrap().as_ref()),
+    "env" => state.permissions.request_env(),
+    "hrtime" => state.permissions.request_hrtime(),
+    _ => Ok(()),
+  }?;
+  Ok(JsonOp::Sync(json!({
+    "state": state.permissions.get_permission_string(args.name)?
+  })))
 }
 
 pub fn op_revoke_permission(
@@ -40,9 +78,8 @@ pub fn op_revoke_permission(
   args: Value,
   _zero_copy: Option<PinnedBuf>,
 ) -> Result<JsonOp, ErrBox> {
-  let args: RevokePermissionArgs = serde_json::from_value(args)?;
-  let permission = args.permission.as_ref();
-  match permission {
+  let args: PermissionArgs = serde_json::from_value(args)?;
+  match args.name.as_ref() {
     "run" => state.permissions.revoke_run(),
     "read" => state.permissions.revoke_read(),
     "write" => state.permissions.revoke_write(),
@@ -51,6 +88,7 @@ pub fn op_revoke_permission(
     "hrtime" => state.permissions.revoke_hrtime(),
     _ => Ok(()),
   }?;
-
-  Ok(JsonOp::Sync(json!({})))
+  Ok(JsonOp::Sync(json!({
+    "state": state.permissions.get_permission_string(args.name)?
+  })))
 }

--- a/cli/tests/025_hrtime.ts
+++ b/cli/tests/025_hrtime.ts
@@ -1,3 +1,3 @@
 console.log(performance.now() % 2 !== 0);
-Deno.revokePermission("hrtime");
+Deno.permissions.revoke({ name: "hrtime" });
 console.log(performance.now() % 2 === 0);

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -24,13 +24,7 @@ async function proxyRequest(req: ServerRequest): Promise<void> {
 
 async function testFetch(): Promise<void> {
   const c = Deno.run({
-    args: [
-      Deno.execPath(),
-      "--no-prompt",
-      "--reload",
-      "--allow-net",
-      "045_proxy_client.ts"
-    ],
+    args: [Deno.execPath(), "--reload", "--allow-net", "045_proxy_client.ts"],
     stdout: "piped",
     env: {
       HTTP_PROXY: `http://${addr}`
@@ -44,13 +38,7 @@ async function testFetch(): Promise<void> {
 
 async function testModuleDownload(): Promise<void> {
   const http = Deno.run({
-    args: [
-      Deno.execPath(),
-      "--no-prompt",
-      "--reload",
-      "fetch",
-      "http://deno.land/welcome.ts"
-    ],
+    args: [Deno.execPath(), "--reload", "fetch", "http://deno.land/welcome.ts"],
     stdout: "piped",
     env: {
       HTTP_PROXY: `http://${addr}`

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -452,7 +452,7 @@ itest!(error_014_catch_dynamic_import_error {
 });
 
 itest!(error_015_dynamic_import_permissions {
-  args: "--reload --no-prompt error_015_dynamic_import_permissions.js",
+  args: "--reload error_015_dynamic_import_permissions.js",
   output: "error_015_dynamic_import_permissions.out",
   check_stderr: true,
   exit_code: 1,
@@ -461,8 +461,7 @@ itest!(error_015_dynamic_import_permissions {
 
 // We have an allow-net flag but not allow-read, it should still result in error.
 itest!(error_016_dynamic_import_permissions2 {
-  args:
-    "--no-prompt --reload --allow-net error_016_dynamic_import_permissions2.js",
+  args: "--reload --allow-net error_016_dynamic_import_permissions2.js",
   output: "error_016_dynamic_import_permissions2.out",
   check_stderr: true,
   exit_code: 1,

--- a/website/manual.md
+++ b/website/manual.md
@@ -702,7 +702,6 @@ OPTIONS:
         --importmap <FILE>             Load import map file
     -L, --log-level <log-level>        Set log level [possible values: debug, info]
         --no-fetch                     Do not download remote modules
-        --no-prompt                    Do not use prompts
     -r, --reload=<CACHE_BLACKLIST>     Reload source code cache (recompile TypeScript)
         --seed <NUMBER>                Seed Math.random()
         --v8-flags=<v8-flags>          Set V8 command line options


### PR DESCRIPTION
This PR tries to update the permissions API, following the direction suggested in #2767. 

Now Deno.permissions has 3 methods `query`, `request`, and `revoke`:

For example, `query` works like the below:
```js
// test.js
(async () => {
  console.log(await Deno.permissions.query({ name: "net" }));
})();
```

```console
$ ./target/debug/deno test.js
PermissionStatus { _desc: { name: "net" }, state: "prompt" }
```

Done:
- Removed `allow once` `deny once` options in prompt because they don't make sense with the new API.

There are several remaining works:
- [ ] correct whitelist handling for `read`, `write`, and `net`
- [ ] update the usages of permissions module in rust.
- [x] update lib.deno_runtime.d.ts
- [ ] update documents
---
closes #2767