### PR TITLE
fix: Make std/io copyN write the whole read buffer

### DIFF
--- a/std/io/ioutil.ts
+++ b/std/io/ioutil.ts
@@ -24,7 +24,10 @@ export async function copyN(
     const nread = result ?? 0;
     bytesRead += nread;
     if (nread > 0) {
-      const n = await dest.write(buf.slice(0, nread));
+      let n = 0;
+      while (n < nread) {
+        n += await dest.write(buf.slice(n, nread));
+      }
       assert(n === nread, "could not write");
     }
     if (result === null) {

--- a/std/io/ioutil_test.ts
+++ b/std/io/ioutil_test.ts
@@ -10,7 +10,8 @@ import {
   sliceLongToBytes,
 } from "./ioutil.ts";
 import { BufReader } from "./bufio.ts";
-import { stringsReader } from "./util.ts";
+import { stringsReader, tempFile } from "./util.ts";
+import * as path from "../path/mod.ts";
 
 class BinaryReader implements Reader {
   index = 0;
@@ -84,4 +85,16 @@ Deno.test("testCopyN2", async function (): Promise<void> {
   const n = await copyN(r, w, 11);
   assertEquals(n, 10);
   assertEquals(w.toString(), "abcdefghij");
+});
+
+Deno.test("copyNWriteAllData", async function (): Promise<void> {
+  const { filepath, file } = await tempFile(path.resolve("io"));
+  const size = 16 * 1024 + 1;
+  const data = "a".repeat(32 * 1024);
+  const r = stringsReader(data);
+  const n = await copyN(r, file, size); // Over max file possible buffer
+  file.close();
+  await Deno.remove(filepath);
+
+  assertEquals(n, size);
 });


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
`copyN` is failing when trying to copy over `16384` bytes if `Writer` is a `File`. We need to iterate until the whole read buffer is written.

Added a test to prove that, it fails on master.