### PR TITLE
fmt: `deno fmt -` formats stdin and print to stdout

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -48,6 +48,7 @@ pub enum DenoSubcommand {
   },
   Format {
     check: bool,
+    stdin: bool,
     files: Option<Vec<String>>,
   },
   Help,
@@ -303,9 +304,11 @@ fn fmt_parse(flags: &mut DenoFlags, matches: &clap::ArgMatches) {
   };
 
   let check = matches.is_present("check");
+  let stdin = matches.is_present("stdin");
 
   flags.subcommand = DenoSubcommand::Format {
     check,
+    stdin,
     files: maybe_files,
   }
 }
@@ -553,6 +556,12 @@ fn fmt_subcommand<'a, 'b>() -> App<'a, 'b> {
       Arg::with_name("check")
         .long("check")
         .help("Check if the source files are formatted.")
+        .takes_value(false),
+    )
+    .arg(
+      Arg::with_name("stdin")
+        .long("stdin")
+        .help("Read the code from stdin.")
         .takes_value(false),
     )
     .arg(
@@ -1364,6 +1373,7 @@ mod tests {
       DenoFlags {
         subcommand: DenoSubcommand::Format {
           check: false,
+          stdin: false,
           files: Some(svec!["script_1.ts", "script_2.ts"])
         },
         ..DenoFlags::default()
@@ -1376,6 +1386,20 @@ mod tests {
       DenoFlags {
         subcommand: DenoSubcommand::Format {
           check: true,
+          stdin: false,
+          files: None
+        },
+        ..DenoFlags::default()
+      }
+    );
+
+    let r = flags_from_vec_safe(svec!["deno", "fmt", "--stdin"]);
+    assert_eq!(
+      r.unwrap(),
+      DenoFlags {
+        subcommand: DenoSubcommand::Format {
+          check: false,
+          stdin: true,
           files: None
         },
         ..DenoFlags::default()

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -550,7 +550,9 @@ fn fmt_subcommand<'a, 'b>() -> App<'a, 'b> {
 
   deno fmt myfile1.ts myfile2.ts
 
-  deno fmt --check",
+  deno fmt --check
+
+  cat file.ts | deno fmt --stdin",
     )
     .arg(
       Arg::with_name("check")
@@ -561,7 +563,7 @@ fn fmt_subcommand<'a, 'b>() -> App<'a, 'b> {
     .arg(
       Arg::with_name("stdin")
         .long("stdin")
-        .help("Read the code from stdin.")
+        .help("Read from stdin and write formatted code to stdout.")
         .takes_value(false),
     )
     .arg(

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -48,7 +48,6 @@ pub enum DenoSubcommand {
   },
   Format {
     check: bool,
-    stdin: bool,
     files: Option<Vec<String>>,
   },
   Help,
@@ -304,11 +303,9 @@ fn fmt_parse(flags: &mut DenoFlags, matches: &clap::ArgMatches) {
   };
 
   let check = matches.is_present("check");
-  let stdin = matches.is_present("stdin");
 
   flags.subcommand = DenoSubcommand::Format {
     check,
-    stdin,
     files: maybe_files,
   }
 }
@@ -552,18 +549,13 @@ fn fmt_subcommand<'a, 'b>() -> App<'a, 'b> {
 
   deno fmt --check
 
-  cat file.ts | deno fmt --stdin",
+  # Format stdin and write to stdout
+  cat file.ts | deno fmt -",
     )
     .arg(
       Arg::with_name("check")
         .long("check")
         .help("Check if the source files are formatted.")
-        .takes_value(false),
-    )
-    .arg(
-      Arg::with_name("stdin")
-        .long("stdin")
-        .help("Read from stdin and write formatted code to stdout.")
         .takes_value(false),
     )
     .arg(
@@ -1375,7 +1367,6 @@ mod tests {
       DenoFlags {
         subcommand: DenoSubcommand::Format {
           check: false,
-          stdin: false,
           files: Some(svec!["script_1.ts", "script_2.ts"])
         },
         ..DenoFlags::default()
@@ -1388,20 +1379,18 @@ mod tests {
       DenoFlags {
         subcommand: DenoSubcommand::Format {
           check: true,
-          stdin: false,
           files: None
         },
         ..DenoFlags::default()
       }
     );
 
-    let r = flags_from_vec_safe(svec!["deno", "fmt", "--stdin"]);
+    let r = flags_from_vec_safe(svec!["deno", "fmt"]);
     assert_eq!(
       r.unwrap(),
       DenoFlags {
         subcommand: DenoSubcommand::Format {
           check: false,
-          stdin: true,
           files: None
         },
         ..DenoFlags::default()

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -184,7 +184,8 @@ pub fn format_stdin(check: bool) {
 
   match dprint::format_text("_stdin.ts", &source, &config) {
     Ok(None) => {
-      // Should not happen, but whatever.
+      // Should not happen
+      unreachable!();
     }
     Ok(Some(formatted_text)) => {
       if check {

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -403,11 +403,9 @@ async fn run_script(flags: DenoFlags, script: String) {
   js_check(worker.execute("window.dispatchEvent(new Event('unload'))"));
 }
 
-async fn fmt_command(files: Option<Vec<String>>, check: bool, stdin: bool) {
-  if stdin {
-    fmt::format_stdin(check);
-  } else {
-    fmt::format_files(files, check);
+async fn fmt_command(files: Option<Vec<String>>, check: bool) {
+  if let Err(err) = fmt::format_files(files, check) {
+    print_err_and_exit(err);
   }
 }
 
@@ -442,11 +440,9 @@ pub fn main() {
       }
       DenoSubcommand::Eval { code } => eval_command(flags, code).await,
       DenoSubcommand::Fetch { files } => fetch_command(flags, files).await,
-      DenoSubcommand::Format {
-        check,
-        stdin,
-        files,
-      } => fmt_command(files, check, stdin).await,
+      DenoSubcommand::Format { check, files } => {
+        fmt_command(files, check).await
+      }
       DenoSubcommand::Info { file } => info_command(flags, file).await,
       DenoSubcommand::Install {
         dir,

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -403,8 +403,12 @@ async fn run_script(flags: DenoFlags, script: String) {
   js_check(worker.execute("window.dispatchEvent(new Event('unload'))"));
 }
 
-async fn fmt_command(files: Option<Vec<String>>, check: bool) {
-  fmt::format_files(files, check);
+async fn fmt_command(files: Option<Vec<String>>, check: bool, stdin: bool) {
+  if stdin {
+    fmt::format_stdin(check);
+  } else {
+    fmt::format_files(files, check);
+  }
 }
 
 pub fn main() {
@@ -438,9 +442,11 @@ pub fn main() {
       }
       DenoSubcommand::Eval { code } => eval_command(flags, code).await,
       DenoSubcommand::Fetch { files } => fetch_command(flags, files).await,
-      DenoSubcommand::Format { check, files } => {
-        fmt_command(files, check).await
-      }
+      DenoSubcommand::Format {
+        check,
+        stdin,
+        files,
+      } => fmt_command(files, check, stdin).await,
       DenoSubcommand::Info { file } => info_command(flags, file).await,
       DenoSubcommand::Install {
         dir,

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -601,6 +601,24 @@ itest!(bundle {
   output: "bundle.test.out",
 });
 
+itest!(fmt_stdin {
+  args: "fmt --stdin",
+  input: Some("const a = 1\n"),
+  output_str: Some("const a = 1;\n"),
+});
+
+itest!(fmt_stdin_check_formatted {
+  args: "fmt --stdin --check",
+  input: Some("const a = 1;\n"),
+  output_str: Some(""),
+});
+
+itest!(fmt_stdin_check_not_formatted {
+  args: "fmt --stdin --check",
+  input: Some("const a = 1\n"),
+  output_str: Some("Not formatted stdin\n"),
+});
+
 itest!(circular1 {
   args: "run --reload circular1.js",
   output: "circular1.js.out",
@@ -915,6 +933,7 @@ mod util {
     pub args: &'static str,
     pub output: &'static str,
     pub input: Option<&'static str>,
+    pub output_str: Option<&'static str>,
     pub exit_code: i32,
     pub check_stderr: bool,
     pub http_server: bool,
@@ -980,10 +999,13 @@ mod util {
         );
       }
 
-      let output_path = tests_dir.join(self.output);
-      println!("output path {}", output_path.display());
-      let expected =
-        std::fs::read_to_string(output_path).expect("cannot read output");
+      let expected = if let Some(s) = self.output_str {
+        s.to_owned()
+      } else {
+        let output_path = tests_dir.join(self.output);
+        println!("output path {}", output_path.display());
+        std::fs::read_to_string(output_path).expect("cannot read output")
+      };
 
       if !wildcard_match(&expected, &actual) {
         println!("OUTPUT\n{}\nOUTPUT", actual);

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -602,19 +602,27 @@ itest!(bundle {
 });
 
 itest!(fmt_stdin {
-  args: "fmt --stdin",
+  args: "fmt -",
   input: Some("const a = 1\n"),
   output_str: Some("const a = 1;\n"),
 });
 
+itest!(fmt_stdin_ambiguous {
+  args: "fmt - file.ts",
+  input: Some("const a = 1\n"),
+  check_stderr: true,
+  exit_code: 1,
+  output_str: Some("Ambiguous filename input. To format stdin, provide a single '-' instead.\n"),
+});
+
 itest!(fmt_stdin_check_formatted {
-  args: "fmt --stdin --check",
+  args: "fmt --check -",
   input: Some("const a = 1;\n"),
   output_str: Some(""),
 });
 
 itest!(fmt_stdin_check_not_formatted {
-  args: "fmt --stdin --check",
+  args: "fmt --check -",
   input: Some("const a = 1\n"),
   output_str: Some("Not formatted stdin\n"),
 });


### PR DESCRIPTION
Closes #3877

~~Add `--stdin` flag (also compatible with `--check`) to format stdin input~~

`deno fmt -` now reads from stdin and prints output to stdout.
```
$ echo "const    a=1" | ./target/debug/deno fmt -
const a = 1;
```
