### PR TITLE
Add actual error class to AssertionError message in assertThrows

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -315,9 +315,9 @@ export function assertThrows(
     fn();
   } catch (e) {
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
-      msg = `Expected error to be instance of "${ErrorClass.name}"${
-        msg ? `: ${msg}` : "."
-      }`;
+      msg = `Expected error to be instance of "${ErrorClass.name}", but was "${
+        e.constructor.name
+      }"${msg ? `: ${msg}` : "."}`;
       throw new AssertionError(msg);
     }
     if (msgIncludes && !e.message.includes(msgIncludes)) {

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -230,6 +230,24 @@ test(function testingAssertFail(): void {
   );
 });
 
+test(function testingAssertFailWithWrongErrorClass(): void {
+  assertThrows(
+    (): void => {
+      //This next assertThrows will throw an AssertionError due to the wrong
+      //expected error class
+      assertThrows(
+        (): void => {
+          fail("foo");
+        },
+        Error,
+        "Failed assertion: foo"
+      );
+    },
+    AssertionError,
+    `Expected error to be instance of "Error", but was "AssertionError"`
+  );
+});
+
 const createHeader = (): string[] => [
   "",
   "",


### PR DESCRIPTION
Given the following code:

```typescript
assertThrows(
  (): void => { fail("foo"); },
  MyError,
  "should throw MyError"
);
```

The original output was:
```
AssertionError: Expected error to be instance of "MyError".
```

With this change, the new output is:
```
AssertionError: Expected error to be instance of "MyError", but was "AssertionError".
```