### PR TITLE
fix:(fmt): Format `abstract async` as `abstract async`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d80078f5e36e7e697f5f1cc175cacb4cb206fd5f95c918023778b0a944b33"
+checksum = "d8f6bd2fcf216220b940683d47aa9a6231a3f039ae3303067ed3af60e606eb04"
 dependencies = [
  "dprint-core",
  "serde",
@@ -2431,9 +2431,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.21.9"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b59bca66689a8e1417c5c7ee3e969bb4a933af8fb00ddbc75a89dfcf5d8df4f8"
+checksum = "4eb9f7ffcb1d0fac1a6002a5775ef56defcc44dff43e333bbe6fe3804062fde1"
 dependencies = [
  "either",
  "enum_kind",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.14.0"
+dprint-plugin-typescript = "0.14.1"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.1"


### PR DESCRIPTION
So, `async` is an implementation modifier and doesn't really make sense on `abstract` methods. That said, if someone does `abstract async` then I've changed this to format as `abstract async` instead of `async abstract` (it would flip it before).

That said, swc does not know how to parse `async abstract`... it only knows `abstract async` (both are fine with the TS compiler at the moment). I went to go fix this in swc then thought it wasn't worth the effort though for these reasons:

1. It added a bit more complexity into swc.
2. TypeScript allowing the `async` modifier on abstract methods is a bug. They won't allow it in the future: https://github.com/microsoft/TypeScript/issues/28516 -- So instead of having this temporarily in swc, we should probably fix that bug in the TS compiler.

Anyway, so now it just formats as-is for `abstract async` and still errors on `async abstract`, but in the future TS will error on both of these.

Closes #5014