### PR TITLE
fix(cli/rt): Fix file URL to path conversion on Windows

### DIFF
--- a/cli/rt/06_util.js
+++ b/cli/rt/06_util.js
@@ -64,23 +64,18 @@
   }
 
   function pathFromURLWin32(url) {
-    const hostname = url.hostname;
-    const pathname = decodeURIComponent(url.pathname.replace(/\//g, "\\"));
-
-    if (hostname !== "") {
-      //TODO(actual-size) Node adds a punycode decoding step, we should consider adding this
-      return `\\\\${hostname}${pathname}`;
+    let path = decodeURIComponent(
+      url.pathname
+        .replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/")
+        .replace(/\//g, "\\"),
+    );
+    if (url.hostname != "") {
+      // Note: The `URL` implementation guarantees that the drive letter and
+      // hostname are mutually exclusive. Otherwise it would not have been valid
+      // to append the hostname and path like this.
+      path = `\\\\${url.hostname}${path}`;
     }
-
-    const validPath = /^\\(?<driveLetter>[A-Za-z]):\\/;
-    const matches = validPath.exec(pathname);
-
-    if (!matches?.groups?.driveLetter) {
-      throw new TypeError("A URL with the file schema must be absolute.");
-    }
-
-    // we don't want a leading slash on an absolute path in Windows
-    return pathname.slice(1);
+    return path;
   }
 
   function pathFromURLPosix(url) {

--- a/std/path/from_file_url_test.ts
+++ b/std/path/from_file_url_test.ts
@@ -1,29 +1,49 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { posix, win32 } from "./mod.ts";
-import { assertEquals } from "../testing/asserts.ts";
+import { assertEquals, assertThrows } from "../testing/asserts.ts";
 
 Deno.test("[path] fromFileUrl", function () {
   assertEquals(posix.fromFileUrl(new URL("file:///home/foo")), "/home/foo");
+  assertEquals(posix.fromFileUrl("file:///"), "/");
   assertEquals(posix.fromFileUrl("file:///home/foo"), "/home/foo");
   assertEquals(posix.fromFileUrl("file:///home/foo%20bar"), "/home/foo bar");
   assertEquals(posix.fromFileUrl("file://localhost/foo"), "/foo");
-  assertEquals(posix.fromFileUrl("http://localhost/foo"), "/foo");
-  assertEquals(posix.fromFileUrl("file:///"), "/");
   assertEquals(posix.fromFileUrl("file:///C:"), "/C:");
   assertEquals(posix.fromFileUrl("file:///C:/"), "/C:/");
   assertEquals(posix.fromFileUrl("file:///C:/Users/"), "/C:/Users/");
   assertEquals(posix.fromFileUrl("file:///C:foo/bar"), "/C:foo/bar");
+  assertThrows(
+    () => posix.fromFileUrl("http://localhost/foo"),
+    TypeError,
+    "Must be a file URL.",
+  );
+  assertThrows(
+    () => posix.fromFileUrl("abcd://localhost/foo"),
+    TypeError,
+    "Must be a file URL.",
+  );
 });
 
 Deno.test("[path] fromFileUrl (win32)", function () {
   assertEquals(win32.fromFileUrl(new URL("file:///home/foo")), "\\home\\foo");
+  assertEquals(win32.fromFileUrl("file:///"), "\\");
   assertEquals(win32.fromFileUrl("file:///home/foo"), "\\home\\foo");
   assertEquals(win32.fromFileUrl("file:///home/foo%20bar"), "\\home\\foo bar");
   assertEquals(win32.fromFileUrl("file://localhost/foo"), "\\\\localhost\\foo");
-  assertEquals(win32.fromFileUrl("http://localhost/foo"), "\\\\localhost\\foo");
-  assertEquals(win32.fromFileUrl("file:///"), "\\");
   assertEquals(win32.fromFileUrl("file:///C:"), "C:\\");
   assertEquals(win32.fromFileUrl("file:///C:/"), "C:\\");
+  // Drop the hostname if a drive letter is parsed.
+  assertEquals(win32.fromFileUrl("file://localhost/C:/"), "C:\\");
   assertEquals(win32.fromFileUrl("file:///C:/Users/"), "C:\\Users\\");
   assertEquals(win32.fromFileUrl("file:///C:foo/bar"), "\\C:foo\\bar");
+  assertThrows(
+    () => win32.fromFileUrl("http://localhost/foo"),
+    TypeError,
+    "Must be a file URL.",
+  );
+  assertThrows(
+    () => win32.fromFileUrl("abcd://localhost/foo"),
+    TypeError,
+    "Must be a file URL.",
+  );
 });

--- a/std/path/from_file_url_test.ts
+++ b/std/path/from_file_url_test.ts
@@ -6,7 +6,8 @@ Deno.test("[path] fromFileUrl", function () {
   assertEquals(posix.fromFileUrl(new URL("file:///home/foo")), "/home/foo");
   assertEquals(posix.fromFileUrl("file:///home/foo"), "/home/foo");
   assertEquals(posix.fromFileUrl("file:///home/foo%20bar"), "/home/foo bar");
-  assertEquals(posix.fromFileUrl("https://example.com/foo"), "/foo");
+  assertEquals(posix.fromFileUrl("file://localhost/foo"), "/foo");
+  assertEquals(posix.fromFileUrl("http://localhost/foo"), "/foo");
   assertEquals(posix.fromFileUrl("file:///"), "/");
   assertEquals(posix.fromFileUrl("file:///C:"), "/C:");
   assertEquals(posix.fromFileUrl("file:///C:/"), "/C:/");
@@ -18,7 +19,8 @@ Deno.test("[path] fromFileUrl (win32)", function () {
   assertEquals(win32.fromFileUrl(new URL("file:///home/foo")), "\\home\\foo");
   assertEquals(win32.fromFileUrl("file:///home/foo"), "\\home\\foo");
   assertEquals(win32.fromFileUrl("file:///home/foo%20bar"), "\\home\\foo bar");
-  assertEquals(win32.fromFileUrl("https://example.com/foo"), "\\foo");
+  assertEquals(win32.fromFileUrl("file://localhost/foo"), "\\\\localhost\\foo");
+  assertEquals(win32.fromFileUrl("http://localhost/foo"), "\\\\localhost\\foo");
   assertEquals(win32.fromFileUrl("file:///"), "\\");
   assertEquals(win32.fromFileUrl("file:///C:"), "C:\\");
   assertEquals(win32.fromFileUrl("file:///C:/"), "C:\\");

--- a/std/path/from_file_url_test.ts
+++ b/std/path/from_file_url_test.ts
@@ -8,12 +8,9 @@ Deno.test("[path] fromFileUrl", function () {
   assertEquals(posix.fromFileUrl("file:///home/foo%20bar"), "/home/foo bar");
   assertEquals(posix.fromFileUrl("https://example.com/foo"), "/foo");
   assertEquals(posix.fromFileUrl("file:///"), "/");
-  // Drive letters are supported platform-independently to align with the WHATWG
-  // URL specification.
-  assertEquals(posix.fromFileUrl("file:///c:"), "c:/");
-  assertEquals(posix.fromFileUrl("file:///c:/"), "c:/");
-  assertEquals(posix.fromFileUrl("file:///C:/"), "C:/");
-  assertEquals(posix.fromFileUrl("file:///C:/Users/"), "C:/Users/");
+  assertEquals(posix.fromFileUrl("file:///C:"), "/C:");
+  assertEquals(posix.fromFileUrl("file:///C:/"), "/C:/");
+  assertEquals(posix.fromFileUrl("file:///C:/Users/"), "/C:/Users/");
   assertEquals(posix.fromFileUrl("file:///C:foo/bar"), "/C:foo/bar");
 });
 
@@ -23,8 +20,7 @@ Deno.test("[path] fromFileUrl (win32)", function () {
   assertEquals(win32.fromFileUrl("file:///home/foo%20bar"), "\\home\\foo bar");
   assertEquals(win32.fromFileUrl("https://example.com/foo"), "\\foo");
   assertEquals(win32.fromFileUrl("file:///"), "\\");
-  assertEquals(win32.fromFileUrl("file:///c:"), "c:\\");
-  assertEquals(win32.fromFileUrl("file:///c:/"), "c:\\");
+  assertEquals(win32.fromFileUrl("file:///C:"), "C:\\");
   assertEquals(win32.fromFileUrl("file:///C:/"), "C:\\");
   assertEquals(win32.fromFileUrl("file:///C:/Users/"), "C:\\Users\\");
   assertEquals(win32.fromFileUrl("file:///C:foo/bar"), "\\C:foo\\bar");

--- a/std/path/posix.ts
+++ b/std/path/posix.ts
@@ -435,6 +435,5 @@ export function parse(path: string): ParsedPath {
  * are ignored.
  */
 export function fromFileUrl(url: string | URL): string {
-  return decodeURIComponent((url instanceof URL ? url : new URL(url)).pathname
-    .replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/"));
+  return decodeURIComponent((url instanceof URL ? url : new URL(url)).pathname);
 }

--- a/std/path/posix.ts
+++ b/std/path/posix.ts
@@ -430,10 +430,11 @@ export function parse(path: string): ParsedPath {
 /** Converts a file URL to a path string.
  *
  *      fromFileUrl("file:///home/foo"); // "/home/foo"
- *
- * Note that non-file URLs are treated as file URLs and irrelevant components
- * are ignored.
  */
 export function fromFileUrl(url: string | URL): string {
-  return decodeURIComponent((url instanceof URL ? url : new URL(url)).pathname);
+  url = url instanceof URL ? url : new URL(url);
+  if (url.protocol != "file:") {
+    throw new TypeError("Must be a file URL.");
+  }
+  return decodeURIComponent(url.pathname);
 }

--- a/std/path/win32.ts
+++ b/std/path/win32.ts
@@ -907,14 +907,15 @@ export function parse(path: string): ParsedPath {
 
 /** Converts a file URL to a path string.
  *
- *      fromFileUrl("file:///C:/Users/foo"); // "C:\\Users\\foo"
  *      fromFileUrl("file:///home/foo"); // "\\home\\foo"
- *
- * Note that non-file URLs are treated as file URLs and irrelevant components
- * are ignored.
+ *      fromFileUrl("file:///C:/Users/foo"); // "C:\\Users\\foo"
+ *      fromFileUrl("file://localhost/home/foo"); // "\\\\localhost\\home\\foo"
  */
 export function fromFileUrl(url: string | URL): string {
   url = url instanceof URL ? url : new URL(url);
+  if (url.protocol != "file:") {
+    throw new TypeError("Must be a file URL.");
+  }
   let path = decodeURIComponent(
     url.pathname
       .replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/")

--- a/std/path/win32.ts
+++ b/std/path/win32.ts
@@ -914,9 +914,17 @@ export function parse(path: string): ParsedPath {
  * are ignored.
  */
 export function fromFileUrl(url: string | URL): string {
-  return decodeURIComponent(
-    (url instanceof URL ? url : new URL(url)).pathname
+  url = url instanceof URL ? url : new URL(url);
+  let path = decodeURIComponent(
+    url.pathname
       .replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/")
       .replace(/\//g, "\\"),
   );
+  if (url.hostname != "") {
+    // Note: The `URL` implementation guarantees that the drive letter and
+    // hostname are mutually exclusive. Otherwise it would not have been valid
+    // to append the hostname and path like this.
+    path = `\\\\${url.hostname}${path}`;
+  }
+  return path;
 }


### PR DESCRIPTION
Changes to `std/path - fromFileUrl()`:
- fix: Remove drive letter support in posix.
- fix: Return UNC paths for hostnames in win32.
- fix: Throw for non-file URLs.

---

Makes some final fixes to `fromFileUrl()` in `std` and aligns the built-in version with it.
Fixes #6919.