### PR TITLE
Provide required arguments to walk in example.

### DIFF
--- a/std/fs/README.md
+++ b/std/fs/README.md
@@ -160,7 +160,7 @@ for (const fileInfo of walkSync(".")) {
 
 // Async
 async function printFilesNames() {
-  for await (const entry of walk()) {
+  for await (const entry of walk(".")) {
     console.log(entry.path);
   }
 }


### PR DESCRIPTION
Adds the required first parameter to the example.

Just tried running it while exploring Deno and the walk example gave me and error with:

```
error: TS2554 [ERROR]: Expected 1-2 arguments, but got 0.
  for await (const entry of walk()) {
                            ~~~~~~
    at file:///Users/.../index.ts:5:29

    An argument for 'root' was not provided.
      root: string,
      ~~~~~~~~~~~~
        at https://deno.land/std/fs/walk.ts:86:3
```

This Pull Request adds the required parameter in the example.