### PR TITLE
docs(std/uuid): remove mention of v3 which is not implemented

### DIFF
--- a/std/uuid/README.md
+++ b/std/uuid/README.md
@@ -1,6 +1,6 @@
 # UUID
 
-Support for version 1, 3, 4, and 5 UUIDs.
+Support for version 1, 4, and 5 UUIDs.
 
 ## Usage
 


### PR DESCRIPTION
This removes a mention of v3 as as an implemented uuid variant, it is not implemented.