### PR TITLE
feat(std/wasi) implement fd_filestat_set_size

### DIFF
--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -20,7 +20,7 @@ This module provides an implementation of the WebAssembly System Interface
 - [ ] fd_fdstat_set_flags
 - [ ] fd_fdstat_set_rights
 - [x] fd_filestat_get
-- [ ] fd_filestat_set_size
+- [x] fd_filestat_set_size
 - [x] fd_filestat_set_times
 - [x] fd_pread
 - [x] fd_prestat_get

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -607,7 +607,18 @@ export default class Module {
       },
 
       fd_filestat_set_size: (fd: number, size: bigint): number => {
-        return ERRNO_NOSYS;
+        const entry = this.fds[fd];
+        if (!entry) {
+          return ERRNO_BADF;
+        }
+
+        try {
+          Deno.ftruncateSync(entry.handle.rid, Number(size));
+        } catch (err) {
+          return errno(err);
+        }
+
+        return ERRNO_SUCCESS;
       },
 
       fd_filestat_set_times: (

--- a/std/wasi/testdata/std_fs_file_set_len.rs
+++ b/std/wasi/testdata/std_fs_file_set_len.rs
@@ -1,0 +1,17 @@
+// { "preopens": { "/scratch": "scratch" } }
+
+fn main() {
+  let file = std::fs::File::create("/scratch/file").unwrap();
+
+  assert!(file.set_len(0).is_ok());
+  assert_eq!(file.metadata().unwrap().len(), 0);
+
+  assert!(file.set_len(5).is_ok());
+  assert_eq!(file.metadata().unwrap().len(), 5);
+
+  assert!(file.set_len(25).is_ok());
+  assert_eq!(file.metadata().unwrap().len(), 25);
+
+  assert!(file.set_len(0).is_ok());
+  assert_eq!(file.metadata().unwrap().len(), 0);
+}


### PR DESCRIPTION
This implements fd_filestat_set_size as a trivial 1:1 mapping to Deno.ftruncateSync.