### PR TITLE
Removal of the ansi_term dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,6 @@ dependencies = [
 name = "deno"
 version = "0.34.0"
 dependencies = [
- "ansi_term",
  "atty",
  "base64 0.11.0",
  "byteorder",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,7 +26,6 @@ deno_typescript = { path = "../deno_typescript", version = "0.34.0" }
 deno_core = { path = "../core", version = "0.34.0" }
 deno_typescript = { path = "../deno_typescript", version = "0.34.0" }
 
-ansi_term = "0.11.0"
 atty = "0.2.13"
 base64 = "0.11.0"
 bytes = "0.5.3"

--- a/cli/colors.rs
+++ b/cli/colors.rs
@@ -1,22 +1,20 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use ansi_term::Color::Black;
-use ansi_term::Color::Fixed;
-use ansi_term::Color::Red;
-use ansi_term::Color::White;
-use ansi_term::Style;
 use regex::Regex;
 use std::env;
 use std::fmt;
+use std::io::Write;
+use termcolor::Color::{Ansi256, Black, Red, White};
+use termcolor::{Ansi, ColorSpec, WriteColor};
 
 lazy_static! {
-  // STRIP_ANSI_RE and strip_ansi_codes are lifted from the "console" crate.
-  // Copyright 2017 Armin Ronacher <armin.ronacher@active-4.com>. MIT License.
-  static ref STRIP_ANSI_RE: Regex = Regex::new(
-    r"[\x1b\x9b][\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]"
-  ).unwrap();
-  static ref NO_COLOR: bool = {
-    env::var_os("NO_COLOR").is_some()
-  };
+        // STRIP_ANSI_RE and strip_ansi_codes are lifted from the "console" crate.
+        // Copyright 2017 Armin Ronacher <armin.ronacher@active-4.com>. MIT License.
+        static ref STRIP_ANSI_RE: Regex = Regex::new(
+                r"[\x1b\x9b][\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]"
+        ).unwrap();
+        static ref NO_COLOR: bool = {
+                env::var_os("NO_COLOR").is_some()
+        };
 }
 
 /// Helper function to strip ansi codes.
@@ -28,68 +26,60 @@ pub fn use_color() -> bool {
   !(*NO_COLOR)
 }
 
-pub fn red_bold(s: String) -> impl fmt::Display {
-  let mut style = Style::new();
+fn style(s: &str, colorspec: ColorSpec) -> impl fmt::Display {
+  let mut v = Vec::new();
+  let mut ansi_writer = Ansi::new(&mut v);
   if use_color() {
-    style = style.bold().fg(Red);
+    ansi_writer.set_color(&colorspec).unwrap();
   }
-  style.paint(s)
+  ansi_writer.write_all(s.as_bytes()).unwrap();
+  String::from_utf8_lossy(&v).into_owned()
+}
+
+pub fn red_bold(s: String) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Red)).set_bold(true);
+  style(&s, style_spec)
 }
 
 pub fn italic_bold(s: String) -> impl fmt::Display {
-  let mut style = Style::new();
-  if use_color() {
-    style = style.italic().bold();
-  }
-  style.paint(s)
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_bold(true).set_italic(true);
+  style(&s, style_spec)
 }
 
 pub fn black_on_white(s: String) -> impl fmt::Display {
-  let mut style = Style::new();
-  if use_color() {
-    style = style.on(White).fg(Black);
-  }
-  style.paint(s)
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_bg(Some(White)).set_fg(Some(Black));
+  style(&s, style_spec)
 }
 
 pub fn yellow(s: String) -> impl fmt::Display {
-  let mut style = Style::new();
-  if use_color() {
-    // matches TypeScript's ForegroundColorEscapeSequences.Yellow
-    style = style.fg(Fixed(11));
-  }
-  style.paint(s)
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Ansi256(11)));
+  style(&s, style_spec)
 }
 
 pub fn cyan(s: String) -> impl fmt::Display {
-  let mut style = Style::new();
-  if use_color() {
-    // matches TypeScript's ForegroundColorEscapeSequences.Cyan
-    style = style.fg(Fixed(14));
-  }
-  style.paint(s)
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Ansi256(14)));
+  style(&s, style_spec)
 }
 
 pub fn red(s: String) -> impl fmt::Display {
-  let mut style = Style::new();
-  if use_color() {
-    style = style.fg(Red);
-  }
-  style.paint(s)
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Red));
+  style(&s, style_spec)
 }
 
 pub fn green(s: String) -> impl fmt::Display {
-  let mut style = Style::new();
-  if use_color() {
-    style = style.fg(Fixed(10)).bold();
-  }
-  style.paint(s)
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Ansi256(10)));
+  style(&s, style_spec)
 }
 
 pub fn bold(s: String) -> impl fmt::Display {
-  let mut style = Style::new();
-  if use_color() {
-    style = style.bold();
-  }
-  style.paint(s)
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_bold(true);
+  style(&s, style_spec)
 }

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -388,9 +388,6 @@ async fn test_command(
 }
 
 pub fn main() {
-  #[cfg(windows)]
-  ansi_term::enable_ansi_support().ok(); // For Windows 10
-
   log::set_logger(&LOGGER).unwrap();
   let args: Vec<String> = env::args().collect();
   let flags = flags::flags_from_vec(args);

--- a/cli/permissions.rs
+++ b/cli/permissions.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::colors;
 use crate::flags::DenoFlags;
 use crate::op_error::OpError;
-use ansi_term::Style;
 #[cfg(not(test))]
 use atty;
 use log;
@@ -303,7 +303,7 @@ fn permission_prompt(message: &str) -> bool {
     PERMISSION_EMOJI, message
   );
   // print to stderr so that if deno is > to a file this is still displayed.
-  eprint!("{}", Style::new().bold().paint(msg));
+  eprint!("{}", colors::bold(msg));
   loop {
     let mut input = String::new();
     let stdin = io::stdin();
@@ -319,7 +319,7 @@ fn permission_prompt(message: &str) -> bool {
         // If we don't get a recognized option try again.
         let msg_again =
           format!("Unrecognized option '{}' [g/d (g = grant, d = deny)] ", ch);
-        eprint!("{}", Style::new().bold().paint(msg_again));
+        eprint!("{}", colors::bold(msg_again));
       }
     };
   }
@@ -344,9 +344,7 @@ fn log_perm_access(message: &str) {
   if log_enabled!(log::Level::Info) {
     eprintln!(
       "{}",
-      Style::new()
-        .bold()
-        .paint(format!("{}️  Granted {}", PERMISSION_EMOJI, message))
+      colors::bold(format!("{}️  Granted {}", PERMISSION_EMOJI, message))
     );
   }
 }

--- a/std/encoding/testdata/cargo.toml
+++ b/std/encoding/testdata/cargo.toml
@@ -23,7 +23,6 @@ edition = "2018"
 [dependencies]
 deno_core = { path = "./core" }
 
-ansi_term = "0.11.0"
 atty = "0.2.11"
 dirs = "1.0.5"
 flatbuffers = "0.5.0"

--- a/std/encoding/toml_test.ts
+++ b/std/encoding/toml_test.ts
@@ -260,7 +260,6 @@ Deno.test({
       package: { name: "deno", version: "0.3.4", edition: "2018" },
       dependencies: {
         deno_core: { path: "./core" },
-        ansi_term: "0.11.0",
         atty: "0.2.11",
         dirs: "1.0.5",
         flatbuffers: "0.5.0",


### PR DESCRIPTION
This Pull Request removes the `ansi_term` dependency by implementing the same methods using the `termcolor` dependency. Should close #3817.