### PR TITLE
refactor(cli/build.rs): extract ts version

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,6 @@ path = "main.rs"
 [build-dependencies]
 deno_core = { path = "../core", version = "0.53.0" }
 deno_web = { path = "../op_crates/web", version = "0.3.0" }
-regex = "1.3.9"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1.11"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "main.rs"
 [build-dependencies]
 deno_core = { path = "../core", version = "0.53.0" }
 deno_web = { path = "../op_crates/web", version = "0.3.0" }
+regex = "1.3.9"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1.11"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -71,11 +71,13 @@ fn create_compiler_snapshot(
 }
 
 fn ts_version() -> String {
-  let src = std::fs::read_to_string("tsc/00_typescript.js").unwrap();
-  // The below code supposes that the typescript source has
-  // `ts.version = "X.Y.Z"` pattern in a single line.
-  let line = src.lines().find(|l| l.contains("ts.version = ")).unwrap();
-  line
+  std::fs::read_to_string("tsc/00_typescript.js")
+    .unwrap()
+    .lines()
+    .find(|l| l.contains("ts.version = "))
+    .expect(
+      "Failed to find the pattern `ts.version = ` in typescript source code",
+    )
     .chars()
     .skip_while(|c| !char::is_numeric(*c))
     .take_while(|c| *c != '"')

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -4,6 +4,7 @@ mod op_fetch_asset;
 use deno_core::js_check;
 use deno_core::CoreIsolate;
 use deno_core::StartupData;
+use regex::Regex;
 use std::collections::HashMap;
 use std::env;
 use std::path::Path;
@@ -71,8 +72,11 @@ fn create_compiler_snapshot(
 }
 
 fn ts_version() -> String {
-  // TODO(ry) This should be automatically extracted from typescript.js
-  "3.9.7".to_string()
+  let ts_bytes = std::fs::read("tsc/00_typescript.js").unwrap();
+  let ts_source = String::from_utf8(ts_bytes).unwrap();
+  let re = Regex::new(r#"ts.version = "(\d\.\d\.\d)";"#).unwrap();
+  let caps = re.captures(&ts_source).unwrap();
+  caps.get(1).unwrap().as_str().to_owned()
 }
 
 fn main() {

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -73,7 +73,7 @@ fn create_compiler_snapshot(
 
 fn ts_version() -> String {
   let ts_source = std::fs::read_to_string("tsc/00_typescript.js").unwrap();
-  Regex::new(r#"ts.version = "(\d\.\d\.\d)";"#)
+  Regex::new(r#"ts.version = "(\d+\.\d+\.\d+)";"#)
     .ok()
     .and_then(|re| re.captures(&ts_source))
     .and_then(|caps| caps.get(1))

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -72,11 +72,13 @@ fn create_compiler_snapshot(
 }
 
 fn ts_version() -> String {
-  let ts_bytes = std::fs::read("tsc/00_typescript.js").unwrap();
-  let ts_source = String::from_utf8(ts_bytes).unwrap();
-  let re = Regex::new(r#"ts.version = "(\d\.\d\.\d)";"#).unwrap();
-  let caps = re.captures(&ts_source).unwrap();
-  caps.get(1).unwrap().as_str().to_owned()
+  let ts_source = std::fs::read_to_string("tsc/00_typescript.js").unwrap();
+  Regex::new(r#"ts.version = "(\d\.\d\.\d)";"#)
+    .ok()
+    .and_then(|re| re.captures(&ts_source))
+    .and_then(|caps| caps.get(1))
+    .map(|cap| cap.as_str().to_string())
+    .unwrap()
 }
 
 fn main() {

--- a/cli/dts/README.md
+++ b/cli/dts/README.md
@@ -7,8 +7,6 @@ It works like this currently:
 1. Checkout typescript repo in a seperate directory.
 2. Copy typescript.js into Deno repo
 3. Copy d.ts files into dts directory
-4. Update `ts_version()` in `cli/build.rs`
-   https://github.com/denoland/deno/blob/452693256ce7b607fa0b9454b22c57748f616742/cli/build.rs#L73-L76
 
 So that might look something like this:
 


### PR DESCRIPTION
This addresses a TODO comment in `//cli/build.rs`. This change extracts the typescript version from typescript source code at `//cli/tsc/00_typescript.js`.

The source code says:
```
WARNING: The script `configurePrerelease.ts` uses a regexp to parse out these values.
```
So I think this extraction logic is reliable to a certain extent.