### PR TITLE
Bump actions/checkout from v1 to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: git config --global core.symlinks true
 
       - name: Clone repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           # Use depth > 1, because sometimes we need to rebuild master and if
           # other commits have landed it will become impossible to rebuild if


### PR DESCRIPTION
The Actions team finally decided to add the submodule option back to v2.