### PR TITLE
std: add `dispatch_stateful` (plugin resources)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_dispatch_stateful"
+version = "0.1.0"
+dependencies = [
+ "deno_core 0.28.1",
+]
+
+[[package]]
 name = "deno_typescript"
 version = "0.28.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
   "core",
   "tools/hyper_hello",
   "deno_typescript",
-  "test_plugin"
+  "test_plugin",
+  "std/plugins/dispatch_stateful"
 ]

--- a/core/resources.rs
+++ b/core/resources.rs
@@ -76,5 +76,5 @@ impl ResourceTable {
 /// The only thing it does is implementing `Downcast` trait
 /// that allows to cast resource to concrete type in `TableResource::get`
 /// and `TableResource::get_mut` methods.
-pub trait Resource: Downcast + Any + Send {}
+pub trait Resource: Downcast + Any + Send + Sync {}
 impl_downcast!(Resource);

--- a/std/plugins/dispatch_stateful/Cargo.toml
+++ b/std/plugins/dispatch_stateful/Cargo.toml
@@ -1,0 +1,14 @@
+# Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+[package]
+name = "deno_dispatch_stateful"
+version = "0.1.0"
+authors = ["afinch7 <andyfinch7@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+deno_core = { path = "../../../core" }

--- a/std/plugins/dispatch_stateful/lib.rs
+++ b/std/plugins/dispatch_stateful/lib.rs
@@ -1,0 +1,48 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+use deno_core::*;
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::sync::RwLockReadGuard;
+use std::sync::RwLockWriteGuard;
+
+#[derive(Default)]
+pub struct PluginState {
+  resource_table: Arc<RwLock<ResourceTable>>,
+}
+
+impl Clone for PluginState {
+  fn clone(&self) -> Self {
+    PluginState {
+      resource_table: self.resource_table.clone(),
+    }
+  }
+}
+
+type StatefulOpFn = dyn Fn(&PluginState, &[u8], Option<PinnedBuf>) -> CoreOp
+  + Send
+  + Sync
+  + 'static;
+
+impl PluginState {
+  pub fn lock_resources_mut(&self) -> RwLockWriteGuard<ResourceTable> {
+    self.resource_table.write().unwrap()
+  }
+
+  pub fn lock_resources(&self) -> RwLockReadGuard<ResourceTable> {
+    self.resource_table.read().unwrap()
+  }
+
+  pub fn stateful_op(
+    &self,
+    d: Box<StatefulOpFn>,
+  ) -> Box<dyn Fn(&[u8], Option<PinnedBuf>) -> CoreOp + Send + Sync + 'static>
+  {
+    let state = self.clone();
+
+    Box::new(
+      move |control: &[u8], zero_copy: Option<PinnedBuf>| -> CoreOp {
+        d(&state, control, zero_copy)
+      },
+    )
+  }
+}

--- a/std/plugins/mod.ts
+++ b/std/plugins/mod.ts
@@ -1,0 +1,2 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+export * from "./plugin_filename.ts";

--- a/std/plugins/plugin_filename.ts
+++ b/std/plugins/plugin_filename.ts
@@ -1,0 +1,30 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+export type PluginFilenamePrefixType = "lib" | "";
+
+export const pluginFilenamePrefix = ((): PluginFilenamePrefixType => {
+  switch (Deno.build.os) {
+    case "linux":
+    case "mac":
+      return "lib";
+    case "win":
+    default:
+      return "";
+  }
+})();
+
+export type PluginFilenameExtensionType = "so" | "dylib" | "dll";
+
+export const pluginFilenameExtension = ((): PluginFilenameExtensionType => {
+  switch (Deno.build.os) {
+    case "linux":
+      return "so";
+    case "mac":
+      return "dylib";
+    case "win":
+      return "dll";
+  }
+})();
+
+export function pluginFilename(filenameBase: string): string {
+  return pluginFilenamePrefix + filenameBase + "." + pluginFilenameExtension;
+}

--- a/std/plugins/plugin_filename_test.ts
+++ b/std/plugins/plugin_filename_test.ts
@@ -1,0 +1,22 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { test } from "../testing/mod.ts";
+import { assertEquals, assert } from "../testing/asserts.ts";
+import { pluginFilename } from "./plugin_filename.ts";
+
+test(function filename() {
+  const filename = pluginFilename("someLib_Name");
+  switch (Deno.build.os) {
+    case "linux":
+      assertEquals(filename, "libsomeLib_Name.so");
+      break;
+    case "mac":
+      assertEquals(filename, "libsomeLib_Name.dylib");
+      break;
+    case "win":
+      assertEquals(filename, "someLib_Name.dll");
+      break;
+    default:
+      assert(false);
+      break;
+  }
+});


### PR DESCRIPTION
depends on #3471
This adds a wrapper for plugin ops that functions like state in cli and provides a single resource table per instance.
Example usage:
``` rust
#[macro_use]
extern crate deno_core;

use deno_core::*;
use deno_dispatch_stateful::PluginState;

pub fn init(cx: &mut dyn PluginInitContext) {
  // Create new PluginState
  let state = PluginState::new();
  // Register new "stateful op" using the state from above.
  cx.register_op(
    "someStatefulOp",
    state.stateful_op(Box::new(op_some_stateful_op)),
  );
}

init_fn!(init);

fn op_some_stateful_op(
  state: &PluginState,
  control: &[u8],
  zero_copy: Option<PinnedBuf>
) -> CoreOp {
  // Lock resource table as mutable
  let mut table = state.lock_resources_mut();
  // Create our new resource
  let new_resource = some_lib::ResourceType::new();
  // Insert it into the resource table
  let rid = table.add("some_resource_type", Box::new(new_resource));
  // Return new rid(u32) encoded to [u8; 4]
  CoreOp::Sync(Box::new(rid.to_ne_bytes()));
}
```
This should work pretty well, but some things like `Deno.close` won't work with this solution(see #3453).