### PR TITLE
Issue #6930 toml parser error inline comment

### DIFF
--- a/std/encoding/testdata/boolean.toml
+++ b/std/encoding/testdata/boolean.toml
@@ -1,3 +1,4 @@
 [boolean] # i hate comments
 bool1 = true
 bool2 = false
+bool3 = true # I love comments

--- a/std/encoding/toml.ts
+++ b/std/encoding/toml.ts
@@ -280,16 +280,9 @@ class Parser {
       return dataString.slice(0, endOfString);
     }
 
-    const m = /(?:|\[|{|).*(?:|\]|\|})\s*[^#]/g.exec(dataString);
+    const m = /(?:|\[|{).*(?:|\]|})\s*^((?!#).)*/g.exec(dataString);
     if (m) {
-      // Todo(jaydhelton) Clean this mess up before PR
-      const thing = m[0].trim()
-      const t = /^((?!#).)*/g.exec(thing)
-      // Todo(jaydhelton) This is matching on empty space as well
-      if (t) {
-        return t[0].trim();
-      }
-      return thing;
+      return m[0].trim();
     } else {
       return dataString;
     }

--- a/std/encoding/toml.ts
+++ b/std/encoding/toml.ts
@@ -280,9 +280,16 @@ class Parser {
       return dataString.slice(0, endOfString);
     }
 
-    const m = /(?:|\[|{|).*(?:|\]||})\s*[^#]/g.exec(dataString);
+    const m = /(?:|\[|{|).*(?:|\]|\|})\s*[^#]/g.exec(dataString);
     if (m) {
-      return m[0].trim();
+      // Todo(jaydhelton) Clean this mess up before PR
+      const thing = m[0].trim()
+      const t = /^((?!#).)*/g.exec(thing)
+      // Todo(jaydhelton) This is matching on empty space as well
+      if (t) {
+        return t[0].trim();
+      }
+      return thing;
     } else {
       return dataString;
     }

--- a/std/encoding/toml_test.ts
+++ b/std/encoding/toml_test.ts
@@ -4,7 +4,7 @@ import { existsSync } from "../fs/exists.ts";
 import * as path from "../path/mod.ts";
 import { parse, stringify } from "./toml.ts";
 
-const testFilesDir = path.resolve( "testdata");
+const testFilesDir = path.resolve( "encoding", "testdata");
 
 function parseFile(filePath: string): object {
   if (!existsSync(filePath)) {

--- a/std/encoding/toml_test.ts
+++ b/std/encoding/toml_test.ts
@@ -4,7 +4,7 @@ import { existsSync } from "../fs/exists.ts";
 import * as path from "../path/mod.ts";
 import { parse, stringify } from "./toml.ts";
 
-const testFilesDir = path.resolve( "encoding", "testdata");
+const testFilesDir = path.resolve("encoding", "testdata");
 
 function parseFile(filePath: string): object {
   if (!existsSync(filePath)) {

--- a/std/encoding/toml_test.ts
+++ b/std/encoding/toml_test.ts
@@ -4,7 +4,7 @@ import { existsSync } from "../fs/exists.ts";
 import * as path from "../path/mod.ts";
 import { parse, stringify } from "./toml.ts";
 
-const testFilesDir = path.resolve("encoding", "testdata");
+const testFilesDir = path.resolve( "testdata");
 
 function parseFile(filePath: string): object {
   if (!existsSync(filePath)) {
@@ -48,7 +48,7 @@ Deno.test({
 Deno.test({
   name: "[TOML] Boolean",
   fn(): void {
-    const expected = { boolean: { bool1: true, bool2: false } };
+    const expected = { boolean: { bool1: true, bool2: false, bool3: true } };
     const actual = parseFile(path.join(testFilesDir, "boolean.toml"));
     assertEquals(actual, expected);
   },


### PR DESCRIPTION
### Description
Bugfix for allowing comments inline with booleans for the toml parser

It is my assumption the the regular expression using for the "not a string" cases was intended to grab comments. 
There was an expression for a negated set matching just the '#' char, so i added a negative lookahead in a capture group.
I also added a few tests

Here are some tests i did in a regex tester
<img width="1258" alt="Screen Shot 2020-08-02 at 10 25 10 PM" src="https://user-images.githubusercontent.com/22941561/89140345-64c3ca00-d50f-11ea-9565-8d8c8ede24f0.png">
<img width="1256" alt="Screen Shot 2020-08-02 at 10 25 29 PM" src="https://user-images.githubusercontent.com/22941561/89140347-655c6080-d50f-11ea-8d73-b31748c96f43.png">
<img width="1253" alt="Screen Shot 2020-08-02 at 10 25 23 PM" src="https://user-images.githubusercontent.com/22941561/89140350-65f4f700-d50f-11ea-88b0-4d4a870bb2ef.png">
<img width="1248" alt="Screen Shot 2020-08-02 at 10 25 17 PM" src="https://user-images.githubusercontent.com/22941561/89140351-65f4f700-d50f-11ea-827d-72b547668020.png">

### Concerns

On my machine, i had to remove the  `"encoding"` from  `const testFilesDir = path.resolve("encoding", "testdata");` in ordeer to run tests in `toml_tests.ts`


### Referencees
- #6930 