### PR TITLE
fix(std/http): update listenAndServe argument type

### DIFF
--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -494,7 +494,7 @@ export function serve(addr: string | ServerConfig): Server {
 }
 
 export async function listenAndServe(
-  addr: string,
+  addr: string | ServerConfig,
   handler: (req: ServerRequest) => void
 ): Promise<void> {
   const server = serve(addr);


### PR DESCRIPTION
allow same argument type for `listenAndServe` as `serve`.
fixes: #3774
