### PR TITLE
[WIP] Try adding signal handler ops

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -100,6 +100,7 @@ export {
 } from "./process.ts";
 export { transpileOnly, compile, bundle } from "./compiler_api.ts";
 export { inspect } from "./console.ts";
+export { signal, signals, SignalStream } from "./signals.ts";
 export { build, OperatingSystem, Arch } from "./build.ts";
 export { version } from "./version.ts";
 export const args: string[] = [];

--- a/cli/js/dispatch.ts
+++ b/cli/js/dispatch.ts
@@ -74,6 +74,9 @@ export let OP_HOSTNAME: number;
 export let OP_OPEN_PLUGIN: number;
 export let OP_COMPILE: number;
 export let OP_TRANSPILE: number;
+export let OP_BIND_SIGNAL: number;
+export let OP_UNBIND_SIGNAL: number;
+export let OP_POLL_SIGNAL: number;
 
 /** **WARNING:** This is only available during the snapshotting process and is
  * unavailable at runtime. */

--- a/cli/js/errors.ts
+++ b/cli/js/errors.ts
@@ -79,5 +79,7 @@ export enum ErrorKind {
   TypeError = 51,
 
   /** TODO this is a DomException type, and should be moved out of here when possible */
-  DataCloneError = 52
+  DataCloneError = 52,
+
+  StreamDisposed = 53
 }

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -2106,6 +2106,106 @@ declare namespace Deno {
    */
   export const args: string[];
 
+  // @url js/signal.d.ts
+  export class SignalStream implements AsyncIterator<void>, PromiseLike<void> {
+    constructor(signal: typeof Deno.Signal);
+    then<T, S>(
+      f: (v: void) => T | Promise<T>,
+      g?: (v: void) => S | Promise<S>
+    ): Promise<T | S>;
+    next(): Promise<IteratorResult<void>>;
+    [Symbol.asyncIterator](): AsyncIterator<void>;
+    dispose(): void;
+  }
+  /**
+   * Returns the stream of the given signal number. You can use it as an async
+   * iterator.
+   *
+   *     for await (const _ of Deno.signal(Deno.Signal.SIGTERM)) {
+   *       console.log("got SIGTERM!");
+   *     }
+   *
+   * You can also use it as a promise. In this case you can only receive the
+   * first one.
+   *
+   *     await Deno.signal(Deno.Signal.SIGTERM);
+   *     console.log("SIGTERM received!")
+   *
+   * If you want to stop receiving the signals, you can use .dispose() method
+   * of the signal stream object.
+   *
+   *     const sig = Deno.signal(Deno.Signal.SIGTERM);
+   *     setTimeout(() => { sig.dispose(); }, 5000);
+   *     for await (const _ of sig) {
+   *       console.log("SIGTERM!")
+   *     }
+   *
+   * The above for-await loop exits after 5 seconds when sig.dispose() is called.
+   */
+  export function signal(signo: number): SignalStream;
+  export const signals: {
+    /**
+     * Returns the stream of SIGALRM signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGALRM).
+     */
+    alarm: () => SignalStream;
+    /**
+     * Returns the stream of SIGCHLD signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGCHLD).
+     */
+    child: () => SignalStream;
+    /**
+     * Returns the stream of SIGHUP signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGHUP).
+     */
+    hungup: () => SignalStream;
+    /**
+     * Returns the stream of SIGINFO signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGINFO).
+     */
+    info: () => SignalStream;
+    /**
+     * Returns the stream of SIGINT signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGINT).
+     */
+    interrupt: () => SignalStream;
+    /**
+     * Returns the stream of SIGIO signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGIO).
+     */
+    io: () => SignalStream;
+    /**
+     * Returns the stream of SIGPIPE signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGPIPE).
+     */
+    pipe: () => SignalStream;
+    /**
+     * Returns the stream of SIGQUIT signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGQUIT).
+     */
+    quit: () => SignalStream;
+    /**
+     * Returns the stream of SIGTERM signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGTERM).
+     */
+    terminate: () => SignalStream;
+    /**
+     * Returns the stream of SIGUSR1 signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGUSR1).
+     */
+    userDefined1: () => SignalStream;
+    /**
+     * Returns the stream of SIGUSR2 signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGUSR2).
+     */
+    userDefined2: () => SignalStream;
+    /**
+     * Returns the stream of SIGWINCH signals.
+     * This method is the short hand for Deno.signal(Deno.Signal.SIGWINCH).
+     */
+    windowChange: () => SignalStream;
+  };
+
   /** UNSTABLE: new API. Maybe move EOF here.
    *
    * Special Deno related symbols.

--- a/cli/js/process.ts
+++ b/cli/js/process.ts
@@ -296,7 +296,7 @@ enum MacOSSignal {
 
 /** Signals numbers. This is platform dependent.
  */
-export const Signal = {};
+export const Signal: { [key: string]: number } = {};
 
 export function setSignals(): void {
   if (build.os === "mac") {

--- a/cli/js/signal_test.ts
+++ b/cli/js/signal_test.ts
@@ -1,0 +1,174 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { testPerm, assert, assertEquals, assertThrows } from "./test_util.ts";
+
+function defer(n: number): Promise<void> {
+  return new Promise((resolve, _) => {
+    setTimeout(resolve, n);
+  });
+}
+
+if (Deno.build.os === "win") {
+  testPerm({ run: true }, async function signalsNotImplemented(): Promise<void> {
+    assertThrows(
+      () => {
+        Deno.signal(1);
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.alarm(); // for SIGALRM
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.child(); // for SIGCHLD
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.hungup(); // for SIGHUP
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.info(); // for SIGINFO
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.interrupt(); // for SIGINT
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.io(); // for SIGIO
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.pipe(); // for SIGPIPE
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.quit(); // for SIGQUIT
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.terminate(); // for SIGTERM
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.userDefined1(); // for SIGUSR1
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.userDefined2(); // for SIGURS2
+      },
+      Error,
+      "not implemented"
+    );
+    assertThrows(
+      () => {
+        Deno.signals.windowChange(); // for SIGWINCH
+      },
+      Error,
+      "not implemented"
+    );
+  });
+} else {
+  testPerm({ run: true }, async function signalStreamTest(): Promise<void> {
+    let c = 0;
+    const sig = Deno.signal(Deno.Signal.SIGUSR1);
+
+    setTimeout(async () => {
+      await defer(20);
+      for (const _ of Array(3)) {
+        // Sends SIGUSR1 3 times.
+        Deno.kill(Deno.pid, Deno.Signal.SIGUSR1);
+        await defer(20);
+      }
+      sig.dispose();
+    });
+
+    for await (const _ of sig) {
+      c += 1;
+    }
+
+    assertEquals(c, 3);
+  });
+
+  testPerm({ run: true }, async function signalPromiseTest(): Promise<void> {
+    const sig = Deno.signal(Deno.Signal.SIGUSR1);
+    setTimeout(() => {
+      Deno.kill(Deno.pid, Deno.Signal.SIGUSR1);
+    }, 20);
+    await sig;
+    sig.dispose();
+  });
+
+  testPerm({ run: true }, async function signalShorthandsTest(): Promise<void> {
+    let s: Deno.SignalStream;
+    s = Deno.signals.alarm(); // for SIGALRM
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signals.child(); // for SIGCHLD
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signals.hungup(); // for SIGHUP
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signals.info(); // for SIGINFO
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signals.interrupt(); // for SIGINT
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signals.io(); // for SIGIO
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signals.pipe(); // for SIGPIPE
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signals.quit(); // for SIGQUIT
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signals.terminate(); // for SIGTERM
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signals.userDefined1(); // for SIGUSR1
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signals.userDefined2(); // for SIGURS2
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signals.windowChange(); // for SIGWINCH
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+  });
+}

--- a/cli/js/signals.ts
+++ b/cli/js/signals.ts
@@ -1,0 +1,196 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { Signal } from "./process.ts";
+import * as dispatch from "./dispatch.ts";
+import { sendSync, sendAsync } from "./dispatch_json.ts";
+import { DenoError, ErrorKind } from "./errors.ts";
+import { build } from "./build.ts";
+
+/**
+ * Returns the stream of the given signal number. You can use it as an async
+ * iterator.
+ *
+ *     for await (const _ of Deno.signal(Deno.Signal.SIGTERM)) {
+ *       console.log("got SIGTERM!");
+ *     }
+ *
+ * You can also use it as a promise. In this case you can only receive the
+ * first one.
+ *
+ *     await Deno.signal(Deno.Signal.SIGTERM);
+ *     console.log("SIGTERM received!")
+ *
+ * If you want to stop receiving the signals, you can use .dispose() method
+ * of the signal stream object.
+ *
+ *     const sig = Deno.signal(Deno.Signal.SIGTERM);
+ *     setTimeout(() => { sig.dispose(); }, 5000);
+ *     for await (const _ of sig) {
+ *       console.log("SIGTERM!")
+ *     }
+ *
+ * The above for-await loop exits after 5 seconds when sig.dispose() is called.
+ */
+export function signal(signo: number): SignalStream {
+  return new SignalStream(signo);
+}
+
+export const signals = {
+  /**
+   * Returns the stream of SIGALRM signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGALRM).
+   */
+  alarm(): SignalStream {
+    return createSignalStream(Signal.SIGALRM);
+  },
+  /**
+   * Returns the stream of SIGCHLD signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGCHLD).
+   */
+  child(): SignalStream {
+    return createSignalStream(Signal.SIGCHLD);
+  },
+  /**
+   * Returns the stream of SIGHUP signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGHUP).
+   */
+  hungup(): SignalStream {
+    return createSignalStream(Signal.SIGHUP);
+  },
+  /**
+   * Returns the stream of SIGINFO signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGINFO).
+   */
+  info(): SignalStream {
+    return createSignalStream(Signal.SIGINFO);
+  },
+  /**
+   * Returns the stream of SIGINT signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGINT).
+   */
+  interrupt(): SignalStream {
+    return createSignalStream(Signal.SIGINT);
+  },
+  /**
+   * Returns the stream of SIGIO signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGIO).
+   */
+  io(): SignalStream {
+    return createSignalStream(Signal.SIGIO);
+  },
+  /**
+   * Returns the stream of SIGPIPE signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGPIPE).
+   */
+  pipe(): SignalStream {
+    return createSignalStream(Signal.SIGPIPE);
+  },
+  /**
+   * Returns the stream of SIGQUIT signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGQUIT).
+   */
+  quit(): SignalStream {
+    return createSignalStream(Signal.SIGQUIT);
+  },
+  /**
+   * Returns the stream of SIGTERM signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGTERM).
+   */
+  terminate(): SignalStream {
+    return createSignalStream(Signal.SIGTERM);
+  },
+  /**
+   * Returns the stream of SIGUSR1 signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGUSR1).
+   */
+  userDefined1(): SignalStream {
+    return createSignalStream(Signal.SIGUSR1);
+  },
+  /**
+   * Returns the stream of SIGUSR2 signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGUSR2).
+   */
+  userDefined2(): SignalStream {
+    return createSignalStream(Signal.SIGUSR2);
+  },
+  /**
+   * Returns the stream of SIGWINCH signals.
+   * This method is the short hand for Deno.signal(Deno.Signal.SIGWINCH).
+   */
+  windowChange(): SignalStream {
+    return createSignalStream(Signal.SIGWINCH);
+  }
+};
+
+const createSignalStream = (signal: number): SignalStream => {
+  if (build.os === "win") {
+    throw new Error("not implemented!");
+  }
+  return new SignalStream(signal);
+};
+
+const STREAM_DISPOSED_MESSAGE =
+  "No signal is available because signal stream is disposed";
+
+export class SignalStream implements AsyncIterator<void>, PromiseLike<void> {
+  private rid: number;
+  private currentPromise: Promise<void> = Promise.resolve();
+  private disposed = false;
+  constructor(signo: number) {
+    this.rid = sendSync(dispatch.OP_BIND_SIGNAL, { signo }).rid;
+    this.loop();
+  }
+
+  private async pollSignal(): Promise<void> {
+    const { done } = await sendAsync(dispatch.OP_POLL_SIGNAL, {
+      rid: this.rid
+    });
+
+    if (done) {
+      throw new DenoError(ErrorKind.StreamDisposed, STREAM_DISPOSED_MESSAGE);
+    }
+  }
+
+  private async loop(): Promise<void> {
+    while (!this.disposed) {
+      this.currentPromise = this.pollSignal();
+      try {
+        await this.currentPromise;
+      } catch (e) {
+        if (e instanceof DenoError && e.kind === ErrorKind.StreamDisposed) {
+          // If the stream is disposed, then returns silently.
+          return;
+        }
+        // If it's not StreamDisposed error, it's an unexpected error.
+        throw e;
+      }
+    }
+  }
+
+  then<T, S>(
+    f: (v: void) => T | Promise<T>,
+    g?: (v: void) => S | Promise<S>
+  ): Promise<T | S> {
+    return this.currentPromise.then(f, g);
+  }
+
+  async next(): Promise<IteratorResult<void>> {
+    try {
+      await this.currentPromise;
+      return { done: false, value: undefined };
+    } catch (e) {
+      if (e instanceof DenoError && e.kind === ErrorKind.StreamDisposed) {
+        return { done: true, value: undefined };
+      }
+      throw e;
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<void> {
+    return this;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    sendSync(dispatch.OP_UNBIND_SIGNAL, { rid: this.rid });
+  }
+}

--- a/cli/js/unit_tests.ts
+++ b/cli/js/unit_tests.ts
@@ -42,6 +42,7 @@ import "./read_link_test.ts";
 import "./rename_test.ts";
 import "./request_test.ts";
 import "./resources_test.ts";
+import "./signal_test.ts";
 import "./stat_test.ts";
 import "./symbols_test.ts";
 import "./symlink_test.ts";

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -44,7 +44,7 @@ mod progress;
 mod repl;
 pub mod resolve_addr;
 mod shell;
-mod signal;
+pub mod signal;
 pub mod source_maps;
 mod startup_data;
 pub mod state;

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -21,6 +21,7 @@ pub mod process;
 pub mod random;
 pub mod repl;
 pub mod resources;
+pub mod signal;
 pub mod timers;
 pub mod tls;
 pub mod workers;

--- a/cli/ops/signal.rs
+++ b/cli/ops/signal.rs
@@ -1,0 +1,139 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+#[cfg(unix)]
+use super::dispatch_json::Deserialize;
+use super::dispatch_json::{JsonOp, Value};
+#[cfg(unix)]
+use crate::deno_error::bad_resource;
+use crate::ops::json_op;
+#[cfg(unix)]
+use crate::signal::SignalStreamResource;
+use crate::state::ThreadSafeState;
+use deno_core::*;
+#[cfg(unix)]
+use futures::future::{poll_fn, FutureExt};
+#[cfg(unix)]
+use serde_json;
+#[cfg(unix)]
+use tokio::signal::unix::{signal, SignalKind};
+
+pub fn init(i: &mut Isolate, s: &ThreadSafeState) {
+  i.register_op(
+    "bind_signal",
+    s.core_op(json_op(s.stateful_op(op_bind_signal))),
+  );
+  i.register_op(
+    "unbind_signal",
+    s.core_op(json_op(s.stateful_op(op_unbind_signal))),
+  );
+  i.register_op(
+    "poll_signal",
+    s.core_op(json_op(s.stateful_op(op_poll_signal))),
+  );
+}
+
+#[cfg(unix)]
+#[derive(Deserialize)]
+struct BindSignalArgs {
+  signo: i32,
+}
+
+#[cfg(unix)]
+#[derive(Deserialize)]
+struct UnbindSignalArgs {
+  rid: i32,
+}
+
+#[cfg(unix)]
+#[derive(Deserialize)]
+struct PollSignalArgs {
+  rid: i32,
+}
+
+#[cfg(unix)]
+fn op_bind_signal(
+  state: &ThreadSafeState,
+  args: Value,
+  _zero_copy: Option<PinnedBuf>,
+) -> Result<JsonOp, ErrBox> {
+  let args: BindSignalArgs = serde_json::from_value(args)?;
+  let mut table = state.lock_resource_table();
+  let rid = table.add(
+    "signal",
+    Box::new(SignalStreamResource(
+      signal(SignalKind::from_raw(args.signo)).expect(""),
+      None,
+    )),
+  );
+  Ok(JsonOp::Sync(json!({
+    "rid": rid,
+  })))
+}
+
+#[cfg(unix)]
+fn op_poll_signal(
+  state: &ThreadSafeState,
+  args: Value,
+  _zero_copy: Option<PinnedBuf>,
+) -> Result<JsonOp, ErrBox> {
+  let args: PollSignalArgs = serde_json::from_value(args)?;
+  let rid = args.rid as u32;
+  let state_ = state.clone();
+
+  let future = poll_fn(move |cx| {
+    let mut table = state_.lock_resource_table();
+    if let Some(mut signal) = table.get_mut::<SignalStreamResource>(rid) {
+      signal.1 = Some(cx.waker().clone());
+      return signal.0.poll_recv(cx);
+    }
+    std::task::Poll::Ready(None)
+  })
+  .then(|result| async move { Ok(json!({ "done": result.is_none() })) });
+
+  Ok(JsonOp::Async(future.boxed()))
+}
+
+#[cfg(unix)]
+pub fn op_unbind_signal(
+  state: &ThreadSafeState,
+  args: Value,
+  _zero_copy: Option<PinnedBuf>,
+) -> Result<JsonOp, ErrBox> {
+  let args: UnbindSignalArgs = serde_json::from_value(args)?;
+  let rid = args.rid as u32;
+  let mut table = state.lock_resource_table();
+  let resource = table.get::<SignalStreamResource>(rid);
+  if let Some(signal) = resource {
+    if let Some(waker) = &signal.1 {
+      waker.clone().wake();
+    }
+  }
+  table.close(rid).ok_or_else(bad_resource)?;
+  Ok(JsonOp::Sync(json!({})))
+}
+
+#[cfg(not(unix))]
+pub fn op_bind_signal(
+  _state: &ThreadSafeState,
+  _args: Value,
+  _zero_copy: Option<PinnedBuf>,
+) -> Result<JsonOp, ErrBox> {
+  unimplemented!();
+}
+
+#[cfg(not(unix))]
+fn op_unbind_signal(
+  _state: &ThreadSafeState,
+  _args: Value,
+  _zero_copy: Option<PinnedBuf>,
+) -> Result<JsonOp, ErrBox> {
+  unimplemented!();
+}
+
+#[cfg(not(unix))]
+fn op_poll_signal(
+  _state: &ThreadSafeState,
+  _args: Value,
+  _zero_copy: Option<PinnedBuf>,
+) -> Result<JsonOp, ErrBox> {
+  unimplemented!();
+}

--- a/cli/signal.rs
+++ b/cli/signal.rs
@@ -1,4 +1,10 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use deno_core::ErrBox;
+#[cfg(unix)]
+use deno_core::Resource;
+
+#[cfg(unix)]
+use tokio::signal::unix::Signal;
 
 #[cfg(unix)]
 pub fn kill(pid: i32, signo: i32) -> Result<(), ErrBox> {
@@ -14,3 +20,9 @@ pub fn kill(_pid: i32, _signal: i32) -> Result<(), ErrBox> {
   // TODO: implement this for windows
   Ok(())
 }
+
+#[cfg(unix)]
+pub struct SignalStreamResource(pub Signal, pub Option<std::task::Waker>);
+
+#[cfg(unix)]
+impl Resource for SignalStreamResource {}

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -72,6 +72,7 @@ impl Worker {
       ops::random::init(&mut i, &state);
       ops::repl::init(&mut i, &state);
       ops::resources::init(&mut i, &state);
+      ops::signal::init(&mut i, &state);
       ops::timers::init(&mut i, &state);
       ops::workers::init(&mut i, &state);
 

--- a/std/manual.md
+++ b/std/manual.md
@@ -428,6 +428,39 @@ Uncaught NotFound: No such file or directory (os error 2)
     at handleAsyncMsgFromRust (deno/js/dispatch.ts:27:17)
 ```
 
+### Handle OS Signals
+
+[API Reference](https://deno.land/typedoc/index.html#signal)
+
+You can use `Deno.signal()` function for handling OS signals.
+
+```
+for await (const _ of Deno.signal(Deno.Signal.SIGINT)) {
+  console.log("interrupted!");
+}
+```
+
+`Deno.signal()` also works as a promise.
+
+```
+await Deno.signal(Deno.Singal.SIGINT);
+console.log("interrupted!");
+```
+
+If you want to stop watching the signal, you can use `dispose()` method of the
+signal object.
+
+```
+const sig = Deno.signal(Deno.Signal.SIGINT);
+setTimeout(() => { sig.dispose(); }, 5000);
+
+for await (const _ of sig) {
+  console.log("interrupted");
+}
+```
+
+The above for-await loop exits after 5 seconds when sig.dispose() is called.
+
 ### Linking to third party code
 
 In the above examples, we saw that Deno could execute scripts from URLs. Like


### PR DESCRIPTION
This PR tries to add signal handler APIs. This PR depends on tokio::signal::unix module (v0.2.6) and it supports only unix environment.

This PR adds the following JS APIs:

Streaming API
```ts
for await (const _ for Deno.signal(Deno.Signal.SIGTERM)) {
  console.log("SIGTERM received!");
}
```

Promise API
```ts
await Deno.signal(Deno.Signal.SIGTERM);
console.log("SIGTERM!");
```

and also the stream can be disposed:
```ts
const sig = Deno.signal(Deno.Signal.SIGTERM);
setTimeout(() => { sig.dispose(); }, 5000);

for await (const _ for sig) {
  console.log("SIGTERM received!");
}
```

The above for-await loop exits after 5000ms.

This PR also adds the following shorthand functions:
```ts
Deno.signals.alarm(); // for SIGALRM
Deno.signals.child(); // for SIGCHLD
Deno.signals.hungup(); // for SIGHUP
Deno.signals.info(); // for SIGINFO
Deno.signals.interrupt(); // for SIGINT
Deno.signals.io(); // for SIGIO
Deno.signals.pipe(); // for SIGPIPE
Deno.signals.quit(); // for SIGQUIT
Deno.signals.terminate(); // for SIGTERM
Deno.signals.userDefined1(); // for SIGUSR1
Deno.signals.userDefined2(); // for SIGURS2
Deno.signals.windowChange(); // for SIGWINCH
```
These short hand names are inspired by methods of `tokio::signal::unix::SignalKind`.

---

This PR adds 3 ops:
- op_bind_signal (start watching signals)
- op_poll_singal (poll single signal)
- op_unbind_signal (stop watching signals)

And 1 resource:
- SignalStreamResource

remaining tasks:
- [x] unit tests
- [x] add docs/examples
- [x] add all shorthand methods
- [x] update lib.deno_runtime.d.ts
- [x] fix panic at sig.dispose()
- [x] for-await loop doesn't end after sig.dispose() -> now it works.
- [ ] modify handling of pending_ops

---
First I started with the API design loosely following the suggestion by @sholladay at the comment ( https://github.com/denoland/deno/issues/2339#issuecomment-534327022 ), and then I changed it a little inspired by tokio's naming of SignalKind shorthands https://tokio-rs.github.io/tokio/doc/src/tokio/signal/unix.rs.html#82


---
closes #2339