### PR TITLE
feat: plugin resource table access

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -111,9 +111,9 @@ fn create_main_worker(
     let (stdin, stdout, stderr) = get_stdio();
     let _table = state.resource_table();
     let mut table = _table.borrow_mut();
+    table.add("stdin", Box::new(stdin));
     table.add("stdout", Box::new(stdout));
     table.add("stderr", Box::new(stderr));
-    table.add("stdin", Box::new(stdin));
   }
 
   let mut worker = MainWorker::new(

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -108,11 +108,12 @@ fn create_main_worker(
   let state = State::new(global_state, None, main_module)?;
 
   {
-    let mut s = state.borrow_mut();
     let (stdin, stdout, stderr) = get_stdio();
-    s.resource_table.add("stdin", Box::new(stdin));
-    s.resource_table.add("stdout", Box::new(stdout));
-    s.resource_table.add("stderr", Box::new(stderr));
+    let _table = state.resource_table();
+    let mut table = _table.borrow_mut();
+    table.add("stdout", Box::new(stdout));
+    table.add("stderr", Box::new(stderr));
+    table.add("stdin", Box::new(stdin));
   }
 
   let mut worker = MainWorker::new(

--- a/cli/ops/fetch.rs
+++ b/cli/ops/fetch.rs
@@ -66,8 +66,7 @@ pub fn op_fetch(
     }
 
     let body = HttpBody::from(res);
-    let mut state = state_.borrow_mut();
-    let rid = state.resource_table.add(
+    let rid = state_.resource_table().borrow_mut().add(
       "httpBody",
       Box::new(StreamResource::HttpBody(Box::new(body))),
     );

--- a/cli/ops/fs_events.rs
+++ b/cli/ops/fs_events.rs
@@ -95,8 +95,10 @@ pub fn op_fs_events_open(
     watcher.watch(path, recursive_mode)?;
   }
   let resource = FsEventsResource { watcher, receiver };
-  let table = &mut state.borrow_mut().resource_table;
-  let rid = table.add("fsEvents", Box::new(resource));
+  let rid = state
+    .resource_table()
+    .borrow_mut()
+    .add("fsEvents", Box::new(resource));
   Ok(JsonOp::Sync(json!(rid)))
 }
 
@@ -112,8 +114,9 @@ pub fn op_fs_events_poll(
   let PollArgs { rid } = serde_json::from_value(args)?;
   let state = state.clone();
   let f = poll_fn(move |cx| {
-    let resource_table = &mut state.borrow_mut().resource_table;
-    let watcher = resource_table
+    let _table = state.resource_table();
+    let mut table = _table.borrow_mut();
+    let watcher = table
       .get_mut::<FsEventsResource>(rid)
       .ok_or_else(bad_resource)?;
     watcher

--- a/cli/ops/io.rs
+++ b/cli/ops/io.rs
@@ -166,9 +166,9 @@ where
       panic!("poll a Read after it's done");
     }
 
-    let mut state = inner.state.borrow_mut();
-    let resource = state
-      .resource_table
+    let _table = inner.state.resource_table();
+    let mut table = _table.borrow_mut();
+    let resource = table
       .get_mut::<StreamResource>(inner.rid)
       .ok_or_else(bad_resource)?;
     let nread = ready!(resource.poll_read(cx, &mut inner.buf.as_mut()[..]))?;
@@ -295,9 +295,9 @@ where
     }
 
     if inner.io_state == IoState::Pending {
-      let mut state = inner.state.borrow_mut();
-      let resource = state
-        .resource_table
+      let _table = inner.state.resource_table();
+      let mut table = _table.borrow_mut();
+      let resource = table
         .get_mut::<StreamResource>(inner.rid)
         .ok_or_else(bad_resource)?;
 
@@ -311,9 +311,9 @@ where
     // Figure out why it's needed and preferably remove it.
     // https://github.com/denoland/deno/issues/3565
     if inner.io_state == IoState::Flush {
-      let mut state = inner.state.borrow_mut();
-      let resource = state
-        .resource_table
+      let _table = inner.state.resource_table();
+      let mut table = _table.borrow_mut();
+      let resource = table
         .get_mut::<StreamResource>(inner.rid)
         .ok_or_else(bad_resource)?;
       ready!(resource.poll_flush(cx))?;

--- a/cli/ops/plugins.rs
+++ b/cli/ops/plugins.rs
@@ -66,14 +66,10 @@ pub fn op_open_plugin(
     lib,
     ops: HashMap::new(),
   };
-  let mut state_ = state.borrow_mut();
-  let rid = state_
-    .resource_table
-    .add("plugin", Box::new(plugin_resource));
-  let plugin_resource = state_
-    .resource_table
-    .get_mut::<PluginResource>(rid)
-    .unwrap();
+  let _table = state.resource_table();
+  let mut table = _table.borrow_mut();
+  let rid = table.add("plugin", Box::new(plugin_resource));
+  let plugin_resource = table.get_mut::<PluginResource>(rid).unwrap();
 
   let init_fn = *unsafe {
     plugin_resource

--- a/cli/ops/plugins.rs
+++ b/cli/ops/plugins.rs
@@ -32,6 +32,16 @@ struct PluginResource {
 
 struct InitContext {
   ops: HashMap<String, Box<OpDispatcher>>,
+  state: PluginState,
+}
+
+impl InitContext {
+  fn new(state: State) -> Self {
+    Self {
+      ops: HashMap::new(),
+      state: PluginState::new(state.resource_table()),
+    }
+  }
 }
 
 impl PluginInitContext for InitContext {
@@ -41,6 +51,10 @@ impl PluginInitContext for InitContext {
       existing.is_none(),
       format!("Op already registered: {}", name)
     );
+  }
+
+  fn state(&self) -> PluginState {
+    self.state.clone()
   }
 }
 
@@ -76,9 +90,7 @@ pub fn op_open_plugin(
       .lib
       .symbol::<PluginInitFn>("deno_plugin_init")
   }?;
-  let mut init_context = InitContext {
-    ops: HashMap::new(),
-  };
+  let mut init_context = InitContext::new(state.clone());
   init_fn(&mut init_context);
   for op in init_context.ops {
     // Register each plugin op in the `OpRegistry` with the name

--- a/cli/ops/process.rs
+++ b/cli/ops/process.rs
@@ -31,9 +31,9 @@ pub fn init(i: &mut Isolate, s: &State) {
 }
 
 fn clone_file(rid: u32, state: &State) -> Result<std::fs::File, ErrBox> {
-  let mut state = state.borrow_mut();
-  let repr = state
-    .resource_table
+  let _table = state.resource_table();
+  let mut table = _table.borrow_mut();
+  let repr = table
     .get_mut::<StreamResource>(rid)
     .ok_or_else(bad_resource)?;
   let file = match repr {
@@ -128,8 +128,8 @@ fn op_run(
   let mut child = c.spawn()?;
   let pid = child.id();
 
-  let mut state = state_.borrow_mut();
-  let table = &mut state.resource_table;
+  let _table = state.resource_table();
+  let mut table = _table.borrow_mut();
 
   let stdin_rid = match child.stdin.take() {
     Some(child_stdin) => {
@@ -186,9 +186,9 @@ impl Future for ChildStatus {
 
   fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
     let inner = self.get_mut();
-    let mut state = inner.state.borrow_mut();
-    let child_resource = state
-      .resource_table
+    let _table = inner.state.resource_table();
+    let mut table = _table.borrow_mut();
+    let child_resource = table
       .get_mut::<ChildResource>(inner.rid)
       .ok_or_else(bad_resource)?;
     let child = &mut child_resource.child;

--- a/cli/ops/repl.rs
+++ b/cli/ops/repl.rs
@@ -39,9 +39,11 @@ fn op_repl_start(
   let history_path =
     repl::history_path(&state.borrow().global_state.dir, &args.history_file);
   let repl = repl::Repl::new(history_path);
-  let mut state = state.borrow_mut();
   let resource = ReplResource(Arc::new(Mutex::new(repl)));
-  let rid = state.resource_table.add("repl", Box::new(resource));
+  let rid = state
+    .resource_table()
+    .borrow_mut()
+    .add("repl", Box::new(resource));
   Ok(JsonOp::Sync(json!(rid)))
 }
 
@@ -60,11 +62,9 @@ fn op_repl_readline(
   let rid = args.rid as u32;
   let prompt = args.prompt;
   debug!("op_repl_readline {} {}", rid, prompt);
-  let state = state.borrow();
-  let resource = state
-    .resource_table
-    .get::<ReplResource>(rid)
-    .ok_or_else(bad_resource)?;
+  let _table = state.resource_table();
+  let table = _table.borrow();
+  let resource = table.get::<ReplResource>(rid).ok_or_else(bad_resource)?;
   let repl = resource.0.clone();
 
   blocking_json(false, move || {

--- a/cli/ops/resources.rs
+++ b/cli/ops/resources.rs
@@ -13,7 +13,6 @@ fn op_resources(
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, ErrBox> {
-  let state = state.borrow();
-  let serialized_resources = state.resource_table.entries();
+  let serialized_resources = state.resource_table().borrow().entries();
   Ok(JsonOp::Sync(json!(serialized_resources)))
 }

--- a/cli/ops/signal.rs
+++ b/cli/ops/signal.rs
@@ -103,7 +103,7 @@ pub fn op_signal_unbind(
   let args: SignalArgs = serde_json::from_value(args)?;
   let rid = args.rid as u32;
   let _table = state.resource_table();
-  let table = _table.borrow();
+  let mut table = _table.borrow_mut();
   let resource = table.get::<SignalStreamResource>(rid);
   if let Some(signal) = resource {
     if let Some(waker) = &signal.1 {
@@ -112,11 +112,7 @@ pub fn op_signal_unbind(
       waker.clone().wake();
     }
   }
-  state
-    .resource_table()
-    .borrow_mut()
-    .close(rid)
-    .ok_or_else(bad_resource)?;
+  table.close(rid).ok_or_else(bad_resource)?;
   Ok(JsonOp::Sync(json!({})))
 }
 

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -57,7 +57,7 @@ pub struct StateInner {
   pub next_worker_id: u32,
   pub start_time: Instant,
   pub seeded_rng: Option<StdRng>,
-  pub resource_table: ResourceTable,
+  pub resource_table: Rc<RefCell<ResourceTable>>,
   pub target_lib: TargetLib,
 }
 
@@ -137,6 +137,10 @@ impl State {
     move |args: Value,
           zero_copy: Option<ZeroCopyBuf>|
           -> Result<JsonOp, ErrBox> { dispatcher(&state, args, zero_copy) }
+  }
+
+  pub fn resource_table(&self) -> Rc<RefCell<ResourceTable>> {
+    self.borrow().resource_table.clone()
   }
 }
 
@@ -234,7 +238,7 @@ impl State {
       start_time: Instant::now(),
       seeded_rng,
 
-      resource_table: ResourceTable::default(),
+      resource_table: Rc::new(RefCell::new(ResourceTable::default())),
       target_lib: TargetLib::Main,
     }));
 
@@ -270,7 +274,7 @@ impl State {
       start_time: Instant::now(),
       seeded_rng,
 
-      resource_table: ResourceTable::default(),
+      resource_table: Rc::new(RefCell::new(ResourceTable::default())),
       target_lib: TargetLib::Worker,
     }));
 

--- a/core/plugins.rs
+++ b/core/plugins.rs
@@ -1,7 +1,35 @@
 use crate::isolate::ZeroCopyBuf;
 use crate::ops::CoreOp;
+use crate::resources::ResourceTable;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub struct PluginState {
+  resource_table: Rc<RefCell<ResourceTable>>,
+}
+
+impl Clone for PluginState {
+  fn clone(&self) -> Self {
+    PluginState {
+      resource_table: self.resource_table.clone(),
+    }
+  }
+}
+
+impl PluginState {
+  pub fn new(resource_table: Rc<RefCell<ResourceTable>>) -> Self {
+    Self { resource_table }
+  }
+
+  pub fn resource_table(&self) -> Rc<RefCell<ResourceTable>> {
+    self.resource_table.clone()
+  }
+}
 
 pub type PluginInitFn = fn(context: &mut dyn PluginInitContext);
+
+type StatefulOpFn =
+  dyn Fn(&PluginState, &[u8], Option<ZeroCopyBuf>) -> CoreOp + 'static;
 
 pub trait PluginInitContext {
   fn register_op(
@@ -9,6 +37,21 @@ pub trait PluginInitContext {
     name: &str,
     op: Box<dyn Fn(&[u8], Option<ZeroCopyBuf>) -> CoreOp + 'static>,
   );
+
+  fn state(&self) -> PluginState;
+
+  fn stateful_op(
+    &self,
+    op: Box<StatefulOpFn>,
+  ) -> Box<dyn Fn(&[u8], Option<ZeroCopyBuf>) -> CoreOp + 'static> {
+    let state = self.state();
+
+    Box::new(
+      move |control: &[u8], zero_copy: Option<ZeroCopyBuf>| -> CoreOp {
+        op(&state, control, zero_copy)
+      },
+    )
+  }
 }
 
 #[macro_export]

--- a/test_plugin/src/lib.rs
+++ b/test_plugin/src/lib.rs
@@ -1,17 +1,17 @@
-#[macro_use]
-extern crate deno_core;
 extern crate futures;
 
-use deno_core::CoreOp;
-use deno_core::Op;
-use deno_core::PluginInitContext;
-use deno_core::{Buf, ZeroCopyBuf};
+use deno_core::*;
 use futures::future::FutureExt;
 
 fn init(context: &mut dyn PluginInitContext) {
   context.register_op("testSync", Box::new(op_test_sync));
   context.register_op("testAsync", Box::new(op_test_async));
+  context.register_op(
+    "createResource",
+    context.stateful_op(Box::new(op_create_resource)),
+  );
 }
+
 init_fn!(init);
 
 pub fn op_test_sync(data: &[u8], zero_copy: Option<ZeroCopyBuf>) -> CoreOp {
@@ -50,4 +50,27 @@ pub fn op_test_async(data: &[u8], zero_copy: Option<ZeroCopyBuf>) -> CoreOp {
   };
 
   Op::Async(fut.boxed())
+}
+
+struct TestResource {
+  pub name: String,
+}
+
+impl Drop for TestResource {
+  fn drop(&mut self) {
+    println!("Dropped resource: {}", self.name)
+  }
+}
+
+pub fn op_create_resource(
+  state: &PluginState,
+  data: &[u8],
+  _zero_copy: Option<ZeroCopyBuf>,
+) -> CoreOp {
+  let name = std::str::from_utf8(&data[..]).unwrap().to_string();
+  let _table = state.resource_table();
+  let mut table = _table.borrow_mut();
+  let resource = TestResource { name };
+  let rid = table.add("testResource", Box::new(resource));
+  Op::Sync(Box::new(rid.to_be_bytes()))
 }

--- a/test_plugin/tests/integration_tests.rs
+++ b/test_plugin/tests/integration_tests.rs
@@ -26,7 +26,7 @@ fn basic() {
   let _build_plugin_output = build_plugin.output().unwrap();
   let output = deno_cmd()
     .arg("--allow-plugin")
-    .arg("tests/test.js")
+    .arg("tests/test_basic.js")
     .arg(BUILD_VARIANT)
     .output()
     .unwrap();
@@ -41,6 +41,40 @@ fn basic() {
     "Hello from plugin. data: test | zero_copy: test\nPlugin Sync Response: test\r\nHello from plugin. data: test | zero_copy: test\nPlugin Async Response: test\r\n"
   } else {
     "Hello from plugin. data: test | zero_copy: test\nPlugin Sync Response: test\nHello from plugin. data: test | zero_copy: test\nPlugin Async Response: test\n"
+  };
+  assert_eq!(stdout, expected);
+  assert_eq!(stderr, "");
+}
+
+// TODO(ry) Re-enable this test on windows. It is flaky for an unknown reason.
+// Actually not sure if this one will be flaky but disabling it out of caution.
+#[cfg(not(windows))]
+#[test]
+fn resources() {
+  let mut build_plugin_base = Command::new("cargo");
+  let mut build_plugin =
+    build_plugin_base.arg("build").arg("-p").arg("test_plugin");
+  if BUILD_VARIANT == "release" {
+    build_plugin = build_plugin.arg("--release");
+  }
+  let _build_plugin_output = build_plugin.output().unwrap();
+  let output = deno_cmd()
+    .arg("--allow-plugin")
+    .arg("tests/test_resources.js")
+    .arg(BUILD_VARIANT)
+    .output()
+    .unwrap();
+  let stdout = std::str::from_utf8(&output.stdout).unwrap();
+  let stderr = std::str::from_utf8(&output.stderr).unwrap();
+  if !output.status.success() {
+    println!("stdout {}", stdout);
+    println!("stderr {}", stderr);
+  }
+  assert!(output.status.success());
+  let expected = if cfg!(target_os = "windows") {
+    "testResource\r\ntestResource\r\nDropped resource: two\nDropped resource: one\n"
+  } else {
+    "testResource\ntestResource\nDropped resource: two\nDropped resource: one\n"
   };
   assert_eq!(stdout, expected);
   assert_eq!(stderr, "");

--- a/test_plugin/tests/ops.js
+++ b/test_plugin/tests/ops.js
@@ -1,0 +1,20 @@
+const filenameBase = "test_plugin";
+
+let filenameSuffix = ".so";
+let filenamePrefix = "lib";
+
+if (Deno.build.os === "win") {
+  filenameSuffix = ".dll";
+  filenamePrefix = "";
+}
+if (Deno.build.os === "mac") {
+  filenameSuffix = ".dylib";
+}
+
+const filename = `../target/${Deno.args[0]}/${filenamePrefix}${filenameBase}${filenameSuffix}`;
+
+const plugin = Deno.openPlugin(filename);
+
+const { testSync, testAsync, createResource } = plugin.ops;
+
+export { testSync, testAsync, createResource };

--- a/test_plugin/tests/test_basic.js
+++ b/test_plugin/tests/test_basic.js
@@ -1,21 +1,4 @@
-const filenameBase = "test_plugin";
-
-let filenameSuffix = ".so";
-let filenamePrefix = "lib";
-
-if (Deno.build.os === "win") {
-  filenameSuffix = ".dll";
-  filenamePrefix = "";
-}
-if (Deno.build.os === "mac") {
-  filenameSuffix = ".dylib";
-}
-
-const filename = `../target/${Deno.args[0]}/${filenamePrefix}${filenameBase}${filenameSuffix}`;
-
-const plugin = Deno.openPlugin(filename);
-
-const { testSync, testAsync } = plugin.ops;
+import { testSync, testAsync } from "./ops.js";
 
 const textDecoder = new TextDecoder();
 

--- a/test_plugin/tests/test_resources.js
+++ b/test_plugin/tests/test_resources.js
@@ -1,0 +1,22 @@
+import { createResource as createResourceOp } from "./ops.js";
+
+const textEncoder = new TextEncoder();
+
+function createResource(name) {
+  const response = createResourceOp.dispatch(textEncoder.encode(name));
+  const rid = new DataView(response.buffer, 0, 4).getUint32(0);
+  return {
+    rid
+  };
+}
+
+function dropResource(resource) {
+  Deno.close(resource.rid);
+}
+
+const one = createResource("one");
+const two = createResource("two");
+console.log(Deno.resources()[one.rid]);
+console.log(Deno.resources()[two.rid]);
+dropResource(two);
+dropResource(one);


### PR DESCRIPTION
depends on #4072
fixes #3453
My main goal here is to provide a simple way to access the resource table for plugins. I feel like there should be some filter/mask here that blocks plugins from tampering with cli resources, but still allows utilities like `Deno.close` to work across the board.
Example usage:
```rust
#[macro_use]
extern crate deno_core;

use deno_core::*;

pub fn init(cx: &mut dyn PluginInitContext) {
  // Register new "stateful op" using the state from above.
  cx.register_op(
    "someStatefulOp",
    cx.stateful_op(Box::new(op_some_stateful_op)),
  );
}

init_fn!(init);

fn op_some_stateful_op(
  state: &PluginState,
  control: &[u8],
  zero_copy: Option<PinnedBuf>
) -> CoreOp {
  // Lock resource table as mutable
  let mut table = state.lock_resources_mut();
  // Create our new resource
  let new_resource = some_lib::ResourceType::new();
  // Insert it into the resource table
  let rid = table.add("some_resource_type", Box::new(new_resource));
  // Return new rid(u32) encoded to [u8; 4]
  CoreOp::Sync(Box::new(rid.to_ne_bytes()));
}
```
I would say this is a alternative to #3636, but private resources might still have a place in some applications.
cc @lucacasonato 