### PR TITLE
fix(std/node): import process from 'process'

### DIFF
--- a/std/node/os.ts
+++ b/std/node/os.ts
@@ -21,7 +21,7 @@
 import { notImplemented } from "./_utils.ts";
 import { validateIntegerRange } from "./util.ts";
 import { EOL as fsEOL } from "../fs/eol.ts";
-import { process } from "./process.ts";
+import process from "./process.ts";
 
 const SEE_GITHUB_ISSUE = "See https://github.com/denoland/deno/issues/3802";
 

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -61,7 +61,13 @@ export const process = {
   },
 };
 
-/** use this for access to `process.env` and `process.argv` which cannot be exported directly */
+/** requires the use of await for compatibility with deno */
+export const env = new Promise((resolve) => resolve(process.env));
+
+/** requires the use of await for compatibility with deno */
+export const argv = new Promise((resolve) => resolve(process.argv));
+
+/** use this for access to `process.env` and `process.argv` without the need for await */
 export default process;
 
 Object.defineProperty(process, Symbol.toStringTag, {

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -5,7 +5,7 @@ function on(_event: string, _callback: Function): void {
   notImplemented();
 }
 
-export const process = {
+const process = {
   version: `v${Deno.version.deno}`,
   versions: {
     node: Deno.version.deno,
@@ -41,3 +41,5 @@ Object.defineProperty(globalThis, "process", {
   writable: true,
   configurable: true,
 });
+
+export default process

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -1,27 +1,61 @@
 import { notImplemented } from "./_utils.ts";
 
+/** https://nodejs.org/api/process.html#process_process_events */
 function on(_event: string, _callback: Function): void {
   // TODO(rsp): to be implemented
   notImplemented();
 }
 
-const process = {
-  version: `v${Deno.version.deno}`,
-  versions: {
-    node: Deno.version.deno,
-    ...Deno.version,
-  },
-  platform: Deno.build.os === "windows" ? "win32" : Deno.build.os,
-  arch: Deno.build.arch,
-  pid: Deno.pid,
-  cwd: Deno.cwd,
-  chdir: Deno.chdir,
-  exit: Deno.exit,
+/** https://nodejs.org/api/process.html#process_process_version */
+export const version = `v${Deno.version.deno}`;
+
+/** https://nodejs.org/api/process.html#process_process_versions */
+export const versions = {
+  node: Deno.version.deno,
+  ...Deno.version,
+};
+
+/** https://nodejs.org/api/process.html#process_process_platform */
+export const platform = Deno.build.os === "windows" ? "win32" : Deno.build.os;
+
+/** https://nodejs.org/api/process.html#process_process_arch */
+export const arch = Deno.build.arch;
+
+/** https://nodejs.org/api/process.html#process_process_pid */
+export const pid = Deno.pid;
+
+/** https://nodejs.org/api/process.html#process_process_cwd */
+export const cwd = Deno.cwd;
+
+/** https://nodejs.org/api/process.html#process_process_chdir_directory */
+export const chdir = Deno.chdir;
+
+/** https://nodejs.org/api/process.html#process_process_exit_code */
+export const exit = Deno.exit;
+
+/**
+ * https://nodejs.org/api/process.html#process_process
+ * even though `import { process } from 'process'` is invalid node code
+ * it is what deno used initially, so this functions as backwards compatibility
+ */
+export const process = {
   on,
+  version,
+  versions,
+  platform,
+  arch,
+  pid,
+  cwd,
+  chdir,
+  exit,
+
+  /** https://nodejs.org/api/process.html#process_process_env */
   get env(): { [index: string]: string } {
     // using getter to avoid --allow-env unless it's used
     return Deno.env.toObject();
   },
+
+  /** https://nodejs.org/api/process.html#process_process_argv */
   get argv(): string[] {
     // Deno.execPath() also requires --allow-env
     return [Deno.execPath(), ...Deno.args];

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -42,4 +42,4 @@ Object.defineProperty(globalThis, "process", {
   configurable: true,
 });
 
-export default process
+export default process;

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -1,10 +1,22 @@
 import { notImplemented } from "./_utils.ts";
 
-/** https://nodejs.org/api/process.html#process_process_events */
-function on(_event: string, _callback: Function): void {
-  // TODO(rsp): to be implemented
-  notImplemented();
-}
+/** https://nodejs.org/api/process.html#process_process_arch */
+export const arch = Deno.build.arch;
+
+/** https://nodejs.org/api/process.html#process_process_chdir_directory */
+export const chdir = Deno.chdir;
+
+/** https://nodejs.org/api/process.html#process_process_cwd */
+export const cwd = Deno.cwd;
+
+/** https://nodejs.org/api/process.html#process_process_exit_code */
+export const exit = Deno.exit;
+
+/** https://nodejs.org/api/process.html#process_process_pid */
+export const pid = Deno.pid;
+
+/** https://nodejs.org/api/process.html#process_process_platform */
+export const platform = Deno.build.os === "windows" ? "win32" : Deno.build.os;
 
 /** https://nodejs.org/api/process.html#process_process_version */
 export const version = `v${Deno.version.deno}`;
@@ -15,38 +27,25 @@ export const versions = {
   ...Deno.version,
 };
 
-/** https://nodejs.org/api/process.html#process_process_platform */
-export const platform = Deno.build.os === "windows" ? "win32" : Deno.build.os;
-
-/** https://nodejs.org/api/process.html#process_process_arch */
-export const arch = Deno.build.arch;
-
-/** https://nodejs.org/api/process.html#process_process_pid */
-export const pid = Deno.pid;
-
-/** https://nodejs.org/api/process.html#process_process_cwd */
-export const cwd = Deno.cwd;
-
-/** https://nodejs.org/api/process.html#process_process_chdir_directory */
-export const chdir = Deno.chdir;
-
-/** https://nodejs.org/api/process.html#process_process_exit_code */
-export const exit = Deno.exit;
-
-/**
- * https://nodejs.org/api/process.html#process_process
- * @deprecated exported only for backwards compatibility with old deno versions
- */
+/** https://nodejs.org/api/process.html#process_process */
+// @deprecated exported only for backwards compatibility with old deno versions
 export const process = {
-  on,
+  arch,
+  chdir,
+  cwd,
+  exit,
+  pid,
+  platform,
   version,
   versions,
-  platform,
-  arch,
-  pid,
-  cwd,
-  chdir,
-  exit,
+
+  /** https://nodejs.org/api/process.html#process_process_events */
+  // node --input-type=module -e "import {on} from 'process'; console.log(on)"
+  // on is not exported by node, it is only available within process
+  on(_event: string, _callback: Function): void {
+    // TODO(rsp): to be implemented
+    notImplemented();
+  },
 
   /** https://nodejs.org/api/process.html#process_process_env */
   get env(): { [index: string]: string } {
@@ -61,11 +60,19 @@ export const process = {
   },
 };
 
-/** requires the use of await for compatibility with deno */
-export const env = new Promise((resolve) => resolve(process.env));
+// define the type for configuring the env and argv promises
+// as well as for the global.process declaration
+type Process = typeof process;
 
 /** requires the use of await for compatibility with deno */
-export const argv = new Promise((resolve) => resolve(process.argv));
+export const env = new Promise<Process["env"]>((resolve) =>
+  resolve(process.env)
+);
+
+/** requires the use of await for compatibility with deno */
+export const argv = new Promise<Process["argv"]>((resolve) =>
+  resolve(process.argv)
+);
 
 /** use this for access to `process.env` and `process.argv` without the need for await */
 export default process;
@@ -85,6 +92,5 @@ Object.defineProperty(globalThis, "process", {
 });
 
 declare global {
-  // @ts-ignore
-  var process: typeof process;
+  const process: Process;
 }

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -35,8 +35,7 @@ export const exit = Deno.exit;
 
 /**
  * https://nodejs.org/api/process.html#process_process
- * even though `import { process } from 'process'` is invalid node code
- * it is what deno used initially, so this functions as backwards compatibility
+ * @deprecated exported only for backwards compatibility with old deno versions
  */
 export const process = {
   on,
@@ -62,6 +61,9 @@ export const process = {
   },
 };
 
+/** use this for access to `process.env` and `process.argv` which cannot be exported directly */
+export default process;
+
 Object.defineProperty(process, Symbol.toStringTag, {
   enumerable: false,
   writable: true,
@@ -75,5 +77,3 @@ Object.defineProperty(globalThis, "process", {
   writable: true,
   configurable: true,
 });
-
-export default process;

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -83,3 +83,8 @@ Object.defineProperty(globalThis, "process", {
   writable: true,
   configurable: true,
 });
+
+declare global {
+  // @ts-ignore
+  var process: typeof process;
+}

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -8,8 +8,11 @@ const process = globalThis.process;
 Deno.test({
   name: "process exports are as they should be",
   fn() {
+    // delete the aliases
     const keys = new Set<string>(Object.keys(all));
+    keys.delete("process");
     keys.delete("default");
+    // get into a consistent format for testing
     const str = Array.from(keys).sort().join(" ");
     assertEquals(Object.keys(all.default).sort().join(" "), str);
     assertEquals(Object.keys(all.process).sort().join(" "), str);

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -1,8 +1,21 @@
 import { assert, assertThrows, assertEquals } from "../testing/asserts.ts";
-import process from "./process.ts";
+import * as all from "./process.ts";
+const process = globalThis.process;
 
 // NOTE: Deno.execPath() (and thus process.argv) currently requires --allow-env
 // (Also Deno.env.toObject() (and process.env) requires --allow-env but it's more obvious)
+
+Deno.test({
+  name: "process exports are as they should be",
+  fn() {
+    const keys = new Set<string>(Object.keys(all));
+    keys.delete("default");
+    const str = Array.from(keys).sort().join(" ");
+    assertEquals(Object.keys(all.default).sort().join(" "), str);
+    assertEquals(Object.keys(all.process).sort().join(" "), str);
+    assertEquals(Object.keys(process).sort().join(" "), str);
+  },
+});
 
 Deno.test({
   name: "process.cwd and process.chdir success",
@@ -82,8 +95,9 @@ Deno.test({
 
 Deno.test({
   name: "process.argv",
-  fn() {
+  async fn() {
     assert(Array.isArray(process.argv));
+    assert(Array.isArray(await all.argv));
     assert(
       process.argv[0].match(/[^/\\]*deno[^/\\]*$/),
       "deno included in the file name of argv[0]"
@@ -94,7 +108,8 @@ Deno.test({
 
 Deno.test({
   name: "process.env",
-  fn() {
+  async fn() {
     assertEquals(typeof process.env.PATH, "string");
+    assertEquals(typeof (await all.env).PATH, "string");
   },
 });

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -1,5 +1,5 @@
 import { assert, assertThrows, assertEquals } from "../testing/asserts.ts";
-import { process } from "./process.ts";
+import process from "./process.ts";
 
 // NOTE: Deno.execPath() (and thus process.argv) currently requires --allow-env
 // (Also Deno.env.toObject() (and process.env) requires --allow-env but it's more obvious)

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -1,6 +1,5 @@
 import { assert, assertThrows, assertEquals } from "../testing/asserts.ts";
 import * as all from "./process.ts";
-const process = globalThis.process;
 
 // NOTE: Deno.execPath() (and thus process.argv) currently requires --allow-env
 // (Also Deno.env.toObject() (and process.env) requires --allow-env but it's more obvious)
@@ -100,6 +99,7 @@ Deno.test({
   name: "process.argv",
   async fn() {
     assert(Array.isArray(process.argv));
+    // @ts-ignore
     assert(Array.isArray(await all.argv));
     assert(
       process.argv[0].match(/[^/\\]*deno[^/\\]*$/),
@@ -113,6 +113,7 @@ Deno.test({
   name: "process.env",
   async fn() {
     assertEquals(typeof process.env.PATH, "string");
+    // @ts-ignore
     assertEquals(typeof (await all.env).PATH, "string");
   },
 });


### PR DESCRIPTION
This PR fixes import compatibility with Node.js for `std/node/process.ts`.


# global

## node

Works in node.

``` bash
node -e "console.log(process.env)"
```

## deno

Currently not supported by Deno due to missing Typescript declaration.

``` bash
deno eval "import 'https://deno.land/std/node/process.ts'; console.log(process.env)"
```

```
Compile file:///Users/balupton/__$deno$eval.ts
error: TS2580 [ERROR]: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i @types/node`.
import 'https://deno.land/std/node/process.ts'; console.log(process.env)
                                                            ~~~~~~~
    at file:///Users/balupton/__$deno$eval.ts:1:61
```

## this PR

Adds the Typescript declaration so it works now.

```
deno eval "import './std/node/process.ts'; console.log(process.env)"
```


# `import process from 'process'`

## node

Works in Node.

``` bash
node --input-type=module -e "import process from 'process'; console.log(process.env)"
```

## deno

Support for this was not present in Deno.

``` bash
deno eval "import process from 'https://deno.land/std/node/process.ts'; console.log(process.env)"
```

```
Compile file:///Users/balupton/Projects/active/deno/__$deno$eval.ts
error: TS2613 [ERROR]: Module '"https://deno.land/std/node/process"' has no default export. Did you mean to use 'import { process } from "https://deno.land/std/node/process"' instead?
import process from 'https://deno.land/std/node/process.ts'; console.log(process.env)
       ~~~~~~~
    at file:///Users/balupton/Projects/active/deno/__$deno$eval.ts:1:8
```

## this PR

Adds support for it.

``` bash
deno eval "import process from './std/node/process.ts'; console.log(process.env)"
```



# `import * as process from 'process'`

## node

Works in Node.

``` bash
node --input-type=module -e "import * as process from 'process'; console.log(process.env)"
```

## deno

Support for this was not present in Deno.

``` bash
deno eval "import * as process from 'https://deno.land/std/node/process.ts'; console.log(process.env)"
```

```
Compile file:///Users/balupton/Projects/active/deno/__$deno$eval.ts
error: TS2339 [ERROR]: Property 'env' does not exist on type 'typeof import("https://deno.land/std/node/process")'.
import * as process from 'https://deno.land/std/node/process.ts'; console.log(process.env)
                                                                                      ~~~
    at file:///Users/balupton/Projects/active/deno/__$deno$eval.ts:1:87
```

## this PR

Adds support for it.

``` bash
deno eval "import * as process from './std/node/process.ts'; console.log(process.env)"
```


# `import { env, argv } from 'process'`

## node

Works in Node.

``` bash
node --input-type=module -e "import { env, argv } from 'process'; console.log(env, argv);
```


## deno

Support for this was not present in Deno.

``` bash
deno eval "import { env, argv } as process from 'https://deno.land/std/node/process.ts'; console.log(env, argv)"
```

```
error: Expected Word(from), got Some(Word(as)) at file:///Users/balupton/Projects/active/deno/__$deno$eval.ts:1:21
```

# this PR

Adds support for it uses Promises, which works in both Node and Deno. This was necessary for Deno's permissions.

``` bash
# uses await, which works for both node and deno, so deno's permission requirement is at request not definition
node --input-type=module -e "import { env, argv } from 'process'; (async () => { console.log(await env, await argv); } )()"
deno eval "import { env, argv } from './std/node/process.ts'; console.log(await env, await argv)"
```




# `import { process } from 'process'`

## node

This current Deno functionality was never present in Node, and does not work

``` bash
node --input-type=module -e "import { process } from 'process'; console.log(process.env);"
```

```
file:///Users/balupton/Projects/active/deno/[eval1]:1
import { process } from 'process'; console.log(process.env);
         ^^^^^^^
SyntaxError: The requested module 'process' does not provide an export named 'process'
    at ModuleJob._instantiate (internal/modules/esm/module_job.js:97:21)
    at async ModuleJob.run (internal/modules/esm/module_job.js:135:5)
    at async Loader.eval (internal/modules/esm/loader.js:170:24)
    at async internal/process/execution.js:50:24
```

## deno

```
deno eval "import { process } from './std/node/process.ts'; console.log(process.env)"
```

## this PR

No change.


---

This PR tests all of the above variations, instead of just the `import { process } from 'process'` variation.