### PR TITLE
ci: add RUST_BACKTRACE=full

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           echo ::set-env name=GH_ACTIONS::1
           echo ::set-env name=RUSTC_WRAPPER::sccache
           echo ::set-env name=DENO_BUILD_MODE::release
+          echo ::set-env name=RUST_BACKTRACE::full
 
       - name: Environment (linux)
         if: startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
This PR adds env variable `RUST_BACKTRACE` set to `full` so we can actually see what went wrong during CI runs.

This is an attempt to debug issue described in #3332 