### PR TITLE
chore(ci): update actions to run on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
             kind: test_release
           - os: windows-2019
             kind: test_release
-          - os: ubuntu-16.04
+          - os: ubuntu-latest
             kind: test_release
-          - os: ubuntu-16.04
+          - os: ubuntu-latest
             kind: test_debug
-          - os: ubuntu-16.04
+          - os: ubuntu-latest
             kind: bench
-          - os: ubuntu-16.04
+          - os: ubuntu-latest
             kind: lint
 
       # Always run master branch builds to completion. This allows the cache to


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

macOS virtual environment was updated to macOS-latest in https://github.com/denoland/deno/pull/3250
Unsure on why Ubuntu was not updated.

The current latest ubuntu version is 18.04 https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
