### PR TITLE
test(std/examples): make tests runnable from any directory

### DIFF
--- a/std/examples/chat/server_test.ts
+++ b/std/examples/chat/server_test.ts
@@ -4,6 +4,9 @@ import { TextProtoReader } from "../../textproto/mod.ts";
 import { BufReader } from "../../io/bufio.ts";
 import { connectWebSocket, WebSocket } from "../../ws/mod.ts";
 import { delay } from "../../async/delay.ts";
+import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+
+const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)));
 
 async function startServer(): Promise<
   Deno.Process<Deno.RunOptions & { stdout: "piped" }>
@@ -16,7 +19,7 @@ async function startServer(): Promise<
       "--allow-read",
       "server.ts",
     ],
-    cwd: "examples/chat",
+    cwd: moduleDir,
     stdout: "piped",
   });
   try {

--- a/std/examples/test.ts
+++ b/std/examples/test.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../testing/asserts.ts";
+import { dirname, relative, resolve, fromFileUrl } from "../path/mod.ts";
+
+const moduleDir = dirname(fromFileUrl(import.meta.url));
 
 /** Example of how to do basic tests */
 Deno.test("t1", function (): void {
@@ -17,8 +20,8 @@ Deno.test("catSmoke", async function (): Promise<void> {
       Deno.execPath(),
       "run",
       "--allow-read",
-      "examples/cat.ts",
-      "README.md",
+      relative(Deno.cwd(), resolve(moduleDir, "cat.ts")),
+      relative(Deno.cwd(), resolve(moduleDir, "..", "README.md")),
     ],
     stdout: "null",
     stderr: "null",

--- a/std/examples/tests/cat_test.ts
+++ b/std/examples/tests/cat_test.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertStrictEquals } from "../../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+
+const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
 
 Deno.test("[examples/cat] print multiple files", async () => {
   const decoder = new TextDecoder();
@@ -12,7 +15,7 @@ Deno.test("[examples/cat] print multiple files", async () => {
       "testdata/cat/hello.txt",
       "testdata/cat/world.txt",
     ],
-    cwd: "examples",
+    cwd: moduleDir,
     stdout: "piped",
   });
 

--- a/std/examples/tests/catj_test.ts
+++ b/std/examples/tests/catj_test.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertStrictEquals } from "../../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+
+const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
 
 Deno.test("[examples/catj] print an array", async () => {
   const decoder = new TextDecoder();
@@ -80,7 +83,7 @@ function catj(
 ): Deno.Process<Deno.RunOptions & { stdin: "piped"; stdout: "piped" }> {
   return Deno.run({
     cmd: [Deno.execPath(), "run", "--allow-read", "catj.ts", ...files],
-    cwd: "examples",
+    cwd: moduleDir,
     stdin: "piped",
     stdout: "piped",
     env: { NO_COLOR: "true" },

--- a/std/examples/tests/colors_test.ts
+++ b/std/examples/tests/colors_test.ts
@@ -1,11 +1,14 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertStrictEquals } from "../../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+
+const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
 
 Deno.test("[examples/colors] print a colored text", async () => {
   const decoder = new TextDecoder();
   const process = Deno.run({
     cmd: [Deno.execPath(), "run", "colors.ts"],
-    cwd: "examples",
+    cwd: moduleDir,
     stdout: "piped",
   });
   try {

--- a/std/examples/tests/curl_test.ts
+++ b/std/examples/tests/curl_test.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { serve } from "../../http/server.ts";
 import { assertStrictEquals } from "../../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+
+const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
 
 Deno.test({
   name: "[examples/curl] send a request to a specified url",
@@ -21,7 +24,7 @@ Deno.test({
         "curl.ts",
         "http://localhost:8081",
       ],
-      cwd: "examples",
+      cwd: moduleDir,
       stdout: "piped",
     });
 

--- a/std/examples/tests/echo_server_test.ts
+++ b/std/examples/tests/echo_server_test.ts
@@ -1,13 +1,16 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertStrictEquals, assertNotEquals } from "../../testing/asserts.ts";
 import { BufReader, ReadLineResult } from "../../io/bufio.ts";
+import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+
+const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
 
 Deno.test("[examples/echo_server]", async () => {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   const process = Deno.run({
     cmd: [Deno.execPath(), "run", "--allow-net", "echo_server.ts"],
-    cwd: "examples",
+    cwd: moduleDir,
     stdout: "piped",
   });
 

--- a/std/examples/tests/welcome_test.ts
+++ b/std/examples/tests/welcome_test.ts
@@ -1,11 +1,14 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertStrictEquals } from "../../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+
+const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
 
 Deno.test("[examples/welcome] print a welcome message", async () => {
   const decoder = new TextDecoder();
   const process = Deno.run({
     cmd: [Deno.execPath(), "run", "welcome.ts"],
-    cwd: "examples",
+    cwd: moduleDir,
     stdout: "piped",
   });
   try {

--- a/std/examples/tests/xeval_test.ts
+++ b/std/examples/tests/xeval_test.ts
@@ -7,6 +7,9 @@ import {
   assertStringContains,
   assert,
 } from "../../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+
+const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
 
 Deno.test("xevalSuccess", async function (): Promise<void> {
   const chunks: string[] = [];
@@ -26,7 +29,7 @@ Deno.test("xevalDelimiter", async function (): Promise<void> {
   assertEquals(chunks, ["!MAD", "ADAM!"]);
 });
 
-const xevalPath = "examples/xeval.ts";
+const xevalPath = "xeval.ts";
 
 Deno.test({
   name: "xevalCliReplvar",
@@ -39,6 +42,7 @@ Deno.test({
         "--replvar=abc",
         "console.log(abc)",
       ],
+      cwd: moduleDir,
       stdin: "piped",
       stdout: "piped",
       stderr: "null",
@@ -55,6 +59,7 @@ Deno.test({
 Deno.test("xevalCliSyntaxError", async function (): Promise<void> {
   const p = Deno.run({
     cmd: [Deno.execPath(), "run", xevalPath, "("],
+    cwd: moduleDir,
     stdin: "null",
     stdout: "piped",
     stderr: "piped",


### PR DESCRIPTION
This makes std/example tests runnable from any directory by resolving the examples module directory relative to the module directory from import.meta.url and using that as the current working directory.