### PR TITLE
WIP: get better frame info from prepareStackTrace

### DIFF
--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -153,9 +153,21 @@ fn format_stack_frame(frame: &JSStackFrame, is_internal_frame: bool) -> String {
     source_loc = colors::gray(source_loc).to_string();
   }
   if !frame.function_name.is_empty() {
-    format!("{} {} {}", at_prefix, function_name, source_loc)
+    if frame.is_async {
+      format!(
+        "{} {} {} {}",
+        at_prefix,
+        colors::gray("async".to_owned()).to_string(),
+        function_name,
+        source_loc
+      )
+    } else {
+      format!("{} {} {}", at_prefix, function_name, source_loc)
+    }
   } else if frame.is_eval {
     format!("{} eval {}", at_prefix, source_loc)
+  } else if frame.is_async {
+    format!("{} async {}", at_prefix, source_loc)
   } else {
     format!("{} {}", at_prefix, source_loc)
   }
@@ -270,6 +282,7 @@ mod tests {
           function_name: "foo".to_string(),
           is_eval: false,
           is_constructor: false,
+          is_async: false,
         },
         JSStackFrame {
           line_number: 5,
@@ -278,6 +291,7 @@ mod tests {
           function_name: "qat".to_string(),
           is_eval: false,
           is_constructor: false,
+          is_async: false,
         },
         JSStackFrame {
           line_number: 1,
@@ -286,6 +300,7 @@ mod tests {
           function_name: "".to_string(),
           is_eval: false,
           is_constructor: false,
+          is_async: false,
         },
       ],
     };

--- a/cli/js/error_stack.ts
+++ b/cli/js/error_stack.ts
@@ -235,7 +235,9 @@ function prepareStackTrace(
   error: Error,
   structuredStackTrace: CallSite[]
 ): string {
-  return (
+  // @ts-ignore
+  error["__callSites"] = [];
+  const errorString =
     `${error.name}: ${error.message}\n` +
     structuredStackTrace
       .map(
@@ -256,9 +258,13 @@ function prepareStackTrace(
           return callSite;
         }
       )
-      .map((callSite): string => `    at ${callSiteToString(callSite)}`)
-      .join("\n")
-  );
+      .map((callSite): string => {
+        // @ts-ignore
+        error["__callSites"].push(callSite); // Save callsites to self
+        return `    at ${callSiteToString(callSite)}`;
+      })
+      .join("\n");
+  return errorString;
 }
 
 /** Sets the `prepareStackTrace` method on the Error constructor which will

--- a/cli/source_maps.rs
+++ b/cli/source_maps.rs
@@ -167,6 +167,7 @@ fn frame_apply_source_map<G: SourceMapGetter>(
     column,
     is_eval: frame.is_eval,
     is_constructor: frame.is_constructor,
+    is_async: frame.is_async,
   }
 }
 
@@ -308,6 +309,7 @@ mod tests {
           function_name: "foo".to_string(),
           is_eval: false,
           is_constructor: false,
+          is_async: false,
         },
         JSStackFrame {
           line_number: 5,
@@ -316,6 +318,7 @@ mod tests {
           function_name: "qat".to_string(),
           is_eval: false,
           is_constructor: false,
+          is_async: false,
         },
         JSStackFrame {
           line_number: 1,
@@ -324,6 +327,7 @@ mod tests {
           function_name: "".to_string(),
           is_eval: false,
           is_constructor: false,
+          is_async: false,
         },
       ],
     };
@@ -344,6 +348,7 @@ mod tests {
           function_name: "foo".to_string(),
           is_eval: false,
           is_constructor: false,
+          is_async: false,
         },
         JSStackFrame {
           line_number: 4,
@@ -352,6 +357,7 @@ mod tests {
           function_name: "qat".to_string(),
           is_eval: false,
           is_constructor: false,
+          is_async: false,
         },
         JSStackFrame {
           line_number: 1,
@@ -360,6 +366,7 @@ mod tests {
           function_name: "".to_string(),
           is_eval: false,
           is_constructor: false,
+          is_async: false,
         },
       ],
     };


### PR DESCRIPTION
This is a hacked-up demo of how to leverage `prepareStackTrace` to get better error messages. Currently there are errors if you try throwing non-error or call eval that errors, but those are problems that could be addressed easily after validating this demo.

Example:
```ts
await Deno.open("./BOOM");
```
Before (deno 0.35.0, thus there are a few more frames than master):
```
error: Uncaught NotFound: No such file or directory (os error 2)
► $deno$/errors.ts:37:13
    at NotFound ($deno$/errors.ts:75:5)
    at constructError ($deno$/errors.ts:37:13)
    at unwrapResponse ($deno$/dispatch_json.ts:41:12)
    at sendAsync ($deno$/dispatch_json.ts:96:10)
```

After:
```
error: Uncaught NotFound: No such file or directory (os error 2)
    at unwrapResponse ($deno$/dispatch_json.ts:42:12)
    at sendAsync ($deno$/dispatch_json.ts:97:11)
    at async open ($deno$/files.ts:94:16)
    at async file:///Users/kun/Projects/Deno/test/tla.ts:1:1
```
