### PR TITLE
WIP feat(test): add timeout feature [HELP WANTED]

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -162,7 +162,7 @@ declare namespace Deno {
    * });
    * ```
    * */
-  export function test(name: string, fn: () => void | Promise<void>): void;
+  export function test(name: string, fn: () => void | Promise<void>, timeout?: number): void;
 
   /** Exit the Deno process with optional exit code. If no exit code is supplied
    * then Deno will exit with return code of 0.

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -97,6 +97,7 @@ declare namespace Deno {
   export interface TestDefinition {
     fn: () => void | Promise<void>;
     name: string;
+    timeout?: number;
     ignore?: boolean;
     /** If at lease one test has `only` set to true, only run tests that have
      * `only` set to true and fail the test suite. */

--- a/cli/rt/40_testing.js
+++ b/cli/rt/40_testing.js
@@ -45,7 +45,7 @@
       return new Promise((resolve, reject) => {
         const timeoutHandle = setTimeout(
           () => reject(new TimeoutError(ms)),
-          ms
+          ms,
         );
         fn()
           .then(() => {
@@ -97,9 +97,7 @@ finishing test case.`,
   // Wrap test function in additional assertion that makes sure
   // the test case does not "leak" resources - ie. resource table after
   // the test has exactly the same contents as before the test.
-  function assertResources(
-    fn,
-  ) {
+  function assertResources(fn) {
     return async function resourceSanitizer() {
       const pre = resources();
       await fn();
@@ -121,10 +119,7 @@ finishing test case.`;
 
   // Main test function provided by Deno, as you can see it merely
   // creates a new object with "name" and "fn" fields.
-  function test(
-    t,
-    fn,
-  ) {
+  function test(t, fn) {
     let testDef;
     const defaults = {
       ignore: false,
@@ -228,7 +223,7 @@ finishing test case.`;
           `${message.end.passed} passed; ${message.end.failed} failed; ${message.end.timedout} timed out; ` +
           `${message.end.ignored} ignored; ${message.end.measured} measured; ` +
           `${message.end.filtered} filtered out ` +
-          `${formatDuration(message.end.duration)}\n`
+          `${formatDuration(message.end.duration)}\n`,
       );
 
       if (message.end.usedOnly && message.end.failed == 0) {
@@ -310,10 +305,7 @@ finishing test case.`;
     }
   }
 
-  function createFilterFn(
-    filter,
-    skip,
-  ) {
+  function createFilterFn(filter, skip) {
     return (def) => {
       let passes = true;
 

--- a/cli/rt/40_testing.js
+++ b/cli/rt/40_testing.js
@@ -278,13 +278,12 @@ finishing test case.`;
             endMessage.status = "passed";
             this.stats.passed++;
           } catch (err) {
+            endMessage.error = err;
             if (err instanceof TimeoutError) {
               endMessage.status = "timed out";
-              endMessage.error = err;
               this.stats.timedout++;
             } else {
               endMessage.status = "failed";
-              endMessage.error = err;
               this.stats.failed++;
             }
           }

--- a/cli/rt/40_testing.js
+++ b/cli/rt/40_testing.js
@@ -369,7 +369,10 @@ finishing test case.`;
       globalThis.console = originalConsole;
     }
 
-    if ((endMsg.failed > 0 || endMsg?.usedOnly) && exitOnFail) {
+    if (
+      (endMsg.failed > 0 || endMsg.timedout > 0 || endMsg?.usedOnly) &&
+      exitOnFail
+    ) {
       exit(1);
     }
 

--- a/cli/rt/40_testing.js
+++ b/cli/rt/40_testing.js
@@ -40,7 +40,7 @@
       return fn;
     }
 
-    return function promiseWithTimeout() {
+    return function () {
       return new Promise((resolve, reject) => {
         const timeoutHandle = setTimeout(
           () => reject(new TimeoutError(ms)),

--- a/cli/tests/deno_test.out
+++ b/cli/tests/deno_test.out
@@ -22,5 +22,5 @@ AssertionError: fail3 assertion
 failures:
 [WILDCARD]
 
-test result: FAILED. 1 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out [WILDCARD]
+test result: FAILED. 1 passed; 3 failed; 0 timed out; 0 ignored; 0 measured; 0 filtered out [WILDCARD]
 

--- a/cli/tests/deno_test_fail_fast.out
+++ b/cli/tests/deno_test_fail_fast.out
@@ -11,5 +11,5 @@ AssertionError: fail1 assertion
 failures:
 [WILDCARD]
 
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out [WILDCARD]
+test result: FAILED. 0 passed; 1 failed; 0 timed out; 0 ignored; 0 measured; 0 filtered out [WILDCARD]
 

--- a/cli/tests/deno_test_only.ts.out
+++ b/cli/tests/deno_test_only.ts.out
@@ -1,7 +1,7 @@
 [WILDCARD]running 1 tests
 test def ... ok ([WILDCARD])
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+test result: ok. 1 passed; 0 failed; 0 timed out; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
 FAILED because the "only" option was used
 

--- a/cli/tests/deno_test_timeout.ts
+++ b/cli/tests/deno_test_timeout.ts
@@ -1,0 +1,13 @@
+function foo() {
+  return new Promise((_resolve, _reject) => {
+    // neither resolve nor reject is called
+  });
+}
+
+Deno.test({
+  name: "ever-pending promise",
+  async fn() {
+    await foo();
+  },
+  timeout: 500,
+});

--- a/cli/tests/deno_test_timeout.ts.out
+++ b/cli/tests/deno_test_timeout.ts.out
@@ -1,0 +1,15 @@
+[WILDCARD]
+running 1 tests
+test ever-pending promise ... TIMEOUT ([WILDCARD])
+
+failures:
+
+ever-pending promise
+TimeoutError { message: "Not finished within the 500ms timeout" }
+
+failures:
+
+	ever-pending promise
+
+test result: FAILED. 0 passed; 0 failed; 1 timed out; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1384,6 +1384,12 @@ itest!(deno_test_only {
   output: "deno_test_only.ts.out",
 });
 
+itest!(deno_test_timeout {
+  args: "test deno_test_timeout.ts",
+  exit_code: 1,
+  output: "deno_test_timeout.ts.out",
+});
+
 #[test]
 fn workers() {
   let _g = util::http_server();

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1216,7 +1216,7 @@ fn deno_test_no_color() {
   assert!(out.contains("test success ... ok"));
   assert!(out.contains("test fail ... FAILED"));
   assert!(out.contains("test ignored ... ignored"));
-  assert!(out.contains("test result: FAILED. 1 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out"));
+  assert!(out.contains("test result: FAILED. 1 passed; 1 failed; 0 timed out; 1 ignored; 0 measured; 0 filtered out"));
 }
 
 #[test]


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

Fixes #7088

This PR adds `timeout` option to `Deno.test`.

As described in #7088, a promise that will never be fulfilled or rejected causes strange behavior in deno test - as if the test exits with code 0.
The idea I came up to address this problem is to introduce timeout feature. If a test function is async one, it is wrapped so that the timer will run in parallel. It allows to detect and interrupt ever-pending promises as well as too long operations.
As far as I know, most of famous test frameworks (e.g. Jest) have the timeout option, so it's reasonable to adopt it IMO.

### Example

<details><summary>click here to see the example</summary>
<p>

We can write tests and specify timeout period like:

```ts
function delay(ms: number) {
  return new Promise((resolve) => {
    setTimeout(resolve, ms);
  });
}

function foo() {
  return new Promise((_resolve, _reject) => {
    console.log("in promise");
    // neither resolve nor reject is called
  });
}

Deno.test({
  name: "bug",
  async fn() {
    const a = await foo();
    console.log(a);
  },
});

Deno.test({
  name: "heavy task wituout await",
  async fn() {
    let sum = 0;
    for (let i = 0; i < 5000000000; i++) {
      sum += i;
    }
    console.log(sum);
  },
});

Deno.test({
  name: "sleep with await",
  async fn() {
    await delay(1400);
    console.log("sleep with await done");
  },
  timeout: 1000, // timeout period can be specified. the default value is 2000
});

Deno.test({
  name: "error",
  fn() {
    throw "error!";
  },
});

Deno.test({
  name: "ok",
  async fn() {},
});
```

The output looks like:

![image](https://user-images.githubusercontent.com/23649474/92308065-f6729b80-efd5-11ea-9536-948c933a79bc.png)


</p>
</details>

### Problem (help wanted)

To my sad, my timeout implementation does not work in some cases :( 
Consider the following test:

```ts
// `delay` function is the same as above
Deno.test({
  name: "one",
  async fn() {
    await delay(1200); // (a)
  },
  timeout: 1000,
});

Deno.test(
  "two",
  async function () {
    await delay(400);
  },
  1000
);
```

Unfortunately, this test resulted in the strange output like:

![image](https://user-images.githubusercontent.com/23649474/92327332-ce497200-f093-11ea-89ef-f0a55ab03b75.png)

The test "one" was timed out. It's okay since the delay period is longer than the timeout.
But the test "two" failed unexpectedly due to leaking async ops.
This is because `await delay(1200)` in the test "one" (marked (a)) was still running at the beginning of the test "two", and it finished during the test "two". It is reported as "leaking async ops".

I spend today trying to find a solution to this but in vain.
I'm feeling like it is so hard for both the timeout feature and detecting leaking async ops to work simultaneously.
Should we take either? Or are there any great solutions? Any ideas would be very appreciated!