### PR TITLE
Elevate DenoPermissions lock to top level

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -229,7 +229,7 @@ impl TsCompiler {
   fn setup_worker(global_state: ThreadSafeGlobalState) -> Worker {
     let (int, ext) = ThreadSafeState::create_channels();
     let worker_state =
-      ThreadSafeState::new(global_state.clone(), None, true, int)
+      ThreadSafeState::new(global_state.clone(), None, None, true, int)
         .expect("Unable to create worker state");
 
     // Count how many times we start the compiler worker.

--- a/cli/compilers/wasm.rs
+++ b/cli/compilers/wasm.rs
@@ -47,7 +47,7 @@ impl WasmCompiler {
   fn setup_worker(global_state: ThreadSafeGlobalState) -> Worker {
     let (int, ext) = ThreadSafeState::create_channels();
     let worker_state =
-      ThreadSafeState::new(global_state.clone(), None, true, int)
+      ThreadSafeState::new(global_state.clone(), None, None, true, int)
         .expect("Unable to create worker state");
 
     // Count how many times we start the compiler worker.

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -118,6 +118,7 @@ fn create_worker_and_state(
   let (int, ext) = ThreadSafeState::create_channels();
   let state = ThreadSafeState::new(
     global_state.clone(),
+    None,
     global_state.main_module.clone(),
     true,
     int,

--- a/cli/ops/timers.rs
+++ b/cli/ops/timers.rs
@@ -66,11 +66,12 @@ fn op_now(
   let seconds = state.start_time.elapsed().as_secs();
   let mut subsec_nanos = state.start_time.elapsed().subsec_nanos();
   let reduced_time_precision = 2_000_000; // 2ms in nanoseconds
+  let permissions = state.permissions.lock().unwrap();
 
   // If the permission is not enabled
   // Round the nano result on 2 milliseconds
   // see: https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp#Reduced_time_precision
-  if !state.permissions.allow_hrtime.is_allow() {
+  if !permissions.allow_hrtime.is_allow() {
     subsec_nanos -= subsec_nanos % reduced_time_precision
   }
 

--- a/cli/ops/workers.rs
+++ b/cli/ops/workers.rs
@@ -142,10 +142,13 @@ fn op_create_worker(
   let (int, ext) = ThreadSafeState::create_channels();
   let child_state = ThreadSafeState::new(
     state.global_state.clone(),
+    Some(parent_state.permissions.clone()), // by default share with parent
     Some(module_specifier.clone()),
     include_deno_namespace,
     int,
   )?;
+  // TODO: add a new option to make child worker not sharing permissions
+  // with parent (aka .clone(), requests from child won't reflect in parent)
   let name = format!("USER-WORKER-{}", specifier);
   let deno_main_call = format!("denoMain({})", include_deno_namespace);
   let mut worker =

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -248,6 +248,7 @@ mod tests {
     let (int, ext) = ThreadSafeState::create_channels();
     let state = ThreadSafeState::new(
       global_state,
+      None,
       Some(module_specifier.clone()),
       true,
       int,
@@ -288,6 +289,7 @@ mod tests {
     let (int, ext) = ThreadSafeState::create_channels();
     let state = ThreadSafeState::new(
       global_state,
+      None,
       Some(module_specifier.clone()),
       true,
       int,
@@ -331,6 +333,7 @@ mod tests {
     let (int, ext) = ThreadSafeState::create_channels();
     let state = ThreadSafeState::new(
       global_state.clone(),
+      None,
       Some(module_specifier.clone()),
       true,
       int,


### PR DESCRIPTION
+ Remove independent per detailed state atomics
+ Wrap `DenoPermissions` in `Arc<Mutex<...>>` instead
+ Add argument `shared_permissions` to allow passing down a `Arc<Mutex<DenoPermissions>>` to share with another state

This refactoring is to allow cloning permissions easier. The general idea is to separate the below behaviors in the future:
+ Worker copies permissions from global
+ Worker inherit permissions from parent, updating one of which is reflected to another
+ Worker copies permissions from parent, but future updates on either side are not reflected
+ Worker copies partial permissions or no permissions from parent

cc @bartlomieju @afinch7 