### PR TITLE
fix(cli/flags.rs): Prevent providing --allow-env flag twice

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -155,10 +155,6 @@ impl DenoFlags {
       args.push("--allow-hrtime".to_string());
     }
 
-    if self.allow_env {
-      args.push("--allow-env".to_string());
-    }
-
     args
   }
 }


### PR DESCRIPTION
````rust
  if self.allow_env {
      args.push("--allow-env".to_string());
    }
````

was duplicated in cli/flag.rs

Duplication causes the problem when `deno install --allow-env`

````
error: The argument '--allow-env' was provided more than once, but cannot be used multiple times

USAGE:
    deno run --allow-env --allow-net=<allow-net> --allow-read=<allow-read>

For more information try --help
````
