### PR TITLE
Update crate installation doc to reflect renames

### DIFF
--- a/std/manual.md
+++ b/std/manual.md
@@ -141,10 +141,10 @@ Using [Homebrew](https://formulae.brew.sh/formula/deno) (mac):
 brew install deno
 ```
 
-Using [Cargo](https://crates.io/crates/deno_cli):
+Using [Cargo](https://crates.io/crates/deno):
 
 ```shell
-cargo install deno_cli
+cargo install deno
 ```
 
 Deno binaries can also be installed manually, by downloading a tarball or zip


### PR DESCRIPTION
As documented in the [v.0.29.0 / 2020.01.09](https://github.com/denoland/deno/blob/master/Releases.md#v0290--20200109) release, `deno_cli` has been renamed to `deno`.

https://github.com/denoland/deno/blob/master/Releases.md#v0290--20200109

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
