### PR TITLE
Remove debug prints introduced in e18aaf49c

### DIFF
--- a/cli/doc/module.rs
+++ b/cli/doc/module.rs
@@ -16,7 +16,6 @@ pub fn get_doc_node_for_export_decl(
   let js_doc = doc_parser.js_doc_for_span(export_span);
   let location = doc_parser.ast_parser.get_span_location(export_span).into();
 
-  eprintln!("decl {:#?}", export_decl);
   match &export_decl.decl {
     Decl::Class(class_decl) => {
       let (name, class_def) =

--- a/cli/doc/parser.rs
+++ b/cli/doc/parser.rs
@@ -265,10 +265,7 @@ impl DocParser {
 
         vec![doc_node]
       }
-      ModuleDecl::ExportDefaultExpr(export_default_expr) => {
-        eprintln!("export default expr {:#?}", export_default_expr);
-        vec![]
-      }
+      ModuleDecl::ExportDefaultExpr(_export_default_expr) => vec![],
       _ => vec![],
     }
   }
@@ -455,7 +452,6 @@ impl DocParser {
       if let swc_ecma_ast::ModuleItem::ModuleDecl(module_decl) = node {
         let r = match module_decl {
           ModuleDecl::ExportNamed(named_export) => {
-            eprintln!("export named {:#?}", named_export);
             if let Some(src) = &named_export.src {
               let src_str = src.value.to_string();
               named_export

--- a/cli/doc/tests.rs
+++ b/cli/doc/tests.rs
@@ -32,7 +32,6 @@ impl DocFileLoader for TestLoader {
     &self,
     specifier: &str,
   ) -> Pin<Box<dyn Future<Output = Result<String, OpError>>>> {
-    eprintln!("specifier {:#?}", specifier);
     let res = match self.files.get(specifier) {
       Some(source_code) => Ok(source_code.to_string()),
       None => Err(OpError::other("not found".to_string())),


### PR DESCRIPTION
Currently `deno doc` outputs debug information to stderr.