### PR TITLE
std/node: fs.writeFile/sync path can now be an URL

### DIFF
--- a/std/node/_fs/_fs_writeFile.ts
+++ b/std/node/_fs/_fs_writeFile.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { notImplemented } from "../_utils.ts";
+import { fromFileUrl } from "../path.ts";
 
 import {
   WriteFileOptions,
@@ -10,7 +11,7 @@ import {
 } from "./_fs_common.ts";
 
 export function writeFile(
-  pathOrRid: string | number,
+  pathOrRid: string | number | URL,
   data: string | Uint8Array,
   optOrCallback: string | CallbackWithError | WriteFileOptions | undefined,
   callback?: CallbackWithError
@@ -23,6 +24,8 @@ export function writeFile(
   if (!callbackFn) {
     throw new TypeError("Callback must be a function.");
   }
+
+  pathOrRid = pathOrRid instanceof URL ? fromFileUrl(pathOrRid) : pathOrRid;
 
   const flag: string | undefined = isFileOptions(options)
     ? options.flag
@@ -65,10 +68,12 @@ export function writeFile(
 }
 
 export function writeFileSync(
-  pathOrRid: string | number,
+  pathOrRid: string | number | URL,
   data: string | Uint8Array,
   options?: string | WriteFileOptions
 ): void {
+  pathOrRid = pathOrRid instanceof URL ? fromFileUrl(pathOrRid) : pathOrRid;
+
   const flag: string | undefined = isFileOptions(options)
     ? options.flag
     : undefined;

--- a/std/node/_fs/_fs_writeFile_test.ts
+++ b/std/node/_fs/_fs_writeFile_test.ts
@@ -164,7 +164,12 @@ test("Data is written to correct file", async function testCorrectWriteUsingPath
 
 test("Path can be an URL", async function testCorrectWriteUsingURL() {
   const url = new URL(
-    "file://" + path.join(testDataDir, "_fs_writeFile_test_file_url.txt")
+    Deno.build.os === "windows"
+      ? "file:///" +
+        path
+          .join(testDataDir, "_fs_writeFile_test_file_url.txt")
+          .replace(/\\/g, "/")
+      : "file://" + path.join(testDataDir, "_fs_writeFile_test_file_url.txt")
   );
   const filePath = path.fromFileUrl(url);
   const res = await new Promise((resolve) => {
@@ -248,7 +253,11 @@ test("sync: Path can be an URL", function testCorrectWriteSyncUsingURL() {
     testDataDir,
     "_fs_writeFileSync_test_file_url.txt"
   );
-  const url = new URL("file://" + filePath);
+  const url = new URL(
+    Deno.build.os === "windows"
+      ? "file:///" + filePath.replace(/\\/g, "/")
+      : "file://" + filePath
+  );
   writeFileSync(url, "hello world");
 
   const data = Deno.readFileSync(filePath);

--- a/std/node/_fs/_fs_writeFile_test.ts
+++ b/std/node/_fs/_fs_writeFile_test.ts
@@ -8,7 +8,10 @@ import {
   assertThrows,
 } from "../../testing/asserts.ts";
 import { writeFile, writeFileSync } from "./_fs_writeFile.ts";
+import * as path from "../../path/mod.ts";
 
+const dirname = new URL(".", import.meta.url).pathname;
+const testDataDir = path.join(dirname, "testdata");
 const decoder = new TextDecoder("utf-8");
 
 test("Callback must be a function error", function fn() {
@@ -160,6 +163,20 @@ test("Data is written to correct file", async function testCorrectWriteUsingPath
   assertEquals(decoder.decode(data), "hello world");
 });
 
+test("Path can be an URL", async function testCorrectWriteUsingURL() {
+  const filePath = path.join(testDataDir, "_fs_writeFile_test_file_url.txt");
+  const url = new URL("file://" + filePath);
+  const res = await new Promise((resolve) => {
+    writeFile(url, "hello world", resolve);
+  });
+  assert(res === null);
+
+  const data = await Deno.readFile(filePath);
+  await Deno.remove(filePath);
+  assertEquals(res, null);
+  assertEquals(decoder.decode(data), "hello world");
+});
+
 test("Mode is correctly set", async function testCorrectFileMode() {
   if (Deno.build.os === "windows") return;
   const filename = "_fs_writeFile_test_file.txt";
@@ -222,6 +239,19 @@ test("Data is written synchronously to correct file", function testCorrectWriteS
 
   const data = Deno.readFileSync(file);
   Deno.removeSync(file);
+  assertEquals(decoder.decode(data), "hello world");
+});
+
+test("sync: Path can be an URL", function testCorrectWriteSyncUsingURL() {
+  const filePath = path.join(
+    testDataDir,
+    "_fs_writeFileSync_test_file_url.txt"
+  );
+  const url = new URL("file://" + filePath);
+  writeFileSync(url, "hello world");
+
+  const data = Deno.readFileSync(filePath);
+  Deno.removeSync(filePath);
   assertEquals(decoder.decode(data), "hello world");
 });
 

--- a/std/node/_fs/_fs_writeFile_test.ts
+++ b/std/node/_fs/_fs_writeFile_test.ts
@@ -10,8 +10,7 @@ import {
 import { writeFile, writeFileSync } from "./_fs_writeFile.ts";
 import * as path from "../../path/mod.ts";
 
-const dirname = new URL(".", import.meta.url).pathname;
-const testDataDir = path.join(dirname, "testdata");
+const testDataDir = path.resolve(path.join("node", "_fs", "testdata"));
 const decoder = new TextDecoder("utf-8");
 
 test("Callback must be a function error", function fn() {

--- a/std/node/_fs/_fs_writeFile_test.ts
+++ b/std/node/_fs/_fs_writeFile_test.ts
@@ -163,8 +163,10 @@ test("Data is written to correct file", async function testCorrectWriteUsingPath
 });
 
 test("Path can be an URL", async function testCorrectWriteUsingURL() {
-  const filePath = path.join(testDataDir, "_fs_writeFile_test_file_url.txt");
-  const url = new URL("file://" + filePath);
+  const url = new URL(
+    "file://" + path.join(testDataDir, "_fs_writeFile_test_file_url.txt")
+  );
+  const filePath = path.fromFileUrl(url);
   const res = await new Promise((resolve) => {
     writeFile(url, "hello world", resolve);
   });

--- a/std/node/_fs/promises/_fs_writeFile.ts
+++ b/std/node/_fs/promises/_fs_writeFile.ts
@@ -4,7 +4,7 @@ import { WriteFileOptions } from "../_fs_common.ts";
 import { writeFile as writeFileCallback } from "../_fs_writeFile.ts";
 
 export function writeFile(
-  pathOrRid: string | number,
+  pathOrRid: string | number | URL,
   data: string | Uint8Array,
   options?: string | WriteFileOptions
 ): Promise<void> {


### PR DESCRIPTION
[`fs.writeFile` ](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback)/ `fs.writeFileSync`, `fs.promises.writeFile` can now take an URL as path.