### PR TITLE
Fix old manual links and manual.md ambiguity

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -184,7 +184,7 @@ static ENV_VARIABLES_HELP: &str = "ENVIRONMENT VARIABLES:
 
 static DENO_HELP: &str = "A secure JavaScript and TypeScript runtime
 
-Docs: https://deno.land/std/manual.md
+Docs: https://deno.land/manual
 Modules: https://deno.land/std/ https://deno.land/x/
 Bugs: https://github.com/denoland/deno/issues
 
@@ -1194,7 +1194,7 @@ fn importmap_arg<'a, 'b>() -> Arg<'a, 'b> {
     .long_help(
       "UNSTABLE:
 Load import map file
-Docs: https://deno.land/std/manual.md#import-maps
+Docs: https://deno.land/manual/linking_to_external_code/import_maps
 Specification: https://wicg.github.io/import-maps/
 Examples: https://github.com/WICG/import-maps#the-import-map",
     )

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -652,7 +652,7 @@ declare namespace Deno {
   /** **UNSTABLE**: new API, yet to be vetted.
    *
    * `bundle()` is part the compiler API.  A full description of this functionality
-   * can be found in the [manual](https://deno.land/std/manual.md#denobundle).
+   * can be found in the [manual](https://deno.land/manual/runtime/compiler_apis#denobundle).
    *
    * Takes a root module name, and optionally a record set of sources. Resolves
    * with a single JavaScript string (and bundle diagnostics if issues arise with

--- a/std/manual.md
+++ b/std/manual.md
@@ -1,1 +1,3 @@
-# The manual has moved to //docs
+# The manual has moved.
+
+[Click here](https://deno.land/manual) to read the manual.


### PR DESCRIPTION
Some parts of the CLI contain links to the old manual. This PR resolves this issue by replacing the outdated links with the correct ones.

The PR also makes the message inside of `std/manual.md` less ambiguous/confusing. Right now, when you open https://deno.land/std/manual.md (from the CLI), you'll only see `The manual has moved to //docs` with no link to the actual docs anywhere on the page. One would assume the manual is located under https://deno.land/docs, however, that page doesn't exist.