### PR TITLE
fix(std/node): add fill & encoding args to Buffer.alloc

### DIFF
--- a/std/node/buffer.ts
+++ b/std/node/buffer.ts
@@ -52,8 +52,9 @@ export default class Buffer extends Uint8Array {
     }
 
     const buf = new Buffer(size);
-    let bufFill;
+    if (size === 0) return buf;
 
+    let bufFill;
     if (typeof fill === "string") {
       encoding = checkEncoding(encoding);
       if (typeof fill === "string" && fill.length === 1 && encoding === "utf8")
@@ -61,6 +62,12 @@ export default class Buffer extends Uint8Array {
       else bufFill = Buffer.from(fill, encoding);
     } else if (typeof fill === "number") buf.fill(fill);
     else if (fill instanceof Uint8Array) {
+      if (fill.length === 0) {
+        throw new TypeError(
+          `The argument "value" is invalid. Received ${fill.constructor.name} []`
+        );
+      }
+
       bufFill = fill;
     }
 

--- a/std/node/buffer.ts
+++ b/std/node/buffer.ts
@@ -40,8 +40,46 @@ export default class Buffer extends Uint8Array {
   /**
    * Allocates a new Buffer of size bytes.
    */
-  static alloc(size: number): Buffer {
-    return new Buffer(size);
+  static alloc(
+    size: number,
+    fill?: number | string | Uint8Array | Buffer,
+    encoding = "utf8"
+  ): Buffer {
+    if (typeof size !== "number") {
+      throw new TypeError(
+        `The "size" argument must be of type number. Received type ${typeof size}`
+      );
+    }
+
+    const buf = new Buffer(size);
+    let bufFill;
+
+    if (typeof fill === "string") {
+      encoding = checkEncoding(encoding);
+      if (typeof fill === "string" && fill.length === 1 && encoding === "utf8")
+        buf.fill(fill.charCodeAt(0));
+      else bufFill = Buffer.from(fill, encoding);
+    } else if (typeof fill === "number") buf.fill(fill);
+    else if (fill instanceof Uint8Array) {
+      bufFill = fill;
+    }
+
+    if (bufFill) {
+      if (bufFill.length > buf.length)
+        bufFill = bufFill.subarray(0, buf.length);
+
+      let offset = 0;
+      while (offset < size) {
+        buf.set(bufFill, offset);
+        offset += bufFill.length;
+        if (offset + bufFill.length >= size) break;
+      }
+      if (offset !== size) {
+        buf.set(bufFill.subarray(0, size - offset), offset);
+      }
+    }
+
+    return buf;
   }
 
   /**

--- a/std/node/buffer_test.ts
+++ b/std/node/buffer_test.ts
@@ -16,7 +16,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "alloc fails on if size is not a number",
+  name: "alloc fails if size is not a number",
   fn() {
     const invalidSizes = [{}, "1", "foo", []];
 
@@ -31,6 +31,38 @@ Deno.test({
         `The "size" argument must be of type number. Received type ${typeof size}`,
         "should throw on non-number size"
       );
+    }
+  },
+});
+
+Deno.test({
+  name: "alloc(>0) fails if value is an empty Buffer/Uint8Array",
+  fn() {
+    const invalidValues = [new Uint8Array(), Buffer.alloc(0)];
+
+    for (const value of invalidValues) {
+      assertThrows(
+        () => {
+          // deno-lint-ignore ban-ts-comment
+          // @ts-ignore
+          console.log(value.constructor.name);
+          Buffer.alloc(1, value);
+        },
+        TypeError,
+        `The argument "value" is invalid. Received ${value.constructor.name} []`,
+        "should throw for empty Buffer/Uint8Array"
+      );
+    }
+  },
+});
+
+Deno.test({
+  name: "alloc(0) doesn't fail if value is an empty Buffer/Uint8Array",
+  fn() {
+    const invalidValues = [new Uint8Array(), Buffer.alloc(0)];
+
+    for (const value of invalidValues) {
+      assertEquals(Buffer.alloc(0, value).length, 0);
     }
   },
 });

--- a/std/node/buffer_test.ts
+++ b/std/node/buffer_test.ts
@@ -16,6 +16,26 @@ Deno.test({
 });
 
 Deno.test({
+  name: "alloc fails on if size is not a number",
+  fn() {
+    const invalidSizes = [{}, "1", "foo", []];
+
+    for (const size of invalidSizes) {
+      assertThrows(
+        () => {
+          // deno-lint-ignore ban-ts-comment
+          // @ts-ignore
+          Buffer.alloc(size);
+        },
+        TypeError,
+        `The "size" argument must be of type number. Received type ${typeof size}`,
+        "should throw on non-number size"
+      );
+    }
+  },
+});
+
+Deno.test({
   name: "alloc allocates a buffer with the expected size",
   fn() {
     const buffer: Buffer = Buffer.alloc(1);
@@ -29,6 +49,89 @@ Deno.test({
   fn() {
     const buffer: Buffer = Buffer.alloc(0);
     assertEquals(buffer.length, 0, "Buffer size should be 0");
+  },
+});
+
+Deno.test({
+  name: "alloc filled correctly with integer",
+  fn() {
+    const buffer: Buffer = Buffer.alloc(3, 5);
+    assertEquals(buffer, new Uint8Array([5, 5, 5]));
+  },
+});
+
+Deno.test({
+  name: "alloc filled correctly with single character",
+  fn() {
+    assertEquals(Buffer.alloc(5, "a"), new Uint8Array([97, 97, 97, 97, 97]));
+  },
+});
+
+Deno.test({
+  name: "alloc filled correctly with base64 string",
+  fn() {
+    assertEquals(
+      Buffer.alloc(11, "aGVsbG8gd29ybGQ=", "base64"),
+      new Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
+    );
+  },
+});
+
+Deno.test({
+  name: "alloc filled correctly with hex string",
+  fn() {
+    assertEquals(
+      Buffer.alloc(4, "64656e6f", "hex"),
+      new Uint8Array([100, 101, 110, 111])
+    );
+  },
+});
+
+Deno.test({
+  name: "alloc filled correctly with hex string smaller than alloc size",
+  fn() {
+    assertEquals(
+      Buffer.alloc(13, "64656e6f", "hex").toString(),
+      "denodenodenod"
+    );
+  },
+});
+
+Deno.test({
+  name: "alloc filled correctly with Uint8Array smaller than alloc size",
+  fn() {
+    assertEquals(
+      Buffer.alloc(7, new Uint8Array([100, 101])),
+      new Uint8Array([100, 101, 100, 101, 100, 101, 100])
+    );
+    assertEquals(
+      Buffer.alloc(6, new Uint8Array([100, 101])),
+      new Uint8Array([100, 101, 100, 101, 100, 101])
+    );
+  },
+});
+
+Deno.test({
+  name: "alloc filled correctly with Uint8Array bigger than alloc size",
+  fn() {
+    assertEquals(
+      Buffer.alloc(1, new Uint8Array([100, 101])),
+      new Uint8Array([100])
+    );
+  },
+});
+
+Deno.test({
+  name: "alloc filled correctly with Buffer",
+  fn() {
+    assertEquals(
+      Buffer.alloc(6, new Buffer([100, 101])),
+      new Uint8Array([100, 101, 100, 101, 100, 101])
+    );
+    assertEquals(
+      Buffer.alloc(7, new Buffer([100, 101])),
+      new Uint8Array([100, 101, 100, 101, 100, 101, 100])
+    );
   },
 });
 


### PR DESCRIPTION
Add `fill` & `encoding` arguments to `Buffer.alloc` to match Node [implementation](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding)

```
Buffer.alloc(size[, fill[, encoding]])
```