### PR TITLE
Stop TOML parser from detecting numbers in strings.

### DIFF
--- a/std/encoding/testdata/string.toml
+++ b/std/encoding/testdata/string.toml
@@ -31,3 +31,4 @@ trimmed in raw strings.
 
 withApostrophe = "What if it's not?"
 withSemicolon = "const message = 'hello world';"
+withHexNumberLiteral = "Prevent bug from stripping string here ->0xabcdef"

--- a/std/encoding/toml.ts
+++ b/std/encoding/toml.ts
@@ -218,7 +218,7 @@ class Parser {
     }
 
     // If binary / octal / hex
-    const hex = /(0(?:x|o|b)[0-9a-f_]*)[^#]/gi.exec(dataString);
+    const hex = /^(0(?:x|o|b)[0-9a-f_]*)[^#]/gi.exec(dataString);
     if (hex && hex[0]) {
       return hex[0].trim();
     }

--- a/std/encoding/toml_test.ts
+++ b/std/encoding/toml_test.ts
@@ -29,7 +29,8 @@ Deno.test({
           "whitespace\n   is preserved.",
         withApostrophe: "What if it's not?",
         withSemicolon: `const message = 'hello world';`,
-        withHexNumberLiteral: 'Prevent bug from stripping string here ->0xabcdef',
+        withHexNumberLiteral:
+          "Prevent bug from stripping string here ->0xabcdef",
       },
     };
     const actual = parseFile(path.join(testFilesDir, "string.toml"));

--- a/std/encoding/toml_test.ts
+++ b/std/encoding/toml_test.ts
@@ -29,6 +29,7 @@ Deno.test({
           "whitespace\n   is preserved.",
         withApostrophe: "What if it's not?",
         withSemicolon: `const message = 'hello world';`,
+        withHexNumberLiteral: 'Prevent bug from stripping string here ->0xabcdef',
       },
     };
     const actual = parseFile(path.join(testFilesDir, "string.toml"));


### PR DESCRIPTION
Before this patch the TOML parser would incorrect treat the string
"base64data0xdamaged" in a declaration as a hex number because the
corresponding check triggers even when the "0x" is inside a double
quoted string literal as long as it is followed by at least one hex
character.

Fixes https://github.com/denoland/deno/issues/7063
