### PR TITLE
feat(cli): allow file streams to be truncated

### DIFF
--- a/cli/js/deno_unstable.ts
+++ b/cli/js/deno_unstable.ts
@@ -12,6 +12,7 @@ export { applySourceMap, formatDiagnostics } from "./ops/errors.ts";
 export { signal, signals, Signal, SignalStream } from "./signals.ts";
 export { setRaw } from "./ops/tty.ts";
 export { utimeSync, utime } from "./ops/fs/utime.ts";
+export { ftruncateSync, ftruncate } from "./ops/fs/truncate.ts";
 export { ShutdownMode, shutdown } from "./net.ts";
 export { listen, listenDatagram, connect } from "./net_unstable.ts";
 export { startTls } from "./tls.ts";

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1248,4 +1248,43 @@ declare namespace Deno {
 
   /** **UNSTABLE**: The URL of the file that was originally executed from the command-line. */
   export const mainModule: string;
+
+  /** Synchronously truncates or extends the specified file stream, to reach the
+   * specified `len`.  If `len` is not specified then the entire file contents
+   * are truncated.
+   *
+   * ```ts
+   * // truncate the entire file
+   * const file = Deno.open("my_file.txt", { read: true, write: true, truncate: true, create: true });
+   * Deno.ftruncateSync(file.rid);
+   *
+   * // truncate part of the file
+   * const file = Deno.open("my_file.txt", { read: true, write: true, create: true });
+   * Deno.write(file.rid, new TextEncoder().encode("Hello World"));
+   * Deno.ftruncateSync(file.rid, 7);
+   * const data = new Uint8Array(32);
+   * Deno.readSync(file.rid, data);
+   * console.log(new TextDecoder().decode(data)); // Hello W
+   * ```
+   */
+  export function ftruncateSync(rid: number, len?: number): void;
+
+  /** Truncates or extends the specified file stream, to reach the specified `len`. If
+   * `len` is not specified then the entire file contents are truncated.
+   *
+   * ```ts
+   * // truncate the entire file
+   * const file = Deno.open("my_file.txt", { read: true, write: true, create: true });
+   * await Deno.ftruncate(file.rid);
+   *
+   * // truncate part of the file
+   * const file = Deno.open("my_file.txt", { read: true, write: true, create: true });
+   * await Deno.write(file.rid, new TextEncoder().encode("Hello World"));
+   * await Deno.ftruncate(file.rid, 7);
+   * const data = new Uint8Array(32);
+   * await Deno.read(file.rid, data);
+   * console.log(new TextDecoder().decode(data)); // Hello W
+   * ```
+   */
+  export function ftruncate(rid: number, len?: number): Promise<void>;
 }

--- a/cli/js/ops/fs/truncate.ts
+++ b/cli/js/ops/fs/truncate.ts
@@ -13,6 +13,14 @@ function coerceLen(len?: number): number {
   return len;
 }
 
+export function ftruncateSync(rid: number, len?: number): void {
+  sendSync("op_ftruncate", { rid, len: coerceLen(len) });
+}
+
+export async function ftruncate(rid: number, len?: number): Promise<void> {
+  await sendAsync("op_ftruncate", { rid, len: coerceLen(len) });
+}
+
 export function truncateSync(path: string, len?: number): void {
   sendSync("op_truncate", { path, len: coerceLen(len) });
 }

--- a/cli/tests/unit/truncate_test.ts
+++ b/cli/tests/unit/truncate_test.ts
@@ -3,6 +3,50 @@ import { unitTest, assertEquals, assert } from "./test_util.ts";
 
 unitTest(
   { perms: { read: true, write: true } },
+  function ftruncateSyncSuccess(): void {
+    const filename = Deno.makeTempDirSync() + "/test_ftruncateSync.txt";
+    const file = Deno.openSync(filename, {
+      create: true,
+      read: true,
+      write: true,
+    });
+
+    Deno.ftruncateSync(file.rid, 20);
+    assertEquals(Deno.readFileSync(filename).byteLength, 20);
+    Deno.ftruncateSync(file.rid, 5);
+    assertEquals(Deno.readFileSync(filename).byteLength, 5);
+    Deno.ftruncateSync(file.rid, -5);
+    assertEquals(Deno.readFileSync(filename).byteLength, 0);
+
+    Deno.close(file.rid);
+    Deno.removeSync(filename);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function ftruncateSuccess(): Promise<void> {
+    const filename = Deno.makeTempDirSync() + "/test_ftruncate.txt";
+    const file = await Deno.open(filename, {
+      create: true,
+      read: true,
+      write: true,
+    });
+
+    await Deno.ftruncate(file.rid, 20);
+    assertEquals((await Deno.readFile(filename)).byteLength, 20);
+    await Deno.ftruncate(file.rid, 5);
+    assertEquals((await Deno.readFile(filename)).byteLength, 5);
+    await Deno.ftruncate(file.rid, -5);
+    assertEquals((await Deno.readFile(filename)).byteLength, 0);
+
+    Deno.close(file.rid);
+    await Deno.remove(filename);
+  }
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
   function truncateSyncSuccess(): void {
     const filename = Deno.makeTempDirSync() + "/test_truncateSync.txt";
     Deno.writeFileSync(filename, new Uint8Array(5));


### PR DESCRIPTION
This adds a new op exposed as `Deno.ftruncateSync` and `Deno.ftruncate` taking a `rid` allowing file streams to be truncated.

I'll address adding truncateSync and truncate methods to the `Deno.File` class in a follow-up if this op gets merged.

This would resolve #5767