### PR TITLE
std/installer: add basic uninstaller

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -302,7 +302,7 @@ fn install_parse(flags: &mut DenoFlags, matches: &clap::ArgMatches) {
     println!("dir {}", install_dir);
     flags.argv.push(install_dir.to_string());
   } else {
-    println!("no dir");
+    debug!("install_parse: no dir");
   }
 
   let exe_name = matches.value_of("exe_name").unwrap();

--- a/std/installer/README.md
+++ b/std/installer/README.md
@@ -10,6 +10,12 @@ Install remote or local script as executables.
 deno -A https://deno.land/std/installer/mod.ts deno_installer https://deno.land/std/installer/mod.ts -A
 ```
 
+`uninstaller` can be similarly installed:
+
+```sh
+deno -A https://deno.land/std/installer/mod.ts deno_uninstaller https://deno.land/std/installer/uninstall.ts -A
+```
+
 ## Usage
 
 Install script
@@ -35,6 +41,14 @@ Run installed script:
 ```sh
 $ file_server
 HTTP server listening on http://0.0.0.0:4500/
+```
+
+Uninstall script:
+
+```sh
+# uninstall previously installed command
+$ deno_uninstaller file_server
+> ✅ Successfully uninstalled file_server
 ```
 
 ## Custom installation directory
@@ -86,4 +100,18 @@ ARGS:
 
 OPTIONS:
   -d, --dir <PATH> Installation directory path (defaults to ~/.deno/bin)
+
+$ deno_uninstaller --help
+> deno uninstaller
+  Uninstall previously installed executables.
+
+USAGE:
+  deno -A https://deno.land/std/installer/uninstall.ts [OPTIONS] EXE_NAME
+
+ARGS:
+  EXE_NAME  Name for executable
+
+OPTIONS:
+  -d, --dir <PATH> Installation directory path (defaults to ~/.deno/bin)
+
 ```

--- a/std/installer/uninstall.ts
+++ b/std/installer/uninstall.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env -S deno --allow-all
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+const { env, args, exit } = Deno;
+import { parse } from "../flags/mod.ts";
+import { exists } from "../fs/exists.ts";
+import { ensureDir } from "../fs/ensure_dir.ts";
+import * as path from "../path/mod.ts";
+
+function showHelp(): void {
+  console.log(`deno uninstaller
+  Uninstall previously installed executables.
+
+USAGE:
+  deno -A https://deno.land/std/installer/uninstall.ts [OPTIONS] EXE_NAME
+
+ARGS:
+  EXE_NAME  Name for executable
+
+OPTIONS:
+  -d, --dir <PATH> Installation directory path (defaults to ~/.deno/bin)
+`);
+}
+
+function getInstallerDir(): string {
+  // In Windows's Powershell $HOME environmental variable maybe null
+  // if so use $USERPROFILE instead.
+  const { HOME, USERPROFILE } = env();
+
+  const HOME_PATH = HOME || USERPROFILE;
+
+  if (!HOME_PATH) {
+    throw new Error("$HOME is not defined.");
+  }
+
+  return path.resolve(HOME_PATH, ".deno", "bin");
+}
+
+function validateModuleName(moduleName: string): boolean {
+  if (/^[a-z][\w-]*$/i.test(moduleName)) {
+    return true;
+  } else {
+    throw new Error("Invalid module name: " + moduleName);
+  }
+}
+
+export async function uninstall(
+  executableName: string,
+  installationDir?: string
+): Promise<void> {
+  if (!installationDir) {
+    installationDir = getInstallerDir();
+  }
+  await ensureDir(installationDir);
+  validateModuleName(executableName);
+
+  const filePath = path.join(installationDir, executableName);
+
+  if (!(await exists(filePath))) {
+    console.log(
+      `No installed '${executableName}' found under ${installationDir}`
+    );
+    return;
+  }
+
+  await Deno.remove(filePath);
+  console.log(`✅ Successfully uninstalled ${executableName}`);
+}
+
+async function main(): Promise<void> {
+  const parsedArgs = parse(args, { stopEarly: true });
+
+  if (parsedArgs.h || parsedArgs.help) {
+    return showHelp();
+  }
+
+  if (parsedArgs._.length < 1) {
+    return showHelp();
+  }
+
+  const moduleName = parsedArgs._[0];
+  const installationDir = parsedArgs.d || parsedArgs.dir;
+
+  try {
+    await uninstall(moduleName, installationDir);
+  } catch (e) {
+    console.log(e);
+    exit(1);
+  }
+}
+
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
Add a very basic uninstaller that mirrors the installer, making removal slightly easier.

(Technically this is similar to `rm $(which file_server)`, but based on Gitter conversations it seems that not everyone is familiar with using the shell, and the command might remove other binaries of same name)