### PR TITLE
All multiple Set-Cookie headers

### DIFF
--- a/cli/js/tests/headers_test.ts
+++ b/cli/js/tests/headers_test.ts
@@ -362,6 +362,36 @@ unitTest(function headersAppendMultiple(): void {
   ]);
 });
 
+unitTest(function headersAppendDuplicateSetCookieKey(): void {
+  const headers = new Headers([["Set-Cookie", "foo=bar"]]);
+  headers.append("set-Cookie", "foo=baz");
+  headers.append("Set-cookie", "baz=bar");
+  const actual = [...headers];
+  assertEquals(actual, [
+    ["set-cookie", "foo=baz"],
+    ["set-cookie", "baz=bar"],
+  ]);
+});
+
+unitTest(function headersSetDuplicateCookieKey(): void {
+  const headers = new Headers([["Set-Cookie", "foo=bar"]]);
+  headers.set("set-Cookie", "foo=baz");
+  headers.set("set-cookie", "bar=qat");
+  const actual = [...headers];
+  assertEquals(actual, [
+    ["set-cookie", "foo=baz"],
+    ["set-cookie", "bar=qat"],
+  ]);
+});
+
+unitTest(function headersGetSetCookie(): void {
+  const headers = new Headers([
+    ["Set-Cookie", "foo=bar"],
+    ["set-Cookie", "bar=qat"],
+  ]);
+  assertEquals(headers.get("SET-COOKIE"), "foo=bar, bar=qat");
+});
+
 unitTest(function toStringShouldBeWebCompatibility(): void {
   const headers = new Headers();
   assertEquals(headers.toString(), "[object Headers]");

--- a/cli/js/tests/headers_test.ts
+++ b/cli/js/tests/headers_test.ts
@@ -332,6 +332,36 @@ unitTest(function headerParamsArgumentsCheck(): void {
   });
 });
 
+unitTest(function headersInitMultiple(): void {
+  const headers = new Headers([
+    ["Set-Cookie", "foo=bar"],
+    ["Set-Cookie", "bar=baz"],
+    ["X-Deno", "foo"],
+    ["X-Deno", "bar"],
+  ]);
+  const actual = [...headers];
+  assertEquals(actual, [
+    ["set-cookie", "foo=bar"],
+    ["set-cookie", "bar=baz"],
+    ["x-deno", "foo, bar"],
+  ]);
+});
+
+unitTest(function headersAppendMultiple(): void {
+  const headers = new Headers([
+    ["Set-Cookie", "foo=bar"],
+    ["X-Deno", "foo"],
+  ]);
+  headers.append("set-Cookie", "bar=baz");
+  headers.append("x-Deno", "bar");
+  const actual = [...headers];
+  assertEquals(actual, [
+    ["set-cookie", "foo=bar"],
+    ["x-deno", "foo, bar"],
+    ["set-cookie", "bar=baz"],
+  ]);
+});
+
 unitTest(function toStringShouldBeWebCompatibility(): void {
   const headers = new Headers();
   assertEquals(headers.toString(), "[object Headers]");

--- a/cli/js/web/headers.ts
+++ b/cli/js/web/headers.ts
@@ -119,7 +119,6 @@ function dataSet(
   key: string,
   value: string
 ): void {
-  let found = false;
   for (let i = 0; i < data.length; i++) {
     const [dataKey] = data[i];
     if (dataKey === key) {
@@ -134,13 +133,11 @@ function dataSet(
         }
       } else {
         data[i][1] = value;
-        found = true;
+        return;
       }
     }
   }
-  if (!found) {
-    data.push([key, value]);
-  }
+  data.push([key, value]);
 }
 
 function dataDelete(data: Array<[string, string]>, key: string): void {


### PR DESCRIPTION
Fixes #4826 

This is an alternative PR.  It does not require any changes to any other code.  It does vary from the specification, as the existing implementations concatenate the values for `Set-Cookie`.  This of course could be argued to be an error with the specification, but again the specification wasn't designed to be used with servers, sending to clients.

The following works:

```ts
const headers = new Headers([
  ["Set-Cookie", "foo=bar"],
  ["Set-Cookie", "bar=baz"],
  ["X-Deno", "foo"],
  ["X-Deno", "baz"],
]);

console.log([...headers]);
```

Will output something like:

```js
[
  [ "set-cookie", "foo=bar" ],
  [ "set-cooke", "bar=baz" ],
  [ "x-deno", "foo, bar" ]
]
```

While browsers do this:

```js
[
  [ "set-cookie", "foo=bar, bar=baz" ],
  [ "x-deno", "foo, bar" ]
]
```
