### PR TITLE
Update GitHub Actions, powershell is default on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
         if: matrix.kind == 'test_std'
         run: |
           cd std
-          "../target/release/deno" test -A
+          ../target/release/deno test -A
 
       - name: Test
         if: matrix.kind == 'test'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Environment (windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          echo ::add-path::%cd%\prebuilt\win
-          echo ::add-path::%cd%\target\release
+          echo ::add-path::$(pwd)\prebuilt\win
+          echo ::add-path::$(pwd)\target\release
 
       - name: Log versions
         run: |
@@ -169,7 +169,7 @@ jobs:
 
       - name: Pre-release (windows)
         if: startsWith(matrix.os, 'windows') && matrix.kind == 'test'
-        run: PowerShell -Command "& {Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno_win_x64.zip}"
+        run: Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno_win_x64.zip
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
* https://github.blog/changelog/2019-10-17-github-actions-default-shell-on-windows-runners-is-changing-to-powershell/

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
