### PR TITLE
Adds custom inspect method for URL

### DIFF
--- a/cli/js/url.ts
+++ b/cli/js/url.ts
@@ -3,6 +3,7 @@ import * as urlSearchParams from "./url_search_params.ts";
 import * as domTypes from "./dom_types.ts";
 import { getRandomValues } from "./get_random_values.ts";
 import { window } from "./window.ts";
+import { customInspect } from "./console.ts";
 
 interface URLParts {
   protocol: string;
@@ -143,6 +144,26 @@ function resolvePathFromBase(path: string, basePath: string): string {
 export class URL {
   private _parts: URLParts;
   private _searchParams!: urlSearchParams.URLSearchParams;
+
+  [customInspect](): string {
+    const keys = [
+      "href",
+      "origin",
+      "protocol",
+      "username",
+      "password",
+      "host",
+      "hostname",
+      "port",
+      "pathname",
+      "hash",
+      "search"
+    ];
+    const objectString = keys
+      .map((key: string) => `${key}: "${this[key] || ""}"`)
+      .join(", ");
+    return `URL { ${objectString} }`;
+  }
 
   private _updateSearchParams(): void {
     const searchParams = new urlSearchParams.URLSearchParams(this.search);

--- a/cli/js/url_test.ts
+++ b/cli/js/url_test.ts
@@ -1,5 +1,11 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assert, assertEquals } from "./test_util.ts";
+// Some of these APIs aren't exposed in the types and so we have to cast to any
+// in order to "trick" TypeScript.	// in order to "trick" TypeScript.
+const {
+  customInspect
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} = Deno as any;
 
 test(function urlParsing(): void {
   const url = new URL(
@@ -178,4 +184,12 @@ test(function sortingNonExistentParamRemovesQuestionMarkFromURL(): void {
   url.searchParams.sort();
   assertEquals(url.href, "http://example.com/");
   assertEquals(url.search, "");
+});
+
+test(function customInspectFunction(): void {
+  const url = new URL("http://example.com/?");
+  assertEquals(
+    url[customInspect](),
+    'URL { href: "http://example.com/?", origin: "http://example.com", protocol: "http:", username: "", password: "", host: "example.com", hostname: "example.com", port: "", pathname: "/", hash: "", search: "?" }'
+  );
 });

--- a/cli/js/url_test.ts
+++ b/cli/js/url_test.ts
@@ -1,11 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assert, assertEquals } from "./test_util.ts";
-// Some of these APIs aren't exposed in the types and so we have to cast to any
-// in order to "trick" TypeScript.	// in order to "trick" TypeScript.
-const {
-  customInspect
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} = Deno as any;
 
 test(function urlParsing(): void {
   const url = new URL(
@@ -189,7 +183,7 @@ test(function sortingNonExistentParamRemovesQuestionMarkFromURL(): void {
 test(function customInspectFunction(): void {
   const url = new URL("http://example.com/?");
   assertEquals(
-    url[customInspect](),
+    Deno.inspect(url),
     'URL { href: "http://example.com/?", origin: "http://example.com", protocol: "http:", username: "", password: "", host: "example.com", hostname: "example.com", port: "", pathname: "/", hash: "", search: "?" }'
   );
 });


### PR DESCRIPTION
<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
Adds a custom inspection function for the URL class so that some hardcoded properties will always be listed in full.

Eg.
```
> new URL("http://example.com/?");
URL { href: "http://example.com/?", origin: "http://example.com", protocol: "http:", username: "", password: "", host: "example.com", hostname: "example.com", port: "", pathname: "/", hash: "", search: "?" }
```

Closes https://github.com/denoland/deno/issues/3124

Using custom inspection function implemented in https://github.com/denoland/deno/pull/2791