### PR TITLE
benchmark: align deno_http and node_http response

### DIFF
--- a/std/http/http_bench.ts
+++ b/std/http/http_bench.ts
@@ -7,5 +7,11 @@ const body = new TextEncoder().encode("Hello World");
 
 console.log(`http://${addr}/`);
 for await (const req of server) {
-  req.respond({ body });
+  const res = {
+    body,
+    headers: new Headers()
+  };
+  res.headers.set("Date", new Date().toUTCString());
+  res.headers.set("Connection", "keep-alive");
+  req.respond(res).catch(() => {});
 }

--- a/tools/node_http.js
+++ b/tools/node_http.js
@@ -4,6 +4,6 @@ const port = process.argv[2] || "4544";
 console.log("port", port);
 http
   .Server((req, res) => {
-    res.end("Hello World\n");
+    res.end("Hello World");
   })
   .listen(port);


### PR DESCRIPTION
Align `deno_http` and `node_http` test server response to have similar headers and sizes (s.t. benchmark reflects more correctly).

After this change:
`curl -i` on Node:
```
HTTP/1.1 200 OK
Date: Thu, 12 Dec 2019 01:31:15 GMT
Connection: keep-alive
Content-Length: 11

Hello World
```

`curl -i` on Deno:
```
HTTP/1.1 200 OK
date: Thu, 12 Dec 2019 01:30:58 GMT
connection: keep-alive
content-length: 11

Hello World
```