### PR TITLE
BREAKING CHANGE Remove --allow-run, --allow-plugin

### DIFF
--- a/cli/js/tests/chown_test.ts
+++ b/cli/js/tests/chown_test.ts
@@ -38,7 +38,7 @@ if (Deno.build.os !== "win") {
   });
 
   unitTest(
-    { perms: { run: true, write: true } },
+    { perms: { all: true } },
     async function chownSyncFileNotExist(): Promise<void> {
       const { uid, gid } = await getUidAndGid();
       const filePath = Deno.makeTempDirSync() + "/chown_test_file.txt";
@@ -52,7 +52,7 @@ if (Deno.build.os !== "win") {
   );
 
   unitTest(
-    { perms: { run: true, write: true } },
+    { perms: { all: true } },
     async function chownFileNotExist(): Promise<void> {
       const { uid, gid } = await getUidAndGid();
       const filePath = (await Deno.makeTempDir()) + "/chown_test_file.txt";
@@ -103,30 +103,29 @@ if (Deno.build.os !== "win") {
     }
   );
 
+  unitTest({ perms: { all: true } }, async function chownSyncSucceed(): Promise<
+    void
+  > {
+    // TODO: when a file's owner is actually being changed,
+    // chown only succeeds if run under priviledged user (root)
+    // The test script has no such priviledge, so need to find a better way to test this case
+    const { uid, gid } = await getUidAndGid();
+
+    const enc = new TextEncoder();
+    const dirPath = Deno.makeTempDirSync();
+    const filePath = dirPath + "/chown_test_file.txt";
+    const fileData = enc.encode("Hello");
+    Deno.writeFileSync(filePath, fileData);
+
+    // the test script creates this file with the same uid and gid,
+    // here chown is a noop so it succeeds under non-priviledged user
+    Deno.chownSync(filePath, uid, gid);
+
+    Deno.removeSync(dirPath, { recursive: true });
+  });
+
   unitTest(
-    { perms: { run: true, write: true } },
-    async function chownSyncSucceed(): Promise<void> {
-      // TODO: when a file's owner is actually being changed,
-      // chown only succeeds if run under priviledged user (root)
-      // The test script has no such priviledge, so need to find a better way to test this case
-      const { uid, gid } = await getUidAndGid();
-
-      const enc = new TextEncoder();
-      const dirPath = Deno.makeTempDirSync();
-      const filePath = dirPath + "/chown_test_file.txt";
-      const fileData = enc.encode("Hello");
-      Deno.writeFileSync(filePath, fileData);
-
-      // the test script creates this file with the same uid and gid,
-      // here chown is a noop so it succeeds under non-priviledged user
-      Deno.chownSync(filePath, uid, gid);
-
-      Deno.removeSync(dirPath, { recursive: true });
-    }
-  );
-
-  unitTest(
-    { perms: { run: true, write: true } },
+    { perms: { all: true, write: true } },
     async function chownSucceed(): Promise<void> {
       // TODO: same as chownSyncSucceed
       const { uid, gid } = await getUidAndGid();

--- a/cli/js/tests/os_test.ts
+++ b/cli/js/tests/os_test.ts
@@ -50,7 +50,7 @@ unitTest(function envPermissionDenied2(): void {
 // case-insensitive. Case normalization needs be done using the collation
 // that Windows uses, rather than naively using String.toLowerCase().
 unitTest(
-  { skip: Deno.build.os !== "win", perms: { env: true, run: true } },
+  { skip: Deno.build.os !== "win", perms: { all: true } },
   async function envCaseInsensitive() {
     // Utility function that runs a Deno subprocess with the environment
     // specified in `inputEnv`. The subprocess reads the environment variables

--- a/cli/js/tests/process_test.ts
+++ b/cli/js/tests/process_test.ts
@@ -18,7 +18,7 @@ unitTest(function runPermissions(): void {
   assert(caughtError);
 });
 
-unitTest({ perms: { run: true } }, async function runSuccess(): Promise<void> {
+unitTest({ perms: { all: true } }, async function runSuccess(): Promise<void> {
   const p = run({
     args: ["python", "-c", "print('hello world')"],
     stdout: "piped",
@@ -33,7 +33,7 @@ unitTest({ perms: { run: true } }, async function runSuccess(): Promise<void> {
 });
 
 unitTest(
-  { perms: { run: true } },
+  { perms: { all: true } },
   async function runCommandFailedWithCode(): Promise<void> {
     const p = run({
       args: ["python", "-c", "import sys;sys.exit(41 + 1)"]
@@ -50,7 +50,7 @@ unitTest(
   {
     // No signals on windows.
     skip: Deno.build.os === "win",
-    perms: { run: true }
+    perms: { all: true }
   },
   async function runCommandFailedWithSignal(): Promise<void> {
     const p = run({
@@ -64,7 +64,7 @@ unitTest(
   }
 );
 
-unitTest({ perms: { run: true } }, function runNotFound(): void {
+unitTest({ perms: { all: true } }, function runNotFound(): void {
   let error;
   try {
     run({ args: ["this file hopefully doesn't exist"] });
@@ -75,15 +75,15 @@ unitTest({ perms: { run: true } }, function runNotFound(): void {
   assert(error instanceof Deno.errors.NotFound);
 });
 
-unitTest(
-  { perms: { write: true, run: true } },
-  async function runWithCwdIsAsync(): Promise<void> {
-    const enc = new TextEncoder();
-    const cwd = await makeTempDir({ prefix: "deno_command_test" });
+unitTest({ perms: { all: true } }, async function runWithCwdIsAsync(): Promise<
+  void
+> {
+  const enc = new TextEncoder();
+  const cwd = await makeTempDir({ prefix: "deno_command_test" });
 
-    const exitCodeFile = "deno_was_here";
-    const pyProgramFile = "poll_exit.py";
-    const pyProgram = `
+  const exitCodeFile = "deno_was_here";
+  const pyProgramFile = "poll_exit.py";
+  const pyProgram = `
 from sys import exit
 from time import sleep
 
@@ -99,26 +99,25 @@ while True:
     pass
 `;
 
-    Deno.writeFileSync(`${cwd}/${pyProgramFile}.py`, enc.encode(pyProgram));
-    const p = run({
-      cwd,
-      args: ["python", `${pyProgramFile}.py`]
-    });
+  Deno.writeFileSync(`${cwd}/${pyProgramFile}.py`, enc.encode(pyProgram));
+  const p = run({
+    cwd,
+    args: ["python", `${pyProgramFile}.py`]
+  });
 
-    // Write the expected exit code *after* starting python.
-    // This is how we verify that `run()` is actually asynchronous.
-    const code = 84;
-    Deno.writeFileSync(`${cwd}/${exitCodeFile}`, enc.encode(`${code}`));
+  // Write the expected exit code *after* starting python.
+  // This is how we verify that `run()` is actually asynchronous.
+  const code = 84;
+  Deno.writeFileSync(`${cwd}/${exitCodeFile}`, enc.encode(`${code}`));
 
-    const status = await p.status();
-    assertEquals(status.success, false);
-    assertEquals(status.code, code);
-    assertEquals(status.signal, undefined);
-    p.close();
-  }
-);
+  const status = await p.status();
+  assertEquals(status.success, false);
+  assertEquals(status.code, code);
+  assertEquals(status.signal, undefined);
+  p.close();
+});
 
-unitTest({ perms: { run: true } }, async function runStdinPiped(): Promise<
+unitTest({ perms: { all: true } }, async function runStdinPiped(): Promise<
   void
 > {
   const p = run({
@@ -142,7 +141,7 @@ unitTest({ perms: { run: true } }, async function runStdinPiped(): Promise<
   p.close();
 });
 
-unitTest({ perms: { run: true } }, async function runStdoutPiped(): Promise<
+unitTest({ perms: { all: true } }, async function runStdoutPiped(): Promise<
   void
 > {
   const p = run({
@@ -171,7 +170,7 @@ unitTest({ perms: { run: true } }, async function runStdoutPiped(): Promise<
   p.close();
 });
 
-unitTest({ perms: { run: true } }, async function runStderrPiped(): Promise<
+unitTest({ perms: { all: true } }, async function runStderrPiped(): Promise<
   void
 > {
   const p = run({
@@ -200,7 +199,7 @@ unitTest({ perms: { run: true } }, async function runStderrPiped(): Promise<
   p.close();
 });
 
-unitTest({ perms: { run: true } }, async function runOutput(): Promise<void> {
+unitTest({ perms: { all: true } }, async function runOutput(): Promise<void> {
   const p = run({
     args: ["python", "-c", "import sys; sys.stdout.write('hello')"],
     stdout: "piped"
@@ -211,7 +210,7 @@ unitTest({ perms: { run: true } }, async function runOutput(): Promise<void> {
   p.close();
 });
 
-unitTest({ perms: { run: true } }, async function runStderrOutput(): Promise<
+unitTest({ perms: { all: true } }, async function runStderrOutput(): Promise<
   void
 > {
   const p = run({
@@ -225,7 +224,7 @@ unitTest({ perms: { run: true } }, async function runStderrOutput(): Promise<
 });
 
 unitTest(
-  { perms: { run: true, write: true, read: true } },
+  { perms: { all: true } },
   async function runRedirectStdoutStderr(): Promise<void> {
     const tempDir = await makeTempDir();
     const fileName = tempDir + "/redirected_stdio.txt";
@@ -254,28 +253,27 @@ unitTest(
   }
 );
 
-unitTest(
-  { perms: { run: true, write: true, read: true } },
-  async function runRedirectStdin(): Promise<void> {
-    const tempDir = await makeTempDir();
-    const fileName = tempDir + "/redirected_stdio.txt";
-    const encoder = new TextEncoder();
-    await writeFile(fileName, encoder.encode("hello"));
-    const file = await open(fileName, "r");
+unitTest({ perms: { all: true } }, async function runRedirectStdin(): Promise<
+  void
+> {
+  const tempDir = await makeTempDir();
+  const fileName = tempDir + "/redirected_stdio.txt";
+  const encoder = new TextEncoder();
+  await writeFile(fileName, encoder.encode("hello"));
+  const file = await open(fileName, "r");
 
-    const p = run({
-      args: ["python", "-c", "import sys; assert 'hello' == sys.stdin.read();"],
-      stdin: file.rid
-    });
+  const p = run({
+    args: ["python", "-c", "import sys; assert 'hello' == sys.stdin.read();"],
+    stdin: file.rid
+  });
 
-    const status = await p.status();
-    assertEquals(status.code, 0);
-    p.close();
-    file.close();
-  }
-);
+  const status = await p.status();
+  assertEquals(status.code, 0);
+  p.close();
+  file.close();
+});
 
-unitTest({ perms: { run: true } }, async function runEnv(): Promise<void> {
+unitTest({ perms: { all: true } }, async function runEnv(): Promise<void> {
   const p = run({
     args: [
       "python",
@@ -294,7 +292,7 @@ unitTest({ perms: { run: true } }, async function runEnv(): Promise<void> {
   p.close();
 });
 
-unitTest({ perms: { run: true } }, async function runClose(): Promise<void> {
+unitTest({ perms: { all: true } }, async function runClose(): Promise<void> {
   const p = run({
     args: [
       "python",
@@ -339,7 +337,7 @@ if (Deno.build.os !== "win") {
     assert(caughtError);
   });
 
-  unitTest({ perms: { run: true } }, async function killSuccess(): Promise<
+  unitTest({ perms: { all: true } }, async function killSuccess(): Promise<
     void
   > {
     const p = run({
@@ -359,7 +357,7 @@ if (Deno.build.os !== "win") {
     p.close();
   });
 
-  unitTest({ perms: { run: true } }, async function killFailed(): Promise<
+  unitTest({ perms: { all: true } }, async function killFailed(): Promise<
     void
   > {
     const p = run({

--- a/cli/js/tests/signal_test.ts
+++ b/cli/js/tests/signal_test.ts
@@ -104,7 +104,7 @@ unitTest(
 );
 
 unitTest(
-  { skip: Deno.build.os === "win", perms: { run: true, net: true } },
+  { skip: Deno.build.os === "win", perms: { all: true } },
   async function signalStreamTest(): Promise<void> {
     const resolvable = createResolvable();
     // This prevents the program from exiting.
@@ -138,7 +138,7 @@ unitTest(
 );
 
 unitTest(
-  { skip: Deno.build.os === "win", perms: { run: true } },
+  { skip: Deno.build.os === "win", perms: { all: true } },
   async function signalPromiseTest(): Promise<void> {
     const resolvable = createResolvable();
     // This prevents the program from exiting.
@@ -161,7 +161,7 @@ unitTest(
 );
 
 unitTest(
-  { skip: Deno.build.os === "win", perms: { run: true } },
+  { skip: Deno.build.os === "win", perms: { all: true } },
   async function signalShorthandsTest(): Promise<void> {
     let s: Deno.SignalStream;
     s = Deno.signals.alarm(); // for SIGALRM

--- a/cli/js/tests/test_util.ts
+++ b/cli/js/tests/test_util.ts
@@ -22,12 +22,11 @@ export {
 } from "../../../std/testing/asserts.ts";
 
 interface TestPermissions {
+  all?: boolean;
   read?: boolean;
   write?: boolean;
   net?: boolean;
   env?: boolean;
-  run?: boolean;
-  plugin?: boolean;
   hrtime?: boolean;
 }
 
@@ -36,8 +35,6 @@ export interface Permissions {
   write: boolean;
   net: boolean;
   env: boolean;
-  run: boolean;
-  plugin: boolean;
   hrtime: boolean;
 }
 
@@ -46,12 +43,10 @@ const isGranted = async (name: Deno.PermissionName): Promise<boolean> =>
 
 async function getProcessPermissions(): Promise<Permissions> {
   return {
-    run: await isGranted("run"),
     read: await isGranted("read"),
     write: await isGranted("write"),
     net: await isGranted("net"),
     env: await isGranted("env"),
-    plugin: await isGranted("plugin"),
     hrtime: await isGranted("hrtime")
   };
 }
@@ -81,10 +76,8 @@ function permToString(perms: Permissions): string {
   const w = perms.write ? 1 : 0;
   const n = perms.net ? 1 : 0;
   const e = perms.env ? 1 : 0;
-  const u = perms.run ? 1 : 0;
-  const p = perms.plugin ? 1 : 0;
   const h = perms.hrtime ? 1 : 0;
-  return `permR${r}W${w}N${n}E${e}U${u}P${p}H${h}`;
+  return `permR${r}W${w}N${n}E${e}H${h}`;
 }
 
 function registerPermCombination(perms: Permissions): void {
@@ -96,13 +89,11 @@ function registerPermCombination(perms: Permissions): void {
 
 function normalizeTestPermissions(perms: TestPermissions): Permissions {
   return {
-    read: !!perms.read,
-    write: !!perms.write,
-    net: !!perms.net,
-    run: !!perms.run,
-    env: !!perms.env,
-    plugin: !!perms.plugin,
-    hrtime: !!perms.hrtime
+    read: perms.all || !!perms.read,
+    write: perms.all || !!perms.write,
+    net: perms.all || !!perms.net,
+    env: perms.all || !!perms.env,
+    hrtime: perms.all || !!perms.hrtime
   };
 }
 
@@ -262,8 +253,6 @@ unitTest(function permissionsMatches(): void {
         write: false,
         net: false,
         env: false,
-        run: false,
-        plugin: false,
         hrtime: false
       },
       normalizeTestPermissions({ read: true })
@@ -277,8 +266,6 @@ unitTest(function permissionsMatches(): void {
         write: false,
         net: false,
         env: false,
-        run: false,
-        plugin: false,
         hrtime: false
       },
       normalizeTestPermissions({})
@@ -292,8 +279,6 @@ unitTest(function permissionsMatches(): void {
         write: true,
         net: true,
         env: true,
-        run: true,
-        plugin: true,
         hrtime: true
       },
       normalizeTestPermissions({ read: true })
@@ -308,8 +293,6 @@ unitTest(function permissionsMatches(): void {
         write: false,
         net: true,
         env: false,
-        run: false,
-        plugin: false,
         hrtime: false
       },
       normalizeTestPermissions({ read: true })
@@ -324,8 +307,6 @@ unitTest(function permissionsMatches(): void {
         write: true,
         net: true,
         env: true,
-        run: true,
-        plugin: true,
         hrtime: true
       },
       {
@@ -333,8 +314,6 @@ unitTest(function permissionsMatches(): void {
         write: true,
         net: true,
         env: true,
-        run: true,
-        plugin: true,
         hrtime: true
       }
     )

--- a/cli/ops/permissions.rs
+++ b/cli/ops/permissions.rs
@@ -61,12 +61,10 @@ pub fn op_revoke_permission(
   let mut state = state.borrow_mut();
   let permissions = &mut state.permissions;
   match args.name.as_ref() {
-    "run" => permissions.allow_run.revoke(),
     "read" => permissions.allow_read.revoke(),
     "write" => permissions.allow_write.revoke(),
     "net" => permissions.allow_net.revoke(),
     "env" => permissions.allow_env.revoke(),
-    "plugin" => permissions.allow_plugin.revoke(),
     "hrtime" => permissions.allow_hrtime.revoke(),
     _ => {}
   };
@@ -89,7 +87,6 @@ pub fn op_request_permission(
   let permissions = &mut state.permissions;
   let resolved_path = args.path.as_deref().map(resolve_path);
   let perm = match args.name.as_ref() {
-    "run" => Ok(permissions.request_run()),
     "read" => {
       Ok(permissions.request_read(&resolved_path.as_deref().map(Path::new)))
     }
@@ -98,7 +95,6 @@ pub fn op_request_permission(
     }
     "net" => permissions.request_net(&args.url.as_deref()),
     "env" => Ok(permissions.request_env()),
-    "plugin" => Ok(permissions.request_plugin()),
     "hrtime" => Ok(permissions.request_hrtime()),
     n => Err(OpError::other(format!("No such permission name: {}", n))),
   }?;

--- a/cli/ops/plugins.rs
+++ b/cli/ops/plugins.rs
@@ -60,7 +60,7 @@ pub fn op_open_plugin(
   let args: OpenPluginArgs = serde_json::from_value(args)?;
   let filename = deno_fs::resolve_from_cwd(Path::new(&args.filename))?;
 
-  state.check_plugin(&filename)?;
+  state.check_all()?;
 
   let lib = open_plugin(filename)?;
   let plugin_resource = PluginResource {

--- a/cli/ops/process.rs
+++ b/cli/ops/process.rs
@@ -71,7 +71,7 @@ fn op_run(
 ) -> Result<JsonOp, OpError> {
   let run_args: RunArgs = serde_json::from_value(args)?;
 
-  state.check_run()?;
+  state.check_all()?;
   let state_ = state.clone();
 
   let args = run_args.args;
@@ -188,7 +188,7 @@ fn op_run_status(
   let args: RunStatusArgs = serde_json::from_value(args)?;
   let rid = args.rid as u32;
 
-  state.check_run()?;
+  state.check_all()?;
   let state = state.clone();
 
   let future = async move {
@@ -235,7 +235,7 @@ fn op_kill(
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
-  state.check_run()?;
+  state.check_all()?;
 
   let args: KillArgs = serde_json::from_value(args)?;
   kill(args.pid, args.signo)?;

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -304,6 +304,11 @@ impl State {
   }
 
   #[inline]
+  pub fn check_all(&self) -> Result<(), OpError> {
+    self.borrow().permissions.check_all()
+  }
+
+  #[inline]
   pub fn check_read(&self, path: &Path) -> Result<(), OpError> {
     self.borrow().permissions.check_read(path)
   }
@@ -326,16 +331,6 @@ impl State {
   #[inline]
   pub fn check_net_url(&self, url: &url::Url) -> Result<(), OpError> {
     self.borrow().permissions.check_net_url(url)
-  }
-
-  #[inline]
-  pub fn check_run(&self) -> Result<(), OpError> {
-    self.borrow().permissions.check_run()
-  }
-
-  #[inline]
-  pub fn check_plugin(&self, filename: &Path) -> Result<(), OpError> {
-    self.borrow().permissions.check_plugin(filename)
   }
 
   pub fn check_dyn_import(

--- a/cli/tests/057_revoke_permissions.out
+++ b/cli/tests/057_revoke_permissions.out
@@ -1,10 +1,8 @@
-running 7 tests
-OK     runGranted [WILDCARD]
+running 5 tests
 OK     readGranted [WILDCARD]
 OK     writeGranted [WILDCARD]
 OK     netGranted [WILDCARD]
 OK     envGranted [WILDCARD]
-OK     pluginGranted [WILDCARD]
 OK     hrtimeGranted [WILDCARD]
 
-test result: OK 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out [WILDCARD]
+test result: OK 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out [WILDCARD]

--- a/cli/tests/057_revoke_permissions.ts
+++ b/cli/tests/057_revoke_permissions.ts
@@ -1,12 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 const knownPermissions: Deno.PermissionName[] = [
-  "run",
   "read",
   "write",
   "net",
   "env",
-  "plugin",
   "hrtime"
 ];
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -272,8 +272,7 @@ fn js_unit_tests() {
     .current_dir(util::root_path())
     .arg("run")
     .arg("--reload")
-    .arg("--allow-run")
-    .arg("--allow-env")
+    .arg("--allow-all")
     .arg("cli/js/tests/unit_test_runner.ts")
     .spawn()
     .expect("failed to spawn script");
@@ -973,7 +972,7 @@ itest!(_044_bad_resource {
 });
 
 itest_ignore!(_045_proxy {
-  args: "run --allow-net --allow-env --allow-run --reload 045_proxy_test.ts",
+  args: "run --allow-all --reload 045_proxy_test.ts",
   output: "045_proxy_test.ts.out",
   http_server: true,
 });
@@ -1052,8 +1051,7 @@ itest!(js_import_detect {
 });
 
 itest!(lock_write_fetch {
-  args:
-    "run --allow-read --allow-write --allow-env --allow-run lock_write_fetch.ts",
+  args: "run --allow-all lock_write_fetch.ts",
   output: "lock_write_fetch.ts.out",
   exit_code: 0,
 });
@@ -1936,8 +1934,7 @@ mod util {
 
   use tempfile::TempDir;
 
-  pub const PERMISSION_VARIANTS: [&str; 5] =
-    ["read", "write", "env", "net", "run"];
+  pub const PERMISSION_VARIANTS: [&str; 4] = ["read", "write", "env", "net"];
   pub const PERMISSION_DENIED_PATTERN: &str = "PermissionDenied";
 
   lazy_static! {

--- a/std/manual.md
+++ b/std/manual.md
@@ -376,7 +376,7 @@ await p.status();
 Run it:
 
 ```shell
-$ deno --allow-run ./subprocess_simple.ts
+$ deno --allow-all ./subprocess_simple.ts
 hello
 ```
 
@@ -421,10 +421,10 @@ Deno.exit(code);
 When you run it:
 
 ```shell
-$ deno run --allow-run ./subprocess.ts <somefile>
+$ deno run --allow-all ./subprocess.ts <somefile>
 [file content]
 
-$ deno run --allow-run ./subprocess.ts non_existent_file.md
+$ deno run --allow-all ./subprocess.ts non_existent_file.md
 
 Uncaught NotFound: No such file or directory (os error 2)
     at DenoError (deno/js/errors.ts:22:5)


### PR DESCRIPTION
Use --allow-all instead. This is both simpler and better reflects what
these permissions imply.

Sets up `check_all()` for PRs like #4202 to use.