### PR TITLE
fix: fetch closes unused body

### DIFF
--- a/cli/js/tests/fetch_test.ts
+++ b/cli/js/tests/fetch_test.ts
@@ -174,8 +174,6 @@ unitTest(
 
 unitTest(
   {
-    // TODO(bartlomieju): leaking resources
-    skip: true,
     perms: { net: true }
   },
   async function fetchWithRedirection(): Promise<void> {
@@ -190,8 +188,6 @@ unitTest(
 
 unitTest(
   {
-    // TODO: leaking resources
-    skip: true,
     perms: { net: true }
   },
   async function fetchWithRelativeRedirection(): Promise<void> {
@@ -451,8 +447,6 @@ unitTest(
 
 unitTest(
   {
-    // TODO: leaking resources
-    skip: true,
     perms: { net: true }
   },
   async function fetchWithManualRedirection(): Promise<void> {
@@ -476,8 +470,6 @@ unitTest(
 
 unitTest(
   {
-    // TODO: leaking resources
-    skip: true,
     perms: { net: true }
   },
   async function fetchWithErrorRedirection(): Promise<void> {

--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -531,6 +531,9 @@ export async function fetch(
       redirected
     );
     if ([301, 302, 303, 307, 308].includes(response.status)) {
+      // We won't use body of received response, so close it now
+      // otherwise it will be kept in resource table.
+      close(fetchResponse.bodyRid);
       // We're in a redirect status
       switch ((init && init.redirect) || "follow") {
         case "error":


### PR DESCRIPTION
Closes #4194

This commit makes sure that `httpBody` resource is closed in case of redirections in `fetch` API.