### PR TITLE
fix: Deno.osName is unstable

### DIFF
--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -53,7 +53,7 @@ export {
 export { metrics, Metrics } from "./ops/runtime.ts";
 export { mkdirSync, mkdir, MkdirOptions } from "./ops/fs/mkdir.ts";
 export { connect, listen, Listener, Conn } from "./net.ts";
-export { dir, env, exit, execPath, osName } from "./ops/os.ts";
+export { dir, env, exit, execPath } from "./ops/os.ts";
 export { run, RunOptions, Process, ProcessStatus } from "./process.ts";
 export { DirEntry, readDirSync, readDir } from "./ops/fs/read_dir.ts";
 export { readFileSync, readFile } from "./read_file.ts";

--- a/cli/js/deno_unstable.ts
+++ b/cli/js/deno_unstable.ts
@@ -5,7 +5,7 @@
 export { umask } from "./ops/fs/umask.ts";
 export { linkSync, link } from "./ops/fs/link.ts";
 export { symlinkSync, symlink } from "./ops/fs/symlink.ts";
-export { dir, loadavg, osRelease, hostname } from "./ops/os.ts";
+export { dir, loadavg, osRelease, hostname, osName } from "./ops/os.ts";
 export { openPlugin } from "./ops/plugins.ts";
 export { transpileOnly, compile, bundle } from "./compiler_api.ts";
 export { applySourceMap, formatDiagnostics } from "./ops/errors.ts";


### PR DESCRIPTION
`Deno.osName` is listed in the type library as unstable, but was available without the flag.  This PR moves it properly to be unstable.