### PR TITLE
fetch: support for 101 status code

### DIFF
--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -12,7 +12,7 @@ import { DomFileImpl } from "./dom_file.ts";
 import { getHeaderValueParams } from "./util.ts";
 import { ReadableStreamImpl } from "./streams/readable_stream.ts";
 
-const NULL_BODY_STATUS = [/* 101, */ 204, 205, 304];
+const NULL_BODY_STATUS = [101, 204, 205, 304];
 const REDIRECT_STATUS = [301, 302, 303, 307, 308];
 
 const responseData = new WeakMap();
@@ -115,7 +115,7 @@ export class Response extends Body.Body implements domTypes.Response {
 
     this.url = url;
     this.statusText = statusText;
-    this.status = status;
+    this.status = extraInit.status || status;
     this.headers = headers;
     this.redirected = extraInit.redirected;
     this.type = type;
@@ -329,7 +329,7 @@ export async function fetch(
     }
 
     responseInit = {
-      status: fetchResponse.status,
+      status: 200,
       statusText: fetchResponse.statusText,
       headers: fetchResponse.headers,
     };
@@ -337,6 +337,7 @@ export async function fetch(
     responseData.set(responseInit, {
       redirected,
       rid: fetchResponse.bodyRid,
+      status: fetchResponse.status,
       url,
     });
 

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -767,7 +767,7 @@ unitTest(
 unitTest(
   { perms: { net: true } },
   async function fetchNullBodyStatus(): Promise<void> {
-    const nullBodyStatus = [204, 205, 304];
+    const nullBodyStatus = [101, 204, 205, 304];
 
     for (const status of nullBodyStatus) {
       const headers = new Headers([["x-status", String(status)]]);
@@ -796,6 +796,26 @@ unitTest(
         assertEquals(
           e.message,
           "Response with null body status cannot have body"
+        );
+      }
+    }
+  }
+);
+
+unitTest(
+  { perms: { net: true } },
+  function fetchResponseConstructorInvalidStatus(): void {
+    const invalidStatus = [101, 600, 199];
+
+    for (const status of invalidStatus) {
+      try {
+        new Response("deno", { status });
+        fail("Invalid status");
+      } catch (e) {
+        assert(e instanceof RangeError);
+        assertEquals(
+          e.message,
+          `The status provided (${status}) is outside the range [200, 599]`
         );
       }
     }


### PR DESCRIPTION
This PR adds support for `101` status code responses in case we want to support it (If not just close it, I don't have a strong opinion on this). 

Being honest `101` it's rarely used except for WebSockets and we use `Deno.connect` for that.

---

I find the [spec](https://fetch.spec.whatwg.org/#ref-for-dom-response) is a bit confusing regarding 1xx status codes.

Here's how it works on other browsers:

- **Firefox:** `101` responses work correctly
- **Chrome:** fetch just stays idle and never resolves
- **Opera:** fetch just stays idle and never resolves

In all browsers, the `Response` constructor fails if `status === 101`, the same happens in Deno.

---

Deno `fetch` fails for all `1xx` except `101` with: `invalid HTTP version parsed`.
