### PR TITLE
fix: disable test using 019_media_types

### DIFF
--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -487,6 +487,9 @@ mod tests {
     Ok(graph_loader.get_graph())
   }
 
+  // TODO(bartlomieju): this test is flaky, because it's using 019_media_types
+  // file, reenable once Python server is replaced with Rust one.
+  #[ignore]
   #[tokio::test]
   async fn source_graph_fetch() {
     let http_server_guard = crate::test_util::http_server();


### PR DESCRIPTION
This commit disabled flaky test in cli/module_graph.rs.

The test uses 019_media_types.ts which was known to be flaky
for some time. Test should be reenabled once test HTTP server
is rewritten to Rust.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
