### PR TITLE
Make EOF symbol

### DIFF
--- a/cli/js/io.ts
+++ b/cli/js/io.ts
@@ -3,11 +3,8 @@
 // Documentation liberally lifted from them too.
 // Thank you! We love Go!
 
-// TODO(kt3k): EOF should be `unique symbol` type.
-// That might require some changes of ts_library_builder.
-// See #2591 for more details.
-export const EOF = null;
-export type EOF = null;
+export const EOF: unique symbol = Symbol("EOF");
+export type EOF = typeof EOF;
 
 // Seek whence values.
 // https://golang.org/pkg/io/#pkg-constants

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -83,8 +83,8 @@ declare namespace Deno {
 
   // @url js/io.d.ts
 
-  export const EOF: null;
-  export type EOF = null;
+  export const EOF: unique symbol;
+  export type EOF = typeof EOF;
   export enum SeekMode {
     SEEK_START = 0,
     SEEK_CURRENT = 1,
@@ -2283,8 +2283,6 @@ declare namespace eventTarget {
 declare namespace io {
   // @url js/io.d.ts
 
-  export const EOF: null;
-  export type EOF = null;
   export enum SeekMode {
     SEEK_START = 0,
     SEEK_CURRENT = 1,
@@ -2308,10 +2306,10 @@ declare namespace io {
      *
      * Implementations must not retain `p`.
      */
-    read(p: Uint8Array): Promise<number | EOF>;
+    read(p: Uint8Array): Promise<number | Deno.EOF>;
   }
   export interface SyncReader {
-    readSync(p: Uint8Array): number | EOF;
+    readSync(p: Uint8Array): number | Deno.EOF;
   }
   export interface Writer {
     /** Writes `p.byteLength` bytes from `p` to the underlying data
@@ -2387,7 +2385,7 @@ declare namespace fetchTypes {
     formData(): Promise<domTypes.FormData>;
     json(): Promise<any>;
     text(): Promise<string>;
-    read(p: Uint8Array): Promise<number | io.EOF>;
+    read(p: Uint8Array): Promise<number | Deno.EOF>;
     close(): void;
     cancel(): Promise<void>;
     getReader(): domTypes.ReadableStreamReader;


### PR DESCRIPTION
At the time of #2591, it was not possible to make EOF an unique symbol, but it now seems possible to do it.

This addresses a TODO comment in `//cli/js/io.ts`.