### PR TITLE
Improve http_proxy test

### DIFF
--- a/cli/tests/045_proxy_client.ts
+++ b/cli/tests/045_proxy_client.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 async function main(): Promise<void> {
-  const res = await fetch("http://deno.land/welcome.ts");
+  const res = await fetch("http://localhost:4545/std/examples/colors.ts");
   console.log(`Response http: ${await res.text()}`);
 }
 

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -49,7 +49,7 @@ async function testModuleDownload(): Promise<void> {
       "--no-prompt",
       "--reload",
       "fetch",
-      "http://deno.land/welcome.ts"
+      "http://localhost:4545/std/examples/colors.ts"
     ],
     stdout: "piped",
     env: {

--- a/cli/tests/045_proxy_test.ts.out
+++ b/cli/tests/045_proxy_test.ts.out
@@ -1,3 +1,4 @@
 Proxy server listening on [WILDCARD]
-Proxy request to: http://deno.land/welcome.ts
-Proxy request to: http://deno.land/welcome.ts
+Proxy request to: http://localhost:4545/std/examples/colors.ts
+Proxy request to: http://localhost:4545/std/examples/colors.ts
+Proxy request to: http://localhost:4545/std/fmt/colors.ts

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -314,6 +314,7 @@ itest!(_044_bad_resource {
 itest!(_045_proxy {
   args: "run --allow-net --allow-env --allow-run --reload 045_proxy_test.ts",
   output: "045_proxy_test.ts.out",
+  http_server: true,
 });
 
 itest!(_046_tsx {


### PR DESCRIPTION
`//cli/tests/045_proxy_test.ts` depends on the internet access ( https://deno.land/welcome.ts ). This PR removes that dependency and uses local http server instead.