### PR TITLE
Add File support in FormData

### DIFF
--- a/cli/js/tests/form_data_test.ts
+++ b/cli/js/tests/form_data_test.ts
@@ -76,8 +76,8 @@ unitTest(function formDataParamsSetSuccess(): void {
 unitTest(function fromDataUseDomFile(): void {
   const formData = new FormData();
   const file = new File(["foo"], "bar", {
-    type: "text/plain"
-  })
+    type: "text/plain",
+  });
   formData.append("file", file);
   assertEquals(formData.get("file"), file);
 });

--- a/cli/js/tests/form_data_test.ts
+++ b/cli/js/tests/form_data_test.ts
@@ -73,6 +73,15 @@ unitTest(function formDataParamsSetSuccess(): void {
   assertEquals(formData.get("e"), "null");
 });
 
+unitTest(function fromDataUseDomFile(): void {
+  const formData = new FormData();
+  const file = new File(["foo"], "bar", {
+    type: "text/plain"
+  })
+  formData.append("file", file);
+  assertEquals(formData.get("file"), file);
+});
+
 unitTest(function formDataSetEmptyBlobSuccess(): void {
   const formData = new FormData();
   formData.set("a", new Blob([]), "blank.txt");

--- a/cli/js/web/form_data.ts
+++ b/cli/js/web/form_data.ts
@@ -11,11 +11,18 @@ class FormDataBase {
   [dataSymbol]: Array<[string, domTypes.FormDataEntryValue]> = [];
 
   append(name: string, value: string): void;
+  append(name: string, value: domFile.DomFileImpl): void;
   append(name: string, value: blob.DenoBlob, filename?: string): void;
-  append(name: string, value: string | blob.DenoBlob, filename?: string): void {
+  append(
+    name: string,
+    value: string | blob.DenoBlob | domFile.DomFileImpl,
+    filename?: string
+  ): void {
     requiredArguments("FormData.append", arguments.length, 2);
     name = String(name);
-    if (value instanceof blob.DenoBlob) {
+    if (value instanceof domFile.DomFileImpl) {
+      this[dataSymbol].push([name, value]);
+    } else if (value instanceof blob.DenoBlob) {
       const dfile = new domFile.DomFileImpl([value], filename || name, {
         type: value.type,
       });
@@ -70,8 +77,13 @@ class FormDataBase {
   }
 
   set(name: string, value: string): void;
+  set(name: string, value: domFile.DomFileImpl): void;
   set(name: string, value: blob.DenoBlob, filename?: string): void;
-  set(name: string, value: string | blob.DenoBlob, filename?: string): void {
+  set(
+    name: string,
+    value: string | blob.DenoBlob | domFile.DomFileImpl,
+    filename?: string
+  ): void {
     requiredArguments("FormData.set", arguments.length, 2);
     name = String(name);
 
@@ -82,7 +94,9 @@ class FormDataBase {
     while (i < this[dataSymbol].length) {
       if (this[dataSymbol][i][0] === name) {
         if (!found) {
-          if (value instanceof blob.DenoBlob) {
+          if (value instanceof domFile.DomFileImpl) {
+            this[dataSymbol][i][1] = value;
+          } else if (value instanceof blob.DenoBlob) {
             const dfile = new domFile.DomFileImpl([value], filename || name, {
               type: value.type,
             });
@@ -101,7 +115,9 @@ class FormDataBase {
 
     // Otherwise, append entry to the context object’s entry list.
     if (!found) {
-      if (value instanceof blob.DenoBlob) {
+      if (value instanceof domFile.DomFileImpl) {
+        this[dataSymbol].push([name, value]);
+      } else if (value instanceof blob.DenoBlob) {
         const dfile = new domFile.DomFileImpl([value], filename || name, {
           type: value.type,
         });


### PR DESCRIPTION
fixes #4365 
browsers seem to support it even though it isnt exactly part of the spec, though the spec does loosely mention it. i recommend to include this anyways as it makes using formdata just simpler when using files