### PR TITLE
fix(std/encoding/yaml): fix parseAll of yaml module

### DIFF
--- a/std/encoding/README.md
+++ b/std/encoding/README.md
@@ -192,7 +192,6 @@ name: Eve
 `);
 console.log(data);
 // => [ { id: 1, name: "Alice" }, { id: 2, name: "Bob" }, { id: 3, name: "Eve" } ]
-// TODO(kt3k): This doesn't work now
 ```
 
 ### API

--- a/std/encoding/yaml/loader/loader.ts
+++ b/std/encoding/yaml/loader/loader.ts
@@ -577,7 +577,7 @@ function readPlainScalar(
 
   captureSegment(state, captureStart, captureEnd, false);
 
-  if (!common.isNullOrUndefined(state.result)) {
+  if (state.result) {
     return true;
   }
 

--- a/std/encoding/yaml/parse_test.ts
+++ b/std/encoding/yaml/parse_test.ts
@@ -3,23 +3,55 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
-import { parse } from "./parse.ts";
+import { parse, parseAll } from "./parse.ts";
 import { test } from "../../testing/mod.ts";
 import { assertEquals } from "../../testing/asserts.ts";
 
 test({
-  name: "parsed correctly",
+  name: "`parse` parses single document yaml string",
   fn(): void {
-    const FIXTURE = `
-        test: toto
-        foo:
-          bar: True
-          baz: 1
-          qux: ~
-        `;
+    const yaml = `
+      test: toto
+      foo:
+        bar: True
+        baz: 1
+        qux: ~
+    `;
 
-    const ASSERTS = { test: "toto", foo: { bar: true, baz: 1, qux: null } };
+    const expected = { test: "toto", foo: { bar: true, baz: 1, qux: null } };
 
-    assertEquals(parse(FIXTURE), ASSERTS);
+    assertEquals(parse(yaml), expected);
+  }
+});
+
+test({
+  name: "`parseAll` parses the yaml string with multiple documents",
+  fn(): void {
+    const yaml = `
+---
+id: 1
+name: Alice
+---
+id: 2
+name: Bob
+---
+id: 3
+name: Eve
+    `;
+    const expected = [
+      {
+        id: 1,
+        name: "Alice"
+      },
+      {
+        id: 2,
+        name: "Bob"
+      },
+      {
+        id: 3,
+        name: "Eve"
+      }
+    ];
+    assertEquals(parseAll(yaml), expected);
   }
 });

--- a/std/encoding/yaml/utils.ts
+++ b/std/encoding/yaml/utils.ts
@@ -22,10 +22,6 @@ export function isNull(value: unknown): value is null {
   return value === null;
 }
 
-export function isNullOrUndefined(value: unknown): value is null | undefined {
-  return value === null || value === undefined;
-}
-
 export function isNumber(value: unknown): value is number {
   return typeof value === "number" || value instanceof Number;
 }


### PR DESCRIPTION
This PR fixes the detection of document separator `---` in readPlainScalar method. In the original code in js-yaml, it checks the state.result like `if (state.result)`:
https://github.com/nodeca/js-yaml/blob/d6983dd4291849b2854e8d26e1beb302edfd4c76/lib/js-yaml/loader.js#L535

But in our code it checks like `if (!common.isNullOrUndefined(state.result)) {` and it slips the case of `state.result === ""`, and that seems causing the issue #3534.

closes #3534