### PR TITLE
fix(log-level): Default log level to Warn #6641

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -695,7 +695,7 @@ pub fn main() {
 
   let log_level = match flags.log_level {
     Some(level) => level,
-    None => Level::Info, // Default log level
+    None => Level::Warn, // Default log level
   };
   log::set_max_level(log_level.to_level_filter());
 


### PR DESCRIPTION
Update default log level to Warn to suppress warning #6641 
CLI now will only display log level of Error unless user provides log_level flag or suppresses ERROR with quiet.  
