### PR TITLE
Fix import_maps example code without --allow-net

### DIFF
--- a/docs/linking_to_external_code/import_maps.md
+++ b/docs/linking_to_external_code/import_maps.md
@@ -38,5 +38,5 @@ for await (const req of serve(":8000")) {
 ```
 
 ```shell
-$ deno run --importmap=import_map.json --unstable hello_server.ts
+$ deno run --allow-net --importmap=import_map.json --unstable hello_server.ts
 ```


### PR DESCRIPTION
add `--allow-net` to the example code snippet