### PR TITLE
fix(std/encoding/csv): enable skipped tests

### DIFF
--- a/std/encoding/csv.ts
+++ b/std/encoding/csv.ts
@@ -97,8 +97,6 @@ async function readRecord(
       let field = line;
       if (i >= 0) {
         field = field.substring(0, i);
-      } else {
-        field = field.substring(0, field.length - lengthNL(field));
       }
       // Check to make sure a quote does not appear in field.
       if (!opt.lazyQuotes) {
@@ -133,7 +131,7 @@ async function readRecord(
             line = line.substring(commaLen);
             fieldIndexes.push(recordBuffer.length);
             continue parseField;
-          } else if (lengthNL(line) === line.length) {
+          } else if (0 === line.length) {
             // `"\n` sequence (end of line).
             fieldIndexes.push(recordBuffer.length);
             break parseField;
@@ -209,13 +207,6 @@ async function readLine(tp: TextProtoReader): Promise<string | Deno.EOF> {
   }
 
   return line;
-}
-
-function lengthNL(s: string): number {
-  if (s.length > 0 && s[s.length - 1] === "\n") {
-    return 1;
-  }
-  return 0;
 }
 
 export async function readMatrix(

--- a/std/encoding/csv.ts
+++ b/std/encoding/csv.ts
@@ -221,7 +221,7 @@ export async function readMatrix(
   opt: ReadOptions = {
     comma: ",",
     trimLeadingSpace: false,
-    lazyQuotes: false
+    lazyQuotes: false,
   }
 ): Promise<string[][]> {
   const result: string[][] = [];
@@ -298,7 +298,7 @@ export interface ParseOptions extends ReadOptions {
 export async function parse(
   input: string | BufReader,
   opt: ParseOptions = {
-    header: false
+    header: false,
   }
 ): Promise<unknown[]> {
   let r: string[][];
@@ -318,7 +318,7 @@ export async function parse(
         headers = h.map(
           (e): HeaderOptions => {
             return {
-              name: e
+              name: e,
             };
           }
         );
@@ -329,7 +329,7 @@ export async function parse(
       headers = head.map(
         (e): HeaderOptions => {
           return {
-            name: e
+            name: e,
           };
         }
       );

--- a/std/encoding/csv.ts
+++ b/std/encoding/csv.ts
@@ -83,7 +83,7 @@ async function read(
   const quoteLen = quote.length;
   const commaLen = opt.comma.length;
   let recordBuffer = "";
-  let fieldIndexes = [] as number[];
+  const fieldIndexes = [] as number[];
   parseField: for (;;) {
     if (opt.trimLeadingSpace) {
       line = line.trimLeft();
@@ -100,7 +100,7 @@ async function read(
       }
       // Check to make sure a quote does not appear in field.
       if (!opt.lazyQuotes) {
-        let j = field.indexOf(quote);
+        const j = field.indexOf(quote);
         if (j >= 0) {
           quoteError = ErrBareQuote;
           break parseField;
@@ -117,7 +117,7 @@ async function read(
       // Quoted string field
       line = line.substring(quoteLen);
       for (;;) {
-        let i = line.indexOf(quote);
+        const i = line.indexOf(quote);
         if (i >= 0) {
           // Hit next quote.
           recordBuffer += line.substring(0, i);
@@ -172,7 +172,7 @@ async function read(
   if (quoteError) {
     throw new ParseError(Startline, lineIndex, quoteError);
   }
-  let result = [] as string[];
+  const result = [] as string[];
   let preIdx = 0;
   for (const i of fieldIndexes) {
     result.push(recordBuffer.slice(preIdx, i));

--- a/std/encoding/csv.ts
+++ b/std/encoding/csv.ts
@@ -1,5 +1,7 @@
 // Ported from Go:
 // https://github.com/golang/go/blob/go1.12.5/src/encoding/csv/
+// Copyright 2011 The Go Authors. All rights reserved. BSD license.
+// https://github.com/golang/go/blob/master/LICENSE
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { BufReader } from "../io/bufio.ts";

--- a/std/encoding/csv.ts
+++ b/std/encoding/csv.ts
@@ -58,7 +58,7 @@ function chkOptions(opt: ReadOptions): void {
   }
 }
 
-async function read(
+async function readRecord(
   Startline: number,
   reader: BufReader,
   opt: ReadOptions = { comma: ",", trimLeadingSpace: false }
@@ -232,7 +232,7 @@ export async function readMatrix(
   chkOptions(opt);
 
   for (;;) {
-    const r = await read(lineIndex, reader, opt);
+    const r = await readRecord(lineIndex, reader, opt);
     if (r === Deno.EOF) break;
     lineResult = r;
     lineIndex++;

--- a/std/encoding/csv.ts
+++ b/std/encoding/csv.ts
@@ -11,10 +11,10 @@ import { assert } from "../testing/asserts.ts";
 
 const INVALID_RUNE = ["\r", "\n", '"'];
 
-export const ErrBareQuote = 'bare " in non-quoted-field';
-export const ErrQuote = 'extraneous or missing " in quoted-field';
-export const ErrInvalidDelim = "Invalid Delimiter";
-export const ErrFieldCount = "wrong number of fields";
+export const ERR_BARE_QUOTE = 'bare " in non-quoted-field';
+export const ERR_QUOTE = 'extraneous or missing " in quoted-field';
+export const ERR_INVALID_DELIM = "Invalid Delimiter";
+export const ERR_FIELD_COUNT = "wrong number of fields";
 
 export class ParseError extends Error {
   StartLine: number;
@@ -56,7 +56,7 @@ function chkOptions(opt: ReadOptions): void {
     (typeof opt.comment === "string" && INVALID_RUNE.includes(opt.comment)) ||
     opt.comma === opt.comment
   ) {
-    throw new Error(ErrInvalidDelim);
+    throw new Error(ERR_INVALID_DELIM);
   }
 }
 
@@ -102,7 +102,7 @@ async function readRecord(
       if (!opt.lazyQuotes) {
         const j = field.indexOf(quote);
         if (j >= 0) {
-          quoteError = ErrBareQuote;
+          quoteError = ERR_BARE_QUOTE;
           break parseField;
         }
       }
@@ -140,7 +140,7 @@ async function readRecord(
             recordBuffer += quote;
           } else {
             // `"*` sequence (invalid non-escaped quote).
-            quoteError = ErrQuote;
+            quoteError = ERR_QUOTE;
             break parseField;
           }
         } else if (line.length > 0 || !(await isEOF(tp))) {
@@ -149,7 +149,7 @@ async function readRecord(
           const r = await readLine(tp);
           if (r === Deno.EOF) {
             if (!opt.lazyQuotes) {
-              quoteError = ErrQuote;
+              quoteError = ERR_QUOTE;
               break parseField;
             }
             fieldIndexes.push(recordBuffer.length);
@@ -160,7 +160,7 @@ async function readRecord(
         } else {
           // Abrupt end of file (EOF on error).
           if (!opt.lazyQuotes) {
-            quoteError = ErrQuote;
+            quoteError = ERR_QUOTE;
             break parseField;
           }
           fieldIndexes.push(recordBuffer.length);
@@ -244,7 +244,7 @@ export async function readMatrix(
 
     if (lineResult.length > 0) {
       if (_nbFields && _nbFields !== lineResult.length) {
-        throw new ParseError(lineIndex, lineIndex, ErrFieldCount);
+        throw new ParseError(lineIndex, lineIndex, ERR_FIELD_COUNT);
       }
       result.push(lineResult);
     }

--- a/std/encoding/csv_test.ts
+++ b/std/encoding/csv_test.ts
@@ -7,7 +7,7 @@ import {
   ErrBareQuote,
   ErrQuote,
   ErrInvalidDelim,
-  ErrFieldCount
+  ErrFieldCount,
 } from "./csv.ts";
 import { StringReader } from "../io/readers.ts";
 import { BufReader } from "../io/bufio.ts";
@@ -16,20 +16,20 @@ const testCases = [
   {
     Name: "Simple",
     Input: "a,b,c\n",
-    Output: [["a", "b", "c"]]
+    Output: [["a", "b", "c"]],
   },
   {
     Name: "CRLF",
     Input: "a,b\r\nc,d\r\n",
     Output: [
       ["a", "b"],
-      ["c", "d"]
-    ]
+      ["c", "d"],
+    ],
   },
   {
     Name: "BareCR",
     Input: "a,b\rc,d\r\n",
-    Output: [["a", "b\rc", "d"]]
+    Output: [["a", "b\rc", "d"]],
   },
   {
     Name: "RFC4180test",
@@ -43,19 +43,19 @@ zzz,yyy,xxx`,
       ["#field1", "field2", "field3"],
       ["aaa", "bbb", "ccc"],
       ["a,a", `bbb`, "ccc"],
-      ["zzz", "yyy", "xxx"]
-    ]
+      ["zzz", "yyy", "xxx"],
+    ],
   },
   {
     Name: "NoEOLTest",
     Input: "a,b,c",
-    Output: [["a", "b", "c"]]
+    Output: [["a", "b", "c"]],
   },
   {
     Name: "Semicolon",
     Input: "a;b;c\n",
     Output: [["a", "b", "c"]],
-    Comma: ";"
+    Comma: ";",
   },
   {
     Name: "MultiLine",
@@ -63,103 +63,103 @@ zzz,yyy,xxx`,
 line","one line","three
 line
 field"`,
-    Output: [["two\nline", "one line", "three\nline\nfield"]]
+    Output: [["two\nline", "one line", "three\nline\nfield"]],
   },
   {
     Name: "BlankLine",
     Input: "a,b,c\n\nd,e,f\n\n",
     Output: [
       ["a", "b", "c"],
-      ["d", "e", "f"]
-    ]
+      ["d", "e", "f"],
+    ],
   },
   {
     Name: "BlankLineFieldCount",
     Input: "a,b,c\n\nd,e,f\n\n",
     Output: [
       ["a", "b", "c"],
-      ["d", "e", "f"]
+      ["d", "e", "f"],
     ],
     UseFieldsPerRecord: true,
-    FieldsPerRecord: 0
+    FieldsPerRecord: 0,
   },
   {
     Name: "TrimSpace",
     Input: " a,  b,   c\n",
     Output: [["a", "b", "c"]],
-    TrimLeadingSpace: true
+    TrimLeadingSpace: true,
   },
   {
     Name: "LeadingSpace",
     Input: " a,  b,   c\n",
-    Output: [[" a", "  b", "   c"]]
+    Output: [[" a", "  b", "   c"]],
   },
   {
     Name: "Comment",
     Input: "#1,2,3\na,b,c\n#comment",
     Output: [["a", "b", "c"]],
-    Comment: "#"
+    Comment: "#",
   },
   {
     Name: "NoComment",
     Input: "#1,2,3\na,b,c",
     Output: [
       ["#1", "2", "3"],
-      ["a", "b", "c"]
-    ]
+      ["a", "b", "c"],
+    ],
   },
   {
     Name: "LazyQuotes",
     Input: `a "word","1"2",a","b`,
     Output: [[`a "word"`, `1"2`, `a"`, `b`]],
-    LazyQuotes: true
+    LazyQuotes: true,
   },
   {
     Name: "BareQuotes",
     Input: `a "word","1"2",a"`,
     Output: [[`a "word"`, `1"2`, `a"`]],
-    LazyQuotes: true
+    LazyQuotes: true,
   },
   {
     Name: "BareDoubleQuotes",
     Input: `a""b,c`,
     Output: [[`a""b`, `c`]],
-    LazyQuotes: true
+    LazyQuotes: true,
   },
   {
     Name: "BadDoubleQuotes",
     Input: `a""b,c`,
-    Error: ErrBareQuote
+    Error: ErrBareQuote,
     // Error: &ParseError{StartLine: 1, Line: 1, Column: 1, Err: ErrBareQuote},
   },
   {
     Name: "TrimQuote",
     Input: ` "a"," b",c`,
     Output: [["a", " b", "c"]],
-    TrimLeadingSpace: true
+    TrimLeadingSpace: true,
   },
   {
     Name: "BadBareQuote",
     Input: `a "word","b"`,
-    Error: ErrBareQuote
+    Error: ErrBareQuote,
     // &ParseError{StartLine: 1, Line: 1, Column: 2, Err: ErrBareQuote}
   },
   {
     Name: "BadTrailingQuote",
     Input: `"a word",b"`,
-    Error: ErrBareQuote
+    Error: ErrBareQuote,
   },
   {
     Name: "ExtraneousQuote",
     Input: `"a "word","b"`,
-    Error: ErrQuote
+    Error: ErrQuote,
   },
   {
     Name: "BadFieldCount",
     Input: "a,b,c\nd,e",
     Error: ErrFieldCount,
     UseFieldsPerRecord: true,
-    FieldsPerRecord: 0
+    FieldsPerRecord: 0,
   },
   {
     Name: "BadFieldCount1",
@@ -167,37 +167,37 @@ field"`,
     // Error: &ParseError{StartLine: 1, Line: 1, Err: ErrFieldCount},
     UseFieldsPerRecord: true,
     FieldsPerRecord: 2,
-    Error: ErrFieldCount
+    Error: ErrFieldCount,
   },
   {
     Name: "FieldCount",
     Input: "a,b,c\nd,e",
     Output: [
       ["a", "b", "c"],
-      ["d", "e"]
-    ]
+      ["d", "e"],
+    ],
   },
   {
     Name: "TrailingCommaEOF",
     Input: "a,b,c,",
-    Output: [["a", "b", "c", ""]]
+    Output: [["a", "b", "c", ""]],
   },
   {
     Name: "TrailingCommaEOL",
     Input: "a,b,c,\n",
-    Output: [["a", "b", "c", ""]]
+    Output: [["a", "b", "c", ""]],
   },
   {
     Name: "TrailingCommaSpaceEOF",
     Input: "a,b,c, ",
     Output: [["a", "b", "c", ""]],
-    TrimLeadingSpace: true
+    TrimLeadingSpace: true,
   },
   {
     Name: "TrailingCommaSpaceEOL",
     Input: "a,b,c, \n",
     Output: [["a", "b", "c", ""]],
-    TrimLeadingSpace: true
+    TrimLeadingSpace: true,
   },
   {
     Name: "TrailingCommaLine3",
@@ -205,14 +205,14 @@ field"`,
     Output: [
       ["a", "b", "c"],
       ["d", "e", "f"],
-      ["g", "hi", ""]
+      ["g", "hi", ""],
     ],
-    TrimLeadingSpace: true
+    TrimLeadingSpace: true,
   },
   {
     Name: "NotTrailingComma3",
     Input: "a,b,c, \n",
-    Output: [["a", "b", "c", " "]]
+    Output: [["a", "b", "c", " "]],
   },
   {
     Name: "CommaFieldTest",
@@ -237,89 +237,89 @@ x,,,
       ["x", "y", "z", ""],
       ["x", "y", "", ""],
       ["x", "", "", ""],
-      ["", "", "", ""]
-    ]
+      ["", "", "", ""],
+    ],
   },
   {
     Name: "TrailingCommaIneffective1",
     Input: "a,b,\nc,d,e",
     Output: [
       ["a", "b", ""],
-      ["c", "d", "e"]
+      ["c", "d", "e"],
     ],
-    TrimLeadingSpace: true
+    TrimLeadingSpace: true,
   },
   {
     Name: "ReadAllReuseRecord",
     Input: "a,b\nc,d",
     Output: [
       ["a", "b"],
-      ["c", "d"]
+      ["c", "d"],
     ],
-    ReuseRecord: true
+    ReuseRecord: true,
   },
   {
     Name: "StartLine1", // Issue 19019
     Input: 'a,"b\nc"d,e',
-    Error: ErrQuote
+    Error: ErrQuote,
     // Error: &ParseError{StartLine: 1, Line: 2, Column: 1, Err: ErrQuote},
   },
   {
     Name: "StartLine2",
     Input: 'a,b\n"d\n\n,e',
-    Error: ErrQuote
+    Error: ErrQuote,
     // Error: &ParseError{StartLine: 2, Line: 5, Column: 0, Err: ErrQuote},
   },
   {
     Name: "CRLFInQuotedField", // Issue 21201
     Input: 'A,"Hello\r\nHi",B\r\n',
-    Output: [["A", "Hello\nHi", "B"]]
+    Output: [["A", "Hello\nHi", "B"]],
   },
   {
     Name: "BinaryBlobField", // Issue 19410
     Input: "x09\x41\xb4\x1c,aktau",
-    Output: [["x09A\xb4\x1c", "aktau"]]
+    Output: [["x09A\xb4\x1c", "aktau"]],
   },
   {
     Name: "TrailingCR",
     Input: "field1,field2\r",
-    Output: [["field1", "field2"]]
+    Output: [["field1", "field2"]],
   },
   {
     Name: "QuotedTrailingCR",
     Input: '"field"\r',
-    Output: [["field"]]
+    Output: [["field"]],
   },
   {
     Name: "QuotedTrailingCRCR",
     Input: '"field"\r\r',
-    Error: ErrQuote
+    Error: ErrQuote,
     // Error: &ParseError{StartLine: 1, Line: 1, Column: 6, Err: ErrQuote},
   },
   {
     Name: "FieldCR",
     Input: "field\rfield\r",
-    Output: [["field\rfield"]]
+    Output: [["field\rfield"]],
   },
   {
     Name: "FieldCRCR",
     Input: "field\r\rfield\r\r",
-    Output: [["field\r\rfield\r"]]
+    Output: [["field\r\rfield\r"]],
   },
   {
     Name: "FieldCRCRLF",
     Input: "field\r\r\nfield\r\r\n",
-    Output: [["field\r"], ["field\r"]]
+    Output: [["field\r"], ["field\r"]],
   },
   {
     Name: "FieldCRCRLFCR",
     Input: "field\r\r\n\rfield\r\r\n\r",
-    Output: [["field\r"], ["\rfield\r"]]
+    Output: [["field\r"], ["\rfield\r"]],
   },
   {
     Name: "FieldCRCRLFCRCR",
     Input: "field\r\r\n\r\rfield\r\r\n\r\r",
-    Output: [["field\r"], ["\r\rfield\r"], ["\r"]]
+    Output: [["field\r"], ["\r\rfield\r"], ["\r"]],
   },
   {
     Name: "MultiFieldCRCRLFCRCR",
@@ -327,8 +327,8 @@ x,,,
     Output: [
       ["field1", "field2\r"],
       ["\r\rfield1", "field2\r"],
-      ["\r\r", ""]
-    ]
+      ["\r\r", ""],
+    ],
   },
   {
     Name: "NonASCIICommaAndComment",
@@ -336,14 +336,14 @@ x,,,
     Output: [["a", "b,c", "d,e"]],
     TrimLeadingSpace: true,
     Comma: "£",
-    Comment: "€"
+    Comment: "€",
   },
   {
     Name: "NonASCIICommaAndCommentWithQuotes",
     Input: 'a€"  b,"€ c\nλ comment\n',
     Output: [["a", "  b,", " c"]],
     Comma: "€",
-    Comment: "λ"
+    Comment: "λ",
   },
   {
     // λ and θ start with the same byte.
@@ -352,23 +352,23 @@ x,,,
     Input: '"abθcd"λefθgh',
     Output: [["abθcd", "efθgh"]],
     Comma: "λ",
-    Comment: "€"
+    Comment: "€",
   },
   {
     Name: "NonASCIICommentConfusion",
     Input: "λ\nλ\nθ\nλ\n",
     Output: [["λ"], ["λ"], ["λ"]],
-    Comment: "θ"
+    Comment: "θ",
   },
   {
     Name: "QuotedFieldMultipleLF",
     Input: '"\n\n\n\n"',
-    Output: [["\n\n\n\n"]]
+    Output: [["\n\n\n\n"]],
   },
   {
     Name: "MultipleCRLF",
     Input: "\r\n\r\n\r\n\r\n",
-    Output: []
+    Output: [],
   },
   /**
    * The implementation may read each line in several chunks if
@@ -381,73 +381,73 @@ x,,,
       "#ignore\n".repeat(10000) + "@".repeat(5000) + "," + "*".repeat(5000),
     Output: [["@".repeat(5000), "*".repeat(5000)]],
     Comment: "#",
-    ignore: true
+    ignore: true,
   },
   {
     Name: "QuoteWithTrailingCRLF",
     Input: '"foo"bar"\r\n',
-    Error: ErrQuote
+    Error: ErrQuote,
     // Error: &ParseError{StartLine: 1, Line: 1, Column: 4, Err: ErrQuote},
   },
   {
     Name: "LazyQuoteWithTrailingCRLF",
     Input: '"foo"bar"\r\n',
     Output: [[`foo"bar`]],
-    LazyQuotes: true
+    LazyQuotes: true,
   },
   {
     Name: "DoubleQuoteWithTrailingCRLF",
     Input: '"foo""bar"\r\n',
-    Output: [[`foo"bar`]]
+    Output: [[`foo"bar`]],
   },
   {
     Name: "EvenQuotes",
     Input: `""""""""`,
-    Output: [[`"""`]]
+    Output: [[`"""`]],
   },
   {
     Name: "OddQuotes",
     Input: `"""""""`,
-    Error: ErrQuote
+    Error: ErrQuote,
     // Error:" &ParseError{StartLine: 1, Line: 1, Column: 7, Err: ErrQuote}",
   },
   {
     Name: "LazyOddQuotes",
     Input: `"""""""`,
     Output: [[`"""`]],
-    LazyQuotes: true
+    LazyQuotes: true,
   },
   {
     Name: "BadComma1",
     Comma: "\n",
-    Error: ErrInvalidDelim
+    Error: ErrInvalidDelim,
   },
   {
     Name: "BadComma2",
     Comma: "\r",
-    Error: ErrInvalidDelim
+    Error: ErrInvalidDelim,
   },
   {
     Name: "BadComma3",
     Comma: '"',
-    Error: ErrInvalidDelim
+    Error: ErrInvalidDelim,
   },
   {
     Name: "BadComment1",
     Comment: "\n",
-    Error: ErrInvalidDelim
+    Error: ErrInvalidDelim,
   },
   {
     Name: "BadComment2",
     Comment: "\r",
-    Error: ErrInvalidDelim
+    Error: ErrInvalidDelim,
   },
   {
     Name: "BadCommaComment",
     Comma: "X",
     Comment: "X",
-    Error: ErrInvalidDelim
-  }
+    Error: ErrInvalidDelim,
+  },
 ];
 for (const t of testCases) {
   Deno.test({
@@ -485,7 +485,7 @@ for (const t of testCases) {
               comment: comment,
               trimLeadingSpace: trim,
               fieldsPerRecord: fieldsPerRec,
-              lazyQuotes: lazyquote
+              lazyQuotes: lazyquote,
             }
           );
         } catch (e) {
@@ -501,13 +501,13 @@ for (const t of testCases) {
             comment: comment,
             trimLeadingSpace: trim,
             fieldsPerRecord: fieldsPerRec,
-            lazyQuotes: lazyquote
+            lazyQuotes: lazyquote,
           }
         );
         const expected = t.Output;
         assertEquals(actual, expected);
       }
-    }
+    },
   });
 }
 
@@ -516,13 +516,13 @@ const parseTestCases = [
     name: "simple",
     in: "a,b,c",
     header: false,
-    result: [["a", "b", "c"]]
+    result: [["a", "b", "c"]],
   },
   {
     name: "simple Bufreader",
     in: new BufReader(new StringReader("a,b,c")),
     header: false,
-    result: [["a", "b", "c"]]
+    result: [["a", "b", "c"]],
   },
   {
     name: "multiline",
@@ -530,14 +530,14 @@ const parseTestCases = [
     header: false,
     result: [
       ["a", "b", "c"],
-      ["e", "f", "g"]
-    ]
+      ["e", "f", "g"],
+    ],
   },
   {
     name: "header mapping boolean",
     in: "a,b,c\ne,f,g\n",
     header: true,
-    result: [{ a: "e", b: "f", c: "g" }]
+    result: [{ a: "e", b: "f", c: "g" }],
   },
   {
     name: "header mapping array",
@@ -545,8 +545,8 @@ const parseTestCases = [
     header: ["this", "is", "sparta"],
     result: [
       { this: "a", is: "b", sparta: "c" },
-      { this: "e", is: "f", sparta: "g" }
-    ]
+      { this: "e", is: "f", sparta: "g" },
+    ],
   },
   {
     name: "header mapping object",
@@ -554,8 +554,8 @@ const parseTestCases = [
     header: [{ name: "this" }, { name: "is" }, { name: "sparta" }],
     result: [
       { this: "a", is: "b", sparta: "c" },
-      { this: "e", is: "f", sparta: "g" }
-    ]
+      { this: "e", is: "f", sparta: "g" },
+    ],
   },
   {
     name: "header mapping parse entry",
@@ -565,25 +565,25 @@ const parseTestCases = [
         name: "this",
         parse: (e: string): string => {
           return `b${e}$$`;
-        }
+        },
       },
       {
         name: "is",
         parse: (e: string): number => {
           return e.length;
-        }
+        },
       },
       {
         name: "sparta",
         parse: (e: string): unknown => {
           return { bim: `boom-${e}` };
-        }
-      }
+        },
+      },
     ],
     result: [
       { this: "ba$$", is: 1, sparta: { bim: `boom-c` } },
-      { this: "be$$", is: 1, sparta: { bim: `boom-g` } }
-    ]
+      { this: "be$$", is: 1, sparta: { bim: `boom-g` } },
+    ],
   },
   {
     name: "multiline parse",
@@ -594,8 +594,8 @@ const parseTestCases = [
     header: false,
     result: [
       { super: "a", street: "b", fighter: "c" },
-      { super: "e", street: "f", fighter: "g" }
-    ]
+      { super: "e", street: "f", fighter: "g" },
+    ],
   },
   {
     name: "header mapping object parseline",
@@ -606,9 +606,9 @@ const parseTestCases = [
     },
     result: [
       { super: "a", street: "b", fighter: "c" },
-      { super: "e", street: "f", fighter: "g" }
-    ]
-  }
+      { super: "e", street: "f", fighter: "g" },
+    ],
+  },
 ];
 
 for (const testCase of parseTestCases) {
@@ -617,14 +617,14 @@ for (const testCase of parseTestCases) {
     async fn(): Promise<void> {
       const r = await parse(testCase.in, {
         header: testCase.header,
-        parse: testCase.parse as (input: unknown) => unknown
+        parse: testCase.parse as (input: unknown) => unknown,
       });
       assertEquals(r, testCase.result);
-    }
+    },
   });
 }
 
-import { TextProtoReader } from "../textproto/mod.ts"
+import { TextProtoReader } from "../textproto/mod.ts";
 
 Deno.test(async function readHugeLine() {
   const input = "@".repeat(5000) + "," + "*".repeat(5000);

--- a/std/encoding/csv_test.ts
+++ b/std/encoding/csv_test.ts
@@ -1,33 +1,35 @@
 // Test ported from Golang
 // https://github.com/golang/go/blob/2cc15b1/src/encoding/csv/reader_test.go
 import { assertEquals, assert } from "../testing/asserts.ts";
-import { readMatrix, parse } from "./csv.ts";
+import {
+  readMatrix,
+  parse,
+  ErrBareQuote,
+  ErrQuote,
+  ErrInvalidDelim,
+  ErrFieldCount
+} from "./csv.ts";
 import { StringReader } from "../io/readers.ts";
 import { BufReader } from "../io/bufio.ts";
 
-const ErrInvalidDelim = "Invalid Delimiter";
-const ErrFieldCount = "wrong number of fields";
-const ErrBareQuote = 'bare " in non-quoted-field';
-
-// TODO(zekth): Activate remaining tests
 const testCases = [
   {
     Name: "Simple",
     Input: "a,b,c\n",
-    Output: [["a", "b", "c"]],
+    Output: [["a", "b", "c"]]
   },
   {
     Name: "CRLF",
     Input: "a,b\r\nc,d\r\n",
     Output: [
       ["a", "b"],
-      ["c", "d"],
-    ],
+      ["c", "d"]
+    ]
   },
   {
     Name: "BareCR",
     Input: "a,b\rc,d\r\n",
-    Output: [["a", "b\rc", "d"]],
+    Output: [["a", "b\rc", "d"]]
   },
   {
     Name: "RFC4180test",
@@ -41,20 +43,19 @@ zzz,yyy,xxx`,
       ["#field1", "field2", "field3"],
       ["aaa", "bbb", "ccc"],
       ["a,a", `bbb`, "ccc"],
-      ["zzz", "yyy", "xxx"],
-    ],
-    ignore: true,
+      ["zzz", "yyy", "xxx"]
+    ]
   },
   {
     Name: "NoEOLTest",
     Input: "a,b,c",
-    Output: [["a", "b", "c"]],
+    Output: [["a", "b", "c"]]
   },
   {
     Name: "Semicolon",
     Input: "a;b;c\n",
     Output: [["a", "b", "c"]],
-    Comma: ";",
+    Comma: ";"
   },
   {
     Name: "MultiLine",
@@ -62,104 +63,103 @@ zzz,yyy,xxx`,
 line","one line","three
 line
 field"`,
-    Output: [["two\nline"], ["one line"], ["three\nline\nfield"]],
-    ignore: true,
+    Output: [["two\nline", "one line", "three\nline\nfield"]]
   },
   {
     Name: "BlankLine",
     Input: "a,b,c\n\nd,e,f\n\n",
     Output: [
       ["a", "b", "c"],
-      ["d", "e", "f"],
-    ],
+      ["d", "e", "f"]
+    ]
   },
   {
     Name: "BlankLineFieldCount",
     Input: "a,b,c\n\nd,e,f\n\n",
     Output: [
       ["a", "b", "c"],
-      ["d", "e", "f"],
+      ["d", "e", "f"]
     ],
     UseFieldsPerRecord: true,
-    FieldsPerRecord: 0,
+    FieldsPerRecord: 0
   },
   {
     Name: "TrimSpace",
     Input: " a,  b,   c\n",
     Output: [["a", "b", "c"]],
-    TrimLeadingSpace: true,
+    TrimLeadingSpace: true
   },
   {
     Name: "LeadingSpace",
     Input: " a,  b,   c\n",
-    Output: [[" a", "  b", "   c"]],
+    Output: [[" a", "  b", "   c"]]
   },
   {
     Name: "Comment",
     Input: "#1,2,3\na,b,c\n#comment",
     Output: [["a", "b", "c"]],
-    Comment: "#",
+    Comment: "#"
   },
   {
     Name: "NoComment",
     Input: "#1,2,3\na,b,c",
     Output: [
       ["#1", "2", "3"],
-      ["a", "b", "c"],
-    ],
+      ["a", "b", "c"]
+    ]
   },
   {
     Name: "LazyQuotes",
     Input: `a "word","1"2",a","b`,
     Output: [[`a "word"`, `1"2`, `a"`, `b`]],
-    LazyQuotes: true,
+    LazyQuotes: true
   },
   {
     Name: "BareQuotes",
     Input: `a "word","1"2",a"`,
     Output: [[`a "word"`, `1"2`, `a"`]],
-    LazyQuotes: true,
+    LazyQuotes: true
   },
   {
     Name: "BareDoubleQuotes",
     Input: `a""b,c`,
     Output: [[`a""b`, `c`]],
-    LazyQuotes: true,
+    LazyQuotes: true
   },
   {
     Name: "BadDoubleQuotes",
     Input: `a""b,c`,
-    Error: ErrBareQuote,
+    Error: ErrBareQuote
     // Error: &ParseError{StartLine: 1, Line: 1, Column: 1, Err: ErrBareQuote},
   },
   {
     Name: "TrimQuote",
     Input: ` "a"," b",c`,
     Output: [["a", " b", "c"]],
-    TrimLeadingSpace: true,
+    TrimLeadingSpace: true
   },
   {
     Name: "BadBareQuote",
     Input: `a "word","b"`,
-    Error: ErrBareQuote,
+    Error: ErrBareQuote
     // &ParseError{StartLine: 1, Line: 1, Column: 2, Err: ErrBareQuote}
   },
   {
     Name: "BadTrailingQuote",
     Input: `"a word",b"`,
-    Error: ErrBareQuote,
+    Error: ErrBareQuote
   },
   {
     Name: "ExtraneousQuote",
     Input: `"a "word","b"`,
-    Error: ErrBareQuote,
+    Error: ErrQuote
   },
   {
     Name: "BadFieldCount",
     Input: "a,b,c\nd,e",
     Error: ErrFieldCount,
     UseFieldsPerRecord: true,
-    FieldsPerRecord: 0,
+    FieldsPerRecord: 0
   },
   {
     Name: "BadFieldCount1",
@@ -167,37 +167,37 @@ field"`,
     // Error: &ParseError{StartLine: 1, Line: 1, Err: ErrFieldCount},
     UseFieldsPerRecord: true,
     FieldsPerRecord: 2,
-    Error: ErrFieldCount,
+    Error: ErrFieldCount
   },
   {
     Name: "FieldCount",
     Input: "a,b,c\nd,e",
     Output: [
       ["a", "b", "c"],
-      ["d", "e"],
-    ],
+      ["d", "e"]
+    ]
   },
   {
     Name: "TrailingCommaEOF",
     Input: "a,b,c,",
-    Output: [["a", "b", "c", ""]],
+    Output: [["a", "b", "c", ""]]
   },
   {
     Name: "TrailingCommaEOL",
     Input: "a,b,c,\n",
-    Output: [["a", "b", "c", ""]],
+    Output: [["a", "b", "c", ""]]
   },
   {
     Name: "TrailingCommaSpaceEOF",
     Input: "a,b,c, ",
     Output: [["a", "b", "c", ""]],
-    TrimLeadingSpace: true,
+    TrimLeadingSpace: true
   },
   {
     Name: "TrailingCommaSpaceEOL",
     Input: "a,b,c, \n",
     Output: [["a", "b", "c", ""]],
-    TrimLeadingSpace: true,
+    TrimLeadingSpace: true
   },
   {
     Name: "TrailingCommaLine3",
@@ -205,14 +205,14 @@ field"`,
     Output: [
       ["a", "b", "c"],
       ["d", "e", "f"],
-      ["g", "hi", ""],
+      ["g", "hi", ""]
     ],
-    TrimLeadingSpace: true,
+    TrimLeadingSpace: true
   },
   {
     Name: "NotTrailingComma3",
     Input: "a,b,c, \n",
-    Output: [["a", "b", "c", " "]],
+    Output: [["a", "b", "c", " "]]
   },
   {
     Name: "CommaFieldTest",
@@ -237,98 +237,89 @@ x,,,
       ["x", "y", "z", ""],
       ["x", "y", "", ""],
       ["x", "", "", ""],
-      ["", "", "", ""],
-    ],
+      ["", "", "", ""]
+    ]
   },
   {
     Name: "TrailingCommaIneffective1",
     Input: "a,b,\nc,d,e",
     Output: [
       ["a", "b", ""],
-      ["c", "d", "e"],
+      ["c", "d", "e"]
     ],
-    TrimLeadingSpace: true,
+    TrimLeadingSpace: true
   },
   {
     Name: "ReadAllReuseRecord",
     Input: "a,b\nc,d",
     Output: [
       ["a", "b"],
-      ["c", "d"],
+      ["c", "d"]
     ],
-    ReuseRecord: true,
+    ReuseRecord: true
   },
   {
     Name: "StartLine1", // Issue 19019
     Input: 'a,"b\nc"d,e',
-    Error: true,
+    Error: ErrQuote
     // Error: &ParseError{StartLine: 1, Line: 2, Column: 1, Err: ErrQuote},
-    ignore: true,
   },
   {
     Name: "StartLine2",
     Input: 'a,b\n"d\n\n,e',
-    Error: true,
+    Error: ErrQuote
     // Error: &ParseError{StartLine: 2, Line: 5, Column: 0, Err: ErrQuote},
-    ignore: true,
   },
   {
     Name: "CRLFInQuotedField", // Issue 21201
     Input: 'A,"Hello\r\nHi",B\r\n',
-    Output: [["A", "Hello\nHi", "B"]],
-    ignore: true,
+    Output: [["A", "Hello\nHi", "B"]]
   },
   {
     Name: "BinaryBlobField", // Issue 19410
     Input: "x09\x41\xb4\x1c,aktau",
-    Output: [["x09A\xb4\x1c", "aktau"]],
+    Output: [["x09A\xb4\x1c", "aktau"]]
   },
   {
     Name: "TrailingCR",
     Input: "field1,field2\r",
-    Output: [["field1", "field2"]],
-    ignore: true,
+    Output: [["field1", "field2"]]
   },
   {
     Name: "QuotedTrailingCR",
     Input: '"field"\r',
-    Output: [['"field"']],
-    ignore: true,
+    Output: [["field"]]
   },
   {
     Name: "QuotedTrailingCRCR",
     Input: '"field"\r\r',
-    Error: true,
+    Error: ErrQuote
     // Error: &ParseError{StartLine: 1, Line: 1, Column: 6, Err: ErrQuote},
-    ignore: true,
   },
   {
     Name: "FieldCR",
     Input: "field\rfield\r",
-    Output: [["field\rfield"]],
-    ignore: true,
+    Output: [["field\rfield"]]
   },
   {
     Name: "FieldCRCR",
     Input: "field\r\rfield\r\r",
-    Output: [["field\r\rfield\r"]],
-    ignore: true,
+    Output: [["field\r\rfield\r"]]
   },
   {
     Name: "FieldCRCRLF",
     Input: "field\r\r\nfield\r\r\n",
-    Output: [["field\r"], ["field\r"]],
+    Output: [["field\r"], ["field\r"]]
   },
   {
     Name: "FieldCRCRLFCR",
     Input: "field\r\r\n\rfield\r\r\n\r",
-    Output: [["field\r"], ["\rfield\r"]],
+    Output: [["field\r"], ["\rfield\r"]]
   },
   {
     Name: "FieldCRCRLFCRCR",
     Input: "field\r\r\n\r\rfield\r\r\n\r\r",
-    Output: [["field\r"], ["\r\rfield\r"], ["\r"]],
-    ignore: true,
+    Output: [["field\r"], ["\r\rfield\r"], ["\r"]]
   },
   {
     Name: "MultiFieldCRCRLFCRCR",
@@ -336,9 +327,8 @@ x,,,
     Output: [
       ["field1", "field2\r"],
       ["\r\rfield1", "field2\r"],
-      ["\r\r", ""],
-    ],
-    ignore: true,
+      ["\r\r", ""]
+    ]
   },
   {
     Name: "NonASCIICommaAndComment",
@@ -346,14 +336,14 @@ x,,,
     Output: [["a", "b,c", "d,e"]],
     TrimLeadingSpace: true,
     Comma: "£",
-    Comment: "€",
+    Comment: "€"
   },
   {
     Name: "NonASCIICommaAndCommentWithQuotes",
     Input: 'a€"  b,"€ c\nλ comment\n',
     Output: [["a", "  b,", " c"]],
     Comma: "€",
-    Comment: "λ",
+    Comment: "λ"
   },
   {
     // λ and θ start with the same byte.
@@ -362,24 +352,23 @@ x,,,
     Input: '"abθcd"λefθgh',
     Output: [["abθcd", "efθgh"]],
     Comma: "λ",
-    Comment: "€",
+    Comment: "€"
   },
   {
     Name: "NonASCIICommentConfusion",
     Input: "λ\nλ\nθ\nλ\n",
     Output: [["λ"], ["λ"], ["λ"]],
-    Comment: "θ",
+    Comment: "θ"
   },
   {
     Name: "QuotedFieldMultipleLF",
     Input: '"\n\n\n\n"',
-    Output: [["\n\n\n\n"]],
-    ignore: true,
+    Output: [["\n\n\n\n"]]
   },
   {
     Name: "MultipleCRLF",
     Input: "\r\n\r\n\r\n\r\n",
-    ignore: true,
+    Output: []
   },
   /**
    * The implementation may read each line in several chunks if
@@ -392,77 +381,73 @@ x,,,
       "#ignore\n".repeat(10000) + "@".repeat(5000) + "," + "*".repeat(5000),
     Output: [["@".repeat(5000), "*".repeat(5000)]],
     Comment: "#",
-    ignore: true,
+    ignore: true
   },
   {
     Name: "QuoteWithTrailingCRLF",
     Input: '"foo"bar"\r\n',
-    Error: ErrBareQuote,
+    Error: ErrQuote
     // Error: &ParseError{StartLine: 1, Line: 1, Column: 4, Err: ErrQuote},
   },
   {
     Name: "LazyQuoteWithTrailingCRLF",
     Input: '"foo"bar"\r\n',
     Output: [[`foo"bar`]],
-    LazyQuotes: true,
+    LazyQuotes: true
   },
   {
     Name: "DoubleQuoteWithTrailingCRLF",
     Input: '"foo""bar"\r\n',
-    Output: [[`foo"bar`]],
-    ignore: true,
+    Output: [[`foo"bar`]]
   },
   {
     Name: "EvenQuotes",
     Input: `""""""""`,
-    Output: [[`"""`]],
-    ignore: true,
+    Output: [[`"""`]]
   },
   {
     Name: "OddQuotes",
     Input: `"""""""`,
-    Error: true,
+    Error: ErrQuote
     // Error:" &ParseError{StartLine: 1, Line: 1, Column: 7, Err: ErrQuote}",
-    ignore: true,
   },
   {
     Name: "LazyOddQuotes",
     Input: `"""""""`,
     Output: [[`"""`]],
-    LazyQuotes: true,
-    ignore: true,
+    LazyQuotes: true
   },
   {
     Name: "BadComma1",
     Comma: "\n",
-    Error: ErrInvalidDelim,
+    Error: ErrInvalidDelim
   },
   {
     Name: "BadComma2",
     Comma: "\r",
-    Error: ErrInvalidDelim,
+    Error: ErrInvalidDelim
   },
   {
     Name: "BadComma3",
     Comma: '"',
-    Error: ErrInvalidDelim,
+    Error: ErrInvalidDelim
   },
   {
     Name: "BadComment1",
     Comment: "\n",
-    Error: ErrInvalidDelim,
+    Error: ErrInvalidDelim
   },
   {
     Name: "BadComment2",
     Comment: "\r",
-    Error: ErrInvalidDelim,
+    Error: ErrInvalidDelim
   },
   {
     Name: "BadCommaComment",
     Comma: "X",
     Comment: "X",
-    Error: ErrInvalidDelim,
-  },
+    Error: ErrInvalidDelim
+  }
 ];
 for (const t of testCases) {
   Deno.test({
@@ -500,9 +485,10 @@ for (const t of testCases) {
               comment: comment,
               trimLeadingSpace: trim,
               fieldsPerRecord: fieldsPerRec,
-              lazyQuotes: lazyquote,
+              lazyQuotes: lazyquote
             }
           );
+          console.log(actual);
         } catch (e) {
           err = e;
         }
@@ -516,13 +502,13 @@ for (const t of testCases) {
             comment: comment,
             trimLeadingSpace: trim,
             fieldsPerRecord: fieldsPerRec,
-            lazyQuotes: lazyquote,
+            lazyQuotes: lazyquote
           }
         );
         const expected = t.Output;
         assertEquals(actual, expected);
       }
-    },
+    }
   });
 }
 
@@ -531,13 +517,13 @@ const parseTestCases = [
     name: "simple",
     in: "a,b,c",
     header: false,
-    result: [["a", "b", "c"]],
+    result: [["a", "b", "c"]]
   },
   {
     name: "simple Bufreader",
     in: new BufReader(new StringReader("a,b,c")),
     header: false,
-    result: [["a", "b", "c"]],
+    result: [["a", "b", "c"]]
   },
   {
     name: "multiline",
@@ -545,14 +531,14 @@ const parseTestCases = [
     header: false,
     result: [
       ["a", "b", "c"],
-      ["e", "f", "g"],
-    ],
+      ["e", "f", "g"]
+    ]
   },
   {
     name: "header mapping boolean",
     in: "a,b,c\ne,f,g\n",
     header: true,
-    result: [{ a: "e", b: "f", c: "g" }],
+    result: [{ a: "e", b: "f", c: "g" }]
   },
   {
     name: "header mapping array",
@@ -560,8 +546,8 @@ const parseTestCases = [
     header: ["this", "is", "sparta"],
     result: [
       { this: "a", is: "b", sparta: "c" },
-      { this: "e", is: "f", sparta: "g" },
-    ],
+      { this: "e", is: "f", sparta: "g" }
+    ]
   },
   {
     name: "header mapping object",
@@ -569,8 +555,8 @@ const parseTestCases = [
     header: [{ name: "this" }, { name: "is" }, { name: "sparta" }],
     result: [
       { this: "a", is: "b", sparta: "c" },
-      { this: "e", is: "f", sparta: "g" },
-    ],
+      { this: "e", is: "f", sparta: "g" }
+    ]
   },
   {
     name: "header mapping parse entry",
@@ -580,25 +566,25 @@ const parseTestCases = [
         name: "this",
         parse: (e: string): string => {
           return `b${e}$$`;
-        },
+        }
       },
       {
         name: "is",
         parse: (e: string): number => {
           return e.length;
-        },
+        }
       },
       {
         name: "sparta",
         parse: (e: string): unknown => {
           return { bim: `boom-${e}` };
-        },
-      },
+        }
+      }
     ],
     result: [
       { this: "ba$$", is: 1, sparta: { bim: `boom-c` } },
-      { this: "be$$", is: 1, sparta: { bim: `boom-g` } },
-    ],
+      { this: "be$$", is: 1, sparta: { bim: `boom-g` } }
+    ]
   },
   {
     name: "multiline parse",
@@ -609,8 +595,8 @@ const parseTestCases = [
     header: false,
     result: [
       { super: "a", street: "b", fighter: "c" },
-      { super: "e", street: "f", fighter: "g" },
-    ],
+      { super: "e", street: "f", fighter: "g" }
+    ]
   },
   {
     name: "header mapping object parseline",
@@ -621,9 +607,9 @@ const parseTestCases = [
     },
     result: [
       { super: "a", street: "b", fighter: "c" },
-      { super: "e", street: "f", fighter: "g" },
-    ],
-  },
+      { super: "e", street: "f", fighter: "g" }
+    ]
+  }
 ];
 
 for (const testCase of parseTestCases) {
@@ -632,9 +618,9 @@ for (const testCase of parseTestCases) {
     async fn(): Promise<void> {
       const r = await parse(testCase.in, {
         header: testCase.header,
-        parse: testCase.parse as (input: unknown) => unknown,
+        parse: testCase.parse as (input: unknown) => unknown
       });
       assertEquals(r, testCase.result);
-    },
+    }
   });
 }

--- a/std/encoding/csv_test.ts
+++ b/std/encoding/csv_test.ts
@@ -627,12 +627,3 @@ for (const testCase of parseTestCases) {
     },
   });
 }
-
-import { TextProtoReader } from "../textproto/mod.ts";
-
-Deno.test(async function readHugeLine() {
-  const input = "@".repeat(5000) + "," + "*".repeat(5000);
-  const reader = new TextProtoReader(new BufReader(new StringReader(input)));
-  const out = await reader.readLine();
-  assertEquals(out, input);
-});

--- a/std/encoding/csv_test.ts
+++ b/std/encoding/csv_test.ts
@@ -1,5 +1,9 @@
 // Test ported from Golang
 // https://github.com/golang/go/blob/2cc15b1/src/encoding/csv/reader_test.go
+// Copyright 2011 The Go Authors. All rights reserved. BSD license.
+// https://github.com/golang/go/blob/master/LICENSE
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
 import { assertEquals, assert } from "../testing/asserts.ts";
 import {
   readMatrix,

--- a/std/encoding/csv_test.ts
+++ b/std/encoding/csv_test.ts
@@ -385,7 +385,7 @@ x,,,
       "#ignore\n".repeat(10000) + "@".repeat(5000) + "," + "*".repeat(5000),
     Output: [["@".repeat(5000), "*".repeat(5000)]],
     Comment: "#",
-    ignore: true,
+    ignore: true, // TODO(#4521)
   },
   {
     Name: "QuoteWithTrailingCRLF",

--- a/std/encoding/csv_test.ts
+++ b/std/encoding/csv_test.ts
@@ -488,7 +488,6 @@ for (const t of testCases) {
               lazyQuotes: lazyquote
             }
           );
-          console.log(actual);
         } catch (e) {
           err = e;
         }
@@ -624,3 +623,12 @@ for (const testCase of parseTestCases) {
     }
   });
 }
+
+import { TextProtoReader } from "../textproto/mod.ts"
+
+Deno.test(async function readHugeLine() {
+  const input = "@".repeat(5000) + "," + "*".repeat(5000);
+  const reader = new TextProtoReader(new BufReader(new StringReader(input)));
+  const out = await reader.readLine();
+  assertEquals(out, input);
+});

--- a/std/encoding/csv_test.ts
+++ b/std/encoding/csv_test.ts
@@ -8,10 +8,10 @@ import { assertEquals, assert } from "../testing/asserts.ts";
 import {
   readMatrix,
   parse,
-  ErrBareQuote,
-  ErrQuote,
-  ErrInvalidDelim,
-  ErrFieldCount,
+  ERR_BARE_QUOTE,
+  ERR_QUOTE,
+  ERR_INVALID_DELIM,
+  ERR_FIELD_COUNT,
 } from "./csv.ts";
 import { StringReader } from "../io/readers.ts";
 import { BufReader } from "../io/bufio.ts";
@@ -133,7 +133,7 @@ field"`,
   {
     Name: "BadDoubleQuotes",
     Input: `a""b,c`,
-    Error: ErrBareQuote,
+    Error: ERR_BARE_QUOTE,
     // Error: &ParseError{StartLine: 1, Line: 1, Column: 1, Err: ErrBareQuote},
   },
   {
@@ -145,23 +145,23 @@ field"`,
   {
     Name: "BadBareQuote",
     Input: `a "word","b"`,
-    Error: ErrBareQuote,
+    Error: ERR_BARE_QUOTE,
     // &ParseError{StartLine: 1, Line: 1, Column: 2, Err: ErrBareQuote}
   },
   {
     Name: "BadTrailingQuote",
     Input: `"a word",b"`,
-    Error: ErrBareQuote,
+    Error: ERR_BARE_QUOTE,
   },
   {
     Name: "ExtraneousQuote",
     Input: `"a "word","b"`,
-    Error: ErrQuote,
+    Error: ERR_QUOTE,
   },
   {
     Name: "BadFieldCount",
     Input: "a,b,c\nd,e",
-    Error: ErrFieldCount,
+    Error: ERR_FIELD_COUNT,
     UseFieldsPerRecord: true,
     FieldsPerRecord: 0,
   },
@@ -171,7 +171,7 @@ field"`,
     // Error: &ParseError{StartLine: 1, Line: 1, Err: ErrFieldCount},
     UseFieldsPerRecord: true,
     FieldsPerRecord: 2,
-    Error: ErrFieldCount,
+    Error: ERR_FIELD_COUNT,
   },
   {
     Name: "FieldCount",
@@ -265,13 +265,13 @@ x,,,
   {
     Name: "StartLine1", // Issue 19019
     Input: 'a,"b\nc"d,e',
-    Error: ErrQuote,
+    Error: ERR_QUOTE,
     // Error: &ParseError{StartLine: 1, Line: 2, Column: 1, Err: ErrQuote},
   },
   {
     Name: "StartLine2",
     Input: 'a,b\n"d\n\n,e',
-    Error: ErrQuote,
+    Error: ERR_QUOTE,
     // Error: &ParseError{StartLine: 2, Line: 5, Column: 0, Err: ErrQuote},
   },
   {
@@ -297,7 +297,7 @@ x,,,
   {
     Name: "QuotedTrailingCRCR",
     Input: '"field"\r\r',
-    Error: ErrQuote,
+    Error: ERR_QUOTE,
     // Error: &ParseError{StartLine: 1, Line: 1, Column: 6, Err: ErrQuote},
   },
   {
@@ -390,7 +390,7 @@ x,,,
   {
     Name: "QuoteWithTrailingCRLF",
     Input: '"foo"bar"\r\n',
-    Error: ErrQuote,
+    Error: ERR_QUOTE,
     // Error: &ParseError{StartLine: 1, Line: 1, Column: 4, Err: ErrQuote},
   },
   {
@@ -412,7 +412,7 @@ x,,,
   {
     Name: "OddQuotes",
     Input: `"""""""`,
-    Error: ErrQuote,
+    Error: ERR_QUOTE,
     // Error:" &ParseError{StartLine: 1, Line: 1, Column: 7, Err: ErrQuote}",
   },
   {
@@ -424,33 +424,33 @@ x,,,
   {
     Name: "BadComma1",
     Comma: "\n",
-    Error: ErrInvalidDelim,
+    Error: ERR_INVALID_DELIM,
   },
   {
     Name: "BadComma2",
     Comma: "\r",
-    Error: ErrInvalidDelim,
+    Error: ERR_INVALID_DELIM,
   },
   {
     Name: "BadComma3",
     Comma: '"',
-    Error: ErrInvalidDelim,
+    Error: ERR_INVALID_DELIM,
   },
   {
     Name: "BadComment1",
     Comment: "\n",
-    Error: ErrInvalidDelim,
+    Error: ERR_INVALID_DELIM,
   },
   {
     Name: "BadComment2",
     Comment: "\r",
-    Error: ErrInvalidDelim,
+    Error: ERR_INVALID_DELIM,
   },
   {
     Name: "BadCommaComment",
     Comma: "X",
     Comment: "X",
-    Error: ErrInvalidDelim,
+    Error: ERR_INVALID_DELIM,
   },
 ];
 for (const t of testCases) {


### PR DESCRIPTION
- Enabled skipped tests for `std/encoding/csv.ts` (except for [the `HugeLines` test](https://github.com/denoland/deno/blob/600dace3b4e349b3bf60a915ae76f97f7064a5cf/std/encoding/csv_test.ts#L379). See #4521)
