### PR TITLE
feat(doc): handle detail output for enum

### DIFF
--- a/cli/doc/printer.rs
+++ b/cli/doc/printer.rs
@@ -41,6 +41,7 @@ pub fn format_details(node: doc::DocNode) -> String {
 
   let maybe_extra = match node.kind {
     DocNodeKind::Class => Some(format_class_details(node)),
+    DocNodeKind::Enum => Some(format_enum_details(node)),
     DocNodeKind::Namespace => Some(format_namespace_details(node)),
     _ => None,
   };
@@ -407,6 +408,17 @@ fn format_class_details(node: doc::DocNode) -> String {
       ),
       1,
     ));
+  }
+  details.push_str("\n");
+  details
+}
+
+fn format_enum_details(node: doc::DocNode) -> String {
+  let mut details = String::new();
+  let enum_def = node.enum_def.unwrap();
+  for member in enum_def.members {
+    details
+      .push_str(&add_indent(format!("{}\n", colors::bold(member.name)), 1));
   }
   details.push_str("\n");
   details

--- a/cli/doc/tests.rs
+++ b/cli/doc/tests.rs
@@ -885,6 +885,10 @@ export enum Hello {
   assert_eq!(actual, expected_json);
 
   assert!(colors::strip_ansi_codes(
+    super::printer::format_details(entry.clone()).as_str()
+  )
+  .contains("World"));
+  assert!(colors::strip_ansi_codes(
     super::printer::format(entries.clone()).as_str()
   )
   .contains("Some enum for good measure"));


### PR DESCRIPTION
Towards #4516 (`better detail output for enum`).

Before:

```shell
$ cargo run -- doc ./std/ws/mod.ts OpCode
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/deno doc ./std/ws/mod.ts OpCode`
Defined in file:///home/uki00a/projects/deno/std/ws/mod.ts:16:0 

enum OpCode
```

After:

```shell
$ cargo run -- doc ./std/ws/mod.ts OpCode
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/deno doc ./std/ws/mod.ts OpCode`
Defined in file:///home/uki00a/projects/deno/std/ws/mod.ts:16:0 

enum OpCode

  Continue
  TextFrame
  BinaryFrame
  Close
  Ping
  Pong
```