### PR TITLE
fix(std/fs): Make writeJson func create a POSIX compliant file

### DIFF
--- a/std/fs/write_json.ts
+++ b/std/fs/write_json.ts
@@ -1,10 +1,27 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { EOL, format } from "./eol.ts";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Replacer = (key: string, value: any) => any;
 
 export interface WriteJsonOptions {
   spaces?: number | string;
   replacer?: Array<number | string> | Replacer;
+}
+
+function createJsonWithEol(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  object: any,
+  options: WriteJsonOptions,
+): string {
+  const contentRaw = JSON.stringify(
+    object,
+    options.replacer as string[],
+    options.spaces,
+  );
+
+  const eol = Deno.build.os === "windows" ? EOL.CRLF : EOL.LF;
+  return format(`${contentRaw}\n`, eol);
 }
 
 /* Writes an object to a JSON file. */
@@ -17,11 +34,7 @@ export async function writeJson(
   let contentRaw = "";
 
   try {
-    contentRaw = JSON.stringify(
-      object,
-      options.replacer as string[],
-      options.spaces,
-    );
+    contentRaw = createJsonWithEol(object, options);
   } catch (err) {
     err.message = `${filePath}: ${err.message}`;
     throw err;
@@ -40,11 +53,7 @@ export function writeJsonSync(
   let contentRaw = "";
 
   try {
-    contentRaw = JSON.stringify(
-      object,
-      options.replacer as string[],
-      options.spaces,
-    );
+    contentRaw = createJsonWithEol(object, options);
   } catch (err) {
     err.message = `${filePath}: ${err.message}`;
     throw err;

--- a/std/fs/write_json_test.ts
+++ b/std/fs/write_json_test.ts
@@ -25,7 +25,7 @@ Deno.test("writeJsonIfNotExists", async function (): Promise<void> {
 
   await Deno.remove(notExistsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
+  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
 });
 
 Deno.test("writeJsonIfExists", async function (): Promise<void> {
@@ -46,7 +46,7 @@ Deno.test("writeJsonIfExists", async function (): Promise<void> {
 
   await Deno.remove(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
+  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
 });
 
 Deno.test("writeJsonIfExistsAnInvalidJson", async function (): Promise<void> {
@@ -71,7 +71,7 @@ Deno.test("writeJsonIfExistsAnInvalidJson", async function (): Promise<void> {
 
   await Deno.remove(existsInvalidJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
+  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
 });
 
 Deno.test("writeJsonWithSpaces", async function (): Promise<void> {
@@ -93,7 +93,7 @@ Deno.test("writeJsonWithSpaces", async function (): Promise<void> {
 
   await Deno.remove(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{\n  "a": "1"\n}`);
+  assertEquals(new TextDecoder().decode(content), `{\n  "a": "1"\n}\n`);
 });
 
 Deno.test("writeJsonWithReplacer", async function (): Promise<void> {
@@ -121,7 +121,7 @@ Deno.test("writeJsonWithReplacer", async function (): Promise<void> {
 
   await Deno.remove(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
+  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
 });
 
 Deno.test("writeJsonSyncIfNotExists", function (): void {
@@ -140,7 +140,7 @@ Deno.test("writeJsonSyncIfNotExists", function (): void {
 
   Deno.removeSync(notExistsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
+  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
 });
 
 Deno.test("writeJsonSyncIfExists", function (): void {
@@ -161,7 +161,7 @@ Deno.test("writeJsonSyncIfExists", function (): void {
 
   Deno.removeSync(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
+  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
 });
 
 Deno.test("writeJsonSyncIfExistsAnInvalidJson", function (): void {
@@ -186,7 +186,7 @@ Deno.test("writeJsonSyncIfExistsAnInvalidJson", function (): void {
 
   Deno.removeSync(existsInvalidJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
+  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
 });
 
 Deno.test("writeJsonWithSpaces", function (): void {
@@ -208,7 +208,7 @@ Deno.test("writeJsonWithSpaces", function (): void {
 
   Deno.removeSync(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{\n  "a": "1"\n}`);
+  assertEquals(new TextDecoder().decode(content), `{\n  "a": "1"\n}\n`);
 });
 
 Deno.test("writeJsonWithReplacer", function (): void {
@@ -239,5 +239,5 @@ Deno.test("writeJsonWithReplacer", function (): void {
 
   Deno.removeSync(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}`);
+  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
 });

--- a/std/fs/write_json_test.ts
+++ b/std/fs/write_json_test.ts
@@ -4,10 +4,12 @@ import {
   assertThrowsAsync,
   assertThrows,
 } from "../testing/asserts.ts";
+import { EOL, format } from "./eol.ts";
 import * as path from "../path/mod.ts";
 import { writeJson, writeJsonSync } from "./write_json.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
+const platformEol = Deno.build.os === "windows" ? EOL.CRLF : EOL.LF;
 
 Deno.test("writeJsonIfNotExists", async function (): Promise<void> {
   const notExistsJsonFile = path.join(testdataDir, "file_not_exists.json");
@@ -25,7 +27,8 @@ Deno.test("writeJsonIfNotExists", async function (): Promise<void> {
 
   await Deno.remove(notExistsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
+  const expected = format(`{"a":"1"}\n`, platformEol);
+  assertEquals(new TextDecoder().decode(content), expected);
 });
 
 Deno.test("writeJsonIfExists", async function (): Promise<void> {
@@ -46,7 +49,8 @@ Deno.test("writeJsonIfExists", async function (): Promise<void> {
 
   await Deno.remove(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
+  const expected = format(`{"a":"1"}\n`, platformEol);
+  assertEquals(new TextDecoder().decode(content), expected);
 });
 
 Deno.test("writeJsonIfExistsAnInvalidJson", async function (): Promise<void> {
@@ -71,7 +75,8 @@ Deno.test("writeJsonIfExistsAnInvalidJson", async function (): Promise<void> {
 
   await Deno.remove(existsInvalidJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
+  const expected = format(`{"a":"1"}\n`, platformEol);
+  assertEquals(new TextDecoder().decode(content), expected);
 });
 
 Deno.test("writeJsonWithSpaces", async function (): Promise<void> {
@@ -93,7 +98,8 @@ Deno.test("writeJsonWithSpaces", async function (): Promise<void> {
 
   await Deno.remove(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{\n  "a": "1"\n}\n`);
+  const expected = format(`{\n  "a": "1"\n}\n`, platformEol);
+  assertEquals(new TextDecoder().decode(content), expected);
 });
 
 Deno.test("writeJsonWithReplacer", async function (): Promise<void> {
@@ -121,7 +127,8 @@ Deno.test("writeJsonWithReplacer", async function (): Promise<void> {
 
   await Deno.remove(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
+  const expected = format(`{"a":"1"}\n`, platformEol);
+  assertEquals(new TextDecoder().decode(content), expected);
 });
 
 Deno.test("writeJsonSyncIfNotExists", function (): void {
@@ -140,7 +147,8 @@ Deno.test("writeJsonSyncIfNotExists", function (): void {
 
   Deno.removeSync(notExistsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
+  const expected = format(`{"a":"1"}\n`, platformEol);
+  assertEquals(new TextDecoder().decode(content), expected);
 });
 
 Deno.test("writeJsonSyncIfExists", function (): void {
@@ -161,7 +169,8 @@ Deno.test("writeJsonSyncIfExists", function (): void {
 
   Deno.removeSync(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
+  const expected = format(`{"a":"1"}\n`, platformEol);
+  assertEquals(new TextDecoder().decode(content), expected);
 });
 
 Deno.test("writeJsonSyncIfExistsAnInvalidJson", function (): void {
@@ -186,7 +195,8 @@ Deno.test("writeJsonSyncIfExistsAnInvalidJson", function (): void {
 
   Deno.removeSync(existsInvalidJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
+  const expected = format(`{"a":"1"}\n`, platformEol);
+  assertEquals(new TextDecoder().decode(content), expected);
 });
 
 Deno.test("writeJsonWithSpaces", function (): void {
@@ -208,7 +218,8 @@ Deno.test("writeJsonWithSpaces", function (): void {
 
   Deno.removeSync(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{\n  "a": "1"\n}\n`);
+  const expected = format(`{\n  "a": "1"\n}\n`, platformEol);
+  assertEquals(new TextDecoder().decode(content), expected);
 });
 
 Deno.test("writeJsonWithReplacer", function (): void {
@@ -239,5 +250,6 @@ Deno.test("writeJsonWithReplacer", function (): void {
 
   Deno.removeSync(existsJsonFile);
 
-  assertEquals(new TextDecoder().decode(content), `{"a":"1"}\n`);
+  const expected = format(`{"a":"1"}\n`, platformEol);
+  assertEquals(new TextDecoder().decode(content), expected);
 });


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
Introduces uniform platform-dependent EOL markers in the output of writeJson function.
Makes sure that there is a newline at the end of file.

Closes #6810
