### PR TITLE
dedup Blob declaration

### DIFF
--- a/cli/js/web/blob.ts
+++ b/cli/js/web/blob.ts
@@ -164,9 +164,9 @@ async function readBytes(
 
 // A WeakMap holding blob to byte array mapping.
 // Ensures it does not impact garbage collection.
-export const blobBytesWeakMap = new WeakMap<domTypes.Blob, Uint8Array>();
+export const blobBytesWeakMap = new WeakMap<Blob, Uint8Array>();
 
-export class DenoBlob implements domTypes.Blob {
+export class DenoBlob implements Blob {
   [bytesSymbol]: Uint8Array;
   readonly size: number = 0;
   readonly type: string = "";

--- a/cli/js/web/blob.ts
+++ b/cli/js/web/blob.ts
@@ -63,7 +63,7 @@ function collectSequenceNotCRLF(
 }
 
 function toUint8Arrays(
-  blobParts: domTypes.BlobPart[],
+  blobParts: BlobPart[],
   doNormalizeLineEndingsToNative: boolean
 ): Uint8Array[] {
   const ret: Uint8Array[] = [];
@@ -102,7 +102,7 @@ function toUint8Arrays(
 }
 
 function processBlobParts(
-  blobParts: domTypes.BlobPart[],
+  blobParts: BlobPart[],
   options: domTypes.BlobPropertyBag
 ): Uint8Array {
   const normalizeLineEndingsToNative = options.ending === "native";
@@ -171,10 +171,7 @@ export class DenoBlob implements Blob {
   readonly size: number = 0;
   readonly type: string = "";
 
-  constructor(
-    blobParts?: domTypes.BlobPart[],
-    options?: domTypes.BlobPropertyBag
-  ) {
+  constructor(blobParts?: BlobPart[], options?: domTypes.BlobPropertyBag) {
     if (arguments.length === 0) {
       this[bytesSymbol] = new Uint8Array();
       return;

--- a/cli/js/web/body.ts
+++ b/cli/js/web/body.ts
@@ -10,7 +10,6 @@ const { Headers } = headers;
 // only namespace imports work for now, plucking out what we need
 const { FormData } = formData;
 const { TextEncoder, TextDecoder } = encoding;
-const Blob = blob.DenoBlob;
 const DenoBlob = blob.DenoBlob;
 
 type ReadableStreamReader = domTypes.ReadableStreamReader;
@@ -21,7 +20,7 @@ interface ReadableStreamController {
 }
 
 export type BodySource =
-  | domTypes.Blob
+  | Blob
   | domTypes.BufferSource
   | domTypes.FormData
   | domTypes.URLSearchParams
@@ -161,8 +160,8 @@ export class Body implements domTypes.Body {
     return false;
   }
 
-  public async blob(): Promise<domTypes.Blob> {
-    return new Blob([await this.arrayBuffer()]);
+  public async blob(): Promise<Blob> {
+    return new DenoBlob([await this.arrayBuffer()]);
   }
 
   // ref: https://fetch.spec.whatwg.org/#body-mixin

--- a/cli/js/web/body.ts
+++ b/cli/js/web/body.ts
@@ -21,7 +21,7 @@ interface ReadableStreamController {
 
 export type BodySource =
   | Blob
-  | domTypes.BufferSource
+  | BufferSource
   | domTypes.FormData
   | domTypes.URLSearchParams
   | domTypes.ReadableStream

--- a/cli/js/web/dom_file.ts
+++ b/cli/js/web/dom_file.ts
@@ -7,7 +7,7 @@ export class DomFileImpl extends blob.DenoBlob implements domTypes.DomFile {
   name: string;
 
   constructor(
-    fileBits: domTypes.BlobPart[],
+    fileBits: BlobPart[],
     fileName: string,
     options?: domTypes.FilePropertyBag
   ) {

--- a/cli/js/web/dom_types.d.ts
+++ b/cli/js/web/dom_types.d.ts
@@ -362,15 +362,6 @@ export class FormData {
   values(): IterableIterator<FormDataEntryValue>;
 }
 
-export interface Blob {
-  readonly size: number;
-  readonly type: string;
-  slice(start?: number, end?: number, contentType?: string): Blob;
-  stream(): ReadableStream;
-  text(): Promise<string>;
-  arrayBuffer(): Promise<ArrayBuffer>;
-}
-
 export interface Body {
   readonly body: ReadableStream<Uint8Array> | null;
   readonly bodyUsed: boolean;

--- a/cli/js/web/dom_types.d.ts
+++ b/cli/js/web/dom_types.d.ts
@@ -17,8 +17,6 @@ and limitations under the License.
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export type BufferSource = ArrayBufferView | ArrayBuffer;
-
 export type HeadersInit =
   | Headers
   | Array<[string, string]>
@@ -33,16 +31,6 @@ type BodyInit =
   | string;
 
 export type RequestInfo = Request | string;
-
-type ReferrerPolicy =
-  | ""
-  | "no-referrer"
-  | "no-referrer-when-downgrade"
-  | "origin-only"
-  | "origin-when-cross-origin"
-  | "unsafe-url";
-
-export type BlobPart = BufferSource | Blob | string;
 
 export type FormDataEntryValue = DomFile | string;
 

--- a/cli/js/web/dom_types.d.ts
+++ b/cli/js/web/dom_types.d.ts
@@ -41,10 +41,6 @@ export interface BlobPropertyBag {
   ending?: EndingType;
 }
 
-interface AbortSignalEventMap {
-  abort: ProgressEvent;
-}
-
 export interface ProgressEventInit extends EventInit {
   lengthComputable?: boolean;
   loaded?: number;
@@ -304,37 +300,6 @@ export interface DomFileConstructor {
 
 export interface FilePropertyBag extends BlobPropertyBag {
   lastModified?: number;
-}
-
-interface ProgressEvent extends Event {
-  readonly lengthComputable: boolean;
-  readonly loaded: number;
-  readonly total: number;
-}
-
-export interface AbortSignal extends EventTarget {
-  readonly aborted: boolean;
-  onabort: ((this: AbortSignal, ev: ProgressEvent) => any) | null;
-  addEventListener<K extends keyof AbortSignalEventMap>(
-    type: K,
-    listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
-    options?: boolean | AddEventListenerOptions
-  ): void;
-  addEventListener(
-    type: string,
-    listener: EventListener,
-    options?: boolean | AddEventListenerOptions
-  ): void;
-  removeEventListener<K extends keyof AbortSignalEventMap>(
-    type: K,
-    listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
-    options?: boolean | EventListenerOptions
-  ): void;
-  removeEventListener(
-    type: string,
-    listener: EventListener,
-    options?: boolean | EventListenerOptions
-  ): void;
 }
 
 export class FormData {

--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -80,7 +80,7 @@ class Body
     return this.#bodyPromise;
   }
 
-  async blob(): Promise<domTypes.Blob> {
+  async blob(): Promise<Blob> {
     const arrayBuffer = await this.arrayBuffer();
     return new DenoBlob([arrayBuffer], {
       type: this.contentType,
@@ -384,7 +384,7 @@ export class Response implements domTypes.Response {
     return this.body.arrayBuffer();
   }
 
-  blob(): Promise<domTypes.Blob> {
+  blob(): Promise<Blob> {
     if (this.#bodyViewable() || this.body == null) {
       return Promise.reject(new Error("Response body is null"));
     }

--- a/cli/js/web/streams/shared-internals.ts
+++ b/cli/js/web/streams/shared-internals.ts
@@ -4,18 +4,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // TODO don't disable this warning
 
-import { AbortSignal, QueuingStrategySizeCallback } from "../dom_types.d.ts";
+import { QueuingStrategySizeCallback } from "../dom_types.d.ts";
 
 // common stream fields
 
 export const state_ = Symbol("state_");
 export const storedError_ = Symbol("storedError_");
 
-// ---------
-
 export type ErrorResult = any;
-
-// ---------
 
 export function isInteger(value: number): boolean {
   if (!isFinite(value)) {

--- a/cli/js/web/text_encoding.ts
+++ b/cli/js/web/text_encoding.ts
@@ -25,7 +25,6 @@
 
 import * as base64 from "./base64.ts";
 import { decodeUtf8 } from "./decode_utf8.ts";
-import * as domTypes from "./dom_types.d.ts";
 import { core } from "../core.ts";
 
 const CONTINUE = null;
@@ -449,7 +448,7 @@ export class TextDecoder {
   }
 
   decode(
-    input?: domTypes.BufferSource,
+    input?: BufferSource,
     options: TextDecodeOptions = { stream: false }
   ): string {
     if (options.stream) {

--- a/cli/js/web/url.ts
+++ b/cli/js/web/url.ts
@@ -74,7 +74,7 @@ function generateUUID(): string {
 }
 
 // Keep it outside of URL to avoid any attempts of access.
-export const blobURLMap = new Map<string, domTypes.Blob>();
+export const blobURLMap = new Map<string, Blob>();
 
 function isAbsolutePath(path: string): boolean {
   return path.startsWith("/");
@@ -373,7 +373,7 @@ export class URL implements domTypes.URL {
   }
 
   // TODO(kevinkassimo): implement MediaSource version in the future.
-  static createObjectURL(b: domTypes.Blob): string {
+  static createObjectURL(b: Blob): string {
     const origin = globalThis.location.origin || "http://deno-opaque-origin";
     const key = `blob:${origin}/${generateUUID()}`;
     blobURLMap.set(key, b);


### PR DESCRIPTION
Thanks to @kitsonk's work in #4707 we now have a method of removing duplicated type declarations from `cli/js/web/dom_types.d.ts`. The source of truth should be `cli/js/lib.deno.shared_globals.d.ts`.

This PR is to serve as a template for how other types can be removed. Unfortunately it's a bit difficult to do all of them at once, because there are sometimes subtle changes.