### PR TITLE
feat(cli/web/fetch): timeout option on http client

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1234,6 +1234,9 @@ declare namespace Deno {
      * Requires `allow-read` permission.
      */
     caFile?: string;
+
+    /** Request timeout in milliseconds. Sets deadline for total request + body read. */
+    timeoutMs?: number;
   }
 
   /** **UNSTABLE**: New API, yet to be vetted.

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1236,7 +1236,7 @@ declare namespace Deno {
     caFile?: string;
 
     /** Request timeout in milliseconds. Sets deadline for total request + body read. */
-    timeoutMs?: number;
+    timeout?: number;
   }
 
   /** **UNSTABLE**: New API, yet to be vetted.

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -21,9 +21,9 @@ use std::io::Read;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
+use std::time::Duration;
 use tokio::io::AsyncRead;
 use url::Url;
-use std::time::Duration;
 
 /// Create new instance of async reqwest::Client. This client supports
 /// proxies and doesn't follow redirects.
@@ -32,7 +32,10 @@ pub fn create_http_client(ca_file: Option<&str>) -> Result<Client, ErrBox> {
 }
 /// Create new instance of async reqwest::Client with a request timeout. This client supports
 /// proxies and doesn't follow redirects.
-pub fn create_http_client_with_timeout(ca_file: Option<&str>, timeout_ms: Option<u64>) -> Result<Client, ErrBox> {
+pub fn create_http_client_with_timeout(
+  ca_file: Option<&str>,
+  timeout_ms: Option<u64>,
+) -> Result<Client, ErrBox> {
   let mut headers = HeaderMap::new();
   headers.insert(
     USER_AGENT,

--- a/cli/ops/fetch.rs
+++ b/cli/ops/fetch.rs
@@ -150,10 +150,9 @@ fn op_create_http_client(
     state.check_read(&PathBuf::from(ca_file))?;
   }
 
-  let client = create_http_client_with_timeout(
-    args.ca_file.as_deref(),
-    args.timeout_ms
-  ).unwrap();
+  let client =
+    create_http_client_with_timeout(args.ca_file.as_deref(), args.timeout_ms)
+      .unwrap();
 
   let rid =
     resource_table.add("httpClient", Box::new(HttpClientResource::new(client)));

--- a/cli/ops/fetch.rs
+++ b/cli/ops/fetch.rs
@@ -134,7 +134,7 @@ impl HttpClientResource {
 #[serde(default)]
 struct CreateHttpClientOptions {
   ca_file: Option<String>,
-  timeout_ms: Option<u64>,
+  timeout: Option<u64>,
 }
 
 fn op_create_http_client(
@@ -151,7 +151,7 @@ fn op_create_http_client(
   }
 
   let client =
-    create_http_client_with_timeout(args.ca_file.as_deref(), args.timeout_ms)
+    create_http_client_with_timeout(args.ca_file.as_deref(), args.timeout)
       .unwrap();
 
   let rid =

--- a/cli/ops/fetch.rs
+++ b/cli/ops/fetch.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use super::dispatch_json::{Deserialize, JsonOp, Value};
 use super::io::{StreamResource, StreamResourceHolder};
-use crate::http_util::{create_http_client, HttpBody};
+use crate::http_util::{create_http_client_with_timeout, HttpBody};
 use crate::state::State;
 use deno_core::CoreIsolate;
 use deno_core::CoreIsolateState;
@@ -134,6 +134,7 @@ impl HttpClientResource {
 #[serde(default)]
 struct CreateHttpClientOptions {
   ca_file: Option<String>,
+  timeout_ms: Option<u64>,
 }
 
 fn op_create_http_client(
@@ -149,7 +150,10 @@ fn op_create_http_client(
     state.check_read(&PathBuf::from(ca_file))?;
   }
 
-  let client = create_http_client(args.ca_file.as_deref()).unwrap();
+  let client = create_http_client_with_timeout(
+    args.ca_file.as_deref(),
+    args.timeout_ms
+  ).unwrap();
 
   let rid =
     resource_table.add("httpClient", Box::new(HttpClientResource::new(client)));

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -956,3 +956,39 @@ unitTest(
     client.close();
   },
 );
+
+unitTest(
+  { perms: { net: true, read: true } },
+  async function fetchCustomHttpClientTimeoutError(): Promise<
+    void
+  > {
+    const client = Deno.createHttpClient(
+      { timeout: 1 },
+    );
+    await assertThrowsAsync(async (): Promise<void> => {
+      const _response = await fetch(
+        "https://localhost:4545/cli/tests/fixture.json",
+        { client },
+      );
+    });
+    client.close();
+  },
+);
+unitTest(
+  { perms: { net: true, read: true } },
+  async function fetchCustomHttpClientTimeout(): Promise<
+    void
+  > {
+    const client = Deno.createHttpClient(
+      { timeout: 10000 },
+    );
+    const resp = await fetch(
+      "http://localhost:4545/cli/tests/fixture.json",
+      { client },
+    );
+    assertEquals(resp.status, 200);
+    const json = await resp.json();
+    assertEquals(json.name, "deno");
+    client.close();
+  },
+);

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -970,7 +970,7 @@ unitTest(
         "https://localhost:4545/cli/tests/fixture.json",
         { client },
       );
-    });
+    }, Deno.errors.Http);
     client.close();
   },
 );


### PR DESCRIPTION
This adds a `timeout_ms` option to the HTTP Client Options struct, and passed it to the built in `reqwest` timeout. This is useful for enforcing total request time on `fetch` requests.

There are no tests yet, and not useful exception in JS land. I'll add those but I wanted to make sure this is a desirable feature. This is not part of the fetch spec, but is a simpler option (for now) than #6093.