### PR TITLE
fix: throw TypeError on invalid input types in TextDecoder.decode()

### DIFF
--- a/op_crates/web/08_text_encoding.js
+++ b/op_crates/web/08_text_encoding.js
@@ -442,6 +442,7 @@
         bytes = new Uint8Array(input);
       } else if (
         typeof input === "object" &&
+        input !== null &&
         "buffer" in input &&
         isEitherArrayBuffer(input.buffer)
       ) {

--- a/op_crates/web/08_text_encoding.js
+++ b/op_crates/web/08_text_encoding.js
@@ -395,7 +395,7 @@
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function isEitherArrayBuffer(x) {
-    return x instanceof SharedArrayBuffer || x instanceof ArrayBuffer;
+    return x instanceof SharedArrayBuffer || x instanceof ArrayBuffer || typeof x === "undefined";
   }
 
   class TextDecoder {
@@ -452,7 +452,9 @@
           input.byteLength,
         );
       } else {
-        bytes = new Uint8Array(0);
+        throw new TypeError(
+          "Provided input is not of type ArrayBuffer or ArrayBufferView",
+        );
       }
 
       // For simple utf-8 decoding "Deno.core.decode" can be used for performance

--- a/op_crates/web/08_text_encoding.js
+++ b/op_crates/web/08_text_encoding.js
@@ -395,7 +395,8 @@
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function isEitherArrayBuffer(x) {
-    return x instanceof SharedArrayBuffer || x instanceof ArrayBuffer || typeof x === "undefined";
+    return x instanceof SharedArrayBuffer || x instanceof ArrayBuffer ||
+      typeof x === "undefined";
   }
 
   class TextDecoder {

--- a/op_crates/web/text_encoding_test.js
+++ b/op_crates/web/text_encoding_test.js
@@ -131,10 +131,42 @@ function textDecoderErrorEncoding() {
   assert(didThrow);
 }
 
-function textDecoderHandlesNull() {
-  const fixture = null;
+function textDecoderHandlesUndefined() {
+  const fixture = undefined;
   const decoder = new TextDecoder();
   assert(decoder.decode(fixture) === "");
+}
+
+function textDecoderThrowsOnEmpty() {
+  const fixture = "";
+  const decoder = new TextDecoder();
+  let didThrow = false;
+  try {
+    decoder.decode(fixture);
+  } catch (e) {
+    didThrow = true;
+    assert(
+      e.message ===
+        "Provided input is not of type ArrayBuffer or ArrayBufferView",
+    );
+  }
+  assert(didThrow);
+}
+
+function textDecoderThrowsOnNull() {
+  const fixture = null;
+  const decoder = new TextDecoder();
+  let didThrow = false;
+  try {
+    decoder.decode(fixture);
+  } catch (e) {
+    didThrow = true;
+    assert(
+      e.message ===
+        "Provided input is not of type ArrayBuffer or ArrayBufferView",
+    );
+  }
+  assert(didThrow);
 }
 
 function textEncoder() {
@@ -237,7 +269,9 @@ function main() {
   textDecoderNotBOM();
   textDecoderASCII();
   textDecoderErrorEncoding();
-  textDecoderHandlesNull();
+  textDecoderHandlesUndefined();
+  textDecoderThrowsOnEmpty();
+  textDecoderThrowsOnNull();
   textEncoder();
   textEncodeInto();
   textEncodeInto2();

--- a/op_crates/web/text_encoding_test.js
+++ b/op_crates/web/text_encoding_test.js
@@ -131,6 +131,12 @@ function textDecoderErrorEncoding() {
   assert(didThrow);
 }
 
+function textDecoderHandlesNull() {
+  const fixture = null;
+  const decoder = new TextDecoder();
+  assert(decoder.decode(fixture) === "");
+}
+
 function textEncoder() {
   const fixture = "𝓽𝓮𝔁𝓽";
   const encoder = new TextEncoder();
@@ -231,6 +237,7 @@ function main() {
   textDecoderNotBOM();
   textDecoderASCII();
   textDecoderErrorEncoding();
+  textDecoderHandlesNull();
   textEncoder();
   textEncodeInto();
   textEncodeInto2();


### PR DESCRIPTION
Fixes #7178
Fixes #7181