### PR TITLE
refactor: change left/right diff text to actual/expected

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -52,7 +52,9 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   messages.push("");
   messages.push("");
   messages.push(
-    `    ${gray(bold("[Diff]"))} ${red(bold("Left"))} / ${green(bold("Right"))}`
+    `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${green(
+      bold("Expected")
+    )}`
   );
   messages.push("");
   messages.push("");

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -251,7 +251,9 @@ test(function testingAssertFailWithWrongErrorClass(): void {
 const createHeader = (): string[] => [
   "",
   "",
-  `    ${gray(bold("[Diff]"))} ${red(bold("Left"))} / ${green(bold("Right"))}`,
+  `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${green(
+    bold("Expected")
+  )}`,
   "",
   "",
 ];


### PR DESCRIPTION
Given that the API for testing asserts is defined as such:

```
export function assertEquals(actual: unknown, expected: unknown, msg?: string): void
```
Then the output should report Actual vs Expected rather than Left vs Right:

![Screenshot at 2020-04-10 14:42:05](https://user-images.githubusercontent.com/1248238/78995459-4be77100-7b3a-11ea-9bd9-745541b94625.png)
