### PR TITLE
Web API: window.localStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg 1.0.0",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard 1.1.0",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +517,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sled",
  "sourcemap",
  "swc_ecma_visit",
  "sys-info",
@@ -738,6 +754,16 @@ dependencies = [
  "proc-macro2 1.0.10",
  "swc_macros_common",
  "syn 1.0.17",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1197,7 +1223,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 dependencies = [
  "owning_ref 0.4.1",
- "scopeguard",
+ "scopeguard 0.3.3",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard 1.1.0",
 ]
 
 [[package]]
@@ -1235,6 +1270,15 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "memoffset"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+dependencies = [
+ "autocfg 1.0.0",
+]
 
 [[package]]
 name = "mime"
@@ -1530,8 +1574,18 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 dependencies = [
- "lock_api",
+ "lock_api 0.1.5",
  "parking_lot_core 0.4.0",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.2",
 ]
 
 [[package]]
@@ -1556,6 +1610,20 @@ dependencies = [
  "rand 0.6.5",
  "rustc_version",
  "smallvec 0.6.13",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.3.0",
  "winapi 0.3.8",
 ]
 
@@ -2150,6 +2218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "sct"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,6 +2360,22 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "sled"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb6824dde66ad33bf20c6e8476f5b82b871bc8bc3c129a10ea2f7dae5060fa3"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log 0.4.8",
+ "parking_lot 0.10.2",
+]
 
 [[package]]
 name = "smallvec"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,6 +50,7 @@ rustyline = "6.1.0"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_derive = "1.0.106"
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
+sled = "0.31.0"
 sys-info = "=0.5.8" # 0.5.9 and 0.5.10 are broken on windows.
 sourcemap = "5.0.0"
 tempfile = "3.1.0"

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -25,6 +25,7 @@ import * as request from "./web/request.ts";
 import * as readableStream from "./web/streams/readable_stream.ts";
 import * as queuingStrategy from "./web/streams/queuing_strategy.ts";
 import * as writableStream from "./web/streams/writable_stream.ts";
+import * as storage from "./web/storage.ts";
 
 // These imports are not exposed and therefore are fine to just import the
 // symbols required.
@@ -239,6 +240,13 @@ export const windowOrWorkerGlobalScopeProperties = {
   performance: writable(new performanceUtil.Performance()),
   Worker: nonEnumerable(workers.WorkerImpl),
   WritableStream: nonEnumerable(writableStream.WritableStreamImpl),
+};
+
+export const windowGlobalScopeProperties = {
+  localStorage: getterOnly(() => {
+    throw new (class SecurityError extends domException.DOMExceptionImpl {})();
+  }),
+  sessionStorage: readOnly(storage.sessionStorage),
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -245,6 +245,7 @@ export const windowOrWorkerGlobalScopeProperties = {
 let localStorageIsReady = false;
 export const windowGlobalScopeProperties = {
   localStorage: getterOnly(() => {
+    // @ts-ignore
     const { origin } = location;
     // if (origin === "file://") {
     // throw new domException.DOMExceptionImpl(

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -242,9 +242,21 @@ export const windowOrWorkerGlobalScopeProperties = {
   WritableStream: nonEnumerable(writableStream.WritableStreamImpl),
 };
 
+let localStorageIsReady = false;
 export const windowGlobalScopeProperties = {
   localStorage: getterOnly(() => {
-    throw new (class SecurityError extends domException.DOMExceptionImpl {})();
+    const { origin } = location;
+    // if (origin === "file://") {
+    // throw new domException.DOMExceptionImpl(
+    //   "localStorage is disabled on non-trusted origin",
+    //   "SecurityError"
+    // );
+    // } else
+    if (!localStorageIsReady) {
+      storage.localStorageInit(origin);
+      localStorageIsReady = true;
+    }
+    return storage.localStorage;
   }),
   sessionStorage: readOnly(storage.sessionStorage),
 };

--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -1400,3 +1400,13 @@ declare const AbortSignal: {
   prototype: AbortSignal;
   new (): AbortSignal;
 };
+
+interface Storage {
+  readonly length: number;
+  key: (index: number) => string | null;
+  getItem: (keyName: string) => string | null;
+  setItem: (keyName: string, keyValue: string) => void;
+  removeItem: (keyName: string) => void;
+  clear: () => void;
+  [name: string]: any;
+}

--- a/cli/js/lib.deno.window.d.ts
+++ b/cli/js/lib.deno.window.d.ts
@@ -44,4 +44,7 @@ declare interface Crypto {
   ): T;
 }
 
+declare const sessionStorage: Storage;
+declare const localStorage: Storage;
+
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/cli/js/ops/local_storage.ts
+++ b/cli/js/ops/local_storage.ts
@@ -1,0 +1,30 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { sendSync } from "./dispatch_json.ts";
+
+export function localStorageInit(origin: string): {} {
+  return sendSync("op_local_storage_init", { origin });
+}
+
+export function localStorageClear(): void {
+  return sendSync("op_local_storage_clear", {});
+}
+
+export function localStorageGetItem(key: string): string | null {
+  return sendSync("op_local_storage_get_item", { key }).value;
+}
+
+export function localStorageGetLength(): number {
+  return sendSync("op_local_storage_get_length", {}).length;
+}
+
+export function localStorageSetItem(
+  key: string,
+  value: string
+): { error?: string } {
+  return sendSync("op_local_storage_set_item", { key, value });
+}
+
+export function localStorageRemoveItem(key: string): void {
+  return sendSync("op_local_storage_remove_item", { key });
+}

--- a/cli/js/runtime_main.ts
+++ b/cli/js/runtime_main.ts
@@ -17,6 +17,7 @@ import {
   writable,
   windowOrWorkerGlobalScopeMethods,
   windowOrWorkerGlobalScopeProperties,
+  windowGlobalScopeProperties,
   eventTargetProperties,
   setEventTargetData,
 } from "./globals.ts";
@@ -79,6 +80,7 @@ export function bootstrapMainRuntime(): void {
   hasBootstrapped = true;
   Object.defineProperties(globalThis, windowOrWorkerGlobalScopeMethods);
   Object.defineProperties(globalThis, windowOrWorkerGlobalScopeProperties);
+  Object.defineProperties(globalThis, windowGlobalScopeProperties);
   Object.defineProperties(globalThis, eventTargetProperties);
   Object.defineProperties(globalThis, mainRuntimeGlobalProperties);
   setEventTargetData(globalThis);

--- a/cli/js/tests/storage_test.ts
+++ b/cli/js/tests/storage_test.ts
@@ -75,6 +75,80 @@ unitTest(function lengthShouldBeZeroWhenStorageIsCleared() {
   assertEquals(sessionStorage.length, 0);
 });
 
-unitTest(function accessingLocalStorageShouldThrow() {
-  assertThrows(() => localStorage.length);
+unitTest(function getItemFromUnknownKeyShouldReturnNull() {
+  assertEquals(localStorage.getItem("unknonw_key"), null);
+  assertEquals(localStorage["unknonw_key"], null);
 });
+
+unitTest(function getItemAfterSetItemShouldReturnGivenValue() {
+  const value = "" + Math.random();
+  localStorage.setItem("test_key", value);
+  assertEquals(localStorage.getItem("test_key"), value);
+  assertEquals(localStorage["test_key"], value);
+});
+
+unitTest(function getItemAfterRemoveItemShouldReturnNull() {
+  const value = "" + Math.random();
+  localStorage.setItem("test_key", value);
+  localStorage.removeItem("test_key");
+  assertEquals(localStorage.getItem("test_key"), null);
+  assertEquals(localStorage["test_key"], null);
+});
+
+unitTest(function getItemAfterClearShouldReturnNull() {
+  const value = "" + Math.random();
+  localStorage.setItem("test_key", value);
+  localStorage.clear();
+  assertEquals(localStorage.getItem("test_key"), null);
+  assertEquals(localStorage["test_key"], null);
+});
+
+unitTest(function removeItemFromUnknownKeyShouldDoNothing() {
+  assertEquals(localStorage.removeItem("unknonw_key"), undefined);
+  assertEquals(delete localStorage["unknonw_key"], true);
+});
+
+// unitTest(function keyMethodShouldReturnSetKey() {
+//   const key = "" + Math.random();
+
+//   localStorage.clear();
+//   localStorage.setItem(key, "value");
+//   assertEquals(localStorage.key(0), key);
+// });
+
+unitTest(function lengthShouldGrowWhenAddingItem() {
+  const key = "" + Math.random();
+
+  const expectedLength = localStorage.length + 1;
+  localStorage[key] = "value";
+  assertEquals(localStorage.length, expectedLength);
+});
+
+unitTest(function lengthShouldNotGrowWhenUpdatingExistingItem() {
+  const key = "" + Math.random();
+
+  const expectedLength = localStorage.length + 1;
+  localStorage.setItem(key, "value");
+  assertEquals(localStorage.length, expectedLength);
+  localStorage[key] = "other value";
+  assertEquals(localStorage.length, expectedLength);
+});
+
+unitTest(function lengthShouldShrinkWhenRemovingAnItem() {
+  const key = "" + Math.random();
+
+  const expectedLength = localStorage.length;
+  localStorage[key] = "value";
+  assertEquals(localStorage.length, expectedLength + 1);
+  delete localStorage[key];
+  assertEquals(localStorage.length, expectedLength);
+});
+
+unitTest(function lengthShouldBeZeroWhenStorageIsCleared() {
+  localStorage.clear();
+  assertEquals(localStorage.length, 0);
+});
+
+// unitTest(function accessingLocalStorageShouldThrow() {
+//   assertThrows(() => localStorage.length);
+// });

--- a/cli/js/tests/storage_test.ts
+++ b/cli/js/tests/storage_test.ts
@@ -1,0 +1,80 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+import { unitTest, assertEquals, assertThrows } from "./test_util.ts";
+
+unitTest(function getItemFromUnknownKeyShouldReturnNull() {
+  assertEquals(sessionStorage.getItem("unknonw_key"), null);
+  assertEquals(sessionStorage["unknonw_key"], null);
+});
+
+unitTest(function getItemAfterSetItemShouldReturnGivenValue() {
+  const value = "" + Math.random();
+  sessionStorage.setItem("test_key", value);
+  assertEquals(sessionStorage.getItem("test_key"), value);
+  assertEquals(sessionStorage["test_key"], value);
+});
+
+unitTest(function getItemAfterRemoveItemShouldReturnNull() {
+  const value = "" + Math.random();
+  sessionStorage.setItem("test_key", value);
+  sessionStorage.removeItem("test_key");
+  assertEquals(sessionStorage.getItem("test_key"), null);
+  assertEquals(sessionStorage["test_key"], null);
+});
+
+unitTest(function getItemAfterClearShouldReturnNull() {
+  const value = "" + Math.random();
+  sessionStorage.setItem("test_key", value);
+  sessionStorage.clear();
+  assertEquals(sessionStorage.getItem("test_key"), null);
+  assertEquals(sessionStorage["test_key"], null);
+});
+
+unitTest(function removeItemFromUnknownKeyShouldDoNothing() {
+  assertEquals(sessionStorage.removeItem("unknonw_key"), undefined);
+  assertEquals(delete sessionStorage["unknonw_key"], true);
+});
+
+unitTest(function keyMethodShouldReturnSetKey() {
+  const key = "" + Math.random();
+
+  sessionStorage.clear();
+  sessionStorage.setItem(key, "value");
+  assertEquals(sessionStorage.key(0), key);
+});
+
+unitTest(function lengthShouldGrowWhenAddingItem() {
+  const key = "" + Math.random();
+
+  const expectedLength = sessionStorage.length + 1;
+  sessionStorage[key] = "value";
+  assertEquals(sessionStorage.length, expectedLength);
+});
+
+unitTest(function lengthShouldNotGrowWhenUpdatingExistingItem() {
+  const key = "" + Math.random();
+
+  const expectedLength = sessionStorage.length + 1;
+  sessionStorage.setItem(key, "value");
+  assertEquals(sessionStorage.length, expectedLength);
+  sessionStorage[key] = "other value";
+  assertEquals(sessionStorage.length, expectedLength);
+});
+
+unitTest(function lengthShouldShrinkWhenRemovingAnItem() {
+  const key = "" + Math.random();
+
+  const expectedLength = sessionStorage.length;
+  sessionStorage[key] = "value";
+  assertEquals(sessionStorage.length, expectedLength + 1);
+  delete sessionStorage[key];
+  assertEquals(sessionStorage.length, expectedLength);
+});
+
+unitTest(function lengthShouldBeZeroWhenStorageIsCleared() {
+  sessionStorage.clear();
+  assertEquals(sessionStorage.length, 0);
+});
+
+unitTest(function accessingLocalStorageShouldThrow() {
+  assertThrows(() => localStorage.length);
+});

--- a/cli/js/tests/storage_test.ts
+++ b/cli/js/tests/storage_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assertEquals, assertThrows } from "./test_util.ts";
+import { unitTest, assertEquals } from "./test_util.ts";
 
 unitTest(function getItemFromUnknownKeyShouldReturnNull() {
   assertEquals(sessionStorage.getItem("unknonw_key"), null);

--- a/cli/js/tests/unit_tests.ts
+++ b/cli/js/tests/unit_tests.ts
@@ -54,6 +54,7 @@ import "./signal_test.ts";
 import "./stat_test.ts";
 import "./streams_piping_test.ts";
 import "./streams_writable_test.ts";
+import "./storage_test.ts";
 import "./symlink_test.ts";
 import "./text_encoding_test.ts";
 import "./testing_test.ts";

--- a/cli/js/web/storage.ts
+++ b/cli/js/web/storage.ts
@@ -1,0 +1,61 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+
+const data = Symbol("internal Storage data");
+
+class NonPersistantStorageImpl implements Storage {
+  private [data]: Map<string, string> = new Map();
+
+  get length(): number {
+    return this[data].size;
+  }
+  key(index: number): string | null {
+    if (index >= this[data].size) {
+      return null;
+    } else {
+      return Array.from(this[data].keys())[index];
+    }
+  }
+  getItem(keyName: string): string | null {
+    return this[data].get(keyName) || null;
+  }
+  setItem(keyName: string, keyValue: string): void {
+    this[data].set(keyName, keyValue);
+  }
+  removeItem(keyName: string): void {
+    this[data].delete(keyName);
+  }
+  clear(): void {
+    this[data].clear();
+  }
+}
+
+const storageHandler = {
+  deleteProperty(target: Storage, key: string): boolean {
+    target.removeItem(key);
+    return true;
+  },
+  has(target: Storage, key: string): boolean {
+    return target.getItem(key) !== null || key in target;
+  },
+  get(target: Storage, key: string): string | null | number | void {
+    if ("undefined" !== typeof target[key]) {
+      // @ts-ignore
+      return Reflect.get(...arguments); // eslint-disable-line prefer-rest-params
+    } else {
+      return target.getItem(key);
+    }
+  },
+  set(target: Storage, key: string, value: string): boolean {
+    try {
+      target.setItem(key, value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};
+
+export const sessionStorage = new Proxy(
+  new NonPersistantStorageImpl(),
+  storageHandler
+);

--- a/cli/js/web/storage.ts
+++ b/cli/js/web/storage.ts
@@ -44,6 +44,7 @@ class PersistantStorageImpl implements Storage {
   }
   key(index: number): string | null {
     throw "Unimplemented";
+    index;
   }
   getItem(keyName: string): string | null {
     return localStorageGetItem(keyName);

--- a/cli/ops/local_storage.rs
+++ b/cli/ops/local_storage.rs
@@ -7,9 +7,13 @@ use deno_core::ZeroCopyBuf;
 
 pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op(
-    "op_local_storage_init", s.stateful_json_op(op_local_storage_init));
+    "op_local_storage_init",
+    s.stateful_json_op(op_local_storage_init),
+  );
   i.register_op(
-    "op_local_storage_clear", s.stateful_json_op(op_local_storage_clear));
+    "op_local_storage_clear",
+    s.stateful_json_op(op_local_storage_clear),
+  );
   i.register_op(
     "op_local_storage_get_item",
     s.stateful_json_op(op_local_storage_get_item),
@@ -53,15 +57,19 @@ fn op_local_storage_clear(
   _data: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let state = state.borrow();
-  state.local_storage_db.as_ref().expect("localStorage must initiated before use")
-    .clear().expect("Failed to clear localStorage");
+  state
+    .local_storage_db
+    .as_ref()
+    .expect("localStorage must initiated before use")
+    .clear()
+    .expect("Failed to clear localStorage");
   Ok(JsonOp::Sync(json!({})))
 }
 
 #[derive(Deserialize)]
 struct AccessLocalStorageArgs {
   key: String,
-  value: Option<String>
+  value: Option<String>,
 }
 
 fn op_local_storage_get_item(
@@ -72,14 +80,17 @@ fn op_local_storage_get_item(
   let args: AccessLocalStorageArgs = serde_json::from_value(args)?;
   let key_name = args.key.as_bytes();
   let state = state.borrow();
-  let value = state.local_storage_db.as_ref().expect("localStorage must initiated before use").get(key_name).unwrap();
-  
-  Ok(JsonOp::Sync(
-    match value {
-      Some(v) => json!({"value": String::from_utf8(v.to_vec()).unwrap()}),
-      None => json!({"value":serde_json::Value::Null}),
-    }
-  ))
+  let value = state
+    .local_storage_db
+    .as_ref()
+    .expect("localStorage must initiated before use")
+    .get(key_name)
+    .unwrap();
+
+  Ok(JsonOp::Sync(match value {
+    Some(v) => json!({"value": String::from_utf8(v.to_vec()).unwrap()}),
+    None => json!({ "value": serde_json::Value::Null }),
+  }))
 }
 
 fn op_local_storage_get_length(
@@ -88,7 +99,11 @@ fn op_local_storage_get_length(
   _data: Option<ZeroCopyBuf>,
 ) -> Result<JsonOp, OpError> {
   let state = state.borrow();
-  let length = state.local_storage_db.as_ref().expect("localStorage must initiated before use").len();
+  let length = state
+    .local_storage_db
+    .as_ref()
+    .expect("localStorage must initiated before use")
+    .len();
   Ok(JsonOp::Sync(json!({ "length": length })))
 }
 
@@ -100,10 +115,14 @@ fn op_local_storage_remove_item(
 ) -> Result<JsonOp, OpError> {
   let args: AccessLocalStorageArgs = serde_json::from_value(args)?;
   let key_name = args.key.as_bytes();
-  
+
   let state = state.borrow();
-  state.local_storage_db.as_ref().expect("localStorage must initiated before use")
-    .remove(key_name).expect("Failed to remove item from localStorage");
+  state
+    .local_storage_db
+    .as_ref()
+    .expect("localStorage must initiated before use")
+    .remove(key_name)
+    .expect("Failed to remove item from localStorage");
 
   Ok(JsonOp::Sync(json!({})))
 }
@@ -118,13 +137,16 @@ fn op_local_storage_set_item(
   let key_name = args.key.as_bytes();
   let key_value = args.value.expect("Must provide a value");
   let key_value = key_value.as_bytes();
-  
+
   let state = state.borrow();
-  let insertion = state.local_storage_db.as_ref().expect("localStorage must initiated before use").insert(key_name, key_value);
+  let insertion = state
+    .local_storage_db
+    .as_ref()
+    .expect("localStorage must initiated before use")
+    .insert(key_name, key_value);
 
   match insertion {
     Ok(_v) => serde::export::Ok(JsonOp::Sync(json!({}))),
-    Err(_e) => serde::export::Ok(JsonOp::Sync(json!({"error": "error"})))
+    Err(_e) => serde::export::Ok(JsonOp::Sync(json!({"error": "error"}))),
   }
-
 }

--- a/cli/ops/local_storage.rs
+++ b/cli/ops/local_storage.rs
@@ -1,0 +1,130 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use super::dispatch_json::{Deserialize, JsonOp, Value};
+use crate::op_error::OpError;
+use crate::state::State;
+use deno_core::CoreIsolate;
+use deno_core::ZeroCopyBuf;
+
+pub fn init(i: &mut CoreIsolate, s: &State) {
+  i.register_op(
+    "op_local_storage_init", s.stateful_json_op(op_local_storage_init));
+  i.register_op(
+    "op_local_storage_clear", s.stateful_json_op(op_local_storage_clear));
+  i.register_op(
+    "op_local_storage_get_item",
+    s.stateful_json_op(op_local_storage_get_item),
+  );
+  i.register_op(
+    "op_local_storage_get_length",
+    s.stateful_json_op(op_local_storage_get_length),
+  );
+  i.register_op(
+    "op_local_storage_set_item",
+    s.stateful_json_op(op_local_storage_set_item),
+  );
+  i.register_op(
+    "op_local_storage_remove_item",
+    s.stateful_json_op(op_local_storage_remove_item),
+  );
+}
+
+#[derive(Deserialize)]
+struct CreateLocalStorageArgs {
+  origin: String,
+}
+
+fn op_local_storage_init(
+  state: &State,
+  args: Value,
+  _data: Option<ZeroCopyBuf>,
+) -> Result<JsonOp, OpError> {
+  let args: CreateLocalStorageArgs = serde_json::from_value(args)?;
+
+  let mut state = state.borrow_mut();
+  state.local_storage_db = Some(sled::open(args.origin).unwrap());
+  drop(state);
+
+  Ok(JsonOp::Sync(json!({})))
+}
+
+fn op_local_storage_clear(
+  state: &State,
+  _args: Value,
+  _data: Option<ZeroCopyBuf>,
+) -> Result<JsonOp, OpError> {
+  let state = state.borrow();
+  state.local_storage_db.as_ref().expect("localStorage must initiated before use")
+    .clear().expect("Failed to clear localStorage");
+  Ok(JsonOp::Sync(json!({})))
+}
+
+#[derive(Deserialize)]
+struct AccessLocalStorageArgs {
+  key: String,
+  value: Option<String>
+}
+
+fn op_local_storage_get_item(
+  state: &State,
+  args: Value,
+  _data: Option<ZeroCopyBuf>,
+) -> Result<JsonOp, OpError> {
+  let args: AccessLocalStorageArgs = serde_json::from_value(args)?;
+  let key_name = args.key.as_bytes();
+  let state = state.borrow();
+  let value = state.local_storage_db.as_ref().expect("localStorage must initiated before use").get(key_name).unwrap();
+  
+  Ok(JsonOp::Sync(
+    match value {
+      Some(v) => json!({"value": String::from_utf8(v.to_vec()).unwrap()}),
+      None => json!({"value":serde_json::Value::Null}),
+    }
+  ))
+}
+
+fn op_local_storage_get_length(
+  state: &State,
+  _args: Value,
+  _data: Option<ZeroCopyBuf>,
+) -> Result<JsonOp, OpError> {
+  let state = state.borrow();
+  let length = state.local_storage_db.as_ref().expect("localStorage must initiated before use").len();
+  Ok(JsonOp::Sync(json!({ "length": length })))
+}
+
+/// Get message from guest worker as host
+fn op_local_storage_remove_item(
+  state: &State,
+  args: Value,
+  _data: Option<ZeroCopyBuf>,
+) -> Result<JsonOp, OpError> {
+  let args: AccessLocalStorageArgs = serde_json::from_value(args)?;
+  let key_name = args.key.as_bytes();
+  
+  let state = state.borrow();
+  state.local_storage_db.as_ref().expect("localStorage must initiated before use")
+    .remove(key_name).expect("Failed to remove item from localStorage");
+
+  Ok(JsonOp::Sync(json!({})))
+}
+
+/// Post message to guest worker as host
+fn op_local_storage_set_item(
+  state: &State,
+  args: Value,
+  _data: Option<ZeroCopyBuf>,
+) -> Result<JsonOp, OpError> {
+  let args: AccessLocalStorageArgs = serde_json::from_value(args)?;
+  let key_name = args.key.as_bytes();
+  let key_value = args.value.expect("Must provide a value");
+  let key_value = key_value.as_bytes();
+  
+  let state = state.borrow();
+  let insertion = state.local_storage_db.as_ref().expect("localStorage must initiated before use").insert(key_name, key_value);
+
+  match insertion {
+    Ok(_v) => serde::export::Ok(JsonOp::Sync(json!({}))),
+    Err(_e) => serde::export::Ok(JsonOp::Sync(json!({"error": "error"})))
+  }
+
+}

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -14,6 +14,7 @@ pub mod fetch;
 pub mod fs;
 pub mod fs_events;
 pub mod io;
+pub mod local_storage;
 pub mod net;
 #[cfg(unix)]
 mod net_unix;

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -66,6 +66,7 @@ pub struct StateInner {
   pub seeded_rng: Option<StdRng>,
   pub target_lib: TargetLib,
   pub debug_type: DebugType,
+  pub local_storage_db: Option<sled::Db>,
 }
 
 impl State {
@@ -394,6 +395,7 @@ impl State {
       seeded_rng,
       target_lib: TargetLib::Main,
       debug_type,
+      local_storage_db: None,
     }));
 
     Ok(Self(state))
@@ -429,6 +431,7 @@ impl State {
       seeded_rng,
       target_lib: TargetLib::Worker,
       debug_type: DebugType::Dependent,
+      local_storage_db: None,
     }));
 
     Ok(Self(state))

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -243,6 +243,7 @@ impl MainWorker {
       ops::fs::init(isolate, &state);
       ops::fs_events::init(isolate, &state);
       ops::io::init(isolate, &state);
+      ops::local_storage::init(isolate, &state);
       ops::plugins::init(isolate, &state);
       ops::net::init(isolate, &state);
       ops::tls::init(isolate, &state);


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
Implementation of `window.localStorage` on top of #4973 using the [sled](https://docs.rs/sled/0.31.0/sled/) crates. Please ignore the `sessionStorage` implementation, this PR focuses on commit https://github.com/denoland/deno/commit/b3c225f8e74046e8746524bac08c39f98cff22a9.

This should not land as is, I built it as a proof of concept of what a `localStorage` implementation for Deno could look like. We would need to discuss about:

* [a CLI flag for this feature](https://github.com/denoland/deno/issues/4981).
* Where should the sled db files be written (currently `$CWD/$ORIGIN`...).
* the [security implications](https://github.com/denoland/deno/issues/1657#issuecomment-612484399).
* Code quality: I'm new to Rust, I doubt my code is up to Deno's standards.

Regarding the implementation, I tried to stick to the HTML specs and failed:
   * `localStorage.clear` should be atomic, the [sled method I use is not](https://docs.rs/sled/0.31.0/sled/struct.Db.html?search=#method.clear).
   * `localStorage.key` is not implemented.

Blocked by https://github.com/denoland/deno/pull/4973