### PR TITLE
fix(cli/body): remove args spread on concatenate

### DIFF
--- a/cli/js/web/body.ts
+++ b/cli/js/web/body.ts
@@ -35,7 +35,7 @@ function validateBodyType(owner: Body, bodySource: BodyInit | null): boolean {
   );
 }
 
-function concatenate(...arrays: Uint8Array[]): ArrayBuffer {
+function concatenate(arrays: Uint8Array[]): ArrayBuffer {
   let totalLength = 0;
   for (const arr of arrays) {
     totalLength += arr.length;
@@ -73,7 +73,7 @@ async function bufferFromStream(
     }
   }
 
-  return concatenate(...parts);
+  return concatenate(parts);
 }
 
 export const BodyUsedError =

--- a/cli/tests/unit/body_test.ts
+++ b/cli/tests/unit/body_test.ts
@@ -79,3 +79,28 @@ unitTest({ perms: {} }, async function bodyURLSearchParams(): Promise<void> {
   const text = await body.text();
   assertEquals(text, "hello=world");
 });
+
+unitTest(async function bodyArrayBufferMultipleParts(): Promise<void> {
+  const parts: Uint8Array[] = [];
+  let size = 0;
+  const encoder = new TextEncoder();
+
+  for (let i = 0; i <= 150000; i++) {
+    const part = new Uint8Array([1]);
+    parts.push(part);
+    size += part.length;
+  }
+
+  let offset = 0;
+  const stream = new ReadableStream({
+    pull(controller): void {
+      // parts.shift() takes forever: https://github.com/denoland/deno/issues/5259
+      const chunk = parts[offset++];
+      if (!chunk) return controller.close();
+      controller.enqueue(chunk);
+    },
+  });
+
+  const body = buildBody(stream);
+  assertEquals((await body.arrayBuffer()).byteLength, size);
+});

--- a/cli/tests/unit/body_test.ts
+++ b/cli/tests/unit/body_test.ts
@@ -83,8 +83,6 @@ unitTest({ perms: {} }, async function bodyURLSearchParams(): Promise<void> {
 unitTest(async function bodyArrayBufferMultipleParts(): Promise<void> {
   const parts: Uint8Array[] = [];
   let size = 0;
-  const encoder = new TextEncoder();
-
   for (let i = 0; i <= 150000; i++) {
     const part = new Uint8Array([1]);
     parts.push(part);


### PR DESCRIPTION
fixes #6536

Remove spread operator to prevent `RangeError: Maximum call stack size exceeded` when the request body is quite big.

Should be a bit faster too
