### PR TITLE
Minor improvements to Deno.rename

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1283,8 +1283,11 @@ declare namespace Deno {
    *
    *       Deno.renameSync("old/path", "new/path");
    *
-   * Throws error if attempting to rename to a directory which exists and is not
-   * empty.
+   * On Unix, this operation is like `mv -T` in not following symlinks at
+   * either path.
+   *
+   * It varies between platforms when the operation throws errors, and if so what
+   * they are. It's always an error to rename anything to a non-empty directory.
    *
    * Requires `allow-read` and `allow-write` permissions. */
   export function renameSync(oldpath: string, newpath: string): void;
@@ -1296,10 +1299,13 @@ declare namespace Deno {
    *
    *       await Deno.rename("old/path", "new/path");
    *
-   * Throws error if attempting to rename to a directory which exists and is not
-   * empty.
+   * On Unix, this operation is like `mv -T` in not following symlinks at
+   * either path.
    *
-   * Requires `allow-read` and `allow-write`. */
+   * It varies between platforms when the operation throws errors, and if so what
+   * they are. It's always an error to rename anything to a non-empty directory.
+   *
+   * Requires `allow-read` and `allow-write` permission. */
   export function rename(oldpath: string, newpath: string): Promise<void>;
 
   /** Synchronously reads and returns the entire contents of a file as an array

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1283,8 +1283,7 @@ declare namespace Deno {
    *
    *       Deno.renameSync("old/path", "new/path");
    *
-   * On Unix, this operation is like `mv -T` in not following symlinks at
-   * either path.
+   * On Unix, this operation does not follow symlinks at either path.
    *
    * It varies between platforms when the operation throws errors, and if so what
    * they are. It's always an error to rename anything to a non-empty directory.
@@ -1299,8 +1298,7 @@ declare namespace Deno {
    *
    *       await Deno.rename("old/path", "new/path");
    *
-   * On Unix, this operation is like `mv -T` in not following symlinks at
-   * either path.
+   * On Unix, this operation does not follow symlinks at either path.
    *
    * It varies between platforms when the operation throws errors, and if so what
    * they are. It's always an error to rename anything to a non-empty directory.

--- a/cli/js/tests/rename_test.ts
+++ b/cli/js/tests/rename_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertEquals } from "./test_util.ts";
+import { unitTest, assert, assertEquals, assertThrows } from "./test_util.ts";
 
 function assertMissing(path: string): void {
   let caughtErr = false;
@@ -12,6 +12,11 @@ function assertMissing(path: string): void {
   }
   assert(caughtErr);
   assertEquals(info, undefined);
+}
+
+function assertFile(path: string): void {
+  const info = Deno.lstatSync(path);
+  assert(info.isFile());
 }
 
 function assertDirectory(path: string, mode?: number): void {
@@ -77,5 +82,135 @@ unitTest(
     await Deno.rename(oldpath, newpath);
     assertDirectory(newpath);
     assertMissing(oldpath);
+  }
+);
+
+function readFileString(filename: string): string {
+  const dataRead = Deno.readFileSync(filename);
+  const dec = new TextDecoder("utf-8");
+  return dec.decode(dataRead);
+}
+
+function writeFileString(filename: string, s: string): void {
+  const enc = new TextEncoder();
+  const data = enc.encode(s);
+  Deno.writeFileSync(filename, data, { mode: 0o666 });
+}
+
+unitTest(
+  { ignore: Deno.build.os === "win", perms: { read: true, write: true } },
+  function renameSyncErrorsUnix(): void {
+    const testDir = Deno.makeTempDirSync();
+    const oldfile = testDir + "/oldfile";
+    const olddir = testDir + "/olddir";
+    const emptydir = testDir + "/empty";
+    const fulldir = testDir + "/dir";
+    const file = fulldir + "/file";
+    writeFileString(oldfile, "Hello");
+    Deno.mkdirSync(olddir);
+    Deno.mkdirSync(emptydir);
+    Deno.mkdirSync(fulldir);
+    writeFileString(file, "world");
+
+    assertThrows(
+      (): void => {
+        Deno.renameSync(oldfile, emptydir);
+      },
+      Error,
+      "Is a directory"
+    );
+    assertThrows(
+      (): void => {
+        Deno.renameSync(olddir, fulldir);
+      },
+      Error,
+      "Directory not empty"
+    );
+    assertThrows(
+      (): void => {
+        Deno.renameSync(olddir, file);
+      },
+      Error,
+      "Not a directory"
+    );
+
+    const fileLink = testDir + "/fileLink";
+    const dirLink = testDir + "/dirLink";
+    const danglingLink = testDir + "/danglingLink";
+    Deno.symlinkSync(file, fileLink);
+    Deno.symlinkSync(emptydir, dirLink);
+    Deno.symlinkSync(testDir + "/nonexistent", danglingLink);
+
+    assertThrows(
+      (): void => {
+        Deno.renameSync(olddir, fileLink);
+      },
+      Error,
+      "Not a directory"
+    );
+    assertThrows(
+      (): void => {
+        Deno.renameSync(olddir, dirLink);
+      },
+      Error,
+      "Not a directory"
+    );
+    assertThrows(
+      (): void => {
+        Deno.renameSync(olddir, danglingLink);
+      },
+      Error,
+      "Not a directory"
+    );
+
+    // should succeed on Unix
+    Deno.renameSync(olddir, emptydir);
+    Deno.renameSync(oldfile, dirLink);
+    Deno.renameSync(dirLink, danglingLink);
+    assertFile(danglingLink);
+    assertEquals("Hello", readFileString(danglingLink));
+  }
+);
+
+unitTest(
+  { ignore: Deno.build.os !== "win", perms: { read: true, write: true } },
+  function renameSyncErrorsWin(): void {
+    const testDir = Deno.makeTempDirSync();
+    const oldfile = testDir + "/oldfile";
+    const olddir = testDir + "/olddir";
+    const emptydir = testDir + "/empty";
+    const fulldir = testDir + "/dir";
+    const file = fulldir + "/file";
+    writeFileString(oldfile, "Hello");
+    Deno.mkdirSync(olddir);
+    Deno.mkdirSync(emptydir);
+    Deno.mkdirSync(fulldir);
+    writeFileString(file, "world");
+
+    assertThrows(
+      (): void => {
+        Deno.renameSync(oldfile, emptydir);
+      },
+      Deno.errors.PermissionDenied,
+      "Access is denied"
+    );
+    assertThrows(
+      (): void => {
+        Deno.renameSync(olddir, fulldir);
+      },
+      Deno.errors.PermissionDenied,
+      "Access is denied"
+    );
+    assertThrows(
+      (): void => {
+        Deno.renameSync(olddir, emptydir);
+      },
+      Deno.errors.PermissionDenied,
+      "Access is denied"
+    );
+
+    // should succeed on Windows
+    Deno.renameSync(olddir, file);
+    assertDirectory(file);
   }
 );


### PR DESCRIPTION
This PR contains the parts of #4590 left over after the `createNew` functionality is reverted. (I'll push that stuff to `std/fs` at some point; aiming to get `cli/` settled first.)

What's here are:

* Clarify/expand doc comments.

* We refactor some tests to avoid repetition (functions `assertDirectory` and `assertMissing`).

* We add tests documenting in which conditions the `rename` operation will succeed, and in which it will fail (and with what errors) on each of Windows and Unix. It'll be useful to be alerted if these expectations ever later change (for example, because our implementation of `op_rename` does).

    On Unix: moving a file to directory fails, moving a directory to a file or a non-empty directory fails. Moving a directory to any symlink (even one to an existing directory) also fails. Moving a file to a symlink overwrites the link.

    On Windows: moving a file to a directory fails, moving a directory to any directory fails. Moving a directory to a file overwrites the file.
