### PR TITLE
fixing borken links

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -6,12 +6,12 @@ and TypeScript:
 <!-- prettier-ignore-start -->
 <!-- prettier incorrectly moves the coming soon links to new lines -->
 
-- [bundler (`deno bundle`)](./tools/bundler.md)
-- [debugger (`--inspect, --inspect-brk`)](./tools/debugger.md)
-- [dependency inspector (`deno info`)](./tools/dependency_inspector.md)
-- [documentation generator (`deno doc`)](./tools/documentation_generator.md)
-- [formatter (`deno fmt`)](./tools/formatter.md)
-- [test runner (`deno test`)](./testing.md)
+- [bundler (`deno bundle`)](./manual/tools/bundler.md)
+- [debugger (`--inspect, --inspect-brk`)](./manual/tools/debugger.md)
+- [dependency inspector (`deno info`)](./manual/tools/dependency_inspector.md)
+- [documentation generator (`deno doc`)](./manual/tools/documentation_generator.md)
+- [formatter (`deno fmt`)](./manual/tools/formatter.md)
+- [test runner (`deno test`)](./manual/testing.md)
 - linter (`deno lint`) [coming soon](https://github.com/denoland/deno/issues/1880)
 
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
Links on https://deno.land/manual/tools are missing `/manual` in path.

![deno-doc-fix](https://user-images.githubusercontent.com/516705/82768003-84dd5b80-9df1-11ea-9fd1-4e8613357cc1.gif)

Issue: https://github.com/denoland/deno/issues/5827