### PR TITLE
fix intermittent bug with 048_media_types_jsx

### DIFF
--- a/cli/test_util.rs
+++ b/cli/test_util.rs
@@ -79,7 +79,7 @@ pub fn http_server<'a>() -> HttpServerGuard<'a> {
       let r = out.read_exact(&mut buf);
       if r.is_ok() {
         println!("tools/http_server.py ready");
-        break
+        break;
       }
     }
     std::thread::sleep(std::time::Duration::from_millis(100));

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -178,7 +178,7 @@ def spawn():
     while any(not s.thread.is_alive() for s in servers):
         sleep(0.01)
     try:
-        print("ready")
+        print "ready"
         yield servers
     finally:
         for s in servers:

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -189,7 +189,7 @@ def main():
     with spawn() as servers:
         try:
             while all(s.thread.is_alive() for s in servers):
-                sleep(10)
+                sleep(1)
         except KeyboardInterrupt:
             pass
     sys.exit(1)

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -178,20 +178,20 @@ def spawn():
     while any(not s.thread.is_alive() for s in servers):
         sleep(0.01)
     try:
-        yield
+        print("ready")
+        yield servers
     finally:
         for s in servers:
             s.server.shutdown()
 
 
 def main():
-    servers = (server(), redirect_server(), another_redirect_server(),
-               double_redirects_server(), inf_redirects_server())
-    try:
-        while all(s.thread.is_alive() for s in servers):
-            sleep(10)
-    except KeyboardInterrupt:
-        pass
+    with spawn() as servers:
+        try:
+            while all(s.thread.is_alive() for s in servers):
+                sleep(10)
+        except KeyboardInterrupt:
+            pass
     sys.exit(1)
 
 


### PR DESCRIPTION
This seemed to happen relatively frequently in CI, rather than sleep for N seconds we wait for the server to print something to stdout. This isn't a perfect solution but ought to suffice.

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
