### PR TITLE
fix(std/wasi) path_filestat_get padding

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -864,27 +864,27 @@ export default class Module {
           switch (true) {
             case info.isFile:
               view.setUint8(buf_out, FILETYPE_REGULAR_FILE);
-              buf_out += 4;
+              buf_out += 8;
               break;
 
             case info.isDirectory:
               view.setUint8(buf_out, FILETYPE_DIRECTORY);
-              buf_out += 4;
+              buf_out += 8;
               break;
 
             case info.isSymlink:
               view.setUint8(buf_out, FILETYPE_SYMBOLIC_LINK);
-              buf_out += 4;
+              buf_out += 8;
               break;
 
             default:
               view.setUint8(buf_out, FILETYPE_UNKNOWN);
-              buf_out += 4;
+              buf_out += 8;
               break;
           }
 
           view.setUint32(buf_out, Number(info.nlink), true);
-          buf_out += 4;
+          buf_out += 8;
 
           view.setBigUint64(buf_out, BigInt(info.size), true);
           buf_out += 8;

--- a/std/wasi/testdata/std_fs_metadata.rs
+++ b/std/wasi/testdata/std_fs_metadata.rs
@@ -3,26 +3,24 @@
 fn main() {
   let metadata = std::fs::metadata("/fixture/directory").unwrap();
   assert!(metadata.is_dir());
-  assert!(metadata.len() > 0);
 
   let metadata = std::fs::metadata("/fixture/symlink_to_directory").unwrap();
   assert!(metadata.is_dir());
-  assert!(metadata.len() > 0);
 
   let metadata = std::fs::metadata("/fixture/file").unwrap();
   assert!(metadata.is_file());
-  assert!(metadata.len() > 0);
+  assert_eq!(metadata.len(), 5);
 
   let metadata = std::fs::metadata("/fixture/symlink_to_file").unwrap();
   assert!(metadata.is_file());
-  assert!(metadata.len() > 0);
+  assert_eq!(metadata.len(), 5);
 
   let metadata = std::fs::metadata("/fixture/directory/file").unwrap();
   assert!(metadata.is_file());
-  assert!(metadata.len() > 0);
+  assert_eq!(metadata.len(), 15);
 
   let metadata =
     std::fs::metadata("/fixture/directory/symlink_to_file").unwrap();
   assert!(metadata.is_file());
-  assert!(metadata.len() > 0);
+  assert_eq!(metadata.len(), 15);
 }


### PR DESCRIPTION
Turns out there's an off by one error in `path_filestat_get` (8 byte alignment) 😅 