### PR TITLE
std: add `dispatch_json` tooling for plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_dispatch_json"
+version = "0.1.0"
+dependencies = [
+ "deno_core 0.28.1",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "deno_typescript"
 version = "0.28.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
   "core",
   "tools/hyper_hello",
   "deno_typescript",
-  "test_plugin"
+  "test_plugin",
+  "std/plugins/dispatch_json"
 ]

--- a/std/plugins/dispatch_json/Cargo.toml
+++ b/std/plugins/dispatch_json/Cargo.toml
@@ -1,0 +1,19 @@
+# Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+[package]
+name = "deno_dispatch_json"
+version = "0.1.0"
+authors = ["afinch7 <andyfinch7@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+deno_core = { path = "../../../core" }
+futures = { version = "0.3" }
+log = "0.4.8"
+serde = { version = "1.0.102", features = ["derive"] }
+serde_derive = "1.0.102"
+serde_json = { version = "1.0.41", features = [ "preserve_order" ] }

--- a/std/plugins/dispatch_json/lib.rs
+++ b/std/plugins/dispatch_json/lib.rs
@@ -1,0 +1,94 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+#[macro_use]
+extern crate log;
+
+use deno_core::*;
+use futures::future::FutureExt;
+pub use serde_derive::Deserialize;
+use serde_json::json;
+pub use serde_json::Value;
+use std::future::Future;
+use std::pin::Pin;
+
+pub type AsyncJsonOp =
+  Pin<Box<dyn Future<Output = Result<Value, ErrBox>> + Send>>;
+
+pub enum JsonOp {
+  Sync(Value),
+  Async(AsyncJsonOp),
+}
+
+fn json_err(err: ErrBox) -> Value {
+  json!({
+      "message": err.to_string(),
+  })
+}
+
+fn serialize_result(
+  promise_id: Option<u64>,
+  result: Result<Value, ErrBox>,
+) -> Buf {
+  let value = match result {
+    Ok(v) => json!({ "ok": v, "promiseId": promise_id }),
+    Err(err) => json!({ "err": json_err(err), "promiseId": promise_id }),
+  };
+  let mut vec = serde_json::to_vec(&value).unwrap();
+  debug!("JSON response pre-align, len={}", vec.len());
+  // Align to 32bit word, padding with the space character.
+  vec.resize((vec.len() + 3usize) & !3usize, b' ');
+  vec.into_boxed_slice()
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AsyncArgs {
+  promise_id: Option<u64>,
+}
+
+pub fn json_op(
+  d: Box<
+    dyn Fn(Value, Option<PinnedBuf>) -> Result<JsonOp, ErrBox>
+      + Send
+      + Sync
+      + 'static,
+  >,
+) -> Box<dyn Fn(&[u8], Option<PinnedBuf>) -> CoreOp + Send + Sync + 'static> {
+  Box::new(move |control: &[u8], zero_copy: Option<PinnedBuf>| {
+    let async_args: AsyncArgs = match serde_json::from_slice(control) {
+      Ok(args) => args,
+      Err(e) => {
+        let buf = serialize_result(None, Err(ErrBox::from(e)));
+        return CoreOp::Sync(buf);
+      }
+    };
+    let promise_id = async_args.promise_id;
+    let is_sync = promise_id.is_none();
+
+    let result = serde_json::from_slice(control)
+      .map_err(ErrBox::from)
+      .and_then(|args| d(args, zero_copy));
+
+    // Convert to CoreOp
+    match result {
+      Ok(JsonOp::Sync(sync_value)) => {
+        assert!(promise_id.is_none());
+        CoreOp::Sync(serialize_result(promise_id, Ok(sync_value)))
+      }
+      Ok(JsonOp::Async(fut)) => {
+        assert!(promise_id.is_some());
+        let fut2 = fut.then(move |result| {
+          futures::future::ok(serialize_result(promise_id, result))
+        });
+        CoreOp::Async(fut2.boxed())
+      }
+      Err(sync_err) => {
+        let buf = serialize_result(promise_id, Err(sync_err));
+        if is_sync {
+          CoreOp::Sync(buf)
+        } else {
+          CoreOp::Async(futures::future::ok(buf).boxed())
+        }
+      }
+    }
+  })
+}

--- a/std/plugins/dispatch_json/mod.ts
+++ b/std/plugins/dispatch_json/mod.ts
@@ -85,3 +85,7 @@ export class DispatchJsonPluginOp {
     return unwrapResponse(res);
   }
 }
+
+export function jsonOp(op: Deno.PluginOp): DispatchJsonPluginOp {
+  return new DispatchJsonPluginOp(op);
+}

--- a/std/plugins/dispatch_json/mod.ts
+++ b/std/plugins/dispatch_json/mod.ts
@@ -1,0 +1,87 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { assert } from "../../testing/asserts.ts";
+import { Deferred, deferred } from "../../util/async.ts";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Ok = any;
+
+interface JsonError {
+  message: string;
+}
+
+interface JsonResponse {
+  ok?: Ok;
+  err?: JsonError;
+  promiseId?: number; // Only present in async messages.
+}
+
+function decode(ui8: Uint8Array): JsonResponse {
+  const s = new TextDecoder().decode(ui8);
+  return JSON.parse(s) as JsonResponse;
+}
+
+function encode(args: object): Uint8Array {
+  const s = JSON.stringify(args);
+  return new TextEncoder().encode(s);
+}
+
+function unwrapResponse(res: JsonResponse): Ok {
+  if (res.err != null) {
+    throw new Error(res.err!.message);
+  }
+  assert(res.ok != null);
+  return res.ok;
+}
+
+export class DispatchJsonPluginOp {
+  private readonly promiseTable = new Map<number, Deferred<JsonResponse>>();
+  private _nextPromiseId = 1;
+
+  constructor(private readonly pluginOp: Deno.PluginOp) {
+    pluginOp.setAsyncHandler(resUi8 => this.handleAsync(resUi8));
+  }
+
+  private nextPromiseId(): number {
+    return this._nextPromiseId++;
+  }
+
+  private handleAsync(resUi8: Uint8Array): void {
+    const res = decode(resUi8);
+    assert(res.promiseId != null);
+
+    const promise = this.promiseTable.get(res.promiseId!);
+    assert(promise != null);
+    this.promiseTable.delete(res.promiseId!);
+    promise.resolve(res);
+  }
+
+  dispatchSync(args: object = {}, zeroCopy?: Uint8Array): Ok {
+    const argsUi8 = encode(args);
+    const resUi8 = this.pluginOp.dispatch(argsUi8, zeroCopy);
+    assert(resUi8 != null);
+
+    const res = decode(resUi8!);
+    assert(res.promiseId == null);
+    return unwrapResponse(res);
+  }
+
+  async dispatchAsync(args: object = {}, zeroCopy?: Uint8Array): Promise<Ok> {
+    const promiseId = this.nextPromiseId();
+    args = Object.assign(args, { promiseId });
+    const promise = deferred<Ok>();
+
+    const argsUi8 = encode(args);
+    const buf = this.pluginOp.dispatch(argsUi8, zeroCopy);
+    if (buf) {
+      // Sync result.
+      const res = decode(buf);
+      promise.resolve(res);
+    } else {
+      // Async result.
+      this.promiseTable.set(promiseId, promise);
+    }
+
+    const res = await promise;
+    return unwrapResponse(res);
+  }
+}

--- a/std/plugins/mod.ts
+++ b/std/plugins/mod.ts
@@ -1,0 +1,2 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+export * from "./plugin_filename.ts";

--- a/std/plugins/mod.ts
+++ b/std/plugins/mod.ts
@@ -1,2 +1,3 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 export * from "./plugin_filename.ts";
+export { DispatchJsonPluginOp } from "./dispatch_json/mod.ts";

--- a/std/plugins/mod.ts
+++ b/std/plugins/mod.ts
@@ -1,3 +1,3 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 export * from "./plugin_filename.ts";
-export { DispatchJsonPluginOp } from "./dispatch_json/mod.ts";
+export { jsonOp, DispatchJsonPluginOp } from "./dispatch_json/mod.ts";

--- a/std/plugins/plugin_filename.ts
+++ b/std/plugins/plugin_filename.ts
@@ -1,0 +1,30 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+export type PluginFilenamePrefixType = "lib" | "";
+
+export const pluginFilenamePrefix = ((): PluginFilenamePrefixType => {
+  switch (Deno.build.os) {
+    case "linux":
+    case "mac":
+      return "lib";
+    case "win":
+    default:
+      return "";
+  }
+})();
+
+export type PluginFilenameExtensionType = "so" | "dylib" | "dll";
+
+export const pluginFilenameExtension = ((): PluginFilenameExtensionType => {
+  switch (Deno.build.os) {
+    case "linux":
+      return "so";
+    case "mac":
+      return "dylib";
+    case "win":
+      return "dll";
+  }
+})();
+
+export function pluginFilename(filenameBase: string): string {
+  return pluginFilenamePrefix + filenameBase + "." + pluginFilenameExtension;
+}

--- a/std/plugins/plugin_filename_test.ts
+++ b/std/plugins/plugin_filename_test.ts
@@ -1,0 +1,22 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { test } from "../testing/mod.ts";
+import { assertEquals, assert } from "../testing/asserts.ts";
+import { pluginFilename } from "./plugin_filename.ts";
+
+test(function filename() {
+  const filename = pluginFilename("someLib_Name");
+  switch (Deno.build.os) {
+    case "linux":
+      assertEquals(filename, "libsomeLib_Name.so");
+      break;
+    case "mac":
+      assertEquals(filename, "libsomeLib_Name.dylib");
+      break;
+    case "win":
+      assertEquals(filename, "someLib_Name.dll");
+      break;
+    default:
+      assert(false);
+      break;
+  }
+});


### PR DESCRIPTION
depends on #3471
This adds a wrapper for plugin ops that functions like `dispatch_json` in cli. Example usage:
lib.rs
``` rust
use deno_dispatch_json::json_op;

pub fn init(cx: &mut dyn PluginInitContext) {
  cx.register_op(
    "someJsonOp",
    Box::new(json_op(op_some_json_op)),
  );
}

init_fn!(init);

fn op_some_json_op(
 args: Value,
  zero_copy: Option<PinnedBuf>,
) -> Result<JsonOp, ErrBox> {
  Ok(JsonOp::Sync(json!({ "field": "value", "return": args })))
}
```
mod.ts
``` TypeScript
import { join } from "https://deno.land/std/path/mod.ts";
import { pluginFilename, DispatchJsonPluginOp } from "https://deno.land/std/plugins/mod.ts";
import { assertEquals } from "https://deno.land/std/testing/asserts.ts";

let url = new URL(import.meta.url);
const path = join(url.pathname, "./target/debug")

const plugin = Deno.openPlugin(
  join(
    buildResult.output_root,
    pluginFilename("some_plugin_name")
  )
);

const someJsonOp = new DispatchJsonPluginOp(plugin.ops.someJsonOp);

// const responseSync = { field: "value", return: { data: "test123" } };
const responseSync = someJsonOp.dispatchSync({ data: "test123" });

const responseAsync = await someJsonOp.dispatchAsync({ data: "test123" });

assertEquals(responseSync, responseAsync);
```

TODO:
- [ ] tests
- [ ] docs
