### PR TITLE
std: Add common to std/path

### DIFF
--- a/std/path/common.ts
+++ b/std/path/common.ts
@@ -1,0 +1,38 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { SEP } from "./constants.ts";
+
+/** Determines the common path from a set of paths, using an optional separator,
+ * which defaults to the OS default separator.
+ *
+ *       import { common } from "https://deno.land/std/path/mod.ts";
+ *       const p = common([
+ *         "./deno/std/path/mod.ts",
+ *         "./deno/std/fs/mod.ts",
+ *       ]);
+ *       console.log(p); // "./deno/std/"
+ *
+ */
+export function common(paths: string[], sep = SEP): string {
+  const [first = "", ...remaining] = paths;
+  if (first === "" || remaining.length === 0) {
+    return first.substring(0, first.lastIndexOf(sep) + 1);
+  }
+  const parts = first.split(sep);
+
+  let endOfPrefix = parts.length;
+  for (const path of remaining) {
+    const compare = path.split(sep);
+    for (let i = 0; i < endOfPrefix; i++) {
+      if (compare[i] !== parts[i]) {
+        endOfPrefix = i;
+      }
+    }
+
+    if (endOfPrefix === 0) {
+      return "";
+    }
+  }
+  const prefix = parts.slice(0, endOfPrefix).join(sep);
+  return prefix.endsWith(sep) ? prefix : `${prefix}${sep}`;
+}

--- a/std/path/common_test.ts
+++ b/std/path/common_test.ts
@@ -1,0 +1,47 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+const { test } = Deno;
+import { assertEquals } from "../testing/asserts.ts";
+
+import { common } from "./mod.ts";
+
+test({
+  name: "path - common - basic usage",
+  fn() {
+    const actual = common(
+      [
+        "file://deno/cli/js/deno.ts",
+        "file://deno/std/path/mod.ts",
+        "file://deno/cli/js/main.ts",
+      ],
+      "/"
+    );
+    assertEquals(actual, "file://deno/");
+  },
+});
+
+test({
+  name: "path - common - no shared",
+  fn() {
+    const actual = common(
+      ["file://deno/cli/js/deno.ts", "https://deno.land/std/path/mod.ts"],
+      "/"
+    );
+    assertEquals(actual, "");
+  },
+});
+
+test({
+  name: "path - common - windows sep",
+  fn() {
+    const actual = common(
+      [
+        "c:\\deno\\cli\\js\\deno.ts",
+        "c:\\deno\\std\\path\\mod.ts",
+        "c:\\deno\\cli\\js\\main.ts",
+      ],
+      "\\"
+    );
+    assertEquals(actual, "c:\\deno\\");
+  },
+});

--- a/std/path/mod.ts
+++ b/std/path/mod.ts
@@ -1,5 +1,5 @@
 // Copyright the Browserify authors. MIT License.
-// Ported from https://github.com/browserify/path-browserify/
+// Ported mostly from https://github.com/browserify/path-browserify/
 
 import * as _win32 from "./win32.ts";
 import * as _posix from "./posix.ts";
@@ -10,20 +10,23 @@ const path = isWindows ? _win32 : _posix;
 
 export const win32 = _win32;
 export const posix = _posix;
-export const resolve = path.resolve;
-export const normalize = path.normalize;
-export const isAbsolute = path.isAbsolute;
-export const join = path.join;
-export const relative = path.relative;
-export const toNamespacedPath = path.toNamespacedPath;
-export const dirname = path.dirname;
-export const basename = path.basename;
-export const extname = path.extname;
-export const format = path.format;
-export const parse = path.parse;
-export const sep = path.sep;
-export const delimiter = path.delimiter;
+export const {
+  resolve,
+  normalize,
+  isAbsolute,
+  join,
+  relative,
+  toNamespacedPath,
+  dirname,
+  basename,
+  extname,
+  format,
+  parse,
+  sep,
+  delimiter,
+} = path;
 
+export { common } from "./common.ts";
 export { EOL, SEP, SEP_PATTERN, isWindows } from "./constants.ts";
 export * from "./interface.ts";
 export * from "./glob.ts";

--- a/std/path/test.ts
+++ b/std/path/test.ts
@@ -1,9 +1,0 @@
-import "./basename_test.ts";
-import "./dirname_test.ts";
-import "./extname_test.ts";
-import "./isabsolute_test.ts";
-import "./join_test.ts";
-import "./parse_format_test.ts";
-import "./relative_test.ts";
-import "./resolve_test.ts";
-import "./zero_length_strings_test.ts";


### PR DESCRIPTION
This PR add a utility that I have had to use before in the bundler to `std/path` but wanted to use it elsewhere, where the common path can be determined for a given set of paths.

For example:

```ts
import { common } from "https://deno.land/std/path/mod.ts";

const p = common(
  [
    "./deno/cli/js/deno.ts",
    "./deno/std/path/mod.ts",
    "./deno/cli/js/main.ts"
  ],
  "/"
);
console.log(p); // ./deno/
```
