### PR TITLE
flags: better error message on invalid reload url

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1,4 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use crate::error_exit;
 use crate::fs::resolve_from_cwd;
 use clap::App;
 use clap::AppSettings;
@@ -1232,17 +1233,15 @@ fn permission_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 }
 
 // TODO(ry) move this to utility module and add test.
-/// Strips fragment part of URL. Panics on bad URL.
+/// Strips fragment part of URL.
 pub fn resolve_urls(urls: Vec<String>) -> Vec<String> {
   use url::Url;
   let mut out: Vec<String> = vec![];
   for urlstr in urls.iter() {
     use std::str::FromStr;
-    let result = Url::from_str(urlstr);
-    if result.is_err() {
-      panic!("Bad Url: {}", urlstr);
-    }
-    let mut url = result.unwrap();
+    let mut url = Url::from_str(urlstr).unwrap_or_else(|e| {
+      error_exit!("Unable to resolve URL '{}': {}", urlstr, e);
+    });
     url.set_fragment(None);
     let mut full_url = String::from(url.as_str());
     if full_url.len() > 1 && full_url.ends_with('/') {

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -93,6 +93,14 @@ use std::pin::Pin;
 use upgrade::upgrade_command;
 use url::Url;
 
+#[macro_export]
+macro_rules! error_exit {
+  ($($arg:tt)*) => {
+    eprintln!($($arg)*);
+    std::process::exit(1);
+  };
+}
+
 static LOGGER: Logger = Logger;
 
 // TODO(ry) Switch to env_logger or other standard crate.
@@ -419,8 +427,7 @@ async fn doc_command(
   let doc_nodes = match parse_result {
     Ok(nodes) => nodes,
     Err(e) => {
-      eprintln!("{}", e);
-      std::process::exit(1);
+      error_exit!("{}", e);
     }
   };
 
@@ -433,8 +440,7 @@ async fn doc_command(
       if let Some(node) = node {
         doc::printer::format_details(node)
       } else {
-        eprintln!("Node {} was not found!", filter);
-        std::process::exit(1);
+        error_exit!("Node {} was not found!", filter);
       }
     } else {
       doc::printer::format(doc_nodes)
@@ -589,16 +595,14 @@ pub fn main() {
     }
     DenoSubcommand::Completions { buf } => {
       if let Err(e) = write_to_stdout_ignore_sigpipe(&buf) {
-        eprintln!("{}", e);
-        std::process::exit(1);
+        error_exit!("{}", e);
       }
       return;
     }
     DenoSubcommand::Types => {
       let types = get_types();
       if let Err(e) = write_to_stdout_ignore_sigpipe(types.as_bytes()) {
-        eprintln!("{}", e);
-        std::process::exit(1);
+        error_exit!("{}", e);
       }
       return;
     }
@@ -610,7 +614,6 @@ pub fn main() {
 
   let result = tokio_util::run_basic(fut);
   if let Err(err) = result {
-    eprintln!("{}", err.to_string());
-    std::process::exit(1);
+    error_exit!("{}", err.to_string());
   }
 }


### PR DESCRIPTION
Noticed this during slides prep.

Before:
```
$ deno -r=123 https://deno.land/std/examples/welcome.ts
thread 'main' panicked at 'Bad Url: 123', cli/flags.rs:1238:7
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:
```
./target/debug/deno -r=123 https://deno.land/std/examples/welcome.ts
Unable to resolve URL '123': relative URL without a base
```