### PR TITLE
docs: WASM -> WebAssembly

### DIFF
--- a/docs/getting_started/webassembly.md
+++ b/docs/getting_started/webassembly.md
@@ -1,6 +1,6 @@
-## WASM support
+## WebAssembly support
 
-Deno can execute [wasm](https://webassembly.org/) binaries.
+Deno can execute [WebAssembly](https://webassembly.org/) binaries.
 
 <!-- prettier-ignore-start -->
 ```js


### PR DESCRIPTION
Just a minor nit, we don't refer to TypeScript as TS in the docs so to be consistent; WebAssembly.