### PR TITLE
feat: Return null on error in Deno.dir()

### DIFF
--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -74,6 +74,8 @@ declare namespace Deno {
   /**
    * Returns the user and platform specific directories.
    * Requires the `--allow-env` flag.
+   * Returns null if there is no applicable directory or if any other error
+   * occurs.
    *
    * Argument values: "home", "cache", "config", "data", "data_local", "audio",
    * "desktop", "document", "download", "font", "picture", "public", "template",
@@ -170,7 +172,7 @@ declare namespace Deno {
    * | macOS   | `$HOME`/Movies      | /Users/Alice/Movies   |
    * | Windows | `{FOLDERID_Videos}` | C:\Users\Alice\Videos |
    */
-  export function dir(kind: DirKind): string;
+  export function dir(kind: DirKind): string | null;
 
   /**
    * Returns the path to the current deno executable.

--- a/cli/js/os.ts
+++ b/cli/js/os.ts
@@ -2,6 +2,7 @@
 import { core } from "./core.ts";
 import * as dispatch from "./dispatch.ts";
 import { sendSync } from "./dispatch_json.ts";
+import { ErrorKind } from "./errors.ts";
 import { assert } from "./util.ts";
 import * as util from "./util.ts";
 import { window } from "./window.ts";
@@ -249,7 +250,7 @@ export function dir(kind: DirKind): string | null {
   try {
     return sendSync(dispatch.OP_GET_DIR, { kind });
   } catch (error) {
-    if (error.kind == Deno.ErrorKind.PermissionDenied) {
+    if (error.kind == ErrorKind.PermissionDenied) {
       throw error;
     }
     return null;

--- a/cli/js/os.ts
+++ b/cli/js/os.ts
@@ -248,7 +248,10 @@ type DirKind =
 export function dir(kind: DirKind): string | null {
   try {
     return sendSync(dispatch.OP_GET_DIR, { kind });
-  } catch {
+  } catch (error) {
+    if (error.kind == Deno.ErrorKind.PermissionDenied) {
+      throw error;
+    }
     return null;
   }
 }

--- a/cli/js/os.ts
+++ b/cli/js/os.ts
@@ -147,6 +147,8 @@ type DirKind =
 /**
  * Returns the user and platform specific directories.
  * Requires the `--allow-env` flag.
+ * Returns null if there is no applicable directory or if any other error
+ * occurs.
  *
  * Argument values: "home", "cache", "config", "data", "data_local", "audio",
  * "desktop", "document", "download", "font", "picture", "public", "template",
@@ -243,8 +245,12 @@ type DirKind =
  * | macOS   | `$HOME`/Movies      | /Users/Alice/Movies   |
  * | Windows | `{FOLDERID_Videos}` | C:\Users\Alice\Videos |
  */
-export function dir(kind: DirKind): string {
-  return sendSync(dispatch.OP_GET_DIR, { kind });
+export function dir(kind: DirKind): string | null {
+  try {
+    return sendSync(dispatch.OP_GET_DIR, { kind });
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/cli/js/os_test.ts
+++ b/cli/js/os_test.ts
@@ -242,12 +242,7 @@ testPerm({ env: true }, function getDir(): void {
       if (r.shouldHaveValue) {
         assertNotEquals(Deno.dir(s.kind), "");
       } else {
-        // if not support your platform. it should throw an error
-        assertThrows(
-          () => Deno.dir(s.kind),
-          Deno.DenoError,
-          `Could not get user ${s.kind} directory.`
-        );
+        assertEquals(Deno.dir(s.kind), null);
       }
     }
   }


### PR DESCRIPTION
~Useful here because it would save a lot of `try/catch` blocks for what is a common pattern, even if it seems higher order.~