### PR TITLE
Update link to schematic diagram in manual

### DIFF
--- a/std/manual.md
+++ b/std/manual.md
@@ -1068,7 +1068,7 @@ Metrics is Deno's internal counters for various statics.
 
 ### Schematic diagram
 
-<img src="images/schematic_v0.2.png">
+<img src="https://deno.land/images/schematic_v0.2.png">
 
 ### Profiling
 


### PR DESCRIPTION
Fixes #3209.

Note the full URL - we shouldn't make assumptions about where this is being served since that's happening in a different repo now.