### PR TITLE
chore: improve type safety of cli/js/compiler

### DIFF
--- a/cli/js/compiler.ts
+++ b/cli/js/compiler.ts
@@ -245,6 +245,7 @@ class SourceFile {
   processed = false;
   sourceCode?: string;
   tsSourceFile?: ts.SourceFile;
+  versionHash!: string;
   url!: string;
 
   constructor(json: SourceFileJson) {
@@ -445,7 +446,6 @@ class Host implements ts.CompilerHost {
           sourceFile.sourceCode,
           languageVersion
         );
-        //@ts-ignore
         sourceFile.tsSourceFile.version = sourceFile.versionHash;
         delete sourceFile.sourceCode;
       }

--- a/cli/js/ts_global.d.ts
+++ b/cli/js/ts_global.d.ts
@@ -29,5 +29,9 @@ declare global {
       disable(): void;
       getDuration(value: string): number;
     };
+
+    interface SourceFile {
+      version?: string;
+    }
   }
 }


### PR DESCRIPTION
Using `@ts-ignore` in the compiler to get around a TypeScript API issue obfuscated an incorrect type definition of the compiler Source file.  This PR fixes both issues and removes the `@ts-ignore`.
