### PR TITLE
fix(cli/js/web/url): Support UNC paths on Windows

### DIFF
--- a/cli/js/web/url.ts
+++ b/cli/js/web/url.ts
@@ -62,12 +62,15 @@ function parse(url: string, isBase = true): URLParts | undefined {
     parts.password = "";
     [parts.hostname, restUrl] = takePattern(restUrl, /^[/\\]{2}([^/\\?#]*)/);
     parts.port = "";
+    if (build.os == "windows" && parts.hostname == "") {
+      // UNC paths. e.g. "\\\\localhost\\foo\\bar" on Windows should be
+      // representable as `new URL("file:////localhost/foo/bar")` which is
+      // equivalent to: `new URL("file://localhost/foo/bar")`.
+      [parts.hostname, restUrl] = takePattern(restUrl, /^[/\\]{2,}([^/\\?#]*)/);
+    }
   } else if (specialSchemes.includes(parts.protocol)) {
     let restAuthority;
-    [restAuthority, restUrl] = takePattern(
-      restUrl,
-      /^[/\\]{2}[/\\]*([^/\\?#]+)/
-    );
+    [restAuthority, restUrl] = takePattern(restUrl, /^[/\\]{2,}([^/\\?#]+)/);
     if (isBase && restAuthority == "") {
       return undefined;
     }

--- a/cli/tests/unit/url_test.ts
+++ b/cli/tests/unit/url_test.ts
@@ -191,6 +191,21 @@ unitTest(function urlDriveLetter() {
   assertEquals(new URL("http://example.com/C:").href, "http://example.com/C:");
 });
 
+unitTest(function urlUncHostname() {
+  assertEquals(
+    new URL("file:////").href,
+    Deno.build.os == "windows" ? "file:///" : "file:////"
+  );
+  assertEquals(
+    new URL("file:////server").href,
+    Deno.build.os == "windows" ? "file://server/" : "file:////server"
+  );
+  assertEquals(
+    new URL("file:////server/file").href,
+    Deno.build.os == "windows" ? "file://server/file" : "file:////server/file"
+  );
+});
+
 unitTest(function urlHostnameUpperCase() {
   assertEquals(new URL("https://EXAMPLE.COM").href, "https://example.com/");
 });

--- a/std/path/from_file_url_test.ts
+++ b/std/path/from_file_url_test.ts
@@ -1,37 +1,39 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import * as path from "./mod.ts";
+import { posix, win32 } from "./mod.ts";
 import { assertEquals } from "../testing/asserts.ts";
 
 Deno.test("[path] fromFileUrl", function () {
-  assertEquals(
-    path.posix.fromFileUrl(new URL("file:///home/foo")),
-    "/home/foo"
-  );
-  assertEquals(path.posix.fromFileUrl("file:///home/foo"), "/home/foo");
-  assertEquals(path.posix.fromFileUrl("https://example.com/foo"), "/foo");
-  assertEquals(path.posix.fromFileUrl("file:///"), "/");
+  assertEquals(posix.fromFileUrl(new URL("file:///home/foo")), "/home/foo");
+  assertEquals(posix.fromFileUrl("file:///home/foo"), "/home/foo");
+  assertEquals(posix.fromFileUrl("https://example.com/foo"), "/foo");
+  assertEquals(posix.fromFileUrl("file:///"), "/");
+  // FIXME(nayeemrmn): Remove the condition. UNC paths are supported here when
+  // run on Windows (matching the underlying URL class), but
+  // `posix.fromFileUrl()` should not support them under any circumstance.
+  if (Deno.build.os != "windows") {
+    assertEquals(posix.fromFileUrl("file:////"), "//");
+    assertEquals(posix.fromFileUrl("file:////server"), "//server");
+    assertEquals(posix.fromFileUrl("file:////server/file"), "//server/file");
+  }
 });
 
 Deno.test("[path] fromFileUrl (win32)", function () {
-  assertEquals(
-    path.win32.fromFileUrl(new URL("file:///home/foo")),
-    "\\home\\foo"
-  );
-  assertEquals(path.win32.fromFileUrl("file:///home/foo"), "\\home\\foo");
-  assertEquals(path.win32.fromFileUrl("https://example.com/foo"), "\\foo");
-  assertEquals(path.win32.fromFileUrl("file:///"), "\\");
-  // FIXME(nayeemrmn): Support UNC paths. Needs support in the underlying URL
-  // built-in like Chrome has.
-  // assertEquals(path.win32.fromFileUrl("file:////"), "\\");
-  // assertEquals(path.win32.fromFileUrl("file:////server"), "\\");
-  // assertEquals(path.win32.fromFileUrl("file:////server/file"), "\\file");
-  assertEquals(path.win32.fromFileUrl("file:///c"), "\\c");
-  assertEquals(path.win32.fromFileUrl("file:///c:"), "c:\\");
-  assertEquals(path.win32.fromFileUrl("file:///c:/"), "c:\\");
-  assertEquals(path.win32.fromFileUrl("file:///C:/"), "C:\\");
-  assertEquals(path.win32.fromFileUrl("file:///C:/Users/"), "C:\\Users\\");
-  assertEquals(
-    path.win32.fromFileUrl("file:///C:cwd/another"),
-    "\\C:cwd\\another"
-  );
+  assertEquals(win32.fromFileUrl(new URL("file:///home/foo")), "\\home\\foo");
+  assertEquals(win32.fromFileUrl("file:///home/foo"), "\\home\\foo");
+  assertEquals(win32.fromFileUrl("https://example.com/foo"), "\\foo");
+  assertEquals(win32.fromFileUrl("file:///"), "\\");
+  // FIXME(nayeemrmn): Remove the condition. UNC paths are only supported here
+  // when run on Windows (matching the underlying URL class), but
+  // `win32.fromFileUrl()` should support them under every circumstance.
+  if (Deno.build.os == "windows") {
+    assertEquals(win32.fromFileUrl("file:////"), "\\");
+    assertEquals(win32.fromFileUrl("file:////server"), "\\");
+    assertEquals(win32.fromFileUrl("file:////server/file"), "\\file");
+  }
+  assertEquals(win32.fromFileUrl("file:///c"), "\\c");
+  assertEquals(win32.fromFileUrl("file:///c:"), "c:\\");
+  assertEquals(win32.fromFileUrl("file:///c:/"), "c:\\");
+  assertEquals(win32.fromFileUrl("file:///C:/"), "C:\\");
+  assertEquals(win32.fromFileUrl("file:///C:/Users/"), "C:\\Users\\");
+  assertEquals(win32.fromFileUrl("file:///C:cwd/another"), "\\C:cwd\\another");
 });


### PR DESCRIPTION
Chrome on Windows:

<kbd>![image](https://user-images.githubusercontent.com/29990554/85333593-bff6ab80-b4d1-11ea-9129-e332cb6cc48e.png)</kbd>