### PR TITLE
reorg: move JS ops implementations to cli/js/ops/, part 3

### DIFF
--- a/cli/js/compiler_host.ts
+++ b/cli/js/compiler_host.ts
@@ -2,7 +2,7 @@
 
 import { ASSETS, MediaType, SourceFile } from "./compiler_sourcefile.ts";
 import { OUT_DIR, WriteFileCallback, getAsset } from "./compiler_util.ts";
-import { cwd } from "./dir.ts";
+import { cwd } from "./ops/fs/dir.ts";
 import { assert, notImplemented } from "./util.ts";
 import * as util from "./util.ts";
 

--- a/cli/js/compiler_imports.ts
+++ b/cli/js/compiler_imports.ts
@@ -6,7 +6,7 @@ import {
   SourceFileJson
 } from "./compiler_sourcefile.ts";
 import { normalizeString, CHAR_FORWARD_SLASH } from "./compiler_util.ts";
-import { cwd } from "./dir.ts";
+import { cwd } from "./ops/fs/dir.ts";
 import { assert } from "./util.ts";
 import * as util from "./util.ts";
 import * as compilerOps from "./ops/compiler.ts";

--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -9,18 +9,18 @@ export {
   writeAllSync
 } from "./buffer.ts";
 export { build, OperatingSystem, Arch } from "./build.ts";
-export { chmodSync, chmod } from "./chmod.ts";
-export { chownSync, chown } from "./chown.ts";
+export { chmodSync, chmod } from "./ops/fs/chmod.ts";
+export { chownSync, chown } from "./ops/fs/chown.ts";
 export { transpileOnly, compile, bundle } from "./compiler_api.ts";
 export { inspect } from "./console.ts";
-export { copyFileSync, copyFile } from "./copy_file.ts";
+export { copyFileSync, copyFile } from "./ops/fs/copy_file.ts";
 export {
   Diagnostic,
   DiagnosticCategory,
   DiagnosticItem,
   DiagnosticMessageChain
 } from "./diagnostics.ts";
-export { chdir, cwd } from "./dir.ts";
+export { chdir, cwd } from "./ops/fs/dir.ts";
 export { applySourceMap, formatDiagnostics } from "./ops/errors.ts";
 export { errors } from "./errors.ts";
 export { FileInfo } from "./file_info.ts";
@@ -59,16 +59,16 @@ export {
   ReadWriteCloser,
   ReadWriteSeeker
 } from "./io.ts";
-export { linkSync, link } from "./link.ts";
+export { linkSync, link } from "./ops/fs/link.ts";
 export {
   makeTempDirSync,
   makeTempDir,
   makeTempFileSync,
   makeTempFile,
   MakeTempOptions
-} from "./make_temp.ts";
+} from "./ops/fs/make_temp.ts";
 export { metrics, Metrics } from "./ops/runtime.ts";
-export { mkdirSync, mkdir, MkdirOptions } from "./mkdir.ts";
+export { mkdirSync, mkdir, MkdirOptions } from "./ops/fs/mkdir.ts";
 export {
   Addr,
   connect,
@@ -100,20 +100,20 @@ export {
 export { openPlugin } from "./plugins.ts";
 export { kill } from "./ops/process.ts";
 export { run, RunOptions, Process, ProcessStatus, Signal } from "./process.ts";
-export { readdirSync, readdir } from "./read_dir.ts";
+export { readdirSync, readdir } from "./ops/fs/read_dir.ts";
 export { readFileSync, readFile } from "./read_file.ts";
-export { readlinkSync, readlink } from "./read_link.ts";
-export { realpathSync, realpath } from "./realpath.ts";
-export { removeSync, remove, RemoveOptions } from "./remove.ts";
-export { renameSync, rename } from "./rename.ts";
+export { readlinkSync, readlink } from "./ops/fs/read_link.ts";
+export { realpathSync, realpath } from "./ops/fs/realpath.ts";
+export { removeSync, remove, RemoveOptions } from "./ops/fs/remove.ts";
+export { renameSync, rename } from "./ops/fs/rename.ts";
 export { resources, close } from "./ops/resources.ts";
 export { signal, signals, SignalStream } from "./signals.ts";
-export { statSync, lstatSync, stat, lstat } from "./stat.ts";
-export { symlinkSync, symlink } from "./symlink.ts";
+export { statSync, lstatSync, stat, lstat } from "./ops/fs/stat.ts";
+export { symlinkSync, symlink } from "./ops/fs/symlink.ts";
 export { connectTLS, listenTLS } from "./tls.ts";
-export { truncateSync, truncate } from "./truncate.ts";
+export { truncateSync, truncate } from "./ops/fs/truncate.ts";
 export { isatty, setRaw } from "./ops/tty.ts";
-export { utimeSync, utime } from "./utime.ts";
+export { utimeSync, utime } from "./ops/fs/utime.ts";
 export { version } from "./version.ts";
 export { writeFileSync, writeFile, WriteFileOptions } from "./write_file.ts";
 export const args: string[] = [];

--- a/cli/js/file_info.ts
+++ b/cli/js/file_info.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { StatResponse } from "./stat.ts";
+import { StatResponse } from "./ops/fs/stat.ts";
 import { build } from "./build.ts";
 
 /** A FileInfo describes a file and is returned by `stat`, `lstat`,

--- a/cli/js/files.ts
+++ b/cli/js/files.ts
@@ -10,12 +10,17 @@ import {
   SyncWriter,
   SyncSeeker
 } from "./io.ts";
-import {
-  sendSync as sendSyncJson,
-  sendAsync as sendAsyncJson
-} from "./ops/dispatch_json.ts";
 import { close } from "./ops/resources.ts";
 import { read, readSync, write, writeSync } from "./ops/io.ts";
+import { seek, seekSync } from "./ops/fs/seek.ts";
+export { seek, seekSync } from "./ops/fs/seek.ts";
+import {
+  open as opOpen,
+  openSync as opOpenSync,
+  OpenOptions,
+  OpenMode
+} from "./ops/fs/open.ts";
+export { OpenOptions, OpenMode } from "./ops/fs/open.ts";
 
 /** Synchronously open a file and return an instance of the `File` object.
  *
@@ -24,31 +29,22 @@ import { read, readSync, write, writeSync } from "./ops/io.ts";
  * Requires `allow-read` and `allow-write` permissions depending on mode.
  */
 export function openSync(path: string, mode?: OpenOptions): File;
-
-/** Synchronously open a file and return an instance of the `File` object.
- *
- *       const file = Deno.openSync("/foo/bar.txt", "r");
- *
- * Requires `allow-read` and `allow-write` permissions depending on mode.
- */
 export function openSync(path: string, mode?: OpenMode): File;
-
-/**@internal*/
 export function openSync(
   path: string,
   modeOrOptions: OpenOptions | OpenMode = "r"
 ): File {
-  let mode = null;
-  let options = null;
+  let mode = undefined;
+  let options = undefined;
 
   if (typeof modeOrOptions === "string") {
     mode = modeOrOptions;
   } else {
     checkOpenOptions(modeOrOptions);
-    options = modeOrOptions;
+    options = modeOrOptions as OpenOptions;
   }
 
-  const rid = sendSyncJson("op_open", { path, options, mode });
+  const rid = opOpenSync(path, mode as OpenMode, options);
   return new File(rid);
 }
 
@@ -59,35 +55,22 @@ export function openSync(
  * Requires `allow-read` and `allow-write` permissions depending on mode.
  */
 export async function open(path: string, options?: OpenOptions): Promise<File>;
-
-/** Open a file and resolves to an instance of `Deno.File`.
- *
- *     const file = await Deno.open("/foo/bar.txt, "w+");
- *
- * Requires `allow-read` and `allow-write` permissions depending on mode.
- */
 export async function open(path: string, mode?: OpenMode): Promise<File>;
-
-/**@internal*/
 export async function open(
   path: string,
   modeOrOptions: OpenOptions | OpenMode = "r"
 ): Promise<File> {
-  let mode = null;
-  let options = null;
+  let mode = undefined;
+  let options = undefined;
 
   if (typeof modeOrOptions === "string") {
     mode = modeOrOptions;
   } else {
     checkOpenOptions(modeOrOptions);
-    options = modeOrOptions;
+    options = modeOrOptions as OpenOptions;
   }
 
-  const rid = await sendAsyncJson("op_open", {
-    path,
-    options,
-    mode
-  });
+  const rid = await opOpen(path, mode as OpenMode, options);
   return new File(rid);
 }
 
@@ -111,36 +94,6 @@ export function createSync(path: string): File {
  */
 export function create(path: string): Promise<File> {
   return open(path, "w+");
-}
-
-/** Synchronously seek a file ID to the given offset under mode given by `whence`.
- *
- * Returns the number of cursor position.
- *
- *       const file = Deno.openSync("/foo/bar.txt");
- *       const position = Deno.seekSync(file.rid, 0, 0);
- */
-export function seekSync(
-  rid: number,
-  offset: number,
-  whence: SeekMode
-): number {
-  return sendSyncJson("op_seek", { rid, offset, whence });
-}
-
-/** Seek a file ID to the given offset under mode given by `whence`.
- *
- * Resolves with the number of cursor position.
- *
- *      const file = await Deno.open("/foo/bar.txt");
- *      const position = await Deno.seek(file.rid, 0, 0);
- */
-export async function seek(
-  rid: number,
-  offset: number,
-  whence: SeekMode
-): Promise<number> {
-  return await sendAsyncJson("op_seek", { rid, offset, whence });
 }
 
 /** The Deno abstraction for reading and writing files. */
@@ -190,51 +143,6 @@ export const stdin = new File(0);
 export const stdout = new File(1);
 /** An instance of `Deno.File` for `stderr`. */
 export const stderr = new File(2);
-
-export interface OpenOptions {
-  /** Sets the option for read access. This option, when `true`, means that the
-   * file should be read-able if opened. */
-  read?: boolean;
-  /** Sets the option for write access. This option, when `true`, means that
-   * the file should be write-able if opened. If the file already exists,
-   * any write calls on it will overwrite its contents, by default without
-   * truncating it. */
-  write?: boolean;
-  /**Sets the option for the append mode. This option, when `true`, means that
-   * writes will append to a file instead of overwriting previous contents.
-   * Note that setting `{ write: true, append: true }` has the same effect as
-   * setting only `{ append: true }`. */
-  append?: boolean;
-  /** Sets the option for truncating a previous file. If a file is
-   * successfully opened with this option set it will truncate the file to `0`
-   * length if it already exists. The file must be opened with write access
-   * for truncate to work. */
-  truncate?: boolean;
-  /** Sets the option to allow creating a new file, if one doesn't already
-   * exist at the specified path. Requires write or append access to be
-   * used. */
-  create?: boolean;
-  /** Defaults to `false`. If set to `true`, no file, directory, or symlink is
-   * allowed to exist at the target location. Requires write or append
-   * access to be used. When createNew is set to `true`, create and truncate
-   * are ignored. */
-  createNew?: boolean;
-}
-
-/** A set of string literals which specify the open mode of a file.
- *
- * |Value |Description                                                                                       |
- * |------|--------------------------------------------------------------------------------------------------|
- * |`"r"` |Read-only. Default. Starts at beginning of file.                                                  |
- * |`"r+"`|Read-write. Start at beginning of file.                                                           |
- * |`"w"` |Write-only. Opens and truncates existing file or creates new one for writing only.                |
- * |`"w+"`|Read-write. Opens and truncates existing file or creates new one for writing and reading.         |
- * |`"a"` |Write-only. Opens existing file or creates new one. Each write appends content to the end of file.|
- * |`"a+"`|Read-write. Behaves like `"a"` and allows to read from file.                                      |
- * |`"x"` |Write-only. Exclusive create - creates new file only if one doesn't exist already.                |
- * |`"x+"`|Read-write. Behaves like `x` and allows reading from file.                                        |
- */
-export type OpenMode = "r" | "r+" | "w" | "w+" | "a" | "a+" | "x" | "x+";
 
 /** Check if OpenOptions is set to valid combination of options.
  *  @returns Tuple representing if openMode is valid and error message if it's not

--- a/cli/js/ops/fs/chmod.ts
+++ b/cli/js/ops/fs/chmod.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 /** Synchronously changes the permission of a specific file/directory of
  * specified path.  Ignores the process's umask.

--- a/cli/js/ops/fs/chown.ts
+++ b/cli/js/ops/fs/chown.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 /** Synchronously change owner of a regular file or directory. Linux/Mac OS
  * only at the moment.

--- a/cli/js/ops/fs/copy_file.ts
+++ b/cli/js/ops/fs/copy_file.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 /** Synchronously copies the contents and permissions of one file to another
  * specified path, by default creating a new file if needed, else overwriting.

--- a/cli/js/ops/fs/dir.ts
+++ b/cli/js/ops/fs/dir.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync } from "./ops/dispatch_json.ts";
+import { sendSync } from "../dispatch_json.ts";
 
 /**
  * **UNSTABLE**: maybe needs permissions.

--- a/cli/js/ops/fs/link.ts
+++ b/cli/js/ops/fs/link.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 /** Creates `newname` as a hard link to `oldname`.
  *

--- a/cli/js/ops/fs/make_temp.ts
+++ b/cli/js/ops/fs/make_temp.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 export interface MakeTempOptions {
   /** Directory where the temporary directory should be created (defaults to

--- a/cli/js/ops/fs/mkdir.ts
+++ b/cli/js/ops/fs/mkdir.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 // TODO(ry) The complexity in argument parsing is to support deprecated forms of
 // mkdir and mkdirSync.

--- a/cli/js/ops/fs/open.ts
+++ b/cli/js/ops/fs/open.ts
@@ -1,0 +1,67 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { sendSync, sendAsync } from "../dispatch_json.ts";
+
+export interface OpenOptions {
+  /** Sets the option for read access. This option, when `true`, means that the
+   * file should be read-able if opened. */
+  read?: boolean;
+  /** Sets the option for write access. This option, when `true`, means that
+   * the file should be write-able if opened. If the file already exists,
+   * any write calls on it will overwrite its contents, by default without
+   * truncating it. */
+  write?: boolean;
+  /**Sets the option for the append mode. This option, when `true`, means that
+   * writes will append to a file instead of overwriting previous contents.
+   * Note that setting `{ write: true, append: true }` has the same effect as
+   * setting only `{ append: true }`. */
+  append?: boolean;
+  /** Sets the option for truncating a previous file. If a file is
+   * successfully opened with this option set it will truncate the file to `0`
+   * length if it already exists. The file must be opened with write access
+   * for truncate to work. */
+  truncate?: boolean;
+  /** Sets the option to allow creating a new file, if one doesn't already
+   * exist at the specified path. Requires write or append access to be
+   * used. */
+  create?: boolean;
+  /** Defaults to `false`. If set to `true`, no file, directory, or symlink is
+   * allowed to exist at the target location. Requires write or append
+   * access to be used. When createNew is set to `true`, create and truncate
+   * are ignored. */
+  createNew?: boolean;
+}
+
+/** A set of string literals which specify the open mode of a file.
+ *
+ * |Value |Description                                                                                       |
+ * |------|--------------------------------------------------------------------------------------------------|
+ * |`"r"` |Read-only. Default. Starts at beginning of file.                                                  |
+ * |`"r+"`|Read-write. Start at beginning of file.                                                           |
+ * |`"w"` |Write-only. Opens and truncates existing file or creates new one for writing only.                |
+ * |`"w+"`|Read-write. Opens and truncates existing file or creates new one for writing and reading.         |
+ * |`"a"` |Write-only. Opens existing file or creates new one. Each write appends content to the end of file.|
+ * |`"a+"`|Read-write. Behaves like `"a"` and allows to read from file.                                      |
+ * |`"x"` |Write-only. Exclusive create - creates new file only if one doesn't exist already.                |
+ * |`"x+"`|Read-write. Behaves like `x` and allows reading from file.                                        |
+ */
+export type OpenMode = "r" | "r+" | "w" | "w+" | "a" | "a+" | "x" | "x+";
+
+export function openSync(
+  path: string,
+  mode: OpenMode | undefined,
+  options: OpenOptions | undefined
+): number {
+  return sendSync("op_open", { path, options, mode });
+}
+
+export async function open(
+  path: string,
+  mode: OpenMode | undefined,
+  options: OpenOptions | undefined
+): Promise<number> {
+  return await sendAsync("op_open", {
+    path,
+    options,
+    mode
+  });
+}

--- a/cli/js/ops/fs/read_dir.ts
+++ b/cli/js/ops/fs/read_dir.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
-import { FileInfo, FileInfoImpl } from "./file_info.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
+import { FileInfo, FileInfoImpl } from "../../file_info.ts";
 import { StatResponse } from "./stat.ts";
 
 interface ReadDirResponse {

--- a/cli/js/ops/fs/read_link.ts
+++ b/cli/js/ops/fs/read_link.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 /** Returns the destination of the named symbolic link.
  *

--- a/cli/js/ops/fs/realpath.ts
+++ b/cli/js/ops/fs/realpath.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 /** Returns absolute normalized path with symbolic links resolved synchronously.
  *

--- a/cli/js/ops/fs/remove.ts
+++ b/cli/js/ops/fs/remove.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 export interface RemoveOptions {
   /** Defaults to `false`. If set to `true`, path will be removed even if

--- a/cli/js/ops/fs/rename.ts
+++ b/cli/js/ops/fs/rename.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 /** Synchronously renames (moves) `oldpath` to `newpath`. If `newpath` already
  * exists and is not a directory, `renameSync()` replaces it. OS-specific

--- a/cli/js/ops/fs/seek.ts
+++ b/cli/js/ops/fs/seek.ts
@@ -1,0 +1,33 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { sendSync, sendAsync } from "../dispatch_json.ts";
+import { SeekMode } from "../../io.ts";
+
+/** Synchronously seek a file ID to the given offset under mode given by `whence`.
+ *
+ * Returns the number of cursor position.
+ *
+ *       const file = Deno.openSync("/foo/bar.txt");
+ *       const position = Deno.seekSync(file.rid, 0, 0);
+ */
+export function seekSync(
+  rid: number,
+  offset: number,
+  whence: SeekMode
+): number {
+  return sendSync("op_seek", { rid, offset, whence });
+}
+
+/** Seek a file ID to the given offset under mode given by `whence`.
+ *
+ * Resolves with the number of cursor position.
+ *
+ *      const file = await Deno.open("/foo/bar.txt");
+ *      const position = await Deno.seek(file.rid, 0, 0);
+ */
+export async function seek(
+  rid: number,
+  offset: number,
+  whence: SeekMode
+): Promise<number> {
+  return await sendAsync("op_seek", { rid, offset, whence });
+}

--- a/cli/js/ops/fs/stat.ts
+++ b/cli/js/ops/fs/stat.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
-import { FileInfo, FileInfoImpl } from "./file_info.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
+import { FileInfo, FileInfoImpl } from "../../file_info.ts";
 
 /** @internal */
 export interface StatResponse {

--- a/cli/js/ops/fs/symlink.ts
+++ b/cli/js/ops/fs/symlink.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
-import * as util from "./util.ts";
-import { build } from "./build.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
+import * as util from "../../util.ts";
+import { build } from "../../build.ts";
 
 /** **UNSTABLE**: `type` argument type may be changed to `"dir" | "file"`.
  *

--- a/cli/js/ops/fs/truncate.ts
+++ b/cli/js/ops/fs/truncate.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 function coerceLen(len?: number): number {
   if (!len) {

--- a/cli/js/ops/fs/utime.ts
+++ b/cli/js/ops/fs/utime.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync, sendAsync } from "./ops/dispatch_json.ts";
+import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 function toSecondsFromEpoch(v: number | Date): number {
   return v instanceof Date ? v.valueOf() / 1000 : v;

--- a/cli/js/ops/net.ts
+++ b/cli/js/ops/net.ts
@@ -1,0 +1,117 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { sendSync, sendAsync } from "./dispatch_json.ts";
+
+export type Transport = "tcp" | "udp";
+// TODO support other types:
+// export type Transport = "tcp" | "tcp4" | "tcp6" | "unix" | "unixpacket";
+
+export enum ShutdownMode {
+  // See http://man7.org/linux/man-pages/man2/shutdown.2.html
+  // Corresponding to SHUT_RD, SHUT_WR, SHUT_RDWR
+  Read = 0,
+  Write,
+  ReadWrite // unused
+}
+
+/** Shut down socket send and receive operations.
+ *
+ * Matches behavior of POSIX shutdown(3).
+ *
+ *       const listener = Deno.listen({ port: 80 });
+ *       const conn = await listener.accept();
+ *       Deno.shutdown(conn.rid, Deno.ShutdownMode.Write);
+ */
+export function shutdown(rid: number, how: ShutdownMode): void {
+  sendSync("op_shutdown", { rid, how });
+}
+
+interface AcceptResponse {
+  rid: number;
+  localAddr: {
+    hostname: string;
+    port: number;
+    transport: Transport;
+  };
+  remoteAddr: {
+    hostname: string;
+    port: number;
+    transport: Transport;
+  };
+}
+
+export async function accept(rid: number): Promise<AcceptResponse> {
+  return await sendAsync("op_accept", { rid });
+}
+
+export interface ListenRequest {
+  transport: Transport;
+  hostname: string;
+  port: number;
+}
+
+interface ListenResponse {
+  rid: number;
+  localAddr: {
+    hostname: string;
+    port: number;
+    transport: Transport;
+  };
+}
+
+export function listen(args: ListenRequest): ListenResponse {
+  return sendSync("op_listen", args);
+}
+
+interface ConnectResponse {
+  rid: number;
+  localAddr: {
+    hostname: string;
+    port: number;
+    transport: Transport;
+  };
+  remoteAddr: {
+    hostname: string;
+    port: number;
+    transport: Transport;
+  };
+}
+
+export interface ConnectRequest {
+  transport: Transport;
+  hostname: string;
+  port: number;
+}
+
+export async function connect(args: ConnectRequest): Promise<ConnectResponse> {
+  return await sendAsync("op_connect", args);
+}
+
+interface ReceiveResponse {
+  size: number;
+  remoteAddr: {
+    hostname: string;
+    port: number;
+    transport: Transport;
+  };
+}
+
+export async function receive(
+  rid: number,
+  zeroCopy: Uint8Array
+): Promise<ReceiveResponse> {
+  return await sendAsync("op_receive", { rid }, zeroCopy);
+}
+
+export interface SendRequest {
+  rid: number;
+  hostname: string;
+  port: number;
+  transport: Transport;
+}
+
+export async function send(
+  args: SendRequest,
+  zeroCopy: Uint8Array
+): Promise<void> {
+  await sendAsync("op_send", args, zeroCopy);
+}

--- a/cli/js/ops/timers.ts
+++ b/cli/js/ops/timers.ts
@@ -8,3 +8,12 @@ export function stopGlobalTimer(): void {
 export async function startGlobalTimer(timeout: number): Promise<void> {
   await sendAsync("op_global_timer", { timeout });
 }
+
+interface NowResponse {
+  seconds: number;
+  subsecNanos: number;
+}
+
+export function now(): NowResponse {
+  return sendSync("op_now");
+}

--- a/cli/js/ops/tls.ts
+++ b/cli/js/ops/tls.ts
@@ -1,0 +1,69 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { sendAsync, sendSync } from "./dispatch_json.ts";
+import { Transport } from "./net.ts";
+
+export interface ConnectTLSRequest {
+  transport: Transport;
+  hostname: string;
+  port: number;
+  cert_file?: string;
+}
+
+interface ConnectTLSResponse {
+  rid: number;
+  localAddr: {
+    hostname: string;
+    port: number;
+    transport: Transport;
+  };
+  remoteAddr: {
+    hostname: string;
+    port: number;
+    transport: Transport;
+  };
+}
+
+export async function connectTLS(
+  args: ConnectTLSRequest
+): Promise<ConnectTLSResponse> {
+  return await sendAsync("op_connect_tls", args);
+}
+
+interface AcceptTLSResponse {
+  rid: number;
+  localAddr: {
+    hostname: string;
+    port: number;
+    transport: Transport;
+  };
+  remoteAddr: {
+    hostname: string;
+    port: number;
+    transport: Transport;
+  };
+}
+
+export async function acceptTLS(rid: number): Promise<AcceptTLSResponse> {
+  return await sendAsync("op_accept_tls", { rid });
+}
+
+export interface ListenTLSRequest {
+  port: number;
+  hostname: string;
+  transport: Transport;
+  certFile: string;
+  keyFile: string;
+}
+
+interface ListenTLSResponse {
+  rid: number;
+  localAddr: {
+    hostname: string;
+    port: number;
+    transport: Transport;
+  };
+}
+
+export function listenTLS(args: ListenTLSRequest): ListenTLSResponse {
+  return sendSync("op_listen_tls", args);
+}

--- a/cli/js/performance.ts
+++ b/cli/js/performance.ts
@@ -1,10 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendSync } from "./ops/dispatch_json.ts";
-
-interface NowResponse {
-  seconds: number;
-  subsecNanos: number;
-}
+import { now as opNow } from "./ops/timers.ts";
 
 export class Performance {
   /** Returns a current time from Deno's start in milliseconds.
@@ -15,7 +10,7 @@ export class Performance {
    *       console.log(`${t} ms since start!`);
    */
   now(): number {
-    const res = sendSync("op_now") as NowResponse;
+    const res = opNow();
     return res.seconds * 1e3 + res.subsecNanos / 1e6;
   }
 }

--- a/cli/js/tls.ts
+++ b/cli/js/tls.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { sendAsync, sendSync } from "./ops/dispatch_json.ts";
+import * as tlsOps from "./ops/tls.ts";
 import { Listener, Transport, Conn, ConnImpl, ListenerImpl } from "./net.ts";
 
 // TODO(ry) There are many configuration options to add...
@@ -17,13 +17,13 @@ const connectTLSDefaults = { hostname: "127.0.0.1", transport: "tcp" };
  */
 export async function connectTLS(options: ConnectTLSOptions): Promise<Conn> {
   options = Object.assign(connectTLSDefaults, options);
-  const res = await sendAsync("op_connect_tls", options);
+  const res = await tlsOps.connectTLS(options as tlsOps.ConnectTLSRequest);
   return new ConnImpl(res.rid, res.remoteAddr!, res.localAddr!);
 }
 
 class TLSListenerImpl extends ListenerImpl {
   async accept(): Promise<Conn> {
-    const res = await sendAsync("op_accept_tls", { rid: this.rid });
+    const res = await tlsOps.acceptTLS(this.rid);
     return new ConnImpl(res.rid, res.remoteAddr, res.localAddr);
   }
 }
@@ -52,7 +52,7 @@ export interface ListenTLSOptions {
 export function listenTLS(options: ListenTLSOptions): Listener {
   const hostname = options.hostname || "0.0.0.0";
   const transport = options.transport || "tcp";
-  const res = sendSync("op_listen_tls", {
+  const res = tlsOps.listenTLS({
     hostname,
     port: options.port,
     transport,

--- a/cli/js/write_file.ts
+++ b/cli/js/write_file.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { stat, statSync } from "./stat.ts";
+import { stat, statSync } from "./ops/fs/stat.ts";
 import { open, openSync } from "./files.ts";
-import { chmod, chmodSync } from "./chmod.ts";
+import { chmod, chmodSync } from "./ops/fs/chmod.ts";
 import { writeAll, writeAllSync } from "./buffer.ts";
 
 /** Options for writing to a file. */


### PR DESCRIPTION
Following JS ops were moved to separate files in cli/js/ops directory:
- net
- tls
- fs
