### PR TITLE
Fix Deno.dir and Diagnostics being present at stable runtime

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -59,7 +59,7 @@ export {
 export { metrics, Metrics } from "./ops/runtime.ts";
 export { mkdirSync, mkdir, MkdirOptions } from "./ops/fs/mkdir.ts";
 export { connect, listen, Listener, Conn } from "./net.ts";
-export { dir, env, exit, execPath } from "./ops/os.ts";
+export { env, exit, execPath } from "./ops/os.ts";
 export { run, RunOptions, Process, ProcessStatus } from "./process.ts";
 export { DirEntry, readDirSync, readDir } from "./ops/fs/read_dir.ts";
 export { readFileSync, readFile } from "./read_file.ts";

--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -13,12 +13,6 @@ export { chmodSync, chmod } from "./ops/fs/chmod.ts";
 export { chownSync, chown } from "./ops/fs/chown.ts";
 export { customInspect, inspect } from "./web/console.ts";
 export { copyFileSync, copyFile } from "./ops/fs/copy_file.ts";
-export {
-  Diagnostic,
-  DiagnosticCategory,
-  DiagnosticItem,
-  DiagnosticMessageChain,
-} from "./diagnostics.ts";
 export { chdir, cwd } from "./ops/fs/dir.ts";
 export { errors } from "./errors.ts";
 export {

--- a/cli/js/deno_unstable.ts
+++ b/cli/js/deno_unstable.ts
@@ -23,3 +23,9 @@ export {
   PermissionStatus,
   Permissions,
 } from "./permissions.ts";
+export {
+  Diagnostic,
+  DiagnosticCategory,
+  DiagnosticItem,
+  DiagnosticMessageChain,
+} from "./diagnostics.ts";


### PR DESCRIPTION
Fix #5745 and Fix #5744 