### PR TITLE
Minor: fix Manual link URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ more specifics.
 
 [Website](https://deno.land/)
 
-[Manual](https://deno.land/manual.html)
+[Manual](https://deno.land/manual)
 
 [Install](https://github.com/denoland/deno_install)
 


### PR DESCRIPTION
Hi! 

This is just a super small fix to the 404 error when you click on Manual in the readme. 

Cheers