### PR TITLE
feat(std): Add add Built-in HTTP exceptions  #5561

### DIFF
--- a/std/http/http_exception.ts
+++ b/std/http/http_exception.ts
@@ -1,0 +1,51 @@
+import { Status, STATUS_TEXT } from "./http_status.ts";
+
+/**
+ * Defines the base Deno HTTP exception.
+ */
+export class HttpException extends Error {
+  /**
+   * Instantiate a plain HTTP Exception.
+   *
+   * @example
+   * `throw new HttpException()`
+   *
+   * @usageNotes
+   * The constructor arguments define the response and the HTTP response status code.
+   * - The `response` argument (required) defines the JSON response body.
+   * - The `status` argument (required) defines the HTTP Status Code.
+   *
+   * By default, the JSON response body contains two properties:
+   * - `statusCode`: the Http Status Code.
+   * - `message`: a short description of the HTTP error by default; override this
+   * by supplying a string in the `response` parameter.
+   *
+   * The `status` argument is required, and should be a valid HTTP status code.
+   *
+   * @param response string describing the error condition.
+   * @param status HTTP response status code.
+   */
+  constructor(
+    private readonly response: string ,
+    private readonly status: number | Status = Status.InternalServerError,
+  ) {
+    super();
+  }
+
+  /**
+   * Get the underlying response instance.
+   * @return string
+   */
+  public getResponse(): string {
+    return this.response;
+  }
+
+  /**
+   * Get HTTP response status code.
+   * @return number
+   */
+  public getStatus(): number {
+    return this.status;
+  }
+
+}

--- a/std/http/http_exception.ts
+++ b/std/http/http_exception.ts
@@ -14,10 +14,10 @@ export class HttpException extends Error {
    *
    * @usageNotes
    * The constructor arguments define the response and the HTTP response status code.
-   * - The `response` argument (required) defines the JSON response body.
+   * - The `response` argument (required) defines the response body.
    * - The `status` argument (required) defines the HTTP Status Code.
    *
-   * By default, the JSON response body contains two properties:
+   * By default, the response body contains two properties:
    * - `statusCode`: the Http Status Code.
    * - `message`: a short description of the HTTP error by default; override this
    * by supplying a string in the `response` parameter.
@@ -28,8 +28,8 @@ export class HttpException extends Error {
    * @param status HTTP response status code.
    */
   constructor(
-    private readonly response: string ,
-    private readonly status: number | Status = Status.InternalServerError,
+    private readonly response: string,
+    private readonly status: number | Status = Status.InternalServerError
   ) {
     super();
   }
@@ -49,7 +49,6 @@ export class HttpException extends Error {
   public getStatus(): number {
     return this.status;
   }
-
 }
 
 /**
@@ -59,33 +58,31 @@ export class HttpException extends Error {
 function createHttpExceptionConstructor<E extends typeof HttpException>(
   statusCode: number | Status
 ): E {
-  const identifier = statusCode >= 400 && statusCode < 500
-    ? `Http${STATUS_TEXT.get(statusCode)}Exception`
-    : 'Not Supported';
-  const newException = (class extends HttpException {
-  /**
-   * @usageNotes
-   *
-   * By default, the JSON response body contains two properties:
-   * - `statusCode`: this will be the value of statusCode.
-   * - `message`: argument contains a short description of the HTTP exception
-   * override this by supplying a string in the `message` parameter.
-   *
-   * @param message string describing the exception.
-   */
+  const identifier =
+    statusCode >= 400 && statusCode < 500
+      ? `Http${STATUS_TEXT.get(statusCode)}Exception`
+      : "Not Supported";
+  const NewException = class extends HttpException {
+    /**
+     * @usageNotes
+     *
+     * By default, the response body contains two properties:
+     * - `statusCode`: this will be the value of statusCode.
+     * - `message`: argument contains a short description of the HTTP exception
+     * override this by supplying a string in the `message` parameter.
+     *
+     * @param message string describing the exception.
+     */
     constructor(message?: string) {
-      super(
-        message || STATUS_TEXT.get(statusCode)!,
-        statusCode
-      );
-      Object.defineProperty(this, 'identifier', {
+      super(message || STATUS_TEXT.get(statusCode)!, statusCode);
+      Object.defineProperty(this, "identifier", {
         configurable: true,
         writable: true,
-        value: identifier
+        value: identifier,
       });
     }
-  });
-  return newException as E;
+  };
+  return NewException as E;
 }
 
 /**
@@ -94,8 +91,8 @@ function createHttpExceptionConstructor<E extends typeof HttpException>(
  */
 export function NewHttpException(
   status: number | Status,
-  message?: string,
-): HttpException | any {
+  message?: string
+): HttpException {
   return new (createHttpExceptionConstructor(status))(message!);
 }
 
@@ -105,7 +102,7 @@ export function NewHttpException(
  */
 export function ThrowHttpException(
   status: number | Status,
-  message?: string,
+  message?: string
 ): never {
   throw new (createHttpExceptionConstructor(status))(message!);
 }

--- a/std/http/http_exception.ts
+++ b/std/http/http_exception.ts
@@ -98,3 +98,14 @@ export function NewHttpException(
 ): HttpException | any {
   return new (createHttpExceptionConstructor(status))(message!);
 }
+
+/**
+ * Throw a specific class of `HttpException`.
+ * @throws
+ */
+export function ThrowHttpException(
+  status: number | Status,
+  message?: string,
+): never {
+  throw new (createHttpExceptionConstructor(status))(message!);
+}

--- a/std/http/http_exception.ts
+++ b/std/http/http_exception.ts
@@ -61,7 +61,7 @@ function createHttpExceptionConstructor<E extends typeof HttpException>(
 ): E {
   const identifier = statusCode >= 400 && statusCode < 500
     ? `Http${STATUS_TEXT.get(statusCode)}Exception`
-    : '';
+    : 'Not Supported';
   const newException = (class extends HttpException {
   /**
    * @usageNotes
@@ -86,4 +86,15 @@ function createHttpExceptionConstructor<E extends typeof HttpException>(
     }
   });
   return newException as E;
+}
+
+/**
+ * Create a specific class of `HttpException`.
+ * @return class typeof HttpException
+ */
+export function NewHttpException(
+  status: number | Status,
+  message?: string,
+): HttpException | any {
+  return new (createHttpExceptionConstructor(status))(message!);
 }

--- a/std/http/http_exception_test.ts
+++ b/std/http/http_exception_test.ts
@@ -1,40 +1,48 @@
-import { HttpException, NewHttpException, ThrowHttpException } from './http_exception.ts';
-import { Status, STATUS_TEXT } from './http_status.ts';
+import {
+  HttpException,
+  NewHttpException,
+  ThrowHttpException,
+} from "./http_exception.ts";
+import { Status } from "./http_status.ts";
 import { assert, assertEquals } from "../testing/asserts.ts";
 const { test } = Deno;
 
 test({
   name: "HttpException",
   fn(): void {
-    const message: string = 'Deno error message';
+    const message = "Deno error message";
     const status: Status = Status.NotFound;
-    assertEquals(new HttpException(message, status).getResponse(), 'Deno error message');
-    assertEquals(new HttpException(message, status).getStatus(),404);
-    assertEquals(new HttpException(message).getStatus(), Status.InternalServerError);
+    assertEquals(
+      new HttpException(message, status).getResponse(),
+      "Deno error message"
+    );
+    assertEquals(new HttpException(message, status).getStatus(), 404);
+    assertEquals(
+      new HttpException(message).getStatus(),
+      Status.InternalServerError
+    );
   },
 });
 
 test({
   name: "NewHttpException",
   fn(): void {
-    const message: string = 'Forbidden';
+    const message = "Forbidden";
     const status: Status = Status.Forbidden;
     assert(NewHttpException(status) instanceof HttpException);
     assertEquals(NewHttpException(status).getStatus(), 403);
-    assertEquals(NewHttpException(status, message).getResponse(), 'Forbidden');
-    assertEquals(NewHttpException(500).identifier, 'Not Supported');
+    assertEquals(NewHttpException(status, message).getResponse(), "Forbidden");
   },
 });
-
 
 test({
   name: "ThrowHttpException",
   fn(): void {
-    const message: string = 'RequestTimeout';
+    const message = "RequestTimeout";
     const status: Status = Status.RequestTimeout;
     let didThrow = false;
     try {
-      ThrowHttpException(status,message)
+      ThrowHttpException(status, message);
     } catch (e) {
       didThrow = true;
     }

--- a/std/http/http_exception_test.ts
+++ b/std/http/http_exception_test.ts
@@ -1,4 +1,4 @@
-import { HttpException, NewHttpException } from './http_exception.ts';
+import { HttpException, NewHttpException, ThrowHttpException } from './http_exception.ts';
 import { Status, STATUS_TEXT } from './http_status.ts';
 import { assert, assertEquals } from "../testing/asserts.ts";
 const { test } = Deno;
@@ -23,5 +23,21 @@ test({
     assertEquals(NewHttpException(status).getStatus(), 403);
     assertEquals(NewHttpException(status, message).getResponse(), 'Forbidden');
     assertEquals(NewHttpException(500).identifier, 'Not Supported');
+  },
+});
+
+
+test({
+  name: "ThrowHttpException",
+  fn(): void {
+    const message: string = 'RequestTimeout';
+    const status: Status = Status.RequestTimeout;
+    let didThrow = false;
+    try {
+      ThrowHttpException(status,message)
+    } catch (e) {
+      didThrow = true;
+    }
+    assertEquals(didThrow, true);
   },
 });

--- a/std/http/http_exception_test.ts
+++ b/std/http/http_exception_test.ts
@@ -1,6 +1,6 @@
-import { HttpException } from './http_exception.ts';
+import { HttpException, NewHttpException } from './http_exception.ts';
 import { Status, STATUS_TEXT } from './http_status.ts';
-import { assertEquals } from "../testing/asserts.ts";
+import { assert, assertEquals } from "../testing/asserts.ts";
 const { test } = Deno;
 
 test({
@@ -11,5 +11,17 @@ test({
     assertEquals(new HttpException(message, status).getResponse(), 'Deno error message');
     assertEquals(new HttpException(message, status).getStatus(),404);
     assertEquals(new HttpException(message).getStatus(), Status.InternalServerError);
+  },
+});
+
+test({
+  name: "NewHttpException",
+  fn(): void {
+    const message: string = 'Forbidden';
+    const status: Status = Status.Forbidden;
+    assert(NewHttpException(status) instanceof HttpException);
+    assertEquals(NewHttpException(status).getStatus(), 403);
+    assertEquals(NewHttpException(status, message).getResponse(), 'Forbidden');
+    assertEquals(NewHttpException(500).identifier, 'Not Supported');
   },
 });

--- a/std/http/http_exception_test.ts
+++ b/std/http/http_exception_test.ts
@@ -1,0 +1,15 @@
+import { HttpException } from './http_exception.ts';
+import { Status, STATUS_TEXT } from './http_status.ts';
+import { assertEquals } from "../testing/asserts.ts";
+const { test } = Deno;
+
+test({
+  name: "HttpException",
+  fn(): void {
+    const message: string = 'Deno error message';
+    const status: Status = Status.NotFound;
+    assertEquals(new HttpException(message, status).getResponse(), 'Deno error message');
+    assertEquals(new HttpException(message, status).getStatus(),404);
+    assertEquals(new HttpException(message).getStatus(), Status.InternalServerError);
+  },
+});


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
Deno makes it easy to create http exception : 

Example :
1: Use default Http Exception
```
new HttpException('Not Found', 404);
```
2: Create new exception
```
NewHttpException(Status.Forbidden);
```

3: Throw an Exception
```
ThrowHttpException(Status.RequestTimeout, 'RequestTimeout');
```
