### PR TITLE
Feature: assertInstanceOf

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -393,7 +393,7 @@ export function assertInstanceOf(
   expected: Function,
   msg?: string
 ): void {
-  if ((actual instanceof expected) === false) {
+  if (!(actual instanceof expected)) {
     if (!msg) {
       msg = `actual: "${format(actual)}" expected to match: "${format(expected)}"`;
     }

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -400,9 +400,9 @@ export function assertInstanceOf(
 ): void {
   if (!(actual instanceof expected)) {
     if (!msg) {
-      msg = `actual: "${format(actual)}" expected to match: "${
-        format(expected)
-      }"`;
+      msg = `actual: "${format(actual)}" expected to match: "${format(
+        expected
+      )}"`;
     }
     throw new AssertionError(msg);
   }

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -388,6 +388,19 @@ export async function assertThrowsAsync(
   return error;
 }
 
+export function assertInstanceOf(
+  actual: unknown,
+  expected: Function,
+  msg?: string
+): void {
+  if ((actual instanceof expected) === false) {
+    if (!msg) {
+      msg = `actual: "${format(actual)}" expected to match: "${format(expected)}"`;
+    }
+    throw new AssertionError(msg);
+  }
+}
+
 /** Use this to stub out methods that will throw when invoked. */
 export function unimplemented(msg?: string): never {
   throw new AssertionError(msg || "unimplemented");

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -388,6 +388,11 @@ export async function assertThrowsAsync(
   return error;
 }
 
+/**
+ * Assert an object is an instance of a particular type. This useful to check
+ * polymorphic relationships, for instance check B is an instance of A if B
+ * extends A.
+ */
 export function assertInstanceOf(
   actual: unknown,
   expected: Function,

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -389,7 +389,7 @@ export async function assertThrowsAsync(
 }
 
 /**
- * Assert an object is an instance of a particular type. This useful to check
+ * Assert an object is an instance of a particular type. This is useful to check
  * polymorphic relationships, for instance check B is an instance of A if B
  * extends A.
  */
@@ -400,7 +400,9 @@ export function assertInstanceOf(
 ): void {
   if (!(actual instanceof expected)) {
     if (!msg) {
-      msg = `actual: "${format(actual)}" expected to match: "${format(expected)}"`;
+      msg = `actual: "${format(actual)}" expected to match: "${
+        format(expected)
+      }"`;
     }
     throw new AssertionError(msg);
   }

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -16,7 +16,7 @@ import {
   unimplemented,
   unreachable,
 } from "./asserts.ts";
-import { red, green, gray, bold, yellow } from "../fmt/colors.ts";
+import { red, green, gray, bold, yellow, cyan } from "../fmt/colors.ts";
 const { test } = Deno;
 
 test("testingEqual", function (): void {
@@ -405,5 +405,19 @@ test({
 
     const myArray = new Array(["Hello"]);
     assertInstanceOf(myArray, Array);
+  },
+});
+
+test({
+  name: "testingAssertInstanceOf Fail",
+  fn(): void {
+    class Foo{};
+    class Bar{};
+    const foo = new Foo();
+    assertThrows(
+      (): void => assertInstanceOf(foo, Bar),
+      AssertionError,
+      `actual: "Foo {}" expected to match: "${cyan("[Function: Bar]")}"`
+    );
   },
 });

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -405,6 +405,19 @@ test({
 
     const myArray = new Array(["Hello"]);
     assertInstanceOf(myArray, Array);
+
+    function getThing(): Object {
+      return new String("Yo!");
+    }
+
+    assertInstanceOf(getThing(), String);
+
+    class A{};
+    class B extends A{};
+
+    let b = new B();
+
+    assertInstanceOf(b, A);
   },
 });
 
@@ -418,6 +431,12 @@ test({
       (): void => assertInstanceOf(foo, Bar),
       AssertionError,
       `actual: "Foo {}" expected to match: "${cyan("[Function: Bar]")}"`
+    );
+
+    assertThrows(
+      (): void => assertInstanceOf(new String(), Array),
+      AssertionError,
+      `actual: "${cyan(`[String: ""]`)}" expected to match: "${cyan("[Function: Array]")}"`
     );
   },
 });

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -436,7 +436,9 @@ test({
     assertThrows(
       (): void => assertInstanceOf(new String(), Array),
       AssertionError,
-      `actual: "${cyan(`[String: ""]`)}" expected to match: "${cyan("[Function: Array]")}"`
+      `actual: "${cyan(`[String: ""]`)}" expected to match: "${
+        cyan("[Function: Array]")
+      }"`
     );
   },
 });

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -9,6 +9,7 @@ import {
   assertEquals,
   assertStrictEq,
   assertThrows,
+  assertInstanceOf,
   AssertionError,
   equal,
   fail,
@@ -389,5 +390,20 @@ test({
         red(`     { a: ${yellow("1")}, b: ${yellow("2")} }`),
       ].join("\n")
     );
+  },
+});
+
+test({
+  name: "testingAssertInstanceOf",
+  fn(): void {
+    class Foo{};
+    const foo = new Foo();
+    assertInstanceOf(foo, Foo);
+
+    const myString = new String("Hello");
+    assertInstanceOf(myString, String);
+
+    const myArray = new Array(["Hello"]);
+    assertInstanceOf(myArray, Array);
   },
 });

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -396,7 +396,7 @@ test({
 test({
   name: "testingAssertInstanceOf",
   fn(): void {
-    class Foo{};
+    class Foo {}
     const foo = new Foo();
     assertInstanceOf(foo, Foo);
 
@@ -406,8 +406,8 @@ test({
     const myArray = new Array(["Hello"]);
     assertInstanceOf(myArray, Array);
 
-    class Person {};
-    class Adult extends Person{};
+    class Person {}
+    class Adult extends Person {}
 
     function getThing(): Person {
       return new Adult();
@@ -415,8 +415,8 @@ test({
 
     assertInstanceOf(getThing(), Adult);
 
-    class A{};
-    class B extends A{};
+    class A {}
+    class B extends A {}
 
     const b = new B();
 
@@ -427,8 +427,8 @@ test({
 test({
   name: "testingAssertInstanceOf Fail",
   fn(): void {
-    class Foo{};
-    class Bar{};
+    class Foo {}
+    class Bar {}
     const foo = new Foo();
     assertThrows(
       (): void => assertInstanceOf(foo, Bar),
@@ -439,9 +439,9 @@ test({
     assertThrows(
       (): void => assertInstanceOf(new String(), Array),
       AssertionError,
-      `actual: "${cyan(`[String: ""]`)}" expected to match: "${
-        cyan("[Function: Array]")
-      }"`
+      `actual: "${cyan(`[String: ""]`)}" expected to match: "${cyan(
+        "[Function: Array]"
+      )}"`
     );
   },
 });

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -406,16 +406,19 @@ test({
     const myArray = new Array(["Hello"]);
     assertInstanceOf(myArray, Array);
 
-    function getThing(): Object {
-      return new String("Yo!");
+    class Person {};
+    class Adult extends Person{};
+
+    function getThing(): Person {
+      return new Adult();
     }
 
-    assertInstanceOf(getThing(), String);
+    assertInstanceOf(getThing(), Adult);
 
     class A{};
     class B extends A{};
 
-    let b = new B();
+    const b = new B();
 
     assertInstanceOf(b, A);
   },


### PR DESCRIPTION
New test assertion to allow a developer to assert they have the correct object instance. Useful if there is a polymorphic relationship of some kind.

For example:

```js
class Person {
    age: number;

    constructor(age: number) {
        this.age = age;
    }
}

class Adult extends Person {}

class Child extends Person {}

function definePerson(age: number): Person {
    if (age >= 18) {
        return new Adult(age);
    }

    return new Child(age);
}

console.log(definePerson(17) instanceof Child);
// Output: true
console.log(definePerson(18) instanceof Adult);
// Output: true
```