### PR TITLE
test(url_test): disable `no-self-assign` rule

### DIFF
--- a/cli/tests/unit/url_test.ts
+++ b/cli/tests/unit/url_test.ts
@@ -183,10 +183,13 @@ unitTest(function urlNormalize(): void {
 unitTest(function urlModifyPathname(): void {
   const url = new URL("http://foo.bar/baz%qat/qux%quux");
   assertEquals(url.pathname, "/baz%qat/qux%quux");
+  // Self-assignment is to invoke the setter.
+  // deno-lint-ignore no-self-assign
   url.pathname = url.pathname;
   assertEquals(url.pathname, "/baz%qat/qux%quux");
   url.pathname = "baz#qat qux";
   assertEquals(url.pathname, "/baz%23qat%20qux");
+  // deno-lint-ignore no-self-assign
   url.pathname = url.pathname;
   assertEquals(url.pathname, "/baz%23qat%20qux");
 });
@@ -195,6 +198,7 @@ unitTest(function urlModifyHash(): void {
   const url = new URL("http://foo.bar");
   url.hash = "%foo bar/qat%qux#bar";
   assertEquals(url.hash, "#%foo%20bar/qat%qux#bar");
+  // deno-lint-ignore no-self-assign
   url.hash = url.hash;
   assertEquals(url.hash, "#%foo%20bar/qat%qux#bar");
 });


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

As reported in #7193, linting by the new version of `deno_lint` produces the error like:

```
(no-self-assign) "pathname" is assigned to itself
  url.pathname = url.pathname;
                 ~~~~~~~~~~~~
    at /Users/biwanczuk/dev/deno/cli/tests/unit/url_test.ts:186:17

(no-self-assign) "pathname" is assigned to itself
  url.pathname = url.pathname;
                 ~~~~~~~~~~~~
    at /Users/biwanczuk/dev/deno/cli/tests/unit/url_test.ts:190:17

(no-self-assign) "hash" is assigned to itself
  url.hash = url.hash;
             ~~~~~~~~
    at /Users/biwanczuk/dev/deno/cli/tests/unit/url_test.ts:198:13
```

And according to @nayeemrmn, these self-assignments are required in order to invoke the setters, so the errors should be ignored.
So I added `deno-lint-ignore no-self-assign` lines.