### PR TITLE
fixed assertThrows throws TypeError when thrown undefined or null

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -51,11 +51,9 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   messages.push("");
   messages.push("");
   messages.push(
-    `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${
-      green(
-        bold("Expected"),
-      )
-    }`,
+    `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${green(
+      bold("Expected")
+    )}`
   );
   messages.push("");
   messages.push("");
@@ -145,7 +143,7 @@ export function assert(expr: unknown, msg = ""): asserts expr {
 export function assertEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string
 ): void {
   if (equal(actual, expected)) {
     return;
@@ -156,7 +154,7 @@ export function assertEquals(
   try {
     const diffResult = diff(
       actualString.split("\n"),
-      expectedString.split("\n"),
+      expectedString.split("\n")
     );
     const diffMsg = buildMessage(diffResult).join("\n");
     message = `Values are not equal:\n${diffMsg}`;
@@ -176,7 +174,7 @@ export function assertEquals(
 export function assertNotEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string
 ): void {
   if (!equal(actual, expected)) {
     return;
@@ -206,7 +204,7 @@ export function assertNotEquals(
 export function assertStrictEq(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string
 ): void {
   if (actual === expected) {
     return;
@@ -225,17 +223,14 @@ export function assertStrictEq(
         .split("\n")
         .map((l) => `     ${l}`)
         .join("\n");
-      message =
-        `Values have the same structure but are not reference-equal:\n\n${
-          red(
-            withOffset,
-          )
-        }\n`;
+      message = `Values have the same structure but are not reference-equal:\n\n${red(
+        withOffset
+      )}\n`;
     } else {
       try {
         const diffResult = diff(
           actualString.split("\n"),
-          expectedString.split("\n"),
+          expectedString.split("\n")
         );
         const diffMsg = buildMessage(diffResult).join("\n");
         message = `Values are not strictly equal:\n${diffMsg}`;
@@ -255,7 +250,7 @@ export function assertStrictEq(
 export function assertStrContains(
   actual: string,
   expected: string,
-  msg?: string,
+  msg?: string
 ): void {
   if (!actual.includes(expected)) {
     if (!msg) {
@@ -272,7 +267,7 @@ export function assertStrContains(
 export function assertArrayContains(
   actual: unknown[],
   expected: unknown[],
-  msg?: string,
+  msg?: string
 ): void {
   const missing: unknown[] = [];
   for (let i = 0; i < expected.length; i++) {
@@ -305,7 +300,7 @@ export function assertArrayContains(
 export function assertMatch(
   actual: string,
   expected: RegExp,
-  msg?: string,
+  msg?: string
 ): void {
   if (!expected.test(actual)) {
     if (!msg) {
@@ -331,7 +326,7 @@ export function assertThrows(
   fn: () => void,
   ErrorClass?: Constructor,
   msgIncludes = "",
-  msg?: string,
+  msg?: string
 ): Error {
   let doesThrow = false;
   let error = null;
@@ -340,21 +335,19 @@ export function assertThrows(
   } catch (e) {
     if (e === undefined || e === null) {
       throw new AssertionError(
-        `Expected error to be defined, but received "${e}"`,
+        `Expected error to be defined, but received "${e}"`
       );
     }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
-      msg =
-        `Expected error to be instance of "${ErrorClass.name}", but was "${e.constructor.name}"${
-          msg ? `: ${msg}` : "."
-        }`;
+      msg = `Expected error to be instance of "${ErrorClass.name}", but was "${
+        e.constructor.name
+      }"${msg ? `: ${msg}` : "."}`;
       throw new AssertionError(msg);
     }
     if (msgIncludes && !e.message.includes(msgIncludes)) {
-      msg =
-        `Expected error message to include "${msgIncludes}", but got "${e.message}"${
-          msg ? `: ${msg}` : "."
-        }`;
+      msg = `Expected error message to include "${msgIncludes}", but got "${
+        e.message
+      }"${msg ? `: ${msg}` : "."}`;
       throw new AssertionError(msg);
     }
     doesThrow = true;
@@ -371,7 +364,7 @@ export async function assertThrowsAsync(
   fn: () => Promise<void>,
   ErrorClass?: Constructor,
   msgIncludes = "",
-  msg?: string,
+  msg?: string
 ): Promise<Error> {
   let doesThrow = false;
   let error = null;
@@ -380,21 +373,19 @@ export async function assertThrowsAsync(
   } catch (e) {
     if (e === undefined || e === null) {
       throw new AssertionError(
-        `Expected error to be defined, but received "${e}"`,
+        `Expected error to be defined, but received "${e}"`
       );
     }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
-      msg =
-        `Expected error to be instance of "${ErrorClass.name}", but got "${e.name}"${
-          msg ? `: ${msg}` : "."
-        }`;
+      msg = `Expected error to be instance of "${ErrorClass.name}", but got "${
+        e.name
+      }"${msg ? `: ${msg}` : "."}`;
       throw new AssertionError(msg);
     }
     if (msgIncludes && !e.message.includes(msgIncludes)) {
-      msg =
-        `Expected error message to include "${msgIncludes}", but got "${e.message}"${
-          msg ? `: ${msg}` : "."
-        }`;
+      msg = `Expected error message to include "${msgIncludes}", but got "${
+        e.message
+      }"${msg ? `: ${msg}` : "."}`;
       throw new AssertionError(msg);
     }
     doesThrow = true;

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -333,7 +333,7 @@ export function assertThrows(
   try {
     fn();
   } catch (e) {
-    if (e === undefined || e === null) {
+    if (ErrorClass && (e === undefined || e === null)) {
       throw new AssertionError(
         `Expected error to be defined, but received "${e}"`
       );
@@ -371,7 +371,7 @@ export async function assertThrowsAsync(
   try {
     await fn();
   } catch (e) {
-    if (e === undefined || e === null) {
+    if (ErrorClass && (e === undefined || e === null)) {
       throw new AssertionError(
         `Expected error to be defined, but received "${e}"`
       );

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -338,6 +338,11 @@ export function assertThrows(
   try {
     fn();
   } catch (e) {
+    if (e === undefined || e === null) {
+      throw new AssertionError(
+        `Expected error to be defined, but received "${e}"`,
+      );
+    }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
       msg =
         `Expected error to be instance of "${ErrorClass.name}", but was "${e.constructor.name}"${
@@ -373,6 +378,11 @@ export async function assertThrowsAsync(
   try {
     await fn();
   } catch (e) {
+    if (e === undefined || e === null) {
+      throw new AssertionError(
+        `Expected error to be defined, but received "${e}"`,
+      );
+    }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
       msg =
         `Expected error to be instance of "${ErrorClass.name}", but got "${e.name}"${

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -51,9 +51,11 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   messages.push("");
   messages.push("");
   messages.push(
-    `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${green(
-      bold("Expected")
-    )}`
+    `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${
+      green(
+        bold("Expected"),
+      )
+    }`,
   );
   messages.push("");
   messages.push("");
@@ -143,7 +145,7 @@ export function assert(expr: unknown, msg = ""): asserts expr {
 export function assertEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string
+  msg?: string,
 ): void {
   if (equal(actual, expected)) {
     return;
@@ -154,7 +156,7 @@ export function assertEquals(
   try {
     const diffResult = diff(
       actualString.split("\n"),
-      expectedString.split("\n")
+      expectedString.split("\n"),
     );
     const diffMsg = buildMessage(diffResult).join("\n");
     message = `Values are not equal:\n${diffMsg}`;
@@ -174,7 +176,7 @@ export function assertEquals(
 export function assertNotEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string
+  msg?: string,
 ): void {
   if (!equal(actual, expected)) {
     return;
@@ -204,7 +206,7 @@ export function assertNotEquals(
 export function assertStrictEq(
   actual: unknown,
   expected: unknown,
-  msg?: string
+  msg?: string,
 ): void {
   if (actual === expected) {
     return;
@@ -223,14 +225,17 @@ export function assertStrictEq(
         .split("\n")
         .map((l) => `     ${l}`)
         .join("\n");
-      message = `Values have the same structure but are not reference-equal:\n\n${red(
-        withOffset
-      )}\n`;
+      message =
+        `Values have the same structure but are not reference-equal:\n\n${
+          red(
+            withOffset,
+          )
+        }\n`;
     } else {
       try {
         const diffResult = diff(
           actualString.split("\n"),
-          expectedString.split("\n")
+          expectedString.split("\n"),
         );
         const diffMsg = buildMessage(diffResult).join("\n");
         message = `Values are not strictly equal:\n${diffMsg}`;
@@ -250,7 +255,7 @@ export function assertStrictEq(
 export function assertStrContains(
   actual: string,
   expected: string,
-  msg?: string
+  msg?: string,
 ): void {
   if (!actual.includes(expected)) {
     if (!msg) {
@@ -267,7 +272,7 @@ export function assertStrContains(
 export function assertArrayContains(
   actual: unknown[],
   expected: unknown[],
-  msg?: string
+  msg?: string,
 ): void {
   const missing: unknown[] = [];
   for (let i = 0; i < expected.length; i++) {
@@ -300,7 +305,7 @@ export function assertArrayContains(
 export function assertMatch(
   actual: string,
   expected: RegExp,
-  msg?: string
+  msg?: string,
 ): void {
   if (!expected.test(actual)) {
     if (!msg) {
@@ -326,7 +331,7 @@ export function assertThrows(
   fn: () => void,
   ErrorClass?: Constructor,
   msgIncludes = "",
-  msg?: string
+  msg?: string,
 ): Error {
   let doesThrow = false;
   let error = null;
@@ -334,15 +339,17 @@ export function assertThrows(
     fn();
   } catch (e) {
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
-      msg = `Expected error to be instance of "${ErrorClass.name}", but was "${
-        e.constructor.name
-      }"${msg ? `: ${msg}` : "."}`;
+      msg =
+        `Expected error to be instance of "${ErrorClass.name}", but was "${e.constructor.name}"${
+          msg ? `: ${msg}` : "."
+        }`;
       throw new AssertionError(msg);
     }
     if (msgIncludes && !e.message.includes(msgIncludes)) {
-      msg = `Expected error message to include "${msgIncludes}", but got "${
-        e.message
-      }"${msg ? `: ${msg}` : "."}`;
+      msg =
+        `Expected error message to include "${msgIncludes}", but got "${e.message}"${
+          msg ? `: ${msg}` : "."
+        }`;
       throw new AssertionError(msg);
     }
     doesThrow = true;
@@ -359,7 +366,7 @@ export async function assertThrowsAsync(
   fn: () => Promise<void>,
   ErrorClass?: Constructor,
   msgIncludes = "",
-  msg?: string
+  msg?: string,
 ): Promise<Error> {
   let doesThrow = false;
   let error = null;
@@ -367,15 +374,17 @@ export async function assertThrowsAsync(
     await fn();
   } catch (e) {
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
-      msg = `Expected error to be instance of "${ErrorClass.name}", but got "${
-        e.name
-      }"${msg ? `: ${msg}` : "."}`;
+      msg =
+        `Expected error to be instance of "${ErrorClass.name}", but got "${e.name}"${
+          msg ? `: ${msg}` : "."
+        }`;
       throw new AssertionError(msg);
     }
     if (msgIncludes && !e.message.includes(msgIncludes)) {
-      msg = `Expected error message to include "${msgIncludes}", but got "${
-        e.message
-      }"${msg ? `: ${msg}` : "."}`;
+      msg =
+        `Expected error message to include "${msgIncludes}", but got "${e.message}"${
+          msg ? `: ${msg}` : "."
+        }`;
       throw new AssertionError(msg);
     }
     doesThrow = true;

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -30,14 +30,14 @@ test("testingEqual", function (): void {
   assert(
     equal(
       { hello: "world", hi: { there: "everyone" } },
-      { hello: "world", hi: { there: "everyone" } },
-    ),
+      { hello: "world", hi: { there: "everyone" } }
+    )
   );
   assert(
     !equal(
       { hello: "world", hi: { there: "everyone" } },
-      { hello: "world", hi: { there: "everyone else" } },
-    ),
+      { hello: "world", hi: { there: "everyone else" } }
+    )
   );
   assert(equal(/deno/, /deno/));
   assert(!equal(/deno/, /node/));
@@ -60,20 +60,20 @@ test("testingEqual", function (): void {
       new Map([
         ["foo", "bar"],
         ["baz", "baz"],
-      ]),
-    ),
+      ])
+    )
   );
   assert(
     equal(
       new Map([["foo", new Map([["bar", "baz"]])]]),
-      new Map([["foo", new Map([["bar", "baz"]])]]),
-    ),
+      new Map([["foo", new Map([["bar", "baz"]])]])
+    )
   );
   assert(
     equal(
       new Map([["foo", { bar: "baz" }]]),
-      new Map([["foo", { bar: "baz" }]]),
-    ),
+      new Map([["foo", { bar: "baz" }]])
+    )
   );
   assert(
     equal(
@@ -84,8 +84,8 @@ test("testingEqual", function (): void {
       new Map([
         ["baz", "qux"],
         ["foo", "bar"],
-      ]),
-    ),
+      ])
+    )
   );
   assert(equal(new Map([["foo", ["bar"]]]), new Map([["foo", ["bar"]]])));
   assert(!equal(new Map([["foo", "bar"]]), new Map([["bar", "baz"]])));
@@ -95,14 +95,14 @@ test("testingEqual", function (): void {
       new Map([
         ["foo", "bar"],
         ["bar", "baz"],
-      ]),
-    ),
+      ])
+    )
   );
   assert(
     !equal(
       new Map([["foo", new Map([["bar", "baz"]])]]),
-      new Map([["foo", new Map([["bar", "qux"]])]]),
-    ),
+      new Map([["foo", new Map([["bar", "qux"]])]])
+    )
   );
   assert(equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 1 }, true]])));
   assert(!equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 1 }, false]])));
@@ -170,7 +170,7 @@ test("testingAssertStringContainsThrow", function (): void {
   } catch (e) {
     assert(
       e.message ===
-        `actual: "Denosaurus from Jurassic" expected to contains: "Raptor"`,
+        `actual: "Denosaurus from Jurassic" expected to contains: "Raptor"`
     );
     assert(e instanceof AssertionError);
     didThrow = true;
@@ -189,7 +189,7 @@ test("testingAssertStringMatchingThrows", function (): void {
   } catch (e) {
     assert(
       e.message ===
-        `actual: "Denosaurus from Jurassic" expected to match: "/Raptor/"`,
+        `actual: "Denosaurus from Jurassic" expected to match: "/Raptor/"`
     );
     assert(e instanceof AssertionError);
     didThrow = true;
@@ -228,7 +228,7 @@ test("testingAssertFail", function (): void {
       fail("foo");
     },
     AssertionError,
-    "Failed assertion: foo",
+    "Failed assertion: foo"
   );
 });
 
@@ -242,22 +242,20 @@ test("testingAssertFailWithWrongErrorClass", function (): void {
           fail("foo");
         },
         Error,
-        "Failed assertion: foo",
+        "Failed assertion: foo"
       );
     },
     AssertionError,
-    `Expected error to be instance of "Error", but was "AssertionError"`,
+    `Expected error to be instance of "Error", but was "AssertionError"`
   );
 });
 
 const createHeader = (): string[] => [
   "",
   "",
-  `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${
-    green(
-      bold("Expected"),
-    )
-  }`,
+  `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${green(
+    bold("Expected")
+  )}`,
   "",
   "",
 ];
@@ -288,7 +286,7 @@ test({
         removed(`-   1`),
         added(`+   2`),
         "",
-      ].join("\n"),
+      ].join("\n")
     );
   },
 });
@@ -304,7 +302,7 @@ test({
         ...createHeader(),
         removed(`-   1`),
         added(`+   "1"`),
-      ].join("\n"),
+      ].join("\n")
     );
   },
 });
@@ -321,7 +319,7 @@ test({
         removed(`-   [ 1, "2", 3 ]`),
         added(`+   [ "1", "2", 3 ]`),
         "",
-      ].join("\n"),
+      ].join("\n")
     );
   },
 });
@@ -338,7 +336,7 @@ test({
         removed(`-   { a: 1, b: "2", c: 3 }`),
         added(`+   { a: 1, b: 2, c: [ 3 ] }`),
         "",
-      ].join("\n"),
+      ].join("\n")
     );
   },
 });
@@ -372,7 +370,7 @@ test({
         removed("-   { a: 1, b: 2 }"),
         added("+   { a: 1, c: [ 3 ] }"),
         "",
-      ].join("\n"),
+      ].join("\n")
     );
   },
 });
@@ -386,7 +384,7 @@ test({
       [
         "Values have the same structure but are not reference-equal:\n",
         red("     { a: 1, b: 2 }"),
-      ].join("\n"),
+      ].join("\n")
     );
   },
 });
@@ -399,14 +397,12 @@ bottomTypeCases.forEach((v) => {
     fn(): void {
       assertThrows(
         (): void => {
-          assertThrows(
-            (): void => {
-              throw v;
-            },
-          );
+          assertThrows((): void => {
+            throw v;
+          });
         },
         AssertionError,
-        `Expected error to be defined, but received "${v}"`,
+        `Expected error to be defined, but received "${v}"`
       );
     },
   });
@@ -416,14 +412,12 @@ bottomTypeCases.forEach((v) => {
     fn() {
       assertThrowsAsync(
         async () => {
-          await assertThrowsAsync(
-            async () => {
-              throw v;
-            },
-          );
+          await assertThrowsAsync(() => {
+            throw v;
+          });
         },
         AssertionError,
-        `Expected error to be defined, but received "${v}"`,
+        `Expected error to be defined, but received "${v}"`
       );
     },
   });

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -14,6 +14,7 @@ import {
   fail,
   unimplemented,
   unreachable,
+  assertThrowsAsync,
 } from "./asserts.ts";
 import { red, green, gray, bold } from "../fmt/colors.ts";
 const { test } = Deno;
@@ -29,14 +30,14 @@ test("testingEqual", function (): void {
   assert(
     equal(
       { hello: "world", hi: { there: "everyone" } },
-      { hello: "world", hi: { there: "everyone" } }
-    )
+      { hello: "world", hi: { there: "everyone" } },
+    ),
   );
   assert(
     !equal(
       { hello: "world", hi: { there: "everyone" } },
-      { hello: "world", hi: { there: "everyone else" } }
-    )
+      { hello: "world", hi: { there: "everyone else" } },
+    ),
   );
   assert(equal(/deno/, /deno/));
   assert(!equal(/deno/, /node/));
@@ -59,20 +60,20 @@ test("testingEqual", function (): void {
       new Map([
         ["foo", "bar"],
         ["baz", "baz"],
-      ])
-    )
+      ]),
+    ),
   );
   assert(
     equal(
       new Map([["foo", new Map([["bar", "baz"]])]]),
-      new Map([["foo", new Map([["bar", "baz"]])]])
-    )
+      new Map([["foo", new Map([["bar", "baz"]])]]),
+    ),
   );
   assert(
     equal(
       new Map([["foo", { bar: "baz" }]]),
-      new Map([["foo", { bar: "baz" }]])
-    )
+      new Map([["foo", { bar: "baz" }]]),
+    ),
   );
   assert(
     equal(
@@ -83,8 +84,8 @@ test("testingEqual", function (): void {
       new Map([
         ["baz", "qux"],
         ["foo", "bar"],
-      ])
-    )
+      ]),
+    ),
   );
   assert(equal(new Map([["foo", ["bar"]]]), new Map([["foo", ["bar"]]])));
   assert(!equal(new Map([["foo", "bar"]]), new Map([["bar", "baz"]])));
@@ -94,14 +95,14 @@ test("testingEqual", function (): void {
       new Map([
         ["foo", "bar"],
         ["bar", "baz"],
-      ])
-    )
+      ]),
+    ),
   );
   assert(
     !equal(
       new Map([["foo", new Map([["bar", "baz"]])]]),
-      new Map([["foo", new Map([["bar", "qux"]])]])
-    )
+      new Map([["foo", new Map([["bar", "qux"]])]]),
+    ),
   );
   assert(equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 1 }, true]])));
   assert(!equal(new Map([[{ x: 1 }, true]]), new Map([[{ x: 1 }, false]])));
@@ -169,7 +170,7 @@ test("testingAssertStringContainsThrow", function (): void {
   } catch (e) {
     assert(
       e.message ===
-        `actual: "Denosaurus from Jurassic" expected to contains: "Raptor"`
+        `actual: "Denosaurus from Jurassic" expected to contains: "Raptor"`,
     );
     assert(e instanceof AssertionError);
     didThrow = true;
@@ -188,7 +189,7 @@ test("testingAssertStringMatchingThrows", function (): void {
   } catch (e) {
     assert(
       e.message ===
-        `actual: "Denosaurus from Jurassic" expected to match: "/Raptor/"`
+        `actual: "Denosaurus from Jurassic" expected to match: "/Raptor/"`,
     );
     assert(e instanceof AssertionError);
     didThrow = true;
@@ -227,7 +228,7 @@ test("testingAssertFail", function (): void {
       fail("foo");
     },
     AssertionError,
-    "Failed assertion: foo"
+    "Failed assertion: foo",
   );
 });
 
@@ -241,20 +242,22 @@ test("testingAssertFailWithWrongErrorClass", function (): void {
           fail("foo");
         },
         Error,
-        "Failed assertion: foo"
+        "Failed assertion: foo",
       );
     },
     AssertionError,
-    `Expected error to be instance of "Error", but was "AssertionError"`
+    `Expected error to be instance of "Error", but was "AssertionError"`,
   );
 });
 
 const createHeader = (): string[] => [
   "",
   "",
-  `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${green(
-    bold("Expected")
-  )}`,
+  `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${
+    green(
+      bold("Expected"),
+    )
+  }`,
   "",
   "",
 ];
@@ -285,7 +288,7 @@ test({
         removed(`-   1`),
         added(`+   2`),
         "",
-      ].join("\n")
+      ].join("\n"),
     );
   },
 });
@@ -301,7 +304,7 @@ test({
         ...createHeader(),
         removed(`-   1`),
         added(`+   "1"`),
-      ].join("\n")
+      ].join("\n"),
     );
   },
 });
@@ -318,7 +321,7 @@ test({
         removed(`-   [ 1, "2", 3 ]`),
         added(`+   [ "1", "2", 3 ]`),
         "",
-      ].join("\n")
+      ].join("\n"),
     );
   },
 });
@@ -335,7 +338,7 @@ test({
         removed(`-   { a: 1, b: "2", c: 3 }`),
         added(`+   { a: 1, b: 2, c: [ 3 ] }`),
         "",
-      ].join("\n")
+      ].join("\n"),
     );
   },
 });
@@ -369,7 +372,7 @@ test({
         removed("-   { a: 1, b: 2 }"),
         added("+   { a: 1, c: [ 3 ] }"),
         "",
-      ].join("\n")
+      ].join("\n"),
     );
   },
 });
@@ -383,7 +386,7 @@ test({
       [
         "Values have the same structure but are not reference-equal:\n",
         red("     { a: 1, b: 2 }"),
-      ].join("\n")
+      ].join("\n"),
     );
   },
 });

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -393,13 +393,31 @@ const bottomTypeCases = [undefined, null];
 
 bottomTypeCases.forEach((v) => {
   test({
-    name: `throw ${v}`,
+    name: `acceptable "${v}"`,
+    fn(): void {
+      assertThrows((): void => {
+        throw v;
+      });
+    },
+  });
+
+  test({
+    name: `async acceptable ${v}`,
+    async fn() {
+      await assertThrowsAsync(() => {
+        throw v;
+      });
+    },
+  });
+
+  test({
+    name: `not acceptable "${v}" if ErrorClass is specified`,
     fn(): void {
       assertThrows(
         (): void => {
           assertThrows((): void => {
             throw v;
-          });
+          }, Error);
         },
         AssertionError,
         `Expected error to be defined, but received "${v}"`
@@ -408,13 +426,13 @@ bottomTypeCases.forEach((v) => {
   });
 
   test({
-    name: `async throw ${v}`,
-    fn() {
-      assertThrowsAsync(
+    name: `async not acceptable ${v} if ErrorClass is specified`,
+    async fn() {
+      await assertThrowsAsync(
         async () => {
           await assertThrowsAsync(() => {
             throw v;
-          });
+          }, Error);
         },
         AssertionError,
         `Expected error to be defined, but received "${v}"`

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -390,3 +390,41 @@ test({
     );
   },
 });
+
+const bottomTypeCases = [undefined, null];
+
+bottomTypeCases.forEach((v) => {
+  test({
+    name: `throw ${v}`,
+    fn(): void {
+      assertThrows(
+        (): void => {
+          assertThrows(
+            (): void => {
+              throw v;
+            },
+          );
+        },
+        AssertionError,
+        `Expected error to be defined, but received "${v}"`,
+      );
+    },
+  });
+
+  test({
+    name: `async throw ${v}`,
+    fn() {
+      assertThrowsAsync(
+        async () => {
+          await assertThrowsAsync(
+            async () => {
+              throw v;
+            },
+          );
+        },
+        AssertionError,
+        `Expected error to be defined, but received "${v}"`,
+      );
+    },
+  });
+});


### PR DESCRIPTION
I fixed assertThrows throws AssertionError when thrown `undefined` or `null`.

## Why

We can now get this error. (assertThrowsAsync will also occur)

```
TypeError: Cannot convert undefined or null to object
    at Function.getPrototypeOf (<anonymous>)
```

I don't know whether `undefined` or `null` was thrown, so I want to be clear.

### reproduce

```typescript
test("throw undefined", () => {
  assertThrows(
    () => {
      throw null; // throw undefined;
    },
    Error
  );
});
```