### PR TITLE
refactor: move Child resource to ops/process.rs

### DIFF
--- a/core/resources.rs
+++ b/core/resources.rs
@@ -21,9 +21,7 @@ type ResourceMap = HashMap<ResourceId, (String, Box<dyn Resource>)>;
 
 #[derive(Default)]
 pub struct ResourceTable {
-  // TODO(bartlomieju): remove pub modifier, it is used by
-  // `get_file` method in CLI
-  pub map: ResourceMap,
+  map: ResourceMap,
   next_id: u32,
 }
 


### PR DESCRIPTION
This PR
- removes `resources::get_file` function which was ultra hacky 
- removes `pub` modifier from `ResourceTable.map` field 
- removes `CliResource::Child` and implements `ChildResource` structure inside `ops/process.rs`
