### PR TITLE
fix: setTimeout and co. have too strict types

### DIFF
--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -176,16 +176,16 @@ declare namespace WebAssembly {
 
 /** Sets a timer which executes a function once after the timer expires. */
 declare function setTimeout(
-  cb: (...args: unknown[]) => void,
+  cb: (...args: any[]) => void,
   delay?: number,
-  ...args: unknown[]
+  ...args: any[]
 ): number;
 
 /** Repeatedly calls a function , with a fixed time delay between each call. */
 declare function setInterval(
-  cb: (...args: unknown[]) => void,
+  cb: (...args: any[]) => void,
   delay?: number,
-  ...args: unknown[]
+  ...args: any[]
 ): number;
 declare function clearTimeout(id?: number): void;
 declare function clearInterval(id?: number): void;

--- a/cli/js/web/timers.ts
+++ b/cli/js/web/timers.ts
@@ -179,7 +179,8 @@ function fire(timer: Timer): void {
   callback();
 }
 
-export type Args = unknown[];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Args = any[];
 
 function checkThis(thisArg: unknown): void {
   if (thisArg !== null && thisArg !== undefined && thisArg !== globalThis) {

--- a/std/node/timers.ts
+++ b/std/node/timers.ts
@@ -5,7 +5,9 @@ export const clearTimeout = window.clearTimeout;
 export const setInterval = window.setInterval;
 export const clearInterval = window.clearInterval;
 export const setImmediate = (
-  cb: (...args: unknown[]) => void,
-  ...args: unknown[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  cb: (...args: any[]) => void,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ...args: any[]
 ): number => window.setTimeout(cb, 0, ...args);
 export const clearImmediate = window.clearTimeout;


### PR DESCRIPTION
Should fix #5278 by moving `unknown[]` to `any[]` to line up with TypeScript's behaviour.

Code:
```typescript
setTimeout((x: number) => {
    console.log("test");
}, 0, 1);
```
Shouldn't be getting this error anymore:
```
error: TS2345 [ERROR]: Argument of type '(x: number) => void' is not assignable to parameter of type '(...args: unknown[]) => void'.
  Types of parameters 'x' and 'args' are incompatible.
    Type 'unknown' is not assignable to type 'number'.
setTimeout((x: number) => {
           ~~~~~~~~~~~~~~~~
```

![image](https://user-images.githubusercontent.com/3187536/81975770-d6cef600-9627-11ea-9453-cd505d70cd7c.png)
