### PR TITLE
fix(std/mime) - update default value in comment

### DIFF
--- a/std/mime/multipart.ts
+++ b/std/mime/multipart.ts
@@ -279,7 +279,7 @@ export class MultipartReader {
    * overflowed file data will be written to temporal files.
    * String field values are never written to files.
    * null value means parsing or writing to file was failed in some reason.
-   * @param maxMemory maximum memory size to store file in memory. bytes. @default 1048576 (1MB)
+   * @param maxMemory maximum memory size to store file in memory. bytes. @default 10485760 (10MB)
    *  */
   async readForm(maxMemory = 10 << 20): Promise<MultipartFormData> {
     const fileMap = new Map<string, FormFile>();


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
The default value for `MultipartReader.readForm` is `10mb`.