### PR TITLE
Add createNew option to Deno.rename

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -102,7 +102,7 @@ export { readFileSync, readFile } from "./read_file.ts";
 export { readlinkSync, readlink } from "./ops/fs/read_link.ts";
 export { realpathSync, realpath } from "./ops/fs/realpath.ts";
 export { removeSync, remove, RemoveOptions } from "./ops/fs/remove.ts";
-export { renameSync, rename } from "./ops/fs/rename.ts";
+export { renameSync, rename, RenameOptions } from "./ops/fs/rename.ts";
 export { resources, close } from "./ops/resources.ts";
 export { signal, signals, Signal, SignalStream } from "./signals.ts";
 export { statSync, lstatSync, stat, lstat } from "./ops/fs/stat.ts";

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1289,8 +1289,11 @@ declare namespace Deno {
    *
    *       Deno.renameSync("old/path", "new/path");
    *
-   * Throws error if attempting to rename to a directory which exists and is not
-   * empty.
+   * On Unix, this operation is like `mv -T` in not following symlinks at
+   * either path.
+   *
+   * It varies between platforms when the operation throws errors, and if so what
+   * they are. It's always an error to rename anything to a non-empty directory.
    *
    * Requires `allow-read` and `allow-write` permissions. */
   export function renameSync(
@@ -1306,8 +1309,11 @@ declare namespace Deno {
    *
    *       await Deno.rename("old/path", "new/path");
    *
-   * Throws error if attempting to rename to a directory which exists and is not
-   * empty.
+   * On Unix, this operation is like `mv -T` in not following symlinks at
+   * either path.
+   *
+   * It varies between platforms when the operation throws errors, and if so what
+   * they are. It's always an error to rename anything to a non-empty directory.
    *
    * Requires `allow-read` and `allow-write` permission. */
   export function rename(

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1276,6 +1276,12 @@ declare namespace Deno {
    * Requires `allow-write` permission. */
   export function remove(path: string, options?: RemoveOptions): Promise<void>;
 
+  export interface RenameOptions {
+    /** Defaults to `false`. If set to `true`, no file, directory, or symlink is
+     * allowed to exist at the target location. */
+    createNew?: boolean;
+  }
+
   /** Synchronously renames (moves) `oldpath` to `newpath`. Paths may be files or
    * directories.  If `newpath` already exists and is not a directory,
    * `renameSync()` replaces it. OS-specific restrictions may apply when
@@ -1287,7 +1293,11 @@ declare namespace Deno {
    * empty.
    *
    * Requires `allow-read` and `allow-write` permissions. */
-  export function renameSync(oldpath: string, newpath: string): void;
+  export function renameSync(
+    oldpath: string,
+    newpath: string,
+    options?: RenameOptions
+  ): void;
 
   /** Renames (moves) `oldpath` to `newpath`.  Paths may be files or directories.
    * If `newpath` already exists and is not a directory, `rename()` replaces it.
@@ -1299,8 +1309,12 @@ declare namespace Deno {
    * Throws error if attempting to rename to a directory which exists and is not
    * empty.
    *
-   * Requires `allow-read` and `allow-write`. */
-  export function rename(oldpath: string, newpath: string): Promise<void>;
+   * Requires `allow-read` and `allow-write` permission. */
+  export function rename(
+    oldpath: string,
+    newpath: string,
+    options?: RenameOptions
+  ): Promise<void>;
 
   /** Synchronously reads and returns the entire contents of a file as an array
    * of bytes. `TextDecoder` can be used to transform the bytes to string if

--- a/cli/js/ops/fs/rename.ts
+++ b/cli/js/ops/fs/rename.ts
@@ -1,10 +1,44 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { sendSync, sendAsync } from "../dispatch_json.ts";
 
-export function renameSync(oldpath: string, newpath: string): void {
-  sendSync("op_rename", { oldpath, newpath });
+export interface RenameOptions {
+  createNew?: boolean;
 }
 
-export async function rename(oldpath: string, newpath: string): Promise<void> {
-  await sendAsync("op_rename", { oldpath, newpath });
+interface RenameArgs {
+  oldpath?: string;
+  newpath?: string;
+  createNew: boolean;
+}
+
+export function renameSync(
+  oldpath: string,
+  newpath: string,
+  options: RenameOptions = {}
+): void {
+  const args = checkOptions(options);
+  args.oldpath = oldpath;
+  args.newpath = newpath;
+  sendSync("op_rename", args);
+}
+
+export async function rename(
+  oldpath: string,
+  newpath: string,
+  options: RenameOptions = {}
+): Promise<void> {
+  const args = checkOptions(options);
+  args.oldpath = oldpath;
+  args.newpath = newpath;
+  await sendAsync("op_rename", args);
+}
+
+/** Check we have a valid combination of options.
+ *  @internal
+ */
+function checkOptions(options: RenameOptions): RenameArgs {
+  const createNew = options.createNew;
+  return {
+    createNew: !!createNew,
+  };
 }

--- a/cli/js/tests/rename_test.ts
+++ b/cli/js/tests/rename_test.ts
@@ -14,6 +14,11 @@ function assertMissing(path: string): void {
   assertEquals(info, undefined);
 }
 
+function assertFile(path: string): void {
+  const info = Deno.lstatSync(path);
+  assert(info.isFile());
+}
+
 function assertDirectory(path: string, mode?: number): void {
   const info = Deno.lstatSync(path);
   assert(info.isDirectory());
@@ -77,5 +82,161 @@ unitTest(
     await Deno.rename(oldpath, newpath);
     assertDirectory(newpath);
     assertMissing(oldpath);
+  }
+);
+
+function readFileString(filename: string): string {
+  const dataRead = Deno.readFileSync(filename);
+  const dec = new TextDecoder("utf-8");
+  return dec.decode(dataRead);
+}
+
+function writeFileString(filename: string, s: string): void {
+  const enc = new TextEncoder();
+  const data = enc.encode(s);
+  Deno.writeFileSync(filename, data, { mode: 0o666 });
+}
+
+unitTest(
+  { perms: { read: true, write: true } },
+  function renameSyncCreateNewFile(): void {
+    const testDir = Deno.makeTempDirSync();
+    const oldfile = testDir + "/oldfile";
+    const goodpath = testDir + "/goodpath";
+    const badpath = testDir + "/badpath";
+    writeFileString(oldfile, "Hello");
+    writeFileString(badpath, "");
+    Deno.renameSync(oldfile, goodpath, { createNew: true });
+    assertMissing(oldfile);
+    assertFile(goodpath);
+    assertEquals("Hello", readFileString(goodpath));
+
+    let caughtErr = false;
+    try {
+      Deno.renameSync(goodpath, badpath, { createNew: true });
+    } catch (e) {
+      caughtErr = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtErr);
+
+    Deno.renameSync(goodpath, badpath, { createNew: false });
+    assertMissing(goodpath);
+    assertFile(badpath);
+    assertEquals("Hello", readFileString(badpath));
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function renameCreateNewFile(): Promise<void> {
+    const testDir = Deno.makeTempDirSync();
+    const oldfile = testDir + "/oldfile";
+    const goodpath = testDir + "/goodpath";
+    const badpath = testDir + "/badpath";
+    writeFileString(oldfile, "Hello");
+    writeFileString(badpath, "");
+    await Deno.rename(oldfile, goodpath, { createNew: true });
+    assertMissing(oldfile);
+    assertFile(goodpath);
+    assertEquals("Hello", readFileString(goodpath));
+
+    let caughtErr = false;
+    try {
+      await Deno.rename(goodpath, badpath, { createNew: true });
+    } catch (e) {
+      caughtErr = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtErr);
+
+    await Deno.rename(goodpath, badpath, { createNew: false });
+    assertMissing(goodpath);
+    assertFile(badpath);
+    assertEquals("Hello", readFileString(badpath));
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  function renameSyncCreateNewDir(): void {
+    const testDir = Deno.makeTempDirSync();
+    const olddir = testDir + "/olddir";
+    const goodpath = testDir + "/goodpath";
+    const badpath = testDir + "/badpath";
+    Deno.mkdirSync(olddir, { mode: 0o701 });
+    Deno.mkdirSync(badpath);
+
+    Deno.renameSync(olddir, goodpath, { createNew: true });
+    assertMissing(olddir);
+    assertDirectory(goodpath, 0o701);
+
+    let caughtErr = false;
+    try {
+      Deno.renameSync(goodpath, badpath, { createNew: true });
+    } catch (e) {
+      caughtErr = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtErr);
+
+    if (Deno.build.os === "win") {
+      // Windows won't overwrite a directory
+      caughtErr = false;
+      try {
+        Deno.renameSync(goodpath, badpath, { createNew: false });
+      } catch (e) {
+        caughtErr = true;
+        assert(e instanceof Deno.errors.PermissionDenied);
+      }
+      assert(caughtErr);
+      Deno.removeSync(badpath);
+    }
+
+    Deno.renameSync(goodpath, badpath, { createNew: false });
+    assertMissing(goodpath);
+    assertDirectory(badpath, 0o701);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function renameCreateNewDir(): Promise<void> {
+    const testDir = Deno.makeTempDirSync();
+    const olddir = testDir + "/olddir";
+    const goodpath = testDir + "/goodpath";
+    const badpath = testDir + "/badpath";
+    Deno.mkdirSync(olddir, { mode: 0o701 });
+    Deno.mkdirSync(badpath);
+
+    await Deno.rename(olddir, goodpath, { createNew: true });
+    assertMissing(olddir);
+    assertDirectory(goodpath, 0o701);
+
+    let caughtErr = false;
+    try {
+      await Deno.rename(goodpath, badpath, { createNew: true });
+    } catch (e) {
+      caughtErr = true;
+      assert(e instanceof Deno.errors.AlreadyExists);
+    }
+    assert(caughtErr);
+
+    if (Deno.build.os === "win") {
+      // Windows won't overwrite a directory
+      caughtErr = false;
+      try {
+        await Deno.rename(goodpath, badpath, { createNew: false });
+      } catch (e) {
+        caughtErr = true;
+        assert(e instanceof Deno.errors.PermissionDenied);
+      }
+      assert(caughtErr);
+      Deno.removeSync(badpath);
+    }
+
+    await Deno.rename(goodpath, badpath, { createNew: false });
+    assertMissing(goodpath);
+    assertDirectory(badpath, 0o701);
   }
 );

--- a/cli/op_error.rs
+++ b/cli/op_error.rs
@@ -96,6 +96,10 @@ impl OpError {
     Self::new(ErrorKind::PermissionDenied, msg)
   }
 
+  pub fn already_exists(msg: String) -> OpError {
+    Self::new(ErrorKind::AlreadyExists, msg)
+  }
+
   pub fn bad_resource(msg: String) -> OpError {
     Self::new(ErrorKind::BadResource, msg)
   }


### PR DESCRIPTION
We add a `createNew` option to `rename`, paralleling the one for `open`, `writeFile`, `copyFile,` and `truncate`. See #4569, which discusses how this relates to some concurrent PRs, and also compares to peer languages. As mentioned there, `Deno.rename` with `createNew: true` corresponds to the POSIX shell command `mv -Tn`.

This is part of larger series of filesystem commits (#4017).

* When the source is a directory, the recipe for getting the `createNew` guarantee atomically is complex, and varies between platforms. (On Unix, you can move a directory onto an empty directory but not a file; on Windows you can move a directory onto a file but not a directory.) This is why it seemed desirable to implement the option in our core, alongside the similar functionality for the operations that create and copy files.

* As with `open`, `copyFile`, and `truncate`, this PR makes a special effort to ensure that the errors triggered by `createNew: true` are always AlreadyExists. This requires changing one Windows error.

* As with `writeFile` in #4580, `copyFile` in #4584, and `truncate` in #4587, `rename` has a very simple version of the internal `checkOptions` function, which one may be tempted to inline. I left it factored out because later PRs which we might consider expand would expand this function.

* We refactor some tests to avoid repetition (functions `assertDirectory` and `assertMissing`). We also add tests for the new `createNew` functionality, both when the renamed source is a file and when it's a directory.

* We add tests documenting in which conditions the operation will succeed, and in which it will fail (and with what errors) on each of Windows and Unix. We should be alerted if these expectations ever later change.

    On Unix: moving a file to directory fails, moving a directory to a file or a non-empty directory fails. Moving a directory to any symlink (even one to an existing directory) also fails. Moving a file to a symlink overwrites the link.

    On Windows: moving a file to a directory fails, moving a directory to any directory fails. Moving a directory to a file overwrites the file.