### PR TITLE
fix(console): don't throw RangeError when an invalid date is passed

### DIFF
--- a/cli/js/tests/console_test.ts
+++ b/cli/js/tests/console_test.ts
@@ -1067,6 +1067,15 @@ unitTest(function consoleLogShouldNotThrowError(): void {
   });
 });
 
+// console.log(Invalid Date) test
+unitTest(function consoleLogShoultNotThrowErrorWhenInvalidDateIsPassed(): void {
+  mockConsole((console, out) => {
+    const invalidDate = new Date("test");
+    console.log(invalidDate);
+    assertEquals(out.toString(), "Invalid Date\n");
+  });
+});
+
 // console.dir test
 unitTest(function consoleDir(): void {
   mockConsole((console, out): void => {

--- a/cli/js/web/console.ts
+++ b/cli/js/web/console.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { isTypedArray, TypedArray } from "./util.ts";
+import { isInvalidDate, isTypedArray, TypedArray } from "./util.ts";
 import { cliTable } from "./console_table.ts";
 import { exposeForTest } from "../internals.ts";
 import { PromiseState } from "./promise.ts";
@@ -409,8 +409,7 @@ function createWeakMapString(): string {
 }
 
 function createDateString(value: Date): string {
-  // without quotes, ISO format
-  return value.toISOString();
+  return isInvalidDate(value) ? "Invalid Date" : value.toISOString(); // without quotes, ISO format
 }
 
 function createRegExpString(value: RegExp): string {

--- a/cli/js/web/util.ts
+++ b/cli/js/web/util.ts
@@ -19,6 +19,11 @@ export function isTypedArray(x: unknown): x is TypedArray {
 }
 
 // @internal
+export function isInvalidDate(x: Date): boolean {
+  return isNaN(x.getTime());
+}
+
+// @internal
 export function requiredArguments(
   name: string,
   length: number,


### PR DESCRIPTION
- This PR resolves #4928.