### PR TITLE
refactor(cli): unify display of errors from Rust and JS

### DIFF
--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -438,7 +438,7 @@ mod tests {
   #[test]
   fn diagnostic_to_string2() {
     let d = diagnostic2();
-    let expected = "TS2322 [ERROR]: Example 1\n  values: o => [\n  ~~~~~~\n    at deno/tests/complex_diagnostics.ts:19:3\n\nTS2000 [ERROR]]: Example 2\n  values: undefined,\n  ~~~~~~\n    at /foo/bar.ts:129:3\n\nFound 2 errors.";
+    let expected = "TS2322 [ERROR]: Example 1\n  values: o => [\n  ~~~~~~\n    at deno/tests/complex_diagnostics.ts:19:3\n\nTS2000 [ERROR]: Example 2\n  values: undefined,\n  ~~~~~~\n    at /foo/bar.ts:129:3\n\nFound 2 errors.";
     assert_eq!(expected, strip_ansi_codes(&d.to_string()));
   }
 

--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -89,18 +89,16 @@ fn format_category_and_code(
   code: i64,
 ) -> String {
   let category = match category {
-    DiagnosticCategory::Error => {
-      format!("{}", colors::red_bold("error".to_string()))
-    }
-    DiagnosticCategory::Warning => "warn".to_string(),
-    DiagnosticCategory::Debug => "debug".to_string(),
-    DiagnosticCategory::Info => "info".to_string(),
+    DiagnosticCategory::Error => "ERROR".to_string(),
+    DiagnosticCategory::Warning => "WARN".to_string(),
+    DiagnosticCategory::Debug => "DEBUG".to_string(),
+    DiagnosticCategory::Info => "INFO".to_string(),
     _ => "".to_string(),
   };
 
   let code = colors::bold(format!("TS{}", code.to_string())).to_string();
 
-  format!("{} {}", category, code)
+  format!("{} [{}]", code, category)
 }
 
 fn format_message(
@@ -433,14 +431,14 @@ mod tests {
   #[test]
   fn diagnostic_to_string1() {
     let d = diagnostic1();
-    let expected = "error TS2322: Type \'(o: T) => { v: any; f: (x: B) => string; }[]\' is not assignable to type \'(r: B) => Value<B>[]\'.\n  Types of parameters \'o\' and \'r\' are incompatible.\n    Type \'B\' is not assignable to type \'T\'.\n  values: o => [\n  ~~~~~~\n    at deno/tests/complex_diagnostics.ts:19:3\n\n    The expected type comes from property \'values\' which is declared here on type \'SettingsInterface<B>\'\n      values?: (r: T) => Array<Value<T>>;\n      ~~~~~~\n        at deno/tests/complex_diagnostics.ts:7:3";
+    let expected = "TS2322 [ERROR]: Type \'(o: T) => { v: any; f: (x: B) => string; }[]\' is not assignable to type \'(r: B) => Value<B>[]\'.\n  Types of parameters \'o\' and \'r\' are incompatible.\n    Type \'B\' is not assignable to type \'T\'.\n  values: o => [\n  ~~~~~~\n    at deno/tests/complex_diagnostics.ts:19:3\n\n    The expected type comes from property \'values\' which is declared here on type \'SettingsInterface<B>\'\n      values?: (r: T) => Array<Value<T>>;\n      ~~~~~~\n        at deno/tests/complex_diagnostics.ts:7:3";
     assert_eq!(expected, strip_ansi_codes(&d.to_string()));
   }
 
   #[test]
   fn diagnostic_to_string2() {
     let d = diagnostic2();
-    let expected = "error TS2322: Example 1\n  values: o => [\n  ~~~~~~\n    at deno/tests/complex_diagnostics.ts:19:3\n\nerror TS2000: Example 2\n  values: undefined,\n  ~~~~~~\n    at /foo/bar.ts:129:3\n\nFound 2 errors.";
+    let expected = "TS2322 [ERROR]: Example 1\n  values: o => [\n  ~~~~~~\n    at deno/tests/complex_diagnostics.ts:19:3\n\nTS2000 [ERROR]]: Example 2\n  values: undefined,\n  ~~~~~~\n    at /foo/bar.ts:129:3\n\nFound 2 errors.";
     assert_eq!(expected, strip_ansi_codes(&d.to_string()));
   }
 

--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -150,11 +150,7 @@ impl fmt::Display for JSError {
       "{}",
       &format_stack(
         true,
-        format!(
-          "{}: {}",
-          colors::red_bold("error".to_string()),
-          self.0.message.clone()
-        ),
+        self.0.message.clone(),
         self.0.source_line.clone(),
         self.0.start_column,
         self.0.end_column,

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -626,7 +626,12 @@ pub fn main() {
 
   let result = tokio_util::run_basic(fut);
   if let Err(err) = result {
-    eprintln!("{}", err.to_string());
+    let msg = format!(
+      "{}: {}",
+      colors::red_bold("error".to_string()),
+      err.to_string(),
+    );
+    eprintln!("{}", msg);
     std::process::exit(1);
   }
 }

--- a/cli/tests/038_checkjs.js.out
+++ b/cli/tests/038_checkjs.js.out
@@ -1,4 +1,5 @@
-[WILDCARD]error TS2552: Cannot find name 'consol'. Did you mean 'console'?
+[WILDCARD]
+error: TS2552 [ERROR]: Cannot find name 'consol'. Did you mean 'console'?
 consol.log("hello world!");
 ~~~~~~
     at [WILDCARD]tests/038_checkjs.js:2:1
@@ -8,7 +9,7 @@ consol.log("hello world!");
                 ~~~~~~~
         at [WILDCARD]
 
-error TS2552: Cannot find name 'Foo'. Did you mean 'foo'?
+TS2552 [ERROR]: Cannot find name 'Foo'. Did you mean 'foo'?
 const foo = new Foo();
                 ~~~
     at [WILDCARD]tests/038_checkjs.js:6:17

--- a/cli/tests/config.ts.out
+++ b/cli/tests/config.ts.out
@@ -1,7 +1,7 @@
 [WILDCARD]Unsupported compiler options in "[WILDCARD]config.tsconfig.json"
   The following options were ignored:
     module, target
-error TS2532: Object is possibly 'undefined'.
+error: TS2532 [ERROR]: Object is possibly 'undefined'.
 if (map.get("bar").foo) {
     ~~~~~~~~~~~~~~
     at [WILDCARD]tests/config.ts:3:5

--- a/cli/tests/error_003_typescript.ts.out
+++ b/cli/tests/error_003_typescript.ts.out
@@ -1,4 +1,5 @@
-[WILDCARD]error TS2322: Type '{ a: { b: { c(): { d: number; }; }; }; }' is not assignable to type '{ a: { b: { c(): { d: string; }; }; }; }'.
+[WILDCARD]
+error: TS2322 [ERROR]: Type '{ a: { b: { c(): { d: number; }; }; }; }' is not assignable to type '{ a: { b: { c(): { d: string; }; }; }; }'.
   The types of 'a.b.c().d' are incompatible between these types.
     Type 'number' is not assignable to type 'string'.
 x = y;

--- a/cli/tests/error_013_missing_script.out
+++ b/cli/tests/error_013_missing_script.out
@@ -1,1 +1,1 @@
-Cannot resolve module "[WILDCARD]missing_file_name"
+error: Cannot resolve module "[WILDCARD]missing_file_name"

--- a/cli/tests/error_017_hide_long_source_ts.ts.out
+++ b/cli/tests/error_017_hide_long_source_ts.ts.out
@@ -1,3 +1,3 @@
 [WILDCARD]
-error TS2532 [ERROR]: Object is possibly 'undefined'.
+error: TS2532 [ERROR]: Object is possibly 'undefined'.
     at [WILDCARD]tests/error_017_hide_long_source_ts.ts:2:1

--- a/cli/tests/error_017_hide_long_source_ts.ts.out
+++ b/cli/tests/error_017_hide_long_source_ts.ts.out
@@ -1,2 +1,3 @@
-[WILDCARD]error TS2532: Object is possibly 'undefined'.
+[WILDCARD]
+error TS2532 [ERROR]: Object is possibly 'undefined'.
     at [WILDCARD]tests/error_017_hide_long_source_ts.ts:2:1

--- a/cli/tests/error_local_static_import_from_remote.js.out
+++ b/cli/tests/error_local_static_import_from_remote.js.out
@@ -1,2 +1,2 @@
 [WILDCARD]
-Remote module are not allowed to statically import local modules. Use dynamic import instead.
+error: Remote module are not allowed to statically import local modules. Use dynamic import instead.

--- a/cli/tests/unstable_disabled.out
+++ b/cli/tests/unstable_disabled.out
@@ -1,5 +1,5 @@
 [WILDCARD]
-error TS2339: Property 'loadavg' does not exist on type 'typeof Deno'.
+error: TS2339 [ERROR]: Property 'loadavg' does not exist on type 'typeof Deno'.
 console.log(Deno.loadavg);
                  ~~~~~~~
     at [WILDCARD]/cli/tests/unstable.ts:1:18


### PR DESCRIPTION
Currently error formatting is different for errors originating from JS and Rust:
```
// JS
error: Uncaught URIError: relative import path "bad-module.ts" not prefixed with / or ./ or ../ Imported from "file:///Users/biwanczuk/dev/deno/cli/tests/error_011_bad_module_specifier.ts"

// Rust
Remote module are not allowed to statically import local modules. Use dynamic import instead.
```

This PR changes formatting so both errors are prefixed with red `error:`:
```
// JS
error: Uncaught URIError: relative import path "bad-module.ts" not prefixed with / or ./ or ../ Imported from "file:///Users/biwanczuk/dev/deno/cli/tests/error_011_bad_module_specifier.ts"

// Rust
error: Remote module are not allowed to statically import local modules. Use dynamic import instead.
```

There is also question of diagnostics which have completely different formatting and display as:
```
error TS2339: Property 'loadavg' does not exist on type 'typeof Deno'.
console.log(Deno.loadavg);
```

I propose to change it to:
```
error: TS2339 [ERROR]: Property 'loadavg' does not exist on type 'typeof Deno'.
console.log(Deno.loadavg);
```
The `[ERROR]` describes the category of diagnostic (it can be also warn/debug/info).

EDIT: Already went ahead and did suggested change for diagnostics