### PR TITLE
feat: Added colors to doc output

### DIFF
--- a/cli/colors.rs
+++ b/cli/colors.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use std::env;
 use std::fmt;
 use std::io::Write;
-use termcolor::Color::{Ansi256, Black, Red, White};
+use termcolor::Color::{Ansi256, Black, Magenta, Red, White};
 use termcolor::{Ansi, ColorSpec, WriteColor};
 
 #[cfg(windows)]
@@ -85,6 +85,12 @@ pub fn red(s: String) -> impl fmt::Display {
 pub fn green(s: String) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(10)));
+  style(&s, style_spec)
+}
+
+pub fn magenta(s: String) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Magenta));
   style(&s, style_spec)
 }
 

--- a/cli/doc/tests.rs
+++ b/cli/doc/tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use super::DocParser;
+use crate::colors;
 use serde_json;
 use serde_json::json;
 
@@ -61,7 +62,10 @@ export function foo(a: string, b: number): void {
   let actual = serde_json::to_value(entry).unwrap();
   assert_eq!(actual, expected_json);
 
-  assert!(super::printer::format(entries).contains("Hello there"));
+  assert!(
+    colors::strip_ansi_codes(super::printer::format(entries).as_str())
+      .contains("Hello there")
+  );
 }
 
 #[test]
@@ -90,7 +94,10 @@ fn export_const() {
   let actual = serde_json::to_value(entry).unwrap();
   assert_eq!(actual, expected_json);
 
-  assert!(super::printer::format(entries).contains("Something about fizzBuzz"));
+  assert!(
+    colors::strip_ansi_codes(super::printer::format(entries).as_str())
+      .contains("Something about fizzBuzz")
+  );
 }
 
 #[test]
@@ -299,7 +306,10 @@ export class Foobar extends Fizz implements Buzz {
   let actual = serde_json::to_value(entry).unwrap();
   assert_eq!(actual, expected_json);
 
-  assert!(super::printer::format(entries).contains("class Foobar"));
+  assert!(
+    colors::strip_ansi_codes(super::printer::format(entries).as_str())
+      .contains("class Foobar")
+  );
 }
 
 #[test]
@@ -381,7 +391,10 @@ export interface Reader {
   let actual = serde_json::to_value(entry).unwrap();
   assert_eq!(actual, expected_json);
 
-  assert!(super::printer::format(entries).contains("interface Reader"));
+  assert!(
+    colors::strip_ansi_codes(super::printer::format(entries).as_str())
+      .contains("interface Reader")
+  );
 }
 
 #[test]
@@ -424,7 +437,10 @@ export type NumberArray = Array<number>;
   let actual = serde_json::to_value(entry).unwrap();
   assert_eq!(actual, expected_json);
 
-  assert!(super::printer::format(entries).contains("Array holding numbers"));
+  assert!(
+    colors::strip_ansi_codes(super::printer::format(entries).as_str())
+      .contains("Array holding numbers")
+  );
 }
 
 #[test]
@@ -470,9 +486,14 @@ export enum Hello {
   let actual = serde_json::to_value(entry).unwrap();
   assert_eq!(actual, expected_json);
 
-  assert!(super::printer::format(entries.clone())
-    .contains("Some enum for good measure"));
-  assert!(super::printer::format(entries).contains("enum Hello"));
+  assert!(colors::strip_ansi_codes(
+    super::printer::format(entries.clone()).as_str()
+  )
+  .contains("Some enum for good measure"));
+  assert!(
+    colors::strip_ansi_codes(super::printer::format(entries).as_str())
+      .contains("enum Hello")
+  );
 }
 
 #[test]
@@ -564,5 +585,8 @@ export namespace RootNs {
   });
   let actual = serde_json::to_value(entry).unwrap();
   assert_eq!(actual, expected_json);
-  assert!(super::printer::format(entries).contains("namespace RootNs"));
+  assert!(
+    colors::strip_ansi_codes(super::printer::format(entries).as_str())
+      .contains("namespace RootNs")
+  );
 }


### PR DESCRIPTION
Adds basic coloring and highlighting in `deno doc`.

Dark background:
![image](https://user-images.githubusercontent.com/7829205/77832952-f4a8d000-7139-11ea-814e-0bcdd1dfd48b.png)

Light background:
![image](https://user-images.githubusercontent.com/7829205/77832958-07230980-713a-11ea-932a-3f2efc555821.png)
