### PR TITLE
Rename deno_core::Isolate to deno_core::CoreIsolate

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use deno_core::include_crate_modules;
-use deno_core::Isolate;
+use deno_core::CoreIsolate;
 use deno_core::StartupData;
 use std::collections::HashMap;
 use std::env;
@@ -48,10 +48,10 @@ fn main() {
   .expect("Bundle compilation failed");
   assert!(bundle_path.exists());
 
-  let runtime_isolate = &mut Isolate::new(StartupData::None, true);
+  let mut runtime_isolate = CoreIsolate::new(StartupData::None, true);
 
   deno_typescript::mksnapshot_bundle(
-    runtime_isolate,
+    &mut runtime_isolate,
     &snapshot_path,
     &bundle_path,
     &main_module_name,
@@ -71,7 +71,7 @@ fn main() {
   .expect("Bundle compilation failed");
   assert!(bundle_path.exists());
 
-  let runtime_isolate = &mut Isolate::new(StartupData::None, true);
+  let mut runtime_isolate = CoreIsolate::new(StartupData::None, true);
 
   let mut custom_libs: HashMap<String, PathBuf> = HashMap::new();
   custom_libs.insert(
@@ -96,7 +96,7 @@ fn main() {
   );
 
   deno_typescript::mksnapshot_bundle_ts(
-    runtime_isolate,
+    &mut runtime_isolate,
     &snapshot_path,
     &bundle_path,
     &main_module_name,

--- a/cli/inspector.rs
+++ b/cli/inspector.rs
@@ -308,11 +308,11 @@ impl DenoInspector {
   const CONTEXT_GROUP_ID: i32 = 1;
 
   pub fn new(
-    isolate: &mut deno_core::Isolate,
+    isolate: &mut deno_core::CoreIsolate,
     host: SocketAddr,
     wait_for_debugger: bool,
   ) -> Box<Self> {
-    let deno_core::Isolate {
+    let deno_core::CoreIsolate {
       v8_isolate,
       global_context,
       ..

--- a/cli/js.rs
+++ b/cli/js.rs
@@ -23,7 +23,7 @@ pub static WINDOW_LIB: &str = include_str!("js/lib.deno.window.d.ts");
 
 #[test]
 fn cli_snapshot() {
-  let mut isolate = deno_core::Isolate::new(
+  let mut isolate = deno_core::CoreIsolate::new(
     deno_core::StartupData::Snapshot(deno_core::Snapshot::Static(CLI_SNAPSHOT)),
     false,
   );
@@ -40,7 +40,7 @@ fn cli_snapshot() {
 
 #[test]
 fn compiler_snapshot() {
-  let mut isolate = deno_core::Isolate::new(
+  let mut isolate = deno_core::CoreIsolate::new(
     deno_core::StartupData::Snapshot(deno_core::Snapshot::Static(
       COMPILER_SNAPSHOT,
     )),

--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -6,11 +6,13 @@ use crate::futures::future::try_join_all;
 use crate::msg;
 use crate::op_error::OpError;
 use crate::state::State;
+use deno_core::CoreIsolate;
 use deno_core::ModuleLoader;
-use deno_core::*;
+use deno_core::ModuleSpecifier;
+use deno_core::ZeroCopyBuf;
 use futures::future::FutureExt;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_cache", s.stateful_json_op(op_cache));
   i.register_op("op_resolve_modules", s.stateful_json_op(op_resolve_modules));
   i.register_op(

--- a/cli/ops/dispatch_json.rs
+++ b/cli/ops/dispatch_json.rs
@@ -1,6 +1,9 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::op_error::OpError;
-use deno_core::*;
+use deno_core::Buf;
+use deno_core::CoreIsolate;
+use deno_core::Op;
+use deno_core::ZeroCopyBuf;
 use futures::future::FutureExt;
 pub use serde_derive::Deserialize;
 use serde_json::json;
@@ -43,15 +46,12 @@ struct AsyncArgs {
 
 pub fn json_op<D>(
   d: D,
-) -> impl Fn(&mut deno_core::Isolate, &[u8], Option<ZeroCopyBuf>) -> Op
+) -> impl Fn(&mut CoreIsolate, &[u8], Option<ZeroCopyBuf>) -> Op
 where
-  D: Fn(
-    &mut deno_core::Isolate,
-    Value,
-    Option<ZeroCopyBuf>,
-  ) -> Result<JsonOp, OpError>,
+  D:
+    Fn(&mut CoreIsolate, Value, Option<ZeroCopyBuf>) -> Result<JsonOp, OpError>,
 {
-  move |isolate: &mut deno_core::Isolate,
+  move |isolate: &mut CoreIsolate,
         control: &[u8],
         zero_copy: Option<ZeroCopyBuf>| {
     let async_args: AsyncArgs = match serde_json::from_slice(control) {

--- a/cli/ops/dispatch_minimal.rs
+++ b/cli/ops/dispatch_minimal.rs
@@ -7,6 +7,7 @@
 use crate::op_error::OpError;
 use byteorder::{LittleEndian, WriteBytesExt};
 use deno_core::Buf;
+use deno_core::CoreIsolate;
 use deno_core::Op;
 use deno_core::ZeroCopyBuf;
 use futures::future::FutureExt;
@@ -115,11 +116,11 @@ fn test_parse_min_record() {
 
 pub fn minimal_op<D>(
   d: D,
-) -> impl Fn(&mut deno_core::Isolate, &[u8], Option<ZeroCopyBuf>) -> Op
+) -> impl Fn(&mut CoreIsolate, &[u8], Option<ZeroCopyBuf>) -> Op
 where
-  D: Fn(&mut deno_core::Isolate, bool, i32, Option<ZeroCopyBuf>) -> MinimalOp,
+  D: Fn(&mut CoreIsolate, bool, i32, Option<ZeroCopyBuf>) -> MinimalOp,
 {
-  move |isolate: &mut deno_core::Isolate,
+  move |isolate: &mut CoreIsolate,
         control: &[u8],
         zero_copy: Option<ZeroCopyBuf>| {
     let mut record = match parse_min_record(control) {

--- a/cli/ops/errors.rs
+++ b/cli/ops/errors.rs
@@ -5,10 +5,11 @@ use crate::op_error::OpError;
 use crate::source_maps::get_orig_position;
 use crate::source_maps::CachedMaps;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 use std::collections::HashMap;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op(
     "op_apply_source_map",
     s.stateful_json_op(op_apply_source_map),

--- a/cli/ops/fetch.rs
+++ b/cli/ops/fetch.rs
@@ -4,14 +4,15 @@ use super::io::{StreamResource, StreamResourceHolder};
 use crate::http_util::{create_http_client, HttpBody};
 use crate::op_error::OpError;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 use futures::future::FutureExt;
 use http::header::HeaderName;
 use http::header::HeaderValue;
 use http::Method;
 use std::convert::From;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_fetch", s.stateful_json_op2(op_fetch));
 }
 
@@ -23,7 +24,7 @@ struct FetchArgs {
 }
 
 pub fn op_fetch(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   data: Option<ZeroCopyBuf>,

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -7,7 +7,7 @@ use crate::fs::resolve_from_cwd;
 use crate::op_error::OpError;
 use crate::ops::dispatch_json::JsonResult;
 use crate::state::State;
-use deno_core::Isolate;
+use deno_core::CoreIsolate;
 use deno_core::ZeroCopyBuf;
 use futures::future::FutureExt;
 use std::convert::From;
@@ -17,7 +17,7 @@ use std::time::UNIX_EPOCH;
 
 use rand::{thread_rng, Rng};
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_open", s.stateful_json_op2(op_open));
   i.register_op("op_seek", s.stateful_json_op2(op_seek));
   i.register_op("op_umask", s.stateful_json_op(op_umask));
@@ -68,7 +68,7 @@ struct OpenOptions {
 }
 
 fn op_open(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -205,7 +205,7 @@ struct SeekArgs {
 }
 
 fn op_seek(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/fs_events.rs
+++ b/cli/ops/fs_events.rs
@@ -2,7 +2,9 @@
 use super::dispatch_json::{Deserialize, JsonOp, Value};
 use crate::op_error::OpError;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ErrBox;
+use deno_core::ZeroCopyBuf;
 use futures::future::poll_fn;
 use futures::future::FutureExt;
 use notify::event::Event as NotifyEvent;
@@ -16,7 +18,7 @@ use std::convert::From;
 use std::path::PathBuf;
 use tokio::sync::mpsc;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_fs_events_open", s.stateful_json_op2(op_fs_events_open));
   i.register_op("op_fs_events_poll", s.stateful_json_op2(op_fs_events_poll));
 }
@@ -60,7 +62,7 @@ impl From<NotifyEvent> for FsEvent {
 }
 
 pub fn op_fs_events_open(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -98,7 +100,7 @@ pub fn op_fs_events_open(
 }
 
 pub fn op_fs_events_poll(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/io.rs
+++ b/cli/ops/io.rs
@@ -2,7 +2,9 @@ use super::dispatch_minimal::MinimalOp;
 use crate::http_util::HttpBody;
 use crate::op_error::OpError;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ResourceTable;
+use deno_core::ZeroCopyBuf;
 use futures::future::poll_fn;
 use futures::future::FutureExt;
 use futures::ready;
@@ -58,7 +60,7 @@ lazy_static! {
   };
 }
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_read", s.stateful_minimal_op2(op_read));
   i.register_op("op_write", s.stateful_minimal_op2(op_write));
 }
@@ -204,7 +206,7 @@ impl DenoAsyncRead for StreamResource {
 }
 
 pub fn op_read(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   is_sync: bool,
   rid: i32,
@@ -328,7 +330,7 @@ impl DenoAsyncWrite for StreamResource {
 }
 
 pub fn op_write(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   is_sync: bool,
   rid: i32,

--- a/cli/ops/net.rs
+++ b/cli/ops/net.rs
@@ -4,7 +4,9 @@ use super::io::{StreamResource, StreamResourceHolder};
 use crate::op_error::OpError;
 use crate::resolve_addr::resolve_addr;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ResourceTable;
+use deno_core::ZeroCopyBuf;
 use futures::future::poll_fn;
 use futures::future::FutureExt;
 use std::convert::From;
@@ -19,7 +21,7 @@ use tokio::net::UdpSocket;
 #[cfg(unix)]
 use super::net_unix;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_accept", s.stateful_json_op2(op_accept));
   i.register_op("op_connect", s.stateful_json_op2(op_connect));
   i.register_op("op_shutdown", s.stateful_json_op2(op_shutdown));
@@ -35,7 +37,7 @@ struct AcceptArgs {
 }
 
 fn accept_tcp(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   args: AcceptArgs,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
@@ -95,7 +97,7 @@ fn accept_tcp(
 }
 
 fn op_accept(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   zero_copy: Option<ZeroCopyBuf>,
@@ -119,7 +121,7 @@ struct ReceiveArgs {
 }
 
 fn receive_udp(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: ReceiveArgs,
   zero_copy: Option<ZeroCopyBuf>,
@@ -156,7 +158,7 @@ fn receive_udp(
 }
 
 fn op_receive(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   zero_copy: Option<ZeroCopyBuf>,
@@ -185,7 +187,7 @@ struct SendArgs {
 }
 
 fn op_send(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   zero_copy: Option<ZeroCopyBuf>,
@@ -254,7 +256,7 @@ struct ConnectArgs {
 }
 
 fn op_connect(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -339,7 +341,7 @@ struct ShutdownArgs {
 }
 
 fn op_shutdown(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -479,7 +481,7 @@ fn listen_udp(
 }
 
 fn op_listen(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/net_unix.rs
+++ b/cli/ops/net_unix.rs
@@ -1,9 +1,10 @@
 use super::dispatch_json::{Deserialize, JsonOp};
 use super::io::{StreamResource, StreamResourceHolder};
 use crate::op_error::OpError;
+use deno_core::CoreIsolate;
+use deno_core::ResourceTable;
+use deno_core::ZeroCopyBuf;
 use futures::future::FutureExt;
-
-use deno_core::*;
 use std::fs::remove_file;
 use std::os::unix;
 pub use std::path::Path;
@@ -26,7 +27,7 @@ pub struct UnixListenArgs {
 }
 
 pub fn accept_unix(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   rid: u32,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
@@ -77,7 +78,7 @@ pub fn accept_unix(
 }
 
 pub fn receive_unix_packet(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   rid: u32,
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {

--- a/cli/ops/os.rs
+++ b/cli/ops/os.rs
@@ -2,13 +2,14 @@
 use super::dispatch_json::{Deserialize, JsonOp, Value};
 use crate::op_error::OpError;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 use std::collections::HashMap;
 use std::env;
 use std::io::{Error, ErrorKind};
 use url::Url;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_exit", s.stateful_json_op(op_exit));
   i.register_op("op_env", s.stateful_json_op(op_env));
   i.register_op("op_exec_path", s.stateful_json_op(op_exec_path));

--- a/cli/ops/permissions.rs
+++ b/cli/ops/permissions.rs
@@ -3,10 +3,11 @@ use super::dispatch_json::{Deserialize, JsonOp, Value};
 use crate::fs as deno_fs;
 use crate::op_error::OpError;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 use std::path::Path;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op(
     "op_query_permission",
     s.stateful_json_op(op_query_permission),

--- a/cli/ops/plugins.rs
+++ b/cli/ops/plugins.rs
@@ -3,15 +3,15 @@ use crate::fs as deno_fs;
 use crate::op_error::OpError;
 use crate::ops::json_op;
 use crate::state::State;
-use deno_core::Isolate;
+use deno_core::CoreIsolate;
 use deno_core::ZeroCopyBuf;
 use dlopen::symbor::Library;
 use std::ffi::OsStr;
 use std::path::Path;
 
-pub type PluginInitFn = fn(isolate: &mut deno_core::Isolate);
+pub type PluginInitFn = fn(isolate: &mut CoreIsolate);
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op(
     "op_open_plugin",
     s.core_op(json_op(s.stateful_op2(op_open_plugin))),
@@ -34,7 +34,7 @@ struct OpenPluginArgs {
 }
 
 pub fn op_open_plugin(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/process.rs
+++ b/cli/ops/process.rs
@@ -4,7 +4,9 @@ use super::io::{std_file_resource, StreamResource, StreamResourceHolder};
 use crate::op_error::OpError;
 use crate::signal::kill;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ResourceTable;
+use deno_core::ZeroCopyBuf;
 use futures::future::poll_fn;
 use futures::future::FutureExt;
 use futures::TryFutureExt;
@@ -14,7 +16,7 @@ use tokio::process::Command;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_run", s.stateful_json_op2(op_run));
   i.register_op("op_run_status", s.stateful_json_op2(op_run_status));
   i.register_op("op_kill", s.stateful_json_op(op_kill));
@@ -58,7 +60,7 @@ struct ChildResource {
 }
 
 fn op_run(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -172,7 +174,7 @@ struct RunStatusArgs {
 }
 
 fn op_run_status(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/random.rs
+++ b/cli/ops/random.rs
@@ -2,11 +2,12 @@
 use super::dispatch_json::{JsonOp, Value};
 use crate::op_error::OpError;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 use rand::thread_rng;
 use rand::Rng;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op(
     "op_get_random_values",
     s.stateful_json_op(op_get_random_values),

--- a/cli/ops/repl.rs
+++ b/cli/ops/repl.rs
@@ -4,11 +4,12 @@ use crate::op_error::OpError;
 use crate::repl;
 use crate::repl::Repl;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_repl_start", s.stateful_json_op2(op_repl_start));
   i.register_op("op_repl_readline", s.stateful_json_op2(op_repl_readline));
 }
@@ -22,7 +23,7 @@ struct ReplStartArgs {
 }
 
 fn op_repl_start(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -45,7 +46,7 @@ struct ReplReadlineArgs {
 }
 
 fn op_repl_readline(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/resources.rs
+++ b/cli/ops/resources.rs
@@ -2,15 +2,16 @@
 use super::dispatch_json::{Deserialize, JsonOp, Value};
 use crate::op_error::OpError;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_resources", s.stateful_json_op2(op_resources));
   i.register_op("op_close", s.stateful_json_op2(op_close));
 }
 
 fn op_resources(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -21,7 +22,7 @@ fn op_resources(
 
 /// op_close removes a resource from the resource table.
 fn op_close(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/runtime.rs
+++ b/cli/ops/runtime.rs
@@ -5,7 +5,8 @@ use crate::op_error::OpError;
 use crate::state::State;
 use crate::version;
 use crate::DenoSubcommand;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 use std::env;
 
 /// BUILD_OS and BUILD_ARCH match the values in Deno.build. See js/build.ts.
@@ -18,7 +19,7 @@ static BUILD_OS: &str = "win";
 #[cfg(target_arch = "x86_64")]
 static BUILD_ARCH: &str = "x64";
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_start", s.stateful_json_op(op_start));
   i.register_op("op_metrics", s.stateful_json_op(op_metrics));
 }

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -4,10 +4,11 @@ use crate::compilers::runtime_compile;
 use crate::compilers::runtime_transpile;
 use crate::op_error::OpError;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 use std::collections::HashMap;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_compile", s.stateful_json_op(op_compile));
   i.register_op("op_transpile", s.stateful_json_op(op_transpile));
 }

--- a/cli/ops/signal.rs
+++ b/cli/ops/signal.rs
@@ -2,7 +2,8 @@
 use super::dispatch_json::{JsonOp, Value};
 use crate::op_error::OpError;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 
 #[cfg(unix)]
 use super::dispatch_json::Deserialize;
@@ -13,7 +14,7 @@ use std::task::Waker;
 #[cfg(unix)]
 use tokio::signal::unix::{signal, Signal, SignalKind};
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_signal_bind", s.stateful_json_op2(op_signal_bind));
   i.register_op("op_signal_unbind", s.stateful_json_op2(op_signal_unbind));
   i.register_op("op_signal_poll", s.stateful_json_op2(op_signal_poll));
@@ -38,7 +39,7 @@ struct SignalArgs {
 
 #[cfg(unix)]
 fn op_signal_bind(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -59,7 +60,7 @@ fn op_signal_bind(
 
 #[cfg(unix)]
 fn op_signal_poll(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -85,7 +86,7 @@ fn op_signal_poll(
 
 #[cfg(unix)]
 pub fn op_signal_unbind(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -109,7 +110,7 @@ pub fn op_signal_unbind(
 
 #[cfg(not(unix))]
 pub fn op_signal_bind(
-  _isolate: &mut deno_core::Isolate,
+  _isolate: &mut CoreIsolate,
   _state: &State,
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -119,7 +120,7 @@ pub fn op_signal_bind(
 
 #[cfg(not(unix))]
 fn op_signal_unbind(
-  _isolate: &mut deno_core::Isolate,
+  _isolate: &mut CoreIsolate,
   _state: &State,
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -129,7 +130,7 @@ fn op_signal_unbind(
 
 #[cfg(not(unix))]
 fn op_signal_poll(
-  _isolate: &mut deno_core::Isolate,
+  _isolate: &mut CoreIsolate,
   _state: &State,
   _args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/timers.rs
+++ b/cli/ops/timers.rs
@@ -2,12 +2,13 @@
 use super::dispatch_json::{Deserialize, JsonOp, Value};
 use crate::op_error::OpError;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 use futures::future::FutureExt;
 use std::time::Duration;
 use std::time::Instant;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op(
     "op_global_timer_stop",
     s.stateful_json_op(op_global_timer_stop),

--- a/cli/ops/tls.rs
+++ b/cli/ops/tls.rs
@@ -4,7 +4,8 @@ use super::io::{StreamResource, StreamResourceHolder};
 use crate::op_error::OpError;
 use crate::resolve_addr::resolve_addr;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 use futures::future::poll_fn;
 use futures::future::FutureExt;
 use std::convert::From;
@@ -27,7 +28,7 @@ use tokio_rustls::{
 };
 use webpki::DNSNameRef;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_start_tls", s.stateful_json_op2(op_start_tls));
   i.register_op("op_connect_tls", s.stateful_json_op2(op_connect_tls));
   i.register_op("op_listen_tls", s.stateful_json_op2(op_listen_tls));
@@ -52,7 +53,7 @@ struct StartTLSArgs {
 }
 
 pub fn op_start_tls(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -125,7 +126,7 @@ pub fn op_start_tls(
 }
 
 pub fn op_connect_tls(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -301,7 +302,7 @@ struct ListenTlsArgs {
 }
 
 fn op_listen_tls(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -351,7 +352,7 @@ struct AcceptTlsArgs {
 }
 
 fn op_accept_tls(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/tty.rs
+++ b/cli/ops/tty.rs
@@ -3,7 +3,8 @@ use super::io::std_file_resource;
 use super::io::{StreamResource, StreamResourceHolder};
 use crate::op_error::OpError;
 use crate::state::State;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 #[cfg(unix)]
 use nix::sys::termios;
 use serde_derive::Deserialize;
@@ -33,7 +34,7 @@ fn get_windows_handle(
   Ok(handle)
 }
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_set_raw", s.stateful_json_op2(op_set_raw));
   i.register_op("op_isatty", s.stateful_json_op2(op_isatty));
 }
@@ -45,7 +46,7 @@ struct SetRawArgs {
 }
 
 pub fn op_set_raw(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
@@ -213,7 +214,7 @@ struct IsattyArgs {
 }
 
 pub fn op_isatty(
-  isolate: &mut deno_core::Isolate,
+  isolate: &mut CoreIsolate,
   _state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,

--- a/cli/ops/web_worker.rs
+++ b/cli/ops/web_worker.rs
@@ -5,18 +5,15 @@ use crate::ops::json_op;
 use crate::state::State;
 use crate::web_worker::WebWorkerHandle;
 use crate::worker::WorkerEvent;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
 use futures::channel::mpsc;
 use std::convert::From;
 
 pub fn web_worker_op<D>(
   sender: mpsc::Sender<WorkerEvent>,
   dispatcher: D,
-) -> impl Fn(
-  &mut deno_core::Isolate,
-  Value,
-  Option<ZeroCopyBuf>,
-) -> Result<JsonOp, OpError>
+) -> impl Fn(&mut CoreIsolate, Value, Option<ZeroCopyBuf>) -> Result<JsonOp, OpError>
 where
   D: Fn(
     &mpsc::Sender<WorkerEvent>,
@@ -24,7 +21,7 @@ where
     Option<ZeroCopyBuf>,
   ) -> Result<JsonOp, OpError>,
 {
-  move |_isolate: &mut deno_core::Isolate,
+  move |_isolate: &mut CoreIsolate,
         args: Value,
         zero_copy: Option<ZeroCopyBuf>|
         -> Result<JsonOp, OpError> { dispatcher(&sender, args, zero_copy) }
@@ -34,11 +31,7 @@ pub fn web_worker_op2<D>(
   handle: WebWorkerHandle,
   sender: mpsc::Sender<WorkerEvent>,
   dispatcher: D,
-) -> impl Fn(
-  &mut deno_core::Isolate,
-  Value,
-  Option<ZeroCopyBuf>,
-) -> Result<JsonOp, OpError>
+) -> impl Fn(&mut CoreIsolate, Value, Option<ZeroCopyBuf>) -> Result<JsonOp, OpError>
 where
   D: Fn(
     WebWorkerHandle,
@@ -47,7 +40,7 @@ where
     Option<ZeroCopyBuf>,
   ) -> Result<JsonOp, OpError>,
 {
-  move |_isolate: &mut deno_core::Isolate,
+  move |_isolate: &mut CoreIsolate,
         args: Value,
         zero_copy: Option<ZeroCopyBuf>|
         -> Result<JsonOp, OpError> {
@@ -56,7 +49,7 @@ where
 }
 
 pub fn init(
-  i: &mut Isolate,
+  i: &mut CoreIsolate,
   s: &State,
   sender: &mpsc::Sender<WorkerEvent>,
   handle: WebWorkerHandle,

--- a/cli/ops/worker_host.rs
+++ b/cli/ops/worker_host.rs
@@ -11,12 +11,15 @@ use crate::tokio_util::create_basic_runtime;
 use crate::web_worker::WebWorker;
 use crate::web_worker::WebWorkerHandle;
 use crate::worker::WorkerEvent;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::ErrBox;
+use deno_core::ModuleSpecifier;
+use deno_core::ZeroCopyBuf;
 use futures::future::FutureExt;
 use std::convert::From;
 use std::thread::JoinHandle;
 
-pub fn init(i: &mut Isolate, s: &State) {
+pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_create_worker", s.stateful_json_op(op_create_worker));
   i.register_op(
     "op_host_terminate_worker",

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -71,7 +71,7 @@ impl State {
   pub fn stateful_json_op<D>(
     &self,
     dispatcher: D,
-  ) -> impl Fn(&mut deno_core::Isolate, &[u8], Option<ZeroCopyBuf>) -> Op
+  ) -> impl Fn(&mut deno_core::CoreIsolate, &[u8], Option<ZeroCopyBuf>) -> Op
   where
     D: Fn(&State, Value, Option<ZeroCopyBuf>) -> Result<JsonOp, OpError>,
   {
@@ -82,10 +82,10 @@ impl State {
   pub fn stateful_json_op2<D>(
     &self,
     dispatcher: D,
-  ) -> impl Fn(&mut deno_core::Isolate, &[u8], Option<ZeroCopyBuf>) -> Op
+  ) -> impl Fn(&mut deno_core::CoreIsolate, &[u8], Option<ZeroCopyBuf>) -> Op
   where
     D: Fn(
-      &mut deno_core::Isolate,
+      &mut deno_core::CoreIsolate,
       &State,
       Value,
       Option<ZeroCopyBuf>,
@@ -101,13 +101,13 @@ impl State {
   pub fn core_op<D>(
     &self,
     dispatcher: D,
-  ) -> impl Fn(&mut deno_core::Isolate, &[u8], Option<ZeroCopyBuf>) -> Op
+  ) -> impl Fn(&mut deno_core::CoreIsolate, &[u8], Option<ZeroCopyBuf>) -> Op
   where
-    D: Fn(&mut deno_core::Isolate, &[u8], Option<ZeroCopyBuf>) -> Op,
+    D: Fn(&mut deno_core::CoreIsolate, &[u8], Option<ZeroCopyBuf>) -> Op,
   {
     let state = self.clone();
 
-    move |isolate: &mut deno_core::Isolate,
+    move |isolate: &mut deno_core::CoreIsolate,
           control: &[u8],
           zero_copy: Option<ZeroCopyBuf>|
           -> Op {
@@ -161,10 +161,10 @@ impl State {
   pub fn stateful_minimal_op2<D>(
     &self,
     dispatcher: D,
-  ) -> impl Fn(&mut deno_core::Isolate, &[u8], Option<ZeroCopyBuf>) -> Op
+  ) -> impl Fn(&mut deno_core::CoreIsolate, &[u8], Option<ZeroCopyBuf>) -> Op
   where
     D: Fn(
-      &mut deno_core::Isolate,
+      &mut deno_core::CoreIsolate,
       &State,
       bool,
       i32,
@@ -173,7 +173,7 @@ impl State {
   {
     let state = self.clone();
     self.core_op(crate::ops::minimal_op(
-      move |isolate: &mut deno_core::Isolate,
+      move |isolate: &mut deno_core::CoreIsolate,
             is_sync: bool,
             rid: i32,
             zero_copy: Option<ZeroCopyBuf>|
@@ -186,13 +186,13 @@ impl State {
   /// This is a special function that provides `state` argument to dispatcher.
   ///
   /// NOTE: This only works with JSON dispatcher.
-  /// This is a band-aid for transition to `Isolate.register_op` API as most of our
+  /// This is a band-aid for transition to `CoreIsolate.register_op` API as most of our
   /// ops require `state` argument.
   pub fn stateful_op<D>(
     &self,
     dispatcher: D,
   ) -> impl Fn(
-    &mut deno_core::Isolate,
+    &mut deno_core::CoreIsolate,
     Value,
     Option<ZeroCopyBuf>,
   ) -> Result<JsonOp, OpError>
@@ -200,7 +200,7 @@ impl State {
     D: Fn(&State, Value, Option<ZeroCopyBuf>) -> Result<JsonOp, OpError>,
   {
     let state = self.clone();
-    move |_isolate: &mut deno_core::Isolate,
+    move |_isolate: &mut deno_core::CoreIsolate,
           args: Value,
           zero_copy: Option<ZeroCopyBuf>|
           -> Result<JsonOp, OpError> { dispatcher(&state, args, zero_copy) }
@@ -210,20 +210,20 @@ impl State {
     &self,
     dispatcher: D,
   ) -> impl Fn(
-    &mut deno_core::Isolate,
+    &mut deno_core::CoreIsolate,
     Value,
     Option<ZeroCopyBuf>,
   ) -> Result<JsonOp, OpError>
   where
     D: Fn(
-      &mut deno_core::Isolate,
+      &mut deno_core::CoreIsolate,
       &State,
       Value,
       Option<ZeroCopyBuf>,
     ) -> Result<JsonOp, OpError>,
   {
     let state = self.clone();
-    move |isolate: &mut deno_core::Isolate,
+    move |isolate: &mut deno_core::CoreIsolate,
           args: Value,
           zero_copy: Option<ZeroCopyBuf>|
           -> Result<JsonOp, OpError> {

--- a/core/examples/http_bench.rs
+++ b/core/examples/http_bench.rs
@@ -3,8 +3,12 @@ extern crate derive_deref;
 #[macro_use]
 extern crate log;
 
-use deno_core::Isolate as CoreIsolate;
-use deno_core::*;
+use deno_core::CoreIsolate;
+use deno_core::Op;
+use deno_core::ResourceTable;
+use deno_core::Script;
+use deno_core::StartupData;
+use deno_core::ZeroCopyBuf;
 use futures::future::poll_fn;
 use futures::prelude::*;
 use futures::task::Context;
@@ -111,7 +115,7 @@ impl Isolate {
     F: 'static + Fn(State, u32, Option<ZeroCopyBuf>) -> Result<u32, Error>,
   {
     let state = self.state.clone();
-    let core_handler = move |_isolate: &mut deno_core::Isolate,
+    let core_handler = move |_isolate: &mut CoreIsolate,
                              control_buf: &[u8],
                              zero_copy_buf: Option<ZeroCopyBuf>|
           -> Op {
@@ -141,7 +145,7 @@ impl Isolate {
     <F::Ok as TryInto<i32>>::Error: Debug,
   {
     let state = self.state.clone();
-    let core_handler = move |_isolate: &mut deno_core::Isolate,
+    let core_handler = move |_isolate: &mut CoreIsolate,
                              control_buf: &[u8],
                              zero_copy_buf: Option<ZeroCopyBuf>|
           -> Op {

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use crate::Isolate;
+use crate::CoreIsolate;
 use crate::ZeroCopyBuf;
 use futures::Future;
 use std::collections::HashMap;
@@ -22,7 +22,7 @@ pub enum Op {
 
 /// Main type describing op
 pub type OpDispatcher =
-  dyn Fn(&mut Isolate, &[u8], Option<ZeroCopyBuf>) -> Op + 'static;
+  dyn Fn(&mut CoreIsolate, &[u8], Option<ZeroCopyBuf>) -> Op + 'static;
 
 #[derive(Default)]
 pub struct OpRegistry {
@@ -43,7 +43,7 @@ impl OpRegistry {
 
   pub fn register<F>(&mut self, name: &str, op: F) -> OpId
   where
-    F: Fn(&mut Isolate, &[u8], Option<ZeroCopyBuf>) -> Op + 'static,
+    F: Fn(&mut CoreIsolate, &[u8], Option<ZeroCopyBuf>) -> Op + 'static,
   {
     let op_id = self.dispatchers.len() as u32;
 
@@ -86,7 +86,7 @@ fn test_op_registry() {
   expected.insert("test".to_string(), 1);
   assert_eq!(op_registry.name_to_id, expected);
 
-  let mut isolate = Isolate::new(crate::StartupData::None, false);
+  let mut isolate = CoreIsolate::new(crate::StartupData::None, false);
 
   let dispatch = op_registry.get(test_id).unwrap();
   let res = dispatch(&mut isolate, &[], None);
@@ -126,7 +126,7 @@ fn register_op_during_call() {
   };
   assert!(test_id != 0);
 
-  let mut isolate = Isolate::new(crate::StartupData::None, false);
+  let mut isolate = CoreIsolate::new(crate::StartupData::None, false);
 
   let dispatcher1 = {
     let g = op_registry.lock().unwrap();

--- a/test_plugin/src/lib.rs
+++ b/test_plugin/src/lib.rs
@@ -2,18 +2,19 @@ extern crate deno_core;
 extern crate futures;
 
 use deno_core::Buf;
+use deno_core::CoreIsolate;
 use deno_core::Op;
 use deno_core::ZeroCopyBuf;
 use futures::future::FutureExt;
 
 #[no_mangle]
-pub fn deno_plugin_init(isolate: &mut deno_core::Isolate) {
+pub fn deno_plugin_init(isolate: &mut CoreIsolate) {
   isolate.register_op("testSync", op_test_sync);
   isolate.register_op("testAsync", op_test_async);
 }
 
 pub fn op_test_sync(
-  _isolate: &mut deno_core::Isolate,
+  _isolate: &mut CoreIsolate,
   data: &[u8],
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Op {
@@ -31,7 +32,7 @@ pub fn op_test_sync(
 }
 
 pub fn op_test_async(
-  _isolate: &mut deno_core::Isolate,
+  _isolate: &mut CoreIsolate,
   data: &[u8],
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Op {


### PR DESCRIPTION
This is to avoid shadowing/confusion with v8::Isolate