### PR TITLE
fix(cli/fetch): response constructor default properties

### DIFF
--- a/cli/js/web/fetch.ts
+++ b/cli/js/web/fetch.ts
@@ -34,14 +34,14 @@ export class Response extends Body.Body implements domTypes.Response {
     const extraInit = responseData.get(init) || {};
     let { type = "default", url = "" } = extraInit;
 
-    let status = (Number(init.status) || 0) ?? 200;
+    let status = init.status === undefined ? 200 : Number(init.status || 0);
     let statusText = init.statusText ?? "";
     let headers =
       init.headers instanceof Headers
         ? init.headers
         : new Headers(init.headers);
 
-    if (init.status && (status < 200 || status > 599)) {
+    if (init.status !== undefined && (status < 200 || status > 599)) {
       throw new RangeError(
         `The status provided (${init.status}) is outside the range [200, 599]`
       );
@@ -117,7 +117,7 @@ export class Response extends Body.Body implements domTypes.Response {
     this.statusText = statusText;
     this.status = extraInit.status || status;
     this.headers = headers;
-    this.redirected = extraInit.redirected;
+    this.redirected = extraInit.redirected || false;
     this.type = type;
   }
 

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -851,42 +851,50 @@ unitTest(
   }
 );
 
-unitTest(
-  { perms: { net: true } },
-  function fetchResponseConstructorNullBody(): void {
-    const nullBodyStatus = [204, 205, 304];
+unitTest(function fetchResponseConstructorNullBody(): void {
+  const nullBodyStatus = [204, 205, 304];
 
-    for (const status of nullBodyStatus) {
-      try {
-        new Response("deno", { status });
-        fail("Response with null body status cannot have body");
-      } catch (e) {
-        assert(e instanceof TypeError);
-        assertEquals(
-          e.message,
-          "Response with null body status cannot have body"
-        );
-      }
+  for (const status of nullBodyStatus) {
+    try {
+      new Response("deno", { status });
+      fail("Response with null body status cannot have body");
+    } catch (e) {
+      assert(e instanceof TypeError);
+      assertEquals(
+        e.message,
+        "Response with null body status cannot have body"
+      );
     }
   }
-);
+});
 
-unitTest(
-  { perms: { net: true } },
-  function fetchResponseConstructorInvalidStatus(): void {
-    const invalidStatus = [101, 600, 199];
+unitTest(function fetchResponseConstructorInvalidStatus(): void {
+  const invalidStatus = [101, 600, 199, null, "", NaN];
 
-    for (const status of invalidStatus) {
-      try {
-        new Response("deno", { status });
-        fail("Invalid status");
-      } catch (e) {
-        assert(e instanceof RangeError);
-        assertEquals(
-          e.message,
-          `The status provided (${status}) is outside the range [200, 599]`
-        );
-      }
+  for (const status of invalidStatus) {
+    try {
+      // deno-lint-ignore ban-ts-comment
+      // @ts-ignore
+      new Response("deno", { status });
+      fail(`Invalid status: ${status}`);
+    } catch (e) {
+      assert(e instanceof RangeError);
+      assertEquals(
+        e.message,
+        `The status provided (${status}) is outside the range [200, 599]`
+      );
     }
   }
-);
+});
+
+unitTest(function fetchResponseEmptyConstructor(): void {
+  const response = new Response();
+  assertEquals(response.status, 200);
+  assertEquals(response.body, null);
+  assertEquals(response.type, "default");
+  assertEquals(response.url, "");
+  assertEquals(response.redirected, false);
+  assertEquals(response.ok, true);
+  assertEquals(response.bodyUsed, false);
+  assertEquals([...response.headers], []);
+});


### PR DESCRIPTION
Fix bug in `Response` constructor `.status` and set `false` as default value for `.redirected` 