### PR TITLE
refactor: export chunks in std/io

### DIFF
--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -596,5 +596,7 @@ export async function* chunks(
 
 /** Read from reader until EOF and emit lines */
 export async function* lines(reader: Reader): AsyncIterableIterator<string> {
-  return chunks(reader, "\n");
+  for await (const line of chunks(reader, "\n")) {
+    yield line;
+  }
 }

--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -596,7 +596,5 @@ export async function* chunks(
 
 /** Read from reader until EOF and emit lines */
 export async function* lines(reader: Reader): AsyncIterableIterator<string> {
-  for await (const line of chunks(reader, "\n")) {
-    yield line;
-  }
+  yield* chunks(reader, "\n");
 }

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -406,7 +406,7 @@ test(async function chunksAndLines(): Promise<void> {
     lines_.push(l);
   }
 
-  assertEquals(lines_.length, 3);
+  assertEquals(lines_.length, 10);
   assertEquals(lines_, ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]);
 });
 

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -15,6 +15,8 @@ import {
 import {
   BufReader,
   BufWriter,
+  chunks,
+  lines,
   BufferFullError,
   UnexpectedEOFError
 } from "./bufio.ts";
@@ -381,6 +383,31 @@ test(async function bufReaderReadFull(): Promise<void> {
       assertEquals(dec.decode(buf.subarray(0, 5)), "World");
     }
   }
+});
+
+test(async function chunksAndLines(): Promise<void> {
+  const enc = new TextEncoder();
+  const data = new Buffer(
+    enc.encode("Hello World\tHello World 2\tHello World 3")
+  );
+  const chunks_ = [];
+
+  for await (const c of chunks(data, "\t")) {
+    chunks_.push(c);
+  }
+
+  assertEquals(chunks_.length, 3);
+  assertEquals(chunks_, ["World World", "Hello World 2", "Hello World 3"]);
+
+  const linesData = new Buffer(enc.encode("0\n1\n2\n3\n4\n5\n6\n7\n8\n9"));
+  const lines_ = [];
+
+  for await (const l of lines(linesData)) {
+    lines_.push(l);
+  }
+
+  assertEquals(lines_.length, 3);
+  assertEquals(lines_, ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]);
 });
 
 runIfMain(import.meta);

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -397,7 +397,7 @@ test(async function chunksAndLines(): Promise<void> {
   }
 
   assertEquals(chunks_.length, 3);
-  assertEquals(chunks_, ["World World", "Hello World 2", "Hello World 3"]);
+  assertEquals(chunks_, ["Hello World", "Hello World 2", "Hello World 3"]);
 
   const linesData = new Buffer(enc.encode("0\n1\n2\n3\n4\n5\n6\n7\n8\n9"));
   const lines_ = [];


### PR DESCRIPTION
This PR addresses old TODO to export `chunks` utility method in `std`. 

- move `chunks` from `std/xeval/mod.ts` to `std/io/bufio.ts`
- add `lines` helper which is `chunks(reader, "\n")`
- add simple test case

CC @kevinkassimo @David-Else