### PR TITLE
Fix links in the architecture page from the manual

### DIFF
--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -2,15 +2,15 @@
 
 ### Deno and Linux analogy
 
-|                       **Linux** | **Deno**                         |
-| ------------------------------: | :------------------------------- |
-|                       Processes | Web Workers                      |
-|                        Syscalls | Ops                              |
-|           File descriptors (fd) | [Resource ids (rid)](#resources) |
-|                       Scheduler | Tokio                            |
-| Userland: libc++ / glib / boost | https://deno.land/std/           |
-|                 /proc/\$\$/stat | [Deno.metrics()](#metrics)       |
-|                       man pages | deno types                       |
+|                       **Linux** | **Deno**                                     |
+| ------------------------------: | :------------------------------------------- |
+|                       Processes | Web Workers                                  |
+|                        Syscalls | Ops                                          |
+|           File descriptors (fd) | [Resource ids (rid)](architecture#resources) |
+|                       Scheduler | Tokio                                        |
+| Userland: libc++ / glib / boost | https://deno.land/std/                       |
+|                 /proc/\$\$/stat | [Deno.metrics()](architecture#metrics)       |
+|                       man pages | deno types                                   |
 
 #### Resources
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

I've just fixed minor typos on the anchors that were redirecting on the contriburing page instead of the "architecture" child page.