### PR TITLE
ci: bump Python to 2.7.17 for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,18 @@ jobs:
           rustup component add clippy
           rustup component add rustfmt
 
-      - name: Install python
+      - name: Install Python (macOS)
+        if: startsWith(matrix.os, 'macOS')
         uses: actions/setup-python@v1
         with:
           python-version: "2.7.17"
+          architecture: x64
+
+      - name: Install Python
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'windows')
+        uses: actions/setup-python@v1
+        with:
+          python-version: "2.7.16"
           architecture: x64
 
       - name: Remove unused versions of Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v1
         with:
-          python-version: "2.7.16"
+          python-version: "2.7.17"
           architecture: x64
 
       - name: Remove unused versions of Python


### PR DESCRIPTION
Apparently Python 2.7.16 is no longer supported by `setup-python` on macOS