### PR TITLE
BREAKING(unstable): use millisecond timestamps for Deno.futime and Deno.utime

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -767,7 +767,7 @@ declare namespace Deno {
    *
    * Synchronously changes the access (`atime`) and modification (`mtime`) times
    * of a file system object referenced by `path`. Given times are either in
-   * seconds (UNIX epoch time) or as `Date` objects.
+   * milliseconds (UNIX epoch time) or as `Date` objects.
    *
    * ```ts
    * Deno.utimeSync("myfile.txt", 1556495550, new Date());
@@ -783,7 +783,7 @@ declare namespace Deno {
   /** **UNSTABLE**: needs investigation into high precision time.
    *
    * Changes the access (`atime`) and modification (`mtime`) times of a file
-   * system object referenced by `path`. Given times are either in seconds
+   * system object referenced by `path`. Given times are either in milliseconds
    * (UNIX epoch time) or as `Date` objects.
    *
    * ```ts
@@ -1252,7 +1252,7 @@ declare namespace Deno {
    *
    * Synchronously changes the access (`atime`) and modification (`mtime`) times
    * of a file stream resource referenced by `rid`. Given times are either in
-   * seconds (UNIX epoch time) or as `Date` objects.
+   * milliseconds (UNIX epoch time) or as `Date` objects.
    *
    * ```ts
    * const file = Deno.openSync("file.txt", { create: true });
@@ -1268,7 +1268,7 @@ declare namespace Deno {
   /** **UNSTABLE**: needs investigation into high precision time.
    *
    * Changes the access (`atime`) and modification (`mtime`) times of a file
-   * stream resource referenced by `rid`. Given times are either in seconds
+   * stream resource referenced by `rid`. Given times are either in milliseconds
    * (UNIX epoch time) or as `Date` objects.
    *
    * ```ts

--- a/cli/rt/30_fs.js
+++ b/cli/rt/30_fs.js
@@ -264,20 +264,13 @@
     await sendAsync("op_link_async", { oldpath, newpath });
   }
 
-  function toUnixTimeFromEpoch(value) {
-    if (value instanceof Date) {
-      const time = value.valueOf();
-      const seconds = Math.trunc(time / 1e3);
-      const nanoseconds = Math.trunc(time - (seconds * 1e3)) * 1e6;
-
-      return [
-        seconds,
-        nanoseconds,
-      ];
+  function toUnixTimeFromEpoch(time) {
+    if (time instanceof Date) {
+      time = time.valueOf();
     }
 
-    const seconds = value;
-    const nanoseconds = 0;
+    const seconds = Math.trunc(time / 1e3);
+    const nanoseconds = Math.trunc(time - (seconds * 1e3)) * 1e6;
 
     return [
       seconds,

--- a/cli/tests/unit/utime_test.ts
+++ b/cli/tests/unit/utime_test.ts
@@ -22,8 +22,8 @@ unitTest(
     await Deno.fdatasync(file.rid);
 
     const fileInfo = Deno.statSync(filename);
-    assertEquals(fileInfo.atime, new Date(atime * 1000));
-    assertEquals(fileInfo.mtime, new Date(mtime * 1000));
+    assertEquals(fileInfo.atime, new Date(atime));
+    assertEquals(fileInfo.mtime, new Date(mtime));
     file.close();
   },
 );
@@ -44,8 +44,8 @@ unitTest(
     Deno.fdatasyncSync(file.rid);
 
     const fileInfo = Deno.statSync(filename);
-    assertEquals(fileInfo.atime, new Date(atime * 1000));
-    assertEquals(fileInfo.mtime, new Date(mtime * 1000));
+    assertEquals(fileInfo.atime, new Date(atime));
+    assertEquals(fileInfo.mtime, new Date(mtime));
     file.close();
   },
 );
@@ -64,8 +64,8 @@ unitTest(
     Deno.utimeSync(filename, atime, mtime);
 
     const fileInfo = Deno.statSync(filename);
-    assertEquals(fileInfo.atime, new Date(atime * 1000));
-    assertEquals(fileInfo.mtime, new Date(mtime * 1000));
+    assertEquals(fileInfo.atime, new Date(atime));
+    assertEquals(fileInfo.mtime, new Date(mtime));
   },
 );
 
@@ -79,8 +79,8 @@ unitTest(
     Deno.utimeSync(testDir, atime, mtime);
 
     const dirInfo = Deno.statSync(testDir);
-    assertEquals(dirInfo.atime, new Date(atime * 1000));
-    assertEquals(dirInfo.mtime, new Date(mtime * 1000));
+    assertEquals(dirInfo.atime, new Date(atime));
+    assertEquals(dirInfo.mtime, new Date(mtime));
   },
 );
 
@@ -129,8 +129,8 @@ unitTest(
     Deno.utimeSync(testDir, atime, mtime);
 
     const dirInfo = Deno.statSync(testDir);
-    assertEquals(dirInfo.atime, new Date(atime * 1000));
-    assertEquals(dirInfo.mtime, new Date(mtime * 1000));
+    assertEquals(dirInfo.atime, new Date(atime));
+    assertEquals(dirInfo.mtime, new Date(mtime));
   },
 );
 
@@ -172,8 +172,8 @@ unitTest(
     await Deno.utime(filename, atime, mtime);
 
     const fileInfo = Deno.statSync(filename);
-    assertEquals(fileInfo.atime, new Date(atime * 1000));
-    assertEquals(fileInfo.mtime, new Date(mtime * 1000));
+    assertEquals(fileInfo.atime, new Date(atime));
+    assertEquals(fileInfo.mtime, new Date(mtime));
   },
 );
 
@@ -187,8 +187,8 @@ unitTest(
     await Deno.utime(testDir, atime, mtime);
 
     const dirInfo = Deno.statSync(testDir);
-    assertEquals(dirInfo.atime, new Date(atime * 1000));
-    assertEquals(dirInfo.mtime, new Date(mtime * 1000));
+    assertEquals(dirInfo.atime, new Date(atime));
+    assertEquals(dirInfo.mtime, new Date(mtime));
   },
 );
 


### PR DESCRIPTION
This changes the number overloads of Deno.futime and Deno.utime to be in milliseconds rather than seconds. Seconds is rather surprising considering that the date constructor takes milliseconds and it results in a loss of precision.

Closes #7301 