### PR TITLE
feat(std/testing): benching progress callback

### DIFF
--- a/std/testing/bench.ts
+++ b/std/testing/bench.ts
@@ -189,10 +189,7 @@ export async function runBenchmarks(
       (queued) => queued.name === name && queued.runsCount === runs
     );
     if (queueIndex != -1) {
-      progress.queued.splice(
-        progress.queued.indexOf({ name, runsCount: runs }),
-        1
-      );
+      progress.queued.splice(queueIndex, 1);
     }
     // Init the progress of the running benchmark
     progress.running = { name, runsCount: runs, measuredRunsMs: [] };

--- a/std/testing/bench.ts
+++ b/std/testing/bench.ts
@@ -351,7 +351,7 @@ function publishProgress(
   progress: BenchmarkRunProgress,
   state: ProgressState,
   progressCb?: (progress: BenchmarkRunProgress) => void
-) {
+): void {
   progressCb && progressCb(cloneProgressWithState(progress, state));
 }
 

--- a/std/testing/bench.ts
+++ b/std/testing/bench.ts
@@ -37,8 +37,8 @@ export interface BenchmarkResult {
   name: string;
   totalMs: number;
   runsCount?: number;
-  runsAvgMs?: number;
-  runsMs?: number[];
+  measuredRunsAvgMs?: number;
+  measuredRunsMs?: number[];
 }
 
 export interface BenchmarkRunResult {
@@ -47,8 +47,8 @@ export interface BenchmarkRunResult {
 }
 
 export interface BenchmarkRunProgress extends BenchmarkRunResult {
-  queued: { name: string; runsCount: number }[];
-  running?: { name: string; runsCount: number; measuredMs: number[] }; // TODO measuredRunsMs
+  queued: Array<{ name: string; runsCount: number }>;
+  running?: { name: string; runsCount: number; measuredRunsMs: number[] };
 }
 
 export class BenchmarkRunError extends Error {
@@ -179,7 +179,7 @@ export async function runBenchmarks(
       );
     }
     // Init the progress of the running benchmark
-    progress.running = { name, runsCount: runs, measuredMs: [] };
+    progress.running = { name, runsCount: runs, measuredRunsMs: [] };
     // Publish starting of a benchmark
     progressCb && progressCb(progress);
 
@@ -216,7 +216,7 @@ export async function runBenchmarks(
           // Summing up
           totalMs += measuredMs;
           // Adding partial result
-          progress.running.measuredMs.push(measuredMs);
+          progress.running.measuredRunsMs.push(measuredMs);
           // Publish partial benchmark results
           progressCb && progressCb(progress);
 
@@ -230,8 +230,8 @@ export async function runBenchmarks(
               name,
               totalMs,
               runsCount: runs,
-              runsAvgMs: totalMs / runs,
-              runsMs: progress.running.measuredMs,
+              measuredRunsAvgMs: totalMs / runs,
+              measuredRunsMs: progress.running.measuredRunsMs,
             });
             // Clear currently running
             delete progress.running;

--- a/std/testing/bench.ts
+++ b/std/testing/bench.ts
@@ -196,7 +196,6 @@ export async function runBenchmarks(
   progressCb && progressCb(progress);
 
   if (!silent) {
-    // Iterating given benchmark definitions (await-in-loop)
     console.log(
       "running",
       benchmarks.length,
@@ -204,6 +203,7 @@ export async function runBenchmarks(
     );
   }
 
+  // Iterating given benchmark definitions (await-in-loop)
   for (const { name, runs = 0, func } of benchmarks) {
     if (!silent) {
       // See https://github.com/denoland/deno/pull/1452 about groupCollapsed
@@ -317,7 +317,7 @@ export async function runBenchmarks(
     );
   }
 
-  // Making sure the program exit code is not zero in case of failure
+  // Throw error if there was a failing benchmark
   if (!!failError) {
     throw failError;
   }

--- a/std/testing/bench.ts
+++ b/std/testing/bench.ts
@@ -51,17 +51,11 @@ export interface BenchmarkResult {
   name: string;
   /** The total time it took to run a given bechmark  */
   totalMs: number;
-  /** Times the benchmark was run in succession.
-   *
-   * Only defined if `runs` for this  bench is greater than 1. */
+  /** Times the benchmark was run in succession. Only defined if `runs` for this  bench is greater than 1. */
   runsCount?: number;
-  /** The average time of running the benchmark in milliseconds.
-   *
-   * Only defined if `runs` for this  bench is greater than 1. */
+  /** The average time of running the benchmark in milliseconds. Only defined if `runs` for this  bench is greater than 1. */
   measuredRunsAvgMs?: number;
-  /** The individual measurements in millisecond it took to run the benchmark.
-   *
-   * Only defined if `runs` for this  bench is greater than 1. */
+  /** The individual measurements in millisecond it took to run the benchmark. Only defined if `runs` for this  bench is greater than 1. */
   measuredRunsMs?: number[];
 }
 
@@ -69,13 +63,13 @@ export interface BenchmarkResult {
 export interface BenchmarkRunResult {
   /** How many benchmark were ignored by the provided `only` and `skip` */
   filtered: number;
-  /** The individual results each benchmark that was run */
+  /** The individual results for each benchmark that was run */
   results: BenchmarkResult[];
 }
 
 /** Defines the current progress during the run of `runBenchmarks` */
 export interface BenchmarkRunProgress extends BenchmarkRunResult {
-  /** List of the queued benchmarks to run and their run count */
+  /** List of the queued benchmarks to run with their name and their run count */
   queued: Array<{ name: string; runsCount: number }>;
   /** The currently running benchmark with its name, run count and the already finished measurements in milliseconds */
   running?: { name: string; runsCount: number; measuredRunsMs: number[] };
@@ -169,8 +163,8 @@ export function clearBenchmarks({
 /**
  * Runs all registered and non-skipped benchmarks serially.
  *
- * @param {(progress: BenchmarkRunProgress) => void} [progressCb] provides the possibility to get updates of the current progress during the run of the benchmarking
- * @returns {Promise<BenchmarkRunResult>} the results of the benchmarking
+ * @param [progressCb] provides the possibility to get updates of the current progress during the run of the benchmarking
+ * @returns results of the benchmarking
  */
 export async function runBenchmarks(
   { only = /[^\s]/, skip = /^\s*$/, silent }: BenchmarkRunOptions = {},

--- a/std/testing/bench.ts
+++ b/std/testing/bench.ts
@@ -33,6 +33,11 @@ export interface BenchmarkRunOptions {
   silent?: boolean;
 }
 
+export interface BenchmarkClearOptions {
+  only?: RegExp;
+  skip?: RegExp;
+}
+
 export interface BenchmarkResult {
   name: string;
   totalMs: number;
@@ -121,6 +126,17 @@ export function bench(
       func: benchmark.func,
     });
   }
+}
+
+export function clearBenchmarks({
+  only = /[^\s]/,
+  skip = /$^/,
+}: BenchmarkClearOptions = {}) {
+  const keep = candidates.filter(
+    ({ name }): boolean => !only.test(name) || skip.test(name)
+  );
+  candidates.splice(0, candidates.length);
+  candidates.push(...keep);
 }
 
 /** Runs all registered and non-skipped benchmarks serially. */

--- a/std/testing/bench.ts
+++ b/std/testing/bench.ts
@@ -131,7 +131,7 @@ export function bench(
 export function clearBenchmarks({
   only = /[^\s]/,
   skip = /$^/,
-}: BenchmarkClearOptions = {}) {
+}: BenchmarkClearOptions = {}): void {
   const keep = candidates.filter(
     ({ name }): boolean => !only.test(name) || skip.test(name)
   );
@@ -207,9 +207,12 @@ export async function runBenchmarks(
         await func(b);
         // Making sure the benchmark was started/stopped properly
         assertTiming(clock, name);
-        result = `${clock.stop - clock.start}ms`;
+        // Calculate length of run
+        const measuredMs = clock.stop - clock.start;
+
+        result = `${measuredMs}ms`;
         // Adding one-time run to results
-        progress.results.push({ name, totalMs: clock.stop - clock.start });
+        progress.results.push({ name, totalMs: measuredMs });
         // Clear currently running
         delete progress.running;
         // Publish one-time run benchmark finish

--- a/std/testing/bench.ts
+++ b/std/testing/bench.ts
@@ -153,7 +153,8 @@ export function bench(
   }
 }
 
-/** Clears benchmark candidates which name matches `only` and doesn't match `skip`. Removes all candidates if options were not provided */
+/** Clears benchmark candidates which name matches `only` and doesn't match `skip`.
+ * Removes all candidates if options were not provided */
 export function clearBenchmarks({
   only = /[^\s]/,
   skip = /$^/,
@@ -165,7 +166,12 @@ export function clearBenchmarks({
   candidates.push(...keep);
 }
 
-/** Runs all registered and non-skipped benchmarks serially. */
+/**
+ * Runs all registered and non-skipped benchmarks serially.
+ *
+ * @param {(progress: BenchmarkRunProgress) => void} [progressCb] provides the possibility to get updates of the current progress during the run of the benchmarking
+ * @returns {Promise<BenchmarkRunResult>} the results of the benchmarking
+ */
 export async function runBenchmarks(
   { only = /[^\s]/, skip = /^\s*$/, silent }: BenchmarkRunOptions = {},
   progressCb?: (progress: BenchmarkRunProgress) => void

--- a/std/testing/bench.ts
+++ b/std/testing/bench.ts
@@ -23,36 +23,61 @@ export interface BenchmarkFunction {
 export interface BenchmarkDefinition {
   func: BenchmarkFunction;
   name: string;
+  /** Defines how many times the provided `func` should be benchmarked in succession */
   runs?: number;
 }
 
 /** Defines runBenchmark's run constraints by matching benchmark names. */
 export interface BenchmarkRunOptions {
+  /** Only benchmarks which name match this regexp will be run*/
   only?: RegExp;
+  /** Benchmarks which name match this regexp will be skipped */
   skip?: RegExp;
+  /** Setting it to true prevents default benchmarking progress logs to the commandline*/
   silent?: boolean;
 }
 
+/** Defines clearBenchmark's constraints by matching benchmark names. */
 export interface BenchmarkClearOptions {
+  /** Only benchmarks which name match this regexp will be removed */
   only?: RegExp;
+  /** Benchmarks which name match this regexp will be kept */
   skip?: RegExp;
 }
 
+/** Defines the result of a single benchmark */
 export interface BenchmarkResult {
+  /** The name of the benchmark */
   name: string;
+  /** The total time it took to run a given bechmark  */
   totalMs: number;
+  /** Times the benchmark was run in succession.
+   *
+   * Only defined if `runs` for this  bench is greater than 1. */
   runsCount?: number;
+  /** The average time of running the benchmark in milliseconds.
+   *
+   * Only defined if `runs` for this  bench is greater than 1. */
   measuredRunsAvgMs?: number;
+  /** The individual measurements in millisecond it took to run the benchmark.
+   *
+   * Only defined if `runs` for this  bench is greater than 1. */
   measuredRunsMs?: number[];
 }
 
+/** Defines the result of a `runBenchmarks` call */
 export interface BenchmarkRunResult {
+  /** How many benchmark were ignored by the provided `only` and `skip` */
   filtered: number;
+  /** The individual results each benchmark that was run */
   results: BenchmarkResult[];
 }
 
+/** Defines the current progress during the run of `runBenchmarks` */
 export interface BenchmarkRunProgress extends BenchmarkRunResult {
+  /** List of the queued benchmarks to run and their run count */
   queued: Array<{ name: string; runsCount: number }>;
+  /** The currently running benchmark with its name, run count and the already finished measurements in milliseconds */
   running?: { name: string; runsCount: number; measuredRunsMs: number[] };
 }
 
@@ -128,6 +153,7 @@ export function bench(
   }
 }
 
+/** Clears benchmark candidates which name matches `only` and doesn't match `skip`. Removes all candidates if options were not provided */
 export function clearBenchmarks({
   only = /[^\s]/,
   skip = /$^/,

--- a/std/testing/bench_test.ts
+++ b/std/testing/bench_test.ts
@@ -73,10 +73,10 @@ test({
 
     const resultWithMultipleRuns = resultWithMultipleRunsFiltered[0];
     assert(!!resultWithMultipleRuns.runsCount);
-    assert(!!resultWithMultipleRuns.runsAvgMs);
-    assert(!!resultWithMultipleRuns.runsMs);
+    assert(!!resultWithMultipleRuns.measuredRunsAvgMs);
+    assert(!!resultWithMultipleRuns.measuredRunsMs);
     assertEquals(resultWithMultipleRuns.runsCount, 100);
-    assertEquals(resultWithMultipleRuns.runsMs!.length, 100);
+    assertEquals(resultWithMultipleRuns.measuredRunsMs!.length, 100);
   },
 });
 

--- a/std/testing/bench_test.ts
+++ b/std/testing/bench_test.ts
@@ -326,7 +326,7 @@ test({
   },
 });
 
-function dummyBench(name: string, runs: number = 1): void {
+function dummyBench(name: string, runs = 1): void {
   bench({
     name,
     runs,

--- a/std/testing/bench_test.ts
+++ b/std/testing/bench_test.ts
@@ -89,7 +89,7 @@ test({
 });
 
 test({
-  name: "benchWithoutName",
+  name: "Bench without name should throw",
   fn() {
     assertThrows(
       (): void => {
@@ -102,7 +102,7 @@ test({
 });
 
 test({
-  name: "benchWithoutStop",
+  name: "Bench without stop should throw",
   fn: async function (): Promise<void> {
     await assertThrowsAsync(
       async (): Promise<void> => {
@@ -119,7 +119,7 @@ test({
 });
 
 test({
-  name: "benchWithoutStart",
+  name: "Bench without start should throw",
   fn: async function (): Promise<void> {
     await assertThrowsAsync(
       async (): Promise<void> => {
@@ -136,7 +136,7 @@ test({
 });
 
 test({
-  name: "benchStopBeforeStart",
+  name: "Bench with stop before start should throw",
   fn: async function (): Promise<void> {
     await assertThrowsAsync(
       async (): Promise<void> => {
@@ -154,7 +154,7 @@ test({
 });
 
 test({
-  name: "clearBenchmarks",
+  name: "clearBenchmarks should clear all candidates",
   fn: async function (): Promise<void> {
     dummyBench("test");
 
@@ -167,7 +167,7 @@ test({
 });
 
 test({
-  name: "clearBenchmarksWithOnly",
+  name: "clearBenchmarks with only as option",
   fn: async function (): Promise<void> {
     // to reset candidates
     clearBenchmarks();
@@ -185,7 +185,7 @@ test({
 });
 
 test({
-  name: "clearBenchmarksWithSkip",
+  name: "clearBenchmarks with skip as option",
   fn: async function (): Promise<void> {
     // to reset candidates
     clearBenchmarks();
@@ -203,7 +203,7 @@ test({
 });
 
 test({
-  name: "clearBenchmarksWithOnlySkip",
+  name: "clearBenchmarks with only and skip as option",
   fn: async function (): Promise<void> {
     // to reset candidates
     clearBenchmarks();
@@ -230,7 +230,7 @@ test({
 });
 
 test({
-  name: "benchingProgressCallback",
+  name: "progressCallback of runBenchmarks",
   fn: async function (): Promise<void> {
     clearBenchmarks();
     dummyBench("skip");
@@ -311,7 +311,6 @@ test({
       progress.results.filter(({ name }) => name == "single").length,
       1
     );
-
     const resultOfMultiple = progress.results.filter(
       ({ name }) => name == "multiple"
     );

--- a/std/testing/bench_test.ts
+++ b/std/testing/bench_test.ts
@@ -218,14 +218,8 @@ test({
 
     assertEquals(benchingResults.filtered, 0);
     assertEquals(benchingResults.results.length, 2);
-    assertEquals(
-      benchingResults.results.filter(({ name }) => name === "test").length,
-      1
-    );
-    assertEquals(
-      benchingResults.results.filter(({ name }) => name === "clearskip").length,
-      1
-    );
+    assert(!!benchingResults.results.find(({ name }) => name === "test"));
+    assert(!!benchingResults.results.find(({ name }) => name === "clearskip"));
   },
 });
 
@@ -259,10 +253,7 @@ test({
     progress = progressCallbacks[pc++];
     assertEquals(progress.filtered, 1);
     assertEquals(progress.queued.length, 1);
-    assertEquals(
-      progress.queued.filter(({ name }) => name == "multiple").length,
-      1
-    );
+    assert(!!progress.queued.find(({ name }) => name == "multiple"));
     assertEquals(progress.running, {
       name: "single",
       runsCount: 1,
@@ -275,10 +266,7 @@ test({
     assertEquals(progress.queued.length, 1);
     assertEquals(progress.running, undefined);
     assertEquals(progress.results.length, 1);
-    assertEquals(
-      progress.results.filter(({ name }) => name == "single").length,
-      1
-    );
+    assert(!!progress.results.find(({ name }) => name == "single"));
 
     // Assert start of bench "multiple"
     progress = progressCallbacks[pc++];
@@ -307,17 +295,14 @@ test({
     assertEquals(progress.queued.length, 0);
     assertEquals(progress.running, undefined);
     assertEquals(progress.results.length, 2);
-    assertEquals(
-      progress.results.filter(({ name }) => name == "single").length,
-      1
-    );
+    assert(!!progress.results.find(({ name }) => name == "single"));
     const resultOfMultiple = progress.results.filter(
       ({ name }) => name == "multiple"
     );
     assertEquals(resultOfMultiple.length, 1);
     assert(!!resultOfMultiple[0].measuredRunsMs);
-    assertEquals(resultOfMultiple[0].measuredRunsMs!.length, 2);
     assert(!!resultOfMultiple[0].measuredRunsAvgMs);
+    assertEquals(resultOfMultiple[0].measuredRunsMs!.length, 2);
 
     // The last progress should equal the final result from promise
     progress = progressCallbacks[pc++];

--- a/std/testing/bench_test.ts
+++ b/std/testing/bench_test.ts
@@ -63,7 +63,6 @@ test({
 
     const benchResult = await runBenchmarks({ skip: /throw/ });
 
-    assertEquals(benchResult.measured, 5);
     assertEquals(benchResult.filtered, 1);
     assertEquals(benchResult.results.length, 5);
 


### PR DESCRIPTION
closes: #5942
Related: #5841 

TODOs
- [x] Add callback
- [x] Add possibility to clear registered benches
- [x] Add tests
- [x] deep copy progress
- [ ] Tidy up interfaces

> - [x] ? Add progress state enum ?
> - [ ] ? rename runsCount to runs so it is consistent with `BenchmarkDefinition`

- [x] JS DOC Benching
- [ ] Update README.md
- [ ] Provide examples
