### PR TITLE
feat(std/node): Add Buffer.allocUnsafe

### DIFF
--- a/std/node/buffer.ts
+++ b/std/node/buffer.ts
@@ -60,8 +60,9 @@ export default class Buffer extends Uint8Array {
       if (typeof fill === "string" && fill.length === 1 && encoding === "utf8")
         buf.fill(fill.charCodeAt(0));
       else bufFill = Buffer.from(fill, encoding);
-    } else if (typeof fill === "number") buf.fill(fill);
-    else if (fill instanceof Uint8Array) {
+    } else if (typeof fill === "number") {
+      buf.fill(fill);
+    } else if (fill instanceof Uint8Array) {
       if (fill.length === 0) {
         throw new TypeError(
           `The argument "value" is invalid. Received ${fill.constructor.name} []`
@@ -87,6 +88,10 @@ export default class Buffer extends Uint8Array {
     }
 
     return buf;
+  }
+
+  static allocUnsafe(size: number): Buffer {
+    return new Buffer(size);
   }
 
   /**

--- a/std/node/buffer_test.ts
+++ b/std/node/buffer_test.ts
@@ -97,6 +97,22 @@ Deno.test({
 });
 
 Deno.test({
+  name: "allocUnsafe allocates a buffer with the expected size",
+  fn() {
+    const buffer: Buffer = Buffer.allocUnsafe(1);
+    assertEquals(buffer.length, 1, "Buffer size should be 1");
+  },
+});
+
+Deno.test({
+  name: "allocUnsafe(0) creates an empty buffer",
+  fn() {
+    const buffer: Buffer = Buffer.allocUnsafe(0);
+    assertEquals(buffer.length, 0, "Buffer size should be 0");
+  },
+});
+
+Deno.test({
   name: "alloc filled correctly with integer",
   fn() {
     const buffer: Buffer = Buffer.alloc(3, 5);


### PR DESCRIPTION
The internal implementation is nothing like Node's, but it's enough for a Node Compatibility Library IMO, 
Performance aside it will work the same way. No one should use the compatibility library if performance is key.

If we want to replicate the same internal behaviour with a buffer pool, I can work on it, I don't think it's needed though.