### PR TITLE
Fix non-existing version upgrade message

### DIFF
--- a/cli/upgrade.rs
+++ b/cli/upgrade.rs
@@ -90,14 +90,12 @@ pub async fn upgrade_command(
     }
   };
 
-  println!(
-    "Version has been found\nDeno is upgrading to version {}",
-    &install_version
-  );
-
-  let archive_data =
-    download_package(&compose_url_to_exec(&install_version)?, client).await?;
-
+  let archive_data = download_package(
+    &compose_url_to_exec(&install_version)?,
+    client,
+    &install_version,
+  )
+  .await?;
   let old_exe_path = std::env::current_exe()?;
   let new_exe_path = unpack(archive_data)?;
   let permissions = fs::metadata(&old_exe_path)?.permissions();
@@ -116,15 +114,29 @@ pub async fn upgrade_command(
 fn download_package(
   url: &Url,
   client: Client,
+  version: &Version,
 ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, ErrBox>>>> {
   println!("downloading {}", url);
   let url = url.clone();
+  let version = version.clone();
   let fut = async move {
-    match fetch_once(client.clone(), &url, None).await? {
-      FetchOnceResult::Code(source, _) => Ok(source),
-      FetchOnceResult::NotModified => unreachable!(),
-      FetchOnceResult::Redirect(_url, _) => {
-        download_package(&_url, client).await
+    match fetch_once(client.clone(), &url, None).await {
+      Ok(result) => {
+        println!(
+          "Version has been found\nDeno is upgrading to version {}",
+          &version
+        );
+        match result {
+          FetchOnceResult::Code(source, _) => Ok(source),
+          FetchOnceResult::NotModified => unreachable!(),
+          FetchOnceResult::Redirect(_url, _) => {
+            download_package(&_url, client, &version).await
+          }
+        }
+      }
+      Err(_) => {
+        println!("Version has not been found, aborting");
+        std::process::exit(1)
       }
     }
   };


### PR DESCRIPTION
Fixes  #6329
Failure message will now be:
```
$ deno upgrade --version 1.0.6
downloading https://github.com/denoland/deno/releases/download/v1.0.6/deno-x86_64-apple-darwin.zip
Version has not been found, aborting
```