### PR TITLE
[std/node] add the ability to path argument to be URL type

### DIFF
--- a/std/node/_fs/_fs_access.ts
+++ b/std/node/_fs/_fs_access.ts
@@ -5,19 +5,19 @@ import { notImplemented } from "../_utils.ts";
 
 /** Revist once https://github.com/denoland/deno/issues/4017 lands */
 
-//TODO - 'path' can also be a Buffer or URL.  Neither of these polyfills
+//TODO - 'path' can also be a Buffer.  Neither of these polyfills
 //is available yet.  See https://github.com/denoland/deno/issues/3403
 export function access(
-  path: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+  path: string | URL, // eslint-disable-line @typescript-eslint/no-unused-vars
   modeOrCallback: number | Function, // eslint-disable-line @typescript-eslint/no-unused-vars
   callback?: CallbackWithError // eslint-disable-line @typescript-eslint/no-unused-vars
 ): void {
   notImplemented("Not yet available");
 }
 
-//TODO - 'path' can also be a Buffer or URL.  Neither of these polyfills
+//TODO - 'path' can also be a Buffer.  Neither of these polyfills
 //is available yet.  See https://github.com/denoland/deno/issues/3403
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function accessSync(path: string, mode?: number): void {
+export function accessSync(path: string | URL, mode?: number): void {
   notImplemented("Not yet available");
 }

--- a/std/node/_fs/_fs_appendFile.ts
+++ b/std/node/_fs/_fs_appendFile.ts
@@ -28,9 +28,7 @@ export function appendFile(
   new Promise((resolve, reject) => {
     if (typeof pathOrRid === "number") {
       rid = pathOrRid;
-      Deno.write(rid, buffer)
-        .then(resolve)
-        .catch(reject);
+      Deno.write(rid, buffer).then(resolve).catch(reject);
     } else {
       const mode: number | undefined = isFileOptions(options)
         ? options.mode
@@ -56,7 +54,7 @@ export function appendFile(
       closeRidIfNecessary(typeof pathOrRid === "string", rid);
       callbackFn();
     })
-    .catch(err => {
+    .catch((err) => {
       closeRidIfNecessary(typeof pathOrRid === "string", rid);
       callbackFn(err);
     });

--- a/std/node/_fs/_fs_appendFile.ts
+++ b/std/node/_fs/_fs_appendFile.ts
@@ -1,17 +1,19 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { FileOptions, isFileOptions, CallbackWithError } from "./_fs_common.ts";
 import { notImplemented } from "../_utils.ts";
+import { fromFileUrl } from "../path.ts";
 
 /**
- * TODO: Also accept 'data' parameter as a Node polyfill Buffer or URL type once these
+ * TODO: Also accept 'data' parameter as a Node polyfill Buffer type once these
  * are implemented. See https://github.com/denoland/deno/issues/3403
  */
 export function appendFile(
-  pathOrRid: string | number,
+  pathOrRid: string | number | URL,
   data: string,
   optionsOrCallback: string | FileOptions | CallbackWithError,
   callback?: CallbackWithError
 ): void {
+  pathOrRid = pathOrRid instanceof URL ? fromFileUrl(pathOrRid) : pathOrRid;
   const callbackFn: CallbackWithError | undefined =
     optionsOrCallback instanceof Function ? optionsOrCallback : callback;
   const options: string | FileOptions | undefined =
@@ -26,7 +28,9 @@ export function appendFile(
   new Promise((resolve, reject) => {
     if (typeof pathOrRid === "number") {
       rid = pathOrRid;
-      Deno.write(rid, buffer).then(resolve).catch(reject);
+      Deno.write(rid, buffer)
+        .then(resolve)
+        .catch(reject);
     } else {
       const mode: number | undefined = isFileOptions(options)
         ? options.mode
@@ -39,7 +43,7 @@ export function appendFile(
         //TODO rework once https://github.com/denoland/deno/issues/4017 completes
         notImplemented("Deno does not yet support setting mode on create");
       }
-      Deno.open(pathOrRid, getOpenOptions(flag))
+      Deno.open(pathOrRid as string, getOpenOptions(flag))
         .then(({ rid: openedFileRid }) => {
           rid = openedFileRid;
           return Deno.write(openedFileRid, buffer);
@@ -52,7 +56,7 @@ export function appendFile(
       closeRidIfNecessary(typeof pathOrRid === "string", rid);
       callbackFn();
     })
-    .catch((err) => {
+    .catch(err => {
       closeRidIfNecessary(typeof pathOrRid === "string", rid);
       callbackFn(err);
     });
@@ -66,17 +70,18 @@ function closeRidIfNecessary(isPathString: boolean, rid: number): void {
 }
 
 /**
- * TODO: Also accept 'data' parameter as a Node polyfill Buffer or URL type once these
+ * TODO: Also accept 'data' parameter as a Node polyfill Buffer type once these
  * are implemented. See https://github.com/denoland/deno/issues/3403
  */
 export function appendFileSync(
-  pathOrRid: string | number,
+  pathOrRid: string | number | URL,
   data: string,
   options?: string | FileOptions
 ): void {
   let rid = -1;
 
   validateEncoding(options);
+  pathOrRid = pathOrRid instanceof URL ? fromFileUrl(pathOrRid) : pathOrRid;
 
   try {
     if (typeof pathOrRid === "number") {

--- a/std/node/_fs/_fs_appendFile_test.ts
+++ b/std/node/_fs/_fs_appendFile_test.ts
@@ -2,6 +2,7 @@
 const { test } = Deno;
 import { assertEquals, assertThrows, fail } from "../../testing/asserts.ts";
 import { appendFile, appendFileSync } from "./_fs_appendFile.ts";
+import { fromFileUrl } from "../path.ts";
 
 const decoder = new TextDecoder("utf-8");
 
@@ -113,26 +114,23 @@ test({
   name: "Async: Data is written to passed in URL",
   async fn() {
     const openResourcesBeforeAppend: Deno.ResourceMap = Deno.resources();
+    const fileURL = new URL("_fs_appendFile_test_file.txt", import.meta.url);
     await new Promise((resolve, reject) => {
-      appendFile(
-        new URL("_fs_appendFile_test_file.txt", import.meta.url),
-        "hello world",
-        (err) => {
-          if (err) reject(err);
-          else resolve();
-        }
-      );
+      appendFile(fileURL, "hello world", (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
     })
       .then(async () => {
         assertEquals(Deno.resources(), openResourcesBeforeAppend);
-        const data = await Deno.readFile("_fs_appendFile_test_file.txt");
+        const data = await Deno.readFile(fromFileUrl(fileURL));
         assertEquals(decoder.decode(data), "hello world");
       })
       .catch((err) => {
         fail("No error was expected: " + err);
       })
       .finally(async () => {
-        await Deno.remove("_fs_appendFile_test_file.txt");
+        await Deno.remove(fromFileUrl(fileURL));
       });
   },
 });

--- a/std/node/_fs/_fs_appendFile_test.ts
+++ b/std/node/_fs/_fs_appendFile_test.ts
@@ -15,7 +15,7 @@ test({
       Error,
       "No callback function supplied"
     );
-  }
+  },
 });
 
 test({
@@ -48,12 +48,12 @@ test({
     assertThrows(
       () =>
         appendFileSync("some/path", "some data", {
-          encoding: "made-up-encoding"
+          encoding: "made-up-encoding",
         }),
       Error,
       "Only 'utf8' encoding is currently supported"
     );
-  }
+  },
 });
 
 test({
@@ -63,10 +63,10 @@ test({
     const file: Deno.File = await Deno.open(tempFile, {
       create: true,
       write: true,
-      read: true
+      read: true,
     });
     await new Promise((resolve, reject) => {
-      appendFile(file.rid, "hello world", err => {
+      appendFile(file.rid, "hello world", (err) => {
         if (err) reject();
         else resolve();
       });
@@ -82,7 +82,7 @@ test({
         Deno.close(file.rid);
         await Deno.remove(tempFile);
       });
-  }
+  },
 });
 
 test({
@@ -90,7 +90,7 @@ test({
   async fn() {
     const openResourcesBeforeAppend: Deno.ResourceMap = Deno.resources();
     await new Promise((resolve, reject) => {
-      appendFile("_fs_appendFile_test_file.txt", "hello world", err => {
+      appendFile("_fs_appendFile_test_file.txt", "hello world", (err) => {
         if (err) reject(err);
         else resolve();
       });
@@ -100,13 +100,13 @@ test({
         const data = await Deno.readFile("_fs_appendFile_test_file.txt");
         assertEquals(decoder.decode(data), "hello world");
       })
-      .catch(err => {
+      .catch((err) => {
         fail("No error was expected: " + err);
       })
       .finally(async () => {
         await Deno.remove("_fs_appendFile_test_file.txt");
       });
-  }
+  },
 });
 
 test({
@@ -117,7 +117,7 @@ test({
       appendFile(
         new URL("_fs_appendFile_test_file.txt", import.meta.url),
         "hello world",
-        err => {
+        (err) => {
           if (err) reject(err);
           else resolve();
         }
@@ -128,13 +128,13 @@ test({
         const data = await Deno.readFile("_fs_appendFile_test_file.txt");
         assertEquals(decoder.decode(data), "hello world");
       })
-      .catch(err => {
+      .catch((err) => {
         fail("No error was expected: " + err);
       })
       .finally(async () => {
         await Deno.remove("_fs_appendFile_test_file.txt");
       });
-  }
+  },
 });
 
 test({
@@ -144,7 +144,7 @@ test({
     const openResourcesBeforeAppend: Deno.ResourceMap = Deno.resources();
     const tempFile: string = await Deno.makeTempFile();
     await new Promise((resolve, reject) => {
-      appendFile(tempFile, "hello world", { flag: "ax" }, err => {
+      appendFile(tempFile, "hello world", { flag: "ax" }, (err) => {
         if (err) reject(err);
         else resolve();
       });
@@ -158,7 +158,7 @@ test({
       .finally(async () => {
         await Deno.remove(tempFile);
       });
-  }
+  },
 });
 
 test({
@@ -168,14 +168,14 @@ test({
     const file: Deno.File = Deno.openSync(tempFile, {
       create: true,
       write: true,
-      read: true
+      read: true,
     });
     appendFileSync(file.rid, "hello world");
     Deno.close(file.rid);
     const data = Deno.readFileSync(tempFile);
     assertEquals(decoder.decode(data), "hello world");
     Deno.removeSync(tempFile);
-  }
+  },
 });
 
 test({
@@ -187,7 +187,7 @@ test({
     const data = Deno.readFileSync("_fs_appendFile_test_file_sync.txt");
     assertEquals(decoder.decode(data), "hello world");
     Deno.removeSync("_fs_appendFile_test_file_sync.txt");
-  }
+  },
 });
 
 test({
@@ -203,5 +203,5 @@ test({
     );
     assertEquals(Deno.resources(), openResourcesBeforeAppend);
     Deno.removeSync(tempFile);
-  }
+  },
 });

--- a/std/node/_fs/_fs_appendFile_test.ts
+++ b/std/node/_fs/_fs_appendFile_test.ts
@@ -15,7 +15,7 @@ test({
       Error,
       "No callback function supplied"
     );
-  },
+  }
 });
 
 test({
@@ -48,12 +48,12 @@ test({
     assertThrows(
       () =>
         appendFileSync("some/path", "some data", {
-          encoding: "made-up-encoding",
+          encoding: "made-up-encoding"
         }),
       Error,
       "Only 'utf8' encoding is currently supported"
     );
-  },
+  }
 });
 
 test({
@@ -63,10 +63,10 @@ test({
     const file: Deno.File = await Deno.open(tempFile, {
       create: true,
       write: true,
-      read: true,
+      read: true
     });
     await new Promise((resolve, reject) => {
-      appendFile(file.rid, "hello world", (err) => {
+      appendFile(file.rid, "hello world", err => {
         if (err) reject();
         else resolve();
       });
@@ -82,7 +82,7 @@ test({
         Deno.close(file.rid);
         await Deno.remove(tempFile);
       });
-  },
+  }
 });
 
 test({
@@ -90,7 +90,7 @@ test({
   async fn() {
     const openResourcesBeforeAppend: Deno.ResourceMap = Deno.resources();
     await new Promise((resolve, reject) => {
-      appendFile("_fs_appendFile_test_file.txt", "hello world", (err) => {
+      appendFile("_fs_appendFile_test_file.txt", "hello world", err => {
         if (err) reject(err);
         else resolve();
       });
@@ -100,13 +100,41 @@ test({
         const data = await Deno.readFile("_fs_appendFile_test_file.txt");
         assertEquals(decoder.decode(data), "hello world");
       })
-      .catch((err) => {
+      .catch(err => {
         fail("No error was expected: " + err);
       })
       .finally(async () => {
         await Deno.remove("_fs_appendFile_test_file.txt");
       });
-  },
+  }
+});
+
+test({
+  name: "Async: Data is written to passed in URL",
+  async fn() {
+    const openResourcesBeforeAppend: Deno.ResourceMap = Deno.resources();
+    await new Promise((resolve, reject) => {
+      appendFile(
+        new URL("_fs_appendFile_test_file.txt", import.meta.url),
+        "hello world",
+        err => {
+          if (err) reject(err);
+          else resolve();
+        }
+      );
+    })
+      .then(async () => {
+        assertEquals(Deno.resources(), openResourcesBeforeAppend);
+        const data = await Deno.readFile("_fs_appendFile_test_file.txt");
+        assertEquals(decoder.decode(data), "hello world");
+      })
+      .catch(err => {
+        fail("No error was expected: " + err);
+      })
+      .finally(async () => {
+        await Deno.remove("_fs_appendFile_test_file.txt");
+      });
+  }
 });
 
 test({
@@ -116,7 +144,7 @@ test({
     const openResourcesBeforeAppend: Deno.ResourceMap = Deno.resources();
     const tempFile: string = await Deno.makeTempFile();
     await new Promise((resolve, reject) => {
-      appendFile(tempFile, "hello world", { flag: "ax" }, (err) => {
+      appendFile(tempFile, "hello world", { flag: "ax" }, err => {
         if (err) reject(err);
         else resolve();
       });
@@ -130,7 +158,7 @@ test({
       .finally(async () => {
         await Deno.remove(tempFile);
       });
-  },
+  }
 });
 
 test({
@@ -140,14 +168,14 @@ test({
     const file: Deno.File = Deno.openSync(tempFile, {
       create: true,
       write: true,
-      read: true,
+      read: true
     });
     appendFileSync(file.rid, "hello world");
     Deno.close(file.rid);
     const data = Deno.readFileSync(tempFile);
     assertEquals(decoder.decode(data), "hello world");
     Deno.removeSync(tempFile);
-  },
+  }
 });
 
 test({
@@ -159,7 +187,7 @@ test({
     const data = Deno.readFileSync("_fs_appendFile_test_file_sync.txt");
     assertEquals(decoder.decode(data), "hello world");
     Deno.removeSync("_fs_appendFile_test_file_sync.txt");
-  },
+  }
 });
 
 test({
@@ -175,5 +203,5 @@ test({
     );
     assertEquals(Deno.resources(), openResourcesBeforeAppend);
     Deno.removeSync(tempFile);
-  },
+  }
 });

--- a/std/node/_fs/_fs_chmod.ts
+++ b/std/node/_fs/_fs_chmod.ts
@@ -1,28 +1,32 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { CallbackWithError } from "./_fs_common.ts";
+import { fromFileUrl } from "../path.ts";
 
 const allowedModes = /^[0-7]{3}/;
 
 /**
- * TODO: Also accept 'path' parameter as a Node polyfill Buffer or URL type once these
+ * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
  * are implemented. See https://github.com/denoland/deno/issues/3403
  */
 export function chmod(
-  path: string,
+  path: string | URL,
   mode: string | number,
   callback: CallbackWithError
 ): void {
+  path = path instanceof URL ? fromFileUrl(path) : path;
+
   Deno.chmod(path, getResolvedMode(mode))
     .then(() => callback())
     .catch(callback);
 }
 
 /**
- * TODO: Also accept 'path' parameter as a Node polyfill Buffer or URL type once these
+ * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
  * are implemented. See https://github.com/denoland/deno/issues/3403
  */
-export function chmodSync(path: string, mode: string | number): void {
+export function chmodSync(path: string | URL, mode: string | number): void {
+  path = path instanceof URL ? fromFileUrl(path) : path;
   Deno.chmodSync(path, getResolvedMode(mode));
 }
 

--- a/std/node/_fs/_fs_chown.ts
+++ b/std/node/_fs/_fs_chown.ts
@@ -1,26 +1,31 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { CallbackWithError } from "./_fs_common.ts";
+import { fromFileUrl } from "../path.ts";
 
 /**
- * TODO: Also accept 'path' parameter as a Node polyfill Buffer or URL type once these
+ * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
  * are implemented. See https://github.com/denoland/deno/issues/3403
  */
 export function chown(
-  path: string,
+  path: string | URL,
   uid: number,
   gid: number,
   callback: CallbackWithError
 ): void {
+  path = path instanceof URL ? fromFileUrl(path) : path;
+
   Deno.chown(path, uid, gid)
     .then(() => callback())
     .catch(callback);
 }
 
 /**
- * TODO: Also accept 'path' parameter as a Node polyfill Buffer or URL type once these
+ * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
  * are implemented. See https://github.com/denoland/deno/issues/3403
  */
-export function chownSync(path: string, uid: number, gid: number): void {
+export function chownSync(path: string | URL, uid: number, gid: number): void {
+  path = path instanceof URL ? fromFileUrl(path) : path;
+
   Deno.chownSync(path, uid, gid);
 }

--- a/std/node/_fs/_fs_copy.ts
+++ b/std/node/_fs/_fs_copy.ts
@@ -1,17 +1,21 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { CallbackWithError } from "./_fs_common.ts";
+import { fromFileUrl } from "../path.ts";
 
 export function copyFile(
-  source: string,
+  source: string | URL,
   destination: string,
   callback: CallbackWithError
 ): void {
+  source = source instanceof URL ? fromFileUrl(source) : source;
+
   Deno.copyFile(source, destination)
     .then(() => callback())
     .catch(callback);
 }
 
-export function copyFileSync(source: string, destination: string): void {
+export function copyFileSync(source: string | URL, destination: string): void {
+  source = source instanceof URL ? fromFileUrl(source) : source;
   Deno.copyFileSync(source, destination);
 }

--- a/std/node/_fs/_fs_exists.ts
+++ b/std/node/_fs/_fs_exists.ts
@@ -1,13 +1,15 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { fromFileUrl } from "../path.ts";
 
 type ExitsCallback = (exists: boolean) => void;
 
 /**
- * TODO: Also accept 'path' parameter as a Node polyfill Buffer or URL type once these
+ * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
  * are implemented. See https://github.com/denoland/deno/issues/3403
  * Deprecated in node api
  */
-export function exists(path: string, callback: ExitsCallback): void {
+export function exists(path: string | URL, callback: ExitsCallback): void {
+  path = path instanceof URL ? fromFileUrl(path) : path;
   Deno.lstat(path)
     .then(() => {
       callback(true);
@@ -19,7 +21,8 @@ export function exists(path: string, callback: ExitsCallback): void {
  * TODO: Also accept 'path' parameter as a Node polyfill Buffer or URL type once these
  * are implemented. See https://github.com/denoland/deno/issues/3403
  */
-export function existsSync(path: string): boolean {
+export function existsSync(path: string | URL): boolean {
+  path = path instanceof URL ? fromFileUrl(path) : path;
   try {
     Deno.lstatSync(path);
     return true;

--- a/std/node/_fs/_fs_mkdir.ts
+++ b/std/node/_fs/_fs_mkdir.ts
@@ -1,21 +1,23 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { CallbackWithError } from "./_fs_common.ts";
+import { fromFileUrl } from "../path.ts";
 
 /**
- * TODO: Also accept 'path' parameter as a Node polyfill Buffer or URL type once these
+ * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
  * are implemented. See https://github.com/denoland/deno/issues/3403
  */
-type Path = string;
 type MkdirOptions =
   | { recursive?: boolean; mode?: number | undefined }
   | number
   | boolean;
 
 export function mkdir(
-  path: Path,
+  path: string | URL,
   options?: MkdirOptions | CallbackWithError,
   callback?: CallbackWithError
 ): void {
+  path = path instanceof URL ? fromFileUrl(path) : path;
+
   let mode = 0o777;
   let recursive = false;
 
@@ -39,14 +41,15 @@ export function mkdir(
         callback();
       }
     })
-    .catch((err) => {
+    .catch(err => {
       if (typeof callback === "function") {
         callback(err);
       }
     });
 }
 
-export function mkdirSync(path: Path, options?: MkdirOptions): void {
+export function mkdirSync(path: string | URL, options?: MkdirOptions): void {
+  path = path instanceof URL ? fromFileUrl(path) : path;
   let mode = 0o777;
   let recursive = false;
 

--- a/std/node/_fs/_fs_mkdir.ts
+++ b/std/node/_fs/_fs_mkdir.ts
@@ -41,7 +41,7 @@ export function mkdir(
         callback();
       }
     })
-    .catch(err => {
+    .catch((err) => {
       if (typeof callback === "function") {
         callback(err);
       }

--- a/std/node/_fs/_fs_readFile.ts
+++ b/std/node/_fs/_fs_readFile.ts
@@ -3,7 +3,7 @@
 import {
   notImplemented,
   intoCallbackAPIWithIntercept,
-  MaybeEmpty
+  MaybeEmpty,
 } from "../_utils.ts";
 import { fromFileUrl } from "../path.ts";
 

--- a/std/node/_fs/_fs_readFile.ts
+++ b/std/node/_fs/_fs_readFile.ts
@@ -3,8 +3,9 @@
 import {
   notImplemented,
   intoCallbackAPIWithIntercept,
-  MaybeEmpty,
+  MaybeEmpty
 } from "../_utils.ts";
+import { fromFileUrl } from "../path.ts";
 
 const { readFile: denoReadFile, readFileSync: denoReadFileSync } = Deno;
 
@@ -51,10 +52,11 @@ function maybeDecode(
 }
 
 export function readFile(
-  path: string,
+  path: string | URL,
   optOrCallback: ReadFileCallback | ReadFileOptions,
   callback?: ReadFileCallback
 ): void {
+  path = path instanceof URL ? fromFileUrl(path) : path;
   let cb: ReadFileCallback | undefined;
   if (typeof optOrCallback === "function") {
     cb = optOrCallback;
@@ -73,8 +75,9 @@ export function readFile(
 }
 
 export function readFileSync(
-  path: string,
+  path: string | URL,
   opt?: ReadFileOptions
 ): string | Uint8Array {
+  path = path instanceof URL ? fromFileUrl(path) : path;
   return maybeDecode(denoReadFileSync(path), getEncoding(opt));
 }

--- a/std/node/_fs/_fs_readlink.ts
+++ b/std/node/_fs/_fs_readlink.ts
@@ -2,7 +2,7 @@
 import {
   intoCallbackAPIWithIntercept,
   MaybeEmpty,
-  notImplemented
+  notImplemented,
 } from "../_utils.ts";
 import { fromFileUrl } from "../path.ts";
 

--- a/std/node/_fs/_fs_readlink.ts
+++ b/std/node/_fs/_fs_readlink.ts
@@ -2,8 +2,9 @@
 import {
   intoCallbackAPIWithIntercept,
   MaybeEmpty,
-  notImplemented,
+  notImplemented
 } from "../_utils.ts";
+import { fromFileUrl } from "../path.ts";
 
 const { readLink: denoReadlink, readLinkSync: denoReadlinkSync } = Deno;
 
@@ -49,10 +50,12 @@ function getEncoding(
 }
 
 export function readlink(
-  path: string,
+  path: string | URL,
   optOrCallback: ReadlinkCallback | ReadlinkOptions,
   callback?: ReadlinkCallback
 ): void {
+  path = path instanceof URL ? fromFileUrl(path) : path;
+
   let cb: ReadlinkCallback | undefined;
   if (typeof optOrCallback === "function") {
     cb = optOrCallback;
@@ -71,8 +74,10 @@ export function readlink(
 }
 
 export function readlinkSync(
-  path: string,
+  path: string | URL,
   opt?: ReadlinkOptions
 ): string | Uint8Array {
+  path = path instanceof URL ? fromFileUrl(path) : path;
+
   return maybeEncode(denoReadlinkSync(path), getEncoding(opt));
 }


### PR DESCRIPTION
for instance : 
```ts
export function chmod(
  path: string | URL, // URL type Added
  ...
)
```

according to[ node's path](https://nodejs.org/dist/latest-v14.x/docs/api/fs.html#fs_fs_chmod_path_mode_callback) argument.