### PR TITLE
flag: upgrade std to v0.26.0

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -22,7 +22,7 @@ macro_rules! sset {
 
 macro_rules! std_url {
   ($x:expr) => {
-    concat!("https://deno.land/std@v0.23.0/", $x)
+    concat!("https://deno.land/std@v0.26.0/", $x)
   };
 }
 


### PR DESCRIPTION
upgrade to v0.26.0 until there is a viable synchronization solution
