### PR TITLE
refactor(cli/fmt_errors): Improve source line formatting

### DIFF
--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -10,63 +10,49 @@ use std::ops::Deref;
 
 const SOURCE_ABBREV_THRESHOLD: usize = 150;
 
-/// A trait which specifies parts of a diagnostic like item needs to be able to
-/// generate to conform its display to other diagnostic like items
-pub trait DisplayFormatter {
-  fn format_category_and_code(&self) -> String;
-  fn format_message(&self, level: usize) -> String;
-  fn format_related_info(&self) -> String;
-  fn format_source_line(&self, level: usize) -> String;
-  fn format_source_name(&self) -> String;
-}
-
-fn format_source_name(
-  file_name: String,
-  line_number: i64,
-  column_number: i64,
+pub fn format_stack(
+  is_error: bool,
+  message_line: String,
+  source_line: Option<String>,
+  start_column: Option<i64>,
+  end_column: Option<i64>,
+  formatted_frames: &[String],
+  level: usize,
 ) -> String {
-  let line_number = line_number;
-  let column_number = column_number;
-  let file_name_c = colors::cyan(file_name);
-  let line_c = colors::yellow(line_number.to_string());
-  let column_c = colors::yellow(column_number.to_string());
-  format!("{}:{}:{}", file_name_c, line_c, column_c)
-}
-
-/// Formats optional source, line and column numbers into a single string.
-pub fn format_maybe_source_name(
-  file_name: Option<String>,
-  line_number: Option<i64>,
-  column_number: Option<i64>,
-) -> String {
-  if file_name.is_none() {
-    return "".to_string();
+  let mut s = String::new();
+  s.push_str(&format!("{:indent$}{}", "", message_line, indent = level));
+  s.push_str(&format_maybe_source_line(
+    source_line,
+    start_column,
+    end_column,
+    is_error,
+    level,
+  ));
+  for formatted_frame in formatted_frames {
+    s.push_str(&format!(
+      "\n{:indent$}    at {}",
+      "",
+      formatted_frame,
+      indent = level
+    ));
   }
-
-  assert!(line_number.is_some());
-  assert!(column_number.is_some());
-  format_source_name(
-    file_name.unwrap(),
-    line_number.unwrap(),
-    column_number.unwrap(),
-  )
+  s
 }
 
 /// Take an optional source line and associated information to format it into
 /// a pretty printed version of that line.
-pub fn format_maybe_source_line(
+fn format_maybe_source_line(
   source_line: Option<String>,
-  line_number: Option<i64>,
   start_column: Option<i64>,
   end_column: Option<i64>,
   is_error: bool,
   level: usize,
 ) -> String {
-  if source_line.is_none() || line_number.is_none() {
+  if source_line.is_none() || start_column.is_none() || end_column.is_none() {
     return "".to_string();
   }
 
-  let source_line = source_line.as_ref().unwrap();
+  let source_line = source_line.unwrap();
   // sometimes source_line gets set with an empty string, which then outputs
   // an empty source line when displayed, so need just short circuit here.
   // Also short-circuit on error line too long.
@@ -76,12 +62,6 @@ pub fn format_maybe_source_line(
 
   assert!(start_column.is_some());
   assert!(end_column.is_some());
-  let line_number = line_number.unwrap().to_string();
-  let line_color = colors::black_on_white(line_number.to_string());
-  let line_number_len = line_number.len();
-  let line_padding =
-    colors::black_on_white(format!("{:indent$}", "", indent = line_number_len))
-      .to_string();
   let mut s = String::new();
   let start_column = start_column.unwrap();
   let end_column = end_column.unwrap();
@@ -107,16 +87,7 @@ pub fn format_maybe_source_line(
 
   let indent = format!("{:indent$}", "", indent = level);
 
-  format!(
-    "\n\n{}{} {}\n{}{} {}\n",
-    indent, line_color, source_line, indent, line_padding, color_underline
-  )
-}
-
-/// Format a message to preface with `error: ` with ansi codes for red.
-pub fn format_error_message(msg: String) -> String {
-  let preamble = colors::red("error:".to_string());
-  format!("{} {}", preamble, msg)
+  format!("\n{}{}\n{}{}", indent, source_line, indent, color_underline)
 }
 
 /// Wrapper around deno_core::JSError which provides color to_string.
@@ -141,63 +112,44 @@ impl Deref for JSError {
   }
 }
 
-impl DisplayFormatter for JSError {
-  fn format_category_and_code(&self) -> String {
-    "".to_string()
-  }
-
-  fn format_message(&self, _level: usize) -> String {
-    format!(
-      "{}{}",
-      colors::red_bold("error: ".to_string()),
-      self.0.message.clone()
-    )
-  }
-
-  fn format_related_info(&self) -> String {
-    "".to_string()
-  }
-
-  fn format_source_line(&self, level: usize) -> String {
-    format_maybe_source_line(
-      self.0.source_line.clone(),
-      self.0.line_number,
-      self.0.start_column,
-      self.0.end_column,
-      true,
-      level,
-    )
-  }
-
-  fn format_source_name(&self) -> String {
-    let e = &self.0;
-    if e.script_resource_name.is_none() {
-      return "".to_string();
-    }
-
-    format!(
-      "\n► {}",
-      format_maybe_source_name(
-        e.script_resource_name.clone(),
-        e.line_number,
-        e.start_column.map(|n| n + 1),
-      )
-    )
-  }
-}
-
 impl fmt::Display for JSError {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    // When the stack frame array is empty, but the source location given by
+    // (script_resource_name, line_number, start_column + 1) exists, this is
+    // likely a syntax error. For the sake of formatting we treat it like it was
+    // given as a single stack frame.
+    let formatted_frames = if self.0.formatted_frames.is_empty()
+      && self.0.script_resource_name.is_some()
+      && self.0.line_number.is_some()
+      && self.0.start_column.is_some()
+    {
+      vec![format!(
+        "{}:{}:{}",
+        colors::cyan(self.0.script_resource_name.clone().unwrap()),
+        colors::yellow(self.0.line_number.unwrap().to_string()),
+        colors::yellow((self.0.start_column.unwrap() + 1).to_string())
+      )]
+    } else {
+      self.0.formatted_frames.clone()
+    };
+
     write!(
       f,
-      "{}{}{}",
-      self.format_message(0),
-      self.format_source_name(),
-      self.format_source_line(0),
+      "{}",
+      &format_stack(
+        true,
+        format!(
+          "{}: {}",
+          colors::red_bold("error".to_string()),
+          self.0.message.clone()
+        ),
+        self.0.source_line.clone(),
+        self.0.start_column,
+        self.0.end_column,
+        &formatted_frames,
+        0
+      )
     )?;
-    for formatted_frame in &self.0.formatted_frames {
-      write!(f, "\n    at {}", formatted_frame)?;
-    }
     Ok(())
   }
 }
@@ -210,24 +162,8 @@ mod tests {
   use crate::colors::strip_ansi_codes;
 
   #[test]
-  fn test_format_none_source_name() {
-    let actual = format_maybe_source_name(None, None, None);
-    assert_eq!(actual, "");
-  }
-
-  #[test]
-  fn test_format_some_source_name() {
-    let actual = format_maybe_source_name(
-      Some("file://foo/bar.ts".to_string()),
-      Some(1),
-      Some(2),
-    );
-    assert_eq!(strip_ansi_codes(&actual), "file://foo/bar.ts:1:2");
-  }
-
-  #[test]
   fn test_format_none_source_line() {
-    let actual = format_maybe_source_line(None, None, None, None, false, 0);
+    let actual = format_maybe_source_line(None, None, None, false, 0);
     assert_eq!(actual, "");
   }
 
@@ -236,20 +172,13 @@ mod tests {
     let actual = format_maybe_source_line(
       Some("console.log('foo');".to_string()),
       Some(8),
-      Some(8),
       Some(11),
       true,
       0,
     );
     assert_eq!(
       strip_ansi_codes(&actual),
-      "\n\n8 console.log(\'foo\');\n          ~~~\n"
+      "\nconsole.log(\'foo\');\n        ~~~"
     );
-  }
-
-  #[test]
-  fn test_format_error_message() {
-    let actual = format_error_message("foo".to_string());
-    assert_eq!(strip_ansi_codes(&actual), "error: foo");
   }
 }

--- a/cli/tests/038_checkjs.js.out
+++ b/cli/tests/038_checkjs.js.out
@@ -1,15 +1,21 @@
-[WILDCARD]
-error TS2552: Cannot find name 'consol'. Did you mean 'console'?
+[WILDCARD]error TS2552: Cannot find name 'consol'. Did you mean 'console'?
+consol.log("hello world!");
+~~~~~~
+    at [WILDCARD]tests/038_checkjs.js:2:1
 
-[WILDCARD]tests/038_checkjs.js:2:1
+    'console' is declared here.
+    declare var console: Console;
+                ~~~~~~~
+        at [WILDCARD]
 
-2 consol.log("hello world!");
-[WILDCARD]
 error TS2552: Cannot find name 'Foo'. Did you mean 'foo'?
+const foo = new Foo();
+                ~~~
+    at [WILDCARD]tests/038_checkjs.js:6:17
 
-[WILDCARD]tests/038_checkjs.js:6:17
+    'foo' is declared here.
+    const foo = new Foo();
+          ~~~
+        at [WILDCARD]tests/038_checkjs.js:6:7
 
-6 const foo = new Foo();
-[WILDCARD]
 Found 2 errors.
-[WILDCARD]

--- a/cli/tests/044_bad_resource.ts.out
+++ b/cli/tests/044_bad_resource.ts.out
@@ -1,6 +1,4 @@
-[WILDCARD]
-error: Uncaught BadResource: Bad resource ID
-[WILDCARD]dispatch_json.ts:[WILDCARD]
+[WILDCARD]error: Uncaught BadResource: Bad resource ID
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at Object.sendAsync ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at async main ([WILDCARD]tests/044_bad_resource.ts:[WILDCARD])

--- a/cli/tests/async_error.ts.out
+++ b/cli/tests/async_error.ts.out
@@ -2,10 +2,7 @@
 before error
 world
 error: Uncaught Error: error
-[WILDCARD]tests/async_error.ts:5:9
-
-5   throw Error("error");
-          ^
-
+  throw Error("error");
+        ^
     at foo ([WILDCARD]tests/async_error.ts:5:9)
     at [WILDCARD]tests/async_error.ts:8:1

--- a/cli/tests/config.ts.out
+++ b/cli/tests/config.ts.out
@@ -1,10 +1,7 @@
 [WILDCARD]Unsupported compiler options in "[WILDCARD]config.tsconfig.json"
   The following options were ignored:
     module, target
-[WILDCARD]error TS2532: Object is possibly 'undefined'.
-
-[WILDCARD]tests/config.ts:3:5
-
-3 if (map.get("bar").foo) {
-      ~~~~~~~~~~~~~~
-
+error TS2532: Object is possibly 'undefined'.
+if (map.get("bar").foo) {
+    ~~~~~~~~~~~~~~
+    at [WILDCARD]tests/config.ts:3:5

--- a/cli/tests/error_001.ts.out
+++ b/cli/tests/error_001.ts.out
@@ -1,9 +1,6 @@
 [WILDCARD]error: Uncaught Error: bad
-[WILDCARD]tests/error_001.ts:2:9
-
-2   throw Error("bad");
-          ^
-
+  throw Error("bad");
+        ^
     at foo ([WILDCARD]tests/error_001.ts:2:9)
     at bar ([WILDCARD]tests/error_001.ts:6:3)
     at [WILDCARD]tests/error_001.ts:9:1

--- a/cli/tests/error_002.ts.out
+++ b/cli/tests/error_002.ts.out
@@ -1,9 +1,6 @@
 [WILDCARD]error: Uncaught Error: exception from mod1
-[WILDCARD]tests/subdir/mod1.ts:16:9
-
-16   throw Error("exception from mod1");
-           ^
-
+  throw Error("exception from mod1");
+        ^
     at throwsError ([WILDCARD]tests/subdir/mod1.ts:16:9)
     at foo ([WILDCARD]tests/error_002.ts:4:3)
     at [WILDCARD]tests/error_002.ts:7:1

--- a/cli/tests/error_003_typescript.ts.out
+++ b/cli/tests/error_003_typescript.ts.out
@@ -1,9 +1,6 @@
 [WILDCARD]error TS2322: Type '{ a: { b: { c(): { d: number; }; }; }; }' is not assignable to type '{ a: { b: { c(): { d: string; }; }; }; }'.
   The types of 'a.b.c().d' are incompatible between these types.
     Type 'number' is not assignable to type 'string'.
-
-[WILDCARD]/cli/tests/error_003_typescript.ts:20:1
-
-20 x = y;
-   ^
-
+x = y;
+^
+    at [WILDCARD]/tests/error_003_typescript.ts:20:1

--- a/cli/tests/error_004_missing_module.ts.out
+++ b/cli/tests/error_004_missing_module.ts.out
@@ -1,5 +1,4 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts" from "[WILDCARD]/error_004_missing_module.ts"
-[WILDCARD]dispatch_json.ts:[WILDCARD]
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at Object.sendAsync ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at async processImports ([WILDCARD]compiler/imports.ts:[WILDCARD])

--- a/cli/tests/error_005_missing_dynamic_import.ts.out
+++ b/cli/tests/error_005_missing_dynamic_import.ts.out
@@ -1,5 +1,4 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/bad-module.ts" from "[WILDCARD]/error_005_missing_dynamic_import.ts"
-[WILDCARD]dispatch_json.ts:[WILDCARD]
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at Object.sendAsync ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at async processImports ([WILDCARD]compiler/imports.ts:[WILDCARD])

--- a/cli/tests/error_006_import_ext_failure.ts.out
+++ b/cli/tests/error_006_import_ext_failure.ts.out
@@ -1,5 +1,4 @@
 [WILDCARD]error: Uncaught NotFound: Cannot resolve module "[WILDCARD]/non-existent" from "[WILDCARD]/error_006_import_ext_failure.ts"
-[WILDCARD]dispatch_json.ts:[WILDCARD]
     at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at Object.sendAsync ([WILDCARD]dispatch_json.ts:[WILDCARD])
     at async processImports ([WILDCARD]compiler/imports.ts:[WILDCARD])

--- a/cli/tests/error_008_checkjs.js.out
+++ b/cli/tests/error_008_checkjs.js.out
@@ -1,7 +1,4 @@
 [WILDCARD]error: Uncaught ReferenceError: consol is not defined
-[WILDCARD]tests/error_008_checkjs.js:2:1
-
-2 consol.log("hello world!");
-  ^
-
+consol.log("hello world!");
+^
     at [WILDCARD]tests/error_008_checkjs.js:2:1

--- a/cli/tests/error_011_bad_module_specifier.ts.out
+++ b/cli/tests/error_011_bad_module_specifier.ts.out
@@ -1,5 +1,4 @@
 [WILDCARD]error: Uncaught URIError: relative import path "bad-module.ts" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/error_011_bad_module_specifier.ts"
-[WILDCARD]dispatch_json.ts:[WILDCARD]
     at unwrapResponse ([WILDCARD]ops/dispatch_json.ts:[WILDCARD])
     at Object.sendSync ([WILDCARD]ops/dispatch_json.ts:[WILDCARD])
     at resolveModules ([WILDCARD]compiler/imports.ts:[WILDCARD])

--- a/cli/tests/error_012_bad_dynamic_import_specifier.ts.out
+++ b/cli/tests/error_012_bad_dynamic_import_specifier.ts.out
@@ -1,5 +1,4 @@
 [WILDCARD]error: Uncaught URIError: relative import path "bad-module.ts" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/error_012_bad_dynamic_import_specifier.ts"
-[WILDCARD]dispatch_json.ts:[WILDCARD]
     at unwrapResponse ([WILDCARD]ops/dispatch_json.ts:[WILDCARD])
     at Object.sendSync ([WILDCARD]ops/dispatch_json.ts:[WILDCARD])
     at resolveModules ([WILDCARD]compiler/imports.ts:[WILDCARD])

--- a/cli/tests/error_017_hide_long_source_ts.ts.out
+++ b/cli/tests/error_017_hide_long_source_ts.ts.out
@@ -1,3 +1,2 @@
 [WILDCARD]error TS2532: Object is possibly 'undefined'.
-
-► file:///[WILDCARD]cli/tests/error_017_hide_long_source_ts.ts:2:1
+    at [WILDCARD]tests/error_017_hide_long_source_ts.ts:2:1

--- a/cli/tests/error_018_hide_long_source_js.js.out
+++ b/cli/tests/error_018_hide_long_source_js.js.out
@@ -1,3 +1,2 @@
 error: Uncaught TypeError: Cannot read property 'a' of undefined
-► file:///[WILDCARD]cli/tests/error_018_hide_long_source_js.js:2:206
     at file:///[WILDCARD]cli/tests/error_018_hide_long_source_js.js:2:206

--- a/cli/tests/error_syntax.js.out
+++ b/cli/tests/error_syntax.js.out
@@ -1,6 +1,4 @@
 error: Uncaught SyntaxError: Unexpected identifier
-[WILDCARD]tests/error_syntax.js:3:6
-
-3 (the following is a syntax error  ^^ ! )
-       ~~~~~~~~~
-
+(the following is a syntax error  ^^ ! )
+     ~~~~~~~~~
+    at [WILDCARD]tests/error_syntax.js:3:6

--- a/cli/tests/error_syntax_empty_trailing_line.mjs.out
+++ b/cli/tests/error_syntax_empty_trailing_line.mjs.out
@@ -1,2 +1,2 @@
 error: Uncaught SyntaxError: Unexpected end of input
-► file:///[WILDCARD]cli/tests/error_syntax_empty_trailing_line.mjs:[WILDCARD]
+    at [WILDCARD]tests/error_syntax_empty_trailing_line.mjs:[WILDCARD]

--- a/cli/tests/error_type_definitions.ts.out
+++ b/cli/tests/error_type_definitions.ts.out
@@ -1,5 +1,4 @@
 [WILDCARD]error: Uncaught URIError: relative import path "baz" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/type_definitions/bar.d.ts"
-[WILDCARD]ops/dispatch_json.ts:[WILDCARD]
     at unwrapResponse ([WILDCARD]ops/dispatch_json.ts:[WILDCARD])
     at Object.sendSync ([WILDCARD]ops/dispatch_json.ts:[WILDCARD])
     at Object.resolveModules ([WILDCARD]ops/compiler.ts:[WILDCARD])

--- a/core/js_errors.rs
+++ b/core/js_errors.rs
@@ -1,11 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-// TODO: This currently only applies to uncaught exceptions. It would be nice to
-// also have source maps for situations like this:
-//   const err = new Error("Boo!");
-//   console.log(err.stack);
-// It would require calling into Rust from Error.prototype.prepareStackTrace.
-
 use crate::ErrBox;
 use rusty_v8 as v8;
 use std::convert::TryFrom;
@@ -260,7 +254,6 @@ fn format_source_loc(
   line_number: i64,
   column_number: i64,
 ) -> String {
-  // TODO match this style with how typescript displays errors.
   let line_number = line_number;
   let column_number = column_number;
   format!("{}:{}:{}", file_name, line_number, column_number)


### PR DESCRIPTION
Fixes #4822.

<hr>

```js
throw new Error("thrown error");
```
Before:

<kbd><img src="https://user-images.githubusercontent.com/29990554/79781632-ab613000-8335-11ea-9cbb-8dda2f72b3b5.png" width=420 style="border: 1px solid black;"></kbd>

After:

<kbd><img src="https://user-images.githubusercontent.com/29990554/79781653-b4520180-8335-11ea-8699-608b81499797.png" width=420></kbd>

<hr>

```js
syntax error
```
Before:

<kbd><img src="https://user-images.githubusercontent.com/29990554/79781689-c2a01d80-8335-11ea-9dca-5dc7ef34361a.png" width="420"></kbd>

After:

<kbd><img src="https://user-images.githubusercontent.com/29990554/79781699-c92e9500-8335-11ea-81e7-6e3c6a4331b7.png" width=420></kbd>

<hr>

```ts
let a: string;
a = 1;
a = true;
```
Before:

<kbd><img src="https://user-images.githubusercontent.com/29990554/79781752-e19eaf80-8335-11ea-80e7-29313cfd910a.png" width=420></kbd>

After:

<kbd><img src="https://user-images.githubusercontent.com/29990554/79781758-e6636380-8335-11ea-84c4-a57b21596f1c.png" width=420></kbd>