### PR TITLE
refactor: check permissions in SourceFileFetcher

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -6,7 +6,7 @@ use crate::http_util::create_http_client;
 use crate::http_util::FetchOnceResult;
 use crate::msg;
 use crate::op_error::OpError;
-use crate::permissions::DenoPermissions;
+use crate::permissions::Permissions;
 use deno_core::ErrBox;
 use deno_core::ModuleSpecifier;
 use futures::future::FutureExt;
@@ -110,7 +110,7 @@ impl SourceFileFetcher {
   pub fn fetch_cached_source_file(
     &self,
     specifier: &ModuleSpecifier,
-    _permissions: DenoPermissions,
+    _permissions: Permissions,
   ) -> Option<SourceFile> {
     let maybe_source_file = self.source_file_cache.get(specifier.to_string());
 
@@ -150,7 +150,7 @@ impl SourceFileFetcher {
     &self,
     specifier: &ModuleSpecifier,
     maybe_referrer: Option<ModuleSpecifier>,
-    _permissions: DenoPermissions,
+    _permissions: Permissions,
   ) -> Result<SourceFile, ErrBox> {
     let module_url = specifier.as_url().to_owned();
     debug!("fetch_source_file specifier: {} ", &module_url);
@@ -934,7 +934,7 @@ mod tests {
 
     // first download
     let r = fetcher
-      .fetch_source_file(&specifier, None, DenoPermissions::default())
+      .fetch_source_file(&specifier, None, Permissions::default())
       .await;
     assert!(r.is_ok());
 
@@ -952,7 +952,7 @@ mod tests {
     // header file creation timestamp (should be the same as after first
     // download)
     let r = fetcher
-      .fetch_source_file(&specifier, None, DenoPermissions::default())
+      .fetch_source_file(&specifier, None, Permissions::default())
       .await;
     assert!(r.is_ok());
 
@@ -1336,7 +1336,7 @@ mod tests {
     let specifier =
       ModuleSpecifier::resolve_url(file_url!("/baddir/hello.ts")).unwrap();
     let r = fetcher
-      .fetch_source_file(&specifier, None, DenoPermissions::default())
+      .fetch_source_file(&specifier, None, Permissions::default())
       .await;
     assert!(r.is_err());
 
@@ -1345,7 +1345,7 @@ mod tests {
     let specifier =
       ModuleSpecifier::resolve_url_or_path(p.to_str().unwrap()).unwrap();
     let r = fetcher
-      .fetch_source_file(&specifier, None, DenoPermissions::default())
+      .fetch_source_file(&specifier, None, Permissions::default())
       .await;
     assert!(r.is_ok());
   }
@@ -1359,7 +1359,7 @@ mod tests {
     let specifier =
       ModuleSpecifier::resolve_url(file_url!("/baddir/hello.ts")).unwrap();
     let r = fetcher
-      .fetch_source_file(&specifier, None, DenoPermissions::default())
+      .fetch_source_file(&specifier, None, Permissions::default())
       .await;
     assert!(r.is_err());
 
@@ -1368,7 +1368,7 @@ mod tests {
     let specifier =
       ModuleSpecifier::resolve_url_or_path(p.to_str().unwrap()).unwrap();
     let r = fetcher
-      .fetch_source_file(&specifier, None, DenoPermissions::default())
+      .fetch_source_file(&specifier, None, Permissions::default())
       .await;
     assert!(r.is_ok());
   }
@@ -1383,7 +1383,7 @@ mod tests {
     let specifier =
       ModuleSpecifier::resolve_url_or_path(p.to_str().unwrap()).unwrap();
     let r = fetcher
-      .fetch_source_file(&specifier, None, DenoPermissions::default())
+      .fetch_source_file(&specifier, None, Permissions::default())
       .await;
     assert!(r.is_ok());
   }

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -102,7 +102,7 @@ impl GlobalState {
 
     // TODO(bartlomieju): currently unused, but file fetcher will
     // require them in the near future
-    let permissions = Permissions::default();
+    let permissions = Permissions::allow_all();
 
     let out = self
       .file_fetcher

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -95,14 +95,11 @@ impl GlobalState {
     module_specifier: ModuleSpecifier,
     maybe_referrer: Option<ModuleSpecifier>,
     target_lib: TargetLib,
+    permissions: Permissions,
   ) -> Result<CompiledModule, ErrBox> {
     let state1 = self.clone();
     let state2 = self.clone();
     let module_specifier = module_specifier.clone();
-
-    // TODO(bartlomieju): currently unused, but file fetcher will
-    // require them in the near future
-    let permissions = Permissions::allow_all();
 
     let out = self
       .file_fetcher
@@ -119,14 +116,14 @@ impl GlobalState {
       | msg::MediaType::JSX => {
         state1
           .ts_compiler
-          .compile(state1.clone(), &out, target_lib)
+          .compile(state1.clone(), &out, target_lib, permissions.clone())
           .await
       }
       msg::MediaType::JavaScript => {
         if state1.ts_compiler.compile_js {
           state2
             .ts_compiler
-            .compile(state1.clone(), &out, target_lib)
+            .compile(state1.clone(), &out, target_lib, permissions.clone())
             .await
         } else {
           if let Some(types_url) = out.types_url.clone() {

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -86,7 +86,6 @@ impl GlobalState {
       compiler_starts: AtomicUsize::new(0),
       compile_lock: AsyncMutex::new(()),
     };
-
     Ok(GlobalState(Arc::new(inner)))
   }
 

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -102,7 +102,7 @@ impl GlobalState {
 
     // TODO(bartlomieju): currently unused, but file fetcher will
     // require them in the near future
-    let permissions = DenoPermissions::default();
+    let permissions = Permissions::default();
 
     let out = self
       .file_fetcher

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -100,9 +100,13 @@ impl GlobalState {
     let state2 = self.clone();
     let module_specifier = module_specifier.clone();
 
+    // TODO(bartlomieju): currently unused, but file fetcher will
+    // require them in the near future
+    let permissions = DenoPermissions::default();
+
     let out = self
       .file_fetcher
-      .fetch_source_file(&module_specifier, maybe_referrer)
+      .fetch_source_file(&module_specifier, maybe_referrer, permissions.clone())
       .await?;
 
     // TODO(ry) Try to lift compile_lock as high up in the call stack for
@@ -132,6 +136,7 @@ impl GlobalState {
               .fetch_source_file(
                 &types_specifier,
                 Some(module_specifier.clone()),
+                permissions.clone(),
               )
               .await
               .ok();

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -73,7 +73,7 @@ use crate::global_state::GlobalState;
 use crate::msg::MediaType;
 use crate::op_error::OpError;
 use crate::ops::io::get_stdio;
-use crate::permissions::DenoPermissions;
+use crate::permissions::Permissions;
 use crate::state::DebugType;
 use crate::state::State;
 use crate::tsc::TargetLib;
@@ -188,7 +188,7 @@ async fn print_file_info(
 
   let out = global_state
     .file_fetcher
-    .fetch_source_file(&module_specifier, None, DenoPermissions::default())
+    .fetch_source_file(&module_specifier, None, Permissions::default())
     .await?;
 
   println!(
@@ -409,7 +409,7 @@ async fn doc_command(
 
       async move {
         let source_file = fetcher
-          .fetch_source_file(&specifier, None, DenoPermissions::default())
+          .fetch_source_file(&specifier, None, Permissions::default())
           .await?;
         String::from_utf8(source_file.source_code)
           .map_err(|_| OpError::other("failed to parse".to_string()))

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -73,6 +73,7 @@ use crate::global_state::GlobalState;
 use crate::msg::MediaType;
 use crate::op_error::OpError;
 use crate::ops::io::get_stdio;
+use crate::permissions::DenoPermissions;
 use crate::state::DebugType;
 use crate::state::State;
 use crate::tsc::TargetLib;
@@ -187,7 +188,7 @@ async fn print_file_info(
 
   let out = global_state
     .file_fetcher
-    .fetch_source_file(&module_specifier, None)
+    .fetch_source_file(&module_specifier, None, DenoPermissions::default())
     .await?;
 
   println!(
@@ -407,7 +408,9 @@ async fn doc_command(
       let fetcher = self.clone();
 
       async move {
-        let source_file = fetcher.fetch_source_file(&specifier, None).await?;
+        let source_file = fetcher
+          .fetch_source_file(&specifier, None, DenoPermissions::default())
+          .await?;
         String::from_utf8(source_file.source_code)
           .map_err(|_| OpError::other("failed to parse".to_string()))
       }

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -206,7 +206,12 @@ async fn print_file_info(
   let module_specifier_ = module_specifier.clone();
   global_state
     .clone()
-    .fetch_compiled_module(module_specifier_, None, TargetLib::Main)
+    .fetch_compiled_module(
+      module_specifier_,
+      None,
+      TargetLib::Main,
+      Permissions::allow_all(),
+    )
     .await?;
 
   if out.media_type == msg::MediaType::TypeScript

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -188,7 +188,7 @@ async fn print_file_info(
 
   let out = global_state
     .file_fetcher
-    .fetch_source_file(&module_specifier, None, Permissions::default())
+    .fetch_source_file(&module_specifier, None, Permissions::allow_all())
     .await?;
 
   println!(
@@ -409,7 +409,7 @@ async fn doc_command(
 
       async move {
         let source_file = fetcher
-          .fetch_source_file(&specifier, None, Permissions::default())
+          .fetch_source_file(&specifier, None, Permissions::allow_all())
           .await?;
         String::from_utf8(source_file.source_code)
           .map_err(|_| OpError::other("failed to parse".to_string()))

--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -4,7 +4,6 @@ use super::dispatch_json::JsonOp;
 use super::dispatch_json::Value;
 use crate::futures::future::try_join_all;
 use crate::op_error::OpError;
-use crate::permissions::Permissions;
 use crate::state::State;
 use deno_core::CoreIsolate;
 use deno_core::ModuleLoader;
@@ -70,11 +69,11 @@ fn op_fetch_source_files(
     None
   };
 
-  // TODO(bartlomieju): currently unused, but file fetcher will
-  // require them in the near future
-  let permissions = Permissions::allow_all();
+  let s = state.borrow();
+  let global_state = s.global_state.clone();
+  let permissions = s.permissions.clone();
   let perms_ = permissions.clone();
-  let global_state = state.borrow().global_state.clone();
+  drop(s);
   let file_fetcher = global_state.file_fetcher.clone();
   let specifiers = args.specifiers.clone();
   let future = async move {

--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -72,7 +72,7 @@ fn op_fetch_source_files(
 
   // TODO(bartlomieju): currently unused, but file fetcher will
   // require them in the near future
-  let permissions = Permissions::default();
+  let permissions = Permissions::allow_all();
   let perms_ = permissions.clone();
   let global_state = state.borrow().global_state.clone();
   let file_fetcher = global_state.file_fetcher.clone();

--- a/cli/ops/compiler.rs
+++ b/cli/ops/compiler.rs
@@ -4,7 +4,7 @@ use super::dispatch_json::JsonOp;
 use super::dispatch_json::Value;
 use crate::futures::future::try_join_all;
 use crate::op_error::OpError;
-use crate::permissions::DenoPermissions;
+use crate::permissions::Permissions;
 use crate::state::State;
 use deno_core::CoreIsolate;
 use deno_core::ModuleLoader;
@@ -72,7 +72,7 @@ fn op_fetch_source_files(
 
   // TODO(bartlomieju): currently unused, but file fetcher will
   // require them in the near future
-  let permissions = DenoPermissions::default();
+  let permissions = Permissions::default();
   let perms_ = permissions.clone();
   let global_state = state.borrow().global_state.clone();
   let file_fetcher = global_state.file_fetcher.clone();

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -30,10 +30,14 @@ fn op_compile(
 ) -> Result<JsonOp, OpError> {
   state.check_unstable("Deno.compile");
   let args: CompileArgs = serde_json::from_value(args)?;
-  let global_state = state.borrow().global_state.clone();
+  let s = state.borrow();
+  let global_state = s.global_state.clone();
+  let permissions = s.permissions.clone();
+  drop(s);
   let fut = async move {
     runtime_compile(
       global_state,
+      permissions,
       &args.root_name,
       &args.sources,
       args.bundle,
@@ -58,9 +62,13 @@ fn op_transpile(
 ) -> Result<JsonOp, OpError> {
   state.check_unstable("Deno.transpile");
   let args: TranspileArgs = serde_json::from_value(args)?;
-  let global_state = state.borrow().global_state.clone();
+  let s = state.borrow();
+  let global_state = s.global_state.clone();
+  let permissions = s.permissions.clone();
+  drop(s);
   let fut = async move {
-    runtime_transpile(global_state, &args.sources, &args.options).await
+    runtime_transpile(global_state, permissions, &args.sources, &args.options)
+      .await
   }
   .boxed_local();
   Ok(JsonOp::Async(fut))

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -33,7 +33,6 @@ fn op_compile(
   let s = state.borrow();
   let global_state = s.global_state.clone();
   let permissions = s.permissions.clone();
-  drop(s);
   let fut = async move {
     runtime_compile(
       global_state,
@@ -65,7 +64,6 @@ fn op_transpile(
   let s = state.borrow();
   let global_state = s.global_state.clone();
   let permissions = s.permissions.clone();
-  drop(s);
   let fut = async move {
     runtime_transpile(global_state, permissions, &args.sources, &args.options)
       .await

--- a/cli/permissions.rs
+++ b/cli/permissions.rs
@@ -134,6 +134,19 @@ impl Permissions {
     }
   }
 
+  pub fn allow_all() -> Self {
+    Self {
+      allow_read: PermissionState::from(true),
+      allow_write: PermissionState::from(true),
+      allow_net: PermissionState::from(true),
+      allow_env: PermissionState::from(true),
+      allow_run: PermissionState::from(true),
+      allow_plugin: PermissionState::from(true),
+      allow_hrtime: PermissionState::from(true),
+      ..Default::default()
+    }
+  }
+
   pub fn check_run(&self) -> Result<(), OpError> {
     self
       .allow_run
@@ -328,22 +341,6 @@ fn permission_prompt(message: &str) -> bool {
         eprint!("{}", colors::bold(msg_again));
       }
     };
-  }
-}
-
-#[cfg(test)]
-impl Permissions {
-  pub fn allow_all() -> Self {
-    Self {
-      allow_read: PermissionState::from(true),
-      allow_write: PermissionState::from(true),
-      allow_net: PermissionState::from(true),
-      allow_env: PermissionState::from(true),
-      allow_run: PermissionState::from(true),
-      allow_plugin: PermissionState::from(true),
-      allow_hrtime: PermissionState::from(true),
-      ..Default::default()
-    }
   }
 }
 

--- a/cli/permissions.rs
+++ b/cli/permissions.rs
@@ -332,6 +332,22 @@ fn permission_prompt(message: &str) -> bool {
 }
 
 #[cfg(test)]
+impl Permissions {
+  pub fn allow_all() -> Self {
+    Self {
+      allow_read: PermissionState::from(true),
+      allow_write: PermissionState::from(true),
+      allow_net: PermissionState::from(true),
+      allow_env: PermissionState::from(true),
+      allow_run: PermissionState::from(true),
+      allow_plugin: PermissionState::from(true),
+      allow_hrtime: PermissionState::from(true),
+      ..Default::default()
+    }
+  }
+}
+
+#[cfg(test)]
 lazy_static! {
   /// Lock this when you use `set_prompt_result` in a test case.
   static ref PERMISSION_PROMPT_GUARD: Mutex<()> = Mutex::new(());

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -67,6 +67,7 @@ pub struct StateInner {
   pub seeded_rng: Option<StdRng>,
   pub target_lib: TargetLib,
   pub debug_type: DebugType,
+  pub is_main: bool,
 }
 
 impl State {
@@ -314,10 +315,10 @@ impl ModuleLoader for State {
     let module_url_specified = module_specifier.to_string();
     let global_state = state.global_state.clone();
     let target_lib = state.target_lib.clone();
-    let permissions = if is_dyn_import {
-      state.permissions.clone()
-    } else {
+    let permissions = if state.is_main {
       Permissions::allow_all()
+    } else {
+      state.permissions.clone()
     };
 
     let fut = async move {
@@ -406,6 +407,7 @@ impl State {
       seeded_rng,
       target_lib: TargetLib::Main,
       debug_type,
+      is_main: true,
     }));
 
     Ok(Self(state))
@@ -441,6 +443,7 @@ impl State {
       seeded_rng,
       target_lib: TargetLib::Worker,
       debug_type: DebugType::Dependent,
+      is_main: false,
     }));
 
     Ok(Self(state))

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -314,9 +314,20 @@ impl ModuleLoader for State {
     let module_url_specified = module_specifier.to_string();
     let global_state = state.global_state.clone();
     let target_lib = state.target_lib.clone();
+    let permissions = if is_dyn_import {
+      state.permissions.clone()
+    } else {
+      Permissions::allow_all()
+    };
+
     let fut = async move {
       let compiled_module = global_state
-        .fetch_compiled_module(module_specifier, maybe_referrer, target_lib)
+        .fetch_compiled_module(
+          module_specifier,
+          maybe_referrer,
+          target_lib,
+          permissions,
+        )
         .await?;
       Ok(deno_core::ModuleSource {
         // Real module name, might be different from initial specifier

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1019,6 +1019,7 @@ fn workers() {
     .arg("test")
     .arg("--reload")
     .arg("--allow-net")
+    .arg("--allow-read")
     .arg("--unstable")
     .arg("workers_test.ts")
     .spawn()

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1037,6 +1037,7 @@ fn compiler_api() {
     .arg("test")
     .arg("--unstable")
     .arg("--reload")
+    .arg("--allow-read")
     .arg("compiler_api_test.ts")
     .spawn()
     .unwrap()

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -11,8 +11,7 @@ use crate::global_state::GlobalState;
 use crate::msg;
 use crate::op_error::OpError;
 use crate::ops;
-use crate::ops::JsonResult;
-use crate::permissions::DenoPermissions;
+use crate::permissions::Permissions;
 use crate::source_maps::SourceMapGetter;
 use crate::startup_data;
 use crate::state::State;
@@ -599,7 +598,7 @@ impl TsCompiler {
   ) -> std::io::Result<()> {
     let source_file = self
       .file_fetcher
-      .fetch_cached_source_file(&module_specifier, DenoPermissions::default())
+      .fetch_cached_source_file(&module_specifier, Permissions::default())
       .expect("Source file not found");
 
     // NOTE: JavaScript files are only cached to disk if `checkJs`
@@ -616,7 +615,7 @@ impl TsCompiler {
     self.mark_compiled(module_specifier.as_url());
     let source_file = self
       .file_fetcher
-      .fetch_cached_source_file(&module_specifier, DenoPermissions::default())
+      .fetch_cached_source_file(&module_specifier, Permissions::default())
       .expect("Source file not found");
 
     let version_hash = source_code_version_hash(
@@ -671,7 +670,7 @@ impl TsCompiler {
   ) -> std::io::Result<()> {
     let source_file = self
       .file_fetcher
-      .fetch_cached_source_file(&module_specifier)
+      .fetch_cached_source_file(&module_specifier, Permissions::default())
       .expect("Source file not found");
 
     // NOTE: JavaScript files are only cached to disk if `checkJs`
@@ -726,7 +725,7 @@ impl TsCompiler {
     if let Some(module_specifier) = self.try_to_resolve(script_name) {
       return self.file_fetcher.fetch_cached_source_file(
         &module_specifier,
-        DenoPermissions::default(),
+        Permissions::default(),
       );
     }
 

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -723,10 +723,9 @@ impl TsCompiler {
     script_name: &str,
   ) -> Option<SourceFile> {
     if let Some(module_specifier) = self.try_to_resolve(script_name) {
-      return self.file_fetcher.fetch_cached_source_file(
-        &module_specifier,
-        Permissions::default(),
-      );
+      return self
+        .file_fetcher
+        .fetch_cached_source_file(&module_specifier, Permissions::default());
     }
 
     None

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -598,7 +598,7 @@ impl TsCompiler {
   ) -> std::io::Result<()> {
     let source_file = self
       .file_fetcher
-      .fetch_cached_source_file(&module_specifier, Permissions::default())
+      .fetch_cached_source_file(&module_specifier, Permissions::allow_all())
       .expect("Source file not found");
 
     // NOTE: JavaScript files are only cached to disk if `checkJs`
@@ -615,7 +615,7 @@ impl TsCompiler {
     self.mark_compiled(module_specifier.as_url());
     let source_file = self
       .file_fetcher
-      .fetch_cached_source_file(&module_specifier, Permissions::default())
+      .fetch_cached_source_file(&module_specifier, Permissions::allow_all())
       .expect("Source file not found");
 
     let version_hash = source_code_version_hash(
@@ -670,7 +670,7 @@ impl TsCompiler {
   ) -> std::io::Result<()> {
     let source_file = self
       .file_fetcher
-      .fetch_cached_source_file(&module_specifier, Permissions::default())
+      .fetch_cached_source_file(&module_specifier, Permissions::allow_all())
       .expect("Source file not found");
 
     // NOTE: JavaScript files are only cached to disk if `checkJs`
@@ -725,7 +725,7 @@ impl TsCompiler {
     if let Some(module_specifier) = self.try_to_resolve(script_name) {
       return self
         .file_fetcher
-        .fetch_cached_source_file(&module_specifier, Permissions::default());
+        .fetch_cached_source_file(&module_specifier, Permissions::allow_all());
     }
 
     None

--- a/docs/runtime/compiler_apis.md
+++ b/docs/runtime/compiler_apis.md
@@ -15,9 +15,11 @@ fully qualified module name, and the value is the text source of the module. If
 `sources` is passed, Deno will resolve all the modules from within that hash and
 not attempt to resolve them outside of Deno. If `sources` are not provided, Deno
 will resolve modules as if the root module had been passed on the command line.
-Deno will also cache any of these resources. The `options` argument is a set of
-options of type `Deno.CompilerOptions`, which is a subset of the TypeScript
-compiler options containing the ones supported by Deno.
+Deno will also cache any of these resources. All resolved resources are treated
+as dynamic imports and require read or net permissions depending if they're
+local or remote. The `options` argument is a set of options of type
+`Deno.CompilerOptions`, which is a subset of the TypeScript compiler options
+containing the ones supported by Deno.
 
 The method resolves with a tuple. The first argument contains any diagnostics
 (syntax or type errors) related to the code. The second argument is a map where
@@ -63,10 +65,12 @@ The `sources` is a hash where the key is the fully qualified module name, and
 the value is the text source of the module. If `sources` is passed, Deno will
 resolve all the modules from within that hash and not attempt to resolve them
 outside of Deno. If `sources` are not provided, Deno will resolve modules as if
-the root module had been passed on the command line. Deno will also cache any of
-these resources. The `options` argument is a set of options of type
-`Deno.CompilerOptions`, which is a subset of the TypeScript compiler options
-containing the ones supported by Deno.
+the root module had been passed on the command line. All resolved resources are
+treated as dynamic imports and require read or net permissions depending if
+they're local or remote. Deno will also cache any of these resources. The
+`options` argument is a set of options of type `Deno.CompilerOptions`, which is
+a subset of the TypeScript compiler options containing the ones supported by
+Deno.
 
 An example of providing sources:
 

--- a/docs/runtime/workers.md
+++ b/docs/runtime/workers.md
@@ -18,6 +18,50 @@ new Worker("./worker.js");
 new Worker("./worker.js", { type: "classic" });
 ```
 
+### Permissions
+
+Creating new `Worker` instance is treated the same way as a dynamic import;
+therefore appropriate permission is required depending if worker uses local or
+remote code.
+
+Local workers require `--allow-read` permission:
+
+```ts
+// main.ts
+new Worker("./worker.ts", { type: "module" });
+
+// worker.ts
+console.log("hello world");
+self.close();
+```
+
+```shell
+$ deno run main.ts
+error: Uncaught PermissionDenied: read access to "./worker.ts", run again with the --allow-read flag
+
+$ deno run --allow-read main.ts
+hello world
+```
+
+Remote workers require `--allow-net` permission:
+
+```ts
+// main.ts
+new Worker("https://example.com/worker.ts", { type: "module" });
+
+// worker.ts
+console.log("hello world");
+self.close();
+```
+
+```shell
+$ deno run main.ts
+error: Uncaught PermissionDenied: net access to "https://example.com/worker.ts", run again with the --allow-net flag
+
+$ deno run --allow-net main.ts
+hello world
+```
+
 ### Using Deno in worker
 
 > This is an unstable Deno feature. Learn more about

--- a/docs/runtime/workers.md
+++ b/docs/runtime/workers.md
@@ -20,11 +20,10 @@ new Worker("./worker.js", { type: "classic" });
 
 ### Permissions
 
-Creating new `Worker` instance is treated the same way as a dynamic import;
-therefore appropriate permission is required depending if worker uses local or
-remote code.
+Creating a new `Worker` instance is similar to a dynamic import; therefore Deno
+requires appropriate permission for this action.
 
-Local workers require `--allow-read` permission:
+For workers using local modules; `--allow-read` permission is required:
 
 ```ts
 // main.ts
@@ -43,7 +42,7 @@ $ deno run --allow-read main.ts
 hello world
 ```
 
-Remote workers require `--allow-net` permission:
+For workers using remote modules; `--allow-read` permission is required:
 
 ```ts
 // main.ts


### PR DESCRIPTION
This PR hot-fixes permission escapes in dynamic imports, workers 
and runtime compiler APIs.

`permissions` parameter was added to public APIs of `SourceFileFetcher`
and appropriate permission checks are performed during loading of 
local and remote files.

Fixes #4781
Fixes #4744 