### PR TITLE
test(std): remove unstable from multiple tests

### DIFF
--- a/std/examples/chat/server_test.ts
+++ b/std/examples/chat/server_test.ts
@@ -9,13 +9,11 @@ async function startServer(): Promise<
   Deno.Process<Deno.RunOptions & { stdout: "piped" }>
 > {
   const server = Deno.run({
-    // TODO(lucacasonato): remove unstable once possible
     cmd: [
       Deno.execPath(),
       "run",
       "--allow-net",
       "--allow-read",
-      "--unstable",
       "server.ts",
     ],
     cwd: "examples/chat",

--- a/std/fs/empty_dir_test.ts
+++ b/std/fs/empty_dir_test.ts
@@ -203,8 +203,7 @@ for (const s of scenes) {
       );
 
       try {
-        // TODO(lucacasonato): remove unstable when stabilized
-        const args = [Deno.execPath(), "run", "--unstable"];
+        const args = [Deno.execPath(), "run"];
 
         if (s.read) {
           args.push("--allow-read");

--- a/std/fs/exists_test.ts
+++ b/std/fs/exists_test.ts
@@ -112,8 +112,7 @@ for (const s of scenes) {
   let title = `test ${s.async ? "exists" : "existsSync"}("testdata/${s.file}")`;
   title += ` ${s.read ? "with" : "without"} --allow-read`;
   Deno.test(`[fs] existsPermission ${title}`, async function (): Promise<void> {
-    // TODO(lucacasonato): remove unstable when stabilized
-    const args = [Deno.execPath(), "run", "--unstable"];
+    const args = [Deno.execPath(), "run"];
 
     if (s.read) {
       args.push("--allow-read");

--- a/std/http/racing_server_test.ts
+++ b/std/http/racing_server_test.ts
@@ -5,8 +5,7 @@ import { TextProtoReader } from "../textproto/mod.ts";
 let server: Deno.Process<Deno.RunOptions & { stdout: "piped" }>;
 async function startServer(): Promise<void> {
   server = Deno.run({
-    // TODO(lucacasonato): remove unstable when stabilized
-    cmd: [Deno.execPath(), "run", "--unstable", "-A", "http/racing_server.ts"],
+    cmd: [Deno.execPath(), "run", "-A", "http/racing_server.ts"],
     stdout: "piped",
   });
   // Once racing server is ready it will write to its stdout.


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

```console
$ deno test -A examples/chat/server_test.ts 
Check file:///home/trivikr/workspace/deno/std/.deno.test.ts
running 2 tests
test [examples/chat] GET / should serve html ... ok (58ms)
test [examples/chat] GET /ws should upgrade conn to ws ... ok (50ms)

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (108ms)

$ deno test -A fs/empty_dir_test.ts 
Check file:///home/trivikr/workspace/deno/std/.deno.test.ts
running 12 tests
test emptyDirIfItNotExist ... ok (5ms)
test emptyDirSyncIfItNotExist ... ok (2ms)
test emptyDirIfItExist ... ok (3ms)
test emptyDirSyncIfItExist ... ok (3ms)
test [fs] emptyDirPermission test emptyDir("testdata/testfolder") without --allow-read & without --allow-write ... ok (27ms)
test [fs] emptyDirPermission test emptyDirSync("testdata/testfolder") without --allow-read & without --allow-write ... ok (30ms)
test [fs] emptyDirPermission test emptyDir("testdata/testfolder") with --allow-read & without --allow-write ... ok (30ms)
test [fs] emptyDirPermission test emptyDirSync("testdata/testfolder") with --allow-read & without --allow-write ... ok (29ms)
test [fs] emptyDirPermission test emptyDir("testdata/testfolder") without --allow-read & with --allow-write ... ok (30ms)
test [fs] emptyDirPermission test emptyDirSync("testdata/testfolder") without --allow-read & with --allow-write ... ok (32ms)
test [fs] emptyDirPermission test emptyDir("testdata/testfolder") with --allow-read & with --allow-write ... ok (33ms)
test [fs] emptyDirPermission test emptyDirSync("testdata/testfolder") with --allow-read & with --allow-write ... ok (31ms)

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (255ms)

$ deno test -A fs/exists_test.ts 
Check file:///home/trivikr/workspace/deno/std/.deno.test.ts
running 14 tests
test [fs] existsFile ... ok (4ms)
test [fs] existsFileSync ... ok (1ms)
test [fs] existsDirectory ... ok (1ms)
test [fs] existsDirectorySync ... ok (2ms)
test [fs] existsLinkSync ... ok (1ms)
test [fs] existsLink ... ok (1ms)
test [fs] existsPermission test exists("testdata/0.ts") without --allow-read ... Check file:///home/trivikr/workspace/deno/std/fs/testdata/exists.ts
ok (457ms)
test [fs] existsPermission test existsSync("testdata/0.ts") without --allow-read ... Check file:///home/trivikr/workspace/deno/std/fs/testdata/exists_sync.ts
ok (426ms)
test [fs] existsPermission test exists("testdata/0.ts") with --allow-read ... ok (17ms)
test [fs] existsPermission test existsSync("testdata/0.ts") with --allow-read ... ok (19ms)
test [fs] existsPermission test exists("testdata/no_exist_file_for_test.ts") without --allow-read ... ok (20ms)
test [fs] existsPermission test existsSync("testdata/no_exist_file_for_test.ts") without --allow-read ... ok (20ms)
test [fs] existsPermission test exists("testdata/no_exist_file_for_test.ts") with --allow-read ... ok (19ms)
test [fs] existsPermission test existsSync("testdata/no_exist_file_for_test.ts") with --allow-read ... ok (21ms)

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (1011ms)

$ deno test -A http/racing_server_test.ts 
Check file:///home/trivikr/workspace/deno/std/.deno.test.ts
running 1 tests
test serverPipelineRace ... Check file:///home/trivikr/workspace/deno/std/http/racing_server.ts
ok (3993ms)

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (3993ms) 
```

cc @lucacasonato