### PR TITLE
Fix release assets not being executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,11 +166,11 @@ jobs:
 
       - name: Pre-release (linux)
         if: startsWith(matrix.os, 'ubuntu') && matrix.kind == 'test'
-        run: gzip -S _linux_x64.gz target/release/deno
+        run: gzip -f -S _linux_x64.gz target/release/deno
 
       - name: Pre-release (mac)
         if: startsWith(matrix.os, 'macOS') && matrix.kind == 'test'
-        run: gzip -S _osx_x64.gz target/release/deno
+        run: gzip -f -S _osx_x64.gz target/release/deno
 
       - name: Pre-release (windows)
         if: startsWith(matrix.os, 'windows') && matrix.kind == 'test'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,11 +166,11 @@ jobs:
 
       - name: Pre-release (linux)
         if: startsWith(matrix.os, 'ubuntu') && matrix.kind == 'test'
-        run: gzip -c target/release/deno > target/release/deno_linux_x64.gz
+        run: gzip -S _linux_x64.gz target/release/deno
 
       - name: Pre-release (mac)
         if: startsWith(matrix.os, 'macOS') && matrix.kind == 'test'
-        run: gzip -c target/release/deno > target/release/deno_osx_x64.gz
+        run: gzip -S _osx_x64.gz target/release/deno
 
       - name: Pre-release (windows)
         if: startsWith(matrix.os, 'windows') && matrix.kind == 'test'


### PR DESCRIPTION
For some reason when using stdout the permissions
are stripped.

Fixes #3461.

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
