### PR TITLE
Bundles can be sync or async based on top level await

### DIFF
--- a/cli/js/compiler_api_test.ts
+++ b/cli/js/compiler_api_test.ts
@@ -94,14 +94,14 @@ test(async function bundleApiSources() {
     "/bar.ts": `export const bar = "bar";\n`
   });
   assert(diagnostics == null);
-  assert(actual.includes(`__inst("foo")`));
+  assert(actual.includes(`__inst_s("foo")`));
   assert(actual.includes(`__exp["bar"]`));
 });
 
 test(async function bundleApiNoSources() {
   const [diagnostics, actual] = await bundle("./cli/tests/subdir/mod1.ts");
   assert(diagnostics == null);
-  assert(actual.includes(`__inst("mod1")`));
+  assert(actual.includes(`__inst_s("mod1")`));
   assert(actual.includes(`__exp["printHello3"]`));
 });
 

--- a/cli/tests/bundle.test.out
+++ b/cli/tests/bundle.test.out
@@ -1,6 +1,5 @@
 [WILDCARD]
-let System;
-let __inst;
+let System, __inst, __inst_s;
 [WILDCARD]
 (() => {
 [WILDCARD]

--- a/cli/tests/bundle.test.out
+++ b/cli/tests/bundle.test.out
@@ -16,7 +16,7 @@ System.register("mod1", ["subdir2/mod2"], function (exports_3, context_3) {
 [WILDCARD]
 });
 
-const __exp = await __inst("mod1");
+const __exp = __inst_s("mod1");
 export const returnsHi = __exp["returnsHi"];
 export const returnsFoo2 = __exp["returnsFoo2"];
 export const printHello3 = __exp["printHello3"];

--- a/deno_typescript/system_loader.js
+++ b/deno_typescript/system_loader.js
@@ -2,7 +2,9 @@
 
 // This is a specialised implementation of a System module loader.
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+// @ts-nocheck
+/* eslint-disable */
+
 let System, __inst, __inst_s;
 
 (() => {

--- a/deno_typescript/system_loader.js
+++ b/deno_typescript/system_loader.js
@@ -3,19 +3,13 @@
 // This is a specialised implementation of a System module loader.
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-let System;
-let __inst;
+let System, __inst, __inst_s;
 
 (() => {
   const mMap = new Map();
   System = {
-    register(id, deps, f) {
-      mMap.set(id, {
-        id,
-        deps,
-        f,
-        exp: {}
-      });
+    register(id, d, f) {
+      mMap.set(id, { id, d, f, exp: {} });
     }
   };
 
@@ -28,11 +22,10 @@ let __inst;
     };
   };
 
-  const gE = data => {
-    const { exp } = data;
-    return (id, value) => {
-      const values = typeof id === "string" ? { [id]: value } : id;
-      for (const [id, value] of Object.entries(values)) {
+  const gE = ({ exp }) => {
+    return (id, v) => {
+      const vs = typeof id === "string" ? { [id]: v } : id;
+      for (const [id, value] of Object.entries(vs)) {
         Object.defineProperty(exp, id, {
           value,
           writable: true,
@@ -47,39 +40,58 @@ let __inst;
   const enq = ids => {
     for (const id of ids) {
       if (!iQ.includes(id)) {
-        const { deps } = mMap.get(id);
+        const { d } = mMap.get(id);
         iQ.push(id);
-        enq(deps);
+        enq(d);
       }
     }
   };
 
-  const dr = async main => {
+  const gRQ = main => {
     const rQ = [];
     let id;
     while ((id = iQ.pop())) {
-      const m = mMap.get(id);
-      const { f } = m;
-      if (!f) {
-        return;
-      }
-      rQ.push([m.deps, f(gE(m), gC(m, id === main))]);
-      m.f = undefined;
+      const m = mMap.get(id),
+        { f } = m;
+      if (!f) return;
+      rQ.push([m.d, f(gE(m), gC(m, id === main))]);
+      delete m.f;
     }
+    return rQ;
+  };
+
+  const dr = async main => {
+    const rQ = gRQ(main);
     let r;
     while ((r = rQ.shift())) {
-      const [deps, { execute, setters }] = r;
-      for (let i = 0; i < deps.length; i++) setters[i](mMap.get(deps[i])?.exp);
+      const [d, { execute, setters }] = r;
+      for (let i = 0; i < d.length; i++) setters[i](mMap.get(d[i])?.exp);
       const e = execute();
       if (e) await e;
     }
   };
 
+  const dr_s = main => {
+    const rQ = gRQ(main);
+    let r;
+    while ((r = rQ.shift())) {
+      const [d, { execute, setters }] = r;
+      for (let i = 0; i < d.length; i++) setters[i](mMap.get(d[i])?.exp);
+      execute();
+    }
+  };
+
   __inst = async id => {
-    System = undefined;
-    __inst = undefined;
+    System = __inst = __inst_s = undefined;
     enq([id]);
     await dr(id);
+    return mMap.get(id)?.exp;
+  };
+
+  __inst_s = id => {
+    System = __inst = __inst_s = undefined;
+    enq([id]);
+    dr_s(id);
     return mMap.get(id)?.exp;
   };
 })();


### PR DESCRIPTION
Previously, bundles always utilised top level await, even if the bundled modules didn't require top level await.  This PR performs analysis of the bundle and if none of the bundled modules are asynchronously executed, then the bundle as a whole will be synchronously instantiated.

This does mean though that if a bundled module uses top level await, that will bubble up into the bundle, and currently be incompatible with the browser.  TLA in bundles though won't work until #4100 is merged.

Also this also introduces some minor improvements in the bundle loader which make it even more terse and cryptic in order to save space.

Fixes #4055
Fixes #4123
