### PR TITLE
(fix) URLSearchParams.toString() behaviour is different from browsers

### DIFF
--- a/cli/rt/11_url.js
+++ b/cli/rt/11_url.js
@@ -219,10 +219,25 @@
     }
 
     toString() {
+      const replacer = function (match) {
+        const replace = {
+          "!": "%21",
+          "'": "%27",
+          "(": "%28",
+          ")": "%29",
+          "~": "%7E",
+          "%20": "+",
+        };
+        return replace[match];
+      };
+
+      const serialize = function (str) {
+        return encodeURIComponent(str).replace(/[!'()~]|%20/g, replacer);
+      };
+
       return this.#params
         .map(
-          (tuple) =>
-            `${encodeURIComponent(tuple[0])}=${encodeURIComponent(tuple[1])}`,
+          (tuple) => `${serialize(tuple[0])}=${serialize(tuple[1])}`,
         )
         .join("&");
     }

--- a/cli/rt/11_url.js
+++ b/cli/rt/11_url.js
@@ -15,28 +15,6 @@
   }
 
   const urls = new WeakMap();
-  // deno-fmt-ignore
-  const noEscape = [
-    /*
-      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F
-    */
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x00 - 0x0F
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x10 - 0x1F
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, // 0x20 - 0x2F
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, // 0x30 - 0x3F
-      0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x40 - 0x4F
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, // 0x50 - 0x5F
-      0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x60 - 0x6F
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0  // 0x70 - 0x7F
-  ];
-
-  const hexTable = new Array(256);
-  for (let i = 0; i < 256; ++i) {
-    hexTable[i] = "%" + ((i < 16 ? "0" : "") + i.toString(16)).toUpperCase();
-  }
-  // Special version of hexTable that uses `+` for U+0020 SPACE.
-  const paramHexTable = hexTable.slice();
-  paramHexTable[0x20] = "+";
 
   class URLSearchParams {
     #params = [];
@@ -244,9 +222,7 @@
       return this.#params
         .map(
           (tuple) =>
-            `${encodeStr(tuple[0], noEscape, paramHexTable)}=${
-              encodeStr(tuple[1], noEscape, paramHexTable)
-            }`,
+            `${encodeSearchParam(tuple[0])}=${encodeSearchParam(tuple[1])}`,
         )
         .join("&");
     }
@@ -816,6 +792,11 @@
     return ["\u0000", "\u0009", "\u000A", "\u000D", "\u0020", "\u0023", "\u0025", "\u002F", "\u003A", "\u003C", "\u003E", "\u003F", "\u0040", "\u005B", "\u005C", "\u005D", "\u005E"].includes(c);
   }
 
+  function charInFormUrlencodedSet(c) {
+    // deno-fmt-ignore
+    return charInUserinfoSet(c) || ["\u0021", "\u0024", "\u0025", "\u0026", "\u0027", "\u0028", "\u0029", "\u002B", "\u002C", "\u007E"].includes(c);
+  }
+
   const encoder = new TextEncoder();
 
   function encodeChar(c) {
@@ -900,59 +881,9 @@
     );
   }
 
-  function encodeStr(str, noEscapeTable, hexTable) {
-    const len = str.length;
-    if (len === 0) return "";
-
-    let out = "";
-    let lastPos = 0;
-
-    for (let i = 0; i < len; i++) {
-      let c = str.charCodeAt(i);
-      // ASCII
-      if (c < 0x80) {
-        if (noEscapeTable[c] === 1) continue;
-        if (lastPos < i) out += str.slice(lastPos, i);
-        lastPos = i + 1;
-        out += hexTable[c];
-        continue;
-      }
-
-      if (lastPos < i) out += str.slice(lastPos, i);
-
-      // Multi-byte characters ...
-      if (c < 0x800) {
-        lastPos = i + 1;
-        out += hexTable[0xc0 | (c >> 6)] + hexTable[0x80 | (c & 0x3f)];
-        continue;
-      }
-      if (c < 0xd800 || c >= 0xe000) {
-        lastPos = i + 1;
-        out += hexTable[0xe0 | (c >> 12)] +
-          hexTable[0x80 | ((c >> 6) & 0x3f)] +
-          hexTable[0x80 | (c & 0x3f)];
-        continue;
-      }
-      // Surrogate pair
-      ++i;
-
-      // This branch should never happen because all URLSearchParams entries
-      // should already be converted to USVString. But, included for
-      // completion's sake anyway.
-      if (i >= len) throw new Deno.errors.InvalidData("invalid URI");
-
-      const c2 = str.charCodeAt(i) & 0x3ff;
-
-      lastPos = i + 1;
-      c = 0x10000 + (((c & 0x3ff) << 10) | c2);
-      out += hexTable[0xf0 | (c >> 18)] +
-        hexTable[0x80 | ((c >> 12) & 0x3f)] +
-        hexTable[0x80 | ((c >> 6) & 0x3f)] +
-        hexTable[0x80 | (c & 0x3f)];
-    }
-    if (lastPos === 0) return str;
-    if (lastPos < len) return out + str.slice(lastPos);
-    return out;
+  function encodeSearchParam(s) {
+    return [...s].map((c) => (charInFormUrlencodedSet(c) ? encodeChar(c) : c))
+      .join("").replace("%20", "+");
   }
 
   window.__bootstrap.url = {

--- a/cli/tests/unit/url_search_params_test.ts
+++ b/cli/tests/unit/url_search_params_test.ts
@@ -1,6 +1,44 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { unitTest, assert, assertEquals } from "./test_util.ts";
 
+unitTest(function urlSearchParamsWithSpace(): void {
+  const init = { str: "hello world" };
+  const searchParams = new URLSearchParams(init).toString();
+  assertEquals(searchParams, "str=hello+world");
+});
+
+unitTest(function urlSearchParamsWithExclamation(): void {
+  const init = [
+    ["str", "hello, world!"],
+  ];
+  const searchParams = new URLSearchParams(init).toString();
+  assertEquals(searchParams, "str=hello%2C+world%21");
+});
+
+unitTest(function urlSearchParamsWithQuotes(): void {
+  const init = [
+    ["str", "'hello world'"],
+  ];
+  const searchParams = new URLSearchParams(init).toString();
+  assertEquals(searchParams, "str=%27hello+world%27");
+});
+
+unitTest(function urlSearchParamsWithBraket(): void {
+  const init = [
+    ["str", "(hello world)"],
+  ];
+  const searchParams = new URLSearchParams(init).toString();
+  assertEquals(searchParams, "str=%28hello+world%29");
+});
+
+unitTest(function urlSearchParamsWithTilde(): void {
+  const init = [
+    ["str", "hello~world"],
+  ];
+  const searchParams = new URLSearchParams(init).toString();
+  assertEquals(searchParams, "str=hello%7Eworld");
+});
+
 unitTest(function urlSearchParamsInitString(): void {
   const init = "c=4&a=2&b=3&%C3%A1=1";
   const searchParams = new URLSearchParams(init);


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

According to the discussion at #7001 this PR fixes the issue of `URLSearchParams#toString` method behaving differently than browsers/specs