### PR TITLE
feat(std/node/util) add util.types.isDate

### DIFF
--- a/std/node/_util/_util_types.ts
+++ b/std/node/_util/_util_types.ts
@@ -1,0 +1,31 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+//
+// Adapted from Node.js. Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const _toString = Object.prototype.toString;
+
+const _isObjectLike = (value: unknown): boolean =>
+  value !== null && typeof value === "object";
+
+export function isDate(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Date]";
+}

--- a/std/node/_util/_util_types_test.ts
+++ b/std/node/_util/_util_types_test.ts
@@ -1,0 +1,60 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+//
+// Adapted from Node.js. Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import { assertStrictEq } from "../../testing/asserts.ts";
+
+import { isDate } from "./_util_types.ts";
+
+const { test } = Deno;
+
+test("New date instance with no arguments", () => {
+  assertStrictEq(isDate(new Date()), true);
+});
+
+test("New date instance with value 0", () => {
+  assertStrictEq(isDate(new Date(0)), true);
+});
+
+test("New date instance in new context", () => {
+  assertStrictEq(isDate(new (eval("Date"))()), true);
+});
+
+test("Date function is not of type Date", () => {
+  assertStrictEq(isDate(Date()), false);
+});
+
+test("Object is not of type Date", () => {
+  assertStrictEq(isDate({}), false);
+});
+
+test("Array is not of type Date", () => {
+  assertStrictEq(isDate([]), false);
+});
+
+test("Error is not of type Date", () => {
+  assertStrictEq(isDate(new Error()), false);
+});
+
+test("New object from Date prototype is not of type Date", () => {
+  assertStrictEq(isDate(Object.create(Date.prototype)), false);
+});

--- a/std/node/util.ts
+++ b/std/node/util.ts
@@ -1,4 +1,7 @@
 export { callbackify } from "./_util/_util_callbackify.ts";
+import * as types from "./_util/_util_types.ts";
+
+export { types };
 
 export function isArray(value: unknown): boolean {
   return Array.isArray(value);

--- a/std/node/util_test.ts
+++ b/std/node/util_test.ts
@@ -166,3 +166,11 @@ test({
     assert(te instanceof TextEncoder);
   },
 });
+
+test({
+  name: "[util] isDate",
+  fn() {
+    // Test verifies the method is exposed. See _util/_util_types_test for details
+    assert(util.types.isDate(new Date()));
+  },
+});


### PR DESCRIPTION
This PR adds `util.types.isDate` to the Node compatibility layer. Specs: https://nodejs.org/dist/latest-v14.x/docs/api/util.html#util_util_types_isdate_value

The `util.isDate` method is deprecated. Instead, `util.types.isDate` should be used. That is why I created the `types` module on top of `util`. 

Tests are ported from the NodeJS source code. Implementation details are from Node before it was ported to the internal `types` binding. I couldn't find something similar in Deno (yet) so I went for this approach.

This PR is a requirement for https://github.com/denoland/deno/issues/6011