### PR TITLE
Support for deep `Map` equality with `asserts#equal`

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -56,12 +56,10 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   );
   messages.push("");
   messages.push("");
-  diffResult.forEach(
-    (result: DiffResult<string>): void => {
-      const c = createColor(result.type);
-      messages.push(c(`${createSign(result.type)}${result.value}`));
-    }
-  );
+  diffResult.forEach((result: DiffResult<string>): void => {
+    const c = createColor(result.type);
+    messages.push(c(`${createSign(result.type)}${result.value}`));
+  });
   messages.push("");
 
   return messages;

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -56,10 +56,12 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   );
   messages.push("");
   messages.push("");
-  diffResult.forEach((result: DiffResult<string>): void => {
-    const c = createColor(result.type);
-    messages.push(c(`${createSign(result.type)}${result.value}`));
-  });
+  diffResult.forEach(
+    (result: DiffResult<string>): void => {
+      const c = createColor(result.type);
+      messages.push(c(`${createSign(result.type)}${result.value}`));
+    }
+  );
   messages.push("");
 
   return messages;

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -81,6 +81,19 @@ export function equal(c: unknown, d: unknown): boolean {
       }
       return true;
     }
+    if (a && b && a instanceof Map && b instanceof Map) {
+      if (a.size !== b.size) {
+        return false;
+      }
+
+      for (const [key, value] of a) {
+        if (!compare(value, b.get(key))) {
+          return false;
+        }
+      }
+
+      return true;
+    }
     // Have to render RegExp & Date for string comparison
     // unless it's mistreated as object
     if (

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -51,7 +51,9 @@ test(function testingEqual(): void {
   assert(equal(new Map([["foo", "bar"], ["baz", "baz"]]), new Map([["foo", "bar"], ["baz", "baz"]])));
   assert(equal(new Map([["foo", new Map([["bar", "baz"]])]]), new Map([["foo", new Map([["bar", "baz"]])]])));
   assert(equal(new Map([["foo", { bar: 'baz' }]]), new Map([["foo", { bar: 'baz' }]])));
+  assert(equal(new Map([["foo", "bar"], ["baz", "qux"]]), new Map([["baz", "qux"], ["foo", "bar"]])));
   assert(!equal(new Map([["foo", "bar"]]), new Map([["bar", "baz"]])));
+  assert(!equal(new Map([["foo", "bar"]]), new Map([["foo", "bar"], ["bar", "baz"]])));
   assert(!equal(new Map([["foo", new Map([["bar", "baz"]])]]), new Map([["foo", new Map([["bar", "qux"]])]])));
 });
 

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -48,14 +48,41 @@ test(function testingEqual(): void {
   assert(!equal(new Set([1, 2, 3]), new Set([4, 5, 6])));
   assert(equal(new Set("denosaurus"), new Set("denosaurussss")));
   assert(equal(new Map(), new Map()));
-  assert(equal(new Map([["foo", "bar"], ["baz", "baz"]]), new Map([["foo", "bar"], ["baz", "baz"]])));
-  assert(equal(new Map([["foo", new Map([["bar", "baz"]])]]), new Map([["foo", new Map([["bar", "baz"]])]])));
-  assert(equal(new Map([["foo", { bar: 'baz' }]]), new Map([["foo", { bar: 'baz' }]])));
-  assert(equal(new Map([["foo", "bar"], ["baz", "qux"]]), new Map([["baz", "qux"], ["foo", "bar"]])));
+  assert(
+    equal(
+      new Map([["foo", "bar"], ["baz", "baz"]]),
+      new Map([["foo", "bar"], ["baz", "baz"]])
+    )
+  );
+  assert(
+    equal(
+      new Map([["foo", new Map([["bar", "baz"]])]]),
+      new Map([["foo", new Map([["bar", "baz"]])]])
+    )
+  );
+  assert(
+    equal(
+      new Map([["foo", { bar: "baz" }]]),
+      new Map([["foo", { bar: "baz" }]])
+    )
+  );
+  assert(
+    equal(
+      new Map([["foo", "bar"], ["baz", "qux"]]),
+      new Map([["baz", "qux"], ["foo", "bar"]])
+    )
+  );
   assert(equal(new Map([["foo", ["bar"]]]), new Map([["foo", ["bar"]]])));
   assert(!equal(new Map([["foo", "bar"]]), new Map([["bar", "baz"]])));
-  assert(!equal(new Map([["foo", "bar"]]), new Map([["foo", "bar"], ["bar", "baz"]])));
-  assert(!equal(new Map([["foo", new Map([["bar", "baz"]])]]), new Map([["foo", new Map([["bar", "qux"]])]])));
+  assert(
+    !equal(new Map([["foo", "bar"]]), new Map([["foo", "bar"], ["bar", "baz"]]))
+  );
+  assert(
+    !equal(
+      new Map([["foo", new Map([["bar", "baz"]])]]),
+      new Map([["foo", new Map([["bar", "qux"]])]])
+    )
+  );
 });
 
 test(function testingNotEquals(): void {

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -52,6 +52,7 @@ test(function testingEqual(): void {
   assert(equal(new Map([["foo", new Map([["bar", "baz"]])]]), new Map([["foo", new Map([["bar", "baz"]])]])));
   assert(equal(new Map([["foo", { bar: 'baz' }]]), new Map([["foo", { bar: 'baz' }]])));
   assert(equal(new Map([["foo", "bar"], ["baz", "qux"]]), new Map([["baz", "qux"], ["foo", "bar"]])));
+  assert(equal(new Map([["foo", ["bar"]]]), new Map([["foo", ["bar"]]])));
   assert(!equal(new Map([["foo", "bar"]]), new Map([["bar", "baz"]])));
   assert(!equal(new Map([["foo", "bar"]]), new Map([["foo", "bar"], ["bar", "baz"]])));
   assert(!equal(new Map([["foo", new Map([["bar", "baz"]])]]), new Map([["foo", new Map([["bar", "qux"]])]])));

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -47,6 +47,12 @@ test(function testingEqual(): void {
   assert(!equal(new Set([1, 2]), new Set([3, 2, 1])));
   assert(!equal(new Set([1, 2, 3]), new Set([4, 5, 6])));
   assert(equal(new Set("denosaurus"), new Set("denosaurussss")));
+  assert(equal(new Map(), new Map()));
+  assert(equal(new Map([["foo", "bar"], ["baz", "baz"]]), new Map([["foo", "bar"], ["baz", "baz"]])));
+  assert(equal(new Map([["foo", new Map([["bar", "baz"]])]]), new Map([["foo", new Map([["bar", "baz"]])]])));
+  assert(equal(new Map([["foo", { bar: 'baz' }]]), new Map([["foo", { bar: 'baz' }]])));
+  assert(!equal(new Map([["foo", "bar"]]), new Map([["bar", "baz"]])));
+  assert(!equal(new Map([["foo", new Map([["bar", "baz"]])]]), new Map([["foo", new Map([["bar", "qux"]])]])));
 });
 
 test(function testingNotEquals(): void {


### PR DESCRIPTION
As per #3235, here is my fix for supporting for deeply comparing `Map` instances in the `asserts` module's `equal` function. Much like the conditional branches for `Set` comparisons, this logic has been inlined within `equal` itself.

I've also included a set of test cases (simple equality, nested `Map`s , arrays and objects as `Map` values etc.)