### PR TITLE
fix(#5449): REPL does not exit properly when close() is called

### DIFF
--- a/cli/js/repl.ts
+++ b/cli/js/repl.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { exit } from "./ops/os.ts";
 import { core } from "./core.ts";
-import { writable } from "./globals.ts";
 import { version } from "./version.ts";
 import { stringifyArgs } from "./web/console.ts";
 import { startRepl, readline } from "./ops/repl.ts";
@@ -33,6 +32,13 @@ function isRecoverableError(e: Error): boolean {
   return recoverableErrorMessages.includes(e.message);
 }
 
+// Returns `true` if `close()` is called in REPL.
+// We should quit the REPL when this function returns `true`.
+function isCloseCalled(): boolean {
+  // @ts-ignore
+  return globalThis.closed;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Value = any;
 
@@ -46,7 +52,9 @@ function evaluate(code: string): boolean {
   const [result, errInfo] = core.evalContext(code);
   if (!errInfo) {
     lastEvalResult = result;
-    replLog(result);
+    if (!isCloseCalled()) {
+      replLog(result);
+    }
   } else if (errInfo.isCompileError && isRecoverableError(errInfo.thrown)) {
     // Recoverable compiler error
     return false; // don't consume code.
@@ -107,17 +115,14 @@ export async function replLoop(): Promise<void> {
     },
   });
 
-  // Configure globalThis.close to terminate REPL properly when `close()` is called.
-  Object.defineProperty(
-    globalThis,
-    "close",
-    writable(() => quitRepl(0))
-  );
-
   replLog(`Deno ${version.deno}`);
   replLog("exit using ctrl+d or close()");
 
   while (true) {
+    if (isCloseCalled()) {
+      quitRepl(0);
+    }
+
     let code = "";
     // Top level read
     try {

--- a/cli/js/repl.ts
+++ b/cli/js/repl.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { exit } from "./ops/os.ts";
 import { core } from "./core.ts";
+import { writable } from "./globals.ts";
 import { version } from "./version.ts";
 import { stringifyArgs } from "./web/console.ts";
 import { startRepl, readline } from "./ops/repl.ts";
@@ -105,6 +106,8 @@ export async function replLoop(): Promise<void> {
       console.log("Last thrown error is no longer saved to _error.");
     },
   });
+
+  Object.defineProperty(globalThis, "close", writable(() => quitRepl(0)));
 
   replLog(`Deno ${version.deno}`);
   replLog("exit using ctrl+d or close()");

--- a/cli/js/repl.ts
+++ b/cli/js/repl.ts
@@ -107,7 +107,11 @@ export async function replLoop(): Promise<void> {
     },
   });
 
-  Object.defineProperty(globalThis, "close", writable(() => quitRepl(0)));
+  Object.defineProperty(
+    globalThis,
+    "close",
+    writable(() => quitRepl(0))
+  );
 
   replLog(`Deno ${version.deno}`);
   replLog("exit using ctrl+d or close()");

--- a/cli/js/repl.ts
+++ b/cli/js/repl.ts
@@ -107,6 +107,7 @@ export async function replLoop(): Promise<void> {
     },
   });
 
+  // Configure globalThis.close to terminate REPL properly when `close()` is called.
   Object.defineProperty(
     globalThis,
     "close",

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -663,13 +663,15 @@ const REPL_MSG: &str = "exit using ctrl+d or close()\n";
 
 #[test]
 fn repl_test_close_command() {
-  let (_out, err) = util::run_and_collect_output(
+  let (out, err) = util::run_and_collect_output(
     true,
     "repl",
     Some(vec!["close()", "'ignored'"]),
     None,
     false,
   );
+
+  assert!(!out.contains("ignored"));
   assert!(err.is_empty());
 }
 


### PR DESCRIPTION
Closes #5449.

---

**Before this fix:**

1. User types `close()` in REPL.
2. `globalThis.close()` is called and it queues up a call to `Deno.exit()` as follows:
https://github.com/denoland/deno/blob/a08a4abac116eda498f8ad2df13b3816ec36c9ad/cli/js/runtime_main.ts#L38-L54
3. REPL shows `undefined` which is the result of evaluation of `globalThis.close()` ([https://github.com/denoland/deno/blob/master/cli/js/repl.ts#L48](repl.ts#L48)).
4. REPL shows the prompt and  wait for user to type something ([repl.ts#L116](https://github.com/denoland/deno/blob/master/cli/js/repl.ts#L116)).
5. Before user types something in REPL, the process is terminated by a queued call to `Deno.exit()`.

**After this fix:**

1. User types `close()` in REPL.
2. `globalThis.close()` is called, which immediately terminates REPL and the process.
    - This function is overwritten [at line 111 in repl.ts](https://github.com/denoland/deno/pull/5451/files#diff-73adb4a3036d57af9ca33dde0122d6acR110-R116).
