### PR TITLE
Parallelized deno fmt

### DIFF
--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -223,10 +223,10 @@ fn test_is_supported() {
   assert!(is_supported(Path::new("foo.tsx")));
 }
 
-#[test]
-fn check_tests_dir() {
+#[tokio::test]
+async fn check_tests_dir() {
   // Because of cli/tests/error_syntax.js the following should fail but not
   // crash.
-  let r = format(vec!["./tests".to_string()], true);
+  let r = format(vec!["./tests".to_string()], true).await;
   assert!(r.is_err());
 }

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -566,7 +566,7 @@ pub fn main() {
       cache_command(flags, files).boxed_local()
     }
     DenoSubcommand::Fmt { check, files } => {
-      async move { fmt::format(files, check) }.boxed_local()
+      fmt::format(files, check).boxed_local()
     }
     DenoSubcommand::Info { file } => info_command(flags, file).boxed_local(),
     DenoSubcommand::Install {


### PR DESCRIPTION
This PR parallelizes the "read, format, write"s across files in `deno fmt`. This is my first time using `await` in Rust so please review this with added scrutiny. Also, for some reason I couldn't get code completion and errors showing up in VSCode so I didn't iterate a lot to see if it would be possible to trim down the code more... let me know if you see anything.

Some test results on my machine from a directory of 424 unformatted typescript files (11.2mb):

Prettier: 24s first time, 24s once formatted once (strange? Perhaps they always write files to the file system? I'm using `prettier --write`)
deno fmt (master): 13s first time, 7s once formatted
deno fmt (parallelized): 4.3s first time, 2.1s once formatted once

Closes #3948
