### PR TITLE
fix(std/encoding/mod.ts): Re-export parseAllYaml

### DIFF
--- a/std/encoding/mod.ts
+++ b/std/encoding/mod.ts
@@ -11,4 +11,8 @@ export {
   encodeToString as encodeToHexString
 } from "./hex.ts";
 export { parse as parseToml, stringify as tomlStringify } from "./toml.ts";
-export { parse as parseYaml, stringify as yamlStringify } from "./yaml.ts";
+export {
+  parse as parseYaml,
+  parseAll as parseAllYaml,
+  stringify as yamlStringify
+} from "./yaml.ts";


### PR DESCRIPTION
Follow up to #3592.