### PR TITLE
feat(cli): Enable sub-process to run in detached mode #5501

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1775,6 +1775,7 @@ declare namespace Deno {
      * binary */
     cmd: string[];
     cwd?: string;
+    detached?: boolean;
     env?: {
       [key: string]: string;
     };
@@ -1797,6 +1798,10 @@ declare namespace Deno {
    *
    * Environmental variables for subprocess can be specified using `opt.env`
    * mapping.
+   * 
+   * Set `opt.detached` to true to run the child process in detached mode. 
+   * This is equivalent to setting `DETACHED_PROCESS` flag in windows 
+   * and calling `setsid()` before exec in unix
    *
    * By default subprocess inherits stdio of parent process. To change that
    * `opt.stdout`, `opt.stderr` and `opt.stdin` can be specified independently -

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1798,9 +1798,9 @@ declare namespace Deno {
    *
    * Environmental variables for subprocess can be specified using `opt.env`
    * mapping.
-   * 
-   * Set `opt.detached` to true to run the child process in detached mode. 
-   * This is equivalent to setting `DETACHED_PROCESS` flag in windows 
+   *
+   * Set `opt.detached` to true to run the child process in detached mode.
+   * This is equivalent to setting `DETACHED_PROCESS` flag in windows
    * and calling `setsid()` before exec in unix
    *
    * By default subprocess inherits stdio of parent process. To change that

--- a/cli/js/ops/process.ts
+++ b/cli/js/ops/process.ts
@@ -19,6 +19,7 @@ export function runStatus(rid: number): Promise<RunStatusResponse> {
 interface RunRequest {
   cmd: string[];
   cwd?: string;
+  detached?: boolean;
   env?: Array<[string, string]>;
   stdin: string;
   stdout: string;

--- a/cli/js/process.ts
+++ b/cli/js/process.ts
@@ -12,6 +12,7 @@ export type ProcessStdio = "inherit" | "piped" | "null";
 export interface RunOptions {
   cmd: string[];
   cwd?: string;
+  detached?: boolean;
   env?: { [key: string]: string };
   stdout?: ProcessStdio | number;
   stderr?: ProcessStdio | number;
@@ -110,6 +111,7 @@ interface RunResponse {
 export function run({
   cmd,
   cwd = undefined,
+  detached = false,
   env = {},
   stdout = "inherit",
   stderr = "inherit",
@@ -118,6 +120,7 @@ export function run({
   const res = runOp({
     cmd: cmd.map(String),
     cwd,
+    detached,
     env: Object.entries(env),
     stdin: isRid(stdin) ? "" : stdin,
     stdout: isRid(stdout) ? "" : stdout,

--- a/cli/ops/process.rs
+++ b/cli/ops/process.rs
@@ -128,7 +128,7 @@ fn op_run(
 
   #[cfg(unix)]
   unsafe {
-    if detached {        
+    if detached {
       c.pre_exec(|| {
         libc::setsid();
         Ok(())


### PR DESCRIPTION
The PR is to enable processes started via `Deno.run()` to run in detached mode.

Prior art is detailed in: https://github.com/denoland/deno/issues/5501#issuecomment-629683072

Since the detached process is standard across *nix and windows platforms, node's way of run options is chosen.