### PR TITLE
feat(std/path): Align globToRegExp() with bash glob expansion

### DIFF
--- a/std/fs/expand_glob.ts
+++ b/std/fs/expand_glob.ts
@@ -59,15 +59,17 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
   return 0;
 }
 
-/**
- * Expand the glob string from the specified `root` directory and yield each
+/** Expand the glob string from the specified `root` directory and yield each
  * result as a `WalkEntry` object.
  *
- * Examples:
+ * See [`globToRegExp()`](../path/glob.ts#globToRegExp) for details on supported
+ * syntax.
  *
- *     for await (const file of expandGlob("**\/*.ts")) {
- *       console.log(file);
- *     }
+ * Example:
+ *
+ *      for await (const file of expandGlob("**\/*.ts")) {
+ *        console.log(file);
+ *      }
  */
 export async function* expandGlob(
   glob: string,
@@ -167,15 +169,13 @@ export async function* expandGlob(
   yield* currentMatches;
 }
 
-/**
- * Synchronous version of `expandGlob()`.
+/** Synchronous version of `expandGlob()`.
  *
- * Examples:
+ * Example:
  *
- *     for (const file of expandGlobSync("**\/*.ts")) {
- *       console.log(file);
- *     }
- */
+ *      for (const file of expandGlobSync("**\/*.ts")) {
+ *        console.log(file);
+ *      } */
 export function* expandGlobSync(
   glob: string,
   {

--- a/std/fs/expand_glob.ts
+++ b/std/fs/expand_glob.ts
@@ -175,7 +175,8 @@ export async function* expandGlob(
  *
  *      for (const file of expandGlobSync("**\/*.ts")) {
  *        console.log(file);
- *      } */
+ *      }
+ */
 export function* expandGlobSync(
   glob: string,
   {

--- a/std/path/glob_test.ts
+++ b/std/path/glob_test.ts
@@ -43,7 +43,14 @@ function match(
 Deno.test({
   name: "[path] globToRegExp() Basic RegExp",
   fn(): void {
-    assertEquals(globToRegExp(""), /^$/);
+    assertEquals(globToRegExp("*.js", { os: "linux" }), /^[^/]*\.js\/*$/);
+  },
+});
+
+Deno.test({
+  name: "[path] globToRegExp() Empty glob",
+  fn(): void {
+    assertEquals(globToRegExp(""), /(?!)/);
     assertEquals(globToRegExp("*.js", { os: "linux" }), /^[^/]*\.js\/*$/);
   },
 });
@@ -108,47 +115,54 @@ Deno.test({
       ),
     );
     assert(
-      match(
-        "[[:digit:]]/bar.txt",
-        "1/bar.txt",
-        { extended: false, globstar: false },
-      ),
-    );
-    assert(
-      match(
-        "[[:digit:]b]/bar.txt",
-        "b/bar.txt",
-        { extended: false, globstar: false },
-      ),
-    );
-    assert(
-      match(
-        "[![:digit:]b]/bar.txt",
-        "a/bar.txt",
-        { extended: false, globstar: false },
-      ),
-    );
-    assert(
       !match(
         "[[:alnum:]]/bar.txt",
         "!/bar.txt",
         { extended: false, globstar: false },
       ),
     );
-    assert(
-      !match(
-        "[[:digit:]]/bar.txt",
-        "a/bar.txt",
-        { extended: false, globstar: false },
-      ),
-    );
-    assert(
-      !match(
-        "[[:digit:]b]/bar.txt",
-        "a/bar.txt",
-        { extended: false, globstar: false },
-      ),
-    );
+    for (const c of "09AGZagz") {
+      assert(match("[[:alnum:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "AGZagz") {
+      assert(match("[[:alpha:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "\x00\x20\x7F") {
+      assert(match("[[:ascii:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "\t ") {
+      assert(match("[[:blank:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "\x00\x1F\x7F") {
+      assert(match("[[:cntrl:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "09") {
+      assert(match("[[:digit:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "\x21\x7E") {
+      assert(match("[[:graph:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "az") {
+      assert(match("[[:lower:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "\x20\x7E") {
+      assert(match("[[:print:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "!\"#$%&'()*+,-./:;<=>?@[\\]^_‘{|}~") {
+      assert(match("[[:punct:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "\t\n\v\f\r ") {
+      assert(match("[[:space:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "AZ") {
+      assert(match("[[:upper:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "09AZaz_") {
+      assert(match("[[:word:]]", c, { extended: false, globstar: false }), c);
+    }
+    for (const c of "09AFaf") {
+      assert(match("[[:xdigit:]]", c, { extended: false, globstar: false }), c);
+    }
   },
 });
 
@@ -366,8 +380,11 @@ Deno.test({
   name: "[path] globToRegExp() Special RegExp characters in range",
   fn(): void {
     // Excluding characters checked in the previous test.
-    assertEquals(globToRegExp("[\\$^.=]", { os: "linux" }), /^[\\$^.=]\/*$/);
-    assertEquals(globToRegExp("[!\\$^.=]", { os: "linux" }), /^[^\\$^.=]\/*$/);
+    assertEquals(globToRegExp("[\\\\$^.=]", { os: "linux" }), /^[\\$^.=]\/*$/);
+    assertEquals(
+      globToRegExp("[!\\\\$^.=]", { os: "linux" }),
+      /^[^\\$^.=]\/*$/,
+    );
     assertEquals(globToRegExp("[^^]", { os: "linux" }), /^[\^^]\/*$/);
   },
 });
@@ -405,6 +422,53 @@ Deno.test({
     assert(match("**/bar", "foo\\bar", { os: "windows" }));
     assert(match("**\\bar", "foo/bar", { os: "windows" }));
     assert(match("**\\bar", "foo\\bar", { os: "windows" }));
+  },
+});
+
+Deno.test({
+  name: "[path] globToRegExp() Unclosed groups",
+  fn() {
+    assert(match("{foo,bar}/[ab", "foo/[ab"));
+    assert(match("{foo,bar}/{foo,bar", "foo/{foo,bar"));
+    assert(match("{foo,bar}/?(foo|bar", "foo/?(foo|bar"));
+    assert(match("{foo,bar}/@(foo|bar", "foo/@(foo|bar"));
+    assert(match("{foo,bar}/*(foo|bar", "foo/*(foo|bar"));
+    assert(match("{foo,bar}/+(foo|bar", "foo/+(foo|bar"));
+    assert(match("{foo,bar}/!(foo|bar", "foo/!(foo|bar"));
+    assert(match("{foo,bar}/?({)}", "foo/?({)}"));
+    assert(match("{foo,bar}/{?(})", "foo/{?(})"));
+  },
+});
+
+Deno.test({
+  name: "[path] globToRegExp() Escape glob characters",
+  fn() {
+    assert(match("\\[ab]", "[ab]", { os: "linux" }));
+    assert(match("`[ab]", "[ab]", { os: "windows" }));
+    assert(match("\\{foo,bar}", "{foo,bar}", { os: "linux" }));
+    assert(match("`{foo,bar}", "{foo,bar}", { os: "windows" }));
+    assert(match("\\?(foo|bar)", "?(foo|bar)", { os: "linux" }));
+    assert(match("`?(foo|bar)", "?(foo|bar)", { os: "windows" }));
+    assert(match("\\@(foo|bar)", "@(foo|bar)", { os: "linux" }));
+    assert(match("`@(foo|bar)", "@(foo|bar)", { os: "windows" }));
+    assert(match("\\*(foo|bar)", "*(foo|bar)", { os: "linux" }));
+    assert(match("`*(foo|bar)", "*(foo|bar)", { os: "windows" }));
+    assert(match("\\+(foo|bar)", "+(foo|bar)", { os: "linux" }));
+    assert(match("`+(foo|bar)", "+(foo|bar)", { os: "windows" }));
+    assert(match("\\!(foo|bar)", "!(foo|bar)", { os: "linux" }));
+    assert(match("`!(foo|bar)", "!(foo|bar)", { os: "windows" }));
+    assert(match("@\\(foo|bar)", "@(foo|bar)", { os: "linux" }));
+    assert(match("@`(foo|bar)", "@(foo|bar)", { os: "windows" }));
+    assert(match("{foo,bar}/[ab]\\", "foo/[ab]\\", { os: "linux" }));
+    assert(match("{foo,bar}/[ab]`", "foo/[ab]`", { os: "windows" }));
+  },
+});
+
+Deno.test({
+  name: "[path] globToRegExp() Dangling escape prefix",
+  fn() {
+    assert(match("{foo,bar}/[ab]\\", "foo/[ab]\\", { os: "linux" }));
+    assert(match("{foo,bar}/[ab]`", "foo/[ab]`", { os: "windows" }));
   },
 });
 


### PR DESCRIPTION
- feat: Support escaping glob characters
- feat: Support more character classes
- feat: Match characters literally on segment parse failure
- fix: Match nothing for empty globs
- fix: Contain any glob syntax to its path segment
- perf: Remove extraneous separators from generated regex
- doc: Add detailed JSDoc
- chore: Remove old copyright headers

---

More details in the JSDoc.