### PR TITLE
Implement first part of React Dom Server in std/types

### DIFF
--- a/std/types/react-dom/README.md
+++ b/std/types/react-dom/README.md
@@ -19,7 +19,8 @@ import ReactDomServer from "https://dev.jspm.io/react-dom@16.13.1/server.js";
 
 #### Notes:
 
-React Dom tests were removed to be implemented later in a full test suit that covers all cases
+React Dom tests were removed to be implemented later in a full test suit that
+covers all cases
 
 React Dom Server is partially implemented due to current incompatibility with
 Node's Readable Streams.

--- a/std/types/react-dom/README.md
+++ b/std/types/react-dom/README.md
@@ -19,6 +19,8 @@ import ReactDomServer from "https://dev.jspm.io/react-dom@16.13.1/server.js";
 
 #### Notes:
 
+React Dom tests were removed to be implemented later in a full test suit that covers all cases
+
 React Dom Server is partially implemented due to current incompatibility with
 Node's Readable Streams.
 

--- a/std/types/react-dom/README.md
+++ b/std/types/react-dom/README.md
@@ -14,7 +14,7 @@ import ReactDOM from "https://cdn.pika.dev/@pika/react-dom@v16.13.1";
 
 ```typescript
 // @deno-types="https://deno.land/std/types/react-dom/v16.9.0/server/react-dom-server.d.ts"
-import ReactDOM from "https://dev.jspm.io/react-dom@16.13.1/server.js";
+import ReactDomServer from "https://dev.jspm.io/react-dom@16.13.1/server.js";
 ```
 
 #### Notes:

--- a/std/types/react-dom/README.md
+++ b/std/types/react-dom/README.md
@@ -21,3 +21,8 @@ import ReactDOM from "https://dev.jspm.io/react-dom@16.13.1/server.js";
 
 React Dom Server is partially implemented due to current incompatibility with
 Node's Readable Streams.
+
+Non supported functions:
+
+1. renderToNodeStream
+1. renderToStaticNodeStream

--- a/std/types/react-dom/README.md
+++ b/std/types/react-dom/README.md
@@ -13,7 +13,7 @@ import ReactDOM from "https://cdn.pika.dev/@pika/react-dom@v16.13.1";
 ```
 
 ```typescript
-// @deno-types="https://deno.land/std/types/react-dom/v16.9.0/server/react-dom-server.d.ts"
+// @deno-types="https://deno.land/std/types/react-dom/v16.9.0/server.d.ts"
 import ReactDomServer from "https://dev.jspm.io/react-dom@16.13.1/server.js";
 ```
 

--- a/std/types/react-dom/README.md
+++ b/std/types/react-dom/README.md
@@ -11,3 +11,13 @@ Facebook's React library.
 // @deno-types="https://deno.land/std/types/react-dom/v16.13.1/react-dom.d.ts"
 import ReactDOM from "https://cdn.pika.dev/@pika/react-dom@v16.13.1";
 ```
+
+```typescript
+// @deno-types="https://deno.land/std/types/react-dom/v16.9.0/server/react-dom-server.d.ts"
+import ReactDOM from "https://dev.jspm.io/react-dom@16.13.1/server.js";
+```
+
+#### Notes:
+
+React Dom Server is partially implemented due to current incompatibility with
+Node's Readable Streams.

--- a/std/types/react-dom/v16.13.1/server.d.ts
+++ b/std/types/react-dom/v16.13.1/server.d.ts
@@ -1,4 +1,4 @@
-import { ReactElement } from "../../../react/v16.13.1/react.d.ts";
+import { ReactElement } from "../../react/v16.13.1/react.d.ts";
 
 export function renderToString(element: ReactElement): string;
 export function renderToStaticMarkup(element: ReactElement): string;

--- a/std/types/react-dom/v16.13.1/server/react-dom-server.d.ts
+++ b/std/types/react-dom/v16.13.1/server/react-dom-server.d.ts
@@ -1,0 +1,4 @@
+import { ReactElement } from "../../../react/v16.13.1/react.d.ts";
+
+export function renderToString(element: ReactElement): string;
+export function renderToStaticMarkup(element: ReactElement): string;

--- a/std/types/react-dom/v16.13.1/tests/react-dom_mock.js
+++ b/std/types/react-dom/v16.13.1/tests/react-dom_mock.js
@@ -1,9 +1,0 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-
-const ReactDOM = {
-  render(element) {
-    return JSON.stringify(element);
-  },
-};
-
-export default ReactDOM;

--- a/std/types/react-dom/v16.13.1/tests/react-dom_test.tsx
+++ b/std/types/react-dom/v16.13.1/tests/react-dom_test.tsx
@@ -1,11 +1,34 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 // @deno-types="../../../react/v16.13.1/react.d.ts"
-import React from "./react_mock.js";
+import React from "https://cdn.pika.dev/@pika/react@v16.13.1";
 // @deno-types="../react-dom.d.ts"
-import ReactDOM from "./react-dom_mock.js";
-
+import ReactDOM from "https://dev.jspm.io/react-dom@16.13.1";
+// @deno-types="../server/react-dom-server.d.ts"
+import ReactDomServer from "https://dev.jspm.io/react-dom@16.13.1/server.js";
 import { assertEquals } from "../../../../testing/asserts.ts";
+
+class ClassComponent extends React.Component {
+  render() {
+    return (
+      <h1>Testing class component</h1>
+    );
+  }
+}
+
+const FunctionalComponent = () => (
+  <h1>Testing functional component</h1>
+);
+
+function NestedComponent (){
+  return (
+    <div>
+      <span>Testing nested components</span>,
+      <ClassComponent/>
+      <FunctionalComponent/>
+    </div>
+  );
+}
 
 const { test } = Deno;
 
@@ -17,4 +40,34 @@ test({
       '"{\\"type\\":\\"div\\",\\"props\\":null,\\"children\\":[]}"'
     );
   }
+});
+
+Deno.test({
+  name: "ReactDomServer is typed to render",
+  fn() {
+    assertEquals(
+      ReactDomServer.renderToString(<ClassComponent />),
+      '<h1 data-reactroot="">Testing class component</h1>',
+    );
+    assertEquals(
+      ReactDomServer.renderToString(<FunctionalComponent />),
+      '<h1 data-reactroot="">Testing functional component</h1>',
+    );
+    assertEquals(
+      ReactDomServer.renderToString(<NestedComponent />),
+      '<div data-reactroot=""><span>Testing nested components</span>,<h1>Testing class component</h1><h1>Testing functional component</h1></div>',
+    );
+    assertEquals(
+      ReactDomServer.renderToStaticMarkup(<ClassComponent />),
+      '<h1>Testing class component</h1>',
+    );
+    assertEquals(
+      ReactDomServer.renderToStaticMarkup(<FunctionalComponent />),
+      '<h1>Testing functional component</h1>',
+    );
+    assertEquals(
+      ReactDomServer.renderToStaticMarkup(<NestedComponent />),
+      '<div><span>Testing nested components</span>,<h1>Testing class component</h1><h1>Testing functional component</h1></div>',
+    );
+  },
 });

--- a/std/types/react-dom/v16.13.1/tests/react-dom_test.tsx
+++ b/std/types/react-dom/v16.13.1/tests/react-dom_test.tsx
@@ -2,7 +2,7 @@
 
 // @deno-types="../../../react/v16.13.1/react.d.ts"
 import React from "https://cdn.pika.dev/@pika/react@v16.13.1";
-// @deno-types="../server/react-dom-server.d.ts"
+// @deno-types="../server.d.ts"
 import ReactDomServer from "https://dev.jspm.io/react-dom@16.13.1/server.js";
 import { assertEquals } from "../../../../testing/asserts.ts";
 

--- a/std/types/react-dom/v16.13.1/tests/react-dom_test.tsx
+++ b/std/types/react-dom/v16.13.1/tests/react-dom_test.tsx
@@ -2,8 +2,6 @@
 
 // @deno-types="../../../react/v16.13.1/react.d.ts"
 import React from "https://cdn.pika.dev/@pika/react@v16.13.1";
-// @deno-types="../react-dom.d.ts"
-import ReactDOM from "https://dev.jspm.io/react-dom@16.13.1";
 // @deno-types="../server/react-dom-server.d.ts"
 import ReactDomServer from "https://dev.jspm.io/react-dom@16.13.1/server.js";
 import { assertEquals } from "../../../../testing/asserts.ts";
@@ -29,18 +27,6 @@ function NestedComponent (){
     </div>
   );
 }
-
-const { test } = Deno;
-
-test({
-  name: "ReactDOM is typed to render",
-  fn() {
-    assertEquals(
-      ReactDOM.render(<div />, null),
-      '"{\\"type\\":\\"div\\",\\"props\\":null,\\"children\\":[]}"'
-    );
-  }
-});
 
 Deno.test({
   name: "ReactDomServer is typed to render",

--- a/std/types/react-dom/v16.13.1/tests/react_mock.js
+++ b/std/types/react-dom/v16.13.1/tests/react_mock.js
@@ -1,9 +1,0 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-
-const React = {
-  createElement(type, props, ...children) {
-    return JSON.stringify({ type, props, children });
-  },
-};
-
-export default React;


### PR DESCRIPTION
This PR implements types, tests and documentation for Facebook's react-dom-server library

### Note 
This PR relies in CDN React and ReactDom libraries for its tests
This PR also removes previous tests for ReactDom in order to replace them later for a full test suite

Ref #4722 
