### PR TITLE
chore: multi line deno_lint diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723604b9f2a203366c0f7e6cfc66e43f15439fa8cfd7e98582a0836c8af9ab56"
+checksum = "9818f45029f09d92a06a5dd372130c21cb054bc5f582f3f660089ac2c82e68b3"
 dependencies = [
  "lazy_static",
  "log 0.4.11",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,7 +30,7 @@ winapi = "0.3.9"
 [dependencies]
 deno_core = { path = "../core", version = "0.55.0" }
 deno_doc = { version = "0.1.3" }
-deno_lint = { version = "0.1.26", features = ["json"] }
+deno_lint = { version = "0.1.27", features = ["json"] }
 
 atty = "0.2.14"
 base64 = "0.12.3"

--- a/cli/tests/lint/expected_from_stdin_json.out
+++ b/cli/tests/lint/expected_from_stdin_json.out
@@ -13,7 +13,7 @@
       },
       "filename": "_stdin.ts",
       "message": "`any` type is not allowed",
-      "code": "no-explicit-any",
+      "code": "no-explicit-any"
     }
   ],
   "errors": []

--- a/cli/tests/lint/expected_from_stdin_json.out
+++ b/cli/tests/lint/expected_from_stdin_json.out
@@ -1,15 +1,19 @@
 {
   "diagnostics": [
     {
-      "location": {
-        "line": 1,
-        "col": 7
+      "range": {
+        "start": {
+          "line": 1,
+          "col": 7
+        },
+        "end": {
+          "line": 1,
+          "col": 10
+        }
       },
       "filename": "_stdin.ts",
       "message": "`any` type is not allowed",
       "code": "no-explicit-any",
-      "line_src": "let a: any;",
-      "snippet_length": 3
     }
   ],
   "errors": []

--- a/cli/tests/lint/expected_json.out
+++ b/cli/tests/lint/expected_json.out
@@ -11,9 +11,9 @@
           "col": 19
         }
       },
-      "filename": "[WILDCARD]",
+      "filename": "[WILDCARD]file1.js",
       "message": "Ignore directive requires lint rule code",
-      "code": "ban-untagged-ignore",
+      "code": "ban-untagged-ignore"
     },
     {
       "range": {
@@ -26,9 +26,9 @@
           "col": 16
         }
       },
-      "filename": "[WILDCARD]",
+      "filename": "[WILDCARD]file1.js",
       "message": "Empty block statement",
-      "code": "no-empty",
+      "code": "no-empty"
     },
     {
       "range": {
@@ -41,9 +41,9 @@
           "col": 14
         }
       },
-      "filename": "[WILDCARD]",
+      "filename": "[WILDCARD]file2.ts",
       "message": "Empty block statement",
-      "code": "no-empty",
+      "code": "no-empty"
     }
   ],
   "errors": [

--- a/cli/tests/lint/expected_json.out
+++ b/cli/tests/lint/expected_json.out
@@ -16,16 +16,16 @@
       "code": "ban-untagged-ignore",
     },
     {
-       "range": {
-         "start": {
-           "line": 2,
-           "col": 14
-         },
-         "end": {
-           "line": 2,
-           "col": 16
-         }
-       },
+      "range": {
+        "start": {
+          "line": 2,
+          "col": 14
+        },
+        "end": {
+          "line": 2,
+          "col": 16
+        }
+      },
       "filename": "[WILDCARD]",
       "message": "Empty block statement",
       "code": "no-empty",

--- a/cli/tests/lint/expected_json.out
+++ b/cli/tests/lint/expected_json.out
@@ -1,37 +1,49 @@
 {
   "diagnostics": [
     {
-      "location": {
-        "line": 1,
-        "col": 0
+      "range": {
+        "start": {
+          "line": 1,
+          "col": 0
+        },
+        "end": {
+          "line": 1,
+          "col": 19
+        }
       },
       "filename": "[WILDCARD]",
       "message": "Ignore directive requires lint rule code",
       "code": "ban-untagged-ignore",
-      "line_src": "// deno-lint-ignore",
-      "snippet_length": 19
     },
     {
-      "location": {
-        "line": 2,
-        "col": 14
+       "range": {
+         "start": {
+           "line": 2,
+           "col": 14
+         },
+         "end": {
+           "line": 2,
+           "col": 16
+         }
+       },
+      "filename": "[WILDCARD]",
+      "message": "Empty block statement",
+      "code": "no-empty",
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "col": 12
+        },
+        "end": {
+          "line": 3,
+          "col": 14
+        }
       },
       "filename": "[WILDCARD]",
       "message": "Empty block statement",
       "code": "no-empty",
-      "line_src": "while (false) {}",
-      "snippet_length": 2
-    },
-    {
-      "location": {
-        "line": 3,
-        "col": 12
-      },
-      "filename": "[WILDCARD]",
-      "message": "Empty block statement",
-      "code": "no-empty",
-      "line_src": "} catch (e) {}",
-      "snippet_length": 2
     }
   ],
   "errors": [


### PR DESCRIPTION
TODO
- [x] release new deno_lint and update it here

In the future we should combine this diagnostic formatter with the one in cli/fmt_error.rs.