### PR TITLE
Make `Dino.bundle()` work like `dino bundle`?

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -302,9 +302,10 @@ impl SourceFileFetcher {
     permissions: &Permissions,
   ) -> Result<SourceFile, ErrBox> {
     let filepath = module_url.to_file_path().map_err(|()| {
-      ErrBox::from(OpError::uri_error(
-        "File URL contains invalid path".to_owned(),
-      ))
+      ErrBox::from(OpError::uri_error(format!(
+        "File URL contains invalid path: {:?}",
+        module_url
+      )))
     })?;
 
     permissions.check_read(&filepath)?;

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -8,6 +8,7 @@ extern crate tempfile;
 use test_util as util;
 
 use futures::prelude::*;
+use std::fs;
 use std::io::{BufRead, Write};
 use std::process::Command;
 use tempfile::TempDir;
@@ -966,7 +967,10 @@ fn runtime_bundle_import_map() {
       }}
       ",
       if cfg!(windows) { "/" } else { "" },
-      import.to_str().expect("non-unicode in file path"),
+      fs::canonicalize(&import)
+        .expect("canonicalize failed")
+        .to_str()
+        .expect("non-unicode in file path"),
     ),
   )
   .expect("error writing file");

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -958,14 +958,15 @@ fn runtime_bundle_import_map() {
     &test,
     format!(
       "
-      const [diagnostics, _] = await Deno.bundle(\"file://{}\")
+      const [diagnostics, _] = await Deno.bundle(\"file://{}{}\")
 
       if (diagnostics != null) {{
         diagnostics.forEach(d => console.log(d))
         Deno.exit(1)
       }}
       ",
-      import.to_str().expect("non-unicode in file path")
+      if cfg!(windows) { "/" } else { "" },
+      import.to_str().expect("non-unicode in file path"),
     ),
   )
   .expect("error writing file");

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -956,14 +956,13 @@ fn runtime_bundle_import_map() {
     &test,
     format!(
       "
-      const [diagnostics, _] = await Deno.bundle(\"file://{}{}/{}\")
+      const [diagnostics, _] = await Deno.bundle(\"{}/{}\")
 
       if (diagnostics != null) {{
         diagnostics.forEach(d => console.log(d))
         Deno.exit(1)
       }}
       ",
-      if cfg!(windows) { "/" } else { "" },
       util::root_path()
         .to_str()
         .expect("non-unicode in file path"),

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -958,7 +958,7 @@ fn runtime_bundle_import_map() {
     &test,
     format!(
       "
-      const [diagnostics, _] = await Deno.bundle(\"{}\")
+      const [diagnostics, _] = await Deno.bundle(\"file://{}\")
 
       if (diagnostics != null) {{
         diagnostics.forEach(d => console.log(d))

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -8,7 +8,6 @@ extern crate tempfile;
 use test_util as util;
 
 use futures::prelude::*;
-use std::fs;
 use std::io::{BufRead, Write};
 use std::process::Command;
 use tempfile::TempDir;
@@ -950,16 +949,14 @@ fn bundle_import_map() {
 
 #[test]
 fn runtime_bundle_import_map() {
-  let import = util::root_path().join("cli/tests/bundle_im.ts");
   let import_map_path = util::root_path().join("cli/tests/bundle_im.json");
-  assert!(import.is_file());
   let t = TempDir::new().expect("tempdir fail");
   let test = t.path().join("test.js");
   std::fs::write(
     &test,
     format!(
       "
-      const [diagnostics, _] = await Deno.bundle(\"file://{}{}\")
+      const [diagnostics, _] = await Deno.bundle(\"file://{}{}/{}\")
 
       if (diagnostics != null) {{
         diagnostics.forEach(d => console.log(d))
@@ -967,10 +964,10 @@ fn runtime_bundle_import_map() {
       }}
       ",
       if cfg!(windows) { "/" } else { "" },
-      fs::canonicalize(&import)
-        .expect("canonicalize failed")
+      util::root_path()
         .to_str()
         .expect("non-unicode in file path"),
+      "cli/tests/bundle_im.ts",
     ),
   )
   .expect("error writing file");

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -1115,14 +1115,15 @@ async fn create_runtime_module_graph(
   root_name: &str,
   sources: &Option<HashMap<String, String>>,
   maybe_options: &Option<String>,
+  is_bundle: bool,
 ) -> Result<(Vec<String>, ModuleGraph), OpError> {
   let mut root_names = vec![];
   let mut module_graph_loader = ModuleGraphLoader::new(
     global_state.file_fetcher.clone(),
-    None,
+    global_state.maybe_import_map.clone(),
     permissions,
     false,
-    false,
+    is_bundle,
   );
 
   if let Some(s_map) = sources {
@@ -1174,6 +1175,7 @@ pub async fn runtime_compile(
     root_name,
     sources,
     maybe_options,
+    false,
   )
   .await?;
   let module_graph_json =
@@ -1222,6 +1224,7 @@ pub async fn runtime_bundle(
     root_name,
     sources,
     maybe_options,
+    true,
   )
   .await?;
   let module_graph_json =


### PR DESCRIPTION
This admittedly falls at least a little into the "I'm holding it wrong" category of use-cases, but in trying to see what it would be like to turn `dino` into a quick-and-dirty dev bundler I found that `dino bundle` can handle two things that `Dino.bundle()` won't:

1. Import maps
2. Dynamic imports

This change would bring the two closer together in terms of capability, if that's desirable.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
