### PR TITLE
chore: remove glob dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,6 @@ dependencies = [
  "dprint-plugin-typescript",
  "futures 0.3.5",
  "fwdansi",
- "glob",
  "http",
  "indexmap",
  "lazy_static",
@@ -918,12 +917,6 @@ name = "gimli"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
-
-[[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,6 @@ dissimilar = "1.0"
 dlopen = "0.1.8"
 dprint-plugin-typescript = "0.19.2"
 futures = { version = "0.3.5", features = ["compat", "io-compat"] }
-glob = "0.3.0"
 http = "0.2.1"
 indexmap = "1.3.2"
 lazy_static = "1.4.0"


### PR DESCRIPTION
Seems like `glob` in no longer used?