### PR TITLE
Bug assert async throws

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -385,7 +385,8 @@ export async function assertThrowsAsync<T = void>(
       throw new AssertionError(msg);
     }
     if (
-      msgIncludes && typeof e.message !== "undefined" &&
+      msgIncludes &&
+      typeof e.message !== "undefined" &&
       !stripColor(e.message).includes(stripColor(msgIncludes))
     ) {
       msg = `Expected error message to include "${msgIncludes}", but got "${
@@ -394,12 +395,13 @@ export async function assertThrowsAsync<T = void>(
       throw new AssertionError(msg);
     }
     if (
-      msgIncludes && typeof e.message === "undefined" &&
+      msgIncludes &&
+      typeof e.message === "undefined" &&
       !stripColor(String(e)).includes(stripColor(msgIncludes))
     ) {
-      msg = `Expected error message to include "${msgIncludes}", but got "${
-        e
-      }"${msg ? `: ${msg}` : "."}`;
+      msg = `Expected error message to include "${msgIncludes}", but got "${e}"${
+        msg ? `: ${msg}` : "."
+      }`;
       throw new AssertionError(msg);
     }
     doesThrow = true;

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -380,11 +380,20 @@ export async function assertThrowsAsync<T = void>(
       throw new AssertionError(msg);
     }
     if (
-      msgIncludes &&
+      msgIncludes && typeof e.message !== "undefined" &&
       !stripColor(e.message).includes(stripColor(msgIncludes))
     ) {
       msg = `Expected error message to include "${msgIncludes}", but got "${
         e.message
+      }"${msg ? `: ${msg}` : "."}`;
+      throw new AssertionError(msg);
+    }
+    if (
+      msgIncludes && typeof e.message === "undefined" &&
+      !stripColor(String(e)).includes(stripColor(msgIncludes))
+    ) {
+      msg = `Expected error message to include "${msgIncludes}", but got "${
+        e
       }"${msg ? `: ${msg}` : "."}`;
       throw new AssertionError(msg);
     }

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -362,6 +362,11 @@ export function assertThrows<T = void>(
   return error;
 }
 
+/**
+ * Executes a function which returns a promise, expecting it to throw or reject.
+ * If it does not, then it throws.  An error class and a string that should be
+ * included in the error message can also be asserted.
+ */
 export async function assertThrowsAsync<T = void>(
   fn: () => Promise<T>,
   ErrorClass?: Constructor,

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -409,3 +409,39 @@ Deno.test({
     );
   },
 });
+
+Deno.test("async throws promise rejection with string", () => {
+  assertThrowsAsync((): Promise<string> => {
+    return Promise.reject("Panic!");
+  }, String, "Panic!");
+
+  assertThrowsAsync((): Promise<any> => {
+    return assertThrowsAsync((): Promise<string> => {
+      return Promise.reject("Panic!");
+    }, String, "Error!");
+  }, AssertionError, `Expected error message to include "Error!", but got "Panic!".`);
+});
+
+Deno.test("async throws promise rejection with number", () => {
+  assertThrowsAsync((): Promise<number> => {
+    return Promise.reject(0);
+  }, Number, "0");
+
+  assertThrowsAsync((): Promise<any> => {
+    return assertThrowsAsync((): Promise<number> => {
+      return Promise.reject(0);
+    }, Number, "1");
+  }, AssertionError, `Expected error message to include "1", but got "0".`);
+});
+
+Deno.test("async throws promise rejection with assertion error", () => {
+  assertThrowsAsync((): Promise<any> => {
+    return Promise.reject(new AssertionError("Panic!"));
+  }, AssertionError, "Panic!");
+
+  assertThrowsAsync((): Promise<any> => {
+    return assertThrowsAsync((): Promise<any> => {
+      return Promise.reject(new AssertionError("Panic!"));
+    }, AssertionError, "Error!");
+  }, AssertionError, `Expected error message to include "Error!", but got "Panic!".`);
+});

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -415,7 +415,7 @@ Deno.test("async throws promise rejection with string", () => {
     return Promise.reject("Panic!");
   }, String, "Panic!");
 
-  assertThrowsAsync((): Promise<any> => {
+  assertThrowsAsync((): Promise<Error> => {
     return assertThrowsAsync((): Promise<string> => {
       return Promise.reject("Panic!");
     }, String, "Error!");
@@ -427,7 +427,7 @@ Deno.test("async throws promise rejection with number", () => {
     return Promise.reject(0);
   }, Number, "0");
 
-  assertThrowsAsync((): Promise<any> => {
+  assertThrowsAsync((): Promise<Error> => {
     return assertThrowsAsync((): Promise<number> => {
       return Promise.reject(0);
     }, Number, "1");
@@ -435,12 +435,12 @@ Deno.test("async throws promise rejection with number", () => {
 });
 
 Deno.test("async throws promise rejection with assertion error", () => {
-  assertThrowsAsync((): Promise<any> => {
+  assertThrowsAsync((): Promise<AssertionError> => {
     return Promise.reject(new AssertionError("Panic!"));
   }, AssertionError, "Panic!");
 
-  assertThrowsAsync((): Promise<any> => {
-    return assertThrowsAsync((): Promise<any> => {
+  assertThrowsAsync((): Promise<Error> => {
+    return assertThrowsAsync((): Promise<AssertionError> => {
       return Promise.reject(new AssertionError("Panic!"));
     }, AssertionError, "Error!");
   }, AssertionError, `Expected error message to include "Error!", but got "Panic!".`);

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -411,37 +411,73 @@ Deno.test({
 });
 
 Deno.test("async throws promise rejection with string", () => {
-  assertThrowsAsync((): Promise<string> => {
-    return Promise.reject("Panic!");
-  }, String, "Panic!");
-
-  assertThrowsAsync((): Promise<Error> => {
-    return assertThrowsAsync((): Promise<string> => {
+  assertThrowsAsync(
+    (): Promise<string> => {
       return Promise.reject("Panic!");
-    }, String, "Error!");
-  }, AssertionError, `Expected error message to include "Error!", but got "Panic!".`);
+    },
+    String,
+    "Panic!"
+  );
+
+  assertThrowsAsync(
+    (): Promise<Error> => {
+      return assertThrowsAsync(
+        (): Promise<string> => {
+          return Promise.reject("Panic!");
+        },
+        String,
+        "Error!"
+      );
+    },
+    AssertionError,
+    `Expected error message to include "Error!", but got "Panic!".`
+  );
 });
 
 Deno.test("async throws promise rejection with number", () => {
-  assertThrowsAsync((): Promise<number> => {
-    return Promise.reject(0);
-  }, Number, "0");
-
-  assertThrowsAsync((): Promise<Error> => {
-    return assertThrowsAsync((): Promise<number> => {
+  assertThrowsAsync(
+    (): Promise<number> => {
       return Promise.reject(0);
-    }, Number, "1");
-  }, AssertionError, `Expected error message to include "1", but got "0".`);
+    },
+    Number,
+    "0"
+  );
+
+  assertThrowsAsync(
+    (): Promise<Error> => {
+      return assertThrowsAsync(
+        (): Promise<number> => {
+          return Promise.reject(0);
+        },
+        Number,
+        "1"
+      );
+    },
+    AssertionError,
+    `Expected error message to include "1", but got "0".`
+  );
 });
 
 Deno.test("async throws promise rejection with assertion error", () => {
-  assertThrowsAsync((): Promise<AssertionError> => {
-    return Promise.reject(new AssertionError("Panic!"));
-  }, AssertionError, "Panic!");
-
-  assertThrowsAsync((): Promise<Error> => {
-    return assertThrowsAsync((): Promise<AssertionError> => {
+  assertThrowsAsync(
+    (): Promise<AssertionError> => {
       return Promise.reject(new AssertionError("Panic!"));
-    }, AssertionError, "Error!");
-  }, AssertionError, `Expected error message to include "Error!", but got "Panic!".`);
+    },
+    AssertionError,
+    "Panic!"
+  );
+
+  assertThrowsAsync(
+    (): Promise<Error> => {
+      return assertThrowsAsync(
+        (): Promise<AssertionError> => {
+          return Promise.reject(new AssertionError("Panic!"));
+        },
+        AssertionError,
+        "Error!"
+      );
+    },
+    AssertionError,
+    `Expected error message to include "Error!", but got "Panic!".`
+  );
 });


### PR DESCRIPTION
Currently if a promise rejects you can get a run time error if you attempt to assert the message or content of the rejection using the message includes feature. This occurs when you pass in a string or number to the rejection rather than an error object.