### PR TITLE
Fix jsdoc

### DIFF
--- a/cli/doc/parser.rs
+++ b/cli/doc/parser.rs
@@ -530,7 +530,7 @@ impl DocParser {
 
   pub fn js_doc_for_span(&self, span: Span) -> Option<String> {
     let comments = self.ast_parser.get_span_comments(span);
-    let js_doc_comment = comments.iter().find(|comment| {
+    let js_doc_comment = comments.iter().rev().find(|comment| {
       comment.kind == CommentKind::Block && comment.text.starts_with('*')
     })?;
 

--- a/cli/doc/tests.rs
+++ b/cli/doc/tests.rs
@@ -44,6 +44,10 @@ impl DocFileLoader for TestLoader {
 #[tokio::test]
 async fn export_fn() {
   let source_code = r#"/**
+* @module foo
+*/
+
+/**
 * Hello there, this is a multiline JSdoc.
 *
 * It has many lines
@@ -51,6 +55,9 @@ async fn export_fn() {
 * Or not that many?
 */
 export function foo(a: string, b?: number, cb: (...cbArgs: unknown[]) => void, ...args: unknown[]): void {
+    /**
+     * @todo document all the things.
+     */
     console.log("Hello world");
 }
 "#;
@@ -143,7 +150,7 @@ export function foo(a: string, b?: number, cb: (...cbArgs: unknown[]) => void, .
     "location": {
       "col": 0,
       "filename": "test.ts",
-      "line": 8,
+      "line": 12,
     },
     "name": "foo",
   });


### PR DESCRIPTION
A first go at fixing how the documentation generator behaves, for Issue #5798. Get the last JSDoc comment instead of the first.
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
