### PR TITLE
worker: add option to share resources

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -224,7 +224,7 @@ impl TsCompiler {
   fn setup_worker(global_state: ThreadSafeGlobalState) -> Worker {
     let (int, ext) = ThreadSafeState::create_channels();
     let worker_state =
-      ThreadSafeState::new(global_state.clone(), None, None, true, int)
+      ThreadSafeState::new(global_state.clone(), None, None, None, true, int)
         .expect("Unable to create worker state");
 
     // Count how many times we start the compiler worker.

--- a/cli/compilers/wasm.rs
+++ b/cli/compilers/wasm.rs
@@ -47,7 +47,7 @@ impl WasmCompiler {
   fn setup_worker(global_state: ThreadSafeGlobalState) -> Worker {
     let (int, ext) = ThreadSafeState::create_channels();
     let worker_state =
-      ThreadSafeState::new(global_state.clone(), None, None, true, int)
+      ThreadSafeState::new(global_state.clone(), None, None, None, true, int)
         .expect("Unable to create worker state");
 
     // Count how many times we start the compiler worker.

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -2843,12 +2843,17 @@ declare namespace __workers {
     closed: Promise<void>;
   }
   export interface WorkerOptions {}
-  /** Extended Deno Worker initialization options.
-   * `noDenoNamespace` hides global `window.Deno` namespace for
-   * spawned worker and nested workers spawned by it (default: false).
-   */
+  /** Extended Deno Worker initialization options. */
   export interface DenoWorkerOptions extends WorkerOptions {
+    /** `noDenoNamespace` hides global `window.Deno` namespace for
+     * spawned worker and nested workers spawned by it (default: false).
+     */
     noDenoNamespace?: boolean;
+    /** `shareResources` makes parent and child worker sharing the
+     * same underlying resource table, making it possible for child
+     * to access open resources using the same resource ID.
+     */
+    shareResources?: boolean;
   }
   export class WorkerImpl implements Worker {
     private readonly id;

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -117,6 +117,7 @@ fn create_worker_and_state(
   let state = ThreadSafeState::new(
     global_state.clone(),
     None,
+    None,
     global_state.main_module.clone(),
     true,
     int,

--- a/cli/ops/workers.rs
+++ b/cli/ops/workers.rs
@@ -108,6 +108,7 @@ fn op_worker_post_message(
 struct CreateWorkerArgs {
   specifier: String,
   include_deno_namespace: bool,
+  share_resources: bool,
   has_source_code: bool,
   source_code: String,
 }
@@ -127,6 +128,7 @@ fn op_create_worker(
     args.include_deno_namespace && state.include_deno_namespace;
   let has_source_code = args.has_source_code;
   let source_code = args.source_code;
+  let share_resources = args.share_resources;
 
   let parent_state = state.clone();
 
@@ -139,10 +141,17 @@ fn op_create_worker(
     }
   }
 
+  let resource_table = if share_resources {
+    Some(parent_state.resource_table.clone())
+  } else {
+    None
+  };
+
   let (int, ext) = ThreadSafeState::create_channels();
   let child_state = ThreadSafeState::new(
     state.global_state.clone(),
     Some(parent_state.permissions.clone()), // by default share with parent
+    resource_table,
     Some(module_specifier.clone()),
     include_deno_namespace,
     int,

--- a/cli/tests/053_share_resources.ts
+++ b/cli/tests/053_share_resources.ts
@@ -1,40 +1,12 @@
-interface Deferred<T> extends Promise<T> {
-  resolve: (value?: T | PromiseLike<T>) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  reject: (reason?: any) => void;
-}
-function deferred<T>(): Deferred<T> {
-  let methods;
-  const promise = new Promise<T>((resolve, reject): void => {
-    methods = { resolve, reject };
-  });
-  return Object.assign(promise, methods)! as Deferred<T>;
-}
-
-interface TaggedYieldedValue<T> {
-  iterator: AsyncIterableIterator<T>;
-  value: T;
-}
-
 const _f = Deno.openSync("./shared_resource_worker.ts");
 console.log(Deno.resources());
 
 const w0 = new Worker("./shared_resource_worker.ts", {
   shareResources: true
 });
-const w0Deferred = deferred();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-w0.onmessage = (_e: any): void => {
-  w0Deferred.resolve();
-};
-await w0Deferred;
+w0.postMessage(0);
+await w0.closed;
 
 const w1 = new Worker("./shared_resource_worker.ts");
-const w1Deferred = deferred();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-w1.onmessage = (_e: any): void => {
-  w1Deferred.resolve();
-};
-await w1Deferred;
-
-Deno.exit(0);
+w1.postMessage(1);
+await w1.closed;

--- a/cli/tests/053_share_resources.ts
+++ b/cli/tests/053_share_resources.ts
@@ -1,0 +1,40 @@
+interface Deferred<T> extends Promise<T> {
+  resolve: (value?: T | PromiseLike<T>) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reject: (reason?: any) => void;
+}
+function deferred<T>(): Deferred<T> {
+  let methods;
+  const promise = new Promise<T>((resolve, reject): void => {
+    methods = { resolve, reject };
+  });
+  return Object.assign(promise, methods)! as Deferred<T>;
+}
+
+interface TaggedYieldedValue<T> {
+  iterator: AsyncIterableIterator<T>;
+  value: T;
+}
+
+const _f = Deno.openSync("./shared_resource_worker.ts");
+console.log(Deno.resources());
+
+const w0 = new Worker("./shared_resource_worker.ts", {
+  shareResources: true
+});
+const w0Deferred = deferred();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+w0.onmessage = (_e: any): void => {
+  w0Deferred.resolve();
+};
+await w0Deferred;
+
+const w1 = new Worker("./shared_resource_worker.ts");
+const w1Deferred = deferred();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+w1.onmessage = (_e: any): void => {
+  w1Deferred.resolve();
+};
+await w1Deferred;
+
+Deno.exit(0);

--- a/cli/tests/053_share_resources.ts.out
+++ b/cli/tests/053_share_resources.ts.out
@@ -1,0 +1,3 @@
+{ 0: "stdin", 1: "stdout", 2: "stderr", 3: "fsFile" }
+{ 0: "stdin", 1: "stdout", 2: "stderr", 3: "fsFile" }
+{}

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -406,6 +406,11 @@ itest!(_052_no_remote_flag {
   http_server: true,
 });
 
+itest!(_053_share_resources {
+  args: "--reload --allow-read 053_share_resources.ts",
+  output: "053_share_resources.ts.out",
+});
+
 itest!(lock_check_ok {
   args: "run --lock=lock_check_ok.json http://127.0.0.1:4545/cli/tests/003_relative_import.ts",
   output: "003_relative_import.ts.out",

--- a/cli/tests/shared_resource_worker.ts
+++ b/cli/tests/shared_resource_worker.ts
@@ -1,0 +1,2 @@
+console.log(Deno.resources());
+postMessage("Done");

--- a/cli/tests/shared_resource_worker.ts
+++ b/cli/tests/shared_resource_worker.ts
@@ -1,2 +1,6 @@
+onmessage = (): void => {
+  // workerClose can only work as intended in onmessage.
+  workerClose();
+};
+
 console.log(Deno.resources());
-postMessage("Done");

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -257,6 +257,7 @@ mod tests {
     let state = ThreadSafeState::new(
       global_state,
       None,
+      None,
       Some(module_specifier.clone()),
       true,
       int,
@@ -301,6 +302,7 @@ mod tests {
     let state = ThreadSafeState::new(
       global_state,
       None,
+      None,
       Some(module_specifier.clone()),
       true,
       int,
@@ -343,6 +345,7 @@ mod tests {
     let (int, ext) = ThreadSafeState::create_channels();
     let state = ThreadSafeState::new(
       global_state.clone(),
+      None,
       None,
       Some(module_specifier.clone()),
       true,


### PR DESCRIPTION
Add an option `shareResources` (default `false`) that when `true`, child worker would be able to share parent resource table and interact with corresponding resource id.

This allows simple connection-based http server clustering using workers (With this PR I have attempted a minimal worker cluster, and seems to show better performance with large amount of parallel connections compared to basic single worker case)