### PR TITLE
Fix for issue #6685: --allow-net=:8080 broken

### DIFF
--- a/std/http/server.ts
+++ b/std/http/server.ts
@@ -263,7 +263,7 @@ export function _parseAddrFromStr(addr: string): HTTPOptions {
   }
 
   return {
-    hostname: url.hostname,
+    hostname: url.hostname == "" ? "0.0.0.0" : url.hostname,
     port: url.port === "" ? 80 : Number(url.port),
   };
 }

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -665,5 +665,6 @@ Deno.test({
   fn: (): void => {
     const addr = _parseAddrFromStr(":80");
     assertEquals(addr.port, 80);
+    assertEquals(addr.hostname, "0.0.0.0")
   },
 });

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -665,6 +665,6 @@ Deno.test({
   fn: (): void => {
     const addr = _parseAddrFromStr(":80");
     assertEquals(addr.port, 80);
-    assertEquals(addr.hostname, "0.0.0.0")
+    assertEquals(addr.hostname, "0.0.0.0");
   },
 });


### PR DESCRIPTION
We were not setting the default hostname (0.0.0.0) when parsing the address from a string.

