### PR TITLE
fix(std/log): use writeAllSync instead of writeSync

### DIFF
--- a/std/log/handlers.ts
+++ b/std/log/handlers.ts
@@ -125,7 +125,7 @@ export class FileHandler extends WriterHandler {
   }
 
   log(msg: string): void {
-    Deno.writeSync(this._file.rid, this.#encoder.encode(msg + "\n"));
+    Deno.writeAllSync(this._file, this.#encoder.encode(msg + "\n"));
   }
 
   destroy(): Promise<void> {


### PR DESCRIPTION
Deno.writeSync:
Returns the number of bytes written. 
It is not guaranteed that the full buffer will be written in a single call.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
