### PR TITLE
Check destination length in encodeInto

### DIFF
--- a/cli/js/tests/text_encoding_test.ts
+++ b/cli/js/tests/text_encoding_test.ts
@@ -158,6 +158,19 @@ unitTest(function textEncodeInto2(): void {
   ]);
 });
 
+unitTest(function textEncodeInto3(): void {
+  const fixture = "𝓽𝓮𝔁𝓽";
+  const encoder = new TextEncoder();
+  const bytes = new Uint8Array(5);
+  const result = encoder.encodeInto(fixture, bytes);
+  assertEquals(result.read, 2);
+  assertEquals(result.written, 4);
+  // prettier-ignore
+  assertEquals(Array.from(bytes), [
+    0xf0, 0x9d, 0x93, 0xbd, 0x00,
+  ]);
+});
+
 unitTest(function textDecoderSharedUint8Array(): void {
   const ab = new SharedArrayBuffer(6);
   const dataView = new DataView(ab);

--- a/cli/js/web/text_encoding.ts
+++ b/cli/js/web/text_encoding.ts
@@ -55,13 +55,13 @@ function stringToCodePoints(input: string): number[] {
 }
 
 class UTF8Encoder implements Encoder {
-  handler(codePoint: number): number | number[] {
+  handler(codePoint: number): 'finished' | number[] {
     if (codePoint === END_OF_STREAM) {
-      return FINISHED;
+      return 'finished';
     }
 
     if (inRange(codePoint, 0x00, 0x7f)) {
-      return codePoint;
+      return [codePoint];
     }
 
     let count: number;
@@ -144,7 +144,7 @@ interface Decoder {
 }
 
 interface Encoder {
-  handler(codePoint: number): number | number[];
+  handler(codePoint: number): 'finished' | number[];
 }
 
 class SingleByteDecoder implements Decoder {
@@ -534,14 +534,10 @@ export class TextEncoder {
 
     while (true) {
       const result = encoder.handler(inputStream.read());
-      if (result === FINISHED) {
+      if (result === 'finished') {
         break;
       }
-      if (Array.isArray(result)) {
-        output.push(...result);
-      } else {
-        output.push(result);
-      }
+      output.push(...result);
     }
 
     return new Uint8Array(output);
@@ -554,11 +550,11 @@ export class TextEncoder {
     let read = 0;
     while (true) {
       const result = encoder.handler(inputStream.read());
-      if (result === FINISHED) {
+      if (result === 'finished') {
         break;
       }
-      read++;
-      if (Array.isArray(result)) {
+      if (dest.length - written >= result.length) {
+        read++;
         dest.set(result, written);
         written += result.length;
         if (result.length > 3) {
@@ -566,8 +562,7 @@ export class TextEncoder {
           read++;
         }
       } else {
-        dest[written] = result;
-        written++;
+        break;
       }
     }
 

--- a/cli/js/web/text_encoding.ts
+++ b/cli/js/web/text_encoding.ts
@@ -55,9 +55,9 @@ function stringToCodePoints(input: string): number[] {
 }
 
 class UTF8Encoder implements Encoder {
-  handler(codePoint: number): 'finished' | number[] {
+  handler(codePoint: number): "finished" | number[] {
     if (codePoint === END_OF_STREAM) {
-      return 'finished';
+      return "finished";
     }
 
     if (inRange(codePoint, 0x00, 0x7f)) {
@@ -144,7 +144,7 @@ interface Decoder {
 }
 
 interface Encoder {
-  handler(codePoint: number): 'finished' | number[];
+  handler(codePoint: number): "finished" | number[];
 }
 
 class SingleByteDecoder implements Decoder {
@@ -534,7 +534,7 @@ export class TextEncoder {
 
     while (true) {
       const result = encoder.handler(inputStream.read());
-      if (result === 'finished') {
+      if (result === "finished") {
         break;
       }
       output.push(...result);
@@ -550,7 +550,7 @@ export class TextEncoder {
     let read = 0;
     while (true) {
       const result = encoder.handler(inputStream.read());
-      if (result === 'finished') {
+      if (result === "finished") {
         break;
       }
       if (dest.length - written >= result.length) {


### PR DESCRIPTION
I changed the Encoder interface because adding this check was awkward otherwise. Now it follows the spec more closely.