### PR TITLE
feat: support Deno namespace in Worker API

### DIFF
--- a/cli/compilers/compiler_worker.rs
+++ b/cli/compilers/compiler_worker.rs
@@ -30,7 +30,7 @@ pub struct CompilerWorker(WebWorker);
 impl CompilerWorker {
   pub fn new(name: String, startup_data: StartupData, state: State) -> Self {
     let state_ = state.clone();
-    let mut worker = WebWorker::new(name, startup_data, state_);
+    let mut worker = WebWorker::new(name, startup_data, state_, false);
     {
       let isolate = &mut worker.isolate;
       ops::compiler::init(isolate, &state);

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -391,12 +391,12 @@ async function wasmCompilerOnMessage({
 }
 
 function bootstrapTsCompilerRuntime(): void {
-  bootstrapWorkerRuntime("TS");
+  bootstrapWorkerRuntime("TS", false);
   globalThis.onmessage = tsCompilerOnMessage;
 }
 
 function bootstrapWasmCompilerRuntime(): void {
-  bootstrapWorkerRuntime("WASM");
+  bootstrapWorkerRuntime("WASM", false);
   globalThis.onmessage = wasmCompilerOnMessage;
 }
 

--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -1080,6 +1080,45 @@ declare class Worker extends EventTarget {
     options?: {
       type?: "classic" | "module";
       name?: string;
+      /** UNSTABLE: New API. Expect many changes; most likely this
+       * field will be made into an object for more granular
+       * configuration of worker thread (permissions, import map, etc.).
+       *
+       * Set to `true` to make `Deno` namespace and all of its methods
+       * available to worker thread.
+       *
+       * Currently worker inherits permissions from main thread (permissions
+       * given using `--allow-*` flags).
+       * Configurable permissions are on the roadmap to be implemented.
+       *
+       * Example:
+       *    // mod.ts
+       *    const worker = new Worker("./deno_worker.ts", { type: "module", deno: true });
+       *    worker.postMessage({ cmd: "readFile", fileName: "./log.txt" });
+       *
+       *    // deno_worker.ts
+       *
+       *
+       *    self.onmessage = async function (e) {
+       *        const { cmd, fileName } = e.data;
+       *        if (cmd !== "readFile") {
+       *            throw new Error("Invalid command");
+       *        }
+       *        const buf = await Deno.readFile(fileName);
+       *        const fileContents = new TextDecoder().decode(buf);
+       *        console.log(fileContents);
+       *    }
+       *
+       *    // log.txt
+       *    hello world
+       *    hello world 2
+       *
+       *    // run program
+       *    $ deno run --allow-read mod.ts
+       *    hello world
+       *    hello world2
+       *
+       */
       deno?: boolean;
     }
   );

--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -1080,6 +1080,7 @@ declare class Worker extends EventTarget {
     options?: {
       type?: "classic" | "module";
       name?: string;
+      deno?: boolean;
     }
   );
   postMessage(message: any, transfer: ArrayBuffer[]): void;

--- a/cli/js/lib.deno.worker.d.ts
+++ b/cli/js/lib.deno.worker.d.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */
 
 /// <reference no-default-lib="true" />
+/// <reference lib="deno.ns" />
 /// <reference lib="deno.shared_globals" />
 /// <reference lib="esnext" />
 
@@ -15,6 +16,7 @@ declare interface DedicatedWorkerGlobalScope {
   name: typeof __workerMain.name;
   close: typeof __workerMain.close;
   postMessage: typeof __workerMain.postMessage;
+  Deno: typeof Deno;
 }
 
 declare const self: DedicatedWorkerGlobalScope & typeof globalThis;

--- a/cli/js/ops/worker_host.ts
+++ b/cli/js/ops/worker_host.ts
@@ -6,6 +6,7 @@ export function createWorker(
   specifier: string,
   hasSourceCode: boolean,
   sourceCode: string,
+  useDenoNamespace: boolean,
   name?: string
 ): { id: number } {
   return sendSync("op_create_worker", {
@@ -13,6 +14,7 @@ export function createWorker(
     hasSourceCode,
     sourceCode,
     name,
+    useDenoNamespace,
   });
 }
 

--- a/cli/js/runtime_worker.ts
+++ b/cli/js/runtime_worker.ts
@@ -17,12 +17,23 @@ import {
   eventTargetProperties,
   setEventTargetData,
 } from "./globals.ts";
+import * as Deno from "./deno.ts";
 import * as webWorkerOps from "./ops/web_worker.ts";
 import { LocationImpl } from "./web/location.ts";
 import { log, assert, immutableDefine } from "./util.ts";
 import { MessageEvent, ErrorEvent } from "./web/workers.ts";
 import { TextEncoder } from "./web/text_encoding.ts";
 import * as runtime from "./runtime.ts";
+import { internalObject } from "./internals.ts";
+import { symbols } from "./symbols.ts";
+import { setSignals } from "./signals.ts";
+
+// FIXME(bartlomieju): duplicated in `runtime_main.ts`
+// TODO: factor out `Deno` global assignment to separate function
+// Add internal object to Deno object.
+// This is not exposed as part of the Deno types.
+// @ts-ignore
+Deno[symbols.internal] = internalObject;
 
 const encoder = new TextEncoder();
 
@@ -109,6 +120,7 @@ export const workerRuntimeGlobalProperties = {
 
 export function bootstrapWorkerRuntime(
   name: string,
+  useDenoNamespace: boolean,
   internalName?: string
 ): void {
   if (hasBootstrapped) {
@@ -128,7 +140,21 @@ export function bootstrapWorkerRuntime(
   immutableDefine(globalThis, "location", location);
   Object.freeze(globalThis.location);
 
-  // globalThis.Deno is not available in worker scope
-  delete globalThis.Deno;
-  assert(globalThis.Deno === undefined);
+  if (useDenoNamespace) {
+    Object.defineProperties(Deno, {
+      pid: readOnly(s.pid),
+      noColor: readOnly(s.noColor),
+      args: readOnly(Object.freeze(s.args)),
+    });
+    // Setup `Deno` global - we're actually overriding already
+    // existing global `Deno` with `Deno` namespace from "./deno.ts".
+    immutableDefine(globalThis, "Deno", Deno);
+    Object.freeze(globalThis.Deno);
+    Object.freeze(globalThis.Deno.core);
+    Object.freeze(globalThis.Deno.core.sharedQueue);
+    setSignals();
+  } else {
+    delete globalThis.Deno;
+    assert(globalThis.Deno === undefined);
+  }
 }

--- a/cli/js/web/workers.ts
+++ b/cli/js/web/workers.ts
@@ -105,6 +105,7 @@ export interface Worker {
 export interface WorkerOptions {
   type?: "classic" | "module";
   name?: string;
+  deno?: boolean;
 }
 
 export class WorkerImpl extends EventTarget implements Worker {
@@ -146,10 +147,13 @@ export class WorkerImpl extends EventTarget implements Worker {
     }
     */
 
+    const useDenoNamespace = options ? !!options.deno : false;
+
     const { id } = createWorker(
       specifier,
       hasSourceCode,
       sourceCode,
+      useDenoNamespace,
       options?.name
     );
     this.#id = id;

--- a/cli/tests/subdir/deno_worker.js
+++ b/cli/tests/subdir/deno_worker.js
@@ -1,0 +1,7 @@
+onmessage = function (e) {
+  if (typeof self.Deno === "undefined") {
+    throw new Error("Deno namespace not available in worker");
+  }
+
+  postMessage(e.data);
+};

--- a/cli/tests/subdir/deno_worker.ts
+++ b/cli/tests/subdir/deno_worker.ts
@@ -1,4 +1,4 @@
-onmessage = function (e) {
+onmessage = function (e): void {
   if (typeof self.Deno === "undefined") {
     throw new Error("Deno namespace not available in worker");
   }

--- a/cli/tests/subdir/non_deno_worker.js
+++ b/cli/tests/subdir/non_deno_worker.js
@@ -1,0 +1,7 @@
+onmessage = function (e) {
+  if (typeof self.Deno !== "undefined") {
+    throw new Error("Deno namespace unexpectedly available in worker");
+  }
+
+  postMessage(e.data);
+};

--- a/cli/tests/workers_test.out
+++ b/cli/tests/workers_test.out
@@ -1,4 +1,4 @@
-running 8 tests
+running 9 tests
 test worker terminate ... ok [WILDCARD]
 test worker nested ... ok [WILDCARD]
 test worker throws when executing ... ok [WILDCARD]
@@ -7,5 +7,6 @@ test worker terminate busy loop ... ok [WILDCARD]
 test worker race condition ... ok [WILDCARD]
 test worker is event listener ... ok [WILDCARD]
 test worker scope is event listener ... ok [WILDCARD]
+test worker with Deno namespace ... ok [WILDCARD]
 
-test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out [WILDCARD]
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out [WILDCARD]

--- a/cli/tests/workers_test.ts
+++ b/cli/tests/workers_test.ts
@@ -267,7 +267,7 @@ Deno.test({
     const regularWorker = new Worker("../tests/subdir/non_deno_worker.js", {
       type: "module",
     });
-    const denoWorker = new Worker("../tests/subdir/deno_worker.js", {
+    const denoWorker = new Worker("../tests/subdir/deno_worker.ts", {
       type: "module",
       deno: true,
     });

--- a/cli/tests/workers_test.ts
+++ b/cli/tests/workers_test.ts
@@ -257,3 +257,36 @@ Deno.test({
     worker.terminate();
   },
 });
+
+Deno.test({
+  name: "worker with Deno namespace",
+  fn: async function (): Promise<void> {
+    const promise = createResolvable();
+    const promise2 = createResolvable();
+
+    const regularWorker = new Worker("../tests/subdir/non_deno_worker.js", {
+      type: "module",
+    });
+    const denoWorker = new Worker("../tests/subdir/deno_worker.js", {
+      type: "module",
+      deno: true,
+    });
+
+    regularWorker.onmessage = (e): void => {
+      assertEquals(e.data, "Hello World");
+      regularWorker.terminate();
+      promise.resolve();
+    };
+
+    denoWorker.onmessage = (e): void => {
+      assertEquals(e.data, "Hello World");
+      denoWorker.terminate();
+      promise2.resolve();
+    };
+
+    regularWorker.postMessage("Hello World");
+    await promise;
+    denoWorker.postMessage("Hello World");
+    await promise2;
+  },
+});


### PR DESCRIPTION
Minimal PR that adds `Deno` namespace to `WorkerGlobalScope`. `WorkerOptions.deno` will be changed to object when I add more configuration options (like permissions).