### PR TITLE
Update assertions names in std/testing README

### DIFF
--- a/std/testing/README.md
+++ b/std/testing/README.md
@@ -16,9 +16,9 @@ pretty-printed diff of failing assertion.
   `expected` are not equal.
 - `assertNotEquals()` - Uses the `equal` comparison and throws if the `actual`
   and `expected` are equal.
-- `assertStrictEq()` - Compares `actual` and `expected` strictly, therefore for
+- `assertStrictEquals()` - Compares `actual` and `expected` strictly, therefore for
   non-primitives the values must reference the same instance.
-- `assertStrContains()` - Make an assertion that `actual` contains `expected`.
+- `assertStringContains()` - Make an assertion that `actual` contains `expected`.
 - `assertMatch()` - Make an assertion that `actual` match RegExp `expected`.
 - `assertArrayContains()` - Make an assertion that `actual` array contains the
   `expected` values.
@@ -57,20 +57,20 @@ Deno.test("example", function (): void {
 });
 ```
 
-Using `assertStrictEq()`:
+Using `assertStrictEquals()`:
 
 ```ts
 Deno.test("isStrictlyEqual", function (): void {
   const a = {};
   const b = a;
-  assertStrictEq(a, b);
+  assertStrictEquals(a, b);
 });
 
 // This test fails
 Deno.test("isNotStrictlyEqual", function (): void {
   const a = {};
   const b = {};
-  assertStrictEq(a, b);
+  assertStrictEquals(a, b);
 });
 ```
 

--- a/std/testing/README.md
+++ b/std/testing/README.md
@@ -16,9 +16,10 @@ pretty-printed diff of failing assertion.
   `expected` are not equal.
 - `assertNotEquals()` - Uses the `equal` comparison and throws if the `actual`
   and `expected` are equal.
-- `assertStrictEquals()` - Compares `actual` and `expected` strictly, therefore for
-  non-primitives the values must reference the same instance.
-- `assertStringContains()` - Make an assertion that `actual` contains `expected`.
+- `assertStrictEquals()` - Compares `actual` and `expected` strictly, therefore
+  for non-primitives the values must reference the same instance.
+- `assertStringContains()` - Make an assertion that `actual` contains
+  `expected`.
 - `assertMatch()` - Make an assertion that `actual` match RegExp `expected`.
 - `assertArrayContains()` - Make an assertion that `actual` array contains the
   `expected` values.


### PR DESCRIPTION
Assertions names were changed in #6118, but the README still contains old names.

This PR updates names in the README.