### PR TITLE
feat(bundle): add support for --reload flag

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -393,6 +393,7 @@ fn install_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 fn bundle_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   ca_file_arg_parse(flags, matches);
   config_arg_parse(flags, matches);
+  reload_arg_parse(flags, matches);
   importmap_arg_parse(flags, matches);
   unstable_arg_parse(flags, matches);
   lock_args_parse(flags, matches);
@@ -761,6 +762,7 @@ fn bundle_subcommand<'a, 'b>() -> App<'a, 'b> {
     )
     .arg(Arg::with_name("out_file").takes_value(true).required(false))
     .arg(ca_file_arg())
+    .arg(reload_arg())
     .arg(importmap_arg())
     .arg(unstable_arg())
     .arg(config_arg())

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -2232,7 +2232,7 @@ mod tests {
   #[test]
   fn bundle_with_reload() {
     let r =
-        flags_from_vec_safe(svec!["deno", "bundle", "--reload", "source.ts"]);
+      flags_from_vec_safe(svec!["deno", "bundle", "--reload", "source.ts"]);
     assert_eq!(
       r.unwrap(),
       Flags {

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -2230,6 +2230,23 @@ mod tests {
   }
 
   #[test]
+  fn bundle_with_reload() {
+    let r =
+        flags_from_vec_safe(svec!["deno", "bundle", "--reload", "source.ts"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        reload: true,
+        subcommand: DenoSubcommand::Bundle {
+          source_file: "source.ts".to_string(),
+          out_file: None,
+        },
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
   fn run_importmap() {
     let r = flags_from_vec_safe(svec![
       "deno",


### PR DESCRIPTION
###Description
Adding support for the reload flag for the bundle command

- [x] Add to args parse for bundle
- [x] Manual Testing
- [x] Fix Any Broken Tests
- [x] Add Tests

###References
#6973 

**Current Observations:**

> It looks like the reload flag is based onto global state, and then the file `global.file_fetcher`.
> This would imply that denos global state will handle this scenario simply by providing the flag to the init of state. Testing will confirm.

This was proven true.