### PR TITLE
Remove duplicate resolution algorithm

### DIFF
--- a/cli/compilers/ts.rs
+++ b/cli/compilers/ts.rs
@@ -177,6 +177,7 @@ fn req(
   bundle: bool,
   unstable: bool,
 ) -> Buf {
+  let cwd = std::env::current_dir().unwrap();
   let j = match (compiler_config.path, compiler_config.content) {
     (Some(config_path), Some(config_data)) => json!({
       "type": request_type as i32,
@@ -187,6 +188,7 @@ fn req(
       "unstable": unstable,
       "configPath": config_path,
       "config": str::from_utf8(&config_data).unwrap(),
+      "cwd": cwd,
     }),
     _ => json!({
       "type": request_type as i32,
@@ -195,6 +197,7 @@ fn req(
       "outFile": out_file,
       "bundle": bundle,
       "unstable": unstable,
+      "cwd": cwd,
     }),
   };
 

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -54,6 +54,7 @@ interface CompilerRequestCompile {
   unstable: boolean;
   bundle: boolean;
   outFile?: string;
+  cwd: string;
 }
 
 interface CompilerRequestRuntimeCompile {
@@ -100,6 +101,7 @@ async function compile(
     rootNames,
     target,
     unstable,
+    cwd,
   } = request;
   util.log(">>> compile start", {
     rootNames,
@@ -132,7 +134,7 @@ async function compile(
 
   // if there is a configuration supplied, we need to parse that
   if (config && config.length && configPath) {
-    const configResult = host.configure(configPath, config);
+    const configResult = host.configure(cwd, configPath, config);
     diagnostics = processConfigureResponse(configResult, configPath);
   }
 

--- a/cli/js/compiler/host.ts
+++ b/cli/js/compiler/host.ts
@@ -2,7 +2,6 @@
 
 import { ASSETS, MediaType, SourceFile } from "./sourcefile.ts";
 import { OUT_DIR, WriteFileCallback, getAsset } from "./util.ts";
-import { cwd } from "../ops/fs/dir.ts";
 import { assert, notImplemented } from "../util.ts";
 import * as util from "../util.ts";
 
@@ -167,7 +166,11 @@ export class Host implements ts.CompilerHost {
     }
   }
 
-  configure(path: string, configurationText: string): ConfigureResponse {
+  configure(
+    cwd: string,
+    path: string,
+    configurationText: string
+  ): ConfigureResponse {
     util.log("compiler::host.configure", path);
     assert(configurationText);
     const { config, error } = ts.parseConfigFileTextToJson(
@@ -179,7 +182,7 @@ export class Host implements ts.CompilerHost {
     }
     const { options, errors } = ts.convertCompilerOptionsFromJson(
       config.compilerOptions,
-      cwd()
+      cwd
     );
     const ignoredOptions: string[] = [];
     for (const key of Object.keys(options)) {

--- a/cli/js/compiler/imports.ts
+++ b/cli/js/compiler/imports.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { MediaType, SourceFile, SourceFileJson } from "./sourcefile.ts";
-import { normalizeString, CHAR_FORWARD_SLASH } from "./util.ts";
 import { assert } from "../util.ts";
 import * as util from "../util.ts";
 import * as compilerOps from "../ops/compiler.ts";

--- a/cli/js/compiler/imports.ts
+++ b/cli/js/compiler/imports.ts
@@ -5,9 +5,23 @@ import { assert } from "../util.ts";
 import * as util from "../util.ts";
 import * as compilerOps from "../ops/compiler.ts";
 
-// TODO(ry) Remove. Unnecessary redirection to compilerOps.resolveModules.
 function resolveSpecifier(specifier: string, referrer: string): string {
-  return resolveModules([specifier], referrer)[0];
+  // The resolveModules op only handles fully qualified URLs for referrer.
+  // However we will have cases where referrer is "/foo.ts". We add this dummy
+  // prefix "file://" in order to use the op.
+  // TODO(ry) Maybe we should perhaps ModuleSpecifier::resolve_import() to
+  // handle this situation.
+  let dummyPrefix = false;
+  const prefix = "file://";
+  if (referrer.startsWith("/")) {
+    dummyPrefix = true;
+    referrer = prefix + referrer;
+  }
+  let r = resolveModules([specifier], referrer)[0];
+  if (dummyPrefix) {
+    r = r.replace(prefix, "");
+  }
+  return r;
 }
 
 // TODO(ry) Remove. Unnecessary redirection to compilerOps.resolveModules.

--- a/cli/js/compiler/imports.ts
+++ b/cli/js/compiler/imports.ts
@@ -2,59 +2,16 @@
 
 import { MediaType, SourceFile, SourceFileJson } from "./sourcefile.ts";
 import { normalizeString, CHAR_FORWARD_SLASH } from "./util.ts";
-import { cwd } from "../ops/fs/dir.ts";
 import { assert } from "../util.ts";
 import * as util from "../util.ts";
 import * as compilerOps from "../ops/compiler.ts";
 
-function resolvePath(...pathSegments: string[]): string {
-  let resolvedPath = "";
-  let resolvedAbsolute = false;
-
-  for (let i = pathSegments.length - 1; i >= -1 && !resolvedAbsolute; i--) {
-    let path: string;
-
-    if (i >= 0) path = pathSegments[i];
-    else path = cwd();
-
-    // Skip empty entries
-    if (path.length === 0) {
-      continue;
-    }
-
-    resolvedPath = `${path}/${resolvedPath}`;
-    resolvedAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
-  }
-
-  // At this point the path should be resolved to a full absolute path, but
-  // handle relative paths to be safe (might happen when cwd() fails)
-
-  // Normalize the path
-  resolvedPath = normalizeString(
-    resolvedPath,
-    !resolvedAbsolute,
-    "/",
-    (code) => code === CHAR_FORWARD_SLASH
-  );
-
-  if (resolvedAbsolute) {
-    if (resolvedPath.length > 0) return `/${resolvedPath}`;
-    else return "/";
-  } else if (resolvedPath.length > 0) return resolvedPath;
-  else return ".";
-}
-
+// TODO(ry) Remove. Unnecessary redirection to compilerOps.resolveModules.
 function resolveSpecifier(specifier: string, referrer: string): string {
-  if (!specifier.startsWith(".")) {
-    return specifier;
-  }
-  const pathParts = referrer.split("/");
-  pathParts.pop();
-  let path = pathParts.join("/");
-  path = path.endsWith("/") ? path : `${path}/`;
-  return resolvePath(path, specifier);
+  return resolveModules([specifier], referrer)[0];
 }
 
+// TODO(ry) Remove. Unnecessary redirection to compilerOps.resolveModules.
 export function resolveModules(
   specifiers: string[],
   referrer?: string
@@ -63,6 +20,7 @@ export function resolveModules(
   return compilerOps.resolveModules(specifiers, referrer);
 }
 
+// TODO(ry) Remove. Unnecessary redirection to compilerOps.fetchSourceFiles.
 function fetchSourceFiles(
   specifiers: string[],
   referrer?: string


### PR DESCRIPTION
Make it so the ts compiler doesn't use the cwd op.

Removes duplicate implementation of resolution algorithm.

cc @kitsonk 