### PR TITLE
feat: Deno.create

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -7,6 +7,8 @@ export {
   File,
   open,
   openSync,
+  create,
+  createSync,
   stdin,
   stdout,
   stderr,

--- a/cli/js/files.ts
+++ b/cli/js/files.ts
@@ -39,6 +39,24 @@ export async function open(
   return new File(rid);
 }
 
+/** Creates a file if none exists or truncates an existing file and returns
+ *  an instance of the `File` object synchronously.
+ *
+ *       const file = Deno.createSync("/foo/bar.txt");
+ */
+export function createSync(filename: string): File {
+  return openSync(filename, "w+");
+}
+
+/** Creates a file if none exists or truncates an existing file and returns
+ *  an instance of the `File` object.
+ *
+ *       const file = await Deno.create("/foo/bar.txt");
+ */
+export function create(filename: string): Promise<File> {
+  return open(filename, "w+");
+}
+
 /** Read synchronously from a file ID into an array buffer.
  *
  * Return `number | EOF` for the operation.
@@ -223,11 +241,3 @@ export type OpenMode =
   | "x"
   /** Read-write. Behaves like `x` and allows to read from file. */
   | "x+";
-
-/** A factory function for creating instances of `File` associated with the
- * supplied file name.
- * @internal
- */
-export function create(filename: string): Promise<File> {
-  return open(filename, "w+");
-}

--- a/cli/js/files_test.ts
+++ b/cli/js/files_test.ts
@@ -161,7 +161,7 @@ testPerm({ read: true, write: true }, async function createFile(): Promise<
 > {
   const tempDir = await Deno.makeTempDir();
   const filename = tempDir + "/test.txt";
-  const f = await Deno.open(filename, "w");
+  const f = await Deno.create(filename);
   let fileInfo = Deno.statSync(filename);
   assert(fileInfo.isFile());
   assert(fileInfo.len === 0);

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -306,6 +306,18 @@ declare namespace Deno {
    *       })();
    */
   export function open(filename: string, mode?: OpenMode): Promise<File>;
+    /** Creates a file if none exists or truncates an existing file and returns
+   *  an instance of the `File` object synchronously.
+   *
+   *       const file = Deno.createSync("/foo/bar.txt");
+   */
+  export function createSync(filename: string): File;
+  /** Creates a file if none exists or truncates an existing file and returns
+   *  an instance of the `File` object.
+   *
+   *       const file = await Deno.create("/foo/bar.txt");
+   */
+  export function create(filename: string): Promise<File>;
   /** Read synchronously from a file ID into an array buffer.
    *
    * Return `number | EOF` for the operation.

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -306,7 +306,7 @@ declare namespace Deno {
    *       })();
    */
   export function open(filename: string, mode?: OpenMode): Promise<File>;
-    /** Creates a file if none exists or truncates an existing file and returns
+  /** Creates a file if none exists or truncates an existing file and returns
    *  an instance of the `File` object synchronously.
    *
    *       const file = Deno.createSync("/foo/bar.txt");


### PR DESCRIPTION
Made Deno.create not `@internal` and added to `lib.deno_runtime.d.ts`. Fixes #3627.