### PR TITLE
Publish deno typings on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,7 @@ jobs:
         run: |
           cd target/release
           zip -r deno-x86_64-unknown-linux-gnu.zip deno
+          ./deno types > lib.deno.d.ts
 
       - name: Pre-release (mac)
         if: startsWith(matrix.config.os, 'macOS') && matrix.config.kind == 'test_release'
@@ -187,6 +188,7 @@ jobs:
             target/release/deno-x86_64-unknown-linux-gnu.zip
             target/release/deno-x86_64-apple-darwin.zip
             target/release/deno_src.tar.gz
+            target/release/lib.deno.d.ts
           draft: true
 
       - name: Publish


### PR DESCRIPTION
Currently the only way to get typings for a certain version is by running `deno types` with the binary for that release. This is not feasible for the [auto generated docs](https://github.com/bartlomieju/deno_doc/) because it would have to have manually get typings for all possible Deno versions. Publishing them on release makes them available via a URL and thus solves this issue.