### PR TITLE
doc(http/server): Add coherence to the docs

### DIFF
--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -224,7 +224,7 @@ export class Server implements AsyncIterable<ServerRequest> {
 export type HTTPOptions = Omit<Deno.ListenOptions, "transport">;
 
 /**
- * Start a HTTP server
+ * Create a HTTP server
  *
  *     import { serve } from "https://deno.land/std/http/server.ts";
  *     const body = "Hello World\n";
@@ -243,6 +243,18 @@ export function serve(addr: string | HTTPOptions): Server {
   return new Server(listener);
 }
 
+/**
+ * Start an HTTP server with given options and request handler
+ *
+ *     const body = "Hello World\n";
+ *     const options = { port: 8000 };
+ *     listenAndServeTLS(options, (req) => {
+ *       req.respond({ body });
+ *     });
+ *
+ * @param options Server configuration
+ * @param handler Request handler
+ */
 export async function listenAndServe(
   addr: string | HTTPOptions,
   handler: (req: ServerRequest) => void
@@ -284,7 +296,7 @@ export function serveTLS(options: HTTPSOptions): Server {
 }
 
 /**
- * Create an HTTPS server with given options and request handler
+ * Start an HTTPS server with given options and request handler
  *
  *     const body = "Hello HTTPS";
  *     const options = {


### PR DESCRIPTION
Functions that returns a server are now documented with "Create",
and functions that launches one are documented with "Start".

Also added documentation for listenAndServe that respects these
changes.

Fixes #4367
