### PR TITLE
[WIP] feat: `dispatch_json` in core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,8 @@ dependencies = [
  "libc",
  "log",
  "rusty_v8",
+ "serde",
+ "serde_derive",
  "serde_json",
  "tokio",
  "url 2.1.1",
@@ -2316,6 +2318,9 @@ dependencies = [
  "deno",
  "deno_core",
  "futures 0.3.4",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,6 +22,9 @@ log = "0.4.8"
 serde_json = "1.0.48"
 url = "2.1.1"
 rusty_v8 = "0.3.5"
+# dispatch json stuff
+serde = { version = "1.0.102", features = ["derive"] }
+serde_derive = "1.0.102" 
 
 [[example]]
 name = "deno_core_http_bench"
@@ -31,3 +34,9 @@ path = "examples/http_bench.rs"
 [dev-dependencies]
 derive_deref = "1.1.0"
 tokio = { version = "0.2.13", features = ["rt-core", "tcp"] }
+
+[features]
+default = []
+dispatch_json = [ "default" ]
+dispatch_json_ts = [ "dispatch_json" ]
+dispatch_json_js = [ "dispatch_json" ]

--- a/core/dispatch_json.js
+++ b/core/dispatch_json.js
@@ -1,0 +1,114 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+
+// These utilities are borrowed from std. We don't really
+// have a better way to include them here yet.
+class AssertionError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "AssertionError";
+  }
+}
+
+/** Make an assertion, if not `true`, then throw. */
+function assert(expr, msg = "") {
+  if (!expr) {
+    throw new AssertionError(msg);
+  }
+}
+
+/** Creates a Promise with the `reject` and `resolve` functions
+ * placed as methods on the promise object itself. It allows you to do:
+ *
+ *     const p = deferred<number>();
+ *     // ...
+ *     p.resolve(42);
+ */
+function deferred() {
+  let methods;
+  const promise = new Promise((resolve, reject) => {
+    methods = { resolve, reject };
+  });
+  return Object.assign(promise, methods);
+}
+
+function decode(ui8) {
+  const s = new TextDecoder().decode(ui8);
+  return JSON.parse(s);
+}
+
+function encode(args) {
+  const s = JSON.stringify(args);
+  return new TextEncoder().encode(s);
+}
+
+function unwrapResponse(res) {
+  if (res.err != null) {
+    throw new Error(res.err.message);
+  }
+  assert(res.ok != null);
+  return res.ok;
+}
+
+class DispatchJsonOp {
+  constructor(dispatch) {
+    this.dispatch = dispatch;
+    this.promiseTable = new Map();
+    this._nextPromiseId = 1;
+  }
+
+  nextPromiseId() {
+    return this._nextPromiseId++;
+  }
+
+  handleAsync(resUi8) {
+    const res = decode(resUi8);
+    assert(res.promiseId != null);
+    const promise = this.promiseTable.get(res.promiseId);
+    assert(promise != null);
+    this.promiseTable.delete(res.promiseId);
+    promise.resolve(res);
+  }
+
+  dispatchSync(args = {}, zeroCopy) {
+    const argsUi8 = encode(args);
+    const resUi8 = this.dispatch(argsUi8, zeroCopy);
+    assert(resUi8 != null);
+    const res = decode(resUi8);
+    assert(res.promiseId == null);
+    return unwrapResponse(res);
+  }
+
+  async dispatchAsync(args = {}, zeroCopy) {
+    const promiseId = this.nextPromiseId();
+    args = Object.assign(args, { promiseId });
+    const promise = deferred();
+    const argsUi8 = encode(args);
+    const buf = this.dispatch(argsUi8, zeroCopy);
+    if (buf) {
+      // Sync result.
+      const res = decode(buf);
+      promise.resolve(res);
+    } else {
+      // Async result.
+      this.promiseTable.set(promiseId, promise);
+    }
+    const res = await promise;
+    return unwrapResponse(res);
+  }
+}
+
+export class DispatchJsonCoreOp extends DispatchJsonOp {
+  constructor(opId) {
+    super((c, zc) => Deno["core"].dispatch(this.opId, c, zc));
+    this.opId = opId;
+    Deno["core"].setAsyncHandler(this.opId, resUi8 => this.handleAsync(resUi8));
+  }
+}
+
+export class DispatchJsonPluginOp extends DispatchJsonOp {
+  constructor(pluginOp) {
+    super((c, zc) => this.pluginOp.dispatch(c, zc));
+    this.pluginOp = pluginOp;
+    this.pluginOp.setAsyncHandler(resUi8 => this.handleAsync(resUi8));
+  }
+}

--- a/core/dispatch_json.rs
+++ b/core/dispatch_json.rs
@@ -1,0 +1,114 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::any_error::ErrBox;
+use crate::isolate::ZeroCopyBuf;
+use crate::ops::Buf;
+use crate::ops::CoreOp;
+use futures::future::FutureExt;
+use futures::task::SpawnExt;
+pub use serde_derive::Deserialize;
+use serde_json::json;
+pub use serde_json::Value;
+use std::future::Future;
+use std::pin::Pin;
+
+#[cfg(feature = "dispatch_json_ts")]
+pub static DISPATCH_JSON_TS: &'static str = include_str!("dispatch_json.ts");
+
+#[cfg(feature = "dispatch_json_js")]
+pub static DISPATCH_JSON_JS: &'static str = include_str!("dispatch_json.js");
+
+pub type AsyncJsonOp =
+  Pin<Box<dyn Future<Output = Result<Value, ErrBox>> + Send>>;
+
+pub enum JsonOp {
+  Sync(Value),
+  Async(AsyncJsonOp),
+}
+
+fn json_err(err: ErrBox) -> Value {
+  json!({
+    "message": err.to_string(),
+  })
+}
+
+fn serialize_result(
+  promise_id: Option<u64>,
+  result: Result<Value, ErrBox>,
+) -> Buf {
+  let value = match result {
+    Ok(v) => json!({ "ok": v, "promiseId": promise_id }),
+    Err(err) => json!({ "err": json_err(err), "promiseId": promise_id }),
+  };
+  let mut vec = serde_json::to_vec(&value).unwrap();
+  debug!("JSON response pre-align, len={}", vec.len());
+  // Align to 32bit word, padding with the space character.
+  vec.resize((vec.len() + 3usize) & !3usize, b' ');
+  vec.into_boxed_slice()
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AsyncArgs {
+  promise_id: Option<u64>,
+}
+
+pub fn json_op<D>(d: D) -> impl Fn(&[u8], Option<ZeroCopyBuf>) -> CoreOp
+where
+  D: Fn(Value, Option<ZeroCopyBuf>) -> Result<JsonOp, ErrBox>,
+{
+  move |control: &[u8], zero_copy: Option<ZeroCopyBuf>| {
+    let async_args: AsyncArgs = match serde_json::from_slice(control) {
+      Ok(args) => args,
+      Err(e) => {
+        let buf = serialize_result(None, Err(ErrBox::from(e)));
+        return CoreOp::Sync(buf);
+      }
+    };
+    let promise_id = async_args.promise_id;
+    let is_sync = promise_id.is_none();
+
+    let result = serde_json::from_slice(control)
+      .map_err(ErrBox::from)
+      .and_then(|args| d(args, zero_copy));
+
+    // Convert to CoreOp
+    match result {
+      Ok(JsonOp::Sync(sync_value)) => {
+        assert!(promise_id.is_none());
+        CoreOp::Sync(serialize_result(promise_id, Ok(sync_value)))
+      }
+      Ok(JsonOp::Async(fut)) => {
+        assert!(promise_id.is_some());
+        let fut2 = fut.then(move |result| {
+          futures::future::ok(serialize_result(promise_id, result))
+        });
+        CoreOp::Async(fut2.boxed())
+      }
+      Err(sync_err) => {
+        let buf = serialize_result(promise_id, Err(sync_err));
+        if is_sync {
+          CoreOp::Sync(buf)
+        } else {
+          CoreOp::Async(futures::future::ok(buf).boxed())
+        }
+      }
+    }
+  }
+}
+
+pub fn blocking_json<F>(is_sync: bool, f: F) -> Result<JsonOp, ErrBox>
+where
+  F: 'static + Send + FnOnce() -> Result<Value, ErrBox> + Unpin,
+{
+  if is_sync {
+    Ok(JsonOp::Sync(f()?))
+  } else {
+    //TODO(afinch7) replace this with something more efficent.
+    let pool = futures::executor::ThreadPool::new().unwrap();
+    let handle = pool
+      .spawn_with_handle(futures::future::lazy(move |_cx| f()))
+      .unwrap();
+    Ok(JsonOp::Async(handle.boxed()))
+  }
+}

--- a/core/dispatch_json.ts
+++ b/core/dispatch_json.ts
@@ -1,0 +1,147 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+
+// These utilities are borrowed from std. We don't really
+// have a better way to include them here yet.
+
+class AssertionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AssertionError";
+  }
+}
+
+/** Make an assertion, if not `true`, then throw. */
+function assert(expr: unknown, msg = ""): asserts expr {
+  if (!expr) {
+    throw new AssertionError(msg);
+  }
+}
+
+// TODO(ry) It'd be better to make Deferred a class that inherits from
+// Promise, rather than an interface. This is possible in ES2016, however
+// typescript produces broken code when targeting ES5 code.
+// See https://github.com/Microsoft/TypeScript/issues/15202
+// At the time of writing, the github issue is closed but the problem remains.
+interface Deferred<T> extends Promise<T> {
+  resolve: (value?: T | PromiseLike<T>) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reject: (reason?: any) => void;
+}
+
+/** Creates a Promise with the `reject` and `resolve` functions
+ * placed as methods on the promise object itself. It allows you to do:
+ *
+ *     const p = deferred<number>();
+ *     // ...
+ *     p.resolve(42);
+ */
+function deferred<T>(): Deferred<T> {
+  let methods;
+  const promise = new Promise<T>((resolve, reject): void => {
+    methods = { resolve, reject };
+  });
+  return Object.assign(promise, methods)! as Deferred<T>;
+}
+
+// Actual dispatch_json code begins here.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Ok = any;
+
+interface JsonError {
+  message: string;
+}
+
+interface JsonResponse {
+  ok?: Ok;
+  err?: JsonError;
+  promiseId?: number; // Only present in async messages.
+}
+
+function decode(ui8: Uint8Array): JsonResponse {
+  const s = new TextDecoder().decode(ui8);
+  return JSON.parse(s) as JsonResponse;
+}
+
+function encode(args: object): Uint8Array {
+  const s = JSON.stringify(args);
+  return new TextEncoder().encode(s);
+}
+
+function unwrapResponse(res: JsonResponse): Ok {
+  if (res.err != null) {
+    throw new Error(res.err!.message);
+  }
+  assert(res.ok != null);
+  return res.ok;
+}
+
+abstract class DispatchJsonOp {
+  protected readonly promiseTable = new Map<number, Deferred<JsonResponse>>();
+  protected _nextPromiseId = 1;
+
+  constructor(
+    private readonly dispatch: (
+      control: Uint8Array,
+      zeroCopy?: ArrayBufferView | null
+    ) => Uint8Array | null
+  ) {}
+
+  protected nextPromiseId(): number {
+    return this._nextPromiseId++;
+  }
+
+  protected handleAsync(resUi8: Uint8Array): void {
+    const res = decode(resUi8);
+    assert(res.promiseId != null);
+
+    const promise = this.promiseTable.get(res.promiseId!);
+    assert(promise != null);
+    this.promiseTable.delete(res.promiseId!);
+    promise.resolve(res);
+  }
+
+  dispatchSync(args: object = {}, zeroCopy?: Uint8Array): Ok {
+    const argsUi8 = encode(args);
+    const resUi8 = this.dispatch(argsUi8, zeroCopy);
+    assert(resUi8 != null);
+
+    const res = decode(resUi8!);
+    assert(res.promiseId == null);
+    return unwrapResponse(res);
+  }
+
+  async dispatchAsync(args: object = {}, zeroCopy?: Uint8Array): Promise<Ok> {
+    const promiseId = this.nextPromiseId();
+    args = Object.assign(args, { promiseId });
+    const promise = deferred<Ok>();
+
+    const argsUi8 = encode(args);
+    const buf = this.dispatch(argsUi8, zeroCopy);
+    if (buf) {
+      // Sync result.
+      const res = decode(buf);
+      promise.resolve(res);
+    } else {
+      // Async result.
+      this.promiseTable.set(promiseId, promise);
+    }
+
+    const res = await promise;
+    return unwrapResponse(res);
+  }
+}
+
+export class DispatchJsonCoreOp extends DispatchJsonOp {
+  constructor(private readonly opId: number) {
+    super((c, zc) => Deno["core"].dispatch(this.opId, c, zc));
+    Deno["core"].setAsyncHandler(this.opId, resUi8 => this.handleAsync(resUi8));
+  }
+}
+
+export class DispatchJsonPluginOp extends DispatchJsonOp {
+  constructor(private readonly pluginOp: Deno.PluginOp) {
+    super((c, zc) => this.pluginOp.dispatch(c, zc));
+    this.pluginOp.setAsyncHandler(resUi8 => this.handleAsync(resUi8));
+  }
+}

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -10,6 +10,8 @@ extern crate log;
 
 mod any_error;
 mod bindings;
+#[cfg(feature = "dispatch_json")]
+mod dispatch_json;
 mod es_isolate;
 mod flags;
 mod isolate;
@@ -24,6 +26,8 @@ mod shared_queue;
 use rusty_v8 as v8;
 
 pub use crate::any_error::*;
+#[cfg(feature = "dispatch_json")]
+pub use crate::dispatch_json::*;
 pub use crate::es_isolate::*;
 pub use crate::flags::v8_set_flags;
 pub use crate::isolate::*;

--- a/test_plugin/Cargo.toml
+++ b/test_plugin/Cargo.toml
@@ -10,5 +10,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 futures = "0.3.4"
-deno_core = { path = "../core" }
+deno_core = { path = "../core", features = ["dispatch_json"] }
 deno = { path = "../cli" }
+serde_json = "1.0.44"
+serde = { version = "1.0.102", features = ["derive"] }
+serde_derive = "1.0.102" 

--- a/test_plugin/tests/integration_tests.rs
+++ b/test_plugin/tests/integration_tests.rs
@@ -27,7 +27,7 @@ fn basic() {
   assert!(build_plugin_output.status.success());
   let output = deno_cmd()
     .arg("--allow-plugin")
-    .arg("tests/test.js")
+    .arg("tests/test_basic.js")
     .arg(BUILD_VARIANT)
     .output()
     .unwrap();
@@ -42,6 +42,37 @@ fn basic() {
     "Hello from plugin. data: test | zero_copy: test\nPlugin Sync Response: test\r\nHello from plugin. data: test | zero_copy: test\nPlugin Async Response: test\r\n"
   } else {
     "Hello from plugin. data: test | zero_copy: test\nPlugin Sync Response: test\nHello from plugin. data: test | zero_copy: test\nPlugin Async Response: test\n"
+  };
+  assert_eq!(stdout, expected);
+  assert_eq!(stderr, "");
+}
+
+#[test]
+fn dispatch_json() {
+  let mut build_plugin_base = Command::new("cargo");
+  let mut build_plugin =
+    build_plugin_base.arg("build").arg("-p").arg("test_plugin");
+  if BUILD_VARIANT == "release" {
+    build_plugin = build_plugin.arg("--release");
+  }
+  let _build_plugin_output = build_plugin.output().unwrap();
+  let output = deno_cmd()
+    .arg("--allow-plugin")
+    .arg("tests/test_dispatch_json.js")
+    .arg(BUILD_VARIANT)
+    .output()
+    .unwrap();
+  let stdout = std::str::from_utf8(&output.stdout).unwrap();
+  let stderr = std::str::from_utf8(&output.stderr).unwrap();
+  if !output.status.success() {
+    println!("stdout {}", stdout);
+    println!("stderr {}", stderr);
+  }
+  assert!(output.status.success());
+  let expected = if cfg!(target_os = "windows") {
+    "Hello from json op. size: 12 | name: testObject | zero_copy: test\nPlugin Json Response: { id: 21, name: \"testObject\" }\r\n"
+  } else {
+    "Hello from json op. size: 12 | name: testObject | zero_copy: test\nPlugin Json Response: { id: 21, name: \"testObject\" }\n"
   };
   assert_eq!(stdout, expected);
   assert_eq!(stderr, "");

--- a/test_plugin/tests/ops.js
+++ b/test_plugin/tests/ops.js
@@ -1,0 +1,20 @@
+const filenameBase = "test_plugin";
+
+let filenameSuffix = ".so";
+let filenamePrefix = "lib";
+
+if (Deno.build.os === "win") {
+  filenameSuffix = ".dll";
+  filenamePrefix = "";
+}
+if (Deno.build.os === "mac") {
+  filenameSuffix = ".dylib";
+}
+
+const filename = `../target/${Deno.args[0]}/${filenamePrefix}${filenameBase}${filenameSuffix}`;
+
+const plugin = Deno.openPlugin(filename);
+
+const { testSync, testAsync, jsonTest } = plugin.ops;
+
+export { testSync, testAsync, jsonTest };

--- a/test_plugin/tests/test_basic.js
+++ b/test_plugin/tests/test_basic.js
@@ -1,21 +1,4 @@
-const filenameBase = "test_plugin";
-
-let filenameSuffix = ".so";
-let filenamePrefix = "lib";
-
-if (Deno.build.os === "win") {
-  filenameSuffix = ".dll";
-  filenamePrefix = "";
-}
-if (Deno.build.os === "mac") {
-  filenameSuffix = ".dylib";
-}
-
-const filename = `../target/${Deno.args[0]}/${filenamePrefix}${filenameBase}${filenameSuffix}`;
-
-const plugin = Deno.openPlugin(filename);
-
-const { testSync, testAsync } = plugin.ops;
+import { testSync, testAsync } from "./ops.js";
 
 const textDecoder = new TextDecoder();
 

--- a/test_plugin/tests/test_dispatch_json.js
+++ b/test_plugin/tests/test_dispatch_json.js
@@ -1,0 +1,11 @@
+import { jsonTest as _jsonTest } from "./ops.js";
+import { DispatchJsonPluginOp } from "./../../core/dispatch_json.js";
+
+const jsonTest = new DispatchJsonPluginOp(_jsonTest);
+
+const response = jsonTest.dispatchSync(
+  { size: 12, name: "testObject" },
+  new Uint8Array([116, 101, 115, 116])
+);
+
+console.log("Plugin Json Response:", response);


### PR DESCRIPTION
depends on #3637(changes to testing for plugins)
My plan here is to land a minimal version of `dispatch_json` that can be used in plugins and `deno_core` implementations. This can be implemented into cli in a follow up PR after some other issues are addressed(error kinds, ts/js support, etc). 