### PR TITLE
refactor: Rename JS entry functions

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -246,9 +246,9 @@ impl TsCompiler {
       worker_state,
       ext,
     );
-    worker.execute("denoMain()").unwrap();
+    worker.execute("bootstrapCompilerRuntime('TS')").unwrap();
     worker.execute("bootstrapWorkerRuntime()").unwrap();
-    worker.execute("compilerMain()").unwrap();
+    worker.execute("bootstrapTsCompiler()").unwrap();
     worker
   }
 

--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -247,7 +247,7 @@ impl TsCompiler {
       ext,
     );
     worker.execute("denoMain()").unwrap();
-    worker.execute("workerMain()").unwrap();
+    worker.execute("bootstrapWorkerRuntime()").unwrap();
     worker.execute("compilerMain()").unwrap();
     worker
   }

--- a/cli/compilers/wasm.rs
+++ b/cli/compilers/wasm.rs
@@ -61,7 +61,7 @@ impl WasmCompiler {
       ext,
     );
     worker.execute("denoMain('WASM')").unwrap();
-    worker.execute("workerMain()").unwrap();
+    worker.execute("bootstrapWorkerRuntime()").unwrap();
     worker.execute("wasmCompilerMain()").unwrap();
     worker
   }

--- a/cli/compilers/wasm.rs
+++ b/cli/compilers/wasm.rs
@@ -60,9 +60,9 @@ impl WasmCompiler {
       worker_state,
       ext,
     );
-    worker.execute("denoMain('WASM')").unwrap();
+    worker.execute("bootstrapCompilerRuntime('WASM')").unwrap();
     worker.execute("bootstrapWorkerRuntime()").unwrap();
-    worker.execute("wasmCompilerMain()").unwrap();
+    worker.execute("bootstrapWasmCompiler()").unwrap();
     worker
   }
 

--- a/cli/js.rs
+++ b/cli/js.rs
@@ -42,7 +42,7 @@ fn compiler_snapshot() {
   deno_core::js_check(isolate.execute(
     "<anon>",
     r#"
-      if (!compilerMain) {
+      if (!bootstrapTsCompiler) {
         throw Error("bad");
       }
       console.log(`ts version: ${ts.version}`);

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -32,7 +32,11 @@ import { fromTypeScriptDiagnostic } from "./diagnostics_util.ts";
 import * as os from "./os.ts";
 import { assert } from "./util.ts";
 import * as util from "./util.ts";
-import { postMessage, workerClose, workerMain } from "./worker_main.ts";
+import {
+  postMessage,
+  workerClose,
+  bootstrapWorkerRuntime
+} from "./worker_main.ts";
 
 const self = globalThis;
 
@@ -79,12 +83,12 @@ self.denoMain = function denoMain(compilerType?: string): void {
 };
 
 // bootstrap the worker environment, this gets called as the isolate is setup
-self.workerMain = workerMain;
+self.bootstrapWorkerRuntime = bootstrapWorkerRuntime;
 
 // provide the "main" function that will be called by the privileged side when
 // lazy instantiating the compiler web worker
 self.compilerMain = function compilerMain(): void {
-  // workerMain should have already been called since a compiler is a worker.
+  // bootstrapWorkerRuntime should have already been called since a compiler is a worker.
   self.onmessage = async ({
     data: request
   }: {
@@ -298,7 +302,7 @@ self.compilerMain = function compilerMain(): void {
 };
 
 self.wasmCompilerMain = function wasmCompilerMain(): void {
-  // workerMain should have already been called since a compiler is a worker.
+  // bootstrapWorkerRuntime should have already been called since a compiler is a worker.
   self.onmessage = async ({
     data: binary
   }: {

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -78,8 +78,10 @@ interface CompileResult {
 }
 
 // bootstrap the runtime environment, this gets called as the isolate is setup
-self.denoMain = function denoMain(compilerType?: string): void {
-  os.start(true, compilerType ?? "TS");
+self.bootstrapCompilerRuntime = function bootstrapCompilerRuntime(
+  compilerType: string
+): void {
+  os.start(true, compilerType);
 };
 
 // bootstrap the worker environment, this gets called as the isolate is setup
@@ -87,7 +89,7 @@ self.bootstrapWorkerRuntime = bootstrapWorkerRuntime;
 
 // provide the "main" function that will be called by the privileged side when
 // lazy instantiating the compiler web worker
-self.compilerMain = function compilerMain(): void {
+self.bootstrapTsCompiler = function tsCompilerMain(): void {
   // bootstrapWorkerRuntime should have already been called since a compiler is a worker.
   self.onmessage = async ({
     data: request
@@ -301,7 +303,7 @@ self.compilerMain = function compilerMain(): void {
   };
 };
 
-self.wasmCompilerMain = function wasmCompilerMain(): void {
+self.bootstrapWasmCompiler = function wasmCompilerMain(): void {
   // bootstrapWorkerRuntime should have already been called since a compiler is a worker.
   self.onmessage = async ({
     data: binary

--- a/cli/js/compiler_bootstrap.ts
+++ b/cli/js/compiler_bootstrap.ts
@@ -1,12 +1,19 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { ASSETS, Host } from "./compiler_host.ts";
+import { core } from "./core.ts";
 import * as dispatch from "./dispatch.ts";
 import { sendSync } from "./dispatch_json.ts";
-import { initOps } from "./os.ts";
 
 // This registers ops that are available during the snapshotting process.
-initOps();
+const ops = core.ops();
+for (const [name, opId] of Object.entries(ops)) {
+  const opName = `OP_${name.toUpperCase()}`;
+  // TODO This type casting is dangerous, and should be improved when the same
+  // code in `os.ts` is done.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (dispatch as any)[opName] = opId;
+}
 
 const host = new Host({ writeFile(): void {} });
 const options = host.getCompilationSettings();

--- a/cli/js/compiler_bootstrap.ts
+++ b/cli/js/compiler_bootstrap.ts
@@ -1,19 +1,12 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { ASSETS, Host } from "./compiler_host.ts";
-import { core } from "./core.ts";
 import * as dispatch from "./dispatch.ts";
 import { sendSync } from "./dispatch_json.ts";
+import { initOps } from "./os.ts";
 
 // This registers ops that are available during the snapshotting process.
-const ops = core.ops();
-for (const [name, opId] of Object.entries(ops)) {
-  const opName = `OP_${name.toUpperCase()}`;
-  // TODO This type casting is dangerous, and should be improved when the same
-  // code in `os.ts` is done.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (dispatch as any)[opName] = opId;
-}
+initOps();
 
 const host = new Host({ writeFile(): void {} });
 const options = host.getCompilationSettings();

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -133,7 +133,7 @@ declare global {
   var onunload: ((e: domTypes.Event) => void) | undefined;
   var queueMicrotask: (callback: () => void) => void;
   var wasmCompilerMain: (() => void) | undefined;
-  var workerMain: (() => Promise<void> | void) | undefined;
+  var bootstrapWorkerRuntime: (() => Promise<void> | void) | undefined;
   /* eslint-enable */
 }
 
@@ -198,7 +198,7 @@ const globalProperties = {
   onmessage: writable(workerRuntime.onmessage),
   onerror: writable(workerRuntime.onerror),
 
-  workerMain: nonEnumerable(workerRuntime.workerMain),
+  bootstrapWorkerRuntime: nonEnumerable(workerRuntime.bootstrapWorkerRuntime),
   workerClose: nonEnumerable(workerRuntime.workerClose),
   postMessage: writable(workerRuntime.postMessage),
   Worker: nonEnumerable(workers.WorkerImpl),

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -111,12 +111,13 @@ declare global {
     callback: (event: domTypes.Event) => void | null,
     options?: boolean | domTypes.AddEventListenerOptions | undefined
   ) => void;
-  var compilerMain: (() => void) | undefined;
+  var bootstrapTsCompiler: (() => void) | undefined;
   var console: consoleTypes.Console;
   var Deno: {
     core: DenoCore;
   };
-  var denoMain: (() => void) | undefined;
+  var bootstrapCompilerRuntime: ((compilerType: string) => void) | undefined;
+  var bootstrapMainRuntime: (() => void) | undefined;
   var location: domTypes.Location;
   var onerror:
     | ((
@@ -132,7 +133,7 @@ declare global {
   var onmessage: ((e: { data: any }) => Promise<void> | void) | undefined;
   var onunload: ((e: domTypes.Event) => void) | undefined;
   var queueMicrotask: (callback: () => void) => void;
-  var wasmCompilerMain: (() => void) | undefined;
+  var bootstrapWasmCompiler: (() => void) | undefined;
   var bootstrapWorkerRuntime: (() => Promise<void> | void) | undefined;
   /* eslint-enable */
 }

--- a/cli/js/lib.deno_runtime.d.ts
+++ b/cli/js/lib.deno_runtime.d.ts
@@ -2128,7 +2128,7 @@ declare interface Window {
   performance: __performanceUtil.Performance;
   onmessage: (e: { data: any }) => void;
   onerror: undefined | typeof onerror;
-  workerMain: typeof __workerMain.workerMain;
+  bootstrapWorkerRuntime: typeof __workerMain.bootstrapWorkerRuntime;
   workerClose: typeof __workerMain.workerClose;
   postMessage: typeof __workerMain.postMessage;
   Worker: typeof __workers.WorkerImpl;
@@ -2187,7 +2187,7 @@ declare let onerror:
       e: Event
     ) => boolean | void)
   | undefined;
-declare const workerMain: typeof __workerMain.workerMain;
+declare const bootstrapWorkerRuntime: typeof __workerMain.bootstrapWorkerRuntime;
 declare const workerClose: typeof __workerMain.workerClose;
 declare const postMessage: typeof __workerMain.postMessage;
 declare const Worker: typeof __workers.WorkerImpl;
@@ -3443,7 +3443,7 @@ declare namespace __workerMain {
   export function getMessage(): Promise<any>;
   export let isClosing: boolean;
   export function workerClose(): void;
-  export function workerMain(): Promise<void>;
+  export function bootstrapWorkerRuntime(): Promise<void>;
 }
 
 declare namespace __workers {

--- a/cli/js/main.ts
+++ b/cli/js/main.ts
@@ -11,8 +11,8 @@ import { setLocation } from "./location.ts";
 import { setBuildInfo } from "./build.ts";
 import { setSignals } from "./process.ts";
 
-function denoMain(preserveDenoNamespace = true, name?: string): void {
-  const s = os.start(preserveDenoNamespace, name);
+function bootstrapMainRuntime(): void {
+  const s = os.start(true);
 
   setBuildInfo(s.os, s.arch);
   setSignals();
@@ -35,4 +35,4 @@ function denoMain(preserveDenoNamespace = true, name?: string): void {
     replLoop();
   }
 }
-globalThis["denoMain"] = denoMain;
+globalThis["bootstrapMainRuntime"] = bootstrapMainRuntime;

--- a/cli/js/os.ts
+++ b/cli/js/os.ts
@@ -86,7 +86,7 @@ interface Start {
 
 // TODO(bartlomieju): temporary solution, must be fixed when moving
 // dispatches to separate crates
-export function initOps() {
+export function initOps(): void {
   const ops = core.ops();
   for (const [name, opId] of Object.entries(ops)) {
     const opName = `OP_${name.toUpperCase()}`;

--- a/cli/js/os.ts
+++ b/cli/js/os.ts
@@ -84,13 +84,10 @@ interface Start {
   arch: Arch;
 }
 
-// This function bootstraps an environment within Deno, it is shared both by
-// the runtime and the compiler environments.
-// @internal
-export function start(preserveDenoNamespace = true, source?: string): Start {
+// TODO(bartlomieju): temporary solution, must be fixed when moving
+// dispatches to separate crates
+export function initOps() {
   const ops = core.ops();
-  // TODO(bartlomieju): this is a prototype, we should come up with
-  // something a bit more sophisticated
   for (const [name, opId] of Object.entries(ops)) {
     const opName = `OP_${name.toUpperCase()}`;
     // Assign op ids to actual variables
@@ -98,6 +95,13 @@ export function start(preserveDenoNamespace = true, source?: string): Start {
     ((dispatch as unknown) as { [key: string]: number })[opName] = opId;
     core.setAsyncHandler(opId, dispatch.getAsyncHandler(opName));
   }
+}
+
+// This function bootstraps an environment within Deno, it is shared both by
+// the runtime and the compiler environments.
+// @internal
+export function start(preserveDenoNamespace = true, source?: string): Start {
+  initOps();
   // First we send an empty `Start` message to let the privileged side know we
   // are ready. The response should be a `StartRes` message containing the CLI
   // args and other info.

--- a/cli/js/worker_main.ts
+++ b/cli/js/worker_main.ts
@@ -44,7 +44,7 @@ export function workerClose(): void {
   isClosing = true;
 }
 
-export async function workerMain(): Promise<void> {
+export async function bootstrapWorkerRuntime(): Promise<void> {
   const ops = core.ops();
   // TODO(bartlomieju): this is a prototype, we should come up with
   // something a bit more sophisticated
@@ -56,12 +56,12 @@ export async function workerMain(): Promise<void> {
     core.setAsyncHandler(opId, dispatch.getAsyncHandler(opName));
   }
 
-  log("workerMain");
+  log("bootstrapWorkerRuntime");
 
   while (!isClosing) {
     const data = await getMessage();
     if (data == null) {
-      log("workerMain got null message. quitting.");
+      log("bootstrapWorkerRuntime got null message. quitting.");
       break;
     }
 

--- a/cli/js/worker_main.ts
+++ b/cli/js/worker_main.ts
@@ -5,6 +5,7 @@ import * as dispatch from "./dispatch.ts";
 import { sendAsync, sendSync } from "./dispatch_json.ts";
 import { log } from "./util.ts";
 import { TextDecoder, TextEncoder } from "./text_encoding.ts";
+import { initOps } from "./os.ts";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -45,16 +46,7 @@ export function workerClose(): void {
 }
 
 export async function bootstrapWorkerRuntime(): Promise<void> {
-  const ops = core.ops();
-  // TODO(bartlomieju): this is a prototype, we should come up with
-  // something a bit more sophisticated
-  for (const [name, opId] of Object.entries(ops)) {
-    const opName = `OP_${name.toUpperCase()}`;
-    // Assign op ids to actual variables
-    // TODO(ry) This type casting is gross and should be fixed.
-    ((dispatch as unknown) as { [key: string]: number })[opName] = opId;
-    core.setAsyncHandler(opId, dispatch.getAsyncHandler(opName));
-  }
+  initOps();
 
   log("bootstrapWorkerRuntime");
 

--- a/cli/js/worker_main.ts
+++ b/cli/js/worker_main.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { core } from "./core.ts";
 import * as dispatch from "./dispatch.ts";
 import { sendAsync, sendSync } from "./dispatch_json.ts";
 import { log } from "./util.ts";

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -260,7 +260,7 @@ fn info_command(flags: DenoFlags) {
   let main_module = state.main_module.as_ref().unwrap().clone();
 
   // Setup runtime.
-  js_check(worker.execute("denoMain()"));
+  js_check(worker.execute("bootstrapMainRuntime()"));
   debug!("main_module {}", main_module);
 
   let main_future = async move {
@@ -282,7 +282,7 @@ fn fetch_command(flags: DenoFlags) {
   let main_module = state.main_module.as_ref().unwrap().clone();
 
   // Setup runtime.
-  js_check(worker.execute("denoMain()"));
+  js_check(worker.execute("bootstrapMainRuntime()"));
   debug!("main_module {}", main_module);
 
   let main_future = async move {
@@ -300,7 +300,7 @@ fn eval_command(flags: DenoFlags) {
   let main_module =
     ModuleSpecifier::resolve_url_or_path("./__$deno$eval.ts").unwrap();
 
-  js_check(worker.execute("denoMain()"));
+  js_check(worker.execute("bootstrapMainRuntime()"));
   debug!("main_module {}", &main_module);
 
   let main_future = async move {
@@ -346,7 +346,7 @@ fn bundle_command(flags: DenoFlags) {
 
 fn run_repl(flags: DenoFlags) {
   let (mut worker, _state) = create_worker_and_state(flags);
-  js_check(worker.execute("denoMain()"));
+  js_check(worker.execute("bootstrapMainRuntime()"));
   let main_future = async move {
     loop {
       let result = worker.clone().await;
@@ -371,7 +371,7 @@ fn run_script(flags: DenoFlags) {
   // Normal situation of executing a module.
 
   // Setup runtime.
-  js_check(worker.execute("denoMain()"));
+  js_check(worker.execute("bootstrapMainRuntime()"));
   debug!("main_module {}", main_module);
 
   let mut worker_ = worker.clone();

--- a/cli/ops/worker_host.rs
+++ b/cli/ops/worker_host.rs
@@ -115,7 +115,7 @@ fn op_create_worker(
   let name = format!("USER-WORKER-{}", specifier);
   let mut worker =
     WebWorker::new(name, startup_data::deno_isolate_init(), child_state, ext);
-  js_check(worker.execute("workerMain()"));
+  js_check(worker.execute("bootstrapWorkerRuntime()"));
 
   let worker_id = parent_state.add_child_worker(worker.clone());
 
@@ -269,7 +269,7 @@ fn op_host_resume_worker(
 
   let mut workers_table = state_.workers.lock().unwrap();
   let worker = workers_table.get_mut(&id).unwrap();
-  js_check(worker.execute("workerMain()"));
+  js_check(worker.execute("bootstrapWorkerRuntime()"));
   Ok(JsonOp::Sync(json!({})))
 }
 

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -339,7 +339,7 @@ mod tests {
         state,
         ext,
       );
-      worker.execute("denoMain()").unwrap();
+      worker.execute("bootstrapMainRuntime()").unwrap();
       let result = worker
         .execute_mod_async(&module_specifier, None, false)
         .await;
@@ -371,7 +371,7 @@ mod tests {
       state,
       ext,
     );
-    worker.execute("denoMain()").unwrap();
+    worker.execute("bootstrapMainRuntime()").unwrap();
     worker.execute("bootstrapWorkerRuntime()").unwrap();
     worker
   }

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -372,7 +372,7 @@ mod tests {
       ext,
     );
     worker.execute("denoMain()").unwrap();
-    worker.execute("workerMain()").unwrap();
+    worker.execute("bootstrapWorkerRuntime()").unwrap();
     worker
   }
 


### PR DESCRIPTION
Towards workers

This PR renames JS entry functions so it's more visible what's going on in each scenario.
