### PR TITLE
FFI support

### DIFF
--- a/cli/js/deno_unstable.ts
+++ b/cli/js/deno_unstable.ts
@@ -24,13 +24,13 @@ export {
   Permissions,
 } from "./permissions.ts";
 export {
+  ForeignType,
   ForeignLibrary,
   ForeignFunctionInfo,
   ForeignFunction,
-  foreignABIs,
-  foreignTypes,
-  readMemory,
-  writeMemory,
+  listForeignABIs,
+  bufferStart,
+  bufferFromPointer,
   loadForeignLibrary,
   loadForeignFunction,
 } from "./ffi.ts";

--- a/cli/js/deno_unstable.ts
+++ b/cli/js/deno_unstable.ts
@@ -23,3 +23,14 @@ export {
   PermissionStatus,
   Permissions,
 } from "./permissions.ts";
+export {
+  ForeignLibrary,
+  ForeignFunctionInfo,
+  ForeignFunction,
+  foreignABIs,
+  foreignTypes,
+  readMemory,
+  writeMemory,
+  loadForeignLibrary,
+  loadForeignFunction,
+} from "./ffi.ts";

--- a/cli/js/ffi.ts
+++ b/cli/js/ffi.ts
@@ -1,0 +1,56 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { Closer } from "./io.ts";
+import { close } from "./ops/resources.ts";
+import { lookup, call } from "./ops/ffi.ts";
+import {
+  loadForeignFunction as opLoadFunction,
+  loadForeignLibrary as opLoadLibrary,
+} from "./ops/ffi.ts";
+import { ForeignFunctionInfo } from "./ops/ffi.ts";
+
+export { readMemory, writeMemory } from "./ops/ffi.ts";
+export { ForeignFunctionInfo } from "./ops/ffi.ts";
+
+export class ForeignLibrary implements Closer {
+  constructor(readonly rid: number) {}
+  lookup(symbol: string): number {
+    return lookup(this.rid, symbol);
+  }
+  close(): void {
+    close(this.rid);
+  }
+}
+
+export class ForeignFunction implements Closer {
+  constructor(readonly rid: number) {}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  call(...args: any[]): any {
+    return call(this.rid, args);
+  }
+  close(): void {
+    close(this.rid);
+  }
+}
+
+// Those should be generated at compile time, but how?
+export const foreignABIs: string[] = [
+  /* TODO */
+];
+export const foreignTypes: string[] = [
+  /* TODO */
+];
+
+export function loadForeignLibrary(path: string | null): ForeignLibrary {
+  const rid = opLoadLibrary(path);
+  return new ForeignLibrary(rid);
+}
+
+export function loadForeignFunction(
+  addr: number,
+  abi: string,
+  info: ForeignFunctionInfo
+): ForeignFunction {
+  const rid = opLoadFunction(addr, abi, info);
+  return new ForeignFunction(rid);
+}

--- a/cli/js/ffi.ts
+++ b/cli/js/ffi.ts
@@ -7,14 +7,12 @@ import {
   loadForeignFunction as opLoadFunction,
   loadForeignLibrary as opLoadLibrary,
 } from "./ops/ffi.ts";
-import { ForeignFunctionInfo } from "./ops/ffi.ts";
-
-export { readMemory, writeMemory } from "./ops/ffi.ts";
-export { ForeignFunctionInfo } from "./ops/ffi.ts";
+import { MemoryAddr, ForeignFunctionInfo } from "./ops/ffi.ts";
+export { MemoryAddr, ForeignFunctionInfo } from "./ops/ffi.ts";
 
 export class ForeignLibrary implements Closer {
   constructor(readonly rid: number) {}
-  lookup(symbol: string): number {
+  lookup(symbol: string): MemoryAddr {
     return lookup(this.rid, symbol);
   }
   close(): void {

--- a/cli/js/ffi.ts
+++ b/cli/js/ffi.ts
@@ -2,17 +2,19 @@
 
 import { Closer } from "./io.ts";
 import { close } from "./ops/resources.ts";
-import { lookup, call } from "./ops/ffi.ts";
 import {
+  lookup,
+  call,
   loadForeignFunction as opLoadFunction,
   loadForeignLibrary as opLoadLibrary,
 } from "./ops/ffi.ts";
-import { MemoryAddr, ForeignFunctionInfo } from "./ops/ffi.ts";
-export { MemoryAddr, ForeignFunctionInfo } from "./ops/ffi.ts";
+export { listForeignABIs, bufferStart, bufferFromPointer } from "./ops/ffi.ts";
+import { ForeignFunctionInfo } from "./ops/ffi.ts";
+export { ForeignType, ForeignFunctionInfo } from "./ops/ffi.ts";
 
 export class ForeignLibrary implements Closer {
   constructor(readonly rid: number) {}
-  lookup(symbol: string): MemoryAddr {
+  lookup(symbol: string): BigInt {
     return lookup(this.rid, symbol);
   }
   close(): void {
@@ -24,20 +26,13 @@ export class ForeignFunction implements Closer {
   constructor(readonly rid: number) {}
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   call(...args: any[]): any {
+    // TODO sanitize and type conversion on call and return
     return call(this.rid, args);
   }
   close(): void {
     close(this.rid);
   }
 }
-
-// Those should be generated at compile time, but how?
-export const foreignABIs: string[] = [
-  /* TODO */
-];
-export const foreignTypes: string[] = [
-  /* TODO */
-];
 
 export function loadForeignLibrary(path: string | null): ForeignLibrary {
   const rid = opLoadLibrary(path);

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1285,79 +1285,76 @@ declare namespace Deno {
    */
   export function loadForeignLibrary(path: string | null): ForeignLibrary;
 
-  export enum ForeignABI {
-    DEFAULT_ABI = "DEFAULT_ABI",
-    AIX = "AIX",
-    ARCOMPACT = "ARCOMPACT",
-    ASM = "ASM",
-    CLOSURES = "CLOSURES",
-    COMPAT = "COMPAT",
-    COMPAT_GCC_SYSV = "COMPAT_GCC_SYSV",
-    COMPAT_LINUX = "COMPAT_LINUX",
-    COMPAT_LINUX_SOFT_FLOAT = "COMPAT_LINUX_SOFT_FLOAT",
-    COMPAT_LINUX64 = "COMPAT_LINUX64",
-    COMPAT_SYSV = "COMPAT_SYSV",
-    DARWIN = "DARWIN",
-    EABI = "EABI",
-    EFI64 = "EFI64",
-    ELFBSD = "ELFBSD",
-    EXTRA_CIF_FIELDS = "EXTRA_CIF_FIELDS",
-    FASTCALL = "FASTCALL",
-    GNUW64 = "GNUW64",
-    GO_CLOSURES = "GO_CLOSURES",
-    LINUX = "LINUX",
-    LINUX_LONG_DOUBLE_128 = "LINUX_LONG_DOUBLE_128",
-    LINUX_LONG_DOUBLE_IEEE128 = "LINUX_LONG_DOUBLE_IEEE128",
-    LINUX_STRUCT_ALIGN = "LINUX_STRUCT_ALIGN",
-    MIPS_O32 = "MIPS_O32",
-    MS_CDECL = "MS_CDECL",
-    N32 = "N32",
-    N32_SOFT_FLOAT = "N32_SOFT_FLOAT",
-    N64 = "N64",
-    N64_SOFT_FLOAT = "N64_SOFT_FLOAT",
-    NATIVE_RAW_API = "NATIVE_RAW_API",
-    O32 = "O32",
-    O32_SOFT_FLOAT = "O32_SOFT_FLOAT",
-    OBSD = "OBSD",
-    OSF = "OSF",
-    PA32 = "PA32",
-    PA64 = "PA64",
-    PASCAL = "PASCAL",
-    PPC_TYPE_LAST = "PPC_TYPE_LAST",
-    REGISTER = "REGISTER",
-    STDCALL = "STDCALL",
-    SYSV = "SYSV",
-    SYSV_IBM_LONG_DOUBLE = "SYSV_IBM_LONG_DOUBLE",
-    SYSV_LONG_DOUBLE_128 = "SYSV_LONG_DOUBLE_128",
-    SYSV_SOFT_FLOAT = "SYSV_SOFT_FLOAT",
-    SYSV_STRUCT_RET = "SYSV_STRUCT_RET",
-    SYSV_TYPE_SMALL_STRUCT = "SYSV_TYPE_SMALL_STRUCT",
-    TARGET_HAS_COMPLEX_TYPE = "TARGET_HAS_COMPLEX_TYPE",
-    TARGET_SPECIFIC_VARIADIC = "TARGET_SPECIFIC_VARIADIC",
-    THISCALL = "THISCALL",
-    TRAMPOLINE_SIZE = "TRAMPOLINE_SIZE",
-    TYPE_LAST = "TYPE_LAST",
-    TYPE_UINT128 = "TYPE_UINT128",
-    UNIX = "UNIX",
-    UNIX64 = "UNIX64",
-    UNUSED_1 = "UNUSED_1",
-    UNUSED_2 = "UNUSED_2",
-    UNUSED_3 = "UNUSED_3",
-    V2_TYPE_DOUBLE_HOMOG = "V2_TYPE_DOUBLE_HOMOG",
-    V2_TYPE_FLOAT_HOMOG = "V2_TYPE_FLOAT_HOMOG",
-    V2_TYPE_SMALL_STRUCT = "V2_TYPE_SMALL_STRUCT",
-    V2_TYPE_VECTOR = "V2_TYPE_VECTOR",
-    V2_TYPE_VECTOR_HOMOG = "V2_TYPE_VECTOR_HOMOG",
-    V8 = "V8",
-    V9 = "V9",
-    VFP = "VFP",
-    WIN64 = "WIN64",
+  export const enum ForeignABI {
+    "DEFAULT_ABI",
+    "AIX",
+    "ARCOMPACT",
+    "ASM",
+    "CLOSURES",
+    "COMPAT",
+    "COMPAT_GCC_SYSV",
+    "COMPAT_LINUX",
+    "COMPAT_LINUX_SOFT_FLOAT",
+    "COMPAT_LINUX64",
+    "COMPAT_SYSV",
+    "DARWIN",
+    "EABI",
+    "EFI64",
+    "ELFBSD",
+    "EXTRA_CIF_FIELDS",
+    "FASTCALL",
+    "GNUW64",
+    "GO_CLOSURES",
+    "LINUX",
+    "LINUX_LONG_DOUBLE_128",
+    "LINUX_LONG_DOUBLE_IEEE128",
+    "LINUX_STRUCT_ALIGN",
+    "MIPS_O32",
+    "MS_CDECL",
+    "N32",
+    "N32_SOFT_FLOAT",
+    "N64",
+    "N64_SOFT_FLOAT",
+    "NATIVE_RAW_API",
+    "O32",
+    "O32_SOFT_FLOAT",
+    "OBSD",
+    "OSF",
+    "PA32",
+    "PA64",
+    "PASCAL",
+    "PPC_TYPE_LAST",
+    "REGISTER",
+    "STDCALL",
+    "SYSV",
+    "SYSV_IBM_LONG_DOUBLE",
+    "SYSV_LONG_DOUBLE_128",
+    "SYSV_SOFT_FLOAT",
+    "SYSV_STRUCT_RET",
+    "SYSV_TYPE_SMALL_STRUCT",
+    "TARGET_HAS_COMPLEX_TYPE",
+    "TARGET_SPECIFIC_VARIADIC",
+    "THISCALL",
+    "TRAMPOLINE_SIZE",
+    "TYPE_LAST",
+    "TYPE_UINT128",
+    "UNIX",
+    "UNIX64",
+    "UNUSED_1",
+    "UNUSED_2",
+    "UNUSED_3",
+    "V2_TYPE_DOUBLE_HOMOG",
+    "V2_TYPE_FLOAT_HOMOG",
+    "V2_TYPE_SMALL_STRUCT",
+    "V2_TYPE_VECTOR",
+    "V2_TYPE_VECTOR_HOMOG",
+    "V8",
+    "V9",
+    "VFP",
+    "WIN64",
   }
 
-  export const availableForeignABI: ForeignType[];
-
-  // no struct, sorry
-  export enum ForeignType {
+  export const enum ForeignType {
     "void",
     "uint8",
     "sint8",
@@ -1376,12 +1373,18 @@ declare namespace Deno {
     "complex_longdouble",
   }
 
-  export const availableForeignType: ForeignType[];
+  export const foreignABIs: ForeignType[];
+  export const foreignTypes: ForeignType[];
 
   export interface ForeignFunctionInfo {
     ret: ForeignType;
     args: ForeignType[];
-    // 0 calls prep_cif_var, and null calls prep_cif (fixed args)
+    /** Number of variadic arguments used to call this function.
+     * Is `numVariadic` is null, all arguments are fixed.
+     * Note: If you need to call the same function with different arguments,
+     * call `loadForeignFunction` with different `numVariadic`. The number of arguments
+     * on any instance of `ForeignFunction` is fixed.
+     */
     numVariadic: number | null;
   }
 
@@ -1407,6 +1410,6 @@ declare namespace Deno {
   export function loadForeignFunction(
     addr: MemoryAddr,
     abi: ForeignABI,
-    info: Partial<ForeignFunctionInfo>
+    info: ForeignFunctionInfo
   ): ForeignFunction;
 }

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1243,13 +1243,19 @@ declare namespace Deno {
    */
   export function hostname(): string;
 
-  /** Return the memory address to the start of the `buffer`.
-   * Requires --allow-ffi. */
-  export function bufferStart(buffer: SharedArrayBuffer): BigInt;
-
-  /** Construct a buffer with access to a fixed chunk of memory.
-   * Requires --allow-ffi. */
-  export function bufferFromPointer(start: BigInt, length: number): SharedArrayBuffer;
+  export type ForeignType =
+    | "void" // nothing
+    | "uint8" // number | BigInt
+    | "sint8" // number | BigInt
+    | "uint16" // number | BigInt
+    | "sint16" // number | BigInt
+    | "uint32" // number | BigInt
+    | "sint32" // number | BigInt
+    | "uint64" // number (unsafe) | BigInt
+    | "sint64" // number (unsafe) | BigInt
+    | "float" // number
+    | "double" // number
+    | "pointer"; // BigInt
 
   /** Symbol table of an executable object, usually a shared library. */
   export class ForeignLibrary implements Closer {
@@ -1266,45 +1272,6 @@ declare namespace Deno {
      */
     close(): void;
   }
-
-  /**
-   * Load an executable object and retuns its symbol table.
-   *
-   * ```ts
-   * Deno.loadForeignLibrary(null); // search in the running executable (deno)
-   * Deno.loadForeignLibrary("libraylib.so"); // search in system paths. Implementation is platform-dependent
-   * Deno.loadForeignLibrary("./libraylib.so"); // load from current directory
-   * Deno.loadForeignLibrary("/usr/lib/libraylib.so"); // load from absolute directory
-   * ```
-   *
-   * Throws `Deno.errors.NotFound` if shared object not found or failed to load.
-   *
-   * Requires --allow-ffi.
-   */
-  export function loadForeignLibrary(path: string | null): ForeignLibrary;
-
-  export const enum ForeignABI {
-    "DEFAULT_ABI",
-  }
-
-  export const enum ForeignType {
-    "void", // nothing
-    "uint8",
-    "sint8",
-    "uint16",
-    "sint16",
-    "uint32",
-    "sint32",
-    "uint64",
-    "sint64",
-    "float",
-    "double",
-    "longdouble",
-    "pointer", // BigInt
-  }
-
-  export const foreignABIs: ForeignType[];
-  export const foreignTypes: ForeignType[];
 
   export interface ForeignFunctionInfo {
     ret: ForeignType;
@@ -1326,6 +1293,36 @@ declare namespace Deno {
     close(): void;
   }
 
+  /** Return all ABI available in this runtime. */
+  export function listForeignABIs(): string[];
+
+  /** Return the memory address to the start of the `buffer`.
+   * Requires --allow-ffi. */
+  export function bufferStart(buffer: SharedArrayBuffer): BigInt;
+
+  /** Construct a buffer with access to a fixed chunk of memory.
+   * Requires --allow-ffi. */
+  export function bufferFromPointer(
+    start: BigInt,
+    length: number
+  ): SharedArrayBuffer;
+
+  /**
+   * Load an executable object and retuns its symbol table.
+   *
+   * ```ts
+   * Deno.loadForeignLibrary(null); // search in the running executable (deno)
+   * Deno.loadForeignLibrary("libraylib.so"); // search in system paths. Implementation is platform-dependent
+   * Deno.loadForeignLibrary("./libraylib.so"); // load from current directory
+   * Deno.loadForeignLibrary("/usr/lib/libraylib.so"); // load from absolute directory
+   * ```
+   *
+   * Throws `Deno.errors.NotFound` if shared object not found or failed to load.
+   *
+   * Requires --allow-ffi.
+   */
+  export function loadForeignLibrary(path: string | null): ForeignLibrary;
+
   /**
    * Load a foreign function from memory.
    *
@@ -1339,7 +1336,7 @@ declare namespace Deno {
    */
   export function loadForeignFunction(
     addr: BigInt,
-    abi: ForeignABI,
+    abi: string,
     info: ForeignFunctionInfo
   ): ForeignFunction;
 }

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1242,4 +1242,65 @@ declare namespace Deno {
    *  Requires `allow-env` permission.
    */
   export function hostname(): string;
+
+  /** A live view of memory */
+  export class MemoryCursor
+    implements
+      Reader,
+      ReaderSync,
+      Writer,
+      WriterSync,
+      Seeker,
+      SeekerSync,
+      Closer {
+    readonly rid: number;
+    constructor(rid: number);
+    write(p: Uint8Array): Promise<number>;
+    writeSync(p: Uint8Array): number;
+    read(p: Uint8Array): Promise<number | null>;
+    readSync(p: Uint8Array): number | null;
+    seek(offset: number, whence: SeekMode): Promise<number>;
+    seekSync(offset: number, whence: SeekMode): number;
+    close(): void;
+  }
+
+  /** Open a live view of memary
+   * 
+   * Requires --allow-ffi.
+   */
+  export function openMemory(start: number, length: number): MemoryCursor;
+
+  /** Symbol table of an executable object, usually a shared library. */
+  export class Library implements Closer {
+    readonly rid: number;
+    constructor(rid: number);
+    /** Look up the reference to a given symbol in this object. 
+     * 
+     * Throws `Deno.errors.NotFound` if symbol not found.
+     */
+    lookup(symbol: string): number;
+    /** Discard the symbol table.
+     * 
+     * Throws `Deno.errors.BadResource` if something unexpected happened.
+     */
+    close(): void;
+  }
+
+  /**
+   * Load an executable object and retuns its symbol table.
+   *
+   * ```ts
+   * Deno.loadLibrary("libm.so"); // search in system paths. Implementation is platform-dependent
+   * Deno.loadLibrary("./libm.so"); // load from current directory
+   * Deno.loadLibrary("/usr/lib/libm.so"); // load from absolute directory
+   * ```
+   *
+   * Throws `Deno.errors.NotFound` if shared object not found or failed to load.
+   *
+   * Requires --allow-ffi.
+   */
+  export function loadLibrary(
+    path: string | null,
+    // options?: Partial<LoadLibraryOptions>
+  ): Promise<Library>;
 }

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1286,18 +1286,103 @@ declare namespace Deno {
   export function loadForeignLibrary(path: string | null): ForeignLibrary;
 
   export enum ForeignABI {
-    // TODO
+    DEFAULT_ABI               = "DEFAULT_ABI",
+    AIX                       = "AIX",
+    ARCOMPACT                 = "ARCOMPACT",
+    ASM                       = "ASM",
+    CLOSURES                  = "CLOSURES",
+    COMPAT                    = "COMPAT",
+    COMPAT_GCC_SYSV           = "COMPAT_GCC_SYSV",
+    COMPAT_LINUX              = "COMPAT_LINUX",
+    COMPAT_LINUX_SOFT_FLOAT   = "COMPAT_LINUX_SOFT_FLOAT",
+    COMPAT_LINUX64            = "COMPAT_LINUX64",
+    COMPAT_SYSV               = "COMPAT_SYSV",
+    DARWIN                    = "DARWIN",
+    EABI                      = "EABI",
+    EFI64                     = "EFI64",
+    ELFBSD                    = "ELFBSD",
+    EXTRA_CIF_FIELDS          = "EXTRA_CIF_FIELDS",
+    FASTCALL                  = "FASTCALL",
+    GNUW64                    = "GNUW64",
+    GO_CLOSURES               = "GO_CLOSURES",
+    LINUX                     = "LINUX",
+    LINUX_LONG_DOUBLE_128     = "LINUX_LONG_DOUBLE_128",
+    LINUX_LONG_DOUBLE_IEEE128 = "LINUX_LONG_DOUBLE_IEEE128",
+    LINUX_STRUCT_ALIGN        = "LINUX_STRUCT_ALIGN",
+    MIPS_O32                  = "MIPS_O32",
+    MS_CDECL                  = "MS_CDECL",
+    N32                       = "N32",
+    N32_SOFT_FLOAT            = "N32_SOFT_FLOAT",
+    N64                       = "N64",
+    N64_SOFT_FLOAT            = "N64_SOFT_FLOAT",
+    NATIVE_RAW_API            = "NATIVE_RAW_API",
+    O32                       = "O32",
+    O32_SOFT_FLOAT            = "O32_SOFT_FLOAT",
+    OBSD                      = "OBSD",
+    OSF                       = "OSF",
+    PA32                      = "PA32",
+    PA64                      = "PA64",
+    PASCAL                    = "PASCAL",
+    PPC_TYPE_LAST             = "PPC_TYPE_LAST",
+    REGISTER                  = "REGISTER",
+    STDCALL                   = "STDCALL",
+    SYSV                      = "SYSV",
+    SYSV_IBM_LONG_DOUBLE      = "SYSV_IBM_LONG_DOUBLE",
+    SYSV_LONG_DOUBLE_128      = "SYSV_LONG_DOUBLE_128",
+    SYSV_SOFT_FLOAT           = "SYSV_SOFT_FLOAT",
+    SYSV_STRUCT_RET           = "SYSV_STRUCT_RET",
+    SYSV_TYPE_SMALL_STRUCT    = "SYSV_TYPE_SMALL_STRUCT",
+    TARGET_HAS_COMPLEX_TYPE   = "TARGET_HAS_COMPLEX_TYPE",
+    TARGET_SPECIFIC_VARIADIC  = "TARGET_SPECIFIC_VARIADIC",
+    THISCALL                  = "THISCALL",
+    TRAMPOLINE_SIZE           = "TRAMPOLINE_SIZE",
+    TYPE_LAST                 = "TYPE_LAST",
+    TYPE_UINT128              = "TYPE_UINT128",
+    UNIX                      = "UNIX",
+    UNIX64                    = "UNIX64",
+    UNUSED_1                  = "UNUSED_1",
+    UNUSED_2                  = "UNUSED_2",
+    UNUSED_3                  = "UNUSED_3",
+    V2_TYPE_DOUBLE_HOMOG      = "V2_TYPE_DOUBLE_HOMOG",
+    V2_TYPE_FLOAT_HOMOG       = "V2_TYPE_FLOAT_HOMOG",
+    V2_TYPE_SMALL_STRUCT      = "V2_TYPE_SMALL_STRUCT",
+    V2_TYPE_VECTOR            = "V2_TYPE_VECTOR",
+    V2_TYPE_VECTOR_HOMOG      = "V2_TYPE_VECTOR_HOMOG",
+    V8                        = "V8",
+    V9                        = "V9",
+    VFP                       = "VFP",
+    WIN64                     = "WIN64",
   }
 
+  export const availableForeignABI: ForeignType[];
+
+  // no struct, sorry
   export enum ForeignType {
-    Default = "default",
-    // TODO
+    "void",
+    "uint8",
+    "sint8",
+    "uint16",
+    "sint16",
+    "uint32",
+    "sint32",
+    "uint64",
+    "sint64",
+    "float",
+    "double",
+    "longdouble",
+    "pointer",
+    "complex_float",
+    "complex_double",
+    "complex_longdouble",
   }
+
+  export const availableForeignType: ForeignType[];
 
   export interface ForeignFunctionInfo {
-    abi: ForeignABI;
+    ret: ForeignType;
     args: ForeignType[];
-    numVariadic?: number;
+    // 0 calls prep_cif_var, and null calls prep_cif (fixed args)
+    numVariadic: number | null;
   }
 
   export class ForeignFunction implements Closer {
@@ -1312,10 +1397,11 @@ declare namespace Deno {
    *
    * ```ts
    * const lib = Deno.loadForeignLibrary("msvcrt.dll")
-   * Deno.loadForeignFunction();
+   * const getch = Deno.loadForeignFunction("getch", Deno.ForeignABI.DEFAULT_ABI, {ret: "void", args: [""]});
+   * console.log(getch.call())
    * ```
    *
    * Requires --allow-ffi.
    */
-  export function loadForeignFunction(addr: MemoryAddr, info: ForeignFunctionInfo): ForeignFunction;
+  export function loadForeignFunction(addr: MemoryAddr, abi: ForeignABI, info: Partial<ForeignFunctionInfo>): ForeignFunction;
 }

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1243,15 +1243,19 @@ declare namespace Deno {
    */
   export function hostname(): string;
 
-  type MemoryAddr = number;
+  /** An opaque pointer */
+  export class MemoryAddr {
+    /** Return the memory address to the start of the `buffer`.
+     * Requires --allow-ffi. */
+    static fromBuffer(buffer: SharedArrayBuffer): MemoryAddr;
 
-  /** Read from an arbitrary chunk of memory
-   * Requires --allow-ffi. */
-  export function readMemory(addr: MemoryAddr, p: Uint8Array): void;
+    /** Construct a buffer with access to a fixed chunk of memory.
+     * Requires --allow-ffi. */
+    toBuffer(length: number): SharedArrayBuffer;
 
-  /** Write to an arbitrary chunk of memory
-   * Requires --allow-ffi. */
-  export function writeMemory(addr: MemoryAddr, p: Uint8Array): void;
+    static fromHex(addr: string): MemoryAddr;
+    toHex(): string;
+  }
 
   /** Symbol table of an executable object, usually a shared library. */
   export class ForeignLibrary implements Closer {

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1257,13 +1257,13 @@ declare namespace Deno {
   export class ForeignLibrary implements Closer {
     readonly rid: number;
     constructor(rid: number);
-    /** Look up the reference to a given symbol in this object. 
-     * 
+    /** Look up the reference to a given symbol in this object.
+     *
      * Throws `Deno.errors.NotFound` if symbol not found.
      */
     lookup(symbol: string): MemoryAddr;
     /** Discard the symbol table.
-     * 
+     *
      * Throws `Deno.errors.BadResource` if something unexpected happened.
      */
     close(): void;
@@ -1286,72 +1286,72 @@ declare namespace Deno {
   export function loadForeignLibrary(path: string | null): ForeignLibrary;
 
   export enum ForeignABI {
-    DEFAULT_ABI               = "DEFAULT_ABI",
-    AIX                       = "AIX",
-    ARCOMPACT                 = "ARCOMPACT",
-    ASM                       = "ASM",
-    CLOSURES                  = "CLOSURES",
-    COMPAT                    = "COMPAT",
-    COMPAT_GCC_SYSV           = "COMPAT_GCC_SYSV",
-    COMPAT_LINUX              = "COMPAT_LINUX",
-    COMPAT_LINUX_SOFT_FLOAT   = "COMPAT_LINUX_SOFT_FLOAT",
-    COMPAT_LINUX64            = "COMPAT_LINUX64",
-    COMPAT_SYSV               = "COMPAT_SYSV",
-    DARWIN                    = "DARWIN",
-    EABI                      = "EABI",
-    EFI64                     = "EFI64",
-    ELFBSD                    = "ELFBSD",
-    EXTRA_CIF_FIELDS          = "EXTRA_CIF_FIELDS",
-    FASTCALL                  = "FASTCALL",
-    GNUW64                    = "GNUW64",
-    GO_CLOSURES               = "GO_CLOSURES",
-    LINUX                     = "LINUX",
-    LINUX_LONG_DOUBLE_128     = "LINUX_LONG_DOUBLE_128",
+    DEFAULT_ABI = "DEFAULT_ABI",
+    AIX = "AIX",
+    ARCOMPACT = "ARCOMPACT",
+    ASM = "ASM",
+    CLOSURES = "CLOSURES",
+    COMPAT = "COMPAT",
+    COMPAT_GCC_SYSV = "COMPAT_GCC_SYSV",
+    COMPAT_LINUX = "COMPAT_LINUX",
+    COMPAT_LINUX_SOFT_FLOAT = "COMPAT_LINUX_SOFT_FLOAT",
+    COMPAT_LINUX64 = "COMPAT_LINUX64",
+    COMPAT_SYSV = "COMPAT_SYSV",
+    DARWIN = "DARWIN",
+    EABI = "EABI",
+    EFI64 = "EFI64",
+    ELFBSD = "ELFBSD",
+    EXTRA_CIF_FIELDS = "EXTRA_CIF_FIELDS",
+    FASTCALL = "FASTCALL",
+    GNUW64 = "GNUW64",
+    GO_CLOSURES = "GO_CLOSURES",
+    LINUX = "LINUX",
+    LINUX_LONG_DOUBLE_128 = "LINUX_LONG_DOUBLE_128",
     LINUX_LONG_DOUBLE_IEEE128 = "LINUX_LONG_DOUBLE_IEEE128",
-    LINUX_STRUCT_ALIGN        = "LINUX_STRUCT_ALIGN",
-    MIPS_O32                  = "MIPS_O32",
-    MS_CDECL                  = "MS_CDECL",
-    N32                       = "N32",
-    N32_SOFT_FLOAT            = "N32_SOFT_FLOAT",
-    N64                       = "N64",
-    N64_SOFT_FLOAT            = "N64_SOFT_FLOAT",
-    NATIVE_RAW_API            = "NATIVE_RAW_API",
-    O32                       = "O32",
-    O32_SOFT_FLOAT            = "O32_SOFT_FLOAT",
-    OBSD                      = "OBSD",
-    OSF                       = "OSF",
-    PA32                      = "PA32",
-    PA64                      = "PA64",
-    PASCAL                    = "PASCAL",
-    PPC_TYPE_LAST             = "PPC_TYPE_LAST",
-    REGISTER                  = "REGISTER",
-    STDCALL                   = "STDCALL",
-    SYSV                      = "SYSV",
-    SYSV_IBM_LONG_DOUBLE      = "SYSV_IBM_LONG_DOUBLE",
-    SYSV_LONG_DOUBLE_128      = "SYSV_LONG_DOUBLE_128",
-    SYSV_SOFT_FLOAT           = "SYSV_SOFT_FLOAT",
-    SYSV_STRUCT_RET           = "SYSV_STRUCT_RET",
-    SYSV_TYPE_SMALL_STRUCT    = "SYSV_TYPE_SMALL_STRUCT",
-    TARGET_HAS_COMPLEX_TYPE   = "TARGET_HAS_COMPLEX_TYPE",
-    TARGET_SPECIFIC_VARIADIC  = "TARGET_SPECIFIC_VARIADIC",
-    THISCALL                  = "THISCALL",
-    TRAMPOLINE_SIZE           = "TRAMPOLINE_SIZE",
-    TYPE_LAST                 = "TYPE_LAST",
-    TYPE_UINT128              = "TYPE_UINT128",
-    UNIX                      = "UNIX",
-    UNIX64                    = "UNIX64",
-    UNUSED_1                  = "UNUSED_1",
-    UNUSED_2                  = "UNUSED_2",
-    UNUSED_3                  = "UNUSED_3",
-    V2_TYPE_DOUBLE_HOMOG      = "V2_TYPE_DOUBLE_HOMOG",
-    V2_TYPE_FLOAT_HOMOG       = "V2_TYPE_FLOAT_HOMOG",
-    V2_TYPE_SMALL_STRUCT      = "V2_TYPE_SMALL_STRUCT",
-    V2_TYPE_VECTOR            = "V2_TYPE_VECTOR",
-    V2_TYPE_VECTOR_HOMOG      = "V2_TYPE_VECTOR_HOMOG",
-    V8                        = "V8",
-    V9                        = "V9",
-    VFP                       = "VFP",
-    WIN64                     = "WIN64",
+    LINUX_STRUCT_ALIGN = "LINUX_STRUCT_ALIGN",
+    MIPS_O32 = "MIPS_O32",
+    MS_CDECL = "MS_CDECL",
+    N32 = "N32",
+    N32_SOFT_FLOAT = "N32_SOFT_FLOAT",
+    N64 = "N64",
+    N64_SOFT_FLOAT = "N64_SOFT_FLOAT",
+    NATIVE_RAW_API = "NATIVE_RAW_API",
+    O32 = "O32",
+    O32_SOFT_FLOAT = "O32_SOFT_FLOAT",
+    OBSD = "OBSD",
+    OSF = "OSF",
+    PA32 = "PA32",
+    PA64 = "PA64",
+    PASCAL = "PASCAL",
+    PPC_TYPE_LAST = "PPC_TYPE_LAST",
+    REGISTER = "REGISTER",
+    STDCALL = "STDCALL",
+    SYSV = "SYSV",
+    SYSV_IBM_LONG_DOUBLE = "SYSV_IBM_LONG_DOUBLE",
+    SYSV_LONG_DOUBLE_128 = "SYSV_LONG_DOUBLE_128",
+    SYSV_SOFT_FLOAT = "SYSV_SOFT_FLOAT",
+    SYSV_STRUCT_RET = "SYSV_STRUCT_RET",
+    SYSV_TYPE_SMALL_STRUCT = "SYSV_TYPE_SMALL_STRUCT",
+    TARGET_HAS_COMPLEX_TYPE = "TARGET_HAS_COMPLEX_TYPE",
+    TARGET_SPECIFIC_VARIADIC = "TARGET_SPECIFIC_VARIADIC",
+    THISCALL = "THISCALL",
+    TRAMPOLINE_SIZE = "TRAMPOLINE_SIZE",
+    TYPE_LAST = "TYPE_LAST",
+    TYPE_UINT128 = "TYPE_UINT128",
+    UNIX = "UNIX",
+    UNIX64 = "UNIX64",
+    UNUSED_1 = "UNUSED_1",
+    UNUSED_2 = "UNUSED_2",
+    UNUSED_3 = "UNUSED_3",
+    V2_TYPE_DOUBLE_HOMOG = "V2_TYPE_DOUBLE_HOMOG",
+    V2_TYPE_FLOAT_HOMOG = "V2_TYPE_FLOAT_HOMOG",
+    V2_TYPE_SMALL_STRUCT = "V2_TYPE_SMALL_STRUCT",
+    V2_TYPE_VECTOR = "V2_TYPE_VECTOR",
+    V2_TYPE_VECTOR_HOMOG = "V2_TYPE_VECTOR_HOMOG",
+    V8 = "V8",
+    V9 = "V9",
+    VFP = "VFP",
+    WIN64 = "WIN64",
   }
 
   export const availableForeignABI: ForeignType[];
@@ -1388,6 +1388,7 @@ declare namespace Deno {
   export class ForeignFunction implements Closer {
     readonly rid: number;
     constructor(rid: number);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     call(...args: any[]): any;
     close(): void;
   }
@@ -1403,5 +1404,9 @@ declare namespace Deno {
    *
    * Requires --allow-ffi.
    */
-  export function loadForeignFunction(addr: MemoryAddr, abi: ForeignABI, info: Partial<ForeignFunctionInfo>): ForeignFunction;
+  export function loadForeignFunction(
+    addr: MemoryAddr,
+    abi: ForeignABI,
+    info: Partial<ForeignFunctionInfo>
+  ): ForeignFunction;
 }

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1290,9 +1290,9 @@ declare namespace Deno {
    * Load an executable object and retuns its symbol table.
    *
    * ```ts
-   * Deno.loadLibrary("libm.so"); // search in system paths. Implementation is platform-dependent
-   * Deno.loadLibrary("./libm.so"); // load from current directory
-   * Deno.loadLibrary("/usr/lib/libm.so"); // load from absolute directory
+   * Deno.loadLibrary("libraylib.so"); // search in system paths. Implementation is platform-dependent
+   * Deno.loadLibrary("./libraylib.so"); // load from current directory
+   * Deno.loadLibrary("/usr/lib/libraylib.so"); // load from absolute directory
    * ```
    *
    * Throws `Deno.errors.NotFound` if shared object not found or failed to load.

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1243,19 +1243,13 @@ declare namespace Deno {
    */
   export function hostname(): string;
 
-  /** An opaque pointer */
-  export class MemoryAddr {
-    /** Return the memory address to the start of the `buffer`.
-     * Requires --allow-ffi. */
-    static fromBuffer(buffer: SharedArrayBuffer): MemoryAddr;
+  /** Return the memory address to the start of the `buffer`.
+   * Requires --allow-ffi. */
+  export function bufferStart(buffer: SharedArrayBuffer): BigInt;
 
-    /** Construct a buffer with access to a fixed chunk of memory.
-     * Requires --allow-ffi. */
-    toBuffer(length: number): SharedArrayBuffer;
-
-    static fromHex(addr: string): MemoryAddr;
-    toHex(): string;
-  }
+  /** Construct a buffer with access to a fixed chunk of memory.
+   * Requires --allow-ffi. */
+  export function bufferFromPointer(start: BigInt, length: number): SharedArrayBuffer;
 
   /** Symbol table of an executable object, usually a shared library. */
   export class ForeignLibrary implements Closer {
@@ -1265,7 +1259,7 @@ declare namespace Deno {
      *
      * Throws `Deno.errors.NotFound` if symbol not found.
      */
-    lookup(symbol: string): MemoryAddr;
+    lookup(symbol: string): BigInt;
     /** Discard the symbol table.
      *
      * Throws `Deno.errors.BadResource` if something unexpected happened.
@@ -1291,75 +1285,10 @@ declare namespace Deno {
 
   export const enum ForeignABI {
     "DEFAULT_ABI",
-    "AIX",
-    "ARCOMPACT",
-    "ASM",
-    "CLOSURES",
-    "COMPAT",
-    "COMPAT_GCC_SYSV",
-    "COMPAT_LINUX",
-    "COMPAT_LINUX_SOFT_FLOAT",
-    "COMPAT_LINUX64",
-    "COMPAT_SYSV",
-    "DARWIN",
-    "EABI",
-    "EFI64",
-    "ELFBSD",
-    "EXTRA_CIF_FIELDS",
-    "FASTCALL",
-    "GNUW64",
-    "GO_CLOSURES",
-    "LINUX",
-    "LINUX_LONG_DOUBLE_128",
-    "LINUX_LONG_DOUBLE_IEEE128",
-    "LINUX_STRUCT_ALIGN",
-    "MIPS_O32",
-    "MS_CDECL",
-    "N32",
-    "N32_SOFT_FLOAT",
-    "N64",
-    "N64_SOFT_FLOAT",
-    "NATIVE_RAW_API",
-    "O32",
-    "O32_SOFT_FLOAT",
-    "OBSD",
-    "OSF",
-    "PA32",
-    "PA64",
-    "PASCAL",
-    "PPC_TYPE_LAST",
-    "REGISTER",
-    "STDCALL",
-    "SYSV",
-    "SYSV_IBM_LONG_DOUBLE",
-    "SYSV_LONG_DOUBLE_128",
-    "SYSV_SOFT_FLOAT",
-    "SYSV_STRUCT_RET",
-    "SYSV_TYPE_SMALL_STRUCT",
-    "TARGET_HAS_COMPLEX_TYPE",
-    "TARGET_SPECIFIC_VARIADIC",
-    "THISCALL",
-    "TRAMPOLINE_SIZE",
-    "TYPE_LAST",
-    "TYPE_UINT128",
-    "UNIX",
-    "UNIX64",
-    "UNUSED_1",
-    "UNUSED_2",
-    "UNUSED_3",
-    "V2_TYPE_DOUBLE_HOMOG",
-    "V2_TYPE_FLOAT_HOMOG",
-    "V2_TYPE_SMALL_STRUCT",
-    "V2_TYPE_VECTOR",
-    "V2_TYPE_VECTOR_HOMOG",
-    "V8",
-    "V9",
-    "VFP",
-    "WIN64",
   }
 
   export const enum ForeignType {
-    "void",
+    "void", // nothing
     "uint8",
     "sint8",
     "uint16",
@@ -1371,10 +1300,7 @@ declare namespace Deno {
     "float",
     "double",
     "longdouble",
-    "pointer",
-    "complex_float",
-    "complex_double",
-    "complex_longdouble",
+    "pointer", // BigInt
   }
 
   export const foreignABIs: ForeignType[];
@@ -1412,7 +1338,7 @@ declare namespace Deno {
    * Requires --allow-ffi.
    */
   export function loadForeignFunction(
-    addr: MemoryAddr,
+    addr: BigInt,
     abi: ForeignABI,
     info: ForeignFunctionInfo
   ): ForeignFunction;

--- a/cli/js/ops/ffi.ts
+++ b/cli/js/ops/ffi.ts
@@ -2,54 +2,34 @@
 
 import { sendSync } from "./dispatch_json.ts";
 
-export function lookup(rid: number, symbol: string): MemoryAddr {
-  // TODO return MemoryAddr
-  return sendSync("op_dlsym", {
-    rid,
-    symbol,
-  });
+export function loadForeignLibrary(path: string | null): number {
+  const rid = sendSync("op_dlopen", { path });
+  return rid;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function call(rid: number, args: any[]): any {
-  return sendSync("op_ffi_call", {
-    rid,
-    args,
-  });
+export function lookup(rid: number, symbol: string): BigInt {
+  const addr: string = sendSync("op_dlsym", { rid, symbol });
+  return BigInt(addr);
 }
 
-/** An opaque pointer */
-export class MemoryAddr {
-  /** Return the memory address to the start of the `buffer`.
-   * Requires --allow-ffi. */
-  static fromBuffer(buffer: SharedArrayBuffer): MemoryAddr {
-    // TODO implement this
-  }
-
-  /** Construct a buffer with access to a fixed chunk of memory.
-   * Requires --allow-ffi. */
-  toBuffer(length: number): SharedArrayBuffer {
-    // TODO implement this
-  }
-
-  static fromHex(addr: string): MemoryAddr {
-    // TODO implement this
-  }
-  toHex(): string {
-    // TODO implement this
-  }
-}
+export type ForeignType =
+  | "void"
+  | "uint8"
+  | "sint8"
+  | "uint16"
+  | "sint16"
+  | "uint32"
+  | "sint32"
+  | "uint64"
+  | "sint64"
+  | "float"
+  | "double"
+  | "pointer";
 
 export interface ForeignFunctionInfo {
-  ret: string;
-  args: string[];
+  ret: ForeignType;
+  args: ForeignType[];
   numVariadic: number | null;
-}
-
-export function loadForeignLibrary(path: string | null): number {
-  return sendSync("op_dlopen", {
-    path,
-  });
 }
 
 export function loadForeignFunction(
@@ -57,9 +37,30 @@ export function loadForeignFunction(
   abi: string,
   info: ForeignFunctionInfo
 ): number {
-  return sendSync("op_ffi_prep_cif", {
-    addr,
-    abi,
-    ...info,
-  });
+  const rid = sendSync("op_ffi_prep", { addr, abi, ...info });
+  return rid;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function call(rid: number, args: any[]): any {
+  // TODO BigInt can't fit in JSON
+  // return sendSync("op_ffi_call", {
+  //   rid,
+  //   args,
+  // });
+}
+
+export function listForeignABIs(): string[] {
+  return sendSync("op_ffi_list_abi");
+}
+
+export function bufferStart(buffer: SharedArrayBuffer): BigInt {
+  // TODO how to implement this with op?
+}
+
+export function bufferFromPointer(
+  start: BigInt,
+  length: number
+): SharedArrayBuffer {
+  // TODO how to implement this with op?
 }

--- a/cli/js/ops/ffi.ts
+++ b/cli/js/ops/ffi.ts
@@ -2,7 +2,8 @@
 
 import { sendSync } from "./dispatch_json.ts";
 
-export function lookup(rid: number, symbol: string): number {
+export function lookup(rid: number, symbol: string): MemoryAddr {
+  // TODO return MemoryAddr
   return sendSync("op_dlsym", {
     rid,
     symbol,
@@ -17,12 +18,26 @@ export function call(rid: number, args: any[]): any {
   });
 }
 
-export function readMemory(addr: number, p: Uint8Array): void {
-  // TODO implement this
-}
+/** An opaque pointer */
+export class MemoryAddr {
+  /** Return the memory address to the start of the `buffer`.
+   * Requires --allow-ffi. */
+  static fromBuffer(buffer: SharedArrayBuffer): MemoryAddr {
+    // TODO implement this
+  }
 
-export function writeMemory(addr: number, p: Uint8Array): void {
-  // TODO implement this
+  /** Construct a buffer with access to a fixed chunk of memory.
+   * Requires --allow-ffi. */
+  toBuffer(length: number): SharedArrayBuffer {
+    // TODO implement this
+  }
+
+  static fromHex(addr: string): MemoryAddr {
+    // TODO implement this
+  }
+  toHex(): string {
+    // TODO implement this
+  }
 }
 
 export interface ForeignFunctionInfo {

--- a/cli/js/ops/ffi.ts
+++ b/cli/js/ops/ffi.ts
@@ -17,11 +17,11 @@ export function call(rid: number, args: any[]): any {
   });
 }
 
-export function readMemory(addr: MemoryAddr, p: Uint8Array): void {
+export function readMemory(addr: number, p: Uint8Array): void {
   // TODO implement this
 }
 
-export function writeMemory(addr: MemoryAddr, p: Uint8Array): void {
+export function writeMemory(addr: number, p: Uint8Array): void {
   // TODO implement this
 }
 

--- a/cli/js/ops/ffi.ts
+++ b/cli/js/ops/ffi.ts
@@ -1,0 +1,50 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { sendSync } from "./dispatch_json.ts";
+
+export function lookup(rid: number, symbol: string): number {
+  return sendSync("op_dlsym", {
+    rid,
+    symbol,
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function call(rid: number, args: any[]): any {
+  return sendSync("op_ffi_call", {
+    rid,
+    args,
+  });
+}
+
+export function readMemory(addr: MemoryAddr, p: Uint8Array): void {
+  // TODO implement this
+}
+
+export function writeMemory(addr: MemoryAddr, p: Uint8Array): void {
+  // TODO implement this
+}
+
+export interface ForeignFunctionInfo {
+  ret: string;
+  args: string[];
+  numVariadic: number | null;
+}
+
+export function loadForeignLibrary(path: string | null): number {
+  return sendSync("op_dlopen", {
+    path,
+  });
+}
+
+export function loadForeignFunction(
+  addr: number,
+  abi: string,
+  info: ForeignFunctionInfo
+): number {
+  return sendSync("op_ffi_prep_cif", {
+    addr,
+    abi,
+    ...info,
+  });
+}

--- a/tools/enum_ffi_abi.ts
+++ b/tools/enum_ffi_abi.ts
@@ -1,0 +1,33 @@
+/** Enumerate all ABIs of all architechures
+ * Usage: deno run --unstable --allow-read tools/enum_ffi_abi.ts path/to/libffi/src
+ */
+
+import {walkSync, readFileStrSync} from "https://deno.land/std/fs/mod.ts"
+import {basename} from "https://deno.land/std/path/mod.ts"
+
+const allABI = new Set()
+
+for (const entry of walkSync(Deno.args[0])) {
+    if (basename(entry.path) === "ffitarget.h") {
+        const content = readFileStrSync(entry.path)
+        const match = /typedef enum ffi_abi\s+\{(.*)\}/s.exec(content)
+        if (match) {
+            for (const line of match[1].trim().split('\n')) {
+                const match = /FFI_\w+/.exec(line)
+                if (match) {
+                    allABI.add(match[0])
+                }
+            }
+        } else {
+            console.error(`Invalid format: ${entry.path}`)
+        }
+
+    }
+}
+
+allABI.delete("FFI_FIRST_ABI")
+allABI.delete("FFI_LAST_ABI")
+
+for (const abi of allABI) {
+    console.log(abi)
+}

--- a/tools/enum_ffi_abi.ts
+++ b/tools/enum_ffi_abi.ts
@@ -2,32 +2,31 @@
  * Usage: deno run --unstable --allow-read tools/enum_ffi_abi.ts path/to/libffi/src
  */
 
-import {walkSync, readFileStrSync} from "https://deno.land/std/fs/mod.ts"
-import {basename} from "https://deno.land/std/path/mod.ts"
+import { walkSync, readFileStrSync } from "https://deno.land/std/fs/mod.ts";
+import { basename } from "https://deno.land/std/path/mod.ts";
 
-const allABI = new Set()
+const allABI = new Set();
 
 for (const entry of walkSync(Deno.args[0])) {
-    if (basename(entry.path) === "ffitarget.h") {
-        const content = readFileStrSync(entry.path)
-        const match = /typedef enum ffi_abi\s+\{(.*)\}/s.exec(content)
+  if (basename(entry.path) === "ffitarget.h") {
+    const content = readFileStrSync(entry.path);
+    const match = /typedef enum ffi_abi\s+\{(.*)\}/s.exec(content);
+    if (match) {
+      for (const line of match[1].trim().split("\n")) {
+        const match = /FFI_\w+/.exec(line);
         if (match) {
-            for (const line of match[1].trim().split('\n')) {
-                const match = /FFI_\w+/.exec(line)
-                if (match) {
-                    allABI.add(match[0])
-                }
-            }
-        } else {
-            console.error(`Invalid format: ${entry.path}`)
+          allABI.add(match[0]);
         }
-
+      }
+    } else {
+      console.error(`Invalid format: ${entry.path}`);
     }
+  }
 }
 
-allABI.delete("FFI_FIRST_ABI")
-allABI.delete("FFI_LAST_ABI")
+allABI.delete("FFI_FIRST_ABI");
+allABI.delete("FFI_LAST_ABI");
 
 for (const abi of allABI) {
-    console.log(abi)
+  console.log(abi);
 }


### PR DESCRIPTION
The foreign function interface of Deno should allow code to call functions from shared library with native ABI. The Deno runtime should not segfault the program by itself, but the external library may. 

FFI is inherently unsafe. 

Capability: `--allow-ffi`.

We also need https://tootallnate.github.io/ref/ to manage memory addresses and pointers.

## Prior Art

[Python](https://docs.python.org/3/library/ctypes.html): 
```python
from ctypes import cdll
library = cdll.LoadLibrary("libraylib.so")
library.BeginDrawing()

from ctypes import windll
print(windll.kernel32)  
```

[Go](https://golang.org/cmd/cgo/#hdr-Go_references_to_C):
```go
package main

// typedef int (*intFunc) ();
//
// int
// bridge_int_func(intFunc f)
// {
//		return f();
// }
//
// int fortytwo()
// {
//	    return 42;
// }
import "C"
import "fmt"

func main() {
	f := C.intFunc(C.fortytwo)
	fmt.Println(int(C.bridge_int_func(f)))
	// Output: 42
}
```

Node (thrid-party [node-ffi](https://github.com/node-ffi/node-ffi)):
```
var ffi = require('ffi');

var libm = ffi.Library('libm', {
  'ceil': [ 'double', [ 'double' ] ]
});
libm.ceil(1.5); // 2

// You can also access just functions in the current process by passing a null
var current = ffi.Library(null, {
  'atoi': [ 'int', [ 'string' ] ]
});
current.atoi('1234'); // 1234
```

[LuaJIT](https://luajit.org/ext_ffi.html):
```lua
local ffi = require("ffi")
ffi.cdef[[
int printf(const char *fmt, ...);
]]
ffi.C.printf("Hello %s!", "world")
```

Rust: `extern` keyword

## Questions

- Can a pointer fit inside `number`?
- Can we make a ArrayBuffer represent the whole memory?
- `dlclose` can run code. Should `Library.close` require `--allow-ffi`?
- How to allow reading data from symbols without random memory access?
- How to allow calling foreign functions without ret2libc? That will make `--allow-ffi=path` actually useful.
- Should we make `--allow-ffi` whitelist certain paths even if allowing the program to load any external executable means arbitrary code execution?

## Related issues

#5551 