### PR TITLE
Use for-await in examples and manual

### DIFF
--- a/std/bundle/run.ts
+++ b/std/bundle/run.ts
@@ -2,10 +2,7 @@
 
 import { evaluate, instantiate, load } from "./utils.ts";
 
-async function main(args: string[]): Promise<void> {
-  const text = await load(args);
-  const result = evaluate(text);
-  instantiate(...result);
-}
-
-main(Deno.args);
+const args = Deno.args;
+const text = await load(args);
+const result = evaluate(text);
+instantiate(...result);

--- a/std/examples/curl.ts
+++ b/std/examples/curl.ts
@@ -1,4 +1,4 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-const url = Deno.args[1];
-const res = await fetch(url);
+const url_ = Deno.args[1];
+const res = await fetch(url_);
 await Deno.copy(Deno.stdout, res.body);

--- a/std/examples/echo_server.ts
+++ b/std/examples/echo_server.ts
@@ -3,7 +3,6 @@ const hostname = "0.0.0.0";
 const port = 8080;
 const listener = Deno.listen({ hostname, port });
 console.log(`Listening on ${hostname}:${port}`);
-while (true) {
-  const conn = await listener.accept();
+for await (const conn of listener) {
   Deno.copy(conn, conn);
 }

--- a/std/examples/gist.ts
+++ b/std/examples/gist.ts
@@ -1,7 +1,5 @@
 #!/usr/bin/env -S deno --allow-net --allow-env
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-
-const { args, env, exit, readFile } = Deno;
 import { parse } from "https://deno.land/std/flags/mod.ts";
 
 function pathBase(p: string): string {
@@ -9,57 +7,53 @@ function pathBase(p: string): string {
   return parts[parts.length - 1];
 }
 
-async function main(): Promise<void> {
-  const token = env()["GIST_TOKEN"];
-  if (!token) {
-    console.error("GIST_TOKEN environmental variable not set.");
-    console.error("Get a token here: https://github.com/settings/tokens");
-    exit(1);
-  }
-
-  const parsedArgs = parse(args.slice(1));
-
-  if (parsedArgs._.length === 0) {
-    console.error(
-      "Usage: gist.ts --allow-env --allow-net [-t|--title Example] some_file " +
-        "[next_file]"
-    );
-    exit(1);
-  }
-
-  const files = {};
-  for (const filename of parsedArgs._) {
-    const base = pathBase(filename);
-    const content = await readFile(filename);
-    const contentStr = new TextDecoder().decode(content);
-    files[base] = { content: contentStr };
-  }
-
-  const content = {
-    description: parsedArgs.title || parsedArgs.t || "Example",
-    public: false,
-    files: files
-  };
-  const body = JSON.stringify(content);
-
-  const res = await fetch("https://api.github.com/gists", {
-    method: "POST",
-    headers: [
-      ["Content-Type", "application/json"],
-      ["User-Agent", "Deno-Gist"],
-      ["Authorization", `token ${token}`]
-    ],
-    body
-  });
-
-  if (res.ok) {
-    const resObj = await res.json();
-    console.log("Success");
-    console.log(resObj["html_url"]);
-  } else {
-    const err = await res.text();
-    console.error("Failure to POST", err);
-  }
+const token = Deno.env()["GIST_TOKEN"];
+if (!token) {
+  console.error("GIST_TOKEN environmental variable not set.");
+  console.error("Get a token here: https://github.com/settings/tokens");
+  Deno.exit(1);
 }
 
-main();
+const parsedArgs = parse(Deno.args.slice(1));
+
+if (parsedArgs._.length === 0) {
+  console.error(
+    "Usage: gist.ts --allow-env --allow-net [-t|--title Example] some_file " +
+      "[next_file]"
+  );
+  Deno.exit(1);
+}
+
+const files = {};
+for (const filename of parsedArgs._) {
+  const base = pathBase(filename);
+  const content = await Deno.readFile(filename);
+  const contentStr = new TextDecoder().decode(content);
+  files[base] = { content: contentStr };
+}
+
+const content = {
+  description: parsedArgs.title || parsedArgs.t || "Example",
+  public: false,
+  files: files
+};
+const body = JSON.stringify(content);
+
+const res = await fetch("https://api.github.com/gists", {
+  method: "POST",
+  headers: [
+    ["Content-Type", "application/json"],
+    ["User-Agent", "Deno-Gist"],
+    ["Authorization", `token ${token}`]
+  ],
+  body
+});
+
+if (res.ok) {
+  const resObj = await res.json();
+  console.log("Success");
+  console.log(resObj["html_url"]);
+} else {
+  const err = await res.text();
+  console.error("Failure to POST", err);
+}

--- a/std/http/http_bench.ts
+++ b/std/http/http_bench.ts
@@ -5,11 +5,7 @@ const addr = Deno.args[1] || "127.0.0.1:4500";
 const server = serve(addr);
 const body = new TextEncoder().encode("Hello World");
 
-async function main(): Promise<void> {
-  console.log(`http://${addr}/`);
-  for await (const req of server) {
-    req.respond({ body });
-  }
+console.log(`http://${addr}/`);
+for await (const req of server) {
+  req.respond({ body });
 }
-
-main();

--- a/std/http/racing_server.ts
+++ b/std/http/racing_server.ts
@@ -19,32 +19,28 @@ async function largeRespond(request: ServerRequest, c: string): Promise<void> {
   await request.respond({ status: 200, body: b });
 }
 
-async function main(): Promise<void> {
-  let step = 1;
-  for await (const request of server) {
-    switch (step) {
-      case 1:
-        // Try to wait long enough.
-        // For pipelining, this should cause all the following response
-        // to block.
-        delayedRespond(request);
-        break;
-      case 2:
-        // HUGE body.
-        largeRespond(request, "a");
-        break;
-      case 3:
-        // HUGE body.
-        largeRespond(request, "b");
-        break;
-      default:
-        request.respond({ status: 200, body: body4 });
-        break;
-    }
-    step++;
-  }
-}
-
-main();
-
 console.log("Racing server listening...\n");
+
+let step = 1;
+for await (const request of server) {
+  switch (step) {
+    case 1:
+      // Try to wait long enough.
+      // For pipelining, this should cause all the following response
+      // to block.
+      delayedRespond(request);
+      break;
+    case 2:
+      // HUGE body.
+      largeRespond(request, "a");
+      break;
+    case 3:
+      // HUGE body.
+      largeRespond(request, "b");
+      break;
+    default:
+      request.respond({ status: 200, body: body4 });
+      break;
+  }
+  step++;
+}

--- a/std/manual.md
+++ b/std/manual.md
@@ -312,8 +312,7 @@ and returns to the client anything it sends.
 ```ts
 const listener = Deno.listen({ port: 8080 });
 console.log("listening on 0.0.0.0:8080");
-while (true) {
-  const conn = await listener.accept();
+for await (const conn of listener) {
   Deno.copy(conn, conn);
 }
 ```
@@ -353,26 +352,24 @@ Sometimes a program may want to revoke previously granted permissions. When a
 program, at a later stage, needs those permissions, it will fail.
 
 ```ts
-const { permissions, open, remove } = Deno;
-
 // lookup a permission
-const status = await permissions.query({ name: "write" });
+const status = await Deno.permissions.query({ name: "write" });
 if (status.state !== "granted") {
   throw new Error("need write permission");
 }
 
-const log = await open("request.log", "a+");
+const log = await Deno.open("request.log", "a+");
 
 // revoke some permissions
-await permissions.revoke({ name: "read" });
-await permissions.revoke({ name: "write" });
+await Deno.permissions.revoke({ name: "read" });
+await Deno.permissions.revoke({ name: "write" });
 
 // use the log file
 const encoder = new TextEncoder();
 await log.write(encoder.encode("hello\n"));
 
 // this will fail.
-await remove("request.log");
+await Deno.remove("request.log");
 ```
 
 ### File server

--- a/tools/deno_tcp.ts
+++ b/tools/deno_tcp.ts
@@ -24,12 +24,7 @@ async function handle(conn: Deno.Conn): Promise<void> {
   }
 }
 
-async function main(): Promise<void> {
-  console.log("Listening on", addr);
-  while (true) {
-    const conn = await listener.accept();
-    handle(conn);
-  }
+console.log("Listening on", addr);
+for await (const conn of listener) {
+  handle(conn);
 }
-
-main();

--- a/tools/deno_tcp_proxy.ts
+++ b/tools/deno_tcp_proxy.ts
@@ -24,12 +24,7 @@ async function handle(conn: Deno.Conn): Promise<void> {
   }
 }
 
-async function main(): Promise<void> {
-  console.log(`Proxy listening on http://${addr}/`);
-  while (true) {
-    const conn = await listener.accept();
-    handle(conn);
-  }
+console.log(`Proxy listening on http://${addr}/`);
+for await (const conn of listener) {
+  handle(conn);
 }
-
-main();


### PR DESCRIPTION
follow up to #3212, see also #3216.

There's still a top-level for-await in the website home page, but this should be fixed after 0.22 (once this syntax is released).

https://github.com/denoland/deno_website2/blob/92a20e81c51c051080311c2edefe517049dbafcd/src/Home.js#L7-L15