### PR TITLE
WIP use dprint for internal code formatting

### DIFF
--- a/tools/dprint_config.json
+++ b/tools/dprint_config.json
@@ -1,0 +1,6 @@
+{
+  "lineWidth": "80",
+  "indentWidth": "2",
+  "nextControlFlowPosition": "sameLine",
+  "bracePosition": "sameLine"
+}

--- a/tools/format.py
+++ b/tools/format.py
@@ -18,6 +18,7 @@ def main():
 
     did_fmt = False
     if args.js:
+        dprint()
         prettier()
         did_fmt = True
     if args.py:
@@ -37,8 +38,16 @@ def prettier():
     print "prettier"
     script = os.path.join(third_party_path, "node_modules", "prettier",
                           "bin-prettier.js")
-    source_files = git_ls_files(root_path, ["*.js", "*.json", "*.ts", "*.md"])
+    source_files = git_ls_files(root_path, ["*.json", "*.md"])
     run(["node", script, "--write", "--loglevel=error", "--"] + source_files,
+        shell=False,
+        quiet=True)
+
+def dprint():
+    print "dprint"
+    config = os.path.join(root_path, "tools", "dprint_config.json")
+    source_files = git_ls_files(root_path, ["*.js", "*.ts"])
+    run(["dprint", "--config", config] + source_files,
         shell=False,
         quiet=True)
 


### PR DESCRIPTION
I'm not sure we're ready for this, but I wanted to put up my half attempt to get this working.

Problems:
* configuration for "deno fmt" and "dprint" is now split between cli/fmt.rs and tools/dprint_config.json
* still need prettier for json and md
* need to update CI to install dprint binary
* not all configurations supported via JSON (?)