### PR TITLE
feature: add sync version of BufReader and TextProtoReader

### DIFF
--- a/std/io/README.md
+++ b/std/io/README.md
@@ -48,11 +48,11 @@ for (const line of readLinesSync(new StringReader("Lorem\nipsum\n"))) {
 
 **Output:**
 
-````text
+```text
 read line Lorem
 read line ipsum
-read line 
-````
+read line
+```
 
 ### readStringDelim
 

--- a/std/io/README.md
+++ b/std/io/README.md
@@ -33,6 +33,27 @@ import * as path from "https://deno.land/std/path/mod.ts";
 ## Rest of the file
 ````
 
+### readLinesSync
+
+Synchronous read reader[like file], line by line
+
+```ts title="readLinesSync"
+import { readLinesSync } from "./bufio.ts";
+import { StringReader } from "./readers.ts";
+
+for (const line of readLinesSync(new StringReader("Lorem\nipsum\n"))) {
+  console.log("read line", line);
+}
+```
+
+**Output:**
+
+````text
+read line Lorem
+read line ipsum
+read line 
+````
+
 ### readStringDelim
 
 Read reader`[like file]` chunk by chunk, splitting based on delimiter.

--- a/std/io/_iotestSync.ts
+++ b/std/io/_iotestSync.ts
@@ -1,0 +1,53 @@
+// Ported to Deno from
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+type ReaderSync = Deno.ReaderSync;
+
+/** OneByteReader returns a ReaderSync that implements
+ * each non-empty Read by reading one byte from r.
+ */
+export class OneByteReader implements ReaderSync {
+  constructor(readonly r: ReaderSync) {}
+
+  readSync(p: Uint8Array): number | null {
+    if (p.byteLength === 0) {
+      return 0;
+    }
+    if (!(p instanceof Uint8Array)) {
+      throw Error("expected Uint8Array");
+    }
+    return this.r.readSync(p.subarray(0, 1));
+  }
+}
+
+/** HalfReader returns a ReaderSync that implements Read
+ * by reading half as many requested bytes from r.
+ */
+export class HalfReader implements ReaderSync {
+  constructor(readonly r: ReaderSync) {}
+
+  readSync(p: Uint8Array): number | null {
+    if (!(p instanceof Uint8Array)) {
+      throw Error("expected Uint8Array");
+    }
+    const half = Math.floor((p.byteLength + 1) / 2);
+    return this.r.readSync(p.subarray(0, half));
+  }
+}
+
+/** TimeOutReader returns `Deno.errors.TimedOut` on the second read
+ * with no data. Subsequent calls to read succeed.
+ */
+export class TimeOutReader implements ReaderSync {
+  count = 0;
+  constructor(readonly r: ReaderSync) {}
+
+  readSync(p: Uint8Array): number | null {
+    this.count++;
+    if (this.count === 2) {
+      throw new Deno.errors.TimedOut();
+    }
+    return this.r.readSync(p);
+  }
+}

--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -5,6 +5,7 @@
 
 type Reader = Deno.Reader;
 type Writer = Deno.Writer;
+type ReaderSync = Deno.ReaderSync;
 type WriterSync = Deno.WriterSync;
 import { charCode, copyBytes } from "./util.ts";
 import { assert } from "../_util/assert.ts";
@@ -405,6 +406,375 @@ export class BufReader implements Reader {
   }
 }
 
+/** BufReaderSync implements buffering for a ReaderSync object. */
+export class BufReaderSync implements ReaderSync {
+  private buf!: Uint8Array;
+  private rd!: ReaderSync; // Reader provided by caller.
+  private r = 0; // buf read position.
+  private w = 0; // buf write position.
+  private eof = false;
+  // private lastByte: number;
+  // private lastCharSize: number;
+
+  /** return new BufReaderSync unless r is BufReaderSync */
+  static create(r: ReaderSync, size: number = DEFAULT_BUF_SIZE): BufReaderSync {
+    return r instanceof BufReaderSync ? r : new BufReaderSync(r, size);
+  }
+
+  constructor(rd: ReaderSync, size: number = DEFAULT_BUF_SIZE) {
+    if (size < MIN_BUF_SIZE) {
+      size = MIN_BUF_SIZE;
+    }
+    this._reset(new Uint8Array(size), rd);
+  }
+
+  /** Returns the size of the underlying buffer in bytes. */
+  size(): number {
+    return this.buf.byteLength;
+  }
+
+  buffered(): number {
+    return this.w - this.r;
+  }
+
+  // Reads a new chunk into the buffer.
+  private _fill(): void {
+    // Slide existing data to beginning.
+    if (this.r > 0) {
+      this.buf.copyWithin(0, this.r, this.w);
+      this.w -= this.r;
+      this.r = 0;
+    }
+
+    if (this.w >= this.buf.byteLength) {
+      throw Error("bufio: tried to fill full buffer");
+    }
+
+    // Read new data: try a limited number of times.
+    for (let i = MAX_CONSECUTIVE_EMPTY_READS; i > 0; i--) {
+      const rr = this.rd.readSync(this.buf.subarray(this.w));
+      if (rr === null) {
+        this.eof = true;
+        return;
+      }
+      assert(rr >= 0, "negative read");
+      this.w += rr;
+      if (rr > 0) {
+        return;
+      }
+    }
+
+    throw new Error(
+      `No progress after ${MAX_CONSECUTIVE_EMPTY_READS} read() calls`
+    );
+  }
+
+  /** Discards any buffered data, resets all state, and switches
+   * the buffered reader to read from r.
+   */
+  reset(r: ReaderSync): void {
+    this._reset(this.buf, r);
+  }
+
+  private _reset(buf: Uint8Array, rd: ReaderSync): void {
+    this.buf = buf;
+    this.rd = rd;
+    this.eof = false;
+    // this.lastByte = -1;
+    // this.lastCharSize = -1;
+  }
+
+  /** reads data into p.
+   * It returns the number of bytes read into p.
+   * The bytes are taken from at most one Read on the underlying Reader,
+   * hence n may be less than len(p).
+   * To read exactly len(p) bytes, use io.ReadFull(b, p).
+   */
+  readSync(p: Uint8Array): number | null {
+    let rr: number | null = p.byteLength;
+    if (p.byteLength === 0) return rr;
+
+    if (this.r === this.w) {
+      if (p.byteLength >= this.buf.byteLength) {
+        // Large read, empty buffer.
+        // Read directly into p to avoid copy.
+        const rr = this.rd.readSync(p);
+        const nread = rr ?? 0;
+        assert(nread >= 0, "negative read");
+        // if (rr.nread > 0) {
+        //   this.lastByte = p[rr.nread - 1];
+        //   this.lastCharSize = -1;
+        // }
+        return rr;
+      }
+
+      // One read.
+      // Do not use this.fill, which will loop.
+      this.r = 0;
+      this.w = 0;
+      rr = this.rd.readSync(this.buf);
+      if (rr === 0 || rr === null) return rr;
+      assert(rr >= 0, "negative read");
+      this.w += rr;
+    }
+
+    // copy as much as we can
+    const copied = copyBytes(this.buf.subarray(this.r, this.w), p, 0);
+    this.r += copied;
+    // this.lastByte = this.buf[this.r - 1];
+    // this.lastCharSize = -1;
+    return copied;
+  }
+
+  /** reads exactly `p.length` bytes into `p`.
+   *
+   * If successful, `p` is returned.
+   *
+   * If the end of the underlying stream has been reached, and there are no more
+   * bytes available in the buffer, `readFull()` returns `null` instead.
+   *
+   * An error is thrown if some bytes could be read, but not enough to fill `p`
+   * entirely before the underlying stream reported an error or EOF. Any error
+   * thrown will have a `partial` property that indicates the slice of the
+   * buffer that has been successfully filled with data.
+   *
+   * Ported from https://golang.org/pkg/io/#ReadFull
+   */
+  readFull(p: Uint8Array): Uint8Array | null {
+    let bytesRead = 0;
+    while (bytesRead < p.length) {
+      try {
+        const rr = this.readSync(p.subarray(bytesRead));
+        if (rr === null) {
+          if (bytesRead === 0) {
+            return null;
+          } else {
+            throw new PartialReadError();
+          }
+        }
+        bytesRead += rr;
+      } catch (err) {
+        err.partial = p.subarray(0, bytesRead);
+        throw err;
+      }
+    }
+    return p;
+  }
+
+  /** Returns the next byte [0, 255] or `null`. */
+  readByte(): number | null {
+    while (this.r === this.w) {
+      if (this.eof) return null;
+      this._fill(); // buffer is empty.
+    }
+    const c = this.buf[this.r];
+    this.r++;
+    // this.lastByte = c;
+    return c;
+  }
+
+  /** readString() reads until the first occurrence of delim in the input,
+   * returning a string containing the data up to and including the delimiter.
+   * If ReadString encounters an error before finding a delimiter,
+   * it returns the data read before the error and the error itself
+   * (often `null`).
+   * ReadString returns err != nil if and only if the returned data does not end
+   * in delim.
+   * For simple uses, a Scanner may be more convenient.
+   */
+  readString(delim: string): string | null {
+    if (delim.length !== 1) {
+      throw new Error("Delimiter should be a single character");
+    }
+    const buffer = this.readSlice(delim.charCodeAt(0));
+    if (buffer === null) return null;
+    return new TextDecoder().decode(buffer);
+  }
+
+  /** `readLine()` is a low-level line-reading primitive. Most callers should
+   * use `readString('\n')` instead or use a Scanner.
+   *
+   * `readLine()` tries to return a single line, not including the end-of-line
+   * bytes. If the line was too long for the buffer then `more` is set and the
+   * beginning of the line is returned. The rest of the line will be returned
+   * from future calls. `more` will be false when returning the last fragment
+   * of the line. The returned buffer is only valid until the next call to
+   * `readLine()`.
+   *
+   * The text returned from ReadLine does not include the line end ("\r\n" or
+   * "\n").
+   *
+   * When the end of the underlying stream is reached, the final bytes in the
+   * stream are returned. No indication or error is given if the input ends
+   * without a final line end. When there are no more trailing bytes to read,
+   * `readLine()` returns `null`.
+   *
+   * Calling `unreadByte()` after `readLine()` will always unread the last byte
+   * read (possibly a character belonging to the line end) even if that byte is
+   * not part of the line returned by `readLine()`.
+   */
+  readLine(): ReadLineResult | null {
+    let line: Uint8Array | null;
+
+    try {
+      line = this.readSlice(LF);
+    } catch (err) {
+      let { partial } = err;
+      assert(
+        partial instanceof Uint8Array,
+        "bufio: caught error from `readSlice()` without `partial` property"
+      );
+
+      // Don't throw if `readSlice()` failed with `BufferFullError`, instead we
+      // just return whatever is available and set the `more` flag.
+      if (!(err instanceof BufferFullError)) {
+        throw err;
+      }
+
+      // Handle the case where "\r\n" straddles the buffer.
+      if (
+        !this.eof &&
+        partial.byteLength > 0 &&
+        partial[partial.byteLength - 1] === CR
+      ) {
+        // Put the '\r' back on buf and drop it from line.
+        // Let the next call to ReadLine check for "\r\n".
+        assert(this.r > 0, "bufio: tried to rewind past start of buffer");
+        this.r--;
+        partial = partial.subarray(0, partial.byteLength - 1);
+      }
+
+      return { line: partial, more: !this.eof };
+    }
+
+    if (line === null) {
+      return null;
+    }
+
+    if (line.byteLength === 0) {
+      return { line, more: false };
+    }
+
+    if (line[line.byteLength - 1] == LF) {
+      let drop = 1;
+      if (line.byteLength > 1 && line[line.byteLength - 2] === CR) {
+        drop = 2;
+      }
+      line = line.subarray(0, line.byteLength - drop);
+    }
+    return { line, more: false };
+  }
+
+  /** `readSlice()` reads until the first occurrence of `delim` in the input,
+   * returning a slice pointing at the bytes in the buffer. The bytes stop
+   * being valid at the next read.
+   *
+   * If `readSlice()` encounters an error before finding a delimiter, or the
+   * buffer fills without finding a delimiter, it throws an error with a
+   * `partial` property that contains the entire buffer.
+   *
+   * If `readSlice()` encounters the end of the underlying stream and there are
+   * any bytes left in the buffer, the rest of the buffer is returned. In other
+   * words, EOF is always treated as a delimiter. Once the buffer is empty,
+   * it returns `null`.
+   *
+   * Because the data returned from `readSlice()` will be overwritten by the
+   * next I/O operation, most clients should use `readString()` instead.
+   */
+  readSlice(delim: number): Uint8Array | null {
+    let s = 0; // search start index
+    let slice: Uint8Array | undefined;
+
+    while (true) {
+      // Search buffer.
+      let i = this.buf.subarray(this.r + s, this.w).indexOf(delim);
+      if (i >= 0) {
+        i += s;
+        slice = this.buf.subarray(this.r, this.r + i + 1);
+        this.r += i + 1;
+        break;
+      }
+
+      // EOF?
+      if (this.eof) {
+        if (this.r === this.w) {
+          return null;
+        }
+        slice = this.buf.subarray(this.r, this.w);
+        this.r = this.w;
+        break;
+      }
+
+      // Buffer full?
+      if (this.buffered() >= this.buf.byteLength) {
+        this.r = this.w;
+        // #4521 The internal buffer should not be reused across reads because it causes corruption of data.
+        const oldbuf = this.buf;
+        const newbuf = this.buf.slice(0);
+        this.buf = newbuf;
+        throw new BufferFullError(oldbuf);
+      }
+
+      s = this.w - this.r; // do not rescan area we scanned before
+
+      // Buffer is not full.
+      try {
+        this._fill();
+      } catch (err) {
+        err.partial = slice;
+        throw err;
+      }
+    }
+
+    // Handle last byte, if any.
+    // const i = slice.byteLength - 1;
+    // if (i >= 0) {
+    //   this.lastByte = slice[i];
+    //   this.lastCharSize = -1
+    // }
+
+    return slice;
+  }
+
+  /** `peek()` returns the next `n` bytes without advancing the reader. The
+   * bytes stop being valid at the next read call.
+   *
+   * When the end of the underlying stream is reached, but there are unread
+   * bytes left in the buffer, those bytes are returned. If there are no bytes
+   * left in the buffer, it returns `null`.
+   *
+   * If an error is encountered before `n` bytes are available, `peek()` throws
+   * an error with the `partial` property set to a slice of the buffer that
+   * contains the bytes that were available before the error occurred.
+   */
+  peek(n: number): Uint8Array | null {
+    if (n < 0) {
+      throw Error("negative count");
+    }
+
+    let avail = this.w - this.r;
+    while (avail < n && avail < this.buf.byteLength && !this.eof) {
+      try {
+        this._fill();
+      } catch (err) {
+        err.partial = this.buf.subarray(this.r, this.w);
+        throw err;
+      }
+      avail = this.w - this.r;
+    }
+
+    if (avail === 0 && this.eof) {
+      return null;
+    } else if (avail < n && this.eof) {
+      return this.buf.subarray(this.r, this.r + avail);
+    } else if (avail < n) {
+      throw new BufferFullError(this.buf.subarray(this.r, this.w));
+    }
+
+    return this.buf.subarray(this.r, this.r + n);
+  }
+}
+
 abstract class AbstractBufBase {
   buf!: Uint8Array;
   usedBufferBytes = 0;
@@ -704,6 +1074,65 @@ export async function* readDelim(
   }
 }
 
+/** Read delimited bytes from a Reader. */
+export function* readDelimSync(
+  reader: ReaderSync,
+  delim: Uint8Array,
+): IterableIterator<Uint8Array> {
+  // Avoid unicode problems
+  const delimLen = delim.length;
+  const delimLPS = createLPS(delim);
+
+  let inputBuffer = new Deno.Buffer();
+  const inspectArr = new Uint8Array(Math.max(1024, delimLen + 1));
+
+  // Modified KMP
+  let inspectIndex = 0;
+  let matchIndex = 0;
+  while (true) {
+    const result = reader.readSync(inspectArr);
+    if (result === null) {
+      // Yield last chunk.
+      yield inputBuffer.bytes();
+      return;
+    }
+    if ((result as number) < 0) {
+      // Discard all remaining and silently fail.
+      return;
+    }
+    const sliceRead = inspectArr.subarray(0, result as number);
+    Deno.writeAllSync(inputBuffer, sliceRead);
+
+    let sliceToProcess = inputBuffer.bytes();
+    while (inspectIndex < sliceToProcess.length) {
+      if (sliceToProcess[inspectIndex] === delim[matchIndex]) {
+        inspectIndex++;
+        matchIndex++;
+        if (matchIndex === delimLen) {
+          // Full match
+          const matchEnd = inspectIndex - delimLen;
+          const readyBytes = sliceToProcess.subarray(0, matchEnd);
+          // Copy
+          const pendingBytes = sliceToProcess.slice(inspectIndex);
+          yield readyBytes;
+          // Reset match, different from KMP.
+          sliceToProcess = pendingBytes;
+          inspectIndex = 0;
+          matchIndex = 0;
+        }
+      } else {
+        if (matchIndex === 0) {
+          inspectIndex++;
+        } else {
+          matchIndex = delimLPS[matchIndex - 1];
+        }
+      }
+    }
+    // Keep inspectIndex and matchIndex.
+    inputBuffer = new Deno.Buffer(sliceToProcess);
+  }
+}
+
 /** Read delimited strings from a Reader. */
 export async function* readStringDelim(
   reader: Reader,
@@ -716,10 +1145,30 @@ export async function* readStringDelim(
   }
 }
 
+/** Read delimited strings from a Reader. */
+export function* readStringDelimSync(
+  reader: ReaderSync,
+  delim: string
+): IterableIterator<string> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  for (const chunk of readDelimSync(reader, encoder.encode(delim))) {
+    yield decoder.decode(chunk);
+  }
+}
+
 /** Read strings line-by-line from a Reader. */
 // eslint-disable-next-line require-await
 export async function* readLines(
   reader: Reader
 ): AsyncIterableIterator<string> {
   yield* readStringDelim(reader, "\n");
+}
+
+/** Read strings line-by-line from a Reader. */
+// eslint-disable-next-line require-await
+export function* readLinesSync(
+  reader: ReaderSync
+): IterableIterator<string> {
+  yield* readStringDelimSync(reader, "\n");
 }

--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -1077,7 +1077,7 @@ export async function* readDelim(
 /** Read delimited bytes from a Reader. */
 export function* readDelimSync(
   reader: ReaderSync,
-  delim: Uint8Array,
+  delim: Uint8Array
 ): IterableIterator<Uint8Array> {
   // Avoid unicode problems
   const delimLen = delim.length;
@@ -1167,8 +1167,6 @@ export async function* readLines(
 
 /** Read strings line-by-line from a Reader. */
 // eslint-disable-next-line require-await
-export function* readLinesSync(
-  reader: ReaderSync
-): IterableIterator<string> {
+export function* readLinesSync(reader: ReaderSync): IterableIterator<string> {
   yield* readStringDelimSync(reader, "\n");
 }

--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -7,6 +7,7 @@ type Reader = Deno.Reader;
 type Writer = Deno.Writer;
 type ReaderSync = Deno.ReaderSync;
 type WriterSync = Deno.WriterSync;
+type ReaderMaybeSync = Reader | ReaderSync;
 import { charCode, copyBytes } from "./util.ts";
 import { assert } from "../_util/assert.ts";
 
@@ -37,26 +38,26 @@ export interface ReadLineResult {
   more: boolean;
 }
 
-/** BufReader implements buffering for a Reader object. */
-export class BufReader implements Reader {
-  private buf!: Uint8Array;
-  private rd!: Reader; // Reader provided by caller.
-  private r = 0; // buf read position.
-  private w = 0; // buf write position.
-  private eof = false;
+/** AbstractBufReaderBase implements buffering for a Reader or ReaderSync object. */
+class AbstractBufReaderBase {
+  protected _doSync!: boolean; // concrete derived class must shadow and set
+  protected buf!: Uint8Array;
+  protected rd!: ReaderMaybeSync; // Reader provided by caller.
+  protected bufRdPos = 0; // buf read position.
+  protected bufWrtPos = 0; // buf write position.
+  protected eof = false;
   // private lastByte: number;
   // private lastCharSize: number;
 
-  /** return new BufReader unless r is BufReader */
-  static create(r: Reader, size: number = DEFAULT_BUF_SIZE): BufReader {
-    return r instanceof BufReader ? r : new BufReader(r, size);
+  private _promiseIfAsync(a: any) {
+    return this._doSync ? a : Promise.resolve(a);
   }
 
-  constructor(rd: Reader, size: number = DEFAULT_BUF_SIZE) {
+  constructor(rd: ReaderMaybeSync, size: number = DEFAULT_BUF_SIZE) {
     if (size < MIN_BUF_SIZE) {
       size = MIN_BUF_SIZE;
     }
-    this._reset(new Uint8Array(size), rd);
+    this._resetMaybeSync(new Uint8Array(size), rd);
   }
 
   /** Returns the size of the underlying buffer in bytes. */
@@ -64,50 +65,61 @@ export class BufReader implements Reader {
     return this.buf.byteLength;
   }
 
+  /** Returns the amount buffered. */
   buffered(): number {
-    return this.w - this.r;
+    return this.bufWrtPos - this.bufRdPos;
   }
 
   // Reads a new chunk into the buffer.
-  private async _fill(): Promise<void> {
+  protected _fillMaybeSync(): void | Promise<void> {
     // Slide existing data to beginning.
-    if (this.r > 0) {
-      this.buf.copyWithin(0, this.r, this.w);
-      this.w -= this.r;
-      this.r = 0;
+    if (this.bufRdPos > 0) {
+      this.buf.copyWithin(0, this.bufRdPos, this.bufWrtPos);
+      this.bufWrtPos -= this.bufRdPos;
+      this.bufRdPos = 0;
     }
 
-    if (this.w >= this.buf.byteLength) {
+    if (this.bufWrtPos >= this.buf.byteLength) {
       throw Error("bufio: tried to fill full buffer");
     }
 
     // Read new data: try a limited number of times.
-    for (let i = MAX_CONSECUTIVE_EMPTY_READS; i > 0; i--) {
-      const rr = await this.rd.read(this.buf.subarray(this.w));
-      if (rr === null) {
-        this.eof = true;
-        return;
+    const loopRecur = (attemptsRemaining: number): void | Promise<void> => {
+      if (attemptsRemaining <= 0) {
+        throw new Error(
+          `No progress after ${MAX_CONSECUTIVE_EMPTY_READS} read() calls`
+        );
       }
-      assert(rr >= 0, "negative read");
-      this.w += rr;
-      if (rr > 0) {
-        return;
+      const checkRecur = (rr: number | null) => {
+        if (rr === null) {
+          this.eof = true;
+          return;
+        }
+        assert(rr >= 0, "negative read");
+        this.bufWrtPos += rr;
+        if (rr > 0) {
+          return;
+        }
+        return loopRecur(attemptsRemaining - 1);
+      };
+      if (this._doSync) {
+        const rr = (this.rd as ReaderSync).readSync(
+          this.buf.subarray(this.bufWrtPos)
+        );
+        return checkRecur(rr);
+      } else {
+        const rr = (this.rd as Reader).read(this.buf.subarray(this.bufWrtPos));
+        return rr.then(checkRecur);
       }
-    }
-
-    throw new Error(
-      `No progress after ${MAX_CONSECUTIVE_EMPTY_READS} read() calls`
-    );
+    };
+    let ret = loopRecur(MAX_CONSECUTIVE_EMPTY_READS);
+    return this._promiseIfAsync(ret);
   }
 
   /** Discards any buffered data, resets all state, and switches
-   * the buffered reader to read from r.
+   * the buffered reader to read from rd.
    */
-  reset(r: Reader): void {
-    this._reset(this.buf, r);
-  }
-
-  private _reset(buf: Uint8Array, rd: Reader): void {
+  protected _resetMaybeSync(buf: Uint8Array, rd: ReaderMaybeSync): void {
     this.buf = buf;
     this.rd = rd;
     this.eof = false;
@@ -117,44 +129,463 @@ export class BufReader implements Reader {
 
   /** reads data into p.
    * It returns the number of bytes read into p.
-   * The bytes are taken from at most one Read on the underlying Reader,
+   * The bytes are taken from at most one Read on the underlying ReaderMaybeSync,
    * hence n may be less than len(p).
    * To read exactly len(p) bytes, use io.ReadFull(b, p).
    */
-  async read(p: Uint8Array): Promise<number | null> {
+  protected readMaybeSync(
+    p: Uint8Array
+  ): number | null | Promise<number | null> {
     let rr: number | null = p.byteLength;
-    if (p.byteLength === 0) return rr;
+    if (p.byteLength === 0) return this._promiseIfAsync(rr);
 
-    if (this.r === this.w) {
-      if (p.byteLength >= this.buf.byteLength) {
-        // Large read, empty buffer.
-        // Read directly into p to avoid copy.
-        const rr = await this.rd.read(p);
+    const greedyCopy = () => {
+      // copy as much as we can
+      const copied = copyBytes(
+        this.buf.subarray(this.bufRdPos, this.bufWrtPos),
+        p,
+        0
+      );
+      this.bufRdPos += copied;
+      // this.lastByte = this.buf[this.r - 1];
+      // this.lastCharSize = -1;
+      return this._promiseIfAsync(copied);
+    };
+
+    if (this.bufRdPos !== this.bufWrtPos) {
+      return greedyCopy();
+    } else if (p.byteLength >= this.buf.byteLength) {
+      // Large read, empty buffer.
+      // Read directly into p to avoid copy.
+      const checkRead = (rr: number | null) => {
         const nread = rr ?? 0;
         assert(nread >= 0, "negative read");
         // if (rr.nread > 0) {
         //   this.lastByte = p[rr.nread - 1];
         //   this.lastCharSize = -1;
         // }
-        return rr;
-      }
+        return this._promiseIfAsync(rr);
+      };
 
+      if (this._doSync) {
+        const rr = (this.rd as ReaderSync).readSync(p);
+        return checkRead(rr);
+      } else {
+        const rr = (this.rd as Reader).read(p);
+        return rr.then(checkRead);
+      }
+    } else {
       // One read.
       // Do not use this.fill, which will loop.
-      this.r = 0;
-      this.w = 0;
-      rr = await this.rd.read(this.buf);
-      if (rr === 0 || rr === null) return rr;
-      assert(rr >= 0, "negative read");
-      this.w += rr;
+      this.bufRdPos = 0;
+      this.bufWrtPos = 0;
+      const doOneRead = (rr: number | null) => {
+        if (rr === 0 || rr === null) {
+          return this._promiseIfAsync(rr);
+        } else {
+          assert(rr >= 0, "negative read");
+          this.bufWrtPos += rr;
+          return greedyCopy();
+        }
+      };
+
+      if (this._doSync) {
+        const rr = (this.rd as ReaderSync).readSync(this.buf);
+        return doOneRead(rr);
+      } else {
+        const rr = (this.rd as Reader).read(this.buf);
+        return rr.then(doOneRead);
+      }
+    }
+  }
+
+  /** reads exactly `p.length` bytes into `p`.
+   *
+   * If successful, `p` is returned.
+   *
+   * If the end of the underlying stream has been reached, and there are no more
+   * bytes available in the buffer, `readFull()` returns `null` instead.
+   *
+   * An error is thrown if some bytes could be read, but not enough to fill `p`
+   * entirely before the underlying stream reported an error or EOF. Any error
+   * thrown will have a `partial` property that indicates the slice of the
+   * buffer that has been successfully filled with data.
+   *
+   * Ported from https://golang.org/pkg/io/#ReadFull
+   */
+  protected readFullMaybeSync(
+    p: Uint8Array
+  ): Uint8Array | null | Promise<Uint8Array | null> {
+    let bytesRead = 0;
+    const handleRdErr = (err: any) => {
+      err.partial = p.subarray(0, bytesRead);
+      throw err;
+    };
+
+    const chkRdRecur = (rr: number | null) => {
+      if (rr === null) {
+        if (bytesRead === 0) {
+          return null;
+        } else {
+          throw new PartialReadError();
+        }
+      } else {
+        bytesRead += rr;
+      }
+      return loopRecur();
+    };
+
+    const loopRecur = (): Uint8Array | null | Promise<Uint8Array | null> => {
+      if (bytesRead >= p.length) {
+        return p;
+      }
+
+      if (this._doSync) {
+        try {
+          const rr = this.readMaybeSync(p.subarray(bytesRead)) as number | null;
+          return chkRdRecur(rr);
+        } catch (err) {
+          return handleRdErr(err);
+        }
+      } else {
+        const rr = this.readMaybeSync(p.subarray(bytesRead)) as Promise<
+          number | null
+        >;
+        return rr.then(chkRdRecur).catch(handleRdErr);
+      }
+    };
+    return this._promiseIfAsync(loopRecur());
+  }
+
+  /** Returns the next byte [0, 255] or `null`. */
+  protected readByteMaybeSync(): number | null | Promise<number | null> {
+    const loopRecur = (): number | null | Promise<number | null> => {
+      if (this.bufRdPos !== this.bufWrtPos) {
+        const c = this.buf[this.bufRdPos];
+        this.bufRdPos++;
+        // this.lastByte = c;
+        return c;
+      }
+
+      if (this.eof) {
+        return null;
+      } else {
+        if (this._doSync) {
+          this._fillMaybeSync(); // buffer is empty.
+          return loopRecur();
+        } else {
+          let prom = this._fillMaybeSync() as Promise<void>; // buffer is empty.
+          return prom.then(loopRecur);
+        }
+      }
+    };
+    return this._promiseIfAsync(loopRecur());
+  }
+
+  /** readStringMaybeSync() reads until the first occurrence of delim in the input,
+   * returning a string containing the data up to and including the delimiter.
+   * If readStringMaybeSync encounters an error before finding a delimiter,
+   * it returns the data read before the error and the error itself
+   * (often `null`).
+   * readStringMaybeSync returns err != nil if and only if the returned data does not end
+   * in delim.
+   * For simple uses, a Scanner may be more convenient.
+   */
+  protected readStringMaybeSync(
+    delim: string
+  ): string | null | Promise<string | null> {
+    if (delim.length !== 1) {
+      throw new Error("Delimiter should be a single character");
     }
 
-    // copy as much as we can
-    const copied = copyBytes(this.buf.subarray(this.r, this.w), p, 0);
-    this.r += copied;
-    // this.lastByte = this.buf[this.r - 1];
-    // this.lastCharSize = -1;
-    return copied;
+    const checkRead = (buffer: Uint8Array | null) => {
+      let ret;
+      if (buffer === null) {
+        ret = null;
+      } else {
+        ret = new TextDecoder().decode(buffer);
+      }
+      return this._promiseIfAsync(ret);
+    };
+
+    if (this._doSync) {
+      const buffer = this.readSliceMaybeSync(
+        delim.charCodeAt(0)
+      ) as Uint8Array | null;
+      return checkRead(buffer);
+    } else {
+      const buffer = this.readSliceMaybeSync(
+        delim.charCodeAt(0)
+      ) as Promise<Uint8Array | null>;
+      return buffer.then(checkRead);
+    }
+  }
+
+  /** `readLineMaybeSync()` is a low-level line-reading primitive. Most callers should
+   * use `readStringMaybeSync('\n')` instead or use a Scanner.
+   *
+   * `readLineMaybeSync()` tries to return a single line, not including the end-of-line
+   * bytes. If the line was too long for the buffer then `more` is set and the
+   * beginning of the line is returned. The rest of the line will be returned
+   * from future calls. `more` will be false when returning the last fragment
+   * of the line. The returned buffer is only valid until the next call to
+   * `readLine()`.
+   *
+   * The text returned from readLineMaybeSync does not include the line end ("\r\n" or
+   * "\n").
+   *
+   * When the end of the underlying stream is reached, the final bytes in the
+   * stream are returned. No indication or error is given if the input ends
+   * without a final line end. When there are no more trailing bytes to read,
+   * `readLineMaybeSync()` returns `null`.
+   *
+   * Calling `unreadByte()` after `readLineMaybeSync()` will always unread the last byte
+   * read (possibly a character belonging to the line end) even if that byte is
+   * not part of the line returned by `readLineMaybeSync()`.
+   */
+  protected readLineMaybeSync():
+    | ReadLineResult
+    | null
+    | Promise<ReadLineResult | null> {
+    const handleRdErr = (err: any) => {
+      let { partial } = err;
+      assert(
+        partial instanceof Uint8Array,
+        "bufio: caught error from `readSlice()` without `partial` property"
+      );
+
+      // Don't throw if `readSliceMaybeSync()` failed with `BufferFullError`, instead we
+      // just return whatever is available and set the `more` flag.
+      if (!(err instanceof BufferFullError)) {
+        throw err;
+      }
+
+      // Handle the case where "\r\n" straddles the buffer.
+      if (
+        !this.eof &&
+        partial.byteLength > 0 &&
+        partial[partial.byteLength - 1] === CR
+      ) {
+        // Put the '\r' back on buf and drop it from line.
+        // Let the next call to ReadLine check for "\r\n".
+        assert(
+          this.bufRdPos > 0,
+          "bufio: tried to rewind past start of buffer"
+        );
+        this.bufRdPos--;
+        partial = partial.subarray(0, partial.byteLength - 1);
+      }
+
+      return this._promiseIfAsync({ line: partial, more: !this.eof });
+    };
+
+    const rdLnRes = (line: Uint8Array | null) => {
+      let ret;
+      if (line === null) {
+        ret = null;
+      } else if (line.byteLength === 0) {
+        ret = { line, more: false };
+      } else {
+        if (line[line.byteLength - 1] == LF) {
+          let drop = 1;
+          if (line.byteLength > 1 && line[line.byteLength - 2] === CR) {
+            drop = 2;
+          }
+          line = line.subarray(0, line.byteLength - drop);
+        }
+        ret = { line, more: false };
+      }
+      return this._promiseIfAsync(ret);
+    };
+
+    if (this._doSync) {
+      let line;
+      try {
+        line = this.readSliceMaybeSync(LF) as Uint8Array | null;
+      } catch (err) {
+        return handleRdErr(err);
+      }
+      return rdLnRes(line);
+    } else {
+      let line = this.readSliceMaybeSync(LF) as Promise<Uint8Array | null>;
+      return line.then(rdLnRes, handleRdErr);
+    }
+  }
+
+  /** `readSliceMaybeSync()` reads until the first occurrence of `delim` in the input,
+   * returning a slice pointing at the bytes in the buffer. The bytes stop
+   * being valid at the next read.
+   *
+   * If `readSliceMaybeSync()` encounters an error before finding a delimiter, or the
+   * buffer fills without finding a delimiter, it throws an error with a
+   * `partial` property that contains the entire buffer.
+   *
+   * If `readSliceMaybeSync()` encounters the end of the underlying stream and there are
+   * any bytes left in the buffer, the rest of the buffer is returned. In other
+   * words, EOF is always treated as a delimiter. Once the buffer is empty,
+   * it returns `null`.
+   *
+   * Because the data returned from `readSliceMaybeSync()` will be overwritten by the
+   * next I/O operation, most clients should use `readStringMaybeSync()` instead.
+   */
+  protected readSliceMaybeSync(
+    delim: number
+  ): Uint8Array | null | Promise<Uint8Array | null> {
+    let s = 0; // search start index
+    let slice: Uint8Array | undefined;
+    const handleRdErr = (err: any) => {
+      err.partial = slice;
+      throw err;
+    };
+
+    const loopRecur = (): Uint8Array | null | Promise<Uint8Array | null> => {
+      // Search buffer.
+      let i = this.buf
+        .subarray(this.bufRdPos + s, this.bufWrtPos)
+        .indexOf(delim);
+      if (i >= 0) {
+        i += s;
+        slice = this.buf.subarray(this.bufRdPos, this.bufRdPos + i + 1);
+        this.bufRdPos += i + 1;
+        return slice;
+      }
+
+      // EOF?
+      if (this.eof) {
+        if (this.bufRdPos === this.bufWrtPos) {
+          return null;
+        }
+        slice = this.buf.subarray(this.bufRdPos, this.bufWrtPos);
+        this.bufRdPos = this.bufWrtPos;
+        return slice;
+      }
+
+      // Buffer full?
+      if (this.buffered() >= this.buf.byteLength) {
+        this.bufRdPos = this.bufWrtPos;
+        // #4521 The internal buffer should not be reused across reads because it causes corruption of data.
+        const oldbuf = this.buf;
+        const newbuf = this.buf.slice(0);
+        this.buf = newbuf;
+        throw new BufferFullError(oldbuf);
+      }
+
+      s = this.bufWrtPos - this.bufRdPos; // do not rescan area we scanned before
+
+      // Buffer is not full.
+      if (this._doSync) {
+        try {
+          this._fillMaybeSync();
+        } catch (err) {
+          handleRdErr(err);
+        }
+        return loopRecur();
+      } else {
+        let rr = this._fillMaybeSync() as Promise<void>;
+        return rr.then(loopRecur, handleRdErr);
+      }
+    };
+    return this._promiseIfAsync(loopRecur());
+
+    // Handle last byte, if any.
+    // const i = slice.byteLength - 1;
+    // if (i >= 0) {
+    //   this.lastByte = slice[i];
+    //   this.lastCharSize = -1
+    // }
+
+    //    return slice;
+  }
+
+  /** `peekMaybeSync()` returns the next `n` bytes without advancing the reader. The
+   * bytes stop being valid at the next read call.
+   *
+   * When the end of the underlying stream is reached, but there are unread
+   * bytes left in the buffer, those bytes are returned. If there are no bytes
+   * left in the buffer, it returns `null`.
+   *
+   * If an error is encountered before `n` bytes are available, `peekMaybeSync()` throws
+   * an error with the `partial` property set to a slice of the buffer that
+   * contains the bytes that were available before the error occurred.
+   */
+  protected peekMaybeSync(
+    n: number
+  ): Uint8Array | null | Promise<Uint8Array | null> {
+    if (n < 0) {
+      throw Error("negative count");
+    }
+
+    const handleRdErr = (err: any) => {
+      err.partial = this.buf.subarray(this.bufRdPos, this.bufWrtPos);
+      throw err;
+    };
+
+    const loopRecur = (): Uint8Array | null | Promise<Uint8Array | null> => {
+      const avail = this.bufWrtPos - this.bufRdPos;
+
+      if (avail >= n || avail >= this.buf.byteLength || this.eof) {
+        if (avail === 0 && this.eof) {
+          return null;
+        } else if (avail < n && this.eof) {
+          return this.buf.subarray(this.bufRdPos, this.bufRdPos + avail);
+        } else if (avail < n) {
+          throw new BufferFullError(
+            this.buf.subarray(this.bufRdPos, this.bufWrtPos)
+          );
+        }
+
+        return this.buf.subarray(this.bufRdPos, this.bufRdPos + n);
+      }
+
+      if (this._doSync) {
+        try {
+          this._fillMaybeSync();
+        } catch (err) {
+          handleRdErr(err);
+        }
+        return loopRecur();
+      } else {
+        let rr = this._fillMaybeSync() as Promise<void>;
+        return rr.then(loopRecur, handleRdErr);
+      }
+    };
+    return this._promiseIfAsync(loopRecur());
+  }
+}
+
+/** BufReader implements buffering for a Reader object. */
+export class BufReader extends AbstractBufReaderBase implements Reader {
+  protected _doSync: boolean = false;
+
+  /** return new BufReader unless r is BufReader */
+  static create(r: Reader, size: number = DEFAULT_BUF_SIZE): BufReader {
+    return r instanceof BufReader ? r : new BufReader(r, size);
+  }
+
+  constructor(rd: Reader, size: number = DEFAULT_BUF_SIZE) {
+    super(rd, size);
+  }
+
+  // Reads a new chunk into the buffer.
+  private async _fill(): Promise<void> {
+    return super._fillMaybeSync();
+  }
+
+  /** Discards any buffered data, resets all state, and switches
+   * the buffered reader to read from r.
+   */
+  reset(r: Reader): void {
+    super._resetMaybeSync(this.buf, r);
+  }
+
+  /** reads data into p.
+   * It returns the number of bytes read into p.
+   * The bytes are taken from at most one Read on the underlying Reader,
+   * hence n may be less than len(p).
+   * To read exactly len(p) bytes, use io.ReadFull(b, p).
+   */
+  async read(p: Uint8Array): Promise<number | null> {
+    return super.readMaybeSync(p);
   }
 
   /** reads exactly `p.length` bytes into `p`.
@@ -172,36 +603,12 @@ export class BufReader implements Reader {
    * Ported from https://golang.org/pkg/io/#ReadFull
    */
   async readFull(p: Uint8Array): Promise<Uint8Array | null> {
-    let bytesRead = 0;
-    while (bytesRead < p.length) {
-      try {
-        const rr = await this.read(p.subarray(bytesRead));
-        if (rr === null) {
-          if (bytesRead === 0) {
-            return null;
-          } else {
-            throw new PartialReadError();
-          }
-        }
-        bytesRead += rr;
-      } catch (err) {
-        err.partial = p.subarray(0, bytesRead);
-        throw err;
-      }
-    }
-    return p;
+    return super.readFullMaybeSync(p);
   }
 
   /** Returns the next byte [0, 255] or `null`. */
   async readByte(): Promise<number | null> {
-    while (this.r === this.w) {
-      if (this.eof) return null;
-      await this._fill(); // buffer is empty.
-    }
-    const c = this.buf[this.r];
-    this.r++;
-    // this.lastByte = c;
-    return c;
+    return super.readByteMaybeSync();
   }
 
   /** readString() reads until the first occurrence of delim in the input,
@@ -214,12 +621,7 @@ export class BufReader implements Reader {
    * For simple uses, a Scanner may be more convenient.
    */
   async readString(delim: string): Promise<string | null> {
-    if (delim.length !== 1) {
-      throw new Error("Delimiter should be a single character");
-    }
-    const buffer = await this.readSlice(delim.charCodeAt(0));
-    if (buffer === null) return null;
-    return new TextDecoder().decode(buffer);
+    return super.readStringMaybeSync(delim);
   }
 
   /** `readLine()` is a low-level line-reading primitive. Most callers should
@@ -245,55 +647,7 @@ export class BufReader implements Reader {
    * not part of the line returned by `readLine()`.
    */
   async readLine(): Promise<ReadLineResult | null> {
-    let line: Uint8Array | null;
-
-    try {
-      line = await this.readSlice(LF);
-    } catch (err) {
-      let { partial } = err;
-      assert(
-        partial instanceof Uint8Array,
-        "bufio: caught error from `readSlice()` without `partial` property"
-      );
-
-      // Don't throw if `readSlice()` failed with `BufferFullError`, instead we
-      // just return whatever is available and set the `more` flag.
-      if (!(err instanceof BufferFullError)) {
-        throw err;
-      }
-
-      // Handle the case where "\r\n" straddles the buffer.
-      if (
-        !this.eof &&
-        partial.byteLength > 0 &&
-        partial[partial.byteLength - 1] === CR
-      ) {
-        // Put the '\r' back on buf and drop it from line.
-        // Let the next call to ReadLine check for "\r\n".
-        assert(this.r > 0, "bufio: tried to rewind past start of buffer");
-        this.r--;
-        partial = partial.subarray(0, partial.byteLength - 1);
-      }
-
-      return { line: partial, more: !this.eof };
-    }
-
-    if (line === null) {
-      return null;
-    }
-
-    if (line.byteLength === 0) {
-      return { line, more: false };
-    }
-
-    if (line[line.byteLength - 1] == LF) {
-      let drop = 1;
-      if (line.byteLength > 1 && line[line.byteLength - 2] === CR) {
-        drop = 2;
-      }
-      line = line.subarray(0, line.byteLength - drop);
-    }
-    return { line, more: false };
+    return super.readLineMaybeSync();
   }
 
   /** `readSlice()` reads until the first occurrence of `delim` in the input,
@@ -313,58 +667,7 @@ export class BufReader implements Reader {
    * next I/O operation, most clients should use `readString()` instead.
    */
   async readSlice(delim: number): Promise<Uint8Array | null> {
-    let s = 0; // search start index
-    let slice: Uint8Array | undefined;
-
-    while (true) {
-      // Search buffer.
-      let i = this.buf.subarray(this.r + s, this.w).indexOf(delim);
-      if (i >= 0) {
-        i += s;
-        slice = this.buf.subarray(this.r, this.r + i + 1);
-        this.r += i + 1;
-        break;
-      }
-
-      // EOF?
-      if (this.eof) {
-        if (this.r === this.w) {
-          return null;
-        }
-        slice = this.buf.subarray(this.r, this.w);
-        this.r = this.w;
-        break;
-      }
-
-      // Buffer full?
-      if (this.buffered() >= this.buf.byteLength) {
-        this.r = this.w;
-        // #4521 The internal buffer should not be reused across reads because it causes corruption of data.
-        const oldbuf = this.buf;
-        const newbuf = this.buf.slice(0);
-        this.buf = newbuf;
-        throw new BufferFullError(oldbuf);
-      }
-
-      s = this.w - this.r; // do not rescan area we scanned before
-
-      // Buffer is not full.
-      try {
-        await this._fill();
-      } catch (err) {
-        err.partial = slice;
-        throw err;
-      }
-    }
-
-    // Handle last byte, if any.
-    // const i = slice.byteLength - 1;
-    // if (i >= 0) {
-    //   this.lastByte = slice[i];
-    //   this.lastCharSize = -1
-    // }
-
-    return slice;
+    return super.readSliceMaybeSync(delim);
   }
 
   /** `peek()` returns the next `n` bytes without advancing the reader. The
@@ -379,42 +682,13 @@ export class BufReader implements Reader {
    * contains the bytes that were available before the error occurred.
    */
   async peek(n: number): Promise<Uint8Array | null> {
-    if (n < 0) {
-      throw Error("negative count");
-    }
-
-    let avail = this.w - this.r;
-    while (avail < n && avail < this.buf.byteLength && !this.eof) {
-      try {
-        await this._fill();
-      } catch (err) {
-        err.partial = this.buf.subarray(this.r, this.w);
-        throw err;
-      }
-      avail = this.w - this.r;
-    }
-
-    if (avail === 0 && this.eof) {
-      return null;
-    } else if (avail < n && this.eof) {
-      return this.buf.subarray(this.r, this.r + avail);
-    } else if (avail < n) {
-      throw new BufferFullError(this.buf.subarray(this.r, this.w));
-    }
-
-    return this.buf.subarray(this.r, this.r + n);
+    return super.peekMaybeSync(n);
   }
 }
 
 /** BufReaderSync implements buffering for a ReaderSync object. */
-export class BufReaderSync implements ReaderSync {
-  private buf!: Uint8Array;
-  private rd!: ReaderSync; // Reader provided by caller.
-  private r = 0; // buf read position.
-  private w = 0; // buf write position.
-  private eof = false;
-  // private lastByte: number;
-  // private lastCharSize: number;
+export class BufReaderSync extends AbstractBufReaderBase implements ReaderSync {
+  protected _doSync: boolean = true;
 
   /** return new BufReaderSync unless r is BufReaderSync */
   static create(r: ReaderSync, size: number = DEFAULT_BUF_SIZE): BufReaderSync {
@@ -422,67 +696,28 @@ export class BufReaderSync implements ReaderSync {
   }
 
   constructor(rd: ReaderSync, size: number = DEFAULT_BUF_SIZE) {
-    if (size < MIN_BUF_SIZE) {
-      size = MIN_BUF_SIZE;
-    }
-    this._reset(new Uint8Array(size), rd);
-  }
-
-  /** Returns the size of the underlying buffer in bytes. */
-  size(): number {
-    return this.buf.byteLength;
-  }
-
-  buffered(): number {
-    return this.w - this.r;
+    super(rd, size);
   }
 
   // Reads a new chunk into the buffer.
   private _fill(): void {
-    // Slide existing data to beginning.
-    if (this.r > 0) {
-      this.buf.copyWithin(0, this.r, this.w);
-      this.w -= this.r;
-      this.r = 0;
-    }
-
-    if (this.w >= this.buf.byteLength) {
-      throw Error("bufio: tried to fill full buffer");
-    }
-
-    // Read new data: try a limited number of times.
-    for (let i = MAX_CONSECUTIVE_EMPTY_READS; i > 0; i--) {
-      const rr = this.rd.readSync(this.buf.subarray(this.w));
-      if (rr === null) {
-        this.eof = true;
-        return;
-      }
-      assert(rr >= 0, "negative read");
-      this.w += rr;
-      if (rr > 0) {
-        return;
-      }
-    }
-
-    throw new Error(
-      `No progress after ${MAX_CONSECUTIVE_EMPTY_READS} read() calls`
-    );
+    super._fillMaybeSync();
   }
 
   /** Discards any buffered data, resets all state, and switches
    * the buffered reader to read from r.
    */
   reset(r: ReaderSync): void {
-    this._reset(this.buf, r);
+    super._resetMaybeSync(this.buf, r);
   }
 
-  private _reset(buf: Uint8Array, rd: ReaderSync): void {
-    this.buf = buf;
-    this.rd = rd;
-    this.eof = false;
-    // this.lastByte = -1;
-    // this.lastCharSize = -1;
-  }
+  // private _reset(buf: Uint8Array, rd: ReaderSync): void {
+  //   this.buf = buf;
+  //   this.rd = rd;
+  //   this.eof = false;
+  //   // this.lastByte = -1;
+  //   // this.lastCharSize = -1;
+  // }
 
   /** reads data into p.
    * It returns the number of bytes read into p.
@@ -491,39 +726,7 @@ export class BufReaderSync implements ReaderSync {
    * To read exactly len(p) bytes, use io.ReadFull(b, p).
    */
   readSync(p: Uint8Array): number | null {
-    let rr: number | null = p.byteLength;
-    if (p.byteLength === 0) return rr;
-
-    if (this.r === this.w) {
-      if (p.byteLength >= this.buf.byteLength) {
-        // Large read, empty buffer.
-        // Read directly into p to avoid copy.
-        const rr = this.rd.readSync(p);
-        const nread = rr ?? 0;
-        assert(nread >= 0, "negative read");
-        // if (rr.nread > 0) {
-        //   this.lastByte = p[rr.nread - 1];
-        //   this.lastCharSize = -1;
-        // }
-        return rr;
-      }
-
-      // One read.
-      // Do not use this.fill, which will loop.
-      this.r = 0;
-      this.w = 0;
-      rr = this.rd.readSync(this.buf);
-      if (rr === 0 || rr === null) return rr;
-      assert(rr >= 0, "negative read");
-      this.w += rr;
-    }
-
-    // copy as much as we can
-    const copied = copyBytes(this.buf.subarray(this.r, this.w), p, 0);
-    this.r += copied;
-    // this.lastByte = this.buf[this.r - 1];
-    // this.lastCharSize = -1;
-    return copied;
+    return super.readMaybeSync(p) as number | null;
   }
 
   /** reads exactly `p.length` bytes into `p`.
@@ -541,36 +744,12 @@ export class BufReaderSync implements ReaderSync {
    * Ported from https://golang.org/pkg/io/#ReadFull
    */
   readFull(p: Uint8Array): Uint8Array | null {
-    let bytesRead = 0;
-    while (bytesRead < p.length) {
-      try {
-        const rr = this.readSync(p.subarray(bytesRead));
-        if (rr === null) {
-          if (bytesRead === 0) {
-            return null;
-          } else {
-            throw new PartialReadError();
-          }
-        }
-        bytesRead += rr;
-      } catch (err) {
-        err.partial = p.subarray(0, bytesRead);
-        throw err;
-      }
-    }
-    return p;
+    return super.readFullMaybeSync(p) as Uint8Array | null;
   }
 
   /** Returns the next byte [0, 255] or `null`. */
   readByte(): number | null {
-    while (this.r === this.w) {
-      if (this.eof) return null;
-      this._fill(); // buffer is empty.
-    }
-    const c = this.buf[this.r];
-    this.r++;
-    // this.lastByte = c;
-    return c;
+    return super.readByteMaybeSync() as number | null;
   }
 
   /** readString() reads until the first occurrence of delim in the input,
@@ -583,12 +762,7 @@ export class BufReaderSync implements ReaderSync {
    * For simple uses, a Scanner may be more convenient.
    */
   readString(delim: string): string | null {
-    if (delim.length !== 1) {
-      throw new Error("Delimiter should be a single character");
-    }
-    const buffer = this.readSlice(delim.charCodeAt(0));
-    if (buffer === null) return null;
-    return new TextDecoder().decode(buffer);
+    return super.readStringMaybeSync(delim) as string | null;
   }
 
   /** `readLine()` is a low-level line-reading primitive. Most callers should
@@ -614,55 +788,7 @@ export class BufReaderSync implements ReaderSync {
    * not part of the line returned by `readLine()`.
    */
   readLine(): ReadLineResult | null {
-    let line: Uint8Array | null;
-
-    try {
-      line = this.readSlice(LF);
-    } catch (err) {
-      let { partial } = err;
-      assert(
-        partial instanceof Uint8Array,
-        "bufio: caught error from `readSlice()` without `partial` property"
-      );
-
-      // Don't throw if `readSlice()` failed with `BufferFullError`, instead we
-      // just return whatever is available and set the `more` flag.
-      if (!(err instanceof BufferFullError)) {
-        throw err;
-      }
-
-      // Handle the case where "\r\n" straddles the buffer.
-      if (
-        !this.eof &&
-        partial.byteLength > 0 &&
-        partial[partial.byteLength - 1] === CR
-      ) {
-        // Put the '\r' back on buf and drop it from line.
-        // Let the next call to ReadLine check for "\r\n".
-        assert(this.r > 0, "bufio: tried to rewind past start of buffer");
-        this.r--;
-        partial = partial.subarray(0, partial.byteLength - 1);
-      }
-
-      return { line: partial, more: !this.eof };
-    }
-
-    if (line === null) {
-      return null;
-    }
-
-    if (line.byteLength === 0) {
-      return { line, more: false };
-    }
-
-    if (line[line.byteLength - 1] == LF) {
-      let drop = 1;
-      if (line.byteLength > 1 && line[line.byteLength - 2] === CR) {
-        drop = 2;
-      }
-      line = line.subarray(0, line.byteLength - drop);
-    }
-    return { line, more: false };
+    return super.readLineMaybeSync() as ReadLineResult | null;
   }
 
   /** `readSlice()` reads until the first occurrence of `delim` in the input,
@@ -682,58 +808,7 @@ export class BufReaderSync implements ReaderSync {
    * next I/O operation, most clients should use `readString()` instead.
    */
   readSlice(delim: number): Uint8Array | null {
-    let s = 0; // search start index
-    let slice: Uint8Array | undefined;
-
-    while (true) {
-      // Search buffer.
-      let i = this.buf.subarray(this.r + s, this.w).indexOf(delim);
-      if (i >= 0) {
-        i += s;
-        slice = this.buf.subarray(this.r, this.r + i + 1);
-        this.r += i + 1;
-        break;
-      }
-
-      // EOF?
-      if (this.eof) {
-        if (this.r === this.w) {
-          return null;
-        }
-        slice = this.buf.subarray(this.r, this.w);
-        this.r = this.w;
-        break;
-      }
-
-      // Buffer full?
-      if (this.buffered() >= this.buf.byteLength) {
-        this.r = this.w;
-        // #4521 The internal buffer should not be reused across reads because it causes corruption of data.
-        const oldbuf = this.buf;
-        const newbuf = this.buf.slice(0);
-        this.buf = newbuf;
-        throw new BufferFullError(oldbuf);
-      }
-
-      s = this.w - this.r; // do not rescan area we scanned before
-
-      // Buffer is not full.
-      try {
-        this._fill();
-      } catch (err) {
-        err.partial = slice;
-        throw err;
-      }
-    }
-
-    // Handle last byte, if any.
-    // const i = slice.byteLength - 1;
-    // if (i >= 0) {
-    //   this.lastByte = slice[i];
-    //   this.lastCharSize = -1
-    // }
-
-    return slice;
+    return super.readSliceMaybeSync(delim) as Uint8Array | null;
   }
 
   /** `peek()` returns the next `n` bytes without advancing the reader. The
@@ -748,30 +823,7 @@ export class BufReaderSync implements ReaderSync {
    * contains the bytes that were available before the error occurred.
    */
   peek(n: number): Uint8Array | null {
-    if (n < 0) {
-      throw Error("negative count");
-    }
-
-    let avail = this.w - this.r;
-    while (avail < n && avail < this.buf.byteLength && !this.eof) {
-      try {
-        this._fill();
-      } catch (err) {
-        err.partial = this.buf.subarray(this.r, this.w);
-        throw err;
-      }
-      avail = this.w - this.r;
-    }
-
-    if (avail === 0 && this.eof) {
-      return null;
-    } else if (avail < n && this.eof) {
-      return this.buf.subarray(this.r, this.r + avail);
-    } else if (avail < n) {
-      throw new BufferFullError(this.buf.subarray(this.r, this.w));
-    }
-
-    return this.buf.subarray(this.r, this.r + n);
+    return super.peekMaybeSync(n) as Uint8Array | null;
   }
 }
 

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -93,7 +93,10 @@ const readSyncMakers: ReadSyncMaker[] = [
     name: "byte",
     fn: (r): iotestSync.OneByteReader => new iotestSync.OneByteReader(r),
   },
-  { name: "half", fn: (r): iotestSync.HalfReader => new iotestSync.HalfReader(r) },
+  {
+    name: "half",
+    fn: (r): iotestSync.HalfReader => new iotestSync.HalfReader(r),
+  },
   // TODO { name: "data+err", r => new iotest.DataErrReader(r) },
   // { name: "timeout", fn: r => new iotest.TimeoutReader(r) },
 ];
@@ -256,7 +259,10 @@ Deno.test("bufioBufferFullSync", function (): void {
   const longString =
     "And now, hello, world! It is the time for all good men to come to the" +
     " aid of their party";
-  const buf = new BufReaderSync(new StringReader(longString), MIN_READ_BUFFER_SIZE);
+  const buf = new BufReaderSync(
+    new StringReader(longString),
+    MIN_READ_BUFFER_SIZE
+  );
   const decoder = new TextDecoder();
 
   try {
@@ -787,11 +793,11 @@ Deno.test(
     const bufSize = 25;
     const b = new BufReaderSync(new StringReader(data), bufSize);
 
-    const r1 = (b.readLine()) as ReadLineResult;
+    const r1 = b.readLine() as ReadLineResult;
     assert(r1 !== null);
     assertEquals(decoder.decode(r1.line), "abcdefghijklmnopqrstuvwxy");
 
-    const r2 = (b.readLine()) as ReadLineResult;
+    const r2 = b.readLine() as ReadLineResult;
     assert(r2 !== null);
     assertEquals(decoder.decode(r2.line), "z");
     assert(

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -437,6 +437,11 @@ Deno.test("bufioReadLine", async function (): Promise<void> {
   await testReadLine(testInputrn);
 });
 
+Deno.test("bufioReadLineSync", function (): void {
+  testReadLineSync(testInput);
+  testReadLineSync(testInputrn);
+});
+
 Deno.test("bufioPeek", async function (): Promise<void> {
   const decoder = new TextDecoder();
   const p = new Uint8Array(10);

--- a/std/textproto/mod.ts
+++ b/std/textproto/mod.ts
@@ -199,7 +199,7 @@ export class TextProtoReaderSync {
     if (buf === null) {
       return null;
     } else if (buf[0] == charCode(" ") || buf[0] == charCode("\t")) {
-      line = (this.readLineSlice()) as Uint8Array;
+      line = this.readLineSlice() as Uint8Array;
     }
 
     buf = this.r.peek(1);

--- a/std/textproto/mod.ts
+++ b/std/textproto/mod.ts
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import { BufReader } from "../io/bufio.ts";
+import { BufReader, BufReaderSync } from "../io/bufio.ts";
 import { charCode } from "../io/util.ts";
 import { concat } from "../bytes/mod.ts";
 import { decode } from "../encoding/utf8.ts";
@@ -125,6 +125,143 @@ export class TextProtoReader {
     let line: Uint8Array | undefined;
     while (true) {
       const r = await this.r.readLine();
+      if (r === null) return null;
+      const { line: l, more } = r;
+
+      // Avoid the copy if the first call produced a full line.
+      if (!line && !more) {
+        // TODO(ry):
+        // This skipSpace() is definitely misplaced, but I don't know where it
+        // comes from nor how to fix it.
+        if (this.skipSpace(l) === 0) {
+          return new Uint8Array(0);
+        }
+        return l;
+      }
+      line = line ? concat(line, l) : l;
+      if (!more) {
+        break;
+      }
+    }
+    return line;
+  }
+
+  skipSpace(l: Uint8Array): number {
+    let n = 0;
+    for (let i = 0; i < l.length; i++) {
+      if (l[i] === charCode(" ") || l[i] === charCode("\t")) {
+        continue;
+      }
+      n++;
+    }
+    return n;
+  }
+}
+
+export class TextProtoReaderSync {
+  constructor(readonly r: BufReaderSync) {}
+
+  /** readLine() reads a single line from the TextProtoReaderSync,
+   * eliding the final \n or \r\n from the returned string.
+   */
+  readLine(): string | null {
+    const s = this.readLineSlice();
+    if (s === null) return null;
+    return str(s);
+  }
+
+  /** ReadMIMEHeader reads a MIME-style header from r.
+   * The header is a sequence of possibly continued Key: Value lines
+   * ending in a blank line.
+   * The returned map m maps CanonicalMIMEHeaderKey(key) to a
+   * sequence of values in the same order encountered in the input.
+   *
+   * For example, consider this input:
+   *
+   *	My-Key: Value 1
+   *	Long-Key: Even
+   *	       Longer Value
+   *	My-Key: Value 2
+   *
+   * Given that input, ReadMIMEHeader returns the map:
+   *
+   *	map[string][]string{
+   *		"My-Key": {"Value 1", "Value 2"},
+   *		"Long-Key": {"Even Longer Value"},
+   *	}
+   */
+  readMIMEHeader(): Headers | null {
+    const m = new Headers();
+    let line: Uint8Array | undefined;
+
+    // The first line cannot start with a leading space.
+    let buf = this.r.peek(1);
+    if (buf === null) {
+      return null;
+    } else if (buf[0] == charCode(" ") || buf[0] == charCode("\t")) {
+      line = (this.readLineSlice()) as Uint8Array;
+    }
+
+    buf = this.r.peek(1);
+    if (buf === null) {
+      throw new Deno.errors.UnexpectedEof();
+    } else if (buf[0] == charCode(" ") || buf[0] == charCode("\t")) {
+      throw new Deno.errors.InvalidData(
+        `malformed MIME header initial line: ${str(line)}`
+      );
+    }
+
+    while (true) {
+      const kv = this.readLineSlice(); // readContinuedLineSlice
+      if (kv === null) throw new Deno.errors.UnexpectedEof();
+      if (kv.byteLength === 0) return m;
+
+      // Key ends at first colon
+      let i = kv.indexOf(charCode(":"));
+      if (i < 0) {
+        throw new Deno.errors.InvalidData(
+          `malformed MIME header line: ${str(kv)}`
+        );
+      }
+
+      //let key = canonicalMIMEHeaderKey(kv.subarray(0, endKey));
+      const key = str(kv.subarray(0, i));
+
+      // As per RFC 7230 field-name is a token,
+      // tokens consist of one or more chars.
+      // We could throw `Deno.errors.InvalidData` here,
+      // but better to be liberal in what we
+      // accept, so if we get an empty key, skip it.
+      if (key == "") {
+        continue;
+      }
+
+      // Skip initial spaces in value.
+      i++; // skip colon
+      while (
+        i < kv.byteLength &&
+        (kv[i] == charCode(" ") || kv[i] == charCode("\t"))
+      ) {
+        i++;
+      }
+      const value = str(kv.subarray(i)).replace(
+        invalidHeaderCharRegex,
+        encodeURI
+      );
+
+      // In case of invalid header we swallow the error
+      // example: "Audio Mode" => invalid due to space in the key
+      try {
+        m.append(key, value);
+      } catch {}
+    }
+  }
+
+  readLineSlice(): Uint8Array | null {
+    // this.closeDot();
+    let line: Uint8Array | undefined;
+    while (true) {
+      const r = this.r.readLine();
       if (r === null) return null;
       const { line: l, more } = r;
 

--- a/std/textproto/mod.ts
+++ b/std/textproto/mod.ts
@@ -253,7 +253,9 @@ export class TextProtoReaderSync {
       // example: "Audio Mode" => invalid due to space in the key
       try {
         m.append(key, value);
-      } catch {}
+      } catch {
+        // Pass
+      }
     }
   }
 

--- a/std/textproto/sync_test.ts
+++ b/std/textproto/sync_test.ts
@@ -1,0 +1,193 @@
+// Based on https://github.com/golang/go/blob/master/src/net/textproto/reader_test.go
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import { BufReaderSync } from "../io/bufio.ts";
+import { TextProtoReaderSync } from "./mod.ts";
+import { StringReader } from "../io/readers.ts";
+import { assert, assertEquals, assertThrows } from "../testing/asserts.ts";
+const { test } = Deno;
+
+function reader(s: string): TextProtoReaderSync {
+  return new TextProtoReaderSync(new BufReaderSync(new StringReader(s)));
+}
+
+test({
+  ignore: true,
+  name: "[textproto] Reader : DotBytes",
+  fn(): void {
+    const _input =
+      "dotlines\r\n.foo\r\n..bar\n...baz\nquux\r\n\r\n.\r\nanot.her\r\n";
+    return;
+  },
+});
+
+test("[textproto] ReadEmpty", () => {
+  const r = reader("");
+  const m = r.readMIMEHeader();
+  assertEquals(m, null);
+});
+
+test("[textproto] Reader", () => {
+  const r = reader("line1\nline2\n");
+  let s = r.readLine();
+  assertEquals(s, "line1");
+
+  s = r.readLine();
+  assertEquals(s, "line2");
+
+  s = r.readLine();
+  assert(s === null);
+});
+
+test({
+  name: "[textproto] Reader : MIME Header",
+  fn(): void {
+    const input =
+      "my-key: Value 1  \r\nLong-key: Even Longer Value\r\nmy-Key: " +
+      "Value 2\r\n\n";
+    const r = reader(input);
+    const m = r.readMIMEHeader();
+    assert(m !== null);
+    assertEquals(m.get("My-Key"), "Value 1, Value 2");
+    assertEquals(m.get("Long-key"), "Even Longer Value");
+  },
+});
+
+test({
+  name: "[textproto] Reader : MIME Header Single",
+  fn(): void {
+    const input = "Foo: bar\n\n";
+    const r = reader(input);
+    const m = r.readMIMEHeader();
+    assert(m !== null);
+    assertEquals(m.get("Foo"), "bar");
+  },
+});
+
+test({
+  name: "[textproto] Reader : MIME Header No Key",
+  fn(): void {
+    const input = ": bar\ntest-1: 1\n\n";
+    const r = reader(input);
+    const m = r.readMIMEHeader();
+    assert(m !== null);
+    assertEquals(m.get("Test-1"), "1");
+  },
+});
+
+test({
+  name: "[textproto] Reader : Large MIME Header",
+  fn(): void {
+    const data: string[] = [];
+    // Go test is 16*1024. But seems it can't handle more
+    for (let i = 0; i < 1024; i++) {
+      data.push("x");
+    }
+    const sdata = data.join("");
+    const r = reader(`Cookie: ${sdata}\r\n\r\n`);
+    const m = r.readMIMEHeader();
+    assert(m !== null);
+    assertEquals(m.get("Cookie"), sdata);
+  },
+});
+
+// Test that we don't read MIME headers seen in the wild,
+// with spaces before colons, and spaces in keys.
+test({
+  name: "[textproto] Reader : MIME Header Non compliant",
+  fn(): void {
+    const input = "Foo: bar\r\n" +
+      "Content-Language: en\r\n" +
+      "SID : 0\r\n" +
+      "Audio Mode : None\r\n" +
+      "Privilege : 127\r\n\r\n";
+    const r = reader(input);
+    const m = r.readMIMEHeader();
+    assert(m !== null);
+    assertEquals(m.get("Foo"), "bar");
+    assertEquals(m.get("Content-Language"), "en");
+    // Make sure we drop headers with trailing whitespace
+    assertEquals(m.get("SID"), null);
+    assertEquals(m.get("Privilege"), null);
+    // Not legal http header
+    assertThrows((): void => {
+      assertEquals(m.get("Audio Mode"), "None");
+    });
+  },
+});
+
+test({
+  name: "[textproto] Reader : MIME Header Malformed",
+  fn(): void {
+    const input = [
+      "No colon first line\r\nFoo: foo\r\n\r\n",
+      " No colon first line with leading space\r\nFoo: foo\r\n\r\n",
+      "\tNo colon first line with leading tab\r\nFoo: foo\r\n\r\n",
+      " First: line with leading space\r\nFoo: foo\r\n\r\n",
+      "\tFirst: line with leading tab\r\nFoo: foo\r\n\r\n",
+      "Foo: foo\r\nNo colon second line\r\n\r\n",
+    ];
+    const r = reader(input.join(""));
+
+    let err;
+    try {
+      r.readMIMEHeader();
+    } catch (e) {
+      err = e;
+    }
+    assert(err instanceof Deno.errors.InvalidData);
+  },
+});
+
+test({
+  name: "[textproto] Reader : MIME Header Trim Continued",
+  fn(): void {
+    const input = "" + // for code formatting purpose.
+      "a:\n" +
+      " 0 \r\n" +
+      "b:1 \t\r\n" +
+      "c: 2\r\n" +
+      " 3\t\n" +
+      "  \t 4  \r\n\n";
+    const r = reader(input);
+    let err;
+    try {
+      r.readMIMEHeader();
+    } catch (e) {
+      err = e;
+    }
+    assert(err instanceof Deno.errors.InvalidData);
+  },
+});
+
+test({
+  name: "[textproto] #409 issue : multipart form boundary",
+  fn(): void {
+    const input = [
+      "Accept: */*\r\n",
+      'Content-Disposition: form-data; name="test"\r\n',
+      " \r\n",
+      "------WebKitFormBoundaryimeZ2Le9LjohiUiG--\r\n\n",
+    ];
+    const r = reader(input.join(""));
+    const m = r.readMIMEHeader();
+    assert(m !== null);
+    assertEquals(m.get("Accept"), "*/*");
+    assertEquals(m.get("Content-Disposition"), 'form-data; name="test"');
+  },
+});
+
+test({
+  name: "[textproto] #4521 issue",
+  fn() {
+    const input = "abcdefghijklmnopqrstuvwxyz";
+    const bufSize = 25;
+    const tp = new TextProtoReaderSync(
+      new BufReaderSync(new StringReader(input), bufSize),
+    );
+    const line = tp.readLine();
+    assertEquals(line, input);
+  },
+});

--- a/std/textproto/sync_test.ts
+++ b/std/textproto/sync_test.ts
@@ -98,7 +98,8 @@ test({
 test({
   name: "[textproto] Reader : MIME Header Non compliant",
   fn(): void {
-    const input = "Foo: bar\r\n" +
+    const input =
+      "Foo: bar\r\n" +
       "Content-Language: en\r\n" +
       "SID : 0\r\n" +
       "Audio Mode : None\r\n" +
@@ -144,7 +145,8 @@ test({
 test({
   name: "[textproto] Reader : MIME Header Trim Continued",
   fn(): void {
-    const input = "" + // for code formatting purpose.
+    const input =
+      "" + // for code formatting purpose.
       "a:\n" +
       " 0 \r\n" +
       "b:1 \t\r\n" +
@@ -185,7 +187,7 @@ test({
     const input = "abcdefghijklmnopqrstuvwxyz";
     const bufSize = 25;
     const tp = new TextProtoReaderSync(
-      new BufReaderSync(new StringReader(input), bufSize),
+      new BufReaderSync(new StringReader(input), bufSize)
     );
     const line = tp.readLine();
     assertEquals(line, input);


### PR DESCRIPTION
Added `BufReaderSync` etc. to support synchronous read line from reader like `stdin`, for #1805.

Includes unit tests, and `readLinesSync` documented in readme.

Note: currently doesn't _actually_ work on `Deno.stdin` due to sync read not allowed on `stdin`, a regression from Deno v0.41, see #4789 #6121.  But it otherwise works fine!

Also includes a synchronous `TextProtoReader` along with unit tests.  That's because I had a synchronous version of @johnsonjo4531's [read_lines](https://github.com/johnsonjo4531/read_lines) library, referenced in #1805, that needed it.  Turns out @johnsonjo4531's `read_lines` library no longer even use `TextProtoReader` anymore (I literally just found out).

So if `TextProtoReaderSync` is out of scope for this issue or it's not wanted inside `std`, that's totally fine with me too!

Thanks!