### PR TITLE
errors: replace .lines with explicit .split newline

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -553,7 +553,9 @@ impl SourceMapGetter for TsCompiler {
       .try_resolve_and_get_source_file(script_name)
       .and_then(|out| {
         str::from_utf8(&out.source_code).ok().and_then(|v| {
-          let lines: Vec<&str> = v.lines().collect();
+          // Do NOT use .lines(): it skips the terminating empty line.
+          // (due to internally using .split_terminator() instead of .split())
+          let lines: Vec<&str> = v.split('\n').collect();
           assert!(lines.len() > line);
           Some(lines[line].to_string())
         })

--- a/cli/tests/error_syntax_empty_trailing_line.mjs
+++ b/cli/tests/error_syntax_empty_trailing_line.mjs
@@ -1,0 +1,2 @@
+// Deliberately using .mjs to avoid triggering prettier
+setTimeout(() => {}),

--- a/cli/tests/error_syntax_empty_trailing_line.mjs.out
+++ b/cli/tests/error_syntax_empty_trailing_line.mjs.out
@@ -1,0 +1,2 @@
+error: Uncaught SyntaxError: Unexpected end of input
+► file:///[WILDCARD]cli/tests/error_syntax_empty_trailing_line.mjs:[WILDCARD]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1288,6 +1288,13 @@ itest!(error_syntax {
   output: "error_syntax.js.out",
 });
 
+itest!(error_syntax_empty_trailing_line {
+  args: "run --reload error_syntax_empty_trailing_line.mjs",
+  check_stderr: true,
+  exit_code: 1,
+  output: "error_syntax_empty_trailing_line.mjs.out",
+});
+
 itest!(error_type_definitions {
   args: "run --reload error_type_definitions.ts",
   check_stderr: true,


### PR DESCRIPTION
Closes #4482

See https://github.com/denoland/deno/issues/4482#issuecomment-603515956