### PR TITLE
feat(fmt): Add `deno-fmt-ignore` and `deno-fmt-ignore-file` comment support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,18 +618,18 @@ checksum = "52ba6eb47c2131e784a38b726eb54c1e1484904f013e576a25354d0124161af6"
 
 [[package]]
 name = "dprint-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe2ae2e02c20dcb77d422c6326db6c2a11a3dd37eb012b1cf69703685d272fb"
+checksum = "51503534b100175b33c3a7ed71839c8027ae16be1092ad93c7bb7cb2f8a06bcb"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f6bd2fcf216220b940683d47aa9a6231a3f039ae3303067ed3af60e606eb04"
+checksum = "afad8c8794d11dca59f4257f2901252e3e566704ac9810dad0eee694f1dc2ce7"
 dependencies = [
  "dprint-core",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.14.1"
+dprint-plugin-typescript = "0.16.0"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.1"

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -608,7 +608,6 @@ Ignore formatting code by preceding it with an ignore comment:
 
 Ignore formatting a file by adding an ignore comment at the top of the file:
   // deno-fmt-ignore-file",
-
     )
     .arg(
       Arg::with_name("check")

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -601,7 +601,13 @@ fn fmt_subcommand<'a, 'b>() -> App<'a, 'b> {
   deno fmt --check
 
 Format stdin and write to stdout:
-  cat file.ts | deno fmt -",
+  cat file.ts | deno fmt -
+
+Ignore formatting a file by adding an ignore comment at the top of the file:
+  // deno-fmt-ignore-file
+
+Ignore formatting code by adding an ignore comment before the code:
+  // deno-fmt-ignore",
     )
     .arg(
       Arg::with_name("check")

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -603,7 +603,7 @@ fn fmt_subcommand<'a, 'b>() -> App<'a, 'b> {
 Format stdin and write to stdout:
   cat file.ts | deno fmt -
 
-Ignore formatting code by adding an ignore comment before the code:
+Ignore formatting code by preceding it with an ignore comment:
   // deno-fmt-ignore
 
 Ignore formatting a file by adding an ignore comment at the top of the file:

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -603,11 +603,12 @@ fn fmt_subcommand<'a, 'b>() -> App<'a, 'b> {
 Format stdin and write to stdout:
   cat file.ts | deno fmt -
 
-Ignore formatting a file by adding an ignore comment at the top of the file:
-  // deno-fmt-ignore-file
-
 Ignore formatting code by adding an ignore comment before the code:
-  // deno-fmt-ignore",
+  // deno-fmt-ignore
+
+Ignore formatting a file by adding an ignore comment at the top of the file:
+  // deno-fmt-ignore-file",
+
     )
     .arg(
       Arg::with_name("check")

--- a/std/manual.md
+++ b/std/manual.md
@@ -1298,6 +1298,40 @@ All listeners added using `window.addEventListener` were run, but
 `window.onload` and `window.onunload` defined in `main.ts` overridden handlers
 defined in `imported.ts`.
 
+## `deno fmt`
+
+Deno ships with a built in code formatter that auto-formats TypeScript and
+JavaScript code.
+
+```shell
+# format all JS/TS files in the current directory and subdirectories
+deno fmt
+# format specific files
+deno fmt myfile1.ts myfile2.ts
+# check if all the JS/TS files in the current directory and subdirectories are formatted
+deno fmt --check
+# format stdin and write to stdout
+cat file.ts | deno fmt -
+```
+
+Ignore code to format by preceding it with a `// deno-fmt-ignore` comment:
+
+<!-- prettier-ignore-start -->
+
+```ts
+// deno-fmt-ignore
+export const identity = [
+    1, 0, 0,
+    0, 1, 0,
+    0, 0, 1,
+];
+```
+
+<!-- prettier-ignore-end -->
+
+Or ignore an entire file by adding a `// deno-fmt-ignore-file` comment at the
+top of the file.
+
 ## Internal details
 
 ### Deno and Linux analogy

--- a/std/manual.md
+++ b/std/manual.md
@@ -1314,7 +1314,7 @@ deno fmt --check
 cat file.ts | deno fmt -
 ```
 
-Ignore code to format by preceding it with a `// deno-fmt-ignore` comment:
+Ignore formatting code by preceding it with a `// deno-fmt-ignore` comment:
 
 <!-- prettier-ignore-start -->
 


### PR DESCRIPTION
This PR changes the ignore comments to be `// deno-fmt-ignore` and `// deno-fmt-ignore-file`, which was implemented by making these configurable and then specified in the "deno" top level config.

See https://github.com/dprint/dprint/issues/196 for implementation details.

**`deno-fmt-ignore` Example**

Formats as-is:

```ts
// deno-fmt-ignore
const identity = [
    1, 0, 0,
    0, 1, 0,
    0, 0, 1,
];

const identity = /* deno-fmt-ignore */ [
    1, 0, 0,
    0, 1, 0,
    0, 0, 1,
];
```

**`deno-fmt-ignore-file` Example**

Formats as-is:

```ts
// deno-fmt-ignore-file
some

.random.code(       5 );
call(   1   ,    5  );
```

Currently that must be the first comment in the file, but in the future I'll improve that to just have to be in a comment before the first node.