### PR TITLE
fix(cli/js/symbols): Update symbol descriptions

### DIFF
--- a/cli/js/internals.ts
+++ b/cli/js/internals.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-export const internalSymbol = Symbol("Deno.internal");
+export const internalSymbol = Symbol("Deno.symbols.internal");
 
 // The object where all the internal fields for testing will be living.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cli/js/tests/console_test.ts
+++ b/cli/js/tests/console_test.ts
@@ -631,7 +631,7 @@ unitTest(function consoleTestWithCustomInspectorError(): void {
   assertEquals(stringify(new B({ a: "a" })), "a");
   assertEquals(
     stringify(B.prototype),
-    "{ Symbol(Deno.customInspect): [Function: [Deno.customInspect]] }"
+    "{ Symbol(Deno.symbols.customInspect): [Function: [Deno.symbols.customInspect]] }"
   );
 });
 

--- a/cli/js/web/console.ts
+++ b/cli/js/web/console.ts
@@ -953,7 +953,7 @@ export class Console {
   }
 }
 
-export const customInspect = Symbol.for("Deno.customInspect");
+export const customInspect = Symbol("Deno.symbols.customInspect");
 
 export function inspect(
   value: unknown,


### PR DESCRIPTION
Don't use `Symbol.for()` to define `Deno.symbols.customInspect`.
