### PR TITLE
Test "chaining" of X-TypeScript-Types headers.

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1381,6 +1381,11 @@ itest!(type_directives_02 {
   output: "type_directives_02.ts.out",
 });
 
+itest!(type_directives_03 {
+  args: "run --reload -L debug type_directives_03.ts",
+  output: "type_directives_03.ts.out",
+});
+
 itest!(types {
   args: "types",
   output: "types.out",

--- a/cli/tests/type_directives_03.ts
+++ b/cli/tests/type_directives_03.ts
@@ -1,0 +1,3 @@
+import * as foo from "http://127.0.0.1:4545/xt001.js";
+
+console.log(foo.foo);

--- a/cli/tests/type_directives_03.ts.out
+++ b/cli/tests/type_directives_03.ts.out
@@ -1,0 +1,5 @@
+[WILDCARD]
+DEBUG TS - compiler::host.getSourceFile http://127.0.0.1:4545/xt001.d.ts
+[WILDCARD]
+DEBUG TS - compiler::host.getSourceFile http://127.0.0.1:4545/xt002.d.ts
+[WILDCARD]

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -130,6 +130,40 @@ class ContentTypeHandler(QuietSimpleHTTPRequestHandler):
             self.wfile.write(bytes("export const foo: 'foo';"))
             return
 
+        if "xt001.js" in self.path:
+            self.protocol_version = "HTTP/1.1"
+            self.send_response(200, 'OK')
+            self.send_header('Content-type', 'application/javascript')
+            self.send_header('X-TypeScript-Types', './xt001.d.ts')
+            self.end_headers()
+            self.wfile.write(bytes("export * from './xt002.js';"))
+            return
+
+        if "xt001.d.ts" in self.path:
+            self.protocol_version = "HTTP/1.1"
+            self.send_response(200, 'OK')
+            self.send_header('Content-type', 'application/typescript')
+            self.end_headers()
+            self.wfile.write(bytes("export * from './xt002.js';"))
+            return
+
+        if "xt002.js" in self.path:
+            self.protocol_version = "HTTP/1.1"
+            self.send_response(200, 'OK')
+            self.send_header('Content-type', 'application/javascript')
+            self.send_header('X-TypeScript-Types', './xt002.d.ts')
+            self.end_headers()
+            self.wfile.write(bytes("export const foo = 'foo';"))
+            return
+
+        if "xt002.d.ts" in self.path:
+            self.protocol_version = "HTTP/1.1"
+            self.send_response(200, 'OK')
+            self.send_header('Content-type', 'application/typescript')
+            self.end_headers()
+            self.wfile.write(bytes("export const foo: 'foo';"))
+            return
+
         if "referenceTypes.js" in self.path:
             self.protocol_version = "HTTP/1.1"
             self.send_response(200, 'OK')


### PR DESCRIPTION
Refs #4184
Refs #4040

In #4040 we changed the way JavaScript dependencies are analysed in the TypeScript compiler.  When we encounter a JavaScript file that doesn't have any types, and `checkJs` is disabled, we stop the analysis.  This caused situations where when there was a typed file, loading an untyped file, loading a typed file, we stop the analysis.  We didn't specifically check this "chaining" behaviour in our tests, and there were situations in the while where this behaviour was a regression, so this introduces test to ensure the behaviour as designed is preserved.
