### PR TITLE
refactor(std/encoding/hex)!: reorder encode & decode arguments

### DIFF
--- a/std/encoding/hex.ts
+++ b/std/encoding/hex.ts
@@ -48,7 +48,7 @@ export function encodedLen(n: number): number {
  * @param dst
  * @param src
  */
-export function encode(dst: Uint8Array, src: Uint8Array): number {
+export function encode(src: Uint8Array, dst: Uint8Array): number {
   const srcLength = encodedLen(src.length);
   if (dst.length !== srcLength) {
     throw new Error("Out of index.");
@@ -67,7 +67,7 @@ export function encode(dst: Uint8Array, src: Uint8Array): number {
  */
 export function encodeToString(src: Uint8Array): string {
   const dest = new Uint8Array(encodedLen(src.length));
-  encode(dest, src);
+  encode(src, dest);
   return new TextDecoder().decode(dest);
 }
 
@@ -82,8 +82,8 @@ export function encodeToString(src: Uint8Array): string {
  * @param src
  */
 export function decode(
-  dst: Uint8Array,
-  src: Uint8Array
+  src: Uint8Array,
+  dst: Uint8Array
 ): [number, Error | void] {
   let i = 0;
   for (; i < Math.floor(src.length / 2); i++) {

--- a/std/encoding/hex_test.ts
+++ b/std/encoding/hex_test.ts
@@ -63,7 +63,7 @@ Deno.test({
       const srcStr = "abc";
       const src = new TextEncoder().encode(srcStr);
       const dest = new Uint8Array(encodedLen(src.length));
-      const int = encode(dest, src);
+      const int = encode(src, dest);
       assertEquals(src, new Uint8Array([97, 98, 99]));
       assertEquals(int, 6);
     }
@@ -74,7 +74,7 @@ Deno.test({
       const dest = new Uint8Array(2); // out of index
       assertThrows(
         (): void => {
-          encode(dest, src);
+          encode(src, dest);
         },
         Error,
         "Out of index."
@@ -84,7 +84,7 @@ Deno.test({
     for (const [enc, dec] of testCases) {
       const dest = new Uint8Array(encodedLen(dec.length));
       const src = new Uint8Array(dec as number[]);
-      const n = encode(dest, src);
+      const n = encode(src, dest);
       assertEquals(dest.length, n);
       assertEquals(new TextDecoder().decode(dest), enc);
     }
@@ -125,7 +125,7 @@ Deno.test({
     for (const [enc, dec] of cases) {
       const dest = new Uint8Array(decodedLen(enc.length));
       const src = new TextEncoder().encode(enc as string);
-      const [, err] = decode(dest, src);
+      const [, err] = decode(src, dest);
       assertEquals(err, undefined);
       assertEquals(Array.from(dest), Array.from(dec as number[]));
     }
@@ -148,7 +148,7 @@ Deno.test({
   fn(): void {
     for (const [input, output, expectedErr] of errCases) {
       const out = new Uint8Array((input as string).length + 10);
-      const [n, err] = decode(out, new TextEncoder().encode(input as string));
+      const [n, err] = decode(new TextEncoder().encode(input as string), out);
       assertEquals(
         new TextDecoder("ascii").decode(out.slice(0, n)),
         output as string


### PR DESCRIPTION
BREAKING CHANGE: refactor `std/encoding/hex` to match other methods with `src` & `dst` as arguments

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
