### PR TITLE
fix: remove bootstrap methods from global scope after bootstrapping

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -267,7 +267,7 @@ impl TsCompiler {
       startup_data::compiler_isolate_init(),
       worker_state,
     );
-    worker.execute("bootstrapTsCompilerRuntime()").unwrap();
+    worker.execute("bootstrap.tsCompilerRuntime()").unwrap();
     worker
   }
 

--- a/cli/compilers/wasm.rs
+++ b/cli/compilers/wasm.rs
@@ -67,7 +67,7 @@ impl WasmCompiler {
       startup_data::compiler_isolate_init(),
       worker_state,
     );
-    worker.execute("bootstrapWasmCompilerRuntime()").unwrap();
+    worker.execute("bootstrap.wasmCompilerRuntime()").unwrap();
     worker
   }
 

--- a/cli/js.rs
+++ b/cli/js.rs
@@ -30,7 +30,7 @@ fn cli_snapshot() {
   deno_core::js_check(isolate.execute(
     "<anon>",
     r#"
-      if (!(bootstrapMainRuntime && bootstrapWorkerRuntime)) {
+      if (!(bootstrap.mainRuntime && bootstrap.workerRuntime)) {
         throw Error("bad");
       }
       console.log("we have console.log!!!");
@@ -49,7 +49,7 @@ fn compiler_snapshot() {
   deno_core::js_check(isolate.execute(
     "<anon>",
     r#"
-    if (!(bootstrapTsCompilerRuntime && bootstrapTsCompilerRuntime)) {
+    if (!(bootstrap.tsCompilerRuntime && bootstrap.wasmCompilerRuntime)) {
         throw Error("bad");
       }
       console.log(`ts version: ${ts.version}`);

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -407,16 +407,13 @@ function bootstrapWasmCompilerRuntime(): void {
 delete (Object.prototype as any).__proto__;
 
 Object.defineProperties(globalThis, {
-  bootstrapWasmCompilerRuntime: {
-    value: bootstrapWasmCompilerRuntime,
-    enumerable: false,
-    writable: false,
-    configurable: false,
-  },
-  bootstrapTsCompilerRuntime: {
-    value: bootstrapTsCompilerRuntime,
-    enumerable: false,
-    writable: false,
-    configurable: false,
+  bootstrap: {
+    value: {
+      ...globalThis.bootstrap,
+      wasmCompilerRuntime: bootstrapWasmCompilerRuntime,
+      tsCompilerRuntime: bootstrapTsCompilerRuntime,
+    },
+    configurable: true,
+    writable: true,
   },
 });

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -134,12 +134,19 @@ declare global {
   };
   var onload: ((e: Event) => void) | undefined;
   var onunload: ((e: Event) => void) | undefined;
-  var bootstrapMainRuntime: (() => void) | undefined;
 
-  // Assigned to `self` global - worker runtime and compiler
-  var bootstrapWorkerRuntime:
-    | ((name: string) => Promise<void> | void)
-    | undefined;
+  // These methods are used to prepare different runtime
+  // environments. After bootrapping, this namespace
+  // should be removed from global scope.
+  var bootstrap: {
+    mainRuntime: (() => void) | undefined;
+    // Assigned to `self` global - worker runtime and compiler
+    workerRuntime: ((name: string) => Promise<void> | void) | undefined;
+    // Assigned to `self` global - compiler
+    tsCompilerRuntime: (() => void) | undefined;
+    wasmCompilerRuntime: (() => void) | undefined;
+  };
+
   var onerror:
     | ((
         msg: string,
@@ -156,9 +163,6 @@ declare global {
   var close: () => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   var postMessage: (msg: any) => void;
-  // Assigned to `self` global - compiler
-  var bootstrapTsCompilerRuntime: (() => void) | undefined;
-  var bootstrapWasmCompilerRuntime: (() => void) | undefined;
   /* eslint-enable */
 }
 

--- a/cli/js/main.ts
+++ b/cli/js/main.ts
@@ -9,16 +9,12 @@ import { bootstrapWorkerRuntime } from "./runtime_worker.ts";
 delete (Object.prototype as any).__proto__;
 
 Object.defineProperties(globalThis, {
-  bootstrapMainRuntime: {
-    value: bootstrapMainRuntime,
-    enumerable: false,
-    writable: false,
-    configurable: false,
-  },
-  bootstrapWorkerRuntime: {
-    value: bootstrapWorkerRuntime,
-    enumerable: false,
-    writable: false,
-    configurable: false,
+  bootstrap: {
+    value: {
+      mainRuntime: bootstrapMainRuntime,
+      workerRuntime: bootstrapWorkerRuntime,
+    },
+    configurable: true,
+    writable: true,
   },
 });

--- a/cli/js/runtime_main.ts
+++ b/cli/js/runtime_main.ts
@@ -72,6 +72,9 @@ export function bootstrapMainRuntime(): void {
   if (hasBootstrapped) {
     throw new Error("Worker runtime already bootstrapped");
   }
+  // Remove bootstrapping methods from global scope
+  // @ts-ignore
+  globalThis.bootstrap = undefined;
   log("bootstrapMainRuntime");
   hasBootstrapped = true;
   Object.defineProperties(globalThis, windowOrWorkerGlobalScopeMethods);

--- a/cli/js/runtime_worker.ts
+++ b/cli/js/runtime_worker.ts
@@ -126,6 +126,9 @@ export function bootstrapWorkerRuntime(
   if (hasBootstrapped) {
     throw new Error("Worker runtime already bootstrapped");
   }
+  // Remove bootstrapping methods from global scope
+  // @ts-ignore
+  globalThis.bootstrap = undefined;
   log("bootstrapWorkerRuntime");
   hasBootstrapped = true;
   Object.defineProperties(globalThis, windowOrWorkerGlobalScopeMethods);

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -154,7 +154,7 @@ fn create_main_worker(
     t.add("stderr", Box::new(stderr));
   }
 
-  worker.execute("bootstrapMainRuntime()")?;
+  worker.execute("bootstrap.mainRuntime()")?;
   Ok(worker)
 }
 

--- a/cli/ops/worker_host.rs
+++ b/cli/ops/worker_host.rs
@@ -64,7 +64,7 @@ fn create_web_worker(
   // Instead of using name for log we use `worker-${id}` because
   // WebWorkers can have empty string as name.
   let script = format!(
-    "bootstrapWorkerRuntime(\"{}\", {}, \"worker-{}\")",
+    "bootstrap.workerRuntime(\"{}\", {}, \"worker-{}\")",
     name, worker.has_deno_namespace, worker_id
   );
   worker.execute(&script)?;

--- a/cli/web_worker.rs
+++ b/cli/web_worker.rs
@@ -263,7 +263,7 @@ mod tests {
       false,
     );
     worker
-      .execute("bootstrapWorkerRuntime(\"TEST\", false)")
+      .execute("bootstrap.workerRuntime(\"TEST\", false)")
       .unwrap();
     worker
   }

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -382,7 +382,7 @@ mod tests {
       startup_data::deno_isolate_init(),
       state.clone(),
     );
-    worker.execute("bootstrapMainRuntime()").unwrap();
+    worker.execute("bootstrap.mainRuntime()").unwrap();
     let result = worker.execute_module(&module_specifier).await;
     if let Err(err) = result {
       eprintln!("execute_mod err {:?}", err);
@@ -404,7 +404,7 @@ mod tests {
       startup_data::deno_isolate_init(),
       state,
     );
-    worker.execute("bootstrapMainRuntime()").unwrap();
+    worker.execute("bootstrap.mainRuntime()").unwrap();
     worker
   }
 


### PR DESCRIPTION
Closes #4747

This PR changes how bootstrapping methods are handled:
- instead of `bootstrap` prefix for each method; a `bootstrap` namespace is assigned to global scope
- after runtime is bootstrapped `globalThis.bootstrap` is removed so it doesn't leak to userspace anymore