### PR TITLE
fix(std/encoding/toml): could not parse strings with apostrophes/semicolons

### DIFF
--- a/std/encoding/testdata/string.toml
+++ b/std/encoding/testdata/string.toml
@@ -28,3 +28,6 @@ trimmed in raw strings.
    All other whitespace
    is preserved.
 '''
+
+withApostrophe = "What if it's not?"
+withSemicolon = "const message = 'hello world';"

--- a/std/encoding/toml.ts
+++ b/std/encoding/toml.ts
@@ -263,20 +263,20 @@ class Parser {
     const isString = dataString.startsWith('"') || dataString.startsWith("'");
     if (isString) {
       const [quote] = dataString;
-      let nextIndexOfQuote = 0;
+      let indexOfNextQuote = 0;
       while (
-        (nextIndexOfQuote = dataString.indexOf(quote, nextIndexOfQuote + 1)) !==
+        (indexOfNextQuote = dataString.indexOf(quote, indexOfNextQuote + 1)) !==
           -1
       ) {
-        const isEscaped = dataString[nextIndexOfQuote - 1] === "\\";
+        const isEscaped = dataString[indexOfNextQuote - 1] === "\\";
         if (!isEscaped) {
           break;
         }
       }
-      if (nextIndexOfQuote === -1) {
+      if (indexOfNextQuote === -1) {
         throw new TOMLError("imcomplete string literal");
       }
-      const endOfString = nextIndexOfQuote + 1;
+      const endOfString = indexOfNextQuote + 1;
       return dataString.slice(0, endOfString);
     }
 

--- a/std/encoding/toml.ts
+++ b/std/encoding/toml.ts
@@ -2,6 +2,8 @@
 import { deepAssign } from "../_util/deep_assign.ts";
 import { assert } from "../_util/assert.ts";
 
+class TOMLError extends Error {}
+
 class KeyValuePair {
   constructor(public key: string, public value: unknown) {}
 }
@@ -230,10 +232,7 @@ class Parser {
     if (invalidArr) {
       dataString = dataString.replace(/,]/g, "]");
     }
-    const m = /(?:\'|\[|{|\").*(?:\'|\]|\"|})\s*[^#]/g.exec(dataString);
-    if (m) {
-      dataString = m[0].trim();
-    }
+    dataString = this._stripComment(dataString);
     if (dataString[0] === "{" && dataString[dataString.length - 1] === "}") {
       const reg = /([a-zA-Z0-9-_\.]*) (=)/gi;
       let result;
@@ -259,6 +258,34 @@ class Parser {
       dataString = dataString.replace(`\\n'`, `'`);
     }
     return eval(dataString);
+  }
+  private _stripComment(dataString: string): string {
+    const isString = dataString.startsWith('"') || dataString.startsWith("'");
+    if (isString) {
+      const [quote] = dataString;
+      let nextIndexOfQuote = 0;
+      while (
+        (nextIndexOfQuote = dataString.indexOf(quote, nextIndexOfQuote + 1)) !==
+          -1
+      ) {
+        const isEscaped = dataString[nextIndexOfQuote - 1] === "\\";
+        if (!isEscaped) {
+          break;
+        }
+      }
+      if (nextIndexOfQuote === -1) {
+        throw new TOMLError("imcomplete string literal");
+      }
+      const endOfString = nextIndexOfQuote + 1;
+      return dataString.slice(0, endOfString);
+    }
+
+    const m = /(?:|\[|{|).*(?:|\]||})\s*[^#]/g.exec(dataString);
+    if (m) {
+      return m[0].trim();
+    } else {
+      return dataString;
+    }
   }
   _isLocalTime(str: string): boolean {
     const reg = /(\d{2}):(\d{2}):(\d{2})/;

--- a/std/encoding/toml_test.ts
+++ b/std/encoding/toml_test.ts
@@ -29,6 +29,8 @@ Deno.test({
         str6: "The quick brown\nfox jumps over\nthe lazy dog.",
         lines: "The first newline is\ntrimmed in raw strings.\n   All other " +
           "whitespace\n   is preserved.",
+        withApostrophe: "What if it's not?",
+        withSemicolon: `const message = 'hello world';`,
       },
     };
     const actual = parseFile(path.join(testFilesDir, "string.toml"));


### PR DESCRIPTION
This PR fixes #6776.

## Cause

This bug is caused by a regular expression used to delete TOML comments.
Before this fix, TOML comments were stripped down by the following code:

```typescript
    const m = /(?:\'|\[|{|\").*(?:\'|\]|\"|})\s*[^#]/g.exec(dataString);
    if (m) {
      dataString = m[0].trim();
    }
```

However, this regular expression does not properly handle strings containing apostrophes/semicolons:

```javascript
/(?:\'|\[|{|\").*(?:\'|\]|\"|})\s*[^#]/g.exec(`"What if it's not?"`); // => [ `"What if it's` ]

/(?:\'|\[|{|\").*(?:\'|\]|\"|})\s*[^#]/g.exec(`"const message = 'hello world';"`); // => [ `"const message = 'hello world';` ]
```