### PR TITLE
remove `Send` trait requirement from the `Resource` trait

### DIFF
--- a/core/resources.rs
+++ b/core/resources.rs
@@ -80,8 +80,8 @@ impl ResourceTable {
 /// The only thing it does is implementing `Downcast` trait
 /// that allows to cast resource to concrete type in `TableResource::get`
 /// and `TableResource::get_mut` methods.
-pub trait Resource: Downcast + Any + Send {}
-impl<T> Resource for T where T: Downcast + Any + Send {}
+pub trait Resource: Downcast + Any {}
+impl<T> Resource for T where T: Downcast + Any {}
 impl_downcast!(Resource);
 
 #[cfg(test)]


### PR DESCRIPTION
Pretty sure this isn't needed anymore.
