### PR TITLE
chore: remove xevalDelim from Start interface

### DIFF
--- a/cli/js/os.ts
+++ b/cli/js/os.ts
@@ -83,7 +83,6 @@ interface Start {
   v8Version: string;
   tsVersion: string;
   noColor: boolean;
-  xevalDelim: string;
   os: OperatingSystem;
   arch: Arch;
 }


### PR DESCRIPTION
Notice that we forgot to remove this when moving xeval to std.