### PR TITLE
refactor(cli/tests/unit) to use assertThrows

### DIFF
--- a/cli/tests/unit/buffer_test.ts
+++ b/cli/tests/unit/buffer_test.ts
@@ -6,7 +6,6 @@
 import {
   assertEquals,
   assert,
-  assertStringContains,
   assertThrows,
   assertThrowsAsync,
   unitTest,
@@ -159,15 +158,13 @@ unitTest(async function bufferTooLargeByteWrites(): Promise<void> {
   const buf = new Deno.Buffer(xBytes.buffer as ArrayBuffer);
   await buf.read(tmp);
 
-  let err;
-  try {
-    buf.grow(growLen);
-  } catch (e) {
-    err = e;
-  }
-
-  assert(err instanceof Error);
-  assertStringContains(err.message, "grown beyond the maximum size");
+  assertThrows(
+    () => {
+      buf.grow(growLen);
+    },
+    Error,
+    "grown beyond the maximum size"
+  );
 });
 
 unitTest(async function bufferLargeByteReads(): Promise<void> {

--- a/cli/tests/unit/chmod_test.ts
+++ b/cli/tests/unit/chmod_test.ts
@@ -1,5 +1,11 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertEquals } from "./test_util.ts";
+import {
+  unitTest,
+  assert,
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync,
+} from "./test_util.ts";
 
 unitTest(
   { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
@@ -70,25 +76,16 @@ unitTest(
 );
 
 unitTest({ perms: { write: true } }, function chmodSyncFailure(): void {
-  let err;
-  try {
+  assertThrows(() => {
     const filename = "/badfile.txt";
     Deno.chmodSync(filename, 0o777);
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.NotFound);
+  }, Deno.errors.NotFound);
 });
 
 unitTest({ perms: { write: false } }, function chmodSyncPerm(): void {
-  let err;
-  try {
+  assertThrows(() => {
     Deno.chmodSync("/somefile.txt", 0o777);
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
@@ -163,25 +160,16 @@ unitTest(
 unitTest({ perms: { write: true } }, async function chmodFailure(): Promise<
   void
 > {
-  let err;
-  try {
+  await assertThrowsAsync(async () => {
     const filename = "/badfile.txt";
     await Deno.chmod(filename, 0o777);
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.NotFound);
+  }, Deno.errors.NotFound);
 });
 
 unitTest({ perms: { write: false } }, async function chmodPerm(): Promise<
   void
 > {
-  let err;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.chmod("/somefile.txt", 0o777);
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });

--- a/cli/tests/unit/copy_file_test.ts
+++ b/cli/tests/unit/copy_file_test.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertEquals } from "./test_util.ts";
+import {
+  unitTest,
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync,
+} from "./test_util.ts";
 
 function readFileString(filename: string | URL): string {
   const dataRead = Deno.readFileSync(filename);
@@ -67,14 +72,9 @@ unitTest(
     const fromFilename = tempDir + "/from.txt";
     const toFilename = tempDir + "/to.txt";
     // We skip initial writing here, from.txt does not exist
-    let err;
-    try {
+    assertThrows(() => {
       Deno.copyFileSync(fromFilename, toFilename);
-    } catch (e) {
-      err = e;
-    }
-    assert(!!err);
-    assert(err instanceof Deno.errors.NotFound);
+    }, Deno.errors.NotFound);
 
     Deno.removeSync(tempDir, { recursive: true });
   }
@@ -83,28 +83,18 @@ unitTest(
 unitTest(
   { perms: { write: true, read: false } },
   function copyFileSyncPerm1(): void {
-    let caughtError = false;
-    try {
+    assertThrows(() => {
       Deno.copyFileSync("/from.txt", "/to.txt");
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.PermissionDenied);
-    }
-    assert(caughtError);
+    }, Deno.errors.PermissionDenied);
   }
 );
 
 unitTest(
   { perms: { write: false, read: true } },
   function copyFileSyncPerm2(): void {
-    let caughtError = false;
-    try {
+    assertThrows(() => {
       Deno.copyFileSync("/from.txt", "/to.txt");
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.PermissionDenied);
-    }
-    assert(caughtError);
+    }, Deno.errors.PermissionDenied);
   }
 );
 
@@ -172,14 +162,9 @@ unitTest(
     const fromFilename = tempDir + "/from.txt";
     const toFilename = tempDir + "/to.txt";
     // We skip initial writing here, from.txt does not exist
-    let err;
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.copyFile(fromFilename, toFilename);
-    } catch (e) {
-      err = e;
-    }
-    assert(!!err);
-    assert(err instanceof Deno.errors.NotFound);
+    }, Deno.errors.NotFound);
 
     Deno.removeSync(tempDir, { recursive: true });
   }
@@ -207,27 +192,17 @@ unitTest(
 unitTest(
   { perms: { read: false, write: true } },
   async function copyFilePerm1(): Promise<void> {
-    let caughtError = false;
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.copyFile("/from.txt", "/to.txt");
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.PermissionDenied);
-    }
-    assert(caughtError);
+    }, Deno.errors.PermissionDenied);
   }
 );
 
 unitTest(
   { perms: { read: true, write: false } },
   async function copyFilePerm2(): Promise<void> {
-    let caughtError = false;
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.copyFile("/from.txt", "/to.txt");
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.PermissionDenied);
-    }
-    assert(caughtError);
+    }, Deno.errors.PermissionDenied);
   }
 );

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -3,35 +3,33 @@ import {
   unitTest,
   assert,
   assertEquals,
-  assertStringContains,
   assertThrows,
+  assertThrowsAsync,
   fail,
 } from "./test_util.ts";
 
 unitTest({ perms: { net: true } }, async function fetchProtocolError(): Promise<
   void
 > {
-  let err;
-  try {
-    await fetch("file:///");
-  } catch (err_) {
-    err = err_;
-  }
-  assert(err instanceof TypeError);
-  assertStringContains(err.message, "not supported");
+  await assertThrowsAsync(
+    async (): Promise<void> => {
+      await fetch("file:///");
+    },
+    TypeError,
+    "not supported"
+  );
 });
 
 unitTest(
   { perms: { net: true } },
   async function fetchConnectionError(): Promise<void> {
-    let err;
-    try {
-      await fetch("http://localhost:4000");
-    } catch (err_) {
-      err = err_;
-    }
-    assert(err instanceof Deno.errors.Http);
-    assertStringContains(err.message, "error trying to connect");
+    await assertThrowsAsync(
+      async (): Promise<void> => {
+        await fetch("http://localhost:4000");
+      },
+      Deno.errors.Http,
+      "error trying to connect"
+    );
   }
 );
 
@@ -44,14 +42,9 @@ unitTest({ perms: { net: true } }, async function fetchJsonSuccess(): Promise<
 });
 
 unitTest(async function fetchPerm(): Promise<void> {
-  let err;
-  try {
+  await assertThrowsAsync(async () => {
     await fetch("http://localhost:4545/cli/tests/fixture.json");
-  } catch (err_) {
-    err = err_;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { net: true } }, async function fetchUrl(): Promise<void> {
@@ -208,13 +201,9 @@ unitTest({ perms: { net: true } }, async function responseClone(): Promise<
 unitTest({ perms: { net: true } }, async function fetchEmptyInvalid(): Promise<
   void
 > {
-  let err;
-  try {
+  await assertThrowsAsync(async () => {
     await fetch("");
-  } catch (err_) {
-    err = err_;
-  }
-  assert(err instanceof URIError);
+  }, URIError);
 });
 
 unitTest(

--- a/cli/tests/unit/fs_events_test.ts
+++ b/cli/tests/unit/fs_events_test.ts
@@ -1,37 +1,28 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert } from "./test_util.ts";
+import { unitTest, assert, assertThrows } from "./test_util.ts";
 
 // TODO(ry) Add more tests to specify format.
 
 unitTest({ perms: { read: false } }, function watchFsPermissions() {
-  let thrown = false;
-  try {
+  assertThrows(() => {
     Deno.watchFs(".");
-  } catch (err) {
-    assert(err instanceof Deno.errors.PermissionDenied);
-    thrown = true;
-  }
-  assert(thrown);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, function watchFsInvalidPath() {
-  let thrown = false;
-  try {
-    Deno.watchFs("non-existant.file");
-  } catch (err) {
-    console.error(err);
-    if (Deno.build.os === "windows") {
-      assert(
-        err.message.includes(
-          "Input watch path is neither a file nor a directory"
-        )
-      );
-    } else {
-      assert(err instanceof Deno.errors.NotFound);
-    }
-    thrown = true;
+  if (Deno.build.os === "windows") {
+    assertThrows(
+      () => {
+        Deno.watchFs("non-existant.file");
+      },
+      Error,
+      "Input watch path is neither a file nor a directory"
+    );
+  } else {
+    assertThrows(() => {
+      Deno.watchFs("non-existant.file");
+    }, Deno.errors.NotFound);
   }
-  assert(thrown);
 });
 
 async function getTwoEvents(

--- a/cli/tests/unit/link_test.ts
+++ b/cli/tests/unit/link_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertEquals } from "./test_util.ts";
+import { unitTest, assert, assertEquals, assertThrows } from "./test_util.ts";
 
 unitTest(
   { perms: { read: true, write: true } },
@@ -50,14 +50,9 @@ unitTest(
     // newname is already created.
     Deno.writeFileSync(newName, new TextEncoder().encode("newName"));
 
-    let err;
-    try {
+    assertThrows(() => {
       Deno.linkSync(oldName, newName);
-    } catch (e) {
-      err = e;
-    }
-    assert(!!err);
-    assert(err instanceof Deno.errors.AlreadyExists);
+    }, Deno.errors.AlreadyExists);
   }
 );
 
@@ -68,42 +63,27 @@ unitTest(
     const oldName = testDir + "/oldname";
     const newName = testDir + "/newname";
 
-    let err;
-    try {
+    assertThrows(() => {
       Deno.linkSync(oldName, newName);
-    } catch (e) {
-      err = e;
-    }
-    assert(!!err);
-    assert(err instanceof Deno.errors.NotFound);
+    }, Deno.errors.NotFound);
   }
 );
 
 unitTest(
   { perms: { read: false, write: true } },
   function linkSyncReadPerm(): void {
-    let err;
-    try {
+    assertThrows(() => {
       Deno.linkSync("oldbaddir", "newbaddir");
-    } catch (e) {
-      err = e;
-    }
-    assert(err instanceof Deno.errors.PermissionDenied);
-    assertEquals(err.name, "PermissionDenied");
+    }, Deno.errors.PermissionDenied);
   }
 );
 
 unitTest(
   { perms: { read: true, write: false } },
   function linkSyncWritePerm(): void {
-    let err;
-    try {
+    assertThrows(() => {
       Deno.linkSync("oldbaddir", "newbaddir");
-    } catch (e) {
-      err = e;
-    }
-    assert(err instanceof Deno.errors.PermissionDenied);
-    assertEquals(err.name, "PermissionDenied");
+    }, Deno.errors.PermissionDenied);
   }
 );
 

--- a/cli/tests/unit/make_temp_test.ts
+++ b/cli/tests/unit/make_temp_test.ts
@@ -1,5 +1,11 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertEquals } from "./test_util.ts";
+import {
+  unitTest,
+  assert,
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync,
+} from "./test_util.ts";
 
 unitTest({ perms: { write: true } }, function makeTempDirSyncSuccess(): void {
   const dir1 = Deno.makeTempDirSync({ prefix: "hello", suffix: "world" });
@@ -17,13 +23,9 @@ unitTest({ perms: { write: true } }, function makeTempDirSyncSuccess(): void {
   assert(dir3.startsWith(dir1));
   assert(/^[\\\/]/.test(dir3.slice(dir1.length)));
   // Check that creating a temp dir inside a nonexisting directory fails.
-  let err;
-  try {
+  assertThrows(() => {
     Deno.makeTempDirSync({ dir: "/baddir" });
-  } catch (err_) {
-    err = err_;
-  }
-  assert(err instanceof Deno.errors.NotFound);
+  }, Deno.errors.NotFound);
 });
 
 unitTest(
@@ -39,14 +41,9 @@ unitTest(
 
 unitTest(function makeTempDirSyncPerm(): void {
   // makeTempDirSync should require write permissions (for now).
-  let err;
-  try {
+  assertThrows(() => {
     Deno.makeTempDirSync({ dir: "/baddir" });
-  } catch (err_) {
-    err = err_;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
@@ -67,13 +64,9 @@ unitTest(
     assert(dir3.startsWith(dir1));
     assert(/^[\\\/]/.test(dir3.slice(dir1.length)));
     // Check that creating a temp dir inside a nonexisting directory fails.
-    let err;
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.makeTempDir({ dir: "/baddir" });
-    } catch (err_) {
-      err = err_;
-    }
-    assert(err instanceof Deno.errors.NotFound);
+    }, Deno.errors.NotFound);
   }
 );
 
@@ -105,13 +98,9 @@ unitTest({ perms: { write: true } }, function makeTempFileSyncSuccess(): void {
   assert(file3.startsWith(dir));
   assert(/^[\\\/]/.test(file3.slice(dir.length)));
   // Check that creating a temp file inside a nonexisting directory fails.
-  let err;
-  try {
+  assertThrows(() => {
     Deno.makeTempFileSync({ dir: "/baddir" });
-  } catch (err_) {
-    err = err_;
-  }
-  assert(err instanceof Deno.errors.NotFound);
+  }, Deno.errors.NotFound);
 });
 
 unitTest(
@@ -127,14 +116,9 @@ unitTest(
 
 unitTest(function makeTempFileSyncPerm(): void {
   // makeTempFileSync should require write permissions (for now).
-  let err;
-  try {
+  assertThrows(() => {
     Deno.makeTempFileSync({ dir: "/baddir" });
-  } catch (err_) {
-    err = err_;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
@@ -156,13 +140,9 @@ unitTest(
     assert(file3.startsWith(dir));
     assert(/^[\\\/]/.test(file3.slice(dir.length)));
     // Check that creating a temp file inside a nonexisting directory fails.
-    let err;
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.makeTempFile({ dir: "/baddir" });
-    } catch (err_) {
-      err = err_;
-    }
-    assert(err instanceof Deno.errors.NotFound);
+    }, Deno.errors.NotFound);
   }
 );
 

--- a/cli/tests/unit/mkdir_test.ts
+++ b/cli/tests/unit/mkdir_test.ts
@@ -1,5 +1,11 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertEquals, assertThrows } from "./test_util.ts";
+import {
+  unitTest,
+  assert,
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync,
+} from "./test_util.ts";
 
 function assertDirectory(path: string, mode?: number): void {
   const info = Deno.lstatSync(path);
@@ -28,14 +34,9 @@ unitTest(
 );
 
 unitTest({ perms: { write: false } }, function mkdirSyncPerm(): void {
-  let err;
-  try {
+  assertThrows(() => {
     Deno.mkdirSync("/baddir");
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
@@ -57,25 +58,17 @@ unitTest(
 );
 
 unitTest({ perms: { write: true } }, function mkdirErrSyncIfExists(): void {
-  let err;
-  try {
+  assertThrows(() => {
     Deno.mkdirSync(".");
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.AlreadyExists);
+  }, Deno.errors.AlreadyExists);
 });
 
 unitTest({ perms: { write: true } }, async function mkdirErrIfExists(): Promise<
   void
 > {
-  let err;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.mkdir(".");
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.AlreadyExists);
+  }, Deno.errors.AlreadyExists);
 });
 
 unitTest(

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -3,6 +3,8 @@ import {
   unitTest,
   assert,
   assertEquals,
+  assertThrows,
+  assertThrowsAsync,
   createResolvable,
   assertNotEquals,
 } from "./test_util.ts";
@@ -71,15 +73,13 @@ unitTest(
     const listener = Deno.listen({ port: 4501 });
     const p = listener.accept();
     listener.close();
-    let err;
-    try {
-      await p;
-    } catch (e) {
-      err = e;
-    }
-    assert(!!err);
-    assert(err instanceof Error);
-    assertEquals(err.message, "Listener has been closed");
+    await assertThrowsAsync(
+      async (): Promise<void> => {
+        await p;
+      },
+      Deno.errors.BadResource,
+      "Listener has been closed"
+    );
   }
 );
 
@@ -93,15 +93,13 @@ unitTest(
     });
     const p = listener.accept();
     listener.close();
-    let err;
-    try {
-      await p;
-    } catch (e) {
-      err = e;
-    }
-    assert(!!err);
-    assert(err instanceof Error);
-    assertEquals(err.message, "Listener has been closed");
+    await assertThrowsAsync(
+      async (): Promise<void> => {
+        await p;
+      },
+      Deno.errors.BadResource,
+      "Listener has been closed"
+    );
   }
 );
 
@@ -458,14 +456,9 @@ unitTest(
     assertEquals(2, buf[1]);
     assertEquals(3, buf[2]);
     // Check write should be closed
-    let err;
-    try {
+    await assertThrowsAsync(async () => {
       await conn.write(new Uint8Array([1, 2, 3]));
-    } catch (e) {
-      err = e;
-    }
-    assert(!!err);
-    assert(err instanceof Deno.errors.BrokenPipe);
+    }, Deno.errors.BrokenPipe);
     closeDeferred.resolve();
     listener.close();
     conn.close();
@@ -488,15 +481,10 @@ unitTest(
     });
     const conn = await Deno.connect(addr);
     conn.closeWrite(); // closing write
-    let err;
-    try {
+    assertThrows(() => {
       // Duplicated close should throw error
       conn.closeWrite();
-    } catch (e) {
-      err = e;
-    }
-    assert(!!err);
-    assert(err instanceof Deno.errors.NotConnected);
+    }, Deno.errors.NotConnected);
     closeDeferred.resolve();
     listener.close();
     conn.close();

--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -28,27 +28,15 @@ unitTest({ perms: { env: true } }, function deleteEnv(): void {
 });
 
 unitTest(function envPermissionDenied1(): void {
-  let err;
-  try {
+  assertThrows(() => {
     Deno.env.toObject();
-  } catch (e) {
-    err = e;
-  }
-  assertNotEquals(err, undefined);
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest(function envPermissionDenied2(): void {
-  let err;
-  try {
+  assertThrows(() => {
     Deno.env.get("PATH");
-  } catch (e) {
-    err = e;
-  }
-  assertNotEquals(err, undefined);
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 // This test verifies that on Windows, environment variables are
@@ -143,15 +131,9 @@ unitTest({ perms: { env: true } }, function loadavgSuccess(): void {
 });
 
 unitTest({ perms: { env: false } }, function loadavgPerm(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.loadavg();
-  } catch (err) {
-    caughtError = true;
-    assert(err instanceof Deno.errors.PermissionDenied);
-    assertEquals(err.name, "PermissionDenied");
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { env: true } }, function hostnameDir(): void {
@@ -159,15 +141,9 @@ unitTest({ perms: { env: true } }, function hostnameDir(): void {
 });
 
 unitTest({ perms: { env: false } }, function hostnamePerm(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.hostname();
-  } catch (err) {
-    caughtError = true;
-    assert(err instanceof Deno.errors.PermissionDenied);
-    assertEquals(err.name, "PermissionDenied");
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { env: true } }, function releaseDir(): void {
@@ -175,13 +151,7 @@ unitTest({ perms: { env: true } }, function releaseDir(): void {
 });
 
 unitTest({ perms: { env: false } }, function releasePerm(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.osRelease();
-  } catch (err) {
-    caughtError = true;
-    assert(err instanceof Deno.errors.PermissionDenied);
-    assertEquals(err.name, "PermissionDenied");
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -3,18 +3,14 @@ import {
   assert,
   assertEquals,
   assertStringContains,
+  assertThrows,
   unitTest,
 } from "./test_util.ts";
 
 unitTest(function runPermissions(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.run({ cmd: ["python", "-c", "print('hello world')"] });
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { run: true } }, async function runSuccess(): Promise<void> {
@@ -325,18 +321,13 @@ unitTest(function signalNumbers(): void {
 });
 
 unitTest(function killPermissions(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     // Unlike the other test cases, we don't have permission to spawn a
     // subprocess we can safely kill. Instead we send SIGCONT to the current
     // process - assuming that Deno does not have a special handler set for it
     // and will just continue even if a signal is erroneously sent.
     Deno.kill(Deno.pid, Deno.Signal.SIGCONT);
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { run: true } }, async function killSuccess(): Promise<void> {
@@ -368,14 +359,9 @@ unitTest({ perms: { run: true } }, function killFailed(): void {
   assert(!p.stdin);
   assert(!p.stdout);
 
-  let err;
-  try {
+  assertThrows(() => {
     Deno.kill(p.pid, 12345);
-  } catch (e) {
-    err = e;
-  }
-  assert(!!err);
-  assert(err instanceof TypeError);
+  }, TypeError);
 
   p.close();
 });

--- a/cli/tests/unit/read_dir_test.ts
+++ b/cli/tests/unit/read_dir_test.ts
@@ -3,6 +3,8 @@ import {
   unitTest,
   assert,
   assertEquals,
+  assertThrows,
+  assertThrowsAsync,
   pathToAbsoluteFileUrl,
 } from "./test_util.ts";
 
@@ -30,42 +32,21 @@ unitTest({ perms: { read: true } }, function readDirSyncWithUrl(): void {
 });
 
 unitTest({ perms: { read: false } }, function readDirSyncPerm(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.readDirSync("tests/");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, function readDirSyncNotDir(): void {
-  let caughtError = false;
-  let src;
-
-  try {
-    src = Deno.readDirSync("cli/tests/fixture.json");
-  } catch (err) {
-    caughtError = true;
-    assert(err instanceof Error);
-  }
-  assert(caughtError);
-  assertEquals(src, undefined);
+  assertThrows(() => {
+    Deno.readDirSync("cli/tests/fixture.json");
+  }, Error);
 });
 
 unitTest({ perms: { read: true } }, function readDirSyncNotFound(): void {
-  let caughtError = false;
-  let src;
-
-  try {
-    src = Deno.readDirSync("bad_dir_name");
-  } catch (err) {
-    caughtError = true;
-    assert(err instanceof Deno.errors.NotFound);
-  }
-  assert(caughtError);
-  assertEquals(src, undefined);
+  assertThrows(() => {
+    Deno.readDirSync("bad_dir_name");
+  }, Deno.errors.NotFound);
 });
 
 unitTest({ perms: { read: true } }, async function readDirSuccess(): Promise<
@@ -93,12 +74,7 @@ unitTest({ perms: { read: true } }, async function readDirWithUrl(): Promise<
 unitTest({ perms: { read: false } }, async function readDirPerm(): Promise<
   void
 > {
-  let caughtError = false;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.readDir("tests/")[Symbol.asyncIterator]().next();
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });

--- a/cli/tests/unit/read_file_test.ts
+++ b/cli/tests/unit/read_file_test.ts
@@ -3,6 +3,8 @@ import {
   unitTest,
   assert,
   assertEquals,
+  assertThrows,
+  assertThrowsAsync,
   pathToAbsoluteFileUrl,
 } from "./test_util.ts";
 
@@ -27,27 +29,15 @@ unitTest({ perms: { read: true } }, function readFileSyncUrl(): void {
 });
 
 unitTest({ perms: { read: false } }, function readFileSyncPerm(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.readFileSync("cli/tests/fixture.json");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, function readFileSyncNotFound(): void {
-  let caughtError = false;
-  let data;
-  try {
-    data = Deno.readFileSync("bad_filename");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.NotFound);
-  }
-  assert(caughtError);
-  assert(data === undefined);
+  assertThrows(() => {
+    Deno.readFileSync("bad_filename");
+  }, Deno.errors.NotFound);
 });
 
 unitTest({ perms: { read: true } }, async function readFileUrl(): Promise<
@@ -77,14 +67,9 @@ unitTest({ perms: { read: true } }, async function readFileSuccess(): Promise<
 unitTest({ perms: { read: false } }, async function readFilePerm(): Promise<
   void
 > {
-  let caughtError = false;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.readFile("cli/tests/fixture.json");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, function readFileSyncLoop(): void {

--- a/cli/tests/unit/read_link_test.ts
+++ b/cli/tests/unit/read_link_test.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertEquals } from "./test_util.ts";
+import {
+  unitTest,
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync,
+} from "./test_util.ts";
 
 unitTest(
   { perms: { write: true, read: true } },
@@ -19,27 +24,15 @@ unitTest(
 );
 
 unitTest({ perms: { read: false } }, function readLinkSyncPerm(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.readLinkSync("/symlink");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, function readLinkSyncNotFound(): void {
-  let caughtError = false;
-  let data;
-  try {
-    data = Deno.readLinkSync("bad_filename");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.NotFound);
-  }
-  assert(caughtError);
-  assertEquals(data, undefined);
+  assertThrows(() => {
+    Deno.readLinkSync("bad_filename");
+  }, Deno.errors.NotFound);
 });
 
 unitTest(
@@ -62,12 +55,7 @@ unitTest(
 unitTest({ perms: { read: false } }, async function readLinkPerm(): Promise<
   void
 > {
-  let caughtError = false;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.readLink("/symlink");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });

--- a/cli/tests/unit/read_text_file_test.ts
+++ b/cli/tests/unit/read_text_file_test.ts
@@ -2,6 +2,8 @@ import {
   unitTest,
   assert,
   assertEquals,
+  assertThrows,
+  assertThrowsAsync,
   pathToAbsoluteFileUrl,
 } from "./test_util.ts";
 
@@ -22,27 +24,15 @@ unitTest({ perms: { read: true } }, function readTextFileSyncByUrl(): void {
 });
 
 unitTest({ perms: { read: false } }, function readTextFileSyncPerm(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.readTextFileSync("cli/tests/fixture.json");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, function readTextFileSyncNotFound(): void {
-  let caughtError = false;
-  let data;
-  try {
-    data = Deno.readTextFileSync("bad_filename");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.NotFound);
-  }
-  assert(caughtError);
-  assert(data === undefined);
+  assertThrows(() => {
+    Deno.readTextFileSync("bad_filename");
+  }, Deno.errors.NotFound);
 });
 
 unitTest(
@@ -69,14 +59,9 @@ unitTest({ perms: { read: true } }, async function readTextFileByUrl(): Promise<
 unitTest({ perms: { read: false } }, async function readTextFilePerm(): Promise<
   void
 > {
-  let caughtError = false;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.readTextFile("cli/tests/fixture.json");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, function readTextFileSyncLoop(): void {

--- a/cli/tests/unit/real_path_test.ts
+++ b/cli/tests/unit/real_path_test.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert } from "./test_util.ts";
+import {
+  unitTest,
+  assert,
+  assertThrows,
+  assertThrowsAsync,
+} from "./test_util.ts";
 
 unitTest({ perms: { read: true } }, function realPathSyncSuccess(): void {
   const incompletePath = "cli/tests/fixture.json";
@@ -30,25 +35,15 @@ unitTest(
 );
 
 unitTest({ perms: { read: false } }, function realPathSyncPerm(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.realPathSync("some_file");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, function realPathSyncNotFound(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.realPathSync("bad_filename");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.NotFound);
-  }
-  assert(caughtError);
+  }, Deno.errors.NotFound);
 });
 
 unitTest({ perms: { read: true } }, async function realPathSuccess(): Promise<
@@ -84,25 +79,15 @@ unitTest(
 unitTest({ perms: { read: false } }, async function realPathPerm(): Promise<
   void
 > {
-  let caughtError = false;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.realPath("some_file");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, async function realPathNotFound(): Promise<
   void
 > {
-  let caughtError = false;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.realPath("bad_filename");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.NotFound);
-  }
-  assert(caughtError);
+  }, Deno.errors.NotFound);
 });

--- a/cli/tests/unit/rename_test.ts
+++ b/cli/tests/unit/rename_test.ts
@@ -43,32 +43,22 @@ unitTest(
 unitTest(
   { perms: { read: false, write: true } },
   function renameSyncReadPerm(): void {
-    let err;
-    try {
+    assertThrows(() => {
       const oldpath = "/oldbaddir";
       const newpath = "/newbaddir";
       Deno.renameSync(oldpath, newpath);
-    } catch (e) {
-      err = e;
-    }
-    assert(err instanceof Deno.errors.PermissionDenied);
-    assertEquals(err.name, "PermissionDenied");
+    }, Deno.errors.PermissionDenied);
   }
 );
 
 unitTest(
   { perms: { read: true, write: false } },
   function renameSyncWritePerm(): void {
-    let err;
-    try {
+    assertThrows(() => {
       const oldpath = "/oldbaddir";
       const newpath = "/newbaddir";
       Deno.renameSync(oldpath, newpath);
-    } catch (e) {
-      err = e;
-    }
-    assert(err instanceof Deno.errors.PermissionDenied);
-    assertEquals(err.name, "PermissionDenied");
+    }, Deno.errors.PermissionDenied);
   }
 );
 

--- a/cli/tests/unit/resources_test.ts
+++ b/cli/tests/unit/resources_test.ts
@@ -1,14 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assertEquals, assert } from "./test_util.ts";
+import { unitTest, assertEquals, assert, assertThrows } from "./test_util.ts";
 
 unitTest(function resourcesCloseBadArgs(): void {
-  let err;
-  try {
+  assertThrows(() => {
     Deno.close((null as unknown) as number);
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.InvalidData);
+  }, Deno.errors.InvalidData);
 });
 
 unitTest(function resourcesStdio(): void {

--- a/cli/tests/unit/stat_test.ts
+++ b/cli/tests/unit/stat_test.ts
@@ -3,6 +3,8 @@ import {
   unitTest,
   assert,
   assertEquals,
+  assertThrows,
+  assertThrowsAsync,
   pathToAbsoluteFileUrl,
 } from "./test_util.ts";
 
@@ -98,29 +100,15 @@ unitTest(
 );
 
 unitTest({ perms: { read: false } }, function statSyncPerm(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.statSync("README.md");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, function statSyncNotFound(): void {
-  let caughtError = false;
-  let badInfo;
-
-  try {
-    badInfo = Deno.statSync("bad_file_name");
-  } catch (err) {
-    caughtError = true;
-    assert(err instanceof Deno.errors.NotFound);
-  }
-
-  assert(caughtError);
-  assertEquals(badInfo, undefined);
+  assertThrows(() => {
+    Deno.statSync("bad_file_name");
+  }, Deno.errors.NotFound);
 });
 
 unitTest({ perms: { read: true } }, function lstatSyncSuccess(): void {
@@ -152,29 +140,15 @@ unitTest({ perms: { read: true } }, function lstatSyncSuccess(): void {
 });
 
 unitTest({ perms: { read: false } }, function lstatSyncPerm(): void {
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.lstatSync("README.md");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, function lstatSyncNotFound(): void {
-  let caughtError = false;
-  let badInfo;
-
-  try {
-    badInfo = Deno.lstatSync("bad_file_name");
-  } catch (err) {
-    caughtError = true;
-    assert(err instanceof Deno.errors.NotFound);
-  }
-
-  assert(caughtError);
-  assertEquals(badInfo, undefined);
+  assertThrows(() => {
+    Deno.lstatSync("bad_file_name");
+  }, Deno.errors.NotFound);
 });
 
 unitTest(
@@ -242,31 +216,19 @@ unitTest(
 );
 
 unitTest({ perms: { read: false } }, async function statPerm(): Promise<void> {
-  let caughtError = false;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.stat("README.md");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, async function statNotFound(): Promise<
   void
 > {
-  let caughtError = false;
-  let badInfo;
-
-  try {
-    badInfo = await Deno.stat("bad_file_name");
-  } catch (err) {
-    caughtError = true;
-    assert(err instanceof Deno.errors.NotFound);
-  }
-
-  assert(caughtError);
-  assertEquals(badInfo, undefined);
+  await assertThrowsAsync(
+    async (): Promise<void> => {
+      await Deno.stat("bad_file_name"), Deno.errors.NotFound;
+    }
+  );
 });
 
 unitTest({ perms: { read: true } }, async function lstatSuccess(): Promise<
@@ -300,31 +262,17 @@ unitTest({ perms: { read: true } }, async function lstatSuccess(): Promise<
 });
 
 unitTest({ perms: { read: false } }, async function lstatPerm(): Promise<void> {
-  let caughtError = false;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.lstat("README.md");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { read: true } }, async function lstatNotFound(): Promise<
   void
 > {
-  let caughtError = false;
-  let badInfo;
-
-  try {
-    badInfo = await Deno.lstat("bad_file_name");
-  } catch (err) {
-    caughtError = true;
-    assert(err instanceof Deno.errors.NotFound);
-  }
-
-  assert(caughtError);
-  assertEquals(badInfo, undefined);
+  await assertThrowsAsync(async () => {
+    await Deno.lstat("bad_file_name");
+  }, Deno.errors.NotFound);
 });
 
 unitTest(

--- a/cli/tests/unit/symlink_test.ts
+++ b/cli/tests/unit/symlink_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertEquals } from "./test_util.ts";
+import { unitTest, assert, assertThrows } from "./test_util.ts";
 
 unitTest(
   { perms: { read: true, write: true } },
@@ -18,14 +18,9 @@ unitTest(
 );
 
 unitTest(function symlinkSyncPerm(): void {
-  let err;
-  try {
+  assertThrows(() => {
     Deno.symlinkSync("oldbaddir", "newbaddir");
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest(

--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertEquals } from "./test_util.ts";
+import { unitTest, assert, assertEquals, assertThrows } from "./test_util.ts";
 
 unitTest(function btoaSuccess(): void {
   const text = "hello world";
@@ -52,14 +52,9 @@ unitTest(function atobThrows2(): void {
 
 unitTest(function btoaFailed(): void {
   const text = "你好";
-  let err;
-  try {
+  assertThrows(() => {
     btoa(text);
-  } catch (e) {
-    err = e;
-  }
-  assert(!!err);
-  assert(err instanceof TypeError);
+  }, TypeError);
 });
 
 unitTest(function textDecoder2(): void {

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -2,6 +2,8 @@
 import {
   assert,
   assertEquals,
+  assertThrows,
+  assertThrowsAsync,
   createResolvable,
   unitTest,
 } from "./test_util.ts";
@@ -12,35 +14,24 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 unitTest(async function connectTLSNoPerm(): Promise<void> {
-  let err;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.connectTls({ hostname: "github.com", port: 443 });
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest(async function connectTLSCertFileNoReadPerm(): Promise<void> {
-  let err;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.connectTls({
       hostname: "github.com",
       port: 443,
       certFile: "cli/tests/tls/RootCA.crt",
     });
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
   { perms: { read: true, net: true } },
   function listenTLSNonExistentCertKeyFiles(): void {
-    let err;
     const options = {
       hostname: "localhost",
       port: 3500,
@@ -48,42 +39,31 @@ unitTest(
       keyFile: "cli/tests/tls/localhost.key",
     };
 
-    try {
+    assertThrows(() => {
       Deno.listenTls({
         ...options,
         certFile: "./non/existent/file",
       });
-    } catch (e) {
-      err = e;
-    }
-    assert(err instanceof Deno.errors.NotFound);
+    }, Deno.errors.NotFound);
 
-    try {
+    assertThrows(() => {
       Deno.listenTls({
         ...options,
         keyFile: "./non/existent/file",
       });
-    } catch (e) {
-      err = e;
-    }
-    assert(err instanceof Deno.errors.NotFound);
+    }, Deno.errors.NotFound);
   }
 );
 
 unitTest({ perms: { net: true } }, function listenTLSNoReadPerm(): void {
-  let err;
-  try {
+  assertThrows(() => {
     Deno.listenTls({
       hostname: "localhost",
       port: 3500,
       certFile: "cli/tests/tls/localhost.crt",
       keyFile: "cli/tests/tls/localhost.key",
     });
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
@@ -91,7 +71,6 @@ unitTest(
     perms: { read: true, write: true, net: true },
   },
   function listenTLSEmptyKeyFile(): void {
-    let err;
     const options = {
       hostname: "localhost",
       port: 3500,
@@ -105,22 +84,18 @@ unitTest(
       mode: 0o666,
     });
 
-    try {
+    assertThrows(() => {
       Deno.listenTls({
         ...options,
         keyFile: keyFilename,
       });
-    } catch (e) {
-      err = e;
-    }
-    assert(err instanceof Error);
+    }, Error);
   }
 );
 
 unitTest(
   { perms: { read: true, write: true, net: true } },
   function listenTLSEmptyCertFile(): void {
-    let err;
     const options = {
       hostname: "localhost",
       port: 3500,
@@ -134,15 +109,12 @@ unitTest(
       mode: 0o666,
     });
 
-    try {
+    assertThrows(() => {
       Deno.listenTls({
         ...options,
         certFile: certFilename,
       });
-    } catch (e) {
-      err = e;
-    }
-    assert(err instanceof Error);
+    }, Error);
   }
 );
 

--- a/cli/tests/unit/truncate_test.ts
+++ b/cli/tests/unit/truncate_test.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assertEquals, assert } from "./test_util.ts";
+import {
+  unitTest,
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync,
+} from "./test_util.ts";
 
 unitTest(
   { perms: { read: true, write: true } },
@@ -76,25 +81,15 @@ unitTest(
 );
 
 unitTest({ perms: { write: false } }, function truncateSyncPerm(): void {
-  let err;
-  try {
+  assertThrows(() => {
     Deno.truncateSync("/test_truncateSyncPermission.txt");
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest({ perms: { write: false } }, async function truncatePerm(): Promise<
   void
 > {
-  let err;
-  try {
+  await assertThrowsAsync(async () => {
     await Deno.truncate("/test_truncatePermission.txt");
-  } catch (e) {
-    err = e;
-  }
-  assert(err instanceof Deno.errors.PermissionDenied);
-  assertEquals(err.name, "PermissionDenied");
+  }, Deno.errors.PermissionDenied);
 });

--- a/cli/tests/unit/utime_test.ts
+++ b/cli/tests/unit/utime_test.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert } from "./test_util.ts";
+import {
+  unitTest,
+  assert,
+  assertThrows,
+  assertThrowsAsync,
+} from "./test_util.ts";
 
 // Allow 10 second difference.
 // Note this might not be enough for FAT (but we are not testing on such fs).
@@ -99,14 +104,9 @@ unitTest(
     const atime = 1000;
     const mtime = 50000;
 
-    let caughtError = false;
-    try {
+    assertThrows(() => {
       Deno.utimeSync("/baddir", atime, mtime);
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.NotFound);
-    }
-    assert(caughtError);
+    }, Deno.errors.NotFound);
   }
 );
 
@@ -116,14 +116,9 @@ unitTest(
     const atime = 1000;
     const mtime = 50000;
 
-    let caughtError = false;
-    try {
+    assertThrows(() => {
       Deno.utimeSync("/some_dir", atime, mtime);
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.PermissionDenied);
-    }
-    assert(caughtError);
+    }, Deno.errors.PermissionDenied);
   }
 );
 
@@ -201,14 +196,9 @@ unitTest(
     const atime = 1000;
     const mtime = 50000;
 
-    let caughtError = false;
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.utime("/baddir", atime, mtime);
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.NotFound);
-    }
-    assert(caughtError);
+    }, Deno.errors.NotFound);
   }
 );
 
@@ -218,13 +208,8 @@ unitTest(
     const atime = 1000;
     const mtime = 50000;
 
-    let caughtError = false;
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.utime("/some_dir", atime, mtime);
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.PermissionDenied);
-    }
-    assert(caughtError);
+    }, Deno.errors.PermissionDenied);
   }
 );

--- a/cli/tests/unit/write_file_test.ts
+++ b/cli/tests/unit/write_file_test.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertEquals } from "./test_util.ts";
+import {
+  unitTest,
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync,
+} from "./test_util.ts";
 
 unitTest(
   { perms: { read: true, write: true } },
@@ -39,14 +44,9 @@ unitTest({ perms: { write: true } }, function writeFileSyncFail(): void {
   const data = enc.encode("Hello");
   const filename = "/baddir/test.txt";
   // The following should fail because /baddir doesn't exist (hopefully).
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.writeFileSync(filename, data);
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.NotFound);
-  }
-  assert(caughtError);
+  }, Deno.errors.NotFound);
 });
 
 unitTest({ perms: { write: false } }, function writeFileSyncPerm(): void {
@@ -54,14 +54,9 @@ unitTest({ perms: { write: false } }, function writeFileSyncPerm(): void {
   const data = enc.encode("Hello");
   const filename = "/baddir/test.txt";
   // The following should fail due to no write permission
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.writeFileSync(filename, data);
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
@@ -85,15 +80,10 @@ unitTest(
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
     const filename = Deno.makeTempDirSync() + "/test.txt";
-    let caughtError = false;
     // if create turned off, the file won't be created
-    try {
+    assertThrows(() => {
       Deno.writeFileSync(filename, data, { create: false });
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.NotFound);
-    }
-    assert(caughtError);
+    }, Deno.errors.NotFound);
 
     // Turn on create, should have no error
     Deno.writeFileSync(filename, data, { create: true });
@@ -170,14 +160,9 @@ unitTest(
     const data = enc.encode("Hello");
     const filename = "/baddir/test.txt";
     // The following should fail because /baddir doesn't exist (hopefully).
-    let caughtError = false;
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.writeFile(filename, data);
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.NotFound);
-    }
-    assert(caughtError);
+    }, Deno.errors.NotFound);
   }
 );
 
@@ -188,14 +173,9 @@ unitTest(
     const data = enc.encode("Hello");
     const filename = "/baddir/test.txt";
     // The following should fail due to no write permission
-    let caughtError = false;
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.writeFile(filename, data);
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.PermissionDenied);
-    }
-    assert(caughtError);
+    }, Deno.errors.PermissionDenied);
   }
 );
 
@@ -220,15 +200,10 @@ unitTest(
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
     const filename = Deno.makeTempDirSync() + "/test.txt";
-    let caughtError = false;
     // if create turned off, the file won't be created
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.writeFile(filename, data, { create: false });
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.NotFound);
-    }
-    assert(caughtError);
+    }, Deno.errors.NotFound);
 
     // Turn on create, should have no error
     await Deno.writeFile(filename, data, { create: true });

--- a/cli/tests/unit/write_text_file_test.ts
+++ b/cli/tests/unit/write_text_file_test.ts
@@ -1,4 +1,9 @@
-import { unitTest, assert, assertEquals } from "./test_util.ts";
+import {
+  unitTest,
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync,
+} from "./test_util.ts";
 
 unitTest(
   { perms: { read: true, write: true } },
@@ -28,27 +33,17 @@ unitTest(
 unitTest({ perms: { write: true } }, function writeTextFileSyncFail(): void {
   const filename = "/baddir/test.txt";
   // The following should fail because /baddir doesn't exist (hopefully).
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.writeTextFileSync(filename, "hello");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.NotFound);
-  }
-  assert(caughtError);
+  }, Deno.errors.NotFound);
 });
 
 unitTest({ perms: { write: false } }, function writeTextFileSyncPerm(): void {
   const filename = "/baddir/test.txt";
   // The following should fail due to no write permission
-  let caughtError = false;
-  try {
+  assertThrows(() => {
     Deno.writeTextFileSync(filename, "Hello");
-  } catch (e) {
-    caughtError = true;
-    assert(e instanceof Deno.errors.PermissionDenied);
-  }
-  assert(caughtError);
+  }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
@@ -81,14 +76,9 @@ unitTest(
   async function writeTextFileNotFound(): Promise<void> {
     const filename = "/baddir/test.txt";
     // The following should fail because /baddir doesn't exist (hopefully).
-    let caughtError = false;
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.writeTextFile(filename, "Hello");
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.NotFound);
-    }
-    assert(caughtError);
+    }, Deno.errors.NotFound);
   }
 );
 
@@ -97,13 +87,8 @@ unitTest(
   async function writeTextFilePerm(): Promise<void> {
     const filename = "/baddir/test.txt";
     // The following should fail due to no write permission
-    let caughtError = false;
-    try {
+    await assertThrowsAsync(async () => {
       await Deno.writeTextFile(filename, "Hello");
-    } catch (e) {
-      caughtError = true;
-      assert(e instanceof Deno.errors.PermissionDenied);
-    }
-    assert(caughtError);
+    }, Deno.errors.PermissionDenied);
   }
 );


### PR DESCRIPTION
Been seeing some odd patterns in the unit tests like asserting that something both throws and doesn't return:

```typescript
  let caughtError = false;
  let src;

  try {
    src = Deno.readDirSync("cli/tests/fixture.json");
  } catch (err) {
    caughtError = true;
    assert(err instanceof Error);
  }
  assert(caughtError);
  assertEquals(src, undefined);
```

And calling throwing functions twice in the same try block
```typescript
let caughtError = false;
try {
  await Deno.open("package.json", { read: true });
  await Deno.open("cli/tests/fixture.json", { read: true });
} catch (e) {
  caughtError = true;
  assert(e instanceof Deno.errors.PermissionDenied);
}
assert(caughtError);
```

This refactors ad-hoc try/catch/assert blocks in the cli unit tests to use assertThrows and assertThrowsAsync instead.