### PR TITLE
timer: due/now Math.max instead of min

### DIFF
--- a/cli/js/timers.ts
+++ b/cli/js/timers.ts
@@ -192,7 +192,7 @@ function firePendingTimers(): void {
     pendingScheduleTimers = [];
     // Reschedule for next round of timeout.
     const nextDueNode = dueTree.min();
-    const due = nextDueNode && Math.min(nextDueNode.due, now);
+    const due = nextDueNode && Math.max(nextDueNode.due, now);
     setOrClearGlobalTimeout(due, now);
   } else {
     // Fire a single timer and allow its children microtasks scheduled first.


### PR DESCRIPTION
... which results in the following line failing (as there might be chances when `now` is slightly larger than `due`):

https://github.com/denoland/deno/blob/90c5aadbca8b47fc43bd3ece80e007b1b546c402/cli/js/timers.ts#L43-L44

Instead we should always make `due >= now`, and set `due` to `now` if `due` is in the past already