### PR TITLE
feat(std/node): add os.tmpdir() implementation

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -116,6 +116,7 @@ declare namespace Deno {
     | "picture"
     | "public"
     | "template"
+    | "tmp"
     | "video";
 
   // TODO(ry) markdown in jsdoc broken https://deno.land/typedoc/index.html#dir
@@ -131,7 +132,7 @@ declare namespace Deno {
    *
    * Argument values: `"home"`, `"cache"`, `"config"`, `"executable"`, `"data"`,
    * `"data_local"`, `"audio"`, `"desktop"`, `"document"`, `"download"`,
-   * `"font"`, `"picture"`, `"public"`, `"template"`, `"video"`
+   * `"font"`, `"picture"`, `"public"`, `"template"`, `"tmp"`, `"video"`
    *
    * `"cache"`
    *
@@ -236,6 +237,14 @@ declare namespace Deno {
    * | Linux   | `XDG_TEMPLATES_DIR`    | /home/alice/Templates                                      |
    * | macOS   | –                      | –                                                          |
    * | Windows | `{FOLDERID_Templates}` | C:\Users\Alice\AppData\Roaming\Microsoft\Windows\Templates |
+   *
+   * `"tmp"`
+   *
+   * |Platform | Value                  | Example                                                    |
+   * | ------- | ---------------------- | ---------------------------------------------------------- |
+   * | Linux   | `TMPDIR`               | /tmp                                                       |
+   * | macOS   | `TMPDIR`               | /tmp                                                       |
+   * | Windows | `{TMP}`                | C:\Users\Alice\AppData\Local\Temp                          |
    *
    * `"video"`
    *

--- a/cli/js/os.ts
+++ b/cli/js/os.ts
@@ -88,6 +88,7 @@ type DirKind =
   | "picture"
   | "public"
   | "template"
+  | "tmp"
   | "video";
 
 /**
@@ -190,6 +191,14 @@ type DirKind =
  * | Linux   | `XDG_TEMPLATES_DIR`    | /home/alice/Templates                                      |
  * | macOS   | –                      | –                                                          |
  * | Windows | `{FOLDERID_Templates}` | C:\Users\Alice\AppData\Roaming\Microsoft\Windows\Templates |
+ *
+ * "tmp"
+ *
+ * |Platform | Value                  | Example                                                    |
+ * | ------- | ---------------------- | ---------------------------------------------------------- |
+ * | Linux   | `TMPDIR`               | /tmp                                                       |
+ * | macOS   | `TMPDIR`               | /tmp                                                       |
+ * | Windows | `{TMP}`                | C:\Users\Alice\AppData\Local\Temp                          |
  *
  * "video"
  * |Platform | Value               | Example               |

--- a/cli/js/os_test.ts
+++ b/cli/js/os_test.ts
@@ -234,6 +234,14 @@ testPerm({ env: true }, function getDir(): void {
       ]
     },
     {
+      kind: "tmp",
+      runtime: [
+        { os: "mac", shouldHaveValue: true },
+        { os: "win", shouldHaveValue: true },
+        { os: "linux", shouldHaveValue: true }
+      ]
+    },
+    {
       kind: "video",
       runtime: [
         { os: "mac", shouldHaveValue: true },

--- a/cli/ops/os.rs
+++ b/cli/ops/os.rs
@@ -49,6 +49,7 @@ fn op_get_dir(
     "picture" => dirs::picture_dir(),
     "public" => dirs::public_dir(),
     "template" => dirs::template_dir(),
+    "tmp" => Some(std::env::temp_dir()),
     "video" => dirs::video_dir(),
     _ => {
       return Err(

--- a/std/node/os.ts
+++ b/std/node/os.ts
@@ -180,9 +180,9 @@ export function setPriority(pid: number, priority?: number): void {
   notImplemented(SEE_GITHUB_ISSUE);
 }
 
-/** Not yet implemented */
-export function tmpdir(): string {
-  notImplemented(SEE_GITHUB_ISSUE);
+/** Returns the operating system's default directory for temporary files as a string. */
+export function tmpdir(): string | null {
+  return Deno.dir("tmp");
 }
 
 /** Not yet implemented */

--- a/std/node/os_test.ts
+++ b/std/node/os_test.ts
@@ -17,6 +17,13 @@ test({
 });
 
 test({
+  name: "tmp directory is a string",
+  fn() {
+    assertEquals(typeof os.tmpdir(), "string");
+  }
+});
+
+test({
   name: "hostname is a string",
   fn() {
     assertEquals(typeof os.hostname(), "string");
@@ -226,13 +233,6 @@ test({
     assertThrows(
       () => {
         os.setPriority(0);
-      },
-      Error,
-      "Not implemented"
-    );
-    assertThrows(
-      () => {
-        os.tmpdir();
       },
       Error,
       "Not implemented"


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
this PR implement node os.tmpdir() function. see #3802 and #3403 .

i just extended current `Deno.dir(kind)` to support tmp directory.