### PR TITLE
upgrade: swc, deno_lint, dprint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ead89c9eed9768b51ce67a4508657bf2e012085e5ec642cdecae691541d699"
+checksum = "4ba002330f68c912ad16c723fb365e6982a5ddf3923350145c3e0fe04c54f3f1"
 dependencies = [
  "lazy_static",
  "log 0.4.11",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d8a8e95b0826c2928f05b5165c7ff8a29b77a5b0b6eddfacfc47e5c69fafcd"
+checksum = "3db6fad5c93bca5fbb45d512a7e1a889ac01bad449eb7c9f618c252b2da9d7d8"
 dependencies = [
  "dprint-core",
  "serde",
@@ -2229,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55ba299226ff81dfb5a5165a2dc1dd4e873a7b46b2b29e09db3976362145474"
+checksum = "63ca800e654c425bc5baa314fae8f9420a451f3e12c186d9b5dcba41ab27ec65"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,7 @@ winapi = "0.3.9"
 
 [dependencies]
 deno_core = { path = "../core", version = "0.53.0" }
-deno_lint = { version = "0.1.22", features = ["json"] }
+deno_lint = { version = "0.1.23", features = ["json"] }
 
 
 atty = "0.2.14"
@@ -35,7 +35,7 @@ clap = "2.33.2"
 dissimilar = "1.0.2"
 dlopen = "0.1.8"
 encoding_rs = "0.8.23"
-dprint-plugin-typescript = "0.28.0"
+dprint-plugin-typescript = "0.29.1"
 futures = "0.3.5"
 http = "0.2.1"
 idna = "0.2.0"
@@ -55,7 +55,7 @@ serde_json = { version = "1.0.57", features = [ "preserve_order" ] }
 sys-info = "0.7.0"
 sourcemap = "6.0.1"
 swc_common = { version = "=0.9.1", features = ["sourcemap"] }
-swc_ecmascript = { version = "=0.3.1", features = ["codegen", "parser", "transforms", "visit"] }
+swc_ecmascript = { version = "=0.3.2", features = ["codegen", "parser", "transforms", "visit"] }
 tempfile = "3.1.0"
 termcolor = "1.1.0"
 tokio = { version = "0.2.22", features = ["full"] }


### PR DESCRIPTION
```
cargo bloat --release --crates
 File  .text     Size Crate
20.1%  46.2%   8.2MiB rusty_v8
 7.8%  17.9%   3.2MiB [Unknown]
 2.5%   5.8%   1.0MiB std
 1.8%   4.1% 738.1KiB deno
 1.7%   3.9% 712.0KiB dprint_plugin_typescript
 1.6%   3.6% 654.2KiB swc_ecma_transforms
 1.6%   3.6% 647.3KiB deno_lint
 0.7%   1.7% 307.5KiB reqwest
 0.6%   1.4% 254.3KiB rustls
 0.5%   1.0% 190.4KiB clap
 0.4%   0.9% 171.9KiB regex
 0.4%   0.9% 157.0KiB tokio
 0.3%   0.7% 126.8KiB h2
 0.3%   0.6% 115.4KiB futures_util
 0.3%   0.6% 106.1KiB swc_ecma_ast
 0.2%   0.6% 102.3KiB ring
 0.2%   0.5%  95.9KiB hyper
 0.2%   0.5%  88.9KiB regex_syntax
 0.2%   0.5%  82.6KiB swc_ecma_codegen
 0.2%   0.4%  79.6KiB serde_json
 2.0%   4.7% 851.0KiB And 107 more crates. Use -n N to show more.
43.4% 100.0%  17.7MiB .text section size, the file size is 40.8MiB
```