### PR TITLE
Improve isatty and kill API docs; Deno.kill() - throw on Windows

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1883,15 +1883,22 @@ declare namespace Deno {
    * the stream to `/dev/null`. */
   type ProcessStdio = "inherit" | "piped" | "null";
 
-  /** **UNSTABLE**: the `signo` argument maybe shouldn't be number. Should throw
-   * on Windows instead of silently succeeding.
+  /** **UNSTABLE**: The `signo` argument may change to require the Deno.Signal 
+   * enum. 
    *
-   * Send a signal to process under given `pid`. Linux/Mac OS only currently.
+   * Send a signal to process under given `pid`. This functionality currently
+   * only works on Linux and Mac OS.
    *
    * If `pid` is negative, the signal will be sent to the process group
    * identified by `pid`.
    *
-   * Currently no-op on Windows.
+   *      const p = Deno.run({
+   *        cmd: ["python", "-c", "from time import sleep; sleep(10000)"]
+   *      });
+   *           
+   *      Deno.kill(p.pid, Deno.Signal.SIGINT);
+   *
+   * Throws Error (not yet implemented) on Windows
    *
    * Requires `allow-run` permission. */
   export function kill(pid: number, signo: number): void;

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -741,12 +741,21 @@ declare namespace Deno {
    */
   export type OpenMode = "r" | "r+" | "w" | "w+" | "a" | "a+" | "x" | "x+";
 
-  /** **UNSTABLE**: newly added API
+  /** **UNSTABLE**: new API, yet to be vetted
    *
-   *  Check if a given resource is TTY. */
+   *  Check if a given resource id (`rid`) is a TTY.
+   *
+   *       //This example is system and context specific
+   *       const nonTTYRid = Deno.openSync("my_file.txt").rid;
+   *       const ttyRid = Deno.openSync("/dev/tty6").rid;
+   *       console.log(Deno.isatty(nonTTYRid)); // false
+   *       console.log(Deno.isatty(ttyRid)); // true
+   *       Deno.close(nonTTYRid);
+   *       Deno.close(ttyRid);
+   */
   export function isatty(rid: number): boolean;
 
-  /** **UNSTABLE**: newly added API
+  /** **UNSTABLE**: new API, yet to be vetted
    *
    *  Set TTY to be under raw mode or not. */
   export function setRaw(rid: number, mode: boolean): void;

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1883,8 +1883,8 @@ declare namespace Deno {
    * the stream to `/dev/null`. */
   type ProcessStdio = "inherit" | "piped" | "null";
 
-  /** **UNSTABLE**: The `signo` argument may change to require the Deno.Signal 
-   * enum. 
+  /** **UNSTABLE**: The `signo` argument may change to require the Deno.Signal
+   * enum.
    *
    * Send a signal to process under given `pid`. This functionality currently
    * only works on Linux and Mac OS.
@@ -1895,7 +1895,7 @@ declare namespace Deno {
    *      const p = Deno.run({
    *        cmd: ["python", "-c", "from time import sleep; sleep(10000)"]
    *      });
-   *           
+   *
    *      Deno.kill(p.pid, Deno.Signal.SIGINT);
    *
    * Throws Error (not yet implemented) on Windows

--- a/cli/js/ops/process.ts
+++ b/cli/js/ops/process.ts
@@ -1,9 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { sendSync, sendAsync } from "./dispatch_json.ts";
 import { assert } from "../util.ts";
+import { build } from "../build.ts";
 
 export function kill(pid: number, signo: number): void {
-  if (Deno.build.os === "win") {
+  if (build.os === "win") {
     throw new Error("Not yet implemented");
   }
   sendSync("op_kill", { pid, signo });

--- a/cli/js/ops/process.ts
+++ b/cli/js/ops/process.ts
@@ -3,6 +3,9 @@ import { sendSync, sendAsync } from "./dispatch_json.ts";
 import { assert } from "../util.ts";
 
 export function kill(pid: number, signo: number): void {
+  if (Deno.build.os === "win") {
+    throw new Error("Not yet implemented");
+  }
   sendSync("op_kill", { pid, signo });
 }
 


### PR DESCRIPTION
This PR:
* Improves `isatty` docs with examples
* Improves `kill` docs with example and cleanup
* Makes `kill` throw on Windows