### PR TITLE
Remove --current-thread flag

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -85,8 +85,6 @@ pub struct DenoFlags {
   pub cached_only: bool,
   pub seed: Option<u64>,
   pub v8_flags: Option<Vec<String>>,
-  // Use tokio::runtime::current_thread
-  pub current_thread: bool,
 
   pub bundle_output: Option<String>,
 
@@ -438,10 +436,6 @@ fn run_test_args_parse(flags: &mut DenoFlags, matches: &clap::ArgMatches) {
     flags.cached_only = true;
   }
 
-  if matches.is_present("current-thread") {
-    flags.current_thread = true;
-  }
-
   if matches.is_present("seed") {
     let seed_string = matches.value_of("seed").unwrap();
     let seed = seed_string.parse::<u64>().unwrap();
@@ -753,11 +747,6 @@ fn run_test_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
       Arg::with_name("cached-only")
         .long("cached-only")
         .help("Require that remote dependencies are already cached"),
-    )
-    .arg(
-      Arg::with_name("current-thread")
-        .long("current-thread")
-        .help("Use tokio::runtime::current_thread"),
     )
     .arg(
       Arg::with_name("seed")
@@ -1868,20 +1857,6 @@ mod tests {
         subcommand: DenoSubcommand::Run,
         argv: svec!["deno", "script.ts"],
         cached_only: true,
-        ..DenoFlags::default()
-      }
-    );
-  }
-
-  #[test]
-  fn current_thread() {
-    let r = flags_from_vec_safe(svec!["deno", "--current-thread", "script.ts"]);
-    assert_eq!(
-      r.unwrap(),
-      DenoFlags {
-        subcommand: DenoSubcommand::Run,
-        argv: svec!["deno", "script.ts"],
-        current_thread: true,
         ..DenoFlags::default()
       }
     );

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -378,7 +378,6 @@ fn run_repl(flags: DenoFlags) {
 }
 
 fn run_script(flags: DenoFlags) {
-  let use_current_thread = flags.current_thread;
   let (mut worker, state) = create_worker_and_state(flags);
 
   let maybe_main_module = state.main_module.as_ref();
@@ -416,11 +415,7 @@ fn run_script(flags: DenoFlags) {
     js_check(worker_.execute("window.dispatchEvent(new Event('unload'))"));
   };
 
-  if use_current_thread {
-    tokio_util::run_on_current_thread(main_future);
-  } else {
-    tokio_util::run(main_future);
-  }
+  tokio_util::run(main_future);
 }
 
 fn format_command(files: Option<Vec<String>>, check: bool) {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -320,11 +320,6 @@ itest!(_036_import_map_fetch {
   output: "036_import_map_fetch.out",
 });
 
-itest!(_037_current_thread {
-  args: "run --current-thread --reload 034_onload/main.ts",
-  output: "034_onload.out",
-});
-
 itest!(_038_checkjs {
   // checking if JS file is run through TS compiler
   args: "run --reload --config 038_checkjs.tsconfig.json 038_checkjs.js",

--- a/cli/tokio_util.rs
+++ b/cli/tokio_util.rs
@@ -15,16 +15,3 @@ where
     .expect("Unable to create Tokio runtime");
   rt.block_on(future);
 }
-
-pub fn run_on_current_thread<F>(future: F)
-where
-  F: Future<Output = ()> + Send + 'static,
-{
-  let mut rt = runtime::Builder::new()
-    .basic_scheduler()
-    .enable_all()
-    .thread_name("deno")
-    .build()
-    .expect("Unable to create Tokio runtime");
-  rt.block_on(future);
-}

--- a/std/manual.md
+++ b/std/manual.md
@@ -1267,9 +1267,6 @@ Useful V8 flags during profiling:
 - --log-source-code
 - --track-gc-object-stats
 
-Note that you might need to run Deno with `--current-thread` flag to capture
-full V8 profiling output.
-
 To learn more about `d8` and profiling, check out the following links:
 
 - [https://v8.dev/docs/d8](https://v8.dev/docs/d8)

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -42,17 +42,6 @@ def deno_tcp(deno_exe):
     return run(deno_cmd, port)
 
 
-def deno_tcp_current_thread(deno_exe):
-    port = get_port()
-    deno_cmd = [
-        deno_exe, "run", "--current-thread", "--allow-net",
-        "tools/deno_tcp.ts",
-        server_addr(port)
-    ]
-    print "http_benchmark testing DENO tcp (single-thread)."
-    return run(deno_cmd, port)
-
-
 def deno_http(deno_exe):
     port = get_port()
     deno_cmd = [
@@ -154,7 +143,6 @@ def http_benchmark(build_dir):
     return {
         # "deno_tcp" was once called "deno"
         "deno_tcp": deno_tcp(deno_exe),
-        "deno_tcp_current_thread": deno_tcp_current_thread(deno_exe),
         # "deno_http" was once called "deno_net_http"
         "deno_http": deno_http(deno_exe),
         "deno_proxy": deno_http_proxy(deno_exe, hyper_hello_exe),


### PR DESCRIPTION
This flag was added to evaluate performance relative to the threaded
runtime. Although it's faster in the HTTP benchmark, it's the runtime is
not the only perf problem.

Removing this flag will simplify further refactors, in particular
adopting the #[tokio::main] macro. This will be done in a follow up.

Ultimately we expect to move to the current thread runtime with Isolates
pinned to specific threads, but that will be a much larger refactor. The
--current-thread just complicates that effort.

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
