### PR TITLE
inspector: proper error message on port collision

### DIFF
--- a/cli/inspector.rs
+++ b/cli/inspector.rs
@@ -283,7 +283,12 @@ async fn server(address: SocketAddrV4, mut server_msg_rx: ServerMsgRx) {
   });
 
   let routes = websocket.or(version).or(json_list);
-  let web_handler = warp::serve(routes).bind(address);
+  let (_, web_handler) = warp::serve(routes)
+    .try_bind_ephemeral(address)
+    .unwrap_or_else(|e| {
+      eprintln!("Cannot start inspector server: {}", e);
+      std::process::exit(1);
+    });
 
   future::join(msg_handler, web_handler).await;
 }


### PR DESCRIPTION
Minimal fix to avoid panicking.

Node allows multiple sessions on different ports, and it is useful under certain scenarios. I don't think a global mutex for single inspector session is the right way to go.

Besides 9229, it seems to me that 9222 is also a common port to use and appears by default. You can also add new ports for Chrome inspector detection.

cc @ry