### PR TITLE
feat(std/fmt): rgb24 and bgRgb24 can use numbers for color

### DIFF
--- a/std/fmt/colors.ts
+++ b/std/fmt/colors.ts
@@ -172,8 +172,22 @@ export function bgRgb8(str: string, color: number): string {
   return run(str, code([48, 5, clampAndTruncate(color)], 49));
 }
 
-/** Set text color using 24bit rgb. */
-export function rgb24(str: string, color: Rgb): string {
+/** Set text color using 24bit rgb.
+ * `color` can be a number in range `0x000000` to `0xffffff` or
+ * an `Rgb`.
+ *
+ * To produce the color magenta:
+ *
+ *      rgba24("foo", 0xff00ff);
+ *      rgba24("foo", {r: 255, g: 0, b: 255});
+ */
+export function rgb24(str: string, color: number | Rgb): string {
+  if (typeof color === "number") {
+    return run(
+      str,
+      code([38, 2, (color >> 16) & 0xff, (color >> 8) & 0xff, color & 0xff], 39)
+    );
+  }
   return run(
     str,
     code(
@@ -189,8 +203,22 @@ export function rgb24(str: string, color: Rgb): string {
   );
 }
 
-/** Set background color using 24bit rgb. */
-export function bgRgb24(str: string, color: Rgb): string {
+/** Set background color using 24bit rgb.
+ * `color` can be a number in range `0x000000` to `0xffffff` or
+ * an `Rgb`.
+ *
+ * To produce the color magenta:
+ *
+ *      bgRgba24("foo", 0xff00ff);
+ *      bgRgba24("foo", {r: 255, g: 0, b: 255});
+ */
+export function bgRgb24(str: string, color: number | Rgb): string {
+  if (typeof color === "number") {
+    return run(
+      str,
+      code([48, 2, (color >> 16) & 0xff, (color >> 8) & 0xff, color & 0xff], 49)
+    );
+  }
   return run(
     str,
     code(

--- a/std/fmt/colors_test.ts
+++ b/std/fmt/colors_test.ts
@@ -146,6 +146,10 @@ Deno.test("test_rgb24", function (): void {
   );
 });
 
+Deno.test("test_rgb24number", function (): void {
+  assertEquals(c.rgb24("foo bar", 0x070809), "[38;2;7;8;9mfoo bar[39m");
+});
+
 Deno.test("test_bgRgb24", function (): void {
   assertEquals(
     c.bgRgb24("foo bar", {
@@ -155,4 +159,8 @@ Deno.test("test_bgRgb24", function (): void {
     }),
     "[48;2;41;42;43mfoo bar[49m"
   );
+});
+
+Deno.test("test_bgRgb24number", function (): void {
+  assertEquals(c.bgRgb24("foo bar", 0x070809), "[48;2;7;8;9mfoo bar[49m");
 });


### PR DESCRIPTION
closes #5196 

use case `rgb24("foo", 0xff00ff)` to produce a magenta "foo"