### PR TITLE
Add await into worker.ts

### DIFF
--- a/docs/runtime/workers.md
+++ b/docs/runtime/workers.md
@@ -34,7 +34,7 @@ new Worker("./worker.ts", { type: "module" });
 **worker.ts**
 
 ```ts
-console.log("hello world");
+await console.log("hello world");
 self.close();
 ```
 


### PR DESCRIPTION
I am running this code on Mac, if I did not add that **await** in the front of the console.log I have the error:

```
deno run --allow-read main.ts 
hello world
thread 'deno-worker-0' panicked at 'Failed to post message to host: TrySendError { kind: Disconnected }', cli/ops/worker_host.rs:142:7
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'Worker thread panicked: Any', cli/ops/worker_host.rs:329:11
```
If that **await** before the **console.log** is not be needed this is possible bug. 
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->