### PR TITLE
[WIP] [Help needed] Implement Blob get data methods

### DIFF
--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -939,6 +939,9 @@ declare namespace __blob {
       options?: __domTypes.BlobPropertyBag
     );
     slice(start?: number, end?: number, contentType?: string): DenoBlob;
+    stream(): __domTypes.ReadableStream;
+    text(): Promise<string>;
+    arrayBuffer(): Promise<ArrayBuffer>;
   }
 }
 

--- a/cli/js/tests/blob_test.ts
+++ b/cli/js/tests/blob_test.ts
@@ -67,4 +67,7 @@ unitTest(function nativeEndLine(): void {
   assertEquals(blob.size, Deno.build.os === "win" ? 12 : 11);
 });
 
-// TODO(qti3e) Test the stored data in a Blob after implementing FileReader API.
+unitTest(async function blobText(): void {
+  const blob = new Blob(["Hello World"]);
+  assertEquals(await blob.text(), "Hello World");
+});

--- a/cli/js/web/blob.ts
+++ b/cli/js/web/blob.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import * as domTypes from "./dom_types.ts";
-import { TextEncoder } from "./text_encoding.ts";
+import { TextDecoder, TextEncoder } from "./text_encoding.ts";
 import { build } from "../build.ts";
+import { ReadableStream } from "./streams/mod.ts";
+import { Buffer } from "../buffer.ts";
+
 
 export const bytesSymbol = Symbol("bytes");
 
@@ -124,6 +127,36 @@ function processBlobParts(
   return bytes;
 }
 
+function getStream(blobBytes: Uint8Array): ReadableStream {
+  return new ReadableStream({
+
+  });
+}
+
+async function readBytes(
+  reader: domTypes.ReadableStreamReader
+): Promise<ArrayBuffer> {
+  const bytes = new Buffer();
+  while (true) {
+    try {
+      const {
+        done,
+        value
+      }: { done: boolean; value: Uint8Array } = await reader.read();
+      if (done === false && value instanceof Uint8Array) {
+        bytes.grow(value.length);
+        await bytes.write(value);
+      } else if (done === true) {
+        return Promise.resolve(bytes.bytes().buffer.slice(0, bytes.length));
+      } else {
+        return Promise.reject(new TypeError());
+      }
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  }
+}
+
 export class DenoBlob implements domTypes.Blob {
   [bytesSymbol]: Uint8Array;
   readonly size: number = 0;
@@ -166,5 +199,19 @@ export class DenoBlob implements domTypes.Blob {
     return new DenoBlob([this[bytesSymbol].slice(start, end)], {
       type: contentType || this.type,
     });
+  }
+
+  stream(): ReadableStream {
+    return getStream(this[bytesSymbol]);
+  }
+
+  async text(): Promise<string> {
+    const reader = getStream(this[bytesSymbol]).getReader();
+    const decoder = new TextDecoder();
+    return decoder.decode(await readBytes(reader));
+  }
+
+  async arrayBuffer(): Promise<ArrayBuffer> {
+    return readBytes(getStream(this[bytesSymbol]).getReader());
   }
 }

--- a/cli/js/web/dom_types.ts
+++ b/cli/js/web/dom_types.ts
@@ -277,6 +277,9 @@ export interface Blob {
   readonly size: number;
   readonly type: string;
   slice(start?: number, end?: number, contentType?: string): Blob;
+  stream(): ReadableStream;
+  text(): Promise<string>;
+  arrayBuffer(): Promise<ArrayBuffer>;
 }
 
 export interface Body {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
I am trying to implement Blob's `stream`, `text` & `arrayBuffer` methods, which allow the reading of data from a blob.
This would resolve #2303 & resolve #4142, and also allows me to finalize the tests for #4363. 

The last thing missing is the implementation of the [`get stream` algorithm](https://www.w3.org/TR/FileAPI/#blob-get-stream), for which i need some help.