### PR TITLE
manual: update references to testing/mod.ts

### DIFF
--- a/cli/import_map.rs
+++ b/cli/import_map.rs
@@ -147,7 +147,7 @@ impl ImportMap {
 
   /// Parse provided key as import map specifier.
   ///
-  /// Specifiers must be valid URLs (eg. "https://deno.land/x/std/testing/mod.ts")
+  /// Specifiers must be valid URLs (eg. "https://deno.land/x/std/testing/asserts.ts")
   /// or "bare" specifiers (eg. "moment").
   // TODO: add proper error handling: https://github.com/WICG/import-maps/issues/100
   fn normalize_specifier_key(

--- a/std/manual.md
+++ b/std/manual.md
@@ -465,24 +465,20 @@ The above for-await loop exits after 5 seconds when sig.dispose() is called.
 
 In the above examples, we saw that Deno could execute scripts from URLs. Like
 browser JavaScript, Deno can import libraries directly from URLs. This example
-uses a URL to import a test runner library:
+uses a URL to import an assertion library:
 
 ```ts
-import {
-  assertEquals,
-  runIfMain,
-  test
-} from "https://deno.land/std/testing/mod.ts";
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
 
-test(function t1() {
+Deno.test(function t1() {
   assertEquals("hello", "hello");
 });
 
-test(function t2() {
+Deno.test(function t2() {
   assertEquals("world", "world");
 });
 
-runIfMain(import.meta);
+await Deno.runTests();
 ```
 
 Try running this:
@@ -534,16 +530,16 @@ a subtly different version of a library? Isn't it error prone to maintain URLs
 everywhere in a large project?** The solution is to import and re-export your
 external libraries in a central `deps.ts` file (which serves the same purpose as
 Node's `package.json` file). For example, let's say you were using the above
-testing library across a large project. Rather than importing
-`"https://deno.land/std/testing/mod.ts"` everywhere, you could create a
+assertion library across a large project. Rather than importing
+`"https://deno.land/std/testing/asserts.ts"` everywhere, you could create a
 `deps.ts` file that exports the third-party code:
 
 ```ts
 export {
+  assert,
   assertEquals,
-  runTests,
-  test
-} from "https://deno.land/std/testing/mod.ts";
+  assertStrContains
+} from "https://deno.land/std/testing/asserts.ts";
 ```
 
 And throughout the same project, you can import from the `deps.ts` and avoid

--- a/std/style_guide.md
+++ b/std/style_guide.md
@@ -295,10 +295,9 @@ Example of test:
 
 ```ts
 import { assertEquals } from "https://deno.land/std@v0.11/testing/asserts.ts";
-import { test } from "https://deno.land/std@v0.11/testing/mod.ts";
 import { foo } from "./mod.ts";
 
-test(function myTestFunction() {
+Deno.test(function myTestFunction() {
   assertEquals(foo(), { bar: "bar" });
 });
 ```

--- a/std/testing/README.md
+++ b/std/testing/README.md
@@ -5,14 +5,9 @@ in Deno.
 
 ## Usage
 
-The module exports a `test` function which is the test harness in Deno. It
-accepts either a function (including async functions) or an object which
-contains a `name` property and a `fn` property. When running tests and
-outputting the results, the name of the past function is used, or if the object
-is passed, the `name` property is used to identify the test. If the assertion is
-false an `AssertionError` will be thrown.
-
-Asserts are exposed in `testing/asserts.ts` module.
+`testing/asserts.ts` module provides range of assertion helpers. If the
+assertion is false an `AssertionError` will be thrown which will result in
+pretty-printed diff of failing assertion.
 
 - `equal()` - Deep comparison function, where `actual` and `expected` are
   compared deeply, and if they vary, `equal` returns `false`.
@@ -39,22 +34,12 @@ Asserts are exposed in `testing/asserts.ts` module.
 - `unimplemented()` - Use this to stub out methods that will throw when invoked
 - `unreachable()` - Used to assert unreachable code
 
-`runTests()` executes the declared tests. It accepts a `RunOptions` parameter:
-
-- parallel : Execute tests in a parallel way.
-- exitOnFail : if one test fails, test will throw an error and stop the tests.
-  If not all tests will be processed.
-
 Basic usage:
 
 ```ts
-import {
-  assertEquals,
-  runTests,
-  test
-} from "https://deno.land/std/testing/mod.ts";
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
 
-test({
+Deno.test({
   name: "testing example",
   fn(): void {
     assertEquals("world", "world");
@@ -62,13 +47,13 @@ test({
   }
 });
 
-runTests();
+await Deno.runTests();
 ```
 
 Short syntax (named function instead of object):
 
 ```ts
-test(function example(): void {
+Deno.test(function example(): void {
   assertEquals("world", "world");
   assertEquals({ hello: "world" }, { hello: "world" });
 });
@@ -77,14 +62,14 @@ test(function example(): void {
 Using `assertStrictEq()`:
 
 ```ts
-test(function isStrictlyEqual(): void {
+Deno.test(function isStrictlyEqual(): void {
   const a = {};
   const b = a;
   assertStrictEq(a, b);
 });
 
 // This test fails
-test(function isNotStrictlyEqual(): void {
+Deno.test(function isNotStrictlyEqual(): void {
   const a = {};
   const b = {};
   assertStrictEq(a, b);
@@ -94,7 +79,7 @@ test(function isNotStrictlyEqual(): void {
 Using `assertThrows()`:
 
 ```ts
-test(function doesThrow(): void {
+Deno.test(function doesThrow(): void {
   assertThrows((): void => {
     throw new TypeError("hello world!");
   });
@@ -111,7 +96,7 @@ test(function doesThrow(): void {
 });
 
 // This test will not pass
-test(function fails(): void {
+Deno.test(function fails(): void {
   assertThrows((): void => {
     console.log("Hello world");
   });
@@ -121,7 +106,7 @@ test(function fails(): void {
 Using `assertThrowsAsync()`:
 
 ```ts
-test(async function doesThrow(): Promise<void> {
+Deno.test(async function doesThrow(): Promise<void> {
   await assertThrowsAsync(
     async (): Promise<void> => {
       throw new TypeError("hello world!");
@@ -145,7 +130,7 @@ test(async function doesThrow(): Promise<void> {
 });
 
 // This test will not pass
-test(async function fails(): Promise<void> {
+Deno.test(async function fails(): Promise<void> {
   await assertThrowsAsync(
     async (): Promise<void> => {
       console.log("Hello world");


### PR DESCRIPTION
Updates dead references to `std/testing/mod.ts` after #3865 