### PR TITLE
Lets → Let's

### DIFF
--- a/docs/getting_started/first_steps.md
+++ b/docs/getting_started/first_steps.md
@@ -30,7 +30,7 @@ deno run https://deno.land/std/examples/welcome.ts
 ### Making an HTTP request
 
 Something a lot of programs do is fetching data from a webserver via an HTTP
-request. Lets write a small program that fetches a file and prints the content
+request. Let's write a small program that fetches a file and prints the content
 to the terminal.
 
 Just like in the browser you can use the web standard
@@ -45,7 +45,7 @@ const body = new Uint8Array(await res.arrayBuffer());
 await Deno.stdout.write(body);
 ```
 
-Lets walk through what this application does:
+Let's walk through what this application does:
 
 1. We get the first argument passed to the application and store it in the
    variable `url`.


### PR DESCRIPTION
Noticed this going through the [Getting Started][1] section of the manual. When it's in the sense of "let us," it's "let's", not "lets." See [dictionary.com][2] for a reference.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

[1]: https://deno.land/manual/getting_started/first_steps
[2]: https://www.dictionary.com/e/lets/