### PR TITLE
Fix assertEqual so that it handles URL objects

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -82,7 +82,8 @@ export function equal(c: unknown, d: unknown): boolean {
       a &&
       b &&
       ((a instanceof RegExp && b instanceof RegExp) ||
-        (a instanceof Date && b instanceof Date))
+        (a instanceof Date && b instanceof Date) ||
+        (a instanceof URL && b instanceof URL))
     ) {
       return String(a) === String(b);
     }

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -112,6 +112,15 @@ Deno.test("testingEqual", function (): void {
   assert(!equal([1, 2, 3, 4], [1, 4, 2, 3]));
   assert(equal(new Uint8Array([1, 2, 3, 4]), new Uint8Array([1, 2, 3, 4])));
   assert(!equal(new Uint8Array([1, 2, 3, 4]), new Uint8Array([2, 1, 4, 3])));
+  assert(
+    equal(new URL("https://example.test"), new URL("https://example.test"))
+  );
+  assert(
+    !equal(
+      new URL("https://example.test"),
+      new URL("https://example.test/with-path")
+    )
+  );
 });
 
 Deno.test("testingNotEquals", function (): void {


### PR DESCRIPTION
This fixes the bug where URL objects with different contents would be treated as equal