### PR TITLE
fix(std/node) fs.close

### DIFF
--- a/std/node/_fs/_fs_close.ts
+++ b/std/node/_fs/_fs_close.ts
@@ -6,7 +6,7 @@ export function close(fd: number, callback: CallbackWithError): void {
   queueMicrotask(() => {
     try {
       Deno.close(fd);
-      callback();
+      callback(null);
     } catch (err) {
       callback(err);
     }

--- a/std/node/_fs/_fs_close.ts
+++ b/std/node/_fs/_fs_close.ts
@@ -3,20 +3,14 @@
 import { CallbackWithError } from "./_fs_common.ts";
 
 export function close(fd: number, callback: CallbackWithError): void {
-  new Promise((resolve, reject) => {
+  queueMicrotask(() => {
     try {
       Deno.close(fd);
-      resolve();
-    } catch (err) {
-      reject(err);
-    }
-  })
-    .then(() => {
       callback();
-    })
-    .catch((err) => {
+    } catch (err) {
       callback(err);
-    });
+    }
+  });
 }
 
 export function closeSync(fd: number): void {

--- a/std/node/_fs/_fs_close_test.ts
+++ b/std/node/_fs/_fs_close_test.ts
@@ -12,7 +12,7 @@ test({
     assert(Deno.resources()[file.rid]);
     await new Promise((resolve, reject) => {
       close(file.rid, (err) => {
-        if (err) reject();
+        if (err !== null) reject();
         else resolve();
       });
     })

--- a/std/node/_fs/_fs_close_test.ts
+++ b/std/node/_fs/_fs_close_test.ts
@@ -29,6 +29,26 @@ test({
 });
 
 test({
+  name: "close callback should be asynchronous",
+  async fn() {
+    const tempFile: string = Deno.makeTempFileSync();
+    const file: Deno.File = Deno.openSync(tempFile);
+
+    let foo: string;
+    const promise = new Promise((resolve) => {
+      close(file.rid, () => {
+        assert(foo === "bar");
+        resolve();
+      });
+      foo = "bar";
+    });
+
+    await promise;
+    Deno.removeSync(tempFile);
+  },
+});
+
+test({
   name: "SYNC: File is closed",
   fn() {
     const tempFile: string = Deno.makeTempFileSync();

--- a/std/node/_fs/_fs_close_test.ts
+++ b/std/node/_fs/_fs_close_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 const { test } = Deno;
-import { fail, assert } from "../../testing/asserts.ts";
+import { fail, assert, assertThrows } from "../../testing/asserts.ts";
 import { close, closeSync } from "./_fs_close.ts";
 
 test({
@@ -25,6 +25,18 @@ test({
       .finally(async () => {
         await Deno.remove(tempFile);
       });
+  },
+});
+
+test({
+  name: "ASYNC: Invalid fd",
+  async fn() {
+    await new Promise((resolve, reject) => {
+      close(-1, (err) => {
+        if (err !== null) return resolve();
+        reject();
+      });
+    });
   },
 });
 
@@ -58,5 +70,12 @@ test({
     closeSync(file.rid);
     assert(!Deno.resources()[file.rid]);
     Deno.removeSync(tempFile);
+  },
+});
+
+test({
+  name: "SYNC: Invalid fd",
+  fn() {
+    assertThrows(() => closeSync(-1));
   },
 });


### PR DESCRIPTION
- `error` should be `null` if no error occurred
- Cleanup
- Added test 