### PR TITLE
Web docs

### DIFF
--- a/cli/js/web/README.md
+++ b/cli/js/web/README.md
@@ -9,23 +9,26 @@ Some of the Web APIs are using ops under the hood, eg. `console`, `performance`.
 
 ## Implemented Web APIs
 
-  - [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob)
-  - [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console)
-  - [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent)
-  - [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
-    and [EventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventListener)
+  - [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob): for representing opaque binary data
+  - [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console): for logging purposes
+  - [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent),
+    [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
+    and [EventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventListener): to work with DOM events
+    - **Implementation notes:** There is no DOM hierarchy in Deno, so there is no tree for Events to bubble/capture through.
   - [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL)
-    and [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
+    and [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams): to construct and parse URLSs
   - [fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch),
     [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request),
 	[Response](https://developer.mozilla.org/en-US/docs/Web/API/Response),
 	[Body](https://developer.mozilla.org/en-US/docs/Web/API/Body)
-	and [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers)
-  - [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData)
-  - [Location](https://developer.mozilla.org/en-US/docs/Web/API/Location)
-  - [Performance](https://developer.mozilla.org/en-US/docs/Web/API/Performance)
+	and [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers): modern Promise-based HTTP Request API
+  - [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData): access to a `multipart/form-data` serialization
+  - [Location](https://developer.mozilla.org/en-US/docs/Web/API/Location): parsing the current script's URL
+    - **Implementation notes:** the `globalThis.location` object cannot be manipulated using `assign()`, `reload()` and `replace()` methods. They are not implemented.
+  - [Performance](https://developer.mozilla.org/en-US/docs/Web/API/Performance): retrieving current time with a high precision
   - [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout),
     [setInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval),
-	[clearTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout)
+	[clearTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout): scheduling callbacks in future
 	and [clearInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval)
-  - [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker)
+  - [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker): executing additional code in a separate thread
+    - **Implementation notes:** Blob URLs are not supported, object ownership cannot be transferred, posted data is serialized to JSON instead of [structured cloning](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).

--- a/cli/js/web/README.md
+++ b/cli/js/web/README.md
@@ -9,26 +9,42 @@ Some of the Web APIs are using ops under the hood, eg. `console`, `performance`.
 
 ## Implemented Web APIs
 
-  - [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob): for representing opaque binary data
-  - [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console): for logging purposes
-  - [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent),
-    [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
-    and [EventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventListener): to work with DOM events
-    - **Implementation notes:** There is no DOM hierarchy in Deno, so there is no tree for Events to bubble/capture through.
-  - [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL)
-    and [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams): to construct and parse URLSs
-  - [fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch),
-    [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request),
-	[Response](https://developer.mozilla.org/en-US/docs/Web/API/Response),
-	[Body](https://developer.mozilla.org/en-US/docs/Web/API/Body)
-	and [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers): modern Promise-based HTTP Request API
-  - [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData): access to a `multipart/form-data` serialization
-  - [Location](https://developer.mozilla.org/en-US/docs/Web/API/Location): parsing the current script's URL
-    - **Implementation notes:** the `globalThis.location` object cannot be manipulated using `assign()`, `reload()` and `replace()` methods. They are not implemented.
-  - [Performance](https://developer.mozilla.org/en-US/docs/Web/API/Performance): retrieving current time with a high precision
-  - [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout),
-    [setInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval),
-	[clearTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout): scheduling callbacks in future
-	and [clearInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval)
-  - [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker): executing additional code in a separate thread
-    - **Implementation notes:** Blob URLs are not supported, object ownership cannot be transferred, posted data is serialized to JSON instead of [structured cloning](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+- [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob): for
+  representing opaque binary data
+- [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console): for
+  logging purposes
+- [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent),
+  [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
+  and
+  [EventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventListener):
+  to work with DOM events
+  - **Implementation notes:** There is no DOM hierarchy in Deno, so there is no
+    tree for Events to bubble/capture through.
+- [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) and
+  [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams):
+  to construct and parse URLSs
+- [fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch),
+  [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request),
+  [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response),
+  [Body](https://developer.mozilla.org/en-US/docs/Web/API/Body) and
+  [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers): modern
+  Promise-based HTTP Request API
+- [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData): access
+  to a `multipart/form-data` serialization
+- [Location](https://developer.mozilla.org/en-US/docs/Web/API/Location): parsing
+  the current script's URL
+  - **Implementation notes:** the `globalThis.location` object cannot be
+    manipulated using `assign()`, `reload()` and `replace()` methods. They are
+    not implemented.
+- [Performance](https://developer.mozilla.org/en-US/docs/Web/API/Performance):
+  retrieving current time with a high precision
+- [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout),
+  [setInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval),
+  [clearTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout):
+  scheduling callbacks in future and
+  [clearInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval)
+- [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker): executing
+  additional code in a separate thread
+  - **Implementation notes:** Blob URLs are not supported, object ownership
+    cannot be transferred, posted data is serialized to JSON instead of
+    [structured cloning](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).

--- a/cli/js/web/README.md
+++ b/cli/js/web/README.md
@@ -6,3 +6,26 @@ Please note, that some of implementations might not be completely aligned with
 specification.
 
 Some of the Web APIs are using ops under the hood, eg. `console`, `performance`.
+
+## Implemented Web APIs
+
+  - [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob)
+  - [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console)
+  - [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent)
+  - [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
+    and [EventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventListener)
+  - [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL)
+    and [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
+  - [fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch),
+    [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request),
+	[Response](https://developer.mozilla.org/en-US/docs/Web/API/Response),
+	[Body](https://developer.mozilla.org/en-US/docs/Web/API/Body)
+	and [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers)
+  - [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData)
+  - [Location](https://developer.mozilla.org/en-US/docs/Web/API/Location)
+  - [Performance](https://developer.mozilla.org/en-US/docs/Web/API/Performance)
+  - [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout),
+    [setInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval),
+	[clearTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout)
+	and [clearInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval)
+  - [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker)


### PR DESCRIPTION
Continuing the conversation from https://github.com/denoland/deno/issues/4325. The current README can be seen at https://github.com/ondras/deno/blob/web-docs/cli/js/web/README.md.

Done:
  - summarized Web APIs
  - provided short description
  - added implementation notes where knowledgeable enough

Missing:
  - proofread
  - add more implementation notes?
  - what next?


