### PR TITLE
fix: JS errors should be printed to std

### DIFF
--- a/cli/deno_error.rs
+++ b/cli/deno_error.rs
@@ -35,9 +35,7 @@ pub fn print_err_and_exit(err: ErrBox) {
 }
 
 pub fn js_check(r: Result<(), ErrBox>) {
-  if let Err(err) = r {
-    print_err_and_exit(err);
-  }
+  print_err_and_exit(err);
 }
 
 impl DenoError {


### PR DESCRIPTION
There are multiple types of js exceptions all of them should be printed

<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
