### PR TITLE
refactor: fixes for futures

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -272,8 +272,8 @@ impl TsCompiler {
 
     let worker = TsCompiler::setup_worker(global_state.clone());
     let worker_ = worker.clone();
+    worker.post_message(req_msg).unwrap();
     let first_msg_fut = async move {
-      worker.post_message(req_msg).await.unwrap();
       let result = worker.await;
       if let Err(err) = result {
         // TODO(ry) Need to forward the error instead of exiting.
@@ -382,8 +382,8 @@ impl TsCompiler {
       .add("Compile", &module_url.to_string());
     let global_state_ = global_state.clone();
 
+    worker.post_message(req_msg).unwrap();
     let first_msg_fut = async move {
-      worker.post_message(req_msg).await.unwrap();
       let result = worker.await;
       if let Err(err) = result {
         // TODO(ry) Need to forward the error instead of exiting.

--- a/cli/compilers/wasm.rs
+++ b/cli/compilers/wasm.rs
@@ -86,14 +86,13 @@ impl WasmCompiler {
     let worker_ = worker.clone();
     let url = source_file.url.clone();
 
+    let _res = worker.post_message(
+      serde_json::to_string(&base64_data)
+        .unwrap()
+        .into_boxed_str()
+        .into_boxed_bytes(),
+    );
     let fut = worker
-      .post_message(
-        serde_json::to_string(&base64_data)
-          .unwrap()
-          .into_boxed_str()
-          .into_boxed_bytes(),
-      )
-      .then(move |_| worker)
       .then(move |result| {
         if let Err(err) = result {
           // TODO(ry) Need to forward the error instead of exiting.

--- a/cli/ops/workers.rs
+++ b/cli/ops/workers.rs
@@ -271,7 +271,8 @@ fn op_host_post_message(
   let mut table = state.workers.lock().unwrap();
   // TODO: don't return bad resource anymore
   let worker = table.get_mut(&id).ok_or_else(bad_resource)?;
-  tokio_util::block_on(worker.post_message(msg).boxed())
+  worker
+    .post_message(msg)
     .map_err(|e| DenoError::new(ErrorKind::Other, e.to_string()))?;
   Ok(JsonOp::Sync(json!({})))
 }


### PR DESCRIPTION
This PR is a followup to #3358 
After landing it benchmarks exploded indicating problems with workers and `deno_core_http_bench`.

The bench is already fixed and workers partially. 

EDIT: This PR dramatically fixes churn in thread/syscall count that showed up on benchmarks. Thread count is not back to previous levels but difference went from hundreds/thousands to about ~50.