### PR TITLE
Fix `deno install` command name including dot on Windows

### DIFF
--- a/cli/installer.rs
+++ b/cli/installer.rs
@@ -143,7 +143,7 @@ pub fn install(
   let mut file_path = installation_dir.join(exec_name);
 
   if cfg!(windows) {
-    file_path = file_path.with_extension(".cmd");
+    file_path = file_path.with_extension("cmd");
   }
 
   if file_path.exists() && !force {
@@ -229,7 +229,7 @@ mod tests {
 
     let mut file_path = temp_dir.path().join(".deno/bin/echo_test");
     if cfg!(windows) {
-      file_path = file_path.with_extension(".cmd");
+      file_path = file_path.with_extension("cmd");
     }
 
     assert!(file_path.exists());
@@ -263,7 +263,7 @@ mod tests {
 
     let mut file_path = temp_dir.path().join("echo_test");
     if cfg!(windows) {
-      file_path = file_path.with_extension(".cmd");
+      file_path = file_path.with_extension("cmd");
     }
 
     assert!(file_path.exists());
@@ -292,7 +292,7 @@ mod tests {
 
     let mut file_path = temp_dir.path().join("echo_test");
     if cfg!(windows) {
-      file_path = file_path.with_extension(".cmd");
+      file_path = file_path.with_extension("cmd");
     }
 
     assert!(file_path.exists());
@@ -319,7 +319,7 @@ mod tests {
 
     let mut file_path = temp_dir.path().join("echo_test");
     if cfg!(windows) {
-      file_path = file_path.with_extension(".cmd");
+      file_path = file_path.with_extension("cmd");
     }
 
     assert!(file_path.exists());
@@ -343,7 +343,7 @@ mod tests {
 
     let mut file_path = temp_dir.path().join("echo_test");
     if cfg!(windows) {
-      file_path = file_path.with_extension(".cmd");
+      file_path = file_path.with_extension("cmd");
     }
     assert!(file_path.exists());
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -189,7 +189,7 @@ fn installer_test_local_module_run() {
   .expect("Failed to install");
   let mut file_path = temp_dir.path().join("echo_test");
   if cfg!(windows) {
-    file_path = file_path.with_extension(".cmd");
+    file_path = file_path.with_extension("cmd");
   }
   assert!(file_path.exists());
   let path_var_name = if cfg!(windows) { "Path" } else { "PATH" };
@@ -237,7 +237,7 @@ fn installer_test_remote_module_run() {
   .expect("Failed to install");
   let mut file_path = temp_dir.path().join("echo_test");
   if cfg!(windows) {
-    file_path = file_path.with_extension(".cmd");
+    file_path = file_path.with_extension("cmd");
   }
   assert!(file_path.exists());
   let path_var_name = if cfg!(windows) { "Path" } else { "PATH" };


### PR DESCRIPTION
The [`path.with_extension()`](https://doc.rust-lang.org/std/path/struct.Path.html#method.with_extension)'s arg expect just file extension not include dots like `cmd`
So passing extension starting with a dot, it returns a file path containing two dots like `file..cmd`
This means all commands installed with `demo install` end with a dot like `command.` on Windows

<details>
<summary>Current <code>deno install</code> behavior on Windows (log)</summary>
<pre><code>
PS D:\> deno install --allow-net --allow-read file_server https://deno.land/std/http/file_server.ts
Download https://deno.land/std/http/file_server.ts
Compile https://deno.land/std/http/file_server.ts
Download https://deno.land/std/path/mod.ts
Download https://deno.land/std/http/server.ts
Download https://deno.land/std/flags/mod.ts
Download https://deno.land/std/testing/asserts.ts
Download https://deno.land/std/http/io.ts
Download https://deno.land/std/path/win32.ts
Download https://deno.land/std/path/posix.ts
Download https://deno.land/std/path/constants.ts
Download https://deno.land/std/path/constants.ts
Download https://deno.land/std/path/interface.ts
Download https://deno.land/std/path/glob.ts
Download https://deno.land/std/path/globrex.ts
Download https://deno.land/std/path/utils.ts
Download https://deno.land/std/fmt/colors.ts
Download https://deno.land/std/testing/diff.ts
Download https://deno.land/std/testing/format.ts
Download https://deno.land/std/io/bufio.ts
Download https://deno.land/std/util/async.ts
Download https://deno.land/std/strings/mod.ts
Download https://deno.land/std/io/util.ts
Download https://deno.land/std/strings/encode.ts
Download https://deno.land/std/strings/decode.ts
Download https://deno.land/std/strings/pad.ts
Download https://deno.land/std/textproto/mod.ts
Download https://deno.land/std/http/http_status.ts
✅ Successfully installed file_server
C:\Users\yuta\.deno\bin\file_server..cmd
PS D:\> file_server
file_server : The term 'file_server' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:1
+ file_server
+ ~~~~~~~~~~~
+ CategoryInfo          : ObjectNotFound: (file_server:String) [], CommandNotFoundException
+ FullyQualifiedErrorId : CommandNotFoundException

PS D:\> file_server.

D:\>deno.exe "run" "--allow-read" "--allow-net" "https://deno.land/std/http/file_server.ts"
HTTP server listening on http://0.0.0.0:4500/
^C

PS D:\> file_server..cmd
D:\>deno.exe "run" "--allow-read" "--allow-net" "https://deno.land/std/http/file_server.ts"
HTTP server listening on http://0.0.0.0:4500/
^C
</code></pre>
</details>
