### PR TITLE
Issue 1228: Skip 3 fetch tests on windows

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -367,8 +367,7 @@ function bufferServer(addr: string): Deno.Buffer {
 
 unitTest(
   {
-    // FIXME(bartlomieju)
-    ignore: true,
+    ignore: Deno.build.os === "windows",
     perms: { net: true },
   },
   async function fetchRequest(): Promise<void> {
@@ -381,6 +380,7 @@ unitTest(
         ["Foo", "Bar"],
       ],
     });
+    await response.arrayBuffer();
     assertEquals(response.status, 404);
     assertEquals(response.headers.get("Content-Length"), "2");
 
@@ -389,6 +389,9 @@ unitTest(
       "POST /blah HTTP/1.1\r\n",
       "hello: World\r\n",
       "foo: Bar\r\n",
+      "accept: */*\r\n",
+      `user-agent: Deno/${Deno.version.deno}\r\n`,
+      "accept-encoding: gzip, br\r\n",
       `host: ${addr}\r\n\r\n`,
     ].join("");
     assertEquals(actual, expected);
@@ -397,8 +400,7 @@ unitTest(
 
 unitTest(
   {
-    // FIXME(bartlomieju)
-    ignore: true,
+    ignore:Deno.build.os === "windows",
     perms: { net: true },
   },
   async function fetchPostBodyString(): Promise<void> {
@@ -413,6 +415,7 @@ unitTest(
       ],
       body,
     });
+    await response.arrayBuffer();
     assertEquals(response.status, 404);
     assertEquals(response.headers.get("Content-Length"), "2");
 
@@ -421,6 +424,10 @@ unitTest(
       "POST /blah HTTP/1.1\r\n",
       "hello: World\r\n",
       "foo: Bar\r\n",
+      "content-type: text/plain;charset=UTF-8\r\n",
+      "accept: */*\r\n",
+      `user-agent: Deno/${Deno.version.deno}\r\n`,
+      "accept-encoding: gzip, br\r\n",
       `host: ${addr}\r\n`,
       `content-length: ${body.length}\r\n\r\n`,
       body,
@@ -431,8 +438,7 @@ unitTest(
 
 unitTest(
   {
-    // FIXME(bartlomieju)
-    ignore: true,
+    ignore: Deno.build.os === "windows",
     perms: { net: true },
   },
   async function fetchPostBodyTypedArray(): Promise<void> {
@@ -448,6 +454,7 @@ unitTest(
       ],
       body,
     });
+    await response.arrayBuffer();
     assertEquals(response.status, 404);
     assertEquals(response.headers.get("Content-Length"), "2");
 
@@ -456,6 +463,9 @@ unitTest(
       "POST /blah HTTP/1.1\r\n",
       "hello: World\r\n",
       "foo: Bar\r\n",
+      "accept: */*\r\n",
+      `user-agent: Deno/${Deno.version.deno}\r\n`,
+      "accept-encoding: gzip, br\r\n",
       `host: ${addr}\r\n`,
       `content-length: ${body.byteLength}\r\n\r\n`,
       bodyStr,

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -367,7 +367,6 @@ function bufferServer(addr: string): Deno.Buffer {
 
 unitTest(
   {
-    ignore: Deno.build.os === "windows",
     perms: { net: true },
   },
   async function fetchRequest(): Promise<void> {
@@ -400,7 +399,6 @@ unitTest(
 
 unitTest(
   {
-    ignore: Deno.build.os === "windows",
     perms: { net: true },
   },
   async function fetchPostBodyString(): Promise<void> {
@@ -438,7 +436,6 @@ unitTest(
 
 unitTest(
   {
-    ignore: Deno.build.os === "windows",
     perms: { net: true },
   },
   async function fetchPostBodyTypedArray(): Promise<void> {

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -400,7 +400,7 @@ unitTest(
 
 unitTest(
   {
-    ignore:Deno.build.os === "windows",
+    ignore: Deno.build.os === "windows",
     perms: { net: true },
   },
   async function fetchPostBodyString(): Promise<void> {


### PR DESCRIPTION
Resolves #1228 

Per issue, flaky tests are ignored on windows. Race condition is solved on other OS's. 

fetch_test.ts's tests impacted: 
- fetchRequest
- fetchPostBodyString
- fetchPostBodyTypedArray 