### PR TITLE
feat(std): add deno_shim for browsers

### DIFF
--- a/std/browser/README.md
+++ b/std/browser/README.md
@@ -125,7 +125,7 @@ these APIs will throw with an `Error` saying the feature isn't implemented:
 - `Deno.run`
 - `Deno.inspect`
 
-And there are some unstable:
+And there are some unstable APIs that are not implemented:
 
 - `Deno.openPlugin`
 - `Deno.formatDiagnostics`

--- a/std/browser/README.md
+++ b/std/browser/README.md
@@ -39,6 +39,30 @@ should try to detect the environment you are running in and avoid using `Deno`
 APIs. One easy way to do that is that `Deno.build.target` will be set to
 `"browser"` when the shim is loaded.
 
+#### Unstable APIs
+
+If you want to shim Deno's unstable APIs, like when using the `--unstable` flag
+with the Deno CLI, there is an export of the module which can do this for you.
+Import the `unstable()` function and await it, which will add the unstable APIs
+to the `Deno` namespace.
+
+```ts
+import { unstable } from "https://deno.land/std/browsers/deno_shim.ts";
+
+await unstable();
+```
+
+If your target browser does not support top-level-await yet, you will need to
+avoid using it, even when bundling, by using an IIFE:
+
+```ts
+import { unstable } from "https://deno.land/std/browsers/deno_shim.ts";
+
+(async () => {
+  await unstable();
+})();
+```
+
 ### Virtual File System and Resources
 
 Most of the file system IO operations have been stubbed out in the shim, where
@@ -75,3 +99,16 @@ these APIs will throw with an `Error` saying the feature isn't implemented:
 - `Deno.Process`
 - `Deno.run`
 - `Deno.inspect`
+
+And there are some unstable:
+
+- `Deno.openPlugin`
+- `Deno.formatDiagnostics`
+- `Deno.trasnpileOnly`
+- `Deno.compile`
+- `Deno.bundle`
+- `Deno.applySourceMap`
+- `Deno.SignalStream`
+- `Deno.signal`
+- `Deno.listenDatagram`
+- `Deno.startTls`

--- a/std/browser/README.md
+++ b/std/browser/README.md
@@ -1,0 +1,77 @@
+# std/browser
+
+A collection of modules to help create code that is portable between Deno and
+browsers.
+
+## std/browser/deno_shim.ts
+
+A module that provides a shim of the `Deno` namespace for browsers, providing as
+much of the unique Deno APIs that can be easily supported on the browser or
+aiming to provide a non-operation capability.
+
+When compiling or bundling code in Deno that is also intended to be used in a
+browser, it is sometimes difficult to properly cater for the lack of the `Deno`
+namespace, especially when using strongly typed code which will emit errors.
+This module intends to solve that.
+
+### Usage
+
+This module is designed to just be imported by a script. When the module loads,
+it will detect if the `Deno` namespace is present in the global scope and if not
+it will add the the shim for `Deno`. This should allow most Deno code to access
+the `Deno` global object without issue, as well as perform some `Deno` API
+functions in a browser in a "virtual way".
+
+Specifically this is designed to be used when creating a bundle via
+`deno bundle` that uses `Deno` APIs that you want to run in the web. For
+example, you would want to put this in the root file of your bundle:
+
+```ts
+import "https://deno.land/std/browsers/deno_shim.ts";
+```
+
+And if you were to generate a bundle, the shim would be included in your code,
+and when that bundle is loaded in the browser, accessing most `Deno` APIs will
+not cause your application to throw.
+
+Generally, if you plan for your code to work both in a browser and Deno, you
+should try to detect the environment you are running in and avoid using `Deno`
+APIs. One easy way to do that is that `Deno.build.target` will be set to
+`"browser"` when the shim is loaded.
+
+### Virtual File System and Resources
+
+Most of the file system IO operations have been stubbed out in the shim, where
+there will behave similar to the way they do when running within Deno. You can
+open, read, write, and close in memory virtual files. At this point, there is no
+sense of file structure, files are simply matched based on their path string,
+and there is no file content in any file that is create or opened at load time.
+In order to put content in files, the file would have to be opened with a create
+flag, and written to. Files can be opened multiple times though, and each
+resource ID can have its own position in the file (and own permissions for
+reading and writing).
+
+When closing a file, it will stay in memory, until the page is reloaded. In
+order to free up closed files in memory, the `deno_shim.ts` module exports a
+function named `purgeResources()` which will dereference the closed virtual
+files so their data can be garbage collected by the browser.
+
+### Unimplemented APIs
+
+There are several `Deno` APIs where there is an expected return value, of which
+there is not a logical non-operation that can be performed, in these cases,
+these APIs will throw with an `Error` saying the feature isn't implemented:
+
+- `Deno.readLinkSync`
+- `Deno.readLink`
+- `Deno.lstat`
+- `Deno.lstatSync`
+- `Deno.stat`
+- `Deno.statSync`
+- `Deno.listen`
+- `Deno.listenTls`
+- `Deno.connect`
+- `Deno.connectTls`
+- `Deno.Process`
+- `Deno.run`
+- `Deno.inspect`

--- a/std/browser/_ops_shim.ts
+++ b/std/browser/_ops_shim.ts
@@ -1,0 +1,270 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { errors } from "../../cli/js/errors.ts";
+
+export enum SeekMode {
+  Start = 0,
+  Current = 1,
+  End = 2,
+}
+
+interface Resource {
+  buf: ArrayBuffer;
+  pos: number;
+  name: string;
+  options?: Deno.OpenOptions;
+  closed: boolean;
+}
+
+const resources = new Map<
+  number,
+  Resource
+>();
+let resourceId = 0;
+
+function resourcesIncludes(path: string): number | undefined {
+  for (const [rid, { name }] of resources.entries()) {
+    if (path === name) {
+      return rid;
+    }
+  }
+}
+
+function closeResource(rid: number): void {
+  if (resources.has(rid)) {
+    resources.get(rid)!.closed = true;
+  }
+  throw new errors.BadResource(`Bad Resource: ${rid}`);
+}
+
+function copyResource(from: string, to: string): void {
+  const fromRid = resourcesIncludes(from);
+  if (fromRid === undefined) {
+    throw new errors.NotFound(`File does not exist: ${from}`);
+  }
+  const toRid = openResource(to, { write: true, create: true });
+  const data = new Uint8Array(resources.get(fromRid)!.buf);
+  writeResource(toRid, data);
+  closeResource(toRid);
+}
+
+export function getResources(): Deno.ResourceMap {
+  const result: Deno.ResourceMap = {};
+  for (const [key, value] of resources) {
+    result[key] = value.name;
+  }
+  return result;
+}
+
+function openResource(name: string, options: Deno.OpenOptions): number {
+  const existingRid = resourcesIncludes(name);
+  let buf;
+  if (existingRid !== undefined) {
+    if (options.createNew) {
+      throw new errors.AlreadyExists(`File already exists: ${name}`);
+    }
+    buf = resources.get(existingRid)!.buf;
+  }
+  const rid = resourceId++;
+  if (!buf) {
+    buf = new ArrayBuffer(0);
+  }
+  if (options.truncate) {
+    new Uint8Array(buf).set(new Uint8Array(0), 0);
+  }
+  const pos = options.append ? new Uint8Array(buf).byteLength : 0;
+  resources.set(rid, { buf, pos, name, options, closed: false });
+  return rid;
+}
+
+/** De-reference any virtual files that are closed, so that their contents
+ * can be garbage collected.  The contents of the virtual files will be lost,
+ * if there are no other resources that have the file open. */
+export function purgeResources(): void {
+  const toDelete = [];
+  for (const [key, resource] of resources) {
+    if (resource.closed) {
+      toDelete.push(key);
+    }
+  }
+  for (const key of toDelete) {
+    resources.delete(key);
+  }
+}
+
+function readResource(rid: number, data: Uint8Array): number {
+  if (resources.has(rid)) {
+    const item = resources.get(rid)!;
+    if (item.closed) {
+      throw new Error("rid closed");
+    }
+    if (item.options && !item.options.read) {
+      throw new errors.PermissionDenied(
+        `Resource not open for reading: ${rid}`,
+      );
+    }
+    const { pos } = item;
+    const ab = new Uint8Array(item.buf);
+    const remaining = ab.byteLength - pos;
+    const readLength = remaining > data.byteLength
+      ? data.byteLength
+      : remaining;
+    data.set(ab.slice(pos, pos + readLength), 0);
+    item.pos += readLength;
+    return readLength;
+  }
+  return -1;
+}
+
+function seekResource(rid: number, offset: number, whence: SeekMode): number {
+  if (resources.has(rid)) {
+    const item = resources.get(rid)!;
+    if (item.closed) {
+      throw new errors.BadResource(`Resource is closed: ${rid}`);
+    }
+    const ua = new Uint8Array(item.buf);
+    switch (whence) {
+      case SeekMode.Current:
+        item.pos = item.pos + ua.byteLength;
+        break;
+      case SeekMode.End:
+        item.pos = ua.byteLength - offset;
+        break;
+      case SeekMode.Start:
+        item.pos;
+    }
+    if (item.pos >= ua.byteLength) {
+      item.pos = ua.byteLength - 1;
+    } else if (item.pos < 0) {
+      item.pos = 0;
+    }
+    return item.pos;
+  }
+  throw new errors.BadResource(`Bad Resource: ${rid}`);
+}
+
+function truncateResource(path: string, len = 0): void {
+  const rid = resourcesIncludes(path);
+  if (rid !== undefined) {
+    const item = resources.get(rid)!;
+    const ab = new Uint8Array(item.buf);
+    const nb = new Uint8Array(ab.slice(0, len));
+    ab.set(nb, 0);
+  } else {
+    throw new errors.NotFound(`File not found: ${path}`);
+  }
+}
+
+function writeResource(rid: number, data: Uint8Array): number {
+  if (resources.has(rid)) {
+    const item = resources.get(rid)!;
+    if (item.closed) {
+      throw new errors.BadResource(`Resource is closed: ${rid}`);
+    }
+    if (item.options && !item.options.write) {
+      throw new errors.PermissionDenied(
+        `Resource not open for writing: ${rid}`,
+      );
+    }
+    const ab = new Uint8Array(item.buf);
+    const byteLength = data.byteLength + item.pos;
+    const b = new Uint8Array(
+      ab.byteLength > byteLength ? ab.byteLength : byteLength,
+    );
+    b.set(ab, 0);
+    b.set(data, item.pos);
+    item.buf = b;
+    item.pos += data.byteLength;
+    return data.byteLength;
+  }
+  return -1;
+}
+
+// ops
+
+export function close(rid: number): void {
+  closeResource(rid);
+}
+
+export function copyFile(fromPath: string, toPath: string): void {
+  copyResource(fromPath, toPath);
+}
+
+export function open(path: string, options: Deno.OpenOptions): number {
+  return openResource(path, options);
+}
+
+// eslint-disable-next-line require-await
+export async function read(
+  rid: number,
+  buffer: Uint8Array,
+): Promise<number | null> {
+  if (buffer.length === 0) {
+    return Promise.resolve(0);
+  }
+  const nread = readResource(rid, buffer);
+  if (nread < 0) {
+    throw new Error("read error");
+  } else if (nread === 0) {
+    return null;
+  } else {
+    return nread;
+  }
+}
+
+export function readSync(rid: number, buffer: Uint8Array): number | null {
+  if (buffer.length === 0) {
+    return 0;
+  }
+  const nread = readResource(rid, buffer);
+  if (nread < 0) {
+    throw new Error("read error");
+  } else if (nread === 0) {
+    return null;
+  } else {
+    return nread;
+  }
+}
+
+export function seek(
+  rid: number,
+  offset: number,
+  whence: SeekMode,
+): Promise<number> {
+  try {
+    const result = seekResource(rid, offset, whence);
+    return Promise.resolve(result);
+  } catch (e) {
+    return Promise.reject(e);
+  }
+}
+
+export function seekSync(
+  rid: number,
+  offset: number,
+  whence: SeekMode,
+): number {
+  return seekResource(rid, offset, whence);
+}
+
+export function truncate(path: string, len?: number): void {
+  truncateResource(path, len);
+}
+
+// eslint-disable-next-line require-await
+export async function write(rid: number, data: Uint8Array): Promise<number> {
+  const result = writeResource(rid, data);
+  if (result < 0) {
+    throw new Error("write error");
+  } else {
+    return result;
+  }
+}
+
+export function writeSync(rid: number, data: Uint8Array): number {
+  const result = writeResource(rid, data);
+  if (result < 0) {
+    throw new Error("write error");
+  }
+  return result;
+}

--- a/std/browser/_ops_shim.ts
+++ b/std/browser/_ops_shim.ts
@@ -16,10 +16,7 @@ interface Resource {
   closed: boolean;
 }
 
-const resources = new Map<
-  number,
-  Resource
->();
+const resources = new Map<number, Resource>();
 let resourceId = 0;
 
 function resourcesIncludes(path: string): number | undefined {
@@ -100,15 +97,14 @@ function readResource(rid: number, data: Uint8Array): number {
     }
     if (item.options && !item.options.read) {
       throw new errors.PermissionDenied(
-        `Resource not open for reading: ${rid}`,
+        `Resource not open for reading: ${rid}`
       );
     }
     const { pos } = item;
     const ab = new Uint8Array(item.buf);
     const remaining = ab.byteLength - pos;
-    const readLength = remaining > data.byteLength
-      ? data.byteLength
-      : remaining;
+    const readLength =
+      remaining > data.byteLength ? data.byteLength : remaining;
     data.set(ab.slice(pos, pos + readLength), 0);
     item.pos += readLength;
     return readLength;
@@ -163,13 +159,13 @@ function writeResource(rid: number, data: Uint8Array): number {
     }
     if (item.options && !item.options.write) {
       throw new errors.PermissionDenied(
-        `Resource not open for writing: ${rid}`,
+        `Resource not open for writing: ${rid}`
       );
     }
     const ab = new Uint8Array(item.buf);
     const byteLength = data.byteLength + item.pos;
     const b = new Uint8Array(
-      ab.byteLength > byteLength ? ab.byteLength : byteLength,
+      ab.byteLength > byteLength ? ab.byteLength : byteLength
     );
     b.set(ab, 0);
     b.set(data, item.pos);
@@ -197,7 +193,7 @@ export function open(path: string, options: Deno.OpenOptions): number {
 // eslint-disable-next-line require-await
 export async function read(
   rid: number,
-  buffer: Uint8Array,
+  buffer: Uint8Array
 ): Promise<number | null> {
   if (buffer.length === 0) {
     return Promise.resolve(0);
@@ -229,7 +225,7 @@ export function readSync(rid: number, buffer: Uint8Array): number | null {
 export function seek(
   rid: number,
   offset: number,
-  whence: SeekMode,
+  whence: SeekMode
 ): Promise<number> {
   try {
     const result = seekResource(rid, offset, whence);
@@ -242,7 +238,7 @@ export function seek(
 export function seekSync(
   rid: number,
   offset: number,
-  whence: SeekMode,
+  whence: SeekMode
 ): number {
   return seekResource(rid, offset, whence);
 }

--- a/std/browser/_ops_shim.ts
+++ b/std/browser/_ops_shim.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { errors } from "../../cli/js/errors.ts";
+import { errors } from "https://raw.githubusercontent.com/denoland/deno/v1.1.0/cli/js/errors.ts";
+export { errors } from "https://raw.githubusercontent.com/denoland/deno/v1.1.0/cli/js/errors.ts";
 
 export enum SeekMode {
   Start = 0,

--- a/std/browser/deno_shim.ts
+++ b/std/browser/deno_shim.ts
@@ -88,7 +88,15 @@ export async function unstable(): Promise<void> {
     await getDenoShim();
   }
 
-  const { DiagnosticCategory } = await import("../../cli/js/diagnostics.ts");
+  // from: cli/js/diagnostics.ts
+  enum DiagnosticCategory {
+    Log = 0,
+    Debug = 1,
+    Info = 2,
+    Error = 3,
+    Warning = 4,
+    Suggestion = 5,
+  }
 
   let umaskValue = 0o777;
 
@@ -220,11 +228,17 @@ export async function getDenoShim(): Promise<DenoNamespace> {
     return shim;
   }
 
+  // It would be great to update the version all in one go, but currently this
+  // would fail during the bundle dep analysis.
   const { Buffer, readAll, readAllSync, writeAll, writeAllSync } = await import(
-    "../../cli/js/buffer.ts"
+    "https://raw.githubusercontent.com/denoland/deno/v1.1.0/cli/js/buffer.ts"
   );
-  const { errors } = await import("../../cli/js/errors.ts");
-  const { copy, iter, iterSync } = await import("../../cli/js/io.ts");
+  const { errors } = await import(
+    "https://raw.githubusercontent.com/denoland/deno/v1.1.0/cli/js/errors.ts"
+  );
+  const { copy, iter, iterSync } = await import(
+    "https://raw.githubusercontent.com/denoland/deno/v1.1.0/cli/js/io.ts"
+  );
   const {
     close,
     copyFile: opCopyFile,

--- a/std/browser/deno_shim.ts
+++ b/std/browser/deno_shim.ts
@@ -267,12 +267,12 @@ export async function getDenoShim(): Promise<DenoNamespace> {
   const env: DenoNamespace["env"] = new Env();
 
   function cwd(): string {
-    /* eslint-disable @typescript-eslint/no-explicit-any */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (window && (window as any).location) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const loc: URL = (window as any).location;
       return `${loc.origin}${loc.pathname}`;
     }
-    /* eslint-enable @typescript-eslint/no-explicit-any */
     return "";
   }
 
@@ -323,14 +323,14 @@ export async function getDenoShim(): Promise<DenoNamespace> {
 
     if (createOrCreateNewWithoutWriteOrAppend) {
       throw new Error(
-        "'create' or 'createNew' options require 'write' or 'append' option"
+        "'create' or 'createNew' options require 'write' or 'append' option",
       );
     }
   }
 
   function open(
     path: string,
-    options: Deno.OpenOptions = { read: true }
+    options: Deno.OpenOptions = { read: true },
   ): Promise<File> {
     try {
       checkOpenOptions(options);
@@ -343,7 +343,7 @@ export async function getDenoShim(): Promise<DenoNamespace> {
 
   function openSync(
     path: string,
-    options: Deno.OpenOptions = { read: true }
+    options: Deno.OpenOptions = { read: true },
   ): File {
     checkOpenOptions(options);
     const rid = opOpen(path, options);
@@ -500,7 +500,7 @@ export async function getDenoShim(): Promise<DenoNamespace> {
   function writeFileSync(
     path: string,
     data: Uint8Array,
-    options: Deno.WriteFileOptions
+    options: Deno.WriteFileOptions,
   ): void {
     const openOptions = !!options.append
       ? { write: true, create: true, append: true }
@@ -515,7 +515,7 @@ export async function getDenoShim(): Promise<DenoNamespace> {
   async function writeFile(
     path: string,
     data: Uint8Array,
-    options: Deno.WriteFileOptions
+    options: Deno.WriteFileOptions,
   ): Promise<void> {
     writeFileSync(path, data, options);
   }
@@ -672,6 +672,7 @@ export async function getDenoShim(): Promise<DenoNamespace> {
     args: readOnly([]),
     customInspect: readOnly(customInspect),
     // Intentionally not exposed in the types
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     internal: readOnly(Symbol.for("Deno internal")),
     core: readOnly({}),

--- a/std/browser/deno_shim.ts
+++ b/std/browser/deno_shim.ts
@@ -233,13 +233,11 @@ export async function getDenoShim(): Promise<DenoNamespace> {
   const { Buffer, readAll, readAllSync, writeAll, writeAllSync } = await import(
     "https://raw.githubusercontent.com/denoland/deno/v1.1.0/cli/js/buffer.ts"
   );
-  const { errors } = await import(
-    "https://raw.githubusercontent.com/denoland/deno/v1.1.0/cli/js/errors.ts"
-  );
   const { copy, iter, iterSync } = await import(
     "https://raw.githubusercontent.com/denoland/deno/v1.1.0/cli/js/io.ts"
   );
   const {
+    errors,
     close,
     copyFile: opCopyFile,
     getResources: resources,
@@ -337,14 +335,14 @@ export async function getDenoShim(): Promise<DenoNamespace> {
 
     if (createOrCreateNewWithoutWriteOrAppend) {
       throw new Error(
-        "'create' or 'createNew' options require 'write' or 'append' option",
+        "'create' or 'createNew' options require 'write' or 'append' option"
       );
     }
   }
 
   function open(
     path: string,
-    options: Deno.OpenOptions = { read: true },
+    options: Deno.OpenOptions = { read: true }
   ): Promise<File> {
     try {
       checkOpenOptions(options);
@@ -357,7 +355,7 @@ export async function getDenoShim(): Promise<DenoNamespace> {
 
   function openSync(
     path: string,
-    options: Deno.OpenOptions = { read: true },
+    options: Deno.OpenOptions = { read: true }
   ): File {
     checkOpenOptions(options);
     const rid = opOpen(path, options);
@@ -514,7 +512,7 @@ export async function getDenoShim(): Promise<DenoNamespace> {
   function writeFileSync(
     path: string,
     data: Uint8Array,
-    options: Deno.WriteFileOptions,
+    options: Deno.WriteFileOptions
   ): void {
     const openOptions = !!options.append
       ? { write: true, create: true, append: true }
@@ -529,7 +527,7 @@ export async function getDenoShim(): Promise<DenoNamespace> {
   async function writeFile(
     path: string,
     data: Uint8Array,
-    options: Deno.WriteFileOptions,
+    options: Deno.WriteFileOptions
   ): Promise<void> {
     writeFileSync(path, data, options);
   }

--- a/std/browser/deno_shim.ts
+++ b/std/browser/deno_shim.ts
@@ -13,6 +13,7 @@ export function purgeResources(): void {
   purge && purge();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { SeekMode } from "./_ops_shim.ts";
 
 export async function getDenoShim(): Promise<DenoNamespace> {
@@ -20,13 +21,9 @@ export async function getDenoShim(): Promise<DenoNamespace> {
     return denoShim;
   }
 
-  const {
-    Buffer,
-    readAll,
-    readAllSync,
-    writeAll,
-    writeAllSync,
-  } = await import("../../cli/js/buffer.ts");
+  const { Buffer, readAll, readAllSync, writeAll, writeAllSync } = await import(
+    "../../cli/js/buffer.ts"
+  );
   const { DiagnosticCategory } = await import("../../cli/js/diagnostics.ts");
   const { errors } = await import("../../cli/js/errors.ts");
   const { copy, iter, iterSync } = await import("../../cli/js/io.ts");
@@ -78,10 +75,12 @@ export async function getDenoShim(): Promise<DenoNamespace> {
   const env: DenoNamespace["env"] = new Env();
 
   function cwd(): string {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     if (window && (window as any).location) {
       const loc: URL = (window as any).location;
       return `${loc.origin}${loc.pathname}`;
     }
+    /* eslint-enable @typescript-eslint/no-explicit-any */
     return "";
   }
 
@@ -132,14 +131,14 @@ export async function getDenoShim(): Promise<DenoNamespace> {
 
     if (createOrCreateNewWithoutWriteOrAppend) {
       throw new Error(
-        "'create' or 'createNew' options require 'write' or 'append' option",
+        "'create' or 'createNew' options require 'write' or 'append' option"
       );
     }
   }
 
   function open(
     path: string,
-    options: Deno.OpenOptions = { read: true },
+    options: Deno.OpenOptions = { read: true }
   ): Promise<File> {
     try {
       checkOpenOptions(options);
@@ -152,7 +151,7 @@ export async function getDenoShim(): Promise<DenoNamespace> {
 
   function openSync(
     path: string,
-    options: Deno.OpenOptions = { read: true },
+    options: Deno.OpenOptions = { read: true }
   ): File {
     checkOpenOptions(options);
     const rid = opOpen(path, options);
@@ -242,9 +241,11 @@ export async function getDenoShim(): Promise<DenoNamespace> {
     return false;
   }
 
-  function makeTempDirSync(
-    { dir = "/tmp", prefix = "", suffix = "" }: Deno.MakeTempOptions = {},
-  ): string {
+  function makeTempDirSync({
+    dir = "/tmp",
+    prefix = "",
+    suffix = "",
+  }: Deno.MakeTempOptions = {}): string {
     const str = Math.random().toString(36).substring(7);
     return `${dir}${dir.match(/\/$/) ? "" : "/"}${prefix}${str}${suffix}`;
   }
@@ -307,7 +308,7 @@ export async function getDenoShim(): Promise<DenoNamespace> {
   function writeFileSync(
     path: string,
     data: Uint8Array,
-    options: Deno.WriteFileOptions,
+    options: Deno.WriteFileOptions
   ): void {
     const openOptions = !!options.append
       ? { write: true, create: true, append: true }
@@ -322,7 +323,7 @@ export async function getDenoShim(): Promise<DenoNamespace> {
   async function writeFile(
     path: string,
     data: Uint8Array,
-    options: Deno.WriteFileOptions,
+    options: Deno.WriteFileOptions
   ): Promise<void> {
     writeFileSync(path, data, options);
   }
@@ -396,105 +397,105 @@ export async function getDenoShim(): Promise<DenoNamespace> {
   const shim: DenoNamespace = Object.create(null);
 
   Object.defineProperties(shim, {
-    "errors": readOnly(errors),
-    "pid": readOnly(0),
-    "noColor": readOnly(true),
+    errors: readOnly(errors),
+    pid: readOnly(0),
+    noColor: readOnly(true),
     // TODO figure out what to do about the test interface
-    "test": readOnly(noop),
-    "exit": readOnly(exit),
-    "env": readOnly(env),
-    "execPath": readOnly(() => "/usr/bin/deno"),
-    "chdir": readOnly(noop),
-    "cwd": readOnly(cwd),
-    "SeekMode": readOnly(SeekMode),
-    "copy": readOnly(copy),
-    "iter": readOnly(iter),
-    "iterSync": readOnly(iterSync),
-    "open": readOnly(open),
-    "openSync": readOnly(openSync),
-    "create": readOnly(create),
-    "createSync": readOnly(createSync),
-    "read": readOnly(read),
-    "readSync": readOnly(readSync),
-    "write": readOnly(write),
-    "writeSync": readOnly(writeSync),
-    "seek": readOnly(seek),
-    "seekSync": readOnly(seekSync),
-    "close": readOnly(close),
-    "File": readOnly(File),
-    "stdin": readOnly(stdin),
-    "stdout": readOnly(stdout),
-    "stderr": readOnly(stderr),
-    "isatty": readOnly(isatty),
-    "Buffer": readOnly(Buffer),
-    "readAll": readOnly(readAll),
-    "readAllSync": readOnly(readAllSync),
-    "writeAll": readOnly(writeAll),
-    "writeAllSync": readOnly(writeAllSync),
-    "mkdirSync": readOnly(noop),
-    "mkdir": readOnly(asyncNoop),
-    "makeTempDirSync": readOnly(makeTempDirSync),
-    "makeTempDir": readOnly(makeTempDir),
-    "makeTempFileSync": readOnly(makeTempFileSync),
-    "makeTempFile": readOnly(makeTempFile),
-    "chmodSync": readOnly(noop),
-    "chmod": readOnly(asyncNoop),
-    "chownSync": readOnly(noop),
-    "chown": readOnly(asyncNoop),
+    test: readOnly(noop),
+    exit: readOnly(exit),
+    env: readOnly(env),
+    execPath: readOnly(() => "/usr/bin/deno"),
+    chdir: readOnly(noop),
+    cwd: readOnly(cwd),
+    SeekMode: readOnly(SeekMode),
+    copy: readOnly(copy),
+    iter: readOnly(iter),
+    iterSync: readOnly(iterSync),
+    open: readOnly(open),
+    openSync: readOnly(openSync),
+    create: readOnly(create),
+    createSync: readOnly(createSync),
+    read: readOnly(read),
+    readSync: readOnly(readSync),
+    write: readOnly(write),
+    writeSync: readOnly(writeSync),
+    seek: readOnly(seek),
+    seekSync: readOnly(seekSync),
+    close: readOnly(close),
+    File: readOnly(File),
+    stdin: readOnly(stdin),
+    stdout: readOnly(stdout),
+    stderr: readOnly(stderr),
+    isatty: readOnly(isatty),
+    Buffer: readOnly(Buffer),
+    readAll: readOnly(readAll),
+    readAllSync: readOnly(readAllSync),
+    writeAll: readOnly(writeAll),
+    writeAllSync: readOnly(writeAllSync),
+    mkdirSync: readOnly(noop),
+    mkdir: readOnly(asyncNoop),
+    makeTempDirSync: readOnly(makeTempDirSync),
+    makeTempDir: readOnly(makeTempDir),
+    makeTempFileSync: readOnly(makeTempFileSync),
+    makeTempFile: readOnly(makeTempFile),
+    chmodSync: readOnly(noop),
+    chmod: readOnly(asyncNoop),
+    chownSync: readOnly(noop),
+    chown: readOnly(asyncNoop),
     // TODO consider implementing
-    "removeSync": readOnly(noop),
+    removeSync: readOnly(noop),
     // TODO consider implementing
-    "remove": readOnly(asyncNoop),
+    remove: readOnly(asyncNoop),
     // TODO consider implementing
-    "renameSync": readOnly(noop),
+    renameSync: readOnly(noop),
     // TODO consider implementing
-    "rename": readOnly(asyncNoop),
-    "readTextFileSync": readOnly(readTextFileSync),
-    "readTextFile": readOnly(readTextFile),
-    "readFileSync": readOnly(readFileSync),
-    "readFile": readOnly(readFile),
-    "realPathSync": readOnly(realPathSync),
-    "realPath": readOnly(realPath),
+    rename: readOnly(asyncNoop),
+    readTextFileSync: readOnly(readTextFileSync),
+    readTextFile: readOnly(readTextFile),
+    readFileSync: readOnly(readFileSync),
+    readFile: readOnly(readFile),
+    realPathSync: readOnly(realPathSync),
+    realPath: readOnly(realPath),
     // TODO consider implementing
-    "readDirSync": readOnly(genNoop),
+    readDirSync: readOnly(genNoop),
     // TODO consider implementing
-    "readDir": readOnly(asyncGenNoop),
-    "copyFileSync": readOnly(copyFileSync),
-    "copyFile": readOnly(copyFile),
-    "readLinkSync": readOnly(notImplemented),
-    "readLink": readOnly(notImplemented),
-    "lstat": readOnly(notImplemented),
-    "lstatSync": readOnly(notImplemented),
-    "stat": readOnly(notImplemented),
-    "statSync": readOnly(notImplemented),
-    "writeFileSync": readOnly(writeFileSync),
-    "writeFile": readOnly(writeFile),
-    "writeTextFileSync": readOnly(writeTextFileSync),
-    "writeTextFile": readOnly(writeTextFile),
-    "truncateSync": readOnly(truncateSync),
-    "truncate": readOnly(truncate),
-    "listen": readOnly(notImplemented),
-    "listenTls": readOnly(notImplemented),
-    "connect": readOnly(notImplemented),
-    "connectTls": readOnly(notImplemented),
-    "metrics": readOnly(metrics),
-    "resources": readOnly(resources),
-    "watchFs": readOnly(asyncGenNoop),
-    "Process": readOnly(notImplemented),
-    "run": readOnly(notImplemented),
+    readDir: readOnly(asyncGenNoop),
+    copyFileSync: readOnly(copyFileSync),
+    copyFile: readOnly(copyFile),
+    readLinkSync: readOnly(notImplemented),
+    readLink: readOnly(notImplemented),
+    lstat: readOnly(notImplemented),
+    lstatSync: readOnly(notImplemented),
+    stat: readOnly(notImplemented),
+    statSync: readOnly(notImplemented),
+    writeFileSync: readOnly(writeFileSync),
+    writeFile: readOnly(writeFile),
+    writeTextFileSync: readOnly(writeTextFileSync),
+    writeTextFile: readOnly(writeTextFile),
+    truncateSync: readOnly(truncateSync),
+    truncate: readOnly(truncate),
+    listen: readOnly(notImplemented),
+    listenTls: readOnly(notImplemented),
+    connect: readOnly(notImplemented),
+    connectTls: readOnly(notImplemented),
+    metrics: readOnly(metrics),
+    resources: readOnly(resources),
+    watchFs: readOnly(asyncGenNoop),
+    Process: readOnly(notImplemented),
+    run: readOnly(notImplemented),
     // TODO consider implementing
-    "inspect": readOnly(notImplemented),
-    "build": readOnly(build),
-    "version": readOnly(version),
-    "args": readOnly([]),
-    "customInspect": readOnly(customInspect),
+    inspect: readOnly(notImplemented),
+    build: readOnly(build),
+    version: readOnly(version),
+    args: readOnly([]),
+    customInspect: readOnly(customInspect),
     // Intentionally not in Deno namespace
-    "internal": readOnly(Symbol.for("Deno internal")),
-    "core": readOnly({}),
+    internal: readOnly(Symbol.for("Deno internal")),
+    core: readOnly({}),
     // TODO see: https://github.com/denoland/deno/issues/5744
-    "DiagnosticCategory": readOnly(DiagnosticCategory),
+    DiagnosticCategory: readOnly(DiagnosticCategory),
     // TODO see: https://github.com/denoland/deno/issues/5745
-    "dir": readOnly(notImplemented),
+    dir: readOnly(notImplemented),
   });
 
   Object.freeze(shim);
@@ -502,9 +503,8 @@ export async function getDenoShim(): Promise<DenoNamespace> {
 }
 
 if (!("Deno" in window)) {
-  Object.defineProperty(
-    window,
-    "Deno",
-    { value: await getDenoShim(), enumerable: true },
-  );
+  Object.defineProperty(window, "Deno", {
+    value: await getDenoShim(),
+    enumerable: true,
+  });
 }

--- a/std/browser/deno_shim.ts
+++ b/std/browser/deno_shim.ts
@@ -1,0 +1,510 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+type DenoNamespace = typeof Deno;
+type DenoEnv = DenoNamespace["env"];
+
+let denoShim: DenoNamespace | undefined;
+let purge: () => void | undefined;
+
+/** De-reference any virtual files that are closed, so that their contents
+ * can be garbage collected.  The contents of the virtual files will be lost,
+ * if there are no other resources that have the file open. */
+export function purgeResources(): void {
+  purge && purge();
+}
+
+import type { SeekMode } from "./_ops_shim.ts";
+
+export async function getDenoShim(): Promise<DenoNamespace> {
+  if (denoShim) {
+    return denoShim;
+  }
+
+  const {
+    Buffer,
+    readAll,
+    readAllSync,
+    writeAll,
+    writeAllSync,
+  } = await import("../../cli/js/buffer.ts");
+  const { DiagnosticCategory } = await import("../../cli/js/diagnostics.ts");
+  const { errors } = await import("../../cli/js/errors.ts");
+  const { copy, iter, iterSync } = await import("../../cli/js/io.ts");
+  const {
+    close,
+    copyFile: opCopyFile,
+    getResources: resources,
+    open: opOpen,
+    purgeResources,
+    read,
+    readSync,
+    seek,
+    SeekMode,
+    seekSync,
+    truncate: opTruncate,
+    write,
+    writeSync,
+  } = await import("./_ops_shim.ts");
+
+  purge = purgeResources;
+
+  function readOnly(value: unknown): PropertyDescriptor {
+    return {
+      value,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    };
+  }
+
+  function exit(): void {
+    window && window.close();
+  }
+
+  class Env implements DenoEnv {
+    #env: Record<string, string> = {};
+
+    get(key: string): string | undefined {
+      return this.#env[key];
+    }
+    set(key: string, value: string): void {
+      this.#env[key] = value;
+    }
+    toObject(): Record<string, string> {
+      return { ...this.#env };
+    }
+  }
+
+  const env: DenoNamespace["env"] = new Env();
+
+  function cwd(): string {
+    if (window && (window as any).location) {
+      const loc: URL = (window as any).location;
+      return `${loc.origin}${loc.pathname}`;
+    }
+    return "";
+  }
+
+  class File implements Deno.File {
+    constructor(readonly rid: number) {}
+
+    write(p: Uint8Array): Promise<number> {
+      return write(this.rid, p);
+    }
+
+    writeSync(p: Uint8Array): number {
+      return writeSync(this.rid, p);
+    }
+
+    read(p: Uint8Array): Promise<number | null> {
+      return read(this.rid, p);
+    }
+
+    readSync(p: Uint8Array): number | null {
+      return readSync(this.rid, p);
+    }
+
+    seek(offset: number, whence: SeekMode): Promise<number> {
+      return seek(this.rid, offset, whence);
+    }
+
+    seekSync(offset: number, whence: SeekMode): number {
+      return seekSync(this.rid, offset, whence);
+    }
+
+    close(): void {
+      close(this.rid);
+    }
+  }
+
+  function checkOpenOptions(options: Deno.OpenOptions): void {
+    if (Object.values(options).some((val) => val === true)) {
+      throw new Error("OpenOptions requires at least one option to be true");
+    }
+
+    if (options.truncate && !options.write) {
+      throw new Error("'truncate' option requires 'write' option");
+    }
+
+    const createOrCreateNewWithoutWriteOrAppend =
+      (options.create || options.createNew) &&
+      !(options.write || options.append);
+
+    if (createOrCreateNewWithoutWriteOrAppend) {
+      throw new Error(
+        "'create' or 'createNew' options require 'write' or 'append' option",
+      );
+    }
+  }
+
+  function open(
+    path: string,
+    options: Deno.OpenOptions = { read: true },
+  ): Promise<File> {
+    try {
+      checkOpenOptions(options);
+      const rid = opOpen(path, options);
+      return Promise.resolve(new File(rid));
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  }
+
+  function openSync(
+    path: string,
+    options: Deno.OpenOptions = { read: true },
+  ): File {
+    checkOpenOptions(options);
+    const rid = opOpen(path, options);
+    return new File(rid);
+  }
+
+  function create(path: string): Promise<File> {
+    return open(path, {
+      read: true,
+      write: true,
+      truncate: true,
+      create: true,
+    });
+  }
+
+  function createSync(path: string): File {
+    return openSync(path, {
+      read: true,
+      write: true,
+      truncate: true,
+      create: true,
+    });
+  }
+
+  class Stdin implements Deno.Reader, Deno.ReaderSync, Deno.Closer {
+    readonly rid: number;
+    constructor() {
+      this.rid = opOpen("/dev/stdin", { read: true });
+    }
+
+    read(p: Uint8Array): Promise<number | null> {
+      return read(this.rid, p);
+    }
+
+    readSync(p: Uint8Array): number | null {
+      return readSync(this.rid, p);
+    }
+
+    close(): void {
+      close(this.rid);
+    }
+  }
+
+  class Stdout implements Deno.Writer, Deno.WriterSync, Deno.Closer {
+    readonly rid: number;
+    constructor() {
+      this.rid = opOpen("/dev/stdout", { write: true });
+    }
+
+    write(p: Uint8Array): Promise<number> {
+      return write(this.rid, p);
+    }
+
+    writeSync(p: Uint8Array): number {
+      return writeSync(this.rid, p);
+    }
+
+    close(): void {
+      close(this.rid);
+    }
+  }
+
+  class Stderr implements Deno.Writer, Deno.WriterSync, Deno.Closer {
+    readonly rid: number;
+    constructor() {
+      this.rid = opOpen("/dev/stderr", { write: true });
+    }
+
+    write(p: Uint8Array): Promise<number> {
+      return write(this.rid, p);
+    }
+
+    writeSync(p: Uint8Array): number {
+      return writeSync(this.rid, p);
+    }
+
+    close(): void {
+      close(this.rid);
+    }
+  }
+
+  const stdin = new Stdin();
+  const stdout = new Stdout();
+  const stderr = new Stderr();
+
+  function isatty(): boolean {
+    return false;
+  }
+
+  function makeTempDirSync(
+    { dir = "/tmp", prefix = "", suffix = "" }: Deno.MakeTempOptions = {},
+  ): string {
+    const str = Math.random().toString(36).substring(7);
+    return `${dir}${dir.match(/\/$/) ? "" : "/"}${prefix}${str}${suffix}`;
+  }
+
+  function makeTempDir(options?: Deno.MakeTempOptions): Promise<string> {
+    return Promise.resolve(makeTempDirSync(options));
+  }
+
+  function makeTempFileSync(options?: Deno.MakeTempOptions): string {
+    const str = makeTempDirSync(options);
+    opOpen(str, { read: true });
+    return str;
+  }
+
+  function makeTempFile(options?: Deno.MakeTempOptions): Promise<string> {
+    return Promise.resolve(makeTempFileSync(options));
+  }
+
+  const decoder = new TextDecoder();
+
+  function readTextFileSync(path: string): string {
+    const file = openSync(path);
+    const content = readAllSync(file);
+    file.close();
+    return decoder.decode(content);
+  }
+
+  function readTextFile(path: string): Promise<string> {
+    return Promise.resolve(readTextFileSync(path));
+  }
+
+  function readFileSync(path: string): Uint8Array {
+    const file = openSync(path);
+    const content = readAllSync(file);
+    file.close();
+    return content;
+  }
+
+  function readFile(path: string): Promise<Uint8Array> {
+    return Promise.resolve(readFileSync(path));
+  }
+
+  function realPathSync(path: string): string {
+    return path;
+  }
+
+  function realPath(path: string): Promise<string> {
+    return Promise.resolve(realPathSync(path));
+  }
+
+  function copyFileSync(fromPath: string, toPath: string): void {
+    opCopyFile(fromPath, toPath);
+  }
+
+  // eslint-disable-next-line require-await
+  async function copyFile(fromPath: string, toPath: string): Promise<void> {
+    copyFileSync(fromPath, toPath);
+  }
+
+  function writeFileSync(
+    path: string,
+    data: Uint8Array,
+    options: Deno.WriteFileOptions,
+  ): void {
+    const openOptions = !!options.append
+      ? { write: true, create: true, append: true }
+      : { write: true, create: true, truncate: true };
+    const file = openSync(path, openOptions);
+
+    writeAllSync(file, data);
+    file.close();
+  }
+
+  // eslint-disable-next-line require-await
+  async function writeFile(
+    path: string,
+    data: Uint8Array,
+    options: Deno.WriteFileOptions,
+  ): Promise<void> {
+    writeFileSync(path, data, options);
+  }
+
+  const encoder = new TextEncoder();
+
+  function writeTextFileSync(path: string, data: string): void {
+    const file = openSync(path, { write: true, create: true, truncate: true });
+    const contents = encoder.encode(data);
+    writeAllSync(file, contents);
+    file.close();
+  }
+
+  // eslint-disable-next-line require-await
+  async function writeTextFile(path: string, data: string): Promise<void> {
+    writeTextFileSync(path, data);
+  }
+
+  function truncateSync(path: string, len?: number): void {
+    opTruncate(path, len);
+  }
+
+  // eslint-disable-next-line require-await
+  async function truncate(path: string, len?: number): Promise<void> {
+    opTruncate(path, len);
+  }
+
+  function metrics(): Deno.Metrics {
+    return {
+      opsDispatched: 0,
+      opsDispatchedSync: 0,
+      opsDispatchedAsync: 0,
+      opsDispatchedAsyncUnref: 0,
+      opsCompleted: 0,
+      opsCompletedSync: 0,
+      opsCompletedAsync: 0,
+      opsCompletedAsyncUnref: 0,
+      bytesSentControl: 0,
+      bytesSentData: 0,
+      bytesReceived: 0,
+    };
+  }
+
+  const build = {
+    target: "browser",
+    arch: "x86_64",
+    os: "browser",
+    vendor: "browser",
+  };
+
+  Object.freeze(build);
+
+  const version: Deno.Version = {
+    deno: "0.0.0",
+    typescript: "0.0.0",
+    v8: "0.0.0",
+  };
+
+  Object.freeze(build);
+
+  const customInspect = Symbol.for("custom inspect");
+
+  function noop(): void {}
+  async function asyncNoop(): Promise<void> {}
+  function* genNoop(): Iterable<void> {}
+  async function* asyncGenNoop(): AsyncIterable<void> {}
+  function notImplemented(): never {
+    throw new Error("This feature is not implemented in browsers.");
+  }
+
+  const shim: DenoNamespace = Object.create(null);
+
+  Object.defineProperties(shim, {
+    "errors": readOnly(errors),
+    "pid": readOnly(0),
+    "noColor": readOnly(true),
+    // TODO figure out what to do about the test interface
+    "test": readOnly(noop),
+    "exit": readOnly(exit),
+    "env": readOnly(env),
+    "execPath": readOnly(() => "/usr/bin/deno"),
+    "chdir": readOnly(noop),
+    "cwd": readOnly(cwd),
+    "SeekMode": readOnly(SeekMode),
+    "copy": readOnly(copy),
+    "iter": readOnly(iter),
+    "iterSync": readOnly(iterSync),
+    "open": readOnly(open),
+    "openSync": readOnly(openSync),
+    "create": readOnly(create),
+    "createSync": readOnly(createSync),
+    "read": readOnly(read),
+    "readSync": readOnly(readSync),
+    "write": readOnly(write),
+    "writeSync": readOnly(writeSync),
+    "seek": readOnly(seek),
+    "seekSync": readOnly(seekSync),
+    "close": readOnly(close),
+    "File": readOnly(File),
+    "stdin": readOnly(stdin),
+    "stdout": readOnly(stdout),
+    "stderr": readOnly(stderr),
+    "isatty": readOnly(isatty),
+    "Buffer": readOnly(Buffer),
+    "readAll": readOnly(readAll),
+    "readAllSync": readOnly(readAllSync),
+    "writeAll": readOnly(writeAll),
+    "writeAllSync": readOnly(writeAllSync),
+    "mkdirSync": readOnly(noop),
+    "mkdir": readOnly(asyncNoop),
+    "makeTempDirSync": readOnly(makeTempDirSync),
+    "makeTempDir": readOnly(makeTempDir),
+    "makeTempFileSync": readOnly(makeTempFileSync),
+    "makeTempFile": readOnly(makeTempFile),
+    "chmodSync": readOnly(noop),
+    "chmod": readOnly(asyncNoop),
+    "chownSync": readOnly(noop),
+    "chown": readOnly(asyncNoop),
+    // TODO consider implementing
+    "removeSync": readOnly(noop),
+    // TODO consider implementing
+    "remove": readOnly(asyncNoop),
+    // TODO consider implementing
+    "renameSync": readOnly(noop),
+    // TODO consider implementing
+    "rename": readOnly(asyncNoop),
+    "readTextFileSync": readOnly(readTextFileSync),
+    "readTextFile": readOnly(readTextFile),
+    "readFileSync": readOnly(readFileSync),
+    "readFile": readOnly(readFile),
+    "realPathSync": readOnly(realPathSync),
+    "realPath": readOnly(realPath),
+    // TODO consider implementing
+    "readDirSync": readOnly(genNoop),
+    // TODO consider implementing
+    "readDir": readOnly(asyncGenNoop),
+    "copyFileSync": readOnly(copyFileSync),
+    "copyFile": readOnly(copyFile),
+    "readLinkSync": readOnly(notImplemented),
+    "readLink": readOnly(notImplemented),
+    "lstat": readOnly(notImplemented),
+    "lstatSync": readOnly(notImplemented),
+    "stat": readOnly(notImplemented),
+    "statSync": readOnly(notImplemented),
+    "writeFileSync": readOnly(writeFileSync),
+    "writeFile": readOnly(writeFile),
+    "writeTextFileSync": readOnly(writeTextFileSync),
+    "writeTextFile": readOnly(writeTextFile),
+    "truncateSync": readOnly(truncateSync),
+    "truncate": readOnly(truncate),
+    "listen": readOnly(notImplemented),
+    "listenTls": readOnly(notImplemented),
+    "connect": readOnly(notImplemented),
+    "connectTls": readOnly(notImplemented),
+    "metrics": readOnly(metrics),
+    "resources": readOnly(resources),
+    "watchFs": readOnly(asyncGenNoop),
+    "Process": readOnly(notImplemented),
+    "run": readOnly(notImplemented),
+    // TODO consider implementing
+    "inspect": readOnly(notImplemented),
+    "build": readOnly(build),
+    "version": readOnly(version),
+    "args": readOnly([]),
+    "customInspect": readOnly(customInspect),
+    // Intentionally not in Deno namespace
+    "internal": readOnly(Symbol.for("Deno internal")),
+    "core": readOnly({}),
+    // TODO see: https://github.com/denoland/deno/issues/5744
+    "DiagnosticCategory": readOnly(DiagnosticCategory),
+    // TODO see: https://github.com/denoland/deno/issues/5745
+    "dir": readOnly(notImplemented),
+  });
+
+  Object.freeze(shim);
+  return shim;
+}
+
+if (!("Deno" in window)) {
+  Object.defineProperty(
+    window,
+    "Deno",
+    { value: await getDenoShim(), enumerable: true },
+  );
+}

--- a/std/browser/deno_shim_test.ts
+++ b/std/browser/deno_shim_test.ts
@@ -1,0 +1,27 @@
+import { getDenoShim } from "./deno_shim.ts";
+import { assert } from "../testing/asserts.ts";
+
+const { test } = Deno;
+
+const denoShim = await getDenoShim();
+
+test({
+  name: "denoShim equality",
+  fn() {
+    assert(denoShim !== Deno);
+  },
+});
+
+test({
+  name: "property match",
+  fn() {
+    for (const key of Object.keys(Deno)) {
+      assert(key in denoShim, `${key} should be in denoShim`);
+      assert(
+        typeof denoShim[key as keyof typeof denoShim] ===
+          typeof Deno[key as keyof typeof Deno],
+        `Types of property ${key} should match.`,
+      );
+    }
+  },
+});

--- a/std/browser/deno_shim_test.ts
+++ b/std/browser/deno_shim_test.ts
@@ -20,7 +20,7 @@ test({
       assert(
         typeof denoShim[key as keyof typeof denoShim] ===
           typeof Deno[key as keyof typeof Deno],
-        `Types of property ${key} should match.`,
+        `Types of property ${key} should match.`
       );
     }
   },

--- a/std/browser/deno_shim_test.ts
+++ b/std/browser/deno_shim_test.ts
@@ -1,5 +1,5 @@
-import { getDenoShim } from "./deno_shim.ts";
-import { assert } from "../testing/asserts.ts";
+import { getDenoShim, unstable } from "./deno_shim.ts";
+import { assert, assertEquals } from "../testing/asserts.ts";
 
 const { test } = Deno;
 
@@ -12,16 +12,83 @@ test({
   },
 });
 
+const unstableNames = [
+  "umask",
+  "linkSync",
+  "link",
+  "symlinkSync",
+  "symlink",
+  "dir",
+  "loadavg",
+  "osRelease",
+  "openPlugin",
+  "DiagnosticCategory",
+  "formatDiagnostics",
+  "transpileOnly",
+  "compile",
+  "bundle",
+  "applySourceMap",
+  "Signal",
+  "SignalStream",
+  "signal",
+  "signals",
+  "setRaw",
+  "utimeSync",
+  "utime",
+  "ShutdownMode",
+  "shutdown",
+  "listenDatagram",
+  "startTls",
+  "kill",
+  "Permissions",
+  "permissions",
+  "PermissionStatus",
+  "hostname",
+];
+
 test({
-  name: "property match",
+  name: "deno_shim - property match",
   fn() {
     for (const key of Object.keys(Deno)) {
+      if (unstableNames.includes(key)) {
+        // denoShim does not contain unstable APIs.
+        continue;
+      }
       assert(key in denoShim, `${key} should be in denoShim`);
       assert(
         typeof denoShim[key as keyof typeof denoShim] ===
           typeof Deno[key as keyof typeof Deno],
         `Types of property ${key} should match.`
       );
+      const desc = Object.getOwnPropertyDescriptor(denoShim, key);
+      assert(desc);
+      assertEquals(desc.enumerable, true, "should be enumerable");
+      assertEquals(desc.writable, false, "should be read only");
+      assertEquals(desc.configurable, false, "should not be configurable");
+    }
+  },
+});
+
+test({
+  name: "deno_shim - unstable property match",
+  async fn() {
+    await unstable();
+    const unstableShim = await getDenoShim();
+    for (const key of unstableNames) {
+      if (!(key in Deno)) {
+        continue;
+      }
+      assert(key in unstableShim, `${key} should be in shim`);
+      assert(
+        typeof unstableShim[key as keyof typeof unstableShim] ===
+          typeof Deno[key as keyof typeof Deno],
+        `Types of property ${key} should match.`
+      );
+      const desc = Object.getOwnPropertyDescriptor(unstableShim, key);
+      assert(desc);
+      assertEquals(desc.enumerable, true, "should be enumerable");
+      assertEquals(desc.writable, false, "should be read only");
+      assertEquals(desc.configurable, false, "should not be configurable");
     }
   },
 });

--- a/std/browser/deno_shim_test.ts
+++ b/std/browser/deno_shim_test.ts
@@ -44,6 +44,7 @@ const unstableNames = [
   "permissions",
   "PermissionStatus",
   "hostname",
+  "mainModule",
 ];
 
 test({
@@ -90,5 +91,16 @@ test({
       assertEquals(desc.writable, false, "should be read only");
       assertEquals(desc.configurable, false, "should not be configurable");
     }
+  },
+});
+
+test({
+  name: "deno_shim - basic file system APIs",
+  async fn() {
+    const shim = await getDenoShim();
+    const tmpFile = await shim.makeTempFile();
+    await shim.writeTextFile(tmpFile, "hello world!");
+    const actual = await shim.readTextFile(tmpFile);
+    assertEquals(actual, "hello world!");
   },
 });

--- a/std/browser/examples/main.ts
+++ b/std/browser/examples/main.ts
@@ -1,0 +1,26 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+// This example is designed to simply write out a "hello world!" to a temporary
+// file, read it back in, and log its contents to the console.  If you wanted
+// to run the example in a browser, you would want to bundle it:
+//
+//     $ deno bundle https://deno.land/x/std/browsers/examples/main.ts example.js
+//
+// You would then want to load the example as a module in a web page, like:
+//
+//     <script type="module" src="./example.js"></script>
+//
+// And then navigate to that web page to see the results.
+//
+
+import { init } from "../deno_shim.ts";
+
+async function main(): Promise<void> {
+  await init();
+  const tmpFile = await Deno.makeTempFile();
+  await Deno.writeTextFile(tmpFile, "hello world!");
+  const txt = await Deno.readTextFile(tmpFile);
+  console.log(txt);
+}
+
+main();

--- a/std/browser/examples/main.ts
+++ b/std/browser/examples/main.ts
@@ -4,7 +4,7 @@
 // file, read it back in, and log its contents to the console.  If you wanted
 // to run the example in a browser, you would want to bundle it:
 //
-//     $ deno bundle https://deno.land/x/std/browsers/examples/main.ts example.js
+//     $ deno bundle https://deno.land/x/std/browser/examples/main.ts example.js
 //
 // You would then want to load the example as a module in a web page, like:
 //

--- a/std/browser/examples/main.ts
+++ b/std/browser/examples/main.ts
@@ -4,7 +4,7 @@
 // file, read it back in, and log its contents to the console.  If you wanted
 // to run the example in a browser, you would want to bundle it:
 //
-//     $ deno bundle https://deno.land/x/std/browser/examples/main.ts example.js
+//     $ deno bundle --allow-net https://deno.land/x/std/browser/examples/main.ts example.js
 //
 // You would then want to load the example as a module in a web page, like:
 //


### PR DESCRIPTION
This is a proof of concept to create a shim of the Deno namespace which can be used in browsers with code that touches the Deno namespace but also is intended to be used in browsers.  This "stubs" off all the `Deno` APIs so that any code that touches the `Deno` namespace will not throw accidentally.  It also includes a virtual filesystem/resources so that a lot of the Deno API functionality could be mocked.

The shim could also be used as a pattern for making a fully in browser Deno-like playground.