### PR TITLE
Improve support for diagnostics from runtime compiler APIs

### DIFF
--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -255,7 +255,9 @@ async function tsCompilerOnMessage({
 
       assert(emitResult.emitSkipped === false, "Unexpected skip of the emit.");
       const result = [
-        diagnostics.length ? fromTypeScriptDiagnostic(diagnostics) : undefined,
+        diagnostics.length
+          ? fromTypeScriptDiagnostic(diagnostics).items
+          : undefined,
         bundle ? state.emitBundle : state.emitMap
       ];
       globalThis.postMessage(result);

--- a/cli/js/compiler_api.ts
+++ b/cli/js/compiler_api.ts
@@ -3,7 +3,7 @@
 // This file contains the runtime APIs which will dispatch work to the internal
 // compiler within Deno.
 
-import { Diagnostic } from "./diagnostics.ts";
+import { DiagnosticItem } from "./diagnostics.ts";
 import * as dispatch from "./dispatch.ts";
 import { sendAsync } from "./dispatch_json.ts";
 import * as util from "./util.ts";
@@ -328,7 +328,7 @@ export function compile(
   rootName: string,
   sources?: Record<string, string>,
   options?: CompilerOptions
-): Promise<[Diagnostic | undefined, Record<string, string>]> {
+): Promise<[DiagnosticItem[] | undefined, Record<string, string>]> {
   const payload = {
     rootName: sources ? rootName : checkRelative(rootName),
     sources,
@@ -377,7 +377,7 @@ export function bundle(
   rootName: string,
   sources?: Record<string, string>,
   options?: CompilerOptions
-): Promise<[Diagnostic | undefined, string]> {
+): Promise<[DiagnosticItem[] | undefined, string]> {
   const payload = {
     rootName: sources ? rootName : checkRelative(rootName),
     sources,

--- a/cli/js/compiler_api_test.ts
+++ b/cli/js/compiler_api_test.ts
@@ -105,7 +105,7 @@ test(async function bundleApiConfig() {
 });
 
 test(async function diagnosticsTest() {
-  const [diagnostics] = await compile("foo.ts", {
+  const [diagnostics] = await compile("/foo.ts", {
     "/foo.ts": `document.getElementById("foo");`
   });
   assert(Array.isArray(diagnostics));

--- a/cli/js/compiler_api_test.ts
+++ b/cli/js/compiler_api_test.ts
@@ -103,3 +103,11 @@ test(async function bundleApiConfig() {
   assert(diagnostics == null);
   assert(!actual.includes(`random`));
 });
+
+test(async function diagnosticsTest() {
+  const [diagnostics] = await compile("foo.ts", {
+    "/foo.ts": `document.getElementById("foo");`
+  });
+  assert(Array.isArray(diagnostics));
+  assert(diagnostics.length === 1);
+});

--- a/cli/js/compiler_sourcefile.ts
+++ b/cli/js/compiler_sourcefile.ts
@@ -44,7 +44,9 @@ function getExtension(fileName: string, mediaType: MediaType): ts.Extension {
       return ts.Extension.Js;
     case MediaType.Unknown:
     default:
-      throw TypeError("Cannot resolve extension.");
+      throw TypeError(
+        `Cannot resolve extension for "${fileName}" with mediaType "${MediaType[mediaType]}".`
+      );
   }
 }
 

--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -1,8 +1,29 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 // Public deno module.
-export { dir, env, exit, isTTY, execPath, hostname } from "./os.ts";
+export {
+  Buffer,
+  readAll,
+  readAllSync,
+  writeAll,
+  writeAllSync
+} from "./buffer.ts";
+export { build, OperatingSystem, Arch } from "./build.ts";
+export { chmodSync, chmod } from "./chmod.ts";
+export { chownSync, chown } from "./chown.ts";
+export { transpileOnly, compile, bundle } from "./compiler_api.ts";
+export { inspect } from "./console.ts";
+export { copyFileSync, copyFile } from "./copy_file.ts";
+export {
+  Diagnostic,
+  DiagnosticCategory,
+  DiagnosticItem,
+  DiagnosticMessageChain
+} from "./diagnostics.ts";
 export { chdir, cwd } from "./dir.ts";
+export { applySourceMap } from "./error_stack.ts";
+export { ErrorKind, DenoError } from "./errors.ts";
+export { FileInfo } from "./file_info.ts";
 export {
   File,
   open,
@@ -41,45 +62,14 @@ export {
   ReadWriteCloser,
   ReadWriteSeeker
 } from "./io.ts";
-export {
-  Buffer,
-  readAll,
-  readAllSync,
-  writeAll,
-  writeAllSync
-} from "./buffer.ts";
-export { mkdirSync, mkdir } from "./mkdir.ts";
+export { linkSync, link } from "./link.ts";
 export {
   makeTempDirSync,
   makeTempDir,
   MakeTempDirOptions
 } from "./make_temp_dir.ts";
-export { chmodSync, chmod } from "./chmod.ts";
-export { chownSync, chown } from "./chown.ts";
-export { utimeSync, utime } from "./utime.ts";
-export { removeSync, remove, RemoveOption } from "./remove.ts";
-export { renameSync, rename } from "./rename.ts";
-export { realpathSync, realpath } from "./realpath.ts";
-export { readFileSync, readFile } from "./read_file.ts";
-export { readDirSync, readDir } from "./read_dir.ts";
-export { copyFileSync, copyFile } from "./copy_file.ts";
-export { readlinkSync, readlink } from "./read_link.ts";
-export { statSync, lstatSync, stat, lstat } from "./stat.ts";
-export { linkSync, link } from "./link.ts";
-export { symlinkSync, symlink } from "./symlink.ts";
-export { writeFileSync, writeFile, WriteFileOptions } from "./write_file.ts";
-export { applySourceMap } from "./error_stack.ts";
-export { ErrorKind, DenoError } from "./errors.ts";
-export {
-  permissions,
-  PermissionName,
-  PermissionState,
-  PermissionStatus,
-  Permissions
-} from "./permissions.ts";
-export { truncateSync, truncate } from "./truncate.ts";
-export { FileInfo } from "./file_info.ts";
-export { openPlugin } from "./plugins.ts";
+export { metrics, Metrics } from "./metrics.ts";
+export { mkdirSync, mkdir } from "./mkdir.ts";
 export {
   connect,
   listen,
@@ -88,9 +78,15 @@ export {
   ShutdownMode,
   shutdown
 } from "./net.ts";
-export { connectTLS, listenTLS } from "./tls.ts";
-export { metrics, Metrics } from "./metrics.ts";
-export { resources } from "./resources.ts";
+export { dir, env, exit, isTTY, execPath, hostname } from "./os.ts";
+export {
+  permissions,
+  PermissionName,
+  PermissionState,
+  PermissionStatus,
+  Permissions
+} from "./permissions.ts";
+export { openPlugin } from "./plugins.ts";
 export {
   kill,
   run,
@@ -99,11 +95,21 @@ export {
   ProcessStatus,
   Signal
 } from "./process.ts";
-export { transpileOnly, compile, bundle } from "./compiler_api.ts";
-export { inspect } from "./console.ts";
+export { readDirSync, readDir } from "./read_dir.ts";
+export { readFileSync, readFile } from "./read_file.ts";
+export { readlinkSync, readlink } from "./read_link.ts";
+export { realpathSync, realpath } from "./realpath.ts";
+export { removeSync, remove, RemoveOption } from "./remove.ts";
+export { renameSync, rename } from "./rename.ts";
+export { resources } from "./resources.ts";
 export { signal, signals, SignalStream } from "./signals.ts";
-export { build, OperatingSystem, Arch } from "./build.ts";
+export { statSync, lstatSync, stat, lstat } from "./stat.ts";
+export { symlinkSync, symlink } from "./symlink.ts";
+export { connectTLS, listenTLS } from "./tls.ts";
+export { truncateSync, truncate } from "./truncate.ts";
+export { utimeSync, utime } from "./utime.ts";
 export { version } from "./version.ts";
+export { writeFileSync, writeFile, WriteFileOptions } from "./write_file.ts";
 export const args: string[] = [];
 
 // These are internal Deno APIs.  We are marking them as internal so they do not

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -2093,7 +2093,7 @@ declare namespace Deno {
     rootName: string,
     sources?: Record<string, string>,
     options?: CompilerOptions
-  ): Promise<[Diagnostic | undefined, Record<string, string>]>;
+  ): Promise<[DiagnosticItem[] | undefined, Record<string, string>]>;
 
   /** UNSTABLE: new API, yet to be vetted.
    *
@@ -2129,7 +2129,7 @@ declare namespace Deno {
     rootName: string,
     sources?: Record<string, string>,
     options?: CompilerOptions
-  ): Promise<[Diagnostic | undefined, string]>;
+  ): Promise<[DiagnosticItem[] | undefined, string]>;
 
   /** Returns the script arguments to the program. If for example we run a program
    *


### PR DESCRIPTION
This PR provides the following:

- Exports diagnostic items from `diagnostics.ts` which are missing at runtime.
- Returns an array of diagnostics, instead of an object with a property of `items`.  This is because of the way Rust deals with certain structures, and shouldn't be exposed in the APIs.
