### PR TITLE
fix: isolate tests

### DIFF
--- a/core/modules.rs
+++ b/core/modules.rs
@@ -626,7 +626,7 @@ mod tests {
   impl MockLoader {
     fn new() -> Self {
       let modules = Modules::new();
-      let (isolate, _dispatch_count) = setup(Mode::AsyncImmediate);
+      let (isolate, _dispatch_count) = setup(Mode::Async);
       Self {
         loads: Arc::new(Mutex::new(Vec::new())),
         isolate: Arc::new(Mutex::new(isolate)),


### PR DESCRIPTION
Fixes Isolate tests as pointed by @kevinkassimo in Gitter.

I screwed it up during #3358 and #3434 because I used `pool.spawn_ok` which doesn't panic on errors.

