### PR TITLE
Update manual to reflect newer test running

### DIFF
--- a/std/manual.md
+++ b/std/manual.md
@@ -498,8 +498,6 @@ Deno.test(function t1() {
 Deno.test(function t2() {
   assertEquals("world", "world");
 });
-
-await Deno.runTests();
 ```
 
 Try running this:


### PR DESCRIPTION
This updates this example code to follow the new test running conventions.

The code as is, when ran produces the following output:

```
➜  dencro git:(master) ✗ deno test        
Compile file:///Users/hswolff/Sites/dencro/test.ts
running 2 tests
OK     oneTest (2.00ms)
OK     t2 (0.00ms)

test result: OK 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (2.00ms)

running 2 tests
OK     oneTest (0.00ms)
OK     t2 (0.00ms)

test result: OK 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (0.00ms)

➜  dencro git:(master) ✗ 
```

Removing `await Deno.runTests();` just causes the tests to run once.

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
