### PR TITLE
cat.ts example is broken: Deno.copy args are reversed

### DIFF
--- a/std/examples/cat.ts
+++ b/std/examples/cat.ts
@@ -2,6 +2,6 @@
 const filenames = Deno.args;
 for (const filename of filenames) {
   const file = await Deno.open(filename);
-  await Deno.copy(file, Deno.stdout);
+  await Deno.copy(Deno.stdout, file);
   file.close();
 }


### PR DESCRIPTION
The example `cat.ts` hangs forever.  The arguments to `Deno.copy` are in the wrong order.

https://deno.land/typedoc/index.html#copy

The correct order is `copy(destination, source)`, which is surprising.

This is the first example in the [manual](https://deno.land/std/manual.md#an-implementation-of-the-unix-cat-program).  The code in the manual works, but the code at `https://deno.land/std/examples/cat.ts` is different and fails.

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
