### PR TITLE
test(cli/unit): remove redundant console.log statement

### DIFF
--- a/cli/tests/unit/files_test.ts
+++ b/cli/tests/unit/files_test.ts
@@ -21,7 +21,6 @@ unitTest({ perms: { read: true } }, async function filesCopyToStdout(): Promise<
   const bytesWritten = await Deno.copy(file, Deno.stdout);
   const fileSize = Deno.statSync(filename).size;
   assertEquals(bytesWritten, fileSize);
-  console.log("bytes written", bytesWritten);
   file.close();
 });
 


### PR DESCRIPTION
This removes a seemingly rogue console.log statement that is contributing to the output noise when running cargo test.