### PR TITLE
Bug fix for format method in asserts module

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -19,10 +19,13 @@ export class AssertionError extends Error {
   }
 }
 
-function format(v: unknown): string {
-  let string = globalThis.Deno ? Deno.inspect(v) : String(v);
-  if (typeof v == "string") {
-    string = `"${string.replace(/(?=["\\])/g, "\\")}"`;
+/**
+ * Format value to string for output to CLI on error.
+ */
+function format(value: unknown): string {
+  const string = globalThis.Deno ? Deno.inspect(value) : String(value);
+  if (typeof value == "string") {
+    return `"${string}"`;
   }
   return string;
 }

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -24,7 +24,7 @@ export class AssertionError extends Error {
  */
 function format(value: unknown): string {
   const string = globalThis.Deno ? Deno.inspect(value) : String(value);
-  if (typeof value == "string") {
+  if (typeof value === "string") {
     return `"${string}"`;
   }
   return string;

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -409,3 +409,24 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "failed with string contains quote",
+  fn(): void {
+    assertThrows(
+      (): void =>
+        assertEquals(
+          'John said, "Hello!" to Dave.',
+          'John said, "Hello" to Dave.'
+        ),
+      AssertionError,
+      [
+        "Values are not equal:",
+        ...createHeader(),
+        removed(`-   "John said, "Hello!" to Dave."`),
+        added(`+   "John said, "Hello" to Dave."`),
+        "",
+      ].join("\n")
+    );
+  },
+});


### PR DESCRIPTION
This PR fixes #5590 

Within the format method of the asserts module the `replace(/(?=["\\])/g, "\\")}` expression is unnecessary due to the use of the template literal. It adds escaping slashes to quote marks within strings and this can generate misleading or confusing CLI output.

Additional Work
- Adds comment to explain purpose of method.
- There is no need to reassign the `string` variable.
- Single letter parameters like `v` are generally regarded as a code smell.
- There's no reason not to use the strict `===` operator on the typeof check.

**Note:** you could remove variable assignment entirely from this method if this statement was abstracted `globalThis.Deno ? Deno.inspect(value) : String(value);`. 