### PR TITLE
Expose global state publicly

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -33,7 +33,7 @@ pub mod flags;
 mod fmt;
 pub mod fmt_errors;
 mod fs;
-mod global_state;
+pub mod global_state;
 mod global_timer;
 pub mod http_cache;
 mod http_util;


### PR DESCRIPTION
In order to be able to use the `deno` crate in other programs, one should be able to run stuff like the `TsCompiler`, which is exposed, but needs a `GlobalState` object in some function signatures.

This change would enable that usage.

An alternative would be to just expose the `GlobalState` struct instead of the full module.