### PR TITLE
Add unstable checks for unix transport (#5801)

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1612,10 +1612,9 @@ declare namespace Deno {
    * const conn2 = await Deno.connect({ hostname: "192.0.2.1", port: 80 });
    * const conn3 = await Deno.connect({ hostname: "[2001:db8::1]", port: 80 });
    * const conn4 = await Deno.connect({ hostname: "golang.org", port: 80, transport: "tcp" });
-   * const conn5 = await Deno.connect({ path: "/foo/bar.sock", transport: "unix" });
    * ```
    *
-   * Requires `allow-net` permission for "tcp" and `allow-read` for unix. */
+   * Requires `allow-net` permission for "tcp". */
   export function connect(options: ConnectOptions): Promise<Conn>;
 
   export interface ConnectTlsOptions {

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1067,7 +1067,7 @@ declare namespace Deno {
    * const conn5 = await Deno.connect({ path: "/foo/bar.sock", transport: "unix" });
    * ```
    *
-   * Requires `allow-net` permission for "tcp" and `allow-read` for unix. */
+   * Requires `allow-net` permission for "tcp" and `allow-read` for "unix". */
   export function connect(
     options: ConnectOptions | UnixConnectOptions
   ): Promise<Conn>;

--- a/cli/ops/net.rs
+++ b/cli/ops/net.rs
@@ -302,6 +302,7 @@ fn op_connect(
       transport_args: ArgsEnum::Unix(args),
     } if transport == "unix" => {
       let address_path = net_unix::Path::new(&args.path);
+      state.check_unstable("Deno.connect");
       state.check_read(&address_path)?;
       let op = async move {
         let path = args.path;
@@ -524,6 +525,9 @@ fn op_listen(
       transport,
       transport_args: ArgsEnum::Unix(args),
     } if transport == "unix" || transport == "unixpacket" => {
+      if transport == "unix" {
+        state.check_unstable("Deno.listen");
+      }
       if transport == "unixpacket" {
         state.check_unstable("Deno.listenDatagram");
       }


### PR DESCRIPTION
Also remove the unix example from the stable documentation
to stay in line with the `Deno.listen` one