### PR TITLE
fix(std/wasi): invalid number to bigint conversion in fd_tell

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -913,7 +913,7 @@ export default class Context {
         const view = new DataView(this.memory.buffer);
 
         const offset = entry.handle.seekSync(0, Deno.SeekMode.Current);
-        view.setBigUint64(offset_out, offset, true);
+        view.setBigUint64(offset_out, BigInt(offset), true);
 
         return ERRNO_SUCCESS;
       }),


### PR DESCRIPTION
The fd_tell syscall always throws an error because a number is not a bigint.

This explicitly converts the number to bigint returned from Deno.seek to fix that and brings in a test case to verify the behaviour.