### PR TITLE
fix: test_create_cache_if_dir_not_exit nerver passes once executed

### DIFF
--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -146,11 +146,10 @@ mod tests {
 
   #[test]
   fn test_create_cache_if_dir_not_exits() {
-    let cache_location = if cfg!(target_os = "windows") {
-      PathBuf::from(r"C:\deno_dir\foo")
-    } else {
-      PathBuf::from("~/deno_dir/foo")
-    };
+    let temp_dir = TempDir::new().unwrap();
+    let mut cache_location = temp_dir.path().to_owned();
+    assert!(fs::remove_dir(&cache_location).is_ok());
+    cache_location.push("foo");
     assert_eq!(cache_location.is_dir(), false);
     DiskCache::new(&cache_location);
     assert_eq!(cache_location.is_dir(), true);


### PR DESCRIPTION
This test doesn't remove created directory after test. It will fail on next run.

```✗ cargo test test_create_cache_if_dir_not_exits
   Compiling deno v0.39.0 (/Users/keroxp/src/deno/cli)
   Compiling test_plugin v0.0.1 (/Users/keroxp/src/deno/test_plugin)
    Finished test [unoptimized + debuginfo] target(s) in 28.69s
     Running target/debug/deps/deno-dadb83997376169a

running 1 test
test disk_cache::tests::test_create_cache_if_dir_not_exits ... FAILED

failures:

---- disk_cache::tests::test_create_cache_if_dir_not_exits stdout ----
thread 'disk_cache::tests::test_create_cache_if_dir_not_exits' panicked at 'assertion failed: `(left == right)`
  left: `true`,
 right: `false`', cli/disk_cache.rs:154:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    disk_cache::tests::test_create_cache_if_dir_not_exits

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 220 filtered out
```

