### PR TITLE
docs: Fix broken link

### DIFF
--- a/docs/examples/os_signals.md
+++ b/docs/examples/os_signals.md
@@ -3,7 +3,7 @@
 > This program makes use of an unstable Deno feature. Learn more about
 > [unstable features](../runtime/stability.md).
 
-[API Reference](https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/js/lib.deno.unstable.d.ts#Deno.signal)
+[API Reference](https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/dts/lib.deno.unstable.d.ts#Deno.signal)
 
 You can use `Deno.signal()` function for handling OS signals.
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -10,19 +10,19 @@ For APIs where a web standard already exists, like `fetch` for HTTP requests,
 Deno uses these rather than inventing a new proprietary API.
 
 The detailed documentation for implemented Web APIs can be found on
-[doc.deno.land](https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/js/lib.deno.shared_globals.d.ts).
+[doc.deno.land](https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/dts/lib.deno.shared_globals.d.ts).
 Additionally, a full list of the Web APIs which Deno implements is also
 available
 [in the repository](https://github.com/denoland/deno/blob/master/cli/js/web/README.md).
 
 The TypeScript definitions for the implemented web APIs can be found in the
-[`lib.deno.shared_globals.d.ts`](https://github.com/denoland/deno/blob/master/cli/js/lib.deno.shared_globals.d.ts)
+[`lib.deno.shared_globals.d.ts`](https://github.com/denoland/deno/blob/master/cli/dts/lib.deno.shared_globals.d.ts)
 and
-[`lib.deno.window.d.ts`](https://github.com/denoland/deno/blob/master/cli/js/lib.deno.window.d.ts)
+[`lib.deno.window.d.ts`](https://github.com/denoland/deno/blob/master/cli/dts/lib.deno.window.d.ts)
 files.
 
 Definitions that are specific to workers can be found in the
-[`lib.deno.worker.d.ts`](https://github.com/denoland/deno/blob/master/cli/js/lib.deno.worker.d.ts)
+[`lib.deno.worker.d.ts`](https://github.com/denoland/deno/blob/master/cli/dts/lib.deno.worker.d.ts)
 file.
 
 ## `Deno` global
@@ -32,8 +32,8 @@ It has the APIs for reading from files, opening TCP sockets, and executing
 subprocesses, etc.
 
 The TypeScript definitions for the Deno namespaces can be found in the
-[`lib.deno.ns.d.ts`](https://github.com/denoland/deno/blob/master/cli/js/lib.deno.ns.d.ts)
+[`lib.deno.ns.d.ts`](https://github.com/denoland/deno/blob/master/cli/dts/lib.deno.ns.d.ts)
 file.
 
 The documentation for all of the Deno specific APIs can be found on
-[doc.deno.land](https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/js/lib.deno.ns.d.ts).
+[doc.deno.land](https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/dts/lib.deno.ns.d.ts).

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -13,7 +13,7 @@ The detailed documentation for implemented Web APIs can be found on
 [doc.deno.land](https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/dts/lib.deno.shared_globals.d.ts).
 Additionally, a full list of the Web APIs which Deno implements is also
 available
-[in the repository](https://github.com/denoland/deno/blob/master/cli/js/web/README.md).
+[in the repository](https://github.com/denoland/deno/blob/master/cli/js2/README.md).
 
 The TypeScript definitions for the implemented web APIs can be found in the
 [`lib.deno.shared_globals.d.ts`](https://github.com/denoland/deno/blob/master/cli/dts/lib.deno.shared_globals.d.ts)

--- a/docs/runtime/stability.md
+++ b/docs/runtime/stability.md
@@ -15,7 +15,7 @@ Passing this flag does a few things:
 
 - It enables the use of unstable APIs during runtime.
 - It adds the
-  [`lib.deno.unstable.d.ts`](https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/js/lib.deno.unstable.d.ts)
+  [`lib.deno.unstable.d.ts`](https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/dts/lib.deno.unstable.d.ts)
   file to the list of TypeScript definitions that are used for type checking.
   This includes the output of `deno types`.
 

--- a/docs/standard_library.md
+++ b/docs/standard_library.md
@@ -69,7 +69,7 @@ deno run --allow-read --allow-write --unstable main.ts
 ```
 
 To make sure that API producing error is unstable check
-[`lib.deno.unstable.d.ts`](https://github.com/denoland/deno/blob/master/cli/js/lib.deno.unstable.d.ts)
+[`lib.deno.unstable.d.ts`](https://github.com/denoland/deno/blob/master/cli/dts/lib.deno.unstable.d.ts)
 declaration.
 
 This problem should be fixed in the near future. Feel free to omit the flag if


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

I fixed some broken links in the doc.

It seems that `https://github.com/denoland/deno/blob/master/cli/js/` was moved to `https://github.com/denoland/deno/blob/master/cli/dts/`

