### PR TITLE
Revert "Change release build flags to optimize for size (#6907)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,3 @@ members = [
 exclude = [
   "std/hash/_wasm"
 ]
-
-
-[profile.release]
-codegen-units = 1
-lto = true
-opt-level = 'z' # Optimize for size


### PR DESCRIPTION
The non-default build (codegen) flags are applied only when building the
binary, however they are not used when building the tests. This makes
cargo recompile all crate dependencies and effectively doubles the time
to build and test in release mode.

Additionally when we were "watching" the benchmarks, this was likely a
meaningless activity as they too could have been built without these
alternative flags.

This reverts commit b7942bf0f6f151e172db9b1e08cf4436e8365e8b.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
