### PR TITLE
lock: support lock-write for fetch command

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -290,6 +290,17 @@ fn fetch_command(flags: DenoFlags) {
   let main_future = async move {
     let result = worker.execute_mod_async(&main_module, None, true).await;
     js_check(result);
+    if state.flags.lock_write {
+      if let Some(ref lockfile) = state.lockfile {
+        let g = lockfile.lock().unwrap();
+        if let Err(e) = g.write() {
+          print_err_and_exit(ErrBox::from(e));
+        }
+      } else {
+        eprintln!("--lock flag must be specified when using --lock-write");
+        std::process::exit(11);
+      }
+    }
   };
 
   tokio_util::run(main_future);

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -385,6 +385,13 @@ itest!(_052_no_remote_flag {
   http_server: true,
 });
 
+itest!(lock_write_fetch {
+  args:
+    "run --allow-read --allow-write --allow-env --allow-run lock_write_fetch.ts",
+  output: "lock_write_fetch.ts.out",
+  exit_code: 0,
+});
+
 itest!(lock_check_ok {
   args: "run --lock=lock_check_ok.json http://127.0.0.1:4545/cli/tests/003_relative_import.ts",
   output: "003_relative_import.ts.out",

--- a/cli/tests/lock_write_fetch.ts
+++ b/cli/tests/lock_write_fetch.ts
@@ -7,6 +7,7 @@ const fetchProc = Deno.run({
   stderr: "null",
   args: [
     Deno.execPath(),
+    "fetch",
     "--reload",
     "--lock=lock_write_fetch.json",
     "--lock-write",
@@ -16,6 +17,20 @@ const fetchProc = Deno.run({
 
 const fetchCode = (await fetchProc.status()).code;
 console.log(`fetch code: ${fetchCode}`);
+
+const fetchCheckProc = Deno.run({
+  stdout: "null",
+  stderr: "null",
+  args: [
+    Deno.execPath(),
+    "fetch",
+    "--lock=lock_write_fetch.json",
+    "https_import.ts"
+  ]
+});
+
+const fetchCheckProcCode = (await fetchCheckProc.status()).code;
+console.log(`fetch check code: ${fetchCheckProcCode}`);
 
 const runProc = Deno.run({
   stdout: "null",

--- a/cli/tests/lock_write_fetch.ts
+++ b/cli/tests/lock_write_fetch.ts
@@ -1,0 +1,29 @@
+try {
+  Deno.removeSync("./lock_write_fetch.json");
+} catch {}
+
+const fetchProc = Deno.run({
+  stdout: "null",
+  stderr: "null",
+  args: [
+    Deno.execPath(),
+    "--reload",
+    "--lock=lock_write_fetch.json",
+    "--lock-write",
+    "https_import.ts"
+  ]
+});
+
+const fetchCode = (await fetchProc.status()).code;
+console.log(`fetch code: ${fetchCode}`);
+
+const runProc = Deno.run({
+  stdout: "null",
+  stderr: "null",
+  args: [Deno.execPath(), "--lock=lock_write_fetch.json", "https_import.ts"]
+});
+
+const runCode = (await runProc.status()).code;
+console.log(`run code: ${runCode}`);
+
+Deno.removeSync("./lock_write_fetch.json");

--- a/cli/tests/lock_write_fetch.ts.out
+++ b/cli/tests/lock_write_fetch.ts.out
@@ -1,0 +1,2 @@
+fetch code: 0
+run code: 0

--- a/cli/tests/lock_write_fetch.ts.out
+++ b/cli/tests/lock_write_fetch.ts.out
@@ -1,2 +1,3 @@
 fetch code: 0
+fetch check code: 0
 run code: 0


### PR DESCRIPTION
Closes #3772 

Now `deno fetch --lock=lock.json --lock-write main.ts` would write a lockfile.