### PR TITLE
std/node: toString for globals

### DIFF
--- a/std/node/global.ts
+++ b/std/node/global.ts
@@ -1,2 +1,9 @@
+Object.defineProperty(globalThis, Symbol.toStringTag, {
+  value: 'global',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});
+
 // @ts-ignore
 globalThis["global"] = globalThis;

--- a/std/node/global.ts
+++ b/std/node/global.ts
@@ -1,8 +1,8 @@
 Object.defineProperty(globalThis, Symbol.toStringTag, {
-  value: 'global',
+  value: "global",
   writable: false,
   enumerable: false,
-  configurable: true
+  configurable: true,
 });
 
 // @ts-ignore

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -38,6 +38,13 @@ export const process = {
   },
 };
 
+Object.defineProperty(process, Symbol.toStringTag, {
+  enumerable: false,
+  writable: true,
+  configurable: false,
+  value: 'process'
+});
+
 Object.defineProperty(globalThis, "process", {
   value: process,
   enumerable: false,

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -42,7 +42,7 @@ Object.defineProperty(process, Symbol.toStringTag, {
   enumerable: false,
   writable: true,
   configurable: false,
-  value: 'process'
+  value: "process",
 });
 
 Object.defineProperty(globalThis, "process", {


### PR DESCRIPTION
Some modules check for `process+'' === '[object process]'`.