### PR TITLE
fix(cli/lint): use `deno_lint::rules::get_recommended_rules`to get rules

### DIFF
--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -95,64 +95,8 @@ pub async fn lint_files(
   Ok(())
 }
 
-/// List of lint rules used available in "deno lint" subcommand
-fn get_rules() -> Vec<Box<dyn LintRule>> {
-  vec![
-    rules::ban_ts_comment::BanTsComment::new(),
-    rules::ban_untagged_ignore::BanUntaggedIgnore::new(),
-    rules::constructor_super::ConstructorSuper::new(),
-    rules::for_direction::ForDirection::new(),
-    rules::getter_return::GetterReturn::new(),
-    rules::no_array_constructor::NoArrayConstructor::new(),
-    rules::no_async_promise_executor::NoAsyncPromiseExecutor::new(),
-    rules::no_case_declarations::NoCaseDeclarations::new(),
-    rules::no_class_assign::NoClassAssign::new(),
-    rules::no_compare_neg_zero::NoCompareNegZero::new(),
-    rules::no_cond_assign::NoCondAssign::new(),
-    rules::no_debugger::NoDebugger::new(),
-    rules::no_delete_var::NoDeleteVar::new(),
-    rules::no_dupe_args::NoDupeArgs::new(),
-    rules::no_dupe_class_members::NoDupeClassMembers::new(),
-    rules::no_dupe_else_if::NoDupeElseIf::new(),
-    rules::no_dupe_keys::NoDupeKeys::new(),
-    rules::no_duplicate_case::NoDuplicateCase::new(),
-    rules::no_empty_character_class::NoEmptyCharacterClass::new(),
-    rules::no_empty_interface::NoEmptyInterface::new(),
-    rules::no_empty_pattern::NoEmptyPattern::new(),
-    rules::no_empty::NoEmpty::new(),
-    rules::no_ex_assign::NoExAssign::new(),
-    rules::no_explicit_any::NoExplicitAny::new(),
-    rules::no_extra_boolean_cast::NoExtraBooleanCast::new(),
-    rules::no_extra_non_null_assertion::NoExtraNonNullAssertion::new(),
-    rules::no_extra_semi::NoExtraSemi::new(),
-    rules::no_func_assign::NoFuncAssign::new(),
-    rules::no_misused_new::NoMisusedNew::new(),
-    rules::no_namespace::NoNamespace::new(),
-    rules::no_new_symbol::NoNewSymbol::new(),
-    rules::no_obj_calls::NoObjCalls::new(),
-    rules::no_octal::NoOctal::new(),
-    rules::no_prototype_builtins::NoPrototypeBuiltins::new(),
-    rules::no_regex_spaces::NoRegexSpaces::new(),
-    rules::no_setter_return::NoSetterReturn::new(),
-    rules::no_this_alias::NoThisAlias::new(),
-    rules::no_this_before_super::NoThisBeforeSuper::new(),
-    rules::no_unsafe_finally::NoUnsafeFinally::new(),
-    rules::no_unsafe_negation::NoUnsafeNegation::new(),
-    rules::no_with::NoWith::new(),
-    rules::prefer_as_const::PreferAsConst::new(),
-    rules::prefer_namespace_keyword::PreferNamespaceKeyword::new(),
-    rules::require_yield::RequireYield::new(),
-    rules::triple_slash_reference::TripleSlashReference::new(),
-    rules::use_isnan::UseIsNaN::new(),
-    rules::valid_typeof::ValidTypeof::new(),
-    rules::no_inferrable_types::NoInferrableTypes::new(),
-    rules::no_unused_labels::NoUnusedLabels::new(),
-    rules::no_shadow_restricted_names::NoShadowRestrictedNames::new(),
-  ]
-}
-
 pub fn print_rules_list() {
-  let lint_rules = get_rules();
+  let lint_rules = rules::get_recommended_rules();
 
   println!("Available rules:");
   for rule in lint_rules {
@@ -181,7 +125,7 @@ fn lint_file(file_path: PathBuf) -> Result<Vec<LintDiagnostic>, ErrBox> {
   let media_type = map_file_extension(&file_path);
   let syntax = swc_util::get_syntax_for_media_type(media_type);
 
-  let lint_rules = get_rules();
+  let lint_rules = rules::get_recommended_rules();
   let mut linter = create_linter(syntax, lint_rules);
 
   let file_diagnostics = linter.lint(file_name, source_code)?;

--- a/docs/tools/linter.md
+++ b/docs/tools/linter.md
@@ -14,8 +14,10 @@ deno lint --unstable myfile1.ts myfile2.ts
 
 ### Available rules
 
+- `adjacent-overload-signatures`
 - `ban-ts-comment`
 - `ban-untagged-ignore`
+- `ban-types`
 - `constructor-super`
 - `for-direction`
 - `getter-return`
@@ -25,9 +27,12 @@ deno lint --unstable myfile1.ts myfile2.ts
 - `no-class-assign`
 - `no-compare-neg-zero`
 - `no-cond-assign`
+- `no-control-regex`
 - `no-debugger`
 - `no-delete-var`
 - `no-dupe-args`
+- `no-dupe-class-members`
+- `no-dupe-else-if`
 - `no-dupe-keys`
 - `no-duplicate-case`
 - `no-empty-character-class`
@@ -36,7 +41,12 @@ deno lint --unstable myfile1.ts myfile2.ts
 - `no-empty`
 - `no-ex-assign`
 - `no-explicit-any`
+- `no-extra-boolean-cast`
+- `no-extra-non-null-assertion`
+- `no-extra-semi`
+- `no-mixed-spaces-and-tabs`
 - `no-func-assign`
+- `no-irregular-whitespace`
 - `no-misused-new`
 - `no-namespace`
 - `no-new-symbol`
@@ -45,8 +55,10 @@ deno lint --unstable myfile1.ts myfile2.ts
 - `no-prototype-builtins`
 - `no-regex-spaces`
 - `no-setter-return`
+- `no-self-assign`
 - `no-this-alias`
 - `no-this-before-super`
+- `no-unexpected-multiline`
 - `no-unsafe-finally`
 - `no-unsafe-negation`
 - `no-with`
@@ -56,6 +68,11 @@ deno lint --unstable myfile1.ts myfile2.ts
 - `triple-slash-reference`
 - `use-isnan`
 - `valid-typeof`
+- `no-inferrable-types`
+- `no-invalid-regexp`
+- `no-unused-labels`
+- `no-shadow-restricted-names`
+- `no-constant-condition`
 
 ### Ignore directives
 

--- a/docs/tools/linter.md
+++ b/docs/tools/linter.md
@@ -16,8 +16,8 @@ deno lint --unstable myfile1.ts myfile2.ts
 
 - `adjacent-overload-signatures`
 - `ban-ts-comment`
-- `ban-untagged-ignore`
 - `ban-types`
+- `ban-untagged-ignore`
 - `constructor-super`
 - `for-direction`
 - `getter-return`
@@ -27,6 +27,7 @@ deno lint --unstable myfile1.ts myfile2.ts
 - `no-class-assign`
 - `no-compare-neg-zero`
 - `no-cond-assign`
+- `no-constant-condition`
 - `no-control-regex`
 - `no-debugger`
 - `no-delete-var`
@@ -35,32 +36,36 @@ deno lint --unstable myfile1.ts myfile2.ts
 - `no-dupe-else-if`
 - `no-dupe-keys`
 - `no-duplicate-case`
+- `no-empty`
 - `no-empty-character-class`
 - `no-empty-interface`
 - `no-empty-pattern`
-- `no-empty`
 - `no-ex-assign`
 - `no-explicit-any`
 - `no-extra-boolean-cast`
 - `no-extra-non-null-assertion`
 - `no-extra-semi`
-- `no-mixed-spaces-and-tabs`
 - `no-func-assign`
+- `no-inferrable-types`
+- `no-invalid-regexp`
 - `no-irregular-whitespace`
 - `no-misused-new`
+- `no-mixed-spaces-and-tabs`
 - `no-namespace`
 - `no-new-symbol`
 - `no-obj-call`
 - `no-octal`
 - `no-prototype-builtins`
 - `no-regex-spaces`
-- `no-setter-return`
 - `no-self-assign`
+- `no-setter-return`
+- `no-shadow-restricted-names`
 - `no-this-alias`
 - `no-this-before-super`
 - `no-unexpected-multiline`
 - `no-unsafe-finally`
 - `no-unsafe-negation`
+- `no-unused-labels`
 - `no-with`
 - `prefer-as-const`
 - `prefer-namespace-keyword`
@@ -68,11 +73,6 @@ deno lint --unstable myfile1.ts myfile2.ts
 - `triple-slash-reference`
 - `use-isnan`
 - `valid-typeof`
-- `no-inferrable-types`
-- `no-invalid-regexp`
-- `no-unused-labels`
-- `no-shadow-restricted-names`
-- `no-constant-condition`
 
 ### Ignore directives
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

Currently, Deno CLI has its own lint rules to be used. It doesn't use `deno_lint::rules::get_recommended_rules` because some rules were broken.
But now, thanks to awesome work by the contributors, already known bugs have been fixed.
So there seems no problem switching to `deno_lint::rules::get_recommended_rules`.

By switching, these rules are going to be added:

- adjacent_overload_signatures
- ban_types
- no_constant_condition
- no_control_regex
- no_invalid_regexp
- no_irregular_whitespace
- no_mixed_spaces_and_tabs
- no_self_assign
- no_unexpected_multiline


related: https://github.com/denoland/deno_lint/issues/277
CC: @bartlomieju 