### PR TITLE
Add create/createNew options to Deno.copyFile

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -13,7 +13,7 @@ export { chmodSync, chmod } from "./ops/fs/chmod.ts";
 export { chownSync, chown } from "./ops/fs/chown.ts";
 export { transpileOnly, compile, bundle } from "./compiler/api.ts";
 export { inspect } from "./web/console.ts";
-export { copyFileSync, copyFile } from "./ops/fs/copy_file.ts";
+export { copyFileSync, copyFile, CopyFileOptions } from "./ops/fs/copy_file.ts";
 export {
   Diagnostic,
   DiagnosticCategory,

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1439,6 +1439,16 @@ declare namespace Deno {
    * Requires `allow-read` permission. */
   export function readdir(path: string): Promise<FileInfo[]>;
 
+  export interface CopyFileOptions {
+    /** Defaults to `false`. If set to `true`, no file, directory, or symlink is
+     * allowed to exist at the target location. When createNew is set to `true`,
+     * create is ignored. */
+    createNew?: boolean;
+    /** Sets the option to allow creating a new file, if one doesn't already
+     * exist at the specified path (defaults to `true`). */
+    create?: boolean;
+  }
+
   /** Synchronously copies the contents and permissions of one file to another
    * specified path, by default creating a new file if needed, else overwriting.
    * Fails if target path is a directory or is unwritable.
@@ -1447,7 +1457,11 @@ declare namespace Deno {
    *
    * Requires `allow-read` permission on fromPath.
    * Requires `allow-write` permission on toPath. */
-  export function copyFileSync(fromPath: string, toPath: string): void;
+  export function copyFileSync(
+    fromPath: string,
+    toPath: string,
+    options?: CopyFileOptions
+  ): void;
 
   /** Copies the contents and permissions of one file to another specified path,
    * by default creating a new file if needed, else overwriting. Fails if target
@@ -1457,7 +1471,11 @@ declare namespace Deno {
    *
    * Requires `allow-read` permission on fromPath.
    * Requires `allow-write` permission on toPath. */
-  export function copyFile(fromPath: string, toPath: string): Promise<void>;
+  export function copyFile(
+    fromPath: string,
+    toPath: string,
+    options?: CopyFileOptions
+  ): Promise<void>;
 
   /** Returns the full path destination of the named symbolic link.
    *

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1440,9 +1440,13 @@ declare namespace Deno {
   export function readdir(path: string): Promise<FileInfo[]>;
 
   export interface CopyFileOptions {
-    /** Defaults to `false`. If set to `true`, no file, directory, or symlink is
-     * allowed to exist at the target location. When createNew is set to `true`,
-     * create is ignored. */
+    /** Defaults to `false`. If set to `true`, an AlreadyExists error will be
+     * thrown if any file, directory, or symlink exists at the target location.
+     * This option is useful because it is atomic: otherwise between checking
+     * whether a file exists and creating a new one, the file may have been
+     * created by another process (a TOCTOU race condition/attack).
+     *
+     * When createNew is set to `true`, create is ignored. */
     createNew?: boolean;
     /** Sets the option to allow creating a new file, if one doesn't already
      * exist at the specified path (defaults to `true`). */

--- a/cli/js/ops/fs/copy_file.ts
+++ b/cli/js/ops/fs/copy_file.ts
@@ -1,13 +1,49 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { sendSync, sendAsync } from "../dispatch_json.ts";
 
-export function copyFileSync(fromPath: string, toPath: string): void {
-  sendSync("op_copy_file", { from: fromPath, to: toPath });
+export interface CopyFileOptions {
+  createNew?: boolean;
+  create?: boolean;
+}
+
+interface CopyFileArgs {
+  createNew: boolean;
+  create: boolean;
+  oldpath?: string;
+  newpath?: string;
+}
+
+export function copyFileSync(
+  fromPath: string,
+  toPath: string,
+  options: CopyFileOptions = {}
+): void {
+  const args = checkOptions(options);
+  args.oldpath = fromPath;
+  args.newpath = toPath;
+  sendSync("op_copy_file", args);
 }
 
 export async function copyFile(
   fromPath: string,
-  toPath: string
+  toPath: string,
+  options: CopyFileOptions = {}
 ): Promise<void> {
-  await sendAsync("op_copy_file", { from: fromPath, to: toPath });
+  const args = checkOptions(options);
+  args.oldpath = fromPath;
+  args.newpath = toPath;
+  await sendAsync("op_copy_file", args);
+}
+
+/** Check we have a valid combination of options.
+ *  @internal
+ */
+function checkOptions(options: CopyFileOptions): CopyFileArgs {
+  const createNew = options.createNew;
+  const create = options.create;
+  return {
+    ...options,
+    createNew: !!createNew,
+    create: createNew || create !== false,
+  };
 }

--- a/cli/js/tests/copy_file_test.ts
+++ b/cli/js/tests/copy_file_test.ts
@@ -314,3 +314,91 @@ unitTest(
     assertEquals(readFileString(to), "world");
   }
 );
+
+unitTest(
+  { perms: { read: true, write: true } },
+  function copyFileSyncDir(): void {
+    const testDir = Deno.makeTempDirSync();
+    const from = testDir + "/from.txt";
+    const dir = testDir + "/dir";
+    writeFileString(from, "Hello");
+    Deno.mkdirSync(dir);
+
+    let caughtError = false;
+    try {
+      Deno.copyFileSync(from, dir);
+    } catch (e) {
+      caughtError = true;
+      if (Deno.build.os == "win") {
+        assert(e instanceof Deno.errors.PermissionDenied);
+      } else {
+        assert(e.message.includes("Is a directory"));
+      }
+    }
+    assert(caughtError);
+    caughtError = false;
+    try {
+      Deno.copyFileSync(from, dir, { create: false });
+    } catch (e) {
+      caughtError = true;
+      if (Deno.build.os == "win") {
+        assert(e instanceof Deno.errors.PermissionDenied);
+      } else {
+        assert(e.message.includes("Is a directory"));
+      }
+    }
+    assert(caughtError);
+    caughtError = false;
+    try {
+      Deno.copyFileSync(from, dir, { createNew: true });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtError);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function copyFileDir(): Promise<void> {
+    const testDir = Deno.makeTempDirSync();
+    const from = testDir + "/from.txt";
+    const dir = testDir + "/dir";
+    writeFileString(from, "Hello");
+    Deno.mkdirSync(dir);
+
+    let caughtError = false;
+    try {
+      await Deno.copyFile(from, dir);
+    } catch (e) {
+      caughtError = true;
+      if (Deno.build.os == "win") {
+        assert(e instanceof Deno.errors.PermissionDenied);
+      } else {
+        assert(e.message.includes("Is a directory"));
+      }
+    }
+    assert(caughtError);
+    caughtError = false;
+    try {
+      await Deno.copyFile(from, dir, { create: false });
+    } catch (e) {
+      caughtError = true;
+      if (Deno.build.os == "win") {
+        assert(e instanceof Deno.errors.PermissionDenied);
+      } else {
+        assert(e.message.includes("Is a directory"));
+      }
+    }
+    assert(caughtError);
+    caughtError = false;
+    try {
+      await Deno.copyFile(from, dir, { createNew: true });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtError);
+  }
+);

--- a/cli/op_error.rs
+++ b/cli/op_error.rs
@@ -96,6 +96,10 @@ impl OpError {
     Self::new(ErrorKind::PermissionDenied, msg)
   }
 
+  pub fn already_exists(msg: String) -> OpError {
+    Self::new(ErrorKind::AlreadyExists, msg)
+  }
+
   pub fn bad_resource(msg: String) -> OpError {
     Self::new(ErrorKind::BadResource, msg)
   }


### PR DESCRIPTION
We add `create` and `createNew` options to `copyFile`, paralleling those for `open` and `writeFile`. See #4569, which discusses how this relates to some concurrent PRs, and also compares to peer languages. As mentioned there, `Deno.copyFile` with `createNew: true` corresponds to Node's `fs.copyFile` with the `COPYFILE_EXCL` flag, and to the POSIX shell command `cp -Tn`.

This is part of larger series of filesystem commits (#4017).

* When possible, we use the fastest implementation provided by Rust (`std::fs::copy`; `create` must be true and `createNew` false). In other cases, for the operations to still be atomic, we need to open two files and copy the data using `std::io::copy`. That may be slower because it requires copying data out of kernel space.

* Note for the future: if we ever shift to a `tokio::fs` version of `op_copy_file` (see #4188), I discovered that Tokio's implementation of this always uses the slower path, via `tokio::io::copy`. It also wasn't copying permissions correctly. (See https://github.com/tokio-rs/tokio/issues/2341.)

    (PRs I plan to propose later make use of some Unix-specific functionality when available, which means bypassing Tokio here anyway.)

* As with `open` in #4580, this PR makes a special effort to ensure that the errors triggered by `createNew: true` are always AlreadyExists. We also ensure that the errors triggered by `create: false` are always NotFound. In other cases, we let the different platforms generate their different errors. (For example, on Unix attempting to copy a file onto a directory gives a "Is a directory" error, but on Windows it's a PermissionDenied.)

* This PR also makes an effort to ensure that when the source path is a directory, we get a predictable error, regardless of the presence of `create` or `createNew` options governing the destination path. That is, the check on the source takes priority.

    (I didn't set out aiming for any specific pattern of errors. Just hoped to find minimal interventions that did the most towards cleaning up the messy complexity we were getting of which errors were reported how, before this PR, and then the different messy complexity we were getting after introducing the other changes in this PR. I think I found a good balance. It involves changing one Unix error and one Windows error. See comments in op_copy_file.)

* As with `writeFile` in #4580, `copyFile` has a very simple version of the internal `checkOpenOptions` function, which one may be tempted to inline. I left it factored out because later PRs which we might consider expand would expand this function.

* We refactor some `copyFile` tests to avoid repetition (`assertFile` function).

* We add tests of the new `create` and `createNew` functionality. We also add tests documenting the different errors that Windows and Unix give when trying to copy onto directories. (It would be good to know if/when we ever build on a system where these are different.) And verifying that the errors are always AlreadyExists if triggered by `createNew` being true.

* We haven't yet implemented creating symlinks on Windows. On Unix, we verify that `copyFile` gives an error when writing to a path that contains any *valid* symlink when `createNew` is `true`, and that the error is always `AlreadyExists`. Also that it gives a (different) error when `createNew` is false, but writing to a path that contains a symlink to a directory. If the options are `{ create: false, createNew: false }`, and the target is a dangling symlink, the error is `NotFound.

* The underlying Rust machinery we rely on *doesn't* give an error when `create` or `createNew` are `true`, but writing to a path that contains a *dangling* symlink. Instead it creates a new file at the target destination, and copies the file there. (It "copies through" the dangling symlink.) Python's `shutil.copy` and Node's `fs.copyFileSync` also do this. The shell `cp` operation on the other hand, won't perform the copy if the destination is a dangling symlink. We'd have to make special efforts (with runtime cost) to match the shell, and I haven't done that here.

* Some of the `copyFile` tests in our codebase rely on the older behavior of `writeFile` wrt `mode`, and need to be updated after #4580 lands. Whichever of this PR or #4580 is merged first, I can push a commit to the other PR that updates those copyFile tests.