### PR TITLE
 Added support for input multiple

### DIFF
--- a/std/mime/multipart.ts
+++ b/std/mime/multipart.ts
@@ -252,13 +252,13 @@ function skipLWSPChar(u: Uint8Array): Uint8Array {
 }
 
 export interface MultipartFormData {
-  file(key: string): FormFile | Array<FormFile> | undefined;
+  file(key: string): FormFile | FormFile[] | undefined;
   value(key: string): string | undefined;
   entries(): IterableIterator<
-    [string, string | FormFile | Array<FormFile> | undefined]
+    [string, string | FormFile | FormFile[] | undefined]
   >;
   [Symbol.iterator](): IterableIterator<
-    [string, string | FormFile | Array<FormFile> | undefined]
+    [string, string | FormFile | FormFile[] | undefined]
   >;
   /** Remove all tempfiles */
   removeAll(): Promise<void>;
@@ -284,7 +284,7 @@ export class MultipartReader {
    * @param maxMemory maximum memory size to store file in memory. bytes. @default 10485760 (10MB)
    *  */
   async readForm(maxMemory = 10 << 20): Promise<MultipartFormData> {
-    const fileMap = new Map<string, FormFile | Array<FormFile>>();
+    const fileMap = new Map<string, FormFile | FormFile[]>();
     const valueMap = new Map<string, string>();
     let maxValueBytes = maxMemory + (10 << 20);
     const buf = new Buffer(new Uint8Array(maxValueBytes));
@@ -309,7 +309,7 @@ export class MultipartReader {
         continue;
       }
       // file
-      let formFile: FormFile | Array<FormFile> | undefined;
+      let formFile: FormFile | FormFile[] | undefined;
       const n = await copyN(p, buf, maxValueBytes);
       const contentType = p.headers.get("content-type");
       assert(contentType != null, "content-type must be set");
@@ -422,17 +422,17 @@ export class MultipartReader {
 }
 
 function multipatFormData(
-  fileMap: Map<string, FormFile | Array<FormFile>>,
+  fileMap: Map<string, FormFile | FormFile[]>,
   valueMap: Map<string, string>,
 ): MultipartFormData {
-  function file(key: string): FormFile | Array<FormFile> | undefined {
+  function file(key: string): FormFile | FormFile[] | undefined {
     return fileMap.get(key);
   }
   function value(key: string): string | undefined {
     return valueMap.get(key);
   }
   function* entries(): IterableIterator<
-    [string, string | FormFile | Array<FormFile> | undefined]
+    [string, string | FormFile | FormFile[] | undefined]
   > {
     yield* fileMap;
     yield* valueMap;
@@ -458,7 +458,7 @@ function multipatFormData(
     entries,
     removeAll,
     [Symbol.iterator](): IterableIterator<
-      [string, string | FormFile | Array<FormFile> | undefined]
+      [string, string | FormFile | FormFile[] | undefined]
     > {
       return entries();
     },

--- a/std/mime/multipart.ts
+++ b/std/mime/multipart.ts
@@ -345,7 +345,7 @@ export class MultipartReader {
         maxValueBytes -= n;
       }
       if (formFile) {
-        let mapVal = fileMap.get(p.formName);
+        const mapVal = fileMap.get(p.formName);
         if (mapVal !== undefined) {
           if (Array.isArray(mapVal)) {
             mapVal.push(formFile);

--- a/std/mime/multipart.ts
+++ b/std/mime/multipart.ts
@@ -65,7 +65,7 @@ function randomBoundary(): string {
 export function matchAfterPrefix(
   buf: Uint8Array,
   prefix: Uint8Array,
-  eof: boolean,
+  eof: boolean
 ): -1 | 0 | 1 {
   if (buf.length === prefix.length) {
     return eof ? 1 : 0;
@@ -104,7 +104,7 @@ export function scanUntilBoundary(
   dashBoundary: Uint8Array,
   newLineDashBoundary: Uint8Array,
   total: number,
-  eof: boolean,
+  eof: boolean
 ): number | null {
   if (total === 0) {
     // At beginning of body, allow dashBoundary.
@@ -174,7 +174,7 @@ class PartReader implements Reader, Closer {
         this.mr.dashBoundary,
         this.mr.newLineDashBoundary,
         this.total,
-        eof,
+        eof
       );
       if (this.n === 0) {
         // Force buffered I/O to read more into buffer.
@@ -423,7 +423,7 @@ export class MultipartReader {
 
 function multipatFormData(
   fileMap: Map<string, FormFile | FormFile[]>,
-  valueMap: Map<string, string>,
+  valueMap: Map<string, string>
 ): MultipartFormData {
   function file(key: string): FormFile | FormFile[] | undefined {
     return fileMap.get(key);
@@ -474,7 +474,7 @@ class PartWriter implements Writer {
     private writer: Writer,
     readonly boundary: string,
     public headers: Headers,
-    isFirstBoundary: boolean,
+    isFirstBoundary: boolean
   ) {
     let buf = "";
     if (isFirstBoundary) {
@@ -555,7 +555,7 @@ export class MultipartWriter {
       this.writer,
       this.boundary,
       headers,
-      !this.lastPart,
+      !this.lastPart
     );
     this.lastPart = part;
     return part;
@@ -565,7 +565,7 @@ export class MultipartWriter {
     const h = new Headers();
     h.set(
       "Content-Disposition",
-      `form-data; name="${field}"; filename="${filename}"`,
+      `form-data; name="${field}"; filename="${filename}"`
     );
     h.set("Content-Type", "application/octet-stream");
     return this.createPart(h);
@@ -586,7 +586,7 @@ export class MultipartWriter {
   async writeFile(
     field: string,
     filename: string,
-    file: Reader,
+    file: Reader
   ): Promise<void> {
     const f = await this.createFormFile(field, filename);
     await copy(file, f);

--- a/std/mime/multipart_test.ts
+++ b/std/mime/multipart_test.ts
@@ -14,7 +14,6 @@ import {
   isFormFile,
   matchAfterPrefix,
   scanUntilBoundary,
-  FormFile,
 } from "./multipart.ts";
 import { StringWriter } from "../io/writers.ts";
 

--- a/std/mime/multipart_test.ts
+++ b/std/mime/multipart_test.ts
@@ -14,6 +14,7 @@ import {
   isFormFile,
   matchAfterPrefix,
   scanUntilBoundary,
+  FormFile,
 } from "./multipart.ts";
 import { StringWriter } from "../io/writers.ts";
 
@@ -225,7 +226,10 @@ test({
     try {
       assertEquals(form.value("deno"), "land");
       assertEquals(form.value("bar"), "bar");
-      const file: any = form.file("file");
+      let file: FormFile | FormFile[] | undefined = form.file("file");
+      if (Array.isArray(file)) {
+        file = file[0];
+      }
       assert(file != null);
       assert(file.tempfile != null);
       assertEquals(file.size, size);
@@ -249,7 +253,10 @@ test({
       "--------------------------434049563556637648550474"
     );
     const form = await mr.readForm(20);
-    const file: any = form.file("file");
+    let file: FormFile | FormFile[] | undefined = form.file("file");
+    if (Array.isArray(file)) {
+      file = file[0];
+    }
     assert(file != null);
     const { tempfile, content } = file;
     assert(tempfile != null);

--- a/std/mime/multipart_test.ts
+++ b/std/mime/multipart_test.ts
@@ -225,7 +225,7 @@ test({
     try {
       assertEquals(form.value("deno"), "land");
       assertEquals(form.value("bar"), "bar");
-      const file = form.file("file");
+      const file: any = form.file("file");
       assert(file != null);
       assert(file.tempfile != null);
       assertEquals(file.size, size);
@@ -249,7 +249,7 @@ test({
       "--------------------------434049563556637648550474"
     );
     const form = await mr.readForm(20);
-    const file = form.file("file");
+    const file: any = form.file("file");
     assert(file != null);
     const { tempfile, content } = file;
     assert(tempfile != null);

--- a/std/mime/multipart_test.ts
+++ b/std/mime/multipart_test.ts
@@ -226,7 +226,7 @@ test({
     try {
       assertEquals(form.value("deno"), "land");
       assertEquals(form.value("bar"), "bar");
-      let file: FormFile | FormFile[] | undefined = form.file("file");
+      let file = form.file("file");
       if (Array.isArray(file)) {
         file = file[0];
       }
@@ -253,7 +253,7 @@ test({
       "--------------------------434049563556637648550474"
     );
     const form = await mr.readForm(20);
-    let file: FormFile | FormFile[] | undefined = form.file("file");
+    let file = form.file("file");
     if (Array.isArray(file)) {
       file = file[0];
     }


### PR DESCRIPTION
 Added support for input multiple (<input type = "file" ... multiple>) without breaking the api.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
