### PR TITLE
fix(cli/blob) name for DenoBlob

### DIFF
--- a/cli/js/web/blob.ts
+++ b/cli/js/web/blob.ts
@@ -161,7 +161,7 @@ async function readBytes(
 // Ensures it does not impact garbage collection.
 export const blobBytesWeakMap = new WeakMap<Blob, Uint8Array>();
 
-export class DenoBlob implements Blob {
+class DenoBlob implements Blob {
   [bytesSymbol]: Uint8Array;
   readonly size: number = 0;
   readonly type: string = "";
@@ -216,3 +216,11 @@ export class DenoBlob implements Blob {
     return readBytes(getStream(this[bytesSymbol]).getReader());
   }
 }
+
+// we want the Base class name to be the name of the class.
+Object.defineProperty(DenoBlob, "name", {
+  value: "Blob",
+  configurable: true,
+});
+
+export { DenoBlob };

--- a/cli/tests/unit/blob_test.ts
+++ b/cli/tests/unit/blob_test.ts
@@ -90,3 +90,8 @@ unitTest(async function blobStream(): Promise<void> {
   await read();
   assertEquals(decode(bytes), "Hello World");
 });
+
+unitTest(function blobConstructorNameIsBlob(): void {
+  const blob = new Blob();
+  assertEquals(blob.constructor.name, "Blob");
+});


### PR DESCRIPTION
This should fix https://github.com/denoland/deno/issues/5851

Executed as described in this comment: https://github.com/denoland/deno/pull/4736/files#r407832029

Until all cli code is converted to JS this should fix `Blob` being named `DenoBlob`. 

```
const b = new Blob()
b.constructor.name
DenoBlob
```