### PR TITLE
feat(std/wasi): implement fd_sync

### DIFF
--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -30,7 +30,7 @@ This module provides an implementation of the WebAssembly System Interface
 - [ ] fd_readdir
 - [x] fd_renumber
 - [x] fd_seek
-- [ ] fd_sync
+- [x] fd_sync
 - [x] fd_tell
 - [x] fd_write
 - [x] path_create_directory

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -842,7 +842,18 @@ export default class Module {
       },
 
       fd_sync: (fd: number): number => {
-        return ERRNO_NOSYS;
+        const entry = this.fds[fd];
+        if (!entry) {
+          return ERRNO_BADF;
+        }
+
+        try {
+          Deno.fsyncSync(entry.handle.rid);
+        } catch (err) {
+          return errno(err);
+        }
+
+        return ERRNO_SUCCESS;
       },
 
       fd_tell: (fd: number, offset_out: number): number => {

--- a/std/wasi/testdata/std_fs_file_sync_all.rs
+++ b/std/wasi/testdata/std_fs_file_sync_all.rs
@@ -1,0 +1,15 @@
+// { "preopens": { "/scratch": "scratch" } }
+
+fn main() {
+  let file = std::fs::File::create("/scratch/file").unwrap();
+
+  assert!(file.set_len(5).is_ok());
+  assert!(file.sync_all().is_ok());
+  let metadata = std::fs::metadata("/scratch/file").unwrap();
+  assert_eq!(metadata.len(), 5);
+
+  assert!(file.set_len(25).is_ok());
+  assert!(file.sync_all().is_ok());
+  let metadata = std::fs::metadata("/scratch/file").unwrap();
+  assert_eq!(metadata.len(), 25);
+}


### PR DESCRIPTION
This implements fd_sync as a trivial mapping to Deno.fsyncSync.