### PR TITLE
Improve ts_version() in cli/build.rs

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "main.rs"
 [build-dependencies]
 deno_core = { path = "../core", version = "0.53.0" }
 deno_web = { path = "../op_crates/web", version = "0.3.0" }
+regex = "1.3.9"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1.11"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -4,11 +4,11 @@ mod op_fetch_asset;
 use deno_core::js_check;
 use deno_core::CoreIsolate;
 use deno_core::StartupData;
+use regex::Regex;
 use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::path::PathBuf;
-use regex::Regex;
 
 fn create_snapshot(
   mut isolate: CoreIsolate,

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::path::PathBuf;
+use regex::Regex;
 
 fn create_snapshot(
   mut isolate: CoreIsolate,
@@ -71,8 +72,10 @@ fn create_compiler_snapshot(
 }
 
 fn ts_version() -> String {
-  // TODO(ry) This should be automatically extracted from typescript.js
-  "3.9.7".to_string()
+  let typescript_js = std::fs::read_to_string("tsc/00_typescript.js").unwrap();
+  let re = Regex::new(r#"ts.version = "(\d+\.\d+\.\d+)""#).unwrap();
+  let caps = re.captures(&typescript_js).unwrap();
+  caps[1].to_string()
 }
 
 fn main() {

--- a/cli/dts/README.md
+++ b/cli/dts/README.md
@@ -7,8 +7,6 @@ It works like this currently:
 1. Checkout typescript repo in a seperate directory.
 2. Copy typescript.js into Deno repo
 3. Copy d.ts files into dts directory
-4. Update `ts_version()` in `cli/build.rs`
-   https://github.com/denoland/deno/blob/452693256ce7b607fa0b9454b22c57748f616742/cli/build.rs#L73-L76
 
 So that might look something like this:
 


### PR DESCRIPTION
this PR is for `// TODO(ry) This should be automatically extracted from typescript.js` in `cli/build.rs` line 74

using regex crate to get typescript version