### PR TITLE
Text encoding speedup

### DIFF
--- a/cli/js/encode_utf8.ts
+++ b/cli/js/encode_utf8.ts
@@ -22,7 +22,6 @@ export function encodeUtf8(
 ): Uint8Array {
   let pos = 0;
   const len = input.length;
-  const out = [];
 
   let at = 0;  // output position
   let tlen = Math.max(32, len + (len >> 1) + 7);  // 1.5x size

--- a/cli/js/encode_utf8.ts
+++ b/cli/js/encode_utf8.ts
@@ -17,15 +17,13 @@
 // the License.
 //
 
-export function encodeUtf8(
-  input: string
-): Uint8Array {
+export function encodeUtf8(input: string): Uint8Array {
   let pos = 0;
   const len = input.length;
 
-  let at = 0;  // output position
-  let tlen = Math.max(32, len + (len >> 1) + 7);  // 1.5x size
-  let target = new Uint8Array((tlen >> 3) << 3);  // ... but at 8 byte offset
+  let at = 0; // output position
+  let tlen = Math.max(32, len + (len >> 1) + 7); // 1.5x size
+  let target = new Uint8Array((tlen >> 3) << 3); // ... but at 8 byte offset
 
   while (pos < len) {
     let value = input.charCodeAt(pos++);
@@ -39,33 +37,37 @@ export function encodeUtf8(
         }
       }
       if (value >= 0xd800 && value <= 0xdbff) {
-        continue;  // drop lone surrogate
+        continue; // drop lone surrogate
       }
     }
 
     // expand the buffer if we couldn't write 4 bytes
     if (at + 4 > target.length) {
-      tlen += 8;  // minimum extra
-      tlen *= (1.0 + (pos / input.length) * 2);  // take 2x the remaining
-      tlen = (tlen >> 3) << 3;  // 8 byte offset
+      tlen += 8; // minimum extra
+      tlen *= 1.0 + (pos / input.length) * 2; // take 2x the remaining
+      tlen = (tlen >> 3) << 3; // 8 byte offset
 
       const update = new Uint8Array(tlen);
       update.set(target);
       target = update;
     }
 
-    if ((value & 0xffffff80) === 0) {  // 1-byte
-      target[at++] = value;  // ASCII
+    if ((value & 0xffffff80) === 0) {
+      // 1-byte
+      target[at++] = value; // ASCII
       continue;
-    } else if ((value & 0xfffff800) === 0) {  // 2-byte
-      target[at++] = ((value >>  6) & 0x1f) | 0xc0;
-    } else if ((value & 0xffff0000) === 0) {  // 3-byte
+    } else if ((value & 0xfffff800) === 0) {
+      // 2-byte
+      target[at++] = ((value >> 6) & 0x1f) | 0xc0;
+    } else if ((value & 0xffff0000) === 0) {
+      // 3-byte
       target[at++] = ((value >> 12) & 0x0f) | 0xe0;
-      target[at++] = ((value >>  6) & 0x3f) | 0x80;
-    } else if ((value & 0xffe00000) === 0) {  // 4-byte
+      target[at++] = ((value >> 6) & 0x3f) | 0x80;
+    } else if ((value & 0xffe00000) === 0) {
+      // 4-byte
       target[at++] = ((value >> 18) & 0x07) | 0xf0;
       target[at++] = ((value >> 12) & 0x3f) | 0x80;
-      target[at++] = ((value >>  6) & 0x3f) | 0x80;
+      target[at++] = ((value >> 6) & 0x3f) | 0x80;
     } else {
       // FIXME: do we care
       continue;

--- a/cli/js/encode_utf8.ts
+++ b/cli/js/encode_utf8.ts
@@ -1,0 +1,79 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// The following code is based off:
+// https://github.com/samthor/fast-text-encoding
+//
+// Copyright 2017 Sam Thorogood. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//
+
+export function encodeUtf8(
+  input: string
+): Uint8Array {
+  let pos = 0;
+  const len = input.length;
+  const out = [];
+
+  let at = 0;  // output position
+  let tlen = Math.max(32, len + (len >> 1) + 7);  // 1.5x size
+  let target = new Uint8Array((tlen >> 3) << 3);  // ... but at 8 byte offset
+
+  while (pos < len) {
+    let value = input.charCodeAt(pos++);
+    if (value >= 0xd800 && value <= 0xdbff) {
+      // high surrogate
+      if (pos < len) {
+        const extra = input.charCodeAt(pos);
+        if ((extra & 0xfc00) === 0xdc00) {
+          ++pos;
+          value = ((value & 0x3ff) << 10) + (extra & 0x3ff) + 0x10000;
+        }
+      }
+      if (value >= 0xd800 && value <= 0xdbff) {
+        continue;  // drop lone surrogate
+      }
+    }
+
+    // expand the buffer if we couldn't write 4 bytes
+    if (at + 4 > target.length) {
+      tlen += 8;  // minimum extra
+      tlen *= (1.0 + (pos / input.length) * 2);  // take 2x the remaining
+      tlen = (tlen >> 3) << 3;  // 8 byte offset
+
+      const update = new Uint8Array(tlen);
+      update.set(target);
+      target = update;
+    }
+
+    if ((value & 0xffffff80) === 0) {  // 1-byte
+      target[at++] = value;  // ASCII
+      continue;
+    } else if ((value & 0xfffff800) === 0) {  // 2-byte
+      target[at++] = ((value >>  6) & 0x1f) | 0xc0;
+    } else if ((value & 0xffff0000) === 0) {  // 3-byte
+      target[at++] = ((value >> 12) & 0x0f) | 0xe0;
+      target[at++] = ((value >>  6) & 0x3f) | 0x80;
+    } else if ((value & 0xffe00000) === 0) {  // 4-byte
+      target[at++] = ((value >> 18) & 0x07) | 0xf0;
+      target[at++] = ((value >> 12) & 0x3f) | 0x80;
+      target[at++] = ((value >>  6) & 0x3f) | 0x80;
+    } else {
+      // FIXME: do we care
+      continue;
+    }
+
+    target[at++] = (value & 0x3f) | 0x80;
+  }
+
+  return target.slice(0, at);
+}

--- a/cli/js/text_encoding.ts
+++ b/cli/js/text_encoding.ts
@@ -26,6 +26,7 @@
 import * as base64 from "./base64.ts";
 import { decodeUtf8 } from "./decode_utf8.ts";
 import * as domTypes from "./dom_types.ts";
+import { encodeUtf8 } from "./encode_utf8.ts";
 import { DenoError, ErrorKind } from "./errors.ts";
 
 const CONTINUE = null;
@@ -405,6 +406,12 @@ export class TextEncoder {
   readonly encoding = "utf-8";
   /** Returns the result of running UTF-8's encoder. */
   encode(input = ""): Uint8Array {
+    // For performance reasons we utilise a highly optimised decoder instead of
+    // the general decoder.
+    if (this.encoding === "utf-8") {
+      return encodeUtf8(input);
+    }
+  
     const encoder = new UTF8Encoder();
     const inputStream = new Stream(stringToCodePoints(input));
     const output: number[] = [];

--- a/cli/js/text_encoding.ts
+++ b/cli/js/text_encoding.ts
@@ -411,7 +411,7 @@ export class TextEncoder {
     if (this.encoding === "utf-8") {
       return encodeUtf8(input);
     }
-  
+
     const encoder = new UTF8Encoder();
     const inputStream = new Stream(stringToCodePoints(input));
     const output: number[] = [];

--- a/cli/tests/text_encoder_perf.js
+++ b/cli/tests/text_encoder_perf.js
@@ -1,0 +1,33 @@
+const mixed = "@Ā๐😀";
+
+function generateRandom(bytes) {
+  let result = "";
+  let i = 0;
+  while (i < bytes) {
+    const toAdd = Math.floor(Math.random() * Math.min(4, bytes - i));
+    switch (toAdd) {
+      case 0:
+        result += mixed[0];
+        i++;
+        break;
+      case 1:
+        result += mixed[1];
+        i++;
+        break;
+      case 2:
+        result += mixed[2];
+        i++;
+        break;
+      case 3:
+        result += mixed[3];
+        result += mixed[4];
+        i += 2;
+        break;
+    }
+  }
+  return result;
+}
+
+const randomData = generateRandom(1024);
+const encoder = new TextEncoder();
+for (let i = 0; i < 10_000; i++) encoder.encode(randomData);

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -28,6 +28,7 @@ exec_time_benchmarks = [
     ("workers_startup", ["tests/workers_startup_bench.ts"]),
     ("workers_round_robin", ["tests/workers_round_robin_bench.ts"]),
     ("text_decoder", ["cli/tests/text_decoder_perf.js"]),
+    ("text_encoder", ["cli/tests/text_encoder_perf.js"]),
 ]
 
 


### PR DESCRIPTION
I have sped up the TextEncoder for UTF-8 encoding by utilizing a encoding function from https://github.com/samthor/fast-text-encoding.

The speed improvement is about 4.5x. This is probably because there are way less allocations as the encoded bytes are written right into a Uint8Array. Maybe this can be optimized further, but it is a definite improvement over what we have now.

I did not do this for TextEncoder#encodeInto as I can not guarantee that passed Uint8Array() is long enough for the content. TextEncoder#encodeInto still uses the old encoder.