### PR TITLE
Update CLI for unit_test_runner.ts

### DIFF
--- a/cli/js/tests/test_util.ts
+++ b/cli/js/tests/test_util.ts
@@ -13,6 +13,7 @@ export {
   fail
 } from "../../../std/testing/asserts.ts";
 export { readLines } from "../../../std/io/bufio.ts";
+export { parse as parseArgs } from "../../../std/flags/mod.ts";
 
 export interface Permissions {
   read: boolean;

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -274,6 +274,7 @@ fn js_unit_tests() {
     .arg("--reload")
     .arg("-A")
     .arg("cli/js/tests/unit_test_runner.ts")
+    .arg("--master")
     .spawn()
     .expect("failed to spawn script");
   let status = deno.wait().expect("failed to wait for the child process");

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -277,9 +277,9 @@ fn js_unit_tests() {
     .spawn()
     .expect("failed to spawn script");
   let status = deno.wait().expect("failed to wait for the child process");
+  drop(g);
   assert_eq!(Some(0), status.code());
   assert!(status.success());
-  drop(g);
 }
 
 #[test]


### PR DESCRIPTION
Ref #4345

See commit messages for details

Addresses:
> When running "cargo test" and the js_unit_tests fails, it causes a cascade of other test failures. This is related to how the tools/http_server.py is shut down.

>People who are adding features need a quick guide and shouldn't have to read through the increasingly complex test runner code. Add information to cli/js/tests/README.md:
 how to run specific tests
 how to get raw stdout/stderr of tests.
 how to run tests with specific permissions, avoiding the test runner parent process.