### PR TITLE
BREAKING(std/wasi): rename Module to Context

### DIFF
--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -55,9 +55,9 @@ This module provides an implementation of the WebAssembly System Interface
 ## Usage
 
 ```typescript
-import WASI from "https://deno.land/std/wasi/snapshot_preview1.ts";
+import Context from "https://deno.land/std/wasi/snapshot_preview1.ts";
 
-const wasi = new WASI({
+const context = new Context({
   args: Deno.args,
   env: Deno.env,
 });
@@ -65,10 +65,10 @@ const wasi = new WASI({
 const binary = await Deno.readFile("path/to/your/module.wasm");
 const module = await WebAssembly.compile(binary);
 const instance = await WebAssembly.instantiate(module, {
-  wasi_snapshot_preview1: wasi.exports,
+  wasi_snapshot_preview1: context.exports,
 });
 
-wasi.memory = instance.exports.memory;
+context.memory = context.exports.memory;
 
 if (module.exports._start) {
   instance.exports._start();

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -277,14 +277,14 @@ function errno(err: Error) {
   }
 }
 
-export interface ModuleOptions {
+export interface ContextOptions {
   args?: string[];
   env?: { [key: string]: string | undefined };
   preopens?: { [key: string]: string };
   memory?: WebAssembly.Memory;
 }
 
-export default class Module {
+export default class Context {
   args: string[];
   env: { [key: string]: string | undefined };
   memory: WebAssembly.Memory;
@@ -295,7 +295,7 @@ export default class Module {
   // deno-lint-ignore no-explicit-any
   exports: { [key: string]: any };
 
-  constructor(options: ModuleOptions) {
+  constructor(options: ContextOptions) {
     this.args = options.args ? options.args : [];
     this.env = options.env ? options.env : {};
     this.memory = options.memory!;

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -2,24 +2,24 @@
 
 import { assert, assertEquals } from "../testing/asserts.ts";
 import * as path from "../path/mod.ts";
-import WASI from "./snapshot_preview1.ts";
+import Context from "./snapshot_preview1.ts";
 
 if (import.meta.main) {
   const options = JSON.parse(Deno.args[0]);
   const binary = await Deno.readFile(Deno.args[1]);
   const module = await WebAssembly.compile(binary);
 
-  const wasi = new WASI({
+  const context = new Context({
     env: options.env,
     args: options.args,
     preopens: options.preopens,
   });
 
   const instance = new WebAssembly.Instance(module, {
-    wasi_snapshot_preview1: wasi.exports,
+    wasi_snapshot_preview1: context.exports,
   });
 
-  wasi.memory = instance.exports.memory;
+  context.memory = instance.exports.memory;
 
   instance.exports._start();
 } else {


### PR DESCRIPTION
This renames Module and ModuleOptions to context to avoid stutter confusion, e.g avoid having documentation that says things like instantiate the snapshot's module's module.