### PR TITLE
perf: share http client in file fetcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'windows')
         uses: actions/setup-python@v1
         with:
-          python-version: "2.7.16"
+          python-version: "2.7.17"
           architecture: x64
 
       - name: Remove unused versions of Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'windows')
         uses: actions/setup-python@v1
         with:
-          python-version: "2.7.17"
+          python-version: "2.7.16"
           architecture: x64
 
       - name: Remove unused versions of Python

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -31,7 +31,7 @@ use url::Url;
 
 /// Create new instance of async reqwest::Client. This client supports
 /// proxies and doesn't follow redirects.
-pub fn get_client() -> Client {
+pub fn create_http_client() -> Client {
   let mut headers = HeaderMap::new();
   headers.insert(
     USER_AGENT,
@@ -86,11 +86,11 @@ pub enum FetchOnceResult {
 /// If redirect occurs, does not follow and
 /// yields Redirect(url).
 pub fn fetch_string_once(
+  client: Client,
   url: &Url,
   cached_etag: Option<String>,
 ) -> impl Future<Output = Result<FetchOnceResult, ErrBox>> {
   let url = url.clone();
-  let client = get_client();
 
   let fut = async move {
     let mut request = client
@@ -254,15 +254,16 @@ mod tests {
     // Relies on external http server. See tools/http_server.py
     let url =
       Url::parse("http://127.0.0.1:4545/cli/tests/fixture.json").unwrap();
-
-    let fut = fetch_string_once(&url, None).map(|result| match result {
-      Ok(FetchOnceResult::Code(code, maybe_content_type, etag)) => {
-        assert!(!code.is_empty());
-        assert_eq!(maybe_content_type, Some("application/json".to_string()));
-        assert_eq!(etag, None)
-      }
-      _ => panic!(),
-    });
+    let client = create_http_client();
+    let fut =
+      fetch_string_once(client, &url, None).map(|result| match result {
+        Ok(FetchOnceResult::Code(code, maybe_content_type, etag)) => {
+          assert!(!code.is_empty());
+          assert_eq!(maybe_content_type, Some("application/json".to_string()));
+          assert_eq!(etag, None)
+        }
+        _ => panic!(),
+      });
 
     tokio_util::run(fut);
     drop(http_server_guard);
@@ -276,19 +277,20 @@ mod tests {
       "http://127.0.0.1:4545/cli/tests/053_import_compression/gziped",
     )
     .unwrap();
-
-    let fut = fetch_string_once(&url, None).map(|result| match result {
-      Ok(FetchOnceResult::Code(code, maybe_content_type, etag)) => {
-        assert!(!code.is_empty());
-        assert_eq!(code, "console.log('gzip')");
-        assert_eq!(
-          maybe_content_type,
-          Some("application/javascript".to_string())
-        );
-        assert_eq!(etag, None);
-      }
-      _ => panic!(),
-    });
+    let client = create_http_client();
+    let fut =
+      fetch_string_once(client, &url, None).map(|result| match result {
+        Ok(FetchOnceResult::Code(code, maybe_content_type, etag)) => {
+          assert!(!code.is_empty());
+          assert_eq!(code, "console.log('gzip')");
+          assert_eq!(
+            maybe_content_type,
+            Some("application/javascript".to_string())
+          );
+          assert_eq!(etag, None);
+        }
+        _ => panic!(),
+      });
 
     tokio_util::run(fut);
     drop(http_server_guard);
@@ -298,9 +300,9 @@ mod tests {
   fn test_fetch_with_etag() {
     let http_server_guard = crate::test_util::http_server();
     let url = Url::parse("http://127.0.0.1:4545/etag_script.ts").unwrap();
-
+    let client = create_http_client();
     let fut = async move {
-      fetch_string_once(&url, None)
+      fetch_string_once(client.clone(), &url, None)
         .map(|result| match result {
           Ok(FetchOnceResult::Code(code, maybe_content_type, etag)) => {
             assert!(!code.is_empty());
@@ -315,8 +317,12 @@ mod tests {
         })
         .await;
 
-      let res =
-        fetch_string_once(&url, Some("33a64df551425fcc55e".to_string())).await;
+      let res = fetch_string_once(
+        client,
+        &url,
+        Some("33a64df551425fcc55e".to_string()),
+      )
+      .await;
       assert_eq!(res.unwrap(), FetchOnceResult::NotModified);
     };
 
@@ -332,19 +338,20 @@ mod tests {
       "http://127.0.0.1:4545/cli/tests/053_import_compression/brotli",
     )
     .unwrap();
-
-    let fut = fetch_string_once(&url, None).map(|result| match result {
-      Ok(FetchOnceResult::Code(code, maybe_content_type, etag)) => {
-        assert!(!code.is_empty());
-        assert_eq!(code, "console.log('brotli');");
-        assert_eq!(
-          maybe_content_type,
-          Some("application/javascript".to_string())
-        );
-        assert_eq!(etag, None);
-      }
-      _ => panic!(),
-    });
+    let client = create_http_client();
+    let fut =
+      fetch_string_once(client, &url, None).map(|result| match result {
+        Ok(FetchOnceResult::Code(code, maybe_content_type, etag)) => {
+          assert!(!code.is_empty());
+          assert_eq!(code, "console.log('brotli');");
+          assert_eq!(
+            maybe_content_type,
+            Some("application/javascript".to_string())
+          );
+          assert_eq!(etag, None);
+        }
+        _ => panic!(),
+      });
 
     tokio_util::run(fut);
     drop(http_server_guard);
@@ -359,12 +366,14 @@ mod tests {
     // Dns resolver substitutes `127.0.0.1` with `localhost`
     let target_url =
       Url::parse("http://localhost:4545/cli/tests/fixture.json").unwrap();
-    let fut = fetch_string_once(&url, None).map(move |result| match result {
-      Ok(FetchOnceResult::Redirect(url)) => {
-        assert_eq!(url, target_url);
-      }
-      _ => panic!(),
-    });
+    let client = create_http_client();
+    let fut =
+      fetch_string_once(client, &url, None).map(move |result| match result {
+        Ok(FetchOnceResult::Redirect(url)) => {
+          assert_eq!(url, target_url);
+        }
+        _ => panic!(),
+      });
 
     tokio_util::run(fut);
     drop(http_server_guard);

--- a/cli/ops/fetch.rs
+++ b/cli/ops/fetch.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use super::dispatch_json::{Deserialize, JsonOp, Value};
 use super::io::StreamResource;
-use crate::http_util::{get_client, HttpBody};
+use crate::http_util::{create_http_client, HttpBody};
 use crate::ops::json_op;
 use crate::state::ThreadSafeState;
 use deno_core::*;
@@ -31,7 +31,7 @@ pub fn op_fetch(
   let args: FetchArgs = serde_json::from_value(args)?;
   let url = args.url;
 
-  let client = get_client();
+  let client = create_http_client();
 
   let method = match args.method {
     Some(method_str) => Method::from_bytes(method_str.as_bytes())?,


### PR DESCRIPTION
Depends on #3685 

Follow up to #3657

This PR brings back shared HTTP client for file fetcher but still uses one-off clients for `fetch` API.