### PR TITLE
Better error message when unable to create cache dirs

### DIFF
--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -31,6 +31,7 @@ impl DenoDir {
       root,
       gen_cache: DiskCache::new(&gen_path),
     };
+    deno_dir.gen_cache.ensure_location()?;
 
     Ok(deno_dir)
   }

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -1,6 +1,7 @@
 use crate::fs as deno_fs;
 use std::ffi::OsStr;
 use std::fs;
+use std::io;
 use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
@@ -22,12 +23,22 @@ fn with_io_context<T: AsRef<str>>(
 
 impl DiskCache {
   pub fn new(location: &Path) -> Self {
-    if !&location.is_dir() {
-      fs::create_dir_all(&location).ok();
-    }
     Self {
       location: location.to_owned(),
     }
+  }
+
+  /// Ensures the location of the cache.
+  pub fn ensure_location(&self) -> io::Result<()> {
+    if self.location.is_dir() {
+      return Ok(());
+    }
+    fs::create_dir_all(&self.location).map_err(|e| {
+      io::Error::new(e.kind(), format!(
+        "Could not create TypeScript compiler cache location: {:?}\nCheck the permission of the directory.",
+        self.location
+      ))
+    })
   }
 
   pub fn get_cache_filename(&self, url: &Url) -> PathBuf {
@@ -140,7 +151,8 @@ mod tests {
     let cache_location = TempDir::new().unwrap();
     let mut cache_path = cache_location.path().to_owned();
     cache_path.push("foo");
-    DiskCache::new(&cache_path);
+    let cache = DiskCache::new(&cache_path);
+    cache.ensure_location().expect("Testing expect:");
     assert!(cache_path.is_dir());
   }
 
@@ -151,7 +163,8 @@ mod tests {
     assert!(fs::remove_dir(&cache_location).is_ok());
     cache_location.push("foo");
     assert_eq!(cache_location.is_dir(), false);
-    DiskCache::new(&cache_location);
+    let cache = DiskCache::new(&cache_location);
+    cache.ensure_location().expect("Testing expect:");
     assert_eq!(cache_location.is_dir(), true);
   }
 

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -661,7 +661,7 @@ mod tests {
 
   fn setup_file_fetcher(dir_path: &Path) -> SourceFileFetcher {
     SourceFileFetcher::new(
-      HttpCache::new(&dir_path.to_path_buf().join("deps")).unwrap(),
+      HttpCache::new(&dir_path.to_path_buf().join("deps")),
       true,
       vec![],
       false,

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -54,7 +54,8 @@ impl GlobalState {
     let custom_root = env::var("DENO_DIR").map(String::into).ok();
     let dir = deno_dir::DenoDir::new(custom_root)?;
     let deps_cache_location = dir.root.join("deps");
-    let http_cache = http_cache::HttpCache::new(&deps_cache_location)?;
+    let http_cache = http_cache::HttpCache::new(&deps_cache_location);
+    http_cache.ensure_location()?;
 
     let file_fetcher = SourceFileFetcher::new(
       http_cache,


### PR DESCRIPTION
This PR improves the error messages in the cases when DENO_DIR is not owned by the current user and unable to create cache dirs.

The error messages become like the below:

```shellsession
$ sudo mkdir deno_dir
$ sudo chmod 755 deno_dir
$ DENO_DIR=./deno_dir ./target/debug/deno run test.js 
Could not create TypeScript compiler cache location: "./deno_dir/gen"
Check the permission of the directory.
$ sudo mkdir deno_dir/gen
$ DENO_DIR=./deno_dir ./target/debug/deno run test.js 
Could not create remote modules cache location: "./deno_dir/deps"
Check the permission of the directory.
$ sudo mkdir deno_dir/deps
$ DENO_DIR=./deno_dir ./target/debug/deno run test.js 
1
```

This (maybe) closes #2731