### PR TITLE
test(std/wasi): add std file read and write tests

### DIFF
--- a/std/wasi/testdata/std_fs_file_read.rs
+++ b/std/wasi/testdata/std_fs_file_read.rs
@@ -1,0 +1,16 @@
+// { "preopens": { "/fixture": "fixture" } }
+
+use std::io::Read;
+
+fn main() {
+  let mut file = std::fs::File::open("/fixture/file").unwrap();
+  let mut buffer = [0; 2];
+
+  assert_eq!(file.read(&mut buffer).unwrap(), 2);
+  assert_eq!(&buffer, b"fi");
+
+  assert_eq!(file.read(&mut buffer).unwrap(), 2);
+  assert_eq!(&buffer, b"le");
+
+  assert_eq!(file.read(&mut buffer).unwrap(), 1);
+}

--- a/std/wasi/testdata/std_fs_file_write.rs
+++ b/std/wasi/testdata/std_fs_file_write.rs
@@ -1,0 +1,9 @@
+// { "preopens": { "/scratch": "scratch" }, "files": { "scratch/file": "file" } }
+
+use std::io::Write;
+
+fn main() {
+  let mut file = std::fs::File::create("/scratch/file").unwrap();
+  assert_eq!(file.write(b"fi").unwrap(), 2);
+  assert_eq!(file.write(b"le").unwrap(), 2);
+}


### PR DESCRIPTION
This adds a couple of read and write tests for std::fs::File.