### PR TITLE
Move resource_table from deno::State to deno_core::Isolate

### DIFF
--- a/cli/js/tests/README.md
+++ b/cli/js/tests/README.md
@@ -69,6 +69,8 @@ target/debug/deno -A cli/js/tests/unit_test_runner.ts --worker --addr=127.0.0.1:
 
 # Run specific tests
 target/debug/deno --allow-net cli/js/tests/unit_test_runner.ts -- netTcpListenClose
+
+RUST_BACKTRACE=1 cargo run --  --allow-read --allow-write cli/js/tests/unit_test_runner.ts -- netUnixDialListen
 ```
 
 ### Http server

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -148,7 +148,7 @@ fn create_main_worker(
 
   {
     let (stdin, stdout, stderr) = get_stdio();
-    let t = std::rc::Rc::get_mut(&mut worker.resource_table).unwrap();
+    let mut t = worker.resource_table.borrow_mut();
     t.add("stdin", Box::new(stdin));
     t.add("stdout", Box::new(stdout));
     t.add("stderr", Box::new(stderr));

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -90,7 +90,6 @@ use std::env;
 use std::io::Write;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::rc::Rc;
 use upgrade::upgrade_command;
 use url::Url;
 
@@ -149,7 +148,7 @@ fn create_main_worker(
 
   {
     let (stdin, stdout, stderr) = get_stdio();
-    let t = Rc::get_mut(&mut worker.resource_table);
+    let t = std::rc::Rc::get_mut(&mut worker.resource_table).unwrap();
     t.add("stdin", Box::new(stdin));
     t.add("stdout", Box::new(stdout));
     t.add("stderr", Box::new(stderr));

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -90,6 +90,7 @@ use std::env;
 use std::io::Write;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::rc::Rc;
 use upgrade::upgrade_command;
 use url::Url;
 

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -140,19 +140,20 @@ fn create_main_worker(
 ) -> Result<MainWorker, ErrBox> {
   let state = State::new(global_state, None, main_module, DebugType::Main)?;
 
-  {
-    let mut s = state.borrow_mut();
-    let (stdin, stdout, stderr) = get_stdio();
-    s.resource_table.add("stdin", Box::new(stdin));
-    s.resource_table.add("stdout", Box::new(stdout));
-    s.resource_table.add("stderr", Box::new(stderr));
-  }
-
   let mut worker = MainWorker::new(
     "main".to_string(),
     startup_data::deno_isolate_init(),
     state,
   );
+
+  {
+    let (stdin, stdout, stderr) = get_stdio();
+    let t = Rc::get_mut(&mut worker.resource_table);
+    t.add("stdin", Box::new(stdin));
+    t.add("stdout", Box::new(stdout));
+    t.add("stderr", Box::new(stderr));
+  }
+
   worker.execute("bootstrapMainRuntime()")?;
   Ok(worker)
 }

--- a/cli/ops/dispatch_minimal.rs
+++ b/cli/ops/dispatch_minimal.rs
@@ -117,9 +117,9 @@ pub fn minimal_op<D>(
   d: D,
 ) -> impl Fn(&mut deno_core::Isolate, &[u8], Option<ZeroCopyBuf>) -> Op
 where
-  D: Fn(bool, i32, Option<ZeroCopyBuf>) -> MinimalOp,
+  D: Fn(&mut deno_core::Isolate, bool, i32, Option<ZeroCopyBuf>) -> MinimalOp,
 {
-  move |_isolate: &mut deno_core::Isolate,
+  move |isolate: &mut deno_core::Isolate,
         control: &[u8],
         zero_copy: Option<ZeroCopyBuf>| {
     let mut record = match parse_min_record(control) {
@@ -137,7 +137,7 @@ where
     };
     let is_sync = record.promise_id == 0;
     let rid = record.arg;
-    let min_op = d(is_sync, rid, zero_copy);
+    let min_op = d(isolate, is_sync, rid, zero_copy);
 
     match min_op {
       MinimalOp::Sync(sync_result) => Op::Sync(match sync_result {

--- a/cli/ops/fetch.rs
+++ b/cli/ops/fetch.rs
@@ -12,7 +12,7 @@ use http::Method;
 use std::convert::From;
 
 pub fn init(i: &mut Isolate, s: &State) {
-  i.register_op("op_fetch", s.stateful_json_op(op_fetch));
+  i.register_op("op_fetch", s.stateful_json_op2(op_fetch));
 }
 
 #[derive(Deserialize)]
@@ -65,9 +65,8 @@ pub fn op_fetch(
     request = request.header(name, v);
   }
   debug!("Before fetch {}", url);
-  let state_ = state.clone();
 
-  let resource_table = isolate.resource_table.clone();
+  let mut resource_table = isolate.resource_table.clone();
   let future = async move {
     let res = request.send().await?;
     debug!("Fetch response {}", url);

--- a/cli/ops/fetch.rs
+++ b/cli/ops/fetch.rs
@@ -66,7 +66,7 @@ pub fn op_fetch(
   }
   debug!("Before fetch {}", url);
 
-  let mut resource_table = isolate.resource_table.clone();
+  let resource_table = isolate.resource_table.clone();
   let future = async move {
     let res = request.send().await?;
     debug!("Fetch response {}", url);
@@ -77,7 +77,7 @@ pub fn op_fetch(
     }
 
     let body = HttpBody::from(res);
-    let resource_table = std::rc::Rc::get_mut(&mut resource_table).unwrap();
+    let mut resource_table = resource_table.borrow_mut();
     let rid = resource_table.add(
       "httpBody",
       Box::new(StreamResourceHolder::new(StreamResource::HttpBody(

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -18,8 +18,8 @@ use std::time::UNIX_EPOCH;
 use rand::{thread_rng, Rng};
 
 pub fn init(i: &mut Isolate, s: &State) {
-  i.register_op("op_open", s.stateful_json_op(op_open));
-  i.register_op("op_seek", s.stateful_json_op(op_seek));
+  i.register_op("op_open", s.stateful_json_op2(op_open));
+  i.register_op("op_seek", s.stateful_json_op2(op_seek));
   i.register_op("op_umask", s.stateful_json_op(op_umask));
   i.register_op("op_chdir", s.stateful_json_op(op_chdir));
   i.register_op("op_mkdir", s.stateful_json_op(op_mkdir));
@@ -75,8 +75,7 @@ fn op_open(
 ) -> Result<JsonOp, OpError> {
   let args: OpenArgs = serde_json::from_value(args)?;
   let path = resolve_from_cwd(Path::new(&args.path))?;
-  let state_ = state.clone();
-  let resource_table = isolate.resource_table.clone();
+  let mut resource_table = isolate.resource_table.clone();
 
   let mut open_options = std::fs::OpenOptions::new();
 
@@ -207,7 +206,7 @@ struct SeekArgs {
 
 fn op_seek(
   isolate: &mut deno_core::Isolate,
-  state: &State,
+  _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
@@ -229,8 +228,7 @@ fn op_seek(
     }
   };
 
-  let resource_table = isolate.resource_table.clone();
-  let state = state.clone();
+  let mut resource_table = isolate.resource_table.clone();
   let is_sync = args.promise_id.is_none();
 
   if is_sync {
@@ -247,7 +245,7 @@ fn op_seek(
     // tokio::fs::File::start_seek and tokio::fs::File::poll_complete
     let fut = async move {
       let resource_table = std::rc::Rc::get_mut(&mut resource_table).unwrap();
-      let pos = std_file_resource(&mut resource_table, rid, |r| match r {
+      let pos = std_file_resource(resource_table, rid, |r| match r {
         Ok(std_file) => std_file.seek(seek_from).map_err(OpError::from),
         Err(_) => Err(OpError::type_error(
           "cannot seek on this type of resource".to_string(),

--- a/cli/ops/io.rs
+++ b/cli/ops/io.rs
@@ -59,8 +59,8 @@ lazy_static! {
 }
 
 pub fn init(i: &mut Isolate, s: &State) {
-  i.register_op("op_read", s.core_op(s.stateful_minimal_op2(op_read)));
-  i.register_op("op_write", s.core_op(s.stateful_minimal_op2(op_write)));
+  i.register_op("op_read", s.stateful_minimal_op2(op_read));
+  i.register_op("op_write", s.stateful_minimal_op2(op_write));
 }
 
 pub fn get_stdio() -> (

--- a/cli/ops/io.rs
+++ b/cli/ops/io.rs
@@ -1,7 +1,6 @@
 use super::dispatch_minimal::MinimalOp;
 use crate::http_util::HttpBody;
 use crate::op_error::OpError;
-use crate::ops::minimal_op;
 use crate::state::State;
 use deno_core::*;
 use futures::future::poll_fn;
@@ -60,14 +59,8 @@ lazy_static! {
 }
 
 pub fn init(i: &mut Isolate, s: &State) {
-  i.register_op(
-    "op_read",
-    s.core_op(minimal_op(s.stateful_minimal_op(op_read))),
-  );
-  i.register_op(
-    "op_write",
-    s.core_op(minimal_op(s.stateful_minimal_op(op_write))),
-  );
+  i.register_op("op_read", s.core_op(s.stateful_minimal_op2(op_read)));
+  i.register_op("op_write", s.core_op(s.stateful_minimal_op2(op_write)));
 }
 
 pub fn get_stdio() -> (
@@ -211,7 +204,8 @@ impl DenoAsyncRead for StreamResource {
 }
 
 pub fn op_read(
-  state: &State,
+  isolate: &mut deno_core::Isolate,
+  _state: &State,
   is_sync: bool,
   rid: i32,
   zero_copy: Option<ZeroCopyBuf>,
@@ -220,14 +214,14 @@ pub fn op_read(
   if zero_copy.is_none() {
     return MinimalOp::Sync(Err(no_buffer_specified()));
   }
+  let mut resource_table = isolate.resource_table.clone();
 
-  let state = state.clone();
   let mut buf = zero_copy.unwrap();
 
   if is_sync {
     MinimalOp::Sync({
       // First we look up the rid in the resource table.
-      let resource_table = &mut state.borrow_mut().resource_table;
+      let resource_table = std::rc::Rc::get_mut(&mut resource_table).unwrap();
       std_file_resource(resource_table, rid as u32, move |r| match r {
         Ok(std_file) => {
           use std::io::Read;
@@ -244,7 +238,7 @@ pub fn op_read(
   } else {
     MinimalOp::Async(
       poll_fn(move |cx| {
-        let resource_table = &mut state.borrow_mut().resource_table;
+        let resource_table = std::rc::Rc::get_mut(&mut resource_table).unwrap();
         let resource_holder = resource_table
           .get_mut::<StreamResourceHolder>(rid as u32)
           .ok_or_else(OpError::bad_resource_id)?;
@@ -335,7 +329,7 @@ impl DenoAsyncWrite for StreamResource {
 
 pub fn op_write(
   isolate: &mut deno_core::Isolate,
-  state: &State,
+  _state: &State,
   is_sync: bool,
   rid: i32,
   zero_copy: Option<ZeroCopyBuf>,
@@ -345,7 +339,6 @@ pub fn op_write(
     return MinimalOp::Sync(Err(no_buffer_specified()));
   }
 
-  let state = state.clone();
   let buf = zero_copy.unwrap();
 
   if is_sync {
@@ -367,7 +360,7 @@ pub fn op_write(
       })
     })
   } else {
-    let resource_table = isolate.resource_table.clone();
+    let mut resource_table = isolate.resource_table.clone();
     MinimalOp::Async(
       async move {
         let nwritten = poll_fn(|cx| {

--- a/cli/ops/net.rs
+++ b/cli/ops/net.rs
@@ -20,12 +20,12 @@ use tokio::net::UdpSocket;
 use super::net_unix;
 
 pub fn init(i: &mut Isolate, s: &State) {
-  i.register_op("op_accept", s.stateful_json_op(op_accept));
-  i.register_op("op_connect", s.stateful_json_op(op_connect));
-  i.register_op("op_shutdown", s.stateful_json_op(op_shutdown));
-  i.register_op("op_listen", s.stateful_json_op(op_listen));
-  i.register_op("op_receive", s.stateful_json_op(op_receive));
-  i.register_op("op_send", s.stateful_json_op(op_send));
+  i.register_op("op_accept", s.stateful_json_op2(op_accept));
+  i.register_op("op_connect", s.stateful_json_op2(op_connect));
+  i.register_op("op_shutdown", s.stateful_json_op2(op_shutdown));
+  i.register_op("op_listen", s.stateful_json_op2(op_listen));
+  i.register_op("op_receive", s.stateful_json_op2(op_receive));
+  i.register_op("op_send", s.stateful_json_op2(op_send));
 }
 
 #[derive(Deserialize)]
@@ -36,12 +36,11 @@ struct AcceptArgs {
 
 fn accept_tcp(
   isolate: &mut deno_core::Isolate,
-  state: &State,
   args: AcceptArgs,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let rid = args.rid as u32;
-  let resource_table = isolate.resource_table.clone();
+  let mut resource_table = isolate.resource_table.clone();
 
   let op = async move {
     let accept_fut = poll_fn(|cx| {
@@ -96,15 +95,16 @@ fn accept_tcp(
 }
 
 fn op_accept(
-  state: &State,
+  isolate: &mut deno_core::Isolate,
+  _state: &State,
   args: Value,
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: AcceptArgs = serde_json::from_value(args)?;
   match args.transport.as_str() {
-    "tcp" => accept_tcp(state, args, zero_copy),
+    "tcp" => accept_tcp(isolate, args, zero_copy),
     #[cfg(unix)]
-    "unix" => net_unix::accept_unix(state, args.rid as u32, zero_copy),
+    "unix" => net_unix::accept_unix(isolate, args.rid as u32, zero_copy),
     _ => Err(OpError::other(format!(
       "Unsupported transport protocol {}",
       args.transport
@@ -120,7 +120,7 @@ struct ReceiveArgs {
 
 fn receive_udp(
   isolate: &mut deno_core::Isolate,
-  state: &State,
+  _state: &State,
   args: ReceiveArgs,
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
@@ -128,7 +128,7 @@ fn receive_udp(
 
   let rid = args.rid as u32;
 
-  let resource_table = isolate.resource_table.clone();
+  let mut resource_table = isolate.resource_table.clone();
 
   let op = async move {
     let receive_fut = poll_fn(|cx| {
@@ -156,6 +156,7 @@ fn receive_udp(
 }
 
 fn op_receive(
+  isolate: &mut deno_core::Isolate,
   state: &State,
   args: Value,
   zero_copy: Option<ZeroCopyBuf>,
@@ -163,10 +164,10 @@ fn op_receive(
   assert!(zero_copy.is_some());
   let args: ReceiveArgs = serde_json::from_value(args)?;
   match args.transport.as_str() {
-    "udp" => receive_udp(state, args, zero_copy),
+    "udp" => receive_udp(isolate, state, args, zero_copy),
     #[cfg(unix)]
     "unixpacket" => {
-      net_unix::receive_unix_packet(state, args.rid as u32, zero_copy)
+      net_unix::receive_unix_packet(isolate, args.rid as u32, zero_copy)
     }
     _ => Err(OpError::other(format!(
       "Unsupported transport protocol {}",
@@ -191,7 +192,7 @@ fn op_send(
 ) -> Result<JsonOp, OpError> {
   assert!(zero_copy.is_some());
   let buf = zero_copy.unwrap();
-  let resource_table = isolate.resource_table.clone();
+  let mut resource_table = isolate.resource_table.clone();
   match serde_json::from_value(args)? {
     SendArgs {
       rid,
@@ -258,13 +259,12 @@ fn op_connect(
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
-  let resource_table = isolate.resource_table.clone();
+  let mut resource_table = isolate.resource_table.clone();
   match serde_json::from_value(args)? {
     ConnectArgs {
       transport,
       transport_args: ArgsEnum::Ip(args),
     } if transport == "tcp" => {
-      let state_ = state.clone();
       state.check_net(&args.hostname, args.port)?;
       let op = async move {
         let addr = resolve_addr(&args.hostname, args.port)?;
@@ -300,7 +300,6 @@ fn op_connect(
       transport_args: ArgsEnum::Unix(args),
     } if transport == "unix" => {
       let address_path = net_unix::Path::new(&args.address);
-      let state_ = state.clone();
       state.check_read(&address_path)?;
       let op = async move {
         let address = args.address;
@@ -340,7 +339,8 @@ struct ShutdownArgs {
 }
 
 fn op_shutdown(
-  state: &State,
+  isolate: &mut deno_core::Isolate,
+  _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
@@ -355,9 +355,9 @@ fn op_shutdown(
     _ => unimplemented!(),
   };
 
-  let mut state = state.borrow_mut();
-  let resource_holder = state
-    .resource_table
+  let resource_table =
+    std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
+  let resource_holder = resource_table
     .get_mut::<StreamResourceHolder>(rid)
     .ok_or_else(OpError::bad_resource_id)?;
   match resource_holder.resource {
@@ -450,10 +450,9 @@ struct ListenArgs {
 }
 
 fn listen_tcp(
-  state: &State,
+  resource_table: &mut ResourceTable,
   addr: SocketAddr,
 ) -> Result<(u32, SocketAddr), OpError> {
-  let mut state = state.borrow_mut();
   let std_listener = std::net::TcpListener::bind(&addr)?;
   let listener = TcpListener::from_std(std_listener)?;
   let local_addr = listener.local_addr()?;
@@ -462,34 +461,32 @@ fn listen_tcp(
     waker: None,
     local_addr,
   };
-  let rid = state
-    .resource_table
-    .add("tcpListener", Box::new(listener_resource));
+  let rid = resource_table.add("tcpListener", Box::new(listener_resource));
 
   Ok((rid, local_addr))
 }
 
 fn listen_udp(
-  state: &State,
+  resource_table: &mut ResourceTable,
   addr: SocketAddr,
 ) -> Result<(u32, SocketAddr), OpError> {
-  let mut state = state.borrow_mut();
   let std_socket = std::net::UdpSocket::bind(&addr)?;
   let socket = UdpSocket::from_std(std_socket)?;
   let local_addr = socket.local_addr()?;
   let socket_resource = UdpSocketResource { socket };
-  let rid = state
-    .resource_table
-    .add("udpSocket", Box::new(socket_resource));
+  let rid = resource_table.add("udpSocket", Box::new(socket_resource));
 
   Ok((rid, local_addr))
 }
 
 fn op_listen(
+  isolate: &mut deno_core::Isolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
+  let resource_table =
+    std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
   match serde_json::from_value(args)? {
     ListenArgs {
       transport,
@@ -498,9 +495,9 @@ fn op_listen(
       state.check_net(&args.hostname, args.port)?;
       let addr = resolve_addr(&args.hostname, args.port)?;
       let (rid, local_addr) = if transport == "tcp" {
-        listen_tcp(state, addr)?
+        listen_tcp(resource_table, addr)?
       } else {
-        listen_udp(state, addr)?
+        listen_udp(resource_table, addr)?
       };
       debug!(
         "New listener {} {}:{}",
@@ -525,9 +522,9 @@ fn op_listen(
       let address_path = net_unix::Path::new(&args.address);
       state.check_read(&address_path)?;
       let (rid, local_addr) = if transport == "unix" {
-        net_unix::listen_unix(state, &address_path)?
+        net_unix::listen_unix(resource_table, &address_path)?
       } else {
-        net_unix::listen_unix_packet(state, &address_path)?
+        net_unix::listen_unix_packet(resource_table, &address_path)?
       };
       debug!(
         "New listener {} {}",

--- a/cli/ops/net_unix.rs
+++ b/cli/ops/net_unix.rs
@@ -49,7 +49,6 @@ pub fn accept_unix(
 
     let (unix_stream, _socket_addr) =
       listener_resource.listener.accept().await?;
-    drop(listener_resource);
     drop(resource_table_);
 
     let local_addr = unix_stream.local_addr()?;

--- a/cli/ops/net_unix.rs
+++ b/cli/ops/net_unix.rs
@@ -49,6 +49,9 @@ pub fn accept_unix(
 
     let (unix_stream, _socket_addr) =
       listener_resource.listener.accept().await?;
+    drop(listener_resource);
+    drop(resource_table_);
+
     let local_addr = unix_stream.local_addr()?;
     let remote_addr = unix_stream.peer_addr()?;
     let mut resource_table_ = resource_table.borrow_mut();
@@ -83,8 +86,8 @@ pub fn receive_unix_packet(
   let resource_table = isolate.resource_table.clone();
 
   let op = async move {
-    let mut resource_table = resource_table.borrow_mut();
-    let resource = resource_table
+    let mut resource_table_ = resource_table.borrow_mut();
+    let resource = resource_table_
       .get_mut::<UnixDatagramResource>(rid)
       .ok_or_else(|| {
         OpError::bad_resource("Socket has been closed".to_string())

--- a/cli/ops/net_unix.rs
+++ b/cli/ops/net_unix.rs
@@ -1,7 +1,6 @@
 use super::dispatch_json::{Deserialize, JsonOp};
 use super::io::{StreamResource, StreamResourceHolder};
 use crate::op_error::OpError;
-use crate::state::State;
 use futures::future::FutureExt;
 
 use deno_core::*;
@@ -28,14 +27,12 @@ pub struct UnixListenArgs {
 
 pub fn accept_unix(
   isolate: &mut deno_core::Isolate,
-  state: &State,
   rid: u32,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
-  let resource_table = isolate.resource_table.clone();
-  let state_ = state.clone();
+  let mut resource_table = isolate.resource_table.clone();
   {
-    let state = resource_table
+    let _ = resource_table
       .get::<UnixListenerResource>(rid)
       .ok_or_else(OpError::bad_resource_id)?;
   }
@@ -77,12 +74,11 @@ pub fn accept_unix(
 
 pub fn receive_unix_packet(
   isolate: &mut deno_core::Isolate,
-  state: &State,
   rid: u32,
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let mut buf = zero_copy.unwrap();
-  let resource_table = isolate.resource_table.clone();
+  let mut resource_table = isolate.resource_table.clone();
 
   let op = async move {
     let resource_table = std::rc::Rc::get_mut(&mut resource_table).unwrap();
@@ -105,28 +101,24 @@ pub fn receive_unix_packet(
 }
 
 pub fn listen_unix(
-  state: &State,
+  resource_table: &mut ResourceTable,
   addr: &Path,
 ) -> Result<(u32, unix::net::SocketAddr), OpError> {
-  let mut state = state.borrow_mut();
   if addr.exists() {
     remove_file(&addr).unwrap();
   }
   let listener = UnixListener::bind(&addr)?;
   let local_addr = listener.local_addr()?;
   let listener_resource = UnixListenerResource { listener };
-  let rid = state
-    .resource_table
-    .add("unixListener", Box::new(listener_resource));
+  let rid = resource_table.add("unixListener", Box::new(listener_resource));
 
   Ok((rid, local_addr))
 }
 
 pub fn listen_unix_packet(
-  state: &State,
+  resource_table: &mut ResourceTable,
   addr: &Path,
 ) -> Result<(u32, unix::net::SocketAddr), OpError> {
-  let mut state = state.borrow_mut();
   if addr.exists() {
     remove_file(&addr).unwrap();
   }
@@ -136,9 +128,7 @@ pub fn listen_unix_packet(
     socket,
     local_addr: local_addr.clone(),
   };
-  let rid = state
-    .resource_table
-    .add("unixDatagram", Box::new(datagram_resource));
+  let rid = resource_table.add("unixDatagram", Box::new(datagram_resource));
 
   Ok((rid, local_addr))
 }

--- a/cli/ops/plugins.rs
+++ b/cli/ops/plugins.rs
@@ -46,14 +46,10 @@ pub fn op_open_plugin(
 
   let lib = open_plugin(filename).unwrap();
   let plugin_resource = PluginResource { lib };
-  let mut state_ = state.borrow_mut();
-  let rid = state_
-    .resource_table
-    .add("plugin", Box::new(plugin_resource));
-  let plugin_resource = state_
-    .resource_table
-    .get_mut::<PluginResource>(rid)
-    .unwrap();
+  let resource_table =
+    std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
+  let rid = resource_table.add("plugin", Box::new(plugin_resource));
+  let plugin_resource = resource_table.get_mut::<PluginResource>(rid).unwrap();
 
   let deno_plugin_init = *unsafe {
     plugin_resource

--- a/cli/ops/process.rs
+++ b/cli/ops/process.rs
@@ -173,6 +173,7 @@ struct RunStatusArgs {
 }
 
 fn op_run_status(
+  isolate: &mut deno_core::Isolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -182,10 +183,11 @@ fn op_run_status(
 
   state.check_run()?;
   let state = state.clone();
+  let resource_table = isolate.resource_table.clone();
 
   let future = async move {
     let run_status = poll_fn(|cx| {
-      let resource_table = &mut state.borrow_mut().resource_table;
+      let resource_table = std::rc::Rc::get_mut(&mut resource_table).unwrap();
       let child_resource = resource_table
         .get_mut::<ChildResource>(rid)
         .ok_or_else(OpError::bad_resource_id)?;

--- a/cli/ops/process.rs
+++ b/cli/ops/process.rs
@@ -15,15 +15,16 @@ use tokio::process::Command;
 use std::os::unix::process::ExitStatusExt;
 
 pub fn init(i: &mut Isolate, s: &State) {
-  i.register_op("op_run", s.stateful_json_op(op_run));
-  i.register_op("op_run_status", s.stateful_json_op(op_run_status));
+  i.register_op("op_run", s.stateful_json_op2(op_run));
+  i.register_op("op_run_status", s.stateful_json_op2(op_run_status));
   i.register_op("op_kill", s.stateful_json_op(op_kill));
 }
 
-fn clone_file(rid: u32, state: &State) -> Result<std::fs::File, OpError> {
-  let mut state = state.borrow_mut();
-
-  std_file_resource(&mut state.resource_table, rid, move |r| match r {
+fn clone_file(
+  rid: u32,
+  resource_table: &mut ResourceTable,
+) -> Result<std::fs::File, OpError> {
+  std_file_resource(resource_table, rid, move |r| match r {
     Ok(std_file) => std_file.try_clone().map_err(OpError::from),
     Err(_) => Err(OpError::bad_resource_id()),
   })
@@ -57,6 +58,7 @@ struct ChildResource {
 }
 
 fn op_run(
+  isolate: &mut deno_core::Isolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -64,7 +66,8 @@ fn op_run(
   let run_args: RunArgs = serde_json::from_value(args)?;
 
   state.check_run()?;
-  let state_ = state.clone();
+  let resource_table =
+    std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
 
   let args = run_args.cmd;
   let env = run_args.env;
@@ -83,7 +86,7 @@ fn op_run(
   // TODO: make this work with other resources, eg. sockets
   let stdin_rid = run_args.stdin_rid;
   if stdin_rid > 0 {
-    let file = clone_file(stdin_rid, &state_)?;
+    let file = clone_file(stdin_rid, resource_table)?;
     c.stdin(file);
   } else {
     c.stdin(subprocess_stdio_map(run_args.stdin.as_ref()));
@@ -91,7 +94,7 @@ fn op_run(
 
   let stdout_rid = run_args.stdout_rid;
   if stdout_rid > 0 {
-    let file = clone_file(stdout_rid, &state_)?;
+    let file = clone_file(stdout_rid, resource_table)?;
     c.stdout(file);
   } else {
     c.stdout(subprocess_stdio_map(run_args.stdout.as_ref()));
@@ -99,7 +102,7 @@ fn op_run(
 
   let stderr_rid = run_args.stderr_rid;
   if stderr_rid > 0 {
-    let file = clone_file(stderr_rid, &state_)?;
+    let file = clone_file(stderr_rid, resource_table)?;
     c.stderr(file);
   } else {
     c.stderr(subprocess_stdio_map(run_args.stderr.as_ref()));
@@ -112,12 +115,9 @@ fn op_run(
   let mut child = c.spawn()?;
   let pid = child.id();
 
-  let mut state = state_.borrow_mut();
-  let table = &mut state.resource_table;
-
   let stdin_rid = match child.stdin.take() {
     Some(child_stdin) => {
-      let rid = table.add(
+      let rid = resource_table.add(
         "childStdin",
         Box::new(StreamResourceHolder::new(StreamResource::ChildStdin(
           child_stdin,
@@ -130,7 +130,7 @@ fn op_run(
 
   let stdout_rid = match child.stdout.take() {
     Some(child_stdout) => {
-      let rid = table.add(
+      let rid = resource_table.add(
         "childStdout",
         Box::new(StreamResourceHolder::new(StreamResource::ChildStdout(
           child_stdout,
@@ -143,7 +143,7 @@ fn op_run(
 
   let stderr_rid = match child.stderr.take() {
     Some(child_stderr) => {
-      let rid = table.add(
+      let rid = resource_table.add(
         "childStderr",
         Box::new(StreamResourceHolder::new(StreamResource::ChildStderr(
           child_stderr,
@@ -155,7 +155,7 @@ fn op_run(
   };
 
   let child_resource = ChildResource { child };
-  let child_rid = table.add("child", Box::new(child_resource));
+  let child_rid = resource_table.add("child", Box::new(child_resource));
 
   Ok(JsonOp::Sync(json!({
     "rid": child_rid,
@@ -182,8 +182,7 @@ fn op_run_status(
   let rid = args.rid as u32;
 
   state.check_run()?;
-  let state = state.clone();
-  let resource_table = isolate.resource_table.clone();
+  let mut resource_table = isolate.resource_table.clone();
 
   let future = async move {
     let run_status = poll_fn(|cx| {

--- a/cli/ops/repl.rs
+++ b/cli/ops/repl.rs
@@ -33,8 +33,7 @@ fn op_repl_start(
     repl::history_path(&state.borrow().global_state.dir, &args.history_file);
   let repl = repl::Repl::new(history_path);
   let resource = ReplResource(Arc::new(Mutex::new(repl)));
-  let resource_table =
-    std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
+  let mut resource_table = isolate.resource_table.borrow_mut();
   let rid = resource_table.add("repl", Box::new(resource));
   Ok(JsonOp::Sync(json!(rid)))
 }
@@ -55,8 +54,8 @@ fn op_repl_readline(
   let rid = args.rid as u32;
   let prompt = args.prompt;
   debug!("op_repl_readline {} {}", rid, prompt);
-  let resource = isolate
-    .resource_table
+  let resource_table = isolate.resource_table.borrow();
+  let resource = resource_table
     .get::<ReplResource>(rid)
     .ok_or_else(OpError::bad_resource_id)?;
   let repl = resource.0.clone();

--- a/cli/ops/repl.rs
+++ b/cli/ops/repl.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 pub fn init(i: &mut Isolate, s: &State) {
-  i.register_op("op_repl_start", s.stateful_json_op(op_repl_start));
-  i.register_op("op_repl_readline", s.stateful_json_op(op_repl_readline));
+  i.register_op("op_repl_start", s.stateful_json_op2(op_repl_start));
+  i.register_op("op_repl_readline", s.stateful_json_op2(op_repl_readline));
 }
 
 struct ReplResource(Arc<Mutex<Repl>>);
@@ -22,19 +22,20 @@ struct ReplStartArgs {
 }
 
 fn op_repl_start(
+  isolate: &mut deno_core::Isolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: ReplStartArgs = serde_json::from_value(args)?;
-
   debug!("op_repl_start {}", args.history_file);
   let history_path =
     repl::history_path(&state.borrow().global_state.dir, &args.history_file);
   let repl = repl::Repl::new(history_path);
-  let mut state = state.borrow_mut();
   let resource = ReplResource(Arc::new(Mutex::new(repl)));
-  let rid = state.resource_table.add("repl", Box::new(resource));
+  let resource_table =
+    std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
+  let rid = resource_table.add("repl", Box::new(resource));
   Ok(JsonOp::Sync(json!(rid)))
 }
 
@@ -45,7 +46,8 @@ struct ReplReadlineArgs {
 }
 
 fn op_repl_readline(
-  state: &State,
+  isolate: &mut deno_core::Isolate,
+  _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
@@ -53,8 +55,7 @@ fn op_repl_readline(
   let rid = args.rid as u32;
   let prompt = args.prompt;
   debug!("op_repl_readline {} {}", rid, prompt);
-  let state = state.borrow();
-  let resource = state
+  let resource = isolate
     .resource_table
     .get::<ReplResource>(rid)
     .ok_or_else(OpError::bad_resource_id)?;

--- a/cli/ops/resources.rs
+++ b/cli/ops/resources.rs
@@ -15,7 +15,7 @@ fn op_resources(
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
-  let serialized_resources = isolate.resource_table.entries();
+  let serialized_resources = isolate.resource_table.borrow().entries();
   Ok(JsonOp::Sync(json!(serialized_resources)))
 }
 
@@ -31,8 +31,7 @@ fn op_close(
     rid: i32,
   }
   let args: CloseArgs = serde_json::from_value(args).unwrap();
-  let resource_table =
-    std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
+  let mut resource_table = isolate.resource_table.borrow_mut();
   resource_table
     .close(args.rid as u32)
     .ok_or_else(OpError::bad_resource_id)?;

--- a/cli/ops/resources.rs
+++ b/cli/ops/resources.rs
@@ -5,23 +5,24 @@ use crate::state::State;
 use deno_core::*;
 
 pub fn init(i: &mut Isolate, s: &State) {
-  i.register_op("op_resources", s.stateful_json_op(op_resources));
-  i.register_op("op_close", s.stateful_json_op(op_close));
+  i.register_op("op_resources", s.stateful_json_op2(op_resources));
+  i.register_op("op_close", s.stateful_json_op2(op_close));
 }
 
 fn op_resources(
-  state: &State,
+  isolate: &mut deno_core::Isolate,
+  _state: &State,
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
-  let state = state.borrow();
-  let serialized_resources = state.resource_table.entries();
+  let serialized_resources = isolate.resource_table.entries();
   Ok(JsonOp::Sync(json!(serialized_resources)))
 }
 
 /// op_close removes a resource from the resource table.
 fn op_close(
-  state: &State,
+  isolate: &mut deno_core::Isolate,
+  _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
@@ -30,9 +31,9 @@ fn op_close(
     rid: i32,
   }
   let args: CloseArgs = serde_json::from_value(args).unwrap();
-  let mut state = state.borrow_mut();
-  state
-    .resource_table
+  let resource_table =
+    std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
+  resource_table
     .close(args.rid as u32)
     .ok_or_else(OpError::bad_resource_id)?;
   Ok(JsonOp::Sync(json!({})))

--- a/cli/ops/signal.rs
+++ b/cli/ops/signal.rs
@@ -109,6 +109,7 @@ pub fn op_signal_unbind(
 
 #[cfg(not(unix))]
 pub fn op_signal_bind(
+  isolate: &mut deno_core::Isolate,
   _state: &State,
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -118,6 +119,7 @@ pub fn op_signal_bind(
 
 #[cfg(not(unix))]
 fn op_signal_unbind(
+  isolate: &mut deno_core::Isolate,
   _state: &State,
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -127,6 +129,7 @@ fn op_signal_unbind(
 
 #[cfg(not(unix))]
 fn op_signal_poll(
+  isolate: &mut deno_core::Isolate,
   _state: &State,
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/signal.rs
+++ b/cli/ops/signal.rs
@@ -44,8 +44,7 @@ fn op_signal_bind(
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let args: BindSignalArgs = serde_json::from_value(args)?;
-  let resource_table =
-    std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
+  let mut resource_table = isolate.resource_table.borrow_mut();
   let rid = resource_table.add(
     "signal",
     Box::new(SignalStreamResource(
@@ -67,10 +66,10 @@ fn op_signal_poll(
 ) -> Result<JsonOp, OpError> {
   let args: SignalArgs = serde_json::from_value(args)?;
   let rid = args.rid as u32;
-  let mut resource_table = isolate.resource_table.clone();
+  let resource_table = isolate.resource_table.clone();
 
   let future = poll_fn(move |cx| {
-    let resource_table = std::rc::Rc::get_mut(&mut resource_table).unwrap();
+    let mut resource_table = resource_table.borrow_mut();
     if let Some(mut signal) =
       resource_table.get_mut::<SignalStreamResource>(rid)
     {
@@ -93,8 +92,7 @@ pub fn op_signal_unbind(
 ) -> Result<JsonOp, OpError> {
   let args: SignalArgs = serde_json::from_value(args)?;
   let rid = args.rid as u32;
-  let resource_table =
-    std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
+  let mut resource_table = isolate.resource_table.borrow_mut();
   let resource = resource_table.get::<SignalStreamResource>(rid);
   if let Some(signal) = resource {
     if let Some(waker) = &signal.1 {

--- a/cli/ops/signal.rs
+++ b/cli/ops/signal.rs
@@ -109,7 +109,7 @@ pub fn op_signal_unbind(
 
 #[cfg(not(unix))]
 pub fn op_signal_bind(
-  isolate: &mut deno_core::Isolate,
+  _isolate: &mut deno_core::Isolate,
   _state: &State,
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -119,7 +119,7 @@ pub fn op_signal_bind(
 
 #[cfg(not(unix))]
 fn op_signal_unbind(
-  isolate: &mut deno_core::Isolate,
+  _isolate: &mut deno_core::Isolate,
   _state: &State,
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -129,7 +129,7 @@ fn op_signal_unbind(
 
 #[cfg(not(unix))]
 fn op_signal_poll(
-  isolate: &mut deno_core::Isolate,
+  _isolate: &mut deno_core::Isolate,
   _state: &State,
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/tls.rs
+++ b/cli/ops/tls.rs
@@ -97,8 +97,8 @@ pub fn op_start_tls(
         DNSNameRef::try_from_ascii_str(&domain).expect("Invalid DNS lookup");
       let tls_stream = tls_connector.connect(dnsname, tcp_stream).await?;
 
-      let mut resource_table = resource_table.borrow_mut();
-      let rid = resource_table.add(
+      let mut resource_table_ = resource_table.borrow_mut();
+      let rid = resource_table_.add(
         "clientTlsStream",
         Box::new(StreamResourceHolder::new(StreamResource::ClientTlsStream(
           Box::new(tls_stream),
@@ -161,8 +161,8 @@ pub fn op_connect_tls(
     let dnsname =
       DNSNameRef::try_from_ascii_str(&domain).expect("Invalid DNS lookup");
     let tls_stream = tls_connector.connect(dnsname, tcp_stream).await?;
-    let mut resource_table = resource_table.borrow_mut();
-    let rid = resource_table.add(
+    let mut resource_table_ = resource_table.borrow_mut();
+    let rid = resource_table_.add(
       "clientTlsStream",
       Box::new(StreamResourceHolder::new(StreamResource::ClientTlsStream(
         Box::new(tls_stream),
@@ -386,8 +386,8 @@ fn op_accept_tls(
     let (tcp_stream, _socket_addr) = accept_fut.await?;
     let local_addr = tcp_stream.local_addr()?;
     let remote_addr = tcp_stream.peer_addr()?;
-    let mut resource_table = resource_table.borrow_mut();
     let tls_acceptor = {
+      let resource_table = resource_table.borrow();
       let resource = resource_table
         .get::<TlsListenerResource>(rid)
         .ok_or_else(OpError::bad_resource_id)
@@ -396,6 +396,7 @@ fn op_accept_tls(
     };
     let tls_stream = tls_acceptor.accept(tcp_stream).await?;
     let rid = {
+      let mut resource_table = resource_table.borrow_mut();
       resource_table.add(
         "serverTlsStream",
         Box::new(StreamResourceHolder::new(StreamResource::ServerTlsStream(

--- a/cli/ops/tty.rs
+++ b/cli/ops/tty.rs
@@ -66,8 +66,7 @@ pub fn op_set_raw(
     use winapi::shared::minwindef::FALSE;
     use winapi::um::{consoleapi, handleapi};
 
-    let resource_table =
-      std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
+    let mut resource_table = isolate.resource_table.borrow_mut();
     let resource_holder = resource_table.get_mut::<StreamResourceHolder>(rid);
     if resource_holder.is_none() {
       return Err(OpError::bad_resource_id());
@@ -133,8 +132,7 @@ pub fn op_set_raw(
   {
     use std::os::unix::io::AsRawFd;
 
-    let resource_table =
-      std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
+    let mut resource_table = isolate.resource_table.borrow_mut();
     let resource_holder = resource_table.get_mut::<StreamResourceHolder>(rid);
     if resource_holder.is_none() {
       return Err(OpError::bad_resource_id());
@@ -224,10 +222,9 @@ pub fn op_isatty(
   let args: IsattyArgs = serde_json::from_value(args)?;
   let rid = args.rid;
 
-  let resource_table =
-    std::rc::Rc::get_mut(&mut isolate.resource_table).unwrap();
+  let mut resource_table = isolate.resource_table.borrow_mut();
   let isatty: bool =
-    std_file_resource(resource_table, rid as u32, move |r| match r {
+    std_file_resource(&mut resource_table, rid as u32, move |r| match r {
       Ok(std_file) => {
         #[cfg(windows)]
         {

--- a/cli/ops/tty.rs
+++ b/cli/ops/tty.rs
@@ -2,7 +2,6 @@ use super::dispatch_json::JsonOp;
 use super::io::std_file_resource;
 use super::io::{StreamResource, StreamResourceHolder};
 use crate::op_error::OpError;
-use crate::ops::json_op;
 use crate::state::State;
 use deno_core::*;
 #[cfg(unix)]
@@ -35,8 +34,8 @@ fn get_windows_handle(
 }
 
 pub fn init(i: &mut Isolate, s: &State) {
-  i.register_op("op_set_raw", s.core_op(json_op(s.stateful_op2(op_set_raw))));
-  i.register_op("op_isatty", s.core_op(json_op(s.stateful_op2(op_isatty))));
+  i.register_op("op_set_raw", s.stateful_json_op2(op_set_raw));
+  i.register_op("op_isatty", s.stateful_json_op2(op_isatty));
 }
 
 #[derive(Deserialize)]

--- a/cli/ops/worker_host.rs
+++ b/cli/ops/worker_host.rs
@@ -43,20 +43,21 @@ fn create_web_worker(
   let state =
     State::new_for_worker(global_state, Some(permissions), specifier)?;
 
-  if has_deno_namespace {
-    let mut s = state.borrow_mut();
-    let (stdin, stdout, stderr) = get_stdio();
-    s.resource_table.add("stdin", Box::new(stdin));
-    s.resource_table.add("stdout", Box::new(stdout));
-    s.resource_table.add("stderr", Box::new(stderr));
-  }
-
   let mut worker = WebWorker::new(
     name.clone(),
     startup_data::deno_isolate_init(),
     state,
     has_deno_namespace,
   );
+
+  if has_deno_namespace {
+    let resource_table =
+      std::rc::Rc::get_mut(&mut worker.resource_table).unwrap();
+    let (stdin, stdout, stderr) = get_stdio();
+    resource_table.add("stdin", Box::new(stdin));
+    resource_table.add("stdout", Box::new(stdout));
+    resource_table.add("stderr", Box::new(stderr));
+  }
 
   // Instead of using name for log we use `worker-${id}` because
   // WebWorkers can have empty string as name.

--- a/cli/ops/worker_host.rs
+++ b/cli/ops/worker_host.rs
@@ -51,8 +51,7 @@ fn create_web_worker(
   );
 
   if has_deno_namespace {
-    let resource_table =
-      std::rc::Rc::get_mut(&mut worker.resource_table).unwrap();
+    let mut resource_table = worker.resource_table.borrow_mut();
     let (stdin, stdout, stderr) = get_stdio();
     resource_table.add("stdin", Box::new(stdin));
     resource_table.add("stdout", Box::new(stdout));

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -64,7 +64,6 @@ pub struct StateInner {
   pub next_worker_id: u32,
   pub start_time: Instant,
   pub seeded_rng: Option<StdRng>,
-  pub resource_table: ResourceTable,
   pub target_lib: TargetLib,
   pub debug_type: DebugType,
 }
@@ -300,7 +299,6 @@ impl State {
       next_worker_id: 0,
       start_time: Instant::now(),
       seeded_rng,
-      resource_table: ResourceTable::default(),
       target_lib: TargetLib::Main,
       debug_type,
     }));
@@ -336,7 +334,6 @@ impl State {
       next_worker_id: 0,
       start_time: Instant::now(),
       seeded_rng,
-      resource_table: ResourceTable::default(),
       target_lib: TargetLib::Worker,
       debug_type: DebugType::Dependent,
     }));

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -14,7 +14,6 @@ use deno_core::ErrBox;
 use deno_core::ModuleLoader;
 use deno_core::ModuleSpecifier;
 use deno_core::Op;
-use deno_core::ResourceTable;
 use deno_core::ZeroCopyBuf;
 use futures::future::FutureExt;
 use rand::rngs::StdRng;

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -209,6 +209,19 @@ impl Future for Worker {
   }
 }
 
+impl Deref for Worker {
+  type Target = deno_core::EsIsolate;
+  fn deref(&self) -> &Self::Target {
+    &self.isolate
+  }
+}
+
+impl DerefMut for Worker {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.isolate
+  }
+}
+
 /// This worker is created and used by Deno executable.
 ///
 /// It provides ops available in the `Deno` namespace.

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -13,6 +13,7 @@ use crate::js_errors::JSError;
 use crate::ops::*;
 use crate::shared_queue::SharedQueue;
 use crate::shared_queue::RECOMMENDED_SIZE;
+use crate::ResourceTable;
 use futures::future::FutureExt;
 use futures::stream::select;
 use futures::stream::FuturesUnordered;
@@ -28,6 +29,7 @@ use std::mem::forget;
 use std::ops::{Deref, DerefMut};
 use std::option::Option;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::sync::{Arc, Mutex, Once};
 use std::task::Context;
 use std::task::Poll;
@@ -163,6 +165,7 @@ pub struct Isolate {
   snapshot_creator: Option<v8::SnapshotCreator>,
   has_snapshotted: bool,
   snapshot: Option<SnapshotConfig>,
+  pub resource_table: Rc<ResourceTable>,
   pub global_context: v8::Global<v8::Context>,
   pub(crate) shared_ab: v8::Global<v8::SharedArrayBuffer>,
   pub(crate) js_recv_cb: v8::Global<v8::Function>,
@@ -297,6 +300,7 @@ impl Isolate {
     let core_isolate = Self {
       v8_isolate: None,
       global_context,
+      resource_table: Rc::new(ResourceTable::default()),
       pending_promise_exceptions: HashMap::new(),
       shared_ab: v8::Global::<v8::SharedArrayBuffer>::new(),
       js_recv_cb: v8::Global::<v8::Function>::new(),

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -21,6 +21,7 @@ use futures::stream::StreamExt;
 use futures::task::AtomicWaker;
 use futures::Future;
 use libc::c_void;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::From;
 use std::error::Error;
@@ -165,7 +166,7 @@ pub struct Isolate {
   snapshot_creator: Option<v8::SnapshotCreator>,
   has_snapshotted: bool,
   snapshot: Option<SnapshotConfig>,
-  pub resource_table: Rc<ResourceTable>,
+  pub resource_table: Rc<RefCell<ResourceTable>>,
   pub global_context: v8::Global<v8::Context>,
   pub(crate) shared_ab: v8::Global<v8::SharedArrayBuffer>,
   pub(crate) js_recv_cb: v8::Global<v8::Function>,
@@ -300,7 +301,7 @@ impl Isolate {
     let core_isolate = Self {
       v8_isolate: None,
       global_context,
-      resource_table: Rc::new(ResourceTable::default()),
+      resource_table: Rc::new(RefCell::new(ResourceTable::default())),
       pending_promise_exceptions: HashMap::new(),
       shared_ab: v8::Global::<v8::SharedArrayBuffer>::new(),
       js_recv_cb: v8::Global::<v8::Function>::new(),


### PR DESCRIPTION
Fixes #3453, 

Towards #4222

This is not the most elegant patch, but I need to force resource_table into deno_core::Isolate now, and this is the best I can do at the moment.