### PR TITLE
fix(cli): make blocking async fs ops be internally async

### DIFF
--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -297,12 +297,21 @@ async fn op_fdatasync_async(
   state.check_unstable("Deno.fdatasync");
   let args: FdatasyncArgs = serde_json::from_value(args)?;
   let rid = args.rid as u32;
-  std_file_resource(&state, rid, |r| match r {
-    Ok(std_file) => std_file.sync_data().map_err(ErrBox::from),
-    Err(_) => Err(ErrBox::type_error(
-      "cannot sync this type of resource".to_string(),
+
+  let mut resource_table = state.resource_table.borrow_mut();
+  let resource_holder = resource_table
+    .get_mut::<StreamResourceHolder>(rid)
+    .ok_or_else(ErrBox::bad_resource_id)?;
+
+  match &mut resource_holder.resource {
+    StreamResource::FsFile(Some((file, _))) => {
+      file.sync_data().await.map_err(ErrBox::from)
+    }
+    _ => Err(ErrBox::type_error(
+      "cannot sync on this type of resource".to_string(),
     )),
-  })?;
+  }?;
+
   Ok(json!({}))
 }
 


### PR DESCRIPTION
This makes the following ops internally async via tokio::fs::File calls:

- op_fstat_async
- op_ftruncate_async
- op_seek_async
- op_fdatasync_async
- op_fsync_async

Fixes #7400 