### PR TITLE
Cleanup Deno.open and Deno.writeFile

### DIFF
--- a/cli/js/files.ts
+++ b/cli/js/files.ts
@@ -36,8 +36,7 @@ export function openSync(
   if (typeof modeOrOptions === "string") {
     openMode = modeOrOptions;
   } else {
-    checkOpenOptions(modeOrOptions);
-    options = modeOrOptions as OpenOptions;
+    options = checkOpenOptions(modeOrOptions);
   }
 
   const rid = opOpenSync(path, openMode as OpenMode, options);
@@ -58,8 +57,7 @@ export async function open(
   if (typeof modeOrOptions === "string") {
     openMode = modeOrOptions;
   } else {
-    checkOpenOptions(modeOrOptions);
-    options = modeOrOptions as OpenOptions;
+    options = checkOpenOptions(modeOrOptions);
   }
 
   const rid = await opOpen(path, openMode as OpenMode, options);
@@ -118,7 +116,7 @@ export const stdin = new File(0);
 export const stdout = new File(1);
 export const stderr = new File(2);
 
-function checkOpenOptions(options: OpenOptions): void {
+function checkOpenOptions(options: OpenOptions): OpenOptions {
   if (Object.values(options).filter((val) => val === true).length === 0) {
     throw new Error("OpenOptions requires at least one option to be true");
   }
@@ -127,12 +125,15 @@ function checkOpenOptions(options: OpenOptions): void {
     throw new Error("'truncate' option requires 'write' option");
   }
 
-  const createOrCreateNewWithoutWriteOrAppend =
-    (options.create || options.createNew) && !(options.write || options.append);
+  const createOrCreateNew = options.create || options.createNew;
 
-  if (createOrCreateNewWithoutWriteOrAppend) {
+  const writeOrAppend = options.write || options.append;
+
+  if (createOrCreateNew && !writeOrAppend) {
     throw new Error(
       "'create' or 'createNew' options require 'write' or 'append' option"
     );
   }
+
+  return options;
 }

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -819,10 +819,15 @@ declare namespace Deno {
      * exist at the specified path. Requires write or append access to be
      * used. */
     create?: boolean;
-    /** Defaults to `false`. If set to `true`, no file, directory, or symlink is
-     * allowed to exist at the target location. Requires write or append
-     * access to be used. When createNew is set to `true`, create and truncate
-     * are ignored. */
+    /** Defaults to `false`. If set to `true`, an AlreadyExists error will be
+     * thrown if any file, directory, or symlink exists at the target location.
+     * This option is useful because it is atomic: otherwise between checking
+     * whether a file exists and creating a new one, the file may have been
+     * created by another process (a TOCTOU race condition/attack).
+     *
+     * Requires write or append access to be used.
+     *
+     * When createNew is set to `true`, create and truncate are ignored. */
     createNew?: boolean;
     /** Permissions to use if creating the file (defaults to `0o666`, before
      * the process's umask).
@@ -1572,9 +1577,13 @@ declare namespace Deno {
     /** Defaults to `false`. If set to `true`, will append to a file instead of
      * overwriting previous contents. */
     append?: boolean;
-    /** Defaults to `false`. If set to `true`, no file, directory, or symlink is
-     * allowed to exist at the target location. When createNew is set to `true`,
-     * create is ignored. */
+    /** Defaults to `false`. If set to `true`, an AlreadyExists error will be
+     * thrown if any file, directory, or symlink exists at the target location.
+     * This option is useful because it is atomic: otherwise between checking
+     * whether a file exists and creating a new one, the file may have been
+     * created by another process (a TOCTOU race condition/attack).
+     *
+     * When createNew is set to `true`, create is ignored. */
     createNew?: boolean;
     /** Sets the option to allow creating a new file, if one doesn't already
      * exist at the specified path (defaults to `true`). */

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1572,10 +1572,16 @@ declare namespace Deno {
     /** Defaults to `false`. If set to `true`, will append to a file instead of
      * overwriting previous contents. */
     append?: boolean;
+    /** Defaults to `false`. If set to `true`, no file, directory, or symlink is
+     * allowed to exist at the target location. When createNew is set to `true`,
+     * create is ignored. */
+    createNew?: boolean;
     /** Sets the option to allow creating a new file, if one doesn't already
      * exist at the specified path (defaults to `true`). */
     create?: boolean;
-    /** Permissions always applied to file. */
+    /** Permissions to use if creating the file (defaults to `0o666`, before
+     * the process's umask).
+     * Ignored on Windows. */
     mode?: number;
   }
 
@@ -1589,9 +1595,7 @@ declare namespace Deno {
    *       Deno.writeFileSync("hello3.txt", data, {mode: 0o777});  //set permissions on new file
    *       Deno.writeFileSync("hello4.txt", data, {append: true});  //add data to the end of the file
    *
-   * Requires `allow-write` permission, and `allow-read` if `options.create` is
-   * `false`.
-   */
+   * Requires `allow-write` permission. */
   export function writeFileSync(
     path: string,
     data: Uint8Array,
@@ -1608,8 +1612,7 @@ declare namespace Deno {
    *       await Deno.writeFile("hello3.txt", data, {mode: 0o777});  //set permissions on new file
    *       await Deno.writeFile("hello4.txt", data, {append: true});  //add data to the end of the file
    *
-   * Requires `allow-write` permission, and `allow-read` if `options.create` is `false`.
-   */
+   * Requires `allow-write` permission. */
   export function writeFile(
     path: string,
     data: Uint8Array,

--- a/cli/js/ops/fs/open.ts
+++ b/cli/js/ops/fs/open.ts
@@ -8,10 +8,6 @@ export interface OpenOptions {
   truncate?: boolean;
   create?: boolean;
   createNew?: boolean;
-  /** Permissions to use if creating the file (defaults to `0o666`, before
-   * the process's umask).
-   * It's an error to specify mode without also setting create or createNew to `true`.
-   * Ignored on Windows. */
   mode?: number;
 }
 

--- a/cli/js/tests/stat_test.ts
+++ b/cli/js/tests/stat_test.ts
@@ -200,13 +200,13 @@ unitTest(
     const tempDir = Deno.makeTempDirSync();
     const filename = tempDir + "/test.txt";
     const filename2 = tempDir + "/test2.txt";
-    Deno.writeFileSync(filename, data, { mode: 0o666 });
+    Deno.writeFileSync(filename, data, { mode: 0o626 });
     // Create a link
     Deno.linkSync(filename, filename2);
     const s = Deno.statSync(filename);
     assert(s.dev !== null);
     assert(s.ino !== null);
-    assertEquals(s.mode! & 0o666, 0o666);
+    assertEquals(s.mode! & 0o666, 0o626 & ~Deno.umask());
     assertEquals(s.nlink, 2);
     assert(s.uid !== null);
     assert(s.gid !== null);

--- a/cli/js/tests/write_file_test.ts
+++ b/cli/js/tests/write_file_test.ts
@@ -94,6 +94,36 @@ unitTest(
 
 unitTest(
   { perms: { read: true, write: true } },
+  function writeFileSyncCreateNew(): void {
+    const enc = new TextEncoder();
+    const data1 = enc.encode("Hello");
+    const data2 = enc.encode("world");
+    const dec = new TextDecoder("utf-8");
+    const filename = Deno.makeTempDirSync() + "/test.txt";
+    // file newly created
+    Deno.writeFileSync(filename, data1, { createNew: true });
+    const dataRead1 = Deno.readFileSync(filename);
+    const actual1 = dec.decode(dataRead1);
+    assertEquals("Hello", actual1);
+    // createNew: true but file exists
+    let caughtError = false;
+    try {
+      Deno.writeFileSync(filename, data2, { createNew: true });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtError);
+    // createNew: false and file exists
+    Deno.writeFileSync(filename, data2, { createNew: false });
+    const dataRead2 = Deno.readFileSync(filename);
+    const actual2 = dec.decode(dataRead2);
+    assertEquals("world", actual2);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
   function writeFileSyncAppend(): void {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -211,6 +241,36 @@ unitTest(
     const dec = new TextDecoder("utf-8");
     const actual = dec.decode(dataRead);
     assertEquals("Hello", actual);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function writeFileCreateNew(): Promise<void> {
+    const enc = new TextEncoder();
+    const data1 = enc.encode("Hello");
+    const data2 = enc.encode("world");
+    const dec = new TextDecoder("utf-8");
+    const filename = Deno.makeTempDirSync() + "/test.txt";
+    // file newly created
+    await Deno.writeFile(filename, data1, { createNew: true });
+    const dataRead1 = Deno.readFileSync(filename);
+    const actual1 = dec.decode(dataRead1);
+    assertEquals("Hello", actual1);
+    // createNew: true but file exists
+    let caughtError = false;
+    try {
+      await Deno.writeFile(filename, data2, { createNew: true });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtError);
+    // createNew: false and file exists
+    await Deno.writeFile(filename, data2, { createNew: false });
+    const dataRead2 = Deno.readFileSync(filename);
+    const actual2 = dec.decode(dataRead2);
+    assertEquals("world", actual2);
   }
 );
 

--- a/cli/js/tests/write_file_test.ts
+++ b/cli/js/tests/write_file_test.ts
@@ -18,8 +18,8 @@ unitTest(
 unitTest({ perms: { write: true } }, function writeFileSyncFail(): void {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  const filename = "/baddir/test.txt";
-  // The following should fail because /baddir doesn't exist (hopefully).
+  const filename = Deno.makeTempDirSync() + "/baddir/test.txt";
+  // The following should fail because /baddir doesn't exist
   let caughtError = false;
   try {
     Deno.writeFileSync(filename, data);
@@ -136,8 +136,8 @@ unitTest(
   async function writeFileNotFound(): Promise<void> {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
-    const filename = "/baddir/test.txt";
-    // The following should fail because /baddir doesn't exist (hopefully).
+    const filename = Deno.makeTempDirSync() + "/baddir/test.txt";
+    // The following should fail because /baddir doesn't exist
     let caughtError = false;
     try {
       await Deno.writeFile(filename, data);

--- a/cli/js/tests/write_file_test.ts
+++ b/cli/js/tests/write_file_test.ts
@@ -298,3 +298,65 @@ unitTest(
     assertEquals("Hello", actual);
   }
 );
+
+unitTest(
+  { perms: { read: true, write: true } },
+  function writeFileSyncDir(): void {
+    const enc = new TextEncoder();
+    const data = enc.encode("Hello");
+    const testDir = Deno.makeTempDirSync();
+    const dir = testDir + "/dir";
+    Deno.mkdirSync(dir);
+    let caughtError = false;
+    try {
+      Deno.writeFileSync(dir, data);
+    } catch (e) {
+      caughtError = true;
+      if (Deno.build.os == "win") {
+        assert(e instanceof Deno.errors.PermissionDenied);
+      } else {
+        assert(e.message.includes("Is a directory"));
+      }
+    }
+    assert(caughtError);
+    caughtError = false;
+    try {
+      Deno.writeFileSync(dir, data, { createNew: true });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtError);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function writeFileDir(): Promise<void> {
+    const enc = new TextEncoder();
+    const data = enc.encode("Hello");
+    const testDir = Deno.makeTempDirSync();
+    const dir = testDir + "/dir";
+    Deno.mkdirSync(dir);
+    let caughtError = false;
+    try {
+      await Deno.writeFile(dir, data);
+    } catch (e) {
+      caughtError = true;
+      if (Deno.build.os == "win") {
+        assert(e instanceof Deno.errors.PermissionDenied);
+      } else {
+        assert(e.message.includes("Is a directory"));
+      }
+    }
+    assert(caughtError);
+    caughtError = false;
+    try {
+      await Deno.writeFile(dir, data, { createNew: true });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtError);
+  }
+);

--- a/cli/js/tests/write_file_test.ts
+++ b/cli/js/tests/write_file_test.ts
@@ -52,10 +52,16 @@ unitTest(
       const enc = new TextEncoder();
       const data = enc.encode("Hello");
       const filename = Deno.makeTempDirSync() + "/test.txt";
-      Deno.writeFileSync(filename, data, { mode: 0o755 });
-      assertEquals(Deno.statSync(filename).mode! & 0o777, 0o755);
-      Deno.writeFileSync(filename, data, { mode: 0o666 });
-      assertEquals(Deno.statSync(filename).mode! & 0o777, 0o666);
+      Deno.writeFileSync(filename, data, { mode: 0o626 });
+      assertEquals(
+        Deno.statSync(filename).mode! & 0o777,
+        0o626 & ~Deno.umask()
+      );
+      Deno.writeFileSync(filename, data, { mode: 0o737 });
+      assertEquals(
+        Deno.statSync(filename).mode! & 0o777,
+        0o626 & ~Deno.umask()
+      );
     }
   }
 );
@@ -168,10 +174,16 @@ unitTest(
       const enc = new TextEncoder();
       const data = enc.encode("Hello");
       const filename = Deno.makeTempDirSync() + "/test.txt";
-      await Deno.writeFile(filename, data, { mode: 0o755 });
-      assertEquals(Deno.statSync(filename).mode! & 0o777, 0o755);
-      await Deno.writeFile(filename, data, { mode: 0o666 });
-      assertEquals(Deno.statSync(filename).mode! & 0o777, 0o666);
+      await Deno.writeFile(filename, data, { mode: 0o626 });
+      assertEquals(
+        Deno.statSync(filename).mode! & 0o777,
+        0o626 & ~Deno.umask()
+      );
+      await Deno.writeFile(filename, data, { mode: 0o737 });
+      assertEquals(
+        Deno.statSync(filename).mode! & 0o777,
+        0o626 & ~Deno.umask()
+      );
     }
   }
 );

--- a/cli/op_error.rs
+++ b/cli/op_error.rs
@@ -96,6 +96,10 @@ impl OpError {
     Self::new(ErrorKind::PermissionDenied, msg)
   }
 
+  pub fn already_exists(msg: String) -> OpError {
+    Self::new(ErrorKind::AlreadyExists, msg)
+  }
+
   pub fn bad_resource(msg: String) -> OpError {
     Self::new(ErrorKind::BadResource, msg)
   }


### PR DESCRIPTION
This is part of larger series of filesystem commits (#4017).

* We refactor the internal `checkOpenOptions` function in cli/js/files.ts to parallel the stucture it will have in some concurrent PRs (see #4569, which also compares to peer languages).

* We remove a stray doc comment that got left/merged into `cli/js/ops/fs/open.ts`. (Currently, we're only putting comments in `cli/js/lib.deno.*`.)

* File system operarations tend to fail in different circumstances on Unix and Windows, and to give different errors when they do. However, with only a little effort on our part, we can ensure that errors triggered by violation of a `createNew` option are always AlreadyExists on all platforms. We now do this (with minimal runtime cost) in `op_open`.

* We change the implementation of `writeFile` to use the `create` option of `open` and also expose the `createNew` option (again, see #4569). This has the effect that the `mode` applied by `writeFile` is now only for newly created files, and honors the process's umask. Also `writeFile` no longer requires `--allow-read` permissions. (See #4423 for discussion about whether/when this should be required by `create`/`createNew`.)

* In this PR, `writeFile` has a very simple version of the internal `checkOpenOptions` function, which one may be tempted to inline. I left it factored out because later PRs which we might consider expand would expand this function.

* We changed the `writeFile` tests to accommodate the new behavior described two bullet points ago. One of the relevant tests (which exercises both `writeFile` and `stat`) is in `cli/js/tests/stat_test.ts`.

* We also add tests for the new `createNew` functionality on `writeFile`.

* Now that we have a `makeTempDir`, one `writeFile` test no longer needs to assume that the test machine has no file at `/baddir`.

* We also add tests for when one tries to `writeFile` to a path where a directory already exists. This gives different errors on Windows and Unix, but we verify that when `createNew` is true, the error is always AlreadyExists.

* We haven't yet implemented creating symlinks on Windows. On Unix, we verify that `writeFile` gives an error when writing to a path that contains any symlink when `createNew` is true, and that the error is always AlreadyExists. Also that it gives a (different) error when `createNew` is false, but writing to a path that contains a symlink to a directory. Also that it succeeds (gives no error) when `createNew` is false, and writing to a path that contains a symlink to a file, or a dangling symlink. The symlinks are left in place and we write at their target location. (These behaviors aren't ones we specifically design for; they're just what follows out of the implementations we're currently using. It seems good to test for them so that we'll be alerted if they ever change.)