### PR TITLE
fix(std/encoding/yaml): export parseAll

### DIFF
--- a/std/encoding/yaml.ts
+++ b/std/encoding/yaml.ts
@@ -3,7 +3,7 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-export { ParseOptions, parse } from "./yaml/parse.ts";
+export { ParseOptions, parse, parseAll } from "./yaml/parse.ts";
 export {
   DumpOptions as StringifyOptions,
   stringify


### PR DESCRIPTION
This PR fixes #3591.