### PR TITLE
std/http: add serveTLS and listenAndServeTLS

### DIFF
--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -401,13 +401,19 @@ export async function listenAndServe(
   }
 }
 
-export function serveTLS(options: Deno.ListenTLSOptions): Server {
-  const listener = listenTLS(options);
+export type HTTPSOptions = Omit<Deno.ListenTLSOptions, "transport">;
+
+export function serveTLS(options: HTTPSOptions): Server {
+  const tlsOptions: Deno.ListenTLSOptions = {
+    ...options,
+    transport: "tcp"
+  };
+  const listener = listenTLS(tlsOptions);
   return new Server(listener);
 }
 
 export async function listenAndServeTLS(
-  options: Deno.ListenTLSOptions,
+  options: HTTPSOptions,
   handler: (req: ServerRequest) => void
 ): Promise<void> {
   const server = serveTLS(options);

--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -401,8 +401,25 @@ export async function listenAndServe(
   }
 }
 
+/** Options for creating an HTTPS server. */
 export type HTTPSOptions = Omit<Deno.ListenTLSOptions, "transport">;
 
+/**
+ * Create an HTTPS server with given options
+ * @param options Server configuration
+ * @return Async iterable server instance for incoming requests
+ *
+ *       const body = new TextEncoder().encode("Hello HTTPS");
+ *       const options = {
+ *         hostname: "localhost",
+ *         port: 443,
+ *         certFile: "./path/to/localhost.crt",
+ *         keyFile: "./path/to/localhost.key",
+ *       };
+ *       for await (const req of serveTLS(options)) {
+ *         req.respond({ body });
+ *       }
+ */
 export function serveTLS(options: HTTPSOptions): Server {
   const tlsOptions: Deno.ListenTLSOptions = {
     ...options,
@@ -412,6 +429,22 @@ export function serveTLS(options: HTTPSOptions): Server {
   return new Server(listener);
 }
 
+/**
+ * Create an HTTPS server with given options and request handler
+ * @param options Server configuration
+ * @param handler Request handler
+ *
+ *       const body = new TextEncoder().encode("Hello HTTPS");
+ *       const options = {
+ *         hostname: "localhost",
+ *         port: 443,
+ *         certFile: "./path/to/localhost.crt",
+ *         keyFile: "./path/to/localhost.key",
+ *       };
+ *       listenAndServeTLS(options, (req) => {
+ *         req.respond({ body });
+ *       });
+ */
 export async function listenAndServeTLS(
   options: HTTPSOptions,
   handler: (req: ServerRequest) => void

--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-const { listen, copy, toAsyncIterator } = Deno;
+const { listen, listenTLS, copy, toAsyncIterator } = Deno;
 type Listener = Deno.Listener;
 type Conn = Deno.Conn;
 type Reader = Deno.Reader;
@@ -395,6 +395,22 @@ export async function listenAndServe(
   handler: (req: ServerRequest) => void
 ): Promise<void> {
   const server = serve(addr);
+
+  for await (const request of server) {
+    handler(request);
+  }
+}
+
+export function serveTLS(options: Deno.ListenTLSOptions): Server {
+  const listener = listenTLS(options);
+  return new Server(listener);
+}
+
+export async function listenAndServeTLS(
+  options: Deno.ListenTLSOptions,
+  handler: (req: ServerRequest) => void
+): Promise<void> {
+  const server = serveTLS(options);
 
   for await (const request of server) {
     handler(request);

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -557,8 +557,6 @@ test({
         )
         .catch((_): void => {}); // Ignores the error when closing the process.
 
-      await delay(100);
-
       // Requests to the server and immediately closes the connection
       const conn = await Deno.dialTLS({
         hostname: "localhost",

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -529,4 +529,57 @@ test({
   }
 });
 
+test({
+  name: "[http] serveTLS",
+  async fn(): Promise<void> {
+    // Runs a simple server as another process
+    const p = Deno.run({
+      args: [
+        Deno.execPath(),
+        "http/testdata/simple_https_server.ts",
+        "--allow-net",
+        "--allow-read"
+      ],
+      stdout: "piped"
+    });
+
+    try {
+      const r = new TextProtoReader(new BufReader(p.stdout!));
+      const s = await r.readLine();
+      assert(s !== Deno.EOF && s.includes("server listening"));
+
+      let serverIsRunning = true;
+      p.status()
+        .then(
+          (): void => {
+            serverIsRunning = false;
+          }
+        )
+        .catch((_): void => {}); // Ignores the error when closing the process.
+
+      await delay(100);
+
+      // Requests to the server and immediately closes the connection
+      const conn = await Deno.dialTLS({
+        hostname: "localhost",
+        port: 4503,
+        certFile: "http/testdata/tls/RootCA.pem"
+      });
+      await Deno.writeAll(
+        conn,
+        new TextEncoder().encode("GET / HTTP/1.0\r\n\r\n")
+      );
+      const res = new Uint8Array(100);
+      const nread = assertNotEOF(await conn.read(res));
+      conn.close();
+      const resStr = new TextDecoder().decode(res.subarray(0, nread));
+      assert(resStr.includes("Hello HTTPS"));
+      assert(serverIsRunning);
+    } finally {
+      // Stops the sever.
+      p.close();
+    }
+  }
+});
+
 runIfMain(import.meta);

--- a/std/http/testdata/simple_https_server.ts
+++ b/std/http/testdata/simple_https_server.ts
@@ -8,8 +8,9 @@ const tlsOptions = {
   certFile: "./http/testdata/tls/localhost.crt",
   keyFile: "./http/testdata/tls/localhost.key",
 };
+const s = serveTLS(tlsOptions);
 console.log(`Simple HTTPS server listening on ${tlsOptions.hostname}:${tlsOptions.port}`);
 const body = new TextEncoder().encode("Hello HTTPS");
-for await (const req of serveTLS(tlsOptions)) {
+for await (const req of s) {
   req.respond({ body });
 }

--- a/std/http/testdata/simple_https_server.ts
+++ b/std/http/testdata/simple_https_server.ts
@@ -1,0 +1,15 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+// This is an example of a https server
+import { serveTLS } from "../server.ts";
+
+const tlsOptions = {
+  hostname: "localhost",
+  port: 4503,
+  certFile: "./http/testdata/tls/localhost.crt",
+  keyFile: "./http/testdata/tls/localhost.key",
+};
+console.log(`Simple HTTPS server listening on ${tlsOptions.hostname}:${tlsOptions.port}`);
+const body = new TextEncoder().encode("Hello HTTPS");
+for await (const req of serveTLS(tlsOptions)) {
+  req.respond({ body });
+}

--- a/std/http/testdata/tls
+++ b/std/http/testdata/tls
@@ -1,0 +1,1 @@
+../../../cli/tests/tls


### PR DESCRIPTION
Created `serveTLS` using `listenTLS` for HTTPS instead of `listen` for HTTP.

Example:
```ts
import { serve, serveTLS } from "./std/http/server.ts";

const tlsOptions = {
  hostname: "localhost",
  port: 443,
  certFile: "./localhost.pem",
  keyFile: "./localhost-key.pem",
};

async function httpServer() {
  console.log(`Simple HTTP server listening on localhost:80`);
  for await (const req of serve("localhost:80")) {
    const headers = new Headers();
    headers.set("Location", "https://localhost");
    req.respond({ status: 307, headers });
  }
}

async function httpsServer() {
  console.log(`Simple HTTPS server listening on ${tlsOptions.hostname}:${tlsOptions.port}`);
  const body = new TextEncoder().encode("Hello HTTPS");
  for await (const req of serveTLS(tlsOptions)) {
    req.respond({ body });
  }
}

httpServer();
httpsServer();
```
<img width="211" alt="Screen Shot 2019-11-03 at 11 55 10 AM" src="https://user-images.githubusercontent.com/15007517/68091153-0c04bb00-fe31-11e9-9cc3-c99f541488c8.png">

There seems to be still some issue when plain HTTP payload is submitted to the `serveTLS` that yields `InvalidData` error. We need to investigate how to gracefully handle the error in potentially another PR.