### PR TITLE
BREAKING(std/wasi): use record for exports

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -292,8 +292,7 @@ export default class Module {
   // deno-lint-ignore no-explicit-any
   fds: any[];
 
-  // deno-lint-ignore no-explicit-any
-  exports: { [key: string]: any };
+  exports: Record<string, Function>;
 
   constructor(options: ModuleOptions) {
     this.args = options.args ? options.args : [];


### PR DESCRIPTION
This changes the signature of the context exports to use Records so we can avoid it being any.

Practically the usage remains the same it's just a slightly stricter type that is still compatible with WebAssembly.instantiate.