### PR TITLE
refactor(log): support enum log level

### DIFF
--- a/std/log/README.md
+++ b/std/log/README.md
@@ -19,7 +19,7 @@ await log.setup({
   handlers: {
     console: new log.handlers.ConsoleHandler("DEBUG"),
 
-    file: new log.handlers.FileHandler("WARNING", {
+    file: new log.handlers.FileHandler(log.LogLevels.DEBUG, {
       filename: "./log.txt",
       // you can change format of output message using any keys in `LogRecord`
       formatter: "{levelName} {msg}",
@@ -34,7 +34,7 @@ await log.setup({
     },
 
     tasks: {
-      level: "ERROR",
+      level: log.LogLevels.ERROR,
       handlers: ["console"],
     },
   },

--- a/std/log/handlers.ts
+++ b/std/log/handlers.ts
@@ -2,7 +2,7 @@
 const { open, openSync, close, renameSync, statSync } = Deno;
 type File = Deno.File;
 type Writer = Deno.Writer;
-import { getLevelByName, LogLevel } from "./levels.ts";
+import { getLevelByName, LogLevel, LogLevels } from "./levels.ts";
 import { LogRecord } from "./logger.ts";
 import { red, yellow, blue, bold } from "../fmt/colors.ts";
 import { existsSync, exists } from "../fs/exists.ts";
@@ -17,10 +17,10 @@ interface HandlerOptions {
 
 export class BaseHandler {
   level: number;
-  levelName: string;
+  levelName: LogLevel;
   formatter: string | FormatterFunction;
 
-  constructor(levelName: string, options: HandlerOptions = {}) {
+  constructor(levelName: LogLevel, options: HandlerOptions = {}) {
     this.level = getLevelByName(levelName);
     this.levelName = levelName;
 
@@ -61,16 +61,16 @@ export class ConsoleHandler extends BaseHandler {
     let msg = super.format(logRecord);
 
     switch (logRecord.level) {
-      case LogLevel.INFO:
+      case LogLevels.INFO:
         msg = blue(msg);
         break;
-      case LogLevel.WARNING:
+      case LogLevels.WARNING:
         msg = yellow(msg);
         break;
-      case LogLevel.ERROR:
+      case LogLevels.ERROR:
         msg = red(msg);
         break;
-      case LogLevel.CRITICAL:
+      case LogLevels.CRITICAL:
         msg = bold(red(msg));
         break;
       default:
@@ -103,7 +103,7 @@ export class FileHandler extends WriterHandler {
   protected _mode: LogMode;
   #encoder = new TextEncoder();
 
-  constructor(levelName: string, options: FileHandlerOptions) {
+  constructor(levelName: LogLevel, options: FileHandlerOptions) {
     super(levelName, options);
     this._filename = options.filename;
     // default to append mode, write only
@@ -133,7 +133,7 @@ export class RotatingFileHandler extends FileHandler {
   #maxBytes: number;
   #maxBackupCount: number;
 
-  constructor(levelName: string, options: RotatingFileHandlerOptions) {
+  constructor(levelName: LogLevel, options: RotatingFileHandlerOptions) {
     super(levelName, options);
     this.#maxBytes = options.maxBytes;
     this.#maxBackupCount = options.maxBackupCount;

--- a/std/log/handlers.ts
+++ b/std/log/handlers.ts
@@ -2,7 +2,7 @@
 const { open, openSync, close, renameSync, statSync } = Deno;
 type File = Deno.File;
 type Writer = Deno.Writer;
-import { getLevelByName, LogLevel, LogLevels } from "./levels.ts";
+import { getLevelByName, LevelName, LogLevels } from "./levels.ts";
 import { LogRecord } from "./logger.ts";
 import { red, yellow, blue, bold } from "../fmt/colors.ts";
 import { existsSync, exists } from "../fs/exists.ts";
@@ -17,10 +17,10 @@ interface HandlerOptions {
 
 export class BaseHandler {
   level: number;
-  levelName: LogLevel;
+  levelName: LevelName;
   formatter: string | FormatterFunction;
 
-  constructor(levelName: LogLevel, options: HandlerOptions = {}) {
+  constructor(levelName: LevelName, options: HandlerOptions = {}) {
     this.level = getLevelByName(levelName);
     this.levelName = levelName;
 
@@ -103,7 +103,7 @@ export class FileHandler extends WriterHandler {
   protected _mode: LogMode;
   #encoder = new TextEncoder();
 
-  constructor(levelName: LogLevel, options: FileHandlerOptions) {
+  constructor(levelName: LevelName, options: FileHandlerOptions) {
     super(levelName, options);
     this._filename = options.filename;
     // default to append mode, write only
@@ -133,7 +133,7 @@ export class RotatingFileHandler extends FileHandler {
   #maxBytes: number;
   #maxBackupCount: number;
 
-  constructor(levelName: LogLevel, options: RotatingFileHandlerOptions) {
+  constructor(levelName: LevelName, options: RotatingFileHandlerOptions) {
     super(levelName, options);
     this.#maxBytes = options.maxBytes;
     this.#maxBackupCount = options.maxBackupCount;

--- a/std/log/handlers_test.ts
+++ b/std/log/handlers_test.ts
@@ -6,7 +6,7 @@ import {
   LogLevelNames,
   getLevelName,
   getLevelByName,
-  LogLevel,
+  LevelName,
 } from "./levels.ts";
 import { BaseHandler, FileHandler, RotatingFileHandler } from "./handlers.ts";
 import { LogRecord } from "./logger.ts";
@@ -56,7 +56,7 @@ test(function simpleHandler(): void {
     const handler = new TestHandler(testLevel);
 
     for (const levelName of LogLevelNames) {
-      const level = getLevelByName(levelName as LogLevel);
+      const level = getLevelByName(levelName as LevelName);
       handler.handle(
         new LogRecord(`${levelName.toLowerCase()}-test`, [], level)
       );

--- a/std/log/handlers_test.ts
+++ b/std/log/handlers_test.ts
@@ -1,7 +1,13 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 const { test } = Deno;
 import { assert, assertEquals, assertThrowsAsync } from "../testing/asserts.ts";
-import { LogLevel, getLevelName, getLevelByName } from "./levels.ts";
+import {
+  LogLevels,
+  LogLevelNames,
+  getLevelName,
+  getLevelByName,
+  LogLevel,
+} from "./levels.ts";
 import { BaseHandler, FileHandler, RotatingFileHandler } from "./handlers.ts";
 import { LogRecord } from "./logger.ts";
 import { existsSync } from "../fs/exists.ts";
@@ -19,7 +25,7 @@ class TestHandler extends BaseHandler {
 test(function simpleHandler(): void {
   const cases = new Map<number, string[]>([
     [
-      LogLevel.DEBUG,
+      LogLevels.DEBUG,
       [
         "DEBUG debug-test",
         "INFO info-test",
@@ -29,7 +35,7 @@ test(function simpleHandler(): void {
       ],
     ],
     [
-      LogLevel.INFO,
+      LogLevels.INFO,
       [
         "INFO info-test",
         "WARNING warning-test",
@@ -38,19 +44,19 @@ test(function simpleHandler(): void {
       ],
     ],
     [
-      LogLevel.WARNING,
+      LogLevels.WARNING,
       ["WARNING warning-test", "ERROR error-test", "CRITICAL critical-test"],
     ],
-    [LogLevel.ERROR, ["ERROR error-test", "CRITICAL critical-test"]],
-    [LogLevel.CRITICAL, ["CRITICAL critical-test"]],
+    [LogLevels.ERROR, ["ERROR error-test", "CRITICAL critical-test"]],
+    [LogLevels.CRITICAL, ["CRITICAL critical-test"]],
   ]);
 
   for (const [testCase, messages] of cases.entries()) {
     const testLevel = getLevelName(testCase);
     const handler = new TestHandler(testLevel);
 
-    for (const levelName in LogLevel) {
-      const level = getLevelByName(levelName);
+    for (const levelName of LogLevelNames) {
+      const level = getLevelByName(levelName as LogLevel);
       handler.handle(
         new LogRecord(`${levelName.toLowerCase()}-test`, [], level)
       );
@@ -67,7 +73,7 @@ test(function testFormatterAsString(): void {
     formatter: "test {levelName} {msg}",
   });
 
-  handler.handle(new LogRecord("Hello, world!", [], LogLevel.DEBUG));
+  handler.handle(new LogRecord("Hello, world!", [], LogLevels.DEBUG));
 
   assertEquals(handler.messages, ["test DEBUG Hello, world!"]);
 });
@@ -78,7 +84,7 @@ test(function testFormatterAsFunction(): void {
       `fn formatter ${logRecord.levelName} ${logRecord.msg}`,
   });
 
-  handler.handle(new LogRecord("Hello, world!", [], LogLevel.ERROR));
+  handler.handle(new LogRecord("Hello, world!", [], LogLevels.ERROR));
 
   assertEquals(handler.messages, ["fn formatter ERROR Hello, world!"]);
 });
@@ -92,12 +98,12 @@ test({
     });
 
     await fileHandler.setup();
-    fileHandler.handle(new LogRecord("Hello World", [], LogLevel.WARNING));
+    fileHandler.handle(new LogRecord("Hello World", [], LogLevels.WARNING));
     await fileHandler.destroy();
     const firstFileSize = (await Deno.stat(LOG_FILE)).size;
 
     await fileHandler.setup();
-    fileHandler.handle(new LogRecord("Hello World", [], LogLevel.WARNING));
+    fileHandler.handle(new LogRecord("Hello World", [], LogLevels.WARNING));
     await fileHandler.destroy();
     const secondFileSize = (await Deno.stat(LOG_FILE)).size;
 
@@ -198,11 +204,11 @@ test({
     });
     await fileHandler.setup();
 
-    fileHandler.handle(new LogRecord("AAA", [], LogLevel.ERROR)); // 'ERROR AAA\n' = 10 bytes
+    fileHandler.handle(new LogRecord("AAA", [], LogLevels.ERROR)); // 'ERROR AAA\n' = 10 bytes
     assertEquals((await Deno.stat(LOG_FILE)).size, 10);
-    fileHandler.handle(new LogRecord("AAA", [], LogLevel.ERROR));
+    fileHandler.handle(new LogRecord("AAA", [], LogLevels.ERROR));
     assertEquals((await Deno.stat(LOG_FILE)).size, 20);
-    fileHandler.handle(new LogRecord("AAA", [], LogLevel.ERROR));
+    fileHandler.handle(new LogRecord("AAA", [], LogLevels.ERROR));
     // Rollover occurred. Log file now has 1 record, rollover file has the original 2
     assertEquals((await Deno.stat(LOG_FILE)).size, 10);
     assertEquals((await Deno.stat(LOG_FILE + ".1")).size, 20);
@@ -238,7 +244,7 @@ test({
       mode: "a",
     });
     await fileHandler.setup();
-    fileHandler.handle(new LogRecord("AAA", [], LogLevel.ERROR)); // 'ERROR AAA\n' = 10 bytes
+    fileHandler.handle(new LogRecord("AAA", [], LogLevels.ERROR)); // 'ERROR AAA\n' = 10 bytes
     await fileHandler.destroy();
 
     const decoder = new TextDecoder();

--- a/std/log/levels.ts
+++ b/std/log/levels.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+/** Get log level numeric values through enum constants
+ */
 export enum LogLevels {
   NOTSET = 0,
   DEBUG = 10,
@@ -8,10 +10,12 @@ export enum LogLevels {
   CRITICAL = 50,
 }
 
+/** Permitted log level names */
 export const LogLevelNames = Object.keys(LogLevels).filter((key) =>
   isNaN(Number(key))
 );
 
+/** Union of valid log level strings */
 export type LogLevel = keyof typeof LogLevels;
 
 const byLevel: Record<string, LogLevel> = {
@@ -23,6 +27,9 @@ const byLevel: Record<string, LogLevel> = {
   [String(LogLevels.CRITICAL)]: "CRITICAL",
 };
 
+/** Returns the numeric log level associated with the passed,
+ * stringy log level name.
+ */
 export function getLevelByName(name: LogLevel): number {
   switch (name) {
     case "NOTSET":
@@ -42,6 +49,7 @@ export function getLevelByName(name: LogLevel): number {
   }
 }
 
+/** Returns the stringy log level name provided the numeric log level */
 export function getLevelName(level: number): LogLevel {
   const levelName = byLevel[level];
   if (levelName) {

--- a/std/log/levels.ts
+++ b/std/log/levels.ts
@@ -16,9 +16,9 @@ export const LogLevelNames = Object.keys(LogLevels).filter((key) =>
 );
 
 /** Union of valid log level strings */
-export type LogLevel = keyof typeof LogLevels;
+export type LevelName = keyof typeof LogLevels;
 
-const byLevel: Record<string, LogLevel> = {
+const byLevel: Record<string, LevelName> = {
   [String(LogLevels.NOTSET)]: "NOTSET",
   [String(LogLevels.DEBUG)]: "DEBUG",
   [String(LogLevels.INFO)]: "INFO",
@@ -30,7 +30,7 @@ const byLevel: Record<string, LogLevel> = {
 /** Returns the numeric log level associated with the passed,
  * stringy log level name.
  */
-export function getLevelByName(name: LogLevel): number {
+export function getLevelByName(name: LevelName): number {
   switch (name) {
     case "NOTSET":
       return LogLevels.NOTSET;
@@ -50,7 +50,7 @@ export function getLevelByName(name: LogLevel): number {
 }
 
 /** Returns the stringy log level name provided the numeric log level */
-export function getLevelName(level: number): LogLevel {
+export function getLevelName(level: number): LevelName {
   const levelName = byLevel[level];
   if (levelName) {
     return levelName;

--- a/std/log/levels.ts
+++ b/std/log/levels.ts
@@ -1,26 +1,51 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-export const LogLevel: Record<string, number> = {
-  NOTSET: 0,
-  DEBUG: 10,
-  INFO: 20,
-  WARNING: 30,
-  ERROR: 40,
-  CRITICAL: 50,
-};
-
-const byLevel = {
-  [LogLevel.NOTSET]: "NOTSET",
-  [LogLevel.DEBUG]: "DEBUG",
-  [LogLevel.INFO]: "INFO",
-  [LogLevel.WARNING]: "WARNING",
-  [LogLevel.ERROR]: "ERROR",
-  [LogLevel.CRITICAL]: "CRITICAL",
-};
-
-export function getLevelByName(name: string): number {
-  return LogLevel[name];
+export enum LogLevels {
+  NOTSET = 0,
+  DEBUG = 10,
+  INFO = 20,
+  WARNING = 30,
+  ERROR = 40,
+  CRITICAL = 50,
 }
 
-export function getLevelName(level: number): string {
-  return byLevel[level];
+export const LogLevelNames = Object.keys(LogLevels).filter((key) =>
+  isNaN(Number(key))
+);
+
+export type LogLevel = keyof typeof LogLevels;
+
+const byLevel: Record<string, LogLevel> = {
+  [String(LogLevels.NOTSET)]: "NOTSET",
+  [String(LogLevels.DEBUG)]: "DEBUG",
+  [String(LogLevels.INFO)]: "INFO",
+  [String(LogLevels.WARNING)]: "WARNING",
+  [String(LogLevels.ERROR)]: "ERROR",
+  [String(LogLevels.CRITICAL)]: "CRITICAL",
+};
+
+export function getLevelByName(name: LogLevel): number {
+  switch (name) {
+    case "NOTSET":
+      return LogLevels.NOTSET;
+    case "DEBUG":
+      return LogLevels.DEBUG;
+    case "INFO":
+      return LogLevels.INFO;
+    case "WARNING":
+      return LogLevels.WARNING;
+    case "ERROR":
+      return LogLevels.ERROR;
+    case "CRITICAL":
+      return LogLevels.CRITICAL;
+    default:
+      throw new Error(`no log level found for "${name}"`);
+  }
+}
+
+export function getLevelName(level: number): LogLevel {
+  const levelName = byLevel[level];
+  if (levelName) {
+    return levelName;
+  }
+  throw new Error(`no level name found for level: ${level}`);
 }

--- a/std/log/logger.ts
+++ b/std/log/logger.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { LogLevels, getLevelByName, getLevelName, LevelName } from "./levels.ts";
+import {
+  LogLevels,
+  getLevelByName,
+  getLevelName,
+  LevelName,
+} from "./levels.ts";
 import { BaseHandler } from "./handlers.ts";
 
 export class LogRecord {

--- a/std/log/logger.ts
+++ b/std/log/logger.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { LogLevels, getLevelByName, getLevelName, LogLevel } from "./levels.ts";
+import { LogLevels, getLevelByName, getLevelName, LevelName } from "./levels.ts";
 import { BaseHandler } from "./handlers.ts";
 
 export class LogRecord {
@@ -26,11 +26,11 @@ export class LogRecord {
 
 export class Logger {
   level: number;
-  levelName: LogLevel;
+  levelName: LevelName;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handlers: any[];
 
-  constructor(levelName: LogLevel, handlers?: BaseHandler[]) {
+  constructor(levelName: LevelName, handlers?: BaseHandler[]) {
     this.level = getLevelByName(levelName);
     this.levelName = levelName;
 

--- a/std/log/logger.ts
+++ b/std/log/logger.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { LogLevel, getLevelByName, getLevelName } from "./levels.ts";
+import { LogLevels, getLevelByName, getLevelName, LogLevel } from "./levels.ts";
 import { BaseHandler } from "./handlers.ts";
 
 export class LogRecord {
@@ -26,11 +26,11 @@ export class LogRecord {
 
 export class Logger {
   level: number;
-  levelName: string;
+  levelName: LogLevel;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handlers: any[];
 
-  constructor(levelName: string, handlers?: BaseHandler[]) {
+  constructor(levelName: LogLevel, handlers?: BaseHandler[]) {
     this.level = getLevelByName(levelName);
     this.levelName = levelName;
 
@@ -48,22 +48,22 @@ export class Logger {
   }
 
   debug(msg: string, ...args: unknown[]): void {
-    this._log(LogLevel.DEBUG, msg, ...args);
+    this._log(LogLevels.DEBUG, msg, ...args);
   }
 
   info(msg: string, ...args: unknown[]): void {
-    this._log(LogLevel.INFO, msg, ...args);
+    this._log(LogLevels.INFO, msg, ...args);
   }
 
   warning(msg: string, ...args: unknown[]): void {
-    this._log(LogLevel.WARNING, msg, ...args);
+    this._log(LogLevels.WARNING, msg, ...args);
   }
 
   error(msg: string, ...args: unknown[]): void {
-    this._log(LogLevel.ERROR, msg, ...args);
+    this._log(LogLevels.ERROR, msg, ...args);
   }
 
   critical(msg: string, ...args: unknown[]): void {
-    this._log(LogLevel.CRITICAL, msg, ...args);
+    this._log(LogLevels.CRITICAL, msg, ...args);
   }
 }

--- a/std/log/logger_test.ts
+++ b/std/log/logger_test.ts
@@ -2,7 +2,7 @@
 const { test } = Deno;
 import { assertEquals } from "../testing/asserts.ts";
 import { LogRecord, Logger } from "./logger.ts";
-import { LogLevel } from "./levels.ts";
+import { LogLevels, LogLevel } from "./levels.ts";
 import { BaseHandler } from "./handlers.ts";
 
 class TestHandler extends BaseHandler {
@@ -23,7 +23,7 @@ test(function simpleLogger(): void {
   const handler = new TestHandler("DEBUG");
   let logger = new Logger("DEBUG");
 
-  assertEquals(logger.level, LogLevel.DEBUG);
+  assertEquals(logger.level, LogLevels.DEBUG);
   assertEquals(logger.levelName, "DEBUG");
   assertEquals(logger.handlers, []);
 
@@ -41,14 +41,14 @@ test(function customHandler(): void {
   const record = handler.records[0];
   assertEquals(record.msg, "foo");
   assertEquals(record.args, [1, 2]);
-  assertEquals(record.level, LogLevel.DEBUG);
+  assertEquals(record.level, LogLevels.DEBUG);
   assertEquals(record.levelName, "DEBUG");
 
   assertEquals(handler.messages, ["DEBUG foo"]);
 });
 
 test(function logFunctions(): void {
-  const doLog = (level: string): TestHandler => {
+  const doLog = (level: LogLevel): TestHandler => {
     const handler = new TestHandler(level);
     const logger = new Logger(level, [handler]);
     logger.debug("foo");

--- a/std/log/logger_test.ts
+++ b/std/log/logger_test.ts
@@ -2,7 +2,7 @@
 const { test } = Deno;
 import { assertEquals } from "../testing/asserts.ts";
 import { LogRecord, Logger } from "./logger.ts";
-import { LogLevels, LogLevel } from "./levels.ts";
+import { LogLevels, LevelName } from "./levels.ts";
 import { BaseHandler } from "./handlers.ts";
 
 class TestHandler extends BaseHandler {
@@ -48,7 +48,7 @@ test(function customHandler(): void {
 });
 
 test(function logFunctions(): void {
-  const doLog = (level: LogLevel): TestHandler => {
+  const doLog = (level: LevelName): TestHandler => {
     const handler = new TestHandler(level);
     const logger = new Logger(level, [handler]);
     logger.debug("foo");

--- a/std/log/mod.ts
+++ b/std/log/mod.ts
@@ -8,12 +8,12 @@ import {
   RotatingFileHandler,
 } from "./handlers.ts";
 import { assert } from "../testing/asserts.ts";
-import { LogLevel } from "./levels.ts";
+import { LevelName } from "./levels.ts";
 
 export { LogLevels } from "./levels.ts";
 
 export class LoggerConfig {
-  level?: LogLevel;
+  level?: LevelName;
   handlers?: string[];
 }
 

--- a/std/log/mod.ts
+++ b/std/log/mod.ts
@@ -8,9 +8,12 @@ import {
   RotatingFileHandler,
 } from "./handlers.ts";
 import { assert } from "../testing/asserts.ts";
+import { LogLevel } from "./levels.ts";
+
+export { LogLevels } from "./levels.ts";
 
 export class LoggerConfig {
-  level?: string;
+  level?: LogLevel;
   handlers?: string[];
 }
 

--- a/std/log/test.ts
+++ b/std/log/test.ts
@@ -4,7 +4,7 @@ import { assertEquals, assertThrows } from "../testing/asserts.ts";
 import * as log from "./mod.ts";
 import {
   LogLevelNames,
-  LogLevel,
+  LevelName,
   getLevelByName,
   getLevelName,
 } from "./levels.ts";
@@ -34,7 +34,7 @@ test(async function defaultHandlers(): Promise<void> {
     }
 
     const logger = loggers[levelName];
-    const handler = new TestHandler(levelName as LogLevel);
+    const handler = new TestHandler(levelName as LevelName);
 
     await log.setup({
       handlers: {
@@ -42,7 +42,7 @@ test(async function defaultHandlers(): Promise<void> {
       },
       loggers: {
         default: {
-          level: levelName as LogLevel,
+          level: levelName as LevelName,
           handlers: ["default"],
         },
       },
@@ -110,6 +110,6 @@ test(async function getLoggerUnknown(): Promise<void> {
 });
 
 test(function getInvalidLoggerLevels(): void {
-  assertThrows(() => getLevelByName("FAKE_LOG_LEVEL" as LogLevel));
+  assertThrows(() => getLevelByName("FAKE_LOG_LEVEL" as LevelName));
   assertThrows(() => getLevelName(5000));
 });

--- a/std/log/test.ts
+++ b/std/log/test.ts
@@ -1,8 +1,13 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 const { test } = Deno;
-import { assertEquals } from "../testing/asserts.ts";
+import { assertEquals, assertThrows } from "../testing/asserts.ts";
 import * as log from "./mod.ts";
-import { LogLevel } from "./levels.ts";
+import {
+  LogLevelNames,
+  LogLevel,
+  getLevelByName,
+  getLevelName,
+} from "./levels.ts";
 
 class TestHandler extends log.handlers.BaseHandler {
   public messages: string[] = [];
@@ -23,13 +28,13 @@ test(async function defaultHandlers(): Promise<void> {
     CRITICAL: log.critical,
   };
 
-  for (const levelName in LogLevel) {
+  for (const levelName of LogLevelNames) {
     if (levelName === "NOTSET") {
       continue;
     }
 
     const logger = loggers[levelName];
-    const handler = new TestHandler(levelName);
+    const handler = new TestHandler(levelName as LogLevel);
 
     await log.setup({
       handlers: {
@@ -37,7 +42,7 @@ test(async function defaultHandlers(): Promise<void> {
       },
       loggers: {
         default: {
-          level: levelName,
+          level: levelName as LogLevel,
           handlers: ["default"],
         },
       },
@@ -102,4 +107,9 @@ test(async function getLoggerUnknown(): Promise<void> {
 
   assertEquals(logger.levelName, "NOTSET");
   assertEquals(logger.handlers, []);
+});
+
+test(function getInvalidLoggerLevels(): void {
+  assertThrows(() => getLevelByName("FAKE_LOG_LEVEL" as LogLevel));
+  assertThrows(() => getLevelName(5000));
 });


### PR DESCRIPTION
# problem

- on setting up my own logger instance, i observed that exported log levels by levelName were of type `Record<string, number>`, and did not constrain my input to a valid, case-sensitive, stringy value

# solution

- `enum`ify  and expose `LogLevels`
- type `levelName` to have type `LogLevel`, which is just a good ol' string union of `"INFO" | "DEBUG" | ...` etc
- update `mod.ts` with enum export
- update docs w/ inline examples _using_ said enum export
- increase strictness around providing bogus log levels

# discussion

this is one of those topics that i think people can validly debate if more typing helps or hurts. i'm not married to this proposal or the implementation details, so by all means--fire away. i _do_ want type safety here and am fine to bring it into userspace if we decide we dont want such _stuff_ here.