### PR TITLE
fmt: allow configuration of Prettier options

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -343,68 +343,68 @@ Automatically downloads Prettier dependencies on first run.
             .takes_value(false),
         )
         .arg(
-          Arg::with_name("prettier-print-width")
-            .long("prettier-print-width")
+          Arg::with_name("fmt-print-width")
+            .long("fmt-print-width")
             .help("Specify the line length that the printer will wrap on.")
             .takes_value(true)
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("prettier-tab-width")
-            .long("prettier-tab-width")
+          Arg::with_name("fmt-tab-width")
+            .long("fmt-tab-width")
             .help("Specify the number of spaces per indentation-level.")
             .takes_value(true)
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("prettier-use-tabs")
-            .long("prettier-use-tabs")
+          Arg::with_name("fmt-use-tabs")
+            .long("fmt-use-tabs")
             .help("Indent lines with tabs instead of spaces.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("prettier-no-semi")
-            .long("prettier-no-semi")
+          Arg::with_name("fmt-no-semi")
+            .long("fmt-no-semi")
             .help("Print semicolons at the ends of statements.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("prettier-single-quote")
-            .long("prettier-single-quote")
+          Arg::with_name("fmt-single-quote")
+            .long("fmt-single-quote")
             .help("Use single quotes instead of double quotes.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("prettier-trailing-comma")
-            .long("prettier-trailing-comma")
+          Arg::with_name("fmt-trailing-comma")
+            .long("fmt-trailing-comma")
             .help("Print trailing commas wherever possible when multi-line.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("prettier-no-bracket-spacing")
-            .long("prettier-no-bracket-spacing")
+          Arg::with_name("fmt-no-bracket-spacing")
+            .long("fmt-no-bracket-spacing")
             .help("Print spaces between brackets in object literals.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("prettier-arrow-parens")
-            .long("prettier-arrow-parens")
+          Arg::with_name("fmt-arrow-parens")
+            .long("fmt-arrow-parens")
             .help("Include parentheses around a sole arrow function parameter.")
             .takes_value(true)
             .possible_values(&["avoid", "always"])
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("prettier-prose-wrap")
-            .long("prettier-prose-wrap")
+          Arg::with_name("fmt-prose-wrap")
+            .long("fmt-prose-wrap")
             .help("How to wrap prose.")
             .takes_value(true)
             .possible_values(&["always", "never", "preserve"])
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("prettier-end-of-line")
-            .long("prettier-end-of-line")
+          Arg::with_name("fmt-end-of-line")
+            .long("fmt-end-of-line")
             .help("Which end of line characters to apply.")
             .takes_value(true)
             .possible_values(&["auto", "lf", "crlf", "cr"])
@@ -972,7 +972,7 @@ pub fn flags_from_vec(
       for opt in &prettier_flags {
         let t = opt[0];
         let keyword = opt[1];
-        let flg = format!("prettier-{}", keyword);
+        let flg = format!("fmt-{}", keyword);
 
         if fmt_match.is_present(&flg) {
           if t == "0" {
@@ -2032,11 +2032,13 @@ mod tests {
     let (flags, subcommand, argv) = flags_from_vec(svec![
       "deno",
       "fmt",
-      "--prettier-print-width=100",
-      "--prettier-tab-width=4",
-      "--prettier-use-tabs",
-      "--prettier-no-semi",
-      "--prettier-arrow-parens=always",
+      "--fmt-print-width=100",
+      "--fmt-tab-width=4",
+      "--fmt-use-tabs",
+      "--fmt-no-semi",
+      "--fmt-arrow-parens=always",
+      "--fmt-prose-wrap=preserve",
+      "--fmt-end-of-line=crlf",
       "script.ts"
     ]);
     assert_eq!(
@@ -2062,7 +2064,11 @@ mod tests {
         "--use-tabs",
         "--no-semi",
         "--arrow-parens",
-        "always"
+        "always",
+        "--prose-wrap",
+        "preserve",
+        "--end-of-line",
+        "crlf"
       ]
     );
   }

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -343,68 +343,68 @@ Automatically downloads Prettier dependencies on first run.
             .takes_value(false),
         )
         .arg(
-          Arg::with_name("fmt-print-width")
-            .long("fmt-print-width")
+          Arg::with_name("print-width")
+            .long("print-width")
             .help("Specify the line length that the printer will wrap on.")
             .takes_value(true)
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("fmt-tab-width")
-            .long("fmt-tab-width")
+          Arg::with_name("tab-width")
+            .long("tab-width")
             .help("Specify the number of spaces per indentation-level.")
             .takes_value(true)
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("fmt-use-tabs")
-            .long("fmt-use-tabs")
+          Arg::with_name("use-tabs")
+            .long("use-tabs")
             .help("Indent lines with tabs instead of spaces.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("fmt-no-semi")
-            .long("fmt-no-semi")
+          Arg::with_name("no-semi")
+            .long("no-semi")
             .help("Print semicolons at the ends of statements.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("fmt-single-quote")
-            .long("fmt-single-quote")
+          Arg::with_name("single-quote")
+            .long("single-quote")
             .help("Use single quotes instead of double quotes.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("fmt-trailing-comma")
-            .long("fmt-trailing-comma")
+          Arg::with_name("trailing-comma")
+            .long("trailing-comma")
             .help("Print trailing commas wherever possible when multi-line.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("fmt-no-bracket-spacing")
-            .long("fmt-no-bracket-spacing")
+          Arg::with_name("no-bracket-spacing")
+            .long("no-bracket-spacing")
             .help("Print spaces between brackets in object literals.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("fmt-arrow-parens")
-            .long("fmt-arrow-parens")
+          Arg::with_name("arrow-parens")
+            .long("arrow-parens")
             .help("Include parentheses around a sole arrow function parameter.")
             .takes_value(true)
             .possible_values(&["avoid", "always"])
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("fmt-prose-wrap")
-            .long("fmt-prose-wrap")
+          Arg::with_name("prose-wrap")
+            .long("prose-wrap")
             .help("How to wrap prose.")
             .takes_value(true)
             .possible_values(&["always", "never", "preserve"])
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("fmt-end-of-line")
-            .long("fmt-end-of-line")
+          Arg::with_name("end-of-line")
+            .long("end-of-line")
             .help("Which end of line characters to apply.")
             .takes_value(true)
             .possible_values(&["auto", "lf", "crlf", "cr"])
@@ -972,14 +972,13 @@ pub fn flags_from_vec(
       for opt in &prettier_flags {
         let t = opt[0];
         let keyword = opt[1];
-        let flg = format!("fmt-{}", keyword);
 
-        if fmt_match.is_present(&flg) {
+        if fmt_match.is_present(&keyword) {
           if t == "0" {
             argv.push(format!("--{}", keyword));
           } else {
             argv.push(format!("--{}", keyword));
-            argv.push(fmt_match.value_of(&flg).unwrap().to_string());
+            argv.push(fmt_match.value_of(keyword).unwrap().to_string());
           }
         }
       }
@@ -2032,13 +2031,13 @@ mod tests {
     let (flags, subcommand, argv) = flags_from_vec(svec![
       "deno",
       "fmt",
-      "--fmt-print-width=100",
-      "--fmt-tab-width=4",
-      "--fmt-use-tabs",
-      "--fmt-no-semi",
-      "--fmt-arrow-parens=always",
-      "--fmt-prose-wrap=preserve",
-      "--fmt-end-of-line=crlf",
+      "--print-width=100",
+      "--tab-width=4",
+      "--use-tabs",
+      "--no-semi",
+      "--arrow-parens=always",
+      "--prose-wrap=preserve",
+      "--end-of-line=crlf",
       "script.ts"
     ]);
     assert_eq!(

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -377,6 +377,33 @@ Automatically downloads Prettier dependencies on first run.
             .takes_value(false)
         )
         .arg(
+          Arg::with_name("quote-props")
+            .long("quote-props")
+            .value_name("as-needed|consistent|preserve")
+            .help("Change when properties in objects are quoted.")
+            .takes_value(true)
+            .possible_values(&["as-needed", "consistent", "preserve"])
+            .require_equals(true)
+        )
+        .arg(
+          Arg::with_name("jsx-single-quote")
+            .long("jsx-single-quote")
+            .help("Use single quotes instead of double quotes in JSX.")
+            .takes_value(false)
+        )
+        .arg(
+          Arg::with_name("jsx-bracket-same-line")
+            .long("jsx-bracket-same-line")
+            .help(
+              "Put the > of a multi-line JSX element at
+            the end of the last line instead of
+            being alone on the next line (does not
+            apply to self closing elements).
+            "
+            )
+            .takes_value(false)
+        )
+        .arg(
           Arg::with_name("trailing-comma")
             .long("trailing-comma")
             .help("Print trailing commas wherever possible when multi-line.")
@@ -967,6 +994,9 @@ pub fn flags_from_vec(
         ["0", "use-tabs"],
         ["0", "no-semi"],
         ["0", "single-quote"],
+        ["1", "quote-props"],
+        ["0", "jsx-single-quote"],
+        ["0", "jsx-bracket-same-line"],
         ["0", "trailing-comma"],
         ["0", "no-bracket-spacing"],
         ["1", "arrow-parens"],
@@ -2040,9 +2070,13 @@ mod tests {
       "--tab-width=4",
       "--use-tabs",
       "--no-semi",
+      "--single-quote",
       "--arrow-parens=always",
       "--prose-wrap=preserve",
       "--end-of-line=crlf",
+      "--quote-props=preserve",
+      "--jsx-single-quote",
+      "--jsx-bracket-same-line",
       "script.ts"
     ]);
     assert_eq!(
@@ -2067,6 +2101,11 @@ mod tests {
         "4",
         "--use-tabs",
         "--no-semi",
+        "--single-quote",
+        "--quote-props",
+        "preserve",
+        "--jsx-single-quote",
+        "--jsx-bracket-same-line",
         "--arrow-parens",
         "always",
         "--prose-wrap",

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -343,68 +343,68 @@ Automatically downloads Prettier dependencies on first run.
             .takes_value(false),
         )
         .arg(
-          Arg::with_name("print-width")
-            .long("print-width")
+          Arg::with_name("prettier-print-width")
+            .long("prettier-print-width")
             .help("Specify the line length that the printer will wrap on.")
             .takes_value(true)
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("tab-width")
-            .long("tab-width")
+          Arg::with_name("prettier-tab-width")
+            .long("prettier-tab-width")
             .help("Specify the number of spaces per indentation-level.")
             .takes_value(true)
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("use-tabs")
-            .long("use-tabs")
+          Arg::with_name("prettier-use-tabs")
+            .long("prettier-use-tabs")
             .help("Indent lines with tabs instead of spaces.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("no-semi")
-            .long("no-semi")
+          Arg::with_name("prettier-no-semi")
+            .long("prettier-no-semi")
             .help("Print semicolons at the ends of statements.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("single-quote")
-            .long("single-quote")
+          Arg::with_name("prettier-single-quote")
+            .long("prettier-single-quote")
             .help("Use single quotes instead of double quotes.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("trailing-comma")
-            .long("trailing-comma")
+          Arg::with_name("prettier-trailing-comma")
+            .long("prettier-trailing-comma")
             .help("Print trailing commas wherever possible when multi-line.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("no-bracket-spacing")
-            .long("no-bracket-spacing")
+          Arg::with_name("prettier-no-bracket-spacing")
+            .long("prettier-no-bracket-spacing")
             .help("Print spaces between brackets in object literals.")
             .takes_value(false)
         )
         .arg(
-          Arg::with_name("arrow-parens")
-            .long("arrow-parens")
+          Arg::with_name("prettier-arrow-parens")
+            .long("prettier-arrow-parens")
             .help("Include parentheses around a sole arrow function parameter.")
             .takes_value(true)
             .possible_values(&["avoid", "always"])
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("prose-wrap")
-            .long("prose-wrap")
+          Arg::with_name("prettier-prose-wrap")
+            .long("prettier-prose-wrap")
             .help("How to wrap prose.")
             .takes_value(true)
             .possible_values(&["always", "never", "preserve"])
             .require_equals(true)
         )
         .arg(
-          Arg::with_name("end-of-line")
-            .long("end-of-line")
+          Arg::with_name("prettier-end-of-line")
+            .long("prettier-end-of-line")
             .help("Which end of line characters to apply.")
             .takes_value(true)
             .possible_values(&["auto", "lf", "crlf", "cr"])
@@ -956,58 +956,32 @@ pub fn flags_from_vec(
         argv.push("--write".to_string());
       }
 
-      if fmt_match.is_present("print-width") {
-        let prettier_print_width = fmt_match.value_of("print-width").unwrap();
-        argv.push("--print-width".to_string());
-        argv.push(prettier_print_width.to_string());
-      }
+      let prettier_flags = [
+        ["1", "print-width"],
+        ["1", "tab-width"],
+        ["0", "use-tabs"],
+        ["0", "no-semi"],
+        ["0", "single-quote"],
+        ["0", "trailing-comma"],
+        ["0", "no-bracket-spacing"],
+        ["1", "arrow-parens"],
+        ["1", "prose-wrap"],
+        ["1", "end-of-line"],
+      ];
 
-      if fmt_match.is_present("tab-width") {
-        let prettier_tab_width = fmt_match.value_of("tab-width").unwrap();
-        argv.push("--tab-width".to_string());
-        argv.push(prettier_tab_width.to_string());
-      }
+      for opt in &prettier_flags {
+        let t = opt[0];
+        let keyword = opt[1];
+        let flg = format!("prettier-{}", keyword);
 
-      if fmt_match.is_present("use-tabs") {
-        argv.push("--use-tabs".to_string());
-      }
-
-      if fmt_match.is_present("no-semi") {
-        argv.push("--no-semi".to_string());
-      }
-
-      if fmt_match.is_present("single-quote") {
-        argv.push("--single-quote".to_string());
-      }
-
-      if fmt_match.is_present("trailing-comma") {
-        argv.push("--trailing-comma".to_string());
-      }
-
-      if fmt_match.is_present("no-bracket-spacing") {
-        argv.push("--no-bracket-spacing".to_string());
-      }
-
-      if fmt_match.is_present("no-bracket-spacing") {
-        argv.push("--no-bracket-spacing".to_string());
-      }
-
-      if fmt_match.is_present("arrow-parens") {
-        let prettier_arrow_parens = fmt_match.value_of("arrow-parens").unwrap();
-        argv.push("--arrow-parens".to_string());
-        argv.push(prettier_arrow_parens.to_string());
-      }
-
-      if fmt_match.is_present("prose-wrap") {
-        let prettier_prose_wrap = fmt_match.value_of("prose-wrap").unwrap();
-        argv.push("--prose-wrap".to_string());
-        argv.push(prettier_prose_wrap.to_string());
-      }
-
-      if fmt_match.is_present("end-of-line") {
-        let prettier_end_of_line = fmt_match.value_of("end-of-line").unwrap();
-        argv.push("--end-of-line".to_string());
-        argv.push(prettier_end_of_line.to_string());
+        if fmt_match.is_present(&flg) {
+          if t == "0" {
+            argv.push(format!("--{}", keyword));
+          } else {
+            argv.push(format!("--{}", keyword));
+            argv.push(fmt_match.value_of(&flg).unwrap().to_string());
+          }
+        }
       }
 
       DenoSubcommand::Run
@@ -2058,11 +2032,11 @@ mod tests {
     let (flags, subcommand, argv) = flags_from_vec(svec![
       "deno",
       "fmt",
-      "--print-width=100",
-      "--tab-width=4",
-      "--use-tabs",
-      "--no-semi",
-      "--arrow-parens=always",
+      "--prettier-print-width=100",
+      "--prettier-tab-width=4",
+      "--prettier-use-tabs",
+      "--prettier-no-semi",
+      "--prettier-arrow-parens=always",
       "script.ts"
     ]);
     assert_eq!(

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -345,6 +345,7 @@ Automatically downloads Prettier dependencies on first run.
         .arg(
           Arg::with_name("print-width")
             .long("print-width")
+            .value_name("int")
             .help("Specify the line length that the printer will wrap on.")
             .takes_value(true)
             .require_equals(true)
@@ -352,6 +353,7 @@ Automatically downloads Prettier dependencies on first run.
         .arg(
           Arg::with_name("tab-width")
             .long("tab-width")
+            .value_name("int")
             .help("Specify the number of spaces per indentation-level.")
             .takes_value(true)
             .require_equals(true)
@@ -389,6 +391,7 @@ Automatically downloads Prettier dependencies on first run.
         .arg(
           Arg::with_name("arrow-parens")
             .long("arrow-parens")
+            .value_name("avoid|always")
             .help("Include parentheses around a sole arrow function parameter.")
             .takes_value(true)
             .possible_values(&["avoid", "always"])
@@ -397,6 +400,7 @@ Automatically downloads Prettier dependencies on first run.
         .arg(
           Arg::with_name("prose-wrap")
             .long("prose-wrap")
+            .value_name("always|never|preserve")
             .help("How to wrap prose.")
             .takes_value(true)
             .possible_values(&["always", "never", "preserve"])
@@ -405,6 +409,7 @@ Automatically downloads Prettier dependencies on first run.
         .arg(
           Arg::with_name("end-of-line")
             .long("end-of-line")
+            .value_name("auto|lf|crlf|cr")
             .help("Which end of line characters to apply.")
             .takes_value(true)
             .possible_values(&["auto", "lf", "crlf", "cr"])

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -392,6 +392,7 @@ Automatically downloads Prettier dependencies on first run.
             .help("Include parentheses around a sole arrow function parameter.")
             .takes_value(true)
             .possible_values(&["avoid", "always"])
+            .require_equals(true)
         )
         .arg(
           Arg::with_name("prose-wrap")
@@ -399,6 +400,7 @@ Automatically downloads Prettier dependencies on first run.
             .help("How to wrap prose.")
             .takes_value(true)
             .possible_values(&["always", "never", "preserve"])
+            .require_equals(true)
         )
         .arg(
           Arg::with_name("end-of-line")
@@ -406,6 +408,7 @@ Automatically downloads Prettier dependencies on first run.
             .help("Which end of line characters to apply.")
             .takes_value(true)
             .possible_values(&["auto", "lf", "crlf", "cr"])
+            .require_equals(true)
         )
         .arg(
           Arg::with_name("files")

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -395,11 +395,8 @@ Automatically downloads Prettier dependencies on first run.
           Arg::with_name("jsx-bracket-same-line")
             .long("jsx-bracket-same-line")
             .help(
-              "Put the > of a multi-line JSX element at
-            the end of the last line instead of
-            being alone on the next line (does not
-            apply to self closing elements).
-            "
+              "Put the > of a multi-line JSX element at the end of the last line
+instead of being alone on the next line (does not apply to self closing elements)."
             )
             .takes_value(false)
         )

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -335,12 +335,79 @@ This command has implicit access to all permissions (equivalent to deno run --al
 Automatically downloads Prettier dependencies on first run.
 
   deno fmt myfile1.ts myfile2.ts",
-        ).arg(
+        )
+        .arg(
           Arg::with_name("stdout")
             .long("stdout")
             .help("Output formated code to stdout")
             .takes_value(false),
-        ).arg(
+        )
+        .arg(
+          Arg::with_name("print-width")
+            .long("print-width")
+            .help("Specify the line length that the printer will wrap on.")
+            .takes_value(true)
+            .require_equals(true)
+        )
+        .arg(
+          Arg::with_name("tab-width")
+            .long("tab-width")
+            .help("Specify the number of spaces per indentation-level.")
+            .takes_value(true)
+            .require_equals(true)
+        )
+        .arg(
+          Arg::with_name("use-tabs")
+            .long("use-tabs")
+            .help("Indent lines with tabs instead of spaces.")
+            .takes_value(false)
+        )
+        .arg(
+          Arg::with_name("no-semi")
+            .long("no-semi")
+            .help("Print semicolons at the ends of statements.")
+            .takes_value(false)
+        )
+        .arg(
+          Arg::with_name("single-quote")
+            .long("single-quote")
+            .help("Use single quotes instead of double quotes.")
+            .takes_value(false)
+        )
+        .arg(
+          Arg::with_name("trailing-comma")
+            .long("trailing-comma")
+            .help("Print trailing commas wherever possible when multi-line.")
+            .takes_value(false)
+        )
+        .arg(
+          Arg::with_name("no-bracket-spacing")
+            .long("no-bracket-spacing")
+            .help("Print spaces between brackets in object literals.")
+            .takes_value(false)
+        )
+        .arg(
+          Arg::with_name("arrow-parens")
+            .long("arrow-parens")
+            .help("Include parentheses around a sole arrow function parameter.")
+            .takes_value(true)
+            .possible_values(&["avoid", "always"])
+        )
+        .arg(
+          Arg::with_name("prose-wrap")
+            .long("prose-wrap")
+            .help("How to wrap prose.")
+            .takes_value(true)
+            .possible_values(&["always", "never", "preserve"])
+        )
+        .arg(
+          Arg::with_name("end-of-line")
+            .long("end-of-line")
+            .help("Which end of line characters to apply.")
+            .takes_value(true)
+            .possible_values(&["auto", "lf", "crlf", "cr"])
+        )
+        .arg(
           Arg::with_name("files")
             .takes_value(true)
             .multiple(true)
@@ -884,6 +951,60 @@ pub fn flags_from_vec(
       if !fmt_match.is_present("stdout") {
         // `deno fmt` writes to the files by default
         argv.push("--write".to_string());
+      }
+
+      if fmt_match.is_present("print-width") {
+        let prettier_print_width = fmt_match.value_of("print-width").unwrap();
+        argv.push("--print-width".to_string());
+        argv.push(prettier_print_width.to_string());
+      }
+
+      if fmt_match.is_present("tab-width") {
+        let prettier_tab_width = fmt_match.value_of("tab-width").unwrap();
+        argv.push("--tab-width".to_string());
+        argv.push(prettier_tab_width.to_string());
+      }
+
+      if fmt_match.is_present("use-tabs") {
+        argv.push("--use-tabs".to_string());
+      }
+
+      if fmt_match.is_present("no-semi") {
+        argv.push("--no-semi".to_string());
+      }
+
+      if fmt_match.is_present("single-quote") {
+        argv.push("--single-quote".to_string());
+      }
+
+      if fmt_match.is_present("trailing-comma") {
+        argv.push("--trailing-comma".to_string());
+      }
+
+      if fmt_match.is_present("no-bracket-spacing") {
+        argv.push("--no-bracket-spacing".to_string());
+      }
+
+      if fmt_match.is_present("no-bracket-spacing") {
+        argv.push("--no-bracket-spacing".to_string());
+      }
+
+      if fmt_match.is_present("arrow-parens") {
+        let prettier_arrow_parens = fmt_match.value_of("arrow-parens").unwrap();
+        argv.push("--arrow-parens".to_string());
+        argv.push(prettier_arrow_parens.to_string());
+      }
+
+      if fmt_match.is_present("prose-wrap") {
+        let prettier_prose_wrap = fmt_match.value_of("prose-wrap").unwrap();
+        argv.push("--prose-wrap".to_string());
+        argv.push(prettier_prose_wrap.to_string());
+      }
+
+      if fmt_match.is_present("end-of-line") {
+        let prettier_end_of_line = fmt_match.value_of("end-of-line").unwrap();
+        argv.push("--end-of-line".to_string());
+        argv.push(prettier_end_of_line.to_string());
       }
 
       DenoSubcommand::Run
@@ -1927,5 +2048,45 @@ mod tests {
     );
     assert_eq!(subcommand, DenoSubcommand::Run);
     assert_eq!(argv, svec!["deno", "script.ts"])
+  }
+
+  #[test]
+  fn test_flags_from_vec_39() {
+    let (flags, subcommand, argv) = flags_from_vec(svec![
+      "deno",
+      "fmt",
+      "--print-width=100",
+      "--tab-width=4",
+      "--use-tabs",
+      "--no-semi",
+      "--arrow-parens=always",
+      "script.ts"
+    ]);
+    assert_eq!(
+      flags,
+      DenoFlags {
+        allow_write: true,
+        allow_read: true,
+        ..DenoFlags::default()
+      }
+    );
+    assert_eq!(subcommand, DenoSubcommand::Run);
+    assert_eq!(
+      argv,
+      svec![
+        "deno",
+        PRETTIER_URL,
+        "script.ts",
+        "--write",
+        "--print-width",
+        "100",
+        "--tab-width",
+        "4",
+        "--use-tabs",
+        "--no-semi",
+        "--arrow-parens",
+        "always"
+      ]
+    );
   }
 }

--- a/std/prettier/main.ts
+++ b/std/prettier/main.ts
@@ -61,6 +61,15 @@ JS/TS Styling Options:
                                         beginning of lines which may need them.
   --single-quote                        Use single quotes instead of double
                                         quotes. Defaults to false.
+  --quote-props <as-needed|consistent|preserve>
+                                        Change when properties in objects are
+                                        quoted. Defaults to as-needed.
+  --jsx-single-quote                    Use single quotes instead of double
+                                        quotes in JSX.
+  --jsx-bracket-same-line               Put the > of a multi-line JSX element at
+                                        the end of the last line instead of
+                                        being alone on the next line (does not
+                                        apply to self closing elements).
   --trailing-comma <none|es5|all>       Print trailing commas wherever possible
                                         when multi-line. Defaults to none.
   --no-bracket-spacing                  Do not print spaces between brackets.
@@ -103,6 +112,9 @@ interface PrettierOptions {
   useTabs: boolean;
   semi: boolean;
   singleQuote: boolean;
+  quoteProps: string;
+  jsxSingleQuote: boolean;
+  jsxBracketSameLine: boolean;
   trailingComma: string;
   bracketSpacing: boolean;
   arrowParens: string;
@@ -340,6 +352,9 @@ async function main(opts): Promise<void> {
     useTabs: Boolean(opts["use-tabs"]),
     semi: Boolean(opts["semi"]),
     singleQuote: Boolean(opts["single-quote"]),
+    quoteProps: opts["quote-props"],
+    jsxSingleQuote: Boolean(opts["jsx-single-quote"]),
+    jsxBracketSameLine: Boolean(opts["jsx-bracket-same-line	"]),
     trailingComma: opts["trailing-comma"],
     bracketSpacing: Boolean(opts["bracket-spacing"]),
     arrowParens: opts["arrow-parens"],
@@ -387,7 +402,8 @@ main(
       "arrow-parens",
       "prose-wrap",
       "end-of-line",
-      "stdin-parser"
+      "stdin-parser",
+      "quote-props"
     ],
     boolean: [
       "check",
@@ -397,7 +413,9 @@ main(
       "single-quote",
       "bracket-spacing",
       "write",
-      "stdin"
+      "stdin",
+      "jsx-single-quote",
+      "jsx-bracket-same-line"
     ],
     default: {
       ignore: [],
@@ -413,7 +431,10 @@ main(
       "end-of-line": "auto",
       write: false,
       stdin: false,
-      "stdin-parser": "typescript"
+      "stdin-parser": "typescript",
+      "quote-props": "as-needed",
+      "jsx-single-quote": false,
+      "jsx-bracket-same-line": false
     },
     alias: {
       H: "help"


### PR DESCRIPTION
close #3033

Added flag for `deno fmt` to set Prettier options

### current `deno fmt` output

```shell
$ ./target/release/deno fmt --help
deno-fmt 
Auto-format JavaScript/TypeScript source code using Prettier

Automatically downloads Prettier dependencies on first run.

  deno fmt myfile1.ts myfile2.ts

USAGE:
    deno fmt [OPTIONS] <files>...

OPTIONS:
        --arrow-parens=<avoid|always>
            Include parentheses around a sole arrow function parameter. [possible values: avoid, always]

    -c, --config <FILE>                                  
            Load tsconfig.json configuration file

        --current-thread                                 
            Use tokio::runtime::current_thread

        --end-of-line=<auto|lf|crlf|cr>
            Which end of line characters to apply. [possible values: auto, lf, crlf, cr]

    -h, --help                                           
            Prints help information

        --importmap <FILE>                               
            Load import map file
            Specification: https://wicg.github.io/import-maps/
            Examples: https://github.com/WICG/import-maps#the-import-map
        --jsx-bracket-same-line
            Put the > of a multi-line JSX element at the end of the last line
            instead of being alone on the next line (does not apply to self closing elements).
        --jsx-single-quote                               
            Use single quotes instead of double quotes in JSX.

        --lock <FILE>                                    
            Check the specified lock file

        --lock-write                                     
            Write lock file. Use with --lock.

    -L, --log-level <log-level>                          
            Set log level [possible values: debug, info]

        --no-bracket-spacing                             
            Print spaces between brackets in object literals.

        --no-semi                                        
            Print semicolons at the ends of statements.

        --print-width=<int>                              
            Specify the line length that the printer will wrap on.

        --prose-wrap=<always|never|preserve>             
            How to wrap prose. [possible values: always, never, preserve]

        --quote-props=<as-needed|consistent|preserve>
            Change when properties in objects are quoted. [possible values: as-needed, consistent, preserve]

    -r, --reload=<CACHE_BLACKLIST>                       
            Reload source code cache (recompile TypeScript)
                      --reload
                        Reload everything
                      --reload=https://deno.land/std
                        Reload all standard modules
                      --reload=https://deno.land/std/fs/utils.ts,https://deno.land/std/fmt/colors.ts
                        Reloads specific modules
        --seed <NUMBER>                                  
            Seed Math.random()

        --single-quote                                   
            Use single quotes instead of double quotes.

        --stdout                                         
            Output formated code to stdout

        --tab-width=<int>                                
            Specify the number of spaces per indentation-level.

        --trailing-comma                                 
            Print trailing commas wherever possible when multi-line.

        --use-tabs                                       
            Indent lines with tabs instead of spaces.

        --v8-flags=<v8-flags>                            
            Set V8 command line options

        --v8-options                                     
            Print V8 command line options


ARGS:
    <files>...    
            
```