### PR TITLE
`deno doc` parses super-class names

### DIFF
--- a/cli/doc/class.rs
+++ b/cli/doc/class.rs
@@ -60,6 +60,7 @@ pub struct ClassDef {
   pub constructors: Vec<ClassConstructorDef>,
   pub properties: Vec<ClassPropertyDef>,
   pub methods: Vec<ClassMethodDef>,
+  pub super_class: Option<String>,
 }
 
 fn prop_name_to_string(
@@ -84,6 +85,18 @@ pub fn get_doc_for_class_decl(
   let mut constructors = vec![];
   let mut methods = vec![];
   let mut properties = vec![];
+
+  let super_class: Option<String> = match &class_decl.class.super_class {
+    Some(boxed) => {
+      use swc_ecma_ast::Expr;
+      let expr: &Expr = &**boxed;
+      match expr {
+        Expr::Ident(ident) => Some(ident.sym.to_string()),
+        _ => None,
+      }
+    }
+    None => None,
+  };
 
   for member in &class_decl.class.body {
     use swc_ecma_ast::ClassMember::*;
@@ -198,6 +211,7 @@ pub fn get_doc_for_class_decl(
   let class_name = class_decl.ident.sym.to_string();
   let class_def = ClassDef {
     is_abstract: class_decl.class.is_abstract,
+    super_class,
     constructors,
     properties,
     methods,

--- a/cli/doc/printer.rs
+++ b/cli/doc/printer.rs
@@ -428,14 +428,15 @@ fn format_function_signature(node: &doc::DocNode, indent: i64) -> String {
 
 fn format_class_signature(node: &doc::DocNode, indent: i64) -> String {
   let class_def = node.class_def.clone().unwrap();
-  let mut super_suffix = String::from("");
-  if class_def.super_class.is_some() {
-    super_suffix = format!(
+  let super_suffix = if class_def.super_class.is_some() {
+    format!(
       " {} {}",
       colors::magenta("extends".to_string()),
       colors::bold(class_def.super_class.unwrap())
-    );
-  }
+    )
+  } else {
+    String::from("")
+  };
 
   add_indent(
     format!(

--- a/cli/doc/printer.rs
+++ b/cli/doc/printer.rs
@@ -428,11 +428,11 @@ fn format_function_signature(node: &doc::DocNode, indent: i64) -> String {
 
 fn format_class_signature(node: &doc::DocNode, indent: i64) -> String {
   let class_def = node.class_def.clone().unwrap();
-  let super_suffix = if class_def.super_class.is_some() {
+  let super_suffix = if let Some(super_class) = class_def.super_class {
     format!(
       " {} {}",
       colors::magenta("extends".to_string()),
-      colors::bold(class_def.super_class.unwrap())
+      super_class
     )
   } else {
     String::from("")

--- a/cli/doc/printer.rs
+++ b/cli/doc/printer.rs
@@ -427,11 +427,22 @@ fn format_function_signature(node: &doc::DocNode, indent: i64) -> String {
 }
 
 fn format_class_signature(node: &doc::DocNode, indent: i64) -> String {
+  let class_def = node.class_def.clone().unwrap();
+  let mut super_suffix = String::from("");
+  if class_def.super_class.is_some() {
+    super_suffix = format!(
+      " {} {}",
+      colors::magenta("extends".to_string()),
+      colors::bold(class_def.super_class.unwrap())
+    );
+  }
+
   add_indent(
     format!(
-      "{} {}\n",
+      "{} {}{}\n",
       colors::magenta("class".to_string()),
-      colors::bold(node.name.clone())
+      colors::bold(node.name.clone()),
+      super_suffix
     ),
     indent,
   )

--- a/cli/doc/printer.rs
+++ b/cli/doc/printer.rs
@@ -432,7 +432,7 @@ fn format_class_signature(node: &doc::DocNode, indent: i64) -> String {
     format!(
       " {} {}",
       colors::magenta("extends".to_string()),
-      super_class
+      colors::bold(super_class)
     )
   } else {
     String::from("")

--- a/cli/doc/tests.rs
+++ b/cli/doc/tests.rs
@@ -309,7 +309,7 @@ export class Foobar extends Fizz implements Buzz {
 
   assert!(
     colors::strip_ansi_codes(super::printer::format(entries).as_str())
-      .contains("class Foobar")
+      .contains("class Foobar extends Fizz")
   );
 }
 

--- a/cli/doc/tests.rs
+++ b/cli/doc/tests.rs
@@ -8,9 +8,9 @@ use serde_json::json;
 fn export_fn() {
   let source_code = r#"/**
 * Hello there, this is a multiline JSdoc.
-* 
+*
 * It has many lines
-* 
+*
 * Or not that many?
 */
 export function foo(a: string, b: number): void {
@@ -139,6 +139,7 @@ export class Foobar extends Fizz implements Buzz {
     "jsDoc": "Class doc",
     "classDef": {
       "isAbstract": false,
+      "superClass": "Fizz",
       "constructors": [
         {
           "jsDoc": "Constructor js doc",


### PR DESCRIPTION
Well.

This is my noobish attempt at making `deno doc` parse the `extends` clause of a class definition. Incidentally, it is also my very first rust code ever written. Still no idea how the Box stuff is supposed to function.

It seems to work and I also added a test for the feature.
