### PR TITLE
Rename ThreadSafeGlobalState to just GlobalState

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -680,6 +680,7 @@ pub fn runtime_transpile_async<S: BuildHasher>(
 mod tests {
   use super::*;
   use crate::fs as deno_fs;
+  use crate::global_state::GlobalState;
   use deno_core::ModuleSpecifier;
   use std::path::PathBuf;
   use tempfile::TempDir;
@@ -703,7 +704,7 @@ mod tests {
       GlobalState::mock(vec![String::from("deno"), String::from("hello.js")]);
     let result = mock_state
       .ts_compiler
-      .compile_async(mock_state.clone(), &out, TargetLib::Main)
+      .compile_async(&out, TargetLib::Main)
       .await;
     assert!(result.is_ok());
     assert!(result
@@ -732,11 +733,7 @@ mod tests {
 
     let result = state
       .ts_compiler
-      .bundle_async(
-        state.clone(),
-        module_name,
-        Some(String::from("$deno$/bundle.js")),
-      )
+      .bundle_async(module_name, Some(String::from("$deno$/bundle.js")))
       .await;
     assert!(result.is_ok());
   }

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -113,6 +113,7 @@ impl GlobalState {
     }));
 
     let mut g = GLOBAL_STATE.lock().unwrap();
+    #[cfg(not(test))]
     assert!(g.is_none()); // Only one global state should ever be created.
     *g = Some(global_state.clone());
 

--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -128,11 +128,7 @@ fn op_fetch_source_files(
         // This allows TS to do correct export types.
         let source_code = match file.media_type {
           msg::MediaType::Wasm => {
-            global_state
-              .wasm_compiler
-              .compile_async(global_state.clone(), &file)
-              .await?
-              .code
+            global_state.wasm_compiler.compile_async(&file).await?.code
           }
           _ => String::from_utf8(file.source_code).unwrap(),
         };

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -22,13 +22,12 @@ struct CompileArgs {
 }
 
 fn op_compile(
-  state: &ThreadSafeState,
+  _state: &ThreadSafeState,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, ErrBox> {
   let args: CompileArgs = serde_json::from_value(args)?;
   Ok(JsonOp::Async(runtime_compile_async(
-    state.global_state.clone(),
     &args.root_name,
     &args.sources,
     args.bundle,
@@ -43,13 +42,12 @@ struct TranspileArgs {
 }
 
 fn op_transpile(
-  state: &ThreadSafeState,
+  _state: &ThreadSafeState,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, ErrBox> {
   let args: TranspileArgs = serde_json::from_value(args)?;
   Ok(JsonOp::Async(runtime_transpile_async(
-    state.global_state.clone(),
     &args.sources,
     &args.options,
   )))

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::compilers::TargetLib;
 use crate::deno_error::permission_denied;
-use crate::global_state::ThreadSafeGlobalState;
+use crate::global_state::GlobalState;
 use crate::global_timer::GlobalTimer;
 use crate::import_map::ImportMap;
 use crate::metrics::Metrics;
@@ -45,7 +45,7 @@ pub struct ThreadSafeState(Arc<State>);
 
 #[cfg_attr(feature = "cargo-clippy", allow(stutter))]
 pub struct State {
-  pub global_state: ThreadSafeGlobalState,
+  pub global_state: GlobalState,
   pub permissions: Arc<Mutex<DenoPermissions>>,
   pub main_module: ModuleSpecifier,
   /// When flags contains a `.import_map_path` option, the content of the
@@ -223,7 +223,7 @@ impl Loader for ThreadSafeState {
 impl ThreadSafeState {
   /// If `shared_permission` is None then permissions from globa state are used.
   pub fn new(
-    global_state: ThreadSafeGlobalState,
+    global_state: GlobalState,
     shared_permissions: Option<Arc<Mutex<DenoPermissions>>>,
     main_module: ModuleSpecifier,
   ) -> Result<Self, ErrBox> {
@@ -267,7 +267,7 @@ impl ThreadSafeState {
 
   /// If `shared_permission` is None then permissions from globa state are used.
   pub fn new_for_worker(
-    global_state: ThreadSafeGlobalState,
+    global_state: GlobalState,
     shared_permissions: Option<Arc<Mutex<DenoPermissions>>>,
     main_module: ModuleSpecifier,
   ) -> Result<Self, ErrBox> {
@@ -375,7 +375,7 @@ impl ThreadSafeState {
     let module_specifier = ModuleSpecifier::resolve_url_or_path(main_module)
       .expect("Invalid entry module");
     ThreadSafeState::new(
-      ThreadSafeGlobalState::mock(vec!["deno".to_string()]),
+      GlobalState::mock(vec!["deno".to_string()]),
       None,
       module_specifier,
     )

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -280,8 +280,7 @@ mod tests {
     let module_specifier =
       ModuleSpecifier::resolve_url_or_path(&p.to_string_lossy()).unwrap();
     let global_state =
-      GlobalState::new(flags::DenoFlags::default(), Progress::new())
-        .unwrap();
+      GlobalState::new(flags::DenoFlags::default(), Progress::new()).unwrap();
     let state =
       ThreadSafeState::new(global_state, None, module_specifier.clone())
         .unwrap();
@@ -315,8 +314,7 @@ mod tests {
     let module_specifier =
       ModuleSpecifier::resolve_url_or_path(&p.to_string_lossy()).unwrap();
     let global_state =
-      GlobalState::new(flags::DenoFlags::default(), Progress::new())
-        .unwrap();
+      GlobalState::new(flags::DenoFlags::default(), Progress::new()).unwrap();
     let state =
       ThreadSafeState::new(global_state, None, module_specifier.clone())
         .unwrap();
@@ -357,8 +355,7 @@ mod tests {
       reload: true,
       ..flags::DenoFlags::default()
     };
-    let global_state =
-      GlobalState::new(flags, Progress::new()).unwrap();
+    let global_state = GlobalState::new(flags, Progress::new()).unwrap();
     let state = ThreadSafeState::new(
       global_state.clone(),
       None,

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -255,7 +255,7 @@ impl DerefMut for MainWorker {
 mod tests {
   use super::*;
   use crate::flags;
-  use crate::global_state::ThreadSafeGlobalState;
+  use crate::global_state::GlobalState;
   use crate::progress::Progress;
   use crate::startup_data;
   use crate::state::ThreadSafeState;
@@ -280,7 +280,7 @@ mod tests {
     let module_specifier =
       ModuleSpecifier::resolve_url_or_path(&p.to_string_lossy()).unwrap();
     let global_state =
-      ThreadSafeGlobalState::new(flags::DenoFlags::default(), Progress::new())
+      GlobalState::new(flags::DenoFlags::default(), Progress::new())
         .unwrap();
     let state =
       ThreadSafeState::new(global_state, None, module_specifier.clone())
@@ -315,7 +315,7 @@ mod tests {
     let module_specifier =
       ModuleSpecifier::resolve_url_or_path(&p.to_string_lossy()).unwrap();
     let global_state =
-      ThreadSafeGlobalState::new(flags::DenoFlags::default(), Progress::new())
+      GlobalState::new(flags::DenoFlags::default(), Progress::new())
         .unwrap();
     let state =
       ThreadSafeState::new(global_state, None, module_specifier.clone())
@@ -358,7 +358,7 @@ mod tests {
       ..flags::DenoFlags::default()
     };
     let global_state =
-      ThreadSafeGlobalState::new(flags, Progress::new()).unwrap();
+      GlobalState::new(flags, Progress::new()).unwrap();
     let state = ThreadSafeState::new(
       global_state.clone(),
       None,


### PR DESCRIPTION
And add crate::global_state::get() which allows the global state to be    accessed from anywhere without having to pass it around.