### PR TITLE
FileInfo len->length, StatResponse len->size

### DIFF
--- a/cli/js/file_info.ts
+++ b/cli/js/file_info.ts
@@ -7,7 +7,7 @@ import { build } from "./build.ts";
  * `readdirSync`. */
 export interface FileInfo {
   /** The size of the file, in bytes. */
-  len: number;
+  length: number;
   /** The last modification time of the file. This corresponds to the `mtime`
    * field from `stat` on Linux/Mac OS and `ftLastWriteTime` on Windows. This
    * may not be available on all platforms. */
@@ -74,7 +74,7 @@ export interface FileInfo {
 export class FileInfoImpl implements FileInfo {
   private readonly _isFile: boolean;
   private readonly _isSymlink: boolean;
-  len: number;
+  length: number;
   modified: number | null;
   accessed: number | null;
   created: number | null;
@@ -112,7 +112,7 @@ export class FileInfoImpl implements FileInfo {
 
     this._isFile = this._res.isFile;
     this._isSymlink = this._res.isSymlink;
-    this.len = this._res.len;
+    this.length = this._res.size;
     this.modified = modified ? modified : null;
     this.accessed = accessed ? accessed : null;
     this.created = created ? created : null;

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -997,16 +997,12 @@ declare namespace Deno {
 
   // @url js/file_info.d.ts
 
-  /** UNSTABLE: 'len' maybe should be 'length' or 'size'.
-   *
-   * A FileInfo describes a file and is returned by `stat`, `lstat`,
+  /** A FileInfo describes a file and is returned by `stat`, `lstat`,
    * `statSync`, `lstatSync`. A list of FileInfo is returned by `readdir`,
    * `readdirSync`. */
   export interface FileInfo {
-    /** **UNSTABLE**: `.len` maybe should be `.length` or `.size`.
-     *
-     * The size of the file, in bytes. */
-    len: number;
+    /** The size of the file, in bytes. */
+    length: number;
     /** The last modification time of the file. This corresponds to the `mtime`
      * field from `stat` on Linux/Mac OS and `ftLastWriteTime` on Windows. This
      * may not be available on all platforms. */

--- a/cli/js/ops/fs/stat.ts
+++ b/cli/js/ops/fs/stat.ts
@@ -6,7 +6,7 @@ import { FileInfo, FileInfoImpl } from "../../file_info.ts";
 export interface StatResponse {
   isFile: boolean;
   isSymlink: boolean;
-  len: number;
+  size: number;
   modified: number;
   accessed: number;
   created: number;

--- a/cli/js/tests/files_test.ts
+++ b/cli/js/tests/files_test.ts
@@ -19,7 +19,7 @@ unitTest({ perms: { read: true } }, async function filesCopyToStdout(): Promise<
   const file = await Deno.open(filename);
   assert(file.rid > 2);
   const bytesWritten = await Deno.copy(Deno.stdout, file);
-  const fileSize = Deno.statSync(filename).len;
+  const fileSize = Deno.statSync(filename).length;
   assertEquals(bytesWritten, fileSize);
   console.log("bytes written", bytesWritten);
   file.close();
@@ -234,12 +234,12 @@ unitTest(
     const f = await Deno.create(filename);
     let fileInfo = Deno.statSync(filename);
     assert(fileInfo.isFile());
-    assert(fileInfo.len === 0);
+    assert(fileInfo.length === 0);
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
     await f.write(data);
     fileInfo = Deno.statSync(filename);
-    assert(fileInfo.len === 5);
+    assert(fileInfo.length === 5);
     f.close();
 
     // TODO: test different modes
@@ -258,11 +258,11 @@ unitTest(
     // assert file was created
     let fileInfo = Deno.statSync(filename);
     assert(fileInfo.isFile());
-    assertEquals(fileInfo.len, 0);
+    assertEquals(fileInfo.length, 0);
     // write some data
     await file.write(data);
     fileInfo = Deno.statSync(filename);
-    assertEquals(fileInfo.len, 13);
+    assertEquals(fileInfo.length, 13);
     // assert we can't read from file
     let thrown = false;
     try {
@@ -277,7 +277,7 @@ unitTest(
     // assert that existing file is truncated on open
     file = await Deno.open(filename, "w");
     file.close();
-    const fileSize = Deno.statSync(filename).len;
+    const fileSize = Deno.statSync(filename).length;
     assertEquals(fileSize, 0);
     await Deno.remove(tempDir, { recursive: true });
   }
@@ -296,11 +296,11 @@ unitTest(
     // assert file was created
     let fileInfo = Deno.statSync(filename);
     assert(fileInfo.isFile());
-    assertEquals(fileInfo.len, 0);
+    assertEquals(fileInfo.length, 0);
     // write some data
     await file.write(data);
     fileInfo = Deno.statSync(filename);
-    assertEquals(fileInfo.len, 13);
+    assertEquals(fileInfo.length, 13);
 
     const buf = new Uint8Array(20);
     // seeking from beginning of a file

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -469,7 +469,7 @@ fn get_stat_json(
   let mut json_val = json!({
     "isFile": metadata.is_file(),
     "isSymlink": metadata.file_type().is_symlink(),
-    "len": metadata.len(),
+    "size": metadata.len(),
     // In seconds. Available on both Unix or Windows.
     "modified":to_seconds!(metadata.modified()),
     "accessed":to_seconds!(metadata.accessed()),

--- a/std/archive/tar.ts
+++ b/std/archive/tar.ts
@@ -334,7 +334,7 @@ export class Tar {
       );
     }
 
-    const fileSize = info?.len ?? opts.contentSize;
+    const fileSize = info?.length ?? opts.contentSize;
     assert(fileSize != null, "fileSize must be set");
     const tarData: TarDataWithSource = {
       fileName,

--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -102,7 +102,7 @@ async function serveFile(
 ): Promise<Response> {
   const [file, fileInfo] = await Promise.all([open(filePath), stat(filePath)]);
   const headers = new Headers();
-  headers.set("content-length", fileInfo.len.toString());
+  headers.set("content-length", fileInfo.length.toString());
   headers.set("content-type", "text/plain; charset=utf-8");
 
   const res = {
@@ -135,7 +135,7 @@ async function serveDir(
     } catch (e) {}
     listEntry.push({
       mode: modeToString(fileInfo.isDirectory(), mode),
-      size: fileInfo.isFile() ? fileLenToString(fileInfo.len) : "",
+      size: fileInfo.isFile() ? fileLenToString(fileInfo.length) : "",
       name: fileInfo.name ?? "",
       url: fileUrl
     });

--- a/std/node/_fs/_fs_dirent_test.ts
+++ b/std/node/_fs/_fs_dirent_test.ts
@@ -3,7 +3,7 @@ import { assert, assertEquals, assertThrows } from "../../testing/asserts.ts";
 import Dirent from "./_fs_dirent.ts";
 
 class FileInfoMock implements Deno.FileInfo {
-  len = -1;
+  length = -1;
   modified = -1;
   accessed = -1;
   created = -1;


### PR DESCRIPTION
Comments in the code proposed that the `FileInfo.len` field might be renamed to `length`, and that is implemented by this PR.

`len` is what the Rust API uses, but most of the corresponding Javascript APIs use `length`. Node uses `size`. The underlying field in the libc structure is st_size.

StatResponse is an internal interface; in the spirit of keeping its field names close to those of the
underlying libc structure, renamed its `len` which corresponds to st_size to `size`. We could also change that to `length` too, or leave it as `len`... though the last choice is likely to be most confusing, as it would have only a historical explanation.
