### PR TITLE
fix(std/io): BufWriter/StringWriter bug

### DIFF
--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -486,6 +486,7 @@ export class BufWriter extends AbstractBufBase implements Writer {
 
     this.checkBytesWritten(numBytesWritten);
 
+    this.buf = new Uint8Array(this.buf.length);
     this.usedBufferBytes = 0;
   }
 
@@ -580,6 +581,7 @@ export class BufWriterSync extends AbstractBufBase implements WriterSync {
 
     this.checkBytesWritten(numBytesWritten);
 
+    this.buf = new Uint8Array(this.buf.length);
     this.usedBufferBytes = 0;
   }
 

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -18,6 +18,7 @@ import {
 } from "./bufio.ts";
 import * as iotest from "./_iotest.ts";
 import { StringReader } from "./readers.ts";
+import { StringWriter } from "./writers.ts";
 import { charCode, copyBytes } from "./util.ts";
 
 const encoder = new TextEncoder();
@@ -469,3 +470,33 @@ Deno.test(
     );
   }
 );
+
+Deno.test({
+  name: "Reset buffer after flush",
+  async fn(): Promise<void> {
+    const stringWriter = new StringWriter();
+    const bufWriter = new BufWriter(stringWriter);
+    const encoder = new TextEncoder();
+    await bufWriter.write(encoder.encode("hello\nworld\nhow\nare\nyou?\n\n"));
+    await bufWriter.flush();
+    await bufWriter.write(encoder.encode("foobar\n\n"));
+    await bufWriter.flush();
+    const actual = stringWriter.toString();
+    assertEquals(actual, "hello\nworld\nhow\nare\nyou?\n\nfoobar\n\n");
+  },
+});
+
+Deno.test({
+  name: "Reset buffer after flush sync",
+  fn(): void {
+    const stringWriter = new StringWriter();
+    const bufWriter = new BufWriterSync(stringWriter);
+    const encoder = new TextEncoder();
+    bufWriter.writeSync(encoder.encode("hello\nworld\nhow\nare\nyou?\n\n"));
+    bufWriter.flush();
+    bufWriter.writeSync(encoder.encode("foobar\n\n"));
+    bufWriter.flush();
+    const actual = stringWriter.toString();
+    assertEquals(actual, "hello\nworld\nhow\nare\nyou?\n\nfoobar\n\n");
+  },
+});

--- a/std/io/writers.ts
+++ b/std/io/writers.ts
@@ -1,9 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 type Writer = Deno.Writer;
+type WriterSync = Deno.WriterSync;
 import { decode, encode } from "../encoding/utf8.ts";
 
 /** Writer utility for buffering string chunks */
-export class StringWriter implements Writer {
+export class StringWriter implements Writer, WriterSync {
   private chunks: Uint8Array[] = [];
   private byteLength = 0;
   private cache: string | undefined;
@@ -15,10 +16,14 @@ export class StringWriter implements Writer {
   }
 
   write(p: Uint8Array): Promise<number> {
+    return Promise.resolve(this.writeSync(p));
+  }
+
+  writeSync(p: Uint8Array): number {
     this.chunks.push(p);
     this.byteLength += p.byteLength;
     this.cache = undefined;
-    return Promise.resolve(p.byteLength);
+    return p.byteLength;
   }
 
   toString(): string {

--- a/std/io/writers_test.ts
+++ b/std/io/writers_test.ts
@@ -12,3 +12,12 @@ test("ioStringWriter", async function (): Promise<void> {
   await copy(r, w);
   assertEquals(w.toString(), "base0123456789");
 });
+
+test("ioStringWriterSync", function (): void {
+  const encoder = new TextEncoder();
+  const w = new StringWriter("");
+  w.writeSync(encoder.encode("deno"));
+  assertEquals(w.toString(), "deno");
+  w.writeSync(encoder.encode("\nland"));
+  assertEquals(w.toString(), "deno\nland");
+});


### PR DESCRIPTION
Fixes #6220

The issue is that `StringWriter` buffers the `Uint8Array` in every `.write`, and that chunk is pointing to the buffer from `BufWriter`, so when a new chunk is written, is modifying the buffered chunk in `StringWriter`.

There are at least 3 possible solutions that I can think of:

- Using `.slice` instead of `.subarray` in `BufWriter.flush` (The one I used to show the issue)
- Resetting `this.buf` in `BufWriter.flush`: `this.buf = new Uint8Array(this.buf.length)`
- Using `p.slice` in `StringWriter.write` 

