### PR TITLE
Simplify deno_core_http_bench op state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,6 @@ dependencies = [
 name = "deno_core"
 version = "0.53.0"
 dependencies = [
- "derive_deref",
  "downcast-rs",
  "futures",
  "lazy_static",
@@ -416,17 +415,6 @@ version = "0.3.0"
 dependencies = [
  "deno_core",
  "futures",
-]
-
-[[package]]
-name = "derive_deref"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdbcee2d9941369faba772587a565f4f534e42cb8d17e5295871de730163b2b"
-dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.36",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,5 +30,4 @@ path = "examples/http_bench.rs"
 
 # These dependendencies are only used for deno_core_http_bench.
 [dev-dependencies]
-derive_deref = "1.1.1"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/core/examples/http_bench.rs
+++ b/core/examples/http_bench.rs
@@ -1,6 +1,4 @@
 #[macro_use]
-extern crate derive_deref;
-#[macro_use]
 extern crate log;
 
 use deno_core::CoreIsolate;
@@ -11,9 +9,9 @@ use deno_core::Script;
 use deno_core::StartupData;
 use deno_core::ZeroCopyBuf;
 use futures::future::poll_fn;
-use futures::prelude::*;
-use futures::task::Context;
-use futures::task::Poll;
+use futures::future::FutureExt;
+use futures::future::TryFuture;
+use futures::future::TryFutureExt;
 use std::cell::RefCell;
 use std::convert::TryInto;
 use std::env;
@@ -77,56 +75,37 @@ impl From<Record> for RecordBuf {
   }
 }
 
-struct Isolate {
-  core_isolate: CoreIsolate,
-  state: State,
-}
+pub fn isolate_new() -> CoreIsolate {
+  let startup_data = StartupData::Script(Script {
+    source: include_str!("http_bench.js"),
+    filename: "http_bench.js",
+  });
 
-#[derive(Clone, Default, Deref)]
-struct State(Rc<RefCell<StateInner>>);
+  let mut isolate = CoreIsolate::new(startup_data, false);
 
-#[derive(Default)]
-struct StateInner {
-  resource_table: ResourceTable,
-}
-
-impl Isolate {
-  pub fn new() -> Self {
-    let startup_data = StartupData::Script(Script {
-      source: include_str!("http_bench.js"),
-      filename: "http_bench.js",
-    });
-
-    let mut isolate = Self {
-      core_isolate: CoreIsolate::new(startup_data, false),
-      state: Default::default(),
-    };
-
-    isolate.register_sync_op("listen", op_listen);
-    isolate.register_op("accept", op_accept);
-    isolate.register_op("read", op_read);
-    isolate.register_op("write", op_write);
-    isolate.register_sync_op("close", op_close);
-
-    isolate
-  }
-
-  fn register_sync_op<F>(&mut self, name: &'static str, handler: F)
-  where
-    F: 'static + Fn(State, u32, &mut [ZeroCopyBuf]) -> Result<u32, Error>,
+  fn register_sync_op<F>(
+    isolate: &mut CoreIsolate,
+    name: &'static str,
+    handler: F,
+  ) where
+    F: 'static
+      + Fn(
+        Rc<RefCell<ResourceTable>>,
+        u32,
+        &mut [ZeroCopyBuf],
+      ) -> Result<u32, Error>,
   {
-    let state = self.state.clone();
-    let core_handler = move |_isolate_state: &mut CoreIsolateState,
+    let core_handler = move |state: &mut CoreIsolateState,
                              zero_copy_bufs: &mut [ZeroCopyBuf]|
           -> Op {
       assert!(!zero_copy_bufs.is_empty());
-      let state = state.clone();
       let record = Record::from(zero_copy_bufs[0].as_ref());
       let is_sync = record.promise_id == 0;
       assert!(is_sync);
 
+      let resource_table = state.resource_table.clone();
       let result: i32 =
-        match handler(state, record.rid, &mut zero_copy_bufs[1..]) {
+        match handler(resource_table, record.rid, &mut zero_copy_bufs[1..]) {
           Ok(r) => r as i32,
           Err(_) => -1,
         };
@@ -134,31 +113,32 @@ impl Isolate {
       Op::Sync(buf)
     };
 
-    self.core_isolate.register_op(name, core_handler);
+    isolate.register_op(name, core_handler);
   }
 
-  fn register_op<F>(
-    &mut self,
+  fn register_async_op<F>(
+    isolate: &mut CoreIsolate,
     name: &'static str,
-    handler: impl Fn(State, u32, &mut [ZeroCopyBuf]) -> F + Copy + 'static,
+    handler: impl Fn(Rc<RefCell<ResourceTable>>, u32, &mut [ZeroCopyBuf]) -> F
+      + Copy
+      + 'static,
   ) where
     F: TryFuture,
     F::Ok: TryInto<i32>,
     <F::Ok as TryInto<i32>>::Error: Debug,
   {
-    let state = self.state.clone();
-    let core_handler = move |_isolate_state: &mut CoreIsolateState,
+    let core_handler = move |state: &mut CoreIsolateState,
                              zero_copy_bufs: &mut [ZeroCopyBuf]|
           -> Op {
       assert!(!zero_copy_bufs.is_empty());
-      let state = state.clone();
       let record = Record::from(zero_copy_bufs[0].as_ref());
       let is_sync = record.promise_id == 0;
       assert!(!is_sync);
 
       let mut zero_copy = zero_copy_bufs[1..].to_vec();
+      let resource_table = state.resource_table.clone();
       let fut = async move {
-        let op = handler(state, record.rid, &mut zero_copy);
+        let op = handler(resource_table, record.rid, &mut zero_copy);
         let result = op
           .map_ok(|r| r.try_into().expect("op result does not fit in i32"))
           .unwrap_or_else(|_| -1)
@@ -169,25 +149,25 @@ impl Isolate {
       Op::Async(fut.boxed_local())
     };
 
-    self.core_isolate.register_op(name, core_handler);
+    isolate.register_op(name, core_handler);
   }
-}
 
-impl Future for Isolate {
-  type Output = <CoreIsolate as Future>::Output;
+  register_sync_op(&mut isolate, "listen", op_listen);
+  register_async_op(&mut isolate, "accept", op_accept);
+  register_async_op(&mut isolate, "read", op_read);
+  register_async_op(&mut isolate, "write", op_write);
+  register_sync_op(&mut isolate, "close", op_close);
 
-  fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-    self.core_isolate.poll_unpin(cx)
-  }
+  isolate
 }
 
 fn op_close(
-  state: State,
+  resource_table: Rc<RefCell<ResourceTable>>,
   rid: u32,
   _buf: &mut [ZeroCopyBuf],
 ) -> Result<u32, Error> {
   debug!("close rid={}", rid);
-  let resource_table = &mut state.borrow_mut().resource_table;
+  let resource_table = &mut resource_table.borrow_mut();
   resource_table
     .close(rid)
     .map(|_| 0)
@@ -195,7 +175,7 @@ fn op_close(
 }
 
 fn op_listen(
-  state: State,
+  resource_table: Rc<RefCell<ResourceTable>>,
   _rid: u32,
   _buf: &mut [ZeroCopyBuf],
 ) -> Result<u32, Error> {
@@ -203,20 +183,20 @@ fn op_listen(
   let addr = "127.0.0.1:4544".parse::<SocketAddr>().unwrap();
   let std_listener = std::net::TcpListener::bind(&addr)?;
   let listener = TcpListener::from_std(std_listener)?;
-  let resource_table = &mut state.borrow_mut().resource_table;
+  let resource_table = &mut resource_table.borrow_mut();
   let rid = resource_table.add("tcpListener", Box::new(listener));
   Ok(rid)
 }
 
 fn op_accept(
-  state: State,
+  resource_table: Rc<RefCell<ResourceTable>>,
   rid: u32,
   _buf: &mut [ZeroCopyBuf],
 ) -> impl TryFuture<Ok = u32, Error = Error> {
   debug!("accept rid={}", rid);
 
   poll_fn(move |cx| {
-    let resource_table = &mut state.borrow_mut().resource_table;
+    let resource_table = &mut resource_table.borrow_mut();
     let listener = resource_table
       .get_mut::<TcpListener>(rid)
       .ok_or_else(bad_resource)?;
@@ -227,7 +207,7 @@ fn op_accept(
 }
 
 fn op_read(
-  state: State,
+  resource_table: Rc<RefCell<ResourceTable>>,
   rid: u32,
   bufs: &mut [ZeroCopyBuf],
 ) -> impl TryFuture<Ok = usize, Error = Error> {
@@ -237,7 +217,7 @@ fn op_read(
   debug!("read rid={}", rid);
 
   poll_fn(move |cx| {
-    let resource_table = &mut state.borrow_mut().resource_table;
+    let resource_table = &mut resource_table.borrow_mut();
     let stream = resource_table
       .get_mut::<TcpStream>(rid)
       .ok_or_else(bad_resource)?;
@@ -246,7 +226,7 @@ fn op_read(
 }
 
 fn op_write(
-  state: State,
+  resource_table: Rc<RefCell<ResourceTable>>,
   rid: u32,
   bufs: &mut [ZeroCopyBuf],
 ) -> impl TryFuture<Ok = usize, Error = Error> {
@@ -255,7 +235,7 @@ fn op_write(
   debug!("write rid={}", rid);
 
   poll_fn(move |cx| {
-    let resource_table = &mut state.borrow_mut().resource_table;
+    let resource_table = &mut resource_table.borrow_mut();
     let stream = resource_table
       .get_mut::<TcpStream>(rid)
       .ok_or_else(bad_resource)?;
@@ -279,7 +259,7 @@ fn main() {
   // NOTE: `--help` arg will display V8 help and exit
   deno_core::v8_set_flags(env::args().collect());
 
-  let isolate = Isolate::new();
+  let isolate = isolate_new();
   let mut runtime = tokio::runtime::Builder::new()
     .basic_scheduler()
     .enable_all()


### PR DESCRIPTION
Removes unnecessary wrappers around ResourceTable and CoreIsolate.

Importantly: now uses the resource table inside CoreIsolateState rather than a different one.

Removes derive_deref dependency 