### PR TITLE
fix: ws handshake with correctly empty search string

### DIFF
--- a/std/ws/mod.ts
+++ b/std/ws/mod.ts
@@ -411,13 +411,13 @@ export function createSecKey(): string {
   return btoa(key);
 }
 
-async function handshake(
+export async function handshake(
   url: URL,
   headers: Headers,
   bufReader: BufReader,
   bufWriter: BufWriter
 ): Promise<void> {
-  const { hostname, pathname, searchParams } = url;
+  const { hostname, pathname, search } = url;
   const key = createSecKey();
 
   if (!headers.has("host")) {
@@ -428,7 +428,7 @@ async function handshake(
   headers.set("sec-websocket-key", key);
   headers.set("sec-websocket-version", "13");
 
-  let headerStr = `GET ${pathname}?${searchParams || ""} HTTP/1.1\r\n`;
+  let headerStr = `GET ${pathname}${search} HTTP/1.1\r\n`;
   for (const [key, value] of headers) {
     headerStr += `${key}: ${value}\r\n`;
   }


### PR DESCRIPTION
some real-world websocket server return 400 even if querystring is empty("?")

https://github.com/denoland/deno/blob/bfab4ed0dfa5e2034005133a257201c934bc3a80/std/ws/mod.ts#L431

```
# return 400
GET path? HTTP/1.1\r\n
```

so passthrough raw `search` string, it's safety.

```
> new URL('http://example.com?a=1')
URL { href: "http://example.com/?a=1", origin: "http://example.com", protocol: "http:", username: "", password: "", host: "example.com", hostname: "example.com", port: "", pathname: "/", hash: "", search: "?a=1" }

> new URL('http://example.com')
URL { href: "http://example.com/", origin: "http://example.com", protocol: "http:", username: "", password: "", host: "example.com", hostname: "example.com", port: "", pathname: "/", hash: "", search: "" }
```