### PR TITLE
fix(#5742): using Deno.watchFs with the read whitelist and relative path causes PermissionDenied

### DIFF
--- a/cli/ops/fs_events.rs
+++ b/cli/ops/fs_events.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use super::dispatch_json::{Deserialize, JsonOp, Value};
+use crate::fs::resolve_from_cwd;
 use crate::op_error::OpError;
 use crate::state::State;
 use deno_core::CoreIsolate;
@@ -15,7 +16,7 @@ use notify::RecursiveMode;
 use notify::Watcher;
 use serde::Serialize;
 use std::convert::From;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::sync::mpsc;
 
 pub fn init(i: &mut CoreIsolate, s: &State) {
@@ -90,7 +91,7 @@ pub fn op_fs_events_open(
     RecursiveMode::NonRecursive
   };
   for path in &args.paths {
-    state.check_read(&PathBuf::from(path))?;
+    state.check_read(&resolve_from_cwd(Path::new(&path))?)?;
     watcher.watch(path, recursive_mode).map_err(ErrBox::from)?;
   }
   let resource = FsEventsResource { watcher, receiver };

--- a/cli/tests/complex_permissions_test.ts
+++ b/cli/tests/complex_permissions_test.ts
@@ -11,6 +11,9 @@ const test: { [key: string]: Function } = {
       writeFileSync(file, new Uint8Array(0), { append: true })
     );
   },
+  readWatchFs(paths: string[]): void {
+    paths.forEach((path) => Deno.watchFs(path));
+  },
   netFetch(hosts: string[]): void {
     hosts.forEach((host) => fetch(host));
   },

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2063,6 +2063,18 @@ fn test_permissions_rw_no_prefix() {
 }
 
 #[test]
+fn test_permissions_read_watch_fs_allow_cwd() {
+  let (_, err) = util::run_and_collect_output(
+    true,
+    "run --allow-read=. complex_permissions_test.ts readWatchFs tls",
+    None,
+    None,
+    true,
+  );
+  assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+}
+
+#[test]
 fn test_permissions_net_fetch_allow_localhost_4545() {
   let (_, err) = util::run_and_collect_output(
     true,

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2063,7 +2063,7 @@ fn test_permissions_rw_no_prefix() {
 }
 
 #[test]
-fn test_permissions_read_watch_fs_allow_cwd() {
+fn test_permissions_read_watch_fs_with_relative_path() {
   let (_, err) = util::run_and_collect_output(
     true,
     "run --allow-read=. complex_permissions_test.ts readWatchFs tls",


### PR DESCRIPTION
This PR closes #5742.

- Fixed the path passed to `Permission.check_read` to the absolute path format.