### PR TITLE
doc(std/wasi) add a list of supported syscalls

### DIFF
--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -4,6 +4,54 @@ This module provides an implementation of the WebAssembly System Interface
 
 ## Supported Syscalls
 
+### wasi_snapshot_preview1
+
+- [x] args_get
+- [x] args_sizes_get
+- [x] environ_get
+- [x] environ_sizes_get
+- [x] clock_res_get
+- [x] clock_time_get
+- [ ] fd_advise
+- [ ] fd_allocate
+- [x] fd_close
+- [ ] fd_datasync
+- [x] fd_fdstat_get
+- [ ] fd_fdstat_set_flags
+- [ ] fd_fdstat_set_rights
+- [ ] fd_filestat_get
+- [ ] fd_filestat_set_size
+- [x] fd_filestat_set_times
+- [x] fd_pread
+- [x] fd_prestat_get
+- [x] fd_prestat_dir_name
+- [x] fd_pwrite
+- [x] fd_read
+- [ ] fd_readdir
+- [x] fd_renumber
+- [x] fd_seek
+- [ ] fd_sync
+- [x] fd_tell
+- [x] fd_write
+- [x] path_create_directory
+- [x] path_filestat_get
+- [x] path_filestat_set_times
+- [x] path_link
+- [x] path_open
+- [x] path_readlink
+- [x] path_remove_directory
+- [x] path_rename
+- [x] path_symlink
+- [x] path_unlink_file
+- [x] poll_oneoff
+- [x] proc_exit
+- [ ] proc_raise
+- [ ] sched_yield
+- [x] random_get
+- [ ] sock_recv
+- [ ] sock_send
+- [ ] sock_shutdown
+
 ## Usage
 
 ```typescript


### PR DESCRIPTION
This adds a list of supported syscalls in the same style as std/node's list of supported builtins.