### PR TITLE
feat(std/fmt): Format specifier and returns the string as a value that satisfies error

### DIFF
--- a/std/fmt/errorf.ts
+++ b/std/fmt/errorf.ts
@@ -2,14 +2,14 @@
 //
 // This implementation is inspired by Golang but does not port
 // implementation code.
-import { Printf } from './printf.ts';
+import { Printf } from "./printf.ts";
 
 // Errorf formats according to a format specifier and returns the string as a
 // value that satisfies error.
 export function errorf(format: string, ...args: unknown[]): Error {
-  let p = new Printf(format, ...args);
+  const p = new Printf(format, ...args);
   p.doPrintf();
-  let s = p.buf.toString();
-  let err = new Error(s);
+  const s = p.buf.toString();
+  const err = new Error(s);
   return err;
 }

--- a/std/fmt/errorf.ts
+++ b/std/fmt/errorf.ts
@@ -1,0 +1,15 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+//
+// This implementation is inspired by Golang but does not port
+// implementation code.
+import { Printf } from './printf.ts';
+
+// Errorf formats according to a format specifier and returns the string as a
+// value that satisfies error.
+export function errorf(format: string, ...args: unknown[]): Error {
+  let p = new Printf(format, ...args);
+  p.doPrintf();
+  let s = p.buf.toString();
+  let err = new Error(s);
+  return err;
+}

--- a/std/fmt/errorf_test.ts
+++ b/std/fmt/errorf_test.ts
@@ -1,0 +1,21 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+//
+import { errorf } from './errorf.ts';
+import { assertEquals } from "../testing/asserts.ts";
+
+Deno.test("noVerb", function (): void {
+  assertEquals(errorf("bla").message, "bla");
+});
+
+Deno.test("testString", function (): void {
+  assertEquals(errorf("%s", "bla").message, "bla");
+});
+
+
+Deno.test("testBoolean", function (): void {
+  assertEquals(errorf("%t", true).message, "true");
+  assertEquals(errorf("%t", false).message, "false");
+  assertEquals(errorf("bla%t", true).message, "blatrue");
+  assertEquals(errorf("%tbla", false).message, "falsebla");
+});
+

--- a/std/fmt/errorf_test.ts
+++ b/std/fmt/errorf_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 //
-import { errorf } from './errorf.ts';
+import { errorf } from "./errorf.ts";
 import { assertEquals } from "../testing/asserts.ts";
 
 Deno.test("noVerb", function (): void {
@@ -11,11 +11,9 @@ Deno.test("testString", function (): void {
   assertEquals(errorf("%s", "bla").message, "bla");
 });
 
-
 Deno.test("testBoolean", function (): void {
   assertEquals(errorf("%t", true).message, "true");
   assertEquals(errorf("%t", false).message, "false");
   assertEquals(errorf("bla%t", true).message, "blatrue");
   assertEquals(errorf("%tbla", false).message, "falsebla");
 });
-

--- a/std/fmt/printf.ts
+++ b/std/fmt/printf.ts
@@ -40,7 +40,7 @@ enum F {
   exponent,
 }
 
-class Printf {
+export class Printf {
   format: string;
   args: unknown[];
   i: number;
@@ -680,3 +680,4 @@ export function printf(format: string, ...args: unknown[]): void {
   const s = sprintf(format, ...args);
   Deno.stdout.writeSync(new TextEncoder().encode(s));
 }
+

--- a/std/fmt/printf.ts
+++ b/std/fmt/printf.ts
@@ -680,4 +680,3 @@ export function printf(format: string, ...args: unknown[]): void {
   const s = sprintf(format, ...args);
   Deno.stdout.writeSync(new TextEncoder().encode(s));
 }
-


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
The Errorf function lets us use formatting features to create descriptive error messages.

```ts
errorf("%s", "bla");
```
```ts
errorf("bla");
```
```ts
errorf("bla%t", true);
```