### PR TITLE
Add sha256 and sha224 support (along with HMAC variants)

### DIFF
--- a/std/util/sha256.ts
+++ b/std/util/sha256.ts
@@ -1,0 +1,575 @@
+/*
+ * Adapted to deno from:
+ *
+ * [js-sha256]{@link https://github.com/emn178/js-sha256}
+ *
+ * @version 0.9.0
+ * @author Chen, Yi-Cyuan [emn178@gmail.com]
+ * @copyright Chen, Yi-Cyuan 2014-2017
+ * @license MIT
+ */
+
+export type Message = string | number[] | ArrayBuffer | Uint8Array;
+
+const ERROR = "input is invalid type";
+const HEX_CHARS = "0123456789abcdef".split("");
+const EXTRA = [-2147483648, 8388608, 32768, 128] as const;
+const SHIFT = [24, 16, 8, 0] as const;
+// prettier-ignore
+// dprint-ignore
+const K = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+] as const;
+
+const blocks: number[] = [];
+
+export class Sha256 {
+  #block!: number;
+  #blocks!: number[];
+  #bytes!: number;
+  #finalized!: boolean;
+  #first!: boolean;
+  #h0!: number;
+  #h1!: number;
+  #h2!: number;
+  #h3!: number;
+  #h4!: number;
+  #h5!: number;
+  #h6!: number;
+  #h7!: number;
+  #hashed!: boolean;
+  #hBytes!: number;
+  #is224!: boolean;
+  #lastByteIndex = 0;
+  #start!: number;
+
+  constructor(is224 = false, sharedMemory = false) {
+    this.init(is224, sharedMemory);
+  }
+
+  protected init(is224: boolean, sharedMemory: boolean): void {
+    if (sharedMemory) {
+      blocks[0] = blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] = blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+      this.#blocks = blocks;
+    } else {
+      this.#blocks = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    }
+
+    if (is224) {
+      this.#h0 = 0xc1059ed8;
+      this.#h1 = 0x367cd507;
+      this.#h2 = 0x3070dd17;
+      this.#h3 = 0xf70e5939;
+      this.#h4 = 0xffc00b31;
+      this.#h5 = 0x68581511;
+      this.#h6 = 0x64f98fa7;
+      this.#h7 = 0xbefa4fa4;
+    } else {
+      // 256
+      this.#h0 = 0x6a09e667;
+      this.#h1 = 0xbb67ae85;
+      this.#h2 = 0x3c6ef372;
+      this.#h3 = 0xa54ff53a;
+      this.#h4 = 0x510e527f;
+      this.#h5 = 0x9b05688c;
+      this.#h6 = 0x1f83d9ab;
+      this.#h7 = 0x5be0cd19;
+    }
+
+    this.#block = this.#start = this.#bytes = this.#hBytes = 0;
+    this.#finalized = this.#hashed = false;
+    this.#first = true;
+    this.#is224 = is224;
+  }
+
+  /** Update hash
+   *
+   * @param message The message you want to hash.
+   */
+  update(message: Message): this {
+    if (this.#finalized) {
+      return this;
+    }
+    let msg: string | number[] | Uint8Array | undefined;
+    if (typeof message !== "string") {
+      if (typeof message === "object") {
+        if (message === null) {
+          throw new Error(ERROR);
+        } else if (message instanceof ArrayBuffer) {
+          msg = new Uint8Array(message);
+        } else if (!Array.isArray(message)) {
+          if (!ArrayBuffer.isView(message)) {
+            throw new Error(ERROR);
+          }
+        }
+      } else {
+        throw new Error(ERROR);
+      }
+    }
+    if (msg === undefined) {
+      msg = message as string | number[];
+    }
+    let index = 0;
+    const length = msg.length;
+    const blocks = this.#blocks;
+
+    while (index < length) {
+      let i: number;
+      if (this.#hashed) {
+        this.#hashed = false;
+        blocks[0] = this.#block;
+        blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] = blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+      }
+
+      if (typeof msg !== "string") {
+        for (i = this.#start; index < length && i < 64; ++index) {
+          blocks[i >> 2] |= msg[index] << SHIFT[i++ & 3];
+        }
+      } else {
+        for (i = this.#start; index < length && i < 64; ++index) {
+          let code = msg.charCodeAt(index);
+          if (code < 0x80) {
+            blocks[i >> 2] |= code << SHIFT[i++ & 3];
+          } else if (code < 0x800) {
+            blocks[i >> 2] |= (0xc0 | (code >> 6)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+          } else if (code < 0xd800 || code >= 0xe000) {
+            blocks[i >> 2] |= (0xe0 | (code >> 12)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | ((code >> 6) & 0x3f)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+          } else {
+            code =
+              0x10000 +
+              (((code & 0x3ff) << 10) | (msg.charCodeAt(++index) & 0x3ff));
+            blocks[i >> 2] |= (0xf0 | (code >> 18)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | ((code >> 12) & 0x3f)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | ((code >> 6) & 0x3f)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+          }
+        }
+      }
+
+      this.#lastByteIndex = i;
+      this.#bytes += i - this.#start;
+      if (i >= 64) {
+        this.#block = blocks[16];
+        this.#start = i - 64;
+        this.hash();
+        this.#hashed = true;
+      } else {
+        this.#start = i;
+      }
+    }
+    if (this.#bytes > 4294967295) {
+      this.#hBytes += (this.#bytes / 4294967296) << 0;
+      this.#bytes = this.#bytes % 4294967296;
+    }
+    return this;
+  }
+
+  protected finalize(): void {
+    if (this.#finalized) {
+      return;
+    }
+    this.#finalized = true;
+    const blocks = this.#blocks;
+    const i = this.#lastByteIndex;
+    blocks[16] = this.#block;
+    blocks[i >> 2] |= EXTRA[i & 3];
+    this.#block = blocks[16];
+    if (i >= 56) {
+      if (!this.#hashed) {
+        this.hash();
+      }
+      blocks[0] = this.#block;
+      blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] = blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+    }
+    blocks[14] = (this.#hBytes << 3) | (this.#bytes >>> 29);
+    blocks[15] = this.#bytes << 3;
+    this.hash();
+  }
+
+  protected hash(): void {
+    let a = this.#h0;
+    let b = this.#h1;
+    let c = this.#h2;
+    let d = this.#h3;
+    let e = this.#h4;
+    let f = this.#h5;
+    let g = this.#h6;
+    let h = this.#h7;
+    const blocks = this.#blocks;
+    let s0: number;
+    let s1: number;
+    let maj: number;
+    let t1: number;
+    let t2: number;
+    let ch: number;
+    let ab: number;
+    let da: number;
+    let cd: number;
+    let bc: number;
+
+    for (let j = 16; j < 64; ++j) {
+      // rightrotate
+      t1 = blocks[j - 15];
+      s0 = ((t1 >>> 7) | (t1 << 25)) ^ ((t1 >>> 18) | (t1 << 14)) ^ (t1 >>> 3);
+      t1 = blocks[j - 2];
+      s1 =
+        ((t1 >>> 17) | (t1 << 15)) ^ ((t1 >>> 19) | (t1 << 13)) ^ (t1 >>> 10);
+      blocks[j] = (blocks[j - 16] + s0 + blocks[j - 7] + s1) << 0;
+    }
+
+    bc = b & c;
+    for (let j = 0; j < 64; j += 4) {
+      if (this.#first) {
+        if (this.#is224) {
+          ab = 300032;
+          t1 = blocks[0] - 1413257819;
+          h = (t1 - 150054599) << 0;
+          d = (t1 + 24177077) << 0;
+        } else {
+          ab = 704751109;
+          t1 = blocks[0] - 210244248;
+          h = (t1 - 1521486534) << 0;
+          d = (t1 + 143694565) << 0;
+        }
+        this.#first = false;
+      } else {
+        s0 =
+          ((a >>> 2) | (a << 30)) ^
+          ((a >>> 13) | (a << 19)) ^
+          ((a >>> 22) | (a << 10));
+        s1 =
+          ((e >>> 6) | (e << 26)) ^
+          ((e >>> 11) | (e << 21)) ^
+          ((e >>> 25) | (e << 7));
+        ab = a & b;
+        maj = ab ^ (a & c) ^ bc;
+        ch = (e & f) ^ (~e & g);
+        t1 = h + s1 + ch + K[j] + blocks[j];
+        t2 = s0 + maj;
+        h = (d + t1) << 0;
+        d = (t1 + t2) << 0;
+      }
+      s0 =
+        ((d >>> 2) | (d << 30)) ^
+        ((d >>> 13) | (d << 19)) ^
+        ((d >>> 22) | (d << 10));
+      s1 =
+        ((h >>> 6) | (h << 26)) ^
+        ((h >>> 11) | (h << 21)) ^
+        ((h >>> 25) | (h << 7));
+      da = d & a;
+      maj = da ^ (d & b) ^ ab;
+      ch = (h & e) ^ (~h & f);
+      t1 = g + s1 + ch + K[j + 1] + blocks[j + 1];
+      t2 = s0 + maj;
+      g = (c + t1) << 0;
+      c = (t1 + t2) << 0;
+      s0 =
+        ((c >>> 2) | (c << 30)) ^
+        ((c >>> 13) | (c << 19)) ^
+        ((c >>> 22) | (c << 10));
+      s1 =
+        ((g >>> 6) | (g << 26)) ^
+        ((g >>> 11) | (g << 21)) ^
+        ((g >>> 25) | (g << 7));
+      cd = c & d;
+      maj = cd ^ (c & a) ^ da;
+      ch = (g & h) ^ (~g & e);
+      t1 = f + s1 + ch + K[j + 2] + blocks[j + 2];
+      t2 = s0 + maj;
+      f = (b + t1) << 0;
+      b = (t1 + t2) << 0;
+      s0 =
+        ((b >>> 2) | (b << 30)) ^
+        ((b >>> 13) | (b << 19)) ^
+        ((b >>> 22) | (b << 10));
+      s1 =
+        ((f >>> 6) | (f << 26)) ^
+        ((f >>> 11) | (f << 21)) ^
+        ((f >>> 25) | (f << 7));
+      bc = b & c;
+      maj = bc ^ (b & d) ^ cd;
+      ch = (f & g) ^ (~f & h);
+      t1 = e + s1 + ch + K[j + 3] + blocks[j + 3];
+      t2 = s0 + maj;
+      e = (a + t1) << 0;
+      a = (t1 + t2) << 0;
+    }
+
+    this.#h0 = (this.#h0 + a) << 0;
+    this.#h1 = (this.#h1 + b) << 0;
+    this.#h2 = (this.#h2 + c) << 0;
+    this.#h3 = (this.#h3 + d) << 0;
+    this.#h4 = (this.#h4 + e) << 0;
+    this.#h5 = (this.#h5 + f) << 0;
+    this.#h6 = (this.#h6 + g) << 0;
+    this.#h7 = (this.#h7 + h) << 0;
+  }
+
+  /** Return hash in hex string. */
+  hex(): string {
+    this.finalize();
+
+    const h0 = this.#h0;
+    const h1 = this.#h1;
+    const h2 = this.#h2;
+    const h3 = this.#h3;
+    const h4 = this.#h4;
+    const h5 = this.#h5;
+    const h6 = this.#h6;
+    const h7 = this.#h7;
+
+    let hex =
+      HEX_CHARS[(h0 >> 28) & 0x0f] +
+      HEX_CHARS[(h0 >> 24) & 0x0f] +
+      HEX_CHARS[(h0 >> 20) & 0x0f] +
+      HEX_CHARS[(h0 >> 16) & 0x0f] +
+      HEX_CHARS[(h0 >> 12) & 0x0f] +
+      HEX_CHARS[(h0 >> 8) & 0x0f] +
+      HEX_CHARS[(h0 >> 4) & 0x0f] +
+      HEX_CHARS[h0 & 0x0f] +
+      HEX_CHARS[(h1 >> 28) & 0x0f] +
+      HEX_CHARS[(h1 >> 24) & 0x0f] +
+      HEX_CHARS[(h1 >> 20) & 0x0f] +
+      HEX_CHARS[(h1 >> 16) & 0x0f] +
+      HEX_CHARS[(h1 >> 12) & 0x0f] +
+      HEX_CHARS[(h1 >> 8) & 0x0f] +
+      HEX_CHARS[(h1 >> 4) & 0x0f] +
+      HEX_CHARS[h1 & 0x0f] +
+      HEX_CHARS[(h2 >> 28) & 0x0f] +
+      HEX_CHARS[(h2 >> 24) & 0x0f] +
+      HEX_CHARS[(h2 >> 20) & 0x0f] +
+      HEX_CHARS[(h2 >> 16) & 0x0f] +
+      HEX_CHARS[(h2 >> 12) & 0x0f] +
+      HEX_CHARS[(h2 >> 8) & 0x0f] +
+      HEX_CHARS[(h2 >> 4) & 0x0f] +
+      HEX_CHARS[h2 & 0x0f] +
+      HEX_CHARS[(h3 >> 28) & 0x0f] +
+      HEX_CHARS[(h3 >> 24) & 0x0f] +
+      HEX_CHARS[(h3 >> 20) & 0x0f] +
+      HEX_CHARS[(h3 >> 16) & 0x0f] +
+      HEX_CHARS[(h3 >> 12) & 0x0f] +
+      HEX_CHARS[(h3 >> 8) & 0x0f] +
+      HEX_CHARS[(h3 >> 4) & 0x0f] +
+      HEX_CHARS[h3 & 0x0f] +
+      HEX_CHARS[(h4 >> 28) & 0x0f] +
+      HEX_CHARS[(h4 >> 24) & 0x0f] +
+      HEX_CHARS[(h4 >> 20) & 0x0f] +
+      HEX_CHARS[(h4 >> 16) & 0x0f] +
+      HEX_CHARS[(h4 >> 12) & 0x0f] +
+      HEX_CHARS[(h4 >> 8) & 0x0f] +
+      HEX_CHARS[(h4 >> 4) & 0x0f] +
+      HEX_CHARS[h4 & 0x0f] +
+      HEX_CHARS[(h5 >> 28) & 0x0f] +
+      HEX_CHARS[(h5 >> 24) & 0x0f] +
+      HEX_CHARS[(h5 >> 20) & 0x0f] +
+      HEX_CHARS[(h5 >> 16) & 0x0f] +
+      HEX_CHARS[(h5 >> 12) & 0x0f] +
+      HEX_CHARS[(h5 >> 8) & 0x0f] +
+      HEX_CHARS[(h5 >> 4) & 0x0f] +
+      HEX_CHARS[h5 & 0x0f] +
+      HEX_CHARS[(h6 >> 28) & 0x0f] +
+      HEX_CHARS[(h6 >> 24) & 0x0f] +
+      HEX_CHARS[(h6 >> 20) & 0x0f] +
+      HEX_CHARS[(h6 >> 16) & 0x0f] +
+      HEX_CHARS[(h6 >> 12) & 0x0f] +
+      HEX_CHARS[(h6 >> 8) & 0x0f] +
+      HEX_CHARS[(h6 >> 4) & 0x0f] +
+      HEX_CHARS[h6 & 0x0f];
+    if (!this.#is224) {
+      hex +=
+        HEX_CHARS[(h7 >> 28) & 0x0f] +
+        HEX_CHARS[(h7 >> 24) & 0x0f] +
+        HEX_CHARS[(h7 >> 20) & 0x0f] +
+        HEX_CHARS[(h7 >> 16) & 0x0f] +
+        HEX_CHARS[(h7 >> 12) & 0x0f] +
+        HEX_CHARS[(h7 >> 8) & 0x0f] +
+        HEX_CHARS[(h7 >> 4) & 0x0f] +
+        HEX_CHARS[h7 & 0x0f];
+    }
+    return hex;
+  }
+
+  /** Return hash in hex string. */
+  toString(): string {
+    return this.hex();
+  }
+
+  /** Return hash in integer array. */
+  digest(): number[] {
+    this.finalize();
+
+    const h0 = this.#h0;
+    const h1 = this.#h1;
+    const h2 = this.#h2;
+    const h3 = this.#h3;
+    const h4 = this.#h4;
+    const h5 = this.#h5;
+    const h6 = this.#h6;
+    const h7 = this.#h7;
+
+    const arr = [
+      (h0 >> 24) & 0xff,
+      (h0 >> 16) & 0xff,
+      (h0 >> 8) & 0xff,
+      h0 & 0xff,
+      (h1 >> 24) & 0xff,
+      (h1 >> 16) & 0xff,
+      (h1 >> 8) & 0xff,
+      h1 & 0xff,
+      (h2 >> 24) & 0xff,
+      (h2 >> 16) & 0xff,
+      (h2 >> 8) & 0xff,
+      h2 & 0xff,
+      (h3 >> 24) & 0xff,
+      (h3 >> 16) & 0xff,
+      (h3 >> 8) & 0xff,
+      h3 & 0xff,
+      (h4 >> 24) & 0xff,
+      (h4 >> 16) & 0xff,
+      (h4 >> 8) & 0xff,
+      h4 & 0xff,
+      (h5 >> 24) & 0xff,
+      (h5 >> 16) & 0xff,
+      (h5 >> 8) & 0xff,
+      h5 & 0xff,
+      (h6 >> 24) & 0xff,
+      (h6 >> 16) & 0xff,
+      (h6 >> 8) & 0xff,
+      h6 & 0xff,
+    ];
+    if (!this.#is224) {
+      arr.push(
+        (h7 >> 24) & 0xff,
+        (h7 >> 16) & 0xff,
+        (h7 >> 8) & 0xff,
+        h7 & 0xff
+      );
+    }
+    return arr;
+  }
+
+  /** Return hash in integer array. */
+  array(): number[] {
+    return this.digest();
+  }
+
+  /** Return hash in ArrayBuffer. */
+  arrayBuffer(): ArrayBuffer {
+    this.finalize();
+
+    const buffer = new ArrayBuffer(this.#is224 ? 28 : 32);
+    const dataView = new DataView(buffer);
+    dataView.setUint32(0, this.#h0);
+    dataView.setUint32(4, this.#h1);
+    dataView.setUint32(8, this.#h2);
+    dataView.setUint32(12, this.#h3);
+    dataView.setUint32(16, this.#h4);
+    dataView.setUint32(20, this.#h5);
+    dataView.setUint32(24, this.#h6);
+    if (!this.#is224) {
+      dataView.setUint32(28, this.#h7);
+    }
+    return buffer;
+  }
+}
+
+export class HmacSha256 extends Sha256 {
+  #inner: boolean;
+  #is224: boolean;
+  #oKeyPad: number[];
+  #sharedMemory: boolean;
+
+  constructor(secretKey: Message, is224 = false, sharedMemory = false) {
+    super(is224, sharedMemory);
+
+    let key: number[] | Uint8Array | undefined;
+    if (typeof secretKey === "string") {
+      const bytes: number[] = [];
+      const length = secretKey.length;
+      let index = 0;
+      for (let i = 0; i < length; ++i) {
+        let code = secretKey.charCodeAt(i);
+        if (code < 0x80) {
+          bytes[index++] = code;
+        } else if (code < 0x800) {
+          bytes[index++] = 0xc0 | (code >> 6);
+          bytes[index++] = 0x80 | (code & 0x3f);
+        } else if (code < 0xd800 || code >= 0xe000) {
+          bytes[index++] = 0xe0 | (code >> 12);
+          bytes[index++] = 0x80 | ((code >> 6) & 0x3f);
+          bytes[index++] = 0x80 | (code & 0x3f);
+        } else {
+          code =
+            0x10000 +
+            (((code & 0x3ff) << 10) | (secretKey.charCodeAt(++i) & 0x3ff));
+          bytes[index++] = 0xf0 | (code >> 18);
+          bytes[index++] = 0x80 | ((code >> 12) & 0x3f);
+          bytes[index++] = 0x80 | ((code >> 6) & 0x3f);
+          bytes[index++] = 0x80 | (code & 0x3f);
+        }
+      }
+      key = bytes;
+    } else {
+      if (typeof secretKey === "object") {
+        if (secretKey === null) {
+          throw new Error(ERROR);
+        } else if (secretKey instanceof ArrayBuffer) {
+          key = new Uint8Array(secretKey);
+        } else if (!Array.isArray(secretKey)) {
+          if (!ArrayBuffer.isView(secretKey)) {
+            throw new Error(ERROR);
+          }
+        }
+      } else {
+        throw new Error(ERROR);
+      }
+    }
+    if (key === undefined) {
+      key = secretKey as number[] | Uint8Array;
+    }
+
+    if (key.length > 64) {
+      key = new Sha256(is224, true).update(key).array();
+    }
+
+    const oKeyPad: number[] = [];
+    const iKeyPad: number[] = [];
+    for (let i = 0; i < 64; ++i) {
+      const b = key[i] || 0;
+      oKeyPad[i] = 0x5c ^ b;
+      iKeyPad[i] = 0x36 ^ b;
+    }
+
+    this.update(iKeyPad);
+    this.#oKeyPad = oKeyPad;
+    this.#inner = true;
+    this.#is224 = is224;
+    this.#sharedMemory = sharedMemory;
+  }
+
+  protected finalize(): void {
+    super.finalize();
+    if (this.#inner) {
+      this.#inner = false;
+      const innerHash = this.array();
+      super.init(this.#is224, this.#sharedMemory);
+      this.update(this.#oKeyPad);
+      this.update(innerHash);
+      super.finalize();
+    }
+  }
+}

--- a/std/util/sha256_test.ts
+++ b/std/util/sha256_test.ts
@@ -1,0 +1,296 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { Sha256, HmacSha256, Message } from "./sha256.ts";
+import { assertEquals } from "../testing/asserts.ts";
+
+const { test } = Deno;
+
+/** Handy function to convert an array/array buffer to a string of hex values. */
+function toHexString(value: number[] | ArrayBuffer): string {
+  const array = new Uint8Array(value);
+  let hex = "";
+  for (const v of array) {
+    const c = v.toString(16);
+    hex += c.length === 1 ? `0${c}` : c;
+  }
+  return hex;
+}
+
+// prettier-ignore
+// dprint-ignore
+const fixtures: {
+  sha256: Record<string, Record<string, Message>>;
+  sha224: Record<string, Record<string, Message>>;
+  sha256Hmac: Record<string, Record<string, [Message, Message]>>;
+  sha224Hmac: Record<string, Record<string, [Message, Message]>>;
+} = {
+  sha256: {
+    "ascii": {
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": "",
+      "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592": "The quick brown fox jumps over the lazy dog",
+      "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c": "The quick brown fox jumps over the lazy dog."
+    },
+    "ascii more than 64 bytes": {
+      "54e73d89e1924fdcd056390266a983924b6d6d461e9470b6cd50bbaf69b5c54c": "The MD5 message-digest algorithm is a widely used cryptographic hash function producing a 128-bit (16-byte) hash value, typically expressed in text format as a 32 digit hexadecimal number. MD5 has been utilized in a wide variety of cryptographic applications, and is also commonly used to verify data integrity."
+    },
+    "UTF8": {
+      "72726d8818f693066ceb69afa364218b692e62ea92b385782363780f47529c21": "中文",
+      "53196d1acfce0c4b264e01e8018c989d571351f59e33f055f76ff15b4f0516c6": "aécio",
+      "8d10a48685dbc34484696de7ea7434d80a54c1d60100530faccf697463ef19c9": "𠜎"
+    },
+    "UTF8 more than 64 bytes": {
+      "d691014feebf35b3500ef6f6738d0094cac63628a7a018a980a40292a77703d1": "訊息摘要演算法第五版（英語：Message-Digest Algorithm 5，縮寫為MD5），是當前電腦領域用於確保資訊傳輸完整一致而廣泛使用的雜湊演算法之一",
+      "81a1472ebdeb09406a783d607ff49ee2fde3e9f44ac1cd158ad8d6ad3c4e69fa": "訊息摘要演算法第五版（英語：Message-Digest Algorithm 5，縮寫為MD5），是當前電腦領域用於確保資訊傳輸完整一致而廣泛使用的雜湊演算法之一（又譯雜湊演算法、摘要演算法等），主流程式語言普遍已有MD5的實作。"
+    },
+    "special length": {
+      "5e6b963e2b6444dab8544beab8532850cef2a9d143872a6a5384abe37e61b3db": "0123456780123456780123456780123456780123456780123456780",
+      "85d240a4a03a0710423fc4f701da51e8785c9eaa96d718ab1c7991d6afd60d62": "01234567801234567801234567801234567801234567801234567801",
+      "c3ee464d5620eb2dde3dfda4c7955dbd9e9e2e9b113c13983fc67b0dfd892a53": "0123456780123456780123456780123456780123456780123456780123456780",
+      "74b51c6911f9a8b5e7c499effe7604e43b672166818873c27752c248de434841": "01234567801234567801234567801234567801234567801234567801234567801234567",
+      "6fba9e623ae6abf028a1b195748814aa95eebfb22e3ec5e15d2444cd6c48186a": "012345678012345678012345678012345678012345678012345678012345678012345678"
+    },
+    "Array": {
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": [],
+      "182889f925ae4e5cc37118ded6ed87f7bdc7cab5ec5e78faef2e50048999473f": [211, 212],
+      "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592": [84, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 32, 106, 117, 109, 112, 115, 32, 111, 118, 101, 114, 32, 116, 104, 101, 32, 108, 97, 122, 121, 32, 100, 111, 103],
+      "74b51c6911f9a8b5e7c499effe7604e43b672166818873c27752c248de434841": [48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55]
+    }
+  },
+  sha224: {
+    "ascii": {
+      "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f": "",
+      "730e109bd7a8a32b1cb9d9a09aa2325d2430587ddbc0c38bad911525": "The quick brown fox jumps over the lazy dog",
+      "619cba8e8e05826e9b8c519c0a5c68f4fb653e8a3d8aa04bb2c8cd4c": "The quick brown fox jumps over the lazy dog."
+    },
+    "ascii more than 64 bytes": {
+      "4d97e15967391d2e846ea7d21bb480efadbae5868b731e7cc6267006": "The MD5 message-digest algorithm is a widely used cryptographic hash function producing a 128-bit (16-byte) hash value, typically expressed in text format as a 32 digit hexadecimal number. MD5 has been utilized in a wide variety of cryptographic applications, and is also commonly used to verify data integrity."
+    },
+    "UTF8": {
+      "dfbab71afdf54388af4d55f8bd3de8c9b15e0eb916bf9125f4a959d4": "中文",
+      "d12841cafd89c534924a839e62bf35a2b5f3717b7802eb19bd8d8e15": "aécio",
+      "eaa0129b5509f5701db218fb7076b282e4409da52d06363aa3bdd63d": "𠜎"
+    },
+    "UTF8 more than 64 bytes": {
+      "0dda421f3f81272418e1313673e9d74b7f2d04efc9c52c69458e12c3": "訊息摘要演算法第五版（英語：Message-Digest Algorithm 5，縮寫為MD5），是當前電腦領域用於確保資訊傳輸完整一致而廣泛使用的雜湊演算法之一",
+      "a8cb74a54e6dc6ab6110db3915ba08ffe5e1abafaea78538fa12a626": "訊息摘要演算法第五版（英語：Message-Digest Algorithm 5，縮寫為MD5），是當前電腦領域用於確保資訊傳輸完整一致而廣泛使用的雜湊演算法之一（又譯雜湊演算法、摘要演算法等），主流程式語言普遍已有MD5的實作。"
+    },
+    "special length": {
+      "bc4a354d66f3cff4bc6dd6a88fbb0435cede7fd5fe94da0760cb1924": "0123456780123456780123456780123456780123456780123456780",
+      "2f148f757d1295784a7c69bf328b8bf827a536669e132234cd6f50e7": "01234567801234567801234567801234567801234567801234567801",
+      "496275a96bf41aa27ce89c3ae0fc63c3a3eab063887a8ea075bd091b": "0123456780123456780123456780123456780123456780123456780123456780",
+      "16ee1b101fe0e0d8dd156d598931ec19d75b0f8dc0a0455733c168c8": "01234567801234567801234567801234567801234567801234567801234567801234567",
+      "04c7a30079c640e440d884cdf0d7ab04fd05501d4498cb21be29ca1f": "012345678012345678012345678012345678012345678012345678012345678012345678"
+    },
+    "Array": {
+      "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f": [],
+      "730e109bd7a8a32b1cb9d9a09aa2325d2430587ddbc0c38bad911525": [84, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 32, 106, 117, 109, 112, 115, 32, 111, 118, 101, 114, 32, 116, 104, 101, 32, 108, 97, 122, 121, 32, 100, 111, 103],
+      "16ee1b101fe0e0d8dd156d598931ec19d75b0f8dc0a0455733c168c8": [48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55, 56, 48, 49, 50, 51, 52, 53, 54, 55]
+    }
+  },
+  sha256Hmac: {
+    "Test Vectors": {
+      "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7": [
+        [0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b],
+        "Hi There"
+      ],
+      "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843": [
+        "Jefe",
+        "what do ya want for nothing?"
+      ],
+      "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe": [
+        [0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa],
+        [0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd]
+      ],
+      "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b": [
+        [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19],
+        [0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd]
+      ],
+      "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54": [
+        [0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa],
+        "Test Using Larger Than Block-Size Key - Hash Key First"
+      ],
+      "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2": [
+        [0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa],
+        "This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm."
+      ]
+    },
+    "UTF8": {
+      "865cc329d317f6d9fdbd183a3c5cc5fd4c370d11f98abbbb404bceb1e6392c7e": ["中文", "中文"],
+      "efeef87be5731506b69bb64a9898a456dd12c94834c36a4d8ba99e3db79ad7ed": ["aécio", "aécio"],
+      "8a6e527049b9cfc7e1c84bcf356a1289c95da68a586c03de3327f3de0d3737fe": ["𠜎", "𠜎"]
+    }
+  },
+  sha224Hmac: {
+    "Test Vectors": {
+      "896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22": [
+        [0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b],
+        "Hi There"
+      ],
+      "a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44": [
+        "Jefe",
+        "what do ya want for nothing?"
+      ],
+      "7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea": [
+        [0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa],
+        [0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd]
+      ],
+      "6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a": [
+        [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19],
+        [0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd]
+      ],
+      "95e9a0db962095adaebe9b2d6f0dbce2d499f112f2d2b7273fa6870e": [
+        [0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa],
+        "Test Using Larger Than Block-Size Key - Hash Key First"
+      ],
+      "3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1": [
+        [0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa],
+        "This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm."
+      ]
+    },
+    "UTF8": {
+      "e2280928fe813aeb7fa59aa14dd5e589041bfdf91945d19d25b9f3db": ["中文", "中文"],
+      "86c53dc054b16f6e006a254891bc9ff0da5df8e1a6faee3b0aaa732d": ["aécio", "aécio"],
+      "e9e5991bfb84506b105f800afac1599ff807bb8e20db8ffda48997b9": ["𠜎", "𠜎"]
+    }
+  },
+};
+
+// prettier-ignore
+// dprint-ignore
+fixtures.sha256.Uint8Array = {
+  '182889f925ae4e5cc37118ded6ed87f7bdc7cab5ec5e78faef2e50048999473f': new Uint8Array([211, 212]),
+  'd7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592': new Uint8Array([84, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 32, 106, 117, 109, 112, 115, 32, 111, 118, 101, 114, 32, 116, 104, 101, 32, 108, 97, 122, 121, 32, 100, 111, 103])
+};
+// prettier-ignore
+// dprint-ignore
+fixtures.sha256.Int8Array = {
+  'd7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592': new Int8Array([84, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 32, 106, 117, 109, 112, 115, 32, 111, 118, 101, 114, 32, 116, 104, 101, 32, 108, 97, 122, 121, 32, 100, 111, 103])
+};
+// prettier-ignore
+// dprint-ignore
+fixtures.sha256.ArrayBuffer = {
+  'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855': new ArrayBuffer(0),
+  '6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d': new ArrayBuffer(1)
+};
+// prettier-ignore
+// dprint-ignore
+fixtures.sha224.Uint8Array = {
+  'e17541396a3ecd1cd5a2b968b84e597e8eae3b0ea3127963bf48dd3b': new Uint8Array([211, 212]),
+  '730e109bd7a8a32b1cb9d9a09aa2325d2430587ddbc0c38bad911525': new Uint8Array([84, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 32, 106, 117, 109, 112, 115, 32, 111, 118, 101, 114, 32, 116, 104, 101, 32, 108, 97, 122, 121, 32, 100, 111, 103])    
+};
+// prettier-ignore
+// dprint-ignore
+fixtures.sha224.Int8Array = {
+  '730e109bd7a8a32b1cb9d9a09aa2325d2430587ddbc0c38bad911525': new Int8Array([84, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 32, 106, 117, 109, 112, 115, 32, 111, 118, 101, 114, 32, 116, 104, 101, 32, 108, 97, 122, 121, 32, 100, 111, 103])
+};
+// prettier-ignore
+// dprint-ignore
+fixtures.sha224.ArrayBuffer = {
+  'd14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f': new ArrayBuffer(0),
+  'fff9292b4201617bdc4d3053fce02734166a683d7d858a7f5f59b073': new ArrayBuffer(1),
+};
+fixtures.sha256Hmac.Uint8Array = {
+  e48411262715c8370cd5e7bf8e82bef53bd53712d007f3429351843b77c7bb9b: [
+    new Uint8Array(0),
+    "Hi There",
+  ],
+};
+fixtures.sha256Hmac.ArrayBuffer = {
+  e48411262715c8370cd5e7bf8e82bef53bd53712d007f3429351843b77c7bb9b: [
+    new ArrayBuffer(0),
+    "Hi There",
+  ],
+};
+fixtures.sha224Hmac.Uint8Array = {
+  da8f94de91d62154b55ea4e8d6eb133f6d553bcd1f1ba205b9488945: [
+    new Uint8Array(0),
+    "Hi There",
+  ],
+};
+fixtures.sha224Hmac.ArrayBuffer = {
+  da8f94de91d62154b55ea4e8d6eb133f6d553bcd1f1ba205b9488945: [
+    new ArrayBuffer(0),
+    "Hi There",
+  ],
+};
+
+const methods = ["array", "arrayBuffer", "digest", "hex"] as const;
+
+for (const method of methods) {
+  for (const [name, tests] of Object.entries(fixtures.sha256)) {
+    let i = 1;
+    for (const [expected, message] of Object.entries(tests)) {
+      test({
+        name: `sha256.${method}() - ${name} - #${i++}`,
+        fn() {
+          const algorithm = new Sha256();
+          algorithm.update(message);
+          const actual =
+            method === "hex"
+              ? algorithm[method]()
+              : toHexString(algorithm[method]());
+          assertEquals(actual, expected);
+        },
+      });
+    }
+  }
+}
+
+for (const method of methods) {
+  for (const [name, tests] of Object.entries(fixtures.sha224)) {
+    let i = 1;
+    for (const [expected, message] of Object.entries(tests)) {
+      test({
+        name: `sha224.${method}() - ${name} - #${i++}`,
+        fn() {
+          const algorithm = new Sha256(true);
+          algorithm.update(message);
+          const actual =
+            method === "hex"
+              ? algorithm[method]()
+              : toHexString(algorithm[method]());
+          assertEquals(actual, expected);
+        },
+      });
+    }
+  }
+}
+
+for (const method of methods) {
+  for (const [name, tests] of Object.entries(fixtures.sha256Hmac)) {
+    let i = 1;
+    for (const [expected, [key, message]] of Object.entries(tests)) {
+      test({
+        name: `hmacSha256.${method}() - ${name} - #${i++}`,
+        fn() {
+          const algorithm = new HmacSha256(key);
+          algorithm.update(message);
+          const actual =
+            method === "hex"
+              ? algorithm[method]()
+              : toHexString(algorithm[method]());
+          assertEquals(actual, expected);
+        },
+      });
+    }
+  }
+}
+
+for (const method of methods) {
+  for (const [name, tests] of Object.entries(fixtures.sha224Hmac)) {
+    let i = 1;
+    for (const [expected, [key, message]] of Object.entries(tests)) {
+      test({
+        name: `hmacSha224.${method}() - ${name} - #${i++}`,
+        fn() {
+          const algorithm = new HmacSha256(key, true);
+          algorithm.update(message);
+          const actual =
+            method === "hex"
+              ? algorithm[method]()
+              : toHexString(algorithm[method]());
+          assertEquals(actual, expected);
+        },
+      });
+    }
+  }
+}


### PR DESCRIPTION
I was working on something that needs more secure hashing support than SHA1 provides (as SHA1 is considered insecure for new development).  I adapted [js-sha256](https://github.com/emn178/js-sha256) for TypeScript and Deno.