### PR TITLE
fix(std/encoding/yaml): Correct exports

### DIFF
--- a/std/encoding/yaml.ts
+++ b/std/encoding/yaml.ts
@@ -8,4 +8,9 @@ export {
   DumpOptions as StringifyOptions,
   stringify,
 } from "./_yaml/stringify.ts";
-export { Schema, SchemaDefinition, TypeMap } from "./_yaml/schema/mod.ts";
+export {
+  CORE_SCHEMA,
+  DEFAULT_SCHEMA,
+  FAILSAFE_SCHEMA,
+  JSON_SCHEMA,
+} from "./_yaml/schema/mod.ts";

--- a/std/encoding/yaml.ts
+++ b/std/encoding/yaml.ts
@@ -8,6 +8,8 @@ export {
   DumpOptions as StringifyOptions,
   stringify,
 } from "./_yaml/stringify.ts";
+export { SchemaDefinition } from "./_yaml/schema.ts";
+export { StyleVariant } from "./_yaml/type.ts";
 export {
   CORE_SCHEMA,
   DEFAULT_SCHEMA,

--- a/std/encoding/yaml_test.ts
+++ b/std/encoding/yaml_test.ts
@@ -2,3 +2,6 @@
 
 import "./_yaml/parse_test.ts";
 import "./_yaml/stringify_test.ts";
+
+// Type check.
+import "./yaml.ts";


### PR DESCRIPTION
Fixes #5190.

In [this change](https://github.com/denoland/deno/pull/5087/files#diff-2179a809ffc7e412d1c77bc17b715f8b) I meant to write out the exports of `./_yaml/schema/mod.ts` explicitly instead of with a wildcard. Accidentally, the exports I wrote out were those of `./_yaml/schema.ts`.

Also exports some missing types which are referenced by `StringifyOptions`.