### PR TITLE
Bug assert throws error

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -376,6 +376,9 @@ export async function assertThrowsAsync<T = void>(
   try {
     await fn();
   } catch (e) {
+    if (e === undefined || e === null || typeof e.message === "undefined") {
+      throw new AssertionError("Please throw or reject a valid Error object.");
+    }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
       msg = `Expected error to be instance of "${ErrorClass.name}", but got "${
         e.name

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -322,7 +322,8 @@ export function fail(msg?: string): void {
   assert(false, `Failed assertion${msg ? `: ${msg}` : "."}`);
 }
 
-/** Executes a function, expecting it to throw.  If it does not, then it
+/**
+ * Executes a function, expecting it to throw.  If it does not, then it
  * throws.  An error class and a string that should be included in the
  * error message can also be asserted.
  */
@@ -365,6 +366,11 @@ export function assertThrows<T = void>(
   return error;
 }
 
+/**
+ * Executes a function which returns a promise, expecting it to throw or reject.
+ * If it does not, then it throws.  An error class and a string that should be
+ * included in the error message can also be asserted.
+ */
 export async function assertThrowsAsync<T = void>(
   fn: () => Promise<T>,
   ErrorClass?: Constructor,

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -337,6 +337,9 @@ export function assertThrows<T = void>(
   try {
     fn();
   } catch (e) {
+    if (e === undefined || e === null || typeof e.message === "undefined") {
+      throw new AssertionError("Please throw a valid Error object.");
+    }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
       msg = `Expected error to be instance of "${ErrorClass.name}", but was "${
         e.constructor.name

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -337,7 +337,7 @@ export function assertThrows<T = void>(
   try {
     fn();
   } catch (e) {
-    if (e === undefined || e === null || typeof e.message === "undefined") {
+    if (e instanceof Error === false) {
       throw new AssertionError("Please throw a valid Error object.");
     }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
@@ -376,7 +376,7 @@ export async function assertThrowsAsync<T = void>(
   try {
     await fn();
   } catch (e) {
-    if (e === undefined || e === null || typeof e.message === "undefined") {
+    if (e instanceof Error === false) {
       throw new AssertionError("Please throw or reject a valid Error object.");
     }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -338,7 +338,7 @@ export function assertThrows<T = void>(
     fn();
   } catch (e) {
     if (e instanceof Error === false) {
-      throw new AssertionError("Please throw a valid Error object.");
+      throw new AssertionError("A non-Error object was thrown.");
     }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
       msg = `Expected error to be instance of "${ErrorClass.name}", but was "${
@@ -377,7 +377,7 @@ export async function assertThrowsAsync<T = void>(
     await fn();
   } catch (e) {
     if (e instanceof Error === false) {
-      throw new AssertionError("Please throw or reject a valid Error object.");
+      throw new AssertionError("A non-Error object was thrown or rejected.");
     }
     if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
       msg = `Expected error to be instance of "${ErrorClass.name}", but got "${

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -413,14 +413,6 @@ Deno.test({
 Deno.test("Assert Throws Non-Error Fail", () => {
   assertThrows(
     () => {
-      throw new Error("Panic!");
-    },
-    Error,
-    "Panic!"
-  );
-
-  assertThrows(
-    () => {
       assertThrows(
         () => {
           throw "Panic!";
@@ -455,14 +447,6 @@ Deno.test("Assert Throws Non-Error Fail", () => {
 });
 
 Deno.test("Assert Throws Async Non-Error Fail", () => {
-  assertThrowsAsync(
-    () => {
-      return Promise.reject(new Error("Panic!"));
-    },
-    Error,
-    "Panic!"
-  );
-
   assertThrowsAsync(
     () => {
       return assertThrowsAsync(

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -422,7 +422,7 @@ Deno.test("Assert Throws Non-Error Fail", () => {
       );
     },
     AssertionError,
-    "Please throw a valid Error object."
+    "A non-Error object was thrown."
   );
 
   assertThrows(
@@ -432,7 +432,7 @@ Deno.test("Assert Throws Non-Error Fail", () => {
       });
     },
     AssertionError,
-    "Please throw a valid Error object."
+    "A non-Error object was thrown."
   );
 
   assertThrows(
@@ -442,7 +442,7 @@ Deno.test("Assert Throws Non-Error Fail", () => {
       });
     },
     AssertionError,
-    "Please throw a valid Error object."
+    "A non-Error object was thrown."
   );
 });
 
@@ -458,7 +458,7 @@ Deno.test("Assert Throws Async Non-Error Fail", () => {
       );
     },
     AssertionError,
-    "Please throw or reject a valid Error object."
+    "A non-Error object was thrown or rejected."
   );
 
   assertThrowsAsync(
@@ -468,7 +468,7 @@ Deno.test("Assert Throws Async Non-Error Fail", () => {
       });
     },
     AssertionError,
-    "Please throw or reject a valid Error object."
+    "A non-Error object was thrown or rejected."
   );
 
   assertThrowsAsync(
@@ -478,7 +478,7 @@ Deno.test("Assert Throws Async Non-Error Fail", () => {
       });
     },
     AssertionError,
-    "Please throw or reject a valid Error object."
+    "A non-Error object was thrown or rejected."
   );
 
   assertThrowsAsync(
@@ -489,6 +489,6 @@ Deno.test("Assert Throws Async Non-Error Fail", () => {
       });
     },
     AssertionError,
-    "Please throw or reject a valid Error object."
+    "A non-Error object was thrown or rejected."
   );
 });

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -453,3 +453,58 @@ Deno.test("Assert Throws Non-Error Fail", () => {
     "Please throw a valid Error object."
   );
 });
+
+Deno.test("Assert Throws Async Non-Error Fail", () => {
+  assertThrowsAsync(
+    () => {
+      return Promise.reject(new Error("Panic!"));
+    },
+    Error,
+    "Panic!"
+  );
+
+  assertThrowsAsync(
+    () => {
+      return assertThrowsAsync(
+        () => {
+          return Promise.reject("Panic!");
+        },
+        String,
+        "Panic!"
+      );
+    },
+    AssertionError,
+    "Please throw or reject a valid Error object."
+  );
+
+  assertThrowsAsync(
+    () => {
+      return assertThrowsAsync(() => {
+        return Promise.reject(null);
+      });
+    },
+    AssertionError,
+    "Please throw or reject a valid Error object."
+  );
+
+  assertThrowsAsync(
+    () => {
+      return assertThrowsAsync(() => {
+        return Promise.reject(undefined);
+      });
+    },
+    AssertionError,
+    "Please throw or reject a valid Error object."
+  );
+
+  assertThrowsAsync(
+    () => {
+      return assertThrowsAsync(() => {
+        throw undefined;
+        return Promise.resolve("Ok!");
+      });
+    },
+    AssertionError,
+    "Please throw or reject a valid Error object."
+  );
+});

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -409,3 +409,47 @@ Deno.test({
     );
   },
 });
+
+Deno.test("Assert Throws Non-Error Fail", () => {
+  assertThrows(
+    () => {
+      throw new Error("Panic!");
+    },
+    Error,
+    "Panic!"
+  );
+
+  assertThrows(
+    () => {
+      assertThrows(
+        () => {
+          throw "Panic!";
+        },
+        String,
+        "Panic!"
+      );
+    },
+    AssertionError,
+    "Please throw a valid Error object."
+  );
+
+  assertThrows(
+    () => {
+      assertThrows(() => {
+        throw null;
+      });
+    },
+    AssertionError,
+    "Please throw a valid Error object."
+  );
+
+  assertThrows(
+    () => {
+      assertThrows(() => {
+        throw undefined;
+      });
+    },
+    AssertionError,
+    "Please throw a valid Error object."
+  );
+});


### PR DESCRIPTION
Currently you can cause cause run time errors in the `assertThrows()` and `assertThrowsAsync()` methods in the asserts module if you don't throw or reject a valid Error object. This happens when a developer attempts to assert the error message.

This code change enables this scenario to be captured and fail gracefully so the developer knows where they have gone wrong.

Is an improvement based on conversations in pull request #6314.
