### PR TITLE
feat(std/node): add os.loadavg

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -85,7 +85,7 @@ export {
   ShutdownMode,
   shutdown
 } from "./net.ts";
-export { dir, env, exit, isTTY, execPath, hostname } from "./os.ts";
+export { dir, env, exit, isTTY, execPath, hostname, loadavg } from "./os.ts";
 export {
   permissions,
   PermissionName,

--- a/cli/js/dispatch.ts
+++ b/cli/js/dispatch.ts
@@ -80,6 +80,7 @@ export let OP_TRANSPILE: number;
 export let OP_SIGNAL_BIND: number;
 export let OP_SIGNAL_UNBIND: number;
 export let OP_SIGNAL_POLL: number;
+export let OP_LOADAVG: number;
 
 const PLUGIN_ASYNC_HANDLER_MAP: Map<number, AsyncHandler> = new Map();
 

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -40,6 +40,12 @@ declare namespace Deno {
     stderr: boolean;
   };
 
+  /** Get the loadavg. Requires the `--allow-env` flag.
+   *
+   *       console.log(Deno.loadavg());
+   */
+  export function loadavg(): number[];
+
   /** Get the hostname. Requires the `--allow-env` flag.
    *
    *       console.log(Deno.hostname());

--- a/cli/js/os.ts
+++ b/cli/js/os.ts
@@ -11,6 +11,14 @@ import * as util from "./util.ts";
 export function isTTY(): { stdin: boolean; stdout: boolean; stderr: boolean } {
   return sendSync(dispatch.OP_IS_TTY);
 }
+/** Get the loadavg.
+ * Requires the `--allow-env` flag.
+ *
+ *       console.log(Deno.loadavg());
+ */
+export function loadavg(): number[] {
+  return sendSync(dispatch.OP_LOADAVG);
+}
 
 /** Get the hostname.
  * Requires the `--allow-env` flag.

--- a/cli/js/os_test.ts
+++ b/cli/js/os_test.ts
@@ -283,6 +283,23 @@ testPerm({ env: false }, function execPathPerm(): void {
   assert(caughtError);
 });
 
+testPerm({ env: true }, function loadavgSuccess(): void {
+  const load = Deno.loadavg();
+  assertEquals(load.length, 3);
+});
+
+testPerm({ env: false }, function loadavgPerm(): void {
+  let caughtError = false;
+  try {
+    Deno.loadavg();
+  } catch (err) {
+    caughtError = true;
+    assert(err instanceof Deno.Err.PermissionDenied);
+    assertEquals(err.name, "PermissionDenied");
+  }
+  assert(caughtError);
+});
+
 testPerm({ env: true }, function hostnameDir(): void {
   assertNotEquals(Deno.hostname(), "");
 });

--- a/std/node/os.ts
+++ b/std/node/os.ts
@@ -133,12 +133,12 @@ export function hostname(): string {
   return Deno.hostname();
 }
 
-/** Not yet implemented */
+/** Returns an array containing the 1, 5, and 15 minute load averages */
 export function loadavg(): number[] {
   if (Deno.build.os == "win") {
     return [0, 0, 0];
   }
-  notImplemented(SEE_GITHUB_ISSUE);
+  return Deno.loadavg();
 }
 
 /** Not yet implemented */

--- a/std/node/os_test.ts
+++ b/std/node/os_test.ts
@@ -1,10 +1,5 @@
 const { test } = Deno;
-import {
-  assert,
-  assertThrows,
-  assertEquals,
-  AssertionError
-} from "../testing/asserts.ts";
+import { assert, assertThrows, assertEquals } from "../testing/asserts.ts";
 import * as os from "./os.ts";
 
 test({
@@ -168,26 +163,14 @@ test({
   }
 });
 
-// Method is currently implemented correctly for windows but not for any other os
 test({
   name: "Load average is an array of 3 numbers",
   fn() {
-    try {
-      const result = os.loadavg();
-      assert(result.length == 3);
-      assertEquals(typeof result[0], "number");
-      assertEquals(typeof result[1], "number");
-      assertEquals(typeof result[2], "number");
-    } catch (error) {
-      if (!(Object.getPrototypeOf(error) === Error.prototype)) {
-        const errMsg = `Unexpected error class: ${error.name}`;
-        throw new AssertionError(errMsg);
-      } else if (!error.message.includes("Not implemented")) {
-        throw new AssertionError(
-          "Expected this error to contain 'Not implemented'"
-        );
-      }
-    }
+    const result = os.loadavg();
+    assert(result.length == 3);
+    assertEquals(typeof result[0], "number");
+    assertEquals(typeof result[1], "number");
+    assertEquals(typeof result[2], "number");
   }
 });
 


### PR DESCRIPTION
PR for one of the multples tasks of #3802 for #3403
uses rust sys_info but disables it for windows as node does not implement it for windows