### PR TITLE
re-enable symlink tests on windows

### DIFF
--- a/std/node/_fs/_fs_readlink_test.ts
+++ b/std/node/_fs/_fs_readlink_test.ts
@@ -4,8 +4,8 @@ import { assertEquals, assert } from "../../testing/asserts.ts";
 import * as path from "../path.ts";
 
 const testDir = Deno.makeTempDirSync();
-const oldname = path.join(testDir + "/oldname");
-const newname = path.join(testDir + "/newname");
+const oldname = path.join(testDir, "oldname");
+const newname = path.join(testDir, "newname");
 
 if (Deno.build.os === "windows") {
   Deno.symlinkSync(oldname, newname, { type: "file" });

--- a/std/node/_fs/_fs_readlink_test.ts
+++ b/std/node/_fs/_fs_readlink_test.ts
@@ -1,18 +1,20 @@
 const { test } = Deno;
 import { readlink, readlinkSync } from "./_fs_readlink.ts";
 import { assertEquals, assert } from "../../testing/asserts.ts";
+import * as path from "../path.ts";
 
 const testDir = Deno.makeTempDirSync();
-const oldname = testDir + "/oldname";
-const newname = testDir + "/newname";
+const oldname = path.join(testDir + "/oldname");
+const newname = path.join(testDir + "/newname");
 
-if (Deno.build.os !== "windows") {
+if (Deno.build.os === "windows") {
+  Deno.symlinkSync(oldname, newname, { type: "file" });
+} else {
   Deno.symlinkSync(oldname, newname);
 }
 
 test({
   name: "readlinkSuccess",
-  ignore: Deno.build.os === "windows",
   async fn() {
     const data = await new Promise((res, rej) => {
       readlink(newname, (err, data) => {
@@ -30,7 +32,6 @@ test({
 
 test({
   name: "readlinkEncodeBufferSuccess",
-  ignore: Deno.build.os === "windows",
   async fn() {
     const data = await new Promise((res, rej) => {
       readlink(newname, { encoding: "buffer" }, (err, data) => {
@@ -48,7 +49,6 @@ test({
 
 test({
   name: "readlinkSyncSuccess",
-  ignore: Deno.build.os === "windows",
   fn() {
     const data = readlinkSync(newname);
     assertEquals(typeof data, "string");
@@ -58,7 +58,6 @@ test({
 
 test({
   name: "readlinkEncodeBufferSuccess",
-  ignore: Deno.build.os === "windows",
   fn() {
     const data = readlinkSync(newname, { encoding: "buffer" });
     assert(data instanceof Uint8Array);


### PR DESCRIPTION
 after #5533 landed, this PR is going to re-enable symlink tests in `std/node/_fs/_fs_readlink_test.ts`.
