### PR TITLE
refactor: uncomment tests broken tests, use skip

### DIFF
--- a/cli/js/tests/fetch_test.ts
+++ b/cli/js/tests/fetch_test.ts
@@ -203,15 +203,18 @@ unitTest(
   }
 );
 
-// The feature below is not implemented, but the test should work after implementation
-/*
-unitTest({ perms: { net: true} }, async function fetchWithInfRedirection(): Promise<
-  void
-> {
-  const response = await fetch("http://localhost:4549/cli/tests"); // will redirect to the same place
-  assertEquals(response.status, 0); // network error
-});
-*/
+unitTest(
+  {
+    // FIXME(bartlomieju):
+    // The feature below is not implemented, but the test should work after implementation
+    skip: true,
+    perms: { net: true }
+  },
+  async function fetchWithInfRedirection(): Promise<void> {
+    const response = await fetch("http://localhost:4549/cli/tests"); // will redirect to the same place
+    assertEquals(response.status, 0); // network error
+  }
+);
 
 unitTest(
   { perms: { net: true } },
@@ -320,11 +323,14 @@ unitTest({ perms: { net: true } }, async function fetchUserAgent(): Promise<
 //     at Object.assertEquals (file:///C:/deno/js/testing/util.ts:29:11)
 //     at fetchPostBodyString (file
 
-/*
 function bufferServer(addr: string): Deno.Buffer {
-  const listener = Deno.listen(addr);
+  const [hostname, port] = addr.split(":");
+  const listener = Deno.listen({
+    hostname,
+    port: Number(port)
+  }) as Deno.Listener;
   const buf = new Deno.Buffer();
-  listener.accept().then(async conn => {
+  listener.accept().then(async (conn: Deno.Conn) => {
     const p1 = buf.readFrom(conn);
     const p2 = conn.write(
       new TextEncoder().encode(
@@ -344,75 +350,104 @@ function bufferServer(addr: string): Deno.Buffer {
   return buf;
 }
 
-unitTest({ perms: { net: true} }, async function fetchRequest():Promise<void> {
-  const addr = "127.0.0.1:4501";
-  const buf = bufferServer(addr);
-  const response = await fetch(`http://${addr}/blah`, {
-    method: "POST",
-    headers: [["Hello", "World"], ["Foo", "Bar"]]
-  });
-  assertEquals(response.status, 404);
-  assertEquals(response.headers.get("Content-Length"), "2");
+unitTest(
+  {
+    // FIXME(bartlomieju)
+    skip: true,
+    perms: { net: true }
+  },
+  async function fetchRequest(): Promise<void> {
+    const addr = "127.0.0.1:4501";
+    const buf = bufferServer(addr);
+    const response = await fetch(`http://${addr}/blah`, {
+      method: "POST",
+      headers: [
+        ["Hello", "World"],
+        ["Foo", "Bar"]
+      ]
+    });
+    assertEquals(response.status, 404);
+    assertEquals(response.headers.get("Content-Length"), "2");
 
-  const actual = new TextDecoder().decode(buf.bytes());
-  const expected = [
-    "POST /blah HTTP/1.1\r\n",
-    "hello: World\r\n",
-    "foo: Bar\r\n",
-    `host: ${addr}\r\n\r\n`
-  ].join("");
-  assertEquals(actual, expected);
-});
+    const actual = new TextDecoder().decode(buf.bytes());
+    const expected = [
+      "POST /blah HTTP/1.1\r\n",
+      "hello: World\r\n",
+      "foo: Bar\r\n",
+      `host: ${addr}\r\n\r\n`
+    ].join("");
+    assertEquals(actual, expected);
+  }
+);
 
-unitTest({ perms: { net: true} }, async function fetchPostBodyString():Promise<void> {
-  const addr = "127.0.0.1:4502";
-  const buf = bufferServer(addr);
-  const body = "hello world";
-  const response = await fetch(`http://${addr}/blah`, {
-    method: "POST",
-    headers: [["Hello", "World"], ["Foo", "Bar"]],
-    body
-  });
-  assertEquals(response.status, 404);
-  assertEquals(response.headers.get("Content-Length"), "2");
+unitTest(
+  {
+    // FIXME(bartlomieju)
+    skip: true,
+    perms: { net: true }
+  },
+  async function fetchPostBodyString(): Promise<void> {
+    const addr = "127.0.0.1:4502";
+    const buf = bufferServer(addr);
+    const body = "hello world";
+    const response = await fetch(`http://${addr}/blah`, {
+      method: "POST",
+      headers: [
+        ["Hello", "World"],
+        ["Foo", "Bar"]
+      ],
+      body
+    });
+    assertEquals(response.status, 404);
+    assertEquals(response.headers.get("Content-Length"), "2");
 
-  const actual = new TextDecoder().decode(buf.bytes());
-  const expected = [
-    "POST /blah HTTP/1.1\r\n",
-    "hello: World\r\n",
-    "foo: Bar\r\n",
-    `host: ${addr}\r\n`,
-    `content-length: ${body.length}\r\n\r\n`,
-    body
-  ].join("");
-  assertEquals(actual, expected);
-});
+    const actual = new TextDecoder().decode(buf.bytes());
+    const expected = [
+      "POST /blah HTTP/1.1\r\n",
+      "hello: World\r\n",
+      "foo: Bar\r\n",
+      `host: ${addr}\r\n`,
+      `content-length: ${body.length}\r\n\r\n`,
+      body
+    ].join("");
+    assertEquals(actual, expected);
+  }
+);
 
-unitTest({ perms: { net: true} }, async function fetchPostBodyTypedArray():Promise<void> {
-  const addr = "127.0.0.1:4503";
-  const buf = bufferServer(addr);
-  const bodyStr = "hello world";
-  const body = new TextEncoder().encode(bodyStr);
-  const response = await fetch(`http://${addr}/blah`, {
-    method: "POST",
-    headers: [["Hello", "World"], ["Foo", "Bar"]],
-    body
-  });
-  assertEquals(response.status, 404);
-  assertEquals(response.headers.get("Content-Length"), "2");
+unitTest(
+  {
+    // FIXME(bartlomieju)
+    skip: true,
+    perms: { net: true }
+  },
+  async function fetchPostBodyTypedArray(): Promise<void> {
+    const addr = "127.0.0.1:4503";
+    const buf = bufferServer(addr);
+    const bodyStr = "hello world";
+    const body = new TextEncoder().encode(bodyStr);
+    const response = await fetch(`http://${addr}/blah`, {
+      method: "POST",
+      headers: [
+        ["Hello", "World"],
+        ["Foo", "Bar"]
+      ],
+      body
+    });
+    assertEquals(response.status, 404);
+    assertEquals(response.headers.get("Content-Length"), "2");
 
-  const actual = new TextDecoder().decode(buf.bytes());
-  const expected = [
-    "POST /blah HTTP/1.1\r\n",
-    "hello: World\r\n",
-    "foo: Bar\r\n",
-    `host: ${addr}\r\n`,
-    `content-length: ${body.byteLength}\r\n\r\n`,
-    bodyStr
-  ].join("");
-  assertEquals(actual, expected);
-});
-*/
+    const actual = new TextDecoder().decode(buf.bytes());
+    const expected = [
+      "POST /blah HTTP/1.1\r\n",
+      "hello: World\r\n",
+      "foo: Bar\r\n",
+      `host: ${addr}\r\n`,
+      `content-length: ${body.byteLength}\r\n\r\n`,
+      bodyStr
+    ].join("");
+    assertEquals(actual, expected);
+  }
+);
 
 unitTest(
   {

--- a/cli/js/tests/net_test.ts
+++ b/cli/js/tests/net_test.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertEquals } from "./test_util.ts";
+import {
+  unitTest,
+  assert,
+  assertEquals,
+  createResolvable
+} from "./test_util.ts";
 
 unitTest({ perms: { net: true } }, function netTcpListenClose(): void {
   const listener = Deno.listen({ hostname: "127.0.0.1", port: 4500 });
@@ -158,150 +163,176 @@ unitTest(
   }
 );
 
-/* TODO(ry) Re-enable this test.
-unitTest({ perms: { net: true } }, async function netListenAsyncIterator(): Promise<void> {
-  const listener = Deno.listen(":4500");
-  const runAsyncIterator = async (): Promise<void> => {
-    for await (let conn of listener) {
-      await conn.write(new Uint8Array([1, 2, 3]));
-      conn.close();
-    }
-  };
-  runAsyncIterator();
-  const conn = await Deno.connect("127.0.0.1:4500");
-  const buf = new Uint8Array(1024);
-  const readResult = await conn.read(buf);
-  assertEquals(3, readResult);
-  assertEquals(1, buf[0]);
-  assertEquals(2, buf[1]);
-  assertEquals(3, buf[2]);
-  assert(conn.rid > 0);
-
-  assert(readResult !== Deno.EOF);
-
-  const readResult2 = await conn.read(buf);
-  assertEquals(Deno.EOF, readResult2);
-
-  listener.close();
-  conn.close();
-});
- */
-
-/* TODO Fix broken test.
-unitTest({ perms: { net: true } }, async function netCloseReadSuccess() {
-  const addr = "127.0.0.1:4500";
-  const listener = Deno.listen(addr);
-  const closeDeferred = deferred();
-  const closeReadDeferred = deferred();
-  listener.accept().then(async conn => {
-    await closeReadDeferred.promise;
-    await conn.write(new Uint8Array([1, 2, 3]));
+unitTest(
+  {
+    // FIXME(bartlomieju)
+    skip: true,
+    perms: { net: true }
+  },
+  async function netListenAsyncIterator(): Promise<void> {
+    const addr = { hostname: "127.0.0.1", port: 4500 };
+    const listener = Deno.listen(addr);
+    const runAsyncIterator = async (): Promise<void> => {
+      for await (const conn of listener) {
+        await conn.write(new Uint8Array([1, 2, 3]));
+        conn.close();
+      }
+    };
+    runAsyncIterator();
+    const conn = await Deno.connect(addr);
     const buf = new Uint8Array(1024);
     const readResult = await conn.read(buf);
     assertEquals(3, readResult);
-    assertEquals(4, buf[0]);
-    assertEquals(5, buf[1]);
-    assertEquals(6, buf[2]);
+    assertEquals(1, buf[0]);
+    assertEquals(2, buf[1]);
+    assertEquals(3, buf[2]);
+    assert(conn.rid > 0);
+
+    assert(readResult !== Deno.EOF);
+
+    const readResult2 = await conn.read(buf);
+    assertEquals(Deno.EOF, readResult2);
+
+    listener.close();
     conn.close();
+  }
+);
+
+unitTest(
+  {
+    // FIXME(bartlomieju)
+    skip: true,
+    perms: { net: true }
+  },
+  async function netCloseReadSuccess() {
+    const addr = { hostname: "127.0.0.1", port: 4500 };
+    const listener = Deno.listen(addr);
+    const closeDeferred = createResolvable();
+    const closeReadDeferred = createResolvable();
+    listener.accept().then(async conn => {
+      await closeReadDeferred;
+      await conn.write(new Uint8Array([1, 2, 3]));
+      const buf = new Uint8Array(1024);
+      const readResult = await conn.read(buf);
+      assertEquals(3, readResult);
+      assertEquals(4, buf[0]);
+      assertEquals(5, buf[1]);
+      assertEquals(6, buf[2]);
+      conn.close();
+      closeDeferred.resolve();
+    });
+    const conn = await Deno.connect(addr);
+    conn.closeRead(); // closing read
+    closeReadDeferred.resolve();
+    const buf = new Uint8Array(1024);
+    const readResult = await conn.read(buf);
+    assertEquals(Deno.EOF, readResult); // with immediate EOF
+    // Ensure closeRead does not impact write
+    await conn.write(new Uint8Array([4, 5, 6]));
+    await closeDeferred;
+    listener.close();
+    conn.close();
+  }
+);
+
+unitTest(
+  {
+    // FIXME(bartlomieju)
+    skip: true,
+    perms: { net: true }
+  },
+  async function netDoubleCloseRead() {
+    const addr = { hostname: "127.0.0.1", port: 4500 };
+    const listener = Deno.listen(addr);
+    const closeDeferred = createResolvable();
+    listener.accept().then(async conn => {
+      await conn.write(new Uint8Array([1, 2, 3]));
+      await closeDeferred;
+      conn.close();
+    });
+    const conn = await Deno.connect(addr);
+    conn.closeRead(); // closing read
+    let err;
+    try {
+      // Duplicated close should throw error
+      conn.closeRead();
+    } catch (e) {
+      err = e;
+    }
+    assert(!!err);
+    assert(err instanceof Deno.errors.NotConnected);
     closeDeferred.resolve();
-  });
-  const conn = await Deno.connect(addr);
-  conn.closeRead(); // closing read
-  closeReadDeferred.resolve();
-  const buf = new Uint8Array(1024);
-  const readResult = await conn.read(buf);
-  assertEquals(Deno.EOF, readResult); // with immediate EOF
-  // Ensure closeRead does not impact write
-  await conn.write(new Uint8Array([4, 5, 6]));
-  await closeDeferred.promise;
-  listener.close();
-  conn.close();
-});
-*/
-
-/* TODO Fix broken test.
-unitTest({ perms: { net: true } }, async function netDoubleCloseRead() {
-  const addr = "127.0.0.1:4500";
-  const listener = Deno.listen(addr);
-  const closeDeferred = deferred();
-  listener.accept().then(async conn => {
-    await conn.write(new Uint8Array([1, 2, 3]));
-    await closeDeferred.promise;
+    listener.close();
     conn.close();
-  });
-  const conn = await Deno.connect(addr);
-  conn.closeRead(); // closing read
-  let err;
-  try {
-    // Duplicated close should throw error
-    conn.closeRead();
-  } catch (e) {
-    err = e;
   }
-  assert(!!err);
-  assert(err instanceof Deno.errors.NotConnected);
-  closeDeferred.resolve();
-  listener.close();
-  conn.close();
-});
-*/
+);
 
-/* TODO Fix broken test.
-unitTest({ perms: { net: true } }, async function netCloseWriteSuccess() {
-  const addr = "127.0.0.1:4500";
-  const listener = Deno.listen(addr);
-  const closeDeferred = deferred();
-  listener.accept().then(async conn => {
-    await conn.write(new Uint8Array([1, 2, 3]));
-    await closeDeferred.promise;
+unitTest(
+  {
+    // FIXME(bartlomieju)
+    skip: true,
+    perms: { net: true }
+  },
+  async function netCloseWriteSuccess() {
+    const addr = { hostname: "127.0.0.1", port: 4500 };
+    const listener = Deno.listen(addr);
+    const closeDeferred = createResolvable();
+    listener.accept().then(async conn => {
+      await conn.write(new Uint8Array([1, 2, 3]));
+      await closeDeferred;
+      conn.close();
+    });
+    const conn = await Deno.connect(addr);
+    conn.closeWrite(); // closing write
+    const buf = new Uint8Array(1024);
+    // Check read not impacted
+    const readResult = await conn.read(buf);
+    assertEquals(3, readResult);
+    assertEquals(1, buf[0]);
+    assertEquals(2, buf[1]);
+    assertEquals(3, buf[2]);
+    // Check write should be closed
+    let err;
+    try {
+      await conn.write(new Uint8Array([1, 2, 3]));
+    } catch (e) {
+      err = e;
+    }
+    assert(!!err);
+    assert(err instanceof Deno.errors.BrokenPipe);
+    closeDeferred.resolve();
+    listener.close();
     conn.close();
-  });
-  const conn = await Deno.connect(addr);
-  conn.closeWrite(); // closing write
-  const buf = new Uint8Array(1024);
-  // Check read not impacted
-  const readResult = await conn.read(buf);
-  assertEquals(3, readResult);
-  assertEquals(1, buf[0]);
-  assertEquals(2, buf[1]);
-  assertEquals(3, buf[2]);
-  // Check write should be closed
-  let err;
-  try {
-    await conn.write(new Uint8Array([1, 2, 3]));
-  } catch (e) {
-    err = e;
   }
-  assert(!!err);
-  assert(err instanceof Deno.errors.BrokenPipe);
-  closeDeferred.resolve();
-  listener.close();
-  conn.close();
-});
-*/
+);
 
-/* TODO Fix broken test.
-unitTest({ perms: { net: true } }, async function netDoubleCloseWrite() {
-  const addr = "127.0.0.1:4500";
-  const listener = Deno.listen(addr);
-  const closeDeferred = deferred();
-  listener.accept().then(async conn => {
-    await closeDeferred.promise;
+unitTest(
+  {
+    // FIXME(bartlomieju)
+    skip: true,
+    perms: { net: true }
+  },
+  async function netDoubleCloseWrite() {
+    const addr = { hostname: "127.0.0.1", port: 4500 };
+    const listener = Deno.listen(addr);
+    const closeDeferred = createResolvable();
+    listener.accept().then(async conn => {
+      await closeDeferred;
+      conn.close();
+    });
+    const conn = await Deno.connect(addr);
+    conn.closeWrite(); // closing write
+    let err;
+    try {
+      // Duplicated close should throw error
+      conn.closeWrite();
+    } catch (e) {
+      err = e;
+    }
+    assert(!!err);
+    assert(err instanceof Deno.errors.NotConnected);
+    closeDeferred.resolve();
+    listener.close();
     conn.close();
-  });
-  const conn = await Deno.connect(addr);
-  conn.closeWrite(); // closing write
-  let err;
-  try {
-    // Duplicated close should throw error
-    conn.closeWrite();
-  } catch (e) {
-    err = e;
   }
-  assert(!!err);
-  assert(err instanceof Deno.errors.NotConnected);
-  closeDeferred.resolve();
-  listener.close();
-  conn.close();
-});
-*/
+);

--- a/cli/js/tests/url_test.ts
+++ b/cli/js/tests/url_test.ts
@@ -180,15 +180,19 @@ unitTest(function sortingNonExistentParamRemovesQuestionMarkFromURL(): void {
   assertEquals(url.search, "");
 });
 
-/*
-unitTest(function customInspectFunction(): void {
-  const url = new URL("http://example.com/?");
-  assertEquals(
-    Deno.inspect(url),
-    'URL { href: "http://example.com/?", origin: "http://example.com", protocol: "http:", username: "", password: "", host: "example.com", hostname: "example.com", port: "", pathname: "/", hash: "", search: "?" }'
-  );
-});
-*/
+unitTest(
+  {
+    // FIXME(bartlomieju)
+    skip: true
+  },
+  function customInspectFunction(): void {
+    const url = new URL("http://example.com/?");
+    assertEquals(
+      Deno.inspect(url),
+      'URL { href: "http://example.com/?", origin: "http://example.com", protocol: "http:", username: "", password: "", host: "example.com", hostname: "example.com", port: "", pathname: "/", hash: "", search: "?" }'
+    );
+  }
+);
 
 unitTest(function protocolNotHttpOrFile() {
   const url = new URL("about:blank");


### PR DESCRIPTION
This PR uncomments all commented out tests and uses `UnitTestOptions.skip` to not run them.

This ensures tests still contain valid code.