### PR TITLE
Exit HandleScope before snapshotting

### DIFF
--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -232,7 +232,7 @@ fn write_snapshot(
   snapshot_filename: &Path,
 ) -> Result<(), ErrBox> {
   println!("Creating snapshot...");
-  let snapshot = runtime_isolate.snapshot()?;
+  let snapshot = runtime_isolate.snapshot();
   let snapshot_slice: &[u8] = &*snapshot;
   println!("Snapshot size: {}", snapshot_slice.len());
   fs::write(&snapshot_filename, snapshot_slice)?;


### PR DESCRIPTION
The V8 documentation explicitly states that SnapshotCreator::CreateBlob()
should not be called from within a HandleScope.

Additionally, this patch removes some non-functional error handling code
from the deno_core::Isolate::snapshot() method.