### PR TITLE
[BREAKING] refactor (std): Reduce dependencies

### DIFF
--- a/std/bytes/README.md
+++ b/std/bytes/README.md
@@ -77,3 +77,15 @@ import { concat } from "https://deno.land/std/bytes/mod.ts";
 
 concat(new Uint8Array([1, 2]), new Uint8Array([3, 4])); // returns Uint8Array(4) [ 1, 2, 3, 4 ]
 ```
+
+## copyBytes
+
+Copy bytes from one binary array to another.
+
+```typescript
+import { concat } from "https://deno.land/std/bytes/mod.ts";
+
+const dst = new Uint8Array(4);
+const src = Uint8Array.of(1, 2, 3, 4);
+const len = copyBytes(src, dest); // returns len = 4
+```

--- a/std/bytes/mod.ts
+++ b/std/bytes/mod.ts
@@ -1,8 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { copyBytes } from "../io/util.ts";
 
 /** Find first index of binary pattern from a. If not found, then return -1
- * @param source soruce array
+ * @param source source array
  * @param pat pattern to find in source array
  */
 export function findIndex(source: Uint8Array, pat: Uint8Array): number {
@@ -27,7 +26,7 @@ export function findIndex(source: Uint8Array, pat: Uint8Array): number {
 }
 
 /** Find last index of binary pattern from a. If not found, then return -1.
- * @param source soruce array
+ * @param source source array
  * @param pat pattern to find in source array
  */
 export function findLastIndex(source: Uint8Array, pat: Uint8Array): number {
@@ -75,7 +74,7 @@ export function hasPrefix(source: Uint8Array, prefix: Uint8Array): boolean {
 }
 
 /** Check whether binary array ends with suffix.
- * @param source srouce array
+ * @param source source array
  * @param suffix suffix array to check in source
  */
 export function hasSuffix(source: Uint8Array, suffix: Uint8Array): boolean {
@@ -132,10 +131,29 @@ export function concat(origin: Uint8Array, b: Uint8Array): Uint8Array {
   return output;
 }
 
-/** Check srouce array contains pattern array.
- * @param source srouce array
+/** Check source array contains pattern array.
+ * @param source source array
  * @param pat patter array
  */
 export function contains(source: Uint8Array, pat: Uint8Array): boolean {
   return findIndex(source, pat) != -1;
+}
+
+/**
+ * Copy bytes from one Uint8Array to another.  Bytes from `src` which don't fit
+ * into `dst` will not be copied.
+ *
+ * @param src Source byte array
+ * @param dst Destination byte array
+ * @param off Offset into `dst` at which to begin writing values from `src`.
+ * @return number of bytes copied
+ */
+export function copyBytes(src: Uint8Array, dst: Uint8Array, off = 0): number {
+  off = Math.max(0, Math.min(off, dst.byteLength));
+  const dstBytesAvailable = dst.byteLength - off;
+  if (src.byteLength > dstBytesAvailable) {
+    src = src.subarray(0, dstBytesAvailable);
+  }
+  dst.set(src, off);
+  return src.byteLength;
 }

--- a/std/bytes/test.ts
+++ b/std/bytes/test.ts
@@ -9,6 +9,7 @@ import {
   repeat,
   concat,
   contains,
+  copyBytes,
 } from "./mod.ts";
 import { assertEquals, assertThrows, assert } from "../testing/asserts.ts";
 import { encode, decode } from "../encoding/utf8.ts";
@@ -116,4 +117,38 @@ Deno.test("[bytes] contain", () => {
   assert(contains(source, pattern));
 
   assert(contains(new Uint8Array([0, 1, 2, 3]), new Uint8Array([2, 3])));
+});
+
+Deno.test("[io/tuil] copyBytes", function (): void {
+  const dst = new Uint8Array(4);
+
+  dst.fill(0);
+  let src = Uint8Array.of(1, 2);
+  let len = copyBytes(src, dst, 0);
+  assert(len === 2);
+  assertEquals(dst, Uint8Array.of(1, 2, 0, 0));
+
+  dst.fill(0);
+  src = Uint8Array.of(1, 2);
+  len = copyBytes(src, dst, 1);
+  assert(len === 2);
+  assertEquals(dst, Uint8Array.of(0, 1, 2, 0));
+
+  dst.fill(0);
+  src = Uint8Array.of(1, 2, 3, 4, 5);
+  len = copyBytes(src, dst);
+  assert(len === 4);
+  assertEquals(dst, Uint8Array.of(1, 2, 3, 4));
+
+  dst.fill(0);
+  src = Uint8Array.of(1, 2);
+  len = copyBytes(src, dst, 100);
+  assert(len === 0);
+  assertEquals(dst, Uint8Array.of(0, 0, 0, 0));
+
+  dst.fill(0);
+  src = Uint8Array.of(3, 4);
+  len = copyBytes(src, dst, -2);
+  assert(len === 2);
+  assertEquals(dst, Uint8Array.of(3, 4, 0, 0));
 });

--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -6,14 +6,14 @@
 type Reader = Deno.Reader;
 type Writer = Deno.Writer;
 type WriterSync = Deno.WriterSync;
-import { charCode, copyBytes } from "./util.ts";
+import { copyBytes } from "../bytes/mod.ts";
 import { assert } from "../_util/assert.ts";
 
 const DEFAULT_BUF_SIZE = 4096;
 const MIN_BUF_SIZE = 16;
 const MAX_CONSECUTIVE_EMPTY_READS = 100;
-const CR = charCode("\r");
-const LF = charCode("\n");
+const CR = "\r".charCodeAt(0);
+const LF = "\n".charCodeAt(0);
 
 export class BufferFullError extends Error {
   name = "BufferFullError";

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -16,7 +16,8 @@ import {
 import * as iotest from "./_iotest.ts";
 import { StringReader } from "./readers.ts";
 import { StringWriter } from "./writers.ts";
-import { charCode, copyBytes } from "./util.ts";
+import { charCode } from "./util.ts";
+import { copyBytes } from "../bytes/mod.ts";
 
 const encoder = new TextEncoder();
 

--- a/std/io/util.ts
+++ b/std/io/util.ts
@@ -1,25 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import * as path from "../path/mod.ts";
 
-/**
- * Copy bytes from one Uint8Array to another.  Bytes from `src` which don't fit
- * into `dst` will not be copied.
- *
- * @param src Source byte array
- * @param dst Destination byte array
- * @param off Offset into `dst` at which to begin writing values from `src`.
- * @return number of bytes copied
- */
-export function copyBytes(src: Uint8Array, dst: Uint8Array, off = 0): number {
-  off = Math.max(0, Math.min(off, dst.byteLength));
-  const dstBytesAvailable = dst.byteLength - off;
-  if (src.byteLength > dstBytesAvailable) {
-    src = src.subarray(0, dstBytesAvailable);
-  }
-  dst.set(src, off);
-  return src.byteLength;
-}
-
 export function charCode(s: string): number {
   return s.charCodeAt(0);
 }

--- a/std/io/util_test.ts
+++ b/std/io/util_test.ts
@@ -1,41 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals } from "../testing/asserts.ts";
+import { assert } from "../testing/asserts.ts";
 import * as path from "../path/mod.ts";
-import { copyBytes, tempFile } from "./util.ts";
-
-Deno.test("[io/tuil] copyBytes", function (): void {
-  const dst = new Uint8Array(4);
-
-  dst.fill(0);
-  let src = Uint8Array.of(1, 2);
-  let len = copyBytes(src, dst, 0);
-  assert(len === 2);
-  assertEquals(dst, Uint8Array.of(1, 2, 0, 0));
-
-  dst.fill(0);
-  src = Uint8Array.of(1, 2);
-  len = copyBytes(src, dst, 1);
-  assert(len === 2);
-  assertEquals(dst, Uint8Array.of(0, 1, 2, 0));
-
-  dst.fill(0);
-  src = Uint8Array.of(1, 2, 3, 4, 5);
-  len = copyBytes(src, dst);
-  assert(len === 4);
-  assertEquals(dst, Uint8Array.of(1, 2, 3, 4));
-
-  dst.fill(0);
-  src = Uint8Array.of(1, 2);
-  len = copyBytes(src, dst, 100);
-  assert(len === 0);
-  assertEquals(dst, Uint8Array.of(0, 0, 0, 0));
-
-  dst.fill(0);
-  src = Uint8Array.of(3, 4);
-  len = copyBytes(src, dst, -2);
-  assert(len === 2);
-  assertEquals(dst, Uint8Array.of(3, 4, 0, 0));
-});
+import { tempFile } from "./util.ts";
 
 Deno.test({
   name: "[io/util] tempfile",

--- a/std/textproto/mod.ts
+++ b/std/textproto/mod.ts
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 import { BufReader } from "../io/bufio.ts";
-import { charCode } from "../io/util.ts";
 import { concat } from "../bytes/mod.ts";
 import { decode } from "../encoding/utf8.ts";
 
@@ -17,6 +16,10 @@ function str(buf: Uint8Array | null | undefined): string {
   } else {
     return decode(buf);
   }
+}
+
+function charCode(s: string): number {
+  return s.charCodeAt(0);
 }
 
 export class TextProtoReader {


### PR DESCRIPTION
With a few minor tweaks and one breaking change, this PR reduces the number of dependencies across a number of `std` modules.  The breaking change is to move `copyBytes` out of `std/io/util.ts` and into `std/bytes/mod.ts`.  In addition to providing the core solution of removing dependencies here, `std/bytes` seems a more natural home for this function anyway.

Essentially, `std/path/mod.ts` has 20 dependencies(*) and was being indirectly imported without use in a number of modules.  A small amount of code reshuffling in this PR has enabled the dependency on `std/path/mod.ts` to be removed from many modules resulting in a large drop in dependencies for these modules.

Example `deno info std/io/bufio.ts` on master:
```
local: /home/dev/deno/std/io/bufio.ts
type: TypeScript
compiled: /home/dev/.cache/deno/gen/file/home/dev/deno/std/io/bufio.ts.js
map: /home/dev/.cache/deno/gen/file/home/dev/deno/std/io/bufio.ts.js.map
deps:
file:///home/dev/deno/std/io/bufio.ts
  ├─┬ file:///home/dev/deno/std/io/util.ts
  │ └─┬ file:///home/dev/deno/std/path/mod.ts
  │   ├── file:///home/dev/deno/std/path/_constants.ts
  │   ├─┬ file:///home/dev/deno/std/path/win32.ts
  │   │ ├── file:///home/dev/deno/std/path/_constants.ts
  │   │ ├─┬ file:///home/dev/deno/std/path/_util.ts
  │   │ │ └── file:///home/dev/deno/std/path/_constants.ts
  │   │ └── file:///home/dev/deno/std/_util/assert.ts
  │   ├─┬ file:///home/dev/deno/std/path/posix.ts
  │   │ ├── file:///home/dev/deno/std/path/_constants.ts
  │   │ └── file:///home/dev/deno/std/path/_util.ts
  │   ├─┬ file:///home/dev/deno/std/path/common.ts
  │   │ └─┬ file:///home/dev/deno/std/path/separator.ts
  │   │   └── file:///home/dev/deno/std/path/_constants.ts
  │   ├── file:///home/dev/deno/std/path/separator.ts
  │   ├── file:///home/dev/deno/std/path/_interface.ts
  │   └─┬ file:///home/dev/deno/std/path/glob.ts
  │     ├── file:///home/dev/deno/std/path/separator.ts
  │     ├─┬ file:///home/dev/deno/std/path/_globrex.ts
  │     │ └── file:///home/dev/deno/std/path/_constants.ts
  │     ├── file:///home/dev/deno/std/path/mod.ts
  │     └── file:///home/dev/deno/std/_util/assert.ts
  └── file:///home/dev/deno/std/_util/assert.ts
```
Example `deno info std/io/bufio.ts` on this PR:
```
local: /home/dev/deno/std/io/bufio.ts
type: TypeScript
compiled: /home/dev/.cache/deno/gen/file/home/dev/deno/std/io/bufio.ts.js
map: /home/dev/.cache/deno/gen/file/home/dev/deno/std/io/bufio.ts.js.map
deps:
file:///home/dev/deno/std/io/bufio.ts
  ├── file:///home/dev/deno/std/bytes/mod.ts
  └── file:///home/dev/deno/std/_util/assert.ts
```

module|Dependency count on master|Dependency count with this PR
-----------|----------------------------------------|-----------------------------------------
std/bytes/mod.ts|22|1
std/io/bufio.ts|23|2
std/textproto/mod.ts|25|2
std/ws/mod.ts|59|30
std/archive/tar.ts|33|6
std/encoding/csv.ts|32|9
std/http/_io.ts|48|19
std/io/mod.ts|30|9
std/log/handlers.ts|33|6
std/mime/multipart.ts|45|37

* NOTE - all dependency counts taken from `deno info` and are not de-duped, meaning the numbers can be inflated if the same dependency is being pulled in multiple times.