### PR TITLE
ci: Set restore-keys for cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,10 @@ jobs:
             target/*/gn_out
           key:
             ${{ matrix.config.os }}-${{ matrix.config.kind }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.config.os }}-${{ matrix.config.kind }}-${{ hashFiles('Cargo.lock') }}
+            ${{ matrix.config.os }}-${{ matrix.config.kind }}-
+            ${{ matrix.config.os }}-
 
       - name: lint.py
         if: matrix.config.kind == 'lint'


### PR DESCRIPTION
Before this commit, when Cargo.lock changes, cache is completely rebuilt, wasting time.

After this commit, if cache for a specific Cargo.lock is not found, it will fallback to find cache of another Cargo.lock.

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
