### PR TITLE
std/http/server::serve aligned to std/http/server::serveTLS

### DIFF
--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -468,11 +468,6 @@ export class Server implements AsyncIterable<ServerRequest> {
   }
 }
 
-interface ServerConfig {
-  port: number;
-  hostname?: string;
-}
-
 /**
  * Start a HTTP server
  *
@@ -483,7 +478,7 @@ interface ServerConfig {
  *       req.respond({ body });
  *     }
  */
-export function serve(addr: string | ServerConfig): Server {
+export function serve(addr: string | Deno.ListenOptions): Server {
   if (typeof addr === "string") {
     const [hostname, port] = addr.split(":");
     addr = { hostname, port: Number(port) };
@@ -494,7 +489,7 @@ export function serve(addr: string | ServerConfig): Server {
 }
 
 export async function listenAndServe(
-  addr: string | ServerConfig,
+  addr: string | Deno.ListenOptions,
   handler: (req: ServerRequest) => void
 ): Promise<void> {
   const server = serve(addr);

--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -468,6 +468,9 @@ export class Server implements AsyncIterable<ServerRequest> {
   }
 }
 
+/** Options for creating an HTTP server. */
+export type HTTPOptions = Omit<Deno.ListenOptions, "transport">;
+
 /**
  * Start a HTTP server
  *
@@ -478,7 +481,7 @@ export class Server implements AsyncIterable<ServerRequest> {
  *       req.respond({ body });
  *     }
  */
-export function serve(addr: string | Deno.ListenOptions): Server {
+export function serve(addr: string | HTTPOptions): Server {
   if (typeof addr === "string") {
     const [hostname, port] = addr.split(":");
     addr = { hostname, port: Number(port) };
@@ -489,7 +492,7 @@ export function serve(addr: string | Deno.ListenOptions): Server {
 }
 
 export async function listenAndServe(
-  addr: string | Deno.ListenOptions,
+  addr: string | HTTPOptions,
   handler: (req: ServerRequest) => void
 ): Promise<void> {
   const server = serve(addr);


### PR DESCRIPTION
Previously, `std/http::serve()` previously create a new interface which it didn't export that was the same as `Deno.ListenOptions`.  It is better that it just use the built in interface.
