### PR TITLE
Remove unused property of StringReader

### DIFF
--- a/std/io/readers.ts
+++ b/std/io/readers.ts
@@ -7,7 +7,7 @@ import { encode } from "../encoding/utf8.ts";
 
 /** Reader utility for strings */
 export class StringReader extends Deno.Buffer {
-  constructor(private readonly s: string) {
+  constructor(s: string) {
     super(encode(s).buffer);
   }
 }


### PR DESCRIPTION
* Remove unused property of StringReader.
  - Without this change, `strict: true` outputs error below.
  -  `s` is needed for constructor only.

```
error: TS6138 [ERROR]: Property 's' is declared but its value is never read.
  constructor(private readonly s: string) {
```

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
