### PR TITLE
fix(std/node): fix readFile types, add encoding types: fix #6450

### DIFF
--- a/std/node/_fs/_fs_appendFile.ts
+++ b/std/node/_fs/_fs_appendFile.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import {
+  Encodings,
   WriteFileOptions,
   isFileOptions,
   CallbackWithError,
@@ -15,13 +16,13 @@ import { fromFileUrl } from "../path.ts";
 export function appendFile(
   pathOrRid: string | number | URL,
   data: string,
-  optionsOrCallback: string | WriteFileOptions | CallbackWithError,
+  optionsOrCallback: Encodings | WriteFileOptions | CallbackWithError,
   callback?: CallbackWithError
 ): void {
   pathOrRid = pathOrRid instanceof URL ? fromFileUrl(pathOrRid) : pathOrRid;
   const callbackFn: CallbackWithError | undefined =
     optionsOrCallback instanceof Function ? optionsOrCallback : callback;
-  const options: string | WriteFileOptions | undefined =
+  const options: Encodings | WriteFileOptions | undefined =
     optionsOrCallback instanceof Function ? undefined : optionsOrCallback;
   if (!callbackFn) {
     throw new Error("No callback function supplied");
@@ -79,7 +80,7 @@ function closeRidIfNecessary(isPathString: boolean, rid: number): void {
 export function appendFileSync(
   pathOrRid: string | number | URL,
   data: string,
-  options?: string | WriteFileOptions
+  options?: Encodings | WriteFileOptions
 ): void {
   let rid = -1;
 
@@ -115,7 +116,7 @@ export function appendFileSync(
 }
 
 function validateEncoding(
-  encodingOption: string | WriteFileOptions | undefined
+  encodingOption: Encodings | WriteFileOptions | undefined
 ): void {
   if (!encodingOption) return;
 

--- a/std/node/_fs/_fs_appendFile_test.ts
+++ b/std/node/_fs/_fs_appendFile_test.ts
@@ -23,6 +23,7 @@ Deno.test({
   fn() {
     assertThrows(
       () => {
+        // @ts-expect-error Type '"made-up-encoding"' is not assignable to type
         appendFile("some/path", "some data", "made-up-encoding", () => {});
       },
       Error,
@@ -33,6 +34,7 @@ Deno.test({
         appendFile(
           "some/path",
           "some data",
+          // @ts-expect-error Type '"made-up-encoding"' is not assignable to type
           { encoding: "made-up-encoding" },
           () => {}
         );
@@ -41,6 +43,7 @@ Deno.test({
       "Only 'utf8' encoding is currently supported"
     );
     assertThrows(
+      // @ts-expect-error Type '"made-up-encoding"' is not assignable to type
       () => appendFileSync("some/path", "some data", "made-up-encoding"),
       Error,
       "Only 'utf8' encoding is currently supported"
@@ -48,6 +51,7 @@ Deno.test({
     assertThrows(
       () =>
         appendFileSync("some/path", "some data", {
+          // @ts-expect-error Type '"made-up-encoding"' is not assignable to type
           encoding: "made-up-encoding",
         }),
       Error,

--- a/std/node/_fs/_fs_common.ts
+++ b/std/node/_fs/_fs_common.ts
@@ -47,8 +47,8 @@ export function isFileOptions(
 }
 
 export function getEncoding(
-  optOrCallback?: FileOptions | WriteFileOptions | Function | string
-): string | null {
+  optOrCallback?: FileOptions | WriteFileOptions | Function | Encodings | null
+): Encodings | null {
   if (!optOrCallback || typeof optOrCallback === "function") {
     return null;
   }
@@ -59,13 +59,15 @@ export function getEncoding(
   return encoding;
 }
 
-export function checkEncoding(encoding: string | null): string | null {
+export function checkEncoding(encoding: Encodings | null): Encodings | null {
   if (!encoding) return null;
   if (encoding === "utf8" || encoding === "utf-8") {
     return "utf8";
   }
-  if (encoding === "buffer") {
-    return "buffer";
+  if (encoding === "binary") {
+    return "binary";
+    // before this was buffer, however buffer is not used in Node
+    // node -e "require('fs').readFile('../world.txt', 'buffer', console.log)"
   }
 
   const notImplementedEncodings = [
@@ -74,7 +76,6 @@ export function checkEncoding(encoding: string | null): string | null {
     "base64",
     "hex",
     "ascii",
-    "binary",
     "ucs2",
   ];
 

--- a/std/node/_fs/_fs_common.ts
+++ b/std/node/_fs/_fs_common.ts
@@ -4,10 +4,31 @@ import { notImplemented } from "../_utils.ts";
 
 export type CallbackWithError = (err?: Error | null) => void;
 
+export type TextEncodings =
+  | "ascii"
+  | "utf8"
+  | "utf-8"
+  | "utf16le"
+  | "ucs2"
+  | "ucs-2"
+  | "base64"
+  | "latin1"
+  | "hex";
+export type BinaryEncodings = "binary";
+export type Encodings = TextEncodings | BinaryEncodings;
+
 export interface FileOptions {
-  encoding?: string;
+  encoding?: Encodings;
   flag?: string;
 }
+
+export type TextOptionsArgument =
+  | TextEncodings
+  | ({ encoding: TextEncodings } & FileOptions);
+export type BinaryOptionsArgument =
+  | BinaryEncodings
+  | ({ encoding: BinaryEncodings } & FileOptions);
+export type FileOptionsArgument = Encodings | FileOptions;
 
 export interface WriteFileOptions extends FileOptions {
   mode?: number;

--- a/std/node/_fs/_fs_readFile.ts
+++ b/std/node/_fs/_fs_readFile.ts
@@ -1,30 +1,58 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { intoCallbackAPIWithIntercept, MaybeEmpty } from "../_utils.ts";
-import { getEncoding, FileOptions } from "./_fs_common.ts";
+import {
+  Encodings,
+  getEncoding,
+  FileOptionsArgument,
+  TextOptionsArgument,
+  BinaryOptionsArgument,
+  TextEncodings,
+  BinaryEncodings,
+} from "./_fs_common.ts";
 import { Buffer } from "../buffer.ts";
 import { fromFileUrl } from "../path.ts";
 
-type ReadFileCallback = (
-  err: MaybeEmpty<Error>,
-  data: MaybeEmpty<string | Buffer>
-) => void;
-
+function maybeDecode(data: Uint8Array, encoding: TextEncodings): string;
 function maybeDecode(
   data: Uint8Array,
-  encoding: string | null
+  encoding: BinaryEncodings | null
+): Buffer;
+function maybeDecode(
+  data: Uint8Array,
+  encoding: Encodings | null
 ): string | Buffer {
   const buffer = new Buffer(data.buffer, data.byteOffset, data.byteLength);
-  if (encoding) return buffer.toString(encoding);
+  if (encoding && encoding !== "binary") return buffer.toString(encoding);
   return buffer;
 }
 
+type TextCallback = (err: Error | null, data?: string) => void;
+type BinaryCallback = (err: Error | null, data?: Buffer) => void;
+type GenericCallback = (err: Error | null, data?: string | Buffer) => void;
+type Callback = TextCallback | BinaryCallback | GenericCallback;
+
 export function readFile(
   path: string | URL,
-  optOrCallback: ReadFileCallback | FileOptions | string | undefined,
-  callback?: ReadFileCallback
+  options: TextOptionsArgument,
+  callback: TextCallback
+): void;
+export function readFile(
+  path: string | URL,
+  options: BinaryOptionsArgument,
+  callback: BinaryCallback
+): void;
+export function readFile(
+  path: string | URL,
+  options: null | undefined | FileOptionsArgument,
+  callback: BinaryCallback
+): void;
+export function readFile(path: string | URL, callback: BinaryCallback): void;
+export function readFile(
+  path: string | URL,
+  optOrCallback?: FileOptionsArgument | Callback | null | undefined,
+  callback?: Callback
 ): void {
   path = path instanceof URL ? fromFileUrl(path) : path;
-  let cb: ReadFileCallback | undefined;
+  let cb: Callback | undefined;
   if (typeof optOrCallback === "function") {
     cb = optOrCallback;
   } else {
@@ -33,18 +61,39 @@ export function readFile(
 
   const encoding = getEncoding(optOrCallback);
 
-  intoCallbackAPIWithIntercept<Uint8Array, string | Buffer>(
-    Deno.readFile,
-    (data: Uint8Array): string | Buffer => maybeDecode(data, encoding),
-    cb,
-    path
-  );
+  const p = Deno.readFile(path);
+
+  if (cb) {
+    p.then((data: Uint8Array) => {
+      if (encoding && encoding !== "binary") {
+        const text = maybeDecode(data, encoding);
+        return (cb as TextCallback)(null, text);
+      }
+      const buffer = maybeDecode(data, encoding);
+      (cb as BinaryCallback)(null, buffer);
+    }).catch((err) => cb && cb(err));
+  }
 }
 
 export function readFileSync(
   path: string | URL,
-  opt?: FileOptions | string
+  opt: TextOptionsArgument
+): string;
+export function readFileSync(
+  path: string | URL,
+  opt?: BinaryOptionsArgument
+): Buffer;
+export function readFileSync(
+  path: string | URL,
+  opt?: FileOptionsArgument
 ): string | Buffer {
   path = path instanceof URL ? fromFileUrl(path) : path;
-  return maybeDecode(Deno.readFileSync(path), getEncoding(opt));
+  const data = Deno.readFileSync(path);
+  const encoding = getEncoding(opt);
+  if (encoding && encoding !== "binary") {
+    const text = maybeDecode(data, encoding);
+    return text;
+  }
+  const buffer = maybeDecode(data, encoding);
+  return buffer;
 }

--- a/std/node/_fs/_fs_writeFile.ts
+++ b/std/node/_fs/_fs_writeFile.ts
@@ -3,6 +3,7 @@ import { notImplemented } from "../_utils.ts";
 import { fromFileUrl } from "../path.ts";
 
 import {
+  Encodings,
   WriteFileOptions,
   CallbackWithError,
   isFileOptions,
@@ -14,12 +15,12 @@ import {
 export function writeFile(
   pathOrRid: string | number | URL,
   data: string | Uint8Array,
-  optOrCallback: string | CallbackWithError | WriteFileOptions | undefined,
+  optOrCallback: Encodings | CallbackWithError | WriteFileOptions | undefined,
   callback?: CallbackWithError
 ): void {
   const callbackFn: CallbackWithError | undefined =
     optOrCallback instanceof Function ? optOrCallback : callback;
-  const options: string | WriteFileOptions | undefined =
+  const options: Encodings | WriteFileOptions | undefined =
     optOrCallback instanceof Function ? undefined : optOrCallback;
 
   if (!callbackFn) {
@@ -71,7 +72,7 @@ export function writeFile(
 export function writeFileSync(
   pathOrRid: string | number | URL,
   data: string | Uint8Array,
-  options?: string | WriteFileOptions
+  options?: Encodings | WriteFileOptions
 ): void {
   pathOrRid = pathOrRid instanceof URL ? fromFileUrl(pathOrRid) : pathOrRid;
 

--- a/std/node/_fs/_fs_writeFile_test.ts
+++ b/std/node/_fs/_fs_writeFile_test.ts
@@ -24,6 +24,7 @@ Deno.test("Callback must be a function error", function fn() {
 Deno.test("Invalid encoding results in error()", function testEncodingErrors() {
   assertThrows(
     () => {
+      // @ts-expect-error Type '"made-up-encoding"' is not assignable to type
       writeFile("some/path", "some data", "made-up-encoding", () => {});
     },
     Error,
@@ -32,6 +33,7 @@ Deno.test("Invalid encoding results in error()", function testEncodingErrors() {
 
   assertThrows(
     () => {
+      // @ts-expect-error Type '"made-up-encoding"' is not assignable to type
       writeFileSync("some/path", "some data", "made-up-encoding");
     },
     Error,
@@ -44,6 +46,7 @@ Deno.test("Invalid encoding results in error()", function testEncodingErrors() {
         "some/path",
         "some data",
         {
+          // @ts-expect-error Type '"made-up-encoding"' is not assignable to type
           encoding: "made-up-encoding",
         },
         () => {}
@@ -56,6 +59,7 @@ Deno.test("Invalid encoding results in error()", function testEncodingErrors() {
   assertThrows(
     () => {
       writeFileSync("some/path", "some data", {
+        // @ts-expect-error Type '"made-up-encoding"' is not assignable to type
         encoding: "made-up-encoding",
       });
     },

--- a/std/node/_fs/promises/_fs_readFile.ts
+++ b/std/node/_fs/promises/_fs_readFile.ts
@@ -1,16 +1,28 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { FileOptions } from "../_fs_common.ts";
-import { MaybeEmpty } from "../../_utils.ts";
-
+import {
+  FileOptionsArgument,
+  BinaryOptionsArgument,
+  TextOptionsArgument,
+} from "../_fs_common.ts";
 import { readFile as readFileCallback } from "../_fs_readFile.ts";
 
 export function readFile(
   path: string | URL,
-  options?: FileOptions | string
-): Promise<MaybeEmpty<string | Uint8Array>> {
+  options: TextOptionsArgument
+): Promise<string>;
+export function readFile(
+  path: string | URL,
+  options?: BinaryOptionsArgument
+): Promise<Uint8Array>;
+export function readFile(
+  path: string | URL,
+  options?: FileOptionsArgument
+): Promise<string | Uint8Array> {
   return new Promise((resolve, reject) => {
     readFileCallback(path, options, (err, data): void => {
       if (err) return reject(err);
+      if (data == null)
+        return reject(new Error("Invalid state: data missing, but no error"));
       resolve(data);
     });
   });

--- a/std/node/_fs/promises/_fs_readFile_test.ts
+++ b/std/node/_fs/promises/_fs_readFile_test.ts
@@ -7,24 +7,38 @@ const testData = path.resolve(
 );
 
 Deno.test("readFileSuccess", async function () {
-  const data = await readFile(testData);
+  const data: Uint8Array = await readFile(testData);
 
   assert(data instanceof Uint8Array);
-  assertEquals(new TextDecoder().decode(data as Uint8Array), "hello world");
+  assertEquals(new TextDecoder().decode(data), "hello world");
 });
 
-Deno.test("readFileEncodeUtf8Success", async function () {
-  const data = await readFile(testData, { encoding: "utf8" });
+Deno.test("readFileBinarySuccess", async function () {
+  const data: Uint8Array = await readFile(testData, "binary");
 
-  assertEquals(typeof data, "string");
-  assertEquals(data as string, "hello world");
+  assert(data instanceof Uint8Array);
+  assertEquals(new TextDecoder().decode(data), "hello world");
 });
 
-Deno.test("readFileEncodingAsString", async function () {
-  const data = await readFile(testData, "utf8");
+Deno.test("readFileBinaryObjectSuccess", async function () {
+  const data: Uint8Array = await readFile(testData, { encoding: "binary" });
+
+  assert(data instanceof Uint8Array);
+  assertEquals(new TextDecoder().decode(data), "hello world");
+});
+
+Deno.test("readFileStringObjectSuccess", async function () {
+  const data: string = await readFile(testData, { encoding: "utf8" });
 
   assertEquals(typeof data, "string");
-  assertEquals(data as string, "hello world");
+  assertEquals(data, "hello world");
+});
+
+Deno.test("readFileStringSuccess", async function () {
+  const data: string = await readFile(testData, "utf8");
+
+  assertEquals(typeof data, "string");
+  assertEquals(data, "hello world");
 });
 
 Deno.test("readFileError", async function () {

--- a/std/node/_fs/promises/_fs_writeFile.ts
+++ b/std/node/_fs/promises/_fs_writeFile.ts
@@ -1,12 +1,12 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { WriteFileOptions } from "../_fs_common.ts";
+import { Encodings, WriteFileOptions } from "../_fs_common.ts";
 
 import { writeFile as writeFileCallback } from "../_fs_writeFile.ts";
 
 export function writeFile(
   pathOrRid: string | number | URL,
   data: string | Uint8Array,
-  options?: string | WriteFileOptions
+  options?: Encodings | WriteFileOptions
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     writeFileCallback(pathOrRid, data, options, (err?: Error | null) => {

--- a/std/node/_fs/promises/_fs_writeFile_test.ts
+++ b/std/node/_fs/promises/_fs_writeFile_test.ts
@@ -12,6 +12,7 @@ const decoder = new TextDecoder("utf-8");
 Deno.test("Invalid encoding results in error()", function testEncodingErrors() {
   assertThrowsAsync(
     async () => {
+      // @ts-expect-error Type '"made-up-encoding"' is not assignable to type
       await writeFile("some/path", "some data", "made-up-encoding");
     },
     Error,
@@ -20,6 +21,7 @@ Deno.test("Invalid encoding results in error()", function testEncodingErrors() {
   assertThrowsAsync(
     async () => {
       await writeFile("some/path", "some data", {
+        // @ts-expect-error Type '"made-up-encoding"' is not assignable to type
         encoding: "made-up-encoding",
       });
     },


### PR DESCRIPTION
This PR corrects the node readFile types. See #6450 for the bug report. It is ready for review and at your discretion merging.

In short:

1. the promised readFile will either reject with an error, or resolve with the data - there will never be a case where they are both `null | undefined`
2. the promise, callback, and sync readFiles will return/resolve a string if a string encoding was provided, or a buffer if a binary encoding (or no encoding) was provided

This PR corrects these issues, and includes new type information for binary and text encodings such that methods can be overloaded accordingly to resolve the correct types depending on the inputs.

There was also another issue, where there was an encoding type `buffer` defined, however that does not exist in Node.js, and I couldn't find any usages of it within Deno either. It seemed it was meant to be `binary` (an encoding that returns a Buffer instance), so I changed it accordingly and added a comment.

# promises.readFile

## node

``` bash
echo 'hello' > ../world.txt
node --input-type=module -e "import { promises as fsPromises } from 'fs'; (async () => { const str = await fsPromises.readFile('../world.txt', 'utf8'); console.log(str) })()"
```

```
hello
```

## deno before

``` bash
echo 'hello' > ../world.txt
deno eval -T "import { promises as fsPromises } from 'https://deno.land/std/node/fs.ts'; const str: string = await fsPromises.readFile('../world.txt', 'utf8'); console.log(str)"
```

```
Compile file:///Users/balupton/Projects/active/deno/__$deno$eval.ts
error: TS2322 [ERROR]: Type 'MaybeEmpty<string | Uint8Array>' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.
    at file:///Users/balupton/Projects/active/deno/__$deno$eval.ts:1:82
```

## deno after

``` bash
echo 'hello' > ../world.txt
deno eval -T "import { promises as fsPromises } from './std/node/fs.ts'; const str: string = await fsPromises.readFile('../world.txt', 'utf8'); console.log(str)"
```

```
Compile file:///Users/balupton/Projects/active/deno/__$deno$eval.ts
hello
```


# readFile

## node

``` bash
echo 'hello' > ../world.txt
node --input-type=module -e "import { readFile } from 'fs'; readFile('../world.txt', 'utf8', (err, str) => console.log(err, str) )"
```

```
null hello
```

## deno before

``` bash
echo 'hello' > ../world.txt
deno eval -T "import { readFile } from 'https://deno.land/std/node/fs.ts'; readFile('../world.txt', 'utf8', (err, str: string) => console.log(err, str) )"
```

```
Compile file:///Users/balupton/Projects/active/deno/__$deno$eval.ts
error: TS2345 [ERROR]: Argument of type '(err: Error | null | undefined, str?: string | undefined) => void' is not assignable to parameter of type 'ReadFileCallback'.
  Types of parameters 'str' and 'data' are incompatible.
    Type 'MaybeEmpty<string | Buffer>' is not assignable to type 'string | undefined'.
      Type 'null' is not assignable to type 'string | undefined'.
import { readFile } from 'https://deno.land/std/node/fs.ts'; readFile('../world.txt', 'utf8', (err, str?: string) => console.log(err, str) )
                                                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    at file:///Users/balupton/Projects/active/deno/__$deno$eval.ts:1:95
```

## deno after

``` bash
echo 'hello' > ../world.txt
deno eval -T "import { readFile } from './std/node/fs.ts'; readFile('../world.txt', 'utf8', (err, str?: string) => console.log(err, str) )"
```

```
Compile file:///Users/balupton/Projects/active/deno/__$deno$eval.ts
null hello
```



# readFileSync

## node

``` bash
echo 'hello' > ../world.txt
node --input-type=module -e "import { readFileSync } from 'fs'; const str = readFileSync('../world.txt', 'utf8'); console.log(str)"
```

```
hello
```

## deno before

``` bash
echo 'hello' > ../world.txt
deno eval -T "import { readFileSync } from 'https://deno.land/std/node/fs.ts'; const str: string = readFileSync('../world.txt', 'utf8'); console.log(str)"
```

```
Compile file:///Users/balupton/Projects/active/deno/__$deno$eval.ts
error: TS2322 [ERROR]: Type 'string | Buffer' is not assignable to type 'string'.
  Type 'Buffer' is not assignable to type 'string'.
import { readFileSync } from 'https://deno.land/std/node/fs.ts'; const str: string = readFileSync('../world.txt', 'utf8'); console.log(str)
                                                                       ~~~
    at file:///Users/balupton/Projects/active/deno/__$deno$eval.ts:1:72
```

## deno after

``` bash
echo 'hello' > ../world.txt
deno eval -T "import { readFileSync } from './std/node/fs.ts'; const str: string = readFileSync('../world.txt', 'utf8'); console.log(str)"
```

```
Compile file:///Users/balupton/Projects/active/deno/__$deno$eval.ts
hello
```


---

Tests have been updated accordingly. Static type checks in the tests capture this.
