### PR TITLE
std: fix BufReader.readString to actually return Deno.EOF at end 

### DIFF
--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -207,15 +207,15 @@ export class BufReader implements Reader {
    * it returns the data read before the error and the error itself
    * (often io.EOF).
    * ReadString returns err != nil if and only if the returned data does not end
-   * in
-   * delim.
+   * in delim.
    * For simple uses, a Scanner may be more convenient.
    */
   async readString(delim: string): Promise<string | Deno.EOF> {
     if (delim.length !== 1)
       throw new Error("Delimiter should be a single character");
     const buffer = await this.readSlice(delim.charCodeAt(0));
-    return new TextDecoder().decode(buffer || undefined);
+    if (buffer == Deno.EOF) return Deno.EOF;
+    return new TextDecoder().decode(buffer);
   }
 
   /** `readLine()` is a low-level line-reading primitive. Most callers should

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -168,6 +168,12 @@ test(async function bufioReadString(): Promise<void> {
   assertEquals(line, "And now,");
   assertEquals(line.length, 8);
 
+  const line2 = assertNotEOF(await buf.readString(","));
+  const line3 = assertNotEOF(await buf.readString(","));
+  assertEquals(line3, " world!");
+
+  assertEquals(await buf.readString(","), Deno.EOF);
+
   try {
     await buf.readString("deno");
 

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -161,7 +161,7 @@ test(async function bufioBufferFull(): Promise<void> {
 });
 
 test(async function bufioReadString(): Promise<void> {
-  const string = "And now, hello, world!";
+  const string = "And now, hello world!";
   const buf = new BufReader(stringsReader(string), MIN_READ_BUFFER_SIZE);
 
   const line = assertNotEOF(await buf.readString(","));
@@ -169,8 +169,7 @@ test(async function bufioReadString(): Promise<void> {
   assertEquals(line.length, 8);
 
   const line2 = assertNotEOF(await buf.readString(","));
-  const line3 = assertNotEOF(await buf.readString(","));
-  assertEquals(line3, " world!");
+  assertEquals(line2, " hello world!");
 
   assertEquals(await buf.readString(","), Deno.EOF);
 


### PR DESCRIPTION
Fixes #3190