### PR TITLE
add copyFile & copyFileSync to std/node/fs

### DIFF
--- a/std/node/_fs/_fs_copy.ts
+++ b/std/node/_fs/_fs_copy.ts
@@ -1,0 +1,32 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { CallbackWithError } from "./_fs_common.ts";
+
+export function copyFile(
+  source: string,
+  destination: string,
+  callback: CallbackWithError,
+): void {
+  new Promise(async (resolve, reject) => {
+    try {
+      await Deno.copyFile(source, destination);
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  })
+    .then(() => {
+      callback();
+    })
+    .catch((err) => {
+      callback(err);
+    });
+}
+
+export function copyFileSync(source: string, destination: string): void {
+  try {
+    Deno.copyFileSync(source, destination);
+  } catch (err) {
+    throw err;
+  }
+}

--- a/std/node/_fs/_fs_copy.ts
+++ b/std/node/_fs/_fs_copy.ts
@@ -5,7 +5,7 @@ import { CallbackWithError } from "./_fs_common.ts";
 export function copyFile(
   source: string,
   destination: string,
-  callback: CallbackWithError,
+  callback: CallbackWithError
 ): void {
   new Promise(async (resolve, reject) => {
     try {

--- a/std/node/_fs/_fs_copy_test.ts
+++ b/std/node/_fs/_fs_copy_test.ts
@@ -11,7 +11,7 @@ test({
   name: "[std/node/fs] copy file",
   fn: async () => {
     const srouceFile = Deno.makeTempFileSync();
-    const err = await new Promise(async (resolve) => {
+    const err = await new Promise((resolve) => {
       copyFile(srouceFile, destFile, (err: Error | undefined) => resolve(err));
     });
     assert(!err);

--- a/std/node/_fs/_fs_copy_test.ts
+++ b/std/node/_fs/_fs_copy_test.ts
@@ -1,0 +1,33 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { copyFile, copyFileSync } from "./_fs_copy.ts";
+import { existsSync } from "./_fs_exists.ts";
+
+import { assert } from "../../testing/asserts.ts";
+const { test } = Deno;
+
+const destFile = "./destination.txt";
+
+test({
+  name: "[std/node/fs] copy file",
+  fn: async () => {
+    const err = await new Promise(async (resolve) => {
+      const srouceFile = await Deno.makeTempFile();
+      copyFile(srouceFile, destFile, (err: Error | undefined) => resolve(err));
+      Deno.remove(srouceFile);
+    });
+    assert(!err);
+    assert(existsSync(destFile));
+    Deno.remove(destFile);
+  },
+});
+
+test({
+  name: "[std/node/fs] copy file sync",
+  fn: () => {
+    const srouceFile = Deno.makeTempFileSync();
+    copyFileSync(srouceFile, destFile);
+    assert(existsSync(destFile));
+    Deno.removeSync(srouceFile);
+    Deno.removeSync(destFile);
+  },
+});

--- a/std/node/_fs/_fs_copy_test.ts
+++ b/std/node/_fs/_fs_copy_test.ts
@@ -10,13 +10,13 @@ const destFile = "./destination.txt";
 test({
   name: "[std/node/fs] copy file",
   fn: async () => {
+    const srouceFile = Deno.makeTempFileSync();
     const err = await new Promise(async (resolve) => {
-      const srouceFile = await Deno.makeTempFile();
       copyFile(srouceFile, destFile, (err: Error | undefined) => resolve(err));
-      Deno.remove(srouceFile);
     });
     assert(!err);
     assert(existsSync(destFile));
+    Deno.removeSync(srouceFile);
     Deno.removeSync(destFile);
   },
 });

--- a/std/node/_fs/_fs_copy_test.ts
+++ b/std/node/_fs/_fs_copy_test.ts
@@ -17,7 +17,7 @@ test({
     });
     assert(!err);
     assert(existsSync(destFile));
-    Deno.remove(destFile);
+    Deno.removeSync(destFile);
   },
 });
 

--- a/std/node/fs.ts
+++ b/std/node/fs.ts
@@ -10,6 +10,7 @@ import { readFile, readFileSync } from "./_fs/_fs_readFile.ts";
 import { readlink, readlinkSync } from "./_fs/_fs_readlink.ts";
 import { exists, existsSync } from "./_fs/_fs_exists.ts";
 import { mkdir, mkdirSync } from "./_fs/_fs_mkdir.ts";
+import { copyFile, copyFileSync } from "./_fs/_fs_copy.ts";
 
 export {
   access,
@@ -23,6 +24,8 @@ export {
   close,
   closeSync,
   constants,
+  copyFile,
+  copyFileSync,
   exists,
   existsSync,
   readFile,


### PR DESCRIPTION
this PR is going to add copyFile and copyFileSync functions to std/node/fs module
tests are added too