### PR TITLE
Do not panic and improve error message on cache failure

### DIFF
--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -13,6 +13,13 @@ pub struct DiskCache {
   pub location: PathBuf,
 }
 
+fn with_io_context<T: AsRef<str>>(
+  e: &std::io::Error,
+  context: T,
+) -> std::io::Error {
+  std::io::Error::new(e.kind(), format!("{} (for '{}')", e, context.as_ref()))
+}
+
 impl DiskCache {
   pub fn new(location: &Path) -> Self {
     // TODO: ensure that 'location' is a directory
@@ -107,10 +114,12 @@ impl DiskCache {
   pub fn set(&self, filename: &Path, data: &[u8]) -> std::io::Result<()> {
     let path = self.location.join(filename);
     match path.parent() {
-      Some(ref parent) => fs::create_dir_all(parent),
+      Some(ref parent) => fs::create_dir_all(parent)
+        .map_err(|e| with_io_context(&e, format!("{:#?}", &path))),
       None => Ok(()),
     }?;
     deno_fs::write_file(&path, data, 0o666)
+      .map_err(|e| with_io_context(&e, format!("{:#?}", &path)))
   }
 
   pub fn remove(&self, filename: &Path) -> std::io::Result<()> {


### PR DESCRIPTION
Related to #3776 (but does not really solve it)

Instead of panicking, print an error with better messages:

Before:
```
deno -r https://dev.jspm.io/react-dom
Download https://dev.jspm.io/react-dom
Download https://dev.jspm.io/npm:react-dom@16.12.0/index.dew.js
Download https://dev.jspm.io/npm:react-dom@16.12.0/cjs/react-dom.development.dew.js
Download https://dev.jspm.io/npm:react@16?dew
Download https://dev.jspm.io/npm:object-assign@4?dew
Download https://dev.jspm.io/npm:scheduler@0.18?dew
Download https://dev.jspm.io/npm:prop-types@15/checkPropTypes?dew
Download https://dev.jspm.io/npm:scheduler@0.18/tracing?dew
Download https://dev.jspm.io/npm:object-assign@4.1.1/index.dew.js
Download https://dev.jspm.io/npm:react@16.12.0/index.dew.js
Download https://dev.jspm.io/npm:react@16.12.0/cjs/react.development.dew.js
Download https://dev.jspm.io/npm:prop-types@15.7.2/checkPropTypes.dew.js
Download https://dev.jspm.io/npm:prop-types@15.7.2/lib/ReactPropTypesSecret.dew.js
Download https://dev.jspm.io/npm:scheduler@0.18.0/index.dew.js
Download https://dev.jspm.io/npm:scheduler@0.18.0/cjs/scheduler.development.dew.js
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 17, kind: AlreadyExists, message: "File exists" }', src/libcore/result.rs:1165:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

After:
```
deno -r https://dev.jspm.io/react-dom
Download https://dev.jspm.io/react-dom
Download https://dev.jspm.io/npm:react-dom@16.12.0/index.dew.js
Download https://dev.jspm.io/npm:react-dom@16.12.0/cjs/react-dom.development.dew.js
Download https://dev.jspm.io/npm:react@16?dew
Download https://dev.jspm.io/npm:object-assign@4?dew
Download https://dev.jspm.io/npm:scheduler@0.18?dew
Download https://dev.jspm.io/npm:prop-types@15/checkPropTypes?dew
Download https://dev.jspm.io/npm:scheduler@0.18/tracing?dew
Download https://dev.jspm.io/npm:object-assign@4.1.1/index.dew.js
Download https://dev.jspm.io/npm:prop-types@15.7.2/checkPropTypes.dew.js
Download https://dev.jspm.io/npm:prop-types@15.7.2/lib/ReactPropTypesSecret.dew.js
Download https://dev.jspm.io/npm:react@16.12.0/index.dew.js
Download https://dev.jspm.io/npm:react@16.12.0/cjs/react.development.dew.js
Download https://dev.jspm.io/npm:scheduler@0.18.0/index.dew.js
Download https://dev.jspm.io/npm:scheduler@0.18.0/cjs/scheduler.development.dew.js
Source code header cache failed for 'https://dev.jspm.io/npm:scheduler@0.18/tracing?dew': File exists (os error 17) (for '"/Users/[REDACTED]/Library/Caches/deno/deps/https/dev.jspm.io/npm:scheduler@0.18/tracing.headers.json"')
```