### PR TITLE
Rename perm to mode

### DIFF
--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -19,16 +19,16 @@ use nix::unistd::{chown as unix_chown, Gid, Uid};
 pub fn write_file<T: AsRef<[u8]>>(
   filename: &Path,
   data: T,
-  perm: u32,
+  mode: u32,
 ) -> std::io::Result<()> {
-  write_file_2(filename, data, true, perm, true, false)
+  write_file_2(filename, data, true, mode, true, false)
 }
 
 pub fn write_file_2<T: AsRef<[u8]>>(
   filename: &Path,
   data: T,
-  update_perm: bool,
-  perm: u32,
+  update_mode: bool,
+  mode: u32,
   is_create: bool,
   is_append: bool,
 ) -> std::io::Result<()> {
@@ -40,21 +40,21 @@ pub fn write_file_2<T: AsRef<[u8]>>(
     .create(is_create)
     .open(filename)?;
 
-  if update_perm {
-    set_permissions(&mut file, perm)?;
+  if update_mode {
+    set_permissions(&mut file, mode)?;
   }
 
   file.write_all(data.as_ref())
 }
 
 #[cfg(unix)]
-fn set_permissions(file: &mut File, perm: u32) -> std::io::Result<()> {
-  debug!("set file perm to {}", perm);
-  file.set_permissions(PermissionsExt::from_mode(perm & 0o777))
+fn set_permissions(file: &mut File, mode: u32) -> std::io::Result<()> {
+  debug!("set file mode to {}", mode);
+  file.set_permissions(PermissionsExt::from_mode(mode & 0o777))
 }
 
 #[cfg(not(unix))]
-fn set_permissions(_file: &mut File, _perm: u32) -> std::io::Result<()> {
+fn set_permissions(_file: &mut File, _mode: u32) -> std::io::Result<()> {
   // NOOP on windows
   Ok(())
 }
@@ -94,22 +94,22 @@ pub fn make_temp(
   }
 }
 
-pub fn mkdir(path: &Path, perm: u32, recursive: bool) -> std::io::Result<()> {
+pub fn mkdir(path: &Path, mode: u32, recursive: bool) -> std::io::Result<()> {
   debug!("mkdir -p {}", path.display());
   let mut builder = DirBuilder::new();
   builder.recursive(recursive);
-  set_dir_permission(&mut builder, perm);
+  set_dir_permission(&mut builder, mode);
   builder.create(path)
 }
 
 #[cfg(unix)]
-fn set_dir_permission(builder: &mut DirBuilder, perm: u32) {
-  debug!("set dir perm to {}", perm);
-  builder.mode(perm & 0o777);
+fn set_dir_permission(builder: &mut DirBuilder, mode: u32) {
+  debug!("set dir mode to {}", mode);
+  builder.mode(mode & 0o777);
 }
 
 #[cfg(not(unix))]
-fn set_dir_permission(_builder: &mut DirBuilder, _perm: u32) {
+fn set_dir_permission(_builder: &mut DirBuilder, _mode: u32) {
   // NOOP on windows
 }
 

--- a/cli/js/chmod_test.ts
+++ b/cli/js/chmod_test.ts
@@ -10,7 +10,7 @@ unitTest(
     const data = enc.encode("Hello");
     const tempDir = Deno.makeTempDirSync();
     const filename = tempDir + "/test.txt";
-    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o666 });
 
     // On windows no effect, but should not crash
     Deno.chmodSync(filename, 0o777);
@@ -36,7 +36,7 @@ unitTest(
     const tempDir = Deno.makeTempDirSync();
 
     const filename = tempDir + "/test.txt";
-    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o666 });
     const symlinkName = tempDir + "/test_symlink.txt";
     Deno.symlinkSync(filename, symlinkName);
 
@@ -85,7 +85,7 @@ unitTest(
     const data = enc.encode("Hello");
     const tempDir = Deno.makeTempDirSync();
     const filename = tempDir + "/test.txt";
-    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o666 });
 
     // On windows no effect, but should not crash
     await Deno.chmod(filename, 0o777);
@@ -112,7 +112,7 @@ unitTest(
     const tempDir = Deno.makeTempDirSync();
 
     const filename = tempDir + "/test.txt";
-    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o666 });
     const symlinkName = tempDir + "/test_symlink.txt";
     Deno.symlinkSync(filename, symlinkName);
 

--- a/cli/js/copy_file_test.ts
+++ b/cli/js/copy_file_test.ts
@@ -10,7 +10,7 @@ function readFileString(filename: string): string {
 function writeFileString(filename: string, s: string): void {
   const enc = new TextEncoder();
   const data = enc.encode(s);
-  Deno.writeFileSync(filename, data, { perm: 0o666 });
+  Deno.writeFileSync(filename, data, { mode: 0o666 });
 }
 
 function assertSameContent(filename1: string, filename2: string): void {

--- a/cli/js/file_info.ts
+++ b/cli/js/file_info.ts
@@ -30,9 +30,10 @@ export interface FileInfo {
    *
    * _Linux/Mac OS only._ */
   ino: number | null;
-  /** The underlying raw st_mode bits that contain the standard Unix permissions
-   * for this file/directory. TODO Match behavior with Go on windows for mode.
-   */
+  /** **UNSTABLE**: Match behavior with Go on windows for `mode`.
+   *
+   * The underlying raw `st_mode` bits that contain the standard Unix
+   * permissions for this file/directory. */
   mode: number | null;
   /** Number of hard links pointing to this file.
    *

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1023,7 +1023,7 @@ declare namespace Deno {
     ino: number | null;
     /** **UNSTABLE**: Match behavior with Go on Windows for `mode`.
      *
-     * The underlying raw `st_mod`e bits that contain the standard Linux/Mac OS
+     * The underlying raw `st_mode` bits that contain the standard Unix
      * permissions for this file/directory. */
     mode: number | null;
     /** Number of hard links pointing to this file.
@@ -1233,7 +1233,7 @@ declare namespace Deno {
      * exist at the specified path (defaults to `true`). */
     create?: boolean;
     /** Permissions always applied to file. */
-    perm?: number;
+    mode?: number;
   }
 
   /** Synchronously write data to the given path, by default creating a new

--- a/cli/js/metrics_test.ts
+++ b/cli/js/metrics_test.ts
@@ -34,7 +34,7 @@ unitTest(
     const filename = Deno.makeTempDirSync() + "/test.txt";
 
     const data = new Uint8Array([41, 42, 43]);
-    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o666 });
 
     const metrics = Deno.metrics();
     assert(metrics.opsDispatched === metrics.opsCompleted);
@@ -48,7 +48,7 @@ unitTest(
     const filename = Deno.makeTempDirSync() + "/test.txt";
 
     const data = new Uint8Array([41, 42, 43]);
-    await Deno.writeFile(filename, data, { perm: 0o666 });
+    await Deno.writeFile(filename, data, { mode: 0o666 });
 
     const metrics = Deno.metrics();
     assert(metrics.opsDispatched === metrics.opsCompleted);

--- a/cli/js/remove_test.ts
+++ b/cli/js/remove_test.ts
@@ -31,7 +31,7 @@ unitTest(
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
     const filename = Deno.makeTempDirSync() + "/test.txt";
-    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o666 });
     const fileInfo = Deno.statSync(filename);
     assert(fileInfo.isFile()); // check exist first
     Deno.removeSync(filename); // remove
@@ -115,7 +115,7 @@ unitTest(
     const tempDir = Deno.makeTempDirSync();
     const filePath = tempDir + "/test.txt";
     const validSymlinkPath = tempDir + "/valid_symlink";
-    Deno.writeFileSync(filePath, data, { perm: 0o666 });
+    Deno.writeFileSync(filePath, data, { mode: 0o666 });
     // TODO(#3832): Remove "Not Implemented" error checking when symlink creation is implemented for Windows
     let errOnWindows;
     try {
@@ -199,7 +199,7 @@ unitTest(
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
     const filename = Deno.makeTempDirSync() + "/test.txt";
-    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o666 });
     const fileInfo = Deno.statSync(filename);
     assert(fileInfo.isFile()); // check exist first
     Deno.removeSync(filename, { recursive: true }); // remove
@@ -268,7 +268,7 @@ unitTest(
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
     const filename = Deno.makeTempDirSync() + "/test.txt";
-    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o666 });
     const fileInfo = Deno.statSync(filename);
     assert(fileInfo.isFile()); // check exist first
     await Deno.remove(filename); // remove
@@ -351,7 +351,7 @@ unitTest(
     const tempDir = Deno.makeTempDirSync();
     const filePath = tempDir + "/test.txt";
     const validSymlinkPath = tempDir + "/valid_symlink";
-    Deno.writeFileSync(filePath, data, { perm: 0o666 });
+    Deno.writeFileSync(filePath, data, { mode: 0o666 });
     // TODO(#3832): Remove "Not Implemented" error checking when symlink creation is implemented for Windows
     let errOnWindows;
     try {
@@ -437,7 +437,7 @@ unitTest(
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
     const filename = Deno.makeTempDirSync() + "/test.txt";
-    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o666 });
     const fileInfo = Deno.statSync(filename);
     assert(fileInfo.isFile()); // check exist first
     await Deno.remove(filename, { recursive: true }); // remove

--- a/cli/js/stat_test.ts
+++ b/cli/js/stat_test.ts
@@ -190,7 +190,7 @@ unitTest(
     const data = enc.encode("Hello");
     const tempDir = Deno.makeTempDirSync();
     const filename = tempDir + "/test.txt";
-    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o666 });
     const s = Deno.statSync(filename);
     assert(s.dev === null);
     assert(s.ino === null);
@@ -212,7 +212,7 @@ unitTest(
     const tempDir = Deno.makeTempDirSync();
     const filename = tempDir + "/test.txt";
     const filename2 = tempDir + "/test2.txt";
-    Deno.writeFileSync(filename, data, { perm: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o666 });
     // Create a link
     Deno.linkSync(filename, filename2);
     const s = Deno.statSync(filename);

--- a/cli/js/tls_test.ts
+++ b/cli/js/tls_test.ts
@@ -105,7 +105,7 @@ unitTest(
     const testDir = Deno.makeTempDirSync();
     const keyFilename = testDir + "/key.pem";
     Deno.writeFileSync(keyFilename, new Uint8Array([]), {
-      perm: 0o666
+      mode: 0o666
     });
 
     try {
@@ -134,7 +134,7 @@ unitTest(
     const testDir = Deno.makeTempDirSync();
     const certFilename = testDir + "/cert.crt";
     Deno.writeFileSync(certFilename, new Uint8Array([]), {
-      perm: 0o666
+      mode: 0o666
     });
 
     try {

--- a/cli/js/utime_test.ts
+++ b/cli/js/utime_test.ts
@@ -15,7 +15,7 @@ unitTest(
     const testDir = Deno.makeTempDirSync();
     const filename = testDir + "/file.txt";
     Deno.writeFileSync(filename, new TextEncoder().encode("hello"), {
-      perm: 0o666
+      mode: 0o666
     });
 
     const atime = 1000;
@@ -115,7 +115,7 @@ unitTest(
     const testDir = Deno.makeTempDirSync();
     const filename = testDir + "/file.txt";
     Deno.writeFileSync(filename, new TextEncoder().encode("hello"), {
-      perm: 0o666
+      mode: 0o666
     });
 
     const atime = 1000;

--- a/cli/js/write_file.ts
+++ b/cli/js/write_file.ts
@@ -13,7 +13,7 @@ export interface WriteFileOptions {
    * exist at the specified path (defaults to `true`). */
   create?: boolean;
   /** Permissions always applied to file. */
-  perm?: number;
+  mode?: number;
 }
 
 /** Synchronously write data to the given path, by default creating a new
@@ -41,8 +41,8 @@ export function writeFileSync(
   const openMode = !!options.append ? "a" : "w";
   const file = openSync(path, openMode);
 
-  if (options.perm !== undefined && options.perm !== null) {
-    chmodSync(path, options.perm);
+  if (options.mode !== undefined && options.mode !== null) {
+    chmodSync(path, options.mode);
   }
 
   writeAllSync(file, data);
@@ -74,8 +74,8 @@ export async function writeFile(
   const openMode = !!options.append ? "a" : "w";
   const file = await open(path, openMode);
 
-  if (options.perm !== undefined && options.perm !== null) {
-    await chmod(path, options.perm);
+  if (options.mode !== undefined && options.mode !== null) {
+    await chmod(path, options.mode);
   }
 
   await writeAll(file, data);

--- a/cli/js/write_file_test.ts
+++ b/cli/js/write_file_test.ts
@@ -47,14 +47,14 @@ unitTest({ perms: { write: false } }, function writeFileSyncPerm(): void {
 
 unitTest(
   { perms: { read: true, write: true } },
-  function writeFileSyncUpdatePerm(): void {
+  function writeFileSyncUpdateMode(): void {
     if (Deno.build.os !== "win") {
       const enc = new TextEncoder();
       const data = enc.encode("Hello");
       const filename = Deno.makeTempDirSync() + "/test.txt";
-      Deno.writeFileSync(filename, data, { perm: 0o755 });
+      Deno.writeFileSync(filename, data, { mode: 0o755 });
       assertEquals(Deno.statSync(filename).mode! & 0o777, 0o755);
-      Deno.writeFileSync(filename, data, { perm: 0o666 });
+      Deno.writeFileSync(filename, data, { mode: 0o666 });
       assertEquals(Deno.statSync(filename).mode! & 0o777, 0o666);
     }
   }
@@ -163,14 +163,14 @@ unitTest(
 
 unitTest(
   { perms: { read: true, write: true } },
-  async function writeFileUpdatePerm(): Promise<void> {
+  async function writeFileUpdateMode(): Promise<void> {
     if (Deno.build.os !== "win") {
       const enc = new TextEncoder();
       const data = enc.encode("Hello");
       const filename = Deno.makeTempDirSync() + "/test.txt";
-      await Deno.writeFile(filename, data, { perm: 0o755 });
+      await Deno.writeFile(filename, data, { mode: 0o755 });
       assertEquals(Deno.statSync(filename).mode! & 0o777, 0o755);
-      await Deno.writeFile(filename, data, { perm: 0o666 });
+      await Deno.writeFile(filename, data, { mode: 0o666 });
       assertEquals(Deno.statSync(filename).mode! & 0o777, 0o666);
     }
   }


### PR DESCRIPTION
There's a lot of variation in doc comments and internal code about whether chmod/0o777-style permissions are called `mode` or `perm`. (For example, mkdir and writeFile choose differently.)

An earlier PR #4245 had proposed moving these all consistently to `perm`. But `mode` was more popular, so this PR proposes moving them all consistently to `mode`.

This is part of a series of PRs towards #4017 (and most of the substantial commits in that series wait upon this one being merged first).