### PR TITLE
Assert success on build_test_plugin

### DIFF
--- a/test_plugin/tests/integration_tests.rs
+++ b/test_plugin/tests/integration_tests.rs
@@ -23,7 +23,8 @@ fn basic() {
   if BUILD_VARIANT == "release" {
     build_plugin = build_plugin.arg("--release");
   }
-  let _build_plugin_output = build_plugin.output().unwrap();
+  let build_plugin_output = build_plugin.output().unwrap();
+  assert!(build_plugin_output.status.success());
   let output = deno_cmd()
     .arg("--allow-plugin")
     .arg("tests/test.js")


### PR DESCRIPTION
The `ubuntu-test-debug` check will fail on the basic test located on `test_plugin/tests/integration_tests.rs` if the build_plugin `Command` isn't successful. This command is silent so there is no information that this was the cause.

**Example:** If a change is made somewhere that causes the build_plugin `Command` to fail, but there was a successful build in the past, then `cargo test basic` will be successful on local but it will fail on the CI `ubuntu-test-debug` check.

This PR ensures that the build must be successful. 