### PR TITLE
fix: file_server.ts not setting the correct content-type when serving index.html #4056

### DIFF
--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -107,7 +107,7 @@ async function serveFile(
   const [file, fileInfo] = await Promise.all([open(filePath), stat(filePath)]);
   const headers = new Headers();
   headers.set("content-length", fileInfo.len.toString());
-  headers.set("content-type", "text/plain; charset=utf-8");
+  headers.set("content-type", "text/html; charset=utf-8");
 
   const res = {
     status: 200,


### PR DESCRIPTION
Fix for #4056
Behavior it solves: When file_server.ts is serving the index.html, the browser was not rendering the page because it was receiving text/plain header for the content-type.

