### PR TITLE
Adds Fetch Data and Read Write Examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -9,6 +9,7 @@ more about the runtime.
 - [Import and Export Modules](./examples/import_export)
 - [How to Manage Dependencies](./examples/manage_dependencies)
 - [Fetch Data](./examples/fetch_data)
+- [Read and Write Files](./examples/read_write_files)
 
 ## Advanced
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -8,6 +8,7 @@ more about the runtime.
 - [Hello World](./examples/hello_world)
 - [Import and Export Modules](./examples/import_export)
 - [How to Manage Dependencies](./examples/manage_dependencies)
+- [Fetch Data](./examples/fetch_data)
 
 ## Advanced
 

--- a/docs/examples/fetch_data.md
+++ b/docs/examples/fetch_data.md
@@ -3,6 +3,8 @@
 When building any sort of web application developers will usually need to
 retrieve data from somewhere else on the web. This works no differently in Deno
 than in any other JavaScript application, just call the the `fetch()` method.
+For more information on fetch read the
+[MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
 The exception with Deno occurs when running a script which makes a call over the
 web. Deno is secure by default which means access to IO (Input / Output) is

--- a/docs/examples/fetch_data.md
+++ b/docs/examples/fetch_data.md
@@ -1,0 +1,41 @@
+## Fetch Data
+
+When building any sort of web application developers will usually need to retrieve data from somewhere else on the web. This works no differently in Deno than in any other JavaScript application, just call the the `fetch()` method.
+
+The exception with Deno occurs when running a script which makes a call over the web. Deno is secure by default, which means access to IO (Input / Output) is prohibited by default. To make a call over the web Deno must be explicitly told it is ok to do so. This is achieved by adding the `--allow-net` flag to the `deno run` command.
+
+**Command:** `deno run --allow-net fetch.ts`
+
+```js
+async function callApi(url: string): Promise<Response> {
+  try {
+    return await fetch(url);
+  } catch (e) {
+    throw new Error(e.message);
+  }
+}
+
+/**
+ * Output: JSON Data
+**/
+callApi("https://api.github.com/users/denoland")
+  .then((response) => {
+    return response.json();
+  })
+  .then(json => console.log(json));
+
+/**
+ * Output: HTML Data
+**/
+callApi("https://deno.land/")
+  .then((response) => {
+    return response.text();
+  })
+  .then(text => console.log(text));
+
+/**
+ * Output: Error Message
+**/
+callApi("https://does.not.exist/")
+  .catch(error => console.log(error));
+```

--- a/docs/examples/fetch_data.md
+++ b/docs/examples/fetch_data.md
@@ -5,8 +5,8 @@ retrieve data from somewhere else on the web. This works no differently in Deno
 than in any other JavaScript application, just call the the `fetch()` method.
 
 The exception with Deno occurs when running a script which makes a call over the
-web. Deno is secure by default, which means access to IO (Input / Output) is
-prohibited by default. To make a call over the web Deno must be explicitly told
+web. Deno is secure by default which means access to IO (Input / Output) is
+prohibited. To make a call over the web Deno must be explicitly told
 it is ok to do so. This is achieved by adding the `--allow-net` flag to the
 `deno run` command.
 

--- a/docs/examples/fetch_data.md
+++ b/docs/examples/fetch_data.md
@@ -1,4 +1,4 @@
-## Fetch Data
+# Fetch Data
 
 When building any sort of web application developers will usually need to retrieve data from somewhere else on the web. This works no differently in Deno than in any other JavaScript application, just call the the `fetch()` method.
 

--- a/docs/examples/fetch_data.md
+++ b/docs/examples/fetch_data.md
@@ -13,35 +13,32 @@ command.
 **Command:** `deno run --allow-net fetch.ts`
 
 ```js
-async function callApi(url: string): Promise<Response> {
-  try {
-    return await fetch(url);
-  } catch (e) {
-    throw new Error(e.message);
-  }
-}
-
 /**
  * Output: JSON Data
-**/
-callApi("https://api.github.com/users/denoland")
-  .then((response) => {
-    return response.json();
-  })
-  .then((json) => console.log(json));
+ */
+const json = fetch("https://api.github.com/users/denoland");
+
+json.then((response) => {
+  return response.json();
+}).then((jsonData) => {
+  console.log(jsonData);
+});
 
 /**
  * Output: HTML Data
-**/
-callApi("https://deno.land/")
-  .then((response) => {
-    return response.text();
-  })
-  .then((text) => console.log(text));
+ */
+const text = fetch("https://deno.land/");
+
+text.then((response) => {
+  return response.text();
+}).then((textData) => {
+  console.log(textData);
+});
 
 /**
  * Output: Error Message
-**/
-callApi("https://does.not.exist/")
-  .catch((error) => console.log(error));
+ */
+const error = fetch("https://does.not.exist/");
+
+error.catch((error) => console.log(error.message));
 ```

--- a/docs/examples/fetch_data.md
+++ b/docs/examples/fetch_data.md
@@ -1,8 +1,14 @@
 # Fetch Data
 
-When building any sort of web application developers will usually need to retrieve data from somewhere else on the web. This works no differently in Deno than in any other JavaScript application, just call the the `fetch()` method.
+When building any sort of web application developers will usually need to
+retrieve data from somewhere else on the web. This works no differently in Deno
+than in any other JavaScript application, just call the the `fetch()` method.
 
-The exception with Deno occurs when running a script which makes a call over the web. Deno is secure by default, which means access to IO (Input / Output) is prohibited by default. To make a call over the web Deno must be explicitly told it is ok to do so. This is achieved by adding the `--allow-net` flag to the `deno run` command.
+The exception with Deno occurs when running a script which makes a call over the
+web. Deno is secure by default, which means access to IO (Input / Output) is
+prohibited by default. To make a call over the web Deno must be explicitly told
+it is ok to do so. This is achieved by adding the `--allow-net` flag to the
+`deno run` command.
 
 **Command:** `deno run --allow-net fetch.ts`
 
@@ -22,7 +28,7 @@ callApi("https://api.github.com/users/denoland")
   .then((response) => {
     return response.json();
   })
-  .then(json => console.log(json));
+  .then((json) => console.log(json));
 
 /**
  * Output: HTML Data
@@ -31,11 +37,11 @@ callApi("https://deno.land/")
   .then((response) => {
     return response.text();
   })
-  .then(text => console.log(text));
+  .then((text) => console.log(text));
 
 /**
  * Output: Error Message
 **/
 callApi("https://does.not.exist/")
-  .catch(error => console.log(error));
+  .catch((error) => console.log(error));
 ```

--- a/docs/examples/fetch_data.md
+++ b/docs/examples/fetch_data.md
@@ -6,9 +6,9 @@ than in any other JavaScript application, just call the the `fetch()` method.
 
 The exception with Deno occurs when running a script which makes a call over the
 web. Deno is secure by default which means access to IO (Input / Output) is
-prohibited. To make a call over the web Deno must be explicitly told
-it is ok to do so. This is achieved by adding the `--allow-net` flag to the
-`deno run` command.
+prohibited. To make a call over the web Deno must be explicitly told it is ok to
+do so. This is achieved by adding the `--allow-net` flag to the `deno run`
+command.
 
 **Command:** `deno run --allow-net fetch.ts`
 

--- a/docs/examples/read_write_files.md
+++ b/docs/examples/read_write_files.md
@@ -53,8 +53,8 @@ flag is required along with the `deno run` command.
 **Command:** `deno run --unstable --allow-read read.ts`
 
 ```js
-import { readJsonSync } from "https://deno.land/std@0.65.0/fs/mod.ts";
-import { fromFileUrl } from "https://deno.land/std@0.65.0/path/mod.ts";
+import { readJsonSync } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
 
 function readJson(path: string): object {
   const file = fromFileUrl(new URL(path, import.meta.url));
@@ -77,8 +77,8 @@ console.log(readJson("./people.json"));
 ## Write
 
 The Deno runtime API allows developers to write text to files via the
-`writeTextFile()` method. It just requires a file path and text string. On
-success the method will return an empty promise.
+`writeTextFile()` method. It just requires a file path and text string. The
+method returns a promise which resolves when the file was successfully written.
 
 To run the command the `--allow-write` flag must be supplied to the `deno run`
 command.
@@ -119,7 +119,7 @@ write and read flags.
 import {
   ensureFileSync,
   writeJsonSync,
-} from "https://deno.land/std@0.65.0/fs/mod.ts";
+} from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
 
 function writeJson(path: string, data: object): string {
   try {

--- a/docs/examples/read_write_files.md
+++ b/docs/examples/read_write_files.md
@@ -2,7 +2,8 @@
 
 Interacting with the filesystem to read and write files is a basic requirement
 of most development projects. Deno provides a number of ways to do this via the
-[standard library]() and the [Deno runtime API]().
+[standard library](https://deno.land/std) and the
+[Deno runtime API](https://doc.deno.land/builtin/stable).
 
 As highlighted in the [Fetch Data example](./fetch_data) Deno restricts access
 to Input / Output by default for security reasons. So when interacting with the
@@ -13,7 +14,7 @@ filesystem the `--allow-read` and `--allow-write` flags must be used with the
 
 The Deno runtime API makes it possible to read text files via the
 `readTextFile()` method, it just requires a path string or URL object. The
-method returns a promise which provides access to the text data.
+method returns a promise which provides access to the file's text data.
 
 **Command:** `deno run --allow-read read.ts`
 
@@ -39,9 +40,12 @@ text.then((response) => console.log(response));
 
 The Deno standard library enables more advanced interaction with the filesystem
 and provides methods to read and parse files. The `readJson()` and
-`readJsonSync()` allow developers to read and parse files containing JSON. All
-these methods require is a valid file path string which can be generated using
-the `fromFileUrl()` method.
+`readJsonSync()` methods allow developers to read and parse files containing
+JSON. All these methods require is a valid file path string which can be
+generated using the `fromFileUrl()` method.
+
+In the example below the `readJsonSync()` method is used, for asynchronus
+execution use the `readJson()` method.
 
 Currently some of this functionality is marked as unstable so the `--unstable`
 flag is required along with the `deno run` command.
@@ -101,12 +105,12 @@ file.
 
 This requires a combination of the `ensureFile()`, `ensureFileSync()`,
 `writeJson()` and `writeJsonSync()` methods. In the example below the
-`ensureFileSync()` and the `writeJsonSync()` methods. The former checks for the
-existence of a file, and if it doesn't exist creates it. The latter method then
-writes the object to the file as JSON. If asynchronus execution is required use
-the `ensureFile()` and `writeJson()` methods.
+`ensureFileSync()` and the `writeJsonSync()` methods are used. The former checks
+for the existence of a file, and if it doesn't exist creates it. The latter
+method then writes the object to the file as JSON. If asynchronus execution is
+required use the `ensureFile()` and `writeJson()` methods.
 
-To execute the code the `deno run` command needs the stable flag and both the
+To execute the code the `deno run` command needs the unstable flag and both the
 write and read flags.
 
 **Command:** `deno run --allow-write --allow-read --unstable write.ts`

--- a/docs/examples/read_write_files.md
+++ b/docs/examples/read_write_files.md
@@ -1,14 +1,22 @@
 # Read and Write Files
 
-Interacting with the filesystem to read and write files is a basic requirement of most development projects. Deno provides a number of ways to do this via the [standard library]() and the [Deno runtime API]().
+Interacting with the filesystem to read and write files is a basic requirement
+of most development projects. Deno provides a number of ways to do this via the
+[standard library]() and the [Deno runtime API]().
 
-As highlighted in the [Fetch Data example](./fetch_data) Deno restricts access to Input / Output by default for security reasons. So when interacting with the filesystem the `--allow-read` and `--allow-write` flags must be used with the `deno run` command.
+As highlighted in the [Fetch Data example](./fetch_data) Deno restricts access
+to Input / Output by default for security reasons. So when interacting with the
+filesystem the `--allow-read` and `--allow-write` flags must be used with the
+`deno run` command.
 
 ## Read
 
-The Deno runtime API makes it possible to read text files via the `readTextFile()` method, it just requires a path string or URL object. The method returns a promise which provides access to the text data.
+The Deno runtime API makes it possible to read text files via the
+`readTextFile()` method, it just requires a path string or URL object. The
+method returns a promise which provides access to the text data.
 
 **Command:** `deno run --allow-read read.ts`
+
 ```js
 async function readFile(path: string): Promise<string> {
   return await Deno.readTextFile(new URL(path, import.meta.url));
@@ -28,11 +36,18 @@ text.then((response) => console.log(response));
  * ]
  */
 ```
-The Deno standard library enables more advanced interaction with the filesystem and provides methods to read and parse files. The `readJson()` and `readJsonSync()` allow developers to read and parse files containing JSON. All these methods require is a valid file path string which can be generated using the `fromFileUrl()` method.
 
-Currently some of this functionality is marked as unstable so the `--unstable` flag is required along with the `deno run` command.
+The Deno standard library enables more advanced interaction with the filesystem
+and provides methods to read and parse files. The `readJson()` and
+`readJsonSync()` allow developers to read and parse files containing JSON. All
+these methods require is a valid file path string which can be generated using
+the `fromFileUrl()` method.
+
+Currently some of this functionality is marked as unstable so the `--unstable`
+flag is required along with the `deno run` command.
 
 **Command:** `deno run --unstable --allow-read read.ts`
+
 ```js
 import { readJsonSync } from "https://deno.land/std@0.65.0/fs/mod.ts";
 import { fromFileUrl } from "https://deno.land/std@0.65.0/path/mod.ts";
@@ -57,11 +72,15 @@ console.log(readJson("./people.json"));
 
 ## Write
 
-The Deno runtime API allows developers to write text to files via the `writeTextFile()` method. It just requires a file path and text string. On success the method will return an empty promise.
+The Deno runtime API allows developers to write text to files via the
+`writeTextFile()` method. It just requires a file path and text string. On
+success the method will return an empty promise.
 
-To run the command the `--allow-write` flag must be supplied to the `deno run` command.
+To run the command the `--allow-write` flag must be supplied to the `deno run`
+command.
 
 **Command:** `deno run --allow-write write.ts`
+
 ```js
 async function writeFile(path: string, text: string): Promise<void> {
   return await Deno.writeTextFile(path, text);
@@ -75,13 +94,23 @@ write.then(() => console.log("File written to."));
  * Output: File written to.
  */
 ```
-The Deno standard library makes available more advanced features to write to the filesystem. For instance it is possible to write an object literal to a JSON file.
 
-This requires a combination of the `ensureFile()`, `ensureFileSync()`, `writeJson()` and `writeJsonSync()` methods. In the example below the `ensureFileSync()` and the `writeJsonSync()` methods. The former checks for the existence of a file, and if it doesn't exist creates it. The latter method then writes the object to the file as JSON. If asynchronus execution is required use the `ensureFile()` and `writeJson()` methods.
+The Deno standard library makes available more advanced features to write to the
+filesystem. For instance it is possible to write an object literal to a JSON
+file.
 
-To execute the code the `deno run` command needs the stable flag and both the write and read flags.
+This requires a combination of the `ensureFile()`, `ensureFileSync()`,
+`writeJson()` and `writeJsonSync()` methods. In the example below the
+`ensureFileSync()` and the `writeJsonSync()` methods. The former checks for the
+existence of a file, and if it doesn't exist creates it. The latter method then
+writes the object to the file as JSON. If asynchronus execution is required use
+the `ensureFile()` and `writeJson()` methods.
+
+To execute the code the `deno run` command needs the stable flag and both the
+write and read flags.
 
 **Command:** `deno run --allow-write --allow-read --unstable write.ts`
+
 ```js
 import {
   ensureFileSync,

--- a/docs/examples/read_write_files.md
+++ b/docs/examples/read_write_files.md
@@ -1,0 +1,107 @@
+# Read and Write Files
+
+Interacting with the filesystem to read and write files is a basic requirement of most development projects. Deno provides a number of ways to do this via the [standard library]() and the [Deno runtime API]().
+
+As highlighted in the [Fetch Data example](./fetch_data) Deno restricts access to Input / Output by default for security reasons. So when interacting with the filesystem the `--allow-read` and `--allow-write` flags must be used with the `deno run` command.
+
+## Read
+
+The Deno runtime API makes it possible to read text files via the `readTextFile()` method, it just requires a path string or URL object. The method returns a promise which provides access to the text data.
+
+**Command:** `deno run --allow-read read.ts`
+```js
+async function readFile(path: string): Promise<string> {
+  return await Deno.readTextFile(new URL(path, import.meta.url));
+}
+
+const text = readFile("./people.json");
+
+text.then((response) => console.log(response));
+
+/**
+ * Output:
+ *
+ * [
+ *   {"id": 1, "name": "John", "age": 23},
+ *   {"id": 2, "name": "Sandra", "age": 51},
+ *   {"id": 5, "name": "Devika", "age": 11}
+ * ]
+ */
+```
+The Deno standard library enables more advanced interaction with the filesystem and provides methods to read and parse files. The `readJson()` and `readJsonSync()` allow developers to read and parse files containing JSON. All these methods require is a valid file path string which can be generated using the `fromFileUrl()` method.
+
+Currently some of this functionality is marked as unstable so the `--unstable` flag is required along with the `deno run` command.
+
+**Command:** `deno run --unstable --allow-read read.ts`
+```js
+import { readJsonSync } from "https://deno.land/std@0.65.0/fs/mod.ts";
+import { fromFileUrl } from "https://deno.land/std@0.65.0/path/mod.ts";
+
+function readJson(path: string): object {
+  const file = fromFileUrl(new URL(path, import.meta.url));
+  return readJsonSync(file) as object;
+}
+
+console.log(readJson("./people.json"));
+
+/**
+ * Output:
+ *
+ * [
+ *   {"id": 1, "name": "John", "age": 23},
+ *   {"id": 2, "name": "Sandra", "age": 51},
+ *   {"id": 5, "name": "Devika", "age": 11}
+ * ]
+ */
+```
+
+## Write
+
+The Deno runtime API allows developers to write text to files via the `writeTextFile()` method. It just requires a file path and text string. On success the method will return an empty promise.
+
+To run the command the `--allow-write` flag must be supplied to the `deno run` command.
+
+**Command:** `deno run --allow-write write.ts`
+```js
+async function writeFile(path: string, text: string): Promise<void> {
+  return await Deno.writeTextFile(path, text);
+}
+
+const write = writeFile("./hello.txt", "Hello World!");
+
+write.then(() => console.log("File written to."));
+
+/**
+ * Output: File written to.
+ */
+```
+The Deno standard library makes available more advanced features to write to the filesystem. For instance it is possible to write an object literal to a JSON file.
+
+This requires a combination of the `ensureFile()`, `ensureFileSync()`, `writeJson()` and `writeJsonSync()` methods. In the example below the `ensureFileSync()` and the `writeJsonSync()` methods. The former checks for the existence of a file, and if it doesn't exist creates it. The latter method then writes the object to the file as JSON. If asynchronus execution is required use the `ensureFile()` and `writeJson()` methods.
+
+To execute the code the `deno run` command needs the stable flag and both the write and read flags.
+
+**Command:** `deno run --allow-write --allow-read --unstable write.ts`
+```js
+import {
+  ensureFileSync,
+  writeJsonSync,
+} from "https://deno.land/std@0.65.0/fs/mod.ts";
+
+function writeJson(path: string, data: object): string {
+  try {
+    ensureFileSync(path);
+    writeJsonSync(path, data);
+
+    return "Written to " + path;
+  } catch (e) {
+    return e.message;
+  }
+}
+
+console.log(writeJson("./data.json", { hello: "World" }));
+
+/**
+ * Output: Written to ./data.json
+ */
+```

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -73,6 +73,7 @@
       "import_export": "Import and Export Modules",
       "manage_dependencies": "Manage Dependencies",
       "fetch_data": "Fetch Data",
+      "read_write_files": "Read and Write Files",
       "unix_cat": "Unix cat program",
       "file_server": "File server",
       "tcp_echo": "TCP echo server",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -72,6 +72,7 @@
       "hello_world": "Hello World",
       "import_export": "Import and Export Modules",
       "manage_dependencies": "Manage Dependencies",
+      "fetch_data": "Fetch Data",
       "unix_cat": "Unix cat program",
       "file_server": "File server",
       "tcp_echo": "TCP echo server",


### PR DESCRIPTION
This pull requests adds two further basic examples to the examples list, the aim is to introduce concepts such as security, flags and the differences between the runtime API and the standard library.

Examples include:
- Fetch data over the web.
- Read and write files to the file system.

Work contributes further to #6844.

Future PRs may add one final basic example and will also begin tidying up existing advanced examples. 
