### PR TITLE
Remove media_types from std/README.md

### DIFF
--- a/std/README.md
+++ b/std/README.md
@@ -28,7 +28,6 @@ Here are the dedicated documentations of modules:
 - [fs](fs/README.md)
 - [http](http/README.md)
 - [log](log/README.md)
-- [media_types](media_types/README.md)
 - [strings](strings/README.md)
 - [testing](testing/README.md)
 - [uuid](uuid/README.md)


### PR DESCRIPTION
media_types  module transferred to third party modules and should remove from std readme.

And does anyone working on other module documents or completing the previous ones?
If it doesn't, I'm interested in doing it