### PR TITLE
Fix readLinkSync and readLink tests to run on Windows

### DIFF
--- a/cli/tests/unit/read_link_test.ts
+++ b/cli/tests/unit/read_link_test.ts
@@ -10,16 +10,14 @@ unitTest(
   { perms: { write: true, read: true } },
   function readLinkSyncSuccess(): void {
     const testDir = Deno.makeTempDirSync();
-    const target = testDir + "/target";
-    const symlink = testDir + "/symln";
+    const target =
+      testDir + (Deno.build.os == "windows" ? "\\target" : "/target");
+    const symlink =
+      testDir + (Deno.build.os == "windows" ? "\\symlink" : "/symlink");
     Deno.mkdirSync(target);
-    // TODO Add test for Windows once symlink is implemented for Windows.
-    // See https://github.com/denoland/deno/issues/815.
-    if (Deno.build.os !== "windows") {
-      Deno.symlinkSync(target, symlink);
-      const targetPath = Deno.readLinkSync(symlink);
-      assertEquals(targetPath, target);
-    }
+    Deno.symlinkSync(target, symlink);
+    const targetPath = Deno.readLinkSync(symlink);
+    assertEquals(targetPath, target);
   }
 );
 
@@ -39,16 +37,14 @@ unitTest(
   { perms: { write: true, read: true } },
   async function readLinkSuccess(): Promise<void> {
     const testDir = Deno.makeTempDirSync();
-    const target = testDir + "/target";
-    const symlink = testDir + "/symln";
+    const target =
+      testDir + (Deno.build.os == "windows" ? "\\target" : "/target");
+    const symlink =
+      testDir + (Deno.build.os == "windows" ? "\\symlink" : "/symlink");
     Deno.mkdirSync(target);
-    // TODO Add test for Windows once symlink is implemented for Windows.
-    // See https://github.com/denoland/deno/issues/815.
-    if (Deno.build.os !== "windows") {
-      Deno.symlinkSync(target, symlink);
-      const targetPath = await Deno.readLink(symlink);
-      assertEquals(targetPath, target);
-    }
+    Deno.symlinkSync(target, symlink);
+    const targetPath = await Deno.readLink(symlink);
+    assertEquals(targetPath, target);
   }
 );
 


### PR DESCRIPTION
The readLink tests were practically ignored on windows via a condition check leaving us with no coverage, this special cases the paths being asserted instead the whole assertion.

This could be cleaner if we had something in test_util to deal with paths but, leaving that for future refactoring I just want to get the test coverage in the CI for now.