### PR TITLE
Add support for AbortController/AbortSignal

### DIFF
--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -2,6 +2,8 @@
 
 import "./lib.deno.shared_globals.d.ts";
 
+import * as abortController from "./web/abort_controller.ts";
+import * as abortSignal from "./web/abort_signal.ts";
 import * as blob from "./web/blob.ts";
 import * as consoleTypes from "./web/console.ts";
 import * as promiseTypes from "./web/promise.ts";
@@ -73,7 +75,7 @@ declare global {
     dispatch(
       opId: number,
       control: Uint8Array,
-      zeroCopy?: ArrayBufferView | null
+      zeroCopy?: ArrayBufferView | null,
     ): Uint8Array | null;
     setAsyncHandler(opId: number, cb: (msg: Uint8Array) => void): void;
     sharedQueue: {
@@ -92,7 +94,7 @@ declare global {
     send(
       opId: number,
       control: null | ArrayBufferView,
-      data?: ArrayBufferView
+      data?: ArrayBufferView,
     ): null | Uint8Array;
 
     setMacrotaskCallback(cb: () => boolean): void;
@@ -101,7 +103,7 @@ declare global {
 
     evalContext(
       code: string,
-      scriptName?: string
+      scriptName?: string,
     ): [unknown, EvalErrorInfo | null];
 
     formatError: (e: Error) => string;
@@ -140,12 +142,12 @@ declare global {
     | undefined;
   var onerror:
     | ((
-        msg: string,
-        source: string,
-        lineno: number,
-        colno: number,
-        e: Event
-      ) => boolean | void)
+      msg: string,
+      source: string,
+      lineno: number,
+      colno: number,
+      e: Event,
+    ) => boolean | void)
     | undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -207,6 +209,8 @@ export const windowOrWorkerGlobalScopeMethods = {
 // Other properties shared between WindowScope and WorkerGlobalScope
 export const windowOrWorkerGlobalScopeProperties = {
   console: writable(new consoleTypes.Console(core.print)),
+  AbortController: nonEnumerable(abortController.AbortControllerImpl),
+  AbortSignal: nonEnumerable(abortSignal.AbortSignalImpl),
   Blob: nonEnumerable(blob.DenoBlob),
   File: nonEnumerable(domFile.DomFileImpl),
   CustomEvent: nonEnumerable(customEvent.CustomEventImpl),
@@ -233,10 +237,10 @@ export function setEventTargetData(value: any): void {
 
 export const eventTargetProperties = {
   addEventListener: readOnly(
-    eventTarget.EventTargetImpl.prototype.addEventListener
+    eventTarget.EventTargetImpl.prototype.addEventListener,
   ),
   dispatchEvent: readOnly(eventTarget.EventTargetImpl.prototype.dispatchEvent),
   removeEventListener: readOnly(
-    eventTarget.EventTargetImpl.prototype.removeEventListener
+    eventTarget.EventTargetImpl.prototype.removeEventListener,
   ),
 };

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -75,7 +75,7 @@ declare global {
     dispatch(
       opId: number,
       control: Uint8Array,
-      zeroCopy?: ArrayBufferView | null,
+      zeroCopy?: ArrayBufferView | null
     ): Uint8Array | null;
     setAsyncHandler(opId: number, cb: (msg: Uint8Array) => void): void;
     sharedQueue: {
@@ -94,7 +94,7 @@ declare global {
     send(
       opId: number,
       control: null | ArrayBufferView,
-      data?: ArrayBufferView,
+      data?: ArrayBufferView
     ): null | Uint8Array;
 
     setMacrotaskCallback(cb: () => boolean): void;
@@ -103,7 +103,7 @@ declare global {
 
     evalContext(
       code: string,
-      scriptName?: string,
+      scriptName?: string
     ): [unknown, EvalErrorInfo | null];
 
     formatError: (e: Error) => string;
@@ -142,12 +142,12 @@ declare global {
     | undefined;
   var onerror:
     | ((
-      msg: string,
-      source: string,
-      lineno: number,
-      colno: number,
-      e: Event,
-    ) => boolean | void)
+        msg: string,
+        source: string,
+        lineno: number,
+        colno: number,
+        e: Event
+      ) => boolean | void)
     | undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -237,10 +237,10 @@ export function setEventTargetData(value: any): void {
 
 export const eventTargetProperties = {
   addEventListener: readOnly(
-    eventTarget.EventTargetImpl.prototype.addEventListener,
+    eventTarget.EventTargetImpl.prototype.addEventListener
   ),
   dispatchEvent: readOnly(eventTarget.EventTargetImpl.prototype.dispatchEvent),
   removeEventListener: readOnly(
-    eventTarget.EventTargetImpl.prototype.removeEventListener,
+    eventTarget.EventTargetImpl.prototype.removeEventListener
   ),
 };

--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -31,7 +31,7 @@ declare namespace WebAssembly {
    * its first `WebAssembly.Instance`. */
   function instantiate(
     bufferSource: BufferSource,
-    importObject?: object
+    importObject?: object,
   ): Promise<WebAssemblyInstantiatedSource>;
 
   /** Takes an already-compiled `WebAssembly.Module` and returns a `Promise`
@@ -39,7 +39,7 @@ declare namespace WebAssembly {
    * the `Module` has already been compiled. */
   function instantiate(
     module: Module,
-    importObject?: object
+    importObject?: object,
   ): Promise<Instance>;
 
   /** Compiles and instantiates a WebAssembly module directly from a streamed
@@ -47,7 +47,7 @@ declare namespace WebAssembly {
    * code. */
   function instantiateStreaming(
     source: Promise<Response>,
-    importObject?: object
+    importObject?: object,
   ): Promise<WebAssemblyInstantiatedSource>;
 
   /** Validates a given typed array of WebAssembly binary code, returning
@@ -73,7 +73,7 @@ declare namespace WebAssembly {
      * custom sections in the module with the given string name. */
     static customSections(
       moduleObject: Module,
-      sectionName: string
+      sectionName: string,
     ): ArrayBuffer;
 
     /** Given a `Module`, returns an array containing descriptions of all the
@@ -197,7 +197,7 @@ declare var location: Location;
 declare function addEventListener(
   type: string,
   callback: EventListenerOrEventListenerObject | null,
-  options?: boolean | AddEventListenerOptions | undefined
+  options?: boolean | AddEventListenerOptions | undefined,
 ): void;
 
 declare function dispatchEvent(event: Event): boolean;
@@ -205,7 +205,7 @@ declare function dispatchEvent(event: Event): boolean;
 declare function removeEventListener(
   type: string,
   callback: EventListenerOrEventListenerObject | null,
-  options?: boolean | EventListenerOptions | undefined
+  options?: boolean | EventListenerOptions | undefined,
 ): void;
 
 declare interface ImportMeta {
@@ -220,7 +220,7 @@ interface DomIterable<K, V> {
   [Symbol.iterator](): IterableIterator<[K, V]>;
   forEach(
     callback: (value: V, key: K, parent: this) => void,
-    thisArg?: any
+    thisArg?: any,
   ): void;
 }
 
@@ -438,7 +438,7 @@ declare class Console {
       depth: number;
       colors: boolean;
       indentLevel: number;
-    }>
+    }>,
   ) => void;
 
   /** From MDN:
@@ -458,7 +458,7 @@ declare class Console {
       depth: number;
       colors: boolean;
       indentLevel: number;
-    }>
+    }>,
   ) => void;
 
   /** Writes the arguments to stdout */
@@ -553,7 +553,7 @@ interface Headers {
   set(name: string, value: string): void;
   forEach(
     callbackfn: (value: string, key: string, parent: Headers) => void,
-    thisArg?: any
+    thisArg?: any,
   ): void;
 }
 
@@ -591,7 +591,7 @@ interface Headers extends DomIterable<string, string> {
   values(): IterableIterator<string>;
   forEach(
     callbackfn: (value: string, key: string, parent: this) => void,
-    thisArg?: any
+    thisArg?: any,
   ): void;
   /** The Symbol.iterator well-known symbol specifies the default
    * iterator for this Headers object
@@ -842,7 +842,7 @@ declare const Response: {
     rid: number,
     redirected_: boolean,
     type_?: null | ResponseType,
-    body_?: null | Body
+    body_?: null | Body,
   ): Response;
 
   error(): Response;
@@ -852,7 +852,7 @@ declare const Response: {
 /** Fetch a resource from the network. */
 declare function fetch(
   input: Request | URL | string,
-  init?: RequestInit
+  init?: RequestInit,
 ): Promise<Response>;
 
 declare function atob(s: string): string;
@@ -869,7 +869,7 @@ declare class TextDecoder {
   readonly ignoreBOM = false;
   constructor(
     label?: string,
-    options?: { fatal?: boolean; ignoreBOM?: boolean }
+    options?: { fatal?: boolean; ignoreBOM?: boolean },
   );
   /** Returns the result of running encoding's decoder. */
   decode(input?: BufferSource, options?: { stream?: false }): string;
@@ -883,7 +883,7 @@ declare class TextEncoder {
   encode(input?: string): Uint8Array;
   encodeInto(
     input: string,
-    dest: Uint8Array
+    dest: Uint8Array,
   ): { read: number; written: number };
   readonly [Symbol.toStringTag]: string;
 }
@@ -954,7 +954,7 @@ interface URLSearchParams {
    */
   forEach(
     callbackfn: (value: string, key: string, parent: this) => void,
-    thisArg?: any
+    thisArg?: any,
   ): void;
 
   /** Returns an iterator allowing to go through all keys contained
@@ -1007,7 +1007,7 @@ interface URLSearchParams {
 declare const URLSearchParams: {
   prototype: URLSearchParams;
   new (
-    init?: string[][] | Record<string, string> | string | URLSearchParams
+    init?: string[][] | Record<string, string> | string | URLSearchParams,
   ): URLSearchParams;
   toString(): string;
 };
@@ -1080,7 +1080,7 @@ declare class Worker extends EventTarget {
     options?: {
       type?: "classic" | "module";
       name?: string;
-    }
+    },
   );
   postMessage(message: any, transfer: ArrayBuffer[]): void;
   postMessage(message: any, options?: PostMessageOptions): void;
@@ -1198,7 +1198,7 @@ declare class EventTarget {
   addEventListener(
     type: string,
     listener: EventListenerOrEventListenerObject | null,
-    options?: boolean | AddEventListenerOptions
+    options?: boolean | AddEventListenerOptions,
   ): void;
   /** Dispatches a synthetic event event to target and returns true if either
    * event's cancelable attribute value is false or its preventDefault() method
@@ -1209,7 +1209,7 @@ declare class EventTarget {
   removeEventListener(
     type: string,
     callback: EventListenerOrEventListenerObject | null,
-    options?: EventListenerOptions | boolean
+    options?: EventListenerOptions | boolean,
   ): void;
   [Symbol.toStringTag]: string;
 }
@@ -1256,38 +1256,46 @@ declare class CustomEvent<T = any> extends Event {
   readonly detail: T;
 }
 
+/** A controller object that allows you to abort one or more DOM requests as and
+ * when desired. */
+declare class AbortController {
+  /** Returns the AbortSignal object associated with this object. */
+  readonly signal: AbortSignal;
+  /** Invoking this method will set this object's AbortSignal's aborted flag and
+   * signal to any observers that the associated activity is to be aborted. */
+  abort(): void;
+}
+
 interface AbortSignalEventMap {
-  abort: Event;
+  "abort": Event;
 }
 
 /** A signal object that allows you to communicate with a DOM request (such as a
  * Fetch) and abort it if required via an AbortController object. */
 interface AbortSignal extends EventTarget {
-  /**
-   * Returns true if this AbortSignal's AbortController has signaled to abort,
-   * and false otherwise.
-   */
+  /** Returns true if this AbortSignal's AbortController has signaled to abort,
+   * and false otherwise. */
   readonly aborted: boolean;
   onabort: ((this: AbortSignal, ev: Event) => any) | null;
   addEventListener<K extends keyof AbortSignalEventMap>(
     type: K,
     listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
-    options?: boolean | AddEventListenerOptions
+    options?: boolean | AddEventListenerOptions,
   ): void;
   addEventListener(
     type: string,
     listener: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions
+    options?: boolean | AddEventListenerOptions,
   ): void;
   removeEventListener<K extends keyof AbortSignalEventMap>(
     type: K,
     listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
-    options?: boolean | EventListenerOptions
+    options?: boolean | EventListenerOptions,
   ): void;
   removeEventListener(
     type: string,
     listener: EventListenerOrEventListenerObject,
-    options?: boolean | EventListenerOptions
+    options?: boolean | EventListenerOptions,
   ): void;
 }
 

--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -31,7 +31,7 @@ declare namespace WebAssembly {
    * its first `WebAssembly.Instance`. */
   function instantiate(
     bufferSource: BufferSource,
-    importObject?: object,
+    importObject?: object
   ): Promise<WebAssemblyInstantiatedSource>;
 
   /** Takes an already-compiled `WebAssembly.Module` and returns a `Promise`
@@ -39,7 +39,7 @@ declare namespace WebAssembly {
    * the `Module` has already been compiled. */
   function instantiate(
     module: Module,
-    importObject?: object,
+    importObject?: object
   ): Promise<Instance>;
 
   /** Compiles and instantiates a WebAssembly module directly from a streamed
@@ -47,7 +47,7 @@ declare namespace WebAssembly {
    * code. */
   function instantiateStreaming(
     source: Promise<Response>,
-    importObject?: object,
+    importObject?: object
   ): Promise<WebAssemblyInstantiatedSource>;
 
   /** Validates a given typed array of WebAssembly binary code, returning
@@ -73,7 +73,7 @@ declare namespace WebAssembly {
      * custom sections in the module with the given string name. */
     static customSections(
       moduleObject: Module,
-      sectionName: string,
+      sectionName: string
     ): ArrayBuffer;
 
     /** Given a `Module`, returns an array containing descriptions of all the
@@ -197,7 +197,7 @@ declare var location: Location;
 declare function addEventListener(
   type: string,
   callback: EventListenerOrEventListenerObject | null,
-  options?: boolean | AddEventListenerOptions | undefined,
+  options?: boolean | AddEventListenerOptions | undefined
 ): void;
 
 declare function dispatchEvent(event: Event): boolean;
@@ -205,7 +205,7 @@ declare function dispatchEvent(event: Event): boolean;
 declare function removeEventListener(
   type: string,
   callback: EventListenerOrEventListenerObject | null,
-  options?: boolean | EventListenerOptions | undefined,
+  options?: boolean | EventListenerOptions | undefined
 ): void;
 
 declare interface ImportMeta {
@@ -220,7 +220,7 @@ interface DomIterable<K, V> {
   [Symbol.iterator](): IterableIterator<[K, V]>;
   forEach(
     callback: (value: V, key: K, parent: this) => void,
-    thisArg?: any,
+    thisArg?: any
   ): void;
 }
 
@@ -438,7 +438,7 @@ declare class Console {
       depth: number;
       colors: boolean;
       indentLevel: number;
-    }>,
+    }>
   ) => void;
 
   /** From MDN:
@@ -458,7 +458,7 @@ declare class Console {
       depth: number;
       colors: boolean;
       indentLevel: number;
-    }>,
+    }>
   ) => void;
 
   /** Writes the arguments to stdout */
@@ -553,7 +553,7 @@ interface Headers {
   set(name: string, value: string): void;
   forEach(
     callbackfn: (value: string, key: string, parent: Headers) => void,
-    thisArg?: any,
+    thisArg?: any
   ): void;
 }
 
@@ -591,7 +591,7 @@ interface Headers extends DomIterable<string, string> {
   values(): IterableIterator<string>;
   forEach(
     callbackfn: (value: string, key: string, parent: this) => void,
-    thisArg?: any,
+    thisArg?: any
   ): void;
   /** The Symbol.iterator well-known symbol specifies the default
    * iterator for this Headers object
@@ -842,7 +842,7 @@ declare const Response: {
     rid: number,
     redirected_: boolean,
     type_?: null | ResponseType,
-    body_?: null | Body,
+    body_?: null | Body
   ): Response;
 
   error(): Response;
@@ -852,7 +852,7 @@ declare const Response: {
 /** Fetch a resource from the network. */
 declare function fetch(
   input: Request | URL | string,
-  init?: RequestInit,
+  init?: RequestInit
 ): Promise<Response>;
 
 declare function atob(s: string): string;
@@ -869,7 +869,7 @@ declare class TextDecoder {
   readonly ignoreBOM = false;
   constructor(
     label?: string,
-    options?: { fatal?: boolean; ignoreBOM?: boolean },
+    options?: { fatal?: boolean; ignoreBOM?: boolean }
   );
   /** Returns the result of running encoding's decoder. */
   decode(input?: BufferSource, options?: { stream?: false }): string;
@@ -883,7 +883,7 @@ declare class TextEncoder {
   encode(input?: string): Uint8Array;
   encodeInto(
     input: string,
-    dest: Uint8Array,
+    dest: Uint8Array
   ): { read: number; written: number };
   readonly [Symbol.toStringTag]: string;
 }
@@ -954,7 +954,7 @@ interface URLSearchParams {
    */
   forEach(
     callbackfn: (value: string, key: string, parent: this) => void,
-    thisArg?: any,
+    thisArg?: any
   ): void;
 
   /** Returns an iterator allowing to go through all keys contained
@@ -1007,7 +1007,7 @@ interface URLSearchParams {
 declare const URLSearchParams: {
   prototype: URLSearchParams;
   new (
-    init?: string[][] | Record<string, string> | string | URLSearchParams,
+    init?: string[][] | Record<string, string> | string | URLSearchParams
   ): URLSearchParams;
   toString(): string;
 };
@@ -1080,7 +1080,7 @@ declare class Worker extends EventTarget {
     options?: {
       type?: "classic" | "module";
       name?: string;
-    },
+    }
   );
   postMessage(message: any, transfer: ArrayBuffer[]): void;
   postMessage(message: any, options?: PostMessageOptions): void;
@@ -1198,7 +1198,7 @@ declare class EventTarget {
   addEventListener(
     type: string,
     listener: EventListenerOrEventListenerObject | null,
-    options?: boolean | AddEventListenerOptions,
+    options?: boolean | AddEventListenerOptions
   ): void;
   /** Dispatches a synthetic event event to target and returns true if either
    * event's cancelable attribute value is false or its preventDefault() method
@@ -1209,7 +1209,7 @@ declare class EventTarget {
   removeEventListener(
     type: string,
     callback: EventListenerOrEventListenerObject | null,
-    options?: EventListenerOptions | boolean,
+    options?: EventListenerOptions | boolean
   ): void;
   [Symbol.toStringTag]: string;
 }
@@ -1267,7 +1267,7 @@ declare class AbortController {
 }
 
 interface AbortSignalEventMap {
-  "abort": Event;
+  abort: Event;
 }
 
 /** A signal object that allows you to communicate with a DOM request (such as a
@@ -1280,22 +1280,22 @@ interface AbortSignal extends EventTarget {
   addEventListener<K extends keyof AbortSignalEventMap>(
     type: K,
     listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
-    options?: boolean | AddEventListenerOptions,
+    options?: boolean | AddEventListenerOptions
   ): void;
   addEventListener(
     type: string,
     listener: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions,
+    options?: boolean | AddEventListenerOptions
   ): void;
   removeEventListener<K extends keyof AbortSignalEventMap>(
     type: K,
     listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
-    options?: boolean | EventListenerOptions,
+    options?: boolean | EventListenerOptions
   ): void;
   removeEventListener(
     type: string,
     listener: EventListenerOrEventListenerObject,
-    options?: boolean | EventListenerOptions,
+    options?: boolean | EventListenerOptions
   ): void;
 }
 

--- a/cli/js/tests/abort_controller_test.ts
+++ b/cli/js/tests/abort_controller_test.ts
@@ -1,0 +1,56 @@
+import { unitTest, assert, assertEquals } from "./test_util.ts";
+
+unitTest(function basicAbortController() {
+  const controller = new AbortController();
+  assert(controller);
+  const { signal } = controller;
+  assert(signal);
+  assertEquals(signal.aborted, false);
+  controller.abort();
+  assertEquals(signal.aborted, true);
+});
+
+unitTest(function signalCallsOnabort() {
+  const controller = new AbortController();
+  const { signal } = controller;
+  let called = false;
+  signal.onabort = (evt): void => {
+    assert(evt);
+    assertEquals(evt.type, "abort");
+    called = true;
+  };
+  controller.abort();
+  assert(called);
+});
+
+unitTest(function signalEventListener() {
+  const controller = new AbortController();
+  const { signal } = controller;
+  let called = false;
+  signal.addEventListener("abort", function (ev) {
+    assert(this === signal);
+    assertEquals(ev.type, "abort");
+    called = true;
+  });
+  controller.abort();
+  assert(called);
+});
+
+unitTest(function onlyAbortsOnce() {
+  const controller = new AbortController();
+  const { signal } = controller;
+  let called = 0;
+  signal.addEventListener("abort", () => called++);
+  signal.onabort = (): void => {
+    called++;
+  };
+  controller.abort();
+  assertEquals(called, 2);
+  controller.abort();
+  assertEquals(called, 2);
+});
+
+unitTest(function controllerHasProperToString() {
+  const actual = Object.prototype.toString.call(new AbortController());
+  assertEquals(actual, "[object AbortController]");
+});

--- a/cli/js/tests/unit_tests.ts
+++ b/cli/js/tests/unit_tests.ts
@@ -4,6 +4,7 @@
 //
 // Test runner automatically spawns subprocesses for each required permissions combination.
 
+import "./abort_controller_test.ts";
 import "./blob_test.ts";
 import "./body_test.ts";
 import "./buffer_test.ts";

--- a/cli/js/web/abort_controller.ts
+++ b/cli/js/web/abort_controller.ts
@@ -1,0 +1,23 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { AbortSignalImpl, signalAbort } from "./abort_signal.ts";
+
+export class AbortControllerImpl implements AbortController {
+  #signal = new AbortSignalImpl();
+
+  get signal(): AbortSignal {
+    return this.#signal;
+  }
+
+  abort(): void {
+    this.#signal[signalAbort]();
+  }
+
+  get [Symbol.toStringTag](): string {
+    return "AbortController";
+  }
+}
+
+Object.defineProperty(AbortControllerImpl, "name", {
+  value: "AbortController",
+  configurable: true,
+});

--- a/cli/js/web/abort_signal.ts
+++ b/cli/js/web/abort_signal.ts
@@ -10,6 +10,7 @@ export class AbortSignalImpl extends EventTargetImpl implements AbortSignal {
   #aborted?: boolean;
   #abortAlgorithms = new Set<() => void>();
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onabort: ((this: AbortSignal, ev: Event) => any) | null = null;
 
   [add](algorithm: () => void): void {

--- a/cli/js/web/abort_signal.ts
+++ b/cli/js/web/abort_signal.ts
@@ -1,0 +1,57 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { EventImpl } from "./event.ts";
+import { EventTargetImpl } from "./event_target.ts";
+
+export const add = Symbol("add");
+export const signalAbort = Symbol("signalAbort");
+export const remove = Symbol("remove");
+
+export class AbortSignalImpl extends EventTargetImpl implements AbortSignal {
+  #aborted?: boolean;
+  #abortAlgorithms = new Set<() => void>();
+
+  onabort: ((this: AbortSignal, ev: Event) => any) | null = null;
+
+  [add](algorithm: () => void): void {
+    this.#abortAlgorithms.add(algorithm);
+  }
+
+  [signalAbort](): void {
+    if (this.#aborted) {
+      return;
+    }
+    this.#aborted = true;
+    for (const algorithm of this.#abortAlgorithms) {
+      algorithm();
+    }
+    this.#abortAlgorithms.clear();
+    this.dispatchEvent(new EventImpl("abort"));
+  }
+
+  [remove](algorithm: () => void): void {
+    this.#abortAlgorithms.delete(algorithm);
+  }
+
+  constructor() {
+    super();
+    this.addEventListener("abort", (evt: Event) => {
+      const { onabort } = this;
+      if (typeof onabort === "function") {
+        onabort.call(this, evt);
+      }
+    });
+  }
+
+  get aborted(): boolean {
+    return Boolean(this.#aborted);
+  }
+
+  get [Symbol.toStringTag](): string {
+    return "AbortSignal";
+  }
+}
+
+Object.defineProperty(AbortSignalImpl, "name", {
+  value: "AbortSignal",
+  configurable: true,
+});


### PR DESCRIPTION
Fixes #3345

This add support for [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).  It is needed by Streams (not sure how we got away without it currently) and it is needed for abortable Fetch.

There would still be work to integrate it into Fetch and have the correct behaviour when a signal is aborted, but the mechanics should be compliant with the DOM spec now.