### PR TITLE
inspector: server auto finding free port

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -103,6 +103,7 @@ pub struct Flags {
   pub cached_only: bool,
   pub inspect: Option<String>,
   pub inspect_brk: Option<String>,
+  pub inspect_try_ports: bool,
   pub seed: Option<u64>,
   pub v8_flags: Option<Vec<String>>,
 
@@ -987,10 +988,12 @@ fn inspect_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
 
 fn inspect_arg_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   const DEFAULT: &str = "127.0.0.1:9229";
+  let mut try_ports = false;
   flags.inspect = if matches.is_present("inspect") {
     if let Some(host) = matches.value_of("inspect") {
       Some(host.to_string())
     } else {
+      try_ports = true;
       Some(DEFAULT.to_string())
     }
   } else {
@@ -1000,11 +1003,13 @@ fn inspect_arg_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     if let Some(host) = matches.value_of("inspect-brk") {
       Some(host.to_string())
     } else {
+      try_ports = true;
       Some(DEFAULT.to_string())
     }
   } else {
     None
   };
+  flags.inspect_try_ports = try_ports;
 }
 
 fn reload_arg<'a, 'b>() -> Arg<'a, 'b> {
@@ -2389,6 +2394,7 @@ fn inspect_default_host() {
         script: "foo.js".to_string(),
       },
       inspect: Some("127.0.0.1:9229".to_string()),
+      inspect_try_ports: true,
       ..Flags::default()
     }
   );

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -993,7 +993,7 @@ fn inspect_arg_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     if let Some(host) = matches.value_of("inspect") {
       Some(host.to_string())
     } else {
-      try_ports = true;
+      try_ports = true; // only try ports if not explicitly specify.
       Some(DEFAULT.to_string())
     }
   } else {
@@ -1003,7 +1003,7 @@ fn inspect_arg_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     if let Some(host) = matches.value_of("inspect-brk") {
       Some(host.to_string())
     } else {
-      try_ports = true;
+      try_ports = true; // only try ports if not explicitly specify.
       Some(DEFAULT.to_string())
     }
   } else {

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -85,9 +85,9 @@ impl GlobalState {
     };
 
     let inspector_server = if let Some(ref host) = flags.inspect {
-      Some(InspectorServer::new(host, false))
+      Some(InspectorServer::new(host, false, flags.inspect_try_ports))
     } else if let Some(ref host) = flags.inspect_brk {
-      Some(InspectorServer::new(host, true))
+      Some(InspectorServer::new(host, true, flags.inspect_try_ports))
     } else {
       None
     };


### PR DESCRIPTION
Currently, `deno run --inspect main.ts` would panic if 2 process try to create inspector server.

With this change, if no port is given, a new port will be sought with max tries 50 ports away from default. If port is given and collides, error and exit.

~~Need to tidy the code a bit and probably add test~~