### PR TITLE
added bytes/hasSuffix

### DIFF
--- a/std/bytes/mod.ts
+++ b/std/bytes/mod.ts
@@ -62,6 +62,14 @@ export function hasPrefix(a: Uint8Array, prefix: Uint8Array): boolean {
   return true;
 }
 
+/** Check whether binary array has binary suffix  **/
+export function hasSuffix(a: Uint8Array, suffix: Uint8Array): boolean {
+  return (
+    a.length >= suffix.length &&
+    equal(a.slice(a.length - suffix.length), suffix)
+  );
+}
+
 /**
  * Repeat bytes. returns a new byte slice consisting of `count` copies of `b`.
  * @param b The origin bytes

--- a/std/bytes/test.ts
+++ b/std/bytes/test.ts
@@ -7,6 +7,7 @@ import {
   hasPrefix,
   repeat,
   concat,
+  hasSuffix,
 } from "./mod.ts";
 import { assertEquals, assertThrows, assert } from "../testing/asserts.ts";
 import { encode, decode } from "../encoding/utf8.ts";
@@ -44,6 +45,11 @@ Deno.test("[bytes] equal", () => {
 
 Deno.test("[bytes] hasPrefix", () => {
   const v = hasPrefix(new Uint8Array([0, 1, 2]), new Uint8Array([0, 1]));
+  assertEquals(v, true);
+});
+
+Deno.test("[bytes] hasSuffix", () => {
+  const v = hasSuffix(new Uint8Array([0, 1, 2]), new Uint8Array([1, 2]));
   assertEquals(v, true);
 });
 


### PR DESCRIPTION
I added `hasSuffix` in bytes module.

In another PR, I would also like to fix the hasPrefix logic to a non for-loop implementation
