### PR TITLE
feat(std/wasi): implement fd_datasync

### DIFF
--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -15,7 +15,7 @@ This module provides an implementation of the WebAssembly System Interface
 - [ ] fd_advise
 - [ ] fd_allocate
 - [x] fd_close
-- [ ] fd_datasync
+- [x] fd_datasync
 - [x] fd_fdstat_get
 - [ ] fd_fdstat_set_flags
 - [ ] fd_fdstat_set_rights

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -492,7 +492,18 @@ export default class Module {
       },
 
       fd_datasync: (fd: number): number => {
-        return ERRNO_NOSYS;
+        const entry = this.fds[fd];
+        if (!entry) {
+          return ERRNO_BADF;
+        }
+
+        try {
+          Deno.fdatasyncSync(entry.handle.rid);
+        } catch (err) {
+          return errno(err);
+        }
+
+        return ERRNO_SUCCESS;
       },
 
       fd_fdstat_get: (fd: number, stat_out: number): number => {

--- a/std/wasi/testdata/std_fs_file_sync_data.rs
+++ b/std/wasi/testdata/std_fs_file_sync_data.rs
@@ -1,0 +1,15 @@
+// { "preopens": { "/scratch": "scratch" } }
+
+use std::io::Write;
+
+fn main() {
+  let mut file = std::fs::File::create("/scratch/file").unwrap();
+
+  assert!(file.write(b"Hello").is_ok());
+  assert!(file.sync_data().is_ok());
+  assert_eq!(std::fs::read("/scratch/file").unwrap(), b"Hello");
+
+  assert!(file.write(b", world!").is_ok());
+  assert!(file.sync_data().is_ok());
+  assert_eq!(std::fs::read("/scratch/file").unwrap(), b"Hello, world!");
+}


### PR DESCRIPTION
This implements fd_datasync as a direct mapping to Deno.fdatasync