### PR TITLE
Add github action for cargo publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, windows-2019, ubuntu-16.04]
-        kind: ['test', 'test_debug', 'bench', 'lint']
+        kind: ['test', 'test_debug', 'bench', 'lint', 'test_publish']
         exclude:
           - os: windows-2019
             kind: 'bench'
@@ -26,6 +26,11 @@ jobs:
             kind: 'test_debug'
           - os: macOS-latest
             kind: 'test_debug'
+
+          - os: windows-2019
+            kind: 'test_publish'
+          - os: macOS-latest
+            kind: 'test_publish'
     steps:
       - name: Configure git
         run: git config --global core.symlinks true
@@ -127,6 +132,10 @@ jobs:
         if: matrix.kind == 'test' || matrix.kind == 'bench'
         run: cargo build --release --locked --all-targets
 
+      - name: dry-run cargo package
+        if: matrix.kind == 'test_publish'
+        run: ./tools/cargo_publish.py --dry-run
+
       - name: Test
         if: matrix.kind == 'test'
         run: cargo test --release --locked --all-targets
@@ -190,7 +199,8 @@ jobs:
         if: >
           startsWith(github.ref, 'refs/tags/') &&
           github.repository == 'denoland/deno' &&
-          runner.os == 'Linux'
+          matrix.kind == 'test' &&
+          startsWith(matrix.os, 'ubuntu')
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: ./tools/cargo_publish.py


### PR DESCRIPTION
This makes two changes:
- Adds a new CI build which will do a dry-run of the publish procedure, checking that we can package the crates. This is to prevent issues like https://github.com/denoland/deno/issues/3712 from popping up again.
- Adjusts the publish-on-tag action, so that it's only done by a single worker.

