### PR TITLE
chore: capture stderr in integration tests

### DIFF
--- a/cli/tests/057_revoke_permissions.out
+++ b/cli/tests/057_revoke_permissions.out
@@ -1,3 +1,4 @@
+[WILDCARD]
 running 7 tests
 test runGranted ... ok [WILDCARD]
 test readGranted ... ok [WILDCARD]

--- a/cli/tests/deno_test.out
+++ b/cli/tests/deno_test.out
@@ -1,3 +1,4 @@
+[WILDCARD]
 running 4 tests
 test fail1 ... FAILED [WILDCARD]
 test fail2 ... FAILED [WILDCARD]

--- a/cli/tests/deno_test_fail_fast.out
+++ b/cli/tests/deno_test_fail_fast.out
@@ -1,3 +1,4 @@
+[WILDCARD]
 running 4 tests
 test fail1 ... FAILED [WILDCARD]
 

--- a/cli/tests/import_map_no_unstable.out
+++ b/cli/tests/import_map_no_unstable.out
@@ -1,0 +1,1 @@
+Unstable API '--importmap'. The --unstable flag must be provided.

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1228,7 +1228,7 @@ itest!(_056_make_temp_file_write_perm {
 
 // TODO(lucacasonato): remove --unstable when permissions goes stable
 itest!(_057_revoke_permissions {
-  args: "test --quiet -A --unstable 057_revoke_permissions.ts",
+  args: "test -A --unstable 057_revoke_permissions.ts",
   output: "057_revoke_permissions.out",
 });
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -926,63 +926,63 @@ itest!(_001_hello {
 });
 
 itest!(_002_hello {
-  args: "run --reload 002_hello.ts",
+  args: "run --quiet --reload 002_hello.ts",
   output: "002_hello.ts.out",
 });
 
 itest!(_003_relative_import {
-  args: "run --reload 003_relative_import.ts",
+  args: "run --quiet --reload 003_relative_import.ts",
   output: "003_relative_import.ts.out",
 });
 
 itest!(_004_set_timeout {
-  args: "run --reload 004_set_timeout.ts",
+  args: "run --quiet --reload 004_set_timeout.ts",
   output: "004_set_timeout.ts.out",
 });
 
 itest!(_005_more_imports {
-  args: "run --reload 005_more_imports.ts",
+  args: "run --quiet --reload 005_more_imports.ts",
   output: "005_more_imports.ts.out",
 });
 
 itest!(_006_url_imports {
-  args: "run --reload 006_url_imports.ts",
+  args: "run --quiet --reload 006_url_imports.ts",
   output: "006_url_imports.ts.out",
   http_server: true,
 });
 
 itest!(_012_async {
-  args: "run --reload 012_async.ts",
+  args: "run --quiet --reload 012_async.ts",
   output: "012_async.ts.out",
 });
 
 itest!(_013_dynamic_import {
-  args: "run --reload --allow-read 013_dynamic_import.ts",
+  args: "run --quiet --reload --allow-read 013_dynamic_import.ts",
   output: "013_dynamic_import.ts.out",
 });
 
 itest!(_014_duplicate_import {
-  args: "run --reload --allow-read 014_duplicate_import.ts ",
+  args: "run --quiet --reload --allow-read 014_duplicate_import.ts ",
   output: "014_duplicate_import.ts.out",
 });
 
 itest!(_015_duplicate_parallel_import {
-  args: "run --reload --allow-read 015_duplicate_parallel_import.js",
+  args: "run --quiet --reload --allow-read 015_duplicate_parallel_import.js",
   output: "015_duplicate_parallel_import.js.out",
 });
 
 itest!(_016_double_await {
-  args: "run --allow-read --reload 016_double_await.ts",
+  args: "run --quiet --allow-read --reload 016_double_await.ts",
   output: "016_double_await.ts.out",
 });
 
 itest!(_017_import_redirect {
-  args: "run --reload 017_import_redirect.ts",
+  args: "run --quiet --reload 017_import_redirect.ts",
   output: "017_import_redirect.ts.out",
 });
 
 itest!(_018_async_catch {
-  args: "run --reload 018_async_catch.ts",
+  args: "run --quiet --reload 018_async_catch.ts",
   output: "018_async_catch.ts.out",
 });
 
@@ -995,13 +995,12 @@ itest_ignore!(_019_media_types {
 
 itest!(_020_json_modules {
   args: "run --reload 020_json_modules.ts",
-  check_stderr: true,
   output: "020_json_modules.ts.out",
   exit_code: 1,
 });
 
 itest!(_021_mjs_modules {
-  args: "run --reload 021_mjs_modules.ts",
+  args: "run --quiet --reload 021_mjs_modules.ts",
   output: "021_mjs_modules.ts.out",
 });
 
@@ -1025,17 +1024,17 @@ itest_ignore!(_024_import_no_ext_with_headers {
 
 // TODO(lucacasonato): remove --unstable when permissions goes stable
 itest!(_025_hrtime {
-  args: "run --allow-hrtime --unstable --reload 025_hrtime.ts",
+  args: "run --quiet --allow-hrtime --unstable --reload 025_hrtime.ts",
   output: "025_hrtime.ts.out",
 });
 
 itest!(_025_reload_js_type_error {
-  args: "run --reload 025_reload_js_type_error.js",
+  args: "run --quiet --reload 025_reload_js_type_error.js",
   output: "025_reload_js_type_error.js.out",
 });
 
 itest!(_026_redirect_javascript {
-  args: "run --reload 026_redirect_javascript.js",
+  args: "run --quiet --reload 026_redirect_javascript.js",
   output: "026_redirect_javascript.js.out",
   http_server: true,
 });
@@ -1088,13 +1087,13 @@ fn compiler_api() {
 }
 
 itest!(_027_redirect_typescript {
-  args: "run --reload 027_redirect_typescript.ts",
+  args: "run --quiet --reload 027_redirect_typescript.ts",
   output: "027_redirect_typescript.ts.out",
   http_server: true,
 });
 
 itest!(_028_args {
-  args: "run --reload 028_args.ts --arg1 val1 --arg2=val2 -- arg3 arg4",
+  args: "run --quiet --reload 028_args.ts --arg1 val1 --arg2=val2 -- arg3 arg4",
   output: "028_args.ts.out",
 });
 
@@ -1105,25 +1104,25 @@ itest!(_029_eval {
 
 // Ugly parentheses due to whitespace delimiting problem.
 itest!(_030_eval_ts {
-  args: "eval -T console.log((123)as(number))", // 'as' is a TS keyword only
+  args: "eval --quiet -T console.log((123)as(number))", // 'as' is a TS keyword only
   output: "030_eval_ts.out",
 });
 
 itest!(_033_import_map {
   args:
-    "run --reload --importmap=importmaps/import_map.json --unstable importmaps/test.ts",
+    "run --quiet --reload --importmap=importmaps/import_map.json --unstable importmaps/test.ts",
   output: "033_import_map.out",
 });
 
 itest!(import_map_no_unstable {
   args:
-    "run --reload --importmap=importmaps/import_map.json importmaps/test.ts",
+    "run --quiet --reload --importmap=importmaps/import_map.json importmaps/test.ts",
   output: "import_map_no_unstable.out",
   exit_code: 70,
 });
 
 itest!(_034_onload {
-  args: "run --reload 034_onload/main.ts",
+  args: "run --quiet --reload 034_onload/main.ts",
   output: "034_onload.out",
 });
 
@@ -1133,19 +1132,17 @@ itest_ignore!(_035_cached_only_flag {
     "--reload --cached-only http://127.0.0.1:4545/cli/tests/019_media_types.ts",
   output: "035_cached_only_flag.out",
   exit_code: 1,
-  check_stderr: true,
   http_server: true,
 });
 
 itest!(_036_import_map_fetch {
   args:
-    "cache --reload --importmap=importmaps/import_map.json --unstable importmaps/test.ts",
+    "cache --quiet --reload --importmap=importmaps/import_map.json --unstable importmaps/test.ts",
   output: "036_import_map_fetch.out",
 });
 
 itest!(_037_fetch_multiple {
   args: "cache --reload fetch/test.ts fetch/other.ts",
-  check_stderr: true,
   http_server: true,
   output: "037_fetch_multiple.out",
 });
@@ -1153,7 +1150,6 @@ itest!(_037_fetch_multiple {
 itest!(_038_checkjs {
   // checking if JS file is run through TS compiler
   args: "run --reload --config 038_checkjs.tsconfig.json 038_checkjs.js",
-  check_stderr: true,
   exit_code: 1,
   output: "038_checkjs.js.out",
 });
@@ -1169,14 +1165,13 @@ itest!(_041_info_flag {
 });
 
 itest!(_042_dyn_import_evalcontext {
-  args: "run --allow-read --reload 042_dyn_import_evalcontext.ts",
+  args: "run --quiet --allow-read --reload 042_dyn_import_evalcontext.ts",
   output: "042_dyn_import_evalcontext.ts.out",
 });
 
 itest!(_044_bad_resource {
-  args: "run --reload --allow-read 044_bad_resource.ts",
+  args: "run --quiet --reload --allow-read 044_bad_resource.ts",
   output: "044_bad_resource.ts.out",
-  check_stderr: true,
   exit_code: 1,
 });
 
@@ -1187,12 +1182,12 @@ itest_ignore!(_045_proxy {
 });
 
 itest!(_046_tsx {
-  args: "run --reload 046_jsx_test.tsx",
+  args: "run --quiet --reload 046_jsx_test.tsx",
   output: "046_jsx_test.tsx.out",
 });
 
 itest!(_047_jsx {
-  args: "run  --reload 047_jsx_test.jsx",
+  args: "run --quiet --reload 047_jsx_test.jsx",
   output: "047_jsx_test.jsx.out",
 });
 
@@ -1216,42 +1211,41 @@ itest_ignore!(_052_no_remote_flag {
     "--reload --no-remote http://127.0.0.1:4545/cli/tests/019_media_types.ts",
   output: "052_no_remote_flag.out",
   exit_code: 1,
-  check_stderr: true,
   http_server: true,
 });
 
 itest!(_054_info_local_imports {
-  args: "info 005_more_imports.ts",
+  args: "info --quiet 005_more_imports.ts",
   output: "054_info_local_imports.out",
   exit_code: 0,
 });
 
 itest!(_056_make_temp_file_write_perm {
   args:
-    "run --allow-read --allow-write=./subdir/ 056_make_temp_file_write_perm.ts",
+    "run --quiet --allow-read --allow-write=./subdir/ 056_make_temp_file_write_perm.ts",
   output: "056_make_temp_file_write_perm.out",
 });
 
 // TODO(lucacasonato): remove --unstable when permissions goes stable
 itest!(_057_revoke_permissions {
-  args: "test -A --unstable 057_revoke_permissions.ts",
+  args: "test --quiet -A --unstable 057_revoke_permissions.ts",
   output: "057_revoke_permissions.out",
 });
 
 itest!(_058_tasks_microtasks_close {
-  args: "run 058_tasks_microtasks_close.ts",
+  args: "run --quiet 058_tasks_microtasks_close.ts",
   output: "058_tasks_microtasks_close.ts.out",
 });
 
 itest!(js_import_detect {
-  args: "run --reload js_import_detect.ts",
+  args: "run --quiet --reload js_import_detect.ts",
   output: "js_import_detect.ts.out",
   exit_code: 0,
 });
 
 itest!(lock_write_fetch {
   args:
-    "run --allow-read --allow-write --allow-env --allow-run lock_write_fetch.ts",
+    "run --quiet --allow-read --allow-write --allow-env --allow-run lock_write_fetch.ts",
   output: "lock_write_fetch.ts.out",
   exit_code: 0,
 });
@@ -1272,7 +1266,6 @@ itest_ignore!(lock_check_ok2 {
 itest!(lock_check_err {
   args: "run --lock=lock_check_err.json http://127.0.0.1:4545/cli/tests/003_relative_import.ts",
   output: "lock_check_err.out",
-  check_stderr: true,
   exit_code: 10,
   http_server: true,
 });
@@ -1281,7 +1274,6 @@ itest!(lock_check_err {
 itest_ignore!(lock_check_err2 {
   args: "run --lock=lock_check_err2.json 019_media_types.ts",
   output: "lock_check_err2.out",
-  check_stderr: true,
   exit_code: 10,
   http_server: true,
 });
@@ -1289,7 +1281,6 @@ itest_ignore!(lock_check_err2 {
 itest!(async_error {
   exit_code: 1,
   args: "run --reload async_error.ts",
-  check_stderr: true,
   output: "async_error.ts.out",
 });
 
@@ -1323,28 +1314,24 @@ itest!(circular1 {
 
 itest!(config {
   args: "run --reload --config config.tsconfig.json config.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "config.ts.out",
 });
 
 itest!(error_001 {
   args: "run --reload error_001.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "error_001.ts.out",
 });
 
 itest!(error_002 {
   args: "run --reload error_002.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "error_002.ts.out",
 });
 
 itest!(error_003_typescript {
   args: "run --reload error_003_typescript.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "error_003_typescript.ts.out",
 });
@@ -1355,63 +1342,54 @@ itest!(error_003_typescript {
 // https://github.com/denoland/deno/issues/2436
 itest!(error_003_typescript2 {
   args: "run error_003_typescript.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "error_003_typescript.ts.out",
 });
 
 itest!(error_004_missing_module {
   args: "run --reload error_004_missing_module.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "error_004_missing_module.ts.out",
 });
 
 itest!(error_005_missing_dynamic_import {
   args: "run --reload error_005_missing_dynamic_import.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "error_005_missing_dynamic_import.ts.out",
 });
 
 itest!(error_006_import_ext_failure {
   args: "run --reload error_006_import_ext_failure.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "error_006_import_ext_failure.ts.out",
 });
 
 itest!(error_007_any {
   args: "run --reload error_007_any.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "error_007_any.ts.out",
 });
 
 itest!(error_008_checkjs {
   args: "run --reload error_008_checkjs.js",
-  check_stderr: true,
   exit_code: 1,
   output: "error_008_checkjs.js.out",
 });
 
 itest!(error_011_bad_module_specifier {
   args: "run --reload error_011_bad_module_specifier.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "error_011_bad_module_specifier.ts.out",
 });
 
 itest!(error_012_bad_dynamic_import_specifier {
   args: "run --reload error_012_bad_dynamic_import_specifier.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "error_012_bad_dynamic_import_specifier.ts.out",
 });
 
 itest!(error_013_missing_script {
   args: "run --reload missing_file_name",
-  check_stderr: true,
   exit_code: 1,
   output: "error_013_missing_script.out",
 });
@@ -1424,7 +1402,6 @@ itest!(error_014_catch_dynamic_import_error {
 itest!(error_015_dynamic_import_permissions {
   args: "run --reload error_015_dynamic_import_permissions.js",
   output: "error_015_dynamic_import_permissions.out",
-  check_stderr: true,
   exit_code: 1,
   http_server: true,
 });
@@ -1433,7 +1410,6 @@ itest!(error_015_dynamic_import_permissions {
 itest!(error_016_dynamic_import_permissions2 {
   args: "run --reload --allow-net error_016_dynamic_import_permissions2.js",
   output: "error_016_dynamic_import_permissions2.out",
-  check_stderr: true,
   exit_code: 1,
   http_server: true,
 });
@@ -1441,90 +1417,77 @@ itest!(error_016_dynamic_import_permissions2 {
 itest!(error_017_hide_long_source_ts {
   args: "run --reload error_017_hide_long_source_ts.ts",
   output: "error_017_hide_long_source_ts.ts.out",
-  check_stderr: true,
   exit_code: 1,
 });
 
 itest!(error_018_hide_long_source_js {
   args: "run error_018_hide_long_source_js.js",
   output: "error_018_hide_long_source_js.js.out",
-  check_stderr: true,
   exit_code: 1,
 });
 
 itest!(error_019_stack_function {
   args: "run error_019_stack_function.ts",
   output: "error_019_stack_function.ts.out",
-  check_stderr: true,
   exit_code: 1,
 });
 
 itest!(error_020_stack_constructor {
   args: "run error_020_stack_constructor.ts",
   output: "error_020_stack_constructor.ts.out",
-  check_stderr: true,
   exit_code: 1,
 });
 
 itest!(error_021_stack_method {
   args: "run error_021_stack_method.ts",
   output: "error_021_stack_method.ts.out",
-  check_stderr: true,
   exit_code: 1,
 });
 
 itest!(error_022_stack_custom_error {
   args: "run error_022_stack_custom_error.ts",
   output: "error_022_stack_custom_error.ts.out",
-  check_stderr: true,
   exit_code: 1,
 });
 
 itest!(error_023_stack_async {
   args: "run error_023_stack_async.ts",
   output: "error_023_stack_async.ts.out",
-  check_stderr: true,
   exit_code: 1,
 });
 
 itest!(error_024_stack_promise_all {
   args: "run error_024_stack_promise_all.ts",
   output: "error_024_stack_promise_all.ts.out",
-  check_stderr: true,
   exit_code: 1,
 });
 
 itest!(error_025_tab_indent {
   args: "run error_025_tab_indent",
   output: "error_025_tab_indent.out",
-  check_stderr: true,
   exit_code: 1,
 });
 
 itest!(error_syntax {
   args: "run --reload error_syntax.js",
-  check_stderr: true,
   exit_code: 1,
   output: "error_syntax.js.out",
 });
 
 itest!(error_syntax_empty_trailing_line {
   args: "run --reload error_syntax_empty_trailing_line.mjs",
-  check_stderr: true,
   exit_code: 1,
   output: "error_syntax_empty_trailing_line.mjs.out",
 });
 
 itest!(error_type_definitions {
   args: "run --reload error_type_definitions.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "error_type_definitions.ts.out",
 });
 
 itest!(error_local_static_import_from_remote_ts {
   args: "run --reload http://localhost:4545/cli/tests/error_local_static_import_from_remote.ts",
-  check_stderr: true,
   exit_code: 1,
   http_server: true,
   output: "error_local_static_import_from_remote.ts.out",
@@ -1532,7 +1495,6 @@ itest!(error_local_static_import_from_remote_ts {
 
 itest!(error_local_static_import_from_remote_js {
   args: "run --reload http://localhost:4545/cli/tests/error_local_static_import_from_remote.js",
-  check_stderr: true,
   exit_code: 1,
   http_server: true,
   output: "error_local_static_import_from_remote.js.out",
@@ -1540,32 +1502,32 @@ itest!(error_local_static_import_from_remote_js {
 
 itest!(exit_error42 {
   exit_code: 42,
-  args: "run --reload exit_error42.ts",
+  args: "run --quiet --reload exit_error42.ts",
   output: "exit_error42.ts.out",
 });
 
 itest!(https_import {
-  args: "run --reload https_import.ts",
+  args: "run --quiet --reload https_import.ts",
   output: "https_import.ts.out",
 });
 
 itest!(if_main {
-  args: "run --reload if_main.ts",
+  args: "run --quiet --reload if_main.ts",
   output: "if_main.ts.out",
 });
 
 itest!(import_meta {
-  args: "run --reload import_meta.ts",
+  args: "run --quiet --reload import_meta.ts",
   output: "import_meta.ts.out",
 });
 
 itest!(lib_ref {
-  args: "run --unstable --reload lib_ref.ts",
+  args: "run --quiet --unstable --reload lib_ref.ts",
   output: "lib_ref.ts.out",
 });
 
 itest!(lib_runtime_api {
-  args: "run --unstable --reload lib_runtime_api.ts",
+  args: "run --quiet --unstable --reload lib_runtime_api.ts",
   output: "lib_runtime_api.ts.out",
 });
 
@@ -1593,7 +1555,6 @@ itest!(type_directives_02 {
 itest!(type_directives_js_main {
   args: "run --reload -L debug type_directives_js_main.js",
   output: "type_directives_js_main.js.out",
-  check_stderr: true,
   exit_code: 0,
 });
 
@@ -1604,12 +1565,11 @@ itest!(types {
 
 itest!(unbuffered_stderr {
   args: "run --reload unbuffered_stderr.ts",
-  check_stderr: true,
   output: "unbuffered_stderr.ts.out",
 });
 
 itest!(unbuffered_stdout {
-  args: "run --reload unbuffered_stdout.ts",
+  args: "run --quiet --reload unbuffered_stdout.ts",
   output: "unbuffered_stdout.ts.out",
 });
 
@@ -1633,12 +1593,11 @@ itest!(run_v8_help {
 itest!(unsupported_dynamic_import_scheme {
   args: "eval import('xxx:')",
   output: "unsupported_dynamic_import_scheme.out",
-  check_stderr: true,
   exit_code: 1,
 });
 
 itest!(wasm {
-  args: "run wasm.ts",
+  args: "run --quiet wasm.ts",
   output: "wasm.ts.out",
 });
 
@@ -1653,29 +1612,28 @@ itest!(top_level_await {
 });
 
 itest!(top_level_await_ts {
-  args: "run --allow-read top_level_await.ts",
+  args: "run --quiet --allow-read top_level_await.ts",
   output: "top_level_await.out",
 });
 
 itest!(top_level_for_await {
-  args: "run top_level_for_await.js",
+  args: "run --quiet top_level_for_await.js",
   output: "top_level_for_await.out",
 });
 
 itest!(top_level_for_await_ts {
-  args: "run top_level_for_await.ts",
+  args: "run --quiet top_level_for_await.ts",
   output: "top_level_for_await.out",
 });
 
 itest!(unstable_disabled {
   args: "run --reload unstable.ts",
-  check_stderr: true,
   exit_code: 1,
   output: "unstable_disabled.out",
 });
 
 itest!(unstable_enabled {
-  args: "run --reload --unstable unstable.ts",
+  args: "run --quiet --reload --unstable unstable.ts",
   output: "unstable_enabled.out",
 });
 
@@ -1685,24 +1643,25 @@ itest!(unstable_disabled_js {
 });
 
 itest!(unstable_enabled_js {
-  args: "run --reload --unstable unstable.ts",
+  args: "run --quiet --reload --unstable unstable.ts",
   output: "unstable_enabled_js.out",
 });
 
 itest!(_053_import_compression {
-  args: "run --reload --allow-net 053_import_compression/main.ts",
+  args: "run --quiet --reload --allow-net 053_import_compression/main.ts",
   output: "053_import_compression.out",
   http_server: true,
 });
 
 itest!(cafile_url_imports {
-  args: "run --reload --cert tls/RootCA.pem cafile_url_imports.ts",
+  args: "run --quiet --reload --cert tls/RootCA.pem cafile_url_imports.ts",
   output: "cafile_url_imports.ts.out",
   http_server: true,
 });
 
 itest!(cafile_ts_fetch {
-  args: "run --reload --allow-net --cert tls/RootCA.pem cafile_ts_fetch.ts",
+  args:
+    "run --quiet --reload --allow-net --cert tls/RootCA.pem cafile_ts_fetch.ts",
   output: "cafile_ts_fetch.ts.out",
   http_server: true,
 });
@@ -1721,12 +1680,12 @@ itest_ignore!(cafile_info {
 });
 
 itest!(fix_js_import_js {
-  args: "run --reload fix_js_import_js.ts",
+  args: "run --quiet --reload fix_js_import_js.ts",
   output: "fix_js_import_js.ts.out",
 });
 
 itest!(fix_js_imports {
-  args: "run --reload fix_js_imports.ts",
+  args: "run --quiet --reload fix_js_imports.ts",
   output: "fix_js_imports.ts.out",
 });
 
@@ -2695,7 +2654,6 @@ mod util {
     pub input: Option<&'static str>,
     pub output_str: Option<&'static str>,
     pub exit_code: i32,
-    pub check_stderr: bool,
     pub http_server: bool,
   }
 
@@ -2719,13 +2677,8 @@ mod util {
       command.args(args);
       command.current_dir(&tests_dir);
       command.stdin(Stdio::piped());
-      command.stderr(Stdio::null());
-
-      if self.check_stderr {
-        let writer_clone = writer.try_clone().unwrap();
-        command.stderr(writer_clone);
-      }
-
+      let writer_clone = writer.try_clone().unwrap();
+      command.stderr(writer_clone);
       command.stdout(writer);
 
       let mut process = command.spawn().expect("failed to execute process");


### PR DESCRIPTION
This commit removes "check_stderr" setting from itest! macro used
to generate integration tests. Without this setting on tests discarded
output of stderr making it very hard to debug the problem in test.

Numerous tests were changed by adding "--quiet" flag to not display
"Compile"/"Download" prompts.

Closes #5010
