### PR TITLE
expose AST parser API to runtime.

### DIFF
--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -2,7 +2,6 @@
 use super::dispatch_json::{Deserialize, JsonOp, Value};
 use crate::futures::FutureExt;
 use crate::op_error::OpError;
-use crate::permissions::Permissions;
 use crate::state::State;
 use crate::swc_util::AstParser;
 use crate::tsc::runtime_bundle;
@@ -105,10 +104,11 @@ fn op_parse(
   let global_state = s.global_state.clone();
   let module_specifier =
     ModuleSpecifier::resolve_url_or_path(&args.source_file)?;
+  let permissions = s.permissions.clone();
   let fut = async move {
     let out = global_state
       .file_fetcher
-      .fetch_source_file(&module_specifier, None, Permissions::allow_all())
+      .fetch_source_file(&module_specifier, None, permissions)
       .await?;
     let src = std::str::from_utf8(&out.source_code).unwrap();
     let parser = AstParser::new();

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -93,6 +93,8 @@ struct ParseArgs {
   source_file: String,
 }
 
+// TODO(divy-work): Should we take swc parse options?
+// TODO(divy-work): Accept multiple source_files to parse
 fn op_parse(
   state: &State,
   args: Value,

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -2,17 +2,21 @@
 use super::dispatch_json::{Deserialize, JsonOp, Value};
 use crate::futures::FutureExt;
 use crate::op_error::OpError;
+use crate::permissions::Permissions;
 use crate::state::State;
+use crate::swc_util::AstParser;
 use crate::tsc::runtime_bundle;
 use crate::tsc::runtime_compile;
 use crate::tsc::runtime_transpile;
 use deno_core::CoreIsolate;
+use deno_core::ModuleSpecifier;
 use deno_core::ZeroCopyBuf;
 use std::collections::HashMap;
 
 pub fn init(i: &mut CoreIsolate, s: &State) {
   i.register_op("op_compile", s.stateful_json_op(op_compile));
   i.register_op("op_transpile", s.stateful_json_op(op_transpile));
+  i.register_op("op_parse", s.stateful_json_op(op_parse));
 }
 
 #[derive(Deserialize, Debug)]
@@ -80,6 +84,43 @@ fn op_transpile(
   let fut = async move {
     runtime_transpile(global_state, permissions, &args.sources, &args.options)
       .await
+  }
+  .boxed_local();
+  Ok(JsonOp::Async(fut))
+}
+
+#[derive(Deserialize, Debug)]
+struct ParseArgs {
+  source_file: String,
+}
+
+fn op_parse(
+  state: &State,
+  args: Value,
+  _zero_copy: &mut [ZeroCopyBuf],
+) -> Result<JsonOp, OpError> {
+  state.check_unstable("Deno.ast");
+  let args: ParseArgs = serde_json::from_value(args)?;
+  let s = state.borrow();
+  let global_state = s.global_state.clone();
+  let module_specifier =
+    ModuleSpecifier::resolve_url_or_path(&args.source_file)?;
+  let fut = async move {
+    let out = global_state
+      .file_fetcher
+      .fetch_source_file(&module_specifier, None, Permissions::allow_all())
+      .await?;
+    let src = std::str::from_utf8(&out.source_code).unwrap();
+    let parser = AstParser::new();
+    parser.parse_module::<_, Result<Value, OpError>>(
+      &module_specifier.to_string(),
+      out.media_type,
+      &src,
+      |parse_result| {
+        let module = parse_result.unwrap();
+        Ok(serde_json::to_value(module)?)
+      },
+    )
   }
   .boxed_local();
   Ok(JsonOp::Async(fut))

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -90,11 +90,10 @@ fn op_transpile(
 
 #[derive(Deserialize, Debug)]
 struct ParseArgs {
-  source_file: String,
+  source: String,
 }
 
 // TODO(divy-work): Should we take swc parse options?
-// TODO(divy-work): Accept multiple source_files to parse
 fn op_parse(
   state: &State,
   args: Value,
@@ -104,8 +103,7 @@ fn op_parse(
   let args: ParseArgs = serde_json::from_value(args)?;
   let s = state.borrow();
   let global_state = s.global_state.clone();
-  let module_specifier =
-    ModuleSpecifier::resolve_url_or_path(&args.source_file)?;
+  let module_specifier = ModuleSpecifier::resolve_url_or_path(&args.source)?;
   let permissions = s.permissions.clone();
   let fut = async move {
     let out = global_state

--- a/cli/rt/40_compiler_api.js
+++ b/cli/rt/40_compiler_api.js
@@ -10,6 +10,10 @@
     return sendAsync("op_compile", request);
   }
 
+  function opAst(request) {
+    return sendAsync("op_parse", request);
+  }
+
   function opTranspile(
     request,
   ) {
@@ -20,6 +24,15 @@
     return specifier.match(/^([\.\/\\]|https?:\/{2}|file:\/{2})/)
       ? specifier
       : `./${specifier}`;
+  }
+
+  // TODO(divy-work): Use AST type interface from swc?
+  function ast(source_file) {
+    util.log("Deno.ast", { source_file });
+    const payload = {
+      source_file,
+    };
+    return opAst(payload);
   }
 
   // TODO(bartlomieju): change return type to interface?
@@ -96,5 +109,6 @@
     bundle,
     compile,
     transpileOnly,
+    ast,
   };
 })(this);

--- a/cli/rt/40_compiler_api.js
+++ b/cli/rt/40_compiler_api.js
@@ -26,11 +26,11 @@
       : `./${specifier}`;
   }
 
-  // TODO(divy-work): Use AST type interface from swc?
-  function ast(source_file) {
-    util.log("Deno.ast", { source_file });
+  // TODO(divy-work): Use AST type interface from swc as return type?
+  function ast(source) {
+    util.log("Deno.ast", { source });
     const payload = {
-      source_file,
+      source,
     };
     return opAst(payload);
   }

--- a/cli/rt/90_deno_ns.js
+++ b/cli/rt/90_deno_ns.js
@@ -89,6 +89,7 @@ __bootstrap.denoNsUnstable = {
   signals: __bootstrap.signals.signals,
   Signal: __bootstrap.signals.Signal,
   SignalStream: __bootstrap.signals.SignalStream,
+  ast: __bootstrap.compilerApi.ast,
   transpileOnly: __bootstrap.compilerApi.transpileOnly,
   compile: __bootstrap.compilerApi.compile,
   bundle: __bootstrap.compilerApi.bundle,


### PR DESCRIPTION
Exposes `swc`'s AST parser API to the runtime behind the `--unstable` flag. 

```typescript
await Deno.ast("file.ts"); // returns the ast json
```

**Prior Art**:
N/A - this feature is specific to the runtime compiler ops.

**Corresponding command**:
`deno ast file.ts --unstable`

**Features**:

- [x] No extra crates included. Uses `swc_utils.rs`
- [ ] AST is typed. See https://github.com/swc-project/swc/blob/ea885df521031b6f913615975b6e76f6c08308bc/node-swc/src/types.ts#L1278. But since the code has moved to js, i don't know how we can achieve that (cc @bartlomieju)
- [x] Better than using `typescript`'s AST as it is faster and much easier to serialise.
