### PR TITLE
Node `process` object compatibility

### DIFF
--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -2,7 +2,7 @@ export const version = `v${Deno.version.deno}`;
 
 export const versions = {
   node: Deno.version.deno,
-  ...Deno.version,
+  ...Deno.version
 };
 
 const osToPlatform = (os: Deno.OperatingSystem): string =>
@@ -12,7 +12,7 @@ export const platform = osToPlatform(Deno.build.os);
 
 export const { arch } = Deno.build;
 
-export const argv = [ Deno.execPath(), ...Deno.args ];
+export const argv = [Deno.execPath(), ...Deno.args];
 
 // TODO(rsp): currently setting env seems to be working by modifying the object
 // that is returnd by Deno.env(). Need to make sure that this is the final API

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -5,7 +5,7 @@ export const versions = {
   ...Deno.version,
 };
 
-const osToPlatform = (os: Deno.OperatingSystem) =>
+const osToPlatform = (os: Deno.OperatingSystem): string =>
   os === "win" ? "win32" : os === "mac" ? "darwin" : os;
 
 export const platform = osToPlatform(Deno.build.os);
@@ -21,7 +21,7 @@ export const env = Deno.env();
 
 export const { pid, cwd, chdir, exit } = Deno;
 
-export function on(event: string, callback: Function) {
+export function on(_event: string, _callback: Function): void {
   // TODO(rsp): to be implemented
   // This is needed and empty func is actually sufficient for code that do things like:
   // process.on("uncaughtException", (err) => {

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -1,6 +1,6 @@
-export const version = `v${Deno.version.deno}`;
+const version = `v${Deno.version.deno}`;
 
-export const versions = {
+const versions = {
   node: Deno.version.deno,
   ...Deno.version
 };
@@ -8,20 +8,33 @@ export const versions = {
 const osToPlatform = (os: Deno.OperatingSystem): string =>
   os === "win" ? "win32" : os === "mac" ? "darwin" : os;
 
-export const platform = osToPlatform(Deno.build.os);
+const platform = osToPlatform(Deno.build.os);
 
-export const { arch } = Deno.build;
+const { arch } = Deno.build;
 
-export const argv = [Deno.execPath(), ...Deno.args];
+const { pid, cwd, chdir, exit } = Deno;
 
-// TODO(rsp): currently setting env seems to be working by modifying the object
-// that is returnd by Deno.env(). Need to make sure that this is the final API
-// or Deno.env('key', 'value') is to be used in the future.
-export const env = Deno.env();
-
-export const { pid, cwd, chdir, exit } = Deno;
-
-export function on(_event: string, _callback: Function): void {
+function on(_event: string, _callback: Function): void {
   // TODO(rsp): to be implemented
   throw Error("unimplemented");
 }
+
+export const process = {
+  version,
+  versions,
+  platform,
+  arch,
+  pid,
+  cwd,
+  chdir,
+  exit,
+  on,
+  get env(): { [index: string]: string } {
+    // using getter to avoid --allow-env unless it's used
+    return Deno.env();
+  },
+  get argv(): string[] {
+    // Deno.execPath() also requires --allow-env
+    return [Deno.execPath(), ...Deno.args];
+  }
+};

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -23,10 +23,5 @@ export const { pid, cwd, chdir, exit } = Deno;
 
 export function on(_event: string, _callback: Function): void {
   // TODO(rsp): to be implemented
-  // This is needed and empty func is actually sufficient for code that do things like:
-  // process.on("uncaughtException", (err) => {
-  //   if (!(err instanceof ExitStatus)) throw err;
-  // });
-  // Deno dies on uncaught exceptions anyway, but without it it will also die on
-  // registering the callback itself.
+  throw Error("unimplemented");
 }

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -1,0 +1,32 @@
+export const version = `v${Deno.version.deno}`;
+
+export const versions = {
+  node: Deno.version.deno,
+  ...Deno.version,
+};
+
+const osToPlatform = (os: Deno.OperatingSystem) =>
+  os === "win" ? "win32" : os === "mac" ? "darwin" : os;
+
+export const platform = osToPlatform(Deno.build.os);
+
+export const { arch } = Deno.build;
+
+export const argv = [ Deno.execPath(), ...Deno.args ];
+
+// TODO(rsp): currently setting env seems to be working by modifying the object
+// that is returnd by Deno.env(). Need to make sure that this is the final API
+// or Deno.env('key', 'value') is to be used in the future.
+export const env = Deno.env();
+
+export const { pid, cwd, chdir, exit } = Deno;
+
+export function on(event: string, callback: Function) {
+  // TODO(rsp): to be implemented
+  // This is needed and empty func is actually sufficient for code that do things like:
+  // process.on("uncaughtException", (err) => {
+  //   if (!(err instanceof ExitStatus)) throw err;
+  // });
+  // Deno dies on uncaught exceptions anyway, but without it it will also die on
+  // registering the callback itself.
+}

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -1,3 +1,5 @@
+import { notImplemented } from "./_utils.ts";
+
 const version = `v${Deno.version.deno}`;
 
 const versions = {
@@ -16,7 +18,7 @@ const { pid, cwd, chdir, exit } = Deno;
 
 function on(_event: string, _callback: Function): void {
   // TODO(rsp): to be implemented
-  throw Error("unimplemented");
+  notImplemented();
 }
 
 export const process = {

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -1,9 +1,9 @@
 import { test } from "../testing/mod.ts";
 import { assert, assertThrows, assertEquals } from "../testing/asserts.ts";
-import * as process from "./process.ts";
+import { process } from "./process.ts";
 
-// NOTE: Deno.cwd() and Deno.chdir() currently require --allow-env
-// (Also Deno.env() requires --allow-env but it's more obvious)
+// NOTE: Deno.execPath() (and thus process.argv) currently requires --allow-env
+// (Also Deno.env() (and process.env) requires --allow-env but it's more obvious)
 
 test({
   name: "process.cwd and process.chdir success",

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -82,7 +82,12 @@ test({
   name: "process.argv",
   fn() {
     assert(Array.isArray(process.argv));
-    assert(process.argv.filter(x => x.match(/process_test[.]ts$/)).length > 0);
+    assert(
+      process.argv.filter(x => x.match(/process_test[.]ts$/)).length > 0,
+      `file name process_test.ts in process.argv = ${JSON.stringify(
+        process.argv
+      )}`
+    );
   }
 });
 

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -76,7 +76,6 @@ test({
   name: "process.argv",
   fn() {
     assert(Array.isArray(process.argv));
-    assert(process.argv.filter(x => x.match(/[^/\\]*deno[^/\\]*$/)).length > 0);
     assert(process.argv.filter(x => x.match(/process_test[.]ts$/)).length > 0);
   }
 });

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -64,7 +64,7 @@ test({
   name: "process.on",
   fn() {
     assertEquals(typeof process.on, "function");
-    process.on("uncaughtException", (err: any) => {
+    process.on("uncaughtException", (_err: Error) => {
     });
   },
 });

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -14,22 +14,26 @@ test({
     assert(process.cwd().match(/\Wnode$/));
     process.chdir("..");
     assert(process.cwd().match(/\Wstd$/));
-    },
+  }
 });
 
 test({
   name: "process.chdir failure",
   fn() {
-    assertThrows(() => {
-      process.chdir("non-existent-directory-name");
-    }, Deno.DenoError, "No such file");
-  },
+    assertThrows(
+      () => {
+        process.chdir("non-existent-directory-name");
+      },
+      Deno.DenoError,
+      "No such file"
+    );
+  }
 });
 
 test({
   name: "process.version",
   fn() {
-    assertEquals(typeof process, "object")
+    assertEquals(typeof process, "object");
     assertEquals(typeof process.version, "string");
     assertEquals(typeof process.versions, "object");
     assertEquals(typeof process.versions.node, "string");
@@ -40,7 +44,7 @@ test({
   name: "process.platform",
   fn() {
     assertEquals(typeof process.platform, "string");
-  },
+  }
 });
 
 test({
@@ -49,7 +53,7 @@ test({
     assertEquals(typeof process.arch, "string");
     // TODO(rsp): make sure that the arch strings should be the same in Node and Deno:
     assertEquals(process.arch, Deno.build.arch);
-  },
+  }
 });
 
 test({
@@ -57,16 +61,15 @@ test({
   fn() {
     assertEquals(typeof process.pid, "number");
     assertEquals(process.pid, Deno.pid);
-  },
+  }
 });
 
 test({
   name: "process.on",
   fn() {
     assertEquals(typeof process.on, "function");
-    process.on("uncaughtException", (_err: Error) => {
-    });
-  },
+    process.on("uncaughtException", (_err: Error) => {});
+  }
 });
 
 test({
@@ -75,13 +78,12 @@ test({
     assert(Array.isArray(process.argv));
     assert(process.argv[0].match(/[^/\\]*deno[^/\\]*$/));
     assert(process.argv.slice(-1)[0].match(/process_test[.]ts$/));
-  },
+  }
 });
 
 test({
   name: "process.env",
   fn() {
-    assertEquals(typeof process.env.PATH, 'string'); 
-  },
+    assertEquals(typeof process.env.PATH, "string");
+  }
 });
-

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -1,0 +1,87 @@
+import { test } from "../testing/mod.ts";
+import { assert, assertThrows, assertEquals } from "../testing/asserts.ts";
+import * as process from "./process.ts";
+
+// NOTE: Deno.cwd() and Deno.chdir() currently require --allow-env
+// (Also Deno.env() requires --allow-env but it's more obvious)
+
+test({
+  name: "process.cwd and process.chdir success",
+  fn() {
+    // this should be run like other tests from directory up
+    assert(process.cwd().match(/\Wstd$/));
+    process.chdir("node");
+    assert(process.cwd().match(/\Wnode$/));
+    process.chdir("..");
+    assert(process.cwd().match(/\Wstd$/));
+    },
+});
+
+test({
+  name: "process.chdir failure",
+  fn() {
+    assertThrows(() => {
+      process.chdir("non-existent-directory-name");
+    }, Deno.DenoError, "No such file");
+  },
+});
+
+test({
+  name: "process.version",
+  fn() {
+    assertEquals(typeof process, "object")
+    assertEquals(typeof process.version, "string");
+    assertEquals(typeof process.versions, "object");
+    assertEquals(typeof process.versions.node, "string");
+  }
+});
+
+test({
+  name: "process.platform",
+  fn() {
+    assertEquals(typeof process.platform, "string");
+  },
+});
+
+test({
+  name: "process.arch",
+  fn() {
+    assertEquals(typeof process.arch, "string");
+    // TODO(rsp): make sure that the arch strings should be the same in Node and Deno:
+    assertEquals(process.arch, Deno.build.arch);
+  },
+});
+
+test({
+  name: "process.pid",
+  fn() {
+    assertEquals(typeof process.pid, "number");
+    assertEquals(process.pid, Deno.pid);
+  },
+});
+
+test({
+  name: "process.on",
+  fn() {
+    assertEquals(typeof process.on, "function");
+    process.on("uncaughtException", (err: any) => {
+    });
+  },
+});
+
+test({
+  name: "process.argv",
+  fn() {
+    assert(Array.isArray(process.argv));
+    assert(process.argv[0].match(/[^/\\]*deno[^/\\]*$/));
+    assert(process.argv.slice(-1)[0].match(/process_test[.]ts$/));
+  },
+});
+
+test({
+  name: "process.env",
+  fn() {
+    assertEquals(typeof process.env.PATH, 'string'); 
+  },
+});
+

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -78,7 +78,7 @@ test({
         process.on("uncaughtException", (_err: Error) => {});
       },
       Error,
-      "unimplemented"
+      "implemented"
     );
   }
 });

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -83,11 +83,10 @@ test({
   fn() {
     assert(Array.isArray(process.argv));
     assert(
-      process.argv.filter(x => x.match(/process_test[.]ts$/)).length > 0,
-      `file name process_test.ts in process.argv = ${JSON.stringify(
-        process.argv
-      )}`
+      process.argv[0].match(/[^/\\]*deno[^/\\]*$/),
+      "deno included in the file name of argv[0]"
     );
+    // we cannot test for anything else (we see test runner arguments here)
   }
 });
 

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -76,8 +76,8 @@ test({
   name: "process.argv",
   fn() {
     assert(Array.isArray(process.argv));
-    assert(process.argv[0].match(/[^/\\]*deno[^/\\]*$/));
-    assert(process.argv.slice(-1)[0].match(/process_test[.]ts$/));
+    assert(process.argv.filter(x => x.match(/[^/\\]*deno[^/\\]*$/)).length > 0);
+    assert(process.argv.filter(x => x.match(/process_test[.]ts$/)).length > 0);
   }
 });
 

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -25,7 +25,12 @@ test({
         process.chdir("non-existent-directory-name");
       },
       Deno.DenoError,
-      "No such file"
+      "file"
+      // On every OS Deno returns: "No such file" except for Windows, where it's:
+      // "The system cannot find the file specified. (os error 2)" so "file" is
+      // the only common string here.
+      // TODO(rsp): Crazy idea: 404 for things like this?
+      // It would be nice to have error codes like 404 or 403 in addition to strings.
     );
   }
 });

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -68,7 +68,13 @@ test({
   name: "process.on",
   fn() {
     assertEquals(typeof process.on, "function");
-    process.on("uncaughtException", (_err: Error) => {});
+    assertThrows(
+      () => {
+        process.on("uncaughtException", (_err: Error) => {});
+      },
+      Error,
+      "unimplemented"
+    );
   }
 });
 


### PR DESCRIPTION
This PR adds a partial implementation of Node-compatible process:

- `process.cwd()`
- `process.chdir()`
- `process.version`
- `process.versions`
- `process.platform`
- `process.arch`
- `process.pid`
- `process.on` (no-op)
- `process.argv`
- `process.env`

This is very incomplete but should be sufficient for a library that I need to port to Deno that uses some of those to sniff for Node.

If it is ok to have a partial implementation for a good start then it's better to have it here, if not then let me know and I'll put it as a third-party module on deno.land/x