### PR TITLE
feat(std): Add the current date-time formatted as DD MM hh:mm:ss

### DIFF
--- a/std/datetime/mod.ts
+++ b/std/datetime/mod.ts
@@ -38,8 +38,6 @@ export function parseDate(dateStr: string, format: DateFormat): Date {
   return new Date(Number(y), Number(m) - 1, Number(d));
 }
 
-
-
 export type DateTimeFormat =
   | "mm-dd-yyyy hh:mm"
   | "dd-mm-yyyy hh:mm"
@@ -135,8 +133,22 @@ const months = [
  * until the resulting string reaches the given length.
  * @return Pads the current string.
  */
-function dtPad(v: string, lPad = 2): any {
+function dtPad(v: string, lPad = 2): string {
   return v.padStart(lPad, "0");
+}
+
+/**
+ * Get the current date-time formatted as DD MM hh:mm:ss
+ * @example 21 Feb 13:12:44
+ * @return Format date
+ */
+export function timestamp(date = new Date()): string {
+  const time = [
+    dtPad(date.getHours().toString()),
+    dtPad(date.getMinutes().toString()),
+    dtPad(date.getSeconds().toString()),
+  ].join(":");
+  return [date.getDate(), months[date.getMonth()], time].join(" ");
 }
 
 /**

--- a/std/datetime/mod.ts
+++ b/std/datetime/mod.ts
@@ -38,6 +38,8 @@ export function parseDate(dateStr: string, format: DateFormat): Date {
   return new Date(Number(y), Number(m) - 1, Number(d));
 }
 
+
+
 export type DateTimeFormat =
   | "mm-dd-yyyy hh:mm"
   | "dd-mm-yyyy hh:mm"
@@ -113,6 +115,21 @@ export function currentDayOfYear(): number {
   return dayOfYear(new Date());
 }
 
+const months = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
 /**
  * Parse a date to return a IMF formated string date
  * RFC: https://tools.ietf.org/html/rfc7231#section-7.1.1.1
@@ -132,20 +149,6 @@ export function toIMF(date: Date): string {
   const s = dtPad(date.getUTCSeconds().toString());
   const y = date.getUTCFullYear();
   const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-  const months = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec",
-  ];
   return `${days[date.getUTCDay()]}, ${d} ${
     months[date.getUTCMonth()]
   } ${y} ${h}:${min}:${s} GMT`;

--- a/std/datetime/mod.ts
+++ b/std/datetime/mod.ts
@@ -131,6 +131,15 @@ const months = [
 ];
 
 /**
+ * Pads the current string with another string
+ * until the resulting string reaches the given length.
+ * @return Pads the current string.
+ */
+function dtPad(v: string, lPad = 2): any {
+  return v.padStart(lPad, "0");
+}
+
+/**
  * Parse a date to return a IMF formated string date
  * RFC: https://tools.ietf.org/html/rfc7231#section-7.1.1.1
  * IMF is the time format to use when generating times in HTTP
@@ -140,9 +149,6 @@ const months = [
  * @return IMF date formated string
  */
 export function toIMF(date: Date): string {
-  function dtPad(v: string, lPad = 2): string {
-    return v.padStart(lPad, "0");
-  }
   const d = dtPad(date.getUTCDate().toString());
   const h = dtPad(date.getUTCHours().toString());
   const min = dtPad(date.getUTCMinutes().toString());

--- a/std/datetime/test.ts
+++ b/std/datetime/test.ts
@@ -76,6 +76,11 @@ Deno.test("currentDayOfYear", function (): void {
   assertEquals(datetime.currentDayOfYear(), datetime.dayOfYear(new Date()));
 });
 
+Deno.test("timestamp", function (): void {
+  const expected = "5 Apr 23:02:06";
+  assertEquals(datetime.timestamp(new Date(2020, 3, 5, 23, 2, 6)), expected);
+});
+
 Deno.test({
   name: "[DateTime] to IMF",
   fn(): void {


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

Get the current date-time formatted as DD MM hh:mm:ss for example : 
```
timestamp();
```
result : 

`21 Feb 13:12:44`