### PR TITLE
BREAKING CHANGE: Remove deprecated mkdir, mkdirSync APIs

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1043,13 +1043,6 @@ declare namespace Deno {
    * Requires `allow-write` permission. */
   export function mkdirSync(path: string, options?: MkdirOptions): void;
 
-  /** @deprecated */
-  export function mkdirSync(
-    path: string,
-    recursive?: boolean,
-    mode?: number
-  ): void;
-
   /** Creates a new directory with the specified path.
    *
    *       await Deno.mkdir("new_dir");
@@ -1060,13 +1053,6 @@ declare namespace Deno {
    *
    * Requires `allow-write` permission. */
   export function mkdir(path: string, options?: MkdirOptions): Promise<void>;
-
-  /** @deprecated */
-  export function mkdir(
-    path: string,
-    recursive?: boolean,
-    mode?: number
-  ): Promise<void>;
 
   export interface MakeTempOptions {
     /** Directory where the temporary directory should be created (defaults to

--- a/cli/js/ops/fs/mkdir.ts
+++ b/cli/js/ops/fs/mkdir.ts
@@ -3,25 +3,14 @@ import { sendSync, sendAsync } from "../dispatch_json.ts";
 
 type MkdirArgs = { path: string; recursive: boolean; mode?: number };
 
-// TODO(ry) The complexity in argument parsing is to support deprecated forms of
-// mkdir and mkdirSync.
-function mkdirArgs(
-  path: string,
-  optionsOrRecursive?: MkdirOptions | boolean,
-  mode?: number
-): MkdirArgs {
+function mkdirArgs(path: string, options?: MkdirOptions): MkdirArgs {
   const args: MkdirArgs = { path, recursive: false };
-  if (typeof optionsOrRecursive == "boolean") {
-    args.recursive = optionsOrRecursive;
-    if (mode) {
-      args.mode = mode;
+  if (options) {
+    if (typeof options.recursive == "boolean") {
+      args.recursive = options.recursive;
     }
-  } else if (optionsOrRecursive) {
-    if (typeof optionsOrRecursive.recursive == "boolean") {
-      args.recursive = optionsOrRecursive.recursive;
-    }
-    if (optionsOrRecursive.mode) {
-      args.mode = optionsOrRecursive.mode;
+    if (options.mode) {
+      args.mode = options.mode;
     }
   }
   return args;
@@ -32,18 +21,13 @@ export interface MkdirOptions {
   mode?: number;
 }
 
-export function mkdirSync(
-  path: string,
-  optionsOrRecursive?: MkdirOptions | boolean,
-  mode?: number
-): void {
-  sendSync("op_mkdir", mkdirArgs(path, optionsOrRecursive, mode));
+export function mkdirSync(path: string, options?: MkdirOptions): void {
+  sendSync("op_mkdir", mkdirArgs(path, options));
 }
 
 export async function mkdir(
   path: string,
-  optionsOrRecursive?: MkdirOptions | boolean,
-  mode?: number
+  options?: MkdirOptions
 ): Promise<void> {
-  await sendAsync("op_mkdir", mkdirArgs(path, optionsOrRecursive, mode));
+  await sendAsync("op_mkdir", mkdirArgs(path, options));
 }


### PR DESCRIPTION
While updating the API documentation, I noticed that mkdir and mkdirSync were the only APIs with deprecated variants.  This PR removes these deprecated variants to clean up the API in advance of the Deno 1.0 release.  The variants removed have been deprecated since 0.29.0.