### PR TITLE
Remove CoreResource::inspect_repr method

### DIFF
--- a/cli/ops/repl.rs
+++ b/cli/ops/repl.rs
@@ -24,11 +24,7 @@ pub fn init(i: &mut Isolate, s: &ThreadSafeState) {
 
 struct ReplResource(Arc<Mutex<Repl>>);
 
-impl CoreResource for ReplResource {
-  fn inspect_repr(&self) -> &str {
-    "repl"
-  }
-}
+impl CoreResource for ReplResource {}
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -49,7 +45,7 @@ fn op_repl_start(
   let repl = repl::Repl::new(history_path);
   let resource = ReplResource(Arc::new(Mutex::new(repl)));
   let mut table = resources::lock_resource_table();
-  let rid = table.add(Box::new(resource));
+  let rid = table.add("repl", Box::new(resource));
   Ok(JsonOp::Sync(json!(rid)))
 }
 

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -196,7 +196,7 @@ impl ThreadSafeState {
     };
 
     let mut table = resources::lock_resource_table();
-    let rid = table.add(Box::new(external_channels));
+    let rid = table.add("worker", Box::new(external_channels));
 
     let import_map: Option<ImportMap> =
       match global_state.flags.import_map_path.as_ref() {

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -31,11 +31,7 @@ pub struct WorkerChannels {
   pub receiver: mpsc::Receiver<Buf>,
 }
 
-impl CoreResource for WorkerChannels {
-  fn inspect_repr(&self) -> &str {
-    "worker"
-  }
-}
+impl CoreResource for WorkerChannels {}
 
 /// Wraps deno::Isolate to provide source maps, ops for the CLI, and
 /// high-level module loading.

--- a/core/examples/http_bench.rs
+++ b/core/examples/http_bench.rs
@@ -190,19 +190,11 @@ pub fn bad_resource() -> Error {
 
 struct TcpListener(tokio::net::TcpListener);
 
-impl Resource for TcpListener {
-  fn inspect_repr(&self) -> &str {
-    "tcpListener"
-  }
-}
+impl Resource for TcpListener {}
 
 struct TcpStream(tokio::net::TcpStream);
 
-impl Resource for TcpStream {
-  fn inspect_repr(&self) -> &str {
-    "tcpStream"
-  }
-}
+impl Resource for TcpStream {}
 
 lazy_static! {
   static ref RESOURCE_TABLE: Mutex<ResourceTable> =
@@ -225,7 +217,7 @@ fn op_accept(record: Record, _zero_copy_buf: Option<PinnedBuf>) -> Box<HttpOp> {
   .and_then(move |(stream, addr)| {
     debug!("accept success {}", addr);
     let mut table = lock_resource_table();
-    let rid = table.add(Box::new(TcpStream(stream)));
+    let rid = table.add("tcpStream", Box::new(TcpStream(stream)));
     Ok(rid as i32)
   });
   Box::new(fut)
@@ -239,7 +231,7 @@ fn op_listen(
   let addr = "127.0.0.1:4544".parse::<SocketAddr>().unwrap();
   let listener = tokio::net::TcpListener::bind(&addr).unwrap();
   let mut table = lock_resource_table();
-  let rid = table.add(Box::new(TcpListener(listener)));
+  let rid = table.add("tcpListener", Box::new(TcpListener(listener)));
   Box::new(futures::future::ok(rid as i32))
 }
 


### PR DESCRIPTION
Towards simplifying (or better removing entirely) the CoreResource
trait. Resources should be any bit of privileged heap allocated memory
that needs to be referenced from JS, not very specific trait
implementations. Therefore CoreResource should be pushed towards being
as general as possible.
cc @bartlomieju 
note: less code