### PR TITLE
fix: Allow isolated "%"s when parsing file URLs

### DIFF
--- a/cli/rt/06_util.js
+++ b/cli/rt/06_util.js
@@ -63,11 +63,13 @@
     });
   }
 
+  // Keep in sync with `fromFileUrl()` in `std/path/win32.ts`.
   function pathFromURLWin32(url) {
     let path = decodeURIComponent(
       url.pathname
         .replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/")
-        .replace(/\//g, "\\"),
+        .replace(/\//g, "\\")
+        .replace(/%(?![0-9A-Fa-f]{2})/g, "%25"),
     );
     if (url.hostname != "") {
       // Note: The `URL` implementation guarantees that the drive letter and
@@ -78,12 +80,15 @@
     return path;
   }
 
+  // Keep in sync with `fromFileUrl()` in `std/path/posix.ts`.
   function pathFromURLPosix(url) {
     if (url.hostname !== "") {
       throw new TypeError(`Host must be empty.`);
     }
 
-    return decodeURIComponent(url.pathname);
+    return decodeURIComponent(
+      url.pathname.replace(/%(?![0-9A-Fa-f]{2})/g, "%25"),
+    );
   }
 
   function pathFromURL(pathOrUrl) {

--- a/std/path/from_file_url_test.ts
+++ b/std/path/from_file_url_test.ts
@@ -7,6 +7,7 @@ Deno.test("[path] fromFileUrl", function () {
   assertEquals(posix.fromFileUrl("file:///"), "/");
   assertEquals(posix.fromFileUrl("file:///home/foo"), "/home/foo");
   assertEquals(posix.fromFileUrl("file:///home/foo%20bar"), "/home/foo bar");
+  assertEquals(posix.fromFileUrl("file:///%"), "/%");
   assertEquals(posix.fromFileUrl("file://localhost/foo"), "/foo");
   assertEquals(posix.fromFileUrl("file:///C:"), "/C:");
   assertEquals(posix.fromFileUrl("file:///C:/"), "/C:/");
@@ -29,6 +30,7 @@ Deno.test("[path] fromFileUrl (win32)", function () {
   assertEquals(win32.fromFileUrl("file:///"), "\\");
   assertEquals(win32.fromFileUrl("file:///home/foo"), "\\home\\foo");
   assertEquals(win32.fromFileUrl("file:///home/foo%20bar"), "\\home\\foo bar");
+  assertEquals(win32.fromFileUrl("file:///%"), "\\%");
   assertEquals(win32.fromFileUrl("file://localhost/foo"), "\\\\localhost\\foo");
   assertEquals(win32.fromFileUrl("file:///C:"), "C:\\");
   assertEquals(win32.fromFileUrl("file:///C:/"), "C:\\");

--- a/std/path/posix.ts
+++ b/std/path/posix.ts
@@ -436,5 +436,7 @@ export function fromFileUrl(url: string | URL): string {
   if (url.protocol != "file:") {
     throw new TypeError("Must be a file URL.");
   }
-  return decodeURIComponent(url.pathname);
+  return decodeURIComponent(
+    url.pathname.replace(/%(?![0-9A-Fa-f]{2})/g, "%25"),
+  );
 }

--- a/std/path/win32.ts
+++ b/std/path/win32.ts
@@ -919,7 +919,8 @@ export function fromFileUrl(url: string | URL): string {
   let path = decodeURIComponent(
     url.pathname
       .replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/")
-      .replace(/\//g, "\\"),
+      .replace(/\//g, "\\")
+      .replace(/%(?![0-9A-Fa-f]{2})/g, "%25"),
   );
   if (url.hostname != "") {
     // Note: The `URL` implementation guarantees that the drive letter and


### PR DESCRIPTION
Fixes #7094.