### PR TITLE
Util functions take slices instead of heap values

### DIFF
--- a/cli/checksum.rs
+++ b/cli/checksum.rs
@@ -1,6 +1,6 @@
-pub fn gen(v: Vec<&[u8]>) -> String {
+pub fn gen(v: &[&[u8]]) -> String {
   let mut ctx = ring::digest::Context::new(&ring::digest::SHA256);
-  for src in v.iter() {
+  for src in v {
     ctx.update(src);
   }
   let digest = ctx.finish();

--- a/cli/colors.rs
+++ b/cli/colors.rs
@@ -46,85 +46,85 @@ fn style(s: &str, colorspec: ColorSpec) -> impl fmt::Display {
   String::from_utf8_lossy(&v).into_owned()
 }
 
-pub fn red_bold(s: String) -> impl fmt::Display {
+pub fn red_bold(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Red)).set_bold(true);
   style(&s, style_spec)
 }
 
-pub fn green_bold(s: String) -> impl fmt::Display {
+pub fn green_bold(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(10))).set_bold(true);
   style(&s, style_spec)
 }
 
-pub fn italic_bold(s: String) -> impl fmt::Display {
+pub fn italic_bold(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bold(true).set_italic(true);
   style(&s, style_spec)
 }
 
-pub fn black_on_white(s: String) -> impl fmt::Display {
+pub fn black_on_white(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bg(Some(White)).set_fg(Some(Black));
   style(&s, style_spec)
 }
 
-pub fn white_on_red(s: String) -> impl fmt::Display {
+pub fn white_on_red(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bg(Some(Red)).set_fg(Some(White));
   style(&s, style_spec)
 }
 
-pub fn white_on_green(s: String) -> impl fmt::Display {
+pub fn white_on_green(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bg(Some(Ansi256(10))).set_fg(Some(White));
   style(&s, style_spec)
 }
 
-pub fn yellow(s: String) -> impl fmt::Display {
+pub fn yellow(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(11)));
   style(&s, style_spec)
 }
 
-pub fn cyan(s: String) -> impl fmt::Display {
+pub fn cyan(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(14)));
   style(&s, style_spec)
 }
 
-pub fn red(s: String) -> impl fmt::Display {
+pub fn red(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Red));
   style(&s, style_spec)
 }
 
-pub fn green(s: String) -> impl fmt::Display {
+pub fn green(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(10)));
   style(&s, style_spec)
 }
 
-pub fn magenta(s: String) -> impl fmt::Display {
+pub fn magenta(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Magenta));
   style(&s, style_spec)
 }
 
-pub fn bold(s: String) -> impl fmt::Display {
+pub fn bold(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bold(true);
   style(&s, style_spec)
 }
 
-pub fn gray(s: String) -> impl fmt::Display {
+pub fn gray(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(8)));
   style(&s, style_spec)
 }
 
-pub fn italic_bold_gray(s: String) -> impl fmt::Display {
+pub fn italic_bold_gray(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec
     .set_fg(Some(Ansi256(8)))

--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -96,7 +96,7 @@ fn format_category_and_code(
     _ => "".to_string(),
   };
 
-  let code = colors::bold(format!("TS{}", code.to_string())).to_string();
+  let code = colors::bold(&format!("TS{}", code.to_string())).to_string();
 
   format!("{} [{}]", code, category)
 }
@@ -120,7 +120,7 @@ fn format_message(
 
 /// Formats optional source, line and column numbers into a single string.
 fn format_maybe_frame(
-  file_name: Option<String>,
+  file_name: Option<&str>,
   line_number: Option<i64>,
   column_number: Option<i64>,
 ) -> String {
@@ -134,8 +134,8 @@ fn format_maybe_frame(
   let line_number = line_number.unwrap();
   let column_number = column_number.unwrap();
   let file_name_c = colors::cyan(file_name.unwrap());
-  let line_c = colors::yellow(line_number.to_string());
-  let column_c = colors::yellow(column_number.to_string());
+  let line_c = colors::yellow(&line_number.to_string());
+  let column_c = colors::yellow(&column_number.to_string());
   format!("{}:{}:{}", file_name_c, line_c, column_c)
 }
 
@@ -156,13 +156,13 @@ fn format_maybe_related_information(
           DiagnosticCategory::Error => true,
           _ => false,
         },
-        format_message(&rd.message_chain, &rd.message, 0),
-        rd.source_line.clone(),
+        &format_message(&rd.message_chain, &rd.message, 0),
+        rd.source_line.as_deref(),
         rd.start_column,
         rd.end_column,
         // Formatter expects 1-based line and column numbers, but ours are 0-based.
         &[format_maybe_frame(
-          rd.script_resource_name.clone(),
+          rd.script_resource_name.as_deref(),
           rd.line_number.map(|n| n + 1),
           rd.start_column.map(|n| n + 1),
         )],
@@ -184,17 +184,17 @@ impl fmt::Display for DiagnosticItem {
           DiagnosticCategory::Error => true,
           _ => false,
         },
-        format!(
+        &format!(
           "{}: {}",
           format_category_and_code(&self.category, self.code),
           format_message(&self.message_chain, &self.message, 0)
         ),
-        self.source_line.clone(),
+        self.source_line.as_deref(),
         self.start_column,
         self.end_column,
         // Formatter expects 1-based line and column numbers, but ours are 0-based.
         &[format_maybe_frame(
-          self.script_resource_name.clone(),
+          self.script_resource_name.as_deref(),
           self.line_number.map(|n| n + 1),
           self.start_column.map(|n| n + 1)
         )],
@@ -453,11 +453,8 @@ mod tests {
 
   #[test]
   fn test_format_some_frame() {
-    let actual = format_maybe_frame(
-      Some("file://foo/bar.ts".to_string()),
-      Some(1),
-      Some(2),
-    );
+    let actual =
+      format_maybe_frame(Some("file://foo/bar.ts"), Some(1), Some(2));
     assert_eq!(strip_ansi_codes(&actual), "file://foo/bar.ts:1:2");
   }
 }

--- a/cli/diff.rs
+++ b/cli/diff.rs
@@ -5,26 +5,26 @@ use std::fmt;
 use std::fmt::Write;
 
 fn fmt_add() -> String {
-  format!("{}", colors::green_bold("+".to_string()))
+  format!("{}", colors::green_bold("+"))
 }
 
-fn fmt_add_text(x: String) -> String {
+fn fmt_add_text(x: &str) -> String {
   format!("{}", colors::green(x))
 }
 
-fn fmt_add_text_highlight(x: String) -> String {
+fn fmt_add_text_highlight(x: &str) -> String {
   format!("{}", colors::white_on_green(x))
 }
 
 fn fmt_rem() -> String {
-  format!("{}", colors::red_bold("-".to_string()))
+  format!("{}", colors::red_bold("-"))
 }
 
-fn fmt_rem_text(x: String) -> String {
+fn fmt_rem_text(x: &str) -> String {
   format!("{}", colors::red(x))
 }
 
-fn fmt_rem_text_highlight(x: String) -> String {
+fn fmt_rem_text_highlight(x: &str) -> String {
   format!("{}", colors::white_on_red(x))
 }
 
@@ -42,7 +42,7 @@ fn write_line_diff(
       diff,
       "{:0width$}{} ",
       *orig_line + i,
-      colors::gray("|".to_string()),
+      colors::gray("|"),
       width = line_number_width
     )?;
     write!(diff, "{}", fmt_rem())?;
@@ -56,7 +56,7 @@ fn write_line_diff(
       diff,
       "{:0width$}{} ",
       *edit_line + i,
-      colors::gray("|".to_string()),
+      colors::gray("|"),
       width = line_number_width
     )?;
     write!(diff, "{}", fmt_add())?;
@@ -107,7 +107,7 @@ pub fn diff(orig_text: &str, edit_text: &str) -> Result<String, fmt::Error> {
           if i > 0 {
             orig.push_str("\n");
           }
-          orig.push_str(&fmt_rem_text_highlight(s.to_string()));
+          orig.push_str(&fmt_rem_text_highlight(s));
         }
         changes = true
       }
@@ -117,7 +117,7 @@ pub fn diff(orig_text: &str, edit_text: &str) -> Result<String, fmt::Error> {
           if i > 0 {
             edit.push_str("\n");
           }
-          edit.push_str(&fmt_add_text_highlight(s.to_string()));
+          edit.push_str(&fmt_add_text_highlight(s));
         }
         changes = true
       }
@@ -142,8 +142,8 @@ pub fn diff(orig_text: &str, edit_text: &str) -> Result<String, fmt::Error> {
               edit_line += 1;
             }
           }
-          orig.push_str(&fmt_rem_text(s.to_string()));
-          edit.push_str(&fmt_add_text(s.to_string()));
+          orig.push_str(&fmt_rem_text(s));
+          edit.push_str(&fmt_add_text(s));
         }
       }
     }

--- a/cli/doc/printer.rs
+++ b/cli/doc/printer.rs
@@ -25,7 +25,7 @@ pub fn format_details(node: doc::DocNode) -> String {
 
   details.push_str(&format!(
     "{}",
-    colors::gray(format!(
+    colors::gray(&format!(
       "Defined in {}:{}:{} \n\n",
       node.location.filename, node.location.line, node.location.col
     ))
@@ -319,7 +319,7 @@ fn format_jsdoc(jsdoc: String, indent: i64) -> String {
     js_doc.push_str(&add_indent(format!("{}\n", line), indent + 1));
   }
 
-  format!("{}", colors::gray(js_doc))
+  format!("{}", colors::gray(&js_doc))
 }
 
 fn format_class_details(node: doc::DocNode) -> String {
@@ -330,8 +330,8 @@ fn format_class_details(node: doc::DocNode) -> String {
     details.push_str(&add_indent(
       format!(
         "{} {}({})\n",
-        colors::magenta("constructor".to_string()),
-        colors::bold(node.name),
+        colors::magenta("constructor"),
+        colors::bold(&node.name),
         render_params(node.params),
       ),
       1,
@@ -351,11 +351,11 @@ fn format_class_details(node: doc::DocNode) -> String {
             .accessibility
             .unwrap_or(swc_ecma_ast::Accessibility::Public)
           {
-            swc_ecma_ast::Accessibility::Protected => "protected ".to_string(),
-            _ => "".to_string(),
+            swc_ecma_ast::Accessibility::Protected => "protected ",
+            _ => "",
           }
         ),
-        colors::bold(node.name.clone()),
+        colors::bold(&node.name),
         if node.optional {
           "?".to_string()
         } else {
@@ -385,21 +385,17 @@ fn format_class_details(node: doc::DocNode) -> String {
             .accessibility
             .unwrap_or(swc_ecma_ast::Accessibility::Public)
           {
-            swc_ecma_ast::Accessibility::Protected => "protected ".to_string(),
-            _ => "".to_string(),
+            swc_ecma_ast::Accessibility::Protected => "protected ",
+            _ => "",
           }
         ),
         colors::magenta(match node.kind {
-          swc_ecma_ast::MethodKind::Getter => "get ".to_string(),
-          swc_ecma_ast::MethodKind::Setter => "set ".to_string(),
-          _ => "".to_string(),
+          swc_ecma_ast::MethodKind::Getter => "get ",
+          swc_ecma_ast::MethodKind::Setter => "set ",
+          _ => "",
         }),
-        colors::bold(node.name.clone()),
-        if node.optional {
-          "?".to_string()
-        } else {
-          "".to_string()
-        },
+        colors::bold(&node.name),
+        if node.optional { "?" } else { "" },
         render_params(function_def.params),
         if let Some(return_type) = function_def.return_type {
           format!(": {}", render_ts_type(return_type))
@@ -419,7 +415,7 @@ fn format_enum_details(node: doc::DocNode) -> String {
   let enum_def = node.enum_def.unwrap();
   for member in enum_def.members {
     details
-      .push_str(&add_indent(format!("{}\n", colors::bold(member.name)), 1));
+      .push_str(&add_indent(format!("{}\n", colors::bold(&member.name)), 1));
   }
   details.push_str("\n");
   details
@@ -441,8 +437,8 @@ fn format_function_signature(node: &doc::DocNode, indent: i64) -> String {
   add_indent(
     format!(
       "{} {}({}){}\n",
-      colors::magenta("function".to_string()),
-      colors::bold(node.name.clone()),
+      colors::magenta("function"),
+      colors::bold(&node.name),
       render_params(function_def.params),
       if let Some(return_type) = function_def.return_type {
         format!(": {}", render_ts_type(return_type).as_str())
@@ -457,11 +453,7 @@ fn format_function_signature(node: &doc::DocNode, indent: i64) -> String {
 fn format_class_signature(node: &doc::DocNode, indent: i64) -> String {
   let class_def = node.class_def.clone().unwrap();
   let extends_suffix = if let Some(extends) = class_def.extends {
-    format!(
-      " {} {}",
-      colors::magenta("extends".to_string()),
-      colors::bold(extends)
-    )
+    format!(" {} {}", colors::magenta("extends"), colors::bold(&extends))
   } else {
     String::from("")
   };
@@ -470,8 +462,8 @@ fn format_class_signature(node: &doc::DocNode, indent: i64) -> String {
   let implements_suffix = if !implements.is_empty() {
     format!(
       " {} {}",
-      colors::magenta("implements".to_string()),
-      colors::bold(implements.join(", "))
+      colors::magenta("implements"),
+      colors::bold(&implements.join(", "))
     )
   } else {
     String::from("")
@@ -480,8 +472,8 @@ fn format_class_signature(node: &doc::DocNode, indent: i64) -> String {
   add_indent(
     format!(
       "{} {}{}{}\n",
-      colors::magenta("class".to_string()),
-      colors::bold(node.name.clone()),
+      colors::magenta("class"),
+      colors::bold(&node.name),
       extends_suffix,
       implements_suffix,
     ),
@@ -495,11 +487,11 @@ fn format_variable_signature(node: &doc::DocNode, indent: i64) -> String {
     format!(
       "{} {}{}\n",
       colors::magenta(match variable_def.kind {
-        swc_ecma_ast::VarDeclKind::Const => "const".to_string(),
-        swc_ecma_ast::VarDeclKind::Let => "let".to_string(),
-        swc_ecma_ast::VarDeclKind::Var => "var".to_string(),
+        swc_ecma_ast::VarDeclKind::Const => "const",
+        swc_ecma_ast::VarDeclKind::Let => "let",
+        swc_ecma_ast::VarDeclKind::Var => "var",
       }),
-      colors::bold(node.name.clone()),
+      colors::bold(&node.name),
       if let Some(ts_type) = variable_def.ts_type {
         format!(": {}", render_ts_type(ts_type))
       } else {
@@ -512,11 +504,7 @@ fn format_variable_signature(node: &doc::DocNode, indent: i64) -> String {
 
 fn format_enum_signature(node: &doc::DocNode, indent: i64) -> String {
   add_indent(
-    format!(
-      "{} {}\n",
-      colors::magenta("enum".to_string()),
-      colors::bold(node.name.clone())
-    ),
+    format!("{} {}\n", colors::magenta("enum"), colors::bold(&node.name)),
     indent,
   )
 }
@@ -527,8 +515,8 @@ fn format_interface_signature(node: &doc::DocNode, indent: i64) -> String {
   let extends_suffix = if !extends.is_empty() {
     format!(
       " {} {}",
-      colors::magenta("extends".to_string()),
-      colors::bold(extends.join(", "))
+      colors::magenta("extends"),
+      colors::bold(&extends.join(", "))
     )
   } else {
     String::from("")
@@ -536,8 +524,8 @@ fn format_interface_signature(node: &doc::DocNode, indent: i64) -> String {
   add_indent(
     format!(
       "{} {}{}\n",
-      colors::magenta("interface".to_string()),
-      colors::bold(node.name.clone()),
+      colors::magenta("interface"),
+      colors::bold(&node.name),
       extends_suffix
     ),
     indent,
@@ -546,11 +534,7 @@ fn format_interface_signature(node: &doc::DocNode, indent: i64) -> String {
 
 fn format_type_alias_signature(node: &doc::DocNode, indent: i64) -> String {
   add_indent(
-    format!(
-      "{} {}\n",
-      colors::magenta("type".to_string()),
-      colors::bold(node.name.clone())
-    ),
+    format!("{} {}\n", colors::magenta("type"), colors::bold(&node.name)),
     indent,
   )
 }
@@ -559,8 +543,8 @@ fn format_namespace_signature(node: &doc::DocNode, indent: i64) -> String {
   add_indent(
     format!(
       "{} {}\n",
-      colors::magenta("namespace".to_string()),
-      colors::bold(node.name.clone())
+      colors::magenta("namespace"),
+      colors::bold(&node.name)
     ),
     indent,
   )

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -448,11 +448,7 @@ impl SourceFileFetcher {
       .boxed_local();
     }
 
-    info!(
-      "{} {}",
-      colors::green("Download".to_string()),
-      module_url.to_string()
-    );
+    info!("{} {}", colors::green("Download"), module_url.to_string());
 
     let dir = self.clone();
     let module_url = module_url.clone();

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -69,7 +69,7 @@ async fn check_source_files(
                 println!();
                 println!(
                   "{} {}:",
-                  colors::bold("from".to_string()),
+                  colors::bold("from"),
                   file_path.display().to_string()
                 );
                 println!("{}", diff);

--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -10,19 +10,19 @@ use std::ops::Deref;
 
 const SOURCE_ABBREV_THRESHOLD: usize = 150;
 
-pub fn format_location(filename: String, line: i64, col: i64) -> String {
+pub fn format_location(filename: &str, line: i64, col: i64) -> String {
   format!(
     "{}:{}:{}",
     colors::cyan(filename),
-    colors::yellow(line.to_string()),
-    colors::yellow(col.to_string())
+    colors::yellow(&line.to_string()),
+    colors::yellow(&col.to_string())
   )
 }
 
 pub fn format_stack(
   is_error: bool,
-  message_line: String,
-  source_line: Option<String>,
+  message_line: &str,
+  source_line: Option<&str>,
   start_column: Option<i64>,
   end_column: Option<i64>,
   formatted_frames: &[String],
@@ -51,7 +51,7 @@ pub fn format_stack(
 /// Take an optional source line and associated information to format it into
 /// a pretty printed version of that line.
 fn format_maybe_source_line(
-  source_line: Option<String>,
+  source_line: Option<&str>,
   start_column: Option<i64>,
   end_column: Option<i64>,
   is_error: bool,
@@ -93,9 +93,9 @@ fn format_maybe_source_line(
     s.push(underline_char);
   }
   let color_underline = if is_error {
-    colors::red(s).to_string()
+    colors::red(&s).to_string()
   } else {
-    colors::cyan(s).to_string()
+    colors::cyan(&s).to_string()
   };
 
   let indent = format!("{:indent$}", "", indent = level);
@@ -147,7 +147,7 @@ impl fmt::Display for JSError {
       && self.0.start_column.is_some()
     {
       formatted_frames = vec![format_location(
-        self.0.script_resource_name.clone().unwrap(),
+        self.0.script_resource_name.as_ref().unwrap(),
         self.0.line_number.unwrap(),
         self.0.start_column.unwrap() + 1,
       )]
@@ -158,8 +158,8 @@ impl fmt::Display for JSError {
       "{}",
       &format_stack(
         true,
-        self.0.message.clone(),
-        self.0.source_line.clone(),
+        &self.0.message,
+        self.0.source_line.as_deref(),
         self.0.start_column,
         self.0.end_column,
         &formatted_frames,
@@ -186,7 +186,7 @@ mod tests {
   #[test]
   fn test_format_some_source_line() {
     let actual = format_maybe_source_line(
-      Some("console.log('foo');".to_string()),
+      Some("console.log('foo');"),
       Some(8),
       Some(11),
       true,

--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -64,7 +64,7 @@ pub fn url_to_filename(url: &Url) -> PathBuf {
   // NOTE: fragment is omitted on purpose - it's not taken into
   // account when caching - it denotes parts of webpage, which
   // in case of static resources doesn't make much sense
-  let hashed_filename = crate::checksum::gen(vec![rest_str.as_bytes()]);
+  let hashed_filename = crate::checksum::gen(&[rest_str.as_bytes()]);
   cache_filename.push(hashed_filename);
   cache_filename
 }

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -121,7 +121,7 @@ pub fn fetch_once(
     if let Some(warning) = headers.get("X-Deno-Warning") {
       eprintln!(
         "{} {}",
-        crate::colors::yellow("Warning".to_string()),
+        crate::colors::yellow("Warning"),
         warning.to_str().unwrap()
       );
     }

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -102,20 +102,17 @@ fn lint_file(file_path: PathBuf) -> Result<Vec<LintDiagnostic>, ErrBox> {
 }
 
 fn format_diagnostic(d: &LintDiagnostic) -> String {
-  let pretty_message = format!(
-    "({}) {}",
-    colors::gray(d.code.to_string()),
-    d.message.clone()
-  );
+  let pretty_message =
+    format!("({}) {}", colors::gray(&d.code), d.message.clone());
 
   fmt_errors::format_stack(
     true,
-    pretty_message,
-    Some(d.line_src.clone()),
+    &pretty_message,
+    Some(&d.line_src),
     Some(d.location.col as i64),
     Some((d.location.col + d.snippet_length) as i64),
     &[fmt_errors::format_location(
-      d.location.filename.clone(),
+      &d.location.filename,
       d.location.line as i64,
       d.location.col as i64,
     )],

--- a/cli/lockfile.rs
+++ b/cli/lockfile.rs
@@ -53,7 +53,7 @@ impl Lockfile {
     }
     assert!(!self.need_read);
     Ok(if let Some(lockfile_checksum) = self.map.get(&url_str) {
-      let compiled_checksum = crate::checksum::gen(vec![&code]);
+      let compiled_checksum = crate::checksum::gen(&[&code]);
       lockfile_checksum == &compiled_checksum
     } else {
       false
@@ -66,7 +66,7 @@ impl Lockfile {
     if url_str.starts_with("file:") {
       return false;
     }
-    let checksum = crate::checksum::gen(vec![&code]);
+    let checksum = crate::checksum::gen(&[&code]);
     self.map.insert(url_str, checksum).is_none()
   }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -156,17 +156,17 @@ fn write_lockfile(global_state: GlobalState) -> Result<(), std::io::Error> {
 fn print_cache_info(state: &GlobalState) {
   println!(
     "{} {:?}",
-    colors::bold("DENO_DIR location:".to_string()),
+    colors::bold("DENO_DIR location:"),
     state.dir.root
   );
   println!(
     "{} {:?}",
-    colors::bold("Remote modules cache:".to_string()),
+    colors::bold("Remote modules cache:"),
     state.file_fetcher.http_cache.location
   );
   println!(
     "{} {:?}",
-    colors::bold("TypeScript compiler cache:".to_string()),
+    colors::bold("TypeScript compiler cache:"),
     state.dir.gen_cache.location
   );
 }
@@ -186,13 +186,13 @@ async fn print_file_info(
 
   println!(
     "{} {}",
-    colors::bold("local:".to_string()),
+    colors::bold("local:"),
     out.filename.to_str().unwrap()
   );
 
   println!(
     "{} {}",
-    colors::bold("type:".to_string()),
+    colors::bold("type:"),
     msg::enum_name_media_type(out.media_type)
   );
 
@@ -224,7 +224,7 @@ async fn print_file_info(
 
     println!(
       "{} {}",
-      colors::bold("compiled:".to_string()),
+      colors::bold("compiled:"),
       compiled_source_file.filename.to_str().unwrap(),
     );
   }
@@ -236,7 +236,7 @@ async fn print_file_info(
   {
     println!(
       "{} {}",
-      colors::bold("map:".to_string()),
+      colors::bold("map:"),
       source_map.filename.to_str().unwrap()
     );
   }
@@ -245,7 +245,7 @@ async fn print_file_info(
   let es_state = es_state_rc.borrow();
 
   if let Some(deps) = es_state.modules.deps(&module_specifier) {
-    println!("{}{}", colors::bold("deps:\n".to_string()), deps.name);
+    println!("{}{}", colors::bold("deps:\n"), deps.name);
     if let Some(ref depsdeps) = deps.deps {
       for d in depsdeps {
         println!("{}", d);
@@ -254,7 +254,7 @@ async fn print_file_info(
   } else {
     println!(
       "{} cannot retrieve full dependency graph",
-      colors::bold("deps:".to_string()),
+      colors::bold("deps:"),
     );
   }
 
@@ -431,7 +431,7 @@ async fn bundle_command(
 
   info!(
     "{} {}",
-    colors::green("Bundle".to_string()),
+    colors::green("Bundle"),
     module_specifier.to_string()
   );
 
@@ -452,9 +452,9 @@ async fn bundle_command(
     deno_fs::write_file(out_file_, output_bytes, 0o666)?;
     info!(
       "{} {:?} ({})",
-      colors::green("Emit".to_string()),
+      colors::green("Emit"),
       out_file_,
-      colors::gray(human_size(output_len as f64))
+      colors::gray(&human_size(output_len as f64))
     );
   } else {
     println!("{}", output);
@@ -761,11 +761,7 @@ pub fn main() {
 
   let result = tokio_util::run_basic(fut);
   if let Err(err) = result {
-    let msg = format!(
-      "{}: {}",
-      colors::red_bold("error".to_string()),
-      err.to_string(),
-    );
+    let msg = format!("{}: {}", colors::red_bold("error"), err.to_string(),);
     eprintln!("{}", msg);
     std::process::exit(1);
   }

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -457,7 +457,7 @@ impl ModuleGraphLoader {
           url: module_specifier.to_string(),
           redirect: Some(source_file.url.to_string()),
           filename: source_file.filename.to_str().unwrap().to_string(),
-          version_hash: checksum::gen(vec![
+          version_hash: checksum::gen(&[
             &source_file.source_code,
             version::DENO.as_bytes(),
           ]),
@@ -474,7 +474,7 @@ impl ModuleGraphLoader {
 
     let module_specifier = ModuleSpecifier::from(source_file.url.clone());
     let version_hash =
-      checksum::gen(vec![&source_file.source_code, version::DENO.as_bytes()]);
+      checksum::gen(&[&source_file.source_code, version::DENO.as_bytes()]);
     let source_code = String::from_utf8(source_file.source_code)?;
 
     if SUPPORTED_MEDIA_TYPES.contains(&source_file.media_type) {

--- a/cli/permissions.rs
+++ b/cli/permissions.rs
@@ -478,7 +478,7 @@ fn permission_prompt(message: &str) -> bool {
     PERMISSION_EMOJI, message
   );
   // print to stderr so that if deno is > to a file this is still displayed.
-  eprint!("{}", colors::bold(msg));
+  eprint!("{}", colors::bold(&msg));
   loop {
     let mut input = String::new();
     let stdin = io::stdin();
@@ -494,7 +494,7 @@ fn permission_prompt(message: &str) -> bool {
         // If we don't get a recognized option try again.
         let msg_again =
           format!("Unrecognized option '{}' [g/d (g = grant, d = deny)] ", ch);
-        eprint!("{}", colors::bold(msg_again));
+        eprint!("{}", colors::bold(&msg_again));
       }
     };
   }
@@ -524,7 +524,7 @@ fn permission_prompt(_message: &str) -> bool {
 fn log_perm_access(message: &str) {
   debug!(
     "{}",
-    colors::bold(format!("{}️  Granted {}", PERMISSION_EMOJI, message))
+    colors::bold(&format!("{}️  Granted {}", PERMISSION_EMOJI, message))
   );
 }
 

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -309,7 +309,7 @@ pub fn source_code_version_hash(
   version: &str,
   config_hash: &[u8],
 ) -> String {
-  crate::checksum::gen(vec![source_code, version.as_bytes(), config_hash])
+  crate::checksum::gen(&[source_code, version.as_bytes(), config_hash])
 }
 
 fn maybe_log_stats(maybe_stats: Option<Vec<Stat>>) {
@@ -476,7 +476,7 @@ impl TsCompiler {
         if let Some(source_file) = file_fetcher
           .fetch_cached_source_file(&specifier, Permissions::allow_all())
         {
-          let existing_hash = crate::checksum::gen(vec![
+          let existing_hash = crate::checksum::gen(&[
             &source_file.source_code,
             version::DENO.as_bytes(),
           ]);
@@ -583,11 +583,7 @@ impl TsCompiler {
     let req_msg = j.to_string().into_boxed_str().into_boxed_bytes();
 
     // TODO(bartlomieju): lift this call up - TSC shouldn't print anything
-    info!(
-      "{} {}",
-      colors::green("Check".to_string()),
-      module_url.to_string()
-    );
+    info!("{} {}", colors::green("Check"), module_url.to_string());
 
     let msg =
       execute_in_same_thread(global_state.clone(), permissions, req_msg)


### PR DESCRIPTION
Several functions in the checksum, colors and diff modules take heap allocated collections instead of the for their purposes sufficient slices.
This PR changes these functions to take slices instead which eliminates several heap allocations.