### PR TITLE
Readme cleanup in encoding and ws

### DIFF
--- a/std/encoding/README.md
+++ b/std/encoding/README.md
@@ -187,8 +187,8 @@ will output:
 #### Parse
 
 ```ts
-import { parse } from "./parser.ts";
-import { readFileStrSync } from "../fs/read_file_str.ts";
+import { parse } from "https://deno.land/std/encoding/toml.ts";
+import { readFileStrSync } from "https://deno.land/std/fs/read_file_str.ts";
 
 const tomlObject = parse(readFileStrSync("file.toml"));
 
@@ -199,7 +199,7 @@ const tomlObject22 = parse(tomlString);
 #### Stringify
 
 ```ts
-import { stringify } from "./parser.ts";
+import { stringify } from "https://deno.land/std/encoding/toml.ts";
 const obj = {
   bin: [
     { name: "deno", path: "cli/main.rs" },

--- a/std/encoding/README.md
+++ b/std/encoding/README.md
@@ -182,24 +182,10 @@ will output:
 }
 ```
 
-### Usage
-
-#### Parse
+### Basic usage
 
 ```ts
-import { parse } from "https://deno.land/std/encoding/toml.ts";
-import { readFileStrSync } from "https://deno.land/std/fs/read_file_str.ts";
-
-const tomlObject = parse(readFileStrSync("file.toml"));
-
-const tomlString = 'foo.bar = "Deno"';
-const tomlObject22 = parse(tomlString);
-```
-
-#### Stringify
-
-```ts
-import { stringify } from "https://deno.land/std/encoding/toml.ts";
+import { parse, stringify } from "https://deno.land/std/encoding/toml.ts";
 const obj = {
   bin: [
     { name: "deno", path: "cli/main.rs" },
@@ -208,6 +194,32 @@ const obj = {
   nib: [{ name: "node", path: "not_found" }],
 };
 const tomlString = stringify(obj);
+console.log(tomlString);
+
+// =>
+// [[bin]]
+// name = "deno"
+// path = "cli/main.rs"
+
+// [[bin]]
+// name = "deno_core"
+// path = "src/foo.rs"
+
+// [[nib]]
+// name = "node"
+// path = "not_found"
+
+const tomlObject = parse(tomlString);
+console.log(tomlObject);
+
+// =>
+// {
+//     bin: [
+//       { name: "deno", path: "cli/main.rs" },
+//       { name: "deno_core", path: "src/foo.rs" }
+//     ],
+//     nib: [ { name: "node", path: "not_found" } ]
+//   }
 ```
 
 ## YAML

--- a/std/encoding/README.md
+++ b/std/encoding/README.md
@@ -77,6 +77,7 @@ function is as follows:
 ### Usage
 
 ```ts
+import { parse } from "https://deno.land/std/encoding/csv.ts";
 const string = "a,b,c\nd,e,f";
 
 console.log(

--- a/std/ws/README.md
+++ b/std/ws/README.md
@@ -8,13 +8,13 @@ ws module is made to provide helpers to create WebSocket client/server.
 
 ```ts
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { serve } from "../../http/server.ts";
+import { serve } from "https://deno.land/std/http/server.ts";
 import {
   acceptWebSocket,
   isWebSocketCloseEvent,
   isWebSocketPingEvent,
   WebSocket,
-} from "../../ws/mod.ts";
+} from "https://deno.land/std/ws/mod.ts";
 
 async function handleWs(sock: WebSocket) {
   console.log("socket connected!");


### PR DESCRIPTION
Changes so that examples in the encoding and ws README.md work with copy/paste:

- Change imports to be via URL
- Corrected .toml example to have the correct imports and removed dependency on a file
- Added import to csv example