### PR TITLE
Revert "Fix definition of URL constructor (#5521)"

### DIFF
--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -1172,7 +1172,7 @@ interface URL {
 
 declare const URL: {
   prototype: URL;
-  new (url: string, base?: string | URL): URL;
+  new (url: string | URL, base?: string | URL): URL;
   createObjectURL(object: any): string;
   revokeObjectURL(url: string): void;
 };

--- a/std/path/posix.ts
+++ b/std/path/posix.ts
@@ -430,5 +430,5 @@ export function parse(path: string): ParsedPath {
  * are ignored.
  */
 export function fromFileUrl(url: string | URL): string {
-  return new URL(url.toString()).pathname;
+  return new URL(url).pathname;
 }

--- a/std/path/win32.ts
+++ b/std/path/win32.ts
@@ -908,7 +908,7 @@ export function parse(path: string): ParsedPath {
  * are ignored.
  */
 export function fromFileUrl(url: string | URL): string {
-  return new URL(url.toString()).pathname
+  return new URL(url).pathname
     .replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/")
     .replace(/\//g, "\\");
 }


### PR DESCRIPTION
I landed this change without thinking about it too much. This is an interface change - it actually breaks Oak. We should not land it in the next patch release (1.0.1). I think we should land it in 1.1.0.

This reverts commit 63bc468365bceda929a39b5eb93b605e2dc2bd9c.

cc @3846masa