### PR TITLE
Add create/createNew and mode options to Deno.truncate

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -108,7 +108,7 @@ export { signal, signals, Signal, SignalStream } from "./signals.ts";
 export { statSync, lstatSync, stat, lstat } from "./ops/fs/stat.ts";
 export { symlinkSync, symlink } from "./ops/fs/symlink.ts";
 export { connectTLS, listenTLS } from "./tls.ts";
-export { truncateSync, truncate } from "./ops/fs/truncate.ts";
+export { truncateSync, truncate, TruncateOptions } from "./ops/fs/truncate.ts";
 export { isatty, setRaw } from "./ops/tty.ts";
 export { umask } from "./ops/fs/umask.ts";
 export { utimeSync, utime } from "./ops/fs/utime.ts";

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1768,6 +1768,16 @@ declare namespace Deno {
     constructor(state: PermissionState);
   }
 
+  export interface TruncateOptions {
+    /** Defaults to `false`. If set to `true`, no file, directory, or symlink is
+     * allowed to exist at the target location. When createNew is set to `true`,
+     * create is ignored. */
+    createNew?: boolean;
+    /** Sets the option to allow creating a new file, if one doesn't already
+     * exist at the specified path (defaults to `true`). */
+    create?: boolean;
+  }
+
   /** Synchronously truncates or extends the specified file, to reach the
    * specified `len`.  If `len` is not specified then the entire file contents
    * are truncated.
@@ -1783,7 +1793,11 @@ declare namespace Deno {
    *       console.log(new TextDecoder().decode(data));
    *
    * Requires `allow-write` permission. */
-  export function truncateSync(name: string, len?: number): void;
+  export function truncateSync(
+    path: string,
+    len?: number,
+    options?: TruncateOptions
+  ): void;
 
   /** Truncates or extends the specified file, to reach the specified `len`. If
    * `len` is not specified then the entire file contents are truncated.
@@ -1799,7 +1813,11 @@ declare namespace Deno {
    *       console.log(new TextDecoder().decode(data));  //"Hello W"
    *
    * Requires `allow-write` permission. */
-  export function truncate(name: string, len?: number): Promise<void>;
+  export function truncate(
+    path: string,
+    len?: number,
+    options?: TruncateOptions
+  ): Promise<void>;
 
   export interface AsyncHandler {
     (msg: Uint8Array): void;

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1776,6 +1776,10 @@ declare namespace Deno {
     /** Sets the option to allow creating a new file, if one doesn't already
      * exist at the specified path (defaults to `true`). */
     create?: boolean;
+    /** Permissions to use if creating the file (defaults to `0o666`, before
+     * the process's umask).
+     * Ignored on Windows. */
+    mode?: number;
   }
 
   /** Synchronously truncates or extends the specified file, to reach the

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1769,9 +1769,13 @@ declare namespace Deno {
   }
 
   export interface TruncateOptions {
-    /** Defaults to `false`. If set to `true`, no file, directory, or symlink is
-     * allowed to exist at the target location. When createNew is set to `true`,
-     * create is ignored. */
+    /** Defaults to `false`. If set to `true`, an AlreadyExists error will be
+     * thrown if any file, directory, or symlink exists at the target location.
+     * This option is useful because it is atomic: otherwise between checking
+     * whether a file exists and creating a new one, the file may have been
+     * created by another process (a TOCTOU race condition/attack).
+     *
+     * When createNew is set to `true`, create is ignored. */
     createNew?: boolean;
     /** Sets the option to allow creating a new file, if one doesn't already
      * exist at the specified path (defaults to `true`). */

--- a/cli/js/ops/fs/truncate.ts
+++ b/cli/js/ops/fs/truncate.ts
@@ -1,6 +1,11 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { sendSync, sendAsync } from "../dispatch_json.ts";
 
+export interface TruncateOptions {
+  createNew?: boolean;
+  create?: boolean;
+}
+
 function coerceLen(len?: number): number {
   if (!len) {
     return 0;
@@ -13,10 +18,44 @@ function coerceLen(len?: number): number {
   return len;
 }
 
-export function truncateSync(path: string, len?: number): void {
-  sendSync("op_truncate", { path, len: coerceLen(len) });
+interface TruncateArgs {
+  createNew: boolean;
+  create: boolean;
+  path?: string;
+  len?: number;
 }
 
-export async function truncate(path: string, len?: number): Promise<void> {
-  await sendAsync("op_truncate", { path, len: coerceLen(len) });
+export function truncateSync(
+  path: string,
+  len?: number,
+  options: TruncateOptions = {}
+): void {
+  const args = checkOptions(options);
+  args.path = path;
+  args.len = coerceLen(len);
+  sendSync("op_truncate", args);
+}
+
+export async function truncate(
+  path: string,
+  len?: number,
+  options: TruncateOptions = {}
+): Promise<void> {
+  const args = checkOptions(options);
+  args.path = path;
+  args.len = coerceLen(len);
+  await sendAsync("op_truncate", args);
+}
+
+/** Check we have a valid combination of options.
+ *  @internal
+ */
+function checkOptions(options: TruncateOptions): TruncateArgs {
+  const createNew = options.createNew;
+  const create = options.create;
+  return {
+    ...options,
+    createNew: !!createNew,
+    create: createNew || create !== false,
+  };
 }

--- a/cli/js/ops/fs/truncate.ts
+++ b/cli/js/ops/fs/truncate.ts
@@ -4,6 +4,7 @@ import { sendSync, sendAsync } from "../dispatch_json.ts";
 export interface TruncateOptions {
   createNew?: boolean;
   create?: boolean;
+  mode?: number;
 }
 
 function coerceLen(len?: number): number {
@@ -21,6 +22,7 @@ function coerceLen(len?: number): number {
 interface TruncateArgs {
   createNew: boolean;
   create: boolean;
+  mode?: number;
   path?: string;
   len?: number;
 }

--- a/cli/js/tests/truncate_test.ts
+++ b/cli/js/tests/truncate_test.ts
@@ -197,3 +197,61 @@ unitTest(
     assertFile(filename, 10);
   }
 );
+
+unitTest(
+  { perms: { read: true, write: true } },
+  function truncateSyncDir(): void {
+    const testDir = Deno.makeTempDirSync();
+    const dir = testDir + "/dir";
+    Deno.mkdirSync(dir);
+    let caughtError = false;
+    try {
+      Deno.truncateSync(dir, 0);
+    } catch (e) {
+      caughtError = true;
+      if (Deno.build.os == "win") {
+        assert(e instanceof Deno.errors.PermissionDenied);
+      } else {
+        assert(e.message.includes("Is a directory"));
+      }
+    }
+    assert(caughtError);
+    caughtError = false;
+    try {
+      Deno.truncateSync(dir, 0, { createNew: true });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtError);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function truncateDir(): Promise<void> {
+    const testDir = Deno.makeTempDirSync();
+    const dir = testDir + "/dir";
+    Deno.mkdirSync(dir);
+    let caughtError = false;
+    try {
+      await Deno.truncate(dir, 0);
+    } catch (e) {
+      caughtError = true;
+      if (Deno.build.os == "win") {
+        assert(e instanceof Deno.errors.PermissionDenied);
+      } else {
+        assert(e.message.includes("Is a directory"));
+      }
+    }
+    assert(caughtError);
+    caughtError = false;
+    try {
+      await Deno.truncate(dir, 0, { createNew: true });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtError);
+  }
+);

--- a/cli/js/tests/truncate_test.ts
+++ b/cli/js/tests/truncate_test.ts
@@ -111,3 +111,89 @@ unitTest({ perms: { write: false } }, async function truncatePerm(): Promise<
   assert(err instanceof Deno.errors.PermissionDenied);
   assertEquals(err.name, "PermissionDenied");
 });
+
+unitTest(
+  { perms: { read: true, write: true } },
+  function truncateSyncCreate(): void {
+    const filename = Deno.makeTempDirSync() + "/test.txt";
+    let caughtError = false;
+    // if create turned off, the file won't be created
+    try {
+      Deno.truncateSync(filename, 0, { create: false });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.NotFound);
+    }
+    assert(caughtError);
+
+    // Turn on create, should have no error
+    Deno.truncateSync(filename, 10, { create: true });
+    assertFile(filename, 10);
+    Deno.truncateSync(filename, 0, { create: false });
+    assertFile(filename, 0);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function truncateCreate(): Promise<void> {
+    const filename = Deno.makeTempDirSync() + "/test.txt";
+    let caughtError = false;
+    // if create turned off, the file won't be created
+    try {
+      await Deno.truncate(filename, 0, { create: false });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.NotFound);
+    }
+    assert(caughtError);
+
+    // Turn on create, should have no error
+    await Deno.truncate(filename, 10, { create: true });
+    assertFile(filename, 10);
+    await Deno.truncate(filename, 0, { create: false });
+    assertFile(filename, 0);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  function truncateSyncCreateNew(): void {
+    const filename = Deno.makeTempDirSync() + "/test.txt";
+    // file newly created
+    Deno.truncateSync(filename, 0, { createNew: true });
+    // createNew: true but file exists
+    let caughtError = false;
+    try {
+      Deno.truncateSync(filename, 0, { createNew: true });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtError);
+    // createNew: false and file exists
+    Deno.truncateSync(filename, 10, { createNew: false });
+    assertFile(filename, 10);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function truncateCreateNew(): Promise<void> {
+    const filename = Deno.makeTempDirSync() + "/test.txt";
+    // file newly created
+    await Deno.truncate(filename, 0, { createNew: true });
+    // createNew: true but file exists
+    let caughtError = false;
+    try {
+      await Deno.truncate(filename, 0, { createNew: true });
+    } catch (e) {
+      caughtError = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtError);
+    // createNew: false and file exists
+    await Deno.truncate(filename, 10, { createNew: false });
+    assertFile(filename, 10);
+  }
+);

--- a/cli/op_error.rs
+++ b/cli/op_error.rs
@@ -96,6 +96,10 @@ impl OpError {
     Self::new(ErrorKind::PermissionDenied, msg)
   }
 
+  pub fn already_exists(msg: String) -> OpError {
+    Self::new(ErrorKind::AlreadyExists, msg)
+  }
+
   pub fn bad_resource(msg: String) -> OpError {
     Self::new(ErrorKind::BadResource, msg)
   }


### PR DESCRIPTION
We add `create` and `createNew` options to `truncate`, paralleling those for `open`, `writeFile`, and `copyFile`. See #4569, which discusses how this relates to some concurrent PRs, and also compares to peer languages.

We also add a `mode` option (originally proposed in #4288, but unable to be tested there because the ability for `truncate` to create new files hadn't yet been pushed). As with `mkdir`, `open`, and `writeFile` (after #4580), the mode is applied only when a new file is created.  Defaults to 0o666.

This is part of larger series of filesystem commits (#4017).

* The `create` option here defaults to `true`, matching its default on other operations where it's present. But note that the previous behavior of `truncate` corresponds to having `create` be `false`.

* A question was floated earlier (https://github.com/denoland/deno/pull/4288#discussion_r389418696) about whether to make the (optional) `len` parameter (defaults to `0`) part of the `options?` parameter, rather than a positional parameter. I haven't implemented that here, just left the status quo.

* As with `writeFile` in #4580 and `copyFile` in #4584, `truncate` has a very simple version of the internal `checkOpenOptions` function, which one may be tempted to inline. I left it factored out because later PRs which we might consider expand would expand this function.

* As with `open` and `copyFile`, this PR makes a special effort to ensure that the errors triggered by `createNew: true` are always AlreadyExists. This requires changing one Windows error.

* We add tests for the new `create` and `createNew` options, and verifying that the `mode` applied is subject to the process's umask.

* We also add tests documenting the different errors that Windows and Unix give when trying to truncate an existing directory. (It would be good to know if/when we ever build on a system where these are different.) And verifying that the errors are always AlreadyExists if triggered by `createNew` being true.

* We haven't yet implemented creating symlinks on Windows. On Unix, we verify that `truncate` gives an AlreadyExists error when `createNew` is true and any symlink is at the specified path. And that it gives a (different) error when `createNew` is false, but a symlink to a directory is at the specified path.

* `truncate` succeeds when `createNew` is false, but a symlink to a file or a dangling link is at the specified path. In both cases, it creates/truncates a file at the path the symlink targets.