### PR TITLE
refactor: Rust filesystem modules

### DIFF
--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -49,8 +49,9 @@ pub fn write_file_2<T: AsRef<[u8]>>(
 
 #[cfg(unix)]
 fn set_permissions(file: &mut File, perm: u32) -> std::io::Result<()> {
-  debug!("set file perm to {}", perm);
-  file.set_permissions(PermissionsExt::from_mode(perm & 0o777))
+  let perm = perm & 0o777;
+  debug!("set file perm to {:o}", perm);
+  file.set_permissions(PermissionsExt::from_mode(perm))
 }
 
 #[cfg(not(unix))]
@@ -95,7 +96,7 @@ pub fn make_temp(
 }
 
 pub fn mkdir(path: &Path, perm: u32, recursive: bool) -> std::io::Result<()> {
-  debug!("mkdir -p {}", path.display());
+  // debug!("mkdir -p {}", path.display());
   let mut builder = DirBuilder::new();
   builder.recursive(recursive);
   set_dir_permission(&mut builder, perm);
@@ -104,8 +105,9 @@ pub fn mkdir(path: &Path, perm: u32, recursive: bool) -> std::io::Result<()> {
 
 #[cfg(unix)]
 fn set_dir_permission(builder: &mut DirBuilder, perm: u32) {
-  debug!("set dir perm to {}", perm);
-  builder.mode(perm & 0o777);
+  let perm = perm & 0o777;
+  debug!("set dir perm to {:o}", perm);
+  builder.mode(perm);
 }
 
 #[cfg(not(unix))]

--- a/cli/ops/files.rs
+++ b/cli/ops/files.rs
@@ -204,6 +204,7 @@ fn op_seek(
   let mut file = futures::executor::block_on(tokio_file.try_clone())?;
 
   let fut = async move {
+    debug!("op_seek {} {} {}", rid, offset, whence);
     let pos = file.seek(seek_from).await?;
     Ok(json!(pos))
   };

--- a/cli/ops/files.rs
+++ b/cli/ops/files.rs
@@ -10,7 +10,7 @@ use std;
 use std::convert::From;
 use std::io::SeekFrom;
 use std::path::Path;
-use tokio;
+use tokio::fs as tokio_fs;
 
 pub fn init(i: &mut Isolate, s: &State) {
   i.register_op("op_open", s.stateful_json_op(op_open));
@@ -47,7 +47,7 @@ fn op_open(
   let args: OpenArgs = serde_json::from_value(args)?;
   let filename = deno_fs::resolve_from_cwd(Path::new(&args.filename))?;
   let state_ = state.clone();
-  let mut open_options = tokio::fs::OpenOptions::new();
+  let mut open_options = tokio_fs::OpenOptions::new();
 
   if let Some(options) = args.options {
     if options.read {

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -12,6 +12,8 @@ use std::fs;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
 
+use utime::set_file_times;
+
 #[cfg(unix)]
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
@@ -616,7 +618,7 @@ fn op_utime(
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_utime {} {} {}", args.filename, args.atime, args.mtime);
-    utime::set_file_times(args.filename, args.atime, args.mtime)?;
+    set_file_times(args.filename, args.atime, args.mtime)?;
     Ok(json!({}))
   })
 }

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -429,7 +429,7 @@ fn op_link(
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_link {} {}", oldname.display(), newname.display());
-    std::fs::hard_link(&oldname, &newname)?;
+    fs::hard_link(&oldname, &newname)?;
     Ok(json!({}))
   })
 }

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -72,7 +72,12 @@ fn op_mkdir(
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_mkdir {}", path.display());
+    debug!(
+      "op_mkdir {} {:o} {}",
+      path.display(),
+      args.mode,
+      args.recursive
+    );
     deno_fs::mkdir(&path, args.mode, args.recursive)?;
     Ok(json!({}))
   })
@@ -99,11 +104,11 @@ fn op_chmod(
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_chmod {}", path.display());
     // Still check file/dir exists on windows
     let _metadata = fs::metadata(&path)?;
     #[cfg(unix)]
     {
+      debug!("op_chmod {} {:o}", path.display(), args.mode);
       let mut permissions = _metadata.permissions();
       permissions.set_mode(args.mode);
       fs::set_permissions(&path, permissions)?;
@@ -133,7 +138,7 @@ fn op_chown(
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_chown {}", path.display());
+    debug!("op_chown {} {} {}", path.display(), args.uid, args.gid);
     deno_fs::chown(args.path.as_ref(), args.uid, args.gid)?;
     Ok(json!({}))
   })
@@ -160,8 +165,8 @@ fn op_remove(
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_remove {}", path.display());
     let metadata = fs::symlink_metadata(&path)?;
+    debug!("op_remove {} {}", path.display(), recursive);
     let file_type = metadata.file_type();
     if file_type.is_file() || file_type.is_symlink() {
       fs::remove_file(&path)?;
@@ -194,9 +199,9 @@ fn op_copy_file(
   state.check_read(&from)?;
   state.check_write(&to)?;
 
-  debug!("op_copy_file {} {}", from.display(), to.display());
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
+    debug!("op_copy_file {} {}", from.display(), to.display());
     // On *nix, Rust reports non-existent `from` as ErrorKind::InvalidInput
     // See https://github.com/rust-lang/rust/issues/54800
     // Once the issue is resolved, we should remove this workaround.


### PR DESCRIPTION
This is part of a series of smaller PRs towards #4017.

It improves debug! calls, and does some other cleanup-type refactoring in Rust filesystem modules.
