### PR TITLE
bump dprint to 0.9.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,10 +493,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sourcemap",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_parser_macros",
  "sys-info",
  "tempfile",
  "termcolor",
@@ -620,16 +616,15 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.9.6"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d1fc740f63f2fd73c63d4c55632f81fa41ec84ae531258e0e1e014bb3eb30a"
+checksum = "5101e3f156c5286c9cf0bdbc145861f37215967d1a9adaf9ed2bf754aa9386de"
 dependencies = [
  "dprint-core",
  "serde",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_parser",
- "swc_ecma_parser_macros",
 ]
 
 [[package]]
@@ -2439,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.21.8"
+version = "0.21.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fd022bbe8fdd94649a0165a53dc7fbd850370a40609b9c3fddd404b99427fb"
+checksum = "b59bca66689a8e1417c5c7ee3e969bb4a933af8fb00ddbc75a89dfcf5d8df4f8"
 dependencies = [
  "either",
  "enum_kind",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5101e3f156c5286c9cf0bdbc145861f37215967d1a9adaf9ed2bf754aa9386de"
+checksum = "1e048086c7d61c4004c3305511553e7891c729c727acb31e8260a6f3d1d5b6c6"
 dependencies = [
  "dprint-core",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.9.9"
+dprint-plugin-typescript = "0.9.10"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.9.6"
+dprint-plugin-typescript = "0.9.9"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.0"
@@ -63,12 +63,6 @@ webpki-roots = "0.19.0"
 walkdir = "2.3.1"
 warp = "0.2.2"
 semver-parser = "0.9.0"
-# TODO(bartlomieju): make sure we're using exactly same versions
-# of "swc_*" as dprint-plugin-typescript
-swc_common = "=0.5.9"
-swc_ecma_ast = "=0.18.1"
-swc_ecma_parser = "=0.21.8"
-swc_ecma_parser_macros = "=0.4.1"
 uuid = { version = "0.8", features = ["v4"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/cli/doc/class.rs
+++ b/cli/doc/class.rs
@@ -1,9 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::swc_common::SourceMap;
+use crate::swc_common::Spanned;
+use crate::swc_ecma_ast;
 use serde::Serialize;
-use swc_common;
-use swc_common::SourceMap;
-use swc_common::Spanned;
-use swc_ecma_ast;
 
 use super::function::function_to_function_def;
 use super::function::FunctionDef;
@@ -67,7 +66,7 @@ fn prop_name_to_string(
   source_map: &SourceMap,
   prop_name: &swc_ecma_ast::PropName,
 ) -> String {
-  use swc_ecma_ast::PropName;
+  use crate::swc_ecma_ast::PropName;
   match prop_name {
     PropName::Ident(ident) => ident.sym.to_string(),
     PropName::Str(str_) => str_.value.to_string(),
@@ -88,7 +87,7 @@ pub fn get_doc_for_class_decl(
 
   let super_class: Option<String> = match &class_decl.class.super_class {
     Some(boxed) => {
-      use swc_ecma_ast::Expr;
+      use crate::swc_ecma_ast::Expr;
       let expr: &Expr = &**boxed;
       match expr {
         Expr::Ident(ident) => Some(ident.sym.to_string()),
@@ -99,7 +98,7 @@ pub fn get_doc_for_class_decl(
   };
 
   for member in &class_decl.class.body {
-    use swc_ecma_ast::ClassMember::*;
+    use crate::swc_ecma_ast::ClassMember::*;
 
     match member {
       Constructor(ctor) => {
@@ -110,8 +109,8 @@ pub fn get_doc_for_class_decl(
         let mut params = vec![];
 
         for param in &ctor.params {
-          use swc_ecma_ast::Pat;
-          use swc_ecma_ast::PatOrTsParamProp::*;
+          use crate::swc_ecma_ast::Pat;
+          use crate::swc_ecma_ast::PatOrTsParamProp::*;
 
           let param_def = match param {
             Pat(pat) => match pat {
@@ -180,7 +179,7 @@ pub fn get_doc_for_class_decl(
           .as_ref()
           .map(|rt| ts_type_ann_to_def(&doc_parser.source_map, rt));
 
-        use swc_ecma_ast::Expr;
+        use crate::swc_ecma_ast::Expr;
         let prop_name = match &*class_prop.key {
           Expr::Ident(ident) => ident.sym.to_string(),
           _ => "<TODO>".to_string(),

--- a/cli/doc/enum.rs
+++ b/cli/doc/enum.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::swc_ecma_ast;
 use serde::Serialize;
-use swc_ecma_ast;
 
 use super::parser::DocParser;
 
@@ -24,7 +24,7 @@ pub fn get_doc_for_ts_enum_decl(
   let mut members = vec![];
 
   for enum_member in &enum_decl.members {
-    use swc_ecma_ast::TsEnumMemberId::*;
+    use crate::swc_ecma_ast::TsEnumMemberId::*;
 
     let member_name = match &enum_member.id {
       Ident(ident) => ident.sym.to_string(),

--- a/cli/doc/function.rs
+++ b/cli/doc/function.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::swc_ecma_ast;
 use serde::Serialize;
-use swc_ecma_ast;
 
 use super::parser::DocParser;
 use super::ts_type::ts_type_ann_to_def;
@@ -24,7 +24,7 @@ pub fn function_to_function_def(
   let mut params = vec![];
 
   for param in &function.params {
-    use swc_ecma_ast::Pat;
+    use crate::swc_ecma_ast::Pat;
 
     let param_def = match param {
       Pat::Ident(ident) => {

--- a/cli/doc/interface.rs
+++ b/cli/doc/interface.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::swc_ecma_ast;
 use serde::Serialize;
-use swc_ecma_ast;
 
 use super::parser::DocParser;
 use super::ts_type::ts_type_ann_to_def;
@@ -52,8 +52,8 @@ pub struct InterfaceDef {
 }
 
 fn expr_to_name(expr: &swc_ecma_ast::Expr) -> String {
-  use swc_ecma_ast::Expr::*;
-  use swc_ecma_ast::ExprOrSuper::*;
+  use crate::swc_ecma_ast::Expr::*;
+  use crate::swc_ecma_ast::ExprOrSuper::*;
 
   match expr {
     Ident(ident) => ident.sym.to_string(),
@@ -80,7 +80,7 @@ pub fn get_doc_for_ts_interface_decl(
   let mut call_signatures = vec![];
 
   for type_element in &interface_decl.body.body {
-    use swc_ecma_ast::TsTypeElement::*;
+    use crate::swc_ecma_ast::TsTypeElement::*;
 
     match &type_element {
       TsMethodSignature(ts_method_sig) => {
@@ -89,7 +89,7 @@ pub fn get_doc_for_ts_interface_decl(
         let mut params = vec![];
 
         for param in &ts_method_sig.params {
-          use swc_ecma_ast::TsFnParam::*;
+          use crate::swc_ecma_ast::TsFnParam::*;
 
           let param_def = match param {
             Ident(ident) => {
@@ -141,7 +141,7 @@ pub fn get_doc_for_ts_interface_decl(
         let mut params = vec![];
 
         for param in &ts_prop_sig.params {
-          use swc_ecma_ast::TsFnParam::*;
+          use crate::swc_ecma_ast::TsFnParam::*;
 
           let param_def = match param {
             Ident(ident) => {
@@ -188,7 +188,7 @@ pub fn get_doc_for_ts_interface_decl(
 
         let mut params = vec![];
         for param in &ts_call_sig.params {
-          use swc_ecma_ast::TsFnParam::*;
+          use crate::swc_ecma_ast::TsFnParam::*;
 
           let param_def = match param {
             Ident(ident) => {

--- a/cli/doc/module.rs
+++ b/cli/doc/module.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use swc_common;
-use swc_common::Spanned;
-use swc_ecma_ast;
+use crate::swc_common::Spanned;
+use crate::swc_ecma_ast;
 
 use super::parser::DocParser;
 use super::DocNode;
@@ -12,7 +11,7 @@ pub fn get_doc_node_for_export_decl(
   export_decl: &swc_ecma_ast::ExportDecl,
 ) -> DocNode {
   let export_span = export_decl.span();
-  use swc_ecma_ast::Decl;
+  use crate::swc_ecma_ast::Decl;
 
   let js_doc = doc_parser.js_doc_for_span(export_span);
   let location = doc_parser
@@ -165,7 +164,7 @@ pub fn get_doc_nodes_for_named_export(
     .specifiers
     .iter()
     .map(|export_specifier| {
-      use swc_ecma_ast::ExportSpecifier::*;
+      use crate::swc_ecma_ast::ExportSpecifier::*;
 
       match export_specifier {
         Named(named_export_specifier) => {

--- a/cli/doc/namespace.rs
+++ b/cli/doc/namespace.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::swc_ecma_ast;
 use serde::Serialize;
-use swc_ecma_ast;
 
 use super::parser::DocParser;
 use super::DocNode;
@@ -22,7 +22,7 @@ pub fn get_doc_for_ts_namespace_decl(
     .into();
   let namespace_name = ts_namespace_decl.id.sym.to_string();
 
-  use swc_ecma_ast::TsNamespaceBody::*;
+  use crate::swc_ecma_ast::TsNamespaceBody::*;
 
   let elements = match &*ts_namespace_decl.body {
     TsModuleBlock(ts_module_block) => {
@@ -54,14 +54,14 @@ pub fn get_doc_for_ts_module(
   doc_parser: &DocParser,
   ts_module_decl: &swc_ecma_ast::TsModuleDecl,
 ) -> (String, NamespaceDef) {
-  use swc_ecma_ast::TsModuleName;
+  use crate::swc_ecma_ast::TsModuleName;
   let namespace_name = match &ts_module_decl.id {
     TsModuleName::Ident(ident) => ident.sym.to_string(),
     TsModuleName::Str(str_) => str_.value.to_string(),
   };
 
   let elements = if let Some(body) = &ts_module_decl.body {
-    use swc_ecma_ast::TsNamespaceBody::*;
+    use crate::swc_ecma_ast::TsNamespaceBody::*;
 
     match &body {
       TsModuleBlock(ts_module_block) => {

--- a/cli/doc/node.rs
+++ b/cli/doc/node.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::swc_common;
 use serde::Serialize;
-use swc_common;
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -30,7 +30,7 @@ pub struct Location {
 
 impl Into<Location> for swc_common::Loc {
   fn into(self) -> Location {
-    use swc_common::FileName::*;
+    use crate::swc_common::FileName::*;
 
     let filename = match &self.file.name {
       Real(path_buf) => path_buf.to_string_lossy().to_string(),

--- a/cli/doc/parser.rs
+++ b/cli/doc/parser.rs
@@ -1,26 +1,30 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::swc_common;
+use crate::swc_common::comments::CommentKind;
+use crate::swc_common::comments::Comments;
+use crate::swc_common::errors::Diagnostic;
+use crate::swc_common::errors::DiagnosticBuilder;
+use crate::swc_common::errors::Emitter;
+use crate::swc_common::errors::Handler;
+use crate::swc_common::errors::HandlerFlags;
+use crate::swc_common::FileName;
+use crate::swc_common::Globals;
+use crate::swc_common::SourceMap;
+use crate::swc_common::Span;
+use crate::swc_ecma_ast;
+use crate::swc_ecma_ast::Decl;
+use crate::swc_ecma_ast::ModuleDecl;
+use crate::swc_ecma_ast::Stmt;
+use crate::swc_ecma_parser::lexer::Lexer;
+use crate::swc_ecma_parser::JscTarget;
+use crate::swc_ecma_parser::Parser;
+use crate::swc_ecma_parser::Session;
+use crate::swc_ecma_parser::SourceFileInput;
+use crate::swc_ecma_parser::Syntax;
+use crate::swc_ecma_parser::TsConfig;
 use regex::Regex;
 use std::sync::Arc;
 use std::sync::RwLock;
-use swc_common;
-use swc_common::comments::CommentKind;
-use swc_common::comments::Comments;
-use swc_common::errors::Diagnostic;
-use swc_common::errors::DiagnosticBuilder;
-use swc_common::errors::Emitter;
-use swc_common::errors::Handler;
-use swc_common::errors::HandlerFlags;
-use swc_common::FileName;
-use swc_common::Globals;
-use swc_common::SourceMap;
-use swc_common::Span;
-use swc_ecma_parser::lexer::Lexer;
-use swc_ecma_parser::JscTarget;
-use swc_ecma_parser::Parser;
-use swc_ecma_parser::Session;
-use swc_ecma_parser::SourceFileInput;
-use swc_ecma_parser::Syntax;
-use swc_ecma_parser::TsConfig;
 
 use super::DocNode;
 use super::DocNodeKind;
@@ -118,10 +122,8 @@ impl DocParser {
 
   pub fn get_doc_nodes_for_module_decl(
     &self,
-    module_decl: &swc_ecma_ast::ModuleDecl,
+    module_decl: &ModuleDecl,
   ) -> Vec<DocNode> {
-    use swc_ecma_ast::ModuleDecl;
-
     match module_decl {
       ModuleDecl::ExportDecl(export_decl) => {
         vec![super::module::get_doc_node_for_export_decl(
@@ -143,12 +145,7 @@ impl DocParser {
     }
   }
 
-  pub fn get_doc_node_for_stmt(
-    &self,
-    stmt: &swc_ecma_ast::Stmt,
-  ) -> Option<DocNode> {
-    use swc_ecma_ast::Stmt;
-
+  pub fn get_doc_node_for_stmt(&self, stmt: &Stmt) -> Option<DocNode> {
     match stmt {
       Stmt::Decl(decl) => self.get_doc_node_for_decl(decl),
       _ => None,
@@ -161,12 +158,7 @@ impl DocParser {
     (js_doc, location)
   }
 
-  pub fn get_doc_node_for_decl(
-    &self,
-    decl: &swc_ecma_ast::Decl,
-  ) -> Option<DocNode> {
-    use swc_ecma_ast::Decl;
-
+  pub fn get_doc_node_for_decl(&self, decl: &Decl) -> Option<DocNode> {
     match decl {
       Decl::Class(class_decl) => {
         if !class_decl.declare {

--- a/cli/doc/printer.rs
+++ b/cli/doc/printer.rs
@@ -14,6 +14,7 @@ use crate::colors;
 use crate::doc;
 use crate::doc::ts_type::TsTypeDefKind;
 use crate::doc::DocNodeKind;
+use crate::swc_ecma_ast;
 
 pub fn format(doc_nodes: Vec<doc::DocNode>) -> String {
   format_(doc_nodes, 0)

--- a/cli/doc/ts_type.rs
+++ b/cli/doc/ts_type.rs
@@ -1,27 +1,27 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use super::ParamDef;
+use crate::swc_common::SourceMap;
+use crate::swc_ecma_ast;
+use crate::swc_ecma_ast::TsArrayType;
+use crate::swc_ecma_ast::TsConditionalType;
+use crate::swc_ecma_ast::TsFnOrConstructorType;
+use crate::swc_ecma_ast::TsIndexedAccessType;
+use crate::swc_ecma_ast::TsKeywordType;
+use crate::swc_ecma_ast::TsLit;
+use crate::swc_ecma_ast::TsLitType;
+use crate::swc_ecma_ast::TsOptionalType;
+use crate::swc_ecma_ast::TsParenthesizedType;
+use crate::swc_ecma_ast::TsRestType;
+use crate::swc_ecma_ast::TsThisType;
+use crate::swc_ecma_ast::TsTupleType;
+use crate::swc_ecma_ast::TsType;
+use crate::swc_ecma_ast::TsTypeAnn;
+use crate::swc_ecma_ast::TsTypeLit;
+use crate::swc_ecma_ast::TsTypeOperator;
+use crate::swc_ecma_ast::TsTypeQuery;
+use crate::swc_ecma_ast::TsTypeRef;
+use crate::swc_ecma_ast::TsUnionOrIntersectionType;
 use serde::Serialize;
-use swc_common::SourceMap;
-use swc_ecma_ast;
-use swc_ecma_ast::TsArrayType;
-use swc_ecma_ast::TsConditionalType;
-use swc_ecma_ast::TsFnOrConstructorType;
-use swc_ecma_ast::TsIndexedAccessType;
-use swc_ecma_ast::TsKeywordType;
-use swc_ecma_ast::TsLit;
-use swc_ecma_ast::TsLitType;
-use swc_ecma_ast::TsOptionalType;
-use swc_ecma_ast::TsParenthesizedType;
-use swc_ecma_ast::TsRestType;
-use swc_ecma_ast::TsThisType;
-use swc_ecma_ast::TsTupleType;
-use swc_ecma_ast::TsType;
-use swc_ecma_ast::TsTypeAnn;
-use swc_ecma_ast::TsTypeLit;
-use swc_ecma_ast::TsTypeOperator;
-use swc_ecma_ast::TsTypeQuery;
-use swc_ecma_ast::TsTypeRef;
-use swc_ecma_ast::TsUnionOrIntersectionType;
 
 // pub enum TsType {
 //  *      TsKeywordType(TsKeywordType),
@@ -119,7 +119,7 @@ impl Into<TsTypeDef> for &TsTupleType {
 
 impl Into<TsTypeDef> for &TsUnionOrIntersectionType {
   fn into(self) -> TsTypeDef {
-    use swc_ecma_ast::TsUnionOrIntersectionType::*;
+    use crate::swc_ecma_ast::TsUnionOrIntersectionType::*;
 
     match self {
       TsUnionType(union_type) => {
@@ -158,7 +158,7 @@ impl Into<TsTypeDef> for &TsUnionOrIntersectionType {
 
 impl Into<TsTypeDef> for &TsKeywordType {
   fn into(self) -> TsTypeDef {
-    use swc_ecma_ast::TsKeywordTypeKind::*;
+    use crate::swc_ecma_ast::TsKeywordTypeKind::*;
 
     let keyword_str = match self.kind {
       TsAnyKeyword => "any",
@@ -248,7 +248,7 @@ impl Into<TsTypeDef> for &TsThisType {
 }
 
 fn ts_entity_name_to_name(entity_name: &swc_ecma_ast::TsEntityName) -> String {
-  use swc_ecma_ast::TsEntityName::*;
+  use crate::swc_ecma_ast::TsEntityName::*;
 
   match entity_name {
     Ident(ident) => ident.sym.to_string(),
@@ -262,7 +262,7 @@ fn ts_entity_name_to_name(entity_name: &swc_ecma_ast::TsEntityName) -> String {
 
 impl Into<TsTypeDef> for &TsTypeQuery {
   fn into(self) -> TsTypeDef {
-    use swc_ecma_ast::TsTypeQueryExpr::*;
+    use crate::swc_ecma_ast::TsTypeQueryExpr::*;
 
     let type_name = match &self.expr_name {
       TsEntityName(entity_name) => ts_entity_name_to_name(&*entity_name),
@@ -331,14 +331,14 @@ impl Into<TsTypeDef> for &TsTypeLit {
     let mut call_signatures = vec![];
 
     for type_element in &self.members {
-      use swc_ecma_ast::TsTypeElement::*;
+      use crate::swc_ecma_ast::TsTypeElement::*;
 
       match &type_element {
         TsMethodSignature(ts_method_sig) => {
           let mut params = vec![];
 
           for param in &ts_method_sig.params {
-            use swc_ecma_ast::TsFnParam::*;
+            use crate::swc_ecma_ast::TsFnParam::*;
 
             let param_def = match param {
               Ident(ident) => {
@@ -380,7 +380,7 @@ impl Into<TsTypeDef> for &TsTypeLit {
           let mut params = vec![];
 
           for param in &ts_prop_sig.params {
-            use swc_ecma_ast::TsFnParam::*;
+            use crate::swc_ecma_ast::TsFnParam::*;
 
             let param_def = match param {
               Ident(ident) => {
@@ -418,7 +418,7 @@ impl Into<TsTypeDef> for &TsTypeLit {
         TsCallSignatureDecl(ts_call_sig) => {
           let mut params = vec![];
           for param in &ts_call_sig.params {
-            use swc_ecma_ast::TsFnParam::*;
+            use crate::swc_ecma_ast::TsFnParam::*;
 
             let param_def = match param {
               Ident(ident) => {
@@ -486,14 +486,14 @@ impl Into<TsTypeDef> for &TsConditionalType {
 
 impl Into<TsTypeDef> for &TsFnOrConstructorType {
   fn into(self) -> TsTypeDef {
-    use swc_ecma_ast::TsFnOrConstructorType::*;
+    use crate::swc_ecma_ast::TsFnOrConstructorType::*;
 
     let fn_def = match self {
       TsFnType(ts_fn_type) => {
         let mut params = vec![];
 
         for param in &ts_fn_type.params {
-          use swc_ecma_ast::TsFnParam::*;
+          use crate::swc_ecma_ast::TsFnParam::*;
 
           let param_def = match param {
             Ident(ident) => {
@@ -527,7 +527,7 @@ impl Into<TsTypeDef> for &TsFnOrConstructorType {
         let mut params = vec![];
 
         for param in &ctor_type.params {
-          use swc_ecma_ast::TsFnParam::*;
+          use crate::swc_ecma_ast::TsFnParam::*;
 
           let param_def = match param {
             Ident(ident) => {
@@ -569,7 +569,7 @@ impl Into<TsTypeDef> for &TsFnOrConstructorType {
 
 impl Into<TsTypeDef> for &TsType {
   fn into(self) -> TsTypeDef {
-    use swc_ecma_ast::TsType::*;
+    use crate::swc_ecma_ast::TsType::*;
 
     match self {
       TsKeywordType(ref keyword_type) => keyword_type.into(),
@@ -787,7 +787,7 @@ pub fn ts_type_ann_to_def(
   source_map: &SourceMap,
   type_ann: &TsTypeAnn,
 ) -> TsTypeDef {
-  use swc_ecma_ast::TsType::*;
+  use crate::swc_ecma_ast::TsType::*;
 
   match &*type_ann.type_ann {
     TsKeywordType(keyword_type) => keyword_type.into(),

--- a/cli/doc/type_alias.rs
+++ b/cli/doc/type_alias.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::swc_ecma_ast;
 use serde::Serialize;
-use swc_ecma_ast;
 
 use super::parser::DocParser;
 use super::ts_type::TsTypeDef;

--- a/cli/doc/variable.rs
+++ b/cli/doc/variable.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::swc_ecma_ast;
 use serde::Serialize;
-use swc_ecma_ast;
 
 use super::parser::DocParser;
 use super::ts_type::ts_type_ann_to_def;

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -61,6 +61,10 @@ pub mod version;
 mod web_worker;
 pub mod worker;
 
+pub use dprint_plugin_typescript::swc_common;
+pub use dprint_plugin_typescript::swc_ecma_ast;
+pub use dprint_plugin_typescript::swc_ecma_parser;
+
 use crate::compilers::TargetLib;
 use crate::file_fetcher::SourceFile;
 use crate::global_state::GlobalState;


### PR DESCRIPTION
Closes #4557 

Upgrades `dprint` to `0.9.10` and uses reexported `swc` from `dprint` instead of specifying deps in `Cargo.toml`