### PR TITLE
Improve empty test case error messages.

### DIFF
--- a/std/testing/mod.ts
+++ b/std/testing/mod.ts
@@ -10,7 +10,7 @@ import {
   yellow,
   italic
 } from "../fmt/colors.ts";
-import { assert } from "./asserts.ts"
+import { assert } from "./asserts.ts";
 export type TestFunction = () => void | Promise<void>;
 
 export interface TestDefinition {

--- a/std/testing/mod.ts
+++ b/std/testing/mod.ts
@@ -121,14 +121,26 @@ export function test(
       throw new Error("Missing test function");
     }
     name = t;
-  } else {
-    fn = typeof t === "function" ? t : t.fn;
+    if (!name) {
+      throw new Error("The name of test case can't be empty");
+    }
+  } else if (typeof t === "function") {
+    fn = t;
     name = t.name;
+    if (!name) {
+      throw new Error("Test function can't be anonymous");
+    }
+  } else {
+    fn = t.fn;
+    if (!fn) {
+      throw new Error("Missing test function");
+    }
+    name = t.name;
+    if (!name) {
+      throw new Error("The name of test case can't be empty");
+    }
   }
 
-  if (!name) {
-    throw new Error("Test function may not be anonymous");
-  }
   if (filter(name)) {
     candidates.push({ fn, name });
   } else {

--- a/std/testing/mod.ts
+++ b/std/testing/mod.ts
@@ -10,6 +10,7 @@ import {
   yellow,
   italic
 } from "../fmt/colors.ts";
+import { assert } from "./asserts.ts"
 export type TestFunction = () => void | Promise<void>;
 
 export interface TestDefinition {
@@ -140,6 +141,8 @@ export function test(
       throw new Error("The name of test case can't be empty");
     }
   }
+  assert(!!name, "The name of test case shouldn't be empty");
+  assert(!!fn, "Test function shouldn't be empty");
 
   if (filter(name)) {
     candidates.push({ fn, name });

--- a/std/testing/test.ts
+++ b/std/testing/test.ts
@@ -260,4 +260,34 @@ test("test fn overloading", (): void => {
   assert(true);
 });
 
+test("The name of test case can't be empty", () => {
+  assertThrows(
+    () => {
+      test("", () => {});
+    },
+    Error,
+    "The name of test case can't be empty"
+  );
+  assertThrows(
+    () => {
+      test({
+        name: "",
+        fn: () => {}
+      });
+    },
+    Error,
+    "The name of test case can't be empty"
+  );
+});
+
+test("test function can't be anonymous", () => {
+  assertThrows(
+    () => {
+      test(function() {});
+    },
+    Error,
+    "Test function can't be anonymous"
+  );
+});
+
 runIfMain(import.meta);


### PR DESCRIPTION
This PR improves the error messages when the name of test case is empty.

closes #3513 