### PR TITLE
Feat testing filter info

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -106,10 +106,12 @@ directory (recursively) that match the glob `{*_,*.,}test.{js,mjs,ts,jsx,tsx}`
 will be run. If you pass a directory, all files in the directory that match this
 glob will be run.
 
-Tests can be run individually or in groups using the command line `--filter` option.
+Tests can be run individually or in groups using the command line `--filter`
+option.
 
 ```shell
 deno test --filter "hello world" tests/
 ```
 
-This command will run any test which contains the pattern "hello world" in its name stored within the `tests/` directory.
+This command will run any test which contains the pattern "hello world" in its
+name stored within the `tests/` directory.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -105,3 +105,11 @@ You can also omit the file name, in which case all tests in the current
 directory (recursively) that match the glob `{*_,*.,}test.{js,mjs,ts,jsx,tsx}`
 will be run. If you pass a directory, all files in the directory that match this
 glob will be run.
+
+Tests can be run individually or in groups using the command line `--filter` option.
+
+```shell
+deno test --filter "hello world" tests/
+```
+
+This command will run any test which contains the pattern "hello world" in its name stored within the `tests/` directory.


### PR DESCRIPTION
Adds a small amount of information to the testing documentation on how to use the `--filter` option when running deno tests.