### PR TITLE
Fix incorrect assumption truncate tests

### DIFF
--- a/cli/tests/unit/truncate_test.ts
+++ b/cli/tests/unit/truncate_test.ts
@@ -1,36 +1,17 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { unitTest, assertEquals, assert } from "./test_util.ts";
 
-function readDataSync(name: string): string {
-  const data = Deno.readFileSync(name);
-  const decoder = new TextDecoder("utf-8");
-  const text = decoder.decode(data);
-  return text;
-}
-
-async function readData(name: string): Promise<string> {
-  const data = await Deno.readFile(name);
-  const decoder = new TextDecoder("utf-8");
-  const text = decoder.decode(data);
-  return text;
-}
-
 unitTest(
   { perms: { read: true, write: true } },
   function truncateSyncSuccess(): void {
-    const enc = new TextEncoder();
-    const d = enc.encode("Hello");
     const filename = Deno.makeTempDirSync() + "/test_truncateSync.txt";
-    Deno.writeFileSync(filename, d);
+    Deno.writeFileSync(filename, new Uint8Array(5));
     Deno.truncateSync(filename, 20);
-    let data = readDataSync(filename);
-    assertEquals(data.length, 20);
+    assertEquals(Deno.readFileSync(filename).byteLength, 20);
     Deno.truncateSync(filename, 5);
-    data = readDataSync(filename);
-    assertEquals(data.length, 5);
+    assertEquals(Deno.readFileSync(filename).byteLength, 5);
     Deno.truncateSync(filename, -5);
-    data = readDataSync(filename);
-    assertEquals(data.length, 0);
+    assertEquals(Deno.readFileSync(filename).byteLength, 0);
     Deno.removeSync(filename);
   }
 );
@@ -38,19 +19,14 @@ unitTest(
 unitTest(
   { perms: { read: true, write: true } },
   async function truncateSuccess(): Promise<void> {
-    const enc = new TextEncoder();
-    const d = enc.encode("Hello");
     const filename = Deno.makeTempDirSync() + "/test_truncate.txt";
-    await Deno.writeFile(filename, d);
+    await Deno.writeFile(filename, new Uint8Array(5));
     await Deno.truncate(filename, 20);
-    let data = await readData(filename);
-    assertEquals(data.length, 20);
+    assertEquals((await Deno.readFile(filename)).byteLength, 20);
     await Deno.truncate(filename, 5);
-    data = await readData(filename);
-    assertEquals(data.length, 5);
+    assertEquals((await Deno.readFile(filename)).byteLength, 5);
     await Deno.truncate(filename, -5);
-    data = await readData(filename);
-    assertEquals(data.length, 0);
+    assertEquals((await Deno.readFile(filename)).byteLength, 0);
     await Deno.remove(filename);
   }
 );


### PR DESCRIPTION
The tests for `Deno.truncateSync` and `Deno.truncate` are making the incorrect assumption that a string's length is equal to the number of bytes, which is not true and works just due to circumstance where no characters in the string are outside of the ASCII range.

This removes any conversion to strings in the tests and just checks the raw byte-length to what it is expected to be.