### PR TITLE
fix(cli): run --lock-write for long-lived programs

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -139,6 +139,19 @@ fn write_to_stdout_ignore_sigpipe(bytes: &[u8]) -> Result<(), std::io::Error> {
   }
 }
 
+fn write_lockfile(global_state : GlobalState) -> Result<(), std::io::Error>  {
+  if global_state.flags.lock_write {
+    if let Some(ref lockfile) = global_state.lockfile {
+      let g = lockfile.lock().unwrap();
+      g.write()?;
+    } else {
+      eprintln!("--lock flag must be specified when using --lock-write");
+      std::process::exit(11);
+    }
+  }
+  Ok(())
+}
+
 fn create_main_worker(
   global_state: GlobalState,
   main_module: ModuleSpecifier,
@@ -325,19 +338,11 @@ async fn cache_command(flags: Flags, files: Vec<String>) -> Result<(), ErrBox> {
   let mut worker =
     create_main_worker(global_state.clone(), main_module.clone())?;
 
+  write_lockfile(global_state)?;
+
   for file in files {
     let specifier = ModuleSpecifier::resolve_url_or_path(&file)?;
     worker.preload_module(&specifier).await.map(|_| ())?;
-  }
-
-  if global_state.flags.lock_write {
-    if let Some(ref lockfile) = global_state.lockfile {
-      let g = lockfile.lock().unwrap();
-      g.write()?;
-    } else {
-      eprintln!("--lock flag must be specified when using --lock-write");
-      std::process::exit(11);
-    }
   }
 
   Ok(())
@@ -513,19 +518,11 @@ async fn run_command(flags: Flags, script: String) -> Result<(), ErrBox> {
   let mut worker =
     create_main_worker(global_state.clone(), main_module.clone())?;
   debug!("main_module {}", main_module);
+  write_lockfile(global_state)?;
   worker.execute_module(&main_module).await?;
   worker.execute("window.dispatchEvent(new Event('load'))")?;
   (&mut *worker).await?;
   worker.execute("window.dispatchEvent(new Event('unload'))")?;
-  if global_state.flags.lock_write {
-    if let Some(ref lockfile) = global_state.lockfile {
-      let g = lockfile.lock().unwrap();
-      g.write()?;
-    } else {
-      eprintln!("--lock flag must be specified when using --lock-write");
-      std::process::exit(11);
-    }
-  }
   Ok(())
 }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -139,7 +139,7 @@ fn write_to_stdout_ignore_sigpipe(bytes: &[u8]) -> Result<(), std::io::Error> {
   }
 }
 
-fn write_lockfile(global_state : GlobalState) -> Result<(), std::io::Error>  {
+fn write_lockfile(global_state: GlobalState) -> Result<(), std::io::Error> {
   if global_state.flags.lock_write {
     if let Some(ref lockfile) = global_state.lockfile {
       let g = lockfile.lock().unwrap();
@@ -338,12 +338,12 @@ async fn cache_command(flags: Flags, files: Vec<String>) -> Result<(), ErrBox> {
   let mut worker =
     create_main_worker(global_state.clone(), main_module.clone())?;
 
-  write_lockfile(global_state)?;
-
   for file in files {
     let specifier = ModuleSpecifier::resolve_url_or_path(&file)?;
     worker.preload_module(&specifier).await.map(|_| ())?;
   }
+
+  write_lockfile(global_state)?;
 
   Ok(())
 }
@@ -518,8 +518,8 @@ async fn run_command(flags: Flags, script: String) -> Result<(), ErrBox> {
   let mut worker =
     create_main_worker(global_state.clone(), main_module.clone())?;
   debug!("main_module {}", main_module);
-  write_lockfile(global_state)?;
   worker.execute_module(&main_module).await?;
+  write_lockfile(global_state)?;
   worker.execute("window.dispatchEvent(new Event('load'))")?;
   (&mut *worker).await?;
   worker.execute("window.dispatchEvent(new Event('unload'))")?;

--- a/cli/tests/file_exists.ts
+++ b/cli/tests/file_exists.ts
@@ -1,0 +1,6 @@
+try {
+  Deno.openSync(Deno.args[0]);
+  Deno.exit(0);
+} catch(e) {
+  Deno.exit(1);
+}

--- a/cli/tests/file_exists.ts
+++ b/cli/tests/file_exists.ts
@@ -1,6 +1,6 @@
 try {
-  Deno.openSync(Deno.args[0]);
+  await Deno.open(Deno.args[0]);
   Deno.exit(0);
-} catch(e) {
+} catch (e) {
   Deno.exit(1);
 }

--- a/cli/tests/lock_write_fetch.ts
+++ b/cli/tests/lock_write_fetch.ts
@@ -32,6 +32,8 @@ const fetchCheckProc = Deno.run({
 const fetchCheckProcCode = (await fetchCheckProc.status()).code;
 console.log(`fetch check code: ${fetchCheckProcCode}`);
 
+Deno.removeSync("./lock_write_fetch.json");
+
 const runProc = Deno.run({
   stdout: "null",
   stderr: "null",
@@ -39,7 +41,10 @@ const runProc = Deno.run({
     Deno.execPath(),
     "run",
     "--lock=lock_write_fetch.json",
-    "https_import.ts",
+    "--lock-write",
+    "--allow-read",
+    "file_exists.ts",
+    "lock_write_fetch.json",
   ],
 });
 


### PR DESCRIPTION
Write the lock file before running any code. 

This fixes an issue where `deno run --lock=lock.json --lock-write some_long_lived_program.ts` will not write the lock file. This of course also applies to long lived servers, which is likely to be many of the programs written in Deno.

Related: https://github.com/denoland/deno/issues/5231
https://github.com/denoland/deno/issues/4790 will also help with making tests more robust.

First time Rust contributor, go easy. 😃 