### PR TITLE
Refactoring fs.rs and ops/fs.rs, try 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,6 @@ dependencies = [
  "pty",
  "rand 0.7.3",
  "regex",
- "remove_dir_all",
  "reqwest",
  "ring",
  "rustyline",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,7 +44,6 @@ log = "0.4.8"
 notify = "5.0.0-pre.2"
 rand = "0.7.3"
 regex = "1.3.5"
-remove_dir_all = "0.5.2"
 reqwest = { version = "0.10.4", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli"] }
 ring = "0.16.11"
 rustyline = "6.0.0"

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -1,17 +1,15 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use std;
-use std::fs::{DirBuilder, File, OpenOptions};
-use std::io::ErrorKind;
+use std::fs::File;
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 
 use deno_core::ErrBox;
-use rand;
-use rand::Rng;
 use walkdir::WalkDir;
 
 #[cfg(unix)]
-use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::PermissionsExt;
 
 #[cfg(unix)]
 use nix::unistd::{chown as unix_chown, Gid, Uid};
@@ -57,62 +55,6 @@ fn set_permissions(file: &mut File, mode: u32) -> std::io::Result<()> {
 fn set_permissions(_file: &mut File, _mode: u32) -> std::io::Result<()> {
   // NOOP on windows
   Ok(())
-}
-
-pub fn make_temp(
-  dir: Option<&Path>,
-  prefix: Option<&str>,
-  suffix: Option<&str>,
-  is_dir: bool,
-) -> std::io::Result<PathBuf> {
-  let prefix_ = prefix.unwrap_or("");
-  let suffix_ = suffix.unwrap_or("");
-  let mut buf: PathBuf = match dir {
-    Some(ref p) => p.to_path_buf(),
-    None => std::env::temp_dir(),
-  }
-  .join("_");
-  let mut rng = rand::thread_rng();
-  loop {
-    let unique = rng.gen::<u32>();
-    buf.set_file_name(format!("{}{:08x}{}", prefix_, unique, suffix_));
-    let r = if is_dir {
-      let mut builder = DirBuilder::new();
-      set_dir_permission(&mut builder, 0o700);
-      builder.create(buf.as_path())
-    } else {
-      let mut open_options = OpenOptions::new();
-      open_options.write(true).create_new(true);
-      #[cfg(unix)]
-      open_options.mode(0o600);
-      open_options.open(buf.as_path())?;
-      Ok(())
-    };
-    match r {
-      Err(ref e) if e.kind() == ErrorKind::AlreadyExists => continue,
-      Ok(_) => return Ok(buf),
-      Err(e) => return Err(e),
-    }
-  }
-}
-
-pub fn mkdir(path: &Path, mode: u32, recursive: bool) -> std::io::Result<()> {
-  let mut builder = DirBuilder::new();
-  builder.recursive(recursive);
-  set_dir_permission(&mut builder, mode);
-  builder.create(path)
-}
-
-#[cfg(unix)]
-fn set_dir_permission(builder: &mut DirBuilder, mode: u32) {
-  let mode = mode & 0o777;
-  debug!("set dir mode to {:o}", mode);
-  builder.mode(mode);
-}
-
-#[cfg(not(unix))]
-fn set_dir_permission(_builder: &mut DirBuilder, _mode: u32) {
-  // NOOP on windows
 }
 
 #[cfg(unix)]

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use std;
+use std::env::current_dir;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
@@ -84,7 +85,7 @@ pub fn resolve_from_cwd(path: &Path) -> Result<PathBuf, ErrBox> {
   let resolved_path = if path.is_absolute() {
     path.to_owned()
   } else {
-    let cwd = std::env::current_dir().unwrap();
+    let cwd = current_dir().unwrap();
     cwd.join(path)
   };
 
@@ -97,19 +98,19 @@ mod tests {
 
   #[test]
   fn resolve_from_cwd_child() {
-    let cwd = std::env::current_dir().unwrap();
+    let cwd = current_dir().unwrap();
     assert_eq!(resolve_from_cwd(Path::new("a")).unwrap(), cwd.join("a"));
   }
 
   #[test]
   fn resolve_from_cwd_dot() {
-    let cwd = std::env::current_dir().unwrap();
+    let cwd = current_dir().unwrap();
     assert_eq!(resolve_from_cwd(Path::new(".")).unwrap(), cwd);
   }
 
   #[test]
   fn resolve_from_cwd_parent() {
-    let cwd = std::env::current_dir().unwrap();
+    let cwd = current_dir().unwrap();
     assert_eq!(resolve_from_cwd(Path::new("a/..")).unwrap(), cwd);
   }
 

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -7,9 +7,6 @@ use std::path::{Component, Path, PathBuf};
 use deno_core::ErrBox;
 use walkdir::WalkDir;
 
-#[cfg(unix)]
-use nix::unistd::{chown as unix_chown, Gid, Uid};
-
 pub fn write_file<T: AsRef<[u8]>>(
   filename: &Path,
   data: T,
@@ -48,25 +45,6 @@ pub fn write_file_2<T: AsRef<[u8]>>(
   }
 
   file.write_all(data.as_ref())
-}
-
-#[cfg(unix)]
-pub fn chown(path: &str, uid: u32, gid: u32) -> Result<(), ErrBox> {
-  let nix_uid = Uid::from_raw(uid);
-  let nix_gid = Gid::from_raw(gid);
-  unix_chown(path, Option::Some(nix_uid), Option::Some(nix_gid))
-    .map_err(ErrBox::from)
-}
-
-#[cfg(not(unix))]
-pub fn chown(_path: &str, _uid: u32, _gid: u32) -> Result<(), ErrBox> {
-  // FAIL on Windows
-  // TODO: implement chown for Windows
-  let e = std::io::Error::new(
-    std::io::ErrorKind::Other,
-    "Not implemented".to_string(),
-  );
-  Err(ErrBox::from(e))
 }
 
 /// Normalize all itermediate components of the path (ie. remove "./" and "../" components).

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use std;
 use std::env::current_dir;
 use std::fs::OpenOptions;
 use std::io::Write;

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1291,25 +1291,25 @@ declare namespace Deno {
 
   // @url js/link.d.ts
 
-  /** Creates `newname` as a hard link to `oldname`.
+  /** Creates `newpath` as a hard link to `oldpath`.
    *
    *       Deno.linkSync("old/name", "new/name");
    *
    * Requires `allow-read` and `allow-write` permissions. */
-  export function linkSync(oldname: string, newname: string): void;
+  export function linkSync(oldpath: string, newpath: string): void;
 
-  /** Creates `newname` as a hard link to `oldname`.
+  /** Creates `newpath` as a hard link to `oldpath`.
    *
    *       await Deno.link("old/name", "new/name");
    *
    * Requires `allow-read` and `allow-write` permissions. */
-  export function link(oldname: string, newname: string): Promise<void>;
+  export function link(oldpath: string, newpath: string): Promise<void>;
 
   // @url js/symlink.d.ts
 
   /** **UNSTABLE**: `type` argument type may be changed to `"dir" | "file"`.
    *
-   * Creates `newname` as a symbolic link to `oldname`. The type argument can be
+   * Creates `newpath` as a symbolic link to `oldpath`. The type argument can be
    * set to `dir` or `file`. Is only available on Windows and ignored on other
    * platforms.
    *
@@ -1317,14 +1317,14 @@ declare namespace Deno {
    *
    * Requires `allow-read` and `allow-write` permissions. */
   export function symlinkSync(
-    oldname: string,
-    newname: string,
+    oldpath: string,
+    newpath: string,
     type?: string
   ): void;
 
   /** **UNSTABLE**: `type` argument may be changed to "dir" | "file"
    *
-   * Creates `newname` as a symbolic link to `oldname`. The type argument can be
+   * Creates `newpath` as a symbolic link to `oldpath`. The type argument can be
    * set to `dir` or `file`. Is only available on Windows and ignored on other
    * platforms.
    *
@@ -1332,8 +1332,8 @@ declare namespace Deno {
    *
    * Requires `allow-read` and `allow-write` permissions. */
   export function symlink(
-    oldname: string,
-    newname: string,
+    oldpath: string,
+    newpath: string,
     type?: string
   ): Promise<void>;
 

--- a/cli/js/ops/fs/link.ts
+++ b/cli/js/ops/fs/link.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { sendSync, sendAsync } from "../dispatch_json.ts";
 
-export function linkSync(oldname: string, newname: string): void {
-  sendSync("op_link", { oldname, newname });
+export function linkSync(oldpath: string, newpath: string): void {
+  sendSync("op_link", { oldpath, newpath });
 }
 
-export async function link(oldname: string, newname: string): Promise<void> {
-  await sendAsync("op_link", { oldname, newname });
+export async function link(oldpath: string, newpath: string): Promise<void> {
+  await sendAsync("op_link", { oldpath, newpath });
 }

--- a/cli/js/ops/fs/symlink.ts
+++ b/cli/js/ops/fs/symlink.ts
@@ -4,23 +4,23 @@ import * as util from "../../util.ts";
 import { build } from "../../build.ts";
 
 export function symlinkSync(
-  oldname: string,
-  newname: string,
+  oldpath: string,
+  newpath: string,
   type?: string
 ): void {
   if (build.os === "win" && type) {
     return util.notImplemented();
   }
-  sendSync("op_symlink", { oldname, newname });
+  sendSync("op_symlink", { oldpath, newpath });
 }
 
 export async function symlink(
-  oldname: string,
-  newname: string,
+  oldpath: string,
+  newpath: string,
   type?: string
 ): Promise<void> {
   if (build.os === "win" && type) {
     return util.notImplemented();
   }
-  await sendAsync("op_symlink", { oldname, newname });
+  await sendAsync("op_symlink", { oldpath, newpath });
 }

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -2,7 +2,7 @@
 // Some deserializer fields are only used on Unix and Windows build fails without it
 use super::dispatch_json::{blocking_json, Deserialize, JsonOp, Value};
 use super::io::{FileMetadata, StreamResource, StreamResourceHolder};
-use crate::fs as deno_fs;
+use crate::fs::resolve_from_cwd;
 use crate::op_error::OpError;
 use crate::ops::dispatch_json::JsonResult;
 use crate::state::State;
@@ -72,7 +72,7 @@ fn op_open(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: OpenArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
   let state_ = state.clone();
 
   let mut open_options = if let Some(mode) = args.mode {
@@ -309,7 +309,7 @@ fn op_mkdir(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: MkdirArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
   let mode = args.mode.unwrap_or(0o777) & 0o777;
 
   state.check_write(&path)?;
@@ -345,7 +345,7 @@ fn op_chmod(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: ChmodArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
 
   state.check_write(&path)?;
 
@@ -380,7 +380,7 @@ fn op_chown(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: ChownArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
 
   state.check_write(&path)?;
 
@@ -418,7 +418,7 @@ fn op_remove(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: RemoveArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
   let recursive = args.recursive;
 
   state.check_write(&path)?;
@@ -453,8 +453,8 @@ fn op_copy_file(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: CopyFileArgs = serde_json::from_value(args)?;
-  let from = deno_fs::resolve_from_cwd(Path::new(&args.from))?;
-  let to = deno_fs::resolve_from_cwd(Path::new(&args.to))?;
+  let from = resolve_from_cwd(Path::new(&args.from))?;
+  let to = resolve_from_cwd(Path::new(&args.to))?;
 
   state.check_read(&from)?;
   state.check_write(&to)?;
@@ -552,7 +552,7 @@ fn op_stat(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: StatArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
   let lstat = args.lstat;
 
   state.check_read(&path)?;
@@ -582,7 +582,7 @@ fn op_realpath(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: RealpathArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
 
   state.check_read(&path)?;
 
@@ -614,7 +614,7 @@ fn op_read_dir(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: ReadDirArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
 
   state.check_read(&path)?;
 
@@ -653,8 +653,8 @@ fn op_rename(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: RenameArgs = serde_json::from_value(args)?;
-  let oldpath = deno_fs::resolve_from_cwd(Path::new(&args.oldpath))?;
-  let newpath = deno_fs::resolve_from_cwd(Path::new(&args.newpath))?;
+  let oldpath = resolve_from_cwd(Path::new(&args.oldpath))?;
+  let newpath = resolve_from_cwd(Path::new(&args.newpath))?;
 
   state.check_read(&oldpath)?;
   state.check_write(&oldpath)?;
@@ -682,8 +682,8 @@ fn op_link(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: LinkArgs = serde_json::from_value(args)?;
-  let oldname = deno_fs::resolve_from_cwd(Path::new(&args.oldname))?;
-  let newname = deno_fs::resolve_from_cwd(Path::new(&args.newname))?;
+  let oldname = resolve_from_cwd(Path::new(&args.oldname))?;
+  let newname = resolve_from_cwd(Path::new(&args.newname))?;
 
   state.check_read(&oldname)?;
   state.check_write(&newname)?;
@@ -710,8 +710,8 @@ fn op_symlink(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: SymlinkArgs = serde_json::from_value(args)?;
-  let oldname = deno_fs::resolve_from_cwd(Path::new(&args.oldname))?;
-  let newname = deno_fs::resolve_from_cwd(Path::new(&args.newname))?;
+  let oldname = resolve_from_cwd(Path::new(&args.oldname))?;
+  let newname = resolve_from_cwd(Path::new(&args.newname))?;
 
   state.check_write(&newname)?;
   // TODO Use type for Windows.
@@ -740,7 +740,7 @@ fn op_read_link(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: ReadLinkArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
 
   state.check_read(&path)?;
 
@@ -768,7 +768,7 @@ fn op_truncate(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: TruncateArgs = serde_json::from_value(args)?;
-  let path = deno_fs::resolve_from_cwd(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
   let len = args.len;
 
   state.check_write(&path)?;
@@ -843,9 +843,7 @@ fn op_make_temp_dir(
 ) -> Result<JsonOp, OpError> {
   let args: MakeTempArgs = serde_json::from_value(args)?;
 
-  let dir = args
-    .dir
-    .map(|s| deno_fs::resolve_from_cwd(Path::new(&s)).unwrap());
+  let dir = args.dir.map(|s| resolve_from_cwd(Path::new(&s)).unwrap());
   let prefix = args.prefix.map(String::from);
   let suffix = args.suffix.map(String::from);
 
@@ -876,9 +874,7 @@ fn op_make_temp_file(
 ) -> Result<JsonOp, OpError> {
   let args: MakeTempArgs = serde_json::from_value(args)?;
 
-  let dir = args
-    .dir
-    .map(|s| deno_fs::resolve_from_cwd(Path::new(&s)).unwrap());
+  let dir = args.dir.map(|s| resolve_from_cwd(Path::new(&s)).unwrap());
   let prefix = args.prefix.map(String::from);
   let suffix = args.suffix.map(String::from);
 

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -364,28 +364,6 @@ fn op_chmod(
   })
 }
 
-#[cfg(unix)]
-use nix::unistd::{chown as unix_chown, Gid, Uid};
-
-#[cfg(unix)]
-pub fn chown(path: &str, uid: u32, gid: u32) -> Result<(), ErrBox> {
-  let nix_uid = Uid::from_raw(uid);
-  let nix_gid = Gid::from_raw(gid);
-  unix_chown(path, Option::Some(nix_uid), Option::Some(nix_gid))
-    .map_err(ErrBox::from)
-}
-
-#[cfg(not(unix))]
-pub fn chown(_path: &str, _uid: u32, _gid: u32) -> Result<(), ErrBox> {
-  // FAIL on Windows
-  // TODO: implement chown for Windows
-  let e = std::io::Error::new(
-    std::io::ErrorKind::Other,
-    "Not implemented".to_string(),
-  );
-  Err(ErrBox::from(e))
-}
-
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ChownArgs {
@@ -407,9 +385,21 @@ fn op_chown(
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_chown {}", path.display());
-    chown(args.path.as_ref(), args.uid, args.gid)?;
-    Ok(json!({}))
+    debug!("op_chown {} {} {}", path.display(), args.uid, args.gid);
+    #[cfg(unix)]
+    {
+      use nix::unistd::{chown, Gid, Uid};
+      let path: &str = args.path.as_ref();
+      let nix_uid = Uid::from_raw(args.uid);
+      let nix_gid = Gid::from_raw(args.gid);
+      chown(path, Option::Some(nix_uid), Option::Some(nix_gid))?;
+      Ok(json!({}))
+    }
+    #[cfg(not(unix))]
+    {
+      // TODO: implement chown for Windows
+      Err(OpError::not_implemented())
+    }
   })
 }
 

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -315,7 +315,6 @@ fn op_mkdir(
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_mkdir {} {:o} {}", path.display(), mode, args.recursive);
-    // #[allow(unused_mut)]
     let mut builder = std::fs::DirBuilder::new();
     builder.recursive(args.recursive);
     #[cfg(unix)]

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -332,7 +332,6 @@ fn op_mkdir(
 struct ChmodArgs {
   promise_id: Option<u64>,
   path: String,
-  #[allow(unused)]
   mode: u32,
 }
 
@@ -343,20 +342,24 @@ fn op_chmod(
 ) -> Result<JsonOp, OpError> {
   let args: ChmodArgs = serde_json::from_value(args)?;
   let path = resolve_from_cwd(Path::new(&args.path))?;
+  let mode = args.mode & 0o777;
 
   state.check_write(&path)?;
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_chmod {}", path.display());
-    // Still check file/dir exists on windows
-    let _metadata = std::fs::metadata(&path)?;
+    debug!("op_chmod {} {:o}", path.display(), mode);
     #[cfg(unix)]
     {
       use std::os::unix::fs::PermissionsExt;
-      let mut permissions = _metadata.permissions();
-      permissions.set_mode(args.mode);
+      let permissions = PermissionsExt::from_mode(mode);
       std::fs::set_permissions(&path, permissions)?;
+    }
+    // TODO Implement chmod for Windows (#4357)
+    #[cfg(not(unix))]
+    {
+      // Still check file/dir exists on Windows
+      let _metadata = std::fs::metadata(&path)?;
     }
     Ok(json!({}))
   })

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -364,6 +364,28 @@ fn op_chmod(
   })
 }
 
+#[cfg(unix)]
+use nix::unistd::{chown as unix_chown, Gid, Uid};
+
+#[cfg(unix)]
+pub fn chown(path: &str, uid: u32, gid: u32) -> Result<(), ErrBox> {
+  let nix_uid = Uid::from_raw(uid);
+  let nix_gid = Gid::from_raw(gid);
+  unix_chown(path, Option::Some(nix_uid), Option::Some(nix_gid))
+    .map_err(ErrBox::from)
+}
+
+#[cfg(not(unix))]
+pub fn chown(_path: &str, _uid: u32, _gid: u32) -> Result<(), ErrBox> {
+  // FAIL on Windows
+  // TODO: implement chown for Windows
+  let e = std::io::Error::new(
+    std::io::ErrorKind::Other,
+    "Not implemented".to_string(),
+  );
+  Err(ErrBox::from(e))
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ChownArgs {
@@ -386,7 +408,7 @@ fn op_chown(
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_chown {}", path.display());
-    deno_fs::chown(args.path.as_ref(), args.uid, args.gid)?;
+    chown(args.path.as_ref(), args.uid, args.gid)?;
     Ok(json!({}))
   })
 }

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -387,16 +387,17 @@ fn op_chown(
     #[cfg(unix)]
     {
       use nix::unistd::{chown, Gid, Uid};
-      let path: &str = args.path.as_ref();
       let nix_uid = Uid::from_raw(args.uid);
       let nix_gid = Gid::from_raw(args.gid);
-      chown(path, Option::Some(nix_uid), Option::Some(nix_gid))?;
+      chown(&path, Option::Some(nix_uid), Option::Some(nix_gid))?;
       Ok(json!({}))
     }
+    // TODO Implement chown for Windows
     #[cfg(not(unix))]
     {
-      // TODO: implement chown for Windows
-      Err(OpError::not_implemented())
+      // Still check file/dir exists on Windows
+      let _metadata = std::fs::metadata(&path)?;
+      return Err(OpError::not_implemented());
     }
   })
 }

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -910,7 +910,10 @@ fn op_utime(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: UtimeArgs = serde_json::from_value(args)?;
-  state.check_write(Path::new(&args.path))?;
+  let path = resolve_from_cwd(Path::new(&args.path))?;
+
+  state.check_write(&path)?;
+
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
     debug!("op_utime {} {} {}", args.path, args.atime, args.mtime);

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -673,8 +673,8 @@ fn op_rename(
 #[serde(rename_all = "camelCase")]
 struct LinkArgs {
   promise_id: Option<u64>,
-  oldname: String,
-  newname: String,
+  oldpath: String,
+  newpath: String,
 }
 
 fn op_link(
@@ -683,16 +683,16 @@ fn op_link(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: LinkArgs = serde_json::from_value(args)?;
-  let oldname = resolve_from_cwd(Path::new(&args.oldname))?;
-  let newname = resolve_from_cwd(Path::new(&args.newname))?;
+  let oldpath = resolve_from_cwd(Path::new(&args.oldpath))?;
+  let newpath = resolve_from_cwd(Path::new(&args.newpath))?;
 
-  state.check_read(&oldname)?;
-  state.check_write(&newname)?;
+  state.check_read(&oldpath)?;
+  state.check_write(&newpath)?;
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_link {} {}", oldname.display(), newname.display());
-    std::fs::hard_link(&oldname, &newname)?;
+    debug!("op_link {} {}", oldpath.display(), newpath.display());
+    std::fs::hard_link(&oldpath, &newpath)?;
     Ok(json!({}))
   })
 }
@@ -701,8 +701,8 @@ fn op_link(
 #[serde(rename_all = "camelCase")]
 struct SymlinkArgs {
   promise_id: Option<u64>,
-  oldname: String,
-  newname: String,
+  oldpath: String,
+  newpath: String,
 }
 
 fn op_symlink(
@@ -711,19 +711,19 @@ fn op_symlink(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: SymlinkArgs = serde_json::from_value(args)?;
-  let oldname = resolve_from_cwd(Path::new(&args.oldname))?;
-  let newname = resolve_from_cwd(Path::new(&args.newname))?;
+  let oldpath = resolve_from_cwd(Path::new(&args.oldpath))?;
+  let newpath = resolve_from_cwd(Path::new(&args.newpath))?;
 
-  state.check_write(&newname)?;
+  state.check_write(&newpath)?;
   // TODO Use type for Windows.
   if cfg!(not(unix)) {
     return Err(OpError::other("Not implemented".to_string()));
   }
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_symlink {} {}", oldname.display(), newname.display());
+    debug!("op_symlink {} {}", oldpath.display(), newpath.display());
     #[cfg(unix)]
-    std::os::unix::fs::symlink(&oldname, &newname)?;
+    std::os::unix::fs::symlink(&oldpath, &newpath)?;
     Ok(json!({}))
   })
 }

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -8,7 +8,6 @@ use crate::ops::dispatch_json::JsonResult;
 use crate::state::State;
 use deno_core::*;
 use futures::future::FutureExt;
-use remove_dir_all::remove_dir_all;
 use std::convert::From;
 use std::env::{current_dir, set_current_dir, temp_dir};
 use std::io::SeekFrom;
@@ -426,13 +425,13 @@ fn op_remove(
 
   let is_sync = args.promise_id.is_none();
   blocking_json(is_sync, move || {
-    debug!("op_remove {}", path.display());
     let metadata = std::fs::symlink_metadata(&path)?;
+    debug!("op_remove {} {}", path.display(), recursive);
     let file_type = metadata.file_type();
     if file_type.is_file() || file_type.is_symlink() {
       std::fs::remove_file(&path)?;
     } else if recursive {
-      remove_dir_all(&path)?;
+      std::fs::remove_dir_all(&path)?;
     } else {
       std::fs::remove_dir(&path)?;
     }


### PR DESCRIPTION
This a complex boring PR that shifts around code (primarily) in cli/fs.rs and cli/ops/fs.rs. The gain of this refactoring is to ease the way for #4188 and #4017, and also to avoid some future development pain.

Mostly there is no change in functionality (less than in a previous attempt, #4410). Except:

* We squashed bugs where op_utime and op_chown weren't using `resolve_from_cwd(Path::new(&args.path))?;`

* We eliminated the use of the external `remove_dir_all` crate.

* We move everything from cli/fs.rs that's only called by cli/ops/fs.rs to the latter location.

* op_chmod now only queries metadata to verify file/dir exists on Windows (it will already fail on Unix if it doesn't)

* op_chown now verifies the file/dir's existence on Windows like chmod does

This PR preserves the existing different behavior between op_chown and op_chmod on Windows (the former fails, the latter is a noop). See #4306. A later PR will propose making chmod behave like chown.

Another later PR will propose using `Err(OpError::not_implemented())` consistently throughout cli/ops/fs.rs. Currently, we sometimes use that and other times use `Err(OpError::other("Not implemented".to_string()))`. This change isn't straightforward, as it interacts with capitalization differences across the codebase.

Finally, a PR for #4188 and more PRs for the series #4017 are waiting to be pushed once this one is merged.

I recommend reviewing this one commit at a time, I organized them so as to make the reviewer's job easier.
