### PR TITLE
refactor(std/signal): Replace setTimeout with IIFE

### DIFF
--- a/std/signal/mod.ts
+++ b/std/signal/mod.ts
@@ -61,12 +61,12 @@ export function signal(
 export function onSignal(signo: number, callback: () => void): Disposable {
   const sig = signal(signo);
 
-  //setTimeout allows `sig` to be returned before blocking on the await
-  setTimeout(async () => {
+  // allows `sig` to be returned before blocking on the await
+  (async (): Promise<void> => {
     for await (const _ of sig) {
       callback();
     }
-  }, 0);
+  })();
 
   return sig;
 }


### PR DESCRIPTION
Replace unnecessary `setTimeout` with an IIFE. `setTimeout` adds an extra function call that's not needed.

In case we want for some reason to start listening on the next tick, `queueMicrotask` should be used instead.

