### PR TITLE
test(std/wasi): explicitly list modules for deterministic test runs

### DIFF
--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -4,8 +4,67 @@ import { assert, assertEquals } from "../testing/asserts.ts";
 import { copy } from "../fs/mod.ts";
 import * as path from "../path/mod.ts";
 
+const tests = [
+  "testdata/std_env_args_none.wasm",
+  "testdata/std_env_args_some.wasm",
+  "testdata/std_env_vars_none.wasm",
+  "testdata/std_env_vars_some.wasm",
+  "testdata/std_fs_create_dir_absolute.wasm",
+  "testdata/std_fs_create_dir_relative.wasm",
+  "testdata/std_fs_file_create_absolute.wasm",
+  "testdata/std_fs_file_create_relative.wasm",
+  "testdata/std_fs_file_metadata_absolute.wasm",
+  "testdata/std_fs_file_metadata_relative.wasm",
+  "testdata/std_fs_file_seek_absolute.wasm",
+  "testdata/std_fs_file_seek_relative.wasm",
+  "testdata/std_fs_file_set_len_absolute.wasm",
+  "testdata/std_fs_file_set_len_relative.wasm",
+  "testdata/std_fs_file_sync_all_absolute.wasm",
+  "testdata/std_fs_file_sync_all_relative.wasm",
+  "testdata/std_fs_file_sync_data_absolute.wasm",
+  "testdata/std_fs_file_sync_data_relative.wasm",
+  "testdata/std_fs_hard_link_absolute.wasm",
+  "testdata/std_fs_hard_link_relative.wasm",
+  "testdata/std_fs_metadata_absolute.wasm",
+  "testdata/std_fs_metadata_relative.wasm",
+  "testdata/std_fs_read_absolute.wasm",
+  "testdata/std_fs_read_dir_absolute.wasm",
+  "testdata/std_fs_read_dir_relative.wasm",
+  "testdata/std_fs_read_relative.wasm",
+  "testdata/std_fs_remove_dir_all_absolute.wasm",
+  "testdata/std_fs_remove_dir_all_relative.wasm",
+  "testdata/std_fs_rename_absolute.wasm",
+  "testdata/std_fs_rename_relative.wasm",
+  "testdata/std_fs_symlink_metadata_absolute.wasm",
+  "testdata/std_fs_symlink_metadata_relative.wasm",
+  "testdata/std_fs_write_absolute.wasm",
+  "testdata/std_fs_write_relative.wasm",
+  "testdata/std_io_stderr.wasm",
+  "testdata/std_io_stdin.wasm",
+  "testdata/std_io_stdout.wasm",
+  "testdata/std_process_exit.wasm",
+  "testdata/wasi_clock_res_get_monotonic.wasm",
+  "testdata/wasi_clock_res_get_process.wasm",
+  "testdata/wasi_clock_res_get_realtime.wasm",
+  "testdata/wasi_clock_res_get_thread.wasm",
+  "testdata/wasi_clock_time_get_monotonic.wasm",
+  "testdata/wasi_clock_time_get_process.wasm",
+  "testdata/wasi_clock_time_get_realtime.wasm",
+  "testdata/wasi_clock_time_get_thread.wasm",
+  "testdata/wasi_fd_fdstat_get_stderr.wasm",
+  "testdata/wasi_fd_fdstat_get_stdin.wasm",
+  "testdata/wasi_fd_fdstat_get_stdout.wasm",
+  "testdata/wasi_fd_tell_file.wasm",
+  "testdata/wasi_fd_write_file.wasm",
+  "testdata/wasi_fd_write_stderr.wasm",
+  "testdata/wasi_fd_write_stdout.wasm",
+  "testdata/wasi_proc_exit_one.wasm",
+  "testdata/wasi_proc_exit_zero.wasm",
+  "testdata/wasi_random_get.wasm",
+];
+
 const ignore = [
-  "wasi_clock_time_get_realtime.wasm",
+  "testdata/wasi_clock_time_get_realtime.wasm",
 ];
 
 // TODO(caspervonb) investigate why these tests are failing on windows and fix
@@ -20,18 +79,13 @@ if (Deno.build.os == "windows") {
 const rootdir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdir = path.join(rootdir, "testdata");
 
-for await (const entry of Deno.readDir(testdir)) {
-  if (!entry.name.endsWith(".wasm")) {
-    continue;
-  }
-
+for (const pathname of tests) {
   Deno.test({
-    name: entry.name,
-    ignore: ignore.includes(entry.name),
+    name: path.basename(pathname),
+    ignore: ignore.includes(pathname),
     fn: async function () {
-      const basename = entry.name.replace(/\.wasm$/, ".json");
       const prelude = await Deno.readTextFile(
-        path.resolve(testdir, basename),
+        path.resolve(rootdir, pathname.replace(/\.wasm$/, ".json")),
       );
       const options = JSON.parse(prelude);
 
@@ -52,7 +106,7 @@ for await (const entry of Deno.readDir(testdir)) {
             "--allow-all",
             path.resolve(rootdir, "snapshot_preview1_test_runner.ts"),
             prelude,
-            path.resolve(testdir, entry.name),
+            path.resolve(rootdir, pathname),
           ],
           stdin: "piped",
           stdout: "piped",

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -70,10 +70,10 @@ const ignore = [
 // TODO(caspervonb) investigate why these tests are failing on windows and fix
 // them.
 if (Deno.build.os == "windows") {
-  ignore.push("std_fs_metadata_absolute.wasm");
-  ignore.push("std_fs_metadata_relative.wasm");
-  ignore.push("std_fs_read_dir_absolute.wasm");
-  ignore.push("std_fs_read_dir_relative.wasm");
+  ignore.push("testdata/std_fs_metadata_absolute.wasm");
+  ignore.push("testdata/std_fs_metadata_relative.wasm");
+  ignore.push("testdata/std_fs_read_dir_absolute.wasm");
+  ignore.push("testdata/std_fs_read_dir_relative.wasm");
 }
 
 const rootdir = path.dirname(path.fromFileUrl(import.meta.url));


### PR DESCRIPTION
This explicitly lists std/wasi test modules in a pre-sorted array for deterministic test runs.

As a side effect it makes it a bit more visible when a test has been added or removed aside from having to look at the submodule update.