### PR TITLE
Typo in zsh env setup steps

### DIFF
--- a/docs/getting_started/setup_your_environment.md
+++ b/docs/getting_started/setup_your_environment.md
@@ -40,7 +40,7 @@ Example (zsh without framework):
 
 ```shell
 mkdir ~/.zsh # create a folder to save your completions. it can be anywhere
-deno completions zsh > .zsh/_deno
+deno completions zsh > ~/.zsh/_deno
 ```
 
 then add this to your `.zshrc`


### PR DESCRIPTION
Super trivial typo that I noticed, and fixed, when setting up my zsh environement