### PR TITLE
Run `deno eval` code as module

### DIFF
--- a/cli/ops/workers.rs
+++ b/cli/ops/workers.rs
@@ -172,7 +172,7 @@ fn op_create_worker(
   }
 
   let op = worker
-    .execute_mod_async(&module_specifier, false)
+    .execute_mod_async(&module_specifier, None, false)
     .and_then(move |()| Ok(exec_cb(worker)));
 
   let result = op.wait()?;


### PR DESCRIPTION
Allow `deno eval` to take in code as module.
This automatically enables ES imports, top level await and TS support.

Through:
+ Add an `Option` for code to `RecursiveLoad::Main`
+ Add an `Option` for code to `worker.execute_mod_async`