### PR TITLE
WIP: Allow multiple set-cookie headers

### DIFF
--- a/std/http/io.ts
+++ b/std/http/io.ts
@@ -258,7 +258,7 @@ export async function writeResponse(
   const headers = r.headers;
 
   for (const [key, value] of headers) {
-    if (key !== 'set-cookie') {
+    if (key !== "set-cookie") {
       out += `${key}: ${value}\r\n`;
     } else {
       value.split(", ").forEach(v => {

--- a/std/http/io.ts
+++ b/std/http/io.ts
@@ -261,7 +261,7 @@ export async function writeResponse(
     if (key !== "set-cookie") {
       out += `${key}: ${value}\r\n`;
     } else {
-      value.split(", ").forEach(v => {
+      value.split(", ").forEach((v: string) => {
         out += `${key}: ${v}\r\n`;
       });
     }

--- a/std/http/io.ts
+++ b/std/http/io.ts
@@ -258,7 +258,13 @@ export async function writeResponse(
   const headers = r.headers;
 
   for (const [key, value] of headers) {
-    out += `${key}: ${value}\r\n`;
+    if (key !== 'set-cookie') {
+      out += `${key}: ${value}\r\n`;
+    } else {
+      value.split(", ").forEach(v => {
+        out += `${key}: ${v}\r\n`;
+      });
+    }
   }
   out += "\r\n";
 

--- a/std/http/io.ts
+++ b/std/http/io.ts
@@ -125,7 +125,7 @@ const kProhibitedTrailerHeaders = [
  * */
 export async function readTrailers(
   headers: Headers,
-  r: BufReader,
+  r: BufReader
 ): Promise<void> {
   const keys = parseTrailer(headers.get("trailer"));
   if (!keys) return;
@@ -161,7 +161,7 @@ function parseTrailer(field: string | null): Set<string> | undefined {
 
 export async function writeChunkedBody(
   w: Deno.Writer,
-  r: Deno.Reader,
+  r: Deno.Reader
 ): Promise<void> {
   const writer = BufWriter.create(w);
   for await (const chunk of Deno.toAsyncIterator(r)) {
@@ -181,7 +181,7 @@ export async function writeChunkedBody(
 export async function writeTrailers(
   w: Deno.Writer,
   headers: Headers,
-  trailers: Headers,
+  trailers: Headers
 ): Promise<void> {
   const trailer = headers.get("trailer");
   if (trailer === null) {
@@ -190,7 +190,7 @@ export async function writeTrailers(
   const transferEncoding = headers.get("transfer-encoding");
   if (transferEncoding === null || !transferEncoding.match(/^chunked/)) {
     throw new Error(
-      `trailer headers is only allowed for "transfer-encoding: chunked": got "${transferEncoding}"`,
+      `trailer headers is only allowed for "transfer-encoding: chunked": got "${transferEncoding}"`
     );
   }
   const writer = BufWriter.create(w);
@@ -200,13 +200,13 @@ export async function writeTrailers(
   for (const f of trailerHeaderFields) {
     assert(
       !kProhibitedTrailerHeaders.includes(f),
-      `"${f}" is prohibited for trailer header`,
+      `"${f}" is prohibited for trailer header`
     );
   }
   for (const [key, value] of trailers) {
     assert(
       trailerHeaderFields.includes(key),
-      `Not trailer header field: ${key}`,
+      `Not trailer header field: ${key}`
     );
     await writer.write(encoder.encode(`${key}: ${value}\r\n`));
   }
@@ -234,7 +234,7 @@ export function setContentLength(r: Response): void {
 
 export async function writeResponse(
   w: Deno.Writer,
-  r: Response,
+  r: Response
 ): Promise<void> {
   const protoMajor = 1;
   const protoMinor = 1;
@@ -348,7 +348,7 @@ export function parseHTTPVersion(vers: string): [number, number] {
 
 export async function readRequest(
   conn: Deno.Conn,
-  bufr: BufReader,
+  bufr: BufReader
 ): Promise<ServerRequest | Deno.EOF> {
   const tp = new TextProtoReader(bufr);
   const firstLine = await tp.readLine(); // e.g. GET /index.html HTTP/1.0
@@ -387,7 +387,7 @@ function fixLength(req: ServerRequest): void {
       // that contains a Transfer-Encoding header field.
       // rfc: https://tools.ietf.org/html/rfc7230#section-3.3.2
       throw new Error(
-        "http: Transfer-Encoding and Content-Length cannot be send together",
+        "http: Transfer-Encoding and Content-Length cannot be send together"
       );
     }
   }

--- a/std/http/io.ts
+++ b/std/http/io.ts
@@ -125,7 +125,7 @@ const kProhibitedTrailerHeaders = [
  * */
 export async function readTrailers(
   headers: Headers,
-  r: BufReader
+  r: BufReader,
 ): Promise<void> {
   const keys = parseTrailer(headers.get("trailer"));
   if (!keys) return;
@@ -161,7 +161,7 @@ function parseTrailer(field: string | null): Set<string> | undefined {
 
 export async function writeChunkedBody(
   w: Deno.Writer,
-  r: Deno.Reader
+  r: Deno.Reader,
 ): Promise<void> {
   const writer = BufWriter.create(w);
   for await (const chunk of Deno.toAsyncIterator(r)) {
@@ -181,7 +181,7 @@ export async function writeChunkedBody(
 export async function writeTrailers(
   w: Deno.Writer,
   headers: Headers,
-  trailers: Headers
+  trailers: Headers,
 ): Promise<void> {
   const trailer = headers.get("trailer");
   if (trailer === null) {
@@ -190,7 +190,7 @@ export async function writeTrailers(
   const transferEncoding = headers.get("transfer-encoding");
   if (transferEncoding === null || !transferEncoding.match(/^chunked/)) {
     throw new Error(
-      `trailer headers is only allowed for "transfer-encoding: chunked": got "${transferEncoding}"`
+      `trailer headers is only allowed for "transfer-encoding: chunked": got "${transferEncoding}"`,
     );
   }
   const writer = BufWriter.create(w);
@@ -200,13 +200,13 @@ export async function writeTrailers(
   for (const f of trailerHeaderFields) {
     assert(
       !kProhibitedTrailerHeaders.includes(f),
-      `"${f}" is prohibited for trailer header`
+      `"${f}" is prohibited for trailer header`,
     );
   }
   for (const [key, value] of trailers) {
     assert(
       trailerHeaderFields.includes(key),
-      `Not trailer header field: ${key}`
+      `Not trailer header field: ${key}`,
     );
     await writer.write(encoder.encode(`${key}: ${value}\r\n`));
   }
@@ -234,7 +234,7 @@ export function setContentLength(r: Response): void {
 
 export async function writeResponse(
   w: Deno.Writer,
-  r: Response
+  r: Response,
 ): Promise<void> {
   const protoMajor = 1;
   const protoMinor = 1;
@@ -261,7 +261,7 @@ export async function writeResponse(
     if (key !== "set-cookie") {
       out += `${key}: ${value}\r\n`;
     } else {
-      value.split(", ").forEach((v: string) => {
+      value.split(/(?<!; expires\=\w+), /).forEach((v: string) => {
         out += `${key}: ${v}\r\n`;
       });
     }
@@ -348,7 +348,7 @@ export function parseHTTPVersion(vers: string): [number, number] {
 
 export async function readRequest(
   conn: Deno.Conn,
-  bufr: BufReader
+  bufr: BufReader,
 ): Promise<ServerRequest | Deno.EOF> {
   const tp = new TextProtoReader(bufr);
   const firstLine = await tp.readLine(); // e.g. GET /index.html HTTP/1.0
@@ -387,7 +387,7 @@ function fixLength(req: ServerRequest): void {
       // that contains a Transfer-Encoding header field.
       // rfc: https://tools.ietf.org/html/rfc7230#section-3.3.2
       throw new Error(
-        "http: Transfer-Encoding and Content-Length cannot be send together"
+        "http: Transfer-Encoding and Content-Length cannot be send together",
       );
     }
   }

--- a/std/http/io_test.ts
+++ b/std/http/io_test.ts
@@ -351,7 +351,8 @@ test("writeResponse with repeating headers", async () => {
       ["set-cookie", "user.session=qwertz; Max-Age=86400"],
       [
         "set-cookie",
-        "mykey=myvalue; expires=Mon, 17-Jul-2017 16:06:00 GMT; Max-Age=31449600; Path=/; secure",
+        "mykey=myvalue; expires=Mon, 17-Jul-2017" +
+        " 16:06:00 GMT; Max-Age=31449600; Path=/; secure",
       ],
       ["set-cookie", "b=456; Domain=example.com; Secure; HttpOnly"],
       ["x-other-header", "some, value"],
@@ -367,7 +368,8 @@ test("writeResponse with repeating headers", async () => {
     "HTTP/1.1 200 OK",
     `content-length: ${body.length}`,
     "set-cookie: user.session=qwertz; Max-Age=86400",
-    "set-cookie: mykey=myvalue; expires=Mon, 17-Jul-2017 16:06:00 GMT; Max-Age=31449600; Path=/; secure",
+    "set-cookie: mykey=myvalue; expires=Mon, 17-Jul-2017" +
+    " 16:06:00 GMT; Max-Age=31449600; Path=/; secure",
     "set-cookie: b=456; Domain=example.com; Secure; HttpOnly",
     "x-other-header: some, value, custom=pair; values",
     "",

--- a/std/http/io_test.ts
+++ b/std/http/io_test.ts
@@ -107,7 +107,7 @@ test("readTrailer should throw if undeclared headers found in trailer", async ()
         await readTrailers(h, new BufReader(new Buffer(encode(trailer))));
       },
       Error,
-      "Undeclared trailer field",
+      "Undeclared trailer field"
     );
   }
 });
@@ -122,7 +122,7 @@ test("readTrailer should throw if trailer contains prohibited fields", async () 
         await readTrailers(h, new BufReader(new Buffer()));
       },
       Error,
-      "Prohibited field for trailer",
+      "Prohibited field for trailer"
     );
   }
 });
@@ -132,7 +132,7 @@ test("writeTrailer", async () => {
   await writeTrailers(
     w,
     new Headers({ "transfer-encoding": "chunked", trailer: "deno,node" }),
-    new Headers({ deno: "land", node: "js" }),
+    new Headers({ deno: "land", node: "js" })
   );
   assertEquals(w.toString(), "deno: land\r\nnode: js\r\n\r\n");
 });
@@ -144,14 +144,14 @@ test("writeTrailer should throw", async () => {
       return writeTrailers(w, new Headers(), new Headers());
     },
     Error,
-    'must have "trailer"',
+    'must have "trailer"'
   );
   await assertThrowsAsync(
     () => {
       return writeTrailers(w, new Headers({ trailer: "deno" }), new Headers());
     },
     Error,
-    "only allowed",
+    "only allowed"
   );
   for (const f of ["content-length", "trailer", "transfer-encoding"]) {
     await assertThrowsAsync(
@@ -159,11 +159,11 @@ test("writeTrailer should throw", async () => {
         return writeTrailers(
           w,
           new Headers({ "transfer-encoding": "chunked", trailer: f }),
-          new Headers({ [f]: "1" }),
+          new Headers({ [f]: "1" })
         );
       },
       AssertionError,
-      "prohibited",
+      "prohibited"
     );
   }
   await assertThrowsAsync(
@@ -171,11 +171,11 @@ test("writeTrailer should throw", async () => {
       return writeTrailers(
         w,
         new Headers({ "transfer-encoding": "chunked", trailer: "deno" }),
-        new Headers({ node: "js" }),
+        new Headers({ node: "js" })
       );
     },
     AssertionError,
-    "Not trailer",
+    "Not trailer"
   );
 });
 
@@ -348,19 +348,17 @@ test("writeResponse with repeating headers", async () => {
 
   const res: Response = {
     body,
-    headers: new Headers(
+    headers: new Headers([
+      ["set-cookie", "user.session=qwertz; Max-Age=86400"],
       [
-        ["set-cookie", "user.session=qwertz; Max-Age=86400"],
-        [
-          "set-cookie",
-          "mykey=myvalue; expires=Mon, 17-Jul-2017" +
+        "set-cookie",
+        "mykey=myvalue; expires=Mon, 17-Jul-2017" +
           " 16:06:00 GMT; Max-Age=31449600; Path=/; secure",
-        ],
-        ["set-cookie", "b=456; Domain=example.com; Secure; HttpOnly"],
-        ["x-other-header", "some, value"],
-        ["x-other-header", "custom=pair; values"],
       ],
-    ),
+      ["set-cookie", "b=456; Domain=example.com; Secure; HttpOnly"],
+      ["x-other-header", "some, value"],
+      ["x-other-header", "custom=pair; values"],
+    ]),
   };
 
   const w = new Buffer();
@@ -372,7 +370,7 @@ test("writeResponse with repeating headers", async () => {
     `content-length: ${body.length}`,
     "set-cookie: user.session=qwertz; Max-Age=86400",
     "set-cookie: mykey=myvalue; expires=Mon, 17-Jul-2017" +
-    " 16:06:00 GMT; Max-Age=31449600; Path=/; secure",
+      " 16:06:00 GMT; Max-Age=31449600; Path=/; secure",
     "set-cookie: b=456; Domain=example.com; Secure; HttpOnly",
     "x-other-header: some, value, custom=pair; values",
     "",
@@ -425,17 +423,20 @@ test(async function testReadRequestError(): Promise<void> {
     // deduplicated if same or reject otherwise
     // See Issue 16490.
     {
-      in: "POST / HTTP/1.1\r\nContent-Length: 10\r\nContent-Length: 0\r\n\r\n" +
+      in:
+        "POST / HTTP/1.1\r\nContent-Length: 10\r\nContent-Length: 0\r\n\r\n" +
         "Gopher hey\r\n",
       err: "cannot contain multiple Content-Length headers",
     },
     {
-      in: "POST / HTTP/1.1\r\nContent-Length: 10\r\nContent-Length: 6\r\n\r\n" +
+      in:
+        "POST / HTTP/1.1\r\nContent-Length: 10\r\nContent-Length: 6\r\n\r\n" +
         "Gopher\r\n",
       err: "cannot contain multiple Content-Length headers",
     },
     {
-      in: "PUT / HTTP/1.1\r\nContent-Length: 6 \r\nContent-Length: 6\r\n" +
+      in:
+        "PUT / HTTP/1.1\r\nContent-Length: 6 \r\nContent-Length: 6\r\n" +
         "Content-Length:6\r\n\r\nGopher\r\n",
       headers: [{ key: "Content-Length", value: "6" }],
     },
@@ -454,7 +455,8 @@ test(async function testReadRequestError(): Promise<void> {
       headers: [{ key: "Content-Length", value: "0" }],
     },
     {
-      in: "POST / HTTP/1.1\r\nContent-Length:0\r\ntransfer-encoding: " +
+      in:
+        "POST / HTTP/1.1\r\nContent-Length:0\r\ntransfer-encoding: " +
         "chunked\r\n\r\n",
       headers: [],
       err: "http: Transfer-Encoding and Content-Length cannot be send together",

--- a/std/http/io_test.ts
+++ b/std/http/io_test.ts
@@ -346,19 +346,22 @@ test("writeResponse with trailer", async () => {
 test("writeResponse with repeating headers", async () => {
   const body = "Hello";
 
-  const res: Response = { body, headers: new Headers(
-    [
-      ["set-cookie", "user.session=qwertz; Max-Age=86400"],
+  const res: Response = {
+    body,
+    headers: new Headers(
       [
-        "set-cookie",
-        "mykey=myvalue; expires=Mon, 17-Jul-2017" +
-        " 16:06:00 GMT; Max-Age=31449600; Path=/; secure",
+        ["set-cookie", "user.session=qwertz; Max-Age=86400"],
+        [
+          "set-cookie",
+          "mykey=myvalue; expires=Mon, 17-Jul-2017" +
+          " 16:06:00 GMT; Max-Age=31449600; Path=/; secure",
+        ],
+        ["set-cookie", "b=456; Domain=example.com; Secure; HttpOnly"],
+        ["x-other-header", "some, value"],
+        ["x-other-header", "custom=pair; values"],
       ],
-      ["set-cookie", "b=456; Domain=example.com; Secure; HttpOnly"],
-      ["x-other-header", "some, value"],
-      ["x-other-header", "custom=pair; values"],
-    ],
-  ) };
+    ),
+  };
 
   const w = new Buffer();
   await writeResponse(w, res);

--- a/std/http/io_test.ts
+++ b/std/http/io_test.ts
@@ -107,7 +107,7 @@ test("readTrailer should throw if undeclared headers found in trailer", async ()
         await readTrailers(h, new BufReader(new Buffer(encode(trailer))));
       },
       Error,
-      "Undeclared trailer field"
+      "Undeclared trailer field",
     );
   }
 });
@@ -122,7 +122,7 @@ test("readTrailer should throw if trailer contains prohibited fields", async () 
         await readTrailers(h, new BufReader(new Buffer()));
       },
       Error,
-      "Prohibited field for trailer"
+      "Prohibited field for trailer",
     );
   }
 });
@@ -132,7 +132,7 @@ test("writeTrailer", async () => {
   await writeTrailers(
     w,
     new Headers({ "transfer-encoding": "chunked", trailer: "deno,node" }),
-    new Headers({ deno: "land", node: "js" })
+    new Headers({ deno: "land", node: "js" }),
   );
   assertEquals(w.toString(), "deno: land\r\nnode: js\r\n\r\n");
 });
@@ -144,14 +144,14 @@ test("writeTrailer should throw", async () => {
       return writeTrailers(w, new Headers(), new Headers());
     },
     Error,
-    'must have "trailer"'
+    'must have "trailer"',
   );
   await assertThrowsAsync(
     () => {
       return writeTrailers(w, new Headers({ trailer: "deno" }), new Headers());
     },
     Error,
-    "only allowed"
+    "only allowed",
   );
   for (const f of ["content-length", "trailer", "transfer-encoding"]) {
     await assertThrowsAsync(
@@ -159,11 +159,11 @@ test("writeTrailer should throw", async () => {
         return writeTrailers(
           w,
           new Headers({ "transfer-encoding": "chunked", trailer: f }),
-          new Headers({ [f]: "1" })
+          new Headers({ [f]: "1" }),
         );
       },
       AssertionError,
-      "prohibited"
+      "prohibited",
     );
   }
   await assertThrowsAsync(
@@ -171,11 +171,11 @@ test("writeTrailer should throw", async () => {
       return writeTrailers(
         w,
         new Headers({ "transfer-encoding": "chunked", trailer: "deno" }),
-        new Headers({ node: "js" })
+        new Headers({ node: "js" }),
       );
     },
     AssertionError,
-    "Not trailer"
+    "Not trailer",
   );
 });
 
@@ -343,6 +343,42 @@ test("writeResponse with trailer", async () => {
   assertEquals(ret, exp);
 });
 
+test("writeResponse with repeating headers", async () => {
+  const body = "Hello";
+
+  const res: Response = { body, headers: new Headers(
+    [
+      ["set-cookie", "user.session=qwertz; Max-Age=86400"],
+      [
+        "set-cookie",
+        "mykey=myvalue; expires=Mon, 17-Jul-2017 16:06:00 GMT; Max-Age=31449600; Path=/; secure",
+      ],
+      ["set-cookie", "b=456; Domain=example.com; Secure; HttpOnly"],
+      ["x-other-header", "some, value"],
+      ["x-other-header", "custom=pair; values"],
+    ],
+  ) };
+
+  const w = new Buffer();
+  await writeResponse(w, res);
+
+  const ret = w.toString();
+  const exp = [
+    "HTTP/1.1 200 OK",
+    `content-length: ${body.length}`,
+    "set-cookie: user.session=qwertz; Max-Age=86400",
+    "set-cookie: mykey=myvalue; expires=Mon, 17-Jul-2017 16:06:00 GMT; Max-Age=31449600; Path=/; secure",
+    "set-cookie: b=456; Domain=example.com; Secure; HttpOnly",
+    "x-other-header: some, value, custom=pair; values",
+    "",
+    "5",
+    body,
+    "0",
+    "",
+  ].join("\r\n");
+  assertEquals(ret, exp);
+});
+
 test(async function readRequestError(): Promise<void> {
   const input = `GET / HTTP/1.1
 malformedHeader
@@ -384,20 +420,17 @@ test(async function testReadRequestError(): Promise<void> {
     // deduplicated if same or reject otherwise
     // See Issue 16490.
     {
-      in:
-        "POST / HTTP/1.1\r\nContent-Length: 10\r\nContent-Length: 0\r\n\r\n" +
+      in: "POST / HTTP/1.1\r\nContent-Length: 10\r\nContent-Length: 0\r\n\r\n" +
         "Gopher hey\r\n",
       err: "cannot contain multiple Content-Length headers",
     },
     {
-      in:
-        "POST / HTTP/1.1\r\nContent-Length: 10\r\nContent-Length: 6\r\n\r\n" +
+      in: "POST / HTTP/1.1\r\nContent-Length: 10\r\nContent-Length: 6\r\n\r\n" +
         "Gopher\r\n",
       err: "cannot contain multiple Content-Length headers",
     },
     {
-      in:
-        "PUT / HTTP/1.1\r\nContent-Length: 6 \r\nContent-Length: 6\r\n" +
+      in: "PUT / HTTP/1.1\r\nContent-Length: 6 \r\nContent-Length: 6\r\n" +
         "Content-Length:6\r\n\r\nGopher\r\n",
       headers: [{ key: "Content-Length", value: "6" }],
     },
@@ -416,8 +449,7 @@ test(async function testReadRequestError(): Promise<void> {
       headers: [{ key: "Content-Length", value: "0" }],
     },
     {
-      in:
-        "POST / HTTP/1.1\r\nContent-Length:0\r\ntransfer-encoding: " +
+      in: "POST / HTTP/1.1\r\nContent-Length:0\r\ntransfer-encoding: " +
         "chunked\r\n\r\n",
       headers: [],
       err: "http: Transfer-Encoding and Content-Length cannot be send together",


### PR DESCRIPTION
Fixes #4826. The separator `, ` is only allowed as a separator within `Set-Cookie` but not within other headers. This fix only works for `Set-Cookie`, the only standard-complient header witch is allowed to be set multiple times. Should this work for custom headers, too?