### PR TITLE
file_server: update media_types

### DIFF
--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -47,10 +47,10 @@ const MEDIA_TYPES: Record<string, string> = {
   ".json": "application/json",
   ".map": "application/json",
   ".txt": "text/plain",
-  ".ts": "application/typescript",
-  ".tsx": "application/typescript",
+  ".ts": "text/typescript",
+  ".tsx": "text/tsx",
   ".js": "application/javascript",
-  ".jsx": "application/jsx",
+  ".jsx": "text/jsx",
   ".gz": "application/gzip",
 };
 


### PR DESCRIPTION
I just tried it and found that using `application/typescript`, the browser will download the file directly, I think that `.ts` should be mapped to `application/javascript` or `text/typescript`