### PR TITLE
Refactor fs.rs and ops/fs.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,6 @@ dependencies = [
  "pty",
  "rand 0.7.3",
  "regex",
- "remove_dir_all",
  "reqwest",
  "ring",
  "rustyline",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,7 +44,6 @@ log = "0.4.8"
 notify = "5.0.0-pre.2"
 rand = "0.7.3"
 regex = "1.3.4"
-remove_dir_all = "0.5.2"
 reqwest = { version = "0.10.4", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli"] }
 ring = "0.16.11"
 rustyline = "6.0.0"

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -8,9 +8,6 @@ use std::path::{Component, Path, PathBuf};
 use deno_core::ErrBox;
 use walkdir::WalkDir;
 
-#[cfg(unix)]
-use nix::unistd::{chown as unix_chown, Gid, Uid};
-
 pub fn write_file<T: AsRef<[u8]>>(
   filename: &Path,
   data: T,
@@ -49,25 +46,6 @@ pub fn write_file_2<T: AsRef<[u8]>>(
   }
 
   file.write_all(data.as_ref())
-}
-
-#[cfg(unix)]
-pub fn chown(path: &str, uid: u32, gid: u32) -> Result<(), ErrBox> {
-  let nix_uid = Uid::from_raw(uid);
-  let nix_gid = Gid::from_raw(gid);
-  unix_chown(path, Option::Some(nix_uid), Option::Some(nix_gid))
-    .map_err(ErrBox::from)
-}
-
-#[cfg(not(unix))]
-pub fn chown(_path: &str, _uid: u32, _gid: u32) -> Result<(), ErrBox> {
-  // FAIL on Windows
-  // TODO: implement chown for Windows
-  let e = std::io::Error::new(
-    std::io::ErrorKind::Other,
-    "Not implemented".to_string(),
-  );
-  Err(ErrBox::from(e))
 }
 
 /// Normalize all itermediate components of the path (ie. remove "./" and "../" components).

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use std;
+use std::env::current_dir;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
@@ -106,7 +107,7 @@ pub fn resolve_from_cwd(path: &Path) -> Result<PathBuf, ErrBox> {
   let resolved_path = if path.is_absolute() {
     path.to_owned()
   } else {
-    let cwd = std::env::current_dir().unwrap();
+    let cwd = current_dir().unwrap();
     cwd.join(path)
   };
 
@@ -119,19 +120,19 @@ mod tests {
 
   #[test]
   fn resolve_from_cwd_child() {
-    let cwd = std::env::current_dir().unwrap();
+    let cwd = current_dir().unwrap();
     assert_eq!(resolve_from_cwd(Path::new("a")).unwrap(), cwd.join("a"));
   }
 
   #[test]
   fn resolve_from_cwd_dot() {
-    let cwd = std::env::current_dir().unwrap();
+    let cwd = current_dir().unwrap();
     assert_eq!(resolve_from_cwd(Path::new(".")).unwrap(), cwd);
   }
 
   #[test]
   fn resolve_from_cwd_parent() {
-    let cwd = std::env::current_dir().unwrap();
+    let cwd = current_dir().unwrap();
     assert_eq!(resolve_from_cwd(Path::new("a/..")).unwrap(), cwd);
   }
 

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -1,17 +1,15 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use std;
-use std::fs::{DirBuilder, File, OpenOptions};
-use std::io::ErrorKind;
+use std::fs::File;
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 
 use deno_core::ErrBox;
-use rand;
-use rand::Rng;
 use walkdir::WalkDir;
 
 #[cfg(unix)]
-use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::PermissionsExt;
 
 #[cfg(unix)]
 use nix::unistd::{chown as unix_chown, Gid, Uid};
@@ -57,62 +55,6 @@ fn set_permissions(file: &mut File, mode: u32) -> std::io::Result<()> {
 fn set_permissions(_file: &mut File, _mode: u32) -> std::io::Result<()> {
   // NOOP on windows
   Ok(())
-}
-
-pub fn make_temp(
-  dir: Option<&Path>,
-  prefix: Option<&str>,
-  suffix: Option<&str>,
-  is_dir: bool,
-) -> std::io::Result<PathBuf> {
-  let prefix_ = prefix.unwrap_or("");
-  let suffix_ = suffix.unwrap_or("");
-  let mut buf: PathBuf = match dir {
-    Some(ref p) => p.to_path_buf(),
-    None => std::env::temp_dir(),
-  }
-  .join("_");
-  let mut rng = rand::thread_rng();
-  loop {
-    let unique = rng.gen::<u32>();
-    buf.set_file_name(format!("{}{:08x}{}", prefix_, unique, suffix_));
-    let r = if is_dir {
-      let mut builder = DirBuilder::new();
-      set_dir_permission(&mut builder, 0o700);
-      builder.create(buf.as_path())
-    } else {
-      let mut open_options = OpenOptions::new();
-      open_options.write(true).create_new(true);
-      #[cfg(unix)]
-      open_options.mode(0o600);
-      open_options.open(buf.as_path())?;
-      Ok(())
-    };
-    match r {
-      Err(ref e) if e.kind() == ErrorKind::AlreadyExists => continue,
-      Ok(_) => return Ok(buf),
-      Err(e) => return Err(e),
-    }
-  }
-}
-
-pub fn mkdir(path: &Path, mode: u32, recursive: bool) -> std::io::Result<()> {
-  let mut builder = DirBuilder::new();
-  builder.recursive(recursive);
-  set_dir_permission(&mut builder, mode);
-  builder.create(path)
-}
-
-#[cfg(unix)]
-fn set_dir_permission(builder: &mut DirBuilder, mode: u32) {
-  let mode = mode & 0o777;
-  debug!("set dir mode to {:o}", mode);
-  builder.mode(mode);
-}
-
-#[cfg(not(unix))]
-fn set_dir_permission(_builder: &mut DirBuilder, _mode: u32) {
-  // NOOP on windows
 }
 
 #[cfg(unix)]

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use std;
 use std::env::current_dir;
 use std::fs::OpenOptions;
 use std::io::Write;

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1258,25 +1258,25 @@ declare namespace Deno {
 
   // @url js/link.d.ts
 
-  /** Creates `newname` as a hard link to `oldname`.
+  /** Creates `newpath` as a hard link to `oldpath`.
    *
    *       Deno.linkSync("old/name", "new/name");
    *
    * Requires `allow-read` and `allow-write` permissions. */
-  export function linkSync(oldname: string, newname: string): void;
+  export function linkSync(oldpath: string, newpath: string): void;
 
-  /** Creates `newname` as a hard link to `oldname`.
+  /** Creates `newpath` as a hard link to `oldpath`.
    *
    *       await Deno.link("old/name", "new/name");
    *
    * Requires `allow-read` and `allow-write` permissions. */
-  export function link(oldname: string, newname: string): Promise<void>;
+  export function link(oldpath: string, newpath: string): Promise<void>;
 
   // @url js/symlink.d.ts
 
   /** **UNSTABLE**: `type` argument type may be changed to `"dir" | "file"`.
    *
-   * Creates `newname` as a symbolic link to `oldname`. The type argument can be
+   * Creates `newpath` as a symbolic link to `oldpath`. The type argument can be
    * set to `dir` or `file`. Is only available on Windows and ignored on other
    * platforms.
    *
@@ -1284,14 +1284,14 @@ declare namespace Deno {
    *
    * Requires `allow-read` and `allow-write` permissions. */
   export function symlinkSync(
-    oldname: string,
-    newname: string,
+    oldpath: string,
+    newpath: string,
     type?: string
   ): void;
 
   /** **UNSTABLE**: `type` argument may be changed to "dir" | "file"
    *
-   * Creates `newname` as a symbolic link to `oldname`. The type argument can be
+   * Creates `newpath` as a symbolic link to `oldpath`. The type argument can be
    * set to `dir` or `file`. Is only available on Windows and ignored on other
    * platforms.
    *
@@ -1299,8 +1299,8 @@ declare namespace Deno {
    *
    * Requires `allow-read` and `allow-write` permissions. */
   export function symlink(
-    oldname: string,
-    newname: string,
+    oldpath: string,
+    newpath: string,
     type?: string
   ): Promise<void>;
 

--- a/cli/js/ops/fs/link.ts
+++ b/cli/js/ops/fs/link.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { sendSync, sendAsync } from "../dispatch_json.ts";
 
-export function linkSync(oldname: string, newname: string): void {
-  sendSync("op_link", { oldname, newname });
+export function linkSync(oldpath: string, newpath: string): void {
+  sendSync("op_link", { oldpath, newpath });
 }
 
-export async function link(oldname: string, newname: string): Promise<void> {
-  await sendAsync("op_link", { oldname, newname });
+export async function link(oldpath: string, newpath: string): Promise<void> {
+  await sendAsync("op_link", { oldpath, newpath });
 }

--- a/cli/js/ops/fs/symlink.ts
+++ b/cli/js/ops/fs/symlink.ts
@@ -4,23 +4,23 @@ import * as util from "../../util.ts";
 import { build } from "../../build.ts";
 
 export function symlinkSync(
-  oldname: string,
-  newname: string,
+  oldpath: string,
+  newpath: string,
   type?: string
 ): void {
   if (build.os === "win" && type) {
     return util.notImplemented();
   }
-  sendSync("op_symlink", { oldname, newname });
+  sendSync("op_symlink", { oldpath, newpath });
 }
 
 export async function symlink(
-  oldname: string,
-  newname: string,
+  oldpath: string,
+  newpath: string,
   type?: string
 ): Promise<void> {
   if (build.os === "win" && type) {
     return util.notImplemented();
   }
-  await sendAsync("op_symlink", { oldname, newname });
+  await sendAsync("op_symlink", { oldpath, newpath });
 }

--- a/cli/js/tests/chmod_test.ts
+++ b/cli/js/tests/chmod_test.ts
@@ -1,10 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { unitTest, assert, assertEquals } from "./test_util.ts";
 
-const isNotWindows = Deno.build.os !== "win";
-
 unitTest(
-  { perms: { read: true, write: true } },
+  { skip: Deno.build.os === "win", perms: { read: true, write: true } },
   function chmodSyncSuccess(): void {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -12,15 +10,11 @@ unitTest(
     const filename = tempDir + "/test.txt";
     Deno.writeFileSync(filename, data, { mode: 0o666 });
 
-    // On windows no effect, but should not crash
     Deno.chmodSync(filename, 0o777);
 
-    // Check success when not on windows
-    if (isNotWindows) {
-      const fileInfo = Deno.statSync(filename);
-      assert(fileInfo.mode);
-      assertEquals(fileInfo.mode & 0o777, 0o777);
-    }
+    const fileInfo = Deno.statSync(filename);
+    assert(fileInfo.mode);
+    assertEquals(fileInfo.mode & 0o777, 0o777);
   }
 );
 
@@ -79,7 +73,7 @@ unitTest({ perms: { write: false } }, function chmodSyncPerm(): void {
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { skip: Deno.build.os === "win", perms: { read: true, write: true } },
   async function chmodSuccess(): Promise<void> {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -87,15 +81,11 @@ unitTest(
     const filename = tempDir + "/test.txt";
     Deno.writeFileSync(filename, data, { mode: 0o666 });
 
-    // On windows no effect, but should not crash
     await Deno.chmod(filename, 0o777);
 
-    // Check success when not on windows
-    if (isNotWindows) {
-      const fileInfo = Deno.statSync(filename);
-      assert(fileInfo.mode);
-      assertEquals(fileInfo.mode & 0o777, 0o777);
-    }
+    const fileInfo = Deno.statSync(filename);
+    assert(fileInfo.mode);
+    assertEquals(fileInfo.mode & 0o777, 0o777);
   }
 );
 

--- a/cli/js/tests/remove_test.ts
+++ b/cli/js/tests/remove_test.ts
@@ -83,7 +83,7 @@ unitTest(
   { perms: { write: true, read: true } },
   function removeSyncDanglingSymlinkSuccess(): void {
     const danglingSymlinkPath = Deno.makeTempDirSync() + "/dangling_symlink";
-    // TODO(#3832): Remove "Not Implemented" error checking when symlink creation is implemented for Windows
+    // TODO(#3832): Remove "not Implemented" error checking when symlink creation is implemented for Windows
     let errOnWindows;
     try {
       Deno.symlinkSync("unexistent_file", danglingSymlinkPath);
@@ -91,7 +91,7 @@ unitTest(
       errOnWindows = err;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const pathInfo = Deno.lstatSync(danglingSymlinkPath);
       assert(pathInfo.isSymlink());
@@ -116,7 +116,7 @@ unitTest(
     const filePath = tempDir + "/test.txt";
     const validSymlinkPath = tempDir + "/valid_symlink";
     Deno.writeFileSync(filePath, data, { mode: 0o666 });
-    // TODO(#3832): Remove "Not Implemented" error checking when symlink creation is implemented for Windows
+    // TODO(#3832): Remove "not Implemented" error checking when symlink creation is implemented for Windows
     let errOnWindows;
     try {
       Deno.symlinkSync(filePath, validSymlinkPath);
@@ -124,7 +124,7 @@ unitTest(
       errOnWindows = err;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const symlinkPathInfo = Deno.statSync(validSymlinkPath);
       assert(symlinkPathInfo.isFile());
@@ -319,7 +319,7 @@ unitTest(
   { perms: { write: true, read: true } },
   async function removeDanglingSymlinkSuccess(): Promise<void> {
     const danglingSymlinkPath = Deno.makeTempDirSync() + "/dangling_symlink";
-    // TODO(#3832): Remove "Not Implemented" error checking when symlink creation is implemented for Windows
+    // TODO(#3832): Remove "not Implemented" error checking when symlink creation is implemented for Windows
     let errOnWindows;
     try {
       Deno.symlinkSync("unexistent_file", danglingSymlinkPath);
@@ -327,7 +327,7 @@ unitTest(
       errOnWindows = e;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const pathInfo = Deno.lstatSync(danglingSymlinkPath);
       assert(pathInfo.isSymlink());
@@ -352,7 +352,7 @@ unitTest(
     const filePath = tempDir + "/test.txt";
     const validSymlinkPath = tempDir + "/valid_symlink";
     Deno.writeFileSync(filePath, data, { mode: 0o666 });
-    // TODO(#3832): Remove "Not Implemented" error checking when symlink creation is implemented for Windows
+    // TODO(#3832): Remove "not Implemented" error checking when symlink creation is implemented for Windows
     let errOnWindows;
     try {
       Deno.symlinkSync(filePath, validSymlinkPath);
@@ -360,7 +360,7 @@ unitTest(
       errOnWindows = e;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const symlinkPathInfo = Deno.statSync(validSymlinkPath);
       assert(symlinkPathInfo.isFile());

--- a/cli/js/tests/symlink_test.ts
+++ b/cli/js/tests/symlink_test.ts
@@ -17,7 +17,7 @@ unitTest(
     }
     if (errOnWindows) {
       assertEquals(Deno.build.os, "win");
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const newNameInfoLStat = Deno.lstatSync(newname);
       const newNameInfoStat = Deno.statSync(newname);
@@ -54,7 +54,8 @@ unitTest(
     }
     if (err) {
       assertEquals(Deno.build.os, "win");
-      assertEquals(err.message, "Not implemented");
+      // from cli/js/util.ts:notImplemented
+      assertEquals(err.message, "not implemented");
     }
   }
 );
@@ -74,7 +75,7 @@ unitTest(
       errOnWindows = e;
     }
     if (errOnWindows) {
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const newNameInfoLStat = Deno.lstatSync(newname);
       const newNameInfoStat = Deno.statSync(newname);

--- a/cli/js/util.ts
+++ b/cli/js/util.ts
@@ -53,7 +53,7 @@ export function createResolvable<T>(): Resolvable<T> {
 
 // @internal
 export function notImplemented(): never {
-  throw new Error("Not implemented");
+  throw new Error("not implemented");
 }
 
 // @internal

--- a/cli/js/write_file.ts
+++ b/cli/js/write_file.ts
@@ -3,6 +3,7 @@ import { stat, statSync } from "./ops/fs/stat.ts";
 import { open, openSync } from "./files.ts";
 import { chmod, chmodSync } from "./ops/fs/chmod.ts";
 import { writeAll, writeAllSync } from "./buffer.ts";
+import { build } from "./build.ts";
 
 export interface WriteFileOptions {
   append?: boolean;
@@ -29,7 +30,7 @@ export function writeFileSync(
   if (
     options.mode !== undefined &&
     options.mode !== null &&
-    Deno.build.os !== "win"
+    build.os !== "win"
   ) {
     chmodSync(path, options.mode);
   }
@@ -57,7 +58,7 @@ export async function writeFile(
   if (
     options.mode !== undefined &&
     options.mode !== null &&
-    Deno.build.os !== "win"
+    build.os !== "win"
   ) {
     await chmod(path, options.mode);
   }

--- a/cli/js/write_file.ts
+++ b/cli/js/write_file.ts
@@ -26,7 +26,11 @@ export function writeFileSync(
   const openMode = !!options.append ? "a" : "w";
   const file = openSync(path, openMode);
 
-  if (options.mode !== undefined && options.mode !== null) {
+  if (
+    options.mode !== undefined &&
+    options.mode !== null &&
+    Deno.build.os !== "win"
+  ) {
     chmodSync(path, options.mode);
   }
 
@@ -50,7 +54,11 @@ export async function writeFile(
   const openMode = !!options.append ? "a" : "w";
   const file = await open(path, openMode);
 
-  if (options.mode !== undefined && options.mode !== null) {
+  if (
+    options.mode !== undefined &&
+    options.mode !== null &&
+    Deno.build.os !== "win"
+  ) {
     await chmod(path, options.mode);
   }
 

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -714,7 +714,7 @@ fn op_symlink(
   // TODO Use type for Windows.
   if cfg!(not(unix)) {
     let _ = oldname; // avoid unused warning
-    return Err(OpError::other("Not implemented".to_string()));
+    return Err(OpError::not_implemented());
   }
 
   let is_sync = args.promise_id.is_none();

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -703,13 +703,18 @@ fn op_symlink(
   state.check_write(&newname)?;
   // TODO Use type for Windows.
   if cfg!(not(unix)) {
+    let _ = oldname; // avoid unused warning
     return Err(OpError::other("Not implemented".to_string()));
   }
+
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_symlink {} {}", oldname.display(), newname.display());
     #[cfg(unix)]
-    std::os::unix::fs::symlink(&oldname, &newname)?;
+    {
+      use std::os::unix::fs::symlink;
+      debug!("op_symlink {} {}", oldname.display(), newname.display());
+      symlink(&oldname, &newname)?;
+    }
     Ok(json!({}))
   })
 }

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -314,7 +314,6 @@ fn op_mkdir(
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_mkdir {} {:o} {}", path.display(), mode, args.recursive);
-    // #[allow(unused_mut)]
     let mut builder = std::fs::DirBuilder::new();
     builder.recursive(args.recursive);
     #[cfg(unix)]

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -354,6 +354,7 @@ fn op_chmod(
       use std::os::unix::fs::PermissionsExt;
       let permissions = PermissionsExt::from_mode(mode);
       std::fs::set_permissions(&path, permissions)?;
+      Ok(json!({}))
     }
     // TODO Implement chmod for Windows (#4357)
     #[cfg(not(unix))]
@@ -362,7 +363,6 @@ fn op_chmod(
       let _metadata = std::fs::metadata(&path)?;
       return Err(OpError::not_implemented());
     }
-    Ok(json!({}))
   })
 }
 
@@ -394,6 +394,7 @@ fn op_chown(
       let nix_uid = Uid::from_raw(args.uid);
       let nix_gid = Gid::from_raw(args.gid);
       chown(&path, Option::Some(nix_uid), Option::Some(nix_gid))?;
+      Ok(json!({}))
     }
     // TODO Implement chown for Windows
     #[cfg(not(unix))]
@@ -402,7 +403,6 @@ fn op_chown(
       let _metadata = std::fs::metadata(&path)?;
       return Err(OpError::not_implemented());
     }
-    Ok(json!({}))
   })
 }
 
@@ -723,6 +723,7 @@ fn op_symlink(
     {
       use std::os::unix::fs::symlink;
       symlink(&oldpath, &newpath)?;
+      Ok(json!({}))
     }
     // TODO Implement symlink, use type for Windows
     #[cfg(not(unix))]
@@ -732,7 +733,6 @@ fn op_symlink(
       let _ = oldpath; // avoid unused warning
       return Err(OpError::not_implemented());
     }
-    Ok(json!({}))
   })
 }
 

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -8,7 +8,6 @@ use crate::ops::dispatch_json::JsonResult;
 use crate::state::State;
 use deno_core::*;
 use futures::future::FutureExt;
-use remove_dir_all::remove_dir_all;
 use std::convert::From;
 use std::env::{current_dir, set_current_dir, temp_dir};
 use std::io::SeekFrom;
@@ -424,13 +423,13 @@ fn op_remove(
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_remove {}", path.display());
     let metadata = std::fs::symlink_metadata(&path)?;
+    debug!("op_remove {} {}", path.display(), recursive);
     let file_type = metadata.file_type();
     if file_type.is_file() || file_type.is_symlink() {
       std::fs::remove_file(&path)?;
     } else if recursive {
-      remove_dir_all(&path)?;
+      std::fs::remove_dir_all(&path)?;
     } else {
       std::fs::remove_dir(&path)?;
     }

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -391,17 +391,18 @@ fn op_chown(
     #[cfg(unix)]
     {
       use nix::unistd::{chown, Gid, Uid};
-      let path: &str = args.path.as_ref();
       let nix_uid = Uid::from_raw(args.uid);
       let nix_gid = Gid::from_raw(args.gid);
-      chown(path, Option::Some(nix_uid), Option::Some(nix_gid))?;
-      Ok(json!({}))
+      chown(&path, Option::Some(nix_uid), Option::Some(nix_gid))?;
     }
+    // TODO Implement chown for Windows
     #[cfg(not(unix))]
     {
-      // TODO: implement chown for Windows
-      Err(OpError::not_implemented())
+      // Still check file/dir exists on Windows
+      let _metadata = std::fs::metadata(&path)?;
+      return Err(OpError::not_implemented());
     }
+    Ok(json!({}))
   })
 }
 

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -391,7 +391,6 @@ fn op_chown(
     #[cfg(unix)]
     {
       use nix::unistd::{chown, Gid, Uid};
-      // let path: &str = args.path.as_ref(); // FIXME
       let nix_uid = Uid::from_raw(args.uid);
       let nix_gid = Gid::from_raw(args.gid);
       chown(&path, Option::Some(nix_uid), Option::Some(nix_gid))?;

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -2,7 +2,7 @@
 // Some deserializer fields are only used on Unix and Windows build fails without it
 use super::dispatch_json::{blocking_json, Deserialize, JsonOp, Value};
 use super::io::{FileMetadata, StreamResource, StreamResourceHolder};
-use crate::fs as deno_fs;
+use crate::fs::resolve_from_cwd;
 use crate::op_error::OpError;
 use crate::ops::dispatch_json::JsonResult;
 use crate::state::State;
@@ -72,7 +72,7 @@ fn op_open(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: OpenArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
   let state_ = state.clone();
 
   let mut open_options = if let Some(mode) = args.mode {
@@ -309,7 +309,7 @@ fn op_mkdir(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: MkdirArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
   let mode = args.mode.unwrap_or(0o777) & 0o777;
 
   state.check_write(&path)?;
@@ -345,7 +345,7 @@ fn op_chmod(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: ChmodArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
 
   state.check_write(&path)?;
 
@@ -380,7 +380,7 @@ fn op_chown(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: ChownArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
 
   state.check_write(&path)?;
 
@@ -418,7 +418,7 @@ fn op_remove(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: RemoveArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
   let recursive = args.recursive;
 
   state.check_write(&path)?;
@@ -453,8 +453,8 @@ fn op_copy_file(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: CopyFileArgs = serde_json::from_value(args)?;
-  let from = deno_fs::resolve_from_cwd(Path::new(&args.from))?;
-  let to = deno_fs::resolve_from_cwd(Path::new(&args.to))?;
+  let from = resolve_from_cwd(Path::new(&args.from))?;
+  let to = resolve_from_cwd(Path::new(&args.to))?;
 
   state.check_read(&from)?;
   state.check_write(&to)?;
@@ -552,7 +552,7 @@ fn op_stat(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: StatArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
   let lstat = args.lstat;
 
   state.check_read(&path)?;
@@ -582,7 +582,7 @@ fn op_realpath(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: RealpathArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
 
   state.check_read(&path)?;
 
@@ -614,7 +614,7 @@ fn op_read_dir(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: ReadDirArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
 
   state.check_read(&path)?;
 
@@ -653,8 +653,8 @@ fn op_rename(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: RenameArgs = serde_json::from_value(args)?;
-  let oldpath = deno_fs::resolve_from_cwd(Path::new(&args.oldpath))?;
-  let newpath = deno_fs::resolve_from_cwd(Path::new(&args.newpath))?;
+  let oldpath = resolve_from_cwd(Path::new(&args.oldpath))?;
+  let newpath = resolve_from_cwd(Path::new(&args.newpath))?;
 
   state.check_read(&oldpath)?;
   state.check_write(&oldpath)?;
@@ -682,8 +682,8 @@ fn op_link(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: LinkArgs = serde_json::from_value(args)?;
-  let oldname = deno_fs::resolve_from_cwd(Path::new(&args.oldname))?;
-  let newname = deno_fs::resolve_from_cwd(Path::new(&args.newname))?;
+  let oldname = resolve_from_cwd(Path::new(&args.oldname))?;
+  let newname = resolve_from_cwd(Path::new(&args.newname))?;
 
   state.check_read(&oldname)?;
   state.check_write(&newname)?;
@@ -710,8 +710,8 @@ fn op_symlink(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: SymlinkArgs = serde_json::from_value(args)?;
-  let oldname = deno_fs::resolve_from_cwd(Path::new(&args.oldname))?;
-  let newname = deno_fs::resolve_from_cwd(Path::new(&args.newname))?;
+  let oldname = resolve_from_cwd(Path::new(&args.oldname))?;
+  let newname = resolve_from_cwd(Path::new(&args.newname))?;
 
   state.check_write(&newname)?;
   // TODO Use type for Windows.
@@ -745,7 +745,7 @@ fn op_read_link(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: ReadLinkArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
 
   state.check_read(&path)?;
 
@@ -773,7 +773,7 @@ fn op_truncate(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: TruncateArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
   let len = args.len;
 
   state.check_write(&path)?;
@@ -848,9 +848,7 @@ fn op_make_temp_dir(
 ) -> Result<JsonOp, OpError> {
   let args: MakeTempArgs = serde_json::from_value(args)?;
 
-  let dir = args
-    .dir
-    .map(|s| deno_fs::resolve_from_cwd(Path::new(&s)).unwrap());
+  let dir = args.dir.map(|s| resolve_from_cwd(Path::new(&s)).unwrap());
   let prefix = args.prefix.map(String::from);
   let suffix = args.suffix.map(String::from);
 
@@ -881,9 +879,7 @@ fn op_make_temp_file(
 ) -> Result<JsonOp, OpError> {
   let args: MakeTempArgs = serde_json::from_value(args)?;
 
-  let dir = args
-    .dir
-    .map(|s| deno_fs::resolve_from_cwd(Path::new(&s)).unwrap());
+  let dir = args.dir.map(|s| resolve_from_cwd(Path::new(&s)).unwrap());
   let prefix = args.prefix.map(String::from);
   let suffix = args.suffix.map(String::from);
 

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -915,7 +915,10 @@ fn op_utime(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: UtimeArgs = serde_json::from_value(args)?;
-  state.check_write(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
+
+  state.check_write(&path)?;
+
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_utime {} {} {}", args.path, args.atime, args.mtime);

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -12,6 +12,7 @@ use remove_dir_all::remove_dir_all;
 use std;
 use std::convert::From;
 use std::fs;
+use std::env::{current_dir, set_current_dir, temp_dir};
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
@@ -289,7 +290,7 @@ fn op_chdir(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: ChdirArgs = serde_json::from_value(args)?;
-  std::env::set_current_dir(&args.directory)?;
+  set_current_dir(&args.directory)?;
   Ok(JsonOp::Sync(json!({})))
 }
 
@@ -784,7 +785,7 @@ fn make_temp(
   let suffix_ = suffix.unwrap_or("");
   let mut buf: PathBuf = match dir {
     Some(ref p) => p.to_path_buf(),
-    None => std::env::temp_dir(),
+    None => temp_dir(),
   }
   .join("_");
   let mut rng = thread_rng();
@@ -841,8 +842,7 @@ fn op_make_temp_dir(
   let prefix = args.prefix.map(String::from);
   let suffix = args.suffix.map(String::from);
 
-  state
-    .check_write(dir.clone().unwrap_or_else(std::env::temp_dir).as_path())?;
+  state.check_write(dir.clone().unwrap_or_else(temp_dir).as_path())?;
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
@@ -875,8 +875,7 @@ fn op_make_temp_file(
   let prefix = args.prefix.map(String::from);
   let suffix = args.suffix.map(String::from);
 
-  state
-    .check_write(dir.clone().unwrap_or_else(std::env::temp_dir).as_path())?;
+  state.check_write(dir.clone().unwrap_or_else(temp_dir).as_path())?;
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
@@ -925,7 +924,7 @@ fn op_cwd(
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
-  let path = std::env::current_dir()?;
+  let path = current_dir()?;
   let path_str = path.into_os_string().into_string().unwrap();
   Ok(JsonOp::Sync(json!(path_str)))
 }

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -391,6 +391,7 @@ fn op_chown(
     #[cfg(unix)]
     {
       use nix::unistd::{chown, Gid, Uid};
+      // let path: &str = args.path.as_ref(); // FIXME
       let nix_uid = Uid::from_raw(args.uid);
       let nix_gid = Gid::from_raw(args.gid);
       chown(&path, Option::Some(nix_uid), Option::Some(nix_gid))?;

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -365,28 +365,6 @@ fn op_chmod(
   })
 }
 
-#[cfg(unix)]
-use nix::unistd::{chown as unix_chown, Gid, Uid};
-
-#[cfg(unix)]
-pub fn chown(path: &str, uid: u32, gid: u32) -> Result<(), ErrBox> {
-  let nix_uid = Uid::from_raw(uid);
-  let nix_gid = Gid::from_raw(gid);
-  unix_chown(path, Option::Some(nix_uid), Option::Some(nix_gid))
-    .map_err(ErrBox::from)
-}
-
-#[cfg(not(unix))]
-pub fn chown(_path: &str, _uid: u32, _gid: u32) -> Result<(), ErrBox> {
-  // FAIL on Windows
-  // TODO: implement chown for Windows
-  let e = std::io::Error::new(
-    std::io::ErrorKind::Other,
-    "Not implemented".to_string(),
-  );
-  Err(ErrBox::from(e))
-}
-
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ChownArgs {
@@ -408,9 +386,21 @@ fn op_chown(
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_chown {}", path.display());
-    chown(args.path.as_ref(), args.uid, args.gid)?;
-    Ok(json!({}))
+    debug!("op_chown {} {} {}", path.display(), args.uid, args.gid);
+    #[cfg(unix)]
+    {
+      use nix::unistd::{chown, Gid, Uid};
+      let path: &str = args.path.as_ref();
+      let nix_uid = Uid::from_raw(args.uid);
+      let nix_gid = Gid::from_raw(args.gid);
+      chown(path, Option::Some(nix_uid), Option::Some(nix_gid))?;
+      Ok(json!({}))
+    }
+    #[cfg(not(unix))]
+    {
+      // TODO: implement chown for Windows
+      Err(OpError::not_implemented())
+    }
   })
 }
 

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -9,9 +9,7 @@ use crate::state::State;
 use deno_core::*;
 use futures::future::FutureExt;
 use remove_dir_all::remove_dir_all;
-use std;
 use std::convert::From;
-use std::fs;
 use std::env::{current_dir, set_current_dir, temp_dir};
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
@@ -77,7 +75,7 @@ fn op_open(
 
   let mut open_options = if let Some(mode) = args.mode {
     #[allow(unused_mut)]
-    let mut std_options = fs::OpenOptions::new();
+    let mut std_options = std::fs::OpenOptions::new();
     // mode only used if creating the file on Unix
     // if not specified, defaults to 0o666
     #[cfg(unix)]
@@ -353,13 +351,13 @@ fn op_chmod(
   blocking_json(is_sync, move || {
     debug!("op_chmod {}", path.display());
     // Still check file/dir exists on windows
-    let _metadata = fs::metadata(&path)?;
+    let _metadata = std::fs::metadata(&path)?;
     #[cfg(unix)]
     {
       use std::os::unix::fs::PermissionsExt;
       let mut permissions = _metadata.permissions();
       permissions.set_mode(args.mode);
-      fs::set_permissions(&path, permissions)?;
+      std::fs::set_permissions(&path, permissions)?;
     }
     Ok(json!({}))
   })
@@ -426,14 +424,14 @@ fn op_remove(
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_remove {}", path.display());
-    let metadata = fs::symlink_metadata(&path)?;
+    let metadata = std::fs::symlink_metadata(&path)?;
     let file_type = metadata.file_type();
     if file_type.is_file() || file_type.is_symlink() {
-      fs::remove_file(&path)?;
+      std::fs::remove_file(&path)?;
     } else if recursive {
       remove_dir_all(&path)?;
     } else {
-      fs::remove_dir(&path)?;
+      std::fs::remove_dir(&path)?;
     }
     Ok(json!({}))
   })
@@ -470,7 +468,7 @@ fn op_copy_file(
     }
 
     // returns size of from as u64 (we ignore)
-    fs::copy(&from, &to)?;
+    std::fs::copy(&from, &to)?;
     Ok(json!({}))
   })
 }
@@ -487,7 +485,7 @@ macro_rules! to_seconds {
 
 #[inline(always)]
 fn get_stat_json(
-  metadata: fs::Metadata,
+  metadata: std::fs::Metadata,
   maybe_name: Option<String>,
 ) -> JsonResult {
   // Unix stat member (number types only). 0 if not on unix.
@@ -561,9 +559,9 @@ fn op_stat(
   blocking_json(is_sync, move || {
     debug!("op_stat {} {}", path.display(), lstat);
     let metadata = if lstat {
-      fs::symlink_metadata(&path)?
+      std::fs::symlink_metadata(&path)?
     } else {
-      fs::metadata(&path)?
+      std::fs::metadata(&path)?
     };
     get_stat_json(metadata, None)
   })
@@ -591,7 +589,7 @@ fn op_realpath(
     debug!("op_realpath {}", path.display());
     // corresponds to the realpath on Unix and
     // CreateFile and GetFinalPathNameByHandle on Windows
-    let realpath = fs::canonicalize(&path)?;
+    let realpath = std::fs::canonicalize(&path)?;
     let mut realpath_str =
       realpath.to_str().unwrap().to_owned().replace("\\", "/");
     if cfg!(windows) {
@@ -621,7 +619,7 @@ fn op_read_dir(
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_read_dir {}", path.display());
-    let entries: Vec<_> = fs::read_dir(path)?
+    let entries: Vec<_> = std::fs::read_dir(path)?
       .filter_map(|entry| {
         let entry = entry.unwrap();
         let metadata = entry.metadata().unwrap();
@@ -663,7 +661,7 @@ fn op_rename(
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_rename {} {}", oldpath.display(), newpath.display());
-    fs::rename(&oldpath, &newpath)?;
+    std::fs::rename(&oldpath, &newpath)?;
     Ok(json!({}))
   })
 }
@@ -752,7 +750,7 @@ fn op_read_link(
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_read_link {}", path.display());
-    let path = fs::read_link(&path)?;
+    let path = std::fs::read_link(&path)?;
     let path_str = path.to_str().unwrap();
 
     Ok(json!(path_str))
@@ -781,7 +779,7 @@ fn op_truncate(
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_truncate {} {}", path.display(), len);
-    let f = fs::OpenOptions::new().write(true).open(&path)?;
+    let f = std::fs::OpenOptions::new().write(true).open(&path)?;
     f.set_len(len)?;
     Ok(json!({}))
   })

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -673,8 +673,8 @@ fn op_rename(
 #[serde(rename_all = "camelCase")]
 struct LinkArgs {
   promise_id: Option<u64>,
-  oldname: String,
-  newname: String,
+  oldpath: String,
+  newpath: String,
 }
 
 fn op_link(
@@ -683,16 +683,16 @@ fn op_link(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: LinkArgs = serde_json::from_value(args)?;
-  let oldname = resolve_from_cwd(Path::new(&args.oldname))?;
-  let newname = resolve_from_cwd(Path::new(&args.newname))?;
+  let oldpath = resolve_from_cwd(Path::new(&args.oldpath))?;
+  let newpath = resolve_from_cwd(Path::new(&args.newpath))?;
 
-  state.check_read(&oldname)?;
-  state.check_write(&newname)?;
+  state.check_read(&oldpath)?;
+  state.check_write(&newpath)?;
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_link {} {}", oldname.display(), newname.display());
-    std::fs::hard_link(&oldname, &newname)?;
+    debug!("op_link {} {}", oldpath.display(), newpath.display());
+    std::fs::hard_link(&oldpath, &newpath)?;
     Ok(json!({}))
   })
 }
@@ -701,8 +701,8 @@ fn op_link(
 #[serde(rename_all = "camelCase")]
 struct SymlinkArgs {
   promise_id: Option<u64>,
-  oldname: String,
-  newname: String,
+  oldpath: String,
+  newpath: String,
 }
 
 fn op_symlink(
@@ -711,13 +711,13 @@ fn op_symlink(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: SymlinkArgs = serde_json::from_value(args)?;
-  let oldname = resolve_from_cwd(Path::new(&args.oldname))?;
-  let newname = resolve_from_cwd(Path::new(&args.newname))?;
+  let oldpath = resolve_from_cwd(Path::new(&args.oldpath))?;
+  let newpath = resolve_from_cwd(Path::new(&args.newpath))?;
 
-  state.check_write(&newname)?;
+  state.check_write(&newpath)?;
   // TODO Use type for Windows.
   if cfg!(not(unix)) {
-    let _ = oldname; // avoid unused warning
+    let _ = oldpath; // avoid unused warning
     return Err(OpError::not_implemented());
   }
 
@@ -726,8 +726,8 @@ fn op_symlink(
     #[cfg(unix)]
     {
       use std::os::unix::fs::symlink;
-      debug!("op_symlink {} {}", oldname.display(), newname.display());
-      symlink(&oldname, &newname)?;
+      debug!("op_symlink {} {}", oldpath.display(), newpath.display());
+      symlink(&oldpath, &newpath)?;
     }
     Ok(json!({}))
   })

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -715,19 +715,22 @@ fn op_symlink(
   let newpath = resolve_from_cwd(Path::new(&args.newpath))?;
 
   state.check_write(&newpath)?;
-  // TODO Use type for Windows.
-  if cfg!(not(unix)) {
-    let _ = oldpath; // avoid unused warning
-    return Err(OpError::not_implemented());
-  }
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
+    debug!("op_symlink {} {}", oldpath.display(), newpath.display());
     #[cfg(unix)]
     {
       use std::os::unix::fs::symlink;
-      debug!("op_symlink {} {}", oldpath.display(), newpath.display());
       symlink(&oldpath, &newpath)?;
+    }
+    // TODO Implement symlink, use type for Windows
+    #[cfg(not(unix))]
+    {
+      // Unlike with chmod/chown, here we don't
+      // require `oldpath` to exist on Windows
+      let _ = oldpath; // avoid unused warning
+      return Err(OpError::not_implemented());
     }
     Ok(json!({}))
   })

--- a/std/fs/ensure_symlink_test.ts
+++ b/std/fs/ensure_symlink_test.ts
@@ -56,7 +56,7 @@ Deno.test(async function ensureSymlinkIfItExist(): Promise<void> {
     await assertThrowsAsync(
       (): Promise<void> => ensureSymlink(testFile, linkFile),
       Error,
-      "Not implemented"
+      "not implemented"
     );
     await Deno.remove(testDir, { recursive: true });
     return;
@@ -85,7 +85,7 @@ Deno.test(function ensureSymlinkSyncIfItExist(): void {
     assertThrows(
       (): void => ensureSymlinkSync(testFile, linkFile),
       Error,
-      "Not implemented"
+      "not implemented"
     );
     Deno.removeSync(testDir, { recursive: true });
     return;
@@ -115,7 +115,7 @@ Deno.test(async function ensureSymlinkDirectoryIfItExist(): Promise<void> {
     await assertThrowsAsync(
       (): Promise<void> => ensureSymlink(testDir, linkDir),
       Error,
-      "Not implemented"
+      "not implemented"
     );
     await Deno.remove(testDir, { recursive: true });
     return;
@@ -147,7 +147,7 @@ Deno.test(function ensureSymlinkSyncDirectoryIfItExist(): void {
     assertThrows(
       (): void => ensureSymlinkSync(testDir, linkDir),
       Error,
-      "Not implemented"
+      "not implemented"
     );
     Deno.removeSync(testDir, { recursive: true });
     return;

--- a/std/fs/walk_test.ts
+++ b/std/fs/walk_test.ts
@@ -20,7 +20,7 @@ export async function testWalk(
       await t();
     } finally {
       chdir(origCwd);
-      remove(d, { recursive: true });
+      await remove(d, { recursive: true });
     }
   }
   Deno.test({ skip, name: `[walk] ${name}`, fn });


### PR DESCRIPTION
This a complex boring PR that shifts around code (primarily) in `cli/fs.rs` and `cli/ops/fs.rs` for no change in functionality. (Though see the commit messages, especially on the last commit re the spelling of "not implemented" error messages.)

The gain of this refactoring is to ease the way for #4188 and #4017, and also to avoid some future development pain. Also, we move everything from `cli/fs.rs` that's only called by `cli/ops/fs.rs` to the latter location, and we drop the need for one external crate (`remove_dir_all`).

Highly recommend reviewing this one commit at a time, I organized them so as to make the reviewer's job easier.

A PR for #4188 and more PRs for the series #4017 are waiting to be pushed as soon as this one is merged.