### PR TITLE
ops/fs.rs: symlink, util.ts: use "not implemented"

### DIFF
--- a/cli/js/tests/remove_test.ts
+++ b/cli/js/tests/remove_test.ts
@@ -83,7 +83,7 @@ unitTest(
   { perms: { write: true, read: true } },
   function removeSyncDanglingSymlinkSuccess(): void {
     const danglingSymlinkPath = Deno.makeTempDirSync() + "/dangling_symlink";
-    // TODO(#3832): Remove "Not Implemented" error checking when symlink creation is implemented for Windows
+    // TODO(#3832): Remove "not Implemented" error checking when symlink creation is implemented for Windows
     let errOnWindows;
     try {
       Deno.symlinkSync("unexistent_file", danglingSymlinkPath);
@@ -91,7 +91,7 @@ unitTest(
       errOnWindows = err;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const pathInfo = Deno.lstatSync(danglingSymlinkPath);
       assert(pathInfo.isSymlink());
@@ -116,7 +116,7 @@ unitTest(
     const filePath = tempDir + "/test.txt";
     const validSymlinkPath = tempDir + "/valid_symlink";
     Deno.writeFileSync(filePath, data, { mode: 0o666 });
-    // TODO(#3832): Remove "Not Implemented" error checking when symlink creation is implemented for Windows
+    // TODO(#3832): Remove "not Implemented" error checking when symlink creation is implemented for Windows
     let errOnWindows;
     try {
       Deno.symlinkSync(filePath, validSymlinkPath);
@@ -124,7 +124,7 @@ unitTest(
       errOnWindows = err;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const symlinkPathInfo = Deno.statSync(validSymlinkPath);
       assert(symlinkPathInfo.isFile());
@@ -319,7 +319,7 @@ unitTest(
   { perms: { write: true, read: true } },
   async function removeDanglingSymlinkSuccess(): Promise<void> {
     const danglingSymlinkPath = Deno.makeTempDirSync() + "/dangling_symlink";
-    // TODO(#3832): Remove "Not Implemented" error checking when symlink creation is implemented for Windows
+    // TODO(#3832): Remove "not Implemented" error checking when symlink creation is implemented for Windows
     let errOnWindows;
     try {
       Deno.symlinkSync("unexistent_file", danglingSymlinkPath);
@@ -327,7 +327,7 @@ unitTest(
       errOnWindows = e;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const pathInfo = Deno.lstatSync(danglingSymlinkPath);
       assert(pathInfo.isSymlink());
@@ -352,7 +352,7 @@ unitTest(
     const filePath = tempDir + "/test.txt";
     const validSymlinkPath = tempDir + "/valid_symlink";
     Deno.writeFileSync(filePath, data, { mode: 0o666 });
-    // TODO(#3832): Remove "Not Implemented" error checking when symlink creation is implemented for Windows
+    // TODO(#3832): Remove "not Implemented" error checking when symlink creation is implemented for Windows
     let errOnWindows;
     try {
       Deno.symlinkSync(filePath, validSymlinkPath);
@@ -360,7 +360,7 @@ unitTest(
       errOnWindows = e;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const symlinkPathInfo = Deno.statSync(validSymlinkPath);
       assert(symlinkPathInfo.isFile());

--- a/cli/js/tests/symlink_test.ts
+++ b/cli/js/tests/symlink_test.ts
@@ -17,7 +17,7 @@ unitTest(
     }
     if (errOnWindows) {
       assertEquals(Deno.build.os, "win");
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const newNameInfoLStat = Deno.lstatSync(newname);
       const newNameInfoStat = Deno.statSync(newname);
@@ -54,7 +54,8 @@ unitTest(
     }
     if (err) {
       assertEquals(Deno.build.os, "win");
-      assertEquals(err.message, "Not implemented");
+      // from cli/js/util.ts:notImplemented
+      assertEquals(err.message, "not implemented");
     }
   }
 );
@@ -74,7 +75,7 @@ unitTest(
       errOnWindows = e;
     }
     if (errOnWindows) {
-      assertEquals(errOnWindows.message, "Not implemented");
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const newNameInfoLStat = Deno.lstatSync(newname);
       const newNameInfoStat = Deno.statSync(newname);

--- a/cli/js/util.ts
+++ b/cli/js/util.ts
@@ -53,7 +53,7 @@ export function createResolvable<T>(): Resolvable<T> {
 
 // @internal
 export function notImplemented(): never {
-  throw new Error("Not implemented");
+  throw new Error("not implemented");
 }
 
 // @internal

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -730,7 +730,7 @@ fn op_symlink(
       // Unlike with chmod/chown, here we don't
       // require `oldpath` to exist on Windows
       let _ = oldpath; // avoid unused warning
-      return Err(OpError::other("Not implemented".to_string()));
+      return Err(OpError::not_implemented());
     }
   })
 }

--- a/std/fs/ensure_symlink_test.ts
+++ b/std/fs/ensure_symlink_test.ts
@@ -56,7 +56,7 @@ Deno.test(async function ensureSymlinkIfItExist(): Promise<void> {
     await assertThrowsAsync(
       (): Promise<void> => ensureSymlink(testFile, linkFile),
       Error,
-      "Not implemented"
+      "not implemented"
     );
     await Deno.remove(testDir, { recursive: true });
     return;
@@ -85,7 +85,7 @@ Deno.test(function ensureSymlinkSyncIfItExist(): void {
     assertThrows(
       (): void => ensureSymlinkSync(testFile, linkFile),
       Error,
-      "Not implemented"
+      "not implemented"
     );
     Deno.removeSync(testDir, { recursive: true });
     return;
@@ -115,7 +115,7 @@ Deno.test(async function ensureSymlinkDirectoryIfItExist(): Promise<void> {
     await assertThrowsAsync(
       (): Promise<void> => ensureSymlink(testDir, linkDir),
       Error,
-      "Not implemented"
+      "not implemented"
     );
     await Deno.remove(testDir, { recursive: true });
     return;
@@ -147,7 +147,7 @@ Deno.test(function ensureSymlinkSyncDirectoryIfItExist(): void {
     assertThrows(
       (): void => ensureSymlinkSync(testDir, linkDir),
       Error,
-      "Not implemented"
+      "not implemented"
     );
     Deno.removeSync(testDir, { recursive: true });
     return;


### PR DESCRIPTION
Following the lead of @ry in #4270 (commit b4a6fbb), I wanted to shift from OpError::other("Not implemented") in op_symlink to OpError::not_implemented. But this triggered an awkward cascade having to do with our unsystematic spelling of errors generated in different places. The OpError::not_implemented (following our other Rust errors) is uncapitalized. But then some other errors for Deno.symlink come from cli/js/util.ts: notImplemented(), where the error was capitalized. Changing that to lower case for consistency in the tests (and to keep from having to guess the capitalization depending on the error) required changing the capitalization of checks against the error in cli/js/tests/remove_test.ts and std/fs/ensure_symlink_test.ts.

That's enough to stop this cascade. But really we ought to either: (1) settle on a consistent formatting/spelling scheme for our error messages, whether they come from Rust, or cli/js (or presumably std too). And/or: (2) make the checks against the errors in our tests case-insensitive.
