### PR TITLE
std: add ignore parser for std/prettier

### DIFF
--- a/std/prettier/ignore.ts
+++ b/std/prettier/ignore.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
 /**
- * Parse the contents of the ignore file and return partterns.
+ * Parse the contents of the ignore file and return patterns.
  * It can parse files like .gitignore/.npmignore/.prettierignore
  * @param ignoreString
- * @returns partterns
+ * @returns patterns
  */
 export function parse(ignoreString: string): Set<string> {
   const partterns = ignoreString

--- a/std/prettier/ignore.ts
+++ b/std/prettier/ignore.ts
@@ -1,0 +1,15 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Parse the contents of the ignore file and return partterns.
+ * It can parse files like .gitignore/.npmignore/.prettierignore
+ * @param ignoreString
+ * @returns partterns
+ */
+export function parse(ignoreString: string): Set<string> {
+  const partterns = ignoreString
+    .split(/\r?\n/)
+    .filter(line => line.trim() !== "" && line.charAt(0) !== "#");
+
+  return new Set(partterns);
+}

--- a/std/prettier/ignore_test.ts
+++ b/std/prettier/ignore_test.ts
@@ -1,0 +1,81 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { test, runIfMain } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./ignore.ts";
+
+const testCases = [
+  {
+    input: `# this is a comment
+node_modules
+`,
+    output: new Set(["node_modules"])
+  },
+  {
+    input: ` # invalid comment
+`,
+    output: new Set([" # invalid comment"])
+  },
+  {
+    input: `
+node_modules
+package.json
+`,
+    output: new Set(["node_modules", "package.json"])
+  },
+  {
+    input: `
+    node_modules
+    package.json
+`,
+    output: new Set(["    node_modules", "    package.json"])
+  },
+  {
+    input: `*.orig
+*.pyc
+*.swp
+
+/.idea/
+/.vscode/
+gclient_config.py_entries
+/gh-pages/
+/target/
+
+# Files that help ensure VSCode can work but we don't want checked into the
+# repo
+/node_modules
+/tsconfig.json
+
+# We use something stronger than lockfiles, we have all NPM modules stored in a
+# git. We do not download from NPM during build.
+# https://github.com/denoland/deno_third_party
+yarn.lock
+# yarn creates this in error.
+tools/node_modules/
+    `,
+    output: new Set([
+      "*.orig",
+      "*.pyc",
+      "*.swp",
+      "/.idea/",
+      "/.vscode/",
+      "gclient_config.py_entries",
+      "/gh-pages/",
+      "/target/",
+      "/node_modules",
+      "/tsconfig.json",
+      "yarn.lock",
+      "tools/node_modules/"
+    ])
+  }
+];
+
+test({
+  name: "[encoding.ignore] basic",
+  fn(): void {
+    for (const { input, output } of testCases) {
+      assertEquals(parse(input), output);
+    }
+  }
+});
+
+runIfMain(import.meta);


### PR DESCRIPTION
ignore parser to parse ignore files like `.gitignore`/`.npmignore`/`.prettierignore`

Because it parses `.prettierignore` in the std/prettier

https://github.com/denoland/deno/blob/c6bb3d5a10ba8acceadcaa66050abcaefb7bc0bb/std/prettier/main.ts#L479-L486

so I think it can be isolated