### PR TITLE
Chunk prettier invocation

### DIFF
--- a/tools/format.py
+++ b/tools/format.py
@@ -58,8 +58,7 @@ def prettier():
                           "bin-prettier.js")
     source_files = get_sources(root_path, ["*.js", "*.json", "*.ts", "*.md"])
     if source_files:
-        # https://support.microsoft.com/en-us/help/830473/command-prompt-cmd-exe-command-line-string-limitation
-        max_command_length = 8191
+        max_command_length = 32000
         while len(source_files) > 0:
             command = ["node", script, "--write", "--loglevel=error", "--"]
             while len(source_files) > 0:

--- a/tools/format.py
+++ b/tools/format.py
@@ -58,15 +58,14 @@ def prettier():
                           "bin-prettier.js")
     source_files = get_sources(root_path, ["*.js", "*.json", "*.ts", "*.md"])
     if source_files:
-        max_command_length = 32000
+        max_command_length = 24000
         while len(source_files) > 0:
             command = ["node", script, "--write", "--loglevel=error", "--"]
             while len(source_files) > 0:
                 command.append(source_files.pop())
                 if len(" ".join(command)) > max_command_length:
-                    source_files.append(command.pop())
+                    run(command, shell=False, quiet=True)
                     break
-            run(command, shell=False, quiet=True)
 
 
 def yapf():

--- a/tools/format.py
+++ b/tools/format.py
@@ -58,11 +58,16 @@ def prettier():
                           "bin-prettier.js")
     source_files = get_sources(root_path, ["*.js", "*.json", "*.ts", "*.md"])
     if source_files:
-        print_command("prettier", source_files)
-        run(["node", script, "--write", "--loglevel=error", "--"] +
-            source_files,
-            shell=False,
-            quiet=True)
+        # https://support.microsoft.com/en-us/help/830473/command-prompt-cmd-exe-command-line-string-limitation
+        max_command_length = 8191
+        while len(source_files) > 0:
+            command = ["node", script, "--write", "--loglevel=error", "--"]
+            while len(source_files) > 0:
+                command.append(source_files.pop())
+                if len(" ".join(command)) > max_command_length:
+                    source_files.append(command.pop())
+                    break
+            run(command, shell=False, quiet=True)
 
 
 def yapf():


### PR DESCRIPTION
Fixes #5017.

Not sure whether the max command line length should be 32768 or 8191. I opted for 8191 just to be save.

I'm also not familiar with Python and I didn't wanna have any off-by-one errors so this code doesn't do any fancy arithmetic or even list slicing. It's literally just "Add another file to the command. Is it too long now? Oh well, remove it again, and run the formatting. Repeat until there are no files left."

cc @piscisaureus 