### PR TITLE
fix(cli): use millisecond precision for Deno.futime and Deno.utime

### DIFF
--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -1683,8 +1683,8 @@ async fn op_make_temp_file_async(
 #[serde(rename_all = "camelCase")]
 struct FutimeArgs {
   rid: i32,
-  atime: i64,
-  mtime: i64,
+  atime: (i64, u32),
+  mtime: (i64, u32),
 }
 
 fn op_futime_sync(
@@ -1696,8 +1696,8 @@ fn op_futime_sync(
   state.check_unstable("Deno.futimeSync");
   let args: FutimeArgs = serde_json::from_value(args)?;
   let rid = args.rid as u32;
-  let atime = filetime::FileTime::from_unix_time(args.atime, 0);
-  let mtime = filetime::FileTime::from_unix_time(args.mtime, 0);
+  let atime = filetime::FileTime::from_unix_time(args.atime.0, args.atime.1);
+  let mtime = filetime::FileTime::from_unix_time(args.mtime.0, args.mtime.1);
 
   std_file_resource(resource_table, rid, |r| match r {
     Ok(std_file) => {
@@ -1721,8 +1721,8 @@ async fn op_futime_async(
   state.check_unstable("Deno.futime");
   let args: FutimeArgs = serde_json::from_value(args)?;
   let rid = args.rid as u32;
-  let atime = filetime::FileTime::from_unix_time(args.atime, 0);
-  let mtime = filetime::FileTime::from_unix_time(args.mtime, 0);
+  let atime = filetime::FileTime::from_unix_time(args.atime.0, args.atime.1);
+  let mtime = filetime::FileTime::from_unix_time(args.mtime.0, args.mtime.1);
 
   let mut resource_table = resource_table.borrow_mut();
   std_file_resource(&mut resource_table, rid, |r| match r {
@@ -1742,8 +1742,8 @@ async fn op_futime_async(
 #[serde(rename_all = "camelCase")]
 struct UtimeArgs {
   path: String,
-  atime: i64,
-  mtime: i64,
+  atime: (i64, u32),
+  mtime: (i64, u32),
 }
 
 fn op_utime_sync(
@@ -1756,11 +1756,10 @@ fn op_utime_sync(
 
   let args: UtimeArgs = serde_json::from_value(args)?;
   let path = PathBuf::from(&args.path);
-  let atime = filetime::FileTime::from_unix_time(args.atime, 0);
-  let mtime = filetime::FileTime::from_unix_time(args.mtime, 0);
+  let atime = filetime::FileTime::from_unix_time(args.atime.0, args.atime.1);
+  let mtime = filetime::FileTime::from_unix_time(args.mtime.0, args.mtime.1);
 
   state.check_write(&path)?;
-  debug!("op_utime_sync {} {} {}", args.path, args.atime, args.mtime);
   filetime::set_file_times(path, atime, mtime)?;
   Ok(json!({}))
 }
@@ -1775,13 +1774,12 @@ async fn op_utime_async(
 
   let args: UtimeArgs = serde_json::from_value(args)?;
   let path = PathBuf::from(&args.path);
-  let atime = filetime::FileTime::from_unix_time(args.atime, 0);
-  let mtime = filetime::FileTime::from_unix_time(args.mtime, 0);
+  let atime = filetime::FileTime::from_unix_time(args.atime.0, args.atime.1);
+  let mtime = filetime::FileTime::from_unix_time(args.mtime.0, args.mtime.1);
 
   state.check_write(&path)?;
 
   tokio::task::spawn_blocking(move || {
-    debug!("op_utime_async {} {} {}", args.path, args.atime, args.mtime);
     filetime::set_file_times(path, atime, mtime)?;
     Ok(json!({}))
   })

--- a/cli/rt/30_fs.js
+++ b/cli/rt/30_fs.js
@@ -264,8 +264,25 @@
     await sendAsync("op_link_async", { oldpath, newpath });
   }
 
-  function toSecondsFromEpoch(v) {
-    return v instanceof Date ? Math.trunc(v.valueOf() / 1000) : v;
+  function toUnixTimeFromEpoch(value) {
+    if (value instanceof Date) {
+      const time = value.valueOf();
+      const seconds = Math.trunc(time / 1e3);
+      const nanoseconds = Math.trunc(time - (seconds * 1e3)) * 1e6;
+
+      return [
+        seconds,
+        nanoseconds,
+      ];
+    }
+
+    const seconds = value;
+    const nanoseconds = 0;
+
+    return [
+      seconds,
+      nanoseconds,
+    ];
   }
 
   function futimeSync(
@@ -275,9 +292,8 @@
   ) {
     sendSync("op_futime_sync", {
       rid,
-      // TODO(caspervonb) split atime, mtime into [seconds, nanoseconds] tuple
-      atime: toSecondsFromEpoch(atime),
-      mtime: toSecondsFromEpoch(mtime),
+      atime: toUnixTimeFromEpoch(atime),
+      mtime: toUnixTimeFromEpoch(mtime),
     });
   }
 
@@ -288,9 +304,8 @@
   ) {
     await sendAsync("op_futime_async", {
       rid,
-      // TODO(caspervonb) split atime, mtime into [seconds, nanoseconds] tuple
-      atime: toSecondsFromEpoch(atime),
-      mtime: toSecondsFromEpoch(mtime),
+      atime: toUnixTimeFromEpoch(atime),
+      mtime: toUnixTimeFromEpoch(mtime),
     });
   }
 
@@ -301,9 +316,8 @@
   ) {
     sendSync("op_utime_sync", {
       path,
-      // TODO(ry) split atime, mtime into [seconds, nanoseconds] tuple
-      atime: toSecondsFromEpoch(atime),
-      mtime: toSecondsFromEpoch(mtime),
+      atime: toUnixTimeFromEpoch(atime),
+      mtime: toUnixTimeFromEpoch(mtime),
     });
   }
 
@@ -314,9 +328,8 @@
   ) {
     await sendAsync("op_utime_async", {
       path,
-      // TODO(ry) split atime, mtime into [seconds, nanoseconds] tuple
-      atime: toSecondsFromEpoch(atime),
-      mtime: toSecondsFromEpoch(mtime),
+      atime: toUnixTimeFromEpoch(atime),
+      mtime: toUnixTimeFromEpoch(mtime),
     });
   }
 

--- a/cli/tests/unit/utime_test.ts
+++ b/cli/tests/unit/utime_test.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import {
   unitTest,
-  assert,
   assertEquals,
   assertThrows,
   assertThrowsAsync,

--- a/cli/tests/unit/utime_test.ts
+++ b/cli/tests/unit/utime_test.ts
@@ -2,16 +2,10 @@
 import {
   unitTest,
   assert,
+  assertEquals,
   assertThrows,
   assertThrowsAsync,
 } from "./test_util.ts";
-
-// Allow 10 second difference.
-// Note this might not be enough for FAT (but we are not testing on such fs).
-function assertFuzzyTimestampEquals(t1: Date | null, t2: Date): void {
-  assert(t1 instanceof Date);
-  assert(Math.abs(t1.valueOf() - t2.valueOf()) < 10_000);
-}
 
 unitTest(
   { perms: { read: true, write: true } },
@@ -29,8 +23,8 @@ unitTest(
     await Deno.fdatasync(file.rid);
 
     const fileInfo = Deno.statSync(filename);
-    assertFuzzyTimestampEquals(fileInfo.atime, new Date(atime * 1000));
-    assertFuzzyTimestampEquals(fileInfo.mtime, new Date(mtime * 1000));
+    assertEquals(fileInfo.atime, new Date(atime * 1000));
+    assertEquals(fileInfo.mtime, new Date(mtime * 1000));
     file.close();
   },
 );
@@ -51,8 +45,8 @@ unitTest(
     Deno.fdatasyncSync(file.rid);
 
     const fileInfo = Deno.statSync(filename);
-    assertFuzzyTimestampEquals(fileInfo.atime, new Date(atime * 1000));
-    assertFuzzyTimestampEquals(fileInfo.mtime, new Date(mtime * 1000));
+    assertEquals(fileInfo.atime, new Date(atime * 1000));
+    assertEquals(fileInfo.mtime, new Date(mtime * 1000));
     file.close();
   },
 );
@@ -71,8 +65,8 @@ unitTest(
     Deno.utimeSync(filename, atime, mtime);
 
     const fileInfo = Deno.statSync(filename);
-    assertFuzzyTimestampEquals(fileInfo.atime, new Date(atime * 1000));
-    assertFuzzyTimestampEquals(fileInfo.mtime, new Date(mtime * 1000));
+    assertEquals(fileInfo.atime, new Date(atime * 1000));
+    assertEquals(fileInfo.mtime, new Date(mtime * 1000));
   },
 );
 
@@ -86,8 +80,8 @@ unitTest(
     Deno.utimeSync(testDir, atime, mtime);
 
     const dirInfo = Deno.statSync(testDir);
-    assertFuzzyTimestampEquals(dirInfo.atime, new Date(atime * 1000));
-    assertFuzzyTimestampEquals(dirInfo.mtime, new Date(mtime * 1000));
+    assertEquals(dirInfo.atime, new Date(atime * 1000));
+    assertEquals(dirInfo.mtime, new Date(mtime * 1000));
   },
 );
 
@@ -101,8 +95,8 @@ unitTest(
     Deno.utimeSync(testDir, atime, mtime);
 
     const dirInfo = Deno.statSync(testDir);
-    assertFuzzyTimestampEquals(dirInfo.atime, atime);
-    assertFuzzyTimestampEquals(dirInfo.mtime, mtime);
+    assertEquals(dirInfo.atime, atime);
+    assertEquals(dirInfo.mtime, mtime);
   },
 );
 
@@ -119,8 +113,8 @@ unitTest(
     Deno.utimeSync(filename, atime, mtime);
 
     const fileInfo = Deno.statSync(filename);
-    assertFuzzyTimestampEquals(fileInfo.atime, atime);
-    assertFuzzyTimestampEquals(fileInfo.mtime, mtime);
+    assertEquals(fileInfo.atime, atime);
+    assertEquals(fileInfo.mtime, mtime);
   },
 );
 
@@ -136,8 +130,8 @@ unitTest(
     Deno.utimeSync(testDir, atime, mtime);
 
     const dirInfo = Deno.statSync(testDir);
-    assertFuzzyTimestampEquals(dirInfo.atime, new Date(atime * 1000));
-    assertFuzzyTimestampEquals(dirInfo.mtime, new Date(mtime * 1000));
+    assertEquals(dirInfo.atime, new Date(atime * 1000));
+    assertEquals(dirInfo.mtime, new Date(mtime * 1000));
   },
 );
 
@@ -179,8 +173,8 @@ unitTest(
     await Deno.utime(filename, atime, mtime);
 
     const fileInfo = Deno.statSync(filename);
-    assertFuzzyTimestampEquals(fileInfo.atime, new Date(atime * 1000));
-    assertFuzzyTimestampEquals(fileInfo.mtime, new Date(mtime * 1000));
+    assertEquals(fileInfo.atime, new Date(atime * 1000));
+    assertEquals(fileInfo.mtime, new Date(mtime * 1000));
   },
 );
 
@@ -194,8 +188,8 @@ unitTest(
     await Deno.utime(testDir, atime, mtime);
 
     const dirInfo = Deno.statSync(testDir);
-    assertFuzzyTimestampEquals(dirInfo.atime, new Date(atime * 1000));
-    assertFuzzyTimestampEquals(dirInfo.mtime, new Date(mtime * 1000));
+    assertEquals(dirInfo.atime, new Date(atime * 1000));
+    assertEquals(dirInfo.mtime, new Date(mtime * 1000));
   },
 );
 
@@ -209,8 +203,8 @@ unitTest(
     await Deno.utime(testDir, atime, mtime);
 
     const dirInfo = Deno.statSync(testDir);
-    assertFuzzyTimestampEquals(dirInfo.atime, atime);
-    assertFuzzyTimestampEquals(dirInfo.mtime, mtime);
+    assertEquals(dirInfo.atime, atime);
+    assertEquals(dirInfo.mtime, mtime);
   },
 );
 
@@ -228,8 +222,8 @@ unitTest(
     await Deno.utime(filename, atime, mtime);
 
     const fileInfo = Deno.statSync(filename);
-    assertFuzzyTimestampEquals(fileInfo.atime, atime);
-    assertFuzzyTimestampEquals(fileInfo.mtime, mtime);
+    assertEquals(fileInfo.atime, atime);
+    assertEquals(fileInfo.mtime, mtime);
   },
 );
 

--- a/std/fs/copy_test.ts
+++ b/std/fs/copy_test.ts
@@ -32,15 +32,6 @@ function testCopy(
   });
 }
 
-function testCopyIgnore(
-  name: string,
-  cb: (tempDir: string) => Promise<void>,
-): void {
-  testCopy(name, cb, true);
-}
-
-testCopyIgnore("This should not exist", function() {});
-
 function testCopySync(name: string, cb: (tempDir: string) => void): void {
   Deno.test({
     name,

--- a/std/fs/copy_test.ts
+++ b/std/fs/copy_test.ts
@@ -39,6 +39,8 @@ function testCopyIgnore(
   testCopy(name, cb, true);
 }
 
+testCopyIgnore("This should not exist", function() {});
+
 function testCopySync(name: string, cb: (tempDir: string) => void): void {
   Deno.test({
     name,

--- a/std/fs/copy_test.ts
+++ b/std/fs/copy_test.ts
@@ -144,8 +144,7 @@ testCopy(
   },
 );
 
-// TODO(#6644) This case is ignored because of the issue #5065.
-testCopyIgnore(
+testCopy(
   "[fs] copy with preserve timestamps",
   async (tempDir: string): Promise<void> => {
     const srcFile = path.join(testdataDir, "copy_file.txt");


### PR DESCRIPTION
This uses millisecond precision in Deno.futime and Deno.utime when sourcing a timestamp from a Date object.

Fixes #2411
Fixes #5065