### PR TITLE
chore: use ts-expect-error instead of ts-ignore

### DIFF
--- a/std/node/_util/_util_promisify.ts
+++ b/std/node/_util/_util_promisify.ts
@@ -61,9 +61,9 @@ export function promisify(original: Function): Function {
     throw new NodeInvalidArgTypeError("original", "Function", original);
   }
 
-  // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
+  // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
   if (original[kCustomPromisifiedSymbol]) {
-    // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
+    // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
     const fn = original[kCustomPromisifiedSymbol];
     if (typeof fn !== "function") {
       throw new NodeInvalidArgTypeError(
@@ -82,12 +82,12 @@ export function promisify(original: Function): Function {
 
   // Names to create an object from in case the callback receives multiple
   // arguments, e.g. ['bytesRead', 'buffer'] for fs.read.
-  // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
+  // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
   const argumentNames = original[kCustomPromisifyArgsSymbol];
 
   function fn(...args: unknown[]): Promise<unknown> {
     return new Promise((resolve, reject) => {
-      // @ts-ignore: 'this' implicitly has type 'any' because it does not have a type annotation
+      // @ts-expect-error: 'this' implicitly has type 'any' because it does not have a type annotation
       original.call(this, ...args, (err: Error, ...values: unknown[]) => {
         if (err) {
           return reject(err);
@@ -95,7 +95,7 @@ export function promisify(original: Function): Function {
         if (argumentNames !== undefined && values.length > 1) {
           const obj = {};
           for (let i = 0; i < argumentNames.length; i++) {
-            // @ts-ignore TypeScript
+            // @ts-expect-error TypeScript
             obj[argumentNames[i]] = values[i];
           }
           resolve(obj);

--- a/std/node/_util/_util_promisify_test.ts
+++ b/std/node/_util/_util_promisify_test.ts
@@ -43,7 +43,7 @@ Deno.test("Promisify.custom", async function testPromisifyCustom() {
   function fn(): void {}
 
   function promisifedFn(): void {}
-  // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
+  // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
   fn[promisify.custom] = promisifedFn;
 
   const promisifiedFnA = promisify(fn);
@@ -63,7 +63,7 @@ Deno.test("promiisfy.custom symbol", function testPromisifyCustomSymbol() {
   // util.promisify.custom is a shared symbol which can be accessed
   // as `Symbol.for("nodejs.util.promisify.custom")`.
   const kCustomPromisifiedSymbol = Symbol.for("nodejs.util.promisify.custom");
-  // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
+  // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
   fn[kCustomPromisifiedSymbol] = promisifiedFn;
 
   assertStrictEquals(kCustomPromisifiedSymbol, promisify.custom);
@@ -73,7 +73,7 @@ Deno.test("promiisfy.custom symbol", function testPromisifyCustomSymbol() {
 
 Deno.test("Invalid argument should throw", function testThrowInvalidArgument() {
   function fn(): void {}
-  // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
+  // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
   fn[promisify.custom] = 42;
   try {
     promisify(fn);
@@ -91,7 +91,7 @@ Deno.test("Custom promisify args", async function testPromisifyCustomArgs() {
     callback(null, firstValue, secondValue);
   }
 
-  // @ts-ignore TypeScript (as of 3.7) does not support indexing namespaces by symbol
+  // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
   fn[customPromisifyArgs] = ["first", "second"];
 
   const obj = await promisify(fn)();
@@ -159,7 +159,7 @@ Deno.test(
 Deno.test("Rejected value", async function testPromisifyWithAsObjectMethod() {
   const o: { fn?: Function } = {};
   const fn = promisify(function (cb: Function): void {
-    // @ts-ignore TypeScript
+    // @ts-expect-error TypeScript
     cb(null, this === o);
   });
 
@@ -220,7 +220,7 @@ Deno.test("Test error", async function testInvalidArguments() {
 Deno.test("Test invalid arguments", function testInvalidArguments() {
   [undefined, null, true, 0, "str", {}, [], Symbol()].forEach((input) => {
     try {
-      // @ts-ignore TypeScript
+      // @ts-expect-error TypeScript
       promisify(input);
     } catch (e) {
       assertStrictEquals(e.code, "ERR_INVALID_ARG_TYPE");

--- a/std/node/buffer_test.ts
+++ b/std/node/buffer_test.ts
@@ -5,10 +5,10 @@ Deno.test({
   name: "Buffer global scope",
   fn() {
     // deno-lint-ignore ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error
     assert(window.Buffer === Buffer);
     // deno-lint-ignore ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error
     assert(globalThis.Buffer === Buffer);
   },
 });
@@ -36,7 +36,7 @@ Deno.test({
       assertThrows(
         () => {
           // deno-lint-ignore ban-ts-comment
-          // @ts-ignore
+          // @ts-expect-error
           Buffer.alloc(size);
         },
         TypeError,
@@ -55,8 +55,6 @@ Deno.test({
     for (const value of invalidValues) {
       assertThrows(
         () => {
-          // deno-lint-ignore ban-ts-comment
-          // @ts-ignore
           console.log(value.constructor.name);
           Buffer.alloc(1, value);
         },
@@ -399,7 +397,7 @@ Deno.test({
       assertThrows(
         () => {
           // deno-lint-ignore ban-ts-comment
-          // @ts-ignore
+          // @ts-expect-error
           buffer.toString(encoding);
         },
         TypeError,
@@ -418,15 +416,13 @@ Deno.test({
 
     for (const encoding of defaultToUtf8Encodings) {
       // deno-lint-ignore ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error
       assertEquals(Buffer.from("yes", encoding).toString(), "yes");
     }
 
     for (const encoding of invalidEncodings) {
       assertThrows(
         () => {
-          // deno-lint-ignore ban-ts-comment
-          // @ts-ignore
           Buffer.from("yes", encoding);
         },
         TypeError,
@@ -445,8 +441,6 @@ Deno.test({
     for (const encoding of notImplemented) {
       assertThrows(
         () => {
-          // deno-lint-ignore ban-ts-comment
-          // @ts-ignore
           buffer.toString(encoding);
         },
         Error,
@@ -456,8 +450,6 @@ Deno.test({
 
       assertThrows(
         () => {
-          // deno-lint-ignore ban-ts-comment
-          // @ts-ignore
           Buffer.from("", encoding);
         },
         Error,
@@ -586,7 +578,7 @@ Deno.test({
 
     assertThrows(
       // deno-lint-ignore ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error
       () => Buffer.alloc(1).equals("abc"),
       TypeError,
       `The "otherBuffer" argument must be an instance of Buffer or Uint8Array. Received type string`,


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

TypeScript 3.9 release notes on `// @ts-expect-error` https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#-ts-expect-error-comments

It's being used in newly written TS code of Deno https://github.com/denoland/deno/search?q=ts-expect-error&unscoped_q=ts-expect-error