### PR TITLE
update: use std@v0.21.0 for subcommands

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -15,7 +15,7 @@ use url::Url;
 
 macro_rules! std_url {
   ($x:expr) => {
-    concat!("https://deno.land/std@8c90bd9/", $x)
+    concat!("https://deno.land/std@v0.21.0/", $x)
   };
 }
 


### PR DESCRIPTION
Now I realized that this patch will be included v0.22.0... Is it possible to share tags with subcommands? 