### PR TITLE
fix(cli): realPath honors non-unc win32 path separator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "dirs",
  "dlopen",
  "dprint-plugin-typescript",
+ "dunce",
  "futures 0.3.5",
  "fwdansi",
  "glob",
@@ -610,6 +611,12 @@ name = "dtoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
+
+[[package]]
+name = "dunce"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ad6bf6a88548d1126045c413548df1453d9be094a8ab9fd59bf1fdd338da4f"
 
 [[package]]
 name = "either"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -61,6 +61,7 @@ warp = "0.2.3"
 semver-parser = "0.9.0"
 uuid = { version = "0.8.1", features = ["v4"] }
 swc_ecma_visit = "0.5.1"
+dunce = "1.0.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.8"

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -9,6 +9,7 @@ use crate::state::State;
 use deno_core::CoreIsolate;
 use deno_core::CoreIsolateState;
 use deno_core::ZeroCopyBuf;
+use dunce::canonicalize;
 use futures::future::FutureExt;
 use std::convert::From;
 use std::env::{current_dir, set_current_dir, temp_dir};
@@ -577,12 +578,9 @@ fn op_realpath(
     debug!("op_realpath {}", path.display());
     // corresponds to the realpath on Unix and
     // CreateFile and GetFinalPathNameByHandle on Windows
-    let realpath = std::fs::canonicalize(&path)?;
-    let mut realpath_str =
-      into_string(realpath.into_os_string())?.replace("\\", "/");
-    if cfg!(windows) {
-      realpath_str = realpath_str.trim_start_matches("//?/").to_string();
-    }
+    let realpath = canonicalize(&path)?;
+    let realpath_str = into_string(realpath.into_os_string())?;
+
     Ok(json!(realpath_str))
   })
 }

--- a/cli/tests/unit/real_path_test.ts
+++ b/cli/tests/unit/real_path_test.ts
@@ -1,14 +1,16 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { unitTest, assert } from "./test_util.ts";
+import { sep } from "../../../std/path/mod.ts";
 
 unitTest({ perms: { read: true } }, function realPathSyncSuccess(): void {
-  const incompletePath = "cli/tests/fixture.json";
+  const incompletePath = `cli${sep}tests${sep}fixture.json`;
   const realPath = Deno.realPathSync(incompletePath);
   if (Deno.build.os !== "windows") {
     assert(realPath.startsWith("/"));
   } else {
     assert(/^[A-Z]/.test(realPath));
   }
+
   assert(realPath.endsWith(incompletePath));
 });
 
@@ -54,7 +56,7 @@ unitTest({ perms: { read: true } }, function realPathSyncNotFound(): void {
 unitTest({ perms: { read: true } }, async function realPathSuccess(): Promise<
   void
 > {
-  const incompletePath = "cli/tests/fixture.json";
+  const incompletePath = `cli${sep}tests${sep}fixture.json`;
   const realPath = await Deno.realPath(incompletePath);
   if (Deno.build.os !== "windows") {
     assert(realPath.startsWith("/"));


### PR DESCRIPTION
- closes #5685

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

Description:

This PR tries to fix path separator returned by `realPah`. 

It looks like issue stemmed from https://github.com/rust-lang/rust/issues/42869. Canonicalize on windows returns UNC path, stripping unc host (https://github.com/denoland/deno/blob/master/cli/ops/fs.rs?rgh-link-date=2020-06-02T04%3A57%3A06Z#L584) will leave rest of path do not honor win32 path separator. Given std canonicalize does not provide workaround yet, stripping UNC via drop-in replacement (gitlab.com/kornelski/dunce) seems the easiest way to fix instead of re-implementing UNC stripping logics.

It may possible using another crate may not be desired or other way to workaround may exist.
