### PR TITLE
Properly propagate error when deno_core::Isolate gets syntax error

### DIFF
--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -1162,16 +1162,12 @@ pub mod tests {
 
   #[test]
   fn syntax_error() {
-    run_in_task(|mut cx| {
-      let (mut isolate, _dispatch_count) = setup(Mode::Async);
-      match isolate.execute("i.js", "hocuspocus(") {
-        Ok(_) => panic!("Test failed"),
-        Err(e) => print!("Successfully failed: {}", e),
-      }
-      if let Poll::Ready(Err(_)) = isolate.poll_unpin(&mut cx) {
-        unreachable!();
-      }
-    });
+    let mut isolate = Isolate::new(StartupData::None, false);
+    let src = "hocuspocus(";
+    let r = isolate.execute("i.js", src);
+    let e = r.unwrap_err();
+    let js_error = e.downcast::<JSError>().unwrap();
+    assert_eq!(js_error.end_column, Some(11));
   }
 
   #[test]

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -449,7 +449,6 @@ impl Isolate {
       match v8::Script::compile(scope, context, source, Some(&origin)) {
         Some(script) => script,
         None => {
-          assert!(tc.has_caught());
           let exception = tc.exception().unwrap();
           return exception_to_err_result(scope, exception, js_error_create_fn);
         }

--- a/core/js_errors.rs
+++ b/core/js_errors.rs
@@ -16,7 +16,7 @@ use std::fmt;
 /// A `JSError` represents an exception coming from V8, with stack frames and
 /// line numbers. The deno_cli crate defines another `JSError` type, which wraps
 /// the one defined here, that adds source map support and colorful formatting.
-#[derive(Default, Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct JSError {
   pub message: String,
   pub source_line: Option<String>,

--- a/core/js_errors.rs
+++ b/core/js_errors.rs
@@ -16,7 +16,7 @@ use std::fmt;
 /// A `JSError` represents an exception coming from V8, with stack frames and
 /// line numbers. The deno_cli crate defines another `JSError` type, which wraps
 /// the one defined here, that adds source map support and colorful formatting.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Default, Debug, PartialEq, Clone)]
 pub struct JSError {
   pub message: String,
   pub source_line: Option<String>,


### PR DESCRIPTION
# merge on approval