### PR TITLE
fix permission errors are swallowed by fs.copy()

### DIFF
--- a/std/fs/copy.ts
+++ b/std/fs/copy.ts
@@ -190,6 +190,7 @@ function copyDirSync(src: string, dest: string, options: CopyOptions): void {
 
 /**
  * Copy a file or directory. The directory can have contents. Like `cp -r`.
+ * Requires the `--allow-read` and `--alow-write` flag.
  * @param src the file/directory path.
  *            Note that if `src` is a directory it will copy everything inside
  *            of this directory, not the entire directory itself
@@ -228,6 +229,7 @@ export async function copy(
 
 /**
  * Copy a file or directory. The directory can have contents. Like `cp -r`.
+ * Requires the `--allow-read` and `--alow-write` flag.
  * @param src the file/directory path.
  *            Note that if `src` is a directory it will copy everything inside
  *            of this directory, not the entire directory itself

--- a/std/fs/ensure_dir.ts
+++ b/std/fs/ensure_dir.ts
@@ -1,49 +1,49 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { getFileInfoType } from "./utils.ts";
+const { lstat, lstatSync, mkdir, mkdirSync, ErrorKind } = Deno;
+
 /**
  * Ensures that the directory exists.
  * If the directory structure does not exist, it is created. Like mkdir -p.
+ * Requires the `--allow-read` and `--alow-write` flag.
  */
 export async function ensureDir(dir: string): Promise<void> {
-  let pathExists = false;
   try {
-    // if dir exists
-    const stat = await Deno.stat(dir);
-    pathExists = true;
-    if (!stat.isDirectory()) {
+    const fileInfo = await lstat(dir);
+    if (!fileInfo.isDirectory()) {
       throw new Error(
-        `Ensure path exists, expected 'dir', got '${getFileInfoType(stat)}'`
+        `Ensure path exists, expected 'dir', got '${getFileInfoType(fileInfo)}'`
       );
     }
   } catch (err) {
-    if (pathExists) {
-      throw err;
+    if (err instanceof Deno.DenoError && err.kind === ErrorKind.NotFound) {
+      // if dir not exists. then create it.
+      await mkdir(dir, true);
+      return;
     }
-    // if dir not exists. then create it.
-    await Deno.mkdir(dir, true);
+    throw err;
   }
 }
 
 /**
  * Ensures that the directory exists.
  * If the directory structure does not exist, it is created. Like mkdir -p.
+ * Requires the `--allow-read` and `--alow-write` flag.
  */
 export function ensureDirSync(dir: string): void {
-  let pathExists = false;
   try {
-    // if dir exists
-    const stat = Deno.statSync(dir);
-    pathExists = true;
-    if (!stat.isDirectory()) {
+    const fileInfo = lstatSync(dir);
+    if (!fileInfo.isDirectory()) {
       throw new Error(
-        `Ensure path exists, expected 'dir', got '${getFileInfoType(stat)}'`
+        `Ensure path exists, expected 'dir', got '${getFileInfoType(fileInfo)}'`
       );
     }
   } catch (err) {
-    if (pathExists) {
-      throw err;
+    if (err instanceof Deno.DenoError && err.kind == ErrorKind.NotFound) {
+      // if dir not exists. then create it.
+      mkdirSync(dir, true);
+      return;
     }
-    // if dir not exists. then create it.
-    Deno.mkdirSync(dir, true);
+    throw err;
   }
 }


### PR DESCRIPTION
ref: #3483 
and refactor `ensureDir()` and `ensureFile()` make it more clearer