### PR TITLE
Move JS doc tags like `@param [obj.prop]` to the interface

### DIFF
--- a/std/encoding/csv.ts
+++ b/std/encoding/csv.ts
@@ -264,6 +264,20 @@ export interface HeaderOptions {
 
 export interface ParseOptions extends ReadOptions {
   header: boolean | string[] | HeaderOptions[];
+  /** Parse function for rows.
+   * Example:
+   *     const r = await parseFile('a,b,c\ne,f,g\n', {
+   *      header: ["this", "is", "sparta"],
+   *       parse: (e: Record<string, unknown>) => {
+   *         return { super: e.this, street: e.is, fighter: e.sparta };
+   *       }
+   *     });
+   * // output
+   * [
+   *   { super: "a", street: "b", fighter: "c" },
+   *   { super: "e", street: "f", fighter: "g" }
+   * ]
+   */
   parse?: (input: unknown) => unknown;
 }
 
@@ -273,20 +287,6 @@ export interface ParseOptions extends ReadOptions {
  * for columns and rows.
  * @param input Input to parse. Can be a string or BufReader.
  * @param opt options of the parser.
- * @param [opt.header=false] HeaderOptions
- * @param [opt.parse=null] Parse function for rows.
- * Example:
- *     const r = await parseFile('a,b,c\ne,f,g\n', {
- *      header: ["this", "is", "sparta"],
- *       parse: (e: Record<string, unknown>) => {
- *         return { super: e.this, street: e.is, fighter: e.sparta };
- *       }
- *     });
- * // output
- * [
- *   { super: "a", street: "b", fighter: "c" },
- *   { super: "e", street: "f", fighter: "g" }
- * ]
  */
 export async function parse(
   input: string | BufReader,

--- a/std/http/cookie.ts
+++ b/std/http/cookie.ts
@@ -10,15 +10,26 @@ export interface Cookies {
 }
 
 export interface Cookie {
+  /** Name of the cookie. */
   name: string;
+  /** Value of the cookie. */
   value: string;
+  /** Expiration date of the cookie. */
   expires?: Date;
+  /** Max-Age of the Cookie. Must be integer superior to 0. */
   maxAge?: number;
+  /** Specifies those hosts to which the cookie will be sent. */
   domain?: string;
+  /** Indicates a URL path that must exist in the request. */
   path?: string;
+  /** Indicates if the cookie is made using SSL & HTTPS. */
   secure?: boolean;
+  /** Indicates that cookie is not accessible via Javascript. **/
   httpOnly?: boolean;
+  /** Allows servers to assert that a cookie ought not to
+   * be sent along with cross-site requests. */
   sameSite?: SameSite;
+  /** Additional key value pairs with the form "key=value" */
   unparsed?: string[];
 }
 
@@ -95,17 +106,6 @@ export function getCookies(req: ServerRequest): Cookies {
  * Set the cookie header properly in the Response
  * @param res Server Response
  * @param cookie Cookie to set
- * @param [cookie.name] Name of the cookie
- * @param [cookie.value] Value of the cookie
- * @param [cookie.expires] Expiration Date of the cookie
- * @param [cookie.maxAge] Max-Age of the Cookie. Must be integer superior to 0
- * @param [cookie.domain] Specifies those hosts to which the cookie will be sent
- * @param [cookie.path] Indicates a URL path that must exist in the request.
- * @param [cookie.secure] Indicates if the cookie is made using SSL & HTTPS.
- * @param [cookie.httpOnly] Indicates that cookie is not accessible via
- *                          Javascript
- * @param [cookie.sameSite] Allows servers to assert that a cookie ought not to
- *                          be sent along with cross-site requests
  * Example:
  *
  *     setCookie(response, { name: 'deno', value: 'runtime',

--- a/std/path/globrex.ts
+++ b/std/path/globrex.ts
@@ -12,18 +12,23 @@ const GLOBSTAR_SEGMENT = `((?:[^${SEP_ESC}/]*(?:${SEP_ESC}|\/|$))*)`;
 const WILDCARD_SEGMENT = `(?:[^${SEP_ESC}/]*)`;
 
 export interface GlobrexOptions {
-  // Allow ExtGlob features
+  /** Allow ExtGlob features.
+   * @default false */
   extended?: boolean;
-  // When globstar is true, '/foo/**' is equivelant
-  // to '/foo/*' when globstar is false.
-  // Having globstar set to true is the same usage as
-  // using wildcards in bash
+  /** Support globstar.
+   * @remarks When globstar is `true`, '/foo/**' is equivelant
+   * to '/foo/*' when globstar is `false`.
+   * Having globstar set to `true` is the same usage as
+   * using wildcards in bash.
+   * @default false */
   globstar?: boolean;
-  // be laissez faire about mutiple slashes
+  /** Be laissez-faire about mutiple slashes.
+   * @default true */
   strict?: boolean;
-  // Parse as filepath for extra path related features
+  /** Parse as filepath for extra path related features.
+   * @default false */
   filepath?: boolean;
-  // Flag to use in the generated RegExp
+  /** Flag to use in the generated RegExp. */
   flags?: string;
 }
 
@@ -40,11 +45,6 @@ export interface GlobrexResult {
  * Convert any glob pattern to a JavaScript Regexp object
  * @param glob Glob pattern to convert
  * @param opts Configuration object
- * @param [opts.extended=false] Support advanced ext globbing
- * @param [opts.globstar=false] Support globstar
- * @param [opts.strict=true] be laissez faire about mutiple slashes
- * @param [opts.filepath=""] Parse as filepath for extra path related features
- * @param [opts.flags=""] RegExp globs
  * @returns Converted object with string, segments and RegExp object
  */
 export function globrex(


### PR DESCRIPTION
I was looking at Deno Doc and it looks like this:

![image](https://user-images.githubusercontent.com/1609021/80532639-70c94a00-896a-11ea-8d7e-edb9b63cf277.png)
![image](https://user-images.githubusercontent.com/1609021/80532650-758dfe00-896a-11ea-8f7d-1c43e086329a.png)

This PR moves any `@param [obj.prop]` jsdoc tags those docs to the interface object, which will improve how it looks in Deno Doc.

I know there's no issue for this, but this seemed like an easy quick fix to not bother (took only a few minutes).