### PR TITLE
chore: Update third party dprint to fix "too many open files" error on some Macs

### DIFF
--- a/.dprintrc.json
+++ b/.dprintrc.json
@@ -13,6 +13,7 @@
   "excludes": [
     ".cargo_home",
     "deno_typescript/typescript",
+    "gh-pages",
     "std/**/testdata",
     "std/**/vendor",
     "std/node_modules",


### PR DESCRIPTION
1. Fixes this error that was occurring on some Macs (I couldn't reproduce it on my Mac though).
    ```
    Error formatting ./std/node/_fs/_fs_close.ts. Message: Too many open files (os error 24)
    Error formatting ./cli/tests/unit/read_link_test.ts. Message: Too many open files (os error 24)
    Error formatting ./std/node/_fs/_fs_close_test.ts. Message: Too many open files (os error 24)
    Error formatting ./std/node/events_test.ts. Message: Too many open files (os error 24)
    Error formatting ./std/node/_fs/_fs_chmod.ts. Message: Too many open files (os error 24)
    ```
2. Ignores the gh-pages directory. I opened https://github.com/dprint/dprint/issues/261, but I'm not sure how or if I want to implement that.

---

In other news, there's a new `./third_party/prebuilt/mac/dprint output-format-times` command that lists how long it takes to format each file. Here's the files that have above 40ms format times for me:

```
42ms - ./std\encoding\toml.ts
45ms - ./std\hash\sha1.ts
46ms - ./docs\contributing\style_guide.md
46ms - ./std\path\_globrex_test.ts
46ms - ./cli\tests\unit\fetch_test.ts
47ms - ./cli\js\buffer.ts
54ms - ./cli\tests\unit\console_test.ts
54ms - ./std\encoding\_yaml\dumper\dumper.ts
56ms - ./std\hash\sha256.ts
65ms - ./std\wasi\snapshot_preview1.ts
78ms - ./std\path\win32.ts
79ms - ./cli\js\web\console.ts
95ms - ./Releases.md
97ms - ./std\fmt\printf_test.ts
122ms - ./cli\js\lib.deno.shared_globals.d.ts
147ms - ./std\node\module.ts
227ms - ./std\encoding\_yaml\loader\loader.ts
252ms - ./cli\js\compiler.ts
314ms - ./std\hash\_sha3\keccakf.ts
426ms - ./cli\js\web\streams\internals.ts
```

I have some ideas for some analysis tools to understand why it takes a long time to format some files, but those will take a bit of time to create and it's not a priority for me at the moment.