### PR TITLE
Update to dprint 0.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40a2ed665c9cb3192b689bcfc6934a1dbe16009e363c84b6db19ce1c36ef274"
+checksum = "66d1fc740f63f2fd73c63d4c55632f81fa41ec84ae531258e0e1e014bb3eb30a"
 dependencies = [
  "dprint-core",
  "serde",
@@ -2435,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.21.6"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701e681b7783c5b9d3df9e18592494ca3cba7a2fa8fc98d4d4f423ae993df155"
+checksum = "c7fd022bbe8fdd94649a0165a53dc7fbd850370a40609b9c3fddd404b99427fb"
 dependencies = [
  "either",
  "enum_kind",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.9.5"
+dprint-plugin-typescript = "0.9.6"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.0"


### PR DESCRIPTION
Updates to dprint 0.9.6 which includes the fix for https://github.com/dsherret/dprint/issues/163.