### PR TITLE
refactor: Cleanup options object parameters

### DIFF
--- a/cli/js/compiler_api.ts
+++ b/cli/js/compiler_api.ts
@@ -302,12 +302,12 @@ export interface TranspileOnlyResult {
  */
 export async function transpileOnly(
   sources: Record<string, string>,
-  options?: CompilerOptions
+  options: CompilerOptions = {}
 ): Promise<Record<string, TranspileOnlyResult>> {
   util.log("Deno.transpileOnly", { sources: Object.keys(sources), options });
   const payload = {
     sources,
-    options: options ? JSON.stringify(options) : undefined
+    options: JSON.stringify(options)
   };
   const result = await runtimeCompilerOps.transpile(payload);
   return JSON.parse(result);
@@ -343,12 +343,12 @@ export async function transpileOnly(
 export async function compile(
   rootName: string,
   sources?: Record<string, string>,
-  options?: CompilerOptions
+  options: CompilerOptions = {}
 ): Promise<[DiagnosticItem[] | undefined, Record<string, string>]> {
   const payload = {
     rootName: sources ? rootName : checkRelative(rootName),
     sources,
-    options: options ? JSON.stringify(options) : undefined,
+    options: JSON.stringify(options),
     bundle: false
   };
   util.log("Deno.compile", {
@@ -391,12 +391,12 @@ export async function compile(
 export async function bundle(
   rootName: string,
   sources?: Record<string, string>,
-  options?: CompilerOptions
+  options: CompilerOptions = {}
 ): Promise<[DiagnosticItem[] | undefined, string]> {
   const payload = {
     rootName: sources ? rootName : checkRelative(rootName),
     sources,
-    options: options ? JSON.stringify(options) : undefined,
+    options: JSON.stringify(options),
     bundle: true
   };
   util.log("Deno.bundle", {

--- a/cli/js/compiler_host.ts
+++ b/cli/js/compiler_host.ts
@@ -165,8 +165,7 @@ export class Host implements ts.CompilerHost {
   /* Deno specific APIs */
 
   /** Provides the `ts.HostCompiler` interface for Deno. */
-  constructor(options: CompilerHostOptions) {
-    const { bundle = false, target, writeFile } = options;
+  constructor({ bundle = false, target, writeFile }: CompilerHostOptions) {
     this._target = target;
     this._writeFile = writeFile;
     if (bundle) {

--- a/cli/js/console.ts
+++ b/cli/js/console.ts
@@ -367,7 +367,7 @@ function createObjectString(
 /** @internal */
 export function stringifyArgs(
   args: unknown[],
-  options: ConsoleOptions = {}
+  { depth = DEFAULT_MAX_DEPTH, indentLevel = 0 }: ConsoleOptions = {}
 ): string {
   const first = args[0];
   let a = 0;
@@ -411,12 +411,7 @@ export function stringifyArgs(
             case CHAR_LOWERCASE_O:
             case CHAR_UPPERCASE_O:
               // format as an object
-              tempStr = stringify(
-                args[++a],
-                new Set<unknown>(),
-                0,
-                options.depth != undefined ? options.depth : DEFAULT_MAX_DEPTH
-              );
+              tempStr = stringify(args[++a], new Set<unknown>(), 0, depth);
               break;
             case CHAR_PERCENT:
               str += first.slice(lastPos, i);
@@ -459,19 +454,13 @@ export function stringifyArgs(
       str += value;
     } else {
       // use default maximum depth for null or undefined argument
-      str += stringify(
-        value,
-        new Set<unknown>(),
-        0,
-        options.depth != undefined ? options.depth : DEFAULT_MAX_DEPTH
-      );
+      str += stringify(value, new Set<unknown>(), 0, depth);
     }
     join = " ";
     a++;
   }
 
-  const { indentLevel } = options;
-  if (indentLevel != null && indentLevel > 0) {
+  if (indentLevel > 0) {
     const groupIndent = " ".repeat(indentLevel);
     if (str.indexOf("\n") !== -1) {
       str = str.replace(/\n/g, `\n${groupIndent}`);
@@ -771,17 +760,14 @@ export const customInspect = Symbol.for("Deno.customInspect");
  * `inspect()` converts input into string that has the same format
  * as printed by `console.log(...)`;
  */
-export function inspect(value: unknown, options?: ConsoleOptions): string {
-  const opts = options || {};
+export function inspect(
+  value: unknown,
+  { depth = DEFAULT_MAX_DEPTH }: ConsoleOptions = {}
+): string {
   if (typeof value === "string") {
     return value;
   } else {
-    return stringify(
-      value,
-      new Set<unknown>(),
-      0,
-      opts.depth != undefined ? opts.depth : DEFAULT_MAX_DEPTH
-    );
+    return stringify(value, new Set<unknown>(), 0, depth);
   }
 }
 

--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -503,11 +503,11 @@ declare namespace __domTypes {
     readonly total: number;
   }
   export interface EventListenerOptions {
-    capture: boolean;
+    capture?: boolean;
   }
   export interface AddEventListenerOptions extends EventListenerOptions {
-    once: boolean;
-    passive: boolean;
+    once?: boolean;
+    passive?: boolean;
   }
   interface AbortSignal extends EventTarget {
     readonly aborted: boolean;

--- a/cli/js/net.ts
+++ b/cli/js/net.ts
@@ -206,8 +206,6 @@ export interface ListenOptions {
   transport?: Transport;
 }
 
-const listenDefaults = { hostname: "0.0.0.0", transport: "tcp" };
-
 /** Listen announces on the local transport address.
  *
  * @param options
@@ -229,11 +227,14 @@ export function listen(
   options: ListenOptions & { transport?: "tcp" }
 ): Listener;
 export function listen(options: ListenOptions & { transport: "udp" }): UDPConn;
-export function listen(options: ListenOptions): Listener | UDPConn {
-  const args = { ...listenDefaults, ...options };
-  const res = netOps.listen(args as netOps.ListenRequest);
+export function listen({
+  port,
+  hostname = "0.0.0.0",
+  transport = "tcp"
+}: ListenOptions): Listener | UDPConn {
+  const res = netOps.listen({ port, hostname, transport });
 
-  if (args.transport === "tcp") {
+  if (transport === "tcp") {
     return new ListenerImpl(res.rid, res.localAddr);
   } else {
     return new UDPConnImpl(res.rid, res.localAddr);
@@ -245,8 +246,6 @@ export interface ConnectOptions {
   hostname?: string;
   transport?: Transport;
 }
-
-const connectDefaults = { hostname: "127.0.0.1", transport: "tcp" };
 
 /** Connects to the address on the named transport.
  *
@@ -265,8 +264,11 @@ const connectDefaults = { hostname: "127.0.0.1", transport: "tcp" };
  *     connect({ hostname: "[2001:db8::1]", port: 80 });
  *     connect({ hostname: "golang.org", port: 80, transport: "tcp" })
  */
-export async function connect(options: ConnectOptions): Promise<Conn> {
-  options = Object.assign(connectDefaults, options);
-  const res = await netOps.connect(options as netOps.ConnectRequest);
+export async function connect({
+  port,
+  hostname = "127.0.0.1",
+  transport = "tcp"
+}: ConnectOptions): Promise<Conn> {
+  const res = await netOps.connect({ port, hostname, transport });
   return new ConnImpl(res.rid, res.remoteAddr!, res.localAddr!);
 }

--- a/cli/js/ops/tls.ts
+++ b/cli/js/ops/tls.ts
@@ -6,7 +6,7 @@ export interface ConnectTLSRequest {
   transport: Transport;
   hostname: string;
   port: number;
-  cert_file?: string;
+  certFile?: string;
 }
 
 interface ConnectTLSResponse {

--- a/cli/js/tests/console_test.ts
+++ b/cli/js/tests/console_test.ts
@@ -186,7 +186,7 @@ unitTest(function consoleTestStringifyWithDepth(): void {
   );
   assertEquals(stringifyArgs([nestedObj], { depth: 0 }), "[Object]");
   assertEquals(
-    stringifyArgs([nestedObj], { depth: null }),
+    stringifyArgs([nestedObj]),
     "{ a: { b: { c: { d: [Object] } } } }"
   );
   // test inspect is working the same way

--- a/cli/js/tls.ts
+++ b/cli/js/tls.ts
@@ -10,14 +10,22 @@ interface ConnectTLSOptions {
   hostname?: string;
   certFile?: string;
 }
-const connectTLSDefaults = { hostname: "127.0.0.1", transport: "tcp" };
 
 /**
  * Establishes a secure connection over TLS (transport layer security).
  */
-export async function connectTLS(options: ConnectTLSOptions): Promise<Conn> {
-  options = Object.assign(connectTLSDefaults, options);
-  const res = await tlsOps.connectTLS(options as tlsOps.ConnectTLSRequest);
+export async function connectTLS({
+  port,
+  hostname = "127.0.0.1",
+  transport = "tcp",
+  certFile = undefined
+}: ConnectTLSOptions): Promise<Conn> {
+  const res = await tlsOps.connectTLS({
+    port,
+    hostname,
+    transport,
+    certFile
+  });
   return new ConnImpl(res.rid, res.remoteAddr!, res.localAddr!);
 }
 
@@ -49,15 +57,19 @@ export interface ListenTLSOptions {
  *
  *     Deno.listenTLS({ port: 443, certFile: "./my_server.crt", keyFile: "./my_server.key" })
  */
-export function listenTLS(options: ListenTLSOptions): Listener {
-  const hostname = options.hostname || "0.0.0.0";
-  const transport = options.transport || "tcp";
+export function listenTLS({
+  port,
+  certFile,
+  keyFile,
+  hostname = "0.0.0.0",
+  transport = "tcp"
+}: ListenTLSOptions): Listener {
   const res = tlsOps.listenTLS({
+    port,
+    certFile,
+    keyFile,
     hostname,
-    port: options.port,
-    transport,
-    certFile: options.certFile,
-    keyFile: options.keyFile
+    transport
   });
   return new TLSListenerImpl(res.rid, res.localAddr);
 }

--- a/cli/js/web/blob.ts
+++ b/cli/js/web/blob.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import * as domTypes from "./dom_types.ts";
-import { hasOwnProperty } from "../util.ts";
 import { TextEncoder } from "./text_encoding.ts";
 import { build } from "../build.ts";
 
@@ -144,34 +143,29 @@ export class DenoBlob implements domTypes.Blob {
       return;
     }
 
-    options = options || {};
-    // Set ending property's default value to "transparent".
-    if (!hasOwnProperty(options, "ending")) {
-      options.ending = "transparent";
-    }
-
-    if (options.type && !containsOnlyASCII(options.type)) {
+    const { ending = "transparent", type = "" } = options ?? {};
+    if (!containsOnlyASCII(type)) {
       const errMsg = "The 'type' property must consist of ASCII characters.";
       throw new SyntaxError(errMsg);
     }
 
-    const bytes = processBlobParts(blobParts!, options);
+    const bytes = processBlobParts(blobParts!, { ending, type });
     // Normalize options.type.
-    let type = options.type ? options.type : "";
+    let normalizedType = type;
     if (type.length) {
       for (let i = 0; i < type.length; ++i) {
         const char = type[i];
         if (char < "\u0020" || char > "\u007E") {
-          type = "";
+          normalizedType = "";
           break;
         }
       }
-      type = type.toLowerCase();
+      normalizedType = type.toLowerCase();
     }
     // Set Blob object's properties.
     this[bytesSymbol] = bytes;
     this.size = bytes.byteLength;
-    this.type = type;
+    this.type = normalizedType;
 
     // Register bytes for internal private use.
     blobBytesWeakMap.set(this, bytes);

--- a/cli/js/web/dom_file.ts
+++ b/cli/js/web/dom_file.ts
@@ -11,14 +11,14 @@ export class DomFileImpl extends blob.DenoBlob implements domTypes.DomFile {
     fileName: string,
     options?: domTypes.FilePropertyBag
   ) {
-    options = options || {};
-    super(fileBits, options);
+    const { lastModified = Date.now(), ...blobPropertyBag } = options ?? {};
+    super(fileBits, blobPropertyBag);
 
     // 4.1.2.1 Replace any "/" character (U+002F SOLIDUS)
     // with a ":" (U + 003A COLON)
     this.name = String(fileName).replace(/\u002F/g, "\u003A");
     // 4.1.3.3 If lastModified is not provided, set lastModified to the current
     // date and time represented in number of milliseconds since the Unix Epoch.
-    this.lastModified = options.lastModified || Date.now();
+    this.lastModified = lastModified;
   }
 }

--- a/cli/js/web/dom_types.ts
+++ b/cli/js/web/dom_types.ts
@@ -258,12 +258,12 @@ interface ProgressEvent extends Event {
 }
 
 export interface EventListenerOptions {
-  capture: boolean;
+  capture?: boolean;
 }
 
 export interface AddEventListenerOptions extends EventListenerOptions {
-  once: boolean;
-  passive: boolean;
+  once?: boolean;
+  passive?: boolean;
 }
 
 export interface AbortSignal extends EventTarget {

--- a/cli/js/web/text_encoding.ts
+++ b/cli/js/web/text_encoding.ts
@@ -154,11 +154,14 @@ class SingleByteDecoder implements Decoder {
   private _index: number[];
   private _fatal: boolean;
 
-  constructor(index: number[], options: DecoderOptions) {
-    if (options.ignoreBOM) {
+  constructor(
+    index: number[],
+    { ignoreBOM = false, fatal = false }: DecoderOptions = {}
+  ) {
+    if (ignoreBOM) {
       throw new TypeError("Ignoring the BOM is available only with utf-8.");
     }
-    this._fatal = options.fatal || false;
+    this._fatal = fatal;
     this._index = index;
   }
   handler(stream: Stream, byte: number): number {

--- a/cli/js/workers.ts
+++ b/cli/js/workers.ts
@@ -58,12 +58,7 @@ export class WorkerImpl extends EventTarget implements Worker {
 
   constructor(specifier: string, options?: WorkerOptions) {
     super();
-
-    let type = "classic";
-
-    if (options?.type) {
-      type = options.type;
-    }
+    const { type = "classic", name = "unknown" } = options ?? {};
 
     if (type !== "module") {
       throw new Error(
@@ -71,7 +66,7 @@ export class WorkerImpl extends EventTarget implements Worker {
       );
     }
 
-    this.name = options?.name ?? "unknown";
+    this.name = name;
     const hasSourceCode = false;
     const sourceCode = decoder.decode(new Uint8Array());
 

--- a/std/flags/mod.ts
+++ b/std/flags/mod.ts
@@ -27,31 +27,31 @@ export interface ArgParsingOptions {
    *
    * Defaults to `false`.
    */
-  "--": boolean;
+  "--"?: boolean;
 
   /** An object mapping string names to strings or arrays of string argument
    * names to use as aliases */
-  alias: Record<string, string | string[]>;
+  alias?: Record<string, string | string[]>;
 
   /** A boolean, string or array of strings to always treat as booleans. If
    * `true` will treat all double hyphenated arguments without equal signs as
    * `boolean` (e.g. affects `--foo`, not `-f` or `--foo=bar`) */
-  boolean: boolean | string | string[];
+  boolean?: boolean | string | string[];
 
   /** An object mapping string argument names to default values. */
-  default: Record<string, unknown>;
+  default?: Record<string, unknown>;
 
   /** When `true`, populate the result `_` with everything after the first
    * non-option. */
-  stopEarly: boolean;
+  stopEarly?: boolean;
 
   /** A string or array of strings argument names to always treat as strings. */
-  string: string | string[];
+  string?: string | string[];
 
   /** A function which is invoked with a command line parameter not defined in
    * the `options` configuration object. If the function returns `false`, the
    * unknown option is not added to `parsedArgs`. */
-  unknown: (i: unknown) => unknown;
+  unknown?: (i: unknown) => unknown;
 }
 
 interface Flags {
@@ -108,7 +108,7 @@ export function parse(
     stopEarly = false,
     string = [],
     unknown = (i: unknown): unknown => i
-  }: Partial<ArgParsingOptions> = {}
+  }: ArgParsingOptions = {}
 ): Args {
   const flags: Flags = {
     bools: {},

--- a/std/fs/move.ts
+++ b/std/fs/move.ts
@@ -10,7 +10,7 @@ interface MoveOptions {
 export async function move(
   src: string,
   dest: string,
-  options?: MoveOptions
+  { overwrite = false }: MoveOptions = {}
 ): Promise<void> {
   const srcStat = await Deno.stat(src);
 
@@ -20,7 +20,7 @@ export async function move(
     );
   }
 
-  if (options && options.overwrite) {
+  if (overwrite) {
     await Deno.remove(dest, { recursive: true });
     await Deno.rename(src, dest);
   } else {
@@ -37,7 +37,7 @@ export async function move(
 export function moveSync(
   src: string,
   dest: string,
-  options?: MoveOptions
+  { overwrite = false }: MoveOptions = {}
 ): void {
   const srcStat = Deno.statSync(src);
 
@@ -47,7 +47,7 @@ export function moveSync(
     );
   }
 
-  if (options && options.overwrite) {
+  if (overwrite) {
     Deno.removeSync(dest, { recursive: true });
     Deno.renameSync(src, dest);
   } else {

--- a/std/testing/bench.ts
+++ b/std/testing/bench.ts
@@ -171,7 +171,7 @@ export async function runBenchmarks({
 /** Runs specified benchmarks if the enclosing script is main. */
 export async function runIfMain(
   meta: ImportMeta,
-  opts?: BenchmarkRunOptions
+  opts: BenchmarkRunOptions = {}
 ): Promise<void> {
   if (meta.main) {
     return runBenchmarks(opts);


### PR DESCRIPTION
Destructure where appropriate. Try to specify defaults to options at the top of the function rather than some `DEFAULT_OPTIONS` object or scattered around the function.

Also includes fix for partial options to `addEventListener()`:
```ts
addEventListener("load", console.log, { once: false }); // Options object is partial.
```
which doesn't compile currently.

Refactors `Deno.run()`.

--

You'll notice that in most cases I've done
```ts
function foo(
  arg1: string,
  { option1 = "default1", option2 = "default2" }: FooOptions = {}
): void {
  // ...
}
```
but in some cases it's
```ts
function foo(
  arg1: string,
  options?: FooOptions
): void {
  const { option1 = "default1", option2 = "default2" } = options ?? {};
  // ...
}
```
The difference is that the first pattern will break when you _explicitly_ pass null in place of the options: `foo("arg1", null)`, but the second pattern handles it the same as `foo("arg1")` and applies the defaults. Passing `null` there is a valid error case and there's no need for Deno APIs to accommodate it, however a lot of web APIs do in browsers so for compatibility the second pattern is used where required.