### PR TITLE
Add close method to Plugin (#4670)

### DIFF
--- a/cli/js/plugins.ts
+++ b/cli/js/plugins.ts
@@ -1,5 +1,6 @@
 import { openPlugin as openPluginOp } from "./ops/plugins.ts";
 import { core } from "./core.ts";
+import { close } from "./ops/resources.ts";
 
 export interface AsyncHandler {
   (msg: Uint8Array): void;
@@ -32,18 +33,17 @@ class PluginOpImpl implements PluginOp {
   }
 }
 
-// TODO(afinch7): add close method.
-
 interface Plugin {
   ops: {
     [name: string]: PluginOp;
   };
+  close(): void;
 }
 
 class PluginImpl implements Plugin {
   #ops: { [name: string]: PluginOp } = {};
 
-  constructor(_rid: number, ops: { [name: string]: number }) {
+  constructor(readonly rid: number, ops: { [name: string]: number }) {
     for (const op in ops) {
       this.#ops[op] = new PluginOpImpl(ops[op]);
     }
@@ -51,6 +51,10 @@ class PluginImpl implements Plugin {
 
   get ops(): { [name: string]: PluginOp } {
     return Object.assign({}, this.#ops);
+  }
+
+  close(): void {
+    close(this.rid);
   }
 }
 

--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -13,6 +13,10 @@ if (Deno.build.os === "mac") {
 
 const filename = `../target/${Deno.args[0]}/${filenamePrefix}${filenameBase}${filenameSuffix}`;
 
+// This will be checked against open resources after Plugin.close()
+// in runTestClose() below.
+const resourcesPre = Deno.resources();
+
 const plugin = Deno.openPlugin(filename);
 
 const { testSync, testAsync } = plugin.ops;
@@ -60,7 +64,23 @@ function runTestOpCount() {
   }
 }
 
+function runTestPluginClose() {
+
+  plugin.close();
+
+  const resourcesPost = Deno.resources();
+
+  const preStr = JSON.stringify(resourcesPre, null, 2);
+  const postStr = JSON.stringify(resourcesPost, null, 2);
+  if (preStr !== postStr) {
+    throw new Error(`Difference in open resources before openPlugin and after Plugin.close(): 
+Before: ${preStr}
+After: ${postStr}`);
+  }
+}
+
 runTestSync();
 runTestAsync();
 
 runTestOpCount();
+runTestPluginClose();

--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -65,7 +65,6 @@ function runTestOpCount() {
 }
 
 function runTestPluginClose() {
-
   plugin.close();
 
   const resourcesPost = Deno.resources();


### PR DESCRIPTION
Went for a "good first issue": #4670
Added a `close()` method to `Plugin`.
Looked at `File.close` and added the same implementation: Adds a `readonly rid`, and runs `close` from `ops/resources.ts`, returning `void`.

I don't think there is testing of plugins set up in `cli/js/tests`, but a few simple tests in `test_plugin` which can be checked by `cargo test`.

In `test_plugin/test.js` I record the open resources at the beginning of the file, and check for equality after running `Plugin.close()` in the end.
This is a simple adaptation of `assertResources()` in `cli/js/testing.js`, which would probably be preferable if plugin tests were added to `cli/js/tests`.