### PR TITLE
Add link to each section in getting_started

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,11 +2,11 @@
 
 In this chapter we'll discuss:
 
-- Installing Deno
-- Setting up your environment
-- Running a `Hello World` script
-- Writing our own script
-- Command line interface
-- Understanding permissions
-- Using Deno with TypeScript
-- Using WebAssembly
+- [Installing Deno](./getting_started/installation.md)
+- [Setting up your environment](./getting_started/setup_your_environment.md)
+- [Running a `Hello World` script](./getting_started/first_steps.md)
+- [Writing our own script](./getting_started/first_steps.md)
+- [Command line interface](./getting_started/command_line_interface.md)
+- [Understanding permissions](./getting_started/permissions.md)
+- [Using Deno with TypeScript](./getting_started/typescript.md)
+- [Using WebAssembly](./getting_started/webassembly.md)


### PR DESCRIPTION
[tools](https://deno.land/manual/tools) and [examples](https://deno.land/manual/examples) have link to each section, but [getting started](https://deno.land/manual/getting_started) doesn't.

in docs/getting_started.md

> - Installing Deno
> - Setting up your environment
> - Running a `Hello World` script
> - Writing our own script
> - Command line interface
> - Understanding permissions
> - Using Deno with TypeScript
> - Using WebAssembly

to

> - [Installing Deno](./getting_started/installation.md)
> - [Setting up your environment](./getting_started/setup_your_environment.md)
> - [Running a `Hello World` script](./getting_started/first_steps.md)
> - [Writing our own script](./getting_started/first_steps.md)
> - [Command line interface](./getting_started/command_line_interface.md)
> - [Understanding permissions](./getting_started/.permissionsmd)
> - [Using Deno with TypeScript](./getting_started/typescript.md)
> - [Using WebAssembly](./getting_started/webassembly.md)