### PR TITLE
Link to the golang textproto page is 404

### DIFF
--- a/std/textproto/mod.ts
+++ b/std/textproto/mod.ts
@@ -1,4 +1,4 @@
-// Based on https://github.com/golang/go/blob/891682/src/net/textproto/
+// Based on https://github.com/golang/go/tree/master/src/net/textproto
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
Replaced with the current master version

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
