### PR TITLE
feat(install): add support for --no-check flag

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -361,6 +361,7 @@ fn install_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   permission_args_parse(flags, matches);
   config_arg_parse(flags, matches);
   ca_file_arg_parse(flags, matches);
+  no_check_arg_parse(flags, matches);
   unstable_arg_parse(flags, matches);
 
   let root = if matches.is_present("root") {
@@ -720,6 +721,7 @@ fn install_subcommand<'a, 'b>() -> App<'a, 'b> {
             .short("f")
             .help("Forcefully overwrite existing installation")
             .takes_value(false))
+        .arg(no_check_arg())
         .arg(ca_file_arg())
         .arg(unstable_arg())
         .arg(config_arg())

--- a/cli/installer.rs
+++ b/cli/installer.rs
@@ -218,6 +218,10 @@ pub fn install(
     }
   }
 
+  if flags.no_check {
+    executable_args.push("--no-check".to_string());
+  }
+
   if flags.unstable {
     executable_args.push("--unstable".to_string());
   }
@@ -554,6 +558,7 @@ mod tests {
       Flags {
         allow_net: true,
         allow_read: true,
+        no_check: true,
         log_level: Some(Level::Error),
         ..Flags::default()
       },
@@ -572,7 +577,7 @@ mod tests {
 
     assert!(file_path.exists());
     let content = fs::read_to_string(file_path).unwrap();
-    assert!(content.contains(r#""run" "--allow-read" "--allow-net" "--quiet" "http://localhost:4545/cli/tests/echo_server.ts" "--foobar""#));
+    assert!(content.contains(r#""run" "--allow-read" "--allow-net" "--quiet" "--no-check" "http://localhost:4545/cli/tests/echo_server.ts" "--foobar""#));
   }
 
   #[test]


### PR DESCRIPTION
### Description
Adding support for the `--no-check` flag with the `deno install` command.
The flag will simply be passed through to the executable made.

### Check Off

- [x] Add --no-check for the subcommand and pass it to the executable
- [x] Determine how this should affect the pre-caching per [this comment](https://github.com/denoland/deno/issues/6921#issuecomment-666639040)


### References 
- #6921 