### PR TITLE
Example `console.log` in debugging session (#4989)

### DIFF
--- a/cli/js/web/console.ts
+++ b/cli/js/web/console.ts
@@ -684,6 +684,8 @@ const countMap = new Map<string, number>();
 const timerMap = new Map<string, number>();
 const isConsoleInstance = Symbol("isConsoleInstance");
 
+const builtinConsole = globalThis.console;
+
 export class Console {
   #printFunc: PrintFunc;
   indentLevel: number;
@@ -704,6 +706,12 @@ export class Console {
   }
 
   log = (...args: unknown[]): void => {
+
+    if ((globalThis as any).__isInspector) {
+      builtinConsole.log.apply(builtinConsole, args);
+      return;
+    }
+
     this.#printFunc(
       stringifyArgs(args, {
         indentLevel: this.indentLevel,

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -121,7 +121,7 @@ impl Worker {
 
     let (internal_channels, external_channels) = create_channels();
 
-    Self {
+    let mut worker = Self {
       name,
       isolate,
       state,
@@ -129,7 +129,13 @@ impl Worker {
       internal_channels,
       external_channels,
       inspector,
+    };
+
+    if worker.inspector.is_some() {
+      worker.execute("globalThis.__isInspector = true;").expect("Could not set inspector status");
     }
+
+    worker
   }
 
   /// Same as execute2() but the filename defaults to "$CWD/__anonymous__".


### PR DESCRIPTION
Communicates whether the worker was made with an attached inspector running `globalThis.__isInspector = true`. During worker creation.

To pipe console methods to v8 builtins, holds onto `globalThis.console` as `builtinConsole`, and calls this in the `Console.log` method.

Example to illustrate issue #4989 

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
