### PR TITLE
Add radix to parseInt

### DIFF
--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -37,7 +37,7 @@ export class ServerRequest {
     if (this._contentLength === undefined) {
       const cl = this.headers.get("content-length");
       if (cl) {
-        this._contentLength = parseInt(cl);
+        this._contentLength = parseInt(cl, 10);
         // Convert NaN to null (as NaN harder to test)
         if (Number.isNaN(this._contentLength)) {
           this._contentLength = null;

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -459,7 +459,7 @@ test("close server while iterating", async (): Promise<void> => {
 
 test({
   name: "[http] test Content-Length header parsed correctly",
-  async fn(): Promise<void> {
+  fn(): Promise<void> {
     const req = new ServerRequest();
     req.headers = new Headers();
     req.headers.set("content-length", "1776");

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -459,7 +459,7 @@ test("close server while iterating", async (): Promise<void> => {
 
 test({
   name: "[http] test Content-Length header parsed correctly",
-  fn(): Promise<void> {
+  fn(): void {
     const req = new ServerRequest();
     req.headers = new Headers();
     req.headers.set("content-length", "1776");

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -458,6 +458,18 @@ test("close server while iterating", async (): Promise<void> => {
 });
 
 test({
+  name: "[http] test Content-Length header parsed correctly",
+  async fn(): Promise<void> {
+    const req = new ServerRequest();
+    req.headers = new Headers();
+    req.headers.set("content-length", "1776");
+    assertEquals(req.contentLength, 1776);
+    req.headers.set("content-length", "0xcafebebe");
+    assertEquals(req.contentLength, null);
+  }
+});
+
+test({
   name: "[http] close server while connection is open",
   async fn(): Promise<void> {
     async function iteratorReq(server: Server): Promise<void> {


### PR DESCRIPTION
Otherwise 0x... hexadecimal content-lengths could be parsed

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
