### PR TITLE
fix(#4521): BufReader should not share the internal buffer across reads

### DIFF
--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -337,7 +337,11 @@ export class BufReader implements Reader {
       // Buffer full?
       if (this.buffered() >= this.buf.byteLength) {
         this.r = this.w;
-        throw new BufferFullError(this.buf);
+        // #4521 The internal buffer should not be reused across reads because it causes corruption of data.
+        const oldbuf = this.buf;
+        const newbuf = this.buf.slice(0);
+        this.buf = newbuf;
+        throw new BufferFullError(oldbuf);
       }
 
       s = this.w - this.r; // do not rescan area we scanned before

--- a/std/textproto/test.ts
+++ b/std/textproto/test.ts
@@ -178,3 +178,14 @@ test({
     assertEquals(m.get("Content-Disposition"), 'form-data; name="test"');
   },
 });
+
+test({
+  name: "[textproto] #4521 issue",
+  async fn() {
+    const input = "abcdefghijklmnopqrstuvwxyz";
+    const bufSize = 25;
+    const tp = new TextProtoReader(new BufReader(stringsReader(input), bufSize));
+    const line = await tp.readLine();
+    assertEquals(line, input);
+  },
+});

--- a/std/textproto/test.ts
+++ b/std/textproto/test.ts
@@ -184,7 +184,9 @@ test({
   async fn() {
     const input = "abcdefghijklmnopqrstuvwxyz";
     const bufSize = 25;
-    const tp = new TextProtoReader(new BufReader(stringsReader(input), bufSize));
+    const tp = new TextProtoReader(
+      new BufReader(stringsReader(input), bufSize)
+    );
     const line = await tp.readLine();
     assertEquals(line, input);
   },


### PR DESCRIPTION
This PR resolves #4521.

The problem was in BufReader, not TextProtoReader.

```typescript
const decoder = new TextDecoder();
const bufSize = 16;
const input = "01234567890123456"; // a string longer than buffer
const b = new BufReader(stringsReader(input), bufSize);
const r1 = await b.readLine();
const r2 = await b.readLine();
if (r1 !== Deno.EOF && r2 !== Deno.EOF) {
  console.log(decoder.decode(r1.line));
  console.log(decoder.decode(r2.line));
}
```

The output is as follows:

**Before:**

```
6123456789012345 // corrupted
6
```

**After:**

```
0123456789012345
6
```

The above problem is caused because `r1` and `r2` internally share the same array buffer.