### PR TITLE
fix(std/wasi) use Deno.futime for fd_filestat_set_times

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -636,10 +636,6 @@ export default class Context {
           return ERRNO_BADF;
         }
 
-        if (!entry.path) {
-          return ERRNO_INVAL;
-        }
-
         if ((fst_flags & FSTFLAGS_ATIM_NOW) == FSTFLAGS_ATIM_NOW) {
           atim = BigInt(Date.now() * 1e6);
         }
@@ -648,7 +644,7 @@ export default class Context {
           mtim = BigInt(Date.now() * 1e6);
         }
 
-        Deno.utimeSync(entry.path, Number(atim), Number(mtim));
+        Deno.futimeSync(entry.rid, Number(atim), Number(mtim));
 
         return ERRNO_SUCCESS;
       }),


### PR DESCRIPTION
Currently fd_filestat_set_times uses Deno.utime internally, this replaces that call with Deno.futime so that it doesn't have to rely on a file descriptor storing a file path in addition to resource handle.