### PR TITLE
fix: emit when bundle contains single module

### DIFF
--- a/cli/js/compiler_bundler.ts
+++ b/cli/js/compiler_bundler.ts
@@ -38,7 +38,10 @@ export function buildBundle(
   // specifiers which are used to define the modules, and doesn't expose them
   // publicly, so we have to try to replicate
   const sources = sourceFiles.map(sf => sf.fileName);
-  const sharedPath = commonPath(sources);
+  const sharedPath =
+    sources.length > 1
+      ? commonPath(sources)
+      : rootName.substring(0, rootName.lastIndexOf("/") + 1);
   rootName = normalizeUrl(rootName)
     .replace(sharedPath, "")
     .replace(/\.\w+$/i, "");

--- a/cli/js/compiler_bundler.ts
+++ b/cli/js/compiler_bundler.ts
@@ -38,10 +38,7 @@ export function buildBundle(
   // specifiers which are used to define the modules, and doesn't expose them
   // publicly, so we have to try to replicate
   const sources = sourceFiles.map(sf => sf.fileName);
-  const sharedPath =
-    sources.length > 1
-      ? commonPath(sources)
-      : rootName.substring(0, rootName.lastIndexOf("/") + 1);
+  const sharedPath = commonPath(sources);
   rootName = normalizeUrl(rootName)
     .replace(sharedPath, "")
     .replace(/\.\w+$/i, "");

--- a/cli/js/util.ts
+++ b/cli/js/util.ts
@@ -306,7 +306,7 @@ export function normalizeString(
 export function commonPath(paths: string[], sep = "/"): string {
   const [first = "", ...remaining] = paths;
   if (first === "" || remaining.length === 0) {
-    return "";
+    return first.substring(0, first.lastIndexOf(sep) + 1);
   }
   const parts = first.split(sep);
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -245,7 +245,6 @@ fn bundle_exports() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("run")
-    .arg("--reload")
     .arg(&test)
     .output()
     .expect("failed to spawn script");
@@ -280,7 +279,6 @@ fn bundle_circular() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("run")
-    .arg("--reload")
     .arg(&bundle)
     .output()
     .expect("failed to spawn script");

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -297,7 +297,8 @@ fn bundle_single_module() {
   use tempfile::TempDir;
 
   // First we have to generate a bundle of some module that has exports.
-  let single_module = util::root_path().join("cli/tests/subdir/single_module.ts");
+  let single_module =
+    util::root_path().join("cli/tests/subdir/single_module.ts");
   assert!(single_module.is_file());
   let t = TempDir::new().expect("tempdir fail");
   let bundle = t.path().join("single_module.bundle.js");
@@ -319,7 +320,7 @@ fn bundle_single_module() {
     .arg(&bundle)
     .output()
     .expect("failed to spawn script");
-  check the output of the the bundle program.
+  // check the output of the the bundle program.
   assert!(std::str::from_utf8(&output.stdout)
     .unwrap()
     .trim()

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -245,6 +245,7 @@ fn bundle_exports() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("run")
+    .arg("--reload")
     .arg(&test)
     .output()
     .expect("failed to spawn script");
@@ -279,6 +280,7 @@ fn bundle_circular() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("run")
+    .arg("--reload")
     .arg(&bundle)
     .output()
     .expect("failed to spawn script");
@@ -287,6 +289,41 @@ fn bundle_circular() {
     .unwrap()
     .trim()
     .ends_with("f1\nf2"));
+  assert_eq!(output.stderr, b"");
+}
+
+#[test]
+fn bundle_single_module() {
+  use tempfile::TempDir;
+
+  // First we have to generate a bundle of some module that has exports.
+  let single_module = util::root_path().join("cli/tests/subdir/single_module.ts");
+  assert!(single_module.is_file());
+  let t = TempDir::new().expect("tempdir fail");
+  let bundle = t.path().join("single_module.bundle.js");
+  let mut deno = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("bundle")
+    .arg(single_module)
+    .arg(&bundle)
+    .spawn()
+    .expect("failed to spawn script");
+  let status = deno.wait().expect("failed to wait for the child process");
+  assert!(status.success());
+  assert!(bundle.is_file());
+
+  let output = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("run")
+    .arg("--reload")
+    .arg(&bundle)
+    .output()
+    .expect("failed to spawn script");
+  check the output of the the bundle program.
+  assert!(std::str::from_utf8(&output.stdout)
+    .unwrap()
+    .trim()
+    .ends_with("Hello world!"));
   assert_eq!(output.stderr, b"");
 }
 

--- a/cli/tests/subdir/single_module.ts
+++ b/cli/tests/subdir/single_module.ts
@@ -1,0 +1,2 @@
+console.log("Hello world!");
+export {};


### PR DESCRIPTION
Fixes #4031

When a bundle contains a single module, we were incorrectly determining the module name, resulting in a non-functional bundle.  This PR corrects that determination.

Note though that modules need to be detected as modules by TypeScript though, and not scripts, so a module needs at least one import/export or use:

```js
export {};
```
