### PR TITLE
Use SWC to strip types for "--no-check" flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,12 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
-
-[[package]]
 name = "anymap"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f432b637e17203e6b2e985867fb204051546b88308aca7e811e7ec62f4b9d534"
+checksum = "fbdf386c931a0c09550f80ea3ac6c59e115d3e8c2cffb5e196d4cda1aeff690c"
 dependencies = [
  "dprint-plugin-typescript",
  "lazy_static",
@@ -529,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c1e5e9977e6b800a70a9a05734e44ec63da3987e8d4b6ece1907511894603b"
+checksum = "afab3ed9d8240f14f68e05ccf200dd6034a8bb55fcf0e945f775030d0fca78fa"
 dependencies = [
  "dprint-core",
  "serde",
@@ -2218,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e577708ae0d39827e2cb5fd0d62bbcf433c9cfc1fb0a21bf98f5ef635a63a"
+checksum = "9dcdd53f72ccc81568bcf789f9aeaa065588705ab46113e9f6ba4014f8829f5d"
 dependencies = [
  "enum_kind",
  "is-macro",
@@ -2233,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.28.3"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4788c9802262d13a53b677bb812354f15867bc851523f734d8015cb101ecf5c7"
+checksum = "8d48467780147af9075def6d7c75198af57e1b74ad28e8508850974be785f8cd"
 dependencies = [
  "bitflags",
  "num-bigint",
@@ -2261,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "813282d73d2e86942b5e259613276b36f4c69ed2d7139de37db18e04ccbc0602"
+checksum = "9226cca2e6d482ffe48be00b83c9745b9e574d6d5833e1e3735837a502784af9"
 dependencies = [
  "either",
  "enum_kind",
@@ -2296,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32621ba8874cc1a1fed27abe4b0c079d05f42fa19fe593f02c50a95e882759f9"
+checksum = "f37a55159354623098b9a54893d26c655109833df807d846c54e34103a349a4f"
 dependencies = [
  "Inflector",
  "arrayvec",
@@ -2326,11 +2320,10 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654cf8ddcf6d980f1d036e3246a2dbd56082712baa3d114f11e4922d82658091"
+checksum = "229c983a8e263edaf1b8ec5b79d92664d158303cc1fa4bff93690b6a2585e668"
 dependencies = [
- "anyhow",
  "once_cell",
  "scoped-tls 1.0.0",
  "swc_atoms",
@@ -2343,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c98c6b3b4e29f12d11b8eaf2663e5d3cd264cd7bd7b55aadc295eb727eda73"
+checksum = "9516e5e423776d9ee88628b0caef0bcdab1aacf3e33469b7fc4fdfb9aa7e1617"
 dependencies = [
  "num-bigint",
  "swc_atoms",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "dprint-core",
  "serde",
@@ -2229,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.28.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b1b654354df8ebdc35d4046436157da9f4858a9e6e3b3058576157dcf885ed"
+checksum = "4788c9802262d13a53b677bb812354f15867bc851523f734d8015cb101ecf5c7"
 dependencies = [
  "bitflags",
  "num-bigint",
@@ -2292,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884147b4f0f99522627c9590ba6657ae6b3c80cd0e3f32081bd094e01b353421"
+checksum = "32621ba8874cc1a1fed27abe4b0c079d05f42fa19fe593f02c50a95e882759f9"
 dependencies = [
  "Inflector",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+
+[[package]]
 name = "anymap"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +75,12 @@ name = "arc-swap"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "ast_node"
@@ -400,6 +412,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sourcemap",
+ "swc_ecma_codegen",
+ "swc_ecma_transforms",
  "sys-info",
  "tempfile",
  "termcolor",
@@ -438,8 +452,6 @@ dependencies = [
 [[package]]
 name = "deno_lint"
 version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d13c7f86b00ec9d37d82feda3ae7903d239c86923b0e8157d76636587d494aa"
 dependencies = [
  "dprint-plugin-typescript",
  "lazy_static",
@@ -515,9 +527,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71677ecb7ac1522167c60ba7132811b25b03bec76d7b4276a66770ea4063d58"
+version = "0.22.0"
 dependencies = [
  "dprint-core",
  "serde",
@@ -1352,6 +1362,15 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "ordered-float"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "os_pipe"
@@ -2195,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aacf20b5d1587fcbfdd5e09c9e9ee55fa862c93f3ddeea9ec847a124eff27a2"
+checksum = "8f1e577708ae0d39827e2cb5fd0d62bbcf433c9cfc1fb0a21bf98f5ef635a63a"
 dependencies = [
  "enum_kind",
  "is-macro",
@@ -2209,10 +2228,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_parser"
+name = "swc_ecma_codegen"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77389b91b7ee1a59b8d424c86c835147da95eccec1ad289860e42ef1a109fd28"
+checksum = "e9b1b654354df8ebdc35d4046436157da9f4858a9e6e3b3058576157dcf885ed"
+dependencies = [
+ "bitflags",
+ "num-bigint",
+ "sourcemap",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen_macros",
+]
+
+[[package]]
+name = "swc_ecma_codegen_macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04378143fd1296af71dd3aea2e096bef6fbf8aa3c25352d44d62d7f28aa9851b"
+dependencies = [
+ "pmutil",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "swc_macros_common",
+ "syn 1.0.33",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "813282d73d2e86942b5e259613276b36f4c69ed2d7139de37db18e04ccbc0602"
 dependencies = [
  "either",
  "enum_kind",
@@ -2244,10 +2291,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_visit"
-version = "0.9.0"
+name = "swc_ecma_transforms"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb14e6a02ccd20b815f79b030b4372a12cb6a2b117a4794fb8d89c3fe1f78fc"
+checksum = "884147b4f0f99522627c9590ba6657ae6b3c80cd0e3f32081bd094e01b353421"
+dependencies = [
+ "Inflector",
+ "arrayvec",
+ "dashmap",
+ "either",
+ "fxhash",
+ "indexmap",
+ "is-macro",
+ "log 0.4.11",
+ "once_cell",
+ "ordered-float",
+ "regex",
+ "scoped-tls 1.0.0",
+ "serde",
+ "serde_json",
+ "smallvec 1.4.1",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654cf8ddcf6d980f1d036e3246a2dbd56082712baa3d114f11e4922d82658091"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "scoped-tls 1.0.0",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_visit",
+ "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c98c6b3b4e29f12d11b8eaf2663e5d3cd264cd7bd7b55aadc295eb727eda73"
 dependencies = [
  "num-bigint",
  "swc_atoms",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.1.17"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f432b637e17203e6b2e985867fb204051546b88308aca7e811e7ec62f4b9d534"
 dependencies = [
  "dprint-plugin-typescript",
  "lazy_static",
@@ -528,6 +530,8 @@ dependencies = [
 [[package]]
 name = "dprint-plugin-typescript"
 version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c1e5e9977e6b800a70a9a05734e44ec63da3987e8d4b6ece1907511894603b"
 dependencies = [
  "dprint-core",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ winapi = "0.3.8"
 
 [dependencies]
 deno_core = { path = "../core", version = "0.50.0" }
-deno_lint = { path = "../../dlint", version = "0.1.17" }
+deno_lint = "0.1.18"
 
 atty = "0.2.14"
 base64 = "0.12.2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ winapi = "0.3.8"
 
 [dependencies]
 deno_core = { path = "../core", version = "0.50.0" }
-deno_lint = "0.1.17"
+deno_lint = { path = "../../dlint", version = "0.1.17" }
 
 atty = "0.2.14"
 base64 = "0.12.2"
@@ -50,6 +50,8 @@ serde_derive = "1.0.112"
 serde_json = { version = "1.0.55", features = [ "preserve_order" ] }
 sys-info = "0.7.0"
 sourcemap = "6.0.0"
+swc_ecma_transforms = "=0.15.0"
+swc_ecma_codegen = "=0.28.0"
 tempfile = "3.1.0"
 termcolor = "1.1.0"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,8 +50,8 @@ serde_derive = "1.0.112"
 serde_json = { version = "1.0.55", features = [ "preserve_order" ] }
 sys-info = "0.7.0"
 sourcemap = "6.0.0"
-swc_ecma_transforms = "=0.15.0"
-swc_ecma_codegen = "=0.28.0"
+swc_ecma_transforms = "=0.15.2"
+swc_ecma_codegen = "=0.28.3"
 tempfile = "3.1.0"
 termcolor = "1.1.0"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ winapi = "0.3.8"
 
 [dependencies]
 deno_core = { path = "../core", version = "0.50.0" }
-deno_lint = "0.1.18"
+deno_lint = "0.1.19"
 
 atty = "0.2.14"
 base64 = "0.12.2"
@@ -50,8 +50,8 @@ serde_derive = "1.0.112"
 serde_json = { version = "1.0.55", features = [ "preserve_order" ] }
 sys-info = "0.7.0"
 sourcemap = "6.0.0"
-swc_ecma_transforms = "=0.15.2"
-swc_ecma_codegen = "=0.28.3"
+swc_ecma_transforms = "=0.16.0"
+swc_ecma_codegen = "=0.29.1"
 tempfile = "3.1.0"
 termcolor = "1.1.0"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -176,7 +176,7 @@ impl GlobalState {
       if self.flags.no_check {
         self
           .ts_compiler
-          .transpile(self.clone(), permissions, module_graph)
+          .transpile(module_graph)
           .await?;
       } else {
         self

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -174,10 +174,7 @@ impl GlobalState {
 
     if should_compile {
       if self.flags.no_check {
-        self
-          .ts_compiler
-          .transpile(module_graph)
-          .await?;
+        self.ts_compiler.transpile(module_graph).await?;
       } else {
         self
           .ts_compiler

--- a/cli/swc_util.rs
+++ b/cli/swc_util.rs
@@ -281,15 +281,3 @@ impl AstParser {
     }
   }
 }
-
-#[test]
-fn test_strip_types() {
-  let ast_parser = AstParser::new();
-  let result = ast_parser.strip_types(
-    "test.ts",
-    MediaType::TypeScript,
-    "const a: number = 10;",
-  );
-  assert!(result.is_ok());
-  assert_eq!(result.unwrap(), "const a = 10;\n");
-}

--- a/cli/swc_util.rs
+++ b/cli/swc_util.rs
@@ -220,9 +220,9 @@ impl AstParser {
     self.parse_module(file_name, media_type, source_code, |parse_result| {
       let module = parse_result?;
       let program = Program::Module(module);
-      let mut pass = chain!(typescript::strip(), fixer(),);
+      let mut compiler_pass = chain!(typescript::strip(), fixer());
       let program = swc_ecma_transforms::util::COMMENTS
-        .set(&self.comments, || program.fold_with(&mut pass));
+        .set(&self.comments, || program.fold_with(&mut compiler_pass));
 
       let mut src_map_buf = vec![];
       let mut buf = vec![];

--- a/cli/swc_util.rs
+++ b/cli/swc_util.rs
@@ -253,7 +253,7 @@ impl AstParser {
           .to_writer(&mut buf)?;
         let map = String::from_utf8(buf)?;
 
-        src.push_str("\n//# sourceMappingURL=data:application/json;base64,");
+        src.push_str("//# sourceMappingURL=data:application/json;base64,");
         let encoded_map = base64::encode(map.as_bytes());
         src.push_str(&encoded_map);
       }
@@ -285,11 +285,10 @@ impl AstParser {
 #[test]
 fn test_strip_types() {
   let ast_parser = AstParser::new();
-  let result = ast_parser.strip_types(
-    "test.ts",
-    MediaType::TypeScript,
-    "const a: number = 10;",
-  );
-  assert!(result.is_ok());
-  assert_eq!(result.unwrap(), "const a = 10;\n");
+  let result = ast_parser
+    .strip_types("test.ts", MediaType::TypeScript, "const a: number = 10;")
+    .unwrap();
+  assert!(result.starts_with(
+    "const a = 10;\n//# sourceMappingURL=data:application/json;base64,"
+  ));
 }

--- a/cli/swc_util.rs
+++ b/cli/swc_util.rs
@@ -281,3 +281,15 @@ impl AstParser {
     }
   }
 }
+
+#[test]
+fn test_strip_types() {
+  let ast_parser = AstParser::new();
+  let result = ast_parser.strip_types(
+    "test.ts",
+    MediaType::TypeScript,
+    "const a: number = 10;",
+  );
+  assert!(result.is_ok());
+  assert_eq!(result.unwrap(), "const a = 10;\n");
+}

--- a/cli/swc_util.rs
+++ b/cli/swc_util.rs
@@ -284,7 +284,7 @@ impl AstParser {
 
 #[test]
 fn test_strip_types() {
-  let ast_parser = AstParser::new();
+  let ast_parser = AstParser::default();
   let result = ast_parser
     .strip_types("test.ts", MediaType::TypeScript, "const a: number = 10;")
     .unwrap();

--- a/cli/swc_util.rs
+++ b/cli/swc_util.rs
@@ -12,18 +12,30 @@ use crate::swc_common::Globals;
 use crate::swc_common::SourceMap;
 use crate::swc_common::Span;
 use crate::swc_ecma_ast;
+use crate::swc_ecma_ast::Program;
 use crate::swc_ecma_parser::lexer::Lexer;
 use crate::swc_ecma_parser::EsConfig;
 use crate::swc_ecma_parser::JscTarget;
 use crate::swc_ecma_parser::Parser;
-use crate::swc_ecma_parser::Session;
 use crate::swc_ecma_parser::SourceFileInput;
 use crate::swc_ecma_parser::Syntax;
 use crate::swc_ecma_parser::TsConfig;
+use crate::swc_ecma_visit::FoldWith;
+use deno_core::ErrBox;
 use std::error::Error;
 use std::fmt;
 use std::sync::Arc;
 use std::sync::RwLock;
+use swc_ecma_codegen::text_writer::JsWriter;
+use swc_ecma_codegen::Node;
+use swc_ecma_transforms::helpers;
+use swc_ecma_transforms::helpers::Helpers;
+use swc_ecma_transforms::typescript;
+use swc_ecma_transforms::util;
+
+struct DummyHandler;
+
+impl swc_ecma_codegen::Handlers for DummyHandler {}
 
 fn get_default_es_config() -> EsConfig {
   let mut config = EsConfig::default();
@@ -179,31 +191,84 @@ impl AstParser {
       );
 
       let buffered_err = self.buffered_error.clone();
-      let session = Session {
-        handler: &self.handler,
-      };
-
       let syntax = get_syntax_for_media_type(media_type);
 
       let lexer = Lexer::new(
-        session,
         syntax,
         JscTarget::Es2019,
         SourceFileInput::from(&*swc_source_file),
         Some(&self.comments),
       );
 
-      let mut parser = Parser::new_from(session, lexer);
+      let mut parser = Parser::new_from(lexer);
 
       let parse_result =
         parser
           .parse_module()
-          .map_err(move |mut err: DiagnosticBuilder| {
-            err.emit();
+          .map_err(move |err| {
+            let mut diagnostic = err.into_diagnostic(&self.handler);
+            diagnostic.emit();
             SwcDiagnosticBuffer::from_swc_error(buffered_err, self)
           });
 
       callback(parse_result)
+    })
+  }
+
+  pub fn strip_types(
+    &self,
+    file_name: &str,
+    media_type: MediaType,
+    source_code: &str,
+  ) -> Result<String, ErrBox> {
+    self.parse_module(file_name, media_type, source_code, |parse_result| {
+      let module = parse_result?;
+      let program = Program::Module(module);
+      let mut pass = typescript::strip();
+      let program = helpers::HELPERS.set(&Helpers::new(false), || {
+        util::HANDLER.set(&self.handler, || {
+          // Fold module
+          program.fold_with(&mut pass)
+        })
+      });
+
+      let mut src_map_buf = vec![];
+      let mut buf = vec![];
+      {
+        let handlers = Box::new(DummyHandler);
+        let writer = Box::new(JsWriter::new(
+          self.source_map.clone(),
+          "\n",
+          &mut buf,
+          Some(&mut src_map_buf),
+        ));
+        let config = swc_ecma_codegen::Config { minify: false };
+        let mut emitter = swc_ecma_codegen::Emitter {
+          cfg: config,
+          comments: Some(&self.comments),
+          cm: self.source_map.clone(),
+          wr: writer,
+          handlers,
+        };
+        program.emit_with(&mut emitter)?;
+      }
+      let mut src = String::from_utf8(buf).map_err(ErrBox::from)?;
+      {
+        let mut buf = vec![];
+        self
+          .source_map
+          .build_source_map_from(&mut src_map_buf, None)
+          .to_writer(&mut buf)?;
+        let map = String::from_utf8(buf)?;
+
+        src.push_str("\n//# sourceMappingURL=data:application/json;base64,");
+        base64::encode_config_buf(
+          map.as_bytes(),
+          base64::Config::new(base64::CharacterSet::UrlSafe, true),
+          &mut src,
+        );
+      }
+      Ok(src)
     })
   }
 
@@ -226,4 +291,16 @@ impl AstParser {
       vec![]
     }
   }
+}
+
+#[test]
+fn test_strip_types() {
+  let ast_parser = AstParser::new();
+  let result = ast_parser.strip_types(
+    "test.ts",
+    MediaType::TypeScript,
+    "const a: number = 10;",
+  );
+  assert!(result.is_ok());
+  assert_eq!(result.unwrap(), "const a = 10;\n");
 }

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -1707,7 +1707,7 @@ mod tests {
     let source_code = compiled_file.code;
     assert!(source_code
       .as_bytes()
-      .starts_with(b"console.log('Hello World');"));
+      .starts_with(b"console.log(\"Hello World\");"));
     let mut lines: Vec<String> =
       source_code.split('\n').map(|s| s.to_string()).collect();
     let last_line = lines.pop().unwrap();

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -756,7 +756,7 @@ impl TsCompiler {
     let mut emit_map = HashMap::new();
 
     for source_file in source_files {
-      let parser = AstParser::new();
+      let parser = AstParser::default();
       let stripped_source = parser.strip_types(
         &source_file.file_name,
         MediaType::TypeScript,

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -1687,9 +1687,7 @@ mod tests {
     )
     .unwrap();
 
-    let result = ts_compiler
-      .transpile(module_graph)
-      .await;
+    let result = ts_compiler.transpile(module_graph).await;
     assert!(result.is_ok());
     let compiled_file = ts_compiler.get_compiled_module(&out.url).unwrap();
     let source_code = compiled_file.code;

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -414,16 +414,6 @@ struct CompileResponse {
   stats: Option<Vec<Stat>>,
 }
 
-// TODO(bartlomieju): remove
-#[allow(unused)]
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct TranspileResponse {
-  diagnostics: Diagnostic,
-  emit_map: HashMap<String, EmittedSource>,
-  stats: Option<Vec<Stat>>,
-}
-
 // TODO(bartlomieju): possible deduplicate once TS refactor is stabilized
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -735,8 +735,6 @@ impl TsCompiler {
 
   pub async fn transpile(
     &self,
-    _global_state: GlobalState,
-    _permissions: Permissions,
     module_graph: ModuleGraph,
   ) -> Result<(), ErrBox> {
     let mut source_files: Vec<TranspileSourceFile> = Vec::new();
@@ -1690,7 +1688,7 @@ mod tests {
     .unwrap();
 
     let result = ts_compiler
-      .transpile(mock_state.clone(), Permissions::allow_all(), module_graph)
+      .transpile(module_graph)
       .await;
     assert!(result.is_ok());
     let compiled_file = ts_compiler.get_compiled_module(&out.url).unwrap();


### PR DESCRIPTION
`v1.2.1`

```
▶ ./third_party/prebuilt/mac/hyperfine -w 3 -i 'deno cache --reload --no-check std/examples/chat/server_test.ts'
Benchmark #1: deno cache --reload --no-check std/examples/chat/server_test.ts

  Time (mean ± σ):     979.5 ms ±  10.7 ms    [User: 1.640 s, System: 0.071 s]

  Range (min … max):   967.1 ms … 1003.7 ms

```

`this PR`
```
▶ ./third_party/prebuilt/mac/hyperfine -w 3 -i 'target/release/deno cache --reload --no-check std/examples/chat/server_test.ts'
Benchmark #1: target/release/deno cache --reload --no-check std/examples/chat/server_test.ts

  Time (mean ± σ):      90.3 ms ±   3.5 ms    [User: 69.6 ms, System: 16.7 ms]

  Range (min … max):    86.5 ms … 100.1 ms

```

Binary size increased from `55942928` to `58668472`

Closes #6864 

<s>Blocked by https://github.com/swc-project/swc/issues/903</s>
