### PR TITLE
fix(Deno.ppid): improve error message when --unstable is missing

### DIFF
--- a/cli/js/diagnostics_util.ts
+++ b/cli/js/diagnostics_util.ts
@@ -64,15 +64,19 @@ const unstableDenoGlobalProperties = [
   "Permissions",
   "PermissionStatus",
   "hostname",
+  "ppid",
 ];
 
 function transformMessageText(messageText: string, code: number): string {
-  if (code === 2339) {
+  if (code === 2339 || code === 2551) {
     const property = messageText
       .replace(/^Property '/, "")
-      .replace(/' does not exist on type 'typeof Deno'\.$/, "");
+      .replace(/' does not exist on type 'typeof Deno'\./, "")
+      .replace(/ Did you mean '.+'\?$/, "");
+
     if (
-      messageText.endsWith("on type 'typeof Deno'.") &&
+      (messageText.endsWith("on type 'typeof Deno'.") ||
+        /on type 'typeof Deno'\. Did you mean '.+'\?$/.test(messageText)) &&
       unstableDenoGlobalProperties.includes(property)
     ) {
       return `${messageText} 'Deno.${property}' is an unstable API. Did you forget to run with the '--unstable' flag?`;

--- a/cli/js/diagnostics_util.ts
+++ b/cli/js/diagnostics_util.ts
@@ -88,13 +88,13 @@ function transformMessageText(messageText: string, code: number): string {
         .replace(/^Property '/, "")
         .replace(/' does not exist on type 'typeof Deno'\./, "")
         .replace(suggestionMessagePattern, "");
-      const match = messageText.match(suggestionMessagePattern);
+      const suggestion = messageText.match(suggestionMessagePattern);
       const replacedMessageText = messageText.replace(
         suggestionMessagePattern,
         ""
       );
-      if (match && unstableDenoGlobalProperties.includes(property)) {
-        const suggestedProperty = match[1];
+      if (suggestion && unstableDenoGlobalProperties.includes(property)) {
+        const suggestedProperty = suggestion[1];
         return `${replacedMessageText} 'Deno.${property}' is an unstable API. Did you forget to run with the '--unstable' flag, or did you mean '${suggestedProperty}'?`;
       }
       break;

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2073,6 +2073,12 @@ itest!(unstable_enabled_js {
   output: "unstable_enabled_js.out",
 });
 
+itest!(unstable_disabled_ts2551 {
+  args: "run --reload unstable_ts2551.ts",
+  exit_code: 1,
+  output: "unstable_disabled_ts2551.out",
+});
+
 itest!(_053_import_compression {
   args: "run --quiet --reload --allow-net 053_import_compression/main.ts",
   output: "053_import_compression.out",

--- a/cli/tests/unstable_disabled_ts2551.out
+++ b/cli/tests/unstable_disabled_ts2551.out
@@ -1,0 +1,10 @@
+[WILDCARD]
+error: TS2551 [ERROR]: Property 'ppid' does not exist on type 'typeof Deno'. Did you mean 'pid'? 'Deno.ppid' is an unstable API. Did you forget to run with the '--unstable' flag?
+console.log(Deno.ppid);
+                 ~~~~
+    at [WILDCARD]cli/tests/unstable_ts2551.ts:1:18
+
+    'pid' is declared here.
+      export const pid: number;
+                   ~~~
+        at asset:///lib.deno.ns.d.ts:[WILDCARD]

--- a/cli/tests/unstable_disabled_ts2551.out
+++ b/cli/tests/unstable_disabled_ts2551.out
@@ -1,5 +1,5 @@
 [WILDCARD]
-error: TS2551 [ERROR]: Property 'ppid' does not exist on type 'typeof Deno'. Did you mean 'pid'? 'Deno.ppid' is an unstable API. Did you forget to run with the '--unstable' flag?
+error: TS2551 [ERROR]: Property 'ppid' does not exist on type 'typeof Deno'. 'Deno.ppid' is an unstable API. Did you forget to run with the '--unstable' flag, or did you mean 'pid'?
 console.log(Deno.ppid);
                  ~~~~
     at [WILDCARD]cli/tests/unstable_ts2551.ts:1:18

--- a/cli/tests/unstable_ts2551.ts
+++ b/cli/tests/unstable_ts2551.ts
@@ -1,0 +1,1 @@
+console.log(Deno.ppid);


### PR DESCRIPTION
**test.ts**
```typescript
console.log(Deno.ppid)
```

**Before this fix:**
```shell
$ cargo run -- run test.ts
error: TS2551 [ERROR]: Property 'ppid' does not exist on type 'typeof Deno'. Did you mean 'pid'?
console.log(Deno.ppid);
                 ~~~~
    at file:///home/uki00a/work/test.ts:1:18

    'pid' is declared here.
      export const pid: number;
                   ~~~
        at asset:///lib.deno.ns.d.ts:46:16
```

**After this fix:**
```shell
$ cargo run -- run test.ts
error: TS2551 [ERROR]: Property 'ppid' does not exist on type 'typeof Deno'. 'Deno.ppid' is an unstable API. Did you forget to run with the '--unstable' flag, or did you mean 'pid'?
console.log(Deno.ppid);
                 ~~~~
    at file:///home/uki00a/work/test.ts:1:18

    'pid' is declared here.
      export const pid: number;
                   ~~~
        at asset:///lib.deno.ns.d.ts:124:16
```