### PR TITLE
BREAKING: reorder std/io/utils copyBytes arguments

### DIFF
--- a/std/bytes/mod.ts
+++ b/std/bytes/mod.ts
@@ -86,10 +86,10 @@ export function repeat(b: Uint8Array, count: number): Uint8Array {
 
   const nb = new Uint8Array(b.length * count);
 
-  let bp = copyBytes(nb, b);
+  let bp = copyBytes(b, nb);
 
   for (; bp < nb.length; bp *= 2) {
-    copyBytes(nb, nb.slice(0, bp), bp);
+    copyBytes(nb.slice(0, bp), nb, bp);
   }
 
   return nb;

--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -149,7 +149,7 @@ export class BufReader implements Reader {
     }
 
     // copy as much as we can
-    const copied = copyBytes(p, this.buf.subarray(this.r, this.w), 0);
+    const copied = copyBytes(this.buf.subarray(this.r, this.w), p, 0);
     this.r += copied;
     // this.lastByte = this.buf[this.r - 1];
     // this.lastCharSize = -1;
@@ -509,7 +509,7 @@ export class BufWriter extends AbstractBufBase implements Writer {
           throw e;
         }
       } else {
-        numBytesWritten = copyBytes(this.buf, data, this.usedBufferBytes);
+        numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
         this.usedBufferBytes += numBytesWritten;
         await this.flush();
       }
@@ -517,7 +517,7 @@ export class BufWriter extends AbstractBufBase implements Writer {
       data = data.subarray(numBytesWritten);
     }
 
-    numBytesWritten = copyBytes(this.buf, data, this.usedBufferBytes);
+    numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
     this.usedBufferBytes += numBytesWritten;
     totalBytesWritten += numBytesWritten;
     return totalBytesWritten;
@@ -603,7 +603,7 @@ export class BufWriterSync extends AbstractBufBase implements WriterSync {
           throw e;
         }
       } else {
-        numBytesWritten = copyBytes(this.buf, data, this.usedBufferBytes);
+        numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
         this.usedBufferBytes += numBytesWritten;
         this.flush();
       }
@@ -611,7 +611,7 @@ export class BufWriterSync extends AbstractBufBase implements WriterSync {
       data = data.subarray(numBytesWritten);
     }
 
-    numBytesWritten = copyBytes(this.buf, data, this.usedBufferBytes);
+    numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
     this.usedBufferBytes += numBytesWritten;
     totalBytesWritten += numBytesWritten;
     return totalBytesWritten;

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -201,7 +201,7 @@ class TestReader implements Reader {
     if (nread === 0) {
       return Promise.resolve(null);
     }
-    copyBytes(buf as Uint8Array, this.data);
+    copyBytes(this.data, buf as Uint8Array);
     this.data = this.data.subarray(nread);
     return Promise.resolve(nread);
   }

--- a/std/io/util.ts
+++ b/std/io/util.ts
@@ -9,12 +9,12 @@ import { encode } from "../encoding/utf8.ts";
  * Copy bytes from one Uint8Array to another.  Bytes from `src` which don't fit
  * into `dst` will not be copied.
  *
- * @param dst Destination byte array
  * @param src Source byte array
+ * @param dst Destination byte array
  * @param off Offset into `dst` at which to begin writing values from `src`.
  * @return number of bytes copied
  */
-export function copyBytes(dst: Uint8Array, src: Uint8Array, off = 0): number {
+export function copyBytes(src: Uint8Array, dst: Uint8Array, off = 0): number {
   off = Math.max(0, Math.min(off, dst.byteLength));
   const dstBytesAvailable = dst.byteLength - off;
   if (src.byteLength > dstBytesAvailable) {

--- a/std/io/util_test.ts
+++ b/std/io/util_test.ts
@@ -9,13 +9,13 @@ test("[io/tuil] copyBytes", function (): void {
 
   dst.fill(0);
   let src = Uint8Array.of(1, 2);
-  let len = copyBytes(dst, src, 0);
+  let len = copyBytes(src, dst, 0);
   assert(len === 2);
   assertEquals(dst, Uint8Array.of(1, 2, 0, 0));
 
   dst.fill(0);
   src = Uint8Array.of(1, 2);
-  len = copyBytes(dst, src, 1);
+  len = copyBytes(src, dst, 1);
   assert(len === 2);
   assertEquals(dst, Uint8Array.of(0, 1, 2, 0));
 
@@ -27,13 +27,13 @@ test("[io/tuil] copyBytes", function (): void {
 
   dst.fill(0);
   src = Uint8Array.of(1, 2);
-  len = copyBytes(dst, src, 100);
+  len = copyBytes(src, dst, 100);
   assert(len === 0);
   assertEquals(dst, Uint8Array.of(0, 0, 0, 0));
 
   dst.fill(0);
   src = Uint8Array.of(3, 4);
-  len = copyBytes(dst, src, -2);
+  len = copyBytes(src, dst, -2);
   assert(len === 2);
   assertEquals(dst, Uint8Array.of(3, 4, 0, 0));
 });

--- a/std/io/util_test.ts
+++ b/std/io/util_test.ts
@@ -21,7 +21,7 @@ test("[io/tuil] copyBytes", function (): void {
 
   dst.fill(0);
   src = Uint8Array.of(1, 2, 3, 4, 5);
-  len = copyBytes(dst, src);
+  len = copyBytes(src, dst);
   assert(len === 4);
   assertEquals(dst, Uint8Array.of(1, 2, 3, 4));
 

--- a/std/ws/mod.ts
+++ b/std/ws/mod.ts
@@ -338,11 +338,11 @@ class WebSocketImpl implements WebSocket {
   async read(p: Uint8Array): Promise<number | null> {
     for await (const ev of this.receive()) {
       if (ev instanceof Uint8Array) {
-        return copyBytes(p, ev);
+        return copyBytes(ev, p);
       }
 
       if (typeof ev === "string") {
-        return copyBytes(p, encode(ev));
+        return copyBytes(encode(ev), p);
       }
     }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
Reorder `copyBytes` argument to match other `Deno.copy` / `copyN` implementations.