### PR TITLE
feat(cli): Added support for the --cert flag with 'deno upgrade'

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -2636,7 +2636,7 @@ mod tests {
           force: false,
           dry_run: false,
           version: None,
-          ca_file: None
+          ca_file: Some("example.crt".to_owned()),
         },
         ca_file: Some("example.crt".to_owned()),
         ..Flags::default()

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -70,6 +70,7 @@ pub enum DenoSubcommand {
     dry_run: bool,
     force: bool,
     version: Option<String>,
+    ca_file: Option<String>,
   },
 }
 
@@ -563,13 +564,17 @@ fn test_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 }
 
 fn upgrade_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
+  ca_file_arg_parse(flags, matches);
+
   let dry_run = matches.is_present("dry-run");
   let force = matches.is_present("force");
   let version = matches.value_of("version").map(|s| s.to_string());
+  let ca_file = matches.value_of("cert").map(|s| s.to_string());
   flags.subcommand = DenoSubcommand::Upgrade {
     dry_run,
     force,
     version,
+    ca_file,
   };
 }
 
@@ -862,6 +867,7 @@ and is used to replace the current executable.",
         .short("f")
         .help("Replace current exe even if not out-of-date"),
     )
+    .arg(ca_file_arg())
 }
 
 fn doc_subcommand<'a, 'b>() -> App<'a, 'b> {
@@ -1392,7 +1398,8 @@ mod tests {
         subcommand: DenoSubcommand::Upgrade {
           force: true,
           dry_run: true,
-          version: None
+          version: None,
+          ca_file: None
         },
         ..Flags::default()
       }
@@ -2613,6 +2620,25 @@ mod tests {
         allow_write: true,
         allow_plugin: true,
         allow_hrtime: true,
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn upgrade_with_ca_file() {
+    let r =
+      flags_from_vec_safe(svec!["deno", "upgrade", "--cert", "example.crt"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Upgrade {
+          force: false,
+          dry_run: false,
+          version: None,
+          ca_file: None
+        },
+        ca_file: Some("example.crt".to_owned()),
         ..Flags::default()
       }
     );

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -749,7 +749,8 @@ pub fn main() {
       force,
       dry_run,
       version,
-    } => upgrade_command(dry_run, force, version).boxed_local(),
+      ca_file,
+    } => upgrade_command(dry_run, force, version, ca_file).boxed_local(),
     _ => unreachable!(),
   };
 

--- a/cli/upgrade.rs
+++ b/cli/upgrade.rs
@@ -17,7 +17,6 @@ use reqwest::{redirect::Policy, Client};
 use semver_parser::version::parse as semver_parse;
 use semver_parser::version::Version;
 use std::fs;
-use std::fs::File;
 use std::future::Future;
 use std::io::prelude::*;
 use std::path::Path;
@@ -63,9 +62,8 @@ pub async fn upgrade_command(
 
   // If we have been provided a CA Certificate, add it into the HTTP client
   if let Some(ca_file) = ca_file {
-    let mut buf = Vec::new();
-    File::open(ca_file)?.read_to_end(&mut buf)?;
-    let cert = reqwest::Certificate::from_pem(&buf)?;
+    let buf = std::fs::read(ca_file);
+    let cert = reqwest::Certificate::from_pem(&buf.unwrap())?;
     client_builder = client_builder.add_root_certificate(cert);
   }
 


### PR DESCRIPTION
I've added support for the `--cert` flag for `deno upgrade` I'm not 100% sure I've done it right as it seems different commands implement the use of --cert differently. Please feel free to point out the correct way I should do it. 

Looks to be working on my machine here:
![image](https://user-images.githubusercontent.com/2946071/86356857-e13f6080-bc64-11ea-8b3a-7536bf02705a.png)
