### PR TITLE
fix(cli/web): Body.bodyUsed should use IsReadableStreamDisturbed

### DIFF
--- a/cli/js/web/body.ts
+++ b/cli/js/web/body.ts
@@ -2,6 +2,7 @@ import * as blob from "./blob.ts";
 import * as encoding from "./text_encoding.ts";
 import * as domTypes from "./dom_types.d.ts";
 import { ReadableStreamImpl } from "./streams/readable_stream.ts";
+import { isReadableStreamDisturbed } from "./streams/internals.ts";
 import { getHeaderValueParams, hasHeaderValueOf } from "./util.ts";
 
 // only namespace imports work for now, plucking out what we need
@@ -115,7 +116,7 @@ export class Body implements domTypes.Body {
   }
 
   get bodyUsed(): boolean {
-    if (this.body && this.body.locked) {
+    if (this.body && isReadableStreamDisturbed(this.body)) {
       return true;
     }
     return false;

--- a/cli/js/web/streams/internals.ts
+++ b/cli/js/web/streams/internals.ts
@@ -367,6 +367,11 @@ export function isReadableStreamLocked(stream: ReadableStreamImpl): boolean {
   return stream[sym.reader] ? true : false;
 }
 
+export function isReadableStreamDisturbed(stream: ReadableStream): boolean {
+  assert(isReadableStream(stream));
+  return stream[sym.disturbed] ? true : false;
+}
+
 export function isTransformStream(
   x: unknown
 ): x is TransformStreamImpl<any, any> {


### PR DESCRIPTION
As per the [specification](https://fetch.spec.whatwg.org/#dom-body-bodyused)

> The bodyUsed attribute’s getter must return true if disturbed, and false otherwise.

And in order to check if `disturbed` is `true`, [`IsReadableStreamDisturbed`](https://streams.spec.whatwg.org/#is-readable-stream-disturbed) internal method should be used.


The following is currently `true` in Deno & `false` in Browsers.

```
 const res = await fetch("https://deno.land");
 const reader = res.body.getReader()
 console.log(res.bodyUsed); // true
``` 