### PR TITLE
throw error for missing cmd field in Deno.run

### DIFF
--- a/cli/js/process.ts
+++ b/cli/js/process.ts
@@ -125,6 +125,9 @@ export function run<T extends RunOptions = RunOptions>({
   stderr = "inherit",
   stdin = "inherit",
 }: T): Process<T> {
+  if (!Array.isArray(cmd)) {
+    throw new TypeError("cmd field should be an array");
+  }
   const res = runOp({
     cmd: cmd.map(String),
     cwd,


### PR DESCRIPTION
Throws type error if `cmd` field is not provided in the argument of `Deno.run` or is not an array.