### PR TITLE
refactor(cli/ops/net): rename op_receive, op_send and op_send return byteLength that sent

### DIFF
--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -988,7 +988,7 @@ declare namespace Deno {
     /** UNSTABLE: new API, yet to be vetted.
      *
      * Sends a message to the target. */
-    send(p: Uint8Array, addr: Addr): Promise<void>;
+    send(p: Uint8Array, addr: Addr): Promise<number>;
     /** UNSTABLE: new API, yet to be vetted.
      *
      * Close closes the socket. Any pending message promises will be rejected

--- a/cli/js/net.ts
+++ b/cli/js/net.ts
@@ -10,7 +10,7 @@ export { ShutdownMode, shutdown, NetAddr, UnixAddr } from "./ops/net.ts";
 export interface DatagramConn extends AsyncIterable<[Uint8Array, Addr]> {
   receive(p?: Uint8Array): Promise<[Uint8Array, Addr]>;
 
-  send(p: Uint8Array, addr: Addr): Promise<void>;
+  send(p: Uint8Array, addr: Addr): Promise<number>;
 
   close(): void;
 
@@ -109,11 +109,12 @@ export class DatagramImpl implements DatagramConn {
     return [sub, remoteAddr];
   }
 
-  async send(p: Uint8Array, addr: Addr): Promise<void> {
+  async send(p: Uint8Array, addr: Addr): Promise<number> {
     const remote = { hostname: "127.0.0.1", ...addr };
 
     const args = { ...remote, rid: this.rid };
-    await netOps.send(args as netOps.SendRequest, p);
+    const byteLength = await netOps.send(args as netOps.SendRequest, p);
+    return byteLength;
   }
 
   close(): void {

--- a/cli/js/ops/net.ts
+++ b/cli/js/ops/net.ts
@@ -73,7 +73,7 @@ export function receive(
   transport: string,
   zeroCopy: Uint8Array
 ): Promise<ReceiveResponse> {
-  return sendAsync("op_receive", { rid, transport }, zeroCopy);
+  return sendAsync("op_datagram_receive", { rid, transport }, zeroCopy);
 }
 
 export type SendRequest = {
@@ -83,6 +83,7 @@ export type SendRequest = {
 export async function send(
   args: SendRequest,
   zeroCopy: Uint8Array
-): Promise<void> {
-  await sendAsync("op_send", args, zeroCopy);
+): Promise<number> {
+  const byteLength = await sendAsync("op_datagram_send", args, zeroCopy);
+  return byteLength;
 }

--- a/cli/ops/net.rs
+++ b/cli/ops/net.rs
@@ -27,8 +27,11 @@ pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_connect", s.stateful_json_op2(op_connect));
   i.register_op("op_shutdown", s.stateful_json_op2(op_shutdown));
   i.register_op("op_listen", s.stateful_json_op2(op_listen));
-  i.register_op("op_receive", s.stateful_json_op2(op_receive));
-  i.register_op("op_send", s.stateful_json_op2(op_send));
+  i.register_op(
+    "op_datagram_receive",
+    s.stateful_json_op2(op_datagram_receive),
+  );
+  i.register_op("op_datagram_send", s.stateful_json_op2(op_datagram_send));
 }
 
 #[derive(Deserialize)]
@@ -161,8 +164,7 @@ fn receive_udp(
   Ok(JsonOp::Async(op.boxed_local()))
 }
 
-// TODO(ry) Rename to op_datagram_receive
-fn op_receive(
+fn op_datagram_receive(
   isolate_state: &mut CoreIsolateState,
   state: &State,
   args: Value,
@@ -192,8 +194,7 @@ struct SendArgs {
   transport_args: ArgsEnum,
 }
 
-// TODO(ry) Rename to op_datagram_send
-fn op_send(
+fn op_datagram_send(
   isolate_state: &mut CoreIsolateState,
   state: &State,
   args: Value,
@@ -222,7 +223,7 @@ fn op_send(
           .socket
           .poll_send_to(cx, &zero_copy, &addr)
           .map_err(OpError::from)
-          .map_ok(|_| json!({}))
+          .map_ok(|byte_length| json!(byte_length))
       });
       Ok(JsonOp::Async(f.boxed_local()))
     }

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -240,7 +240,9 @@ unitTest(
     assertEquals(bob.addr.hostname, "127.0.0.1");
 
     const sent = new Uint8Array([1, 2, 3]);
-    await alice.send(sent, bob.addr);
+    const byteLength = await alice.send(sent, bob.addr);
+
+    assertEquals(byteLength, 3);
 
     const [recvd, remote] = await bob.receive();
     assert(remote.transport === "udp");


### PR DESCRIPTION
[#6231](https://github.com/denoland/deno/issues/6231)

- refactor(cli/ops/net): rename `op_receive` to `op_datagram_receive` and `op_send` to `op_datagram_send`;
- fix(cli/ops/net): `op_datagram_send` return the byteLength of the send data;

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
