### PR TITLE
fetch: proper error for unsupported protocol

### DIFF
--- a/cli/js/fetch_test.ts
+++ b/cli/js/fetch_test.ts
@@ -9,6 +9,17 @@ import {
   fail
 } from "./test_util.ts";
 
+testPerm({ net: true }, async function fetchProtocolError(): Promise<void> {
+  let err;
+  try {
+    await fetch("file:///");
+  } catch (err_) {
+    err = err_;
+  }
+  assert(err instanceof TypeError);
+  assertStrContains(err.message, "not supported");
+});
+
 testPerm({ net: true }, async function fetchConnectionError(): Promise<void> {
   let err;
   try {

--- a/cli/permissions.rs
+++ b/cli/permissions.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::deno_error::{other_error, permission_denied_msg};
+use crate::deno_error::{DenoError, ErrorKind};
 use crate::flags::DenoFlags;
 use ansi_term::Style;
 #[cfg(not(test))]
@@ -193,8 +194,11 @@ impl DenoPermissions {
   }
 
   pub fn check_net_url(&self, url: &url::Url) -> Result<(), ErrBox> {
+    let host = url.host_str().ok_or_else(|| {
+      DenoError::new(ErrorKind::URIError, "missing host".to_owned())
+    })?;
     self
-      .get_state_net(&format!("{}", url.host().unwrap()), url.port())
+      .get_state_net(host, url.port())
       .check(&format!("network access to \"{}\"", url), "--allow-net")
   }
 


### PR DESCRIPTION
Related to #4038

Don't panic. Throw a proper error when fetching a protocol not support/not yet supported