### PR TITLE
doc: remove unstable API marker form Deno.Metrics and Deno.RunOptions

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -2042,7 +2042,6 @@ declare namespace Deno {
     options?: StartTlsOptions
   ): Promise<Conn>;
 
-  /** **UNSTABLE**: not sure if broken or not */
   export interface Metrics {
     opsDispatched: number;
     opsDispatchedSync: number;
@@ -2193,8 +2192,6 @@ declare namespace Deno {
         signal?: number;
       };
 
-  /** **UNSTABLE**: `args` has been recently renamed to `cmd` to differentiate from
-   * `Deno.args`. */
   export interface RunOptions {
     /** Arguments to pass. Note, the first element needs to be a path to the
      * binary */


### PR DESCRIPTION
Contributions towards #4933:
* `Deno.Metrics should be made stable.`
* `RunOptions should be made stable`
