### PR TITLE
Upgrade dprint to 0.9.0

### DIFF
--- a/.dprintrc.json
+++ b/.dprintrc.json
@@ -25,8 +25,8 @@
     "third_party"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.19.9.wasm",
-    "https://plugins.dprint.dev/json-0.4.1.wasm",
-    "https://plugins.dprint.dev/markdown-0.2.4.wasm"
+    "https://plugins.dprint.dev/typescript-0.29.0.wasm",
+    "https://plugins.dprint.dev/json-0.7.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.4.0.wasm"
   ]
 }


### PR DESCRIPTION
There were some breaking changes to the plugin interface to support a lot of new functionality.

Also, some bug fixes in the plugins themselves.