### PR TITLE
fix: unit test runner on Windows

### DIFF
--- a/cli/js/tests/test_util.ts
+++ b/cli/js/tests/test_util.ts
@@ -272,10 +272,6 @@ export class SocketReporter implements Deno.TestReporter {
   async end(msg: Deno.TestEventEnd): Promise<void> {
     await this.write(msg);
   }
-
-  close(): void {
-    this.conn.close();
-  }
 }
 
 unitTest(function permissionsMatches(): void {

--- a/cli/js/tests/unit_test_runner.ts
+++ b/cli/js/tests/unit_test_runner.ts
@@ -116,6 +116,8 @@ function spawnWorkerRunner(
 }
 
 async function runTestsForPermissionSet(
+  listener: Deno.Listener,
+  addrStr: string,
   verbose: boolean,
   reporter: Deno.ConsoleTestReporter,
   perms: Permissions,
@@ -123,49 +125,31 @@ async function runTestsForPermissionSet(
 ): Promise<PermissionSetTestResult> {
   const permsFmt = fmtPerms(perms);
   console.log(`Running tests for: ${permsFmt}`);
-  const addr = { hostname: "127.0.0.1", port: 4510 };
-  const addrStr = `${addr.hostname}:${addr.port}`;
-  const workerListener = Deno.listen(addr);
-
   const workerProcess = spawnWorkerRunner(verbose, addrStr, perms, filter);
-
   // Wait for worker subprocess to go online
-  const conn = await workerListener.accept();
+  const conn = await listener.accept();
 
-  let err;
-  let hasThrown = false;
   let expectedPassedTests;
   let endEvent;
 
-  try {
-    for await (const line of readLines(conn)) {
-      const msg = JSON.parse(line);
+  for await (const line of readLines(conn)) {
+    const msg = JSON.parse(line);
 
-      if (msg.kind === Deno.TestEvent.Start) {
-        expectedPassedTests = msg.tests;
-        await reporter.start(msg);
-        continue;
-      } else if (msg.kind === Deno.TestEvent.TestStart) {
-        await reporter.testStart(msg);
-        continue;
-      } else if (msg.kind === Deno.TestEvent.TestEnd) {
-        await reporter.testEnd(msg);
-        continue;
-      } else {
-        endEvent = msg;
-        await reporter.end(msg);
-        break;
-      }
+    if (msg.kind === Deno.TestEvent.Start) {
+      expectedPassedTests = msg.tests;
+      await reporter.start(msg);
+      continue;
+    } else if (msg.kind === Deno.TestEvent.TestStart) {
+      await reporter.testStart(msg);
+      continue;
+    } else if (msg.kind === Deno.TestEvent.TestEnd) {
+      await reporter.testEnd(msg);
+      continue;
+    } else {
+      endEvent = msg;
+      await reporter.end(msg);
+      break;
     }
-  } catch (e) {
-    hasThrown = true;
-    err = e;
-  } finally {
-    workerListener.close();
-  }
-
-  if (hasThrown) {
-    throw err;
   }
 
   if (typeof expectedPassedTests === "undefined") {
@@ -213,9 +197,14 @@ async function masterRunnerMain(
 
   const testResults = new Set<PermissionSetTestResult>();
   const consoleReporter = new Deno.ConsoleTestReporter();
+  const addr = { hostname: "127.0.0.1", port: 4510 };
+  const addrStr = `${addr.hostname}:${addr.port}`;
+  const listener = Deno.listen(addr);
 
   for (const perms of permissionCombinations.values()) {
     const result = await runTestsForPermissionSet(
+      listener,
+      addrStr,
       verbose,
       consoleReporter,
       perms,

--- a/cli/js/tests/unit_test_runner.ts
+++ b/cli/js/tests/unit_test_runner.ts
@@ -71,8 +71,6 @@ async function workerRunnerMain(
     reporter: socketReporter,
     only: filter
   });
-  // Notify parent process we're done
-  socketReporter.close();
 }
 
 function spawnWorkerRunner(
@@ -151,6 +149,9 @@ async function runTestsForPermissionSet(
       break;
     }
   }
+
+  // Close socket to worker, it should shutdown gracefully.
+  conn.close();
 
   if (typeof expectedPassedTests === "undefined") {
     throw new Error("Worker runner didn't report start");


### PR DESCRIPTION
This PR attempts to fix intermittent errors occurring on Windows for `cli/tests/unit_test_runner.ts`. Runner has been reworked to create only single TCP listener instead of one listener per worker. 
Additionally worker doesn't close TCP socket - it waits for parent process to close the socket and only then exits.


Attempt to fix #4373 (suspected problems with `SO_REUSEADDR`)