### PR TITLE
Extend std/util/node types

### DIFF
--- a/std/node/_util/_util_types.ts
+++ b/std/node/_util/_util_types.ts
@@ -26,6 +26,207 @@ const _toString = Object.prototype.toString;
 const _isObjectLike = (value: unknown): boolean =>
   value !== null && typeof value === "object";
 
+const _isFunctionLike = (value: unknown): boolean =>
+  value !== null && typeof value === "function";
+
+export function isAnyArrayBuffer(value: unknown): boolean {
+  return (
+    _isObjectLike(value) &&
+    (_toString.call(value) === "[object ArrayBuffer]" ||
+      _toString.call(value) === "[object SharedArrayBuffer]")
+  );
+}
+
+export function isArrayBufferView(value: unknown): boolean {
+  return ArrayBuffer.isView(value);
+}
+
+export function isArgumentsObject(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Arguments]";
+}
+
+export function isArrayBuffer(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object ArrayBuffer]"
+  );
+}
+
+export function isAsyncFunction(value: unknown): boolean {
+  return (
+    _isFunctionLike(value) && _toString.call(value) === "[object AsyncFunction]"
+  );
+}
+
+export function isBigInt64Array(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object BigInt64Array]"
+  );
+}
+
+export function isBigUint64Array(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object BigUint64Array]"
+  );
+}
+
+export function isBooleanObject(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Boolean]";
+}
+
+export function isBoxedPrimitive(value: unknown): boolean {
+  return (
+    isBooleanObject(value) ||
+    isStringObject(value) ||
+    isNumberObject(value) ||
+    isSymbolObject(value) ||
+    isBigIntObject(value)
+  );
+}
+
+export function isDataView(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object DataView]";
+}
+
 export function isDate(value: unknown): boolean {
   return _isObjectLike(value) && _toString.call(value) === "[object Date]";
+}
+
+// isExternal: Not implemented
+
+export function isFloat32Array(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object Float32Array]"
+  );
+}
+
+export function isFloat64Array(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object Float64Array]"
+  );
+}
+
+export function isGeneratorFunction(value: unknown): boolean {
+  return (
+    _isFunctionLike(value) &&
+    _toString.call(value) === "[object GeneratorFunction]"
+  );
+}
+
+export function isGeneratorObject(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Generator]";
+}
+
+export function isInt8Array(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Int8Array]";
+}
+
+export function isInt16Array(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object Int16Array]"
+  );
+}
+
+export function isInt32Array(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object Int32Array]"
+  );
+}
+
+export function isMap(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Map]";
+}
+
+export function isMapIterator(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object Map Iterator]"
+  );
+}
+
+export function isModuleNamespaceObject(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Module]";
+}
+
+export function isNativeError(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Error]";
+}
+
+export function isNumberObject(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Number]";
+}
+
+export function isBigIntObject(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object BigInt]";
+}
+
+export function isPromise(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Promise]";
+}
+
+export function isRegExp(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object RegExp]";
+}
+
+export function isSet(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Set]";
+}
+
+export function isSetIterator(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object Set Iterator]"
+  );
+}
+
+export function isSharedArrayBuffer(value: unknown): boolean {
+  return (
+    _isObjectLike(value) &&
+    _toString.call(value) === "[object SharedArrayBuffer]"
+  );
+}
+
+export function isStringObject(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object String]";
+}
+
+export function isSymbolObject(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object Symbol]";
+}
+
+// Adapted from Lodash
+export function isTypedArray(value: unknown): boolean {
+  /** Used to match `toStringTag` values of typed arrays. */
+  const reTypedTag = /^\[object (?:Float(?:32|64)|(?:Int|Uint)(?:8|16|32)|Uint8Clamped)Array\]$/;
+  return _isObjectLike(value) && reTypedTag.test(_toString.call(value));
+}
+
+export function isUint8Array(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object Uint8Array]"
+  );
+}
+
+export function isUint8ClampedArray(value: unknown): boolean {
+  return (
+    _isObjectLike(value) &&
+    _toString.call(value) === "[object Uint8ClampedArray]"
+  );
+}
+
+export function isUint16Array(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object Uint16Array]"
+  );
+}
+
+export function isUint32Array(value: unknown): boolean {
+  return (
+    _isObjectLike(value) && _toString.call(value) === "[object Uint32Array]"
+  );
+}
+
+export function isWeakMap(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object WeakMap]";
+}
+
+export function isWeakSet(value: unknown): boolean {
+  return _isObjectLike(value) && _toString.call(value) === "[object WeakSet]";
 }

--- a/std/node/_util/_util_types_test.ts
+++ b/std/node/_util/_util_types_test.ts
@@ -21,40 +21,491 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import { assertStrictEquals } from "../../testing/asserts.ts";
-
-import { isDate } from "./_util_types.ts";
-
 const { test } = Deno;
+import { assertStrictEquals } from "../../testing/asserts.ts";
+import {
+  isDate,
+  isMap,
+  isSet,
+  isAnyArrayBuffer,
+  isArrayBufferView,
+  isArgumentsObject,
+  isArrayBuffer,
+  isStringObject,
+  isAsyncFunction,
+  isBigInt64Array,
+  isBigUint64Array,
+  isBooleanObject,
+  isBoxedPrimitive,
+  isDataView,
+  isFloat32Array,
+  isFloat64Array,
+  isGeneratorFunction,
+  isGeneratorObject,
+  isInt8Array,
+  isInt16Array,
+  isInt32Array,
+  isMapIterator,
+  isModuleNamespaceObject,
+  isNativeError,
+  isSymbolObject,
+  isTypedArray,
+  isUint8Array,
+  isUint8ClampedArray,
+  isUint16Array,
+  isUint32Array,
+  isNumberObject,
+  isBigIntObject,
+  isPromise,
+  isRegExp,
+  isSetIterator,
+  isSharedArrayBuffer,
+  isWeakMap,
+  isWeakSet,
+} from "./_util_types.ts";
 
-test("New date instance with no arguments", () => {
+// Used to test isModuleNamespaceObject
+import * as testModuleNamespaceOpbject from "./_util_types.ts";
+
+// isAnyArrayBuffer
+test("Should return true for valid ArrayBuffer types", () => {
+  assertStrictEquals(isAnyArrayBuffer(new ArrayBuffer(0)), true);
+  assertStrictEquals(isAnyArrayBuffer(new SharedArrayBuffer(0)), true);
+});
+
+test("Should return false for invalid ArrayBuffer types", () => {
+  assertStrictEquals(isAnyArrayBuffer({}), false);
+  assertStrictEquals(isAnyArrayBuffer([]), false);
+  assertStrictEquals(isAnyArrayBuffer(new Error()), false);
+});
+
+// isArrayBufferView
+test("Should return true for valid ArrayBufferView types", () => {
+  assertStrictEquals(isArrayBufferView(new Int8Array(0)), true);
+  assertStrictEquals(isArrayBufferView(new Uint8Array(0)), true);
+  assertStrictEquals(isArrayBufferView(new Uint8ClampedArray(0)), true);
+  assertStrictEquals(isArrayBufferView(new Int16Array(0)), true);
+  assertStrictEquals(isArrayBufferView(new Uint16Array(0)), true);
+  assertStrictEquals(isArrayBufferView(new Int32Array(0)), true);
+  assertStrictEquals(isArrayBufferView(new Uint32Array(0)), true);
+  assertStrictEquals(isArrayBufferView(new Float32Array(0)), true);
+  assertStrictEquals(isArrayBufferView(new Float64Array(0)), true);
+  assertStrictEquals(isArrayBufferView(new DataView(new ArrayBuffer(0))), true);
+});
+
+test("Should return false for invalid ArrayBufferView types", () => {
+  assertStrictEquals(isArrayBufferView({}), false);
+  assertStrictEquals(isArrayBufferView([]), false);
+  assertStrictEquals(isArrayBufferView(new Error()), false);
+  assertStrictEquals(isArrayBufferView(new ArrayBuffer(0)), false);
+});
+
+// isArgumentsObject
+// Note: not testable in TS
+
+test("Should return false for invalid Argument types", () => {
+  assertStrictEquals(isArgumentsObject({}), false);
+  assertStrictEquals(isArgumentsObject([]), false);
+  assertStrictEquals(isArgumentsObject(new Error()), false);
+});
+
+// isArrayBuffer
+test("Should return true for valid ArrayBuffer types", () => {
+  assertStrictEquals(isArrayBuffer(new ArrayBuffer(0)), true);
+});
+
+test("Should return false for invalid ArrayBuffer types", () => {
+  assertStrictEquals(isArrayBuffer(new SharedArrayBuffer(0)), false);
+  assertStrictEquals(isArrayBuffer({}), false);
+  assertStrictEquals(isArrayBuffer([]), false);
+  assertStrictEquals(isArrayBuffer(new Error()), false);
+});
+
+// isAsyncFunction
+test("Should return true for valid async function types", () => {
+  const asyncFunction = async (): Promise<void> => {};
+  assertStrictEquals(isAsyncFunction(asyncFunction), true);
+});
+
+test("Should return false for invalid async function types", () => {
+  const syncFunction = (): void => {};
+  assertStrictEquals(isAsyncFunction(syncFunction), false);
+  assertStrictEquals(isAsyncFunction({}), false);
+  assertStrictEquals(isAsyncFunction([]), false);
+  assertStrictEquals(isAsyncFunction(new Error()), false);
+});
+
+// isBigInt64Array
+test("Should return true for valid BigInt64Array types", () => {
+  assertStrictEquals(isBigInt64Array(new BigInt64Array()), true);
+});
+
+test("Should return false for invalid BigInt64Array types", () => {
+  assertStrictEquals(isBigInt64Array(new BigUint64Array()), false);
+  assertStrictEquals(isBigInt64Array(new Float32Array()), false);
+  assertStrictEquals(isBigInt64Array(new Int32Array()), false);
+});
+
+// isBigUint64Array
+test("Should return true for valid isBigUint64Array types", () => {
+  assertStrictEquals(isBigUint64Array(new BigUint64Array()), true);
+});
+
+test("Should return false for invalid isBigUint64Array types", () => {
+  assertStrictEquals(isBigUint64Array(new BigInt64Array()), false);
+  assertStrictEquals(isBigUint64Array(new Float32Array()), false);
+  assertStrictEquals(isBigUint64Array(new Int32Array()), false);
+});
+
+// isBooleanObject
+test("Should return true for valid Boolean object types", () => {
+  assertStrictEquals(isBooleanObject(new Boolean(false)), true);
+  assertStrictEquals(isBooleanObject(new Boolean(true)), true);
+});
+
+test("Should return false for invalid isBigUint64Array types", () => {
+  assertStrictEquals(isBooleanObject(false), false);
+  assertStrictEquals(isBooleanObject(true), false);
+  assertStrictEquals(isBooleanObject(Boolean(false)), false);
+  assertStrictEquals(isBooleanObject(Boolean(true)), false);
+});
+
+// isBoxedPrimitive
+test("Should return true for valid boxed primitive values", () => {
+  assertStrictEquals(isBoxedPrimitive(new Boolean(false)), true);
+  assertStrictEquals(isBoxedPrimitive(Object(Symbol("foo"))), true);
+  assertStrictEquals(isBoxedPrimitive(Object(BigInt(5))), true);
+  assertStrictEquals(isBoxedPrimitive(new String("foo")), true);
+});
+
+test("Should return false for invalid boxed primitive values", () => {
+  assertStrictEquals(isBoxedPrimitive(false), false);
+  assertStrictEquals(isBoxedPrimitive(Symbol("foo")), false);
+});
+
+// isDateView
+test("Should return true for valid DataView types", () => {
+  assertStrictEquals(isDataView(new DataView(new ArrayBuffer(0))), true);
+});
+
+test("Should return false for invalid DataView types", () => {
+  assertStrictEquals(isDataView(new Float64Array(0)), false);
+});
+
+// isDate
+test("Should return true for valid date types", () => {
   assertStrictEquals(isDate(new Date()), true);
-});
-
-test("New date instance with value 0", () => {
   assertStrictEquals(isDate(new Date(0)), true);
-});
-
-test("New date instance in new context", () => {
   assertStrictEquals(isDate(new (eval("Date"))()), true);
 });
 
-test("Date function is not of type Date", () => {
+test("Should return false for invalid date types", () => {
   assertStrictEquals(isDate(Date()), false);
-});
-
-test("Object is not of type Date", () => {
   assertStrictEquals(isDate({}), false);
-});
-
-test("Array is not of type Date", () => {
   assertStrictEquals(isDate([]), false);
-});
-
-test("Error is not of type Date", () => {
   assertStrictEquals(isDate(new Error()), false);
+  assertStrictEquals(isDate(Object.create(Date.prototype)), false);
 });
 
-test("New object from Date prototype is not of type Date", () => {
-  assertStrictEquals(isDate(Object.create(Date.prototype)), false);
+// isFloat32Array
+test("Should return true for valid Float32Array types", () => {
+  assertStrictEquals(isFloat32Array(new Float32Array(0)), true);
+});
+
+test("Should return false for invalid Float32Array types", () => {
+  assertStrictEquals(isFloat32Array(new ArrayBuffer(0)), false);
+  assertStrictEquals(isFloat32Array(new Float64Array(0)), false);
+});
+
+// isFloat64Array
+test("Should return true for valid Float64Array types", () => {
+  assertStrictEquals(isFloat64Array(new Float64Array(0)), true);
+});
+
+test("Should return false for invalid Float64Array types", () => {
+  assertStrictEquals(isFloat64Array(new ArrayBuffer(0)), false);
+  assertStrictEquals(isFloat64Array(new Uint8Array(0)), false);
+});
+
+// isGeneratorFunction
+test("Should return true for valid generator functions", () => {
+  assertStrictEquals(
+    isGeneratorFunction(function* foo() {}),
+    true
+  );
+});
+
+test("Should return false for invalid generator functions", () => {
+  assertStrictEquals(
+    isGeneratorFunction(function foo() {}),
+    false
+  );
+});
+
+// isGeneratorObject
+test("Should return true for valid generator object types", () => {
+  function* foo(): Iterator<void> {}
+  assertStrictEquals(isGeneratorObject(foo()), true);
+});
+
+test("Should return false for invalid generation object types", () => {
+  assertStrictEquals(
+    isGeneratorObject(function* foo() {}),
+    false
+  );
+});
+
+// isInt8Array
+test("Should return true for valid Int8Array types", () => {
+  assertStrictEquals(isInt8Array(new Int8Array(0)), true);
+});
+
+test("Should return false for invalid Int8Array types", () => {
+  assertStrictEquals(isInt8Array(new ArrayBuffer(0)), false);
+  assertStrictEquals(isInt8Array(new Float64Array(0)), false);
+});
+
+// isInt16Array
+test("Should return true for valid Int16Array types", () => {
+  assertStrictEquals(isInt16Array(new Int16Array(0)), true);
+});
+
+test("Should return false for invalid Int16Array type", () => {
+  assertStrictEquals(isInt16Array(new ArrayBuffer(0)), false);
+  assertStrictEquals(isInt16Array(new Float64Array(0)), false);
+});
+
+// isInt32Array
+test("Should return true for valid isInt32Array types", () => {
+  assertStrictEquals(isInt32Array(new Int32Array(0)), true);
+});
+
+test("Should return false for invalid isInt32Array type", () => {
+  assertStrictEquals(isInt32Array(new ArrayBuffer(0)), false);
+  assertStrictEquals(isInt32Array(new Float64Array(0)), false);
+});
+
+// isStringObject
+test("Should return true for valid String types", () => {
+  assertStrictEquals(isStringObject(new String("")), true);
+  assertStrictEquals(isStringObject(new String("Foo")), true);
+});
+
+test("Should return false for invalid String types", () => {
+  assertStrictEquals(isStringObject(""), false);
+  assertStrictEquals(isStringObject("Foo"), false);
+});
+
+// isMap
+test("Should return true for valid Map types", () => {
+  assertStrictEquals(isMap(new Map()), true);
+});
+
+test("Should return false for invalid Map types", () => {
+  assertStrictEquals(isMap({}), false);
+  assertStrictEquals(isMap([]), false);
+  assertStrictEquals(isMap(new Date()), false);
+  assertStrictEquals(isMap(new Error()), false);
+});
+
+// isMapIterator
+test("Should return true for valid Map Iterator types", () => {
+  const map = new Map();
+  assertStrictEquals(isMapIterator(map.keys()), true);
+  assertStrictEquals(isMapIterator(map.values()), true);
+  assertStrictEquals(isMapIterator(map.entries()), true);
+  assertStrictEquals(isMapIterator(map[Symbol.iterator]()), true);
+});
+
+test("Should return false for invalid Map iterator types", () => {
+  assertStrictEquals(isMapIterator(new Map()), false);
+  assertStrictEquals(isMapIterator([]), false);
+  assertStrictEquals(isMapIterator(new Date()), false);
+  assertStrictEquals(isMapIterator(new Error()), false);
+});
+
+// isModuleNamespaceObject
+test("Should return true for valid module namespace objects", () => {
+  assertStrictEquals(isModuleNamespaceObject(testModuleNamespaceOpbject), true);
+});
+
+test("Should return false for invalid  module namespace objects", () => {
+  assertStrictEquals(isModuleNamespaceObject(assertStrictEquals), false);
+});
+
+// isNativeError
+test("Should return true for valid Error types", () => {
+  assertStrictEquals(isNativeError(new Error()), true);
+  assertStrictEquals(isNativeError(new TypeError()), true);
+  assertStrictEquals(isNativeError(new RangeError()), true);
+});
+
+test("Should return false for invalid Error types", () => {
+  assertStrictEquals(isNativeError(null), false);
+  assertStrictEquals(isNativeError(NaN), false);
+});
+
+// isNumberObject
+test("Should return true for valid number objects", () => {
+  assertStrictEquals(isNumberObject(new Number(0)), true);
+});
+
+test("Should return false for invalid number types", () => {
+  assertStrictEquals(isNumberObject(0), false);
+});
+
+// isBigIntObject
+test("Should return true for valid number objects", () => {
+  assertStrictEquals(isBigIntObject(new Object(BigInt(42))), true);
+});
+
+test("Should return false for invalid number types", () => {
+  assertStrictEquals(isBigIntObject(BigInt(42)), false);
+});
+
+// isPromise
+test("Should return true for valid Promise types", () => {
+  assertStrictEquals(isPromise(Promise.resolve(42)), true);
+});
+
+test("Should return false for invalid Promise types", () => {
+  assertStrictEquals(isPromise(new Object()), false);
+});
+
+// isRegExp
+test("Should return true for valid RegExp", () => {
+  assertStrictEquals(isRegExp(/abc/), true);
+  assertStrictEquals(isRegExp(new RegExp("abc")), true);
+});
+
+test("Should return false for invalid RegExp types", () => {
+  assertStrictEquals(isRegExp({}), false);
+  assertStrictEquals(isRegExp("/abc/"), false);
+});
+
+// isSet
+test("Should return true for valid Set types", () => {
+  assertStrictEquals(isSet(new Set()), true);
+});
+
+test("Should return false for invalid Set types", () => {
+  assertStrictEquals(isSet({}), false);
+  assertStrictEquals(isSet([]), false);
+  assertStrictEquals(isSet(new Map()), false);
+  assertStrictEquals(isSet(new Error()), false);
+});
+
+// isSetIterator
+test("Should return true for valid Set Iterator types", () => {
+  const set = new Set();
+  assertStrictEquals(isSetIterator(set.keys()), true);
+  assertStrictEquals(isSetIterator(set.values()), true);
+  assertStrictEquals(isSetIterator(set.entries()), true);
+  assertStrictEquals(isSetIterator(set[Symbol.iterator]()), true);
+});
+
+test("Should return false for invalid Set Iterator types", () => {
+  assertStrictEquals(isSetIterator(new Set()), false);
+  assertStrictEquals(isSetIterator([]), false);
+  assertStrictEquals(isSetIterator(new Map()), false);
+  assertStrictEquals(isSetIterator(new Error()), false);
+});
+
+// isSharedArrayBuffer
+test("Should return true for valid SharedArrayBuffer types", () => {
+  assertStrictEquals(isSharedArrayBuffer(new SharedArrayBuffer(0)), true);
+});
+
+test("Should return false for invalid SharedArrayBuffer types", () => {
+  assertStrictEquals(isSharedArrayBuffer(new ArrayBuffer(0)), false);
+});
+
+// isStringObject
+test("Should return true for valid String Object types", () => {
+  assertStrictEquals(isStringObject(new String("")), true);
+  assertStrictEquals(isStringObject(new String("Foo")), true);
+});
+
+test("Should return false for invalid String Object types", () => {
+  assertStrictEquals(isStringObject(""), false);
+  assertStrictEquals(isStringObject("Foo"), false);
+});
+
+// isSymbolObject
+test("Should return true for valid Symbol types", () => {
+  assertStrictEquals(isSymbolObject(Object(Symbol("foo"))), true);
+});
+
+test("Should return false for invalid Symbol types", () => {
+  assertStrictEquals(isSymbolObject(Symbol("foo")), false);
+});
+
+// isTypedArray
+test("Should return true for valid TypedArray types", () => {
+  assertStrictEquals(isTypedArray(new Uint8Array(0)), true);
+  assertStrictEquals(isTypedArray(new Float64Array(0)), true);
+});
+
+test("Should return false for invalid TypedArray types", () => {
+  assertStrictEquals(isTypedArray(new ArrayBuffer(0)), false);
+});
+
+// isUint8Array
+test("Should return true for valid Uint8Array types", () => {
+  assertStrictEquals(isUint8Array(new Uint8Array(0)), true);
+});
+
+test("Should return false for invalid Uint8Array types", () => {
+  assertStrictEquals(isUint8Array(new ArrayBuffer(0)), false);
+  assertStrictEquals(isUint8Array(new Float64Array(0)), false);
+});
+
+// isUint8ClampedArray
+test("Should return true for valid Uint8ClampedArray types", () => {
+  assertStrictEquals(isUint8ClampedArray(new Uint8ClampedArray(0)), true);
+});
+
+test("Should return false for invalid Uint8Array types", () => {
+  assertStrictEquals(isUint8ClampedArray(new ArrayBuffer(0)), false);
+  assertStrictEquals(isUint8ClampedArray(new Float64Array(0)), false);
+});
+
+// isUint16Array
+test("Should return true for valid isUint16Array types", () => {
+  assertStrictEquals(isUint16Array(new Uint16Array(0)), true);
+});
+
+test("Should return false for invalid Uint16Array types", () => {
+  assertStrictEquals(isUint16Array(new ArrayBuffer(0)), false);
+  assertStrictEquals(isUint16Array(new Float64Array(0)), false);
+});
+
+// isUint32Array
+test("Should return true for valid Uint32Array types", () => {
+  assertStrictEquals(isUint32Array(new Uint32Array(0)), true);
+});
+
+test("Should return false for invalid isUint16Array types", () => {
+  assertStrictEquals(isUint32Array(new ArrayBuffer(0)), false);
+  assertStrictEquals(isUint32Array(new Float64Array(0)), false);
+});
+
+// isWeakMap
+test("Should return true for valid WeakMap types", () => {
+  assertStrictEquals(isWeakMap(new WeakMap()), true);
+});
+
+test("Should return false for invalid WeakMap types", () => {
+  assertStrictEquals(isWeakMap(new Set()), false);
+  assertStrictEquals(isWeakMap(new Map()), false);
+});
+
+// isWeakSet
+test("Should return true for valid WeakSet types", () => {
+  assertStrictEquals(isWeakSet(new WeakSet()), true);
+});
+
+test("Should return false for invalid WeakSet types", () => {
+  assertStrictEquals(isWeakSet(new Set()), false);
+  assertStrictEquals(isWeakSet(new Map()), false);
 });


### PR DESCRIPTION
This PR adds all missing `util.types` to the std Node library. See: https://nodejs.org/api/util.html#util_util_types

Tests are created from the examples in the Node docs.

Node is using internal bindings to verify the types. That is why I sometimes adapted the implementation from Lodash instead.

Exceptions:
- `isProxy`. Could not be implemented in Typescript.
- `isExternal`. Specific to Node bindings and not portable.

This is a requirement for https://github.com/denoland/deno/issues/6011