### PR TITLE
Fix definition of URL constructor

### DIFF
--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -1172,7 +1172,7 @@ interface URL {
 
 declare const URL: {
   prototype: URL;
-  new (url: string | URL, base?: string | URL): URL;
+  new (url: string, base?: string | URL): URL;
   createObjectURL(object: any): string;
   revokeObjectURL(url: string): void;
 };

--- a/std/path/posix.ts
+++ b/std/path/posix.ts
@@ -430,5 +430,5 @@ export function parse(path: string): ParsedPath {
  * are ignored.
  */
 export function fromFileUrl(url: string | URL): string {
-  return new URL(url).pathname;
+  return new URL(url.toString()).pathname;
 }

--- a/std/path/win32.ts
+++ b/std/path/win32.ts
@@ -908,7 +908,7 @@ export function parse(path: string): ParsedPath {
  * are ignored.
  */
 export function fromFileUrl(url: string | URL): string {
-  return new URL(url).pathname
+  return new URL(url.toString()).pathname
     .replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/")
     .replace(/\//g, "\\");
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

Currently, deno's URL constructor allows to pass `URL` or `string` as 1st argument.
However, WHATWG spec's URL constructor allows to pass only `string` as 1st argument.

This PR fix the definition of URL constructor in order to conform to WHATWG spec.

Fixes https://github.com/denoland/deno/issues/5365

---

TypeScript lib.dom.d.ts: https://github.com/microsoft/TypeScript/blob/v3.9.2/lib/lib.dom.d.ts#L15938-L15943

```ts
declare var URL: {
    prototype: URL;
    new(url: string, base?: string | URL): URL;
    createObjectURL(object: any): string;
    revokeObjectURL(url: string): void;
};
```

MDN: https://developer.mozilla.org/en-US/docs/Web/API/URL/URL

> A USVString representing an absolute or relative URL. If url is a relative URL, base is required, and will be used as the base URL.

WHATWG spec: https://url.spec.whatwg.org/#url-class

```
[Exposed=(Window,Worker),
 LegacyWindowAlias=webkitURL]
interface URL {
  constructor(USVString url, optional USVString base);

  stringifier attribute USVString href;
  readonly attribute USVString origin;
           attribute USVString protocol;
           attribute USVString username;
           attribute USVString password;
           attribute USVString host;
           attribute USVString hostname;
           attribute USVString port;
           attribute USVString pathname;
           attribute USVString search;
  [SameObject] readonly attribute URLSearchParams searchParams;
           attribute USVString hash;

  USVString toJSON();
};
```