### PR TITLE
docs(std): update links to documents

### DIFF
--- a/std/README.md
+++ b/std/README.md
@@ -28,7 +28,7 @@ Here are the dedicated documentations of modules:
 - [fs](fs/README.md)
 - [http](http/README.md)
 - [log](log/README.md)
-- [strings](strings/README.md)
+- [node](node/README.md)
 - [testing](testing/README.md)
 - [uuid](uuid/README.md)
 - [ws](ws/README.md)


### PR DESCRIPTION
- Added **node** link to `/std/README.md`
- Removed **strings** link from `/std/README.md` because `/std/strings/` was deleted at #4565