### PR TITLE
fix(cli/doc): Added extends field to interface

### DIFF
--- a/cli/doc/class.rs
+++ b/cli/doc/class.rs
@@ -62,7 +62,7 @@ pub struct ClassDef {
   pub constructors: Vec<ClassConstructorDef>,
   pub properties: Vec<ClassPropertyDef>,
   pub methods: Vec<ClassMethodDef>,
-  pub super_class: Option<String>,
+  pub extends: Option<String>,
   pub implements: Vec<String>,
   pub type_params: Vec<TsTypeParamDef>,
 }
@@ -90,7 +90,7 @@ pub fn get_doc_for_class_decl(
   let mut methods = vec![];
   let mut properties = vec![];
 
-  let super_class: Option<String> = match &class_decl.class.super_class {
+  let extends: Option<String> = match &class_decl.class.super_class {
     Some(boxed) => {
       use crate::swc_ecma_ast::Expr;
       let expr: &Expr = &**boxed;
@@ -213,7 +213,7 @@ pub fn get_doc_for_class_decl(
   let class_name = class_decl.ident.sym.to_string();
   let class_def = ClassDef {
     is_abstract: class_decl.class.is_abstract,
-    super_class,
+    extends,
     implements,
     constructors,
     properties,

--- a/cli/doc/interface.rs
+++ b/cli/doc/interface.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 use super::params::ts_fn_param_to_param_def;
 use super::parser::DocParser;
+use super::ts_type::ts_entity_name_to_name;
 use super::ts_type::ts_type_ann_to_def;
 use super::ts_type::TsTypeDef;
 use super::ts_type_param::maybe_type_param_decl_to_type_param_defs;
@@ -48,7 +49,7 @@ pub struct InterfaceCallSignatureDef {
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct InterfaceDef {
-  // TODO(bartlomieju): extends
+  pub extends: Vec<String>,
   pub methods: Vec<InterfaceMethodDef>,
   pub properties: Vec<InterfacePropertyDef>,
   pub call_signatures: Vec<InterfaceCallSignatureDef>,
@@ -199,7 +200,14 @@ pub fn get_doc_for_ts_interface_decl(
     interface_decl.type_params.as_ref(),
   );
 
+  let extends: Vec<String> = interface_decl
+    .extends
+    .iter()
+    .map(|expr| ts_entity_name_to_name(&expr.expr))
+    .collect();
+
   let interface_def = InterfaceDef {
+    extends,
     methods,
     properties,
     call_signatures,

--- a/cli/doc/printer.rs
+++ b/cli/doc/printer.rs
@@ -429,11 +429,11 @@ fn format_function_signature(node: &doc::DocNode, indent: i64) -> String {
 
 fn format_class_signature(node: &doc::DocNode, indent: i64) -> String {
   let class_def = node.class_def.clone().unwrap();
-  let super_suffix = if let Some(super_class) = class_def.super_class {
+  let extends_suffix = if let Some(extends) = class_def.extends {
     format!(
       " {} {}",
       colors::magenta("extends".to_string()),
-      colors::bold(super_class)
+      colors::bold(extends)
     )
   } else {
     String::from("")
@@ -455,7 +455,7 @@ fn format_class_signature(node: &doc::DocNode, indent: i64) -> String {
       "{} {}{}{}\n",
       colors::magenta("class".to_string()),
       colors::bold(node.name.clone()),
-      super_suffix,
+      extends_suffix,
       implements_suffix,
     ),
     indent,
@@ -495,11 +495,23 @@ fn format_enum_signature(node: &doc::DocNode, indent: i64) -> String {
 }
 
 fn format_interface_signature(node: &doc::DocNode, indent: i64) -> String {
+  let interface_def = node.interface_def.clone().unwrap();
+  let extends = &interface_def.extends;
+  let extends_suffix = if !extends.is_empty() {
+    format!(
+      " {} {}",
+      colors::magenta("extends".to_string()),
+      colors::bold(extends.join(", "))
+    )
+  } else {
+    String::from("")
+  };
   add_indent(
     format!(
-      "{} {}\n",
+      "{} {}{}\n",
       colors::magenta("interface".to_string()),
-      colors::bold(node.name.clone())
+      colors::bold(node.name.clone()),
+      extends_suffix
     ),
     indent,
   )

--- a/cli/doc/tests.rs
+++ b/cli/doc/tests.rs
@@ -304,7 +304,7 @@ export class Foobar extends Fizz implements Buzz, Aldrin {
     "jsDoc": "Class doc",
     "classDef": {
       "isAbstract": false,
-      "superClass": "Fizz",
+      "extends": "Fizz",
       "implements": ["Buzz", "Aldrin"],
       "typeParams": [],
       "constructors": [
@@ -496,10 +496,16 @@ export class Foobar extends Fizz implements Buzz, Aldrin {
 #[tokio::test]
 async fn export_interface() {
   let source_code = r#"
+interface Foo {
+  foo(): void;
+}
+interface Bar {
+  bar(): void;
+}
 /**
  * Interface js doc
  */
-export interface Reader {
+export interface Reader extends Foo, Bar {
     /** Read n bytes */
     read(buf: Uint8Array, something: unknown): Promise<number>
 }
@@ -514,17 +520,18 @@ export interface Reader {
       "name": "Reader",
       "location": {
         "filename": "test.ts",
-        "line": 5,
+        "line": 11,
         "col": 0
       },
       "jsDoc": "Interface js doc",
       "interfaceDef": {
+        "extends": ["Foo", "Bar"],
         "methods": [
           {
             "name": "read",
             "location": {
               "filename": "test.ts",
-              "line": 7,
+              "line": 13,
               "col": 4
             },
             "jsDoc": "Read n bytes",
@@ -578,7 +585,7 @@ export interface Reader {
 
   assert!(
     colors::strip_ansi_codes(super::printer::format(entries).as_str())
-      .contains("interface Reader")
+      .contains("interface Reader extends Foo, Bar")
   );
 }
 
@@ -604,6 +611,7 @@ export interface TypedIface<T> {
       },
       "jsDoc": null,
       "interfaceDef": {
+        "extends": [],
         "methods": [
           {
             "name": "something",


### PR DESCRIPTION
**breaking**

Also renamed the `super_class` field in the `ClassDef` to `extends`, because it can be an `interface` *or* `class`.