### PR TITLE
op_chmod: throw on Windows

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -950,7 +950,7 @@ declare namespace Deno {
    *
    * For a full description, see [chmod](#chmod)
    *
-   * NOTE: This API currently has no effect on Windows
+   * NOTE: This API currently throws on Windows
    *
    * Requires `allow-write` permission. */
   export function chmodSync(path: string, mode: number): void;
@@ -978,7 +978,7 @@ declare namespace Deno {
    * | 1      | execute only |
    * | 0      | no permission |
    *
-   * NOTE: This API currently has no effect on Windows
+   * NOTE: This API currently throws on Windows
    *
    * Requires `allow-write` permission. */
   export function chmod(path: string, mode: number): Promise<void>;

--- a/cli/js/tests/chmod_test.ts
+++ b/cli/js/tests/chmod_test.ts
@@ -1,10 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { unitTest, assert, assertEquals } from "./test_util.ts";
 
-const isNotWindows = Deno.build.os !== "win";
-
 unitTest(
-  { perms: { read: true, write: true } },
+  { ignore: Deno.build.os === "win", perms: { read: true, write: true } },
   function chmodSyncSuccess(): void {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -12,15 +10,11 @@ unitTest(
     const filename = tempDir + "/test.txt";
     Deno.writeFileSync(filename, data, { mode: 0o666 });
 
-    // On windows no effect, but should not crash
     Deno.chmodSync(filename, 0o777);
 
-    // Check success when not on windows
-    if (isNotWindows) {
-      const fileInfo = Deno.statSync(filename);
-      assert(fileInfo.mode);
-      assertEquals(fileInfo.mode & 0o777, 0o777);
-    }
+    const fileInfo = Deno.statSync(filename);
+    assert(fileInfo.mode);
+    assertEquals(fileInfo.mode & 0o777, 0o777);
   }
 );
 
@@ -79,7 +73,7 @@ unitTest({ perms: { write: false } }, function chmodSyncPerm(): void {
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { ignore: Deno.build.os === "win", perms: { read: true, write: true } },
   async function chmodSuccess(): Promise<void> {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -87,15 +81,11 @@ unitTest(
     const filename = tempDir + "/test.txt";
     Deno.writeFileSync(filename, data, { mode: 0o666 });
 
-    // On windows no effect, but should not crash
     await Deno.chmod(filename, 0o777);
 
-    // Check success when not on windows
-    if (isNotWindows) {
-      const fileInfo = Deno.statSync(filename);
-      assert(fileInfo.mode);
-      assertEquals(fileInfo.mode & 0o777, 0o777);
-    }
+    const fileInfo = Deno.statSync(filename);
+    assert(fileInfo.mode);
+    assertEquals(fileInfo.mode & 0o777, 0o777);
   }
 );
 

--- a/cli/js/write_file.ts
+++ b/cli/js/write_file.ts
@@ -3,6 +3,7 @@ import { stat, statSync } from "./ops/fs/stat.ts";
 import { open, openSync } from "./files.ts";
 import { chmod, chmodSync } from "./ops/fs/chmod.ts";
 import { writeAll, writeAllSync } from "./buffer.ts";
+import { build } from "./build.ts";
 
 export interface WriteFileOptions {
   append?: boolean;
@@ -26,7 +27,11 @@ export function writeFileSync(
   const openMode = !!options.append ? "a" : "w";
   const file = openSync(path, openMode);
 
-  if (options.mode !== undefined && options.mode !== null) {
+  if (
+    options.mode !== undefined &&
+    options.mode !== null &&
+    build.os !== "win"
+  ) {
     chmodSync(path, options.mode);
   }
 
@@ -50,7 +55,11 @@ export async function writeFile(
   const openMode = !!options.append ? "a" : "w";
   const file = await open(path, openMode);
 
-  if (options.mode !== undefined && options.mode !== null) {
+  if (
+    options.mode !== undefined &&
+    options.mode !== null &&
+    build.os !== "win"
+  ) {
     await chmod(path, options.mode);
   }
 

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -353,14 +353,15 @@ fn op_chmod(
       use std::os::unix::fs::PermissionsExt;
       let permissions = PermissionsExt::from_mode(mode);
       std::fs::set_permissions(&path, permissions)?;
+      Ok(json!({}))
     }
     // TODO Implement chmod for Windows (#4357)
     #[cfg(not(unix))]
     {
       // Still check file/dir exists on Windows
       let _metadata = std::fs::metadata(&path)?;
+      return Err(OpError::not_implemented());
     }
-    Ok(json!({}))
   })
 }
 


### PR DESCRIPTION
Currently chmod is a noop on Windows, while analogous functions like
chown and umask throw (see #4306). Symlink also currently throws, but
that can be implemented on Windows, it just hasn't been done yet
(see #815, an implementation was crafted but there were issues that
haven't been resolved yet).

It's possible to implement chmod in Windows to a limited degree: Rust
lets one make Windows files read-only. But the API for how this should
work hasn't been settled (see #4357). Until we do implement chmod on
Windows, perhaps we should make it throw like the other
Windows-unimplemented functions in /cli/ops/fs.rs do?

If so, this PR provides an implementation, and fixes tests accordingly.

Note that the current implementation of writeFile applies its `mode`
option to the file regardless of whether the file was created (and does
so using chmod, so it has to be touched by this PR). A forthcoming PR in
the #4017 series will make writeFile instead use the new `mode` option
in open for new files, and so no longer rely on chmod.
