### PR TITLE
Allow non-void promises in assertThrowsAsync

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -325,8 +325,8 @@ export function fail(msg?: string): void {
  * throws.  An error class and a string that should be included in the
  * error message can also be asserted.
  */
-export function assertThrows(
-  fn: () => void,
+export function assertThrows<T = void>(
+  fn: () => T,
   ErrorClass?: Constructor,
   msgIncludes = "",
   msg?: string
@@ -361,8 +361,8 @@ export function assertThrows(
   return error;
 }
 
-export async function assertThrowsAsync(
-  fn: () => Promise<void>,
+export async function assertThrowsAsync<T = void>(
+  fn: () => Promise<T>,
   ErrorClass?: Constructor,
   msgIncludes = "",
   msg?: string

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -250,27 +250,33 @@ test("testingAssertFailWithReturnTypes", function (): void {
   const shouldFail = true;
 
   assertThrows(() => {
-    if (shouldFail) throw new Error('failed')
+    if (shouldFail) throw new Error("failed");
 
     return "a string";
   });
   assertThrows(() => {
-    if (shouldFail) throw new Error('failed')
+    if (shouldFail) throw new Error("failed");
 
     return 123;
   });
   assertThrows(() => {
-    if (shouldFail) throw new Error('failed')
+    if (shouldFail) throw new Error("failed");
 
-    return {a: true};
+    return { a: true };
   });
 });
 
 test("testingAssertFailAsync", function (): void {
-  assertThrowsAsync(async () => fail(), AssertionError, "Failed assertion.");
+  assertThrowsAsync(
+    async () => {
+      await Promise.resolve(fail());
+    },
+    AssertionError,
+    "Failed assertion."
+  );
   assertThrowsAsync(
     async (): Promise<void> => {
-      fail("foo");
+      await Promise.resolve(fail("foo"));
     },
     AssertionError,
     "Failed assertion: foo"
@@ -281,19 +287,19 @@ test("testingAssertFailAsyncWithReturnTypes", function (): void {
   const shouldFail = true;
 
   assertThrowsAsync(async () => {
-    if (shouldFail) throw new Error('failed')
-
-    return "a Promise<string>";
+    if (shouldFail) throw new Error("failed");
+    const a = await Promise.resolve("a Promise<string>");
+    return a;
   });
   assertThrowsAsync(async () => {
-    if (shouldFail) throw new Error('failed')
-
-    return 123;
+    if (shouldFail) throw new Error("failed");
+    const a = await Promise.resolve(123);
+    return a;
   });
   assertThrowsAsync(async () => {
-    if (shouldFail) throw new Error('failed')
-
-    return {a: true};
+    if (shouldFail) throw new Error("failed");
+    const a = await Promise.resolve({ a: true });
+    return a;
   });
 });
 

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -268,16 +268,12 @@ test("testingAssertFailWithReturnTypes", function (): void {
 
 test("testingAssertFailAsync", function (): void {
   assertThrowsAsync(
-    async () => {
-      await Promise.resolve(fail());
-    },
+    () => Promise.resolve(fail()),
     AssertionError,
     "Failed assertion."
   );
   assertThrowsAsync(
-    async (): Promise<void> => {
-      await Promise.resolve(fail("foo"));
-    },
+    () => Promise.resolve(fail("foo")),
     AssertionError,
     "Failed assertion: foo"
   );
@@ -286,20 +282,17 @@ test("testingAssertFailAsync", function (): void {
 test("testingAssertFailAsyncWithReturnTypes", function (): void {
   const shouldFail = true;
 
-  assertThrowsAsync(async () => {
+  assertThrowsAsync(() => {
     if (shouldFail) throw new Error("failed");
-    const a = await Promise.resolve("a Promise<string>");
-    return a;
+    return Promise.resolve("a Promise<string>");
   });
-  assertThrowsAsync(async () => {
+  assertThrowsAsync(() => {
     if (shouldFail) throw new Error("failed");
-    const a = await Promise.resolve(123);
-    return a;
+    return Promise.resolve(123);
   });
-  assertThrowsAsync(async () => {
+  assertThrowsAsync(() => {
     if (shouldFail) throw new Error("failed");
-    const a = await Promise.resolve({ a: true });
-    return a;
+    return Promise.resolve({ a: true });
   });
 });
 

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -246,23 +246,11 @@ test("testingAssertFailWithWrongErrorClass", function (): void {
   );
 });
 
-test("testingAssertFailWithReturnTypes", function (): void {
+test("testingAssertFailWithReturnType", function (): void {
   const shouldFail = true;
-
   assertThrows(() => {
     if (shouldFail) throw new Error("failed");
-
     return "a string";
-  });
-  assertThrows(() => {
-    if (shouldFail) throw new Error("failed");
-
-    return 123;
-  });
-  assertThrows(() => {
-    if (shouldFail) throw new Error("failed");
-
-    return { a: true };
   });
 });
 
@@ -279,20 +267,11 @@ test("testingAssertFailAsync", function (): void {
   );
 });
 
-test("testingAssertFailAsyncWithReturnTypes", function (): void {
+test("testingAssertFailAsyncWithReturnType", function (): void {
   const shouldFail = true;
-
   assertThrowsAsync(() => {
     if (shouldFail) throw new Error("failed");
     return Promise.resolve("a Promise<string>");
-  });
-  assertThrowsAsync(() => {
-    if (shouldFail) throw new Error("failed");
-    return Promise.resolve(123);
-  });
-  assertThrowsAsync(() => {
-    if (shouldFail) throw new Error("failed");
-    return Promise.resolve({ a: true });
   });
 });
 

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -247,9 +247,8 @@ test("testingAssertFailWithWrongErrorClass", function (): void {
 });
 
 test("testingAssertFailWithReturnType", function (): void {
-  const shouldFail = true;
   assertThrows(() => {
-    if (shouldFail) throw new Error("failed");
+    throw new Error();
     return "a string";
   });
 });
@@ -268,9 +267,8 @@ test("testingAssertFailAsync", function (): void {
 });
 
 test("testingAssertFailAsyncWithReturnType", function (): void {
-  const shouldFail = true;
   assertThrowsAsync(() => {
-    if (shouldFail) throw new Error("failed");
+    throw new Error();
     return Promise.resolve("a Promise<string>");
   });
 });

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -246,27 +246,14 @@ test("testingAssertFailWithWrongErrorClass", function (): void {
   );
 });
 
-test("testingAssertFailWithReturnType", function (): void {
+test("testingAssertFailWithReturnType", () => {
   assertThrows(() => {
     throw new Error();
     return "a string";
   });
 });
 
-test("testingAssertFailAsync", function (): void {
-  assertThrowsAsync(
-    () => Promise.resolve(fail()),
-    AssertionError,
-    "Failed assertion."
-  );
-  assertThrowsAsync(
-    () => Promise.resolve(fail("foo")),
-    AssertionError,
-    "Failed assertion: foo"
-  );
-});
-
-test("testingAssertFailAsyncWithReturnType", function (): void {
+test("testingAssertFailAsyncWithReturnType", () => {
   assertThrowsAsync(() => {
     throw new Error();
     return Promise.resolve("a Promise<string>");

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -9,6 +9,7 @@ import {
   assertEquals,
   assertStrictEq,
   assertThrows,
+  assertThrowsAsync,
   AssertionError,
   equal,
   fail,
@@ -243,6 +244,57 @@ test("testingAssertFailWithWrongErrorClass", function (): void {
     AssertionError,
     `Expected error to be instance of "Error", but was "AssertionError"`
   );
+});
+
+test("testingAssertFailWithReturnTypes", function (): void {
+  const shouldFail = true;
+
+  assertThrows(() => {
+    if (shouldFail) throw new Error('failed')
+
+    return "a string";
+  });
+  assertThrows(() => {
+    if (shouldFail) throw new Error('failed')
+
+    return 123;
+  });
+  assertThrows(() => {
+    if (shouldFail) throw new Error('failed')
+
+    return {a: true};
+  });
+});
+
+test("testingAssertFailAsync", function (): void {
+  assertThrowsAsync(async () => fail(), AssertionError, "Failed assertion.");
+  assertThrowsAsync(
+    async (): Promise<void> => {
+      fail("foo");
+    },
+    AssertionError,
+    "Failed assertion: foo"
+  );
+});
+
+test("testingAssertFailAsyncWithReturnTypes", function (): void {
+  const shouldFail = true;
+
+  assertThrowsAsync(async () => {
+    if (shouldFail) throw new Error('failed')
+
+    return "a Promise<string>";
+  });
+  assertThrowsAsync(async () => {
+    if (shouldFail) throw new Error('failed')
+
+    return 123;
+  });
+  assertThrowsAsync(async () => {
+    if (shouldFail) throw new Error('failed')
+
+    return {a: true};
+  });
 });
 
 const createHeader = (): string[] => [

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -246,14 +246,14 @@ test("testingAssertFailWithWrongErrorClass", function (): void {
   );
 });
 
-test("testingAssertFailWithReturnType", () => {
+test("testingAssertThrowsWithReturnType", () => {
   assertThrows(() => {
     throw new Error();
     return "a string";
   });
 });
 
-test("testingAssertFailAsyncWithReturnType", () => {
+test("testingAssertThrowsAsyncWithReturnType", () => {
   assertThrowsAsync(() => {
     throw new Error();
     return Promise.resolve("a Promise<string>");


### PR DESCRIPTION
Fixes #6051

Allows return-type of the Promise to be inferred, or declared.

### Before
![image](https://user-images.githubusercontent.com/21317379/83547779-a11c7f00-a4fa-11ea-8bb1-0600642c5be1.png)

### After
![image](https://user-images.githubusercontent.com/21317379/83555448-35401380-a506-11ea-855a-6d788cd757f5.png)