### PR TITLE
refactor(cli/js/web): Use a Deno symbol for non-standard worker options

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -110,6 +110,7 @@ export { writeFileSync, writeFile, WriteFileOptions } from "./write_file.ts";
 export { writeTextFileSync, writeTextFile } from "./write_text_file.ts";
 export const args: string[] = [];
 export { TestDefinition, test } from "./testing.ts";
+export { extensions } from "./web/extensions.ts";
 
 // These are internal Deno APIs.  We are marking them as internal so they do not
 // appear in the runtime type library.

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -131,6 +131,7 @@ declare global {
   // Assigned to `window` global - main runtime
   var Deno: {
     core: DenoCore;
+    readonly extensions: unique symbol;
   };
   var onload: ((e: Event) => void) | undefined;
   var onunload: ((e: Event) => void) | undefined;

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -2872,8 +2872,20 @@ declare namespace Deno {
     windowChange: () => SignalStream;
   };
 
-  /** A symbol which can be used as a key for a custom method which will be
-   * called when `Deno.inspect()` is called, or when the object is logged to
-   * the console. */
+  /** A key for a custom method which will be called when `Deno.inspect()` is
+   * called, or when the object is logged to the console. */
   export const customInspect: unique symbol;
+
+  /** A key for a bag of Deno-owned extensions to an API which is not
+   * Deno-owned, usually a web API.
+
+   *      new Worker("./worker.ts", {
+   *        type: "module",
+   *        name: "my-worker",
+   *        [Deno.extensions]: {
+   *          includeNamespace: true,
+   *        },
+   *      });
+   *  */
+  export const extensions: unique symbol;
 }

--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -1155,7 +1155,12 @@ declare class Worker extends EventTarget {
        *
        * Example:
        *    // mod.ts
-       *    const worker = new Worker("./deno_worker.ts", { type: "module", deno: true });
+       *    const worker = new Worker("./deno_worker.ts", {
+       *      type: "module",
+       *      [Deno.extensions]: {
+       *        includeNamespace: true,
+       *      },
+       *    });
        *    worker.postMessage({ cmd: "readFile", fileName: "./log.txt" });
        *
        *    // deno_worker.ts
@@ -1181,7 +1186,9 @@ declare class Worker extends EventTarget {
        *    hello world2
        *
        */
-      deno?: boolean;
+      [Deno.extensions]?: {
+        includeNamespace: boolean;
+      };
     }
   );
   postMessage(message: any, transfer: ArrayBuffer[]): void;

--- a/cli/js/web/extensions.ts
+++ b/cli/js/web/extensions.ts
@@ -1,0 +1,3 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+export const extensions = Symbol("Deno.extensions");

--- a/cli/js/web/workers.ts
+++ b/cli/js/web/workers.ts
@@ -13,6 +13,7 @@ import { blobURLMap } from "./web/url.ts";
 */
 import { EventImpl as Event } from "./event.ts";
 import { EventTargetImpl as EventTarget } from "./event_target.ts";
+import { extensions } from "./extensions.ts";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -105,7 +106,9 @@ export interface Worker {
 export interface WorkerOptions {
   type?: "classic" | "module";
   name?: string;
-  deno?: boolean;
+  [extensions]?: {
+    includeNamespace: boolean;
+  };
 }
 
 export class WorkerImpl extends EventTarget implements Worker {
@@ -119,7 +122,11 @@ export class WorkerImpl extends EventTarget implements Worker {
 
   constructor(specifier: string, options?: WorkerOptions) {
     super();
-    const { type = "classic", name = "unknown" } = options ?? {};
+    const {
+      type = "classic",
+      name = "unknown",
+      [extensions]: { includeNamespace = false } = {},
+    } = options ?? {};
 
     if (type !== "module") {
       throw new Error(
@@ -147,13 +154,11 @@ export class WorkerImpl extends EventTarget implements Worker {
     }
     */
 
-    const useDenoNamespace = options ? !!options.deno : false;
-
     const { id } = createWorker(
       specifier,
       hasSourceCode,
       sourceCode,
-      useDenoNamespace,
+      includeNamespace,
       options?.name
     );
     this.#id = id;

--- a/cli/tests/workers_test.ts
+++ b/cli/tests/workers_test.ts
@@ -269,7 +269,7 @@ Deno.test({
     });
     const denoWorker = new Worker("../tests/subdir/deno_worker.ts", {
       type: "module",
-      deno: true,
+      [Deno.extensions]: { includeNamespace: true },
     });
 
     regularWorker.onmessage = (e): void => {


### PR DESCRIPTION
@bartlomieju Please review.

This PR turns
```ts
const worker = new Worker("./temp-worker.ts", {
  type: "module",
  name: "my-worker",
  deno: true,
});
```
into
```ts
const worker = new Worker("./temp-worker.ts", {
  type: "module",
  name: "my-worker",
  [Deno.extensions]: {
    includeNamespace: true,
  },
});
```
It is a proof-of-concept for `Deno.extensions`.

Compatible with #4867.

I don't know if the existing API _technically_ satisfies our compatibility rule, but either way we need need a consistent pattern to add Deno-owned extensions to web APIs. A required reference to the Deno namespace is clear, nice and allows for better static analysis.