### PR TITLE
doc: Stabilize Deno.permissions

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1760,9 +1760,7 @@ declare namespace Deno {
     request(desc: PermissionDescriptor): Promise<PermissionStatus>;
   }
 
-  /** **UNSTABLE**: maybe move to `navigator.permissions` to match web API. It
-   * could look like `navigator.permissions.query({ name: Deno.symbols.read })`.
-   */
+  /** Functions that can be used to query and update permission status. */
   export const permissions: Permissions;
 
   /** see: https://w3c.github.io/permissions/#permissionstatus */


### PR DESCRIPTION
With `Deno.symbols` gone and a disinclination to add more symbols, there is no compatible way to move `Deno.permissions` to `navigator.permissions`. Also not listed in #4933. So I assume this is stable as it is.