### PR TITLE
REPL commands now start with .

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -573,7 +573,7 @@ fn repl_test_exit_command() {
   let (out, err) = util::run_and_collect_output(
     true,
     "repl",
-    Some(vec!["exit", "'ignored'"]),
+    Some(vec![".exit"]),
     None,
     false,
   );
@@ -583,19 +583,34 @@ fn repl_test_exit_command() {
 
 #[test]
 fn repl_test_help_command() {
-  let (out, err) =
-    util::run_and_collect_output(true, "repl", Some(vec!["help"]), None, false);
+  let (out, err) = util::run_and_collect_output(
+    true,
+    "repl",
+    Some(vec![".help"]),
+    None,
+    false,
+  );
   assert_eq!(
     out,
     vec![
+      "",
       "_       Get last evaluation result",
       "_error  Get last thrown error",
-      "exit    Exit the REPL",
-      "help    Print this help message",
+      ".exit   Exit the REPL",
+      ".help   Print this help message",
+      "",
       "",
     ]
     .join("\n")
   );
+  assert!(err.is_empty());
+}
+
+#[test]
+fn repl_test_invalid_command() {
+  let (out, err) =
+    util::run_and_collect_output(true, "repl", Some(vec![".bad"]), None, false);
+  assert_eq!(out, "Invalid REPL command\n");
   assert!(err.is_empty());
 }
 
@@ -2437,7 +2452,7 @@ mod util {
   pub const PERMISSION_DENIED_PATTERN: &str = "PermissionDenied";
 
   lazy_static! {
-    static ref DENO_DIR: TempDir = { TempDir::new().expect("tempdir fail") };
+    static ref DENO_DIR: TempDir = TempDir::new().expect("tempdir fail");
   }
 
   pub fn run_and_collect_output(


### PR DESCRIPTION
Fixes #4772

Now to exit from the REPL, you type `.exit` and to get help in the REPL you type `.help`.

This PR changes the way REPL commands are handled as well.  In evaluate, if the code starts with `.` then the command is matched against the valid REPL commands.  This means that REPL commands never exist in the global namespace nor can they occupy "surprising" variables.  The only ones that exist then are `_` and `_error`.
