### PR TITLE
feat: Add isUrl in std/_util

### DIFF
--- a/std/_util/is_url.ts
+++ b/std/_util/is_url.ts
@@ -1,0 +1,11 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+/** isUrl checks if a url is valid */
+export function isURl(url: string){
+  try {
+    new URL(url)
+    return true
+  }  catch {
+    return false
+  }
+ }

--- a/std/_util/is_url_test.ts
+++ b/std/_util/is_url_test.ts
@@ -1,0 +1,14 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+const { test } = Deno;
+import { isURL } from "./is_url.ts"
+import { assert } from "../testing/asserts.ts"
+
+test("isUrl", function(): void {
+  assert(isURL("https://example.com"))
+  assert(isURL("https://localhost:4000"))
+  assert(isURL("https://localhost"))
+  assert(isURL("postgres://user:postgres@example.com:5432/database"))
+  assert(!isURL("https://"))
+  assert(!isURL("example"))
+  assert(!isURL("example.com"))
+})


### PR DESCRIPTION
# Reasoning
I found is_url package here -
https://deno.land/x/is_url/mod.ts

I think it should be a common enough operation to add. It is a similar convenient utility in https://deno.land/std/encoding/utf8.ts

As for the relative path checking, may I add an is_relative_path?



