### PR TITLE
Improvements to std/flags.

### DIFF
--- a/std/flags/num_test.ts
+++ b/std/flags/num_test.ts
@@ -33,7 +33,7 @@ Deno.test(function nums(): void {
 });
 
 Deno.test(function alreadyNumber(): void {
-  const argv = parse(["-x", 1234, 789]);
+  const argv = parse(["-x", "1234", "789"]);
   assertEquals(argv, { x: 1234, _: [789] });
   assertEquals(typeof argv.x, "number");
   assertEquals(typeof argv._[0], "number");


### PR DESCRIPTION
Adds JSDoc to module, improves the typing of the return type, uses iteration instead of Array forEach, uses the dotall support in Regular Expression which is now supported in JavaScript, uses destructuring and nullish coalescing where appropriate, uses `Record` instead of index types where appropriate.
