### PR TITLE
Use BTreeMap for deterministic key order

### DIFF
--- a/cli/lockfile.rs
+++ b/cli/lockfile.rs
@@ -1,19 +1,19 @@
 use crate::compilers::CompiledModule;
 use serde_json::json;
 pub use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::Result;
 
 pub struct Lockfile {
   need_read: bool,
-  map: HashMap<String, String>,
+  map: BTreeMap<String, String>,
   pub filename: String,
 }
 
 impl Lockfile {
   pub fn new(filename: String) -> Lockfile {
     Lockfile {
-      map: HashMap::new(),
+      map: BTreeMap::new(),
       filename,
       need_read: true,
     }


### PR DESCRIPTION
Fix https://github.com/denoland/deno/issues/4790

**Testing Needed:** I want a way to test not only parsed content of lock files, but also its key order. I don't know how, so I would appreciate some help.

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
