### PR TITLE
BREAKING CHANGE: rename TLS APIs to camel case

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -107,7 +107,7 @@ export { resources, close } from "./ops/resources.ts";
 export { signal, signals, Signal, SignalStream } from "./signals.ts";
 export { FileInfo, statSync, lstatSync, stat, lstat } from "./ops/fs/stat.ts";
 export { symlinkSync, symlink } from "./ops/fs/symlink.ts";
-export { connectTLS, listenTLS, startTLS } from "./tls.ts";
+export { connectTls, listenTls, startTls } from "./tls.ts";
 export { truncateSync, truncate } from "./ops/fs/truncate.ts";
 export { isatty, setRaw } from "./ops/tty.ts";
 export { umask } from "./ops/fs/umask.ts";

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -2018,7 +2018,7 @@ declare namespace Deno {
     options: UnixListenOptions & { transport: "unixpacket" }
   ): DatagramConn;
 
-  export interface ListenTLSOptions extends ListenOptions {
+  export interface ListenTlsOptions extends ListenOptions {
     /** Server certificate file. */
     certFile: string;
     /** Server public key file. */
@@ -2030,10 +2030,10 @@ declare namespace Deno {
   /** Listen announces on the local transport address over TLS (transport layer
    * security).
    *
-   *      const lstnr = Deno.listenTLS({ port: 443, certFile: "./server.crt", keyFile: "./server.key" });
+   *      const lstnr = Deno.listenTls({ port: 443, certFile: "./server.crt", keyFile: "./server.key" });
    *
    * Requires `allow-net` permission. */
-  export function listenTLS(options: ListenTLSOptions): Listener;
+  export function listenTls(options: ListenTlsOptions): Listener;
 
   export interface ConnectOptions {
     /** The port to connect to. */
@@ -2064,7 +2064,7 @@ declare namespace Deno {
     options: ConnectOptions | UnixConnectOptions
   ): Promise<Conn>;
 
-  export interface ConnectTLSOptions {
+  export interface ConnectTlsOptions {
     /** The port to connect to. */
     port: number;
     /** A literal IP address or host name that can be resolved to an IP address.
@@ -2079,16 +2079,16 @@ declare namespace Deno {
    * cert file is optional and if not included Mozilla's root certificates will
    * be used (see also https://github.com/ctz/webpki-roots for specifics)
    *
-   *     const conn1 = await Deno.connectTLS({ port: 80 });
-   *     const conn2 = await Deno.connectTLS({ certFile: "./certs/my_custom_root_CA.pem", hostname: "192.0.2.1", port: 80 });
-   *     const conn3 = await Deno.connectTLS({ hostname: "[2001:db8::1]", port: 80 });
-   *     const conn4 = await Deno.connectTLS({ certFile: "./certs/my_custom_root_CA.pem", hostname: "golang.org", port: 80});
+   *     const conn1 = await Deno.connectTls({ port: 80 });
+   *     const conn2 = await Deno.connectTls({ certFile: "./certs/my_custom_root_CA.pem", hostname: "192.0.2.1", port: 80 });
+   *     const conn3 = await Deno.connectTls({ hostname: "[2001:db8::1]", port: 80 });
+   *     const conn4 = await Deno.connectTls({ certFile: "./certs/my_custom_root_CA.pem", hostname: "golang.org", port: 80});
    *
    * Requires `allow-net` permission.
    */
-  export function connectTLS(options: ConnectTLSOptions): Promise<Conn>;
+  export function connectTls(options: ConnectTlsOptions): Promise<Conn>;
 
-  export interface StartTLSOptions {
+  export interface StartTlsOptions {
     /** A literal IP address or host name that can be resolved to an IP address.
      * If not specified, defaults to `127.0.0.1`. */
     hostname?: string;
@@ -2106,13 +2106,13 @@ declare namespace Deno {
    * prepared for TLS handshake.
    *
    *     const conn = await Deno.connect({ port: 80, hostname: "127.0.0.1" });
-   *     const tlsConn = await Deno.startTLS(conn, { certFile: "./certs/my_custom_root_CA.pem", hostname: "127.0.0.1", port: 80 });
+   *     const tlsConn = await Deno.startTls(conn, { certFile: "./certs/my_custom_root_CA.pem", hostname: "127.0.0.1", port: 80 });
    *
    * Requires `allow-net` permission.
    */
-  export function startTLS(
+  export function startTls(
     conn: Conn,
-    options?: StartTLSOptions
+    options?: StartTlsOptions
   ): Promise<Conn>;
 
   /** **UNSTABLE**: not sure if broken or not */

--- a/cli/js/ops/tls.ts
+++ b/cli/js/ops/tls.ts
@@ -22,7 +22,7 @@ interface EstablishTLSResponse {
   };
 }
 
-export function connectTLS(
+export function connectTls(
   args: ConnectTLSRequest
 ): Promise<EstablishTLSResponse> {
   return sendAsync("op_connect_tls", args);
@@ -63,7 +63,7 @@ interface ListenTLSResponse {
   };
 }
 
-export function listenTLS(args: ListenTLSRequest): ListenTLSResponse {
+export function listenTls(args: ListenTLSRequest): ListenTLSResponse {
   return sendSync("op_listen_tls", args);
 }
 
@@ -73,6 +73,6 @@ export interface StartTLSRequest {
   certFile?: string;
 }
 
-export function startTLS(args: StartTLSRequest): Promise<EstablishTLSResponse> {
+export function startTls(args: StartTLSRequest): Promise<EstablishTLSResponse> {
   return sendAsync("op_start_tls", args);
 }

--- a/cli/js/tests/tls_test.ts
+++ b/cli/js/tests/tls_test.ts
@@ -14,7 +14,7 @@ const decoder = new TextDecoder();
 unitTest(async function connectTLSNoPerm(): Promise<void> {
   let err;
   try {
-    await Deno.connectTLS({ hostname: "github.com", port: 443 });
+    await Deno.connectTls({ hostname: "github.com", port: 443 });
   } catch (e) {
     err = e;
   }
@@ -25,7 +25,7 @@ unitTest(async function connectTLSNoPerm(): Promise<void> {
 unitTest(async function connectTLSCertFileNoReadPerm(): Promise<void> {
   let err;
   try {
-    await Deno.connectTLS({
+    await Deno.connectTls({
       hostname: "github.com",
       port: 443,
       certFile: "cli/tests/tls/RootCA.crt",
@@ -49,7 +49,7 @@ unitTest(
     };
 
     try {
-      Deno.listenTLS({
+      Deno.listenTls({
         ...options,
         certFile: "./non/existent/file",
       });
@@ -59,7 +59,7 @@ unitTest(
     assert(err instanceof Deno.errors.NotFound);
 
     try {
-      Deno.listenTLS({
+      Deno.listenTls({
         ...options,
         keyFile: "./non/existent/file",
       });
@@ -73,7 +73,7 @@ unitTest(
 unitTest({ perms: { net: true } }, function listenTLSNoReadPerm(): void {
   let err;
   try {
-    Deno.listenTLS({
+    Deno.listenTls({
       hostname: "localhost",
       port: 4500,
       certFile: "cli/tests/tls/localhost.crt",
@@ -106,7 +106,7 @@ unitTest(
     });
 
     try {
-      Deno.listenTLS({
+      Deno.listenTls({
         ...options,
         keyFile: keyFilename,
       });
@@ -135,7 +135,7 @@ unitTest(
     });
 
     try {
-      Deno.listenTLS({
+      Deno.listenTls({
         ...options,
         certFile: certFilename,
       });
@@ -153,7 +153,7 @@ unitTest(
     const hostname = "localhost";
     const port = 4500;
 
-    const listener = Deno.listenTLS({
+    const listener = Deno.listenTls({
       hostname,
       port,
       certFile: "cli/tests/tls/localhost.crt",
@@ -177,7 +177,7 @@ unitTest(
       }
     );
 
-    const conn = await Deno.connectTLS({
+    const conn = await Deno.connectTls({
       hostname,
       port,
       certFile: "cli/tests/tls/RootCA.pem",
@@ -212,7 +212,7 @@ unitTest(
 
 unitTest(
   { perms: { read: true, net: true } },
-  async function startTLS(): Promise<void> {
+  async function startTls(): Promise<void> {
     const hostname = "smtp.gmail.com";
     const port = 587;
     const encoder = new TextEncoder();
@@ -244,7 +244,7 @@ unitTest(
     // Received the message that the server is ready to establish TLS
     assertEquals(line, "220 2.0.0 Ready to start TLS");
 
-    conn = await Deno.startTLS(conn, { hostname });
+    conn = await Deno.startTls(conn, { hostname });
     writer = new BufWriter(conn);
     reader = new TextProtoReader(new BufReader(conn));
 

--- a/cli/js/tls.ts
+++ b/cli/js/tls.ts
@@ -4,20 +4,20 @@ import { Listener, Conn, ConnImpl, ListenerImpl } from "./net.ts";
 
 // TODO(ry) There are many configuration options to add...
 // https://docs.rs/rustls/0.16.0/rustls/struct.ClientConfig.html
-interface ConnectTLSOptions {
+interface ConnectTlsOptions {
   transport?: "tcp";
   port: number;
   hostname?: string;
   certFile?: string;
 }
 
-export async function connectTLS({
+export async function connectTls({
   port,
   hostname = "127.0.0.1",
   transport = "tcp",
   certFile = undefined,
-}: ConnectTLSOptions): Promise<Conn> {
-  const res = await tlsOps.connectTLS({
+}: ConnectTlsOptions): Promise<Conn> {
+  const res = await tlsOps.connectTls({
     port,
     hostname,
     transport,
@@ -33,7 +33,7 @@ class TLSListenerImpl extends ListenerImpl {
   }
 }
 
-export interface ListenTLSOptions {
+export interface ListenTlsOptions {
   port: number;
   hostname?: string;
   transport?: "tcp";
@@ -41,14 +41,14 @@ export interface ListenTLSOptions {
   keyFile: string;
 }
 
-export function listenTLS({
+export function listenTls({
   port,
   certFile,
   keyFile,
   hostname = "0.0.0.0",
   transport = "tcp",
-}: ListenTLSOptions): Listener {
-  const res = tlsOps.listenTLS({
+}: ListenTlsOptions): Listener {
+  const res = tlsOps.listenTls({
     port,
     certFile,
     keyFile,
@@ -58,16 +58,16 @@ export function listenTLS({
   return new TLSListenerImpl(res.rid, res.localAddr);
 }
 
-interface StartTLSOptions {
+interface StartTlsOptions {
   hostname?: string;
   certFile?: string;
 }
 
-export async function startTLS(
+export async function startTls(
   conn: Conn,
-  { hostname = "127.0.0.1", certFile = undefined }: StartTLSOptions = {}
+  { hostname = "127.0.0.1", certFile = undefined }: StartTlsOptions = {}
 ): Promise<Conn> {
-  const res = await tlsOps.startTLS({
+  const res = await tlsOps.startTls({
     rid: conn.rid,
     hostname,
     certFile,

--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -13,7 +13,7 @@ import {
 import Listener = Deno.Listener;
 import Conn = Deno.Conn;
 import Reader = Deno.Reader;
-const { listen, listenTLS } = Deno;
+const { listen, listenTls } = Deno;
 
 export class ServerRequest {
   url!: string;
@@ -286,7 +286,7 @@ export async function listenAndServe(
 }
 
 /** Options for creating an HTTPS server. */
-export type HTTPSOptions = Omit<Deno.ListenTLSOptions, "transport">;
+export type HTTPSOptions = Omit<Deno.ListenTlsOptions, "transport">;
 
 /**
  * Create an HTTPS server with given options
@@ -306,11 +306,11 @@ export type HTTPSOptions = Omit<Deno.ListenTLSOptions, "transport">;
  * @return Async iterable server instance for incoming requests
  */
 export function serveTLS(options: HTTPSOptions): Server {
-  const tlsOptions: Deno.ListenTLSOptions = {
+  const tlsOptions: Deno.ListenTlsOptions = {
     ...options,
     transport: "tcp",
   };
-  const listener = listenTLS(tlsOptions);
+  const listener = listenTls(tlsOptions);
   return new Server(listener);
 }
 

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -423,7 +423,7 @@ test({
         "server must be started"
       );
       // Requests to the server and immediately closes the connection
-      const conn = await Deno.connectTLS({
+      const conn = await Deno.connectTls({
         hostname: "localhost",
         port: 4503,
         certFile: "http/testdata/tls/RootCA.pem",

--- a/std/ws/mod.ts
+++ b/std/ws/mod.ts
@@ -527,7 +527,7 @@ export async function connectWebSocket(
     conn = await Deno.connect({ hostname, port });
   } else if (url.protocol === "https:" || url.protocol === "wss:") {
     const port = parseInt(url.port || "443");
-    conn = await Deno.connectTLS({ hostname, port });
+    conn = await Deno.connectTls({ hostname, port });
   } else {
     throw new Error("ws: unsupported protocol: " + url.protocol);
   }


### PR DESCRIPTION
This commit renames all APIs containing "TLS" to use camel case
(connectTLS -> connectTls, etc.)

Ref #4882