### PR TITLE
fetch support URL instance as input

### DIFF
--- a/cli/js/fetch.ts
+++ b/cli/js/fetch.ts
@@ -13,6 +13,7 @@ import * as io from "./io.ts";
 import { read, close } from "./files.ts";
 import { Buffer } from "./buffer.ts";
 import { FormData } from "./form_data.ts";
+import { URL } from "./url.ts";
 import { URLSearchParams } from "./url_search_params.ts";
 import * as dispatch from "./dispatch.ts";
 import { sendAsync } from "./dispatch_json.ts";
@@ -367,7 +368,7 @@ async function sendFetchReq(
 
 /** Fetch a resource from the network. */
 export async function fetch(
-  input: domTypes.Request | string,
+  input: domTypes.Request | URL | string,
   init?: domTypes.RequestInit
 ): Promise<Response> {
   let url: string;
@@ -377,8 +378,8 @@ export async function fetch(
   let redirected = false;
   let remRedirectCount = 20; // TODO: use a better way to handle
 
-  if (typeof input === "string") {
-    url = input;
+  if (typeof input === "string" || input instanceof URL) {
+    url = typeof input === "string" ? (input as string) : (input as URL).href;
     if (init != null) {
       method = init.method || null;
       if (init.headers) {

--- a/cli/js/fetch_test.ts
+++ b/cli/js/fetch_test.ts
@@ -7,7 +7,7 @@ import {
   assertStrContains,
   assertThrows
 } from "./test_util.ts";
-import { URL } from "./url";
+import { URL } from "./url.ts";
 
 testPerm({ net: true }, async function fetchConnectionError(): Promise<void> {
   let err;

--- a/cli/js/fetch_test.ts
+++ b/cli/js/fetch_test.ts
@@ -7,7 +7,6 @@ import {
   assertStrContains,
   assertThrows
 } from "./test_util.ts";
-import { URL } from "./url.ts";
 
 testPerm({ net: true }, async function fetchConnectionError(): Promise<void> {
   let err;

--- a/cli/js/fetch_test.ts
+++ b/cli/js/fetch_test.ts
@@ -7,6 +7,7 @@ import {
   assertStrContains,
   assertThrows
 } from "./test_util.ts";
+import { URL } from "./url";
 
 testPerm({ net: true }, async function fetchConnectionError(): Promise<void> {
   let err;
@@ -39,6 +40,13 @@ test(async function fetchPerm(): Promise<void> {
 
 testPerm({ net: true }, async function fetchUrl(): Promise<void> {
   const response = await fetch("http://localhost:4545/cli/tests/fixture.json");
+  assertEquals(response.url, "http://localhost:4545/cli/tests/fixture.json");
+});
+
+testPerm({ net: true }, async function fetchURL(): Promise<void> {
+  const response = await fetch(
+    new URL("http://localhost:4545/cli/tests/fixture.json")
+  );
   assertEquals(response.url, "http://localhost:4545/cli/tests/fixture.json");
 });
 

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -2675,35 +2675,12 @@ declare namespace __url {
     toJSON(): string;
   }
 
-  export var URL: {
+  export const URL: {
     prototype: URL;
     new (url: string, base?: string | URL): URL;
     createObjectURL(object: __domTypes.Blob): string;
     revokeObjectURL(url: string): void;
   };
-
-  // export class URL {
-  //   private _parts;
-  //   private _searchParams;
-  //   private _updateSearchParams;
-  //   hash: string;
-  //   host: string;
-  //   hostname: string;
-  //   href: string;
-  //   readonly origin: string;
-  //   password: string;
-  //   pathname: string;
-  //   port: string;
-  //   protocol: string;
-  //   search: string;
-  //   username: string;
-  //   readonly searchParams: __urlSearchParams.URLSearchParams;
-  //   constructor(url: string, base?: string | URL);
-  //   toString(): string;
-  //   toJSON(): string;
-  //   static createObjectURL(b: __domTypes.Blob): string;
-  //   static revokeObjectURL(url: string): void;
-  // }
 }
 
 declare namespace __workers {

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -2658,11 +2658,7 @@ declare namespace __urlSearchParams {
 
 declare namespace __url {
   // @url js/url.d.ts
-
-  export class URL {
-    private _parts;
-    private _searchParams;
-    private _updateSearchParams;
+  export interface URL {
     hash: string;
     host: string;
     hostname: string;
@@ -2673,14 +2669,41 @@ declare namespace __url {
     port: string;
     protocol: string;
     search: string;
-    username: string;
     readonly searchParams: __urlSearchParams.URLSearchParams;
-    constructor(url: string, base?: string | URL);
+    username: string;
     toString(): string;
     toJSON(): string;
-    static createObjectURL(b: __domTypes.Blob): string;
-    static revokeObjectURL(url: string): void;
   }
+
+  export var URL: {
+    prototype: URL;
+    new (url: string, base?: string | URL): URL;
+    createObjectURL(object: __domTypes.Blob): string;
+    revokeObjectURL(url: string): void;
+  };
+
+  // export class URL {
+  //   private _parts;
+  //   private _searchParams;
+  //   private _updateSearchParams;
+  //   hash: string;
+  //   host: string;
+  //   hostname: string;
+  //   href: string;
+  //   readonly origin: string;
+  //   password: string;
+  //   pathname: string;
+  //   port: string;
+  //   protocol: string;
+  //   search: string;
+  //   username: string;
+  //   readonly searchParams: __urlSearchParams.URLSearchParams;
+  //   constructor(url: string, base?: string | URL);
+  //   toString(): string;
+  //   toJSON(): string;
+  //   static createObjectURL(b: __domTypes.Blob): string;
+  //   static revokeObjectURL(url: string): void;
+  // }
 }
 
 declare namespace __workers {

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -2481,7 +2481,7 @@ declare namespace __fetch {
   }
   /** Fetch a resource from the network. */
   export function fetch(
-    input: __domTypes.Request | string,
+    input: __domTypes.Request | __url.URL | string,
     init?: __domTypes.RequestInit
   ): Promise<Response>;
 }


### PR DESCRIPTION
```ts
const response = await fetch(new URL('http://www.example.com/démonstration.html'));
```

BTW, the URL implementation does not meet the specification

ref:
https://url.spec.whatwg.org/#api
https://w3c.github.io/FileAPI/#creating-revoking