### PR TITLE
test(std/node): make tests runnable from any directory

### DIFF
--- a/std/node/_fs/_fs_readFile_test.ts
+++ b/std/node/_fs/_fs_readFile_test.ts
@@ -2,9 +2,8 @@ import { readFile, readFileSync } from "./_fs_readFile.ts";
 import * as path from "../../path/mod.ts";
 import { assertEquals, assert } from "../../testing/asserts.ts";
 
-const testData = path.resolve(
-  path.join("node", "_fs", "testdata", "hello.txt"),
-);
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testData = path.resolve(moduleDir, "testdata", "hello.txt");
 
 Deno.test("readFileSuccess", async function () {
   const data = await new Promise((res, rej) => {

--- a/std/node/_fs/_fs_writeFile_test.ts
+++ b/std/node/_fs/_fs_writeFile_test.ts
@@ -9,7 +9,8 @@ import { writeFile, writeFileSync } from "./_fs_writeFile.ts";
 import type { TextEncodings } from "./_fs_common.ts";
 import * as path from "../../path/mod.ts";
 
-const testDataDir = path.resolve(path.join("node", "_fs", "testdata"));
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testDataDir = path.resolve(moduleDir, "testdata");
 const decoder = new TextDecoder("utf-8");
 
 Deno.test("Callback must be a function error", function fn() {

--- a/std/node/_fs/promises/_fs_readFile_test.ts
+++ b/std/node/_fs/promises/_fs_readFile_test.ts
@@ -2,9 +2,8 @@ import { readFile } from "./_fs_readFile.ts";
 import * as path from "../../../path/mod.ts";
 import { assertEquals, assert } from "../../../testing/asserts.ts";
 
-const testData = path.resolve(
-  path.join("node", "_fs", "testdata", "hello.txt"),
-);
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testData = path.resolve(moduleDir, "..", "testdata", "hello.txt");
 
 Deno.test("readFileSuccess", async function () {
   const data: Uint8Array = await readFile(testData);

--- a/std/node/module_test.ts
+++ b/std/node/module_test.ts
@@ -4,7 +4,12 @@ import {
   assert,
   assertStringContains,
 } from "../testing/asserts.ts";
+
+import * as path from "../path/mod.ts";
 import { createRequire } from "./module.ts";
+
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testdataDir = path.resolve(moduleDir, path.join("_fs", "testdata"));
 
 const require = createRequire(import.meta.url);
 
@@ -32,8 +37,13 @@ Deno.test("requireBuiltin", function () {
   const fs = require("fs");
   assert("readFileSync" in fs);
   const { readFileSync, isNull, extname } = require("./tests/cjs/cjs_builtin");
+
+  const testData = path.relative(
+    Deno.cwd(),
+    path.join(testdataDir, "hello.txt"),
+  );
   assertEquals(
-    readFileSync("./node/_fs/testdata/hello.txt", { encoding: "utf8" }),
+    readFileSync(testData, { encoding: "utf8" }),
     "hello world",
   );
   assert(isNull(null));

--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -1,4 +1,5 @@
 import { assert, assertThrows, assertEquals } from "../testing/asserts.ts";
+import * as path from "../path/mod.ts";
 import * as all from "./process.ts";
 import { env, argv } from "./process.ts";
 
@@ -27,7 +28,11 @@ Deno.test({
 Deno.test({
   name: "process.cwd and process.chdir success",
   fn() {
-    // this should be run like other tests from directory up
+    assertEquals(process.cwd(), Deno.cwd());
+
+    const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+    process.chdir(path.resolve(moduleDir, ".."));
+
     assert(process.cwd().match(/\Wstd$/));
     process.chdir("node");
     assert(process.cwd().match(/\Wnode$/));


### PR DESCRIPTION
This makes std/node tests runnable from any directory by resolving the testdata directory and files relative to the module directory resolved from import.meta.url.