### PR TITLE
Fix print "{msg}" when log an empty line. (#6380)

### DIFF
--- a/std/log/handlers.ts
+++ b/std/log/handlers.ts
@@ -41,7 +41,7 @@ export class BaseHandler {
       const value = logRecord[p1 as keyof LogRecord];
 
       // do not interpolate missing values
-      if (!value) {
+      if (value == null) {
         return match;
       }
 


### PR DESCRIPTION
Fix for [Log empty line would print "{msg}" unexpected](https://github.com/denoland/deno/issues/6380)
