### PR TITLE
[WIP] async worker module loading

### DIFF
--- a/cli/js/workers.ts
+++ b/cli/js/workers.ts
@@ -159,6 +159,11 @@ export class WorkerImpl implements Worker {
       sourceCode
     );
     this.run();
+    // TODO: this is private method and should be rewritten
+    // like so:
+    // - in run poll for worker being ready
+    // - `isClosing` should be set to true when we receive null message - signalizing channel was closed
+    // - `isClosedPromise` could be then removed :))
     this.isClosedPromise = hostGetWorkerClosed(this.id);
     this.isClosedPromise.then((): void => {
       this.isClosing = true;

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -246,10 +246,12 @@ itest!(_026_redirect_javascript {
   http_server: true,
 });
 
+/* TODO(bartlomieju): reenable
 itest!(_026_workers {
   args: "run --reload 026_workers.ts",
   output: "026_workers.ts.out",
 });
+*/
 
 itest!(_027_redirect_typescript {
   args: "run --reload 027_redirect_typescript.ts",

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -246,12 +246,11 @@ itest!(_026_redirect_javascript {
   http_server: true,
 });
 
-/* TODO(bartlomieju): reenable
 itest!(_026_workers {
   args: "run --reload 026_workers.ts",
   output: "026_workers.ts.out",
+  check_stderr: true,
 });
-*/
 
 itest!(_027_redirect_typescript {
   args: "run --reload 027_redirect_typescript.ts",


### PR DESCRIPTION
Prototype for asynchronous module loading for workers. 

With this patch you can run multiple workers on single-threaded runtime (`--current-thread`)