### PR TITLE
Fix illegal trailing comma regression in arrow function expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a30d83f56d1adb78643a99a81fe25b5b9b6bff7798623a13caa12040f9899d"
+checksum = "a9789e9282a2fef314dd58df1e203de44035b0f032923b52f751c7917f7adff3"
 dependencies = [
  "dprint-core",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,7 +29,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.18.3"
+dprint-plugin-typescript = "0.18.4"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.1"


### PR DESCRIPTION
Fixes trailing comma issue. Updates to dprint 0.18.4.

**Cause:** Some parameters are now a `Param` AST node and some are still `Pat` because they don't support decorators. The code checking for a pat expression was now expecting all parameters to be `Param` instead of checking for both. I didn't have a test for the scenario where it was a `Pat`.

**Future regression mitigation:** Added a test for this scenario. Opened https://github.com/dprint/dprint/issues/215 which I will up the priority on.

Closes #5658