### PR TITLE
Fix finalize, which consumes too much data

### DIFF
--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -123,7 +123,7 @@ export class ServerRequest {
     if (this.r.buffered() > 0) {
       const body = this.body;
       const buf = new Uint8Array(1024);
-      while ((await body.read(buf)) !== Deno.EOF) { }
+      while ((await body.read(buf)) !== Deno.EOF) {}
     }
   }
 }

--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -114,11 +114,17 @@ export class ServerRequest {
   private finalized = false;
   async finalize(): Promise<void> {
     if (this.finalized) return;
-    // Consume unread body
-    const body = this.body;
-    const buf = new Uint8Array(1024);
-    while ((await body.read(buf)) !== Deno.EOF) {}
     this.finalized = true;
+
+    try {
+      await this.r.peek(1);
+    } catch (e) {}
+    // Consume unread body
+    if (this.r.buffered() > 0) {
+      const body = this.body;
+      const buf = new Uint8Array(1024);
+      while ((await body.read(buf)) !== Deno.EOF) { }
+    }
   }
 }
 

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -189,10 +189,7 @@ test("ServerRequest.finalize() should consume unread body / content-length / mul
   console.log("buf.length: " + buf.length);
   await req.finalize();
   assertEquals(buf.length, 0);
-
 });
-
-
 
 test("ServerRequest.finalize() should consume unread body / chunked, trailers", async () => {
   const text = [

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -159,6 +159,41 @@ test("ServerRequest.finalize() should consume unread body / content-length", asy
   await req.finalize();
   assertEquals(tr.total, text.length);
 });
+
+test("ServerRequest.finalize() should consume unread body / content-length / multiple requests", async () => {
+  let text = "deno.land";
+  let req = new ServerRequest();
+  req.headers = new Headers();
+  req.headers.set("content-length", "" + text.length);
+  //const tr = totalReader(new Buffer(encode(text)));
+  const buf = new Buffer(encode(text));
+  const reader = new BufReader(buf);
+
+  req.r = reader;
+  req.w = new BufWriter(new Buffer());
+  await req.respond({ status: 200, body: "ok" });
+  assertEquals(buf.length, text.length);
+  await req.finalize();
+  assertEquals(buf.length, 0);
+
+  text = "2nd request";
+  buf.write(encode(text));
+  reader.peek(1);
+
+  req = new ServerRequest();
+  req.headers = new Headers();
+  req.headers.set("content-length", "" + text.length);
+  req.r = reader;
+  req.w = new BufWriter(new Buffer());
+  await req.respond({ status: 200, body: "ok" });
+  console.log("buf.length: " + buf.length);
+  await req.finalize();
+  assertEquals(buf.length, 0);
+
+});
+
+
+
 test("ServerRequest.finalize() should consume unread body / chunked, trailers", async () => {
   const text = [
     "5",


### PR DESCRIPTION
It looks like the read in the finalize method is blocking and consuming data from following requests in the same connection.

I got this problem when sending PUT requests with insomnia.