### PR TITLE
Reland "Create an old program to be used in snapshot."

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
 
@@ -15,11 +14,10 @@ fn main() {
   let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
   let o = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
-  let mut custom_libs: HashMap<String, PathBuf> = HashMap::new();
-  custom_libs.insert(
+  let custom_libs = vec![(
     "lib.deno_runtime.d.ts".to_string(),
     c.join("js/lib.deno_runtime.d.ts"),
-  );
+  )];
 
   let root_names = vec![c.join("js/main.ts")];
   let bundle = o.join("CLI_SNAPSHOT.js");
@@ -29,11 +27,10 @@ fn main() {
   assert!(bundle.exists());
   deno_typescript::mksnapshot_bundle(&bundle, state).unwrap();
 
-  let mut custom_libs: HashMap<String, PathBuf> = HashMap::new();
-  custom_libs.insert(
+  let custom_libs = vec![(
     "lib.deno_runtime.d.ts".to_string(),
     c.join("js/lib.deno_runtime.d.ts"),
-  );
+  )];
 
   let root_names = vec![c.join("js/compiler.ts")];
   let bundle = o.join("COMPILER_SNAPSHOT.js");

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,4 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
 
@@ -14,15 +15,31 @@ fn main() {
   let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
   let o = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
+  let mut custom_libs: HashMap<String, PathBuf> = HashMap::new();
+  custom_libs.insert(
+    "lib.deno_runtime.d.ts".to_string(),
+    c.join("js/lib.deno_runtime.d.ts"),
+  );
+
   let root_names = vec![c.join("js/main.ts")];
   let bundle = o.join("CLI_SNAPSHOT.js");
-  let state = deno_typescript::compile_bundle(&bundle, root_names).unwrap();
+  let state =
+    deno_typescript::compile_bundle(&bundle, root_names, Some(custom_libs))
+      .unwrap();
   assert!(bundle.exists());
   deno_typescript::mksnapshot_bundle(&bundle, state).unwrap();
 
+  let mut custom_libs: HashMap<String, PathBuf> = HashMap::new();
+  custom_libs.insert(
+    "lib.deno_runtime.d.ts".to_string(),
+    c.join("js/lib.deno_runtime.d.ts"),
+  );
+
   let root_names = vec![c.join("js/compiler.ts")];
   let bundle = o.join("COMPILER_SNAPSHOT.js");
-  let state = deno_typescript::compile_bundle(&bundle, root_names).unwrap();
+  let state =
+    deno_typescript::compile_bundle(&bundle, root_names, Some(custom_libs))
+      .unwrap();
   assert!(bundle.exists());
   deno_typescript::mksnapshot_bundle_ts(&bundle, state).unwrap();
 }

--- a/cli/js.rs
+++ b/cli/js.rs
@@ -16,15 +16,7 @@ pub static COMPILER_SNAPSHOT_MAP: &[u8] =
 pub static COMPILER_SNAPSHOT_DTS: &[u8] =
   include_bytes!(concat!(env!("OUT_DIR"), "/COMPILER_SNAPSHOT.d.ts"));
 
-static DENO_RUNTIME: &str = include_str!("js/lib.deno_runtime.d.ts");
-
-/// Same as deno_typescript::get_asset but also has lib.deno_runtime.d.ts
-pub fn get_asset(name: &str) -> Option<&'static str> {
-  match name {
-    "lib.deno_runtime.d.ts" => Some(DENO_RUNTIME),
-    _ => deno_typescript::get_asset(name),
-  }
-}
+pub static DENO_RUNTIME: &str = include_str!("js/lib.deno_runtime.d.ts");
 
 #[test]
 fn cli_snapshot() {

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -6,6 +6,7 @@ import "./globals.ts";
 import "./ts_global.d.ts";
 
 import { TranspileOnlyResult } from "./compiler_api.ts";
+import { oldProgram } from "./compiler_bootstrap.ts";
 import { setRootExports } from "./compiler_bundler.ts";
 import {
   defaultBundlerOptions,
@@ -142,7 +143,12 @@ self.bootstrapTsCompiler = function tsCompilerMain(): void {
         // to generate the program and possibly emit it.
         if (!diagnostics || (diagnostics && diagnostics.length === 0)) {
           const options = host.getCompilationSettings();
-          const program = ts.createProgram(rootNames, options, host);
+          const program = ts.createProgram({
+            rootNames,
+            options,
+            host,
+            oldProgram
+          });
 
           diagnostics = ts
             .getPreEmitDiagnostics(program)
@@ -220,11 +226,12 @@ self.bootstrapTsCompiler = function tsCompilerMain(): void {
         }
         host.mergeOptions(...compilerOptions);
 
-        const program = ts.createProgram(
+        const program = ts.createProgram({
           rootNames,
-          host.getCompilationSettings(),
-          host
-        );
+          options: host.getCompilationSettings(),
+          host,
+          oldProgram
+        });
 
         if (bundle) {
           setRootExports(program, rootNames[0]);

--- a/cli/js/compiler_bootstrap.ts
+++ b/cli/js/compiler_bootstrap.ts
@@ -1,0 +1,34 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { ASSETS, Host } from "./compiler_host.ts";
+import { core } from "./core.ts";
+import * as dispatch from "./dispatch.ts";
+import { sendSync } from "./dispatch_json.ts";
+
+// This registers ops that are available during the snapshotting process.
+const ops = core.ops();
+for (const [name, opId] of Object.entries(ops)) {
+  const opName = `OP_${name.toUpperCase()}`;
+  // TODO This type casting is dangerous, and should be improved when the same
+  // code in `os.ts` is done.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (dispatch as any)[opName] = opId;
+}
+
+const host = new Host({ writeFile(): void {} });
+const options = host.getCompilationSettings();
+
+/** Used to generate the foundational AST for all other compilations, so it can
+ * be cached as part of the snapshot and available to speed up startup */
+export const oldProgram = ts.createProgram({
+  rootNames: [`${ASSETS}/bootstrap.ts`],
+  options,
+  host
+});
+
+/** A module loader which is concatenated into bundle files.  We read all static
+ * assets during the snapshotting process, which is why this is located in
+ * compiler_bootstrap. */
+export const bundleLoader = sendSync(dispatch.OP_FETCH_ASSET, {
+  name: "bundle_loader.js"
+});

--- a/cli/js/compiler_bundler.ts
+++ b/cli/js/compiler_bundler.ts
@@ -1,18 +1,12 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import * as dispatch from "./dispatch.ts";
-import { sendSync } from "./dispatch_json.ts";
+import { bundleLoader } from "./compiler_bootstrap.ts";
 import {
   assert,
   commonPath,
   normalizeString,
   CHAR_FORWARD_SLASH
 } from "./util.ts";
-
-const BUNDLE_LOADER = "bundle_loader.js";
-
-/** A loader of bundled modules that we will inline into any bundle outputs. */
-let bundleLoader: string;
 
 /** Local state of what the root exports are of a root module. */
 let rootExports: string[] | undefined;
@@ -40,12 +34,6 @@ export function buildBundle(
   data: string,
   sourceFiles: readonly ts.SourceFile[]
 ): string {
-  // we can only do this once we are bootstrapped and easiest way to do it is
-  // inline here
-  if (!bundleLoader) {
-    bundleLoader = sendSync(dispatch.OP_FETCH_ASSET, { name: BUNDLE_LOADER });
-  }
-
   // when outputting to AMD and a single outfile, TypeScript makes up the module
   // specifiers which are used to define the modules, and doesn't expose them
   // publicly, so we have to try to replicate

--- a/cli/js/compiler_sourcefile.ts
+++ b/cli/js/compiler_sourcefile.ts
@@ -61,7 +61,7 @@ export class SourceFile {
 
   mediaType!: MediaType;
   processed = false;
-  sourceCode!: string;
+  sourceCode?: string;
   tsSourceFile?: ts.SourceFile;
   url!: string;
 

--- a/cli/js/dispatch.ts
+++ b/cli/js/dispatch.ts
@@ -70,11 +70,14 @@ export let OP_TRUNCATE: number;
 export let OP_MAKE_TEMP_DIR: number;
 export let OP_CWD: number;
 export let OP_CONNECT_TLS: number;
-export let OP_FETCH_ASSET: number;
 export let OP_HOSTNAME: number;
 export let OP_OPEN_PLUGIN: number;
 export let OP_COMPILE: number;
 export let OP_TRANSPILE: number;
+
+/** **WARNING:** This is only available during the snapshotting process and is
+ * unavailable at runtime. */
+export let OP_FETCH_ASSET: number;
 
 const PLUGIN_ASYNC_HANDLER_MAP: Map<number, AsyncHandler> = new Map();
 

--- a/cli/js/dispatch_json.ts
+++ b/cli/js/dispatch_json.ts
@@ -62,7 +62,7 @@ export function sendSync(
   const resUi8 = core.dispatch(opId, argsUi8, zeroCopy);
   util.assert(resUi8 != null);
 
-  const res = decode(resUi8!);
+  const res = decode(resUi8);
   util.assert(res.promiseId == null);
   return unwrapResponse(res);
 }

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -146,8 +146,7 @@ fn create_worker_and_state(
 }
 
 fn types_command() {
-  let content = crate::js::get_asset("lib.deno_runtime.d.ts").unwrap();
-  println!("{}", content);
+  println!("{}", crate::js::DENO_RUNTIME);
 }
 
 fn print_cache_info(worker: MainWorker) {

--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -17,10 +17,6 @@ pub fn init(i: &mut Isolate, s: &ThreadSafeState) {
     "fetch_source_files",
     s.core_op(json_op(s.stateful_op(op_fetch_source_files))),
   );
-  i.register_op(
-    "fetch_asset",
-    s.core_op(json_op(s.stateful_op(op_fetch_asset))),
-  );
 }
 
 #[derive(Deserialize)]
@@ -148,22 +144,4 @@ fn op_fetch_source_files(
   });
 
   Ok(JsonOp::Async(future))
-}
-
-#[derive(Deserialize)]
-struct FetchAssetArgs {
-  name: String,
-}
-
-fn op_fetch_asset(
-  _state: &ThreadSafeState,
-  args: Value,
-  _zero_copy: Option<PinnedBuf>,
-) -> Result<JsonOp, ErrBox> {
-  let args: FetchAssetArgs = serde_json::from_value(args)?;
-  if let Some(source_code) = crate::js::get_asset(&args.name) {
-    Ok(JsonOp::Sync(json!(source_code)))
-  } else {
-    panic!("op_fetch_asset bad asset {}", args.name)
-  }
 }

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -680,6 +680,7 @@ impl Isolate {
     let mut hs = v8::HandleScope::new(locker.enter());
     let scope = hs.enter();
     self.global_context.reset(scope);
+    self.shared_response_buf.reset(scope);
 
     let snapshot_creator = self.snapshot_creator.as_mut().unwrap();
     let snapshot = snapshot_creator

--- a/core/shared_queue.js
+++ b/core/shared_queue.js
@@ -184,7 +184,6 @@ SharedQueue Binary Layout
   }
 
   function dispatch(opId, control, zeroCopy = null) {
-    maybeInit();
     return Deno.core.send(opId, control, zeroCopy);
   }
 

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -16,6 +16,7 @@ use deno_core::PinnedBuf;
 use deno_core::StartupData;
 pub use ops::EmitResult;
 use ops::WrittenFile;
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -37,6 +38,7 @@ pub struct TSState {
   bundle: bool,
   exit_code: i32,
   emit_result: Option<EmitResult>,
+  custom_assets: Option<HashMap<String, PathBuf>>,
   /// A list of files emitted by typescript. WrittenFile is tuple of the form
   /// (url, corresponding_module, source_code)
   written_files: Vec<WrittenFile>,
@@ -76,6 +78,7 @@ impl TSIsolate {
 
     let state = Arc::new(Mutex::new(TSState {
       bundle,
+      custom_assets: None,
       exit_code: 0,
       emit_result: None,
       written_files: Vec::new(),
@@ -119,13 +122,22 @@ impl TSIsolate {
     self.isolate.execute("<anon>", source)?;
     Ok(self.state)
   }
+
+  pub fn add_custom_assets(&mut self, custom_assets: HashMap<String, PathBuf>) {
+    let mut state = self.state.lock().unwrap();
+    state.custom_assets = Some(custom_assets);
+  }
 }
 
 pub fn compile_bundle(
   bundle: &Path,
   root_names: Vec<PathBuf>,
+  custom_assets: Option<HashMap<String, PathBuf>>,
 ) -> Result<Arc<Mutex<TSState>>, ErrBox> {
-  let ts_isolate = TSIsolate::new(true);
+  let mut ts_isolate = TSIsolate::new(true);
+  if let Some(assets) = custom_assets {
+    ts_isolate.add_custom_assets(assets);
+  }
 
   let config_json = serde_json::json!({
     "compilerOptions": {
@@ -203,6 +215,10 @@ pub fn mksnapshot_bundle_ts(
   state: Arc<Mutex<TSState>>,
 ) -> Result<(), ErrBox> {
   let runtime_isolate = &mut Isolate::new(StartupData::None, true);
+  runtime_isolate.register_op(
+    "fetch_asset",
+    compiler_op(state.clone(), ops::json_op(ops::fetch_asset)),
+  );
   let source_code_vec = std::fs::read(bundle)?;
   let source_code = std::str::from_utf8(&source_code_vec)?;
 
@@ -255,6 +271,7 @@ pub fn get_asset(name: &str) -> Option<&'static str> {
   }
   match name {
     "bundle_loader.js" => Some(include_str!("bundle_loader.js")),
+    "bootstrap.ts" => Some("console.log(\"hello deno\");"),
     "typescript.d.ts" => inc!("typescript.d.ts"),
     "lib.esnext.d.ts" => inc!("lib.esnext.d.ts"),
     "lib.es2020.d.ts" => inc!("lib.es2020.d.ts"),

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -18,6 +18,7 @@ pub use ops::EmitResult;
 use ops::WrittenFile;
 use std::collections::HashMap;
 use std::fs;
+use std::hash::BuildHasher;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -129,10 +130,10 @@ impl TSIsolate {
   }
 }
 
-pub fn compile_bundle(
+pub fn compile_bundle<S: BuildHasher>(
   bundle: &Path,
   root_names: Vec<PathBuf>,
-  custom_assets: Option<HashMap<String, PathBuf>>,
+  custom_assets: Option<HashMap<String, PathBuf, S>>,
 ) -> Result<Arc<Mutex<TSState>>, ErrBox> {
   let mut ts_isolate = TSIsolate::new(true);
   if let Some(assets) = custom_assets {

--- a/deno_typescript/ops.rs
+++ b/deno_typescript/ops.rs
@@ -46,19 +46,12 @@ pub fn read_file(s: &mut TSState, v: Value) -> Result<Value, ErrBox> {
   let (module_name, source_code) = if v.file_name.starts_with("$asset$/") {
     let asset = v.file_name.replace("$asset$/", "");
 
-    let mut source_code = None;
+    let source_code = match s.custom_assets.get(&asset) {
+      Some(asset_path) => std::fs::read_to_string(&asset_path)?,
+      None => crate::get_asset2(&asset)?.to_string(),
+    };
 
-    if let Some(custom_assets) = &s.custom_assets {
-      if let Some(asset_path) = custom_assets.get(&asset) {
-        source_code = Some(std::fs::read_to_string(&asset_path)?);
-      }
-    }
-
-    if source_code.is_none() {
-      source_code = Some(crate::get_asset2(&asset)?.to_string());
-    }
-
-    (asset, source_code.unwrap())
+    (asset, source_code)
   } else {
     assert!(!v.file_name.starts_with("$assets$"), "you meant $asset$");
     let module_specifier = ModuleSpecifier::resolve_url_or_path(&v.file_name)?;
@@ -131,11 +124,9 @@ struct FetchAssetArgs {
 pub fn fetch_asset(s: &mut TSState, v: Value) -> Result<Value, ErrBox> {
   let args: FetchAssetArgs = serde_json::from_value(v)?;
 
-  if let Some(custom_assets) = &s.custom_assets {
-    if let Some(asset_path) = custom_assets.get(&args.name) {
-      let source_code = std::fs::read_to_string(&asset_path)?;
-      return Ok(json!(source_code));
-    }
+  if let Some(asset_path) = s.custom_assets.get(&args.name) {
+    let source_code = std::fs::read_to_string(&asset_path)?;
+    return Ok(json!(source_code));
   }
 
   if let Some(source_code) = crate::get_asset(&args.name) {


### PR DESCRIPTION
This time assets outside `deno_typescript/` are read from disk during snapshotting. It is facilitated by passing optional hashmap of (asset name, path) to snapshotting isolate.

Currently testing "cargo package"...