### PR TITLE
docs: document default value of sanitizeOps and sanitizeResources

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -17,7 +17,7 @@ declare namespace Deno {
     name: string;
     ignore?: boolean;
     /** Check that the number of async completed ops after the test is the same
-     * as number of dispatched ops. Defaults to false.*/
+     * as number of dispatched ops. Defaults to true.*/
     sanitizeOps?: boolean;
     /** Ensure the test case does not "leak" resources - ie. the resource table
      * after the test has exactly the same contents as before the test. Defaults

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -16,7 +16,12 @@ declare namespace Deno {
     fn: () => void | Promise<void>;
     name: string;
     ignore?: boolean;
+    /** Check that the number of async completed ops after the test is the same
+     * as number of dispatched ops. Defaults to false.*/
     sanitizeOps?: boolean;
+    /** Ensure the test case does not "leak" resources - ie. the resource table
+     * after the test has exactly the same contents as before the test. Defaults
+     * to true. */
     sanitizeResources?: boolean;
   }
 

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -104,7 +104,7 @@ export function test(
   let testDef: TestDefinition;
   const defaults = {
     ignore: false,
-    sanitizeOps: true,
+    sanitizeOps: false,
     sanitizeResources: true,
   };
 

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -104,7 +104,7 @@ export function test(
   let testDef: TestDefinition;
   const defaults = {
     ignore: false,
-    sanitizeOps: false,
+    sanitizeOps: true,
     sanitizeResources: true,
   };
 


### PR DESCRIPTION
Contribution towards #4933, `"update d.ts for "sanitizeOps" // Defaults to false"`.  Note, review comments have highlighted that `"Defaults to false"` should really be `"Defaults to true"`, making this a documentation update only change with no functional changes.