### PR TITLE
fix(std/http): Prevent crash on UnexpectedEof and InvalidData

### DIFF
--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -211,8 +211,12 @@ export class Server implements AsyncIterable<ServerRequest> {
     try {
       conn = await this.listener.accept();
     } catch (error) {
-      if (error instanceof Deno.errors.BadResource) {
-        return;
+      if (
+        error instanceof Deno.errors.BadResource ||
+        error instanceof Deno.errors.InvalidData ||
+        error instanceof Deno.errors.UnexpectedEof
+      ) {
+        return mux.add(this.acceptConnAndIterateHttpRequests(mux));
       }
       throw error;
     }

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -576,8 +576,6 @@ test({
         s !== null && s.includes("server listening"),
         "server must be started"
       );
-      // Requests to the server and immediately closes the connection
-
       // Invalid certificate, connection should throw
       // but should not crash the server
       assertThrowsAsync(

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -545,3 +545,75 @@ test({
     assert((await entry).done);
   },
 });
+
+test({
+  name: "serveTLS Invalid Cert",
+  fn: async (): Promise<void> => {
+    // Runs a simple server as another process
+    const p = Deno.run({
+      cmd: [
+        Deno.execPath(),
+        "run",
+        "--allow-net",
+        "--allow-read",
+        "http/testdata/simple_https_server.ts",
+      ],
+      stdout: "piped",
+    });
+
+    let serverIsRunning = true;
+    const statusPromise = p
+      .status()
+      .then((): void => {
+        serverIsRunning = false;
+      })
+      .catch((_): void => {}); // Ignores the error when closing the process.
+
+    try {
+      const r = new TextProtoReader(new BufReader(p.stdout!));
+      const s = await r.readLine();
+      assert(
+        s !== null && s.includes("server listening"),
+        "server must be started"
+      );
+      // Requests to the server and immediately closes the connection
+
+      // Invalid certificate, connection should throw
+      // but should not crash the server
+      assertThrowsAsync(
+        () =>
+          Deno.connectTls({
+            hostname: "localhost",
+            port: 4503,
+            // certFile
+          }),
+        Deno.errors.InvalidData
+      );
+
+      // Valid request after invalid
+      const conn = await Deno.connectTls({
+        hostname: "localhost",
+        port: 4503,
+        certFile: "http/testdata/tls/RootCA.pem",
+      });
+
+      await Deno.writeAll(
+        conn,
+        new TextEncoder().encode("GET / HTTP/1.0\r\n\r\n")
+      );
+      const res = new Uint8Array(100);
+      const nread = await conn.read(res);
+      assert(nread !== null);
+      conn.close();
+      const resStr = new TextDecoder().decode(res.subarray(0, nread));
+      assert(resStr.includes("Hello HTTPS"));
+      assert(serverIsRunning);
+    } finally {
+      // Stops the sever and allows `p.status()` promise to resolve
+      Deno.kill(p.pid, Deno.Signal.SIGKILL);
+      await statusPromise;
+      p.stdout!.close();
+      p.close();
+    }
+  },
+});


### PR DESCRIPTION
Might fix: #5857 #5260

Encountered `error: Uncaught InvalidData: received fatal alert: BadCertificate` today, these changes fixed the issue but I'm still looking into how to write some tests.

Works perfectly fine for the following snippet provided by @Lonniebiz (https://github.com/denoland/deno/issues/5260#issuecomment-636422509)

```javascript
import { listenAndServeTLS } from "/var/www/deno/std/http/server.ts";

const body = "Hello HTTPS";
const options = {
   hostname: "localhost",
   port: 4433, // Not 443--> https://github.com/denoland/deno/issues/5816#issuecomment-635528888
   certFile: "./server.cert",
   keyFile: "./private.key",
};
listenAndServeTLS(options, (req) => {
   req.respond({ body: "yes" });
});
```

After accessing in the browser it does not crash and I can proceed to the untrusted site after confirmation.