### PR TITLE
rewrite permission revoke test as integration test

### DIFF
--- a/cli/js/permissions_test.ts
+++ b/cli/js/permissions_test.ts
@@ -1,34 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { test, testPerm, assert, assertEquals } from "./test_util.ts";
-
-const knownPermissions: Deno.PermissionName[] = [
-  "run",
-  "read",
-  "write",
-  "net",
-  "env",
-  "plugin",
-  "hrtime"
-];
-
-function genFunc(grant: Deno.PermissionName): () => Promise<void> {
-  const gen: () => Promise<void> = async function Granted(): Promise<void> {
-    const status0 = await Deno.permissions.query({ name: grant });
-    assert(status0 != null);
-    assertEquals(status0.state, "granted");
-
-    const status1 = await Deno.permissions.revoke({ name: grant });
-    assert(status1 != null);
-    assertEquals(status1.state, "prompt");
-  };
-  // Properly name these generated functions.
-  Object.defineProperty(gen, "name", { value: grant + "Granted" });
-  return gen;
-}
-
-for (const grant of knownPermissions) {
-  testPerm({ [grant]: true }, genFunc(grant));
-}
+import { test, assert } from "./test_util.ts";
 
 test(async function permissionInvalidName(): Promise<void> {
   let thrown = false;

--- a/cli/js/unit_tests.ts
+++ b/cli/js/unit_tests.ts
@@ -37,6 +37,7 @@ import "./mixins/dom_iterable_test.ts";
 import "./mkdir_test.ts";
 import "./net_test.ts";
 import "./os_test.ts";
+import "./permissions_test.ts";
 import "./process_test.ts";
 import "./realpath_test.ts";
 import "./read_dir_test.ts";
@@ -62,11 +63,6 @@ import "./write_file_test.ts";
 import "./performance_test.ts";
 import "./version_test.ts";
 import "./workers_test.ts";
-
-// FIXME(bartlomieju):
-// This test file revokes permissions, it must be run last,
-// otherwise it might revoke permission for tests that need them.
-import "./permissions_test.ts";
 
 if (import.meta.main) {
   await Deno.runTests();

--- a/cli/tests/057_revoke_permissions.out
+++ b/cli/tests/057_revoke_permissions.out
@@ -1,0 +1,10 @@
+running 7 tests
+OK     runGranted [WILDCARD]
+OK     readGranted [WILDCARD]
+OK     writeGranted [WILDCARD]
+OK     netGranted [WILDCARD]
+OK     envGranted [WILDCARD]
+OK     pluginGranted [WILDCARD]
+OK     hrtimeGranted [WILDCARD]
+
+test result: OK 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out [WILDCARD]

--- a/cli/tests/057_revoke_permissions.ts
+++ b/cli/tests/057_revoke_permissions.ts
@@ -34,5 +34,3 @@ function genFunc(grant: Deno.PermissionName): () => Promise<void> {
 for (const grant of knownPermissions) {
   Deno.test(genFunc(grant));
 }
-
-await Deno.runTests();

--- a/cli/tests/057_revoke_permissions.ts
+++ b/cli/tests/057_revoke_permissions.ts
@@ -1,0 +1,38 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+const knownPermissions: Deno.PermissionName[] = [
+  "run",
+  "read",
+  "write",
+  "net",
+  "env",
+  "plugin",
+  "hrtime"
+];
+
+export function assert(cond: unknown): asserts cond {
+  if (!cond) {
+    throw Error("Assertion failed");
+  }
+}
+
+function genFunc(grant: Deno.PermissionName): () => Promise<void> {
+  const gen: () => Promise<void> = async function Granted(): Promise<void> {
+    const status0 = await Deno.permissions.query({ name: grant });
+    assert(status0 != null);
+    assert(status0.state === "granted");
+
+    const status1 = await Deno.permissions.revoke({ name: grant });
+    assert(status1 != null);
+    assert(status1.state === "prompt");
+  };
+  // Properly name these generated functions.
+  Object.defineProperty(gen, "name", { value: grant + "Granted" });
+  return gen;
+}
+
+for (const grant of knownPermissions) {
+  Deno.test(genFunc(grant));
+}
+
+await Deno.runTests();

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -916,7 +916,7 @@ itest!(_056_make_temp_file_write_perm {
 });
 
 itest!(_057_revoke_permissions {
-  args: "run -A 057_revoke_permissions.ts",
+  args: "test -A 057_revoke_permissions.ts",
   output: "057_revoke_permissions.out",
 });
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -915,6 +915,11 @@ itest!(_056_make_temp_file_write_perm {
   output: "056_make_temp_file_write_perm.out",
 });
 
+itest!(_057_revoke_permissions {
+  args: "run -A 057_revoke_permissions.ts",
+  output: "057_revoke_permissions.out",
+});
+
 itest!(js_import_detect {
   args: "run --reload js_import_detect.ts",
   output: "js_import_detect.ts.out",


### PR DESCRIPTION
Effort towards simplifying `cli/js/` unit tests