### PR TITLE
add option to lint and format only staged files

### DIFF
--- a/cli/js/ts_global.d.ts
+++ b/cli/js/ts_global.d.ts
@@ -9,6 +9,8 @@
 // deno_typescript/typescript/lib/typescript.d.ts. Ideally we could simply point
 // to that in this import specifier, but "cargo package" is very strict and
 // requires all files to be present in a crate's subtree.
+// to get proper editor intellisense, you can substitute "$asset$" with
+// "../../deno_typescript/typescript/lib" - remember to revert before committing
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import * as ts_ from "$asset$/typescript.d.ts";
 

--- a/tools/util.py
+++ b/tools/util.py
@@ -193,6 +193,23 @@ def git_ls_files(base_dir, patterns=None):
     return files
 
 
+# list all files staged for commit
+def git_staged(base_dir, patterns=None):
+    base_dir = os.path.abspath(base_dir)
+    args = [
+        "git", "-C", base_dir, "diff", "--staged", "--diff-filter=ACMR",
+        "--name-only", "-z"
+    ]
+    if patterns:
+        args += ["--"] + patterns
+    output = subprocess.check_output(args)
+    files = [
+        os.path.normpath(os.path.join(base_dir, f)) for f in output.split("\0")
+        if f != ""
+    ]
+    return files
+
+
 # The Python equivalent of `rm -rf`.
 def rmtree(directory):
     # On Windows, shutil.rmtree() won't delete files that have a readonly bit.
@@ -406,3 +423,8 @@ def tty_capture(cmd, bytes_input, timeout=5):
         os.close(fd)  # can't do it sooner: it leads to errno.EIO error
     p.wait()
     return p.returncode, res['stdout'], res['stderr']
+
+
+def print_command(cmd, files):
+    noun = "file" if len(files) == 1 else "files"
+    print "%s (%d %s)" % (cmd, len(files), noun)


### PR DESCRIPTION
Currently linting and formatting takes unnecessarily long time, largely due to the fact that it applies to the whole codebase every time you do it, regardless of which files have already been checked. I added a `--staged` option to the scripts to apply the checks only to files that have been staged for commit, I think that should make pre-commit checking significantly faster. It can also be added to pre-commit hooks.

Also, I added a little note on how to modify the `ts_global.d.ts` file so that VSCode properly recognizes the `ts` namespace when editing the compiler source. Modifying that file could also be added to a pre- and post-commit hook.