### PR TITLE
cli/js2/lib: Closer.close should return a promise

### DIFF
--- a/cli/js2/lib.deno.ns.d.ts
+++ b/cli/js2/lib.deno.ns.d.ts
@@ -343,7 +343,7 @@ declare namespace Deno {
   }
 
   export interface Closer {
-    close(): void;
+    close(): Promise<void>;
   }
 
   export interface Seeker {


### PR DESCRIPTION
> Finally, write() and close() return promises that are processed to deal with success or failure of chunks and streams.
> https://developer.mozilla.org/en-US/docs/Web/API/WritableStream

> close(): Promise<void>
> https://doc.deno.land/https/github.com/denoland/deno/releases/latest/download/lib.deno.d.ts#WritableStream

However, it seems that it is actually coded as to not return a promise:

1. https://github.com/denoland/deno/blob/fa61956f03491101b6ef64423ea2f1f73af26a73/cli/js2/30_files.js#L145-L147
1. https://github.com/denoland/deno/blob/fa61956f03491101b6ef64423ea2f1f73af26a73/cli/js2/11_resources.js#L15-L17
1. https://github.com/denoland/deno/blob/fa61956f03491101b6ef64423ea2f1f73af26a73/cli/js2/10_dispatch_json.js#L41-L53