### PR TITLE
test(std/wasi): add hard-link test

### DIFF
--- a/std/wasi/testdata/std_fs_hard_link.rs
+++ b/std/wasi/testdata/std_fs_hard_link.rs
@@ -1,0 +1,11 @@
+// { "preopens": { "/fixture": "fixture", "/scratch": "scratch" } }
+
+fn main() {
+  assert!(
+    std::fs::hard_link("/fixture/file", "/scratch/hardlink_to_file").is_ok()
+  );
+  assert_eq!(
+    std::fs::read("/fixture/file").unwrap(),
+    std::fs::read("/scratch/hardlink_to_file").unwrap()
+  );
+}


### PR DESCRIPTION
This adds a *very basic* to hard-link test via std::fs::hard_link, can't really test fields like *ino* etc with just std::fs.