### PR TITLE
fix(std): fix broken style guide link (#5204)

### DIFF
--- a/std/README.md
+++ b/std/README.md
@@ -42,4 +42,5 @@ building Go. We generally welcome direct ports of Go's code.
 
 Please ensure the copyright headers cite the code's origin.
 
-Follow the [style guide](https://github.com/denoland/deno/blob/master/docs/contributing/style_guide.md).
+Follow the
+[style guide](https://github.com/denoland/deno/blob/master/docs/contributing/style_guide.md).

--- a/std/README.md
+++ b/std/README.md
@@ -42,4 +42,4 @@ building Go. We generally welcome direct ports of Go's code.
 
 Please ensure the copyright headers cite the code's origin.
 
-Follow the [style guide](https://deno.land/style_guide.html).
+Follow the [style guide](https://github.com/denoland/deno/blob/master/docs/contributing/style_guide.md).


### PR DESCRIPTION
Closes #5204 

missed link in `/std` for style guides
