### PR TITLE
Alternative solution for `stateful_json_op_{a}sync()`

### DIFF
--- a/cli/ops/dispatch_json.rs
+++ b/cli/ops/dispatch_json.rs
@@ -30,7 +30,7 @@ fn json_err(err: OpError) -> Value {
   })
 }
 
-fn serialize_result(promise_id: Option<u64>, result: JsonResult) -> Buf {
+pub fn serialize_result(promise_id: Option<u64>, result: JsonResult) -> Buf {
   let value = match result {
     Ok(v) => json!({ "ok": v, "promiseId": promise_id }),
     Err(err) => json!({ "err": json_err(err), "promiseId": promise_id }),

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -3,6 +3,7 @@ mod dispatch_json;
 mod dispatch_minimal;
 
 pub use dispatch_json::json_op;
+pub use dispatch_json::serialize_result;
 pub use dispatch_json::JsonOp;
 pub use dispatch_json::JsonResult;
 pub use dispatch_minimal::minimal_op;

--- a/cli/rt/30_files.js
+++ b/cli/rt/30_files.js
@@ -28,7 +28,10 @@
   ) {
     checkOpenOptions(options);
     const mode = options?.mode;
-    const rid = sendSync("op_open", { path: pathFromURL(path), options, mode });
+    const rid = sendSync(
+      "op_open_sync",
+      { path: pathFromURL(path), options, mode },
+    );
 
     return new File(rid);
   }
@@ -40,7 +43,7 @@
     checkOpenOptions(options);
     const mode = options?.mode;
     const rid = await sendAsync(
-      "op_open",
+      "op_open_async",
       { path: pathFromURL(path), options, mode },
     );
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3203,6 +3203,8 @@ fn set_raw_should_not_panic_on_no_tty() {
 }
 
 #[cfg(windows)]
+// Clippy suggests to remove the `NoStd` prefix from all variants. I disagree.
+#[allow(clippy::enum_variant_names)]
 enum WinProcConstraints {
   NoStdIn,
   NoStdOut,

--- a/core/core_isolate.rs
+++ b/core/core_isolate.rs
@@ -991,10 +991,7 @@ pub mod tests {
          "#,
       ));
       assert_eq!(dispatch_count.load(Ordering::Relaxed), 1);
-      assert!(match isolate.poll_unpin(cx) {
-        Poll::Ready(Ok(_)) => true,
-        _ => false,
-      });
+      assert!(matches!(isolate.poll_unpin(cx), Poll::Ready(Ok(_))));
       assert_eq!(dispatch_count.load(Ordering::Relaxed), 1);
       js_check(isolate.execute(
         "check2.js",
@@ -1005,17 +1002,11 @@ pub mod tests {
          "#,
       ));
       assert_eq!(dispatch_count.load(Ordering::Relaxed), 2);
-      assert!(match isolate.poll_unpin(cx) {
-        Poll::Ready(Ok(_)) => true,
-        _ => false,
-      });
+      assert!(matches!(isolate.poll_unpin(cx), Poll::Ready(Ok(_))));
       js_check(isolate.execute("check3.js", "assert(nrecv == 2)"));
       assert_eq!(dispatch_count.load(Ordering::Relaxed), 2);
       // We are idle, so the next poll should be the last.
-      assert!(match isolate.poll_unpin(cx) {
-        Poll::Ready(Ok(_)) => true,
-        _ => false,
-      });
+      assert!(matches!(isolate.poll_unpin(cx), Poll::Ready(Ok(_))));
     });
   }
 
@@ -1037,10 +1028,7 @@ pub mod tests {
       assert_eq!(dispatch_count.load(Ordering::Relaxed), 1);
       // The above op never finish, but isolate can finish
       // because the op is an unreffed async op.
-      assert!(match isolate.poll_unpin(cx) {
-        Poll::Ready(Ok(_)) => true,
-        _ => false,
-      });
+      assert!(matches!(isolate.poll_unpin(cx), Poll::Ready(Ok(_))));
     })
   }
 
@@ -1167,10 +1155,7 @@ pub mod tests {
          "#,
       ));
       assert_eq!(dispatch_count.load(Ordering::Relaxed), 1);
-      assert!(match isolate.poll_unpin(cx) {
-        Poll::Ready(Ok(_)) => true,
-        _ => false,
-      });
+      assert!(matches!(isolate.poll_unpin(cx), Poll::Ready(Ok(_))));
       js_check(isolate.execute("check.js", "assert(asyncRecv == 1);"));
     });
   }

--- a/core/es_isolate.rs
+++ b/core/es_isolate.rs
@@ -891,23 +891,14 @@ pub mod tests {
       ));
 
       // First poll runs `prepare_load` hook.
-      assert!(match isolate.poll_unpin(cx) {
-        Poll::Pending => true,
-        _ => false,
-      });
+      assert!(matches!(isolate.poll_unpin(cx), Poll::Pending));
       assert_eq!(prepare_load_count.load(Ordering::Relaxed), 1);
 
       // Second poll actually loads modules into the isolate.
-      assert!(match isolate.poll_unpin(cx) {
-        Poll::Ready(Ok(_)) => true,
-        _ => false,
-      });
+      assert!(matches!(isolate.poll_unpin(cx), Poll::Ready(Ok(_))));
       assert_eq!(resolve_count.load(Ordering::Relaxed), 4);
       assert_eq!(load_count.load(Ordering::Relaxed), 2);
-      assert!(match isolate.poll_unpin(cx) {
-        Poll::Ready(Ok(_)) => true,
-        _ => false,
-      });
+      assert!(matches!(isolate.poll_unpin(cx), Poll::Ready(Ok(_))));
       assert_eq!(resolve_count.load(Ordering::Relaxed), 4);
       assert_eq!(load_count.load(Ordering::Relaxed), 2);
     })

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -51,6 +51,7 @@ pub use crate::ops::Op;
 pub use crate::ops::OpAsyncFuture;
 pub use crate::ops::OpId;
 pub use crate::resources::ResourceTable;
+pub use crate::zero_copy_buf::BufVec;
 pub use crate::zero_copy_buf::ZeroCopyBuf;
 
 pub fn v8_version() -> &'static str {

--- a/core/zero_copy_buf.rs
+++ b/core/zero_copy_buf.rs
@@ -1,7 +1,10 @@
 use crate::bindings;
 use rusty_v8 as v8;
+use smallvec::SmallVec;
 use std::ops::Deref;
 use std::ops::DerefMut;
+
+pub type BufVec = SmallVec<[ZeroCopyBuf; 2]>;
 
 /// A ZeroCopyBuf encapsulates a slice that's been borrowed from a JavaScript
 /// ArrayBuffer object. JavaScript objects can normally be garbage collected,


### PR DESCRIPTION
Maybe this is a nicer solution.

A JSON op can no longer have full access to `CoreIsolateState`. But it seems that indeed there's nothing in there except for the resource table that ops need access to.