### PR TITLE
refactor(cli/checksum): use map to generate hex string

### DIFF
--- a/cli/checksum.rs
+++ b/cli/checksum.rs
@@ -1,15 +1,13 @@
-use std::fmt::Write;
-
 pub fn gen(v: Vec<&[u8]>) -> String {
   let mut ctx = ring::digest::Context::new(&ring::digest::SHA256);
   for src in v.iter() {
     ctx.update(src);
   }
   let digest = ctx.finish();
-  let mut out = String::new();
-  // TODO There must be a better way to do this...
-  for byte in digest.as_ref() {
-    write!(&mut out, "{:02x}", byte).unwrap();
-  }
-  out
+  let out: Vec<String> = digest
+    .as_ref()
+    .iter()
+    .map(|byte| format!("{:02x}", byte))
+    .collect();
+  out.join("")
 }


### PR DESCRIPTION
Using the map to generate the hex string for checksum, remove the dependency for std::fmt::Write