### PR TITLE
BREAKING: remove overload of Deno.test()

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -58,24 +58,6 @@ declare namespace Deno {
    *
    *        import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
    *
-   *        Deno.test(function myTestFunction():void {
-   *          assertEquals("hello", "hello");
-   *        });
-   *
-   *        Deno.test(async function myAsyncTestFunction():Promise<void> {
-   *          const decoder = new TextDecoder("utf-8");
-   *          const data = await Deno.readFile("hello_world.txt");
-   *          assertEquals(decoder.decode(data), "Hello world")
-   *        });
-   **/
-  export function test(fn: () => void | Promise<void>): void;
-
-  /** Register a test which will be run when `deno test` is used on the command
-   * line and the containing module looks like a test module.
-   * `fn` can be async if required.
-   *
-   *        import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
-   *
    *        Deno.test("My test description", ():void => {
    *          assertEquals("hello", "hello");
    *        });

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -93,12 +93,11 @@ export interface TestDefinition {
 const TEST_REGISTRY: TestDefinition[] = [];
 
 export function test(t: TestDefinition): void;
-export function test(fn: () => void | Promise<void>): void;
 export function test(name: string, fn: () => void | Promise<void>): void;
 // Main test function provided by Deno, as you can see it merely
 // creates a new object with "name" and "fn" fields.
 export function test(
-  t: string | TestDefinition | (() => void | Promise<void>),
+  t: string | TestDefinition,
   fn?: () => void | Promise<void>
 ): void {
   let testDef: TestDefinition;
@@ -116,11 +115,6 @@ export function test(
       throw new TypeError("The test name can't be empty");
     }
     testDef = { fn: fn as () => void | Promise<void>, name: t, ...defaults };
-  } else if (typeof t === "function") {
-    if (!t.name) {
-      throw new TypeError("The test function can't be anonymous");
-    }
-    testDef = { fn: t, name: t.name, ...defaults };
   } else {
     if (!t.fn) {
       throw new TypeError("Missing test function");

--- a/cli/js/tests/testing_test.ts
+++ b/cli/js/tests/testing_test.ts
@@ -25,13 +25,3 @@ unitTest(function nameOfTestCaseCantBeEmpty(): void {
     "The test name can't be empty"
   );
 });
-
-unitTest(function testFnCantBeAnonymous(): void {
-  assertThrows(
-    () => {
-      Deno.test(function () {});
-    },
-    TypeError,
-    "The test function can't be anonymous"
-  );
-});

--- a/cli/tests/057_revoke_permissions.ts
+++ b/cli/tests/057_revoke_permissions.ts
@@ -16,7 +16,7 @@ export function assert(cond: unknown): asserts cond {
   }
 }
 
-function genFunc(grant: Deno.PermissionName): () => Promise<void> {
+function genFunc(grant: Deno.PermissionName): [string, () => Promise<void>] {
   const gen: () => Promise<void> = async function Granted(): Promise<void> {
     const status0 = await Deno.permissions.query({ name: grant });
     assert(status0 != null);
@@ -26,11 +26,11 @@ function genFunc(grant: Deno.PermissionName): () => Promise<void> {
     assert(status1 != null);
     assert(status1.state === "prompt");
   };
-  // Properly name these generated functions.
-  Object.defineProperty(gen, "name", { value: grant + "Granted" });
-  return gen;
+  const name = grant + "Granted";
+  return [name, gen];
 }
 
 for (const grant of knownPermissions) {
-  Deno.test(genFunc(grant));
+  const [name, fn] = genFunc(grant);
+  Deno.test(name, fn);
 }

--- a/cli/tests/compiler_api_test.ts
+++ b/cli/tests/compiler_api_test.ts
@@ -3,7 +3,7 @@
 import { assert, assertEquals } from "../../std/testing/asserts.ts";
 const { compile, transpileOnly, bundle, test } = Deno;
 
-test(async function compilerApiCompileSources() {
+test("compilerApiCompileSources", async function () {
   const [diagnostics, actual] = await compile("/foo.ts", {
     "/foo.ts": `import * as bar from "./bar.ts";\n\nconsole.log(bar);\n`,
     "/bar.ts": `export const bar = "bar";\n`,
@@ -18,7 +18,7 @@ test(async function compilerApiCompileSources() {
   ]);
 });
 
-test(async function compilerApiCompileNoSources() {
+test("compilerApiCompileNoSources", async function () {
   const [diagnostics, actual] = await compile("./subdir/mod1.ts");
   assert(diagnostics == null);
   assert(actual);
@@ -28,7 +28,7 @@ test(async function compilerApiCompileNoSources() {
   assert(keys[1].endsWith("print_hello.js"));
 });
 
-test(async function compilerApiCompileOptions() {
+test("compilerApiCompileOptions", async function () {
   const [diagnostics, actual] = await compile(
     "/foo.ts",
     {
@@ -45,7 +45,7 @@ test(async function compilerApiCompileOptions() {
   assert(actual["/foo.js"].startsWith("define("));
 });
 
-test(async function compilerApiCompileLib() {
+test("compilerApiCompileLib", async function () {
   const [diagnostics, actual] = await compile(
     "/foo.ts",
     {
@@ -61,7 +61,7 @@ test(async function compilerApiCompileLib() {
   assertEquals(Object.keys(actual), ["/foo.js.map", "/foo.js"]);
 });
 
-test(async function compilerApiCompileTypes() {
+test("compilerApiCompileTypes", async function () {
   const [diagnostics, actual] = await compile(
     "/foo.ts",
     {
@@ -76,7 +76,7 @@ test(async function compilerApiCompileTypes() {
   assertEquals(Object.keys(actual), ["/foo.js.map", "/foo.js"]);
 });
 
-test(async function transpileOnlyApi() {
+test("transpileOnlyApi", async function () {
   const actual = await transpileOnly({
     "foo.ts": `export enum Foo { Foo, Bar, Baz };\n`,
   });
@@ -86,7 +86,7 @@ test(async function transpileOnlyApi() {
   assert(actual["foo.ts"].map);
 });
 
-test(async function transpileOnlyApiConfig() {
+test("transpileOnlyApiConfig", async function () {
   const actual = await transpileOnly(
     {
       "foo.ts": `export enum Foo { Foo, Bar, Baz };\n`,
@@ -102,7 +102,7 @@ test(async function transpileOnlyApiConfig() {
   assert(actual["foo.ts"].map == null);
 });
 
-test(async function bundleApiSources() {
+test("bundleApiSources", async function () {
   const [diagnostics, actual] = await bundle("/foo.ts", {
     "/foo.ts": `export * from "./bar.ts";\n`,
     "/bar.ts": `export const bar = "bar";\n`,
@@ -112,14 +112,14 @@ test(async function bundleApiSources() {
   assert(actual.includes(`__exp["bar"]`));
 });
 
-test(async function bundleApiNoSources() {
+test("bundleApiNoSources", async function () {
   const [diagnostics, actual] = await bundle("./subdir/mod1.ts");
   assert(diagnostics == null);
   assert(actual.includes(`__instantiate("mod1")`));
   assert(actual.includes(`__exp["printHello3"]`));
 });
 
-test(async function bundleApiConfig() {
+test("bundleApiConfig", async function () {
   const [diagnostics, actual] = await bundle(
     "/foo.ts",
     {
@@ -134,7 +134,7 @@ test(async function bundleApiConfig() {
   assert(!actual.includes(`random`));
 });
 
-test(async function bundleApiJsModules() {
+test("bundleApiJsModules", async function () {
   const [diagnostics, actual] = await bundle("/foo.js", {
     "/foo.js": `export * from "./bar.js";\n`,
     "/bar.js": `export const bar = "bar";\n`,
@@ -143,7 +143,7 @@ test(async function bundleApiJsModules() {
   assert(actual.includes(`System.register("bar",`));
 });
 
-test(async function diagnosticsTest() {
+test("diagnosticsTest", async function () {
   const [diagnostics] = await compile("/foo.ts", {
     "/foo.ts": `document.getElementById("foo");`,
   });

--- a/cli/tests/test_runner_test.ts
+++ b/cli/tests/test_runner_test.ts
@@ -2,18 +2,18 @@
 
 import { assert } from "../../std/testing/asserts.ts";
 
-Deno.test(function fail1() {
+Deno.test("fail1", function () {
   assert(false, "fail1 assertion");
 });
 
-Deno.test(function fail2() {
+Deno.test("fail2", function () {
   assert(false, "fail2 assertion");
 });
 
-Deno.test(function success1() {
+Deno.test("success1", function () {
   assert(true);
 });
 
-Deno.test(function fail3() {
+Deno.test("fail3", function () {
   assert(false, "fail3 assertion");
 });

--- a/std/archive/tar_test.ts
+++ b/std/archive/tar_test.ts
@@ -15,7 +15,7 @@ import { Tar, Untar } from "./tar.ts";
 
 const filePath = resolve("archive", "testdata", "example.txt");
 
-Deno.test(async function createTarArchive(): Promise<void> {
+Deno.test("createTarArchive", async function (): Promise<void> {
   // initialize
   const tar = new Tar();
 
@@ -40,7 +40,7 @@ Deno.test(async function createTarArchive(): Promise<void> {
   assertEquals(wrote, 3072);
 });
 
-Deno.test(async function deflateTarArchive(): Promise<void> {
+Deno.test("deflateTarArchive", async function (): Promise<void> {
   const fileName = "output.txt";
   const text = "hello tar world!";
 
@@ -63,7 +63,9 @@ Deno.test(async function deflateTarArchive(): Promise<void> {
   assertEquals(untarText, text);
 });
 
-Deno.test(async function appendFileWithLongNameToTarArchive(): Promise<void> {
+Deno.test("appendFileWithLongNameToTarArchive", async function (): Promise<
+  void
+> {
   // 9 * 15 + 13 = 148 bytes
   const fileName = new Array(10).join("long-file-name/") + "file-name.txt";
   const text = "hello tar world!";

--- a/std/datetime/test.ts
+++ b/std/datetime/test.ts
@@ -2,7 +2,7 @@
 import { assertEquals, assertThrows } from "../testing/asserts.ts";
 import * as datetime from "./mod.ts";
 
-Deno.test(function parseDateTime(): void {
+Deno.test("parseDateTime", function (): void {
   assertEquals(
     datetime.parseDateTime("01-03-2019 16:30", "mm-dd-yyyy hh:mm"),
     new Date(2019, 0, 3, 16, 30)
@@ -29,7 +29,7 @@ Deno.test(function parseDateTime(): void {
   );
 });
 
-Deno.test(function invalidParseDateTimeFormatThrows(): void {
+Deno.test("invalidParseDateTimeFormatThrows", function (): void {
   assertThrows(
     (): void => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,7 +40,7 @@ Deno.test(function invalidParseDateTimeFormatThrows(): void {
   );
 });
 
-Deno.test(function parseDate(): void {
+Deno.test("parseDate", function (): void {
   assertEquals(
     datetime.parseDate("01-03-2019", "mm-dd-yyyy"),
     new Date(2019, 0, 3)
@@ -55,7 +55,7 @@ Deno.test(function parseDate(): void {
   );
 });
 
-Deno.test(function invalidParseDateFormatThrows(): void {
+Deno.test("invalidParseDateFormatThrows", function (): void {
   assertThrows(
     (): void => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -66,13 +66,13 @@ Deno.test(function invalidParseDateFormatThrows(): void {
   );
 });
 
-Deno.test(function DayOfYear(): void {
+Deno.test("DayOfYear", function (): void {
   assertEquals(1, datetime.dayOfYear(new Date("2019-01-01T03:24:00")));
   assertEquals(70, datetime.dayOfYear(new Date("2019-03-11T03:24:00")));
   assertEquals(365, datetime.dayOfYear(new Date("2019-12-31T03:24:00")));
 });
 
-Deno.test(function currentDayOfYear(): void {
+Deno.test("currentDayOfYear", function (): void {
   assertEquals(datetime.currentDayOfYear(), datetime.dayOfYear(new Date()));
 });
 

--- a/std/encoding/binary_test.ts
+++ b/std/encoding/binary_test.ts
@@ -14,14 +14,14 @@ import {
   writeVarnum,
 } from "./binary.ts";
 
-Deno.test(async function testGetNBytes(): Promise<void> {
+Deno.test("testGetNBytes", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
   const buff = new Deno.Buffer(data.buffer);
   const rslt = await getNBytes(buff, 8);
   assertEquals(rslt, data);
 });
 
-Deno.test(async function testGetNBytesThrows(): Promise<void> {
+Deno.test("testGetNBytesThrows", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4]);
   const buff = new Deno.Buffer(data.buffer);
   await assertThrowsAsync(async () => {
@@ -29,7 +29,7 @@ Deno.test(async function testGetNBytesThrows(): Promise<void> {
   }, Deno.errors.UnexpectedEof);
 });
 
-Deno.test(function testPutVarbig(): void {
+Deno.test("testPutVarbig", function (): void {
   const buff = new Uint8Array(8);
   putVarbig(buff, 0xffeeddccbbaa9988n);
   assertEquals(
@@ -38,7 +38,7 @@ Deno.test(function testPutVarbig(): void {
   );
 });
 
-Deno.test(function testPutVarbigLittleEndian(): void {
+Deno.test("testPutVarbigLittleEndian", function (): void {
   const buff = new Uint8Array(8);
   putVarbig(buff, 0x8899aabbccddeeffn, { endian: "little" });
   assertEquals(
@@ -47,47 +47,47 @@ Deno.test(function testPutVarbigLittleEndian(): void {
   );
 });
 
-Deno.test(function testPutVarnum(): void {
+Deno.test("testPutVarnum", function (): void {
   const buff = new Uint8Array(4);
   putVarnum(buff, 0xffeeddcc);
   assertEquals(buff, new Uint8Array([0xff, 0xee, 0xdd, 0xcc]));
 });
 
-Deno.test(function testPutVarnumLittleEndian(): void {
+Deno.test("testPutVarnumLittleEndian", function (): void {
   const buff = new Uint8Array(4);
   putVarnum(buff, 0xccddeeff, { endian: "little" });
   assertEquals(buff, new Uint8Array([0xff, 0xee, 0xdd, 0xcc]));
 });
 
-Deno.test(async function testReadVarbig(): Promise<void> {
+Deno.test("testReadVarbig", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
   const buff = new Deno.Buffer(data.buffer);
   const rslt = await readVarbig(buff);
   assertEquals(rslt, 0x0102030405060708n);
 });
 
-Deno.test(async function testReadVarbigLittleEndian(): Promise<void> {
+Deno.test("testReadVarbigLittleEndian", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
   const buff = new Deno.Buffer(data.buffer);
   const rslt = await readVarbig(buff, { endian: "little" });
   assertEquals(rslt, 0x0807060504030201n);
 });
 
-Deno.test(async function testReadVarnum(): Promise<void> {
+Deno.test("testReadVarnum", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4]);
   const buff = new Deno.Buffer(data.buffer);
   const rslt = await readVarnum(buff);
   assertEquals(rslt, 0x01020304);
 });
 
-Deno.test(async function testReadVarnumLittleEndian(): Promise<void> {
+Deno.test("testReadVarnumLittleEndian", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4]);
   const buff = new Deno.Buffer(data.buffer);
   const rslt = await readVarnum(buff, { endian: "little" });
   assertEquals(rslt, 0x04030201);
 });
 
-Deno.test(function testSizeof(): void {
+Deno.test("testSizeof", function (): void {
   assertEquals(1, sizeof("int8"));
   assertEquals(1, sizeof("uint8"));
   assertEquals(2, sizeof("int16"));
@@ -100,30 +100,30 @@ Deno.test(function testSizeof(): void {
   assertEquals(8, sizeof("float64"));
 });
 
-Deno.test(function testVarbig(): void {
+Deno.test("testVarbig", function (): void {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
   const rslt = varbig(data);
   assertEquals(rslt, 0x0102030405060708n);
 });
 
-Deno.test(function testVarbigLittleEndian(): void {
+Deno.test("testVarbigLittleEndian", function (): void {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
   const rslt = varbig(data, { endian: "little" });
   assertEquals(rslt, 0x0807060504030201n);
 });
 
-Deno.test(function testVarnum(): void {
+Deno.test("testVarnum", function (): void {
   const data = new Uint8Array([1, 2, 3, 4]);
   const rslt = varnum(data);
   assertEquals(rslt, 0x01020304);
 });
-Deno.test(function testVarnumLittleEndian(): void {
+Deno.test("testVarnumLittleEndian", function (): void {
   const data = new Uint8Array([1, 2, 3, 4]);
   const rslt = varnum(data, { endian: "little" });
   assertEquals(rslt, 0x04030201);
 });
 
-Deno.test(async function testWriteVarbig(): Promise<void> {
+Deno.test("testWriteVarbig", async function (): Promise<void> {
   const data = new Uint8Array(8);
   const buff = new Deno.Buffer();
   await writeVarbig(buff, 0x0102030405060708n);
@@ -134,7 +134,7 @@ Deno.test(async function testWriteVarbig(): Promise<void> {
   );
 });
 
-Deno.test(async function testWriteVarbigLittleEndian(): Promise<void> {
+Deno.test("testWriteVarbigLittleEndian", async function (): Promise<void> {
   const data = new Uint8Array(8);
   const buff = new Deno.Buffer();
   await writeVarbig(buff, 0x0807060504030201n, { endian: "little" });
@@ -145,7 +145,7 @@ Deno.test(async function testWriteVarbigLittleEndian(): Promise<void> {
   );
 });
 
-Deno.test(async function testWriteVarnum(): Promise<void> {
+Deno.test("testWriteVarnum", async function (): Promise<void> {
   const data = new Uint8Array(4);
   const buff = new Deno.Buffer();
   await writeVarnum(buff, 0x01020304);
@@ -153,7 +153,7 @@ Deno.test(async function testWriteVarnum(): Promise<void> {
   assertEquals(data, new Uint8Array([0x01, 0x02, 0x03, 0x04]));
 });
 
-Deno.test(async function testWriteVarnumLittleEndian(): Promise<void> {
+Deno.test("testWriteVarnumLittleEndian", async function (): Promise<void> {
   const data = new Uint8Array(4);
   const buff = new Deno.Buffer();
   await writeVarnum(buff, 0x04030201, { endian: "little" });

--- a/std/examples/test.ts
+++ b/std/examples/test.ts
@@ -3,16 +3,16 @@ const { run } = Deno;
 import { assertEquals } from "../testing/asserts.ts";
 
 /** Example of how to do basic tests */
-Deno.test(function t1(): void {
+Deno.test("t1", function (): void {
   assertEquals("hello", "hello");
 });
 
-Deno.test(function t2(): void {
+Deno.test("t2", function (): void {
   assertEquals("world", "world");
 });
 
 /** A more complicated test that runs a subprocess. */
-Deno.test(async function catSmoke(): Promise<void> {
+Deno.test("catSmoke", async function (): Promise<void> {
   const p = run({
     cmd: [
       Deno.execPath(),

--- a/std/examples/tests/xeval_test.ts
+++ b/std/examples/tests/xeval_test.ts
@@ -9,13 +9,13 @@ import {
 } from "../../testing/asserts.ts";
 const { execPath, run } = Deno;
 
-Deno.test(async function xevalSuccess(): Promise<void> {
+Deno.test("xevalSuccess", async function (): Promise<void> {
   const chunks: string[] = [];
   await xeval(stringsReader("a\nb\nc"), ($): number => chunks.push($));
   assertEquals(chunks, ["a", "b", "c"]);
 });
 
-Deno.test(async function xevalDelimiter(): Promise<void> {
+Deno.test("xevalDelimiter", async function (): Promise<void> {
   const chunks: string[] = [];
   await xeval(stringsReader("!MADMADAMADAM!"), ($): number => chunks.push($), {
     delimiter: "MADAM",
@@ -43,7 +43,7 @@ Deno.test({
   },
 });
 
-Deno.test(async function xevalCliSyntaxError(): Promise<void> {
+Deno.test("xevalCliSyntaxError", async function (): Promise<void> {
   const p = run({
     cmd: [execPath(), xevalPath, "("],
     stdin: "null",

--- a/std/flags/all_bool_test.ts
+++ b/std/flags/all_bool_test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
 // flag boolean true (default all --args to boolean)
-Deno.test(function flagBooleanTrue(): void {
+Deno.test("flagBooleanTrue", function (): void {
   const argv = parse(["moo", "--honk", "cow"], {
     boolean: true,
   });
@@ -17,7 +17,7 @@ Deno.test(function flagBooleanTrue(): void {
 });
 
 // flag boolean true only affects double hyphen arguments without equals signs
-Deno.test(function flagBooleanTrueOnlyAffectsDoubleDash(): void {
+Deno.test("flagBooleanTrueOnlyAffectsDoubleDash", function (): void {
   const argv = parse(["moo", "--honk", "cow", "-p", "55", "--tacos=good"], {
     boolean: true,
   });

--- a/std/flags/bool_test.ts
+++ b/std/flags/bool_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
-Deno.test(function flagBooleanDefaultFalse(): void {
+Deno.test("flagBooleanDefaultFalse", function (): void {
   const argv = parse(["moo"], {
     boolean: ["t", "verbose"],
     default: { verbose: false, t: false },
@@ -18,7 +18,7 @@ Deno.test(function flagBooleanDefaultFalse(): void {
   assertEquals(typeof argv.t, "boolean");
 });
 
-Deno.test(function booleanGroups(): void {
+Deno.test("booleanGroups", function (): void {
   const argv = parse(["-x", "-z", "one", "two", "three"], {
     boolean: ["x", "y", "z"],
   });
@@ -35,7 +35,7 @@ Deno.test(function booleanGroups(): void {
   assertEquals(typeof argv.z, "boolean");
 });
 
-Deno.test(function booleanAndAliasWithChainableApi(): void {
+Deno.test("booleanAndAliasWithChainableApi", function (): void {
   const aliased = ["-h", "derp"];
   const regular = ["--herp", "derp"];
   const aliasedArgv = parse(aliased, {
@@ -56,7 +56,7 @@ Deno.test(function booleanAndAliasWithChainableApi(): void {
   assertEquals(propertyArgv, expected);
 });
 
-Deno.test(function booleanAndAliasWithOptionsHash(): void {
+Deno.test("booleanAndAliasWithOptionsHash", function (): void {
   const aliased = ["-h", "derp"];
   const regular = ["--herp", "derp"];
   const opts = {
@@ -74,7 +74,7 @@ Deno.test(function booleanAndAliasWithOptionsHash(): void {
   assertEquals(propertyArgv, expected);
 });
 
-Deno.test(function booleanAndAliasArrayWithOptionsHash(): void {
+Deno.test("booleanAndAliasArrayWithOptionsHash", function (): void {
   const aliased = ["-h", "derp"];
   const regular = ["--herp", "derp"];
   const alt = ["--harp", "derp"];
@@ -96,7 +96,7 @@ Deno.test(function booleanAndAliasArrayWithOptionsHash(): void {
   assertEquals(altPropertyArgv, expected);
 });
 
-Deno.test(function booleanAndAliasUsingExplicitTrue(): void {
+Deno.test("booleanAndAliasUsingExplicitTrue", function (): void {
   const aliased = ["-h", "true"];
   const regular = ["--herp", "true"];
   const opts = {
@@ -117,7 +117,7 @@ Deno.test(function booleanAndAliasUsingExplicitTrue(): void {
 
 // regression, see https://github.com/substack/node-optimist/issues/71
 // boolean and --x=true
-Deno.test(function booleanAndNonBoolean(): void {
+Deno.test("booleanAndNonBoolean", function (): void {
   const parsed = parse(["--boool", "--other=true"], {
     boolean: "boool",
   });
@@ -133,7 +133,7 @@ Deno.test(function booleanAndNonBoolean(): void {
   assertEquals(parsed2.other, "false");
 });
 
-Deno.test(function booleanParsingTrue(): void {
+Deno.test("booleanParsingTrue", function (): void {
   const parsed = parse(["--boool=true"], {
     default: {
       boool: false,
@@ -144,7 +144,7 @@ Deno.test(function booleanParsingTrue(): void {
   assertEquals(parsed.boool, true);
 });
 
-Deno.test(function booleanParsingFalse(): void {
+Deno.test("booleanParsingFalse", function (): void {
   const parsed = parse(["--boool=false"], {
     default: {
       boool: true,
@@ -155,7 +155,7 @@ Deno.test(function booleanParsingFalse(): void {
   assertEquals(parsed.boool, false);
 });
 
-Deno.test(function booleanParsingTrueLike(): void {
+Deno.test("booleanParsingTrueLike", function (): void {
   const parsed = parse(["-t", "true123"], { boolean: ["t"] });
   assertEquals(parsed.t, true);
 
@@ -166,7 +166,7 @@ Deno.test(function booleanParsingTrueLike(): void {
   assertEquals(parsed3.t, true);
 });
 
-Deno.test(function booleanNegationAfterBoolean(): void {
+Deno.test("booleanNegationAfterBoolean", function (): void {
   const parsed = parse(["--foo", "--no-foo"], { boolean: ["foo"] });
   assertEquals(parsed.foo, false);
 
@@ -174,7 +174,7 @@ Deno.test(function booleanNegationAfterBoolean(): void {
   assertEquals(parsed2.foo, false);
 });
 
-Deno.test(function booleanAfterBooleanNegation(): void {
+Deno.test("booleanAfterBooleanNegation", function (): void {
   const parsed = parse(["--no--foo", "--foo"], { boolean: ["foo"] });
   assertEquals(parsed.foo, true);
 
@@ -182,7 +182,7 @@ Deno.test(function booleanAfterBooleanNegation(): void {
   assertEquals(parsed2.foo, true);
 });
 
-Deno.test(function latestFlagIsBooleanNegation(): void {
+Deno.test("latestFlagIsBooleanNegation", function (): void {
   const parsed = parse(["--no-foo", "--foo", "--no-foo"], { boolean: ["foo"] });
   assertEquals(parsed.foo, false);
 
@@ -192,7 +192,7 @@ Deno.test(function latestFlagIsBooleanNegation(): void {
   assertEquals(parsed2.foo, false);
 });
 
-Deno.test(function latestFlagIsBoolean(): void {
+Deno.test("latestFlagIsBoolean", function (): void {
   const parsed = parse(["--foo", "--no-foo", "--foo"], { boolean: ["foo"] });
   assertEquals(parsed.foo, true);
 

--- a/std/flags/dash_test.ts
+++ b/std/flags/dash_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
-Deno.test(function hyphen(): void {
+Deno.test("hyphen", function (): void {
   assertEquals(parse(["-n", "-"]), { n: "-", _: [] });
   assertEquals(parse(["-"]), { _: ["-"] });
   assertEquals(parse(["-f-"]), { f: "-", _: [] });
@@ -10,13 +10,13 @@ Deno.test(function hyphen(): void {
   assertEquals(parse(["-s", "-"], { string: "s" }), { s: "-", _: [] });
 });
 
-Deno.test(function doubleDash(): void {
+Deno.test("doubleDash", function (): void {
   assertEquals(parse(["-a", "--", "b"]), { a: true, _: ["b"] });
   assertEquals(parse(["--a", "--", "b"]), { a: true, _: ["b"] });
   assertEquals(parse(["--a", "--", "b"]), { a: true, _: ["b"] });
 });
 
-Deno.test(function moveArgsAfterDoubleDashIntoOwnArray(): void {
+Deno.test("moveArgsAfterDoubleDashIntoOwnArray", function (): void {
   assertEquals(
     parse(["--name", "John", "before", "--", "after"], { "--": true }),
     {

--- a/std/flags/default_bool_test.ts
+++ b/std/flags/default_bool_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
-Deno.test(function booleanDefaultTrue(): void {
+Deno.test("booleanDefaultTrue", function (): void {
   const argv = parse([], {
     boolean: "sometrue",
     default: { sometrue: true },
@@ -10,7 +10,7 @@ Deno.test(function booleanDefaultTrue(): void {
   assertEquals(argv.sometrue, true);
 });
 
-Deno.test(function booleanDefaultFalse(): void {
+Deno.test("booleanDefaultFalse", function (): void {
   const argv = parse([], {
     boolean: "somefalse",
     default: { somefalse: false },
@@ -18,7 +18,7 @@ Deno.test(function booleanDefaultFalse(): void {
   assertEquals(argv.somefalse, false);
 });
 
-Deno.test(function booleanDefaultNull(): void {
+Deno.test("booleanDefaultNull", function (): void {
   const argv = parse([], {
     boolean: "maybe",
     default: { maybe: null },

--- a/std/flags/dotted_test.ts
+++ b/std/flags/dotted_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
-Deno.test(function dottedAlias(): void {
+Deno.test("dottedAlias", function (): void {
   const argv = parse(["--a.b", "22"], {
     default: { "a.b": 11 },
     alias: { "a.b": "aa.bb" },
@@ -11,13 +11,13 @@ Deno.test(function dottedAlias(): void {
   assertEquals(argv.aa.bb, 22);
 });
 
-Deno.test(function dottedDefault(): void {
+Deno.test("dottedDefault", function (): void {
   const argv = parse([], { default: { "a.b": 11 }, alias: { "a.b": "aa.bb" } });
   assertEquals(argv.a.b, 11);
   assertEquals(argv.aa.bb, 11);
 });
 
-Deno.test(function dottedDefaultWithNoAlias(): void {
+Deno.test("dottedDefaultWithNoAlias", function (): void {
   const argv = parse([], { default: { "a.b": 11 } });
   assertEquals(argv.a.b, 11);
 });

--- a/std/flags/kv_short_test.ts
+++ b/std/flags/kv_short_test.ts
@@ -2,12 +2,12 @@
 import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
-Deno.test(function short(): void {
+Deno.test("short", function (): void {
   const argv = parse(["-b=123"]);
   assertEquals(argv, { b: 123, _: [] });
 });
 
-Deno.test(function multiShort(): void {
+Deno.test("multiShort", function (): void {
   const argv = parse(["-a=whatever", "-b=robots"]);
   assertEquals(argv, { a: "whatever", b: "robots", _: [] });
 });

--- a/std/flags/long_test.ts
+++ b/std/flags/long_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
-Deno.test(function longOpts(): void {
+Deno.test("longOpts", function (): void {
   assertEquals(parse(["--bool"]), { bool: true, _: [] });
   assertEquals(parse(["--pow", "xixxle"]), { pow: "xixxle", _: [] });
   assertEquals(parse(["--pow=xixxle"]), { pow: "xixxle", _: [] });

--- a/std/flags/num_test.ts
+++ b/std/flags/num_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
-Deno.test(function nums(): void {
+Deno.test("nums", function (): void {
   const argv = parse([
     "-x",
     "1234",
@@ -32,7 +32,7 @@ Deno.test(function nums(): void {
   assertEquals(typeof argv._[0], "number");
 });
 
-Deno.test(function alreadyNumber(): void {
+Deno.test("alreadyNumber", function (): void {
   const argv = parse(["-x", "1234", "789"]);
   assertEquals(argv, { x: 1234, _: [789] });
   assertEquals(typeof argv.x, "number");

--- a/std/flags/parse_test.ts
+++ b/std/flags/parse_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
-Deno.test(function parseArgs(): void {
+Deno.test("parseArgs", function (): void {
   assertEquals(parse(["--no-moo"]), { moo: false, _: [] });
   assertEquals(parse(["-v", "a", "-v", "b", "-v", "c"]), {
     v: ["a", "b", "c"],
@@ -10,7 +10,7 @@ Deno.test(function parseArgs(): void {
   });
 });
 
-Deno.test(function comprehensive(): void {
+Deno.test("comprehensive", function (): void {
   assertEquals(
     parse([
       "--name=meowmers",
@@ -47,13 +47,13 @@ Deno.test(function comprehensive(): void {
   );
 });
 
-Deno.test(function flagBoolean(): void {
+Deno.test("flagBoolean", function (): void {
   const argv = parse(["-t", "moo"], { boolean: "t" });
   assertEquals(argv, { t: true, _: ["moo"] });
   assertEquals(typeof argv.t, "boolean");
 });
 
-Deno.test(function flagBooleanValue(): void {
+Deno.test("flagBooleanValue", function (): void {
   const argv = parse(["--verbose", "false", "moo", "-t", "true"], {
     boolean: ["t", "verbose"],
     default: { verbose: true },
@@ -69,7 +69,7 @@ Deno.test(function flagBooleanValue(): void {
   assertEquals(typeof argv.t, "boolean");
 });
 
-Deno.test(function newlinesInParams(): void {
+Deno.test("newlinesInParams", function (): void {
   const args = parse(["-s", "X\nX"]);
   assertEquals(args, { _: [], s: "X\nX" });
 
@@ -81,7 +81,7 @@ Deno.test(function newlinesInParams(): void {
   assertEquals(args2, { _: [], s: "X\nX" });
 });
 
-Deno.test(function strings(): void {
+Deno.test("strings", function (): void {
   const s = parse(["-s", "0001234"], { string: "s" }).s;
   assertEquals(s, "0001234");
   assertEquals(typeof s, "string");
@@ -91,7 +91,7 @@ Deno.test(function strings(): void {
   assertEquals(typeof x, "string");
 });
 
-Deno.test(function stringArgs(): void {
+Deno.test("stringArgs", function (): void {
   const s = parse(["  ", "  "], { string: "_" })._;
   assertEquals(s.length, 2);
   assertEquals(typeof s[0], "string");
@@ -100,7 +100,7 @@ Deno.test(function stringArgs(): void {
   assertEquals(s[1], "  ");
 });
 
-Deno.test(function emptyStrings(): void {
+Deno.test("emptyStrings", function (): void {
   const s = parse(["-s"], { string: "s" }).s;
   assertEquals(s, "");
   assertEquals(typeof s, "string");
@@ -118,7 +118,7 @@ Deno.test(function emptyStrings(): void {
   assertEquals(letters.t, "");
 });
 
-Deno.test(function stringAndAlias(): void {
+Deno.test("stringAndAlias", function (): void {
   const x = parse(["--str", "000123"], {
     string: "s",
     alias: { s: "str" },
@@ -140,7 +140,7 @@ Deno.test(function stringAndAlias(): void {
   assertEquals(typeof y.s, "string");
 });
 
-Deno.test(function slashBreak(): void {
+Deno.test("slashBreak", function (): void {
   assertEquals(parse(["-I/foo/bar/baz"]), { I: "/foo/bar/baz", _: [] });
   assertEquals(parse(["-xyz/foo/bar/baz"]), {
     x: true,
@@ -150,7 +150,7 @@ Deno.test(function slashBreak(): void {
   });
 });
 
-Deno.test(function alias(): void {
+Deno.test("alias", function (): void {
   const argv = parse(["-f", "11", "--zoom", "55"], {
     alias: { z: "zoom" },
   });
@@ -159,7 +159,7 @@ Deno.test(function alias(): void {
   assertEquals(argv.f, 11);
 });
 
-Deno.test(function multiAlias(): void {
+Deno.test("multiAlias", function (): void {
   const argv = parse(["-f", "11", "--zoom", "55"], {
     alias: { z: ["zm", "zoom"] },
   });
@@ -169,7 +169,7 @@ Deno.test(function multiAlias(): void {
   assertEquals(argv.f, 11);
 });
 
-Deno.test(function nestedDottedObjects(): void {
+Deno.test("nestedDottedObjects", function (): void {
   const argv = parse([
     "--foo.bar",
     "3",
@@ -192,7 +192,7 @@ Deno.test(function nestedDottedObjects(): void {
   assertEquals(argv.beep, { boop: true });
 });
 
-Deno.test(function flagBuiltinProperty(): void {
+Deno.test("flagBuiltinProperty", function (): void {
   const argv = parse(["--toString", "--valueOf", "foo"]);
   assertEquals(argv, { toString: true, valueOf: "foo", _: [] });
   assertEquals(typeof argv.toString, "boolean");

--- a/std/flags/short_test.ts
+++ b/std/flags/short_test.ts
@@ -2,12 +2,12 @@
 import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
-Deno.test(function numbericShortArgs(): void {
+Deno.test("numbericShortArgs", function (): void {
   assertEquals(parse(["-n123"]), { n: 123, _: [] });
   assertEquals(parse(["-123", "456"]), { 1: true, 2: true, 3: 456, _: [] });
 });
 
-Deno.test(function short(): void {
+Deno.test("short", function (): void {
   assertEquals(parse(["-b"]), { b: true, _: [] });
   assertEquals(parse(["foo", "bar", "baz"]), { _: ["foo", "bar", "baz"] });
   assertEquals(parse(["-cats"]), { c: true, a: true, t: true, s: true, _: [] });
@@ -26,7 +26,7 @@ Deno.test(function short(): void {
   });
 });
 
-Deno.test(function mixedShortBoolAndCapture(): void {
+Deno.test("mixedShortBoolAndCapture", function (): void {
   assertEquals(parse(["-h", "localhost", "-fp", "555", "script.js"]), {
     f: true,
     p: 555,
@@ -35,7 +35,7 @@ Deno.test(function mixedShortBoolAndCapture(): void {
   });
 });
 
-Deno.test(function shortAndLong(): void {
+Deno.test("shortAndLong", function (): void {
   assertEquals(parse(["-h", "localhost", "-fp", "555", "script.js"]), {
     f: true,
     p: 555,

--- a/std/flags/stop_early_test.ts
+++ b/std/flags/stop_early_test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
 // stops parsing on the first non-option when stopEarly is set
-Deno.test(function stopParsing(): void {
+Deno.test("stopParsing", function (): void {
   const argv = parse(["--aaa", "bbb", "ccc", "--ddd"], {
     stopEarly: true,
   });

--- a/std/flags/unknown_test.ts
+++ b/std/flags/unknown_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
-Deno.test(function booleanAndAliasIsNotUnknown(): void {
+Deno.test("booleanAndAliasIsNotUnknown", function (): void {
   const unknown: unknown[] = [];
   function unknownFn(arg: string, k?: string, v?: unknown): boolean {
     unknown.push({ arg, k, v });
@@ -24,28 +24,31 @@ Deno.test(function booleanAndAliasIsNotUnknown(): void {
   ]);
 });
 
-Deno.test(function flagBooleanTrueAnyDoubleHyphenArgumentIsNotUnknown(): void {
-  const unknown: unknown[] = [];
-  function unknownFn(arg: string, k?: string, v?: unknown): boolean {
-    unknown.push({ arg, k, v });
-    return false;
+Deno.test(
+  "flagBooleanTrueAnyDoubleHyphenArgumentIsNotUnknown",
+  function (): void {
+    const unknown: unknown[] = [];
+    function unknownFn(arg: string, k?: string, v?: unknown): boolean {
+      unknown.push({ arg, k, v });
+      return false;
+    }
+    const argv = parse(["--honk", "--tacos=good", "cow", "-p", "55"], {
+      boolean: true,
+      unknown: unknownFn,
+    });
+    assertEquals(unknown, [
+      { arg: "--tacos=good", k: "tacos", v: "good" },
+      { arg: "cow", k: undefined, v: undefined },
+      { arg: "-p", k: "p", v: "55" },
+    ]);
+    assertEquals(argv, {
+      honk: true,
+      _: [],
+    });
   }
-  const argv = parse(["--honk", "--tacos=good", "cow", "-p", "55"], {
-    boolean: true,
-    unknown: unknownFn,
-  });
-  assertEquals(unknown, [
-    { arg: "--tacos=good", k: "tacos", v: "good" },
-    { arg: "cow", k: undefined, v: undefined },
-    { arg: "-p", k: "p", v: "55" },
-  ]);
-  assertEquals(argv, {
-    honk: true,
-    _: [],
-  });
-});
+);
 
-Deno.test(function stringAndAliasIsNotUnkown(): void {
+Deno.test("stringAndAliasIsNotUnkown", function (): void {
   const unknown: unknown[] = [];
   function unknownFn(arg: string, k?: string, v?: unknown): boolean {
     unknown.push({ arg, k, v });
@@ -67,7 +70,7 @@ Deno.test(function stringAndAliasIsNotUnkown(): void {
   ]);
 });
 
-Deno.test(function defaultAndAliasIsNotUnknown(): void {
+Deno.test("defaultAndAliasIsNotUnknown", function (): void {
   const unknown: unknown[] = [];
   function unknownFn(arg: string, k?: string, v?: unknown): boolean {
     unknown.push({ arg, k, v });
@@ -86,7 +89,7 @@ Deno.test(function defaultAndAliasIsNotUnknown(): void {
   assertEquals(unknown, []);
 });
 
-Deno.test(function valueFollowingDoubleHyphenIsNotUnknown(): void {
+Deno.test("valueFollowingDoubleHyphenIsNotUnknown", function (): void {
   const unknown: unknown[] = [];
   function unknownFn(arg: string, k?: string, v?: unknown): boolean {
     unknown.push({ arg, k, v });

--- a/std/flags/whitespace_test.ts
+++ b/std/flags/whitespace_test.ts
@@ -2,6 +2,6 @@
 import { assertEquals } from "../testing/asserts.ts";
 import { parse } from "./mod.ts";
 
-Deno.test(function whitespaceShouldBeWhitespace(): void {
+Deno.test("whitespaceShouldBeWhitespace", function (): void {
   assertEquals(parse(["-x", "\t"]).x, "\t");
 });

--- a/std/fmt/colors_test.ts
+++ b/std/fmt/colors_test.ts
@@ -3,19 +3,19 @@ import { assertEquals } from "../testing/asserts.ts";
 import * as c from "./colors.ts";
 import "../examples/colors.ts";
 
-Deno.test(function singleColor(): void {
+Deno.test("singleColor", function (): void {
   assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
 });
 
-Deno.test(function doubleColor(): void {
+Deno.test("doubleColor", function (): void {
   assertEquals(c.bgBlue(c.red("foo bar")), "[44m[31mfoo bar[39m[49m");
 });
 
-Deno.test(function replacesCloseCharacters(): void {
+Deno.test("replacesCloseCharacters", function (): void {
   assertEquals(c.red("Hel[39mlo"), "[31mHel[31mlo[39m");
 });
 
-Deno.test(function enablingColors(): void {
+Deno.test("enablingColors", function (): void {
   assertEquals(c.getColorEnabled(), true);
   c.setColorEnabled(false);
   assertEquals(c.bgBlue(c.red("foo bar")), "foo bar");
@@ -23,98 +23,98 @@ Deno.test(function enablingColors(): void {
   assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
 });
 
-Deno.test(function testBold(): void {
+Deno.test("testBold", function (): void {
   assertEquals(c.bold("foo bar"), "[1mfoo bar[22m");
 });
 
-Deno.test(function testDim(): void {
+Deno.test("testDim", function (): void {
   assertEquals(c.dim("foo bar"), "[2mfoo bar[22m");
 });
 
-Deno.test(function testItalic(): void {
+Deno.test("testItalic", function (): void {
   assertEquals(c.italic("foo bar"), "[3mfoo bar[23m");
 });
 
-Deno.test(function testUnderline(): void {
+Deno.test("testUnderline", function (): void {
   assertEquals(c.underline("foo bar"), "[4mfoo bar[24m");
 });
 
-Deno.test(function testInverse(): void {
+Deno.test("testInverse", function (): void {
   assertEquals(c.inverse("foo bar"), "[7mfoo bar[27m");
 });
 
-Deno.test(function testHidden(): void {
+Deno.test("testHidden", function (): void {
   assertEquals(c.hidden("foo bar"), "[8mfoo bar[28m");
 });
 
-Deno.test(function testStrikethrough(): void {
+Deno.test("testStrikethrough", function (): void {
   assertEquals(c.strikethrough("foo bar"), "[9mfoo bar[29m");
 });
 
-Deno.test(function testBlack(): void {
+Deno.test("testBlack", function (): void {
   assertEquals(c.black("foo bar"), "[30mfoo bar[39m");
 });
 
-Deno.test(function testRed(): void {
+Deno.test("testRed", function (): void {
   assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
 });
 
-Deno.test(function testGreen(): void {
+Deno.test("testGreen", function (): void {
   assertEquals(c.green("foo bar"), "[32mfoo bar[39m");
 });
 
-Deno.test(function testYellow(): void {
+Deno.test("testYellow", function (): void {
   assertEquals(c.yellow("foo bar"), "[33mfoo bar[39m");
 });
 
-Deno.test(function testBlue(): void {
+Deno.test("testBlue", function (): void {
   assertEquals(c.blue("foo bar"), "[34mfoo bar[39m");
 });
 
-Deno.test(function testMagenta(): void {
+Deno.test("testMagenta", function (): void {
   assertEquals(c.magenta("foo bar"), "[35mfoo bar[39m");
 });
 
-Deno.test(function testCyan(): void {
+Deno.test("testCyan", function (): void {
   assertEquals(c.cyan("foo bar"), "[36mfoo bar[39m");
 });
 
-Deno.test(function testWhite(): void {
+Deno.test("testWhite", function (): void {
   assertEquals(c.white("foo bar"), "[37mfoo bar[39m");
 });
 
-Deno.test(function testGray(): void {
+Deno.test("testGray", function (): void {
   assertEquals(c.gray("foo bar"), "[90mfoo bar[39m");
 });
 
-Deno.test(function testBgBlack(): void {
+Deno.test("testBgBlack", function (): void {
   assertEquals(c.bgBlack("foo bar"), "[40mfoo bar[49m");
 });
 
-Deno.test(function testBgRed(): void {
+Deno.test("testBgRed", function (): void {
   assertEquals(c.bgRed("foo bar"), "[41mfoo bar[49m");
 });
 
-Deno.test(function testBgGreen(): void {
+Deno.test("testBgGreen", function (): void {
   assertEquals(c.bgGreen("foo bar"), "[42mfoo bar[49m");
 });
 
-Deno.test(function testBgYellow(): void {
+Deno.test("testBgYellow", function (): void {
   assertEquals(c.bgYellow("foo bar"), "[43mfoo bar[49m");
 });
 
-Deno.test(function testBgBlue(): void {
+Deno.test("testBgBlue", function (): void {
   assertEquals(c.bgBlue("foo bar"), "[44mfoo bar[49m");
 });
 
-Deno.test(function testBgMagenta(): void {
+Deno.test("testBgMagenta", function (): void {
   assertEquals(c.bgMagenta("foo bar"), "[45mfoo bar[49m");
 });
 
-Deno.test(function testBgCyan(): void {
+Deno.test("testBgCyan", function (): void {
   assertEquals(c.bgCyan("foo bar"), "[46mfoo bar[49m");
 });
 
-Deno.test(function testBgWhite(): void {
+Deno.test("testBgWhite", function (): void {
   assertEquals(c.bgWhite("foo bar"), "[47mfoo bar[49m");
 });

--- a/std/fmt/sprintf_test.ts
+++ b/std/fmt/sprintf_test.ts
@@ -4,17 +4,17 @@ import { assertEquals } from "../testing/asserts.ts";
 
 const S = sprintf;
 
-Deno.test(function noVerb(): void {
+Deno.test("noVerb", function (): void {
   assertEquals(sprintf("bla"), "bla");
 });
 
-Deno.test(function percent(): void {
+Deno.test("percent", function (): void {
   assertEquals(sprintf("%%"), "%");
   assertEquals(sprintf("!%%!"), "!%!");
   assertEquals(sprintf("!%%"), "!%");
   assertEquals(sprintf("%%!"), "%!");
 });
-Deno.test(function testBoolean(): void {
+Deno.test("testBoolean", function (): void {
   assertEquals(sprintf("%t", true), "true");
   assertEquals(sprintf("%10t", true), "      true");
   assertEquals(sprintf("%-10t", false), "false     ");
@@ -23,7 +23,7 @@ Deno.test(function testBoolean(): void {
   assertEquals(sprintf("%tbla", false), "falsebla");
 });
 
-Deno.test(function testIntegerB(): void {
+Deno.test("testIntegerB", function (): void {
   assertEquals(S("%b", 4), "100");
   assertEquals(S("%b", -4), "-100");
   assertEquals(
@@ -47,7 +47,7 @@ Deno.test(function testIntegerB(): void {
   assertEquals(S("%4b", 4), " 100");
 });
 
-Deno.test(function testIntegerC(): void {
+Deno.test("testIntegerC", function (): void {
   assertEquals(S("%c", 0x31), "1");
   assertEquals(S("%c%b", 0x31, 1), "11");
   assertEquals(S("%c", 0x1f4a9), "💩");
@@ -55,14 +55,14 @@ Deno.test(function testIntegerC(): void {
   assertEquals(S("%4c", 0x31), "   1");
 });
 
-Deno.test(function testIntegerD(): void {
+Deno.test("testIntegerD", function (): void {
   assertEquals(S("%d", 4), "4");
   assertEquals(S("%d", -4), "-4");
   assertEquals(S("%d", Number.MAX_SAFE_INTEGER), "9007199254740991");
   assertEquals(S("%d", Number.MIN_SAFE_INTEGER), "-9007199254740991");
 });
 
-Deno.test(function testIntegerO(): void {
+Deno.test("testIntegerO", function (): void {
   assertEquals(S("%o", 4), "4");
   assertEquals(S("%o", -4), "-4");
   assertEquals(S("%o", 9), "11");
@@ -72,7 +72,7 @@ Deno.test(function testIntegerO(): void {
   // width
   assertEquals(S("%4o", 4), "   4");
 });
-Deno.test(function testIntegerx(): void {
+Deno.test("testIntegerx", function (): void {
   assertEquals(S("%x", 4), "4");
   assertEquals(S("%x", -4), "-4");
   assertEquals(S("%x", 9), "9");
@@ -86,7 +86,7 @@ Deno.test(function testIntegerx(): void {
   assertEquals(S("%+4x", 4), "  +4");
   assertEquals(S("%-+4x", 4), "+4  ");
 });
-Deno.test(function testIntegerX(): void {
+Deno.test("testIntegerX", function (): void {
   assertEquals(S("%X", 4), "4");
   assertEquals(S("%X", -4), "-4");
   assertEquals(S("%X", 9), "9");
@@ -95,7 +95,7 @@ Deno.test(function testIntegerX(): void {
   assertEquals(S("%X", Number.MIN_SAFE_INTEGER), "-1FFFFFFFFFFFFF");
 });
 
-Deno.test(function testFloate(): void {
+Deno.test("testFloate", function (): void {
   assertEquals(S("%e", 4), "4.000000e+00");
   assertEquals(S("%e", -4), "-4.000000e+00");
   assertEquals(S("%e", 4.1), "4.100000e+00");
@@ -103,7 +103,7 @@ Deno.test(function testFloate(): void {
   assertEquals(S("%e", Number.MAX_SAFE_INTEGER), "9.007199e+15");
   assertEquals(S("%e", Number.MIN_SAFE_INTEGER), "-9.007199e+15");
 });
-Deno.test(function testFloatE(): void {
+Deno.test("testFloatE", function (): void {
   assertEquals(S("%E", 4), "4.000000E+00");
   assertEquals(S("%E", -4), "-4.000000E+00");
   assertEquals(S("%E", 4.1), "4.100000E+00");
@@ -113,7 +113,7 @@ Deno.test(function testFloatE(): void {
   assertEquals(S("%E", Number.MIN_VALUE), "5.000000E-324");
   assertEquals(S("%E", Number.MAX_VALUE), "1.797693E+308");
 });
-Deno.test(function testFloatfF(): void {
+Deno.test("testFloatfF", function (): void {
   assertEquals(S("%f", 4), "4.000000");
   assertEquals(S("%F", 4), "4.000000");
   assertEquals(S("%f", -4), "-4.000000");
@@ -145,32 +145,32 @@ Deno.test(function testFloatfF(): void {
   );
 });
 
-Deno.test(function testString(): void {
+Deno.test("testString", function (): void {
   assertEquals(S("%s World%s", "Hello", "!"), "Hello World!");
 });
 
-Deno.test(function testHex(): void {
+Deno.test("testHex", function (): void {
   assertEquals(S("%x", "123"), "313233");
   assertEquals(S("%x", "n"), "6e");
 });
-Deno.test(function testHeX(): void {
+Deno.test("testHeX", function (): void {
   assertEquals(S("%X", "123"), "313233");
   assertEquals(S("%X", "n"), "6E");
 });
 
-Deno.test(function testType(): void {
+Deno.test("testType", function (): void {
   assertEquals(S("%T", new Date()), "object");
   assertEquals(S("%T", 123), "number");
   assertEquals(S("%T", "123"), "string");
   assertEquals(S("%.3T", "123"), "str");
 });
 
-Deno.test(function testPositional(): void {
+Deno.test("testPositional", function (): void {
   assertEquals(S("%[1]d%[2]d", 1, 2), "12");
   assertEquals(S("%[2]d%[1]d", 1, 2), "21");
 });
 
-Deno.test(function testSharp(): void {
+Deno.test("testSharp", function (): void {
   assertEquals(S("%#x", "123"), "0x313233");
   assertEquals(S("%#X", "123"), "0X313233");
   assertEquals(S("%#x", 123), "0x7b");
@@ -179,7 +179,7 @@ Deno.test(function testSharp(): void {
   assertEquals(S("%#b", 4), "0b100");
 });
 
-Deno.test(function testWidthAndPrecision(): void {
+Deno.test("testWidthAndPrecision", function (): void {
   assertEquals(
     S("%9.99d", 9),
     // eslint-disable-next-line max-len
@@ -205,21 +205,21 @@ Deno.test(function testWidthAndPrecision(): void {
   assertEquals(S("%#*x", 4, 1), " 0x1");
 });
 
-Deno.test(function testDash(): void {
+Deno.test("testDash", function (): void {
   assertEquals(S("%-2s", "a"), "a ");
   assertEquals(S("%-2d", 1), "1 ");
 });
-Deno.test(function testPlus(): void {
+Deno.test("testPlus", function (): void {
   assertEquals(S("%-+3d", 1), "+1 ");
   assertEquals(S("%+3d", 1), " +1");
   assertEquals(S("%+3d", -1), " -1");
 });
 
-Deno.test(function testSpace(): void {
+Deno.test("testSpace", function (): void {
   assertEquals(S("% -3d", 3), " 3 ");
 });
 
-Deno.test(function testZero(): void {
+Deno.test("testZero", function (): void {
   assertEquals(S("%04s", "a"), "000a");
 });
 
@@ -576,7 +576,7 @@ const tests: Array<[string, any, string]> = [
   ["% +07.2f", -1.0, "-001.00"],
 ];
 
-Deno.test(function testThorough(): void {
+Deno.test("testThorough", function (): void {
   tests.forEach((t, i): void => {
     //            p(t)
     const is = S(t[0], t[1]);
@@ -589,7 +589,7 @@ Deno.test(function testThorough(): void {
   });
 });
 
-Deno.test(function testWeirdos(): void {
+Deno.test("testWeirdos", function (): void {
   assertEquals(S("%.d", 9), "9");
   assertEquals(
     S("dec[%d]=%d hex[%[1]d]=%#x oct[%[1]d]=%#o %s", 1, 255, "Third"),
@@ -597,7 +597,7 @@ Deno.test(function testWeirdos(): void {
   );
 });
 
-Deno.test(function formatV(): void {
+Deno.test("formatV", function (): void {
   const a = { a: { a: { a: { a: { a: { a: { a: {} } } } } } } };
   assertEquals(S("%v", a), "[object Object]");
   assertEquals(S("%#v", a), "{ a: { a: { a: { a: [Object] } } } }");
@@ -608,12 +608,12 @@ Deno.test(function formatV(): void {
   assertEquals(S("%#.1v", a), "{ a: [Object] }");
 });
 
-Deno.test(function formatJ(): void {
+Deno.test("formatJ", function (): void {
   const a = { a: { a: { a: { a: { a: { a: { a: {} } } } } } } };
   assertEquals(S("%j", a), `{"a":{"a":{"a":{"a":{"a":{"a":{"a":{}}}}}}}}`);
 });
 
-Deno.test(function flagLessThan(): void {
+Deno.test("flagLessThan", function (): void {
   const a = { a: { a: { a: { a: { a: { a: { a: {} } } } } } } };
   const aArray = [a, a, a];
   assertEquals(
@@ -624,7 +624,7 @@ Deno.test(function flagLessThan(): void {
   assertEquals(S("%<.2f", fArray), "[ 1.23, 0.99, 123456789.57 ]");
 });
 
-Deno.test(function testErrors(): void {
+Deno.test("testErrors", function (): void {
   // wrong type : TODO strict mode ...
   //assertEquals(S("%f", "not a number"), "%!(BADTYPE flag=f type=string)")
   assertEquals(S("A %h", ""), "A %!(BAD VERB 'h')");

--- a/std/fs/empty_dir_test.ts
+++ b/std/fs/empty_dir_test.ts
@@ -11,7 +11,7 @@ import { emptyDir, emptyDirSync } from "./empty_dir.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
 
-Deno.test(async function emptyDirIfItNotExist(): Promise<void> {
+Deno.test("emptyDirIfItNotExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "empty_dir_test_1");
   const testNestDir = path.join(testDir, "nest");
   // empty a dir which not exist. then it will create new one
@@ -27,7 +27,7 @@ Deno.test(async function emptyDirIfItNotExist(): Promise<void> {
   }
 });
 
-Deno.test(function emptyDirSyncIfItNotExist(): void {
+Deno.test("emptyDirSyncIfItNotExist", function (): void {
   const testDir = path.join(testdataDir, "empty_dir_test_2");
   const testNestDir = path.join(testDir, "nest");
   // empty a dir which not exist. then it will create new one
@@ -43,7 +43,7 @@ Deno.test(function emptyDirSyncIfItNotExist(): void {
   }
 });
 
-Deno.test(async function emptyDirIfItExist(): Promise<void> {
+Deno.test("emptyDirIfItExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "empty_dir_test_3");
   const testNestDir = path.join(testDir, "nest");
   // create test dir
@@ -86,7 +86,7 @@ Deno.test(async function emptyDirIfItExist(): Promise<void> {
   }
 });
 
-Deno.test(function emptyDirSyncIfItExist(): void {
+Deno.test("emptyDirSyncIfItExist", function (): void {
   const testDir = path.join(testdataDir, "empty_dir_test_4");
   const testNestDir = path.join(testDir, "nest");
   // create test dir

--- a/std/fs/ensure_dir_test.ts
+++ b/std/fs/ensure_dir_test.ts
@@ -6,7 +6,7 @@ import { ensureFile, ensureFileSync } from "./ensure_file.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
 
-Deno.test(async function ensureDirIfItNotExist(): Promise<void> {
+Deno.test("ensureDirIfItNotExist", async function (): Promise<void> {
   const baseDir = path.join(testdataDir, "ensure_dir_not_exist");
   const testDir = path.join(baseDir, "test");
 
@@ -23,7 +23,7 @@ Deno.test(async function ensureDirIfItNotExist(): Promise<void> {
   await Deno.remove(baseDir, { recursive: true });
 });
 
-Deno.test(function ensureDirSyncIfItNotExist(): void {
+Deno.test("ensureDirSyncIfItNotExist", function (): void {
   const baseDir = path.join(testdataDir, "ensure_dir_sync_not_exist");
   const testDir = path.join(baseDir, "test");
 
@@ -34,7 +34,7 @@ Deno.test(function ensureDirSyncIfItNotExist(): void {
   Deno.removeSync(baseDir, { recursive: true });
 });
 
-Deno.test(async function ensureDirIfItExist(): Promise<void> {
+Deno.test("ensureDirIfItExist", async function (): Promise<void> {
   const baseDir = path.join(testdataDir, "ensure_dir_exist");
   const testDir = path.join(baseDir, "test");
 
@@ -54,7 +54,7 @@ Deno.test(async function ensureDirIfItExist(): Promise<void> {
   await Deno.remove(baseDir, { recursive: true });
 });
 
-Deno.test(function ensureDirSyncIfItExist(): void {
+Deno.test("ensureDirSyncIfItExist", function (): void {
   const baseDir = path.join(testdataDir, "ensure_dir_sync_exist");
   const testDir = path.join(baseDir, "test");
 
@@ -71,7 +71,7 @@ Deno.test(function ensureDirSyncIfItExist(): void {
   Deno.removeSync(baseDir, { recursive: true });
 });
 
-Deno.test(async function ensureDirIfItAsFile(): Promise<void> {
+Deno.test("ensureDirIfItAsFile", async function (): Promise<void> {
   const baseDir = path.join(testdataDir, "ensure_dir_exist_file");
   const testFile = path.join(baseDir, "test");
 
@@ -88,7 +88,7 @@ Deno.test(async function ensureDirIfItAsFile(): Promise<void> {
   await Deno.remove(baseDir, { recursive: true });
 });
 
-Deno.test(function ensureDirSyncIfItAsFile(): void {
+Deno.test("ensureDirSyncIfItAsFile", function (): void {
   const baseDir = path.join(testdataDir, "ensure_dir_exist_file_async");
   const testFile = path.join(baseDir, "test");
 

--- a/std/fs/ensure_file_test.ts
+++ b/std/fs/ensure_file_test.ts
@@ -5,7 +5,7 @@ import { ensureFile, ensureFileSync } from "./ensure_file.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
 
-Deno.test(async function ensureFileIfItNotExist(): Promise<void> {
+Deno.test("ensureFileIfItNotExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "ensure_file_1");
   const testFile = path.join(testDir, "test.txt");
 
@@ -22,7 +22,7 @@ Deno.test(async function ensureFileIfItNotExist(): Promise<void> {
   await Deno.remove(testDir, { recursive: true });
 });
 
-Deno.test(function ensureFileSyncIfItNotExist(): void {
+Deno.test("ensureFileSyncIfItNotExist", function (): void {
   const testDir = path.join(testdataDir, "ensure_file_2");
   const testFile = path.join(testDir, "test.txt");
 
@@ -36,7 +36,7 @@ Deno.test(function ensureFileSyncIfItNotExist(): void {
   Deno.removeSync(testDir, { recursive: true });
 });
 
-Deno.test(async function ensureFileIfItExist(): Promise<void> {
+Deno.test("ensureFileIfItExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "ensure_file_3");
   const testFile = path.join(testDir, "test.txt");
 
@@ -56,7 +56,7 @@ Deno.test(async function ensureFileIfItExist(): Promise<void> {
   await Deno.remove(testDir, { recursive: true });
 });
 
-Deno.test(function ensureFileSyncIfItExist(): void {
+Deno.test("ensureFileSyncIfItExist", function (): void {
   const testDir = path.join(testdataDir, "ensure_file_4");
   const testFile = path.join(testDir, "test.txt");
 
@@ -73,7 +73,7 @@ Deno.test(function ensureFileSyncIfItExist(): void {
   Deno.removeSync(testDir, { recursive: true });
 });
 
-Deno.test(async function ensureFileIfItExistAsDir(): Promise<void> {
+Deno.test("ensureFileIfItExistAsDir", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "ensure_file_5");
 
   await Deno.mkdir(testDir, { recursive: true });
@@ -89,7 +89,7 @@ Deno.test(async function ensureFileIfItExistAsDir(): Promise<void> {
   await Deno.remove(testDir, { recursive: true });
 });
 
-Deno.test(function ensureFileSyncIfItExistAsDir(): void {
+Deno.test("ensureFileSyncIfItExistAsDir", function (): void {
   const testDir = path.join(testdataDir, "ensure_file_6");
 
   Deno.mkdirSync(testDir, { recursive: true });

--- a/std/fs/ensure_link_test.ts
+++ b/std/fs/ensure_link_test.ts
@@ -10,7 +10,7 @@ import { ensureLink, ensureLinkSync } from "./ensure_link.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
 
-Deno.test(async function ensureLinkIfItNotExist(): Promise<void> {
+Deno.test("ensureLinkIfItNotExist", async function (): Promise<void> {
   const srcDir = path.join(testdataDir, "ensure_link_1");
   const destDir = path.join(testdataDir, "ensure_link_1_2");
   const testFile = path.join(srcDir, "test.txt");
@@ -25,7 +25,7 @@ Deno.test(async function ensureLinkIfItNotExist(): Promise<void> {
   await Deno.remove(destDir, { recursive: true });
 });
 
-Deno.test(function ensureLinkSyncIfItNotExist(): void {
+Deno.test("ensureLinkSyncIfItNotExist", function (): void {
   const testDir = path.join(testdataDir, "ensure_link_2");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
@@ -37,7 +37,7 @@ Deno.test(function ensureLinkSyncIfItNotExist(): void {
   Deno.removeSync(testDir, { recursive: true });
 });
 
-Deno.test(async function ensureLinkIfItExist(): Promise<void> {
+Deno.test("ensureLinkIfItExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "ensure_link_3");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
@@ -84,7 +84,7 @@ Deno.test(async function ensureLinkIfItExist(): Promise<void> {
   await Deno.remove(testDir, { recursive: true });
 });
 
-Deno.test(function ensureLinkSyncIfItExist(): void {
+Deno.test("ensureLinkSyncIfItExist", function (): void {
   const testDir = path.join(testdataDir, "ensure_link_4");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
@@ -132,7 +132,7 @@ Deno.test(function ensureLinkSyncIfItExist(): void {
   Deno.removeSync(testDir, { recursive: true });
 });
 
-Deno.test(async function ensureLinkDirectoryIfItExist(): Promise<void> {
+Deno.test("ensureLinkDirectoryIfItExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "ensure_link_origin_3");
   const linkDir = path.join(testdataDir, "ensure_link_link_3");
   const testFile = path.join(testDir, "test.txt");
@@ -151,7 +151,7 @@ Deno.test(async function ensureLinkDirectoryIfItExist(): Promise<void> {
   Deno.removeSync(testDir, { recursive: true });
 });
 
-Deno.test(function ensureLinkSyncDirectoryIfItExist(): void {
+Deno.test("ensureLinkSyncDirectoryIfItExist", function (): void {
   const testDir = path.join(testdataDir, "ensure_link_origin_3");
   const linkDir = path.join(testdataDir, "ensure_link_link_3");
   const testFile = path.join(testDir, "test.txt");

--- a/std/fs/ensure_symlink_test.ts
+++ b/std/fs/ensure_symlink_test.ts
@@ -11,7 +11,7 @@ import { ensureSymlink, ensureSymlinkSync } from "./ensure_symlink.ts";
 const testdataDir = path.resolve("fs", "testdata");
 const isWindows = Deno.build.os === "win";
 
-Deno.test(async function ensureSymlinkIfItNotExist(): Promise<void> {
+Deno.test("ensureSymlinkIfItNotExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "link_file_1");
   const testFile = path.join(testDir, "test.txt");
 
@@ -30,7 +30,7 @@ Deno.test(async function ensureSymlinkIfItNotExist(): Promise<void> {
   );
 });
 
-Deno.test(function ensureSymlinkSyncIfItNotExist(): void {
+Deno.test("ensureSymlinkSyncIfItNotExist", function (): void {
   const testDir = path.join(testdataDir, "link_file_2");
   const testFile = path.join(testDir, "test.txt");
 
@@ -44,7 +44,7 @@ Deno.test(function ensureSymlinkSyncIfItNotExist(): void {
   });
 });
 
-Deno.test(async function ensureSymlinkIfItExist(): Promise<void> {
+Deno.test("ensureSymlinkIfItExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "link_file_3");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
@@ -73,7 +73,7 @@ Deno.test(async function ensureSymlinkIfItExist(): Promise<void> {
   await Deno.remove(testDir, { recursive: true });
 });
 
-Deno.test(function ensureSymlinkSyncIfItExist(): void {
+Deno.test("ensureSymlinkSyncIfItExist", function (): void {
   const testDir = path.join(testdataDir, "link_file_4");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
@@ -103,7 +103,7 @@ Deno.test(function ensureSymlinkSyncIfItExist(): void {
   Deno.removeSync(testDir, { recursive: true });
 });
 
-Deno.test(async function ensureSymlinkDirectoryIfItExist(): Promise<void> {
+Deno.test("ensureSymlinkDirectoryIfItExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "link_file_origin_3");
   const linkDir = path.join(testdataDir, "link_file_link_3");
   const testFile = path.join(testDir, "test.txt");
@@ -135,7 +135,7 @@ Deno.test(async function ensureSymlinkDirectoryIfItExist(): Promise<void> {
   await Deno.remove(testDir, { recursive: true });
 });
 
-Deno.test(function ensureSymlinkSyncDirectoryIfItExist(): void {
+Deno.test("ensureSymlinkSyncDirectoryIfItExist", function (): void {
   const testDir = path.join(testdataDir, "link_file_origin_3");
   const linkDir = path.join(testdataDir, "link_file_link_3");
   const testFile = path.join(testDir, "test.txt");

--- a/std/fs/expand_glob_test.ts
+++ b/std/fs/expand_glob_test.ts
@@ -51,7 +51,7 @@ const EG_OPTIONS: ExpandGlobOptions = {
   globstar: false,
 };
 
-Deno.test(async function expandGlobWildcard(): Promise<void> {
+Deno.test("expandGlobWildcard", async function (): Promise<void> {
   const options = EG_OPTIONS;
   assertEquals(await expandGlobArray("*", options), [
     "abc",
@@ -61,12 +61,12 @@ Deno.test(async function expandGlobWildcard(): Promise<void> {
   ]);
 });
 
-Deno.test(async function expandGlobTrailingSeparator(): Promise<void> {
+Deno.test("expandGlobTrailingSeparator", async function (): Promise<void> {
   const options = EG_OPTIONS;
   assertEquals(await expandGlobArray("*/", options), ["subdir"]);
 });
 
-Deno.test(async function expandGlobParent(): Promise<void> {
+Deno.test("expandGlobParent", async function (): Promise<void> {
   const options = EG_OPTIONS;
   assertEquals(await expandGlobArray("subdir/../*", options), [
     "abc",
@@ -76,7 +76,7 @@ Deno.test(async function expandGlobParent(): Promise<void> {
   ]);
 });
 
-Deno.test(async function expandGlobExt(): Promise<void> {
+Deno.test("expandGlobExt", async function (): Promise<void> {
   const options = { ...EG_OPTIONS, extended: true };
   assertEquals(await expandGlobArray("abc?(def|ghi)", options), [
     "abc",
@@ -96,7 +96,7 @@ Deno.test(async function expandGlobExt(): Promise<void> {
   assertEquals(await expandGlobArray("abc!(def|ghi)", options), ["abc"]);
 });
 
-Deno.test(async function expandGlobGlobstar(): Promise<void> {
+Deno.test("expandGlobGlobstar", async function (): Promise<void> {
   const options = { ...EG_OPTIONS, globstar: true };
   assertEquals(
     await expandGlobArray(joinGlobs(["**", "abc"], options), options),
@@ -104,7 +104,7 @@ Deno.test(async function expandGlobGlobstar(): Promise<void> {
   );
 });
 
-Deno.test(async function expandGlobGlobstarParent(): Promise<void> {
+Deno.test("expandGlobGlobstarParent", async function (): Promise<void> {
   const options = { ...EG_OPTIONS, globstar: true };
   assertEquals(
     await expandGlobArray(joinGlobs(["subdir", "**", ".."], options), options),
@@ -112,12 +112,12 @@ Deno.test(async function expandGlobGlobstarParent(): Promise<void> {
   );
 });
 
-Deno.test(async function expandGlobIncludeDirs(): Promise<void> {
+Deno.test("expandGlobIncludeDirs", async function (): Promise<void> {
   const options = { ...EG_OPTIONS, includeDirs: false };
   assertEquals(await expandGlobArray("subdir", options), []);
 });
 
-Deno.test(async function expandGlobPermError(): Promise<void> {
+Deno.test("expandGlobPermError", async function (): Promise<void> {
   const exampleUrl = new URL("testdata/expand_wildcard.js", import.meta.url);
   const p = run({
     cmd: [execPath(), exampleUrl.toString()],

--- a/std/fs/move_test.ts
+++ b/std/fs/move_test.ts
@@ -12,7 +12,7 @@ import { exists, existsSync } from "./exists.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
 
-Deno.test(async function moveDirectoryIfSrcNotExists(): Promise<void> {
+Deno.test("moveDirectoryIfSrcNotExists", async function (): Promise<void> {
   const srcDir = path.join(testdataDir, "move_test_src_1");
   const destDir = path.join(testdataDir, "move_test_dest_1");
   // if src directory not exist
@@ -23,7 +23,7 @@ Deno.test(async function moveDirectoryIfSrcNotExists(): Promise<void> {
   );
 });
 
-Deno.test(async function moveDirectoryIfDestNotExists(): Promise<void> {
+Deno.test("moveDirectoryIfDestNotExists", async function (): Promise<void> {
   const srcDir = path.join(testdataDir, "move_test_src_2");
   const destDir = path.join(testdataDir, "move_test_dest_2");
 
@@ -42,28 +42,29 @@ Deno.test(async function moveDirectoryIfDestNotExists(): Promise<void> {
   await Deno.remove(destDir);
 });
 
-Deno.test(async function moveDirectoryIfDestNotExistsAndOverwrite(): Promise<
-  void
-> {
-  const srcDir = path.join(testdataDir, "move_test_src_2");
-  const destDir = path.join(testdataDir, "move_test_dest_2");
+Deno.test(
+  "moveDirectoryIfDestNotExistsAndOverwrite",
+  async function (): Promise<void> {
+    const srcDir = path.join(testdataDir, "move_test_src_2");
+    const destDir = path.join(testdataDir, "move_test_dest_2");
 
-  await Deno.mkdir(srcDir, { recursive: true });
+    await Deno.mkdir(srcDir, { recursive: true });
 
-  // if dest directory not exist
-  await assertThrowsAsync(
-    async (): Promise<void> => {
-      await move(srcDir, destDir, { overwrite: true });
-      throw new Error("should not throw error");
-    },
-    Error,
-    "should not throw error"
-  );
+    // if dest directory not exist
+    await assertThrowsAsync(
+      async (): Promise<void> => {
+        await move(srcDir, destDir, { overwrite: true });
+        throw new Error("should not throw error");
+      },
+      Error,
+      "should not throw error"
+    );
 
-  await Deno.remove(destDir);
-});
+    await Deno.remove(destDir);
+  }
+);
 
-Deno.test(async function moveFileIfSrcNotExists(): Promise<void> {
+Deno.test("moveFileIfSrcNotExists", async function (): Promise<void> {
   const srcFile = path.join(testdataDir, "move_test_src_3", "test.txt");
   const destFile = path.join(testdataDir, "move_test_dest_3", "test.txt");
 
@@ -75,7 +76,7 @@ Deno.test(async function moveFileIfSrcNotExists(): Promise<void> {
   );
 });
 
-Deno.test(async function moveFileIfDestExists(): Promise<void> {
+Deno.test("moveFileIfDestExists", async function (): Promise<void> {
   const srcDir = path.join(testdataDir, "move_test_src_4");
   const destDir = path.join(testdataDir, "move_test_dest_4");
   const srcFile = path.join(srcDir, "test.txt");
@@ -125,7 +126,7 @@ Deno.test(async function moveFileIfDestExists(): Promise<void> {
   ]);
 });
 
-Deno.test(async function moveDirectory(): Promise<void> {
+Deno.test("moveDirectory", async function (): Promise<void> {
   const srcDir = path.join(testdataDir, "move_test_src_5");
   const destDir = path.join(testdataDir, "move_test_dest_5");
   const srcFile = path.join(srcDir, "test.txt");
@@ -150,42 +151,43 @@ Deno.test(async function moveDirectory(): Promise<void> {
   await Deno.remove(destDir, { recursive: true });
 });
 
-Deno.test(async function moveIfSrcAndDestDirectoryExistsAndOverwrite(): Promise<
-  void
-> {
-  const srcDir = path.join(testdataDir, "move_test_src_6");
-  const destDir = path.join(testdataDir, "move_test_dest_6");
-  const srcFile = path.join(srcDir, "test.txt");
-  const destFile = path.join(destDir, "test.txt");
-  const srcContent = new TextEncoder().encode("src");
-  const destContent = new TextEncoder().encode("dest");
+Deno.test(
+  "moveIfSrcAndDestDirectoryExistsAndOverwrite",
+  async function (): Promise<void> {
+    const srcDir = path.join(testdataDir, "move_test_src_6");
+    const destDir = path.join(testdataDir, "move_test_dest_6");
+    const srcFile = path.join(srcDir, "test.txt");
+    const destFile = path.join(destDir, "test.txt");
+    const srcContent = new TextEncoder().encode("src");
+    const destContent = new TextEncoder().encode("dest");
 
-  await Promise.all([
-    Deno.mkdir(srcDir, { recursive: true }),
-    Deno.mkdir(destDir, { recursive: true }),
-  ]);
-  assertEquals(await exists(srcDir), true);
-  assertEquals(await exists(destDir), true);
-  await Promise.all([
-    Deno.writeFile(srcFile, srcContent),
-    Deno.writeFile(destFile, destContent),
-  ]);
+    await Promise.all([
+      Deno.mkdir(srcDir, { recursive: true }),
+      Deno.mkdir(destDir, { recursive: true }),
+    ]);
+    assertEquals(await exists(srcDir), true);
+    assertEquals(await exists(destDir), true);
+    await Promise.all([
+      Deno.writeFile(srcFile, srcContent),
+      Deno.writeFile(destFile, destContent),
+    ]);
 
-  await move(srcDir, destDir, { overwrite: true });
+    await move(srcDir, destDir, { overwrite: true });
 
-  assertEquals(await exists(srcDir), false);
-  assertEquals(await exists(destDir), true);
-  assertEquals(await exists(destFile), true);
+    assertEquals(await exists(srcDir), false);
+    assertEquals(await exists(destDir), true);
+    assertEquals(await exists(destFile), true);
 
-  const destFileContent = new TextDecoder().decode(
-    await Deno.readFile(destFile)
-  );
-  assertEquals(destFileContent, "src");
+    const destFileContent = new TextDecoder().decode(
+      await Deno.readFile(destFile)
+    );
+    assertEquals(destFileContent, "src");
 
-  await Deno.remove(destDir, { recursive: true });
-});
+    await Deno.remove(destDir, { recursive: true });
+  }
+);
 
-Deno.test(async function moveIntoSubDir(): Promise<void> {
+Deno.test("moveIntoSubDir", async function (): Promise<void> {
   const srcDir = path.join(testdataDir, "move_test_src_7");
   const destDir = path.join(srcDir, "nest");
 
@@ -201,7 +203,7 @@ Deno.test(async function moveIntoSubDir(): Promise<void> {
   await Deno.remove(srcDir, { recursive: true });
 });
 
-Deno.test(function moveSyncDirectoryIfSrcNotExists(): void {
+Deno.test("moveSyncDirectoryIfSrcNotExists", function (): void {
   const srcDir = path.join(testdataDir, "move_sync_test_src_1");
   const destDir = path.join(testdataDir, "move_sync_test_dest_1");
   // if src directory not exist
@@ -210,7 +212,7 @@ Deno.test(function moveSyncDirectoryIfSrcNotExists(): void {
   });
 });
 
-Deno.test(function moveSyncDirectoryIfDestNotExists(): void {
+Deno.test("moveSyncDirectoryIfDestNotExists", function (): void {
   const srcDir = path.join(testdataDir, "move_sync_test_src_2");
   const destDir = path.join(testdataDir, "move_sync_test_dest_2");
 
@@ -229,7 +231,7 @@ Deno.test(function moveSyncDirectoryIfDestNotExists(): void {
   Deno.removeSync(destDir);
 });
 
-Deno.test(function moveSyncDirectoryIfDestNotExistsAndOverwrite(): void {
+Deno.test("moveSyncDirectoryIfDestNotExistsAndOverwrite", function (): void {
   const srcDir = path.join(testdataDir, "move_sync_test_src_2");
   const destDir = path.join(testdataDir, "move_sync_test_dest_2");
 
@@ -248,7 +250,7 @@ Deno.test(function moveSyncDirectoryIfDestNotExistsAndOverwrite(): void {
   Deno.removeSync(destDir);
 });
 
-Deno.test(function moveSyncFileIfSrcNotExists(): void {
+Deno.test("moveSyncFileIfSrcNotExists", function (): void {
   const srcFile = path.join(testdataDir, "move_sync_test_src_3", "test.txt");
   const destFile = path.join(testdataDir, "move_sync_test_dest_3", "test.txt");
 
@@ -258,7 +260,7 @@ Deno.test(function moveSyncFileIfSrcNotExists(): void {
   });
 });
 
-Deno.test(function moveSyncFileIfDestExists(): void {
+Deno.test("moveSyncFileIfDestExists", function (): void {
   const srcDir = path.join(testdataDir, "move_sync_test_src_4");
   const destDir = path.join(testdataDir, "move_sync_test_dest_4");
   const srcFile = path.join(srcDir, "test.txt");
@@ -305,7 +307,7 @@ Deno.test(function moveSyncFileIfDestExists(): void {
   Deno.removeSync(destDir, { recursive: true });
 });
 
-Deno.test(function moveSyncDirectory(): void {
+Deno.test("moveSyncDirectory", function (): void {
   const srcDir = path.join(testdataDir, "move_sync_test_src_5");
   const destDir = path.join(testdataDir, "move_sync_test_dest_5");
   const srcFile = path.join(srcDir, "test.txt");
@@ -328,7 +330,7 @@ Deno.test(function moveSyncDirectory(): void {
   Deno.removeSync(destDir, { recursive: true });
 });
 
-Deno.test(function moveSyncIfSrcAndDestDirectoryExistsAndOverwrite(): void {
+Deno.test("moveSyncIfSrcAndDestDirectoryExistsAndOverwrite", function (): void {
   const srcDir = path.join(testdataDir, "move_sync_test_src_6");
   const destDir = path.join(testdataDir, "move_sync_test_dest_6");
   const srcFile = path.join(srcDir, "test.txt");
@@ -355,7 +357,7 @@ Deno.test(function moveSyncIfSrcAndDestDirectoryExistsAndOverwrite(): void {
   Deno.removeSync(destDir, { recursive: true });
 });
 
-Deno.test(function moveSyncIntoSubDir(): void {
+Deno.test("moveSyncIntoSubDir", function (): void {
   const srcDir = path.join(testdataDir, "move_sync_test_src_7");
   const destDir = path.join(srcDir, "nest");
 

--- a/std/fs/read_file_str_test.ts
+++ b/std/fs/read_file_str_test.ts
@@ -4,14 +4,14 @@ import { readFileStrSync, readFileStr } from "./read_file_str.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
 
-Deno.test(function testReadFileSync(): void {
+Deno.test("testReadFileSync", function (): void {
   const jsonFile = path.join(testdataDir, "json_valid_obj.json");
   const strFile = readFileStrSync(jsonFile);
   assert(typeof strFile === "string");
   assert(strFile.length > 0);
 });
 
-Deno.test(async function testReadFile(): Promise<void> {
+Deno.test("testReadFile", async function (): Promise<void> {
   const jsonFile = path.join(testdataDir, "json_valid_obj.json");
   const strFile = await readFileStr(jsonFile);
   assert(typeof strFile === "string");

--- a/std/fs/read_json_test.ts
+++ b/std/fs/read_json_test.ts
@@ -9,7 +9,7 @@ import { readJson, readJsonSync } from "./read_json.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
 
-Deno.test(async function readJsonFileNotExists(): Promise<void> {
+Deno.test("readJsonFileNotExists", async function (): Promise<void> {
   const emptyJsonFile = path.join(testdataDir, "json_not_exists.json");
 
   await assertThrowsAsync(
@@ -19,7 +19,7 @@ Deno.test(async function readJsonFileNotExists(): Promise<void> {
   );
 });
 
-Deno.test(async function readEmptyJsonFile(): Promise<void> {
+Deno.test("readEmptyJsonFile", async function (): Promise<void> {
   const emptyJsonFile = path.join(testdataDir, "json_empty.json");
 
   await assertThrowsAsync(
@@ -29,7 +29,7 @@ Deno.test(async function readEmptyJsonFile(): Promise<void> {
   );
 });
 
-Deno.test(async function readInvalidJsonFile(): Promise<void> {
+Deno.test("readInvalidJsonFile", async function (): Promise<void> {
   const invalidJsonFile = path.join(testdataDir, "json_invalid.json");
 
   await assertThrowsAsync(
@@ -39,7 +39,7 @@ Deno.test(async function readInvalidJsonFile(): Promise<void> {
   );
 });
 
-Deno.test(async function readValidArrayJsonFile(): Promise<void> {
+Deno.test("readValidArrayJsonFile", async function (): Promise<void> {
   const invalidJsonFile = path.join(testdataDir, "json_valid_array.json");
 
   const json = await readJson(invalidJsonFile);
@@ -47,7 +47,7 @@ Deno.test(async function readValidArrayJsonFile(): Promise<void> {
   assertEquals(json, ["1", "2", "3"]);
 });
 
-Deno.test(async function readValidObjJsonFile(): Promise<void> {
+Deno.test("readValidObjJsonFile", async function (): Promise<void> {
   const invalidJsonFile = path.join(testdataDir, "json_valid_obj.json");
 
   const json = await readJson(invalidJsonFile);
@@ -55,13 +55,15 @@ Deno.test(async function readValidObjJsonFile(): Promise<void> {
   assertEquals(json, { key1: "value1", key2: "value2" });
 });
 
-Deno.test(async function readValidObjJsonFileWithRelativePath(): Promise<void> {
+Deno.test("readValidObjJsonFileWithRelativePath", async function (): Promise<
+  void
+> {
   const json = await readJson("./fs/testdata/json_valid_obj.json");
 
   assertEquals(json, { key1: "value1", key2: "value2" });
 });
 
-Deno.test(function readJsonFileNotExistsSync(): void {
+Deno.test("readJsonFileNotExistsSync", function (): void {
   const emptyJsonFile = path.join(testdataDir, "json_not_exists.json");
 
   assertThrows((): void => {
@@ -69,7 +71,7 @@ Deno.test(function readJsonFileNotExistsSync(): void {
   });
 });
 
-Deno.test(function readEmptyJsonFileSync(): void {
+Deno.test("readEmptyJsonFileSync", function (): void {
   const emptyJsonFile = path.join(testdataDir, "json_empty.json");
 
   assertThrows((): void => {
@@ -77,7 +79,7 @@ Deno.test(function readEmptyJsonFileSync(): void {
   });
 });
 
-Deno.test(function readInvalidJsonFile(): void {
+Deno.test("readInvalidJsonFile", function (): void {
   const invalidJsonFile = path.join(testdataDir, "json_invalid.json");
 
   assertThrows((): void => {
@@ -85,7 +87,7 @@ Deno.test(function readInvalidJsonFile(): void {
   });
 });
 
-Deno.test(function readValidArrayJsonFileSync(): void {
+Deno.test("readValidArrayJsonFileSync", function (): void {
   const invalidJsonFile = path.join(testdataDir, "json_valid_array.json");
 
   const json = readJsonSync(invalidJsonFile);
@@ -93,7 +95,7 @@ Deno.test(function readValidArrayJsonFileSync(): void {
   assertEquals(json, ["1", "2", "3"]);
 });
 
-Deno.test(function readValidObjJsonFileSync(): void {
+Deno.test("readValidObjJsonFileSync", function (): void {
   const invalidJsonFile = path.join(testdataDir, "json_valid_obj.json");
 
   const json = readJsonSync(invalidJsonFile);
@@ -101,7 +103,7 @@ Deno.test(function readValidObjJsonFileSync(): void {
   assertEquals(json, { key1: "value1", key2: "value2" });
 });
 
-Deno.test(function readValidObjJsonFileSyncWithRelativePath(): void {
+Deno.test("readValidObjJsonFileSyncWithRelativePath", function (): void {
   const json = readJsonSync("./fs/testdata/json_valid_obj.json");
 
   assertEquals(json, { key1: "value1", key2: "value2" });

--- a/std/fs/utils_test.ts
+++ b/std/fs/utils_test.ts
@@ -8,7 +8,7 @@ import { ensureDirSync } from "./ensure_dir.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
 
-Deno.test(function _isSubdir(): void {
+Deno.test("_isSubdir", function (): void {
   const pairs = [
     ["", "", false, path.posix.sep],
     ["/first/second", "/first", false, path.posix.sep],
@@ -33,7 +33,7 @@ Deno.test(function _isSubdir(): void {
   });
 });
 
-Deno.test(function _getFileInfoType(): void {
+Deno.test("_getFileInfoType", function (): void {
   const pairs = [
     [path.join(testdataDir, "file_type_1"), "file"],
     [path.join(testdataDir, "file_type_dir_1"), "dir"],

--- a/std/fs/write_file_str_test.ts
+++ b/std/fs/write_file_str_test.ts
@@ -4,7 +4,7 @@ import { writeFileStr, writeFileStrSync } from "./write_file_str.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
 
-Deno.test(function testReadFileSync(): void {
+Deno.test("testReadFileSync", function (): void {
   const jsonFile = path.join(testdataDir, "write_file_1.json");
   const content = "write_file_str_test";
   writeFileStrSync(jsonFile, content);
@@ -20,7 +20,7 @@ Deno.test(function testReadFileSync(): void {
   assertEquals(content, result);
 });
 
-Deno.test(async function testReadFile(): Promise<void> {
+Deno.test("testReadFile", async function (): Promise<void> {
   const jsonFile = path.join(testdataDir, "write_file_2.json");
   const content = "write_file_str_test";
   await writeFileStr(jsonFile, content);

--- a/std/fs/write_json_test.ts
+++ b/std/fs/write_json_test.ts
@@ -9,7 +9,7 @@ import { writeJson, writeJsonSync } from "./write_json.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
 
-Deno.test(async function writeJsonIfNotExists(): Promise<void> {
+Deno.test("writeJsonIfNotExists", async function (): Promise<void> {
   const notExistsJsonFile = path.join(testdataDir, "file_not_exists.json");
 
   await assertThrowsAsync(
@@ -28,7 +28,7 @@ Deno.test(async function writeJsonIfNotExists(): Promise<void> {
   assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
 });
 
-Deno.test(async function writeJsonIfExists(): Promise<void> {
+Deno.test("writeJsonIfExists", async function (): Promise<void> {
   const existsJsonFile = path.join(testdataDir, "file_write_exists.json");
 
   await Deno.writeFile(existsJsonFile, new Uint8Array());
@@ -49,7 +49,7 @@ Deno.test(async function writeJsonIfExists(): Promise<void> {
   assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
 });
 
-Deno.test(async function writeJsonIfExistsAnInvalidJson(): Promise<void> {
+Deno.test("writeJsonIfExistsAnInvalidJson", async function (): Promise<void> {
   const existsInvalidJsonFile = path.join(
     testdataDir,
     "file_write_invalid.json"
@@ -74,7 +74,7 @@ Deno.test(async function writeJsonIfExistsAnInvalidJson(): Promise<void> {
   assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
 });
 
-Deno.test(async function writeJsonWithSpaces(): Promise<void> {
+Deno.test("writeJsonWithSpaces", async function (): Promise<void> {
   const existsJsonFile = path.join(testdataDir, "file_write_spaces.json");
 
   const invalidJsonContent = new TextEncoder().encode();
@@ -96,7 +96,7 @@ Deno.test(async function writeJsonWithSpaces(): Promise<void> {
   assertEquals(new TextDecoder().decode(content), `{\n  "a": "1"\n}`);
 });
 
-Deno.test(async function writeJsonWithReplacer(): Promise<void> {
+Deno.test("writeJsonWithReplacer", async function (): Promise<void> {
   const existsJsonFile = path.join(testdataDir, "file_write_replacer.json");
 
   const invalidJsonContent = new TextEncoder().encode();
@@ -124,7 +124,7 @@ Deno.test(async function writeJsonWithReplacer(): Promise<void> {
   assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
 });
 
-Deno.test(function writeJsonSyncIfNotExists(): void {
+Deno.test("writeJsonSyncIfNotExists", function (): void {
   const notExistsJsonFile = path.join(testdataDir, "file_not_exists_sync.json");
 
   assertThrows(
@@ -143,7 +143,7 @@ Deno.test(function writeJsonSyncIfNotExists(): void {
   assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
 });
 
-Deno.test(function writeJsonSyncIfExists(): void {
+Deno.test("writeJsonSyncIfExists", function (): void {
   const existsJsonFile = path.join(testdataDir, "file_write_exists_sync.json");
 
   Deno.writeFileSync(existsJsonFile, new Uint8Array());
@@ -164,7 +164,7 @@ Deno.test(function writeJsonSyncIfExists(): void {
   assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
 });
 
-Deno.test(function writeJsonSyncIfExistsAnInvalidJson(): void {
+Deno.test("writeJsonSyncIfExistsAnInvalidJson", function (): void {
   const existsInvalidJsonFile = path.join(
     testdataDir,
     "file_write_invalid_sync.json"
@@ -189,7 +189,7 @@ Deno.test(function writeJsonSyncIfExistsAnInvalidJson(): void {
   assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
 });
 
-Deno.test(function writeJsonWithSpaces(): void {
+Deno.test("writeJsonWithSpaces", function (): void {
   const existsJsonFile = path.join(testdataDir, "file_write_spaces_sync.json");
 
   const invalidJsonContent = new TextEncoder().encode();
@@ -211,7 +211,7 @@ Deno.test(function writeJsonWithSpaces(): void {
   assertEquals(new TextDecoder().decode(content), `{\n  "a": "1"\n}`);
 });
 
-Deno.test(function writeJsonWithReplacer(): void {
+Deno.test("writeJsonWithReplacer", function (): void {
   const existsJsonFile = path.join(
     testdataDir,
     "file_write_replacer_sync.json"

--- a/std/http/file_server_test.ts
+++ b/std/http/file_server_test.ts
@@ -50,7 +50,7 @@ test("file_server serveFile", async (): Promise<void> => {
   }
 });
 
-test(async function serveDirectory(): Promise<void> {
+test("serveDirectory", async function (): Promise<void> {
   await startFileServer();
   try {
     const res = await fetch("http://localhost:4500/");
@@ -72,7 +72,7 @@ test(async function serveDirectory(): Promise<void> {
   }
 });
 
-test(async function serveFallback(): Promise<void> {
+test("serveFallback", async function (): Promise<void> {
   await startFileServer();
   try {
     const res = await fetch("http://localhost:4500/badfile.txt");
@@ -85,7 +85,7 @@ test(async function serveFallback(): Promise<void> {
   }
 });
 
-test(async function serveWithUnorthodoxFilename(): Promise<void> {
+test("serveWithUnorthodoxFilename", async function (): Promise<void> {
   await startFileServer();
   try {
     let res = await fetch("http://localhost:4500/http/testdata/%");
@@ -103,7 +103,7 @@ test(async function serveWithUnorthodoxFilename(): Promise<void> {
   }
 });
 
-test(async function servePermissionDenied(): Promise<void> {
+test("servePermissionDenied", async function (): Promise<void> {
   const deniedServer = Deno.run({
     cmd: [Deno.execPath(), "run", "--allow-net", "http/file_server.ts"],
     stdout: "piped",
@@ -130,7 +130,7 @@ test(async function servePermissionDenied(): Promise<void> {
   }
 });
 
-test(async function printHelp(): Promise<void> {
+test("printHelp", async function (): Promise<void> {
   const helpProcess = Deno.run({
     cmd: [Deno.execPath(), "run", "http/file_server.ts", "--help"],
     stdout: "piped",

--- a/std/http/io_test.ts
+++ b/std/http/io_test.ts
@@ -211,7 +211,7 @@ test("parseHttpVersion", (): void => {
   }
 });
 
-test(async function writeUint8ArrayResponse(): Promise<void> {
+test("writeUint8ArrayResponse", async function (): Promise<void> {
   const shortText = "Hello";
 
   const body = new TextEncoder().encode(shortText);
@@ -244,7 +244,7 @@ test(async function writeUint8ArrayResponse(): Promise<void> {
   assertEquals(eof, Deno.EOF);
 });
 
-test(async function writeStringResponse(): Promise<void> {
+test("writeStringResponse", async function (): Promise<void> {
   const body = "Hello";
 
   const res: Response = { body };
@@ -276,7 +276,7 @@ test(async function writeStringResponse(): Promise<void> {
   assertEquals(eof, Deno.EOF);
 });
 
-test(async function writeStringReaderResponse(): Promise<void> {
+test("writeStringReaderResponse", async function (): Promise<void> {
   const shortText = "Hello";
 
   const body = new StringReader(shortText);
@@ -344,7 +344,7 @@ test("writeResponse with trailer", async () => {
   assertEquals(ret, exp);
 });
 
-test(async function readRequestError(): Promise<void> {
+test("readRequestError", async function (): Promise<void> {
   const input = `GET / HTTP/1.1
 malformedHeader
 `;
@@ -362,7 +362,7 @@ malformedHeader
 // Ported from Go
 // https://github.com/golang/go/blob/go1.12.5/src/net/http/request_test.go#L377-L443
 // TODO(zekth) fix tests
-test(async function testReadRequestError(): Promise<void> {
+test("testReadRequestError", async function (): Promise<void> {
   const testCases = [
     {
       in: "GET / HTTP/1.1\r\nheader: foo\r\n\r\n",

--- a/std/http/racing_server_test.ts
+++ b/std/http/racing_server_test.ts
@@ -58,7 +58,7 @@ content-length: 6
 Step7
 `;
 
-test(async function serverPipelineRace(): Promise<void> {
+test("serverPipelineRace", async function (): Promise<void> {
   await startServer();
 
   const conn = await connect({ port: 4501 });

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -54,7 +54,7 @@ const responseTests: ResponseTest[] = [
   },
 ];
 
-test(async function responseWrite(): Promise<void> {
+test("responseWrite", async function (): Promise<void> {
   for (const testCase of responseTests) {
     const buf = new Buffer();
     const bufw = new BufWriter(buf);
@@ -69,7 +69,7 @@ test(async function responseWrite(): Promise<void> {
   }
 });
 
-test(function requestContentLength(): void {
+test("requestContentLength", function (): void {
   // Has content length
   {
     const req = new ServerRequest();
@@ -122,7 +122,7 @@ function totalReader(r: Deno.Reader): TotalReader {
     },
   };
 }
-test(async function requestBodyWithContentLength(): Promise<void> {
+test("requestBodyWithContentLength", async function (): Promise<void> {
   {
     const req = new ServerRequest();
     req.headers = new Headers();
@@ -191,7 +191,7 @@ test("ServerRequest.finalize() should consume unread body / chunked, trailers", 
   assertEquals(req.headers.get("deno"), "land");
   assertEquals(req.headers.get("node"), "js");
 });
-test(async function requestBodyWithTransferEncoding(): Promise<void> {
+test("requestBodyWithTransferEncoding", async function (): Promise<void> {
   {
     const shortText = "Hello";
     const req = new ServerRequest();
@@ -240,7 +240,7 @@ test(async function requestBodyWithTransferEncoding(): Promise<void> {
   }
 });
 
-test(async function requestBodyReaderWithContentLength(): Promise<void> {
+test("requestBodyReaderWithContentLength", async function (): Promise<void> {
   {
     const shortText = "Hello";
     const req = new ServerRequest();
@@ -283,7 +283,7 @@ test(async function requestBodyReaderWithContentLength(): Promise<void> {
   }
 });
 
-test(async function requestBodyReaderWithTransferEncoding(): Promise<void> {
+test("requestBodyReaderWithTransferEncoding", async function (): Promise<void> {
   {
     const shortText = "Hello";
     const req = new ServerRequest();

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -40,7 +40,7 @@ async function readBytes(buf: BufReader): Promise<string> {
   return decoder.decode(b.subarray(0, nb));
 }
 
-Deno.test(async function bufioReaderSimple(): Promise<void> {
+Deno.test("bufioReaderSimple", async function (): Promise<void> {
   const data = "hello world";
   const b = new BufReader(stringsReader(data));
   const s = await readBytes(b);
@@ -108,7 +108,7 @@ const bufsizes: number[] = [
   4096,
 ];
 
-Deno.test(async function bufioBufReader(): Promise<void> {
+Deno.test("bufioBufReader", async function (): Promise<void> {
   const texts = new Array<string>(31);
   let str = "";
   let all = "";
@@ -136,7 +136,7 @@ Deno.test(async function bufioBufReader(): Promise<void> {
   }
 });
 
-Deno.test(async function bufioBufferFull(): Promise<void> {
+Deno.test("bufioBufferFull", async function (): Promise<void> {
   const longString =
     "And now, hello, world! It is the time for all good men to come to the" +
     " aid of their party";
@@ -157,7 +157,7 @@ Deno.test(async function bufioBufferFull(): Promise<void> {
   assertEquals(actual, "world!");
 });
 
-Deno.test(async function bufioReadString(): Promise<void> {
+Deno.test("bufioReadString", async function (): Promise<void> {
   const string = "And now, hello world!";
   const buf = new BufReader(stringsReader(string), MIN_READ_BUFFER_SIZE);
 
@@ -239,12 +239,12 @@ async function testReadLine(input: Uint8Array): Promise<void> {
   }
 }
 
-Deno.test(async function bufioReadLine(): Promise<void> {
+Deno.test("bufioReadLine", async function (): Promise<void> {
   await testReadLine(testInput);
   await testReadLine(testInputrn);
 });
 
-Deno.test(async function bufioPeek(): Promise<void> {
+Deno.test("bufioPeek", async function (): Promise<void> {
   const decoder = new TextDecoder();
   const p = new Uint8Array(10);
   // string is 16 (minReadBufferSize) long.
@@ -320,7 +320,7 @@ Deno.test(async function bufioPeek(): Promise<void> {
   */
 });
 
-Deno.test(async function bufioWriter(): Promise<void> {
+Deno.test("bufioWriter", async function (): Promise<void> {
   const data = new Uint8Array(8192);
 
   for (let i = 0; i < data.byteLength; i++) {
@@ -354,7 +354,7 @@ Deno.test(async function bufioWriter(): Promise<void> {
   }
 });
 
-Deno.test(function bufioWriterSync(): void {
+Deno.test("bufioWriterSync", function (): void {
   const data = new Uint8Array(8192);
 
   for (let i = 0; i < data.byteLength; i++) {
@@ -388,7 +388,7 @@ Deno.test(function bufioWriterSync(): void {
   }
 });
 
-Deno.test(async function bufReaderReadFull(): Promise<void> {
+Deno.test("bufReaderReadFull", async function (): Promise<void> {
   const enc = new TextEncoder();
   const dec = new TextDecoder();
   const text = "Hello World";
@@ -414,7 +414,7 @@ Deno.test(async function bufReaderReadFull(): Promise<void> {
   }
 });
 
-Deno.test(async function readStringDelimAndLines(): Promise<void> {
+Deno.test("readStringDelimAndLines", async function (): Promise<void> {
   const enc = new TextEncoder();
   const data = new Buffer(
     enc.encode("Hello World\tHello World 2\tHello World 3")

--- a/std/io/ioutil_test.ts
+++ b/std/io/ioutil_test.ts
@@ -24,19 +24,19 @@ class BinaryReader implements Reader {
   }
 }
 
-Deno.test(async function testReadShort(): Promise<void> {
+Deno.test("testReadShort", async function (): Promise<void> {
   const r = new BinaryReader(new Uint8Array([0x12, 0x34]));
   const short = await readShort(new BufReader(r));
   assertEquals(short, 0x1234);
 });
 
-Deno.test(async function testReadInt(): Promise<void> {
+Deno.test("testReadInt", async function (): Promise<void> {
   const r = new BinaryReader(new Uint8Array([0x12, 0x34, 0x56, 0x78]));
   const int = await readInt(new BufReader(r));
   assertEquals(int, 0x12345678);
 });
 
-Deno.test(async function testReadLong(): Promise<void> {
+Deno.test("testReadLong", async function (): Promise<void> {
   const r = new BinaryReader(
     new Uint8Array([0x00, 0x00, 0x00, 0x78, 0x12, 0x34, 0x56, 0x78])
   );
@@ -44,7 +44,7 @@ Deno.test(async function testReadLong(): Promise<void> {
   assertEquals(long, 0x7812345678);
 });
 
-Deno.test(async function testReadLong2(): Promise<void> {
+Deno.test("testReadLong2", async function (): Promise<void> {
   const r = new BinaryReader(
     new Uint8Array([0, 0, 0, 0, 0x12, 0x34, 0x56, 0x78])
   );
@@ -52,7 +52,7 @@ Deno.test(async function testReadLong2(): Promise<void> {
   assertEquals(long, 0x12345678);
 });
 
-Deno.test(function testSliceLongToBytes(): void {
+Deno.test("testSliceLongToBytes", function (): void {
   const arr = sliceLongToBytes(0x1234567890abcdef);
   const actual = readLong(new BufReader(new BinaryReader(new Uint8Array(arr))));
   const expected = readLong(
@@ -65,12 +65,12 @@ Deno.test(function testSliceLongToBytes(): void {
   assertEquals(actual, expected);
 });
 
-Deno.test(function testSliceLongToBytes2(): void {
+Deno.test("testSliceLongToBytes2", function (): void {
   const arr = sliceLongToBytes(0x12345678);
   assertEquals(arr, [0, 0, 0, 0, 0x12, 0x34, 0x56, 0x78]);
 });
 
-Deno.test(async function testCopyN1(): Promise<void> {
+Deno.test("testCopyN1", async function (): Promise<void> {
   const w = new Buffer();
   const r = stringsReader("abcdefghij");
   const n = await copyN(r, w, 3);
@@ -78,7 +78,7 @@ Deno.test(async function testCopyN1(): Promise<void> {
   assertEquals(w.toString(), "abc");
 });
 
-Deno.test(async function testCopyN2(): Promise<void> {
+Deno.test("testCopyN2", async function (): Promise<void> {
   const w = new Buffer();
   const r = stringsReader("abcdefghij");
   const n = await copyN(r, w, 11);

--- a/std/io/readers_test.ts
+++ b/std/io/readers_test.ts
@@ -5,7 +5,7 @@ import { StringWriter } from "./writers.ts";
 import { copyN } from "./ioutil.ts";
 import { decode } from "../encoding/utf8.ts";
 
-test(async function ioStringReader(): Promise<void> {
+test("ioStringReader", async function (): Promise<void> {
   const r = new StringReader("abcdef");
   const res0 = await r.read(new Uint8Array(6));
   assertEquals(res0, 6);
@@ -13,7 +13,7 @@ test(async function ioStringReader(): Promise<void> {
   assertEquals(res1, Deno.EOF);
 });
 
-test(async function ioStringReader(): Promise<void> {
+test("ioStringReader", async function (): Promise<void> {
   const r = new StringReader("abcdef");
   const buf = new Uint8Array(3);
   const res1 = await r.read(buf);
@@ -27,7 +27,7 @@ test(async function ioStringReader(): Promise<void> {
   assertEquals(decode(buf), "def");
 });
 
-test(async function ioMultiReader(): Promise<void> {
+test("ioMultiReader", async function (): Promise<void> {
   const r = new MultiReader(new StringReader("abc"), new StringReader("def"));
   const w = new StringWriter();
   const n = await copyN(r, w, 4);

--- a/std/io/writers_test.ts
+++ b/std/io/writers_test.ts
@@ -4,7 +4,7 @@ import { StringWriter } from "./writers.ts";
 import { StringReader } from "./readers.ts";
 import { copyN } from "./ioutil.ts";
 
-test(async function ioStringWriter(): Promise<void> {
+test("ioStringWriter", async function (): Promise<void> {
   const w = new StringWriter("base");
   const r = new StringReader("0123456789");
   await copyN(r, w, 4);

--- a/std/log/handlers_test.ts
+++ b/std/log/handlers_test.ts
@@ -22,7 +22,7 @@ class TestHandler extends BaseHandler {
   }
 }
 
-test(function simpleHandler(): void {
+test("simpleHandler", function (): void {
   const cases = new Map<number, string[]>([
     [
       LogLevels.DEBUG,
@@ -68,7 +68,7 @@ test(function simpleHandler(): void {
   }
 });
 
-test(function testFormatterAsString(): void {
+test("testFormatterAsString", function (): void {
   const handler = new TestHandler("DEBUG", {
     formatter: "test {levelName} {msg}",
   });
@@ -78,7 +78,7 @@ test(function testFormatterAsString(): void {
   assertEquals(handler.messages, ["test DEBUG Hello, world!"]);
 });
 
-test(function testFormatterAsFunction(): void {
+test("testFormatterAsFunction", function (): void {
   const handler = new TestHandler("DEBUG", {
     formatter: (logRecord): string =>
       `fn formatter ${logRecord.levelName} ${logRecord.msg}`,

--- a/std/log/logger_test.ts
+++ b/std/log/logger_test.ts
@@ -19,7 +19,7 @@ class TestHandler extends BaseHandler {
   }
 }
 
-test(function simpleLogger(): void {
+test("simpleLogger", function (): void {
   const handler = new TestHandler("DEBUG");
   let logger = new Logger("DEBUG");
 
@@ -32,7 +32,7 @@ test(function simpleLogger(): void {
   assertEquals(logger.handlers, [handler]);
 });
 
-test(function customHandler(): void {
+test("customHandler", function (): void {
   const handler = new TestHandler("DEBUG");
   const logger = new Logger("DEBUG", [handler]);
 
@@ -47,7 +47,7 @@ test(function customHandler(): void {
   assertEquals(handler.messages, ["DEBUG foo"]);
 });
 
-test(function logFunctions(): void {
+test("logFunctions", function (): void {
   const doLog = (level: LevelName): TestHandler => {
     const handler = new TestHandler(level);
     const logger = new Logger(level, [handler]);

--- a/std/log/test.ts
+++ b/std/log/test.ts
@@ -17,7 +17,7 @@ class TestHandler extends log.handlers.BaseHandler {
   }
 }
 
-test(async function defaultHandlers(): Promise<void> {
+test("defaultHandlers", async function (): Promise<void> {
   const loggers: {
     [key: string]: (msg: string, ...args: unknown[]) => void;
   } = {
@@ -55,7 +55,7 @@ test(async function defaultHandlers(): Promise<void> {
   }
 });
 
-test(async function getLogger(): Promise<void> {
+test("getLogger", async function (): Promise<void> {
   const handler = new TestHandler("DEBUG");
 
   await log.setup({
@@ -76,7 +76,7 @@ test(async function getLogger(): Promise<void> {
   assertEquals(logger.handlers, [handler]);
 });
 
-test(async function getLoggerWithName(): Promise<void> {
+test("getLoggerWithName", async function (): Promise<void> {
   const fooHandler = new TestHandler("DEBUG");
 
   await log.setup({
@@ -97,7 +97,7 @@ test(async function getLoggerWithName(): Promise<void> {
   assertEquals(logger.handlers, [fooHandler]);
 });
 
-test(async function getLoggerUnknown(): Promise<void> {
+test("getLoggerUnknown", async function (): Promise<void> {
   await log.setup({
     handlers: {},
     loggers: {},
@@ -109,7 +109,7 @@ test(async function getLoggerUnknown(): Promise<void> {
   assertEquals(logger.handlers, []);
 });
 
-test(function getInvalidLoggerLevels(): void {
+test("getInvalidLoggerLevels", function (): void {
   assertThrows(() => getLevelByName("FAKE_LOG_LEVEL" as LevelName));
   assertThrows(() => getLevelName(5000));
 });

--- a/std/manual.md
+++ b/std/manual.md
@@ -491,11 +491,11 @@ uses a URL to import an assertion library:
 ```ts
 import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
 
-Deno.test(function t1() {
+Deno.test("t1", function () {
   assertEquals("hello", "hello");
 });
 
-Deno.test(function t2() {
+Deno.test("t2", function () {
   assertEquals("world", "world");
 });
 ```

--- a/std/mime/multipart_test.ts
+++ b/std/mime/multipart_test.ts
@@ -22,7 +22,7 @@ const boundary = "--abcde";
 const dashBoundary = e.encode("--" + boundary);
 const nlDashBoundary = e.encode("\r\n--" + boundary);
 
-test(function multipartScanUntilBoundary1(): void {
+test("multipartScanUntilBoundary1", function (): void {
   const data = `--${boundary}`;
   const n = scanUntilBoundary(
     e.encode(data),
@@ -34,7 +34,7 @@ test(function multipartScanUntilBoundary1(): void {
   assertEquals(n, Deno.EOF);
 });
 
-test(function multipartScanUntilBoundary2(): void {
+test("multipartScanUntilBoundary2", function (): void {
   const data = `foo\r\n--${boundary}`;
   const n = scanUntilBoundary(
     e.encode(data),
@@ -46,7 +46,7 @@ test(function multipartScanUntilBoundary2(): void {
   assertEquals(n, 3);
 });
 
-test(function multipartScanUntilBoundary3(): void {
+test("multipartScanUntilBoundary3", function (): void {
   const data = `foobar`;
   const n = scanUntilBoundary(
     e.encode(data),
@@ -58,7 +58,7 @@ test(function multipartScanUntilBoundary3(): void {
   assertEquals(n, data.length);
 });
 
-test(function multipartScanUntilBoundary4(): void {
+test("multipartScanUntilBoundary4", function (): void {
   const data = `foo\r\n--`;
   const n = scanUntilBoundary(
     e.encode(data),
@@ -70,25 +70,25 @@ test(function multipartScanUntilBoundary4(): void {
   assertEquals(n, 3);
 });
 
-test(function multipartMatchAfterPrefix1(): void {
+test("multipartMatchAfterPrefix1", function (): void {
   const data = `${boundary}\r`;
   const v = matchAfterPrefix(e.encode(data), e.encode(boundary), false);
   assertEquals(v, 1);
 });
 
-test(function multipartMatchAfterPrefix2(): void {
+test("multipartMatchAfterPrefix2", function (): void {
   const data = `${boundary}hoge`;
   const v = matchAfterPrefix(e.encode(data), e.encode(boundary), false);
   assertEquals(v, -1);
 });
 
-test(function multipartMatchAfterPrefix3(): void {
+test("multipartMatchAfterPrefix3", function (): void {
   const data = `${boundary}`;
   const v = matchAfterPrefix(e.encode(data), e.encode(boundary), false);
   assertEquals(v, 0);
 });
 
-test(async function multipartMultipartWriter(): Promise<void> {
+test("multipartMultipartWriter", async function (): Promise<void> {
   const buf = new Buffer();
   const mw = new MultipartWriter(buf);
   await mw.writeField("foo", "foo");
@@ -101,7 +101,7 @@ test(async function multipartMultipartWriter(): Promise<void> {
   f.close();
 });
 
-test(function multipartMultipartWriter2(): void {
+test("multipartMultipartWriter2", function (): void {
   const w = new StringWriter();
   assertThrows(
     (): MultipartWriter => new MultipartWriter(w, ""),
@@ -130,7 +130,7 @@ test(function multipartMultipartWriter2(): void {
   );
 });
 
-test(async function multipartMultipartWriter3(): Promise<void> {
+test("multipartMultipartWriter3", async function (): Promise<void> {
   const w = new StringWriter();
   const mw = new MultipartWriter(w);
   await mw.writeField("foo", "foo");

--- a/std/node/_fs/_fs_exists_test.ts
+++ b/std/node/_fs/_fs_exists_test.ts
@@ -5,7 +5,7 @@ import { exists, existsSync } from "./_fs_exists.ts";
 
 const { test } = Deno;
 
-test(async function existsFile() {
+test("existsFile", async function () {
   const availableFile = await new Promise((resolve) => {
     const tmpFilePath = Deno.makeTempFileSync();
     exists(tmpFilePath, (exists: boolean) => {
@@ -20,7 +20,7 @@ test(async function existsFile() {
   assertEquals(notAvailableFile, false);
 });
 
-test(function existsSyncFile() {
+test("existsSyncFile", function () {
   const tmpFilePath = Deno.makeTempFileSync();
   assertEquals(existsSync(tmpFilePath), true);
   Deno.removeSync(tmpFilePath);

--- a/std/node/_fs/_fs_readFile_test.ts
+++ b/std/node/_fs/_fs_readFile_test.ts
@@ -7,7 +7,7 @@ const testData = path.resolve(
   path.join("node", "_fs", "testdata", "hello.txt")
 );
 
-test(async function readFileSuccess() {
+test("readFileSuccess", async function () {
   const data = await new Promise((res, rej) => {
     readFile(testData, (err, data) => {
       if (err) {
@@ -21,7 +21,7 @@ test(async function readFileSuccess() {
   assertEquals(new TextDecoder().decode(data as Uint8Array), "hello world");
 });
 
-test(async function readFileEncodeUtf8Success() {
+test("readFileEncodeUtf8Success", async function () {
   const data = await new Promise((res, rej) => {
     readFile(testData, { encoding: "utf8" }, (err, data) => {
       if (err) {
@@ -35,13 +35,13 @@ test(async function readFileEncodeUtf8Success() {
   assertEquals(data as string, "hello world");
 });
 
-test(function readFileSyncSuccess() {
+test("readFileSyncSuccess", function () {
   const data = readFileSync(testData);
   assert(data instanceof Uint8Array);
   assertEquals(new TextDecoder().decode(data as Uint8Array), "hello world");
 });
 
-test(function readFileEncodeUtf8Success() {
+test("readFileEncodeUtf8Success", function () {
   const data = readFileSync(testData, { encoding: "utf8" });
   assertEquals(typeof data, "string");
   assertEquals(data as string, "hello world");

--- a/std/node/module_test.ts
+++ b/std/node/module_test.ts
@@ -6,7 +6,7 @@ import { createRequire } from "./module.ts";
 
 const require = createRequire(import.meta.url);
 
-test(function requireSuccess() {
+test("requireSuccess", function () {
   // Relative to import.meta.url
   const result = require("./tests/cjs/cjs_a.js");
   assert("helloA" in result);
@@ -19,14 +19,14 @@ test(function requireSuccess() {
   assertEquals(result.leftPad("pad", 4), " pad");
 });
 
-test(function requireCycle() {
+test("requireCycle", function () {
   const resultA = require("./tests/cjs/cjs_cycle_a");
   const resultB = require("./tests/cjs/cjs_cycle_b");
   assert(resultA);
   assert(resultB);
 });
 
-test(function requireBuiltin() {
+test("requireBuiltin", function () {
   const fs = require("fs");
   assert("readFileSync" in fs);
   const { readFileSync, isNull, extname } = require("./tests/cjs/cjs_builtin");
@@ -38,18 +38,18 @@ test(function requireBuiltin() {
   assertEquals(extname("index.html"), ".html");
 });
 
-test(function requireIndexJS() {
+test("requireIndexJS", function () {
   const { isIndex } = require("./tests/cjs");
   assert(isIndex);
 });
 
-test(function requireNodeOs() {
+test("requireNodeOs", function () {
   const os = require("os");
   assert(os.arch);
   assert(typeof os.arch() == "string");
 });
 
-test(function requireStack() {
+test("requireStack", function () {
   const { hello } = require("./tests/cjs/cjs_throw");
   try {
     hello();

--- a/std/path/basename_test.ts
+++ b/std/path/basename_test.ts
@@ -5,7 +5,7 @@ const { test } = Deno;
 import { assertEquals } from "../testing/asserts.ts";
 import * as path from "./mod.ts";
 
-test(function basename() {
+test("basename", function () {
   assertEquals(path.basename(".js", ".js"), "");
   assertEquals(path.basename(""), "");
   assertEquals(path.basename("/dir/basename.ext"), "basename.ext");
@@ -50,7 +50,7 @@ test(function basename() {
   );
 });
 
-test(function basenameWin32() {
+test("basenameWin32", function () {
   assertEquals(path.win32.basename("\\dir\\basename.ext"), "basename.ext");
   assertEquals(path.win32.basename("\\basename.ext"), "basename.ext");
   assertEquals(path.win32.basename("basename.ext"), "basename.ext");

--- a/std/path/dirname_test.ts
+++ b/std/path/dirname_test.ts
@@ -5,7 +5,7 @@ const { test } = Deno;
 import { assertEquals } from "../testing/asserts.ts";
 import * as path from "./mod.ts";
 
-test(function dirname() {
+test("dirname", function () {
   assertEquals(path.posix.dirname("/a/b/"), "/a");
   assertEquals(path.posix.dirname("/a/b"), "/a");
   assertEquals(path.posix.dirname("/a"), "/");
@@ -16,7 +16,7 @@ test(function dirname() {
   assertEquals(path.posix.dirname("foo"), ".");
 });
 
-test(function dirnameWin32() {
+test("dirnameWin32", function () {
   assertEquals(path.win32.dirname("c:\\"), "c:\\");
   assertEquals(path.win32.dirname("c:\\foo"), "c:\\");
   assertEquals(path.win32.dirname("c:\\foo\\"), "c:\\");

--- a/std/path/extname_test.ts
+++ b/std/path/extname_test.ts
@@ -52,7 +52,7 @@ const pairs = [
   ["file.//", "."],
 ];
 
-test(function extname() {
+test("extname", function () {
   pairs.forEach(function (p) {
     const input = p[0];
     const expected = p[1];
@@ -70,7 +70,7 @@ test(function extname() {
   assertEquals(path.posix.extname("file.\\\\"), ".\\\\");
 });
 
-test(function extnameWin32() {
+test("extnameWin32", function () {
   pairs.forEach(function (p) {
     const input = p[0].replace(slashRE, "\\");
     const expected = p[1];

--- a/std/path/glob_test.ts
+++ b/std/path/glob_test.ts
@@ -239,10 +239,10 @@ test({
   },
 });
 
-test(function normalizeGlobGlobstar(): void {
+test("normalizeGlobGlobstar", function (): void {
   assertEquals(normalizeGlob(`**${SEP}..`, { globstar: true }), `**${SEP}..`);
 });
 
-test(function joinGlobsGlobstar(): void {
+test("joinGlobsGlobstar", function (): void {
   assertEquals(joinGlobs(["**", ".."], { globstar: true }), `**${SEP}..`);
 });

--- a/std/path/isabsolute_test.ts
+++ b/std/path/isabsolute_test.ts
@@ -5,14 +5,14 @@ const { test } = Deno;
 import { assertEquals } from "../testing/asserts.ts";
 import * as path from "./mod.ts";
 
-test(function isAbsolute() {
+test("isAbsolute", function () {
   assertEquals(path.posix.isAbsolute("/home/foo"), true);
   assertEquals(path.posix.isAbsolute("/home/foo/.."), true);
   assertEquals(path.posix.isAbsolute("bar/"), false);
   assertEquals(path.posix.isAbsolute("./baz"), false);
 });
 
-test(function isAbsoluteWin32() {
+test("isAbsoluteWin32", function () {
   assertEquals(path.win32.isAbsolute("/"), true);
   assertEquals(path.win32.isAbsolute("//"), true);
   assertEquals(path.win32.isAbsolute("//server"), true);

--- a/std/path/join_test.ts
+++ b/std/path/join_test.ts
@@ -106,7 +106,7 @@ const windowsJoinTests = [
   [["c:", "file"], "c:\\file"],
 ];
 
-test(function join() {
+test("join", function () {
   joinTests.forEach(function (p) {
     const _p = p[0] as string[];
     const actual = path.posix.join.apply(null, _p);
@@ -114,7 +114,7 @@ test(function join() {
   });
 });
 
-test(function joinWin32() {
+test("joinWin32", function () {
   joinTests.forEach(function (p) {
     const _p = p[0] as string[];
     const actual = path.win32.join.apply(null, _p).replace(backslashRE, "/");

--- a/std/path/parse_format_test.ts
+++ b/std/path/parse_format_test.ts
@@ -113,20 +113,20 @@ function checkFormat(path: any, testCases: unknown[][]): void {
   });
 }
 
-test(function parseWin32() {
+test("parseWin32", function () {
   checkParseFormat(path.win32, winPaths);
   checkSpecialCaseParseFormat(path.win32, winSpecialCaseParseTests);
 });
 
-test(function parse() {
+test("parse", function () {
   checkParseFormat(path.posix, unixPaths);
 });
 
-test(function formatWin32() {
+test("formatWin32", function () {
   checkFormat(path.win32, winSpecialCaseFormatTests);
 });
 
-test(function format() {
+test("format", function () {
   checkFormat(path.posix, unixSpecialCaseFormatTests);
 });
 
@@ -162,7 +162,7 @@ const posixTrailingTests = [
   ],
 ];
 
-test(function parseTrailingWin32() {
+test("parseTrailingWin32", function () {
   windowsTrailingTests.forEach(function (p) {
     const actual = path.win32.parse(p[0] as string);
     const expected = p[1];
@@ -170,7 +170,7 @@ test(function parseTrailingWin32() {
   });
 });
 
-test(function parseTrailing() {
+test("parseTrailing", function () {
   posixTrailingTests.forEach(function (p) {
     const actual = path.posix.parse(p[0] as string);
     const expected = p[1];

--- a/std/path/relative_test.ts
+++ b/std/path/relative_test.ts
@@ -50,7 +50,7 @@ const relativeTests = {
   ],
 };
 
-test(function relative() {
+test("relative", function () {
   relativeTests.posix.forEach(function (p) {
     const expected = p[2];
     const actual = path.posix.relative(p[0], p[1]);
@@ -58,7 +58,7 @@ test(function relative() {
   });
 });
 
-test(function relativeWin32() {
+test("relativeWin32", function () {
   relativeTests.win32.forEach(function (p) {
     const expected = p[2];
     const actual = path.win32.relative(p[0], p[1]);

--- a/std/path/resolve_test.ts
+++ b/std/path/resolve_test.ts
@@ -34,7 +34,7 @@ const posixTests =
     [["/foo/tmp.3/", "../tmp.3/cycles/root.js"], "/foo/tmp.3/cycles/root.js"],
   ];
 
-test(function resolve() {
+test("resolve", function () {
   posixTests.forEach(function (p) {
     const _p = p[0] as string[];
     const actual = path.posix.resolve.apply(null, _p);
@@ -42,7 +42,7 @@ test(function resolve() {
   });
 });
 
-test(function resolveWin32() {
+test("resolveWin32", function () {
   windowsTests.forEach(function (p) {
     const _p = p[0] as string[];
     const actual = path.win32.resolve.apply(null, _p);

--- a/std/path/zero_length_strings_test.ts
+++ b/std/path/zero_length_strings_test.ts
@@ -7,7 +7,7 @@ import * as path from "./mod.ts";
 
 const pwd = cwd();
 
-test(function joinZeroLength() {
+test("joinZeroLength", function () {
   // join will internally ignore all the zero-length strings and it will return
   // '.' if the joined string is a zero-length string.
   assertEquals(path.posix.join(""), ".");
@@ -18,28 +18,28 @@ test(function joinZeroLength() {
   assertEquals(path.join(pwd, ""), pwd);
 });
 
-test(function normalizeZeroLength() {
+test("normalizeZeroLength", function () {
   // normalize will return '.' if the input is a zero-length string
   assertEquals(path.posix.normalize(""), ".");
   if (path.win32) assertEquals(path.win32.normalize(""), ".");
   assertEquals(path.normalize(pwd), pwd);
 });
 
-test(function isAbsoluteZeroLength() {
+test("isAbsoluteZeroLength", function () {
   // Since '' is not a valid path in any of the common environments,
   // return false
   assertEquals(path.posix.isAbsolute(""), false);
   if (path.win32) assertEquals(path.win32.isAbsolute(""), false);
 });
 
-test(function resolveZeroLength() {
+test("resolveZeroLength", function () {
   // resolve, internally ignores all the zero-length strings and returns the
   // current working directory
   assertEquals(path.resolve(""), pwd);
   assertEquals(path.resolve("", ""), pwd);
 });
 
-test(function relativeZeroLength() {
+test("relativeZeroLength", function () {
   // relative, internally calls resolve. So, '' is actually the current
   // directory
   assertEquals(path.relative("", pwd), "");

--- a/std/style_guide.md
+++ b/std/style_guide.md
@@ -281,7 +281,7 @@ Example of test:
 import { assertEquals } from "https://deno.land/std@v0.11/testing/asserts.ts";
 import { foo } from "./mod.ts";
 
-Deno.test(function myTestFunction() {
+Deno.test("myTestFunction" function() {
   assertEquals(foo(), { bar: "bar" });
 });
 ```

--- a/std/testing/README.md
+++ b/std/testing/README.md
@@ -51,7 +51,7 @@ Deno.test({
 Short syntax (named function instead of object):
 
 ```ts
-Deno.test(function example(): void {
+Deno.test("example", function (): void {
   assertEquals("world", "world");
   assertEquals({ hello: "world" }, { hello: "world" });
 });
@@ -60,14 +60,14 @@ Deno.test(function example(): void {
 Using `assertStrictEq()`:
 
 ```ts
-Deno.test(function isStrictlyEqual(): void {
+Deno.test("isStrictlyEqual", function (): void {
   const a = {};
   const b = a;
   assertStrictEq(a, b);
 });
 
 // This test fails
-Deno.test(function isNotStrictlyEqual(): void {
+Deno.test("isNotStrictlyEqual", function (): void {
   const a = {};
   const b = {};
   assertStrictEq(a, b);
@@ -77,7 +77,7 @@ Deno.test(function isNotStrictlyEqual(): void {
 Using `assertThrows()`:
 
 ```ts
-Deno.test(function doesThrow(): void {
+Deno.test("doesThrow", function (): void {
   assertThrows((): void => {
     throw new TypeError("hello world!");
   });
@@ -94,7 +94,7 @@ Deno.test(function doesThrow(): void {
 });
 
 // This test will not pass
-Deno.test(function fails(): void {
+Deno.test("fails", function (): void {
   assertThrows((): void => {
     console.log("Hello world");
   });
@@ -104,7 +104,7 @@ Deno.test(function fails(): void {
 Using `assertThrowsAsync()`:
 
 ```ts
-Deno.test(async function doesThrow(): Promise<void> {
+Deno.test("doesThrow", async function (): Promise<void> {
   await assertThrowsAsync(
     async (): Promise<void> => {
       throw new TypeError("hello world!");
@@ -128,7 +128,7 @@ Deno.test(async function doesThrow(): Promise<void> {
 });
 
 // This test will not pass
-Deno.test(async function fails(): Promise<void> {
+Deno.test("fails", async function (): Promise<void> {
   await assertThrowsAsync(
     async (): Promise<void> => {
       console.log("Hello world");

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -17,7 +17,7 @@ import {
 import { red, green, gray, bold } from "../fmt/colors.ts";
 const { test } = Deno;
 
-test(function testingEqual(): void {
+test("testingEqual", function (): void {
   assert(equal("world", "world"));
   assert(!equal("hello", "world"));
   assert(equal(5, 5));
@@ -114,7 +114,7 @@ test(function testingEqual(): void {
   assert(!equal(new Uint8Array([1, 2, 3, 4]), new Uint8Array([2, 1, 4, 3])));
 });
 
-test(function testingNotEquals(): void {
+test("testingNotEquals", function (): void {
   const a = { foo: "bar" };
   const b = { bar: "foo" };
   assertNotEquals(a, b);
@@ -130,7 +130,7 @@ test(function testingNotEquals(): void {
   assertEquals(didThrow, true);
 });
 
-test(function testingAssertStringContains(): void {
+test("testingAssertStringContains", function (): void {
   assertStrContains("Denosaurus", "saur");
   assertStrContains("Denosaurus", "Deno");
   assertStrContains("Denosaurus", "rus");
@@ -145,7 +145,7 @@ test(function testingAssertStringContains(): void {
   assertEquals(didThrow, true);
 });
 
-test(function testingArrayContains(): void {
+test("testingArrayContains", function (): void {
   const fixture = ["deno", "iz", "luv"];
   const fixtureObject = [{ deno: "luv" }, { deno: "Js" }];
   assertArrayContains(fixture, ["deno"]);
@@ -161,7 +161,7 @@ test(function testingArrayContains(): void {
   assertEquals(didThrow, true);
 });
 
-test(function testingAssertStringContainsThrow(): void {
+test("testingAssertStringContainsThrow", function (): void {
   let didThrow = false;
   try {
     assertStrContains("Denosaurus from Jurassic", "Raptor");
@@ -176,11 +176,11 @@ test(function testingAssertStringContainsThrow(): void {
   assert(didThrow);
 });
 
-test(function testingAssertStringMatching(): void {
+test("testingAssertStringMatching", function (): void {
   assertMatch("foobar@deno.com", RegExp(/[a-zA-Z]+@[a-zA-Z]+.com/));
 });
 
-test(function testingAssertStringMatchingThrows(): void {
+test("testingAssertStringMatchingThrows", function (): void {
   let didThrow = false;
   try {
     assertMatch("Denosaurus from Jurassic", RegExp(/Raptor/));
@@ -195,7 +195,7 @@ test(function testingAssertStringMatchingThrows(): void {
   assert(didThrow);
 });
 
-test(function testingAssertsUnimplemented(): void {
+test("testingAssertsUnimplemented", function (): void {
   let didThrow = false;
   try {
     unimplemented();
@@ -207,7 +207,7 @@ test(function testingAssertsUnimplemented(): void {
   assert(didThrow);
 });
 
-test(function testingAssertsUnreachable(): void {
+test("testingAssertsUnreachable", function (): void {
   let didThrow = false;
   try {
     unreachable();
@@ -219,7 +219,7 @@ test(function testingAssertsUnreachable(): void {
   assert(didThrow);
 });
 
-test(function testingAssertFail(): void {
+test("testingAssertFail", function (): void {
   assertThrows(fail, AssertionError, "Failed assertion.");
   assertThrows(
     (): void => {
@@ -230,7 +230,7 @@ test(function testingAssertFail(): void {
   );
 });
 
-test(function testingAssertFailWithWrongErrorClass(): void {
+test("testingAssertFailWithWrongErrorClass", function (): void {
   assertThrows(
     (): void => {
       //This next assertThrows will throw an AssertionError due to the wrong

--- a/std/util/async_test.ts
+++ b/std/util/async_test.ts
@@ -3,7 +3,7 @@ const { test } = Deno;
 import { assert, assertEquals, assertStrictEq } from "../testing/asserts.ts";
 import { collectUint8Arrays, deferred, MuxAsyncIterator } from "./async.ts";
 
-test(function asyncDeferred(): Promise<void> {
+test("asyncDeferred", function (): Promise<void> {
   const d = deferred<number>();
   d.resolve(12);
   return Promise.resolve();
@@ -23,7 +23,7 @@ async function* gen456(): AsyncIterableIterator<number> {
   yield 6;
 }
 
-test(async function asyncMuxAsyncIterator(): Promise<void> {
+test("asyncMuxAsyncIterator", async function (): Promise<void> {
   const mux = new MuxAsyncIterator<number>();
   mux.add(gen123());
   mux.add(gen456());
@@ -34,21 +34,21 @@ test(async function asyncMuxAsyncIterator(): Promise<void> {
   assertEquals(results.size, 6);
 });
 
-test(async function collectUint8Arrays0(): Promise<void> {
+test("collectUint8Arrays0", async function (): Promise<void> {
   async function* gen(): AsyncIterableIterator<Uint8Array> {}
   const result = await collectUint8Arrays(gen());
   assert(result instanceof Uint8Array);
   assertEquals(result.length, 0);
 });
 
-test(async function collectUint8Arrays0(): Promise<void> {
+test("collectUint8Arrays0", async function (): Promise<void> {
   async function* gen(): AsyncIterableIterator<Uint8Array> {}
   const result = await collectUint8Arrays(gen());
   assert(result instanceof Uint8Array);
   assertStrictEq(result.length, 0);
 });
 
-test(async function collectUint8Arrays1(): Promise<void> {
+test("collectUint8Arrays1", async function (): Promise<void> {
   const buf = new Uint8Array([1, 2, 3]);
   // eslint-disable-next-line require-await
   async function* gen(): AsyncIterableIterator<Uint8Array> {
@@ -59,7 +59,7 @@ test(async function collectUint8Arrays1(): Promise<void> {
   assertStrictEq(result.length, 3);
 });
 
-test(async function collectUint8Arrays4(): Promise<void> {
+test("collectUint8Arrays4", async function (): Promise<void> {
   // eslint-disable-next-line require-await
   async function* gen(): AsyncIterableIterator<Uint8Array> {
     yield new Uint8Array([1, 2, 3]);

--- a/std/util/deep_assign_test.ts
+++ b/std/util/deep_assign_test.ts
@@ -3,7 +3,7 @@ const { test } = Deno;
 import { assertEquals, assert } from "../testing/asserts.ts";
 import { deepAssign } from "./deep_assign.ts";
 
-test(function deepAssignTest(): void {
+test("deepAssignTest", function (): void {
   const date = new Date("1979-05-27T07:32:00Z");
   const reg = RegExp(/DENOWOWO/);
   const obj1 = { deno: { bar: { deno: ["is", "not", "node"] } } };


### PR DESCRIPTION
This commit removes overload of Deno.test() that accepted named
function.
