### PR TITLE
fix(std/io): Fix types on fromStreamWriter and fromStreamReader

### DIFF
--- a/std/io/streams.ts
+++ b/std/io/streams.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 export function fromStreamWriter(
-  streamWriter: WritableStreamDefaultWriter<Uint8Array>
+  streamWriter: WritableStream<Uint8Array>
 ): Deno.Writer {
   return {
     async write(p: Uint8Array): Promise<number> {
@@ -13,7 +13,7 @@ export function fromStreamWriter(
 }
 
 export function fromStreamReader(
-  streamReader: ReadableStreamDefaultReader<Uint8Array>
+  streamReader: ReadableStream<Uint8Array>
 ): Deno.Reader {
   const buffer = new Deno.Buffer();
 


### PR DESCRIPTION
The generic is `ReadableStream` and not `ReadableStreamDefaultReader`.