### PR TITLE
Export TextDecoder and TextEncoder from std/node/util.ts

### DIFF
--- a/std/node/_utils.ts
+++ b/std/node/_utils.ts
@@ -3,6 +3,12 @@ export function notImplemented(msg?: string): never {
   throw new Error(message);
 }
 
+export type _TextDecoder = typeof TextDecoder.prototype;
+export const _TextDecoder = TextDecoder;
+
+export type _TextEncoder = typeof TextEncoder.prototype;
+export const _TextEncoder = TextEncoder;
+
 // API helpers
 
 export type MaybeNull<T> = T | null;

--- a/std/node/util.ts
+++ b/std/node/util.ts
@@ -68,3 +68,14 @@ export function validateIntegerRange(
     );
   }
 }
+
+
+import { _TextDecoder, _TextEncoder } from "./_utils.ts";
+
+/** The global TextDecoder */
+export type TextDecoder= import("./_utils.ts")._TextDecoder;
+export const TextDecoder= _TextDecoder;
+
+/** The global TextEncoder */
+export type TextEncoder= import("./_utils.ts")._TextEncoder;
+export const TextEncoder= _TextEncoder;

--- a/std/node/util_test.ts
+++ b/std/node/util_test.ts
@@ -148,3 +148,21 @@ test({
     assert(!util.isPrimitive(objectType));
   },
 });
+
+test({
+  name: "[util] TextDecoder",
+  fn() {
+    assert(util.TextDecoder === TextDecoder);
+    const td: util.TextDecoder = new util.TextDecoder();
+    assert(td instanceof TextDecoder);
+  }
+});
+
+test({
+  name: "[util] TextEncoder",
+  fn() {
+    assert(util.TextEncoder === TextEncoder);
+    const te: util.TextEncoder = new util.TextEncoder();
+    assert(te instanceof TextEncoder);
+  }
+});


### PR DESCRIPTION
Hello,  
It might seem useless but it is important for the [build tool](https://github.com/garronej/denoify) I am working on.

I didn't find a more elegant way to do it as ``TextDecoder`` and ``TextEncoder`` are not attached to ``gobalThis``...

Regards,