### PR TITLE
Add Async Mutex

### DIFF
--- a/std/async/mutex.ts
+++ b/std/async/mutex.ts
@@ -38,11 +38,9 @@ export class Mutex implements Locker {
     }
   }
 
-
   private static mus: {
     [key: string]: Mutex;
   } = {};
-
 
   /**
    *  Execute an async function that cannot be interrupted by 
@@ -67,7 +65,7 @@ export class Mutex implements Locker {
       await cb();
     } finally {
       Mutex.mus[name].unlock();
-      if(!Mutex.mus[name].locked){//nobody waiting?
+      if (!Mutex.mus[name].locked) { //nobody waiting?
         delete Mutex.mus[name];
       }
     }

--- a/std/async/mutex.ts
+++ b/std/async/mutex.ts
@@ -1,0 +1,75 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { deferred } from "./deferred.ts";
+
+export interface Locker {
+  lock: () => Promise<void>;
+  unlock: () => void;
+}
+
+export class Mutex implements Locker {
+  private queue: Array<() => void> = []; //currently waiting Locks
+  private locked = false;
+
+  /** Request a lock.  It is the callers responsibility to await this. */
+  lock(): Promise<void> {
+    if (this.locked) {
+      const retProm = deferred<void>();
+      this.queue.push(function (): void {
+        retProm.resolve();
+      });
+      return retProm;
+    } else {
+      this.locked = true;
+      return Promise.resolve();
+    }
+  }
+
+  /** Release the lock. */
+  unlock(): void {
+    if (this.locked) {
+      if (this.queue.length > 0) {
+        this.queue[0]();
+        this.queue.splice(0, 1);
+      } else {
+        this.locked = false;
+      }
+    } else {
+      throw new Error("not locked");
+    }
+  }
+
+
+  private static mus: {
+    [key: string]: Mutex;
+  } = {};
+
+
+  /**
+   *  Execute an async function that cannot be interrupted by 
+   *  functions requesting a lock of the same name.  
+   *
+   *  Example usage: 
+   *
+   *      await doAtomic("name_of_lock", async function(){
+   *        const dat = await read_from_shared_resource();
+   *        await write_to_shared_resource(dat + 1);
+   *      )};
+   */
+  static async doAtomic(
+    name: string,
+    cb: () => Promise<void>,
+  ): Promise<void> {
+    if (!Mutex.mus[name]) {
+      Mutex.mus[name] = new Mutex();
+    }
+    await Mutex.mus[name].lock();
+    try {
+      await cb();
+    } finally {
+      Mutex.mus[name].unlock();
+      if(!Mutex.mus[name].locked){//nobody waiting?
+        delete Mutex.mus[name];
+      }
+    }
+  }
+}

--- a/std/async/mutex.ts
+++ b/std/async/mutex.ts
@@ -43,20 +43,17 @@ export class Mutex implements Locker {
   } = {};
 
   /**
-   *  Execute an async function that cannot be interrupted by 
-   *  functions requesting a lock of the same name.  
+   *  Execute an async function that cannot be interrupted by
+   *  functions requesting a lock of the same name.
    *
-   *  Example usage: 
+   *  Example usage:
    *
    *      await doAtomic("name_of_lock", async function(){
    *        const dat = await read_from_shared_resource();
    *        await write_to_shared_resource(dat + 1);
    *      )};
    */
-  static async doAtomic(
-    name: string,
-    cb: () => Promise<void>,
-  ): Promise<void> {
+  static async doAtomic(name: string, cb: () => Promise<void>): Promise<void> {
     if (!Mutex.mus[name]) {
       Mutex.mus[name] = new Mutex();
     }
@@ -65,7 +62,8 @@ export class Mutex implements Locker {
       await cb();
     } finally {
       Mutex.mus[name].unlock();
-      if (!Mutex.mus[name].locked) { //nobody waiting?
+      if (!Mutex.mus[name].locked) {
+        //nobody waiting?
         delete Mutex.mus[name];
       }
     }

--- a/std/async/mutex_test.ts
+++ b/std/async/mutex_test.ts
@@ -2,7 +2,6 @@
 import { Mutex } from "./mutex.ts";
 import { delay as sleep } from "./delay.ts";
 
-
 let x = 0;
 async function needsLockX(): Promise<void> {
   const oldX: number = x;
@@ -79,13 +78,11 @@ Deno.test("without locks (2)", async function () {
   ]);
   if (x !== 1 || y !== 1) {
     throw new Error(
-      "Code without locks behaves unexpectedly: " + 
-      "x = " + x + ", y = " + y
+      "Code without locks behaves unexpectedly: " +
+        "x = " + x + ", y = " + y,
     );
   }
 });
-
-
 
 Deno.test("doAtomic with multiple named locks", async function () {
   x = 0;
@@ -148,27 +145,26 @@ Deno.test("deadlock should not occur if locked function throws", async function 
   await testDonep; // wait for timeout to fire before exiting test
 });
 
-
-Deno.test('reusing a lock name should be possible', async function(){
+Deno.test("reusing a lock name should be possible", async function () {
   x = 0;
 
-  await Mutex.doAtomic('x', needsLockX);
+  await Mutex.doAtomic("x", needsLockX);
   await sleep(100);
-  await Mutex.doAtomic('x', needsLockX);
+  await Mutex.doAtomic("x", needsLockX);
 
-  if(x !== 2){
-    throw new Error('Race condition detected: x = ');
+  if (x !== 2) {
+    throw new Error("Race condition detected: x = ");
   }
 });
 
-Deno.test('reusing a lock should be possible', async function(){
+Deno.test("reusing a lock should be possible", async function () {
   x = 0;
 
   //Mutex.doAtomic does some cleanup that could mask errors
   const recycledMu = new Mutex();
-  async function recyclingDoAtomic(cb: () => void): Promise<void>{
+  async function recyclingDoAtomic(cb: () => void): Promise<void> {
     await recycledMu.lock();
-    try{
+    try {
       await cb();
     } finally {
       recycledMu.unlock();
@@ -179,65 +175,55 @@ Deno.test('reusing a lock should be possible', async function(){
   await sleep(100);
   await recyclingDoAtomic(needsLockX);
 
-  if(x !== 2){
-    throw new Error('Race condition detected: x = ');
+  if (x !== 2) {
+    throw new Error("Race condition detected: x = ");
   }
 });
 
-
-
-Deno.test('should not be allowed to unlock before locking', function(){
-
+Deno.test("should not be allowed to unlock before locking", function () {
   const mu = new Mutex();
-  try{
+  try {
     mu.unlock();
   } catch (e) {
     return;
   }
 
-  throw new Error('no error when releasing nonexistent lock');
+  throw new Error("no error when releasing nonexistent lock");
 });
 
-
-Deno.test('Should not be allowed to unlock the same lock twice', async function(){
-
+Deno.test("Should not be allowed to unlock the same lock twice", async function () {
   const mu = new Mutex();
   await mu.lock();
   mu.unlock();
-  try{
+  try {
     mu.unlock();
   } catch (e) {
     return;
   }
-  throw new Error('no error when double unlocking');
-
+  throw new Error("no error when double unlocking");
 });
 
-
-Deno.test('locking twice should deadlock', async function(){
+Deno.test("locking twice should deadlock", async function () {
   const mu = new Mutex();
   await mu.lock();
-  let done = function(): void {};
-  const donep = new Promise<void>(function(res, _){
+  let done = function (): void {};
+  const donep = new Promise<void>(function (res, _) {
     done = res;
   });
-  const lockOrTimeoutp = new Promise<void>(function(res,rej){
-    sleep(200).then(()=>{res();done();});
+  const lockOrTimeoutp = new Promise<void>(function (res, rej) {
+    sleep(200).then(() => {
+      res();
+      done();
+    });
     mu.lock()
-      .then(()=>{rej('No deadlock detected');})
-      .catch(()=>{rej('No deadlock detected');});
+      .then(() => {
+        rej("No deadlock detected");
+      })
+      .catch(() => {
+        rej("No deadlock detected");
+      });
   });
 
   await lockOrTimeoutp;
   await donep;
 });
-
-
-
-
-
-
-
-
-
-

--- a/std/async/mutex_test.ts
+++ b/std/async/mutex_test.ts
@@ -1,0 +1,243 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { Mutex } from "./mutex.ts";
+import { delay as sleep } from "./delay.ts";
+
+
+let x = 0;
+async function needsLockX(): Promise<void> {
+  const oldX: number = x;
+  await sleep(10);
+  x = oldX + 1;
+}
+
+async function isLockedX(): Promise<void> {
+  await Mutex.doAtomic("x", needsLockX);
+}
+
+let y = 0;
+async function needsLockY(): Promise<void> {
+  const oldY: number = y;
+  await sleep(10);
+  y = oldY + 1;
+}
+
+async function isLockedY(): Promise<void> {
+  await Mutex.doAtomic("y", needsLockY);
+}
+
+let z = 0;
+async function needsLockButThrows(): Promise<void> {
+  const zOld = z;
+  await sleep(10);
+  z = zOld + 1;
+  throw new Error("Some error");
+}
+
+async function lockFail(): Promise<void> {
+  try {
+    await Mutex.doAtomic("z", needsLockButThrows);
+  } catch (e) {
+  }
+}
+
+Deno.test("code without locks is subject to race conditions", async function () {
+  x = 0;
+  await Promise.all([needsLockX(), needsLockX(), needsLockX()]);
+  if (x !== 1) {
+    throw new Error("Code without locks behaves unexpectedly: x = " + x);
+  }
+});
+
+Deno.test("doAtomic prevents race conditions", async function () {
+  x = 0;
+  await Promise.all([isLockedX(), isLockedX(), isLockedX()]);
+  if (x !== 3) {
+    throw new Error("race condition detected: x = " + x);
+  }
+});
+
+Deno.test("without locks (2)", async function () {
+  x = 0;
+  y = 0;
+  await Promise.all([
+    needsLockY(),
+    needsLockX(),
+    needsLockY(),
+    needsLockX(),
+    needsLockY(),
+    needsLockX(),
+    needsLockY(),
+    needsLockY(),
+    needsLockY(),
+    needsLockY(),
+    needsLockX(),
+    needsLockX(),
+    needsLockY(),
+    needsLockY(),
+    needsLockY(),
+    needsLockY(),
+  ]);
+  if (x !== 1 || y !== 1) {
+    throw new Error(
+      "Code without locks behaves unexpectedly: " + 
+      "x = " + x + ", y = " + y
+    );
+  }
+});
+
+
+
+Deno.test("doAtomic with multiple named locks", async function () {
+  x = 0;
+  y = 0;
+  await Promise.all([
+    isLockedY(),
+    isLockedX(),
+    isLockedY(),
+    isLockedX(),
+    isLockedY(),
+    isLockedX(),
+    isLockedY(),
+    isLockedY(),
+    isLockedY(),
+    isLockedY(),
+    isLockedX(),
+    isLockedX(),
+    isLockedY(),
+    isLockedY(),
+    isLockedY(),
+    isLockedY(),
+  ]);
+  if (x !== 5 || y !== 11) {
+    throw new Error("Race condition detected: x = " + x + ", y = " + y);
+  }
+});
+
+Deno.test("deadlock should not occur if locked function throws", async function () {
+  z = 0;
+  const multiFailp = Promise.all([lockFail(), lockFail(), lockFail()]);
+
+  let testDonec = function (): void {};
+
+  const testDonep = new Promise<void>(function (res, _) {
+    testDonec = res;
+  });
+
+  const multiFailOrTimeoutp = new Promise<void>(function (res, rej) {
+    multiFailp.then(() => {
+      res();
+    }).catch(() => {
+      rej();
+    });
+    // 10ms * 3 = should only take ~30ms.  100ms for some breathing room
+    sleep(100).then(function () {
+      rej(); //will be ignored if the above fired first
+      testDonec();
+    });
+  });
+
+  try {
+    await multiFailOrTimeoutp;
+  } catch (e) {
+    throw new Error("Deadlock Detected");
+  }
+  if (z !== 3) {
+    throw new Error("Race condition detected: z = " + z);
+  }
+
+  await testDonep; // wait for timeout to fire before exiting test
+});
+
+
+Deno.test('reusing a lock name should be possible', async function(){
+  x = 0;
+
+  await Mutex.doAtomic('x', needsLockX);
+  await sleep(100);
+  await Mutex.doAtomic('x', needsLockX);
+
+  if(x !== 2){
+    throw new Error('Race condition detected: x = ');
+  }
+});
+
+Deno.test('reusing a lock should be possible', async function(){
+  x = 0;
+
+  //Mutex.doAtomic does some cleanup that could mask errors
+  const recycledMu = new Mutex();
+  async function recyclingDoAtomic(cb: () => void): Promise<void>{
+    await recycledMu.lock();
+    try{
+      await cb();
+    } finally {
+      recycledMu.unlock();
+    }
+  }
+
+  await recyclingDoAtomic(needsLockX);
+  await sleep(100);
+  await recyclingDoAtomic(needsLockX);
+
+  if(x !== 2){
+    throw new Error('Race condition detected: x = ');
+  }
+});
+
+
+
+Deno.test('should not be allowed to unlock before locking', function(){
+
+  const mu = new Mutex();
+  try{
+    mu.unlock();
+  } catch (e) {
+    return;
+  }
+
+  throw new Error('no error when releasing nonexistent lock');
+});
+
+
+Deno.test('Should not be allowed to unlock the same lock twice', async function(){
+
+  const mu = new Mutex();
+  await mu.lock();
+  mu.unlock();
+  try{
+    mu.unlock();
+  } catch (e) {
+    return;
+  }
+  throw new Error('no error when double unlocking');
+
+});
+
+
+Deno.test('locking twice should deadlock', async function(){
+  const mu = new Mutex();
+  await mu.lock();
+  let done = function(): void {};
+  const donep = new Promise<void>(function(res, _){
+    done = res;
+  });
+  const lockOrTimeoutp = new Promise<void>(function(res,rej){
+    sleep(200).then(()=>{res();done();});
+    mu.lock()
+      .then(()=>{rej('No deadlock detected');})
+      .catch(()=>{rej('No deadlock detected');});
+  });
+
+  await lockOrTimeoutp;
+  await donep;
+});
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
This adds a Mutex object which can help when executing multiple async functions that access the same shared resource.  

In addition to the basic "lock" and "unlock" functions, this also includes "doAtomic," a wrapper function which accepts a callback and manages locks automatically.  