### PR TITLE
fix(docs): add another vscode-deno

### DIFF
--- a/docs/getting_started/setup_your_environment.md
+++ b/docs/getting_started/setup_your_environment.md
@@ -47,6 +47,8 @@ The community has developed extensions for some editors to solve these issues:
 
 - [VS Code](https://marketplace.visualstudio.com/items?itemName=axetroy.vscode-deno)
   by [@axetroy](https://github.com/axetroy).
+- [VS Code](https://marketplace.visualstudio.com/items?itemName=justjavac.vscode-deno)
+  by [@justjavac](https://github.com/justjavac).
 
 Support for JetBrains IDEs is not yet available, but you can follow and upvote
 these issues to stay up to date:


### PR DESCRIPTION
I hope to add the vscode extension developed by me to the docs.

At the end of last year, I never updated this extension for 3 months due to work. Now I refactored the [typescript-deno-plugin](https://github.com/justjavac/typescript-deno-plugin) code to support import maps and other Deno features.

I am currently rewriting the plugin with LSP(like axetroy's). And I also created [deno_vscode_languageserver](https://github.com/denodev/deno_vscode_languageserver) repo, maybe in the future we can develop vscode language server with Deno itself.

-------------

the good idea is, to create a `denoland/vscode-deno` repo, and we jointly maintain the same code base.

cc @ry @lucacasonato @axetroy 