### PR TITLE
test(std/wasi): add create directory and file tests

### DIFF
--- a/std/wasi/testdata/std_fs_create_dir.rs
+++ b/std/wasi/testdata/std_fs_create_dir.rs
@@ -1,0 +1,6 @@
+// { "preopens": { "/scratch": "scratch" } }
+
+fn main() {
+  assert!(std::fs::create_dir("/scratch/directory").is_ok());
+  assert!(std::fs::metadata("/scratch/directory").unwrap().is_dir());
+}

--- a/std/wasi/testdata/std_fs_file_create.rs
+++ b/std/wasi/testdata/std_fs_file_create.rs
@@ -1,0 +1,6 @@
+// { "preopens": { "/scratch": "scratch" } }
+
+fn main() {
+  assert!(std::fs::File::create("/scratch/file").is_ok());
+  assert!(std::fs::metadata("/scratch/file").unwrap().is_file());
+}


### PR DESCRIPTION
This adds some fairly basic tests for std::fs::create_dir and std::fs::File::create.