### PR TITLE
chore(cli/diagnostics): remove TODO about manual JSON parsing

### DIFF
--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -2,9 +2,6 @@
 //! This module encodes TypeScript errors (diagnostics) into Rust structs and
 //! contains code for printing them to the console.
 
-// TODO(ry) This module does a lot of JSON parsing manually. It should use
-// serde_json.
-
 use crate::colors;
 use crate::fmt_errors::format_stack;
 use serde::Deserialize;


### PR DESCRIPTION
The manual JSON parsing was removed in #5071
https://github.com/denoland/deno/pull/5071/files#diff-0b025d7ebf1d0c287b74b5e19f63b480