### PR TITLE
fix(docs): add missing "deno run"

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1718,7 +1718,7 @@ declare namespace Deno {
   /** Returns the script arguments to the program. If for example we run a
    * program:
    *
-   *      deno --allow-read https://deno.land/std/examples/cat.ts /etc/passwd
+   *      deno run --allow-read https://deno.land/std/examples/cat.ts /etc/passwd
    *
    * Then `Deno.args` will contain:
    *

--- a/docs/contributing/building_from_source.md
+++ b/docs/contributing/building_from_source.md
@@ -85,5 +85,5 @@ cargo build -vv
 cargo clean && cargo build -vv
 
 # Run:
-./target/debug/deno cli/tests/002_hello.ts
+./target/debug/deno run cli/tests/002_hello.ts
 ```

--- a/docs/tools/bundler.md
+++ b/docs/tools/bundler.md
@@ -15,7 +15,7 @@ If you omit the out file, the bundle will be sent to `stdout`.
 The bundle can just be run as any other module in Deno would:
 
 ```
-deno colors.bundle.js
+deno run colors.bundle.js
 ```
 
 The output is a self contained ES Module, where any exports from the main module

--- a/std/examples/README.md
+++ b/std/examples/README.md
@@ -10,7 +10,7 @@ bookmark to a program.)
 ### A TCP echo server
 
 ```shell
-deno  --allow-net https://deno.land/std/examples/echo_server.ts
+deno run --allow-net https://deno.land/std/examples/echo_server.ts
 ```
 
 Or
@@ -40,7 +40,7 @@ echo example.json | catj -
 ### curl - print the contents of a url to standard output
 
 ```shell
-deno --allow-net=deno.land https://deno.land/std/examples/curl.ts https://deno.land/
+deno run --allow-net=deno.land https://deno.land/std/examples/curl.ts https://deno.land/
 ```
 
 ### gist - easily create and upload Gists
@@ -55,7 +55,7 @@ gist --t "Example gist 2" script2.ts
 ### chat - WebSocket chat server and browser client
 
 ```shell
-deno --allow-net --allow-read https://deno.land/std/examples/chat/server.ts
+deno run --allow-net --allow-read https://deno.land/std/examples/chat/server.ts
 ```
 
 Open http://localhost:8080 on the browser.

--- a/std/examples/xeval.ts
+++ b/std/examples/xeval.ts
@@ -14,16 +14,16 @@ const HELP_MSG = `xeval
 Run a script for each new-line or otherwise delimited chunk of standard input.
 
 Print all the usernames in /etc/passwd:
-  cat /etc/passwd | deno -A https://deno.land/std/examples/xeval.ts "a = $.split(':'); if (a) console.log(a[0])"
+  cat /etc/passwd | deno run -A https://deno.land/std/examples/xeval.ts "a = $.split(':'); if (a) console.log(a[0])"
 
 A complicated way to print the current git branch:
-  git branch | deno -A https://deno.land/std/examples/xeval.ts -I 'line' "if (line.startsWith('*')) console.log(line.slice(2))"
+  git branch | deno run -A https://deno.land/std/examples/xeval.ts -I 'line' "if (line.startsWith('*')) console.log(line.slice(2))"
 
 Demonstrates breaking the input up by space delimiter instead of by lines:
-  cat LICENSE | deno -A https://deno.land/std/examples/xeval.ts -d " " "if ($ === 'MIT') console.log('MIT licensed')",
+  cat LICENSE | deno run -A https://deno.land/std/examples/xeval.ts -d " " "if ($ === 'MIT') console.log('MIT licensed')",
 
 USAGE:
-  deno -A https://deno.land/std/examples/xeval.ts [OPTIONS] <code>
+  deno run -A https://deno.land/std/examples/xeval.ts [OPTIONS] <code>
 OPTIONS:
   -d, --delim <delim>       Set delimiter, defaults to newline
   -I, --replvar <replvar>   Set variable name to be used in eval, defaults to $

--- a/std/flags/README.md
+++ b/std/flags/README.md
@@ -12,12 +12,12 @@ console.dir(parse(args));
 ```
 
 ```
-$ deno example.ts -a beep -b boop
+$ deno run example.ts -a beep -b boop
 { _: [], a: 'beep', b: 'boop' }
 ```
 
 ```
-$ deno example.ts -x 3 -y 4 -n5 -abc --beep=boop foo bar baz
+$ deno run example.ts -x 3 -y 4 -n5 -abc --beep=boop foo bar baz
 { _: [ 'foo', 'bar', 'baz' ],
   x: 3,
   y: 4,
@@ -60,11 +60,11 @@ options can be:
   import { parse } from "https://deno.land/std/flags/mod.ts";
   // options['--'] is now set to false
   console.dir(parse(args, { "--": false }));
-  // $ deno example.ts -- a arg1
+  // $ deno run example.ts -- a arg1
   // output: { _: [ "example.ts", "a", "arg1" ] }
   // options['--'] is now set to true
   console.dir(parse(args, { "--": true }));
-  // $ deno example.ts -- a arg1
+  // $ deno run example.ts -- a arg1
   // output: { _: [ "example.ts" ], --: [ "a", "arg1" ] }
   ```
 - `options.unknown` - a function which is invoked with a command line parameter

--- a/std/flags/mod.ts
+++ b/std/flags/mod.ts
@@ -18,11 +18,11 @@ export interface ArgParsingOptions {
    *      import { parse } from "https://deno.land/std/flags/mod.ts";
    *      // options['--'] is now set to false
    *      console.dir(parse(args, { "--": false }));
-   *      // $ deno example.ts -- a arg1
+   *      // $ deno run example.ts -- a arg1
    *      // output: { _: [ "example.ts", "a", "arg1" ] }
    *      // options['--'] is now set to true
    *      console.dir(parse(args, { "--": true }));
-   *      // $ deno example.ts -- a arg1
+   *      // $ deno run example.ts -- a arg1
    *      // output: { _: [ "example.ts" ], --: [ "a", "arg1" ] }
    *
    * Defaults to `false`.

--- a/std/http/README.md
+++ b/std/http/README.md
@@ -14,7 +14,7 @@ for await (const req of s) {
 A small program for serving local files over HTTP
 
 ```sh
-deno --allow-net --allow-read https://deno.land/std/http/file_server.ts
+deno run --allow-net --allow-read https://deno.land/std/http/file_server.ts
 > HTTP server listening on http://0.0.0.0:4500/
 ```
 


### PR DESCRIPTION
this should be all missing "deno run" that were left

regex for future reference
`deno (?!bundle|cache|completions|doc|eval|fmt|help|info|install|repl|run|test|types|upgrade|lint)`