### PR TITLE
Endianness

### DIFF
--- a/std/node/os.ts
+++ b/std/node/os.ts
@@ -97,9 +97,9 @@ export function cpus(): CPUCoreInfo[] {
   notImplemented(SEE_GITHUB_ISSUE);
 }
 
-/** 
- * Returns a string identifying the endianness of the CPU for which the Deno 
- * binary was compiled. Possible values are 'BE' for big endian and 'LE' for 
+/**
+ * Returns a string identifying the endianness of the CPU for which the Deno
+ * binary was compiled. Possible values are 'BE' for big endian and 'LE' for
  * little endian.
  **/
 export function endianness(): "BE" | "LE" {

--- a/std/node/os.ts
+++ b/std/node/os.ts
@@ -96,9 +96,17 @@ export function cpus(): CPUCoreInfo[] {
   notImplemented(SEE_GITHUB_ISSUE);
 }
 
-/** Not yet implemented */
+/** 
+ * Returns a string identifying the endianness of the CPU for which the Deno 
+ * binary was compiled. Possible values are 'BE' for big endian and 'LE' for 
+ * little endian.
+ **/
 export function endianness(): "BE" | "LE" {
-  notImplemented(SEE_GITHUB_ISSUE);
+  // Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView#Endianness
+  const buffer = new ArrayBuffer(2);
+  new DataView(buffer).setInt16(0, 256, true /* littleEndian */);
+  // Int16Array uses the platform's endianness.
+  return new Int16Array(buffer)[0] === 256 ? "LE" : "BE";
 }
 
 /** Not yet implemented */

--- a/std/node/os.ts
+++ b/std/node/os.ts
@@ -19,6 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 import { notImplemented } from "./_utils.ts";
+import { EOL as fsEOL } from "../fs/eol.ts";
 
 const SEE_GITHUB_ISSUE = "See https://github.com/denoland/deno/issues/3802";
 
@@ -209,7 +210,7 @@ export const constants = {
   }
 };
 
-export const EOL = Deno.build.os == "win" ? "\r\n" : "\n";
+export const EOL = Deno.build.os == "win" ? fsEOL.CRLF : fsEOL.LF;
 
 const validateInt32 = (
   value: number,

--- a/std/node/os_test.ts
+++ b/std/node/os_test.ts
@@ -154,6 +154,13 @@ test({
   }
 });
 
+test({
+  name: "Endianness is determined",
+  fn() {
+    assert(["LE", "BE"].includes(os.endianness()));
+  }
+});
+
 // Method is currently implemented correctly for windows but not for any other os
 test({
   name: "Load average is an array of 3 numbers",
@@ -183,13 +190,6 @@ test({
     assertThrows(
       () => {
         os.cpus();
-      },
-      Error,
-      "Not implemented"
-    );
-    assertThrows(
-      () => {
-        os.endianness();
       },
       Error,
       "Not implemented"


### PR DESCRIPTION
Endianness can be determined via a few simple lines of Javascript.  Ideally this would be implemented alongside other os functionality in Deno, but for now it provides the necessary polyfill for the node os module.  [Credit to Mozilla](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView#Endianness).

