### PR TITLE
feat(std/async): add asyncPool utility

### DIFF
--- a/std/async/mod.ts
+++ b/std/async/mod.ts
@@ -2,4 +2,4 @@
 export * from "./deferred.ts";
 export * from "./delay.ts";
 export * from "./mux_async_iterator.ts";
-export * from "./pool.ts"; 
+export * from "./pool.ts";

--- a/std/async/mod.ts
+++ b/std/async/mod.ts
@@ -2,3 +2,4 @@
 export * from "./deferred.ts";
 export * from "./delay.ts";
 export * from "./mux_async_iterator.ts";
+export * from "./pool.ts"; 

--- a/std/async/pool.ts
+++ b/std/async/pool.ts
@@ -17,8 +17,8 @@ export async function asyncPool<T, R>(
   array: T[],
   iteratorFn: (data: T, array: T[]) => Promise<R>,
 ): Promise<R[]> {
-  const ret: Promise<R>[] = [];
-  const executing: Promise<unknown>[] = [];
+  const ret: Array<Promise<R>> = [];
+  const executing: Array<Promise<unknown>> = [];
   for (const item of array) {
     const p = Promise.resolve().then(() => iteratorFn(item, array));
     ret.push(p);

--- a/std/async/pool.ts
+++ b/std/async/pool.ts
@@ -19,12 +19,12 @@ export function pooledMap<T, R>(
     async transform(
       p: Promise<R>,
       controller: TransformStreamDefaultController<R>,
-    ) {
+    ): Promise<void> {
       controller.enqueue(await p);
     },
   });
   // Start processing items from the iterator
-  (async () => {
+  (async (): Promise<void> => {
     const writer = res.writable.getWriter();
     const executing: Array<Promise<unknown>> = [];
     for await (const item of array) {

--- a/std/async/pool.ts
+++ b/std/async/pool.ts
@@ -1,0 +1,34 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+// From https://github.com/rxaviers/async-pool/blob/master/lib/es7.js.
+// Copyright (c) 2017 Rafael Xavier de Souza http://rafael.xavier.blog.br
+// Licensed under MIT
+
+/**
+ * asyncPool is like Promise.all(array.map(async () => {...})), except that you
+ * can specify the maximum amount of items being processed concurrently.
+ * 
+ * @param poolLimit The maximum count of items being processed concurrently. 
+ * @param array The input array for mapping.
+ * @param iteratorFn The function to call for every item of the array.
+ */
+export async function asyncPool<T, R>(
+  poolLimit: number,
+  array: T[],
+  iteratorFn: (data: T, array: T[]) => Promise<R>,
+): Promise<R[]> {
+  const ret: Promise<R>[] = [];
+  const executing: Promise<unknown>[] = [];
+  for (const item of array) {
+    const p = Promise.resolve().then(() => iteratorFn(item, array));
+    ret.push(p);
+    const e: Promise<unknown> = p.then(() =>
+      executing.splice(executing.indexOf(e), 1)
+    );
+    executing.push(e);
+    if (executing.length >= poolLimit) {
+      await Promise.race(executing);
+    }
+  }
+  return Promise.all(ret);
+}

--- a/std/async/pool.ts
+++ b/std/async/pool.ts
@@ -15,12 +15,12 @@
 export async function asyncPool<T, R>(
   poolLimit: number,
   array: T[],
-  iteratorFn: (data: T, array: T[]) => Promise<R>,
+  iteratorFn: (data: T) => Promise<R>,
 ): Promise<R[]> {
   const ret: Array<Promise<R>> = [];
   const executing: Array<Promise<unknown>> = [];
   for (const item of array) {
-    const p = Promise.resolve().then(() => iteratorFn(item, array));
+    const p = Promise.resolve().then(() => iteratorFn(item));
     ret.push(p);
     const e: Promise<unknown> = p.then(() =>
       executing.splice(executing.indexOf(e), 1)

--- a/std/async/pool_test.ts
+++ b/std/async/pool_test.ts
@@ -1,0 +1,19 @@
+import { pooledMap } from "./pool.ts";
+import { assert } from "../testing/asserts.ts";
+
+Deno.test("[async] pooledMap", async function (): Promise<void> {
+  const start = new Date();
+  const results = pooledMap(
+    2,
+    [1, 2, 3],
+    (i) => new Promise((r) => setTimeout(() => r(i), 1000)),
+  );
+  for await (const value of results) {
+    console.log(value);
+  }
+  const diff = new Date().getTime() - start.getTime();
+  assert(diff >= 2000);
+  assert(diff < 3000);
+});
+
+export {};


### PR DESCRIPTION
`asyncPool` is like `Promise.all(array.map(async () => {...}))`, except that you can specify the maximum amount of items being processed concurrently.