### PR TITLE
docs: document and add examples of expandGlob

### DIFF
--- a/std/fs/README.md
+++ b/std/fs/README.md
@@ -196,3 +196,28 @@ import {
 writeFileStr("./target.dat", "file content"); // returns a promise
 writeFileStrSync("./target.dat", "file content"); // void
 ```
+
+### expandGlob
+
+Expand the glob string from the specified `root` directory and yield each result
+as a `WalkEntry` object.
+
+```ts
+import { expandGlob } from "https://deno.land/std/fs/mod.ts";
+
+for await (const file of expandGlob("**/*.ts")) {
+  console.log(file);
+}
+```
+
+### expandGlobSync
+
+Synchronous version of `expandGlob()`.
+
+```ts
+import { expandGlobSync } from "https://deno.land/std/fs/mod.ts";
+
+for (const file of expandGlobSync("**/*.ts")) {
+  console.log(file);
+}
+```

--- a/std/fs/expand_glob.ts
+++ b/std/fs/expand_glob.ts
@@ -66,7 +66,7 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
  * Examples:
  *
  *     for await (const file of expandGlob("**\/*.ts")) {
- *       console.log(file.path);
+ *       console.log(file);
  *     }
  */
 export async function* expandGlob(

--- a/std/fs/expand_glob.ts
+++ b/std/fs/expand_glob.ts
@@ -62,6 +62,12 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
 /**
  * Expand the glob string from the specified `root` directory and yield each
  * result as a `WalkEntry` object.
+ *
+ * Examples:
+ *
+ *     for await (const file of expandGlob("**\/*.ts")) {
+ *       console.log(file.path);
+ *     }
  */
 export async function* expandGlob(
   glob: string,
@@ -161,7 +167,15 @@ export async function* expandGlob(
   yield* currentMatches;
 }
 
-/** Synchronous version of `expandGlob()`. */
+/**
+ * Synchronous version of `expandGlob()`.
+ *
+ * Examples:
+ *
+ *     for (const file of expandGlobSync("**\/*.ts")) {
+ *       console.log(file);
+ *     }
+ */
 export function* expandGlobSync(
   glob: string,
   {


### PR DESCRIPTION
This PR adds documents and examples of expandGlob(Sync) of the standard modules.

cc @nayeemrmn 
