### PR TITLE
docs(http-server): naming of s to server

### DIFF
--- a/docs/tools/debugger.md
+++ b/docs/tools/debugger.md
@@ -108,10 +108,10 @@ This time let's try with local source file, create `server.ts`:
 
 ```ts
 import { serve } from "https://deno.land/std@v0.50.0/http/server.ts";
-const s = serve({ port: 8000 });
+const server = serve({ port: 8000 });
 console.log("http://localhost:8000/");
 
-for await (const req of s) {
+for await (const req of server) {
   req.respond({ body: "Hello World\n" });
 }
 ```

--- a/std/http/README.md
+++ b/std/http/README.md
@@ -2,9 +2,9 @@
 
 ```typescript
 import { serve } from "https://deno.land/std/http/server.ts";
-const s = serve({ port: 8000 });
+const server = serve({ port: 8000 });
 console.log("http://localhost:8000/");
-for await (const req of s) {
+for await (const req of server) {
   req.respond({ body: "Hello World\n" });
 }
 ```

--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -78,7 +78,7 @@ export class ServerRequest {
             .map((e): string => e.trim().toLowerCase());
           assert(
             parts.includes("chunked"),
-            'transfer-encoding must include "chunked" if content-length is not set'
+            'transfer-encoding must include "chunked" if content-length is not set',
           );
           this._body = chunkedBodyReader(this.headers, this.r);
         } else {
@@ -145,7 +145,7 @@ export class Server implements AsyncIterable<ServerRequest> {
 
   // Yields all HTTP requests on a single TCP connection.
   private async *iterateHttpRequests(
-    conn: Conn
+    conn: Conn,
   ): AsyncIterableIterator<ServerRequest> {
     const reader = new BufReader(conn);
     const writer = new BufWriter(conn);
@@ -212,7 +212,7 @@ export class Server implements AsyncIterable<ServerRequest> {
   // same kind and adds it to the request multiplexer so that another TCP
   // connection can be accepted.
   private async *acceptConnAndIterateHttpRequests(
-    mux: MuxAsyncIterator<ServerRequest>
+    mux: MuxAsyncIterator<ServerRequest>,
   ): AsyncIterableIterator<ServerRequest> {
     if (this.closing) return;
     // Wait for a new connection.
@@ -247,8 +247,8 @@ export type HTTPOptions = Omit<Deno.ListenOptions, "transport">;
  *
  *     import { serve } from "https://deno.land/std/http/server.ts";
  *     const body = "Hello World\n";
- *     const s = serve({ port: 8000 });
- *     for await (const req of s) {
+ *     const server = serve({ port: 8000 });
+ *     for await (const req of server) {
  *       req.respond({ body });
  *     }
  */
@@ -276,7 +276,7 @@ export function serve(addr: string | HTTPOptions): Server {
  */
 export async function listenAndServe(
   addr: string | HTTPOptions,
-  handler: (req: ServerRequest) => void
+  handler: (req: ServerRequest) => void,
 ): Promise<void> {
   const server = serve(addr);
 
@@ -333,7 +333,7 @@ export function serveTLS(options: HTTPSOptions): Server {
  */
 export async function listenAndServeTLS(
   options: HTTPSOptions,
-  handler: (req: ServerRequest) => void
+  handler: (req: ServerRequest) => void,
 ): Promise<void> {
   const server = serveTLS(options);
 

--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -78,7 +78,7 @@ export class ServerRequest {
             .map((e): string => e.trim().toLowerCase());
           assert(
             parts.includes("chunked"),
-            'transfer-encoding must include "chunked" if content-length is not set',
+            'transfer-encoding must include "chunked" if content-length is not set'
           );
           this._body = chunkedBodyReader(this.headers, this.r);
         } else {
@@ -145,7 +145,7 @@ export class Server implements AsyncIterable<ServerRequest> {
 
   // Yields all HTTP requests on a single TCP connection.
   private async *iterateHttpRequests(
-    conn: Conn,
+    conn: Conn
   ): AsyncIterableIterator<ServerRequest> {
     const reader = new BufReader(conn);
     const writer = new BufWriter(conn);
@@ -212,7 +212,7 @@ export class Server implements AsyncIterable<ServerRequest> {
   // same kind and adds it to the request multiplexer so that another TCP
   // connection can be accepted.
   private async *acceptConnAndIterateHttpRequests(
-    mux: MuxAsyncIterator<ServerRequest>,
+    mux: MuxAsyncIterator<ServerRequest>
   ): AsyncIterableIterator<ServerRequest> {
     if (this.closing) return;
     // Wait for a new connection.
@@ -276,7 +276,7 @@ export function serve(addr: string | HTTPOptions): Server {
  */
 export async function listenAndServe(
   addr: string | HTTPOptions,
-  handler: (req: ServerRequest) => void,
+  handler: (req: ServerRequest) => void
 ): Promise<void> {
   const server = serve(addr);
 
@@ -333,7 +333,7 @@ export function serveTLS(options: HTTPSOptions): Server {
  */
 export async function listenAndServeTLS(
   options: HTTPSOptions,
-  handler: (req: ServerRequest) => void,
+  handler: (req: ServerRequest) => void
 ): Promise<void> {
   const server = serveTLS(options);
 


### PR DESCRIPTION
As someone just starting with Deno, I was confused about variable `s`. I checked `serve` and saw that it returned a server, so I thought it would be nice to have a clear naming for the cos here.