### PR TITLE
Add AssertionError and NotImplemented

### DIFF
--- a/cli/js/errors.ts
+++ b/cli/js/errors.ts
@@ -181,24 +181,55 @@ class Busy extends Error {
     this.name = "Busy";
   }
 }
+/* eslint-disable @typescript-eslint/no-explicit-any */
+class AssertionError extends Error {
+  #actual: any;
+  #expected: any;
+  constructor(
+    message?: string,
+    { actual, expected }: { actual?: any; expected?: any } = {}
+  ) {
+    super(message);
+    this.name = "AssertionError";
+    this.#actual = actual;
+    this.#expected = expected;
+  }
+
+  get actual(): any {
+    return this.#actual;
+  }
+
+  get expected(): any {
+    return this.#expected;
+  }
+}
+/* eslint-enable */
+class NotImplemented extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "NotImplemented";
+  }
+}
 
 export const errors = {
-  NotFound: NotFound,
-  PermissionDenied: PermissionDenied,
-  ConnectionRefused: ConnectionRefused,
-  ConnectionReset: ConnectionReset,
-  ConnectionAborted: ConnectionAborted,
-  NotConnected: NotConnected,
-  AddrInUse: AddrInUse,
-  AddrNotAvailable: AddrNotAvailable,
-  BrokenPipe: BrokenPipe,
-  AlreadyExists: AlreadyExists,
-  InvalidData: InvalidData,
-  TimedOut: TimedOut,
-  Interrupted: Interrupted,
-  WriteZero: WriteZero,
-  UnexpectedEof: UnexpectedEof,
-  BadResource: BadResource,
-  Http: Http,
-  Busy: Busy,
+  NotFound,
+  PermissionDenied,
+  ConnectionRefused,
+  ConnectionReset,
+  ConnectionAborted,
+  NotConnected,
+  AddrInUse,
+  AddrNotAvailable,
+  BrokenPipe,
+  AlreadyExists,
+  InvalidData,
+  TimedOut,
+  Interrupted,
+  WriteZero,
+  UnexpectedEof,
+  BadResource,
+  Http,
+  Busy,
+  AssertionError,
+  NotImplemented,
 };

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1702,26 +1702,36 @@ declare namespace Deno {
   export function applySourceMap(location: Location): Location;
 
   /** A set of error constructors that are raised by Deno APIs. */
-  export const errors: {
-    NotFound: ErrorConstructor;
-    PermissionDenied: ErrorConstructor;
-    ConnectionRefused: ErrorConstructor;
-    ConnectionReset: ErrorConstructor;
-    ConnectionAborted: ErrorConstructor;
-    NotConnected: ErrorConstructor;
-    AddrInUse: ErrorConstructor;
-    AddrNotAvailable: ErrorConstructor;
-    BrokenPipe: ErrorConstructor;
-    AlreadyExists: ErrorConstructor;
-    InvalidData: ErrorConstructor;
-    TimedOut: ErrorConstructor;
-    Interrupted: ErrorConstructor;
-    WriteZero: ErrorConstructor;
-    UnexpectedEof: ErrorConstructor;
-    BadResource: ErrorConstructor;
-    Http: ErrorConstructor;
-    Busy: ErrorConstructor;
-  };
+  export namespace errors {
+    export const NotFound: ErrorConstructor;
+    export const PermissionDenied: ErrorConstructor;
+    export const ConnectionRefused: ErrorConstructor;
+    export const ConnectionReset: ErrorConstructor;
+    export const ConnectionAborted: ErrorConstructor;
+    export const NotConnected: ErrorConstructor;
+    export const AddrInUse: ErrorConstructor;
+    export const AddrNotAvailable: ErrorConstructor;
+    export const BrokenPipe: ErrorConstructor;
+    export const AlreadyExists: ErrorConstructor;
+    export const InvalidData: ErrorConstructor;
+    export const TimedOut: ErrorConstructor;
+    export const Interrupted: ErrorConstructor;
+    export const WriteZero: ErrorConstructor;
+    export const UnexpectedEof: ErrorConstructor;
+    export const BadResource: ErrorConstructor;
+    export const Http: ErrorConstructor;
+    export const Busy: ErrorConstructor;
+    /** An error raised when an internal API assertion fails.  Can also be used
+     * for raising other assertion failures. */
+    export class AssertionError extends Error {
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      constructor(message?: string, options?: { actual: any; expected: any });
+      readonly actual?: any;
+      readonly expected?: any;
+      /* eslint-enable */
+    }
+    export const NotImplemented: ErrorConstructor;
+  }
 
   /** **UNSTABLE**: potentially want names to overlap more with browser.
    *

--- a/cli/js/signals.ts
+++ b/cli/js/signals.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { bindSignal, pollSignal, unbindSignal } from "./ops/signal.ts";
 import { build } from "./build.ts";
+import { notImplemented } from "./util.ts";
 
 // From `kill -l`
 enum LinuxSignal {
@@ -84,7 +85,7 @@ export function setSignals(): void {
 
 export function signal(signo: number): SignalStream {
   if (build.os === "win") {
-    throw new Error("not implemented!");
+    notImplemented();
   }
   return new SignalStream(signo);
 }

--- a/cli/js/tests/assertion_error_test.ts
+++ b/cli/js/tests/assertion_error_test.ts
@@ -1,0 +1,26 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { unitTest, assert, assertEquals } from "./test_util.ts";
+
+unitTest(function canCreateAssertionError() {
+  const as = new Deno.errors.AssertionError();
+  assertEquals(as.message, "");
+  assertEquals(as.actual, undefined);
+  assertEquals(as.expected, undefined);
+});
+
+unitTest(function canPassActualExpected() {
+  const as = new Deno.errors.AssertionError("test", {
+    actual: "foo",
+    expected: "bar",
+  });
+  assertEquals(as.message, "test");
+  assertEquals(as.actual, "foo");
+  assertEquals(as.expected, "bar");
+});
+
+unitTest(function assertionInstanceOf() {
+  const as = new Deno.errors.AssertionError();
+  assert(as instanceof Deno.errors.AssertionError);
+  assert(as instanceof Error);
+});

--- a/cli/js/tests/remove_test.ts
+++ b/cli/js/tests/remove_test.ts
@@ -91,7 +91,10 @@ unitTest(
       errOnWindows = err;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "not implemented");
+      assertEquals(
+        errOnWindows.message,
+        "This capability is currently not implemented in Deno."
+      );
     } else {
       const pathInfo = Deno.lstatSync(danglingSymlinkPath);
       assert(pathInfo.isSymlink);
@@ -124,7 +127,10 @@ unitTest(
       errOnWindows = err;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "not implemented");
+      assertEquals(
+        errOnWindows.message,
+        "This capability is currently not implemented in Deno."
+      );
     } else {
       const symlinkPathInfo = Deno.statSync(validSymlinkPath);
       assert(symlinkPathInfo.isFile);
@@ -327,7 +333,10 @@ unitTest(
       errOnWindows = e;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "not implemented");
+      assertEquals(
+        errOnWindows.message,
+        "This capability is currently not implemented in Deno."
+      );
     } else {
       const pathInfo = Deno.lstatSync(danglingSymlinkPath);
       assert(pathInfo.isSymlink);
@@ -360,7 +369,10 @@ unitTest(
       errOnWindows = e;
     }
     if (Deno.build.os === "win") {
-      assertEquals(errOnWindows.message, "not implemented");
+      assertEquals(
+        errOnWindows.message,
+        "This capability is currently not implemented in Deno."
+      );
     } else {
       const symlinkPathInfo = Deno.statSync(validSymlinkPath);
       assert(symlinkPathInfo.isFile);

--- a/cli/js/tests/remove_test.ts
+++ b/cli/js/tests/remove_test.ts
@@ -91,10 +91,7 @@ unitTest(
       errOnWindows = err;
     }
     if (Deno.build.os === "win") {
-      assertEquals(
-        errOnWindows.message,
-        "This capability is currently not implemented in Deno."
-      );
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const pathInfo = Deno.lstatSync(danglingSymlinkPath);
       assert(pathInfo.isSymlink);
@@ -127,10 +124,7 @@ unitTest(
       errOnWindows = err;
     }
     if (Deno.build.os === "win") {
-      assertEquals(
-        errOnWindows.message,
-        "This capability is currently not implemented in Deno."
-      );
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const symlinkPathInfo = Deno.statSync(validSymlinkPath);
       assert(symlinkPathInfo.isFile);
@@ -333,10 +327,7 @@ unitTest(
       errOnWindows = e;
     }
     if (Deno.build.os === "win") {
-      assertEquals(
-        errOnWindows.message,
-        "This capability is currently not implemented in Deno."
-      );
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const pathInfo = Deno.lstatSync(danglingSymlinkPath);
       assert(pathInfo.isSymlink);
@@ -369,10 +360,7 @@ unitTest(
       errOnWindows = e;
     }
     if (Deno.build.os === "win") {
-      assertEquals(
-        errOnWindows.message,
-        "This capability is currently not implemented in Deno."
-      );
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const symlinkPathInfo = Deno.statSync(validSymlinkPath);
       assert(symlinkPathInfo.isFile);

--- a/cli/js/tests/signal_test.ts
+++ b/cli/js/tests/signal_test.ts
@@ -20,85 +20,85 @@ unitTest(
       () => {
         Deno.signal(1);
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
     assertThrows(
       () => {
         Deno.signals.alarm(); // for SIGALRM
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
     assertThrows(
       () => {
         Deno.signals.child(); // for SIGCHLD
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
     assertThrows(
       () => {
         Deno.signals.hungup(); // for SIGHUP
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
     assertThrows(
       () => {
         Deno.signals.interrupt(); // for SIGINT
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
     assertThrows(
       () => {
         Deno.signals.io(); // for SIGIO
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
     assertThrows(
       () => {
         Deno.signals.pipe(); // for SIGPIPE
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
     assertThrows(
       () => {
         Deno.signals.quit(); // for SIGQUIT
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
     assertThrows(
       () => {
         Deno.signals.terminate(); // for SIGTERM
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
     assertThrows(
       () => {
         Deno.signals.userDefined1(); // for SIGUSR1
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
     assertThrows(
       () => {
         Deno.signals.userDefined2(); // for SIGURS2
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
     assertThrows(
       () => {
         Deno.signals.windowChange(); // for SIGWINCH
       },
-      Error,
-      "not implemented"
+      Deno.errors.NotImplemented,
+      "This capability is currently not implemented in Deno."
     );
   }
 );

--- a/cli/js/tests/symlink_test.ts
+++ b/cli/js/tests/symlink_test.ts
@@ -17,7 +17,10 @@ unitTest(
     }
     if (errOnWindows) {
       assertEquals(Deno.build.os, "win");
-      assertEquals(errOnWindows.message, "not implemented");
+      assertEquals(
+        errOnWindows.message,
+        "This capability is currently not implemented in Deno."
+      );
     } else {
       const newNameInfoLStat = Deno.lstatSync(newname);
       const newNameInfoStat = Deno.statSync(newname);
@@ -78,7 +81,10 @@ unitTest(
       errOnWindows = e;
     }
     if (errOnWindows) {
-      assertEquals(errOnWindows.message, "not implemented");
+      assertEquals(
+        errOnWindows.message,
+        "This capability is currently not implemented in Deno."
+      );
     } else {
       const newNameInfoLStat = Deno.lstatSync(newname);
       const newNameInfoStat = Deno.statSync(newname);

--- a/cli/js/tests/symlink_test.ts
+++ b/cli/js/tests/symlink_test.ts
@@ -55,7 +55,10 @@ unitTest(
     if (err) {
       assertEquals(Deno.build.os, "win");
       // from cli/js/util.ts:notImplemented
-      assertEquals(err.message, "not implemented");
+      assertEquals(
+        err.message,
+        "This capability is currently not implemented in Deno."
+      );
     }
   }
 );

--- a/cli/js/tests/symlink_test.ts
+++ b/cli/js/tests/symlink_test.ts
@@ -17,10 +17,7 @@ unitTest(
     }
     if (errOnWindows) {
       assertEquals(Deno.build.os, "win");
-      assertEquals(
-        errOnWindows.message,
-        "This capability is currently not implemented in Deno."
-      );
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const newNameInfoLStat = Deno.lstatSync(newname);
       const newNameInfoStat = Deno.statSync(newname);
@@ -81,10 +78,7 @@ unitTest(
       errOnWindows = e;
     }
     if (errOnWindows) {
-      assertEquals(
-        errOnWindows.message,
-        "This capability is currently not implemented in Deno."
-      );
+      assertEquals(errOnWindows.message, "not implemented");
     } else {
       const newNameInfoLStat = Deno.lstatSync(newname);
       const newNameInfoStat = Deno.statSync(newname);

--- a/cli/js/tests/unit_tests.ts
+++ b/cli/js/tests/unit_tests.ts
@@ -5,6 +5,7 @@
 // Test runner automatically spawns subprocesses for each required permissions combination.
 
 import "./abort_controller_test.ts";
+import "./assertion_error_test.ts";
 import "./blob_test.ts";
 import "./body_test.ts";
 import "./buffer_test.ts";

--- a/cli/js/util.ts
+++ b/cli/js/util.ts
@@ -1,5 +1,9 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+import { errors } from "./errors.ts";
+
+const { AssertionError, NotImplemented } = errors;
+
 let logDebug = false;
 let logSource = "JS";
 
@@ -20,9 +24,12 @@ export function log(...args: unknown[]): void {
 }
 
 // @internal
-export function assert(cond: unknown, msg = "assert"): asserts cond {
+export function assert(
+  cond: unknown,
+  msg = "The assertion failed."
+): asserts cond {
   if (!cond) {
-    throw Error(msg);
+    throw new AssertionError(msg);
   }
 }
 
@@ -52,8 +59,10 @@ export function createResolvable<T>(): Resolvable<T> {
 }
 
 // @internal
-export function notImplemented(): never {
-  throw new Error("not implemented");
+export function notImplemented(
+  msg = "This capability is currently not implemented in Deno."
+): never {
+  throw new NotImplemented(msg);
 }
 
 // @internal

--- a/std/fs/ensure_symlink_test.ts
+++ b/std/fs/ensure_symlink_test.ts
@@ -10,6 +10,7 @@ import { ensureSymlink, ensureSymlinkSync } from "./ensure_symlink.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
 const isWindows = Deno.build.os === "win";
+const { NotImplemented } = Deno.errors;
 
 Deno.test(async function ensureSymlinkIfItNotExist(): Promise<void> {
   const testDir = path.join(testdataDir, "link_file_1");
@@ -114,7 +115,7 @@ Deno.test(async function ensureSymlinkDirectoryIfItExist(): Promise<void> {
   if (isWindows) {
     await assertThrowsAsync(
       (): Promise<void> => ensureSymlink(testDir, linkDir),
-      Error,
+      NotImplemented,
       "not implemented"
     );
     await Deno.remove(testDir, { recursive: true });

--- a/std/fs/ensure_symlink_test.ts
+++ b/std/fs/ensure_symlink_test.ts
@@ -56,7 +56,7 @@ Deno.test(async function ensureSymlinkIfItExist(): Promise<void> {
   if (isWindows) {
     await assertThrowsAsync(
       (): Promise<void> => ensureSymlink(testFile, linkFile),
-      Error,
+      NotImplemented,
       "not implemented"
     );
     await Deno.remove(testDir, { recursive: true });
@@ -85,7 +85,7 @@ Deno.test(function ensureSymlinkSyncIfItExist(): void {
   if (isWindows) {
     assertThrows(
       (): void => ensureSymlinkSync(testFile, linkFile),
-      Error,
+      NotImplemented,
       "not implemented"
     );
     Deno.removeSync(testDir, { recursive: true });
@@ -147,7 +147,7 @@ Deno.test(function ensureSymlinkSyncDirectoryIfItExist(): void {
   if (isWindows) {
     assertThrows(
       (): void => ensureSymlinkSync(testDir, linkDir),
-      Error,
+      NotImplemented,
       "not implemented"
     );
     Deno.removeSync(testDir, { recursive: true });

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -9,12 +9,7 @@ interface Constructor {
   new (...args: any[]): any;
 }
 
-export class AssertionError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "AssertionError";
-  }
-}
+export const { AssertionError } = Deno.errors;
 
 function format(v: unknown): string {
   let string = Deno.inspect(v);


### PR DESCRIPTION
I've run into scenarios where in internal code trying to implement standards, where I need to disambiguate between an expected runtime error and an internal assertion error failing.  While `std/testing` `assert()` throws an `AssertionError`, internal Deno `assert()` throws just a plain error.

To fix this I have introduced `Deno.errors.AssertionError` which also improves over the `std/testing` AssertionError by providing `actual` and `expected` properties, which can be used in the future to create better diff output.  This is a common pattern of other AssertionErrors available in the world today. (Also re-exported `Deno.errors.AssertionError` from the std module as well)

I also took the opportunity to ensure that `notImplemented()` throws an `Deno.errors.NotImplemented` instead of a plain error and improve the UX of the error message, as well as clean up a couple places where we were not using the internal helper when functionality wasn't implemented.