### PR TITLE
ci: Use fetch-depth: 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v1
         with:
-          fetch-depth: 1
+          # Use depth > 1, because sometimes we need to rebuild master and if
+          # other commits have landed it will become impossible to rebuild if
+          # the checkout is too shallow.
+          fetch-depth: 5
           submodules: true
 
       - name: Create source tarballs (release, linux)


### PR DESCRIPTION
see https://github.com/denoland/deno/runs/467426697

```
git checkout --progress --force 91b606aaae23bcb790b55adc5fe70a182a37d564
##[error]fatal: reference is not a tree: 91b606aaae23bcb790b55adc5fe70a182a37d564
##[warning]Git checkout failed on shallow repository, this might because of git fetch with depth '1' doesn't include the checkout commit '91b606aaae23bcb790b55adc5fe70a182a37d564'.
Removed matchers: 'checkout-git'
##[error]Git checkout failed with exit code: 128
##[error]Exit code 1 returned from process: file name '/home/runner/runners/2.165.2/bin/Runner.PluginHost', arguments 'action "GitHub.Runner.Plugins.Repository.v1_0.CheckoutTask, Runner.Plugins"'.
```

# merge on approval