### PR TITLE
Move benchmark data to different repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           DENOBOT_PAT: ${{ secrets.DENOBOT_PAT }}
         run: |
-          git clone --depth 1 -b gh-pages https://${DENOBOT_PAT}@github.com/denoland/deno.git gh-pages
+          git clone --depth 1 -b gh-pages https://${DENOBOT_PAT}@github.com/denoland/benchmark_data.git gh-pages
           python ./tools/build_benchmark_jsons.py
           cd gh-pages
           git config user.email "propelml@gmail.com"


### PR DESCRIPTION
Moving this out of the main repo so we get a less confusing output of `git log --graph --oneline --all`

Website already updated here https://github.com/denoland/deno_website2/pull/258

New repo https://github.com/denoland/benchmark_data

new data links:
https://denoland.github.io/benchmark_data/data.json
https://denoland.github.io/benchmark_data/recent.json

cc @kt3k 

# merge on approval 