### PR TITLE
Ignore some files that facilitate editors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ gclient_config.py_entries
 /gh-pages/
 /target/
 
+# Files that help ensure VSCode can work but we don't want checked into the
+# repo
+/node_modules
+/tsconfig.json
+
 # We use something stronger than lockfiles, we have all NPM modules stored in a
 # git. We do not download from NPM during build.
 # https://github.com/denoland/deno_third_party


### PR DESCRIPTION
Using an editor, such as VSCode, some of the plugins require some
files locally to provide a good editing experience.  These were
removed from the repo, but allowing people to add them back locally
but ensure they don't end up committed by accident would be helpful.
