### PR TITLE
BREAKING: disallow static import of local modules from remote modules

### DIFF
--- a/cli/tests/error_local_static_import_from_remote.js
+++ b/cli/tests/error_local_static_import_from_remote.js
@@ -1,0 +1,1 @@
+import "file:///some/dir/file.js";

--- a/cli/tests/error_local_static_import_from_remote.js.out
+++ b/cli/tests/error_local_static_import_from_remote.js.out
@@ -1,0 +1,2 @@
+[WILDCARD]
+Remote module are not allowed to statically import local modules. Use dynamic import instead.

--- a/cli/tests/error_local_static_import_from_remote.ts
+++ b/cli/tests/error_local_static_import_from_remote.ts
@@ -1,0 +1,1 @@
+import "file:///some/dir/file.ts";

--- a/cli/tests/error_local_static_import_from_remote.ts.out
+++ b/cli/tests/error_local_static_import_from_remote.ts.out
@@ -1,0 +1,9 @@
+[WILDCARD]
+error: Uncaught PermissionDenied: Remote module are not allowed to statically import local modules. Use dynamic import instead.
+    at unwrapResponse ($deno$/ops/dispatch_json.ts:[WILDCARD])
+    at Object.sendAsync ($deno$/ops/dispatch_json.ts:[WILDCARD])
+    at async processImports ($deno$/compiler/imports.ts:[WILDCARD])
+    at async Object.processImports ($deno$/compiler/imports.ts:[WILDCARD])
+    at async compile ([WILDCARD]compiler.ts:[WILDCARD])
+    at async tsCompilerOnMessage ([WILDCARD]compiler.ts:[WILDCARD])
+    at async workerMessageRecvCallback ($deno$/runtime_worker.ts:[WILDCARD])

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1422,6 +1422,22 @@ itest!(error_type_definitions {
   output: "error_type_definitions.ts.out",
 });
 
+itest!(error_local_static_import_from_remote_ts {
+  args: "run --reload http://localhost:4545/cli/tests/error_local_static_import_from_remote.ts",
+  check_stderr: true,
+  exit_code: 1,
+  http_server: true,
+  output: "error_local_static_import_from_remote.ts.out",
+});
+
+itest!(error_local_static_import_from_remote_js {
+  args: "run --reload http://localhost:4545/cli/tests/error_local_static_import_from_remote.js",
+  check_stderr: true,
+  exit_code: 1,
+  http_server: true,
+  output: "error_local_static_import_from_remote.js.out",
+});
+
 // TODO(bartlomieju) Re-enable
 itest_ignore!(error_worker_dynamic {
   args: "run --reload error_worker_dynamic.ts",


### PR DESCRIPTION
This commit changes module loading logic to disallow statically import
local module (file:// scheme) from remote modules (http://, https://
schemes).

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
