### PR TITLE
always_fetch_reference_types_for_js

### DIFF
--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -138,6 +138,18 @@ impl GlobalState {
             .compile(state1.clone(), &out, target_lib)
             .await
         } else {
+          if let Some(types_url) = out.types_url.clone() {
+            let types_specifier = ModuleSpecifier::from(types_url);
+            state1
+              .file_fetcher
+              .fetch_source_file(
+                &types_specifier,
+                Some(module_specifier.clone()),
+              )
+              .await
+              .ok();
+          };
+
           state1.js_compiler.compile(out).await
         }
       }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1415,6 +1415,13 @@ itest!(type_directives_02 {
   output: "type_directives_02.ts.out",
 });
 
+itest!(type_directives_js_main {
+  args: "run --reload -L debug type_directives_js_main.js",
+  output: "type_directives_js_main.js.out",
+  check_stderr: true,
+  exit_code: 0,
+});
+
 itest!(types {
   args: "types",
   output: "types.out",

--- a/cli/tests/type_directives_js_main.js
+++ b/cli/tests/type_directives_js_main.js
@@ -1,0 +1,3 @@
+import * as foo from "./subdir/type_reference.js";
+
+console.log(foo.foo);

--- a/cli/tests/type_directives_js_main.js.out
+++ b/cli/tests/type_directives_js_main.js.out
@@ -1,0 +1,3 @@
+[WILDCARD]
+fetch_source_file specifier: file:[WILDCARD]cli/tests/subdir/type_reference.d.ts 
+[WILDCARD]


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
Fixes #4000 and fixes #4476. Now always tries to fetch reference types for JS files. Does not throw if it fails, since Typescript compiler will complain if the file is not there(it will try to fetch it again first) and people who just use JS should not be bothered by this error.

Not sure about my test, it passes and catches the bug but maybe there is a better way to express it.