### PR TITLE
HTTP Server API with `{ port: number }` and `server.url` object (URL)

### DIFF
--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -305,7 +305,7 @@ export class Server implements AsyncIterable<ServerRequest> {
   private closing = false;
   url: string;
 
-  constructor(public listener: Listener, options: ServerOptions) {
+  constructor(public listener: Listener, options: ServerOptions = { port: 0 }) {
     this.url = `${options.protocol || "http"}://${options.hostname ||
       "localhost"}:${options.port}/`;
   }

--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -303,11 +303,13 @@ export async function readRequest(
 
 export class Server implements AsyncIterable<ServerRequest> {
   private closing = false;
-  url: string;
+  url: URL;
 
   constructor(public listener: Listener, options: ServerOptions = { port: 0 }) {
-    this.url = `${options.protocol || "http"}://${options.hostname ||
-      "localhost"}:${options.port}/`;
+    this.url = new URL(
+      `${options.protocol || "http"}://${options.hostname ||
+        "localhost"}:${options.port || 0}/`
+    );
   }
 
   close(): void {

--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -383,18 +383,26 @@ export class Server implements AsyncIterable<ServerRequest> {
   }
 }
 
-export function serve(addr: string): Server {
-  // TODO(ry) Update serve to also take { hostname, port }.
-  const [hostname, port] = addr.split(":");
-  const listener = listen({ hostname, port: Number(port) });
+export type ServeOptions = string | Deno.ListenOptions;
+
+function serveOptions(options: ServeOptions): Deno.ListenOptions {
+  if (typeof options === "string") {
+    const [hostname, port] = options.split(":");
+    return { hostname, port: Number(port) };
+  }
+  return options;
+}
+
+export function serve(options: ServeOptions): Server {
+  const listener = listen(serveOptions(options));
   return new Server(listener);
 }
 
 export async function listenAndServe(
-  addr: string,
+  options: ServeOptions,
   handler: (req: ServerRequest) => void
 ): Promise<void> {
-  const server = serve(addr);
+  const server = serve(options);
 
   for await (const request of server) {
     handler(request);


### PR DESCRIPTION
Implements #3228 but using URL objects instead of strings, to make this work:

```ts
import { serve } from "https://deno.land/std/http/server.ts";
const body = new TextEncoder().encode("Hello World\n");
const s = serve({ port: 8000 }); // or serve(':8000');
console.log(s.url.href); // s.url is a URL object
for await (const req of s) {
  req.respond({ body });
}
```

(This is the same as PR #3278 but uses `URL` objects instead of strings)