### PR TITLE
REPL evaluates in strict mode

### DIFF
--- a/cli/js/repl.ts
+++ b/cli/js/repl.ts
@@ -55,9 +55,10 @@ function evaluate(code: string): boolean {
   if (!errInfo) {
     // when a function is eval'ed with just "use strict" sometimes the result
     // is "use strict" which should be discarded
-    lastEvalResult = typeof result === "string" && result === "use strict"
-      ? undefined
-      : result;
+    lastEvalResult =
+      typeof result === "string" && result === "use strict"
+        ? undefined
+        : result;
     if (!isCloseCalled()) {
       replLog(lastEvalResult);
     }

--- a/cli/js/repl.ts
+++ b/cli/js/repl.ts
@@ -49,11 +49,17 @@ let lastThrownError: Value = undefined;
 // Returns true if code is consumed (no error/irrecoverable error).
 // Returns false if error is recoverable
 function evaluate(code: string): boolean {
-  const [result, errInfo] = core.evalContext(code);
+  // each evalContext is a separate function body, and we want strict mode to
+  // work, so we should ensure that the code starts with "use strict"
+  const [result, errInfo] = core.evalContext(`"use strict";\n\n${code}`);
   if (!errInfo) {
-    lastEvalResult = result;
+    // when a function is eval'ed with just "use strict" sometimes the result
+    // is "use strict" which should be discarded
+    lastEvalResult = typeof result === "string" && result === "use strict"
+      ? undefined
+      : result;
     if (!isCloseCalled()) {
-      replLog(result);
+      replLog(lastEvalResult);
     }
   } else if (errInfo.isCompileError && isRecoverableError(errInfo.thrown)) {
     // Recoverable compiler error

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -693,6 +693,25 @@ fn repl_test_eof() {
   assert!(err.is_empty());
 }
 
+#[test]
+fn repl_test_strict() {
+  let (out, err) = util::run_and_collect_output(
+    true,
+    "repl",
+    Some(vec![
+      "let a = {};",
+      "Object.preventExtensions(a);",
+      "a.c = 1;",
+    ]),
+    None,
+    false,
+  );
+  assert!(out.ends_with("undefined\n{}\n"));
+  assert!(err.contains(
+    "Uncaught TypeError: Cannot add property c, object is not extensible"
+  ));
+}
+
 const REPL_MSG: &str = "exit using ctrl+d or close()\n";
 
 #[test]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -695,7 +695,7 @@ fn repl_test_eof() {
 
 #[test]
 fn repl_test_strict() {
-  let (out, err) = util::run_and_collect_output(
+  let (_, err) = util::run_and_collect_output(
     true,
     "repl",
     Some(vec![
@@ -706,10 +706,7 @@ fn repl_test_strict() {
     None,
     false,
   );
-  assert!(out.ends_with("undefined\n{}\n"));
-  assert!(err.contains(
-    "Uncaught TypeError: Cannot add property c, object is not extensible"
-  ));
+  assert!(err.contains("Uncaught TypeError: Cannot add property c, object is not extensible"));
 }
 
 const REPL_MSG: &str = "exit using ctrl+d or close()\n";

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -706,7 +706,9 @@ fn repl_test_strict() {
     None,
     false,
   );
-  assert!(err.contains("Uncaught TypeError: Cannot add property c, object is not extensible"));
+  assert!(err.contains(
+    "Uncaught TypeError: Cannot add property c, object is not extensible"
+  ));
 }
 
 const REPL_MSG: &str = "exit using ctrl+d or close()\n";

--- a/deno_typescript/compiler_main.js
+++ b/deno_typescript/compiler_main.js
@@ -5,6 +5,8 @@
 // understood by the TypeScript language service, so it allows type safety
 // checking in VSCode.
 
+"use strict";
+
 const ASSETS = "$asset$";
 
 /**

--- a/deno_typescript/system_loader.js
+++ b/deno_typescript/system_loader.js
@@ -2,6 +2,8 @@
 
 // This is a specialised implementation of a System module loader.
 
+"use strict";
+
 // @ts-nocheck
 /* eslint-disable */
 let System, __instantiateAsync, __instantiate;


### PR DESCRIPTION
Fixes #5504 

Since everything that Deno loads is treated as an ES Module, it means that all code is treated as `"use strict"` except for when using the REPL.  This PR changes that so code in the REPL is also always evaluated with `"use strict"`.  There are also a couple other places where we load code as scripts which should also use `"use strict"` just in case.