### PR TITLE
fix: move ImportMeta to deno.ns lib

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -3,6 +3,22 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 
+declare interface ImportMeta {
+  /** A string representation of the fully qualified module URL. */
+  url: string;
+
+  /** A flag that indicates if the current module is the main module that was
+   * called when starting the program under Deno.
+   *
+   * ```ts
+   * if (import.meta.main) {
+   *   // this was loaded as the main module, maybe do some bootstrapping
+   * }
+   * ```
+   */
+  main: boolean;
+}
+
 declare namespace Deno {
   /** A set of error constructors that are raised by Deno APIs. */
   export const errors: {

--- a/cli/js/lib.deno.shared_globals.d.ts
+++ b/cli/js/lib.deno.shared_globals.d.ts
@@ -219,6 +219,10 @@ declare function clearInterval(id?: number): void;
  */
 declare function clearTimeout(id?: number): void;
 
+interface VoidFunction {
+  (): void;
+}
+
 /** A microtask is a short function which is executed after the function or
  * module which created it exits and only if the JavaScript execution stack is
  * empty, but before returning control to the event loop being used to drive the
@@ -227,7 +231,7 @@ declare function clearTimeout(id?: number): void;
  *
  *     queueMicrotask(() => { console.log('This event loop stack is complete'); });
  */
-declare function queueMicrotask(func: Function): void;
+declare function queueMicrotask(func: VoidFunction): void;
 
 declare var console: Console;
 declare var crypto: Crypto;
@@ -265,11 +269,6 @@ declare function removeEventListener(
   callback: EventListenerOrEventListenerObject | null,
   options?: boolean | EventListenerOptions | undefined
 ): void;
-
-declare interface ImportMeta {
-  url: string;
-  main: boolean;
-}
 
 interface DomIterable<K, V> {
   keys(): IterableIterator<K>;


### PR DESCRIPTION
Fixes #6564 

When users use libraries that require a configuration that loads the `dom` lib, they cannot also load `deno.shared_globals` because there are too many variances from how Deno defines things and how they are defined in `dom`.  Most of the differences are for very valid reasons (like `Console` varies greatly) as well as we declare classes instead of interfaces for a lot of structures which make them not open ended, like interfaces.

The long story short, users do lose the ability to have `import.meta` type checked.  This PR moves this to `deno.ns` so when someone loads `"lib": ["dom", "dom.iterable", "deno.ns"]` they still get the type safety around `import.meta.main` and `import.meta.url`.

I looked at the rest of the shared globals, and there is nothing else that is very Deno specific that we should worry about at the moment.  `Console` does vary quite a bit, but it is only esoteric parts of the it.  It might make sense to revisit it and align the whole thing much closer to the way it is described in `dom` though.

I also found that `queueMicrotask()` definition varied from the TypeScript `dom` one, so I fixed that so they align now.