### PR TITLE
[WIP] Refactor the compiler

### DIFF
--- a/.dprintrc.json
+++ b/.dprintrc.json
@@ -16,6 +16,7 @@
     "cli/dts",
     "cli/tests/encoding",
     "cli/tsc/*typescript.js",
+    "compiler/system_loader_es5.js",
     "gh-pages",
     "std/**/testdata",
     "std/**/vendor",

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,7 @@
 cli/compilers/wasm_wrap.js
+cli/dts/*
 cli/tests/error_syntax.js
+cli/tsc/*typescript.js
 std/deno.d.ts
 std/**/testdata/
 std/**/node_modules/
-cli/tsc/*typescript.js
-cli/dts/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "bytecount"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0017894339f586ccb943b01b9555de56770c11cda818e7e3d8bd93f4ed7f46e"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +267,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
+dependencies = [
+ "getrandom",
+ "proc-macro-hack",
 ]
 
 [[package]]
@@ -320,6 +355,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "3.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
+dependencies = [
+ "ahash",
+ "cfg-if",
+ "num_cpus",
+]
+
+[[package]]
 name = "deno"
 version = "1.3.1"
 dependencies = [
@@ -375,6 +421,32 @@ dependencies = [
  "webpki-roots",
  "winapi 0.3.9",
  "winres",
+]
+
+[[package]]
+name = "deno_compiler"
+version = "0.49.0"
+dependencies = [
+ "base64 0.12.3",
+ "bytecount",
+ "deno_core",
+ "either",
+ "futures",
+ "indexmap",
+ "jsonc-parser",
+ "lazy_static",
+ "regex",
+ "ring",
+ "serde",
+ "serde_json",
+ "sourcemap",
+ "swc_common",
+ "swc_ecma_transforms",
+ "swc_ecmascript",
+ "tempfile",
+ "termcolor",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -507,9 +579,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "either"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "encoding_rs"
@@ -1011,6 +1083,12 @@ dependencies = [
  "swc_atoms",
  "swc_common",
 ]
+
+[[package]]
+name = "jsonc-parser"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030c40aab885ff629ec30ac02b5a4fda3d4ed09992d7daf2f188ff931f6f301b"
 
 [[package]]
 name = "kernel32-sys"
@@ -2243,6 +2321,7 @@ checksum = "c3e99fc5c5b87871fa19036fd8a622ecf6b2a29b30b4d632e48f6a1923e393ea"
 dependencies = [
  "Inflector",
  "arrayvec",
+ "dashmap",
  "either",
  "fxhash",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "cli",
+  "compiler",
   "core",
   "test_plugin",
   "test_util",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "deno_compiler"
+version = "0.49.0"
+license = "MIT"
+description = "ESM and TypeScript dependency analysis, compiling, bundling and transforming for Deno."
+repository = "https://github.com/denoland/deno"
+authors = ["the Deno authors"]
+edition = "2018"
+
+exclude = [
+  "typescript/tests/*",
+  "typescript/src/*",
+  "typescript/scripts/*",
+  "typescript/doc/*",
+  "typescript/lib/*/*.json",
+]
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+base64 = "0.12.3"
+bytecount = "0.6.0"
+deno_core = { path = "../core", version = "0.54.0" }
+either = "1.6.0"
+futures = "0.3.5"
+indexmap = "1.5.1"
+jsonc-parser = "0.12.2"
+lazy_static = "1.4.0"
+regex = "1.3.9"
+ring = "0.16.15"
+serde_json = "1.0.57"
+serde = { version = "1.0.115", features = ["derive"] }
+sourcemap = "6.0.1"
+swc_common = { version = "=0.10.0", features = ["sourcemap"] }
+swc_ecma_transforms = { version = "=0.22.1", features = ["react"] }
+swc_ecmascript = { version = "=0.6.1", features = ["codegen", "parser", "transforms", "utils", "visit"] }
+termcolor = "1.1.0"
+url = "2.1.1"
+
+[dev-dependencies]
+tempfile = "3.1.0"
+tokio = { version = "0.2.22", features = ["full"] }

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,0 +1,1 @@
+# deno_compiler

--- a/compiler/ast.rs
+++ b/compiler/ast.rs
@@ -1,0 +1,846 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+use crate::msg::MediaType;
+use crate::Result;
+
+use deno_core::ErrBox;
+use deno_core::ModuleSpecifier;
+use either::Either;
+use std::error::Error;
+use std::fmt;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::RwLock;
+use swc_common::chain;
+use swc_common::comments::Comment;
+use swc_common::comments::SingleThreadedComments;
+use swc_common::errors::Diagnostic;
+use swc_common::errors::DiagnosticBuilder;
+use swc_common::errors::Emitter;
+use swc_common::errors::Handler;
+use swc_common::errors::HandlerFlags;
+use swc_common::FileName;
+use swc_common::Globals;
+use swc_common::Loc;
+pub use swc_common::SourceMap;
+pub use swc_common::Span;
+use swc_ecmascript::ast::Module;
+use swc_ecmascript::ast::Program;
+use swc_ecmascript::codegen::text_writer::JsWriter;
+use swc_ecmascript::codegen::Config;
+use swc_ecmascript::codegen::Node;
+use swc_ecmascript::parser::lexer::Lexer;
+use swc_ecmascript::parser::EsConfig;
+use swc_ecmascript::parser::JscTarget;
+use swc_ecmascript::parser::StringInput;
+use swc_ecmascript::parser::Syntax;
+use swc_ecmascript::parser::TsConfig;
+use swc_ecmascript::transforms::fixer;
+use swc_ecmascript::transforms::helpers;
+use swc_ecmascript::transforms::proposals::decorators;
+use swc_ecmascript::transforms::react;
+use swc_ecmascript::transforms::typescript;
+use swc_ecmascript::visit;
+use swc_ecmascript::visit::FoldWith;
+use swc_ecmascript::visit::Visit;
+
+static TARGET: JscTarget = JscTarget::Es2020;
+
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct Location {
+  pub filename: String,
+  pub line: usize,
+  pub col: usize,
+}
+
+impl Into<Location> for Loc {
+  fn into(self) -> Location {
+    use swc_common::FileName::*;
+
+    let filename = match &self.file.name {
+      Real(path_buf) => path_buf.to_string_lossy().to_string(),
+      Custom(str_) => str_.to_string(),
+      _ => panic!("invalid filename"),
+    };
+
+    Location {
+      filename,
+      line: self.line,
+      col: self.col_display,
+    }
+  }
+}
+
+/// A buffer for collecting diagnostic messages from the AST parser.
+#[derive(Debug)]
+pub struct DiagnosticBuffer(Vec<String>);
+
+impl Error for DiagnosticBuffer {}
+
+impl fmt::Display for DiagnosticBuffer {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let s = self.0.join(",");
+    f.pad(&s)
+  }
+}
+
+impl DiagnosticBuffer {
+  pub fn from_error_buffer<F>(error_buffer: ErrorBuffer, get_loc: F) -> Self
+  where
+    F: Fn(Span) -> Loc,
+  {
+    let s = error_buffer.0.read().unwrap().clone();
+    let diagnostics = s
+      .iter()
+      .map(|d| {
+        let mut msg = d.message();
+
+        if let Some(span) = d.span.primary_span() {
+          let loc = get_loc(span);
+          let file_name = match &loc.file.name {
+            FileName::Custom(n) => n,
+            _ => unreachable!(),
+          };
+          msg = format!(
+            "{} at {}:{}:{}",
+            msg, file_name, loc.line, loc.col_display
+          );
+        }
+
+        msg
+      })
+      .collect::<Vec<String>>();
+
+    Self(diagnostics)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct ErrorBuffer(Arc<RwLock<Vec<Diagnostic>>>);
+
+impl ErrorBuffer {
+  pub fn new() -> Self {
+    Self(Arc::new(RwLock::new(Vec::new())))
+  }
+}
+
+impl Emitter for ErrorBuffer {
+  fn emit(&mut self, db: &DiagnosticBuilder) {
+    self.0.write().unwrap().push((**db).clone());
+  }
+}
+
+fn get_es_config(jsx: bool) -> EsConfig {
+  EsConfig {
+    class_private_methods: true,
+    class_private_props: true,
+    class_props: true,
+    dynamic_import: true,
+    export_default_from: true,
+    export_namespace_from: true,
+    import_meta: true,
+    jsx,
+    nullish_coalescing: true,
+    num_sep: true,
+    optional_chaining: true,
+    top_level_await: true,
+    ..EsConfig::default()
+  }
+}
+
+fn get_ts_config(tsx: bool) -> TsConfig {
+  TsConfig {
+    decorators: true,
+    dynamic_import: true,
+    tsx,
+    ..TsConfig::default()
+  }
+}
+
+fn get_syntax(media_type: MediaType) -> Syntax {
+  match media_type {
+    MediaType::JavaScript => Syntax::Es(get_es_config(false)),
+    MediaType::JSX => Syntax::Es(get_es_config(true)),
+    MediaType::TypeScript => Syntax::Typescript(get_ts_config(false)),
+    MediaType::TSX => Syntax::Typescript(get_ts_config(true)),
+    _ => Syntax::Es(get_es_config(false)),
+  }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DependencyDescriptor {
+  /// A flag indicating if the import is dynamic or not.
+  pub is_dynamic: bool,
+  /// A flag indicating that the import is a `type` only type of import.
+  pub is_type: bool,
+  /// Any leading comments associated with the dependency.  This is used for
+  /// further processing of supported pragma that impact the dependency.
+  pub leading_comments: Vec<Comment>,
+  /// The location of the import/export statement.
+  pub location: Location,
+  /// The text specifier associated with the import/export statement.
+  pub specifier: String,
+}
+
+/// Visits a pattern node, recursively looking for any names that end up in the
+/// local scope, pushing them onto the passed vector.
+fn visit_pat(pat: &swc_ecmascript::ast::Pat, names: &mut Vec<String>) {
+  match pat {
+    swc_ecmascript::ast::Pat::Ident(ident) => names.push(ident.sym.to_string()),
+    swc_ecmascript::ast::Pat::Array(array_pat) => {
+      for elem in array_pat.elems.iter() {
+        if let Some(pat) = elem {
+          visit_pat(pat, names);
+        }
+      }
+    }
+    swc_ecmascript::ast::Pat::Rest(rest_pat) => {
+      visit_pat(rest_pat.arg.as_ref(), names)
+    }
+    swc_ecmascript::ast::Pat::Object(object_pat) => {
+      for prop in object_pat.props.iter() {
+        match prop {
+          swc_ecmascript::ast::ObjectPatProp::Assign(assign_pat) => {
+            names.push(assign_pat.key.sym.to_string())
+          }
+          swc_ecmascript::ast::ObjectPatProp::KeyValue(key_value) => {
+            visit_pat(key_value.value.as_ref(), names)
+          }
+          swc_ecmascript::ast::ObjectPatProp::Rest(rest_pat) => {
+            visit_pat(rest_pat.arg.as_ref(), names)
+          }
+        }
+      }
+    }
+    swc_ecmascript::ast::Pat::Assign(assign_pat) => {
+      visit_pat(assign_pat.left.as_ref(), names)
+    }
+    // Invalid and Expressions are noops
+    _ => {}
+  }
+}
+
+#[derive(Default)]
+struct ExportCollector {
+  pub names: Vec<String>,
+  pub export_all_specifiers: Vec<String>,
+}
+
+impl Visit for ExportCollector {
+  fn visit_export_decl(
+    &mut self,
+    node: &swc_ecmascript::ast::ExportDecl,
+    _parent: &dyn visit::Node,
+  ) {
+    match &node.decl {
+      swc_ecmascript::ast::Decl::Class(class_decl) => {
+        self.names.push(class_decl.ident.sym.to_string());
+      }
+      swc_ecmascript::ast::Decl::Fn(fn_decl) => {
+        self.names.push(fn_decl.ident.sym.to_string());
+      }
+      swc_ecmascript::ast::Decl::Var(var_decl) => {
+        for decl in var_decl.decls.iter() {
+          visit_pat(&decl.name, &mut self.names);
+        }
+      }
+      swc_ecmascript::ast::Decl::TsEnum(ts_enum_decl) => {
+        self.names.push(ts_enum_decl.id.sym.to_string());
+      }
+      // Interfaces, Type Aliases, and TS Module/Namespace decl are noops
+      _ => {}
+    }
+  }
+
+  fn visit_named_export(
+    &mut self,
+    node: &swc_ecmascript::ast::NamedExport,
+    _parent: &dyn visit::Node,
+  ) {
+    for spec in node.specifiers.iter() {
+      match spec {
+        swc_ecmascript::ast::ExportSpecifier::Named(named_spec) => {
+          if let Some(ident) = &named_spec.exported {
+            self.names.push(ident.sym.to_string());
+          } else {
+            self.names.push(named_spec.orig.sym.to_string());
+          }
+        }
+        swc_ecmascript::ast::ExportSpecifier::Namespace(namespace_spec) => {
+          self.names.push(namespace_spec.name.sym.to_string());
+        }
+        // Default is only proposed syntax, not current supported, so noop
+        _ => {}
+      }
+    }
+  }
+
+  fn visit_export_default_decl(
+    &mut self,
+    node: &swc_ecmascript::ast::ExportDefaultDecl,
+    _parent: &dyn visit::Node,
+  ) {
+    match &node.decl {
+      swc_ecmascript::ast::DefaultDecl::Class(_) => {
+        self.names.push("default".to_string())
+      }
+      swc_ecmascript::ast::DefaultDecl::Fn(_) => {
+        self.names.push("default".to_string())
+      }
+      // Interface is a noop
+      _ => {}
+    }
+  }
+
+  fn visit_export_default_expr(
+    &mut self,
+    _node: &swc_ecmascript::ast::ExportDefaultExpr,
+    _parent: &dyn visit::Node,
+  ) {
+    self.names.push("default".to_string());
+  }
+
+  fn visit_export_all(
+    &mut self,
+    node: &swc_ecmascript::ast::ExportAll,
+    _parent: &dyn visit::Node,
+  ) {
+    self.export_all_specifiers.push(node.src.value.to_string());
+  }
+}
+
+struct DependencyCollector<'a> {
+  comments: &'a SingleThreadedComments,
+  pub items: Vec<DependencyDescriptor>,
+  source_map: &'a SourceMap,
+}
+
+impl<'a> Visit for DependencyCollector<'a> {
+  fn visit_import_decl(
+    &mut self,
+    node: &swc_ecmascript::ast::ImportDecl,
+    _parent: &dyn visit::Node,
+  ) {
+    let specifier = node.src.value.to_string();
+    let span = node.span;
+    let location: Location = self.source_map.lookup_char_pos(span.lo).into();
+    let leading_comments = self
+      .comments
+      .with_leading(span.lo, |comments| comments.to_vec());
+    self.items.push(DependencyDescriptor {
+      leading_comments,
+      location,
+      specifier,
+      ..Default::default()
+    });
+  }
+
+  fn visit_named_export(
+    &mut self,
+    node: &swc_ecmascript::ast::NamedExport,
+    _parent: &dyn visit::Node,
+  ) {
+    if let Some(src) = &node.src {
+      let specifier = src.value.to_string();
+      let span = node.span;
+      let location: Location = self.source_map.lookup_char_pos(span.lo).into();
+      let leading_comments = self
+        .comments
+        .with_leading(span.lo, |comments| comments.to_vec());
+      self.items.push(DependencyDescriptor {
+        leading_comments,
+        location,
+        specifier,
+        ..Default::default()
+      });
+    }
+  }
+
+  fn visit_export_all(
+    &mut self,
+    node: &swc_ecmascript::ast::ExportAll,
+    _parent: &dyn visit::Node,
+  ) {
+    let specifier = node.src.value.to_string();
+    let span = node.span;
+    let location: Location = self.source_map.lookup_char_pos(span.lo).into();
+    let leading_comments = self
+      .comments
+      .with_leading(span.lo, |comments| comments.to_vec());
+    self.items.push(DependencyDescriptor {
+      leading_comments,
+      location,
+      specifier,
+      ..Default::default()
+    });
+  }
+
+  fn visit_ts_import_type(
+    &mut self,
+    node: &swc_ecmascript::ast::TsImportType,
+    _parent: &dyn visit::Node,
+  ) {
+    let specifier = node.arg.value.to_string();
+    let span = node.span;
+    let location: Location = self.source_map.lookup_char_pos(span.lo).into();
+    let leading_comments = self
+      .comments
+      .with_leading(span.lo, |comments| comments.to_vec());
+    self.items.push(DependencyDescriptor {
+      is_type: true,
+      leading_comments,
+      location,
+      specifier,
+      ..Default::default()
+    });
+  }
+
+  fn visit_call_expr(
+    &mut self,
+    node: &swc_ecmascript::ast::CallExpr,
+    _parent: &dyn visit::Node,
+  ) {
+    use swc_ecmascript::ast::Expr::*;
+    use swc_ecmascript::ast::ExprOrSuper::*;
+
+    swc_ecmascript::visit::visit_call_expr(self, node, _parent);
+    let call_expr = match node.callee.clone() {
+      Super(_) => return,
+      Expr(boxed) => boxed,
+    };
+
+    match &*call_expr {
+      Ident(ident) => {
+        if &ident.sym.to_string() != "import" {
+          return;
+        }
+      }
+      _ => return,
+    };
+
+    if let Some(arg) = node.args.get(0) {
+      if let Lit(lit) = &*arg.expr {
+        if let swc_ecmascript::ast::Lit::Str(str_) = lit {
+          let specifier = str_.value.to_string();
+          let span = node.span;
+          let location: Location =
+            self.source_map.lookup_char_pos(span.lo).into();
+          let leading_comments = self
+            .comments
+            .with_leading(span.lo, |comments| comments.to_vec());
+          self.items.push(DependencyDescriptor {
+            is_dynamic: true,
+            leading_comments,
+            location,
+            specifier,
+            ..Default::default()
+          });
+        }
+      }
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct EmitTranspileOptions {
+  /// When emitting a legacy decorator, also emit experimental decorator meta
+  /// data.  Defaults to `false`.
+  pub emit_metadata: bool,
+  /// Should the source map be inlined in the emitted code file, or provided
+  /// as a separate file.  Defaults to `true`.
+  pub inline_source_map: bool,
+  /// When transforming JSX, what value should be used for the JSX factory.
+  /// Defaults to `React.createElement`.
+  pub jsx_factory: String,
+  /// When transforming JSX, what value should be used for the JSX fragment
+  /// factory.  Defaults to `React.Fragment`.
+  pub jsx_fragment_factory: String,
+  /// Should JSX be transformed or preserved.  Defaults to `true`.
+  pub transform_jsx: bool,
+}
+
+impl Default for EmitTranspileOptions {
+  fn default() -> Self {
+    EmitTranspileOptions {
+      emit_metadata: false,
+      inline_source_map: true,
+      jsx_factory: "React.createElement".into(),
+      jsx_fragment_factory: "React.Fragment".into(),
+      transform_jsx: true,
+    }
+  }
+}
+
+/// A logical structure to hold the value of a parsed module for further
+/// processing.
+#[derive(Clone)]
+pub struct ParsedModule {
+  comments: SingleThreadedComments,
+  /// Leading comments for the module, where references and pragmas might be
+  /// contained.
+  pub leading_comments: Vec<Comment>,
+  module: Module,
+  /// The AST source for the module.
+  pub source_map: Rc<SourceMap>,
+}
+
+impl fmt::Debug for ParsedModule {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "ParsedModule {{ }}")
+  }
+}
+
+impl ParsedModule {
+  /// Identifies all syntactical dependencies of a module (e.g. `import` and
+  /// `export` statements) and returns them as a vector of descriptors.
+  pub fn get_dependencies(&self) -> Vec<DependencyDescriptor> {
+    let mut collector = DependencyCollector {
+      comments: &self.comments,
+      items: Vec::new(),
+      source_map: &self.source_map,
+    };
+    collector.visit_module(&self.module, &self.module);
+
+    collector.items
+  }
+
+  /// Identifies all the names that are exported from a module, or where there
+  /// is an export all statement, the string specifier of the re-exported
+  /// module.
+  pub fn get_export_names(&self) -> (Vec<String>, Vec<String>) {
+    let mut collector = ExportCollector::default();
+    collector.visit_module(&self.module, &self.module);
+
+    (collector.names, collector.export_all_specifiers)
+  }
+
+  /// Transpile a module to JavaScript supportable by Deno, erasing TypeScript
+  /// types and performing other transforms.
+  pub fn transpile(
+    self,
+    options: &EmitTranspileOptions,
+  ) -> Result<(String, Option<String>)> {
+    let program = Program::Module(self.module);
+    let base_pass = chain!(
+      decorators::decorators(decorators::Config {
+        legacy: true,
+        emit_metadata: options.emit_metadata,
+      }),
+      helpers::inject_helpers(),
+      typescript::strip(),
+      fixer(Some(&self.comments)),
+    );
+    let jsx_pass = react::react(
+      self.source_map.clone(),
+      react::Options {
+        pragma: options.jsx_factory.clone(),
+        pragma_frag: options.jsx_fragment_factory.clone(),
+        // this will use `Object.assign()` instead of the `_extends` helper
+        // when spreading props.
+        use_builtins: true,
+        ..Default::default()
+      },
+    );
+    let mut passes = if options.transform_jsx {
+      Either::Left(chain!(jsx_pass, base_pass))
+    } else {
+      Either::Right(base_pass)
+    };
+    let program = swc_common::GLOBALS.set(&Globals::new(), || {
+      helpers::HELPERS.set(&helpers::Helpers::new(false), || {
+        program.fold_with(&mut passes)
+      })
+    });
+
+    let mut mappings = Vec::new();
+    let mut buf = Vec::new();
+    {
+      let wr = Box::new(JsWriter::new(
+        self.source_map.clone(),
+        "\n",
+        &mut buf,
+        Some(&mut mappings),
+      ));
+      let cfg = Config { minify: false };
+      let mut emitter = swc_ecmascript::codegen::Emitter {
+        cfg,
+        comments: Some(&self.comments),
+        cm: self.source_map.clone(),
+        wr,
+      };
+      program.emit_with(&mut emitter)?;
+    }
+    let mut code = String::from_utf8(buf)?;
+    let mut map: Option<String> = None;
+    {
+      let mut buf = Vec::new();
+      self
+        .source_map
+        .build_source_map_from(&mut mappings, None)
+        .to_writer(&mut buf)?;
+
+      if options.inline_source_map {
+        code.push_str("//# sourceMappingURL=data:application/json;base64,");
+        let encoded_map = base64::encode(buf);
+        code.push_str(&encoded_map);
+      } else {
+        map = Some(String::from_utf8(buf)?);
+      }
+    }
+
+    Ok((code, map))
+  }
+}
+
+/// For a given specifier, source, and media type, parse the source of the
+/// module and return a representation which can be further processed.
+///
+/// # Arguments
+///
+/// - `specifier` - The module specifier for the module.
+/// - `source` - The source code for the module.
+/// - `media_type` - The media type for the module.
+///
+pub fn parse(
+  specifier: &ModuleSpecifier,
+  source: &str,
+  media_type: MediaType,
+) -> Result<ParsedModule> {
+  let source_map = SourceMap::default();
+  let source_file = source_map.new_source_file(
+    FileName::Custom(specifier.to_string()),
+    source.to_string(),
+  );
+  let error_buffer = ErrorBuffer::new();
+  let syntax = get_syntax(media_type);
+  let input = StringInput::from(&*source_file);
+  let comments = SingleThreadedComments::default();
+
+  let handler = Handler::with_emitter_and_flags(
+    Box::new(error_buffer.clone()),
+    HandlerFlags {
+      can_emit_warnings: true,
+      dont_buffer_diagnostics: true,
+      ..HandlerFlags::default()
+    },
+  );
+
+  let lexer = Lexer::new(syntax, TARGET, input, Some(&comments));
+  let mut parser = swc_ecmascript::parser::Parser::new_from(lexer);
+
+  let sm = &source_map;
+  let module = parser.parse_module().map_err(move |err| {
+    let mut diagnostic = err.into_diagnostic(&handler);
+    diagnostic.emit();
+
+    ErrBox::from(DiagnosticBuffer::from_error_buffer(error_buffer, |span| {
+      sm.lookup_char_pos(span.lo)
+    }))
+  })?;
+  let leading_comments =
+    comments.with_leading(module.span.lo, |comments| comments.to_vec());
+
+  Ok(ParsedModule {
+    leading_comments,
+    module,
+    source_map: Rc::new(source_map),
+    comments,
+  })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_parsed_module_get_dependencies() {
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/mod.js")
+        .unwrap();
+    let source = r#"import * as bar from "./test.ts";
+    const foo = await import("./foo.ts");
+    "#;
+    let parsed_module = parse(&specifier, source, MediaType::JavaScript)
+      .expect("could not parse module");
+    let actual = parsed_module.get_dependencies();
+    assert_eq!(
+      actual,
+      vec![
+        DependencyDescriptor {
+          is_dynamic: false,
+          is_type: false,
+          leading_comments: Vec::new(),
+          location: Location {
+            filename: "https://deno.land/x/mod.js".to_owned(),
+            col: 0,
+            line: 1,
+          },
+          specifier: "./test.ts".to_owned()
+        },
+        DependencyDescriptor {
+          is_dynamic: true,
+          is_type: false,
+          leading_comments: Vec::new(),
+          location: Location {
+            filename: "https://deno.land/x/mod.js".to_owned(),
+            col: 22,
+            line: 2,
+          },
+          specifier: "./foo.ts".to_owned()
+        }
+      ]
+    );
+  }
+
+  #[test]
+  fn test_parsed_module_get_export_names() {
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/mod.ts")
+        .unwrap();
+    let source = r#"
+    export * from "./a.ts";
+
+    export { a, b as c } from "./b.ts";
+
+    export default function () {
+      console.log("hello");
+    }
+
+    export enum C {
+      A,
+      B,
+      C,
+    }
+
+    export const [d, e, ...f] = [1, 2, 3, 4, 5];
+
+    export const g = 1;
+
+    export const { h, i: j, ...k } = { h: true, i: false, j: 1, k: 2 };
+
+    export class A {}
+
+    export function l() {}
+
+    export * as m from "./m.ts";
+    "#;
+    let parsed_module = parse(&specifier, source, MediaType::TypeScript)
+      .expect("could not parse module");
+    let (names, export_all_specifiers) = parsed_module.get_export_names();
+    assert_eq!(
+      names,
+      vec![
+        "a", "c", "default", "C", "d", "e", "f", "g", "h", "j", "k", "A", "l",
+        "m"
+      ]
+    );
+    assert_eq!(export_all_specifiers, vec!["./a.ts"]);
+  }
+
+  #[test]
+  fn test_parsed_module_get_leading_comments() {
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/mod.ts")
+        .unwrap();
+    let source = r#"// this is the first comment
+      // this is the second comment
+      import * as bar from "./test.ts";"#;
+    let parsed_module = parse(&specifier, source, MediaType::TypeScript)
+      .expect("could not parse module");
+    let dependencies = parsed_module.get_dependencies();
+    let leading_comments: Vec<&str> = dependencies[0]
+      .leading_comments
+      .iter()
+      .map(|c| c.text.as_str())
+      .collect();
+    assert_eq!(
+      leading_comments,
+      vec![" this is the first comment", " this is the second comment"]
+    );
+  }
+
+  #[test]
+  fn test_transpile() {
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/mod.ts")
+        .expect("could not resolve specifier");
+    let source = r#"
+    enum D {
+      A,
+      B,
+      C,
+    }
+
+    export class A {
+      private b: string;
+      protected c: number = 1;
+      e: "foo";
+      constructor (public d = D.A) {
+        const e = "foo" as const;
+        this.e = e;
+      }
+    }
+    "#;
+    let module = parse(&specifier, source, MediaType::TypeScript)
+      .expect("could not parse module");
+    let (code, maybe_map) = module
+      .transpile(&EmitTranspileOptions::default())
+      .expect("could not strip types");
+    assert!(code.starts_with("var D;\n(function(D) {\n"));
+    assert!(
+      code.contains("\n//# sourceMappingURL=data:application/json;base64,")
+    );
+    assert!(maybe_map.is_none());
+  }
+
+  #[test]
+  fn test_transpile_tsx() {
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/mod.ts")
+        .expect("could not resolve specifier");
+    let source = r#"
+    export class A {
+      render() {
+        return <div><span></span></div>
+      }
+    }
+    "#;
+    let module = parse(&specifier, source, MediaType::TSX)
+      .expect("could not parse module");
+    let (code, _) = module
+      .transpile(&EmitTranspileOptions::default())
+      .expect("could not strip types");
+    assert!(code.contains("React.createElement(\"div\", null"));
+  }
+
+  #[test]
+  fn test_transpile_decorators() {
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/mod.ts")
+        .expect("could not resolve specifier");
+    let source = r#"
+    function enumerable(value: boolean) {
+      return function (
+        _target: any,
+        _propertyKey: string,
+        descriptor: PropertyDescriptor,
+      ) {
+        descriptor.enumerable = value;
+      };
+    }
+    
+    export class A {
+      @enumerable(false)
+      a() {
+        Test.value;
+      }
+    }
+    "#;
+    let module = parse(&specifier, source, MediaType::TypeScript)
+      .expect("could not parse module");
+    let (code, _) = module
+      .transpile(&EmitTranspileOptions::default())
+      .expect("could not strip types");
+    assert!(code.contains("_applyDecoratedDescriptor("));
+  }
+}

--- a/compiler/bundler.rs
+++ b/compiler/bundler.rs
@@ -1,0 +1,194 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+use crate::source_map_bundler::SourceMapBundler;
+use crate::Result;
+
+use deno_core::ErrBox;
+use regex::Regex;
+use std::error::Error;
+use std::fmt;
+
+static SYSTEM_LOADER_CODE: &str = include_str!("system_loader.js");
+static SYSTEM_LOADER_ES5_CODE: &str = include_str!("system_loader_es5.js");
+
+lazy_static! {
+  static ref SOURCE_MAPPING_URL_RE: Regex =
+    Regex::new(r#"(?m)^//#\ssourceMappingURL=.+$"#).unwrap();
+}
+
+fn count_newlines(s: &str) -> usize {
+  bytecount::count(s.as_bytes(), b'\n')
+}
+
+struct BundleError(String);
+
+impl fmt::Display for BundleError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "Bundle Error: {}", self.0)
+  }
+}
+
+impl fmt::Debug for BundleError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "BundleError {{ message: {} }}", self.0)
+  }
+}
+
+impl Error for BundleError {}
+
+pub struct BundleFile {
+  pub code: String,
+  pub map: String,
+}
+
+#[derive(Default)]
+pub struct BundleOptions {
+  /// If `true` the source map will be inlined into the bundled JavaScript file.
+  /// Otherwise it will be returned in the result.
+  pub inline_source_map: bool,
+  /// The main module specifier to initialize to bootstrap the bundle.
+  pub main_specifier: String,
+  /// Any named exports that the main module specifier might have that should be
+  /// re-exported in the bundle.
+  pub maybe_named_exports: Option<Vec<String>>,
+  /// If `false` then a bundle loader that is compatible with ES2017 or later
+  /// will be used to bootstrap the module. If `true` then a bundle loader that
+  /// is compatible with ES5 or later will be used.  *Note* when targeting ES5
+  /// the `bundle()` function will error if the bundle requires top level await
+  /// for one of the modules.
+  pub target_es5: bool,
+}
+
+/// Take a vector of files and a structure of options and output a single file
+/// JavaScript file bundle.
+///
+/// # Arguments
+///
+/// * `files` - A vector of `BundleFile`s, which are preprocessed files where
+///   the code is a SystemJS module with a module specifier and the source map
+///   is a map between the original source code and the supplied code.
+/// * `options` - A structure of options which affect the behavior of the
+///   function.
+///
+/// # Errors
+///
+/// The function will error if there are issues processing the source map files
+/// or if there are incompatible option settings.
+///
+pub fn bundle(
+  files: Vec<BundleFile>,
+  options: BundleOptions,
+) -> Result<(String, Option<String>)> {
+  let mut code = String::new();
+  let preamble = if options.target_es5 {
+    SYSTEM_LOADER_ES5_CODE
+  } else {
+    SYSTEM_LOADER_CODE
+  };
+  code.push_str(preamble);
+  let mut source_map_bundle = SourceMapBundler::new(None);
+  for file in files.iter() {
+    let line_offset = count_newlines(&code);
+    let file_code = SOURCE_MAPPING_URL_RE.replace(&file.code, "");
+    code.push_str(&file_code);
+    source_map_bundle.append_from_str(&file.map, line_offset)?;
+  }
+  let has_exports = options.maybe_named_exports.is_some();
+  let top_level_await = code.contains("execute: async function");
+  if top_level_await && options.target_es5 {
+    let message = "The bundle target does not support top level await, but top level await is required.".to_string();
+    return Err(ErrBox::from(BundleError(message)));
+  }
+  let init_code = if has_exports {
+    if top_level_await {
+      format!(
+        "\nvar __exp = await __instantiate(\"{}\", true);\n",
+        options.main_specifier
+      )
+    } else {
+      format!(
+        "\nvar __exp = __instantiate(\"{}\", false);\n",
+        options.main_specifier
+      )
+    }
+  } else if top_level_await {
+    format!(
+      "\nawait __instantiate(\"{}\", true);\n",
+      options.main_specifier
+    )
+  } else {
+    format!("\n__instantiate(\"{}\", false);\n", options.main_specifier)
+  };
+  code.push_str(&init_code);
+  if let Some(named_exports) = options.maybe_named_exports {
+    for named_export in named_exports.iter() {
+      let export_code = match named_export.as_str() {
+        "default" => "export default __exp[\"default\"];\n".to_string(),
+        _ => format!(
+          "export var {} = __exp[\"{}\"];\n",
+          named_export, named_export
+        ),
+      };
+      code.push_str(&export_code);
+    }
+  };
+  let mut map_bytes: Vec<u8> = vec![];
+  source_map_bundle
+    .into_sourcemap()
+    .to_writer(&mut map_bytes)?;
+
+  if options.inline_source_map {
+    let map_base64 = base64::encode(map_bytes);
+    let map_pragma = format!(
+      "\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,{}\n",
+      map_base64
+    );
+    code.push_str(&map_pragma);
+
+    Ok((code, None))
+  } else {
+    let maybe_map = Some(String::from_utf8(map_bytes)?);
+
+    Ok((code, maybe_map))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_bundle() {
+    let (code, maybe_map) = bundle(
+      vec![BundleFile {
+        code: r#"System.register("https://deno.land/x/a.ts", [], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            console.log("hello deno");
+        }
+    };
+});
+"#.to_string(),
+        map: r#"{
+  "version": 3,
+  "sources": ["coolstuff.js"],
+  "names": ["x", "alert"],
+  "mappings": "AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM"
+}"#.to_string(),
+      }],
+      BundleOptions {
+        inline_source_map: true,
+        main_specifier: "https://deno.land/x/a.ts".to_string(),
+        maybe_named_exports: None,
+        target_es5: false,
+      },
+    )
+    .unwrap();
+    println!("{}", code);
+    assert!(code.starts_with("// Copyright 2018"));
+    assert!(maybe_map.is_none());
+  }
+}

--- a/compiler/colors.rs
+++ b/compiler/colors.rs
@@ -1,0 +1,159 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+use regex::Regex;
+use std::env;
+use std::fmt;
+use std::io::Write;
+use termcolor::Ansi;
+use termcolor::Color;
+use termcolor::ColorSpec;
+use termcolor::WriteColor;
+
+#[cfg(windows)]
+use termcolor::{BufferWriter, ColorChoice};
+
+lazy_static! {
+  // STRIP_ANSI_RE and strip_ansi_codes are lifted from the "console" crate.
+  // Copyright 2017 Armin Ronacher <armin.ronacher@active-4.com>. MIT License.
+  static ref STRIP_ANSI_RE: Regex = Regex::new(
+    r"[\x1b\x9b][\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]"
+  ).unwrap();
+
+  static ref NO_COLOR: bool = {
+    env::var_os("NO_COLOR").is_some()
+  };
+}
+
+/// Helper function to strip ansi codes.
+pub fn strip_ansi_codes(s: &str) -> std::borrow::Cow<str> {
+  STRIP_ANSI_RE.replace_all(s, "")
+}
+
+pub fn use_color() -> bool {
+  !(*NO_COLOR)
+}
+
+#[cfg(windows)]
+pub fn enable_ansi() {
+  BufferWriter::stdout(ColorChoice::AlwaysAnsi);
+}
+
+fn style(s: &str, colorspec: ColorSpec) -> impl fmt::Display {
+  if !use_color() {
+    return String::from(s);
+  }
+  let mut v = Vec::new();
+  let mut ansi_writer = Ansi::new(&mut v);
+  ansi_writer.set_color(&colorspec).unwrap();
+  ansi_writer.write_all(s.as_bytes()).unwrap();
+  ansi_writer.reset().unwrap();
+  String::from_utf8_lossy(&v).into_owned()
+}
+
+pub fn red_bold(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Color::Red)).set_bold(true);
+  style(&s, style_spec)
+}
+
+pub fn green_bold(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec
+    .set_fg(Some(Color::Green))
+    .set_bold(true)
+    .set_intense(true);
+  style(&s, style_spec)
+}
+
+pub fn italic_bold(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_bold(true).set_italic(true);
+  style(&s, style_spec)
+}
+
+pub fn black_on_white(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec
+    .set_bg(Some(Color::White))
+    .set_fg(Some(Color::Black));
+  style(&s, style_spec)
+}
+
+pub fn white_on_red(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec
+    .set_bg(Some(Color::Red))
+    .set_fg(Some(Color::White));
+  style(&s, style_spec)
+}
+
+pub fn white_on_green(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec
+    .set_bg(Some(Color::Ansi256(10)))
+    .set_fg(Some(Color::White));
+  style(&s, style_spec)
+}
+
+pub fn yellow(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Color::Ansi256(11)));
+  style(&s, style_spec)
+}
+
+pub fn cyan(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Color::Ansi256(14)));
+  style(&s, style_spec)
+}
+
+pub fn red(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Color::Red));
+  style(&s, style_spec)
+}
+
+pub fn green(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Color::Green)).set_intense(true);
+  style(&s, style_spec)
+}
+
+pub fn magenta(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Color::Magenta));
+  style(&s, style_spec)
+}
+
+pub fn bold(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_bold(true);
+  style(&s, style_spec)
+}
+
+pub fn gray(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Color::Ansi256(8)));
+  style(&s, style_spec)
+}
+
+pub fn italic_gray(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Color::Ansi256(8))).set_italic(true);
+  style(&s, style_spec)
+}
+
+pub fn italic_bold_gray(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec
+    .set_fg(Some(Color::Ansi256(8)))
+    .set_bold(true)
+    .set_italic(true);
+  style(&s, style_spec)
+}
+
+pub fn intense_blue(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Color::Blue)).set_intense(true);
+  style(&s, style_spec)
+}

--- a/compiler/compiler.js
+++ b/compiler/compiler.js
@@ -1,0 +1,427 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+// @ts-check
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="./globals.d.ts" />
+
+const ASSETS = "asset:///";
+const CACHE = "cache:///";
+
+const IGNORED_DIAGNOSTICS = [
+  1063, // TS1063: An export assignment cannot be used in a namespace.
+  2691, // TS2691: An import path cannot end with a '.ts' extension.
+  5009, // TS5009: Cannot find the common subdirectory path for the input files.
+];
+
+/** **Warning!** Op ids must be acquired from Rust using `Deno.core.ops()`
+ * before dispatching any action.
+ * @type {Record<string, number>} */
+let ops;
+
+/** @type {boolean | undefined} */
+let debugFlag = true;
+
+/** @type {Map<string, ts.SourceFile>} */
+const sourceFileCache = new Map();
+
+/**
+ * @param {unknown} cond
+ * @param {string} msg
+ * @returns {asserts cond}
+ */
+function assert(cond, msg = "assert") {
+  if (!cond) {
+    throw Error(msg);
+  }
+}
+
+/**
+ * @param {string} opName
+ * @param {Record<string,any>} args
+ */
+function dispatch(opName, args) {
+  const opId = ops[opName];
+
+  if (!opId) {
+    throw new Error(`Unknown op: ${opName}`);
+  }
+
+  const msg = Deno.core.encode(JSON.stringify(args));
+  const resUi8 = Deno.core.dispatch(opId, msg);
+  const res = JSON.parse(Deno.core.decode(resUi8));
+  if (!res["ok"]) {
+    throw Error(
+      `${opName} failed ${res["err"]}. Args: ${JSON.stringify(args)}`,
+    );
+  }
+  return res["ok"];
+}
+
+/** @param  {...string} s */
+function println(...s) {
+  if (debugFlag) {
+    Deno.core.print(`[TS]: ${s.join(" ")}\n`);
+  }
+}
+
+/** @returns {never} */
+function unreachable() {
+  throw Error("unreachable");
+}
+
+/**
+ * @param {readonly ts.Diagnostic[]} diagnostics
+ * @returns {readonly any[]}
+ */
+function processDiagnostics(diagnostics) {
+  return diagnostics.map((diagnostic) => {
+    /** @type {any} */
+    const { messageText, file, ...result } = diagnostic;
+    if (file) {
+      result.sourceFile = file.fileName;
+    }
+    if (typeof messageText === "string") {
+      result.messageText = messageText;
+    } else {
+      result.messageChain = messageText;
+    }
+    return result;
+  });
+}
+
+/** @type {ts.CompilerHost} */
+const host = {
+  fileExists(fileName) {
+    println(`host.fileExists("${fileName}")`);
+    return unreachable();
+  },
+  readFile(fileName) {
+    println(`host.readFile("${fileName}")`);
+    return dispatch("op_read_file", { fileName }).data;
+  },
+  getSourceFile(
+    specifier,
+    languageVersion,
+    onError,
+    _shouldCreateNewSourceFile,
+  ) {
+    println(
+      `host.getSourceFile("${specifier}", ${ts.ScriptTarget[languageVersion]})`,
+    );
+    const sourceFile = sourceFileCache.get(specifier);
+    if (sourceFile) {
+      return sourceFile;
+    }
+
+    try {
+      /** @type {{ data: string; hash: string; }} */
+      const { data, hash } = dispatch("op_load_module", { specifier });
+      const sourceFile = ts.createSourceFile(specifier, data, languageVersion);
+      sourceFile.moduleName = specifier;
+      sourceFile.version = hash;
+      sourceFileCache.set(specifier, sourceFile);
+      return sourceFile;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : JSON.stringify(err);
+      println(`  !! error: ${message}`);
+      if (onError) {
+        onError(message);
+      } else {
+        throw err;
+      }
+    }
+  },
+  getDefaultLibFileName() {
+    return `lib.esnext.d.ts`;
+  },
+  getDefaultLibLocation() {
+    return ASSETS;
+  },
+  writeFile(fileName, data, _writeByteOrderMark, _onError, sourceFiles) {
+    println(`host.writeFile("${fileName}")`);
+    let maybeModuleName;
+    if (sourceFiles) {
+      assert(sourceFiles.length === 1, "unexpected number of source files");
+      const [sourceFile] = sourceFiles;
+      maybeModuleName = sourceFile.moduleName;
+      println(`  moduleName: ${maybeModuleName}`);
+    }
+    return dispatch("op_write_file", { maybeModuleName, fileName, data });
+  },
+  getCurrentDirectory() {
+    return CACHE;
+  },
+  getCanonicalFileName(fileName) {
+    return fileName;
+  },
+  useCaseSensitiveFileNames() {
+    return true;
+  },
+  getNewLine() {
+    return "\n";
+  },
+  resolveModuleNames(specifiers, base) {
+    println(`host.resolveModuleNames()`);
+    println(`  base: ${base}`);
+    println(`  specifiers: ${specifiers.join(", ")}`);
+    /** @type {Array<[string, ts.Extension]>} */
+    const resolved = dispatch("op_resolve_specifiers", {
+      specifiers,
+      base,
+    });
+    return resolved.map(([resolvedFileName, extension]) => ({
+      resolvedFileName,
+      extension,
+      isExternalLibraryImport: false,
+    }));
+  },
+  createHash(data) {
+    return dispatch("op_create_hash", { data }).hash;
+  },
+};
+
+/**
+ * @param {Record<string, any>} compilerOptions
+ * @returns {{ options: ts.CompilerOptions, diagnostics?: ts.Diagnostic[] }}
+ */
+function configure(compilerOptions) {
+  const { options, errors } = ts.convertCompilerOptionsFromJson(
+    compilerOptions,
+    "",
+    "tsconfig.json",
+  );
+  return { options, diagnostics: errors.length ? errors : undefined };
+}
+
+/**
+ * @param {[string, number][]} stats
+ * @param {number} start
+ */
+function addTimes(stats, start) {
+  const programTime = ts.performance.getDuration("Program");
+  const bindTime = ts.performance.getDuration("Bind");
+  const checkTime = ts.performance.getDuration("Check");
+  const emitTime = ts.performance.getDuration("Emit");
+  stats.push(["Parse time", programTime]);
+  stats.push(["Bind time", bindTime]);
+  stats.push(["Check time", checkTime]);
+  stats.push(["Emit time", emitTime]);
+  stats.push(["Total TS time", programTime + bindTime + checkTime + emitTime]);
+  ts.performance.disable();
+  stats.push(["Duration", Date.now() - start]);
+}
+
+/**
+ * @typedef {object} Source
+ * @property {string} data
+ * @property {string=} hash
+ */
+
+/**
+ * @typedef {object} CompileRequest
+ * @property {Record<string, any>} compilerOptions
+ * @property {boolean} debug
+ * @property {string[]} rootNames
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/**
+ * @param {CompileRequest} request
+ */
+function compile(request) {
+  const start = Date.now();
+  ts.performance.enable();
+  const { compilerOptions, debug, rootNames } = request;
+  debugFlag = debug;
+
+  println(">>> compile");
+
+  const { options, diagnostics: configFileParsingDiagnostics } = configure(
+    compilerOptions,
+  );
+
+  assert(rootNames.length === 1, "only single root names supported");
+  const [rootSpecifier] = rootNames;
+  const builderProgram = ts.createIncrementalProgram({
+    rootNames: [rootSpecifier],
+    options,
+    host,
+    configFileParsingDiagnostics,
+  });
+
+  const diagnostics = [
+    ...builderProgram.getConfigFileParsingDiagnostics(),
+    ...builderProgram.getSyntacticDiagnostics(),
+    ...builderProgram.getOptionsDiagnostics(),
+    ...builderProgram.getGlobalDiagnostics(),
+    ...builderProgram.getSemanticDiagnostics(),
+  ].filter(({ code }) => !IGNORED_DIAGNOSTICS.includes(code));
+
+  /** @type {ts.EmitResult} */
+  let emitResult;
+
+  if (diagnostics.length) {
+    emitResult = { emitSkipped: true, diagnostics };
+  } else {
+    const { emitSkipped, diagnostics: emitDiagnostics } = builderProgram.emit();
+    emitResult = {
+      emitSkipped,
+      diagnostics: emitDiagnostics.filter(
+        ({ code }) => !IGNORED_DIAGNOSTICS.includes(code),
+      ),
+    };
+  }
+
+  /** @type {[string, number][]} */
+  const stats = [];
+  const program = builderProgram.getProgram();
+  stats.push(["Files", program.getSourceFiles().length]);
+  stats.push(["Nodes", program.getNodeCount()]);
+  stats.push(["Identifiers", program.getIdentifierCount()]);
+  stats.push(["Symbols", program.getSymbolCount()]);
+  stats.push(["Types", program.getTypeCount()]);
+  stats.push(["Instantiations", program.getInstantiationCount()]);
+  addTimes(stats, start);
+  ts.performance.disable();
+
+  dispatch(
+    "op_set_emit_result",
+    Object.assign(emitResult, {
+      diagnostics: processDiagnostics(emitResult.diagnostics),
+      stats,
+    }),
+  );
+  println("<<< compile");
+}
+
+/**
+ * @typedef {object} SourceFile
+ * @property {string} data
+ * @property {ts.MapLike<string>=} renamedDependencies
+ */
+
+/**
+ * @typedef {object} TranspileRequest
+ * @property {Record<string, any>} compilerOptions
+ * @property {boolean} debug
+ * @property {Record<string, SourceFile>} sources
+ */
+
+/**
+ * @param {TranspileRequest} request
+ */
+function transpile(request) {
+  const start = Date.now();
+  ts.performance.enable();
+  const { compilerOptions, debug, sources } = request;
+  debugFlag = debug;
+
+  println(">>> transpile");
+
+  const { options, diagnostics } = configure(compilerOptions);
+
+  /** @type {string[]} */
+  const emittedFiles = [];
+  /** @type {ts.EmitResult | undefined} */
+  let emitResult;
+  if (diagnostics && diagnostics.length) {
+    emitResult = { emitSkipped: true, diagnostics: diagnostics, emittedFiles };
+  } else {
+    for (
+      const [fileName, { data, renamedDependencies }] of Object.entries(
+        sources,
+      )
+    ) {
+      const { outputText, sourceMapText, diagnostics } = ts.transpileModule(
+        data,
+        {
+          fileName,
+          moduleName: fileName,
+          compilerOptions: options,
+          reportDiagnostics: true,
+          renamedDependencies,
+        },
+      );
+      if (diagnostics && diagnostics.length) {
+        emitResult = { emitSkipped: true, diagnostics, emittedFiles };
+        break;
+      }
+      assert(outputText, "missing code output");
+      const codeFileName = fileName.replace(/\.ts$/, ".js");
+      dispatch("op_write_file", {
+        maybeModuleName: fileName,
+        fileName: codeFileName,
+        data: outputText,
+      });
+      emittedFiles.push(codeFileName);
+      if (options.sourceMap) {
+        assert(sourceMapText, "missing source map");
+        const mapFileName = fileName.replace(/\.ts$/, ".js.map");
+        dispatch("op_write_file", {
+          maybeModuleName: fileName,
+          fileName: mapFileName,
+          data: sourceMapText,
+        });
+        emittedFiles.push(mapFileName);
+      }
+    }
+    if (!emitResult) {
+      emitResult = { emitSkipped: false, diagnostics: [], emittedFiles };
+    }
+  }
+
+  /** @type {[string, number][]} */
+  const stats = [];
+  addTimes(stats, start);
+  ts.performance.disable();
+
+  dispatch(
+    "op_set_emit_result",
+    Object.assign(emitResult, {
+      diagnostics: processDiagnostics(emitResult.diagnostics),
+      stats,
+    }),
+  );
+  println("<<< transpile");
+}
+
+/**
+ * @typedef {object} BootstrapConfig
+ * @property {string} bootSpecifier
+ * @property {Record<string, any>} compilerOptions
+ * @property {Record<string, string>} libs
+ */
+
+/**
+ * Bootstrap the compiler.  This acquires the ops for the isolate and generates
+ * a program, which hydrates the static assets as source modules.  At this point
+ * the isolate can be snapshotted with as much of the TypeScript compiler warmed
+ * up as possible.
+ *
+ * @param {BootstrapConfig} config
+ */
+function main(config) {
+  println(`main(${JSON.stringify(config)})`);
+  ops = Deno.core.ops();
+  const { bootSpecifier, compilerOptions, libs } = config;
+  for (const [lib, specifier] of Object.entries(libs)) {
+    if (!ts.libs.includes(lib)) {
+      ts.libs.push(lib);
+      ts.libMap.set(lib, specifier);
+    }
+    assert(host.getSourceFile(`${ASSETS}${specifier}`, ts.ScriptTarget.ESNext));
+  }
+  const { options, diagnostics: configFileParsingDiagnostics } = configure(
+    compilerOptions,
+  );
+  const program = ts.createProgram({
+    rootNames: [bootSpecifier],
+    options,
+    host,
+    configFileParsingDiagnostics,
+  });
+  program.emit();
+  dispatch("op_set_version", { version: ts.version });
+}
+/* eslint-enable */

--- a/compiler/compiler.rs
+++ b/compiler/compiler.rs
@@ -1,0 +1,623 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+use crate::config::json_merge;
+use crate::config::parse_config;
+use crate::module_graph::ModuleProvider;
+use crate::msg::as_ts_filename;
+use crate::msg::CompilerStats;
+use crate::msg::Diagnostics;
+use crate::msg::EmittedFile;
+use crate::msg::IgnoredCompilerOptions;
+use crate::msg::TranspileSourceFile;
+use crate::ops;
+use crate::ops::compiler_op;
+use crate::ops::json_op;
+use crate::CompileOptions;
+use crate::Result;
+use crate::TranspileOptions;
+
+use deno_core::js_check;
+use deno_core::CoreIsolate;
+use deno_core::ModuleSpecifier;
+use deno_core::StartupData;
+use serde::Deserialize;
+use serde_json::json;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+pub type Sources = HashMap<String, String>;
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EmitResult {
+  pub emit_skipped: bool,
+  pub diagnostics: Diagnostics,
+  pub emitted_files: Option<Vec<String>>,
+  pub stats: CompilerStats,
+}
+
+#[derive(Default)]
+pub struct CompilerState {
+  pub emit_result: Option<EmitResult>,
+  pub hash_data: Vec<Vec<u8>>,
+  pub maybe_assets_path: Option<PathBuf>,
+  pub maybe_build_info: Option<String>,
+  pub maybe_provider: Option<Rc<RefCell<dyn ModuleProvider>>>,
+  pub maybe_shared_path: Option<String>,
+  pub sources: Sources,
+  pub version: String,
+  pub written_files: Vec<EmittedFile>,
+}
+
+pub struct InternalCompileOptions<'a> {
+  pub bundle: bool,
+  pub check_only: bool,
+  pub provider: Rc<RefCell<dyn ModuleProvider>>,
+  pub root_names: Vec<&'a ModuleSpecifier>,
+  pub maybe_build_info: Option<String>,
+  pub maybe_shared_path: Option<String>,
+  pub compile_options: CompileOptions<'a>,
+}
+
+pub struct InternalTranspileOptions {
+  pub bundle: bool,
+  pub sources: HashMap<String, TranspileSourceFile>,
+  pub transpile_options: TranspileOptions,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// The result of a compilation.
+pub struct CompilerEmit {
+  pub cache_js: bool,
+  /// Statistics returned from the compiler regarding the transpilation.
+  pub stats: CompilerStats,
+  pub maybe_build_info: Option<String>,
+  /// If a configuration was supplied and the configuration contained options
+  /// that were ignored, the would be returned here.
+  pub maybe_ignored_options: Option<IgnoredCompilerOptions>,
+  pub written_files: Vec<EmittedFile>,
+}
+
+/// Register operations that will be called from the compiler's JavaScript code.
+fn register_ops(isolate: &mut CoreIsolate, state: &Arc<Mutex<CompilerState>>) {
+  isolate.register_op(
+    "op_create_hash",
+    compiler_op(state.clone(), json_op(ops::op_create_hash)),
+  );
+  isolate.register_op(
+    "op_load_module",
+    compiler_op(state.clone(), json_op(ops::op_load_module)),
+  );
+  isolate.register_op(
+    "op_read_file",
+    compiler_op(state.clone(), json_op(ops::op_read_file)),
+  );
+  isolate.register_op(
+    "op_resolve_specifiers",
+    compiler_op(state.clone(), json_op(ops::op_resolve_specifiers)),
+  );
+  isolate.register_op(
+    "op_set_emit_result",
+    compiler_op(state.clone(), json_op(ops::op_set_emit_result)),
+  );
+  isolate.register_op(
+    "op_set_version",
+    compiler_op(state.clone(), json_op(ops::op_set_version)),
+  );
+  isolate.register_op(
+    "op_write_file",
+    compiler_op(state.clone(), json_op(ops::op_write_file)),
+  );
+}
+
+/// Create a snapshot of a Deno TypeScript compiler.  The return value is the
+/// version of the TypeScript compiler that the snapshot was created for.
+///
+/// # Arguments
+///
+/// * `snapshot_path` - the path the resulting snapshot (`.bin`) should be
+///   written to.
+/// * `assets_path` - the path that contains `typescript.js` and all of the
+///   default `.d.ts` files which will be built into the snapshot.
+/// * `custom_libs` - A hashmap that contains any custom libs to be registered
+///   with the compiler snapshot.
+///
+/// # Examples
+///
+/// ```
+/// use deno_compiler::create_compiler_snapshot;
+///
+/// # let c = std::path::PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
+/// # let mut custom_libs = std::collections::HashMap::new();
+/// # custom_libs.insert("test".to_string(), c.join("fixtures/lib.test.d.ts"));
+/// let version = create_compiler_snapshot(
+///   std::env::temp_dir().join("TEST_COMPILER.bin"),
+///   c.join("../cli/dts"),
+///   custom_libs,
+/// ).expect("snapshot creation failed");
+/// ```
+///
+pub fn create_compiler_snapshot(
+  snapshot_path: PathBuf,
+  assets_path: PathBuf,
+  custom_libs: HashMap<String, PathBuf>,
+) -> Result<String> {
+  let mut isolate = CoreIsolate::new(StartupData::None, true);
+  let typescript_path = assets_path.join("../tsc/00_typescript.js");
+  let typescript_source = fs::read_to_string(typescript_path)?;
+  let compiler_source = fs::read_to_string("compiler.js")?;
+  js_check(isolate.execute("typescript.js", &typescript_source));
+  js_check(isolate.execute("compiler.js", &compiler_source));
+
+  let mut libs: HashMap<&str, &str> = HashMap::new();
+  libs.insert("dom", "lib.dom.d.ts");
+  libs.insert("dom.iterable", "lib.dom.iterable.d.ts");
+  libs.insert("es5", "lib.es5.d.ts");
+  libs.insert("es6", "lib.es6.d.ts");
+  libs.insert("es2015.collection", "lib.es2015.collection.d.ts");
+  libs.insert("es2015.core", "lib.es2015.core.d.ts");
+  libs.insert("es2015", "lib.es2015.d.ts");
+  libs.insert("es2015.generator", "lib.es2015.generator.d.ts");
+  libs.insert("es2015.iterable", "lib.es2015.iterable.d.ts");
+  libs.insert("es2015.promise", "lib.es2015.promise.d.ts");
+  libs.insert("es2015.proxy", "lib.es2015.proxy.d.ts");
+  libs.insert("es2015.reflect", "lib.es2015.reflect.d.ts");
+  libs.insert("es2015.symbol", "lib.es2015.symbol.d.ts");
+  libs.insert(
+    "es2015.symbol.wellknown",
+    "lib.es2015.symbol.wellknown.d.ts",
+  );
+  libs.insert("es2016.array.include", "lib.es2016.array.include.d.ts");
+  libs.insert("es2016", "lib.es2016.d.ts");
+  libs.insert("es2017", "lib.es2017.d.ts");
+  libs.insert("es2017.intl", "lib.es2017.intl.d.ts");
+  libs.insert("es2017.object", "lib.es2017.object.d.ts");
+  libs.insert("es2017.sharedmemory", "lib.es2017.sharedmemory.d.ts");
+  libs.insert("es2017.string", "lib.es2017.string.d.ts");
+  libs.insert("es2017.typedarrays", "lib.es2017.typedarrays.d.ts");
+  libs.insert("es2018.asyncgenerator", "lib.es2018.asyncgenerator.d.ts");
+  libs.insert("es2018.asynciterable", "lib.es2018.asynciterable.d.ts");
+  libs.insert("es2018", "lib.es2018.d.ts");
+  libs.insert("es2018.intl", "lib.es2018.intl.d.ts");
+  libs.insert("es2018.promise", "lib.es2018.promise.d.ts");
+  libs.insert("es2018.regexp", "lib.es2018.regexp.d.ts");
+  libs.insert("es2019.array", "lib.es2019.array.d.ts");
+  libs.insert("es2019", "lib.es2019.d.ts");
+  libs.insert("es2019.object", "lib.es2019.object.d.ts");
+  libs.insert("es2019.string", "lib.es2019.string.d.ts");
+  libs.insert("es2019.symbol", "lib.es2019.symbol.d.ts");
+  libs.insert("es2020.bigint", "lib.es2020.bigint.d.ts");
+  libs.insert("es2020", "lib.es2020.d.ts");
+  libs.insert("es2020.intl", "lib.es2020.intl.d.ts");
+  libs.insert("es2020.promise", "lib.es2020.promise.d.ts");
+  libs.insert("es2020.string", "lib.es2020.string.d.ts");
+  libs.insert(
+    "es2020.symbol.wellknown",
+    "lib.es2020.symbol.wellknown.d.ts",
+  );
+  libs.insert("esnext", "lib.esnext.d.ts");
+  libs.insert("esnext.intl", "lib.esnext.intl.d.ts");
+  libs.insert("esnext.promise", "lib.esnext.promise.d.ts");
+  libs.insert("esnext.string", "lib.esnext.string.d.ts");
+  libs.insert("scripthost", "lib.scripthost.d.ts");
+  libs.insert("webworker", "lib.webworker.d.ts");
+  libs.insert(
+    "webworker.importscripts",
+    "lib.webworker.importscripts.d.ts",
+  );
+
+  let mut sources: HashMap<String, String> = HashMap::new();
+  sources.insert(
+    "file:///bootstrap.ts".to_string(),
+    "console.log(\"hello deno\");\nexport {}; \n".to_string(),
+  );
+
+  for (lib, file_path) in custom_libs.iter() {
+    let source = std::fs::read_to_string(file_path)?;
+    let file_name = file_path.file_name().unwrap().to_str().unwrap();
+    let specifier = format!("asset:///{}", file_name);
+    libs.insert(lib, file_name);
+    sources.insert(specifier, source);
+  }
+
+  let state = Arc::new(Mutex::new(CompilerState {
+    maybe_assets_path: Some(assets_path),
+    sources,
+    ..Default::default()
+  }));
+
+  register_ops(&mut isolate, &state);
+
+  let compiler_options = json!({
+    "lib": ["esnext"],
+    "module": "esnext",
+    "target": "esnext",
+  });
+
+  let config = json!({
+    "bootSpecifier": "file:///bootstrap.ts",
+    "compilerOptions": compiler_options,
+    "libs": libs,
+  });
+
+  let js_source = format!("main({})", config);
+
+  js_check(isolate.execute("<anon>", &js_source));
+
+  let snapshot = isolate.snapshot();
+  let snapshot_slice: &[u8] = &*snapshot;
+  println!("[RS]: snapshot size: {}", snapshot_slice.len());
+  fs::write(snapshot_path.clone(), snapshot_slice)?;
+  println!("[RS]: snapshot written to: {} ", snapshot_path.display());
+  let state = state.lock().expect("could not lock state");
+  let version = state.version.clone();
+
+  Ok(version)
+}
+
+/// An abstraction for a Deno isolate which allows code to be compiled and
+/// transformed from TypeScript to JavaScript.
+pub struct CompilerIsolate {
+  isolate: CoreIsolate,
+  state: Arc<Mutex<CompilerState>>,
+}
+
+impl CompilerIsolate {
+  /// Returns an instance of a Deno compiler isolate based on the provided
+  /// start-up data.
+  ///
+  /// # Arguments
+  ///
+  /// * `startup_data` - This should be startup data based on a snapshot created
+  ///   by `create_compiler_snapshot()`.
+  ///
+  pub fn new(startup_data: StartupData) -> Self {
+    let mut isolate = CoreIsolate::new(startup_data, false);
+
+    let state = Arc::new(Mutex::new(CompilerState::default()));
+
+    register_ops(&mut isolate, &state);
+
+    CompilerIsolate { isolate, state }
+  }
+
+  /// Given a module graph, perform a type check and return the emitted files
+  /// plus other data.  This method also supports incremental compilation.
+  ///
+  /// # Arguments
+  ///
+  /// * `options` - A structure of compile options.
+  ///
+  /// # Errors
+  ///
+  /// If there are TypeScript diagnostics returned from the isolate when
+  /// emitting the program, this method will error with those diagnostics.
+  ///
+  pub fn compile(
+    &mut self,
+    options: InternalCompileOptions,
+  ) -> Result<CompilerEmit> {
+    let mut compiler_options = json!({
+      "allowJs": true,
+      "esModuleInterop": true,
+      "inlineSourceMap": true,
+      "jsx": "react",
+      "lib": options.compile_options.lib,
+      "module": "esnext",
+      "outDir": "cache:///",
+      "removeComments": true,
+      "strict": true,
+      "target": "esnext",
+    });
+    if options.compile_options.incremental {
+      let incremental_options = json!({
+        "incremental": true,
+        "tsBuildInfoFile": "cache:///.tsbuildinfo",
+      });
+      json_merge(&mut compiler_options, &incremental_options);
+    }
+    if options.bundle {
+      let bundle_options = json!({
+        "inlineSourceMap": false,
+        "module": "system",
+        "sourceMap": true,
+      });
+      json_merge(&mut compiler_options, &bundle_options);
+    }
+    if options.check_only {
+      let check_only_options = json!({
+        "noEmit": true,
+      });
+      json_merge(&mut compiler_options, &check_only_options);
+    }
+
+    let maybe_ignored_options =
+      if let Some(config_text) = options.compile_options.maybe_config {
+        let (user_config, ignored_options) = parse_config(config_text)?;
+        json_merge(&mut compiler_options, &user_config);
+        ignored_options
+      } else {
+        None
+      };
+
+    let mut cache_js = false;
+    if let Some(value) = compiler_options.as_object().unwrap().get("checkJs") {
+      cache_js = value.as_bool().unwrap_or(false);
+    }
+
+    let mut state = self.state.lock().expect("clould not lock state");
+    state.maybe_provider = Some(options.provider);
+    let maybe_shared_path = options.maybe_shared_path.clone();
+    state.maybe_build_info = options.maybe_build_info;
+    state.maybe_shared_path = options.maybe_shared_path.clone();
+    drop(state);
+
+    let root_names: Vec<String> = options
+      .root_names
+      .iter()
+      .map(|s| as_ts_filename(s, &maybe_shared_path))
+      .collect();
+    let request = json!({
+      "compilerOptions": compiler_options,
+      "debug": options.compile_options.debug,
+      "rootNames": root_names,
+    });
+
+    let js_source = format!("compile({})", request);
+    js_check(self.isolate.execute("<anon>", &js_source));
+
+    let state = self.state.lock().unwrap();
+    let emit_result = state.emit_result.clone().unwrap();
+    if !emit_result.diagnostics.0.is_empty() {
+      Err(emit_result.diagnostics.into())
+    } else {
+      Ok(CompilerEmit {
+        cache_js,
+        stats: emit_result.stats,
+        maybe_build_info: state.maybe_build_info.clone(),
+        maybe_ignored_options,
+        written_files: state.written_files.clone(),
+      })
+    }
+  }
+
+  /// Given a module graph, return transpiled sources, without performing any
+  /// type checking.
+  ///
+  /// # Arguments
+  ///
+  /// * `options` - A structure of transpile options.
+  ///
+  /// # Errors
+  ///
+  /// If there are TypeScript diagnostics returned from the isolate when
+  /// emitting the program, this method will error with those diagnostics.
+  ///
+  pub fn transpile(
+    &mut self,
+    options: InternalTranspileOptions,
+  ) -> Result<CompilerEmit> {
+    let mut compiler_options = json!({
+      "esModuleInterop": true,
+      "inlineSourceMap": true,
+      "jsx": "react",
+      "module": "esnext",
+      "removeComments": true,
+      "target": "esnext",
+    });
+
+    if options.bundle {
+      let bundle_options = json!({
+        "inlineSourceMap": false,
+        "module": "system",
+        "sourceMap": true,
+      });
+      json_merge(&mut compiler_options, &bundle_options);
+    }
+
+    let maybe_ignored_options =
+      if let Some(config_text) = options.transpile_options.maybe_config {
+        let (user_config, ignored_options) = parse_config(config_text)?;
+        json_merge(&mut compiler_options, &user_config);
+        ignored_options
+      } else {
+        None
+      };
+
+    let request = json!({
+      "compilerOptions": compiler_options,
+      "debug": options.transpile_options.debug,
+      "sources": options.sources,
+    });
+
+    let js_source = format!("transpile({})", request);
+    js_check(self.isolate.execute("<anon>", &js_source));
+
+    let state = self.state.lock().unwrap();
+    let emit_result = state.emit_result.clone().unwrap();
+    if !emit_result.diagnostics.0.is_empty() {
+      Err(emit_result.diagnostics.into())
+    } else {
+      Ok(CompilerEmit {
+        cache_js: false,
+        stats: emit_result.stats,
+        maybe_build_info: None,
+        maybe_ignored_options,
+        written_files: state.written_files.clone(),
+      })
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::module_graph::GraphBuilder;
+  use crate::tests::MockSpecifierHandler;
+  use deno_core::ModuleSpecifier;
+  use deno_core::Snapshot;
+  use std::cell::RefCell;
+  use std::env;
+  use std::rc::Rc;
+  use tempfile::TempDir;
+
+  fn get_compiler(rebuild: bool) -> Result<CompilerIsolate> {
+    let o = env::temp_dir();
+    let snapshot_path = o.join("TEST_COMPILER.bin");
+    if rebuild || !snapshot_path.is_file() {
+      let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+      let assets_path = c.join("../cli/dts");
+      assert!(assets_path.is_dir());
+      let test_fixtures_path = c.join("fixtures");
+      assert!(test_fixtures_path.is_dir());
+      let mut custom_libs = HashMap::new();
+      custom_libs
+        .insert("test".to_string(), test_fixtures_path.join("lib.test.d.ts"));
+      create_compiler_snapshot(
+        snapshot_path.clone(),
+        assets_path,
+        custom_libs,
+      )?;
+    }
+    let snapshot_data = std::fs::read(snapshot_path)?.into_boxed_slice();
+    let startup_data = StartupData::Snapshot(Snapshot::Boxed(snapshot_data));
+
+    Ok(CompilerIsolate::new(startup_data))
+  }
+
+  #[test]
+  fn test_create_compiler_snapshot() {
+    let temp_dir = TempDir::new().unwrap();
+    let o = temp_dir.path();
+    let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let snapshot_path = o.join("TEST.bin");
+    let assets_path = c.join("../cli/dts");
+    let test_fixtures_path = c.join("fixtures");
+    let mut custom_libs = HashMap::new();
+    custom_libs
+      .insert("test".to_string(), test_fixtures_path.join("lib.test.d.ts"));
+    let version =
+      create_compiler_snapshot(snapshot_path.clone(), assets_path, custom_libs)
+        .unwrap();
+    assert!(snapshot_path.is_file());
+    assert_eq!(version, "4.0.2".to_string());
+  }
+
+  #[tokio::test]
+  async fn test_compile_bundle() {
+    let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let fixtures = c.join("fixtures");
+    let handler = Rc::new(RefCell::new(MockSpecifierHandler {
+      fixtures,
+      ..MockSpecifierHandler::default()
+    }));
+    let mut builder = GraphBuilder::new(handler.clone(), None);
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/a.ts")
+        .expect("could not resolve");
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    let lib = vec!["test"];
+
+    let mut compiler = get_compiler(false).expect("failed to get compiler");
+    let compile_result = compiler
+      .compile(InternalCompileOptions {
+        provider: Rc::new(RefCell::new(graph)),
+        root_names: vec![&specifier],
+        maybe_build_info: None,
+        maybe_shared_path: None,
+        bundle: true,
+        check_only: false,
+        compile_options: CompileOptions {
+          lib,
+          ..CompileOptions::default()
+        },
+      })
+      .unwrap();
+    assert!(compile_result.maybe_ignored_options.is_none());
+    assert_eq!(compile_result.written_files.len(), 4);
+  }
+
+  #[tokio::test]
+  async fn test_compile_incremental() {
+    let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let fixtures = c.join("fixtures");
+    let handler = Rc::new(RefCell::new(MockSpecifierHandler {
+      fixtures,
+      ..MockSpecifierHandler::default()
+    }));
+    let mut builder = GraphBuilder::new(handler.clone(), None);
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/a.ts")
+        .expect("could not resolve");
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    let lib = vec!["test"];
+
+    let mut compiler = get_compiler(false).expect("failed to get compiler");
+    let compiler_result = compiler
+      .compile(InternalCompileOptions {
+        provider: Rc::new(RefCell::new(graph)),
+        bundle: false,
+        check_only: false,
+        root_names: vec![&specifier],
+        maybe_build_info: None,
+        maybe_shared_path: None,
+        compile_options: CompileOptions {
+          lib,
+          incremental: true,
+          ..CompileOptions::default()
+        },
+      })
+      .expect("failed to compile");
+    assert_eq!(
+      compiler_result.written_files.len(),
+      2,
+      "should have written to files"
+    );
+    assert!(compiler_result.maybe_build_info.is_some());
+    let maybe_build_info = compiler_result.maybe_build_info;
+
+    let mut builder = GraphBuilder::new(handler.clone(), None);
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    let lib = vec!["test"];
+
+    let mut compiler = get_compiler(false).expect("failed to get compiler");
+    let compiler_result = compiler
+      .compile(InternalCompileOptions {
+        provider: Rc::new(RefCell::new(graph)),
+        bundle: false,
+        check_only: false,
+        root_names: vec![&specifier],
+        maybe_build_info: maybe_build_info.clone(),
+        maybe_shared_path: None,
+        compile_options: CompileOptions {
+          lib,
+          incremental: true,
+          ..CompileOptions::default()
+        },
+      })
+      .expect("failed to compile");
+    assert_eq!(
+      compiler_result.written_files.len(),
+      0,
+      "should not have written any files"
+    );
+    assert_eq!(compiler_result.maybe_build_info, maybe_build_info);
+  }
+}

--- a/compiler/config.rs
+++ b/compiler/config.rs
@@ -1,0 +1,208 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+use crate::msg::IgnoredCompilerOptions;
+use crate::Result;
+
+use jsonc_parser::JsonValue;
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+/// A static slice of all the compiler options that should be ignored that
+/// either have no effect on the compilation or would cause the emit to not work
+/// in Deno.
+const IGNORED_COMPILER_OPTIONS: [&str; 61] = [
+  "allowSyntheticDefaultImports",
+  "allowUmdGlobalAccess",
+  "assumeChangesOnlyAffectDirectDependencies",
+  "baseUrl",
+  "build",
+  "composite",
+  "declaration",
+  "declarationDir",
+  "declarationMap",
+  "diagnostics",
+  "downlevelIteration",
+  "emitBOM",
+  "emitDeclarationOnly",
+  "esModuleInterop",
+  "extendedDiagnostics",
+  "forceConsistentCasingInFileNames",
+  "generateCpuProfile",
+  "help",
+  "importHelpers",
+  "incremental",
+  "inlineSourceMap",
+  "inlineSources",
+  "init",
+  "listEmittedFiles",
+  "listFiles",
+  "mapRoot",
+  "maxNodeModuleJsDepth",
+  "module",
+  "moduleResolution",
+  "newLine",
+  "noEmit",
+  "noEmitHelpers",
+  "noEmitOnError",
+  "noLib",
+  "noResolve",
+  "out",
+  "outDir",
+  "outFile",
+  "paths",
+  "preserveConstEnums",
+  "preserveSymlinks",
+  "preserveWatchOutput",
+  "pretty",
+  "reactNamespace",
+  "resolveJsonModule",
+  "rootDir",
+  "rootDirs",
+  "showConfig",
+  "skipDefaultLibCheck",
+  "skipLibCheck",
+  "sourceMap",
+  "sourceRoot",
+  "stripInternal",
+  "target",
+  "traceResolution",
+  "tsBuildInfoFile",
+  "types",
+  "typeRoots",
+  "useDefineForClassFields",
+  "version",
+  "watch",
+];
+
+/// A function that works like JavaScript's `Object.assign()`.
+pub fn json_merge(a: &mut Value, b: &Value) {
+  match (a, b) {
+    (&mut Value::Object(ref mut a), &Value::Object(ref b)) => {
+      for (k, v) in b {
+        json_merge(a.entry(k.clone()).or_insert(Value::Null), v);
+      }
+    }
+    (a, b) => {
+      *a = b.clone();
+    }
+  }
+}
+
+/// Convert a jsonc libraries `JsonValue` to a serde `Value`.
+fn jsonc_to_serde(j: JsonValue) -> Value {
+  match j {
+    JsonValue::Array(arr) => {
+      let vec = arr.into_iter().map(jsonc_to_serde).collect();
+      Value::Array(vec)
+    }
+    JsonValue::Boolean(bool) => Value::Bool(bool),
+    JsonValue::Null => Value::Null,
+    JsonValue::Number(num) => {
+      let number =
+        serde_json::Number::from_str(&num).expect("could not parse number");
+      Value::Number(number)
+    }
+    JsonValue::Object(obj) => {
+      let mut map = serde_json::map::Map::new();
+      for (key, json_value) in obj.into_iter() {
+        map.insert(key, jsonc_to_serde(json_value));
+      }
+      Value::Object(map)
+    }
+    JsonValue::String(str) => Value::String(str),
+  }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TSConfigJson {
+  compiler_options: Option<HashMap<String, Value>>,
+  exclude: Option<Vec<String>>,
+  extends: Option<String>,
+  files: Option<Vec<String>>,
+  include: Option<Vec<String>>,
+  references: Option<Value>,
+  type_acquisition: Option<Value>,
+}
+
+/// Take a string of JSONC, parse it and return a serde `Value` of the text.
+/// The result also contains any options that were ignored.
+pub fn parse_config<T: AsRef<str>>(
+  config_text: T,
+) -> Result<(Value, Option<IgnoredCompilerOptions>)> {
+  let config: TSConfigJson = serde_json::from_value(jsonc_to_serde(
+    jsonc_parser::parse_to_value(config_text.as_ref())
+      .expect("cannot parse JSONC")
+      .unwrap(),
+  ))?;
+  let mut compiler_options: HashMap<String, Value> = HashMap::new();
+  let mut items: Vec<String> = Vec::new();
+
+  if let Some(in_compiler_options) = config.compiler_options {
+    for (key, value) in in_compiler_options.iter() {
+      if IGNORED_COMPILER_OPTIONS.contains(&key.as_str()) {
+        items.push(key.to_owned());
+      } else {
+        compiler_options.insert(key.to_owned(), value.to_owned());
+      }
+    }
+  }
+  let options_value = serde_json::to_value(compiler_options)?;
+  let ignored_options = if !items.is_empty() {
+    Some(IgnoredCompilerOptions(items))
+  } else {
+    None
+  };
+
+  Ok((options_value, ignored_options))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serde_json::json;
+
+  #[test]
+  fn test_json_merge() {
+    let mut value_a = json!({
+      "a": true,
+      "b": "c"
+    });
+    let value_b = json!({
+      "b": "d",
+      "e": false,
+    });
+    json_merge(&mut value_a, &value_b);
+    assert_eq!(
+      value_a,
+      json!({
+        "a": true,
+        "b": "d",
+        "e": false,
+      })
+    );
+  }
+
+  #[test]
+  fn test_parse_config() {
+    let config_text = r#"{
+      "compilerOptions": {
+        "build": true,
+        // comments are allowed
+        "strict": true
+      }
+    }"#;
+    let (options_value, ignored) =
+      parse_config(config_text).expect("error parsing");
+    assert!(options_value.is_object());
+    let options = options_value.as_object().unwrap();
+    assert!(options.contains_key("strict"));
+    assert_eq!(options.len(), 1);
+    assert_eq!(
+      ignored,
+      Some(IgnoredCompilerOptions(vec!["build".to_string()])),
+    );
+  }
+}

--- a/compiler/fixtures/file_tests-bundle-root.ts
+++ b/compiler/fixtures/file_tests-bundle-root.ts
@@ -1,0 +1,3 @@
+export * from "https://deno.land/x/bundle/a.js";
+export { b } from "https://deno.land/x/bundle/b.ts";
+export class C {}

--- a/compiler/fixtures/file_tests-decorators.ts
+++ b/compiler/fixtures/file_tests-decorators.ts
@@ -1,0 +1,18 @@
+/* eslint-disable */
+
+function enumerable(value: boolean) {
+  return function (
+    _target: any,
+    _propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    descriptor.enumerable = value;
+  };
+}
+
+class A {
+  @enumerable(false)
+  a() {
+    Test.value;
+  }
+}

--- a/compiler/fixtures/file_tests-deno_types.ts
+++ b/compiler/fixtures/file_tests-deno_types.ts
@@ -1,0 +1,4 @@
+// @deno-types="https://deno.land/x/jquery.d.ts"
+import * as $ from "https://deno.land/x/jquery.js";
+
+console.log($);

--- a/compiler/fixtures/file_tests-mixed-a.ts
+++ b/compiler/fixtures/file_tests-mixed-a.ts
@@ -1,0 +1,4 @@
+export * as b from "./b.js";
+import * as b from "./b.js";
+
+b.c();

--- a/compiler/fixtures/file_tests-mixed-b.js
+++ b/compiler/fixtures/file_tests-mixed-b.js
@@ -1,0 +1,5 @@
+export const b = "b";
+
+export function c() {
+  return d("d");
+}

--- a/compiler/fixtures/file_tests-mixed-c.js
+++ b/compiler/fixtures/file_tests-mixed-c.js
@@ -1,0 +1,8 @@
+export * as d from "./d.ts";
+import * as d from "./d.ts";
+
+d.f();
+
+export function g(h) {
+  return h;
+}

--- a/compiler/fixtures/file_tests-mixed-d.ts
+++ b/compiler/fixtures/file_tests-mixed-d.ts
@@ -1,0 +1,3 @@
+export const d = "d";
+
+export function e() {}

--- a/compiler/fixtures/file_tests-mixed-main_js.js
+++ b/compiler/fixtures/file_tests-mixed-main_js.js
@@ -1,0 +1,3 @@
+import * as a from "./a.ts";
+
+console.log(a.b);

--- a/compiler/fixtures/file_tests-mixed-main_ts.ts
+++ b/compiler/fixtures/file_tests-mixed-main_ts.ts
@@ -1,0 +1,6 @@
+import * as c from "./c.js";
+
+c.d.e();
+
+const h = c.g("foo");
+c.g(h);

--- a/compiler/fixtures/file_tests-mod.ts
+++ b/compiler/fixtures/file_tests-mod.ts
@@ -1,0 +1,3 @@
+import * as typeReference from "./type_reference.js";
+
+console.log(typeReference);

--- a/compiler/fixtures/file_tests-preact.tsx
+++ b/compiler/fixtures/file_tests-preact.tsx
@@ -1,0 +1,13 @@
+/* eslint-disable */
+
+export const frag = (
+  <>
+    <span>Some fragment</span>
+  </>
+);
+
+export default class A {
+  render() {
+    return <div>Hello Deno</div>;
+  }
+}

--- a/compiler/fixtures/file_tests-type_reference.d.ts
+++ b/compiler/fixtures/file_tests-type_reference.d.ts
@@ -1,0 +1,3 @@
+const exp: { foo: string };
+
+export default exp;

--- a/compiler/fixtures/file_tests-type_reference.js
+++ b/compiler/fixtures/file_tests-type_reference.js
@@ -1,0 +1,7 @@
+/* some arbitrary comment */
+
+/// <reference types="./type_reference.d.ts" />
+
+exports = {
+  foo: "bar",
+};

--- a/compiler/fixtures/https_deno.land-x-a.ts
+++ b/compiler/fixtures/https_deno.land-x-a.ts
@@ -1,0 +1,4 @@
+import * as b from "./b.ts";
+b.c;
+Test.value;
+export * from "./b.ts";

--- a/compiler/fixtures/https_deno.land-x-b.ts
+++ b/compiler/fixtures/https_deno.land-x-b.ts
@@ -1,0 +1,1 @@
+export const c = 1;

--- a/compiler/fixtures/https_deno.land-x-bundle-a.js
+++ b/compiler/fixtures/https_deno.land-x-bundle-a.js
@@ -1,0 +1,1 @@
+export function a() {}

--- a/compiler/fixtures/https_deno.land-x-bundle-b.ts
+++ b/compiler/fixtures/https_deno.land-x-bundle-b.ts
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/compiler/fixtures/https_deno.land-x-import_map.ts
+++ b/compiler/fixtures/https_deno.land-x-import_map.ts
@@ -1,0 +1,4 @@
+import * as $ from "jquery";
+import * as _ from "lodash";
+
+console.log($, _);

--- a/compiler/fixtures/https_deno.land-x-jquery.d.ts
+++ b/compiler/fixtures/https_deno.land-x-jquery.d.ts
@@ -1,0 +1,3 @@
+/* eslint-disable */
+declare const $: {};
+export default $;

--- a/compiler/fixtures/https_deno.land-x-jquery.js
+++ b/compiler/fixtures/https_deno.land-x-jquery.js
@@ -1,0 +1,3 @@
+const $ = {};
+
+export default $;

--- a/compiler/fixtures/https_deno.land-x-test-a.ts
+++ b/compiler/fixtures/https_deno.land-x-test-a.ts
@@ -1,0 +1,1 @@
+export const a = "hello";

--- a/compiler/fixtures/https_deno.land-x-test-mod.ts
+++ b/compiler/fixtures/https_deno.land-x-test-mod.ts
@@ -1,0 +1,3 @@
+import * as a from "./a.ts";
+
+console.log(a);

--- a/compiler/fixtures/https_unpkg.com-lodash-index.js
+++ b/compiler/fixtures/https_unpkg.com-lodash-index.js
@@ -1,0 +1,3 @@
+const _ = {};
+
+export default _;

--- a/compiler/fixtures/lib.test.d.ts
+++ b/compiler/fixtures/lib.test.d.ts
@@ -1,0 +1,10 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+/// <reference no-default-lib="true"/>
+
+/// <reference lib="esnext" />
+
+/* eslint-disable */
+declare namespace Test {
+  var value: string;
+}

--- a/compiler/globals.d.ts
+++ b/compiler/globals.d.ts
@@ -1,0 +1,33 @@
+import _ts from "../cli/dts/typescript.d.ts";
+
+declare global {
+  namespace ts {
+    export = _ts;
+  }
+
+  namespace ts {
+    // this are marked @internal in TypeScript, but we need to access them,
+    // there is a risk these could change in future versions of TypeScript
+    export const libs: string[];
+    export const libMap: Map<string, string>;
+    export const performance: {
+      enable(): void;
+      disable(): void;
+      getDuration(value: string): number;
+    };
+
+    interface SourceFile {
+      version?: string;
+    }
+  }
+
+  namespace Deno {
+    const core: {
+      decode(value: Uint8Array): string;
+      dispatch(opId: number, msg: Uint8Array): Uint8Array;
+      encode(value: string): Uint8Array;
+      ops(): Record<string, number>;
+      print(msg: string): void;
+    };
+  }
+}

--- a/compiler/import_map.rs
+++ b/compiler/import_map.rs
@@ -1,0 +1,2082 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+use crate::Result;
+
+use deno_core::ModuleSpecifier;
+use indexmap::IndexMap;
+use serde_json::Map;
+use serde_json::Value;
+use std::cmp::Ordering;
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::io;
+use url::Url;
+
+#[derive(Debug)]
+pub struct ImportMapError {
+  pub msg: String,
+}
+
+impl ImportMapError {
+  pub fn new(msg: &str) -> Self {
+    ImportMapError {
+      msg: msg.to_string(),
+    }
+  }
+}
+
+impl fmt::Display for ImportMapError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    f.pad(&self.msg)
+  }
+}
+
+impl Error for ImportMapError {}
+
+// NOTE: here is difference between deno and reference implementation - deno currently
+//  can't resolve URL with other schemes (eg. data:, about:, blob:)
+const SUPPORTED_FETCH_SCHEMES: [&str; 3] = ["http", "https", "file"];
+
+type SpecifierMap = IndexMap<String, Vec<ModuleSpecifier>>;
+type ScopesMap = IndexMap<String, SpecifierMap>;
+
+#[derive(Debug, Clone)]
+pub struct ImportMap {
+  base_url: String,
+  imports: SpecifierMap,
+  scopes: ScopesMap,
+}
+
+impl ImportMap {
+  pub fn load(file_path: &str) -> Result<Self> {
+    let file_url = ModuleSpecifier::resolve_url_or_path(file_path)?.to_string();
+    let resolved_path = std::env::current_dir().unwrap().join(file_path);
+
+    // Load the contents of import map
+    let json_string = fs::read_to_string(&resolved_path).map_err(|err| {
+      io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!(
+          "Error retrieving import map file at \"{}\": {}",
+          resolved_path.to_str().unwrap(),
+          err.to_string()
+        ),
+      )
+    })?;
+    // The URL of the import map is the base URL for its values.
+    ImportMap::from_json(&file_url, &json_string)
+  }
+
+  pub fn from_json(base_url: &str, json_string: &str) -> Result<Self> {
+    // TODO(kitsonk) use serde Deserialize
+    let v: Value = match serde_json::from_str(json_string) {
+      Ok(v) => v,
+      Err(_) => {
+        return Err(
+          ImportMapError::new("Unable to parse import map JSON").into(),
+        );
+      }
+    };
+
+    match v {
+      Value::Object(_) => {}
+      _ => {
+        return Err(
+          ImportMapError::new("Import map JSON must be an object").into(),
+        );
+      }
+    }
+
+    let normalized_imports = match &v.get("imports") {
+      Some(imports_map) => {
+        if !imports_map.is_object() {
+          return Err(
+            ImportMapError::new("Import map's 'imports' must be an object")
+              .into(),
+          );
+        }
+
+        let imports_map = imports_map.as_object().unwrap();
+        ImportMap::parse_specifier_map(imports_map, base_url)
+      }
+      None => IndexMap::new(),
+    };
+
+    let normalized_scopes = match &v.get("scopes") {
+      Some(scope_map) => {
+        if !scope_map.is_object() {
+          return Err(
+            ImportMapError::new("Import map's 'scopes' must be an object")
+              .into(),
+          );
+        }
+
+        let scope_map = scope_map.as_object().unwrap();
+        ImportMap::parse_scope_map(scope_map, base_url)?
+      }
+      None => IndexMap::new(),
+    };
+
+    let import_map = ImportMap {
+      base_url: base_url.to_string(),
+      imports: normalized_imports,
+      scopes: normalized_scopes,
+    };
+
+    Ok(import_map)
+  }
+
+  fn try_url_like_specifier(specifier: &str, base: &str) -> Option<Url> {
+    // this should never fail
+    if specifier.starts_with('/')
+      || specifier.starts_with("./")
+      || specifier.starts_with("../")
+    {
+      let base_url = Url::parse(base).unwrap();
+      let url = base_url.join(specifier).unwrap();
+      return Some(url);
+    }
+
+    if let Ok(url) = Url::parse(specifier) {
+      if SUPPORTED_FETCH_SCHEMES.contains(&url.scheme()) {
+        return Some(url);
+      }
+    }
+
+    None
+  }
+
+  /// Parse provided key as import map specifier.
+  ///
+  /// Specifiers must be valid URLs (eg. "https://deno.land/x/std/testing/asserts.ts")
+  /// or "bare" specifiers (eg. "moment").
+  // TODO: add proper error handling: https://github.com/WICG/import-maps/issues/100
+  fn normalize_specifier_key(
+    specifier_key: &str,
+    base_url: &str,
+  ) -> Option<String> {
+    // ignore empty keys
+    if specifier_key.is_empty() {
+      return None;
+    }
+
+    if let Some(url) =
+      ImportMap::try_url_like_specifier(specifier_key, base_url)
+    {
+      return Some(url.to_string());
+    }
+
+    // "bare" specifier
+    Some(specifier_key.to_string())
+  }
+
+  /// Parse provided addresses as valid URLs.
+  ///
+  /// Non-valid addresses are skipped.
+  fn normalize_addresses(
+    specifier_key: &str,
+    base_url: &str,
+    potential_addresses: Vec<String>,
+  ) -> Vec<ModuleSpecifier> {
+    let mut normalized_addresses: Vec<ModuleSpecifier> = vec![];
+
+    for potential_address in potential_addresses {
+      let url =
+        match ImportMap::try_url_like_specifier(&potential_address, base_url) {
+          Some(url) => url,
+          None => continue,
+        };
+
+      let url_string = url.to_string();
+      if specifier_key.ends_with('/') && !url_string.ends_with('/') {
+        eprintln!(
+          "Invalid target address {:?} for package specifier {:?}.\
+           Package address targets must end with \"/\".",
+          url_string, specifier_key
+        );
+        continue;
+      }
+
+      normalized_addresses.push(url.into());
+    }
+
+    normalized_addresses
+  }
+
+  /// Convert provided JSON map to valid SpecifierMap.
+  ///
+  /// From specification:
+  /// - order of iteration must be retained
+  /// - SpecifierMap's keys are sorted in longest and alphabetic order
+  fn parse_specifier_map(
+    json_map: &Map<String, Value>,
+    base_url: &str,
+  ) -> SpecifierMap {
+    let mut normalized_map: SpecifierMap = SpecifierMap::new();
+
+    // Order is preserved because of "preserve_order" feature of "serde_json".
+    for (specifier_key, value) in json_map.iter() {
+      let normalized_specifier_key =
+        match ImportMap::normalize_specifier_key(specifier_key, base_url) {
+          Some(s) => s,
+          None => continue,
+        };
+
+      let potential_addresses: Vec<String> = match value {
+        Value::String(address) => vec![address.to_string()],
+        Value::Array(address_array) => {
+          let mut string_addresses: Vec<String> = vec![];
+
+          for address in address_array {
+            match address {
+              Value::String(address) => {
+                string_addresses.push(address.to_string())
+              }
+              _ => continue,
+            }
+          }
+
+          string_addresses
+        }
+        Value::Null => vec![],
+        _ => vec![],
+      };
+
+      let normalized_address_array = ImportMap::normalize_addresses(
+        &normalized_specifier_key,
+        base_url,
+        potential_addresses,
+      );
+
+      // debug!(
+      //   "normalized specifier {:?}; {:?}",
+      //   normalized_specifier_key, normalized_address_array
+      // );
+      normalized_map.insert(normalized_specifier_key, normalized_address_array);
+    }
+
+    // Sort in longest and alphabetical order.
+    normalized_map.sort_by(|k1, _v1, k2, _v2| match k1.cmp(&k2) {
+      Ordering::Greater => Ordering::Less,
+      Ordering::Less => Ordering::Greater,
+      Ordering::Equal => k2.cmp(k1),
+    });
+
+    normalized_map
+  }
+
+  /// Convert provided JSON map to valid ScopeMap.
+  ///
+  /// From specification:
+  /// - order of iteration must be retained
+  /// - ScopeMap's keys are sorted in longest and alphabetic order
+  fn parse_scope_map(
+    scope_map: &Map<String, Value>,
+    base_url: &str,
+  ) -> Result<ScopesMap> {
+    let mut normalized_map: ScopesMap = ScopesMap::new();
+
+    // Order is preserved because of "preserve_order" feature of "serde_json".
+    for (scope_prefix, potential_specifier_map) in scope_map.iter() {
+      if !potential_specifier_map.is_object() {
+        return Err(
+          ImportMapError::new(&format!(
+            "The value for the {:?} scope prefix must be an object",
+            scope_prefix
+          ))
+          .into(),
+        );
+      }
+
+      let potential_specifier_map =
+        potential_specifier_map.as_object().unwrap();
+
+      let scope_prefix_url =
+        match Url::parse(base_url).unwrap().join(scope_prefix) {
+          Ok(url) => {
+            if !SUPPORTED_FETCH_SCHEMES.contains(&url.scheme()) {
+              eprintln!(
+              "Invalid scope {:?}. Scope URLs must have a valid fetch scheme.",
+              url.to_string()
+            );
+              continue;
+            }
+            url.to_string()
+          }
+          _ => continue,
+        };
+
+      let norm_map =
+        ImportMap::parse_specifier_map(potential_specifier_map, base_url);
+
+      normalized_map.insert(scope_prefix_url, norm_map);
+    }
+
+    // Sort in longest and alphabetical order.
+    normalized_map.sort_by(|k1, _v1, k2, _v2| match k1.cmp(&k2) {
+      Ordering::Greater => Ordering::Less,
+      Ordering::Less => Ordering::Greater,
+      Ordering::Equal => k2.cmp(k1),
+    });
+
+    Ok(normalized_map)
+  }
+
+  fn resolve_scopes_match(
+    scopes: &ScopesMap,
+    normalized_specifier: &str,
+    referrer: &str,
+  ) -> Result<Option<ModuleSpecifier>> {
+    // exact-match
+    if let Some(scope_imports) = scopes.get(referrer) {
+      if let Ok(scope_match) =
+        ImportMap::resolve_imports_match(scope_imports, normalized_specifier)
+      {
+        // Return only if there was actual match (not None).
+        if scope_match.is_some() {
+          return Ok(scope_match);
+        }
+      }
+    }
+
+    for (normalized_scope_key, scope_imports) in scopes.iter() {
+      if normalized_scope_key.ends_with('/')
+        && referrer.starts_with(normalized_scope_key)
+      {
+        if let Ok(scope_match) =
+          ImportMap::resolve_imports_match(scope_imports, normalized_specifier)
+        {
+          // Return only if there was actual match (not None).
+          if scope_match.is_some() {
+            return Ok(scope_match);
+          }
+        }
+      }
+    }
+
+    Ok(None)
+  }
+
+  // TODO: https://github.com/WICG/import-maps/issues/73#issuecomment-439327758
+  // for some more optimized candidate implementations.
+  fn resolve_imports_match(
+    imports: &SpecifierMap,
+    normalized_specifier: &str,
+  ) -> Result<Option<ModuleSpecifier>> {
+    // exact-match
+    if let Some(address_vec) = imports.get(normalized_specifier) {
+      if address_vec.is_empty() {
+        return Err(
+          ImportMapError::new(&format!(
+            "Specifier {:?} was mapped to no addresses.",
+            normalized_specifier
+          ))
+          .into(),
+        );
+      } else if address_vec.len() == 1 {
+        let address = address_vec.first().unwrap();
+        // debug!(
+        //   "Specifier {:?} was mapped to {:?}.",
+        //   normalized_specifier, address
+        // );
+        return Ok(Some(address.clone()));
+      } else {
+        return Err(
+          ImportMapError::new("Multi-address mappings are not yet supported")
+            .into(),
+        );
+      }
+    }
+
+    // package-prefix match
+    // "most-specific wins", i.e. when there are multiple matching keys,
+    // choose the longest.
+    // https://github.com/WICG/import-maps/issues/102
+    for (specifier_key, address_vec) in imports.iter() {
+      if specifier_key.ends_with('/')
+        && normalized_specifier.starts_with(specifier_key)
+      {
+        if address_vec.is_empty() {
+          return Err(ImportMapError::new(&format!("Specifier {:?} was mapped to no addresses (via prefix specifier key {:?}).", normalized_specifier, specifier_key)).into());
+        } else if address_vec.len() == 1 {
+          let address = address_vec.first().unwrap();
+          let after_prefix = &normalized_specifier[specifier_key.len()..];
+
+          let base_url = address.as_url();
+          if let Ok(url) = base_url.join(after_prefix) {
+            // debug!("Specifier {:?} was mapped to {:?} (via prefix specifier key {:?}).", normalized_specifier, url, address);
+            return Ok(Some(ModuleSpecifier::from(url)));
+          }
+
+          unreachable!();
+        } else {
+          return Err(
+            ImportMapError::new("Multi-address mappings are not yet supported")
+              .into(),
+          );
+        }
+      }
+    }
+
+    // debug!(
+    //   "Specifier {:?} was not mapped in import map.",
+    //   normalized_specifier
+    // );
+
+    Ok(None)
+  }
+
+  // TODO: add support for built-in modules
+  /// Currently we support two types of specifiers: URL (http://, https://, file://)
+  /// and "bare" (moment, jquery, lodash)
+  ///
+  /// Scenarios:
+  ///   1. import resolved using import map -> String
+  ///   2. import restricted by import map -> ImportMapError
+  ///   3. import not mapped -> None
+  pub fn resolve(
+    &self,
+    specifier: &str,
+    referrer: &str,
+  ) -> Result<Option<ModuleSpecifier>> {
+    let resolved_url: Option<Url> =
+      ImportMap::try_url_like_specifier(specifier, referrer);
+    let normalized_specifier = match &resolved_url {
+      Some(url) => url.to_string(),
+      None => specifier.to_string(),
+    };
+
+    let scopes_match = ImportMap::resolve_scopes_match(
+      &self.scopes,
+      &normalized_specifier,
+      &referrer.to_string(),
+    )?;
+
+    // match found in scopes map
+    if scopes_match.is_some() {
+      return Ok(scopes_match);
+    }
+
+    let imports_match =
+      ImportMap::resolve_imports_match(&self.imports, &normalized_specifier)?;
+
+    // match found in import map
+    if imports_match.is_some() {
+      return Ok(imports_match);
+    }
+
+    // no match in import map but we got resolvable URL
+    if let Some(resolved_url) = resolved_url {
+      return Ok(Some(ModuleSpecifier::from(resolved_url)));
+    }
+
+    Err(
+      ImportMapError::new(&format!(
+        "Unmapped bare specifier {:?}",
+        normalized_specifier
+      ))
+      .into(),
+    )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serde_json::json;
+
+  #[test]
+  fn load_nonexistent() {
+    let file_path = "nonexistent_import_map.json";
+    assert!(ImportMap::load(file_path).is_err());
+  }
+
+  #[test]
+  fn from_json_1() {
+    let base_url = "https://deno.land";
+
+    // empty JSON
+    assert!(ImportMap::from_json(base_url, "{}").is_ok());
+
+    let non_object_strings = vec!["null", "true", "1", "\"foo\"", "[]"];
+
+    // invalid JSON
+    for non_object in non_object_strings.to_vec() {
+      assert!(ImportMap::from_json(base_url, non_object).is_err());
+    }
+
+    // invalid schema: 'imports' is non-object
+    for non_object in non_object_strings.to_vec() {
+      assert!(ImportMap::from_json(
+        base_url,
+        &format!("{{\"imports\": {}}}", non_object),
+      )
+      .is_err());
+    }
+
+    // invalid schema: 'scopes' is non-object
+    for non_object in non_object_strings.to_vec() {
+      assert!(ImportMap::from_json(
+        base_url,
+        &format!("{{\"scopes\": {}}}", non_object),
+      )
+      .is_err());
+    }
+  }
+
+  #[test]
+  fn from_json_2() {
+    let json_map = r#"{
+      "imports": {
+        "foo": "https://example.com/1",
+        "bar": ["https://example.com/2"],
+        "fizz": null
+      }
+    }"#;
+    let result = ImportMap::from_json("https://deno.land", json_map);
+    assert!(result.is_ok());
+  }
+
+  #[test]
+  fn parse_specifier_keys_relative() {
+    // Should absolutize strings prefixed with ./, ../, or / into the corresponding URLs..
+    let json_map = r#"{
+      "imports": {
+        "./foo": "/dotslash",
+        "../foo": "/dotdotslash",
+        "/foo": "/slash"
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert_eq!(
+      import_map
+        .imports
+        .get("https://base.example/path1/path2/foo")
+        .unwrap()[0],
+      "https://base.example/dotslash".to_string()
+    );
+    assert_eq!(
+      import_map
+        .imports
+        .get("https://base.example/path1/foo")
+        .unwrap()[0],
+      "https://base.example/dotdotslash".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("https://base.example/foo").unwrap()[0],
+      "https://base.example/slash".to_string()
+    );
+
+    // Should absolutize the literal strings ./, ../, or / with no suffix..
+    let json_map = r#"{
+      "imports": {
+        "./": "/dotslash/",
+        "../": "/dotdotslash/",
+        "/": "/slash/"
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert_eq!(
+      import_map
+        .imports
+        .get("https://base.example/path1/path2/")
+        .unwrap()[0],
+      "https://base.example/dotslash/".to_string()
+    );
+    assert_eq!(
+      import_map
+        .imports
+        .get("https://base.example/path1/")
+        .unwrap()[0],
+      "https://base.example/dotdotslash/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("https://base.example/").unwrap()[0],
+      "https://base.example/slash/".to_string()
+    );
+
+    // Should treat percent-encoded variants of ./, ../, or / as bare specifiers..
+    let json_map = r#"{
+      "imports": {
+        "%2E/": "/dotSlash1/",
+        "%2E%2E/": "/dotDotSlash1/",
+        ".%2F": "/dotSlash2",
+        "..%2F": "/dotDotSlash2",
+        "%2F": "/slash2",
+        "%2E%2F": "/dotSlash3",
+        "%2E%2E%2F": "/dotDotSlash3"
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert_eq!(
+      import_map.imports.get("%2E/").unwrap()[0],
+      "https://base.example/dotSlash1/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("%2E%2E/").unwrap()[0],
+      "https://base.example/dotDotSlash1/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get(".%2F").unwrap()[0],
+      "https://base.example/dotSlash2".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("..%2F").unwrap()[0],
+      "https://base.example/dotDotSlash2".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("%2F").unwrap()[0],
+      "https://base.example/slash2".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("%2E%2F").unwrap()[0],
+      "https://base.example/dotSlash3".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("%2E%2E%2F").unwrap()[0],
+      "https://base.example/dotDotSlash3".to_string()
+    );
+  }
+
+  #[test]
+  fn parse_specifier_keys_absolute() {
+    // Should only accept absolute URL specifier keys with fetch schemes,.
+    // treating others as bare specifiers.
+    let json_map = r#"{
+      "imports": {
+        "file:///good": "/file",
+        "http://good/": "/http/",
+        "https://good/": "/https/",
+        "about:bad": "/about",
+        "blob:bad": "/blob",
+        "data:bad": "/data",
+        "filesystem:bad": "/filesystem",
+        "ftp://bad/": "/ftp/",
+        "import:bad": "/import",
+        "mailto:bad": "/mailto",
+        "javascript:bad": "/javascript",
+        "wss:bad": "/wss"
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert_eq!(
+      import_map.imports.get("http://good/").unwrap()[0],
+      "https://base.example/http/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("https://good/").unwrap()[0],
+      "https://base.example/https/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("file:///good").unwrap()[0],
+      "https://base.example/file".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("http://good/").unwrap()[0],
+      "https://base.example/http/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("import:bad").unwrap()[0],
+      "https://base.example/import".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("mailto:bad").unwrap()[0],
+      "https://base.example/mailto".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("javascript:bad").unwrap()[0],
+      "https://base.example/javascript".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("wss:bad").unwrap()[0],
+      "https://base.example/wss".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("about:bad").unwrap()[0],
+      "https://base.example/about".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("blob:bad").unwrap()[0],
+      "https://base.example/blob".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("data:bad").unwrap()[0],
+      "https://base.example/data".to_string()
+    );
+
+    // Should parse absolute URLs, treating unparseable ones as bare specifiers..
+    let json_map = r#"{
+      "imports": {
+        "https://ex ample.org/": "/unparseable1/",
+        "https://example.com:demo": "/unparseable2",
+        "http://[www.example.com]/": "/unparseable3/",
+        "https:example.org": "/invalidButParseable1/",
+        "https://///example.com///": "/invalidButParseable2/",
+        "https://example.net": "/prettyNormal/",
+        "https://ex%41mple.com/": "/percentDecoding/",
+        "https://example.com/%41": "/noPercentDecoding"
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert_eq!(
+      import_map.imports.get("https://ex ample.org/").unwrap()[0],
+      "https://base.example/unparseable1/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("https://example.com:demo").unwrap()[0],
+      "https://base.example/unparseable2".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("http://[www.example.com]/").unwrap()[0],
+      "https://base.example/unparseable3/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("https://example.org/").unwrap()[0],
+      "https://base.example/invalidButParseable1/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("https://example.com///").unwrap()[0],
+      "https://base.example/invalidButParseable2/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("https://example.net/").unwrap()[0],
+      "https://base.example/prettyNormal/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("https://example.com/").unwrap()[0],
+      "https://base.example/percentDecoding/".to_string()
+    );
+    assert_eq!(
+      import_map.imports.get("https://example.com/%41").unwrap()[0],
+      "https://base.example/noPercentDecoding".to_string()
+    );
+  }
+
+  #[test]
+  fn parse_scope_keys_relative() {
+    // Should work with no prefix..
+    let json_map = r#"{
+      "scopes": {
+        "foo": {}
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo"));
+
+    // Should work with ./, ../, and / prefixes..
+    let json_map = r#"{
+      "scopes": {
+        "./foo": {},
+        "../foo": {},
+        "/foo": {}
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo"));
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/foo"));
+    assert!(import_map.scopes.contains_key("https://base.example/foo"));
+
+    // Should work with /s, ?s, and #s..
+    let json_map = r#"{
+      "scopes": {
+        "foo/bar?baz#qux": {}
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo/bar?baz#qux"));
+
+    // Should work with an empty string scope key..
+    let json_map = r#"{
+      "scopes": {
+        "": {}
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/path3"));
+
+    // Should work with / suffixes..
+    let json_map = r#"{
+      "scopes": {
+        "foo/": {},
+        "./foo/": {},
+        "../foo/": {},
+        "/foo/": {},
+        "/foo//": {}
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo/"));
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo/"));
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/foo/"));
+    assert!(import_map.scopes.contains_key("https://base.example/foo/"));
+    assert!(import_map.scopes.contains_key("https://base.example/foo//"));
+
+    // Should deduplicate based on URL parsing rules..
+    let json_map = r#"{
+      "scopes": {
+        "foo/\\": {},
+        "foo//": {},
+        "foo\\\\": {}
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/foo//"));
+    assert_eq!(import_map.scopes.len(), 1);
+  }
+
+  #[test]
+  fn parse_scope_keys_absolute() {
+    // Should only accept absolute URL scope keys with fetch schemes..
+    let json_map = r#"{
+      "scopes": {
+        "http://good/": {},
+        "https://good/": {},
+        "file:///good": {},
+        "about:bad": {},
+        "blob:bad": {},
+        "data:bad": {},
+        "filesystem:bad": {},
+        "ftp://bad/": {},
+        "import:bad": {},
+        "mailto:bad": {},
+        "javascript:bad": {},
+        "wss:bad": {}
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    assert!(import_map.scopes.contains_key("http://good/"));
+    assert!(import_map.scopes.contains_key("https://good/"));
+    assert!(import_map.scopes.contains_key("file:///good"));
+    assert_eq!(import_map.scopes.len(), 3);
+
+    // Should parse absolute URL scope keys, ignoring unparseable ones..
+    let json_map = r#"{
+      "scopes": {
+        "https://ex ample.org/": {},
+        "https://example.com:demo": {},
+        "http://[www.example.com]/": {},
+        "https:example.org": {},
+        "https://///example.com///": {},
+        "https://example.net": {},
+        "https://ex%41mple.com/foo/": {},
+        "https://example.com/%41": {}
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+    // tricky case! remember we have a base URL
+    assert!(import_map
+      .scopes
+      .contains_key("https://base.example/path1/path2/example.org"));
+    assert!(import_map.scopes.contains_key("https://example.com///"));
+    assert!(import_map.scopes.contains_key("https://example.net/"));
+    assert!(import_map.scopes.contains_key("https://example.com/foo/"));
+    assert!(import_map.scopes.contains_key("https://example.com/%41"));
+    assert_eq!(import_map.scopes.len(), 5);
+  }
+
+  #[test]
+  fn parse_addresses_relative_url_like() {
+    // Should accept strings prefixed with ./, ../, or /..
+    let json_map = r#"{
+      "imports": {
+        "dotSlash": "./foo",
+        "dotDotSlash": "../foo",
+        "slash": "/foo"
+       }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+
+    assert_eq!(
+      import_map.imports.get("dotSlash").unwrap(),
+      &vec!["https://base.example/path1/path2/foo".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("dotDotSlash").unwrap(),
+      &vec!["https://base.example/path1/foo".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("slash").unwrap(),
+      &vec!["https://base.example/foo".to_string()]
+    );
+
+    // Should accept the literal strings ./, ../, or / with no suffix..
+    let json_map = r#"{
+      "imports": {
+        "dotSlash": "./",
+        "dotDotSlash": "../",
+        "slash": "/"
+       }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+
+    assert_eq!(
+      import_map.imports.get("dotSlash").unwrap(),
+      &vec!["https://base.example/path1/path2/".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("dotDotSlash").unwrap(),
+      &vec!["https://base.example/path1/".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("slash").unwrap(),
+      &vec!["https://base.example/".to_string()]
+    );
+
+    // Should ignore percent-encoded variants of ./, ../, or /..
+    let json_map = r#"{
+      "imports": {
+        "dotSlash1": "%2E/",
+        "dotDotSlash1": "%2E%2E/",
+        "dotSlash2": ".%2F",
+        "dotDotSlash2": "..%2F",
+        "slash2": "%2F",
+        "dotSlash3": "%2E%2F",
+        "dotDotSlash3": "%2E%2E%2F"
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+
+    assert!(import_map.imports.get("dotSlash1").unwrap().is_empty());
+    assert!(import_map.imports.get("dotDotSlash1").unwrap().is_empty());
+    assert!(import_map.imports.get("dotSlash2").unwrap().is_empty());
+    assert!(import_map.imports.get("dotDotSlash2").unwrap().is_empty());
+    assert!(import_map.imports.get("slash2").unwrap().is_empty());
+    assert!(import_map.imports.get("dotSlash3").unwrap().is_empty());
+    assert!(import_map.imports.get("dotDotSlash3").unwrap().is_empty());
+  }
+
+  #[test]
+  fn parse_addresses_absolute_with_fetch_schemes() {
+    // Should only accept absolute URL addresses with fetch schemes..
+    let json_map = r#"{
+      "imports": {
+        "http": "http://good/",
+        "https": "https://good/",
+        "file": "file:///good",
+        "about": "about:bad",
+        "blob": "blob:bad",
+        "data": "data:bad",
+        "filesystem": "filesystem:bad",
+        "ftp": "ftp://good/",
+        "import": "import:bad",
+        "mailto": "mailto:bad",
+        "javascript": "javascript:bad",
+        "wss": "wss:bad"
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+
+    assert_eq!(
+      import_map.imports.get("file").unwrap(),
+      &vec!["file:///good".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("http").unwrap(),
+      &vec!["http://good/".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("https").unwrap(),
+      &vec!["https://good/".to_string()]
+    );
+
+    assert!(import_map.imports.get("about").unwrap().is_empty());
+    assert!(import_map.imports.get("blob").unwrap().is_empty());
+    assert!(import_map.imports.get("data").unwrap().is_empty());
+    assert!(import_map.imports.get("filesystem").unwrap().is_empty());
+    assert!(import_map.imports.get("ftp").unwrap().is_empty());
+    assert!(import_map.imports.get("import").unwrap().is_empty());
+    assert!(import_map.imports.get("mailto").unwrap().is_empty());
+    assert!(import_map.imports.get("javascript").unwrap().is_empty());
+    assert!(import_map.imports.get("wss").unwrap().is_empty());
+  }
+
+  #[test]
+  fn parse_addresses_absolute_with_fetch_schemes_arrays() {
+    // Should only accept absolute URL addresses with fetch schemes inside arrays..
+    let json_map = r#"{
+      "imports": {
+        "http": ["http://good/"],
+        "https": ["https://good/"],
+        "file": ["file:///good"],
+        "about": ["about:bad"],
+        "blob": ["blob:bad"],
+        "data": ["data:bad"],
+        "filesystem": ["filesystem:bad"],
+        "ftp": ["ftp://good/"],
+        "import": ["import:bad"],
+        "mailto": ["mailto:bad"],
+        "javascript": ["javascript:bad"],
+        "wss": ["wss:bad"]
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+
+    assert_eq!(
+      import_map.imports.get("file").unwrap(),
+      &vec!["file:///good".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("http").unwrap(),
+      &vec!["http://good/".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("https").unwrap(),
+      &vec!["https://good/".to_string()]
+    );
+
+    assert!(import_map.imports.get("about").unwrap().is_empty());
+    assert!(import_map.imports.get("blob").unwrap().is_empty());
+    assert!(import_map.imports.get("data").unwrap().is_empty());
+    assert!(import_map.imports.get("filesystem").unwrap().is_empty());
+    assert!(import_map.imports.get("ftp").unwrap().is_empty());
+    assert!(import_map.imports.get("import").unwrap().is_empty());
+    assert!(import_map.imports.get("mailto").unwrap().is_empty());
+    assert!(import_map.imports.get("javascript").unwrap().is_empty());
+    assert!(import_map.imports.get("wss").unwrap().is_empty());
+  }
+
+  #[test]
+  fn parse_addresses_unparseable() {
+    // Should parse absolute URLs, ignoring unparseable ones..
+    let json_map = r#"{
+      "imports": {
+        "unparseable1": "https://ex ample.org/",
+        "unparseable2": "https://example.com:demo",
+        "unparseable3": "http://[www.example.com]/",
+        "invalidButParseable1": "https:example.org",
+        "invalidButParseable2": "https://///example.com///",
+        "prettyNormal": "https://example.net",
+        "percentDecoding": "https://ex%41mple.com/",
+        "noPercentDecoding": "https://example.com/%41"
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+
+    assert_eq!(
+      import_map.imports.get("invalidButParseable1").unwrap(),
+      &vec!["https://example.org/".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("invalidButParseable2").unwrap(),
+      &vec!["https://example.com///".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("prettyNormal").unwrap(),
+      &vec!["https://example.net/".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("percentDecoding").unwrap(),
+      &vec!["https://example.com/".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("noPercentDecoding").unwrap(),
+      &vec!["https://example.com/%41".to_string()]
+    );
+
+    assert!(import_map.imports.get("unparseable1").unwrap().is_empty());
+    assert!(import_map.imports.get("unparseable2").unwrap().is_empty());
+    assert!(import_map.imports.get("unparseable3").unwrap().is_empty());
+  }
+
+  #[test]
+  fn parse_addresses_unparseable_arrays() {
+    // Should parse absolute URLs, ignoring unparseable ones inside arrays..
+    let json_map = r#"{
+      "imports": {
+        "unparseable1": ["https://ex ample.org/"],
+        "unparseable2": ["https://example.com:demo"],
+        "unparseable3": ["http://[www.example.com]/"],
+        "invalidButParseable1": ["https:example.org"],
+        "invalidButParseable2": ["https://///example.com///"],
+        "prettyNormal": ["https://example.net"],
+        "percentDecoding": ["https://ex%41mple.com/"],
+        "noPercentDecoding": ["https://example.com/%41"]
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+
+    assert_eq!(
+      import_map.imports.get("invalidButParseable1").unwrap(),
+      &vec!["https://example.org/".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("invalidButParseable2").unwrap(),
+      &vec!["https://example.com///".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("prettyNormal").unwrap(),
+      &vec!["https://example.net/".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("percentDecoding").unwrap(),
+      &vec!["https://example.com/".to_string()]
+    );
+    assert_eq!(
+      import_map.imports.get("noPercentDecoding").unwrap(),
+      &vec!["https://example.com/%41".to_string()]
+    );
+
+    assert!(import_map.imports.get("unparseable1").unwrap().is_empty());
+    assert!(import_map.imports.get("unparseable2").unwrap().is_empty());
+    assert!(import_map.imports.get("unparseable3").unwrap().is_empty());
+  }
+
+  #[test]
+  fn parse_addresses_mismatched_trailing_slashes() {
+    // Should parse absolute URLs, ignoring unparseable ones inside arrays..
+    let json_map = r#"{
+      "imports": {
+        "trailer/": "/notrailer"
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+
+    assert!(import_map.imports.get("trailer/").unwrap().is_empty());
+    // TODO: I'd be good to assert that warning was shown
+  }
+
+  #[test]
+  fn parse_addresses_mismatched_trailing_slashes_array() {
+    // Should warn for a mismatch alone in an array..
+    let json_map = r#"{
+      "imports": {
+        "trailer/": ["/notrailer"]
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+
+    assert!(import_map.imports.get("trailer/").unwrap().is_empty());
+    // TODO: I'd be good to assert that warning was shown
+  }
+
+  #[test]
+  fn parse_addresses_mismatched_trailing_slashes_with_nonmismatched_array() {
+    // Should warn for a mismatch alone in an array..
+    let json_map = r#"{
+      "imports": {
+        "trailer/": ["/atrailer/", "/notrailer"]
+      }
+    }"#;
+    let import_map =
+      ImportMap::from_json("https://base.example/path1/path2/path3", json_map)
+        .unwrap();
+
+    assert_eq!(
+      import_map.imports.get("trailer/").unwrap(),
+      &vec!["https://base.example/atrailer/".to_string()]
+    );
+    // TODO: I'd be good to assert that warning was shown
+  }
+
+  #[test]
+  fn parse_addresses_other_invalid() {
+    // Should ignore unprefixed strings that are not absolute URLs.
+    for bad in &["bar", "\\bar", "~bar", "#bar", "?bar"] {
+      let json_map = json!({
+        "imports": {
+          "foo": bad
+        }
+      });
+      let import_map = ImportMap::from_json(
+        "https://base.example/path1/path2/path3",
+        &json_map.to_string(),
+      )
+      .unwrap();
+
+      assert!(import_map.imports.get("foo").unwrap().is_empty());
+    }
+  }
+
+  fn get_empty_import_map() -> ImportMap {
+    ImportMap {
+      base_url: "https://example.com/app/main.ts".to_string(),
+      imports: IndexMap::new(),
+      scopes: IndexMap::new(),
+    }
+  }
+
+  fn assert_resolve(
+    result: Result<Option<ModuleSpecifier>>,
+    expected_url: &str,
+  ) {
+    let maybe_url = result
+      .unwrap_or_else(|err| panic!("ImportMap::resolve failed: {:?}", err));
+    let resolved_url =
+      maybe_url.unwrap_or_else(|| panic!("Unexpected None resolved URL"));
+    assert_eq!(resolved_url, expected_url.to_string());
+  }
+
+  #[test]
+  fn resolve_unmapped_relative_specifiers() {
+    let referrer_url = "https://example.com/js/script.ts";
+    let import_map = get_empty_import_map();
+
+    // Should resolve ./ specifiers as URLs.
+    assert_resolve(
+      import_map.resolve("./foo", referrer_url),
+      "https://example.com/js/foo",
+    );
+    assert_resolve(
+      import_map.resolve("./foo/bar", referrer_url),
+      "https://example.com/js/foo/bar",
+    );
+    assert_resolve(
+      import_map.resolve("./foo/../bar", referrer_url),
+      "https://example.com/js/bar",
+    );
+    assert_resolve(
+      import_map.resolve("./foo/../../bar", referrer_url),
+      "https://example.com/bar",
+    );
+
+    // Should resolve ../ specifiers as URLs.
+    assert_resolve(
+      import_map.resolve("../foo", referrer_url),
+      "https://example.com/foo",
+    );
+    assert_resolve(
+      import_map.resolve("../foo/bar", referrer_url),
+      "https://example.com/foo/bar",
+    );
+    assert_resolve(
+      import_map.resolve("../../../foo/bar", referrer_url),
+      "https://example.com/foo/bar",
+    );
+  }
+
+  #[test]
+  fn resolve_unmapped_absolute_specifiers() {
+    let referrer_url = "https://example.com/js/script.ts";
+    let import_map = get_empty_import_map();
+
+    // Should resolve / specifiers as URLs.
+    assert_resolve(
+      import_map.resolve("/foo", referrer_url),
+      "https://example.com/foo",
+    );
+    assert_resolve(
+      import_map.resolve("/foo/bar", referrer_url),
+      "https://example.com/foo/bar",
+    );
+    assert_resolve(
+      import_map.resolve("../../foo/bar", referrer_url),
+      "https://example.com/foo/bar",
+    );
+    assert_resolve(
+      import_map.resolve("/../foo/../bar", referrer_url),
+      "https://example.com/bar",
+    );
+
+    // Should parse absolute fetch-scheme URLs.
+    assert_resolve(
+      import_map.resolve("https://example.net", referrer_url),
+      "https://example.net/",
+    );
+    assert_resolve(
+      import_map.resolve("https://ex%41mple.com/", referrer_url),
+      "https://example.com/",
+    );
+    assert_resolve(
+      import_map.resolve("https:example.org", referrer_url),
+      "https://example.org/",
+    );
+    assert_resolve(
+      import_map.resolve("https://///example.com///", referrer_url),
+      "https://example.com///",
+    );
+  }
+
+  #[test]
+  fn resolve_unmapped_bad_specifiers() {
+    let referrer_url = "https://example.com/js/script.ts";
+    let import_map = get_empty_import_map();
+
+    // Should fail for absolute non-fetch-scheme URLs.
+    assert!(import_map.resolve("about:good", referrer_url).is_err());
+    assert!(import_map.resolve("mailto:bad", referrer_url).is_err());
+    assert!(import_map.resolve("import:bad", referrer_url).is_err());
+    assert!(import_map.resolve("javascript:bad", referrer_url).is_err());
+    assert!(import_map.resolve("wss:bad", referrer_url).is_err());
+
+    // Should fail for string not parseable as absolute URLs and not starting with ./, ../ or /.
+    assert!(import_map.resolve("foo", referrer_url).is_err());
+    assert!(import_map.resolve("\\foo", referrer_url).is_err());
+    assert!(import_map.resolve(":foo", referrer_url).is_err());
+    assert!(import_map.resolve("@foo", referrer_url).is_err());
+    assert!(import_map.resolve("%2E/foo", referrer_url).is_err());
+    assert!(import_map.resolve("%2E%2Efoo", referrer_url).is_err());
+    assert!(import_map.resolve(".%2Efoo", referrer_url).is_err());
+    assert!(import_map
+      .resolve("https://ex ample.org", referrer_url)
+      .is_err());
+    assert!(import_map
+      .resolve("https://example.org:deno", referrer_url)
+      .is_err());
+    assert!(import_map
+      .resolve("https://[example.org]", referrer_url)
+      .is_err());
+  }
+
+  #[test]
+  fn resolve_imports_mapped() {
+    let base_url = "https://example.com/app/main.ts";
+    let referrer_url = "https://example.com/js/script.ts";
+
+    // Should fail when mapping is to an empty array.
+    let json_map = r#"{
+    "imports": {
+      "moment": null,
+      "lodash": []
+    }
+  }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+    assert!(import_map.resolve("moment", referrer_url).is_err());
+    assert!(import_map.resolve("lodash", referrer_url).is_err());
+  }
+
+  #[test]
+  fn resolve_imports_package_like_modules() {
+    let base_url = "https://example.com/app/main.ts";
+    let referrer_url = "https://example.com/js/script.ts";
+
+    let json_map = r#"{
+    "imports": {
+      "moment": "/deps/moment/src/moment.js",
+      "moment/": "/deps/moment/src/",
+      "lodash-dot": "./deps/lodash-es/lodash.js",
+      "lodash-dot/": "./deps/lodash-es/",
+      "lodash-dotdot": "../deps/lodash-es/lodash.js",
+      "lodash-dotdot/": "../deps/lodash-es/",
+      "nowhere/": []
+    }
+  }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+    // Should work for package main modules.
+    assert_resolve(
+      import_map.resolve("moment", referrer_url),
+      "https://example.com/deps/moment/src/moment.js",
+    );
+    assert_resolve(
+      import_map.resolve("lodash-dot", referrer_url),
+      "https://example.com/app/deps/lodash-es/lodash.js",
+    );
+    assert_resolve(
+      import_map.resolve("lodash-dotdot", referrer_url),
+      "https://example.com/deps/lodash-es/lodash.js",
+    );
+
+    // Should work for package submodules.
+    assert_resolve(
+      import_map.resolve("moment/foo", referrer_url),
+      "https://example.com/deps/moment/src/foo",
+    );
+    assert_resolve(
+      import_map.resolve("lodash-dot/foo", referrer_url),
+      "https://example.com/app/deps/lodash-es/foo",
+    );
+    assert_resolve(
+      import_map.resolve("lodash-dotdot/foo", referrer_url),
+      "https://example.com/deps/lodash-es/foo",
+    );
+
+    // Should work for package names that end in a slash.
+    assert_resolve(
+      import_map.resolve("moment/", referrer_url),
+      "https://example.com/deps/moment/src/",
+    );
+
+    // Should fail for package modules that are not declared.
+    assert!(import_map.resolve("underscore/", referrer_url).is_err());
+    assert!(import_map.resolve("underscore/foo", referrer_url).is_err());
+
+    // Should fail for package submodules that map to nowhere.
+    assert!(import_map.resolve("nowhere/foo", referrer_url).is_err());
+  }
+
+  #[test]
+  fn resolve_imports_tricky_specifiers() {
+    let base_url = "https://example.com/app/main.ts";
+    let referrer_url = "https://example.com/js/script.ts";
+
+    let json_map = r#"{
+    "imports": {
+      "package/withslash": "/deps/package-with-slash/index.mjs",
+      "not-a-package": "/lib/not-a-package.mjs",
+      ".": "/lib/dot.mjs",
+      "..": "/lib/dotdot.mjs",
+      "..\\\\": "/lib/dotdotbackslash.mjs",
+      "%2E": "/lib/percent2e.mjs",
+      "%2F": "/lib/percent2f.mjs"
+    }
+  }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+    // Should work for explicitly-mapped specifiers that happen to have a slash.
+    assert_resolve(
+      import_map.resolve("package/withslash", referrer_url),
+      "https://example.com/deps/package-with-slash/index.mjs",
+    );
+
+    // Should work when the specifier has punctuation.
+    assert_resolve(
+      import_map.resolve(".", referrer_url),
+      "https://example.com/lib/dot.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("..", referrer_url),
+      "https://example.com/lib/dotdot.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("..\\\\", referrer_url),
+      "https://example.com/lib/dotdotbackslash.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("%2E", referrer_url),
+      "https://example.com/lib/percent2e.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("%2F", referrer_url),
+      "https://example.com/lib/percent2f.mjs",
+    );
+
+    // Should fail for attempting to get a submodule of something not declared with a trailing slash.
+    assert!(import_map
+      .resolve("not-a-package/foo", referrer_url)
+      .is_err());
+  }
+
+  #[test]
+  fn resolve_imports_url_like_specifier() {
+    let base_url = "https://example.com/app/main.ts";
+    let referrer_url = "https://example.com/js/script.ts";
+
+    let json_map = r#"{
+    "imports": {
+      "/node_modules/als-polyfill/index.mjs": "std:kv-storage",
+      "/lib/foo.mjs": "./more/bar.mjs",
+      "./dotrelative/foo.mjs": "/lib/dot.mjs",
+      "../dotdotrelative/foo.mjs": "/lib/dotdot.mjs",
+      "/lib/no.mjs": null,
+      "./dotrelative/no.mjs": [],
+      "/": "/lib/slash-only/",
+      "./": "/lib/dotslash-only/",
+      "/test/": "/lib/url-trailing-slash/",
+      "./test/": "/lib/url-trailing-slash-dot/",
+      "/test": "/lib/test1.mjs",
+      "../test": "/lib/test2.mjs"
+    }
+  }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+    // Should remap to other URLs.
+    assert_resolve(
+      import_map.resolve("https://example.com/lib/foo.mjs", referrer_url),
+      "https://example.com/app/more/bar.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("https://///example.com/lib/foo.mjs", referrer_url),
+      "https://example.com/app/more/bar.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("/lib/foo.mjs", referrer_url),
+      "https://example.com/app/more/bar.mjs",
+    );
+    assert_resolve(
+      import_map
+        .resolve("https://example.com/app/dotrelative/foo.mjs", referrer_url),
+      "https://example.com/lib/dot.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("../app/dotrelative/foo.mjs", referrer_url),
+      "https://example.com/lib/dot.mjs",
+    );
+    assert_resolve(
+      import_map
+        .resolve("https://example.com/dotdotrelative/foo.mjs", referrer_url),
+      "https://example.com/lib/dotdot.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("../dotdotrelative/foo.mjs", referrer_url),
+      "https://example.com/lib/dotdot.mjs",
+    );
+
+    // Should fail for URLs that remap to empty arrays.
+    assert!(import_map
+      .resolve("https://example.com/lib/no.mjs", referrer_url)
+      .is_err());
+    assert!(import_map.resolve("/lib/no.mjs", referrer_url).is_err());
+    assert!(import_map.resolve("../lib/no.mjs", referrer_url).is_err());
+    assert!(import_map
+      .resolve("https://example.com/app/dotrelative/no.mjs", referrer_url)
+      .is_err());
+    assert!(import_map
+      .resolve("/app/dotrelative/no.mjs", referrer_url)
+      .is_err());
+    assert!(import_map
+      .resolve("../app/dotrelative/no.mjs", referrer_url)
+      .is_err());
+
+    // Should remap URLs that are just composed from / and ..
+    assert_resolve(
+      import_map.resolve("https://example.com/", referrer_url),
+      "https://example.com/lib/slash-only/",
+    );
+    assert_resolve(
+      import_map.resolve("/", referrer_url),
+      "https://example.com/lib/slash-only/",
+    );
+    assert_resolve(
+      import_map.resolve("../", referrer_url),
+      "https://example.com/lib/slash-only/",
+    );
+    assert_resolve(
+      import_map.resolve("https://example.com/app/", referrer_url),
+      "https://example.com/lib/dotslash-only/",
+    );
+    assert_resolve(
+      import_map.resolve("/app/", referrer_url),
+      "https://example.com/lib/dotslash-only/",
+    );
+    assert_resolve(
+      import_map.resolve("../app/", referrer_url),
+      "https://example.com/lib/dotslash-only/",
+    );
+
+    // Should remap URLs that are prefix-matched by keys with trailing slashes.
+    assert_resolve(
+      import_map.resolve("/test/foo.mjs", referrer_url),
+      "https://example.com/lib/url-trailing-slash/foo.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("https://example.com/app/test/foo.mjs", referrer_url),
+      "https://example.com/lib/url-trailing-slash-dot/foo.mjs",
+    );
+
+    // Should use the last entry's address when URL-like specifiers parse to the same absolute URL.
+    //
+    // NOTE: this works properly because of "preserve_order" feature flag to "serde_json" crate
+    assert_resolve(
+      import_map.resolve("/test", referrer_url),
+      "https://example.com/lib/test2.mjs",
+    );
+  }
+
+  #[test]
+  fn resolve_imports_overlapping_entities_with_trailing_slashes() {
+    let base_url = "https://example.com/app/main.ts";
+    let referrer_url = "https://example.com/js/script.ts";
+
+    // Should favor the most-specific key (no empty arrays).
+    {
+      let json_map = r#"{
+      "imports": {
+        "a": "/1",
+        "a/": "/2/",
+        "a/b": "/3",
+        "a/b/": "/4/"
+      }
+    }"#;
+      let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+      assert_resolve(
+        import_map.resolve("a", referrer_url),
+        "https://example.com/1",
+      );
+      assert_resolve(
+        import_map.resolve("a/", referrer_url),
+        "https://example.com/2/",
+      );
+      assert_resolve(
+        import_map.resolve("a/b", referrer_url),
+        "https://example.com/3",
+      );
+      assert_resolve(
+        import_map.resolve("a/b/", referrer_url),
+        "https://example.com/4/",
+      );
+      assert_resolve(
+        import_map.resolve("a/b/c", referrer_url),
+        "https://example.com/4/c",
+      );
+    }
+
+    // Should favor the most-specific key when empty arrays are involved for less-specific keys.
+    {
+      let json_map = r#"{
+      "imports": {
+        "a": [],
+        "a/": [],
+        "a/b": "/3",
+        "a/b/": "/4/"
+      }
+    }"#;
+      let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+      assert!(import_map.resolve("a", referrer_url).is_err());
+      assert!(import_map.resolve("a/", referrer_url).is_err());
+      assert!(import_map.resolve("a/x", referrer_url).is_err());
+      assert_resolve(
+        import_map.resolve("a/b", referrer_url),
+        "https://example.com/3",
+      );
+      assert_resolve(
+        import_map.resolve("a/b/", referrer_url),
+        "https://example.com/4/",
+      );
+      assert_resolve(
+        import_map.resolve("a/b/c", referrer_url),
+        "https://example.com/4/c",
+      );
+      assert!(import_map.resolve("a/x/c", referrer_url).is_err());
+    }
+  }
+
+  #[test]
+  fn resolve_scopes_map_to_empty_array() {
+    let base_url = "https://example.com/app/main.ts";
+    let referrer_url = "https://example.com/js";
+
+    let json_map = r#"{
+    "scopes": {
+      "/js/": {
+        "moment": "null",
+        "lodash": []
+      }
+    }
+  }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+    assert!(import_map.resolve("moment", referrer_url).is_err());
+    assert!(import_map.resolve("lodash", referrer_url).is_err());
+  }
+
+  #[test]
+  fn resolve_scopes_exact_vs_prefix_matching() {
+    let base_url = "https://example.com/app/main.ts";
+
+    let json_map = r#"{
+    "scopes": {
+      "/js": {
+        "moment": "/only-triggered-by-exact/moment",
+        "moment/": "/only-triggered-by-exact/moment/"
+      },
+      "/js/": {
+        "moment": "/triggered-by-any-subpath/moment",
+        "moment/": "/triggered-by-any-subpath/moment/"
+      }
+    }
+  }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+    let js_non_dir = "https://example.com/js";
+    let js_in_dir = "https://example.com/js/app.mjs";
+    let with_js_prefix = "https://example.com/jsiscool";
+
+    assert_resolve(
+      import_map.resolve("moment", js_non_dir),
+      "https://example.com/only-triggered-by-exact/moment",
+    );
+    assert_resolve(
+      import_map.resolve("moment/foo", js_non_dir),
+      "https://example.com/only-triggered-by-exact/moment/foo",
+    );
+    assert_resolve(
+      import_map.resolve("moment", js_in_dir),
+      "https://example.com/triggered-by-any-subpath/moment",
+    );
+    assert_resolve(
+      import_map.resolve("moment/foo", js_in_dir),
+      "https://example.com/triggered-by-any-subpath/moment/foo",
+    );
+    assert!(import_map.resolve("moment", with_js_prefix).is_err());
+    assert!(import_map.resolve("moment/foo", with_js_prefix).is_err());
+  }
+
+  #[test]
+  fn resolve_scopes_only_exact_in_map() {
+    let base_url = "https://example.com/app/main.ts";
+
+    let json_map = r#"{
+    "scopes": {
+      "/js": {
+        "moment": "/only-triggered-by-exact/moment",
+        "moment/": "/only-triggered-by-exact/moment/"
+      }
+    }
+  }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+    // Should match correctly when only an exact match is in the map.
+    let js_non_dir = "https://example.com/js";
+    let js_in_dir = "https://example.com/js/app.mjs";
+    let with_js_prefix = "https://example.com/jsiscool";
+
+    assert_resolve(
+      import_map.resolve("moment", js_non_dir),
+      "https://example.com/only-triggered-by-exact/moment",
+    );
+    assert_resolve(
+      import_map.resolve("moment/foo", js_non_dir),
+      "https://example.com/only-triggered-by-exact/moment/foo",
+    );
+    assert!(import_map.resolve("moment", js_in_dir).is_err());
+    assert!(import_map.resolve("moment/foo", js_in_dir).is_err());
+    assert!(import_map.resolve("moment", with_js_prefix).is_err());
+    assert!(import_map.resolve("moment/foo", with_js_prefix).is_err());
+  }
+
+  #[test]
+  fn resolve_scopes_only_prefix_in_map() {
+    let base_url = "https://example.com/app/main.ts";
+
+    let json_map = r#"{
+    "scopes": {
+      "/js/": {
+        "moment": "/triggered-by-any-subpath/moment",
+        "moment/": "/triggered-by-any-subpath/moment/"
+      }
+    }
+  }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+    // Should match correctly when only a prefix match is in the map.
+    let js_non_dir = "https://example.com/js";
+    let js_in_dir = "https://example.com/js/app.mjs";
+    let with_js_prefix = "https://example.com/jsiscool";
+
+    assert!(import_map.resolve("moment", js_non_dir).is_err());
+    assert!(import_map.resolve("moment/foo", js_non_dir).is_err());
+    assert_resolve(
+      import_map.resolve("moment", js_in_dir),
+      "https://example.com/triggered-by-any-subpath/moment",
+    );
+    assert_resolve(
+      import_map.resolve("moment/foo", js_in_dir),
+      "https://example.com/triggered-by-any-subpath/moment/foo",
+    );
+    assert!(import_map.resolve("moment", with_js_prefix).is_err());
+    assert!(import_map.resolve("moment/foo", with_js_prefix).is_err());
+  }
+
+  #[test]
+  fn resolve_scopes_package_like() {
+    let base_url = "https://example.com/app/main.ts";
+
+    let json_map = r#"{
+    "imports": {
+      "moment": "/node_modules/moment/src/moment.js",
+      "moment/": "/node_modules/moment/src/",
+      "lodash-dot": "./node_modules/lodash-es/lodash.js",
+      "lodash-dot/": "./node_modules/lodash-es/",
+      "lodash-dotdot": "../node_modules/lodash-es/lodash.js",
+      "lodash-dotdot/": "../node_modules/lodash-es/"
+    },
+    "scopes": {
+      "/": {
+        "moment": "/node_modules_3/moment/src/moment.js",
+        "vue": "/node_modules_3/vue/dist/vue.runtime.esm.js"
+      },
+      "/js/": {
+        "lodash-dot": "./node_modules_2/lodash-es/lodash.js",
+        "lodash-dot/": "./node_modules_2/lodash-es/",
+        "lodash-dotdot": "../node_modules_2/lodash-es/lodash.js",
+        "lodash-dotdot/": "../node_modules_2/lodash-es/"
+      }
+    }
+  }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+    // Should match correctly when only a prefix match is in the map.
+    let js_in_dir = "https://example.com/js/app.mjs";
+    let top_level = "https://example.com/app.mjs";
+
+    // Should resolve scoped.
+    assert_resolve(
+      import_map.resolve("lodash-dot", js_in_dir),
+      "https://example.com/app/node_modules_2/lodash-es/lodash.js",
+    );
+    assert_resolve(
+      import_map.resolve("lodash-dotdot", js_in_dir),
+      "https://example.com/node_modules_2/lodash-es/lodash.js",
+    );
+    assert_resolve(
+      import_map.resolve("lodash-dot/foo", js_in_dir),
+      "https://example.com/app/node_modules_2/lodash-es/foo",
+    );
+    assert_resolve(
+      import_map.resolve("lodash-dotdot/foo", js_in_dir),
+      "https://example.com/node_modules_2/lodash-es/foo",
+    );
+
+    // Should apply best scope match.
+    assert_resolve(
+      import_map.resolve("moment", top_level),
+      "https://example.com/node_modules_3/moment/src/moment.js",
+    );
+    assert_resolve(
+      import_map.resolve("moment", js_in_dir),
+      "https://example.com/node_modules_3/moment/src/moment.js",
+    );
+    assert_resolve(
+      import_map.resolve("vue", js_in_dir),
+      "https://example.com/node_modules_3/vue/dist/vue.runtime.esm.js",
+    );
+
+    // Should fallback to "imports".
+    assert_resolve(
+      import_map.resolve("moment/foo", top_level),
+      "https://example.com/node_modules/moment/src/foo",
+    );
+    assert_resolve(
+      import_map.resolve("moment/foo", js_in_dir),
+      "https://example.com/node_modules/moment/src/foo",
+    );
+    assert_resolve(
+      import_map.resolve("lodash-dot", top_level),
+      "https://example.com/app/node_modules/lodash-es/lodash.js",
+    );
+    assert_resolve(
+      import_map.resolve("lodash-dotdot", top_level),
+      "https://example.com/node_modules/lodash-es/lodash.js",
+    );
+    assert_resolve(
+      import_map.resolve("lodash-dot/foo", top_level),
+      "https://example.com/app/node_modules/lodash-es/foo",
+    );
+    assert_resolve(
+      import_map.resolve("lodash-dotdot/foo", top_level),
+      "https://example.com/node_modules/lodash-es/foo",
+    );
+
+    // Should still fail for package-like specifiers that are not declared.
+    assert!(import_map.resolve("underscore/", js_in_dir).is_err());
+    assert!(import_map.resolve("underscore/foo", js_in_dir).is_err());
+  }
+
+  #[test]
+  fn resolve_scopes_inheritance() {
+    // https://github.com/WICG/import-maps#scope-inheritance
+    let base_url = "https://example.com/app/main.ts";
+
+    let json_map = r#"{
+    "imports": {
+      "a": "/a-1.mjs",
+      "b": "/b-1.mjs",
+      "c": "/c-1.mjs"
+    },
+    "scopes": {
+      "/scope2/": {
+        "a": "/a-2.mjs"
+      },
+      "/scope2/scope3/": {
+        "b": "/b-3.mjs"
+      }
+    }
+  }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+    let scope_1_url = "https://example.com/scope1/foo.mjs";
+    let scope_2_url = "https://example.com/scope2/foo.mjs";
+    let scope_3_url = "https://example.com/scope2/scope3/foo.mjs";
+
+    // Should fall back to "imports" when none match.
+    assert_resolve(
+      import_map.resolve("a", scope_1_url),
+      "https://example.com/a-1.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("b", scope_1_url),
+      "https://example.com/b-1.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("c", scope_1_url),
+      "https://example.com/c-1.mjs",
+    );
+
+    // Should use a direct scope override.
+    assert_resolve(
+      import_map.resolve("a", scope_2_url),
+      "https://example.com/a-2.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("b", scope_2_url),
+      "https://example.com/b-1.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("c", scope_2_url),
+      "https://example.com/c-1.mjs",
+    );
+
+    // Should use an indirect scope override.
+    assert_resolve(
+      import_map.resolve("a", scope_3_url),
+      "https://example.com/a-2.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("b", scope_3_url),
+      "https://example.com/b-3.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("c", scope_3_url),
+      "https://example.com/c-1.mjs",
+    );
+  }
+
+  #[test]
+  fn resolve_scopes_relative_url_keys() {
+    // https://github.com/WICG/import-maps#scope-inheritance
+    let base_url = "https://example.com/app/main.ts";
+
+    let json_map = r#"{
+    "imports": {
+      "a": "/a-1.mjs",
+      "b": "/b-1.mjs",
+      "c": "/c-1.mjs"
+    },
+    "scopes": {
+      "": {
+        "a": "/a-empty-string.mjs"
+      },
+      "./": {
+        "b": "/b-dot-slash.mjs"
+      },
+      "../": {
+        "c": "/c-dot-dot-slash.mjs"
+      }
+    }
+  }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+    let in_same_dir_as_map = "https://example.com/app/foo.mjs";
+    let in_dir_above_map = "https://example.com/foo.mjs";
+
+    // Should resolve an empty string scope using the import map URL.
+    assert_resolve(
+      import_map.resolve("a", base_url),
+      "https://example.com/a-empty-string.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("a", in_same_dir_as_map),
+      "https://example.com/a-1.mjs",
+    );
+
+    // Should resolve a ./ scope using the import map URL's directory.
+    assert_resolve(
+      import_map.resolve("b", base_url),
+      "https://example.com/b-dot-slash.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("b", in_same_dir_as_map),
+      "https://example.com/b-dot-slash.mjs",
+    );
+
+    // Should resolve a ../ scope using the import map URL's directory.
+    assert_resolve(
+      import_map.resolve("c", base_url),
+      "https://example.com/c-dot-dot-slash.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("c", in_same_dir_as_map),
+      "https://example.com/c-dot-dot-slash.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("c", in_dir_above_map),
+      "https://example.com/c-dot-dot-slash.mjs",
+    );
+  }
+
+  #[test]
+  fn cant_resolve_to_built_in() {
+    let base_url = "https://example.com/app/main.ts";
+
+    let import_map = ImportMap::from_json(base_url, "{}").unwrap();
+
+    assert!(import_map.resolve("std:blank", base_url).is_err());
+  }
+
+  #[test]
+  fn resolve_builtins_remap() {
+    let base_url = "https://example.com/app/main.ts";
+
+    let json_map = r#"{
+      "imports": {
+        "std:blank": "./blank.mjs",
+        "std:none": "./none.mjs"
+      }
+    }"#;
+    let import_map = ImportMap::from_json(base_url, json_map).unwrap();
+
+    assert_resolve(
+      import_map.resolve("std:blank", base_url),
+      "https://example.com/app/blank.mjs",
+    );
+    assert_resolve(
+      import_map.resolve("std:none", base_url),
+      "https://example.com/app/none.mjs",
+    );
+  }
+}

--- a/compiler/lib.rs
+++ b/compiler/lib.rs
@@ -1,0 +1,648 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+#![deny(warnings)]
+
+extern crate base64;
+extern crate bytecount;
+extern crate deno_core;
+extern crate either;
+extern crate futures;
+extern crate jsonc_parser;
+#[macro_use]
+extern crate lazy_static;
+extern crate regex;
+extern crate ring;
+extern crate serde;
+extern crate serde_json;
+extern crate sourcemap;
+extern crate swc_common;
+extern crate swc_ecma_transforms;
+extern crate swc_ecmascript;
+extern crate termcolor;
+extern crate url;
+
+mod ast;
+mod bundler;
+pub mod colors;
+mod compiler;
+mod config;
+mod import_map;
+mod module_graph;
+mod msg;
+mod ops;
+mod source_map_bundler;
+
+use deno_core::ErrBox;
+use std::result;
+
+pub use crate::bundler::bundle;
+pub use crate::compiler::create_compiler_snapshot;
+pub use crate::compiler::CompilerIsolate;
+pub use crate::compiler::Sources;
+pub use crate::import_map::ImportMap;
+pub use crate::import_map::ImportMapError;
+pub use crate::module_graph::CacheType;
+pub use crate::module_graph::CachedDependencies;
+pub use crate::module_graph::CachedDependency;
+pub use crate::module_graph::CachedModule;
+pub use crate::module_graph::DependencyType;
+pub use crate::module_graph::FetchFuture;
+pub use crate::module_graph::Graph;
+pub use crate::module_graph::GraphBuilder;
+pub use crate::module_graph::GraphError;
+pub use crate::module_graph::SpecifierHandler;
+pub use crate::msg::IgnoredCompilerOptions;
+pub use crate::msg::MediaType;
+
+type Result<V> = result::Result<V, ErrBox>;
+
+pub struct BundleOptions<'a> {
+  /// Indicates if the source code should be typed checked or simply transpiled.
+  /// Defaults to `true`.
+  pub check: bool,
+  /// Informs the TypeScript compiler to output debug logging.
+  pub debug: bool,
+  /// Utilizes build information associated with the graph to speed up type
+  /// checking.
+  pub incremental: bool,
+  /// Indicates if the source map should be inlined into the emitted bundle
+  /// code.  This defaults to `true`.
+  pub inline_source_map: bool,
+  /// A vector of libs to be used when type checking the code.  For example:
+  ///
+  /// ```rust
+  /// let lib = vec!["deno.ns"];
+  /// ```
+  ///
+  pub lib: Vec<&'a str>,
+  /// A string of configuration data that augments the the default configuration
+  /// passed to the TypeScript compiler.  This is typically the contents of a
+  /// user supplied `tsconfig.json`.
+  pub maybe_config: Option<String>,
+}
+
+impl<'a> Default for BundleOptions<'a> {
+  fn default() -> Self {
+    BundleOptions {
+      check: true,
+      debug: false,
+      incremental: false,
+      inline_source_map: true,
+      lib: Vec::new(),
+      maybe_config: None,
+    }
+  }
+}
+
+/// A structure which provides options when compiling modules.
+#[derive(Default)]
+pub struct CompileOptions<'a> {
+  /// If `true` then debug logging will be output from the isolate.
+  pub debug: bool,
+  /// A flag to indicate that the compilation should be incremental, and only
+  /// changed sources will be emitted based on information supplied in the
+  /// `maybe_build_info` argument.
+  pub incremental: bool,
+  /// A vector of libs to be used when type checking the code.  For example:
+  ///
+  /// ```rust
+  /// let lib = vec!["deno.ns"];
+  /// ```
+  ///
+  pub lib: Vec<&'a str>,
+  /// A string of configuration data that augments the the default configuration
+  /// passed to the TypeScript compiler.  This is typically the contents of a
+  /// user supplied `tsconfig.json`.
+  pub maybe_config: Option<String>,
+}
+
+/// A structure which provides options when transpiling modules.
+#[derive(Default)]
+pub struct TranspileOptions {
+  /// If `true` then debug logging will be output from the isolate.
+  pub debug: bool,
+  /// A string of configuration data that augments the the default configuration
+  /// passed to the TypeScript compiler.  This is typically the contents of a
+  /// user supplied `tsconfig.json`.
+  pub maybe_config: Option<String>,
+}
+
+#[cfg(test)]
+pub mod tests {
+  use super::*;
+
+  use deno_core::ModuleSpecifier;
+  use futures::future;
+  use std::cell::RefCell;
+  use std::collections::HashMap;
+  use std::env;
+  use std::fs;
+  use std::path::PathBuf;
+  use std::rc::Rc;
+
+  /// A mock specifier handler which can be used to stub off the handler for a
+  /// graph.
+  #[derive(Debug, Default)]
+  pub struct MockSpecifierHandler {
+    pub fixtures: PathBuf,
+    pub build_info: HashMap<ModuleSpecifier, String>,
+    pub build_info_calls: Vec<(ModuleSpecifier, CacheType, String)>,
+    pub cache_calls: Vec<(ModuleSpecifier, CacheType, String, Option<String>)>,
+    pub deps_calls: Vec<(ModuleSpecifier, CachedDependencies)>,
+    pub types_calls: Vec<(ModuleSpecifier, String)>,
+  }
+
+  impl MockSpecifierHandler {}
+
+  impl SpecifierHandler for MockSpecifierHandler {
+    fn fetch(&mut self, specifier: &ModuleSpecifier) -> FetchFuture {
+      Box::pin(future::ready(Ok(specifier.clone())))
+    }
+    fn get_cache(&self, specifier: &ModuleSpecifier) -> Result<CachedModule> {
+      let specifier_text = specifier
+        .to_string()
+        .replace(":///", "_")
+        .replace("://", "_")
+        .replace("/", "-");
+      let specifier_path = self.fixtures.join(specifier_text);
+      let media_type =
+        match specifier_path.extension().unwrap().to_str().unwrap() {
+          "ts" => MediaType::TypeScript,
+          "tsx" => MediaType::TSX,
+          "js" => MediaType::JavaScript,
+          "jsx" => MediaType::JSX,
+          _ => MediaType::Unknown,
+        };
+      let source = fs::read_to_string(specifier_path)?;
+
+      Ok(CachedModule {
+        source,
+        media_type,
+        ..CachedModule::default()
+      })
+    }
+    fn get_build_info(
+      &self,
+      specifier: &ModuleSpecifier,
+      _cache_type: &CacheType,
+    ) -> Result<Option<String>> {
+      Ok(self.build_info.get(specifier).cloned())
+    }
+    fn set_cache(
+      &mut self,
+      specifier: &ModuleSpecifier,
+      cache_type: &CacheType,
+      code: String,
+      maybe_map: Option<String>,
+    ) -> Result<()> {
+      self.cache_calls.push((
+        specifier.clone(),
+        cache_type.clone(),
+        code,
+        maybe_map,
+      ));
+      Ok(())
+    }
+    fn set_types(
+      &mut self,
+      specifier: &ModuleSpecifier,
+      types: String,
+    ) -> Result<()> {
+      self.types_calls.push((specifier.clone(), types));
+      Ok(())
+    }
+    fn set_build_info(
+      &mut self,
+      specifier: &ModuleSpecifier,
+      cache_type: &CacheType,
+      build_info: String,
+    ) -> Result<()> {
+      self
+        .build_info
+        .insert(specifier.clone(), build_info.clone());
+      self.build_info_calls.push((
+        specifier.clone(),
+        cache_type.clone(),
+        build_info,
+      ));
+      Ok(())
+    }
+    fn set_deps(
+      &mut self,
+      specifier: &ModuleSpecifier,
+      dependencies: CachedDependencies,
+    ) -> Result<()> {
+      self.deps_calls.push((specifier.clone(), dependencies));
+      Ok(())
+    }
+  }
+
+  fn get_snapshot_data(rebuild: bool) -> Result<Box<[u8]>> {
+    let o = env::temp_dir();
+    let snapshot_path = o.join("TEST_COMPILER.bin");
+    if rebuild || !snapshot_path.is_file() {
+      let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+      let assets_path = c.join("../cli/dts");
+      assert!(assets_path.is_dir());
+      let test_fixtures_path = c.join("fixtures");
+      assert!(test_fixtures_path.is_dir());
+      let mut custom_libs = HashMap::new();
+      custom_libs
+        .insert("test".to_string(), test_fixtures_path.join("lib.test.d.ts"));
+      create_compiler_snapshot(
+        snapshot_path.clone(),
+        assets_path,
+        custom_libs,
+      )?;
+    }
+
+    Ok(std::fs::read(snapshot_path)?.into_boxed_slice())
+  }
+
+  fn get_handler() -> Rc<RefCell<MockSpecifierHandler>> {
+    let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let fixtures = c.join("fixtures");
+
+    Rc::new(RefCell::new(MockSpecifierHandler {
+      fixtures,
+      ..MockSpecifierHandler::default()
+    }))
+  }
+
+  type Handler = Rc<RefCell<MockSpecifierHandler>>;
+  type SetupResult = Result<(GraphBuilder, Handler, Box<[u8]>)>;
+
+  fn setup(rebuild: bool, maybe_import_map: Option<ImportMap>) -> SetupResult {
+    let handler = get_handler();
+
+    Ok((
+      GraphBuilder::new(handler.clone(), maybe_import_map),
+      handler,
+      get_snapshot_data(rebuild)?,
+    ))
+  }
+
+  #[tokio::test]
+  async fn test_graph_compile() {
+    let (mut builder, handler, snapshot_data) =
+      setup(false, None).expect("could not setup");
+
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/a.ts").unwrap();
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    let (_, maybe_ignored_options) = graph
+      .compile(
+        CompileOptions {
+          lib: vec!["test"],
+          ..CompileOptions::default()
+        },
+        false,
+        Some(snapshot_data),
+      )
+      .unwrap();
+    assert!(maybe_ignored_options.is_none());
+    let h = handler.borrow();
+    assert_eq!(h.cache_calls.len(), 2, "should have 2 calls");
+    assert_eq!(
+      h.cache_calls[0].1,
+      CacheType::Cli,
+      "cache type should be set to Cli"
+    );
+    assert_eq!(
+      h.cache_calls[1].1,
+      CacheType::Cli,
+      "cache type should be set to Cli"
+    );
+    assert!(h.cache_calls[0].3.is_none(), "shouldn't have maybe map");
+    assert!(h.cache_calls[1].3.is_none(), "shouldn't have maybe map");
+  }
+
+  #[tokio::test]
+  async fn test_graph_compile_user_config() {
+    let (mut builder, handler, snapshot_data) =
+      setup(false, None).expect("could not setup");
+
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("file:///tests/decorators.ts")
+        .unwrap();
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    let maybe_config = Some(
+      r#"{
+      "compilerOptions": {
+        "experimentalDecorators": true,
+        "outFile": "something.js"
+      }
+    }"#
+        .to_string(),
+    );
+    let (_, maybe_ignored_options) = graph
+      .compile(
+        CompileOptions {
+          lib: vec!["test"],
+          maybe_config,
+          ..CompileOptions::default()
+        },
+        false,
+        Some(snapshot_data),
+      )
+      .unwrap();
+    assert_eq!(
+      maybe_ignored_options,
+      Some(IgnoredCompilerOptions(vec!["outFile".to_string()])),
+      "should have ignored outFile"
+    );
+    let h = handler.borrow();
+    assert_eq!(h.cache_calls.len(), 1, "should have 1 calls");
+    let code = h.cache_calls[0].2.clone();
+    assert!(code.contains("__decorate = "));
+  }
+
+  #[tokio::test]
+  async fn test_graph_compile_mixed_1() {
+    let (mut builder, handler, snapshot_data) =
+      setup(false, None).expect("could not setup");
+
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("/tests/mixed/main_js.js").unwrap();
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    graph
+      .compile(
+        CompileOptions {
+          lib: vec!["test"],
+          ..CompileOptions::default()
+        },
+        false,
+        Some(snapshot_data),
+      )
+      .unwrap();
+    let h = handler.borrow();
+    assert_eq!(h.cache_calls.len(), 1, "only emit TS file");
+    assert_eq!(
+      h.cache_calls[0].0,
+      ModuleSpecifier::resolve_url_or_path("file:///tests/mixed/a.ts").unwrap()
+    );
+  }
+
+  #[tokio::test]
+  async fn test_graph_compile_mixed_2() {
+    let (mut builder, handler, snapshot_data) =
+      setup(false, None).expect("could not setup");
+
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("/tests/mixed/main_ts.ts").unwrap();
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    graph
+      .compile(
+        CompileOptions {
+          lib: vec!["test"],
+          ..CompileOptions::default()
+        },
+        false,
+        Some(snapshot_data),
+      )
+      .unwrap();
+    let h = handler.borrow();
+    assert_eq!(h.cache_calls.len(), 2, "only emit TS file");
+    assert_eq!(
+      h.cache_calls[0].0,
+      ModuleSpecifier::resolve_url_or_path("file:///tests/mixed/main_ts.ts")
+        .unwrap()
+    );
+    assert_eq!(
+      h.cache_calls[1].0,
+      ModuleSpecifier::resolve_url_or_path("file:///tests/mixed/d.ts").unwrap()
+    );
+  }
+
+  #[tokio::test]
+  async fn test_graph_compile_check_only() {
+    let (mut builder, handler, snapshot_data) =
+      setup(false, None).expect("could not setup");
+
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/a.ts").unwrap();
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    let (_, maybe_ignored_options) = graph
+      .compile(
+        CompileOptions {
+          lib: vec!["test"],
+          ..CompileOptions::default()
+        },
+        true,
+        Some(snapshot_data),
+      )
+      .unwrap();
+    assert!(maybe_ignored_options.is_none());
+    let h = handler.borrow();
+    assert_eq!(h.cache_calls.len(), 0, "should have 2 calls");
+  }
+
+  #[tokio::test]
+  async fn test_graph_transpile() {
+    let (mut builder, handler, _) =
+      setup(false, None).expect("could not setup");
+
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/a.ts").unwrap();
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    let (_, maybe_ignored_options) =
+      graph.transpile(TranspileOptions::default(), None).unwrap();
+    assert!(maybe_ignored_options.is_none());
+    let h = handler.borrow();
+    assert_eq!(h.cache_calls.len(), 2, "should have 2 calls");
+    assert_eq!(
+      h.cache_calls[0].1,
+      CacheType::Cli,
+      "cache type should be set to Cli"
+    );
+    assert_eq!(
+      h.cache_calls[1].1,
+      CacheType::Cli,
+      "cache type should be set to Cli"
+    );
+    assert!(h.cache_calls[0].3.is_none(), "shouldn't have maybe map");
+    assert!(h.cache_calls[1].3.is_none(), "shouldn't have maybe map");
+  }
+
+  #[tokio::test]
+  async fn test_graph_transpile_user_config() {
+    let (mut builder, handler, _) =
+      setup(false, None).expect("could not setup");
+
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("file:///tests/preact.tsx").unwrap();
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    let maybe_config = Some(
+      r#"{
+        "compilerOptions": {
+          "jsxFactory": "Preact.h",
+          "jsxFragmentFactory": "Preact.Fragment",
+          "outFile": "something.js"
+        }
+      }"#
+        .to_string(),
+    );
+    let (_, maybe_ignored_options) = graph
+      .transpile(
+        TranspileOptions {
+          maybe_config,
+          ..Default::default()
+        },
+        None,
+      )
+      .unwrap();
+    assert_eq!(
+      maybe_ignored_options,
+      Some(IgnoredCompilerOptions(vec!["outFile".to_string()])),
+      "should have ignored outFile"
+    );
+    let h = handler.borrow();
+    assert_eq!(h.cache_calls.len(), 1, "should have 1 calls");
+    let code = h.cache_calls[0].2.clone();
+    assert!(code.contains("Preact.Fragment"));
+  }
+
+  #[tokio::test]
+  async fn test_graph_bundle() {
+    let (mut builder, handler, snapshot_data) =
+      setup(false, None).expect("could not setup");
+
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/a.ts").unwrap();
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    let (code, maybe_map, _, maybe_ignored_options) = graph
+      .bundle(
+        BundleOptions {
+          lib: vec!["test"],
+          ..Default::default()
+        },
+        Some(snapshot_data),
+      )
+      .unwrap();
+    assert!(maybe_ignored_options.is_none());
+    let h = handler.borrow();
+    assert_eq!(h.cache_calls.len(), 2, "should have 2 calls");
+    assert_eq!(
+      h.cache_calls[0].1,
+      CacheType::Bundle,
+      "cache type should be set to Cli"
+    );
+    assert_eq!(
+      h.cache_calls[1].1,
+      CacheType::Bundle,
+      "cache type should be set to Cli"
+    );
+    assert!(h.cache_calls[0].3.is_some(), "should have had a map");
+    assert!(h.cache_calls[1].3.is_some(), "should have had a map");
+    assert!(code.contains(
+      "\n\nvar __exp = __instantiate(\"/https/deno.land/x/a.ts\", false);\n"
+    ));
+    assert!(maybe_map.is_none());
+  }
+
+  #[tokio::test]
+  async fn test_graph_bundle_complex_exports() {
+    let (mut builder, _, snapshot_data) =
+      setup(false, None).expect("could not setup");
+
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("file:///tests/bundle/root.ts")
+        .unwrap();
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    let (code, maybe_map, _, _) = graph
+      .bundle(
+        BundleOptions {
+          lib: vec!["test"],
+          ..Default::default()
+        },
+        Some(snapshot_data),
+      )
+      .unwrap();
+    assert!(code
+      .contains("\n\nvar __exp = __instantiate(\"/file/root.ts\", false);\n"));
+    assert!(code.contains("\nexport var b = __exp[\"b\"];\n"));
+    assert!(code.contains("\nexport var C = __exp[\"C\"];\n"));
+    assert!(code.contains("\nexport var a = __exp[\"a\"];\n"));
+    assert!(maybe_map.is_none());
+  }
+
+  #[tokio::test]
+  async fn test_graph_bundle_no_check() {
+    let (mut builder, handler, snapshot_data) =
+      setup(false, None).expect("could not setup");
+
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/a.ts").unwrap();
+    builder
+      .insert(&specifier)
+      .await
+      .expect("could not insert module");
+    let graph = builder.get_graph();
+    let (code, maybe_map, _, maybe_ignored_options) = graph
+      .bundle(
+        BundleOptions {
+          check: false,
+          lib: vec!["test"],
+          ..Default::default()
+        },
+        Some(snapshot_data),
+      )
+      .unwrap();
+    assert!(maybe_ignored_options.is_none());
+    let h = handler.borrow();
+    assert_eq!(h.cache_calls.len(), 2, "should have 2 calls");
+    assert_eq!(
+      h.cache_calls[0].1,
+      CacheType::Bundle,
+      "cache type should be set to Cli"
+    );
+    assert_eq!(
+      h.cache_calls[1].1,
+      CacheType::Bundle,
+      "cache type should be set to Cli"
+    );
+    assert!(h.cache_calls[0].3.is_some(), "should have had a map");
+    assert!(h.cache_calls[1].3.is_some(), "should have had a map");
+    assert!(code.contains("System.register(\"/https/deno.land/x/a.ts\", [\"/https/deno.land/x/b.ts\"]"));
+    assert!(code.contains(
+      "\n\nvar __exp = __instantiate(\"/https/deno.land/x/a.ts\", false);\n"
+    ));
+    assert!(maybe_map.is_none());
+  }
+}

--- a/compiler/module_graph.rs
+++ b/compiler/module_graph.rs
@@ -1,0 +1,1375 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+use crate::ast::parse;
+use crate::ast::EmitTranspileOptions;
+use crate::ast::Location;
+use crate::ast::ParsedModule;
+use crate::bundler;
+use crate::compiler::CompilerIsolate;
+use crate::compiler::InternalCompileOptions;
+use crate::compiler::InternalTranspileOptions;
+use crate::config::json_merge;
+use crate::config::parse_config;
+use crate::import_map::ImportMap;
+use crate::msg::as_ts_filename;
+use crate::msg::common_path_reduce;
+use crate::msg::CompilerStats;
+use crate::msg::EmittedFile;
+use crate::msg::IgnoredCompilerOptions;
+use crate::msg::MediaType;
+use crate::msg::TranspileSourceFile;
+use crate::BundleOptions;
+use crate::CompileOptions;
+use crate::Result;
+use crate::TranspileOptions;
+
+use deno_core::ModuleSpecifier;
+use deno_core::Snapshot;
+use deno_core::StartupData;
+use futures::stream::FuturesUnordered;
+use futures::stream::StreamExt;
+use futures::Future;
+use regex::Regex;
+use serde::Deserialize;
+use serde_json::json;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::error::Error;
+use std::fmt;
+use std::pin::Pin;
+use std::rc::Rc;
+
+pub type FetchFuture =
+  Pin<Box<(dyn Future<Output = Result<ModuleSpecifier>> + 'static)>>;
+
+/// A trait which provides the methods required for a module graph to be built
+/// and any changes to be notified back to the handler.
+pub trait SpecifierHandler {
+  /// Instructs the handler to fetch a specifier, resolving when finished.
+  fn fetch(&mut self, specifier: &ModuleSpecifier) -> FetchFuture;
+
+  /// Get a module from cache, which has been previously fetched. It is expected
+  /// that source for the module had been invalidated that the related emitted
+  /// code would not be returned either.
+  fn get_cache(&self, specifier: &ModuleSpecifier) -> Result<CachedModule>;
+
+  /// Get the optional build info from the cache for a given module specifier.
+  /// Because build infos are only associated with the "root" modules, they are
+  /// not expected to be cached for each module, but are "lazily" checked when
+  /// a root module is identified.  The `cache_type` also indicates what form
+  /// of the module the build info is valid for.
+  fn get_build_info(
+    &self,
+    specifier: &ModuleSpecifier,
+    cache_type: &CacheType,
+  ) -> Result<Option<String>>;
+
+  /// Set the emitted code (and maybe map) for a given module specifier.  The
+  /// cache type indicates what form the emit is related to.
+  fn set_cache(
+    &mut self,
+    specifier: &ModuleSpecifier,
+    cache_type: &CacheType,
+    code: String,
+    maybe_map: Option<String>,
+  ) -> Result<()>;
+
+  /// When parsed out of a JavaScript module source, the triple slash reference
+  /// to the types should be stored in the cache.
+  fn set_types(
+    &mut self,
+    specifier: &ModuleSpecifier,
+    types: String,
+  ) -> Result<()>;
+
+  /// Set the build info for a module specifier, also providing the cache type.
+  fn set_build_info(
+    &mut self,
+    specifier: &ModuleSpecifier,
+    cache_type: &CacheType,
+    build_info: String,
+  ) -> Result<()>;
+
+  /// Set the graph dependencies for a given module specifier.
+  fn set_deps(
+    &mut self,
+    specifier: &ModuleSpecifier,
+    dependencies: CachedDependencies,
+  ) -> Result<()>;
+}
+
+impl std::fmt::Debug for dyn SpecifierHandler {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    write!(f, "SpecifierHandler {{ }}")
+  }
+}
+
+/// A trait, implemented by `Graph` that provides the interfaces that the
+/// compiler ops require to be able to retrieve and set information about a
+/// compilation.
+pub trait ModuleProvider {
+  /// Get the source for a given module specifier.  If the module is not part
+  /// of the graph, the result will be `None`.
+  fn get_source(&self, specifier: &ModuleSpecifier) -> Option<String>;
+  /// Given a string specifier and a referring module specifier, provide the
+  /// resulting module specifier and media type for the module that is part of
+  /// the graph.
+  fn resolve(
+    &self,
+    specifier: &str,
+    referrer: &ModuleSpecifier,
+  ) -> Result<(ModuleSpecifier, MediaType)>;
+}
+
+lazy_static! {
+  /// Matched the `@deno-types` pragma.
+  static ref DENO_TYPES_RE: Regex =
+    Regex::new(r#"(?i)^\s*@deno-types\s*=\s*(?:["']([^"']+)["']|(\S+))"#)
+      .unwrap();
+  /// Matches a `/// <reference ... />` comment reference.
+  static ref TRIPLE_SLASH_REFERENCE_RE: Regex =
+    Regex::new(r"(?i)^/\s*<reference\s.*?/>").unwrap();
+  /// Matches a path reference, which adds a dependency to a module
+  static ref PATH_REFERENCE_RE: Regex =
+    Regex::new(r#"(?i)\spath\s*=\s*["']([^"']*)["']"#).unwrap();
+  /// Matches a types reference, which for JavaScript files indicates the
+  /// location of types to use when type checking a program that includes it as
+  /// a dependency.
+  static ref TYPES_REFERENCE_RE: Regex =
+    Regex::new(r#"(?i)\stypes\s*=\s*["']([^"']*)["']"#).unwrap();
+}
+
+#[derive(Clone, Debug)]
+pub struct CachedDependency {
+  pub specifier: String,
+  pub maybe_code: Option<ModuleSpecifier>,
+  pub maybe_type: Option<ModuleSpecifier>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CachedDependencies(pub Vec<CachedDependency>);
+
+impl From<&HashMap<String, ModuleDependency>> for CachedDependencies {
+  fn from(dependencies: &HashMap<String, ModuleDependency>) -> Self {
+    let mut cached_deps = Vec::new();
+    for (specifier, dep) in dependencies.iter() {
+      let cached_dep = CachedDependency {
+        specifier: specifier.clone(),
+        maybe_code: dep.maybe_code.clone(),
+        maybe_type: dep.maybe_type.clone(),
+      };
+      cached_deps.push(cached_dep);
+    }
+    CachedDependencies(cached_deps)
+  }
+}
+
+/// The logical representation of a cached module that is returned from a
+/// specifier handler.
+#[derive(Clone, Debug)]
+pub struct CachedModule {
+  pub bundle_code: Option<String>,
+  pub bundle_map: Option<String>,
+  pub code: Option<String>,
+  pub map: Option<String>,
+  pub maybe_dependencies: Option<CachedDependencies>,
+  pub maybe_types: Option<String>,
+  pub media_type: MediaType,
+  pub source: String,
+}
+
+#[cfg(test)]
+impl Default for CachedModule {
+  fn default() -> Self {
+    CachedModule {
+      bundle_code: None,
+      bundle_map: None,
+      code: None,
+      map: None,
+      maybe_dependencies: None,
+      maybe_types: None,
+      media_type: MediaType::Unknown,
+      source: "".to_string(),
+    }
+  }
+}
+
+/// Represents different types of cached code which can be generated for a
+/// specifier.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum CacheType {
+  /// A cache version which is a valid JavaScript ES Module
+  Cli,
+  /// A cache version which is a SystemJS Module
+  Bundle,
+}
+
+impl Default for CacheType {
+  fn default() -> Self {
+    CacheType::Cli
+  }
+}
+
+/// A group of errors that represent errors that can occur when interacting with
+/// a module graph.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GraphError {
+  /// A module using the HTTPS protocol is trying to import a module with an
+  /// HTTP schema.
+  InvalidDowngrade(ModuleSpecifier, Location),
+  /// A remote module is trying to import a local module.
+  InvalidLocalImport(ModuleSpecifier, Location),
+  /// A module specifier could not be resolved for a given import.
+  InvalidSpecifier(String, Location),
+  /// An unexpected dependency was requested for a module.
+  MissingDependency(ModuleSpecifier, String),
+  /// An unexpected specifier was requested.
+  MissingSpecifier(ModuleSpecifier),
+  /// Snapshot data was not present in a situation where it was required.
+  MissingSnapshotData,
+  /// The current feature is not supported.
+  NotSupported(String),
+}
+use GraphError::*;
+
+impl fmt::Display for GraphError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      InvalidDowngrade(ref specifier, ref location) => write!(f, "Modules imported via https are not allowed to import http modules.\n  Importing: {}\n    at {}:{}:{}", specifier, location.filename, location.line, location.col),
+      InvalidLocalImport(ref specifier, ref location) => write!(f, "Remote modules are not allowed to import local modules.\n  Importing: {}\n    at {}:{}:{}", specifier, location.filename, location.line, location.col),
+      InvalidSpecifier(ref specifier, ref location) => write!(f, "Unable to resolve dependency specifier.\n  Specifier: {}\n    at {}:{}:{}", specifier, location.filename, location.line, location.col),
+      MissingDependency(ref referrer, specifier) => write!(
+        f,
+        "The graph is missing a dependency.\n  Specifier: {} from {}",
+        specifier, referrer
+      ),
+      MissingSpecifier(ref specifier) => write!(
+        f,
+        "The graph is missing a specifier.\n  Specifier: {}",
+        specifier
+      ),
+      MissingSnapshotData => write!(f, "Snapshot data was not supplied, but required."),
+      NotSupported(ref msg) => write!(f, "{}", msg),
+    }
+  }
+}
+
+impl Error for GraphError {}
+
+/// Represents the type of dependencies for a specifier, as code and type
+/// dependencies are treated differently when checking a program.
+pub enum DependencyType {
+  // These are the code dependencies, which their code output will be needed
+  // at runtime.
+  Code,
+  // These are type dependencies, which are needed to type check the the
+  // source code.
+  Type,
+}
+
+/// Determine if a comment contains a `@deno-types` pragma and optionally return
+/// its value.
+fn parse_deno_types(comment: &str) -> Option<String> {
+  if let Some(captures) = DENO_TYPES_RE.captures(comment) {
+    if let Some(m) = captures.get(1) {
+      Some(m.as_str().to_string())
+    } else if let Some(m) = captures.get(2) {
+      Some(m.as_str().to_string())
+    } else {
+      panic!("unreachable");
+    }
+  } else {
+    None
+  }
+}
+
+enum TypeScriptReference {
+  Path(String),
+  Types(String),
+}
+
+/// Parse out any `path` or `types` triple-slash references in a comment string
+/// and return it.
+fn parse_ts_reference(comment: &str) -> Option<TypeScriptReference> {
+  if !TRIPLE_SLASH_REFERENCE_RE.is_match(comment) {
+    None
+  } else if let Some(captures) = PATH_REFERENCE_RE.captures(comment) {
+    Some(TypeScriptReference::Path(
+      captures.get(1).unwrap().as_str().to_string(),
+    ))
+  } else if let Some(captures) = TYPES_REFERENCE_RE.captures(comment) {
+    Some(TypeScriptReference::Types(
+      captures.get(1).unwrap().as_str().to_string(),
+    ))
+  } else {
+    None
+  }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ModuleDependency {
+  maybe_code: Option<ModuleSpecifier>,
+  maybe_type: Option<ModuleSpecifier>,
+}
+
+/// A logical representation of a module within a module graph.
+#[derive(Debug, Clone)]
+pub struct Module {
+  /// The module specifier for the module
+  specifier: ModuleSpecifier,
+  /// The media type for the module
+  media_type: MediaType,
+  /// A hash map of dependencies, where the key is the string of the dependency
+  /// from the module, and the value is a descriptor of the dependency
+  dependencies: HashMap<String, ModuleDependency>,
+  /// The source code of the dependency
+  pub source: String,
+  /// An optional import map which will be used when resolving imported modules.
+  maybe_import_map: Option<Rc<RefCell<ImportMap>>>,
+  maybe_parsed_module: Option<ParsedModule>,
+  /// If there is an `X-TypeScript-Types` header or the source contains a
+  /// triple slash reference to some types, this will be populated with the
+  /// specifier that should be used instead.
+  maybe_types: Option<(String, ModuleSpecifier)>,
+  /// If the module has been emitted, for the CLI, the emitted code is here.
+  code: Option<String>,
+  /// If the module has been emitted, if it has a separate source map, it is
+  /// here.
+  map: Option<String>,
+  /// If the module has been emitted, for a bundle, the emitted code is here.
+  bundle_code: Option<String>,
+  /// If the module has been emitted for a bundle, and has a separate source
+  /// map, it is here.
+  bundle_map: Option<String>,
+  /// A flag that indicates that the emit of the module is dirty and needs to
+  /// have its cache updated.
+  is_dirty: bool,
+  /// A flag to indicated if the module has had its dependencies analysed.
+  is_parsed: bool,
+  /// A flag to indicate if the file has been hydrated based on its cached
+  /// value from the specifier handler.
+  is_hydrated: bool,
+}
+
+impl Module {
+  pub fn new(
+    specifier: ModuleSpecifier,
+    maybe_import_map: Option<Rc<RefCell<ImportMap>>>,
+  ) -> Self {
+    Module {
+      specifier,
+      maybe_import_map,
+      media_type: MediaType::Unknown,
+      ..Module::default()
+    }
+  }
+
+  pub fn default() -> Self {
+    Module {
+      specifier: ModuleSpecifier::resolve_url("https://deno.land/x/").unwrap(),
+      media_type: MediaType::Unknown,
+      dependencies: HashMap::new(),
+      source: "".to_string(),
+      maybe_import_map: None,
+      maybe_parsed_module: None,
+      maybe_types: None,
+      is_dirty: false,
+      code: None,
+      map: None,
+      bundle_code: None,
+      bundle_map: None,
+      is_parsed: false,
+      is_hydrated: false,
+    }
+  }
+
+  /// Take the cached representation of a module and _hydrate_ its structure.
+  pub fn hydrate(&mut self, cached_module: CachedModule) {
+    self.media_type = cached_module.media_type;
+    self.source = cached_module.source;
+    if self.maybe_import_map.is_none() {
+      if let Some(ref dependencies) = cached_module.maybe_dependencies {
+        for cached_dep in dependencies.0.iter() {
+          self.dependencies.insert(
+            cached_dep.specifier.clone(),
+            ModuleDependency {
+              maybe_code: cached_dep.maybe_code.clone(),
+              maybe_type: cached_dep.maybe_type.clone(),
+            },
+          );
+        }
+        self.is_parsed = true;
+      }
+    }
+    self.maybe_types = if let Some(ref specifier) = cached_module.maybe_types {
+      Some((
+        specifier.clone(),
+        self
+          .resolve_import(&specifier, None)
+          .expect("could not resolve module"),
+      ))
+    } else {
+      None
+    };
+    self.is_dirty = false;
+    self.code = cached_module.code;
+    self.map = cached_module.map;
+    self.bundle_code = cached_module.bundle_code;
+    self.bundle_map = cached_module.bundle_map;
+    self.is_hydrated = true;
+  }
+
+  /// Perform a parse of the source of the module, identifying any dependencies.
+  ///
+  /// This has specific logic that parses out triple slash references supported
+  /// by Deno as well as `@deno-types` pragmas in addition to identifying any
+  /// _standard_ ES module dependencies.
+  pub fn parse(&mut self) -> Result<()> {
+    let parsed_module = parse(&self.specifier, &self.source, self.media_type)?;
+
+    // Parse out any triple slash references
+    for comment in parsed_module.leading_comments.iter() {
+      if let Some(ts_reference) = parse_ts_reference(&comment.text) {
+        let location: Location = parsed_module
+          .source_map
+          .lookup_char_pos(comment.span.lo)
+          .into();
+        match ts_reference {
+          TypeScriptReference::Path(import) => {
+            let specifier = self.resolve_import(&import, Some(location))?;
+            let dep = self.dependencies.entry(import).or_default();
+            dep.maybe_code = Some(specifier);
+          }
+          TypeScriptReference::Types(import) => {
+            let specifier = self.resolve_import(&import, Some(location))?;
+            if self.media_type == MediaType::JavaScript
+              || self.media_type == MediaType::JSX
+            {
+              // TODO(kitsonk) we need to specifically update the cache when
+              // this value changes
+              self.maybe_types = Some((import.clone(), specifier));
+            } else {
+              let dep = self.dependencies.entry(import).or_default();
+              dep.maybe_type = Some(specifier);
+            }
+          }
+        }
+      }
+    }
+
+    // Parse out all the syntactical dependencies for a module
+    let dependencies = parsed_module.get_dependencies();
+    for desc in dependencies.iter() {
+      let specifier =
+        self.resolve_import(&desc.specifier, Some(desc.location.clone()))?;
+
+      // Parse out any `@deno-types` pragmas and modify dependency
+      let maybe_types_specifier = if !desc.leading_comments.is_empty() {
+        let comment = desc.leading_comments.last().unwrap();
+        if let Some(deno_types) = parse_deno_types(&comment.text).as_ref() {
+          Some(self.resolve_import(deno_types, Some(desc.location.clone()))?)
+        } else {
+          None
+        }
+      } else {
+        None
+      };
+
+      let dep = self.dependencies.entry(desc.specifier.clone()).or_default();
+      if desc.is_type {
+        dep.maybe_type = Some(specifier);
+      } else {
+        dep.maybe_code = Some(specifier);
+      }
+      if let Some(types_specifier) = maybe_types_specifier {
+        dep.maybe_type = Some(types_specifier);
+      }
+    }
+
+    self.is_parsed = true;
+    self.maybe_parsed_module = Some(parsed_module);
+
+    Ok(())
+  }
+
+  fn resolve_import(
+    &self,
+    specifier: &str,
+    maybe_location: Option<Location>,
+  ) -> Result<ModuleSpecifier> {
+    let maybe_resolve = if let Some(import_map) = self.maybe_import_map.clone()
+    {
+      import_map
+        .borrow()
+        .resolve(specifier, self.specifier.as_str())?
+    } else {
+      None
+    };
+    let specifier = if let Some(module_specifier) = maybe_resolve {
+      module_specifier
+    } else {
+      ModuleSpecifier::resolve_import(specifier, self.specifier.as_str())?
+    };
+
+    let referrer_scheme = self.specifier.as_url().scheme();
+    let specifier_scheme = specifier.as_url().scheme();
+    let location = maybe_location.unwrap_or(Location {
+      filename: self.specifier.to_string(),
+      line: 0,
+      col: 0,
+    });
+
+    // Disallow downgrades from HTTPS to HTTP
+    if referrer_scheme == "https" && specifier_scheme == "http" {
+      return Err(InvalidDowngrade(specifier.clone(), location).into());
+    }
+
+    // Disallow a remote URL from trying to import a local URL
+    if (referrer_scheme == "https" || referrer_scheme == "http")
+      && !(specifier_scheme == "https" || specifier_scheme == "http")
+    {
+      return Err(InvalidLocalImport(specifier.clone(), location).into());
+    }
+
+    Ok(specifier)
+  }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TranspileTsOptions {
+  check_js: bool,
+  emit_decorator_metadata: bool,
+  jsx: String,
+  jsx_factory: String,
+  jsx_fragment_factory: String,
+}
+
+/// A structure which represents a dependency graph of a set of modules, which
+/// can be used to compile or transpile source code into code that can be run
+/// within an isolate.
+#[derive(Debug, Clone)]
+pub struct Graph {
+  build_info: HashMap<CacheType, String>,
+  handler: Rc<RefCell<dyn SpecifierHandler>>,
+  modules: HashMap<ModuleSpecifier, Module>,
+  roots: Vec<ModuleSpecifier>,
+}
+
+impl Graph {
+  pub fn new(handler: Rc<RefCell<dyn SpecifierHandler>>) -> Self {
+    Graph {
+      build_info: HashMap::new(),
+      handler,
+      modules: HashMap::new(),
+      roots: Vec::new(),
+    }
+  }
+
+  /// Create a single file output for the module graph, updating any emitted
+  /// modules and build info with the specifier handler.
+  ///
+  /// # Arguments
+  ///
+  /// - `options` - a structure of options that effect the generation of the
+  ///   bundle.
+  /// - `maybe_snapshot_data` - A snapshot of a TypeScript compiler isolate,
+  ///   which will be used to compile the modules.  Currently, this is required
+  ///   but maybe optional in the future.  If not present, the result will
+  ///   error.
+  ///
+  pub fn bundle(
+    self,
+    options: BundleOptions,
+    maybe_snapshot_data: Option<Box<[u8]>>,
+  ) -> Result<(
+    String,
+    Option<String>,
+    CompilerStats,
+    Option<IgnoredCompilerOptions>,
+  )> {
+    if self.roots.len() != 1 {
+      return Err(
+        NotSupported(format!(
+          "Bundling only supports a single root file.  Graph has {} root(s).",
+          self.roots.len()
+        ))
+        .into(),
+      );
+    }
+    if let Some(snapshot_data) = maybe_snapshot_data {
+      let roots = self.roots.clone();
+      let maybe_shared_path = self.get_shared_path();
+      let main_specifier = as_ts_filename(&roots[0], &maybe_shared_path);
+      let maybe_named_exports = self.get_root_export_names()?;
+      let startup_data = StartupData::Snapshot(Snapshot::Boxed(snapshot_data));
+      let mut compiler = CompilerIsolate::new(startup_data);
+      let cache_type = CacheType::Bundle;
+      let provider = Rc::new(RefCell::new(self));
+      let emit_result: Result<(CompilerStats, Option<IgnoredCompilerOptions>)> =
+        if options.check {
+          let p = provider.borrow();
+          let maybe_build_info = p.build_info.get(&cache_type).cloned();
+          let root_names = p.roots.iter().clone().collect();
+
+          let emit = compiler.compile(InternalCompileOptions {
+            bundle: true,
+            check_only: false,
+            compile_options: CompileOptions {
+              debug: options.debug,
+              incremental: options.incremental,
+              lib: options.lib.clone(),
+              maybe_config: options.maybe_config.clone(),
+            },
+            maybe_build_info,
+            maybe_shared_path,
+            provider: provider.clone(),
+            root_names,
+          })?;
+          drop(p);
+          let mut p = provider.borrow_mut();
+          p.update(emit.written_files, &cache_type, true)?;
+          p.flush(&cache_type)?;
+
+          Ok((emit.stats, emit.maybe_ignored_options))
+        } else {
+          let p = provider.borrow();
+          let sources = p.get_sources(true, &cache_type);
+          drop(p);
+
+          let emit = compiler.transpile(InternalTranspileOptions {
+            bundle: true,
+            sources,
+            transpile_options: TranspileOptions {
+              debug: options.debug,
+              maybe_config: options.maybe_config.clone(),
+            },
+          })?;
+          let mut p = provider.borrow_mut();
+          p.update(emit.written_files, &cache_type, true)?;
+          p.flush(&cache_type)?;
+
+          Ok((emit.stats, emit.maybe_ignored_options))
+        };
+      let (stats, maybe_ignored_options) = emit_result?;
+      let p = provider.borrow();
+      let files: Vec<bundler::BundleFile> = p
+        .modules
+        .iter()
+        .map(|(_, m)| bundler::BundleFile {
+          code: m.bundle_code.clone().unwrap(),
+          map: m.bundle_map.clone().unwrap(),
+        })
+        .collect();
+
+      let (bundle_code, maybe_bundle_map) = bundler::bundle(
+        files,
+        bundler::BundleOptions {
+          inline_source_map: options.inline_source_map,
+          main_specifier,
+          maybe_named_exports,
+          target_es5: false,
+        },
+      )?;
+
+      Ok((bundle_code, maybe_bundle_map, stats, maybe_ignored_options))
+    } else {
+      Err(
+        NotSupported(
+          "Compiling without snapshot data currently not supported.".into(),
+        )
+        .into(),
+      )
+    }
+  }
+
+  /// Compile (type check and transform) the graph, updating any emitted modules
+  /// and build info with the specifier handler.  The result contains any
+  /// performance stats from the compiler and optionally any user provided
+  /// configuration compiler options that were ignored.
+  ///
+  /// # Arguments
+  ///
+  /// - `options` - A structure of compiler options which effect how the modules
+  ///   in the graph are compiled.
+  /// - `check_only` - Do a compilation of the graph, but do not emit any files
+  ///   and update the graph.
+  /// - `maybe_snapshot_data` - A snapshot of a TypeScript compiler isolate,
+  ///   which will be used to compile the modules.  Currently, this is required
+  ///   but maybe optional in the future.  If not present, the result will
+  ///   error.
+  ///
+  pub fn compile(
+    self,
+    compile_options: CompileOptions,
+    check_only: bool,
+    maybe_snapshot_data: Option<Box<[u8]>>,
+  ) -> Result<(CompilerStats, Option<IgnoredCompilerOptions>)> {
+    if let Some(snapshot_data) = maybe_snapshot_data {
+      let cache_type = CacheType::Cli;
+      let startup_data = StartupData::Snapshot(Snapshot::Boxed(snapshot_data));
+      let mut compiler = CompilerIsolate::new(startup_data);
+      let provider = Rc::new(RefCell::new(self));
+      let p = provider.borrow();
+      let maybe_build_info = p.build_info.get(&cache_type).cloned();
+      let root_names = p.roots.iter().clone().collect();
+
+      let emit = compiler.compile(InternalCompileOptions {
+        bundle: false,
+        check_only,
+        compile_options,
+        maybe_build_info,
+        maybe_shared_path: None,
+        provider: provider.clone(),
+        root_names,
+      })?;
+      drop(p);
+      if !check_only {
+        let mut p = provider.borrow_mut();
+        p.update(emit.written_files, &cache_type, emit.cache_js)?;
+        p.flush(&cache_type)?;
+      }
+
+      Ok((emit.stats, emit.maybe_ignored_options))
+    } else {
+      Err(
+        NotSupported(
+          "Compiling without snapshot data currently not supported.".into(),
+        )
+        .into(),
+      )
+    }
+  }
+
+  /// Update the handler with any modules that are marked as _dirty_ and update
+  /// any build info if present.
+  fn flush(&mut self, cache_type: &CacheType) -> Result<()> {
+    let mut handler = self.handler.borrow_mut();
+    for (_, module) in self.modules.iter_mut() {
+      if module.is_dirty {
+        match cache_type {
+          CacheType::Cli => handler.set_cache(
+            &module.specifier,
+            &cache_type,
+            module.code.clone().unwrap(),
+            module.map.clone(),
+          )?,
+          CacheType::Bundle => handler.set_cache(
+            &module.specifier,
+            &cache_type,
+            module.bundle_code.clone().unwrap(),
+            module.bundle_map.clone(),
+          )?,
+        }
+        module.is_dirty = false;
+      }
+    }
+    for root_specifier in self.roots.iter() {
+      if let Some(build_info) = self.build_info.get(&cache_type) {
+        handler.set_build_info(
+          root_specifier,
+          &cache_type,
+          build_info.to_owned(),
+        )?;
+      }
+    }
+
+    Ok(())
+  }
+
+  /// Recursively get the exported names of a module.  This handles situations
+  /// where the `export * from 'spec'` exports.
+  fn get_export_names(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Result<Vec<String>> {
+    if let Some(module) = self.modules.get(specifier) {
+      let mut names: Vec<String> = Vec::new();
+      if let Some(parsed_module) = module.maybe_parsed_module.as_ref() {
+        let (mut parsed_names, export_all_specifiers) =
+          parsed_module.get_export_names();
+        names.append(&mut parsed_names);
+        for spec in export_all_specifiers.iter() {
+          let (exp_specifier, _) = self.resolve(spec, specifier)?;
+          let mut parsed_names = self.get_export_names(&exp_specifier)?;
+          names.append(&mut parsed_names);
+        }
+      }
+
+      Ok(names)
+    } else {
+      Err(MissingSpecifier(specifier.clone()).into())
+    }
+  }
+
+  /// For the root module, optionally return a vector of the strings of the
+  /// names of those exports.  This is used when bundling to "re-export" the
+  /// surface area of the root module from the bundle.
+  fn get_root_export_names(&self) -> Result<Option<Vec<String>>> {
+    let root_specifier = &self.roots[0];
+    let names = self.get_export_names(root_specifier)?;
+
+    if !names.is_empty() {
+      Ok(Some(names))
+    } else {
+      Ok(None)
+    }
+  }
+
+  fn get_shared_path(&self) -> Option<String> {
+    let specifiers: Vec<&ModuleSpecifier> = self
+      .modules
+      .iter()
+      .filter(|(k, _)| k.as_url().scheme() == "file")
+      .map(|(k, _)| k)
+      .collect();
+    let maybe_shared_path = common_path_reduce(specifiers);
+    if let Some(specifier) = maybe_shared_path.as_ref() {
+      Some(as_ts_filename(specifier, &None))
+    } else {
+      None
+    }
+  }
+
+  /// Retrieve the graph of dependencies as a hash map, typically used for
+  /// transpiling/type stripping.
+  ///
+  /// Note, that when the `cache_type` is `CacheType::Bundle`, the source files
+  /// will contain a remapping of the module specifiers, to those provided in
+  /// the bundle.
+  fn get_sources(
+    &self,
+    include_js: bool,
+    cache_type: &CacheType,
+  ) -> HashMap<String, TranspileSourceFile> {
+    let mut sources: HashMap<String, TranspileSourceFile> = HashMap::new();
+    for (specifier, module) in self.modules.iter() {
+      // we will skip any files where we have valid source, as it is expected
+      // that if the cache is invalid, the handler will not provide the code
+      if match cache_type {
+        CacheType::Cli => module.code.is_some(),
+        CacheType::Bundle => module.bundle_code.is_some(),
+      } {
+        continue;
+      }
+      if !(include_js
+        || module.media_type == MediaType::TypeScript
+        || module.media_type == MediaType::TSX)
+      {
+        continue;
+      }
+      if *cache_type == CacheType::Bundle {
+        let shared_path = self.get_shared_path();
+        let key = as_ts_filename(specifier, &shared_path);
+        let mut renamed_dependencies = HashMap::new();
+        for (spec, dep) in module.dependencies.iter() {
+          if let Some(dep_code) = &dep.maybe_code {
+            renamed_dependencies
+              .insert(spec.clone(), as_ts_filename(dep_code, &shared_path));
+          }
+        }
+        sources.insert(
+          key,
+          TranspileSourceFile {
+            data: module.source.clone(),
+            renamed_dependencies: Some(renamed_dependencies),
+          },
+        );
+      } else {
+        sources.insert(
+          specifier.to_string(),
+          TranspileSourceFile {
+            data: module.source.clone(),
+            renamed_dependencies: None,
+          },
+        );
+      }
+    }
+
+    sources
+  }
+
+  /// Checks the modules in the graph of any that are lacking an emit, and if
+  /// so return `true` otherwise return `false`.  The argument `include_js` will
+  /// determine if JavaScript in the graph are considered in this.
+  pub fn needs_emit(&self, include_js: bool) -> bool {
+    self.modules.iter().fold(false, |acc, (_, m)| {
+      if !include_js && m.media_type == MediaType::JavaScript {
+        acc
+      } else if m.code.is_none() {
+        true
+      } else {
+        acc
+      }
+    })
+  }
+
+  /// Transpile (only transform) the graph, updating any emitted modules
+  /// with the specifier handler.  The result contains any performance stats
+  /// from the compiler and optionally any user provided configuration compiler
+  /// options that were ignored.
+  ///
+  /// # Arguments
+  ///
+  /// - `options` - A structure of options which impact how the code is
+  ///   transpiled.
+  /// - `maybe_shanpshot_data` - If provided, it is expected that the data is
+  ///   a snapshot of the TypeScript compiler, which will in turn be used to
+  ///   perform the transpilation.  If none, then the transpilation will be
+  ///   performed by swc.
+  ///
+  pub fn transpile(
+    mut self,
+    options: TranspileOptions,
+    maybe_snapshot_data: Option<Box<[u8]>>,
+  ) -> Result<(CompilerStats, Option<IgnoredCompilerOptions>)> {
+    let cache_type = CacheType::Cli;
+    if let Some(snapshot_data) = maybe_snapshot_data {
+      let startup_data = StartupData::Snapshot(Snapshot::Boxed(snapshot_data));
+      let mut compiler = CompilerIsolate::new(startup_data);
+      let sources = self.get_sources(false, &cache_type);
+
+      let emit = compiler.transpile(InternalTranspileOptions {
+        bundle: false,
+        sources,
+        transpile_options: options,
+      })?;
+      self.update(emit.written_files, &cache_type, true)?;
+      self.flush(&cache_type)?;
+
+      Ok((emit.stats, emit.maybe_ignored_options))
+    } else {
+      let mut compiler_options = json!({
+        "checkJs": false,
+        "emitDecoratorMetadata": false,
+        "jsx": "react",
+        "jsxFactory": "React.createElement",
+        "jsxFragmentFactory": "React.Fragment",
+      });
+
+      let maybe_ignored_options =
+        if let Some(config_text) = options.maybe_config {
+          let (user_config, ignored_options) = parse_config(config_text)?;
+          json_merge(&mut compiler_options, &user_config);
+          ignored_options
+        } else {
+          None
+        };
+
+      let compiler_options: TranspileTsOptions =
+        serde_json::from_value(compiler_options)?;
+      let check_js = compiler_options.check_js;
+      let transform_jsx = compiler_options.jsx == "react";
+      let emit_options = EmitTranspileOptions {
+        emit_metadata: compiler_options.emit_decorator_metadata,
+        inline_source_map: true,
+        jsx_factory: compiler_options.jsx_factory,
+        jsx_fragment_factory: compiler_options.jsx_fragment_factory,
+        transform_jsx,
+      };
+
+      for (_, module) in self.modules.iter_mut() {
+        // skip modules that already have a valid emit
+        if module.code.is_some() {
+          continue;
+        }
+        // if we don't have check_js enabled, we won't touch non TypeScript
+        // modules
+        if !(check_js
+          || module.media_type == MediaType::TSX
+          || module.media_type == MediaType::TypeScript)
+        {
+          continue;
+        }
+        // if the module looks like it is a dts module, we should skip it as well
+        if module.specifier.as_url().path().ends_with(".d.ts") {
+          continue;
+        }
+        if module.maybe_parsed_module.is_none() {
+          module.parse()?;
+        }
+        let parsed_module = module.maybe_parsed_module.clone().unwrap();
+        let (code, maybe_map) = parsed_module.transpile(&emit_options)?;
+        module.code = Some(code);
+        module.map = maybe_map;
+        module.is_dirty = true;
+      }
+      self.flush(&cache_type)?;
+
+      // TODO @kitsonk - provide some useful stats
+
+      Ok((CompilerStats { items: vec![] }, maybe_ignored_options))
+    }
+  }
+
+  /// Given a set of emitted files, update the modules that are part of the
+  /// graph, marking updated modules as _dirty_ so they will be updated when
+  /// flushed.
+  fn update(
+    &mut self,
+    files: Vec<EmittedFile>,
+    cache_type: &CacheType,
+    cache_js: bool,
+  ) -> Result<()> {
+    for file in files.iter() {
+      if let Some(module_name) = file.maybe_module_name.as_ref() {
+        let specifier = ModuleSpecifier::resolve_url_or_path(module_name)?;
+        if let Some(module) = self.modules.get_mut(&specifier) {
+          if !cache_js && module.media_type == MediaType::JavaScript {
+            continue;
+          }
+          let is_map = file.url.ends_with(".map");
+          let data = file.data.clone();
+          match cache_type {
+            CacheType::Cli => {
+              if is_map {
+                module.map = Some(data);
+              } else {
+                module.code = Some(data);
+              }
+            }
+            CacheType::Bundle => {
+              if is_map {
+                module.bundle_map = Some(data);
+              } else {
+                module.bundle_code = Some(data);
+              }
+            }
+          };
+          module.is_dirty = true;
+        } else {
+          return Err(MissingSpecifier(specifier).into());
+        }
+      }
+    }
+
+    Ok(())
+  }
+}
+
+impl ModuleProvider for Graph {
+  fn get_source(&self, specifier: &ModuleSpecifier) -> Option<String> {
+    if let Some(module) = self.modules.get(specifier) {
+      Some(module.source.clone())
+    } else {
+      None
+    }
+  }
+
+  fn resolve(
+    &self,
+    specifier: &str,
+    referrer: &ModuleSpecifier,
+  ) -> Result<(ModuleSpecifier, MediaType)> {
+    if !self.modules.contains_key(referrer) {
+      return Err(MissingSpecifier(referrer.to_owned()).into());
+    }
+    let module = self.modules.get(referrer).unwrap();
+    if !module.dependencies.contains_key(specifier) {
+      return Err(
+        MissingDependency(referrer.to_owned(), specifier.to_owned()).into(),
+      );
+    }
+    let dependency = module.dependencies.get(specifier).unwrap();
+    // If there is a @deno-types pragma that impacts the dependency, then the
+    // maybe_type property will be set with that specifier, otherwise we use the
+    // specifier that point to the runtime code.
+    let resolved_specifier =
+      if let Some(type_specifier) = dependency.maybe_type.clone() {
+        type_specifier
+      } else if let Some(code_specifier) = dependency.maybe_code.clone() {
+        code_specifier
+      } else {
+        return Err(
+          MissingDependency(referrer.to_owned(), specifier.to_owned()).into(),
+        );
+      };
+    if !self.modules.contains_key(&resolved_specifier) {
+      return Err(
+        MissingDependency(referrer.to_owned(), resolved_specifier.to_string())
+          .into(),
+      );
+    }
+    let dep_module = self.modules.get(&resolved_specifier).unwrap();
+    // In the case that there is a X-TypeScript-Types or a triple-slash types,
+    // then the `maybe_types` specifier will be populated and we should use that
+    // instead.
+    let result = if let Some((_, types)) = dep_module.maybe_types.clone() {
+      if let Some(types_module) = self.modules.get(&types) {
+        (types, types_module.media_type)
+      } else {
+        return Err(
+          MissingDependency(referrer.to_owned(), types.to_string()).into(),
+        );
+      }
+    } else {
+      (resolved_specifier, dep_module.media_type)
+    };
+
+    Ok(result)
+  }
+}
+
+/// A structure for building a dependency graph of modules.
+pub struct GraphBuilder {
+  fetched: HashSet<ModuleSpecifier>,
+  graph: Graph,
+  maybe_import_map: Option<Rc<RefCell<ImportMap>>>,
+  pending: FuturesUnordered<FetchFuture>,
+}
+
+impl GraphBuilder {
+  pub fn new(
+    handler: Rc<RefCell<dyn SpecifierHandler>>,
+    maybe_import_map: Option<ImportMap>,
+  ) -> Self {
+    let internal_import_map = if let Some(import_map) = maybe_import_map {
+      Some(Rc::new(RefCell::new(import_map)))
+    } else {
+      None
+    };
+    GraphBuilder {
+      graph: Graph::new(handler),
+      fetched: HashSet::new(),
+      maybe_import_map: internal_import_map,
+      pending: FuturesUnordered::new(),
+    }
+  }
+
+  /// Request a module to be fetched from the handler and queue up its future
+  /// to be awaited to be resolved.
+  fn fetch(&mut self, specifier: &ModuleSpecifier) -> Result<()> {
+    if self.fetched.contains(&specifier) {
+      return Ok(());
+    }
+
+    self.fetched.insert(specifier.clone());
+    let future = self.graph.handler.borrow_mut().fetch(specifier);
+    self.pending.push(future);
+
+    Ok(())
+  }
+
+  /// Visit a module that has been fetched, hydrating the module, analyzing its
+  /// dependencies if required, fetching those dependencies, and inserting the
+  /// module into the graph.
+  fn visit(&mut self, specifier: &ModuleSpecifier) -> Result<()> {
+    let cached_module = self.graph.handler.borrow().get_cache(specifier)?;
+    let mut module =
+      Module::new(specifier.clone(), self.maybe_import_map.clone());
+    module.hydrate(cached_module);
+    if !module.is_parsed {
+      let has_types = module.maybe_types.is_some();
+      module.parse()?;
+      if self.maybe_import_map.is_none() {
+        let mut handler = self.graph.handler.borrow_mut();
+        handler.set_deps(
+          specifier,
+          CachedDependencies::from(&module.dependencies),
+        )?;
+        if !has_types {
+          if let Some((types, _)) = module.maybe_types.clone() {
+            handler.set_types(specifier, types)?;
+          }
+        }
+      }
+    }
+    for (_, dep) in module.dependencies.iter() {
+      if let Some(specifier) = dep.maybe_code.as_ref() {
+        self.fetch(specifier)?;
+      }
+      if let Some(specifier) = dep.maybe_type.as_ref() {
+        self.fetch(specifier)?;
+      }
+    }
+    if let Some((_, specifier)) = module.maybe_types.as_ref() {
+      self.fetch(specifier)?;
+    }
+    self.graph.modules.insert(specifier.clone(), module);
+
+    Ok(())
+  }
+
+  /// Insert a module into the graph based on a module specifier.  The module
+  /// and any dependencies will be fetched from the handler.  The module will
+  /// also be treated as a _root_ module in the graph.
+  pub async fn insert(&mut self, specifier: &ModuleSpecifier) -> Result<()> {
+    self.fetch(specifier)?;
+
+    loop {
+      let next_specifier = self.pending.next().await.unwrap()?;
+      self.visit(&next_specifier)?;
+      if self.pending.is_empty() {
+        break;
+      }
+    }
+
+    if !self.graph.roots.contains(specifier) {
+      let handler = self.graph.handler.borrow();
+      // any specifier that is inserted becomes a root specifier
+      self.graph.roots.push(specifier.clone());
+      // if there is currently not any build info, check the specifier handler
+      // to see if there is any and populate it
+      if self.graph.build_info.is_empty() {
+        if let Some(build_info) =
+          handler.get_build_info(specifier, &CacheType::Cli)?
+        {
+          self.graph.build_info.insert(CacheType::Cli, build_info);
+        }
+        if let Some(build_info) =
+          handler.get_build_info(specifier, &CacheType::Bundle)?
+        {
+          self.graph.build_info.insert(CacheType::Bundle, build_info);
+        }
+      }
+    }
+
+    Ok(())
+  }
+
+  /// Move out the graph from the builder to be utilized further.
+  pub fn get_graph(self) -> Graph {
+    self.graph
+  }
+}
+
+#[cfg(test)]
+pub mod tests {
+  use super::*;
+
+  use crate::tests::MockSpecifierHandler;
+  use std::env;
+  use std::path::PathBuf;
+
+  #[tokio::test]
+  async fn test_graph_builder() {
+    let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let fixtures = c.join("fixtures");
+    let handler = Rc::new(RefCell::new(MockSpecifierHandler {
+      fixtures,
+      ..MockSpecifierHandler::default()
+    }));
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/test/mod.ts")
+        .expect("could not resolve module");
+    let mut builder = GraphBuilder::new(handler, None);
+    builder
+      .insert(&specifier)
+      .await
+      .expect("module not inserted");
+    let graph = builder.get_graph();
+    let actual = graph
+      .resolve("./a.ts", &specifier)
+      .expect("module to resolve");
+    let expected = (
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/test/a.ts")
+        .expect("unable to resolve"),
+      MediaType::TypeScript,
+    );
+    assert_eq!(actual, expected);
+  }
+
+  #[tokio::test]
+  async fn test_graph_builder_types() {
+    let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let fixtures = c.join("fixtures");
+    let handler = Rc::new(RefCell::new(MockSpecifierHandler {
+      fixtures,
+      ..MockSpecifierHandler::default()
+    }));
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("file:///tests/mod.ts")
+        .expect("could not resolve module");
+    let mut builder = GraphBuilder::new(handler, None);
+    builder
+      .insert(&specifier)
+      .await
+      .expect("module not inserted");
+    let graph = builder.get_graph();
+    let actual = graph
+      .resolve("./type_reference.js", &specifier)
+      .expect("module to resolve");
+    let expected = (
+      ModuleSpecifier::resolve_url_or_path("file:///tests/type_reference.d.ts")
+        .expect("unable to resolve"),
+      MediaType::TypeScript,
+    );
+    assert_eq!(actual, expected);
+  }
+
+  #[tokio::test]
+  async fn test_graph_builder_deno_types() {
+    let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let fixtures = c.join("fixtures");
+    let handler = Rc::new(RefCell::new(MockSpecifierHandler {
+      fixtures,
+      ..MockSpecifierHandler::default()
+    }));
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("file:///tests/deno_types.ts")
+        .expect("could not resolve module");
+    let mut builder = GraphBuilder::new(handler, None);
+    builder
+      .insert(&specifier)
+      .await
+      .expect("module not inserted");
+    let graph = builder.get_graph();
+    let actual = graph
+      .resolve("https://deno.land/x/jquery.js", &specifier)
+      .expect("module to resolve");
+    let expected = (
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/jquery.d.ts")
+        .expect("unable to resolve"),
+      MediaType::TypeScript,
+    );
+    assert_eq!(actual, expected);
+  }
+
+  #[tokio::test]
+  async fn test_graph_builder_import_map() {
+    let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let fixtures = c.join("fixtures");
+    let handler = Rc::new(RefCell::new(MockSpecifierHandler {
+      fixtures,
+      ..MockSpecifierHandler::default()
+    }));
+    let import_map = ImportMap::from_json(
+      "https://deno.land/x/import_map.ts",
+      r#"{
+      "imports": {
+        "jquery": "./jquery.js",
+        "lodash": "https://unpkg.com/lodash/index.js"
+      }
+    }"#,
+    )
+    .expect("could not load import map");
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/import_map.ts")
+        .expect("could not resolve module");
+    let mut builder = GraphBuilder::new(handler, Some(import_map));
+    builder
+      .insert(&specifier)
+      .await
+      .expect("module not inserted");
+    let graph = builder.get_graph();
+    let actual_jquery = graph
+      .resolve("jquery", &specifier)
+      .expect("module to resolve");
+    let expected_jquery = (
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/jquery.js")
+        .expect("unable to resolve"),
+      MediaType::JavaScript,
+    );
+    assert_eq!(actual_jquery, expected_jquery);
+    let actual_lodash = graph
+      .resolve("lodash", &specifier)
+      .expect("module to resolve");
+    let expected_lodash = (
+      ModuleSpecifier::resolve_url_or_path("https://unpkg.com/lodash/index.js")
+        .expect("unable to resolve"),
+      MediaType::JavaScript,
+    );
+    assert_eq!(actual_lodash, expected_lodash);
+  }
+}

--- a/compiler/msg.rs
+++ b/compiler/msg.rs
@@ -1,0 +1,493 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+use deno_core::ModuleResolutionError;
+use deno_core::ModuleSpecifier;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct EmittedFile {
+  pub data: String,
+  pub maybe_module_name: Option<String>,
+  pub url: String,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum MediaType {
+  JavaScript,
+  JSX,
+  TypeScript,
+  TSX,
+  Json,
+  Wasm,
+  BuildInfo,
+  Unknown,
+}
+
+impl MediaType {
+  /// Convert a MediaType to a `ts.Extension`.
+  ///
+  /// *NOTE* This is defined in TypeScript as a string based enum.  Changes to
+  /// that enum in TypeScript should be reflected here.
+  pub fn to_ts_extension(&self, specifier: &ModuleSpecifier) -> &str {
+    match self {
+      MediaType::JavaScript => ".js",
+      MediaType::JSX => ".jsx",
+      MediaType::TypeScript => {
+        let url = specifier.as_url();
+        let path = url.path();
+        if path.ends_with(".d.ts") {
+          ".d.ts"
+        } else {
+          ".ts"
+        }
+      }
+      MediaType::TSX => ".tsx",
+      MediaType::Json => ".json",
+      // TypeScript doesn't have an "unknown", so we will treat WASM as JS for
+      // mapping purposes, though in reality, it is unlikely to ever be passed
+      // to the compiler.
+      MediaType::Wasm => ".js",
+      MediaType::BuildInfo => ".tsbuildinfo",
+      // TypeScript doesn't have an "unknown", so we will treat WASM as JS for
+      // mapping purposes, though in reality, it is unlikely to ever be passed
+      // to the compiler.
+      MediaType::Unknown => ".js",
+    }
+  }
+}
+
+fn common_path(
+  a: &ModuleSpecifier,
+  b: &ModuleSpecifier,
+) -> Option<ModuleSpecifier> {
+  let mut result = a.as_url().clone();
+  result.set_path("");
+  let a = a.as_url();
+  let b = b.as_url();
+  if a.scheme() == b.scheme() {
+    let a = a.path_segments();
+    let b = b.path_segments();
+    if let (Some(mut a), Some(mut b)) = (a, b) {
+      let mut found = false;
+      loop {
+        let a_seg = a.next();
+        let b_seg = b.next();
+        if a_seg.is_some() && a_seg == b_seg {
+          let input = format!("{}/", a_seg.unwrap());
+          result = result.join(&input).unwrap();
+          found = true;
+        } else {
+          break;
+        }
+      }
+
+      if found {
+        Some(result.into())
+      } else {
+        None
+      }
+    } else {
+      None
+    }
+  } else {
+    None
+  }
+}
+
+pub fn common_path_reduce(
+  specifiers: Vec<&ModuleSpecifier>,
+) -> Option<ModuleSpecifier> {
+  if specifiers.is_empty() {
+    return None;
+  }
+  if specifiers.len() == 1 {
+    let spec = specifiers.first().cloned().cloned().unwrap();
+    let mut url = spec.as_url().to_owned();
+    url.path_segments_mut().unwrap().pop().push("");
+
+    return Some(ModuleSpecifier::from(url));
+  }
+  let init = specifiers.first().cloned().cloned();
+
+  specifiers.iter().fold(init, |a, b| {
+    if let Some(a) = a.as_ref() {
+      common_path(a, b)
+    } else {
+      a
+    }
+  })
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CompilerStats {
+  pub items: Vec<(String, u64)>,
+}
+
+impl<'de> Deserialize<'de> for CompilerStats {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    let items: Vec<(String, u64)> = Deserialize::deserialize(deserializer)?;
+    Ok(CompilerStats { items })
+  }
+}
+
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranspileSourceFile {
+  pub data: String,
+  pub renamed_dependencies: Option<HashMap<String, String>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IgnoredCompilerOptions(pub Vec<String>);
+
+impl fmt::Display for IgnoredCompilerOptions {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{}", self.0.join(", "))?;
+
+    Ok(())
+  }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum DiagnosticCategory {
+  Warning,
+  Error,
+  Suggestion,
+  Message,
+}
+
+impl fmt::Display for DiagnosticCategory {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(
+      f,
+      "{}",
+      match self {
+        DiagnosticCategory::Warning => "WARN ",
+        DiagnosticCategory::Error => "ERROR ",
+        DiagnosticCategory::Suggestion => "",
+        DiagnosticCategory::Message => "",
+      }
+    )
+  }
+}
+
+impl<'de> Deserialize<'de> for DiagnosticCategory {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    let s: i64 = Deserialize::deserialize(deserializer)?;
+    Ok(DiagnosticCategory::from(s))
+  }
+}
+
+impl From<i64> for DiagnosticCategory {
+  fn from(value: i64) -> Self {
+    match value {
+      0 => DiagnosticCategory::Warning,
+      1 => DiagnosticCategory::Error,
+      2 => DiagnosticCategory::Suggestion,
+      3 => DiagnosticCategory::Message,
+      _ => panic!("Unknown value: {}", value),
+    }
+  }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticMessageChain {
+  message_text: String,
+  category: DiagnosticCategory,
+  code: i64,
+  next: Box<Option<DiagnosticMessageChain>>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Diagnostic {
+  pub category: DiagnosticCategory,
+  pub code: u64,
+  pub start: Option<u64>,
+  pub length: Option<u64>,
+  pub message_text: Option<String>,
+  pub message_chain: Option<DiagnosticMessageChain>,
+  pub source: Option<String>,
+  pub source_file: Option<String>,
+  pub related_information: Box<Option<Diagnostic>>,
+}
+
+// impl Diagnostic {
+//   fn format_category_and_code(&self) -> String {
+//     let category = match self.category {
+//       DiagnosticCategory::Error => "ERROR",
+//       DiagnosticCategory::Warning => "WARN",
+//       _ => "",
+//     };
+//   }
+
+//   fn format_stack(&self) -> String {
+//     let is_error = self.category == DiagnosticCategory::Error;
+//     let mut s = String::new();
+//     let message_line = format!("{}: {}", self.format_category_and_code())
+//   }
+// }
+
+impl fmt::Display for Diagnostic {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(
+      f,
+      "{}[TS{}] {}",
+      self.category,
+      self.code,
+      self
+        .message_text
+        .clone()
+        .unwrap_or_else(|| "[message chain]".to_string())
+    )
+    // write!(
+    //   f,
+    //   "{}",
+    //   format_stack(
+    //     match self.category {
+    //       DiagnosticCategory::Error => true,
+    //       _ => false,
+    //     },
+    //     &format!(
+    //       "{}: {}",
+    //       format_category_and_code(&self.category, self.code),
+    //       format_message(&self.message_chain, &self.message, 0)
+    //     ),
+    //     self.source_line.as_deref(),
+    //     self.start_column,
+    //     self.end_column,
+    //     // Formatter expects 1-based line and column numbers, but ours are 0-based.
+    //     &[format_maybe_frame(
+    //       self.script_resource_name.as_deref(),
+    //       self.line_number.map(|n| n + 1),
+    //       self.start_column.map(|n| n + 1)
+    //     )],
+    //     0
+    //   )
+    // )?;
+    // write!(
+    //   f,
+    //   "{}",
+    //   format_maybe_related_information(&self.related_information),
+    // )
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct Diagnostics(pub Vec<Diagnostic>);
+
+impl<'de> Deserialize<'de> for Diagnostics {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    let items: Vec<Diagnostic> = Deserialize::deserialize(deserializer)?;
+    Ok(Diagnostics(items))
+  }
+}
+
+impl fmt::Display for Diagnostics {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    let mut i = 0;
+    for item in &self.0 {
+      if i > 0 {
+        write!(f, "\n\n")?;
+      }
+      write!(f, "{}", item.to_string())?;
+      i += 1;
+    }
+
+    if i > 1 {
+      write!(f, "\n\nFound {} errors.", i)?;
+    }
+
+    Ok(())
+  }
+}
+
+impl Error for Diagnostics {}
+
+/// Convert a module specifier into a string in the format that can be safely
+/// used within the TypeScript compiler. When module specifiers exist in
+/// different schemes, TypeScript fails to find a common root and then will not
+/// output files to their virtual location, and will not attempt to write any
+/// files that are named the same on emit (e.g. JavaScript files).
+pub fn as_ts_filename(
+  specifier: &ModuleSpecifier,
+  maybe_shared_path: &Option<String>,
+) -> String {
+  match specifier.as_url().scheme() {
+    "http" => specifier.as_str().replace("http://", "/http/"),
+    "https" => specifier.as_str().replace("https://", "/https/"),
+    "file" => {
+      let specifier = specifier.as_str().replace("file:///", "/file/");
+      if let Some(shared_path) = maybe_shared_path {
+        specifier.replace(shared_path, "/file/")
+      } else {
+        specifier
+      }
+    }
+    _ => specifier.as_str().to_string(),
+  }
+}
+
+/// Take a converted string specifier used internally within the TypeScript
+/// compiler and covert it to a `ModuleSpecifier`.
+pub fn from_ts_filename(
+  file_name: &str,
+  maybe_shared_path: &Option<String>,
+) -> Result<ModuleSpecifier, ModuleResolutionError> {
+  if file_name == "cache:///.tsbuildinfo" {
+    ModuleSpecifier::resolve_url_or_path(file_name)
+  } else {
+    let file_name = if file_name.starts_with("cache:///") {
+      file_name.replace("cache:///", "/")
+    } else {
+      file_name.to_string()
+    };
+    let specifier = if file_name.starts_with("/http/") {
+      file_name.replace("/http/", "http://")
+    } else if file_name.starts_with("/https/") {
+      file_name.replace("/https/", "https://")
+    } else if file_name.starts_with("/file/") {
+      if let Some(shared_path) = maybe_shared_path {
+        file_name
+          .replace("/file/", shared_path)
+          .replace("/file/", "file:///")
+      } else {
+        file_name.replace("/file/", "file:///")
+      }
+    } else {
+      file_name
+    };
+
+    ModuleSpecifier::resolve_url_or_path(&specifier)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serde_json::json;
+
+  #[test]
+  fn test_de_diagnostics() {
+    let value = json!([
+      {
+        "messageText": "test message",
+        "category": 1,
+        "code": 1234,
+      },
+      {
+        "messageText": "test message 2",
+        "category": 0,
+        "code": 5678,
+      }, {
+        "messageChain": {
+          "messageText": "chain 1",
+          "category": 1,
+          "code": 9999,
+          "next": {
+            "messageText": "chain 2",
+            "category": 1,
+            "code": 8888,
+          }
+        },
+        "category": 1,
+        "code": 9999,
+      }
+    ]);
+    let diagnostics: Diagnostics =
+      serde_json::from_value(value).expect("cannot deserialize");
+    assert_eq!(diagnostics.0.len(), 3);
+    assert!(diagnostics.0[2].message_text.is_none());
+    assert!(diagnostics.0[2].message_chain.is_some());
+  }
+
+  #[test]
+  fn test_from_ts_filename() {
+    let specifier =
+      ModuleSpecifier::resolve_url_or_path("/foo/bar/baz/qat.ts").unwrap();
+    let actual = as_ts_filename(&specifier, &None);
+    assert_eq!(actual, "/file/foo/bar/baz/qat.ts");
+  }
+
+  #[test]
+  fn test_as_ts_filename() {
+    let actual = from_ts_filename("/file/foo/bar/baz/qat.ts", &None);
+    assert_eq!(
+      actual,
+      Ok(
+        ModuleSpecifier::resolve_url_or_path("file:///foo/bar/baz/qat.ts")
+          .unwrap()
+      )
+    );
+  }
+
+  #[test]
+  fn test_common_path() {
+    let a =
+      ModuleSpecifier::resolve_url_or_path("/foo/bar/baz/qat.ts").unwrap();
+    let b =
+      ModuleSpecifier::resolve_url_or_path("/foo/bar/qat/baz.ts").unwrap();
+    let actual = common_path(&a, &b);
+    assert_eq!(
+      actual,
+      Some(ModuleSpecifier::resolve_url_or_path("file:///foo/bar/").unwrap())
+    );
+  }
+
+  #[test]
+  fn test_common_path_none() {
+    let a =
+      ModuleSpecifier::resolve_url_or_path("/foo/bar/baz/qat.ts").unwrap();
+    let b =
+      ModuleSpecifier::resolve_url_or_path("/bar/baz/qat/foo.ts").unwrap();
+    let actual = common_path(&a, &b);
+    assert_eq!(actual, None);
+  }
+
+  #[test]
+  fn test_common_path_reduce() {
+    let fixtures = vec![
+      ModuleSpecifier::resolve_url_or_path("/foo/bar/baz/qat.ts").unwrap(),
+      ModuleSpecifier::resolve_url_or_path("/foo/bar/baz/qux.ts").unwrap(),
+      ModuleSpecifier::resolve_url_or_path("/foo/bar/qat/qux.ts").unwrap(),
+    ];
+
+    let actual = common_path_reduce(fixtures.iter().collect());
+    assert_eq!(
+      actual,
+      Some(ModuleSpecifier::resolve_url_or_path("file:///foo/bar/").unwrap())
+    );
+  }
+
+  #[test]
+  fn test_common_path_reduce_single() {
+    let fixtures = vec![ModuleSpecifier::resolve_url_or_path(
+      "/foo/bar/baz/qat.ts",
+    )
+    .unwrap()];
+
+    let actual = common_path_reduce(fixtures.iter().collect());
+    assert_eq!(
+      actual,
+      Some(
+        ModuleSpecifier::resolve_url_or_path("file:///foo/bar/baz/").unwrap()
+      )
+    );
+  }
+}

--- a/compiler/ops.rs
+++ b/compiler/ops.rs
@@ -1,0 +1,290 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+use crate::compiler::CompilerState;
+use crate::compiler::EmitResult;
+use crate::msg::as_ts_filename;
+use crate::msg::from_ts_filename;
+use crate::msg::EmittedFile;
+
+use deno_core::CoreIsolateState;
+use deno_core::ErrBox;
+use deno_core::ModuleSpecifier;
+use deno_core::Op;
+use deno_core::ZeroCopyBuf;
+use ring::digest;
+use serde::Deserialize;
+use serde_json::json;
+use serde_json::Value;
+use std::result;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+type OpResult = result::Result<Value, ErrBox>;
+type Dispatcher = fn(state: &mut CompilerState, args: Value) -> OpResult;
+
+pub fn compiler_op<D>(
+  state: Arc<Mutex<CompilerState>>,
+  dispatcher: D,
+) -> impl Fn(&mut CoreIsolateState, &mut [ZeroCopyBuf]) -> Op
+where
+  D: Fn(&mut CompilerState, &[u8]) -> Op,
+{
+  move |_state: &mut CoreIsolateState,
+        zero_copy_bufs: &mut [ZeroCopyBuf]|
+        -> Op {
+    assert_eq!(zero_copy_bufs.len(), 1, "Invalid number of arguments");
+    let mut s = state.lock().unwrap();
+    dispatcher(&mut s, &zero_copy_bufs[0])
+  }
+}
+
+// Fn(&mut CoreIsolateState, &mut [ZeroCopyBuf]) -> Op + 'static
+
+pub fn json_op(d: Dispatcher) -> impl Fn(&mut CompilerState, &[u8]) -> Op {
+  move |state: &mut CompilerState, control: &[u8]| {
+    let result = serde_json::from_slice(control)
+      .map_err(ErrBox::from)
+      .and_then(move |args| d(state, args));
+
+    let response = match result {
+      Ok(v) => json!({ "ok": v }),
+      Err(err) => json!({ "err": err.to_string() }),
+    };
+
+    let x = serde_json::to_string(&response).unwrap();
+    let vec = x.into_bytes();
+    Op::Sync(vec.into_boxed_slice())
+  }
+}
+
+/// Generate a SHA256 hash of the data passed and return it as a `String`
+fn gen_hash(v: &[impl AsRef<[u8]>]) -> String {
+  let mut ctx = digest::Context::new(&digest::SHA256);
+  for src in v {
+    ctx.update(src.as_ref());
+  }
+  let digest = ctx.finish();
+  let out: Vec<String> = digest
+    .as_ref()
+    .iter()
+    .map(|byte| format!("{:02x}", byte))
+    .collect();
+  out.join("")
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateHash {
+  data: String,
+}
+
+pub fn op_create_hash(s: &mut CompilerState, v: Value) -> OpResult {
+  let v: CreateHash = serde_json::from_value(v)?;
+  let mut hash_data = vec![v.data.as_bytes().to_owned()];
+  hash_data.extend_from_slice(&s.hash_data);
+  Ok(json!({ "hash": gen_hash(&hash_data) }))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LoadModule {
+  specifier: String,
+}
+
+pub fn op_load_module(s: &mut CompilerState, v: Value) -> OpResult {
+  let v: LoadModule = serde_json::from_value(v)?;
+  let module_specifier = from_ts_filename(&v.specifier, &s.maybe_shared_path)?;
+  let data = if let Some(provider) = s.maybe_provider.as_ref() {
+    if let Some(module) = provider.borrow().get_source(&module_specifier) {
+      module
+    } else {
+      return Err(
+        std::io::Error::new(
+          std::io::ErrorKind::NotFound,
+          format!("Resource not found. Specifier: {}", module_specifier),
+        )
+        .into(),
+      );
+    }
+  } else if let Some(source) = s.sources.get(&module_specifier.to_string()) {
+    source.clone()
+  } else {
+    let module_url = module_specifier.as_url();
+    match module_url.scheme() {
+      "asset" => {
+        let file_name = v.specifier.replace("asset:///", "");
+        let path = s.maybe_assets_path.clone().unwrap().join(file_name);
+        let data = std::fs::read_to_string(path);
+        data.unwrap()
+      }
+      _ => {
+        return Err(
+          std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Resource not found. Specifier: {}", module_specifier),
+          )
+          .into(),
+        );
+      }
+    }
+  };
+  let mut hash_data = vec![data.as_bytes().to_owned()];
+  hash_data.extend_from_slice(&s.hash_data);
+  let hash = gen_hash(&hash_data);
+  Ok(json!({ "data": data, "hash": hash }))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReadFile {
+  file_name: String,
+}
+
+pub fn op_read_file(s: &mut CompilerState, v: Value) -> OpResult {
+  let v: ReadFile = serde_json::from_value(v)?;
+  let file_specifier = ModuleSpecifier::resolve_url_or_path(&v.file_name)?;
+  let data = match file_specifier.as_str() {
+    "cache:///.tsbuildinfo" => s.maybe_build_info.clone(),
+    _ => None,
+  };
+  Ok(json!({
+    "data": data,
+  }))
+}
+
+/// A mapping function from a specifier to a ts.Extension that is used only for
+/// specifiers where we don't have a media type provided (like internal sources)
+fn get_ts_extension(specifier: &str) -> &str {
+  if specifier.ends_with(".d.ts") {
+    ".d.ts"
+  } else if specifier.ends_with(".ts") {
+    ".ts"
+  } else if specifier.ends_with(".tsx") {
+    ".tsx"
+  } else if specifier.ends_with(".jsx") {
+    ".jsx"
+  } else if specifier.ends_with(".json") {
+    ".json"
+  } else if specifier.ends_with(".tsbuildinfo") {
+    ".tsbuildinfo"
+  } else {
+    ".js"
+  }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResolveSpecifiers {
+  specifiers: Vec<String>,
+  base: String,
+}
+
+pub fn op_resolve_specifiers(s: &mut CompilerState, v: Value) -> OpResult {
+  let v: ResolveSpecifiers = serde_json::from_value(v).unwrap();
+  let mut resolved: Vec<(String, String)> = Vec::new();
+  let base = from_ts_filename(&v.base, &s.maybe_shared_path)?;
+  for specifier in v.specifiers {
+    if specifier.starts_with("asset:///") {
+      resolved
+        .push((specifier.clone(), get_ts_extension(&specifier).to_string()));
+    } else if let Some(provider) = s.maybe_provider.as_ref() {
+      let (ms, media_type) = provider.borrow().resolve(&specifier, &base)?;
+      resolved.push((
+        as_ts_filename(&ms, &s.maybe_shared_path),
+        media_type.to_ts_extension(&ms).to_string(),
+      ));
+    } else {
+      unreachable!();
+    }
+  }
+  Ok(json!(resolved))
+}
+
+pub fn op_set_emit_result(s: &mut CompilerState, v: Value) -> OpResult {
+  let v: EmitResult = serde_json::from_value(v)?;
+  s.emit_result = Some(v);
+  Ok(json!(true))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Version {
+  version: String,
+}
+
+pub fn op_set_version(s: &mut CompilerState, v: Value) -> OpResult {
+  let v: Version = serde_json::from_value(v)?;
+  s.version = v.version;
+  Ok(json!(true))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WriteFile {
+  file_name: String,
+  data: String,
+  maybe_module_name: Option<String>,
+}
+
+pub fn op_write_file(s: &mut CompilerState, v: Value) -> OpResult {
+  let v: WriteFile = serde_json::from_value(v)?;
+  let module_specifier = from_ts_filename(&v.file_name, &s.maybe_shared_path)?;
+  match module_specifier.as_str() {
+    "cache:///.tsbuildinfo" => s.maybe_build_info = Some(v.data),
+    _ => {
+      s.written_files.push(EmittedFile {
+        data: v.data,
+        maybe_module_name: if let Some(module_name) = v.maybe_module_name {
+          Some(
+            from_ts_filename(&module_name, &s.maybe_shared_path)?
+              .as_str()
+              .to_string(),
+          )
+        } else {
+          None
+        },
+        url: module_specifier.as_str().to_string(),
+      });
+    }
+  }
+
+  Ok(json!(true))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn setup() -> CompilerState {
+    CompilerState {
+      ..CompilerState::default()
+    }
+  }
+
+  #[test]
+  fn test_gen_hash() {
+    let actual = gen_hash(&[b"hello world"]);
+    assert_eq!(
+      actual,
+      "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+    );
+  }
+
+  #[derive(Debug, Deserialize)]
+  #[serde(rename_all = "camelCase")]
+  struct HashResponse {
+    hash: String,
+  }
+
+  #[test]
+  fn test_op_create_hash() {
+    let mut state = setup();
+    let value = json!({ "data": "hello world" });
+    let response = op_create_hash(&mut state, value).unwrap();
+    let actual: HashResponse = serde_json::from_value(response).unwrap();
+    assert_eq!(
+      actual.hash,
+      "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+    );
+  }
+}

--- a/compiler/source_map_bundler.rs
+++ b/compiler/source_map_bundler.rs
@@ -1,0 +1,66 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+use crate::Result;
+
+use sourcemap::SourceMap;
+use sourcemap::SourceMapBuilder;
+
+pub struct SourceMapBundler {
+  builder: SourceMapBuilder,
+}
+
+impl SourceMapBundler {
+  pub fn new(file: Option<&str>) -> Self {
+    SourceMapBundler {
+      builder: SourceMapBuilder::new(file),
+    }
+  }
+
+  pub fn append(&mut self, sm: &SourceMap, line_offset: usize) {
+    for (idx, src) in sm.sources().enumerate() {
+      let src_id = self.builder.add_source(src);
+      self
+        .builder
+        .set_source_contents(src_id, sm.get_source_contents(idx as u32));
+    }
+    for token in sm.tokens() {
+      self.builder.add(
+        token.get_dst_line() + line_offset as u32,
+        token.get_dst_col(),
+        token.get_src_line(),
+        token.get_src_col(),
+        token.get_source(),
+        token.get_name(),
+      );
+    }
+  }
+
+  pub fn append_from_str(&mut self, s: &str, line_offset: usize) -> Result<()> {
+    let sm = SourceMap::from_reader(s.as_bytes())?;
+    self.append(&sm, line_offset);
+    Ok(())
+  }
+
+  pub fn into_sourcemap(self) -> SourceMap {
+    self.builder.into_sourcemap()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_source_map_append_from_str() {
+    let mut smb = SourceMapBundler::new(None);
+    let input = r#"{
+      "version": 3,
+      "sources": ["coolstuff.js"],
+      "names": ["x", "alert"],
+      "mappings": "AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM"
+    }"#;
+    smb.append_from_str(input, 10).unwrap();
+    let sm = smb.into_sourcemap();
+    assert_eq!(sm.sources().count(), 1);
+  }
+}

--- a/compiler/system_loader.js
+++ b/compiler/system_loader.js
@@ -1,0 +1,99 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// @ts-nocheck
+/* eslint-disable */
+
+// This is a specialised implementation of a System module loader.
+
+"use strict";
+
+let System, __instantiate;
+(() => {
+  const r = new Map();
+
+  System = {
+    register(id, d, f) {
+      r.set(id, { d, f, exp: {} });
+    },
+  };
+  async function dI(mid, src) {
+    let id = mid.replace(/\.\w+$/i, "");
+    if (id.includes("./")) {
+      const [o, ...ia] = id.split("/").reverse(),
+        [, ...sa] = src.split("/").reverse(),
+        oa = [o];
+      let s = 0,
+        i;
+      while ((i = ia.shift())) {
+        if (i === "..") s++;
+        else if (i === ".") break;
+        else oa.push(i);
+      }
+      if (s < sa.length) oa.push(...sa.slice(s));
+      id = oa.reverse().join("/");
+    }
+    return r.has(id) ? gExpA(id) : import(mid);
+  }
+
+  function gC(id, main) {
+    return {
+      id,
+      import: (m) => dI(m, id),
+      meta: { url: id, main },
+    };
+  }
+
+  function gE(exp) {
+    return (id, v) => {
+      v = typeof id === "string" ? { [id]: v } : id;
+      for (const [id, value] of Object.entries(v)) {
+        Object.defineProperty(exp, id, {
+          value,
+          writable: true,
+          enumerable: true,
+        });
+      }
+    };
+  }
+
+  function rF(main) {
+    for (const [id, m] of r.entries()) {
+      const { f, exp } = m;
+      const { execute: e, setters: s } = f(gE(exp), gC(id, id === main));
+      delete m.f;
+      m.e = e;
+      m.s = s;
+    }
+  }
+
+  async function gExpA(id) {
+    if (!r.has(id)) return;
+    const m = r.get(id);
+    if (m.s) {
+      const { d, e, s } = m;
+      delete m.s;
+      delete m.e;
+      for (let i = 0; i < s.length; i++) s[i](await gExpA(d[i]));
+      const r = e();
+      if (r) await r;
+    }
+    return m.exp;
+  }
+
+  function gExp(id) {
+    if (!r.has(id)) return;
+    const m = r.get(id);
+    if (m.s) {
+      const { d, e, s } = m;
+      delete m.s;
+      delete m.e;
+      for (let i = 0; i < s.length; i++) s[i](gExp(d[i]));
+      e();
+    }
+    return m.exp;
+  }
+  __instantiate = (m, a) => {
+    System = __instantiate = undefined;
+    rF(m);
+    return a ? gExpA(m) : gExp(m);
+  };
+})();

--- a/compiler/system_loader_es5.js
+++ b/compiler/system_loader_es5.js
@@ -1,0 +1,265 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// @ts-nocheck
+/* eslint-disable */
+
+// This is a specialised implementation of a System module loader.
+
+"use strict";
+
+var System, __instantiate;
+(function () {
+  var __awaiter = (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function (resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done
+            ? resolve(result.value)
+            : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+  var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = {
+        label: 0,
+        sent: function () {
+          if (t[0] & 1) throw t[1];
+          return t[1];
+        },
+        trys: [],
+        ops: [],
+      },
+      f,
+      y,
+      t,
+      g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) },
+      typeof Symbol === "function" && (g[Symbol.iterator] = function () {
+        return this;
+      }),
+      g;
+    function verb(n) {
+      return function (v) {
+        return step([n, v]);
+      };
+    }
+    function step(op) {
+      if (f) throw new TypeError("Generator is already executing.");
+      while (_) {
+        try {
+          if (
+            f = 1,
+              y && (t = op[0] & 2
+                ? y["return"]
+                : op[0]
+                ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                : y.next) && !(t = t.call(y, op[1])).done
+          ) {
+            return t;
+          }
+          if (y = 0, t) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+            case 0:
+            case 1:
+              t = op;
+              break;
+            case 4:
+              _.label++;
+              return { value: op[1], done: false };
+            case 5:
+              _.label++;
+              y = op[1];
+              op = [0];
+              continue;
+            case 7:
+              op = _.ops.pop();
+              _.trys.pop();
+              continue;
+            default:
+              if (
+                !(t = _.trys, t = t.length > 0 && t[t.length - 1]) &&
+                (op[0] === 6 || op[0] === 2)
+              ) {
+                _ = 0;
+                continue;
+              }
+              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                _.label = op[1];
+                break;
+              }
+              if (op[0] === 6 && _.label < t[1]) {
+                _.label = t[1];
+                t = op;
+                break;
+              }
+              if (t && _.label < t[2]) {
+                _.label = t[2];
+                _.ops.push(op);
+                break;
+              }
+              if (t[2]) _.ops.pop();
+              _.trys.pop();
+              continue;
+          }
+          op = body.call(thisArg, _);
+        } catch (e) {
+          op = [6, e];
+          y = 0;
+        } finally {
+          f = t = 0;
+        }
+      }
+      if (op[0] & 5) throw op[1];
+      return { value: op[0] ? op[1] : void 0, done: true };
+    }
+  };
+  var r = Object.create(null);
+  System = {
+    register: function (id, d, f) {
+      r[id] = { d: d, f: f, exp: {} };
+    },
+  };
+  function dI(mid, src) {
+    return __awaiter(this, void 0, void 0, function () {
+      var id, _a, o, ia, _b, sa, oa, s, i;
+      return __generator(this, function (_c) {
+        id = mid.replace(/\.\w+$/i, "");
+        if (id.indexOf("./") >= 0) {
+          _a = id.split("/").reverse(),
+            o = _a[0],
+            ia = _a.slice(1),
+            _b = src.split("/").reverse(),
+            sa = _b.slice(1),
+            oa = [o];
+          s = 0, i = void 0;
+          while ((i = ia.shift())) {
+            if (i === "..") {
+              s++;
+            } else if (i === ".") {
+              break;
+            } else {
+              oa.push(i);
+            }
+          }
+          if (s < sa.length) {
+            oa.push.apply(oa, sa.slice(s));
+          }
+          id = oa.reverse().join("/");
+        }
+        return [2, /*return*/ gExpA(id)];
+      });
+    });
+  }
+  function gC(id, main) {
+    return {
+      id: id,
+      import: function (m) {
+        return dI(m, id);
+      },
+      meta: { url: id, main: main },
+    };
+  }
+  function gE(exp) {
+    return function (id, v) {
+      var _a;
+      v = typeof id === "string" ? (_a = {}, _a[id] = v, _a) : id;
+      for (var id_1 in v) {
+        var value = v[id_1];
+        Object.defineProperty(exp, id_1, {
+          value: value,
+          writable: true,
+          enumerable: true,
+        });
+      }
+    };
+  }
+  function rF(main) {
+    for (var id in r) {
+      var m = r[id];
+      var f = m.f, exp = m.exp;
+      var _a = f(gE(exp), gC(id, id === main)), e = _a.execute, s = _a.setters;
+      delete m.f;
+      m.e = e;
+      m.s = s;
+    }
+  }
+  function gExpA(id) {
+    return __awaiter(this, void 0, void 0, function () {
+      var m, d, e, s, i, _a, _b, r_1;
+      return __generator(this, function (_c) {
+        switch (_c.label) {
+          case 0:
+            if (!(id in r)) {
+              return [2 /*return*/];
+            }
+            m = r[id];
+            if (!m.s) return [3, /*break*/ 6];
+            d = m.d, e = m.e, s = m.s;
+            delete m.s;
+            delete m.e;
+            i = 0;
+            _c.label = 1;
+          case 1:
+            if (!(i < s.length)) return [3, /*break*/ 4];
+            _b = (_a = s)[i];
+            return [4, /*yield*/ gExpA(d[i])];
+          case 2:
+            _b.apply(_a, [_c.sent()]);
+            _c.label = 3;
+          case 3:
+            i++;
+            return [3, /*break*/ 1];
+          case 4:
+            r_1 = e();
+            if (!r_1) return [3, /*break*/ 6];
+            return [4, /*yield*/ r_1];
+          case 5:
+            _c.sent();
+            _c.label = 6;
+          case 6:
+            return [2, /*return*/ m.exp];
+        }
+      });
+    });
+  }
+  function gExp(id) {
+    if (!(id in r)) {
+      return;
+    }
+    var m = r.get(id);
+    if (m.s) {
+      var d = m.d, e = m.e, s = m.s;
+      delete m.s;
+      delete m.e;
+      for (var i = 0; i < s.length; i++) {
+        s[i](gExp(d[i]));
+      }
+      e();
+    }
+    return m.exp;
+  }
+  __instantiate = function (m, a) {
+    System = __instantiate = undefined;
+    rF(m);
+    return a ? gExpA(m) : gExp(m);
+  };
+})();


### PR DESCRIPTION
This is a major refactor of the TypeScript compilation infrastructure.  Raising for early visibility, but it is still very much a work in progress.  It totally rewrites how the compilations are handled to abstract out the logic, which should make it easier to move parts and pieces in the future, at the same time leveraging more Rust infrastructure and signficantly "dumbing" down the interface to the TypeScript compiler.

Currently it is a seperate crate as that has been easier for me to work on it without having to deal with merge conflicts and other changes.

Currently I have the following working:

- Ability to create snapshots with custom libs (like `deno.ns`).
- Ability to compile a set of sources and specify any custom libs to type check against.
- Ability to transpile an arbitrary set of sources.

Things that I need to do:

- Introduce bundling, which the bundle creation will be done in Rust, using the TypeScript compiler just for type checking and transpilation.
- Finish off the display of the diagnostics.
- Look at moving the dependency graph logic in.
- Integrate into the CLI.

When finished this will:

Fixes #5606 
Fixes #5607
Fixes #6686 
