### PR TITLE
feat: expose assert in Deno namespace

### DIFF
--- a/cli/js/assert.ts
+++ b/cli/js/assert.ts
@@ -1,0 +1,41 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface AssertionErrorOptions {
+  message?: string;
+  actual?: any;
+  expected?: any;
+  operator?: string;
+  stackStartFn?: Function;
+}
+
+export class AssertionError extends Error {
+  actual?: any;
+  expected?: any;
+  operator?: string;
+
+  constructor({
+    message,
+    actual,
+    expected,
+    operator,
+    stackStartFn = AssertionError,
+  }: AssertionErrorOptions = {}) {
+    super(message);
+    this.name = "AssertionError";
+    this.actual = actual;
+    this.expected = expected;
+    this.operator = operator;
+    Error.captureStackTrace(this, stackStartFn);
+  }
+}
+/* eslint-enable */
+
+export function assert(
+  cond: unknown,
+  message = "Assertion failed."
+): asserts cond {
+  if (!cond) {
+    throw new AssertionError({ message, stackStartFn: assert });
+  }
+}

--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -4,8 +4,8 @@
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.
 // https://github.com/golang/go/blob/master/LICENSE
 
+import { assert } from "./assert.ts";
 import type { Reader, Writer, ReaderSync, WriterSync } from "./io.ts";
-import { assert } from "./util.ts";
 
 // MIN_READ is the minimum ArrayBuffer size passed to a read call by
 // buffer.ReadFrom. As long as the Buffer has at least MIN_READ bytes beyond

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -13,13 +13,14 @@
 // NOTE: this import has side effects!
 import "./ts_global.d.ts";
 
+import { assert } from "./assert.ts";
 import { bold, cyan, yellow } from "./colors.ts";
 import type { CompilerOptions } from "./compiler_options.ts";
 import type { Diagnostic, DiagnosticItem } from "./diagnostics.ts";
 import { fromTypeScriptDiagnostic } from "./diagnostics_util.ts";
 import type { TranspileOnlyResult } from "./ops/runtime_compiler.ts";
 import { bootstrapWorkerRuntime } from "./runtime_worker.ts";
-import { assert, log, notImplemented } from "./util.ts";
+import { log, notImplemented } from "./util.ts";
 import { core } from "./core.ts";
 
 // We really don't want to depend on JSON dispatch during snapshotting, so

--- a/cli/js/compiler_api.ts
+++ b/cli/js/compiler_api.ts
@@ -3,6 +3,7 @@
 // This file contains the runtime APIs which will dispatch work to the internal
 // compiler within Deno.
 
+import { assert } from "./assert.ts";
 import type { DiagnosticItem } from "./diagnostics.ts";
 import * as util from "./util.ts";
 import * as runtimeCompilerOps from "./ops/runtime_compiler.ts";
@@ -18,7 +19,7 @@ function checkRelative(specifier: string): string {
 // TODO(bartlomieju): change return type to interface?
 export function transpileOnly(
   sources: Record<string, string>,
-  options: CompilerOptions = {}
+  options: CompilerOptions = {},
 ): Promise<Record<string, TranspileOnlyResult>> {
   util.log("Deno.transpileOnly", { sources: Object.keys(sources), options });
   const payload = {
@@ -32,7 +33,7 @@ export function transpileOnly(
 export async function compile(
   rootName: string,
   sources?: Record<string, string>,
-  options: CompilerOptions = {}
+  options: CompilerOptions = {},
 ): Promise<[DiagnosticItem[] | undefined, Record<string, string>]> {
   const payload = {
     rootName: sources ? rootName : checkRelative(rootName),
@@ -46,9 +47,10 @@ export async function compile(
     options,
   });
   const result = await runtimeCompilerOps.compile(payload);
-  util.assert(result.emitMap);
-  const maybeDiagnostics =
-    result.diagnostics.length === 0 ? undefined : result.diagnostics;
+  assert(result.emitMap);
+  const maybeDiagnostics = result.diagnostics.length === 0
+    ? undefined
+    : result.diagnostics;
 
   const emitMap: Record<string, string> = {};
 
@@ -63,7 +65,7 @@ export async function compile(
 export async function bundle(
   rootName: string,
   sources?: Record<string, string>,
-  options: CompilerOptions = {}
+  options: CompilerOptions = {},
 ): Promise<[DiagnosticItem[] | undefined, string]> {
   const payload = {
     rootName: sources ? rootName : checkRelative(rootName),
@@ -77,8 +79,9 @@ export async function bundle(
     options,
   });
   const result = await runtimeCompilerOps.compile(payload);
-  util.assert(result.output);
-  const maybeDiagnostics =
-    result.diagnostics.length === 0 ? undefined : result.diagnostics;
+  assert(result.output);
+  const maybeDiagnostics = result.diagnostics.length === 0
+    ? undefined
+    : result.diagnostics;
   return [maybeDiagnostics, result.output];
 }

--- a/cli/js/compiler_api.ts
+++ b/cli/js/compiler_api.ts
@@ -19,7 +19,7 @@ function checkRelative(specifier: string): string {
 // TODO(bartlomieju): change return type to interface?
 export function transpileOnly(
   sources: Record<string, string>,
-  options: CompilerOptions = {},
+  options: CompilerOptions = {}
 ): Promise<Record<string, TranspileOnlyResult>> {
   util.log("Deno.transpileOnly", { sources: Object.keys(sources), options });
   const payload = {
@@ -33,7 +33,7 @@ export function transpileOnly(
 export async function compile(
   rootName: string,
   sources?: Record<string, string>,
-  options: CompilerOptions = {},
+  options: CompilerOptions = {}
 ): Promise<[DiagnosticItem[] | undefined, Record<string, string>]> {
   const payload = {
     rootName: sources ? rootName : checkRelative(rootName),
@@ -48,9 +48,8 @@ export async function compile(
   });
   const result = await runtimeCompilerOps.compile(payload);
   assert(result.emitMap);
-  const maybeDiagnostics = result.diagnostics.length === 0
-    ? undefined
-    : result.diagnostics;
+  const maybeDiagnostics =
+    result.diagnostics.length === 0 ? undefined : result.diagnostics;
 
   const emitMap: Record<string, string> = {};
 
@@ -65,7 +64,7 @@ export async function compile(
 export async function bundle(
   rootName: string,
   sources?: Record<string, string>,
-  options: CompilerOptions = {},
+  options: CompilerOptions = {}
 ): Promise<[DiagnosticItem[] | undefined, string]> {
   const payload = {
     rootName: sources ? rootName : checkRelative(rootName),
@@ -80,8 +79,7 @@ export async function bundle(
   });
   const result = await runtimeCompilerOps.compile(payload);
   assert(result.output);
-  const maybeDiagnostics = result.diagnostics.length === 0
-    ? undefined
-    : result.diagnostics;
+  const maybeDiagnostics =
+    result.diagnostics.length === 0 ? undefined : result.diagnostics;
   return [maybeDiagnostics, result.output];
 }

--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -2,6 +2,8 @@
 
 // This module exports stable Deno APIs.
 
+export { AssertionError } from "./assert.ts";
+export type { AssertionErrorOptions } from "./assert.ts";
 export {
   Buffer,
   readAll,

--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -2,7 +2,7 @@
 
 // This module exports stable Deno APIs.
 
-export { AssertionError } from "./assert.ts";
+export { assert, AssertionError } from "./assert.ts";
 export type { AssertionErrorOptions } from "./assert.ts";
 export {
   Buffer,

--- a/cli/js/error_stack.ts
+++ b/cli/js/error_stack.ts
@@ -2,9 +2,9 @@
 
 // Some of the code here is adapted directly from V8 and licensed under a BSD
 // style license available here: https://github.com/v8/v8/blob/24886f2d1c565287d33d71e4109a53bf0b54b75c/LICENSE.v8
+import { assert } from "./assert.ts";
 import * as colors from "./colors.ts";
 import { applySourceMap, Location } from "./ops/errors.ts";
-import { assert } from "./util.ts";
 import { exposeForTest } from "./internals.ts";
 
 function patchCallSite(callSite: CallSite, location: Location): CallSite {

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -2,6 +2,7 @@
 
 import "./lib.deno.shared_globals.d.ts";
 
+import * as assert from "./assert.ts";
 import * as abortController from "./web/abort_controller.ts";
 import * as abortSignal from "./web/abort_signal.ts";
 import * as blob from "./web/blob.ts";
@@ -201,6 +202,7 @@ export function getterOnly(getter: () => any): PropertyDescriptor {
 
 // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope
 export const windowOrWorkerGlobalScopeMethods = {
+  assert: writable(assert.assert),
   atob: writable(textEncoding.atob),
   btoa: writable(textEncoding.btoa),
   clearInterval: writable(timers.clearInterval),

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -2,7 +2,6 @@
 
 import "./lib.deno.shared_globals.d.ts";
 
-import * as assert from "./assert.ts";
 import * as abortController from "./web/abort_controller.ts";
 import * as abortSignal from "./web/abort_signal.ts";
 import * as blob from "./web/blob.ts";
@@ -202,7 +201,6 @@ export function getterOnly(getter: () => any): PropertyDescriptor {
 
 // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope
 export const windowOrWorkerGlobalScopeMethods = {
-  assert: writable(assert.assert),
   atob: writable(textEncoding.atob),
   btoa: writable(textEncoding.btoa),
   clearInterval: writable(timers.clearInterval),

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -81,6 +81,13 @@ declare namespace Deno {
   }
   /* eslint-enable */
 
+  /** Asserts that the condition argument is "truthy".  If the assertion fails,
+   * a `Deno.AssertionError` will be raised. */
+  export function assert(
+    condition: unknown,
+    message?: string
+  ): asserts condition;
+
   /** The current process id of the runtime. */
   export const pid: number;
 

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -42,6 +42,45 @@ declare namespace Deno {
     Busy: ErrorConstructor;
   };
 
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  export interface AssertionErrorOptions {
+    /** If provided, the error message is set to this value. */
+    message?: string;
+
+    /** The `actual` property on the error instance. */
+    actual?: any;
+
+    /** The `expected` property on the error instance. */
+    expected?: any;
+
+    /** The `operator` property on the error instance. */
+    operator?: string;
+
+    /** If provided, the generated stack trace omits frames before this
+     * function. */
+    stackStartFn?: Function;
+  }
+
+  /** A class of error that indicates a failure of an assertion.  It includes
+   * properties that make it possible to provide informative diagnostic
+   * information about the failure. */
+  export class AssertionError extends Error {
+    /** Set to the `actual` argument for assertions where there is an actual
+     * and expected arguments. */
+    actual?: any;
+
+    /** Set to the `expected` argument for assertions where there is an actual
+     * and expected arguments. */
+    expected?: any;
+
+    /** Set to the `operator` that was used to compare the actual and expected
+     * results. */
+    operator?: string;
+
+    constructor(options?: AssertionErrorOptions);
+  }
+  /* eslint-enable */
+
   /** The current process id of the runtime. */
   export const pid: number;
 

--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -174,6 +174,13 @@ declare namespace WebAssembly {
   }
 }
 
+/** Asserts that the condition argument is "truthy".  If the assertion fails,
+ * a `Deno.AssertionError` will be raised. */
+declare function assert(
+  condition: unknown,
+  message?: string
+): asserts condition;
+
 /** Sets a timer which executes a function once after the timer expires. Returns
  * an id which may be used to cancel the timeout.
  *

--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -174,13 +174,6 @@ declare namespace WebAssembly {
   }
 }
 
-/** Asserts that the condition argument is "truthy".  If the assertion fails,
- * a `Deno.AssertionError` will be raised. */
-declare function assert(
-  condition: unknown,
-  message?: string
-): asserts condition;
-
 /** Sets a timer which executes a function once after the timer expires. Returns
  * an id which may be used to cancel the timeout.
  *

--- a/cli/js/ops/dispatch_json.ts
+++ b/cli/js/ops/dispatch_json.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+import { assert } from "../assert.ts";
 import * as util from "../util.ts";
 import { core } from "../core.ts";
 import { ErrorKind, getErrorClass } from "../errors.ts";
@@ -41,16 +42,16 @@ function unwrapResponse(res: JsonResponse): Ok {
   if (res.err != null) {
     throw new (getErrorClass(res.err.kind))(res.err.message);
   }
-  util.assert(res.ok != null);
+  assert(res.ok != null);
   return res.ok;
 }
 
 export function asyncMsgFromRust(resUi8: Uint8Array): void {
   const res = decode(resUi8);
-  util.assert(res.promiseId != null);
+  assert(res.promiseId != null);
 
   const promise = promiseTable[res.promiseId!];
-  util.assert(promise != null);
+  assert(promise != null);
   delete promiseTable[res.promiseId!];
   promise.resolve(res);
 }
@@ -63,9 +64,9 @@ export function sendSync(
   util.log("sendSync", opName);
   const argsUi8 = encode(args);
   const resUi8 = core.dispatchByName(opName, argsUi8, ...zeroCopy);
-  util.assert(resUi8 != null);
+  assert(resUi8 != null);
   const res = decode(resUi8);
-  util.assert(res.promiseId == null);
+  assert(res.promiseId == null);
   return unwrapResponse(res);
 }
 

--- a/cli/js/ops/dispatch_minimal.ts
+++ b/cli/js/ops/dispatch_minimal.ts
@@ -38,7 +38,7 @@ export function recordFromBufMinimal(ui8: Uint8Array): RecordMinimal {
   const buf32 = new Int32Array(
     header.buffer,
     header.byteOffset,
-    header.byteLength / 4,
+    header.byteLength / 4
   );
   const promiseId = buf32[0];
   const arg = buf32[1];
@@ -72,7 +72,7 @@ const scratch32 = new Int32Array(3);
 const scratchBytes = new Uint8Array(
   scratch32.buffer,
   scratch32.byteOffset,
-  scratch32.byteLength,
+  scratch32.byteLength
 );
 assert(scratchBytes.byteLength === scratch32.length * 4);
 
@@ -88,7 +88,7 @@ export function asyncMsgFromRust(ui8: Uint8Array): void {
 export async function sendAsyncMinimal(
   opName: string,
   arg: number,
-  zeroCopy: Uint8Array,
+  zeroCopy: Uint8Array
 ): Promise<number> {
   const promiseId = nextPromiseId(); // AKA cmdId
   scratch32[0] = promiseId;
@@ -112,7 +112,7 @@ export async function sendAsyncMinimal(
 export function sendSyncMinimal(
   opName: string,
   arg: number,
-  zeroCopy: Uint8Array,
+  zeroCopy: Uint8Array
 ): number {
   scratch32[0] = 0; // promiseId 0 indicates sync
   scratch32[1] = arg;

--- a/cli/js/ops/dispatch_minimal.ts
+++ b/cli/js/ops/dispatch_minimal.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+import { assert } from "../assert.ts";
 import * as util from "../util.ts";
 import { core } from "../core.ts";
 import { TextDecoder } from "../web/text_encoding.ts";
@@ -37,7 +38,7 @@ export function recordFromBufMinimal(ui8: Uint8Array): RecordMinimal {
   const buf32 = new Int32Array(
     header.buffer,
     header.byteOffset,
-    header.byteLength / 4
+    header.byteLength / 4,
   );
   const promiseId = buf32[0];
   const arg = buf32[1];
@@ -71,23 +72,23 @@ const scratch32 = new Int32Array(3);
 const scratchBytes = new Uint8Array(
   scratch32.buffer,
   scratch32.byteOffset,
-  scratch32.byteLength
+  scratch32.byteLength,
 );
-util.assert(scratchBytes.byteLength === scratch32.length * 4);
+assert(scratchBytes.byteLength === scratch32.length * 4);
 
 export function asyncMsgFromRust(ui8: Uint8Array): void {
   const record = recordFromBufMinimal(ui8);
   const { promiseId } = record;
   const promise = promiseTableMin[promiseId];
   delete promiseTableMin[promiseId];
-  util.assert(promise);
+  assert(promise);
   promise.resolve(record);
 }
 
 export async function sendAsyncMinimal(
   opName: string,
   arg: number,
-  zeroCopy: Uint8Array
+  zeroCopy: Uint8Array,
 ): Promise<number> {
   const promiseId = nextPromiseId(); // AKA cmdId
   scratch32[0] = promiseId;
@@ -111,7 +112,7 @@ export async function sendAsyncMinimal(
 export function sendSyncMinimal(
   opName: string,
   arg: number,
-  zeroCopy: Uint8Array
+  zeroCopy: Uint8Array,
 ): number {
   scratch32[0] = 0; // promiseId 0 indicates sync
   scratch32[1] = arg;

--- a/cli/js/ops/get_random_values.ts
+++ b/cli/js/ops/get_random_values.ts
@@ -11,14 +11,14 @@ export function getRandomValues<
     | Int16Array
     | Uint16Array
     | Int32Array
-    | Uint32Array,
+    | Uint32Array
 >(typedArray: T): T {
   assert(typedArray !== null, "Input must not be null");
   assert(typedArray.length <= 65536, "Input must not be longer than 65536");
   const ui8 = new Uint8Array(
     typedArray.buffer,
     typedArray.byteOffset,
-    typedArray.byteLength,
+    typedArray.byteLength
   );
   sendSync("op_get_random_values", {}, ui8);
   return typedArray;

--- a/cli/js/ops/get_random_values.ts
+++ b/cli/js/ops/get_random_values.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+import { assert } from "../assert.ts";
 import { sendSync } from "./dispatch_json.ts";
-import { assert } from "../util.ts";
 
 export function getRandomValues<
   T extends
@@ -11,14 +11,14 @@ export function getRandomValues<
     | Int16Array
     | Uint16Array
     | Int32Array
-    | Uint32Array
+    | Uint32Array,
 >(typedArray: T): T {
   assert(typedArray !== null, "Input must not be null");
   assert(typedArray.length <= 65536, "Input must not be longer than 65536");
   const ui8 = new Uint8Array(
     typedArray.buffer,
     typedArray.byteOffset,
-    typedArray.byteLength
+    typedArray.byteLength,
   );
   sendSync("op_get_random_values", {}, ui8);
   return typedArray;

--- a/cli/js/ops/process.ts
+++ b/cli/js/ops/process.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+import { assert } from "../assert.ts";
 import { sendSync, sendAsync } from "./dispatch_json.ts";
-import { assert } from "../util.ts";
 
 export function kill(pid: number, signo: number): void {
   sendSync("op_kill", { pid, signo });

--- a/cli/js/rbtree.ts
+++ b/cli/js/rbtree.ts
@@ -2,7 +2,7 @@
 
 // Derived from https://github.com/vadimg/js_bintrees. MIT Licensed.
 
-import { assert } from "./util.ts";
+import { assert } from "./assert.ts";
 
 class RBNode<T> {
   public left: this | null;

--- a/cli/js/runtime_worker.ts
+++ b/cli/js/runtime_worker.ts
@@ -8,6 +8,7 @@
 //   It sets up runtime by providing globals for `DedicatedWorkerScope`.
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { assert } from "./assert.ts";
 import {
   readOnly,
   writable,
@@ -21,7 +22,7 @@ import { unstableMethods, unstableProperties } from "./globals_unstable.ts";
 import * as denoNs from "./deno.ts";
 import * as denoUnstableNs from "./deno_unstable.ts";
 import * as webWorkerOps from "./ops/web_worker.ts";
-import { log, assert, immutableDefine } from "./util.ts";
+import { log, immutableDefine } from "./util.ts";
 import { ErrorEventImpl as ErrorEvent } from "./web/error_event.ts";
 import { MessageEvent } from "./web/workers.ts";
 import { TextEncoder } from "./web/text_encoding.ts";

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+import { assert } from "./assert.ts";
 import { gray, green, italic, red, yellow } from "./colors.ts";
 import { exit } from "./ops/os.ts";
 import { Console, stringifyArgs } from "./web/console.ts";
@@ -8,7 +9,6 @@ import { exposeForTest } from "./internals.ts";
 import { TextEncoder } from "./web/text_encoding.ts";
 import { metrics } from "./ops/runtime.ts";
 import { resources } from "./ops/resources.ts";
-import { assert } from "./util.ts";
 
 const disabledConsole = new Console((): void => {});
 
@@ -52,7 +52,7 @@ After:
   - completed: ${post.opsCompletedAsync}
 
 Make sure to await all promises returned from Deno APIs before
-finishing test case.`
+finishing test case.`,
     );
   };
 }
@@ -61,7 +61,7 @@ finishing test case.`
 // the test case does not "leak" resources - ie. resource table after
 // the test has exactly the same contents as before the test.
 function assertResources(
-  fn: () => void | Promise<void>
+  fn: () => void | Promise<void>,
 ): () => void | Promise<void> {
   return async function resourceSanitizer(): Promise<void> {
     const pre = resources();
@@ -97,7 +97,7 @@ export function test(name: string, fn: () => void | Promise<void>): void;
 // creates a new object with "name" and "fn" fields.
 export function test(
   t: string | TestDefinition,
-  fn?: () => void | Promise<void>
+  fn?: () => void | Promise<void>,
 ): void {
   let testDef: TestDefinition;
   const defaults = {
@@ -220,7 +220,7 @@ function reportToConsole(message: TestMessage): void {
         `${message.end.passed} passed; ${message.end.failed} failed; ` +
         `${message.end.ignored} ignored; ${message.end.measured} measured; ` +
         `${message.end.filtered} filtered out ` +
-        `${formatDuration(message.end.duration)}\n`
+        `${formatDuration(message.end.duration)}\n`,
     );
 
     if (message.end.usedOnly && message.end.failed == 0) {
@@ -247,7 +247,7 @@ class TestRunner {
   constructor(
     tests: TestDefinition[],
     public filterFn: (def: TestDefinition) => boolean,
-    public failFast: boolean
+    public failFast: boolean,
   ) {
     const onlyTests = tests.filter(({ only }) => only);
     this.#usedOnly = onlyTests.length > 0;
@@ -300,7 +300,7 @@ class TestRunner {
 
 function createFilterFn(
   filter: undefined | string | RegExp,
-  skip: undefined | string | RegExp
+  skip: undefined | string | RegExp,
 ): (def: TestDefinition) => boolean {
   return (def: TestDefinition): boolean => {
     let passes = true;

--- a/cli/js/testing.ts
+++ b/cli/js/testing.ts
@@ -52,7 +52,7 @@ After:
   - completed: ${post.opsCompletedAsync}
 
 Make sure to await all promises returned from Deno APIs before
-finishing test case.`,
+finishing test case.`
     );
   };
 }
@@ -61,7 +61,7 @@ finishing test case.`,
 // the test case does not "leak" resources - ie. resource table after
 // the test has exactly the same contents as before the test.
 function assertResources(
-  fn: () => void | Promise<void>,
+  fn: () => void | Promise<void>
 ): () => void | Promise<void> {
   return async function resourceSanitizer(): Promise<void> {
     const pre = resources();
@@ -97,7 +97,7 @@ export function test(name: string, fn: () => void | Promise<void>): void;
 // creates a new object with "name" and "fn" fields.
 export function test(
   t: string | TestDefinition,
-  fn?: () => void | Promise<void>,
+  fn?: () => void | Promise<void>
 ): void {
   let testDef: TestDefinition;
   const defaults = {
@@ -220,7 +220,7 @@ function reportToConsole(message: TestMessage): void {
         `${message.end.passed} passed; ${message.end.failed} failed; ` +
         `${message.end.ignored} ignored; ${message.end.measured} measured; ` +
         `${message.end.filtered} filtered out ` +
-        `${formatDuration(message.end.duration)}\n`,
+        `${formatDuration(message.end.duration)}\n`
     );
 
     if (message.end.usedOnly && message.end.failed == 0) {
@@ -247,7 +247,7 @@ class TestRunner {
   constructor(
     tests: TestDefinition[],
     public filterFn: (def: TestDefinition) => boolean,
-    public failFast: boolean,
+    public failFast: boolean
   ) {
     const onlyTests = tests.filter(({ only }) => only);
     this.#usedOnly = onlyTests.length > 0;
@@ -300,7 +300,7 @@ class TestRunner {
 
 function createFilterFn(
   filter: undefined | string | RegExp,
-  skip: undefined | string | RegExp,
+  skip: undefined | string | RegExp
 ): (def: TestDefinition) => boolean {
   return (def: TestDefinition): boolean => {
     let passes = true;

--- a/cli/js/util.ts
+++ b/cli/js/util.ts
@@ -22,21 +22,6 @@ export function log(...args: unknown[]): void {
   }
 }
 
-// @internal
-export class AssertionError extends Error {
-  constructor(msg?: string) {
-    super(msg);
-    this.name = "AssertionError";
-  }
-}
-
-// @internal
-export function assert(cond: unknown, msg = "Assertion failed."): asserts cond {
-  if (!cond) {
-    throw new AssertionError(msg);
-  }
-}
-
 export type ResolveFunction<T> = (value?: T | PromiseLike<T>) => void;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RejectFunction = (reason?: any) => void;

--- a/cli/js/web/event.ts
+++ b/cli/js/web/event.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+import { assert } from "../assert.ts";
 import type * as domTypes from "./dom_types.d.ts";
 import { defineEnumerableProps, requiredArguments } from "./util.ts";
-import { assert } from "../util.ts";
 
 /** Stores a non-accessible view of the event path which is used internally in
  * the logic for determining the path of an event. */
@@ -53,7 +53,7 @@ export function getStopImmediatePropagation(event: Event): boolean {
 
 export function setCurrentTarget(
   event: Event,
-  value: EventTarget | null
+  value: EventTarget | null,
 ): void {
   (event as EventImpl).currentTarget = value;
 }
@@ -85,7 +85,7 @@ export function setPath(event: Event, value: EventPath[]): void {
 
 export function setRelatedTarget<T extends Event>(
   event: T,
-  value: EventTarget | null
+  value: EventTarget | null,
 ): void {
   if ("relatedTarget" in event) {
     (event as T & {
@@ -100,7 +100,7 @@ export function setTarget(event: Event, value: EventTarget | null): void {
 
 export function setStopImmediatePropagation(
   event: Event,
-  value: boolean
+  value: boolean,
 ): void {
   const data = eventData.get(event as Event);
   if (data) {
@@ -111,7 +111,7 @@ export function setStopImmediatePropagation(
 // Type guards that widen the event type
 
 export function hasRelatedTarget(
-  event: Event
+  event: Event,
 ): event is domTypes.FocusEvent | domTypes.MouseEvent {
   return "relatedTarget" in event;
 }

--- a/cli/js/web/event.ts
+++ b/cli/js/web/event.ts
@@ -53,7 +53,7 @@ export function getStopImmediatePropagation(event: Event): boolean {
 
 export function setCurrentTarget(
   event: Event,
-  value: EventTarget | null,
+  value: EventTarget | null
 ): void {
   (event as EventImpl).currentTarget = value;
 }
@@ -85,7 +85,7 @@ export function setPath(event: Event, value: EventPath[]): void {
 
 export function setRelatedTarget<T extends Event>(
   event: T,
-  value: EventTarget | null,
+  value: EventTarget | null
 ): void {
   if ("relatedTarget" in event) {
     (event as T & {
@@ -100,7 +100,7 @@ export function setTarget(event: Event, value: EventTarget | null): void {
 
 export function setStopImmediatePropagation(
   event: Event,
-  value: boolean,
+  value: boolean
 ): void {
   const data = eventData.get(event as Event);
   if (data) {
@@ -111,7 +111,7 @@ export function setStopImmediatePropagation(
 // Type guards that widen the event type
 
 export function hasRelatedTarget(
-  event: Event,
+  event: Event
 ): event is domTypes.FocusEvent | domTypes.MouseEvent {
   return "relatedTarget" in event;
 }

--- a/cli/js/web/streams/internals.ts
+++ b/cli/js/web/streams/internals.ts
@@ -20,7 +20,7 @@ import { WritableStreamImpl } from "./writable_stream.ts";
 import { AbortSignalImpl } from "../abort_signal.ts";
 import { DOMExceptionImpl as DOMException } from "../dom_exception.ts";
 import { cloneValue } from "../util.ts";
-import { assert, AssertionError } from "../../util.ts";
+import { assert, AssertionError } from "../../assert.ts";
 
 export type AbortAlgorithm = (reason?: any) => PromiseLike<void>;
 export interface AbortRequest {

--- a/cli/js/web/streams/readable_byte_stream_controller.ts
+++ b/cli/js/web/streams/readable_byte_stream_controller.ts
@@ -22,8 +22,8 @@ import {
 } from "./internals.ts";
 import type { ReadableStreamImpl } from "./readable_stream.ts";
 import * as sym from "./symbols.ts";
-import { assert } from "../../util.ts";
 import { customInspect } from "../console.ts";
+import { assert } from "../../assert.ts";
 
 export class ReadableByteStreamControllerImpl
   implements ReadableByteStreamController {

--- a/cli/js/web/streams/readable_stream_async_iterator.ts
+++ b/cli/js/web/streams/readable_stream_async_iterator.ts
@@ -9,7 +9,7 @@ import {
   readableStreamReaderGenericRelease,
   readableStreamDefaultReaderRead,
 } from "./internals.ts";
-import { assert } from "../../util.ts";
+import { assert } from "../../assert.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const AsyncIteratorPrototype: AsyncIterableIterator<any> = Object.getPrototypeOf(

--- a/cli/js/web/streams/writable_stream_default_writer.ts
+++ b/cli/js/web/streams/writable_stream_default_writer.ts
@@ -18,7 +18,7 @@ import {
 import * as sym from "./symbols.ts";
 import type { WritableStreamImpl } from "./writable_stream.ts";
 import { customInspect } from "../console.ts";
-import { assert } from "../../util.ts";
+import { assert } from "../../assert.ts";
 
 export class WritableStreamDefaultWriterImpl<W>
   implements WritableStreamDefaultWriter<W> {

--- a/cli/js/web/timers.ts
+++ b/cli/js/web/timers.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { assert } from "../util.ts";
+import { assert } from "../assert.ts";
 import { startGlobalTimer, stopGlobalTimer } from "../ops/timers.ts";
 import { RBTree } from "../rbtree.ts";
 
@@ -149,7 +149,7 @@ function unschedule(timer: Timer): void {
       const nextDueNode: DueNode | null = dueTree.min();
       setOrClearGlobalTimeout(
         nextDueNode && nextDueNode.due,
-        OriginalDate.now()
+        OriginalDate.now(),
       );
     }
   } else {
@@ -203,7 +203,7 @@ function setTimer(
   cb: (...args: Args) => void,
   delay: number,
   args: Args,
-  repeat: boolean
+  repeat: boolean,
 ): number {
   // Bind `args` to the callback and bind `this` to globalThis(global).
   const callback: () => void = cb.bind(globalThis, ...args);
@@ -215,7 +215,7 @@ function setTimer(
     console.warn(
       `${delay} does not fit into` +
         " a 32-bit signed integer." +
-        "\nTimeout duration was set to 1."
+        "\nTimeout duration was set to 1.",
     );
     delay = 1;
   }

--- a/cli/js/web/timers.ts
+++ b/cli/js/web/timers.ts
@@ -149,7 +149,7 @@ function unschedule(timer: Timer): void {
       const nextDueNode: DueNode | null = dueTree.min();
       setOrClearGlobalTimeout(
         nextDueNode && nextDueNode.due,
-        OriginalDate.now(),
+        OriginalDate.now()
       );
     }
   } else {
@@ -203,7 +203,7 @@ function setTimer(
   cb: (...args: Args) => void,
   delay: number,
   args: Args,
-  repeat: boolean,
+  repeat: boolean
 ): number {
   // Bind `args` to the callback and bind `this` to globalThis(global).
   const callback: () => void = cb.bind(globalThis, ...args);
@@ -215,7 +215,7 @@ function setTimer(
     console.warn(
       `${delay} does not fit into` +
         " a 32-bit signed integer." +
-        "\nTimeout duration was set to 1.",
+        "\nTimeout duration was set to 1."
     );
     delay = 1;
   }

--- a/cli/tests/unit/assert_test.ts
+++ b/cli/tests/unit/assert_test.ts
@@ -1,0 +1,21 @@
+import { unitTest } from "./test_util.ts";
+
+unitTest(function denoAssert() {
+  if (!("assert" in Deno)) {
+    throw new Error("Deno.assert missing");
+  }
+  if (typeof Deno.assert !== "function") {
+    throw new Error("Deno.assert not a function");
+  }
+  Deno.assert(true);
+  try {
+    Deno.assert(false, "a failure");
+  } catch (e) {
+    if (!(e instanceof Deno.AssertionError)) {
+      throw new Error("Deno.assert does not throw properly");
+    }
+    if (e.message !== "a failure") {
+      throw new Error("Deno.assert does not properly set message");
+    }
+  }
+});

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -1,11 +1,14 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { assert, assertEquals } from "../../../std/testing/asserts.ts";
+import { assertEquals } from "../../../std/testing/asserts.ts";
 import * as colors from "../../../std/fmt/colors.ts";
 export { colors };
 import { resolve } from "../../../std/path/mod.ts";
+export const assert: (
+  condition: unknown,
+  message?: string | undefined
+) => asserts condition = Deno.assert;
 export {
-  assert,
   assertThrows,
   assertThrowsAsync,
   assertEquals,
@@ -150,7 +153,7 @@ export function unitTest(
   optionsOrFn: UnitTestOptions | TestFunction,
   maybeFn?: TestFunction
 ): void {
-  assert(optionsOrFn, "At least one argument is required");
+  Deno.assert(optionsOrFn, "At least one argument is required");
 
   let options: UnitTestOptions;
   let name: string;
@@ -163,14 +166,14 @@ export function unitTest(
     assert(name, "Missing test function name");
   } else {
     options = optionsOrFn;
-    assert(maybeFn, "Missing test function definition");
-    assert(
+    Deno.assert(maybeFn, "Missing test function definition");
+    Deno.assert(
       typeof maybeFn === "function",
       "Second argument should be test function definition"
     );
     fn = maybeFn;
     name = fn.name;
-    assert(name, "Missing test function name");
+    Deno.assert(name, "Missing test function name");
   }
 
   const normalizedPerms = normalizeTestPermissions(options.perms || {});
@@ -248,7 +251,7 @@ export async function reportToConn(
 }
 
 unitTest(function permissionsMatches(): void {
-  assert(
+  Deno.assert(
     permissionsMatch(
       {
         read: true,
@@ -263,7 +266,7 @@ unitTest(function permissionsMatches(): void {
     )
   );
 
-  assert(
+  Deno.assert(
     permissionsMatch(
       {
         read: false,
@@ -310,7 +313,7 @@ unitTest(function permissionsMatches(): void {
     false
   );
 
-  assert(
+  Deno.assert(
     permissionsMatch(
       {
         read: true,

--- a/cli/tests/unit/unit_tests.ts
+++ b/cli/tests/unit/unit_tests.ts
@@ -4,6 +4,7 @@
 //
 // Test runner automatically spawns subprocesses for each required permissions combination.
 
+import "./assert_test.ts";
 import "./abort_controller_test.ts";
 import "./blob_test.ts";
 import "./body_test.ts";

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -137,7 +137,7 @@ export function equal(c: unknown, d: unknown): boolean {
 export const assert: (
   condition: unknown,
   message?: string | undefined,
-) => asserts condition = globalThis.assert;
+) => asserts condition = Deno.assert;
 
 /**
  * Make an assertion that `actual` and `expected` are equal, deeply. If not
@@ -422,7 +422,7 @@ export function assertThrows<T = void>(
     fn();
   } catch (e) {
     if (e instanceof Error === false) {
-      throw new AssertionError("A non-Error object was thrown.");
+      throw new AssertionError({ message: "A non-Error object was thrown." });
     }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
       message =
@@ -480,7 +480,9 @@ export async function assertThrowsAsync<T = void>(
     await fn();
   } catch (e) {
     if (e instanceof Error === false) {
-      throw new AssertionError("A non-Error object was thrown or rejected.");
+      throw new AssertionError({
+        message: "A non-Error object was thrown or rejected.",
+      });
     }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
       message =

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -135,7 +135,13 @@ export function equal(c: unknown, d: unknown): boolean {
 export const assert: (
   condition: unknown,
   message?: string | undefined
-) => asserts condition = Deno.assert;
+) => asserts condition = globalThis.Deno
+  ? Deno.assert
+  : (condition, message = "Assertion failed"): asserts condition => {
+      if (!condition) {
+        throw new AssertionError({ message, stackStartFn: assert });
+      }
+    };
 
 /**
  * Make an assertion that `actual` and `expected` are equal, deeply. If not

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -49,11 +49,9 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   messages.push("");
   messages.push("");
   messages.push(
-    `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${
-      green(
-        bold("Expected"),
-      )
-    }`,
+    `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${green(
+      bold("Expected")
+    )}`
   );
   messages.push("");
   messages.push("");
@@ -136,7 +134,7 @@ export function equal(c: unknown, d: unknown): boolean {
  * value. */
 export const assert: (
   condition: unknown,
-  message?: string | undefined,
+  message?: string | undefined
 ) => asserts condition = Deno.assert;
 
 /**
@@ -152,13 +150,13 @@ export const assert: (
 export function assertEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string
 ): void;
 export function assertEquals<T>(actual: T, expected: T, msg?: string): void;
 export function assertEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string
 ): void {
   if (equal(actual, expected)) {
     return;
@@ -169,7 +167,7 @@ export function assertEquals(
   try {
     const diffResult = diff(
       actualString.split("\n"),
-      expectedString.split("\n"),
+      expectedString.split("\n")
     );
     const diffMsg = buildMessage(diffResult).join("\n");
     message = `Values are not equal:\n${diffMsg}`;
@@ -201,13 +199,13 @@ export function assertEquals(
 export function assertNotEquals(
   actual: unknown,
   expected: unknown,
-  message?: string,
+  message?: string
 ): void;
 export function assertNotEquals<T>(actual: T, expected: T, msg?: string): void;
 export function assertNotEquals(
   actual: unknown,
   expected: unknown,
-  message?: string,
+  message?: string
 ): void {
   if (!equal(actual, expected)) {
     return;
@@ -246,7 +244,7 @@ export function assertNotEquals(
 export function assertStrictEquals<T>(
   actual: T,
   expected: T,
-  msg?: string,
+  msg?: string
 ): void {
   if (actual === expected) {
     return;
@@ -265,17 +263,14 @@ export function assertStrictEquals<T>(
         .split("\n")
         .map((l) => `     ${l}`)
         .join("\n");
-      message =
-        `Values have the same structure but are not reference-equal:\n\n${
-          red(
-            withOffset,
-          )
-        }\n`;
+      message = `Values have the same structure but are not reference-equal:\n\n${red(
+        withOffset
+      )}\n`;
     } else {
       try {
         const diffResult = diff(
           actualString.split("\n"),
-          expectedString.split("\n"),
+          expectedString.split("\n")
         );
         const diffMsg = buildMessage(diffResult).join("\n");
         message = `Values are not strictly equal:\n${diffMsg}`;
@@ -301,7 +296,7 @@ export function assertStrictEquals<T>(
 export function assertStringContains(
   actual: string,
   expected: string,
-  message?: string,
+  message?: string
 ): void {
   if (!actual.includes(expected)) {
     if (!message) {
@@ -330,17 +325,17 @@ export function assertStringContains(
 export function assertArrayContains(
   actual: ArrayLike<unknown>,
   expected: ArrayLike<unknown>,
-  message?: string,
+  message?: string
 ): void;
 export function assertArrayContains<T>(
   actual: ArrayLike<T>,
   expected: ArrayLike<T>,
-  message?: string,
+  message?: string
 ): void;
 export function assertArrayContains(
   actual: ArrayLike<unknown>,
   expected: ArrayLike<unknown>,
-  message?: string,
+  message?: string
 ): void {
   const missing: unknown[] = [];
   for (let i = 0; i < expected.length; i++) {
@@ -359,11 +354,9 @@ export function assertArrayContains(
     return;
   }
   if (!message) {
-    message = `actual: "${format(actual)}" expected to contain: "${
-      format(
-        expected,
-      )
-    }"\nmissing: ${format(missing)}`;
+    message = `actual: "${format(actual)}" expected to contain: "${format(
+      expected
+    )}"\nmissing: ${format(missing)}`;
   }
   throw new AssertionError({
     message,
@@ -381,7 +374,7 @@ export function assertArrayContains(
 export function assertMatch(
   actual: string,
   expected: RegExp,
-  message?: string,
+  message?: string
 ): void {
   if (!expected.test(actual)) {
     if (!message) {
@@ -414,7 +407,7 @@ export function assertThrows<T = void>(
   fn: () => T,
   ErrorClass?: Constructor,
   msgIncludes = "",
-  message?: string,
+  message?: string
 ): Error {
   let doesThrow = false;
   let error = null;
@@ -425,10 +418,9 @@ export function assertThrows<T = void>(
       throw new AssertionError({ message: "A non-Error object was thrown." });
     }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
-      message =
-        `Expected error to be instance of "${ErrorClass.name}", but was "${e.constructor.name}"${
-          message ? `: ${message}` : "."
-        }`;
+      message = `Expected error to be instance of "${
+        ErrorClass.name
+      }", but was "${e.constructor.name}"${message ? `: ${message}` : "."}`;
       throw new AssertionError({
         message,
         operator: "throws",
@@ -439,10 +431,9 @@ export function assertThrows<T = void>(
       msgIncludes &&
       !stripColor(e.message).includes(stripColor(msgIncludes))
     ) {
-      message =
-        `Expected error message to include "${msgIncludes}", but got "${e.message}"${
-          message ? `: ${message}` : "."
-        }`;
+      message = `Expected error message to include "${msgIncludes}", but got "${
+        e.message
+      }"${message ? `: ${message}` : "."}`;
       throw new AssertionError({
         message,
         operator: "throws",
@@ -472,7 +463,7 @@ export async function assertThrowsAsync<T = void>(
   fn: () => Promise<T>,
   ErrorClass?: Constructor,
   msgIncludes = "",
-  message?: string,
+  message?: string
 ): Promise<Error> {
   let doesThrow = false;
   let error = null;
@@ -485,10 +476,9 @@ export async function assertThrowsAsync<T = void>(
       });
     }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
-      message =
-        `Expected error to be instance of "${ErrorClass.name}", but got "${e.name}"${
-          message ? `: ${message}` : "."
-        }`;
+      message = `Expected error to be instance of "${
+        ErrorClass.name
+      }", but got "${e.name}"${message ? `: ${message}` : "."}`;
       throw new AssertionError({
         message,
         operator: "throws",
@@ -499,10 +489,9 @@ export async function assertThrowsAsync<T = void>(
       msgIncludes &&
       !stripColor(e.message).includes(stripColor(msgIncludes))
     ) {
-      message =
-        `Expected error message to include "${msgIncludes}", but got "${e.message}"${
-          message ? `: ${message}` : "."
-        }`;
+      message = `Expected error message to include "${msgIncludes}", but got "${
+        e.message
+      }"${message ? `: ${message}` : "."}`;
       throw new AssertionError({
         message,
         operator: "throws",


### PR DESCRIPTION
Resolves #5684 

This PR exposes the internal `assert()` function globally in Deno.  It also adds `Deno.AssertionError` and `Deno.AssertionErrorOptions` and improves the internal `AssertionError` to align more to the common conventions around assertion errors in JavaScript (including an `actual`, `expected`, `operator` properties, which can be used to provide more intelligent logging of assertion errors as well as providing a mechanism to re-anchor the stack to the point where the assertion failure occurred).

This is a _breaking change_ for `std` as `std/testing/asserts.ts` uses the `Deno.AssertionError` and re-exports it.