### PR TITLE
Refactor and expand mkdir tests

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1022,7 +1022,8 @@ declare namespace Deno {
      * directories will also be created (as with the shell command `mkdir -p`).
      * Intermediate directories are created with the same permissions.
      * When recursive is set to `true`, succeeds silently (without changing any
-     * permissions) if a directory already exists at the path. */
+     * permissions) if a directory already exists at the path, or if the path
+     * is a symlink to an existing directory. */
     recursive?: boolean;
     /** Permissions to use when creating the directory (defaults to `0o777`,
      * before the process's umask).
@@ -1036,7 +1037,7 @@ declare namespace Deno {
    *       Deno.mkdirSync("nested/directories", { recursive: true });
    *       Deno.mkdirSync("restricted_access_dir", { mode: 0o700 });
    *
-   * Throws error if the directory already exists.
+   * Defaults to throwing error if the directory already exists.
    *
    * Requires `allow-write` permission. */
   export function mkdirSync(path: string, options?: MkdirOptions): void;
@@ -1054,7 +1055,7 @@ declare namespace Deno {
    *       await Deno.mkdir("nested/directories", { recursive: true });
    *       await Deno.mkdir("restricted_access_dir", { mode: 0o700 });
    *
-   * Throws error if the directory already exists.
+   * Defaults to throwing error if the directory already exists.
    *
    * Requires `allow-write` permission. */
   export function mkdir(path: string, options?: MkdirOptions): Promise<void>;

--- a/cli/js/tests/mkdir_test.ts
+++ b/cli/js/tests/mkdir_test.ts
@@ -56,10 +56,22 @@ unitTest(
   }
 );
 
-unitTest({ perms: { write: true } }, function mkdirErrIfExists(): void {
+unitTest({ perms: { write: true } }, function mkdirErrSyncIfExists(): void {
   let err;
   try {
     Deno.mkdirSync(".");
+  } catch (e) {
+    err = e;
+  }
+  assert(err instanceof Deno.errors.AlreadyExists);
+});
+
+unitTest({ perms: { write: true } }, async function mkdirErrIfExists(): Promise<
+  void
+> {
+  let err;
+  try {
+    await Deno.mkdir(".");
   } catch (e) {
     err = e;
   }

--- a/cli/js/tests/mkdir_test.ts
+++ b/cli/js/tests/mkdir_test.ts
@@ -1,13 +1,20 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { unitTest, assert, assertEquals } from "./test_util.ts";
 
+function assertDirectory(path: string, mode?: number): void {
+  const info = Deno.lstatSync(path);
+  assert(info.isDirectory());
+  if (Deno.build.os !== "win" && mode !== undefined) {
+    assertEquals(info.mode! & 0o777, mode & ~Deno.umask());
+  }
+}
+
 unitTest(
   { perms: { read: true, write: true } },
   function mkdirSyncSuccess(): void {
     const path = Deno.makeTempDirSync() + "/dir";
     Deno.mkdirSync(path);
-    const pathInfo = Deno.statSync(path);
-    assert(pathInfo.isDirectory());
+    assertDirectory(path);
   }
 );
 
@@ -16,10 +23,7 @@ unitTest(
   function mkdirSyncMode(): void {
     const path = Deno.makeTempDirSync() + "/dir";
     Deno.mkdirSync(path, { mode: 0o737 });
-    const pathInfo = Deno.statSync(path);
-    if (Deno.build.os !== "win") {
-      assertEquals(pathInfo.mode! & 0o777, 0o737 & ~Deno.umask());
-    }
+    assertDirectory(path, 0o737);
   }
 );
 
@@ -39,8 +43,7 @@ unitTest(
   async function mkdirSuccess(): Promise<void> {
     const path = Deno.makeTempDirSync() + "/dir";
     await Deno.mkdir(path);
-    const pathInfo = Deno.statSync(path);
-    assert(pathInfo.isDirectory());
+    assertDirectory(path);
   }
 );
 
@@ -49,10 +52,7 @@ unitTest(
   async function mkdirMode(): Promise<void> {
     const path = Deno.makeTempDirSync() + "/dir";
     await Deno.mkdir(path, { mode: 0o737 });
-    const pathInfo = Deno.statSync(path);
-    if (Deno.build.os !== "win") {
-      assertEquals(pathInfo.mode! & 0o777, 0o737 & ~Deno.umask());
-    }
+    assertDirectory(path, 0o737);
   }
 );
 
@@ -71,8 +71,7 @@ unitTest(
   function mkdirSyncRecursive(): void {
     const path = Deno.makeTempDirSync() + "/nested/directory";
     Deno.mkdirSync(path, { recursive: true });
-    const pathInfo = Deno.statSync(path);
-    assert(pathInfo.isDirectory());
+    assertDirectory(path);
   }
 );
 
@@ -81,7 +80,6 @@ unitTest(
   async function mkdirRecursive(): Promise<void> {
     const path = Deno.makeTempDirSync() + "/nested/directory";
     await Deno.mkdir(path, { recursive: true });
-    const pathInfo = Deno.statSync(path);
-    assert(pathInfo.isDirectory());
+    assertDirectory(path);
   }
 );

--- a/cli/js/tests/mkdir_test.ts
+++ b/cli/js/tests/mkdir_test.ts
@@ -95,3 +95,61 @@ unitTest(
     assertDirectory(path);
   }
 );
+
+unitTest(
+  { perms: { read: true, write: true } },
+  function mkdirSyncRecursiveMode(): void {
+    const nested = Deno.makeTempDirSync() + "/nested";
+    const path = nested + "/dir";
+    Deno.mkdirSync(path, { mode: 0o737, recursive: true });
+    assertDirectory(path, 0o737);
+    assertDirectory(nested, 0o737);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function mkdirRecursiveMode(): Promise<void> {
+    const nested = Deno.makeTempDirSync() + "/nested";
+    const path = nested + "/dir";
+    await Deno.mkdir(path, { mode: 0o737, recursive: true });
+    assertDirectory(path, 0o737);
+    assertDirectory(nested, 0o737);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  function mkdirSyncRecursiveIfExists(): void {
+    const path = Deno.makeTempDirSync() + "/dir";
+    Deno.mkdirSync(path, { mode: 0o737 });
+    Deno.mkdirSync(path, { recursive: true });
+    Deno.mkdirSync(path, { recursive: true, mode: 0o731 });
+    assertDirectory(path, 0o737);
+    if (Deno.build.os != "win") {
+      const pathLink = path + "Link";
+      Deno.symlinkSync(path, pathLink);
+      Deno.mkdirSync(pathLink, { recursive: true });
+      Deno.mkdirSync(pathLink, { recursive: true, mode: 0o731 });
+      assertDirectory(path, 0o737);
+    }
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function mkdirRecursiveIfExists(): Promise<void> {
+    const path = Deno.makeTempDirSync() + "/dir";
+    await Deno.mkdir(path, { mode: 0o737 });
+    await Deno.mkdir(path, { recursive: true });
+    await Deno.mkdir(path, { recursive: true, mode: 0o731 });
+    assertDirectory(path, 0o737);
+    if (Deno.build.os != "win") {
+      const pathLink = path + "Link";
+      Deno.symlinkSync(path, pathLink);
+      await Deno.mkdir(pathLink, { recursive: true });
+      await Deno.mkdir(pathLink, { recursive: true, mode: 0o731 });
+      assertDirectory(path, 0o737);
+    }
+  }
+);


### PR DESCRIPTION
This is part of series of filesystem commits (#4017).

We refine the tests and comments for `mkdir`. We add mode tests for when `recursive` is true, both for when the destination already exists and when it doesn't. We verify that the error type returned when the destination already exists is AlreadyExists (except for when recursive is true, and the destination is a directory or a symlink to a directory).

The comments currently say "intermediate directories are created with the same permissions", and that's true of this implementation. But as the implementation evolves in later PRs, it changes to having intermediate directories created with default (0o777 & ~umask) permissions, which is the behavior of the shell and peer languages. More on that in later PRs.