### PR TITLE
Display symbol props of objects in console

### DIFF
--- a/cli/js/console.ts
+++ b/cli/js/console.ts
@@ -274,7 +274,7 @@ function createNumberWrapperString(value: Number): string {
 // TODO: Proxy
 
 function createRawObjectString(
-  value: { [key: string]: unknown },
+  value: object,
   ctx: ConsoleContext,
   level: number,
   maxLevel: number
@@ -291,13 +291,14 @@ function createRawObjectString(
   if (className && className !== "Object" && className !== "anonymous") {
     shouldShowClassName = true;
   }
-  const keys = Object.keys(value);
+  const keys = [ ...Object.keys(value), ...Object.getOwnPropertySymbols(value) ];
   const entries: string[] = keys.map(
     (key): string => {
+      const stringKey = String(key)
       if (keys.length > OBJ_ABBREVIATE_SIZE) {
-        return key;
+        return stringKey;
       } else {
-        return `${key}: ${stringifyWithQuotes(
+        return `${stringKey}: ${stringifyWithQuotes(
           value[key],
           ctx,
           level + 1,

--- a/cli/js/console.ts
+++ b/cli/js/console.ts
@@ -292,19 +292,21 @@ function createRawObjectString(
     shouldShowClassName = true;
   }
   const keys = [...Object.keys(value), ...Object.getOwnPropertySymbols(value)];
-  const entries: string[] = keys.map((key): string => {
-    const stringKey = String(key);
-    if (keys.length > OBJ_ABBREVIATE_SIZE) {
-      return stringKey;
-    } else {
-      return `${stringKey}: ${stringifyWithQuotes(
-        value[key],
-        ctx,
-        level + 1,
-        maxLevel
-      )}`;
+  const entries: string[] = keys.map(
+    (key): string => {
+      const stringKey = String(key);
+      if (keys.length > OBJ_ABBREVIATE_SIZE) {
+        return stringKey;
+      } else {
+        return `${stringKey}: ${stringifyWithQuotes(
+          value[key],
+          ctx,
+          level + 1,
+          maxLevel
+        )}`;
+      }
     }
-  });
+  );
 
   ctx.delete(value);
 
@@ -639,39 +641,43 @@ export class Console {
       let idx = 0;
       resultData = {};
 
-      data.forEach((v: unknown, k: unknown): void => {
-        resultData[idx] = { Key: k, Values: v };
-        idx++;
-      });
+      data.forEach(
+        (v: unknown, k: unknown): void => {
+          resultData[idx] = { Key: k, Values: v };
+          idx++;
+        }
+      );
     } else {
       resultData = data!;
     }
 
-    Object.keys(resultData).forEach((k, idx): void => {
-      const value: unknown = resultData[k]!;
+    Object.keys(resultData).forEach(
+      (k, idx): void => {
+        const value: unknown = resultData[k]!;
 
-      if (value !== null && typeof value === "object") {
-        Object.entries(value as { [key: string]: unknown }).forEach(
-          ([k, v]): void => {
-            if (properties && !properties.includes(k)) {
-              return;
+        if (value !== null && typeof value === "object") {
+          Object.entries(value as { [key: string]: unknown }).forEach(
+            ([k, v]): void => {
+              if (properties && !properties.includes(k)) {
+                return;
+              }
+
+              if (objectValues[k]) {
+                objectValues[k].push(stringifyValue(v));
+              } else {
+                objectValues[k] = createColumn(v, idx);
+              }
             }
+          );
 
-            if (objectValues[k]) {
-              objectValues[k].push(stringifyValue(v));
-            } else {
-              objectValues[k] = createColumn(v, idx);
-            }
-          }
-        );
+          values.push("");
+        } else {
+          values.push(stringifyValue(value));
+        }
 
-        values.push("");
-      } else {
-        values.push(stringifyValue(value));
+        indexKeys.push(k);
       }
-
-      indexKeys.push(k);
-    });
+    );
 
     const headerKeys = Object.keys(objectValues);
     const bodyValues = Object.values(objectValues);

--- a/cli/js/console.ts
+++ b/cli/js/console.ts
@@ -291,22 +291,20 @@ function createRawObjectString(
   if (className && className !== "Object" && className !== "anonymous") {
     shouldShowClassName = true;
   }
-  const keys = [ ...Object.keys(value), ...Object.getOwnPropertySymbols(value) ];
-  const entries: string[] = keys.map(
-    (key): string => {
-      const stringKey = String(key)
-      if (keys.length > OBJ_ABBREVIATE_SIZE) {
-        return stringKey;
-      } else {
-        return `${stringKey}: ${stringifyWithQuotes(
-          value[key],
-          ctx,
-          level + 1,
-          maxLevel
-        )}`;
-      }
+  const keys = [...Object.keys(value), ...Object.getOwnPropertySymbols(value)];
+  const entries: string[] = keys.map((key): string => {
+    const stringKey = String(key);
+    if (keys.length > OBJ_ABBREVIATE_SIZE) {
+      return stringKey;
+    } else {
+      return `${stringKey}: ${stringifyWithQuotes(
+        value[key],
+        ctx,
+        level + 1,
+        maxLevel
+      )}`;
     }
-  );
+  });
 
   ctx.delete(value);
 
@@ -641,43 +639,39 @@ export class Console {
       let idx = 0;
       resultData = {};
 
-      data.forEach(
-        (v: unknown, k: unknown): void => {
-          resultData[idx] = { Key: k, Values: v };
-          idx++;
-        }
-      );
+      data.forEach((v: unknown, k: unknown): void => {
+        resultData[idx] = { Key: k, Values: v };
+        idx++;
+      });
     } else {
       resultData = data!;
     }
 
-    Object.keys(resultData).forEach(
-      (k, idx): void => {
-        const value: unknown = resultData[k]!;
+    Object.keys(resultData).forEach((k, idx): void => {
+      const value: unknown = resultData[k]!;
 
-        if (value !== null && typeof value === "object") {
-          Object.entries(value as { [key: string]: unknown }).forEach(
-            ([k, v]): void => {
-              if (properties && !properties.includes(k)) {
-                return;
-              }
-
-              if (objectValues[k]) {
-                objectValues[k].push(stringifyValue(v));
-              } else {
-                objectValues[k] = createColumn(v, idx);
-              }
+      if (value !== null && typeof value === "object") {
+        Object.entries(value as { [key: string]: unknown }).forEach(
+          ([k, v]): void => {
+            if (properties && !properties.includes(k)) {
+              return;
             }
-          );
 
-          values.push("");
-        } else {
-          values.push(stringifyValue(value));
-        }
+            if (objectValues[k]) {
+              objectValues[k].push(stringifyValue(v));
+            } else {
+              objectValues[k] = createColumn(v, idx);
+            }
+          }
+        );
 
-        indexKeys.push(k);
+        values.push("");
+      } else {
+        values.push(stringifyValue(value));
       }
-    );
+
+      indexKeys.push(k);
+    });
 
     const headerKeys = Object.keys(objectValues);
     const bodyValues = Object.values(objectValues);

--- a/cli/js/console.ts
+++ b/cli/js/console.ts
@@ -294,6 +294,8 @@ function createRawObjectString(
   const keys = [...Object.keys(value), ...Object.getOwnPropertySymbols(value)];
   const entries: string[] = keys.map(
     (key): string => {
+      if (key === customInspect) return;
+
       const stringKey = String(key);
       if (keys.length > OBJ_ABBREVIATE_SIZE) {
         return stringKey;

--- a/cli/js/console_test.ts
+++ b/cli/js/console_test.ts
@@ -105,7 +105,7 @@ test(function consoleTestStringifyCircular(): void {
   };
 
   nestedObj.o = circularObj;
-  const nestedObjExpected = `{ num, bool, str, method, asyncMethod, generatorMethod, un, nu, arrowFunc, extendedClass, nFunc, extendedCstr, Symbol('test'), o }`;
+  const nestedObjExpected = `{ num, bool, str, method, asyncMethod, generatorMethod, un, nu, arrowFunc, extendedClass, nFunc, extendedCstr, o, Symbol('test') }`;
 
   assertEquals(stringify(1), "1");
   assertEquals(stringify(-0), "-0");

--- a/cli/js/console_test.ts
+++ b/cli/js/console_test.ts
@@ -411,47 +411,50 @@ function mockConsole(f: ConsoleExamineFunc): void {
 
 // console.group test
 test(function consoleGroup(): void {
-  mockConsole((console, out): void => {
-    console.group("1");
-    console.log("2");
-    console.group("3");
-    console.log("4");
-    console.groupEnd();
-    console.groupEnd();
-    console.log("5");
-    console.log("6");
+  mockConsole(
+    (console, out): void => {
+      console.group("1");
+      console.log("2");
+      console.group("3");
+      console.log("4");
+      console.groupEnd();
+      console.groupEnd();
+      console.log("5");
+      console.log("6");
 
-    assertEquals(
-      out.toString(),
-      `1
+      assertEquals(
+        out.toString(),
+        `1
   2
   3
     4
 5
 6
 `
-    );
-  });
+      );
+    }
+  );
 });
 
 // console.group with console.warn test
 test(function consoleGroupWarn(): void {
-  mockConsole((console, _out, _err, both): void => {
-    console.warn("1");
-    console.group();
-    console.warn("2");
-    console.group();
-    console.warn("3");
-    console.groupEnd();
-    console.warn("4");
-    console.groupEnd();
-    console.warn("5");
+  mockConsole(
+    (console, _out, _err, both): void => {
+      console.warn("1");
+      console.group();
+      console.warn("2");
+      console.group();
+      console.warn("3");
+      console.groupEnd();
+      console.warn("4");
+      console.groupEnd();
+      console.warn("5");
 
-    console.warn("6");
-    console.warn("7");
-    assertEquals(
-      both.toString(),
-      `1
+      console.warn("6");
+      console.warn("7");
+      assertEquals(
+        both.toString(),
+        `1
   2
     3
   4
@@ -459,43 +462,49 @@ test(function consoleGroupWarn(): void {
 6
 7
 `
-    );
-  });
+      );
+    }
+  );
 });
 
 // console.table test
 test(function consoleTable(): void {
-  mockConsole((console, out): void => {
-    console.table({ a: "test", b: 1 });
-    assertEquals(
-      out.toString(),
-      `┌─────────┬────────┐
+  mockConsole(
+    (console, out): void => {
+      console.table({ a: "test", b: 1 });
+      assertEquals(
+        out.toString(),
+        `┌─────────┬────────┐
 │ (index) │ Values │
 ├─────────┼────────┤
 │    a    │ "test" │
 │    b    │   1    │
 └─────────┴────────┘
 `
-    );
-  });
-  mockConsole((console, out): void => {
-    console.table({ a: { b: 10 }, b: { b: 20, c: 30 } }, ["c"]);
-    assertEquals(
-      out.toString(),
-      `┌─────────┬────┐
+      );
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.table({ a: { b: 10 }, b: { b: 20, c: 30 } }, ["c"]);
+      assertEquals(
+        out.toString(),
+        `┌─────────┬────┐
 │ (index) │ c  │
 ├─────────┼────┤
 │    a    │    │
 │    b    │ 30 │
 └─────────┴────┘
 `
-    );
-  });
-  mockConsole((console, out): void => {
-    console.table([1, 2, [3, [4]], [5, 6], [[7], [8]]]);
-    assertEquals(
-      out.toString(),
-      `┌─────────┬───────┬───────┬────────┐
+      );
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.table([1, 2, [3, [4]], [5, 6], [[7], [8]]]);
+      assertEquals(
+        out.toString(),
+        `┌─────────┬───────┬───────┬────────┐
 │ (index) │   0   │   1   │ Values │
 ├─────────┼───────┼───────┼────────┤
 │    0    │       │       │   1    │
@@ -505,13 +514,15 @@ test(function consoleTable(): void {
 │    4    │ [ 7 ] │ [ 8 ] │        │
 └─────────┴───────┴───────┴────────┘
 `
-    );
-  });
-  mockConsole((console, out): void => {
-    console.table(new Set([1, 2, 3, "test"]));
-    assertEquals(
-      out.toString(),
-      `┌───────────────────┬────────┐
+      );
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.table(new Set([1, 2, 3, "test"]));
+      assertEquals(
+        out.toString(),
+        `┌───────────────────┬────────┐
 │ (iteration index) │ Values │
 ├───────────────────┼────────┤
 │         0         │   1    │
@@ -520,32 +531,36 @@ test(function consoleTable(): void {
 │         3         │ "test" │
 └───────────────────┴────────┘
 `
-    );
-  });
-  mockConsole((console, out): void => {
-    console.table(new Map([[1, "one"], [2, "two"]]));
-    assertEquals(
-      out.toString(),
-      `┌───────────────────┬─────┬────────┐
+      );
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.table(new Map([[1, "one"], [2, "two"]]));
+      assertEquals(
+        out.toString(),
+        `┌───────────────────┬─────┬────────┐
 │ (iteration index) │ Key │ Values │
 ├───────────────────┼─────┼────────┤
 │         0         │  1  │ "one"  │
 │         1         │  2  │ "two"  │
 └───────────────────┴─────┴────────┘
 `
-    );
-  });
-  mockConsole((console, out): void => {
-    console.table({
-      a: true,
-      b: { c: { d: 10 }, e: [1, 2, [5, 6]] },
-      f: "test",
-      g: new Set([1, 2, 3, "test"]),
-      h: new Map([[1, "one"]])
-    });
-    assertEquals(
-      out.toString(),
-      `┌─────────┬───────────┬───────────────────┬────────┐
+      );
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.table({
+        a: true,
+        b: { c: { d: 10 }, e: [1, 2, [5, 6]] },
+        f: "test",
+        g: new Set([1, 2, 3, "test"]),
+        h: new Map([[1, "one"]])
+      });
+      assertEquals(
+        out.toString(),
+        `┌─────────┬───────────┬───────────────────┬────────┐
 │ (index) │     c     │         e         │ Values │
 ├─────────┼───────────┼───────────────────┼────────┤
 │    a    │           │                   │  true  │
@@ -555,19 +570,21 @@ test(function consoleTable(): void {
 │    h    │           │                   │        │
 └─────────┴───────────┴───────────────────┴────────┘
 `
-    );
-  });
-  mockConsole((console, out): void => {
-    console.table([
-      1,
-      "test",
-      false,
-      { a: 10 },
-      ["test", { b: 20, c: "test" }]
-    ]);
-    assertEquals(
-      out.toString(),
-      `┌─────────┬────────┬──────────────────────┬────┬────────┐
+      );
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.table([
+        1,
+        "test",
+        false,
+        { a: 10 },
+        ["test", { b: 20, c: "test" }]
+      ]);
+      assertEquals(
+        out.toString(),
+        `┌─────────┬────────┬──────────────────────┬────┬────────┐
 │ (index) │   0    │          1           │ a  │ Values │
 ├─────────┼────────┼──────────────────────┼────┼────────┤
 │    0    │        │                      │    │   1    │
@@ -577,56 +594,67 @@ test(function consoleTable(): void {
 │    4    │ "test" │ { b: 20, c: "test" } │    │        │
 └─────────┴────────┴──────────────────────┴────┴────────┘
 `
-    );
-  });
-  mockConsole((console, out): void => {
-    console.table([]);
-    assertEquals(
-      out.toString(),
-      `┌─────────┐
+      );
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.table([]);
+      assertEquals(
+        out.toString(),
+        `┌─────────┐
 │ (index) │
 ├─────────┤
 └─────────┘
 `
-    );
-  });
-  mockConsole((console, out): void => {
-    console.table({});
-    assertEquals(
-      out.toString(),
-      `┌─────────┐
+      );
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.table({});
+      assertEquals(
+        out.toString(),
+        `┌─────────┐
 │ (index) │
 ├─────────┤
 └─────────┘
 `
-    );
-  });
-  mockConsole((console, out): void => {
-    console.table(new Set());
-    assertEquals(
-      out.toString(),
-      `┌───────────────────┐
+      );
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.table(new Set());
+      assertEquals(
+        out.toString(),
+        `┌───────────────────┐
 │ (iteration index) │
 ├───────────────────┤
 └───────────────────┘
 `
-    );
-  });
-  mockConsole((console, out): void => {
-    console.table(new Map());
-    assertEquals(
-      out.toString(),
-      `┌───────────────────┐
+      );
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.table(new Map());
+      assertEquals(
+        out.toString(),
+        `┌───────────────────┐
 │ (iteration index) │
 ├───────────────────┤
 └───────────────────┘
 `
-    );
-  });
-  mockConsole((console, out): void => {
-    console.table("test");
-    assertEquals(out.toString(), "test\n");
-  });
+      );
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.table("test");
+      assertEquals(out.toString(), "test\n");
+    }
+  );
 });
 
 // console.log(Error) test
@@ -641,40 +669,52 @@ test(function consoleLogShouldNotThrowError(): void {
   assertEquals(result, 1);
 
   // output errors to the console should not include "Uncaught"
-  mockConsole((console, out): void => {
-    console.log(new Error("foo"));
-    assertEquals(out.toString().includes("Uncaught"), false);
-  });
+  mockConsole(
+    (console, out): void => {
+      console.log(new Error("foo"));
+      assertEquals(out.toString().includes("Uncaught"), false);
+    }
+  );
 });
 
 // console.dir test
 test(function consoleDir(): void {
-  mockConsole((console, out): void => {
-    console.dir("DIR");
-    assertEquals(out.toString(), "DIR\n");
-  });
-  mockConsole((console, out): void => {
-    console.dir("DIR", { indentLevel: 2 });
-    assertEquals(out.toString(), "  DIR\n");
-  });
+  mockConsole(
+    (console, out): void => {
+      console.dir("DIR");
+      assertEquals(out.toString(), "DIR\n");
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.dir("DIR", { indentLevel: 2 });
+      assertEquals(out.toString(), "  DIR\n");
+    }
+  );
 });
 
 // console.dir test
 test(function consoleDirXml(): void {
-  mockConsole((console, out): void => {
-    console.dirxml("DIRXML");
-    assertEquals(out.toString(), "DIRXML\n");
-  });
-  mockConsole((console, out): void => {
-    console.dirxml("DIRXML", { indentLevel: 2 });
-    assertEquals(out.toString(), "  DIRXML\n");
-  });
+  mockConsole(
+    (console, out): void => {
+      console.dirxml("DIRXML");
+      assertEquals(out.toString(), "DIRXML\n");
+    }
+  );
+  mockConsole(
+    (console, out): void => {
+      console.dirxml("DIRXML", { indentLevel: 2 });
+      assertEquals(out.toString(), "  DIRXML\n");
+    }
+  );
 });
 
 // console.trace test
 test(function consoleTrace(): void {
-  mockConsole((console, _out, err): void => {
-    console.trace("%s", "custom message");
-    assert(err.toString().includes("Trace: custom message"));
-  });
+  mockConsole(
+    (console, _out, err): void => {
+      console.trace("%s", "custom message");
+      assert(err.toString().includes("Trace: custom message"));
+    }
+  );
 });

--- a/cli/js/console_test.ts
+++ b/cli/js/console_test.ts
@@ -87,7 +87,8 @@ test(function consoleTestStringifyCircular(): void {
     arrowFunc: () => {},
     extendedClass: new Extended(),
     nFunc: new Function(),
-    extendedCstr: Extended
+    extendedCstr: Extended,
+    [Symbol('test')]: 'test'
   };
 
   const circularObj = {
@@ -104,7 +105,7 @@ test(function consoleTestStringifyCircular(): void {
   };
 
   nestedObj.o = circularObj;
-  const nestedObjExpected = `{ num, bool, str, method, asyncMethod, generatorMethod, un, nu, arrowFunc, extendedClass, nFunc, extendedCstr, o }`;
+  const nestedObjExpected = `{ num, bool, str, method, asyncMethod, generatorMethod, un, nu, arrowFunc, extendedClass, nFunc, extendedCstr, Symbol('test'), o }`;
 
   assertEquals(stringify(1), "1");
   assertEquals(stringify(-0), "-0");

--- a/cli/js/console_test.ts
+++ b/cli/js/console_test.ts
@@ -88,7 +88,7 @@ test(function consoleTestStringifyCircular(): void {
     extendedClass: new Extended(),
     nFunc: new Function(),
     extendedCstr: Extended,
-    [Symbol('test')]: 'test'
+    [Symbol("test")]: "test"
   };
 
   const circularObj = {
@@ -411,50 +411,47 @@ function mockConsole(f: ConsoleExamineFunc): void {
 
 // console.group test
 test(function consoleGroup(): void {
-  mockConsole(
-    (console, out): void => {
-      console.group("1");
-      console.log("2");
-      console.group("3");
-      console.log("4");
-      console.groupEnd();
-      console.groupEnd();
-      console.log("5");
-      console.log("6");
+  mockConsole((console, out): void => {
+    console.group("1");
+    console.log("2");
+    console.group("3");
+    console.log("4");
+    console.groupEnd();
+    console.groupEnd();
+    console.log("5");
+    console.log("6");
 
-      assertEquals(
-        out.toString(),
-        `1
+    assertEquals(
+      out.toString(),
+      `1
   2
   3
     4
 5
 6
 `
-      );
-    }
-  );
+    );
+  });
 });
 
 // console.group with console.warn test
 test(function consoleGroupWarn(): void {
-  mockConsole(
-    (console, _out, _err, both): void => {
-      console.warn("1");
-      console.group();
-      console.warn("2");
-      console.group();
-      console.warn("3");
-      console.groupEnd();
-      console.warn("4");
-      console.groupEnd();
-      console.warn("5");
+  mockConsole((console, _out, _err, both): void => {
+    console.warn("1");
+    console.group();
+    console.warn("2");
+    console.group();
+    console.warn("3");
+    console.groupEnd();
+    console.warn("4");
+    console.groupEnd();
+    console.warn("5");
 
-      console.warn("6");
-      console.warn("7");
-      assertEquals(
-        both.toString(),
-        `1
+    console.warn("6");
+    console.warn("7");
+    assertEquals(
+      both.toString(),
+      `1
   2
     3
   4
@@ -462,49 +459,43 @@ test(function consoleGroupWarn(): void {
 6
 7
 `
-      );
-    }
-  );
+    );
+  });
 });
 
 // console.table test
 test(function consoleTable(): void {
-  mockConsole(
-    (console, out): void => {
-      console.table({ a: "test", b: 1 });
-      assertEquals(
-        out.toString(),
-        `┌─────────┬────────┐
+  mockConsole((console, out): void => {
+    console.table({ a: "test", b: 1 });
+    assertEquals(
+      out.toString(),
+      `┌─────────┬────────┐
 │ (index) │ Values │
 ├─────────┼────────┤
 │    a    │ "test" │
 │    b    │   1    │
 └─────────┴────────┘
 `
-      );
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.table({ a: { b: 10 }, b: { b: 20, c: 30 } }, ["c"]);
-      assertEquals(
-        out.toString(),
-        `┌─────────┬────┐
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table({ a: { b: 10 }, b: { b: 20, c: 30 } }, ["c"]);
+    assertEquals(
+      out.toString(),
+      `┌─────────┬────┐
 │ (index) │ c  │
 ├─────────┼────┤
 │    a    │    │
 │    b    │ 30 │
 └─────────┴────┘
 `
-      );
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.table([1, 2, [3, [4]], [5, 6], [[7], [8]]]);
-      assertEquals(
-        out.toString(),
-        `┌─────────┬───────┬───────┬────────┐
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table([1, 2, [3, [4]], [5, 6], [[7], [8]]]);
+    assertEquals(
+      out.toString(),
+      `┌─────────┬───────┬───────┬────────┐
 │ (index) │   0   │   1   │ Values │
 ├─────────┼───────┼───────┼────────┤
 │    0    │       │       │   1    │
@@ -514,15 +505,13 @@ test(function consoleTable(): void {
 │    4    │ [ 7 ] │ [ 8 ] │        │
 └─────────┴───────┴───────┴────────┘
 `
-      );
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.table(new Set([1, 2, 3, "test"]));
-      assertEquals(
-        out.toString(),
-        `┌───────────────────┬────────┐
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table(new Set([1, 2, 3, "test"]));
+    assertEquals(
+      out.toString(),
+      `┌───────────────────┬────────┐
 │ (iteration index) │ Values │
 ├───────────────────┼────────┤
 │         0         │   1    │
@@ -531,36 +520,32 @@ test(function consoleTable(): void {
 │         3         │ "test" │
 └───────────────────┴────────┘
 `
-      );
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.table(new Map([[1, "one"], [2, "two"]]));
-      assertEquals(
-        out.toString(),
-        `┌───────────────────┬─────┬────────┐
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table(new Map([[1, "one"], [2, "two"]]));
+    assertEquals(
+      out.toString(),
+      `┌───────────────────┬─────┬────────┐
 │ (iteration index) │ Key │ Values │
 ├───────────────────┼─────┼────────┤
 │         0         │  1  │ "one"  │
 │         1         │  2  │ "two"  │
 └───────────────────┴─────┴────────┘
 `
-      );
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.table({
-        a: true,
-        b: { c: { d: 10 }, e: [1, 2, [5, 6]] },
-        f: "test",
-        g: new Set([1, 2, 3, "test"]),
-        h: new Map([[1, "one"]])
-      });
-      assertEquals(
-        out.toString(),
-        `┌─────────┬───────────┬───────────────────┬────────┐
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table({
+      a: true,
+      b: { c: { d: 10 }, e: [1, 2, [5, 6]] },
+      f: "test",
+      g: new Set([1, 2, 3, "test"]),
+      h: new Map([[1, "one"]])
+    });
+    assertEquals(
+      out.toString(),
+      `┌─────────┬───────────┬───────────────────┬────────┐
 │ (index) │     c     │         e         │ Values │
 ├─────────┼───────────┼───────────────────┼────────┤
 │    a    │           │                   │  true  │
@@ -570,21 +555,19 @@ test(function consoleTable(): void {
 │    h    │           │                   │        │
 └─────────┴───────────┴───────────────────┴────────┘
 `
-      );
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.table([
-        1,
-        "test",
-        false,
-        { a: 10 },
-        ["test", { b: 20, c: "test" }]
-      ]);
-      assertEquals(
-        out.toString(),
-        `┌─────────┬────────┬──────────────────────┬────┬────────┐
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table([
+      1,
+      "test",
+      false,
+      { a: 10 },
+      ["test", { b: 20, c: "test" }]
+    ]);
+    assertEquals(
+      out.toString(),
+      `┌─────────┬────────┬──────────────────────┬────┬────────┐
 │ (index) │   0    │          1           │ a  │ Values │
 ├─────────┼────────┼──────────────────────┼────┼────────┤
 │    0    │        │                      │    │   1    │
@@ -594,67 +577,56 @@ test(function consoleTable(): void {
 │    4    │ "test" │ { b: 20, c: "test" } │    │        │
 └─────────┴────────┴──────────────────────┴────┴────────┘
 `
-      );
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.table([]);
-      assertEquals(
-        out.toString(),
-        `┌─────────┐
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table([]);
+    assertEquals(
+      out.toString(),
+      `┌─────────┐
 │ (index) │
 ├─────────┤
 └─────────┘
 `
-      );
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.table({});
-      assertEquals(
-        out.toString(),
-        `┌─────────┐
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table({});
+    assertEquals(
+      out.toString(),
+      `┌─────────┐
 │ (index) │
 ├─────────┤
 └─────────┘
 `
-      );
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.table(new Set());
-      assertEquals(
-        out.toString(),
-        `┌───────────────────┐
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table(new Set());
+    assertEquals(
+      out.toString(),
+      `┌───────────────────┐
 │ (iteration index) │
 ├───────────────────┤
 └───────────────────┘
 `
-      );
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.table(new Map());
-      assertEquals(
-        out.toString(),
-        `┌───────────────────┐
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table(new Map());
+    assertEquals(
+      out.toString(),
+      `┌───────────────────┐
 │ (iteration index) │
 ├───────────────────┤
 └───────────────────┘
 `
-      );
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.table("test");
-      assertEquals(out.toString(), "test\n");
-    }
-  );
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table("test");
+    assertEquals(out.toString(), "test\n");
+  });
 });
 
 // console.log(Error) test
@@ -669,52 +641,40 @@ test(function consoleLogShouldNotThrowError(): void {
   assertEquals(result, 1);
 
   // output errors to the console should not include "Uncaught"
-  mockConsole(
-    (console, out): void => {
-      console.log(new Error("foo"));
-      assertEquals(out.toString().includes("Uncaught"), false);
-    }
-  );
+  mockConsole((console, out): void => {
+    console.log(new Error("foo"));
+    assertEquals(out.toString().includes("Uncaught"), false);
+  });
 });
 
 // console.dir test
 test(function consoleDir(): void {
-  mockConsole(
-    (console, out): void => {
-      console.dir("DIR");
-      assertEquals(out.toString(), "DIR\n");
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.dir("DIR", { indentLevel: 2 });
-      assertEquals(out.toString(), "  DIR\n");
-    }
-  );
+  mockConsole((console, out): void => {
+    console.dir("DIR");
+    assertEquals(out.toString(), "DIR\n");
+  });
+  mockConsole((console, out): void => {
+    console.dir("DIR", { indentLevel: 2 });
+    assertEquals(out.toString(), "  DIR\n");
+  });
 });
 
 // console.dir test
 test(function consoleDirXml(): void {
-  mockConsole(
-    (console, out): void => {
-      console.dirxml("DIRXML");
-      assertEquals(out.toString(), "DIRXML\n");
-    }
-  );
-  mockConsole(
-    (console, out): void => {
-      console.dirxml("DIRXML", { indentLevel: 2 });
-      assertEquals(out.toString(), "  DIRXML\n");
-    }
-  );
+  mockConsole((console, out): void => {
+    console.dirxml("DIRXML");
+    assertEquals(out.toString(), "DIRXML\n");
+  });
+  mockConsole((console, out): void => {
+    console.dirxml("DIRXML", { indentLevel: 2 });
+    assertEquals(out.toString(), "  DIRXML\n");
+  });
 });
 
 // console.trace test
 test(function consoleTrace(): void {
-  mockConsole(
-    (console, _out, err): void => {
-      console.trace("%s", "custom message");
-      assert(err.toString().includes("Trace: custom message"));
-    }
-  );
+  mockConsole((console, _out, err): void => {
+    console.trace("%s", "custom message");
+    assert(err.toString().includes("Trace: custom message"));
+  });
 });


### PR DESCRIPTION
<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
Example of test object: `{ [Symbol.iterator]: 'a', a: 'a', 1: 'a' }`
Fixes #3253 