### PR TITLE
chore: use matches macro for bool matches

### DIFF
--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -149,10 +149,7 @@ fn format_maybe_related_information(
     for rd in related_information {
       s.push_str("\n\n");
       s.push_str(&format_stack(
-        match rd.category {
-          DiagnosticCategory::Error => true,
-          _ => false,
-        },
+        matches!(rd.category, DiagnosticCategory::Error),
         &format_message(&rd.message_chain, &rd.message, 0),
         rd.source_line.as_deref(),
         rd.start_column,
@@ -177,10 +174,7 @@ impl fmt::Display for DiagnosticItem {
       f,
       "{}",
       format_stack(
-        match self.category {
-          DiagnosticCategory::Error => true,
-          _ => false,
-        },
+        matches!(self.category, DiagnosticCategory::Error),
         &format!(
           "{}: {}",
           format_category_and_code(&self.category, self.code),

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -586,10 +586,7 @@ impl TsCompiler {
     };
     let root_names = vec![module_url.to_string()];
     let unstable = self.flags.unstable;
-    let performance = match self.flags.log_level {
-      Some(Level::Debug) => true,
-      _ => false,
-    };
+    let performance = matches!(self.flags.log_level, Some(Level::Debug));
     let compiler_config = self.config.clone();
     let cwd = std::env::current_dir().unwrap();
 
@@ -695,10 +692,8 @@ impl TsCompiler {
     let root_names = vec![module_specifier.to_string()];
     let target = "main";
     let cwd = std::env::current_dir().unwrap();
-    let performance = match global_state.flags.log_level {
-      Some(Level::Debug) => true,
-      _ => false,
-    };
+    let performance =
+      matches!(global_state.flags.log_level, Some(Level::Debug));
 
     let compiler_config = self.config.clone();
 
@@ -771,10 +766,8 @@ impl TsCompiler {
       serde_json::to_value(source_files).expect("Filed to serialize data");
     let compiler_config = self.config.clone();
     let cwd = std::env::current_dir().unwrap();
-    let performance = match global_state.flags.log_level {
-      Some(Level::Debug) => true,
-      _ => false,
-    };
+    let performance =
+      matches!(global_state.flags.log_level, Some(Level::Debug));
     let j = match (compiler_config.path, compiler_config.content) {
       (Some(config_path), Some(config_data)) => json!({
         "config": str::from_utf8(&config_data).unwrap(),

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -340,10 +340,7 @@ impl ModuleNameMap {
   /// Check if a name is an alias to another module.
   pub fn is_alias(&self, name: &str) -> bool {
     let cond = self.inner.get(name);
-    match cond {
-      Some(SymbolicModule::Alias(_)) => true,
-      _ => false,
-    }
+    matches!(cond, Some(SymbolicModule::Alias(_)))
   }
 }
 


### PR DESCRIPTION
Nightly clippy flags these up as errors, but there appears to issue with adopting this style prematurely.