### PR TITLE
fix(std/log): modify the calculation method of byte length 

### DIFF
--- a/std/log/handlers.ts
+++ b/std/log/handlers.ts
@@ -142,7 +142,7 @@ interface RotatingFileHandlerOptions extends FileHandlerOptions {
 export class RotatingFileHandler extends FileHandler {
   #maxBytes: number;
   #maxBackupCount: number;
-  #currentFileSize!: number;
+  #currentFileSize = 0;
   #encoder = new TextEncoder();
 
   constructor(levelName: LevelName, options: RotatingFileHandlerOptions) {
@@ -178,8 +178,9 @@ export class RotatingFileHandler extends FileHandler {
           );
         }
       }
+    } else {
+      this.#currentFileSize = (await stat(this._filename)).size;
     }
-    this.#currentFileSize = (await stat(this._filename)).size;
   }
 
   handle(logRecord: LogRecord): void {

--- a/std/log/handlers.ts
+++ b/std/log/handlers.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-const { open, openSync, close, renameSync, statSync } = Deno;
+const { open, openSync, close, renameSync, stat } = Deno;
 type File = Deno.File;
 type Writer = Deno.Writer;
 type OpenOptions = Deno.OpenOptions;
@@ -142,6 +142,8 @@ interface RotatingFileHandlerOptions extends FileHandlerOptions {
 export class RotatingFileHandler extends FileHandler {
   #maxBytes: number;
   #maxBackupCount: number;
+  #currentFileSize!: number;
+  #encoder = new TextEncoder();
 
   constructor(levelName: LevelName, options: RotatingFileHandlerOptions) {
     super(levelName, options);
@@ -183,9 +185,12 @@ export class RotatingFileHandler extends FileHandler {
     if (this.level > logRecord.level) return;
 
     const msg = this.format(logRecord);
-    const currentFileSize = statSync(this._filename).size;
-    if (currentFileSize + msg.length > this.#maxBytes) {
+    const msgByteLength = this.#encoder.encode(msg).byteLength + 1;
+    if (this.#currentFileSize + msgByteLength > this.#maxBytes) {
       this.rotateLogFiles();
+      this.#currentFileSize = msgByteLength;
+    } else {
+      this.#currentFileSize += msgByteLength;
     }
 
     return this.log(msg);

--- a/std/log/handlers.ts
+++ b/std/log/handlers.ts
@@ -179,6 +179,7 @@ export class RotatingFileHandler extends FileHandler {
         }
       }
     }
+    this.#currentFileSize = (await stat(this._filename)).size;
   }
 
   handle(logRecord: LogRecord): void {

--- a/std/log/handlers_test.ts
+++ b/std/log/handlers_test.ts
@@ -1,6 +1,11 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 const { test } = Deno;
-import { assert, assertEquals, assertThrowsAsync, assertNotEquals } from "../testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertThrowsAsync,
+  assertNotEquals,
+} from "../testing/asserts.ts";
 import {
   LogLevels,
   LogLevelNames,

--- a/std/log/handlers_test.ts
+++ b/std/log/handlers_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 const { test } = Deno;
-import { assert, assertEquals, assertThrowsAsync } from "../testing/asserts.ts";
+import { assert, assertEquals, assertThrowsAsync, assertNotEquals } from "../testing/asserts.ts";
 import {
   LogLevels,
   LogLevelNames,
@@ -305,5 +305,31 @@ test({
       Error,
       "maxBackupCount cannot be less than 1"
     );
+  },
+});
+
+test({
+  name: "RotatingFileHandler fileSize equal to bytelength of message + 1",
+  async fn() {
+    const fileHandler = new RotatingFileHandler("WARNING", {
+      filename: LOG_FILE,
+      maxBytes: 100,
+      maxBackupCount: 1,
+      mode: "w",
+    });
+    await fileHandler.setup();
+
+    const msg = "。";
+    const msgLength = msg.length;
+    const msgByteLength = new TextEncoder().encode(msg).byteLength;
+    await fileHandler.log(msg);
+    const fileSzie = (await Deno.stat(LOG_FILE)).size;
+
+    assertEquals(fileSzie, msgByteLength + 1);
+    assertNotEquals(fileSzie, msgLength);
+    assertNotEquals(fileSzie, msgLength + 1);
+
+    await fileHandler.destroy();
+    Deno.removeSync(LOG_FILE);
   },
 });


### PR DESCRIPTION
* File size can be recorded instead of the size of the file read each time, especially during a very frequent write.
* The length of the string is not always equal to the length of the string in bytes. 
should be 
```ts
this.#encoder.encode(msg).byteLength
```
Also, should add 1 for  "\n"
```ts
log(msg: string): void {
  Deno.writeSync(this._file.rid, this.#encoder.encode(msg + "\n"));
}
```

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
