### PR TITLE
Remove Deno.symbols namespace 2

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -12,7 +12,7 @@ export { build, OperatingSystem, Arch } from "./build.ts";
 export { chmodSync, chmod } from "./ops/fs/chmod.ts";
 export { chownSync, chown } from "./ops/fs/chown.ts";
 export { transpileOnly, compile, bundle } from "./compiler/api.ts";
-export { inspect } from "./web/console.ts";
+export { customInspect, inspect } from "./web/console.ts";
 export { copyFileSync, copyFile } from "./ops/fs/copy_file.ts";
 export {
   Diagnostic,
@@ -38,6 +38,7 @@ export {
 } from "./files.ts";
 export { read, readSync, write, writeSync } from "./ops/io.ts";
 export { FsEvent, watchFs } from "./ops/fs_events.ts";
+export { internalSymbol as internal } from "./internals.ts";
 export {
   EOF,
   copy,
@@ -123,5 +124,3 @@ export { core } from "./core.ts";
 export let pid: number;
 
 export let noColor: boolean;
-
-export { symbols } from "./symbols.ts";

--- a/cli/js/internals.ts
+++ b/cli/js/internals.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-export const internalSymbol = Symbol("Deno.symbols.internal");
+export const internalSymbol = Symbol("Deno.internal");
 
 // The object where all the internal fields for testing will be living.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cli/js/internals.ts
+++ b/cli/js/internals.ts
@@ -6,7 +6,7 @@ export const internalSymbol = Symbol("Deno.symbols.internal");
 export const internalObject: { [key: string]: any } = {};
 
 // Register a field to internalObject for test access,
-// through Deno[Deno.symbols.internal][name].
+// through Deno[Deno.internal][name].
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function exposeForTest(name: string, value: any): void {
   Object.defineProperty(internalObject, name, {

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -368,7 +368,6 @@ declare namespace Deno {
    */
   export function umask(mask?: number): number;
 
-  /** **UNSTABLE**: will be removed in favor of `null` (#3932). */
   export const EOF: unique symbol;
   export type EOF = typeof EOF;
 

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -368,6 +368,7 @@ declare namespace Deno {
    */
   export function umask(mask?: number): number;
 
+  /** **UNSTABLE**: might be removed in favor of `null` (#3932). */
   export const EOF: unique symbol;
   export type EOF = typeof EOF;
 

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -2849,14 +2849,7 @@ declare namespace Deno {
     windowChange: () => SignalStream;
   };
 
-  /** **UNSTABLE**: recently moved out of the `Deno.symbols` namespace.
-   *
-   * Symbol to access exposed internal Deno API */
-  export const internal: unique symbol;
-
-  /** **UNSTABLE**: recently moved out of the `Deno.symbols` namespace.
-   *
-   * A symbol which can be used as a key for a custom method which will be
+  /** A symbol which can be used as a key for a custom method which will be
    * called when `Deno.inspect()` is called, or when the object is logged to
    * the console. */
   export const customInspect: unique symbol;

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -368,7 +368,7 @@ declare namespace Deno {
    */
   export function umask(mask?: number): number;
 
-  /** **UNSTABLE**: might move to `Deno.symbols`. */
+  /** **UNSTABLE**: will be removed in favor of `null` (#3932). */
   export const EOF: unique symbol;
   export type EOF = typeof EOF;
 
@@ -2327,7 +2327,7 @@ declare namespace Deno {
    *      class A {
    *        x = 10;
    *        y = "hello";
-   *        [Deno.symbols.customInspect](): string {
+   *        [Deno.customInspect](): string {
    *          return "x=" + this.x + ", y=" + this.y;
    *        }
    *      }
@@ -2849,16 +2849,15 @@ declare namespace Deno {
     windowChange: () => SignalStream;
   };
 
-  /** **UNSTABLE**: new API. Maybe move `Deno.EOF` here.
+  /** **UNSTABLE**: recently moved out of the `Deno.symbols` namespace.
    *
-   * Special Deno related symbols. */
-  export const symbols: {
-    /** Symbol to access exposed internal Deno API */
-    readonly internal: unique symbol;
-    /** A symbol which can be used as a key for a custom method which will be
-     * called when `Deno.inspect()` is called, or when the object is logged to
-     * the console. */
-    readonly customInspect: unique symbol;
-    // TODO(ry) move EOF here?
-  };
+   * Symbol to access exposed internal Deno API */
+  export const internal: unique symbol;
+
+  /** **UNSTABLE**: recently moved out of the `Deno.symbols` namespace.
+   *
+   * A symbol which can be used as a key for a custom method which will be
+   * called when `Deno.inspect()` is called, or when the object is logged to
+   * the console. */
+  export const customInspect: unique symbol;
 }

--- a/cli/js/runtime_main.ts
+++ b/cli/js/runtime_main.ts
@@ -19,20 +19,19 @@ import {
   eventTargetProperties,
   setEventTargetData,
 } from "./globals.ts";
-import { internalObject } from "./internals.ts";
+import { internalObject, internalSymbol } from "./internals.ts";
 import { setSignals } from "./signals.ts";
 import { replLoop } from "./repl.ts";
 import { LocationImpl } from "./web/location.ts";
 import { setTimeout } from "./web/timers.ts";
 import * as runtime from "./runtime.ts";
-import { symbols } from "./symbols.ts";
 import { log, immutableDefine } from "./util.ts";
 
 // TODO: factor out `Deno` global assignment to separate function
 // Add internal object to Deno object.
 // This is not exposed as part of the Deno types.
 // @ts-ignore
-Deno[symbols.internal] = internalObject;
+Deno[internalSymbol] = internalObject;
 
 let windowIsClosing = false;
 

--- a/cli/js/runtime_worker.ts
+++ b/cli/js/runtime_worker.ts
@@ -24,8 +24,7 @@ import { log, assert, immutableDefine } from "./util.ts";
 import { MessageEvent, ErrorEvent } from "./web/workers.ts";
 import { TextEncoder } from "./web/text_encoding.ts";
 import * as runtime from "./runtime.ts";
-import { internalObject } from "./internals.ts";
-import { symbols } from "./symbols.ts";
+import { internalObject, internalSymbol } from "./internals.ts";
 import { setSignals } from "./signals.ts";
 
 // FIXME(bartlomieju): duplicated in `runtime_main.ts`
@@ -33,7 +32,7 @@ import { setSignals } from "./signals.ts";
 // Add internal object to Deno object.
 // This is not exposed as part of the Deno types.
 // @ts-ignore
-Deno[symbols.internal] = internalObject;
+Deno[internalSymbol] = internalObject;
 
 const encoder = new TextEncoder();
 

--- a/cli/js/symbols.ts
+++ b/cli/js/symbols.ts
@@ -1,8 +1,0 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { internalSymbol } from "./internals.ts";
-import { customInspect } from "./web/console.ts";
-
-export const symbols = {
-  internal: internalSymbol,
-  customInspect,
-};

--- a/cli/js/tests/console_test.ts
+++ b/cli/js/tests/console_test.ts
@@ -8,12 +8,12 @@ const {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } = Deno as any;
 
-const customInspect = Deno.symbols.customInspect;
+const customInspect = Deno.customInspect;
 const {
   Console,
   stringifyArgs,
   // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
-} = Deno[Deno.symbols.internal];
+} = Deno[Deno.internal];
 
 function stringify(...args: unknown[]): string {
   return stringifyArgs(args).replace(/\n$/, "");

--- a/cli/js/tests/dom_iterable_test.ts
+++ b/cli/js/tests/dom_iterable_test.ts
@@ -21,7 +21,7 @@ function setup() {
     // This is using an internal API we don't want published as types, so having
     // to cast to any to "trick" TypeScript
     // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
-    DomIterable: Deno[Deno.symbols.internal].DomIterableMixin(Base, dataSymbol),
+    DomIterable: Deno[Deno.internal].DomIterableMixin(Base, dataSymbol),
   };
 }
 

--- a/cli/js/tests/error_stack_test.ts
+++ b/cli/js/tests/error_stack_test.ts
@@ -2,7 +2,7 @@
 import { unitTest, assert } from "./test_util.ts";
 
 // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
-const { setPrepareStackTrace } = Deno[Deno.symbols.internal];
+const { setPrepareStackTrace } = Deno[Deno.internal];
 
 interface CallSite {
   getThis(): unknown;

--- a/cli/js/tests/headers_test.ts
+++ b/cli/js/tests/headers_test.ts
@@ -8,7 +8,7 @@ import {
 const {
   stringifyArgs,
   // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
-} = Deno[Deno.symbols.internal];
+} = Deno[Deno.internal];
 
 // Logic heavily copied from web-platform-tests, make
 // sure pass mostly header basic test

--- a/cli/js/tests/internals_test.ts
+++ b/cli/js/tests/internals_test.ts
@@ -5,6 +5,6 @@ unitTest(function internalsExists(): void {
   const {
     stringifyArgs,
     // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
-  } = Deno[Deno.symbols.internal];
+  } = Deno[Deno.internal];
   assert(!!stringifyArgs);
 });

--- a/cli/js/tests/symbols_test.ts
+++ b/cli/js/tests/symbols_test.ts
@@ -1,7 +1,0 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert } from "./test_util.ts";
-
-unitTest(function symbolsExists(): void {
-  assert("internal" in Deno.symbols);
-  assert("customInspect" in Deno.symbols);
-});

--- a/cli/js/tests/unit_test_runner.ts
+++ b/cli/js/tests/unit_test_runner.ts
@@ -11,8 +11,8 @@ import {
   reportToConn,
 } from "./test_util.ts";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const internalObj = (Deno as any)[Deno.symbols.internal];
+// @ts-ignore
+const internalObj = Deno[Deno.internal];
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const reportToConsole = internalObj.reportToConsole as (message: any) => void;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cli/js/tests/unit_tests.ts
+++ b/cli/js/tests/unit_tests.ts
@@ -52,7 +52,6 @@ import "./request_test.ts";
 import "./resources_test.ts";
 import "./signal_test.ts";
 import "./stat_test.ts";
-import "./symbols_test.ts";
 import "./symlink_test.ts";
 import "./text_encoding_test.ts";
 import "./testing_test.ts";

--- a/cli/js/web/streams/readable_byte_stream_controller.ts
+++ b/cli/js/web/streams/readable_byte_stream_controller.ts
@@ -22,7 +22,7 @@ import {
 import { ReadableStreamImpl } from "./readable_stream.ts";
 import * as sym from "./symbols.ts";
 import { assert } from "../../util.ts";
-import { symbols } from "../../symbols.ts";
+import { customInspect } from "../../web/console.ts";
 
 export class ReadableByteStreamControllerImpl
   implements ReadableByteStreamController {
@@ -135,7 +135,7 @@ export class ReadableByteStreamControllerImpl
     return promise;
   }
 
-  [symbols.customInspect](): string {
+  [customInspect](): string {
     return `ReadableByteStreamController { byobRequest: ${String(
       this.byobRequest
     )}, desiredSize: ${String(this.desiredSize)} }`;

--- a/cli/js/web/streams/readable_stream.ts
+++ b/cli/js/web/streams/readable_stream.ts
@@ -18,8 +18,8 @@ import { ReadableByteStreamControllerImpl } from "./readable_byte_stream_control
 import { ReadableStreamAsyncIteratorPrototype } from "./readable_stream_async_iterator.ts";
 import { ReadableStreamDefaultControllerImpl } from "./readable_stream_default_controller.ts";
 import * as sym from "./symbols.ts";
-import { symbols } from "../../symbols.ts";
 import { notImplemented } from "../../util.ts";
+import { customInspect } from "../../web/console.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class ReadableStreamImpl<R = any> implements ReadableStream<R> {
@@ -202,7 +202,7 @@ export class ReadableStreamImpl<R = any> implements ReadableStream<R> {
     return readableStreamTee(this, false);
   }
 
-  [symbols.customInspect](): string {
+  [customInspect](): string {
     return `ReadableStream { locked: ${String(this.locked)} }`;
   }
 

--- a/cli/js/web/streams/readable_stream_default_controller.ts
+++ b/cli/js/web/streams/readable_stream_default_controller.ts
@@ -21,7 +21,7 @@ import {
 } from "./internals.ts";
 import { ReadableStreamImpl } from "./readable_stream.ts";
 import * as sym from "./symbols.ts";
-import { symbols } from "../../symbols.ts";
+import { customInspect } from "../../web/console.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class ReadableStreamDefaultControllerImpl<R = any>
@@ -112,7 +112,7 @@ export class ReadableStreamDefaultControllerImpl<R = any>
     return pendingPromise;
   }
 
-  [symbols.customInspect](): string {
+  [customInspect](): string {
     return `ReadableStreamDefaultController { desiredSize: ${String(
       this.desiredSize
     )} }`;

--- a/cli/js/web/streams/readable_stream_default_reader.ts
+++ b/cli/js/web/streams/readable_stream_default_reader.ts
@@ -12,7 +12,7 @@ import {
 } from "./internals.ts";
 import { ReadableStreamImpl } from "./readable_stream.ts";
 import * as sym from "./symbols.ts";
-import { symbols } from "../../symbols.ts";
+import { customInspect } from "../../web/console.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class ReadableStreamDefaultReaderImpl<R = any>
@@ -83,7 +83,7 @@ export class ReadableStreamDefaultReaderImpl<R = any>
     readableStreamReaderGenericRelease(this);
   }
 
-  [symbols.customInspect](): string {
+  [customInspect](): string {
     return `ReadableStreamDefaultReader { closed: Promise }`;
   }
 }

--- a/cli/test_runner.rs
+++ b/cli/test_runner.rs
@@ -79,7 +79,7 @@ pub fn render_test_file(
   };
 
   let run_tests_cmd = format!(
-    "(Deno as any)[Deno.symbols.internal].runTests({});\n",
+    "// @ts-ignore\nDeno[Deno.symbols.internal].runTests({});\n",
     options
   );
   test_file.push_str(&run_tests_cmd);

--- a/cli/test_runner.rs
+++ b/cli/test_runner.rs
@@ -79,7 +79,7 @@ pub fn render_test_file(
   };
 
   let run_tests_cmd = format!(
-    "// @ts-ignore\nDeno[Deno.symbols.internal].runTests({});\n",
+    "// @ts-ignore\nDeno[Deno.internal].runTests({});\n",
     options
   );
   test_file.push_str(&run_tests_cmd);


### PR DESCRIPTION
- Move `Deno.symbols.customInspect` to `Deno.customInspect`.
- Move `Deno.symbols.internal` to `Deno.internal`.
- Remove `Deno.internal` from the runtime type library.

Closes #4870 (please read through), part of #4933.