### PR TITLE
Remove Deno.SymlinkOptions

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -234,7 +234,7 @@ function syscall(target: Function): Function {
     try {
       return target(...args);
     } catch (err) {
-      console.log(err);
+      console.debug(err.message, err.stack);
       switch (err.name) {
         case "NotFound":
           return ERRNO_NOENT;

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -991,13 +991,16 @@ export default class Context {
         if (!entry.path) {
           return ERRNO_INVAL;
         }
+        console.log("PATH_FILESTAT_GET", entry.path);
 
         const text = new TextDecoder();
         const data = new Uint8Array(this.memory.buffer, path_ptr, path_len);
         const path = resolve(entry.path, text.decode(data));
 
+
         const view = new DataView(this.memory.buffer);
 
+        console.log("DENO LSTAT PATH", path);
         const info = (flags & LOOKUPFLAGS_SYMLINK_FOLLOW) != 0
           ? Deno.statSync(path)
           : Deno.lstatSync(path);

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -808,6 +808,7 @@ export default class Context {
 
         let bufused = 0;
 
+        console.log("FD_READDIR PATH: %s", entry.path);
         const entries = Array.from(Deno.readDirSync(entry.path));
         for (let i = Number(cookie); i < entries.length; i++) {
           const name_data = new TextEncoder().encode(entries[i].name);

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -234,6 +234,7 @@ function syscall(target: Function): Function {
     try {
       return target(...args);
     } catch (err) {
+      console.log(err);
       switch (err.name) {
         case "NotFound":
           return ERRNO_NOENT;

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -8,15 +8,6 @@ const ignore = [
   "wasi_clock_time_get_realtime.wasm",
 ];
 
-// TODO(caspervonb) investigate why these tests are failing on windows and fix
-// them.
-if (Deno.build.os == "windows") {
-  ignore.push("std_fs_metadata_absolute.wasm");
-  ignore.push("std_fs_metadata_relative.wasm");
-  ignore.push("std_fs_read_dir_absolute.wasm");
-  ignore.push("std_fs_read_dir_relative.wasm");
-}
-
 const rootdir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdir = path.join(rootdir, "testdata");
 


### PR DESCRIPTION
Currently we expose Deno.SymlinkOptions which just a leak of an internal implementation for Windows.
I propose we remove it while the ops using it are still unstable.