### PR TITLE
fix(docs): replace "eslint-ignore-" with "eslint-disable-"

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1031,7 +1031,7 @@ rule name:
 Names of rules to ignore must be specified after ignore comment.
 
 ESLint ignore comments are also supported:
-  // eslint-ignore-next-line @typescrit-eslint/no-explicit-any no-empty
+  // eslint-disable-next-line @typescrit-eslint/no-explicit-any no-empty
 
 Ignore linting a file by adding an ignore comment at the top of the file:
   // deno-lint-ignore-file

--- a/docs/tools/linter.md
+++ b/docs/tools/linter.md
@@ -131,14 +131,14 @@ function bar(a: any) {
 ```
 
 To provide some compatibility with ESLint `deno lint` also supports
-`// eslint-ignore-next-line` directive. Just like with `// deno-lint-ignore`,
+`// eslint-disable-next-line` directive. Just like with `// deno-lint-ignore`,
 it's required to specify the ignored rule name:
 
 ```ts
-// eslint-ignore-next-line no-empty
+// eslint-disable-next-line no-empty
 while (true) {}
 
-// eslint-ignore-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function bar(a: any) {
   // ...
 }


### PR DESCRIPTION
I updated the Linter section of the `deno` manual.
I found a typo in the section. The manual says we need to write `eslint-ignore` when ignoring rules in the `es-lint` format. But in that case we need to write `eslint-disable`.
It seems that `deno lint` is also expecting `eslint-disable`.