### PR TITLE
Add FileInfo.anyModified

### DIFF
--- a/cli/js/file_info.ts
+++ b/cli/js/file_info.ts
@@ -12,6 +12,10 @@ export interface FileInfo {
    * field from `stat` on Linux/Mac OS and `ftLastWriteTime` on Windows. This
    * may not be available on all platforms. */
   modified: number | null;
+  /** The last time either the file or its metadata was modified. This corresponds
+   * to the `ctime` field from `stat` on Unix. Updated whenever `modified` is, and
+   * also when the file is chown/chmod/renamed/moved. Unix only. */
+  anyModified: number | null;
   /** The last access time of the file. This corresponds to the `atime`
    * field from `stat` on Unix and `ftLastAccessTime` on Windows. This may not
    * be available on all platforms. */
@@ -76,6 +80,7 @@ export class FileInfoImpl implements FileInfo {
   private readonly _isSymlink: boolean;
   len: number;
   modified: number | null;
+  anyModified: number | null;
   accessed: number | null;
   created: number | null;
   name: string | null;
@@ -99,6 +104,7 @@ export class FileInfoImpl implements FileInfo {
     const name = this._res.name;
     // Unix only
     const {
+      ctime,
       dev,
       ino,
       mode,
@@ -118,6 +124,7 @@ export class FileInfoImpl implements FileInfo {
     this.created = created ? created : null;
     this.name = name ? name : null;
     // Only non-null if on Unix
+    this.anyModified = isUnix ? ctime : null;
     this.dev = isUnix ? dev : null;
     this.ino = isUnix ? ino : null;
     this.mode = isUnix ? mode : null;

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1011,6 +1011,10 @@ declare namespace Deno {
      * field from `stat` on Linux/Mac OS and `ftLastWriteTime` on Windows. This
      * may not be available on all platforms. */
     modified: number | null;
+    /** The last time either the file or its metadata was modified. This corresponds
+     * to the `ctime` field from `stat` on Unix. Updated whenever `modified` is, and
+     * also when the file is chown/chmod/renamed/moved. Unix only. */
+    anyModified: number | null;
     /** The last access time of the file. This corresponds to the `atime`
      * field from `stat` on Unix and `ftLastAccessTime` on Windows. This may not
      * be available on all platforms. */

--- a/cli/js/ops/fs/stat.ts
+++ b/cli/js/ops/fs/stat.ts
@@ -12,6 +12,7 @@ export interface StatResponse {
   created: number;
   name: string | null;
   // Unix only members
+  ctime: number;
   dev: number;
   ino: number;
   mode: number;

--- a/cli/js/tests/stat_test.ts
+++ b/cli/js/tests/stat_test.ts
@@ -201,6 +201,7 @@ unitTest(
     assert(s.rdev === null);
     assert(s.blksize === null);
     assert(s.blocks === null);
+    assert(s.anyModified === null);
   }
 );
 
@@ -225,5 +226,6 @@ unitTest(
     assert(s.rdev !== null);
     assert(s.blksize !== null);
     assert(s.blocks !== null);
+    assert(s.anyModified !== null);
   }
 );

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -475,6 +475,7 @@ fn get_stat_json(
     "accessed":to_seconds!(metadata.accessed()),
     "created":to_seconds!(metadata.created()),
     // Following are only valid under Unix.
+    "ctime": usm!(ctime),
     "dev": usm!(dev),
     "ino": usm!(ino),
     "mode": usm!(mode),

--- a/std/node/_fs/_fs_dirent_test.ts
+++ b/std/node/_fs/_fs_dirent_test.ts
@@ -6,6 +6,7 @@ class FileInfoMock implements Deno.FileInfo {
   len = -1;
   modified = -1;
   accessed = -1;
+  anyModified = -1;
   created = -1;
   name = "";
   dev = -1;


### PR DESCRIPTION
This is part of a series of PRs towards #4017.

This reports the `ctime` field from Unix (and that's what the field is
named in the internal StatResponse structure).

Better names to use on the TypeScript side are welcome. `ctime` is
problematic because it often gets confused with creation-time.
`metadataModified` is a reasonable candidate, because this field (unlike
`modified`) gets refreshed whenever a file is chmod-ed, etc. But this
field is *also* refreshed whenever data is written. (So it will always
be at least as new as `modified`.)
