### PR TITLE
refactor(cli/js/testing): Rename disableOpSanitizer to sanitizeOps

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -17,7 +17,7 @@ declare namespace Deno {
     name: string;
     ignore?: boolean;
     sanitizeOps?: boolean;
-    santizeResources?: boolean;
+    sanitizeResources?: boolean;
   }
 
   /** Register a test which will be run when `deno test` is used on the command

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -16,8 +16,8 @@ declare namespace Deno {
     fn: () => void | Promise<void>;
     name: string;
     ignore?: boolean;
-    disableOpSanitizer?: boolean;
-    disableResourceSanitizer?: boolean;
+    sanitizeOps?: boolean;
+    santizeResources?: boolean;
   }
 
   /** Register a test which will be run when `deno test` is used on the command

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -96,7 +96,11 @@ export function test(
   fn?: () => void | Promise<void>
 ): void {
   let testDef: TestDefinition;
-  const defaults = { ignore: false, sanitizeOps: true, sanitizeResources: true };
+  const defaults = {
+    ignore: false,
+    sanitizeOps: true,
+    sanitizeResources: true,
+  };
 
   if (typeof t === "string") {
     if (!fn || typeof fn != "function") {

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -80,8 +80,8 @@ export interface TestDefinition {
   fn: () => void | Promise<void>;
   name: string;
   ignore?: boolean;
-  disableOpSanitizer?: boolean;
-  disableResourceSanitizer?: boolean;
+  sanitizeOps?: boolean;
+  santizeResources?: boolean;
 }
 
 const TEST_REGISTRY: TestDefinition[] = [];
@@ -96,6 +96,7 @@ export function test(
   fn?: () => void | Promise<void>
 ): void {
   let testDef: TestDefinition;
+  const defaults = { ignore: false, sanitizeOps: true, santizeResources: true };
 
   if (typeof t === "string") {
     if (!fn || typeof fn != "function") {
@@ -104,12 +105,12 @@ export function test(
     if (!t) {
       throw new TypeError("The test name can't be empty");
     }
-    testDef = { fn: fn as () => void | Promise<void>, name: t, ignore: false };
+    testDef = { fn: fn as () => void | Promise<void>, name: t, ...defaults };
   } else if (typeof t === "function") {
     if (!t.name) {
       throw new TypeError("The test function can't be anonymous");
     }
-    testDef = { fn: t, name: t.name, ignore: false };
+    testDef = { fn: t, name: t.name, ...defaults };
   } else {
     if (!t.fn) {
       throw new TypeError("Missing test function");
@@ -117,14 +118,14 @@ export function test(
     if (!t.name) {
       throw new TypeError("The test name can't be empty");
     }
-    testDef = { ...t, ignore: Boolean(t.ignore) };
+    testDef = { ...defaults, ...t };
   }
 
-  if (testDef.disableOpSanitizer !== true) {
+  if (testDef.sanitizeOps) {
     testDef.fn = assertOps(testDef.fn);
   }
 
-  if (testDef.disableResourceSanitizer !== true) {
+  if (testDef.santizeResources) {
     testDef.fn = assertResources(testDef.fn);
   }
 

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -81,7 +81,7 @@ export interface TestDefinition {
   name: string;
   ignore?: boolean;
   sanitizeOps?: boolean;
-  santizeResources?: boolean;
+  sanitizeResources?: boolean;
 }
 
 const TEST_REGISTRY: TestDefinition[] = [];
@@ -96,7 +96,7 @@ export function test(
   fn?: () => void | Promise<void>
 ): void {
   let testDef: TestDefinition;
-  const defaults = { ignore: false, sanitizeOps: true, santizeResources: true };
+  const defaults = { ignore: false, sanitizeOps: true, sanitizeResources: true };
 
   if (typeof t === "string") {
     if (!fn || typeof fn != "function") {
@@ -125,7 +125,7 @@ export function test(
     testDef.fn = assertOps(testDef.fn);
   }
 
-  if (testDef.santizeResources) {
+  if (testDef.sanitizeResources) {
     testDef.fn = assertResources(testDef.fn);
   }
 


### PR DESCRIPTION
And `disableResourceSanitizer` to `sanitizeResources`. Defaulting to `true` instead of `false`. It's not a helpful prefix and makes it unnecessarily long.

cc @bartlomieju