### PR TITLE
Adjusting the HTTPS_PROXY flag text

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -179,7 +179,8 @@ static ENV_VARIABLES_HELP: &str = "ENVIRONMENT VARIABLES:
     NO_COLOR             Set to disable color
     HTTP_PROXY           Proxy address for HTTP requests
                          (module downloads, fetch)
-    HTTPS_PROXY          Same but for HTTPS";
+    HTTPS_PROXY          Proxy address for HTTPS requests
+                         (module downloads, fetch)";
 
 static DENO_HELP: &str = "A secure JavaScript and TypeScript runtime
 


### PR DESCRIPTION
Being lazy is not good, changing the text of the flag HTTPS_PROXY from "Same but for HTTPS" to "Proxy address for HTTPS requests (module downloads, fetch)"