### PR TITLE
chore(std/encoding): disable `no-control-regex`

### DIFF
--- a/std/encoding/_yaml/loader/loader.ts
+++ b/std/encoding/_yaml/loader/loader.ts
@@ -26,6 +26,7 @@ const CHOMPING_STRIP = 2;
 const CHOMPING_KEEP = 3;
 
 const PATTERN_NON_PRINTABLE =
+  // deno-lint-ignore no-control-regex
   /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
 const PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/;
 const PATTERN_FLOW_INDICATORS = /[,\[\]\{\}]/;


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

I'd like to apply the latest version of the recommended rules of `deno_lint`, listed [here](https://github.com/denoland/deno_lint/blob/master/src/rules/mod.rs#L93-L155).
This list has `no-control-regex` rule, and it generates an error at `std/encoding/_yaml/loader/loader.ts`. Here control characters seem to be required and intentional, so we can ignore this lint error.

related: #7193 
CC @bartlomieju 
