### PR TITLE
BREAKING CHANGE: rename Deno.toAsyncIterator() to Deno.iter()

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -42,7 +42,8 @@ export { FsEvent, fsEvents } from "./ops/fs_events.ts";
 export {
   EOF,
   copy,
-  toAsyncIterator,
+  iter,
+  iterSync,
   SeekMode,
   Reader,
   SyncReader,

--- a/cli/js/io.ts
+++ b/cli/js/io.ts
@@ -84,8 +84,11 @@ export async function copy(dst: Writer, src: Reader): Promise<number> {
   return n;
 }
 
-export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array> {
-  const b = new Uint8Array(1024);
+export function iter(
+  r: Reader,
+  bufSize?: number
+): AsyncIterableIterator<Uint8Array> {
+  const b = new Uint8Array(bufSize ?? 1024);
   return {
     [Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array> {
       return this;
@@ -93,6 +96,30 @@ export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array> {
 
     async next(): Promise<IteratorResult<Uint8Array>> {
       const result = await r.read(b);
+      if (result === EOF) {
+        return { value: new Uint8Array(), done: true };
+      }
+
+      return {
+        value: b.subarray(0, result),
+        done: false,
+      };
+    },
+  };
+}
+
+export function iterSync(
+  r: SyncReader,
+  bufSize?: number
+): IterableIterator<Uint8Array> {
+  const b = new Uint8Array(bufSize ?? 1024);
+  return {
+    [Symbol.iterator](): IterableIterator<Uint8Array> {
+      return this;
+    },
+
+    next(): IteratorResult<Uint8Array> {
+      const result = r.readSync(b);
       if (result === EOF) {
         return { value: new Uint8Array(), done: true };
       }

--- a/cli/js/io.ts
+++ b/cli/js/io.ts
@@ -84,50 +84,32 @@ export async function copy(dst: Writer, src: Reader): Promise<number> {
   return n;
 }
 
-export function iter(
+export async function* iter(
   r: Reader,
   bufSize?: number
 ): AsyncIterableIterator<Uint8Array> {
   const b = new Uint8Array(bufSize ?? 1024);
-  return {
-    [Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array> {
-      return this;
-    },
+  while (true) {
+    const result = await r.read(b);
+    if (result === EOF) {
+      break;
+    }
 
-    async next(): Promise<IteratorResult<Uint8Array>> {
-      const result = await r.read(b);
-      if (result === EOF) {
-        return { value: new Uint8Array(), done: true };
-      }
-
-      return {
-        value: b.subarray(0, result),
-        done: false,
-      };
-    },
-  };
+    yield b.subarray(0, result);
+  }
 }
 
-export function iterSync(
+export function* iterSync(
   r: SyncReader,
   bufSize?: number
 ): IterableIterator<Uint8Array> {
   const b = new Uint8Array(bufSize ?? 1024);
-  return {
-    [Symbol.iterator](): IterableIterator<Uint8Array> {
-      return this;
-    },
+  while (true) {
+    const result = r.readSync(b);
+    if (result === EOF) {
+      break;
+    }
 
-    next(): IteratorResult<Uint8Array> {
-      const result = r.readSync(b);
-      if (result === EOF) {
-        return { value: new Uint8Array(), done: true };
-      }
-
-      return {
-        value: b.subarray(0, result),
-        done: false,
-      };
-    },
-  };
+    yield b.subarray(0, result);
+  }
 }

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -575,11 +575,39 @@ declare namespace Deno {
 
   /** Turns a Reader, `r`, into an async iterator.
    *
-   *      for await (const chunk of toAsyncIterator(reader)) {
+   *      for await (const chunk of iter(reader)) {
+   *        console.log(chunk);
+   *      }
+   *
+   * Second argument can be used to tune size of buffer.
+   * Default size of buffer is 1024 bytes.
+   *
+   *      for await (const chunk of iter(reader, 1024 * 1024)) {
    *        console.log(chunk);
    *      }
    */
-  export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array>;
+  export function iter(
+    r: Reader,
+    bufSize?: number
+  ): AsyncIterableIterator<Uint8Array>;
+
+  /** Turns a SyncReader, `r`, into an iterator.
+   *
+   *      for (const chunk of iterSync(reader)) {
+   *        console.log(chunk);
+   *      }
+   *
+   * Second argument can be used to tune size of buffer.
+   * Default size of buffer is 1024 bytes.
+   *
+   *      for (const chunk of iterSync(reader, 1024 * 1024)) {
+   *        console.log(chunk);
+   *      }
+   */
+  export function iterSync(
+    r: SyncReader,
+    bufSize?: number
+  ): IterableIterator<Uint8Array>;
 
   /** Synchronously open a file and return an instance of `Deno.File`.  The
    * file does not need to previously exist if using the `create` or `createNew`

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -573,7 +573,8 @@ declare namespace Deno {
    */
   export function copy(dst: Writer, src: Reader): Promise<number>;
 
-  /** Turns a Reader, `r`, into an async iterator.
+  /** **UNSTABLE**: new API, yet to be vetted
+   * Turns a Reader, `r`, into an async iterator.
    *
    *      let f = await open("/etc/passwd");
    *      for await (const chunk of iter(f)) {
@@ -590,13 +591,18 @@ declare namespace Deno {
    *      }
    *      f.close();
    *
+   * Iterator uses internal buffer of fixed size for efficiency returning
+   * a view on that buffer on each iteration. It it therefore callers
+   * responsibility to copy contents of the buffer if needed; otherwise
+   * next iteration will overwrite contents of previously returned chunk.
    */
   export function iter(
     r: Reader,
     bufSize?: number
   ): AsyncIterableIterator<Uint8Array>;
 
-  /** Turns a SyncReader, `r`, into an iterator.
+  /** **UNSTABLE**: new API, yet to be vetted
+   * Turns a SyncReader, `r`, into an iterator.
    *
    *      let f = await open("/etc/passwd");
    *      for (const chunk of iterSync(reader)) {
@@ -613,6 +619,10 @@ declare namespace Deno {
    *      }
    *      f.close()
    *
+   * Iterator uses internal buffer of fixed size for efficiency returning
+   * a view on that buffer on each iteration. It it therefore callers
+   * responsibility to copy contents of the buffer if needed; otherwise
+   * next iteration will overwrite contents of previously returned chunk.
    */
   export function iterSync(
     r: SyncReader,

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -575,16 +575,21 @@ declare namespace Deno {
 
   /** Turns a Reader, `r`, into an async iterator.
    *
-   *      for await (const chunk of iter(reader)) {
+   *      let f = await open("/etc/passwd");
+   *      for await (const chunk of iter(f)) {
    *        console.log(chunk);
    *      }
+   *      f.close();
    *
-   * Second argument can be used to tune size of buffer.
-   * Default size of buffer is 1024 bytes.
+   * Second argument can be used to tune size of a buffer.
+   * Default size of the buffer is 1024 bytes.
    *
-   *      for await (const chunk of iter(reader, 1024 * 1024)) {
+   *      let f = await open("/etc/passwd");
+   *      for await (const chunk of iter(f, 1024 * 1024)) {
    *        console.log(chunk);
    *      }
+   *      f.close();
+   *
    */
   export function iter(
     r: Reader,
@@ -593,16 +598,21 @@ declare namespace Deno {
 
   /** Turns a SyncReader, `r`, into an iterator.
    *
+   *      let f = await open("/etc/passwd");
    *      for (const chunk of iterSync(reader)) {
    *        console.log(chunk);
    *      }
+   *      f.close();
    *
-   * Second argument can be used to tune size of buffer.
-   * Default size of buffer is 1024 bytes.
+   * Second argument can be used to tune size of a buffer.
+   * Default size of the buffer is 1024 bytes.
    *
+   *      let f = await open("/etc/passwd");
    *      for (const chunk of iterSync(reader, 1024 * 1024)) {
    *        console.log(chunk);
    *      }
+   *      f.close()
+   *
    */
   export function iterSync(
     r: SyncReader,

--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -248,7 +248,7 @@ class Body implements domTypes.Body, ReadableStream<Uint8Array>, io.ReadCloser {
   }
 
   [Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array> {
-    return io.toAsyncIterator(this);
+    return io.iter(this);
   }
 
   get bodyUsed(): boolean {

--- a/std/http/io.ts
+++ b/std/http/io.ts
@@ -164,7 +164,7 @@ export async function writeChunkedBody(
   r: Deno.Reader
 ): Promise<void> {
   const writer = BufWriter.create(w);
-  for await (const chunk of Deno.toAsyncIterator(r)) {
+  for await (const chunk of Deno.iter(r)) {
     if (chunk.byteLength <= 0) continue;
     const start = encoder.encode(`${chunk.byteLength.toString(16)}\r\n`);
     const end = encoder.encode("\r\n");


### PR DESCRIPTION
* adds sync version Deno.iterSync()
* adds optional second argument for buffer size
