### PR TITLE
fix(std/fs): remove re-exports of readFileStr, readFileStrSync, writeFileStr and writeFileStrSync

### DIFF
--- a/std/fs/mod.ts
+++ b/std/fs/mod.ts
@@ -8,8 +8,6 @@ export * from "./exists.ts";
 export * from "./expand_glob.ts";
 export * from "./move.ts";
 export * from "./copy.ts";
-export * from "./read_file_str.ts";
-export * from "./write_file_str.ts";
 export * from "./read_json.ts";
 export * from "./write_json.ts";
 export * from "./walk.ts";

--- a/std/fs/test.ts
+++ b/std/fs/test.ts
@@ -1,0 +1,1 @@
+import "./mod.ts";


### PR DESCRIPTION
The modules write_file_str.ts and read_file_str.ts have been removed in #6847 and #6848 respectively but the mod.ts file still re-exports them as I forgot about it.

This removes the offending exports and adds a test that imports mod.ts to ensure it doesn't occur again in the future.

Closes #6849