### PR TITLE
feat(lint): add --rules flag

### DIFF
--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -64,6 +64,15 @@ pub async fn lint_files(args: Vec<String>) -> Result<(), ErrBox> {
   Ok(())
 }
 
+pub fn print_rules_list() {
+  let lint_rules = rules::get_recommended_rules();
+
+  println!("Available rules:");
+  for rule in lint_rules {
+    println!(" - {}", rule.code());
+  }
+}
+
 fn create_linter() -> Linter {
   Linter::new(
     "deno-lint-ignore-file".to_string(),

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -316,7 +316,11 @@ async fn install_command(
     .map_err(ErrBox::from)
 }
 
-async fn lint_command(flags: Flags, files: Vec<String>) -> Result<(), ErrBox> {
+async fn lint_command(
+  flags: Flags,
+  files: Vec<String>,
+  list_rules: bool,
+) -> Result<(), ErrBox> {
   let global_state = GlobalState::new(flags)?;
 
   // TODO(bartlomieju): refactor, it's non-sense to create
@@ -331,6 +335,12 @@ async fn lint_command(flags: Flags, files: Vec<String>) -> Result<(), ErrBox> {
   )?;
 
   state.check_unstable("lint");
+
+  if list_rules {
+    lint::print_rules_list();
+    return Ok(());
+  }
+
   lint::lint_files(files).await
 }
 
@@ -708,7 +718,9 @@ pub fn main() {
     } => {
       install_command(flags, module_url, args, name, root, force).boxed_local()
     }
-    DenoSubcommand::Lint { files } => lint_command(flags, files).boxed_local(),
+    DenoSubcommand::Lint { files, rules } => {
+      lint_command(flags, files, rules).boxed_local()
+    }
     DenoSubcommand::Repl => run_repl(flags).boxed_local(),
     DenoSubcommand::Run { script } => run_command(flags, script).boxed_local(),
     DenoSubcommand::Test {


### PR DESCRIPTION
```
▶ target/debug/deno lint --unstable --rules
Available rules:
 - ban-ts-comment
 - ban-untagged-ignore
 - constructor-super
 - for-direction
 - getter-return
 - no-array-constructor
 - no-async-promise-executor
 - no-case-declarations
 - no-class-assign
 - no-compare-neg-zero
 - no-cond-assign
 - no-debugger
 - no-delete-var
 - no-dupe-args
 - no-dupe-keys
 - no-duplicate-case
 - no-empty-character-class
 - no-empty-interface
 - no-empty-pattern
 - no-empty
 - no-ex-assign
 - no-explicit-any
 - no-func-assign
 - no-misused-new
 - no-namespace
 - no-new-symbol
 - no-obj-call
 - no-octal
 - no-prototype-builtins
 - no-regex-spaces
 - no-setter-return
 - no-this-alias
 - no-this-before-super
 - no-unsafe-finally
 - no-unsafe-negation
 - no-with
 - prefer-as-const
 - prefer-namespace-keyword
 - require-yield
 - triple-slash-reference
 - use-isnan
 - valid-typeof

```