### PR TITLE
cli: don't panic on Deno.close invalid argument

### DIFF
--- a/cli/js/tests/resources_test.ts
+++ b/cli/js/tests/resources_test.ts
@@ -1,6 +1,16 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { unitTest, assertEquals, assert } from "./test_util.ts";
 
+unitTest(function resourcesCloseBadArgs(): void {
+  let err;
+  try {
+    Deno.close((null as unknown) as number);
+  } catch (e) {
+    err = e;
+  }
+  assert(err instanceof Deno.errors.InvalidData);
+});
+
 unitTest(function resourcesStdio(): void {
   const res = Deno.resources();
 

--- a/cli/ops/resources.rs
+++ b/cli/ops/resources.rs
@@ -31,7 +31,7 @@ fn op_close(
   struct CloseArgs {
     rid: i32,
   }
-  let args: CloseArgs = serde_json::from_value(args).unwrap();
+  let args: CloseArgs = serde_json::from_value(args)?;
   let mut resource_table = isolate.resource_table.borrow_mut();
   resource_table
     .close(args.rid as u32)


### PR DESCRIPTION
Closes #5313 

Simple 1 line fix to avoid Rust panic on invalid argument (don't unwrap).