### PR TITLE
fix: async ops sanitizer false positives in timers

### DIFF
--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -14,6 +14,12 @@ const GREEN_OK = green("ok");
 const YELLOW_IGNORED = yellow("ignored");
 const disabledConsole = new Console((): void => {});
 
+function defer(n: number): Promise<void> {
+  return new Promise((resolve: () => void, _) => {
+    setTimeout(resolve, n);
+  });
+}
+
 function formatDuration(time = 0): string {
   const timeStr = `(${time}ms)`;
   return gray(italic(timeStr));
@@ -28,6 +34,10 @@ function assertOps(fn: () => void | Promise<void>): () => void | Promise<void> {
   return async function asyncOpSanitizer(): Promise<void> {
     const pre = metrics();
     await fn();
+    // Defer till next event loop turn - that way timeouts and intervals
+    // cleared can actually be removed from resource table, otherwise
+    // false positives may occur (4591)
+    await defer(0);
     const post = metrics();
     // We're checking diff because one might spawn HTTP server in the background
     // that will be a pending async op before test starts.

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -36,7 +36,7 @@ function assertOps(fn: () => void | Promise<void>): () => void | Promise<void> {
     await fn();
     // Defer till next event loop turn - that way timeouts and intervals
     // cleared can actually be removed from resource table, otherwise
-    // false positives may occur (4591)
+    // false positives may occur (https://github.com/denoland/deno/issues/4591)
     await defer(0);
     const post = metrics();
     // We're checking diff because one might spawn HTTP server in the background

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -14,7 +14,7 @@ const GREEN_OK = green("ok");
 const YELLOW_IGNORED = yellow("ignored");
 const disabledConsole = new Console((): void => {});
 
-function defer(n: number): Promise<void> {
+function delay(n: number): Promise<void> {
   return new Promise((resolve: () => void, _) => {
     setTimeout(resolve, n);
   });
@@ -34,10 +34,10 @@ function assertOps(fn: () => void | Promise<void>): () => void | Promise<void> {
   return async function asyncOpSanitizer(): Promise<void> {
     const pre = metrics();
     await fn();
-    // Defer till next event loop turn - that way timeouts and intervals
+    // Defer until next event loop turn - that way timeouts and intervals
     // cleared can actually be removed from resource table, otherwise
     // false positives may occur (https://github.com/denoland/deno/issues/4591)
-    await defer(0);
+    await delay(0);
     const post = metrics();
     // We're checking diff because one might spawn HTTP server in the background
     // that will be a pending async op before test starts.

--- a/cli/js/tests/signal_test.ts
+++ b/cli/js/tests/signal_test.ts
@@ -130,9 +130,6 @@ unitTest(
     assertEquals(c, 3);
 
     clearInterval(t);
-    // Defer for a moment to allow async op from `setInterval` to resolve;
-    // for more explanation see `FIXME` in `cli/js/timers.ts::setGlobalTimeout`
-    await defer(20);
     await resolvable;
   }
 );
@@ -153,9 +150,6 @@ unitTest(
     sig.dispose();
 
     clearInterval(t);
-    // Defer for a moment to allow async op from `setInterval` to resolve;
-    // for more explanation see `FIXME` in `cli/js/timers.ts::setGlobalTimeout`
-    await defer(20);
     await resolvable;
   }
 );


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/4591

This PR fixes false positive errors in `asyncOpsSanitizer` - due to how timers work, after clearing timeout or interval there will still be 1 not completed op; adding 0s timeout before asserting ops fixes this problem as it allows another turn of event loop which in turn allows timer promise to resolve.