### PR TITLE
Fix std/node/assert misnamed exports, close #7102

### DIFF
--- a/std/node/assert.ts
+++ b/std/node/assert.ts
@@ -7,11 +7,11 @@ import {
   assertThrows,
 } from "../testing/asserts.ts";
 
-export { 
-  assert as default, 
-  assert as ok, 
-  assert, 
-  fail 
+export {
+  assert as default,
+  assert as ok,
+  assert,
+  fail,
 } from "../testing/asserts.ts";
 
 export const deepStrictEqual = assertEquals;

--- a/std/node/assert.ts
+++ b/std/node/assert.ts
@@ -7,7 +7,12 @@ import {
   assertThrows,
 } from "../testing/asserts.ts";
 
-export { assert as ok, assert, fail } from "../testing/asserts.ts";
+export { 
+  assert as default, 
+  assert as ok, 
+  assert, 
+  fail 
+} from "../testing/asserts.ts";
 
 export const deepStrictEqual = assertEquals;
 export const notDeepStrictEqual = assertNotEquals;

--- a/std/node/assert.ts
+++ b/std/node/assert.ts
@@ -8,8 +8,8 @@ import {
 
 export { assert as ok, assert, fail } from "../testing/asserts.ts";
 
-export const equal = assertEquals;
-export const notEqual = assertNotEquals;
+export const deepStrictEqual = assertEquals;
+export const notDeepStrictEqual = assertNotEquals;
 export const strictEqual = assertStrictEquals;
 export const match = assertMatch;
 export const throws = assertThrows;

--- a/std/node/assert.ts
+++ b/std/node/assert.ts
@@ -6,7 +6,7 @@ import {
   assertThrows,
 } from "../testing/asserts.ts";
 
-export { assert, fail } from "../testing/asserts.ts";
+export { assert as ok, assert, fail } from "../testing/asserts.ts";
 
 export const equal = assertEquals;
 export const notEqual = assertNotEquals;

--- a/std/node/assert.ts
+++ b/std/node/assert.ts
@@ -2,6 +2,7 @@ import {
   assertEquals,
   assertNotEquals,
   assertStrictEquals,
+  assertNotStrictEquals,
   assertMatch,
   assertThrows,
 } from "../testing/asserts.ts";
@@ -11,5 +12,6 @@ export { assert as ok, assert, fail } from "../testing/asserts.ts";
 export const deepStrictEqual = assertEquals;
 export const notDeepStrictEqual = assertNotEquals;
 export const strictEqual = assertStrictEquals;
+export const notStrictEqual = assertNotStrictEquals;
 export const match = assertMatch;
 export const throws = assertThrows;

--- a/std/node/assert_test.ts
+++ b/std/node/assert_test.ts
@@ -1,0 +1,27 @@
+import {
+  assert as denoAssert,
+  assertEquals,
+  assertNotEquals,
+  assertStrictEquals,
+  assertMatch,
+  assertThrows
+} from "../testing/asserts.ts";
+
+import {  
+  ok,
+  assert, 
+  equal,
+  notEqual,
+  strictEqual,
+  match,
+  throws
+} from './assert.ts';
+
+assertStrictEquals(assert, denoAssert, '`assert()` should be exposed');
+// ref: https://nodejs.org/dist/latest-v14.x/docs/api/assert.html#assert_assert_value_message
+assertStrictEquals(assert, ok, '`assert()` should be an alias of `ok()`');
+assertStrictEquals(assertEquals, equal, '`assertEquals()` should be exposed as `equal()`');
+assertStrictEquals(assertNotEquals, notEqual, '`assertNotEquals()` should be exposed as `notEqual()`');
+assertStrictEquals(assertStrictEquals, strictEqual, '`assertStrictEquals()` should be exposed as `strictEqual()`');
+assertStrictEquals(assertMatch, match, '`assertMatch()` should be exposed as `match()`');
+assertStrictEquals(assertThrows, throws, '`assertThrows()` should be exposed as `throws()`');

--- a/std/node/assert_test.ts
+++ b/std/node/assert_test.ts
@@ -11,20 +11,21 @@ import {
 import {  
   ok,
   assert, 
-  equal,
-  notEqual,
+  deepStrictEqual,
+  notDeepStrictEqual,
   strictEqual,
   match,
   throws,
   fail
 } from './assert.ts';
 
-assertStrictEquals(assert, denoAssert, '`assert()` should be exposed');
-// ref: https://nodejs.org/dist/latest-v14.x/docs/api/assert.html#assert_assert_value_message
-assertStrictEquals(assert, ok, '`assert()` should be an alias of `ok()`');
-assertStrictEquals(assertEquals, equal, '`assertEquals()` should be exposed as `equal()`');
-assertStrictEquals(assertNotEquals, notEqual, '`assertNotEquals()` should be exposed as `notEqual()`');
-assertStrictEquals(assertStrictEquals, strictEqual, '`assertStrictEquals()` should be exposed as `strictEqual()`');
-assertStrictEquals(assertMatch, match, '`assertMatch()` should be exposed as `match()`');
-assertStrictEquals(assertThrows, throws, '`assertThrows()` should be exposed as `throws()`');
-assertStrictEquals(fail, denoFail, '`fail()` should be exposed');
+Deno.test('API should be exposed', () => {
+  assertStrictEquals(assert, denoAssert, '`assert()` should be exposed');
+  assertStrictEquals(assert, ok, '`assert()` should be an alias of `ok()`');
+  assertStrictEquals(assertEquals, deepStrictEqual, '`assertEquals()` should be exposed as `deepStrictEqual()`');
+  assertStrictEquals(assertNotEquals, notDeepStrictEqual, '`assertNotEquals()` should be exposed as `notDeepStrictEqual()`');
+  assertStrictEquals(assertStrictEquals, strictEqual, '`assertStrictEquals()` should be exposed as `strictEqual()`');
+  assertStrictEquals(assertMatch, match, '`assertMatch()` should be exposed as `match()`');
+  assertStrictEquals(assertThrows, throws, '`assertThrows()` should be exposed as `throws()`');
+  assertStrictEquals(fail, denoFail, '`fail()` should be exposed');
+});

--- a/std/node/assert_test.ts
+++ b/std/node/assert_test.ts
@@ -9,9 +9,11 @@ import {
   fail as denoFail
 } from "../testing/asserts.ts";
 
+import assert from "./assert.ts";
+
 import {  
   ok,
-  assert, 
+  assert as assert_, 
   deepStrictEqual,
   notDeepStrictEqual,
   strictEqual,
@@ -22,8 +24,9 @@ import {
 } from './assert.ts';
 
 Deno.test('API should be exposed', () => {
-  assertStrictEquals(assert, denoAssert, '`assert()` should be exposed');
-  assertStrictEquals(assert, ok, '`assert()` should be an alias of `ok()`');
+  assertStrictEquals(assert_, assert, '`assert()` should be the default export');
+  assertStrictEquals(assert_, denoAssert, '`assert()` should be exposed');
+  assertStrictEquals(assert_, ok, '`assert()` should be an alias of `ok()`');
   assertStrictEquals(assertEquals, deepStrictEqual, '`assertEquals()` should be exposed as `deepStrictEqual()`');
   assertStrictEquals(assertNotEquals, notDeepStrictEqual, '`assertNotEquals()` should be exposed as `notDeepStrictEqual()`');
   assertStrictEquals(assertStrictEquals, strictEqual, '`assertStrictEquals()` should be exposed as `strictEqual()`');

--- a/std/node/assert_test.ts
+++ b/std/node/assert_test.ts
@@ -3,6 +3,7 @@ import {
   assertEquals,
   assertNotEquals,
   assertStrictEquals,
+  assertNotStrictEquals,
   assertMatch,
   assertThrows,
   fail as denoFail
@@ -14,6 +15,7 @@ import {
   deepStrictEqual,
   notDeepStrictEqual,
   strictEqual,
+  notStrictEqual,
   match,
   throws,
   fail
@@ -25,6 +27,7 @@ Deno.test('API should be exposed', () => {
   assertStrictEquals(assertEquals, deepStrictEqual, '`assertEquals()` should be exposed as `deepStrictEqual()`');
   assertStrictEquals(assertNotEquals, notDeepStrictEqual, '`assertNotEquals()` should be exposed as `notDeepStrictEqual()`');
   assertStrictEquals(assertStrictEquals, strictEqual, '`assertStrictEquals()` should be exposed as `strictEqual()`');
+  assertStrictEquals(assertNotStrictEquals, notStrictEqual, '`assertNotStrictEquals()` should be exposed as `notStrictEqual()`');
   assertStrictEquals(assertMatch, match, '`assertMatch()` should be exposed as `match()`');
   assertStrictEquals(assertThrows, throws, '`assertThrows()` should be exposed as `throws()`');
   assertStrictEquals(fail, denoFail, '`fail()` should be exposed');

--- a/std/node/assert_test.ts
+++ b/std/node/assert_test.ts
@@ -4,7 +4,8 @@ import {
   assertNotEquals,
   assertStrictEquals,
   assertMatch,
-  assertThrows
+  assertThrows,
+  fail as denoFail
 } from "../testing/asserts.ts";
 
 import {  
@@ -14,7 +15,8 @@ import {
   notEqual,
   strictEqual,
   match,
-  throws
+  throws,
+  fail
 } from './assert.ts';
 
 assertStrictEquals(assert, denoAssert, '`assert()` should be exposed');
@@ -25,3 +27,4 @@ assertStrictEquals(assertNotEquals, notEqual, '`assertNotEquals()` should be exp
 assertStrictEquals(assertStrictEquals, strictEqual, '`assertStrictEquals()` should be exposed as `strictEqual()`');
 assertStrictEquals(assertMatch, match, '`assertMatch()` should be exposed as `match()`');
 assertStrictEquals(assertThrows, throws, '`assertThrows()` should be exposed as `throws()`');
+assertStrictEquals(fail, denoFail, '`fail()` should be exposed');

--- a/std/node/assert_test.ts
+++ b/std/node/assert_test.ts
@@ -6,32 +6,60 @@ import {
   assertNotStrictEquals,
   assertMatch,
   assertThrows,
-  fail as denoFail
+  fail as denoFail,
 } from "../testing/asserts.ts";
 
 import assert from "./assert.ts";
 
-import {  
+import {
   ok,
-  assert as assert_, 
+  assert as assert_,
   deepStrictEqual,
   notDeepStrictEqual,
   strictEqual,
   notStrictEqual,
   match,
   throws,
-  fail
-} from './assert.ts';
+  fail,
+} from "./assert.ts";
 
-Deno.test('API should be exposed', () => {
-  assertStrictEquals(assert_, assert, '`assert()` should be the default export');
-  assertStrictEquals(assert_, denoAssert, '`assert()` should be exposed');
-  assertStrictEquals(assert_, ok, '`assert()` should be an alias of `ok()`');
-  assertStrictEquals(assertEquals, deepStrictEqual, '`assertEquals()` should be exposed as `deepStrictEqual()`');
-  assertStrictEquals(assertNotEquals, notDeepStrictEqual, '`assertNotEquals()` should be exposed as `notDeepStrictEqual()`');
-  assertStrictEquals(assertStrictEquals, strictEqual, '`assertStrictEquals()` should be exposed as `strictEqual()`');
-  assertStrictEquals(assertNotStrictEquals, notStrictEqual, '`assertNotStrictEquals()` should be exposed as `notStrictEqual()`');
-  assertStrictEquals(assertMatch, match, '`assertMatch()` should be exposed as `match()`');
-  assertStrictEquals(assertThrows, throws, '`assertThrows()` should be exposed as `throws()`');
-  assertStrictEquals(fail, denoFail, '`fail()` should be exposed');
+Deno.test("API should be exposed", () => {
+  assertStrictEquals(
+    assert_,
+    assert,
+    "`assert()` should be the default export",
+  );
+  assertStrictEquals(assert_, denoAssert, "`assert()` should be exposed");
+  assertStrictEquals(assert_, ok, "`assert()` should be an alias of `ok()`");
+  assertStrictEquals(
+    assertEquals,
+    deepStrictEqual,
+    "`assertEquals()` should be exposed as `deepStrictEqual()`",
+  );
+  assertStrictEquals(
+    assertNotEquals,
+    notDeepStrictEqual,
+    "`assertNotEquals()` should be exposed as `notDeepStrictEqual()`",
+  );
+  assertStrictEquals(
+    assertStrictEquals,
+    strictEqual,
+    "`assertStrictEquals()` should be exposed as `strictEqual()`",
+  );
+  assertStrictEquals(
+    assertNotStrictEquals,
+    notStrictEqual,
+    "`assertNotStrictEquals()` should be exposed as `notStrictEqual()`",
+  );
+  assertStrictEquals(
+    assertMatch,
+    match,
+    "`assertMatch()` should be exposed as `match()`",
+  );
+  assertStrictEquals(
+    assertThrows,
+    throws,
+    "`assertThrows()` should be exposed as `throws()`",
+  );
+  assertStrictEquals(fail, denoFail, "`fail()` should be exposed");
 });

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -247,7 +247,11 @@ export function assertStrictEquals(
   expected: unknown,
   msg?: string,
 ): void;
-export function assertStrictEquals<T>(actual: T, expected: T, msg?: string): void;
+export function assertStrictEquals<T>(
+  actual: T,
+  expected: T,
+  msg?: string,
+): void;
 export function assertStrictEquals(
   actual: unknown,
   expected: unknown,
@@ -303,7 +307,11 @@ export function assertNotStrictEquals(
   expected: unknown,
   msg?: string,
 ): void;
-export function assertNotStrictEquals<T>(actual: T, expected: T, msg?: string): void;
+export function assertNotStrictEquals<T>(
+  actual: T,
+  expected: T,
+  msg?: string,
+): void;
 export function assertNotStrictEquals(
   actual: unknown,
   expected: unknown,
@@ -314,7 +322,7 @@ export function assertNotStrictEquals(
   }
 
   throw new AssertionError(
-    msg ?? `Expected "actual" to be strictly unequal to: ${_format(actual)}\n`
+    msg ?? `Expected "actual" to be strictly unequal to: ${_format(actual)}\n`,
   );
 }
 

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -242,9 +242,15 @@ export function assertNotEquals(
  * assertStrictEquals(1, 2)
  * ```
  */
-export function assertStrictEquals<T>(
-  actual: T,
-  expected: T,
+export function assertStrictEquals(
+  actual: unknown,
+  expected: unknown,
+  msg?: string,
+): void;
+export function assertStrictEquals<T>(actual: T, expected: T, msg?: string): void;
+export function assertStrictEquals(
+  actual: unknown,
+  expected: unknown,
   msg?: string,
 ): void {
   if (actual === expected) {
@@ -279,6 +285,51 @@ export function assertStrictEquals<T>(
       } catch (e) {
         message = `\n${red(CAN_NOT_DISPLAY)} + \n\n`;
       }
+    }
+  }
+
+  throw new AssertionError(message);
+}
+
+/**
+ * Make an assertion that `actual` and `expected` are not strictly equal.  
+ * If the values are strictly equal then throw.
+ * ```ts
+ * assertNotStrictEquals(1, 1)
+ * ```
+ */
+export function assertNotStrictEquals(
+  actual: unknown,
+  expected: unknown,
+  msg?: string,
+): void;
+export function assertNotStrictEquals<T>(actual: T, expected: T, msg?: string): void;
+export function assertNotStrictEquals(
+  actual: unknown,
+  expected: unknown,
+  msg?: string,
+): void {
+  if (actual !== expected) {
+    return;
+  }
+
+  let message: string;
+
+  if (msg) {
+    message = msg;
+  } else {
+    const actualString = _format(actual);
+    const expectedString = _format(expected);
+
+    try {
+      const diffResult = diff(
+        actualString.split("\n"),
+        expectedString.split("\n"),
+      );
+      const diffMsg = buildMessage(diffResult).join("\n");
+      message = `Expected "actual" to be strictly unequal to:\n${diffMsg}`;
+    } catch (e) {
+      message = `\n${red(CAN_NOT_DISPLAY)} + \n\n`;
     }
   }
 

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -313,27 +313,9 @@ export function assertNotStrictEquals(
     return;
   }
 
-  let message: string;
-
-  if (msg) {
-    message = msg;
-  } else {
-    const actualString = _format(actual);
-    const expectedString = _format(expected);
-
-    try {
-      const diffResult = diff(
-        actualString.split("\n"),
-        expectedString.split("\n"),
-      );
-      const diffMsg = buildMessage(diffResult).join("\n");
-      message = `Expected "actual" to be strictly unequal to:\n${diffMsg}`;
-    } catch (e) {
-      message = `\n${red(CAN_NOT_DISPLAY)} + \n\n`;
-    }
-  }
-
-  throw new AssertionError(message);
+  throw new AssertionError(
+    msg ?? `Expected "actual" to be strictly unequal to: ${_format(actual)}\n`
+  );
 }
 
 /**

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -464,31 +464,31 @@ Deno.test({
 });
 
 Deno.test({
-  name: 'strictly unequal pass case',
+  name: "strictly unequal pass case",
   fn(): void {
     assertNotStrictEquals(true, false);
     assertNotStrictEquals(10, 11);
-    assertNotStrictEquals('abc', 'xyz');
+    assertNotStrictEquals("abc", "xyz");
     assertNotStrictEquals(1, "1");
 
-    const xs = [1, false, 'foo'];
-    const ys = [1, true, 'bar'];
+    const xs = [1, false, "foo"];
+    const ys = [1, true, "bar"];
     assertNotStrictEquals(xs, ys);
 
     const x = { a: 1 };
     const y = { a: 2 };
     assertNotStrictEquals(x, y);
-  }
+  },
 });
 
 Deno.test({
-  name: 'strictly unequal fail case',
+  name: "strictly unequal fail case",
   fn(): void {
     assertThrows(
       () => assertNotStrictEquals(1, 1),
-      AssertionError
-    )
-  }
+      AssertionError,
+    );
+  },
 });
 
 Deno.test({

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -8,6 +8,7 @@ import {
   assertMatch,
   assertEquals,
   assertStrictEquals,
+  assertNotStrictEquals,
   assertThrows,
   assertThrowsAsync,
   AssertionError,
@@ -463,13 +464,42 @@ Deno.test({
 });
 
 Deno.test({
-  name: "assert* functions with specified type paratemeter",
+  name: 'strictly unequal pass case',
+  fn(): void {
+    assertNotStrictEquals(true, false);
+    assertNotStrictEquals(10, 11);
+    assertNotStrictEquals('abc', 'xyz');
+    assertNotStrictEquals(1, "1");
+
+    const xs = [1, false, 'foo'];
+    const ys = [1, true, 'bar'];
+    assertNotStrictEquals(xs, ys);
+
+    const x = { a: 1 };
+    const y = { a: 2 };
+    assertNotStrictEquals(x, y);
+  }
+});
+
+Deno.test({
+  name: 'strictly unequal fail case',
+  fn(): void {
+    assertThrows(
+      () => assertNotStrictEquals(1, 1),
+      AssertionError
+    )
+  }
+});
+
+Deno.test({
+  name: "assert* functions with specified type parameter",
   fn(): void {
     assertEquals<string>("hello", "hello");
     assertNotEquals<number>(1, 2);
     assertArrayContains<boolean>([true, false], [true]);
     const value = { x: 1 };
     assertStrictEquals<typeof value>(value, value);
+    assertNotStrictEquals<number>(1, '1' as any);
   },
 });
 

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -499,7 +499,7 @@ Deno.test({
     assertArrayContains<boolean>([true, false], [true]);
     const value = { x: 1 };
     assertStrictEquals<typeof value>(value, value);
-    assertNotStrictEquals<number>(1, '1' as any);
+    assertNotStrictEquals<object>(value, { x: 1 });
   },
 });
 


### PR DESCRIPTION
The re-exports of assertion methods from `std/testing` defined in `std/node/assert` are named incorrectly, because `assertEquals()` performs a [strict deep equality check](https://github.com/denoland/deno/blob/master/std/testing/asserts.ts#L154-L155), so it should be called `deepStrictEqual()` to match the expected behavior described in the corresponding Node.js [docs](https://nodejs.org/dist/latest-v14.x/docs/api/assert.html#assert_assert_deepstrictequal_actual_expected_message). The same applies to `assertNotEquals()` and `notDeepStrictEqual()`. 

In Node, `assert()` is just an [alias](https://nodejs.org/dist/latest-v14.x/docs/api/assert.html#assert_assert_ok_value_message) of `ok()`. This PR adds that alias as well, so it closes #7102.

Node's `equals()` and `notEquals()` methods are deprecated anyway, so I'm not sure we should implement them at all.

This PR also adds `assertNotStrictEquals()` in `std/testing` and re-exports it in `std/node/assert` as `notStrictEqual()`.