### PR TITLE
Change release build flags to optimize for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,9 @@ members = [
 exclude = [
   "std/hash/_wasm"
 ]
+
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = 'z' # Optimize for size


### PR DESCRIPTION
This decreases binary size by about 11% and also speeds up built-time for release builds (due to `codegen-units = 1`).
```
target/release/deno
this pr    41800776
master     47233300
```
I want to land this and see what the effects on the benchmarks are. Because V8 is compiled separately, and is generally the bottleneck, it's possible this change will not effect the benchmarks much.

I got these tips from https://github.com/johnthagen/min-sized-rust 