### PR TITLE
Fix handling of multiple spaces in URLSearchParams

### DIFF
--- a/cli/rt/11_url.js
+++ b/cli/rt/11_url.js
@@ -883,7 +883,7 @@
 
   function encodeSearchParam(s) {
     return [...s].map((c) => (charInFormUrlencodedSet(c) ? encodeChar(c) : c))
-      .join("").replace("%20", "+");
+      .join("").replace(/%20/g, "+");
   }
 
   window.__bootstrap.url = {

--- a/cli/tests/unit/url_search_params_test.ts
+++ b/cli/tests/unit/url_search_params_test.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { unitTest, assert, assertEquals } from "./test_util.ts";
 
-unitTest(function urlSearchParamsWithSpace(): void {
-  const init = { str: "hello world" };
+unitTest(function urlSearchParamsWithMultipleSpaces(): void {
+  const init = { str: "this string has spaces in it" };
   const searchParams = new URLSearchParams(init).toString();
-  assertEquals(searchParams, "str=hello+world");
+  assertEquals(searchParams, "str=this+string+has+spaces+in+it");
 });
 
 unitTest(function urlSearchParamsWithExclamation(): void {


### PR DESCRIPTION
This ensures that all spaces are set to be "+" in the string rather than just the first and brings deno into line with how browsers handle spaces in URLSearchParams, see #7001.