### PR TITLE
Fix: Deno.args typings

### DIFF
--- a/cli/js2/lib.deno.ns.d.ts
+++ b/cli/js2/lib.deno.ns.d.ts
@@ -2019,7 +2019,7 @@ declare namespace Deno {
    *
    * [ "/etc/passwd" ]
    */
-  export const args: readonly (string | undefined)[];
+  export const args: readonly string[];
 
   /** A symbol which can be used as a key for a custom method which will be
    * called when `Deno.inspect()` is called, or when the object is logged to

--- a/cli/js2/lib.deno.ns.d.ts
+++ b/cli/js2/lib.deno.ns.d.ts
@@ -2019,7 +2019,7 @@ declare namespace Deno {
    *
    * [ "/etc/passwd" ]
    */
-  export const args: string[];
+  export const args: readonly (string | undefined)[];
 
   /** A symbol which can be used as a key for a custom method which will be
    * called when `Deno.inspect()` is called, or when the object is logged to


### PR DESCRIPTION
`Deno.args` is always an immutable string array ~~(which may be empty)~~, but the typings don't seem to reflect this. E.g., the following line passes compile-time checks but causes a runtime error:

```typescript
Deno.args.push("xyz"); 
// Compile file:///[...]/test.ts
// error: Uncaught TypeError: Cannot add property 0, object is not extensible
```

This PR changes `Deno.args` from `string[]` to `readonly string[]`.

Thanks!


**Update: removed undefined index issue and updated PR accordingly**

```typescript
// Deno.args[0].split("");
// Compile file:///[...]/test.ts
// error: Uncaught TypeError: Cannot read property 'split' of undefined
```