### PR TITLE
feat(std/node): add os Symbol.toPrimitive methods

### DIFF
--- a/std/node/os.ts
+++ b/std/node/os.ts
@@ -89,6 +89,17 @@ interface UserInfo {
   homedir: string;
 }
 
+arch[Symbol.toPrimitive] = (): string => arch();
+endianness[Symbol.toPrimitive] = (): string => endianness();
+freemem[Symbol.toPrimitive] = (): number => freemem();
+homedir[Symbol.toPrimitive] = (): string | null => homedir();
+hostname[Symbol.toPrimitive] = (): string | null => hostname();
+platform[Symbol.toPrimitive] = (): string => platform();
+release[Symbol.toPrimitive] = (): string => release();
+totalmem[Symbol.toPrimitive] = (): number => totalmem();
+type[Symbol.toPrimitive] = (): string => type();
+uptime[Symbol.toPrimitive] = (): number => uptime();
+
 /** Returns the operating system CPU architecture for which the Deno binary was compiled */
 export function arch(): string {
   return Deno.build.arch;

--- a/std/node/os_test.ts
+++ b/std/node/os_test.ts
@@ -192,6 +192,17 @@ test({
 });
 
 test({
+  name: "Primitive coercion works as expected",
+  fn() {
+    assertEquals(`${os.arch}`, os.arch());
+    assertEquals(`${os.endianness}`, os.endianness());
+    assertEquals(`${os.homedir}`, os.homedir());
+    assertEquals(`${os.hostname}`, os.hostname());
+    assertEquals(`${os.platform}`, os.platform());
+  }
+});
+
+test({
   name: "APIs not yet implemented",
   fn() {
     assertThrows(


### PR DESCRIPTION
Node's os module exports a number of methods that evaluate to themselves
when coerced to a primitive.

I.e., `"" + os.arch` and `os.arch()` evaluate to the same string, and
now Deno's shims do too.