### PR TITLE
fix: Better use of @ts-expect-error

### DIFF
--- a/cli/js/error_stack.ts
+++ b/cli/js/error_stack.ts
@@ -214,7 +214,13 @@ function evaluateCallSite(callSite: CallSite): CallSiteEval {
   };
 }
 
-function prepareStackTrace(error: Error, callSites: CallSite[]): string {
+function prepareStackTrace(
+  error: Error & {
+    __callSiteEvals: CallSiteEval[];
+    __formattedFrames: string[];
+  },
+  callSites: CallSite[]
+): string {
   const mappedCallSites = callSites.map(
     (callSite): CallSite => {
       const fileName = callSite.getFileName();
@@ -238,19 +244,14 @@ function prepareStackTrace(error: Error, callSites: CallSite[]): string {
     __formattedFrames: { value: [], configurable: true },
   });
   for (const callSite of mappedCallSites) {
-    // @ts-expect-error
     error.__callSiteEvals.push(Object.freeze(evaluateCallSite(callSite)));
     const isInternal = callSite.getFileName()?.startsWith("$deno$") ?? false;
-    // @ts-expect-error
     error.__formattedFrames.push(callSiteToString(callSite, isInternal));
   }
-  // @ts-expect-error
   Object.freeze(error.__callSiteEvals);
-  // @ts-expect-error
   Object.freeze(error.__formattedFrames);
   return (
     `${error.name}: ${error.message}\n` +
-    // @ts-expect-error
     error.__formattedFrames
       .map((s: string) => `    at ${colors.stripColor(s)}`)
       .join("\n")

--- a/cli/js/repl.ts
+++ b/cli/js/repl.ts
@@ -35,8 +35,8 @@ function isRecoverableError(e: Error): boolean {
 // Returns `true` if `close()` is called in REPL.
 // We should quit the REPL when this function returns `true`.
 function isCloseCalled(): boolean {
-  // @ts-expect-error
-  return globalThis.closed;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (globalThis as any).closed;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cli/js/runtime_main.ts
+++ b/cli/js/runtime_main.ts
@@ -30,8 +30,8 @@ import { log, immutableDefine } from "./util.ts";
 // TODO: factor out `Deno` global assignment to separate function
 // Add internal object to Deno object.
 // This is not exposed as part of the Deno types.
-// @ts-expect-error
-denoNs[internalSymbol] = internalObject;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(denoNs as any)[internalSymbol] = internalObject;
 
 let windowIsClosing = false;
 
@@ -71,8 +71,8 @@ export function bootstrapMainRuntime(): void {
     throw new Error("Worker runtime already bootstrapped");
   }
   // Remove bootstrapping methods from global scope
-  // @ts-expect-error
-  globalThis.bootstrap = undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).bootstrap = undefined;
   log("bootstrapMainRuntime");
   hasBootstrapped = true;
   Object.defineProperties(globalThis, windowOrWorkerGlobalScopeMethods);

--- a/cli/js/runtime_worker.ts
+++ b/cli/js/runtime_worker.ts
@@ -33,8 +33,8 @@ import { setSignals } from "./signals.ts";
 // TODO: factor out `Deno` global assignment to separate function
 // Add internal object to Deno object.
 // This is not exposed as part of the Deno types.
-// @ts-expect-error
-denoNs[internalSymbol] = internalObject;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(denoNs as any)[internalSymbol] = internalObject;
 
 const encoder = new TextEncoder();
 
@@ -128,8 +128,8 @@ export function bootstrapWorkerRuntime(
     throw new Error("Worker runtime already bootstrapped");
   }
   // Remove bootstrapping methods from global scope
-  // @ts-expect-error
-  globalThis.bootstrap = undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).bootstrap = undefined;
   log("bootstrapWorkerRuntime");
   hasBootstrapped = true;
   Object.defineProperties(globalThis, windowOrWorkerGlobalScopeMethods);

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -336,8 +336,8 @@ async function runTests({
   const originalConsole = globalThis.console;
 
   if (disableLog) {
-    // @ts-expect-error
-    globalThis.console = disabledConsole;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).console = disabledConsole;
   }
 
   let endMsg: TestMessage["end"];

--- a/cli/js/web/console.ts
+++ b/cli/js/web/console.ts
@@ -216,14 +216,18 @@ function groupEntries<T>(
       lineMaxLength += separatorSpace;
       maxLineLength[i] = lineMaxLength;
     }
-    let order = "padStart";
+    let order: "padStart" | "padEnd" = "padStart";
     if (value !== undefined) {
       for (let i = 0; i < entries.length; i++) {
-        //@ts-expect-error
-        if (typeof value[i] !== "number" && typeof value[i] !== "bigint") {
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        if (
+          typeof (value as any)[i] !== "number" &&
+          typeof (value as any)[i] !== "bigint"
+        ) {
           order = "padEnd";
           break;
         }
+        /* eslint-enable */
       }
     }
     // Each iteration creates a single line of grouped entries.
@@ -235,7 +239,6 @@ function groupEntries<T>(
       for (; j < max - 1; j++) {
         // In future, colors should be taken here into the account
         const padding = maxLineLength[j - i];
-        //@ts-expect-error
         str += `${entries[j]}, `[order](padding, " ");
       }
       if (order === "padStart") {
@@ -408,8 +411,8 @@ function createMapString(
     },
     group: false,
   };
-  //@ts-expect-error
-  return createIterableString(value, ctx, level, maxLevel, printConfig);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return createIterableString(value as any, ctx, level, maxLevel, printConfig);
 }
 
 function createWeakSetString(): string {
@@ -477,7 +480,7 @@ function createPromiseString(
 // TODO: Proxy
 
 function createRawObjectString(
-  value: { [key: string]: unknown },
+  value: Record<string, unknown>,
   ctx: ConsoleContext,
   level: number,
   maxLevel: number
@@ -490,8 +493,9 @@ function createRawObjectString(
   let baseString = "";
 
   let shouldShowDisplayName = false;
-  // @ts-expect-error
-  let displayName = value[Symbol.toStringTag];
+  let displayName = (value as { [Symbol.toStringTag]: string })[
+    Symbol.toStringTag
+  ];
   if (!displayName) {
     displayName = getClassInstanceName(value);
   }
@@ -511,8 +515,8 @@ function createRawObjectString(
   for (const key of symbolKeys) {
     entries.push(
       `${key.toString()}: ${stringifyWithQuotes(
-        // @ts-expect-error
-        value[key],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        value[key as any],
         ctx,
         level + 1,
         maxLevel

--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -187,7 +187,7 @@ function sendFetchReq(
 }
 
 export async function fetch(
-  input: domTypes.Request | URL | string,
+  input: (domTypes.Request & { _bodySource?: unknown }) | URL | string,
   init?: domTypes.RequestInit
 ): Promise<Response> {
   let url: string;
@@ -285,7 +285,6 @@ export async function fetch(
     method = input.method;
     headers = input.headers;
 
-    //@ts-expect-error
     if (input._bodySource) {
       body = new DataView(await input.arrayBuffer());
     }

--- a/cli/js/web/timers.ts
+++ b/cli/js/web/timers.ts
@@ -234,23 +234,23 @@ function setTimer(
 }
 
 export function setTimeout(
+  this: unknown,
   cb: (...args: Args) => void,
   delay = 0,
   ...args: Args
 ): number {
   checkBigInt(delay);
-  // @ts-expect-error
   checkThis(this);
   return setTimer(cb, delay, args, false);
 }
 
 export function setInterval(
+  this: unknown,
   cb: (...args: Args) => void,
   delay = 0,
   ...args: Args
 ): number {
   checkBigInt(delay);
-  // @ts-expect-error
   checkThis(this);
   return setTimer(cb, delay, args, true);
 }

--- a/cli/tests/unit/body_test.ts
+++ b/cli/tests/unit/body_test.ts
@@ -42,8 +42,8 @@ unitTest(
 
     const body = buildBody(text);
 
-    // @ts-expect-error
-    body.contentType = "multipart/form-data;boundary=boundary";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (body as any).contentType = "multipart/form-data;boundary=boundary";
 
     const formData = await body.formData();
     assert(formData.has("field_1"));
@@ -62,8 +62,8 @@ unitTest(
 
     const body = buildBody(text);
 
-    // @ts-expect-error
-    body.contentType = "application/x-www-form-urlencoded";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (body as any).contentType = "application/x-www-form-urlencoded";
 
     const formData = await body.formData();
     assert(formData.has("field_1"));

--- a/cli/tests/unit/dispatch_json_test.ts
+++ b/cli/tests/unit/dispatch_json_test.ts
@@ -19,14 +19,19 @@ unitTest(
   }
 );
 
+/* eslint-disable @typescript-eslint/no-namespace, @typescript-eslint/no-explicit-any,no-var */
+declare global {
+  namespace Deno {
+    var core: any;
+  }
+}
+/* eslint-enable */
+
 unitTest(function malformedJsonControlBuffer(): void {
-  // @ts-expect-error
   const opId = Deno.core.ops()["op_open"];
-  // @ts-expect-error
   const res = Deno.core.send(opId, new Uint8Array([1, 2, 3, 4, 5]));
   const resText = new TextDecoder().decode(res);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const resJson = JSON.parse(resText) as any;
+  const resJson = JSON.parse(resText);
   assert(!resJson.ok);
   assert(resJson.err);
 });

--- a/cli/tests/unit/dispatch_minimal_test.ts
+++ b/cli/tests/unit/dispatch_minimal_test.ts
@@ -25,10 +25,16 @@ unitTest(async function sendAsyncStackTrace(): Promise<void> {
   }
 });
 
+/* eslint-disable @typescript-eslint/no-namespace, @typescript-eslint/no-explicit-any,no-var */
+declare global {
+  namespace Deno {
+    var core: any;
+  }
+}
+/* eslint-enable */
+
 unitTest(function malformedMinimalControlBuffer(): void {
-  // @ts-expect-error
   const readOpId = Deno.core.ops()["op_read"];
-  // @ts-expect-error
   const res = Deno.core.send(readOpId, new Uint8Array([1, 2, 3, 4, 5]));
   const header = res.slice(0, 12);
   const buf32 = new Int32Array(

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -92,9 +92,8 @@ unitTest({ perms: { net: true } }, async function fetchBodyUsed(): Promise<
   const response = await fetch("http://localhost:4545/cli/tests/fixture.json");
   assertEquals(response.bodyUsed, false);
   assertThrows((): void => {
-    // Assigning to read-only property throws in the strict mode.
-    // @ts-expect-error
-    response.bodyUsed = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (response as any).bodyUsed = true;
   });
   await response.blob();
   assertEquals(response.bodyUsed, true);
@@ -657,10 +656,9 @@ unitTest({ perms: { net: true } }, async function fetchBodyReadTwice(): Promise<
   assert(_json);
 
   // All calls after the body was consumed, should fail
-  const methods = ["json", "text", "formData", "arrayBuffer"];
+  const methods = ["json", "text", "formData", "arrayBuffer"] as const;
   for (const method of methods) {
     try {
-      // @ts-expect-error
       await response[method]();
       fail(
         "Reading body multiple times should failed, the stream should've been locked."

--- a/cli/tests/unit/files_test.ts
+++ b/cli/tests/unit/files_test.ts
@@ -290,8 +290,8 @@ unitTest(
     // writing null should throw an error
     let err;
     try {
-      // @ts-expect-error
-      await file.write(null);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await file.write(null as any);
     } catch (e) {
       err = e;
     }
@@ -322,8 +322,8 @@ unitTest(
     // reading file into null buffer should throw an error
     let err;
     try {
-      // @ts-expect-error
-      await file.read(null);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await file.read(null as any);
     } catch (e) {
       err = e;
     }

--- a/cli/tests/unit/form_data_test.ts
+++ b/cli/tests/unit/form_data_test.ts
@@ -41,10 +41,10 @@ unitTest(function formDataParamsGetSuccess(): void {
   formData.append("a", "true");
   formData.append("b", "false");
   formData.append("a", "null");
-  // @ts-expect-error
-  formData.append("d", undefined);
-  // @ts-expect-error
-  formData.append("e", null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  formData.append("d", undefined as any);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  formData.append("e", null as any);
   assertEquals(formData.get("a"), "true");
   assertEquals(formData.get("b"), "false");
   assertEquals(formData.get("c"), null);
@@ -70,11 +70,11 @@ unitTest(function formDataParamsSetSuccess(): void {
   assertEquals(formData.getAll("b"), ["false"]);
   formData.set("a", "false");
   assertEquals(formData.getAll("a"), ["false"]);
-  // @ts-expect-error
-  formData.set("d", undefined);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  formData.set("d", undefined as any);
   assertEquals(formData.get("d"), "undefined");
-  // @ts-expect-error
-  formData.set("e", null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  formData.set("e", null as any);
   assertEquals(formData.get("e"), "null");
 });
 
@@ -143,8 +143,8 @@ unitTest(function formDataParamsArgumentsCheck(): void {
     let hasThrown = 0;
     let errMsg = "";
     try {
-      // @ts-expect-error
-      formData[method]();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (formData as any)[method]();
       hasThrown = 1;
     } catch (err) {
       errMsg = err.message;
@@ -167,8 +167,8 @@ unitTest(function formDataParamsArgumentsCheck(): void {
     let errMsg = "";
 
     try {
-      // @ts-expect-error
-      formData[method]();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (formData as any)[method]();
       hasThrown = 1;
     } catch (err) {
       errMsg = err.message;
@@ -187,8 +187,8 @@ unitTest(function formDataParamsArgumentsCheck(): void {
     hasThrown = 0;
     errMsg = "";
     try {
-      // @ts-expect-error
-      formData[method]("foo");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (formData as any)[method]("foo");
       hasThrown = 1;
     } catch (err) {
       errMsg = err.message;

--- a/cli/tests/unit/globals_test.ts
+++ b/cli/tests/unit/globals_test.ts
@@ -45,16 +45,24 @@ unitTest(function webAssemblyExists(): void {
   assert(typeof WebAssembly.compile === "function");
 });
 
+/* eslint-disable @typescript-eslint/no-namespace, @typescript-eslint/no-explicit-any,no-var */
+declare global {
+  namespace Deno {
+    var core: any;
+  }
+}
+/* eslint-enable */
+
 unitTest(function DenoNamespaceImmutable(): void {
   const denoCopy = window.Deno;
   try {
-    // @ts-expect-error
-    Deno = 1;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Deno as any) = 1;
   } catch {}
   assert(denoCopy === Deno);
   try {
-    // @ts-expect-error
-    window.Deno = 1;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).Deno = 1;
   } catch {}
   assert(denoCopy === Deno);
   try {
@@ -64,8 +72,8 @@ unitTest(function DenoNamespaceImmutable(): void {
 
   const { readFile } = Deno;
   try {
-    // @ts-expect-error
-    Deno.readFile = 1;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Deno as any).readFile = 1;
   } catch {}
   assert(readFile === Deno.readFile);
   try {
@@ -73,19 +81,14 @@ unitTest(function DenoNamespaceImmutable(): void {
   } catch {}
   assert(readFile === Deno.readFile);
 
-  // @ts-expect-error
   const { print } = Deno.core;
   try {
-    // @ts-expect-error
     Deno.core.print = 1;
   } catch {}
-  // @ts-expect-error
   assert(print === Deno.core.print);
   try {
-    // @ts-expect-error
     delete Deno.core.print;
   } catch {}
-  // @ts-expect-error
   assert(print === Deno.core.print);
 });
 

--- a/cli/tests/unit/headers_test.ts
+++ b/cli/tests/unit/headers_test.ts
@@ -22,8 +22,8 @@ unitTest(function newHeaderTest(): void {
   new Headers(undefined);
   new Headers({});
   try {
-    // @ts-expect-error
-    new Headers(null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    new Headers(null as any);
   } catch (e) {
     assertEquals(
       e.message,
@@ -36,8 +36,8 @@ const headerDict: Record<string, string> = {
   name1: "value1",
   name2: "value2",
   name3: "value3",
-  // @ts-expect-error
-  name4: undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  name4: undefined as any,
   "Content-Type": "value4",
 };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -264,17 +264,17 @@ unitTest(function headerParamsShouldThrowTypeError(): void {
 });
 
 unitTest(function headerParamsArgumentsCheck(): void {
-  const methodRequireOneParam = ["delete", "get", "has", "forEach"];
+  const methodRequireOneParam = ["delete", "get", "has", "forEach"] as const;
 
-  const methodRequireTwoParams = ["append", "set"];
+  const methodRequireTwoParams = ["append", "set"] as const;
 
   methodRequireOneParam.forEach((method): void => {
     const headers = new Headers();
     let hasThrown = 0;
     let errMsg = "";
     try {
-      // @ts-expect-error
-      headers[method]();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (headers as any)[method]();
       hasThrown = 1;
     } catch (err) {
       errMsg = err.message;
@@ -297,8 +297,8 @@ unitTest(function headerParamsArgumentsCheck(): void {
     let errMsg = "";
 
     try {
-      // @ts-expect-error
-      headers[method]();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (headers as any)[method]();
       hasThrown = 1;
     } catch (err) {
       errMsg = err.message;
@@ -317,8 +317,8 @@ unitTest(function headerParamsArgumentsCheck(): void {
     hasThrown = 0;
     errMsg = "";
     try {
-      // @ts-expect-error
-      headers[method]("foo");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (headers as any)[method]("foo");
       hasThrown = 1;
     } catch (err) {
       errMsg = err.message;

--- a/cli/tests/unit/request_test.ts
+++ b/cli/tests/unit/request_test.ts
@@ -10,22 +10,22 @@ unitTest(function fromInit(): void {
     },
   });
 
-  // @ts-expect-error
-  assertEquals("ahoyhoy", req._bodySource);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assertEquals("ahoyhoy", (req as any)._bodySource);
   assertEquals(req.url, "https://example.com");
   assertEquals(req.headers.get("test-header"), "value");
 });
 
 unitTest(function fromRequest(): void {
   const r = new Request("https://example.com");
-  // @ts-expect-error
-  r._bodySource = "ahoyhoy";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (r as any)._bodySource = "ahoyhoy";
   r.headers.set("test-header", "value");
 
   const req = new Request(r);
 
-  // @ts-expect-error
-  assertEquals(req._bodySource, r._bodySource);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assertEquals((req as any)._bodySource, (r as any)._bodySource);
   assertEquals(req.url, r.url);
   assertEquals(req.headers.get("test-header"), r.headers.get("test-header"));
 });
@@ -44,6 +44,6 @@ unitTest(async function cloneRequestBodyStream(): Promise<void> {
 
   assertEquals(b1, b2);
 
-  // @ts-expect-error
-  assert(r1._bodySource !== r2._bodySource);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assert((r1 as any)._bodySource !== (r2 as any)._bodySource);
 });

--- a/cli/tests/unit/streams_internal_test.ts
+++ b/cli/tests/unit/streams_internal_test.ts
@@ -2,15 +2,12 @@
 import { unitTest, assertThrows } from "./test_util.ts";
 
 unitTest(function streamReadableHwmError() {
-  const invalidHwm = [NaN, Number("NaN"), {}, -1, "two"];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const invalidHwm: any[] = [NaN, Number("NaN"), {}, -1, "two"];
   for (const highWaterMark of invalidHwm) {
     assertThrows(
       () => {
-        new ReadableStream<number>(
-          undefined,
-          // @ts-expect-error
-          { highWaterMark }
-        );
+        new ReadableStream<number>(undefined, { highWaterMark });
       },
       RangeError,
       "highWaterMark must be a positive number or Infinity.  Received:"
@@ -20,20 +17,20 @@ unitTest(function streamReadableHwmError() {
   assertThrows(() => {
     new ReadableStream<number>(
       undefined,
-      // @ts-expect-error
-      { highWaterMark: Symbol("hwk") }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { highWaterMark: Symbol("hwk") as any }
     );
   }, TypeError);
 });
 
 unitTest(function streamWriteableHwmError() {
-  const invalidHwm = [NaN, Number("NaN"), {}, -1, "two"];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const invalidHwm: any[] = [NaN, Number("NaN"), {}, -1, "two"];
   for (const highWaterMark of invalidHwm) {
     assertThrows(
       () => {
         new WritableStream(
           undefined,
-          // @ts-expect-error
           new CountQueuingStrategy({ highWaterMark })
         );
       },
@@ -45,23 +42,19 @@ unitTest(function streamWriteableHwmError() {
   assertThrows(() => {
     new WritableStream(
       undefined,
-      // @ts-expect-error
-      new CountQueuingStrategy({ highWaterMark: Symbol("hwmk") })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      new CountQueuingStrategy({ highWaterMark: Symbol("hwmk") as any })
     );
   }, TypeError);
 });
 
 unitTest(function streamTransformHwmError() {
-  const invalidHwm = [NaN, Number("NaN"), {}, -1, "two"];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const invalidHwm: any[] = [NaN, Number("NaN"), {}, -1, "two"];
   for (const highWaterMark of invalidHwm) {
     assertThrows(
       () => {
-        new TransformStream(
-          undefined,
-          undefined,
-          // @ts-expect-error
-          { highWaterMark }
-        );
+        new TransformStream(undefined, undefined, { highWaterMark });
       },
       RangeError,
       "highWaterMark must be a positive number or Infinity.  Received:"
@@ -72,8 +65,8 @@ unitTest(function streamTransformHwmError() {
     new TransformStream(
       undefined,
       undefined,
-      // @ts-expect-error
-      { highWaterMark: Symbol("hwmk") }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { highWaterMark: Symbol("hwmk") as any }
     );
   }, TypeError);
 });

--- a/cli/tests/unit/url_search_params_test.ts
+++ b/cli/tests/unit/url_search_params_test.ts
@@ -177,8 +177,8 @@ unitTest(function urlSearchParamsAppendArgumentsCheck(): void {
       const searchParams = new URLSearchParams();
       let hasThrown = 0;
       try {
-        // @ts-expect-error
-        searchParams[method]();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (searchParams as any)[method]();
         hasThrown = 1;
       } catch (err) {
         if (err instanceof TypeError) {
@@ -194,8 +194,8 @@ unitTest(function urlSearchParamsAppendArgumentsCheck(): void {
     const searchParams = new URLSearchParams();
     let hasThrown = 0;
     try {
-      // @ts-expect-error
-      searchParams[method]("foo");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (searchParams as any)[method]("foo");
       hasThrown = 1;
     } catch (err) {
       if (err instanceof TypeError) {
@@ -235,8 +235,10 @@ unitTest(function urlSearchParamsCustomSymbolIterator(): void {
 unitTest(
   function urlSearchParamsCustomSymbolIteratorWithNonStringParams(): void {
     const params = {};
-    // @ts-expect-error
-    params[Symbol.iterator] = function* (): IterableIterator<[number, number]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (params as any)[Symbol.iterator] = function* (): IterableIterator<
+      [number, number]
+    > {
       yield [1, 2];
     };
     const params1 = new URLSearchParams((params as unknown) as string[][]);

--- a/std/mime/multipart_test.ts
+++ b/std/mime/multipart_test.ts
@@ -145,8 +145,8 @@ test("multipartMultipartWriter3", async function (): Promise<void> {
   );
   await assertThrowsAsync(
     async (): Promise<void> => {
-      // @ts-expect-error
-      await mw.writeFile("bar", "file", null);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await mw.writeFile("bar", "file", null as any);
     },
     Error,
     "closed"

--- a/std/node/global.ts
+++ b/std/node/global.ts
@@ -5,5 +5,5 @@ Object.defineProperty(globalThis, Symbol.toStringTag, {
   configurable: true,
 });
 
-// @ts-expect-error
-globalThis["global"] = globalThis;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any)["global"] = globalThis;

--- a/std/signal/test.ts
+++ b/std/signal/test.ts
@@ -9,8 +9,8 @@ test({
   fn() {
     assertThrows(
       () => {
-        // @ts-expect-error
-        signal();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (signal as any)();
       },
       Error,
       "No signals are given. You need to specify at least one signal to create a signal stream."

--- a/std/ws/mod.ts
+++ b/std/ws/mod.ts
@@ -491,7 +491,7 @@ export async function handshake(
     throw new Error("ws: invalid status line: " + statusLine);
   }
 
-  // @ts-expect-error
+  assert(m.groups);
   const { version, statusCode } = m.groups;
   if (version !== "HTTP/1.1" || statusCode !== "101") {
     throw new Error(


### PR DESCRIPTION
Fixes #6033 

There was a significant amount of overuse of `@ts-ignore` or `@ts-expect-error` in the code base.  As found in #6033 this can cause problems.  We should really only ever ignore or expect TypeScript errors when it is a legitimate limitation of TypeScript (which is rare), not to work around the type system.  There are sufficient tools to work around the type system which are not then specific to the configuration of the compiler, like using the `any` keyword.  It is better to use the `any` hammer and adjust the linting rules, then it is to just "ignore" errors in TypeScript.

In a lot of cases that were fixed, better typing was all that was required.