### PR TITLE
Make Deno.Buffer implement only sync I/O

### DIFF
--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -171,7 +171,6 @@ export class Buffer implements SyncReader, SyncWriter {
   }
 }
 
-      
 export function readAllSync(r: SyncReader): Uint8Array {
   const buf = new Buffer();
   buf.readFromSync(r);

--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -4,7 +4,7 @@
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.
 // https://github.com/golang/go/blob/master/LICENSE
 
-import { Reader, Writer, EOF, SyncReader, SyncWriter } from "./io.ts";
+import { EOF, SyncReader, SyncWriter } from "./io.ts";
 import { assert } from "./util.ts";
 import { TextDecoder } from "./web/text_encoding.ts";
 
@@ -27,7 +27,7 @@ function copyBytes(dst: Uint8Array, src: Uint8Array, off = 0): number {
   return src.byteLength;
 }
 
-export class Buffer implements Reader, SyncReader, Writer, SyncWriter {
+export class Buffer implements SyncReader, SyncWriter {
   #buf: Uint8Array; // contents are the bytes buf[off : len(buf)]
   #off = 0; // read at buf[off], write at buf[buf.byteLength]
 
@@ -106,19 +106,9 @@ export class Buffer implements Reader, SyncReader, Writer, SyncWriter {
     return nread;
   }
 
-  read(p: Uint8Array): Promise<number | EOF> {
-    const rr = this.readSync(p);
-    return Promise.resolve(rr);
-  }
-
   writeSync(p: Uint8Array): number {
     const m = this.#grow(p.byteLength);
     return copyBytes(this.#buf, p, m);
-  }
-
-  write(p: Uint8Array): Promise<number> {
-    const n = this.writeSync(p);
-    return Promise.resolve(n);
   }
 
   #grow = (n: number): number => {

--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -4,7 +4,7 @@
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.
 // https://github.com/golang/go/blob/master/LICENSE
 
-import { EOF, SyncReader, SyncWriter } from "./io.ts";
+import { Reader, Writer, EOF, SyncReader, SyncWriter } from "./io.ts";
 import { assert } from "./util.ts";
 import { TextDecoder } from "./web/text_encoding.ts";
 

--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -1,12 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 // Public deno module.
-export {
-  Buffer,
-  readAllSync,
-  writeAll,
-  writeAllSync,
-} from "./buffer.ts";
+export { Buffer, readAllSync, writeAll, writeAllSync } from "./buffer.ts";
 export { build, OperatingSystem, Arch } from "./build.ts";
 export { chmodSync, chmod } from "./ops/fs/chmod.ts";
 export { chownSync, chown } from "./ops/fs/chown.ts";

--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -3,7 +3,6 @@
 // Public deno module.
 export {
   Buffer,
-  readAll,
   readAllSync,
   writeAll,
   writeAllSync,

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -857,7 +857,7 @@ declare namespace Deno {
    * of ArrayBuffer.
    *
    * Based on [Go Buffer](https://golang.org/pkg/bytes/#Buffer). */
-  export class Buffer implements Reader, SyncReader, Writer, SyncWriter {
+  export class Buffer implements SyncReader, SyncWriter {
     constructor(ab?: ArrayBuffer);
     /** Returns a slice holding the unread portion of the buffer.
      *
@@ -894,9 +894,7 @@ declare namespace Deno {
     /** Reads the next `p.length` bytes from the buffer or until the buffer is
      * drained. Resolves to the number of bytes read. If the buffer has no
      * data to return, resolves to `Deno.EOF`. */
-    read(p: Uint8Array): Promise<number | EOF>;
     writeSync(p: Uint8Array): number;
-    write(p: Uint8Array): Promise<number>;
     /** Grows the buffer's capacity, if necessary, to guarantee space for
      * another `n` bytes. After `.grow(n)`, at least `n` bytes can be written to
      * the buffer without another allocation. If `n` is negative, `.grow()` will
@@ -906,13 +904,6 @@ declare namespace Deno {
      * [Buffer.Grow](https://golang.org/pkg/bytes/#Buffer.Grow). */
     grow(n: number): void;
     /** Reads data from `r` until `Deno.EOF` and appends it to the buffer,
-     * growing the buffer as needed. It resolves to the number of bytes read.
-     * If the buffer becomes too large, `.readFrom()` will reject with an error.
-     *
-     * Based on Go Lang's
-     * [Buffer.ReadFrom](https://golang.org/pkg/bytes/#Buffer.ReadFrom). */
-    readFrom(r: Reader): Promise<number>;
-    /** Reads data from `r` until `Deno.EOF` and appends it to the buffer,
      * growing the buffer as needed. It returns the number of bytes read. If the
      * buffer becomes too large, `.readFromSync()` will throw an error.
      *
@@ -920,25 +911,6 @@ declare namespace Deno {
      * [Buffer.ReadFrom](https://golang.org/pkg/bytes/#Buffer.ReadFrom). */
     readFromSync(r: SyncReader): number;
   }
-
-  /** Read Reader `r` until end of file (`Deno.EOF`) and resolve to the content
-   * as `Uint8Array`.
-   *
-   *       // Example from stdin
-   *       const stdinContent = await Deno.readAll(Deno.stdin);
-   *
-   *       // Example from file
-   *       const file = await Deno.open("my_file.txt", {read: true});
-   *       const myFileContent = await Deno.readAll(file);
-   *       Deno.close(file.rid);
-   *
-   *       // Example from buffer
-   *       const myData = new Uint8Array(100);
-   *       // ... fill myData array with data
-   *       const reader = new Deno.Buffer(myData.buffer as ArrayBuffer);
-   *       const bufferContent = await Deno.readAll(reader);
-   */
-  export function readAll(r: Reader): Promise<Uint8Array>;
 
   /** Synchronously reads Reader `r` until end of file (`Deno.EOF`) and returns
    * the content as `Uint8Array`.

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1881,7 +1881,7 @@ declare namespace Deno {
     [Symbol.asyncIterator](): AsyncIterableIterator<Conn>;
   }
 
-  export interface Conn extends Reader, Writer, Closer {
+  export interface Conn extends SyncReader, Reader, Writer, Closer {
     /** The local address of the connection. */
     readonly localAddr: Addr;
     /** The remote address of the connection. */

--- a/cli/js/net.ts
+++ b/cli/js/net.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { errors } from "./errors.ts";
-import { EOF, Reader, Writer, Closer } from "./io.ts";
-import { read, write } from "./ops/io.ts";
+import { EOF, SyncReader, Reader, Writer, Closer } from "./io.ts";
+import { readSync, read, write } from "./ops/io.ts";
 import { close } from "./ops/resources.ts";
 import * as netOps from "./ops/net.ts";
 import { Addr } from "./ops/net.ts";
@@ -42,6 +42,11 @@ export class ConnImpl implements Conn {
 
   read(p: Uint8Array): Promise<number | EOF> {
     return read(this.rid, p);
+  }
+
+  readSync(p: Uint8Array): number | EOF {
+    // TODO(jcao219): Verify that readSync op works for all conn rids.
+    return readSync(this.rid, p);
   }
 
   close(): void {
@@ -126,7 +131,7 @@ export class DatagramImpl implements DatagramConn {
   }
 }
 
-export interface Conn extends Reader, Writer, Closer {
+export interface Conn extends SyncReader, Reader, Writer, Closer {
   localAddr: Addr;
   remoteAddr: Addr;
   rid: number;

--- a/cli/js/process.ts
+++ b/cli/js/process.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { File } from "./files.ts";
 import { close } from "./ops/resources.ts";
-import { ReadCloser, WriteCloser } from "./io.ts";
+import { SyncReader, Closer, WriteCloser } from "./io.ts";
 import { readAllSync } from "./buffer.ts";
 import { kill, runStatus as runStatusOp, run as runOp } from "./ops/process.ts";
 
@@ -34,8 +34,8 @@ export class Process {
   readonly rid: number;
   readonly pid: number;
   readonly stdin?: WriteCloser;
-  readonly stdout?: ReadCloser;
-  readonly stderr?: ReadCloser;
+  readonly stdout?: SyncReader & Closer;
+  readonly stderr?: SyncReader & Closer;
 
   // @internal
   constructor(res: RunResponse) {

--- a/cli/js/process.ts
+++ b/cli/js/process.ts
@@ -59,7 +59,7 @@ export class Process {
     return runStatus(this.rid);
   }
 
-  async output(): Promise<Uint8Array> {
+  output(): Uint8Array {
     if (!this.stdout) {
       throw new Error("Process.output: stdout is undefined");
     }
@@ -70,7 +70,7 @@ export class Process {
     }
   }
 
-  async stderrOutput(): Promise<Uint8Array> {
+  stderrOutput(): Uint8Array {
     if (!this.stderr) {
       throw new Error("Process.stderrOutput: stderr is undefined");
     }

--- a/cli/js/process.ts
+++ b/cli/js/process.ts
@@ -2,7 +2,7 @@
 import { File } from "./files.ts";
 import { close } from "./ops/resources.ts";
 import { ReadCloser, WriteCloser } from "./io.ts";
-import { readAll } from "./buffer.ts";
+import { readAllSync } from "./buffer.ts";
 import { kill, runStatus as runStatusOp, run as runOp } from "./ops/process.ts";
 
 export type ProcessStdio = "inherit" | "piped" | "null";
@@ -64,7 +64,7 @@ export class Process {
       throw new Error("Process.output: stdout is undefined");
     }
     try {
-      return await readAll(this.stdout);
+      return readAllSync(this.stdout);
     } finally {
       this.stdout.close();
     }
@@ -75,7 +75,7 @@ export class Process {
       throw new Error("Process.stderrOutput: stderr is undefined");
     }
     try {
-      return await readAll(this.stderr);
+      return readAllSync(this.stderr);
     } finally {
       this.stderr.close();
     }

--- a/cli/js/read_file.ts
+++ b/cli/js/read_file.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { open, openSync } from "./files.ts";
-import { readAll, readAllSync } from "./buffer.ts";
+import { readAllSync } from "./buffer.ts";
 
 export function readFileSync(path: string): Uint8Array {
   const file = openSync(path);
@@ -11,7 +11,7 @@ export function readFileSync(path: string): Uint8Array {
 
 export async function readFile(path: string): Promise<Uint8Array> {
   const file = await open(path);
-  const contents = await readAll(file);
+  const contents = readAllSync(file);
   file.close();
   return contents;
 }

--- a/cli/js/read_text_file.ts
+++ b/cli/js/read_text_file.ts
@@ -1,5 +1,5 @@
 import { open, openSync } from "./files.ts";
-import { readAll, readAllSync } from "./buffer.ts";
+import { readAllSync } from "./buffer.ts";
 
 export function readTextFileSync(path: string): string {
   const decoder = new TextDecoder();
@@ -12,7 +12,7 @@ export function readTextFileSync(path: string): string {
 export async function readTextFile(path: string): Promise<string> {
   const decoder = new TextDecoder();
   const file = await open(path);
-  const content = await readAll(file);
+  const content = readAllSync(file);
   file.close();
   return decoder.decode(content);
 }

--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -5,7 +5,7 @@ import * as domTypes from "./dom_types.d.ts";
 import { TextDecoder, TextEncoder } from "./text_encoding.ts";
 import { DenoBlob, bytesSymbol as blobBytesSymbol } from "./blob.ts";
 import * as io from "../io.ts";
-import { read } from "../ops/io.ts";
+import { readSync } from "../ops/io.ts";
 import { close } from "../ops/resources.ts";
 import { Buffer } from "../buffer.ts";
 import { fetch as opFetch, FetchResponse } from "../ops/fetch.ts";

--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -41,6 +41,7 @@ class Body implements domTypes.Body, ReadableStream<Uint8Array>, io.ReadCloser, 
     this.body = this;
   }
 
+  // eslint-disable-next-line require-await
   #bodyBuffer = async (): Promise<ArrayBuffer> => {
     assert(this.#bodyPromise == null);
     const buf = new Buffer();

--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -5,7 +5,7 @@ import * as domTypes from "./dom_types.d.ts";
 import { TextDecoder, TextEncoder } from "./text_encoding.ts";
 import { DenoBlob, bytesSymbol as blobBytesSymbol } from "./blob.ts";
 import * as io from "../io.ts";
-import { readSync } from "../ops/io.ts";
+import { read, readSync } from "../ops/io.ts";
 import { close } from "../ops/resources.ts";
 import { Buffer } from "../buffer.ts";
 import { fetch as opFetch, FetchResponse } from "../ops/fetch.ts";

--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -28,7 +28,12 @@ function hasHeaderValueOf(s: string, value: string): boolean {
   return new RegExp(`^${value}[\t\s]*;?`).test(s);
 }
 
-class Body implements domTypes.Body, ReadableStream<Uint8Array>, io.ReadCloser, io.SyncReader {
+class Body
+  implements
+    domTypes.Body,
+    ReadableStream<Uint8Array>,
+    io.ReadCloser,
+    io.SyncReader {
   #bodyUsed = false;
   #bodyPromise: Promise<ArrayBuffer> | null = null;
   #data: ArrayBuffer | null = null;

--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -666,7 +666,7 @@ export async function* readDelim(
       return;
     }
     const sliceRead = inspectArr.subarray(0, result as number);
-    await Deno.writeAll(inputBuffer, sliceRead);
+    Deno.writeAllSync(inputBuffer, sliceRead);
 
     let sliceToProcess = inputBuffer.bytes();
     while (inspectIndex < sliceToProcess.length) {

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -64,11 +64,11 @@ const readMakers: ReadMaker[] = [
 ];
 
 // Call read to accumulate the text of a file
-async function reads(buf: BufReader, m: number): Promise<string> {
+function reads(buf: BufReader, m: number): string {
   const b = new Uint8Array(1000);
   let nb = 0;
   while (true) {
-    const result = await buf.read(b.subarray(nb, nb + m));
+    const result = buf.readSync(b.subarray(nb, nb + m));
     if (result === Deno.EOF) {
       break;
     }
@@ -80,16 +80,16 @@ async function reads(buf: BufReader, m: number): Promise<string> {
 
 interface NamedBufReader {
   name: string;
-  fn: (r: BufReader) => Promise<string>;
+  fn: (r: BufReader) => string;
 }
 
 const bufreaders: NamedBufReader[] = [
-  { name: "1", fn: (b: BufReader): Promise<string> => reads(b, 1) },
-  { name: "2", fn: (b: BufReader): Promise<string> => reads(b, 2) },
-  { name: "3", fn: (b: BufReader): Promise<string> => reads(b, 3) },
-  { name: "4", fn: (b: BufReader): Promise<string> => reads(b, 4) },
-  { name: "5", fn: (b: BufReader): Promise<string> => reads(b, 5) },
-  { name: "7", fn: (b: BufReader): Promise<string> => reads(b, 7) },
+  { name: "1", fn: (b: BufReader): string => reads(b, 1) },
+  { name: "2", fn: (b: BufReader): string => reads(b, 2) },
+  { name: "3", fn: (b: BufReader): string => reads(b, 3) },
+  { name: "4", fn: (b: BufReader): string => reads(b, 4) },
+  { name: "5", fn: (b: BufReader): string => reads(b, 5) },
+  { name: "7", fn: (b: BufReader): string => reads(b, 7) },
   { name: "bytes", fn: readBytes },
   // { name: "lines", fn: readLines },
 ];
@@ -125,7 +125,7 @@ Deno.test(async function bufioBufReader(): Promise<void> {
         for (const bufsize of bufsizes) {
           const read = readmaker.fn(stringsReader(text));
           const buf = new BufReader(read, bufsize);
-          const s = await bufreader.fn(buf);
+          const s = bufreader.fn(buf);
           const debugStr =
             `reader=${readmaker.name} ` +
             `fn=${bufreader.name} bufsize=${bufsize} want=${text} got=${s}`;

--- a/std/io/util.ts
+++ b/std/io/util.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 const { Buffer, mkdir, open } = Deno;
 type File = Deno.File;
-type Reader = Deno.Reader;
+type SyncReader = Deno.SyncReader;
 import * as path from "../path/mod.ts";
 import { encode } from "../encoding/utf8.ts";
 
@@ -28,7 +28,7 @@ export function charCode(s: string): number {
   return s.charCodeAt(0);
 }
 
-export function stringsReader(s: string): Reader {
+export function stringsReader(s: string): SyncReader {
   return new Buffer(encode(s).buffer);
 }
 


### PR DESCRIPTION
Deno.Buffer shouldn't implement async read and write

https://github.com/denoland/deno/issues/4933