### PR TITLE
feat(unstable): add Deno.fstatSync and fstat

### DIFF
--- a/cli/js/deno_unstable.ts
+++ b/cli/js/deno_unstable.ts
@@ -4,6 +4,7 @@
 
 export { umask } from "./ops/fs/umask.ts";
 export { linkSync, link } from "./ops/fs/link.ts";
+export { fstatSync, fstat } from "./ops/fs/stat.ts";
 export { fsyncSync, fsync } from "./ops/fs/sync.ts";
 export { symlinkSync, symlink } from "./ops/fs/symlink.ts";
 export { loadavg, osRelease, hostname } from "./ops/os.ts";

--- a/cli/js/lib.deno.unstable.d.ts
+++ b/cli/js/lib.deno.unstable.d.ts
@@ -1142,4 +1142,26 @@ declare namespace Deno {
    * ```
    */
   export function fsync(rid: number): Promise<void>;
+
+  /** **UNSTABLE**: New API, yet to be vetted.
+   * Synchronously returns a `Deno.FileInfo` for the given file stream.
+   *
+   * ```ts
+   * const file = Deno.openSync("file.txt", { read: true });
+   * const fileInfo = Deno.fstatSync(file.rid);
+   * assert(fileInfo.isFile);
+   * ```
+   */
+  export function fstatSync(rid: number): FileInfo;
+
+  /** **UNSTABLE**: New API, yet to be vetted.
+   * Returns a `Deno.FileInfo` for the given file stream.
+   *
+   * ```ts
+   * const file = await Deno.open("file.txt", { read: true });
+   * const fileInfo = await Deno.fstat(file.rid);
+   * assert(fileInfo.isFile);
+   * ```
+   */
+  export function fstat(rid: number): Promise<FileInfo>;
 }

--- a/cli/js/ops/fs/stat.ts
+++ b/cli/js/ops/fs/stat.ts
@@ -66,6 +66,14 @@ export function parseFileInfo(response: StatResponse): FileInfo {
   };
 }
 
+export function fstatSync(rid: number): FileInfo {
+  return parseFileInfo(sendSync("op_fstat", { rid }));
+}
+
+export async function fstat(rid: number): Promise<FileInfo> {
+  return parseFileInfo(await sendAsync("op_fstat", { rid }));
+}
+
 export async function lstat(path: string | URL): Promise<FileInfo> {
   path = pathFromURL(path);
   const res = (await sendAsync("op_stat", {

--- a/cli/tests/unit/stat_test.ts
+++ b/cli/tests/unit/stat_test.ts
@@ -6,6 +6,36 @@ import {
   pathToAbsoluteFileUrl,
 } from "./test_util.ts";
 
+unitTest({ perms: { read: true } }, function fstatSyncSuccess(): void {
+  const file = Deno.openSync("README.md");
+  const fileInfo = Deno.fstatSync(file.rid);
+  assert(fileInfo.isFile);
+  assert(!fileInfo.isSymlink);
+  assert(!fileInfo.isDirectory);
+  assert(fileInfo.size);
+  assert(fileInfo.atime);
+  assert(fileInfo.mtime);
+  assert(fileInfo.birthtime);
+
+  Deno.close(file.rid);
+});
+
+unitTest({ perms: { read: true } }, async function fstatSuccess(): Promise<
+  void
+> {
+  const file = await Deno.open("README.md");
+  const fileInfo = await Deno.fstat(file.rid);
+  assert(fileInfo.isFile);
+  assert(!fileInfo.isSymlink);
+  assert(!fileInfo.isDirectory);
+  assert(fileInfo.size);
+  assert(fileInfo.atime);
+  assert(fileInfo.mtime);
+  assert(fileInfo.birthtime);
+
+  Deno.close(file.rid);
+});
+
 unitTest(
   { perms: { read: true, write: true } },
   function statSyncSuccess(): void {


### PR DESCRIPTION
This adds a new op for calling fstat(2) on file streams which is exposed as Deno.fdatasyncSync and Deno.fdatasync.

Note that calling fstat on other types of resources is undefined behaviour; for example; you can fstat a directory on UNIX but not on Windows due to how Deno.open works.