### PR TITLE
test: ignore max buffer tests

### DIFF
--- a/cli/tests/unit/buffer_test.ts
+++ b/cli/tests/unit/buffer_test.ts
@@ -17,12 +17,7 @@ const N = 100;
 let testBytes: Uint8Array | null;
 let testString: string | null;
 
-let ignoreMaxSizeTests = false;
-try {
-  new ArrayBuffer(MAX_SIZE);
-} catch (e) {
-  ignoreMaxSizeTests = true;
-}
+const ignoreMaxSizeTests = true;
 
 function init(): void {
   if (testBytes == null) {


### PR DESCRIPTION
Fixes #6731 

Disable MAX_SIZE buffer tests until we come up with a better solution for testing MAX_SIZE logic