### PR TITLE
docs(testing): fix test glob pattern

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1030,7 +1030,7 @@ report results to standard output:
   deno test src/fetch_test.ts src/signal_test.ts
 
 Directory arguments are expanded to all contained files matching the glob
-{*_,}test.{js,ts,jsx,tsx}:
+{*_,*.,}test.{js,ts,jsx,tsx}:
   deno test src/",
     )
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -100,6 +100,6 @@ deno test my_test.ts
 ```
 
 You can also omit the file name, in which case all tests in the current
-directory (recursively) that match the glob `{*_,}test.{js,ts,jsx,tsx}` will be
-run. If you pass a directory, all files in the directory that match this glob
+directory (recursively) that match the glob `{*_,*.,}test.{js,ts,jsx,tsx}` will
+be run. If you pass a directory, all files in the directory that match this glob
 will be run.


### PR DESCRIPTION
`a.test.ts` should also be matched. 
https://github.com/denoland/deno/blob/eb5acb39d5936d3e0fde44a33357cda88a5ff55f/cli/test_runner.rs#L14

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
