### PR TITLE
Tweaks and doc comments for op_seek

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -703,7 +703,8 @@ declare namespace Deno {
   export function write(rid: number, data: Uint8Array): Promise<number>;
 
   /** Synchronously seek a resource ID (`rid`) to the given `offset` under mode
-   * given by `whence`.  The current position within the resource is returned.
+   * given by `whence`.  The new position within the resource (bytes from the
+   * start) is returned.
    *
    *        const file = Deno.openSync('hello.txt', {read: true, write: true, truncate: true, create: true});
    *        Deno.writeSync(file.rid, new TextEncoder().encode("Hello world"));
@@ -731,7 +732,7 @@ declare namespace Deno {
   ): number;
 
   /** Seek a resource ID (`rid`) to the given `offset` under mode given by `whence`.
-   * The call resolves to the current position within the resource.
+   * The call resolves to the new position within the resource (bytes from the start).
    *
    *        const file = await Deno.open('hello.txt', {read: true, write: true, truncate: true, create: true});
    *        await Deno.write(file.rid, new TextEncoder().encode("Hello world"));

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -226,12 +226,14 @@ fn op_seek(
   };
   let mut file = futures::executor::block_on(tokio_file.try_clone())?;
 
+  let is_sync = args.promise_id.is_none();
   let fut = async move {
+    debug!("op_seek {} {} {}", rid, offset, whence);
     let pos = file.seek(seek_from).await?;
     Ok(json!(pos))
   };
 
-  if args.promise_id.is_none() {
+  if is_sync {
     let buf = futures::executor::block_on(fut)?;
     Ok(JsonOp::Sync(buf))
   } else {


### PR DESCRIPTION
This PR clarifies the return value of `Deno.seek` and `Deno.seekSync`.

It also tweaks the `op_seek` code for uniformity with the rest of `cli/ops/fs.rs`, and adds a `debug!` logger.