### PR TITLE
Mark Deno.umask unstable

### DIFF
--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -208,10 +208,11 @@ struct UmaskArgs {
 }
 
 fn op_umask(
-  _state: &State,
+  state: &State,
   args: Value,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
+  state.check_unstable("Deno.umask");
   let args: UmaskArgs = serde_json::from_value(args)?;
   // TODO implement umask for Windows
   // see https://github.com/nodejs/node/blob/master/src/node_process_methods.cc


### PR DESCRIPTION
Update op state to mark `Deno.umask` unstable, as per #4933.
