### PR TITLE
fix typos across repo

### DIFF
--- a/cli/js/tests/README.md
+++ b/cli/js/tests/README.md
@@ -41,7 +41,7 @@ ways:
 
 `unit_test_runner.ts` is the main script used to run unit tests.
 
-Runner discoveres required permissions combinations by loading
+Runner discovers required permissions combinations by loading
 `cli/js/tests/unit_tests.ts` and going through all registered instances of
 `unitTest`.
 

--- a/cli/js/tests/chown_test.ts
+++ b/cli/js/tests/chown_test.ts
@@ -108,7 +108,7 @@ if (Deno.build.os !== "windows") {
     async function chownSyncSucceed(): Promise<void> {
       // TODO: when a file's owner is actually being changed,
       // chown only succeeds if run under priviledged user (root)
-      // The test script has no such priviledge, so need to find a better way to test this case
+      // The test script has no such privilege, so need to find a better way to test this case
       const { uid, gid } = await getUidAndGid();
 
       const enc = new TextEncoder();

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -228,7 +228,7 @@ impl DerefMut for Worker {
 ///
 /// It provides ops available in the `Deno` namespace.
 ///
-/// All WebWorkers created during program execution are decendants of
+/// All WebWorkers created during program execution are descendants of
 /// this worker.
 pub struct MainWorker(Worker);
 

--- a/core/es_isolate.rs
+++ b/core/es_isolate.rs
@@ -489,7 +489,7 @@ impl EsIsolate {
     // 2. Source code resolved result have a different name as requested:
     //   2a. The module with resolved module name has been registered
     //     -> alias
-    //   2b. The module with resolved module name has not yet been registerd
+    //   2b. The module with resolved module name has not yet been registered
     //     -> register & alias
 
     // If necessary, register an alias.

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -100,7 +100,7 @@ impl AsMut<[u8]> for ZeroCopyBuf {
   }
 }
 
-/// Stores a script used to initalize a Isolate
+/// Stores a script used to initialize a Isolate
 pub struct Script<'a> {
   pub source: &'a str,
   pub filename: &'a str,

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -133,7 +133,7 @@ impl TSIsolate {
 ///
 /// This function writes compiled bundle to disk at provided path.
 ///
-/// Source map file and type declaration file are emmited
+/// Source map file and type declaration file are emitted
 /// alongside the bundle.
 ///
 /// To instantiate bundle use returned `module_name`.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -26,7 +26,7 @@ file.
 
 All APIs that are not web standard are contained in the global `Deno` namespace.
 It has the APIs for reading from files, opening TCP sockets, and executing
-subprocesses, ect.
+subprocesses, etc.
 
 The TypeScript definitions for the Deno namespaces can be found in the
 [`lib.deno.ns.d.ts`](https://github.com/denoland/deno/blob/master/cli/js/lib.deno.ns.d.ts)

--- a/docs/tools/debugger.md
+++ b/docs/tools/debugger.md
@@ -119,7 +119,7 @@ Change `<entry_point>` to `server.ts` and run created configuration:
 
 ### Other
 
-Any client that implementes Devtools protocol should be able to connect to Deno
+Any client that implements Devtools protocol should be able to connect to Deno
 process.
 
 ### Limitations

--- a/std/encoding/_yaml/dumper/dumper_state.ts
+++ b/std/encoding/_yaml/dumper/dumper_state.ts
@@ -54,7 +54,7 @@ export interface DumperStateOptions {
   skipInvalid?: boolean;
   /**
    * specifies level of nesting, when to switch from
-   * block to flow style for collections. -1 means block style everwhere
+   * block to flow style for collections. -1 means block style everywhere
    */
   flowLevel?: number;
   /** Each tag may have own set of styles.	- "tag" => "style" map. */

--- a/std/encoding/csv.ts
+++ b/std/encoding/csv.ts
@@ -34,7 +34,7 @@ export class ParseError extends Error {
  * @property lazyQuotes - Allow unquoted quote in a quoted field or non double
  *           quoted quotes in quoted field Default: 'false'
  * @property fieldsPerRecord - Enabling the check of fields for each row.
- *           If == 0, first row is used as referal for the number of fields.
+ *           If == 0, first row is used as referral for the number of fields.
  */
 export interface ReadOptions {
   comma?: string;

--- a/std/fmt/README.md
+++ b/std/fmt/README.md
@@ -18,7 +18,7 @@ This is very much a work-in-progress. I'm actively soliciting feedback.
 - behaviour of `%v` verb. In Golang, this is a shortcut verb to "print the
   default format" of the argument. It is currently implemented to format using
   `toString` in the default case and `inpect` if the `%#v` alternative format
-  flag is used in the format directive. Alternativly, `%V` could be used to
+  flag is used in the format directive. Alternatively, `%V` could be used to
   distinguish the two.
 
   `inspect` output is not defined, however. This may be problematic if using
@@ -32,7 +32,7 @@ This is very much a work-in-progress. I'm actively soliciting feedback.
   Consider possible modifier flags, etc.
 
 - `<` verb. This is an extension that assumes the argument is an array and will
-  format each element according to the format (surrounded by [] and seperated by
+  format each element according to the format (surrounded by [] and separated by
   comma) (`<` Mnemonic: pull each element out of array)
 
 - how to deal with more newfangled Javascript features ( generic Iterables, Map
@@ -176,7 +176,7 @@ the 'depth' config parameter
 
 ## Positional arguments
 
-Arguments do not need to be consumed in the order they are provded and may be
+Arguments do not need to be consumed in the order they are provided and may be
 consumed more than once. E.g.:
 
     sprintf("%[2]s %[1]s", "World", "Hello")

--- a/std/fmt/sprintf.ts
+++ b/std/fmt/sprintf.ts
@@ -206,7 +206,7 @@ class Printf {
             default:
               const val = parseInt(c);
               // most likely parseInt does something stupid that makes
-              // it unusuable for this scenario ...
+              // it unusable for this scenario ...
               // if we encounter a non (number|*|.) we're done with prec & wid
               if (isNaN(val)) {
                 this.i--;

--- a/std/mime/multipart.ts
+++ b/std/mime/multipart.ts
@@ -578,7 +578,7 @@ export class MultipartWriter {
     return this.bufWriter.flush();
   }
 
-  /** Close writer. No additional data can be writen to stream */
+  /** Close writer. No additional data can be written to stream */
   async close(): Promise<void> {
     if (this.isClosed) {
       throw new Error("multipart: writer is closed");

--- a/std/node/events_test.ts
+++ b/std/node/events_test.ts
@@ -444,7 +444,7 @@ test({
 });
 
 test({
-  name: "asyncronous iteration of events are handled as expected",
+  name: "asynchronous iteration of events are handled as expected",
   async fn() {
     const ee = new EventEmitter();
     setTimeout(() => {
@@ -472,7 +472,7 @@ test({
 });
 
 test({
-  name: "asyncronous error handling of emitted events works as expected",
+  name: "asynchronous error handling of emitted events works as expected",
   async fn() {
     const ee = new EventEmitter();
     const _err = new Error("kaboom");
@@ -497,7 +497,7 @@ test({
 });
 
 test({
-  name: "error thrown during asyncronous processing of events is handled",
+  name: "error thrown during asynchronous processing of events is handled",
   async fn() {
     const ee = new EventEmitter();
     const _err = new Error("kaboom");
@@ -527,7 +527,7 @@ test({
 
 test({
   name:
-    "error thrown in processing loop of asyncronous event prevents processing of additional events",
+    "error thrown in processing loop of asynchronous event prevents processing of additional events",
   async fn() {
     const ee = new EventEmitter();
     const _err = new Error("kaboom");
@@ -552,7 +552,7 @@ test({
 });
 
 test({
-  name: "asyncronous iterator next() works as expected",
+  name: "asynchronous iterator next() works as expected",
   async fn() {
     const ee = new EventEmitter();
     const iterable = on(ee, "foo");

--- a/std/node/module.ts
+++ b/std/node/module.ts
@@ -1000,7 +1000,7 @@ function emitCircularRequireWarning(prop: any): void {
 }
 
 // A Proxy that can be used as the prototype of a module.exports object and
-// warns when non-existend properties are accessed.
+// warns when non-existent properties are accessed.
 const CircularRequirePrototypeWarningProxy = new Proxy(
   {},
   {

--- a/std/path/_globrex.ts
+++ b/std/path/_globrex.ts
@@ -16,7 +16,7 @@ export interface GlobrexOptions {
    * @default false */
   extended?: boolean;
   /** Support globstar.
-   * @remarks When globstar is `true`, '/foo/**' is equivelant
+   * @remarks When globstar is `true`, '/foo/**' is equivalent
    * to '/foo/*' when globstar is `false`.
    * Having globstar set to `true` is the same usage as
    * using wildcards in bash.

--- a/tools/deno_tcp_proxy.ts
+++ b/tools/deno_tcp_proxy.ts
@@ -1,4 +1,4 @@
-// Used for benchmarking Deno's tcp proxy perfromance. See tools/http_benchmark.py
+// Used for benchmarking Deno's tcp proxy performance. See tools/http_benchmark.py
 const addr = Deno.args[0] || "127.0.0.1:4500";
 const originAddr = Deno.args[1] || "127.0.0.1:4501";
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
Files that have typos:
```
cli/js/tests/README.md:44:7: corrected "discoveres" to "discovers"
cli/js/tests/chown_test.ts:111:37: corrected "priviledge" to "privilege"
cli/worker.rs:231:56: corrected "decendants" to "descendants"
deno_typescript/lib.rs:136:50: corrected "emmited" to "emitted"
core/es_isolate.rs:492:67: corrected "registerd" to "registered"
core/isolate.rs:103:28: corrected "initalize" to "initialize"
docs/runtime.md:29:14: corrected "ect" to "etc"
docs/tools/debugger.md:122:16: corrected "implementes" to "implements"
std/encoding/_yaml/dumper/dumper_state.ts:57:63: corrected "everwhere" to "everywhere"
std/encoding/csv.ts:37:43: corrected "referal" to "referral"
std/fmt/sprintf.ts:209:20: corrected "unusuable" to "unusable"
std/fmt/README.md:21:40: corrected "Alternativly" to "Alternatively"
std/fmt/README.md:35:68: corrected "seperated" to "separated"
std/fmt/README.md:179:59: corrected "provded" to "provided"
std/mime/multipart.ts:581:46: corrected "writen" to "written"
std/path/_globrex.ts:19:52: corrected "equivelant" to "equivalent"
std/node/events_test.ts:447:9: corrected "asyncronous" to "asynchronous"
std/node/events_test.ts:475:9: corrected "asyncronous" to "asynchronous"
std/node/events_test.ts:500:29: corrected "asyncronous" to "asynchronous"
std/node/events_test.ts:530:40: corrected "asyncronous" to "asynchronous"
std/node/events_test.ts:555:9: corrected "asyncronous" to "asynchronous"
tools/deno_tcp_proxy.ts:1:42: corrected "perfromance" to "performance"
std/node/module.ts:1003:18: corrected "existend" to "existed"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos