### PR TITLE
Add support for multiple files in fetch command

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -339,8 +339,10 @@ fn fetch_parse(flags: &mut DenoFlags, matches: &clap::ArgMatches) {
   importmap_arg_parse(flags, matches);
   config_arg_parse(flags, matches);
   no_remote_arg_parse(flags, matches);
-  if let Some(file) = matches.value_of("file") {
-    flags.argv.push(file.into());
+  if let Some(files) = matches.values_of("file") {
+    for file in files {
+      flags.argv.push(file.into());
+    }
   }
 }
 
@@ -662,7 +664,12 @@ fn fetch_subcommand<'a, 'b>() -> App<'a, 'b> {
     .arg(importmap_arg())
     .arg(config_arg())
     .arg(no_remote_arg())
-    .arg(Arg::with_name("file").takes_value(true).required(true))
+    .arg(
+      Arg::with_name("file")
+        .takes_value(true)
+        .required(true)
+        .min_values(1),
+    )
     .about("Fetch the dependencies")
     .long_about(
       "Fetch and compile remote dependencies recursively.

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -520,7 +520,7 @@ fn fmt_subcommand<'a, 'b>() -> App<'a, 'b> {
   deno fmt
 
   deno fmt myfile1.ts myfile2.ts
-  
+
   deno fmt --check",
     )
     .arg(
@@ -1615,6 +1615,20 @@ mod tests {
         subcommand: DenoSubcommand::Fetch,
         argv: svec!["deno", "script.ts"],
         import_map_path: Some("importmap.json".to_owned()),
+        ..DenoFlags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn fetch_multiple() {
+    let r =
+      flags_from_vec_safe(svec!["deno", "fetch", "script.ts", "script_two.ts"]);
+    assert_eq!(
+      r.unwrap(),
+      DenoFlags {
+        subcommand: DenoSubcommand::Fetch,
+        argv: svec!["deno", "script.ts", "script_two.ts"],
         ..DenoFlags::default()
       }
     );

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -90,6 +90,15 @@ impl ThreadSafeGlobalState {
     let main_module: Option<ModuleSpecifier> = if flags.argv.len() <= 1 {
       None
     } else {
+      // resolve modules for rest of args if present (for fetch)
+      let files_len = flags.argv.len();
+      if files_len > 2 {
+        for i in 2..files_len {
+          let next_specifier = flags.argv[i].clone();
+          let _res = ModuleSpecifier::resolve_url_or_path(&next_specifier);
+        }
+      }
+      // then resolve root
       let root_specifier = flags.argv[1].clone();
       Some(ModuleSpecifier::resolve_url_or_path(&root_specifier)?)
     };

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -90,15 +90,6 @@ impl ThreadSafeGlobalState {
     let main_module: Option<ModuleSpecifier> = if flags.argv.len() <= 1 {
       None
     } else {
-      // resolve modules for rest of args if present (for fetch)
-      let files_len = flags.argv.len();
-      if files_len > 2 {
-        for i in 2..files_len {
-          let next_specifier = flags.argv[i].clone();
-          let _res = ModuleSpecifier::resolve_url_or_path(&next_specifier);
-        }
-      }
-      // then resolve root
       let root_specifier = flags.argv[1].clone();
       Some(ModuleSpecifier::resolve_url_or_path(&root_specifier)?)
     };

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -297,8 +297,7 @@ async fn fetch_command(flags: DenoFlags) {
   // resolve modules for rest of args if present
   let files_len = args.len();
   if files_len > 2 {
-    for i in 2..files_len {
-      let next_specifier = args[i].clone();
+    for next_specifier in args.iter().take(files_len).skip(2) {
       let next_module =
         ModuleSpecifier::resolve_url_or_path(&next_specifier).unwrap();
       let result = worker.execute_mod_async(&next_module, None, true).await;

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -299,7 +299,8 @@ async fn fetch_command(flags: DenoFlags) {
   if files_len > 2 {
     for i in 2..files_len {
       let next_specifier = args[i].clone();
-      let next_module = ModuleSpecifier::resolve_url_or_path(&next_specifier).unwrap();
+      let next_module =
+        ModuleSpecifier::resolve_url_or_path(&next_specifier).unwrap();
       let result = worker.execute_mod_async(&next_module, None, true).await;
       js_check(result);
     }

--- a/cli/tests/037_fetch_multiple.out
+++ b/cli/tests/037_fetch_multiple.out
@@ -1,6 +1,5 @@
-Compile file:///home/yamalight/projects/bxjs/deno/cli/tests/fetch/test.ts
-Download https://unpkg.com/leaflet/dist/leaflet-src.esm.js
-Download https://unpkg.com/leaflet@1.6.0/dist/leaflet-src.esm.js
-Compile file:///home/yamalight/projects/bxjs/deno/cli/tests/fetch/other.ts
-Download https://www.unpkg.com/vue/dist/vue.runtime.esm.js
-Download https://www.unpkg.com/vue@2.6.11/dist/vue.runtime.esm.js
+Compile [WILDCARD]/fetch/test.ts
+Download http://localhost:4545/cli/tests/subdir/mod2.ts
+Download http://localhost:4545/cli/tests/subdir/print_hello.ts
+Compile [WILDCARD]/fetch/other.ts
+Download http://localhost:4545/cli/tests/subdir/mt_text_typescript.t1.ts

--- a/cli/tests/037_fetch_multiple.out
+++ b/cli/tests/037_fetch_multiple.out
@@ -1,0 +1,4 @@
+Download https://www.unpkg.com/vue@2.6.11/dist/vue.runtime.esm.js
+Compile file:///home/yamalight/projects/bxjs/deno/cli/tests/fetch/test.ts
+Download https://unpkg.com/leaflet/dist/leaflet-src.esm.js
+Download https://unpkg.com/leaflet@1.6.0/dist/leaflet-src.esm.js

--- a/cli/tests/037_fetch_multiple.out
+++ b/cli/tests/037_fetch_multiple.out
@@ -1,4 +1,6 @@
-Download https://www.unpkg.com/vue@2.6.11/dist/vue.runtime.esm.js
 Compile file:///home/yamalight/projects/bxjs/deno/cli/tests/fetch/test.ts
 Download https://unpkg.com/leaflet/dist/leaflet-src.esm.js
 Download https://unpkg.com/leaflet@1.6.0/dist/leaflet-src.esm.js
+Compile file:///home/yamalight/projects/bxjs/deno/cli/tests/fetch/other.ts
+Download https://www.unpkg.com/vue/dist/vue.runtime.esm.js
+Download https://www.unpkg.com/vue@2.6.11/dist/vue.runtime.esm.js

--- a/cli/tests/fetch/other.ts
+++ b/cli/tests/fetch/other.ts
@@ -1,2 +1,1 @@
 import "https://www.unpkg.com/vue/dist/vue.runtime.esm.js";
-

--- a/cli/tests/fetch/other.ts
+++ b/cli/tests/fetch/other.ts
@@ -1,1 +1,1 @@
-import "https://www.unpkg.com/vue/dist/vue.runtime.esm.js";
+import "http://localhost:4545/cli/tests/subdir/mt_text_typescript.t1.ts";

--- a/cli/tests/fetch/other.ts
+++ b/cli/tests/fetch/other.ts
@@ -1,0 +1,2 @@
+import "https://www.unpkg.com/vue/dist/vue.runtime.esm.js";
+

--- a/cli/tests/fetch/test.ts
+++ b/cli/tests/fetch/test.ts
@@ -1,2 +1,1 @@
 import "https://unpkg.com/leaflet/dist/leaflet-src.esm.js";
-

--- a/cli/tests/fetch/test.ts
+++ b/cli/tests/fetch/test.ts
@@ -1,1 +1,1 @@
-import "https://unpkg.com/leaflet/dist/leaflet-src.esm.js";
+import "http://localhost:4545/cli/tests/subdir/mod2.ts";

--- a/cli/tests/fetch/test.ts
+++ b/cli/tests/fetch/test.ts
@@ -1,0 +1,2 @@
+import "https://unpkg.com/leaflet/dist/leaflet-src.esm.js";
+

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -323,6 +323,7 @@ itest!(_036_import_map_fetch {
 itest!(_037_fetch_multiple {
   args: "fetch --reload fetch/test.ts fetch/other.ts",
   check_stderr: true,
+  http_server: true,
   output: "037_fetch_multiple.out",
 });
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -322,6 +322,7 @@ itest!(_036_import_map_fetch {
 
 itest!(_037_fetch_multiple {
   args: "fetch --reload fetch/test.ts fetch/other.ts",
+  check_stderr: true,
   output: "037_fetch_multiple.out",
 });
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -320,6 +320,11 @@ itest!(_036_import_map_fetch {
   output: "036_import_map_fetch.out",
 });
 
+itest!(_037_fetch_multiple {
+  args: "fetch --reload fetch/test.ts fetch/other.ts",
+  output: "037_fetch_multiple.out",
+});
+
 itest!(_038_checkjs {
   // checking if JS file is run through TS compiler
   args: "run --reload --config 038_checkjs.tsconfig.json 038_checkjs.js",


### PR DESCRIPTION
Hello!
I've tried addressing #3149 since it seemed like nobody else was working on it.
This PR adds basic support for multiple files (and globs expanded by shell), but doesn't address `"**.ts"` case (which as far as I understood from discussion wasn't needed)
My first time using Rust, so please let me know if there's anything I could've done better.
