### PR TITLE
Fix read sync on stdin

### DIFF
--- a/cli/tests/unit/stdio_test.ts
+++ b/cli/tests/unit/stdio_test.ts
@@ -1,0 +1,32 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { unitTest, assertEquals } from "./test_util.ts";
+
+unitTest(async function stdioStdinRead() {
+  const nread = await Deno.stdin.read(new Uint8Array(0));
+  assertEquals(nread, 0);
+});
+
+unitTest(function stdioStdinReadSync() {
+  const nread = Deno.stdin.readSync(new Uint8Array(0));
+  assertEquals(nread, 0);
+});
+
+unitTest(async function stdioStdoutWrite() {
+  const nwritten = await Deno.stdout.write(new Uint8Array(0));
+  assertEquals(nwritten, 0);
+});
+
+unitTest(function stdioStdoutWriteSync() {
+  const nwritten = Deno.stdout.writeSync(new Uint8Array(0));
+  assertEquals(nwritten, 0);
+});
+
+unitTest(async function stdioStderrWrite() {
+  const nwritten = await Deno.stderr.write(new Uint8Array(0));
+  assertEquals(nwritten, 0);
+});
+
+unitTest(function stdioStderrWriteSync() {
+  const nwritten = Deno.stderr.writeSync(new Uint8Array(0));
+  assertEquals(nwritten, 0);
+});

--- a/cli/tests/unit/unit_tests.ts
+++ b/cli/tests/unit/unit_tests.ts
@@ -52,6 +52,7 @@ import "./request_test.ts";
 import "./resources_test.ts";
 import "./signal_test.ts";
 import "./stat_test.ts";
+import "./stdio_test.ts";
 import "./streams_internal_test.ts";
 import "./streams_piping_test.ts";
 import "./streams_transform_test.ts";


### PR DESCRIPTION
Currently sync operations on stdin are failing because tokio::Stdin cannot be converted to a std::File.

This replaces tokio::stdin with a raw file descriptor wrapped in a std::fs::File which can be converted to a tokio::File and back again making the synchronous version of op_read actually work.

This fixes #6121 