### PR TITLE
feat(Deno.run): Support executable file URLs

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1896,7 +1896,7 @@ declare namespace Deno {
   export interface RunOptions {
     /** Arguments to pass. Note, the first element needs to be a path to the
      * binary */
-    cmd: string[];
+    cmd: string[] | [URL, ...string[]];
     cwd?: string;
     env?: {
       [key: string]: string;

--- a/cli/rt/40_process.js
+++ b/cli/rt/40_process.js
@@ -5,7 +5,7 @@
   const { close } = window.__bootstrap.resources;
   const { readAll } = window.__bootstrap.buffer;
   const { sendSync, sendAsync } = window.__bootstrap.dispatchJson;
-  const { assert } = window.__bootstrap.util;
+  const { assert, pathFromURL } = window.__bootstrap.util;
 
   function opKill(pid, signo) {
     sendSync("op_kill", { pid, signo });
@@ -98,6 +98,9 @@
     stderr = "inherit",
     stdin = "inherit",
   }) {
+    if (cmd[0] != null) {
+      cmd[0] = pathFromURL(cmd[0]);
+    }
     const res = opRun({
       cmd: cmd.map(String),
       cwd,

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -26,6 +26,29 @@ unitTest({ perms: { run: true } }, async function runSuccess(): Promise<void> {
   p.stdout.close();
   p.close();
 });
+
+unitTest({ perms: { run: true } }, async function runUrl(): Promise<void> {
+  const q = Deno.run({
+    cmd: ["python", "-c", "import sys; print sys.executable"],
+    stdout: "piped",
+  });
+  await q.status();
+  const pythonPath = new TextDecoder().decode(await q.output()).trim();
+  q.close();
+
+  const p = Deno.run({
+    cmd: [new URL(`file:///${pythonPath}`), "-c", "print('hello world')"],
+    stdout: "piped",
+    stderr: "null",
+  });
+  const status = await p.status();
+  assertEquals(status.success, true);
+  assertEquals(status.code, 0);
+  assertEquals(status.signal, undefined);
+  p.stdout.close();
+  p.close();
+});
+
 unitTest({ perms: { run: true } }, async function runStdinRid0(): Promise<
   void
 > {


### PR DESCRIPTION
```js
Deno.run({ cmd: [new URL("temp.sh", import.meta.url), "foo", "bar"] });
```