### PR TITLE
add missing period in docs/contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,7 +11,7 @@
 
 - Please be professional in the forums. We follow
   [Rust's code of conduct](https://www.rust-lang.org/policies/code-of-conduct)
-  (CoC) Have a problem? Email ry@tinyclouds.org.
+  (CoC). Have a problem? Email ry@tinyclouds.org.
 
 ## Development
 


### PR DESCRIPTION
I found missing period in docs/contributing

> - Please be professional in the forums. We follow [Rust's code of conduct](https://www.rust-lang.org/policies/code-of-conduct) (CoC) Have a problem? Email ry@tinyclouds.org.

This should be this

> - Please be professional in the forums. We follow [Rust's code of conduct](https://www.rust-lang.org/policies/code-of-conduct) (CoC). Have a problem? Email ry@tinyclouds.org.