### PR TITLE
remove tokio_util::block_on

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -521,7 +521,8 @@ impl TsCompiler {
 
         let source_file = self
           .file_fetcher
-          .fetch_cached_source_file(&module_specifier);
+          .fetch_cached_source_file(&module_specifier)
+          .expect("Source file not found");
 
         let version_hash = source_code_version_hash(
           &source_file.source_code,
@@ -628,11 +629,9 @@ impl TsCompiler {
     script_name: &str,
   ) -> Option<SourceFile> {
     if let Some(module_specifier) = self.try_to_resolve(script_name) {
-      return Some(
-        self
-          .file_fetcher
-          .fetch_cached_source_file(&module_specifier),
-      );
+      return self
+        .file_fetcher
+        .fetch_cached_source_file(&module_specifier);
     }
 
     None

--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -521,8 +521,7 @@ impl TsCompiler {
 
         let source_file = self
           .file_fetcher
-          .fetch_source_file(&module_specifier)
-          .expect("Source file not found");
+          .fetch_cached_source_file(&module_specifier);
 
         let version_hash = source_code_version_hash(
           &source_file.source_code,
@@ -629,10 +628,11 @@ impl TsCompiler {
     script_name: &str,
   ) -> Option<SourceFile> {
     if let Some(module_specifier) = self.try_to_resolve(script_name) {
-      return match self.file_fetcher.fetch_source_file(&module_specifier) {
-        Ok(out) => Some(out),
-        Err(_) => None,
-      };
+      return Some(
+        self
+          .file_fetcher
+          .fetch_cached_source_file(&module_specifier),
+      );
     }
 
     None

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -676,7 +676,6 @@ mod tests {
   use super::*;
   use crate::fs as deno_fs;
   use crate::tokio_util;
-  use futures::executor::block_on;
   use tempfile::TempDir;
 
   fn setup_file_fetcher(dir_path: &Path) -> SourceFileFetcher {
@@ -997,51 +996,51 @@ mod tests {
     drop(http_server_guard);
   }
 
-  //  #[test]
-  //  fn test_get_source_code_multiple_downloads_of_same_file() {
-  //    let http_server_guard = crate::test_util::http_server();
-  //    let (_temp_dir, fetcher) = test_setup();
-  //    // http_util::fetch_sync_string requires tokio
-  //    tokio_util::init(|| {
-  //      let specifier = ModuleSpecifier::resolve_url(
-  //        "http://localhost:4545/tests/subdir/mismatch_ext.ts",
-  //      )
-  //      .unwrap();
-  //      let headers_file_name = fetcher.deps_cache.location.join(
-  //        fetcher.deps_cache.get_cache_filename_with_extension(
-  //          specifier.as_url(),
-  //          "headers.json",
-  //        ),
-  //      );
-  //
-  //      // first download
-  //      let result = block_on(fetcher.fetch_source_file_async(&specifier));
-  //      assert!(result.is_ok());
-  //
-  //      let result = fs::File::open(&headers_file_name);
-  //      assert!(result.is_ok());
-  //      let headers_file = result.unwrap();
-  //      // save modified timestamp for headers file
-  //      let headers_file_metadata = headers_file.metadata().unwrap();
-  //      let headers_file_modified = headers_file_metadata.modified().unwrap();
-  //
-  //      // download file again, it should use already fetched file even though `use_disk_cache` is set to
-  //      // false, this can be verified using source header file creation timestamp (should be
-  //      // the same as after first download)
-  //      let result = block_on(fetcher.fetch_source_file_async(&specifier));
-  //      assert!(result.is_ok());
-  //
-  //      let result = fs::File::open(&headers_file_name);
-  //      assert!(result.is_ok());
-  //      let headers_file_2 = result.unwrap();
-  //      // save modified timestamp for headers file
-  //      let headers_file_metadata_2 = headers_file_2.metadata().unwrap();
-  //      let headers_file_modified_2 = headers_file_metadata_2.modified().unwrap();
-  //
-  //      assert_eq!(headers_file_modified, headers_file_modified_2);
-  //    });
-  //    drop(http_server_guard);
-  //  }
+  #[test]
+  fn test_get_source_code_multiple_downloads_of_same_file() {
+    let http_server_guard = crate::test_util::http_server();
+    let (_temp_dir, fetcher) = test_setup();
+    let specifier = ModuleSpecifier::resolve_url(
+      "http://localhost:4545/tests/subdir/mismatch_ext.ts",
+    )
+    .unwrap();
+    let headers_file_name = fetcher.deps_cache.location.join(
+      fetcher
+        .deps_cache
+        .get_cache_filename_with_extension(specifier.as_url(), "headers.json"),
+    );
+
+    // first download
+    tokio_util::run(fetcher.fetch_source_file_async(&specifier).then(|r| {
+      assert!(r.is_ok());
+      futures::future::ok(())
+    }));
+
+    let result = fs::File::open(&headers_file_name);
+    assert!(result.is_ok());
+    let headers_file = result.unwrap();
+    // save modified timestamp for headers file
+    let headers_file_metadata = headers_file.metadata().unwrap();
+    let headers_file_modified = headers_file_metadata.modified().unwrap();
+
+    // download file again, it should use already fetched file even though `use_disk_cache` is set to
+    // false, this can be verified using source header file creation timestamp (should be
+    // the same as after first download)
+    tokio_util::run(fetcher.fetch_source_file_async(&specifier).then(|r| {
+      assert!(r.is_ok());
+      futures::future::ok(())
+    }));
+
+    let result = fs::File::open(&headers_file_name);
+    assert!(result.is_ok());
+    let headers_file_2 = result.unwrap();
+    // save modified timestamp for headers file
+    let headers_file_metadata_2 = headers_file_2.metadata().unwrap();
+    let headers_file_modified_2 = headers_file_metadata_2.modified().unwrap();
+
+    assert_eq!(headers_file_modified, headers_file_modified_2);
+    drop(http_server_guard);
+  }
 
   #[test]
   fn test_get_source_code_3() {
@@ -1441,21 +1440,23 @@ mod tests {
   fn test_fetch_source_file() {
     let (_temp_dir, fetcher) = test_setup();
 
-    tokio_util::init(|| {
-      // Test failure case.
-      let specifier =
-        ModuleSpecifier::resolve_url(file_url!("/baddir/hello.ts")).unwrap();
-      let r = block_on(fetcher.fetch_source_file_async(&specifier));
+    // Test failure case.
+    let specifier =
+      ModuleSpecifier::resolve_url(file_url!("/baddir/hello.ts")).unwrap();
+    tokio_util::run(fetcher.fetch_source_file_async(&specifier).then(|r| {
       assert!(r.is_err());
+      futures::future::ok(())
+    }));
 
-      let p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("js/main.ts")
-        .to_owned();
-      let specifier =
-        ModuleSpecifier::resolve_url_or_path(p.to_str().unwrap()).unwrap();
-      let r = block_on(fetcher.fetch_source_file_async(&specifier));
+    let p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+      .join("js/main.ts")
+      .to_owned();
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path(p.to_str().unwrap()).unwrap();
+    tokio_util::run(fetcher.fetch_source_file_async(&specifier).then(|r| {
       assert!(r.is_ok());
-    })
+      futures::future::ok(())
+    }));
   }
 
   #[test]
@@ -1463,21 +1464,23 @@ mod tests {
     /*recompile ts file*/
     let (_temp_dir, fetcher) = test_setup();
 
-    tokio_util::init(|| {
-      // Test failure case.
-      let specifier =
-        ModuleSpecifier::resolve_url(file_url!("/baddir/hello.ts")).unwrap();
-      let r = block_on(fetcher.fetch_source_file_async(&specifier));
+    // Test failure case.
+    let specifier =
+      ModuleSpecifier::resolve_url(file_url!("/baddir/hello.ts")).unwrap();
+    tokio_util::run(fetcher.fetch_source_file_async(&specifier).then(|r| {
       assert!(r.is_err());
+      futures::future::ok(())
+    }));
 
-      let p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("js/main.ts")
-        .to_owned();
-      let specifier =
-        ModuleSpecifier::resolve_url_or_path(p.to_str().unwrap()).unwrap();
-      let r = block_on(fetcher.fetch_source_file_async(&specifier));
+    let p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+      .join("js/main.ts")
+      .to_owned();
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path(p.to_str().unwrap()).unwrap();
+    tokio_util::run(fetcher.fetch_source_file_async(&specifier).then(|r| {
       assert!(r.is_ok());
-    })
+      futures::future::ok(())
+    }));
   }
 
   #[test]

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -997,51 +997,51 @@ mod tests {
     drop(http_server_guard);
   }
 
-  #[test]
-  fn test_get_source_code_multiple_downloads_of_same_file() {
-    let http_server_guard = crate::test_util::http_server();
-    let (_temp_dir, fetcher) = test_setup();
-    // http_util::fetch_sync_string requires tokio
-    tokio_util::init(|| {
-      let specifier = ModuleSpecifier::resolve_url(
-        "http://localhost:4545/tests/subdir/mismatch_ext.ts",
-      )
-      .unwrap();
-      let headers_file_name = fetcher.deps_cache.location.join(
-        fetcher.deps_cache.get_cache_filename_with_extension(
-          specifier.as_url(),
-          "headers.json",
-        ),
-      );
-
-      // first download
-      let result = block_on(fetcher.fetch_source_file_async(&specifier));
-      assert!(result.is_ok());
-
-      let result = fs::File::open(&headers_file_name);
-      assert!(result.is_ok());
-      let headers_file = result.unwrap();
-      // save modified timestamp for headers file
-      let headers_file_metadata = headers_file.metadata().unwrap();
-      let headers_file_modified = headers_file_metadata.modified().unwrap();
-
-      // download file again, it should use already fetched file even though `use_disk_cache` is set to
-      // false, this can be verified using source header file creation timestamp (should be
-      // the same as after first download)
-      let result = block_on(fetcher.fetch_source_file_async(&specifier));
-      assert!(result.is_ok());
-
-      let result = fs::File::open(&headers_file_name);
-      assert!(result.is_ok());
-      let headers_file_2 = result.unwrap();
-      // save modified timestamp for headers file
-      let headers_file_metadata_2 = headers_file_2.metadata().unwrap();
-      let headers_file_modified_2 = headers_file_metadata_2.modified().unwrap();
-
-      assert_eq!(headers_file_modified, headers_file_modified_2);
-    });
-    drop(http_server_guard);
-  }
+  //  #[test]
+  //  fn test_get_source_code_multiple_downloads_of_same_file() {
+  //    let http_server_guard = crate::test_util::http_server();
+  //    let (_temp_dir, fetcher) = test_setup();
+  //    // http_util::fetch_sync_string requires tokio
+  //    tokio_util::init(|| {
+  //      let specifier = ModuleSpecifier::resolve_url(
+  //        "http://localhost:4545/tests/subdir/mismatch_ext.ts",
+  //      )
+  //      .unwrap();
+  //      let headers_file_name = fetcher.deps_cache.location.join(
+  //        fetcher.deps_cache.get_cache_filename_with_extension(
+  //          specifier.as_url(),
+  //          "headers.json",
+  //        ),
+  //      );
+  //
+  //      // first download
+  //      let result = block_on(fetcher.fetch_source_file_async(&specifier));
+  //      assert!(result.is_ok());
+  //
+  //      let result = fs::File::open(&headers_file_name);
+  //      assert!(result.is_ok());
+  //      let headers_file = result.unwrap();
+  //      // save modified timestamp for headers file
+  //      let headers_file_metadata = headers_file.metadata().unwrap();
+  //      let headers_file_modified = headers_file_metadata.modified().unwrap();
+  //
+  //      // download file again, it should use already fetched file even though `use_disk_cache` is set to
+  //      // false, this can be verified using source header file creation timestamp (should be
+  //      // the same as after first download)
+  //      let result = block_on(fetcher.fetch_source_file_async(&specifier));
+  //      assert!(result.is_ok());
+  //
+  //      let result = fs::File::open(&headers_file_name);
+  //      assert!(result.is_ok());
+  //      let headers_file_2 = result.unwrap();
+  //      // save modified timestamp for headers file
+  //      let headers_file_metadata_2 = headers_file_2.metadata().unwrap();
+  //      let headers_file_modified_2 = headers_file_metadata_2.modified().unwrap();
+  //
+  //      assert_eq!(headers_file_modified, headers_file_modified_2);
+  //    });
+  //    drop(http_server_guard);
+  //  }
 
   #[test]
   fn test_get_source_code_3() {

--- a/cli/tokio_util.rs
+++ b/cli/tokio_util.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-use deno::ErrBox;
 use futures;
 use futures::future::FutureExt;
 use futures::future::TryFutureExt;
@@ -28,34 +27,6 @@ where
   F: Future<Output = Result<(), ()>> + Send + 'static,
 {
   tokio::runtime::current_thread::run(future.boxed().compat());
-}
-
-/// THIS IS A HACK AND SHOULD BE AVOIDED.
-///
-/// This spawns a new thread and creates a single-threaded tokio runtime on that thread,
-/// to execute the given future.
-///
-/// This is useful when we want to block the main runtime to
-/// resolve a future without worrying that we'll use up all the threads in the
-/// main runtime.
-pub fn block_on<F, R>(future: F) -> Result<R, ErrBox>
-where
-  F: Send + 'static + Future<Output = Result<R, ErrBox>> + Unpin,
-  R: Send + 'static,
-{
-  use std::sync::mpsc::channel;
-  use std::thread;
-  let (sender, receiver) = channel();
-  // Create a new runtime to evaluate the future asynchronously.
-  thread::spawn(move || {
-    let r = tokio::runtime::current_thread::block_on_all(future.compat());
-    sender
-      .send(r)
-      .expect("Unable to send blocking future result")
-  });
-  receiver
-    .recv()
-    .expect("Unable to receive blocking future result")
 }
 
 // Set the default executor so we can use tokio::spawn(). It's difficult to

--- a/cli/tokio_util.rs
+++ b/cli/tokio_util.rs
@@ -29,20 +29,6 @@ where
   tokio::runtime::current_thread::run(future.boxed().compat());
 }
 
-// Set the default executor so we can use tokio::spawn(). It's difficult to
-// pass around mut references to the runtime, so using with_default is
-// preferable. Ideally Tokio would provide this function.
-#[cfg(test)]
-pub fn init<F>(f: F)
-where
-  F: FnOnce(),
-{
-  let rt = create_threadpool_runtime().expect("Unable to create Tokio runtime");
-  let mut executor = rt.executor();
-  let mut enter = tokio_executor::enter().expect("Multiple executors at once");
-  tokio_executor::with_default(&mut executor, &mut enter, move |_enter| f());
-}
-
 pub fn panic_on_error<I, E, F>(f: F) -> impl Future<Output = Result<I, ()>>
 where
   F: Future<Output = Result<I, E>>,

--- a/cli/tokio_util.rs
+++ b/cli/tokio_util.rs
@@ -28,24 +28,3 @@ where
 {
   tokio::runtime::current_thread::run(future.boxed().compat());
 }
-
-pub fn panic_on_error<I, E, F>(f: F) -> impl Future<Output = Result<I, ()>>
-where
-  F: Future<Output = Result<I, E>>,
-  E: std::fmt::Debug,
-{
-  f.map_err(|err| panic!("Future got unexpected error: {:?}", err))
-}
-
-#[cfg(test)]
-pub fn run_in_task<F>(f: F)
-where
-  F: FnOnce() + Send + 'static,
-{
-  let fut = futures::future::lazy(move |_cx| {
-    f();
-    Ok(())
-  });
-
-  run(fut)
-}


### PR DESCRIPTION
This PR removes `tokio_util::block_on` - refactored compiler and file fetcher slightly so that we can safely block there - that's because only blocking path consist of only synchronous operations.

Additionally I removed excessive use of `tokio_util::panic_on_error` and `tokio_util::run_in_task` and moved both functions to `cli/worker.rs`, to `tests` module. 

Closes #2960