### PR TITLE
Remove v8-options from manual, add v8-flags example

### DIFF
--- a/std/manual.md
+++ b/std/manual.md
@@ -764,9 +764,15 @@ source /usr/local/etc/bash_completion.d/deno.bash
 
 ### V8 flags
 
-V8 has many many internal command-line flags, that you can see with
-`--v8-options`.
-[It looks like this.](https://gist.github.com/ry/a610ce48cba2f0225f9c81a5a833fc87)
+V8 has many many internal command-line flags.
+
+```shell
+# list available v8 flags
+$ deno --v8-flags=--help
+
+#  example for applying multiple flags
+$ deno --v8-flags=--expose-gc,--use-strict
+```
 
 Particularly useful ones:
 


### PR DESCRIPTION
fixes the manual for: https://github.com/denoland/deno/pull/3389

removed the gist link https://gist.github.com/ry/a610ce48cba2f0225f9c81a5a833fc87 as it points to something else.

took me a while to figure out on how to apply an option or multiple options, since there is no feedback when applied wrong.

```shell
$ deno --v8-flags=foo-bar  # no error
$ deno --v8-flags=--foo-bar  # no error
```

