### PR TITLE
cleanup std/tar

### DIFF
--- a/std/archive/tar.ts
+++ b/std/archive/tar.ts
@@ -1,5 +1,5 @@
 /**
- * Ported and modified from: https://github.com/jshttp/mime-types and
+ * Ported and modified from: https://github.com/beatgammit/tar-js and
  * licensed as:
  *
  * (The MIT License)
@@ -259,15 +259,9 @@ export interface UntarOptions extends TarInfo {
  */
 export class Tar {
   data: TarDataWithSource[];
-  written: number;
-  out: Uint8Array;
-  private blockSize: number;
 
-  constructor(recordsPerBlock?: number) {
+  constructor() {
     this.data = [];
-    this.written = 0;
-    this.blockSize = (recordsPerBlock || 20) * recordSize;
-    this.out = clean(this.blockSize);
   }
 
   /**


### PR DESCRIPTION

- Was ported from https://github.com/beatgammit/tar-js instead of https://github.com/jshttp/mime-types (see https://github.com/denoland/deno_std/pull/388)
- Remove unused properties (properties used in the original version, not in the ported one)