### PR TITLE
removed .stats. from runTest doc string

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -147,7 +147,7 @@ declare namespace Deno {
    *        // Run tests
    *        const runInfo = await Deno.runTests();
    *        console.log(runInfo.duration);  // all tests duration, e.g. "5" (in ms)
-   *        console.log(runInfo.stats.passed);  // e.g. 1
+   *        console.log(runInfo.passed);  // e.g. 1
    *        console.log(runInfo.results[0].name);  // e.g. "example test"
    */
   export function runTests(


### PR DESCRIPTION
I run into this one by copy, pasting the code from the [doc](https://doc.deno.land/https/github.com/denoland/deno/releases/latest/download/lib.deno.d.ts#Deno.runTests) and was wondering why vscodes deno (justjavac's) extension had red underlined it. turns out `.passed` is just one level down.