### PR TITLE
Add buffer size argument to copy

### DIFF
--- a/cli/js/io.ts
+++ b/cli/js/io.ts
@@ -70,9 +70,13 @@ export interface ReadWriteCloser extends Reader, Writer, Closer {}
 // https://golang.org/pkg/io/#ReadWriteSeeker
 export interface ReadWriteSeeker extends Reader, Writer, Seeker {}
 
-export async function copy(src: Reader, dst: Writer): Promise<number> {
+export async function copy(
+  src: Reader,
+  dst: Writer,
+  bufSize?: number
+): Promise<number> {
   let n = 0;
-  const b = new Uint8Array(DEFAULT_BUFFER_SIZE);
+  const b = new Uint8Array(bufSize ?? DEFAULT_BUFFER_SIZE);
   let gotEOF = false;
   while (gotEOF === false) {
     const result = await src.read(b);

--- a/cli/js/io.ts
+++ b/cli/js/io.ts
@@ -73,10 +73,13 @@ export interface ReadWriteSeeker extends Reader, Writer, Seeker {}
 export async function copy(
   src: Reader,
   dst: Writer,
-  bufSize?: number
+  options?: {
+    bufSize?: number;
+  }
 ): Promise<number> {
   let n = 0;
-  const b = new Uint8Array(bufSize ?? DEFAULT_BUFFER_SIZE);
+  const bufSize = options?.bufSize ?? DEFAULT_BUFFER_SIZE;
+  const b = new Uint8Array(bufSize);
   let gotEOF = false;
   while (gotEOF === false) {
     const result = await src.read(b);

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -572,12 +572,14 @@ declare namespace Deno {
    *
    * @param src The source to copy from
    * @param dst The destination to copy to
-   * @param bufsize An optional size for the buffer. Default size is 32kB
+   * @param options Can be used to tune size of the buffer. Default size is 32kB
    */
   export function copy(
     src: Reader,
     dst: Writer,
-    bufsize?: number
+    options?: {
+      bufSize?: number;
+    }
   ): Promise<number>;
 
   /** Turns a Reader, `r`, into an async iterator.

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -572,8 +572,13 @@ declare namespace Deno {
    *
    * @param src The source to copy from
    * @param dst The destination to copy to
+   * @param bufsize An optional size for the buffer. Default size is 32kB
    */
-  export function copy(src: Reader, dst: Writer): Promise<number>;
+  export function copy(
+    src: Reader,
+    dst: Writer,
+    bufsize?: number
+  ): Promise<number>;
 
   /** Turns a Reader, `r`, into an async iterator.
    *

--- a/cli/js/tests/io_test.ts
+++ b/cli/js/tests/io_test.ts
@@ -1,0 +1,57 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { unitTest, assertEquals } from "./test_util.ts";
+
+const DEFAULT_BUF_SIZE = 32 * 1024;
+
+type Spy = { calls: number };
+
+function repeat(c: string, bytes: number): Uint8Array {
+  assertEquals(c.length, 1);
+  const ui8 = new Uint8Array(bytes);
+  ui8.fill(c.charCodeAt(0));
+  return ui8;
+}
+
+function spyRead(obj: Deno.Buffer): Spy {
+  const spy: Spy = {
+    calls: 0,
+  };
+
+  const orig = obj.read.bind(obj);
+
+  obj.read = (p: Uint8Array): Promise<number | Deno.EOF> => {
+    spy.calls++;
+    return orig(p);
+  };
+
+  return spy;
+}
+
+unitTest(async function copyWithDefaultBufferSize() {
+  const xBytes = repeat("b", DEFAULT_BUF_SIZE);
+  const reader = new Deno.Buffer(xBytes.buffer as ArrayBuffer);
+  const write = new Deno.Buffer();
+
+  const readSpy = spyRead(reader);
+
+  const n = await Deno.copy(reader, write);
+
+  assertEquals(n, xBytes.length);
+  assertEquals(write.length, xBytes.length);
+  assertEquals(readSpy.calls, 2); // read with DEFAULT_BUF_SIZE bytes + read with 0 bytes
+});
+
+unitTest(async function copyWithCustomBufferSize() {
+  const bufSize = 1024;
+  const xBytes = repeat("b", DEFAULT_BUF_SIZE);
+  const reader = new Deno.Buffer(xBytes.buffer as ArrayBuffer);
+  const write = new Deno.Buffer();
+
+  const readSpy = spyRead(reader);
+
+  const n = await Deno.copy(reader, write, { bufSize });
+
+  assertEquals(n, xBytes.length);
+  assertEquals(write.length, xBytes.length);
+  assertEquals(readSpy.calls, DEFAULT_BUF_SIZE / bufSize + 1);
+});

--- a/cli/js/tests/unit_tests.ts
+++ b/cli/js/tests/unit_tests.ts
@@ -31,6 +31,7 @@ import "./get_random_values_test.ts";
 import "./globals_test.ts";
 import "./headers_test.ts";
 import "./internals_test.ts";
+import "./io_test.ts";
 import "./link_test.ts";
 import "./location_test.ts";
 import "./make_temp_test.ts";


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
Add `bufSize` argument to `copy`. [Go implementation](https://golang.org/src/io/io.go?s=11951:12021#L383) has a `CopyBuffer` which allows passing a buffer of any size, if nothing is passed it defaults to 32kb

I'll add some tests if this gets a :+1: 