### PR TITLE
std/node fs.readFile should allow string as option

### DIFF
--- a/std/node/_fs/_fs_readFile.ts
+++ b/std/node/_fs/_fs_readFile.ts
@@ -24,7 +24,7 @@ function maybeDecode(
 
 export function readFile(
   path: string | URL,
-  optOrCallback: ReadFileCallback | FileOptions,
+  optOrCallback: ReadFileCallback | FileOptions | string,
   callback?: ReadFileCallback
 ): void {
   path = path instanceof URL ? fromFileUrl(path) : path;
@@ -47,7 +47,7 @@ export function readFile(
 
 export function readFileSync(
   path: string | URL,
-  opt?: FileOptions
+  opt?: FileOptions | string
 ): string | Uint8Array {
   path = path instanceof URL ? fromFileUrl(path) : path;
   return maybeDecode(denoReadFileSync(path), getEncoding(opt));

--- a/std/node/_fs/_fs_readFile_test.ts
+++ b/std/node/_fs/_fs_readFile_test.ts
@@ -35,6 +35,20 @@ test("readFileEncodeUtf8Success", async function () {
   assertEquals(data as string, "hello world");
 });
 
+test("readFileEncodingAsString", async function () {
+  const data = await new Promise((res, rej) => {
+    readFile(testData, "utf8", (err, data) => {
+      if (err) {
+        rej(err);
+      }
+      res(data);
+    });
+  });
+
+  assertEquals(typeof data, "string");
+  assertEquals(data as string, "hello world");
+});
+
 test("readFileSyncSuccess", function () {
   const data = readFileSync(testData);
   assert(data instanceof Uint8Array);
@@ -43,6 +57,12 @@ test("readFileSyncSuccess", function () {
 
 test("readFileEncodeUtf8Success", function () {
   const data = readFileSync(testData, { encoding: "utf8" });
+  assertEquals(typeof data, "string");
+  assertEquals(data as string, "hello world");
+});
+
+test("readFileEncodeAsString", function () {
+  const data = readFileSync(testData, "utf8");
   assertEquals(typeof data, "string");
   assertEquals(data as string, "hello world");
 });


### PR DESCRIPTION
[`fs.readFile`](https://nodejs.org/api/fs.html#fs_fs_readfile_path_options_callback) & `fs.readFileSync` should allow a `string` as options.

```
fs.readFile('./file.txt', 'utf8', console.log);
```