### PR TITLE
refactor(cli/js): Replace constructError() with getErrorClass()

### DIFF
--- a/cli/js/dispatch_json.ts
+++ b/cli/js/dispatch_json.ts
@@ -3,7 +3,7 @@ import * as util from "./util.ts";
 import { TextEncoder, TextDecoder } from "./text_encoding.ts";
 import { core } from "./core.ts";
 import { OPS_CACHE } from "./runtime.ts";
-import { ErrorKind, constructError } from "./errors.ts";
+import { ErrorKind, getErrorClass } from "./errors.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Ok = any;
@@ -38,7 +38,7 @@ function encode(args: object): Uint8Array {
 
 function unwrapResponse(res: JsonResponse): Ok {
   if (res.err != null) {
-    return constructError(res.err!.kind, res.err!.message);
+    throw new (getErrorClass(res.err.kind))(res.err.message);
   }
   util.assert(res.ok != null);
   return res.ok;

--- a/cli/js/dispatch_minimal.ts
+++ b/cli/js/dispatch_minimal.ts
@@ -2,7 +2,7 @@
 import * as util from "./util.ts";
 import { core } from "./core.ts";
 import { TextDecoder } from "./text_encoding.ts";
-import { errors, ErrorKind, constructError } from "./errors.ts";
+import { ErrorKind, errors, getErrorClass } from "./errors.ts";
 
 const promiseTableMin = new Map<number, util.Resolvable<RecordMinimal>>();
 // Note it's important that promiseId starts at 1 instead of 0, because sync
@@ -56,7 +56,7 @@ export function recordFromBufMinimal(ui8: Uint8Array): RecordMinimal {
 
 function unwrapResponse(res: RecordMinimal): number {
   if (res.err != null) {
-    return constructError(res.err!.kind, res.err!.message);
+    throw new (getErrorClass(res.err.kind))(res.err.message);
   }
   return res.result;
 }

--- a/cli/js/errors.ts
+++ b/cli/js/errors.ts
@@ -25,48 +25,48 @@ export enum ErrorKind {
   Other = 22
 }
 
-export function constructError(kind: ErrorKind, msg: string): never {
+export function getErrorClass(kind: ErrorKind): { new (msg: string): Error } {
   switch (kind) {
     case ErrorKind.TypeError:
-      throw new TypeError(msg);
+      return TypeError;
     case ErrorKind.Other:
-      throw new Error(msg);
+      return Error;
     case ErrorKind.URIError:
-      throw new URIError(msg);
+      return URIError;
     case ErrorKind.NotFound:
-      throw new NotFound(msg);
+      return NotFound;
     case ErrorKind.PermissionDenied:
-      throw new PermissionDenied(msg);
+      return PermissionDenied;
     case ErrorKind.ConnectionRefused:
-      throw new ConnectionRefused(msg);
+      return ConnectionRefused;
     case ErrorKind.ConnectionReset:
-      throw new ConnectionReset(msg);
+      return ConnectionReset;
     case ErrorKind.ConnectionAborted:
-      throw new ConnectionAborted(msg);
+      return ConnectionAborted;
     case ErrorKind.NotConnected:
-      throw new NotConnected(msg);
+      return NotConnected;
     case ErrorKind.AddrInUse:
-      throw new AddrInUse(msg);
+      return AddrInUse;
     case ErrorKind.AddrNotAvailable:
-      throw new AddrNotAvailable(msg);
+      return AddrNotAvailable;
     case ErrorKind.BrokenPipe:
-      throw new BrokenPipe(msg);
+      return BrokenPipe;
     case ErrorKind.AlreadyExists:
-      throw new AlreadyExists(msg);
+      return AlreadyExists;
     case ErrorKind.InvalidData:
-      throw new InvalidData(msg);
+      return InvalidData;
     case ErrorKind.TimedOut:
-      throw new TimedOut(msg);
+      return TimedOut;
     case ErrorKind.Interrupted:
-      throw new Interrupted(msg);
+      return Interrupted;
     case ErrorKind.WriteZero:
-      throw new WriteZero(msg);
+      return WriteZero;
     case ErrorKind.UnexpectedEof:
-      throw new UnexpectedEof(msg);
+      return UnexpectedEof;
     case ErrorKind.BadResource:
-      throw new BadResource(msg);
+      return BadResource;
     case ErrorKind.Http:
-      throw new Http(msg);
+      return Http;
   }
 }
 

--- a/cli/tests/044_bad_resource.ts.out
+++ b/cli/tests/044_bad_resource.ts.out
@@ -1,6 +1,6 @@
 [WILDCARD]
 error: Uncaught BadResource: bad resource id
-[WILDCARD]errors.ts:[WILDCARD]
+[WILDCARD]dispatch_json.ts:[WILDCARD]
     at BadResource ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendAsync ([WILDCARD]dispatch_json.ts:[WILDCARD])

--- a/cli/tests/044_bad_resource.ts.out
+++ b/cli/tests/044_bad_resource.ts.out
@@ -2,6 +2,5 @@
 error: Uncaught BadResource: bad resource id
 [WILDCARD]errors.ts:[WILDCARD]
     at BadResource ([WILDCARD]errors.ts:[WILDCARD])
-    at constructError ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendAsync ([WILDCARD]dispatch_json.ts:[WILDCARD])

--- a/cli/tests/error_004_missing_module.ts.out
+++ b/cli/tests/error_004_missing_module.ts.out
@@ -1,6 +1,5 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts" from "[WILDCARD]/error_004_missing_module.ts"
 [WILDCARD]errors.ts:[WILDCARD]
     at NotFound ([WILDCARD]errors.ts:[WILDCARD])
-    at constructError ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendAsync[WILDCARD] ([WILDCARD]dispatch_json.ts:[WILDCARD])

--- a/cli/tests/error_004_missing_module.ts.out
+++ b/cli/tests/error_004_missing_module.ts.out
@@ -1,5 +1,5 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts" from "[WILDCARD]/error_004_missing_module.ts"
-[WILDCARD]errors.ts:[WILDCARD]
+[WILDCARD]dispatch_json.ts:[WILDCARD]
     at NotFound ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendAsync[WILDCARD] ([WILDCARD]dispatch_json.ts:[WILDCARD])

--- a/cli/tests/error_005_missing_dynamic_import.ts.out
+++ b/cli/tests/error_005_missing_dynamic_import.ts.out
@@ -1,6 +1,5 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts" from "[WILDCARD]/error_005_missing_dynamic_import.ts"
 [WILDCARD]errors.ts:[WILDCARD]
     at NotFound ([WILDCARD]errors.ts:[WILDCARD])
-    at constructError ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendAsync[WILDCARD] ([WILDCARD]dispatch_json.ts:[WILDCARD])

--- a/cli/tests/error_005_missing_dynamic_import.ts.out
+++ b/cli/tests/error_005_missing_dynamic_import.ts.out
@@ -1,5 +1,5 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts" from "[WILDCARD]/error_005_missing_dynamic_import.ts"
-[WILDCARD]errors.ts:[WILDCARD]
+[WILDCARD]dispatch_json.ts:[WILDCARD]
     at NotFound ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendAsync[WILDCARD] ([WILDCARD]dispatch_json.ts:[WILDCARD])

--- a/cli/tests/error_006_import_ext_failure.ts.out
+++ b/cli/tests/error_006_import_ext_failure.ts.out
@@ -1,6 +1,5 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/non-existent" from "[WILDCARD]/error_006_import_ext_failure.ts"
 [WILDCARD]errors.ts:[WILDCARD]
     at NotFound ([WILDCARD]errors.ts:[WILDCARD])
-    at constructError ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendAsync[WILDCARD] ([WILDCARD]dispatch_json.ts:[WILDCARD])

--- a/cli/tests/error_006_import_ext_failure.ts.out
+++ b/cli/tests/error_006_import_ext_failure.ts.out
@@ -1,5 +1,5 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/non-existent" from "[WILDCARD]/error_006_import_ext_failure.ts"
-[WILDCARD]errors.ts:[WILDCARD]
+[WILDCARD]dispatch_json.ts:[WILDCARD]
     at NotFound ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at sendAsync[WILDCARD] ([WILDCARD]dispatch_json.ts:[WILDCARD])

--- a/cli/tests/error_011_bad_module_specifier.ts.out
+++ b/cli/tests/error_011_bad_module_specifier.ts.out
@@ -1,6 +1,5 @@
 [WILDCARD]error: Uncaught URIError: relative import path "bad-module.ts" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/error_011_bad_module_specifier.ts"
 [WILDCARD]errors.ts:[WILDCARD]
-    at constructError ($deno$/errors.ts:[WILDCARD])
     at unwrapResponse ($deno$/dispatch_json.ts:[WILDCARD])
     at sendSync ($deno$/dispatch_json.ts:[WILDCARD])
     at resolveModules ($deno$/compiler_imports.ts:[WILDCARD])

--- a/cli/tests/error_011_bad_module_specifier.ts.out
+++ b/cli/tests/error_011_bad_module_specifier.ts.out
@@ -1,5 +1,5 @@
 [WILDCARD]error: Uncaught URIError: relative import path "bad-module.ts" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/error_011_bad_module_specifier.ts"
-[WILDCARD]errors.ts:[WILDCARD]
+[WILDCARD]dispatch_json.ts:[WILDCARD]
     at unwrapResponse ($deno$/dispatch_json.ts:[WILDCARD])
     at sendSync ($deno$/dispatch_json.ts:[WILDCARD])
     at resolveModules ($deno$/compiler_imports.ts:[WILDCARD])

--- a/cli/tests/error_012_bad_dynamic_import_specifier.ts.out
+++ b/cli/tests/error_012_bad_dynamic_import_specifier.ts.out
@@ -1,5 +1,5 @@
 [WILDCARD]error: Uncaught URIError: relative import path "bad-module.ts" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/error_012_bad_dynamic_import_specifier.ts"
-[WILDCARD]errors.ts:[WILDCARD]
+[WILDCARD]dispatch_json.ts:[WILDCARD]
     at unwrapResponse ($deno$/dispatch_json.ts:[WILDCARD])
     at sendSync ($deno$/dispatch_json.ts:[WILDCARD])
     at resolveModules ($deno$/compiler_imports.ts:[WILDCARD])

--- a/cli/tests/error_012_bad_dynamic_import_specifier.ts.out
+++ b/cli/tests/error_012_bad_dynamic_import_specifier.ts.out
@@ -1,6 +1,5 @@
 [WILDCARD]error: Uncaught URIError: relative import path "bad-module.ts" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/error_012_bad_dynamic_import_specifier.ts"
 [WILDCARD]errors.ts:[WILDCARD]
-    at constructError ($deno$/errors.ts:[WILDCARD])
     at unwrapResponse ($deno$/dispatch_json.ts:[WILDCARD])
     at sendSync ($deno$/dispatch_json.ts:[WILDCARD])
     at resolveModules ($deno$/compiler_imports.ts:[WILDCARD])

--- a/cli/tests/error_type_definitions.ts.out
+++ b/cli/tests/error_type_definitions.ts.out
@@ -1,5 +1,5 @@
 [WILDCARD]error: Uncaught URIError: relative import path "baz" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/type_definitions/bar.d.ts"
-[WILDCARD]errors.ts:[WILDCARD]
+[WILDCARD]dispatch_json.ts:[WILDCARD]
     at unwrapResponse ($deno$/dispatch_json.ts:[WILDCARD])
     at sendSync ($deno$/dispatch_json.ts:[WILDCARD])
     at resolveModules ($deno$/compiler_imports.ts:[WILDCARD])

--- a/cli/tests/error_type_definitions.ts.out
+++ b/cli/tests/error_type_definitions.ts.out
@@ -1,6 +1,5 @@
 [WILDCARD]error: Uncaught URIError: relative import path "baz" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/type_definitions/bar.d.ts"
 [WILDCARD]errors.ts:[WILDCARD]
-    at constructError ($deno$/errors.ts:[WILDCARD])
     at unwrapResponse ($deno$/dispatch_json.ts:[WILDCARD])
     at sendSync ($deno$/dispatch_json.ts:[WILDCARD])
     at resolveModules ($deno$/compiler_imports.ts:[WILDCARD])


### PR DESCRIPTION
Flattens dispatch error handling to produce one less useless stack frame on op errors.

```js
await Deno.open("nonexistent").catch(console.log);
```
```diff
  NotFound: No such file or directory (os error 2)
-     at Object.constructError ($deno$/errors.ts:37:13)
      at unwrapResponse ($deno$/dispatch_json.ts:41:12)
      at Object.sendAsync ($deno$/dispatch_json.ts:96:10)
      at async Object.open ($deno$/files.ts:85:15)
      at async file:///mnt/c/Users/Nayeem/projects/deno/temp.js:1:1
```