### PR TITLE
docs: fix some grammar mistakes in permissions.md

### DIFF
--- a/docs/getting_started/permissions.md
+++ b/docs/getting_started/permissions.md
@@ -2,11 +2,11 @@
 
 Deno is secure by default. Therefore, unless you specifically enable it, a deno
 module has no file, network, or environment access for example. Access to
-security sensitive areas or functions requires the use of permissions to be
+security-sensitive areas or functions requires the use of permissions to be
 granted to a deno process on the command line.
 
 For the following example, `mod.ts` has been granted read-only access to the
-file system. It cannot write to it, or perform any other security sensitive
+file system. It cannot write to it, or perform any other security-sensitive
 functions.
 
 ```shell
@@ -20,21 +20,21 @@ The following permissions are available:
 - **-A, --allow-all** Allow all permissions. This disables all security.
 - **--allow-env** Allow environment access for things like getting and setting
   of environment variables.
-- **--allow-hrtime** Allow high resolution time measurement. High resolution
+- **--allow-hrtime** Allow high-resolution time measurement. High-resolution
   time can be used in timing attacks and fingerprinting.
 - **--allow-net=\<allow-net\>** Allow network access. You can specify an
-  optional, comma separated list of domains to provide a allow-list of allowed
+  optional, comma-separated list of domains to provide an allow-list of allowed
   domains.
 - **--allow-plugin** Allow loading plugins. Please note that --allow-plugin is
   an unstable feature.
 - **--allow-read=\<allow-read\>** Allow file system read access. You can specify
-  an optional, comma separated list of directories or files to provide a
+  an optional, comma-separated list of directories or files to provide a
   allow-list of allowed file system access.
 - **--allow-run** Allow running subprocesses. Be aware that subprocesses are not
   run in a sandbox and therefore do not have the same security restrictions as
   the deno process. Therefore, use with caution.
 - **--allow-write=\<allow-write\>** Allow file system write access. You can
-  specify an optional, comma separated list of directories or files to provide a
+  specify an optional, comma-separated list of directories or files to provide a
   allow-list of allowed file system access.
 
 ### Permissions allow-list
@@ -70,7 +70,7 @@ _fetch.ts_:
 const result = await fetch("https://deno.land/");
 ```
 
-This is an example on how to allow-list hosts/urls:
+This is an example of how to allow-list hosts/urls:
 
 ```shell
 deno run --allow-net=github.com,deno.land fetch.ts


### PR DESCRIPTION
- "security sensitive" to "security-sensitive"
- "high resolution" to "high-resolution"
- "comma separated" to "comma-separated"
- "a allow-list" to "an allow-list"
- "an example on" to "an example of"

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
