### PR TITLE
fix(std/wasi): return errno::success from fd_tell

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -871,7 +871,7 @@ export default class Module {
           return ERRNO_INVAL;
         }
 
-        return ERRNO_NOSYS;
+        return ERRNO_SUCCESS;
       },
 
       fd_write: (


### PR DESCRIPTION
Currently fd_seek is returning errno::nosys despite being implemented.
This fixes that by returning errno::success as would be expected.