### PR TITLE
fix(URLSearchParams): fix handling of + character

### DIFF
--- a/cli/rt/11_url.js
+++ b/cli/rt/11_url.js
@@ -14,6 +14,10 @@
     return sendSync("op_domain_to_ascii", { domain, beStrict });
   }
 
+  function decodeQueryParam(p) {
+    return decodeURIComponent(p.replace(/\+/g, " "));
+  }
+
   const urls = new WeakMap();
 
   class URLSearchParams {
@@ -63,7 +67,7 @@
         const position = pair.indexOf("=");
         const name = pair.slice(0, position === -1 ? pair.length : position);
         const value = pair.slice(name.length + 1);
-        this.#append(decodeURIComponent(name), decodeURIComponent(value));
+        this.#append(decodeQueryParam(name), decodeQueryParam(value));
       }
     };
 

--- a/cli/rt/11_url.js
+++ b/cli/rt/11_url.js
@@ -14,7 +14,7 @@
     return sendSync("op_domain_to_ascii", { domain, beStrict });
   }
 
-  function decodeQueryParam(p) {
+  function decodeSearchParam(p) {
     return decodeURIComponent(p.replace(/\+/g, " "));
   }
 
@@ -67,7 +67,7 @@
         const position = pair.indexOf("=");
         const name = pair.slice(0, position === -1 ? pair.length : position);
         const value = pair.slice(name.length + 1);
-        this.#append(decodeQueryParam(name), decodeQueryParam(value));
+        this.#append(decodeSearchParam(name), decodeSearchParam(value));
       }
     };
 

--- a/cli/tests/unit/url_search_params_test.ts
+++ b/cli/tests/unit/url_search_params_test.ts
@@ -48,6 +48,13 @@ unitTest(function urlSearchParamsInitString(): void {
   );
 });
 
+unitTest(function urlSearchParamsInitStringWithPlusCharacter(): void {
+  const init = "q=a+b";
+  const searchParams = new URLSearchParams(init);
+  assertEquals(searchParams.toString(), init);
+  assertEquals(searchParams.get("q"), "a b");
+});
+
 unitTest(function urlSearchParamsInitIterable(): void {
   const init = [
     ["a", "54"],


### PR DESCRIPTION
This PR changes the handling of `+` character in URLSearchParams constructor and aligns it with major browsers' implementations.

The following MDN page hints that we need this `.replace()` call before using `decodeURIComponent()`.

ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent

Fixes #7308

