### PR TITLE
Fix shebangs

### DIFF
--- a/std/examples/catj.ts
+++ b/std/examples/catj.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno --allow-read
+#!/usr/bin/env -S deno run --allow-read
 // Ported from: https://github.com/soheilpro/catj
 // Copyright (c) 2014 Soheil Rashidi
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.

--- a/std/examples/gist.ts
+++ b/std/examples/gist.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno --allow-net --allow-env
+#!/usr/bin/env -S deno run --allow-net --allow-env
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 // A program to post files to gist.github.com. Use the following to install it:
 // deno install -f --allow-env --allow-read --allow-net=api.github.com https://deno.land/std/examples/gist.ts

--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno --allow-net
+#!/usr/bin/env -S deno run --allow-net --allow-read
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 // This program serves files in the current directory over HTTP.


### PR DESCRIPTION
Noticed an outdated shebang while working on #5896.

This fixes shebangs in http/file_sever, examples/catj and examples/gist.