### PR TITLE
refactor(cli/op_error): Allow BadResource errors to take a message

### DIFF
--- a/cli/op_error.rs
+++ b/cli/op_error.rs
@@ -91,8 +91,13 @@ impl OpError {
     Self::new(ErrorKind::PermissionDenied, msg)
   }
 
-  pub fn bad_resource() -> OpError {
-    Self::new(ErrorKind::BadResource, "bad resource id".to_string())
+  pub fn bad_resource(msg: String) -> OpError {
+    Self::new(ErrorKind::BadResource, msg)
+  }
+
+  // BadResource usually needs no additional detail, hence this helper.
+  pub fn bad_resource_id() -> OpError {
+    Self::new(ErrorKind::BadResource, "Bad resource ID".to_string())
   }
 }
 
@@ -444,10 +449,18 @@ mod tests {
 
   #[test]
   fn test_bad_resource() {
-    let err = OpError::bad_resource();
+    let err = OpError::bad_resource("Resource has been closed".to_string());
     assert_eq!(err.kind, ErrorKind::BadResource);
-    assert_eq!(err.to_string(), "bad resource id");
+    assert_eq!(err.to_string(), "Resource has been closed");
   }
+
+  #[test]
+  fn test_bad_resource_id() {
+    let err = OpError::bad_resource_id();
+    assert_eq!(err.kind, ErrorKind::BadResource);
+    assert_eq!(err.to_string(), "Bad resource ID");
+  }
+
   #[test]
   fn test_permission_denied() {
     let err = OpError::permission_denied(

--- a/cli/ops/files.rs
+++ b/cli/ops/files.rs
@@ -156,7 +156,7 @@ fn op_close(
   state
     .resource_table
     .close(args.rid as u32)
-    .ok_or_else(OpError::bad_resource)?;
+    .ok_or_else(OpError::bad_resource_id)?;
   Ok(JsonOp::Sync(json!({})))
 }
 
@@ -195,11 +195,11 @@ fn op_seek(
   let resource = state
     .resource_table
     .get::<StreamResource>(rid)
-    .ok_or_else(OpError::bad_resource)?;
+    .ok_or_else(OpError::bad_resource_id)?;
 
   let tokio_file = match resource {
     StreamResource::FsFile(ref file, _) => file,
-    _ => return Err(OpError::bad_resource()),
+    _ => return Err(OpError::bad_resource_id()),
   };
   let mut file = futures::executor::block_on(tokio_file.try_clone())?;
 

--- a/cli/ops/fs_events.rs
+++ b/cli/ops/fs_events.rs
@@ -109,7 +109,7 @@ pub fn op_fs_events_poll(
     let resource_table = &mut state.borrow_mut().resource_table;
     let watcher = resource_table
       .get_mut::<FsEventsResource>(rid)
-      .ok_or_else(OpError::bad_resource)?;
+      .ok_or_else(OpError::bad_resource_id)?;
     watcher
       .receiver
       .poll_recv(cx)

--- a/cli/ops/io.rs
+++ b/cli/ops/io.rs
@@ -127,7 +127,7 @@ impl DenoAsyncRead for StreamResource {
       ChildStdout(f) => Box::pin(f),
       ChildStderr(f) => Box::pin(f),
       HttpBody(f) => Box::pin(f),
-      _ => return Err(OpError::bad_resource()).into(),
+      _ => return Err(OpError::bad_resource_id()).into(),
     };
 
     let v = ready!(f.as_mut().poll_read(cx, buf))?;
@@ -152,7 +152,7 @@ pub fn op_read(
     let resource_table = &mut state.borrow_mut().resource_table;
     let resource = resource_table
       .get_mut::<StreamResource>(rid as u32)
-      .ok_or_else(OpError::bad_resource)?;
+      .ok_or_else(OpError::bad_resource_id)?;
     let nread = ready!(resource.poll_read(cx, &mut buf.as_mut()[..]))?;
     Poll::Ready(Ok(nread as i32))
   })
@@ -188,7 +188,7 @@ impl DenoAsyncWrite for StreamResource {
       ClientTlsStream(f) => Box::pin(f),
       ServerTlsStream(f) => Box::pin(f),
       ChildStdin(f) => Box::pin(f),
-      _ => return Err(OpError::bad_resource()).into(),
+      _ => return Err(OpError::bad_resource_id()).into(),
     };
 
     let v = ready!(f.as_mut().poll_write(cx, buf))?;
@@ -205,7 +205,7 @@ impl DenoAsyncWrite for StreamResource {
       ClientTlsStream(f) => Box::pin(f),
       ServerTlsStream(f) => Box::pin(f),
       ChildStdin(f) => Box::pin(f),
-      _ => return Err(OpError::bad_resource()).into(),
+      _ => return Err(OpError::bad_resource_id()).into(),
     };
 
     ready!(f.as_mut().poll_flush(cx))?;
@@ -235,7 +235,7 @@ pub fn op_write(
       let resource_table = &mut state.borrow_mut().resource_table;
       let resource = resource_table
         .get_mut::<StreamResource>(rid as u32)
-        .ok_or_else(OpError::bad_resource)?;
+        .ok_or_else(OpError::bad_resource_id)?;
       resource.poll_write(cx, &buf.as_ref()[..])
     })
     .await?;
@@ -248,7 +248,7 @@ pub fn op_write(
       let resource_table = &mut state.borrow_mut().resource_table;
       let resource = resource_table
         .get_mut::<StreamResource>(rid as u32)
-        .ok_or_else(OpError::bad_resource)?;
+        .ok_or_else(OpError::bad_resource_id)?;
       resource.poll_flush(cx)
     })
     .await?;

--- a/cli/ops/net.rs
+++ b/cli/ops/net.rs
@@ -45,7 +45,7 @@ fn op_accept(
     state
       .resource_table
       .get::<TcpListenerResource>(rid)
-      .ok_or_else(OpError::bad_resource)?;
+      .ok_or_else(OpError::bad_resource_id)?;
   }
 
   let state = state.clone();
@@ -250,12 +250,12 @@ fn op_shutdown(
   let resource = state
     .resource_table
     .get_mut::<StreamResource>(rid)
-    .ok_or_else(OpError::bad_resource)?;
+    .ok_or_else(OpError::bad_resource_id)?;
   match resource {
     StreamResource::TcpStream(ref mut stream) => {
       TcpStream::shutdown(stream, shutdown_mode).map_err(OpError::from)?;
     }
-    _ => return Err(OpError::bad_resource()),
+    _ => return Err(OpError::bad_resource_id()),
   }
 
   Ok(JsonOp::Sync(json!({})))

--- a/cli/ops/process.rs
+++ b/cli/ops/process.rs
@@ -27,10 +27,10 @@ fn clone_file(rid: u32, state: &State) -> Result<std::fs::File, OpError> {
   let repr = state
     .resource_table
     .get_mut::<StreamResource>(rid)
-    .ok_or_else(OpError::bad_resource)?;
+    .ok_or_else(OpError::bad_resource_id)?;
   let file = match repr {
     StreamResource::FsFile(ref mut file, _) => file,
-    _ => return Err(OpError::bad_resource()),
+    _ => return Err(OpError::bad_resource_id()),
   };
   let tokio_file = futures::executor::block_on(file.try_clone())?;
   let std_file = futures::executor::block_on(tokio_file.into_std());
@@ -190,7 +190,7 @@ fn op_run_status(
       let resource_table = &mut state.borrow_mut().resource_table;
       let child_resource = resource_table
         .get_mut::<ChildResource>(rid)
-        .ok_or_else(OpError::bad_resource)?;
+        .ok_or_else(OpError::bad_resource_id)?;
       let child = &mut child_resource.child;
       child.map_err(OpError::from).poll_unpin(cx)
     })

--- a/cli/ops/repl.rs
+++ b/cli/ops/repl.rs
@@ -57,7 +57,7 @@ fn op_repl_readline(
   let resource = state
     .resource_table
     .get::<ReplResource>(rid)
-    .ok_or_else(OpError::bad_resource)?;
+    .ok_or_else(OpError::bad_resource_id)?;
   let repl = resource.0.clone();
 
   blocking_json(false, move || {

--- a/cli/ops/signal.rs
+++ b/cli/ops/signal.rs
@@ -103,7 +103,7 @@ pub fn op_signal_unbind(
   state
     .resource_table
     .close(rid)
-    .ok_or_else(OpError::bad_resource)?;
+    .ok_or_else(OpError::bad_resource_id)?;
   Ok(JsonOp::Sync(json!({})))
 }
 

--- a/cli/ops/tls.rs
+++ b/cli/ops/tls.rs
@@ -309,7 +309,7 @@ fn op_accept_tls(
       let resource = state
         .resource_table
         .get::<TlsListenerResource>(rid)
-        .ok_or_else(OpError::bad_resource)
+        .ok_or_else(OpError::bad_resource_id)
         .expect("Can't find tls listener");
       resource.tls_acceptor.clone()
     };

--- a/cli/ops/tty.rs
+++ b/cli/ops/tty.rs
@@ -78,7 +78,7 @@ pub fn op_set_raw(
     let state = state_.borrow_mut();
     let resource = state.resource_table.get::<StreamResource>(rid);
     if resource.is_none() {
-      return Err(OpError::bad_resource());
+      return Err(OpError::bad_resource_id());
     }
 
     // For now, only stdin.
@@ -117,7 +117,7 @@ pub fn op_set_raw(
     let mut state = state_.borrow_mut();
     let resource = state.resource_table.get_mut::<StreamResource>(rid);
     if resource.is_none() {
-      return Err(OpError::bad_resource());
+      return Err(OpError::bad_resource_id());
     }
 
     if is_raw {
@@ -201,7 +201,7 @@ pub fn op_isatty(
 
   let state = state_.borrow_mut();
   if !state.resource_table.has(rid) {
-    return Err(OpError::bad_resource());
+    return Err(OpError::bad_resource_id());
   }
 
   let resource = state.resource_table.get::<StreamResource>(rid);

--- a/cli/tests/044_bad_resource.ts.out
+++ b/cli/tests/044_bad_resource.ts.out
@@ -1,5 +1,5 @@
 [WILDCARD]
-error: Uncaught BadResource: bad resource id
+error: Uncaught BadResource: Bad resource ID
 [WILDCARD]dispatch_json.ts:[WILDCARD]
     at BadResource ([WILDCARD]errors.ts:[WILDCARD])
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])


### PR DESCRIPTION
I left a helper with a default message. An example of where extra context can be provided with a `BadResource` error is https://github.com/denoland/deno/blob/1dcead320d0926cac2df9aa49069db93a49432d8/cli/ops/net.rs#L59 which wrongly uses `Other` at the moment. That will be fixed in #4236.

cc @bartlomieju 