### PR TITLE
Port Complex Permissions Tests to Rust 

### DIFF
--- a/cli/tests/complex_permissions_test.ts
+++ b/cli/tests/complex_permissions_test.ts
@@ -1,0 +1,46 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+const { args, readFileSync, writeFileSync, exit } = Deno;
+
+const name = args[0];
+const test: { [key: string]: Function } = {
+  read(files: string[]): void {
+    files.forEach(file => readFileSync(file));
+  },
+  write(files: string[]): void {
+    files.forEach(file =>
+      writeFileSync(file, new Uint8Array(0), { append: true })
+    );
+  },
+  netFetch(hosts: string[]): void {
+    hosts.forEach(host => fetch(host));
+  },
+  netListen(endpoints: string[]): void {
+    endpoints.forEach(endpoint => {
+      const [hostname, port] = endpoint.split(":");
+      const listener = Deno.listen({
+        transport: "tcp",
+        hostname,
+        port: parseInt(port, 10)
+      });
+      listener.close();
+    });
+  },
+  async netConnect(endpoints: string[]): Promise<void> {
+    for (const endpoint of endpoints) {
+      const [hostname, port] = endpoint.split(":");
+      const listener = await Deno.connect({
+        transport: "tcp",
+        hostname,
+        port: parseInt(port, 10)
+      });
+      listener.close();
+    }
+  }
+};
+
+if (!test[name]) {
+  console.log("Unknown test:", name);
+  exit(1);
+}
+
+test[name](args.slice(1));

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -442,6 +442,7 @@ fn repl_test_console_log() {
     "repl",
     Some(vec!["console.log('hello')", "'world'"]),
     None,
+    false,
   );
   assert_eq!(out, "hello\nundefined\nworld\n");
   assert!(err.is_empty());
@@ -451,7 +452,7 @@ fn repl_test_console_log() {
 #[test]
 fn repl_test_eof() {
   let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["1 + 2"]), None);
+    util::run_and_collect_output("repl", Some(vec!["1 + 2"]), None, false);
   assert_eq!(out, "3\n");
   assert!(err.is_empty());
   assert_eq!(code, 0);
@@ -459,8 +460,12 @@ fn repl_test_eof() {
 
 #[test]
 fn repl_test_exit_command() {
-  let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["exit", "'ignored'"]), None);
+  let (out, err, code) = util::run_and_collect_output(
+    "repl",
+    Some(vec!["exit", "'ignored'"]),
+    None,
+    false,
+  );
   assert!(out.is_empty());
   assert!(err.is_empty());
   assert_eq!(code, 0);
@@ -469,7 +474,7 @@ fn repl_test_exit_command() {
 #[test]
 fn repl_test_help_command() {
   let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["help"]), None);
+    util::run_and_collect_output("repl", Some(vec!["help"]), None, false);
   assert_eq!(
     out,
     vec![
@@ -491,6 +496,7 @@ fn repl_test_function() {
     "repl",
     Some(vec!["Deno.writeFileSync"]),
     None,
+    false,
   );
   assert_eq!(out, "[Function: writeFileSync]\n");
   assert!(err.is_empty());
@@ -499,8 +505,12 @@ fn repl_test_function() {
 
 #[test]
 fn repl_test_multiline() {
-  let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["(\n1 + 2\n)"]), None);
+  let (out, err, code) = util::run_and_collect_output(
+    "repl",
+    Some(vec!["(\n1 + 2\n)"]),
+    None,
+    false,
+  );
   assert_eq!(out, "3\n");
   assert!(err.is_empty());
   assert_eq!(code, 0);
@@ -509,7 +519,7 @@ fn repl_test_multiline() {
 #[test]
 fn repl_test_eval_unterminated() {
   let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["eval('{')"]), None);
+    util::run_and_collect_output("repl", Some(vec!["eval('{')"]), None, false);
   assert!(out.is_empty());
   assert!(err.contains("Unexpected end of input"));
   assert_eq!(code, 0);
@@ -517,8 +527,12 @@ fn repl_test_eval_unterminated() {
 
 #[test]
 fn repl_test_reference_error() {
-  let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["not_a_variable"]), None);
+  let (out, err, code) = util::run_and_collect_output(
+    "repl",
+    Some(vec!["not_a_variable"]),
+    None,
+    false,
+  );
   assert!(out.is_empty());
   assert!(err.contains("not_a_variable is not defined"));
   assert_eq!(code, 0);
@@ -526,8 +540,12 @@ fn repl_test_reference_error() {
 
 #[test]
 fn repl_test_syntax_error() {
-  let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["syntax error"]), None);
+  let (out, err, code) = util::run_and_collect_output(
+    "repl",
+    Some(vec!["syntax error"]),
+    None,
+    false,
+  );
   assert!(out.is_empty());
   assert!(err.contains("Unexpected identifier"));
   assert_eq!(code, 0);
@@ -536,7 +554,7 @@ fn repl_test_syntax_error() {
 #[test]
 fn repl_test_type_error() {
   let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["console()"]), None);
+    util::run_and_collect_output("repl", Some(vec!["console()"]), None, false);
   assert!(out.is_empty());
   assert!(err.contains("console is not a function"));
   assert_eq!(code, 0);
@@ -544,8 +562,12 @@ fn repl_test_type_error() {
 
 #[test]
 fn repl_test_variable() {
-  let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["var a = 123;", "a"]), None);
+  let (out, err, code) = util::run_and_collect_output(
+    "repl",
+    Some(vec!["var a = 123;", "a"]),
+    None,
+    false,
+  );
   assert_eq!(out, "undefined\n123\n");
   assert!(err.is_empty());
   assert_eq!(code, 0);
@@ -553,8 +575,12 @@ fn repl_test_variable() {
 
 #[test]
 fn repl_test_lexical_scoped_variable() {
-  let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["let a = 123;", "a"]), None);
+  let (out, err, code) = util::run_and_collect_output(
+    "repl",
+    Some(vec!["let a = 123;", "a"]),
+    None,
+    false,
+  );
   assert_eq!(out, "undefined\n123\n");
   assert!(err.is_empty());
   assert_eq!(code, 0);
@@ -570,6 +596,7 @@ fn repl_test_missing_deno_dir() {
     "repl",
     Some(vec!["1"]),
     Some(vec![("DENO_DIR".to_owned(), DENO_DIR.to_owned())]),
+    false,
   );
   assert!(read_dir(&test_deno_dir).is_ok());
   remove_dir_all(&test_deno_dir).unwrap();
@@ -581,7 +608,7 @@ fn repl_test_missing_deno_dir() {
 #[test]
 fn repl_test_save_last_eval() {
   let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["1", "_"]), None);
+    util::run_and_collect_output("repl", Some(vec!["1", "_"]), None, false);
   assert_eq!(out, "1\n1\n");
   assert!(err.is_empty());
   assert_eq!(code, 0);
@@ -589,8 +616,12 @@ fn repl_test_save_last_eval() {
 
 #[test]
 fn repl_test_save_last_thrown() {
-  let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["throw 1", "_error"]), None);
+  let (out, err, code) = util::run_and_collect_output(
+    "repl",
+    Some(vec!["throw 1", "_error"]),
+    None,
+    false,
+  );
   assert_eq!(out, "1\n");
   assert_eq!(err, "Thrown: 1\n");
   assert_eq!(code, 0);
@@ -598,8 +629,12 @@ fn repl_test_save_last_thrown() {
 
 #[test]
 fn repl_test_assign_underscore() {
-  let (out, err, code) =
-    util::run_and_collect_output("repl", Some(vec!["_ = 1", "2", "_"]), None);
+  let (out, err, code) = util::run_and_collect_output(
+    "repl",
+    Some(vec!["_ = 1", "2", "_"]),
+    None,
+    false,
+  );
   assert_eq!(
     out,
     "Last evaluation result is no longer saved to _.\n1\n2\n1\n"
@@ -614,6 +649,7 @@ fn repl_test_assign_underscore_error() {
     "repl",
     Some(vec!["_error = 1", "throw 2", "_error"]),
     None,
+    false,
   );
   assert_eq!(
     out,
@@ -1476,6 +1512,7 @@ fn test_permissions_with_allow() {
       &format!("run --allow-{0} permission_test.ts {0}Required", permission),
       None,
       None,
+      false,
     );
     assert_eq!(code, 0);
     assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
@@ -1489,10 +1526,329 @@ fn test_permissions_without_allow() {
       &format!("run permission_test.ts {0}Required", permission),
       None,
       None,
+      false,
     );
     assert_eq!(code, 1);
     assert!(err.contains(util::PERMISSION_DENIED_PATTERN));
   }
+}
+
+#[test]
+fn test_permissions_rw_inside_project_dir() {
+  const PERMISSION_VARIANTS: [&str; 2] = ["read", "write"];
+  for permission in &PERMISSION_VARIANTS {
+    let (_, err, code) = util::run_and_collect_output(
+      &format!(
+        "run --allow-{0}={1} complex_permissions_test.ts {0} {2} {2}",
+        permission,
+        util::root_path().into_os_string().into_string().unwrap(),
+        "complex_permissions_test.ts"
+      ),
+      None,
+      None,
+      false,
+    );
+    assert_eq!(code, 0);
+    assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+  }
+}
+
+#[test]
+fn test_permissions_rw_outside_test_dir() {
+  const PERMISSION_VARIANTS: [&str; 2] = ["read", "write"];
+  for permission in &PERMISSION_VARIANTS {
+    let (_, err, code) = util::run_and_collect_output(
+      &format!(
+        "run --allow-{0}={1} complex_permissions_test.ts {0} {2}",
+        permission,
+        util::root_path()
+          .join("cli")
+          .join("tests")
+          .into_os_string()
+          .into_string()
+          .unwrap(),
+        util::root_path()
+          .join("Cargo.toml")
+          .into_os_string()
+          .into_string()
+          .unwrap(),
+      ),
+      None,
+      None,
+      false,
+    );
+    assert_eq!(code, 1);
+    assert!(err.contains(util::PERMISSION_DENIED_PATTERN));
+  }
+}
+
+#[test]
+fn test_permissions_rw_inside_test_dir() {
+  const PERMISSION_VARIANTS: [&str; 2] = ["read", "write"];
+  for permission in &PERMISSION_VARIANTS {
+    let (_, err, code) = util::run_and_collect_output(
+      &format!(
+        "run --allow-{0}={1} complex_permissions_test.ts {0} {2}",
+        permission,
+        util::root_path()
+          .join("cli")
+          .join("tests")
+          .into_os_string()
+          .into_string()
+          .unwrap(),
+        "complex_permissions_test.ts"
+      ),
+      None,
+      None,
+      false,
+    );
+    assert_eq!(code, 0);
+    assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+  }
+}
+
+#[test]
+fn test_permissions_rw_outside_test_and_js_dir() {
+  const PERMISSION_VARIANTS: [&str; 2] = ["read", "write"];
+  let test_dir = util::root_path()
+    .join("cli")
+    .join("tests")
+    .into_os_string()
+    .into_string()
+    .unwrap();
+  let js_dir = util::root_path()
+    .join("js")
+    .into_os_string()
+    .into_string()
+    .unwrap();
+  for permission in &PERMISSION_VARIANTS {
+    let (_, err, code) = util::run_and_collect_output(
+      &format!(
+        "run --allow-{0}={1},{2} complex_permissions_test.ts {0} {3}",
+        permission,
+        test_dir,
+        js_dir,
+        util::root_path()
+          .join("Cargo.toml")
+          .into_os_string()
+          .into_string()
+          .unwrap(),
+      ),
+      None,
+      None,
+      false,
+    );
+    assert_eq!(code, 1);
+    assert!(err.contains(util::PERMISSION_DENIED_PATTERN));
+  }
+}
+
+#[test]
+fn test_permissions_rw_inside_test_and_js_dir() {
+  const PERMISSION_VARIANTS: [&str; 2] = ["read", "write"];
+  let test_dir = util::root_path()
+    .join("cli")
+    .join("tests")
+    .into_os_string()
+    .into_string()
+    .unwrap();
+  let js_dir = util::root_path()
+    .join("js")
+    .into_os_string()
+    .into_string()
+    .unwrap();
+  for permission in &PERMISSION_VARIANTS {
+    let (_, err, code) = util::run_and_collect_output(
+      &format!(
+        "run --allow-{0}={1},{2} complex_permissions_test.ts {0} {3}",
+        permission, test_dir, js_dir, "complex_permissions_test.ts"
+      ),
+      None,
+      None,
+      false,
+    );
+    assert_eq!(code, 0);
+    assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+  }
+}
+
+#[test]
+fn test_permissions_rw_relative() {
+  const PERMISSION_VARIANTS: [&str; 2] = ["read", "write"];
+  for permission in &PERMISSION_VARIANTS {
+    let (_, err, code) = util::run_and_collect_output(
+      &format!(
+				"run --allow-{0}=. complex_permissions_test.ts {0} complex_permissions_test.ts",
+				permission
+			),
+      None,
+      None,
+      false,
+    );
+    assert_eq!(code, 0);
+    assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+  }
+}
+
+#[test]
+fn test_permissions_rw_no_prefix() {
+  const PERMISSION_VARIANTS: [&str; 2] = ["read", "write"];
+  for permission in &PERMISSION_VARIANTS {
+    let (_, err, code) = util::run_and_collect_output(
+			&format!(
+				"run --allow-{0}=tls/../ complex_permissions_test.ts {0} complex_permissions_test.ts",
+				permission
+			),
+			None,
+			None,
+			false,
+		);
+    assert_eq!(code, 0);
+    assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+  }
+}
+
+#[test]
+fn test_permissions_net_fetch_allow_localhost_4545() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=localhost:4545 complex_permissions_test.ts netFetch http://localhost:4545/",
+			None,
+			None,true,
+		);
+  assert_eq!(code, 0);
+  assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
+fn test_permissions_net_fetch_allow_deno_land() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=deno.land complex_permissions_test.ts netFetch http://localhost:4545/",
+			None,
+			None,
+			true,
+		);
+  assert_eq!(code, 1);
+  assert!(err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
+fn test_permissions_net_fetch_localhost_4545_fail() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=localhost:4545 complex_permissions_test.ts netFetch http://localhost:4546/",
+			None,
+			None,
+			true,
+		);
+  assert_eq!(code, 1);
+  assert!(err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
+fn test_permissions_net_fetch_localhost() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=localhost complex_permissions_test.ts netFetch http://localhost:4545/ http://localhost:4546/ http://localhost:4547/",
+			None,
+			None,
+			true,
+		);
+  assert_eq!(code, 0);
+  assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
+fn test_permissions_net_connect_allow_localhost_ip_4555() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=127.0.0.1:4545 complex_permissions_test.ts netConnect 127.0.0.1:4545",
+			None,
+			None,
+			true,
+		);
+  assert_eq!(code, 0);
+  assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
+fn test_permissions_net_connect_allow_deno_land() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=deno.land complex_permissions_test.ts netConnect 127.0.0.1:4546",
+			None,
+			None,
+			true,
+		);
+  assert_eq!(code, 1);
+  assert!(err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
+fn test_permissions_net_connect_allow_localhost_ip_4545_fail() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=127.0.0.1:4545 complex_permissions_test.ts netConnect 127.0.0.1:4546",
+			None,
+			None,
+			true,
+		);
+  assert_eq!(code, 1);
+  assert!(err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
+fn test_permissions_net_connect_allow_localhost_ip() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=127.0.0.1 complex_permissions_test.ts netConnect 127.0.0.1:4545 127.0.0.1:4546 127.0.0.1:4547",
+			None,
+			None,
+			true,
+		);
+  assert_eq!(code, 0);
+  assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
+fn test_permissions_net_listen_allow_localhost_4555() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=localhost:4558 complex_permissions_test.ts netListen localhost:4558",
+			None,
+			None,
+			false,
+		);
+  assert_eq!(code, 0);
+  assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
+fn test_permissions_net_listen_allow_deno_land() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=deno.land complex_permissions_test.ts netListen localhost:4545",
+			None,
+			None,
+			false,
+		);
+  assert_eq!(code, 1);
+  assert!(err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
+fn test_permissions_net_listen_allow_localhost_4555_fail() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=localhost:4555 complex_permissions_test.ts netListen localhost:4556",
+			None,
+			None,
+			false,
+		);
+  assert_eq!(code, 1);
+  assert!(err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
+fn test_permissions_net_listen_allow_localhost() {
+  let (_, err, code) = util::run_and_collect_output(
+			"run --allow-net=localhost complex_permissions_test.ts netListen localhost:4545 localhost:4546 localhost:4547",
+			None,
+			None,
+			false,
+		);
+  assert_eq!(code, 0);
+  assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
 }
 
 mod util {
@@ -1518,6 +1874,7 @@ mod util {
     args: &str,
     input: Option<Vec<&str>>,
     envs: Option<Vec<(String, String)>>,
+    need_http_server: bool,
   ) -> (String, String, i32) {
     let root = root_path();
     let tests_dir = root.join("cli").join("tests");
@@ -1531,6 +1888,11 @@ mod util {
     if let Some(envs) = envs {
       deno_process_builder.envs(envs);
     }
+    let http_guard = if need_http_server {
+      Some(http_server())
+    } else {
+      None
+    };
     let mut deno = deno_process_builder
       .spawn()
       .expect("failed to spawn script");
@@ -1545,6 +1907,7 @@ mod util {
       stderr,
       status,
     } = deno.wait_with_output().expect("failed to wait on child");
+    drop(http_guard);
     (
       String::from_utf8(stdout).unwrap(),
       String::from_utf8(stderr).unwrap(),


### PR DESCRIPTION
This PR should close the task Port `complex_permissions_tests` to Rust currently open on #2988. It should also close #3129.