### PR TITLE
fix: globToRegExp moved to path mod

### DIFF
--- a/std/fs/README.md
+++ b/std/fs/README.md
@@ -99,21 +99,6 @@ exists("./foo"); // returns a Promise<boolean>
 existsSync("./foo"); // returns boolean
 ```
 
-### globToRegExp
-
-Generate a regex based on glob pattern and options This was meant to be using
-the the `fs.walk` function but can be used anywhere else.
-
-```ts
-import { globToRegExp } from "https://deno.land/std/fs/mod.ts";
-
-globToRegExp("foo/**/*.json", {
-  flags: "g",
-  extended: true,
-  globstar: true,
-}); // returns the regex to find all .json files in the folder foo
-```
-
 ### move
 
 Moves a file or directory. Overwrites it if option provided


### PR DESCRIPTION
The globToRegExp method has been moved to the path module
