### PR TITLE
fix: TSX analysis in module graph loader

### DIFF
--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -48,6 +48,13 @@ where
   }
 }
 
+const SUPPORTED_MEDIA_TYPES: [MediaType; 4] = [
+  MediaType::JavaScript,
+  MediaType::TypeScript,
+  MediaType::JSX,
+  MediaType::TSX,
+];
+
 #[derive(Debug, Serialize)]
 pub struct ModuleGraph(HashMap<String, ModuleGraphFile>);
 
@@ -384,9 +391,7 @@ impl ModuleGraphLoader {
     let module_specifier = ModuleSpecifier::from(source_file.url.clone());
     let source_code = String::from_utf8(source_file.source_code)?;
 
-    if source_file.media_type == MediaType::JavaScript
-      || source_file.media_type == MediaType::TypeScript
-    {
+    if SUPPORTED_MEDIA_TYPES.contains(&source_file.media_type) {
       if let Some(types_specifier) = source_file.types_header {
         let type_header = ReferenceDescriptor {
           specifier: types_specifier.to_string(),

--- a/cli/swc_util.rs
+++ b/cli/swc_util.rs
@@ -147,6 +147,7 @@ impl AstParser {
       let mut ts_config = TsConfig::default();
       ts_config.dynamic_import = true;
       ts_config.decorators = true;
+      ts_config.tsx = true;
       let syntax = Syntax::Typescript(ts_config);
 
       let lexer = Lexer::new(

--- a/cli/tests/Component.tsx
+++ b/cli/tests/Component.tsx
@@ -1,0 +1,1 @@
+import "./046_jsx_test.tsx";

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1723,6 +1723,11 @@ itest!(disallow_http_from_https_ts {
   exit_code: 1,
 });
 
+itest!(tsx_imports {
+  args: "run --reload tsx_imports.ts",
+  output: "tsx_imports.ts.out",
+});
+
 itest!(fix_js_import_js {
   args: "run --quiet --reload fix_js_import_js.ts",
   output: "fix_js_import_js.ts.out",

--- a/cli/tests/tsx_imports.ts
+++ b/cli/tests/tsx_imports.ts
@@ -1,0 +1,1 @@
+import "./Component.tsx";

--- a/cli/tests/tsx_imports.ts.out
+++ b/cli/tests/tsx_imports.ts.out
@@ -1,0 +1,2 @@
+Compile [WILDCARD]tsx_imports.ts
+{ factory: [Function: View], props: null, children: [] }


### PR DESCRIPTION
Yet another problem with module graph loader: it was ignoring 
TSX/JSX files.

This commit makes sure that JSX/TSX files are parsed and analyzed as 
well; with a test case ensuring that only single compilation takes place.

Fixes https://github.com/denoland/deno/issues/5776
Fixes https://github.com/denoland/deno/issues/5772