### PR TITLE
stream output of js unit tests

### DIFF
--- a/cli/js/unit_test_runner.ts
+++ b/cli/js/unit_test_runner.ts
@@ -61,8 +61,8 @@ async function main(): Promise<void> {
       stdout: "piped"
     });
 
-    const { actual, expected, resultOutput } = parseUnitTestOutput(
-      await p.output(),
+    const { actual, expected, resultOutput } = await parseUnitTestOutput(
+      p.stdout!,
       true
     );
 


### PR DESCRIPTION
A small change that makes it so output of JS runtime unit tests is streamed to console instead of waiting for full output to print it. Doesn't change any behavior I just hated waiting on output for so long and now it's easily doable thanks to `readLines` from `std/io/bufio.ts`