### PR TITLE
Remove __timers namespace

### DIFF
--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -15,12 +15,7 @@ declare interface WindowOrWorkerGlobalScope {
   // methods
   atob: typeof __textEncoding.atob;
   btoa: typeof __textEncoding.btoa;
-  clearInterval: typeof __timers.clearInterval;
-  clearTimeout: typeof __timers.clearTimeout;
   fetch: typeof __fetch.fetch;
-  setInterval: typeof __timers.setInterval;
-  queueMicrotask: typeof __timers.queueMicrotask;
-  setTimeout: typeof __timers.setTimeout;
   // properties
   console: __console.Console;
   Blob: typeof __blob.DenoBlob;
@@ -228,12 +223,23 @@ declare namespace WebAssembly {
 
 declare const atob: typeof __textEncoding.atob;
 declare const btoa: typeof __textEncoding.btoa;
-declare const clearInterval: typeof __timers.clearInterval;
-declare const clearTimeout: typeof __timers.clearTimeout;
 declare const fetch: typeof __fetch.fetch;
-declare const setInterval: typeof __timers.setInterval;
-declare const setTimeout: typeof __timers.setTimeout;
-declare const queueMicrotask: typeof __timers.queueMicrotask;
+
+/** Sets a timer which executes a function once after the timer expires. */
+declare function setTimeout(
+  cb: (...args: unknown[]) => void,
+  delay?: number,
+  ...args: unknown[]
+): number;
+/** Repeatedly calls a function , with a fixed time delay between each call. */
+declare function setInterval(
+  cb: (...args: unknown[]) => void,
+  delay?: number,
+  ...args: unknown[]
+): number;
+declare function clearTimeout(id?: number): void;
+declare function clearInterval(id?: number): void;
+declare function queueMicrotask(func: Function): void;
 
 declare const console: __console.Console;
 declare const Blob: typeof __blob.DenoBlob;
@@ -1398,25 +1404,6 @@ declare namespace __textEncoding {
     encodeInto(input: string, dest: Uint8Array): TextEncoderEncodeIntoResult;
     readonly [Symbol.toStringTag]: string;
   }
-}
-
-declare namespace __timers {
-  export type Args = unknown[];
-  /** Sets a timer which executes a function once after the timer expires. */
-  export function setTimeout(
-    cb: (...args: Args) => void,
-    delay?: number,
-    ...args: Args
-  ): number;
-  /** Repeatedly calls a function , with a fixed time delay between each call. */
-  export function setInterval(
-    cb: (...args: Args) => void,
-    delay?: number,
-    ...args: Args
-  ): number;
-  export function clearTimeout(id?: number): void;
-  export function clearInterval(id?: number): void;
-  export function queueMicrotask(func: Function): void;
 }
 
 declare namespace __urlSearchParams {

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -327,6 +327,9 @@ pub fn trace_serializer() {
 pub fn op_fetch_asset<S: ::std::hash::BuildHasher>(
   custom_assets: HashMap<String, PathBuf, S>,
 ) -> impl Fn(&[u8], Option<ZeroCopyBuf>) -> CoreOp {
+  for (_, path) in custom_assets.iter() {
+    println!("cargo:rerun-if-changed={}", path.display());
+  }
   move |control: &[u8], zero_copy_buf: Option<ZeroCopyBuf>| -> CoreOp {
     assert!(zero_copy_buf.is_none()); // zero_copy_buf unused in this op.
     let name = std::str::from_utf8(control).unwrap();


### PR DESCRIPTION
With `deno doc` some of these internal namespaces are more visible. While it may be that some of these are necessary for organization, we should try to eliminate unnecessary ones. In this PR I've take a first stab at this by removing the `__timers` namespace, which should clean up this bit of nastiness:

https://doc.deno.land/https/github.com/denoland/deno/releases/latest/download/lib.deno.d.ts#__timers.setTimeout
<img width="1280" alt="Screen Shot 2020-04-07 at 10 50 05 AM" src="https://user-images.githubusercontent.com/80/78683668-93ad9480-78bd-11ea-9b82-3542e4072f5e.png">


cc @kitsonk @lucacasonato 