### PR TITLE
/std/ws: Fix args index for WS examples

### DIFF
--- a/std/ws/README.md
+++ b/std/ws/README.md
@@ -16,7 +16,7 @@ import {
 } from "https://deno.land/std/ws/mod.ts";
 
 /** websocket echo server */
-const port = Deno.args[1] || "8080";
+const port = Deno.args[0] || "8080";
 console.log(`websocket server is running on :${port}`);
 for await (const req of serve(`:${port}`)) {
   const { headers, conn } = req;
@@ -80,7 +80,7 @@ import { BufReader } from "https://deno.land/std/io/bufio.ts";
 import { TextProtoReader } from "https://deno.land/std/textproto/mod.ts";
 import { blue, green, red, yellow } from "https://deno.land/std/fmt/colors.ts";
 
-const endpoint = Deno.args[1] || "ws://127.0.0.1:8080";
+const endpoint = Deno.args[0] || "ws://127.0.0.1:8080";
 /** simple websocket cli */
 const sock = await connectWebSocket(endpoint);
 console.log(green("ws connected! (type 'close' to quit)"));

--- a/std/ws/example_client.ts
+++ b/std/ws/example_client.ts
@@ -9,7 +9,7 @@ import { BufReader } from "../io/bufio.ts";
 import { TextProtoReader } from "../textproto/mod.ts";
 import { blue, green, red, yellow } from "../fmt/colors.ts";
 
-const endpoint = Deno.args[1] || "ws://127.0.0.1:8080";
+const endpoint = Deno.args[0] || "ws://127.0.0.1:8080";
 /** simple websocket cli */
 const sock = await connectWebSocket(endpoint);
 console.log(green("ws connected! (type 'close' to quit)"));

--- a/std/ws/example_server.ts
+++ b/std/ws/example_server.ts
@@ -8,7 +8,7 @@ import {
 } from "./mod.ts";
 
 /** websocket echo server */
-const port = Deno.args[1] || "8080";
+const port = Deno.args[0] || "8080";
 console.log(`websocket server is running on :${port}`);
 for await (const req of serve(`:${port}`)) {
   const { headers, conn } = req;


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
The examples from https://deno.land/std/ws/ uses `args[1]` instead of `args[0]`.

The `Deno.args[1]` is somehow wrong. Or is `Deno.args` changed in the past by removing the invoked command from the `args`?

Checking with https://deno.land/typedoc/index.html#args this PR does it right :-)

