### PR TITLE
(std/node) feat: add link/linkSync polyfill

### DIFF
--- a/std/node/_fs/_fs_link.ts
+++ b/std/node/_fs/_fs_link.ts
@@ -1,0 +1,37 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { CallbackWithError } from "./_fs_common.ts";
+import { fromFileUrl } from "../path.ts";
+
+/**
+ * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
+ * are implemented. See https://github.com/denoland/deno/issues/3403
+ */
+export function link(
+  existingPath: string | URL,
+  newPath: string | URL,
+  callback: CallbackWithError
+): void {
+  existingPath =
+    existingPath instanceof URL ? fromFileUrl(existingPath) : existingPath;
+  newPath = newPath instanceof URL ? fromFileUrl(newPath) : newPath;
+
+  Deno.link(existingPath, newPath)
+    .then(() => callback())
+    .catch(callback);
+}
+
+/**
+ * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
+ * are implemented. See https://github.com/denoland/deno/issues/3403
+ */
+export function linkSync(
+  existingPath: string | URL,
+  newPath: string | URL
+): void {
+  existingPath =
+    existingPath instanceof URL ? fromFileUrl(existingPath) : existingPath;
+  newPath = newPath instanceof URL ? fromFileUrl(newPath) : newPath;
+
+  Deno.linkSync(existingPath, newPath);
+}

--- a/std/node/_fs/_fs_link_test.ts
+++ b/std/node/_fs/_fs_link_test.ts
@@ -1,0 +1,69 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+const { test } = Deno;
+import { fail, assertEquals } from "../../testing/asserts.ts";
+import { link, linkSync } from "./_fs_link.ts";
+import { writeFileStrSync } from "../../fs/write_file_str.ts";
+import { readFileStrSync } from "../../fs/read_file_str.ts";
+import { assert } from "https://deno.land/std@v0.50.0/testing/asserts.ts";
+const isWindows = Deno.build.os === "windows";
+
+test({
+  ignore: isWindows,
+  name: "ASYNC: hard linking files works as expected",
+  async fn() {
+    const tempFile: string = await Deno.makeTempFile();
+    await new Promise((res, rej) => {
+      link(tempFile, tempFile + ".link", (err) => {
+        if (err) rej(err);
+        else res();
+      });
+    })
+      .then(() => {
+        writeFileStrSync(tempFile, "hello world");
+        assertEquals(readFileStrSync(tempFile + ".link"), "hello world");
+      })
+      .catch(() => {
+        fail("Expected to succeed");
+      })
+      .finally(() => {
+        Deno.removeSync(tempFile);
+        Deno.removeSync(tempFile + ".link");
+      });
+  },
+});
+
+test({
+  ignore: isWindows,
+  name: "ASYNC: hard linking files passes error to callback",
+  async fn() {
+    let failed = false;
+    await new Promise((res, rej) => {
+      link("no-such-file", "no-such-file", (err) => {
+        if (err) rej(err);
+        else res();
+      });
+    })
+      .then(() => {
+        fail("Expected to succeed");
+      })
+      .catch((err) => {
+        assert(err);
+        failed = true;
+      });
+    assert(failed);
+  },
+});
+
+test({
+  ignore: isWindows,
+  name: "SYNC: hard linking files works as expected",
+  fn() {
+    const tempFile: string = Deno.makeTempFileSync();
+    linkSync(tempFile, tempFile + ".link");
+
+    writeFileStrSync(tempFile, "hello world");
+    assertEquals(readFileStrSync(tempFile + ".link"), "hello world");
+    Deno.removeSync(tempFile);
+    Deno.removeSync(tempFile + ".link");
+  },
+});

--- a/std/node/_fs/_fs_link_test.ts
+++ b/std/node/_fs/_fs_link_test.ts
@@ -2,8 +2,6 @@
 const { test } = Deno;
 import { fail, assertEquals } from "../../testing/asserts.ts";
 import { link, linkSync } from "./_fs_link.ts";
-import { writeFileStrSync } from "../../fs/write_file_str.ts";
-import { readFileStrSync } from "../../fs/read_file_str.ts";
 import { assert } from "https://deno.land/std@v0.50.0/testing/asserts.ts";
 const isWindows = Deno.build.os === "windows";
 
@@ -12,22 +10,22 @@ test({
   name: "ASYNC: hard linking files works as expected",
   async fn() {
     const tempFile: string = await Deno.makeTempFile();
+    const linkedFile: string = tempFile + ".link";
     await new Promise((res, rej) => {
-      link(tempFile, tempFile + ".link", (err) => {
+      link(tempFile, linkedFile, (err) => {
         if (err) rej(err);
         else res();
       });
     })
       .then(() => {
-        writeFileStrSync(tempFile, "hello world");
-        assertEquals(readFileStrSync(tempFile + ".link"), "hello world");
+        assertEquals(Deno.statSync(tempFile), Deno.statSync(linkedFile));
       })
       .catch(() => {
         fail("Expected to succeed");
       })
       .finally(() => {
         Deno.removeSync(tempFile);
-        Deno.removeSync(tempFile + ".link");
+        Deno.removeSync(linkedFile);
       });
   },
 });
@@ -59,11 +57,11 @@ test({
   name: "SYNC: hard linking files works as expected",
   fn() {
     const tempFile: string = Deno.makeTempFileSync();
-    linkSync(tempFile, tempFile + ".link");
+    const linkedFile: string = tempFile + ".link";
+    linkSync(tempFile, linkedFile);
 
-    writeFileStrSync(tempFile, "hello world");
-    assertEquals(readFileStrSync(tempFile + ".link"), "hello world");
+    assertEquals(Deno.statSync(tempFile), Deno.statSync(linkedFile));
     Deno.removeSync(tempFile);
-    Deno.removeSync(tempFile + ".link");
+    Deno.removeSync(linkedFile);
   },
 });


### PR DESCRIPTION
This PR adds `link` and `linkSync` node polyfills.
