### PR TITLE
fix(std/log): await default logger setup

### DIFF
--- a/std/log/mod.ts
+++ b/std/log/mod.ts
@@ -127,4 +127,4 @@ export async function setup(config: LogConfig): Promise<void> {
   }
 }
 
-setup(DEFAULT_CONFIG);
+await setup(DEFAULT_CONFIG);

--- a/std/log/mod_test.ts
+++ b/std/log/mod_test.ts
@@ -1,0 +1,16 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+const { test } = Deno;
+import { Logger } from "./logger.ts";
+import { assert } from "../testing/asserts.ts";
+import { getLogger } from "./mod.ts";
+
+let logger: Logger | null = null;
+try {
+  // Need to initialize it here
+  // otherwise it will be already initialized on Deno.test
+  logger = getLogger();
+} catch {}
+
+test("logger is initialized", function (): void {
+  assert(logger instanceof Logger);
+});


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
Take the following snippet taken from [SO Question](https://stackoverflow.com/questions/61796886/unable-to-see-in-the-console-in-deno-logger/61797202#61797202)

```typescript
import * as log from "https://deno.land/std/log/mod.ts";

export class Test1 {
    public show() {
        log.debug("Hello world");
        log.info("Hello world");
        log.warning("Hello world");
        log.error("Hello world");
        log.critical("500 Internal server error");
        console.log("Hello ....")
    }
}

const test = new Test1();
test.show();
```

You get the following output:

```
Hello ....
```

That happens because `log.setup` is an async function and we're not waiting for it to resolve.

With the fix we're now getting the right output:

```
INFO Hello world
WARNING Hello world
ERROR Hello world
CRITICAL 500 Internal server error
Hello ....
```
