### PR TITLE
Add global "quiet" flag

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -7,6 +7,7 @@ use crate::diagnostics::Diagnostic;
 use crate::disk_cache::DiskCache;
 use crate::file_fetcher::SourceFile;
 use crate::file_fetcher::SourceFileFetcher;
+use crate::flags::DenoVerbosity;
 use crate::global_state::GlobalState;
 use crate::msg;
 use crate::op_error::OpError;
@@ -373,11 +374,14 @@ impl TsCompiler {
 
     let ts_compiler = self.clone();
 
-    eprintln!(
-      "{} {}",
-      colors::green("Compile".to_string()),
-      module_url.to_string()
-    );
+    if global_state.flags.verbosity >= DenoVerbosity::Normal {
+      eprintln!(
+        "{} {}",
+        colors::green("Compile".to_string()),
+        module_url.to_string()
+      );
+    }
+
     let msg = execute_in_thread(global_state.clone(), req_msg).await?;
 
     let json_str = std::str::from_utf8(&msg).unwrap();

--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -7,7 +7,7 @@ use crate::diagnostics::Diagnostic;
 use crate::disk_cache::DiskCache;
 use crate::file_fetcher::SourceFile;
 use crate::file_fetcher::SourceFileFetcher;
-use crate::flags::DenoVerbosity;
+use crate::flags::Verbosity;
 use crate::global_state::GlobalState;
 use crate::msg;
 use crate::op_error::OpError;
@@ -220,6 +220,7 @@ pub struct TsCompilerInner {
   pub use_disk_cache: bool,
   /// This setting is controlled by `compilerOptions.checkJs`
   pub compile_js: bool,
+  pub verbosity: Verbosity,
 }
 
 #[derive(Clone)]
@@ -238,6 +239,7 @@ impl TsCompiler {
     disk_cache: DiskCache,
     use_disk_cache: bool,
     config_path: Option<String>,
+    verbosity: Verbosity,
   ) -> Result<Self, ErrBox> {
     let config = CompilerConfig::load(config_path)?;
     Ok(TsCompiler(Arc::new(TsCompilerInner {
@@ -247,6 +249,7 @@ impl TsCompiler {
       config,
       compiled: Mutex::new(HashSet::new()),
       use_disk_cache,
+      verbosity,
     })))
   }
 
@@ -374,7 +377,7 @@ impl TsCompiler {
 
     let ts_compiler = self.clone();
 
-    if global_state.flags.verbosity >= DenoVerbosity::Normal {
+    if self.verbosity >= Verbosity::Normal {
       eprintln!(
         "{} {}",
         colors::green("Compile".to_string()),

--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -7,7 +7,6 @@ use crate::diagnostics::Diagnostic;
 use crate::disk_cache::DiskCache;
 use crate::file_fetcher::SourceFile;
 use crate::file_fetcher::SourceFileFetcher;
-use crate::flags::Verbosity;
 use crate::global_state::GlobalState;
 use crate::msg;
 use crate::op_error::OpError;
@@ -23,7 +22,7 @@ use deno_core::Buf;
 use deno_core::ErrBox;
 use deno_core::ModuleSpecifier;
 use futures::future::FutureExt;
-use log::Level;
+use log::info;
 use regex::Regex;
 use serde_json::json;
 use std::collections::HashMap;
@@ -221,7 +220,6 @@ pub struct TsCompilerInner {
   pub use_disk_cache: bool,
   /// This setting is controlled by `compilerOptions.checkJs`
   pub compile_js: bool,
-  pub verbosity: Verbosity,
 }
 
 #[derive(Clone)]
@@ -240,7 +238,6 @@ impl TsCompiler {
     disk_cache: DiskCache,
     use_disk_cache: bool,
     config_path: Option<String>,
-    verbosity: Verbosity,
   ) -> Result<Self, ErrBox> {
     let config = CompilerConfig::load(config_path)?;
     Ok(TsCompiler(Arc::new(TsCompilerInner {
@@ -250,7 +247,6 @@ impl TsCompiler {
       config,
       compiled: Mutex::new(HashSet::new()),
       use_disk_cache,
-      verbosity,
     })))
   }
 
@@ -378,13 +374,11 @@ impl TsCompiler {
 
     let ts_compiler = self.clone();
 
-    if self.verbosity.includes(Level::Info) {
-      eprintln!(
-        "{} {}",
-        colors::green("Compile".to_string()),
-        module_url.to_string()
-      );
-    }
+    info!(
+      "{} {}",
+      colors::green("Compile".to_string()),
+      module_url.to_string()
+    );
 
     let msg = execute_in_thread(global_state.clone(), req_msg).await?;
 

--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -23,6 +23,7 @@ use deno_core::Buf;
 use deno_core::ErrBox;
 use deno_core::ModuleSpecifier;
 use futures::future::FutureExt;
+use log::Level;
 use regex::Regex;
 use serde_json::json;
 use std::collections::HashMap;
@@ -377,7 +378,7 @@ impl TsCompiler {
 
     let ts_compiler = self.clone();
 
-    if self.verbosity >= Verbosity::Normal {
+    if self.verbosity.includes(Level::Info) {
       eprintln!(
         "{} {}",
         colors::green("Compile".to_string()),

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::colors;
+use crate::flags::Verbosity;
 use crate::http_cache::HttpCache;
 use crate::http_util;
 use crate::http_util::create_http_client;
@@ -69,6 +70,7 @@ pub struct SourceFileFetcher {
   no_remote: bool,
   cached_only: bool,
   http_client: reqwest::Client,
+  verbosity: Verbosity,
   // This field is public only to expose it's location
   pub http_cache: HttpCache,
 }
@@ -81,6 +83,7 @@ impl SourceFileFetcher {
     no_remote: bool,
     cached_only: bool,
     ca_file: Option<String>,
+    verbosity: Verbosity,
   ) -> Result<Self, ErrBox> {
     let file_fetcher = Self {
       http_cache,
@@ -90,6 +93,7 @@ impl SourceFileFetcher {
       no_remote,
       cached_only,
       http_client: create_http_client(ca_file)?,
+      verbosity,
     };
 
     Ok(file_fetcher)
@@ -391,11 +395,14 @@ impl SourceFileFetcher {
       .boxed_local();
     }
 
-    eprintln!(
-      "{} {}",
-      colors::green("Download".to_string()),
-      module_url.to_string()
-    );
+    if self.verbosity >= Verbosity::Normal {
+      eprintln!(
+        "{} {}",
+        colors::green("Download".to_string()),
+        module_url.to_string()
+      );
+    }
+
     let dir = self.clone();
     let module_url = module_url.clone();
     let module_etag = match self.http_cache.get(&module_url) {

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -10,6 +10,7 @@ use crate::op_error::OpError;
 use deno_core::ErrBox;
 use deno_core::ModuleSpecifier;
 use futures::future::FutureExt;
+use log::Level;
 use regex::Regex;
 use reqwest;
 use std;
@@ -395,7 +396,7 @@ impl SourceFileFetcher {
       .boxed_local();
     }
 
-    if self.verbosity >= Verbosity::Normal {
+    if self.verbosity.includes(Level::Info) {
       eprintln!(
         "{} {}",
         colors::green("Download".to_string()),
@@ -634,7 +635,7 @@ mod tests {
       false,
       false,
       None,
-      Verbosity::Normal,
+      Verbosity::default(),
     )
     .expect("setup fail")
   }

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -634,6 +634,7 @@ mod tests {
       false,
       false,
       None,
+      Verbosity::Normal,
     )
     .expect("setup fail")
   }

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -627,7 +627,6 @@ mod tests {
       false,
       false,
       None,
-      Verbosity::default(),
     )
     .expect("setup fail")
   }

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::colors;
-use crate::flags::Verbosity;
 use crate::http_cache::HttpCache;
 use crate::http_util;
 use crate::http_util::create_http_client;
@@ -10,10 +9,9 @@ use crate::op_error::OpError;
 use deno_core::ErrBox;
 use deno_core::ModuleSpecifier;
 use futures::future::FutureExt;
-use log::Level;
+use log::info;
 use regex::Regex;
 use reqwest;
-use std;
 use std::collections::HashMap;
 use std::fs;
 use std::future::Future;
@@ -25,7 +23,6 @@ use std::result::Result;
 use std::str;
 use std::sync::Arc;
 use std::sync::Mutex;
-use url;
 use url::Url;
 
 /// Structure representing local or remote file.
@@ -71,7 +68,6 @@ pub struct SourceFileFetcher {
   no_remote: bool,
   cached_only: bool,
   http_client: reqwest::Client,
-  verbosity: Verbosity,
   // This field is public only to expose it's location
   pub http_cache: HttpCache,
 }
@@ -84,7 +80,6 @@ impl SourceFileFetcher {
     no_remote: bool,
     cached_only: bool,
     ca_file: Option<String>,
-    verbosity: Verbosity,
   ) -> Result<Self, ErrBox> {
     let file_fetcher = Self {
       http_cache,
@@ -94,7 +89,6 @@ impl SourceFileFetcher {
       no_remote,
       cached_only,
       http_client: create_http_client(ca_file)?,
-      verbosity,
     };
 
     Ok(file_fetcher)
@@ -396,13 +390,11 @@ impl SourceFileFetcher {
       .boxed_local();
     }
 
-    if self.verbosity.includes(Level::Info) {
-      eprintln!(
-        "{} {}",
-        colors::green("Download".to_string()),
-        module_url.to_string()
-      );
-    }
+    info!(
+      "{} {}",
+      colors::green("Download".to_string()),
+      module_url.to_string()
+    );
 
     let dir = self.clone();
     let module_url = module_url.clone();

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -71,14 +71,14 @@ impl Default for DenoSubcommand {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum DenoVerbosity {
+pub enum Verbosity {
   Quiet,
   Normal,
 }
 
-impl Default for DenoVerbosity {
-  fn default() -> DenoVerbosity {
-    DenoVerbosity::Normal
+impl Default for Verbosity {
+  fn default() -> Verbosity {
+    Verbosity::Normal
   }
 }
 
@@ -90,7 +90,7 @@ pub struct DenoFlags {
   pub subcommand: DenoSubcommand,
 
   pub log_level: Option<Level>,
-  pub verbosity: DenoVerbosity,
+  pub verbosity: Verbosity,
   pub version: bool,
   pub reload: bool,
   pub config_path: Option<String>,
@@ -244,7 +244,7 @@ pub fn flags_from_vec_safe(args: Vec<String>) -> clap::Result<DenoFlags> {
   }
 
   if matches.is_present("quiet") {
-    flags.verbosity = DenoVerbosity::Quiet;
+    flags.verbosity = Verbosity::Quiet;
   }
 
   if let Some(m) = matches.subcommand_matches("run") {
@@ -302,7 +302,12 @@ fn clap_root<'a, 'b>() -> App<'a, 'b> {
       Arg::with_name("quiet")
         .short("q")
         .long("quiet")
-        .help("Reduce verbosity")
+        .help("Suppress diagnostic output")
+        .long_help(
+          "Suppress diagnostic output
+By default, subcommands print human-readable diagnostic messages to stderr.
+If the flag is set, restrict the output to warnings and errors.",
+        )
         .global(true),
     )
     .subcommand(bundle_subcommand())
@@ -1923,7 +1928,7 @@ mod tests {
         subcommand: DenoSubcommand::Run {
           script: "script.ts".to_string(),
         },
-        verbosity: DenoVerbosity::Quiet,
+        verbosity: Verbosity::Quiet,
         ..DenoFlags::default()
       }
     );

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1914,7 +1914,7 @@ mod tests {
         subcommand: DenoSubcommand::Run {
           script: "script.ts".to_string(),
         },
-        verbosity: Verbosity::new(Level::Error),
+        log_level: Some(Level::Error),
         ..Flags::default()
       }
     );

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -70,27 +70,6 @@ impl Default for DenoSubcommand {
   }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Verbosity {
-  pub level: Level,
-}
-
-impl Default for Verbosity {
-  fn default() -> Verbosity {
-    Verbosity::new(Level::Info)
-  }
-}
-
-impl Verbosity {
-  pub const fn new(level: Level) -> Verbosity {
-    Verbosity { level }
-  }
-
-  pub fn includes(self, level: Level) -> bool {
-    self.level >= level
-  }
-}
-
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Flags {
   /// Vector of CLI arguments - these are user script arguments, all Deno
@@ -99,7 +78,6 @@ pub struct Flags {
   pub subcommand: DenoSubcommand,
 
   pub log_level: Option<Level>,
-  pub verbosity: Verbosity,
   pub version: bool,
   pub reload: bool,
   pub config_path: Option<String>,
@@ -251,9 +229,8 @@ pub fn flags_from_vec_safe(args: Vec<String>) -> clap::Result<Flags> {
       _ => unreachable!(),
     };
   }
-
   if matches.is_present("quiet") {
-    flags.verbosity = Verbosity::new(Level::Error);
+    flags.log_level = Some(Level::Error);
   }
 
   if let Some(m) = matches.subcommand_matches("run") {

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -292,7 +292,7 @@ fn clap_root<'a, 'b>() -> App<'a, 'b> {
         .long_help(
           "Suppress diagnostic output
 By default, subcommands print human-readable diagnostic messages to stderr.
-If the flag is set, restrict the output to warnings and errors.",
+If the flag is set, restrict these messages to errors.",
         )
         .global(true),
     )

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -70,15 +70,24 @@ impl Default for DenoSubcommand {
   }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Verbosity {
-  Quiet,
-  Normal,
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Verbosity {
+  pub level: Level,
 }
 
 impl Default for Verbosity {
   fn default() -> Verbosity {
-    Verbosity::Normal
+    Verbosity::new(Level::Info)
+  }
+}
+
+impl Verbosity {
+  pub const fn new(level: Level) -> Verbosity {
+    Verbosity { level }
+  }
+
+  pub fn includes(self, level: Level) -> bool {
+    self.level >= level
   }
 }
 
@@ -244,7 +253,7 @@ pub fn flags_from_vec_safe(args: Vec<String>) -> clap::Result<Flags> {
   }
 
   if matches.is_present("quiet") {
-    flags.verbosity = Verbosity::Quiet;
+    flags.verbosity = Verbosity::new(Level::Error);
   }
 
   if let Some(m) = matches.subcommand_matches("run") {
@@ -1924,12 +1933,12 @@ mod tests {
     let r = flags_from_vec_safe(svec!["deno", "-q", "script.ts"]);
     assert_eq!(
       r.unwrap(),
-      DenoFlags {
+      Flags {
         subcommand: DenoSubcommand::Run {
           script: "script.ts".to_string(),
         },
-        verbosity: Verbosity::Quiet,
-        ..DenoFlags::default()
+        verbosity: Verbosity::new(Level::Error),
+        ..Flags::default()
       }
     );
   }

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -66,6 +66,7 @@ impl GlobalState {
       flags.no_remote,
       flags.cached_only,
       flags.ca_file.clone(),
+      flags.verbosity,
     )?;
 
     let ts_compiler = TsCompiler::new(
@@ -73,6 +74,7 @@ impl GlobalState {
       dir.gen_cache.clone(),
       !flags.reload,
       flags.config_path.clone(),
+      flags.verbosity,
     )?;
 
     // Note: reads lazily from disk on first call to lockfile.check()

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -66,7 +66,6 @@ impl GlobalState {
       flags.no_remote,
       flags.cached_only,
       flags.ca_file.clone(),
-      flags.verbosity,
     )?;
 
     let ts_compiler = TsCompiler::new(
@@ -74,7 +73,6 @@ impl GlobalState {
       dir.gen_cache.clone(),
       !flags.reload,
       flags.config_path.clone(),
-      flags.verbosity,
     )?;
 
     // Note: reads lazily from disk on first call to lockfile.check()

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -348,7 +348,6 @@ async fn test_command(
   flags: DenoFlags,
   include: Option<Vec<String>>,
   fail_fast: bool,
-  _quiet: bool,
   allow_none: bool,
 ) -> Result<(), ErrBox> {
   let global_state = GlobalState::new(flags.clone())?;
@@ -431,13 +430,10 @@ pub fn main() {
     DenoSubcommand::Repl => run_repl(flags).boxed_local(),
     DenoSubcommand::Run { script } => run_command(flags, script).boxed_local(),
     DenoSubcommand::Test {
-      quiet,
       fail_fast,
       include,
       allow_none,
-    } => {
-      test_command(flags, include, fail_fast, quiet, allow_none).boxed_local()
-    }
+    } => test_command(flags, include, fail_fast, allow_none).boxed_local(),
     DenoSubcommand::Completions { buf } => {
       print!("{}", std::str::from_utf8(&buf).unwrap());
       return;

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -79,6 +79,7 @@ use url::Url;
 
 static LOGGER: Logger = Logger;
 
+// TODO(ry) Switch to env_logger or other standard crate.
 struct Logger;
 
 impl log::Log for Logger {
@@ -95,7 +96,11 @@ impl log::Log for Logger {
         target.push_str(&line_no.to_string());
       }
 
-      println!("{} RS - {} - {}", record.level(), target, record.args());
+      if record.level() >= Level::Info {
+        eprintln!("{}", record.args());
+      } else {
+        eprintln!("{} RS - {} - {}", record.level(), target, record.args());
+      }
     }
   }
   fn flush(&self) {}
@@ -399,7 +404,7 @@ pub fn main() {
 
   let log_level = match flags.log_level {
     Some(level) => level,
-    None => Level::Warn,
+    None => Level::Info, // Default log level
   };
   log::set_max_level(log_level.to_level_filter());
 

--- a/cli/permissions.rs
+++ b/cli/permissions.rs
@@ -4,7 +4,6 @@ use crate::flags::Flags;
 use crate::op_error::OpError;
 #[cfg(not(test))]
 use atty;
-use log;
 use std::collections::HashSet;
 use std::fmt;
 #[cfg(not(test))]
@@ -349,12 +348,10 @@ fn permission_prompt(_message: &str) -> bool {
 }
 
 fn log_perm_access(message: &str) {
-  if log_enabled!(log::Level::Info) {
-    eprintln!(
-      "{}",
-      colors::bold(format!("{}️  Granted {}", PERMISSION_EMOJI, message))
-    );
-  }
+  debug!(
+    "{}",
+    colors::bold(format!("{}️  Granted {}", PERMISSION_EMOJI, message))
+  );
 }
 
 fn check_path_white_list(path: &Path, white_list: &HashSet<PathBuf>) -> bool {


### PR DESCRIPTION
Addresses #3162.

This addresses the concrete message the issue mentions, the "Compile <url>" line when (re-)compiling TypeScript modules. There are of course a lot more places that write status messages to stderr that could check this flag. Before hunting those down, I'd like feedback on the general approach.