### PR TITLE
pref: add textEncoder instead of using Uint8Array in test_plugin example

### DIFF
--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -32,7 +32,7 @@ const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
  
 function runTestSync() {
-  var view = textEncoder.encode("test");
+  let view = textEncoder.encode("test");
   
   const response = Deno.core.dispatch(
     testSync,
@@ -48,7 +48,7 @@ Deno.core.setAsyncHandler(testAsync, (response) => {
 });
 
 function runTestAsync() {
-  var view = textEncoder.encode("test");
+  let view = textEncoder.encode("test");
   
   const response = Deno.core.dispatch(
     testAsync,

--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -29,11 +29,15 @@ if (!(testAsync > 0)) {
 
 const textDecoder = new TextDecoder();
 
+const textEncoder = new TextEncoder();
+ 
 function runTestSync() {
+  var view = textEncoder.encode("test");
+  
   const response = Deno.core.dispatch(
     testSync,
-    new Uint8Array([116, 101, 115, 116]),
-    new Uint8Array([116, 101, 115, 116])
+    view,
+    view
   );
 
   console.log(`Plugin Sync Response: ${textDecoder.decode(response)}`);
@@ -44,10 +48,12 @@ Deno.core.setAsyncHandler(testAsync, (response) => {
 });
 
 function runTestAsync() {
+  var view = textEncoder.encode("test");
+  
   const response = Deno.core.dispatch(
     testAsync,
-    new Uint8Array([116, 101, 115, 116]),
-    new Uint8Array([116, 101, 115, 116])
+    view,
+    view
   );
 
   if (response != null || response != undefined) {

--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -30,15 +30,11 @@ if (!(testAsync > 0)) {
 const textDecoder = new TextDecoder();
 
 const textEncoder = new TextEncoder();
- 
+
 function runTestSync() {
   const view = textEncoder.encode("test");
-  
-  const response = Deno.core.dispatch(
-    testSync,
-    view,
-    view
-  );
+
+  const response = Deno.core.dispatch(testSync, view, view);
 
   console.log(`Plugin Sync Response: ${textDecoder.decode(response)}`);
 }
@@ -49,12 +45,8 @@ Deno.core.setAsyncHandler(testAsync, (response) => {
 
 function runTestAsync() {
   const view = textEncoder.encode("test");
-  
-  const response = Deno.core.dispatch(
-    testAsync,
-    view,
-    view
-  );
+
+  const response = Deno.core.dispatch(testAsync, view, view);
 
   if (response != null || response != undefined) {
     throw new Error("Expected null response!");

--- a/test_plugin/tests/test.js
+++ b/test_plugin/tests/test.js
@@ -32,7 +32,7 @@ const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
  
 function runTestSync() {
-  let view = textEncoder.encode("test");
+  const view = textEncoder.encode("test");
   
   const response = Deno.core.dispatch(
     testSync,
@@ -48,7 +48,7 @@ Deno.core.setAsyncHandler(testAsync, (response) => {
 });
 
 function runTestAsync() {
-  let view = textEncoder.encode("test");
+  const view = textEncoder.encode("test");
   
   const response = Deno.core.dispatch(
     testAsync,


### PR DESCRIPTION
To make it easier for people to understand what's going on, I've added a textEncoder in the test_plugin.