### PR TITLE
added mjs files for default test

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1022,7 +1022,7 @@ report results to standard output:
   deno test src/fetch_test.ts src/signal_test.ts
 
 Directory arguments are expanded to all contained files matching the glob
-{*_,*.,}test.{js,ts,jsx,tsx}:
+{*_,*.,}test.{js,mjs,ts,jsx,tsx}:
   deno test src/",
     )
 }

--- a/cli/test_runner.rs
+++ b/cli/test_runner.rs
@@ -14,14 +14,17 @@ fn is_supported(p: &Path) -> bool {
     basename.ends_with("_test.ts")
       || basename.ends_with("_test.tsx")
       || basename.ends_with("_test.js")
+      || basename.ends_with("_test.mjs")
       || basename.ends_with("_test.jsx")
       || basename.ends_with(".test.ts")
       || basename.ends_with(".test.tsx")
       || basename.ends_with(".test.js")
+      || basename.ends_with(".test.mjs")
       || basename.ends_with(".test.jsx")
       || basename == "test.ts"
       || basename == "test.tsx"
       || basename == "test.js"
+      || basename == "test.mjs"
       || basename == "test.jsx"
   } else {
     false

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -102,6 +102,6 @@ deno test my_test.ts
 ```
 
 You can also omit the file name, in which case all tests in the current
-directory (recursively) that match the glob `{*_,*.,}test.{js,ts,jsx,tsx}` will
+directory (recursively) that match the glob `{*_,*.,}test.{js,mjs,ts,jsx,tsx}` will
 be run. If you pass a directory, all files in the directory that match this glob
 will be run.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -102,6 +102,6 @@ deno test my_test.ts
 ```
 
 You can also omit the file name, in which case all tests in the current
-directory (recursively) that match the glob `{*_,*.,}test.{js,mjs,ts,jsx,tsx}` will
-be run. If you pass a directory, all files in the directory that match this glob
-will be run.
+directory (recursively) that match the glob `{*_,*.,}test.{js,mjs,ts,jsx,tsx}`
+will be run. If you pass a directory, all files in the directory that match this
+glob will be run.


### PR DESCRIPTION
In JavaScript, mjs is good for both Deno and browsers.
Test runners should also support mjs.

Related Issue
https://github.com/denoland/deno/issues/2947