### PR TITLE
std datetime: fix toIMF

### DIFF
--- a/std/datetime/mod.ts
+++ b/std/datetime/mod.ts
@@ -126,11 +126,12 @@ export function toIMF(date: Date): string {
   const min = dtPad(date.getUTCMinutes().toString());
   const s = dtPad(date.getUTCSeconds().toString());
   const y = date.getUTCFullYear();
-  const days = ["Sun", "Mon", "Tue", "Wed", "Thus", "Fri", "Sat"];
+  const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
   const months = [
     "Jan",
     "Feb",
     "Mar",
+    "Apr",
     "May",
     "Jun",
     "Jul",

--- a/std/datetime/test.ts
+++ b/std/datetime/test.ts
@@ -81,7 +81,7 @@ test({
   name: "[DateTime] to IMF",
   fn(): void {
     const actual = datetime.toIMF(new Date(Date.UTC(1994, 3, 5, 15, 32)));
-    const expected = "Tue, 05 May 1994 15:32:00 GMT";
+    const expected = "Tue, 05 Apr 1994 15:32:00 GMT";
     assertEquals(actual, expected);
   }
 });
@@ -90,7 +90,7 @@ test({
   name: "[DateTime] to IMF 0",
   fn(): void {
     const actual = datetime.toIMF(new Date(0));
-    const expected = "Thus, 01 Jan 1970 00:00:00 GMT";
+    const expected = "Thu, 01 Jan 1970 00:00:00 GMT";
     assertEquals(actual, expected);
   }
 });

--- a/std/http/cookie_test.ts
+++ b/std/http/cookie_test.ts
@@ -39,7 +39,7 @@ test({
     delCookie(res, "deno");
     assertEquals(
       res.headers!.get("Set-Cookie"),
-      "deno=; Expires=Thus, 01 Jan 1970 00:00:00 GMT"
+      "deno=; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
     );
   }
 });


### PR DESCRIPTION
before
`datetime.toIMF(new Date(0))` = `"Thus, 01 Jan 1970 00:00:00 GMT"`
`datetime.toIMF(new Date(Date.UTC(1994, 3, 5, 15, 32)))` = `"Tue, 05 May 1994 15:32:00 GMT"`

after
`datetime.toIMF(new Date(0))` = `"Thu, 01 Jan 1970 00:00:00 GMT"`
`datetime.toIMF(new Date(Date.UTC(1994, 3, 5, 15, 32)))` = `"Tue, 05 Apr 1994 15:32:00 GMT"`