### PR TITLE
fix(std/node/process): env, argv exports

### DIFF
--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -102,9 +102,9 @@ Deno.test({
 
 Deno.test({
   name: "process.argv",
-  async fn() {
+  fn() {
     assert(Array.isArray(process.argv));
-    assert(Array.isArray(await argv));
+    assert(Array.isArray(argv));
     assert(
       process.argv[0].match(/[^/\\]*deno[^/\\]*$/),
       "deno included in the file name of argv[0]"
@@ -115,8 +115,8 @@ Deno.test({
 
 Deno.test({
   name: "process.env",
-  async fn() {
+  fn() {
     assertEquals(typeof process.env.PATH, "string");
-    assertEquals(typeof (await env).PATH, "string");
+    assertEquals(typeof env.PATH, "string");
   },
 });


### PR DESCRIPTION
Regrettably, the promise approach still required permissions to be specified at initialisation, rather than at request.

Using a Proxy instance solves this permission issue.

The Proxy instance approach also eliminates the need for the await workaround. Achieving direct compatibility with Node.js.

/ref pr #6392
/ref commit d16337cc9c59732fe81655482e08b72d844472e6


# `import { env, argv } from 'process'`

## node

``` bash
node --input-type=module -e "import { env, argv } from 'process'; console.log(env, argv);
```
## deno before

``` bash
deno eval "import { env, argv } from './std/node/process.ts'; console.log(await env, await argv)"
```

## deno after

``` bash
deno eval "import { env, argv } from './std/node/process.ts'; console.log(env, argv);"
```

