### PR TITLE
test(std/wasi): explicitly assert each expected arg

### DIFF
--- a/std/wasi/testdata/std_env_args.rs
+++ b/std/wasi/testdata/std_env_args.rs
@@ -1,6 +1,9 @@
 // { "args": ["one", "two", "three" ]}
 
 fn main() {
-  let args = std::env::args();
+  let mut args = std::env::args();
   assert_eq!(args.len(), 3);
+  assert_eq!(args.next().unwrap(), "one");
+  assert_eq!(args.next().unwrap(), "two");
+  assert_eq!(args.next().unwrap(), "three");
 }


### PR DESCRIPTION
This adds explicit assertions for each expected value returned by std::env::args.