### PR TITLE
feat: support wrapped plugin ops

### DIFF
--- a/cli/ops/plugin.rs
+++ b/cli/ops/plugin.rs
@@ -102,6 +102,10 @@ impl<'a> plugin_api::Interface for PluginInterface<'a> {
     self.state.register_op(
       name,
       move |state: Rc<State>, mut zero_copy: BufVec| {
+        // This is a hack that ensures that dispatch_op_fn is dropped first to
+        // prevent segfaults.
+        let _ = &dispatch_op_fn;
+        let _ = &plugin_lib;
         let mut interface = PluginInterface::new(&state, &plugin_lib);
         let op = dispatch_op_fn(&mut interface, &mut zero_copy);
         match op {

--- a/cli/ops/plugin.rs
+++ b/cli/ops/plugin.rs
@@ -96,7 +96,7 @@ impl<'a> plugin_api::Interface for PluginInterface<'a> {
   fn register_op(
     &mut self,
     name: &str,
-    dispatch_op_fn: plugin_api::DispatchOpFn,
+    dispatch_op_fn: Box<plugin_api::DispatchOpFn>,
   ) -> OpId {
     let plugin_lib = self.plugin_lib.clone();
     self.state.register_op(

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -55,7 +55,7 @@ pub struct State {
   pub is_internal: bool,
   pub http_client: RefCell<reqwest::Client>,
   pub resource_table: RefCell<ResourceTable>,
-  pub op_table: RefCell<OpTable<Self>>,
+  pub op_table: Rc<RefCell<OpTable<Self>>>,
 }
 
 impl State {

--- a/core/core_isolate.rs
+++ b/core/core_isolate.rs
@@ -163,6 +163,15 @@ impl DerefMut for CoreIsolate {
   }
 }
 
+impl Drop for CoreIsolateState {
+  fn drop(&mut self) {
+    // TODO(afinch7) this is a temporary fix for a segfault that occurus when
+    // dropping plugin ops. I know that the plugin Rc<Library> value gets dropped
+    // early for some reason, but still not quite sure why.
+    drop(std::mem::take(&mut self.op_registry));
+  }
+}
+
 impl Drop for CoreIsolate {
   fn drop(&mut self) {
     if let Some(creator) = self.snapshot_creator.take() {

--- a/core/core_isolate.rs
+++ b/core/core_isolate.rs
@@ -163,15 +163,6 @@ impl DerefMut for CoreIsolate {
   }
 }
 
-impl Drop for CoreIsolateState {
-  fn drop(&mut self) {
-    // TODO(afinch7) this is a temporary fix for a segfault that occurus when
-    // dropping plugin ops. I know that the plugin Rc<Library> value gets dropped
-    // early for some reason, but still not quite sure why.
-    drop(std::mem::take(&mut self.op_registry));
-  }
-}
-
 impl Drop for CoreIsolate {
   fn drop(&mut self) {
     if let Some(creator) = self.snapshot_creator.take() {

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -116,6 +116,10 @@ impl<S: OpRegistry> OpTable<S> {
     self.keys().cloned().zip(0..).collect()
   }
 
+  pub fn unregister_op(&mut self, name: &str) {
+    drop(self.0.remove(name));
+  }
+
   fn op_get_op_catalog(state: Rc<S>, _bufs: BufVec) -> Op {
     let ops = state.get_op_catalog();
     let buf = serde_json::to_vec(&ops).map(Into::into).unwrap();

--- a/core/plugin_api.rs
+++ b/core/plugin_api.rs
@@ -14,8 +14,7 @@ pub use crate::ZeroCopyBuf;
 
 pub type InitFn = fn(&mut dyn Interface);
 
-pub type DispatchOpFn =
-  dyn Fn(&mut dyn Interface, &mut [ZeroCopyBuf]) -> Op;
+pub type DispatchOpFn = dyn Fn(&mut dyn Interface, &mut [ZeroCopyBuf]) -> Op;
 pub trait Interface {
   fn register_op(&mut self, name: &str, dispatcher: Box<DispatchOpFn>) -> OpId;
-}	
+}

--- a/core/plugin_api.rs
+++ b/core/plugin_api.rs
@@ -14,8 +14,8 @@ pub use crate::ZeroCopyBuf;
 
 pub type InitFn = fn(&mut dyn Interface);
 
-pub type DispatchOpFn = fn(&mut dyn Interface, &mut [ZeroCopyBuf]) -> Op;
-
+pub type DispatchOpFn =
+  dyn Fn(&mut dyn Interface, &mut [ZeroCopyBuf]) -> Op;
 pub trait Interface {
-  fn register_op(&mut self, name: &str, dispatcher: DispatchOpFn) -> OpId;
-}
+  fn register_op(&mut self, name: &str, dispatcher: Box<DispatchOpFn>) -> OpId;
+}	

--- a/test_plugin/src/lib.rs
+++ b/test_plugin/src/lib.rs
@@ -1,12 +1,14 @@
 use deno_core::plugin_api::Interface;
 use deno_core::plugin_api::Op;
 use deno_core::plugin_api::ZeroCopyBuf;
+use deno_core::plugin_api::DispatchOpFn;
 use futures::future::FutureExt;
 
-#[no_mangle]
+#[no_mangle]  
 pub fn deno_plugin_init(interface: &mut dyn Interface) {
-  interface.register_op("testSync", op_test_sync);
-  interface.register_op("testAsync", op_test_async);
+  interface.register_op("testSync", Box::new(op_test_sync));
+  interface.register_op("testAsync", Box::new(op_test_async));
+  interface.register_op("testWrapped", wrap_op(op_wrapped));
 }
 
 fn op_test_sync(
@@ -47,6 +49,49 @@ fn op_test_async(
     assert!(rx.await.is_ok());
     let result = b"test";
     let result_box: Box<[u8]> = Box::new(*result);
+    result_box
+  };
+
+  Op::Async(fut.boxed())
+}
+
+fn wrap_op<D>(d: D) -> Box<DispatchOpFn> 
+where 
+  D: Fn(
+    &mut dyn Interface,
+    String,
+    &mut [ZeroCopyBuf],
+  ) -> Op + 'static
+{
+  Box::new(move |i: &mut dyn Interface, zero_copy: &mut [ZeroCopyBuf]| {
+    let first_buf_str = std::str::from_utf8(&zero_copy[0][..]).unwrap();
+    d(i, first_buf_str.to_string(), &mut zero_copy[1..])
+  })
+}
+
+fn op_wrapped(
+  _interface: &mut dyn Interface,
+  first_buf_str: String,
+  zero_copy: &mut [ZeroCopyBuf],
+) -> Op {
+  if !zero_copy.is_empty() {
+    println!("Hello from wrapped op.");
+  }
+  let zero_copy = zero_copy.to_vec();
+  let fut = async move {
+    println!("first_buf: {}", first_buf_str);
+    for (idx, buf) in zero_copy.iter().enumerate() {
+      let buf_str = std::str::from_utf8(&buf[..]).unwrap();
+      println!("zero_copy[{}]: {}", idx, buf_str);
+    }
+    let (tx, rx) = futures::channel::oneshot::channel::<Result<(), ()>>();
+    std::thread::spawn(move || {
+      std::thread::sleep(std::time::Duration::from_secs(1));
+      tx.send(Ok(())).unwrap();
+    });
+    assert!(rx.await.is_ok());
+    let result = b"test";
+    let result_box: Buf = Box::new(*result);
     result_box
   };
 

--- a/test_plugin/src/lib.rs
+++ b/test_plugin/src/lib.rs
@@ -1,10 +1,10 @@
+use deno_core::plugin_api::DispatchOpFn;
 use deno_core::plugin_api::Interface;
 use deno_core::plugin_api::Op;
 use deno_core::plugin_api::ZeroCopyBuf;
-use deno_core::plugin_api::DispatchOpFn;
 use futures::future::FutureExt;
 
-#[no_mangle]  
+#[no_mangle]
 pub fn deno_plugin_init(interface: &mut dyn Interface) {
   interface.register_op("testSync", Box::new(op_test_sync));
   interface.register_op("testAsync", Box::new(op_test_async));
@@ -55,18 +55,16 @@ fn op_test_async(
   Op::Async(fut.boxed())
 }
 
-fn wrap_op<D>(d: D) -> Box<DispatchOpFn> 
-where 
-  D: Fn(
-    &mut dyn Interface,
-    String,
-    &mut [ZeroCopyBuf],
-  ) -> Op + 'static
+fn wrap_op<D>(d: D) -> Box<DispatchOpFn>
+where
+  D: Fn(&mut dyn Interface, String, &mut [ZeroCopyBuf]) -> Op + 'static,
 {
-  Box::new(move |i: &mut dyn Interface, zero_copy: &mut [ZeroCopyBuf]| {
-    let first_buf_str = std::str::from_utf8(&zero_copy[0][..]).unwrap();
-    d(i, first_buf_str.to_string(), &mut zero_copy[1..])
-  })
+  Box::new(
+    move |i: &mut dyn Interface, zero_copy: &mut [ZeroCopyBuf]| {
+      let first_buf_str = std::str::from_utf8(&zero_copy[0][..]).unwrap();
+      d(i, first_buf_str.to_string(), &mut zero_copy[1..])
+    },
+  )
 }
 
 fn op_wrapped(
@@ -91,7 +89,7 @@ fn op_wrapped(
     });
     assert!(rx.await.is_ok());
     let result = b"test";
-    let result_box: Buf = Box::new(*result);
+    let result_box: Box<[u8]> = Box::new(*result);
     result_box
   };
 

--- a/test_plugin/tests/integration_tests.rs
+++ b/test_plugin/tests/integration_tests.rs
@@ -36,7 +36,7 @@ fn basic() {
     println!("stderr {}", stderr);
   }
   assert!(output.status.success());
-  let expected = "Hello from plugin.\nzero_copy[0]: test\nzero_copy[1]: 123\nzero_copy[2]: cba\nPlugin Sync Response: test\nHello from plugin.\nzero_copy[0]: test\nzero_copy[1]: 123\nPlugin Async Response: test\n";
+  let expected = "Hello from plugin.\nzero_copy[0]: test\nzero_copy[1]: 123\nzero_copy[2]: cba\nPlugin Sync Response: test\nHello from plugin.\nzero_copy[0]: test\nzero_copy[1]: 123\nPlugin Async Response: test\nHello from wrapped op.\nfirst_buf: test\nzero_copy[0]: 123\nPlugin Async Response: test\n";
   assert_eq!(stdout, expected);
   assert_eq!(stderr, "");
 }

--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -117,6 +117,11 @@ Before: ${preStr}
 After: ${postStr}`,
     );
   }
+
+  const ops = Deno.core.ops();
+  if (ops["testSync"] || ops["testAsync"] || ops["testWrapped"]) {
+    throw new Error("Expected plugin ops to be unregistered: ", ops);
+  }
 }
 
 runTestSync();

--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -37,7 +37,9 @@ const promiseTestAsync = new Promise((resolve) => resolveTestAsync = resolve);
 
 let resolveTestWrapped;
 
-const promiseTestWrapped = new Promise((resolve) => resolveTestWrapped = resolve);
+const promiseTestWrapped = new Promise((resolve) =>
+  resolveTestWrapped = resolve
+);
 
 function runTestSync() {
   const response = Deno.core.dispatch(


### PR DESCRIPTION
Add support for op wrapping pattern used in cli:

``` rust
#[no_mangle]
pub fn deno_plugin_init(interface: &mut dyn Interface) {
  // this won't work when `register_op` takes a function pointer(`fn`)
  interface.register_op("example", wrap_op(op_example));
}

fn wrap_op<D>(d: D) -> Box<dyn Fn(&mut dyn Interface, Value, Option<ZeroCopyBuf>) -> Op> 
where
  D: Fn(&mut dyn Interface, Value, Option<ZeroCopyBuf>) -> Op,
{
  // code for wrapping op
}

fn op_example(
  _interface: &mut dyn Interface,
  control: &[u8],
  zero_copy: Option<ZeroCopyBuf>,
) -> Op {
  // Op code
}
```
fixes #5478