### PR TITLE
feat(std/wasi): implement sock_shutdown

### DIFF
--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -50,7 +50,7 @@ This module provides an implementation of the WebAssembly System Interface
 - [x] random_get
 - [ ] sock_recv
 - [ ] sock_send
-- [ ] sock_shutdown
+- [x] sock_shutdown
 
 ## Usage
 

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -1442,7 +1442,18 @@ export default class Module {
       },
 
       sock_shutdown: (fd: number, how: number): number => {
-        return ERRNO_NOSYS;
+        const entry = this.fds[fd];
+        if (!entry) {
+          return ERRNO_BADF;
+        }
+
+        try {
+          Deno.shutdown(entry.handle.rid, how);
+        } catch (err) {
+          return errno(err);
+        }
+
+        return ERRNO_SUCCESS;
       },
     };
   }


### PR DESCRIPTION
This implements sock_shutdown as a trivial mapping to Deno.shutdown.