### PR TITLE
Update to dprint 0.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,18 +618,18 @@ checksum = "52ba6eb47c2131e784a38b726eb54c1e1484904f013e576a25354d0124161af6"
 
 [[package]]
 name = "dprint-core"
-version = "0.17.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51503534b100175b33c3a7ed71839c8027ae16be1092ad93c7bb7cb2f8a06bcb"
+checksum = "8b62634626adceb7abdab6e4dd5fc8cedcb177b2cb80a6491519092370afa037"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.16.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afad8c8794d11dca59f4257f2901252e3e566704ac9810dad0eee694f1dc2ce7"
+checksum = "9e945fe5978d1cb0edddf522dc360c8a5d691ecd2fe98a9de74efb3997ed0ec6"
 dependencies = [
  "dprint-core",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.16.0"
+dprint-plugin-typescript = "0.17.2"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.1"


### PR DESCRIPTION
I'll try to give these style updates in my PRs from now on.

**Improvement: Binary Expression Operator Precedence**

For example, given the following:

```ts
test && testttttttttttttttttttttttt || aaaaaaaaaaaaaaa && testttttttttttttttttttt;
```

It now formats like so:

```ts
test && testttttttttttttttttttttttt ||
    aaaaaaaaaaaaaaa && testttttttttttttttttttt;
```

Previously, `&&` and `||` had the same precedence along with basically everything else.

Prettier formats like so and I've opened https://github.com/dprint/dprint/issues/200 for adding parens like this:

```ts
(test && testttttttttttttttttttttttt) ||
  (aaaaaaaaaaaaaaa && testttttttttttttttttttt);
```

Note, I deviated from prettier and gave division and multiplication the same precedence. It made sense to me that they should be equal precedence because they're essentially the same thing.

**Other Improvements**

* JSX elements, JSX attributes, and decorators now use the same "multi-line" behaviour as elsewhere.
* JSX text now wraps.

**Performance**

Overall, the performance has degraded by about 25% lately. I am planning on working on some dprint specific debugging tools to make it very fast, but right now I'm more focused on making sure it works well.

**Future**

* I'm still working on the `preferSingleLine` config, which is currently `false`. The config is all wired up, but I've noticed how it formats when that's `true` still needs lots of work for certain edge cases.
* I opened a preliminary work in progress PR in swc for parsing parameter decorators. Hopefully that can move forward fast.