### PR TITLE
refactor: remove duplicated argv member from ThreadSafeGlobalState

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -63,6 +63,8 @@ impl Default for DenoSubcommand {
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct DenoFlags {
+  /// Vector of CLI arguments - these are user script arguments, all Deno
+  /// specific flags are removed.
   pub argv: Vec<String>,
   pub subcommand: DenoSubcommand,
 

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -110,9 +110,7 @@ fn create_worker_and_state(
     }
   });
 
-  // TODO(ry) Remove argv param from ThreadSafeGlobalState::new.
-  let argv = flags.argv.clone();
-  let global_state = ThreadSafeGlobalState::new(flags, argv, progress)
+  let global_state = ThreadSafeGlobalState::new(flags, progress)
     .map_err(deno_error::print_err_and_exit)
     .unwrap();
 
@@ -297,8 +295,8 @@ fn fetch_command(flags: DenoFlags) {
 }
 
 fn eval_command(flags: DenoFlags) {
-  let (mut worker, state) = create_worker_and_state(flags);
-  let ts_source = state.argv[1].clone();
+  let ts_source = flags.argv[1].clone();
+  let (mut worker, _state) = create_worker_and_state(flags);
   // Force TypeScript compile.
   let main_module =
     ModuleSpecifier::resolve_url_or_path("./__$deno$eval.ts").unwrap();

--- a/cli/ops/os.rs
+++ b/cli/ops/os.rs
@@ -44,7 +44,7 @@ fn op_start(
   Ok(JsonOp::Sync(json!({
     "cwd": deno_fs::normalize_path(&env::current_dir().unwrap()),
     "pid": std::process::id(),
-    "argv": gs.argv,
+    "argv": gs.flags.argv,
     "mainModule": gs.main_module.as_ref().map(|x| x.to_string()),
     "debugFlag": gs.flags.log_level.map_or(false, |l| l == log::Level::Debug),
     "versionFlag": gs.flags.version,

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -200,7 +200,6 @@ impl Future for WorkerReceiver {
 mod tests {
   use super::*;
   use crate::flags;
-  use crate::flags::DenoFlags;
   use crate::global_state::ThreadSafeGlobalState;
   use crate::progress::Progress;
   use crate::startup_data;
@@ -238,10 +237,11 @@ mod tests {
       .to_owned();
     let module_specifier =
       ModuleSpecifier::resolve_url_or_path(&p.to_string_lossy()).unwrap();
-    let argv = vec![String::from("./deno"), module_specifier.to_string()];
     let global_state = ThreadSafeGlobalState::new(
-      flags::DenoFlags::default(),
-      argv,
+      flags::DenoFlags {
+        argv: vec![String::from("./deno"), module_specifier.to_string()],
+        ..flags::DenoFlags::default()
+      },
       Progress::new(),
     )
     .unwrap();
@@ -282,10 +282,14 @@ mod tests {
       .to_owned();
     let module_specifier =
       ModuleSpecifier::resolve_url_or_path(&p.to_string_lossy()).unwrap();
-    let argv = vec![String::from("deno"), module_specifier.to_string()];
-    let global_state =
-      ThreadSafeGlobalState::new(DenoFlags::default(), argv, Progress::new())
-        .unwrap();
+    let global_state = ThreadSafeGlobalState::new(
+      flags::DenoFlags {
+        argv: vec![String::from("deno"), module_specifier.to_string()],
+        ..flags::DenoFlags::default()
+      },
+      Progress::new(),
+    )
+    .unwrap();
     let (int, ext) = ThreadSafeState::create_channels();
     let state = ThreadSafeState::new(
       global_state,
@@ -325,11 +329,11 @@ mod tests {
       .to_owned();
     let module_specifier =
       ModuleSpecifier::resolve_url_or_path(&p.to_string_lossy()).unwrap();
-    let argv = vec![String::from("deno"), module_specifier.to_string()];
     let mut flags = flags::DenoFlags::default();
+    flags.argv = vec![String::from("deno"), module_specifier.to_string()];
     flags.reload = true;
     let global_state =
-      ThreadSafeGlobalState::new(flags, argv, Progress::new()).unwrap();
+      ThreadSafeGlobalState::new(flags, Progress::new()).unwrap();
     let (int, ext) = ThreadSafeState::create_channels();
     let state = ThreadSafeState::new(
       global_state.clone(),


### PR DESCRIPTION
Continuation of work from #3389
