### PR TITLE
Correct WritableStreamDefaultWriterImpl TypeError text

### DIFF
--- a/cli/js/web/streams/writable_stream_default_writer.ts
+++ b/cli/js/web/streams/writable_stream_default_writer.ts
@@ -31,7 +31,7 @@ export class WritableStreamDefaultWriterImpl<W>
       throw new TypeError("Invalid stream.");
     }
     if (isWritableStreamLocked(stream)) {
-      throw new TypeError("Cannot create a reader for a locked stream.");
+      throw new TypeError("Cannot create a writer for a locked stream.");
     }
     this[sym.ownerWritableStream] = stream;
     stream[sym.writer] = this;


### PR DESCRIPTION
Fix a small typo the error scenario where a user calls `getWriter()`, the default writable stream is used and the stream is already locked.
