### PR TITLE
misc: reduce unnecesarry output in cli/js tests

### DIFF
--- a/cli/js/console_test.ts
+++ b/cli/js/console_test.ts
@@ -37,16 +37,17 @@ test(function consoleHasRightInstance(): void {
 });
 
 test(function consoleTestAssertShouldNotThrowError(): void {
-  console.assert(true);
-
-  let hasThrown = undefined;
-  try {
-    console.assert(false);
-    hasThrown = false;
-  } catch {
-    hasThrown = true;
-  }
-  assertEquals(hasThrown, false);
+  mockConsole(console => {
+    console.assert(true);
+    let hasThrown = undefined;
+    try {
+      console.assert(false);
+      hasThrown = false;
+    } catch {
+      hasThrown = true;
+    }
+    assertEquals(hasThrown, false);
+  });
 });
 
 test(function consoleTestStringifyComplexObjects(): void {
@@ -302,19 +303,18 @@ test(function consoleTestWithVariousOrInvalidFormatSpecifier(): void {
 
 test(function consoleTestCallToStringOnLabel(): void {
   const methods = ["count", "countReset", "time", "timeLog", "timeEnd"];
-
-  for (const method of methods) {
-    let hasCalled = false;
-
-    // @ts-ignore
-    console[method]({
-      toString(): void {
-        hasCalled = true;
-      }
-    });
-
-    assertEquals(hasCalled, true);
-  }
+  mockConsole(console => {
+    for (const method of methods) {
+      let hasCalled = false;
+      // @ts-ignore
+      console[method]({
+        toString(): void {
+          hasCalled = true;
+        }
+      });
+      assertEquals(hasCalled, true);
+    }
+  });
 });
 
 test(function consoleTestError(): void {
@@ -355,40 +355,42 @@ test(function consoleTestClear(): void {
 
 // Test bound this issue
 test(function consoleDetachedLog(): void {
-  const log = console.log;
-  const dir = console.dir;
-  const dirxml = console.dirxml;
-  const debug = console.debug;
-  const info = console.info;
-  const warn = console.warn;
-  const error = console.error;
-  const consoleAssert = console.assert;
-  const consoleCount = console.count;
-  const consoleCountReset = console.countReset;
-  const consoleTable = console.table;
-  const consoleTime = console.time;
-  const consoleTimeLog = console.timeLog;
-  const consoleTimeEnd = console.timeEnd;
-  const consoleGroup = console.group;
-  const consoleGroupEnd = console.groupEnd;
-  const consoleClear = console.clear;
-  log("Hello world");
-  dir("Hello world");
-  dirxml("Hello world");
-  debug("Hello world");
-  info("Hello world");
-  warn("Hello world");
-  error("Hello world");
-  consoleAssert(true);
-  consoleCount("Hello world");
-  consoleCountReset("Hello world");
-  consoleTable({ test: "Hello world" });
-  consoleTime("Hello world");
-  consoleTimeLog("Hello world");
-  consoleTimeEnd("Hello world");
-  consoleGroup("Hello world");
-  consoleGroupEnd();
-  consoleClear();
+  mockConsole(console => {
+    const log = console.log;
+    const dir = console.dir;
+    const dirxml = console.dirxml;
+    const debug = console.debug;
+    const info = console.info;
+    const warn = console.warn;
+    const error = console.error;
+    const consoleAssert = console.assert;
+    const consoleCount = console.count;
+    const consoleCountReset = console.countReset;
+    const consoleTable = console.table;
+    const consoleTime = console.time;
+    const consoleTimeLog = console.timeLog;
+    const consoleTimeEnd = console.timeEnd;
+    const consoleGroup = console.group;
+    const consoleGroupEnd = console.groupEnd;
+    const consoleClear = console.clear;
+    log("Hello world");
+    dir("Hello world");
+    dirxml("Hello world");
+    debug("Hello world");
+    info("Hello world");
+    warn("Hello world");
+    error("Hello world");
+    consoleAssert(true);
+    consoleCount("Hello world");
+    consoleCountReset("Hello world");
+    consoleTable({ test: "Hello world" });
+    consoleTime("Hello world");
+    consoleTimeLog("Hello world");
+    consoleTimeEnd("Hello world");
+    consoleGroup("Hello world");
+    consoleGroupEnd();
+    consoleClear();
+  });
 });
 
 class StringBuffer {
@@ -652,14 +654,16 @@ test(function consoleTable(): void {
 
 // console.log(Error) test
 test(function consoleLogShouldNotThrowError(): void {
-  let result = 0;
-  try {
-    console.log(new Error("foo"));
-    result = 1;
-  } catch (e) {
-    result = 2;
-  }
-  assertEquals(result, 1);
+  mockConsole(console => {
+    let result = 0;
+    try {
+      console.log(new Error("foo"));
+      result = 1;
+    } catch (e) {
+      result = 2;
+    }
+    assertEquals(result, 1);
+  });
 
   // output errors to the console should not include "Uncaught"
   mockConsole((console, out): void => {

--- a/cli/js/dir_test.ts
+++ b/cli/js/dir_test.ts
@@ -30,7 +30,7 @@ testPerm({ write: true }, function dirCwdError(): void {
       throw Error("current directory removed, should throw error");
     } catch (err) {
       if (err instanceof Deno.errors.NotFound) {
-        console.log(err.name === "NotFound");
+        assert(err.name === "NotFound");
       } else {
         throw Error("raised different exception");
       }
@@ -46,7 +46,7 @@ testPerm({ write: true }, function dirChdirError(): void {
     throw Error("directory not available, should throw error");
   } catch (err) {
     if (err instanceof Deno.errors.NotFound) {
-      console.log(err.name === "NotFound");
+      assert(err.name === "NotFound");
     } else {
       throw Error("raised different exception");
     }

--- a/cli/js/fs_events_test.ts
+++ b/cli/js/fs_events_test.ts
@@ -19,7 +19,6 @@ async function getTwoEvents(
 ): Promise<Deno.FsEvent[]> {
   const events = [];
   for await (const event of iter) {
-    // console.log(">>>> event", event);
     events.push(event);
     if (events.length > 2) break;
   }
@@ -43,7 +42,6 @@ testPerm({ read: true, write: true }, async function fsEventsBasic(): Promise<
 
   // We should have gotten two fs events.
   const events = await eventsPromise;
-  // console.log("events", events);
   assert(events.length >= 2);
   assert(events[0].kind == "create");
   assert(events[0].paths[0].includes(testDir));

--- a/cli/js/fs_events_test.ts
+++ b/cli/js/fs_events_test.ts
@@ -19,7 +19,7 @@ async function getTwoEvents(
 ): Promise<Deno.FsEvent[]> {
   const events = [];
   for await (const event of iter) {
-    console.log(">>>> event", event);
+    // console.log(">>>> event", event);
     events.push(event);
     if (events.length > 2) break;
   }
@@ -43,7 +43,7 @@ testPerm({ read: true, write: true }, async function fsEventsBasic(): Promise<
 
   // We should have gotten two fs events.
   const events = await eventsPromise;
-  console.log("events", events);
+  // console.log("events", events);
   assert(events.length >= 2);
   assert(events[0].kind == "create");
   assert(events[0].paths[0].includes(testDir));

--- a/cli/js/location_test.ts
+++ b/cli/js/location_test.ts
@@ -3,6 +3,5 @@ import { test, assert } from "./test_util.ts";
 
 test(function locationBasic(): void {
   // location example: file:///Users/rld/src/deno/js/unit_tests.ts
-  console.log("location", window.location.toString());
   assert(window.location.toString().endsWith("unit_tests.ts"));
 });

--- a/cli/js/metrics_test.ts
+++ b/cli/js/metrics_test.ts
@@ -11,7 +11,7 @@ test(async function metrics(): Promise<void> {
 
   // Write to stdout to ensure a "data" message gets sent instead of just
   // control messages.
-  const dataMsg = new Uint8Array([41, 42, 43]);
+  const dataMsg = new Uint8Array([13, 13, 13]); // "\r\r\r",
   await Deno.stdout.write(dataMsg);
 
   const m2 = Deno.metrics();

--- a/cli/js/os_test.ts
+++ b/cli/js/os_test.ts
@@ -111,7 +111,6 @@ if (Deno.build.os === "win") {
 }
 
 test(function osPid(): void {
-  console.log("pid", Deno.pid);
   assert(Deno.pid > 0);
 });
 

--- a/cli/js/process_test.ts
+++ b/cli/js/process_test.ts
@@ -29,6 +29,7 @@ testPerm({ run: true }, async function runSuccess(): Promise<void> {
   assertEquals(status.success, true);
   assertEquals(status.code, 0);
   assertEquals(status.signal, undefined);
+  p.stdout!.close();
   p.close();
 });
 

--- a/cli/js/process_test.ts
+++ b/cli/js/process_test.ts
@@ -26,13 +26,9 @@ testPerm({ run: true }, async function runSuccess(): Promise<void> {
     stderr: "null"
   });
   const status = await p.status();
-  assert(p.stdout != null);
-  const out = await Deno.readAll(p.stdout);
-  const dec = new TextDecoder();
   assertEquals(status.success, true);
   assertEquals(status.code, 0);
   assertEquals(status.signal, undefined);
-  assertEquals(dec.decode(out), "hello world\n");
   p.close();
 });
 

--- a/cli/js/process_test.ts
+++ b/cli/js/process_test.ts
@@ -21,13 +21,18 @@ test(function runPermissions(): void {
 
 testPerm({ run: true }, async function runSuccess(): Promise<void> {
   const p = run({
-    args: ["python", "-c", "print('hello world')"]
+    args: ["python", "-c", "print('hello world')"],
+    stdout: "piped",
+    stderr: "null"
   });
   const status = await p.status();
-  console.log("status", status);
+  assert(p.stdout != null);
+  const out = await Deno.readAll(p.stdout);
+  const dec = new TextDecoder();
   assertEquals(status.success, true);
   assertEquals(status.code, 0);
   assertEquals(status.signal, undefined);
+  assertEquals(dec.decode(out), "hello world\n");
   p.close();
 });
 

--- a/cli/js/timers_test.ts
+++ b/cli/js/timers_test.ts
@@ -297,7 +297,6 @@ test(async function timerMaxCpuBug(): Promise<void> {
   const { opsDispatched } = Deno.metrics();
   await waitForMs(100);
   const opsDispatched_ = Deno.metrics().opsDispatched;
-  // console.log("opsDispatched", opsDispatched, "opsDispatched_", opsDispatched_);
   assert(opsDispatched_ - opsDispatched < 10);
 });
 

--- a/cli/js/timers_test.ts
+++ b/cli/js/timers_test.ts
@@ -297,7 +297,7 @@ test(async function timerMaxCpuBug(): Promise<void> {
   const { opsDispatched } = Deno.metrics();
   await waitForMs(100);
   const opsDispatched_ = Deno.metrics().opsDispatched;
-  console.log("opsDispatched", opsDispatched, "opsDispatched_", opsDispatched_);
+  // console.log("opsDispatched", opsDispatched, "opsDispatched_", opsDispatched_);
   assert(opsDispatched_ - opsDispatched < 10);
 });
 


### PR DESCRIPTION
- Continuing #4148 
- `filesCopyToStdout` and stdout from `test_worker.ts` are still remaining.