### PR TITLE
ops/fs: Add Deno.realpath

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -56,6 +56,7 @@ export { chownSync, chown } from "./chown.ts";
 export { utimeSync, utime } from "./utime.ts";
 export { removeSync, remove, RemoveOption } from "./remove.ts";
 export { renameSync, rename } from "./rename.ts";
+export { realpathSync, realpath } from "./realpath.ts";
 export { readFileSync, readFile } from "./read_file.ts";
 export { readDirSync, readDir } from "./read_dir.ts";
 export { copyFileSync, copyFile } from "./copy_file.ts";

--- a/cli/js/dispatch.ts
+++ b/cli/js/dispatch.ts
@@ -55,6 +55,7 @@ export let OP_CHOWN: number;
 export let OP_REMOVE: number;
 export let OP_COPY_FILE: number;
 export let OP_STAT: number;
+export let OP_REALPATH: number;
 export let OP_READ_DIR: number;
 export let OP_RENAME: number;
 export let OP_LINK: number;
@@ -97,6 +98,7 @@ export function asyncMsgFromRust(opId: number, ui8: Uint8Array): void {
     case OP_REMOVE:
     case OP_COPY_FILE:
     case OP_STAT:
+    case OP_REALPATH:
     case OP_READ_DIR:
     case OP_RENAME:
     case OP_LINK:

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -605,6 +605,21 @@ declare namespace Deno {
     isSymlink(): boolean;
   }
 
+  // @url js/realpath.d.ts
+
+  /** Returns absolute normalized path with symbolic links resolved
+   * synchronously.
+   *
+   *       const realPath = Deno.realpathSync("./some/path");
+   */
+  export function realpathSync(path: string): string;
+
+  /** Returns absolute normalized path with symbolic links resolved.
+   *
+   *       const realPath = await Deno.realpath("./some/path");
+   */
+  export function realpath(path: string): Promise<string>;
+
   // @url js/read_dir.d.ts
 
   /** Reads the directory given by path and returns a list of file info

--- a/cli/js/realpath.ts
+++ b/cli/js/realpath.ts
@@ -1,0 +1,19 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { sendSync, sendAsync } from "./dispatch_json.ts";
+import * as dispatch from "./dispatch.ts";
+
+/** Returns absolute normalized path with symbolic links resolved synchronously.
+ *
+ *       const realPath = Deno.realpathSync("./some/path");
+ */
+export function realpathSync(path: string): string {
+  return sendSync(dispatch.OP_REALPATH, { path });
+}
+
+/** Returns absolute normalized path with symbolic links resolved.
+ *
+ *       const realPath = await Deno.realpath("./some/path");
+ */
+export async function realpath(path: string): Promise<string> {
+  return await sendAsync(dispatch.OP_REALPATH, { path });
+}

--- a/cli/js/unit_tests.ts
+++ b/cli/js/unit_tests.ts
@@ -33,6 +33,7 @@ import "./mkdir_test.ts";
 import "./net_test.ts";
 import "./os_test.ts";
 import "./process_test.ts";
+import "./realpath_test.ts";
 import "./read_dir_test.ts";
 import "./read_file_test.ts";
 import "./read_link_test.ts";


### PR DESCRIPTION
Basically just `std::fs::canonicalize`. Noticed that we did not have this binding when I worked on `require` polyfill.

Our API names seems growing a bit inconsistent, with `readlink` vs `readDir` vs `mkdir` vs `makeTempDir`. We might need to do some renaming.