### PR TITLE
fix depot_tools on macOS Catalina by upgrading it to 23247b9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,14 @@ jobs:
           python-version: "2.7.16"
           architecture: x64
 
+      - name: Remove unused versions of Python
+        if: startsWith(matrix.os, 'windows')
+        run: |-
+          $env:PATH -split ";" |
+            Where-Object { Test-Path "$_\python.exe" } |
+            Select-Object -Skip 1 |
+            ForEach-Object { Move-Item "$_" "$_.disabled" }
+
       - name: Environment (common)
         run: |
           echo ::set-env name=GH_ACTIONS::1

--- a/tools/gclient_config.py
+++ b/tools/gclient_config.py
@@ -26,7 +26,7 @@ solutions = [
     },
     {
         'url':
-        'https://chromium.googlesource.com/chromium/tools/depot_tools@efce0d1b7657c440c90f0f4bce614b96672b9e0b',
+        'https://chromium.googlesource.com/chromium/tools/depot_tools@23247b99321549c24e62ad45200409419423695d',
         'name':
         'depot_tools'
     },


### PR DESCRIPTION
The macOS Catalina fix floated over `third_party/depot_tools` in https://github.com/denoland/deno_third_party/commit/818d33a13b06c4863b0ddc20e89d35715c35b37c got accidentally reverted in the v8 7.9.317.12 upgrade in https://github.com/denoland/deno_third_party/commit/cab4821cd937dd3c927430f0f0e05a38af1b84a0#diff-452661d791c32d03de51b6ef4c687bf1L47-R47. This breaks running `./tools/setup.py` on a fresh clone on macOS Catalina again.

This PR finally fixes the issue by doing the full `depot_tools` upgrade to `23247b9` (the version used in v8 8.0). It also ports the required Windows virtualenv fixes from https://github.com/denoland/rusty_v8/commit/7dbde4e6fba6c7653a16d9b0737d313a7f6c1d1e#diff-e9f950f17198d3d5e3122a44230a09b9R33-R46 to the CI workflow, which prevented the upgrade the last time we tried it here in #3438.

Refs: https://github.com/denoland/deno_third_party/pull/58
Fixes: #3440
Fixes: #3153 

BTW: Also `+4,311 −9,830` in `third_party` looks nice, however the virtualenv setup on Windows add a couple of seconds to the `setup.py`-step execution time.