### PR TITLE
synchronize deno and deno_std versions

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -13,7 +13,12 @@ macro_rules! svec {
 
 macro_rules! std_url {
   ($x:expr) => {
-    concat!("https://deno.land/std@v0.23.0/", $x)
+    concat!(
+      "https://deno.land/std@v",
+      env!("CARGO_PKG_VERSION"),
+      "/",
+      $x
+    )
   };
 }
 


### PR DESCRIPTION
close: #3410 
close: #3320 (Should it be close?)
close: #3395 

Keep deno and std versions consistent