### PR TITLE
Allow starting isolate from snapshot bytes on the heap

### DIFF
--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -125,6 +125,7 @@ impl From<Script<'_>> for OwnedScript {
 pub enum Snapshot {
   Static(&'static [u8]),
   JustCreated(v8::StartupData),
+  Boxed(Box<[u8]>),
 }
 
 /// Represents data used to initialize isolate at startup
@@ -250,6 +251,7 @@ impl CoreIsolate {
         params = match snapshot {
           Snapshot::Static(data) => params.snapshot_blob(data),
           Snapshot::JustCreated(data) => params.snapshot_blob(data),
+          Snapshot::Boxed(data) => params.snapshot_blob(data),
         };
         true
       } else {

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -1177,6 +1177,20 @@ pub mod tests {
     let mut isolate2 = CoreIsolate::new(startup_data, false);
     js_check(isolate2.execute("check.js", "if (a != 3) throw Error('x')"));
   }
+
+  #[test]
+  fn test_from_boxed_snapshot() {
+    let snapshot = {
+      let mut isolate = CoreIsolate::new(StartupData::None, true);
+      js_check(isolate.execute("a.js", "a = 1 + 2"));
+      let snap: &[u8] = &*isolate.snapshot();
+      Vec::from(snap).into_boxed_slice()
+    };
+
+    let startup_data = StartupData::Snapshot(Snapshot::Boxed(snapshot));
+    let mut isolate2 = CoreIsolate::new(startup_data, false);
+    js_check(isolate2.execute("check.js", "if (a != 3) throw Error('x')"));
+  }
 }
 
 // TODO(piscisaureus): rusty_v8 should implement the Error trait on


### PR DESCRIPTION
Fixes #4402

Since there has been a [refactor for isolate startup data](https://github.com/denoland/rusty_v8/pull/357), fixing this has gotten sooo much easier. Thank you for that.