### PR TITLE
fix(std/wasi): use lookupflags for path_filestat_get

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -853,7 +853,10 @@ export default class Module {
         const view = new DataView(this.memory.buffer);
 
         try {
-          const info = Deno.statSync(path);
+          const info =
+            (flags & LOOKUPFLAGS_SYMLINK_FOLLOW) != 0
+              ? Deno.statSync(path)
+              : Deno.lstatSync(path);
 
           view.setBigUint64(buf_out, BigInt(info.dev ? info.dev : 0), true);
           buf_out += 8;

--- a/std/wasi/testdata/std_fs_symlink_metadata.rs
+++ b/std/wasi/testdata/std_fs_symlink_metadata.rs
@@ -1,0 +1,23 @@
+// { "preopens": { "/fixture": "fixture" } }
+
+fn main() {
+  let metadata = std::fs::symlink_metadata("/fixture/directory").unwrap();
+  assert!(metadata.file_type().is_dir());
+
+  let metadata =
+    std::fs::symlink_metadata("/fixture/symlink_to_directory").unwrap();
+  assert!(metadata.file_type().is_symlink());
+
+  let metadata = std::fs::symlink_metadata("/fixture/file").unwrap();
+  assert!(metadata.file_type().is_file());
+
+  let metadata = std::fs::symlink_metadata("/fixture/symlink_to_file").unwrap();
+  assert!(metadata.file_type().is_symlink());
+
+  let metadata = std::fs::symlink_metadata("/fixture/directory/file").unwrap();
+  assert!(metadata.file_type().is_file());
+
+  let metadata =
+    std::fs::symlink_metadata("/fixture/directory/symlink_to_file").unwrap();
+  assert!(metadata.file_type().is_symlink());
+}


### PR DESCRIPTION
There's a symlink_follow bit that can be set to determine if symlinks should be followed or not (e.g branch into lstat or stat) which was not taken into consideration in path_filestat_get.

This fixes that.