### PR TITLE
BREAKING(std/log): remove string formatter

### DIFF
--- a/cli/errors.rs
+++ b/cli/errors.rs
@@ -156,12 +156,14 @@ fn get_url_parse_error_class(_error: &url::ParseError) -> &'static str {
 fn get_nix_error_class(error: &nix::Error) -> &'static str {
   use nix::errno::Errno::*;
   match error {
-    nix::Error::Sys(EPERM) => "PermissionDenied",
+    nix::Error::Sys(ECHILD) => "NotFound",
     nix::Error::Sys(EINVAL) => "TypeError",
     nix::Error::Sys(ENOENT) => "NotFound",
     nix::Error::Sys(ENOTTY) => "BadResource",
-    nix::Error::Sys(UnknownErrno) => unreachable!(),
-    nix::Error::Sys(_) => unreachable!(),
+    nix::Error::Sys(EPERM) => "PermissionDenied",
+    nix::Error::Sys(ESRCH) => "NotFound",
+    nix::Error::Sys(UnknownErrno) => "Error",
+    nix::Error::Sys(_) => "Error",
     nix::Error::InvalidPath => "TypeError",
     nix::Error::InvalidUtf8 => "InvalidData",
     nix::Error::UnsupportedOperation => unreachable!(),

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -375,6 +375,30 @@ unitTest({ perms: { run: true } }, async function runClose(): Promise<void> {
   p.stderr.close();
 });
 
+unitTest(
+  { perms: { run: true } },
+  async function runKillAfterStatus(): Promise<void> {
+    const p = Deno.run({
+      cmd: ["python", "-c", 'print("hello")'],
+    });
+    await p.status();
+
+    // On Windows the underlying Rust API returns `ERROR_ACCESS_DENIED`,
+    // which serves kind of as a catch all error code. More specific
+    // error codes do exist, e.g. `ERROR_WAIT_NO_CHILDREN`; it's unclear
+    // why they're not returned.
+    const expectedErrorType = Deno.build.os === "windows"
+      ? Deno.errors.PermissionDenied
+      : Deno.errors.NotFound;
+    assertThrows(
+      () => p.kill(Deno.Signal.SIGTERM),
+      expectedErrorType,
+    );
+
+    p.close();
+  },
+);
+
 unitTest(function signalNumbers(): void {
   if (Deno.build.os === "darwin") {
     assertEquals(Deno.Signal.SIGSTOP, 17);

--- a/std/log/README.md
+++ b/std/log/README.md
@@ -22,7 +22,7 @@ await log.setup({
     file: new log.handlers.FileHandler("WARNING", {
       filename: "./log.txt",
       // you can change format of output message using any keys in `LogRecord`
-      formatter: "{levelName} {msg}",
+      formatter: ({ levelName, msg }) => `${levelName} ${msg}`,
     }),
   },
 
@@ -101,7 +101,7 @@ console via `console.log()`. This logger takes `HandlerOptions`:
 type FormatterFunction = (logRecord: LogRecord) => string;
 
 interface HandlerOptions {
-  formatter?: string | FormatterFunction; //see `Custom message format` below
+  formatter?: FormatterFunction; //see `Custom message format` below
 }
 ```
 
@@ -115,7 +115,7 @@ process completion. This logger takes `FileOptions`:
 
 ```typescript
 interface FileHandlerOptions {
-  formatter?: string | FormatterFunction; //see `Custom message format` below
+  formatter?: FormatterFunction; //see `Custom message format` below
   filename: string;
   mode?: LogMode; // 'a', 'w', 'x'
 }
@@ -163,7 +163,7 @@ Options for this handler are:
 interface RotatingFileHandlerOptions {
   maxBytes: number;
   maxBackupCount: number;
-  formatter?: string | FormatterFunction; //see `Custom message format` below
+  formatter?: FormatterFunction; //see `Custom message format` below
   filename: string;
   mode?: LogMode; // 'a', 'w', 'x'
 }
@@ -185,9 +185,8 @@ log files.
 ### Custom message format
 
 If you want to override default format of message you can define `formatter`
-option for handler. It can be either simple string-based format that uses
-`LogRecord` fields or more complicated function-based one that takes `LogRecord`
-as argument and outputs string.
+option for handler. It is a function-based format that takes `LogRecord` as an
+argument and outputs a string.
 
 Eg.
 
@@ -195,7 +194,7 @@ Eg.
 await log.setup({
   handlers: {
     stringFmt: new log.handlers.ConsoleHandler("DEBUG", {
-      formatter: "[{levelName}] {msg}"
+      formatter: ({levelName, msg}) => `[${levelName}] ${msg}`
     }),
 
     functionFmt: new log.handlers.ConsoleHandler("DEBUG", {
@@ -211,7 +210,7 @@ await log.setup({
     }),
 
     anotherFmt: new log.handlers.ConsoleHandler("DEBUG", {
-      formatter: "[{loggerName}] - {levelName} {msg}"
+      formatter: ({loggerName, levelName, msg}) => `[${loggerName}] - ${levelName} ${msg}`
     }),
   },
 

--- a/std/log/handlers_test.ts
+++ b/std/log/handlers_test.ts
@@ -12,7 +12,12 @@ import {
   getLevelByName,
   LevelName,
 } from "./levels.ts";
-import { BaseHandler, FileHandler, RotatingFileHandler } from "./handlers.ts";
+import {
+  BaseHandler,
+  FileHandler,
+  RotatingFileHandler,
+  FormatterFunction,
+} from "./handlers.ts";
 import { LogRecord } from "./logger.ts";
 import { existsSync } from "../fs/exists.ts";
 
@@ -79,7 +84,8 @@ Deno.test("simpleHandler", function (): void {
 
 Deno.test("testFormatterAsString", function (): void {
   const handler = new TestHandler("DEBUG", {
-    formatter: "test {levelName} {msg}",
+    formatter: (({ levelName, msg }) =>
+      `test ${levelName} ${msg}`) as FormatterFunction,
   });
 
   handler.handle(
@@ -96,7 +102,8 @@ Deno.test("testFormatterAsString", function (): void {
 
 Deno.test("testFormatterWithEmptyMsg", function () {
   const handler = new TestHandler("DEBUG", {
-    formatter: "test {levelName} {msg}",
+    formatter: (({ levelName, msg }) =>
+      `test ${levelName} ${msg}`) as FormatterFunction,
   });
 
   handler.handle(

--- a/std/log/logger_test.ts
+++ b/std/log/logger_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals, assert } from "../testing/asserts.ts";
 import { LogRecord, Logger } from "./logger.ts";
 import { LogLevels, LevelName } from "./levels.ts";
-import { BaseHandler } from "./handlers.ts";
+import { BaseHandler, FormatterFunction } from "./handlers.ts";
 
 class TestHandler extends BaseHandler {
   public messages: string[] = [];
@@ -23,7 +23,8 @@ Deno.test({
   fn() {
     const handlerNoName = new TestHandler("DEBUG");
     const handlerWithLoggerName = new TestHandler("DEBUG", {
-      formatter: "[{loggerName}] {levelName} {msg}",
+      formatter: (({ loggerName, levelName, msg }) =>
+        `[${loggerName}] ${levelName} ${msg}`) as FormatterFunction,
     });
 
     const logger = new Logger("config", "DEBUG", {

--- a/std/log/mod_test.ts
+++ b/std/log/mod_test.ts
@@ -12,7 +12,7 @@ import {
   LogLevels,
   LevelName,
 } from "./mod.ts";
-import { BaseHandler } from "./handlers.ts";
+import { BaseHandler, FormatterFunction } from "./handlers.ts";
 
 class TestHandler extends BaseHandler {
   public messages: string[] = [];
@@ -64,7 +64,8 @@ Deno.test({
   async fn() {
     const consoleHandler = new TestHandler("DEBUG");
     const anotherConsoleHandler = new TestHandler("DEBUG", {
-      formatter: "[{loggerName}] {levelName} {msg}",
+      formatter: (({ loggerName, levelName, msg }) =>
+        `[${loggerName}] ${levelName} ${msg}`) as FormatterFunction,
     });
     await setup({
       handlers: {


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
Breaking change: remove string based formatter  in favor of function based formatter and template strings. 