### PR TITLE
console: Hide `values` for console.table if display not necessary

### DIFF
--- a/cli/js/web/console.ts
+++ b/cli/js/web/console.ts
@@ -842,27 +842,33 @@ export class Console {
       resultData = data!;
     }
 
+    let hasPrimitives = false;
     Object.keys(resultData).forEach((k, idx): void => {
-      const value: unknown = resultData[k]!;
-
-      if (value !== null && typeof value === "object") {
-        Object.entries(value as { [key: string]: unknown }).forEach(
-          ([k, v]): void => {
-            if (properties && !properties.includes(k)) {
-              return;
-            }
-
+      let value: unknown = resultData[k]!;
+      const primitive =
+        value === null ||
+        (typeof value !== "function" && typeof value !== "object");
+      if (properties === undefined && primitive) {
+        hasPrimitives = true;
+        values.push(stringifyValue(value));
+      } else {
+        const valueObj = (value as { [key: string]: unknown }) || {};
+        const keys = properties || Object.keys(valueObj);
+        for (const k of keys) {
+          if (primitive || !valueObj.hasOwnProperty(k)) {
             if (objectValues[k]) {
-              objectValues[k].push(stringifyValue(v));
+              // fill with blanks for idx to avoid misplacing from later values
+              objectValues[k].push("");
+            }
+          } else {
+            if (objectValues[k]) {
+              objectValues[k].push(stringifyValue(valueObj[k]));
             } else {
-              objectValues[k] = createColumn(v, idx);
+              objectValues[k] = createColumn(valueObj[k], idx);
             }
           }
-        );
-
+        }
         values.push("");
-      } else {
-        values.push(stringifyValue(value));
       }
 
       indexKeys.push(k);
@@ -872,10 +878,7 @@ export class Console {
     const bodyValues = Object.values(objectValues);
     const header = [
       indexKey,
-      ...(properties || [
-        ...headerKeys,
-        !isMap && values.length > 0 && valuesKey,
-      ]),
+      ...(properties || [...headerKeys, !isMap && hasPrimitives && valuesKey]),
     ].filter(Boolean) as string[];
     const body = [indexKeys, ...bodyValues, values];
 

--- a/cli/js/web/console.ts
+++ b/cli/js/web/console.ts
@@ -844,7 +844,7 @@ export class Console {
 
     let hasPrimitives = false;
     Object.keys(resultData).forEach((k, idx): void => {
-      let value: unknown = resultData[k]!;
+      const value: unknown = resultData[k]!;
       const primitive =
         value === null ||
         (typeof value !== "function" && typeof value !== "object");

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -571,7 +571,7 @@ unitTest(function consoleTestStringifyIterable() {
     `[ <4 empty items>, 0, 0, <4 empty items> ]`
   );
 
-  /* TODO(ry) Fix this test 
+  /* TODO(ry) Fix this test
   const lWithEmptyEl = Array(200);
   lWithEmptyEl.fill(0, 50, 80);
   assertEquals(
@@ -1070,6 +1070,36 @@ unitTest(function consoleTable(): void {
 │   1   │ "你好"  │
 │   2   │ "Amapá" │
 └───────┴─────────┘
+`
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table([
+      [1, 2],
+      [3, 4],
+    ]);
+    assertEquals(
+      stripColor(out.toString()),
+      `┌───────┬───┬───┐
+│ (idx) │ 0 │ 1 │
+├───────┼───┼───┤
+│   0   │ 1 │ 2 │
+│   1   │ 3 │ 4 │
+└───────┴───┴───┘
+`
+    );
+  });
+  mockConsole((console, out): void => {
+    console.table({ 1: { a: 4, b: 5 }, 2: null, 3: { b: 6, c: 7 } }, ["b"]);
+    assertEquals(
+      stripColor(out.toString()),
+      `┌───────┬───┐
+│ (idx) │ b │
+├───────┼───┤
+│   1   │ 5 │
+│   2   │   │
+│   3   │ 6 │
+└───────┴───┘
 `
     );
   });


### PR DESCRIPTION
Fixes #5902 
This is potentially a more comprehensive version than attempt in #5905 
The actual main problem is that we attempted to display `values` on cases where `values` is filled only with empty strings. Now instead we only display values when there is actually interesting values to display (not primitive) and there are no explicit `properties` given.

This fix also tweaks the logic when we push `""` for `objectValues[k]`: original code also has a second bug that when a column is created for a key, but then a following property does not have the value for that column. This causes a misplacement upwards (see Example 3 below)

Before (Deno 1.0.2):
```
> console.table([[1,2],[3,4]])
┌───────┬───┬───┬────────┐
│ (idx) │ 0 │ 1 │ Values │
├───────┼───┼───┼────────┤
│   0   │ 1 │ 2 │        │
│   1   │ 3 │ 4 │        │
└───────┴───┴───┴────────┘
undefined
> console.table([{a:1,b:2},{a:3,b:4}])
┌───────┬───┬───┬────────┐
│ (idx) │ a │ b │ Values │
├───────┼───┼───┼────────┤
│   0   │ 1 │ 2 │        │
│   1   │ 3 │ 4 │        │
└───────┴───┴───┴────────┘
undefined
> console.table({1: {a: 4, b: 5}, 2: null, 3: {b: 6, c: 7}}, ['b']) // Example 3, notice that b:6 got misplaced to idx 2 instead of idx 3
┌───────┬───┐
│ (idx) │ b │
├───────┼───┤
│   1   │ 5 │
│   2   │ 6 │
│   3   │   │
└───────┴───┘
undefined
```

After this PR:
```
> console.table([[1,2],[3,4]])
┌───────┬───┬───┐
│ (idx) │ 0 │ 1 │
├───────┼───┼───┤
│   0   │ 1 │ 2 │
│   1   │ 3 │ 4 │
└───────┴───┴───┘
undefined
> console.table([{a:1,b:2},{a:3,b:4}])
┌───────┬───┬───┐
│ (idx) │ a │ b │
├───────┼───┼───┤
│   0   │ 1 │ 2 │
│   1   │ 3 │ 4 │
└───────┴───┴───┘
undefined
> console.table({1: {a: 4, b: 5}, 2: null, 3: {b: 6, c: 7}}, ['b'])
┌───────┬───┐
│ (idx) │ b │
├───────┼───┤
│   1   │ 5 │
│   2   │   │
│   3   │ 6 │
└───────┴───┘
undefined
```
In comparison, this is the result received on Node v14.3.0, reflecting the fix in this PR:
```
> console.table([[1,2],[3,4]])
┌─────────┬───┬───┐
│ (index) │ 0 │ 1 │
├─────────┼───┼───┤
│    0    │ 1 │ 2 │
│    1    │ 3 │ 4 │
└─────────┴───┴───┘
undefined
> console.table([{a:1,b:2},{a:3,b:4}])
┌─────────┬───┬───┐
│ (index) │ a │ b │
├─────────┼───┼───┤
│    0    │ 1 │ 2 │
│    1    │ 3 │ 4 │
└─────────┴───┴───┘
undefined
> console.table({1: {a: 4, b: 5}, 2: null, 3: {b: 6, c: 7}}, ['b'])
┌─────────┬───┐
│ (index) │ b │
├─────────┼───┤
│    1    │ 5 │
│    2    │   │
│    3    │ 6 │
└─────────┴───┘
undefined
```