### PR TITLE
fix: Propagating unstable flag for installer

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -2188,6 +2188,30 @@ mod tests {
   }
 
   #[test]
+  fn install_unstable() {
+    let r = flags_from_vec_safe(svec![
+      "deno",
+      "install",
+      "--unstable",
+      "https://deno.land/std/examples/colors.ts"
+    ]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        unstable: true,
+        subcommand: DenoSubcommand::Install {
+          name: None,
+          module_url: "https://deno.land/std/examples/colors.ts".to_string(),
+          args: svec![],
+          root: None,
+          force: false,
+        },
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
   fn install_with_args() {
     let r = flags_from_vec_safe(svec![
       "deno",

--- a/cli/installer.rs
+++ b/cli/installer.rs
@@ -208,6 +208,11 @@ pub fn install(
       executable_args.push(log_level.to_string());
     }
   }
+
+  if flags.unstable {
+    executable_args.push("--unstable".to_string());
+  }
+
   executable_args.push(module_url.to_string());
   executable_args.extend_from_slice(&args);
 
@@ -352,6 +357,39 @@ mod tests {
     if let Some(user_profile) = original_user_profile {
       env::set_var("USERPROFILE", user_profile);
     }
+  }
+
+  #[test]
+  fn install_unstable() {
+    let temp_dir = TempDir::new().expect("tempdir fail");
+    let bin_dir = temp_dir.path().join("bin");
+    std::fs::create_dir(&bin_dir).unwrap();
+
+    install(
+      Flags {
+        unstable: true,
+        ..Flags::default()
+      },
+      "http://localhost:4545/cli/tests/echo_server.ts",
+      vec![],
+      Some("echo_test".to_string()),
+      Some(temp_dir.path().to_path_buf()),
+      false,
+    )
+    .expect("Install failed");
+
+    let mut file_path = bin_dir.join("echo_test");
+    if cfg!(windows) {
+      file_path = file_path.with_extension("cmd");
+    }
+
+    assert!(file_path.exists());
+
+    let content = fs::read_to_string(file_path).unwrap();
+    println!("this is the file path {:?}", content);
+    assert!(content.contains(
+      r#""run" "--unstable" "http://localhost:4545/cli/tests/echo_server.ts"#
+    ));
   }
 
   #[test]


### PR DESCRIPTION
Addresses #5008

It looks like there already was a function in `flags.rs` that checks for any `--unstable` flags in the command line and adds it to registered flags. This code ensures that the unstable flag is propagated through to the installer function so unstable works for `deno install`. This PR also includes tests to check that the unstable flag is properly registered.