### PR TITLE
std/http: close connection on .respond() error

### DIFF
--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -590,55 +590,69 @@ test({
   }
 });
 
-test({
-  name: "[http] respond error handling",
-  async fn(): Promise<void> {
-    const connClosedPromise = deferred();
-    const serverRoutine = async (): Promise<void> => {
-      let reqCount = 0;
-      const server = serve(":8124");
-      const serverRid = server.listener["rid"];
-      let connRid = -1;
-      for await (const req of server) {
-        connRid = req.conn.rid;
-        reqCount++;
-        await req.body();
-        await connClosedPromise;
-        try {
-          await req.respond({ body: new TextEncoder().encode("Hello World") });
-          await delay(100);
-          req.done = deferred();
-          // This duplicate respond is to ensure we get a write failure from the
-          // other side. Our client would enter CLOSE_WAIT stage after close(),
-          // meaning first server .send (.respond) after close would still work.
-          // However, a second send would fail under RST, which is similar
-          // to the scenario where a failure happens during .respond
-          await req.respond({ body: new TextEncoder().encode("Hello World") });
-        } catch {
-          break;
+// TODO(kevinkassimo): create a test that works on Windows.
+// The following test is to ensure that if an error occurs during respond
+// would result in connection closed. (such that fd/resource is freed).
+// On *nix, a delayed second attempt to write to a CLOSE_WAIT connection would
+// receive a RST and thus trigger an error during response for us to test.
+// We need to find a way to similarly trigger an error on Windows so that
+// we can test if connection is closed.
+if (Deno.build.os !== "win") {
+  test({
+    name: "[http] respond error handling",
+    async fn(): Promise<void> {
+      const connClosedPromise = deferred();
+      const serverRoutine = async (): Promise<void> => {
+        let reqCount = 0;
+        const server = serve(":8124");
+        const serverRid = server.listener["rid"];
+        let connRid = -1;
+        for await (const req of server) {
+          connRid = req.conn.rid;
+          reqCount++;
+          await req.body();
+          await connClosedPromise;
+          try {
+            await req.respond({
+              body: new TextEncoder().encode("Hello World")
+            });
+            await delay(100);
+            req.done = deferred();
+            // This duplicate respond is to ensure we get a write failure from the
+            // other side. Our client would enter CLOSE_WAIT stage after close(),
+            // meaning first server .send (.respond) after close would still work.
+            // However, a second send would fail under RST, which is similar
+            // to the scenario where a failure happens during .respond
+            await req.respond({
+              body: new TextEncoder().encode("Hello World")
+            });
+          } catch {
+            break;
+          }
         }
-      }
-      server.close();
-      const resources = Deno.resources();
-      assert(reqCount === 1);
-      // Server should be gone
-      assert(!(serverRid in resources));
-      // The connection should be destroyed
-      assert(!(connRid in resources));
-    };
-    const p = serverRoutine();
-    const conn = await Deno.dial({
-      hostname: "127.0.0.1",
-      port: 8124
-    });
-    await Deno.writeAll(
-      conn,
-      new TextEncoder().encode("GET / HTTP/1.1\r\n\r\n")
-    );
-    conn.close(); // abruptly closing connection before response.
-    connClosedPromise.resolve();
-    await p;
-  }
-});
+        server.close();
+        const resources = Deno.resources();
+        assert(reqCount === 1);
+        // Server should be gone
+        assert(!(serverRid in resources));
+        // The connection should be destroyed
+        assert(!(connRid in resources));
+      };
+      const p = serverRoutine();
+      const conn = await Deno.dial({
+        hostname: "127.0.0.1",
+        port: 8124
+      });
+      await Deno.writeAll(
+        conn,
+        new TextEncoder().encode("GET / HTTP/1.1\r\n\r\n")
+      );
+      conn.close(); // abruptly closing connection before response.
+      // conn on server side enters CLOSE_WAIT state.
+      connClosedPromise.resolve();
+      await p;
+    }
+  });
+}
 
 runIfMain(import.meta);

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -17,7 +17,7 @@ import {
   readRequest,
   parseHTTPVersion
 } from "./server.ts";
-import { delay } from "../util/async.ts";
+import { delay, deferred } from "../util/async.ts";
 import {
   BufReader,
   BufWriter,
@@ -587,6 +587,57 @@ test({
 
     const nextAfterClosing = server[Symbol.asyncIterator]().next();
     assertEquals(await nextAfterClosing, { value: undefined, done: true });
+  }
+});
+
+test({
+  name: "[http] respond error handling",
+  async fn(): Promise<void> {
+    const connClosedPromise = deferred();
+    const serverRoutine = async (): Promise<void> => {
+      let reqCount = 0;
+      const server = serve(":8124");
+      const serverRid = server.listener["rid"];
+      let connRid = -1;
+      for await (const req of server) {
+        connRid = req.conn.rid;
+        reqCount++;
+        await req.body();
+        await connClosedPromise;
+        try {
+          await req.respond({ body: new TextEncoder().encode("Hello World") });
+          await delay(100);
+          req.done = deferred();
+          // This duplicate respond is to ensure we get a write failure from the
+          // other side. Our client would enter CLOSE_WAIT stage after close(),
+          // meaning first server .send (.respond) after close would still work.
+          // However, a second send would fail under RST, which is similar
+          // to the scenario where a failure happens during .respond
+          await req.respond({ body: new TextEncoder().encode("Hello World") });
+        } catch {
+          break;
+        }
+      }
+      server.close();
+      const resources = Deno.resources();
+      assert(reqCount === 1);
+      // Server should be gone
+      assert(!(serverRid in resources));
+      // The connection should be destroyed
+      assert(!(connRid in resources));
+    };
+    const p = serverRoutine();
+    const conn = await Deno.dial({
+      hostname: "127.0.0.1",
+      port: 8124
+    });
+    await Deno.writeAll(
+      conn,
+      new TextEncoder().encode("GET / HTTP/1.1\r\n\r\n")
+    );
+    conn.close(); // abruptly closing connection before response.
+    connClosedPromise.resolve();
+    await p;
   }
 });
 


### PR DESCRIPTION
Previously we did not handle automatic connection closing on `.respond()` error. This leaves the supposedly dead connection not closed (`CLOSE_WAIT`) (since `req.done` is never resolved due to error), resulting in errors like `Too many files open`. (which might be the cause of https://github.com/denoland/deno/issues/3463#issuecomment-563056609)

A simple demonstration of what this patch fixes is with the following:

```ts
import { serve } from 'https://deno.land/std/http/server.ts';
const body = new TextEncoder().encode("Hello World\n");
const s = serve({ port: 8000 });

console.log("Listening on port 8000");

setInterval(() => {
  console.log(Object.keys(Deno.resources()).length);
}, 10000);

for await (const req of s) {
  req.respond({ body }).catch(() => {});
}
```

If you fire a few `autocannon -c 100 -d 5 -p 10 http://localhost:8000` to this, you'll notice that `Object.keys(Deno.resources()).length` keeps growing. (likely due to `autocannon` closing conn on its side thus making `.respond()` fail (especially under pipelining))

With this patch, `Object.keys(Deno.resources()).length` should eventually return to a fixed amount.
