### PR TITLE
fix: deno_tcp bench segfault on exit

### DIFF
--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -201,6 +201,11 @@ impl Drop for Isolate {
         drop(creator);
       }
     }
+    // TODO(afinch7) This prevents a segfault when dropping ZeroCopyBuf values after
+    // the isolate is dropped.(see #4149) This seems to be a bug with v8, so we should be able
+    // to remove this once the bug has been fixed.
+    let ops = std::mem::take(&mut self.pending_ops);
+    drop(ops);
   }
 }
 


### PR DESCRIPTION
Fixes segfault that occurs on exit of `deno_tcp` bench sometimes. This issue may be a bug in v8, so this fix may be temporary.
ref #4149

cc @bartlomieju @piscisaureus 
