### PR TITLE
[WIP] Refactor: Export function as arrow function const

### DIFF
--- a/std/async/delay.ts
+++ b/std/async/delay.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 /* Resolves after the given number of milliseconds. */
-export function delay(ms: number): Promise<void> {
+export const delay = (ms: number): Promise<void> => {
   return new Promise((res): number =>
     setTimeout((): void => {
       res();

--- a/std/async/delay.ts
+++ b/std/async/delay.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 /* Resolves after the given number of milliseconds. */
 export const delay = (ms: number): Promise<void> => {
-  return new Promise((res): number =>
-    setTimeout(res, ms)
-  );
+  return new Promise(res => {
+    setTimeout(res, ms);
+  });
 }

--- a/std/async/delay.ts
+++ b/std/async/delay.ts
@@ -2,8 +2,6 @@
 /* Resolves after the given number of milliseconds. */
 export const delay = (ms: number): Promise<void> => {
   return new Promise((res): number =>
-    setTimeout((): void => {
-      res();
-    }, ms)
+    setTimeout(res, ms)
   );
 }


### PR DESCRIPTION
This PR is WIP and needs your review to continue.

I am proud to get an opportunity to improve typescript `std` modules.
I have more than 16 years of experience in EcmaScript and will be happy if you allow me to make some improvement.

For example I think exporting functions as arrow syntax is better in ecmascript because of cost of function isolation like separate `this`, etc.

As seen in many popular projects like google polymer project
https://github.com/Polymer/lit-element/blob/master/src/lib/css-tag.ts#L87

Will you allow me to continue?
Thank you.