### PR TITLE
feat(cli/js/testing): Add TestDefinition::only

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -38,6 +38,8 @@ declare namespace Deno {
     fn: () => void | Promise<void>;
     name: string;
     ignore?: boolean;
+    /** If at lease one test has `only` set to true, only run tests that have
+     * `only` set to true and fail the test suite. */
     only?: boolean;
     /** Check that the number of async completed ops after the test is the same
      * as number of dispatched ops. Defaults to true.*/

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -38,6 +38,7 @@ declare namespace Deno {
     fn: () => void | Promise<void>;
     name: string;
     ignore?: boolean;
+    only?: boolean;
     /** Check that the number of async completed ops after the test is the same
      * as number of dispatched ops. Defaults to true.*/
     sanitizeOps?: boolean;

--- a/cli/tests/deno_test_only.ts
+++ b/cli/tests/deno_test_only.ts
@@ -1,0 +1,15 @@
+Deno.test({
+  name: "abc",
+  fn() {},
+});
+
+Deno.test({
+  only: true,
+  name: "def",
+  fn() {},
+});
+
+Deno.test({
+  name: "ghi",
+  fn() {},
+});

--- a/cli/tests/deno_test_only.ts.out
+++ b/cli/tests/deno_test_only.ts.out
@@ -1,0 +1,7 @@
+[WILDCARD]running 1 tests
+test def ... ok ([WILDCARD])
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+FAILED because the "only" option was used
+

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1259,16 +1259,22 @@ itest!(_026_redirect_javascript {
   http_server: true,
 });
 
+itest!(deno_test {
+  args: "test test_runner_test.ts",
+  exit_code: 1,
+  output: "deno_test.out",
+});
+
 itest!(deno_test_fail_fast {
   args: "test --failfast test_runner_test.ts",
   exit_code: 1,
   output: "deno_test_fail_fast.out",
 });
 
-itest!(deno_test {
-  args: "test test_runner_test.ts",
+itest!(deno_test_only {
+  args: "test deno_test_only.ts",
   exit_code: 1,
-  output: "deno_test.out",
+  output: "deno_test_only.ts.out",
 });
 
 #[test]

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { assert, assertEquals } from "../../../std/testing/asserts.ts";
+import * as colors from "../../../std/fmt/colors.ts";
+export { colors };
 import { resolve } from "../../../std/path/mod.ts";
 export {
   assert,
@@ -93,7 +95,9 @@ function registerPermCombination(perms: Permissions): void {
 export async function registerUnitTests(): Promise<void> {
   const processPerms = await getProcessPermissions();
 
-  for (const unitTestDefinition of REGISTERED_UNIT_TESTS) {
+  const onlyTests = REGISTERED_UNIT_TESTS.filter(({ only }) => only);
+  const unitTests = onlyTests.length > 0 ? onlyTests : REGISTERED_UNIT_TESTS;
+  for (const unitTestDefinition of unitTests) {
     if (!permissionsMatch(processPerms, unitTestDefinition.perms)) {
       continue;
     }
@@ -126,11 +130,13 @@ interface UnitTestPermissions {
 
 interface UnitTestOptions {
   ignore?: boolean;
+  only?: boolean;
   perms?: UnitTestPermissions;
 }
 
 interface UnitTestDefinition extends Deno.TestDefinition {
   ignore: boolean;
+  only: boolean;
   perms: Permissions;
 }
 
@@ -174,6 +180,7 @@ export function unitTest(
     name,
     fn,
     ignore: !!options.ignore,
+    only: !!options.only,
     perms: normalizedPerms,
   };
 

--- a/cli/tests/unit/unit_test_runner.ts
+++ b/cli/tests/unit/unit_test_runner.ts
@@ -2,6 +2,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import "./unit_tests.ts";
 import {
+  REGISTERED_UNIT_TESTS,
+  colors,
   readLines,
   permissionCombinations,
   Permissions,
@@ -225,6 +227,13 @@ async function masterRunnerMain(
   }
 
   console.log("Unit tests passed");
+
+  if (REGISTERED_UNIT_TESTS.find(({ only }) => only)) {
+    console.error(
+      `\n${colors.red("FAILED")} because the "only" option was used`
+    );
+    Deno.exit(1);
+  }
 }
 
 const HELP = `Unit test runner


### PR DESCRIPTION
Closes #5197.

If there are tests with `only: true`, only those tests will be run and the runner will exit with code 1.