### PR TITLE
Get `file` and `fileInfo` concurrently

### DIFF
--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -82,8 +82,7 @@ async function serveFile(
   req: ServerRequest,
   filePath: string
 ): Promise<Response> {
-  const file = await open(filePath);
-  const fileInfo = await stat(filePath);
+  const [file, fileInfo] = await Promise.all([open(filePath), stat(filePath)]);
   const headers = new Headers();
   headers.set("content-length", fileInfo.len.toString());
   headers.set("content-type", "text/plain");


### PR DESCRIPTION
Now we get the `file` and `fileInfo` sequentially. This change is to make it concurrently, which reduces time cost from `open()  + stat()` to `max(open(), stat())`