### PR TITLE
feat(cli): add options argument to Buffer.bytes

### DIFF
--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -26,6 +26,10 @@ function copyBytes(src: Uint8Array, dst: Uint8Array, off = 0): number {
   return src.byteLength;
 }
 
+export interface BytesOptions {
+  copy?: boolean;
+}
+
 export class Buffer implements Reader, ReaderSync, Writer, WriterSync {
   #buf: Uint8Array; // contents are the bytes buf[off : len(buf)]
   #off = 0; // read at buf[off], write at buf[buf.byteLength]
@@ -39,9 +43,9 @@ export class Buffer implements Reader, ReaderSync, Writer, WriterSync {
     this.#buf = new Uint8Array(ab);
   }
 
-  bytes(copy = true): Uint8Array {
-    if (copy === true) return this.#buf.slice(this.#off);
-    return this.#buf.subarray(this.#off);
+  bytes(options: BytesOptions = { copy: true }): Uint8Array {
+    if (options.copy === false) return this.#buf.subarray(this.#off);
+    return this.#buf.slice(this.#off);
   }
 
   empty(): boolean {

--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -40,7 +40,7 @@ export class Buffer implements Reader, ReaderSync, Writer, WriterSync {
   }
 
   bytes(copy = true): Uint8Array {
-    if (copy) return this.#buf.slice(this.#off);
+    if (copy === true) return this.#buf.slice(this.#off);
     return this.#buf.subarray(this.#off);
   }
 

--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -26,10 +26,6 @@ function copyBytes(src: Uint8Array, dst: Uint8Array, off = 0): number {
   return src.byteLength;
 }
 
-export interface BytesOptions {
-  copy?: boolean;
-}
-
 export class Buffer implements Reader, ReaderSync, Writer, WriterSync {
   #buf: Uint8Array; // contents are the bytes buf[off : len(buf)]
   #off = 0; // read at buf[off], write at buf[buf.byteLength]
@@ -43,7 +39,7 @@ export class Buffer implements Reader, ReaderSync, Writer, WriterSync {
     this.#buf = new Uint8Array(ab);
   }
 
-  bytes(options: BytesOptions = { copy: true }): Uint8Array {
+  bytes(options: { copy?: boolean } = { copy: true }): Uint8Array {
     if (options.copy === false) return this.#buf.subarray(this.#off);
     return this.#buf.slice(this.#off);
   }

--- a/cli/js/buffer.ts
+++ b/cli/js/buffer.ts
@@ -39,8 +39,9 @@ export class Buffer implements Reader, ReaderSync, Writer, WriterSync {
     this.#buf = new Uint8Array(ab);
   }
 
-  bytes(): Uint8Array {
-    return this.#buf.slice(this.#off);
+  bytes(copy = true): Uint8Array {
+    if (copy) return this.#buf.slice(this.#off);
+    return this.#buf.subarray(this.#off);
   }
 
   empty(): boolean {

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -756,12 +756,6 @@ declare namespace Deno {
    */
   export function isatty(rid: number): boolean;
 
-  export interface BytesOptions {
-    /** Defaults to `true`. Whether a copy or a view of the unread portion of the buffer is returned
-     */
-    copy?: boolean;
-  }
-
   /** A variable-sized buffer of bytes with `read()` and `write()` methods.
    *
    * Deno.Buffer is almost always used with some I/O like files and sockets. It
@@ -785,8 +779,9 @@ declare namespace Deno {
      * `reset()`, or `truncate()`). If `options.copy` is false the slice aliases the buffer content at
      * least until the next buffer modification, so immediate changes to the
      * slice will affect the result of future reads.
+     * @param options Defaults to `{ copy: true }`
      */
-    bytes(options?: BytesOptions): Uint8Array;
+    bytes(options?: { copy?: boolean }): Uint8Array;
     /** Returns whether the unread portion of the buffer is empty. */
     empty(): boolean;
     /** A read only number of bytes of the unread portion of the buffer. */

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -779,7 +779,7 @@ declare namespace Deno {
      * `reset()`, or `truncate()`). The slice aliases the buffer content at
      * least until the next buffer modification, so immediate changes to the
      * slice will affect the result of future reads. */
-    bytes(): Uint8Array;
+    bytes(copy: boolean): Uint8Array;
     /** Returns whether the unread portion of the buffer is empty. */
     empty(): boolean;
     /** A read only number of bytes of the unread portion of the buffer. */

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -776,10 +776,12 @@ declare namespace Deno {
      *
      * The slice is valid for use only until the next buffer modification (that
      * is, only until the next call to a method like `read()`, `write()`,
-     * `reset()`, or `truncate()`). The slice aliases the buffer content at
+     * `reset()`, or `truncate()`). If `copy` is false the slice aliases the buffer content at
      * least until the next buffer modification, so immediate changes to the
-     * slice will affect the result of future reads. */
-    bytes(copy: boolean): Uint8Array;
+     * slice will affect the result of future reads.
+     * @param copy Whether a copy is created or not. Defaults to `true`
+     */
+    bytes(copy?: boolean): Uint8Array;
     /** Returns whether the unread portion of the buffer is empty. */
     empty(): boolean;
     /** A read only number of bytes of the unread portion of the buffer. */

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -756,6 +756,12 @@ declare namespace Deno {
    */
   export function isatty(rid: number): boolean;
 
+  export interface BytesOptions {
+    /** Defaults to `true`. Whether a copy or a view of the unread portion of the buffer is returned
+     */
+    copy?: boolean;
+  }
+
   /** A variable-sized buffer of bytes with `read()` and `write()` methods.
    *
    * Deno.Buffer is almost always used with some I/O like files and sockets. It
@@ -776,12 +782,11 @@ declare namespace Deno {
      *
      * The slice is valid for use only until the next buffer modification (that
      * is, only until the next call to a method like `read()`, `write()`,
-     * `reset()`, or `truncate()`). If `copy` is false the slice aliases the buffer content at
+     * `reset()`, or `truncate()`). If `options.copy` is false the slice aliases the buffer content at
      * least until the next buffer modification, so immediate changes to the
      * slice will affect the result of future reads.
-     * @param copy Whether a copy is created or not. Defaults to `true`
      */
-    bytes(copy?: boolean): Uint8Array;
+    bytes(options?: BytesOptions): Uint8Array;
     /** Returns whether the unread portion of the buffer is empty. */
     empty(): boolean;
     /** A read only number of bytes of the unread portion of the buffer. */

--- a/cli/tests/unit/buffer_test.ts
+++ b/cli/tests/unit/buffer_test.ts
@@ -402,7 +402,8 @@ unitTest(function testWriteAllSync(): void {
 });
 
 unitTest(function testBufferBytesArrayBufferLength(): void {
-  const bytes = new TextEncoder().encode("a");
+  const bufSize = 64 * 1024;
+  const bytes = new TextEncoder().encode("a".repeat(bufSize));
   const reader = new Deno.Buffer();
   Deno.writeAllSync(reader, bytes);
 
@@ -410,6 +411,35 @@ unitTest(function testBufferBytesArrayBufferLength(): void {
   writer.readFromSync(reader);
   const actualBytes = writer.bytes();
 
-  assertEquals(bytes.byteLength, 1);
-  assertEquals(bytes.byteLength, actualBytes.buffer.byteLength);
+  assertEquals(actualBytes.byteLength, bufSize);
+  assertEquals(actualBytes.byteLength, actualBytes.buffer.byteLength);
+});
+
+unitTest(function testBufferBytesCopyFalse(): void {
+  const bufSize = 64 * 1024;
+  const bytes = new TextEncoder().encode("a".repeat(bufSize));
+  const reader = new Deno.Buffer();
+  Deno.writeAllSync(reader, bytes);
+
+  const writer = new Deno.Buffer();
+  writer.readFromSync(reader);
+  const actualBytes = writer.bytes(false);
+
+  assertEquals(actualBytes.byteLength, bufSize);
+  assert(actualBytes.buffer.byteLength > actualBytes.byteLength);
+});
+
+unitTest(function testBufferBytesCopyFalseGrowExactBytes(): void {
+  const bufSize = 64 * 1024;
+  const bytes = new TextEncoder().encode("a".repeat(bufSize));
+  const reader = new Deno.Buffer();
+  Deno.writeAllSync(reader, bytes);
+
+  const writer = new Deno.Buffer();
+  writer.grow(bufSize);
+  writer.readFromSync(reader);
+  const actualBytes = writer.bytes(false);
+
+  assertEquals(actualBytes.byteLength, bufSize);
+  assertEquals(actualBytes.buffer.byteLength, actualBytes.byteLength);
 });


### PR DESCRIPTION
Add `copy = true` argument to `Buffer.bytes` method.

In most cases, the underlying `ArrayBuffer` size is greater than `buf.length`, reason why `.slice` (#6511)  it's used to create a copy where `ArrayBuffer.byteLength === Uint8Array.byteLength`, but sometimes you don't need a copy and prefer the speed of `.subarray` (either because you won't use the ArrayBuffer, or because you know they're the same length)

```
buf.grow(1024);
// ... write exactly 1024 bytes
const bytes = buf.bytes({ copy: false });
// bytes.buffer.byteLength === bytes.byteLength
```