### PR TITLE
fix(cli/web/formData): set default filename for Blob to "blob"

### DIFF
--- a/cli/js/web/form_data.ts
+++ b/cli/js/web/form_data.ts
@@ -22,7 +22,7 @@ class FormDataBase {
     if (value instanceof domFile.DomFileImpl) {
       this[dataSymbol].push([name, value]);
     } else if (value instanceof blob.DenoBlob) {
-      const dfile = new domFile.DomFileImpl([value], filename || name, {
+      const dfile = new domFile.DomFileImpl([value], filename || "blob", {
         type: value.type,
       });
       this[dataSymbol].push([name, dfile]);
@@ -96,7 +96,7 @@ class FormDataBase {
           if (value instanceof domFile.DomFileImpl) {
             this[dataSymbol][i][1] = value;
           } else if (value instanceof blob.DenoBlob) {
-            const dfile = new domFile.DomFileImpl([value], filename || name, {
+            const dfile = new domFile.DomFileImpl([value], filename || "blob", {
               type: value.type,
             });
             this[dataSymbol][i][1] = dfile;
@@ -117,7 +117,7 @@ class FormDataBase {
       if (value instanceof domFile.DomFileImpl) {
         this[dataSymbol].push([name, value]);
       } else if (value instanceof blob.DenoBlob) {
-        const dfile = new domFile.DomFileImpl([value], filename || name, {
+        const dfile = new domFile.DomFileImpl([value], filename || "blob", {
           type: value.type,
         });
         this[dataSymbol].push([name, dfile]);

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -359,6 +359,24 @@ unitTest(
   }
 );
 
+unitTest(
+  { perms: { net: true } },
+  async function fetchInitFormDataBlobFilenameBody(): Promise<void> {
+    const form = new FormData();
+    form.append("field", "value");
+    form.append("file", new Blob([new TextEncoder().encode("deno")]));
+    const response = await fetch("http://localhost:4545/echo_server", {
+      method: "POST",
+      body: form,
+    });
+    const resultForm = await response.formData();
+    assertEquals(form.get("field"), resultForm.get("field"));
+    const file = resultForm.get("file");
+    assert(file instanceof File);
+    assertEquals(file.name, "blob");
+  }
+);
+
 unitTest({ perms: { net: true } }, async function fetchUserAgent(): Promise<
   void
 > {

--- a/cli/tests/unit/form_data_test.ts
+++ b/cli/tests/unit/form_data_test.ts
@@ -99,6 +99,15 @@ unitTest(function formDataSetEmptyBlobSuccess(): void {
   */
 });
 
+unitTest(function formDataBlobFilename(): void {
+  const formData = new FormData();
+  const content = new TextEncoder().encode("deno");
+  formData.set("a", new Blob([content]));
+  const file = formData.get("a");
+  assert(file instanceof File);
+  assertEquals(file.name, "blob");
+});
+
 unitTest(function formDataParamsForEachSuccess(): void {
   const init = [
     ["a", "54"],


### PR DESCRIPTION
As per the [specification](https://xhr.spec.whatwg.org/#create-an-entry):

> If value is a Blob object and not a File object, then set value to a new File object, representing the same bytes, whose name attribute value is "blob".

```javascript
const form = new FormData();
form.append('file', new Blob([]));
form.get('file').name; // blob
```