### PR TITLE
Add ignore fn to deno test

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -47,55 +47,64 @@ declare namespace Deno {
     sanitizeResources?: boolean;
   }
 
-  /** Register a test which will be run when `deno test` is used on the command
-   * line and the containing module looks like a test module.
-   * `fn` can be async if required.
-   *
-   *          import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
-   *
-   *          Deno.test({
-   *            name: "example test",
-   *            fn(): void {
-   *              assertEquals("world", "world");
-   *            },
-   *          });
-   *
-   *          Deno.test({
-   *            name: "example ignored test",
-   *            ignore: Deno.build.os === "windows"
-   *            fn(): void {
-   *              // This test is ignored only on Windows machines
-   *            },
-   *          });
-   *
-   *          Deno.test({
-   *            name: "example async test",
-   *            async fn() {
-   *              const decoder = new TextDecoder("utf-8");
-   *              const data = await Deno.readFile("hello_world.txt");
-   *              assertEquals(decoder.decode(data), "Hello world")
-   *            }
-   *          });
-   */
-  export function test(t: TestDefinition): void;
+  interface TestFn {
+    /** Register a test which will be run when `deno test` is used on the command
+     * line and the containing module looks like a test module.
+     * `fn` can be async if required.
+     *
+     *          import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
+     *
+     *          Deno.test({
+     *            name: "example test",
+     *            fn(): void {
+     *              assertEquals("world", "world");
+     *            },
+     *          });
+     *
+     *          Deno.test({
+     *            name: "example ignored test",
+     *            ignore: Deno.build.os === "windows"
+     *            fn(): void {
+     *              // This test is ignored only on Windows machines
+     *            },
+     *          });
+     *
+     *          Deno.test({
+     *            name: "example async test",
+     *            async fn() {
+     *              const decoder = new TextDecoder("utf-8");
+     *              const data = await Deno.readFile("hello_world.txt");
+     *              assertEquals(decoder.decode(data), "Hello world")
+     *            }
+     *          });
+     */
+    (t: TestDefinition): void;
 
-  /** Register a test which will be run when `deno test` is used on the command
-   * line and the containing module looks like a test module.
-   * `fn` can be async if required.
-   *
-   *        import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
-   *
-   *        Deno.test("My test description", ():void => {
-   *          assertEquals("hello", "hello");
-   *        });
-   *
-   *        Deno.test("My async test description", async ():Promise<void> => {
-   *          const decoder = new TextDecoder("utf-8");
-   *          const data = await Deno.readFile("hello_world.txt");
-   *          assertEquals(decoder.decode(data), "Hello world")
-   *        });
-   * */
-  export function test(name: string, fn: () => void | Promise<void>): void;
+    /** Register a test which will be run when `deno test` is used on the command
+     * line and the containing module looks like a test module.
+     * `fn` can be async if required.
+     *
+     *        import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
+     *
+     *        Deno.test("My test description", ():void => {
+     *          assertEquals("hello", "hello");
+     *        });
+     *
+     *        Deno.test("My async test description", async ():Promise<void> => {
+     *          const decoder = new TextDecoder("utf-8");
+     *          const data = await Deno.readFile("hello_world.txt");
+     *          assertEquals(decoder.decode(data), "Hello world")
+     *        });
+     * */
+    (name: string, fn: () => void | Promise<void>): void;
+  }
+
+  export interface Ignore {
+    ignore: TestFn;
+  }
+
+  export type Test = TestFn & Ignore;
+  export const test: Test;
 
   /** Exit the Deno process with optional exit code. If no exit code is supplied
    * then Deno will exit with return code of 0.

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -109,9 +109,7 @@ const ignoreDefaults = {
   ignore: true,
 };
 
-function configureTestFn(
-  defaults: Partial<TestDefinition>
-): TestFn{
+function configureTestFn(defaults: Partial<TestDefinition>): TestFn {
   function buildTestDefinition(t: TestDefinition): void;
   function buildTestDefinition(
     name: string,

--- a/cli/js/tests/testing_test.ts
+++ b/cli/js/tests/testing_test.ts
@@ -6,6 +6,10 @@ unitTest(function testFnOverloading(): void {
   Deno.test("test fn overloading", (): void => {});
 });
 
+unitTest(function testIgnore(): void {
+  Deno.test.ignore("test .ignore()", (): void => {});
+});
+
 unitTest(function nameOfTestCaseCantBeEmpty(): void {
   assertThrows(
     () => {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -90,12 +90,13 @@ Deno.test({
 });
 ```
 
-Alternatively if you wish to ignore a test temporarily you can call `Deno.test.ignore` instead of `Deno.test`.
+Alternatively if you wish to ignore a test temporarily you can call
+`Deno.test.ignore` instead of `Deno.test`.
 
 ```ts
-Deno.test.ignore('testing unimplemented feature', () => {
+Deno.test.ignore("testing unimplemented feature", () => {
   unimplementedFeature();
-})
+});
 ```
 
 ## Running tests

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -90,6 +90,14 @@ Deno.test({
 });
 ```
 
+Alternatively if you wish to ignore a test temporarily you can call `Deno.test.ignore` instead of `Deno.test`.
+
+```ts
+Deno.test.ignore('testing unimplemented feature', () => {
+  unimplementedFeature();
+})
+```
+
 ## Running tests
 
 To run the test, call `deno test` with the file that contains your test


### PR DESCRIPTION
Addresses `Deno.test.ignore` feature request of #5197 

**Known issues**
Currently the inline docs for .ignore are the same as .test. This means the examples use `Deno.test` instead of `Deno.test.ignore`. Not sure what the preferred solution to this would be.

I did not see a test for the existing ignore feature. So other than a test calling `Deno.test.ignore` there is no test ensuring the ignore flag is properly set on the test definition when calling `Deno.test.ignore`
