### PR TITLE
used native padStart/End where possible

### DIFF
--- a/std/datetime/mod.ts
+++ b/std/datetime/mod.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { pad } from "../strings/pad.ts";
 import { assert } from "../testing/asserts.ts";
 
 export type DateFormat = "mm-dd-yyyy" | "dd-mm-yyyy" | "yyyy-mm-dd";
@@ -125,7 +124,7 @@ export function currentDayOfYear(): number {
  */
 export function toIMF(date: Date): string {
   function dtPad(v: string, lPad = 2): string {
-    return pad(v, lPad, { char: "0" });
+    return v.padStart(lPad, "0");
   }
   const d = dtPad(date.getUTCDate().toString());
   const h = dtPad(date.getUTCHours().toString());

--- a/std/encoding/toml.ts
+++ b/std/encoding/toml.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { deepAssign } from "../util/deep_assign.ts";
-import { pad } from "../strings/pad.ts";
 import { assert } from "../testing/asserts.ts";
 
 class KeyValuePair {
@@ -514,7 +513,7 @@ class Dumper {
   }
   _dateDeclaration(keys: string[], value: Date): string {
     function dtPad(v: string, lPad = 2): string {
-      return pad(v, lPad, { char: "0" });
+      return v.padStart(lPad, "0");
     }
     const m = dtPad((value.getUTCMonth() + 1).toString());
     const d = dtPad(value.getUTCDate().toString());
@@ -542,7 +541,7 @@ class Dumper {
       } else {
         const m = rDeclaration.exec(l);
         if (m) {
-          out.push(l.replace(m[1], pad(m[1], this.maxPad, { side: "right" })));
+          out.push(l.replace(m[1], m[1].padEnd(this.maxPad)));
         } else {
           out.push(l);
         }


### PR DESCRIPTION
As discussed in https://github.com/denoland/deno/issues/4529, I replaced three occurences of the `std/strings/pad` module with native `pad{Start,End}` functions. Tests are passing.