### PR TITLE
feat: add "--ignore" flag to deno fmt

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -671,6 +671,7 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
         .takes_value(true)
         .use_delimiter(true)
         .require_equals(true)
+        .requires("unstable")
         .help("Ignore formatting particular source files."),
     )
     .arg(

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -671,7 +671,6 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
         .takes_value(true)
         .use_delimiter(true)
         .require_equals(true)
-        .requires("unstable")
         .help("Ignore formatting particular source files."),
     )
     .arg(

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1680,6 +1680,7 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Fmt {
+          ignore: vec![],
           check: false,
           files: vec!["script_1.ts".to_string(), "script_2.ts".to_string()]
         },
@@ -1692,6 +1693,7 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Fmt {
+          ignore: vec![],
           check: true,
           files: vec![],
         },
@@ -1704,6 +1706,7 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Fmt {
+          ignore: vec![],
           check: false,
           files: vec![],
         },

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -340,6 +340,7 @@ fn types_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 }
 
 fn fmt_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
+  // TODO(divy-work): remove `--unstable` in 1.3.0
   unstable_arg_parse(flags, matches);
   let files = match matches.values_of("files") {
     Some(f) => f.map(String::from).collect(),

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -39,7 +39,7 @@ pub enum DenoSubcommand {
   Fmt {
     check: bool,
     files: Vec<String>,
-    ignore: Vec<String>,
+    exclude: Vec<String>,
   },
   Help,
   Info {
@@ -102,7 +102,7 @@ pub struct Flags {
   pub ca_file: Option<String>,
   pub cached_only: bool,
   pub config_path: Option<String>,
-  pub ignore: Vec<String>,
+  pub exclude: Vec<String>,
   pub import_map_path: Option<String>,
   pub inspect: Option<SocketAddr>,
   pub inspect_brk: Option<SocketAddr>,
@@ -346,14 +346,14 @@ fn fmt_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     Some(f) => f.map(String::from).collect(),
     None => vec![],
   };
-  let ignore = match matches.values_of("ignore") {
+  let exclude = match matches.values_of("exclude") {
     Some(f) => f.map(String::from).collect(),
     None => vec![],
   };
   flags.subcommand = DenoSubcommand::Fmt {
     check: matches.is_present("check"),
     files,
-    ignore,
+    exclude,
   }
 }
 
@@ -668,8 +668,8 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
         .takes_value(false),
     )
     .arg(
-      Arg::with_name("ignore")
-        .long("ignore")
+      Arg::with_name("exclude")
+        .long("exclude")
         .requires("unstable")
         .takes_value(true)
         .use_delimiter(true)
@@ -1684,7 +1684,7 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Fmt {
-          ignore: vec![],
+          exclude: vec![],
           check: false,
           files: vec!["script_1.ts".to_string(), "script_2.ts".to_string()]
         },
@@ -1697,7 +1697,7 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Fmt {
-          ignore: vec![],
+          exclude: vec![],
           check: true,
           files: vec![],
         },
@@ -1710,7 +1710,7 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Fmt {
-          ignore: vec![],
+          exclude: vec![],
           check: false,
           files: vec![],
         },

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -340,6 +340,7 @@ fn types_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 }
 
 fn fmt_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
+  unstable_arg_parse(flags, matches);
   let files = match matches.values_of("files") {
     Some(f) => f.map(String::from).collect(),
     None => vec![],
@@ -668,11 +669,13 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
     .arg(
       Arg::with_name("ignore")
         .long("ignore")
+        .requires("unstable")
         .takes_value(true)
         .use_delimiter(true)
         .require_equals(true)
-        .help("Ignore formatting particular source files."),
+        .help("Ignore formatting particular source files. Use with --unstable"),
     )
+    .arg(unstable_arg())
     .arg(
       Arg::with_name("files")
         .takes_value(true)

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -39,7 +39,7 @@ pub enum DenoSubcommand {
   Fmt {
     check: bool,
     files: Vec<String>,
-    exclude: Vec<String>,
+    ignore: Vec<String>,
   },
   Help,
   Info {
@@ -102,7 +102,7 @@ pub struct Flags {
   pub ca_file: Option<String>,
   pub cached_only: bool,
   pub config_path: Option<String>,
-  pub exclude: Vec<String>,
+  pub ignore: Vec<String>,
   pub import_map_path: Option<String>,
   pub inspect: Option<SocketAddr>,
   pub inspect_brk: Option<SocketAddr>,
@@ -346,14 +346,14 @@ fn fmt_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     Some(f) => f.map(String::from).collect(),
     None => vec![],
   };
-  let exclude = match matches.values_of("exclude") {
+  let ignore = match matches.values_of("ignore") {
     Some(f) => f.map(String::from).collect(),
     None => vec![],
   };
   flags.subcommand = DenoSubcommand::Fmt {
     check: matches.is_present("check"),
     files,
-    exclude,
+    ignore,
   }
 }
 
@@ -668,8 +668,8 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
         .takes_value(false),
     )
     .arg(
-      Arg::with_name("exclude")
-        .long("exclude")
+      Arg::with_name("ignore")
+        .long("ignore")
         .requires("unstable")
         .takes_value(true)
         .use_delimiter(true)
@@ -1684,7 +1684,7 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Fmt {
-          exclude: vec![],
+          ignore: vec![],
           check: false,
           files: vec!["script_1.ts".to_string(), "script_2.ts".to_string()]
         },
@@ -1697,7 +1697,7 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Fmt {
-          exclude: vec![],
+          ignore: vec![],
           check: true,
           files: vec![],
         },
@@ -1710,7 +1710,7 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Fmt {
-          exclude: vec![],
+          ignore: vec![],
           check: false,
           files: vec![],
         },

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -39,6 +39,7 @@ pub enum DenoSubcommand {
   Fmt {
     check: bool,
     files: Vec<String>,
+    ignore: Vec<String>,
   },
   Help,
   Info {
@@ -101,6 +102,7 @@ pub struct Flags {
   pub ca_file: Option<String>,
   pub cached_only: bool,
   pub config_path: Option<String>,
+  pub ignore: Vec<String>,
   pub import_map_path: Option<String>,
   pub inspect: Option<SocketAddr>,
   pub inspect_brk: Option<SocketAddr>,
@@ -342,9 +344,14 @@ fn fmt_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     Some(f) => f.map(String::from).collect(),
     None => vec![],
   };
+  let ignore = match matches.values_of("ignore") {
+    Some(f) => f.map(String::from).collect(),
+    None => vec![],
+  };
   flags.subcommand = DenoSubcommand::Fmt {
     check: matches.is_present("check"),
     files,
+    ignore,
   }
 }
 
@@ -657,6 +664,14 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
         .long("check")
         .help("Check if the source files are formatted.")
         .takes_value(false),
+    )
+    .arg(
+      Arg::with_name("ignore")
+        .long("ignore")
+        .takes_value(true)
+        .use_delimiter(true)
+        .require_equals(true)
+        .help("Ignore formatting particular source files."),
     )
     .arg(
       Arg::with_name("files")

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -40,6 +40,8 @@ pub async fn format(
   let mut target_files = collect_files(args)?;
   if !ignore.is_empty() {
     let ignore_files = collect_files(ignore)?;
+
+    println!("{:?}", ignore_files);
     target_files.retain(|f| ignore_files.contains(&f));
   }
   let config = get_config();
@@ -225,7 +227,7 @@ pub fn collect_files(files: Vec<String>) -> Result<Vec<PathBuf>, ErrBox> {
       if p.is_dir() {
         target_files.extend(files_in_subtree(p, is_supported));
       } else {
-        target_files.push(p);
+        target_files.push(p.canonicalize()?);
       };
     }
   }

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -37,8 +37,11 @@ pub async fn format(
   if args.len() == 1 && args[0] == "-" {
     return format_stdin(check);
   }
+  // collect all files provided.
   let mut target_files = collect_files(args)?;
   if !ignore.is_empty() {
+    // collect all files to be ignored
+    // and retain only files that should be formatted.
     let ignore_files = collect_files(ignore)?;
     target_files.retain(|f| !ignore_files.contains(&f));
   }

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -32,17 +32,17 @@ const BOM_CHAR: char = '\u{FEFF}';
 pub async fn format(
   args: Vec<String>,
   check: bool,
-  ignore: Vec<String>,
+  exclude: Vec<String>,
 ) -> Result<(), ErrBox> {
   if args.len() == 1 && args[0] == "-" {
     return format_stdin(check);
   }
   // collect all files provided.
   let mut target_files = collect_files(args)?;
-  if !ignore.is_empty() {
+  if !exclude.is_empty() {
     // collect all files to be ignored
     // and retain only files that should be formatted.
-    let ignore_files = collect_files(ignore)?;
+    let ignore_files = collect_files(exclude)?;
     target_files.retain(|f| !ignore_files.contains(&f));
   }
   let config = get_config();

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -39,7 +39,7 @@ pub async fn format(
   }
   let mut target_files = collect_files(args)?;
   let ignore_files = collect_files(ignore)?;
-  if ignore_files.len() > 0 {
+  if !ignore_files.is_empty() {
     target_files.retain(|f| ignore_files.contains(&f));
   }
   let config = get_config();

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -38,8 +38,8 @@ pub async fn format(
     return format_stdin(check);
   }
   let mut target_files = collect_files(args)?;
-  let ignore_files = collect_files(ignore)?;
-  if !ignore_files.is_empty() {
+  if !ignore.is_empty() {
+    let ignore_files = collect_files(ignore)?;
     target_files.retain(|f| ignore_files.contains(&f));
   }
   let config = get_config();

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -29,13 +29,19 @@ const BOM_CHAR: char = '\u{FEFF}';
 ///
 /// First argument supports globs, and if it is `None`
 /// then the current directory is recursively walked.
-pub async fn format(args: Vec<String>, check: bool) -> Result<(), ErrBox> {
+pub async fn format(
+  args: Vec<String>,
+  check: bool,
+  ignore: Vec<String>,
+) -> Result<(), ErrBox> {
   if args.len() == 1 && args[0] == "-" {
     return format_stdin(check);
   }
-
-  let target_files = collect_files(args)?;
-
+  let mut target_files = collect_files(args)?;
+  let ignore_files = collect_files(ignore)?;
+  if ignore_files.len() > 0 {
+    target_files.retain(|f| ignore_files.contains(&f));
+  }
   let config = get_config();
   if check {
     check_source_files(config, target_files).await

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -27,7 +27,7 @@ const BOM_CHAR: char = '\u{FEFF}';
 
 /// Format JavaScript/TypeScript files.
 ///
-/// First argument supports globs, and if it is `None`
+/// First argument and ignore supports globs, and if it is `None`
 /// then the current directory is recursively walked.
 pub async fn format(
   args: Vec<String>,

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -40,9 +40,7 @@ pub async fn format(
   let mut target_files = collect_files(args)?;
   if !ignore.is_empty() {
     let ignore_files = collect_files(ignore)?;
-
-    println!("{:?}", ignore_files);
-    target_files.retain(|f| ignore_files.contains(&f));
+    target_files.retain(|f| !ignore_files.contains(&f));
   }
   let config = get_config();
   if check {
@@ -225,7 +223,7 @@ pub fn collect_files(files: Vec<String>) -> Result<Vec<PathBuf>, ErrBox> {
     for arg in files {
       let p = PathBuf::from(arg);
       if p.is_dir() {
-        target_files.extend(files_in_subtree(p, is_supported));
+        target_files.extend(files_in_subtree(p.canonicalize()?, is_supported));
       } else {
         target_files.push(p.canonicalize()?);
       };

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -719,9 +719,11 @@ pub fn main() {
     DenoSubcommand::Cache { files } => {
       cache_command(flags, files).boxed_local()
     }
-    DenoSubcommand::Fmt { check, files } => {
-      fmt::format(files, check).boxed_local()
-    }
+    DenoSubcommand::Fmt {
+      check,
+      files,
+      ignore,
+    } => fmt::format(files, check, ignore).boxed_local(),
     DenoSubcommand::Info { file, json } => {
       info_command(flags, file, json).boxed_local()
     }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -722,8 +722,8 @@ pub fn main() {
     DenoSubcommand::Fmt {
       check,
       files,
-      ignore,
-    } => fmt::format(files, check, ignore).boxed_local(),
+      exclude,
+    } => fmt::format(files, check, exclude).boxed_local(),
     DenoSubcommand::Info { file, json } => {
       info_command(flags, file, json).boxed_local()
     }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -722,8 +722,8 @@ pub fn main() {
     DenoSubcommand::Fmt {
       check,
       files,
-      exclude,
-    } => fmt::format(files, check, exclude).boxed_local(),
+      ignore,
+    } => fmt::format(files, check, ignore).boxed_local(),
     DenoSubcommand::Info { file, json } => {
       info_command(flags, file, json).boxed_local()
     }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -356,7 +356,7 @@ fn fmt_test() {
   let status = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("fmt")
-    .arg(format!("--ignore={}", badly_formatted_str))
+    .arg(format!("--exclude={}", badly_formatted_str))
     .arg("--unstable")
     .arg("--check")
     .arg(badly_formatted_str)

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -357,6 +357,7 @@ fn fmt_test() {
     .current_dir(util::root_path())
     .arg("fmt")
     .arg(format!("--ignore={}", badly_formatted_str))
+    .arg("--unstable")
     .arg("--check")
     .arg(badly_formatted_str)
     .spawn()

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -356,7 +356,7 @@ fn fmt_test() {
   let status = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("fmt")
-    .arg(format!("--exclude={}", badly_formatted_str))
+    .arg(format!("--ignore={}", badly_formatted_str))
     .arg("--unstable")
     .arg("--check")
     .arg(badly_formatted_str)

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -352,6 +352,19 @@ fn fmt_test() {
   let badly_formatted_str = badly_formatted.to_str().unwrap();
   std::fs::copy(&badly_formatted_original, &badly_formatted)
     .expect("Failed to copy file");
+  // First, check formatting by ignoring the badly formatted file.
+  let status = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("fmt")
+    .arg(format!("--ignore={}", badly_formatted_str))
+    .arg("--check")
+    .arg(badly_formatted_str)
+    .spawn()
+    .expect("Failed to spawn script")
+    .wait()
+    .expect("Failed to wait for child process");
+  assert!(status.success());
+  // Check without ignore.
   let status = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("fmt")
@@ -362,6 +375,7 @@ fn fmt_test() {
     .wait()
     .expect("Failed to wait for child process");
   assert!(!status.success());
+  // Format the source file.
   let status = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("fmt")


### PR DESCRIPTION
Adds `--ignore` to `deno fmt`

**Use case**:
`deno fmt --ignore=./node_modules/` 

**Status**:
Ready for review

Ref: #4459 
