### PR TITLE
BugFix(6975) Dash Value Treated As Arg

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1,9 +1,9 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use clap::App;
 use clap::AppSettings;
+use clap::ArgSettings;
 use clap::Arg;
 use clap::ArgMatches;
-use clap::ArgSettings;
 use clap::SubCommand;
 use log::Level;
 use std::net::SocketAddr;
@@ -989,10 +989,10 @@ Show documentation for runtime built-ins:
     // https://github.com/clap-rs/clap/issues/1794. Currently `--builtin` is
     // just a possible value of `source_file` so leading hyphens must be
     // enabled.
+    .setting(clap::AppSettings::AllowLeadingHyphen)
     .arg(Arg::with_name("source_file").takes_value(true))
     .arg(
       Arg::with_name("filter")
-        .set(ArgSettings::AllowLeadingHyphen)
         .help("Dot separated path to symbol.")
         .takes_value(true)
         .required(false)
@@ -1180,11 +1180,11 @@ fn test_subcommand<'a, 'b>() -> App<'a, 'b> {
     )
     .arg(
       Arg::with_name("filter")
+        .set(ArgSettings::AllowLeadingHyphen)
         .long("filter")
         .takes_value(true)
         .help("Run tests with this string or pattern in the test name"),
     )
-    .setting(clap::AppSettings::AllowLeadingHyphen)
     .arg(
       Arg::with_name("files")
         .help("List of file names to run")

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1,9 +1,9 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use clap::App;
 use clap::AppSettings;
-use clap::ArgSettings;
 use clap::Arg;
 use clap::ArgMatches;
+use clap::ArgSettings;
 use clap::SubCommand;
 use log::Level;
 use std::net::SocketAddr;

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1183,6 +1183,7 @@ fn test_subcommand<'a, 'b>() -> App<'a, 'b> {
         .takes_value(true)
         .help("Run tests with this string or pattern in the test name"),
     )
+    .setting(clap::AppSettings::AllowLeadingHyphen)
     .arg(
       Arg::with_name("files")
         .help("List of file names to run")
@@ -2839,6 +2840,25 @@ mod tests {
           allow_none: false,
           quiet: false,
           filter: Some("foo".to_string()),
+          include: Some(svec!["dir1"]),
+        },
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn test_filter_leading_hyphen() {
+    let r =
+      flags_from_vec_safe(svec!["deno", "test", "--filter", "- foo", "dir1"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Test {
+          fail_fast: false,
+          allow_none: false,
+          quiet: false,
+          filter: Some("- foo".to_string()),
           include: Some(svec!["dir1"]),
         },
         ..Flags::default()

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -3,6 +3,7 @@ use clap::App;
 use clap::AppSettings;
 use clap::Arg;
 use clap::ArgMatches;
+use clap::ArgSettings;
 use clap::SubCommand;
 use log::Level;
 use std::net::SocketAddr;
@@ -988,10 +989,10 @@ Show documentation for runtime built-ins:
     // https://github.com/clap-rs/clap/issues/1794. Currently `--builtin` is
     // just a possible value of `source_file` so leading hyphens must be
     // enabled.
-    .setting(clap::AppSettings::AllowLeadingHyphen)
     .arg(Arg::with_name("source_file").takes_value(true))
     .arg(
       Arg::with_name("filter")
+        .set(ArgSettings::AllowLeadingHyphen)
         .help("Dot separated path to symbol.")
         .takes_value(true)
         .required(false)


### PR DESCRIPTION
### Description
Quick bug fix to add the leading dash setting for the --filter arg in the test subcommand


### References
#6975 
[AllowLeadingHyphen Docs](https://docs.rs/clap/2.33.2/clap/enum.AppSettings.html#variant.AllowLeadingHyphen)
