### PR TITLE
std/node: better error message for read perm in require()

### DIFF
--- a/std/node/module.ts
+++ b/std/node/module.ts
@@ -54,6 +54,9 @@ function stat(filename: string): StatResult {
     if (statCache !== null) statCache.set(filename, result);
     return result;
   } catch (e) {
+    if (e.kind === Deno.ErrorKind.PermissionDenied) {
+      throw new Error("CJS loader requires --allow-read.");
+    }
     return -1;
   }
 }


### PR DESCRIPTION
Throw an error with better message indicating it needs `--allow-read` permission for CJS loader.

Previously it would simply complain "module not found" due to `stat()` returning -1 on permission denied