### PR TITLE
test(std/fs): make tests runnable from any directory

### DIFF
--- a/std/fs/_util_test.ts
+++ b/std/fs/_util_test.ts
@@ -6,7 +6,8 @@ import { isSubdir, getFileInfoType, PathType } from "./_util.ts";
 import { ensureFileSync } from "./ensure_file.ts";
 import { ensureDirSync } from "./ensure_dir.ts";
 
-const testdataDir = path.resolve("fs", "testdata");
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("_isSubdir", function (): void {
   const pairs = [

--- a/std/fs/copy_test.ts
+++ b/std/fs/copy_test.ts
@@ -12,7 +12,8 @@ import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { ensureFile, ensureFileSync } from "./ensure_file.ts";
 import { ensureSymlink, ensureSymlinkSync } from "./ensure_symlink.ts";
 
-const testdataDir = path.resolve("fs", "testdata");
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testdataDir = path.resolve(moduleDir, "testdata");
 
 function testCopy(
   name: string,

--- a/std/fs/empty_dir_test.ts
+++ b/std/fs/empty_dir_test.ts
@@ -9,7 +9,8 @@ import {
 import * as path from "../path/mod.ts";
 import { emptyDir, emptyDirSync } from "./empty_dir.ts";
 
-const testdataDir = path.resolve("fs", "testdata");
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("emptyDirIfItNotExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "empty_dir_test_1");

--- a/std/fs/ensure_dir_test.ts
+++ b/std/fs/ensure_dir_test.ts
@@ -4,7 +4,8 @@ import * as path from "../path/mod.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { ensureFile, ensureFileSync } from "./ensure_file.ts";
 
-const testdataDir = path.resolve("fs", "testdata");
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("ensureDirIfItNotExist", async function (): Promise<void> {
   const baseDir = path.join(testdataDir, "ensure_dir_not_exist");

--- a/std/fs/ensure_file_test.ts
+++ b/std/fs/ensure_file_test.ts
@@ -3,7 +3,8 @@ import { assertThrows, assertThrowsAsync } from "../testing/asserts.ts";
 import * as path from "../path/mod.ts";
 import { ensureFile, ensureFileSync } from "./ensure_file.ts";
 
-const testdataDir = path.resolve("fs", "testdata");
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("ensureFileIfItNotExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "ensure_file_1");

--- a/std/fs/ensure_link_test.ts
+++ b/std/fs/ensure_link_test.ts
@@ -8,7 +8,8 @@ import {
 import * as path from "../path/mod.ts";
 import { ensureLink, ensureLinkSync } from "./ensure_link.ts";
 
-const testdataDir = path.resolve("fs", "testdata");
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("ensureLinkIfItNotExist", async function (): Promise<void> {
   const srcDir = path.join(testdataDir, "ensure_link_1");

--- a/std/fs/ensure_symlink_test.ts
+++ b/std/fs/ensure_symlink_test.ts
@@ -8,7 +8,8 @@ import {
 import * as path from "../path/mod.ts";
 import { ensureSymlink, ensureSymlinkSync } from "./ensure_symlink.ts";
 
-const testdataDir = path.resolve("fs", "testdata");
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("ensureSymlinkIfItNotExist", async function (): Promise<void> {
   const testDir = path.join(testdataDir, "link_file_1");

--- a/std/fs/exists_test.ts
+++ b/std/fs/exists_test.ts
@@ -3,7 +3,8 @@ import { assertEquals, assertStringContains } from "../testing/asserts.ts";
 import * as path from "../path/mod.ts";
 import { exists, existsSync } from "./exists.ts";
 
-const testdataDir = path.resolve("fs", "testdata");
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("[fs] existsFile", async function (): Promise<void> {
   assertEquals(

--- a/std/fs/move_test.ts
+++ b/std/fs/move_test.ts
@@ -10,7 +10,8 @@ import { ensureFile, ensureFileSync } from "./ensure_file.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { exists, existsSync } from "./exists.ts";
 
-const testdataDir = path.resolve("fs", "testdata");
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("moveDirectoryIfSrcNotExists", async function (): Promise<void> {
   const srcDir = path.join(testdataDir, "move_test_src_1");


### PR DESCRIPTION
This makes std/fs tests runnable from any directory by resolving the testdata directory relative to the module directory resolved from import.meta.url.