### PR TITLE
refactor(cli/rt): inline single line single use open helper functions

### DIFF
--- a/cli/rt/30_files.js
+++ b/cli/rt/30_files.js
@@ -22,25 +22,14 @@
     return sendAsync("op_seek", { rid, offset, whence });
   }
 
-  function opOpenSync(path, options) {
-    const mode = options?.mode;
-    return sendSync("op_open", { path: pathFromURL(path), options, mode });
-  }
-
-  function opOpen(
-    path,
-    options,
-  ) {
-    const mode = options?.mode;
-    return sendAsync("op_open", { path: pathFromURL(path), options, mode });
-  }
-
   function openSync(
     path,
     options = { read: true },
   ) {
     checkOpenOptions(options);
-    const rid = opOpenSync(path, options);
+    const mode = options?.mode;
+    const rid = sendSync("op_open", { path: pathFromURL(path), options, mode });
+
     return new File(rid);
   }
 
@@ -49,7 +38,12 @@
     options = { read: true },
   ) {
     checkOpenOptions(options);
-    const rid = await opOpen(path, options);
+    const mode = options?.mode;
+    const rid = await sendAsync(
+      "op_open",
+      { path: pathFromURL(path), options, mode },
+    );
+
     return new File(rid);
   }
 


### PR DESCRIPTION
This inlines the helper functions for the open ops as they introduce more code than they remove and are not re-used anywhere.