### PR TITLE
update: deno lint to v0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886dbbba1d26b726e4e6c4c03001b7f21b31384acb2a038e5bce430c42de4190"
+checksum = "dc10bb331262fd598e6925ab8b59f72b01cc9c3a5a818ce7d57652e4b23fe45a"
 dependencies = [
  "lazy_static",
  "regex",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,7 +20,7 @@ deno_typescript = { path = "../deno_typescript", version = "0.47.1" }
 
 [dependencies]
 deno_core = { path = "../core", version = "0.47.1" }
-deno_lint = { version = "0.1.9" }
+deno_lint = { version = "0.1.10" }
 deno_typescript = { path = "../deno_typescript", version = "0.47.1" }
 
 atty = "0.2.14"

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -264,7 +264,7 @@ fn write_file_contents(
   Ok(fs::write(file_path, file_text)?)
 }
 
-async fn run_parallelized<F>(
+pub async fn run_parallelized<F>(
   file_paths: Vec<PathBuf>,
   f: F,
 ) -> Result<(), ErrBox>

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -10,6 +10,7 @@
 use crate::colors;
 use crate::file_fetcher::map_file_extension;
 use crate::fmt::collect_files;
+use crate::fmt::run_parallelized;
 use crate::fmt_errors;
 use crate::swc_util;
 use deno_core::ErrBox;
@@ -18,27 +19,61 @@ use deno_lint::linter::Linter;
 use deno_lint::rules;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
-pub fn lint_files(args: Vec<String>) -> Result<(), ErrBox> {
+pub async fn lint_files(args: Vec<String>) -> Result<(), ErrBox> {
   let target_files = collect_files(args)?;
 
-  let mut error_counts = 0;
+  let error_count = Arc::new(AtomicUsize::new(0));
 
-  for file_path in target_files {
-    let file_diagnostics = lint_file(file_path)?;
-    error_counts += file_diagnostics.len();
-    for d in file_diagnostics.iter() {
-      let fmt_diagnostic = format_diagnostic(d);
-      eprintln!("{}\n", fmt_diagnostic);
+  // prevent threads outputting at the same time
+  let output_lock = Arc::new(Mutex::new(0));
+
+  run_parallelized(target_files, {
+    let error_count = error_count.clone();
+    move |file_path| {
+      let r = lint_file(file_path.clone());
+
+      match r {
+        Ok(file_diagnostics) => {
+          error_count.fetch_add(file_diagnostics.len(), Ordering::SeqCst);
+          let _g = output_lock.lock().unwrap();
+          for d in file_diagnostics.iter() {
+            let fmt_diagnostic = format_diagnostic(d);
+            eprintln!("{}\n", fmt_diagnostic);
+          }
+        }
+        Err(err) => {
+          eprintln!("Error linting: {}", file_path.to_string_lossy());
+          eprintln!("   {}", err);
+        }
+      }
+      Ok(())
     }
-  }
+  })
+  .await?;
 
-  if error_counts > 0 {
-    eprintln!("Found {} problems", error_counts);
+  let error_count = error_count.load(Ordering::SeqCst);
+  if error_count > 0 {
+    eprintln!("Found {} problems", error_count);
     std::process::exit(1);
   }
 
   Ok(())
+}
+
+fn create_linter() -> Linter {
+  Linter::new(
+    "deno-lint-ignore-file".to_string(),
+    vec![
+      "deno-lint-ignore".to_string(),
+      "eslint-disable-next-line".to_string(),
+    ],
+    // TODO(bartlomieju): switch to true, once
+    // https://github.com/denoland/deno_lint/issues/156 is fixed
+    false,
+  )
 }
 
 fn lint_file(file_path: PathBuf) -> Result<Vec<LintDiagnostic>, ErrBox> {
@@ -47,7 +82,7 @@ fn lint_file(file_path: PathBuf) -> Result<Vec<LintDiagnostic>, ErrBox> {
   let media_type = map_file_extension(&file_path);
   let syntax = swc_util::get_syntax_for_media_type(media_type);
 
-  let mut linter = Linter::default();
+  let mut linter = create_linter();
   let lint_rules = rules::get_recommended_rules();
 
   let file_diagnostics =

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -24,6 +24,7 @@ use std::sync::{Arc, Mutex};
 
 pub async fn lint_files(args: Vec<String>) -> Result<(), ErrBox> {
   let target_files = collect_files(args)?;
+  debug!("Found {} files", target_files.len());
 
   let error_count = Arc::new(AtomicUsize::new(0));
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -331,7 +331,7 @@ async fn lint_command(flags: Flags, files: Vec<String>) -> Result<(), ErrBox> {
   )?;
 
   state.check_unstable("lint");
-  lint::lint_files(files)
+  lint::lint_files(files).await
 }
 
 async fn cache_command(flags: Flags, files: Vec<String>) -> Result<(), ErrBox> {

--- a/cli/tests/lint/expected.out
+++ b/cli/tests/lint/expected.out
@@ -1,26 +1,2 @@
-(ban-untagged-ignore) Ignore directive requires lint rule code
-// deno-lint-ignore
-~~~~~~~~~~~~~~~~~~~
-    at [WILDCARD]file1.js:1:0
-
-(no-empty) Empty block statement
-while (false) {}
-              ~~
-    at [WILDCARD]file1.js:2:14
-
-(no-empty) Empty block statement
-} catch (e) {}
-            ~~
-    at [WILDCARD]file2.ts:3:12
-
-(ban-unused-ignore) Ignore for code "require-await" was not used.
-// deno-lint-ignore no-explicit-any require-await
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    at [WILDCARD]file2.ts:5:0
-
-(no-empty-function) Empty functions are not allowed
-function foo(): any {}
-~~~~~~~~~~~~~~~~~~~~~~
-    at [WILDCARD]file2.ts:6:0
-
-Found 5 problems
+[WILDCARD]
+Found 3 problems

--- a/cli/tests/lint/expected_glob.out
+++ b/cli/tests/lint/expected_glob.out
@@ -1,2 +1,2 @@
 [WILDCARD]
-Found 5 problems
+Found 3 problems


### PR DESCRIPTION
Also parallelize linting (closes #6236)

```
$ time target/release/deno lint --unstable ./std/
target/release/deno lint --unstable ./std/  3.90s user 0.38s system 627% cpu 0.682 total
```

```
$ ./third_party/prebuilt/mac/hyperfine -w 3 -i 'target/release/deno lint --unstable ./std'
Benchmark #1: target/release/deno lint --unstable ./std

  Time (mean ± σ):     610.1 ms ±  22.6 ms    [User: 3.899 s, System: 0.292 s]

  Range (min … max):   587.9 ms … 657.3 ms

  Warning: Ignoring non-zero exit code.

```