### PR TITLE
fix: [ws] chat example dosesn't work on deno.land for CSP

### DIFF
--- a/std/examples/chat/index.html
+++ b/std/examples/chat/index.html
@@ -1,5 +1,6 @@
-<html>
+<html lang="en">
   <head>
+    <meta charset="UTF-8" />
     <title>ws chat example</title>
   </head>
   <body>
@@ -10,7 +11,7 @@
       <button id="closeButton" disabled>close</button>
     </div>
     <div id="status"></div>
-    <ul id="timeline"></div>
+    <ul id="timeline"></ul>
     <script>
       let ws;
       function messageDom(msg) {
@@ -35,7 +36,7 @@
       }
       function connect() {
         if (ws) ws.close();
-        ws = new WebSocket("ws://0.0.0.0:8080/ws");
+        ws = new WebSocket(`ws://${location.host}/ws`);
         ws.addEventListener("open", () => {
           console.log("open", ws);
           applyState({connected: true});

--- a/std/examples/chat/server.ts
+++ b/std/examples/chat/server.ts
@@ -36,12 +36,17 @@ listenAndServe({ port: 8080 }, async req => {
     if (u.protocol.startsWith("http")) {
       // server launched by deno run http(s)://.../server.ts,
       fetch(u.href).then(resp => {
-        resp.headers.set("content-type", "text/html");
-        return req.respond(resp);
+        return req.respond({
+          status: resp.status,
+          headers: new Headers({
+            "content-type": "text/html"
+          }),
+          body: resp.body
+        });
       });
     } else {
       // server launched by deno run ./server.ts
-      const file = await Deno.open("./index.html");
+      const file = await Deno.open(u.pathname);
       req.respond({
         status: 200,
         headers: new Headers({
@@ -50,6 +55,14 @@ listenAndServe({ port: 8080 }, async req => {
         body: file
       });
     }
+  }
+  if (req.method === "GET" && req.url === "/favicon.ico") {
+    req.respond({
+      status: 302,
+      headers: new Headers({
+        location: "https://deno.land/favicon.ico"
+      })
+    });
   }
   if (req.method === "GET" && req.url === "/ws") {
     if (acceptable(req)) {


### PR DESCRIPTION
<img width="546" alt="スクリーンショット 2020-02-24 1 17 19" src="https://user-images.githubusercontent.com/927286/75115608-7755ef80-56a3-11ea-8a18-e0da752d885c.png">

Proxied response headers from deno.land includes `Content-Security-Policy` that bans script. 