### PR TITLE
fix: deno fmt should ignore d.ts from args

### DIFF
--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -158,7 +158,7 @@ pub fn format(args: Vec<String>, check: bool) -> Result<(), ErrBox> {
       let p = PathBuf::from(arg);
       if p.is_dir() {
         target_files.extend(files_in_subtree(p, is_supported));
-      } else {
+      } else if is_supported(&p) {
         target_files.push(p);
       };
     }


### PR DESCRIPTION
`deno fmt` accepts `d.ts` files from args and crashes.

```log
✗ deno fmt cli/js/lib.deno.shared_globals.d.ts
Error formatting: cli/js/lib.deno.shared_globals.d.ts
   Line 985, column 6: A binding pattern parameter cannot be optional in an implementation signature.
```