### PR TITLE
Add 2D Array check for console.table()

### DIFF
--- a/cli/js/web/console.ts
+++ b/cli/js/web/console.ts
@@ -825,6 +825,7 @@ export class Console {
     let resultData: any;
     const isSet = data instanceof Set;
     const isMap = data instanceof Map;
+    const is2DArray = data instanceof Array && data.every(element => element instanceof Array);
     const valuesKey = "Values";
     const indexKey = isSet || isMap ? "(iter idx)" : "(idx)";
 
@@ -874,7 +875,7 @@ export class Console {
       indexKey,
       ...(properties || [
         ...headerKeys,
-        !isMap && values.length > 0 && valuesKey,
+        !isMap && !is2DArray && values.length > 0 && valuesKey,
       ]),
     ].filter(Boolean) as string[];
     const body = [indexKeys, ...bodyValues, values];


### PR DESCRIPTION
### The Issue
https://github.com/denoland/deno/issues/5902

### The Problem
When using `console.table()` on a 1-dimensional array, NodeJS tabulates the array with two columns titled "Index" and "Values" respectively. 
![node_1d_example](https://user-images.githubusercontent.com/35490486/83065863-ce43da00-a081-11ea-93ae-384f721b6fe0.png)


The "Values" column, however, is omitted when dealing with 2-dimensional arrays and it's indices are used as column headings instead.
![node_2d_example](https://user-images.githubusercontent.com/35490486/83066075-2084fb00-a082-11ea-9ffe-943950699392.png)

The module in deno responsible for `console.table()`, `console.ts`, does not check to see if the incoming argument `data` is a 2-dimensional array. This lead to the inclusion of an extra column with the heading "Values".
![deno_2d_example](https://user-images.githubusercontent.com/35490486/83066628-f8e26280-a082-11ea-9b92-b7866c072391.png)

### The Fix

The addition of a simple check to see if the incoming argument `data` is a 2-dimensional array

```ts
const is2DArray = data instanceof Array && data.every(element => element instanceof Array);
```

and employing the check during the creation of the variable `header`.


Changing 
```ts
const header = [
      indexKey,
      ...(properties || [
        ...headerKeys,
        !isMap && values.length > 0 && valuesKey,
      ]),
    ].filter(Boolean) as string[];
```

to
```ts
const header = [
      indexKey,
      ...(properties || [
        ...headerKeys,
        !isMap && !is2DArray && values.length > 0 && valuesKey,
      ]),
    ].filter(Boolean) as string[];
```

Doing so will omit the addition of a column titled "Values" if `is2DArray` is `true`, hence fixing the issue.