### PR TITLE
Fix unwanted ANSI Reset Sequence

### DIFF
--- a/cli/colors.rs
+++ b/cli/colors.rs
@@ -35,11 +35,12 @@ pub fn enable_ansi() {
 }
 
 fn style(s: &str, colorspec: ColorSpec) -> impl fmt::Display {
+  if !use_color() {
+    return String::from(s);
+  }
   let mut v = Vec::new();
   let mut ansi_writer = Ansi::new(&mut v);
-  if use_color() {
-    ansi_writer.set_color(&colorspec).unwrap();
-  }
+  ansi_writer.set_color(&colorspec).unwrap();
   ansi_writer.write_all(s.as_bytes()).unwrap();
   ansi_writer.reset().unwrap();
   String::from_utf8_lossy(&v).into_owned()


### PR DESCRIPTION
This PR closes #4261. This fixes the fact that the ANSI Reset sequence would always be written no matter the value of `use_color()` .