### PR TITLE
test(std/hash): make tests runnable from any directory

### DIFF
--- a/std/hash/sha1_test.ts
+++ b/std/hash/sha1_test.ts
@@ -1,9 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../testing/asserts.ts";
 import { Sha1, Message } from "./sha1.ts";
-import { join, resolve } from "../path/mod.ts";
+import { dirname, join, resolve, fromFileUrl } from "../path/mod.ts";
 
-const testdataDir = resolve("hash", "testdata");
+const moduleDir = dirname(fromFileUrl(import.meta.url));
+const testdataDir = resolve(moduleDir, "testdata");
 
 /** Handy function to convert an array/array buffer to a string of hex values. */
 function toHexString(value: number[] | ArrayBuffer): string {

--- a/std/hash/sha256_test.ts
+++ b/std/hash/sha256_test.ts
@@ -1,9 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { Sha256, HmacSha256, Message } from "./sha256.ts";
 import { assertEquals } from "../testing/asserts.ts";
-import { join, resolve } from "../path/mod.ts";
+import { dirname, join, resolve, fromFileUrl } from "../path/mod.ts";
 
-const testdataDir = resolve("hash", "testdata");
+const moduleDir = dirname(fromFileUrl(import.meta.url));
+const testdataDir = resolve(moduleDir, "testdata");
 
 /** Handy function to convert an array/array buffer to a string of hex values. */
 function toHexString(value: number[] | ArrayBuffer): string {

--- a/std/hash/sha512_test.ts
+++ b/std/hash/sha512_test.ts
@@ -1,9 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { Sha512, HmacSha512, Message } from "./sha512.ts";
 import { assertEquals } from "../testing/asserts.ts";
-import { join, resolve } from "../path/mod.ts";
+import { dirname, join, resolve, fromFileUrl } from "../path/mod.ts";
 
-const testdataDir = resolve("hash", "testdata");
+const moduleDir = dirname(fromFileUrl(import.meta.url));
+const testdataDir = resolve(moduleDir, "testdata");
 
 /** Handy function to convert an array/array buffer to a string of hex values. */
 function toHexString(value: number[] | ArrayBuffer): string {


### PR DESCRIPTION
This makes std/hash tests runnable from any directory by resolving the testdata directory relative to the module directory resolved from import.meta.url.