### PR TITLE
fix: Only swallow NotFound errors in std/fs/expandGlob()

### DIFF
--- a/std/fs/expand_glob.ts
+++ b/std/fs/expand_glob.ts
@@ -52,9 +52,6 @@ function throwUnlessNotFound(error: Error): void {
  * Expand the glob string from the specified `root` directory and yield each
  * result as a `WalkInfo` object.
  */
-// TODO: Use a proper glob expansion algorithm.
-// This is a very incomplete solution. The whole directory tree from `root` is
-// walked and parent paths are not supported.
 export async function* expandGlob(
   glob: string,
   {
@@ -157,7 +154,6 @@ export async function* expandGlob(
 }
 
 /** Synchronous version of `expandGlob()`. */
-// TODO: As `expandGlob()`.
 export function* expandGlobSync(
   glob: string,
   {

--- a/std/fs/expand_glob.ts
+++ b/std/fs/expand_glob.ts
@@ -98,7 +98,7 @@ export async function* expandGlob(
       const parentPath = joinGlobs([walkInfo.filename, ".."], globOptions);
       try {
         if (shouldInclude(parentPath)) {
-          return yield { filename: parentPath, info: await stat(parentPath) }
+          return yield { filename: parentPath, info: await stat(parentPath) };
         }
       } catch (error) {
         if (error.kind != ErrorKind.NotFound) {
@@ -206,7 +206,7 @@ export function* expandGlobSync(
       const parentPath = joinGlobs([walkInfo.filename, ".."], globOptions);
       try {
         if (shouldInclude(parentPath)) {
-          return yield { filename: parentPath, info: statSync(parentPath) }
+          return yield { filename: parentPath, info: statSync(parentPath) };
         }
       } catch (error) {
         if (error.kind != ErrorKind.NotFound) {

--- a/std/fs/expand_glob.ts
+++ b/std/fs/expand_glob.ts
@@ -10,7 +10,8 @@ import {
 } from "../path/mod.ts";
 import { WalkInfo, walk, walkSync } from "./walk.ts";
 const { ErrorKind, cwd, stat, statSync } = Deno;
-type DenoError = Deno.DenoError;
+type ErrorKind = Deno.ErrorKind;
+type DenoError = Deno.DenoError<ErrorKind>;
 type FileInfo = Deno.FileInfo;
 
 export interface ExpandGlobOptions extends GlobOptions {

--- a/std/fs/testdata/expand_wildcard.js
+++ b/std/fs/testdata/expand_wildcard.js
@@ -1,0 +1,6 @@
+import { expandGlob } from "../expand_glob.ts";
+
+const glob = new URL("*", import.meta.url).pathname;
+for await (const { filename } of expandGlob(glob)) {
+  console.log(filename);
+}


### PR DESCRIPTION
Currently if you run `deno https://deno.land/std@v0.26.0/testing/runner.ts` without sufficient permissions it'll just report `No matching test modules found.`.