### PR TITLE
Fixing error TS2345

### DIFF
--- a/std/path/posix.ts
+++ b/std/path/posix.ts
@@ -435,5 +435,5 @@ export function parse(path: string): ParsedPath {
  * are ignored.
  */
 export function fromFileUrl(url: string | URL): string {
-  return new URL(url).pathname;
+  return url instanceof URL ? url?.pathname : new URL(url).pathname;
 }

--- a/std/path/win32.ts
+++ b/std/path/win32.ts
@@ -914,7 +914,9 @@ export function parse(path: string): ParsedPath {
  * are ignored.
  */
 export function fromFileUrl(url: string | URL): string {
-  return new URL(url).pathname
-    .replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/")
-    .replace(/\//g, "\\");
+
+  const pathname = url instanceof URL ? url?.pathname : new URL(url).pathname;
+
+  return pathname?.replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/")
+                  .replace(/\//g, "\\");
 }


### PR DESCRIPTION
Fixing error: TS2345 [ERROR]: Argument of type 'string | URL' is not assignable to parameter of type 'string'.
  Type 'URL' is not assignable to type 'string'.
    return new URL(url).pathname;

which appears when when running the following command with [tsconfig.json](https://github.com/Bidek56/deno-py-websocket/blob/master/client/tsconfig.json)

`deno test -A -c tsconfig.json --unstable .\std\fs\expand_glob_test.ts`