### PR TITLE
fix(std/encoding/toml): Issue # 7072 Comment after arrays causing incorrect output

### DIFF
--- a/std/encoding/testdata/arrays.toml
+++ b/std/encoding/testdata/arrays.toml
@@ -1,8 +1,8 @@
 [arrays]
-data = [ ["gamma", "delta"], [1, 2] ]
+data = [ ["gamma", "delta"], [1, 2] ] # comment after an array caused issue #7072
 
 # Line breaks are OK when inside arrays
 hosts = [
   "alpha",
   "omega"
-]
+] # comment

--- a/std/encoding/testdata/comment.toml
+++ b/std/encoding/testdata/comment.toml
@@ -1,6 +1,6 @@
 # This is a full-line comment
-str0 = "value"  # This is a comment at the end of a line
-str1 = "# This is not a comment" # but this is 
+str0 = 'value' # This is a comment at the end of a line
+str1 = "# This is not a comment" # but this is
 str2 = """ # this is not a comment!
 A multiline string with a #
 # this is also not a comment
@@ -27,4 +27,3 @@ objectives = [ # Comment
  "minimal config file", 
  "#not a comment" # comment
 ] # comment
-

--- a/std/encoding/testdata/comment.toml
+++ b/std/encoding/testdata/comment.toml
@@ -1,0 +1,27 @@
+# This is a full-line comment
+str0 = "value"  # This is a comment at the end of a line
+str1 = "# This is not a comment" # but this is 
+str2 = """ # this is not a comment!
+A multiline string with a #
+# this is also not a comment
+""" # this is definitely a comment
+
+str3 = '''
+"# not a comment"
+	# this is a real tab on purpose 
+# not a comment
+''' # comment
+
+[deno] # this comment is fine
+features = ["#secure by default", "supports typescript # not a comment"] # Comment caused Issue #7072
+url = "https://deno.land/" # comment
+is_not_node = true # comment
+
+[toml] # Comment caused Issue #7072 (case 2)
+name = "Tom's Obvious, Minimal Language"
+objectives = [ # Comment
+ "easy to read", # Comment
+ "minimal config file", 
+ "#not a comment" # comment
+] # comment
+

--- a/std/encoding/testdata/comment.toml
+++ b/std/encoding/testdata/comment.toml
@@ -12,6 +12,9 @@ str3 = '''
 # not a comment
 ''' # comment
 
+point0 = { x = 1, y = 2, str0 = "#not a comment", z = 3 } # comment
+point1 = { x = 7, y = 8, z = 9, str0 = "#not a comment"} # comment
+
 [deno] # this comment is fine
 features = ["#secure by default", "supports typescript # not a comment"] # Comment caused Issue #7072
 url = "https://deno.land/" # comment

--- a/std/encoding/toml.ts
+++ b/std/encoding/toml.ts
@@ -288,7 +288,7 @@ class Parser {
     if (invalidArr) {
       dataString = dataString.replace(/,]/g, "]");
     }
-    dataString = this._stripComment(dataString);
+
     if (dataString[0] === "{" && dataString[dataString.length - 1] === "}") {
       const reg = /([a-zA-Z0-9-_\.]*) (=)/gi;
       let result;
@@ -314,34 +314,6 @@ class Parser {
       dataString = dataString.replace(`\\n'`, `'`);
     }
     return eval(dataString);
-  }
-  private _stripComment(dataString: string): string {
-    const isString = dataString.startsWith('"') || dataString.startsWith("'");
-    if (isString) {
-      const [quote] = dataString;
-      let indexOfNextQuote = 0;
-      while (
-        (indexOfNextQuote = dataString.indexOf(quote, indexOfNextQuote + 1)) !==
-          -1
-      ) {
-        const isEscaped = dataString[indexOfNextQuote - 1] === "\\";
-        if (!isEscaped) {
-          break;
-        }
-      }
-      if (indexOfNextQuote === -1) {
-        throw new TOMLError("imcomplete string literal");
-      }
-      const endOfString = indexOfNextQuote + 1;
-      return dataString.slice(0, endOfString);
-    }
-
-    const m = /(?:|\[|{).*(?:|\]|})\s*^((?!#).)*/g.exec(dataString);
-    if (m) {
-      return m[0].trim();
-    } else {
-      return dataString;
-    }
   }
   _isLocalTime(str: string): boolean {
     const reg = /(\d{2}):(\d{2}):(\d{2})/;

--- a/std/encoding/toml.ts
+++ b/std/encoding/toml.ts
@@ -73,8 +73,8 @@ class Parser {
     for (let i = 0; i < this.tomlLines.length; i++) {
       const line = this.tomlLines[i];
 
-      // stringStart and stringEnd are seperate conditions to 
-      // support multi-line strings 
+      // stringStart and stringEnd are separate conditions to 
+      // support both single-line and multi-line strings 
       if (!isOpenString && stringStart(line)) {
         isOpenString = true;
       }

--- a/std/encoding/toml.ts
+++ b/std/encoding/toml.ts
@@ -32,7 +32,7 @@ class Parser {
     for (let i = 0; i < this.tomlLines.length; i++) {
       const s = this.tomlLines[i];
       const trimmed = s.trim();
-      if (trimmed !== "" && trimmed[0] !== "#") {
+      if (trimmed !== "") {
         out.push(s);
       }
     }

--- a/std/encoding/toml.ts
+++ b/std/encoding/toml.ts
@@ -37,7 +37,7 @@ class Parser {
       }
     }
     this.tomlLines = out;
-    this._removeComments()
+    this._removeComments();
     this._mergeMultilines();
   }
 
@@ -48,33 +48,35 @@ class Parser {
 
     function stringStart(line: string) {
       const m = line.match(/(?:=\s*\[?\s*)("""|'''|"|')/);
-      if (!m) 
+      if (!m) {
         return false;
+      }
 
       // We want to know which syntax was used to open the string
-      openStringMatch = m[1]
+      openStringMatch = m[1];
       return true;
     }
 
     function stringEnd(line: string) {
-      // match the syntax used to open the string when searching for string close 
+      // match the syntax used to open the string when searching for string close
       // e.g. if we open with ''' we must close with a '''
       const reg = RegExp(`(?<!(=\\s*))${openStringMatch}(?!(.*"))`);
-      if (!line.match(reg)) 
+      if (!line.match(reg)) {
         return false;
-      
+      }
+
       openStringMatch = "";
       return true;
     }
 
     const cleaned = [];
     let isOpenString = false;
-    let openStringMatch = ""
+    let openStringMatch = "";
     for (let i = 0; i < this.tomlLines.length; i++) {
       const line = this.tomlLines[i];
 
-      // stringStart and stringEnd are separate conditions to 
-      // support both single-line and multi-line strings 
+      // stringStart and stringEnd are separate conditions to
+      // support both single-line and multi-line strings
       if (!isOpenString && stringStart(line)) {
         isOpenString = true;
       }
@@ -83,7 +85,9 @@ class Parser {
       }
 
       if (!isOpenString && !isFullLineComment(line)) {
-        let out = line.split(/(?<=([\,\[\]\{\}]|".*"|'.*'|\w(?!.*("|')+))\s*)#/gi);
+        let out = line.split(
+          /(?<=([\,\[\]\{\}]|".*"|'.*'|\w(?!.*("|')+))\s*)#/gi,
+        );
         cleaned.push(out[0].trim());
       } else if (isOpenString || !isFullLineComment(line)) {
         cleaned.push(line);

--- a/std/encoding/toml_test.ts
+++ b/std/encoding/toml_test.ts
@@ -413,3 +413,26 @@ the     = "array"
     assertEquals(actual, expected);
   },
 });
+
+Deno.test({
+  name: "[TOML] Comments",
+  fn: () => {
+    const expected = {
+      str0: "value",
+      str1: "# This is not a comment",
+      str2: " # this is not a comment!\nA multiline string with a #\n# this is also not a comment",
+      str3: '"# not a comment"\n\t# this is a real tab on purpose \n# not a comment',
+      deno: {
+        features: ["#secure by default", "supports typescript # not a comment"],
+        url: "https://deno.land/",
+        is_not_node: true
+      },
+      toml: {
+        name: "Tom's Obvious, Minimal Language",
+        objectives: ["easy to read", "minimal config file", "#not a comment"]
+      }
+    }
+    const actual = parseFile(path.join(testFilesDir, "comment.toml"));
+    assertEquals(actual, expected);
+  }
+})

--- a/std/encoding/toml_test.ts
+++ b/std/encoding/toml_test.ts
@@ -420,21 +420,23 @@ Deno.test({
     const expected = {
       str0: "value",
       str1: "# This is not a comment",
-      str2: " # this is not a comment!\nA multiline string with a #\n# this is also not a comment",
-      str3: '"# not a comment"\n\t# this is a real tab on purpose \n# not a comment',
+      str2:
+        " # this is not a comment!\nA multiline string with a #\n# this is also not a comment",
+      str3:
+        '"# not a comment"\n\t# this is a real tab on purpose \n# not a comment',
       point0: { x: 1, y: 2, str0: "#not a comment", z: 3 },
-      point1: { x: 7, y: 8, z: 9, str0: "#not a comment"},
+      point1: { x: 7, y: 8, z: 9, str0: "#not a comment" },
       deno: {
         features: ["#secure by default", "supports typescript # not a comment"],
         url: "https://deno.land/",
-        is_not_node: true
+        is_not_node: true,
       },
       toml: {
         name: "Tom's Obvious, Minimal Language",
-        objectives: ["easy to read", "minimal config file", "#not a comment"]
-      }
-    }
+        objectives: ["easy to read", "minimal config file", "#not a comment"],
+      },
+    };
     const actual = parseFile(path.join(testFilesDir, "comment.toml"));
     assertEquals(actual, expected);
-  }
-})
+  },
+});

--- a/std/encoding/toml_test.ts
+++ b/std/encoding/toml_test.ts
@@ -422,6 +422,8 @@ Deno.test({
       str1: "# This is not a comment",
       str2: " # this is not a comment!\nA multiline string with a #\n# this is also not a comment",
       str3: '"# not a comment"\n\t# this is a real tab on purpose \n# not a comment',
+      point0: { x: 1, y: 2, str0: "#not a comment", z: 3 },
+      point1: { x: 7, y: 8, z: 9, str0: "#not a comment"},
       deno: {
         features: ["#secure by default", "supports typescript # not a comment"],
         url: "https://deno.land/",


### PR DESCRIPTION
Fixes #7072  and consolidates comment stripping into _sanitize() before parsing toml config.
This PR also fixes another issue with multi-line strings: If a new line started with ```#``` then the parser would think it was a comment and remove it. 
