### PR TITLE
ci: upload release snapshots automatically to Githubb artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,27 @@ jobs:
             target/release/deno_src.tar.gz
           draft: true
 
+      - name: Upload release (windows)
+        uses: actions/upload-artifact@v1
+        if: runner.os == 'Windows' && matrix.kind == 'test_release'
+        with:
+          name: deno_win_x64
+          path: ./target/release/deno_win_x64.zip
+
+      - name: Upload release (linux)
+        uses: actions/upload-artifact@v1
+        if: runner.os == 'Linux' && matrix.kind == 'test_release'
+        with:
+          name: deno_linux_x64
+          path: ./target/release/deno_linux_x64.gz
+
+      - name: Upload release (mac)
+        uses: actions/upload-artifact@v1
+        if: runner.os == 'macOS' && matrix.kind == 'test_release'
+        with:
+          name: deno_osx_x64
+          path: ./target/release/deno_osx_x64.gz
+
       - name: Publish
         if: >
           startsWith(github.ref, 'refs/tags/') &&


### PR DESCRIPTION
![截屏2020-02-2401 25 54](https://user-images.githubusercontent.com/9758711/75116595-fef02e00-56a4-11ea-8d72-e60c808e017f.png)


Upload snapshots to Github with every commit

I think this is very useful

eg. when some new features I want to use, but the new version has not been released yet

Then I can download it from the snapshot first without building in local.