### PR TITLE
Fix (cli/net) "unixpacket" send should also return bytes length

### DIFF
--- a/cli/ops/net.rs
+++ b/cli/ops/net.rs
@@ -244,11 +244,11 @@ fn op_datagram_send(
           })?;
 
         let socket = &mut resource.socket;
-        socket
+        let byte_length = socket
           .send_to(&zero_copy, &resource.local_addr.as_pathname().unwrap())
           .await?;
 
-        Ok(json!({}))
+        Ok(json!(byte_length))
       };
 
       Ok(JsonOp::Async(op.boxed_local()))

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -290,7 +290,8 @@ unitTest(
     assertEquals(bob.addr.path, filePath);
 
     const sent = new Uint8Array([1, 2, 3]);
-    await alice.send(sent, bob.addr);
+    const byteLength = await alice.send(sent, bob.addr);
+    assertEquals(byteLength, 3);
 
     const [recvd, remote] = await bob.receive();
     assert(remote.transport === "unixpacket");


### PR DESCRIPTION
Similar to issues: https://github.com/denoland/deno/issues/6231

The "unixpacket" transport protocol should also return the bytes sent from `op_datagram_send`. 

This closes https://github.com/denoland/deno/issues/6231