### PR TITLE
upgrade: deno_lint, dprint, swc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,8 @@ dependencies = [
 [[package]]
 name = "deno_lint"
 version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e2a1067a263cd8cbf75d115c253a152263f67da33711eaafce48132068c1b8"
 dependencies = [
  "lazy_static",
  "log 0.4.11",
@@ -523,6 +525,8 @@ dependencies = [
 [[package]]
 name = "dprint-plugin-typescript"
 version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41224324bd4b71daccb03fd971c38939999cd3115cd705cfb4d44b930cc91dc7"
 dependencies = [
  "dprint-core",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ dependencies = [
  "deno_lint",
  "dissimilar",
  "dlopen",
+ "dprint-plugin-typescript",
  "futures",
  "fwdansi",
  "http",
@@ -406,8 +407,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sourcemap",
- "swc_ecma_codegen",
- "swc_ecma_transforms",
+ "swc_common",
+ "swc_ecmascript",
  "sys-info",
  "tempfile",
  "termcolor",
@@ -445,16 +446,14 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdf386c931a0c09550f80ea3ac6c59e115d3e8c2cffb5e196d4cda1aeff690c"
+version = "0.1.20"
 dependencies = [
- "dprint-plugin-typescript",
  "lazy_static",
  "log 0.4.11",
  "regex",
  "swc_atoms",
- "swc_ecma_visit",
+ "swc_common",
+ "swc_ecmascript",
 ]
 
 [[package]]
@@ -523,16 +522,13 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afab3ed9d8240f14f68e05ccf200dd6034a8bb55fcf0e945f775030d0fca78fa"
+version = "0.25.0"
 dependencies = [
  "dprint-core",
  "serde",
  "serde_json",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_ecmascript",
 ]
 
 [[package]]
@@ -2188,14 +2184,12 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6dfaba645cbfc03f574d154f800952e27f0176d91e24a7c9d3917f1afde7d12"
+checksum = "1063f58571575abc923955abdca528e007cd5a8036dcb9cdbd6c81754590c49a"
 dependencies = [
  "ast_node",
- "atty",
  "cfg-if",
- "dashmap",
  "either",
  "from_variant",
  "fxhash",
@@ -2204,17 +2198,15 @@ dependencies = [
  "scoped-tls 1.0.0",
  "serde",
  "sourcemap",
- "string_cache",
  "swc_visit",
- "termcolor",
  "unicode-width",
 ]
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcdd53f72ccc81568bcf789f9aeaa065588705ab46113e9f6ba4014f8829f5d"
+checksum = "f4d07502831a92f8f0825fc35821ef02a6f47fa348f2b9f73366948517a2648b"
 dependencies = [
  "enum_kind",
  "is-macro",
@@ -2227,9 +2219,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d48467780147af9075def6d7c75198af57e1b74ad28e8508850974be785f8cd"
+checksum = "ebcf7baf25a6263cd03b5d53bfebf933a37aecf98290bf1ecd044f7d484a60ee"
 dependencies = [
  "bitflags",
  "num-bigint",
@@ -2255,16 +2247,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9226cca2e6d482ffe48be00b83c9745b9e574d6d5833e1e3735837a502784af9"
+checksum = "666f4248ee286eac1037d4427ed802f16da131f4eba3f83f2a44f0c3cd84411c"
 dependencies = [
  "either",
  "enum_kind",
+ "fxhash",
  "log 0.4.11",
  "num-bigint",
- "once_cell",
- "regex",
  "serde",
  "smallvec 1.4.1",
  "swc_atoms",
@@ -2290,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37a55159354623098b9a54893d26c655109833df807d846c54e34103a349a4f"
+checksum = "55eb1141303c30c832ad86c91bd993ed5de543bafd8130e1cf0078bc52258dba"
 dependencies = [
  "Inflector",
  "arrayvec",
@@ -2320,31 +2311,43 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229c983a8e263edaf1b8ec5b79d92664d158303cc1fa4bff93690b6a2585e668"
+checksum = "9d43744f8636967eadeae9902597e6f6919f9c23700cc731188795ecaece365d"
 dependencies = [
  "once_cell",
  "scoped-tls 1.0.0",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_parser",
  "swc_ecma_visit",
  "unicode-xid 0.2.1",
 ]
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9516e5e423776d9ee88628b0caef0bcdab1aacf3e33469b7fc4fdfb9aa7e1617"
+checksum = "a89d1b439c0db9a3df486c32dbd6754c0d0f6a9cef5b8d9f2bf4c46698ffcf12"
 dependencies = [
  "num-bigint",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_visit",
+]
+
+[[package]]
+name = "swc_ecmascript"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc49662be9e1203d7d95a84468a5f982bf5a7d7f6b02d19b2121f63a3ad4841"
+dependencies = [
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms",
+ "swc_ecma_visit",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ winapi = "0.3.8"
 
 [dependencies]
 deno_core = { path = "../core", version = "0.50.0" }
-deno_lint = { version = "0.1.20", path = "../../dlint" }
+deno_lint = "0.1.20"
 
 atty = "0.2.14"
 base64 = "0.12.2"
@@ -32,7 +32,7 @@ byteorder = "1.3.4"
 clap = "2.33.1"
 dissimilar = "1.0.2"
 dlopen = "0.1.8"
-dprint-plugin-typescript = { version = "0.25.0", path = "../../dprint-plugin-typescript" }
+dprint-plugin-typescript = "0.25.0"
 futures = "0.3.5"
 http = "0.2.1"
 idna = "0.2.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ winapi = "0.3.8"
 
 [dependencies]
 deno_core = { path = "../core", version = "0.50.0" }
-deno_lint = "0.1.19"
+deno_lint = { version = "0.1.20", path = "../../dlint" }
 
 atty = "0.2.14"
 base64 = "0.12.2"
@@ -32,6 +32,7 @@ byteorder = "1.3.4"
 clap = "2.33.1"
 dissimilar = "1.0.2"
 dlopen = "0.1.8"
+dprint-plugin-typescript = { version = "0.25.0", path = "../../dprint-plugin-typescript" }
 futures = "0.3.5"
 http = "0.2.1"
 idna = "0.2.0"
@@ -50,8 +51,8 @@ serde_derive = "1.0.112"
 serde_json = { version = "1.0.55", features = [ "preserve_order" ] }
 sys-info = "0.7.0"
 sourcemap = "6.0.0"
-swc_ecma_transforms = "=0.16.0"
-swc_ecma_codegen = "=0.29.1"
+swc_common = { version = "=0.8.0", features = ["sourcemap"] }
+swc_ecmascript = { version = "=0.1.0", features = ["codegen", "parser", "transforms", "visit"] }
 tempfile = "3.1.0"
 termcolor = "1.1.0"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/cli/doc/class.rs
+++ b/cli/doc/class.rs
@@ -5,8 +5,8 @@ use crate::doc::display::{
   display_method, display_optional, display_readonly, display_static,
   SliceDisplayer,
 };
-use swc_common::Spanned;
 use serde::Serialize;
+use swc_common::Spanned;
 
 use super::function::function_to_function_def;
 use super::function::FunctionDef;

--- a/cli/doc/class.rs
+++ b/cli/doc/class.rs
@@ -5,8 +5,7 @@ use crate::doc::display::{
   display_method, display_optional, display_readonly, display_static,
   SliceDisplayer,
 };
-use crate::swc_common::Spanned;
-use crate::swc_ecma_ast;
+use swc_common::Spanned;
 use serde::Serialize;
 
 use super::function::function_to_function_def;
@@ -31,7 +30,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 #[serde(rename_all = "camelCase")]
 pub struct ClassConstructorDef {
   pub js_doc: Option<String>,
-  pub accessibility: Option<swc_ecma_ast::Accessibility>,
+  pub accessibility: Option<swc_ecmascript::ast::Accessibility>,
   pub name: String,
   pub params: Vec<ParamDef>,
   pub location: Location,
@@ -55,7 +54,7 @@ pub struct ClassPropertyDef {
   pub js_doc: Option<String>,
   pub ts_type: Option<TsTypeDef>,
   pub readonly: bool,
-  pub accessibility: Option<swc_ecma_ast::Accessibility>,
+  pub accessibility: Option<swc_ecmascript::ast::Accessibility>,
   pub optional: bool,
   pub is_abstract: bool,
   pub is_static: bool,
@@ -109,12 +108,12 @@ impl Display for ClassIndexSignatureDef {
 #[serde(rename_all = "camelCase")]
 pub struct ClassMethodDef {
   pub js_doc: Option<String>,
-  pub accessibility: Option<swc_ecma_ast::Accessibility>,
+  pub accessibility: Option<swc_ecmascript::ast::Accessibility>,
   pub optional: bool,
   pub is_abstract: bool,
   pub is_static: bool,
   pub name: String,
-  pub kind: swc_ecma_ast::MethodKind,
+  pub kind: swc_ecmascript::ast::MethodKind,
   pub function_def: FunctionDef,
   pub location: Location,
 }
@@ -158,7 +157,7 @@ pub struct ClassDef {
 
 pub fn class_to_class_def(
   doc_parser: &DocParser,
-  class: &swc_ecma_ast::Class,
+  class: &swc_ecmascript::ast::Class,
 ) -> ClassDef {
   let mut constructors = vec![];
   let mut methods = vec![];
@@ -167,7 +166,7 @@ pub fn class_to_class_def(
 
   let extends: Option<String> = match &class.super_class {
     Some(boxed) => {
-      use crate::swc_ecma_ast::Expr;
+      use swc_ecmascript::ast::Expr;
       let expr: &Expr = &**boxed;
       match expr {
         Expr::Ident(ident) => Some(ident.sym.to_string()),
@@ -184,7 +183,7 @@ pub fn class_to_class_def(
     .collect::<Vec<TsTypeDef>>();
 
   for member in &class.body {
-    use crate::swc_ecma_ast::ClassMember::*;
+    use swc_ecmascript::ast::ClassMember::*;
 
     match member {
       Constructor(ctor) => {
@@ -197,7 +196,7 @@ pub fn class_to_class_def(
         let mut params = vec![];
 
         for param in &ctor.params {
-          use crate::swc_ecma_ast::ParamOrTsParamProp::*;
+          use swc_ecmascript::ast::ParamOrTsParamProp::*;
 
           let param_def = match param {
             Param(param) => pat_to_param_def(
@@ -205,7 +204,7 @@ pub fn class_to_class_def(
               Some(&doc_parser.ast_parser.source_map),
             ),
             TsParamProp(ts_param_prop) => {
-              use swc_ecma_ast::TsParamPropParam;
+              use swc_ecmascript::ast::TsParamPropParam;
 
               match &ts_param_prop.param {
                 TsParamPropParam::Ident(ident) => ident_to_param_def(
@@ -331,7 +330,7 @@ pub fn class_to_class_def(
 
 pub fn get_doc_for_class_decl(
   doc_parser: &DocParser,
-  class_decl: &swc_ecma_ast::ClassDecl,
+  class_decl: &swc_ecmascript::ast::ClassDecl,
 ) -> (String, ClassDef) {
   let class_name = class_decl.ident.sym.to_string();
   let class_def = class_to_class_def(doc_parser, &class_decl.class);

--- a/cli/doc/display.rs
+++ b/cli/doc/display.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::colors;
-use crate::swc_ecma_ast;
 use std::fmt::{Display, Formatter, Result};
 
 pub(crate) struct Indent(pub i64);
@@ -50,13 +49,13 @@ pub(crate) fn display_abstract(is_abstract: bool) -> impl Display {
 }
 
 pub(crate) fn display_accessibility(
-  accessibility: Option<swc_ecma_ast::Accessibility>,
+  accessibility: Option<swc_ecmascript::ast::Accessibility>,
 ) -> impl Display {
   colors::magenta(
-    match accessibility.unwrap_or(swc_ecma_ast::Accessibility::Public) {
-      swc_ecma_ast::Accessibility::Public => "",
-      swc_ecma_ast::Accessibility::Protected => "protected ",
-      swc_ecma_ast::Accessibility::Private => "private ",
+    match accessibility.unwrap_or(swc_ecmascript::ast::Accessibility::Public) {
+      swc_ecmascript::ast::Accessibility::Public => "",
+      swc_ecmascript::ast::Accessibility::Protected => "protected ",
+      swc_ecmascript::ast::Accessibility::Private => "private ",
     },
   )
 }
@@ -69,10 +68,10 @@ pub(crate) fn display_generator(is_generator: bool) -> impl Display {
   colors::magenta(if is_generator { "*" } else { "" })
 }
 
-pub(crate) fn display_method(method: swc_ecma_ast::MethodKind) -> impl Display {
+pub(crate) fn display_method(method: swc_ecmascript::ast::MethodKind) -> impl Display {
   colors::magenta(match method {
-    swc_ecma_ast::MethodKind::Getter => "get ",
-    swc_ecma_ast::MethodKind::Setter => "set ",
+    swc_ecmascript::ast::MethodKind::Getter => "get ",
+    swc_ecmascript::ast::MethodKind::Setter => "set ",
     _ => "",
   })
 }

--- a/cli/doc/display.rs
+++ b/cli/doc/display.rs
@@ -68,7 +68,9 @@ pub(crate) fn display_generator(is_generator: bool) -> impl Display {
   colors::magenta(if is_generator { "*" } else { "" })
 }
 
-pub(crate) fn display_method(method: swc_ecmascript::ast::MethodKind) -> impl Display {
+pub(crate) fn display_method(
+  method: swc_ecmascript::ast::MethodKind,
+) -> impl Display {
   colors::magenta(match method {
     swc_ecmascript::ast::MethodKind::Getter => "get ",
     swc_ecmascript::ast::MethodKind::Setter => "set ",

--- a/cli/doc/enum.rs
+++ b/cli/doc/enum.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use crate::swc_ecma_ast;
 use serde::Serialize;
 
 use super::parser::DocParser;
@@ -18,13 +17,13 @@ pub struct EnumDef {
 
 pub fn get_doc_for_ts_enum_decl(
   _doc_parser: &DocParser,
-  enum_decl: &swc_ecma_ast::TsEnumDecl,
+  enum_decl: &swc_ecmascript::ast::TsEnumDecl,
 ) -> (String, EnumDef) {
   let enum_name = enum_decl.id.sym.to_string();
   let mut members = vec![];
 
   for enum_member in &enum_decl.members {
-    use crate::swc_ecma_ast::TsEnumMemberId::*;
+    use swc_ecmascript::ast::TsEnumMemberId::*;
 
     let member_name = match &enum_member.id {
       Ident(ident) => ident.sym.to_string(),

--- a/cli/doc/function.rs
+++ b/cli/doc/function.rs
@@ -6,7 +6,6 @@ use super::ts_type::TsTypeDef;
 use super::ts_type_param::maybe_type_param_decl_to_type_param_defs;
 use super::ts_type_param::TsTypeParamDef;
 use super::ParamDef;
-use crate::swc_ecma_ast;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Clone)]
@@ -22,7 +21,7 @@ pub struct FunctionDef {
 
 pub fn function_to_function_def(
   doc_parser: &DocParser,
-  function: &swc_ecma_ast::Function,
+  function: &swc_ecmascript::ast::Function,
 ) -> FunctionDef {
   let mut params = vec![];
 
@@ -51,7 +50,7 @@ pub fn function_to_function_def(
 
 pub fn get_doc_for_fn_decl(
   doc_parser: &DocParser,
-  fn_decl: &swc_ecma_ast::FnDecl,
+  fn_decl: &swc_ecmascript::ast::FnDecl,
 ) -> (String, FunctionDef) {
   let name = fn_decl.ident.sym.to_string();
   let fn_def = function_to_function_def(&doc_parser, &fn_decl.function);

--- a/cli/doc/interface.rs
+++ b/cli/doc/interface.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::colors;
 use crate::doc::display::{display_optional, display_readonly, SliceDisplayer};
-use crate::swc_ecma_ast;
 use serde::Serialize;
 
 use super::params::ts_fn_param_to_param_def;
@@ -115,9 +114,9 @@ pub struct InterfaceDef {
   pub type_params: Vec<TsTypeParamDef>,
 }
 
-pub fn expr_to_name(expr: &swc_ecma_ast::Expr) -> String {
-  use crate::swc_ecma_ast::Expr::*;
-  use crate::swc_ecma_ast::ExprOrSuper::*;
+pub fn expr_to_name(expr: &swc_ecmascript::ast::Expr) -> String {
+  use swc_ecmascript::ast::Expr::*;
+  use swc_ecmascript::ast::ExprOrSuper::*;
 
   match expr {
     Ident(ident) => ident.sym.to_string(),
@@ -135,7 +134,7 @@ pub fn expr_to_name(expr: &swc_ecma_ast::Expr) -> String {
 
 pub fn get_doc_for_ts_interface_decl(
   doc_parser: &DocParser,
-  interface_decl: &swc_ecma_ast::TsInterfaceDecl,
+  interface_decl: &swc_ecmascript::ast::TsInterfaceDecl,
 ) -> (String, InterfaceDef) {
   let interface_name = interface_decl.id.sym.to_string();
 
@@ -145,7 +144,7 @@ pub fn get_doc_for_ts_interface_decl(
   let mut index_signatures = vec![];
 
   for type_element in &interface_decl.body.body {
-    use crate::swc_ecma_ast::TsTypeElement::*;
+    use swc_ecmascript::ast::TsTypeElement::*;
 
     match &type_element {
       TsMethodSignature(ts_method_sig) => {

--- a/cli/doc/module.rs
+++ b/cli/doc/module.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use crate::swc_common::Spanned;
-use crate::swc_ecma_ast;
+use swc_common::Spanned;
 
 use super::parser::DocParser;
 use super::DocNode;
@@ -8,10 +7,10 @@ use super::DocNodeKind;
 
 pub fn get_doc_node_for_export_decl(
   doc_parser: &DocParser,
-  export_decl: &swc_ecma_ast::ExportDecl,
+  export_decl: &swc_ecmascript::ast::ExportDecl,
 ) -> DocNode {
   let export_span = export_decl.span();
-  use crate::swc_ecma_ast::Decl;
+  use swc_ecmascript::ast::Decl;
 
   let js_doc = doc_parser.js_doc_for_span(export_span);
   let location = doc_parser.ast_parser.get_span_location(export_span).into();

--- a/cli/doc/namespace.rs
+++ b/cli/doc/namespace.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use crate::swc_ecma_ast;
 use serde::Serialize;
 
 use super::parser::DocParser;
@@ -13,7 +12,7 @@ pub struct NamespaceDef {
 
 pub fn get_doc_for_ts_namespace_decl(
   doc_parser: &DocParser,
-  ts_namespace_decl: &swc_ecma_ast::TsNamespaceDecl,
+  ts_namespace_decl: &swc_ecmascript::ast::TsNamespaceDecl,
 ) -> DocNode {
   let js_doc = doc_parser.js_doc_for_span(ts_namespace_decl.span);
   let location = doc_parser
@@ -22,7 +21,7 @@ pub fn get_doc_for_ts_namespace_decl(
     .into();
   let namespace_name = ts_namespace_decl.id.sym.to_string();
 
-  use crate::swc_ecma_ast::TsNamespaceBody::*;
+  use swc_ecmascript::ast::TsNamespaceBody::*;
 
   let elements = match &*ts_namespace_decl.body {
     TsModuleBlock(ts_module_block) => {
@@ -52,16 +51,16 @@ pub fn get_doc_for_ts_namespace_decl(
 
 pub fn get_doc_for_ts_module(
   doc_parser: &DocParser,
-  ts_module_decl: &swc_ecma_ast::TsModuleDecl,
+  ts_module_decl: &swc_ecmascript::ast::TsModuleDecl,
 ) -> (String, NamespaceDef) {
-  use crate::swc_ecma_ast::TsModuleName;
+  use swc_ecmascript::ast::TsModuleName;
   let namespace_name = match &ts_module_decl.id {
     TsModuleName::Ident(ident) => ident.sym.to_string(),
     TsModuleName::Str(str_) => str_.value.to_string(),
   };
 
   let elements = if let Some(body) = &ts_module_decl.body {
-    use crate::swc_ecma_ast::TsNamespaceBody::*;
+    use swc_ecmascript::ast::TsNamespaceBody::*;
 
     match &body {
       TsModuleBlock(ts_module_block) => {

--- a/cli/doc/node.rs
+++ b/cli/doc/node.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use swc_common;
 use serde::Serialize;
 
 #[derive(Debug, PartialEq, Serialize, Clone)]

--- a/cli/doc/node.rs
+++ b/cli/doc/node.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use crate::swc_common;
+use swc_common;
 use serde::Serialize;
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
@@ -23,7 +23,7 @@ pub struct Location {
 
 impl Into<Location> for swc_common::Loc {
   fn into(self) -> Location {
-    use crate::swc_common::FileName::*;
+    use swc_common::FileName::*;
 
     let filename = match &self.file.name {
       Real(path_buf) => path_buf.to_string_lossy().to_string(),

--- a/cli/doc/params.rs
+++ b/cli/doc/params.rs
@@ -1,9 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use super::display::{display_optional, SliceDisplayer};
 use super::ts_type::{ts_type_ann_to_def, TsTypeDef};
-use crate::swc_common::SourceMap;
-use crate::swc_ecma_ast;
-use crate::swc_ecma_ast::{ObjectPatProp, Pat, TsFnParam};
+use swc_common::SourceMap;
+use swc_ecmascript::ast::{ObjectPatProp, Pat, TsFnParam};
 use serde::Serialize;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
@@ -146,7 +145,7 @@ impl Display for ObjectPatPropDef {
 }
 
 pub fn ident_to_param_def(
-  ident: &swc_ecma_ast::Ident,
+  ident: &swc_ecmascript::ast::Ident,
   _source_map: Option<&SourceMap>,
 ) -> ParamDef {
   let ts_type = ident.type_ann.as_ref().map(|rt| ts_type_ann_to_def(rt));
@@ -159,7 +158,7 @@ pub fn ident_to_param_def(
 }
 
 fn rest_pat_to_param_def(
-  rest_pat: &swc_ecma_ast::RestPat,
+  rest_pat: &swc_ecmascript::ast::RestPat,
   source_map: Option<&SourceMap>,
 ) -> ParamDef {
   let ts_type = rest_pat.type_ann.as_ref().map(|rt| ts_type_ann_to_def(rt));
@@ -190,7 +189,7 @@ fn object_pat_prop_to_def(
 }
 
 fn object_pat_to_param_def(
-  object_pat: &swc_ecma_ast::ObjectPat,
+  object_pat: &swc_ecmascript::ast::ObjectPat,
   source_map: Option<&SourceMap>,
 ) -> ParamDef {
   let props = object_pat
@@ -211,7 +210,7 @@ fn object_pat_to_param_def(
 }
 
 fn array_pat_to_param_def(
-  array_pat: &swc_ecma_ast::ArrayPat,
+  array_pat: &swc_ecmascript::ast::ArrayPat,
   source_map: Option<&SourceMap>,
 ) -> ParamDef {
   let elements = array_pat
@@ -229,7 +228,7 @@ fn array_pat_to_param_def(
 }
 
 pub fn assign_pat_to_param_def(
-  assign_pat: &swc_ecma_ast::AssignPat,
+  assign_pat: &swc_ecmascript::ast::AssignPat,
   source_map: Option<&SourceMap>,
 ) -> ParamDef {
   let ts_type = assign_pat
@@ -245,7 +244,7 @@ pub fn assign_pat_to_param_def(
 }
 
 pub fn pat_to_param_def(
-  pat: &swc_ecma_ast::Pat,
+  pat: &swc_ecmascript::ast::Pat,
   source_map: Option<&SourceMap>,
 ) -> ParamDef {
   match pat {
@@ -259,7 +258,7 @@ pub fn pat_to_param_def(
 }
 
 pub fn ts_fn_param_to_param_def(
-  ts_fn_param: &swc_ecma_ast::TsFnParam,
+  ts_fn_param: &swc_ecmascript::ast::TsFnParam,
   source_map: Option<&SourceMap>,
 ) -> ParamDef {
   match ts_fn_param {
@@ -275,10 +274,10 @@ pub fn ts_fn_param_to_param_def(
 }
 
 pub fn prop_name_to_string(
-  prop_name: &swc_ecma_ast::PropName,
+  prop_name: &swc_ecmascript::ast::PropName,
   source_map: Option<&SourceMap>,
 ) -> String {
-  use crate::swc_ecma_ast::PropName;
+  use swc_ecmascript::ast::PropName;
   match prop_name {
     PropName::Ident(ident) => ident.sym.to_string(),
     PropName::Str(str_) => str_.value.to_string(),

--- a/cli/doc/params.rs
+++ b/cli/doc/params.rs
@@ -1,10 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use super::display::{display_optional, SliceDisplayer};
 use super::ts_type::{ts_type_ann_to_def, TsTypeDef};
-use swc_common::SourceMap;
-use swc_ecmascript::ast::{ObjectPatProp, Pat, TsFnParam};
 use serde::Serialize;
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use swc_common::SourceMap;
+use swc_ecmascript::ast::{ObjectPatProp, Pat, TsFnParam};
 
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/cli/doc/parser.rs
+++ b/cli/doc/parser.rs
@@ -1,13 +1,12 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::file_fetcher::map_file_extension;
 use crate::op_error::OpError;
-use crate::swc_common::comments::CommentKind;
-use crate::swc_common::Span;
-use crate::swc_ecma_ast;
-use crate::swc_ecma_ast::Decl;
-use crate::swc_ecma_ast::DefaultDecl;
-use crate::swc_ecma_ast::ModuleDecl;
-use crate::swc_ecma_ast::Stmt;
+use swc_common::comments::CommentKind;
+use swc_common::Span;
+use swc_ecmascript::ast::Decl;
+use swc_ecmascript::ast::DefaultDecl;
+use swc_ecmascript::ast::ModuleDecl;
+use swc_ecmascript::ast::Stmt;
 use crate::swc_util::AstParser;
 use crate::swc_util::SwcDiagnosticBuffer;
 
@@ -452,14 +451,14 @@ impl DocParser {
 
   pub fn get_reexports_for_module_body(
     &self,
-    module_body: Vec<swc_ecma_ast::ModuleItem>,
+    module_body: Vec<swc_ecmascript::ast::ModuleItem>,
   ) -> Vec<node::Reexport> {
-    use swc_ecma_ast::ExportSpecifier::*;
+    use swc_ecmascript::ast::ExportSpecifier::*;
 
     let mut reexports: Vec<node::Reexport> = vec![];
 
     for node in module_body.iter() {
-      if let swc_ecma_ast::ModuleItem::ModuleDecl(module_decl) = node {
+      if let swc_ecmascript::ast::ModuleItem::ModuleDecl(module_decl) = node {
         let r = match module_decl {
           ModuleDecl::ExportNamed(named_export) => {
             if let Some(src) = &named_export.src {
@@ -513,16 +512,16 @@ impl DocParser {
 
   pub fn get_doc_nodes_for_module_body(
     &self,
-    module_body: Vec<swc_ecma_ast::ModuleItem>,
+    module_body: Vec<swc_ecmascript::ast::ModuleItem>,
   ) -> Vec<DocNode> {
     let mut doc_entries: Vec<DocNode> = vec![];
     for node in module_body.iter() {
       match node {
-        swc_ecma_ast::ModuleItem::ModuleDecl(module_decl) => {
+        swc_ecmascript::ast::ModuleItem::ModuleDecl(module_decl) => {
           doc_entries
             .extend(self.get_doc_nodes_for_module_exports(module_decl));
         }
-        swc_ecma_ast::ModuleItem::Stmt(stmt) => {
+        swc_ecmascript::ast::ModuleItem::Stmt(stmt) => {
           if let Some(doc_node) = self.get_doc_node_for_stmt(stmt) {
             doc_entries.push(doc_node);
           }

--- a/cli/doc/printer.rs
+++ b/cli/doc/printer.rs
@@ -16,7 +16,6 @@ use crate::doc::display::{
   display_abstract, display_async, display_generator, Indent, SliceDisplayer,
 };
 use crate::doc::DocNodeKind;
-use crate::swc_ecma_ast;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 pub struct DocPrinter<'a> {
@@ -193,8 +192,8 @@ impl<'a> DocPrinter<'a> {
       self.private
         || node
           .accessibility
-          .unwrap_or(swc_ecma_ast::Accessibility::Public)
-          != swc_ecma_ast::Accessibility::Private
+          .unwrap_or(swc_ecmascript::ast::Accessibility::Public)
+          != swc_ecmascript::ast::Accessibility::Private
     }) {
       writeln!(w, "{}{}", Indent(1), node,)?;
       if let Some(js_doc) = &node.js_doc {
@@ -208,8 +207,8 @@ impl<'a> DocPrinter<'a> {
       self.private
         || node
           .accessibility
-          .unwrap_or(swc_ecma_ast::Accessibility::Public)
-          != swc_ecma_ast::Accessibility::Private
+          .unwrap_or(swc_ecmascript::ast::Accessibility::Public)
+          != swc_ecmascript::ast::Accessibility::Private
     }) {
       writeln!(w, "{}{}", Indent(1), node,)?;
       if let Some(js_doc) = &node.js_doc {
@@ -454,9 +453,9 @@ impl<'a> DocPrinter<'a> {
       "{}{} {}",
       Indent(indent),
       colors::magenta(match variable_def.kind {
-        swc_ecma_ast::VarDeclKind::Const => "const",
-        swc_ecma_ast::VarDeclKind::Let => "let",
-        swc_ecma_ast::VarDeclKind::Var => "var",
+        swc_ecmascript::ast::VarDeclKind::Const => "const",
+        swc_ecmascript::ast::VarDeclKind::Let => "let",
+        swc_ecmascript::ast::VarDeclKind::Var => "var",
       }),
       colors::bold(&node.name),
     )?;

--- a/cli/doc/ts_type.rs
+++ b/cli/doc/ts_type.rs
@@ -7,8 +7,7 @@ use super::ts_type_param::TsTypeParamDef;
 use super::ParamDef;
 use crate::colors;
 use crate::doc;
-use crate::swc_ecma_ast;
-use crate::swc_ecma_ast::{
+use swc_ecmascript::ast::{
   TsArrayType, TsConditionalType, TsExprWithTypeArgs, TsFnOrConstructorType,
   TsIndexedAccessType, TsKeywordType, TsLit, TsLitType, TsOptionalType,
   TsParenthesizedType, TsRestType, TsThisType, TsTupleType, TsType, TsTypeAnn,
@@ -129,7 +128,7 @@ impl Into<TsTypeDef> for &TsTupleType {
 
 impl Into<TsTypeDef> for &TsUnionOrIntersectionType {
   fn into(self) -> TsTypeDef {
-    use crate::swc_ecma_ast::TsUnionOrIntersectionType::*;
+    use swc_ecmascript::ast::TsUnionOrIntersectionType::*;
 
     match self {
       TsUnionType(union_type) => {
@@ -168,7 +167,7 @@ impl Into<TsTypeDef> for &TsUnionOrIntersectionType {
 
 impl Into<TsTypeDef> for &TsKeywordType {
   fn into(self) -> TsTypeDef {
-    use crate::swc_ecma_ast::TsKeywordTypeKind::*;
+    use swc_ecmascript::ast::TsKeywordTypeKind::*;
 
     let keyword_str = match self.kind {
       TsAnyKeyword => "any",
@@ -258,9 +257,9 @@ impl Into<TsTypeDef> for &TsThisType {
 }
 
 pub fn ts_entity_name_to_name(
-  entity_name: &swc_ecma_ast::TsEntityName,
+  entity_name: &swc_ecmascript::ast::TsEntityName,
 ) -> String {
-  use crate::swc_ecma_ast::TsEntityName::*;
+  use swc_ecmascript::ast::TsEntityName::*;
 
   match entity_name {
     Ident(ident) => ident.sym.to_string(),
@@ -274,7 +273,7 @@ pub fn ts_entity_name_to_name(
 
 impl Into<TsTypeDef> for &TsTypeQuery {
   fn into(self) -> TsTypeDef {
-    use crate::swc_ecma_ast::TsTypeQueryExpr::*;
+    use swc_ecmascript::ast::TsTypeQueryExpr::*;
 
     let type_name = match &self.expr_name {
       TsEntityName(entity_name) => ts_entity_name_to_name(&*entity_name),
@@ -374,7 +373,7 @@ impl Into<TsTypeDef> for &TsTypeLit {
     let mut index_signatures = vec![];
 
     for type_element in &self.members {
-      use crate::swc_ecma_ast::TsTypeElement::*;
+      use swc_ecmascript::ast::TsTypeElement::*;
 
       match &type_element {
         TsMethodSignature(ts_method_sig) => {
@@ -511,7 +510,7 @@ impl Into<TsTypeDef> for &TsConditionalType {
 
 impl Into<TsTypeDef> for &TsFnOrConstructorType {
   fn into(self) -> TsTypeDef {
-    use crate::swc_ecma_ast::TsFnOrConstructorType::*;
+    use swc_ecmascript::ast::TsFnOrConstructorType::*;
 
     let fn_def = match self {
       TsFnType(ts_fn_type) => {
@@ -563,7 +562,7 @@ impl Into<TsTypeDef> for &TsFnOrConstructorType {
 
 impl Into<TsTypeDef> for &TsType {
   fn into(self) -> TsTypeDef {
-    use crate::swc_ecma_ast::TsType::*;
+    use swc_ecmascript::ast::TsType::*;
 
     match self {
       TsKeywordType(ref keyword_type) => keyword_type.into(),
@@ -829,7 +828,7 @@ pub struct TsTypeDef {
 }
 
 pub fn ts_type_ann_to_def(type_ann: &TsTypeAnn) -> TsTypeDef {
-  use crate::swc_ecma_ast::TsType::*;
+  use swc_ecmascript::ast::TsType::*;
 
   match &*type_ann.type_ann {
     TsKeywordType(keyword_type) => keyword_type.into(),

--- a/cli/doc/ts_type.rs
+++ b/cli/doc/ts_type.rs
@@ -7,6 +7,8 @@ use super::ts_type_param::TsTypeParamDef;
 use super::ParamDef;
 use crate::colors;
 use crate::doc;
+use serde::Serialize;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 use swc_ecmascript::ast::{
   TsArrayType, TsConditionalType, TsExprWithTypeArgs, TsFnOrConstructorType,
   TsIndexedAccessType, TsKeywordType, TsLit, TsLitType, TsOptionalType,
@@ -14,8 +16,6 @@ use swc_ecmascript::ast::{
   TsTypeLit, TsTypeOperator, TsTypeParamInstantiation, TsTypeQuery, TsTypeRef,
   TsUnionOrIntersectionType,
 };
-use serde::Serialize;
-use std::fmt::{Display, Formatter, Result as FmtResult};
 
 // pub enum TsType {
 //  *      TsKeywordType(TsKeywordType),

--- a/cli/doc/ts_type_param.rs
+++ b/cli/doc/ts_type_param.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use super::ts_type::TsTypeDef;
-use crate::swc_ecma_ast::TsTypeParam;
-use crate::swc_ecma_ast::TsTypeParamDecl;
+use swc_ecmascript::ast::TsTypeParam;
+use swc_ecmascript::ast::TsTypeParamDecl;
 use serde::Serialize;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 

--- a/cli/doc/ts_type_param.rs
+++ b/cli/doc/ts_type_param.rs
@@ -1,9 +1,9 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use super::ts_type::TsTypeDef;
-use swc_ecmascript::ast::TsTypeParam;
-use swc_ecmascript::ast::TsTypeParamDecl;
 use serde::Serialize;
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use swc_ecmascript::ast::TsTypeParam;
+use swc_ecmascript::ast::TsTypeParamDecl;
 
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/cli/doc/type_alias.rs
+++ b/cli/doc/type_alias.rs
@@ -3,7 +3,6 @@ use super::parser::DocParser;
 use super::ts_type::TsTypeDef;
 use super::ts_type_param::maybe_type_param_decl_to_type_param_defs;
 use super::ts_type_param::TsTypeParamDef;
-use crate::swc_ecma_ast;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Clone)]
@@ -15,7 +14,7 @@ pub struct TypeAliasDef {
 
 pub fn get_doc_for_ts_type_alias_decl(
   _doc_parser: &DocParser,
-  type_alias_decl: &swc_ecma_ast::TsTypeAliasDecl,
+  type_alias_decl: &swc_ecmascript::ast::TsTypeAliasDecl,
 ) -> (String, TypeAliasDef) {
   let alias_name = type_alias_decl.id.sym.to_string();
   let ts_type = type_alias_decl.type_ann.as_ref().into();

--- a/cli/doc/variable.rs
+++ b/cli/doc/variable.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use crate::swc_ecma_ast;
 use serde::Serialize;
 
 use super::ts_type::ts_type_ann_to_def;
@@ -9,23 +8,23 @@ use super::ts_type::TsTypeDef;
 #[serde(rename_all = "camelCase")]
 pub struct VariableDef {
   pub ts_type: Option<TsTypeDef>,
-  pub kind: swc_ecma_ast::VarDeclKind,
+  pub kind: swc_ecmascript::ast::VarDeclKind,
 }
 
 // TODO: change this function to return Vec<(String, VariableDef)> as single
 // var declaration can have multiple declarators
 pub fn get_doc_for_var_decl(
-  var_decl: &swc_ecma_ast::VarDecl,
+  var_decl: &swc_ecmascript::ast::VarDecl,
 ) -> (String, VariableDef) {
   assert!(!var_decl.decls.is_empty());
   let var_declarator = var_decl.decls.get(0).unwrap();
   let var_name = match &var_declarator.name {
-    swc_ecma_ast::Pat::Ident(ident) => ident.sym.to_string(),
+    swc_ecmascript::ast::Pat::Ident(ident) => ident.sym.to_string(),
     _ => "<TODO>".to_string(),
   };
 
   let maybe_ts_type = match &var_declarator.name {
-    swc_ecma_ast::Pat::Ident(ident) => {
+    swc_ecmascript::ast::Pat::Ident(ident) => {
       ident.type_ann.as_ref().map(|rt| ts_type_ann_to_def(rt))
     }
     _ => None,

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -9,7 +9,7 @@
 
 use crate::colors;
 use crate::diff::diff;
-use crate::dprint_plugin_typescript as dprint;
+use dprint_plugin_typescript as dprint;
 use crate::fs::files_in_subtree;
 use crate::op_error::OpError;
 use deno_core::ErrBox;

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -9,10 +9,10 @@
 
 use crate::colors;
 use crate::diff::diff;
-use dprint_plugin_typescript as dprint;
 use crate::fs::files_in_subtree;
 use crate::op_error::OpError;
 use deno_core::ErrBox;
+use dprint_plugin_typescript as dprint;
 use std::fs;
 use std::io::stdin;
 use std::io::stdout;

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -12,7 +12,7 @@ use crate::file_fetcher::map_file_extension;
 use crate::fmt::collect_files;
 use crate::fmt::run_parallelized;
 use crate::fmt_errors;
-use crate::swc_ecma_parser::Syntax;
+use swc_ecmascript::parser::Syntax;
 use crate::swc_util;
 use deno_core::ErrBox;
 use deno_lint::diagnostic::LintDiagnostic;

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -12,7 +12,6 @@ use crate::file_fetcher::map_file_extension;
 use crate::fmt::collect_files;
 use crate::fmt::run_parallelized;
 use crate::fmt_errors;
-use swc_ecmascript::parser::Syntax;
 use crate::swc_util;
 use deno_core::ErrBox;
 use deno_lint::diagnostic::LintDiagnostic;
@@ -24,6 +23,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use swc_ecmascript::parser::Syntax;
 
 pub async fn lint_files(args: Vec<String>) -> Result<(), ErrBox> {
   let target_files = collect_files(args)?;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -67,12 +67,6 @@ pub mod version;
 mod web_worker;
 pub mod worker;
 
-pub use deno_lint::dprint_plugin_typescript;
-pub use deno_lint::swc_common;
-pub use deno_lint::swc_ecma_ast;
-pub use deno_lint::swc_ecma_parser;
-pub use deno_lint::swc_ecma_visit;
-
 use crate::doc::parser::DocFileLoader;
 use crate::file_fetcher::SourceFile;
 use crate::file_fetcher::SourceFileFetcher;

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -19,12 +19,10 @@ use crate::permissions::Permissions;
 use crate::source_maps::SourceMapGetter;
 use crate::startup_data;
 use crate::state::State;
-use crate::swc_common::comments::CommentKind;
-use crate::swc_common::Span;
-use crate::swc_ecma_ast;
-use crate::swc_ecma_visit;
-use crate::swc_ecma_visit::Node;
-use crate::swc_ecma_visit::Visit;
+use swc_common::comments::CommentKind;
+use swc_common::Span;
+use swc_ecmascript::visit::Node;
+use swc_ecmascript::visit::Visit;
 use crate::swc_util::AstParser;
 use crate::swc_util::SwcDiagnosticBuffer;
 use crate::version;
@@ -1262,7 +1260,7 @@ struct DependencyVisitor {
 impl Visit for DependencyVisitor {
   fn visit_import_decl(
     &mut self,
-    import_decl: &swc_ecma_ast::ImportDecl,
+    import_decl: &swc_ecmascript::ast::ImportDecl,
     _parent: &dyn Node,
   ) {
     let src_str = import_decl.src.value.to_string();
@@ -1275,7 +1273,7 @@ impl Visit for DependencyVisitor {
 
   fn visit_named_export(
     &mut self,
-    named_export: &swc_ecma_ast::NamedExport,
+    named_export: &swc_ecmascript::ast::NamedExport,
     _parent: &dyn Node,
   ) {
     if let Some(src) = &named_export.src {
@@ -1290,7 +1288,7 @@ impl Visit for DependencyVisitor {
 
   fn visit_export_all(
     &mut self,
-    export_all: &swc_ecma_ast::ExportAll,
+    export_all: &swc_ecmascript::ast::ExportAll,
     _parent: &dyn Node,
   ) {
     let src_str = export_all.src.value.to_string();
@@ -1303,7 +1301,7 @@ impl Visit for DependencyVisitor {
 
   fn visit_ts_import_type(
     &mut self,
-    ts_import_type: &swc_ecma_ast::TsImportType,
+    ts_import_type: &swc_ecmascript::ast::TsImportType,
     _parent: &dyn Node,
   ) {
     // TODO(bartlomieju): possibly add separate DependencyKind
@@ -1317,13 +1315,13 @@ impl Visit for DependencyVisitor {
 
   fn visit_call_expr(
     &mut self,
-    call_expr: &swc_ecma_ast::CallExpr,
+    call_expr: &swc_ecmascript::ast::CallExpr,
     parent: &dyn Node,
   ) {
-    use swc_ecma_ast::Expr::*;
-    use swc_ecma_ast::ExprOrSuper::*;
+    use swc_ecmascript::ast::Expr::*;
+    use swc_ecmascript::ast::ExprOrSuper::*;
 
-    swc_ecma_visit::visit_call_expr(self, call_expr, parent);
+    swc_ecmascript::visit::visit_call_expr(self, call_expr, parent);
     let boxed_expr = match call_expr.callee.clone() {
       Super(_) => return,
       Expr(boxed) => boxed,
@@ -1341,7 +1339,7 @@ impl Visit for DependencyVisitor {
     if let Some(arg) = call_expr.args.get(0) {
       match &*arg.expr {
         Lit(lit) => {
-          if let swc_ecma_ast::Lit::Str(str_) = lit {
+          if let swc_ecmascript::ast::Lit::Str(str_) = lit {
             let src_str = str_.value.to_string();
             self.dependencies.push(DependencyDescriptor {
               specifier: src_str,
@@ -1423,8 +1421,7 @@ pub fn pre_process_file(
     // analyze comment from beginning of the file and find TS directives
     let comments = parser
       .comments
-      .take_leading_comments(module_span.lo())
-      .unwrap_or_else(Vec::new);
+      .with_leading(module_span.lo(), |cmts| cmts.to_vec());
 
     let mut references = vec![];
     for comment in comments {

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -19,10 +19,6 @@ use crate::permissions::Permissions;
 use crate::source_maps::SourceMapGetter;
 use crate::startup_data;
 use crate::state::State;
-use swc_common::comments::CommentKind;
-use swc_common::Span;
-use swc_ecmascript::visit::Node;
-use swc_ecmascript::visit::Visit;
 use crate::swc_util::AstParser;
 use crate::swc_util::SwcDiagnosticBuffer;
 use crate::version;
@@ -55,6 +51,10 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::task::Poll;
+use swc_common::comments::CommentKind;
+use swc_common::Span;
+use swc_ecmascript::visit::Node;
+use swc_ecmascript::visit::Visit;
 use url::Url;
 
 pub const AVAILABLE_LIBS: &[&str] = &[
@@ -1387,60 +1387,59 @@ pub fn pre_process_file(
   analyze_dynamic_imports: bool,
 ) -> Result<(Vec<ImportDesc>, Vec<TsReferenceDesc>), SwcDiagnosticBuffer> {
   let parser = AstParser::default();
-  parser.parse_module(file_name, media_type, source_code, |parse_result| {
-    let module = parse_result?;
-    let mut collector = DependencyVisitor {
-      dependencies: vec![],
-    };
-    let module_span = module.span;
-    collector.visit_module(&module, &module);
+  let parse_result = parser.parse_module(file_name, media_type, source_code);
+  let module = parse_result?;
+  let mut collector = DependencyVisitor {
+    dependencies: vec![],
+  };
+  let module_span = module.span;
+  collector.visit_module(&module, &module);
 
-    let dependency_descriptors = collector.dependencies;
+  let dependency_descriptors = collector.dependencies;
 
-    // for each import check if there's relevant @deno-types directive
-    let imports = dependency_descriptors
-      .iter()
-      .filter(|desc| {
-        if analyze_dynamic_imports {
-          return true;
-        }
-
-        desc.kind != DependencyKind::DynamicImport
-      })
-      .map(|desc| {
-        let location = parser.get_span_location(desc.span);
-        let deno_types = get_deno_types(&parser, desc.span);
-        ImportDesc {
-          specifier: desc.specifier.to_string(),
-          deno_types,
-          location: location.into(),
-        }
-      })
-      .collect();
-
-    // analyze comment from beginning of the file and find TS directives
-    let comments = parser
-      .comments
-      .with_leading(module_span.lo(), |cmts| cmts.to_vec());
-
-    let mut references = vec![];
-    for comment in comments {
-      if comment.kind != CommentKind::Line {
-        continue;
+  // for each import check if there's relevant @deno-types directive
+  let imports = dependency_descriptors
+    .iter()
+    .filter(|desc| {
+      if analyze_dynamic_imports {
+        return true;
       }
 
-      let text = comment.text.to_string();
-      if let Some((kind, specifier)) = parse_ts_reference(text.trim()) {
-        let location = parser.get_span_location(comment.span);
-        references.push(TsReferenceDesc {
-          kind,
-          specifier,
-          location: location.into(),
-        });
+      desc.kind != DependencyKind::DynamicImport
+    })
+    .map(|desc| {
+      let location = parser.get_span_location(desc.span);
+      let deno_types = get_deno_types(&parser, desc.span);
+      ImportDesc {
+        specifier: desc.specifier.to_string(),
+        deno_types,
+        location: location.into(),
       }
+    })
+    .collect();
+
+  // analyze comment from beginning of the file and find TS directives
+  let comments = parser
+    .comments
+    .with_leading(module_span.lo(), |cmts| cmts.to_vec());
+
+  let mut references = vec![];
+  for comment in comments {
+    if comment.kind != CommentKind::Line {
+      continue;
     }
-    Ok((imports, references))
-  })
+
+    let text = comment.text.to_string();
+    if let Some((kind, specifier)) = parse_ts_reference(text.trim()) {
+      let location = parser.get_span_location(comment.span);
+      references.push(TsReferenceDesc {
+        kind,
+        specifier,
+        location: location.into(),
+      });
+    }
+  }
+  Ok((imports, references))
 }
 
 fn get_deno_types(parser: &AstParser, span: Span) -> Option<String> {


### PR DESCRIPTION
This commit upgrades:
deno_lint 0.1.20
dprint-plugin-typescript 0.25.0
swc_ecmascript 0.1.0

SWC is no longer reexported from dprint nor deno_lint.

Effectively reducing binary size by about 2.5Mb
```
cargo bloat --release --crates
 File  .text     Size Crate
20.1%  46.0%   8.1MiB rusty_v8
 7.9%  18.2%   3.2MiB [Unknown]
 2.5%   5.8%   1.0MiB std
 1.7%   3.9% 711.9KiB dprint_plugin_typescript
 1.6%   3.6% 653.9KiB swc_ecma_transforms
 1.6%   3.6% 646.2KiB deno_lint
 1.1%   2.5% 451.5KiB deno
 0.9%   2.0% 354.5KiB deno_core
 0.7%   1.7% 305.8KiB reqwest
 0.6%   1.4% 248.3KiB rustls
 0.5%   1.1% 189.7KiB clap
 0.4%   0.9% 170.5KiB regex
 0.4%   0.9% 157.5KiB tokio
 0.3%   0.7% 128.2KiB h2
 0.3%   0.6% 111.1KiB futures_util
 0.3%   0.6% 106.3KiB swc_ecma_ast
 0.2%   0.5%  95.7KiB hyper
 0.2%   0.5%  88.9KiB regex_syntax
 0.2%   0.5%  85.1KiB ring
 0.2%   0.5%  82.5KiB swc_ecma_codegen
 2.0%   4.6% 824.5KiB And 106 more crates. Use -n N to show more.
43.5% 100.0%  17.6MiB .text section size, the file size is 40.4MiB
```