### PR TITLE
Add missing node os.platform() implementation

### DIFF
--- a/std/node/os.ts
+++ b/std/node/os.ts
@@ -21,6 +21,7 @@
 import { notImplemented } from "./_utils.ts";
 import { validateIntegerRange } from "./util.ts";
 import { EOL as fsEOL } from "../fs/eol.ts";
+import { process } from "./process.ts";
 
 const SEE_GITHUB_ISSUE = "See https://github.com/denoland/deno/issues/3802";
 
@@ -144,10 +145,9 @@ export function loadavg(): number[] {
 export function networkInterfaces(): NetworkInterfaces {
   notImplemented(SEE_GITHUB_ISSUE);
 }
-
-/** Not yet implemented */
+/** Returns the a string identifying the operating system platform. The value is set at compile time. Possible values are 'darwin', 'linux', and 'win32'. */
 export function platform(): string {
-  notImplemented(SEE_GITHUB_ISSUE);
+  return process.platform;
 }
 
 /** Not yet implemented */

--- a/std/node/os_test.ts
+++ b/std/node/os_test.ts
@@ -29,6 +29,13 @@ test({
 });
 
 test({
+  name: "platform is a string",
+  fn() {
+    assertEquals(typeof os.platform(), "string");
+  }
+});
+
+test({
   name: "getPriority(): PID must be a 32 bit integer",
   fn() {
     assertThrows(
@@ -211,13 +218,6 @@ test({
     assertThrows(
       () => {
         os.networkInterfaces();
-      },
-      Error,
-      "Not implemented"
-    );
-    assertThrows(
-      () => {
-        os.platform();
       },
       Error,
       "Not implemented"


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
PR for one of the tasks from issue #3802 . Adding platform support as it's now there on process impl .

ps: planning to make more of thoses as i learn deno a little more before starting more serious contributions. 