### PR TITLE
feat(core): enable experimental-wasm-bigint

### DIFF
--- a/core/core_isolate.rs
+++ b/core/core_isolate.rs
@@ -165,6 +165,7 @@ pub unsafe fn v8_init() {
     "".to_string(),
     "--no-wasm-async-compilation".to_string(),
     "--harmony-top-level-await".to_string(),
+    "--experimental-wasm-bigint".to_string(),
   ];
   v8::V8::set_flags_from_command_line(argv);
 }


### PR DESCRIPTION
This flips the switch on [js-bigint-integration](https://github.com/WebAssembly/JS-BigInt-integration) which is currently a stage 4 proposal and in the published working draft.