### PR TITLE
Add wasm to std/http/file_server.ts media types

### DIFF
--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -52,6 +52,7 @@ const MEDIA_TYPES: Record<string, string> = {
   ".jsx": "text/jsx",
   ".gz": "application/gzip",
   ".css": "text/css",
+  ".wasm": "application/wasm",
 };
 
 /** Returns the content-type based on the extension of a path. */


### PR DESCRIPTION
Since browsers and deno support wasm, I think this is reasonable in std’s file_server.

Care if I change or remove the shebang? This one would need `run` and `--allow-read` to work.
