### PR TITLE
6999_ts_expect_error_issue

### DIFF
--- a/std/node/_util/_util_promisify.ts
+++ b/std/node/_util/_util_promisify.ts
@@ -83,10 +83,9 @@ export function promisify(original: Function): Function {
   // arguments, e.g. ['bytesRead', 'buffer'] for fs.read.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const argumentNames = (original as any)[kCustomPromisifyArgsSymbol];
-
-  function fn(...args: unknown[]): Promise<unknown> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function fn(this: any, ...args: unknown[]): Promise<unknown> {
     return new Promise((resolve, reject) => {
-      // @ts-ignore
       original.call(this, ...args, (err: Error, ...values: unknown[]) => {
         if (err) {
           return reject(err);

--- a/std/node/_util/_util_promisify.ts
+++ b/std/node/_util/_util_promisify.ts
@@ -60,11 +60,10 @@ export function promisify(original: Function): Function {
   if (typeof original !== "function") {
     throw new NodeInvalidArgTypeError("original", "Function", original);
   }
-
-  // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
-  if (original[kCustomPromisifiedSymbol]) {
-    // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
-    const fn = original[kCustomPromisifiedSymbol];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((original as any)[kCustomPromisifiedSymbol]) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fn = (original as any)[kCustomPromisifiedSymbol];
     if (typeof fn !== "function") {
       throw new NodeInvalidArgTypeError(
         "util.promisify.custom",
@@ -82,12 +81,12 @@ export function promisify(original: Function): Function {
 
   // Names to create an object from in case the callback receives multiple
   // arguments, e.g. ['bytesRead', 'buffer'] for fs.read.
-  // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
-  const argumentNames = original[kCustomPromisifyArgsSymbol];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const argumentNames = (original as any)[kCustomPromisifyArgsSymbol];
 
   function fn(...args: unknown[]): Promise<unknown> {
     return new Promise((resolve, reject) => {
-      // @ts-expect-error: 'this' implicitly has type 'any' because it does not have a type annotation
+      // @ts-ignore
       original.call(this, ...args, (err: Error, ...values: unknown[]) => {
         if (err) {
           return reject(err);
@@ -95,8 +94,8 @@ export function promisify(original: Function): Function {
         if (argumentNames !== undefined && values.length > 1) {
           const obj = {};
           for (let i = 0; i < argumentNames.length; i++) {
-            // @ts-expect-error TypeScript
-            obj[argumentNames[i]] = values[i];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (obj as any)[argumentNames[i]] = values[i];
           }
           resolve(obj);
         } else {

--- a/std/node/_util/_util_promisify.ts
+++ b/std/node/_util/_util_promisify.ts
@@ -83,7 +83,7 @@ export function promisify(original: Function): Function {
   // arguments, e.g. ['bytesRead', 'buffer'] for fs.read.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const argumentNames = (original as any)[kCustomPromisifyArgsSymbol];
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function fn(this: any, ...args: unknown[]): Promise<unknown> {
     return new Promise((resolve, reject) => {
       original.call(this, ...args, (err: Error, ...values: unknown[]) => {


### PR DESCRIPTION
### Description
Making changes to get rid of the `@ts-expect-error` directives in favor of casting to any and disabling eslint where possible.

Typescript doesnt have full support for Symbols, so we cant quite do everything the cleanest way.

Using ts-expect-errors breaks applications for those who do not use veery strict tsconfigs.

If anyone has any typescript voodoo to trick the compiler, im open to suggestions! 
I do feel this might be the "best" route for now.

### References
#6999 