### PR TITLE
Prevent customInspect error from crashing console

### DIFF
--- a/cli/js/console.ts
+++ b/cli/js/console.ts
@@ -327,8 +327,11 @@ function createObjectString(
   ...args: [ConsoleContext, number, number]
 ): string {
   if (customInspect in value && typeof value[customInspect] === "function") {
-    return String(value[customInspect]!());
-  } else if (value instanceof Error) {
+    try {
+      return String(value[customInspect]!());
+    } catch {}
+  }
+  if (value instanceof Error) {
     return String(value.stack);
   } else if (Array.isArray(value)) {
     return createArrayString(value, ...args);

--- a/cli/js/console_test.ts
+++ b/cli/js/console_test.ts
@@ -190,6 +190,27 @@ test(function consoleTestWithCustomInspector(): void {
   assertEquals(stringify(new A()), "b");
 });
 
+test(function consoleTestWithCustomInspectorError(): void {
+  class A {
+    [customInspect](): string {
+      throw new Error("BOOM");
+      return "b";
+    }
+  }
+
+  assertEquals(stringify(new A()), "A {}");
+
+  class B {
+    constructor(public field: { a: string }) {}
+    [customInspect](): string {
+      return this.field.a;
+    }
+  }
+
+  assertEquals(stringify(new B({ a: "a" })), "a");
+  assertEquals(stringify(B.prototype), "{}");
+});
+
 test(function consoleTestWithIntegerFormatSpecifier(): void {
   assertEquals(stringify("%i"), "%i");
   assertEquals(stringify("%i", 42.0), "42");


### PR DESCRIPTION
Add a try-catch and allow fallback stringify for customInspect.

A current crashing example is inspection towards `Headers.prototype`. This PR fixes this:

Before:
```
> Headers.prototype
error: Uncaught TypeError: Cannot read property 'size' of undefined
► $deno$/headers.ts:90:38
    at [Deno.customInspect] ($deno$/headers.ts:90:38)
    at createObjectString ($deno$/console.ts:330:40)
    at stringify ($deno$/console.ts:143:14)
    at stringifyArgs ($deno$/console.ts:462:14)
    at replLog ($deno$/repl.ts:18:14)
    at evaluate ($deno$/repl.ts:89:5)
    at replLoop ($deno$/repl.ts:176:13)
```

After:
```
> Headers.prototype
HeadersBase {}
```