### PR TITLE
refactor: Deno.listener closes when breaking out of async iterator

### DIFF
--- a/cli/js/net.ts
+++ b/cli/js/net.ts
@@ -58,6 +58,8 @@ export class ConnImpl implements Conn {
 }
 
 export class ListenerImpl implements Listener {
+  #closed = false;
+
   constructor(readonly rid: number, readonly addr: Addr) {}
 
   async accept(): Promise<Conn> {
@@ -65,21 +67,30 @@ export class ListenerImpl implements Listener {
     return new ConnImpl(res.rid, res.remoteAddr, res.localAddr);
   }
 
+  async next(): Promise<IteratorResult<Conn>> {
+    let conn: Conn;
+    try {
+      conn = await this.accept();
+    } catch (error) {
+      if (error instanceof errors.BadResource) {
+        return { value: undefined, done: true };
+      }
+      throw error;
+    }
+    return { value: conn!, done: false };
+  }
+
+  return(value?: Conn): Promise<IteratorResult<Conn>> {
+    this.close();
+    return Promise.resolve({ value, done: true });
+  }
+
   close(): void {
     close(this.rid);
   }
 
-  async *[Symbol.asyncIterator](): AsyncIterableIterator<Conn> {
-    while (true) {
-      try {
-        yield await this.accept();
-      } catch (error) {
-        if (error instanceof errors.BadResource) {
-          break;
-        }
-        throw error;
-      }
-    }
+  [Symbol.asyncIterator](): AsyncIterableIterator<Conn> {
+    return this;
   }
 }
 

--- a/cli/js/net.ts
+++ b/cli/js/net.ts
@@ -58,8 +58,6 @@ export class ConnImpl implements Conn {
 }
 
 export class ListenerImpl implements Listener {
-  #closed = false;
-
   constructor(readonly rid: number, readonly addr: Addr) {}
 
   async accept(): Promise<Conn> {

--- a/cli/js/tests/net_test.ts
+++ b/cli/js/tests/net_test.ts
@@ -281,6 +281,42 @@ unitTest(
 
 unitTest(
   { perms: { net: true } },
+  async function netTcpListenIteratorBreakClosesResource(): Promise<void> {
+    const promise = createResolvable();
+
+    async function iterate(listener: Deno.Listener): Promise<void> {
+      let i = 0;
+
+      for await (const conn of listener) {
+        conn.close();
+        i++;
+
+        if (i > 1) {
+          break;
+        }
+      }
+
+      promise.resolve();
+    }
+
+    const addr = { hostname: "127.0.0.1", port: 8888 };
+    const listener = Deno.listen(addr);
+    iterate(listener);
+
+    await new Promise((resolve: () => void, _) => {
+      setTimeout(resolve, 100);
+    });
+    const conn1 = await Deno.connect(addr);
+    conn1.close();
+    const conn2 = await Deno.connect(addr);
+    conn2.close();
+
+    await promise;
+  }
+);
+
+unitTest(
+  { perms: { net: true } },
   async function netTcpListenCloseWhileIterating(): Promise<void> {
     const listener = Deno.listen({ port: 8000 });
     const nextWhileClosing = listener[Symbol.asyncIterator]().next();


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
