### PR TITLE
Replace panic with invalid_utf8 OpError

### DIFF
--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -156,7 +156,8 @@ fn op_fetch_source_files(
               .map_err(|e| OpError::other(e.to_string()))?
               .code
           }
-          _ => String::from_utf8(file.source_code).unwrap(),
+          _ => String::from_utf8(file.source_code)
+            .map_err(|_| OpError::invalid_utf8())?,
         };
         Ok::<_, OpError>(json!({
           "url": file.url.to_string(),


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
Related to #1489 

A simple change to return an invalid UTF8 OpError instead of panicking. It still dies on UTF8 encoded files, but at least cleans up the message. 

