### PR TITLE
[Docs] Avoid unfortunate ASCII arrow splitting

### DIFF
--- a/docs/getting_started/first_steps.md
+++ b/docs/getting_started/first_steps.md
@@ -96,8 +96,8 @@ for (let i = 0; i < Deno.args.length; i++) {
 }
 ```
 
-The `copy()` function here actually makes no more than the necessary kernel ->
-userspace -> kernel copies. That is, the same memory from which data is read
+The `copy()` function here actually makes no more than the necessary
+kernel→userspace→kernel copies. That is, the same memory from which data is read
 from the file, is written to stdout. This illustrates a general design goal for
 I/O streams in Deno.
 


### PR DESCRIPTION
`s/->/→/`

<img width="743" alt="Screen Shot 2020-05-14 at 11 04 17" src="https://user-images.githubusercontent.com/145676/81915513-f8ea5900-95d2-11ea-8086-526654cfc32a.png">
