### PR TITLE
fix(std/http): form valid URL if no hostname is passed to serve

### DIFF
--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -239,14 +239,14 @@ export type HTTPOptions = Omit<Deno.ListenOptions, "transport">;
 
 /**
  * Parse addr from string
- *
- *     const addr = "::1:8000";
- *     parseAddrFromString(addr);
- *
- * @param addr Address string
+ *     const addr = "[::1]:8000";
+ *     _parseAddrFromStr(addr);
  */
 export function _parseAddrFromStr(addr: string): HTTPOptions {
   let url: URL;
+  if (addr.startsWith(":")) {
+    addr = `0.0.0.0${addr}`;
+  }
   try {
     url = new URL(`http://${addr}`);
   } catch {
@@ -263,7 +263,7 @@ export function _parseAddrFromStr(addr: string): HTTPOptions {
   }
 
   return {
-    hostname: url.hostname == "" ? "0.0.0.0" : url.hostname,
+    hostname: url.hostname,
     port: url.port === "" ? 80 : Number(url.port),
   };
 }


### PR DESCRIPTION
This isn't causing any problems right now, but once proper host parsing has been implemented, calling `serve()` with a string argument without a hostname, e.g.
```
serve(':80')
```
will throw.

~~The proposed fix prepends a placeholder hostname to `addr` just to get the URL through the parser. The advantage this approach has over defining a default hostname in `_parseAddrFromStr()` is that `Deno.listen()`'s default hostname can be used. I think this is the right way to do this.~~ Doing this separately later.

To summarize: `serve()` intentionally accepts a host string which may be invalid as a URL's host, and that string (with `"http://"` prepended to it) is passed to `URL()`, which is currently too lax to reject it.

Thoughts?