### PR TITLE
Consolidates asserts#equal branches for keyed collections (Map/Set) and supports deep equality of Map keys 

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -67,8 +67,10 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   return messages;
 }
 
-function isKeyedCollection(x: unknown): x is Map<unknown, unknown> | Set<unknown> {
-  return [Symbol.iterator, 'has', 'size'].every(key => key in (x as Map<unknown, unknown> | Set<unknown>));
+type KeyedCollection = Map<unknown, unknown> | Set<unknown>;
+
+function isKeyedCollection(x: unknown): x is KeyedCollection {
+  return [Symbol.iterator, 'has', 'size'].every(key => key in (x as KeyedCollection));
 }
 
 export function equal(c: unknown, d: unknown): boolean {

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -105,7 +105,10 @@ export function equal(c: unknown, d: unknown): boolean {
           for (const [bKey, bValue] of b.entries()) {
             /* Given that keys can be references, we need
              * to ensure that they are also deeply equal */
-            if (compare(aKey, bKey) && compare(aValue, bValue)) {
+            if (
+              (aKey === aValue && bKey === bValue && compare(aKey, bKey)) ||
+              (compare(aKey, bKey) && compare(aValue, bValue))
+            ) {
               unmatchedEntries--;
             }
           }

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -67,7 +67,9 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   return messages;
 }
 
-function isKeyedCollection(x: unknown): x is Map<unknown, unknown> | Set<unknown> {
+function isKeyedCollection(
+  x: unknown
+): x is Map<unknown, unknown> | Set<unknown> {
   return x instanceof Map || x instanceof Set;
 }
 
@@ -100,7 +102,7 @@ export function equal(c: unknown, d: unknown): boolean {
         }
 
         for (const [key, value] of a.entries()) {
-          if (!b.has(key) || !compare(value, 'get' in b ? b.get(key) : key)) {
+          if (!b.has(key) || !compare(value, "get" in b ? b.get(key) : key)) {
             return false;
           }
         }

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -67,10 +67,8 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   return messages;
 }
 
-function isKeyedCollection(
-  x: unknown
-): x is Set<unknown> {
-  return [Symbol.iterator, 'size'].every(k => k in (x as Set<unknown>));
+function isKeyedCollection(x: unknown): x is Set<unknown> {
+  return [Symbol.iterator, "size"].every(k => k in (x as Set<unknown>));
 }
 
 export function equal(c: unknown, d: unknown): boolean {

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -103,7 +103,7 @@ export function equal(c: unknown, d: unknown): boolean {
 
         for (const [aKey, aValue] of a.entries()) {
           for (const [bKey, bValue] of b.entries()) {
-            /* Given that keys can be references, we need
+            /* Given that Map keys can be references, we need
              * to ensure that they are also deeply equal */
             if (
               (aKey === aValue && bKey === bValue && compare(aKey, bKey)) ||

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -67,10 +67,8 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   return messages;
 }
 
-type KeyedCollection = Map<unknown, unknown> | Set<unknown>;
-
-function isKeyedCollection(x: unknown): x is KeyedCollection {
-  return [Symbol.iterator, 'has', 'size'].every(key => key in (x as KeyedCollection));
+function isKeyedCollection(x: unknown): x is Map<unknown, unknown> | Set<unknown> {
+  return x instanceof Map || x instanceof Set;
 }
 
 export function equal(c: unknown, d: unknown): boolean {

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -101,19 +101,19 @@ export function equal(c: unknown, d: unknown): boolean {
           return false;
         }
 
-        let matchedEntries = 0;
+        let unmatchedEntries = a.size;
 
         for (const [aKey, aValue] of a.entries()) {
           for (const [bKey, bValue] of b.entries()) {
             /* Given that keys can be references, we need
              * to ensure that they are also deeply equal */
             if (compare(aKey, bKey) && compare(aValue, bValue)) {
-              matchedEntries++;
+              unmatchedEntries--;
             }
           }
         }
 
-        return matchedEntries === a.size;
+        return unmatchedEntries === 0;
       }
       const merged = { ...a, ...b };
       for (const key in merged) {

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -67,33 +67,13 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   return messages;
 }
 
+function isKeyedCollection(x: unknown): x is Map<unknown, unknown> | Set<unknown> {
+  return [Symbol.iterator, 'has', 'size'].every(key => key in (x as Map<unknown, unknown> | Set<unknown>));
+}
+
 export function equal(c: unknown, d: unknown): boolean {
   const seen = new Map();
   return (function compare(a: unknown, b: unknown): boolean {
-    if (a && a instanceof Set && b && b instanceof Set) {
-      if (a.size !== b.size) {
-        return false;
-      }
-      for (const item of b) {
-        if (!a.has(item)) {
-          return false;
-        }
-      }
-      return true;
-    }
-    if (a && b && a instanceof Map && b instanceof Map) {
-      if (a.size !== b.size) {
-        return false;
-      }
-
-      for (const [key, value] of a) {
-        if (!compare(value, b.get(key))) {
-          return false;
-        }
-      }
-
-      return true;
-    }
     // Have to render RegExp & Date for string comparison
     // unless it's mistreated as object
     if (
@@ -113,6 +93,19 @@ export function equal(c: unknown, d: unknown): boolean {
       }
       if (Object.keys(a || {}).length !== Object.keys(b || {}).length) {
         return false;
+      }
+      if (isKeyedCollection(a) && isKeyedCollection(b)) {
+        if (a.size !== b.size) {
+          return false;
+        }
+
+        for (const [key, value] of a.entries()) {
+          if (!b.has(key) || !compare(value, 'get' in b ? b.get(key) : key)) {
+            return false;
+          }
+        }
+
+        return true;
       }
       const merged = { ...a, ...b };
       for (const key in merged) {

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -85,26 +85,11 @@ test(function testingEqual(): void {
     )
   );
 
-  assert(
-    equal(
-      new Map([[{x: 1}, true]]),
-      new Map([[{x: 1}, true]])
-    )
-  );
+  assert(equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 1 }, true]])));
 
-  assert(
-    !equal(
-      new Map([[{x: 1}, true]]),
-      new Map([[{x: 1}, false]])
-    )
-  );
+  assert(!equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 1 }, false]])));
 
-  assert(
-    !equal(
-      new Map([[{x: 1}, true]]),
-      new Map([[{x: 2}, false]])
-    )
-  );
+  assert(!equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 2 }, false]])));
 
   assert(equal([1, 2, 3], [1, 2, 3]));
   assert(equal([1, [2, 3]], [1, [2, 3]]));

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -44,6 +44,7 @@ test(function testingEqual(): void {
   assert(equal(new Set([1]), new Set([1])));
   assert(!equal(new Set([1]), new Set([2])));
   assert(equal(new Set([1, 2, 3]), new Set([3, 2, 1])));
+  assert(equal(new Set([1, new Set([2, 3])]), new Set([new Set([3, 2]), 1])));
   assert(!equal(new Set([1, 2]), new Set([3, 2, 1])));
   assert(!equal(new Set([1, 2, 3]), new Set([4, 5, 6])));
   assert(equal(new Set("denosaurus"), new Set("denosaurussss")));
@@ -81,6 +82,27 @@ test(function testingEqual(): void {
     !equal(
       new Map([["foo", new Map([["bar", "baz"]])]]),
       new Map([["foo", new Map([["bar", "qux"]])]])
+    )
+  );
+
+  assert(
+    equal(
+      new Map([[{x: 1}, true]]),
+      new Map([[{x: 1}, true]])
+    )
+  );
+
+  assert(
+    !equal(
+      new Map([[{x: 1}, true]]),
+      new Map([[{x: 1}, false]])
+    )
+  );
+
+  assert(
+    !equal(
+      new Map([[{x: 1}, true]]),
+      new Map([[{x: 2}, false]])
     )
   );
 

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -83,6 +83,11 @@ test(function testingEqual(): void {
       new Map([["foo", new Map([["bar", "qux"]])]])
     )
   );
+
+  assert(equal([1, 2, 3], [1, 2, 3]));
+  assert(equal([1, [2, 3]], [1, [2, 3]]));
+  assert(!equal([1, 2, 3, 4], [1, 2, 3]));
+  assert(!equal([1, 2, 3, 4], [1, 2, 3]));
 });
 
 test(function testingNotEquals(): void {

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -89,7 +89,7 @@ test(function testingEqual(): void {
 
   assert(!equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 1 }, false]])));
 
-  assert(!equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 2 }, false]])));
+  assert(!equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 2 }, true]])));
 
   assert(equal([1, 2, 3], [1, 2, 3]));
   assert(equal([1, [2, 3]], [1, [2, 3]]));

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -84,19 +84,14 @@ test(function testingEqual(): void {
       new Map([["foo", new Map([["bar", "qux"]])]])
     )
   );
-
   assert(equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 1 }, true]])));
-
   assert(!equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 1 }, false]])));
-
   assert(!equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 2 }, true]])));
-
   assert(equal([1, 2, 3], [1, 2, 3]));
   assert(equal([1, [2, 3]], [1, [2, 3]]));
   assert(!equal([1, 2, 3, 4], [1, 2, 3]));
   assert(!equal([1, 2, 3, 4], [1, 2, 3]));
   assert(!equal([1, 2, 3, 4], [1, 4, 2, 3]));
-
   assert(equal(new Uint8Array([1, 2, 3, 4]), new Uint8Array([1, 2, 3, 4])));
   assert(!equal(new Uint8Array([1, 2, 3, 4]), new Uint8Array([2, 1, 4, 3])));
 });

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -88,6 +88,10 @@ test(function testingEqual(): void {
   assert(equal([1, [2, 3]], [1, [2, 3]]));
   assert(!equal([1, 2, 3, 4], [1, 2, 3]));
   assert(!equal([1, 2, 3, 4], [1, 2, 3]));
+  assert(!equal([1, 2, 3, 4], [1, 4, 2, 3]));
+
+  assert(equal(new Uint8Array([1, 2, 3, 4]), new Uint8Array([1, 2, 3, 4])));
+  assert(!equal(new Uint8Array([1, 2, 3, 4]), new Uint8Array([2, 1, 4, 3])));
 });
 
 test(function testingNotEquals(): void {


### PR DESCRIPTION
In my fix for #3235, I simply added an additional branch to asserts#equal() to deeply compare `Map` instances in a similar fashion to `Set` instances. @kitsonk sensibly raised, however, that I could consolidate these two branches for all iterables. However, it turns out such a unification is not so straightforward.

Foremost, `Map` and `Set` are examples of [_keyed collections_](https://www.ecma-international.org/ecma-262/10.0/index.html#sec-keyed-collections), which are [**not** indexable, linear sequences](https://2ality.com/2015/01/es6-maps-sets.html#why-size-and-not-length%3F). Hence, `equal(new Set([1, 2, 3]), new Set([3, 2, 1]))` should return `true`, but `equal([1, 2, 3], [3, 2, 1])` should return `false`. After some investigation, I can confirm that [this also holds true in Jest](https://gist.github.com/jamesseanwright/cf997824b9fd484eb4be4b85b1fd5bd1) and [Chai](https://gist.github.com/jamesseanwright/017c72f54b2349578607fefb253c45be). Effectively, if two `Map`s or `Set`s _have_ (i.e. `Map`/`Set#has(key)`) the same keys which resolve to deeply-equivalent values, then `equal(a, b) === true`.

Therefore, rather than introduce a common conditional branch for all iterables, I combined the logic for keyed collections only. I'm currently [detecting them with duck typing](https://github.com/jamesseanwright/deno/blob/3b5c42bbb3d1568239a8c83e958b3fa194aadd55/std/testing/asserts.ts#L70), but please let me know if an explicit `instanceof Map || instanceof Set` check would be preferable.

I also realised that the current release (0.22) and my fix also fail to determine if the _keys_ of a keyed collection are deeply equal (i.e. `equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 1 }, true]]))` should be `true`, despite the keys being different references), which I have thus addressed in this PR. Once again, [Jest](https://gist.github.com/jamesseanwright/cf997824b9fd484eb4be4b85b1fd5bd1#file-deep-iterable-equality-jest-js-L17) and [Chai](https://gist.github.com/jamesseanwright/017c72f54b2349578607fefb253c45be#file-deep-iterable-equality-chai-js-L19) handle these cases in the same way.

I should highlight that there's a potential performance downside to my changes: disregarding recursion, the existing solution for both `Map`s and `Set`s has a worst-case complexity of `O(n)` (`O(n)` for iterating over `a` and `O(1)` for `b.has(keyOfA)`/`b.get(keyOfA)`), whereas my changes have an upper bound of `O(n²)`. I understand if this trade-off isn't worth introducing to a standard module, but I don't think it hurts to support true deep equality of keyed collections out of the box if it's going to help with testing while avoiding the need for superfluous third-party dependencies.