### PR TITLE
upgrade: Rust crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,15 +129,6 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
@@ -226,12 +217,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
-dependencies = [
- "loom",
-]
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cargo_gn"
@@ -253,9 +241,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clap"
-version = "2.33.1"
+version = "2.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
 dependencies = [
  "ansi_term",
  "atty",
@@ -416,7 +404,7 @@ dependencies = [
  "termcolor",
  "test_util",
  "tokio",
- "tokio-rustls 0.13.1",
+ "tokio-rustls 0.14.0",
  "tokio-tungstenite",
  "url",
  "utime",
@@ -441,7 +429,7 @@ dependencies = [
  "log 0.4.11",
  "rusty_v8",
  "serde_json",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "tokio",
  "url",
 ]
@@ -527,22 +515,21 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dprint-core"
-version = "0.24.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61856e0f0bdf8360c36a7875225caaa29aedf3f9d7e79546a083bc11e068151a"
+checksum = "fab44561ffc8f70d26d6c4cc81a648ecd47dd60836abecf0599253a7b9fdbf5d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41224324bd4b71daccb03fd971c38939999cd3115cd705cfb4d44b930cc91dc7"
+checksum = "7a4ffbec696a7381331eca6f98e3e221e00c6491a84fb8b0a1c572648d493600"
 dependencies = [
  "dprint-core",
  "serde",
- "serde_json",
  "swc_common",
  "swc_ecmascript",
 ]
@@ -795,19 +782,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
-dependencies = [
- "cc",
- "libc",
- "log 0.4.11",
- "rustc_version",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,17 +916,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
+checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
  "bytes",
  "futures-util",
  "hyper",
  "log 0.4.11",
- "rustls 0.17.0",
+ "rustls 0.18.0",
  "tokio",
- "tokio-rustls 0.13.1",
+ "tokio-rustls 0.14.0",
  "webpki",
 ]
 
@@ -981,9 +955,9 @@ checksum = "c3360c7b59e5ffa2653671fb74b4741a5d343c03f331c0a4aeda42b5c2b0ec7d"
 
 [[package]]
 name = "indexmap"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
+checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
 dependencies = [
  "autocfg 1.0.0",
  "hashbrown",
@@ -1026,6 +1000,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "is-macro"
@@ -1109,17 +1089,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls 0.1.2",
 ]
 
 [[package]]
@@ -1818,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
+checksum = "12427a5577082c24419c9c417db35cfeb65962efc7675bb6b0d5f1f9d315bfe6"
 dependencies = [
  "async-compression",
  "base64 0.12.3",
@@ -1832,6 +1801,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "ipnet",
  "js-sys",
  "lazy_static",
  "log 0.4.11",
@@ -1839,11 +1809,11 @@ dependencies = [
  "mime_guess 2.0.3",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.17.0",
+ "rustls 0.18.0",
  "serde",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls 0.13.1",
+ "tokio-rustls 0.14.0",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1878,11 +1848,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
+checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 dependencies = [
- "base64 0.10.1",
+ "base64 0.11.0",
  "log 0.4.11",
  "ring",
  "sct",
@@ -1891,11 +1861,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+checksum = "cac94b333ee2aac3284c5b8a1b7fb4dd11cba88c244e3fe33cdbd047af0eb693"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.12.3",
  "log 0.4.11",
  "ring",
  "sct",
@@ -1956,12 +1926,6 @@ dependencies = [
 
 [[package]]
 name = "scoped-tls"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
-
-[[package]]
-name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
@@ -2011,18 +1975,18 @@ checksum = "b46e1121e8180c12ff69a742aabc4f310542b6ccb69f1691689ac17fdf8618aa"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
@@ -2104,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "socket2"
@@ -2221,7 +2185,7 @@ dependencies = [
  "fxhash",
  "log 0.4.11",
  "parking_lot",
- "scoped-tls 1.0.0",
+ "scoped-tls",
  "serde",
  "sourcemap",
  "swc_visit",
@@ -2283,7 +2247,7 @@ dependencies = [
  "log 0.4.11",
  "num-bigint",
  "serde",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -2322,10 +2286,10 @@ dependencies = [
  "once_cell",
  "ordered-float",
  "regex",
- "scoped-tls 1.0.0",
+ "scoped-tls",
  "serde",
  "serde_json",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -2342,7 +2306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15097df318b3396cb3bef860689f0ad70b571a77a08b42511dba6acdf73ad35"
 dependencies = [
  "once_cell",
- "scoped-tls 1.0.0",
+ "scoped-tls",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -2581,24 +2545,24 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3068d891551949b37681724d6b73666787cc63fa8e255c812a41d2513aff9775"
-dependencies = [
- "futures-core",
- "rustls 0.16.0",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
 dependencies = [
  "futures-core",
  "rustls 0.17.0",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228139ddd4fea3fa345a29233009635235833e52807af7ea6448ead03890d6a9"
+dependencies = [
+ "futures-core",
+ "rustls 0.18.0",
  "tokio",
  "webpki",
 ]
@@ -2644,6 +2608,36 @@ name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
+name = "tracing"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
+dependencies = [
+ "cfg-if",
+ "log 0.4.11",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
 
 [[package]]
 name = "try-lock"
@@ -2846,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e95175b7a927258ecbb816bdada3cc469cb68593e7940b96a60f4af366a9970"
+checksum = "df341dee97c9ae29dfa5e0b0fbbbf620e0d6a36686389bedf83b3daeb8b0d0ac"
 dependencies = [
  "bytes",
  "futures",
@@ -2860,14 +2854,16 @@ dependencies = [
  "mime_guess 2.0.3",
  "multipart",
  "pin-project",
- "scoped-tls 1.0.0",
+ "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls 0.12.3",
+ "tokio-rustls 0.13.1",
  "tokio-tungstenite",
  "tower-service",
+ "tracing",
+ "tracing-futures",
  "urlencoding",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,57 +19,57 @@ deno_core = { path = "../core", version = "0.52.0" }
 deno_web = { path = "../op_crates/web", version = "0.2.0" }
 
 [target.'cfg(windows)'.build-dependencies]
-winres = "0.1"
-winapi = "0.3.8"
+winres = "0.1.11"
+winapi = "0.3.9"
 
 [dependencies]
 deno_core = { path = "../core", version = "0.52.0" }
 deno_lint = { version = "0.1.21", features = ["json"] }
 
 atty = "0.2.14"
-base64 = "0.12.2"
-bytes = "0.5.5"
+base64 = "0.12.3"
+bytes = "0.5.6"
 byteorder = "1.3.4"
-clap = "2.33.1"
+clap = "2.33.2"
 dissimilar = "1.0.2"
 dlopen = "0.1.8"
 encoding_rs = "0.8.23"
-dprint-plugin-typescript = "0.25.0"
+dprint-plugin-typescript = "0.27.0"
 futures = "0.3.5"
 http = "0.2.1"
 idna = "0.2.0"
-indexmap = "1.4.0"
+indexmap = "1.5.1"
 lazy_static = "1.4.0"
-libc = "0.2.71"
-log = "0.4.8"
-notify = "5.0.0-pre.2"
+libc = "0.2.74"
+log = "0.4.11"
+notify = "5.0.0-pre.3"
 rand = "0.7.3"
 regex = "1.3.9"
-reqwest = { version = "0.10.6", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli"] }
+reqwest = { version = "0.10.7", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli"] }
 ring = "0.16.15"
-rustyline = { version = "6.2", default-features = false }
-serde = { version = "1.0.112", features = ["derive"] }
-serde_derive = "1.0.112"
-serde_json = { version = "1.0.55", features = [ "preserve_order" ] }
+rustyline = { version = "6.2.0", default-features = false }
+serde = { version = "1.0.115", features = ["derive"] }
+serde_derive = "1.0.115"
+serde_json = { version = "1.0.57", features = [ "preserve_order" ] }
 sys-info = "0.7.0"
-sourcemap = "6.0.0"
+sourcemap = "6.0.1"
 swc_common = { version = "=0.8.0", features = ["sourcemap"] }
 swc_ecmascript = { version = "=0.1.0", features = ["codegen", "parser", "transforms", "visit"] }
 tempfile = "3.1.0"
 termcolor = "1.1.0"
 tokio = { version = "0.2.22", features = ["full"] }
-tokio-rustls = "0.13.1"
+tokio-rustls = "0.14.0"
 url = "2.1.1"
-utime = "0.3.0"
+utime = "0.3.1"
 webpki = "0.21.3"
 webpki-roots = "0.19.0"
 walkdir = "2.3.1"
-warp = { version = "0.2.3", features = ["tls"] }
+warp = { version = "0.2.4", features = ["tls"] }
 semver-parser = "0.9.0"
 uuid = { version = "0.8.1", features = ["v4"] }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.8", features = ["knownfolders", "objbase", "shlobj",
+winapi = { version = "0.3.9", features = ["knownfolders", "objbase", "shlobj",
 "winbase", "winerror", "tlhelp32"] }
 fwdansi = "1.1.0"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,14 +14,14 @@ repository = "https://github.com/denoland/deno"
 path = "lib.rs"
 
 [dependencies]
-downcast-rs = "1.1.1"
+downcast-rs = "1.2.0"
 futures = "0.3.5"
 lazy_static = "1.4.0"
-libc = "0.2.71"
-log = "0.4.8"
+libc = "0.2.74"
+log = "0.4.11"
 rusty_v8 = "0.8.1"
-serde_json = { version = "1.0.55", features = [ "preserve_order" ] }
-smallvec = "1.4.0"
+serde_json = { version = "1.0.57", features = [ "preserve_order" ] }
+smallvec = "1.4.2"
 url = "2.1.1"
 
 [[example]]
@@ -30,5 +30,5 @@ path = "examples/http_bench.rs"
 
 # These dependendencies are only used for deno_core_http_bench.
 [dev-dependencies]
-derive_deref = "1.1.0"
+derive_deref = "1.1.1"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -12,9 +12,9 @@ path = "src/test_server.rs"
 [dependencies]
 tokio = { version = "0.2.22", features = ["full"] }
 futures = "0.3.5"
-bytes = "0.5.5"
+bytes = "0.5.6"
 lazy_static = "1.4.0"
 os_pipe = "0.9.2"
 regex = "1.3.9"
 tempfile = "3.1.0"
-warp = { version = "0.2.3", features = ["tls"] }
+warp = { version = "0.2.4", features = ["tls"] }


### PR DESCRIPTION
The following crates were _not_ upgraded to avoid having multiple
versions of the same crate in the dependency tree:

  * tokio-tungstenite v0.10.1 -> v0.11.0
  * swc_common        v0. 8.0 -> v0. 9.1
  * swc_ecmascript    v0. 1.0 -> v0. 3.0
  * webpki-roots      v0.19.0 -> v0.20.0
  * nix               v0.17.0 -> v0.18.0

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
