### PR TITLE
refactor: CLI subcommands and argv

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -241,8 +241,10 @@ impl TsCompiler {
   /// runtime.
   fn setup_worker(global_state: ThreadSafeGlobalState) -> CompilerWorker {
     let (int, ext) = ThreadSafeState::create_channels();
+    let main_module =
+      ModuleSpecifier::resolve_url_or_path("./__$deno$ts_compiler.ts").unwrap();
     let worker_state =
-      ThreadSafeState::new(global_state.clone(), None, None, int)
+      ThreadSafeState::new(global_state.clone(), None, main_module, int)
         .expect("Unable to create worker state");
 
     // Count how many times we start the compiler worker.

--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -241,10 +241,10 @@ impl TsCompiler {
   /// runtime.
   fn setup_worker(global_state: ThreadSafeGlobalState) -> CompilerWorker {
     let (int, ext) = ThreadSafeState::create_channels();
-    let main_module =
+    let entry_point =
       ModuleSpecifier::resolve_url_or_path("./__$deno$ts_compiler.ts").unwrap();
     let worker_state =
-      ThreadSafeState::new(global_state.clone(), None, main_module, int)
+      ThreadSafeState::new(global_state.clone(), None, entry_point, int)
         .expect("Unable to create worker state");
 
     // Count how many times we start the compiler worker.

--- a/cli/compilers/wasm.rs
+++ b/cli/compilers/wasm.rs
@@ -7,6 +7,7 @@ use crate::global_state::ThreadSafeGlobalState;
 use crate::startup_data;
 use crate::state::*;
 use deno_core::ErrBox;
+use deno_core::ModuleSpecifier;
 use futures::FutureExt;
 use serde_derive::Deserialize;
 use serde_json;
@@ -45,8 +46,11 @@ impl WasmCompiler {
   /// Create a new V8 worker with snapshot of WASM compiler and setup compiler's runtime.
   fn setup_worker(global_state: ThreadSafeGlobalState) -> CompilerWorker {
     let (int, ext) = ThreadSafeState::create_channels();
+    let main_module =
+      ModuleSpecifier::resolve_url_or_path("./__$deno$wasm_compiler.ts")
+        .unwrap();
     let worker_state =
-      ThreadSafeState::new(global_state.clone(), None, None, int)
+      ThreadSafeState::new(global_state.clone(), None, main_module, int)
         .expect("Unable to create worker state");
 
     // Count how many times we start the compiler worker.

--- a/cli/compilers/wasm.rs
+++ b/cli/compilers/wasm.rs
@@ -46,11 +46,11 @@ impl WasmCompiler {
   /// Create a new V8 worker with snapshot of WASM compiler and setup compiler's runtime.
   fn setup_worker(global_state: ThreadSafeGlobalState) -> CompilerWorker {
     let (int, ext) = ThreadSafeState::create_channels();
-    let main_module =
+    let entry_point =
       ModuleSpecifier::resolve_url_or_path("./__$deno$wasm_compiler.ts")
         .unwrap();
     let worker_state =
-      ThreadSafeState::new(global_state.clone(), None, main_module, int)
+      ThreadSafeState::new(global_state.clone(), None, entry_point, int)
         .expect("Unable to create worker state");
 
     // Count how many times we start the compiler worker.

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -347,7 +347,6 @@ fn bundle_parse(flags: &mut DenoFlags, matches: &clap::ArgMatches) {
   let source_file = matches.value_of("source_file").unwrap().to_string();
 
   let out_file = if let Some(out_file) = matches.value_of("out_file") {
-    // TODO(bartlomieju): this permission should not be necessary
     flags.allow_write = true;
     Some(out_file.to_string())
   } else {
@@ -1927,7 +1926,7 @@ mod tests {
       flags_from_vec_safe(svec!["deno""script.ts", "foo", "bar"]);
     assert_eq!(flags, DenoFlags::default());
     assert_eq!(subcommand, DenoSubcommand::Run);
-    assert_eq!(argv, svec!["script.ts", "foo", "bar"]);
+  assert_eq!(argv, svec!["script.ts", "foo", "bar"]);
 
     let (flags, subcommand, argv) =
       flags_from_vec_safe(svec!["deno""script.ts", "-"]);

--- a/cli/js/runtime.ts
+++ b/cli/js/runtime.ts
@@ -13,7 +13,7 @@ import { setPrepareStackTrace } from "./error_stack.ts";
 interface Start {
   cwd: string;
   pid: number;
-  argv: string[];
+  args: string[];
   location: string; // Absolute URL.
   repl: boolean;
   debugFlag: boolean;

--- a/cli/js/runtime.ts
+++ b/cli/js/runtime.ts
@@ -14,7 +14,8 @@ interface Start {
   cwd: string;
   pid: number;
   argv: string[];
-  mainModule: string; // Absolute URL.
+  location: string; // Absolute URL.
+  repl: boolean;
   debugFlag: boolean;
   depsFlag: boolean;
   typesFlag: boolean;
@@ -57,10 +58,8 @@ export function start(preserveDenoNamespace = true, source?: string): Start {
   util.setLogDebug(s.debugFlag, source);
 
   // TODO(bartlomieju): this field should always be set
-  if (s.mainModule) {
-    assert(s.mainModule.length > 0);
-    setLocation(s.mainModule);
-  }
+  assert(s.location.length > 0);
+  setLocation(s.location);
   setPrepareStackTrace(Error);
 
   // TODO(bartlomieju): I don't like that it's mixed in here, when

--- a/cli/js/runtime_main.ts
+++ b/cli/js/runtime_main.ts
@@ -78,8 +78,7 @@ export function bootstrapMainRuntime(): void {
   log("args", args);
   Object.freeze(args);
 
-  // TODO(bartlomieju): rename to s.repl
-  if (!s.mainModule) {
+  if (s.repl) {
     replLoop();
   }
 }

--- a/cli/js/runtime_main.ts
+++ b/cli/js/runtime_main.ts
@@ -72,8 +72,8 @@ export function bootstrapMainRuntime(): void {
   setSignals();
 
   log("cwd", s.cwd);
-  for (let i = 0; i < s.argv.length; i++) {
-    args.push(s.argv[i]);
+  for (let i = 0; i < s.args.length; i++) {
+    args.push(s.args[i]);
   }
   log("args", args);
   Object.freeze(args);

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -464,7 +464,9 @@ pub fn main() {
         source_file,
         out_file,
       } => bundle_command(flags, source_file, out_file).await,
-      DenoSubcommand::Completions => {}
+      DenoSubcommand::Completions { buf } => {
+        print!("{}", std::str::from_utf8(&buf).unwrap());
+      }
       DenoSubcommand::Eval => eval_command(flags).await,
       DenoSubcommand::Fetch => fetch_command(flags).await,
       DenoSubcommand::Format { check, files } => {

--- a/cli/ops/runtime.rs
+++ b/cli/ops/runtime.rs
@@ -37,7 +37,7 @@ fn op_start(
     "cwd": deno_fs::normalize_path(&env::current_dir().unwrap()),
     "pid": std::process::id(),
     "argv": script_args,
-    "mainModule": gs.main_module.as_ref().map(|x| x.to_string()),
+    "location": state.main_module.to_string(),
     "debugFlag": gs.flags.log_level.map_or(false, |l| l == log::Level::Debug),
     "versionFlag": gs.flags.version,
     "v8Version": version::v8(),

--- a/cli/ops/runtime.rs
+++ b/cli/ops/runtime.rs
@@ -28,15 +28,11 @@ fn op_start(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, ErrBox> {
   let gs = &state.global_state;
-  let script_args = if gs.flags.argv.len() >= 2 {
-    gs.flags.argv.clone().split_off(2)
-  } else {
-    vec![]
-  };
+
   Ok(JsonOp::Sync(json!({
     "cwd": deno_fs::normalize_path(&env::current_dir().unwrap()),
     "pid": std::process::id(),
-    "argv": script_args,
+    "args": gs.flags.argv.clone(),
     "location": state.main_module.to_string(),
     "debugFlag": gs.flags.log_level.map_or(false, |l| l == log::Level::Debug),
     "versionFlag": gs.flags.version,

--- a/cli/ops/runtime.rs
+++ b/cli/ops/runtime.rs
@@ -5,6 +5,7 @@ use crate::fs as deno_fs;
 use crate::ops::json_op;
 use crate::state::ThreadSafeState;
 use crate::version;
+use crate::DenoSubcommand;
 use deno_core::*;
 use std::env;
 
@@ -33,6 +34,7 @@ fn op_start(
     "cwd": deno_fs::normalize_path(&env::current_dir().unwrap()),
     "pid": std::process::id(),
     "args": gs.flags.argv.clone(),
+    "repl": gs.flags.subcommand == DenoSubcommand::Repl,
     "location": state.main_module.to_string(),
     "debugFlag": gs.flags.log_level.map_or(false, |l| l == log::Level::Debug),
     "versionFlag": gs.flags.version,

--- a/cli/ops/worker_host.rs
+++ b/cli/ops/worker_host.rs
@@ -88,22 +88,20 @@ fn op_create_worker(
     }
     let mut module_specifier = result.unwrap();
     if !has_source_code {
-      if let Some(referrer) = parent_state.main_module.as_ref() {
-        let referrer = referrer.clone().to_string();
-        let result = ModuleSpecifier::resolve_import(&specifier, &referrer);
-        if let Err(err) = result {
-          load_sender.send(Err(err.into())).unwrap();
-          return;
-        }
-        module_specifier = result.unwrap();
+      let referrer = parent_state.main_module.to_string();
+      let result = ModuleSpecifier::resolve_import(&specifier, &referrer);
+      if let Err(err) = result {
+        load_sender.send(Err(err.into())).unwrap();
+        return;
       }
+      module_specifier = result.unwrap();
     }
 
     let (int, ext) = ThreadSafeState::create_channels();
     let result = ThreadSafeState::new_for_worker(
       parent_state.global_state.clone(),
       Some(parent_state.permissions.clone()), // by default share with parent
-      Some(module_specifier.clone()),
+      module_specifier.clone(),
       int,
     );
     if let Err(err) = result {

--- a/cli/ops/worker_host.rs
+++ b/cli/ops/worker_host.rs
@@ -86,16 +86,18 @@ fn op_create_worker(
       load_sender.send(Err(err.into())).unwrap();
       return;
     }
-    let mut module_specifier = result.unwrap();
-    if !has_source_code {
+
+    let module_specifier = if !has_source_code {
       let referrer = parent_state.main_module.to_string();
       let result = ModuleSpecifier::resolve_import(&specifier, &referrer);
       if let Err(err) = result {
         load_sender.send(Err(err.into())).unwrap();
         return;
       }
-      module_specifier = result.unwrap();
-    }
+      result.unwrap()
+    } else {
+      result.unwrap()
+    };
 
     let (int, ext) = ThreadSafeState::create_channels();
     let result = ThreadSafeState::new_for_worker(

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -389,19 +389,13 @@ impl ThreadSafeState {
 
   #[cfg(test)]
   pub fn mock(
-    argv: Vec<String>,
+    main_module: &str,
     internal_channels: WorkerChannels,
   ) -> ThreadSafeState {
-    let module_specifier = if argv.is_empty() {
-      None
-    } else {
-      let module_specifier = ModuleSpecifier::resolve_url_or_path(&argv[0])
-        .expect("Invalid entry module");
-      Some(module_specifier)
-    };
-
+    let module_specifier = ModuleSpecifier::resolve_url_or_path(main_module)
+      .expect("Invalid entry module");
     ThreadSafeState::new(
-      ThreadSafeGlobalState::mock(argv),
+      ThreadSafeGlobalState::mock(vec!["deno".to_string()]),
       None,
       module_specifier,
       internal_channels,
@@ -438,8 +432,5 @@ impl ThreadSafeState {
 fn thread_safe() {
   fn f<S: Send + Sync>(_: S) {}
   let (int, _) = ThreadSafeState::create_channels();
-  f(ThreadSafeState::mock(
-    vec![String::from("./deno"), String::from("hello.js")],
-    int,
-  ));
+  f(ThreadSafeState::mock("./hello.js", int));
 }

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -47,7 +47,7 @@ pub struct ThreadSafeState(Arc<State>);
 pub struct State {
   pub global_state: ThreadSafeGlobalState,
   pub permissions: Arc<Mutex<DenoPermissions>>,
-  pub main_module: Option<ModuleSpecifier>,
+  pub main_module: ModuleSpecifier,
   // TODO(ry) rename to worker_channels_internal
   pub worker_channels: WorkerChannels,
   /// When flags contains a `.import_map_path` option, the content of the
@@ -240,7 +240,7 @@ impl ThreadSafeState {
   pub fn new(
     global_state: ThreadSafeGlobalState,
     shared_permissions: Option<Arc<Mutex<DenoPermissions>>>,
-    main_module: Option<ModuleSpecifier>,
+    main_module: ModuleSpecifier,
     internal_channels: WorkerChannels,
   ) -> Result<Self, ErrBox> {
     let import_map: Option<ImportMap> =
@@ -285,7 +285,7 @@ impl ThreadSafeState {
   pub fn new_for_worker(
     global_state: ThreadSafeGlobalState,
     shared_permissions: Option<Arc<Mutex<DenoPermissions>>>,
-    main_module: Option<ModuleSpecifier>,
+    main_module: ModuleSpecifier,
     internal_channels: WorkerChannels,
   ) -> Result<Self, ErrBox> {
     let seeded_rng = match global_state.flags.seed {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -796,7 +796,7 @@ itest!(run_v8_flags {
 });
 
 itest!(run_v8_help {
-  args: "run --v8-flags=--help",
+  args: "--v8-flags=--help",
   output: "v8_help.out",
 });
 

--- a/cli/web_worker.rs
+++ b/cli/web_worker.rs
@@ -77,10 +77,7 @@ mod tests {
 
   fn create_test_worker() -> WebWorker {
     let (int, ext) = ThreadSafeState::create_channels();
-    let state = ThreadSafeState::mock(
-      vec![String::from("./deno"), String::from("hello.js")],
-      int,
-    );
+    let state = ThreadSafeState::mock("./hello.js", int);
     let mut worker = WebWorker::new(
       "TEST".to_string(),
       startup_data::deno_isolate_init(),

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -303,8 +303,13 @@ mod tests {
       .join("cli/tests/006_url_imports.ts");
     let module_specifier =
       ModuleSpecifier::resolve_url_or_path(&p.to_string_lossy()).unwrap();
-    let mut flags = flags::DenoFlags::default();
-    flags.reload = true;
+    let flags = flags::DenoFlags {
+      subcommand: flags::DenoSubcommand::Run {
+        script: module_specifier.to_string(),
+      },
+      reload: true,
+      ..flags::DenoFlags::default()
+    };
     let global_state =
       ThreadSafeGlobalState::new(flags, Progress::new()).unwrap();
     let (int, ext) = ThreadSafeState::create_channels();

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -230,14 +230,9 @@ mod tests {
       .join("cli/tests/esm_imports_a.js");
     let module_specifier =
       ModuleSpecifier::resolve_url_or_path(&p.to_string_lossy()).unwrap();
-    let global_state = ThreadSafeGlobalState::new(
-      flags::DenoFlags {
-        argv: vec![String::from("./deno"), module_specifier.to_string()],
-        ..flags::DenoFlags::default()
-      },
-      Progress::new(),
-    )
-    .unwrap();
+    let global_state =
+      ThreadSafeGlobalState::new(flags::DenoFlags::default(), Progress::new())
+        .unwrap();
     let (int, ext) = ThreadSafeState::create_channels();
     let state =
       ThreadSafeState::new(global_state, None, module_specifier.clone(), int)
@@ -271,14 +266,9 @@ mod tests {
       .join("tests/circular1.ts");
     let module_specifier =
       ModuleSpecifier::resolve_url_or_path(&p.to_string_lossy()).unwrap();
-    let global_state = ThreadSafeGlobalState::new(
-      flags::DenoFlags {
-        argv: vec![String::from("deno"), module_specifier.to_string()],
-        ..flags::DenoFlags::default()
-      },
-      Progress::new(),
-    )
-    .unwrap();
+    let global_state =
+      ThreadSafeGlobalState::new(flags::DenoFlags::default(), Progress::new())
+        .unwrap();
     let (int, ext) = ThreadSafeState::create_channels();
     let state =
       ThreadSafeState::new(global_state, None, module_specifier.clone(), int)
@@ -314,7 +304,6 @@ mod tests {
     let module_specifier =
       ModuleSpecifier::resolve_url_or_path(&p.to_string_lossy()).unwrap();
     let mut flags = flags::DenoFlags::default();
-    flags.argv = vec![String::from("deno"), module_specifier.to_string()];
     flags.reload = true;
     let global_state =
       ThreadSafeGlobalState::new(flags, Progress::new()).unwrap();

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -239,13 +239,9 @@ mod tests {
     )
     .unwrap();
     let (int, ext) = ThreadSafeState::create_channels();
-    let state = ThreadSafeState::new(
-      global_state,
-      None,
-      Some(module_specifier.clone()),
-      int,
-    )
-    .unwrap();
+    let state =
+      ThreadSafeState::new(global_state, None, module_specifier.clone(), int)
+        .unwrap();
     let state_ = state.clone();
     tokio_util::run_basic(async move {
       let mut worker =
@@ -284,13 +280,9 @@ mod tests {
     )
     .unwrap();
     let (int, ext) = ThreadSafeState::create_channels();
-    let state = ThreadSafeState::new(
-      global_state,
-      None,
-      Some(module_specifier.clone()),
-      int,
-    )
-    .unwrap();
+    let state =
+      ThreadSafeState::new(global_state, None, module_specifier.clone(), int)
+        .unwrap();
     let state_ = state.clone();
     tokio_util::run_basic(async move {
       let mut worker =
@@ -330,7 +322,7 @@ mod tests {
     let state = ThreadSafeState::new(
       global_state.clone(),
       None,
-      Some(module_specifier.clone()),
+      module_specifier.clone(),
       int,
     )
     .unwrap();
@@ -361,10 +353,7 @@ mod tests {
 
   fn create_test_worker() -> MainWorker {
     let (int, ext) = ThreadSafeState::create_channels();
-    let state = ThreadSafeState::mock(
-      vec![String::from("./deno"), String::from("hello.js")],
-      int,
-    );
+    let state = ThreadSafeState::mock("./hello.js", int);
     let mut worker = MainWorker::new(
       "TEST".to_string(),
       startup_data::deno_isolate_init(),


### PR DESCRIPTION
Main goal of this refactor is to eliminate `main_module: Option<String>` fields and replace them with `main_module: String`. As a side effect it allows to eliminate lot of code in tests and cleanup `flags.argv` to not contain "deno" everytime...