### PR TITLE
feat(std/http/server): Respond with 400 on request parse failure

### DIFF
--- a/std/http/io_test.ts
+++ b/std/http/io_test.ts
@@ -5,6 +5,7 @@ import {
   assert,
   assertNotEOF,
   assertNotEquals,
+  assertMatch,
 } from "../testing/asserts.ts";
 import {
   bodyReader,
@@ -349,13 +350,28 @@ malformedHeader
 `;
   const reader = new BufReader(new StringReader(input));
   let err;
+  let responseString: string;
   try {
-    await readRequest(mockConn(), reader);
+    // Capture whatever `readRequest()` attempts to write to the connection on
+    // error. We expect it to be a 400 response.
+    await readRequest(
+      mockConn({
+        write(p: Uint8Array): Promise<number> {
+          responseString = decode(p);
+          return Promise.resolve(p.length);
+        },
+      }),
+      reader
+    );
   } catch (e) {
     err = e;
   }
   assert(err instanceof Error);
   assertEquals(err.message, "malformed MIME header line: malformedHeader");
+  assertMatch(
+    responseString!,
+    /^HTTP\/1\.1 400 Bad Request\r\ncontent-length: \d+\r\n\r\n.*\r\n\r\n$/ms
+  );
 });
 
 // Ported from Go

--- a/std/http/mock.ts
+++ b/std/http/mock.ts
@@ -17,8 +17,8 @@ export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
     read: (): Promise<number | Deno.EOF> => {
       return Promise.resolve(0);
     },
-    write: (): Promise<number> => {
-      return Promise.resolve(-1);
+    write: (p: Uint8Array): Promise<number> => {
+      return Promise.resolve(p.length);
     },
     close: (): void => {},
     ...base,

--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -146,14 +146,14 @@ export class Server implements AsyncIterable<ServerRequest> {
   private async *iterateHttpRequests(
     conn: Conn
   ): AsyncIterableIterator<ServerRequest> {
-    const bufr = new BufReader(conn);
-    const w = new BufWriter(conn);
+    const reader = new BufReader(conn);
+    const writer = new BufWriter(conn);
     let req: ServerRequest | Deno.EOF = Deno.EOF;
     let err: Error | undefined;
 
     while (!this.closing) {
       try {
-        req = await readRequest(conn, bufr);
+        req = await readRequest(conn, reader, writer);
       } catch (e) {
         err = e;
       }
@@ -161,7 +161,6 @@ export class Server implements AsyncIterable<ServerRequest> {
         break;
       }
 
-      req.w = w;
       yield req;
 
       // Wait for the request to be processed before we accept a new request on


### PR DESCRIPTION
Correctly brings back the error handling removed in https://github.com/denoland/deno/pull/4435#discussion_r395373572.