### PR TITLE
chore(std/wasi): enable and fix lint errors in tests

### DIFF
--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -1,6 +1,4 @@
-/* eslint-disable */
-
-import { assert, assertEquals } from "../testing/asserts.ts";
+import { assertEquals } from "../testing/asserts.ts";
 import { copy } from "../fs/mod.ts";
 import * as path from "../path/mod.ts";
 


### PR DESCRIPTION
On the initial merge from deno.land/x/wasi to std/wasi, linting was reduced to only pass deno lint due to a formatter/linter conflict.

This re-enables full linting for snapshot_preview1_test.ts.