### PR TITLE
fix(std/node): support named import for EventEmitter

### DIFF
--- a/std/node/events.ts
+++ b/std/node/events.ts
@@ -328,6 +328,8 @@ export default class EventEmitter {
   }
 }
 
+export { EventEmitter };
+
 /**
  * Creates a Promise that is fulfilled when the EventEmitter emits the given
  * event or that is rejected when the EventEmitter emits 'error'. The Promise


### PR DESCRIPTION
Related to: #3944

Named import for `EventEmitter` should also be supported as follows:

```typescript
import { EventEmitter } from "https://deno.land/std/node/events.ts";
```