### PR TITLE
docs(std/wasi): fix reference to the wrong object in example

### DIFF
--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -68,7 +68,7 @@ const instance = await WebAssembly.instantiate(module, {
   wasi_snapshot_preview1: wasi.exports,
 });
 
-wasi.memory = module.exports.memory;
+wasi.memory = instance.exports.memory;
 
 if (module.exports._start) {
   instance.exports._start();


### PR DESCRIPTION
The example in the README is incorrectly setting the memory to the value of module.exports which doesn't exists. Exports are a property of WebAssembly.Instance objects.

This corrects the offending assignment.