### PR TITLE
Use web standard Permissions API

### DIFF
--- a/cli/deno_error.rs
+++ b/cli/deno_error.rs
@@ -96,6 +96,10 @@ pub fn too_many_redirects() -> ErrBox {
   StaticError(ErrorKind::TooManyRedirects, "too many redirects").into()
 }
 
+pub fn type_error(msg: String) -> ErrBox {
+  DenoError::new(ErrorKind::TypeError, msg).into()
+}
+
 pub trait GetErrorKind {
   fn kind(&self) -> ErrorKind;
 }

--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -68,8 +68,9 @@ export { applySourceMap } from "./error_stack.ts";
 export { ErrorKind, DenoError } from "./errors.ts";
 export {
   permissions,
-  revokePermission,
-  Permission,
+  PermissionName,
+  PermissionState,
+  PermissionStatus,
   Permissions
 } from "./permissions.ts";
 export { truncateSync, truncate } from "./truncate.ts";

--- a/cli/js/dispatch.ts
+++ b/cli/js/dispatch.ts
@@ -36,7 +36,7 @@ export let OP_GET_RANDOM_VALUES: number;
 export let OP_GLOBAL_TIMER_STOP: number;
 export let OP_GLOBAL_TIMER: number;
 export let OP_NOW: number;
-export let OP_PERMISSIONS: number;
+export let OP_QUERY_PERMISSION: number;
 export let OP_REVOKE_PERMISSION: number;
 export let OP_CREATE_WORKER: number;
 export let OP_HOST_GET_WORKER_CLOSED: number;

--- a/cli/js/errors.ts
+++ b/cli/js/errors.ts
@@ -75,5 +75,6 @@ export enum ErrorKind {
   UnsupportedFetchScheme = 47,
   TooManyRedirects = 48,
   Diagnostic = 49,
-  JSError = 50
+  JSError = 50,
+  TypeError = 51
 }

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -883,34 +883,29 @@ declare namespace Deno {
   }
 
   // @url js/permissions.d.ts
-
-  /** Permissions as granted by the caller */
-  export interface Permissions {
-    read: boolean;
-    write: boolean;
-    net: boolean;
-    env: boolean;
-    run: boolean;
-    hrtime: boolean;
+  export type PermissionName =
+    | "run"
+    | "read"
+    | "write"
+    | "net"
+    | "env"
+    | "hrtime";
+  export type PermissionState = "granted" | "denied" | "prompt";
+  interface PermissionDescriptor {
+    name: PermissionName;
+    url?: string;
+    path?: string;
   }
-  export type Permission = keyof Permissions;
-  /** Inspect granted permissions for the current program.
-   *
-   *       if (Deno.permissions().read) {
-   *         const file = await Deno.readFile("example.test");
-   *         // ...
-   *       }
-   */
-  export function permissions(): Permissions;
-  /** Revoke a permission. When the permission was already revoked nothing changes
-   *
-   *       if (Deno.permissions().read) {
-   *         const file = await Deno.readFile("example.test");
-   *         Deno.revokePermission('read');
-   *       }
-   *       Deno.readFile("example.test"); // -> error or permission prompt
-   */
-  export function revokePermission(permission: Permission): void;
+  export class Permissions {
+    query(d: PermissionDescriptor): Promise<PermissionStatus>;
+    revoke(d: PermissionDescriptor): Promise<PermissionStatus>;
+  }
+  export const permissions: Permissions;
+
+  export class PermissionStatus {
+    state: PermissionState;
+    constructor(state: PermissionState);
+  }
 
   // @url js/truncate.d.ts
 

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -883,6 +883,9 @@ declare namespace Deno {
   }
 
   // @url js/permissions.d.ts
+  /** Permissions as granted by the caller
+   * See: https://w3c.github.io/permissions/#permission-registry
+   */
   export type PermissionName =
     | "run"
     | "read"
@@ -890,6 +893,7 @@ declare namespace Deno {
     | "net"
     | "env"
     | "hrtime";
+  /** https://w3c.github.io/permissions/#status-of-a-permission */
   export type PermissionState = "granted" | "denied" | "prompt";
   interface RunPermissionDescriptor {
     name: "run";
@@ -917,11 +921,14 @@ declare namespace Deno {
     | HrtimePermissionDescriptor;
 
   export class Permissions {
+    /** Queries the permission. */
     query(d: PermissionDescriptor): Promise<PermissionStatus>;
+    /** Revokes the permission. */
     revoke(d: PermissionDescriptor): Promise<PermissionStatus>;
   }
   export const permissions: Permissions;
 
+  /** https://w3c.github.io/permissions/#permissionstatus */
   export class PermissionStatus {
     state: PermissionState;
     constructor(state: PermissionState);

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -891,10 +891,10 @@ declare namespace Deno {
     | "env"
     | "hrtime";
   export type PermissionState = "granted" | "denied" | "prompt";
-  interface SimplePermissionDescriptor {
-    name: "run" | "env" | "hrtime";
+  interface RunPermissionDescriptor {
+    name: "run";
   }
-  interface PathPermissionDescriptor {
+  interface ReadWritePermissionDescriptor {
     name: "read" | "write";
     path?: string;
   }
@@ -902,10 +902,20 @@ declare namespace Deno {
     name: "net";
     url?: string;
   }
+  interface EnvPermissionDescriptor {
+    name: "env";
+  }
+  interface HrtimePermissionDescriptor {
+    name: "hrtime";
+  }
+  /** See: https://w3c.github.io/permissions/#permission-descriptor */
   type PermissionDescriptor =
-    | SimplePermissionDescriptor
-    | PathPermissionDescriptor
-    | NetPermissionDescriptor;
+    | RunPermissionDescriptor
+    | ReadWritePermissionDescriptor
+    | NetPermissionDescriptor
+    | EnvPermissionDescriptor
+    | HrtimePermissionDescriptor;
+
   export class Permissions {
     query(d: PermissionDescriptor): Promise<PermissionStatus>;
     revoke(d: PermissionDescriptor): Promise<PermissionStatus>;

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -921,9 +921,17 @@ declare namespace Deno {
     | HrtimePermissionDescriptor;
 
   export class Permissions {
-    /** Queries the permission. */
+    /** Queries the permission.
+     *       const status = await Deno.permissions.query({ name: "read", path: "/etc" });
+     *       if (status.state === "granted") {
+     *         data = await Deno.readFile("/etc/passwd");
+     *       }
+     */
     query(d: PermissionDescriptor): Promise<PermissionStatus>;
-    /** Revokes the permission. */
+    /** Revokes the permission.
+     *       const status = await Deno.permissions.revoke({ name: "run" });
+     *       assert(status.state !== "granted")
+     */
     revoke(d: PermissionDescriptor): Promise<PermissionStatus>;
   }
   export const permissions: Permissions;

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -891,11 +891,21 @@ declare namespace Deno {
     | "env"
     | "hrtime";
   export type PermissionState = "granted" | "denied" | "prompt";
-  interface PermissionDescriptor {
-    name: PermissionName;
-    url?: string;
+  interface SimplePermissionDescriptor {
+    name: "run" | "env" | "hrtime";
+  }
+  interface PathPermissionDescriptor {
+    name: "read" | "write";
     path?: string;
   }
+  interface NetPermissionDescriptor {
+    name: "net";
+    url?: string;
+  }
+  type PermissionDescriptor =
+    | SimplePermissionDescriptor
+    | PathPermissionDescriptor
+    | NetPermissionDescriptor;
   export class Permissions {
     query(d: PermissionDescriptor): Promise<PermissionStatus>;
     revoke(d: PermissionDescriptor): Promise<PermissionStatus>;

--- a/cli/js/permissions.ts
+++ b/cli/js/permissions.ts
@@ -17,25 +17,30 @@ export type PermissionName =
 /** https://w3c.github.io/permissions/#status-of-a-permission */
 export type PermissionState = "granted" | "denied" | "prompt";
 
-/** See: https://w3c.github.io/permissions/#permission-descriptor */
-interface SimplePermissionDescriptor {
-  name: "env" | "run" | "hrtime";
+interface RunPermissionDescriptor {
+  name: "run";
 }
-
+interface ReadWritePermissionDescriptor {
+  name: "read" | "write";
+  path?: string;
+}
 interface NetPermissionDescriptor {
   name: "net";
   url?: string;
 }
-
-interface PathPermissionDescriptor {
-  name: "read" | "write";
-  path?: string;
+interface EnvPermissionDescriptor {
+  name: "env";
 }
-
+interface HrtimePermissionDescriptor {
+  name: "hrtime";
+}
+/** See: https://w3c.github.io/permissions/#permission-descriptor */
 type PermissionDescriptor =
-  | SimplePermissionDescriptor
-  | PathPermissionDescriptor
-  | NetPermissionDescriptor;
+  | RunPermissionDescriptor
+  | ReadWritePermissionDescriptor
+  | NetPermissionDescriptor
+  | EnvPermissionDescriptor
+  | HrtimePermissionDescriptor;
 
 /** https://w3c.github.io/permissions/#permissionstatus */
 export class PermissionStatus {

--- a/cli/js/permissions.ts
+++ b/cli/js/permissions.ts
@@ -2,38 +2,46 @@
 import * as dispatch from "./dispatch.ts";
 import { sendSync } from "./dispatch_json.ts";
 
-/** Permissions as granted by the caller */
-export interface Permissions {
-  read: boolean;
-  write: boolean;
-  net: boolean;
-  env: boolean;
-  run: boolean;
-  hrtime: boolean;
-  // NOTE: Keep in sync with src/permissions.rs
-}
-
-export type Permission = keyof Permissions;
-
-/** Inspect granted permissions for the current program.
- *
- *       if (Deno.permissions().read) {
- *         const file = await Deno.readFile("example.test");
- *         // ...
- *       }
+/** Permissions as granted by the caller
+ * See: https://w3c.github.io/permissions/#permission-registry
  */
-export function permissions(): Permissions {
-  return sendSync(dispatch.OP_PERMISSIONS) as Permissions;
+export type PermissionName =
+  | "read"
+  | "write"
+  | "net"
+  | "env"
+  | "run"
+  | "hrtime";
+// NOTE: Keep in sync with cli/permissions.rs
+
+/** https://w3c.github.io/permissions/#status-of-a-permission */
+export type PermissionState = "granted" | "denied" | "prompt";
+
+/** See: https://w3c.github.io/permissions/#permission-descriptor */
+interface PermissionDescriptor {
+  name: PermissionName;
+  url?: string;
+  path?: string;
 }
 
-/** Revoke a permission. When the permission was already revoked nothing changes
- *
- *       if (Deno.permissions().read) {
- *         const file = await Deno.readFile("example.test");
- *         Deno.revokePermission('read');
- *       }
- *       Deno.readFile("example.test"); // -> error or permission prompt
- */
-export function revokePermission(permission: Permission): void {
-  sendSync(dispatch.OP_REVOKE_PERMISSION, { permission });
+/** https://w3c.github.io/permissions/#permissionstatus */
+export class PermissionStatus {
+  constructor(public state: PermissionState) {}
+  // TODO(kt3k): implement onchange handler
 }
+
+export class Permissions {
+  /** Queries the permission. */
+  async query(desc: PermissionDescriptor): Promise<PermissionStatus> {
+    const { state } = sendSync(dispatch.OP_QUERY_PERMISSION, desc);
+    return new PermissionStatus(state);
+  }
+
+  /** Revokes the permission. */
+  async revoke(desc: PermissionDescriptor): Promise<PermissionStatus> {
+    const { state } = sendSync(dispatch.OP_REVOKE_PERMISSION, desc);
+    return new PermissionStatus(state);
+  }
+}
+
+export const permissions = new Permissions();

--- a/cli/js/permissions.ts
+++ b/cli/js/permissions.ts
@@ -18,11 +18,24 @@ export type PermissionName =
 export type PermissionState = "granted" | "denied" | "prompt";
 
 /** See: https://w3c.github.io/permissions/#permission-descriptor */
-interface PermissionDescriptor {
-  name: PermissionName;
+interface SimplePermissionDescriptor {
+  name: "env" | "run" | "hrtime";
+}
+
+interface NetPermissionDescriptor {
+  name: "net";
   url?: string;
+}
+
+interface PathPermissionDescriptor {
+  name: "read" | "write";
   path?: string;
 }
+
+type PermissionDescriptor =
+  | SimplePermissionDescriptor
+  | PathPermissionDescriptor
+  | NetPermissionDescriptor;
 
 /** https://w3c.github.io/permissions/#permissionstatus */
 export class PermissionStatus {

--- a/cli/js/permissions.ts
+++ b/cli/js/permissions.ts
@@ -49,13 +49,21 @@ export class PermissionStatus {
 }
 
 export class Permissions {
-  /** Queries the permission. */
+  /** Queries the permission.
+   *       const status = await Deno.permissions.query({ name: "read", path: "/etc" });
+   *       if (status.state === "granted") {
+   *         file = await Deno.readFile("/etc/passwd");
+   *       }
+   */
   async query(desc: PermissionDescriptor): Promise<PermissionStatus> {
     const { state } = sendSync(dispatch.OP_QUERY_PERMISSION, desc);
     return new PermissionStatus(state);
   }
 
-  /** Revokes the permission. */
+  /** Revokes the permission.
+   *       const status = await Deno.permissions.revoke({ name: "run" });
+   *       assert(status.state !== "granted")
+   */
   async revoke(desc: PermissionDescriptor): Promise<PermissionStatus> {
     const { state } = sendSync(dispatch.OP_REVOKE_PERMISSION, desc);
     return new PermissionStatus(state);

--- a/cli/js/permissions_test.ts
+++ b/cli/js/permissions_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { testPerm, assert, assertEquals } from "./test_util.ts";
+import { test, testPerm, assert, assertEquals } from "./test_util.ts";
 
-const knownPermissions: Deno.Permission[] = [
+const knownPermissions: Deno.PermissionName[] = [
   "run",
   "read",
   "write",
@@ -11,18 +11,31 @@ const knownPermissions: Deno.Permission[] = [
 ];
 
 for (const grant of knownPermissions) {
-  testPerm({ [grant]: true }, function envGranted(): void {
-    const perms = Deno.permissions();
-    assert(perms !== null);
-    for (const perm in perms) {
-      assertEquals(perms[perm], perm === grant);
-    }
+  testPerm({ [grant]: true }, async function envGranted(): Promise<void> {
+    const status0 = await Deno.permissions.query({ name: grant });
+    assert(status0 != null);
+    assertEquals(status0.state, "granted");
 
-    Deno.revokePermission(grant);
-
-    const revoked = Deno.permissions();
-    for (const perm in revoked) {
-      assertEquals(revoked[perm], false);
-    }
+    const status1 = await Deno.permissions.revoke({ name: grant });
+    assert(status1 != null);
+    assertEquals(status1.state, "prompt");
   });
 }
+
+test(async function permissionInvalidName(): Promise<void> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await Deno.permissions.query({ name: "foo" as any });
+  } catch (e) {
+    assert(e.name === "TypeError");
+  }
+});
+
+test(async function permissionNetInvalidUrl(): Promise<void> {
+  try {
+    // Invalid url causes TypeError.
+    await Deno.permissions.query({ name: "net", url: ":" });
+  } catch (e) {
+    assert(e.name === "TypeError");
+  }
+});

--- a/cli/js/test_util.ts
+++ b/cli/js/test_util.ts
@@ -29,11 +29,34 @@ interface TestPermissions {
   hrtime?: boolean;
 }
 
-const processPerms = Deno.permissions();
+export interface Permissions {
+  read: boolean;
+  write: boolean;
+  net: boolean;
+  env: boolean;
+  run: boolean;
+  hrtime: boolean;
+}
+
+const isGranted = async (name: Deno.PermissionName): Promise<boolean> =>
+  (await Deno.permissions.query({ name })).state === "granted";
+
+async function getProcessPermissions(): Promise<Permissions> {
+  return {
+    run: await isGranted("run"),
+    read: await isGranted("read"),
+    write: await isGranted("write"),
+    net: await isGranted("net"),
+    env: await isGranted("env"),
+    hrtime: await isGranted("hrtime")
+  };
+}
+
+const processPerms = await getProcessPermissions();
 
 function permissionsMatch(
-  processPerms: Deno.Permissions,
-  requiredPerms: Deno.Permissions
+  processPerms: Permissions,
+  requiredPerms: Permissions
 ): boolean {
   for (const permName in processPerms) {
     if (processPerms[permName] !== requiredPerms[permName]) {
@@ -44,9 +67,9 @@ function permissionsMatch(
   return true;
 }
 
-export const permissionCombinations: Map<string, Deno.Permissions> = new Map();
+export const permissionCombinations: Map<string, Permissions> = new Map();
 
-function permToString(perms: Deno.Permissions): string {
+function permToString(perms: Permissions): string {
   const r = perms.read ? 1 : 0;
   const w = perms.write ? 1 : 0;
   const n = perms.net ? 1 : 0;
@@ -56,14 +79,14 @@ function permToString(perms: Deno.Permissions): string {
   return `permR${r}W${w}N${n}E${e}U${u}H${h}`;
 }
 
-function registerPermCombination(perms: Deno.Permissions): void {
+function registerPermCombination(perms: Permissions): void {
   const key = permToString(perms);
   if (!permissionCombinations.has(key)) {
     permissionCombinations.set(key, perms);
   }
 }
 
-function normalizeTestPermissions(perms: TestPermissions): Deno.Permissions {
+function normalizeTestPermissions(perms: TestPermissions): Permissions {
   return {
     read: !!perms.read,
     write: !!perms.write,

--- a/cli/js/unit_test_runner.ts
+++ b/cli/js/unit_test_runner.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env -S deno run --reload --allow-run
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import "./unit_tests.ts";
-import { permissionCombinations, parseUnitTestOutput } from "./test_util.ts";
+import {
+  permissionCombinations,
+  parseUnitTestOutput,
+  Permissions
+} from "./test_util.ts";
 
 interface TestResult {
   perms: string;
@@ -9,7 +13,7 @@ interface TestResult {
   result: number;
 }
 
-function permsToCliFlags(perms: Deno.Permissions): string[] {
+function permsToCliFlags(perms: Permissions): string[] {
   return Object.keys(perms)
     .map(
       (key): string => {
@@ -25,7 +29,7 @@ function permsToCliFlags(perms: Deno.Permissions): string[] {
     .filter((e): boolean => e.length > 0);
 }
 
-function fmtPerms(perms: Deno.Permissions): string {
+function fmtPerms(perms: Permissions): string {
   let fmt = permsToCliFlags(perms).join(" ");
 
   if (!fmt) {

--- a/cli/msg.rs
+++ b/cli/msg.rs
@@ -57,6 +57,7 @@ pub enum ErrorKind {
   TooManyRedirects = 48,
   Diagnostic = 49,
   JSError = 50,
+  TypeError = 51,
 }
 
 // Warning! The values in this enum are duplicated in js/compiler.ts

--- a/cli/ops/timers.rs
+++ b/cli/ops/timers.rs
@@ -70,7 +70,7 @@ fn op_now(
   // If the permission is not enabled
   // Round the nano result on 2 milliseconds
   // see: https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp#Reduced_time_precision
-  if !state.permissions.allows_hrtime() {
+  if !state.permissions.allow_hrtime.is_allow() {
     subsec_nanos -= subsec_nanos % reduced_time_precision
   }
 

--- a/cli/tests/025_hrtime.ts
+++ b/cli/tests/025_hrtime.ts
@@ -1,3 +1,5 @@
-console.log(performance.now() % 2 !== 0);
-Deno.revokePermission("hrtime");
-console.log(performance.now() % 2 === 0);
+window.onload = async (): Promise<void> => {
+  console.log(performance.now() % 2 !== 0);
+  await Deno.permissions.revoke({ name: "hrtime" });
+  console.log(performance.now() % 2 === 0);
+};

--- a/std/manual.md
+++ b/std/manual.md
@@ -353,18 +353,19 @@ Sometimes a program may want to revoke previously granted permissions. When a
 program, at a later stage, needs those permissions, it will fail.
 
 ```ts
-const { permissions, revokePermission, open, remove } = Deno;
+const { permissions, open, remove } = Deno;
 
 // lookup a permission
-if (!permissions().write) {
+const status = await permissions.query({ name: "write" });
+if (status.state !== "granted") {
   throw new Error("need write permission");
 }
 
 const log = await open("request.log", "a+");
 
 // revoke some permissions
-revokePermission("read");
-revokePermission("write");
+await permissions.revoke({ name: "read" });
+await permissions.revoke({ name: "write" });
 
 // use the log file
 const encoder = new TextEncoder();


### PR DESCRIPTION
This PR changes the current permissions API to the web standard [Permissions API](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API).

- Removed op_permissions, added op_query_permission
- Added TypeError for invalid permission name and invalid urls.
- Added a few tests for check handlings of invalid parameters.
- For now I keep permissions object at Deno.permissions. Maybe this should be moved to navigator.permissions later.

---

ref:
- w3c permissions: https://github.com/w3c/permissions
- wicg permissions revoke: https://github.com/WICG/permissions-revoke

---
Partially addresses #2767.