### PR TITLE
Add missing import to sample code in "Testing > Async" manual page

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -35,6 +35,8 @@ You can also test asynchronous code by passing a test function that returns a
 promise. For this you can use the `async` keyword when defining a function:
 
 ```ts
+import { delay } from "https://deno.land/std/async/delay.ts";
+
 Deno.test("async hello world", async () => {
   const x = 1 + 2;
 


### PR DESCRIPTION
Fixes error:
```
error: TS2304 [ERROR]: Cannot find name 'delay'.
    await delay(100);
          ~~~~~
```