### PR TITLE
Stricter permissions for make_temp

### DIFF
--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use std;
-use std::fs::{create_dir, DirBuilder, File, OpenOptions};
+use std::fs::{DirBuilder, File, OpenOptions};
 use std::io::ErrorKind;
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
@@ -11,7 +11,7 @@ use rand::Rng;
 use walkdir::WalkDir;
 
 #[cfg(unix)]
-use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
 
 #[cfg(unix)]
 use nix::unistd::{chown as unix_chown, Gid, Uid};
@@ -76,15 +76,17 @@ pub fn make_temp(
   loop {
     let unique = rng.gen::<u32>();
     buf.set_file_name(format!("{}{:08x}{}", prefix_, unique, suffix_));
-    // TODO: on posix, set mode flags to 0o700.
     let r = if is_dir {
-      create_dir(buf.as_path())
+      let mut builder = DirBuilder::new();
+      set_dir_permission(&mut builder, 0o700);
+      builder.create(buf.as_path())
     } else {
-      OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(buf.as_path())
-        .map(|_| ())
+      let mut open_options = OpenOptions::new();
+      open_options.write(true).create_new(true);
+      #[cfg(unix)]
+      open_options.mode(0o600);
+      open_options.open(buf.as_path())?;
+      Ok(())
     };
     match r {
       Err(ref e) if e.kind() == ErrorKind::AlreadyExists => continue,

--- a/cli/js/tests/make_temp_test.ts
+++ b/cli/js/tests/make_temp_test.ts
@@ -26,6 +26,17 @@ unitTest({ perms: { write: true } }, function makeTempDirSyncSuccess(): void {
   assert(err instanceof Deno.errors.NotFound);
 });
 
+unitTest(
+  { perms: { read: true, write: true } },
+  function makeTempDirSyncMode(): void {
+    const path = Deno.makeTempDirSync();
+    const pathInfo = Deno.statSync(path);
+    if (Deno.build.os !== "win") {
+      assertEquals(pathInfo.mode! & 0o777, 0o700 & ~Deno.umask());
+    }
+  }
+);
+
 unitTest(function makeTempDirSyncPerm(): void {
   // makeTempDirSync should require write permissions (for now).
   let err;
@@ -66,6 +77,17 @@ unitTest(
   }
 );
 
+unitTest(
+  { perms: { read: true, write: true } },
+  async function makeTempDirMode(): Promise<void> {
+    const path = await Deno.makeTempDir();
+    const pathInfo = Deno.statSync(path);
+    if (Deno.build.os !== "win") {
+      assertEquals(pathInfo.mode! & 0o777, 0o700 & ~Deno.umask());
+    }
+  }
+);
+
 unitTest({ perms: { write: true } }, function makeTempFileSyncSuccess(): void {
   const file1 = Deno.makeTempFileSync({ prefix: "hello", suffix: "world" });
   const file2 = Deno.makeTempFileSync({ prefix: "hello", suffix: "world" });
@@ -91,6 +113,17 @@ unitTest({ perms: { write: true } }, function makeTempFileSyncSuccess(): void {
   }
   assert(err instanceof Deno.errors.NotFound);
 });
+
+unitTest(
+  { perms: { read: true, write: true } },
+  function makeTempFileSyncMode(): void {
+    const path = Deno.makeTempFileSync();
+    const pathInfo = Deno.statSync(path);
+    if (Deno.build.os !== "win") {
+      assertEquals(pathInfo.mode! & 0o777, 0o600 & ~Deno.umask());
+    }
+  }
+);
 
 unitTest(function makeTempFileSyncPerm(): void {
   // makeTempFileSync should require write permissions (for now).
@@ -130,5 +163,16 @@ unitTest(
       err = err_;
     }
     assert(err instanceof Deno.errors.NotFound);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function makeTempFileMode(): Promise<void> {
+    const path = await Deno.makeTempFile();
+    const pathInfo = Deno.statSync(path);
+    if (Deno.build.os !== "win") {
+      assertEquals(pathInfo.mode! & 0o777, 0o600 & ~Deno.umask());
+    }
   }
 );


### PR DESCRIPTION
This PR (which replaces #4287, and is part of a series towards #4017), adds some functionality on Unix to makeTempDir and makeTempFile.

* makeTempDir uses stricter permissions of 0o700 (subject to the process's umask, which is usually 0o022 and so has no effect)

* makeTempFile uses stricter permissions of 0o600 (again with the umask)

We also add some tests for this.