### PR TITLE
Publish source tarballs for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,12 @@ jobs:
           fetch-depth: 1
           submodules: true
 
+      - name: Create source tarballs (release, linux)
+        if: startsWith(matrix.os, 'ubuntu') && matrix.kind == 'test' && startsWith(github.ref, 'refs/tags/') && github.repository == 'denoland/deno'
+        run: |
+          mkdir -p target/release
+          tar --exclude=".git*" --exclude=target --exclude=deno_typescript/typescript/tests --exclude=third_party/cpplint --exclude="third_party/node_modules/*" --exclude=third_party/python_packages --exclude=third_party/wrk -czvf target/release/deno_src.tar.gz -C .. deno
+
       - name: Install rust
         uses: hecrj/setup-rust-action@v1
         with:
@@ -180,6 +186,7 @@ jobs:
             target/release/deno_win_x64.zip
             target/release/deno_linux_x64.gz
             target/release/deno_osx_x64.gz
+            target/release/deno_src.tar.gz
           draft: true
 
       - name: Stop sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,10 @@ jobs:
           submodules: true
 
       - name: Create source tarballs (release, linux)
-        if: startsWith(matrix.os, 'ubuntu') && matrix.kind == 'test'
+        if: startsWith(matrix.os, 'ubuntu') && matrix.kind == 'test' && startsWith(github.ref, 'refs/tags/') && github.repository == 'denoland/deno'
         run: |
           mkdir -p target/release
           tar --exclude=".git*" --exclude=target --exclude=deno_typescript/typescript/tests --exclude=third_party/cpplint --exclude="third_party/node_modules/*" --exclude=third_party/python_packages --exclude=third_party/wrk -czvf target/release/deno_src.tar.gz -C .. deno
-          tar -tf target/release/deno_src.tar.gz
-          ls -lah target/release/deno_src.tar.gz
 
       - name: Install rust
         uses: hecrj/setup-rust-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,12 @@ jobs:
           submodules: true
 
       - name: Create source tarballs (release, linux)
-        if: startsWith(matrix.os, 'ubuntu') && matrix.kind == 'test' && startsWith(github.ref, 'refs/tags/') && github.repository == 'denoland/deno'
+        if: startsWith(matrix.os, 'ubuntu') && matrix.kind == 'test'
         run: |
           mkdir -p target/release
           tar --exclude=".git*" --exclude=target --exclude=deno_typescript/typescript/tests --exclude=third_party/cpplint --exclude="third_party/node_modules/*" --exclude=third_party/python_packages --exclude=third_party/wrk -czvf target/release/deno_src.tar.gz -C .. deno
+          tar -tf target/release/deno_src.tar.gz
+          ls -lah target/release/deno_src.tar.gz
 
       - name: Install rust
         uses: hecrj/setup-rust-action@v1


### PR DESCRIPTION
Fixes: #3199 

This PR adds the creation of source tarballs to the release workflow, because the automatically  generated tarballs by GitHub doesn't contain any files from submodules (see #3199 ).

Tarball size is down to ~48MB atm, after exclude all `.git*` files, the big typescript `tests` directory and all format and lint tools from `third_party` (everything except `v8` and `depot_tools` there) to reduce tarball size.

I've confirmed locally that `cargo build` (including `setup.py`) and `cargo test` are still working from withing the extracted source tarball.