### PR TITLE
fix(std/wasi): make parameter & return value of `syscall` typed

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -228,11 +228,9 @@ const clock_time_monotonic = function (): bigint {
 const clock_time_process = clock_time_monotonic;
 const clock_time_thread = clock_time_monotonic;
 
-// deno-lint-ignore no-explicit-any
-type Syscall<T extends any[]> = (...args: T) => number;
-// deno-lint-ignore no-explicit-any
-function syscall<T extends any[]>(target: Syscall<T>): Syscall<T> {
-  return function (...args: T): number {
+// deno-lint-ignore ban-types
+function syscall(target: Function): Function {
+  return function (...args: unknown[]): number {
     try {
       return target(...args);
     } catch (err) {
@@ -301,8 +299,8 @@ export default class Context {
   // deno-lint-ignore no-explicit-any
   fds: any[];
 
-  // deno-lint-ignore no-explicit-any
-  exports: Record<string, Syscall<any[]>>;
+  // deno-lint-ignore ban-types
+  exports: Record<string, Function>;
 
   constructor(options: ContextOptions) {
     this.args = options.args ? options.args : [];

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -228,9 +228,11 @@ const clock_time_monotonic = function (): bigint {
 const clock_time_process = clock_time_monotonic;
 const clock_time_thread = clock_time_monotonic;
 
-type Syscall = (...args: unknown[]) => number;
-function syscall(target: Syscall): Syscall {
-  return function (...args: unknown[]): number {
+// deno-lint-ignore no-explicit-any
+type Syscall<T extends any[]> = (...args: T) => number;
+// deno-lint-ignore no-explicit-any
+function syscall<T extends any[]>(target: Syscall<T>): Syscall<T> {
+  return function (...args: T): number {
     try {
       return target(...args);
     } catch (err) {
@@ -299,7 +301,8 @@ export default class Context {
   // deno-lint-ignore no-explicit-any
   fds: any[];
 
-  exports: Record<string, Syscall>;
+  // deno-lint-ignore no-explicit-any
+  exports: Record<string, Syscall<any[]>>;
 
   constructor(options: ContextOptions) {
     this.args = options.args ? options.args : [];

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -228,8 +228,8 @@ const clock_time_monotonic = function (): bigint {
 const clock_time_process = clock_time_monotonic;
 const clock_time_thread = clock_time_monotonic;
 
-type SyscallFunction = (...args: unknown[]) => number;
-function syscall(target: SyscallFunction): SyscallFunction {
+type Syscall = (...args: unknown[]) => number;
+function syscall(target: Syscall): Syscall {
   return function (...args: unknown[]): number {
     try {
       return target(...args);
@@ -299,7 +299,7 @@ export default class Context {
   // deno-lint-ignore no-explicit-any
   fds: any[];
 
-  exports: Record<string, SyscallFunction>;
+  exports: Record<string, Syscall>;
 
   constructor(options: ContextOptions) {
     this.args = options.args ? options.args : [];

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -228,7 +228,8 @@ const clock_time_monotonic = function (): bigint {
 const clock_time_process = clock_time_monotonic;
 const clock_time_thread = clock_time_monotonic;
 
-function syscall(target: Function): Function {
+type SyscallFunction = (...args: unknown[]) => number;
+function syscall(target: SyscallFunction): SyscallFunction {
   return function (...args: unknown[]): number {
     try {
       return target(...args);
@@ -298,7 +299,7 @@ export default class Context {
   // deno-lint-ignore no-explicit-any
   fds: any[];
 
-  exports: Record<string, Function>;
+  exports: Record<string, SyscallFunction>;
 
   constructor(options: ContextOptions) {
     this.args = options.args ? options.args : [];


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

As reported in #7193, updating `deno_lint` and enabling `ban-types` rule, we get the following lint error:

```
(ban-types) Define the function shape Explicitly.
function syscall(target: Function): Function {
                         ~~~~~~~~
    at /Users/biwanczuk/dev/deno/std/wasi/snapshot_preview1.ts:231:25

(ban-types) Define the function shape Explicitly.
function syscall(target: Function): Function {
                                    ~~~~~~~~
    at /Users/biwanczuk/dev/deno/std/wasi/snapshot_preview1.ts:231:36

(ban-types) Define the function shape Explicitly.
  exports: Record<string, Function>;
                          ~~~~~~~~
    at /Users/biwanczuk/dev/deno/std/wasi/snapshot_preview1.ts:301:26
```

This PR fixes it by making `Function` typed as `(...args: unknown[]) => number` explicitly.