### PR TITLE
Added Math.trunc to toSecondsFromEpoch to conform the result to u64.

### DIFF
--- a/cli/js/ops/fs/utime.ts
+++ b/cli/js/ops/fs/utime.ts
@@ -2,7 +2,7 @@
 import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 function toSecondsFromEpoch(v: number | Date): number {
-  return v instanceof Date ? v.valueOf() / 1000 : v;
+  return v instanceof Date ? Math.trunc(v.valueOf() / 1000) : v;
 }
 
 export function utimeSync(

--- a/cli/js/tests/utime_test.ts
+++ b/cli/js/tests/utime_test.ts
@@ -60,6 +60,31 @@ unitTest(
 
 unitTest(
   { perms: { read: true, write: true } },
+  function utimeSyncFileDateSuccess() {
+    const testDir = Deno.makeTempDirSync();
+    const filename = testDir + "/file.txt";
+    Deno.writeFileSync(filename, new TextEncoder().encode("hello"), {
+      mode: 0o666,
+    });
+    const atime = new Date();
+    const mtime = new Date();
+    Deno.utimeSync(filename, atime, mtime);
+
+    const fileInfo = Deno.statSync(filename);
+    // atime and mtime must be scaled by a factor of 1000 to be recorded in seconds
+    assertFuzzyTimestampEquals(
+      fileInfo.accessed,
+      Math.trunc(atime.valueOf() / 1000)
+    );
+    assertFuzzyTimestampEquals(
+      fileInfo.modified,
+      Math.trunc(mtime.valueOf() / 1000)
+    );
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
   function utimeSyncLargeNumberSuccess(): void {
     const testDir = Deno.makeTempDirSync();
 
@@ -155,6 +180,32 @@ unitTest(
     const dirInfo = Deno.statSync(testDir);
     assertFuzzyTimestampEquals(dirInfo.accessed, atime);
     assertFuzzyTimestampEquals(dirInfo.modified, mtime);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function utimeFileDateSuccess(): Promise<void> {
+    const testDir = Deno.makeTempDirSync();
+    const filename = testDir + "/file.txt";
+    Deno.writeFileSync(filename, new TextEncoder().encode("hello"), {
+      mode: 0o666,
+    });
+
+    const atime = new Date();
+    const mtime = new Date();
+    await Deno.utime(filename, atime, mtime);
+
+    const fileInfo = Deno.statSync(filename);
+    // The dates must be scaled by a factored of 1000 to make them seconds
+    assertFuzzyTimestampEquals(
+      fileInfo.accessed,
+      Math.trunc(atime.valueOf() / 1000)
+    );
+    assertFuzzyTimestampEquals(
+      fileInfo.modified,
+      Math.trunc(mtime.valueOf() / 1000)
+    );
   }
 );
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
The conversion to seconds from unix epoch resulted in a float but a u64 is required. I truncated the result to conform it to u64.

Fixes #4546