### PR TITLE
Fix: Validate all tests included in unit_tests.ts

### DIFF
--- a/cli/js/dispatch_minimal_test.ts
+++ b/cli/js/dispatch_minimal_test.ts
@@ -9,14 +9,14 @@ import {
 const readErrorStackPattern = new RegExp(
   `^.*
     at unwrapResponse \\(.*dispatch_minimal\\.ts:.*\\)
-    at Object.sendAsync \\(.*dispatch_minimal\\.ts:.*\\)
-    at async Object\\.open \\(.*files\\.ts:.*\\).*$`,
+    at Object.sendAsyncMinimal \\(.*dispatch_minimal\\.ts:.*\\)
+    at async Object\\.read \\(.*files\\.ts:.*\\).*$`,
   "ms"
 );
 
 test(async function sendAsyncStackTrace(): Promise<void> {
   const buf = new Uint8Array(10);
-  await Deno.read(999999999999999, buf)
+  await Deno.read(10, buf)
     .then(unreachable)
     .catch((error): void => {
       assertMatch(error.stack, readErrorStackPattern);

--- a/cli/js/dispatch_minimal_test.ts
+++ b/cli/js/dispatch_minimal_test.ts
@@ -16,7 +16,7 @@ const readErrorStackPattern = new RegExp(
 
 test(async function sendAsyncStackTrace(): Promise<void> {
   const buf = new Uint8Array(10);
-  await Deno.read(10, "nonexistent.txt", buf)
+  await Deno.read(-1, buf)
     .then(unreachable)
     .catch((error): void => {
       assertMatch(error.stack, readErrorStackPattern);

--- a/cli/js/dispatch_minimal_test.ts
+++ b/cli/js/dispatch_minimal_test.ts
@@ -16,7 +16,7 @@ const readErrorStackPattern = new RegExp(
 
 test(async function sendAsyncStackTrace(): Promise<void> {
   const buf = new Uint8Array(10);
-  await Deno.read(-1, buf)
+  await Deno.read(999999999999999, buf)
     .then(unreachable)
     .catch((error): void => {
       assertMatch(error.stack, readErrorStackPattern);

--- a/cli/js/dispatch_minimal_test.ts
+++ b/cli/js/dispatch_minimal_test.ts
@@ -16,15 +16,19 @@ const readErrorStackPattern = new RegExp(
 
 test(async function sendAsyncStackTrace(): Promise<void> {
   const buf = new Uint8Array(10);
-  await Deno.read(10, buf)
-    .then(unreachable)
-    .catch((error): void => {
-      assertMatch(error.stack, readErrorStackPattern);
-    });
+  try {
+    await Deno.read(10, buf);
+    unreachable();
+  } catch (error) {
+    assertMatch(error.stack, readErrorStackPattern);
+  }
 });
+
 test(async function malformedMinimalControlBuffer(): Promise<void> {
   // @ts-ignore
-  const res = Deno.core.send(1, new Uint8Array([1, 2, 3, 4, 5]));
+  const readOpId = Deno.core.ops()["read"];
+  // @ts-ignore
+  const res = Deno.core.send(readOpId, new Uint8Array([1, 2, 3, 4, 5]));
   const header = res.slice(0, 12);
   const buf32 = new Int32Array(
     header.buffer,
@@ -33,7 +37,7 @@ test(async function malformedMinimalControlBuffer(): Promise<void> {
   );
   const arg = buf32[1];
   const result = buf32[2];
-  const message = new TextDecoder().decode(res.slice(12));
+  const message = new TextDecoder().decode(res.slice(12)).trim();
   assert(arg < 0);
   assertEquals(result, Deno.ErrorKind.InvalidInput);
   assertEquals(message, "Unparsable control buffer");

--- a/cli/js/test_util.ts
+++ b/cli/js/test_util.ts
@@ -303,7 +303,7 @@ testPerm({ read: true }, async function parsingUnitTestOutput(): Promise<void> {
  */
 testPerm(
   { read: true },
-  async function assertAllUnitTestFilesPresentInUnitTestsFile(): Promise<void> {
+  async function assertAllUnitTestFilesImported(): Promise<void> {
     const directoryTestFiles = Deno.readDirSync("./cli/js")
       .map(k => k.name)
       .filter(file => file.endsWith("_test.ts"));

--- a/cli/js/test_util.ts
+++ b/cli/js/test_util.ts
@@ -296,3 +296,20 @@ testPerm({ read: true }, async function parsingUnitTestOutput(): Promise<void> {
   assertEquals(result.actual, undefined);
   assertEquals(result.expected, undefined);
 });
+  
+/* 
+ * Ensure all unit test files (e.g. xxx_test.ts) are present as imports in 
+ * cli/js/unit_tests.ts as it is easy to miss this out
+ */
+testPerm({ read: true }, async function assertAllUnitTestFilesPresentInUnitTestsFile(): Promise<void> {
+  const directoryTestFiles = Deno.readDirSync("./cli/js").map(k => k.name).filter(file => file.endsWith("_test.ts"));
+  const unitTestsFile: Uint8Array = Deno.readFileSync("./cli/js/unit_tests.ts");
+  const importLines = new TextDecoder("utf-8").decode(unitTestsFile).split("\n").filter(line => (line.startsWith("import") && line.includes("_test.ts")));
+  const importedTestFiles = importLines.map(relativeFilePath => relativeFilePath.match(/\/([^\/]+)";/)[1]);
+  
+  directoryTestFiles.forEach(dirFile => {
+    if (!importedTestFiles.includes(dirFile)) {
+      throw new Error("cil/js/unit_tests.ts is missing import of test file: cli/js/" + dirFile);
+    }
+  });
+});

--- a/cli/js/test_util.ts
+++ b/cli/js/test_util.ts
@@ -296,20 +296,35 @@ testPerm({ read: true }, async function parsingUnitTestOutput(): Promise<void> {
   assertEquals(result.actual, undefined);
   assertEquals(result.expected, undefined);
 });
-  
-/* 
- * Ensure all unit test files (e.g. xxx_test.ts) are present as imports in 
+
+/*
+ * Ensure all unit test files (e.g. xxx_test.ts) are present as imports in
  * cli/js/unit_tests.ts as it is easy to miss this out
  */
-testPerm({ read: true }, async function assertAllUnitTestFilesPresentInUnitTestsFile(): Promise<void> {
-  const directoryTestFiles = Deno.readDirSync("./cli/js").map(k => k.name).filter(file => file.endsWith("_test.ts"));
-  const unitTestsFile: Uint8Array = Deno.readFileSync("./cli/js/unit_tests.ts");
-  const importLines = new TextDecoder("utf-8").decode(unitTestsFile).split("\n").filter(line => (line.startsWith("import") && line.includes("_test.ts")));
-  const importedTestFiles = importLines.map(relativeFilePath => relativeFilePath.match(/\/([^\/]+)";/)[1]);
-  
-  directoryTestFiles.forEach(dirFile => {
-    if (!importedTestFiles.includes(dirFile)) {
-      throw new Error("cil/js/unit_tests.ts is missing import of test file: cli/js/" + dirFile);
-    }
-  });
-});
+testPerm(
+  { read: true },
+  async function assertAllUnitTestFilesPresentInUnitTestsFile(): Promise<void> {
+    const directoryTestFiles = Deno.readDirSync("./cli/js")
+      .map(k => k.name)
+      .filter(file => file.endsWith("_test.ts"));
+    const unitTestsFile: Uint8Array = Deno.readFileSync(
+      "./cli/js/unit_tests.ts"
+    );
+    const importLines = new TextDecoder("utf-8")
+      .decode(unitTestsFile)
+      .split("\n")
+      .filter(line => line.startsWith("import") && line.includes("_test.ts"));
+    const importedTestFiles = importLines.map(
+      relativeFilePath => relativeFilePath.match(/\/([^\/]+)";/)[1]
+    );
+
+    directoryTestFiles.forEach(dirFile => {
+      if (!importedTestFiles.includes(dirFile)) {
+        throw new Error(
+          "cil/js/unit_tests.ts is missing import of test file: cli/js/" +
+            dirFile
+        );
+      }
+    });
+  }
+);

--- a/cli/js/unit_tests.ts
+++ b/cli/js/unit_tests.ts
@@ -14,6 +14,7 @@ import "./console_test.ts";
 import "./copy_file_test.ts";
 import "./custom_event_test.ts";
 import "./dir_test.ts";
+import "./dispatch_minimal_test.ts";
 import "./dispatch_json_test.ts";
 import "./error_stack_test.ts";
 import "./event_test.ts";


### PR DESCRIPTION
A comment in #3860 inspired this attempt at improving unit test robustness:

> Our list of tests in cli/js/unit_tests.ts is rather error prone. We should figure out a better way to do this.

While far from perfect, this should at least highlight when unit tests are missing from the imports in unit_tests.ts. 

Discovered while building this that dispatch_minimal_test.ts was not being run.