### PR TITLE
Asynchronous event iteration node polyfill

### DIFF
--- a/std/node/events.ts
+++ b/std/node/events.ts
@@ -404,12 +404,17 @@ interface AsyncInterable {
   next(): Promise<IteratorResult<any, any>>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return(): Promise<IteratorResult<any, any>>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  throw(err: any): void;
+  throw(err: Error): void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [Symbol.asyncIterator](): any;
 }
 
+/**
+ * Returns an AsyncIterator that iterates eventName events. It will throw if
+ * the EventEmitter emits 'error'. It removes all listeners when exiting the
+ * loop. The value returned by each iteration is an array composed of the
+ * emitted event arguments.
+ */
 export function on(
   emitter: EventEmitter,
   event: string | symbol
@@ -464,13 +469,7 @@ export function on(
       return Promise.resolve(createIterResult(undefined, true));
     },
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    throw(err: any): void {
-      if (!err || !(err instanceof Error)) {
-        throw new Error(
-          "EventEmitter.AsyncIterator.Error: Error expected, but got: " + err
-        );
-      }
+    throw(err: Error): void {
       error = err;
       emitter.removeListener(event, eventHandler);
       emitter.removeListener("error", errorHandler);

--- a/std/node/events_test.ts
+++ b/std/node/events_test.ts
@@ -603,14 +603,6 @@ test({
     const _err = new Error("kaboom");
     let thrown = false;
 
-    assertThrows(
-      () => {
-        iterable.throw(42); //i.e. not of type Error
-      },
-      Error,
-      "EventEmitter.AsyncIterator.Error: "
-    );
-
     const expected = [["bar"], [42]];
 
     try {

--- a/std/node/events_test.ts
+++ b/std/node/events_test.ts
@@ -5,7 +5,7 @@ import {
   fail,
   assertThrows
 } from "../testing/asserts.ts";
-import EventEmitter, { WrappedFunction, once } from "./events.ts";
+import EventEmitter, { WrappedFunction, once, on } from "./events.ts";
 
 const shouldNeverBeEmitted: Function = () => {
   fail("Should never be called");
@@ -437,5 +437,193 @@ test({
     });
     ee.emit("error");
     assertEquals(events, ["errorMonitor event", "error"]);
+  }
+});
+
+test({
+  name: "asyncronous iteration of events are handled as expected",
+  async fn() {
+    const ee = new EventEmitter();
+    setTimeout(() => {
+      ee.emit("foo", "bar");
+      ee.emit("bar", 24);
+      ee.emit("foo", 42);
+    }, 0);
+
+    const iterable = on(ee, "foo");
+
+    const expected = [["bar"], [42]];
+
+    for await (const event of iterable) {
+      const current = expected.shift();
+
+      assertEquals(current, event);
+
+      if (expected.length === 0) {
+        break;
+      }
+    }
+    assertEquals(ee.listenerCount("foo"), 0);
+    assertEquals(ee.listenerCount("error"), 0);
+  }
+});
+
+test({
+  name: "asyncronous error handling of emitted events works as expected",
+  async fn() {
+    const ee = new EventEmitter();
+    const _err = new Error("kaboom");
+    setTimeout(() => {
+      ee.emit("error", _err);
+    }, 0);
+
+    const iterable = on(ee, "foo");
+    let thrown = false;
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const event of iterable) {
+        fail("no events should be processed due to the error thrown");
+      }
+    } catch (err) {
+      thrown = true;
+      assertEquals(err, _err);
+    }
+    assertEquals(thrown, true);
+  }
+});
+
+test({
+  name: "error thrown during asyncronous processing of events is handled",
+  async fn() {
+    const ee = new EventEmitter();
+    const _err = new Error("kaboom");
+    setTimeout(() => {
+      ee.emit("foo", 42);
+      ee.emit("error", _err);
+    }, 0);
+
+    const iterable = on(ee, "foo");
+    const expected = [[42]];
+    let thrown = false;
+
+    try {
+      for await (const event of iterable) {
+        const current = expected.shift();
+        assertEquals(current, event);
+      }
+    } catch (err) {
+      thrown = true;
+      assertEquals(err, _err);
+    }
+    assertEquals(thrown, true);
+    assertEquals(ee.listenerCount("foo"), 0);
+    assertEquals(ee.listenerCount("error"), 0);
+  }
+});
+
+test({
+  name:
+    "error thrown in processing loop of asyncronous event prevents processing of additional events",
+  async fn() {
+    const ee = new EventEmitter();
+    const _err = new Error("kaboom");
+
+    setTimeout(() => {
+      ee.emit("foo", 42);
+      ee.emit("foo", 999);
+    }, 0);
+
+    try {
+      for await (const event of on(ee, "foo")) {
+        assertEquals(event, [42]);
+        throw _err;
+      }
+    } catch (err) {
+      assertEquals(err, _err);
+    }
+
+    assertEquals(ee.listenerCount("foo"), 0);
+    assertEquals(ee.listenerCount("error"), 0);
+  }
+});
+
+test({
+  name: "asyncronous iterator next() works as expected",
+  async fn() {
+    const ee = new EventEmitter();
+    const iterable = on(ee, "foo");
+
+    setTimeout(function() {
+      ee.emit("foo", "bar");
+      ee.emit("foo", 42);
+      iterable.return();
+    }, 0);
+
+    const results = await Promise.all([
+      iterable.next(),
+      iterable.next(),
+      iterable.next()
+    ]);
+
+    assertEquals(results, [
+      {
+        value: ["bar"],
+        done: false
+      },
+      {
+        value: [42],
+        done: false
+      },
+      {
+        value: undefined,
+        done: true
+      }
+    ]);
+
+    assertEquals(await iterable.next(), {
+      value: undefined,
+      done: true
+    });
+  }
+});
+
+test({
+  name: "async iterable throw handles various scenarios",
+  async fn() {
+    const ee = new EventEmitter();
+    const iterable = on(ee, "foo");
+
+    setTimeout(() => {
+      ee.emit("foo", "bar");
+      ee.emit("foo", 42); // lost in the queue
+      iterable.throw(_err);
+    }, 0);
+
+    const _err = new Error("kaboom");
+    let thrown = false;
+
+    assertThrows(
+      () => {
+        iterable.throw(42); //i.e. not of type Error
+      },
+      Error,
+      "EventEmitter.AsyncIterator.Error: "
+    );
+
+    const expected = [["bar"], [42]];
+
+    try {
+      for await (const event of iterable) {
+        assertEquals(event, expected.shift());
+      }
+    } catch (err) {
+      thrown = true;
+      assertEquals(err, _err);
+    }
+    assertEquals(thrown, true);
+    assertEquals(expected.length, 0);
+    assertEquals(ee.listenerCount("foo"), 0);
+    assertEquals(ee.listenerCount("error"), 0);
   }
 });


### PR DESCRIPTION
A port of the Node.js asynchronous event iterator ['on' function](https://github.com/nodejs/node/blob/master/lib/events.js#L674).  This completes the node.js events polyfill, however be aware that the following remain intentionally unimplemented at this time:

* EventEmitter.listenerCount(emitter, eventName) - Deprecated
* Capture Rejections of Promises - Experimental
