### PR TITLE
Update to dprint 0.18.0 and latest swc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333c186929ffefda1e2db1f58a3ee5802e0a79b0fb7c4d7dad88eb8961472da9"
+checksum = "33cbbb2ba27772b1a677e019862186320f36cf79c669f71e58426d66ad30bb8f"
 dependencies = [
  "dprint-core",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33cbbb2ba27772b1a677e019862186320f36cf79c669f71e58426d66ad30bb8f"
+checksum = "c80c3890c3bed9b190befa2184dde735fe804e8a5305784fd7c53ad6e4865917"
 dependencies = [
  "dprint-core",
  "serde",
@@ -2435,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e034fd0f2a837f23fee9e7f92d0b2bd916638fde7d40dddbddcb37389b5c5d"
+checksum = "cb6105718e50b118ff100acda244b6df4f3f46de76b03e5d1baeaa3e69f97a6a"
 dependencies = [
  "enum_kind",
  "num-bigint",
@@ -2449,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78964f597535cfe7668bc1fb5043078656d151fe94e4b552114cc9e99bebca97"
+checksum = "6ddb997ff7671faf7e55040233ed814bed1f69b6d1ad7a0fe78948ebf42d3d6a"
 dependencies = [
  "either",
  "enum_kind",
@@ -2483,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0704052df86db199bd917a9ad35d76b6bcb9a25bc9128a082530ce7f58ee9228"
+checksum = "802b13ac5811ebc6897c9a1ed999aa9ca3dd6faf8e664b9df44e162e2b3a03ed"
 dependencies = [
  "num-bigint",
  "swc_atoms",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e945fe5978d1cb0edddf522dc360c8a5d691ecd2fe98a9de74efb3997ed0ec6"
+checksum = "333c186929ffefda1e2db1f58a3ee5802e0a79b0fb7c4d7dad88eb8961472da9"
 dependencies = [
  "dprint-core",
  "serde",
@@ -2435,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31fb43e08500984ecb795ac12cc41a7dac3e55cc649a5e576fd808917a35a525"
+checksum = "08e034fd0f2a837f23fee9e7f92d0b2bd916638fde7d40dddbddcb37389b5c5d"
 dependencies = [
  "enum_kind",
  "num-bigint",
@@ -2449,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.21.10"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb9f7ffcb1d0fac1a6002a5775ef56defcc44dff43e333bbe6fe3804062fde1"
+checksum = "78964f597535cfe7668bc1fb5043078656d151fe94e4b552114cc9e99bebca97"
 dependencies = [
  "either",
  "enum_kind",
@@ -2483,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdd4d87e6499ff8cc3b32981ab2a3917cea4002a0c4523868181f59d14f4638"
+checksum = "0704052df86db199bd917a9ad35d76b6bcb9a25bc9128a082530ce7f58ee9228"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2496,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit_macros"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceb3a3184ba505b3f94fa4132a72e754d361ad9913b7e0dc4f01ab38649a9d26"
+checksum = "9083af117bcb987631d99129ce57e634315267d84521fd562926135fa49bee38"
 dependencies = [
  "Inflector",
  "pmutil",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "ahash"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f33b5018f120946c1dcf279194f238a9f146725593ead1c08fa47ff22b0b5d3"
-dependencies = [
- "const-random",
-]
-
-[[package]]
-name = "ahash"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0989268a37e128d4d7a8028f1c60099430113fdbc70419010601ce51a228e4fe"
@@ -462,7 +453,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93b8a57df1b6a3f0a96df85297d506a871b31252df23f969b9837ccb5d07455c"
 dependencies = [
- "ahash 0.3.2",
+ "ahash",
  "cfg-if",
  "num_cpus",
 ]
@@ -627,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80c3890c3bed9b190befa2184dde735fe804e8a5305784fd7c53ad6e4865917"
+checksum = "63a30d83f56d1adb78643a99a81fe25b5b9b6bff7798623a13caa12040f9899d"
 dependencies = [
  "dprint-core",
  "serde",
@@ -943,16 +934,6 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
-dependencies = [
- "ahash 0.2.18",
- "autocfg 0.1.7",
 ]
 
 [[package]]
@@ -2411,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.5.9"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f17c61920fa7307f5ea35ecf5f05d455a2610cdb2582dbcf81dbeaa361a3788"
+checksum = "ac5dc408a5004d6d82914e8c415f4c2a8c716b53ff766ab13af9bf0e5a286d98"
 dependencies = [
  "ast_node",
  "atty",
@@ -2422,7 +2403,6 @@ dependencies = [
  "either",
  "from_variant",
  "fxhash",
- "hashbrown",
  "log 0.4.8",
  "parking_lot 0.7.1",
  "scoped-tls",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,7 +29,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.18.0"
+dprint-plugin-typescript = "0.18.1"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,7 +29,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.18.1"
+dprint-plugin-typescript = "0.18.2"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.1"
@@ -60,7 +60,7 @@ walkdir = "2.3.1"
 warp = "0.2.2"
 semver-parser = "0.9.0"
 uuid = { version = "0.8.1", features = ["v4"] }
-swc_ecma_visit = "0.3.0"
+swc_ecma_visit = "0.4.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.8"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,7 +29,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.17.2"
+dprint-plugin-typescript = "0.18.0"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.1"
@@ -60,7 +60,7 @@ walkdir = "2.3.1"
 warp = "0.2.2"
 semver-parser = "0.9.0"
 uuid = { version = "0.8.1", features = ["v4"] }
-swc_ecma_visit = "0.1.0"
+swc_ecma_visit = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.8"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,7 +29,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.18.2"
+dprint-plugin-typescript = "0.18.3"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.1"

--- a/cli/doc/class.rs
+++ b/cli/doc/class.rs
@@ -123,10 +123,10 @@ pub fn class_to_class_def(
         let mut params = vec![];
 
         for param in &ctor.params {
-          use crate::swc_ecma_ast::PatOrTsParamProp::*;
+          use crate::swc_ecma_ast::ParamOrTsParamProp::*;
 
           let param_def = match param {
-            Pat(pat) => pat_to_param_def(pat),
+            Param(param) => pat_to_param_def(&param.pat),
             TsParamProp(ts_param_prop) => {
               use swc_ecma_ast::TsParamPropParam;
 

--- a/cli/doc/function.rs
+++ b/cli/doc/function.rs
@@ -25,7 +25,7 @@ pub fn function_to_function_def(
   let mut params = vec![];
 
   for param in &function.params {
-    let param_def = pat_to_param_def(param);
+    let param_def = pat_to_param_def(&param.pat);
     params.push(param_def);
   }
 

--- a/cli/doc/tests.rs
+++ b/cli/doc/tests.rs
@@ -1435,3 +1435,101 @@ export function fooFn(a: number) {
       .contains("function fooFn(a: number)")
   );
 }
+
+#[tokio::test]
+async fn ts_lit_types() {
+  let source_code = r#"
+export type boolLit = false;
+export type strLit = "text";
+export type tplLit = `text`;
+export type numLit = 5;
+"#;
+  let loader =
+    TestLoader::new(vec![("test.ts".to_string(), source_code.to_string())]);
+  let entries = DocParser::new(loader).parse("test.ts").await.unwrap();
+  let actual = serde_json::to_value(entries).unwrap();
+  let expected_json = json!([
+    {
+      "kind": "typeAlias",
+      "name": "boolLit",
+      "location": {
+        "filename": "test.ts",
+        "line": 2,
+        "col": 0
+      },
+      "jsDoc": null,
+      "typeAliasDef": {
+        "tsType": {
+          "repr": "false",
+          "kind": "literal",
+          "literal": {
+            "kind": "boolean",
+            "boolean": false
+          }
+        },
+        "typeParams": []
+      }
+    }, {
+      "kind": "typeAlias",
+      "name": "strLit",
+      "location": {
+        "filename": "test.ts",
+        "line": 3,
+        "col": 0
+      },
+      "jsDoc": null,
+      "typeAliasDef": {
+        "tsType": {
+          "repr": "text",
+          "kind": "literal",
+          "literal": {
+            "kind": "string",
+            "string": "text"
+          }
+        },
+        "typeParams": []
+      }
+    }, {
+      "kind": "typeAlias",
+      "name": "tplLit",
+      "location": {
+        "filename": "test.ts",
+        "line": 4,
+        "col": 0
+      },
+      "jsDoc": null,
+      "typeAliasDef": {
+        "tsType": {
+          "repr": "text",
+          "kind": "literal",
+          "literal": {
+            "kind": "string",
+            "string": "text"
+          }
+        },
+        "typeParams": []
+      }
+    }, {
+      "kind": "typeAlias",
+      "name": "numLit",
+      "location": {
+        "filename": "test.ts",
+        "line": 5,
+        "col": 0
+      },
+      "jsDoc": null,
+      "typeAliasDef": {
+        "tsType": {
+          "repr": "5",
+          "kind": "literal",
+          "literal": {
+            "kind": "number",
+            "number": 5.0
+          }
+        },
+        "typeParams": []
+      }
+    }
+  ]);
+  assert_eq!(actual, expected_json);
+}

--- a/cli/doc/ts_type.rs
+++ b/cli/doc/ts_type.rs
@@ -69,6 +69,21 @@ impl Into<TsTypeDef> for &TsLitType {
           boolean: None,
         },
       ),
+      TsLit::Tpl(tpl) => {
+        // A template literal in a type is not allowed to have
+        // expressions, so there will only be one quasi.
+        let quasi = tpl.quasis.get(0).expect("Expected tpl to have a quasi.");
+        let text = quasi.raw.value.to_string();
+        (
+          text.clone(),
+          LiteralDef {
+            kind: LiteralDefKind::String, // semantically the same
+            number: None,
+            string: Some(text),
+            boolean: None,
+          },
+        )
+      },
       TsLit::Bool(bool_) => (
         bool_.value.to_string(),
         LiteralDef {

--- a/cli/doc/ts_type.rs
+++ b/cli/doc/ts_type.rs
@@ -83,7 +83,7 @@ impl Into<TsTypeDef> for &TsLitType {
             boolean: None,
           },
         )
-      },
+      }
       TsLit::Bool(bool_) => (
         bool_.value.to_string(),
         LiteralDef {


### PR DESCRIPTION
Closes #5180.

Also fixes swc parsing and formatting for template literals in types (ex. ``export type Permission = `test`;``).