### PR TITLE
Fix for #5329: Misleading code in Manual - Program Lifecycle section

### DIFF
--- a/docs/runtime/program_lifecycle.md
+++ b/docs/runtime/program_lifecycle.md
@@ -28,6 +28,8 @@ window.onunload = (e: Event): void => {
   console.log(`got ${e.type} event in onunload function (main)`);
 };
 
+console.log("log from main script");
+
 // imported.ts
 const handler = (e: Event): void => {
   console.log(`got ${e.type} event in event handler (imported)`);


### PR DESCRIPTION
This PR is fix for https://github.com/denoland/deno/issues/5329

I have added missing `console.log("log from main script")` to code example. Now output in console matches code provided by example
