### PR TITLE
fix(std/log): fix FileHandler setup bug

### DIFF
--- a/std/log/handlers.ts
+++ b/std/log/handlers.ts
@@ -120,6 +120,17 @@ export class FileHandler extends WriterHandler {
   }
 
   async setup(): Promise<void> {
+    if (this._mode === "w") {
+      if (await exists(this._filename)) {
+        await Deno.remove(this._filename);
+      }
+    } else if (this._mode === "x") {
+      if (await exists(this._filename) {
+        throw new Deno.errors.AlreadyExists(
+          "Log file " + this._filename + " already exists"
+        );
+      }
+    }
     this._file = await open(this._filename, this._openOptions);
     this._writer = this._file;
   }


### PR DESCRIPTION
When FileHandler setup , it should remove file when mode is ‘w’ or throw an error when mode is ‘x’.

in FileHandler doc:
Behavior of the log modes is as follows:
'a' - Default mode. Appends new log messages to the end of an existing log file, or create a new log file if none exists
'w' - Upon creation of the handler, any existing log file will be removed and a new one created.
'x' - This will create a new log file and throw an error if one already exists

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
