### PR TITLE
test(web/fetch): Add tests for fetch response body

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -586,7 +586,6 @@ unitTest({ perms: { net: true } }, async function fetchBodyReadTwice(): Promise<
   void
 > {
   const response = await fetch("http://localhost:4545/cli/tests/fixture.json");
-  assertEquals(response.url, "http://localhost:4545/cli/tests/fixture.json");
 
   // Read body
   const _json = await response.json();

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -590,6 +590,7 @@ unitTest({ perms: { net: true } }, async function fetchBodyReadTwice(): Promise<
 
   // Read body
   const _json = await response.json();
+  assert(_json);
 
   // All calls after the body was consumed, should fail
   const methods = ["json", "text", "formData", "arrayBuffer"];
@@ -610,10 +611,8 @@ unitTest(
     const response = await fetch(
       "http://localhost:4545/cli/tests/fixture.json"
     );
-    const headers = response.headers;
     assert(response.body !== null);
     const reader = await response.body.getReader();
-    let total = 0;
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -624,5 +623,69 @@ unitTest(
       response.body.getReader();
       fail("The stream should've been locked.");
     } catch {}
+  }
+);
+
+unitTest(
+  { perms: { net: true } },
+  async function fetchBodyReaderWithCancelAndNewReader(): Promise<void> {
+    const data = "a".repeat(1 << 10);
+    const response = await fetch(
+      "http://localhost:4545/cli/tests/echo_server",
+      {
+        method: "POST",
+        body: data,
+      }
+    );
+    assert(response.body !== null);
+    const firstReader = await response.body.getReader();
+
+    // Acquire reader without reading & release
+    await firstReader.releaseLock();
+
+    const reader = await response.body.getReader();
+
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      assert(value);
+      total += value.length;
+    }
+
+    assertEquals(total, data.length);
+  }
+);
+
+unitTest(
+  { perms: { net: true } },
+  async function fetchBodyReaderWithReadCancelAndNewReader(): Promise<void> {
+    const data = "a".repeat(1 << 10);
+
+    const response = await fetch(
+      "http://localhost:4545/cli/tests/echo_server",
+      {
+        method: "POST",
+        body: data,
+      }
+    );
+    assert(response.body !== null);
+    const firstReader = await response.body.getReader();
+
+    // Do one single read with first reader
+    const { value: firstValue } = await firstReader.read();
+    assert(firstValue);
+    await firstReader.releaseLock();
+
+    // Continue read with second reader
+    const reader = await response.body.getReader();
+    let total = firstValue.length || 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      assert(value);
+      total += value.length;
+    }
+    assertEquals(total, data.length);
   }
 );


### PR DESCRIPTION
Added more tests to ensure `.json`/`.text`/`.formData`/`.arrayBuffer` fail when called twice and to check the correct behaviour of the `ReadableStream`