### PR TITLE
test(std/datetime): port golang dayOfYear tests

### DIFF
--- a/std/datetime/mod.ts
+++ b/std/datetime/mod.ts
@@ -55,7 +55,7 @@ export function dayOfYear(date: Date): number {
   const diff = date.getTime() -
     yearStart.getTime() +
     (yearStart.getTimezoneOffset() - date.getTimezoneOffset()) * 60 * 1000;
-  return Math.ceil(diff / DAY);
+  return Math.floor(diff / DAY);
 }
 
 /**

--- a/std/datetime/mod.ts
+++ b/std/datetime/mod.ts
@@ -47,11 +47,15 @@ export function format(date: Date, formatString: string): string {
  * @return Number of the day in year
  */
 export function dayOfYear(date: Date): number {
-  const yearStart = new Date(date.getFullYear(), 0, 0);
+  // Values from 0 to 99 map to the years 1900 to 1999. All other values are the actual year. (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date)
+  // Using setFullYear as a workaround
+  const yearStart = new Date(date);
+  yearStart.setFullYear(date.getFullYear(), 0, 0);
+
   const diff = date.getTime() -
     yearStart.getTime() +
     (yearStart.getTimezoneOffset() - date.getTimezoneOffset()) * 60 * 1000;
-  return Math.floor(diff / DAY);
+  return Math.ceil(diff / DAY);
 }
 
 /**

--- a/std/datetime/test.ts
+++ b/std/datetime/test.ts
@@ -111,34 +111,64 @@ Deno.test({
     // Test YearDay in several different scenarios
     // and corner cases
     // Non-leap-year tests
-    assertEquals(datetime.dayOfYear(new Date("2007-01-01T03:24:00")), 1);
-    assertEquals(datetime.dayOfYear(new Date("2007-01-15T03:24:00")), 15);
-    assertEquals(datetime.dayOfYear(new Date("2007-02-01T03:24:00")), 32);
-    assertEquals(datetime.dayOfYear(new Date("2007-02-15T03:24:00")), 46);
-    assertEquals(datetime.dayOfYear(new Date("2007-03-01T03:24:00")), 60);
-    assertEquals(datetime.dayOfYear(new Date("2007-03-15T03:24:00")), 74);
-    assertEquals(datetime.dayOfYear(new Date("2007-04-01T03:24:00")), 91);
-    assertEquals(datetime.dayOfYear(new Date("2007-12-31T03:24:00")), 365);
+    assertEquals(datetime.dayOfYear(new Date("2007-01-01")), 1);
+    assertEquals(datetime.dayOfYear(new Date("2007-01-15")), 15);
+    assertEquals(datetime.dayOfYear(new Date("2007-02-01")), 32);
+    assertEquals(datetime.dayOfYear(new Date("2007-02-15")), 46);
+    assertEquals(datetime.dayOfYear(new Date("2007-03-01")), 60);
+    assertEquals(datetime.dayOfYear(new Date("2007-03-15")), 74);
+    assertEquals(datetime.dayOfYear(new Date("2007-04-01")), 91);
+    assertEquals(datetime.dayOfYear(new Date("2007-12-31")), 365);
 
     // Leap-year tests
-    assertEquals(datetime.dayOfYear(new Date("2008-01-01T03:24:00")), 1);
-    assertEquals(datetime.dayOfYear(new Date("2008-01-15T03:24:00")), 15);
-    assertEquals(datetime.dayOfYear(new Date("2008-02-01T03:24:00")), 32);
-    assertEquals(datetime.dayOfYear(new Date("2008-02-15T03:24:00")), 46);
-    assertEquals(datetime.dayOfYear(new Date("2008-03-01T03:24:00")), 61);
-    assertEquals(datetime.dayOfYear(new Date("2008-03-15T03:24:00")), 75);
-    assertEquals(datetime.dayOfYear(new Date("2008-04-01T03:24:00")), 92);
-    assertEquals(datetime.dayOfYear(new Date("2008-12-31T03:24:00")), 366);
+    assertEquals(datetime.dayOfYear(new Date("2008-01-01")), 1);
+    assertEquals(datetime.dayOfYear(new Date("2008-01-15")), 15);
+    assertEquals(datetime.dayOfYear(new Date("2008-02-01")), 32);
+    assertEquals(datetime.dayOfYear(new Date("2008-02-15")), 46);
+    assertEquals(datetime.dayOfYear(new Date("2008-03-01")), 61);
+    assertEquals(datetime.dayOfYear(new Date("2008-03-15")), 75);
+    assertEquals(datetime.dayOfYear(new Date("2008-04-01")), 92);
+    assertEquals(datetime.dayOfYear(new Date("2008-12-31")), 366);
 
     // Looks like leap-year (but isn't) tests
-    assertEquals(datetime.dayOfYear(new Date("1900-01-01T03:24:00")), 1);
-    assertEquals(datetime.dayOfYear(new Date("1900-01-15T03:24:00")), 15);
-    assertEquals(datetime.dayOfYear(new Date("1900-02-01T03:24:00")), 32);
-    assertEquals(datetime.dayOfYear(new Date("1900-02-15T03:24:00")), 46);
-    assertEquals(datetime.dayOfYear(new Date("1900-03-01T03:24:00")), 60);
-    assertEquals(datetime.dayOfYear(new Date("1900-03-15T03:24:00")), 74);
-    assertEquals(datetime.dayOfYear(new Date("1900-04-01T03:24:00")), 91);
-    assertEquals(datetime.dayOfYear(new Date("1900-12-31T03:24:00")), 365);
+    assertEquals(datetime.dayOfYear(new Date("1900-01-01")), 1);
+    assertEquals(datetime.dayOfYear(new Date("1900-01-15")), 15);
+    assertEquals(datetime.dayOfYear(new Date("1900-02-01")), 32);
+    assertEquals(datetime.dayOfYear(new Date("1900-02-15")), 46);
+    assertEquals(datetime.dayOfYear(new Date("1900-03-01")), 60);
+    assertEquals(datetime.dayOfYear(new Date("1900-03-15")), 74);
+    assertEquals(datetime.dayOfYear(new Date("1900-04-01")), 91);
+    assertEquals(datetime.dayOfYear(new Date("1900-12-31")), 365);
+
+    // Year one tests (non-leap)
+    assertEquals(datetime.dayOfYear(new Date("0001-01-01")), 1);
+    assertEquals(datetime.dayOfYear(new Date("0001-01-15")), 15);
+    assertEquals(datetime.dayOfYear(new Date("0001-02-01")), 32);
+    assertEquals(datetime.dayOfYear(new Date("0001-02-15")), 46);
+    assertEquals(datetime.dayOfYear(new Date("0001-03-01")), 60);
+    assertEquals(datetime.dayOfYear(new Date("0001-03-15")), 74);
+    assertEquals(datetime.dayOfYear(new Date("0001-04-01")), 91);
+    assertEquals(datetime.dayOfYear(new Date("0001-12-31")), 365);
+
+    // Year minus one tests (non-leap)
+    assertEquals(datetime.dayOfYear(new Date("-000001-01-01")), 1);
+    assertEquals(datetime.dayOfYear(new Date("-000001-01-15")), 15);
+    assertEquals(datetime.dayOfYear(new Date("-000001-02-01")), 32);
+    assertEquals(datetime.dayOfYear(new Date("-000001-02-15")), 46);
+    assertEquals(datetime.dayOfYear(new Date("-000001-03-01")), 60);
+    assertEquals(datetime.dayOfYear(new Date("-000001-03-15")), 74);
+    assertEquals(datetime.dayOfYear(new Date("-000001-04-01")), 91);
+    assertEquals(datetime.dayOfYear(new Date("-000001-12-31")), 365);
+
+    // // 400 BC tests (leap-year)
+    assertEquals(datetime.dayOfYear(new Date("-00400-01-01")), 1);
+    assertEquals(datetime.dayOfYear(new Date("-00400-01-15")), 15);
+    assertEquals(datetime.dayOfYear(new Date("-00400-02-01")), 32);
+    assertEquals(datetime.dayOfYear(new Date("-00400-02-15")), 46);
+    assertEquals(datetime.dayOfYear(new Date("-00400-03-01")), 61);
+    assertEquals(datetime.dayOfYear(new Date("-00400-03-15")), 75);
+    assertEquals(datetime.dayOfYear(new Date("-00400-04-01")), 92);
+    assertEquals(datetime.dayOfYear(new Date("-00400-12-31")), 366);
 
     // Special Cases
 

--- a/std/datetime/test.ts
+++ b/std/datetime/test.ts
@@ -107,9 +107,44 @@ Deno.test({
 Deno.test({
   name: "[std/datetime] dayOfYear",
   fn: () => {
-    assertEquals(datetime.dayOfYear(new Date("2019-01-01T03:24:00")), 1);
-    assertEquals(datetime.dayOfYear(new Date("2019-03-11T03:24:00")), 70);
-    assertEquals(datetime.dayOfYear(new Date("2019-12-31T03:24:00")), 365);
+    // from https://golang.org/src/time/time_test.go
+    // Test YearDay in several different scenarios
+    // and corner cases
+    // Non-leap-year tests
+    assertEquals(datetime.dayOfYear(new Date("2007-01-01T03:24:00")), 1);
+    assertEquals(datetime.dayOfYear(new Date("2007-01-15T03:24:00")), 15);
+    assertEquals(datetime.dayOfYear(new Date("2007-02-01T03:24:00")), 32);
+    assertEquals(datetime.dayOfYear(new Date("2007-02-15T03:24:00")), 46);
+    assertEquals(datetime.dayOfYear(new Date("2007-03-01T03:24:00")), 60);
+    assertEquals(datetime.dayOfYear(new Date("2007-03-15T03:24:00")), 74);
+    assertEquals(datetime.dayOfYear(new Date("2007-04-01T03:24:00")), 91);
+    assertEquals(datetime.dayOfYear(new Date("2007-12-31T03:24:00")), 365);
+
+    // Leap-year tests
+    assertEquals(datetime.dayOfYear(new Date("2008-01-01T03:24:00")), 1);
+    assertEquals(datetime.dayOfYear(new Date("2008-01-15T03:24:00")), 15);
+    assertEquals(datetime.dayOfYear(new Date("2008-02-01T03:24:00")), 32);
+    assertEquals(datetime.dayOfYear(new Date("2008-02-15T03:24:00")), 46);
+    assertEquals(datetime.dayOfYear(new Date("2008-03-01T03:24:00")), 61);
+    assertEquals(datetime.dayOfYear(new Date("2008-03-15T03:24:00")), 75);
+    assertEquals(datetime.dayOfYear(new Date("2008-04-01T03:24:00")), 92);
+    assertEquals(datetime.dayOfYear(new Date("2008-12-31T03:24:00")), 366);
+
+    // Looks like leap-year (but isn't) tests
+    assertEquals(datetime.dayOfYear(new Date("1900-01-01T03:24:00")), 1);
+    assertEquals(datetime.dayOfYear(new Date("1900-01-15T03:24:00")), 15);
+    assertEquals(datetime.dayOfYear(new Date("1900-02-01T03:24:00")), 32);
+    assertEquals(datetime.dayOfYear(new Date("1900-02-15T03:24:00")), 46);
+    assertEquals(datetime.dayOfYear(new Date("1900-03-01T03:24:00")), 60);
+    assertEquals(datetime.dayOfYear(new Date("1900-03-15T03:24:00")), 74);
+    assertEquals(datetime.dayOfYear(new Date("1900-04-01T03:24:00")), 91);
+    assertEquals(datetime.dayOfYear(new Date("1900-12-31T03:24:00")), 365);
+
+    // Special Cases
+
+    // Gregorian calendar change (no effect)
+    assertEquals(datetime.dayOfYear(new Date("1582-10-04T03:24:00")), 277);
+    assertEquals(datetime.dayOfYear(new Date("1582-10-15T03:24:00")), 288);
   },
 });
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
- Port `dayOfYear` tests from golang.
- fix `dayOfYear` for years <= 0