### PR TITLE
refactor: replace source-mappings-map with rust-sourcemap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "source-map-mappings",
+ "sourcemap",
  "sys-info",
  "tempfile",
  "termcolor",
@@ -2083,16 +2083,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "source-map-mappings"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89babfa6891f638e3e30c5dd248368937015b627a9704aaa8c9d3b9177bf8bfa"
-dependencies = [
- "rand 0.4.6",
- "vlq",
-]
-
-[[package]]
 name = "sourcemap"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,12 +2538,6 @@ name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
-
-[[package]]
-name = "vlq"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 
 [[package]]
 name = "void"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,7 @@ rustyline = "6.0.0"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_derive = "1.0.104"
 serde_json = { version = "1.0.48", features = [ "preserve_order" ] }
-source-map-mappings = "0.5.0"
+sourcemap = "5"
 sys-info = "=0.5.8" # 0.5.9 and 0.5.10 are broken on windows.
 tempfile = "3.1.0"
 termcolor = "1.1.0"


### PR DESCRIPTION
This PR changes crate we use for source map from `source-mappings-map` to `rust-sourcemap`. SWC that we have as a dependency already uses `rust-sourcemap`.

Closes #4348

Potentially blocked by https://github.com/getsentry/rust-sourcemap/pull/26

