### PR TITLE
Fix(cli/web) Fully support URLSearchParam as Body

### DIFF
--- a/cli/js/web/body.ts
+++ b/cli/js/web/body.ts
@@ -25,6 +25,8 @@ function validateBodyType(owner: Body, bodySource: BodyInit | null): boolean {
     return true;
   } else if (bodySource instanceof FormData) {
     return true;
+  } else if (bodySource instanceof URLSearchParams) {
+    return true;
   } else if (!bodySource) {
     return true; // null body is fine
   }
@@ -193,7 +195,10 @@ export class Body implements domTypes.Body {
       );
     } else if (this._bodySource instanceof ReadableStreamImpl) {
       return bufferFromStream(this._bodySource.getReader());
-    } else if (this._bodySource instanceof FormData) {
+    } else if (
+      this._bodySource instanceof FormData ||
+      this._bodySource instanceof URLSearchParams
+    ) {
       const enc = new TextEncoder();
       return Promise.resolve(
         enc.encode(this._bodySource.toString()).buffer as ArrayBuffer

--- a/cli/tests/unit/body_test.ts
+++ b/cli/tests/unit/body_test.ts
@@ -72,3 +72,10 @@ unitTest(
     assertEquals(formData.get("field_2")!.toString(), "<Deno>");
   }
 );
+
+unitTest({ perms: {} }, async function bodyURLSearchParams(): Promise<void> {
+  const body = buildBody(new URLSearchParams({ hello: "world" }));
+
+  const text = await body.text();
+  assertEquals(text, "hello=world");
+});


### PR DESCRIPTION
The following used to fail in Deno despite working in the browser:

```javascript
new Request('http://localhost/', {method: 'POST', body: new URLSearchParams({hello: 'world'})}).text().then(console.log)
```

(#6415)