### PR TITLE
`deno doc` parses the `implements` clause of a class def

### DIFF
--- a/cli/doc/class.rs
+++ b/cli/doc/class.rs
@@ -8,6 +8,7 @@ use swc_ecma_ast;
 use super::function::function_to_function_def;
 use super::function::FunctionDef;
 use super::parser::DocParser;
+use super::ts_type::ts_entity_name_to_name;
 use super::ts_type::ts_type_ann_to_def;
 use super::ts_type::TsTypeDef;
 use super::Location;
@@ -54,13 +55,13 @@ pub struct ClassMethodDef {
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassDef {
-  // TODO: decorators, super_class, implements,
-  // type_params, super_type_params
+  // TODO: decorators, type_params, super_type_params
   pub is_abstract: bool,
   pub constructors: Vec<ClassConstructorDef>,
   pub properties: Vec<ClassPropertyDef>,
   pub methods: Vec<ClassMethodDef>,
   pub super_class: Option<String>,
+  pub implements: Vec<String>,
 }
 
 fn prop_name_to_string(
@@ -97,6 +98,13 @@ pub fn get_doc_for_class_decl(
     }
     None => None,
   };
+
+  let implements: Vec<String> = class_decl
+    .class
+    .implements
+    .iter()
+    .map(|expr| ts_entity_name_to_name(&expr.expr))
+    .collect();
 
   for member in &class_decl.class.body {
     use swc_ecma_ast::ClassMember::*;
@@ -212,6 +220,7 @@ pub fn get_doc_for_class_decl(
   let class_def = ClassDef {
     is_abstract: class_decl.class.is_abstract,
     super_class,
+    implements,
     constructors,
     properties,
     methods,

--- a/cli/doc/printer.rs
+++ b/cli/doc/printer.rs
@@ -438,12 +438,24 @@ fn format_class_signature(node: &doc::DocNode, indent: i64) -> String {
     String::from("")
   };
 
+  let implements = &class_def.implements;
+  let implements_suffix = if !implements.is_empty() {
+    format!(
+      " {} {}",
+      colors::magenta("implements".to_string()),
+      colors::bold(implements.join(", "))
+    )
+  } else {
+    String::from("")
+  };
+
   add_indent(
     format!(
-      "{} {}{}\n",
+      "{} {}{}{}\n",
       colors::magenta("class".to_string()),
       colors::bold(node.name.clone()),
-      super_suffix
+      super_suffix,
+      implements_suffix,
     ),
     indent,
   )

--- a/cli/doc/tests.rs
+++ b/cli/doc/tests.rs
@@ -104,7 +104,7 @@ fn export_const() {
 fn export_class() {
   let source_code = r#"
 /** Class doc */
-export class Foobar extends Fizz implements Buzz {
+export class Foobar extends Fizz implements Buzz, Aldrin {
     private private1: boolean;
     protected protected1: number;
     public public1: boolean;
@@ -140,6 +140,7 @@ export class Foobar extends Fizz implements Buzz {
     "classDef": {
       "isAbstract": false,
       "superClass": "Fizz",
+      "implements": ["Buzz", "Aldrin"],
       "constructors": [
         {
           "jsDoc": "Constructor js doc",
@@ -309,7 +310,7 @@ export class Foobar extends Fizz implements Buzz {
 
   assert!(
     colors::strip_ansi_codes(super::printer::format(entries).as_str())
-      .contains("class Foobar extends Fizz")
+      .contains("class Foobar extends Fizz implements Buzz, Aldrin")
   );
 }
 

--- a/cli/doc/ts_type.rs
+++ b/cli/doc/ts_type.rs
@@ -247,7 +247,9 @@ impl Into<TsTypeDef> for &TsThisType {
   }
 }
 
-fn ts_entity_name_to_name(entity_name: &swc_ecma_ast::TsEntityName) -> String {
+pub fn ts_entity_name_to_name(
+  entity_name: &swc_ecma_ast::TsEntityName,
+) -> String {
   use swc_ecma_ast::TsEntityName::*;
 
   match entity_name {


### PR DESCRIPTION
This is a continuation of https://github.com/denoland/deno/pull/4595 that implements parsing of the `implements` part of a class definition. Test included.

The `ts_entity_name_to_name` has been made public in order to be used from the `class.rs` file.