### PR TITLE
fix(cli/js/web): IPv6 hostname should be compressed

### DIFF
--- a/cli/js/web/url.ts
+++ b/cli/js/web/url.ts
@@ -565,7 +565,8 @@ function encodeHostname(s: string, isSpecial = true): string {
     if (!s.match(/^\[[0-9A-Fa-f.:]{2,}\]$/)) {
       throw new TypeError("Invalid hostname.");
     }
-    return s.toLowerCase();
+    // IPv6 address compress
+    return s.toLowerCase().replace(/\b:?(?:0+:?){2,}/, "::");
   }
 
   let result = s;

--- a/cli/tests/unit/url_test.ts
+++ b/cli/tests/unit/url_test.ts
@@ -44,6 +44,8 @@ unitTest(function urlHostnameParsing(): void {
   assertEquals(new URL("http://[::1]").hostname, "[::1]");
   assertEquals(new URL("file://[::1]").hostname, "[::1]");
   assertEquals(new URL("abcd://[::1]").hostname, "[::1]");
+  assertEquals(new URL("http://[0:f:0:0:f:f:0:0]").hostname, "[0:f::f:f:0:0]");
+  assertEquals(new URL("http://[0::5:6:7:8]").hostname, "[::5:6:7:8]");
 
   // Forbidden host code point.
   assertThrows(() => new URL("http:// a"), TypeError, "Invalid URL.");


### PR DESCRIPTION
IPv6 hostname is compressed in the browser：
```
new URL("http://[0:f:0:0:f:f:0:0]").hostname
// "[0:f::f:f:0:0]"
```

So，IPv6 hostname should be compressed in Deno.