### PR TITLE
Issue 6096: Use # to demark line in failure messages

### DIFF
--- a/cli/js/error_stack.ts
+++ b/cli/js/error_stack.ts
@@ -119,7 +119,7 @@ function getFileLocation(callSite: CallSite, isInternal = false): string {
 
   const lineNumber = callSite.getLineNumber();
   if (lineNumber != null) {
-    result += `${black(":")}${yellow(lineNumber.toString())}`;
+    result += `${black("#")}${yellow(lineNumber.toString())}`;
 
     const columnNumber = callSite.getColumnNumber();
     if (columnNumber != null) {

--- a/cli/tests/020_json_modules.ts.out
+++ b/cli/tests/020_json_modules.ts.out
@@ -1,9 +1,9 @@
 [WILDCARD]
 error: Uncaught TypeError: Cannot resolve extension for "[WILDCARD]config.json" with mediaType "Json".
-    at getExtension ($deno$/compiler.ts:[WILDCARD])
-    at new SourceFile ($deno$/compiler.ts:[WILDCARD])
-    at Function.addToCache ($deno$/compiler.ts:[WILDCARD])
-    at buildSourceFileCache ($deno$/compiler.ts:[WILDCARD])
-    at compile ($deno$/compiler.ts:[WILDCARD])
-    at tsCompilerOnMessage ($deno$/compiler.ts:[WILDCARD])
+    at getExtension ($deno$/compiler.ts#[WILDCARD])
+    at new SourceFile ($deno$/compiler.ts#[WILDCARD])
+    at Function.addToCache ($deno$/compiler.ts#[WILDCARD])
+    at buildSourceFileCache ($deno$/compiler.ts#[WILDCARD])
+    at compile ($deno$/compiler.ts#[WILDCARD])
+    at tsCompilerOnMessage ($deno$/compiler.ts#[WILDCARD])
 [WILDCARD]

--- a/cli/tests/044_bad_resource.ts.out
+++ b/cli/tests/044_bad_resource.ts.out
@@ -1,4 +1,4 @@
 [WILDCARD]error: Uncaught BadResource: Bad resource ID
-    at unwrapResponse ([WILDCARD]dispatch_json.ts:[WILDCARD])
-    at Object.sendAsync ([WILDCARD]dispatch_json.ts:[WILDCARD])
-    at async main ([WILDCARD]tests/044_bad_resource.ts:[WILDCARD])
+    at unwrapResponse ([WILDCARD]dispatch_json.ts#[WILDCARD])
+    at Object.sendAsync ([WILDCARD]dispatch_json.ts#[WILDCARD])
+    at async main ([WILDCARD]tests/044_bad_resource.ts#[WILDCARD])

--- a/cli/tests/async_error.ts.out
+++ b/cli/tests/async_error.ts.out
@@ -4,5 +4,5 @@ world
 error: Uncaught Error: error
   throw Error("error");
         ^
-    at foo ([WILDCARD]tests/async_error.ts:5:9)
-    at [WILDCARD]tests/async_error.ts:8:1
+    at foo ([WILDCARD]tests/async_error.ts#5:9)
+    at [WILDCARD]tests/async_error.ts#8:1

--- a/cli/tests/error_001.ts.out
+++ b/cli/tests/error_001.ts.out
@@ -1,6 +1,6 @@
 [WILDCARD]error: Uncaught Error: bad
   throw Error("bad");
         ^
-    at foo ([WILDCARD]tests/error_001.ts:2:9)
-    at bar ([WILDCARD]tests/error_001.ts:6:3)
-    at [WILDCARD]tests/error_001.ts:9:1
+    at foo ([WILDCARD]tests/error_001.ts#2:9)
+    at bar ([WILDCARD]tests/error_001.ts#6:3)
+    at [WILDCARD]tests/error_001.ts#9:1

--- a/cli/tests/error_002.ts.out
+++ b/cli/tests/error_002.ts.out
@@ -1,6 +1,6 @@
 [WILDCARD]error: Uncaught Error: exception from mod1
   throw Error("exception from mod1");
         ^
-    at throwsError ([WILDCARD]tests/subdir/mod1.ts:16:9)
-    at foo ([WILDCARD]tests/error_002.ts:4:3)
-    at [WILDCARD]tests/error_002.ts:7:1
+    at throwsError ([WILDCARD]tests/subdir/mod1.ts#16:9)
+    at foo ([WILDCARD]tests/error_002.ts#4:3)
+    at [WILDCARD]tests/error_002.ts#7:1

--- a/cli/tests/error_008_checkjs.js.out
+++ b/cli/tests/error_008_checkjs.js.out
@@ -1,4 +1,4 @@
 [WILDCARD]error: Uncaught ReferenceError: consol is not defined
 consol.log("hello world!");
 ^
-    at [WILDCARD]tests/error_008_checkjs.js:2:1
+    at [WILDCARD]tests/error_008_checkjs.js#2:1

--- a/cli/tests/error_014_catch_dynamic_import_error.js.out
+++ b/cli/tests/error_014_catch_dynamic_import_error.js.out
@@ -6,7 +6,7 @@ TypeError: relative import path "does not exist either" not prefixed with / or .
 
 Caught error thrown by dynamically imported module.
 Error: An error
-    at file:///[WILDCARD]tests/subdir/throws.js:5:7
+    at file:///[WILDCARD]tests/subdir/throws.js#5:7
 Caught error thrown indirectly by dynamically imported module.
 Error: An error
-    at file:///[WILDCARD]tests/subdir/throws.js:5:7
+    at file:///[WILDCARD]tests/subdir/throws.js#5:7

--- a/cli/tests/error_018_hide_long_source_js.js.out
+++ b/cli/tests/error_018_hide_long_source_js.js.out
@@ -1,2 +1,2 @@
 error: Uncaught TypeError: Cannot read property 'a' of undefined
-    at file:///[WILDCARD]cli/tests/error_018_hide_long_source_js.js:2:206
+    at file:///[WILDCARD]cli/tests/error_018_hide_long_source_js.js#2:206

--- a/cli/tests/error_019_stack_function.ts.out
+++ b/cli/tests/error_019_stack_function.ts.out
@@ -1,6 +1,6 @@
 [WILDCARD]Error: function
-    at foo ([WILDCARD]tests/error_019_stack_function.ts:[WILDCARD])
-    at [WILDCARD]tests/error_019_stack_function.ts:[WILDCARD]
+    at foo ([WILDCARD]tests/error_019_stack_function.ts#[WILDCARD])
+    at [WILDCARD]tests/error_019_stack_function.ts#[WILDCARD]
 error: Uncaught Error: function
-    at foo ([WILDCARD]tests/error_019_stack_function.ts:[WILDCARD])
-    at [WILDCARD]tests/error_019_stack_function.ts:[WILDCARD]
+    at foo ([WILDCARD]tests/error_019_stack_function.ts#[WILDCARD])
+    at [WILDCARD]tests/error_019_stack_function.ts#[WILDCARD]

--- a/cli/tests/error_020_stack_constructor.ts.out
+++ b/cli/tests/error_020_stack_constructor.ts.out
@@ -1,6 +1,6 @@
 [WILDCARD]Error: constructor
-    at new A ([WILDCARD]tests/error_020_stack_constructor.ts:[WILDCARD])
-    at [WILDCARD]tests/error_020_stack_constructor.ts:[WILDCARD]
+    at new A ([WILDCARD]tests/error_020_stack_constructor.ts#[WILDCARD])
+    at [WILDCARD]tests/error_020_stack_constructor.ts#[WILDCARD]
 error: Uncaught Error: constructor
-    at new A ([WILDCARD]tests/error_020_stack_constructor.ts:[WILDCARD])
-    at [WILDCARD]tests/error_020_stack_constructor.ts:[WILDCARD]
+    at new A ([WILDCARD]tests/error_020_stack_constructor.ts#[WILDCARD])
+    at [WILDCARD]tests/error_020_stack_constructor.ts#[WILDCARD]

--- a/cli/tests/error_021_stack_method.ts.out
+++ b/cli/tests/error_021_stack_method.ts.out
@@ -1,6 +1,6 @@
 [WILDCARD]Error: method
-    at A.m ([WILDCARD]tests/error_021_stack_method.ts:[WILDCARD])
-    at [WILDCARD]tests/error_021_stack_method.ts:[WILDCARD]
+    at A.m ([WILDCARD]tests/error_021_stack_method.ts#[WILDCARD])
+    at [WILDCARD]tests/error_021_stack_method.ts#[WILDCARD]
 error: Uncaught Error: method
-    at A.m ([WILDCARD]tests/error_021_stack_method.ts:[WILDCARD])
-    at [WILDCARD]tests/error_021_stack_method.ts:[WILDCARD]
+    at A.m ([WILDCARD]tests/error_021_stack_method.ts#[WILDCARD])
+    at [WILDCARD]tests/error_021_stack_method.ts#[WILDCARD]

--- a/cli/tests/error_022_stack_custom_error.ts.out
+++ b/cli/tests/error_022_stack_custom_error.ts.out
@@ -1,4 +1,4 @@
 [WILDCARD]CustomError: custom error
-    at [WILDCARD]tests/error_022_stack_custom_error.ts:[WILDCARD]
+    at [WILDCARD]tests/error_022_stack_custom_error.ts#[WILDCARD]
 error: Uncaught CustomError: custom error
-    at [WILDCARD]tests/error_022_stack_custom_error.ts:[WILDCARD]
+    at [WILDCARD]tests/error_022_stack_custom_error.ts#[WILDCARD]

--- a/cli/tests/error_023_stack_async.ts.out
+++ b/cli/tests/error_023_stack_async.ts.out
@@ -1,8 +1,8 @@
 [WILDCARD]Error: async
-    at [WILDCARD]tests/error_023_stack_async.ts:[WILDCARD]
-    at async [WILDCARD]tests/error_023_stack_async.ts:[WILDCARD]
-    at async [WILDCARD]tests/error_023_stack_async.ts:[WILDCARD]
+    at [WILDCARD]tests/error_023_stack_async.ts#[WILDCARD]
+    at async [WILDCARD]tests/error_023_stack_async.ts#[WILDCARD]
+    at async [WILDCARD]tests/error_023_stack_async.ts#[WILDCARD]
 error: Uncaught Error: async
-    at [WILDCARD]tests/error_023_stack_async.ts:[WILDCARD]
-    at async [WILDCARD]tests/error_023_stack_async.ts:[WILDCARD]
-    at async [WILDCARD]tests/error_023_stack_async.ts:[WILDCARD]
+    at [WILDCARD]tests/error_023_stack_async.ts#[WILDCARD]
+    at async [WILDCARD]tests/error_023_stack_async.ts#[WILDCARD]
+    at async [WILDCARD]tests/error_023_stack_async.ts#[WILDCARD]

--- a/cli/tests/error_024_stack_promise_all.ts.out
+++ b/cli/tests/error_024_stack_promise_all.ts.out
@@ -1,8 +1,8 @@
 [WILDCARD]Error: Promise.all()
-    at [WILDCARD]tests/error_024_stack_promise_all.ts:[WILDCARD]
+    at [WILDCARD]tests/error_024_stack_promise_all.ts#[WILDCARD]
     at async Promise.all (index 0)
-    at async [WILDCARD]tests/error_024_stack_promise_all.ts:[WILDCARD]
+    at async [WILDCARD]tests/error_024_stack_promise_all.ts#[WILDCARD]
 error: Uncaught Error: Promise.all()
-    at [WILDCARD]tests/error_024_stack_promise_all.ts:[WILDCARD]
+    at [WILDCARD]tests/error_024_stack_promise_all.ts#[WILDCARD]
     at async Promise.all (index 0)
-    at async [WILDCARD]tests/error_024_stack_promise_all.ts:[WILDCARD]
+    at async [WILDCARD]tests/error_024_stack_promise_all.ts#[WILDCARD]

--- a/cli/tests/error_025_tab_indent.out
+++ b/cli/tests/error_025_tab_indent.out
@@ -1,6 +1,6 @@
 [WILDCARD]error: Uncaught Error: bad
 	throw Error("bad");
 	      ^
-    at foo ([WILDCARD]tests/error_025_tab_indent:2:8)
-    at bar ([WILDCARD]tests/error_025_tab_indent:6:2)
-    at [WILDCARD]tests/error_025_tab_indent:9:1
+    at foo ([WILDCARD]tests/error_025_tab_indent#2:8)
+    at bar ([WILDCARD]tests/error_025_tab_indent#6:2)
+    at [WILDCARD]tests/error_025_tab_indent#9:1

--- a/cli/tests/unit/dispatch_json_test.ts
+++ b/cli/tests/unit/dispatch_json_test.ts
@@ -2,9 +2,9 @@ import { assert, unitTest, assertMatch, unreachable } from "./test_util.ts";
 
 const openErrorStackPattern = new RegExp(
   `^.*
-    at unwrapResponse \\(.*dispatch_json\\.ts:.*\\)
-    at Object.sendAsync \\(.*dispatch_json\\.ts:.*\\)
-    at async Object\\.open \\(.*files\\.ts:.*\\).*$`,
+    at unwrapResponse \\(.*dispatch_json\\.ts#.*\\)
+    at Object.sendAsync \\(.*dispatch_json\\.ts#.*\\)
+    at async Object\\.open \\(.*files\\.ts#.*\\).*$`,
   "ms"
 );
 

--- a/cli/tests/unit/dispatch_minimal_test.ts
+++ b/cli/tests/unit/dispatch_minimal_test.ts
@@ -8,9 +8,9 @@ import {
 
 const readErrorStackPattern = new RegExp(
   `^.*
-    at unwrapResponse \\(.*dispatch_minimal\\.ts:.*\\)
-    at Object.sendAsyncMinimal \\(.*dispatch_minimal\\.ts:.*\\)
-    at async Object\\.read \\(.*io\\.ts:.*\\).*$`,
+    at unwrapResponse \\(.*dispatch_minimal\\.ts#.*\\)
+    at Object.sendAsyncMinimal \\(.*dispatch_minimal\\.ts#.*\\)
+    at async Object\\.read \\(.*io\\.ts#.*\\).*$`,
   "ms"
 );
 

--- a/cli/tests/unit/error_stack_test.ts
+++ b/cli/tests/unit/error_stack_test.ts
@@ -93,7 +93,7 @@ unitTest(function prepareStackTrace(): void {
     getMockCallSite("CLI_SNAPSHOT.js", 23, 0),
   ]);
   assert(result.startsWith("Error: foo\n"));
-  assert(result.includes(".ts:"), "should remap to something in 'js/'");
+  assert(result.includes(".ts#"), "should remap to something in 'js/'");
 });
 
 unitTest(function captureStackTrace(): void {


### PR DESCRIPTION
Resolves #6096

Line reference moved from `:` to `#` in error messages. 

Before: `https://deno.land/std/testing/asserts.ts:138:11`
After: `https://deno.land/std/testing/asserts.ts#138:11`