### PR TITLE
Deno.bundle supports targets < ES2017.

### DIFF
--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -307,6 +307,10 @@ class Host implements ts.CompilerHost {
     }
   }
 
+  get options(): ts.CompilerOptions {
+    return this.#options;
+  }
+
   configure(
     cwd: string,
     path: string,
@@ -528,6 +532,7 @@ const _TS_SNAPSHOT_PROGRAM = ts.createProgram({
 
 // This function is called only during snapshotting process
 const SYSTEM_LOADER = getAsset("system_loader.js");
+const SYSTEM_LOADER_ES5 = getAsset("system_loader_es5.js");
 
 function buildLocalSourceFileCache(
   sourceFileMap: Record<string, SourceFileMapEntry>
@@ -683,7 +688,12 @@ function createBundleWriteFile(state: WriteFileState): WriteFileCallback {
     assert(state.bundle);
     // we only support single root names for bundles
     assert(state.rootNames.length === 1);
-    state.bundleOutput = buildBundle(state.rootNames[0], data, sourceFiles);
+    state.bundleOutput = buildBundle(
+      state.rootNames[0],
+      data,
+      sourceFiles,
+      state.host.options.target ?? ts.ScriptTarget.ESNext
+    );
   };
 }
 
@@ -949,7 +959,8 @@ function normalizeUrl(rootName: string): string {
 function buildBundle(
   rootName: string,
   data: string,
-  sourceFiles: readonly ts.SourceFile[]
+  sourceFiles: readonly ts.SourceFile[],
+  target: ts.ScriptTarget
 ): string {
   // when outputting to AMD and a single outfile, TypeScript makes up the module
   // specifiers which are used to define the modules, and doesn't expose them
@@ -967,8 +978,8 @@ function buildBundle(
   let instantiate: string;
   if (rootExports && rootExports.length) {
     instantiate = hasTla
-      ? `const __exp = await __instantiateAsync("${rootName}");\n`
-      : `const __exp = __instantiate("${rootName}");\n`;
+      ? `const __exp = await __instantiate("${rootName}", true);\n`
+      : `const __exp = __instantiate("${rootName}", false);\n`;
     for (const rootExport of rootExports) {
       if (rootExport === "default") {
         instantiate += `export default __exp["${rootExport}"];\n`;
@@ -978,10 +989,19 @@ function buildBundle(
     }
   } else {
     instantiate = hasTla
-      ? `await __instantiateAsync("${rootName}");\n`
-      : `__instantiate("${rootName}");\n`;
+      ? `await __instantiate("${rootName}", true);\n`
+      : `__instantiate("${rootName}", false);\n`;
   }
-  return `${SYSTEM_LOADER}\n${data}\n${instantiate}`;
+  const es5Bundle =
+    target === ts.ScriptTarget.ES3 ||
+    target === ts.ScriptTarget.ES5 ||
+    target === ts.ScriptTarget.ES2015 ||
+    target === ts.ScriptTarget.ES2016
+      ? true
+      : false;
+  return `${
+    es5Bundle ? SYSTEM_LOADER_ES5 : SYSTEM_LOADER
+  }\n${data}\n${instantiate}`;
 }
 
 function setRootExports(program: ts.Program, rootModule: string): void {

--- a/cli/tests/bundle.test.out
+++ b/cli/tests/bundle.test.out
@@ -1,6 +1,5 @@
 [WILDCARD]
-let System, __instantiateAsync, __instantiate;
-[WILDCARD]
+let System, __instantiate;
 (() => {
 [WILDCARD]
 })();
@@ -15,7 +14,7 @@ System.register("mod1", ["subdir2/mod2"], function (exports_3, context_3) {
 [WILDCARD]
 });
 
-const __exp = __instantiate("mod1");
+const __exp = __instantiate("mod1", false);
 export const returnsHi = __exp["returnsHi"];
 export const returnsFoo2 = __exp["returnsFoo2"];
 export const printHello3 = __exp["printHello3"];

--- a/cli/tests/compiler_api_test.ts
+++ b/cli/tests/compiler_api_test.ts
@@ -1,150 +1,201 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals } from "../../std/testing/asserts.ts";
 
-Deno.test("compilerApiCompileSources", async function () {
-  const [diagnostics, actual] = await Deno.compile("/foo.ts", {
-    "/foo.ts": `import * as bar from "./bar.ts";\n\nconsole.log(bar);\n`,
-    "/bar.ts": `export const bar = "bar";\n`,
-  });
-  assert(diagnostics == null);
-  assert(actual);
-  assertEquals(Object.keys(actual), [
-    "/bar.js.map",
-    "/bar.js",
-    "/foo.js.map",
-    "/foo.js",
-  ]);
-});
-
-Deno.test("compilerApiCompileNoSources", async function () {
-  const [diagnostics, actual] = await Deno.compile("./subdir/mod1.ts");
-  assert(diagnostics == null);
-  assert(actual);
-  const keys = Object.keys(actual);
-  assertEquals(keys.length, 6);
-  assert(keys[0].endsWith("print_hello.js.map"));
-  assert(keys[1].endsWith("print_hello.js"));
-});
-
-Deno.test("compilerApiCompileOptions", async function () {
-  const [diagnostics, actual] = await Deno.compile(
-    "/foo.ts",
-    {
-      "/foo.ts": `export const foo = "foo";`,
-    },
-    {
-      module: "amd",
-      sourceMap: false,
-    }
-  );
-  assert(diagnostics == null);
-  assert(actual);
-  assertEquals(Object.keys(actual), ["/foo.js"]);
-  assert(actual["/foo.js"].startsWith("define("));
-});
-
-Deno.test("compilerApiCompileLib", async function () {
-  const [diagnostics, actual] = await Deno.compile(
-    "/foo.ts",
-    {
-      "/foo.ts": `console.log(document.getElementById("foo"));
-        console.log(Deno.args);`,
-    },
-    {
-      lib: ["dom", "es2018", "deno.ns"],
-    }
-  );
-  assert(diagnostics == null);
-  assert(actual);
-  assertEquals(Object.keys(actual), ["/foo.js.map", "/foo.js"]);
-});
-
-Deno.test("compilerApiCompileTypes", async function () {
-  const [diagnostics, actual] = await Deno.compile(
-    "/foo.ts",
-    {
-      "/foo.ts": `console.log(Foo.bar);`,
-    },
-    {
-      types: ["./subdir/foo_types.d.ts"],
-    }
-  );
-  assert(diagnostics == null);
-  assert(actual);
-  assertEquals(Object.keys(actual), ["/foo.js.map", "/foo.js"]);
-});
-
-Deno.test("transpileOnlyApi", async function () {
-  const actual = await Deno.transpileOnly({
-    "foo.ts": `export enum Foo { Foo, Bar, Baz };\n`,
-  });
-  assert(actual);
-  assertEquals(Object.keys(actual), ["foo.ts"]);
-  assert(actual["foo.ts"].source.startsWith("export var Foo;"));
-  assert(actual["foo.ts"].map);
-});
-
-Deno.test("transpileOnlyApiConfig", async function () {
-  const actual = await Deno.transpileOnly(
-    {
-      "foo.ts": `export enum Foo { Foo, Bar, Baz };\n`,
-    },
-    {
-      sourceMap: false,
-      module: "amd",
-    }
-  );
-  assert(actual);
-  assertEquals(Object.keys(actual), ["foo.ts"]);
-  assert(actual["foo.ts"].source.startsWith("define("));
-  assert(actual["foo.ts"].map == null);
-});
-
-Deno.test("bundleApiSources", async function () {
-  const [diagnostics, actual] = await Deno.bundle("/foo.ts", {
-    "/foo.ts": `export * from "./bar.ts";\n`,
-    "/bar.ts": `export const bar = "bar";\n`,
-  });
-  assert(diagnostics == null);
-  assert(actual.includes(`__instantiate("foo")`));
-  assert(actual.includes(`__exp["bar"]`));
-});
-
-Deno.test("bundleApiNoSources", async function () {
-  const [diagnostics, actual] = await Deno.bundle("./subdir/mod1.ts");
-  assert(diagnostics == null);
-  assert(actual.includes(`__instantiate("mod1")`));
-  assert(actual.includes(`__exp["printHello3"]`));
-});
-
-Deno.test("bundleApiConfig", async function () {
-  const [diagnostics, actual] = await Deno.bundle(
-    "/foo.ts",
-    {
-      "/foo.ts": `// random comment\nexport * from "./bar.ts";\n`,
+Deno.test({
+  name: "Deno.compile() - sources provided",
+  async fn() {
+    const [diagnostics, actual] = await Deno.compile("/foo.ts", {
+      "/foo.ts": `import * as bar from "./bar.ts";\n\nconsole.log(bar);\n`,
       "/bar.ts": `export const bar = "bar";\n`,
-    },
-    {
-      removeComments: true,
-    }
-  );
-  assert(diagnostics == null);
-  assert(!actual.includes(`random`));
+    });
+    assert(diagnostics == null);
+    assert(actual);
+    assertEquals(Object.keys(actual), [
+      "/bar.js.map",
+      "/bar.js",
+      "/foo.js.map",
+      "/foo.js",
+    ]);
+  },
 });
 
-Deno.test("bundleApiJsModules", async function () {
-  const [diagnostics, actual] = await Deno.bundle("/foo.js", {
-    "/foo.js": `export * from "./bar.js";\n`,
-    "/bar.js": `export const bar = "bar";\n`,
-  });
-  assert(diagnostics == null);
-  assert(actual.includes(`System.register("bar",`));
+Deno.test({
+  name: "Deno.compile() - no sources provided",
+  async fn() {
+    const [diagnostics, actual] = await Deno.compile("./subdir/mod1.ts");
+    assert(diagnostics == null);
+    assert(actual);
+    const keys = Object.keys(actual);
+    assertEquals(keys.length, 6);
+    assert(keys[0].endsWith("print_hello.js.map"));
+    assert(keys[1].endsWith("print_hello.js"));
+  },
 });
 
-Deno.test("diagnosticsTest", async function () {
-  const [diagnostics] = await Deno.compile("/foo.ts", {
-    "/foo.ts": `document.getElementById("foo");`,
-  });
-  assert(Array.isArray(diagnostics));
-  assert(diagnostics.length === 1);
+Deno.test({
+  name: "Deno.compile() - compiler options effects imit",
+  async fn() {
+    const [diagnostics, actual] = await Deno.compile(
+      "/foo.ts",
+      {
+        "/foo.ts": `export const foo = "foo";`,
+      },
+      {
+        module: "amd",
+        sourceMap: false,
+      }
+    );
+    assert(diagnostics == null);
+    assert(actual);
+    assertEquals(Object.keys(actual), ["/foo.js"]);
+    assert(actual["/foo.js"].startsWith("define("));
+  },
+});
+
+Deno.test({
+  name: "Deno.compile() - pass lib in compiler options",
+  async fn() {
+    const [diagnostics, actual] = await Deno.compile(
+      "/foo.ts",
+      {
+        "/foo.ts": `console.log(document.getElementById("foo"));
+        console.log(Deno.args);`,
+      },
+      {
+        lib: ["dom", "es2018", "deno.ns"],
+      }
+    );
+    assert(diagnostics == null);
+    assert(actual);
+    assertEquals(Object.keys(actual), ["/foo.js.map", "/foo.js"]);
+  },
+});
+
+Deno.test({
+  name: "Deno.compile() - properly handles .d.ts files",
+  async fn() {
+    const [diagnostics, actual] = await Deno.compile(
+      "/foo.ts",
+      {
+        "/foo.ts": `console.log(Foo.bar);`,
+      },
+      {
+        types: ["./subdir/foo_types.d.ts"],
+      }
+    );
+    assert(diagnostics == null);
+    assert(actual);
+    assertEquals(Object.keys(actual), ["/foo.js.map", "/foo.js"]);
+  },
+});
+
+Deno.test({
+  name: "Deno.transpileOnly()",
+  async fn() {
+    const actual = await Deno.transpileOnly({
+      "foo.ts": `export enum Foo { Foo, Bar, Baz };\n`,
+    });
+    assert(actual);
+    assertEquals(Object.keys(actual), ["foo.ts"]);
+    assert(actual["foo.ts"].source.startsWith("export var Foo;"));
+    assert(actual["foo.ts"].map);
+  },
+});
+
+Deno.test({
+  name: "Deno.transpileOnly() - config effects commit",
+  async fn() {
+    const actual = await Deno.transpileOnly(
+      {
+        "foo.ts": `export enum Foo { Foo, Bar, Baz };\n`,
+      },
+      {
+        sourceMap: false,
+        module: "amd",
+      }
+    );
+    assert(actual);
+    assertEquals(Object.keys(actual), ["foo.ts"]);
+    assert(actual["foo.ts"].source.startsWith("define("));
+    assert(actual["foo.ts"].map == null);
+  },
+});
+
+Deno.test({
+  name: "Deno.bundle() - sources passed",
+  async fn() {
+    const [diagnostics, actual] = await Deno.bundle("/foo.ts", {
+      "/foo.ts": `export * from "./bar.ts";\n`,
+      "/bar.ts": `export const bar = "bar";\n`,
+    });
+    assert(diagnostics == null);
+    assert(actual.includes(`__instantiate("foo", false)`));
+    assert(actual.includes(`__exp["bar"]`));
+  },
+});
+
+Deno.test({
+  name: "Deno.bundle() - no sources passed",
+  async fn() {
+    const [diagnostics, actual] = await Deno.bundle("./subdir/mod1.ts");
+    assert(diagnostics == null);
+    assert(actual.includes(`__instantiate("mod1", false)`));
+    assert(actual.includes(`__exp["printHello3"]`));
+  },
+});
+
+Deno.test({
+  name: "Deno.bundle() - compiler config effects emit",
+  async fn() {
+    const [diagnostics, actual] = await Deno.bundle(
+      "/foo.ts",
+      {
+        "/foo.ts": `// random comment\nexport * from "./bar.ts";\n`,
+        "/bar.ts": `export const bar = "bar";\n`,
+      },
+      {
+        removeComments: true,
+      }
+    );
+    assert(diagnostics == null);
+    assert(!actual.includes(`random`));
+  },
+});
+
+Deno.test({
+  name: "Deno.bundle() - JS Modules included",
+  async fn() {
+    const [diagnostics, actual] = await Deno.bundle("/foo.js", {
+      "/foo.js": `export * from "./bar.js";\n`,
+      "/bar.js": `export const bar = "bar";\n`,
+    });
+    assert(diagnostics == null);
+    assert(actual.includes(`System.register("bar",`));
+  },
+});
+
+Deno.test({
+  name: "Deno.bundle - pre ES2017 uses ES5 loader",
+  async fn() {
+    const [diagnostics, actual] = await Deno.bundle(
+      "/foo.ts",
+      {
+        "/foo.ts": `console.log("hello world!")\n`,
+      },
+      { target: "es2015" }
+    );
+    assert(diagnostics == null);
+    assert(actual.includes(`var __awaiter = `));
+  },
+});
+
+Deno.test({
+  name: "runtime compiler APIs diagnostics",
+  async fn() {
+    const [diagnostics] = await Deno.compile("/foo.ts", {
+      "/foo.ts": `document.getElementById("foo");`,
+    });
+    assert(Array.isArray(diagnostics));
+    assert(diagnostics.length === 1);
+  },
 });

--- a/deno_typescript/README.md
+++ b/deno_typescript/README.md
@@ -69,9 +69,14 @@ At the time of this writing, while V8 and other JavaScript engines have
 implemented top-level-await, no browsers have it implemented, meaning that most
 browsers could not consume modules that require top-level-await.
 
-In order to facilitate this, there are two functions that are in the scope of
-the module in addition to the `System.register()` method. `__instantiate(main)`
-will bootstrap everything synchronously and `__instantiateAsync(main)` will do
-so asynchronously. When emitting a bundle that contains a module that requires
-top-level-await, Deno will detect this and utilise
-`await __instantiateAsync(main)` instead.
+In order to allow more browsers to consume bundles, there is an argument that is
+passed to the `__instantiate()` function which determines if the code is
+bootstrapped asynchronously or not. When emitting a bundle that contains a
+module that requires top-level-await, Deno will detect this and utilise
+`await __instantiate(main, true)`.
+
+The `system_loader_es5.js` is a transpiled version of `system_loader.js` that is
+designed to work with ES5 or later, and will be used when the bundle target is <
+ES2017. While ES3 is still a potential target which can be passed in a
+`tsconfig.json` to Deno, any resulting bundle will not be compatible, as there
+is a need to utilise items like `Object.defineProperty()`.

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -208,7 +208,7 @@ pub fn mksnapshot_bundle(
   js_check(
     isolate.execute(&bundle_filename.to_string_lossy(), bundle_source_code),
   );
-  let script = &format!("__instantiate(\"{}\");", main_module_name);
+  let script = &format!("__instantiate(\"{}\", false);", main_module_name);
   js_check(isolate.execute("anon", script));
   write_snapshot(isolate, snapshot_filename)?;
   Ok(())
@@ -252,6 +252,7 @@ pub fn get_asset(name: &str) -> Option<&'static str> {
   }
   match name {
     "system_loader.js" => Some(include_str!("system_loader.js")),
+    "system_loader_es5.js" => Some(include_str!("system_loader_es5.js")),
     "bootstrap.ts" => Some("console.log(\"hello deno\");"),
     "typescript.d.ts" => inc!("typescript.d.ts"),
     "lib.dom.d.ts" => inc!("lib.dom.d.ts"),

--- a/deno_typescript/system_loader.js
+++ b/deno_typescript/system_loader.js
@@ -6,17 +6,14 @@
 
 // @ts-nocheck
 /* eslint-disable */
-let System, __instantiateAsync, __instantiate;
-
+let System, __instantiate;
 (() => {
-  const r = new Map();
-
+  const r = Object.create(null);
   System = {
     register(id, d, f) {
-      r.set(id, { d, f, exp: {} });
+      r[id] = { d, f, exp: {} };
     },
   };
-
   async function dI(mid, src) {
     let id = mid.replace(/\.\w+$/i, "");
     if (id.includes("./")) {
@@ -33,9 +30,8 @@ let System, __instantiateAsync, __instantiate;
       if (s < sa.length) oa.push(...sa.slice(s));
       id = oa.reverse().join("/");
     }
-    return r.has(id) ? gExpA(id) : import(mid);
+    return id in r ? gExpA(id) : import(mid);
   }
-
   function gC(id, main) {
     return {
       id,
@@ -43,7 +39,6 @@ let System, __instantiateAsync, __instantiate;
       meta: { url: id, main },
     };
   }
-
   function gE(exp) {
     return (id, v) => {
       v = typeof id === "string" ? { [id]: v } : id;
@@ -56,9 +51,10 @@ let System, __instantiateAsync, __instantiate;
       }
     };
   }
-
   function rF(main) {
-    for (const [id, m] of r.entries()) {
+    let m;
+    for (const id in r) {
+      m = r[id];
       const { f, exp } = m;
       const { execute: e, setters: s } = f(gE(exp), gC(id, id === main));
       delete m.f;
@@ -66,10 +62,9 @@ let System, __instantiateAsync, __instantiate;
       m.s = s;
     }
   }
-
   async function gExpA(id) {
-    if (!r.has(id)) return;
-    const m = r.get(id);
+    if (!(id in r)) return;
+    const m = r[id];
     if (m.s) {
       const { d, e, s } = m;
       delete m.s;
@@ -80,10 +75,9 @@ let System, __instantiateAsync, __instantiate;
     }
     return m.exp;
   }
-
   function gExp(id) {
-    if (!r.has(id)) return;
-    const m = r.get(id);
+    if (!(id in r)) return;
+    const m = r[id];
     if (m.s) {
       const { d, e, s } = m;
       delete m.s;
@@ -93,16 +87,9 @@ let System, __instantiateAsync, __instantiate;
     }
     return m.exp;
   }
-
-  __instantiateAsync = async (m) => {
-    System = __instantiateAsync = __instantiate = undefined;
+  __instantiate = (m, a) => {
+    System = __instantiate = undefined;
     rF(m);
-    return gExpA(m);
-  };
-
-  __instantiate = (m) => {
-    System = __instantiateAsync = __instantiate = undefined;
-    rF(m);
-    return gExp(m);
+    return a ? gExpA(m) : gExp(m);
   };
 })();

--- a/deno_typescript/system_loader_es5.js
+++ b/deno_typescript/system_loader_es5.js
@@ -1,0 +1,182 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+// This is a specialised implementation of a System module loader.
+
+"use strict";
+
+// @ts-nocheck
+/* eslint-disable */
+var System, __instantiate;
+(function () {
+  // prettier-ignore
+  var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  // prettier-ignore
+  var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+  };
+  var r = Object.create(null);
+  System = {
+    register: function (id, d, f) {
+      r[id] = { d: d, f: f, exp: {} };
+    },
+  };
+  function dI(mid, src) {
+    return __awaiter(this, void 0, void 0, function () {
+      var id, _a, o, ia, _b, sa, oa, s, i;
+      return __generator(this, function (_c) {
+        id = mid.replace(/\.\w+$/i, "");
+        if (id.includes("./")) {
+          (_a = id.split("/").reverse()),
+            (o = _a[0]),
+            (ia = _a.slice(1)),
+            (_b = src.split("/").reverse()),
+            (sa = _b.slice(1)),
+            (oa = [o]);
+          (s = 0), (i = void 0);
+          while ((i = ia.shift())) {
+            if (i === "..") s++;
+            else if (i === ".") break;
+            else oa.push(i);
+          }
+          if (s < sa.length) oa.push.apply(oa, sa.slice(s));
+          id = oa.reverse().join("/");
+        }
+        return [
+          2,
+          id in r
+            ? gExpA(id)
+            : Promise.resolve().then(function () {
+                return require(mid);
+              }),
+        ];
+      });
+    });
+  }
+  function gC(id, main) {
+    return {
+      id: id,
+      import: function (m) {
+        return dI(m, id);
+      },
+      meta: { url: id, main: main },
+    };
+  }
+  function gE(exp) {
+    return function (id, v) {
+      var _a;
+      v = typeof id === "string" ? ((_a = {}), (_a[id] = v), _a) : id;
+      for (var _i = 0, _b = Object.entries(v); _i < _b.length; _i++) {
+        var _c = _b[_i],
+          id_1 = _c[0],
+          value = _c[1];
+        Object.defineProperty(exp, id_1, {
+          value: value,
+          writable: true,
+          enumerable: true,
+        });
+      }
+    };
+  }
+  function rF(main) {
+    var m;
+    for (var id in r) {
+      m = r[id];
+      var f = m.f,
+        exp = m.exp;
+      var _a = f(gE(exp), gC(id, id === main)),
+        e = _a.execute,
+        s = _a.setters;
+      delete m.f;
+      m.e = e;
+      m.s = s;
+    }
+  }
+  function gExpA(id) {
+    return __awaiter(this, void 0, void 0, function () {
+      var m, d, e, s, i, _a, _b, r_1;
+      return __generator(this, function (_c) {
+        switch (_c.label) {
+          case 0:
+            if (!(id in r)) return [2];
+            m = r[id];
+            if (!m.s) return [3, 6];
+            (d = m.d), (e = m.e), (s = m.s);
+            delete m.s;
+            delete m.e;
+            i = 0;
+            _c.label = 1;
+          case 1:
+            if (!(i < s.length)) return [3, 4];
+            _b = (_a = s)[i];
+            return [4, gExpA(d[i])];
+          case 2:
+            _b.apply(_a, [_c.sent()]);
+            _c.label = 3;
+          case 3:
+            i++;
+            return [3, 1];
+          case 4:
+            r_1 = e();
+            if (!r_1) return [3, 6];
+            return [4, r_1];
+          case 5:
+            _c.sent();
+            _c.label = 6;
+          case 6:
+            return [2, m.exp];
+        }
+      });
+    });
+  }
+  function gExp(id) {
+    if (!(id in r)) return;
+    var m = r[id];
+    if (m.s) {
+      var d = m.d,
+        e = m.e,
+        s = m.s;
+      delete m.s;
+      delete m.e;
+      for (var i = 0; i < s.length; i++) s[i](gExp(d[i]));
+      e();
+    }
+    return m.exp;
+  }
+  __instantiate = function (m, a) {
+    System = __instantiate = undefined;
+    rF(m);
+    return a ? gExpA(m) : gExp(m);
+  };
+})();


### PR DESCRIPTION
Resolves #6297 

This provides a `system_loader_es5.js` bundle loader which will be added to the bundle when the target is < ES2017, which is the minimum target syntax required for `system_loader.js`.

Supports #5913 (via `Deno.bundle()`) with a couple caveats:

- Allowing `deno bundle` to take a different target is not supported, as we specifically ignore `"target"` when passed in a TypeScript config file.  This is because `deno bundle` is really intended to generate bundles that work in Deno.  It is an unintentional side effect that some bundles are loadable in browsers.  The real
- While a target of `"es3"` will be accepted, the module loader will still only be compatible with ES5 or later.  Realistically no one should be expecting bundles generated by Deno to be used on IE8 and prior, and there is just too much "baggage" to support that at this point.