### PR TITLE
console: Symbol.toStringTag and display Object symbol entries

### DIFF
--- a/cli/js/tests/console_test.ts
+++ b/cli/js/tests/console_test.ts
@@ -163,10 +163,14 @@ unitTest(function consoleTestStringifyCircular(): void {
     "{ a: { b: { c: { d: [Set] } } } }"
   );
   assertEquals(stringify(nestedObj), nestedObjExpected);
-  assertEquals(stringify(JSON), "{}");
+  assertEquals(stringify(JSON), 'JSON { Symbol(Symbol.toStringTag): "JSON" }');
   assertEquals(
     stringify(console),
-    "{ printFunc, log, debug, info, dir, dirxml, warn, error, assert, count, countReset, table, time, timeLog, timeEnd, group, groupCollapsed, groupEnd, clear, trace, indentLevel }"
+    "{ printFunc, log, debug, info, dir, dirxml, warn, error, assert, count, countReset, table, time, timeLog, timeEnd, group, groupCollapsed, groupEnd, clear, trace, indentLevel, Symbol(isConsoleInstance) }"
+  );
+  assertEquals(
+    stringify({ str: 1, [Symbol.for("sym")]: 2, [Symbol.toStringTag]: "TAG" }),
+    'TAG { str: 1, Symbol(sym): 2, Symbol(Symbol.toStringTag): "TAG" }'
   );
   // test inspect is working the same
   assertEquals(inspect(nestedObj), nestedObjExpected);
@@ -224,7 +228,10 @@ unitTest(function consoleTestWithCustomInspectorError(): void {
   }
 
   assertEquals(stringify(new B({ a: "a" })), "a");
-  assertEquals(stringify(B.prototype), "{}");
+  assertEquals(
+    stringify(B.prototype),
+    "{ Symbol(Deno.customInspect): [Function: [Deno.customInspect]] }"
+  );
 });
 
 unitTest(function consoleTestWithIntegerFormatSpecifier(): void {

--- a/cli/tests/041_dyn_import_eval.out
+++ b/cli/tests/041_dyn_import_eval.out
@@ -1,1 +1,1 @@
-{ isMod4: true }
+Module { isMod4: true, Symbol(Symbol.toStringTag): "Module" }

--- a/cli/tests/042_dyn_import_evalcontext.ts.out
+++ b/cli/tests/042_dyn_import_evalcontext.ts.out
@@ -1,1 +1,1 @@
-{ isMod4: true }
+Module { isMod4: true, Symbol(Symbol.toStringTag): "Module" }

--- a/cli/tests/055_import_wasm_via_network.ts.out
+++ b/cli/tests/055_import_wasm_via_network.ts.out
@@ -1,1 +1,1 @@
-{ add_one: [Function: 0], memory: Memory {} }
+Module { add_one: [Function: 0], memory: WebAssembly.Memory {}, Symbol(Symbol.toStringTag): "Module" }

--- a/cli/tests/fix_js_imports.ts.out
+++ b/cli/tests/fix_js_imports.ts.out
@@ -1,1 +1,1 @@
-{}
+Module { Symbol(Symbol.toStringTag): "Module" }


### PR DESCRIPTION
Closes #4362 
Respect `Symbol.toStringTag`, while also printing out other symbol entries in object.

Before:
```
> ({ a: 1, [Symbol.for('b')]: 2, [Symbol.toStringTag]: 'C' })
{ a: 1 }
```
After:
```
> ({ a: 1, [Symbol.for('b')]: 2, [Symbol.toStringTag]: 'C' })
C { a: 1, Symbol(b): 2, Symbol(Symbol.toStringTag): "C" }
```

The behavior of `Symbol.toStringTag` implemented here is closer to that of Chrome. Node.js uses a different and slightly messier strategy: respect the object prototype's `Symbol.toStringTag` and display in brackets. However if there is collision with object itself, nothing is displayed.
```
// Under Node v13.3.0
> let o = {[Symbol.toStringTag]: 'A'};
undefined
> o
{ [Symbol(Symbol.toStringTag)]: 'A' }
> Object.setPrototypeOf(o, {[Symbol.toStringTag]: 'B', constructor: function C() {}});
C { [Symbol(Symbol.toStringTag)]: 'A' }
> o
C { [Symbol(Symbol.toStringTag)]: 'A' }
> delete o[Symbol.toStringTag]
true
> o
C [B] {}

// Under Deno with this PR, similar behavior to Chrome
> let o = {[Symbol.toStringTag]: 'A'};
undefined
> o
A { Symbol(Symbol.toStringTag): "A" }
> Object.setPrototypeOf(o, {[Symbol.toStringTag]: 'B', constructor: function C() {}});
A { Symbol(Symbol.toStringTag): "A" }
> o
A { Symbol(Symbol.toStringTag): "A" }
> delete o[Symbol.toStringTag]
true
> o
B {}
```
Personally I think the behavior of Node is slightly confusing, so for now I followed the behavior of Chrome
