### PR TITLE
feat: add $STD_VERSION replacement variable in docs

### DIFF
--- a/docs/contributing/style_guide.md
+++ b/docs/contributing/style_guide.md
@@ -101,7 +101,7 @@ When designing function interfaces, stick to the following rules.
 export function resolve(
   hostname: string,
   family?: "ipv4" | "ipv6",
-  timeout?: number
+  timeout?: number,
 ): IPAddress[] {}
 
 // GOOD.
@@ -111,7 +111,7 @@ export interface ResolveOptions {
 }
 export function resolve(
   hostname: string,
-  options: ResolveOptions = {}
+  options: ResolveOptions = {},
 ): IPAddress[] {}
 ```
 
@@ -130,7 +130,7 @@ export interface RunShellOptions {
 }
 export function runShellWithEnv(
   cmdline: string,
-  options: RunShellOptions
+  options: RunShellOptions,
 ): string {}
 ```
 
@@ -140,7 +140,7 @@ export function renameSync(
   oldname: string,
   newname: string,
   replaceExisting?: boolean,
-  followLinks?: boolean
+  followLinks?: boolean,
 ) {}
 
 // GOOD.
@@ -151,7 +151,7 @@ interface RenameOptions {
 export function renameSync(
   oldname: string,
   newname: string,
-  options: RenameOptions = {}
+  options: RenameOptions = {},
 ) {}
 ```
 
@@ -162,7 +162,7 @@ export function pwrite(
   buffer: TypedArray,
   offset: number,
   length: number,
-  position: number
+  position: number,
 ) {}
 
 // BETTER.

--- a/docs/contributing/style_guide.md
+++ b/docs/contributing/style_guide.md
@@ -101,7 +101,7 @@ When designing function interfaces, stick to the following rules.
 export function resolve(
   hostname: string,
   family?: "ipv4" | "ipv6",
-  timeout?: number,
+  timeout?: number
 ): IPAddress[] {}
 
 // GOOD.
@@ -111,7 +111,7 @@ export interface ResolveOptions {
 }
 export function resolve(
   hostname: string,
-  options: ResolveOptions = {},
+  options: ResolveOptions = {}
 ): IPAddress[] {}
 ```
 
@@ -130,7 +130,7 @@ export interface RunShellOptions {
 }
 export function runShellWithEnv(
   cmdline: string,
-  options: RunShellOptions,
+  options: RunShellOptions
 ): string {}
 ```
 
@@ -140,7 +140,7 @@ export function renameSync(
   oldname: string,
   newname: string,
   replaceExisting?: boolean,
-  followLinks?: boolean,
+  followLinks?: boolean
 ) {}
 
 // GOOD.
@@ -151,7 +151,7 @@ interface RenameOptions {
 export function renameSync(
   oldname: string,
   newname: string,
-  options: RenameOptions = {},
+  options: RenameOptions = {}
 ) {}
 ```
 
@@ -162,7 +162,7 @@ export function pwrite(
   buffer: TypedArray,
   offset: number,
   length: number,
-  position: number,
+  position: number
 ) {}
 
 // BETTER.
@@ -278,7 +278,7 @@ test myTestFunction ... ok
 Example of test:
 
 ```ts
-import { assertEquals } from "https://deno.land/std@__STD_VERSION__/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 import { foo } from "./mod.ts";
 
 Deno.test("myTestFunction" function() {

--- a/docs/contributing/style_guide.md
+++ b/docs/contributing/style_guide.md
@@ -278,7 +278,7 @@ test myTestFunction ... ok
 Example of test:
 
 ```ts
-import { assertEquals } from "https://deno.land/std@v0.11/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@__STD_VERSION__/testing/asserts.ts";
 import { foo } from "./mod.ts";
 
 Deno.test("myTestFunction" function() {

--- a/docs/examples/file_server.md
+++ b/docs/examples/file_server.md
@@ -3,14 +3,14 @@
 This one serves a local directory in HTTP.
 
 ```shell
-deno install --allow-net --allow-read https://deno.land/std@__STD_VERSION__/http/file_server.ts
+deno install --allow-net --allow-read https://deno.land/std@$STD_VERSION/http/file_server.ts
 ```
 
 Run it:
 
 ```shell
 $ file_server .
-Downloading https://deno.land/std@__STD_VERSION__/http/file_server.ts...
+Downloading https://deno.land/std@$STD_VERSION/http/file_server.ts...
 [...]
 HTTP server listening on http://0.0.0.0:4500/
 ```

--- a/docs/examples/file_server.md
+++ b/docs/examples/file_server.md
@@ -3,14 +3,14 @@
 This one serves a local directory in HTTP.
 
 ```shell
-deno install --allow-net --allow-read https://deno.land/std/http/file_server.ts
+deno install --allow-net --allow-read https://deno.land/std@__STD_VERSION__/http/file_server.ts
 ```
 
 Run it:
 
 ```shell
 $ file_server .
-Downloading https://deno.land/std/http/file_server.ts...
+Downloading https://deno.land/std@__STD_VERSION__/http/file_server.ts...
 [...]
 HTTP server listening on http://0.0.0.0:4500/
 ```

--- a/docs/examples/subprocess.md
+++ b/docs/examples/subprocess.md
@@ -38,7 +38,7 @@ const p = Deno.run({
     "deno",
     "run",
     "--allow-read",
-    "https://deno.land/std/examples/cat.ts",
+    "https://deno.land@__STD_VERSION__/examples/cat.ts",
     ...fileNames,
   ],
   stdout: "piped",

--- a/docs/examples/subprocess.md
+++ b/docs/examples/subprocess.md
@@ -38,7 +38,7 @@ const p = Deno.run({
     "deno",
     "run",
     "--allow-read",
-    "https://deno.land@__STD_VERSION__/examples/cat.ts",
+    "https://deno.land@$STD_VERSION/examples/cat.ts",
     ...fileNames,
   ],
   stdout: "piped",

--- a/docs/examples/tcp_echo.md
+++ b/docs/examples/tcp_echo.md
@@ -14,7 +14,7 @@ for await (const conn of listener) {
 When this program is started, it throws PermissionDenied error.
 
 ```shell
-$ deno run https://deno.land/std/examples/echo_server.ts
+$ deno run https://deno.land/std@__STD_VERSION__/examples/echo_server.ts
 error: Uncaught PermissionDenied: network access to "0.0.0.0:8080", run again with the --allow-net flag
 ► $deno$/dispatch_json.ts:40:11
     at DenoError ($deno$/errors.ts:20:5)
@@ -25,7 +25,7 @@ For security reasons, Deno does not allow programs to access the network without
 explicit permission. To allow accessing the network, use a command-line flag:
 
 ```shell
-deno run --allow-net https://deno.land/std/examples/echo_server.ts
+deno run --allow-net https://deno.land/std@__STD_VERSION__/examples/echo_server.ts
 ```
 
 To test it, try sending data to it with netcat:

--- a/docs/examples/tcp_echo.md
+++ b/docs/examples/tcp_echo.md
@@ -14,7 +14,7 @@ for await (const conn of listener) {
 When this program is started, it throws PermissionDenied error.
 
 ```shell
-$ deno run https://deno.land/std@__STD_VERSION__/examples/echo_server.ts
+$ deno run https://deno.land/std@$STD_VERSION/examples/echo_server.ts
 error: Uncaught PermissionDenied: network access to "0.0.0.0:8080", run again with the --allow-net flag
 ► $deno$/dispatch_json.ts:40:11
     at DenoError ($deno$/errors.ts:20:5)
@@ -25,7 +25,7 @@ For security reasons, Deno does not allow programs to access the network without
 explicit permission. To allow accessing the network, use a command-line flag:
 
 ```shell
-deno run --allow-net https://deno.land/std@__STD_VERSION__/examples/echo_server.ts
+deno run --allow-net https://deno.land/std@$STD_VERSION/examples/echo_server.ts
 ```
 
 To test it, try sending data to it with netcat:

--- a/docs/examples/unix_cat.md
+++ b/docs/examples/unix_cat.md
@@ -20,5 +20,5 @@ I/O streams in Deno.
 Try the program:
 
 ```shell
-deno run --allow-read https://deno.land/std/examples/cat.ts /etc/passwd
+deno run --allow-read https://deno.land/std@__STD_VERSION__/examples/cat.ts /etc/passwd
 ```

--- a/docs/examples/unix_cat.md
+++ b/docs/examples/unix_cat.md
@@ -20,5 +20,5 @@ I/O streams in Deno.
 Try the program:
 
 ```shell
-deno run --allow-read https://deno.land/std@__STD_VERSION__/examples/cat.ts /etc/passwd
+deno run --allow-read https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
 ```

--- a/docs/getting_started/first_steps.md
+++ b/docs/getting_started/first_steps.md
@@ -23,7 +23,7 @@ console.log("Welcome to Deno 🦕");
 Try the program:
 
 ```shell
-deno run https://deno.land/std/examples/welcome.ts
+deno run https://deno.land/std@__STD_VERSION__/examples/welcome.ts
 ```
 
 ### Making an HTTP request
@@ -59,7 +59,7 @@ Let's walk through what this application does:
 Try it out:
 
 ```shell
-deno run https://deno.land/std/examples/curl.ts https://example.com
+deno run https://deno.land/std@__STD_VERSION__/examples/curl.ts https://example.com
 ```
 
 You will see this program returns an error regarding network access, so what did
@@ -70,7 +70,7 @@ permission to do certain 'privileged' actions, such as access the network.
 Try it out again with the correct permission flag:
 
 ```shell
-deno run --allow-net=example.com https://deno.land/std/examples/curl.ts https://example.com
+deno run --allow-net=example.com https://deno.land/std@__STD_VERSION__/examples/curl.ts https://example.com
 ```
 
 ### Reading a file
@@ -102,7 +102,7 @@ I/O streams in Deno.
 Try the program:
 
 ```shell
-deno run --allow-read https://deno.land/std/examples/cat.ts /etc/passwd
+deno run --allow-read https://deno.land/std@__STD_VERSION__/examples/cat.ts /etc/passwd
 ```
 
 ### TCP server
@@ -124,7 +124,7 @@ For security reasons, Deno does not allow programs to access the network without
 explicit permission. To allow accessing the network, use a command-line flag:
 
 ```shell
-deno run --allow-net https://deno.land/std/examples/echo_server.ts
+deno run --allow-net https://deno.land/std@__STD_VERSION__/examples/echo_server.ts
 ```
 
 To test it, try sending data to it with netcat:

--- a/docs/getting_started/first_steps.md
+++ b/docs/getting_started/first_steps.md
@@ -23,7 +23,7 @@ console.log("Welcome to Deno 🦕");
 Try the program:
 
 ```shell
-deno run https://deno.land/std@__STD_VERSION__/examples/welcome.ts
+deno run https://deno.land/std@$STD_VERSION/examples/welcome.ts
 ```
 
 ### Making an HTTP request
@@ -59,7 +59,7 @@ Let's walk through what this application does:
 Try it out:
 
 ```shell
-deno run https://deno.land/std@__STD_VERSION__/examples/curl.ts https://example.com
+deno run https://deno.land/std@$STD_VERSION/examples/curl.ts https://example.com
 ```
 
 You will see this program returns an error regarding network access, so what did
@@ -70,7 +70,7 @@ permission to do certain 'privileged' actions, such as access the network.
 Try it out again with the correct permission flag:
 
 ```shell
-deno run --allow-net=example.com https://deno.land/std@__STD_VERSION__/examples/curl.ts https://example.com
+deno run --allow-net=example.com https://deno.land/std@$STD_VERSION/examples/curl.ts https://example.com
 ```
 
 ### Reading a file
@@ -102,7 +102,7 @@ I/O streams in Deno.
 Try the program:
 
 ```shell
-deno run --allow-read https://deno.land/std@__STD_VERSION__/examples/cat.ts /etc/passwd
+deno run --allow-read https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
 ```
 
 ### TCP server
@@ -124,7 +124,7 @@ For security reasons, Deno does not allow programs to access the network without
 explicit permission. To allow accessing the network, use a command-line flag:
 
 ```shell
-deno run --allow-net https://deno.land/std@__STD_VERSION__/examples/echo_server.ts
+deno run --allow-net https://deno.land/std@$STD_VERSION/examples/echo_server.ts
 ```
 
 To test it, try sending data to it with netcat:

--- a/docs/getting_started/permissions.md
+++ b/docs/getting_started/permissions.md
@@ -47,7 +47,7 @@ directory, however the execution fails as the process was attempting to access a
 file in the `/etc` directory:
 
 ```shell
-$ deno run --allow-read=/usr https://deno.land/std@__STD_VERSION__/examples/cat.ts /etc/passwd
+$ deno run --allow-read=/usr https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
 error: Uncaught PermissionDenied: read access to "/etc/passwd", run again with the --allow-read flag
 ► $deno$/dispatch_json.ts:40:11
     at DenoError ($deno$/errors.ts:20:5)
@@ -57,7 +57,7 @@ error: Uncaught PermissionDenied: read access to "/etc/passwd", run again with t
 Try it out again with the correct permissions by allow-listing `/etc` instead:
 
 ```shell
-deno run --allow-read=/etc https://deno.land/std@__STD_VERSION__/examples/cat.ts /etc/passwd
+deno run --allow-read=/etc https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
 ```
 
 `--allow-write` works the same as `--allow-read`.

--- a/docs/getting_started/permissions.md
+++ b/docs/getting_started/permissions.md
@@ -47,7 +47,7 @@ directory, however the execution fails as the process was attempting to access a
 file in the `/etc` directory:
 
 ```shell
-$ deno run --allow-read=/usr https://deno.land/std/examples/cat.ts /etc/passwd
+$ deno run --allow-read=/usr https://deno.land/std@__STD_VERSION__/examples/cat.ts /etc/passwd
 error: Uncaught PermissionDenied: read access to "/etc/passwd", run again with the --allow-read flag
 ► $deno$/dispatch_json.ts:40:11
     at DenoError ($deno$/errors.ts:20:5)
@@ -57,7 +57,7 @@ error: Uncaught PermissionDenied: read access to "/etc/passwd", run again with t
 Try it out again with the correct permissions by allow-listing `/etc` instead:
 
 ```shell
-deno run --allow-read=/etc https://deno.land/std/examples/cat.ts /etc/passwd
+deno run --allow-read=/etc https://deno.land/std@__STD_VERSION__/examples/cat.ts /etc/passwd
 ```
 
 `--allow-write` works the same as `--allow-read`.

--- a/docs/getting_started/typescript.md
+++ b/docs/getting_started/typescript.md
@@ -10,7 +10,7 @@ no "magical" module resolution. Instead, imported modules are specified as files
 directly imported. E.g.
 
 ```
-import { Response } from "https://deno.land/std@__STD_VERSION__/http/server.ts";
+import { Response } from "https://deno.land/std@$STD_VERSION/http/server.ts";
 import { queue } from "./collections.ts";
 ```
 

--- a/docs/getting_started/typescript.md
+++ b/docs/getting_started/typescript.md
@@ -10,7 +10,7 @@ no "magical" module resolution. Instead, imported modules are specified as files
 directly imported. E.g.
 
 ```
-import { Response } from "https://deno.land/std@0.53.0/http/server.ts";
+import { Response } from "https://deno.land/std@__STD_VERSION__/http/server.ts";
 import { queue } from "./collections.ts";
 ```
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -60,7 +60,7 @@ have been historically written with bash or python.
   imported via URLs:
 
   ```javascript
-  import * as log from "https://deno.land/std@__STD_VERSION__/log/mod.ts";
+  import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";
   ```
 
 ## Other key behaviors

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -60,7 +60,7 @@ have been historically written with bash or python.
   imported via URLs:
 
   ```javascript
-  import * as log from "https://deno.land/std/log/mod.ts";
+  import * as log from "https://deno.land/std@__STD_VERSION__/log/mod.ts";
   ```
 
 ## Other key behaviors

--- a/docs/linking_to_external_code.md
+++ b/docs/linking_to_external_code.md
@@ -7,7 +7,7 @@ directly from URLs. This example uses a URL to import an assertion library:
 **test.ts**
 
 ```ts
-import { assertEquals } from "https://deno.land/std@__STD_VERSION__/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 
 assertEquals("hello", "hello");
 assertEquals("world", "world");
@@ -20,9 +20,9 @@ Try running this:
 ```shell
 $ deno run test.ts
 Compile file:///mnt/f9/Projects/github.com/denoland/deno/docs/test.ts
-Download https://deno.land/std@__STD_VERSION__/testing/asserts.ts
-Download https://deno.land/std@__STD_VERSION__/fmt/colors.ts
-Download https://deno.land/std@__STD_VERSION__/testing/diff.ts
+Download https://deno.land/std@$STD_VERSION/testing/asserts.ts
+Download https://deno.land/std@$STD_VERSION/fmt/colors.ts
+Download https://deno.land/std@$STD_VERSION/testing/diff.ts
 Asserted! ✓
 ```
 
@@ -57,7 +57,7 @@ being run: `https://unpkg.com/liltest@0.0.5/dist/liltest.js`.
 The solution is to import and re-export your external libraries in a central
 `deps.ts` file (which serves the same purpose as Node's `package.json` file).
 For example, let's say you were using the above assertion library across a large
-project. Rather than importing `"https://deno.land/std@__STD_VERSION__/testing/asserts.ts"`
+project. Rather than importing `"https://deno.land/std@$STD_VERSION/testing/asserts.ts"`
 everywhere, you could create a `deps.ts` file that exports the third-party code:
 
 **deps.ts**
@@ -67,7 +67,7 @@ export {
   assert,
   assertEquals,
   assertStrContains,
-} from "https://deno.land/std@__STD_VERSION__/testing/asserts.ts";
+} from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 ```
 
 And throughout the same project, you can import from the `deps.ts` and avoid

--- a/docs/linking_to_external_code.md
+++ b/docs/linking_to_external_code.md
@@ -7,7 +7,7 @@ directly from URLs. This example uses a URL to import an assertion library:
 **test.ts**
 
 ```ts
-import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@__STD_VERSION__/testing/asserts.ts";
 
 assertEquals("hello", "hello");
 assertEquals("world", "world");
@@ -20,9 +20,9 @@ Try running this:
 ```shell
 $ deno run test.ts
 Compile file:///mnt/f9/Projects/github.com/denoland/deno/docs/test.ts
-Download https://deno.land/std/testing/asserts.ts
-Download https://deno.land/std/fmt/colors.ts
-Download https://deno.land/std/testing/diff.ts
+Download https://deno.land/std@__STD_VERSION__/testing/asserts.ts
+Download https://deno.land/std@__STD_VERSION__/fmt/colors.ts
+Download https://deno.land/std@__STD_VERSION__/testing/diff.ts
 Asserted! ✓
 ```
 
@@ -57,7 +57,7 @@ being run: `https://unpkg.com/liltest@0.0.5/dist/liltest.js`.
 The solution is to import and re-export your external libraries in a central
 `deps.ts` file (which serves the same purpose as Node's `package.json` file).
 For example, let's say you were using the above assertion library across a large
-project. Rather than importing `"https://deno.land/std/testing/asserts.ts"`
+project. Rather than importing `"https://deno.land/std@__STD_VERSION__/testing/asserts.ts"`
 everywhere, you could create a `deps.ts` file that exports the third-party code:
 
 **deps.ts**
@@ -67,7 +67,7 @@ export {
   assert,
   assertEquals,
   assertStrContains,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@__STD_VERSION__/testing/asserts.ts";
 ```
 
 And throughout the same project, you can import from the `deps.ts` and avoid

--- a/docs/linking_to_external_code.md
+++ b/docs/linking_to_external_code.md
@@ -57,8 +57,9 @@ being run: `https://unpkg.com/liltest@0.0.5/dist/liltest.js`.
 The solution is to import and re-export your external libraries in a central
 `deps.ts` file (which serves the same purpose as Node's `package.json` file).
 For example, let's say you were using the above assertion library across a large
-project. Rather than importing `"https://deno.land/std@$STD_VERSION/testing/asserts.ts"`
-everywhere, you could create a `deps.ts` file that exports the third-party code:
+project. Rather than importing
+`"https://deno.land/std@$STD_VERSION/testing/asserts.ts"` everywhere, you could
+create a `deps.ts` file that exports the third-party code:
 
 **deps.ts**
 

--- a/docs/linking_to_external_code/import_maps.md
+++ b/docs/linking_to_external_code/import_maps.md
@@ -21,7 +21,7 @@ Example:
 ```js
 {
    "imports": {
-      "fmt/": "https://deno.land/std@0.55.0/fmt/"
+      "fmt/": "https://deno.land/std@__STD_VERSION__/fmt/"
    }
 }
 ```

--- a/docs/linking_to_external_code/import_maps.md
+++ b/docs/linking_to_external_code/import_maps.md
@@ -21,7 +21,7 @@ Example:
 ```js
 {
    "imports": {
-      "fmt/": "https://deno.land/std@__STD_VERSION__/fmt/"
+      "fmt/": "https://deno.land/std@$STD_VERSION/fmt/"
    }
 }
 ```

--- a/docs/linking_to_external_code/integrity_checking.md
+++ b/docs/linking_to_external_code/integrity_checking.md
@@ -25,9 +25,9 @@ dependency:
 
 ```json
 {
-  "https://deno.land/std@v0.50.0/textproto/mod.ts": "3118d7a42c03c242c5a49c2ad91c8396110e14acca1324e7aaefd31a999b71a4",
-  "https://deno.land/std@v0.50.0/io/util.ts": "ae133d310a0fdcf298cea7bc09a599c49acb616d34e148e263bcb02976f80dee",
-  "https://deno.land/std@v0.50.0/async/delay.ts": "35957d585a6e3dd87706858fb1d6b551cb278271b03f52c5a2cb70e65e00c26a",
+  "https://deno.land/std@__STD_VERSION__/textproto/mod.ts": "3118d7a42c03c242c5a49c2ad91c8396110e14acca1324e7aaefd31a999b71a4",
+  "https://deno.land/std@__STD_VERSION__/io/util.ts": "ae133d310a0fdcf298cea7bc09a599c49acb616d34e148e263bcb02976f80dee",
+  "https://deno.land/std@__STD_VERSION__/async/delay.ts": "35957d585a6e3dd87706858fb1d6b551cb278271b03f52c5a2cb70e65e00c26a",
    ...
 }
 ```

--- a/docs/linking_to_external_code/integrity_checking.md
+++ b/docs/linking_to_external_code/integrity_checking.md
@@ -25,9 +25,9 @@ dependency:
 
 ```json
 {
-  "https://deno.land/std@__STD_VERSION__/textproto/mod.ts": "3118d7a42c03c242c5a49c2ad91c8396110e14acca1324e7aaefd31a999b71a4",
-  "https://deno.land/std@__STD_VERSION__/io/util.ts": "ae133d310a0fdcf298cea7bc09a599c49acb616d34e148e263bcb02976f80dee",
-  "https://deno.land/std@__STD_VERSION__/async/delay.ts": "35957d585a6e3dd87706858fb1d6b551cb278271b03f52c5a2cb70e65e00c26a",
+  "https://deno.land/std@$STD_VERSION/textproto/mod.ts": "3118d7a42c03c242c5a49c2ad91c8396110e14acca1324e7aaefd31a999b71a4",
+  "https://deno.land/std@$STD_VERSION/io/util.ts": "ae133d310a0fdcf298cea7bc09a599c49acb616d34e148e263bcb02976f80dee",
+  "https://deno.land/std@$STD_VERSION/async/delay.ts": "35957d585a6e3dd87706858fb1d6b551cb278271b03f52c5a2cb70e65e00c26a",
    ...
 }
 ```

--- a/docs/linking_to_external_code/reloading_modules.md
+++ b/docs/linking_to_external_code/reloading_modules.md
@@ -17,17 +17,17 @@ deno cache --reload my_module.ts
 Sometimes we want to upgrade only some modules. You can control it by passing an
 argument to a `--reload` flag.
 
-To reload all v0.55.0 standard modules
+To reload all **STD_VERSION** standard modules
 
 ```ts
-deno cache --reload=https://deno.land/std@v0.55.0 my_module.ts
+deno cache --reload=https://deno.land/std@__STD_VERSION__ my_module.ts
 ```
 
 To reload specific modules (in this example - colors and file system copy) use a
 comma to separate URLs
 
 ```ts
-deno cache --reload=https://deno.land/std/fs/copy.ts,https://deno.land/std/fmt/colors.ts my_module.ts
+deno cache --reload=https://deno.land/std@__STD_VERSION__/fs/copy.ts,https://deno.land/std@__STD_VERSION__/fmt/colors.ts my_module.ts
 ```
 
 <!-- Should this be part of examples? -->

--- a/docs/linking_to_external_code/reloading_modules.md
+++ b/docs/linking_to_external_code/reloading_modules.md
@@ -17,17 +17,17 @@ deno cache --reload my_module.ts
 Sometimes we want to upgrade only some modules. You can control it by passing an
 argument to a `--reload` flag.
 
-To reload all **STD_VERSION** standard modules
+To reload all \$STD_VERSION standard modules
 
 ```ts
-deno cache --reload=https://deno.land/std@__STD_VERSION__ my_module.ts
+deno cache --reload=https://deno.land/std@$STD_VERSION my_module.ts
 ```
 
 To reload specific modules (in this example - colors and file system copy) use a
 comma to separate URLs
 
 ```ts
-deno cache --reload=https://deno.land/std@__STD_VERSION__/fs/copy.ts,https://deno.land/std@__STD_VERSION__/fmt/colors.ts my_module.ts
+deno cache --reload=https://deno.land/std@$STD_VERSION/fs/copy.ts,https://deno.land/std@$STD_VERSION/fmt/colors.ts my_module.ts
 ```
 
 <!-- Should this be part of examples? -->

--- a/docs/runtime/compiler_apis.md
+++ b/docs/runtime/compiler_apis.md
@@ -48,7 +48,7 @@ could do on the command line. So you could do something like this:
 
 ```ts
 const [diagnostics, emitMap] = await Deno.compile(
-  "https://deno.land/std@$STD_VERSION/examples/welcome.ts"
+  "https://deno.land/std@$STD_VERSION/examples/welcome.ts",
 );
 ```
 
@@ -95,7 +95,7 @@ could do on the command line. So you could do something like this:
 
 ```ts
 const [diagnostics, emit] = await Deno.bundle(
-  "https://deno.land/std@$STD_VERSION/http/server.ts"
+  "https://deno.land/std@$STD_VERSION/http/server.ts",
 );
 ```
 
@@ -151,7 +151,7 @@ const [errors, emitted] = await Deno.compile(
   },
   {
     lib: ["dom", "esnext"],
-  }
+  },
 );
 ```
 
@@ -191,7 +191,7 @@ const [errors, emitted] = await Deno.compile(
   },
   {
     lib: ["dom", "esnext", "deno.ns"],
-  }
+  },
 );
 ```
 

--- a/docs/runtime/compiler_apis.md
+++ b/docs/runtime/compiler_apis.md
@@ -48,7 +48,7 @@ could do on the command line. So you could do something like this:
 
 ```ts
 const [diagnostics, emitMap] = await Deno.compile(
-  "https://deno.land/std/examples/welcome.ts",
+  "https://deno.land/std@__STD_VERSION__/examples/welcome.ts"
 );
 ```
 
@@ -95,7 +95,7 @@ could do on the command line. So you could do something like this:
 
 ```ts
 const [diagnostics, emit] = await Deno.bundle(
-  "https://deno.land/std/http/server.ts",
+  "https://deno.land/std@__STD_VERSION__/http/server.ts"
 );
 ```
 
@@ -151,7 +151,7 @@ const [errors, emitted] = await Deno.compile(
   },
   {
     lib: ["dom", "esnext"],
-  },
+  }
 );
 ```
 
@@ -191,7 +191,7 @@ const [errors, emitted] = await Deno.compile(
   },
   {
     lib: ["dom", "esnext", "deno.ns"],
-  },
+  }
 );
 ```
 

--- a/docs/runtime/compiler_apis.md
+++ b/docs/runtime/compiler_apis.md
@@ -48,7 +48,7 @@ could do on the command line. So you could do something like this:
 
 ```ts
 const [diagnostics, emitMap] = await Deno.compile(
-  "https://deno.land/std@__STD_VERSION__/examples/welcome.ts"
+  "https://deno.land/std@$STD_VERSION/examples/welcome.ts"
 );
 ```
 
@@ -95,7 +95,7 @@ could do on the command line. So you could do something like this:
 
 ```ts
 const [diagnostics, emit] = await Deno.bundle(
-  "https://deno.land/std@__STD_VERSION__/http/server.ts"
+  "https://deno.land/std@$STD_VERSION/http/server.ts"
 );
 ```
 

--- a/docs/standard_library.md
+++ b/docs/standard_library.md
@@ -27,7 +27,7 @@ change:
 
 ```typescript
 // imports from v0.50.0 of std, never changes
-import { copy } from "https://deno.land/std@0.50.0/fs/copy.ts";
+import { copy } from "https://deno.land/std@__STD_VERSION__/fs/copy.ts";
 ```
 
 ## Troubleshooting
@@ -40,7 +40,7 @@ exist:
 
 ```typescript
 // main.ts
-import { copy } from "https://deno.land/std@0.50.0/fs/copy.ts";
+import { copy } from "https://deno.land/std@__STD_VERSION__/fs/copy.ts";
 
 copy("log.txt", "log-old.txt");
 ```
@@ -48,18 +48,18 @@ copy("log.txt", "log-old.txt");
 ```shell
 $ deno run --allow-read --allow-write main.ts
 Compile file:///dev/deno/main.ts
-Download https://deno.land/std@0.50.0/fs/copy.ts
-Download https://deno.land/std@0.50.0/fs/ensure_dir.ts
-Download https://deno.land/std@0.50.0/fs/_util.ts
+Download https://deno.land/std@__STD_VERSION__/fs/copy.ts
+Download https://deno.land/std@__STD_VERSION__/fs/ensure_dir.ts
+Download https://deno.land/std@__STD_VERSION__/fs/_util.ts
 error: TS2339 [ERROR]: Property 'utime' does not exist on type 'typeof Deno'.
     await Deno.utime(dest, statInfo.atime, statInfo.mtime);
                ~~~~~
-    at https://deno.land/std@0.50.0/fs/copy.ts:90:16
+    at https://deno.land/std@__STD_VERSION__/fs/copy.ts:90:16
 
 TS2339 [ERROR]: Property 'utimeSync' does not exist on type 'typeof Deno'.
     Deno.utimeSync(dest, statInfo.atime, statInfo.mtime);
          ~~~~~~~~~
-    at https://deno.land/std@0.50.0/fs/copy.ts:101:10
+    at https://deno.land/std@__STD_VERSION__/fs/copy.ts:101:10
 ```
 
 Solution to that problem requires adding `--unstable` flag:

--- a/docs/standard_library.md
+++ b/docs/standard_library.md
@@ -27,7 +27,7 @@ change:
 
 ```typescript
 // imports from v0.50.0 of std, never changes
-import { copy } from "https://deno.land/std@__STD_VERSION__/fs/copy.ts";
+import { copy } from "https://deno.land/std@$STD_VERSION/fs/copy.ts";
 ```
 
 ## Troubleshooting
@@ -40,7 +40,7 @@ exist:
 
 ```typescript
 // main.ts
-import { copy } from "https://deno.land/std@__STD_VERSION__/fs/copy.ts";
+import { copy } from "https://deno.land/std@$STD_VERSION/fs/copy.ts";
 
 copy("log.txt", "log-old.txt");
 ```
@@ -48,18 +48,18 @@ copy("log.txt", "log-old.txt");
 ```shell
 $ deno run --allow-read --allow-write main.ts
 Compile file:///dev/deno/main.ts
-Download https://deno.land/std@__STD_VERSION__/fs/copy.ts
-Download https://deno.land/std@__STD_VERSION__/fs/ensure_dir.ts
-Download https://deno.land/std@__STD_VERSION__/fs/_util.ts
+Download https://deno.land/std@$STD_VERSION/fs/copy.ts
+Download https://deno.land/std@$STD_VERSION/fs/ensure_dir.ts
+Download https://deno.land/std@$STD_VERSION/fs/_util.ts
 error: TS2339 [ERROR]: Property 'utime' does not exist on type 'typeof Deno'.
     await Deno.utime(dest, statInfo.atime, statInfo.mtime);
                ~~~~~
-    at https://deno.land/std@__STD_VERSION__/fs/copy.ts:90:16
+    at https://deno.land/std@$STD_VERSION/fs/copy.ts:90:16
 
 TS2339 [ERROR]: Property 'utimeSync' does not exist on type 'typeof Deno'.
     Deno.utimeSync(dest, statInfo.atime, statInfo.mtime);
          ~~~~~~~~~
-    at https://deno.land/std@__STD_VERSION__/fs/copy.ts:101:10
+    at https://deno.land/std@$STD_VERSION/fs/copy.ts:101:10
 ```
 
 Solution to that problem requires adding `--unstable` flag:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,8 +27,8 @@ Deno.test({
 
 ## Assertions
 
-There are some useful assertion utilities at https://deno.land/std@$STD_VERSION/testing#usage
-to make testing easier:
+There are some useful assertion utilities at
+https://deno.land/std@$STD_VERSION/testing#usage to make testing easier:
 
 ```ts
 import {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,14 +27,14 @@ Deno.test({
 
 ## Assertions
 
-There are some useful assertion utilities at https://deno.land/std@__STD_VERSION__/testing#usage
+There are some useful assertion utilities at https://deno.land/std@$STD_VERSION/testing#usage
 to make testing easier:
 
 ```ts
 import {
   assertEquals,
   assertArrayContains,
-} from "https://deno.land/std@__STD_VERSION__/testing/asserts.ts";
+} from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 
 Deno.test("hello world", () => {
   const x = 1 + 2;
@@ -49,7 +49,7 @@ You can also test asynchronous code by passing a test function that returns a
 promise. For this you can use the `async` keyword when defining a function:
 
 ```ts
-import { delay } from "https://deno.land/std@__STD_VERSION__/async/delay.ts";
+import { delay } from "https://deno.land/std@$STD_VERSION/async/delay.ts";
 
 Deno.test("async hello world", async () => {
   const x = 1 + 2;

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,14 +27,14 @@ Deno.test({
 
 ## Assertions
 
-There are some useful assertion utilities at https://deno.land/std/testing#usage
+There are some useful assertion utilities at https://deno.land/std@__STD_VERSION__/testing#usage
 to make testing easier:
 
 ```ts
 import {
   assertEquals,
   assertArrayContains,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@__STD_VERSION__/testing/asserts.ts";
 
 Deno.test("hello world", () => {
   const x = 1 + 2;
@@ -49,7 +49,7 @@ You can also test asynchronous code by passing a test function that returns a
 promise. For this you can use the `async` keyword when defining a function:
 
 ```ts
-import { delay } from "https://deno.land/std/async/delay.ts";
+import { delay } from "https://deno.land/std@__STD_VERSION__/async/delay.ts";
 
 Deno.test("async hello world", async () => {
   const x = 1 + 2;

--- a/docs/testing/assertions.md
+++ b/docs/testing/assertions.md
@@ -1,11 +1,11 @@
 ## Assertions
 
 To help developers write tests the Deno standard library comes with a built in
-[assertions module](https://deno.land/std@__STD_VERSION__/testing/asserts.ts) which can be
-imported from `https://deno.land/std@__STD_VERSION__/testing/asserts.ts`.
+[assertions module](https://deno.land/std@$STD_VERSION/testing/asserts.ts) which can be
+imported from `https://deno.land/std@$STD_VERSION/testing/asserts.ts`.
 
 ```js
-import { assert } from "https://deno.land/std@__STD_VERSION__/testing/asserts.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 
 Deno.test("Hello Test", () => {
   assert("Hello");

--- a/docs/testing/assertions.md
+++ b/docs/testing/assertions.md
@@ -1,11 +1,11 @@
 ## Assertions
 
 To help developers write tests the Deno standard library comes with a built in
-[assertions module](https://deno.land/std/testing/asserts.ts) which can be
-imported from `https://deno.land/std/testing/asserts.ts`.
+[assertions module](https://deno.land/std@__STD_VERSION__/testing/asserts.ts) which can be
+imported from `https://deno.land/std@__STD_VERSION__/testing/asserts.ts`.
 
 ```js
-import { assert } from "https://deno.land/std/testing/asserts.ts";
+import { assert } from "https://deno.land/std@__STD_VERSION__/testing/asserts.ts";
 
 Deno.test("Hello Test", () => {
   assert("Hello");
@@ -150,7 +150,7 @@ Deno.test("Test Assert Throws", () => {
       throw new Error("Panic!");
     },
     Error,
-    "Panic!",
+    "Panic!"
   );
 });
 ```
@@ -168,7 +168,7 @@ Deno.test("Test Assert Throws Async", () => {
       });
     },
     Error,
-    "Panic! Threw Error",
+    "Panic! Threw Error"
   );
 
   assertThrowsAsync(
@@ -176,7 +176,7 @@ Deno.test("Test Assert Throws Async", () => {
       return Promise.reject(new Error("Panic! Reject Error"));
     },
     Error,
-    "Panic! Reject Error",
+    "Panic! Reject Error"
   );
 });
 ```

--- a/docs/testing/assertions.md
+++ b/docs/testing/assertions.md
@@ -1,8 +1,8 @@
 ## Assertions
 
 To help developers write tests the Deno standard library comes with a built in
-[assertions module](https://deno.land/std@$STD_VERSION/testing/asserts.ts) which can be
-imported from `https://deno.land/std@$STD_VERSION/testing/asserts.ts`.
+[assertions module](https://deno.land/std@$STD_VERSION/testing/asserts.ts) which
+can be imported from `https://deno.land/std@$STD_VERSION/testing/asserts.ts`.
 
 ```js
 import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
@@ -150,7 +150,7 @@ Deno.test("Test Assert Throws", () => {
       throw new Error("Panic!");
     },
     Error,
-    "Panic!"
+    "Panic!",
   );
 });
 ```
@@ -168,7 +168,7 @@ Deno.test("Test Assert Throws Async", () => {
       });
     },
     Error,
-    "Panic! Threw Error"
+    "Panic! Threw Error",
   );
 
   assertThrowsAsync(
@@ -176,7 +176,7 @@ Deno.test("Test Assert Throws Async", () => {
       return Promise.reject(new Error("Panic! Reject Error"));
     },
     Error,
-    "Panic! Reject Error"
+    "Panic! Reject Error",
   );
 });
 ```

--- a/docs/tools/bundler.md
+++ b/docs/tools/bundler.md
@@ -4,7 +4,7 @@
 dependencies of the specified input. For example:
 
 ```
-> deno bundle https://deno.land/std@__STD_VERSION__/examples/colors.ts colors.bundle.js
+> deno bundle https://deno.land/std@$STD_VERSION/examples/colors.ts colors.bundle.js
 Bundling "colors.bundle.js"
 Emitting bundle to "colors.bundle.js"
 9.2 kB emitted.

--- a/docs/tools/bundler.md
+++ b/docs/tools/bundler.md
@@ -4,7 +4,7 @@
 dependencies of the specified input. For example:
 
 ```
-> deno bundle https://deno.land/std/examples/colors.ts colors.bundle.js
+> deno bundle https://deno.land/std@__STD_VERSION__/examples/colors.ts colors.bundle.js
 Bundling "colors.bundle.js"
 Emitting bundle to "colors.bundle.js"
 9.2 kB emitted.

--- a/docs/tools/debugger.md
+++ b/docs/tools/debugger.md
@@ -15,16 +15,16 @@ the first line of code.
 ### Chrome Devtools
 
 Let's try debugging a program using Chrome Devtools. For this, we'll use
-[file_server.ts](https://deno.land/std@v0.50.0/http/file_server.ts) from `std`,
+[file_server.ts](https://deno.land/std@__STD_VERSION__/http/file_server.ts) from `std`,
 a static file server.
 
 Use the `--inspect-brk` flag to break execution on the first line:
 
 ```shell
-$ deno run --inspect-brk --allow-read --allow-net https://deno.land/std@v0.50.0/http/file_server.ts
+$ deno run --inspect-brk --allow-read --allow-net https://deno.land/std@__STD_VERSION__/http/file_server.ts
 Debugger listening on ws://127.0.0.1:9229/ws/1e82c406-85a9-44ab-86b6-7341583480b1
-Download https://deno.land/std@v0.50.0/http/file_server.ts
-Compile https://deno.land/std@v0.50.0/http/file_server.ts
+Download https://deno.land/std@__STD_VERSION__/http/file_server.ts
+Compile https://deno.land/std@__STD_VERSION__/http/file_server.ts
 ...
 ```
 
@@ -110,7 +110,7 @@ with a script name if you want a fixed entry point.
 Let's try out debugging a local source file. Create `server.ts`:
 
 ```ts
-import { serve } from "https://deno.land/std@v0.50.0/http/server.ts";
+import { serve } from "https://deno.land/std@__STD_VERSION__/http/server.ts";
 const server = serve({ port: 8000 });
 console.log("http://localhost:8000/");
 

--- a/docs/tools/debugger.md
+++ b/docs/tools/debugger.md
@@ -15,8 +15,8 @@ the first line of code.
 ### Chrome Devtools
 
 Let's try debugging a program using Chrome Devtools. For this, we'll use
-[file_server.ts](https://deno.land/std@$STD_VERSION/http/file_server.ts) from `std`,
-a static file server.
+[file_server.ts](https://deno.land/std@$STD_VERSION/http/file_server.ts) from
+`std`, a static file server.
 
 Use the `--inspect-brk` flag to break execution on the first line:
 

--- a/docs/tools/debugger.md
+++ b/docs/tools/debugger.md
@@ -15,16 +15,16 @@ the first line of code.
 ### Chrome Devtools
 
 Let's try debugging a program using Chrome Devtools. For this, we'll use
-[file_server.ts](https://deno.land/std@__STD_VERSION__/http/file_server.ts) from `std`,
+[file_server.ts](https://deno.land/std@$STD_VERSION/http/file_server.ts) from `std`,
 a static file server.
 
 Use the `--inspect-brk` flag to break execution on the first line:
 
 ```shell
-$ deno run --inspect-brk --allow-read --allow-net https://deno.land/std@__STD_VERSION__/http/file_server.ts
+$ deno run --inspect-brk --allow-read --allow-net https://deno.land/std@$STD_VERSION/http/file_server.ts
 Debugger listening on ws://127.0.0.1:9229/ws/1e82c406-85a9-44ab-86b6-7341583480b1
-Download https://deno.land/std@__STD_VERSION__/http/file_server.ts
-Compile https://deno.land/std@__STD_VERSION__/http/file_server.ts
+Download https://deno.land/std@$STD_VERSION/http/file_server.ts
+Compile https://deno.land/std@$STD_VERSION/http/file_server.ts
 ...
 ```
 
@@ -110,7 +110,7 @@ with a script name if you want a fixed entry point.
 Let's try out debugging a local source file. Create `server.ts`:
 
 ```ts
-import { serve } from "https://deno.land/std@__STD_VERSION__/http/server.ts";
+import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
 const server = serve({ port: 8000 });
 console.log("http://localhost:8000/");
 

--- a/docs/tools/script_installer.md
+++ b/docs/tools/script_installer.md
@@ -12,8 +12,8 @@ the specified CLI flags and main module. It is placed in the installation root's
 Example:
 
 ```shell
-$ deno install --allow-net --allow-read https://deno.land/std@__STD_VERSION__/http/file_server.ts
-[1/1] Compiling https://deno.land/std@__STD_VERSION__/http/file_server.ts
+$ deno install --allow-net --allow-read https://deno.land/std@$STD_VERSION/http/file_server.ts
+[1/1] Compiling https://deno.land/std@$STD_VERSION/http/file_server.ts
 
 ✅ Successfully installed file_server.
 /Users/deno/.deno/bin/file_server
@@ -22,7 +22,7 @@ $ deno install --allow-net --allow-read https://deno.land/std@__STD_VERSION__/ht
 To change the executable name, use `-n`/`--name`:
 
 ```shell
-deno install --allow-net --allow-read -n serve https://deno.land/std@__STD_VERSION__/http/file_server.ts
+deno install --allow-net --allow-read -n serve https://deno.land/std@$STD_VERSION/http/file_server.ts
 ```
 
 The executable name is inferred by default:
@@ -36,7 +36,7 @@ The executable name is inferred by default:
 To change the installation root, use `--root`:
 
 ```shell
-deno install --allow-net --allow-read --root /usr/local https://deno.land/std@__STD_VERSION__/http/file_server.ts
+deno install --allow-net --allow-read --root /usr/local https://deno.land/std@$STD_VERSION/http/file_server.ts
 ```
 
 The installation root is determined, in order of precedence:
@@ -55,7 +55,7 @@ You must specify permissions that will be used to run the script at installation
 time.
 
 ```shell
-deno install --allow-net --allow-read https://deno.land/std@__STD_VERSION__/http/file_server.ts -p 8080
+deno install --allow-net --allow-read https://deno.land/std@$STD_VERSION/http/file_server.ts -p 8080
 ```
 
 The above command creates an executable called `file_server` that runs with

--- a/docs/tools/script_installer.md
+++ b/docs/tools/script_installer.md
@@ -12,8 +12,8 @@ the specified CLI flags and main module. It is placed in the installation root's
 Example:
 
 ```shell
-$ deno install --allow-net --allow-read https://deno.land/std/http/file_server.ts
-[1/1] Compiling https://deno.land/std/http/file_server.ts
+$ deno install --allow-net --allow-read https://deno.land/std@__STD_VERSION__/http/file_server.ts
+[1/1] Compiling https://deno.land/std@__STD_VERSION__/http/file_server.ts
 
 ✅ Successfully installed file_server.
 /Users/deno/.deno/bin/file_server
@@ -22,7 +22,7 @@ $ deno install --allow-net --allow-read https://deno.land/std/http/file_server.t
 To change the executable name, use `-n`/`--name`:
 
 ```shell
-deno install --allow-net --allow-read -n serve https://deno.land/std/http/file_server.ts
+deno install --allow-net --allow-read -n serve https://deno.land/std@__STD_VERSION__/http/file_server.ts
 ```
 
 The executable name is inferred by default:
@@ -36,7 +36,7 @@ The executable name is inferred by default:
 To change the installation root, use `--root`:
 
 ```shell
-deno install --allow-net --allow-read --root /usr/local https://deno.land/std/http/file_server.ts
+deno install --allow-net --allow-read --root /usr/local https://deno.land/std@__STD_VERSION__/http/file_server.ts
 ```
 
 The installation root is determined, in order of precedence:
@@ -55,7 +55,7 @@ You must specify permissions that will be used to run the script at installation
 time.
 
 ```shell
-deno install --allow-net --allow-read https://deno.land/std/http/file_server.ts -p 8080
+deno install --allow-net --allow-read https://deno.land/std@__STD_VERSION__/http/file_server.ts -p 8080
 ```
 
 The above command creates an executable called `file_server` that runs with


### PR DESCRIPTION
This locks all std dependencies in the docs `@$STD_VERSION`. This string is replaced by the correct version for a release on the website. Ref https://github.com/denoland/deno_website2/pull/1388

Towards #6844 