### PR TITLE
fix(cli): change seek offset type from i32 to i64

### DIFF
--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -151,7 +151,7 @@ fn op_open(
 struct SeekArgs {
   promise_id: Option<u64>,
   rid: i32,
-  offset: i32,
+  offset: i64,
   whence: i32,
 }
 
@@ -169,8 +169,8 @@ fn op_seek(
   // Translate seek mode to Rust repr.
   let seek_from = match whence {
     0 => SeekFrom::Start(offset as u64),
-    1 => SeekFrom::Current(i64::from(offset)),
-    2 => SeekFrom::End(i64::from(offset)),
+    1 => SeekFrom::Current(offset),
+    2 => SeekFrom::End(offset),
     _ => {
       return Err(OpError::type_error(format!(
         "Invalid seek mode: {}",


### PR DESCRIPTION
This changes the offset type in op_seek's SeekArgs from i32 to i64 which matches the behavior op_ftruncate and op_truncate.

Partially resolves #6481, there's still the case of the last few bits of range in u64 that Number cannot represent.