### PR TITLE
doc: Replace obsolete Deno.homeDir() with Deno.dir('home')

### DIFF
--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1207,7 +1207,7 @@ declare namespace Deno {
      * ```ts
      * const status = await Deno.permissions.request({ name: "env" });
      * if (status.state === "granted") {
-     *   console.log(Deno.homeDir());
+     *   console.log(Deno.dir("home");
      * } else {
      *   console.log("'env' permission is denied.");
      * }


### PR DESCRIPTION
The permissions documentation at https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/js/lib.deno.unstable.d.ts#Deno.Permissions uses `Deno.homeDir()` in example for `revoke`.
`Deno.dirHome` was replaced in #3518, and shouldn't be used in examples anymore.

Fixes #5692 
Signed-off-by: bhumijgupta <bhumijgupta@gmail.com>

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
