### PR TITLE
fix(std/fs/move) - duplicate description between move and moveSync

### DIFF
--- a/std/fs/move.ts
+++ b/std/fs/move.ts
@@ -35,7 +35,7 @@ export async function move(
   return;
 }
 
-/** Moves a file or directory synchronously*/
+/** Moves a file or directory synchronously */
 export function moveSync(
   src: string,
   dest: string,

--- a/std/fs/move.ts
+++ b/std/fs/move.ts
@@ -35,7 +35,7 @@ export async function move(
   return;
 }
 
-/** Moves a file or directory */
+/** Moves a file or directory synchronously*/
 export function moveSync(
   src: string,
   dest: string,


### PR DESCRIPTION
description of the sync function "moveSync" is a duplicate of the async function "move" description.

fixed the duplicate description to make clear the difference between the exported functions "move" and "moveSync".

