### PR TITLE
Renamed Deno.run's args to cmd

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1900,12 +1900,12 @@ declare namespace Deno {
     signal?: number;
   }
 
-  /** **UNSTABLE**:  Maybe rename `args` to `argv` to differentiate from
+  /** **UNSTABLE**: `args` has been recently renamed to `cmd` to differentiate from
    * `Deno.args`. */
   export interface RunOptions {
     /** Arguments to pass. Note, the first element needs to be a path to the
      * binary */
-    args: string[];
+    cmd: string[];
     cwd?: string;
     env?: {
       [key: string]: string;

--- a/cli/js/ops/process.ts
+++ b/cli/js/ops/process.ts
@@ -17,7 +17,7 @@ export function runStatus(rid: number): Promise<RunStatusResponse> {
 }
 
 interface RunRequest {
-  args: string[];
+  cmd: string[];
   cwd?: string;
   env?: Array<[string, string]>;
   stdin: string;
@@ -37,6 +37,6 @@ interface RunResponse {
 }
 
 export function run(request: RunRequest): RunResponse {
-  assert(request.args.length > 0);
+  assert(request.cmd.length > 0);
   return sendSync("op_run", request);
 }

--- a/cli/js/process.ts
+++ b/cli/js/process.ts
@@ -10,7 +10,7 @@ export type ProcessStdio = "inherit" | "piped" | "null";
 // TODO Maybe extend VSCode's 'CommandOptions'?
 // See https://code.visualstudio.com/docs/editor/tasks-appendix#_schema-for-tasksjson
 export interface RunOptions {
-  args: string[];
+  cmd: string[];
   cwd?: string;
   env?: { [key: string]: string };
   stdout?: ProcessStdio | number;
@@ -108,7 +108,7 @@ interface RunResponse {
   stderrRid: number | null;
 }
 export function run({
-  args,
+  cmd,
   cwd = undefined,
   env = {},
   stdout = "inherit",
@@ -116,7 +116,7 @@ export function run({
   stdin = "inherit"
 }: RunOptions): Process {
   const res = runOp({
-    args: args.map(String),
+    cmd: cmd.map(String),
     cwd,
     env: Object.entries(env),
     stdin: isRid(stdin) ? "" : stdin,

--- a/cli/js/tests/chown_test.ts
+++ b/cli/js/tests/chown_test.ts
@@ -7,11 +7,11 @@ if (Deno.build.os !== "win") {
     // get the user ID and group ID of the current process
     const uidProc = Deno.run({
       stdout: "piped",
-      args: ["python", "-c", "import os; print(os.getuid())"]
+      cmd: ["python", "-c", "import os; print(os.getuid())"]
     });
     const gidProc = Deno.run({
       stdout: "piped",
-      args: ["python", "-c", "import os; print(os.getgid())"]
+      cmd: ["python", "-c", "import os; print(os.getgid())"]
     });
 
     assertEquals((await uidProc.status()).code, 0);

--- a/cli/js/tests/os_test.ts
+++ b/cli/js/tests/os_test.ts
@@ -65,7 +65,7 @@ unitTest(
         ${JSON.stringify(Object.keys(expectedEnv))}.map(k => Deno.env(k))
       )`;
       const proc = Deno.run({
-        args: [Deno.execPath(), "eval", src],
+        cmd: [Deno.execPath(), "eval", src],
         env: inputEnv,
         stdout: "piped"
       });

--- a/cli/js/tests/process_test.ts
+++ b/cli/js/tests/process_test.ts
@@ -10,7 +10,7 @@ const { kill, run, readFile, open, makeTempDir, writeFile } = Deno;
 unitTest(function runPermissions(): void {
   let caughtError = false;
   try {
-    Deno.run({ args: ["python", "-c", "print('hello world')"] });
+    Deno.run({ cmd: ["python", "-c", "print('hello world')"] });
   } catch (e) {
     caughtError = true;
     assert(e instanceof Deno.errors.PermissionDenied);
@@ -20,7 +20,7 @@ unitTest(function runPermissions(): void {
 
 unitTest({ perms: { run: true } }, async function runSuccess(): Promise<void> {
   const p = run({
-    args: ["python", "-c", "print('hello world')"],
+    cmd: ["python", "-c", "print('hello world')"],
     stdout: "piped",
     stderr: "null"
   });
@@ -36,7 +36,7 @@ unitTest(
   { perms: { run: true } },
   async function runCommandFailedWithCode(): Promise<void> {
     const p = run({
-      args: ["python", "-c", "import sys;sys.exit(41 + 1)"]
+      cmd: ["python", "-c", "import sys;sys.exit(41 + 1)"]
     });
     const status = await p.status();
     assertEquals(status.success, false);
@@ -54,7 +54,7 @@ unitTest(
   },
   async function runCommandFailedWithSignal(): Promise<void> {
     const p = run({
-      args: ["python", "-c", "import os;os.kill(os.getpid(), 9)"]
+      cmd: ["python", "-c", "import os;os.kill(os.getpid(), 9)"]
     });
     const status = await p.status();
     assertEquals(status.success, false);
@@ -67,7 +67,7 @@ unitTest(
 unitTest({ perms: { run: true } }, function runNotFound(): void {
   let error;
   try {
-    run({ args: ["this file hopefully doesn't exist"] });
+    run({ cmd: ["this file hopefully doesn't exist"] });
   } catch (e) {
     error = e;
   }
@@ -102,7 +102,7 @@ while True:
     Deno.writeFileSync(`${cwd}/${pyProgramFile}.py`, enc.encode(pyProgram));
     const p = run({
       cwd,
-      args: ["python", `${pyProgramFile}.py`]
+      cmd: ["python", `${pyProgramFile}.py`]
     });
 
     // Write the expected exit code *after* starting python.
@@ -122,7 +122,7 @@ unitTest({ perms: { run: true } }, async function runStdinPiped(): Promise<
   void
 > {
   const p = run({
-    args: ["python", "-c", "import sys; assert 'hello' == sys.stdin.read();"],
+    cmd: ["python", "-c", "import sys; assert 'hello' == sys.stdin.read();"],
     stdin: "piped"
   });
   assert(p.stdin);
@@ -146,7 +146,7 @@ unitTest({ perms: { run: true } }, async function runStdoutPiped(): Promise<
   void
 > {
   const p = run({
-    args: ["python", "-c", "import sys; sys.stdout.write('hello')"],
+    cmd: ["python", "-c", "import sys; sys.stdout.write('hello')"],
     stdout: "piped"
   });
   assert(!p.stdin);
@@ -175,7 +175,7 @@ unitTest({ perms: { run: true } }, async function runStderrPiped(): Promise<
   void
 > {
   const p = run({
-    args: ["python", "-c", "import sys; sys.stderr.write('hello')"],
+    cmd: ["python", "-c", "import sys; sys.stderr.write('hello')"],
     stderr: "piped"
   });
   assert(!p.stdin);
@@ -202,7 +202,7 @@ unitTest({ perms: { run: true } }, async function runStderrPiped(): Promise<
 
 unitTest({ perms: { run: true } }, async function runOutput(): Promise<void> {
   const p = run({
-    args: ["python", "-c", "import sys; sys.stdout.write('hello')"],
+    cmd: ["python", "-c", "import sys; sys.stdout.write('hello')"],
     stdout: "piped"
   });
   const output = await p.output();
@@ -215,7 +215,7 @@ unitTest({ perms: { run: true } }, async function runStderrOutput(): Promise<
   void
 > {
   const p = run({
-    args: ["python", "-c", "import sys; sys.stderr.write('error')"],
+    cmd: ["python", "-c", "import sys; sys.stderr.write('error')"],
     stderr: "piped"
   });
   const error = await p.stderrOutput();
@@ -232,7 +232,7 @@ unitTest(
     const file = await open(fileName, "w");
 
     const p = run({
-      args: [
+      cmd: [
         "python",
         "-c",
         "import sys; sys.stderr.write('error\\n'); sys.stdout.write('output\\n');"
@@ -264,7 +264,7 @@ unitTest(
     const file = await open(fileName, "r");
 
     const p = run({
-      args: ["python", "-c", "import sys; assert 'hello' == sys.stdin.read();"],
+      cmd: ["python", "-c", "import sys; assert 'hello' == sys.stdin.read();"],
       stdin: file.rid
     });
 
@@ -277,7 +277,7 @@ unitTest(
 
 unitTest({ perms: { run: true } }, async function runEnv(): Promise<void> {
   const p = run({
-    args: [
+    cmd: [
       "python",
       "-c",
       "import os, sys; sys.stdout.write(os.environ.get('FOO', '') + os.environ.get('BAR', ''))"
@@ -296,7 +296,7 @@ unitTest({ perms: { run: true } }, async function runEnv(): Promise<void> {
 
 unitTest({ perms: { run: true } }, async function runClose(): Promise<void> {
   const p = run({
-    args: [
+    cmd: [
       "python",
       "-c",
       "from time import sleep; import sys; sleep(10000); sys.stderr.write('error')"
@@ -343,7 +343,7 @@ if (Deno.build.os !== "win") {
     void
   > {
     const p = run({
-      args: ["python", "-c", "from time import sleep; sleep(10000)"]
+      cmd: ["python", "-c", "from time import sleep; sleep(10000)"]
     });
 
     assertEquals(Deno.Signal.SIGINT, 2);
@@ -361,7 +361,7 @@ if (Deno.build.os !== "win") {
 
   unitTest({ perms: { run: true } }, function killFailed(): void {
     const p = run({
-      args: ["python", "-c", "from time import sleep; sleep(10000)"]
+      cmd: ["python", "-c", "from time import sleep; sleep(10000)"]
     });
     assert(!p.stdin);
     assert(!p.stdout);

--- a/cli/js/tests/unit_test_runner.ts
+++ b/cli/js/tests/unit_test_runner.ts
@@ -86,7 +86,7 @@ function spawnWorkerRunner(
     })
     .join(",");
 
-  const args = [
+  const cmd = [
     Deno.execPath(),
     "run",
     "-A",
@@ -97,14 +97,14 @@ function spawnWorkerRunner(
   ];
 
   if (filter) {
-    args.push("--");
-    args.push(filter);
+    cmd.push("--");
+    cmd.push(filter);
   }
 
   const ioMode = verbose ? "inherit" : "null";
 
   const p = Deno.run({
-    args,
+    cmd,
     stdin: ioMode,
     stdout: ioMode,
     stderr: ioMode

--- a/cli/ops/process.rs
+++ b/cli/ops/process.rs
@@ -49,7 +49,7 @@ fn subprocess_stdio_map(s: &str) -> std::process::Stdio {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RunArgs {
-  args: Vec<String>,
+  cmd: Vec<String>,
   cwd: Option<String>,
   env: Vec<(String, String)>,
   stdin: String,
@@ -74,7 +74,7 @@ fn op_run(
   state.check_run()?;
   let state_ = state.clone();
 
-  let args = run_args.args;
+  let args = run_args.cmd;
   let env = run_args.env;
   let cwd = run_args.cwd;
 

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -24,7 +24,7 @@ async function proxyRequest(req: ServerRequest): Promise<void> {
 
 async function testFetch(): Promise<void> {
   const c = Deno.run({
-    args: [Deno.execPath(), "--reload", "--allow-net", "045_proxy_client.ts"],
+    cmd: [Deno.execPath(), "--reload", "--allow-net", "045_proxy_client.ts"],
     stdout: "piped",
     env: {
       HTTP_PROXY: `http://${addr}`
@@ -38,7 +38,7 @@ async function testFetch(): Promise<void> {
 
 async function testModuleDownload(): Promise<void> {
   const http = Deno.run({
-    args: [
+    cmd: [
       Deno.execPath(),
       "--reload",
       "fetch",

--- a/cli/tests/lock_write_fetch.ts
+++ b/cli/tests/lock_write_fetch.ts
@@ -5,7 +5,7 @@ try {
 const fetchProc = Deno.run({
   stdout: "null",
   stderr: "null",
-  args: [
+  cmd: [
     Deno.execPath(),
     "fetch",
     "--reload",
@@ -21,7 +21,7 @@ console.log(`fetch code: ${fetchCode}`);
 const fetchCheckProc = Deno.run({
   stdout: "null",
   stderr: "null",
-  args: [
+  cmd: [
     Deno.execPath(),
     "fetch",
     "--lock=lock_write_fetch.json",
@@ -35,7 +35,7 @@ console.log(`fetch check code: ${fetchCheckProcCode}`);
 const runProc = Deno.run({
   stdout: "null",
   stderr: "null",
-  args: [Deno.execPath(), "--lock=lock_write_fetch.json", "https_import.ts"]
+  cmd: [Deno.execPath(), "--lock=lock_write_fetch.json", "https_import.ts"]
 });
 
 const runCode = (await runProc.status()).code;

--- a/cli/tests/permission_test.ts
+++ b/cli/tests/permission_test.ts
@@ -18,7 +18,7 @@ const test: { [key: string]: Function } = {
   },
   runRequired(): void {
     run({
-      args: [
+      cmd: [
         "python",
         "-c",
         "import sys; sys.stdout.write('hello'); sys.stdout.flush()"

--- a/std/examples/chat/server_test.ts
+++ b/std/examples/chat/server_test.ts
@@ -12,7 +12,7 @@ const { test, build } = Deno;
 
 async function startServer(): Promise<Deno.Process> {
   const server = Deno.run({
-    args: [
+    cmd: [
       Deno.execPath(),
       "--allow-net",
       "--allow-read",

--- a/std/examples/test.ts
+++ b/std/examples/test.ts
@@ -14,7 +14,7 @@ Deno.test(function t2(): void {
 /** A more complicated test that runs a subprocess. */
 Deno.test(async function catSmoke(): Promise<void> {
   const p = run({
-    args: [
+    cmd: [
       Deno.execPath(),
       "run",
       "--allow-read",

--- a/std/examples/tests/cat_test.ts
+++ b/std/examples/tests/cat_test.ts
@@ -4,7 +4,7 @@ import { assertStrictEq } from "../../testing/asserts.ts";
 Deno.test("[examples/cat] print multiple files", async () => {
   const decoder = new TextDecoder();
   const process = Deno.run({
-    args: [
+    cmd: [
       Deno.execPath(),
       "--allow-read",
       "cat.ts",

--- a/std/examples/tests/catj_test.ts
+++ b/std/examples/tests/catj_test.ts
@@ -77,7 +77,7 @@ Deno.test("[examples/catj] read from stdin", async () => {
 
 function catj(...files: string[]): Deno.Process {
   return Deno.run({
-    args: [Deno.execPath(), "--allow-read", "catj.ts", ...files],
+    cmd: [Deno.execPath(), "--allow-read", "catj.ts", ...files],
     cwd: "examples",
     stdin: "piped",
     stdout: "piped",

--- a/std/examples/tests/colors_test.ts
+++ b/std/examples/tests/colors_test.ts
@@ -4,7 +4,7 @@ import { assertStrictEq } from "../../testing/asserts.ts";
 Deno.test("[examples/colors] print a colored text", async () => {
   const decoder = new TextDecoder();
   const process = Deno.run({
-    args: [Deno.execPath(), "colors.ts"],
+    cmd: [Deno.execPath(), "colors.ts"],
     cwd: "examples",
     stdout: "piped"
   });

--- a/std/examples/tests/curl_test.ts
+++ b/std/examples/tests/curl_test.ts
@@ -19,7 +19,7 @@ Deno.test({
 
     const decoder = new TextDecoder();
     const process = Deno.run({
-      args: [
+      cmd: [
         Deno.execPath(),
         "--allow-net",
         "curl.ts",

--- a/std/examples/tests/echo_server_test.ts
+++ b/std/examples/tests/echo_server_test.ts
@@ -8,7 +8,7 @@ Deno.test("[examples/echo_server]", async () => {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   const process = Deno.run({
-    args: [Deno.execPath(), "--allow-net", "echo_server.ts", `${port}`],
+    cmd: [Deno.execPath(), "--allow-net", "echo_server.ts", `${port}`],
     cwd: "examples",
     stdout: "piped"
   });

--- a/std/examples/tests/welcome_test.ts
+++ b/std/examples/tests/welcome_test.ts
@@ -4,7 +4,7 @@ import { assertStrictEq } from "../../testing/asserts.ts";
 Deno.test("[examples/welcome] print a welcome message", async () => {
   const decoder = new TextDecoder();
   const process = Deno.run({
-    args: [Deno.execPath(), "welcome.ts"],
+    cmd: [Deno.execPath(), "welcome.ts"],
     cwd: "examples",
     stdout: "piped"
   });

--- a/std/examples/tests/xeval_test.ts
+++ b/std/examples/tests/xeval_test.ts
@@ -29,7 +29,7 @@ Deno.test({
   name: "xevalCliReplvar",
   fn: async function(): Promise<void> {
     const p = run({
-      args: [execPath(), xevalPath, "--replvar=abc", "console.log(abc)"],
+      cmd: [execPath(), xevalPath, "--replvar=abc", "console.log(abc)"],
       stdin: "piped",
       stdout: "piped",
       stderr: "null"
@@ -45,7 +45,7 @@ Deno.test({
 
 Deno.test(async function xevalCliSyntaxError(): Promise<void> {
   const p = run({
-    args: [execPath(), xevalPath, "("],
+    cmd: [execPath(), xevalPath, "("],
     stdin: "null",
     stdout: "piped",
     stderr: "piped"

--- a/std/fs/empty_dir_test.ts
+++ b/std/fs/empty_dir_test.ts
@@ -221,7 +221,7 @@ for (const s of scenes) {
         const p = Deno.run({
           stdout: "piped",
           cwd: testdataDir,
-          args: args
+          cmd: args
         });
 
         assert(p.stdout);

--- a/std/fs/exists_test.ts
+++ b/std/fs/exists_test.ts
@@ -124,7 +124,7 @@ for (const s of scenes) {
     const p = Deno.run({
       stdout: "piped",
       cwd: testdataDir,
-      args: args
+      cmd: args
     });
 
     const output = await p.output();

--- a/std/fs/expand_glob_test.ts
+++ b/std/fs/expand_glob_test.ts
@@ -120,7 +120,7 @@ Deno.test(async function expandGlobIncludeDirs(): Promise<void> {
 Deno.test(async function expandGlobPermError(): Promise<void> {
   const exampleUrl = new URL("testdata/expand_wildcard.js", import.meta.url);
   const p = run({
-    args: [execPath(), exampleUrl.toString()],
+    cmd: [execPath(), exampleUrl.toString()],
     stdin: "null",
     stdout: "piped",
     stderr: "piped"

--- a/std/http/file_server_test.ts
+++ b/std/http/file_server_test.ts
@@ -9,7 +9,7 @@ let fileServer: Deno.Process;
 const port = randomPort();
 async function startFileServer(): Promise<void> {
   fileServer = Deno.run({
-    args: [
+    cmd: [
       Deno.execPath(),
       "run",
       "--allow-read",
@@ -109,7 +109,7 @@ test(async function serveWithUnorthodoxFilename(): Promise<void> {
 test(async function servePermissionDenied(): Promise<void> {
   const _port = randomPort();
   const deniedServer = Deno.run({
-    args: [
+    cmd: [
       Deno.execPath(),
       "run",
       "--allow-net",
@@ -143,7 +143,7 @@ test(async function servePermissionDenied(): Promise<void> {
 
 test(async function printHelp(): Promise<void> {
   const helpProcess = Deno.run({
-    args: [Deno.execPath(), "run", "http/file_server.ts", "--help"],
+    cmd: [Deno.execPath(), "run", "http/file_server.ts", "--help"],
     stdout: "piped"
   });
   assert(helpProcess.stdout != null);

--- a/std/http/racing_server_test.ts
+++ b/std/http/racing_server_test.ts
@@ -8,7 +8,7 @@ const { connect, run, test } = Deno;
 let server: Deno.Process;
 async function startServer(): Promise<void> {
   server = run({
-    args: [
+    cmd: [
       Deno.execPath(),
       "run",
       "-A",

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -358,7 +358,7 @@ test({
     // Runs a simple server as another process
     const port = randomPort();
     const p = Deno.run({
-      args: [
+      cmd: [
         Deno.execPath(),
         "--allow-net",
         "http/testdata/simple_server.ts",
@@ -405,7 +405,7 @@ test({
     const port = randomPort();
     // Runs a simple server as another process
     const p = Deno.run({
-      args: [
+      cmd: [
         Deno.execPath(),
         "--allow-net",
         "--allow-read",

--- a/std/manual.md
+++ b/std/manual.md
@@ -366,7 +366,7 @@ Example:
 ```ts
 // create subprocess
 const p = Deno.run({
-  args: ["echo", "hello"]
+  cmd: ["echo", "hello"]
 });
 
 // await its completion
@@ -393,7 +393,7 @@ you can use `"piped"` option.
 const fileNames = Deno.args;
 
 const p = Deno.run({
-  args: [
+  cmd: [
     "deno",
     "run",
     "--allow-read",


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
WIP. For #3891 
- [X] All test are passing
- [ ] to provide an error message for people using "args". I need help regarding this
