### PR TITLE
fix: panic for runtime error in TS compiler

### DIFF
--- a/cli/tests/compiler_js_error.ts
+++ b/cli/tests/compiler_js_error.ts
@@ -1,0 +1,1 @@
+Deno.compile("main.js", { "main.js": "console.log(foo);" });

--- a/cli/tests/compiler_js_error.ts.out
+++ b/cli/tests/compiler_js_error.ts.out
@@ -1,0 +1,7 @@
+Check [WILDCARD]compiler_js_error.ts
+error: Uncaught Error: Error in TS compiler:
+Uncaught AssertionError: Unexpected skip of the emit.
+[WILDCARD]
+    at unwrapResponse ($deno$/ops/dispatch_json.ts:[WILDCARD])
+    at Object.sendAsync ($deno$/ops/dispatch_json.ts:[WILDCARD])
+    at async Object.compile ($deno$/compiler_api.ts:[WILDCARD])

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2188,6 +2188,12 @@ itest!(deno_lint_glob {
   exit_code: 1,
 });
 
+itest!(compiler_js_error {
+  args: "run --unstable compiler_js_error.ts",
+  output: "compiler_js_error.ts.out",
+  exit_code: 1,
+});
+
 #[test]
 fn cafile_env_fetch() {
   use url::Url;

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -1097,27 +1097,8 @@ async fn execute_in_same_thread(
 
         let buf = match event {
           WorkerEvent::Message(buf) => Ok(buf),
-          WorkerEvent::Error(error) => {
-            let e = match error.downcast::<JSError>() {
-              Ok(js_error) => {
-                let msg = format!("Error in TS compiler:\n{}", js_error);
-                OpError::other(msg).into()
-              }
-              Err(error) => error,
-            };
-            Err(e)
-          }
-          WorkerEvent::TerminalError(error) => {
-            eprintln!("terminal error {:#?}", error);
-            let e = match error.downcast::<JSError>() {
-              Ok(js_error) => {
-                let msg = format!("Error in TS compiler:\n{}", js_error);
-                OpError::other(msg).into()
-              }
-              Err(error) => error,
-            };
-            Err(e)
-          }
+          WorkerEvent::Error(error) => Err(error),
+          WorkerEvent::TerminalError(error) => Err(error),
         }?;
         return Ok(buf);
       }
@@ -1180,6 +1161,18 @@ async fn create_runtime_module_graph(
   Ok((root_names, module_graph_loader.get_graph()))
 }
 
+/// Because TS compiler can raise runtime error, we need to
+/// manually convert formatted JSError into and OpError.
+fn js_error_to_op_error(error: ErrBox) -> OpError {
+  match error.downcast::<JSError>() {
+    Ok(js_error) => {
+      let msg = format!("Error in TS compiler:\n{}", js_error);
+      OpError::other(msg)
+    }
+    Err(error) => error.into(),
+  }
+}
+
 /// This function is used by `Deno.compile()` API.
 pub async fn runtime_compile(
   global_state: GlobalState,
@@ -1213,7 +1206,9 @@ pub async fn runtime_compile(
 
   let compiler = global_state.ts_compiler.clone();
 
-  let msg = execute_in_same_thread(global_state, permissions, req_msg).await?;
+  let msg = execute_in_same_thread(global_state, permissions, req_msg)
+    .await
+    .map_err(js_error_to_op_error)?;
   let json_str = std::str::from_utf8(&msg).unwrap();
 
   let response: RuntimeCompileResponse = serde_json::from_str(json_str)?;
@@ -1259,7 +1254,9 @@ pub async fn runtime_bundle(
   .into_boxed_str()
   .into_boxed_bytes();
 
-  let msg = execute_in_same_thread(global_state, permissions, req_msg).await?;
+  let msg = execute_in_same_thread(global_state, permissions, req_msg)
+    .await
+    .map_err(js_error_to_op_error)?;
   let json_str = std::str::from_utf8(&msg).unwrap();
   let _response: RuntimeBundleResponse = serde_json::from_str(json_str)?;
   // We're returning `Ok()` instead of `Err()` because it's not runtime
@@ -1284,7 +1281,9 @@ pub async fn runtime_transpile(
   .into_boxed_str()
   .into_boxed_bytes();
 
-  let msg = execute_in_same_thread(global_state, permissions, req_msg).await?;
+  let msg = execute_in_same_thread(global_state, permissions, req_msg)
+    .await
+    .map_err(js_error_to_op_error)?;
   let json_str = std::str::from_utf8(&msg).unwrap();
   let v = serde_json::from_str::<serde_json::Value>(json_str)
     .expect("Error decoding JSON string.");


### PR DESCRIPTION
This commit fixes panics that occurred when runtime TS compiler
APIs raised runtime error.

Fixes https://github.com/denoland/deno/issues/6747
Fixes https://github.com/denoland/deno/issues/6423
Fixes https://github.com/denoland/deno/issues/6687