### PR TITLE
feat(cli/js/web/url): Support drive letters in file URLs on Windows

### DIFF
--- a/cli/js/tests/url_test.ts
+++ b/cli/js/tests/url_test.ts
@@ -142,6 +142,25 @@ unitTest(function urlBackSlashes(): void {
   );
 });
 
+unitTest(function urlRequireHost(): void {
+  assertEquals(new URL("file:///").href, "file:///");
+  assertThrows(() => {
+    new URL("ftp:///");
+  });
+  assertThrows(() => {
+    new URL("http:///");
+  });
+  assertThrows(() => {
+    new URL("https:///");
+  });
+  assertThrows(() => {
+    new URL("ws:///");
+  });
+  assertThrows(() => {
+    new URL("wss:///");
+  });
+});
+
 unitTest(function urlBaseURL(): void {
   const base = new URL(
     "https://foo:bar@baz.qat:8000/qux/quux?foo=bar&baz=12#qat"

--- a/cli/js/tests/url_test.ts
+++ b/cli/js/tests/url_test.ts
@@ -132,6 +132,16 @@ unitTest(function urlSearchParamsReuse(): void {
   assert(sp === url.searchParams, "Search params should be reused.");
 });
 
+unitTest(function urlBackSlashes(): void {
+  const url = new URL(
+    "https:\\\\foo:bar@baz.qat:8000\\qux\\quux?foo=bar&baz=12#qat"
+  );
+  assertEquals(
+    url.href,
+    "https://foo:bar@baz.qat:8000/qux/quux?foo=bar&baz=12#qat"
+  );
+});
+
 unitTest(function urlBaseURL(): void {
   const base = new URL(
     "https://foo:bar@baz.qat:8000/qux/quux?foo=bar&baz=12#qat"

--- a/cli/js/tests/url_test.ts
+++ b/cli/js/tests/url_test.ts
@@ -161,6 +161,14 @@ unitTest(function urlRequireHost(): void {
   });
 });
 
+unitTest(function urlDriveLetter() {
+  assertEquals(
+    new URL("file:///C:").href,
+    Deno.build.os == "windows" ? "file:///C:/" : "file:///C:"
+  );
+  assertEquals(new URL("http://example.com/C:").href, "http://example.com/C:");
+});
+
 unitTest(function urlBaseURL(): void {
   const base = new URL(
     "https://foo:bar@baz.qat:8000/qux/quux?foo=bar&baz=12#qat"
@@ -185,6 +193,25 @@ unitTest(function urlRelativeWithBase(): void {
   assertEquals(new URL("b", "file:///a/a/a/").href, "file:///a/a/a/b");
   assertEquals(new URL("b/", "file:///a/a/a").href, "file:///a/a/b/");
   assertEquals(new URL("../b", "file:///a/a/a").href, "file:///a/b");
+});
+
+unitTest(function urlDriveLetterBase() {
+  assertEquals(
+    new URL("/b", "file:///C:/a/b").href,
+    Deno.build.os == "windows" ? "file:///C:/b" : "file:///b"
+  );
+  assertEquals(
+    new URL("D:", "file:///C:/a/b").href,
+    Deno.build.os == "windows" ? "file:///D:/" : "file:///C:/a/D:"
+  );
+  assertEquals(
+    new URL("/D:", "file:///C:/a/b").href,
+    Deno.build.os == "windows" ? "file:///D:/" : "file:///D:"
+  );
+  assertEquals(
+    new URL("D:/b", "file:///C:/a/b").href,
+    Deno.build.os == "windows" ? "file:///D:/b" : "file:///C:/a/D:/b"
+  );
 });
 
 unitTest(function emptyBasePath(): void {

--- a/cli/js/web/url.ts
+++ b/cli/js/web/url.ts
@@ -16,7 +16,7 @@ interface URLParts {
 
 const patterns = {
   protocol: "(?:([a-z]+):)",
-  authority: "(?://([^/?#]*))",
+  authority: "(?:[/\\\\][/\\\\]([^/\\\\?#]*))",
   path: "([^?#]*)",
   query: "(\\?[^#]*)",
   hash: "(#.*)",
@@ -65,7 +65,7 @@ function parse(url: string): URLParts | undefined {
         password: authorityMatch[2] || "",
         hostname: authorityMatch[3] || "",
         port: authorityMatch[4] || "",
-        path: urlMatch[3] || "",
+        path: urlMatch[3].replace(/\\/g, "/") || "",
         query: urlMatch[4] || "",
         hash: urlMatch[5] || "",
       };

--- a/std/path/from_file_url_test.ts
+++ b/std/path/from_file_url_test.ts
@@ -26,7 +26,7 @@ Deno.test("[path] fromFileUrl (win32)", function () {
   // assertEquals(path.win32.fromFileUrl("file:////server"), "\\");
   // assertEquals(path.win32.fromFileUrl("file:////server/file"), "\\file");
   assertEquals(path.win32.fromFileUrl("file:///c"), "\\c");
-  assertEquals(path.win32.fromFileUrl("file:///c:"), "\\c:");
+  assertEquals(path.win32.fromFileUrl("file:///c:"), "c:\\");
   assertEquals(path.win32.fromFileUrl("file:///c:/"), "c:\\");
   assertEquals(path.win32.fromFileUrl("file:///C:/"), "C:\\");
   assertEquals(path.win32.fromFileUrl("file:///C:/Users/"), "C:\\Users\\");

--- a/std/path/win32.ts
+++ b/std/path/win32.ts
@@ -909,6 +909,6 @@ export function parse(path: string): ParsedPath {
  */
 export function fromFileUrl(url: string | URL): string {
   return new URL(url).pathname
-    .replace(/^\/(?=[A-Za-z]:\/)/, "")
+    .replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/")
     .replace(/\//g, "\\");
 }


### PR DESCRIPTION
- refactor: Parse URLs more sequentially. This makes it easier to change matching behaviour depending on the protocol.
- fix: Fail when a host isn't given for certain protocols.
- fix: Convert back-slashes info forward-slashes.