### PR TITLE
Properly track isFile, isSymlink, isDirectory

### DIFF
--- a/cli/js/file_info.ts
+++ b/cli/js/file_info.ts
@@ -25,6 +25,7 @@ export interface FileInfo {
 // @internal
 export class FileInfoImpl implements FileInfo {
   readonly #isFile: boolean;
+  readonly #isDirectory: boolean;
   readonly #isSymlink: boolean;
   size: number;
   modified: number | null;
@@ -53,6 +54,7 @@ export class FileInfoImpl implements FileInfo {
     const { dev, ino, mode, nlink, uid, gid, rdev, blksize, blocks } = res;
 
     this.#isFile = res.isFile;
+    this.#isDirectory = res.isDirectory;
     this.#isSymlink = res.isSymlink;
     this.size = res.size;
     this.modified = modified ? modified : null;
@@ -76,7 +78,7 @@ export class FileInfoImpl implements FileInfo {
   }
 
   isDirectory(): boolean {
-    return !this.#isFile && !this.#isSymlink;
+    return this.#isDirectory;
   }
 
   isSymlink(): boolean {

--- a/cli/js/ops/fs/stat.ts
+++ b/cli/js/ops/fs/stat.ts
@@ -4,6 +4,7 @@ import { FileInfo, FileInfoImpl } from "../../file_info.ts";
 
 export interface StatResponse {
   isFile: boolean;
+  isDirectory: boolean;
   isSymlink: boolean;
   size: number;
   modified: number;

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -509,6 +509,7 @@ fn get_stat_json(
   use std::os::unix::fs::MetadataExt;
   let mut json_val = json!({
     "isFile": metadata.is_file(),
+    "isDirectory": metadata.is_dir(),
     "isSymlink": metadata.file_type().is_symlink(),
     "size": metadata.len(),
     // In seconds. Available on both Unix or Windows.


### PR DESCRIPTION
These don't exhaust all the possibilities, so none of them should be
defined as "neither of the others".
