### PR TITLE
Add missing export of HeapLimits

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -27,6 +27,7 @@ pub use rusty_v8 as v8;
 pub use crate::core_isolate::js_check;
 pub use crate::core_isolate::CoreIsolate;
 pub use crate::core_isolate::CoreIsolateState;
+pub use crate::core_isolate::HeapLimits;
 pub use crate::core_isolate::Script;
 pub use crate::core_isolate::Snapshot;
 pub use crate::core_isolate::StartupData;


### PR DESCRIPTION
Currently this blocks using the ::with_heap_limits constructor of CoreIsolate, because you cannot access the struct.
