### PR TITLE
docs(std/fs): remove stale references to readFileStr and writeFileStr

### DIFF
--- a/std/fs/README.md
+++ b/std/fs/README.md
@@ -174,37 +174,6 @@ async function printFilesNames() {
 printFilesNames().then(() => console.log("Done!"));
 ```
 
-### readFileStr
-
-Read file and output it as a string. Note: this module does not require the
-`--unstable` flag.
-
-**ReadOptions**
-
-- encoding : The encoding to read file. lowercased.
-
-```ts
-import { readFileStr, readFileStrSync } from "https://deno.land/std/fs/mod.ts";
-
-readFileStr("./target.dat", { encoding: "utf8" }); // returns a promise
-readFileStrSync("./target.dat", { encoding: "utf8" }); // string
-```
-
-### writeFileStr
-
-Write the string to file. Note: this module does not require the `--unstable`
-flag.
-
-```ts
-import {
-  writeFileStr,
-  writeFileStrSync,
-} from "https://deno.land/std/fs/mod.ts";
-
-writeFileStr("./target.dat", "file content"); // returns a promise
-writeFileStrSync("./target.dat", "file content"); // void
-```
-
 ### expandGlob
 
 Expand the glob string from the specified `root` directory and yield each result


### PR DESCRIPTION
This removes documentation to functions that were removed in #6848 and #6847.

This seems to have been introduced in #6748.