### PR TITLE
cli/web/fetch: Implement fetch network error on multiple redirects

### DIFF
--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -288,6 +288,7 @@ export async function fetch(
     }
   }
 
+  let responseInit: ResponseInit = {};
   while (remRedirectCount) {
     const fetchResponse = await sendFetchReq(url, method, headers, body);
 
@@ -314,7 +315,7 @@ export async function fetch(
       },
     });
 
-    let responseInit: ResponseInit = {
+    responseInit = {
       status: fetchResponse.status,
       statusText: fetchResponse.statusText,
       headers: fetchResponse.headers,
@@ -374,6 +375,12 @@ export async function fetch(
       return response;
     }
   }
-  // Return a network error due to too many redirections
-  throw notImplemented();
+
+  responseData.set(responseInit, {
+    type: "error",
+    redirected: false,
+    url: "",
+  });
+
+  return new Response(null, responseInit);
 }

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -245,14 +245,13 @@ unitTest(
 
 unitTest(
   {
-    // FIXME(bartlomieju):
-    // The feature below is not implemented, but the test should work after implementation
-    ignore: true,
     perms: { net: true },
   },
   async function fetchWithInfRedirection(): Promise<void> {
     const response = await fetch("http://localhost:4549/cli/tests"); // will redirect to the same place
     assertEquals(response.status, 0); // network error
+    assertEquals(response.type, "error");
+    assertEquals(response.ok, false);
   }
 );
 

--- a/tools/http_server.py
+++ b/tools/http_server.py
@@ -363,7 +363,7 @@ def start(s):
 def spawn():
     servers = (server(), redirect_server(), another_redirect_server(),
                double_redirects_server(), https_server(),
-               absolute_redirect_server())
+               absolute_redirect_server(), inf_redirects_server())
     # In order to wait for each of the servers to be ready, we try connecting to
     # them with a tcp socket.
     for running_server in servers:


### PR DESCRIPTION
Implement [`network error`](https://fetch.spec.whatwg.org/#concept-network-error) response.

It's worth mentioning that both Firefox and Chrome throw a `TypeError` instead.