### PR TITLE
Fix broken links to manual web page in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ A secure runtime for JavaScript and TypeScript.
 Deno aims to provide a productive and secure scripting environment for the
 modern programmer. It is built on top of V8, Rust, and TypeScript.
 
-Please read the [introduction](https://deno.land/manual.html#introduction) for
+Please read the [introduction](https://deno.land/manual#introduction) for
 more specifics.
 
 [Website](https://deno.land/)
 
-[Manual](https://deno.land/manual.html)
+[Manual](https://deno.land/manual)
 
 [Install](https://github.com/denoland/deno_install)
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A secure runtime for JavaScript and TypeScript.
 Deno aims to provide a productive and secure scripting environment for the
 modern programmer. It is built on top of V8, Rust, and TypeScript.
 
-Please read the [introduction](https://deno.land/manual#introduction) for
-more specifics.
+Please read the [introduction](https://deno.land/manual#introduction) for more
+specifics.
 
 [Website](https://deno.land/)
 


### PR DESCRIPTION
The current links to the manual web page in the README.md file include the `.html` extension but this leads to a 404. 

Removing the `.html` fixes this error and leads to the right webpage.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
