### PR TITLE
feat(cli/lint): Add support for reading input from stdin

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1015,6 +1015,10 @@ fn lint_subcommand<'a, 'b>() -> App<'a, 'b> {
 Print result as JSON:
   deno lint --unstable --json
 
+Read from stdin and print result to stdout:
+  cat file.ts | deno lint --unstable -
+  cat file.ts | deno lint --unstable --json -
+
 List available rules:
   deno lint --unstable --rules
 

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1015,7 +1015,7 @@ fn lint_subcommand<'a, 'b>() -> App<'a, 'b> {
 Print result as JSON:
   deno lint --unstable --json
 
-Read from stdin and print result to stdout:
+Read from stdin:
   cat file.ts | deno lint --unstable -
   cat file.ts | deno lint --unstable --json -
 

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -154,7 +154,6 @@ fn lint_stdin(json: bool) -> Result<(), ErrBox> {
   };
   let mut reporter = create_reporter(reporter_kind);
   let lint_rules = rules::get_recommended_rules();
-  // TODO(magurotuna): it'd be better to be able to deal with JavaScript
   let syntax = swc_util::get_syntax_for_media_type(msg::MediaType::TypeScript);
   let mut linter = create_linter(syntax, lint_rules);
   let mut has_error = false;

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -11,6 +11,7 @@ use crate::file_fetcher::map_file_extension;
 use crate::fmt::collect_files;
 use crate::fmt::run_parallelized;
 use crate::fmt_errors;
+use crate::msg;
 use crate::swc_util;
 use deno_core::ErrBox;
 use deno_lint::diagnostic::LintDiagnostic;
@@ -20,6 +21,7 @@ use deno_lint::rules;
 use deno_lint::rules::LintRule;
 use serde::Serialize;
 use std::fs;
+use std::io::{stdin, Read};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -37,11 +39,60 @@ fn create_reporter(kind: LintReporterKind) -> Box<dyn LintReporter + Send> {
   }
 }
 
+/// Lint stdin and write result to stdout.
+/// Treats input as TypeScript.
+/// Compatible with `--json` flag.
+fn lint_stdin(json: bool) -> Result<(), ErrBox> {
+  let mut source = String::new();
+  if stdin().read_to_string(&mut source).is_err() {
+    return Err(ErrBox::error("Failed to read from stdin"));
+  }
+
+  let reporter_kind = if json {
+    LintReporterKind::Json
+  } else {
+    LintReporterKind::Pretty
+  };
+  let mut reporter = create_reporter(reporter_kind);
+  let lint_rules = rules::get_recommended_rules();
+  // TODO(magurotuna): it'd be better to be able to deal with JavaScript
+  let syntax = swc_util::get_syntax_for_media_type(msg::MediaType::TypeScript);
+  let mut linter = create_linter(syntax, lint_rules);
+  let mut has_error = false;
+  let pseudo_file_name = "_stdin.ts";
+  match linter
+    .lint(pseudo_file_name.to_string(), source)
+    .map_err(|e| e.into())
+  {
+    Ok(diagnostics) => {
+      for d in diagnostics {
+        has_error = true;
+        reporter.visit(&d);
+      }
+    }
+    Err(err) => {
+      has_error = true;
+      reporter.visit_error(pseudo_file_name, &err);
+    }
+  }
+
+  reporter.close();
+
+  if has_error {
+    std::process::exit(1);
+  }
+
+  Ok(())
+}
+
 pub async fn lint_files(
   args: Vec<String>,
   ignore: Vec<String>,
   json: bool,
 ) -> Result<(), ErrBox> {
+  if args.len() == 1 && args[0] == "-" {
+    return lint_stdin(json);
+  }
   let mut target_files = collect_files(args)?;
   if !ignore.is_empty() {
     // collect all files to be ignored

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2253,6 +2253,20 @@ itest!(deno_lint_glob {
   exit_code: 1,
 });
 
+itest!(deno_lint_from_stdin {
+  args: "lint --unstable -",
+  input: Some("let a: any;"),
+  output: "lint/expected_from_stdin.out",
+  exit_code: 1,
+});
+
+itest!(deno_lint_from_stdin_json {
+  args: "lint --unstable --json -",
+  input: Some("let a: any;"),
+  output: "lint/expected_from_stdin_json.out",
+  exit_code: 1,
+});
+
 itest!(deno_doc_builtin {
   args: "doc",
   output: "deno_doc_builtin.out",

--- a/cli/tests/lint/expected_from_stdin.out
+++ b/cli/tests/lint/expected_from_stdin.out
@@ -1,0 +1,2 @@
+[WILDCARD]
+Found 1 problem

--- a/cli/tests/lint/expected_from_stdin_json.out
+++ b/cli/tests/lint/expected_from_stdin_json.out
@@ -1,0 +1,16 @@
+{
+  "diagnostics": [
+    {
+      "location": {
+        "line": 1,
+        "col": 7
+      },
+      "filename": "_stdin.ts",
+      "message": "`any` type is not allowed",
+      "code": "no-explicit-any",
+      "line_src": "let a: any;",
+      "snippet_length": 3
+    }
+  ],
+  "errors": []
+}

--- a/docs/tools/linter.md
+++ b/docs/tools/linter.md
@@ -10,7 +10,13 @@ flag**
 deno lint --unstable
 # lint specific files
 deno lint --unstable myfile1.ts myfile2.ts
+# print result as JSON
+deno lint --unstable --json
+# read from stdin
+cat file.ts | deno lint --unstable -
 ```
+
+For more detail, run `deno lint --help`.
 
 ### Available rules
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

Resolves #7218

Given the following file named `file.ts`
```typescript
let a: any;
```

then we can lint it in two ways:

1. `deno lint --unstable file.ts`
2. `cat file.ts | deno lint --unstable -` (new!)

I also added integration tests and updated the doc.

My concerns:

- As I commented to `lint_stdin`, all inputs from stdin are treated as TypeScript. Should some flag like `--ext` be added to handle other types? (something like `cat file.jsx | deno lint --unstable - --ext=jsx`)
- The linter requires `file_name` so I put it as `_stdin.ts` for now, referring to https://github.com/denoland/deno/blob/9bfb0df805719cb3f022a5b5d9f9d898ae954c2e/cli/fmt.rs#L179 I wonder if there is a preferrable file name.