### PR TITLE
store debugger url on DenoInspector

### DIFF
--- a/cli/inspector.rs
+++ b/cli/inspector.rs
@@ -239,8 +239,7 @@ pub struct DenoInspector {
   flags: RefCell<InspectorFlags>,
   waker: Arc<InspectorWaker>,
   _canary_tx: oneshot::Sender<Never>,
-  #[allow(unused)]
-  debugger_url: String,
+  pub debugger_url: String,
 }
 
 impl Deref for DenoInspector {

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -92,7 +92,7 @@ pub struct Worker {
   pub waker: AtomicWaker,
   pub(crate) internal_channels: WorkerChannelsInternal,
   external_channels: WorkerHandle,
-  inspector: Option<Box<DenoInspector>>,
+  pub(crate) inspector: Option<Box<DenoInspector>>,
 }
 
 impl Worker {


### PR DESCRIPTION
Closes #4780

This PR stores `InspectorInfo` on `Worker`. That way it's possible to get inspector URL for certain worker programatically.

Prerequisite for test coverage