### PR TITLE
Tie snapshot lifetime to isolate

### DIFF
--- a/cli/compilers/compiler_worker.rs
+++ b/cli/compilers/compiler_worker.rs
@@ -29,7 +29,11 @@ use std::task::Poll;
 pub struct CompilerWorker<'a>(WebWorker<'a>);
 
 impl<'a> CompilerWorker<'a> {
-  pub fn new(name: String, startup_data: StartupData<'a>, state: State) -> Self {
+  pub fn new(
+    name: String,
+    startup_data: StartupData<'a>,
+    state: State,
+  ) -> Self {
     let state_ = state.clone();
     let mut worker = WebWorker::new(name, startup_data, state_);
     {

--- a/cli/compilers/compiler_worker.rs
+++ b/cli/compilers/compiler_worker.rs
@@ -26,10 +26,10 @@ use std::task::Poll;
 ///
 /// TODO(bartlomieju): add support to reuse the worker - or in other
 /// words support stateful TS compiler
-pub struct CompilerWorker(WebWorker);
+pub struct CompilerWorker<'a>(WebWorker<'a>);
 
-impl CompilerWorker {
-  pub fn new(name: String, startup_data: StartupData, state: State) -> Self {
+impl<'a> CompilerWorker<'a> {
+  pub fn new(name: String, startup_data: StartupData<'a>, state: State) -> Self {
     let state_ = state.clone();
     let mut worker = WebWorker::new(name, startup_data, state_);
     {
@@ -44,20 +44,20 @@ impl CompilerWorker {
   }
 }
 
-impl Deref for CompilerWorker {
-  type Target = WebWorker;
+impl<'a> Deref for CompilerWorker<'a> {
+  type Target = WebWorker<'a>;
   fn deref(&self) -> &Self::Target {
     &self.0
   }
 }
 
-impl DerefMut for CompilerWorker {
+impl DerefMut for CompilerWorker<'_> {
   fn deref_mut(&mut self) -> &mut Self::Target {
     &mut self.0
   }
 }
 
-impl Future for CompilerWorker {
+impl Future for CompilerWorker<'_> {
   type Output = Result<(), ErrBox>;
 
   fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {

--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -252,7 +252,7 @@ impl TsCompiler {
 
   /// Create a new V8 worker with snapshot of TS compiler and setup compiler's
   /// runtime.
-  fn setup_worker(global_state: GlobalState) -> CompilerWorker {
+  fn setup_worker<'a>(global_state: GlobalState) -> CompilerWorker<'a> {
     let entry_point =
       ModuleSpecifier::resolve_url_or_path("./__$deno$ts_compiler.ts").unwrap();
     let worker_state = State::new(global_state.clone(), None, entry_point)

--- a/cli/compilers/wasm.rs
+++ b/cli/compilers/wasm.rs
@@ -52,7 +52,7 @@ pub struct WasmCompiler {
 
 impl WasmCompiler {
   /// Create a new V8 worker with snapshot of WASM compiler and setup compiler's runtime.
-  fn setup_worker(global_state: GlobalState) -> CompilerWorker {
+  fn setup_worker<'a>(global_state: GlobalState) -> CompilerWorker<'a> {
     let entry_point =
       ModuleSpecifier::resolve_url_or_path("./__$deno$wasm_compiler.ts")
         .unwrap();

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -106,10 +106,10 @@ impl log::Log for Logger {
   fn flush(&self) {}
 }
 
-fn create_main_worker(
+fn create_main_worker<'a>(
   global_state: GlobalState,
   main_module: ModuleSpecifier,
-) -> Result<MainWorker, ErrBox> {
+) -> Result<MainWorker<'a>, ErrBox> {
   let state = State::new(global_state, None, main_module)?;
 
   {
@@ -150,7 +150,7 @@ fn print_cache_info(state: &GlobalState) {
 // TODO(bartlomieju): this function de facto repeats
 // whole compilation stack. Can this be done better somehow?
 async fn print_file_info(
-  worker: &MainWorker,
+  worker: &MainWorker<'_>,
   module_specifier: ModuleSpecifier,
 ) -> Result<(), ErrBox> {
   let global_state = worker.state.borrow().global_state.clone();

--- a/cli/ops/worker_host.rs
+++ b/cli/ops/worker_host.rs
@@ -35,12 +35,12 @@ pub fn init(i: &mut Isolate, s: &State) {
   );
 }
 
-fn create_web_worker(
+fn create_web_worker<'a>(
   name: String,
   global_state: GlobalState,
   permissions: DenoPermissions,
   specifier: ModuleSpecifier,
-) -> Result<WebWorker, ErrBox> {
+) -> Result<WebWorker<'a>, ErrBox> {
   let state =
     State::new_for_worker(global_state, Some(permissions), specifier)?;
 

--- a/cli/web_worker.rs
+++ b/cli/web_worker.rs
@@ -22,13 +22,13 @@ use std::task::Poll;
 ///
 /// Each `WebWorker` is either a child of `MainWorker` or other
 /// `WebWorker`.
-pub struct WebWorker {
-  worker: Worker,
+pub struct WebWorker<'a> {
+  worker: Worker<'a>,
   is_ready: bool,
 }
 
-impl WebWorker {
-  pub fn new(name: String, startup_data: StartupData, state: State) -> Self {
+impl<'a> WebWorker<'a> {
+  pub fn new(name: String, startup_data: StartupData<'a>, state: State) -> Self {
     let state_ = state.clone();
     let mut worker = Worker::new(name, startup_data, state_);
     {
@@ -50,20 +50,20 @@ impl WebWorker {
   }
 }
 
-impl Deref for WebWorker {
-  type Target = Worker;
+impl<'a> Deref for WebWorker<'a> {
+  type Target = Worker<'a>;
   fn deref(&self) -> &Self::Target {
     &self.worker
   }
 }
 
-impl DerefMut for WebWorker {
+impl DerefMut for WebWorker<'_> {
   fn deref_mut(&mut self) -> &mut Self::Target {
     &mut self.worker
   }
 }
 
-impl Future for WebWorker {
+impl Future for WebWorker<'_> {
   type Output = Result<(), ErrBox>;
 
   fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
@@ -126,7 +126,7 @@ mod tests {
   use crate::worker::WorkerEvent;
   use crate::worker::WorkerHandle;
 
-  fn create_test_worker() -> WebWorker {
+  fn create_test_worker<'a>() -> WebWorker<'a> {
     let state = State::mock("./hello.js");
     let mut worker = WebWorker::new(
       "TEST".to_string(),

--- a/cli/web_worker.rs
+++ b/cli/web_worker.rs
@@ -28,7 +28,11 @@ pub struct WebWorker<'a> {
 }
 
 impl<'a> WebWorker<'a> {
-  pub fn new(name: String, startup_data: StartupData<'a>, state: State) -> Self {
+  pub fn new(
+    name: String,
+    startup_data: StartupData<'a>,
+    state: State,
+  ) -> Self {
     let state_ = state.clone();
     let mut worker = Worker::new(name, startup_data, state_);
     {

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -100,7 +100,11 @@ pub struct Worker<'a> {
 }
 
 impl<'a> Worker<'a> {
-  pub fn new(name: String, startup_data: StartupData<'a>, state: State) -> Self {
+  pub fn new(
+    name: String,
+    startup_data: StartupData<'a>,
+    state: State,
+  ) -> Self {
     let loader = Rc::new(state.clone());
     let mut isolate = deno_core::EsIsolate::new(loader, startup_data, false);
 
@@ -194,7 +198,11 @@ impl Future for Worker<'_> {
 pub struct MainWorker<'a>(Worker<'a>);
 
 impl<'a> MainWorker<'a> {
-  pub fn new(name: String, startup_data: StartupData<'a>, state: State) -> Self {
+  pub fn new(
+    name: String,
+    startup_data: StartupData<'a>,
+    state: State,
+  ) -> Self {
     let state_ = state.clone();
     let mut worker = Worker::new(name, startup_data, state_);
     {

--- a/core/es_isolate.rs
+++ b/core/es_isolate.rs
@@ -45,8 +45,8 @@ pub type DynImportId = i32;
 /// Creating `EsIsolate` requires to pass `loader` argument
 /// that implements `ModuleLoader` trait - that way actual resolution and
 /// loading of modules can be customized by the implementor.
-pub struct EsIsolate {
-  core_isolate: Box<Isolate>,
+pub struct EsIsolate<'a> {
+  core_isolate: Box<Isolate<'a>>,
   loader: Rc<dyn ModuleLoader>,
   pub modules: Modules,
   pub(crate) next_dyn_import_id: DynImportId,
@@ -57,21 +57,21 @@ pub struct EsIsolate {
   waker: AtomicWaker,
 }
 
-impl Deref for EsIsolate {
-  type Target = Isolate;
+impl<'a> Deref for EsIsolate<'a> {
+  type Target = Isolate<'a>;
 
   fn deref(&self) -> &Self::Target {
     &self.core_isolate
   }
 }
 
-impl DerefMut for EsIsolate {
+impl DerefMut for EsIsolate<'_> {
   fn deref_mut(&mut self) -> &mut Self::Target {
     &mut self.core_isolate
   }
 }
 
-impl EsIsolate {
+impl EsIsolate<'_> {
   pub fn new(
     loader: Rc<dyn ModuleLoader>,
     startup_data: StartupData,
@@ -504,7 +504,7 @@ impl EsIsolate {
   }
 }
 
-impl Future for EsIsolate {
+impl Future for EsIsolate<'_> {
   type Output = Result<(), ErrBox>;
 
   fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {

--- a/core/es_isolate.rs
+++ b/core/es_isolate.rs
@@ -71,10 +71,10 @@ impl DerefMut for EsIsolate<'_> {
   }
 }
 
-impl EsIsolate<'_> {
+impl<'a> EsIsolate<'a> {
   pub fn new(
     loader: Rc<dyn ModuleLoader>,
-    startup_data: StartupData,
+    startup_data: StartupData<'a>,
     will_snapshot: bool,
   ) -> Box<Self> {
     let mut core_isolate = Isolate::new(startup_data, will_snapshot);

--- a/core/examples/http_bench.rs
+++ b/core/examples/http_bench.rs
@@ -72,8 +72,8 @@ impl From<Record> for RecordBuf {
   }
 }
 
-struct Isolate {
-  core_isolate: Box<CoreIsolate>, // Unclear why CoreIsolate::new() returns a box.
+struct Isolate<'a> {
+  core_isolate: Box<CoreIsolate<'a>>, // Unclear why CoreIsolate::new() returns a box.
   state: State,
 }
 
@@ -85,7 +85,7 @@ struct StateInner {
   resource_table: ResourceTable,
 }
 
-impl Isolate {
+impl Isolate<'_> {
   pub fn new() -> Self {
     let startup_data = StartupData::Script(Script {
       source: include_str!("http_bench.js"),
@@ -142,8 +142,8 @@ impl Isolate {
   }
 }
 
-impl Future for Isolate {
-  type Output = <CoreIsolate as Future>::Output;
+impl<'a> Future for Isolate<'a> {
+  type Output = <CoreIsolate<'a> as Future>::Output;
 
   fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
     self.core_isolate.poll_unpin(cx)

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -92,8 +92,8 @@ pub enum SnapshotConfig<'a> {
   Owned(v8::OwnedStartupData),
 }
 
-impl From<&'static [u8]> for SnapshotConfig<'_> {
-  fn from(sd: &'static [u8]) -> Self {
+impl<'a> From<&'a [u8]> for SnapshotConfig<'a> {
+  fn from(sd: &'a [u8]) -> Self {
     Self::Borrowed(v8::StartupData::new(sd))
   }
 }
@@ -141,7 +141,7 @@ impl From<Script<'_>> for OwnedScript {
 /// in the form of the StartupScript struct.
 pub enum StartupData<'a> {
   Script(Script<'a>),
-  Snapshot(&'static [u8]),
+  Snapshot(&'a [u8]),
   OwnedSnapshot(v8::OwnedStartupData),
   None,
 }
@@ -222,10 +222,10 @@ pub unsafe fn v8_init() {
   v8::V8::set_flags_from_command_line(argv);
 }
 
-impl Isolate<'_> {
+impl<'a> Isolate<'a> {
   /// startup_data defines the snapshot or script used at startup to initialize
   /// the isolate.
-  pub fn new(startup_data: StartupData, will_snapshot: bool) -> Box<Self> {
+  pub fn new(startup_data: StartupData<'a>, will_snapshot: bool) -> Box<Self> {
     DENO_INIT.call_once(|| {
       unsafe { v8_init() };
     });

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -60,16 +60,16 @@ where
   }
 }
 
-pub struct TSIsolate {
-  isolate: Box<Isolate>,
+pub struct TSIsolate<'a> {
+  isolate: Box<Isolate<'a>>,
   state: Arc<Mutex<TSState>>,
 }
 
-impl TSIsolate {
-  fn new(
+impl TSIsolate<'_> {
+  fn new<'a>(
     bundle: bool,
     maybe_extern_crate_modules: Option<ExternCrateModules>,
-  ) -> TSIsolate {
+  ) -> TSIsolate<'a> {
     let mut isolate = Isolate::new(StartupData::None, false);
     js_check(isolate.execute("assets/typescript.js", TYPESCRIPT_CODE));
     js_check(isolate.execute("compiler_main.js", COMPILER_CODE));


### PR DESCRIPTION
*Fixes #4402*

This only touches `core` and `cli`. Might be a breaking change.

It is based on a restriction in [`rusty_v8::CreateParams`](https://docs.rs/rusty_v8/0.3.5/rusty_v8/struct.CreateParams.html#method.set_snapshot_blob):

> To avoid unnecessary copies of data, V8 will point directly into the given data blob, so pretty please keep it around until V8 exit.

I'm pretty sure "until V8 exit" actually means until the isolate is dropped. Therefore it should be possible to tie the lifetime of the snapshot to the isolate.