### PR TITLE
fix: panic when $DENO_DIR is a relative path

### DIFF
--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -13,7 +13,7 @@ pub struct DenoDir {
 }
 
 impl DenoDir {
-  pub fn new(custom_root: Option<PathBuf>) -> std::io::Result<Self> {
+  pub fn new(maybe_custom_root: Option<PathBuf>) -> std::io::Result<Self> {
     // Only setup once.
     let home_dir = dirs::home_dir().expect("Could not get home directory.");
     let fallback = home_dir.join(".deno");
@@ -24,7 +24,16 @@ impl DenoDir {
       .map(|d| d.join("deno"))
       .unwrap_or(fallback);
 
-    let root: PathBuf = custom_root.unwrap_or(default);
+    let root: PathBuf = if let Some(root) = maybe_custom_root {
+      if root.is_absolute() {
+        root
+      } else {
+        std::env::current_dir()?.join(root)
+      }
+    } else {
+      default
+    };
+    assert!(root.is_absolute());
     let gen_path = root.join("gen");
 
     let deno_dir = Self {

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -22,7 +22,9 @@ fn with_io_context<T: AsRef<str>>(
 }
 
 impl DiskCache {
+  /// `location` must be an absolute path.
   pub fn new(location: &Path) -> Self {
+    assert!(location.is_absolute());
     Self {
       location: location.to_owned(),
     }
@@ -211,7 +213,12 @@ mod tests {
 
   #[test]
   fn test_get_cache_filename_with_extension() {
-    let cache = DiskCache::new(&PathBuf::from("foo"));
+    let p = if cfg!(target_os = "windows") {
+      "C:\\foo"
+    } else {
+      "/foo"
+    };
+    let cache = DiskCache::new(&PathBuf::from(p));
 
     let mut test_cases = vec![
       (

--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -103,7 +103,10 @@ impl Metadata {
 
 impl HttpCache {
   /// Returns a new instance.
+  ///
+  /// `location` must be an absolute path.
   pub fn new(location: &Path) -> Self {
+    assert!(location.is_absolute());
     Self {
       location: location.to_owned(),
     }


### PR DESCRIPTION
This commit fixes panic occuring when $DENO_DIR is set to a relative
path, eg. "DENO_DIR=denodir deno run main.ts".

Before creating DenoDir instance given path is checked and if necessary
resolved against current working directory.

Additional sanity checks were put in place to ensure all caches
receive absolute path for the location.

Fixes #5293