### PR TITLE
Remove redundant call to ensureDirSync

### DIFF
--- a/std/fs/ensure_symlink.ts
+++ b/std/fs/ensure_symlink.ts
@@ -28,7 +28,6 @@ export async function ensureSymlink(src: string, dest: string): Promise<void> {
 
   await ensureDir(path.dirname(dest));
 
-  ensureDirSync(path.dirname(dest));
   if (Deno.build.os === "windows") {
     await Deno.symlink(src, dest, {
       type: srcFilePathType === "dir" ? "dir" : "file",


### PR DESCRIPTION
There's a seemingly reundant call to `ensureDirSync` right after a call to `await ensureDir`.

This removes the offending call.

Brought up in https://github.com/denoland/deno/issues/6187.