### PR TITLE
remove combined io interface like ReadCloser

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -50,13 +50,6 @@ export {
   SyncWriter,
   Closer,
   Seeker,
-  SyncSeeker,
-  ReadCloser,
-  WriteCloser,
-  ReadSeeker,
-  WriteSeeker,
-  ReadWriteCloser,
-  ReadWriteSeeker,
 } from "./io.ts";
 export { linkSync, link } from "./ops/fs/link.ts";
 export {

--- a/cli/js/io.ts
+++ b/cli/js/io.ts
@@ -52,24 +52,6 @@ export interface SyncSeeker {
   seekSync(offset: number, whence: SeekMode): number;
 }
 
-// https://golang.org/pkg/io/#ReadCloser
-export interface ReadCloser extends Reader, Closer {}
-
-// https://golang.org/pkg/io/#WriteCloser
-export interface WriteCloser extends Writer, Closer {}
-
-// https://golang.org/pkg/io/#ReadSeeker
-export interface ReadSeeker extends Reader, Seeker {}
-
-// https://golang.org/pkg/io/#WriteSeeker
-export interface WriteSeeker extends Writer, Seeker {}
-
-// https://golang.org/pkg/io/#ReadWriteCloser
-export interface ReadWriteCloser extends Reader, Writer, Closer {}
-
-// https://golang.org/pkg/io/#ReadWriteSeeker
-export interface ReadWriteSeeker extends Reader, Writer, Seeker {}
-
 export async function copy(
   src: Reader,
   dst: Writer,

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -491,13 +491,6 @@ declare namespace Deno {
     seekSync(offset: number, whence: SeekMode): number;
   }
 
-  export interface ReadCloser extends Reader, Closer {}
-  export interface WriteCloser extends Writer, Closer {}
-  export interface ReadSeeker extends Reader, Seeker {}
-  export interface WriteSeeker extends Writer, Seeker {}
-  export interface ReadWriteCloser extends Reader, Writer, Closer {}
-  export interface ReadWriteSeeker extends Reader, Writer, Seeker {}
-
   /** Copies from `src` to `dst` until either `EOF` is reached on `src` or an
    * error occurs. It resolves to the number of bytes copied or rejects with
    * the first error encountered while copying.
@@ -2166,9 +2159,9 @@ declare namespace Deno {
   export class Process {
     readonly rid: number;
     readonly pid: number;
-    readonly stdin?: WriteCloser;
-    readonly stdout?: ReadCloser;
-    readonly stderr?: ReadCloser;
+    readonly stdin?: Writer & Closer;
+    readonly stdout?: Reader & Closer;
+    readonly stderr?: Reader & Closer;
     /** Resolves to the current status of the process. */
     status(): Promise<ProcessStatus>;
     /** Buffer the stdout and return it as `Uint8Array` after `Deno.EOF`.

--- a/cli/js/process.ts
+++ b/cli/js/process.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { File } from "./files.ts";
 import { close } from "./ops/resources.ts";
-import { ReadCloser, WriteCloser } from "./io.ts";
+import { Closer, Reader, Writer } from "./io.ts";
 import { readAll } from "./buffer.ts";
 import { kill, runStatus as runStatusOp, run as runOp } from "./ops/process.ts";
 
@@ -33,9 +33,9 @@ async function runStatus(rid: number): Promise<ProcessStatus> {
 export class Process {
   readonly rid: number;
   readonly pid: number;
-  readonly stdin?: WriteCloser;
-  readonly stdout?: ReadCloser;
-  readonly stderr?: ReadCloser;
+  readonly stdin?: Writer & Closer;
+  readonly stdout?: Reader & Closer;
+  readonly stderr?: Reader & Closer;
 
   // @internal
   constructor(res: RunResponse) {

--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -28,7 +28,8 @@ function hasHeaderValueOf(s: string, value: string): boolean {
   return new RegExp(`^${value}[\t\s]*;?`).test(s);
 }
 
-class Body implements domTypes.Body, ReadableStream<Uint8Array>, io.ReadCloser {
+class Body
+  implements domTypes.Body, ReadableStream<Uint8Array>, io.Reader, io.Closer {
   #bodyUsed = false;
   #bodyPromise: Promise<ArrayBuffer> | null = null;
   #data: ArrayBuffer | null = null;


### PR DESCRIPTION
This commit removes "combined" interfaces from cli/js/io.ts; in the
like of "ReadCloser", "WriteCloser" in favor of using intersections
of concrete interfaces.
