### PR TITLE
fix(std/io): Use Deno.test in writers_test

### DIFF
--- a/std/io/writers_test.ts
+++ b/std/io/writers_test.ts
@@ -12,7 +12,7 @@ Deno.test("ioStringWriter", async function (): Promise<void> {
   assertEquals(w.toString(), "base0123456789");
 });
 
-test("ioStringWriterSync", function (): void {
+Deno.test("ioStringWriterSync", function (): void {
   const encoder = new TextEncoder();
   const w = new StringWriter("");
   w.writeSync(encoder.encode("deno"));


### PR DESCRIPTION
Fix test that broke after https://github.com/denoland/deno/pull/6268 was merged.