### PR TITLE
feat: Add internal deprecated API

### DIFF
--- a/cli/tests/unit/deprecated.ts
+++ b/cli/tests/unit/deprecated.ts
@@ -1,0 +1,90 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { assert, assertEquals, unitTest } from "./test_util.ts";
+
+const {
+  deprecatedMap,
+  deprecated,
+  // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
+} = Deno[Deno.internal];
+
+unitTest(function deprecatedMapShouldBeMap() {
+  assert(deprecatedMap instanceof Map);
+});
+
+unitTest(function deprecatedShouldBeFunction() {
+  assert(typeof deprecated === "function");
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mockWarn(): { calls: any[][]; remove(): void } {
+  const origConsoleWarn = Object.getOwnPropertyDescriptor(
+    globalThis.console,
+    "warn",
+  );
+  assert(origConsoleWarn);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const calls: any[][] = [];
+  Object.defineProperty(globalThis.console, "warn", {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    value(...args: any[]) {
+      calls.push(args);
+    },
+    configurable: true,
+  });
+  return {
+    calls,
+    remove() {
+      Object.defineProperty(globalThis.console, "warn", origConsoleWarn);
+    },
+  };
+}
+
+unitTest(function deprecatedShouldWarn() {
+  const m = mockWarn();
+  assert(!deprecatedMap.has("mock-feature"));
+  deprecated("mock-feature", "Mock feature has been deprecated");
+  assertEquals(m.calls, [["Mock feature has been deprecated"]]);
+  assert(deprecatedMap.has("mock-feature"));
+  m.remove();
+});
+
+unitTest(function deprecatedShouldWarnOnce() {
+  const m = mockWarn();
+  assert(!deprecatedMap.has("mock-feature-a"));
+  deprecated("mock-feature-a", "Has been deprecated");
+  deprecated("mock-feature-a", "Should not be sent");
+  assertEquals(m.calls, [["Has been deprecated"]]);
+  m.remove();
+});
+
+unitTest(function deprecatedShouldAllowForce() {
+  const m = mockWarn();
+  assert(!deprecatedMap.has("mock-feature-b"));
+  deprecated("mock-feature-b", "Has been deprecated");
+  deprecated("mock-feature-b", "Should not be sent");
+  deprecated("mock-feature-b", "Can be forced", true);
+  assertEquals(m.calls, [["Has been deprecated"], ["Can be forced"]]);
+  m.remove();
+});
+
+unitTest(function deprecatedShouldHaveDefaultMsg() {
+  const m = mockWarn();
+  assert(!deprecatedMap.has("mock-feature-c"));
+  deprecated("mock-feature-c");
+  assertEquals(m.calls, [[`The feature "mock-feature-c" is deprecated.`]]);
+  m.remove();
+});
+
+unitTest(function deprecatedCanBePrepopulated() {
+  const m = mockWarn();
+  assert(!deprecatedMap.has("mock-feature-d"));
+  deprecatedMap.set("mock-feature-d", {
+    msg: "This value is already set",
+    flag: false,
+  });
+  deprecated("mock-feature-d");
+  deprecated("mock-feature-d");
+  assertEquals(m.calls, [["This value is already set"]]);
+  m.remove();
+});

--- a/cli/tests/unit/unit_tests.ts
+++ b/cli/tests/unit/unit_tests.ts
@@ -14,6 +14,7 @@ import "./chown_test.ts";
 import "./console_test.ts";
 import "./copy_file_test.ts";
 import "./custom_event_test.ts";
+import "./deprecated.ts";
 import "./dir_test.ts";
 import "./dispatch_minimal_test.ts";
 import "./dispatch_json_test.ts";


### PR DESCRIPTION
This is a POC of adding the ability to `console.warn()` on deprecated APIs for the internals of Deno.

It could resolve #7335 

It provides an internal method named `deprecated()` and a map called `deprecatedMap`.  It will by default only warn once per unique feature ID.  For example, if we wanted to deprecate a particular API, we could use something like this in a place where it would be called:

```js
deprecated("feature-tag", "Deno.whatever is deprecated. It will be removed in Deno 2.0.\n  Use Deno.whenever instead.");
```
