### PR TITLE
Start of enhancements/reliability fixes to Deno.Process

### DIFF
--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -278,6 +278,7 @@ export interface ReadAllResponse {
  */
 export async function readAll(
   r: Reader,
+  //eslint-disable-next-line @typescript-eslint/no-unused-vars
   options: ReadAllOption = {}
 ): Promise<ReadAllResponse> {
   const buf = new Buffer();
@@ -289,6 +290,7 @@ export async function readAll(
  */
 export function readAllSync(
   r: SyncReader,
+  //eslint-disable-next-line @typescript-eslint/no-unused-vars
   options: ReadAllOption = {}
 ): ReadAllResponse {
   const buf = new Buffer();

--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -278,9 +278,9 @@ export interface ReadAllResponse {
  */
 export async function readAll(
   r: Reader,
-  //eslint-disable-next-line @typescript-eslint/no-unused-vars
-  options: ReadAllOption = {}
+  options?: ReadAllOption
 ): Promise<ReadAllResponse> {
+  if (!options) options = {};
   const buf = new Buffer();
   await buf.readFrom(r);
   return { content: buf.bytes() };
@@ -290,9 +290,9 @@ export async function readAll(
  */
 export function readAllSync(
   r: SyncReader,
-  //eslint-disable-next-line @typescript-eslint/no-unused-vars
-  options: ReadAllOption = {}
+  options?: ReadAllOption
 ): ReadAllResponse {
+  if (!options) options = {};
   const buf = new Buffer();
   buf.readFromSync(r);
   return { content: buf.bytes() };

--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -263,20 +263,37 @@ export class Buffer implements Reader, SyncReader, Writer, SyncWriter {
   }
 }
 
-/** Read `r` until EOF and return the content as `Uint8Array`.
- */
-export async function readAll(r: Reader): Promise<Uint8Array> {
-  const buf = new Buffer();
-  await buf.readFrom(r);
-  return buf.bytes();
+export interface ReadAllOption {
+  maxBytes?: number;
 }
 
-/** Read synchronously `r` until EOF and return the content as `Uint8Array`.
+export interface ReadAllResponse {
+  content: Uint8Array;
+  closed?: boolean;
+  truncated?: boolean;
+  aborted?: boolean;
+}
+
+/** Read `r` until EOF and return the content as `ReadAllResponse`.
  */
-export function readAllSync(r: SyncReader): Uint8Array {
+export async function readAll(
+  r: Reader,
+  options: ReadAllOption = {}
+): Promise<ReadAllResponse> {
+  const buf = new Buffer();
+  await buf.readFrom(r);
+  return { content: buf.bytes() };
+}
+
+/** Read synchronously `r` until EOF and return the content as `ReadAllResponse`.
+ */
+export function readAllSync(
+  r: SyncReader,
+  options: ReadAllOption = {}
+): ReadAllResponse {
   const buf = new Buffer();
   buf.readFromSync(r);
-  return buf.bytes();
+  return { content: buf.bytes() };
 }
 
 /** Write all the content of `arr` to `w`.

--- a/cli/js/buffer_test.ts
+++ b/cli/js/buffer_test.ts
@@ -237,7 +237,7 @@ test(async function bufferTestGrow(): Promise<void> {
 test(async function testReadAll(): Promise<void> {
   init();
   const reader = new Buffer(testBytes.buffer as ArrayBuffer);
-  const actualBytes = await readAll(reader);
+  const actualBytes = (await readAll(reader)).content;
   assertEquals(testBytes.byteLength, actualBytes.byteLength);
   for (let i = 0; i < testBytes.length; ++i) {
     assertEquals(testBytes[i], actualBytes[i]);
@@ -247,7 +247,7 @@ test(async function testReadAll(): Promise<void> {
 test(function testReadAllSync(): void {
   init();
   const reader = new Buffer(testBytes.buffer as ArrayBuffer);
-  const actualBytes = readAllSync(reader);
+  const actualBytes = readAllSync(reader).content;
   assertEquals(testBytes.byteLength, actualBytes.byteLength);
   for (let i = 0; i < testBytes.length; ++i) {
     assertEquals(testBytes[i], actualBytes[i]);

--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -43,6 +43,8 @@ export {
 } from "./io.ts";
 export {
   Buffer,
+  ReadAllOption,
+  ReadAllResponse,
   readAll,
   readAllSync,
   writeAll,

--- a/cli/js/fetch.ts
+++ b/cli/js/fetch.ts
@@ -48,7 +48,8 @@ class Body implements domTypes.Body, domTypes.ReadableStream, io.ReadCloser {
     assert(this._bodyPromise == null);
     const buf = new Buffer();
     try {
-      const nread = await buf.readFrom(this);
+      let nread = await buf.readFrom(this);
+      nread = nread < 0 ? -nread - 1 : nread;
       const ui8 = buf.bytes();
       assert(ui8.byteLength === nread);
       this._data = ui8.buffer.slice(

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -579,8 +579,10 @@ declare namespace Deno {
      */
     grow(n: number): void;
     /** readFrom() reads data from r until EOF and appends it to the buffer,
-     * growing the buffer as needed. It returns the number of bytes read. If the
-     * buffer becomes too large, readFrom will panic with ErrTooLarge.
+     * growing the buffer as needed. It returns the number of bytes read.
+     * If reader disappears before EOF is reached (including if it was never
+     * available), returns the two's complement of the number of bytes read.
+     * If the buffer becomes too large, readFrom will panic with ErrTooLarge.
      * Based on https://golang.org/pkg/bytes/#Buffer.ReadFrom
      */
     readFrom(r: Reader): Promise<number>;

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -591,11 +591,28 @@ declare namespace Deno {
     readFromSync(r: SyncReader): number;
   }
 
-  /** Read `r` until EOF and return the content as `Uint8Array` */
-  export function readAll(r: Reader): Promise<Uint8Array>;
+  export interface ReadAllOption {
+    maxBytes?: number;
+  }
 
-  /** Read synchronously `r` until EOF and return the content as `Uint8Array`  */
-  export function readAllSync(r: SyncReader): Uint8Array;
+  export interface ReadAllResponse {
+    content: Uint8Array;
+    closed?: boolean;
+    truncated?: boolean;
+    aborted?: boolean;
+  }
+
+  /** Read `r` until EOF and return the content as `ReadAllResponse` */
+  export function readAll(
+    r: Reader,
+    options: ReadAllOption = {}
+  ): Promise<ReadAllResponse>;
+
+  /** Read synchronously `r` until EOF and return the content as `ReadAllResponse`  */
+  export function readAllSync(
+    r: SyncReader,
+    options: ReadAllOption = {}
+  ): ReadAllResponse;
 
   /** Write all the content of `arr` to `w` */
   export function writeAll(w: Writer, arr: Uint8Array): Promise<void>;

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -605,13 +605,13 @@ declare namespace Deno {
   /** Read `r` until EOF and return the content as `ReadAllResponse` */
   export function readAll(
     r: Reader,
-    options: ReadAllOption
+    options?: ReadAllOption
   ): Promise<ReadAllResponse>;
 
   /** Read synchronously `r` until EOF and return the content as `ReadAllResponse`  */
   export function readAllSync(
     r: SyncReader,
-    options: ReadAllOption
+    options?: ReadAllOption
   ): ReadAllResponse;
 
   /** Write all the content of `arr` to `w` */

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -605,13 +605,13 @@ declare namespace Deno {
   /** Read `r` until EOF and return the content as `ReadAllResponse` */
   export function readAll(
     r: Reader,
-    options: ReadAllOption = {}
+    options: ReadAllOption
   ): Promise<ReadAllResponse>;
 
   /** Read synchronously `r` until EOF and return the content as `ReadAllResponse`  */
   export function readAllSync(
     r: SyncReader,
-    options: ReadAllOption = {}
+    options: ReadAllOption
   ): ReadAllResponse;
 
   /** Write all the content of `arr` to `w` */

--- a/cli/js/process.ts
+++ b/cli/js/process.ts
@@ -98,7 +98,8 @@ export class Process {
       throw new Error("Process.output: stdout is undefined");
     }
     try {
-      return await readAll(this.stdout);
+      const output = await readAll(this.stdout);
+      return output.content;
     } finally {
       this.stdout.close();
     }
@@ -113,7 +114,8 @@ export class Process {
       throw new Error("Process.stderrOutput: stderr is undefined");
     }
     try {
-      return await readAll(this.stderr);
+      const output = await readAll(this.stderr);
+      return output.content;
     } finally {
       this.stderr.close();
     }

--- a/cli/js/read_file.ts
+++ b/cli/js/read_file.ts
@@ -10,9 +10,9 @@ import { readAll, readAllSync } from "./buffer.ts";
  */
 export function readFileSync(filename: string): Uint8Array {
   const file = openSync(filename);
-  const contents = readAllSync(file);
+  const output = readAllSync(file);
   file.close();
-  return contents;
+  return output.content;
 }
 
 /** Read the entire contents of a file.
@@ -23,7 +23,7 @@ export function readFileSync(filename: string): Uint8Array {
  */
 export async function readFile(filename: string): Promise<Uint8Array> {
   const file = await open(filename);
-  const contents = await readAll(file);
+  const output = await readAll(file);
   file.close();
-  return contents;
+  return output.content;
 }

--- a/std/examples/catj.ts
+++ b/std/examples/catj.ts
@@ -94,8 +94,8 @@ if (parsedArgs.h || parsedArgs.help || parsedArgs._.length === 0) {
 }
 
 if (parsedArgs._[0] === "-") {
-  const contents = await Deno.readAll(Deno.stdin);
-  const json = JSON.parse(decoder.decode(contents));
+  const output = await Deno.readAll(Deno.stdin);
+  const json = JSON.parse(decoder.decode(output.content));
   print(json);
 } else {
   for (const fileName of parsedArgs._) {

--- a/std/fs/empty_dir_test.ts
+++ b/std/fs/empty_dir_test.ts
@@ -228,7 +228,7 @@ test(async function emptyDirPermission(): Promise<void> {
 
       const output = await Deno.readAll(stdout);
 
-      assertStrContains(new TextDecoder().decode(output), s.output);
+      assertStrContains(new TextDecoder().decode(output.content), s.output);
     }
   } catch (err) {
     await Deno.remove(testfolder, { recursive: true });

--- a/std/fs/exists_test.ts
+++ b/std/fs/exists_test.ts
@@ -134,7 +134,7 @@ test(async function existsPermission(): Promise<void> {
 
     const output = await Deno.readAll(stdout);
 
-    assertStrContains(new TextDecoder().decode(output), s.output);
+    assertStrContains(new TextDecoder().decode(output.content), s.output);
   }
 
   // done

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -144,7 +144,7 @@ test(async function requestBodyWithContentLength(): Promise<void> {
     req.headers.set("content-length", "5");
     const buf = new Buffer(enc.encode("Hello"));
     req.r = new BufReader(buf);
-    const body = dec.decode(await Deno.readAll(req.body));
+    const body = dec.decode((await Deno.readAll(req.body)).content);
     assertEquals(body, "Hello");
   }
 
@@ -156,7 +156,7 @@ test(async function requestBodyWithContentLength(): Promise<void> {
     req.headers.set("Content-Length", "5000");
     const buf = new Buffer(enc.encode(longText));
     req.r = new BufReader(buf);
-    const body = dec.decode(await Deno.readAll(req.body));
+    const body = dec.decode((await Deno.readAll(req.body)).content);
     assertEquals(body, longText);
   }
 });
@@ -181,7 +181,7 @@ test(async function requestBodyWithTransferEncoding(): Promise<void> {
     chunksData += "0\r\n\r\n";
     const buf = new Buffer(enc.encode(chunksData));
     req.r = new BufReader(buf);
-    const body = dec.decode(await Deno.readAll(req.body));
+    const body = dec.decode((await Deno.readAll(req.body)).content);
     assertEquals(body, shortText);
   }
 
@@ -205,7 +205,7 @@ test(async function requestBodyWithTransferEncoding(): Promise<void> {
     chunksData += "0\r\n\r\n";
     const buf = new Buffer(enc.encode(chunksData));
     req.r = new BufReader(buf);
-    const body = dec.decode(await Deno.readAll(req.body));
+    const body = dec.decode((await Deno.readAll(req.body)).content);
     assertEquals(body, longText);
   }
 });


### PR DESCRIPTION
I'm trying to prepare a pull request containing some fixes and enhancements to the Process class (which involves also enhancements to Buffer.readFrom and readAll, see issue #3743 for some context).

At a very early stage in these changes, **the continuous integration tests fail**, for reasons where I don't get enough context to figure out what's going wrong. (Sadly, I'm not currently set up with a machine that's capable of building deno and running the tests itself... I've got an older version of OS X and Xcode that fail when linking rusty_v8. So I have to rely on the github reports to see what breaks.)

The commits I'm interested in are on this pull request, which only diverges from upstream by four commits. The first passes the CI tests, the last three (as a group) fail. (Later commits I'm working on don't seem to introduce any new issues; I've traced the failures back to these early changes.)

Here are the failure reports:

<https://github.com/dubiousjim/deno/runs/421828422?check_suite_focus=true>

<https://pipelines.actions.githubusercontent.com/JimU2Qe2Qgz8Twdqvx5RT0zEp2Um5JpsibiBZZPlnn448KmutQ/_apis/pipelines/1/runs/17/signedlogcontent/6?urlExpires=2020-02-02T15%3A30%3A48.3432600Z&urlSigningMethod=HMACV1&urlSignature=HyR77PpO8ER92PCPkrngA19uuPS1tXOsLaF6Jr%2BlQ6I%3D>

If anyone can help me figure out what I'm doing wrong, I'd appreciate it... and then would be better placed to get these fixes and enhanements submitted properly.