### PR TITLE
POC: unstable feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -79,3 +79,8 @@ tokio-tungstenite = { version = "0.10", features = ["connect"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 pty = "0.2.2"
+
+[features]
+default = []
+# Enable unstable APIs within the CLI
+unstable = []

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -37,6 +37,11 @@ fn main() {
 
   // Main snapshot
   let root_names = vec![c.join("js/main.ts")];
+  let features = if cfg!(feature = "unstable") {
+    vec!["unstable".to_string()]
+  } else {
+    vec![]
+  };
   let bundle_path = o.join("CLI_SNAPSHOT.js");
   let snapshot_path = o.join("CLI_SNAPSHOT.bin");
 
@@ -55,11 +60,17 @@ fn main() {
     &snapshot_path,
     &bundle_path,
     &main_module_name,
+    &features,
   )
   .expect("Failed to create snapshot");
 
   // Compiler snapshot
   let root_names = vec![c.join("js/compiler.ts")];
+  let features = if cfg!(feature = "unstable") {
+    vec!["unstable".to_string()]
+  } else {
+    vec![]
+  };
   let bundle_path = o.join("COMPILER_SNAPSHOT.js");
   let snapshot_path = o.join("COMPILER_SNAPSHOT.bin");
 
@@ -90,6 +101,12 @@ fn main() {
     "lib.deno.ns.d.ts".to_string(),
     c.join("js/lib.deno.ns.d.ts"),
   );
+  if cfg!(feature = "unstable") {
+    custom_libs.insert(
+      "lib.deno.unstable.d.ts".to_string(),
+      c.join("js/lib.deno.unstable.d.ts"),
+    );
+  }
   runtime_isolate.register_op(
     "op_fetch_asset",
     deno_typescript::op_fetch_asset(custom_libs),
@@ -100,6 +117,7 @@ fn main() {
     &snapshot_path,
     &bundle_path,
     &main_module_name,
+    &features,
   )
   .expect("Failed to create snapshot");
 }

--- a/cli/js.rs
+++ b/cli/js.rs
@@ -21,6 +21,8 @@ pub static SHARED_GLOBALS_LIB: &str =
   include_str!("js/lib.deno.shared_globals.d.ts");
 pub static WINDOW_LIB: &str = include_str!("js/lib.deno.window.d.ts");
 
+pub static UNSTABLE_LIB: &str = include_str!("js/lib.deno.unstable.d.ts");
+
 #[test]
 fn cli_snapshot() {
   let mut isolate = deno_core::Isolate::new(

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -14,7 +14,7 @@
 import "./compiler/ts_global.d.ts";
 
 import { TranspileOnlyResult } from "./compiler/api.ts";
-import { TS_SNAPSHOT_PROGRAM } from "./compiler/bootstrap.ts";
+import { TS_SNAPSHOT_PROGRAM, features } from "./compiler/bootstrap.ts";
 import { setRootExports } from "./compiler/bundler.ts";
 import {
   CompilerHostTarget,
@@ -118,6 +118,17 @@ async function compile(
     writeFile,
   }));
   let diagnostics: readonly ts.Diagnostic[] | undefined;
+
+  if (features.includes("unstable")) {
+    host.mergeOptions({
+      lib: [
+        target === CompilerHostTarget.Worker
+          ? "lib.deno.worker.d.ts"
+          : "lib.deno.window.d.ts",
+        "lib.deno.unstable.d.ts",
+      ],
+    });
+  }
 
   // if there is a configuration supplied, we need to parse that
   if (config && config.length && configPath) {

--- a/cli/js/compiler/bootstrap.ts
+++ b/cli/js/compiler/bootstrap.ts
@@ -31,6 +31,18 @@ host.getSourceFile(
   ts.ScriptTarget.ESNext
 );
 
+export const features = [...globalThis.__features];
+
+// bootstrap unstable libraries
+if (features.includes("unstable")) {
+  ts.libs.push("deno.unstable");
+  ts.libMap.set("deno.unstable", "lib.deno.unstable.d.ts");
+  host.getSourceFile(
+    `${ASSETS}/lib.deno.unstable.d.ts`,
+    ts.ScriptTarget.ESNext
+  );
+}
+
 export const TS_SNAPSHOT_PROGRAM = ts.createProgram({
   rootNames: [`${ASSETS}/bootstrap.ts`],
   options,

--- a/cli/js/deno_unstable.ts
+++ b/cli/js/deno_unstable.ts
@@ -1,0 +1,3 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+export {};

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -154,6 +154,8 @@ declare global {
       ) => boolean | void)
     | undefined;
 
+  var __features: string[];
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   var onmessage: ((e: { data: any }) => Promise<void> | void) | undefined;
   // Called in compiler

--- a/cli/js/globals_unstable.ts
+++ b/cli/js/globals_unstable.ts
@@ -1,0 +1,9 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { readOnly } from "./globals.ts";
+
+export const unstableGlobalMethods = {};
+
+export const unstableGlobalProperties = {
+  __unstable: readOnly(true),
+};

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1,0 +1,13 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+/// <reference no-default-lib="true" />
+
+declare namespace Deno {
+  //
+}
+
+declare interface WindowOrWorkerGlobalScope {
+  readonly __unstable: true;
+}
+
+declare const __unstable: true;

--- a/cli/js/runtime_worker.ts
+++ b/cli/js/runtime_worker.ts
@@ -16,6 +16,10 @@ import {
   windowOrWorkerGlobalScopeProperties,
   eventTargetProperties,
 } from "./globals.ts";
+import {
+  unstableGlobalMethods,
+  unstableGlobalProperties,
+} from "./globals_unstable.ts";
 import * as webWorkerOps from "./ops/web_worker.ts";
 import { LocationImpl } from "./web/location.ts";
 import { log, assert, immutableDefine } from "./util.ts";
@@ -37,6 +41,8 @@ export function postMessage(data: any): void {
 
 let isClosing = false;
 let hasBootstrapped = false;
+const features = globalThis.__features;
+delete globalThis.__features;
 
 export function close(): void {
   if (isClosing) {
@@ -99,6 +105,13 @@ export function bootstrapWorkerRuntime(name: string): void {
   Object.defineProperties(globalThis, workerRuntimeGlobalProperties);
   Object.defineProperties(globalThis, eventTargetProperties);
   Object.defineProperties(globalThis, { name: readOnly(name) });
+
+  // Exposes global unstable features.
+  if (features.includes("unstable")) {
+    Object.defineProperties(globalThis, unstableGlobalMethods);
+    Object.defineProperties(globalThis, unstableGlobalProperties);
+  }
+
   const s = runtime.start(name);
 
   const location = new LocationImpl(s.location);

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -564,12 +564,22 @@ pub fn main() {
       return;
     }
     DenoSubcommand::Types => {
-      let types = format!(
-        "{}\n{}\n{}",
-        crate::js::DENO_NS_LIB,
-        crate::js::SHARED_GLOBALS_LIB,
-        crate::js::WINDOW_LIB
-      );
+      let types = if cfg!(feature = "unstable") {
+        format!(
+          "{}\n{}\n{}\n{}",
+          crate::js::DENO_NS_LIB,
+          crate::js::SHARED_GLOBALS_LIB,
+          crate::js::WINDOW_LIB,
+          crate::js::UNSTABLE_LIB
+        )
+      } else {
+        format!(
+          "{}\n{}\n{}",
+          crate::js::DENO_NS_LIB,
+          crate::js::SHARED_GLOBALS_LIB,
+          crate::js::WINDOW_LIB
+        )
+      };
       if let Err(e) = write_to_stdout_ignore_sigpipe(types.as_bytes()) {
         eprintln!("{}", e);
         std::process::exit(1);

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -197,7 +197,7 @@ pub fn mksnapshot_bundle(
   snapshot_filename: &Path,
   bundle_filename: &Path,
   main_module_name: &str,
-  features: &Vec<String>,
+  features: &[String],
 ) -> Result<(), ErrBox> {
   js_check(isolate.execute("system_loader.js", SYSTEM_LOADER));
   let source_code_vec = std::fs::read(bundle_filename).unwrap();
@@ -222,7 +222,7 @@ pub fn mksnapshot_bundle_ts(
   snapshot_filename: &Path,
   bundle_filename: &Path,
   main_module_name: &str,
-  features: &Vec<String>,
+  features: &[String],
 ) -> Result<(), ErrBox> {
   js_check(isolate.execute("typescript.js", TYPESCRIPT_CODE));
   mksnapshot_bundle(

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -197,6 +197,7 @@ pub fn mksnapshot_bundle(
   snapshot_filename: &Path,
   bundle_filename: &Path,
   main_module_name: &str,
+  features: &Vec<String>,
 ) -> Result<(), ErrBox> {
   js_check(isolate.execute("system_loader.js", SYSTEM_LOADER));
   let source_code_vec = std::fs::read(bundle_filename).unwrap();
@@ -204,7 +205,11 @@ pub fn mksnapshot_bundle(
   js_check(
     isolate.execute(&bundle_filename.to_string_lossy(), bundle_source_code),
   );
-  let script = &format!("__instantiate(\"{}\");", main_module_name);
+  let features_json = serde_json::json!(features);
+  let script = &format!(
+    "globalThis.__features = {};\n__instantiate(\"{}\");",
+    features_json, main_module_name
+  );
   js_check(isolate.execute("anon", script));
   write_snapshot(isolate, snapshot_filename)?;
   Ok(())
@@ -217,6 +222,7 @@ pub fn mksnapshot_bundle_ts(
   snapshot_filename: &Path,
   bundle_filename: &Path,
   main_module_name: &str,
+  features: &Vec<String>,
 ) -> Result<(), ErrBox> {
   js_check(isolate.execute("typescript.js", TYPESCRIPT_CODE));
   mksnapshot_bundle(
@@ -224,6 +230,7 @@ pub fn mksnapshot_bundle_ts(
     snapshot_filename,
     bundle_filename,
     main_module_name,
+    features,
   )
 }
 


### PR DESCRIPTION
This is a proof of concept PR to provide an unstable "infrastructure" within Deno.

In particular, if cli is built with the `"unstable"` feature, then the unstable features are added to the runtime environment (including using the unstable types to type check code).

This uses a static build flag, but in doing it, I realised that a runtime flag `--unstable` would be just as easy, and likely better.  So I think it makes sense to rework it, but I thought I would share the current state.

Rust does not support passing feature flags on workspaces at the moment.  There are a couple issues related to it that are about 2 years old.  There is an intent to support it, but that is partly what makes the static feature a bit annoying.  So you if you want to do an unstable build, you need to:

```
$ cd cli
$ cargo build --features unstable
```

Some notes:

- `lib.deno.unstable.d.ts` is intended to contain all the unstable APIs that are exposed.  Right now it is assumed that they would be the same for the main runtime or a worker.  This does present a bit of a problem in that the types for `Deno` in a worker could be typed checked as valid, though they wouldn't be present at runtime.  If that is a real issue, we would like have to move to split out a `lib.deno.ns.unstable.d.ts`.
- `globals_unstable.ts` would include all the global items, similar to `globals.ts`.
- `deno_unstable.ts` would include all the `Deno` namespace items, again similar to `deno.ts`.

Right now the only unstable feature is there is a global `__unstable` set to `true` when you build an unstable version.