### PR TITLE
fix(fmt): Do not panic on new expr with no parens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9789e9282a2fef314dd58df1e203de44035b0f032923b52f751c7917f7adff3"
+checksum = "8f4b628385a13a592afdd6391167921f62f1c1adc1f7b098ecf7e930ab5cc702"
 dependencies = [
  "dprint-core",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,7 +29,7 @@ byteorder = "1.3.4"
 clap = "2.33.0"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.18.4"
+dprint-plugin-typescript = "0.18.5"
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.1"


### PR DESCRIPTION
Closes #5567

Also fixed https://github.com/dprint/dprint/issues/217