### PR TITLE
Add .css to the MEDIA_TYPES.

### DIFF
--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -51,6 +51,7 @@ const MEDIA_TYPES: Record<string, string> = {
   ".js": "application/javascript",
   ".jsx": "text/jsx",
   ".gz": "application/gzip",
+  ".css": "text/css",
 };
 
 /** Returns the content-type based on the extension of a path. */


### PR DESCRIPTION
Fix #5327 

This makes sure CSS files are served with the correct `text/css` content type. It will allow the `filer_server` to serve static websites.