### PR TITLE
Support named imports/exports for subset of properties in JSON modules

### DIFF
--- a/cli/compilers/json.rs
+++ b/cli/compilers/json.rs
@@ -3,7 +3,12 @@ use crate::compilers::CompiledModule;
 use crate::compilers::CompiledModuleFuture;
 use crate::file_fetcher::SourceFile;
 use crate::state::ThreadSafeState;
+use deno::ErrBox;
+use regex::Regex;
 use std::str;
+
+// From https://github.com/mathiasbynens/mothereff.in/blob/master/js-variables/eff.js
+static JS_RESERVED_WORDS: &str = r"^(?:do|if|in|for|let|new|try|var|case|else|enum|eval|false|null|this|true|void|with|await|break|catch|class|const|super|throw|while|yield|delete|export|import|public|return|static|switch|typeof|default|extends|finally|package|private|continue|debugger|function|arguments|interface|protected|implements|instanceof)$";
 
 pub struct JsonCompiler {}
 
@@ -13,11 +18,37 @@ impl JsonCompiler {
     _state: ThreadSafeState,
     source_file: &SourceFile,
   ) -> Box<CompiledModuleFuture> {
+    let maybe_json_value: serde_json::Result<serde_json::Value> =
+      serde_json::from_str(&str::from_utf8(&source_file.source_code).unwrap());
+    if let Err(err) = maybe_json_value {
+      return Box::new(futures::future::err(ErrBox::from(err)));
+    }
+
+    let mut code = format!(
+      "export default {};\n",
+      str::from_utf8(&source_file.source_code).unwrap()
+    );
+
+    if let serde_json::Value::Object(m) = maybe_json_value.unwrap() {
+      // Best effort variable name exports
+      // Actual all allowed JS variable names are way tricker.
+      // We only handle a subset of alphanumeric names.
+      let js_var_regex = Regex::new(r"^[a-zA-Z_$][0-9a-zA-Z_$]*$").unwrap();
+      // Also avoid collision with reserved words.
+      let reserved_words = Regex::new(JS_RESERVED_WORDS).unwrap();
+      for (key, value) in m.iter() {
+        if js_var_regex.is_match(&key) && !reserved_words.is_match(&key) {
+          code.push_str(&format!(
+            "export const {} = {};\n",
+            key,
+            value.to_string()
+          ));
+        }
+      }
+    }
+
     let module = CompiledModule {
-      code: format!(
-        "export default {};",
-        str::from_utf8(&source_file.source_code).unwrap()
-      ),
+      code,
       name: source_file.url.to_string(),
     };
 

--- a/cli/tests/050_more_jsons.ts
+++ b/cli/tests/050_more_jsons.ts
@@ -1,0 +1,7 @@
+import j1, { $var } from "./subdir/json_1.json";
+import j2 from "./subdir/json_2.json";
+console.log($var);
+console.log($var.a);
+console.log(j1);
+console.log(j1["with space"]);
+console.log(j2);

--- a/cli/tests/050_more_jsons.ts.out
+++ b/cli/tests/050_more_jsons.ts.out
@@ -1,0 +1,5 @@
+{ a: 123, b: [ 1, 2, 3 ], c: null }
+123
+{ $var: { a: 123, b: [ 1, 2, 3 ], c: null }, with space: "invalid variable name", function: "reserved word" }
+invalid variable name
+just a string

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -343,6 +343,11 @@ itest!(_049_info_flag_script_jsx {
   http_server: true,
 });
 
+itest!(_050_more_jsons {
+  args: "run --reload 050_more_jsons.ts",
+  output: "050_more_jsons.ts.out",
+});
+
 itest!(async_error {
   exit_code: 1,
   args: "run --reload async_error.ts",

--- a/cli/tests/subdir/json_1.json
+++ b/cli/tests/subdir/json_1.json
@@ -1,0 +1,5 @@
+{
+  "$var": { "a": 123, "b": [1, 2, 3], "c": null },
+  "with space": "invalid variable name",
+  "function": "reserved word"
+}

--- a/cli/tests/subdir/json_2.json
+++ b/cli/tests/subdir/json_2.json
@@ -1,0 +1,1 @@
+"just a string"


### PR DESCRIPTION
Closes #3171

Added some named exports for JSON modules if:
1. JSON contains a single object
2. corresponding field is not a reserved word
3. corresponding field can be represented as a subset of valid variables (alphanumeric only)

Sidenote: I wonder we might be able to take advantage of [SyntheticModule](https://cs.chromium.org/chromium/src/v8/include/v8.h?gsn=SyntheticModuleEvaluationSteps&q=SyntheticModule+file:v8.h&g=0&l=1569-1572) at some point.