### PR TITLE
WIP Fix flakyness by hiding error

### DIFF
--- a/test_plugin/src/lib.rs
+++ b/test_plugin/src/lib.rs
@@ -47,7 +47,7 @@ pub fn op_test_async(
     }
     let (tx, rx) = futures::channel::oneshot::channel::<Result<(), ()>>();
     std::thread::spawn(move || {
-      std::thread::sleep(std::time::Duration::from_secs(1));
+      std::thread::sleep(std::time::Duration::from_millis(10));
       tx.send(Ok(())).unwrap();
     });
     assert!(rx.await.is_ok());

--- a/test_plugin/tests/integration_tests.rs
+++ b/test_plugin/tests/integration_tests.rs
@@ -37,7 +37,10 @@ fn basic() {
   let stdout = std::str::from_utf8(&output.stdout).unwrap();
   let stderr = std::str::from_utf8(&output.stderr).unwrap();
   if !output.status.success() {
-    println!("Deno run command exited with unsuccessful status {}", output.status);
+    println!(
+      "Deno run command exited with unsuccessful status {}",
+      output.status
+    );
     println!("stdout {}", stdout);
     println!("stderr {}", stderr);
   }

--- a/test_plugin/tests/integration_tests.rs
+++ b/test_plugin/tests/integration_tests.rs
@@ -40,6 +40,7 @@ fn basic() {
   let stdout = std::str::from_utf8(&output.stdout).unwrap();
   let stderr = std::str::from_utf8(&output.stderr).unwrap();
   if !output.status.success() {
+    println!("Deno run command exited with unsuccessful status {}", output.status);
     println!("stdout {}", stdout);
     println!("stderr {}", stderr);
   }

--- a/test_plugin/tests/integration_tests.rs
+++ b/test_plugin/tests/integration_tests.rs
@@ -2,9 +2,6 @@
 //   cd test_plugin
 //   ../target/debug/deno run --allow-plugin --unstable tests/test.js debug
 
-// TODO(ry) Re-enable this test on windows. It is flaky for an unknown reason.
-#![cfg(not(windows))]
-
 use deno::test_util::*;
 use std::process::Command;
 

--- a/test_plugin/tests/integration_tests.rs
+++ b/test_plugin/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 // To run this test manually:
 //   cd test_plugin
-//   ../target/debug/deno --allow-plugin tests/test.js debug
+//   ../target/debug/deno run --allow-plugin --unstable tests/test.js debug
 
 // TODO(ry) Re-enable this test on windows. It is flaky for an unknown reason.
 #![cfg(not(windows))]

--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -11,9 +11,7 @@ if (Deno.build.os === "darwin") {
   filenameSuffix = ".dylib";
 }
 
-const filename = `../target/${
-  Deno.args[0]
-}/${filenamePrefix}${filenameBase}${filenameSuffix}`;
+const filename = `../target/${Deno.args[0]}/${filenamePrefix}${filenameBase}${filenameSuffix}`;
 
 // This will be checked against open resources after Plugin.close()
 // in runTestClose() below.
@@ -35,7 +33,7 @@ function runTestSync() {
   const response = Deno.core.dispatch(
     testSync,
     new Uint8Array([116, 101, 115, 116]),
-    new Uint8Array([116, 101, 115, 116]),
+    new Uint8Array([116, 101, 115, 116])
   );
 
   console.log(`Plugin Sync Response: ${textDecoder.decode(response)}`);
@@ -51,7 +49,7 @@ function runTestAsync() {
     const response = Deno.core.dispatch(
       testAsync,
       new Uint8Array([116, 101, 115, 116]),
-      new Uint8Array([116, 101, 115, 116]),
+      new Uint8Array([116, 101, 115, 116])
     );
 
     if (response != null || response != undefined) {
@@ -88,7 +86,7 @@ function runTestPluginClose() {
     throw new Error(
       `Difference in open resources before openPlugin and after Plugin.close():
 Before: ${preStr}
-After: ${postStr}`,
+After: ${postStr}`
     );
   }
 }

--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -94,3 +94,5 @@ await runTestAsync();
 
 runTestOpCount();
 runTestPluginClose();
+
+Deno.exit(0);

--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -11,7 +11,9 @@ if (Deno.build.os === "darwin") {
   filenameSuffix = ".dylib";
 }
 
-const filename = `../target/${Deno.args[0]}/${filenamePrefix}${filenameBase}${filenameSuffix}`;
+const filename = `../target/${
+  Deno.args[0]
+}/${filenamePrefix}${filenameBase}${filenameSuffix}`;
 
 // This will be checked against open resources after Plugin.close()
 // in runTestClose() below.
@@ -33,7 +35,7 @@ function runTestSync() {
   const response = Deno.core.dispatch(
     testSync,
     new Uint8Array([116, 101, 115, 116]),
-    new Uint8Array([116, 101, 115, 116])
+    new Uint8Array([116, 101, 115, 116]),
   );
 
   console.log(`Plugin Sync Response: ${textDecoder.decode(response)}`);
@@ -49,11 +51,11 @@ function runTestAsync() {
     const response = Deno.core.dispatch(
       testAsync,
       new Uint8Array([116, 101, 115, 116]),
-      new Uint8Array([116, 101, 115, 116])
+      new Uint8Array([116, 101, 115, 116]),
     );
 
     if (response != null || response != undefined) {
-      rej( new Error("Expected null response!"));
+      rej(new Error("Expected null response!"));
     }
   });
 }
@@ -83,9 +85,11 @@ function runTestPluginClose() {
   const preStr = JSON.stringify(resourcesPre, null, 2);
   const postStr = JSON.stringify(resourcesPost, null, 2);
   if (preStr !== postStr) {
-    throw new Error(`Difference in open resources before openPlugin and after Plugin.close(): 
+    throw new Error(
+      `Difference in open resources before openPlugin and after Plugin.close():
 Before: ${preStr}
-After: ${postStr}`);
+After: ${postStr}`,
+    );
   }
 }
 

--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -39,20 +39,23 @@ function runTestSync() {
   console.log(`Plugin Sync Response: ${textDecoder.decode(response)}`);
 }
 
-Deno.core.setAsyncHandler(testAsync, (response) => {
-  console.log(`Plugin Async Response: ${textDecoder.decode(response)}`);
-});
-
 function runTestAsync() {
-  const response = Deno.core.dispatch(
-    testAsync,
-    new Uint8Array([116, 101, 115, 116]),
-    new Uint8Array([116, 101, 115, 116])
-  );
+  return new Promise((res, rej) => {
+    Deno.core.setAsyncHandler(testAsync, (response) => {
+      console.log(`Plugin Async Response: ${textDecoder.decode(response)}`);
+      res();
+    });
 
-  if (response != null || response != undefined) {
-    throw new Error("Expected null response!");
-  }
+    const response = Deno.core.dispatch(
+      testAsync,
+      new Uint8Array([116, 101, 115, 116]),
+      new Uint8Array([116, 101, 115, 116])
+    );
+
+    if (response != null || response != undefined) {
+      rej( new Error("Expected null response!"));
+    }
+  });
 }
 
 function runTestOpCount() {
@@ -87,7 +90,7 @@ After: ${postStr}`);
 }
 
 runTestSync();
-runTestAsync();
+await runTestAsync();
 
 runTestOpCount();
 runTestPluginClose();


### PR DESCRIPTION
Related to issue #3473 .

On my PC it fails consistently. The run command always exits with code `-1073741819`. There are 2 causes for problems:
1. Deno exits before the async values are returned to js (i.e. response is not awaited). 
2. Deno exits js with a non-zero code implicitly, while no errors are thrown in js.

This PR is mainly meant as an indication where the flakyness comes from.