### PR TITLE
refactor(cli/js/net): Cleanup iterable APIs

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1514,7 +1514,7 @@ declare namespace Deno {
   /** **UNSTABLE**: new API, yet to be vetted.
    *
    * A generic transport listener for message-oriented protocols. */
-  export interface UDPConn extends AsyncIterator<[Uint8Array, Addr]> {
+  export interface UDPConn extends AsyncIterable<[Uint8Array, Addr]> {
     /** **UNSTABLE**: new API, yet to be vetted.
      *
      * Waits for and resolves to the next message to the `UDPConn`. */
@@ -1534,7 +1534,7 @@ declare namespace Deno {
   }
 
   /** A generic network listener for stream-oriented protocols. */
-  export interface Listener extends AsyncIterator<Conn> {
+  export interface Listener extends AsyncIterable<Conn> {
     /** Waits for and resolves to the next connection to the `Listener`. */
     accept(): Promise<Conn>;
     /** Close closes the listener. Any pending accept promises will be rejected

--- a/cli/js/net.ts
+++ b/cli/js/net.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { errors } from "./errors.ts";
 import { EOF, Reader, Writer, Closer } from "./io.ts";
 import { read, write } from "./files.ts";
 import { close } from "./ops/resources.ts";
@@ -21,7 +22,7 @@ export interface UDPAddr {
 }
 
 /** A socket is a generic transport listener for message-oriented protocols */
-export interface UDPConn extends AsyncIterator<[Uint8Array, Addr]> {
+export interface UDPConn extends AsyncIterable<[Uint8Array, Addr]> {
   /** Waits for and resolves to the next message to the `Socket`. */
   receive(p?: Uint8Array): Promise<[Uint8Array, Addr]>;
 
@@ -40,7 +41,7 @@ export interface UDPConn extends AsyncIterator<[Uint8Array, Addr]> {
 }
 
 /** A Listener is a generic transport listener for stream-oriented protocols. */
-export interface Listener extends AsyncIterator<Conn> {
+export interface Listener extends AsyncIterable<Conn> {
   /** Waits for and resolves to the next connection to the `Listener`. */
   accept(): Promise<Conn>;
 
@@ -110,11 +111,7 @@ export class ConnImpl implements Conn {
 }
 
 export class ListenerImpl implements Listener {
-  constructor(
-    readonly rid: number,
-    readonly addr: Addr,
-    private closing: boolean = false
-  ) {}
+  constructor(readonly rid: number, readonly addr: Addr) {}
 
   async accept(): Promise<Conn> {
     const res = await sendAsync("op_accept", { rid: this.rid });
@@ -122,29 +119,20 @@ export class ListenerImpl implements Listener {
   }
 
   close(): void {
-    this.closing = true;
     close(this.rid);
   }
 
-  async next(): Promise<IteratorResult<Conn>> {
-    if (this.closing) {
-      return { value: undefined, done: true };
-    }
-    return await this.accept()
-      .then(value => ({ value, done: false }))
-      .catch(e => {
-        // It wouldn't be correct to simply check this.closing here.
-        // TODO: Get a proper error kind for this case, don't check the message.
-        // The current error kind is Other.
-        if (e.message == "Listener has been closed") {
-          return { value: undefined, done: true };
+  async *[Symbol.asyncIterator](): AsyncIterator<Conn> {
+    while (true) {
+      try {
+        yield await this.accept();
+      } catch (error) {
+        if (error instanceof errors.BadResource) {
+          break;
         }
-        throw e;
-      });
-  }
-
-  [Symbol.asyncIterator](): AsyncIterator<Conn> {
-    return this;
+        throw error;
+      }
+    }
   }
 }
 
@@ -160,8 +148,7 @@ export class UDPConnImpl implements UDPConn {
   constructor(
     readonly rid: number,
     readonly addr: Addr,
-    public bufSize: number = 1024,
-    private closing: boolean = false
+    public bufSize: number = 1024
   ) {}
 
   async receive(p?: Uint8Array): Promise<[Uint8Array, Addr]> {
@@ -179,29 +166,20 @@ export class UDPConnImpl implements UDPConn {
   }
 
   close(): void {
-    this.closing = true;
     close(this.rid);
   }
 
-  async next(): Promise<IteratorResult<[Uint8Array, Addr]>> {
-    if (this.closing) {
-      return { value: undefined, done: true };
-    }
-    return await this.receive()
-      .then(value => ({ value, done: false }))
-      .catch(e => {
-        // It wouldn't be correct to simply check this.closing here.
-        // TODO: Get a proper error kind for this case, don't check the message.
-        // The current error kind is Other.
-        if (e.message == "Socket has been closed") {
-          return { value: undefined, done: true };
+  async *[Symbol.asyncIterator](): AsyncIterator<[Uint8Array, Addr]> {
+    while (true) {
+      try {
+        yield await this.receive();
+      } catch (error) {
+        if (error instanceof errors.BadResource) {
+          break;
         }
-        throw e;
-      });
-  }
-
-  [Symbol.asyncIterator](): AsyncIterator<[Uint8Array, Addr]> {
-    return this;
+        throw error;
+      }
+    }
   }
 }
 

--- a/cli/ops/net.rs
+++ b/cli/ops/net.rs
@@ -56,7 +56,7 @@ fn op_accept(
       let listener_resource = resource_table
         .get_mut::<TcpListenerResource>(rid)
         .ok_or_else(|| {
-          OpError::other("Listener has been closed".to_string())
+          OpError::bad_resource("Listener has been closed".to_string())
         })?;
       let listener = &mut listener_resource.listener;
       match listener.poll_accept(cx).map_err(OpError::from) {
@@ -122,7 +122,9 @@ fn op_receive(
       let resource_table = &mut state_.borrow_mut().resource_table;
       let resource = resource_table
         .get_mut::<UdpSocketResource>(rid)
-        .ok_or_else(|| OpError::other("Socket has been closed".to_string()))?;
+        .ok_or_else(|| {
+          OpError::bad_resource("Socket has been closed".to_string())
+        })?;
       let socket = &mut resource.socket;
       socket.poll_recv_from(cx, &mut buf).map_err(OpError::from)
     });
@@ -168,7 +170,9 @@ fn op_send(
     let resource = state
       .resource_table
       .get_mut::<UdpSocketResource>(rid)
-      .ok_or_else(|| OpError::other("Socket has been closed".to_string()))?;
+      .ok_or_else(|| {
+        OpError::bad_resource("Socket has been closed".to_string())
+      })?;
 
     let socket = &mut resource.socket;
     let addr = resolve_addr(&args.hostname, args.port).await?;

--- a/cli/ops/tls.rs
+++ b/cli/ops/tls.rs
@@ -283,7 +283,7 @@ fn op_accept_tls(
       let listener_resource = resource_table
         .get_mut::<TlsListenerResource>(rid)
         .ok_or_else(|| {
-          OpError::other("Listener has been closed".to_string())
+          OpError::bad_resource("Listener has been closed".to_string())
         })?;
       let listener = &mut listener_resource.listener;
       match listener.poll_accept(cx).map_err(OpError::from) {


### PR DESCRIPTION
- `Listener` and `UDPConn` are `AsyncIterable`s instead of `AsyncIterator`s.
- The `[Symbol.asyncIterator]()`s are defined as generators and the `next()` methods are gone.
- Throw `BadResource` instead of `Other` on "* has been closed"  errors.
- Favour `try`/`catch` over `Promise::then()`/`Promise::catch()`.

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
