### PR TITLE
fix(console): handle escape sequences when logging objects

### DIFF
--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -450,12 +450,12 @@
     const quote = QUOTES.find((c) => !string.includes(c)) ?? QUOTES[0];
     const escapePattern = new RegExp(`(?=[${quote}\\\\])`, "g");
     string = string.replace(escapePattern, "\\");
-    string = replaceEscaped(string);
+    string = replaceEscapeSequences(string);
     return `${quote}${string}${quote}`;
   }
 
-  // Replace escaped sequences that can modify output.
-  function replaceEscaped(string) {
+  // Replace escape sequences that can modify output.
+  function replaceEscapeSequences(string) {
     return string
       .replace(/[\b]/g, "\\b")
       .replace(/\f/g, "\\f")
@@ -697,7 +697,7 @@
 
     for (const key of stringKeys) {
       entries.push(
-        `${replaceEscaped(key)}: ${
+        `${replaceEscapeSequences(key)}: ${
           inspectValueWithQuotes(
             value[key],
             ctx,
@@ -709,7 +709,7 @@
     }
     for (const key of symbolKeys) {
       entries.push(
-        `${replaceEscaped(key.toString())}: ${
+        `${replaceEscapeSequences(key.toString())}: ${
           inspectValueWithQuotes(
             value[key],
             ctx,

--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -439,16 +439,30 @@
   const QUOTES = ['"', "'", "`"];
 
   /** Surround the string in quotes.
- *
- * The quote symbol is chosen by taking the first of the `QUOTES` array which
- * does not occur in the string. If they all occur, settle with `QUOTES[0]`.
- *
- * Insert a backslash before any occurrence of the chosen quote symbol and
- * before any backslash. */
+   *
+   * The quote symbol is chosen by taking the first of the `QUOTES` array which
+   * does not occur in the string. If they all occur, settle with `QUOTES[0]`.
+   *
+   * Insert a backslash before any occurrence of the chosen quote symbol and
+   * before any backslash.
+   */
   function quoteString(string) {
     const quote = QUOTES.find((c) => !string.includes(c)) ?? QUOTES[0];
     const escapePattern = new RegExp(`(?=[${quote}\\\\])`, "g");
-    return `${quote}${string.replace(escapePattern, "\\")}${quote}`;
+    string = string.replace(escapePattern, "\\");
+    string = replaceEscaped(string);
+    return `${quote}${string}${quote}`;
+  }
+
+  // Replace escaped sequences that can modify output.
+  function replaceEscaped(string) {
+    return string
+      .replace(/[\b]/g, "\\b")
+      .replace(/\f/g, "\\f")
+      .replace(/\n/g, "\\n")
+      .replace(/\r/g, "\\r")
+      .replace(/\t/g, "\\t")
+      .replace(/\v/g, "\\v");
   }
 
   // Print strings when they are inside of arrays or objects with quotes
@@ -683,7 +697,7 @@
 
     for (const key of stringKeys) {
       entries.push(
-        `${key}: ${
+        `${replaceEscaped(key)}: ${
           inspectValueWithQuotes(
             value[key],
             ctx,
@@ -695,7 +709,7 @@
     }
     for (const key of symbolKeys) {
       entries.push(
-        `${key.toString()}: ${
+        `${replaceEscaped(key.toString())}: ${
           inspectValueWithQuotes(
             value[key],
             ctx,

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -57,20 +57,22 @@ unitTest(function consoleTestStringifyComplexObjects(): void {
   assertEquals(stringify({ foo: "bar" }), `{ foo: "bar" }`);
 });
 
-unitTest(function consoleTestStringifyComplexObjectsWithEscapedSequences(): void {
-  assertEquals(
-    stringify(["foo\b", "foo\f", "foo\n", "foo\r", "foo\t", "foo\v"]),
-    `[ "foo\\b", "foo\\f", "foo\\n", "foo\\r", "foo\\t", "foo\\v" ]`
-  );
-  assertEquals(
-    stringify({"foo\b": "bar\n", "bar\r": "baz\t"}),
-    `{ foo\\b: "bar\\n", bar\\r: "baz\\t" }`
-  );
-  assertEquals(
-    stringify(new Set(["foo\n", "foo\r"])),
-    `Set { "foo\\n", "foo\\r" }`
-  );
-});
+unitTest(
+  function consoleTestStringifyComplexObjectsWithEscapedSequences(): void {
+    assertEquals(
+      stringify(["foo\b", "foo\f", "foo\n", "foo\r", "foo\t", "foo\v"]),
+      `[ "foo\\b", "foo\\f", "foo\\n", "foo\\r", "foo\\t", "foo\\v" ]`,
+    );
+    assertEquals(
+      stringify({ "foo\b": "bar\n", "bar\r": "baz\t" }),
+      `{ foo\\b: "bar\\n", bar\\r: "baz\\t" }`,
+    );
+    assertEquals(
+      stringify(new Set(["foo\n", "foo\r"])),
+      `Set { "foo\\n", "foo\\r" }`,
+    );
+  },
+);
 
 unitTest(function consoleTestStringifyQuotes(): void {
   assertEquals(stringify(["\\"]), `[ "\\\\" ]`);

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -57,6 +57,21 @@ unitTest(function consoleTestStringifyComplexObjects(): void {
   assertEquals(stringify({ foo: "bar" }), `{ foo: "bar" }`);
 });
 
+unitTest(function consoleTestStringifyComplexObjectsWithEscapedSequences(): void {
+  assertEquals(
+    stringify(["foo\b", "foo\f", "foo\n", "foo\r", "foo\t", "foo\v"]),
+    `[ "foo\\b", "foo\\f", "foo\\n", "foo\\r", "foo\\t", "foo\\v" ]`
+  );
+  assertEquals(
+    stringify({"foo\b": "bar\n", "bar\r": "baz\t"}),
+    `{ foo\\b: "bar\\n", bar\\r: "baz\\t" }`
+  );
+  assertEquals(
+    stringify(new Set(["foo\n", "foo\r"])),
+    `Set { "foo\\n", "foo\\r" }`
+  );
+});
+
 unitTest(function consoleTestStringifyQuotes(): void {
   assertEquals(stringify(["\\"]), `[ "\\\\" ]`);
   assertEquals(stringify(['\\,"']), `[ '\\\\,"' ]`);


### PR DESCRIPTION
Fix #7090

Replace escape sequences with simple strings when parsing objects, i.e `\n` to `\\n`.
```ts
console.log(["foo\r"])

// Before  " ]foo
// After   [ "foo\r" ]

console.log(["foo\n"])

// Before  [ "foo
//         " ]
// After   [ "foo\n" ]
```