### PR TITLE
fix(std/testing) assertArrayContains should work with any array-like

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -269,8 +269,8 @@ export function assertStringContains(
  * If not then thrown.
  */
 export function assertArrayContains(
-  actual: unknown[],
-  expected: unknown[],
+  actual: ArrayLike<unknown>,
+  expected: ArrayLike<unknown>,
   msg?: string
 ): void {
   const missing: unknown[] = [];

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -159,6 +159,10 @@ Deno.test("testingArrayContains", function (): void {
   const fixtureObject = [{ deno: "luv" }, { deno: "Js" }];
   assertArrayContains(fixture, ["deno"]);
   assertArrayContains(fixtureObject, [{ deno: "luv" }]);
+  assertArrayContains(
+    Uint8Array.from([1, 2, 3, 4]),
+    Uint8Array.from([1, 2, 3])
+  );
   assertThrows(
     (): void => assertArrayContains(fixtureObject, [{ deno: "node" }]),
     AssertionError,


### PR DESCRIPTION
Currently `assertArrayContains` only works with real `Array` objects and not `ArrayLike` objects like TypedArrays; but the actual test only requires the subjects to be array-like so this relaxes the type restrictions further.