### PR TITLE
Fix broken truncate permission tests

### DIFF
--- a/cli/tests/unit/truncate_test.ts
+++ b/cli/tests/unit/truncate_test.ts
@@ -58,7 +58,7 @@ unitTest(
 unitTest({ perms: { write: false } }, function truncateSyncPerm(): void {
   let err;
   try {
-    Deno.mkdirSync("/test_truncateSyncPermission.txt");
+    Deno.truncateSync("/test_truncateSyncPermission.txt");
   } catch (e) {
     err = e;
   }
@@ -71,7 +71,7 @@ unitTest({ perms: { write: false } }, async function truncatePerm(): Promise<
 > {
   let err;
   try {
-    await Deno.mkdir("/test_truncatePermission.txt");
+    await Deno.truncate("/test_truncatePermission.txt");
   } catch (e) {
     err = e;
   }


### PR DESCRIPTION
The tests for testing that `Deno.truncateSync` and `Deno.truncate` require write permissions seem to not call the functions they are testing *at all* and are calling `Deno.mkdir` and `Deno.mkdirSync`
instead.

This replaces those calls with calls to `Deno.truncateSync` and `Deno.truncate` respectively.