### PR TITLE
fix(Deno.watchFs): Ignore polling errors caused by return()

### DIFF
--- a/cli/rt/40_fs_events.js
+++ b/cli/rt/40_fs_events.js
@@ -2,6 +2,7 @@
 
 ((window) => {
   const { sendSync, sendAsync } = window.__bootstrap.dispatchJson;
+  const { errors } = window.__bootstrap.errors;
   const { close } = window.__bootstrap.resources;
 
   class FsWatcher {
@@ -16,10 +17,17 @@
       return this.#rid;
     }
 
-    next() {
-      return sendAsync("op_fs_events_poll", {
-        rid: this.rid,
-      });
+    async next() {
+      try {
+        return await sendAsync("op_fs_events_poll", {
+          rid: this.rid,
+        });
+      } catch (error) {
+        if (error instanceof errors.BadResource) {
+          return { value: undefined, done: true };
+        }
+        throw error;
+      }
     }
 
     return(value) {

--- a/cli/tests/unit/fs_events_test.ts
+++ b/cli/tests/unit/fs_events_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { unitTest, assert, assertThrows } from "./test_util.ts";
+import { unitTest, assert, assertEquals, assertThrows } from "./test_util.ts";
 
 // TODO(ry) Add more tests to specify format.
 
@@ -58,5 +58,23 @@ unitTest(
     assert(events[0].paths[0].includes(testDir));
     assert(events[1].kind == "create" || events[1].kind == "modify");
     assert(events[1].paths[0].includes(testDir));
+  },
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function watchFsReturn(): Promise<void> {
+    const testDir = await Deno.makeTempDir();
+    const iter = Deno.watchFs(testDir);
+
+    // Asynchronously loop events.
+    const eventsPromise = getTwoEvents(iter);
+
+    // Close the watcher.
+    await iter.return!();
+
+    // Expect zero events.
+    const events = await eventsPromise;
+    assertEquals(events, []);
   },
 );


### PR DESCRIPTION
Fixes `watchFs(...).return()`.

Same pattern used in `Deno.Listener`: https://github.com/denoland/deno/blob/6e34f6a7cca11ba245f0b55c3b956b59948b37b7/cli/js/net.ts#L71-L78