### PR TITLE
ignore PoisonError in http_server

### DIFF
--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -78,7 +78,13 @@ impl<'a> Drop for HttpServerGuard<'a> {
 /// will be killed.
 pub fn http_server<'a>() -> HttpServerGuard<'a> {
   // TODO(bartlomieju) Allow tests to use the http server in parallel.
-  let g = GUARD.lock().unwrap();
+  let r = GUARD.lock();
+  let g = if let Err(poison_err) = r {
+    // If panics happened, ignore it. This is for tests.
+    poison_err.into_inner()
+  } else {
+    r.unwrap()
+  };
 
   println!("tools/http_server.py starting...");
   let mut child = Command::new("python")


### PR DESCRIPTION
[From the Mutex documentation](https://doc.rust-lang.org/std/sync/struct.Mutex.html#poisoning):
> The mutexes in this module implement a strategy called "poisoning" where a mutex is considered poisoned whenever a thread panics while holding the mutex. Once a mutex is poisoned, all other threads are unable to access the data by default as it is likely tainted (some invariant is not being upheld).
>
> For a mutex, this means that the lock and try_lock methods return a Result which indicates whether a mutex has been poisoned or not. Most usage of a mutex will simply unwrap() these results, propagating panics among threads to ensure that a possibly invalid invariant is not witnessed.
>
> A poisoned mutex, however, does not prevent all access to the underlying data. The PoisonError type has an into_inner method which will return the guard that would have otherwise been returned on a successful lock. This allows access to the data, despite the lock being poisoned.

Test threads panic regularly. We don't want that to effect subsequent tests.