### PR TITLE
Console log indeed aligning (cleaner pull request)

### DIFF
--- a/cli/js/web/console.ts
+++ b/cli/js/web/console.ts
@@ -339,7 +339,7 @@ function createArrayString(
         const ending = emptyItems > 1 ? "s" : "";
         return dim(`<${emptyItems} empty item${ending}>`);
       } else {
-        return stringifyWithQuotes(val, ctx, level + 1, maxLevel);
+        return stringifyWithQuotes(val, ctx, level, maxLevel);
       }
     },
     group: true,

--- a/cli/js/web/console.ts
+++ b/cli/js/web/console.ts
@@ -124,23 +124,19 @@ function createIterableString<T>(
 
   const iPrefix = `${config.displayName ? config.displayName + " " : ""}`;
 
+  const initIndentation = `\n${DEFAULT_INDENT.repeat(level + 1)}`;
+  const entryIndentation = `,\n${DEFAULT_INDENT.repeat(level + 1)}`;
+  const closingIndentation = `\n${DEFAULT_INDENT.repeat(level)}`;
+
   let iContent: string;
   if (config.group && entries.length > MIN_GROUP_LENGTH) {
     const groups = groupEntries(entries, level, value);
-    const initIndentation = `\n${DEFAULT_INDENT.repeat(level + 1)}`;
-    const entryIndentation = `,\n${DEFAULT_INDENT.repeat(level + 1)}`;
-    const closingIndentation = `\n${DEFAULT_INDENT.repeat(level)}`;
-
     iContent = `${initIndentation}${groups.join(
       entryIndentation
     )}${closingIndentation}`;
   } else {
     iContent = entries.length === 0 ? "" : ` ${entries.join(", ")} `;
     if (stripColor(iContent).length > LINE_BREAKING_LENGTH) {
-      const initIndentation = `\n${DEFAULT_INDENT.repeat(level + 1)}`;
-      const entryIndentation = `,\n${DEFAULT_INDENT.repeat(level + 1)}`;
-      const closingIndentation = `\n`;
-
       iContent = `${initIndentation}${entries.join(
         entryIndentation
       )}${closingIndentation}`;


### PR DESCRIPTION
This reiterated pull request fixes issue #5653 about the console log not aligning.
The indentations have been fixed.
Somehow writing `level + 1` instead of `level` somewhere was messing up everything.

BEFORE:
```ts
> var data = {"totalTax":7.45,"summary":[{"jurisName":"Utah","taxCalculated":4.85,"jurisType":"State","taxType":"Sales"},{"jurisName":"Salt Lake","taxCalculated":1.35,"jurisType":"County","taxType":"Sales"},{"jurisName":"Murray","taxCalculated":0.2,"jurisType":"City","taxType":"Sales"},{"jurisName":"Salt Lake Co Tr","taxCalculated":1.05,"jurisType":"Special","taxType":"Sales"}]};

> console.log(data);
{
 totalTax: 7.45,
 summary: [
  { jurisName: "Utah", taxCalculated: 4.85, jurisType: "State", taxType: "Sales" },
  {
    jurisName: "Salt Lake",
    taxCalculated: 1.35,
    jurisType: "County",
    taxType: "Sales"
   },
  { jurisName: "Murray", taxCalculated: 0.2, jurisType: "City", taxType: "Sales" },
  {
    jurisName: "Salt Lake Co Tr",
    taxCalculated: 1.05,
    jurisType: "Special",
    taxType: "Sales"
   }
]        // I believe this line not aligning is a bug, it has no leading space, better align with above `summary`
}
undefined
```

BEFORE²:
```ts
{
  totalTax: 7.75,
  summary: [
    { jurisName: "California", taxCalculated: 6, jurisType: "State", taxType: "Sales" },
    {
        jurisName: "Riverside",
        taxCalculated: 0.25,
        jurisType: "County",
        taxType: "Sales"
      },   // I just realized this aligning also increased by 1 more space than deno-1.0.0 but I believe it's wrong fix, it's still different than what node shows
    {
        jurisName: "Riverside Co Local Tax Sl",
        taxCalculated: 1,
        jurisType: "Special",
        taxType: "Sales"
      },
    {
        jurisName: "Riverside County District Tax Sp",
        taxCalculated: 0.5,
        jurisType: "Special",
        taxType: "Sales"
      }
]      // what I meant is this line, supposed to be aligned with `summary`, should have 2 leading spaces
}
```

AFTER:
![image](https://user-images.githubusercontent.com/13885008/83071576-a480b800-a06d-11ea-9c83-2211469e764e.png)