### PR TITLE
Rename abbreviated assertions in std/testing

### DIFF
--- a/cli/tests/unit/buffer_test.ts
+++ b/cli/tests/unit/buffer_test.ts
@@ -6,7 +6,7 @@
 import {
   assertEquals,
   assert,
-  assertStrContains,
+  assertStringContains,
   unitTest,
 } from "./test_util.ts";
 
@@ -164,7 +164,7 @@ unitTest(async function bufferTooLargeByteWrites(): Promise<void> {
   }
 
   assert(err instanceof Error);
-  assertStrContains(err.message, "grown beyond the maximum size");
+  assertStringContains(err.message, "grown beyond the maximum size");
 });
 
 unitTest(async function bufferLargeByteReads(): Promise<void> {

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -3,7 +3,7 @@ import {
   unitTest,
   assert,
   assertEquals,
-  assertStrContains,
+  assertStringContains,
   assertThrows,
   fail,
 } from "./test_util.ts";
@@ -18,7 +18,7 @@ unitTest({ perms: { net: true } }, async function fetchProtocolError(): Promise<
     err = err_;
   }
   assert(err instanceof TypeError);
-  assertStrContains(err.message, "not supported");
+  assertStringContains(err.message, "not supported");
 });
 
 unitTest(
@@ -31,7 +31,7 @@ unitTest(
       err = err_;
     }
     assert(err instanceof Deno.errors.Http);
-    assertStrContains(err.message, "error trying to connect");
+    assertStringContains(err.message, "error trying to connect");
   }
 );
 

--- a/cli/tests/unit/files_test.ts
+++ b/cli/tests/unit/files_test.ts
@@ -3,7 +3,7 @@ import {
   unitTest,
   assert,
   assertEquals,
-  assertStrContains,
+  assertStringContains,
 } from "./test_util.ts";
 
 unitTest(function filesStdioFileDescriptors(): void {
@@ -225,7 +225,7 @@ unitTest(async function openOptions(): Promise<void> {
     err = e;
   }
   assert(!!err);
-  assertStrContains(
+  assertStringContains(
     err.message,
     "OpenOptions requires at least one option to be true"
   );
@@ -236,7 +236,10 @@ unitTest(async function openOptions(): Promise<void> {
     err = e;
   }
   assert(!!err);
-  assertStrContains(err.message, "'truncate' option requires 'write' option");
+  assertStringContains(
+    err.message,
+    "'truncate' option requires 'write' option"
+  );
 
   try {
     await Deno.open(filename, { create: true, write: false });
@@ -244,7 +247,7 @@ unitTest(async function openOptions(): Promise<void> {
     err = e;
   }
   assert(!!err);
-  assertStrContains(
+  assertStringContains(
     err.message,
     "'create' or 'createNew' options require 'write' or 'append' option"
   );
@@ -255,7 +258,7 @@ unitTest(async function openOptions(): Promise<void> {
     err = e;
   }
   assert(!!err);
-  assertStrContains(
+  assertStringContains(
     err.message,
     "'create' or 'createNew' options require 'write' or 'append' option"
   );
@@ -560,7 +563,7 @@ unitTest({ perms: { read: true } }, async function seekMode(): Promise<void> {
   }
   assert(!!err);
   assert(err instanceof TypeError);
-  assertStrContains(err.message, "Invalid seek mode");
+  assertStringContains(err.message, "Invalid seek mode");
 
   // We should still be able to read the file
   // since it is still open.

--- a/cli/tests/unit/form_data_test.ts
+++ b/cli/tests/unit/form_data_test.ts
@@ -3,7 +3,7 @@ import {
   unitTest,
   assert,
   assertEquals,
-  assertStrContains,
+  assertStringContains,
 } from "./test_util.ts";
 
 unitTest(function formDataHasCorrectNameProp(): void {
@@ -155,7 +155,7 @@ unitTest(function formDataParamsArgumentsCheck(): void {
       }
     }
     assertEquals(hasThrown, 2);
-    assertStrContains(
+    assertStringContains(
       errMsg,
       `${method} requires at least 1 argument, but only 0 present`
     );
@@ -179,7 +179,7 @@ unitTest(function formDataParamsArgumentsCheck(): void {
       }
     }
     assertEquals(hasThrown, 2);
-    assertStrContains(
+    assertStringContains(
       errMsg,
       `${method} requires at least 2 arguments, but only 0 present`
     );
@@ -199,7 +199,7 @@ unitTest(function formDataParamsArgumentsCheck(): void {
       }
     }
     assertEquals(hasThrown, 2);
-    assertStrContains(
+    assertStringContains(
       errMsg,
       `${method} requires at least 2 arguments, but only 1 present`
     );

--- a/cli/tests/unit/get_random_values_test.ts
+++ b/cli/tests/unit/get_random_values_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assertNotEquals, assertStrictEq } from "./test_util.ts";
+import { unitTest, assertNotEquals, assertStrictEquals } from "./test_util.ts";
 
 unitTest(function getRandomValuesInt8Array(): void {
   const arr = new Int8Array(32);
@@ -47,5 +47,5 @@ unitTest(function getRandomValuesReturnValue(): void {
   const arr = new Uint32Array(8);
   const rtn = crypto.getRandomValues(arr);
   assertNotEquals(arr, new Uint32Array(8));
-  assertStrictEq(rtn, arr);
+  assertStrictEquals(rtn, arr);
 });

--- a/cli/tests/unit/headers_test.ts
+++ b/cli/tests/unit/headers_test.ts
@@ -3,7 +3,7 @@ import {
   unitTest,
   assert,
   assertEquals,
-  assertStrContains,
+  assertStringContains,
 } from "./test_util.ts";
 const {
   stringifyArgs,
@@ -285,7 +285,7 @@ unitTest(function headerParamsArgumentsCheck(): void {
       }
     }
     assertEquals(hasThrown, 2);
-    assertStrContains(
+    assertStringContains(
       errMsg,
       `${method} requires at least 1 argument, but only 0 present`
     );
@@ -309,7 +309,7 @@ unitTest(function headerParamsArgumentsCheck(): void {
       }
     }
     assertEquals(hasThrown, 2);
-    assertStrContains(
+    assertStringContains(
       errMsg,
       `${method} requires at least 2 arguments, but only 0 present`
     );
@@ -329,7 +329,7 @@ unitTest(function headerParamsArgumentsCheck(): void {
       }
     }
     assertEquals(hasThrown, 2);
-    assertStrContains(
+    assertStringContains(
       errMsg,
       `${method} requires at least 2 arguments, but only 1 present`
     );

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -2,7 +2,7 @@
 import {
   assert,
   assertEquals,
-  assertStrContains,
+  assertStringContains,
   unitTest,
 } from "./test_util.ts";
 const {
@@ -260,8 +260,8 @@ unitTest(
     const decoder = new TextDecoder();
     const text = decoder.decode(fileContents);
 
-    assertStrContains(text, "error");
-    assertStrContains(text, "output");
+    assertStringContains(text, "error");
+    assertStringContains(text, "output");
   }
 );
 

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -8,7 +8,7 @@ export {
   assertMatch,
   assertNotEquals,
   assertStrictEquals,
-  assertStrContains,
+  assertStringContains,
   unreachable,
   fail,
 } from "../../../std/testing/asserts.ts";

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -7,7 +7,7 @@ export {
   assertEquals,
   assertMatch,
   assertNotEquals,
-  assertStrictEq,
+  assertStrictEquals,
   assertStrContains,
   unreachable,
   fail,

--- a/std/examples/tests/cat_test.ts
+++ b/std/examples/tests/cat_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertStrictEq } from "../../testing/asserts.ts";
+import { assertStrictEquals } from "../../testing/asserts.ts";
 
 Deno.test("[examples/cat] print multiple files", async () => {
   const decoder = new TextDecoder();
@@ -19,7 +19,7 @@ Deno.test("[examples/cat] print multiple files", async () => {
   try {
     const output = await process.output();
     const actual = decoder.decode(output).trim();
-    assertStrictEq(actual, "Hello\nWorld");
+    assertStrictEquals(actual, "Hello\nWorld");
   } finally {
     process.close();
   }

--- a/std/examples/tests/catj_test.ts
+++ b/std/examples/tests/catj_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertStrictEq } from "../../testing/asserts.ts";
+import { assertStrictEquals } from "../../testing/asserts.ts";
 
 Deno.test("[examples/catj] print an array", async () => {
   const decoder = new TextDecoder();
@@ -15,7 +15,7 @@ Deno.test("[examples/catj] print an array", async () => {
       '.[2].array[1] = "bar"',
     ].join("\n");
 
-    assertStrictEq(actual, expected);
+    assertStrictEquals(actual, expected);
   } finally {
     process.stdin!.close();
     process.close();
@@ -34,7 +34,7 @@ Deno.test("[examples/catj] print an object", async () => {
       '.array[0].message = "hello"',
     ].join("\n");
 
-    assertStrictEq(actual, expected);
+    assertStrictEquals(actual, expected);
   } finally {
     process.stdin!.close();
     process.close();
@@ -52,7 +52,7 @@ Deno.test("[examples/catj] print multiple files", async () => {
     const actual = decoder.decode(output).trim();
     const expected = ['.message = "hello"', ".[0] = 1", ".[1] = 2"].join("\n");
 
-    assertStrictEq(actual, expected);
+    assertStrictEquals(actual, expected);
   } finally {
     process.stdin!.close();
     process.close();
@@ -69,7 +69,7 @@ Deno.test("[examples/catj] read from stdin", async () => {
     const output = await process.output();
     const actual = decoder.decode(output).trim();
 
-    assertStrictEq(actual, '.foo = "bar"');
+    assertStrictEquals(actual, '.foo = "bar"');
   } finally {
     process.close();
   }

--- a/std/examples/tests/colors_test.ts
+++ b/std/examples/tests/colors_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertStrictEq } from "../../testing/asserts.ts";
+import { assertStrictEquals } from "../../testing/asserts.ts";
 
 Deno.test("[examples/colors] print a colored text", async () => {
   const decoder = new TextDecoder();
@@ -12,7 +12,7 @@ Deno.test("[examples/colors] print a colored text", async () => {
     const output = await process.output();
     const actual = decoder.decode(output).trim();
     const expected = "[44m[3m[31m[1mHello world![22m[39m[23m[49m";
-    assertStrictEq(actual, expected);
+    assertStrictEquals(actual, expected);
   } finally {
     process.close();
   }

--- a/std/examples/tests/curl_test.ts
+++ b/std/examples/tests/curl_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { serve } from "../../http/server.ts";
-import { assertStrictEq } from "../../testing/asserts.ts";
+import { assertStrictEquals } from "../../testing/asserts.ts";
 
 Deno.test({
   name: "[examples/curl] send a request to a specified url",
@@ -30,7 +30,7 @@ Deno.test({
       const actual = decoder.decode(output).trim();
       const expected = "Hello world";
 
-      assertStrictEq(actual, expected);
+      assertStrictEquals(actual, expected);
     } finally {
       server.close();
       process.close();

--- a/std/examples/tests/echo_server_test.ts
+++ b/std/examples/tests/echo_server_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertStrictEq, assertNotEquals } from "../../testing/asserts.ts";
+import { assertStrictEquals, assertNotEquals } from "../../testing/asserts.ts";
 import { BufReader, ReadLineResult } from "../../io/bufio.ts";
 
 Deno.test("[examples/echo_server]", async () => {
@@ -17,7 +17,7 @@ Deno.test("[examples/echo_server]", async () => {
     const message = await processReader.readLine();
 
     assertNotEquals(message, null);
-    assertStrictEq(
+    assertStrictEquals(
       decoder.decode((message as ReadLineResult).line).trim(),
       "Listening on 0.0.0.0:8080"
     );
@@ -35,7 +35,7 @@ Deno.test("[examples/echo_server]", async () => {
       .trim();
     const expectedResponse = "Hello echo_server";
 
-    assertStrictEq(actualResponse, expectedResponse);
+    assertStrictEquals(actualResponse, expectedResponse);
   } finally {
     conn?.close();
     process.stdout!.close();

--- a/std/examples/tests/welcome_test.ts
+++ b/std/examples/tests/welcome_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertStrictEq } from "../../testing/asserts.ts";
+import { assertStrictEquals } from "../../testing/asserts.ts";
 
 Deno.test("[examples/welcome] print a welcome message", async () => {
   const decoder = new TextDecoder();
@@ -12,7 +12,7 @@ Deno.test("[examples/welcome] print a welcome message", async () => {
     const output = await process.output();
     const actual = decoder.decode(output).trim();
     const expected = "Welcome to Deno 🦕";
-    assertStrictEq(actual, expected);
+    assertStrictEquals(actual, expected);
   } finally {
     process.close();
   }

--- a/std/examples/tests/xeval_test.ts
+++ b/std/examples/tests/xeval_test.ts
@@ -4,7 +4,7 @@ import { stringsReader } from "../../io/util.ts";
 import { decode, encode } from "../../encoding/utf8.ts";
 import {
   assertEquals,
-  assertStrContains,
+  assertStringContains,
   assert,
 } from "../../testing/asserts.ts";
 const { execPath, run } = Deno;
@@ -52,6 +52,6 @@ Deno.test("xevalCliSyntaxError", async function (): Promise<void> {
   });
   assertEquals(await p.status(), { code: 1, success: false });
   assertEquals(decode(await p.output()), "");
-  assertStrContains(decode(await p.stderrOutput()), "Uncaught SyntaxError");
+  assertStringContains(decode(await p.stderrOutput()), "Uncaught SyntaxError");
   p.close();
 });

--- a/std/fs/empty_dir_test.ts
+++ b/std/fs/empty_dir_test.ts
@@ -2,7 +2,7 @@
 import {
   assert,
   assertEquals,
-  assertStrContains,
+  assertStringContains,
   assertThrows,
   assertThrowsAsync,
 } from "../testing/asserts.ts";
@@ -228,7 +228,7 @@ for (const s of scenes) {
         assert(p.stdout);
         const output = await p.output();
         p.close();
-        assertStrContains(new TextDecoder().decode(output), s.output);
+        assertStringContains(new TextDecoder().decode(output), s.output);
       } catch (err) {
         await Deno.remove(testfolder, { recursive: true });
         throw err;

--- a/std/fs/exists_test.ts
+++ b/std/fs/exists_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertStrContains } from "../testing/asserts.ts";
+import { assertEquals, assertStringContains } from "../testing/asserts.ts";
 import * as path from "../path/mod.ts";
 import { exists, existsSync } from "./exists.ts";
 
@@ -130,7 +130,7 @@ for (const s of scenes) {
 
     const output = await p.output();
     p.close();
-    assertStrContains(new TextDecoder().decode(output), s.output);
+    assertStringContains(new TextDecoder().decode(output), s.output);
   });
   // done
 }

--- a/std/fs/expand_glob_test.ts
+++ b/std/fs/expand_glob_test.ts
@@ -1,6 +1,10 @@
 const { cwd, execPath, run } = Deno;
 import { decode } from "../encoding/utf8.ts";
-import { assert, assertEquals, assertStrContains } from "../testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertStringContains,
+} from "../testing/asserts.ts";
 import {
   join,
   joinGlobs,
@@ -122,7 +126,7 @@ Deno.test("expandGlobPermError", async function (): Promise<void> {
   });
   assertEquals(await p.status(), { code: 1, success: false });
   assertEquals(decode(await p.output()), "");
-  assertStrContains(
+  assertStringContains(
     decode(await p.stderrOutput()),
     "Uncaught PermissionDenied"
   );

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -10,7 +10,7 @@ import {
   assert,
   assertEquals,
   assertMatch,
-  assertStrContains,
+  assertStringContains,
   assertThrowsAsync,
 } from "../testing/asserts.ts";
 import { Response, ServerRequest, Server, serve } from "./server.ts";
@@ -480,7 +480,7 @@ test({
     const nread = await conn.read(res);
     assert(nread !== null);
     const resStr = new TextDecoder().decode(res.subarray(0, nread));
-    assertStrContains(resStr, "/hello");
+    assertStringContains(resStr, "/hello");
     server.close();
     await p;
     // Client connection should still be open, verify that

--- a/std/mime/multipart.ts
+++ b/std/mime/multipart.ts
@@ -12,7 +12,7 @@ import { extname } from "../path/mod.ts";
 import { tempFile } from "../io/util.ts";
 import { BufReader, BufWriter } from "../io/bufio.ts";
 import { encoder } from "../encoding/utf8.ts";
-import { assertStrictEq, assert } from "../testing/asserts.ts";
+import { assertStrictEquals, assert } from "../testing/asserts.ts";
 import { TextProtoReader } from "../textproto/mod.ts";
 import { hasOwnProperty } from "../_util/has_own_property.ts";
 
@@ -178,7 +178,7 @@ class PartReader implements Reader, Closer {
       );
       if (this.n === 0) {
         // Force buffered I/O to read more into buffer.
-        assertStrictEq(eof, false);
+        assertStrictEquals(eof, false);
         peekLength++;
       }
     }
@@ -190,7 +190,7 @@ class PartReader implements Reader, Closer {
     const nread = min(p.length, this.n);
     const buf = p.subarray(0, nread);
     const r = await br.readFull(buf);
-    assertStrictEq(r, buf);
+    assertStrictEquals(r, buf);
     this.n -= nread;
     this.total += nread;
     return nread;

--- a/std/node/_util/_util_callbackify_test.ts
+++ b/std/node/_util/_util_callbackify_test.ts
@@ -24,7 +24,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 const { test } = Deno;
-import { assert, assertStrictEq } from "../../testing/asserts.ts";
+import { assert, assertStrictEquals } from "../../testing/asserts.ts";
 import { callbackify } from "./_util_callbackify.ts";
 
 const values = [
@@ -89,8 +89,8 @@ test("callbackify passes the resolution value as the second argument to the call
     const cbAsyncFn = callbackify(asyncFn);
     testQueue.enqueue((done) => {
       cbAsyncFn((err: unknown, ret: unknown) => {
-        assertStrictEq(err, null);
-        assertStrictEq(ret, value);
+        assertStrictEquals(err, null);
+        assertStrictEquals(ret, value);
         done();
       });
     });
@@ -101,8 +101,8 @@ test("callbackify passes the resolution value as the second argument to the call
     const cbPromiseFn = callbackify(promiseFn);
     testQueue.enqueue((done) => {
       cbPromiseFn((err: unknown, ret: unknown) => {
-        assertStrictEq(err, null);
-        assertStrictEq(ret, value);
+        assertStrictEquals(err, null);
+        assertStrictEquals(ret, value);
         done();
       });
     });
@@ -119,8 +119,8 @@ test("callbackify passes the resolution value as the second argument to the call
     const cbThenableFn = callbackify(thenableFn);
     testQueue.enqueue((done) => {
       cbThenableFn((err: unknown, ret: unknown) => {
-        assertStrictEq(err, null);
-        assertStrictEq(ret, value);
+        assertStrictEquals(err, null);
+        assertStrictEquals(ret, value);
         done();
       });
     });
@@ -138,21 +138,21 @@ test("callbackify passes the rejection value as the first argument to the callba
       return Promise.reject(value);
     }
     const cbAsyncFn = callbackify(asyncFn);
-    assertStrictEq(cbAsyncFn.length, 1);
-    assertStrictEq(cbAsyncFn.name, "asyncFnCallbackified");
+    assertStrictEquals(cbAsyncFn.length, 1);
+    assertStrictEquals(cbAsyncFn.name, "asyncFnCallbackified");
     testQueue.enqueue((done) => {
       cbAsyncFn((err: unknown, ret: unknown) => {
-        assertStrictEq(ret, undefined);
+        assertStrictEquals(ret, undefined);
         if (err instanceof Error) {
           if ("reason" in err) {
             assert(!value);
-            assertStrictEq((err as any).code, "ERR_FALSY_VALUE_REJECTION");
-            assertStrictEq((err as any).reason, value);
+            assertStrictEquals((err as any).code, "ERR_FALSY_VALUE_REJECTION");
+            assertStrictEquals((err as any).reason, value);
           } else {
-            assertStrictEq(String(value).endsWith(err.message), true);
+            assertStrictEquals(String(value).endsWith(err.message), true);
           }
         } else {
-          assertStrictEq(err, value);
+          assertStrictEquals(err, value);
         }
         done();
       });
@@ -170,20 +170,20 @@ test("callbackify passes the rejection value as the first argument to the callba
     });
 
     const cbPromiseFn = callbackify(promiseFn);
-    assertStrictEq(promiseFn.name, obj);
+    assertStrictEquals(promiseFn.name, obj);
     testQueue.enqueue((done) => {
       cbPromiseFn((err: unknown, ret: unknown) => {
-        assertStrictEq(ret, undefined);
+        assertStrictEquals(ret, undefined);
         if (err instanceof Error) {
           if ("reason" in err) {
             assert(!value);
-            assertStrictEq((err as any).code, "ERR_FALSY_VALUE_REJECTION");
-            assertStrictEq((err as any).reason, value);
+            assertStrictEquals((err as any).code, "ERR_FALSY_VALUE_REJECTION");
+            assertStrictEquals((err as any).reason, value);
           } else {
-            assertStrictEq(String(value).endsWith(err.message), true);
+            assertStrictEquals(String(value).endsWith(err.message), true);
           }
         } else {
-          assertStrictEq(err, value);
+          assertStrictEquals(err, value);
         }
         done();
       });
@@ -202,17 +202,17 @@ test("callbackify passes the rejection value as the first argument to the callba
     const cbThenableFn = callbackify(thenableFn);
     testQueue.enqueue((done) => {
       cbThenableFn((err: unknown, ret: unknown) => {
-        assertStrictEq(ret, undefined);
+        assertStrictEquals(ret, undefined);
         if (err instanceof Error) {
           if ("reason" in err) {
             assert(!value);
-            assertStrictEq((err as any).code, "ERR_FALSY_VALUE_REJECTION");
-            assertStrictEq((err as any).reason, value);
+            assertStrictEquals((err as any).code, "ERR_FALSY_VALUE_REJECTION");
+            assertStrictEquals((err as any).reason, value);
           } else {
-            assertStrictEq(String(value).endsWith(err.message), true);
+            assertStrictEquals(String(value).endsWith(err.message), true);
           }
         } else {
-          assertStrictEq(err, value);
+          assertStrictEquals(err, value);
         }
         done();
       });
@@ -228,24 +228,24 @@ test("callbackify passes arguments to the original", async () => {
   for (const value of values) {
     // eslint-disable-next-line require-await
     async function asyncFn<T>(arg: T): Promise<T> {
-      assertStrictEq(arg, value);
+      assertStrictEquals(arg, value);
       return arg;
     }
 
     const cbAsyncFn = callbackify(asyncFn);
-    assertStrictEq(cbAsyncFn.length, 2);
+    assertStrictEquals(cbAsyncFn.length, 2);
     assert(Object.getPrototypeOf(cbAsyncFn) !== Object.getPrototypeOf(asyncFn));
-    assertStrictEq(Object.getPrototypeOf(cbAsyncFn), Function.prototype);
+    assertStrictEquals(Object.getPrototypeOf(cbAsyncFn), Function.prototype);
     testQueue.enqueue((done) => {
       cbAsyncFn(value, (err: unknown, ret: unknown) => {
-        assertStrictEq(err, null);
-        assertStrictEq(ret, value);
+        assertStrictEquals(err, null);
+        assertStrictEquals(ret, value);
         done();
       });
     });
 
     function promiseFn<T>(arg: T): Promise<T> {
-      assertStrictEq(arg, value);
+      assertStrictEquals(arg, value);
       return Promise.resolve(arg);
     }
     const obj = {};
@@ -257,11 +257,11 @@ test("callbackify passes arguments to the original", async () => {
     });
 
     const cbPromiseFn = callbackify(promiseFn);
-    assertStrictEq(promiseFn.length, obj);
+    assertStrictEquals(promiseFn.length, obj);
     testQueue.enqueue((done) => {
       cbPromiseFn(value, (err: unknown, ret: unknown) => {
-        assertStrictEq(err, null);
-        assertStrictEq(ret, value);
+        assertStrictEquals(err, null);
+        assertStrictEquals(ret, value);
         done();
       });
     });
@@ -276,7 +276,7 @@ test("callbackify preserves the `this` binding", async () => {
   for (const value of values) {
     const objectWithSyncFunction = {
       fn(this: unknown, arg: typeof value): Promise<typeof value> {
-        assertStrictEq(this, objectWithSyncFunction);
+        assertStrictEquals(this, objectWithSyncFunction);
         return Promise.resolve(arg);
       },
     };
@@ -287,9 +287,9 @@ test("callbackify preserves the `this` binding", async () => {
         err: unknown,
         ret: unknown
       ) {
-        assertStrictEq(err, null);
-        assertStrictEq(ret, value);
-        assertStrictEq(this, objectWithSyncFunction);
+        assertStrictEquals(err, null);
+        assertStrictEquals(ret, value);
+        assertStrictEquals(this, objectWithSyncFunction);
         done();
       });
     });
@@ -297,7 +297,7 @@ test("callbackify preserves the `this` binding", async () => {
     const objectWithAsyncFunction = {
       // eslint-disable-next-line require-await
       async fn(this: unknown, arg: typeof value): Promise<typeof value> {
-        assertStrictEq(this, objectWithAsyncFunction);
+        assertStrictEquals(this, objectWithAsyncFunction);
         return arg;
       },
     };
@@ -308,9 +308,9 @@ test("callbackify preserves the `this` binding", async () => {
         err: unknown,
         ret: unknown
       ) {
-        assertStrictEq(err, null);
-        assertStrictEq(ret, value);
-        assertStrictEq(this, objectWithAsyncFunction);
+        assertStrictEquals(err, null);
+        assertStrictEquals(ret, value);
+        assertStrictEquals(this, objectWithAsyncFunction);
         done();
       });
     });
@@ -326,9 +326,9 @@ test("callbackify throws with non-function inputs", () => {
       throw Error("We should never reach this error");
     } catch (err) {
       assert(err instanceof TypeError);
-      assertStrictEq((err as any).code, "ERR_INVALID_ARG_TYPE");
-      assertStrictEq(err.name, "TypeError");
-      assertStrictEq(
+      assertStrictEquals((err as any).code, "ERR_INVALID_ARG_TYPE");
+      assertStrictEquals(err.name, "TypeError");
+      assertStrictEquals(
         err.message,
         'The "original" argument must be of type function.'
       );
@@ -353,9 +353,9 @@ test("callbackify returns a function that throws if the last argument is not a f
       throw Error("We should never reach this error");
     } catch (err) {
       assert(err instanceof TypeError);
-      assertStrictEq((err as any).code, "ERR_INVALID_ARG_TYPE");
-      assertStrictEq(err.name, "TypeError");
-      assertStrictEq(
+      assertStrictEquals((err as any).code, "ERR_INVALID_ARG_TYPE");
+      assertStrictEquals(err.name, "TypeError");
+      assertStrictEquals(
         err.message,
         "The last argument must be of type function."
       );

--- a/std/node/_util/_util_types_test.ts
+++ b/std/node/_util/_util_types_test.ts
@@ -21,40 +21,40 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import { assertStrictEq } from "../../testing/asserts.ts";
+import { assertStrictEquals } from "../../testing/asserts.ts";
 
 import { isDate } from "./_util_types.ts";
 
 const { test } = Deno;
 
 test("New date instance with no arguments", () => {
-  assertStrictEq(isDate(new Date()), true);
+  assertStrictEquals(isDate(new Date()), true);
 });
 
 test("New date instance with value 0", () => {
-  assertStrictEq(isDate(new Date(0)), true);
+  assertStrictEquals(isDate(new Date(0)), true);
 });
 
 test("New date instance in new context", () => {
-  assertStrictEq(isDate(new (eval("Date"))()), true);
+  assertStrictEquals(isDate(new (eval("Date"))()), true);
 });
 
 test("Date function is not of type Date", () => {
-  assertStrictEq(isDate(Date()), false);
+  assertStrictEquals(isDate(Date()), false);
 });
 
 test("Object is not of type Date", () => {
-  assertStrictEq(isDate({}), false);
+  assertStrictEquals(isDate({}), false);
 });
 
 test("Array is not of type Date", () => {
-  assertStrictEq(isDate([]), false);
+  assertStrictEquals(isDate([]), false);
 });
 
 test("Error is not of type Date", () => {
-  assertStrictEq(isDate(new Error()), false);
+  assertStrictEquals(isDate(new Error()), false);
 });
 
 test("New object from Date prototype is not of type Date", () => {
-  assertStrictEq(isDate(Object.create(Date.prototype)), false);
+  assertStrictEquals(isDate(Object.create(Date.prototype)), false);
 });

--- a/std/node/module_test.ts
+++ b/std/node/module_test.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 const { test } = Deno;
-import { assertEquals, assert, assertStrContains } from "../testing/asserts.ts";
+import {
+  assertEquals,
+  assert,
+  assertStringContains,
+} from "../testing/asserts.ts";
 import { createRequire } from "./module.ts";
 
 const require = createRequire(import.meta.url);
@@ -54,6 +58,6 @@ test("requireStack", function () {
   try {
     hello();
   } catch (e) {
-    assertStrContains(e.stack, "/tests/cjs/cjs_throw.js");
+    assertStringContains(e.stack, "/tests/cjs/cjs_throw.js");
   }
 });

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -204,7 +204,7 @@ export function assertNotEquals(
  * Make an assertion that `actual` and `expected` are strictly equal.  If
  * not then throw.
  */
-export function assertStrictEq(
+export function assertStrictEquals(
   actual: unknown,
   expected: unknown,
   msg?: string

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -250,7 +250,7 @@ export function assertStrictEquals(
  * Make an assertion that actual contains expected. If not
  * then thrown.
  */
-export function assertStrContains(
+export function assertStringContains(
   actual: string,
   expected: string,
   msg?: string

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -7,7 +7,7 @@ import {
   assertArrayContains,
   assertMatch,
   assertEquals,
-  assertStrictEq,
+  assertStrictEquals,
   assertThrows,
   assertThrowsAsync,
   AssertionError,
@@ -358,17 +358,17 @@ test({
 test({
   name: "strict pass case",
   fn(): void {
-    assertStrictEq(true, true);
-    assertStrictEq(10, 10);
-    assertStrictEq("abc", "abc");
+    assertStrictEquals(true, true);
+    assertStrictEquals(10, 10);
+    assertStrictEquals("abc", "abc");
 
     const xs = [1, false, "foo"];
     const ys = xs;
-    assertStrictEq(xs, ys);
+    assertStrictEquals(xs, ys);
 
     const x = { a: 1 };
     const y = x;
-    assertStrictEq(x, y);
+    assertStrictEquals(x, y);
   },
 });
 
@@ -376,7 +376,7 @@ test({
   name: "strict failed with structure diff",
   fn(): void {
     assertThrows(
-      (): void => assertStrictEq({ a: 1, b: 2 }, { a: 1, c: [3] }),
+      (): void => assertStrictEquals({ a: 1, b: 2 }, { a: 1, c: [3] }),
       AssertionError,
       [
         "Values are not strictly equal:",
@@ -393,7 +393,7 @@ test({
   name: "strict failed with reference diff",
   fn(): void {
     assertThrows(
-      (): void => assertStrictEq({ a: 1, b: 2 }, { a: 1, b: 2 }),
+      (): void => assertStrictEquals({ a: 1, b: 2 }, { a: 1, b: 2 }),
       AssertionError,
       [
         "Values have the same structure but are not reference-equal:\n",

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -3,7 +3,7 @@
 import {
   assert,
   assertNotEquals,
-  assertStrContains,
+  assertStringContains,
   assertArrayContains,
   assertMatch,
   assertEquals,
@@ -133,12 +133,12 @@ test("testingNotEquals", function (): void {
 });
 
 test("testingAssertStringContains", function (): void {
-  assertStrContains("Denosaurus", "saur");
-  assertStrContains("Denosaurus", "Deno");
-  assertStrContains("Denosaurus", "rus");
+  assertStringContains("Denosaurus", "saur");
+  assertStringContains("Denosaurus", "Deno");
+  assertStringContains("Denosaurus", "rus");
   let didThrow;
   try {
-    assertStrContains("Denosaurus", "Raptor");
+    assertStringContains("Denosaurus", "Raptor");
     didThrow = false;
   } catch (e) {
     assert(e instanceof AssertionError);
@@ -162,7 +162,7 @@ test("testingArrayContains", function (): void {
 test("testingAssertStringContainsThrow", function (): void {
   let didThrow = false;
   try {
-    assertStrContains("Denosaurus from Jurassic", "Raptor");
+    assertStringContains("Denosaurus from Jurassic", "Raptor");
   } catch (e) {
     assert(
       e.message ===


### PR DESCRIPTION
This renames the somewhat arbitrary abbreviated assertions to make the assertions library naming more consistent.

```text
assertStrContains -> assertStringContains
assertStrictEq    -> assertStrictEquals
```

This resolves #6097 