### PR TITLE
fix: [std/testing] runner is broken

### DIFF
--- a/std/testing/runner.ts
+++ b/std/testing/runner.ts
@@ -168,7 +168,6 @@ export async function runTestModules({
   exclude = [],
   allowNone = false,
   exitOnFail = false,
-  only = /[^\s]/,
   skip = /^\s*$/,
   disableLog = false,
 }: RunTestModulesOptions = {}): Promise<void> {
@@ -233,7 +232,6 @@ export async function runTestModules({
 
   await Deno.runTests({
     exitOnFail,
-    only,
     skip,
     disableLog,
   });

--- a/std/testing/runner_test.ts
+++ b/std/testing/runner_test.ts
@@ -1,0 +1,2 @@
+// Just type checking
+import "./runner.ts";


### PR DESCRIPTION
In v0.39.0, `std/testing/runner.ts` can't be compiled and it is broken. It may be because of recent type change? I added empty test for `runner.ts` for checking types in std_tests.

```
deno https://deno.land/std@v0.39.0/testing/runner.ts
Compile https://deno.land/std@v0.39.0/testing/runner.ts
error TS2339: Property 'only' does not exist on type 'RunTestModulesOptions'.

► https://deno.land/std@v0.39.0/testing/runner.ts:171:3

171   only = /[^\s]/,
      ~~~~

error TS2345: Argument of type '{ exitOnFail: boolean; only: any; skip: string | RegExp; disableLog: boolean; }' is not assignable to parameter of type 'RunTestsOptions'.
  Object literal may only specify known properties, and 'only' does not exist in type 'RunTestsOptions'.

► https://deno.land/std@v0.39.0/testing/runner.ts:236:5

236     only,
        ~~~~


Found 2 errors.
```