### PR TITLE
refactor: remove tokio_util::block_on from ops/workers.rs

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -272,8 +272,8 @@ impl TsCompiler {
 
     let worker = TsCompiler::setup_worker(global_state.clone());
     let worker_ = worker.clone();
-    worker.post_message(req_msg).unwrap();
     let first_msg_fut = async move {
+      worker.post_message(req_msg).await.unwrap();
       let result = worker.await;
       if let Err(err) = result {
         // TODO(ry) Need to forward the error instead of exiting.
@@ -382,8 +382,8 @@ impl TsCompiler {
       .add("Compile", &module_url.to_string());
     let global_state_ = global_state.clone();
 
-    worker.post_message(req_msg).unwrap();
     let first_msg_fut = async move {
+      worker.post_message(req_msg).await.unwrap();
       let result = worker.await;
       if let Err(err) = result {
         // TODO(ry) Need to forward the error instead of exiting.

--- a/cli/compilers/wasm.rs
+++ b/cli/compilers/wasm.rs
@@ -86,13 +86,14 @@ impl WasmCompiler {
     let worker_ = worker.clone();
     let url = source_file.url.clone();
 
-    let _res = worker.post_message(
-      serde_json::to_string(&base64_data)
-        .unwrap()
-        .into_boxed_str()
-        .into_boxed_bytes(),
-    );
     let fut = worker
+      .post_message(
+        serde_json::to_string(&base64_data)
+          .unwrap()
+          .into_boxed_str()
+          .into_boxed_bytes(),
+      )
+      .then(|_| worker)
       .then(move |result| {
         if let Err(err) = result {
           // TODO(ry) Need to forward the error instead of exiting.

--- a/cli/ops/workers.rs
+++ b/cli/ops/workers.rs
@@ -7,7 +7,6 @@ use crate::deno_error::ErrorKind;
 use crate::ops::json_op;
 use crate::startup_data;
 use crate::state::ThreadSafeState;
-use crate::tokio_util;
 use crate::worker::Worker;
 use deno::*;
 use futures;
@@ -20,6 +19,7 @@ use std::convert::From;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::Ordering;
+use std::sync::mpsc;
 use std::task::Context;
 use std::task::Poll;
 
@@ -153,23 +153,31 @@ fn op_create_worker(
   js_check(worker.execute(&deno_main_call));
   js_check(worker.execute("workerMain()"));
 
-  let exec_cb = move |worker: Worker| {
-    let worker_id = parent_state.add_child_worker(worker);
-    json!(worker_id)
-  };
+  let worker_id = parent_state.add_child_worker(worker.clone());
+  let response = json!(worker_id);
 
   // Has provided source code, execute immediately.
   if has_source_code {
     js_check(worker.execute(&source_code));
-    return Ok(JsonOp::Sync(exec_cb(worker)));
+    return Ok(JsonOp::Sync(response));
   }
 
-  let op = worker
+  // TODO(bartlomieju): this should spawn mod execution on separate tokio task
+  // and block on receving message on a channel or even use sync channel /shrug
+  let (sender, receiver) = mpsc::sync_channel::<Result<(), ErrBox>>(1);
+  let fut = worker
     .execute_mod_async(&module_specifier, None, false)
-    .and_then(move |()| futures::future::ok(exec_cb(worker)));
+    .then(move |result| {
+      sender.send(result).expect("Failed to send message");
+      futures::future::ok(())
+    })
+    .boxed()
+    .compat();
+  tokio::spawn(fut);
 
-  let result = tokio_util::block_on(op.boxed())?;
-  Ok(JsonOp::Sync(result))
+  let result = receiver.recv().expect("Failed to receive message");
+  result?;
+  Ok(JsonOp::Sync(response))
 }
 
 struct GetWorkerClosedFuture {
@@ -271,9 +279,10 @@ fn op_host_post_message(
   let mut table = state.workers.lock().unwrap();
   // TODO: don't return bad resource anymore
   let worker = table.get_mut(&id).ok_or_else(bad_resource)?;
-  worker
+  let fut = worker
     .post_message(msg)
-    .map_err(|e| DenoError::new(ErrorKind::Other, e.to_string()))?;
+    .map_err(|e| DenoError::new(ErrorKind::Other, e.to_string()));
+  futures::executor::block_on(fut)?;
   Ok(JsonOp::Sync(json!({})))
 }
 


### PR DESCRIPTION
Yet another attempt to bring thread count down for workers. If this proves useful I might abstract it away and reuse in `file_fetcher.rs`