### PR TITLE
feat(cli) add dev, ino and nlink fields to Deno.FileInfo on Windows

### DIFF
--- a/cli/tests/unit/stat_test.ts
+++ b/cli/tests/unit/stat_test.ts
@@ -18,6 +18,9 @@ unitTest({ perms: { read: true } }, function fstatSyncSuccess(): void {
   assert(fileInfo.atime);
   assert(fileInfo.mtime);
   assert(fileInfo.birthtime);
+  assert(fileInfo.dev);
+  assert(fileInfo.ino);
+  assert(fileInfo.nlink);
 
   Deno.close(file.rid);
 });
@@ -34,6 +37,9 @@ unitTest({ perms: { read: true } }, async function fstatSuccess(): Promise<
   assert(fileInfo.atime);
   assert(fileInfo.mtime);
   assert(fileInfo.birthtime);
+  assert(fileInfo.dev);
+  assert(fileInfo.ino);
+  assert(fileInfo.nlink);
 
   Deno.close(file.rid);
 });
@@ -284,10 +290,7 @@ unitTest(
     const filename = tempDir + "/test.txt";
     Deno.writeFileSync(filename, data, { mode: 0o666 });
     const s = Deno.statSync(filename);
-    assert(s.dev === null);
-    assert(s.ino === null);
     assert(s.mode === null);
-    assert(s.nlink === null);
     assert(s.uid === null);
     assert(s.gid === null);
     assert(s.rdev === null);


### PR DESCRIPTION
This fills in the dev, ino and nlink fields on Windows when called from Deno.fstat, Deno.lstat or Deno.stat.

These fields come from GetFileInformationByHandle which have been rolled into the std::os::windows::fs::MetadataExt trait as a nightly gated feature so this is blocking on the "windows_by_handle" feature being rolled out to a stable release.

In other words; **do not merge**, leaving this here as a draft proof of concept for now.