### PR TITLE
test(std/node): include windows in link tests

### DIFF
--- a/std/node/_fs/_fs_link_test.ts
+++ b/std/node/_fs/_fs_link_test.ts
@@ -3,10 +3,7 @@ import { fail, assertEquals } from "../../testing/asserts.ts";
 import { link, linkSync } from "./_fs_link.ts";
 import { assert } from "../../testing/asserts.ts";
 
-const isWindows = Deno.build.os === "windows";
-
 Deno.test({
-  ignore: isWindows,
   name: "ASYNC: hard linking files works as expected",
   async fn() {
     const tempFile: string = await Deno.makeTempFile();
@@ -31,7 +28,6 @@ Deno.test({
 });
 
 Deno.test({
-  ignore: isWindows,
   name: "ASYNC: hard linking files passes error to callback",
   async fn() {
     let failed = false;
@@ -53,7 +49,6 @@ Deno.test({
 });
 
 Deno.test({
-  ignore: isWindows,
   name: "SYNC: hard linking files works as expected",
   fn() {
     const tempFile: string = Deno.makeTempFileSync();


### PR DESCRIPTION
This removes the ignore option from std/node's filesystem link tests so that the tests run under windows as-well.

