### PR TITLE
fix(std/encoding/csv): improve error message on ParseError

### DIFF
--- a/std/encoding/csv.ts
+++ b/std/encoding/csv.ts
@@ -45,7 +45,8 @@ export class ParseError extends Error {
       this.message =
         `record on line ${start}; parse error on line ${line}, column ${column}: ${message}`;
     } else {
-      this.message = `parse error on line ${line}, column ${column}: ${message}`;
+      this.message =
+        `parse error on line ${line}, column ${column}: ${message}`;
     }
   }
 }
@@ -190,13 +191,16 @@ async function readRecord(
           recordBuffer += line;
           const r = await readLine(tp);
           lineIndex++;
+          line = r ?? ""; // This is a workaround for making this module behave similarly to the encoding/csv/reader.go.
+          fullLine = line;
           if (r === null) {
             // Abrupt end of file (EOF or error).
             if (!opt.lazyQuotes) {
+              const col = runeCount(fullLine);
               quoteError = new ParseError(
                 startLine + 1,
                 lineIndex,
-                null,
+                col,
                 ERR_QUOTE,
               );
               break parseField;
@@ -205,8 +209,6 @@ async function readRecord(
             break parseField;
           }
           recordBuffer += "\n"; // preserve line feed (This is because TextProtoReader removes it.)
-          line = r;
-          fullLine = line;
         } else {
           // Abrupt end of file (EOF on error).
           if (!opt.lazyQuotes) {

--- a/std/encoding/csv.ts
+++ b/std/encoding/csv.ts
@@ -27,28 +27,25 @@ export class ParseError extends Error {
   line: number;
   /** Column (rune index) where the error occurred */
   column: number | null;
-  /** The actual error */
-  error: string;
 
   constructor(
     start: number,
     line: number,
     column: number | null,
-    error: string,
+    message: string,
   ) {
     super();
     this.startLine = start;
     this.column = column;
     this.line = line;
-    this.error = error;
 
-    if (error === ERR_FIELD_COUNT) {
-      this.message = `record on line ${line}: ${error}`;
+    if (message === ERR_FIELD_COUNT) {
+      this.message = `record on line ${line}: ${message}`;
     } else if (start !== line) {
       this.message =
-        `record on line ${start}; parse error on line ${line}, column ${column}: ${error}`;
+        `record on line ${start}; parse error on line ${line}, column ${column}: ${message}`;
     } else {
-      this.message = `parse error on line ${line}, column ${column}: ${error}`;
+      this.message = `parse error on line ${line}, column ${column}: ${message}`;
     }
   }
 }

--- a/std/encoding/csv_test.ts
+++ b/std/encoding/csv_test.ts
@@ -484,15 +484,7 @@ for (const t of testCases) {
           );
         });
 
-        if (t.Error instanceof ParseError) {
-          assert(err instanceof ParseError);
-          assertEquals(err.error, t.Error.error);
-          assertEquals(err.startLine, t.Error.startLine);
-          assertEquals(err.line, t.Error.line);
-          assertEquals(err.column, t.Error.column);
-        } else {
-          assertEquals(err, t.Error);
-        }
+        assertEquals(err, t.Error);
       } else {
         actual = await readMatrix(
           new BufReader(new StringReader(t.Input ?? "")),

--- a/std/encoding/csv_test.ts
+++ b/std/encoding/csv_test.ts
@@ -4,7 +4,7 @@
 // https://github.com/golang/go/blob/master/LICENSE
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals, assert } from "../testing/asserts.ts";
+import { assert, assertEquals, assertThrowsAsync } from "../testing/asserts.ts";
 import {
   readMatrix,
   parse,
@@ -12,6 +12,7 @@ import {
   ERR_QUOTE,
   ERR_INVALID_DELIM,
   ERR_FIELD_COUNT,
+  ParseError,
 } from "./csv.ts";
 import { StringReader } from "../io/readers.ts";
 import { BufReader } from "../io/bufio.ts";
@@ -133,8 +134,7 @@ field"`,
   {
     Name: "BadDoubleQuotes",
     Input: `a""b,c`,
-    Error: ERR_BARE_QUOTE,
-    // Error: &ParseError{StartLine: 1, Line: 1, Column: 1, Err: ErrBareQuote},
+    Error: new ParseError(1, 1, 1, ERR_BARE_QUOTE),
   },
   {
     Name: "TrimQuote",
@@ -145,33 +145,31 @@ field"`,
   {
     Name: "BadBareQuote",
     Input: `a "word","b"`,
-    Error: ERR_BARE_QUOTE,
-    // &ParseError{StartLine: 1, Line: 1, Column: 2, Err: ErrBareQuote}
+    Error: new ParseError(1, 1, 2, ERR_BARE_QUOTE),
   },
   {
     Name: "BadTrailingQuote",
     Input: `"a word",b"`,
-    Error: ERR_BARE_QUOTE,
+    Error: new ParseError(1, 1, 10, ERR_BARE_QUOTE),
   },
   {
     Name: "ExtraneousQuote",
     Input: `"a "word","b"`,
-    Error: ERR_QUOTE,
+    Error: new ParseError(1, 1, 3, ERR_QUOTE),
   },
   {
     Name: "BadFieldCount",
     Input: "a,b,c\nd,e",
-    Error: ERR_FIELD_COUNT,
+    Error: new ParseError(2, 2, null, ERR_FIELD_COUNT),
     UseFieldsPerRecord: true,
     FieldsPerRecord: 0,
   },
   {
     Name: "BadFieldCount1",
     Input: `a,b,c`,
-    // Error: &ParseError{StartLine: 1, Line: 1, Err: ErrFieldCount},
     UseFieldsPerRecord: true,
     FieldsPerRecord: 2,
-    Error: ERR_FIELD_COUNT,
+    Error: new ParseError(1, 1, null, ERR_FIELD_COUNT),
   },
   {
     Name: "FieldCount",
@@ -265,14 +263,12 @@ x,,,
   {
     Name: "StartLine1", // Issue 19019
     Input: 'a,"b\nc"d,e',
-    Error: ERR_QUOTE,
-    // Error: &ParseError{StartLine: 1, Line: 2, Column: 1, Err: ErrQuote},
+    Error: new ParseError(1, 2, 1, ERR_QUOTE),
   },
   {
     Name: "StartLine2",
-    Input: 'a,b\n"d\n\n,e',
-    Error: ERR_QUOTE,
-    // Error: &ParseError{StartLine: 2, Line: 5, Column: 0, Err: ErrQuote},
+    Input: 'a,b\n\"d\n\n,e',
+    Error: new ParseError(2, 5, null, ERR_QUOTE),
   },
   {
     Name: "CRLFInQuotedField", // Issue 21201
@@ -297,8 +293,7 @@ x,,,
   {
     Name: "QuotedTrailingCRCR",
     Input: '"field"\r\r',
-    Error: ERR_QUOTE,
-    // Error: &ParseError{StartLine: 1, Line: 1, Column: 6, Err: ErrQuote},
+    Error: new ParseError(1, 1, 6, ERR_QUOTE),
   },
   {
     Name: "FieldCR",
@@ -389,8 +384,7 @@ x,,,
   {
     Name: "QuoteWithTrailingCRLF",
     Input: '"foo"bar"\r\n',
-    Error: ERR_QUOTE,
-    // Error: &ParseError{StartLine: 1, Line: 1, Column: 4, Err: ErrQuote},
+    Error: new ParseError(1, 1, 4, ERR_QUOTE),
   },
   {
     Name: "LazyQuoteWithTrailingCRLF",
@@ -411,8 +405,7 @@ x,,,
   {
     Name: "OddQuotes",
     Input: `"""""""`,
-    Error: ERR_QUOTE,
-    // Error:" &ParseError{StartLine: 1, Line: 1, Column: 7, Err: ErrQuote}",
+    Error: new ParseError(1, 1, 7, ERR_QUOTE),
   },
   {
     Name: "LazyOddQuotes",
@@ -423,33 +416,33 @@ x,,,
   {
     Name: "BadComma1",
     Comma: "\n",
-    Error: ERR_INVALID_DELIM,
+    Error: new Error(ERR_INVALID_DELIM),
   },
   {
     Name: "BadComma2",
     Comma: "\r",
-    Error: ERR_INVALID_DELIM,
+    Error: new Error(ERR_INVALID_DELIM),
   },
   {
     Name: "BadComma3",
     Comma: '"',
-    Error: ERR_INVALID_DELIM,
+    Error: new Error(ERR_INVALID_DELIM),
   },
   {
     Name: "BadComment1",
     Comment: "\n",
-    Error: ERR_INVALID_DELIM,
+    Error: new Error(ERR_INVALID_DELIM),
   },
   {
     Name: "BadComment2",
     Comment: "\r",
-    Error: ERR_INVALID_DELIM,
+    Error: new Error(ERR_INVALID_DELIM),
   },
   {
     Name: "BadCommaComment",
     Comma: "X",
     Comment: "X",
-    Error: ERR_INVALID_DELIM,
+    Error: new Error(ERR_INVALID_DELIM),
   },
 ];
 for (const t of testCases) {
@@ -457,8 +450,8 @@ for (const t of testCases) {
     name: `[CSV] ${t.Name}`,
     async fn(): Promise<void> {
       let comma = ",";
-      let comment;
-      let fieldsPerRec;
+      let comment: string | undefined;
+      let fieldsPerRec: number | undefined;
       let trim = false;
       let lazyquote = false;
       if (t.Comma) {
@@ -478,9 +471,8 @@ for (const t of testCases) {
       }
       let actual;
       if (t.Error) {
-        let err;
-        try {
-          actual = await readMatrix(
+        const err = await assertThrowsAsync(async () => {
+          await readMatrix(
             new BufReader(new StringReader(t.Input ?? "")),
             {
               comma: comma,
@@ -490,11 +482,17 @@ for (const t of testCases) {
               lazyQuotes: lazyquote,
             },
           );
-        } catch (e) {
-          err = e;
+        });
+
+        if (t.Error instanceof ParseError) {
+          assert(err instanceof ParseError);
+          assertEquals(err.error, t.Error.error);
+          assertEquals(err.startLine, t.Error.startLine);
+          assertEquals(err.line, t.Error.line);
+          assertEquals(err.column, t.Error.column);
+        } else {
+          assertEquals(err, t.Error);
         }
-        assert(err);
-        assertEquals(err.message, t.Error);
       } else {
         actual = await readMatrix(
           new BufReader(new StringReader(t.Input ?? "")),
@@ -625,3 +623,23 @@ for (const testCase of parseTestCases) {
     },
   });
 }
+
+Deno.test({
+  name: "[CSV] ParseError.message",
+  fn(): void {
+    assertEquals(
+      new ParseError(2, 2, null, ERR_FIELD_COUNT).message,
+      `record on line 2: ${ERR_FIELD_COUNT}`,
+    );
+
+    assertEquals(
+      new ParseError(1, 2, 1, ERR_QUOTE).message,
+      `record on line 1; parse error on line 2, column 1: ${ERR_QUOTE}`,
+    );
+
+    assertEquals(
+      new ParseError(1, 1, 7, ERR_QUOTE).message,
+      `parse error on line 1, column 7: ${ERR_QUOTE}`,
+    );
+  },
+});

--- a/std/encoding/csv_test.ts
+++ b/std/encoding/csv_test.ts
@@ -268,7 +268,7 @@ x,,,
   {
     Name: "StartLine2",
     Input: 'a,b\n\"d\n\n,e',
-    Error: new ParseError(2, 5, null, ERR_QUOTE),
+    Error: new ParseError(2, 5, 0, ERR_QUOTE),
   },
   {
     Name: "CRLFInQuotedField", // Issue 21201

--- a/std/encoding/csv_test.ts
+++ b/std/encoding/csv_test.ts
@@ -4,7 +4,7 @@
 // https://github.com/golang/go/blob/master/LICENSE
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-import { assert, assertEquals, assertThrowsAsync } from "../testing/asserts.ts";
+import { assertEquals, assertThrowsAsync } from "../testing/asserts.ts";
 import {
   readMatrix,
   parse,


### PR DESCRIPTION
- Renamed `ParseError`'s properties from upper camel case to lower camel case
- Added the `column` property to `ParseError`
- Improved error message as follows:

**Before**:
```shell
error: Uncaught Error: extraneous or missing " in quoted-field
    throw new ParseError(Startline, lineIndex, quoteError);
```
**After**:
```shell
error: Uncaught Error: parse error on line 1, column 7: extraneous or missing " in quoted-field
            quoteError = new ParseError(
```