### PR TITLE
Revert "perf: use subarray instead of slice in dispatch minimal"

### DIFF
--- a/cli/js/dispatch_minimal.ts
+++ b/cli/js/dispatch_minimal.ts
@@ -27,7 +27,7 @@ export interface RecordMinimal {
 }
 
 export function recordFromBufMinimal(ui8: Uint8Array): RecordMinimal {
-  const header = ui8.subarray(0, 12);
+  const header = ui8.slice(0, 12);
   const buf32 = new Int32Array(
     header.buffer,
     header.byteOffset,
@@ -40,7 +40,7 @@ export function recordFromBufMinimal(ui8: Uint8Array): RecordMinimal {
 
   if (arg < 0) {
     const kind = result as ErrorKind;
-    const message = decoder.decode(ui8.subarray(12));
+    const message = decoder.decode(ui8.slice(12));
     err = { kind, message };
   } else if (ui8.length != 12) {
     throw new errors.InvalidData("BadMessage");


### PR DESCRIPTION
#4173

This is caused by:
```
error: Uncaught RangeError: start offset of Int32Array should be a multiple of 4
► $deno$/dispatch_minimal.ts:31:17
    at recordFromBufMinimal ($deno$/dispatch_minimal.ts:31:17)
    at asyncMsgFromRust ($deno$/dispatch_minimal.ts:73:18)
    at handleAsyncMsgFromRust (shared_queue.js:181:34)
```
Which was removed in #3935 - I would have been triggered earlier hadn't there been `.slice()` 

