### PR TITLE
chore: Use yapf and rustfmt dprint plugins

### DIFF
--- a/.dprintrc.json
+++ b/.dprintrc.json
@@ -29,9 +29,9 @@
     "third_party"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.29.0.wasm",
+    "https://plugins.dprint.dev/typescript-0.30.0.wasm",
     "https://plugins.dprint.dev/json-0.7.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.4.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.4.1.wasm",
     "https://plugins.dprint.dev/rustfmt-0.3.0.wasm",
     "https://plugins.dprint.dev/yapf-0.1.1.exe-plugin@7550683e5f8b76c4825eec5cf88b5dcbd043ade4019c60d79e989e1e7fb6f4d8"
   ]

--- a/.dprintrc.json
+++ b/.dprintrc.json
@@ -10,7 +10,11 @@
   "markdown": {
     "textWrap": "always"
   },
-  "includes": ["**/*.{ts,tsx,js,jsx,json,md}"],
+  "yapf": {
+    "based_on_style": "pep8",
+    "indentWidth": 4
+  },
+  "includes": ["**/*.{ts,tsx,js,jsx,json,md,rs,py}"],
   "excludes": [
     ".cargo_home",
     "cli/dts",
@@ -27,6 +31,8 @@
   "plugins": [
     "https://plugins.dprint.dev/typescript-0.29.0.wasm",
     "https://plugins.dprint.dev/json-0.7.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.4.0.wasm"
+    "https://plugins.dprint.dev/markdown-0.4.0.wasm",
+    "https://plugins.dprint.dev/rustfmt-0.3.0.wasm",
+    "https://plugins.dprint.dev/yapf-0.1.1.exe-plugin@7550683e5f8b76c4825eec5cf88b5dcbd043ade4019c60d79e989e1e7fb6f4d8"
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,10 @@ jobs:
           rustup target add wasm32-unknown-unknown
           rustup target add wasm32-wasi
 
-      - name: Install clippy and rustfmt
+      - name: Install clippy
         if: matrix.config.kind == 'lint'
         run: |
           rustup component add clippy
-          rustup component add rustfmt
 
       - name: Install Python
         uses: actions/setup-python@v1

--- a/tools/benchmark_test.py
+++ b/tools/benchmark_test.py
@@ -9,9 +9,8 @@ from test_util import DenoTestCase, run_tests
 
 class TestBenchmark(DenoTestCase):
     def test_strace_parse(self):
-        with open(
-                os.path.join(sys.path[0], "testdata/strace_summary.out"),
-                "r") as f:
+        with open(os.path.join(sys.path[0], "testdata/strace_summary.out"),
+                  "r") as f:
             summary = benchmark.strace_parse(f.read())
             # first syscall line
             assert summary["munmap"]["calls"] == 60
@@ -25,9 +24,8 @@ class TestBenchmark(DenoTestCase):
             assert summary["total"]["calls"] == 704
 
     def test_strace_parse2(self):
-        with open(
-                os.path.join(sys.path[0], "testdata/strace_summary2.out"),
-                "r") as f:
+        with open(os.path.join(sys.path[0], "testdata/strace_summary2.out"),
+                  "r") as f:
             summary = benchmark.strace_parse(f.read())
             # first syscall line
             assert summary["futex"]["calls"] == 449

--- a/tools/format.py
+++ b/tools/format.py
@@ -2,87 +2,19 @@
 # Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import os
 import sys
-import argparse
-from third_party import python_env, get_prebuilt_tool_path
-from util import git_ls_files, git_staged, third_party_path, root_path
-from util import print_command, run
-
-cmd_args = None
-
-
-def get_cmd_args():
-    global cmd_args
-
-    if cmd_args:
-        return cmd_args
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--js", help="run dprint", action="store_true")
-    parser.add_argument("--py", help="run yapf", action="store_true")
-    parser.add_argument("--rs", help="run rustfmt", action="store_true")
-    parser.add_argument(
-        "--staged", help="run only on staged files", action="store_true")
-    cmd_args = parser.parse_args()
-    return cmd_args
-
-
-def get_sources(*args):
-    getter = git_staged if get_cmd_args().staged else git_ls_files
-    return getter(*args)
-
+from third_party import get_prebuilt_tool_path
+from util import root_path
+from util import run
 
 def main():
     os.chdir(root_path)
-
-    args = get_cmd_args()
-
-    did_fmt = False
-    if args.js:
-        dprint()
-        did_fmt = True
-    if args.py:
-        yapf()
-        did_fmt = True
-    if args.rs:
-        rustfmt()
-        did_fmt = True
-
-    if not did_fmt:
-        dprint()
-        yapf()
-        rustfmt()
+    dprint()
 
 
 def dprint():
     executable_path = get_prebuilt_tool_path("dprint")
     command = [executable_path, "fmt"]
     run(command, shell=False, quiet=True)
-
-
-def yapf():
-    script = os.path.join(third_party_path, "python_packages", "bin", "yapf")
-    source_files = get_sources(root_path, ["*.py"])
-    if source_files:
-        print_command("yapf", source_files)
-        run([sys.executable, script, "-i", "--style=pep8", "--"] +
-            source_files,
-            env=python_env(),
-            shell=False,
-            quiet=True)
-
-
-def rustfmt():
-    config_file = os.path.join(root_path, ".rustfmt.toml")
-    source_files = get_sources(root_path, ["*.rs"])
-    if source_files:
-        print_command("rustfmt", source_files)
-        run([
-            "rustfmt",
-            "--config-path=" + config_file,
-            "--",
-        ] + source_files,
-            shell=False,
-            quiet=True)
 
 
 if __name__ == "__main__":

--- a/tools/format.py
+++ b/tools/format.py
@@ -6,6 +6,7 @@ from third_party import get_prebuilt_tool_path
 from util import root_path
 from util import run
 
+
 def main():
     os.chdir(root_path)
     dprint()

--- a/tools/http_benchmark.py
+++ b/tools/http_benchmark.py
@@ -64,10 +64,9 @@ def deno_tcp_proxy(deno_exe, hyper_hello_exe):
         server_addr(origin_port)
     ]
     print "http_proxy_benchmark testing DENO using net/tcp."
-    return run(
-        deno_cmd,
-        port,
-        origin_cmd=http_proxy_origin(hyper_hello_exe, origin_port))
+    return run(deno_cmd,
+               port,
+               origin_cmd=http_proxy_origin(hyper_hello_exe, origin_port))
 
 
 def deno_http_proxy(deno_exe, hyper_hello_exe):
@@ -79,10 +78,9 @@ def deno_http_proxy(deno_exe, hyper_hello_exe):
         server_addr(origin_port)
     ]
     print "http_proxy_benchmark testing DENO using net/http."
-    return run(
-        deno_cmd,
-        port,
-        origin_cmd=http_proxy_origin(hyper_hello_exe, origin_port))
+    return run(deno_cmd,
+               port,
+               origin_cmd=http_proxy_origin(hyper_hello_exe, origin_port))
 
 
 def deno_core_http_bench(exe):

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -22,8 +22,9 @@ def get_cmd_args():
     parser.add_argument("--js", help="run eslint", action="store_true")
     parser.add_argument("--py", help="run pylint", action="store_true")
     parser.add_argument("--rs", help="run clippy", action="store_true")
-    parser.add_argument(
-        "--staged", help="run only on staged files", action="store_true")
+    parser.add_argument("--staged",
+                        help="run only on staged files",
+                        action="store_true")
     cmd_args = parser.parse_args()
     return cmd_args
 

--- a/tools/test_util.py
+++ b/tools/test_util.py
@@ -56,19 +56,24 @@ class ColorTextTestRunner(unittest.TextTestRunner):
 
 def create_test_arg_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--failfast', '-f', action='store_true', help='Stop on first failure')
-    parser.add_argument(
-        '--verbose', '-v', action='store_true', help='Verbose output')
+    parser.add_argument('--failfast',
+                        '-f',
+                        action='store_true',
+                        help='Stop on first failure')
+    parser.add_argument('--verbose',
+                        '-v',
+                        action='store_true',
+                        help='Verbose output')
     parser.add_argument("--executable", help="Use external executable of Deno")
-    parser.add_argument(
-        '--release',
-        action='store_true',
-        help='Test against release executable')
-    parser.add_argument(
-        '--pattern', '-p', help='Run tests that match provided pattern')
-    parser.add_argument(
-        '--build-dir', dest="build_dir", help='Deno build directory')
+    parser.add_argument('--release',
+                        action='store_true',
+                        help='Test against release executable')
+    parser.add_argument('--pattern',
+                        '-p',
+                        help='Run tests that match provided pattern')
+    parser.add_argument('--build-dir',
+                        dest="build_dir",
+                        help='Deno build directory')
     return parser
 
 
@@ -132,8 +137,8 @@ def run_tests(test_cases=None):
         filtered_tests = filter_test_suite(suite, args.pattern)
         suite = unittest.TestSuite(filtered_tests)
 
-    runner = ColorTextTestRunner(
-        verbosity=args.verbose + 2, failfast=args.failfast)
+    runner = ColorTextTestRunner(verbosity=args.verbose + 2,
+                                 failfast=args.failfast)
 
     result = runner.run(suite)
     if not result.wasSuccessful():

--- a/tools/third_party.py
+++ b/tools/third_party.py
@@ -76,14 +76,7 @@ def run_pip():
         cwd=third_party_path,
         merge_env=pip_env)
 
-    # Get yapf.
-    run([
-        sys.executable, "-m", "pip", "install", "--upgrade", "--target",
-        python_packages_path, "yapf"
-    ],
-        cwd=third_party_path,
-        merge_env=pip_env)
-
+    # Install pylint.
     run([
         sys.executable, "-m", "pip", "install", "--upgrade", "--target",
         python_packages_path, "pylint==1.5.6"

--- a/tools/util.py
+++ b/tools/util.py
@@ -81,13 +81,12 @@ def run_output(args,
         print " ".join(args)
     env = make_env(env=env, merge_env=merge_env)
     shell = os.name == "nt"  # Run through shell to make .bat/.cmd files work.
-    p = subprocess.Popen(
-        args,
-        cwd=cwd,
-        env=env,
-        shell=shell,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
+    p = subprocess.Popen(args,
+                         cwd=cwd,
+                         env=env,
+                         shell=shell,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
     try:
         out, err = p.communicate()
     except subprocess.CalledProcessError as e:
@@ -98,8 +97,8 @@ def run_output(args,
     if retcode and exit_on_fail:
         sys.exit(retcode)
     # Ignore Windows CRLF (\r\n).
-    return CmdResult(
-        out.replace('\r\n', '\n'), err.replace('\r\n', '\n'), retcode)
+    return CmdResult(out.replace('\r\n', '\n'), err.replace('\r\n', '\n'),
+                     retcode)
 
 
 def shell_quote_win(arg):
@@ -402,8 +401,12 @@ def tty_capture(cmd, bytes_input, timeout=5):
     fdmap = {mo: 'stdout', me: 'stderr', mi: 'stdin'}
 
     timeout_exact = time.time() + timeout
-    p = subprocess.Popen(
-        cmd, bufsize=1, stdin=si, stdout=so, stderr=se, close_fds=True)
+    p = subprocess.Popen(cmd,
+                         bufsize=1,
+                         stdin=si,
+                         stdout=so,
+                         stderr=se,
+                         close_fds=True)
     os.write(mi, bytes_input)
 
     select_timeout = .04  #seconds
@@ -416,8 +419,8 @@ def tty_capture(cmd, bytes_input, timeout=5):
                 if not data:
                     break
                 res[fdmap[fd]] += data
-        elif p.poll() is not None or time.time(
-        ) > timeout_exact:  # select timed-out
+        elif p.poll(
+        ) is not None or time.time() > timeout_exact:  # select timed-out
             break  # p exited
     for fd in [si, so, se, mi, mo, me]:
         os.close(fd)  # can't do it sooner: it leads to errno.EIO error

--- a/tools/util_test.py
+++ b/tools/util_test.py
@@ -2,8 +2,7 @@
 import os
 
 from test_util import DenoTestCase, run_tests
-from util import (parse_exit_code, shell_quote_win, parse_wrk_output,
-                  root_path)
+from util import (parse_exit_code, shell_quote_win, parse_wrk_output, root_path)
 
 
 class TestUtil(DenoTestCase):
@@ -14,8 +13,7 @@ class TestUtil(DenoTestCase):
 
     def test_shell_quote_win(self):
         assert shell_quote_win('simple') == 'simple'
-        assert shell_quote_win(
-            'roof/\\isoprojection') == 'roof/\\isoprojection'
+        assert shell_quote_win('roof/\\isoprojection') == 'roof/\\isoprojection'
         assert shell_quote_win('with space') == '"with space"'
         assert shell_quote_win('embedded"quote') == '"embedded""quote"'
         assert shell_quote_win(


### PR DESCRIPTION
Previously non-incremental: ~5s
Now non-incremental: ~2.5s

Previously incremental: ~2.6s
Now incremental: **~350ms** (most common scenario)

Benefits:

1. It's almost instant to run the format script.
2. Slightly less code to manage yapf and rustfmt.

Problems:

1. Switching from a stable solution to a solution that is quite new. I believe it's working well, but it has the potential to cause some headaches for people if something doesn't work. It would definitely be good for this PR to be tried out on a few additional computers before merging.
2. See https://github.com/denoland/deno/pull/7121#discussion_r473125155 (about needing `python` on the path)
3. Not a blocker to merge, but I need to fix https://github.com/dprint/dprint/issues/298 -- It's a cosmetic issue and makes the output when downloading & initializing all the plugins go a little crazy.

It may not be worth it to merge this PR for now as the current 2.6s with incremental is still pretty fast.