### PR TITLE
refactor(std/datetime): remove currentDayOfYear

### DIFF
--- a/std/datetime/README.md
+++ b/std/datetime/README.md
@@ -64,19 +64,14 @@ format(new Date(2019, 0, 20), "'today:' yyyy-MM-dd") // output : "today: 2019-01
 ...
 ```
 
-### dayOfYear / currentDayOfYear
+### dayOfYear
 
-- `dayOfYear()` - Returns the number of the day in the year.
-- `currentDayOfYear()` - Returns the number of the current day in the year.
+Returns the number of the day in the year.
 
 ```ts
-import {
-  dayOfYear,
-  currentDayOfYear,
-} from "https://deno.land/std/datetime/mod.ts";
+import { dayOfYear } from "https://deno.land/std/datetime/mod.ts";
 
 dayOfYear(new Date("2019-03-11T03:24:00")); // output: 70
-currentDayOfYear(); // output: ** depends on when you run it :) **
 ```
 
 ### weekOfYear

--- a/std/datetime/mod.ts
+++ b/std/datetime/mod.ts
@@ -55,14 +55,6 @@ export function dayOfYear(date: Date): number {
 }
 
 /**
- * Get number of current day in year
- * @return Number of current day in year
- */
-export function currentDayOfYear(): number {
-  return dayOfYear(new Date());
-}
-
-/**
  * Get number of the week in the year (ISO-8601)
  * @return Number of the week in year
  */

--- a/std/datetime/test.ts
+++ b/std/datetime/test.ts
@@ -114,13 +114,6 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[std/datetime] currentDayOfYear",
-  fn: () => {
-    assertEquals(datetime.dayOfYear(new Date()), datetime.currentDayOfYear());
-  },
-});
-
-Deno.test({
   name: "[std/datetime] weekOfYear",
   fn: () => {
     assertEquals(datetime.weekOfYear(new Date("2020-01-05T03:24:00")), 1);


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
remove obsolete ```currentDayOfYear``` sugar function.