### PR TITLE
doc(std/fs): fix sync walk example

### DIFF
--- a/std/fs/README.md
+++ b/std/fs/README.md
@@ -154,8 +154,8 @@ Iterate all files in a directory recursively.
 ```ts
 import { walk, walkSync } from "https://deno.land/std/fs/mod.ts";
 
-for (const fileInfo of walkSync(".")) {
-  console.log(fileInfo.filename);
+for (const entry of walkSync(".")) {
+  console.log(entry.path);
 }
 
 // Async


### PR DESCRIPTION
The example doesn't compile : Property 'filename' does not exist on type 'WalkEntry'.
The property has been renamed : fileInfo.filename → fileInfo.name


See https://github.com/denoland/deno/pull/4941
