### PR TITLE
Catch errors on file_server response.send. Fixes #5624

### DIFF
--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -353,7 +353,11 @@ function main(): void {
           setCORS(response);
         }
         serverLog(req, response!);
-        req.respond(response!);
+        try {
+          await req.respond(response!);
+        } catch (e) {
+          console.error(e.message);
+        }
       }
     }
   );


### PR DESCRIPTION
This PR simply logs errors thrown from `response.send` to the console:

```
2020-06-13 21:13:28] "GET /large.txt HTTP/1.1" 200
Broken pipe (os error 32)
```

I'm not sure if this is actually useful info for users (at least not in the case of #5624). I quickly looked at python's `http.server`, Go's. `FileServer`, nginx and http-party/http-server, and none of them seem to log any info when the client closes connection early.

Is it worth considering changing the `server.ts` api to better communicate when the client closes the connection? (instead of throwing an os error on write). In node, `http.ClientRequest` sends a `close` event when the client disconnects, using `response.write` after that is actually allowed and does not throw an error (last part is also not ideal imho).