### PR TITLE
Migrate from dprint-ignore to deno-fmt-ignore

### DIFF
--- a/std/hash/sha1_test.ts
+++ b/std/hash/sha1_test.ts
@@ -18,7 +18,7 @@ function toHexString(value: number[] | ArrayBuffer): string {
 }
 
 // prettier-ignore
-// dprint-ignore
+// deno-fmt-ignore
 const fixtures: {
   sha1: Record<string, Record<string, Message>>;
 } = {
@@ -75,10 +75,9 @@ for (const method of methods) {
         fn() {
           const algorithm = new Sha1();
           algorithm.update(message);
-          const actual =
-            method === "hex"
-              ? algorithm[method]()
-              : toHexString(algorithm[method]());
+          const actual = method === "hex"
+            ? algorithm[method]()
+            : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });
@@ -95,10 +94,9 @@ for (const method of methods) {
         fn() {
           const algorithm = new Sha1(true);
           algorithm.update(message);
-          const actual =
-            method === "hex"
-              ? algorithm[method]()
-              : toHexString(algorithm[method]());
+          const actual = method === "hex"
+            ? algorithm[method]()
+            : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });

--- a/std/hash/sha1_test.ts
+++ b/std/hash/sha1_test.ts
@@ -75,9 +75,10 @@ for (const method of methods) {
         fn() {
           const algorithm = new Sha1();
           algorithm.update(message);
-          const actual = method === "hex"
-            ? algorithm[method]()
-            : toHexString(algorithm[method]());
+          const actual =
+            method === "hex"
+              ? algorithm[method]()
+              : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });
@@ -94,9 +95,10 @@ for (const method of methods) {
         fn() {
           const algorithm = new Sha1(true);
           algorithm.update(message);
-          const actual = method === "hex"
-            ? algorithm[method]()
-            : toHexString(algorithm[method]());
+          const actual =
+            method === "hex"
+              ? algorithm[method]()
+              : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });

--- a/std/hash/sha256.ts
+++ b/std/hash/sha256.ts
@@ -15,7 +15,7 @@ const HEX_CHARS = "0123456789abcdef".split("");
 const EXTRA = [-2147483648, 8388608, 32768, 128] as const;
 const SHIFT = [24, 16, 8, 0] as const;
 // prettier-ignore
-// dprint-ignore
+// deno-fmt-ignore
 const K = [
   0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
   0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
@@ -58,7 +58,9 @@ export class Sha256 {
 
   protected init(is224: boolean, sharedMemory: boolean): void {
     if (sharedMemory) {
-      blocks[0] = blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] = blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+      blocks[0] = blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] =
+        blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] =
+          blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
       this.#blocks = blocks;
     } else {
       this.#blocks = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -116,7 +118,9 @@ export class Sha256 {
       if (this.#hashed) {
         this.#hashed = false;
         blocks[0] = this.#block;
-        blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] = blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+        blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] =
+          blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] =
+            blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
       }
 
       if (typeof msg !== "string") {
@@ -136,8 +140,7 @@ export class Sha256 {
             blocks[i >> 2] |= (0x80 | ((code >> 6) & 0x3f)) << SHIFT[i++ & 3];
             blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
           } else {
-            code =
-              0x10000 +
+            code = 0x10000 +
               (((code & 0x3ff) << 10) | (msg.charCodeAt(++index) & 0x3ff));
             blocks[i >> 2] |= (0xf0 | (code >> 18)) << SHIFT[i++ & 3];
             blocks[i >> 2] |= (0x80 | ((code >> 12) & 0x3f)) << SHIFT[i++ & 3];
@@ -180,7 +183,9 @@ export class Sha256 {
         this.hash();
       }
       blocks[0] = this.#block;
-      blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] = blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+      blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] =
+        blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] =
+          blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
     }
     blocks[14] = (this.#hBytes << 3) | (this.#bytes >>> 29);
     blocks[15] = this.#bytes << 3;
@@ -213,8 +218,8 @@ export class Sha256 {
       t1 = blocks[j - 15];
       s0 = ((t1 >>> 7) | (t1 << 25)) ^ ((t1 >>> 18) | (t1 << 14)) ^ (t1 >>> 3);
       t1 = blocks[j - 2];
-      s1 =
-        ((t1 >>> 17) | (t1 << 15)) ^ ((t1 >>> 19) | (t1 << 13)) ^ (t1 >>> 10);
+      s1 = ((t1 >>> 17) | (t1 << 15)) ^ ((t1 >>> 19) | (t1 << 13)) ^
+        (t1 >>> 10);
       blocks[j] = (blocks[j - 16] + s0 + blocks[j - 7] + s1) << 0;
     }
 
@@ -234,12 +239,10 @@ export class Sha256 {
         }
         this.#first = false;
       } else {
-        s0 =
-          ((a >>> 2) | (a << 30)) ^
+        s0 = ((a >>> 2) | (a << 30)) ^
           ((a >>> 13) | (a << 19)) ^
           ((a >>> 22) | (a << 10));
-        s1 =
-          ((e >>> 6) | (e << 26)) ^
+        s1 = ((e >>> 6) | (e << 26)) ^
           ((e >>> 11) | (e << 21)) ^
           ((e >>> 25) | (e << 7));
         ab = a & b;
@@ -250,12 +253,10 @@ export class Sha256 {
         h = (d + t1) << 0;
         d = (t1 + t2) << 0;
       }
-      s0 =
-        ((d >>> 2) | (d << 30)) ^
+      s0 = ((d >>> 2) | (d << 30)) ^
         ((d >>> 13) | (d << 19)) ^
         ((d >>> 22) | (d << 10));
-      s1 =
-        ((h >>> 6) | (h << 26)) ^
+      s1 = ((h >>> 6) | (h << 26)) ^
         ((h >>> 11) | (h << 21)) ^
         ((h >>> 25) | (h << 7));
       da = d & a;
@@ -265,12 +266,10 @@ export class Sha256 {
       t2 = s0 + maj;
       g = (c + t1) << 0;
       c = (t1 + t2) << 0;
-      s0 =
-        ((c >>> 2) | (c << 30)) ^
+      s0 = ((c >>> 2) | (c << 30)) ^
         ((c >>> 13) | (c << 19)) ^
         ((c >>> 22) | (c << 10));
-      s1 =
-        ((g >>> 6) | (g << 26)) ^
+      s1 = ((g >>> 6) | (g << 26)) ^
         ((g >>> 11) | (g << 21)) ^
         ((g >>> 25) | (g << 7));
       cd = c & d;
@@ -280,12 +279,10 @@ export class Sha256 {
       t2 = s0 + maj;
       f = (b + t1) << 0;
       b = (t1 + t2) << 0;
-      s0 =
-        ((b >>> 2) | (b << 30)) ^
+      s0 = ((b >>> 2) | (b << 30)) ^
         ((b >>> 13) | (b << 19)) ^
         ((b >>> 22) | (b << 10));
-      s1 =
-        ((f >>> 6) | (f << 26)) ^
+      s1 = ((f >>> 6) | (f << 26)) ^
         ((f >>> 11) | (f << 21)) ^
         ((f >>> 25) | (f << 7));
       bc = b & c;
@@ -320,8 +317,7 @@ export class Sha256 {
     const h6 = this.#h6;
     const h7 = this.#h7;
 
-    let hex =
-      HEX_CHARS[(h0 >> 28) & 0x0f] +
+    let hex = HEX_CHARS[(h0 >> 28) & 0x0f] +
       HEX_CHARS[(h0 >> 24) & 0x0f] +
       HEX_CHARS[(h0 >> 20) & 0x0f] +
       HEX_CHARS[(h0 >> 16) & 0x0f] +
@@ -378,8 +374,7 @@ export class Sha256 {
       HEX_CHARS[(h6 >> 4) & 0x0f] +
       HEX_CHARS[h6 & 0x0f];
     if (!this.#is224) {
-      hex +=
-        HEX_CHARS[(h7 >> 28) & 0x0f] +
+      hex += HEX_CHARS[(h7 >> 28) & 0x0f] +
         HEX_CHARS[(h7 >> 24) & 0x0f] +
         HEX_CHARS[(h7 >> 20) & 0x0f] +
         HEX_CHARS[(h7 >> 16) & 0x0f] +
@@ -444,7 +439,7 @@ export class Sha256 {
         (h7 >> 24) & 0xff,
         (h7 >> 16) & 0xff,
         (h7 >> 8) & 0xff,
-        h7 & 0xff
+        h7 & 0xff,
       );
     }
     return arr;
@@ -501,8 +496,7 @@ export class HmacSha256 extends Sha256 {
           bytes[index++] = 0x80 | ((code >> 6) & 0x3f);
           bytes[index++] = 0x80 | (code & 0x3f);
         } else {
-          code =
-            0x10000 +
+          code = 0x10000 +
             (((code & 0x3ff) << 10) | (secretKey.charCodeAt(++i) & 0x3ff));
           bytes[index++] = 0xf0 | (code >> 18);
           bytes[index++] = 0x80 | ((code >> 12) & 0x3f);

--- a/std/hash/sha256.ts
+++ b/std/hash/sha256.ts
@@ -58,9 +58,7 @@ export class Sha256 {
 
   protected init(is224: boolean, sharedMemory: boolean): void {
     if (sharedMemory) {
-      blocks[0] = blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] =
-        blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] =
-          blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+      blocks[0] = blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] = blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
       this.#blocks = blocks;
     } else {
       this.#blocks = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -118,9 +116,7 @@ export class Sha256 {
       if (this.#hashed) {
         this.#hashed = false;
         blocks[0] = this.#block;
-        blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] =
-          blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] =
-            blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+        blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] = blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
       }
 
       if (typeof msg !== "string") {
@@ -140,7 +136,8 @@ export class Sha256 {
             blocks[i >> 2] |= (0x80 | ((code >> 6) & 0x3f)) << SHIFT[i++ & 3];
             blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
           } else {
-            code = 0x10000 +
+            code =
+              0x10000 +
               (((code & 0x3ff) << 10) | (msg.charCodeAt(++index) & 0x3ff));
             blocks[i >> 2] |= (0xf0 | (code >> 18)) << SHIFT[i++ & 3];
             blocks[i >> 2] |= (0x80 | ((code >> 12) & 0x3f)) << SHIFT[i++ & 3];
@@ -183,9 +180,7 @@ export class Sha256 {
         this.hash();
       }
       blocks[0] = this.#block;
-      blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] =
-        blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] =
-          blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+      blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] = blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
     }
     blocks[14] = (this.#hBytes << 3) | (this.#bytes >>> 29);
     blocks[15] = this.#bytes << 3;
@@ -218,8 +213,8 @@ export class Sha256 {
       t1 = blocks[j - 15];
       s0 = ((t1 >>> 7) | (t1 << 25)) ^ ((t1 >>> 18) | (t1 << 14)) ^ (t1 >>> 3);
       t1 = blocks[j - 2];
-      s1 = ((t1 >>> 17) | (t1 << 15)) ^ ((t1 >>> 19) | (t1 << 13)) ^
-        (t1 >>> 10);
+      s1 =
+        ((t1 >>> 17) | (t1 << 15)) ^ ((t1 >>> 19) | (t1 << 13)) ^ (t1 >>> 10);
       blocks[j] = (blocks[j - 16] + s0 + blocks[j - 7] + s1) << 0;
     }
 
@@ -239,10 +234,12 @@ export class Sha256 {
         }
         this.#first = false;
       } else {
-        s0 = ((a >>> 2) | (a << 30)) ^
+        s0 =
+          ((a >>> 2) | (a << 30)) ^
           ((a >>> 13) | (a << 19)) ^
           ((a >>> 22) | (a << 10));
-        s1 = ((e >>> 6) | (e << 26)) ^
+        s1 =
+          ((e >>> 6) | (e << 26)) ^
           ((e >>> 11) | (e << 21)) ^
           ((e >>> 25) | (e << 7));
         ab = a & b;
@@ -253,10 +250,12 @@ export class Sha256 {
         h = (d + t1) << 0;
         d = (t1 + t2) << 0;
       }
-      s0 = ((d >>> 2) | (d << 30)) ^
+      s0 =
+        ((d >>> 2) | (d << 30)) ^
         ((d >>> 13) | (d << 19)) ^
         ((d >>> 22) | (d << 10));
-      s1 = ((h >>> 6) | (h << 26)) ^
+      s1 =
+        ((h >>> 6) | (h << 26)) ^
         ((h >>> 11) | (h << 21)) ^
         ((h >>> 25) | (h << 7));
       da = d & a;
@@ -266,10 +265,12 @@ export class Sha256 {
       t2 = s0 + maj;
       g = (c + t1) << 0;
       c = (t1 + t2) << 0;
-      s0 = ((c >>> 2) | (c << 30)) ^
+      s0 =
+        ((c >>> 2) | (c << 30)) ^
         ((c >>> 13) | (c << 19)) ^
         ((c >>> 22) | (c << 10));
-      s1 = ((g >>> 6) | (g << 26)) ^
+      s1 =
+        ((g >>> 6) | (g << 26)) ^
         ((g >>> 11) | (g << 21)) ^
         ((g >>> 25) | (g << 7));
       cd = c & d;
@@ -279,10 +280,12 @@ export class Sha256 {
       t2 = s0 + maj;
       f = (b + t1) << 0;
       b = (t1 + t2) << 0;
-      s0 = ((b >>> 2) | (b << 30)) ^
+      s0 =
+        ((b >>> 2) | (b << 30)) ^
         ((b >>> 13) | (b << 19)) ^
         ((b >>> 22) | (b << 10));
-      s1 = ((f >>> 6) | (f << 26)) ^
+      s1 =
+        ((f >>> 6) | (f << 26)) ^
         ((f >>> 11) | (f << 21)) ^
         ((f >>> 25) | (f << 7));
       bc = b & c;
@@ -317,7 +320,8 @@ export class Sha256 {
     const h6 = this.#h6;
     const h7 = this.#h7;
 
-    let hex = HEX_CHARS[(h0 >> 28) & 0x0f] +
+    let hex =
+      HEX_CHARS[(h0 >> 28) & 0x0f] +
       HEX_CHARS[(h0 >> 24) & 0x0f] +
       HEX_CHARS[(h0 >> 20) & 0x0f] +
       HEX_CHARS[(h0 >> 16) & 0x0f] +
@@ -374,7 +378,8 @@ export class Sha256 {
       HEX_CHARS[(h6 >> 4) & 0x0f] +
       HEX_CHARS[h6 & 0x0f];
     if (!this.#is224) {
-      hex += HEX_CHARS[(h7 >> 28) & 0x0f] +
+      hex +=
+        HEX_CHARS[(h7 >> 28) & 0x0f] +
         HEX_CHARS[(h7 >> 24) & 0x0f] +
         HEX_CHARS[(h7 >> 20) & 0x0f] +
         HEX_CHARS[(h7 >> 16) & 0x0f] +
@@ -439,7 +444,7 @@ export class Sha256 {
         (h7 >> 24) & 0xff,
         (h7 >> 16) & 0xff,
         (h7 >> 8) & 0xff,
-        h7 & 0xff,
+        h7 & 0xff
       );
     }
     return arr;
@@ -496,7 +501,8 @@ export class HmacSha256 extends Sha256 {
           bytes[index++] = 0x80 | ((code >> 6) & 0x3f);
           bytes[index++] = 0x80 | (code & 0x3f);
         } else {
-          code = 0x10000 +
+          code =
+            0x10000 +
             (((code & 0x3ff) << 10) | (secretKey.charCodeAt(++i) & 0x3ff));
           bytes[index++] = 0xf0 | (code >> 18);
           bytes[index++] = 0x80 | ((code >> 12) & 0x3f);

--- a/std/hash/sha256_test.ts
+++ b/std/hash/sha256_test.ts
@@ -227,9 +227,10 @@ for (const method of methods) {
         fn() {
           const algorithm = new Sha256();
           algorithm.update(message);
-          const actual = method === "hex"
-            ? algorithm[method]()
-            : toHexString(algorithm[method]());
+          const actual =
+            method === "hex"
+              ? algorithm[method]()
+              : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });
@@ -246,9 +247,10 @@ for (const method of methods) {
         fn() {
           const algorithm = new Sha256(true);
           algorithm.update(message);
-          const actual = method === "hex"
-            ? algorithm[method]()
-            : toHexString(algorithm[method]());
+          const actual =
+            method === "hex"
+              ? algorithm[method]()
+              : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });
@@ -265,9 +267,10 @@ for (const method of methods) {
         fn() {
           const algorithm = new HmacSha256(key);
           algorithm.update(message);
-          const actual = method === "hex"
-            ? algorithm[method]()
-            : toHexString(algorithm[method]());
+          const actual =
+            method === "hex"
+              ? algorithm[method]()
+              : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });
@@ -284,9 +287,10 @@ for (const method of methods) {
         fn() {
           const algorithm = new HmacSha256(key, true);
           algorithm.update(message);
-          const actual = method === "hex"
-            ? algorithm[method]()
-            : toHexString(algorithm[method]());
+          const actual =
+            method === "hex"
+              ? algorithm[method]()
+              : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });
@@ -300,6 +304,6 @@ test("[hash/sha256] test Uint8Array from Reader", async () => {
   const hash = new Sha256().update(data).hex();
   assertEquals(
     hash,
-    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
   );
 });

--- a/std/hash/sha256_test.ts
+++ b/std/hash/sha256_test.ts
@@ -19,7 +19,7 @@ function toHexString(value: number[] | ArrayBuffer): string {
 }
 
 // prettier-ignore
-// dprint-ignore
+// deno-fmt-ignore
 const fixtures: {
   sha256: Record<string, Record<string, Message>>;
   sha224: Record<string, Record<string, Message>>;
@@ -158,35 +158,35 @@ const fixtures: {
 };
 
 // prettier-ignore
-// dprint-ignore
+// deno-fmt-ignore
 fixtures.sha256.Uint8Array = {
   '182889f925ae4e5cc37118ded6ed87f7bdc7cab5ec5e78faef2e50048999473f': new Uint8Array([211, 212]),
   'd7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592': new Uint8Array([84, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 32, 106, 117, 109, 112, 115, 32, 111, 118, 101, 114, 32, 116, 104, 101, 32, 108, 97, 122, 121, 32, 100, 111, 103])
 };
 // prettier-ignore
-// dprint-ignore
+// deno-fmt-ignore
 fixtures.sha256.Int8Array = {
   'd7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592': new Int8Array([84, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 32, 106, 117, 109, 112, 115, 32, 111, 118, 101, 114, 32, 116, 104, 101, 32, 108, 97, 122, 121, 32, 100, 111, 103])
 };
 // prettier-ignore
-// dprint-ignore
+// deno-fmt-ignore
 fixtures.sha256.ArrayBuffer = {
   'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855': new ArrayBuffer(0),
   '6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d': new ArrayBuffer(1)
 };
 // prettier-ignore
-// dprint-ignore
+// deno-fmt-ignore
 fixtures.sha224.Uint8Array = {
   'e17541396a3ecd1cd5a2b968b84e597e8eae3b0ea3127963bf48dd3b': new Uint8Array([211, 212]),
   '730e109bd7a8a32b1cb9d9a09aa2325d2430587ddbc0c38bad911525': new Uint8Array([84, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 32, 106, 117, 109, 112, 115, 32, 111, 118, 101, 114, 32, 116, 104, 101, 32, 108, 97, 122, 121, 32, 100, 111, 103])    
 };
 // prettier-ignore
-// dprint-ignore
+// deno-fmt-ignore
 fixtures.sha224.Int8Array = {
   '730e109bd7a8a32b1cb9d9a09aa2325d2430587ddbc0c38bad911525': new Int8Array([84, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 32, 106, 117, 109, 112, 115, 32, 111, 118, 101, 114, 32, 116, 104, 101, 32, 108, 97, 122, 121, 32, 100, 111, 103])
 };
 // prettier-ignore
-// dprint-ignore
+// deno-fmt-ignore
 fixtures.sha224.ArrayBuffer = {
   'd14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f': new ArrayBuffer(0),
   'fff9292b4201617bdc4d3053fce02734166a683d7d858a7f5f59b073': new ArrayBuffer(1),
@@ -227,10 +227,9 @@ for (const method of methods) {
         fn() {
           const algorithm = new Sha256();
           algorithm.update(message);
-          const actual =
-            method === "hex"
-              ? algorithm[method]()
-              : toHexString(algorithm[method]());
+          const actual = method === "hex"
+            ? algorithm[method]()
+            : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });
@@ -247,10 +246,9 @@ for (const method of methods) {
         fn() {
           const algorithm = new Sha256(true);
           algorithm.update(message);
-          const actual =
-            method === "hex"
-              ? algorithm[method]()
-              : toHexString(algorithm[method]());
+          const actual = method === "hex"
+            ? algorithm[method]()
+            : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });
@@ -267,10 +265,9 @@ for (const method of methods) {
         fn() {
           const algorithm = new HmacSha256(key);
           algorithm.update(message);
-          const actual =
-            method === "hex"
-              ? algorithm[method]()
-              : toHexString(algorithm[method]());
+          const actual = method === "hex"
+            ? algorithm[method]()
+            : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });
@@ -287,10 +284,9 @@ for (const method of methods) {
         fn() {
           const algorithm = new HmacSha256(key, true);
           algorithm.update(message);
-          const actual =
-            method === "hex"
-              ? algorithm[method]()
-              : toHexString(algorithm[method]());
+          const actual = method === "hex"
+            ? algorithm[method]()
+            : toHexString(algorithm[method]());
           assertEquals(actual, expected);
         },
       });
@@ -304,6 +300,6 @@ test("[hash/sha256] test Uint8Array from Reader", async () => {
   const hash = new Sha256().update(data).hex();
   assertEquals(
     hash,
-    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
   );
 });


### PR DESCRIPTION
The latest version of `dprint` supports a custom ignore string, which @dsherret set to `deno-fmt-ignore`, so for `deno fmt` we need to migrate to `// deno-fmt-ignore`.

I don't know if there is any docs we need to update or not...