### PR TITLE
test(wasi/std): remove v8 flags from test runner

### DIFF
--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -79,7 +79,6 @@ if (import.meta.main) {
           "run",
           "--quiet",
           "--unstable",
-          "--v8-flags=--experimental-wasm-bigint",
           "--allow-all",
           import.meta.url,
           prelude,


### PR DESCRIPTION
Its no longer necessary to enable this as it is enabled by default as of https://github.com/denoland/deno/pull/6443