### PR TITLE
Update to dprint 0.19.1 and swc_ecma_parser 0.24.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5879ef29c4623721ded84372b7fd1a8bc2cc2a5fb225b70169a07087162c5f62"
+checksum = "841f7600a292142489a9c3137b89dfac91eb5b2cc93b3bb7e1a09d992d9dd0a7"
 dependencies = [
  "dprint-core",
  "serde",
@@ -2366,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.23.1"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5824a6d526e19b8efd550af53a74611928b76493410ad9499e94b299f6469dc1"
+checksum = "1efa1c06e10cfb5182396d707fe38cbf3bec4e38ef670277e73643dbcb5245b0"
 dependencies = [
  "either",
  "enum_kind",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,7 +29,7 @@ byteorder = "1.3.4"
 clap = "2.33.1"
 dirs = "2.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = "0.19.0"
+dprint-plugin-typescript = "0.19.1"
 futures = { version = "0.3.5", features = ["compat", "io-compat"] }
 glob = "0.3.0"
 http = "0.2.1"


### PR DESCRIPTION
* Closes #6050
* Closes #6047
* Fixed some spaces being erroneously removed in JSX: https://github.com/dprint/dprint/issues/234