### PR TITLE
std/node fs.writeFileSync polyfill

### DIFF
--- a/std/node/fs.ts
+++ b/std/node/fs.ts
@@ -11,7 +11,7 @@ import { readlink, readlinkSync } from "./_fs/_fs_readlink.ts";
 import { exists, existsSync } from "./_fs/_fs_exists.ts";
 import { mkdir, mkdirSync } from "./_fs/_fs_mkdir.ts";
 import { copyFile, copyFileSync } from "./_fs/_fs_copy.ts";
-import { writeFile } from "./_fs/_fs_writeFile.ts";
+import { writeFile, writeFileSync } from "./_fs/_fs_writeFile.ts";
 import * as promises from "./_fs/promises/mod.ts";
 
 export {
@@ -37,5 +37,6 @@ export {
   mkdir,
   mkdirSync,
   writeFile,
+  writeFileSync,
   promises,
 };


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
Add Node's `fs.writeFileSync` method

- `mode` does not work on Windows, will throw if used (not implemented error)
- Only supported encoding is `utf8`