### PR TITLE
(fix) Deno.remove for dir symlinks

### DIFF
--- a/cli/js/tests/remove_test.ts
+++ b/cli/js/tests/remove_test.ts
@@ -479,3 +479,48 @@ unitTest({ perms: { write: false } }, async function removeAllPerm(): Promise<
   assert(err instanceof Deno.errors.PermissionDenied);
   assertEquals(err.name, "PermissionDenied");
 });
+
+if (Deno.build.os == "windows") {
+  unitTest(
+    { perms: { run: true, write: true, read: true } },
+    async function removeFileSymlink(): Promise<void> {
+      let symlink = Deno.run({
+        cmd: ["cmd", "/c", "mklink", "file_link", "bar"],
+        stdout: "null",
+      });
+
+      assert(await symlink.status());
+      symlink.close();
+      await Deno.remove("file_link");
+      let err;
+      try {
+        await Deno.lstat("file_link");
+      } catch (e) {
+        err = e;
+      }
+      assert(err instanceof Deno.errors.NotFound);
+    }
+  );
+
+  unitTest(
+    { perms: { run: true, write: true, read: true } },
+    async function removeDirSymlink(): Promise<void> {
+      let symlink = Deno.run({
+        cmd: ["cmd", "/c", "mklink", "/d", "dir_link", "bar"],
+        stdout: "null",
+      });
+
+      assert(await symlink.status());
+      symlink.close();
+
+      await Deno.remove("dir_link");
+      let err;
+      try {
+        await Deno.lstat("dir_link");
+      } catch (e) {
+        err = e;
+      }
+      assert(err instanceof Deno.errors.NotFound);
+    }
+  );
+}

--- a/cli/js/tests/remove_test.ts
+++ b/cli/js/tests/remove_test.ts
@@ -484,7 +484,7 @@ if (Deno.build.os == "windows") {
   unitTest(
     { perms: { run: true, write: true, read: true } },
     async function removeFileSymlink(): Promise<void> {
-      let symlink = Deno.run({
+      const symlink = Deno.run({
         cmd: ["cmd", "/c", "mklink", "file_link", "bar"],
         stdout: "null",
       });
@@ -505,7 +505,7 @@ if (Deno.build.os == "windows") {
   unitTest(
     { perms: { run: true, write: true, read: true } },
     async function removeDirSymlink(): Promise<void> {
-      let symlink = Deno.run({
+      const symlink = Deno.run({
         cmd: ["cmd", "/c", "mklink", "/d", "dir_link", "bar"],
         stdout: "null",
       });

--- a/cli/js/tests/remove_test.ts
+++ b/cli/js/tests/remove_test.ts
@@ -480,7 +480,7 @@ unitTest({ perms: { write: false } }, async function removeAllPerm(): Promise<
   assertEquals(err.name, "PermissionDenied");
 });
 
-if (Deno.build.os == "windows") {
+if (Deno.build.os === "windows") {
   unitTest(
     { perms: { run: true, write: true, read: true } },
     async function removeFileSymlink(): Promise<void> {

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -397,10 +397,17 @@ fn op_remove(
     let metadata = std::fs::symlink_metadata(&path)?;
     debug!("op_remove {} {}", path.display(), recursive);
     let file_type = metadata.file_type();
-    if file_type.is_file() || file_type.is_symlink() {
+    if file_type.is_file() {
       std::fs::remove_file(&path)?;
     } else if recursive {
       std::fs::remove_dir_all(&path)?;
+    } else if file_type.is_symlink() {
+      let is_symlink_dir = std::fs::metadata(&path)?.is_dir();
+      if is_symlink_dir {
+        std::fs::remove_dir(&path)?;
+      } else {
+        std::fs::remove_file(&path)?;
+      }
     } else {
       std::fs::remove_dir(&path)?;
     }

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -402,11 +402,16 @@ fn op_remove(
     } else if recursive {
       std::fs::remove_dir_all(&path)?;
     } else if file_type.is_symlink() {
-      let is_symlink_dir = std::fs::metadata(&path)?.is_dir();
-      if is_symlink_dir {
-        std::fs::remove_dir(&path)?;
-      } else {
-        std::fs::remove_file(&path)?;
+      #[cfg(unix)]
+      std::fs::remove_file(&path)?;
+      #[cfg(not(unix))]
+      {
+        let is_symlink_dir = std::fs::metadata(&path)?.is_dir();
+        if is_symlink_dir {
+          std::fs::remove_dir(&path)?;
+        } else {
+          std::fs::remove_file(&path)?;
+        }
       }
     } else {
       std::fs::remove_dir(&path)?;

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -410,13 +410,10 @@ fn op_remove(
       std::fs::remove_file(&path)?;
       #[cfg(not(unix))]
       {
-        use winapi::um::winnt::{
-          FILE_ATTRIBUTE_ARCHIVE, FILE_ATTRIBUTE_DIRECTORY,
-        };
-        let file_attributes = metadata.file_attributes();
-        if file_attributes & FILE_ATTRIBUTE_DIRECTORY != 0 {
+        use winapi::um::winnt::FILE_ATTRIBUTE_DIRECTORY;
+        if metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY != 0 {
           std::fs::remove_dir(&path)?;
-        } else if file_attributes & FILE_ATTRIBUTE_ARCHIVE != 0 {
+        } else {
           std::fs::remove_file(&path)?;
         }
       }


### PR DESCRIPTION
this PR is going to make Deno.remove able to remove dir symlinks.

current behavior :
```ts
Deno.removeSync("dirSymlink");
/// Uncaught PermissionDenied: Access is denied. (os error 5)
```

since in windows, we have two kinds of symlinks [ dir, file ]
We need to explicitly state the type of deletion in `op_remove`