### PR TITLE
refactor: remove dead code in tsc

### DIFF
--- a/cli/msg.rs
+++ b/cli/msg.rs
@@ -55,11 +55,10 @@ pub fn enum_name_media_type(mt: MediaType) -> &'static str {
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum CompilerRequestType {
   Compile = 0,
-  Transpile = 1,
-  Bundle = 2,
-  RuntimeCompile = 3,
-  RuntimeBundle = 4,
-  RuntimeTranspile = 5,
+  Bundle = 1,
+  RuntimeCompile = 2,
+  RuntimeBundle = 3,
+  RuntimeTranspile = 4,
 }
 
 impl Serialize for CompilerRequestType {
@@ -69,11 +68,10 @@ impl Serialize for CompilerRequestType {
   {
     let value: i32 = match self {
       CompilerRequestType::Compile => 0 as i32,
-      CompilerRequestType::Transpile => 1 as i32,
-      CompilerRequestType::Bundle => 2 as i32,
-      CompilerRequestType::RuntimeCompile => 3 as i32,
-      CompilerRequestType::RuntimeBundle => 4 as i32,
-      CompilerRequestType::RuntimeTranspile => 5 as i32,
+      CompilerRequestType::Bundle => 1 as i32,
+      CompilerRequestType::RuntimeCompile => 2 as i32,
+      CompilerRequestType::RuntimeBundle => 3 as i32,
+      CompilerRequestType::RuntimeTranspile => 4 as i32,
     };
     Serialize::serialize(&value, serializer)
   }


### PR DESCRIPTION
Remove unused `transpile()` function from `cli/tsc/99_compiler_main.js`
and respective `CompilerRequestType` variant.

CC @kitsonk 