### PR TITLE
BREAKING(unstable): remove Deno.SymlinkOptions

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -58,16 +58,9 @@ declare namespace Deno {
     rows: number;
   };
 
-  export type SymlinkOptions = {
-    type: "file" | "dir";
-  };
-
   /** **UNSTABLE**: This API needs a security review.
    *
    * Creates `newpath` as a symbolic link to `oldpath`.
-   *
-   * The options.type parameter can be set to `file` or `dir`. This argument is only
-   * available on Windows and ignored on other platforms.
    *
    * ```ts
    * Deno.symlinkSync("old/name", "new/name");
@@ -77,15 +70,11 @@ declare namespace Deno {
   export function symlinkSync(
     oldpath: string,
     newpath: string,
-    options?: SymlinkOptions,
   ): void;
 
   /** **UNSTABLE**: This API needs a security review.
    *
    * Creates `newpath` as a symbolic link to `oldpath`.
-   *
-   * The options.type parameter can be set to `file` or `dir`. This argument is only
-   * available on Windows and ignored on other platforms.
    *
    * ```ts
    * await Deno.symlink("old/name", "new/name");
@@ -95,7 +84,6 @@ declare namespace Deno {
   export function symlink(
     oldpath: string,
     newpath: string,
-    options?: SymlinkOptions,
   ): Promise<void>;
 
   /** **Unstable**  There are questions around which permission this needs. And

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -1271,7 +1271,6 @@ fn op_symlink_sync(
   #[cfg(not(unix))]
   {
     use std::os::windows::fs::{symlink_dir, symlink_file};
-    use std::os::windows::fs::{symlink_dir, symlink_file};
     let metadata = std::fs::metadata(&oldpath)?;
     if metadata.is_file() {
       symlink_file(&oldpath, &newpath)?;

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -1271,7 +1271,6 @@ fn op_symlink_sync(
   #[cfg(not(unix))]
   {
     use std::os::windows::fs::{symlink_dir, symlink_file};
-    let metadata = std::fs::metadata(&oldpath);
     if let Ok(metadata) = std::fs::metadata(&oldpath) {
       if metadata.is_file() {
         symlink_file(&oldpath, &newpath)?;
@@ -1314,7 +1313,6 @@ async fn op_symlink_async(
     #[cfg(not(unix))]
     {
       use std::os::windows::fs::{symlink_dir, symlink_file};
-      let metadata = std::fs::metadata(&oldpath);
       if let Ok(metadata) = std::fs::metadata(&oldpath) {
         if metadata.is_file() {
           symlink_file(&oldpath, &newpath)?;

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -1271,12 +1271,17 @@ fn op_symlink_sync(
   #[cfg(not(unix))]
   {
     use std::os::windows::fs::{symlink_dir, symlink_file};
-    let metadata = std::fs::metadata(&oldpath)?;
-    if metadata.is_file() {
+    let metadata = std::fs::metadata(&oldpath);
+    if let Ok(metadata) = std::fs::metadata(&oldpath) {
+      if metadata.is_file() {
+        symlink_file(&oldpath, &newpath)?;
+      } else if metadata.is_dir() {
+        symlink_dir(&oldpath, &newpath)?;
+      }
+    } else {
       symlink_file(&oldpath, &newpath)?;
-    } else if metadata.is_dir() {
-      symlink_dir(&oldpath, &newpath)?;
     }
+
     Ok(json!({}))
   }
 }
@@ -1309,11 +1314,15 @@ async fn op_symlink_async(
     #[cfg(not(unix))]
     {
       use std::os::windows::fs::{symlink_dir, symlink_file};
-      let metadata = std::fs::metadata(&oldpath)?;
-      if metadata.is_file() {
+      let metadata = std::fs::metadata(&oldpath);
+      if let Ok(metadata) = std::fs::metadata(&oldpath) {
+        if metadata.is_file() {
+          symlink_file(&oldpath, &newpath)?;
+        } else if metadata.is_dir() {
+          symlink_dir(&oldpath, &newpath)?;
+        }
+      } else {
         symlink_file(&oldpath, &newpath)?;
-      } else if metadata.is_dir() {
-        symlink_dir(&oldpath, &newpath)?;
       }
 
       Ok(json!({}))

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -1296,7 +1296,11 @@ async fn op_symlink_async(
   state.check_write(&newpath)?;
 
   tokio::task::spawn_blocking(move || {
-    debug!("op_symlink_async {} {}", oldpath.display(), newpath.display());
+    debug!(
+      "op_symlink_async {} {}",
+      oldpath.display(),
+      newpath.display()
+    );
     #[cfg(unix)]
     {
       use std::os::unix::fs::symlink;

--- a/cli/rt/30_fs.js
+++ b/cli/rt/30_fs.js
@@ -296,17 +296,15 @@
   function symlinkSync(
     oldpath,
     newpath,
-    options,
   ) {
-    sendSync("op_symlink", { oldpath, newpath, options });
+    sendSync("op_symlink", { oldpath, newpath });
   }
 
   async function symlink(
     oldpath,
     newpath,
-    options,
   ) {
-    await sendAsync("op_symlink", { oldpath, newpath, options });
+    await sendAsync("op_symlink", { oldpath, newpath });
   }
 
   function fdatasyncSync(rid) {

--- a/cli/tests/unit/remove_test.ts
+++ b/cli/tests/unit/remove_test.ts
@@ -103,13 +103,7 @@ unitTest(
   async function removeDanglingSymlinkSuccess(): Promise<void> {
     for (const method of REMOVE_METHODS) {
       const danglingSymlinkPath = Deno.makeTempDirSync() + "/dangling_symlink";
-      if (Deno.build.os === "windows") {
-        Deno.symlinkSync("unexistent_file", danglingSymlinkPath, {
-          type: "file",
-        });
-      } else {
-        Deno.symlinkSync("unexistent_file", danglingSymlinkPath);
-      }
+      Deno.symlinkSync("unexistent_file", danglingSymlinkPath);
       const pathInfo = Deno.lstatSync(danglingSymlinkPath);
       assert(pathInfo.isSymlink);
       await Deno[method](danglingSymlinkPath);
@@ -130,11 +124,7 @@ unitTest(
       const filePath = tempDir + "/test.txt";
       const validSymlinkPath = tempDir + "/valid_symlink";
       Deno.writeFileSync(filePath, data, { mode: 0o666 });
-      if (Deno.build.os === "windows") {
-        Deno.symlinkSync(filePath, validSymlinkPath, { type: "file" });
-      } else {
-        Deno.symlinkSync(filePath, validSymlinkPath);
-      }
+      Deno.symlinkSync(filePath, validSymlinkPath);
       const symlinkPathInfo = Deno.statSync(validSymlinkPath);
       assert(symlinkPathInfo.isFile);
       await Deno[method](validSymlinkPath);

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -72,7 +72,6 @@ delete Object.prototype.__proto__;
     "Signal",
     "SignalStream",
     "StartTlsOptions",
-    "SymlinkOptions",
     "TranspileOnlyResult",
     "UnixConnectOptions",
     "UnixListenOptions",

--- a/std/fs/copy.ts
+++ b/std/fs/copy.ts
@@ -1,10 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import * as path from "../path/mod.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
-import { isSubdir, getFileInfoType } from "./_util.ts";
+import { isSubdir } from "./_util.ts";
 import { assert } from "../_util/assert.ts";
-
-const isWindows = Deno.build.os === "windows";
 
 export interface CopyOptions {
   /**
@@ -112,14 +110,8 @@ async function copySymLink(
 ): Promise<void> {
   await ensureValidCopy(src, dest, options);
   const originSrcFilePath = await Deno.readLink(src);
-  const type = getFileInfoType(await Deno.lstat(src));
-  if (isWindows) {
-    await Deno.symlink(originSrcFilePath, dest, {
-      type: type === "dir" ? "dir" : "file",
-    });
-  } else {
-    await Deno.symlink(originSrcFilePath, dest);
-  }
+  await Deno.symlink(originSrcFilePath, dest);
+
   if (options.preserveTimestamps) {
     const statInfo = await Deno.lstat(src);
     assert(statInfo.atime instanceof Date, `statInfo.atime is unavailable`);
@@ -136,14 +128,7 @@ function copySymlinkSync(
 ): void {
   ensureValidCopySync(src, dest, options);
   const originSrcFilePath = Deno.readLinkSync(src);
-  const type = getFileInfoType(Deno.lstatSync(src));
-  if (isWindows) {
-    Deno.symlinkSync(originSrcFilePath, dest, {
-      type: type === "dir" ? "dir" : "file",
-    });
-  } else {
-    Deno.symlinkSync(originSrcFilePath, dest);
-  }
+  Deno.symlinkSync(originSrcFilePath, dest);
 
   if (options.preserveTimestamps) {
     const statInfo = Deno.lstatSync(src);

--- a/std/fs/ensure_symlink.ts
+++ b/std/fs/ensure_symlink.ts
@@ -12,8 +12,7 @@ import { getFileInfoType } from "./_util.ts";
  * @param dest the destination link path
  */
 export async function ensureSymlink(src: string, dest: string): Promise<void> {
-  const srcStatInfo = await Deno.lstat(src);
-  const srcFilePathType = getFileInfoType(srcStatInfo);
+  await Deno.lstat(src);
 
   if (await exists(dest)) {
     const destStatInfo = await Deno.lstat(dest);
@@ -27,14 +26,7 @@ export async function ensureSymlink(src: string, dest: string): Promise<void> {
   }
 
   await ensureDir(path.dirname(dest));
-
-  if (Deno.build.os === "windows") {
-    await Deno.symlink(src, dest, {
-      type: srcFilePathType === "dir" ? "dir" : "file",
-    });
-  } else {
-    await Deno.symlink(src, dest);
-  }
+  await Deno.symlink(src, dest);
 }
 
 /**
@@ -45,8 +37,7 @@ export async function ensureSymlink(src: string, dest: string): Promise<void> {
  * @param dest the destination link path
  */
 export function ensureSymlinkSync(src: string, dest: string): void {
-  const srcStatInfo = Deno.lstatSync(src);
-  const srcFilePathType = getFileInfoType(srcStatInfo);
+  Deno.lstatSync(src);
 
   if (existsSync(dest)) {
     const destStatInfo = Deno.lstatSync(dest);
@@ -60,11 +51,5 @@ export function ensureSymlinkSync(src: string, dest: string): void {
   }
 
   ensureDirSync(path.dirname(dest));
-  if (Deno.build.os === "windows") {
-    Deno.symlinkSync(src, dest, {
-      type: srcFilePathType === "dir" ? "dir" : "file",
-    });
-  } else {
-    Deno.symlinkSync(src, dest);
-  }
+  Deno.symlinkSync(src, dest);
 }

--- a/std/node/_fs/_fs_readlink_test.ts
+++ b/std/node/_fs/_fs_readlink_test.ts
@@ -6,11 +6,7 @@ const testDir = Deno.makeTempDirSync();
 const oldname = path.join(testDir, "oldname");
 const newname = path.join(testDir, "newname");
 
-if (Deno.build.os === "windows") {
-  Deno.symlinkSync(oldname, newname, { type: "file" });
-} else {
-  Deno.symlinkSync(oldname, newname);
-}
+Deno.symlinkSync(oldname, newname);
 
 Deno.test({
   name: "readlinkSuccess",


### PR DESCRIPTION
This removes Deno.SymlinkOptions which is leaking internal implementation details on Windows which encourages checking and special casing when running on Windows.

Closes #7234