### PR TITLE
Make Deno.copy write the whole buffer

### DIFF
--- a/cli/js/io.ts
+++ b/cli/js/io.ts
@@ -65,7 +65,11 @@ export async function copy(
     if (result === null) {
       gotEOF = true;
     } else {
-      n += await dst.write(b.subarray(0, result));
+      let nwritten = 0;
+      while (nwritten < result) {
+        nwritten += await dst.write(b.subarray(nwritten, result));
+      }
+      n += nwritten;
     }
   }
   return n;

--- a/cli/js/tests/io_test.ts
+++ b/cli/js/tests/io_test.ts
@@ -55,3 +55,19 @@ unitTest(async function copyWithCustomBufferSize() {
   assertEquals(write.length, xBytes.length);
   assertEquals(readSpy.calls, DEFAULT_BUF_SIZE / bufSize + 1);
 });
+
+unitTest({ perms: { write: true } }, async function copyBufferToFile() {
+  const filePath = "test-file.txt";
+  // bigger than max File possible buffer 16kb
+  const bufSize = 32 * 1024;
+  const xBytes = repeat("b", bufSize);
+  const reader = new Deno.Buffer(xBytes.buffer as ArrayBuffer);
+  const write = await Deno.open(filePath, { write: true, create: true });
+
+  const n = await Deno.copy(reader, write, { bufSize });
+
+  assertEquals(n, xBytes.length);
+
+  write.close();
+  await Deno.remove(filePath);
+});


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
Haven't found the exact reason, most likely it's a limitation in rust. But when trying to write over 16384 bytes to a File, only 16384 bytes are written, this makes `copy`  fail for some files.

Of course the same happens when you try to just write a file using `.write` and the chunk being written is over `16kb`

Added a test to prove that, it fails on master.