### PR TITLE
fix(cli/web): name for Headers and FormData

### DIFF
--- a/cli/js/web/form_data.ts
+++ b/cli/js/web/form_data.ts
@@ -137,3 +137,8 @@ export class FormDataImpl extends DomIterableMixin<
   FormDataEntryValue,
   typeof FormDataBase
 >(FormDataBase, dataSymbol) {}
+
+Object.defineProperty(FormDataImpl, "name", {
+  value: "FormData",
+  configurable: true,
+});

--- a/cli/js/web/headers.ts
+++ b/cli/js/web/headers.ts
@@ -256,3 +256,8 @@ export class HeadersImpl extends DomIterableMixin<
   string,
   typeof HeadersBase
 >(HeadersBase, headersData) {}
+
+Object.defineProperty(HeadersImpl, "name", {
+  value: "Headers",
+  configurable: true,
+});

--- a/cli/tests/unit/form_data_test.ts
+++ b/cli/tests/unit/form_data_test.ts
@@ -6,7 +6,7 @@ import {
   assertStrContains,
 } from "./test_util.ts";
 
-unitTest({ ignore: true }, function formDataHasCorrectNameProp(): void {
+unitTest(function formDataHasCorrectNameProp(): void {
   assertEquals(FormData.name, "FormData");
 });
 

--- a/cli/tests/unit/headers_test.ts
+++ b/cli/tests/unit/headers_test.ts
@@ -10,6 +10,10 @@ const {
   // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
 } = Deno[Deno.internal];
 
+unitTest(function headersHasCorrectNameProp(): void {
+  assertEquals(Headers.name, "Headers");
+});
+
 // Logic heavily copied from web-platform-tests, make
 // sure pass mostly header basic test
 // ref: https://github.com/web-platform-tests/wpt/blob/7c50c216081d6ea3c9afe553ee7b64534020a1b2/fetch/api/headers/headers-basic.html


### PR DESCRIPTION
Fix name for `Headers` & `FormData`

```
> Headers.name
Headers
> FormData.name
FormData
```