### PR TITLE
Disable flaky test lock_check_ok2

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -362,11 +362,13 @@ itest!(lock_check_ok {
   http_server: true,
 });
 
+/* TODO(ry) Re-enable this test. It is flaky and only fails occasionally.
 itest!(lock_check_ok2 {
   args: "run 019_media_types.ts --lock=lock_check_ok2.json",
   output: "019_media_types.ts.out",
   http_server: true,
 });
+*/
 
 itest!(lock_check_err {
   args: "run --lock=lock_check_err.json http://127.0.0.1:4545/cli/tests/003_relative_import.ts",

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -378,6 +378,7 @@ itest!(lock_check_err {
   http_server: true,
 });
 
+/* TODO(ry) Re-enable this test. It is flaky and only fails occasionally.
 itest!(lock_check_err2 {
   args: "run 019_media_types.ts --lock=lock_check_err2.json",
   output: "lock_check_err2.out",
@@ -385,6 +386,7 @@ itest!(lock_check_err2 {
   exit_code: 10,
   http_server: true,
 });
+*/
 
 itest!(async_error {
   exit_code: 1,


### PR DESCRIPTION
It also uses `019_media_types.ts` which is known to be flaky.

ref #3332 