### PR TITLE
net: expose shutdown() and ShutdownMode

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -77,7 +77,15 @@ export {
 export { truncateSync, truncate } from "./truncate.ts";
 export { FileInfo } from "./file_info.ts";
 export { openPlugin } from "./plugins.ts";
-export { connect, dial, listen, Listener, Conn } from "./net.ts";
+export {
+  connect,
+  dial,
+  listen,
+  Listener,
+  Conn,
+  ShutdownMode,
+  shutdown
+} from "./net.ts";
 export { dialTLS, listenTLS } from "./tls.ts";
 export { metrics, Metrics } from "./metrics.ts";
 export { resources } from "./resources.ts";

--- a/cli/js/net.ts
+++ b/cli/js/net.ts
@@ -32,7 +32,7 @@ export interface Listener extends AsyncIterator<Conn> {
   [Symbol.asyncIterator](): AsyncIterator<Conn>;
 }
 
-enum ShutdownMode {
+export enum ShutdownMode {
   // See http://man7.org/linux/man-pages/man2/shutdown.2.html
   // Corresponding to SHUT_RD, SHUT_WR, SHUT_RDWR
   Read = 0,
@@ -40,7 +40,15 @@ enum ShutdownMode {
   ReadWrite // unused
 }
 
-function shutdown(rid: number, how: ShutdownMode): void {
+/** Shut down socket send and receive operations.
+ *
+ * Matches behavior of POSIX shutdown(3).
+ *
+ *       const listener = Deno.listen({ port: 80 });
+ *       const conn = await listener.accept();
+ *       Deno.shutdown(conn.rid, Deno.ShutdownMode.Write);
+ */
+export function shutdown(rid: number, how: ShutdownMode): void {
   sendSync(dispatch.OP_SHUTDOWN, { rid, how });
 }
 


### PR DESCRIPTION
Exposing this to make custom `Conn` interface implementation easier.

It is a standard POSIX API anyways.
