### PR TITLE
refactor(fs): use every instead of reduce

### DIFF
--- a/std/fs/_util.ts
+++ b/std/fs/_util.ts
@@ -16,11 +16,7 @@ export function isSubdir(
   }
   const srcArray = src.split(sep);
   const destArray = dest.split(sep);
-  // see: https://github.com/Microsoft/TypeScript/issues/30821
-  // @ts-ignore
-  return srcArray.reduce((acc: true, current: string, i: number): boolean => {
-    return acc && destArray[i] === current;
-  }, true);
+  return srcArray.every((current, i) => destArray[i] === current);
 }
 
 export type PathType = "file" | "dir" | "symlink";


### PR DESCRIPTION
The previous usage of `reduce` was basically implementing the [`every` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every). A small difference is that the new implementation will stop checking as soon as one element have returned false, which will reduce the number of unnecessary checks.