### PR TITLE
feat(cli): isolate and group tests by module

### DIFF
--- a/cli/rt/40_testing.js
+++ b/cli/rt/40_testing.js
@@ -303,8 +303,6 @@ finishing test case.`;
     reportToConsole: reportToConsole_ = true,
     onMessage = undefined,
   } = {}) {
-    log(`${green("Running")} ${Deno.mainModule}`);
-
     const filterFn = createFilterFn(filter, skip);
     const testRunner = new TestRunner(TEST_REGISTRY, filterFn, failFast);
 

--- a/cli/rt/40_testing.js
+++ b/cli/rt/40_testing.js
@@ -303,6 +303,8 @@ finishing test case.`;
     reportToConsole: reportToConsole_ = true,
     onMessage = undefined,
   } = {}) {
+    log(`${green("Running")} ${Deno.mainModule}`);
+
     const filterFn = createFilterFn(filter, skip);
     const testRunner = new TestRunner(TEST_REGISTRY, filterFn, failFast);
 

--- a/cli/test_runner.rs
+++ b/cli/test_runner.rs
@@ -63,33 +63,6 @@ pub fn prepare_test_modules_urls(
   Ok(prepared)
 }
 
-pub fn render_test_file(
-  modules: Vec<Url>,
-  fail_fast: bool,
-  quiet: bool,
-  filter: Option<String>,
-) -> String {
-  let mut test_file = "".to_string();
-
-  for module in modules {
-    test_file.push_str(&format!("import \"{}\";\n", module.to_string()));
-  }
-
-  let options = if let Some(filter) = filter {
-    json!({ "failFast": fail_fast, "reportToConsole": !quiet, "disableLog": quiet, "filter": filter })
-  } else {
-    json!({ "failFast": fail_fast, "reportToConsole": !quiet, "disableLog": quiet })
-  };
-
-  let run_tests_cmd = format!(
-    "// @ts-ignore\nDeno[Deno.internal].runTests({});\n",
-    options
-  );
-  test_file.push_str(&run_tests_cmd);
-
-  test_file
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -4,7 +4,7 @@ import { assert, assertEquals } from "../testing/asserts.ts";
 import * as path from "../path/mod.ts";
 import WASI from "./snapshot_preview1.ts";
 
-if (import.meta.main) {
+if (Deno.args.length > 0) {
   const options = JSON.parse(Deno.args[0]);
   const binary = await Deno.readFile(Deno.args[1]);
   const module = await WebAssembly.compile(binary);


### PR DESCRIPTION
This runs each test module in its own worker and removes the need for rendering a test file.

This means that tests are grouped together where the output looks more like they are in cargo test and Deno.mainModule is equal the test module that is being run so import semantics are more "correct".

Example output:

```
Check file:///home/caspervonb/deno/std/testing/bench_test.ts
running 11 tests
test benching ... running 5 benchmarks ...
benchmark forIncrementX1e9 ... 
    1051.831278ms
benchmark forDecrementX1e9 ... 
    589.9383739999998ms
benchmark forAwaitFetchDenolandX10 ... 
    587.2021980000002ms
benchmark promiseAllFetchDenolandX10 ... 
    139.58885099999998ms
benchmark runs100ForIncrementX1e6 ... 
    100 runs avg: 1.0118494600000167ms
benchmark result: DONE. 5 measured; 1 filtered
ok (2499ms)
test Bench without name should throw ... ok (4ms)
test Bench without stop should throw ... ok (4ms)
test Bench without start should throw ... ok (3ms)
test Bench with stop before start should throw ... ok (3ms)
test clearBenchmarks should clear all candidates ... ok (3ms)
test clearBenchmarks with only as option ... ok (4ms)
test clearBenchmarks with skip as option ... ok (4ms)
test clearBenchmarks with only and skip as option ... ok (3ms)
test progressCallback of runBenchmarks ... ok (8ms)
test async progressCallback ... ok (3ms)

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (2545ms)

Check file:///home/caspervonb/deno/std/testing/asserts_test.ts
running 31 tests
test testingEqual ... ok (19ms)
test testingNotEquals ... ok (3ms)
test testingAssertStringContains ... ok (3ms)
test testingArrayContains ... ok (6ms)
test testingAssertStringContainsThrow ... ok (3ms)
test testingAssertStringMatching ... ok (3ms)
test testingAssertStringMatchingThrows ... ok (3ms)
test testingAssertsUnimplemented ... ok (3ms)
test testingAssertsUnreachable ... ok (3ms)
test testingAssertFail ... ok (2ms)
test testingAssertFailWithWrongErrorClass ... ok (3ms)
test testingAssertThrowsWithReturnType ... ok (3ms)
test testingAssertThrowsAsyncWithReturnType ... ok (3ms)
test pass case ... ok (3ms)
test failed with number ... ok (5ms)
test failed with number vs string ... ok (3ms)
test failed with array ... ok (4ms)
test failed with object ... ok (4ms)
test failed with date ... ok (4ms)
test strict pass case ... ok (3ms)
test strict failed with structure diff ... ok (4ms)
test strict failed with reference diff ... ok (4ms)
test strictly unequal pass case ... ok (3ms)
test strictly unequal fail case ... ok (3ms)
test assert* functions with specified type parameter ... ok (3ms)
test Assert Throws Non-Error Fail ... ok (3ms)
test Assert Throws Async Non-Error Fail ... ok (3ms)
test assertEquals diff for differently ordered objects ... ok (2ms)
test assert diff formatting ... ok (4ms)
test Assert Throws Parent Error ... ok (3ms)
test Assert Throws Async Parent Error ... ok (3ms)

test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (137ms)

Check file:///home/caspervonb/deno/std/testing/diff_test.ts
running 10 tests
test empty ... ok (8ms)
test "a" vs "b" ... ok (4ms)
test "a" vs "a" ... ok (4ms)
test "a" vs "" ... ok (4ms)
test "" vs "a" ... ok (3ms)
test "a" vs "a, b" ... ok (3ms)
test "strength" vs "string" ... ok (4ms)
test "strength" vs "" ... ok (3ms)
test "" vs "strength" ... ok (3ms)
test "abc", "c" vs "abc", "bcd", "c" ... ok (2ms)

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (43ms)

Check file:///home/caspervonb/deno/std/datetime/test.ts
running 9 tests
test [std/datetime] parse ... ok (20ms)
test [std/datetime] invalidParseDateTimeFormatThrows ... ok (4ms)
test [std/datetime] format ... ok (8ms)
test [std/datetime] dayOfYear ... ok (4ms)
test [std/datetime] weekOfYear ... ok (4ms)
test [std/datetime] to IMF ... ok (3ms)
test [std/datetime] to IMF 0 ... ok (3ms)
test [std/datetime] isLeap ... ok (2ms)
test [std/datetime] difference ... ok (3ms)

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (58ms)
```

Performance hit is negligible, when testing something like std not even measurable.

Closes https://github.com/denoland/deno/issues/4644