### PR TITLE
fix: revert setInterval log flushing as it prevents process completion

### DIFF
--- a/std/log/README.md
+++ b/std/log/README.md
@@ -107,10 +107,10 @@ interface HandlerOptions {
 #### `FileHandler`
 
 This handler will output to a file using an optional mode (default is `a`, e.g.
-append). The file will grow indefinitely. It uses a buffer for writing to file
-and will automatically flush every 30 seconds, though you can trigger this
-yourself with `fileHandler.flush()`. Log messages with a log level greater than
-error are immediately flushed. This logger takes `FileOptions`:
+append). The file will grow indefinitely. It uses a buffer for writing to file.
+Logs can be manually flushed with `fileHandler.flush()`. Log messages with a log
+level greater than error are immediately flushed. Logs are also flushed on
+process completion. This logger takes `FileOptions`:
 
 ```typescript
 interface FileHandlerOptions {
@@ -151,10 +151,10 @@ backups to keep), `log.txt.1` would be renamed to `log.txt.2`, `log.txt` would
 be renamed to `log.txt.1` and finally `log.txt` would be created from scratch
 where the new log message would be written.
 
-This handler uses a buffer for writing to file and will automatically flush
-every 30 seconds, though you can trigger this yourself with
-`fileHandler.flush()`. Log messages with a log level greater than error are
-immediately flushed.
+This handler uses a buffer for writing log messages to file. Logs can be
+manually flushed with `fileHandler.flush()`. Log messages with a log level
+greater than ERROR are immediately flushed. Logs are also flushed on process
+completion.
 
 Options for this handler are:
 

--- a/std/log/handlers.ts
+++ b/std/log/handlers.ts
@@ -106,7 +106,6 @@ export class FileHandler extends WriterHandler {
   protected _mode: LogMode;
   protected _openOptions: OpenOptions;
   protected _encoder = new TextEncoder();
-  #intervalId = -1;
   #unloadCallback = (): Promise<void> => this.destroy();
 
   constructor(levelName: LevelName, options: FileHandlerOptions) {
@@ -129,9 +128,6 @@ export class FileHandler extends WriterHandler {
     this._buf = new BufWriterSync(this._file);
 
     addEventListener("unload", this.#unloadCallback);
-
-    // flush the buffer every 30 seconds
-    this.#intervalId = setInterval(() => this.flush(), 30 * 1000);
   }
 
   handle(logRecord: LogRecord): void {
@@ -158,7 +154,6 @@ export class FileHandler extends WriterHandler {
     this._file?.close();
     this._file = undefined;
     removeEventListener("unload", this.#unloadCallback);
-    clearInterval(this.#intervalId);
     return Promise.resolve();
   }
 }


### PR DESCRIPTION
This is a (small) partial revert of commit c9aded05a6b5e4825e9be362013be74fd51e8620 which added buffered file logging.  In an attempt to match glog's implementation, a timed `flush()` of the buffer was initiated every 30 seconds via `setInterval`. However, `setInterval` prevents process completion and the module hangs forever.  This could possibly be reconsidered if Deno someday implements something similar to Node's [unref()](https://nodejs.org/api/timers.html#timers_timeout_unref) which can allow the process to exit even if the specified timer is still ongoing/incomplete.

There is still an ability to manually flush the buffer whenever desired and therefore clients can manage more frequent flushing on their own.  Log are also flushed through the `unload` event or through calls to `handler.destroy()`.