### PR TITLE
refactor: fix some unwrap() in Rust.(with the searching of is_some())

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -114,7 +114,7 @@ pub struct Flags {
 fn join_paths(whitelist: &[PathBuf], d: &str) -> String {
   whitelist
     .iter()
-    .map(|path| path.to_string_lossy().to_string())
+    .map(|path| path.to_str().unwrap().to_string())
     .collect::<Vec<String>>()
     .join(d)
 }

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1176,7 +1176,7 @@ fn reload_arg_parse(flags: &mut Flags, matches: &ArgMatches) {
   if let Some(cache_bl) = matches.values_of("reload") {
     let raw_cache_blacklist: Vec<String> =
       cache_bl.map(std::string::ToString::to_string).collect();
-    if raw_cache_blacklist.len() == 0 {
+    if raw_cache_blacklist.is_empty() {
       flags.reload = true;
     } else {
       flags.cache_blacklist = resolve_urls(raw_cache_blacklist);
@@ -1237,7 +1237,7 @@ fn permission_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   if let Some(read_wl) = matches.values_of("allow-read") {
     let raw_read_whitelist: Vec<PathBuf> = read_wl.map(PathBuf::from).collect();
 
-    if raw_read_whitelist.len() == 0 {
+    if raw_read_whitelist.is_empty() {
       flags.allow_read = true;
     } else {
       flags.read_whitelist = resolve_fs_whitelist(&raw_read_whitelist);
@@ -1249,7 +1249,7 @@ fn permission_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     let raw_write_whitelist: Vec<PathBuf> =
       write_wl.map(PathBuf::from).collect();
 
-    if raw_write_whitelist.len() == 0 {
+    if raw_write_whitelist.is_empty() {
       flags.allow_write = true;
     } else {
       flags.write_whitelist = resolve_fs_whitelist(&raw_write_whitelist);
@@ -1260,7 +1260,7 @@ fn permission_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   if let Some(net_wl) = matches.values_of("allow-net") {
     let raw_net_whitelist: Vec<String> =
       net_wl.map(std::string::ToString::to_string).collect();
-    if raw_net_whitelist.len() == 0 {
+    if raw_net_whitelist.is_empty() {
       flags.allow_net = true;
     } else {
       flags.net_whitelist = resolve_hosts(raw_net_whitelist);

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -114,7 +114,7 @@ pub struct Flags {
 fn join_paths(whitelist: &[PathBuf], d: &str) -> String {
   whitelist
     .iter()
-    .map(|path| path.to_str().unwrap().to_string())
+    .map(|path| path.to_string_lossy().to_string())
     .collect::<Vec<String>>()
     .join(d)
 }
@@ -1173,16 +1173,15 @@ fn reload_arg<'a, 'b>() -> Arg<'a, 'b> {
 }
 
 fn reload_arg_parse(flags: &mut Flags, matches: &ArgMatches) {
-  if matches.is_present("reload") {
-    if matches.value_of("reload").is_some() {
-      let cache_bl = matches.values_of("reload").unwrap();
-      let raw_cache_blacklist: Vec<String> =
-        cache_bl.map(std::string::ToString::to_string).collect();
+  if let Some(cache_bl) = matches.values_of("reload") {
+    let raw_cache_blacklist: Vec<String> =
+      cache_bl.map(std::string::ToString::to_string).collect();
+    if raw_cache_blacklist.len() == 0 {
+      flags.reload = true;
+    } else {
       flags.cache_blacklist = resolve_urls(raw_cache_blacklist);
       debug!("cache blacklist: {:#?}", &flags.cache_blacklist);
       flags.reload = false;
-    } else {
-      flags.reload = true;
     }
   }
 }
@@ -1235,39 +1234,40 @@ fn no_remote_arg_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 }
 
 fn permission_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
-  if matches.is_present("allow-read") {
-    if matches.value_of("allow-read").is_some() {
-      let read_wl = matches.values_of("allow-read").unwrap();
-      let raw_read_whitelist: Vec<PathBuf> =
-        read_wl.map(PathBuf::from).collect();
+  if let Some(read_wl) = matches.values_of("allow-read") {
+    let raw_read_whitelist: Vec<PathBuf> = read_wl.map(PathBuf::from).collect();
+
+    if raw_read_whitelist.len() == 0 {
+      flags.allow_read = true;
+    } else {
       flags.read_whitelist = resolve_fs_whitelist(&raw_read_whitelist);
       debug!("read whitelist: {:#?}", &flags.read_whitelist);
-    } else {
-      flags.allow_read = true;
     }
   }
-  if matches.is_present("allow-write") {
-    if matches.value_of("allow-write").is_some() {
-      let write_wl = matches.values_of("allow-write").unwrap();
-      let raw_write_whitelist: Vec<PathBuf> =
-        write_wl.map(PathBuf::from).collect();
+
+  if let Some(write_wl) = matches.values_of("allow-write") {
+    let raw_write_whitelist: Vec<PathBuf> =
+      write_wl.map(PathBuf::from).collect();
+
+    if raw_write_whitelist.len() == 0 {
+      flags.allow_write = true;
+    } else {
       flags.write_whitelist = resolve_fs_whitelist(&raw_write_whitelist);
       debug!("write whitelist: {:#?}", &flags.write_whitelist);
-    } else {
-      flags.allow_write = true;
     }
   }
-  if matches.is_present("allow-net") {
-    if matches.value_of("allow-net").is_some() {
-      let net_wl = matches.values_of("allow-net").unwrap();
-      let raw_net_whitelist =
-        net_wl.map(std::string::ToString::to_string).collect();
+
+  if let Some(net_wl) = matches.values_of("allow-net") {
+    let raw_net_whitelist: Vec<String> =
+      net_wl.map(std::string::ToString::to_string).collect();
+    if raw_net_whitelist.len() == 0 {
+      flags.allow_net = true;
+    } else {
       flags.net_whitelist = resolve_hosts(raw_net_whitelist);
       debug!("net whitelist: {:#?}", &flags.net_whitelist);
-    } else {
-      flags.allow_net = true;
     }
   }
+
   if matches.is_present("allow-env") {
     flags.allow_env = true;
   }

--- a/cli/ops/tls.rs
+++ b/cli/ops/tls.rs
@@ -291,9 +291,7 @@ impl TlsListenerResource {
   /// Stop tracking a task.
   /// Happens when the task is done and thus no further tracking is needed.
   pub fn untrack_task(&mut self) {
-    if self.waker.is_some() {
-      self.waker.take();
-    }
+    self.waker.take();
   }
 }
 

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -912,7 +912,7 @@ mod tests {
       ModuleSpecifier::resolve_url_or_path(p.to_str().unwrap()).unwrap();
     let out = SourceFile {
       url: specifier.as_url().clone(),
-      filename: PathBuf::from(p.to_string_lossy().to_string()),
+      filename: PathBuf::from(p.to_str().unwrap().to_string()),
       media_type: msg::MediaType::TypeScript,
       source_code: include_bytes!("./tests/002_hello.ts").to_vec(),
       types_url: None,
@@ -1029,7 +1029,7 @@ mod tests {
     ];
 
     let path = temp_dir_path.join("tsconfig.json");
-    let path_str = path.to_string_lossy().to_string();
+    let path_str = path.to_str().unwrap().to_string();
 
     for (json_str, expected) in test_cases {
       deno_fs::write_file(&path, json_str.as_bytes(), 0o666).unwrap();
@@ -1043,7 +1043,7 @@ mod tests {
     let temp_dir = TempDir::new().expect("tempdir fail");
     let temp_dir_path = temp_dir.path();
     let path = temp_dir_path.join("doesnotexist.json");
-    let path_str = path.to_string_lossy().to_string();
+    let path_str = path.to_str().unwrap().to_string();
     let res = CompilerConfig::load(Some(path_str));
     assert!(res.is_err());
   }

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -912,7 +912,7 @@ mod tests {
       ModuleSpecifier::resolve_url_or_path(p.to_str().unwrap()).unwrap();
     let out = SourceFile {
       url: specifier.as_url().clone(),
-      filename: PathBuf::from(p.to_str().unwrap().to_string()),
+      filename: PathBuf::from(p.to_string_lossy().to_string()),
       media_type: msg::MediaType::TypeScript,
       source_code: include_bytes!("./tests/002_hello.ts").to_vec(),
       types_url: None,
@@ -1029,7 +1029,7 @@ mod tests {
     ];
 
     let path = temp_dir_path.join("tsconfig.json");
-    let path_str = path.to_str().unwrap().to_string();
+    let path_str = path.to_string_lossy().to_string();
 
     for (json_str, expected) in test_cases {
       deno_fs::write_file(&path, json_str.as_bytes(), 0o666).unwrap();
@@ -1043,7 +1043,7 @@ mod tests {
     let temp_dir = TempDir::new().expect("tempdir fail");
     let temp_dir_path = temp_dir.path();
     let path = temp_dir_path.join("doesnotexist.json");
-    let path_str = path.to_str().unwrap().to_string();
+    let path_str = path.to_string_lossy().to_string();
     let res = CompilerConfig::load(Some(path_str));
     assert!(res.is_err());
   }

--- a/core/isolate.rs
+++ b/core/isolate.rs
@@ -529,8 +529,7 @@ impl Future for CoreIsolate {
       assert_eq!(inner.shared.size(), 0);
     }
 
-    if overflow_response.is_some() {
-      let (op_id, buf) = overflow_response.take().unwrap();
+    if let Some((op_id, buf)) = overflow_response.take() {
       async_op_response(
         scope,
         Some((op_id, buf)),

--- a/core/js_errors.rs
+++ b/core/js_errors.rs
@@ -261,8 +261,7 @@ fn format_source_loc(
 
 impl fmt::Display for JSError {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    if self.script_resource_name.is_some() {
-      let script_resource_name = self.script_resource_name.as_ref().unwrap();
+    if let Some(script_resource_name) = &self.script_resource_name {
       if self.line_number.is_some() && self.start_column.is_some() {
         assert!(self.line_number.is_some());
         assert!(self.start_column.is_some());


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
And I find so many unwrap(). 

I think maybe we should replace them with `except` or use
[anyhow](https://docs.rs/anyhow/1.0.31/anyhow/) and [thiserror](https://docs.rs/thiserror/1.0.18/thiserror/) to make the code more robust?