### PR TITLE
introduce unstable flag, make a few things unstable

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -112,6 +112,7 @@ pub struct Flags {
   pub inspect_brk: Option<SocketAddr>,
   pub seed: Option<u64>,
   pub v8_flags: Option<Vec<String>>,
+  pub unstable: bool,
 
   pub lock: Option<String>,
   pub lock_write: bool,
@@ -496,6 +497,10 @@ fn run_test_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 
   if matches.is_present("cached-only") {
     flags.cached_only = true;
+  }
+
+  if matches.is_present("unstable") {
+    flags.unstable = true;
   }
 
   if matches.is_present("seed") {
@@ -918,6 +923,11 @@ fn run_test_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
       Arg::with_name("cached-only")
         .long("cached-only")
         .help("Require that remote dependencies are already cached"),
+    )
+    .arg(
+      Arg::with_name("unstable")
+        .long("unstable")
+        .help("Enable unstable APIs"),
     )
     .arg(
       Arg::with_name("seed")

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1582,12 +1582,16 @@ declare namespace Deno {
 
   /** Creates `newpath` as a hard link to `oldpath`.
    *
+   *  **UNSTABLE**: needs security review.
+   *
    *       await Deno.link("old/name", "new/name");
    *
    * Requires `allow-read` and `allow-write` permissions. */
   export function link(oldpath: string, newpath: string): Promise<void>;
 
   /** **UNSTABLE**: `type` argument type may be changed to `"dir" | "file"`.
+   *
+   *  **UNSTABLE**: needs security review.
    *
    * Creates `newpath` as a symbolic link to `oldpath`.
    *
@@ -1606,6 +1610,8 @@ declare namespace Deno {
   ): void;
 
   /** **UNSTABLE**: `type` argument may be changed to `"dir" | "file"`
+   *
+   *  **UNSTABLE**: needs security review.
    *
    * Creates `newpath` as a symbolic link to `oldpath`.
    *

--- a/cli/js/tests/unit_test_runner.ts
+++ b/cli/js/tests/unit_test_runner.ts
@@ -90,6 +90,7 @@ function spawnWorkerRunner(
   const cmd = [
     Deno.execPath(),
     "run",
+    "--unstable", // TODO(ry) be able to test stable vs unstable
     "-A",
     "cli/js/tests/unit_test_runner.ts",
     "--worker",

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -700,6 +700,7 @@ fn op_link(
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
+  state.check_unstable("Deno.link");
   let args: LinkArgs = serde_json::from_value(args)?;
   let oldpath = resolve_from_cwd(Path::new(&args.oldpath))?;
   let newpath = resolve_from_cwd(Path::new(&args.newpath))?;
@@ -728,6 +729,7 @@ fn op_symlink(
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
+  state.check_unstable("Deno.symlink");
   let args: SymlinkArgs = serde_json::from_value(args)?;
   let oldpath = resolve_from_cwd(Path::new(&args.oldpath))?;
   let newpath = resolve_from_cwd(Path::new(&args.newpath))?;

--- a/cli/ops/plugins.rs
+++ b/cli/ops/plugins.rs
@@ -39,10 +39,9 @@ pub fn op_open_plugin(
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
+  state.check_unstable("Deno.openPlugin");
   let args: OpenPluginArgs = serde_json::from_value(args).unwrap();
   let filename = deno_fs::resolve_from_cwd(Path::new(&args.filename))?;
-
-  state.check_plugin(&filename)?;
 
   let lib = open_plugin(filename).unwrap();
   let plugin_resource = PluginResource { lib };

--- a/cli/ops/plugins.rs
+++ b/cli/ops/plugins.rs
@@ -43,6 +43,8 @@ pub fn op_open_plugin(
   let args: OpenPluginArgs = serde_json::from_value(args).unwrap();
   let filename = deno_fs::resolve_from_cwd(Path::new(&args.filename))?;
 
+  state.check_plugin(&filename)?;
+
   let lib = open_plugin(filename).unwrap();
   let plugin_resource = PluginResource { lib };
 

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -230,6 +230,18 @@ impl State {
       dispatcher(isolate, &state, args, zero_copy)
     }
   }
+
+  /// Quits the process if the --unstable flag was not provided.
+  ///
+  /// This is intentionally a non-recoverable check so that people cannot probe
+  /// for unstable APIs from stable programs.
+  pub fn check_unstable(&self, api_name: &str) {
+    let s = self.0.borrow();
+    if !s.global_state.flags.unstable {
+      eprintln!("--unstable flag not provided for '{}'", api_name);
+      std::process::exit(70);
+    }
+  }
 }
 
 impl ModuleLoader for State {

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -236,9 +236,14 @@ impl State {
   /// This is intentionally a non-recoverable check so that people cannot probe
   /// for unstable APIs from stable programs.
   pub fn check_unstable(&self, api_name: &str) {
+    // TODO(ry) Maybe use IsolateHandle::terminate_execution here to provide a
+    // stack trace in JS.
     let s = self.0.borrow();
     if !s.global_state.flags.unstable {
-      eprintln!("--unstable flag not provided for '{}'", api_name);
+      eprintln!(
+        "Unstable API '{}'. The --unstable flag must be provided.",
+        api_name
+      );
       std::process::exit(70);
     }
   }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1568,6 +1568,13 @@ itest!(top_level_for_await_ts {
   output: "top_level_for_await.out",
 });
 
+itest!(unstable {
+  args: "run unstable.js",
+  check_stderr: true,
+  exit_code: 70,
+  output: "unstable.out",
+});
+
 itest!(_053_import_compression {
   args: "run --reload --allow-net 053_import_compression/main.ts",
   output: "053_import_compression.out",

--- a/cli/tests/std_tests.rs
+++ b/cli/tests/std_tests.rs
@@ -18,6 +18,7 @@ mod tests {
     let mut deno = deno_cmd
       .current_dir(cwd) // note: std tests expect to run from "std" dir
       .arg("test")
+      .arg("--unstable")
       .arg("--seed=86") // Some tests rely on specific random numbers.
       .arg("-A")
       // .arg("-Ldebug")

--- a/cli/tests/unstable.js
+++ b/cli/tests/unstable.js
@@ -1,0 +1,2 @@
+// This program should require the --unstable flag
+Deno.openPlugin("foo");

--- a/cli/tests/unstable.out
+++ b/cli/tests/unstable.out
@@ -1,0 +1,1 @@
+Unstable API 'Deno.openPlugin'. The --unstable flag must be provided.

--- a/test_plugin/tests/integration_tests.rs
+++ b/test_plugin/tests/integration_tests.rs
@@ -31,6 +31,7 @@ fn basic() {
   assert!(build_plugin_output.status.success());
   let output = deno_cmd()
     .arg("--allow-plugin")
+    .arg("--unstable")
     .arg("tests/test.js")
     .arg(BUILD_VARIANT)
     .output()


### PR DESCRIPTION
minimal version of https://github.com/denoland/deno/pull/4639 where we only do a runtime check. Once this is working for a few ops, we can figure out how to also do type checking.

openPlugin, link, linkSync, symlink, symlinkSync now require --unstable flag

Ref https://github.com/denoland/deno/issues/4334