### PR TITLE
deno core: bump Tokio, use Tokio Mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2247,7 +2247,7 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
-"checksum tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5f74af90f3137ddcda0750d904390b289793c40fce7b6e94600b367533205d8"
+"checksum tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "beeef686ef92a222de07e089f455d9f8478bbba9651718f9e4b276babe829082"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,4 +28,4 @@ path = "examples/http_bench.rs"
 
 # tokio is only used for deno_core_http_bench
 [dev_dependencies]
-tokio = { version = "0.2.0", features = ["full"] }
+tokio = { version = "0.2.1", features = ["full"] }


### PR DESCRIPTION
Follow up #3408

Replace `std::sync::Mutex` with Tokio version of Mutex. I almost got it to a point I'm satisfied, sans this bit:
```rust
let fut = async move {
    let mut table = lock_resource_table().await;
    let stream = table.get_mut::<TcpStream>(rid).ok_or_else(bad_resource)?;
    // I'd prefer to do stream.0.write(&zero_copy_buf).await? but it seems
    // `PinnedBuf` does not implement Sync for its fields.
    // (error: `std::ptr::NonNull<u8>` cannot be shared between threads safely)
    // It's strange because `stream.read().await` works fine /shrug
    let write_fut = poll_fn(move |cx| {
      let pinned_stream = Pin::new(&mut stream.0);
      pinned_stream.poll_write(cx, &zero_copy_buf)
    });
    let nwritten = write_fut.await?;
    debug!("write success {}", nwritten);
    Ok(nwritten as i32)
  };
```
It'd be preferable to write it as `stream.0.write(&zero_copy_buf)` but I'm having problems as described above.