### PR TITLE
Update to TypeScript 3.9

### DIFF
--- a/cli/js/net.ts
+++ b/cli/js/net.ts
@@ -108,7 +108,7 @@ export class DatagramImpl implements DatagramConn {
   }
 
   async send(p: Uint8Array, addr: Addr): Promise<void> {
-    const remote = { hostname: "127.0.0.1", transport: "udp", ...addr };
+    const remote = { hostname: "127.0.0.1", ...addr };
 
     const args = { ...remote, rid: this.rid };
     await netOps.send(args as netOps.SendRequest, p);

--- a/cli/js/web/streams/internals.ts
+++ b/cli/js/web/streams/internals.ts
@@ -232,6 +232,7 @@ export function initializeReadableStream<R>(
   stream[sym.disturbed] = false;
 }
 
+<<<<<<< HEAD
 export function initializeTransformStream<I, O>(
   stream: TransformStreamImpl<I, O>,
   startPromise: Promise<void>,
@@ -294,12 +295,24 @@ export function invokeOrNoop<O extends Record<string, any>, P extends keyof O>(
   p: P,
   ...args: Parameters<O[P]>
 ): ReturnType<O[P]> | undefined {
+=======
+function invokeOrNoop<
+  O extends any,
+  P extends keyof O
+  // @ts-ignore see: https://github.com/microsoft/TypeScript/issues/38238
+>(o: O, p: P, ...args: Parameters<O[P]>): ReturnType<O[P]> | undefined {
+>>>>>>> Ignore some errors
   assert(o);
   const method = o[p];
   if (!method) {
     return undefined;
   }
+<<<<<<< HEAD
   return call(method, o, args);
+=======
+  // @ts-ignore see: https://github.com/microsoft/TypeScript/issues/38238
+  return method.call(o, ...args);
+>>>>>>> Ignore some errors
 }
 
 function isCallable(value: unknown): value is (...args: any) => any {

--- a/cli/js/web/streams/internals.ts
+++ b/cli/js/web/streams/internals.ts
@@ -232,7 +232,6 @@ export function initializeReadableStream<R>(
   stream[sym.disturbed] = false;
 }
 
-<<<<<<< HEAD
 export function initializeTransformStream<I, O>(
   stream: TransformStreamImpl<I, O>,
   startPromise: Promise<void>,
@@ -295,24 +294,12 @@ export function invokeOrNoop<O extends Record<string, any>, P extends keyof O>(
   p: P,
   ...args: Parameters<O[P]>
 ): ReturnType<O[P]> | undefined {
-=======
-function invokeOrNoop<
-  O extends any,
-  P extends keyof O
-  // @ts-ignore see: https://github.com/microsoft/TypeScript/issues/38238
->(o: O, p: P, ...args: Parameters<O[P]>): ReturnType<O[P]> | undefined {
->>>>>>> Ignore some errors
   assert(o);
   const method = o[p];
   if (!method) {
     return undefined;
   }
-<<<<<<< HEAD
   return call(method, o, args);
-=======
-  // @ts-ignore see: https://github.com/microsoft/TypeScript/issues/38238
-  return method.call(o, ...args);
->>>>>>> Ignore some errors
 }
 
 function isCallable(value: unknown): value is (...args: any) => any {

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -305,6 +305,8 @@ pub fn get_asset(name: &str) -> Option<&'static str> {
     "lib.esnext.asynciterable.d.ts" => inc!("lib.esnext.asynciterable.d.ts"),
     "lib.esnext.bigint.d.ts" => inc!("lib.esnext.bigint.d.ts"),
     "lib.esnext.intl.d.ts" => inc!("lib.esnext.intl.d.ts"),
+    "lib.esnext.promise.d.ts" => inc!("lib.esnext.promise.d.ts"),
+    "lib.esnext.string.d.ts" => inc!("lib.esnext.string.d.ts"),
     "lib.esnext.symbol.d.ts" => inc!("lib.esnext.symbol.d.ts"),
     "lib.scripthost.d.ts" => inc!("lib.scripthost.d.ts"),
     "lib.webworker.d.ts" => inc!("lib.webworker.d.ts"),

--- a/std/fs/_util.ts
+++ b/std/fs/_util.ts
@@ -17,13 +17,10 @@ export function isSubdir(
   const srcArray = src.split(sep);
   const destArray = dest.split(sep);
   // see: https://github.com/Microsoft/TypeScript/issues/30821
-  return srcArray.reduce(
-    // @ts-ignore
-    (acc: true, current: string, i: number): boolean => {
-      return acc && destArray[i] === current;
-    },
-    true
-  );
+  // @ts-ignore
+  return srcArray.reduce((acc: true, current: string, i: number): boolean => {
+    return acc && destArray[i] === current;
+  }, true);
 }
 
 export type PathType = "file" | "dir" | "symlink";


### PR DESCRIPTION
Preliminary WIP PR for updating to TypeScript 3.9.  TypeScript found one bit of redundant code:

```diff
-    const remote = { hostname: "127.0.0.1", transport: "udp", ...addr };
+    const remote = { hostname: "127.0.0.1", ...addr };
```

The transport property was always getting overwritten because `addr` contains a `transport`.