### PR TITLE
fix(op_crates/web): Use "deno:" URLs for internal script specifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,10 +499,11 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "deno_core",
  "futures",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,6 @@ version = "0.7.1"
 dependencies = [
  "deno_core",
  "futures",
- "url",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,7 @@ path = "./bench/main.rs"
 
 [build-dependencies]
 deno_core = { path = "../core", version = "0.56.0" }
-deno_web = { path = "../op_crates/web", version = "0.7.0" }
+deno_web = { path = "../op_crates/web", version = "0.7.1" }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1.11"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -15,12 +15,20 @@ use std::path::PathBuf;
 fn create_snapshot(
   mut isolate: JsRuntime,
   snapshot_path: &Path,
-  files: Vec<String>,
+  files: Vec<PathBuf>,
 ) {
   deno_web::init(&mut isolate);
+  let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+  // TODO(nayeemrmn): https://github.com/rust-lang/cargo/issues/3946 to get the
+  // workspace root.
+  let display_root_path = manifest_dir.parent().unwrap();
   for file in files {
-    println!("cargo:rerun-if-changed={}", file);
-    js_check(isolate.execute(&file, &std::fs::read_to_string(&file).unwrap()));
+    println!("cargo:rerun-if-changed={}", file.display());
+    let display_path = file.strip_prefix(display_root_path).unwrap();
+    js_check(isolate.execute(
+      &("deno:".to_string() + display_path.to_str().unwrap()),
+      &std::fs::read_to_string(&file).unwrap(),
+    ));
   }
 
   let snapshot = isolate.snapshot();
@@ -30,7 +38,7 @@ fn create_snapshot(
   println!("Snapshot written to: {} ", snapshot_path.display());
 }
 
-fn create_runtime_snapshot(snapshot_path: &Path, files: Vec<String>) {
+fn create_runtime_snapshot(snapshot_path: &Path, files: Vec<PathBuf>) {
   let state = BasicState::new();
   let isolate = JsRuntime::new(state, StartupData::None, true);
   create_snapshot(isolate, snapshot_path, files);
@@ -38,7 +46,7 @@ fn create_runtime_snapshot(snapshot_path: &Path, files: Vec<String>) {
 
 fn create_compiler_snapshot(
   snapshot_path: &Path,
-  files: Vec<String>,
+  files: Vec<PathBuf>,
   cwd: &Path,
 ) {
   let mut custom_libs: HashMap<String, PathBuf> = HashMap::new();
@@ -134,15 +142,16 @@ fn main() {
   }
 }
 
-fn get_js_files(d: &str) -> Vec<String> {
+fn get_js_files(d: &str) -> Vec<PathBuf> {
+  let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
   let mut js_files = std::fs::read_dir(d)
     .unwrap()
     .map(|dir_entry| {
       let file = dir_entry.unwrap();
-      file.path().to_string_lossy().to_string()
+      manifest_dir.join(file.path())
     })
-    .filter(|filename| filename.ends_with(".js"))
-    .collect::<Vec<String>>();
+    .filter(|path| path.extension().unwrap_or_default() == "js")
+    .collect::<Vec<PathBuf>>();
   js_files.sort();
   js_files
 }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -142,7 +142,7 @@ fn main() {
 }
 
 fn get_js_files(d: &str) -> Vec<PathBuf> {
-  let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+  let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
   let mut js_files = std::fs::read_dir(d)
     .unwrap()
     .map(|dir_entry| {

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -18,13 +18,12 @@ fn create_snapshot(
   files: Vec<PathBuf>,
 ) {
   deno_web::init(&mut isolate);
-  let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
   // TODO(nayeemrmn): https://github.com/rust-lang/cargo/issues/3946 to get the
   // workspace root.
-  let display_root_path = manifest_dir.parent().unwrap();
+  let display_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
   for file in files {
     println!("cargo:rerun-if-changed={}", file.display());
-    let display_path = file.strip_prefix(display_root_path).unwrap();
+    let display_path = file.strip_prefix(display_root).unwrap();
     js_check(isolate.execute(
       &("deno:".to_string() + display_path.to_str().unwrap()),
       &std::fs::read_to_string(&file).unwrap(),

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -24,8 +24,9 @@ fn create_snapshot(
   for file in files {
     println!("cargo:rerun-if-changed={}", file.display());
     let display_path = file.strip_prefix(display_root).unwrap();
+    let display_path_str = display_path.display().to_string();
     js_check(isolate.execute(
-      &("deno:".to_string() + display_path.to_str().unwrap()),
+      &("deno:".to_string() + &display_path_str.replace('\\', "/")),
       &std::fs::read_to_string(&file).unwrap(),
     ));
   }

--- a/cli/rt/40_error_stack.js
+++ b/cli/rt/40_error_stack.js
@@ -240,7 +240,7 @@
     });
     for (const callSite of mappedCallSites) {
       error.__callSiteEvals.push(Object.freeze(evaluateCallSite(callSite)));
-      const isInternal = callSite.getFileName()?.startsWith("$deno$") ?? false;
+      const isInternal = callSite.getFileName()?.startsWith("deno:") ?? false;
       error.__formattedFrames.push(callSiteToString(callSite, isInternal));
     }
     Object.freeze(error.__callSiteEvals);

--- a/cli/tests/error_009_op_crates_error.js
+++ b/cli/tests/error_009_op_crates_error.js
@@ -1,0 +1,2 @@
+// Missing arg.
+new Event();

--- a/cli/tests/error_009_op_crates_error.js.out
+++ b/cli/tests/error_009_op_crates_error.js.out
@@ -1,0 +1,3 @@
+[WILDCARD]error: Uncaught TypeError: Event requires at least 1 argument, but only 0 present[WILDCARD]
+    at new Event (web[WILDCARD])
+    at [WILDCARD]

--- a/cli/tests/error_009_op_crates_error.js.out
+++ b/cli/tests/error_009_op_crates_error.js.out
@@ -1,3 +1,3 @@
 [WILDCARD]error: Uncaught TypeError: Event requires at least 1 argument, but only 0 present[WILDCARD]
-    at new Event (deno:op_crates/web[WILDCARD])
+    at new Event (deno:op_crates[WILDCARD]web[WILDCARD])
     at [WILDCARD]

--- a/cli/tests/error_009_op_crates_error.js.out
+++ b/cli/tests/error_009_op_crates_error.js.out
@@ -1,3 +1,3 @@
 [WILDCARD]error: Uncaught TypeError: Event requires at least 1 argument, but only 0 present[WILDCARD]
-    at new Event (web[WILDCARD])
+    at new Event (deno:op_crates/web[WILDCARD])
     at [WILDCARD]

--- a/cli/tests/error_009_op_crates_error.js.out
+++ b/cli/tests/error_009_op_crates_error.js.out
@@ -1,3 +1,3 @@
 [WILDCARD]error: Uncaught TypeError: Event requires at least 1 argument, but only 0 present[WILDCARD]
-    at new Event (deno:op_crates[WILDCARD]web[WILDCARD])
+    at new Event (deno:op_crates/web/[WILDCARD])
     at [WILDCARD]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1811,6 +1811,12 @@ itest!(error_008_checkjs {
   output: "error_008_checkjs.js.out",
 });
 
+itest!(error_009_op_crates_error {
+  args: "run error_009_op_crates_error.js",
+  output: "error_009_op_crates_error.js.out",
+  exit_code: 1,
+});
+
 itest!(error_011_bad_module_specifier {
   args: "run --reload error_011_bad_module_specifier.ts",
   exit_code: 1,

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -1101,6 +1101,9 @@ impl TsCompiler {
     script_name: &str,
   ) -> Option<Vec<u8>> {
     if let Some(module_specifier) = self.try_to_resolve(script_name) {
+      if module_specifier.as_url().scheme() == "deno" {
+        return None;
+      }
       return match self.get_source_map_file(&module_specifier) {
         Ok(out) => Some(out.source_code.into_bytes()),
         Err(_) => {
@@ -1844,11 +1847,11 @@ mod tests {
       (r#"{ "compilerOptions": { "checkJs": true } } "#, true),
       // JSON with comment
       (
-        r#"{ 
-          "compilerOptions": { 
-            // force .js file compilation by Deno 
-            "checkJs": true 
-          } 
+        r#"{
+          "compilerOptions": {
+            // force .js file compilation by Deno
+            "checkJs": true
+          }
         }"#,
         true,
       ),

--- a/op_crates/web/Cargo.toml
+++ b/op_crates/web/Cargo.toml
@@ -16,7 +16,5 @@ path = "lib.rs"
 [dependencies]
 deno_core = { version = "0.56.0", path = "../../core" }
 
-url = "2.1.1"
-
 [dev-dependencies]
 futures = "0.3.5"

--- a/op_crates/web/Cargo.toml
+++ b/op_crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_web"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2018"
 description = "Collection of Web APIs"
 authors = ["the Deno authors"]
@@ -15,6 +15,8 @@ path = "lib.rs"
 
 [dependencies]
 deno_core = { version = "0.56.0", path = "../../core" }
+
+url = "2.1.1"
 
 [dev-dependencies]
 futures = "0.3.5"

--- a/op_crates/web/event_test.js
+++ b/op_crates/web/event_test.js
@@ -30,18 +30,6 @@ function eventInitializedWithTypeAndDict() {
   assert(event.cancelable === true);
 }
 
-function eventMissingArgs() {
-  let threw = false;
-  try {
-    new Event();
-  } catch {
-    threw = true;
-  }
-  if (!threw) {
-    throw new Error("Event constructor without args should have thrown.");
-  }
-}
-
 function eventComposedPathSuccess() {
   const type = "click";
   const event = new Event(type);
@@ -111,7 +99,6 @@ function eventIsTrusted() {
 function main() {
   eventInitializedWithType();
   eventInitializedWithTypeAndDict();
-  eventMissingArgs();
   eventComposedPathSuccess();
   eventStopPropagationSuccess();
   eventStopImmediatePropagationSuccess();

--- a/op_crates/web/event_test.js
+++ b/op_crates/web/event_test.js
@@ -31,10 +31,15 @@ function eventInitializedWithTypeAndDict() {
 }
 
 function eventMissingArgs() {
+  let threw = false;
   try {
     new Event();
+  } catch {
+    threw = true;
+  }
+  if (!threw) {
     throw new Error("Event constructor without args should have thrown.");
-  } catch {}
+  }
 }
 
 function eventComposedPathSuccess() {

--- a/op_crates/web/event_test.js
+++ b/op_crates/web/event_test.js
@@ -30,6 +30,13 @@ function eventInitializedWithTypeAndDict() {
   assert(event.cancelable === true);
 }
 
+function eventMissingArgs() {
+  try {
+    new Event();
+    throw new Error("Event constructor without args should have thrown.");
+  } catch {}
+}
+
 function eventComposedPathSuccess() {
   const type = "click";
   const event = new Event(type);
@@ -99,6 +106,7 @@ function eventIsTrusted() {
 function main() {
   eventInitializedWithType();
   eventInitializedWithTypeAndDict();
+  eventMissingArgs();
   eventComposedPathSuccess();
   eventStopPropagationSuccess();
   eventStopImmediatePropagationSuccess();

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -18,8 +18,9 @@ pub fn init(isolate: &mut JsRuntime) {
   for file in files {
     println!("cargo:rerun-if-changed={}", file.display());
     let display_path = file.strip_prefix(display_root).unwrap();
+    let display_path_str = display_path.display().to_string();
     js_check(isolate.execute(
-      &("deno:".to_string() + display_path.to_str().unwrap()),
+      &("deno:".to_string() + &display_path_str.replace('\\', "/")),
       &std::fs::read_to_string(&file).unwrap(),
     ));
   }
@@ -87,10 +88,7 @@ mod tests {
       if let Err(error) = result {
         let error_string = error.to_string();
         // Test that the script specifier is a URL: `deno:<repo-relative path>`.
-        #[cfg(unix)]
         assert!(error_string.starts_with("deno:op_crates/web/01_event.js"));
-        #[cfg(windows)]
-        assert!(error_string.starts_with("deno:op_crates\\web\\01_event.js"));
         assert!(error_string.contains("Uncaught TypeError"));
       } else {
         unreachable!();

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -12,8 +12,8 @@ pub fn init(isolate: &mut JsRuntime) {
     manifest_dir.join("02_abort_signal.js"),
     manifest_dir.join("08_text_encoding.js"),
   ];
-  // TODO(nayeemrmn): This reference to the repo root breaks encapsulation of
-  // the crate. Probably should be handled in `cli` somehow.
+  // TODO(nayeemrmn): https://github.com/rust-lang/cargo/issues/3946 to get the
+  // workspace root.
   let display_root_path = manifest_dir.parent().unwrap().parent().unwrap();
   for file in files {
     println!("cargo:rerun-if-changed={}", file.display());

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -3,6 +3,7 @@
 use deno_core::js_check;
 use deno_core::JsRuntime;
 use std::path::PathBuf;
+use url::Url;
 
 pub fn init(isolate: &mut JsRuntime) {
   let files = vec![
@@ -14,7 +15,7 @@ pub fn init(isolate: &mut JsRuntime) {
   for file in files {
     println!("cargo:rerun-if-changed={}", file.display());
     js_check(isolate.execute(
-      &file.to_string_lossy(),
+      Url::from_file_path(&file).unwrap().as_str(),
       &std::fs::read_to_string(&file).unwrap(),
     ));
   }

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -16,16 +16,11 @@ pub fn init(isolate: &mut JsRuntime) {
   ];
   for file in files {
     println!("cargo:rerun-if-changed={}", file.display());
-    js_check(
-      isolate.execute(
-        file
-          .strip_prefix(display_root_path)
-          .unwrap()
-          .to_str()
-          .unwrap(),
-        &std::fs::read_to_string(&file).unwrap(),
-      ),
-    );
+    let display_path = file.strip_prefix(display_root_path).unwrap();
+    js_check(isolate.execute(
+      display_path.to_str().unwrap(),
+      &std::fs::read_to_string(&file).unwrap(),
+    ));
   }
 }
 

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -6,19 +6,20 @@ use std::path::PathBuf;
 
 pub fn init(isolate: &mut JsRuntime) {
   let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-  // This should point to "op_crates".
-  let display_root_path = manifest_dir.parent().unwrap();
   let files = vec![
     manifest_dir.join("00_dom_exception.js"),
     manifest_dir.join("01_event.js"),
     manifest_dir.join("02_abort_signal.js"),
     manifest_dir.join("08_text_encoding.js"),
   ];
+  // TODO(nayeemrmn): This reference to the repo root breaks encapsulation of
+  // the crate. Probably should be handled in `cli` somehow.
+  let display_root_path = manifest_dir.parent().unwrap().parent().unwrap();
   for file in files {
     println!("cargo:rerun-if-changed={}", file.display());
     let display_path = file.strip_prefix(display_root_path).unwrap();
     js_check(isolate.execute(
-      display_path.to_str().unwrap(),
+      &("deno:".to_string() + display_path.to_str().unwrap()),
       &std::fs::read_to_string(&file).unwrap(),
     ));
   }

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -80,6 +80,27 @@ mod tests {
   }
 
   #[test]
+  fn test_event_error() {
+    run_in_task(|mut cx| {
+      let mut isolate = setup();
+      let result = isolate.execute("foo.js", "new Event()");
+      if let Err(e) = result {
+        // Test that the script specifier is a URL: `deno:<repo-relative path>`.
+        #[cfg(unix)]
+        assert!(e.to_string().starts_with("deno:op_crates/web/01_event.js"));
+        #[cfg(windows)]
+        assert!(e.to_string().starts_with("deno:op_crates\\web\\01_event.js"));
+        assert!(e.to_string().contains("Uncaught TypeError"));
+      } else {
+        unreachable!();
+      }
+      if let Poll::Ready(Err(_)) = isolate.poll_unpin(&mut cx) {
+        unreachable!();
+      }
+    });
+  }
+
+  #[test]
   fn test_event_target() {
     run_in_task(|mut cx| {
       let mut isolate = setup();

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -2,10 +2,10 @@
 
 use deno_core::js_check;
 use deno_core::JsRuntime;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn init(isolate: &mut JsRuntime) {
-  let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+  let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
   let files = vec![
     manifest_dir.join("00_dom_exception.js"),
     manifest_dir.join("01_event.js"),
@@ -14,10 +14,10 @@ pub fn init(isolate: &mut JsRuntime) {
   ];
   // TODO(nayeemrmn): https://github.com/rust-lang/cargo/issues/3946 to get the
   // workspace root.
-  let display_root_path = manifest_dir.parent().unwrap().parent().unwrap();
+  let display_root = manifest_dir.parent().unwrap().parent().unwrap();
   for file in files {
     println!("cargo:rerun-if-changed={}", file.display());
-    let display_path = file.strip_prefix(display_root_path).unwrap();
+    let display_path = file.strip_prefix(display_root).unwrap();
     js_check(isolate.execute(
       &("deno:".to_string() + display_path.to_str().unwrap()),
       &std::fs::read_to_string(&file).unwrap(),

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -84,13 +84,14 @@ mod tests {
     run_in_task(|mut cx| {
       let mut isolate = setup();
       let result = isolate.execute("foo.js", "new Event()");
-      if let Err(e) = result {
+      if let Err(error) = result {
+        let error_string = error.to_string();
         // Test that the script specifier is a URL: `deno:<repo-relative path>`.
         #[cfg(unix)]
-        assert!(e.to_string().starts_with("deno:op_crates/web/01_event.js"));
+        assert!(error_string.starts_with("deno:op_crates/web/01_event.js"));
         #[cfg(windows)]
-        assert!(e.to_string().starts_with("deno:op_crates\\web\\01_event.js"));
-        assert!(e.to_string().contains("Uncaught TypeError"));
+        assert!(error_string.starts_with("deno:op_crates\\web\\01_event.js"));
+        assert!(error_string.contains("Uncaught TypeError"));
       } else {
         unreachable!();
       }


### PR DESCRIPTION
Fixes `deno.exe eval "new Event()"` panic. Described in https://github.com/denoland/deno/pull/7369#discussion_r484105747.

Internal script specifiers use URLs in the form of `deno:<repo-relative path to file>`. That lets Deno developers conveniently Ctrl+click the paths (checked in VSCode).

<kbd>![image](https://user-images.githubusercontent.com/29990554/92529184-f9fa6280-f221-11ea-8e68-5999bf68a833.png)</kbd>

Additionally, having a clear prefix lets us restore dimming for internal stack frames: #4201.

The [panic](https://github.com/denoland/deno/runs/1078336836) is fixed by ignoring `deno:` URLs when source mapping.