### PR TITLE
feat: Add Deno.dir("executable")

### DIFF
--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -59,6 +59,7 @@ declare namespace Deno {
     | "home"
     | "cache"
     | "config"
+    | "executable"
     | "data"
     | "data_local"
     | "audio"
@@ -75,9 +76,9 @@ declare namespace Deno {
    * Returns the user and platform specific directories.
    * Requires the `--allow-env` flag.
    *
-   * Argument values: "home", "cache", "config", "data", "data_local", "audio",
-   * "desktop", "document", "download", "font", "picture", "public", "template",
-   * "video"
+   * Argument values: "home", "cache", "config", "executable", "data",
+   * "data_local", "audio", "desktop", "document", "download", "font", "picture",
+   * "public", "template", "video"
    *
    * "cache"
    * |Platform | Value                               | Example                      |
@@ -92,6 +93,13 @@ declare namespace Deno {
    * | Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config              |
    * | macOS   | `$HOME`/Library/Preferences           | /Users/Alice/Library/Preferences |
    * | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming   |
+   *
+   * "executable"
+   * |Platform | Value                                                           | Example                |
+   * | ------- | --------------------------------------------------------------- | -----------------------|
+   * | Linux   | `XDG_BIN_HOME` or `$XDG_DATA_HOME`/../bin or `$HOME`/.local/bin | /home/alice/.local/bin |
+   * | macOS   | -                                                               | -                      |
+   * | Windows | -                                                               | -                      |
    *
    * "data"
    * |Platform | Value                                    | Example                                  |

--- a/cli/js/os.ts
+++ b/cli/js/os.ts
@@ -132,6 +132,7 @@ type DirKind =
   | "home"
   | "cache"
   | "config"
+  | "executable"
   | "data"
   | "data_local"
   | "audio"
@@ -148,9 +149,9 @@ type DirKind =
  * Returns the user and platform specific directories.
  * Requires the `--allow-env` flag.
  *
- * Argument values: "home", "cache", "config", "data", "data_local", "audio",
- * "desktop", "document", "download", "font", "picture", "public", "template",
- * "video"
+ * Argument values: "home", "cache", "config", "executable", "data",
+ * "data_local", "audio", "desktop", "document", "download", "font", "picture",
+ * "public", "template", "video"
  *
  * "cache"
  * |Platform | Value                               | Example                      |
@@ -165,6 +166,13 @@ type DirKind =
  * | Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config              |
  * | macOS   | `$HOME`/Library/Preferences           | /Users/Alice/Library/Preferences |
  * | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming   |
+ *
+ * "executable"
+ * |Platform | Value                                                           | Example                |
+ * | ------- | --------------------------------------------------------------- | -----------------------|
+ * | Linux   | `XDG_BIN_HOME` or `$XDG_DATA_HOME`/../bin or `$HOME`/.local/bin | /home/alice/.local/bin |
+ * | macOS   | -                                                               | -                      |
+ * | Windows | -                                                               | -                      |
  *
  * "data"
  * |Platform | Value                                    | Example                                  |

--- a/cli/js/os_test.ts
+++ b/cli/js/os_test.ts
@@ -147,6 +147,14 @@ testPerm({ env: true }, function getDir(): void {
       ]
     },
     {
+      kind: "executable",
+      runtime: [
+        { os: "mac", shouldHaveValue: false },
+        { os: "win", shouldHaveValue: false },
+        { os: "linux", shouldHaveValue: true }
+      ]
+    },
+    {
       kind: "data",
       runtime: [
         { os: "mac", shouldHaveValue: true },
@@ -242,6 +250,7 @@ testPerm({ env: true }, function getDir(): void {
       if (r.shouldHaveValue) {
         assertNotEquals(Deno.dir(s.kind), "");
       } else {
+        console.log(Deno.build.os, r.os, s.kind);
         // if not support your platform. it should throw an error
         assertThrows(
           () => Deno.dir(s.kind),

--- a/cli/ops/os.rs
+++ b/cli/ops/os.rs
@@ -75,6 +75,7 @@ fn op_get_dir(
     "home" => dirs::home_dir(),
     "config" => dirs::config_dir(),
     "cache" => dirs::cache_dir(),
+    "executable" => dirs::executable_dir(),
     "data" => dirs::data_dir(),
     "data_local" => dirs::data_local_dir(),
     "audio" => dirs::audio_dir(),


### PR DESCRIPTION
cc @axetroy 

Was there some reason this was omitted? I'm thinking about using it for `deno install`.