### PR TITLE
Create an old program to be used in snapshot.

### DIFF
--- a/cli/js.rs
+++ b/cli/js.rs
@@ -16,16 +16,6 @@ pub static COMPILER_SNAPSHOT_MAP: &[u8] =
 pub static COMPILER_SNAPSHOT_DTS: &[u8] =
   include_bytes!(concat!(env!("OUT_DIR"), "/COMPILER_SNAPSHOT.d.ts"));
 
-static DENO_RUNTIME: &str = include_str!("js/lib.deno_runtime.d.ts");
-
-/// Same as deno_typescript::get_asset but also has lib.deno_runtime.d.ts
-pub fn get_asset(name: &str) -> Option<&'static str> {
-  match name {
-    "lib.deno_runtime.d.ts" => Some(DENO_RUNTIME),
-    _ => deno_typescript::get_asset(name),
-  }
-}
-
 #[test]
 fn cli_snapshot() {
   let mut isolate = deno_core::Isolate::new(

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -85,10 +85,7 @@ let oldProgram: ts.Program;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (dispatch as any)[opName] = opId;
   }
-  const host = new Host({
-    bundle: false,
-    writeFile(): void {}
-  });
+  const host = new Host({ writeFile(): void {} });
   const options = host.getCompilationSettings();
   oldProgram = ts.createProgram({
     rootNames: [`${ASSETS}/example.ts`],
@@ -99,7 +96,7 @@ let oldProgram: ts.Program;
 
 // bootstrap the runtime environment, this gets called as the isolate is setup
 self.denoMain = function denoMain(compilerType?: string): void {
-  os.start(true, compilerType || "TS");
+  os.start(true, compilerType ?? "TS");
 };
 
 // bootstrap the worker environment, this gets called as the isolate is setup

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -81,14 +81,14 @@ let oldProgram: ts.Program;
 ((): void => {
   const ops = core.ops();
   for (const [name, opId] of Object.entries(ops)) {
-    const opName = `OP_${name.toUpperCase()}` as keyof typeof dispatch;
+    const opName = `OP_${name.toUpperCase()}`;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (dispatch as any)[opName] = opId;
   }
   const host = new Host({ writeFile(): void {} });
   const options = host.getCompilationSettings();
   oldProgram = ts.createProgram({
-    rootNames: [`${ASSETS}/example.ts`],
+    rootNames: [`${ASSETS}/bootstrap.ts`],
     options,
     host
   });

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -72,19 +72,14 @@ interface CompileResult {
   diagnostics?: Diagnostic;
 }
 
-// bootstrap the runtime environment, this gets called as the isolate is setup
-self.denoMain = function denoMain(compilerType?: string): void {
-  os.start(true, compilerType || "TS");
-};
-
-// bootstrap the worker environment, this gets called as the isolate is setup
-self.workerMain = workerMain;
-
 // this is used to generate the foundational AST for all other compilations, so
 // it can be cached as part of the
 let oldProgram: ts.Program;
 
-((): void => {
+// bootstrap the runtime environment, this gets called as the isolate is setup
+self.denoMain = function denoMain(compilerType?: string): void {
+  os.start(true, compilerType || "TS");
+
   const host = new Host({
     bundle: false,
     writeFile(): void {}
@@ -95,7 +90,10 @@ let oldProgram: ts.Program;
     options,
     host
   });
-})();
+};
+
+// bootstrap the worker environment, this gets called as the isolate is setup
+self.workerMain = workerMain;
 
 // provide the "main" function that will be called by the privileged side when
 // lazy instantiating the compiler web worker

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -6,9 +6,9 @@ import "./globals.ts";
 import "./ts_global.d.ts";
 
 import { TranspileOnlyResult } from "./compiler_api.ts";
+import { oldProgram } from "./compiler_bootstrap.ts";
 import { setRootExports } from "./compiler_bundler.ts";
 import {
-  ASSETS,
   defaultBundlerOptions,
   defaultRuntimeCompileOptions,
   defaultTranspileOptions,
@@ -27,9 +27,7 @@ import {
   WriteFileState,
   processConfigureResponse
 } from "./compiler_util.ts";
-import { core } from "./core.ts";
 import { Diagnostic } from "./diagnostics.ts";
-import * as dispatch from "./dispatch.ts";
 import { fromTypeScriptDiagnostic } from "./diagnostics_util.ts";
 import * as os from "./os.ts";
 import { assert } from "./util.ts";
@@ -73,26 +71,6 @@ interface CompileResult {
   emitSkipped: boolean;
   diagnostics?: Diagnostic;
 }
-
-// this is used to generate the foundational AST for all other compilations, so
-// it can be cached as part of the
-let oldProgram: ts.Program;
-
-((): void => {
-  const ops = core.ops();
-  for (const [name, opId] of Object.entries(ops)) {
-    const opName = `OP_${name.toUpperCase()}`;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (dispatch as any)[opName] = opId;
-  }
-  const host = new Host({ writeFile(): void {} });
-  const options = host.getCompilationSettings();
-  oldProgram = ts.createProgram({
-    rootNames: [`${ASSETS}/bootstrap.ts`],
-    options,
-    host
-  });
-})();
 
 // bootstrap the runtime environment, this gets called as the isolate is setup
 self.denoMain = function denoMain(compilerType?: string): void {

--- a/cli/js/compiler_bootstrap.ts
+++ b/cli/js/compiler_bootstrap.ts
@@ -1,0 +1,34 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { ASSETS, Host } from "./compiler_host.ts";
+import { core } from "./core.ts";
+import * as dispatch from "./dispatch.ts";
+import { sendSync } from "./dispatch_json.ts";
+
+// This registers ops that are available during the snapshotting process.
+const ops = core.ops();
+for (const [name, opId] of Object.entries(ops)) {
+  const opName = `OP_${name.toUpperCase()}`;
+  // TODO This type casting is dangerous, and should be improved when the same
+  // code in `os.ts` is done.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (dispatch as any)[opName] = opId;
+}
+
+const host = new Host({ writeFile(): void {} });
+const options = host.getCompilationSettings();
+
+/** Used to generate the foundational AST for all other compilations, so it can
+ * be cached as part of the snapshot and available to speed up startup */
+export const oldProgram = ts.createProgram({
+  rootNames: [`${ASSETS}/bootstrap.ts`],
+  options,
+  host
+});
+
+/** A module loader which is concatenated into bundle files.  We read all static
+ * assets during the snapshotting process, which is why this is located in
+ * compiler_bootstrap. */
+export const bundleLoader = sendSync(dispatch.OP_FETCH_ASSET, {
+  name: "bundle_loader.js"
+});

--- a/cli/js/compiler_bundler.ts
+++ b/cli/js/compiler_bundler.ts
@@ -1,18 +1,12 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import * as dispatch from "./dispatch.ts";
-import { sendSync } from "./dispatch_json.ts";
+import { bundleLoader } from "./compiler_bootstrap.ts";
 import {
   assert,
   commonPath,
   normalizeString,
   CHAR_FORWARD_SLASH
 } from "./util.ts";
-
-const BUNDLE_LOADER = "bundle_loader.js";
-
-/** A loader of bundled modules that we will inline into any bundle outputs. */
-let bundleLoader: string;
 
 /** Local state of what the root exports are of a root module. */
 let rootExports: string[] | undefined;
@@ -40,12 +34,6 @@ export function buildBundle(
   data: string,
   sourceFiles: readonly ts.SourceFile[]
 ): string {
-  // we can only do this once we are bootstrapped and easiest way to do it is
-  // inline here
-  if (!bundleLoader) {
-    bundleLoader = sendSync(dispatch.OP_FETCH_ASSET, { name: BUNDLE_LOADER });
-  }
-
   // when outputting to AMD and a single outfile, TypeScript makes up the module
   // specifiers which are used to define the modules, and doesn't expose them
   // publicly, so we have to try to replicate

--- a/cli/js/compiler_host.ts
+++ b/cli/js/compiler_host.ts
@@ -18,7 +18,7 @@ export interface ConfigureResponse {
   diagnostics?: ts.Diagnostic[];
 }
 
-const ASSETS = "$asset$";
+export const ASSETS = "$asset$";
 
 /** Options that need to be used when generating a bundle (either trusted or
  * runtime). */

--- a/cli/js/compiler_host.ts
+++ b/cli/js/compiler_host.ts
@@ -129,11 +129,11 @@ export class Host implements ts.CompilerHost {
   private _writeFile: WriteFileCallback;
 
   private _getAsset(filename: string): SourceFile {
-    const sourceFile = SourceFile.get(filename);
+    const url = filename.split("/").pop()!;
+    const sourceFile = SourceFile.get(url);
     if (sourceFile) {
       return sourceFile;
     }
-    const url = filename.split("/").pop()!;
     const name = url.includes(".") ? url : `${url}.d.ts`;
     const sourceCode = sendSync(dispatch.OP_FETCH_ASSET, { name });
     return new SourceFile({

--- a/cli/js/compiler_host.ts
+++ b/cli/js/compiler_host.ts
@@ -238,13 +238,15 @@ export class Host implements ts.CompilerHost {
         : SourceFile.get(fileName);
       assert(sourceFile != null);
       if (!sourceFile.tsSourceFile) {
+        assert(sourceFile.sourceCode != null);
         sourceFile.tsSourceFile = ts.createSourceFile(
           fileName,
           sourceFile.sourceCode,
           languageVersion
         );
+        delete sourceFile.sourceCode;
       }
-      return sourceFile!.tsSourceFile;
+      return sourceFile.tsSourceFile;
     } catch (e) {
       if (onError) {
         onError(String(e));

--- a/cli/js/compiler_sourcefile.ts
+++ b/cli/js/compiler_sourcefile.ts
@@ -61,7 +61,7 @@ export class SourceFile {
 
   mediaType!: MediaType;
   processed = false;
-  sourceCode!: string;
+  sourceCode?: string;
   tsSourceFile?: ts.SourceFile;
   url!: string;
 

--- a/cli/js/dispatch.ts
+++ b/cli/js/dispatch.ts
@@ -66,12 +66,15 @@ export let OP_READ_LINK: number;
 export let OP_TRUNCATE: number;
 export let OP_MAKE_TEMP_DIR: number;
 export let OP_CWD: number;
-export let OP_FETCH_ASSET: number;
 export let OP_DIAL_TLS: number;
 export let OP_HOSTNAME: number;
 export let OP_OPEN_PLUGIN: number;
 export let OP_COMPILE: number;
 export let OP_TRANSPILE: number;
+
+/** **WARNING:** This is only available during the snapshotting process and is
+ * unavailable at runtime. */
+export let OP_FETCH_ASSET: number;
 
 const PLUGIN_ASYNC_HANDLER_MAP: Map<number, AsyncHandler> = new Map();
 

--- a/cli/js/dispatch_json.ts
+++ b/cli/js/dispatch_json.ts
@@ -62,7 +62,7 @@ export function sendSync(
   const resUi8 = core.dispatch(opId, argsUi8, zeroCopy);
   util.assert(resUi8 != null);
 
-  const res = decode(resUi8!);
+  const res = decode(resUi8);
   util.assert(res.promiseId == null);
   return unwrapResponse(res);
 }

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -146,7 +146,7 @@ fn create_worker_and_state(
 }
 
 fn types_command() {
-  let content = crate::js::get_asset("lib.deno_runtime.d.ts").unwrap();
+  let content = deno_typescript::get_asset("lib.deno_runtime.d.ts").unwrap();
   println!("{}", content);
 }
 

--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -20,10 +20,6 @@ pub fn init(i: &mut Isolate, s: &ThreadSafeState) {
     "fetch_source_files",
     s.core_op(json_op(s.stateful_op(op_fetch_source_files))),
   );
-  i.register_op(
-    "fetch_asset",
-    s.core_op(json_op(s.stateful_op(op_fetch_asset))),
-  );
   i.register_op("compile", s.core_op(json_op(s.stateful_op(op_compile))));
   i.register_op("transpile", s.core_op(json_op(s.stateful_op(op_transpile))));
 }
@@ -153,24 +149,6 @@ fn op_fetch_source_files(
   });
 
   Ok(JsonOp::Async(future))
-}
-
-#[derive(Deserialize)]
-struct FetchAssetArgs {
-  name: String,
-}
-
-fn op_fetch_asset(
-  _state: &ThreadSafeState,
-  args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  let args: FetchAssetArgs = serde_json::from_value(args)?;
-  if let Some(source_code) = crate::js::get_asset(&args.name) {
-    Ok(JsonOp::Sync(json!(source_code)))
-  } else {
-    panic!("op_fetch_asset bad asset {}", args.name)
-  }
 }
 
 #[derive(Deserialize, Debug)]

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -672,6 +672,7 @@ impl Isolate {
     let mut hs = v8::HandleScope::new(&mut locker);
     let scope = hs.enter();
     self.global_context.reset(scope);
+    self.shared_response_buf.reset(scope);
 
     let snapshot_creator = self.snapshot_creator.as_mut().unwrap();
     let snapshot = snapshot_creator

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -180,7 +180,6 @@ SharedQueue Binary Layout
   }
 
   function dispatch(opId, control, zeroCopy = null) {
-    maybeInit();
     return Deno.core.send(opId, control, zeroCopy);
   }
 

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -204,6 +204,10 @@ pub fn mksnapshot_bundle_ts(
   state: Arc<Mutex<TSState>>,
 ) -> Result<(), ErrBox> {
   let runtime_isolate = &mut Isolate::new(StartupData::None, true);
+  runtime_isolate.register_op(
+    "fetch_asset",
+    compiler_op(state.clone(), ops::json_op(ops::fetch_asset)),
+  );
   let source_code_vec = std::fs::read(bundle)?;
   let source_code = std::str::from_utf8(&source_code_vec)?;
 
@@ -257,6 +261,7 @@ pub fn get_asset(name: &str) -> Option<&'static str> {
   match name {
     "bundle_loader.js" => Some(include_str!("bundle_loader.js")),
     "lib.deno_core.d.ts" => Some(include_str!("lib.deno_core.d.ts")),
+    "lib.deno_runtime.d.ts" => Some(include_str!("../cli/js/lib.deno_runtime.d.ts")),
     "example.ts" => Some("console.log(\"hello deno\");"),
     "typescript.d.ts" => inc!("typescript.d.ts"),
     "lib.esnext.d.ts" => inc!("lib.esnext.d.ts"),

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -257,6 +257,7 @@ pub fn get_asset(name: &str) -> Option<&'static str> {
   match name {
     "bundle_loader.js" => Some(include_str!("bundle_loader.js")),
     "lib.deno_core.d.ts" => Some(include_str!("lib.deno_core.d.ts")),
+    "example.ts" => Some("console.log(\"hello deno\");"),
     "typescript.d.ts" => inc!("typescript.d.ts"),
     "lib.esnext.d.ts" => inc!("lib.esnext.d.ts"),
     "lib.es2020.d.ts" => inc!("lib.es2020.d.ts"),

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -264,7 +264,7 @@ pub fn get_asset(name: &str) -> Option<&'static str> {
     "lib.deno_runtime.d.ts" => {
       Some(include_str!("../cli/js/lib.deno_runtime.d.ts"))
     }
-    "example.ts" => Some("console.log(\"hello deno\");"),
+    "bootstrap.ts" => Some("console.log(\"hello deno\");"),
     "typescript.d.ts" => inc!("typescript.d.ts"),
     "lib.esnext.d.ts" => inc!("lib.esnext.d.ts"),
     "lib.es2020.d.ts" => inc!("lib.es2020.d.ts"),

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -261,7 +261,9 @@ pub fn get_asset(name: &str) -> Option<&'static str> {
   match name {
     "bundle_loader.js" => Some(include_str!("bundle_loader.js")),
     "lib.deno_core.d.ts" => Some(include_str!("lib.deno_core.d.ts")),
-    "lib.deno_runtime.d.ts" => Some(include_str!("../cli/js/lib.deno_runtime.d.ts")),
+    "lib.deno_runtime.d.ts" => {
+      Some(include_str!("../cli/js/lib.deno_runtime.d.ts"))
+    }
     "example.ts" => Some("console.log(\"hello deno\");"),
     "typescript.d.ts" => inc!("typescript.d.ts"),
     "lib.esnext.d.ts" => inc!("lib.esnext.d.ts"),

--- a/deno_typescript/ops.rs
+++ b/deno_typescript/ops.rs
@@ -112,6 +112,21 @@ pub fn resolve_module_names(
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct FetchAssetArgs {
+  name: String,
+}
+
+pub fn fetch_asset(_s: &mut TSState, v: Value) -> Result<Value, ErrBox> {
+  let args: FetchAssetArgs = serde_json::from_value(v)?;
+  if let Some(source_code) = crate::get_asset(&args.name) {
+    Ok(json!(source_code))
+  } else {
+    panic!("op_fetch_asset bad asset {}", args.name)
+  }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct Exit {
   code: i32,
 }


### PR DESCRIPTION
Resolves #3111

This PR caches an "oldProgram" which is effectively the AST of all the foundational libraries as part of the snapshot, which then is re-used when an additional compiler invocation happens.

---

_Original PR text for context_

@ry @bartlomieju I'm pretty sure this approach will speed up TypeScript compilation, but I am running across a couple of issues that aren't easy for me to figure out how to resolve.  The build is failing during the creation of the compiler snapshot at the unwrap in core bindings:

https://github.com/denoland/deno/blob/525784e5642cbd869c682a0fda595f55c785d607/core/bindings.rs#L438-L440

I am not really getting a good error message here (feels like we might want to improve that), but I suspect this is because the code in the snapshot actually needs access to a single op from the CLI:

https://github.com/denoland/deno/blob/525784e5642cbd869c682a0fda595f55c785d607/cli/ops/compiler.rs#L23-L26

Which also would need to have access to all the inlined text resources.  It needs to read out some of that, to generate the AST, so that that AST can be reused later (warming up the compiler).  I am not sure how to provide OPS to an isolate during snapshotting.
