### PR TITLE
feat: add --no-check option

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -453,6 +453,7 @@ fn eval_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 fn info_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   ca_file_arg_parse(flags, matches);
   unstable_arg_parse(flags, matches);
+  no_check_arg_parse(flags, matches);
 
   flags.subcommand = DenoSubcommand::Info {
     file: matches.value_of("file").map(|f| f.to_string()),
@@ -818,6 +819,7 @@ TypeScript compiler cache: Subdirectory containing TS compiler output.",
     )
     .arg(Arg::with_name("file").takes_value(true).required(false))
     .arg(ca_file_arg())
+    .arg(no_check_arg())
     .arg(unstable_arg())
 }
 

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -173,7 +173,7 @@ impl GlobalState {
       if self.flags.no_check {
         self
           .ts_compiler
-          .transpile_module_graph(self.clone(), &out, permissions, module_graph)
+          .transpile_module_graph(self.clone(), permissions, module_graph)
           .await?;
       } else {
         self

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -173,7 +173,7 @@ impl GlobalState {
       if self.flags.no_check {
         self
           .ts_compiler
-          .transpile_module_graph(self.clone(), permissions, module_graph)
+          .transpile(self.clone(), permissions, module_graph)
           .await?;
       } else {
         self

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -170,17 +170,24 @@ impl GlobalState {
     let allow_js = should_allow_js(&module_graph_files);
 
     if should_compile {
-      self
-        .ts_compiler
-        .compile(
-          self.clone(),
-          &out,
-          target_lib,
-          permissions,
-          module_graph,
-          allow_js,
-        )
-        .await?;
+      if self.flags.no_check {
+        self
+          .ts_compiler
+          .transpile_module_graph(self.clone(), &out, permissions, module_graph)
+          .await?;
+      } else {
+        self
+          .ts_compiler
+          .compile(
+            self.clone(),
+            &out,
+            target_lib,
+            permissions,
+            module_graph,
+            allow_js,
+          )
+          .await?;
+      }
     }
 
     if let Some(ref lockfile) = self.lockfile {

--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -4,7 +4,7 @@
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.
 // https://github.com/golang/go/blob/master/LICENSE
 
-import { Reader, Writer, ReaderSync, WriterSync } from "./io.ts";
+import type { Reader, Writer, ReaderSync, WriterSync } from "./io.ts";
 import { assert } from "./util.ts";
 
 // MIN_READ is the minimum ArrayBuffer size passed to a read call by

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -1454,11 +1454,6 @@ function transpile({
   const emitMap: Record<string, EmittedSource> = {};
   let diagnostics: ts.Diagnostic[] = [];
   for (const { sourceCode, fileName } of sourceFiles) {
-    if (fileName.endsWith(".d.ts")) {
-      log("skip transpile", fileName);
-      emitMap[`${fileName}.js`] = { filename: fileName, contents: "" };
-      continue;
-    }
     const {
       outputText,
       sourceMapText,

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -14,10 +14,10 @@
 import "./ts_global.d.ts";
 
 import { bold, cyan, yellow } from "./colors.ts";
-import { CompilerOptions } from "./compiler_options.ts";
-import { Diagnostic, DiagnosticItem } from "./diagnostics.ts";
+import type { CompilerOptions } from "./compiler_options.ts";
+import type { Diagnostic, DiagnosticItem } from "./diagnostics.ts";
 import { fromTypeScriptDiagnostic } from "./diagnostics_util.ts";
-import { TranspileOnlyResult } from "./ops/runtime_compiler.ts";
+import type { TranspileOnlyResult } from "./ops/runtime_compiler.ts";
 import { bootstrapWorkerRuntime } from "./runtime_worker.ts";
 import { assert, log, notImplemented } from "./util.ts";
 import { core } from "./core.ts";

--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -69,7 +69,6 @@ const IGNORED_COMPILER_OPTIONS: readonly string[] = [
   "inlineSourceMap",
   "inlineSources",
   "init",
-  "isolatedModules",
   "listEmittedFiles",
   "listFiles",
   "mapRoot",

--- a/cli/js/compiler_api.ts
+++ b/cli/js/compiler_api.ts
@@ -3,11 +3,11 @@
 // This file contains the runtime APIs which will dispatch work to the internal
 // compiler within Deno.
 
-import { DiagnosticItem } from "./diagnostics.ts";
+import type { DiagnosticItem } from "./diagnostics.ts";
 import * as util from "./util.ts";
 import * as runtimeCompilerOps from "./ops/runtime_compiler.ts";
-import { TranspileOnlyResult } from "./ops/runtime_compiler.ts";
-import { CompilerOptions } from "./compiler_options.ts";
+import type { TranspileOnlyResult } from "./ops/runtime_compiler.ts";
+import type { CompilerOptions } from "./compiler_options.ts";
 
 function checkRelative(specifier: string): string {
   return specifier.match(/^([\.\/\\]|https?:\/{2}|file:\/{2})/)

--- a/cli/js/deno.ts
+++ b/cli/js/deno.ts
@@ -27,16 +27,15 @@ export {
   stderr,
   seek,
   seekSync,
-  OpenOptions,
 } from "./files.ts";
+export type { OpenOptions } from "./files.ts";
 export { read, readSync, write, writeSync } from "./ops/io.ts";
-export { FsEvent, watchFs } from "./ops/fs_events.ts";
+export { watchFs } from "./ops/fs_events.ts";
+export type { FsEvent } from "./ops/fs_events.ts";
 export { internalSymbol as internal } from "./internals.ts";
-export {
-  copy,
-  iter,
-  iterSync,
-  SeekMode,
+export { copy, iter, iterSync } from "./io.ts";
+export { SeekMode } from "./io.ts";
+export type {
   Reader,
   ReaderSync,
   Writer,
@@ -49,30 +48,39 @@ export {
   makeTempDir,
   makeTempFileSync,
   makeTempFile,
-  MakeTempOptions,
 } from "./ops/fs/make_temp.ts";
-export { metrics, Metrics } from "./ops/runtime.ts";
-export { mkdirSync, mkdir, MkdirOptions } from "./ops/fs/mkdir.ts";
-export { connect, listen, Listener, Conn } from "./net.ts";
+export type { MakeTempOptions } from "./ops/fs/make_temp.ts";
+export { metrics } from "./ops/runtime.ts";
+export type { Metrics } from "./ops/runtime.ts";
+export { mkdirSync, mkdir } from "./ops/fs/mkdir.ts";
+export type { MkdirOptions } from "./ops/fs/mkdir.ts";
+export { connect, listen } from "./net.ts";
+export type { Listener, Conn } from "./net.ts";
 export { env, exit, execPath } from "./ops/os.ts";
-export { run, RunOptions, Process, ProcessStatus } from "./process.ts";
-export { DirEntry, readDirSync, readDir } from "./ops/fs/read_dir.ts";
+export { Process, run } from "./process.ts";
+export type { RunOptions, ProcessStatus } from "./process.ts";
+export { readDirSync, readDir } from "./ops/fs/read_dir.ts";
+export type { DirEntry } from "./ops/fs/read_dir.ts";
 export { readFileSync, readFile } from "./read_file.ts";
 export { readTextFileSync, readTextFile } from "./read_text_file.ts";
 export { readLinkSync, readLink } from "./ops/fs/read_link.ts";
 export { realPathSync, realPath } from "./ops/fs/real_path.ts";
-export { removeSync, remove, RemoveOptions } from "./ops/fs/remove.ts";
+export { removeSync, remove } from "./ops/fs/remove.ts";
+export type { RemoveOptions } from "./ops/fs/remove.ts";
 export { renameSync, rename } from "./ops/fs/rename.ts";
 export { resources, close } from "./ops/resources.ts";
-export { FileInfo, statSync, lstatSync, stat, lstat } from "./ops/fs/stat.ts";
+export { statSync, lstatSync, stat, lstat } from "./ops/fs/stat.ts";
+export type { FileInfo } from "./ops/fs/stat.ts";
 export { connectTls, listenTls } from "./tls.ts";
 export { truncateSync, truncate } from "./ops/fs/truncate.ts";
 export { isatty } from "./ops/tty.ts";
 export { version } from "./version.ts";
-export { writeFileSync, writeFile, WriteFileOptions } from "./write_file.ts";
+export { writeFileSync, writeFile } from "./write_file.ts";
+export type { WriteFileOptions } from "./write_file.ts";
 export { writeTextFileSync, writeTextFile } from "./write_text_file.ts";
 export const args: string[] = [];
-export { TestDefinition, test } from "./testing.ts";
+export { test } from "./testing.ts";
+export type { TestDefinition } from "./testing.ts";
 
 // These are internal Deno APIs.  We are marking them as internal so they do not
 // appear in the runtime type library.

--- a/cli/js/deno_unstable.ts
+++ b/cli/js/deno_unstable.ts
@@ -15,20 +15,16 @@ export { signal, signals, Signal, SignalStream } from "./signals.ts";
 export { setRaw } from "./ops/tty.ts";
 export { utimeSync, utime } from "./ops/fs/utime.ts";
 export { ftruncateSync, ftruncate } from "./ops/fs/truncate.ts";
-export { ShutdownMode, shutdown } from "./net.ts";
+export { shutdown, ShutdownMode } from "./net.ts";
 export { listen, listenDatagram, connect } from "./net_unstable.ts";
 export { startTls } from "./tls.ts";
 export { kill } from "./ops/process.ts";
-export {
-  permissions,
-  PermissionName,
-  PermissionState,
-  PermissionStatus,
-  Permissions,
-} from "./permissions.ts";
-export {
+export { permissions, Permissions } from "./permissions.ts";
+export { PermissionStatus } from "./permissions.ts";
+export type { PermissionName, PermissionState } from "./permissions.ts";
+export { DiagnosticCategory } from "./diagnostics.ts";
+export type {
   Diagnostic,
-  DiagnosticCategory,
   DiagnosticItem,
   DiagnosticMessageChain,
 } from "./diagnostics.ts";

--- a/cli/js/files.ts
+++ b/cli/js/files.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import {
+import type {
   Reader,
   Writer,
   Seeker,
@@ -23,7 +23,7 @@ export { OpenOptions } from "./ops/fs/open.ts";
 
 export function openSync(
   path: string | URL,
-  options: OpenOptions = { read: true }
+  options: OpenOptions = { read: true },
 ): File {
   checkOpenOptions(options);
   const rid = opOpenSync(path, options);
@@ -32,7 +32,7 @@ export function openSync(
 
 export async function open(
   path: string | URL,
-  options: OpenOptions = { read: true }
+  options: OpenOptions = { read: true },
 ): Promise<File> {
   checkOpenOptions(options);
   const rid = await opOpen(path, options);
@@ -163,7 +163,7 @@ function checkOpenOptions(options: OpenOptions): void {
 
   if (createOrCreateNewWithoutWriteOrAppend) {
     throw new Error(
-      "'create' or 'createNew' options require 'write' or 'append' option"
+      "'create' or 'createNew' options require 'write' or 'append' option",
     );
   }
 }

--- a/cli/js/files.ts
+++ b/cli/js/files.ts
@@ -23,7 +23,7 @@ export type { OpenOptions } from "./ops/fs/open.ts";
 
 export function openSync(
   path: string | URL,
-  options: OpenOptions = { read: true },
+  options: OpenOptions = { read: true }
 ): File {
   checkOpenOptions(options);
   const rid = opOpenSync(path, options);
@@ -32,7 +32,7 @@ export function openSync(
 
 export async function open(
   path: string | URL,
-  options: OpenOptions = { read: true },
+  options: OpenOptions = { read: true }
 ): Promise<File> {
   checkOpenOptions(options);
   const rid = await opOpen(path, options);
@@ -163,7 +163,7 @@ function checkOpenOptions(options: OpenOptions): void {
 
   if (createOrCreateNewWithoutWriteOrAppend) {
     throw new Error(
-      "'create' or 'createNew' options require 'write' or 'append' option",
+      "'create' or 'createNew' options require 'write' or 'append' option"
     );
   }
 }

--- a/cli/js/files.ts
+++ b/cli/js/files.ts
@@ -19,7 +19,7 @@ import {
   openSync as opOpenSync,
   OpenOptions,
 } from "./ops/fs/open.ts";
-export { OpenOptions } from "./ops/fs/open.ts";
+export type { OpenOptions } from "./ops/fs/open.ts";
 
 export function openSync(
   path: string | URL,

--- a/cli/js/globals.ts
+++ b/cli/js/globals.ts
@@ -7,7 +7,7 @@ import * as abortSignal from "./web/abort_signal.ts";
 import * as blob from "./web/blob.ts";
 import * as consoleTypes from "./web/console.ts";
 import * as csprng from "./ops/get_random_values.ts";
-import * as promiseTypes from "./web/promise.ts";
+import type * as promiseTypes from "./web/promise.ts";
 import * as customEvent from "./web/custom_event.ts";
 import * as domException from "./web/dom_exception.ts";
 import * as domFile from "./web/dom_file.ts";

--- a/cli/js/net.ts
+++ b/cli/js/net.ts
@@ -1,12 +1,13 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { errors } from "./errors.ts";
-import { Reader, Writer, Closer } from "./io.ts";
+import type { Reader, Writer, Closer } from "./io.ts";
 import { read, write } from "./ops/io.ts";
 import { close } from "./ops/resources.ts";
 import * as netOps from "./ops/net.ts";
-import { Addr } from "./ops/net.ts";
-export { ShutdownMode, shutdown, NetAddr, UnixAddr } from "./ops/net.ts";
+import type { Addr } from "./ops/net.ts";
+export type { ShutdownMode, NetAddr, UnixAddr } from "./ops/net.ts";
+export { shutdown } from "./ops/net.ts";
 
 export interface DatagramConn extends AsyncIterable<[Uint8Array, Addr]> {
   receive(p?: Uint8Array): Promise<[Uint8Array, Addr]>;

--- a/cli/js/ops/errors.ts
+++ b/cli/js/ops/errors.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { DiagnosticItem } from "../diagnostics.ts";
+import type { DiagnosticItem } from "../diagnostics.ts";
 import { sendSync } from "./dispatch_json.ts";
 
 export function formatDiagnostics(items: DiagnosticItem[]): string {

--- a/cli/js/ops/fs/seek.ts
+++ b/cli/js/ops/fs/seek.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { sendSync, sendAsync } from "../dispatch_json.ts";
-import { SeekMode } from "../../io.ts";
+import type { SeekMode } from "../../io.ts";
 
 export function seekSync(
   rid: number,

--- a/cli/js/ops/permissions.ts
+++ b/cli/js/ops/permissions.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { sendSync } from "./dispatch_json.ts";
-import { PermissionState } from "../permissions.ts";
+import type { PermissionState } from "../permissions.ts";
 
 interface PermissionRequest {
   name: string;

--- a/cli/js/ops/runtime_compiler.ts
+++ b/cli/js/ops/runtime_compiler.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { sendAsync } from "./dispatch_json.ts";
-import { DiagnosticItem } from "../diagnostics.ts";
+import type { DiagnosticItem } from "../diagnostics.ts";
 
 interface CompileRequest {
   rootName: string;

--- a/cli/js/process.ts
+++ b/cli/js/process.ts
@@ -2,7 +2,7 @@
 
 import { File } from "./files.ts";
 import { close } from "./ops/resources.ts";
-import { Closer, Reader, Writer } from "./io.ts";
+import type { Closer, Reader, Writer } from "./io.ts";
 import { readAll } from "./buffer.ts";
 import { kill, runStatus as runStatusOp, run as runOp } from "./ops/process.ts";
 

--- a/cli/js/web/body.ts
+++ b/cli/js/web/body.ts
@@ -2,7 +2,7 @@
 
 import * as blob from "./blob.ts";
 import * as encoding from "./text_encoding.ts";
-import * as domTypes from "./dom_types.d.ts";
+import type * as domTypes from "./dom_types.d.ts";
 import { ReadableStreamImpl } from "./streams/readable_stream.ts";
 import { isReadableStreamDisturbed } from "./streams/internals.ts";
 import { Buffer } from "../buffer.ts";

--- a/cli/js/web/event.ts
+++ b/cli/js/web/event.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import * as domTypes from "./dom_types.d.ts";
+import type * as domTypes from "./dom_types.d.ts";
 import { defineEnumerableProps, requiredArguments } from "./util.ts";
 import { assert } from "../util.ts";
 

--- a/cli/js/web/event_target.ts
+++ b/cli/js/web/event_target.ts
@@ -6,7 +6,7 @@
 // and impossible logic branches based on what Deno currently supports.
 
 import { DOMExceptionImpl as DOMException } from "./dom_exception.ts";
-import * as domTypes from "./dom_types.d.ts";
+import type * as domTypes from "./dom_types.d.ts";
 import {
   EventImpl as Event,
   EventPath,

--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -2,12 +2,13 @@
 
 import { notImplemented } from "../util.ts";
 import { isTypedArray } from "./util.ts";
-import * as domTypes from "./dom_types.d.ts";
+import type * as domTypes from "./dom_types.d.ts";
 import { TextEncoder } from "./text_encoding.ts";
 import { DenoBlob, bytesSymbol as blobBytesSymbol } from "./blob.ts";
 import { read } from "../ops/io.ts";
 import { close } from "../ops/resources.ts";
-import { fetch as opFetch, FetchResponse } from "../ops/fetch.ts";
+import { fetch as opFetch } from "../ops/fetch.ts";
+import type { FetchResponse } from "../ops/fetch.ts";
 import * as Body from "./body.ts";
 import { getHeaderValueParams } from "./util.ts";
 import { ReadableStreamImpl } from "./streams/readable_stream.ts";

--- a/cli/js/web/request.ts
+++ b/cli/js/web/request.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import * as body from "./body.ts";
-import * as domTypes from "./dom_types.d.ts";
+import type * as domTypes from "./dom_types.d.ts";
 import { ReadableStreamImpl } from "./streams/readable_stream.ts";
 
 function byteUpperCase(s: string): string {

--- a/cli/js/web/streams/internals.ts
+++ b/cli/js/web/streams/internals.ts
@@ -12,7 +12,7 @@ import { ReadableStreamDefaultControllerImpl } from "./readable_stream_default_c
 import { ReadableStreamDefaultReaderImpl } from "./readable_stream_default_reader.ts";
 import { ReadableStreamImpl } from "./readable_stream.ts";
 import * as sym from "./symbols.ts";
-import { TransformStreamImpl } from "./transform_stream.ts";
+import type { TransformStreamImpl } from "./transform_stream.ts";
 import { TransformStreamDefaultControllerImpl } from "./transform_stream_default_controller.ts";
 import { WritableStreamDefaultControllerImpl } from "./writable_stream_default_controller.ts";
 import { WritableStreamDefaultWriterImpl } from "./writable_stream_default_writer.ts";

--- a/cli/js/web/streams/readable_byte_stream_controller.ts
+++ b/cli/js/web/streams/readable_byte_stream_controller.ts
@@ -20,7 +20,7 @@ import {
   readableStreamCreateReadResult,
   setFunctionName,
 } from "./internals.ts";
-import { ReadableStreamImpl } from "./readable_stream.ts";
+import type { ReadableStreamImpl } from "./readable_stream.ts";
 import * as sym from "./symbols.ts";
 import { assert } from "../../util.ts";
 import { customInspect } from "../console.ts";

--- a/cli/js/web/streams/readable_stream.ts
+++ b/cli/js/web/streams/readable_stream.ts
@@ -19,9 +19,9 @@ import {
   setUpReadableStreamDefaultControllerFromUnderlyingSource,
   validateAndNormalizeHighWaterMark,
 } from "./internals.ts";
-import { ReadableByteStreamControllerImpl } from "./readable_byte_stream_controller.ts";
+import type { ReadableByteStreamControllerImpl } from "./readable_byte_stream_controller.ts";
 import { ReadableStreamAsyncIteratorPrototype } from "./readable_stream_async_iterator.ts";
-import { ReadableStreamDefaultControllerImpl } from "./readable_stream_default_controller.ts";
+import type { ReadableStreamDefaultControllerImpl } from "./readable_stream_default_controller.ts";
 import * as sym from "./symbols.ts";
 import { customInspect } from "../console.ts";
 import { AbortSignalImpl } from "../abort_signal.ts";

--- a/cli/js/web/streams/readable_stream_default_controller.ts
+++ b/cli/js/web/streams/readable_stream_default_controller.ts
@@ -20,7 +20,7 @@ import {
   SizeAlgorithm,
   setFunctionName,
 } from "./internals.ts";
-import { ReadableStreamImpl } from "./readable_stream.ts";
+import type { ReadableStreamImpl } from "./readable_stream.ts";
 import * as sym from "./symbols.ts";
 import { customInspect } from "../console.ts";
 

--- a/cli/js/web/streams/readable_stream_default_reader.ts
+++ b/cli/js/web/streams/readable_stream_default_reader.ts
@@ -11,7 +11,7 @@ import {
   readableStreamReaderGenericRelease,
   setFunctionName,
 } from "./internals.ts";
-import { ReadableStreamImpl } from "./readable_stream.ts";
+import type { ReadableStreamImpl } from "./readable_stream.ts";
 import * as sym from "./symbols.ts";
 import { customInspect } from "../console.ts";
 

--- a/cli/js/web/streams/transform_stream.ts
+++ b/cli/js/web/streams/transform_stream.ts
@@ -11,10 +11,10 @@ import {
   setUpTransformStreamDefaultControllerFromTransformer,
   validateAndNormalizeHighWaterMark,
 } from "./internals.ts";
-import { ReadableStreamImpl } from "./readable_stream.ts";
+import type { ReadableStreamImpl } from "./readable_stream.ts";
 import * as sym from "./symbols.ts";
-import { TransformStreamDefaultControllerImpl } from "./transform_stream_default_controller.ts";
-import { WritableStreamImpl } from "./writable_stream.ts";
+import type { TransformStreamDefaultControllerImpl } from "./transform_stream_default_controller.ts";
+import type { WritableStreamImpl } from "./writable_stream.ts";
 import { customInspect, inspect } from "../console.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cli/js/web/streams/transform_stream_default_controller.ts
+++ b/cli/js/web/streams/transform_stream_default_controller.ts
@@ -10,9 +10,9 @@ import {
   transformStreamDefaultControllerError,
   transformStreamDefaultControllerTerminate,
 } from "./internals.ts";
-import { ReadableStreamDefaultControllerImpl } from "./readable_stream_default_controller.ts";
+import type { ReadableStreamDefaultControllerImpl } from "./readable_stream_default_controller.ts";
 import * as sym from "./symbols.ts";
-import { TransformStreamImpl } from "./transform_stream.ts";
+import type { TransformStreamImpl } from "./transform_stream.ts";
 import { customInspect } from "../console.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cli/js/web/streams/writable_stream.ts
+++ b/cli/js/web/streams/writable_stream.ts
@@ -16,8 +16,8 @@ import {
   validateAndNormalizeHighWaterMark,
 } from "./internals.ts";
 import * as sym from "./symbols.ts";
-import { WritableStreamDefaultControllerImpl } from "./writable_stream_default_controller.ts";
-import { WritableStreamDefaultWriterImpl } from "./writable_stream_default_writer.ts";
+import type { WritableStreamDefaultControllerImpl } from "./writable_stream_default_controller.ts";
+import type { WritableStreamDefaultWriterImpl } from "./writable_stream_default_writer.ts";
 import { customInspect } from "../console.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cli/js/web/streams/writable_stream_default_controller.ts
+++ b/cli/js/web/streams/writable_stream_default_controller.ts
@@ -13,7 +13,7 @@ import {
   writableStreamDefaultControllerError,
 } from "./internals.ts";
 import * as sym from "./symbols.ts";
-import { WritableStreamImpl } from "./writable_stream.ts";
+import type { WritableStreamImpl } from "./writable_stream.ts";
 import { customInspect } from "../console.ts";
 
 export class WritableStreamDefaultControllerImpl<W>

--- a/cli/js/web/streams/writable_stream_default_writer.ts
+++ b/cli/js/web/streams/writable_stream_default_writer.ts
@@ -16,7 +16,7 @@ import {
   writableStreamDefaultWriterWrite,
 } from "./internals.ts";
 import * as sym from "./symbols.ts";
-import { WritableStreamImpl } from "./writable_stream.ts";
+import type { WritableStreamImpl } from "./writable_stream.ts";
 import { customInspect } from "../console.ts";
 import { assert } from "../../util.ts";
 

--- a/cli/msg.rs
+++ b/cli/msg.rs
@@ -55,10 +55,11 @@ pub fn enum_name_media_type(mt: MediaType) -> &'static str {
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum CompilerRequestType {
   Compile = 0,
-  Bundle = 1,
-  RuntimeCompile = 2,
-  RuntimeBundle = 3,
-  RuntimeTranspile = 4,
+  Transpile = 1,
+  Bundle = 2,
+  RuntimeCompile = 3,
+  RuntimeBundle = 4,
+  RuntimeTranspile = 5,
 }
 
 impl Serialize for CompilerRequestType {
@@ -68,10 +69,11 @@ impl Serialize for CompilerRequestType {
   {
     let value: i32 = match self {
       CompilerRequestType::Compile => 0 as i32,
-      CompilerRequestType::Bundle => 1 as i32,
-      CompilerRequestType::RuntimeCompile => 2 as i32,
-      CompilerRequestType::RuntimeBundle => 3 as i32,
-      CompilerRequestType::RuntimeTranspile => 4 as i32,
+      CompilerRequestType::Transpile => 1 as i32,
+      CompilerRequestType::Bundle => 2 as i32,
+      CompilerRequestType::RuntimeCompile => 3 as i32,
+      CompilerRequestType::RuntimeBundle => 4 as i32,
+      CompilerRequestType::RuntimeTranspile => 5 as i32,
     };
     Serialize::serialize(&value, serializer)
   }

--- a/cli/tests/error_no_check.ts
+++ b/cli/tests/error_no_check.ts
@@ -1,0 +1,1 @@
+export { AnInterface, isAnInterface } from "./subdir/type_and_code.ts";

--- a/cli/tests/error_no_check.ts.out
+++ b/cli/tests/error_no_check.ts.out
@@ -1,0 +1,1 @@
+error: Uncaught SyntaxError: The requested module './subdir/type_and_code.ts' does not provide an export named 'AnInterface'

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1825,6 +1825,12 @@ itest!(error_025_tab_indent {
   exit_code: 1,
 });
 
+itest!(error_no_check {
+  args: "run --reload --no-check error_no_check.ts",
+  output: "error_no_check.ts.out",
+  exit_code: 1,
+});
+
 itest!(error_syntax {
   args: "run --reload error_syntax.js",
   exit_code: 1,
@@ -1881,6 +1887,12 @@ itest!(import_meta {
 itest!(main_module {
   args: "run --quiet --unstable --allow-read --reload main_module.ts",
   output: "main_module.ts.out",
+});
+
+itest!(no_check {
+  args: "run --quiet --reload --no-check 006_url_imports.ts",
+  output: "006_url_imports.ts.out",
+  http_server: true,
 });
 
 itest!(lib_ref {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -16,6 +16,7 @@ use tempfile::TempDir;
 fn std_tests() {
   let dir = TempDir::new().expect("tempdir fail");
   let std_path = util::root_path().join("std");
+  let std_config = std_path.join("tsconfig_test.json");
   let status = util::deno_cmd()
     .env("DENO_DIR", dir.path())
     .current_dir(std_path) // TODO(ry) change this to root_path
@@ -23,6 +24,8 @@ fn std_tests() {
     .arg("--unstable")
     .arg("--seed=86") // Some tests rely on specific random numbers.
     .arg("-A")
+    .arg("--config")
+    .arg(std_config.to_str().unwrap())
     // .arg("-Ldebug")
     .spawn()
     .unwrap()

--- a/cli/tests/subdir/type_and_code.ts
+++ b/cli/tests/subdir/type_and_code.ts
@@ -1,0 +1,7 @@
+export interface AnInterface {
+  a: string;
+}
+
+export function isAnInterface(value: unknown): value is AnInterface {
+  return value && typeof value === "object" && "a" in value;
+}

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -698,8 +698,9 @@ impl TsCompiler {
     let mut source_files: Vec<TranspileSourceFile> = Vec::new();
     for (_, value) in module_graph.iter() {
       let url = Url::parse(&value.url).expect("Filename is not a valid url");
-      if !self.use_disk_cache
-        || !self.has_compiled_source(&global_state.file_fetcher, &url)
+      if !value.url.ends_with(".d.ts")
+        && (!self.use_disk_cache
+          || !self.has_compiled_source(&global_state.file_fetcher, &url))
       {
         source_files.push(TranspileSourceFile {
           source_code: value.source_code.clone(),

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -148,6 +148,10 @@ pub fn compile_bundle(
   let config_json = serde_json::json!({
     "compilerOptions": {
       "declaration": true,
+      // In order to help ensure there are no type directed emits in the code
+      // which interferes with transpiling only, the setting
+      // `"importsNotUsedAsValues"` set to `"error"` will help ensure that items
+      // that are written as `import type` are caught and are treated as errors.
       "importsNotUsedAsValues": "error",
       // Emit the source alongside the sourcemaps within a single file;
       // requires --inlineSourceMap or --sourceMap to be set.

--- a/deno_typescript/lib.rs
+++ b/deno_typescript/lib.rs
@@ -148,6 +148,7 @@ pub fn compile_bundle(
   let config_json = serde_json::json!({
     "compilerOptions": {
       "declaration": true,
+      "importsNotUsedAsValues": "error",
       // Emit the source alongside the sourcemaps within a single file;
       // requires --inlineSourceMap or --sourceMap to be set.
       // "inlineSources": true,

--- a/std/encoding/_yaml/dumper/dumper.ts
+++ b/std/encoding/_yaml/dumper/dumper.ts
@@ -6,7 +6,7 @@
 /* eslint-disable max-len */
 
 import { YAMLError } from "../error.ts";
-import { RepresentFn, StyleVariant, Type } from "../type.ts";
+import type { RepresentFn, StyleVariant, Type } from "../type.ts";
 import * as common from "../utils.ts";
 import { DumperState, DumperStateOptions } from "./dumper_state.ts";
 

--- a/std/encoding/_yaml/dumper/dumper_state.ts
+++ b/std/encoding/_yaml/dumper/dumper_state.ts
@@ -3,10 +3,10 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { Schema, SchemaDefinition } from "../schema.ts";
+import type { Schema, SchemaDefinition } from "../schema.ts";
 import { State } from "../state.ts";
-import { StyleVariant, Type } from "../type.ts";
-import { ArrayObject, Any } from "../utils.ts";
+import type { StyleVariant, Type } from "../type.ts";
+import type { ArrayObject, Any } from "../utils.ts";
 
 const _hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/std/encoding/_yaml/error.ts
+++ b/std/encoding/_yaml/error.ts
@@ -3,7 +3,7 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { Mark } from "./mark.ts";
+import type { Mark } from "./mark.ts";
 
 export class YAMLError extends Error {
   constructor(

--- a/std/encoding/_yaml/loader/loader.ts
+++ b/std/encoding/_yaml/loader/loader.ts
@@ -7,7 +7,7 @@
 
 import { YAMLError } from "../error.ts";
 import { Mark } from "../mark.ts";
-import { Type } from "../type.ts";
+import type { Type } from "../type.ts";
 import * as common from "../utils.ts";
 import { LoaderState, LoaderStateOptions, ResultType } from "./loader_state.ts";
 

--- a/std/encoding/_yaml/loader/loader_state.ts
+++ b/std/encoding/_yaml/loader/loader_state.ts
@@ -3,11 +3,11 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { YAMLError } from "../error.ts";
-import { Schema, SchemaDefinition, TypeMap } from "../schema.ts";
+import type { YAMLError } from "../error.ts";
+import type { Schema, SchemaDefinition, TypeMap } from "../schema.ts";
 import { State } from "../state.ts";
-import { Type } from "../type.ts";
-import { Any, ArrayObject } from "../utils.ts";
+import type { Type } from "../type.ts";
+import type { Any, ArrayObject } from "../utils.ts";
 
 export interface LoaderStateOptions {
   legacy?: boolean;

--- a/std/encoding/_yaml/parse.ts
+++ b/std/encoding/_yaml/parse.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { CbFunction, load, loadAll } from "./loader/loader.ts";
-import { LoaderStateOptions } from "./loader/loader_state.ts";
+import type { LoaderStateOptions } from "./loader/loader_state.ts";
 
 export type ParseOptions = LoaderStateOptions;
 

--- a/std/encoding/_yaml/schema.ts
+++ b/std/encoding/_yaml/schema.ts
@@ -4,8 +4,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { YAMLError } from "./error.ts";
-import { KindType, Type } from "./type.ts";
-import { ArrayObject, Any } from "./utils.ts";
+import type { KindType, Type } from "./type.ts";
+import type { ArrayObject, Any } from "./utils.ts";
 
 function compileList(
   schema: Schema,

--- a/std/encoding/_yaml/state.ts
+++ b/std/encoding/_yaml/state.ts
@@ -3,7 +3,7 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { SchemaDefinition } from "./schema.ts";
+import type { SchemaDefinition } from "./schema.ts";
 import { DEFAULT_SCHEMA } from "./schema/mod.ts";
 
 export abstract class State {

--- a/std/encoding/_yaml/stringify.ts
+++ b/std/encoding/_yaml/stringify.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { dump } from "./dumper/dumper.ts";
-import { DumperStateOptions } from "./dumper/dumper_state.ts";
+import type { DumperStateOptions } from "./dumper/dumper_state.ts";
 
 export type DumpOptions = DumperStateOptions;
 

--- a/std/encoding/_yaml/type.ts
+++ b/std/encoding/_yaml/type.ts
@@ -3,7 +3,7 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { ArrayObject, Any } from "./utils.ts";
+import type { ArrayObject, Any } from "./utils.ts";
 
 export type KindType = "sequence" | "scalar" | "mapping";
 export type StyleVariant = "lowercase" | "uppercase" | "camelcase" | "decimal";

--- a/std/encoding/_yaml/type/binary.ts
+++ b/std/encoding/_yaml/type/binary.ts
@@ -3,7 +3,7 @@
 // https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { Type } from "../type.ts";
-import { Any } from "../utils.ts";
+import type { Any } from "../utils.ts";
 
 // [ 64, 65, 66 ] -> [ padding, CR, LF ]
 const BASE64_MAP =

--- a/std/encoding/_yaml/type/map.ts
+++ b/std/encoding/_yaml/type/map.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { Type } from "../type.ts";
-import { Any } from "../utils.ts";
+import type { Any } from "../utils.ts";
 
 export const map = new Type("tag:yaml.org,2002:map", {
   construct(data): Any {

--- a/std/encoding/_yaml/type/omap.ts
+++ b/std/encoding/_yaml/type/omap.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { Type } from "../type.ts";
-import { Any } from "../utils.ts";
+import type { Any } from "../utils.ts";
 
 const _hasOwnProperty = Object.prototype.hasOwnProperty;
 const _toString = Object.prototype.toString;

--- a/std/encoding/_yaml/type/pairs.ts
+++ b/std/encoding/_yaml/type/pairs.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { Type } from "../type.ts";
-import { Any } from "../utils.ts";
+import type { Any } from "../utils.ts";
 
 const _toString = Object.prototype.toString;
 

--- a/std/encoding/_yaml/type/seq.ts
+++ b/std/encoding/_yaml/type/seq.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { Type } from "../type.ts";
-import { Any } from "../utils.ts";
+import type { Any } from "../utils.ts";
 
 export const seq = new Type("tag:yaml.org,2002:seq", {
   construct(data): Any {

--- a/std/encoding/_yaml/type/set.ts
+++ b/std/encoding/_yaml/type/set.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { Type } from "../type.ts";
-import { Any } from "../utils.ts";
+import type { Any } from "../utils.ts";
 
 const _hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/std/encoding/yaml.ts
+++ b/std/encoding/yaml.ts
@@ -3,13 +3,12 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-export { ParseOptions, parse, parseAll } from "./_yaml/parse.ts";
-export {
-  DumpOptions as StringifyOptions,
-  stringify,
-} from "./_yaml/stringify.ts";
-export { SchemaDefinition } from "./_yaml/schema.ts";
-export { StyleVariant } from "./_yaml/type.ts";
+export type { ParseOptions } from "./_yaml/parse.ts";
+export { parse, parseAll } from "./_yaml/parse.ts";
+export type { DumpOptions as StringifyOptions } from "./_yaml/stringify.ts";
+export { stringify } from "./_yaml/stringify.ts";
+export type { SchemaDefinition } from "./_yaml/schema.ts";
+export type { StyleVariant } from "./_yaml/type.ts";
 export {
   CORE_SCHEMA,
   DEFAULT_SCHEMA,

--- a/std/hash/_wasm/hash.ts
+++ b/std/hash/_wasm/hash.ts
@@ -10,7 +10,7 @@ import init, {
 
 import * as hex from "../../encoding/hex.ts";
 import * as base64 from "../../encoding/base64.ts";
-import { Hasher, Message, OutputFormat } from "../hasher.ts";
+import type { Hasher, Message, OutputFormat } from "../hasher.ts";
 
 await init(source);
 

--- a/std/hash/mod.ts
+++ b/std/hash/mod.ts
@@ -1,9 +1,9 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 import { Hash } from "./_wasm/hash.ts";
-import { Hasher } from "./hasher.ts";
+import type { Hasher } from "./hasher.ts";
 
-export { Hasher } from "./hasher.ts";
+export type { Hasher } from "./hasher.ts";
 export type SupportedAlgorithm =
   | "md2"
   | "md4"

--- a/std/io/ioutil.ts
+++ b/std/io/ioutil.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { BufReader } from "./bufio.ts";
+import type { BufReader } from "./bufio.ts";
 type Reader = Deno.Reader;
 type Writer = Deno.Writer;
 import { assert } from "../_util/assert.ts";

--- a/std/log/handlers.ts
+++ b/std/log/handlers.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { getLevelByName, LevelName, LogLevels } from "./levels.ts";
-import { LogRecord } from "./logger.ts";
+import type { LogRecord } from "./logger.ts";
 import { red, yellow, blue, bold } from "../fmt/colors.ts";
 import { existsSync, exists } from "../fs/exists.ts";
 import { BufWriterSync } from "../io/bufio.ts";

--- a/std/log/logger.ts
+++ b/std/log/logger.ts
@@ -5,7 +5,7 @@ import {
   getLevelName,
   LevelName,
 } from "./levels.ts";
-import { BaseHandler } from "./handlers.ts";
+import type { BaseHandler } from "./handlers.ts";
 
 export interface LogRecordOptions {
   msg: string;

--- a/std/log/mod.ts
+++ b/std/log/mod.ts
@@ -8,7 +8,7 @@ import {
   RotatingFileHandler,
 } from "./handlers.ts";
 import { assert } from "../_util/assert.ts";
-import { LevelName } from "./levels.ts";
+import type { LevelName } from "./levels.ts";
 
 export { LogLevels, LevelName } from "./levels.ts";
 export { Logger } from "./logger.ts";

--- a/std/node/_fs/_fs_access.ts
+++ b/std/node/_fs/_fs_access.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { CallbackWithError } from "./_fs_common.ts";
+import type { CallbackWithError } from "./_fs_common.ts";
 import { notImplemented } from "../_utils.ts";
 
 /** Revist once https://github.com/denoland/deno/issues/4017 lands */

--- a/std/node/_fs/_fs_chmod.ts
+++ b/std/node/_fs/_fs_chmod.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { CallbackWithError } from "./_fs_common.ts";
+import type { CallbackWithError } from "./_fs_common.ts";
 import { fromFileUrl } from "../path.ts";
 
 const allowedModes = /^[0-7]{3}/;

--- a/std/node/_fs/_fs_chown.ts
+++ b/std/node/_fs/_fs_chown.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { CallbackWithError } from "./_fs_common.ts";
+import type { CallbackWithError } from "./_fs_common.ts";
 import { fromFileUrl } from "../path.ts";
 
 /**

--- a/std/node/_fs/_fs_close.ts
+++ b/std/node/_fs/_fs_close.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { CallbackWithError } from "./_fs_common.ts";
+import type { CallbackWithError } from "./_fs_common.ts";
 
 export function close(fd: number, callback: CallbackWithError): void {
   queueMicrotask(() => {

--- a/std/node/_fs/_fs_copy.ts
+++ b/std/node/_fs/_fs_copy.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { CallbackWithError } from "./_fs_common.ts";
+import type { CallbackWithError } from "./_fs_common.ts";
 import { fromFileUrl } from "../path.ts";
 
 export function copyFile(

--- a/std/node/_fs/_fs_dir_test.ts
+++ b/std/node/_fs/_fs_dir_test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals, fail } from "../../testing/asserts.ts";
 import Dir from "./_fs_dir.ts";
-import Dirent from "./_fs_dirent.ts";
+import type Dirent from "./_fs_dirent.ts";
 
 Deno.test({
   name: "Closing current directory with callback is successful",

--- a/std/node/_fs/_fs_link.ts
+++ b/std/node/_fs/_fs_link.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { CallbackWithError } from "./_fs_common.ts";
+import type { CallbackWithError } from "./_fs_common.ts";
 import { fromFileUrl } from "../path.ts";
 
 /**

--- a/std/node/_fs/_fs_mkdir.ts
+++ b/std/node/_fs/_fs_mkdir.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { CallbackWithError } from "./_fs_common.ts";
+import type { CallbackWithError } from "./_fs_common.ts";
 import { fromFileUrl } from "../path.ts";
 
 /**
@@ -31,10 +31,11 @@ export function mkdir(
     if (options.recursive !== undefined) recursive = options.recursive;
     if (options.mode !== undefined) mode = options.mode;
   }
-  if (typeof recursive !== "boolean")
+  if (typeof recursive !== "boolean") {
     throw new Deno.errors.InvalidData(
       "invalid recursive option , must be a boolean"
     );
+  }
   Deno.mkdir(path, { recursive, mode })
     .then(() => {
       if (typeof callback === "function") {
@@ -61,10 +62,11 @@ export function mkdirSync(path: string | URL, options?: MkdirOptions): void {
     if (options.recursive !== undefined) recursive = options.recursive;
     if (options.mode !== undefined) mode = options.mode;
   }
-  if (typeof recursive !== "boolean")
+  if (typeof recursive !== "boolean") {
     throw new Deno.errors.InvalidData(
       "invalid recursive option , must be a boolean"
     );
+  }
 
   Deno.mkdirSync(path, { recursive, mode });
 }

--- a/std/node/_fs/_fs_writeFile_test.ts
+++ b/std/node/_fs/_fs_writeFile_test.ts
@@ -6,7 +6,7 @@ import {
   assertThrows,
 } from "../../testing/asserts.ts";
 import { writeFile, writeFileSync } from "./_fs_writeFile.ts";
-import { TextEncodings } from "./_fs_common.ts";
+import type { TextEncodings } from "./_fs_common.ts";
 import * as path from "../../path/mod.ts";
 
 const testDataDir = path.resolve(path.join("node", "_fs", "testdata"));

--- a/std/node/_fs/promises/_fs_readFile.ts
+++ b/std/node/_fs/promises/_fs_readFile.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import {
+import type {
   FileOptionsArgument,
   BinaryOptionsArgument,
   TextOptionsArgument,
@@ -21,8 +21,9 @@ export function readFile(
   return new Promise((resolve, reject) => {
     readFileCallback(path, options, (err, data): void => {
       if (err) return reject(err);
-      if (data == null)
+      if (data == null) {
         return reject(new Error("Invalid state: data missing, but no error"));
+      }
       resolve(data);
     });
   });

--- a/std/node/_fs/promises/_fs_writeFile.ts
+++ b/std/node/_fs/promises/_fs_writeFile.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { Encodings, WriteFileOptions } from "../_fs_common.ts";
+import type { Encodings, WriteFileOptions } from "../_fs_common.ts";
 
 import { writeFile as writeFileCallback } from "../_fs_writeFile.ts";
 

--- a/std/node/_fs/promises/_fs_writeFile_test.ts
+++ b/std/node/_fs/promises/_fs_writeFile_test.ts
@@ -6,7 +6,7 @@ import {
   assertThrowsAsync,
 } from "../../../testing/asserts.ts";
 import { writeFile } from "./_fs_writeFile.ts";
-import { TextEncodings } from "../_fs_common.ts";
+import type { TextEncodings } from "../_fs_common.ts";
 
 const decoder = new TextDecoder("utf-8");
 

--- a/std/path/_util.ts
+++ b/std/path/_util.ts
@@ -2,7 +2,7 @@
 // Ported from https://github.com/browserify/path-browserify/
 /** This module is browser compatible. */
 
-import { FormatInputPathObject } from "./_interface.ts";
+import type { FormatInputPathObject } from "./_interface.ts";
 import {
   CHAR_UPPERCASE_A,
   CHAR_LOWERCASE_A,

--- a/std/path/posix.ts
+++ b/std/path/posix.ts
@@ -2,7 +2,7 @@
 // Ported from https://github.com/browserify/path-browserify/
 /** This module is browser compatible. */
 
-import { FormatInputPathObject, ParsedPath } from "./_interface.ts";
+import type { FormatInputPathObject, ParsedPath } from "./_interface.ts";
 import { CHAR_DOT, CHAR_FORWARD_SLASH } from "./_constants.ts";
 
 import {

--- a/std/path/win32.ts
+++ b/std/path/win32.ts
@@ -2,7 +2,7 @@
 // Ported from https://github.com/browserify/path-browserify/
 /** This module is browser compatible. */
 
-import { FormatInputPathObject, ParsedPath } from "./_interface.ts";
+import type { FormatInputPathObject, ParsedPath } from "./_interface.ts";
 import {
   CHAR_DOT,
   CHAR_BACKWARD_SLASH,

--- a/std/textproto/mod.ts
+++ b/std/textproto/mod.ts
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import { BufReader } from "../io/bufio.ts";
+import type { BufReader } from "../io/bufio.ts";
 import { concat } from "../bytes/mod.ts";
 import { decode } from "../encoding/utf8.ts";
 

--- a/std/tsconfig_test.json
+++ b/std/tsconfig_test.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "importsNotUsedAsValues": "error"
+  }
+}

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -31,6 +31,10 @@ exec_time_benchmarks = [
      ["run", "--allow-read", "cli/tests/workers_round_robin_bench.ts"], None),
     ("text_decoder", ["run", "cli/tests/text_decoder_perf.js"], None),
     ("text_encoder", ["run", "cli/tests/text_encoder_perf.js"], None),
+    ("check", ["cache", "--reload", "std/examples/chat/server_test.ts"], None),
+    ("no_check",
+     ["cache", "--reload", "--no-check",
+      "std/examples/chat/server_test.ts"], None),
 ]
 
 


### PR DESCRIPTION
Resolves #5436

This PR adds a `--no-check` option to relative subcommands and adds a request to the compiler of transpile, which takes the module graph and transpiles each module.

There are a few things that I think still need to be addressed:

- [x] There aren't any tests yet, wanted to get any debate over functionality out of the way first.
- [ ] ~I have enabled `isolatedModules` in the `compiler.ts`.  This should try to catch things that like `const enum` which would be breaking when using the `--no-check` option, but...~ this subtly breaks lots of things... in `isolatedModules` any module that looks like a script breaks, which means that having to do `export {}` in a module that doesn't have any imports or exports.  Until TypeScript supports some way of asserting a module that doesn't look like a module, we can't really use `isolatedModules`.
- [ ] Code which does `export { AnInterface } from "mod.ts"` breaks under `--no-check` because the compiler doesn't know to erase it, because it doesn't know it is a type only export.  These need to be written as `export type { AnInterface } from "mod.ts"`.  The compiler option `"importsNotUsedAsValues"` being set to `"error"` could help improve the situation, as it would error during a "normal" compile, requiring `export type` to be used instead, but it would also error on `import { AnInterface } from "mod.ts"`.  This would also likely break a lot of existing code.  The net result is that a `--no-check` will produce errors like this: `error: Uncaught SyntaxError: The requested module 'https://deno.land/std@0.58.0/ws/mod.ts' does not provide an export named 'WebSocket'`.  One action that we could do is make that error more informative, like provide the requesting module.  [This commit](https://github.com/oakserver/oak/commit/c911522cb56816dabf80061f8936178d4345b776) is what I needed to do to oak to get it to be supportable under `--no-check`.
- [x] There could be improvements to the module graph sent to the compiler, as we don't have to send all the dependencies like we have to with a type check.  For example, sending JavaScript just doesn't make sense (unless `checkJs` is true which flags we want transpiling) as well as `.d.ts` files shouldn't be sent (currently, they are returned as blank to appease the logic which processes the result of the module graph).

So the release build, running `deno cache -r https://deno.land/x/oak/examples/server.ts` is taking about ~10s versus `deno cache -r --no-cache https://deno.land/x/oak/examples/server.ts` is taking ~5s, including the time to download all the modules.  So that is a pretty dramatic improvement.  Still would be nice to get the ~5s shorter though.