### PR TITLE
fix(cli): response arrayBuffer, blob, text and json null return

### DIFF
--- a/cli/rt/24_body.js
+++ b/cli/rt/24_body.js
@@ -85,7 +85,7 @@
       const enc = new TextEncoder();
       return enc.encode(bodySource.toString()).buffer;
     } else if (!bodySource) {
-      return null;
+      return new ArrayBuffer(0);
     }
     throw new Error(
       `Body type not implemented: ${bodySource.constructor.name}`,

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -741,8 +741,8 @@ unitTest(function responseRedirect(): void {
 unitTest(async function responseWithoutBody(): Promise<void> {
   const response = new Response();
   assertEquals(await response.arrayBuffer(), new ArrayBuffer(0));
+  assertEquals(await response.blob(), new Blob([]));
   assertEquals(await response.text(), "");
-
   await assertThrowsAsync(async () => {
     await response.json();
   });

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -738,6 +738,16 @@ unitTest(function responseRedirect(): void {
   assertEquals(redir.type, "default");
 });
 
+unitTest(async function responseWithoutBody(): Promise<void> {
+  const response = new Response();
+  assertEquals(await response.arrayBuffer(), new ArrayBuffer(0));
+  assertEquals(await response.text(), "");
+
+  await assertThrowsAsync(async () => {
+    await response.json();
+  });
+});
+
 unitTest({ perms: { net: true } }, async function fetchBodyReadTwice(): Promise<
   void
 > {


### PR DESCRIPTION
This fixes an issue where response.arrayBuffer, response.blob, response.text and response.json returns null on a response object without a body.

These should act as if the buffer source is 0 bytes in length and resolve immediately.
See https://fetch.spec.whatwg.org/#concept-body-consume-body.

Fixes #7338