### PR TITLE
fix: shebangs

### DIFF
--- a/cli/js/unit_test_runner.ts
+++ b/cli/js/unit_test_runner.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S deno run --reload --allow-run
+#!/bin/sh
+":" //; exec /usr/bin/env deno run --reload --allow-run "$0" "$@"
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import "./unit_tests.ts";
 import {

--- a/cli/js/unit_test_runner.ts
+++ b/cli/js/unit_test_runner.ts
@@ -1,5 +1,6 @@
 #!/bin/sh
-":"; //; exec /usr/bin/env deno run --reload --allow-run "$0" "$@"
+":" //; exec /usr/bin/env deno run --reload --allow-run "$0" "$@"
+  .charAt(0);
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import "./unit_tests.ts";
 import {

--- a/cli/js/unit_test_runner.ts
+++ b/cli/js/unit_test_runner.ts
@@ -1,5 +1,5 @@
 #!/bin/sh
-":" //; exec /usr/bin/env deno run --reload --allow-run "$0" "$@"
+":"; //; exec /usr/bin/env deno run --reload --allow-run "$0" "$@"
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import "./unit_tests.ts";
 import {

--- a/std/examples/catj.ts
+++ b/std/examples/catj.ts
@@ -1,5 +1,5 @@
 #!/bin/sh
-":" //; exec /usr/bin/env deno run --allow-read "$0" "$@"
+":"; //; exec /usr/bin/env deno run --allow-read "$0" "$@"
 // Ported from: https://github.com/soheilpro/catj
 // Copyright (c) 2014 Soheil Rashidi
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.

--- a/std/examples/catj.ts
+++ b/std/examples/catj.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S deno --allow-read
+#!/bin/sh
+":" //; exec /usr/bin/env deno run --allow-read "$0" "$@"
 // Ported from: https://github.com/soheilpro/catj
 // Copyright (c) 2014 Soheil Rashidi
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.

--- a/std/examples/catj.ts
+++ b/std/examples/catj.ts
@@ -1,5 +1,6 @@
 #!/bin/sh
-":"; //; exec /usr/bin/env deno run --allow-read "$0" "$@"
+":" //; exec /usr/bin/env deno run --allow-read "$0" "$@"
+  .charAt(0);
 // Ported from: https://github.com/soheilpro/catj
 // Copyright (c) 2014 Soheil Rashidi
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.

--- a/std/examples/gist.ts
+++ b/std/examples/gist.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S deno --allow-net --allow-env
+#!/bin/sh
+":" //; exec /usr/bin/env deno run --allow-net --allow-env "$0" "$@"
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { parse } from "https://deno.land/std/flags/mod.ts";
 

--- a/std/examples/gist.ts
+++ b/std/examples/gist.ts
@@ -1,5 +1,5 @@
 #!/bin/sh
-":" //; exec /usr/bin/env deno run --allow-net --allow-env "$0" "$@"
+":"; //; exec /usr/bin/env deno run --allow-net --allow-env "$0" "$@"
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { parse } from "https://deno.land/std/flags/mod.ts";
 

--- a/std/examples/gist.ts
+++ b/std/examples/gist.ts
@@ -1,5 +1,6 @@
 #!/bin/sh
-":"; //; exec /usr/bin/env deno run --allow-net --allow-env "$0" "$@"
+":" //; exec /usr/bin/env deno run --allow-net --allow-env "$0" "$@"
+  .charAt(0);
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { parse } from "https://deno.land/std/flags/mod.ts";
 

--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S deno --allow-net
+#!/bin/sh
+":" //; exec /usr/bin/env deno run --allow-net "$0" "$@"
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 // This program serves files in the current directory over HTTP.

--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -1,5 +1,5 @@
 #!/bin/sh
-":" //; exec /usr/bin/env deno run --allow-net "$0" "$@"
+":"; //; exec /usr/bin/env deno run --allow-net "$0" "$@"
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 // This program serves files in the current directory over HTTP.

--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -1,5 +1,6 @@
 #!/bin/sh
-":"; //; exec /usr/bin/env deno run --allow-net "$0" "$@"
+":" //; exec /usr/bin/env deno run --allow-net "$0" "$@"
+  .charAt(0);
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 // This program serves files in the current directory over HTTP.

--- a/std/testing/runner.ts
+++ b/std/testing/runner.ts
@@ -1,5 +1,6 @@
 #!/bin/sh
-":"; //; exec /usr/bin/env deno run -A "$0" "$@"
+":" //; exec /usr/bin/env deno run -A "$0" "$@"
+  .charAt(0);
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { parse } from "../flags/mod.ts";
 import { ExpandGlobOptions, expandGlob } from "../fs/mod.ts";

--- a/std/testing/runner.ts
+++ b/std/testing/runner.ts
@@ -1,5 +1,5 @@
 #!/bin/sh
-":" //; exec /usr/bin/env deno run -A "$0" "$@"
+":"; //; exec /usr/bin/env deno run -A "$0" "$@"
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { parse } from "../flags/mod.ts";
 import { ExpandGlobOptions, expandGlob } from "../fs/mod.ts";

--- a/std/testing/runner.ts
+++ b/std/testing/runner.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S deno -A
+#!/bin/sh
+":" //; exec /usr/bin/env deno run -A "$0" "$@"
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { parse } from "../flags/mod.ts";
 import { ExpandGlobOptions, expandGlob } from "../fs/mod.ts";

--- a/std/uuid/test.ts
+++ b/std/uuid/test.ts
@@ -1,5 +1,5 @@
 #!/bin/sh
-":" //; exec /usr/bin/env deno run "$0" "$@"
+":"; //; exec /usr/bin/env deno run "$0" "$@"
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { runIfMain } from "../testing/mod.ts";
 

--- a/std/uuid/test.ts
+++ b/std/uuid/test.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S deno run
+#!/bin/sh
+":" //; exec /usr/bin/env deno run "$0" "$@"
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { runIfMain } from "../testing/mod.ts";
 

--- a/std/uuid/test.ts
+++ b/std/uuid/test.ts
@@ -1,5 +1,6 @@
 #!/bin/sh
-":"; //; exec /usr/bin/env deno run "$0" "$@"
+":" //; exec /usr/bin/env deno run "$0" "$@"
+  .charAt(0);
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { runIfMain } from "../testing/mod.ts";
 


### PR DESCRIPTION
The existing shebangs were not portable to Linux (which has no -S option).
This fix enables the shebangs to function in a more portable way.