### PR TITLE
[WIP] tty: Deno.stdin.setRaw()

### DIFF
--- a/cli/js/dispatch.ts
+++ b/cli/js/dispatch.ts
@@ -74,6 +74,7 @@ export let OP_TRANSPILE: number;
 export let OP_SIGNAL_BIND: number;
 export let OP_SIGNAL_UNBIND: number;
 export let OP_SIGNAL_POLL: number;
+export let OP_SET_RAW: number;
 
 /** **WARNING:** This is only available during the snapshotting process and is
  * unavailable at runtime. */

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -460,8 +460,16 @@ declare namespace Deno {
     seekSync(offset: number, whence: SeekMode): void;
     close(): void;
   }
-  /** An instance of `File` for stdin. */
-  export const stdin: File;
+  export type RestoreModeFunc = () => void;
+  /** Extended file abstraction with setRaw() */
+  export class Stdin extends File {
+    /** Set input mode to raw (non-canonical).
+     * Returns a function that when called, restores previous mode.
+     */
+    setRaw(): RestoreModeFunc;
+  }
+  /** An instance of `Stdin` for stdin. */
+  export const stdin: Stdin;
   /** An instance of `File` for stdout. */
   export const stdout: File;
   /** An instance of `File` for stderr. */

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -27,5 +27,6 @@ pub mod runtime_compiler;
 pub mod signal;
 pub mod timers;
 pub mod tls;
+pub mod tty;
 pub mod web_worker;
 pub mod worker_host;

--- a/cli/ops/tty.rs
+++ b/cli/ops/tty.rs
@@ -28,11 +28,11 @@ macro_rules! wincheck {
 // Create a similar one for our use.
 #[derive(Serialize, Deserialize)]
 struct SerializedTermios {
-  iflags: u64,
-  oflags: u64,
-  cflags: u64,
-  lflags: u64,
-  cc: [u8; libc::NCCS],
+  iflags: libc::tcflag_t,
+  oflags: libc::tcflag_t,
+  cflags: libc::tcflag_t,
+  lflags: libc::tcflag_t,
+  cc: [libc::cc_t; libc::NCCS],
 }
 
 impl From<termios::Termios> for SerializedTermios {
@@ -98,6 +98,7 @@ pub fn op_set_raw(
   #[cfg(windows)]
   {
     use std::os::windows::io::AsRawHandle;
+    use winapi::shared::minwindef::DWORD;
     use winapi::um::{consoleapi, handleapi, winbase, wincon, winuser};
 
     let handle = std::io::stdin().as_raw_handle();
@@ -106,7 +107,7 @@ pub fn op_set_raw(
     } else if handle.is_null() {
       return Err(other_error("null handle".to_owned()));
     }
-    let mut original_mode = 0;
+    let mut original_mode: DWORD = 0;
     let RAW_MODE_MASK =
       ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT;
     wincheck!(consoleapi::GetConsoleMode(handle, &mut original_mode));

--- a/cli/ops/tty.rs
+++ b/cli/ops/tty.rs
@@ -7,7 +7,9 @@ use crate::state::State;
 use deno_core::*;
 #[cfg(unix)]
 use nix::sys::termios;
-use serde_derive::{Deserialize, Serialize};
+use serde_derive::Deserialize;
+#[cfg(unix)]
+use serde_derive::Serialize;
 use serde_json::Value;
 
 pub fn init(i: &mut Isolate, s: &State) {
@@ -117,9 +119,9 @@ pub fn op_set_raw(
       | wincon::ENABLE_PROCESSED_INPUT;
     wincheck!(consoleapi::GetConsoleMode(handle, &mut original_mode));
     let new_mode = if is_raw {
-      original_mode & !RAW_MODE_MASK;
+      original_mode & !RAW_MODE_MASK
     } else {
-      original_mode | RAW_MODE_MASK;
+      original_mode | RAW_MODE_MASK
     };
     wincheck!(consoleapi::SetConsoleMode(handle, new_mode));
 

--- a/cli/ops/tty.rs
+++ b/cli/ops/tty.rs
@@ -117,7 +117,7 @@ pub fn op_set_raw(
     };
     wincheck!(consoleapi::SetConsoleMode(handle, new_mode));
 
-    return Ok(JsonOp::Sync(json!({})));
+    Ok(JsonOp::Sync(json!({})))
   }
   // From https://github.com/kkawakam/rustyline/blob/master/src/tty/unix.rs
   #[cfg(not(windows))]
@@ -144,10 +144,10 @@ pub fn op_set_raw(
       raw.control_chars[termios::SpecialCharacterIndices::VMIN as usize] = 1;
       raw.control_chars[termios::SpecialCharacterIndices::VTIME as usize] = 0;
       termios::tcsetattr(raw_fd, termios::SetArg::TCSADRAIN, &raw)?;
-      return Ok(JsonOp::Sync(json!({
+      Ok(JsonOp::Sync(json!({
         "restore":
           serde_json::to_string(&SerializedTermios::from(original_mode)).unwrap(),
-      })));
+      })))
     } else {
       // Restore old mode.
       if args.restore.is_none() {
@@ -164,7 +164,7 @@ pub fn op_set_raw(
         termios::SetArg::TCSADRAIN,
         &old_termios.into(),
       )?;
-      return Ok(JsonOp::Sync(json!({})));
+      Ok(JsonOp::Sync(json!({})))
     }
   }
 }

--- a/cli/ops/tty.rs
+++ b/cli/ops/tty.rs
@@ -1,0 +1,170 @@
+use super::dispatch_json::JsonOp;
+use super::io::StreamResource;
+use crate::deno_error::bad_resource;
+use crate::deno_error::other_error;
+use crate::ops::json_op;
+use crate::state::State;
+use deno_core::*;
+use nix::sys::termios;
+use serde_derive::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub fn init(i: &mut Isolate, s: &State) {
+  i.register_op("set_raw", s.core_op(json_op(s.stateful_op(op_set_raw))));
+}
+
+#[cfg(windows)]
+macro_rules! wincheck {
+  ($funcall:expr) => {{
+    let rc = unsafe { $funcall };
+    if rc == 0 {
+      Err(std::io::Error::last_os_error())?;
+    }
+    rc
+  }};
+}
+
+// libc::termios cannot be serialized.
+// Create a similar one for our use.
+#[derive(Serialize, Deserialize)]
+struct SerializedTermios {
+  iflags: u64,
+  oflags: u64,
+  cflags: u64,
+  lflags: u64,
+  cc: [u8; libc::NCCS],
+}
+
+impl From<termios::Termios> for SerializedTermios {
+  fn from(t: termios::Termios) -> Self {
+    Self {
+      iflags: t.input_flags.bits(),
+      oflags: t.output_flags.bits(),
+      cflags: t.control_flags.bits(),
+      lflags: t.local_flags.bits(),
+      cc: t.control_chars,
+    }
+  }
+}
+
+impl Into<termios::Termios> for SerializedTermios {
+  fn into(self) -> termios::Termios {
+    let mut t = unsafe { termios::Termios::default_uninit() };
+    t.input_flags = termios::InputFlags::from_bits_truncate(self.iflags);
+    t.output_flags = termios::OutputFlags::from_bits_truncate(self.oflags);
+    t.control_flags = termios::ControlFlags::from_bits_truncate(self.cflags);
+    t.local_flags = termios::LocalFlags::from_bits_truncate(self.lflags);
+    t.control_chars = self.cc;
+    t
+  }
+}
+
+#[derive(Deserialize)]
+struct SetRawArgs {
+  rid: u32,
+  raw: bool,
+  #[cfg(not(windows))]
+  restore: Option<String>, // Only used for *nix
+                           // Saved as string in case of u64 problem in JS
+}
+
+pub fn op_set_raw(
+  state_: &State,
+  args: Value,
+  _zero_copy: Option<ZeroCopyBuf>,
+) -> Result<JsonOp, ErrBox> {
+  let args: SetRawArgs = serde_json::from_value(args)?;
+  let rid = args.rid;
+  let is_raw = args.raw;
+
+  let state = state_.borrow_mut();
+  let resource = state.resource_table.get::<StreamResource>(rid);
+  if resource.is_none() {
+    return Err(bad_resource());
+  }
+
+  // For now, only stdin
+  match resource.unwrap() {
+    StreamResource::Stdin(_) => (),
+    _ => {
+      return Err(other_error(
+        "Resource other than stdin is not implemented".to_owned(),
+      ))
+    }
+  }
+
+  // From https://github.com/kkawakam/rustyline/blob/master/src/tty/windows.rs
+  // and https://github.com/crossterm-rs/crossterm/blob/e35d4d2c1cc4c919e36d242e014af75f6127ab50/src/terminal/sys/windows.rs
+  #[cfg(windows)]
+  {
+    use std::os::windows::io::AsRawHandle;
+    use winapi::um::{consoleapi, handleapi, winbase, wincon, winuser};
+
+    let handle = std::io::stdin().as_raw_handle();
+    if handle == handleapi::INVALID_HANDLE_VALUE {
+      return Err(std::io::Error::last_os_error());
+    } else if handle.is_null() {
+      return Err(other_error("null handle".to_owned()));
+    }
+    let mut original_mode = 0;
+    let RAW_MODE_MASK =
+      ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT;
+    wincheck!(consoleapi::GetConsoleMode(handle, &mut original_mode));
+    let new_mode = if is_raw {
+      original_mode & !RAW_MODE_MASK;
+    } else {
+      original_mode | RAW_MODE_MASK;
+    };
+    wincheck!(consoleapi::SetConsoleMode(handle, new_mode));
+
+    return Ok(JsonOp::Sync(json!({})));
+  }
+  // From https://github.com/kkawakam/rustyline/blob/master/src/tty/unix.rs
+  #[cfg(not(windows))]
+  {
+    use std::os::unix::io::AsRawFd;
+    let raw_fd = std::io::stdin().as_raw_fd();
+
+    if is_raw {
+      let original_mode = termios::tcgetattr(raw_fd)?;
+      let mut raw = original_mode.clone();
+
+      raw.input_flags &= !(termios::InputFlags::BRKINT
+        | termios::InputFlags::ICRNL
+        | termios::InputFlags::INPCK
+        | termios::InputFlags::ISTRIP
+        | termios::InputFlags::IXON);
+
+      raw.control_flags |= termios::ControlFlags::CS8;
+
+      raw.local_flags &= !(termios::LocalFlags::ECHO
+        | termios::LocalFlags::ICANON
+        | termios::LocalFlags::IEXTEN
+        | termios::LocalFlags::ISIG);
+      raw.control_chars[termios::SpecialCharacterIndices::VMIN as usize] = 1;
+      raw.control_chars[termios::SpecialCharacterIndices::VTIME as usize] = 0;
+      termios::tcsetattr(raw_fd, termios::SetArg::TCSADRAIN, &raw)?;
+      return Ok(JsonOp::Sync(json!({
+        "restore":
+          serde_json::to_string(&SerializedTermios::from(original_mode)).unwrap(),
+      })));
+    } else {
+      // Restore old mode.
+      if args.restore.is_none() {
+        return Err(other_error("no termios to restore".to_owned()));
+      }
+      let old_termios =
+        serde_json::from_str::<SerializedTermios>(&args.restore.unwrap());
+      if old_termios.is_err() {
+        return Err(other_error("bad termios to restore".to_owned()));
+      }
+      let old_termios = old_termios.unwrap();
+      termios::tcsetattr(
+        raw_fd,
+        termios::SetArg::TCSADRAIN,
+        &old_termios.into(),
+      )?;
+      return Ok(JsonOp::Sync(json!({})));
+    }
+  }
+}

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -225,6 +225,7 @@ impl MainWorker {
       ops::timers::init(isolate, &state);
       ops::worker_host::init(isolate, &state);
       ops::web_worker::init(isolate, &state);
+      ops::tty::init(isolate, &state);
     }
     Self(worker)
   }


### PR DESCRIPTION
Basic implementation of raw mode for stdin. Implementation is tentative (op names unsure), and code is mostly lifted from crossterm or rustyline (without introducing more deps)

Likely won't work properly on Windows since I cannot test it locally.

```ts
// Returns a function that when called, restores original mode.
// I do not want to expose other tty flags, so this hides away the flags' existence
let restore = Deno.stdin.setRaw();
restore = Deno.stdin.setRaw(); // Safe to call again before restore.

const buf = new Uint8Array(6);
for (let i = 0; i < 6; i++) {
  const nread = await Deno.stdin.read(buf);
  if (nread === Deno.EOF) {
    break;
  } else {
    console.log(`READ ${nread} bytes:`, new TextDecoder().decode(buf.subarray(0, nread)));
  }
}

restore(); // restores old mode. Can be safely called multiple times
restore(); // safe to call multiple times
```
Sample run (assume imput is `is raw`):
```
$ ./target/debug/deno raw_mode.ts
READ 1 bytes: i
READ 1 bytes: s
READ 1 bytes:
READ 1 bytes: r
READ 1 bytes: a
READ 1 bytes: w
```