### PR TITLE
Revert "Synchronize deno and deno_std versions"

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -22,12 +22,7 @@ macro_rules! sset {
 
 macro_rules! std_url {
   ($x:expr) => {
-    concat!(
-      "https://deno.land/std@v",
-      env!("CARGO_PKG_VERSION"),
-      "/",
-      $x
-    )
+    concat!("https://deno.land/std@v0.23.0/", $x)
   };
 }
 

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -22,7 +22,7 @@ macro_rules! sset {
 
 macro_rules! std_url {
   ($x:expr) => {
-    concat!("https://deno.land/std@v0.25.0/", $x)
+    concat!("https://deno.land/std@v0.23.0/", $x)
   };
 }
 

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -22,7 +22,7 @@ macro_rules! sset {
 
 macro_rules! std_url {
   ($x:expr) => {
-    concat!("https://deno.land/std@v0.23.0/", $x)
+    concat!("https://deno.land/std@v0.25.0/", $x)
   };
 }
 


### PR DESCRIPTION
This change is preventing the release of v0.26.0 because it during the bump commit the URL https://deno.land/std@v0.26.0/ does not yet exist. We need to solve this some other way. For now I will just update the links to v0.25.0 so I can get the release out.

Ref https://github.com/denoland/deno/pull/3445
Ref #3415
cc @axetroy 