### PR TITLE
Fix JavaScript dependencies in bundles.

### DIFF
--- a/cli/js/compiler_api_test.ts
+++ b/cli/js/compiler_api_test.ts
@@ -135,6 +135,15 @@ test(async function bundleApiConfig() {
   assert(!actual.includes(`random`));
 });
 
+test(async function bundleApiJsModules() {
+  const [diagnostics, actual] = await bundle("/foo.js", {
+    "/foo.js": `export * from "./bar.js";\n`,
+    "/bar.js": `export const bar = "bar";\n`
+  });
+  assert(diagnostics == null);
+  assert(actual.includes(`System.register("bar",`));
+});
+
 test(async function diagnosticsTest() {
   const [diagnostics] = await compile("/foo.ts", {
     "/foo.ts": `document.getElementById("foo");`

--- a/cli/js/compiler_host.ts
+++ b/cli/js/compiler_host.ts
@@ -37,6 +37,7 @@ export interface ConfigureResponse {
 /** Options that need to be used when generating a bundle (either trusted or
  * runtime). */
 export const defaultBundlerOptions: ts.CompilerOptions = {
+  allowJs: true,
   inlineSourceMap: false,
   module: ts.ModuleKind.System,
   outDir: undefined,

--- a/cli/js/compiler_imports.ts
+++ b/cli/js/compiler_imports.ts
@@ -120,7 +120,7 @@ export function processLocalImports(
   sources: Record<string, string>,
   specifiers: Array<[string, string]>,
   referrer?: string,
-  checkJs = false
+  processJsImports = false
 ): string[] {
   if (!specifiers.length) {
     return [];
@@ -145,9 +145,9 @@ export function processLocalImports(
     if (!sourceFile.processed) {
       processLocalImports(
         sources,
-        sourceFile.imports(checkJs),
+        sourceFile.imports(processJsImports),
         sourceFile.url,
-        checkJs
+        processJsImports
       );
     }
   }
@@ -163,7 +163,7 @@ export function processLocalImports(
 export async function processImports(
   specifiers: Array<[string, string]>,
   referrer?: string,
-  checkJs = false
+  processJsImports = false
 ): Promise<string[]> {
   if (!specifiers.length) {
     return [];
@@ -179,9 +179,9 @@ export async function processImports(
     sourceFile.cache(specifiers[i][0], referrer);
     if (!sourceFile.processed) {
       await processImports(
-        sourceFile.imports(checkJs),
+        sourceFile.imports(processJsImports),
         sourceFile.url,
-        checkJs
+        processJsImports
       );
     }
   }

--- a/cli/js/compiler_sourcefile.ts
+++ b/cli/js/compiler_sourcefile.ts
@@ -91,7 +91,7 @@ export class SourceFile {
   }
 
   /** Process the imports for the file and return them. */
-  imports(checkJs: boolean): Array<[string, string]> {
+  imports(processJsImports: boolean): Array<[string, string]> {
     if (this.processed) {
       throw new Error("SourceFile has already been processed.");
     }
@@ -134,7 +134,7 @@ export class SourceFile {
       }
     } else if (
       !(
-        !checkJs &&
+        !processJsImports &&
         (this.mediaType === MediaType.JavaScript ||
           this.mediaType === MediaType.JSX)
       )

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -437,6 +437,36 @@ fn bundle_tla() {
 }
 
 #[test]
+fn bundle_js() {
+  use tempfile::TempDir;
+
+  // First we have to generate a bundle of some module that has exports.
+  let mod6 = util::root_path().join("cli/tests/subdir/mod6.js");
+  assert!(mod6.is_file());
+  let t = TempDir::new().expect("tempdir fail");
+  let bundle = t.path().join("mod6.bundle.js");
+  let mut deno = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("bundle")
+    .arg(mod6)
+    .arg(&bundle)
+    .spawn()
+    .expect("failed to spawn script");
+  let status = deno.wait().expect("failed to wait for the child process");
+  assert!(status.success());
+  assert!(bundle.is_file());
+
+  let output = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("run")
+    .arg(&bundle)
+    .output()
+    .expect("failed to spawn script");
+  // check that nothing went to stderr
+  assert_eq!(output.stderr, b"");
+}
+
+#[test]
 fn repl_test_console_log() {
   let (out, err, code) = util::run_and_collect_output(
     "repl",


### PR DESCRIPTION
Ref #4206 

We turned off `allowJs` by default, to keep the compiler from grabbing a bunch of files that it wouldn't actually do anything useful with.  On the other hand, this caused problems with bundles, where the compiler needs to gather all the dependencies, including JavaScript ones.  This PR fixes this so that when we are bundling, we analyse JavaScript imports in the compiler.
