### PR TITLE
fix: parse DENO_CERT during flag parse

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -7,6 +7,7 @@ use clap::ArgMatches;
 use clap::ArgSettings;
 use clap::SubCommand;
 use log::Level;
+use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
@@ -1267,7 +1268,10 @@ fn ca_file_arg<'a, 'b>() -> Arg<'a, 'b> {
 }
 
 fn ca_file_arg_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
-  flags.ca_file = matches.value_of("cert").map(ToOwned::to_owned);
+  flags.ca_file = matches
+    .value_of("cert")
+    .map(ToOwned::to_owned)
+    .or_else(|| env::var("DENO_CERT").ok());
 }
 
 fn unstable_arg<'a, 'b>() -> Arg<'a, 'b> {

--- a/cli/global_state.rs
+++ b/cli/global_state.rs
@@ -46,7 +46,7 @@ impl GlobalState {
     let dir = deno_dir::DenoDir::new(custom_root)?;
     let deps_cache_location = dir.root.join("deps");
     let http_cache = http_cache::HttpCache::new(&deps_cache_location);
-    let ca_file = flags.ca_file.clone().or_else(|| env::var("DENO_CERT").ok());
+    let ca_file = flags.ca_file.clone();
 
     let file_fetcher = SourceFileFetcher::new(
       http_cache,


### PR DESCRIPTION
Fixes #7409.

I am not convinced this is the right place to parse the variable, because this would make flag parsing not pure, but it is the most central place it can be done.