### PR TITLE
chore(ci): update actions to run on macos-10.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: macOS-latest
+          - os: macos-10.15
             kind: test_release
           - os: windows-2019
             kind: test_release


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

Explicit versions are preferred, so that bugs (if any) can be fixed during the upgrade
Ref: https://github.com/denoland/deno/pull/6880#issuecomment-664000672

PR which updated macOS virtual environment to macOS-latest is #3250
macos-latest is currently macos-10.15 https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources