### PR TITLE
fix(cli/disk_cache): Support UNC paths in the typescript DiskCache #6198

### DIFF
--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::path::Prefix;
 use std::str;
-use url::Url;
+use url::{Host, Url};
 
 #[derive(Clone)]
 pub struct DiskCache {
@@ -79,6 +79,14 @@ impl DiskCache {
               Prefix::Disk(disk_byte) | Prefix::VerbatimDisk(disk_byte) => {
                 let disk = (disk_byte as char).to_string();
                 out.push(disk);
+              }
+              Prefix::UNC(server, share)
+              | Prefix::VerbatimUNC(server, share) => {
+                out.push("UNC");
+                let host = Host::parse(server.to_str().unwrap()).unwrap();
+                let host = host.to_string().replace(":", "_");
+                out.push(host);
+                out.push(share);
               }
               _ => unreachable!(),
             }
@@ -201,6 +209,21 @@ mod tests {
 
     if cfg!(target_os = "windows") {
       test_cases.push(("file:///D:/a/1/s/format.ts", "file/D/a/1/s/format.ts"));
+      // IPv4 localhost
+      test_cases.push((
+        "file://127.0.0.1/d$/a/1/s/format.ts",
+        "file/UNC/127.0.0.1/d$/a/1/s/format.ts",
+      ));
+      // IPv6 localhost
+      test_cases.push((
+        "file://[0:0:0:0:0:0:0:1]/d$/a/1/s/format.ts",
+        "file/UNC/[__1]/d$/a/1/s/format.ts",
+      ));
+      // shared folder
+      test_cases.push((
+        "file://comp/t-share/a/1/s/format.ts",
+        "file/UNC/comp/t-share/a/1/s/format.ts",
+      ));
     } else {
       test_cases.push((
         "file:///std/http/file_server.ts",


### PR DESCRIPTION
Fixes #6198
It adds UNC folder to deno/gen/file/ as root for Windows UNC paths.