### PR TITLE
std/log - Expose base class for Logger instances

### DIFF
--- a/std/log/handlers.ts
+++ b/std/log/handlers.ts
@@ -195,7 +195,7 @@ export class RotatingFileHandler extends FileHandler {
         if (await exists(this._filename + "." + i)) {
           this.destroy();
           throw new Deno.errors.AlreadyExists(
-            "Backup log file " + this._filename + "." + i + " already exists"
+            "Backup log file " + this._filename + "." + i + " already exists",
           );
         }
       }

--- a/std/log/handlers_test.ts
+++ b/std/log/handlers_test.ts
@@ -67,7 +67,7 @@ Deno.test("simpleHandler", function (): void {
           args: [],
           level: level,
           loggerName: "default",
-        })
+        }),
       );
     }
 
@@ -88,7 +88,7 @@ Deno.test("testFormatterAsString", function (): void {
       args: [],
       level: LogLevels.DEBUG,
       loggerName: "default",
-    })
+    }),
   );
 
   assertEquals(handler.messages, ["test DEBUG Hello, world!"]);
@@ -106,7 +106,7 @@ Deno.test("testFormatterAsFunction", function (): void {
       args: [],
       level: LogLevels.ERROR,
       loggerName: "default",
-    })
+    }),
   );
 
   assertEquals(handler.messages, ["fn formatter ERROR Hello, world!"]);
@@ -127,7 +127,7 @@ Deno.test({
         args: [],
         level: LogLevels.WARNING,
         loggerName: "default",
-      })
+      }),
     );
     await fileHandler.destroy();
     const firstFileSize = (await Deno.stat(LOG_FILE)).size;
@@ -139,7 +139,7 @@ Deno.test({
         args: [],
         level: LogLevels.WARNING,
         loggerName: "default",
-      })
+      }),
     );
     await fileHandler.destroy();
     const secondFileSize = (await Deno.stat(LOG_FILE)).size;
@@ -175,15 +175,15 @@ Deno.test({
     Deno.writeFileSync(LOG_FILE, new TextEncoder().encode("hello world"));
     Deno.writeFileSync(
       LOG_FILE + ".1",
-      new TextEncoder().encode("hello world")
+      new TextEncoder().encode("hello world"),
     );
     Deno.writeFileSync(
       LOG_FILE + ".2",
-      new TextEncoder().encode("hello world")
+      new TextEncoder().encode("hello world"),
     );
     Deno.writeFileSync(
       LOG_FILE + ".3",
-      new TextEncoder().encode("hello world")
+      new TextEncoder().encode("hello world"),
     );
 
     const fileHandler = new RotatingFileHandler("WARNING", {
@@ -210,7 +210,7 @@ Deno.test({
   async fn() {
     Deno.writeFileSync(
       LOG_FILE + ".3",
-      new TextEncoder().encode("hello world")
+      new TextEncoder().encode("hello world"),
     );
     const fileHandler = new RotatingFileHandler("WARNING", {
       filename: LOG_FILE,
@@ -223,7 +223,7 @@ Deno.test({
         await fileHandler.setup();
       },
       Deno.errors.AlreadyExists,
-      "Backup log file " + LOG_FILE + ".3 already exists"
+      "Backup log file " + LOG_FILE + ".3 already exists",
     );
 
     fileHandler.destroy();
@@ -249,7 +249,7 @@ Deno.test({
         args: [],
         level: LogLevels.ERROR,
         loggerName: "default",
-      })
+      }),
     ); // 'ERROR AAA\n' = 10 bytes
     fileHandler.flush();
     assertEquals((await Deno.stat(LOG_FILE)).size, 10);
@@ -259,7 +259,7 @@ Deno.test({
         args: [],
         level: LogLevels.ERROR,
         loggerName: "default",
-      })
+      }),
     );
     fileHandler.flush();
     assertEquals((await Deno.stat(LOG_FILE)).size, 20);
@@ -269,7 +269,7 @@ Deno.test({
         args: [],
         level: LogLevels.ERROR,
         loggerName: "default",
-      })
+      }),
     );
     fileHandler.flush();
     // Rollover occurred. Log file now has 1 record, rollover file has the original 2
@@ -299,7 +299,7 @@ Deno.test({
         args: [],
         level: LogLevels.ERROR,
         loggerName: "default",
-      })
+      }),
     ); // 'ERROR AAA\n' = 10 bytes
     fileHandler.handle(
       new LogRecord({
@@ -307,7 +307,7 @@ Deno.test({
         args: [],
         level: LogLevels.ERROR,
         loggerName: "default",
-      })
+      }),
     );
     fileHandler.handle(
       new LogRecord({
@@ -315,7 +315,7 @@ Deno.test({
         args: [],
         level: LogLevels.ERROR,
         loggerName: "default",
-      })
+      }),
     );
 
     await fileHandler.destroy();
@@ -334,15 +334,15 @@ Deno.test({
     Deno.writeFileSync(LOG_FILE, new TextEncoder().encode("original log file"));
     Deno.writeFileSync(
       LOG_FILE + ".1",
-      new TextEncoder().encode("original log.1 file")
+      new TextEncoder().encode("original log.1 file"),
     );
     Deno.writeFileSync(
       LOG_FILE + ".2",
-      new TextEncoder().encode("original log.2 file")
+      new TextEncoder().encode("original log.2 file"),
     );
     Deno.writeFileSync(
       LOG_FILE + ".3",
-      new TextEncoder().encode("original log.3 file")
+      new TextEncoder().encode("original log.3 file"),
     );
 
     const fileHandler = new RotatingFileHandler("WARNING", {
@@ -358,7 +358,7 @@ Deno.test({
         args: [],
         level: LogLevels.ERROR,
         loggerName: "default",
-      })
+      }),
     ); // 'ERROR AAA\n' = 10 bytes
     await fileHandler.destroy();
 
@@ -366,15 +366,15 @@ Deno.test({
     assertEquals(decoder.decode(Deno.readFileSync(LOG_FILE)), "ERROR AAA\n");
     assertEquals(
       decoder.decode(Deno.readFileSync(LOG_FILE + ".1")),
-      "original log file"
+      "original log file",
     );
     assertEquals(
       decoder.decode(Deno.readFileSync(LOG_FILE + ".2")),
-      "original log.1 file"
+      "original log.1 file",
     );
     assertEquals(
       decoder.decode(Deno.readFileSync(LOG_FILE + ".3")),
-      "original log.2 file"
+      "original log.2 file",
     );
     assert(!existsSync(LOG_FILE + ".4"));
 
@@ -399,7 +399,7 @@ Deno.test({
         await fileHandler.setup();
       },
       Error,
-      "maxBytes cannot be less than 1"
+      "maxBytes cannot be less than 1",
     );
   },
 });
@@ -418,7 +418,7 @@ Deno.test({
         await fileHandler.setup();
       },
       Error,
-      "maxBackupCount cannot be less than 1"
+      "maxBackupCount cannot be less than 1",
     );
   },
 });
@@ -437,7 +437,7 @@ Deno.test({
         args: [],
         level: LogLevels.ERROR,
         loggerName: "default",
-      })
+      }),
     ); // 'ERROR AAA\n' = 10 bytes
 
     assertEquals((await Deno.stat(LOG_FILE)).size, 0);
@@ -497,7 +497,7 @@ Deno.test({
         args: [],
         level: LogLevels.ERROR,
         loggerName: "default",
-      })
+      }),
     );
 
     // ERROR won't trigger immediate flush
@@ -510,7 +510,7 @@ Deno.test({
         args: [],
         level: LogLevels.CRITICAL,
         loggerName: "default",
-      })
+      }),
     );
 
     // CRITICAL will trigger immediate flush

--- a/std/log/logger.ts
+++ b/std/log/logger.ts
@@ -52,7 +52,7 @@ export class Logger {
   constructor(
     loggerName: string,
     levelName: LevelName,
-    options: LoggerOptions = {}
+    options: LoggerOptions = {},
   ) {
     this.loggerName = loggerName;
     this.level = getLevelByName(levelName);

--- a/std/log/logger_test.ts
+++ b/std/log/logger_test.ts
@@ -129,11 +129,11 @@ Deno.test(
     const inlineData: string | undefined = logger.debug(
       expensiveFunction,
       1,
-      2
+      2,
     );
     assert(!called);
     assertEquals(inlineData, undefined);
-  }
+  },
 );
 
 Deno.test("String resolver fn resolves as expected", function (): void {
@@ -235,7 +235,7 @@ Deno.test(
     });
     const data18: { payload: string; other: number } = logger.error(
       { payload: "data", other: 123 },
-      1
+      1,
     );
     assertEquals(data18, {
       payload: "data",
@@ -243,5 +243,5 @@ Deno.test(
     });
     assertEquals(handler.messages[16], 'ERROR {"payload":"data","other":123}');
     assertEquals(handler.messages[17], 'ERROR {"payload":"data","other":123}');
-  }
+  },
 );

--- a/std/log/logger_test.ts
+++ b/std/log/logger_test.ts
@@ -41,11 +41,11 @@ Deno.test("simpleLogger", function (): void {
 
   assertEquals(logger.level, LogLevels.DEBUG);
   assertEquals(logger.levelName, "DEBUG");
-  assertEquals(logger.handlers, []);
+  assertEquals(logger._handlers, []);
 
   logger = new Logger("default", "DEBUG", { handlers: [handler] });
 
-  assertEquals(logger.handlers, [handler]);
+  assertEquals(logger._handlers, [handler]);
 });
 
 Deno.test("customHandler", function (): void {

--- a/std/log/mod.ts
+++ b/std/log/mod.ts
@@ -11,6 +11,7 @@ import { assert } from "../_util/assert.ts";
 import { LevelName } from "./levels.ts";
 
 export { LogLevels } from "./levels.ts";
+export { Logger } from "./logger.ts";
 
 export class LoggerConfig {
   level?: LevelName;

--- a/std/log/mod.ts
+++ b/std/log/mod.ts
@@ -59,7 +59,7 @@ export function getLogger(name?: string): Logger {
     const d = state.loggers.get("default");
     assert(
       d != null,
-      `"default" logger must be set for getting logger without name`
+      `"default" logger must be set for getting logger without name`,
     );
     return d;
   }

--- a/std/log/mod.ts
+++ b/std/log/mod.ts
@@ -10,7 +10,7 @@ import {
 import { assert } from "../_util/assert.ts";
 import { LevelName } from "./levels.ts";
 
-export { LogLevels } from "./levels.ts";
+export { LogLevels, LevelName } from "./levels.ts";
 export { Logger } from "./logger.ts";
 
 export class LoggerConfig {

--- a/std/log/mod_test.ts
+++ b/std/log/mod_test.ts
@@ -145,3 +145,31 @@ Deno.test({
     assertEquals(testHandler.messages[0], "CRITICAL critical3");
   },
 });
+
+Deno.test({
+  name: "Loggers have loggerName to get logger name",
+  async fn() {
+    const testHandler = new TestHandler("DEBUG");
+    await setup({
+      handlers: {
+        test: testHandler,
+      },
+
+      loggers: {
+        namedA: {
+          level: "DEBUG",
+          handlers: ["test"],
+        },
+        namedB: {
+          level: "DEBUG",
+          handlers: ["test"],
+        },
+      },
+    });
+
+    assertEquals(getLogger("namedA").loggerName, "namedA");
+    assertEquals(getLogger("namedB").loggerName, "namedB");
+    assertEquals(getLogger().loggerName, "default");
+    assertEquals(getLogger("nonsetupname").loggerName, "nonsetupname");
+  },
+});

--- a/std/log/mod_test.ts
+++ b/std/log/mod_test.ts
@@ -8,8 +8,8 @@ import {
   error,
   critical,
   setup,
+  Logger,
 } from "./mod.ts";
-import { Logger } from "./logger.ts";
 import { BaseHandler } from "./handlers.ts";
 
 class TestHandler extends BaseHandler {

--- a/std/log/test.ts
+++ b/std/log/test.ts
@@ -72,7 +72,7 @@ Deno.test("getLogger", async function (): Promise<void> {
   const logger = log.getLogger();
 
   assertEquals(logger.levelName, "DEBUG");
-  assertEquals(logger.handlers, [handler]);
+  assertEquals(logger._handlers, [handler]);
 });
 
 Deno.test("getLoggerWithName", async function (): Promise<void> {
@@ -93,7 +93,7 @@ Deno.test("getLoggerWithName", async function (): Promise<void> {
   const logger = log.getLogger("bar");
 
   assertEquals(logger.levelName, "INFO");
-  assertEquals(logger.handlers, [fooHandler]);
+  assertEquals(logger._handlers, [fooHandler]);
 });
 
 Deno.test("getLoggerUnknown", async function (): Promise<void> {
@@ -105,7 +105,7 @@ Deno.test("getLoggerUnknown", async function (): Promise<void> {
   const logger = log.getLogger("nonexistent");
 
   assertEquals(logger.levelName, "NOTSET");
-  assertEquals(logger.handlers, []);
+  assertEquals(logger._handlers, []);
 });
 
 Deno.test("getInvalidLoggerLevels", function (): void {


### PR DESCRIPTION
std/log - Expose a minimal base class for `Logger`

So that user code can name the type returned by public function `log.getLogger(...)`
    
    Create Logger base class with the functions for creating logs.
    Move logger.ts implementation to _logger.ts
    Implementation class named as LoggerImpl
