### PR TITLE
upgrade: dprint 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e9af423272fc71c59bfbf3c34c617c3fe93d39a5232c25e0c123af984e0f1f"
+checksum = "bdb73fe3655b530e17c5606b950cc55b0a05e7bdda50be11578f8eddade7ef96"
 dependencies = [
  "dprint-core",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.13.0"
+dprint-plugin-typescript = "0.13.1"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.1"


### PR DESCRIPTION
* Stops line breaks before `extends` in conditional type, which previously would have caused a parsing error.
* Checks for `// dprint-ignore-file` comment before parsing. This allow files that panic in swc to be ignored.
* Align union and intersection types to have same multi-line behaviour as arguments.
* Fixes a bug in "multi-line" detection.
