### PR TITLE
Fix typo in documentation

### DIFF
--- a/std/encoding/README.md
+++ b/std/encoding/README.md
@@ -29,7 +29,7 @@ writeVarbig(w: Deno.Writer, x: bigint, o: VarbigOptions = {}): Promise<number>
 
 ## CSV
 
-- **`parseCsv(input: string | BufReader, opt: ParseCsvOptions): Promise<unknown[]>`**:
+- **`parse(input: string | BufReader, opt: ParseCsvOptions): Promise<unknown[]>`**:
   Read the string/buffer into an
 
 ### Usage
@@ -38,7 +38,7 @@ writeVarbig(w: Deno.Writer, x: bigint, o: VarbigOptions = {}): Promise<number>
 const string = "a,b,c\nd,e,f";
 
 console.log(
-  await parseCsv(string, {
+  await parse(string, {
     header: false,
   })
 );


### PR DESCRIPTION
parseCsv doesn't exist. There is only parse method. I think it is documentation mistake.

Edit: I think first sentence is a bit harsh so I extend with reason.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
