### PR TITLE
refactor(op_crates/web): move abort signal

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -146,7 +146,7 @@ fn get_js_files_for_rt() -> Vec<String> {
     "rt/01_internals.js",
     "rt/01_version.js",
     "rt/01_web_util.js",
-    "rt/02_abort_signal.js",
+    &web_scripts.abort_signal,
     "rt/02_console.js",
     "rt/03_dom_iterable.js",
     "rt/06_util.js",

--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -1473,54 +1473,6 @@ declare class CustomEvent<T = any> extends Event {
   readonly detail: T;
 }
 
-/** A controller object that allows you to abort one or more DOM requests as and
- * when desired. */
-declare class AbortController {
-  /** Returns the AbortSignal object associated with this object. */
-  readonly signal: AbortSignal;
-  /** Invoking this method will set this object's AbortSignal's aborted flag and
-   * signal to any observers that the associated activity is to be aborted. */
-  abort(): void;
-}
-
-interface AbortSignalEventMap {
-  abort: Event;
-}
-
-/** A signal object that allows you to communicate with a DOM request (such as a
- * Fetch) and abort it if required via an AbortController object. */
-interface AbortSignal extends EventTarget {
-  /** Returns true if this AbortSignal's AbortController has signaled to abort,
-   * and false otherwise. */
-  readonly aborted: boolean;
-  onabort: ((this: AbortSignal, ev: Event) => any) | null;
-  addEventListener<K extends keyof AbortSignalEventMap>(
-    type: K,
-    listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
-    options?: boolean | AddEventListenerOptions,
-  ): void;
-  addEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions,
-  ): void;
-  removeEventListener<K extends keyof AbortSignalEventMap>(
-    type: K,
-    listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
-    options?: boolean | EventListenerOptions,
-  ): void;
-  removeEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | EventListenerOptions,
-  ): void;
-}
-
-declare const AbortSignal: {
-  prototype: AbortSignal;
-  new (): AbortSignal;
-};
-
 interface ErrorConstructor {
   /** See https://v8.dev/docs/stack-trace-api#stack-trace-collection-for-custom-exceptions. */
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/cli/rt/11_streams.js
+++ b/cli/rt/11_streams.js
@@ -9,7 +9,6 @@
 ((window) => {
   /* eslint-disable @typescript-eslint/no-explicit-any,require-await */
 
-  const { AbortSignal } = window.__bootstrap.abortSignal;
   const { cloneValue, setFunctionName } = window.__bootstrap.webUtil;
   const { assert, AssertionError } = window.__bootstrap.util;
   const { customInspect, inspect } = window.__bootstrap.console;

--- a/cli/rt/99_main.js
+++ b/cli/rt/99_main.js
@@ -20,7 +20,6 @@ delete Object.prototype.__proto__;
   const worker = window.__bootstrap.worker;
   const signals = window.__bootstrap.signals;
   const { internalSymbol, internalObject } = window.__bootstrap.internals;
-  const abortSignal = window.__bootstrap.abortSignal;
   const performance = window.__bootstrap.performance;
   const crypto = window.__bootstrap.crypto;
   const url = window.__bootstrap.url;
@@ -217,8 +216,6 @@ delete Object.prototype.__proto__;
   // Other properties shared between WindowScope and WorkerGlobalScope
   const windowOrWorkerGlobalScopeProperties = {
     console: util.writable(new Console(core.print)),
-    AbortController: util.nonEnumerable(abortSignal.AbortController),
-    AbortSignal: util.nonEnumerable(abortSignal.AbortSignal),
     Blob: util.nonEnumerable(blob.Blob),
     ByteLengthQueuingStrategy: util.nonEnumerable(
       queuingStrategy.ByteLengthQueuingStrategy,

--- a/op_crates/web/02_abort_signal.js
+++ b/op_crates/web/02_abort_signal.js
@@ -65,11 +65,12 @@
     }
   }
 
+  window.AbortSignal = AbortSignal;
+  window.AbortController = AbortController;
+  window.__bootstrap = window.__bootstrap || {};
   window.__bootstrap.abortSignal = {
-    AbortSignal,
     add,
     signalAbort,
     remove,
-    AbortController,
   };
 })(this);

--- a/op_crates/web/abort_controller_test.js
+++ b/op_crates/web/abort_controller_test.js
@@ -1,0 +1,75 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+function assert(cond) {
+  if (!cond) {
+    throw Error("assert");
+  }
+}
+
+function assertEquals(left, right) {
+  assert(left === right);
+}
+
+function basicAbortController() {
+  controller = new AbortController();
+  assert(controller);
+  const { signal } = controller;
+  assert(signal);
+  assertEquals(signal.aborted, false);
+  controller.abort();
+  assertEquals(signal.aborted, true);
+}
+
+function signalCallsOnabort() {
+  const controller = new AbortController();
+  const { signal } = controller;
+  let called = false;
+  signal.onabort = (evt) => {
+    assert(evt);
+    assertEquals(evt.type, "abort");
+    called = true;
+  };
+  controller.abort();
+  assert(called);
+}
+
+function signalEventListener() {
+  const controller = new AbortController();
+  const { signal } = controller;
+  let called = false;
+  signal.addEventListener("abort", function (ev) {
+    assert(this === signal);
+    assertEquals(ev.type, "abort");
+    called = true;
+  });
+  controller.abort();
+  assert(called);
+}
+
+function onlyAbortsOnce() {
+  const controller = new AbortController();
+  const { signal } = controller;
+  let called = 0;
+  signal.addEventListener("abort", () => called++);
+  signal.onabort = () => {
+    called++;
+  };
+  controller.abort();
+  assertEquals(called, 2);
+  controller.abort();
+  assertEquals(called, 2);
+}
+
+function controllerHasProperToString() {
+  const actual = Object.prototype.toString.call(new AbortController());
+  assertEquals(actual, "[object AbortController]");
+}
+
+function main() {
+  basicAbortController();
+  signalCallsOnabort();
+  signalEventListener();
+  onlyAbortsOnce();
+  controllerHasProperToString();
+}
+
+main();

--- a/op_crates/web/lib.deno_web.d.ts
+++ b/op_crates/web/lib.deno_web.d.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 

--- a/op_crates/web/lib.deno_web.d.ts
+++ b/op_crates/web/lib.deno_web.d.ts
@@ -188,51 +188,50 @@ declare class TextEncoder {
   readonly [Symbol.toStringTag]: string;
 }
 
-
 /** A controller object that allows you to abort one or more DOM requests as and
  * when desired. */
 declare class AbortController {
-   /** Returns the AbortSignal object associated with this object. */
-   readonly signal: AbortSignal;
-   /** Invoking this method will set this object's AbortSignal's aborted flag and
+  /** Returns the AbortSignal object associated with this object. */
+  readonly signal: AbortSignal;
+  /** Invoking this method will set this object's AbortSignal's aborted flag and
     * signal to any observers that the associated activity is to be aborted. */
-   abort(): void;
- }
- 
- interface AbortSignalEventMap {
-   abort: Event;
- }
- 
- /** A signal object that allows you to communicate with a DOM request (such as a
+  abort(): void;
+}
+
+interface AbortSignalEventMap {
+  abort: Event;
+}
+
+/** A signal object that allows you to communicate with a DOM request (such as a
   * Fetch) and abort it if required via an AbortController object. */
- interface AbortSignal extends EventTarget {
-   /** Returns true if this AbortSignal's AbortController has signaled to abort,
+interface AbortSignal extends EventTarget {
+  /** Returns true if this AbortSignal's AbortController has signaled to abort,
     * and false otherwise. */
-   readonly aborted: boolean;
-   onabort: ((this: AbortSignal, ev: Event) => any) | null;
-   addEventListener<K extends keyof AbortSignalEventMap>(
-     type: K,
-     listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
-     options?: boolean | AddEventListenerOptions,
-   ): void;
-   addEventListener(
-     type: string,
-     listener: EventListenerOrEventListenerObject,
-     options?: boolean | AddEventListenerOptions,
-   ): void;
-   removeEventListener<K extends keyof AbortSignalEventMap>(
-     type: K,
-     listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
-     options?: boolean | EventListenerOptions,
-   ): void;
-   removeEventListener(
-     type: string,
-     listener: EventListenerOrEventListenerObject,
-     options?: boolean | EventListenerOptions,
-   ): void;
- }
- 
- declare const AbortSignal: {
-   prototype: AbortSignal;
-   new (): AbortSignal;
- };
+  readonly aborted: boolean;
+  onabort: ((this: AbortSignal, ev: Event) => any) | null;
+  addEventListener<K extends keyof AbortSignalEventMap>(
+    type: K,
+    listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener<K extends keyof AbortSignalEventMap>(
+    type: K,
+    listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
+    options?: boolean | EventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions,
+  ): void;
+}
+
+declare const AbortSignal: {
+  prototype: AbortSignal;
+  new (): AbortSignal;
+};

--- a/op_crates/web/lib.deno_web.d.ts
+++ b/op_crates/web/lib.deno_web.d.ts
@@ -185,3 +185,52 @@ declare class TextEncoder {
   ): { read: number; written: number };
   readonly [Symbol.toStringTag]: string;
 }
+
+
+/** A controller object that allows you to abort one or more DOM requests as and
+ * when desired. */
+declare class AbortController {
+   /** Returns the AbortSignal object associated with this object. */
+   readonly signal: AbortSignal;
+   /** Invoking this method will set this object's AbortSignal's aborted flag and
+    * signal to any observers that the associated activity is to be aborted. */
+   abort(): void;
+ }
+ 
+ interface AbortSignalEventMap {
+   abort: Event;
+ }
+ 
+ /** A signal object that allows you to communicate with a DOM request (such as a
+  * Fetch) and abort it if required via an AbortController object. */
+ interface AbortSignal extends EventTarget {
+   /** Returns true if this AbortSignal's AbortController has signaled to abort,
+    * and false otherwise. */
+   readonly aborted: boolean;
+   onabort: ((this: AbortSignal, ev: Event) => any) | null;
+   addEventListener<K extends keyof AbortSignalEventMap>(
+     type: K,
+     listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
+     options?: boolean | AddEventListenerOptions,
+   ): void;
+   addEventListener(
+     type: string,
+     listener: EventListenerOrEventListenerObject,
+     options?: boolean | AddEventListenerOptions,
+   ): void;
+   removeEventListener<K extends keyof AbortSignalEventMap>(
+     type: K,
+     listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
+     options?: boolean | EventListenerOptions,
+   ): void;
+   removeEventListener(
+     type: string,
+     listener: EventListenerOrEventListenerObject,
+     options?: boolean | EventListenerOptions,
+   ): void;
+ }
+ 
+ declare const AbortSignal: {
+   prototype: AbortSignal;
+   new (): AbortSignal;
+ };

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -68,7 +68,10 @@ mod tests {
   fn test_abort_controller() {
     run_in_task(|mut cx| {
       let mut isolate = setup();
-      js_check(isolate.execute("abort_controller_test.js", include_str!("abort_controller_test.js")));
+      js_check(isolate.execute(
+        "abort_controller_test.js",
+        include_str!("abort_controller_test.js"),
+      ));
       if let Poll::Ready(Err(_)) = isolate.poll_unpin(&mut cx) {
         unreachable!();
       }

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -55,11 +55,11 @@ mod tests {
     );
     js_check(isolate.execute("01_event.js", include_str!("01_event.js")));
     js_check(
-      isolate
-        .execute("08_text_encoding.js", include_str!("08_text_encoding.js")),
+      isolate.execute("02_abort_signal.js", include_str!("02_abort_signal.js")),
     );
     js_check(
-      isolate.execute("02_abort_signal.js", include_str!("02_abort_signal.js")),
+      isolate
+        .execute("08_text_encoding.js", include_str!("08_text_encoding.js")),
     );
     isolate
   }

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 crate_modules!();
 
 pub struct WebScripts {
+  pub abort_signal: String,
   pub declaration: String,
   pub dom_exception: String,
   pub event: String,
@@ -21,6 +22,7 @@ fn get_str_path(file_name: &str) -> String {
 
 pub fn get_scripts() -> WebScripts {
   WebScripts {
+    abort_signal: get_str_path("02_abort_signal.js"),
     declaration: get_str_path("lib.deno_web.d.ts"),
     dom_exception: get_str_path("00_dom_exception.js"),
     event: get_str_path("01_event.js"),
@@ -56,7 +58,21 @@ mod tests {
       isolate
         .execute("08_text_encoding.js", include_str!("08_text_encoding.js")),
     );
+    js_check(
+      isolate.execute("02_abort_signal.js", include_str!("02_abort_signal.js")),
+    );
     isolate
+  }
+
+  #[test]
+  fn test_abort_controller() {
+    run_in_task(|mut cx| {
+      let mut isolate = setup();
+      js_check(isolate.execute("abort_controller_test.js", include_str!("abort_controller_test.js")));
+      if let Poll::Ready(Err(_)) = isolate.poll_unpin(&mut cx) {
+        unreachable!();
+      }
+    });
   }
 
   #[test]


### PR DESCRIPTION
This PR moves `AbortSignal` and `AbortController` to the `deno_web` op crate.