### PR TITLE
refactor(cli): remove unreachable assertion from exit

### DIFF
--- a/cli/js2/30_os.js
+++ b/cli/js2/30_os.js
@@ -17,7 +17,6 @@
 
   function exit(code = 0) {
     sendSync("op_exit", { code });
-    throw new Error("Code not reachable");
   }
 
   function setEnv(key, value) {


### PR DESCRIPTION
There's an unreachable assertion in Deno.exit which will never be triggered unless the implementation of op_exit is completely broken.

This removes the offending runtime assertion.