### PR TITLE
refactor: Improve path handling in permission checks

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -7,6 +7,7 @@ use clap::ArgMatches;
 use clap::SubCommand;
 use log::Level;
 use std::collections::HashSet;
+use std::path::Path;
 
 /// Creates vector of strings, Vec<String>
 macro_rules! svec {
@@ -397,14 +398,13 @@ fn resolve_fs_whitelist(whitelist: &[String]) -> Vec<String> {
   whitelist
     .iter()
     .map(|raw_path| {
-      resolve_from_cwd(&raw_path)
+      resolve_from_cwd(Path::new(&raw_path))
         .unwrap()
-        .0
         .to_str()
         .unwrap()
         .to_owned()
     })
-    .collect::<Vec<_>>()
+    .collect()
 }
 
 // Shared between the run and test subcommands. They both take similar options.

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -129,11 +129,9 @@ pub fn chown(_path: &str, _uid: u32, _gid: u32) -> Result<(), ErrBox> {
   Err(crate::deno_error::op_not_implemented())
 }
 
-pub fn resolve_from_cwd(path: &str) -> Result<(PathBuf, String), ErrBox> {
-  let candidate_path = Path::new(path);
-
-  let resolved_path = if candidate_path.is_absolute() {
-    candidate_path.to_owned()
+pub fn resolve_from_cwd(path: &Path) -> Result<PathBuf, ErrBox> {
+  let resolved_path = if path.is_absolute() {
+    path.to_owned()
   } else {
     let cwd = std::env::current_dir().unwrap();
     cwd.join(path)
@@ -155,9 +153,7 @@ pub fn resolve_from_cwd(path: &str) -> Result<(PathBuf, String), ErrBox> {
     .to_file_path()
     .expect("URL from a path should contain a valid path");
 
-  let path_string = normalized_path.to_str().unwrap().to_string();
-
-  Ok((normalized_path, path_string))
+  Ok(normalized_path)
 }
 
 #[cfg(test)]
@@ -167,19 +163,19 @@ mod tests {
   #[test]
   fn resolve_from_cwd_child() {
     let cwd = std::env::current_dir().unwrap();
-    assert_eq!(resolve_from_cwd("a").unwrap().0, cwd.join("a"));
+    assert_eq!(resolve_from_cwd(Path::new("a")).unwrap(), cwd.join("a"));
   }
 
   #[test]
   fn resolve_from_cwd_dot() {
     let cwd = std::env::current_dir().unwrap();
-    assert_eq!(resolve_from_cwd(".").unwrap().0, cwd);
+    assert_eq!(resolve_from_cwd(Path::new(".")).unwrap(), cwd);
   }
 
   #[test]
   fn resolve_from_cwd_parent() {
     let cwd = std::env::current_dir().unwrap();
-    assert_eq!(resolve_from_cwd("a/..").unwrap().0, cwd);
+    assert_eq!(resolve_from_cwd(Path::new("a/..")).unwrap(), cwd);
   }
 
   // TODO: Get a good expected value here for Windows.
@@ -187,6 +183,6 @@ mod tests {
   #[test]
   fn resolve_from_cwd_absolute() {
     let expected = Path::new("/a");
-    assert_eq!(resolve_from_cwd("/a").unwrap().0, expected);
+    assert_eq!(resolve_from_cwd(expected).unwrap(), expected);
   }
 }

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -19,6 +19,7 @@ use std;
 use std::env;
 use std::future::Future;
 use std::ops::Deref;
+use std::path::Path;
 use std::str;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -175,12 +176,12 @@ impl ThreadSafeGlobalState {
   }
 
   #[inline]
-  pub fn check_read(&self, filename: &str) -> Result<(), ErrBox> {
+  pub fn check_read(&self, filename: &Path) -> Result<(), ErrBox> {
     self.permissions.check_read(filename)
   }
 
   #[inline]
-  pub fn check_write(&self, filename: &str) -> Result<(), ErrBox> {
+  pub fn check_write(&self, filename: &Path) -> Result<(), ErrBox> {
     self.permissions.check_write(filename)
   }
 
@@ -221,7 +222,7 @@ impl ThreadSafeGlobalState {
           .into_os_string()
           .into_string()
           .unwrap();
-        self.check_read(&filename)?;
+        self.check_read(Path::new(&filename))?;
         Ok(())
       }
       _ => Err(permission_denied()),

--- a/cli/ops/files.rs
+++ b/cli/ops/files.rs
@@ -12,6 +12,7 @@ use futures::future::FutureExt;
 use std;
 use std::convert::From;
 use std::io::SeekFrom;
+use std::path::Path;
 use tokio;
 
 pub fn init(i: &mut Isolate, s: &ThreadSafeState) {
@@ -34,7 +35,7 @@ fn op_open(
   _zero_copy: Option<PinnedBuf>,
 ) -> Result<JsonOp, ErrBox> {
   let args: OpenArgs = serde_json::from_value(args)?;
-  let (filename, filename_) = deno_fs::resolve_from_cwd(&args.filename)?;
+  let filename = deno_fs::resolve_from_cwd(Path::new(&args.filename))?;
   let mode = args.mode.as_ref();
   let state_ = state.clone();
   let mut open_options = tokio::fs::OpenOptions::new();
@@ -75,14 +76,14 @@ fn op_open(
 
   match mode {
     "r" => {
-      state.check_read(&filename_)?;
+      state.check_read(&filename)?;
     }
     "w" | "a" | "x" => {
-      state.check_write(&filename_)?;
+      state.check_write(&filename)?;
     }
     &_ => {
-      state.check_read(&filename_)?;
-      state.check_write(&filename_)?;
+      state.check_read(&filename)?;
+      state.check_write(&filename)?;
     }
   }
 

--- a/cli/ops/permissions.rs
+++ b/cli/ops/permissions.rs
@@ -5,6 +5,7 @@ use crate::fs as deno_fs;
 use crate::ops::json_op;
 use crate::state::ThreadSafeState;
 use deno_core::*;
+use std::path::Path;
 
 pub fn init(i: &mut Isolate, s: &ThreadSafeState) {
   i.register_op(
@@ -29,9 +30,8 @@ struct PermissionArgs {
 }
 
 fn resolve_path(path: &str) -> String {
-  deno_fs::resolve_from_cwd(path)
+  deno_fs::resolve_from_cwd(Path::new(path))
     .unwrap()
-    .0
     .to_str()
     .unwrap()
     .to_string()
@@ -48,7 +48,7 @@ pub fn op_query_permission(
   let perm = permissions.get_permission_state(
     &args.name,
     &args.url.as_ref().map(String::as_str),
-    &resolved_path.as_ref().map(String::as_str),
+    &resolved_path.as_ref().map(String::as_str).map(Path::new),
   )?;
   Ok(JsonOp::Sync(json!({ "state": perm.to_string() })))
 }
@@ -74,7 +74,7 @@ pub fn op_revoke_permission(
   let perm = permissions.get_permission_state(
     &args.name,
     &args.url.as_ref().map(String::as_str),
-    &resolved_path.as_ref().map(String::as_str),
+    &resolved_path.as_ref().map(String::as_str).map(Path::new),
   )?;
   Ok(JsonOp::Sync(json!({ "state": perm.to_string() })))
 }
@@ -89,12 +89,12 @@ pub fn op_request_permission(
   let resolved_path = args.path.as_ref().map(String::as_str).map(resolve_path);
   let perm = match args.name.as_ref() {
     "run" => Ok(permissions.request_run()),
-    "read" => {
-      Ok(permissions.request_read(&resolved_path.as_ref().map(String::as_str)))
-    }
-    "write" => {
-      Ok(permissions.request_write(&resolved_path.as_ref().map(String::as_str)))
-    }
+    "read" => Ok(permissions.request_read(
+      &resolved_path.as_ref().map(String::as_str).map(Path::new),
+    )),
+    "write" => Ok(permissions.request_write(
+      &resolved_path.as_ref().map(String::as_str).map(Path::new),
+    )),
     "net" => permissions.request_net(&args.url.as_ref().map(String::as_str)),
     "env" => Ok(permissions.request_env()),
     "plugin" => Ok(permissions.request_plugin()),

--- a/cli/ops/plugins.rs
+++ b/cli/ops/plugins.rs
@@ -6,6 +6,7 @@ use deno_core::*;
 use dlopen::symbor::Library;
 use std::collections::HashMap;
 use std::ffi::OsStr;
+use std::path::Path;
 use std::sync::Arc;
 
 pub fn init(
@@ -62,9 +63,9 @@ pub fn op_open_plugin(
   _zero_copy: Option<PinnedBuf>,
 ) -> Result<JsonOp, ErrBox> {
   let args: OpenPluginArgs = serde_json::from_value(args)?;
-  let (filename, filename_) = deno_fs::resolve_from_cwd(&args.filename)?;
+  let filename = deno_fs::resolve_from_cwd(Path::new(&args.filename))?;
 
-  state.check_plugin(&filename_)?;
+  state.check_plugin(&filename)?;
 
   let lib = open_plugin(filename)?;
   let plugin_resource = PluginResource {

--- a/cli/ops/tls.rs
+++ b/cli/ops/tls.rs
@@ -16,6 +16,7 @@ use std::fs::File;
 use std::future::Future;
 use std::io::BufReader;
 use std::net::SocketAddr;
+use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Context;
@@ -69,7 +70,7 @@ pub fn op_connect_tls(
   let state_ = state.clone();
   state.check_net(&args.hostname, args.port)?;
   if let Some(path) = cert_file.clone() {
-    state.check_read(&path)?;
+    state.check_read(Path::new(&path))?;
   }
 
   let mut domain = args.hostname.clone();
@@ -254,8 +255,8 @@ fn op_listen_tls(
   let key_file = args.key_file;
 
   state.check_net(&args.hostname, args.port)?;
-  state.check_read(&cert_file)?;
-  state.check_read(&key_file)?;
+  state.check_read(Path::new(&cert_file))?;
+  state.check_read(Path::new(&key_file))?;
 
   let mut config = ServerConfig::new(NoClientAuth::new());
   config

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -26,6 +26,7 @@ use serde_json::Value;
 use std;
 use std::collections::HashMap;
 use std::ops::Deref;
+use std::path::Path;
 use std::pin::Pin;
 use std::str;
 use std::sync::atomic::AtomicUsize;
@@ -268,13 +269,13 @@ impl ThreadSafeState {
   }
 
   #[inline]
-  pub fn check_read(&self, filename: &str) -> Result<(), ErrBox> {
-    self.permissions.lock().unwrap().check_read(filename)
+  pub fn check_read(&self, path: &Path) -> Result<(), ErrBox> {
+    self.permissions.lock().unwrap().check_read(path)
   }
 
   #[inline]
-  pub fn check_write(&self, filename: &str) -> Result<(), ErrBox> {
-    self.permissions.lock().unwrap().check_write(filename)
+  pub fn check_write(&self, path: &Path) -> Result<(), ErrBox> {
+    self.permissions.lock().unwrap().check_write(path)
   }
 
   #[inline]
@@ -298,7 +299,7 @@ impl ThreadSafeState {
   }
 
   #[inline]
-  pub fn check_plugin(&self, filename: &str) -> Result<(), ErrBox> {
+  pub fn check_plugin(&self, filename: &Path) -> Result<(), ErrBox> {
     self.permissions.lock().unwrap().check_plugin(filename)
   }
 
@@ -313,13 +314,13 @@ impl ThreadSafeState {
         Ok(())
       }
       "file" => {
-        let filename = u
+        let path = u
           .to_file_path()
           .unwrap()
           .into_os_string()
           .into_string()
           .unwrap();
-        self.check_read(&filename)?;
+        self.check_read(Path::new(&path))?;
         Ok(())
       }
       _ => Err(permission_denied()),


### PR DESCRIPTION
Uses `Path` instead of `String`/`str` for read/write permission APIs. `resolve_from_cwd()` as used in fs ops can just return a `Path` instead of a tuple.

The whitelists still store paths as `String`s because of some memory issue.