### PR TITLE
fix std/testing/asserts.ts #6705

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -27,7 +27,7 @@ export function _format(v: unknown): string {
         trailingComma: true,
         compact: false,
         iterableLimit: Infinity,
-      })
+      } as Deno.InspectOptions)
     : String(v);
   if (typeof v == "string") {
     string = `"${string.replace(/(?=["\\])/g, "\\")}"`;


### PR DESCRIPTION
Fixed type error that does not allow passing tests using std/testing/asserts.ts

**Currently showing this error:**
![image](https://user-images.githubusercontent.com/17011087/87253205-e22f7980-c43e-11ea-8669-332168903df3.png)

With the proposed change the error message disappears.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
