### PR TITLE
simplify code contributions by fully automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - init: cargo build
+    command: cargo watch -x run

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A secure runtime for JavaScript and TypeScript.
 
 [![Build Status](https://github.com/denoland/deno/workflows/ci/badge.svg?branch=master&event=push)](https://github.com/denoland/deno/actions)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/denoland/deno/)
 
 Deno aims to provide a productive and secure scripting environment for the
 modern programmer. It is built on top of V8, Rust, and TypeScript.


### PR DESCRIPTION
Hi! :slightly_smiling_face: 

This Pr simplifies code contributions by fully automating the dev setup with Gitpod(An online [Eclipse Theia](https://theia-ide.org/) based IDE which is free for Open Source). With a single click, it'll launch a workspace and automatically:

- clone the `deno` repo.
- install the dependencies i.e will run `cargo build`.
- start `cargo watch -x run`.

that way anyone interested in contributing can start straight away without any friction.

You can give it a try on my fork of the repo via the following link: 

https://gitpod.io/#https://github.com/nisarhassan12/deno

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/82107588-67015e00-9742-11ea-83d1-3f0539cdf6f1.png)

A lot of popular OSS projects out there are already using it simplify contributors onboarding some of them are:

- https://github.com/freeCodeCamp/freeCodeCamp
- https://github.com/facebook/docusaurus
- https://github.com/mozilla/pdf.js/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/77501629-64893300-6e7a-11ea-82d7-5599b0215bd4.png)

