### PR TITLE
fix: contribution style guide link is invalid

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-- Read the [style guide](https://github.com/denoland/deno/blob/master/std/style_guide.md).
+- Read the [style guide](../std/style_guide.md).
 - Progress towards future releases is tracked
   [here](https://github.com/denoland/deno/milestones).
 - Please don't make [the benchmarks](https://deno.land/benchmarks.html) worse.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-- Read the [style guide](style_guide.md).
+- Read the [style guide](https://github.com/denoland/deno/blob/master/std/style_guide.md).
 - Progress towards future releases is tracked
   [here](https://github.com/denoland/deno/milestones).
 - Please don't make [the benchmarks](https://deno.land/benchmarks.html) worse.


### PR DESCRIPTION
Fix the guideline link for contribution to deno

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
