### PR TITLE
Web API: sessionStorage

### DIFF
--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -25,6 +25,7 @@ import * as request from "./web/request.ts";
 import * as readableStream from "./web/streams/readable_stream.ts";
 import * as queuingStrategy from "./web/streams/queuing_strategy.ts";
 import * as writableStream from "./web/streams/writable_stream.ts";
+import * as storage from "./web/storage.ts";
 
 // These imports are not exposed and therefore are fine to just import the
 // symbols required.
@@ -239,6 +240,13 @@ export const windowOrWorkerGlobalScopeProperties = {
   performance: writable(new performanceUtil.Performance()),
   Worker: nonEnumerable(workers.WorkerImpl),
   WritableStream: nonEnumerable(writableStream.WritableStreamImpl),
+};
+
+export const windowGlobalScopeProperties = {
+  localStorage: getterOnly(() => {
+    throw new (class SecurityError extends domException.DOMExceptionImpl {})();
+  }),
+  sessionStorage: readOnly(storage.sessionStorage),
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -1400,3 +1400,13 @@ declare const AbortSignal: {
   prototype: AbortSignal;
   new (): AbortSignal;
 };
+
+interface Storage {
+  readonly length: number;
+  key: (index: number) => string | null;
+  getItem: (keyName: string) => string | null;
+  setItem: (keyName: string, keyValue: string) => void;
+  removeItem: (keyName: string) => void;
+  clear: () => void;
+  [name: string]: any;
+}

--- a/cli/js/lib.deno.window.d.ts
+++ b/cli/js/lib.deno.window.d.ts
@@ -44,4 +44,7 @@ declare interface Crypto {
   ): T;
 }
 
+declare const sessionStorage: Storage;
+declare const localStorage: Storage;
+
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/cli/js/runtime_main.ts
+++ b/cli/js/runtime_main.ts
@@ -17,6 +17,7 @@ import {
   writable,
   windowOrWorkerGlobalScopeMethods,
   windowOrWorkerGlobalScopeProperties,
+  windowGlobalScopeProperties,
   eventTargetProperties,
   setEventTargetData,
 } from "./globals.ts";
@@ -79,6 +80,7 @@ export function bootstrapMainRuntime(): void {
   hasBootstrapped = true;
   Object.defineProperties(globalThis, windowOrWorkerGlobalScopeMethods);
   Object.defineProperties(globalThis, windowOrWorkerGlobalScopeProperties);
+  Object.defineProperties(globalThis, windowGlobalScopeProperties);
   Object.defineProperties(globalThis, eventTargetProperties);
   Object.defineProperties(globalThis, mainRuntimeGlobalProperties);
   setEventTargetData(globalThis);

--- a/cli/js/tests/storage_test.ts
+++ b/cli/js/tests/storage_test.ts
@@ -1,0 +1,80 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import { unitTest, assertEquals, assertThrows } from "./test_util.ts";
+
+unitTest(function getItemFromUnknownKeyShouldReturnNull() {
+  assertEquals(sessionStorage.getItem("unknonw_key"), null);
+  assertEquals(sessionStorage["unknonw_key"], null);
+});
+
+unitTest(function getItemAfterSetItemShouldReturnGivenValue() {
+  const value = "" + Math.random();
+  sessionStorage.setItem("test_key", value);
+  assertEquals(sessionStorage.getItem("test_key"), value);
+  assertEquals(sessionStorage["test_key"], value);
+});
+
+unitTest(function getItemAfterRemoveItemShouldReturnNull() {
+  const value = "" + Math.random();
+  sessionStorage.setItem("test_key", value);
+  sessionStorage.removeItem("test_key");
+  assertEquals(sessionStorage.getItem("test_key"), null);
+  assertEquals(sessionStorage["test_key"], null);
+});
+
+unitTest(function getItemAfterClearShouldReturnNull() {
+  const value = "" + Math.random();
+  sessionStorage.setItem("test_key", value);
+  sessionStorage.clear();
+  assertEquals(sessionStorage.getItem("test_key"), null);
+  assertEquals(sessionStorage["test_key"], null);
+});
+
+unitTest(function removeItemFromUnknownKeyShouldDoNothing() {
+  assertEquals(sessionStorage.removeItem("unknonw_key"), undefined);
+  assertEquals(delete sessionStorage["unknonw_key"], true);
+});
+
+unitTest(function keyMethodShouldReturnSetKey() {
+  const key = "" + Math.random();
+
+  sessionStorage.clear();
+  sessionStorage.setItem(key, "value");
+  assertEquals(sessionStorage.key(0), key);
+});
+
+unitTest(function lengthShouldGrowWhenAddingItem() {
+  const key = "" + Math.random();
+
+  const expectedLength = sessionStorage.length + 1;
+  sessionStorage[key] = "value";
+  assertEquals(sessionStorage.length, expectedLength);
+});
+
+unitTest(function lengthShouldNotGrowWhenUpdatingExistingItem() {
+  const key = "" + Math.random();
+
+  const expectedLength = sessionStorage.length + 1;
+  sessionStorage.setItem(key, "value");
+  assertEquals(sessionStorage.length, expectedLength);
+  sessionStorage[key] = "other value";
+  assertEquals(sessionStorage.length, expectedLength);
+});
+
+unitTest(function lengthShouldShrinkWhenRemovingAnItem() {
+  const key = "" + Math.random();
+
+  const expectedLength = sessionStorage.length;
+  sessionStorage[key] = "value";
+  assertEquals(sessionStorage.length, expectedLength + 1);
+  delete sessionStorage[key];
+  assertEquals(sessionStorage.length, expectedLength);
+});
+
+unitTest(function lengthShouldBeZeroWhenStorageIsCleared() {
+  sessionStorage.clear();
+  assertEquals(sessionStorage.length, 0);
+});
+
+unitTest(function accessingLocalStorageShouldThrow() {
+  assertThrows(() => localStorage.length);
+});

--- a/cli/js/tests/unit_tests.ts
+++ b/cli/js/tests/unit_tests.ts
@@ -54,6 +54,7 @@ import "./signal_test.ts";
 import "./stat_test.ts";
 import "./streams_piping_test.ts";
 import "./streams_writable_test.ts";
+import "./storage_test.ts";
 import "./symlink_test.ts";
 import "./text_encoding_test.ts";
 import "./testing_test.ts";

--- a/cli/js/web/storage.ts
+++ b/cli/js/web/storage.ts
@@ -1,0 +1,61 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+
+const data = Symbol("internal Storage data");
+
+class NonPersistantStorageImpl implements Storage {
+  private [data]: Map<string, string> = new Map();
+
+  get length(): number {
+    return this[data].size;
+  }
+  key(index: number): string | null {
+    if (index >= this[data].size) {
+      return null;
+    } else {
+      return Array.from(this[data].keys())[index];
+    }
+  }
+  getItem(keyName: string): string | null {
+    return this[data].get(keyName) || null;
+  }
+  setItem(keyName: string, keyValue: string): void {
+    this[data].set(keyName, keyValue);
+  }
+  removeItem(keyName: string): void {
+    this[data].delete(keyName);
+  }
+  clear(): void {
+    this[data].clear();
+  }
+}
+
+const storageHandler = {
+  deleteProperty(target: Storage, key: string): boolean {
+    target.removeItem(key);
+    return true;
+  },
+  has(target: Storage, key: string): boolean {
+    return target.getItem(key) !== null || key in target;
+  },
+  get(target: Storage, key: string): string | null | number | void {
+    if ("undefined" !== typeof target[key]) {
+      // @ts-ignore
+      return Reflect.get(...arguments); // eslint-disable-line prefer-rest-params
+    } else {
+      return target.getItem(key);
+    }
+  },
+  set(target: Storage, key: string, value: string): boolean {
+    try {
+      target.setItem(key, value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};
+
+export const sessionStorage = new Proxy(
+  new NonPersistantStorageImpl(),
+  storageHandler
+);


### PR DESCRIPTION
Implements `window.sessionStorage` for Deno. 

This is mostly a wrapper around `Map`, that should be 100% compatible with the browser implementation.

`localStorage` is a bit tricky to achieve on Deno, as far as I know their is no obvious equivalent to an origin on Deno, I have chosen to make it throw a `SecurityError` as the specs allows:

> If the request violates a policy decision (e.g. if the user agent is configured to not allow the page to persist data), the user agent may throw a "SecurityError" DOMException instead of returning a Storage object

Missing features: `window.localStorage`, `StorageEvent` class and `storage` event.

Refs: https://html.spec.whatwg.org/multipage/webstorage.html#storage-2
Refs: #1657

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
