### PR TITLE
docs(website/manual): Manual introduction improvements

### DIFF
--- a/website/manual.md
+++ b/website/manual.md
@@ -100,10 +100,11 @@ import * as log from "https://deno.land/std/log/mod.ts";
 - bundling (`deno bundle`)
 - runtime type info (`deno types`)
 - test runner (`deno test`)
-- command-line debugger (`--debug`)
-  [coming soon](https://github.com/denoland/deno/issues/1120)
-- linter (`deno lint`)
-    [coming soon](https://github.com/denoland/deno/issues/1880)
+<!-- prettier-ignore-start -->
+<!-- Prettier incorrectly pushes the coming soon link to a new line -->
+- command-line debugger (`--debug`) [coming soon](https://github.com/denoland/deno/issues/1120)
+- linter (`deno lint`) [coming soon](https://github.com/denoland/deno/issues/1880)
+<!-- prettier-ignore-end -->
 
 ## Setup
 

--- a/website/manual.md
+++ b/website/manual.md
@@ -2,15 +2,10 @@
 
 [toc]
 
-# Deno Manual
-
-[toc]
-
 ## Project Status / Disclaimer
 
 **A word of caution: Deno is very much under development.**
 
-We encourage brave early adopters, but expect bugs large and small. The API is subject to change without
 notice. [Bug reports](https://github.com/denoland/deno/issues) do help!
 
 We are [actively working towards 1.0](https://github.com/denoland/deno/issues/2473), but there is no date guarantee.

--- a/website/manual.md
+++ b/website/manual.md
@@ -89,7 +89,7 @@ import * as log from "https://deno.land/std/log/mod.ts";
 
 - Remote code is fetched and cached on first execution, and never updated until
   the code is run with the `--reload` flag. (So, this will still work on an
-   airplane.)
+  airplane.)
 - Modules/files loaded from remote URLs are intended to be immutable and
   cacheable.
 

--- a/website/manual.md
+++ b/website/manual.md
@@ -66,17 +66,15 @@ have been historically written with bash or python.
 
 - Deno does not use `npm`
   - It uses modules referenced as URLs or file paths
-- Deno does not use a `package.json`
-  - This is a non-goal. There are effective patterns [citation needed] for
-    managing dependencies.
-- Deno provides different APIs than node.
+- Deno does not use `package.json` in its module resolution algorithm.
+- All async actions in Deno return a promise. Thus Deno provides different APIs
+  than Node.
 - Deno requires explicit permissions for file, network, and environment access.
-  - Node is less secure out of the box.
 - Deno always dies on uncaught errors.
-- Uses "ES Modules" and does not support `require()`. Like the browser, allows
-  imports from URLs:
+- Uses "ES Modules" and does not support `require()`. Third party modules are
+  imported via URLs:
 
-```ts
+```javascript
 import * as log from "https://deno.land/std/log/mod.ts";
 ```
 

--- a/website/manual.md
+++ b/website/manual.md
@@ -6,60 +6,80 @@
 
 **A word of caution: Deno is very much under development.**
 
-notice. [Bug reports](https://github.com/denoland/deno/issues) do help!
+We encourage brave early adopters, but expect bugs large and small. The API is
+subject to change without notice.
+[Bug reports](https://github.com/denoland/deno/issues) do help!
 
-We are [actively working towards 1.0](https://github.com/denoland/deno/issues/2473), but there is no date guarantee.
+We are
+[actively working towards 1.0](https://github.com/denoland/deno/issues/2473),
+but there is no date guarantee.
 
 ## Introduction
 
-Deno is a JavaScript/TypeScript runtime with secure defaults and a great developer experience.
+Deno is a JavaScript/TypeScript runtime with secure defaults and a great
+developer experience.
 
 It's built on V8, Rust, and Tokio.
 
 ### Feature Highlights
 
-* Secure by default. No file, network, or environment access (unless explicitly enabled).
-* Supports TypeScript out of the box.
-* Ships a single executable (`deno`).
-* Has built in utilities like a dependency inspector (`deno info`) and a code formatter (`deno fmt`).
-* Has [a set of reviewed (audited) standard modules](https://github.com/denoland/deno/tree/master/std) that are guaranteed to work with Deno.
-* Scripts can be bundled into a single javascript file.
+- Secure by default. No file, network, or environment access (unless explicitly
+  enabled).
+- Supports TypeScript out of the box.
+- Ships a single executable (`deno`).
+- Has built in utilities like a dependency inspector (`deno info`) and a code
+  formatter (`deno fmt`).
+- Has
+  [a set of reviewed (audited) standard modules](https://github.com/denoland/deno/tree/master/std)
+  that are guaranteed to work with Deno.
+- Scripts can be bundled into a single javascript file.
 
 ##### On the Roadmap
 
-* Native modules in Rust.
-* Scripts can be bundled into a binary with the deno runtime.
-  * This makes distribution simple and script startup very fast.
+- Native modules in Rust.
+- Scripts can be bundled into a binary with the deno runtime.
+  - This makes distribution simple and script startup very fast.
 
 ### Philosophy
 
-Deno aims to be a productive and secure scripting environment for the modern programmer.
+Deno aims to be a productive and secure scripting environment for the modern
+programmer.
 
-Deno will always be distributed as a single executable. Given a URL to a Deno program, it is runnable with nothing more than [the 10 megabyte zipped executable](https://github.com/denoland/deno/releases). Deno explicitly takes on the role of both runtime and package manager. It uses a standard browser-compatible protocol for loading modules: URLs.
+Deno will always be distributed as a single executable. Given a URL to a Deno
+program, it is runnable with nothing more than
+[the 10 megabyte zipped executable](https://github.com/denoland/deno/releases).
+Deno explicitly takes on the role of both runtime and package manager. It uses a
+standard browser-compatible protocol for loading modules: URLs.
 
-Among other things, Deno is a great replacement for utility scripts that may have been historically written with bash or python.
+Among other things, Deno is a great replacement for utility scripts that may
+have been historically written with bash or python.
 
 ### Goals
 
 1. Only ship a single executable (`deno`).
 2. Provide Secure Defaults
-   * Unless specifically allowed, scripts can't access files, the environment, or the network.
-3. Browser compatible: The subset of Deno programs which are written completely in JavaScript and do not use the global `Deno` namespace (or feature test for it), ought to also be able to be run in a modern web browser without change.
+   - Unless specifically allowed, scripts can't access files, the environment,
+     or the network.
+3. Browser compatible: The subset of Deno programs which are written completely
+   in JavaScript and do not use the global `Deno` namespace (or feature test for
+   it), ought to also be able to be run in a modern web browser without change.
 4. Be able to serve HTTP efficiently
 5. Provide a great developer experience include built-in tooling.
 6. Does not leak browser or V8 concepts into user land.
 
 ### Comparison to Node.js
 
-* Deno does not use `npm`
-  * It uses modules referenced as URLs or file paths
-* Deno does not use a `package.json`
-  * This is a non-goal. There are effective patterns [citation needed] for managing dependencies.
-* Deno provides different APIs than node.
-* Deno requires explicit permissions for file, network, and environment access.
-  * Node is less secure out of the box.
-* Deno always dies on uncaught errors.
-* Uses "ES Modules" and does not support `require()`. Like the browser, allows imports from URLs:
+- Deno does not use `npm`
+  - It uses modules referenced as URLs or file paths
+- Deno does not use a `package.json`
+  - This is a non-goal. There are effective patterns [citation needed] for
+    managing dependencies.
+- Deno provides different APIs than node.
+- Deno requires explicit permissions for file, network, and environment access.
+  - Node is less secure out of the box.
+- Deno always dies on uncaught errors.
+- Uses "ES Modules" and does not support `require()`. Like the browser, allows
+  imports from URLs:
 
 ```ts
 import * as log from "https://deno.land/std/log/mod.ts";
@@ -67,18 +87,23 @@ import * as log from "https://deno.land/std/log/mod.ts";
 
 ### Other key behaviors
 
-* Remote code is fetched and cached on first execution, and never updated until the code is run with the `--reload` flag. (So, this will still work on an airplane. See `~/.deno/src` for details on the cache.)
-* Modules/files loaded from remote URLs are intended to be immutable and cacheable.
+- Remote code is fetched and cached on first execution, and never updated until
+  the code is run with the `--reload` flag. (So, this will still work on an
+  airplane. See `~/.deno/src` for details on the cache.)
+- Modules/files loaded from remote URLs are intended to be immutable and
+  cacheable.
 
 ## Built-in Deno Utilities / Commands
 
- * dependency inspector (`deno info`)
-  * code formatter (`deno fmt`),
-  * bundling (`deno bundle`)
-  * runtime type info (`deno types`)
-  * test runner (`deno test`)
-  * command-line debugger (`--debug`) [coming soon](https://github.com/denoland/deno/issues/1120)
-    * linter (`deno lint`) [coming soon](https://github.com/denoland/deno/issues/1880)
+- dependency inspector (`deno info`)
+- code formatter (`deno fmt`),
+- bundling (`deno bundle`)
+- runtime type info (`deno types`)
+- test runner (`deno test`)
+- command-line debugger (`--debug`)
+  [coming soon](https://github.com/denoland/deno/issues/1120)
+  - linter (`deno lint`)
+    [coming soon](https://github.com/denoland/deno/issues/1880)
 
 ## Setup
 

--- a/website/manual.md
+++ b/website/manual.md
@@ -50,16 +50,17 @@ have been historically written with bash or python.
 
 ### Goals
 
-1. Only ship a single executable (`deno`).
-2. Provide Secure Defaults
-   - Unless specifically allowed, scripts can't access files, the environment,
-     or the network.
-3. Browser compatible: The subset of Deno programs which are written completely
-   in JavaScript and do not use the global `Deno` namespace (or feature test for
-   it), ought to also be able to be run in a modern web browser without change.
-4. Be able to serve HTTP efficiently
-5. Provide a great developer experience include built-in tooling.
-6. Does not leak browser or V8 concepts into user land.
+- Only ship a single executable (`deno`).
+- Provide Secure Defaults
+  - Unless specifically allowed, scripts can't access files, the environment, or
+    the network.
+- Browser compatible: The subset of Deno programs which are written completely
+  in JavaScript and do not use the global `Deno` namespace (or feature test for
+  it), ought to also be able to be run in a modern web browser without change.
+- Provide built-in tooling like unit testing, code formatting, and linting to
+  improve developer experience.
+- Does not leak V8 concepts into user land.
+- Be able to serve HTTP efficiently
 
 ### Comparison to Node.js
 

--- a/website/manual.md
+++ b/website/manual.md
@@ -34,12 +34,6 @@ It's built on V8, Rust, and Tokio.
   that are guaranteed to work with Deno.
 - Scripts can be bundled into a single javascript file.
 
-##### On the Roadmap
-
-- Native modules in Rust.
-- Scripts can be bundled into a binary with the deno runtime.
-  - This makes distribution simple and script startup very fast.
-
 ### Philosophy
 
 Deno aims to be a productive and secure scripting environment for the modern

--- a/website/manual.md
+++ b/website/manual.md
@@ -89,7 +89,7 @@ import * as log from "https://deno.land/std/log/mod.ts";
 
 - Remote code is fetched and cached on first execution, and never updated until
   the code is run with the `--reload` flag. (So, this will still work on an
-  airplane. See `~/.deno/src` for details on the cache.)
+   airplane.)
 - Modules/files loaded from remote URLs are intended to be immutable and
   cacheable.
 

--- a/website/manual.md
+++ b/website/manual.md
@@ -2,89 +2,88 @@
 
 [toc]
 
-## Disclaimer
+# Deno Manual
 
-A word of caution: Deno is very much under development. We encourage brave early
-adopters, but expect bugs large and small. The API is subject to change without
+[toc]
+
+## Project Status / Disclaimer
+
+**A word of caution: Deno is very much under development.**
+
+We encourage brave early adopters, but expect bugs large and small. The API is subject to change without
 notice. [Bug reports](https://github.com/denoland/deno/issues) do help!
+
+We are [actively working towards 1.0](https://github.com/denoland/deno/issues/2473), but there is no date guarantee.
 
 ## Introduction
 
-A secure JavaScript/TypeScript runtime built with V8, Rust, and Tokio
+Deno is a JavaScript/TypeScript runtime with secure defaults and a great developer experience.
+
+It's built on V8, Rust, and Tokio.
+
+### Feature Highlights
+
+* Secure by default. No file, network, or environment access (unless explicitly enabled).
+* Supports TypeScript out of the box.
+* Ships a single executable (`deno`).
+* Has built in utilities like a dependency inspector (`deno info`) and a code formatter (`deno fmt`).
+* Has [a set of reviewed (audited) standard modules](https://github.com/denoland/deno/tree/master/std) that are guaranteed to work with Deno.
+* Scripts can be bundled into a single javascript file.
+
+##### On the Roadmap
+
+* Native modules in Rust.
+* Scripts can be bundled into a binary with the deno runtime.
+  * This makes distribution simple and script startup very fast.
 
 ### Philosophy
 
-Deno aims to be a productive and secure scripting environment for the modern
-programmer.
+Deno aims to be a productive and secure scripting environment for the modern programmer.
 
-Deno will always be distributed as a single executable. Given a URL to a Deno
-program, it is runnable with nothing more than
-[the 10 megabyte zipped executable](https://github.com/denoland/deno/releases).
-Deno explicitly takes on the role of both runtime and package manager. It uses a
-standard browser-compatible protocol for loading modules: URLs.
+Deno will always be distributed as a single executable. Given a URL to a Deno program, it is runnable with nothing more than [the 10 megabyte zipped executable](https://github.com/denoland/deno/releases). Deno explicitly takes on the role of both runtime and package manager. It uses a standard browser-compatible protocol for loading modules: URLs.
 
-Deno provides security guarantees about how programs can access your system with
-the default being the most restrictive secure sandbox.
-
-Deno provides <a href="https://github.com/denoland/deno/tree/master/std">a set
-of reviewed (audited) standard modules</a> that are guaranteed to work with
-Deno.
+Among other things, Deno is a great replacement for utility scripts that may have been historically written with bash or python.
 
 ### Goals
 
-- Support TypeScript out of the box.
+1. Only ship a single executable (`deno`).
+2. Provide Secure Defaults
+   * Unless specifically allowed, scripts can't access files, the environment, or the network.
+3. Browser compatible: The subset of Deno programs which are written completely in JavaScript and do not use the global `Deno` namespace (or feature test for it), ought to also be able to be run in a modern web browser without change.
+4. Be able to serve HTTP efficiently
+5. Provide a great developer experience include built-in tooling.
+6. Does not leak browser or V8 concepts into user land.
 
-- Uses "ES Modules" and does not support `require()`. Like the browser, allows
-  imports from URLs:
+### Comparison to Node.js
 
-  ```ts
-  import * as log from "https://deno.land/std/log/mod.ts";
-  ```
+* Deno does not use `npm`
+  * It uses modules referenced as URLs or file paths
+* Deno does not use a `package.json`
+  * This is a non-goal. There are effective patterns [citation needed] for managing dependencies.
+* Deno provides different APIs than node.
+* Deno requires explicit permissions for file, network, and environment access.
+  * Node is less secure out of the box.
+* Deno always dies on uncaught errors.
+* Uses "ES Modules" and does not support `require()`. Like the browser, allows imports from URLs:
 
-- Remote code is fetched and cached on first execution, and never updated until
-  the code is run with the `--reload` flag. (So, this will still work on an
-  airplane. See `~/.deno/src` for details on the cache.)
+```ts
+import * as log from "https://deno.land/std/log/mod.ts";
+```
 
-- File system and network access can be controlled in order to run sandboxed
-  code. Access between V8 (unprivileged) and Rust (privileged) is only done via
-  serialized messages. This makes it easy to audit. For example, to enable write
-  access use the flag `--allow-write` or for network access `--allow-net`.
+### Other key behaviors
 
-- Only ship a single executable.
+* Remote code is fetched and cached on first execution, and never updated until the code is run with the `--reload` flag. (So, this will still work on an airplane. See `~/.deno/src` for details on the cache.)
+* Modules/files loaded from remote URLs are intended to be immutable and cacheable.
 
-- Always dies on uncaught errors.
+## Built-in Deno Utilities / Commands
 
-- Browser compatible: The subset of Deno programs which are written completely
-  in JavaScript and do not use the global `Deno` namespace (or feature test for
-  it), ought to also be able to be run in a modern web browser without change.
-
-- [Aims to support top-level `await`.](https://github.com/denoland/deno/issues/471)
-
-- Be able to serve HTTP efficiently.
-  ([Currently it is relatively slow.](https://deno.land/benchmarks.html#req-per-sec))
-
-<!-- prettier-ignore-start -->
-<!-- see https://github.com/prettier/prettier/issues/3679 -->
-
-- Provide useful tooling out of the box:
-    - dependency inspector (`deno info`)
-    - code formatter (`deno fmt`),
-    - bundling (`deno bundle`)
-    - runtime type info (`deno types`)
-    - test runner (`deno test`)
-    - command-line debugger (`--debug`)
-      [not yet](https://github.com/denoland/deno/issues/1120)
-    - linter (`deno lint`) [not yet](https://github.com/denoland/deno/issues/1880)
-
-<!-- prettier-ignore-end -->
-
-### Non-goals
-
-- No `package.json`.
-
-- No npm.
-
-- Not explicitly compatible with Node.
+ * dependency inspector (`deno info`)
+  * code formatter (`deno fmt`),
+  * bundling (`deno bundle`)
+  * runtime type info (`deno types`)
+  * test runner (`deno test`)
+  * command-line debugger (`--debug`) [coming soon](https://github.com/denoland/deno/issues/1120)
+    * linter (`deno lint`) [coming soon](https://github.com/denoland/deno/issues/1880)
 
 ## Setup
 

--- a/website/manual.md
+++ b/website/manual.md
@@ -102,7 +102,7 @@ import * as log from "https://deno.land/std/log/mod.ts";
 - test runner (`deno test`)
 - command-line debugger (`--debug`)
   [coming soon](https://github.com/denoland/deno/issues/1120)
-  - linter (`deno lint`)
+- linter (`deno lint`)
     [coming soon](https://github.com/denoland/deno/issues/1880)
 
 ## Setup

--- a/website/manual.md
+++ b/website/manual.md
@@ -96,7 +96,7 @@ import * as log from "https://deno.land/std/log/mod.ts";
 ## Built-in Deno Utilities / Commands
 
 - dependency inspector (`deno info`)
-- code formatter (`deno fmt`),
+- code formatter (`deno fmt`)
 - bundling (`deno bundle`)
 - runtime type info (`deno types`)
 - test runner (`deno test`)

--- a/website/manual.md
+++ b/website/manual.md
@@ -95,15 +95,17 @@ import * as log from "https://deno.land/std/log/mod.ts";
 
 ## Built-in Deno Utilities / Commands
 
+<!-- prettier-ignore-start -->
+<!-- prettier incorrectly moves the coming soon links to new lines -->
+
 - dependency inspector (`deno info`)
 - code formatter (`deno fmt`)
 - bundling (`deno bundle`)
 - runtime type info (`deno types`)
 - test runner (`deno test`)
-<!-- prettier-ignore-start -->
-<!-- Prettier incorrectly pushes the coming soon link to a new line -->
 - command-line debugger (`--debug`) [coming soon](https://github.com/denoland/deno/issues/1120)
 - linter (`deno lint`) [coming soon](https://github.com/denoland/deno/issues/1880)
+
 <!-- prettier-ignore-end -->
 
 ## Setup


### PR DESCRIPTION
PR Migrated from https://github.com/denoland/deno_website2/pull/9

---------

This reorganizes and improves some of the introduction content.

This is just a first pass, but I think it's an extremely important part of the experience for newcomers to the project.

@ry @kitsonk — This is related to some of the conversations we had at TSConf. I'd love to get your thoughts on these changes.

I've put some comments inline in the PR to help explain some of the specific changes.

