### PR TITLE
feat: signal takes multiple arguments

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -101,7 +101,7 @@ export {
 } from "./process.ts";
 export { transpileOnly, compile, bundle } from "./compiler_api.ts";
 export { inspect } from "./console.ts";
-export { signal, signals, SignalStream } from "./signals.ts";
+export { signal, signals, Signals } from "./signals.ts";
 export { build, OperatingSystem, Arch } from "./build.ts";
 export { version } from "./version.ts";
 export const args: string[] = [];

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -2127,21 +2127,10 @@ declare namespace Deno {
    */
   export const args: string[];
 
-  /** UNSTABLE new API.
-   *
-   * SignalStream represents the stream of signals, implements both
-   * AsyncIterator and PromiseLike
-   */
-  export class SignalStream implements AsyncIterator<void>, PromiseLike<void> {
-    constructor(signal: typeof Deno.Signal);
-    then<T, S>(
-      f: (v: void) => T | Promise<T>,
-      g?: (v: void) => S | Promise<S>
-    ): Promise<T | S>;
-    next(): Promise<IteratorResult<void>>;
-    [Symbol.asyncIterator](): AsyncIterator<void>;
-    dispose(): void;
-  }
+  export type Signals = AsyncIterableIterator<void> &
+    PromiseLike<void> & {
+      dispose: () => void;
+    };
 
   /** UNSTABLE new API.
    *
@@ -2169,43 +2158,43 @@ declare namespace Deno {
    *
    * The above for-await loop exits after 5 seconds when sig.dispose() is called.
    */
-  export function signal(signo: number): SignalStream;
+  export function signal(...signos: [number, ...number[]]): Signals;
 
   /** UNSTABLE new API. */
   export const signals: {
     /** Returns the stream of SIGALRM signals.
      * This method is the shorthand for Deno.signal(Deno.Signal.SIGALRM). */
-    alarm: () => SignalStream;
+    alarm: () => Signals;
     /** Returns the stream of SIGCHLD signals.
      * This method is the shorthand for Deno.signal(Deno.Signal.SIGCHLD). */
-    child: () => SignalStream;
+    child: () => Signals;
     /** Returns the stream of SIGHUP signals.
      * This method is the shorthand for Deno.signal(Deno.Signal.SIGHUP). */
-    hungup: () => SignalStream;
+    hungup: () => Signals;
     /** Returns the stream of SIGINT signals.
      * This method is the shorthand for Deno.signal(Deno.Signal.SIGINT). */
-    interrupt: () => SignalStream;
+    interrupt: () => Signals;
     /** Returns the stream of SIGIO signals.
      * This method is the shorthand for Deno.signal(Deno.Signal.SIGIO). */
-    io: () => SignalStream;
+    io: () => Signals;
     /** Returns the stream of SIGPIPE signals.
      * This method is the shorthand for Deno.signal(Deno.Signal.SIGPIPE). */
-    pipe: () => SignalStream;
+    pipe: () => Signals;
     /** Returns the stream of SIGQUIT signals.
      * This method is the shorthand for Deno.signal(Deno.Signal.SIGQUIT). */
-    quit: () => SignalStream;
+    quit: () => Signals;
     /** Returns the stream of SIGTERM signals.
      * This method is the shorthand for Deno.signal(Deno.Signal.SIGTERM). */
-    terminate: () => SignalStream;
+    terminate: () => Signals;
     /** Returns the stream of SIGUSR1 signals.
      * This method is the shorthand for Deno.signal(Deno.Signal.SIGUSR1). */
-    userDefined1: () => SignalStream;
+    userDefined1: () => Signals;
     /** Returns the stream of SIGUSR2 signals.
      * This method is the shorthand for Deno.signal(Deno.Signal.SIGUSR2). */
-    userDefined2: () => SignalStream;
+    userDefined2: () => Signals;
     /** Returns the stream of SIGWINCH signals.
      * This method is the shorthand for Deno.signal(Deno.Signal.SIGWINCH). */
-    windowChange: () => SignalStream;
+    windowChange: () => Signals;
   };
 
   /** UNSTABLE: new API. Maybe move EOF here.

--- a/cli/js/mux_async_iterator.ts
+++ b/cli/js/mux_async_iterator.ts
@@ -1,0 +1,63 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+/** Returns an async iterator which merges the given async iterators. */
+export function mux<T>(
+  ...iters: Array<AsyncIterator<T>>
+): AsyncIterableIterator<T> & PromiseLike<T> {
+  return new MuxAsyncIterator<T>(iters);
+}
+
+class MuxAsyncIterator<T> implements AsyncIterableIterator<T>, PromiseLike<T> {
+  private nexts: Array<Promise<IteratorResult<T>>>;
+  constructor(private iters: Array<AsyncIterator<T>>) {
+    this.nexts = this.iters.map(iter => iter.next());
+  }
+
+  async next(): Promise<IteratorResult<T>> {
+    while (this.iters.length > 0) {
+      const { next } = await Promise.race(
+        this.nexts.map(async next => {
+          await next;
+          return { next };
+        })
+      );
+      const i = this.nexts.indexOf(next);
+      const res = await next;
+
+      if (res.done) {
+        this.nexts.splice(i, 1);
+        this.iters.splice(i, 1);
+        continue;
+      }
+
+      if (!res.done) {
+        this.nexts.splice(i, 1, this.iters[i].next());
+        return { done: false, value: res.value };
+      }
+    }
+
+    return { done: true, value: undefined };
+  }
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<T> {
+    return this;
+  }
+
+  async then<S, P>(
+    f: (t: T) => S | Promise<S>,
+    g?: (e: Error) => P | Promise<P>
+  ): Promise<S | P> {
+    const { done, value } = await this.next();
+    if (!done) {
+      return f(value);
+    }
+
+    const e = new Error("All async iterators have already been finished.");
+
+    if (g) {
+      return g(e);
+    }
+
+    throw e;
+  }
+}

--- a/cli/js/mux_async_iterator_test.ts
+++ b/cli/js/mux_async_iterator_test.ts
@@ -1,0 +1,64 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { test, assertEquals, assertThrowsAsync } from "./test_util.ts";
+import { mux } from "./mux_async_iterator.ts";
+
+function defer(n: number): Promise<void> {
+  return new Promise((resolve, _) => setTimeout(resolve, n));
+}
+
+async function* foo(): AsyncIteratbleIterator<number> {
+  await defer(10);
+  yield 10;
+  await defer(30);
+  yield 40;
+  await defer(30);
+  yield 70;
+}
+
+async function* bar(): AsyncIterableIterator<number> {
+  await defer(20);
+  yield 20;
+  await defer(30);
+  yield 50;
+  await defer(30);
+  yield 80;
+}
+
+async function* baz(): AsyncIterableIterator<number> {
+  await defer(30);
+  yield 30;
+  await defer(30);
+  yield 60;
+  await defer(30);
+  yield 90;
+}
+
+test("mux returns an async iterator that merges the given async iterators.", async () => {
+  const iter = mux(foo(), bar(), baz());
+  assertEquals(await iter.next(), { done: false, value: 10 });
+  assertEquals(await iter.next(), { done: false, value: 20 });
+  assertEquals(await iter.next(), { done: false, value: 30 });
+  assertEquals(await iter.next(), { done: false, value: 40 });
+  assertEquals(await iter.next(), { done: false, value: 50 });
+  assertEquals(await iter.next(), { done: false, value: 60 });
+  assertEquals(await iter.next(), { done: false, value: 70 });
+  assertEquals(await iter.next(), { done: false, value: 80 });
+  assertEquals(await iter.next(), { done: false, value: 90 });
+  assertEquals(await iter.next(), { done: true, value: undefined });
+});
+
+test("mux returns an promise which resolves with the first item from the merged async iterators.", async () => {
+  const iter = mux(foo(), bar(), baz());
+  assertEquals(await iter, 10);
+  assertEquals(await iter, 20);
+  assertEquals(await iter, 30);
+  assertEquals(await iter, 40);
+  assertEquals(await iter, 50);
+  assertEquals(await iter, 60);
+  assertEquals(await iter, 70);
+  assertEquals(await iter, 80);
+  assertEquals(await iter, 90);
+  assertThrowsAsync(async () => {
+    await iter;
+  });
+});

--- a/cli/js/signals.ts
+++ b/cli/js/signals.ts
@@ -112,7 +112,7 @@ export const signals = {
   }
 };
 
-/** Signals represents the stream of signals, implements both
+/** SignalStream represents the stream of signals, implements both
  * AsyncIterator and PromiseLike */
 class SignalStream implements AsyncIterator<void>, PromiseLike<void> {
   private rid: number;

--- a/cli/js/test_util.ts
+++ b/cli/js/test_util.ts
@@ -11,14 +11,15 @@ import * as testing from "../../std/testing/mod.ts";
 import { assert, assertEquals } from "../../std/testing/asserts.ts";
 export {
   assert,
-  assertThrows,
   assertEquals,
   assertMatch,
   assertNotEquals,
   assertStrictEq,
   assertStrContains,
-  unreachable,
+  assertThrows,
+  assertThrowsAsync,
   fail
+  unreachable
 } from "../../std/testing/asserts.ts";
 
 interface TestPermissions {

--- a/cli/js/test_util.ts
+++ b/cli/js/test_util.ts
@@ -18,7 +18,7 @@ export {
   assertStrContains,
   assertThrows,
   assertThrowsAsync,
-  fail
+  fail,
   unreachable
 } from "../../std/testing/asserts.ts";
 

--- a/tools/hyper_hello/hyper_hello.rs
+++ b/tools/hyper_hello/hyper_hello.rs
@@ -28,8 +28,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // `service_fn` is a helper to convert a function that
     // returns a Response into a `Service`.
     async {
-      Just::Ok(service_fn(|_req| {
-        async { Just::Ok(Response::new(Body::from(&b"Hello World!"[..]))) }
+      Just::Ok(service_fn(|_req| async {
+        Just::Ok(Response::new(Body::from(&b"Hello World!"[..])))
       }))
     }
   });

--- a/tools/hyper_hello/hyper_hello.rs
+++ b/tools/hyper_hello/hyper_hello.rs
@@ -28,8 +28,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // `service_fn` is a helper to convert a function that
     // returns a Response into a `Service`.
     async {
-      Just::Ok(service_fn(|_req| async {
-        Just::Ok(Response::new(Body::from(&b"Hello World!"[..])))
+      Just::Ok(service_fn(|_req| {
+        async { Just::Ok(Response::new(Body::from(&b"Hello World!"[..]))) }
       }))
     }
   });


### PR DESCRIPTION
This PR adds multiple arguments support of Deno.signal (This closes #3773).

- I added `mux` utility which takes multiple async iterators and returns a multiplexer of them.
- I removed `SignalStream` from Deno namespace, instead added `type Signals = AsyncIterableIterator<void> & PromiseLike<void> & { dispose: () => void; }` as a returned type of `signal` function.

cc @axetroy @kevinkassimo 