### PR TITLE
feat(std/fs/read_json):  Make it a generic function

### DIFF
--- a/std/fs/read_json.ts
+++ b/std/fs/read_json.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 /** Reads a JSON file and then parses it into an object */
-export async function readJson(filePath: string): Promise<unknown> {
+export async function readJson<T>(filePath: string): Promise<T> {
   const decoder = new TextDecoder("utf-8");
 
   const content = decoder.decode(await Deno.readFile(filePath));
@@ -15,7 +15,7 @@ export async function readJson(filePath: string): Promise<unknown> {
 }
 
 /** Reads a JSON file and then parses it into an object */
-export function readJsonSync(filePath: string): unknown {
+export function readJsonSync<T>(filePath: string): T {
   const decoder = new TextDecoder("utf-8");
 
   const content = decoder.decode(Deno.readFileSync(filePath));


### PR DESCRIPTION
// Type assertions

```js
import { readJsonSync } from "https://deno.land/std/fs/read_json.ts";

interface DB {
  [index: string]: {
    source?: "string";
    charset?: "string";
    compressible?: boolean;
    extensions?: string[];
  };
}

const db = (readJsonSync("./db.json") as DB); # Type assertions
console.log(db.source);
```


// generic function
```js
import { readJsonSync } from "https://deno.land/std/fs/read_json.ts";

interface DB {
  [index: string]: {
    source?: "string";
    charset?: "string";
    compressible?: boolean;
    extensions?: string[];
  };
}

const db =readJsonSync<DB>("./db.json")  # generic function
console.log(db.source);
```

I think it's better this way

