### PR TITLE
refactor: handle malformed control buffers

### DIFF
--- a/cli/js/dispatch_json_test.ts
+++ b/cli/js/dispatch_json_test.ts
@@ -1,4 +1,11 @@
-import { testPerm, assertMatch, unreachable } from "./test_util.ts";
+import {
+  test,
+  testPerm,
+  assert,
+  assertEquals,
+  assertMatch,
+  unreachable
+} from "./test_util.ts";
 
 const openErrorStackPattern = new RegExp(
   `^.*
@@ -16,4 +23,15 @@ testPerm({ read: true }, async function sendAsyncStackTrace(): Promise<void> {
         assertMatch(error.stack, openErrorStackPattern);
       }
     );
+});
+
+test(async function malformedJsonControlBuffer(): Promise<void> {
+  // @ts-ignore
+  const res = Deno.core.send(10, new Uint8Array([1, 2, 3, 4, 5]));
+  const resText = new TextDecoder().decode(res);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const resJson = JSON.parse(resText) as any;
+  assert(!resJson.ok);
+  assert(resJson.err);
+  assertEquals(resJson.err!.kind, Deno.ErrorKind.InvalidInput);
 });

--- a/cli/js/dispatch_minimal_test.ts
+++ b/cli/js/dispatch_minimal_test.ts
@@ -1,0 +1,18 @@
+import { test, assert, assertEquals } from "./test_util.ts";
+
+test(async function malformedMinimalControlBuffer(): Promise<void> {
+  // @ts-ignore
+  const res = Deno.core.send(1, new Uint8Array([1, 2, 3, 4, 5]));
+  const header = res.slice(0, 12);
+  const buf32 = new Int32Array(
+    header.buffer,
+    header.byteOffset,
+    header.byteLength / 4
+  );
+  const arg = buf32[1];
+  const result = buf32[2];
+  const message = new TextDecoder().decode(res.slice(12));
+  assert(arg < 0);
+  assertEquals(result, Deno.ErrorKind.InvalidInput);
+  assertEquals(message, "Unparsable control buffer");
+});

--- a/cli/ops/dispatch_minimal.rs
+++ b/cli/ops/dispatch_minimal.rs
@@ -5,6 +5,7 @@
 //! messages. The first i32 is used to determine if a message a flatbuffer
 //! message or a "minimal" message.
 use crate::deno_error::GetErrorKind;
+use crate::msg::ErrorKind;
 use byteorder::{LittleEndian, WriteBytesExt};
 use deno::Buf;
 use deno::CoreOp;
@@ -115,7 +116,21 @@ pub fn minimal_op(
   d: Dispatcher,
 ) -> impl Fn(&[u8], Option<PinnedBuf>) -> CoreOp {
   move |control: &[u8], zero_copy: Option<PinnedBuf>| {
-    let mut record = parse_min_record(control).unwrap();
+    let mut record = match parse_min_record(control) {
+      Some(r) => r,
+      None => {
+        let error_record = ErrorRecord {
+          promise_id: 0,
+          arg: -1,
+          error_code: ErrorKind::InvalidData as i32,
+          error_message: "Unparsable control buffer"
+            .to_string()
+            .as_bytes()
+            .to_owned(),
+        };
+        return Op::Sync(error_record.into());
+      }
+    };
     let is_sync = record.promise_id == 0;
     let rid = record.arg;
     let min_op = d(rid, zero_copy);

--- a/cli/ops/dispatch_minimal.rs
+++ b/cli/ops/dispatch_minimal.rs
@@ -122,7 +122,7 @@ pub fn minimal_op(
         let error_record = ErrorRecord {
           promise_id: 0,
           arg: -1,
-          error_code: ErrorKind::InvalidData as i32,
+          error_code: ErrorKind::InvalidInput as i32,
           error_message: "Unparsable control buffer"
             .to_string()
             .as_bytes()


### PR DESCRIPTION
Closes #3117 
Closes #2459

This PR eliminates runtime panics when abusing `Deno.core.send` API with gibberish data.