### PR TITLE
docs: using official vscode extension

### DIFF
--- a/docs/getting_started/setup_your_environment.md
+++ b/docs/getting_started/setup_your_environment.md
@@ -43,10 +43,12 @@ http imports, and the most editors and language servers do not natively support
 this at the moment, many editors will throw errors about being unable to find
 files or imports having unnecessary file extensions.
 
-The community has developed extensions for some editors to solve these issues:
+We have developed extensions for some editors to solve these issues:
 
-- [VS Code](https://marketplace.visualstudio.com/items?itemName=axetroy.vscode-deno)
-  by [@axetroy](https://github.com/axetroy).
+- [vscode_deno](https://github.com/denoland/vscode_deno/), the beta version is
+  published on the
+  [vscode marketplace](https://marketplace.visualstudio.com/items?itemName=justjavac.vscode-deno)
+  by [@justjavac](https://github.com/justjavac), please report any issues.
 
 Support for JetBrains IDEs is not yet available, but you can follow and upvote
 these issues to stay up to date:


### PR DESCRIPTION
Both my and axetroy's original repositories have been marked as deprecated, and now only the official vscode_deno is maintained.

Since ry has not registered an official vscode account, the latest code of the current repository has been posted to justjavac.vscode-deno, because users generally choose to install the most downloaded.