### PR TITLE
update cli/js/tests guide

### DIFF
--- a/cli/js/tests/README.md
+++ b/cli/js/tests/README.md
@@ -50,27 +50,27 @@ There are three ways to run `unit_test_runner.ts`:
 ```
 # Run all tests. Spawns worker processes for each discovered permission
 # combination:
-target/debug/deno -A cli/js/tests/unit_test_runner.ts --master
+target/debug/deno run -A cli/js/tests/unit_test_runner.ts --master
 
 # By default all output of worker processes is discarded; for debug purposes
 # the --verbose flag preserves output from the worker
-target/debug/deno -A cli/js/tests/unit_test_runner.ts --master --verbose
+target/debug/deno run -A cli/js/tests/unit_test_runner.ts --master --verbose
 
 # Run subset of tests that don't require any permissions
-target/debug/deno cli/js/tests/unit_test_runner.ts
+target/debug/deno run --unstable cli/js/tests/unit_test_runner.ts
 
 # Run subset tests that require "net" and "read" permissions
-target/debug/deno --allow-net --allow-read cli/js/tests/unit_test_runner.ts
+target/debug/deno run --unstable --allow-net --allow-read cli/js/tests/unit_test_runner.ts
 
 # "worker" mode communicates with parent using TCP socket on provided address;
 # after initial setup drops permissions to specified set. It shouldn't be used
 # directly, only be "master" process.
-target/debug/deno -A cli/js/tests/unit_test_runner.ts --worker --addr=127.0.0.1:4500 --perms=net,write,run
+target/debug/deno run -A cli/js/tests/unit_test_runner.ts --worker --addr=127.0.0.1:4500 --perms=net,write,run
 
 # Run specific tests
-target/debug/deno --allow-net cli/js/tests/unit_test_runner.ts -- netTcpListenClose
+target/debug/deno run --unstable --allow-net cli/js/tests/unit_test_runner.ts -- netTcpListenClose
 
-RUST_BACKTRACE=1 cargo run --  --allow-read --allow-write cli/js/tests/unit_test_runner.ts -- netUnixDialListen
+RUST_BACKTRACE=1 cargo run -- run --unstable --allow-read --allow-write cli/js/tests/unit_test_runner.ts -- netUnixDialListen
 ```
 
 ### Http server


### PR DESCRIPTION
use a de-hacked version of `run` subcommand and `--unstable` flag where needed.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
