### PR TITLE
feat(unstable): enable importsNotUsedAsValues

### DIFF
--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -623,6 +623,7 @@ impl TsCompiler {
       "inlineSourceMap": true,
       // TODO(lucacasonato): enable this by default in 1.5.0
       "isolatedModules": unstable,
+      "importsNotUsedAsValues": if unstable { "error" } else { "remove" },
       "jsx": "react",
       "lib": lib,
       "module": "esnext",
@@ -1259,6 +1260,7 @@ pub async fn runtime_compile(
     "esModuleInterop": true,
     // TODO(lucacasonato): enable this by default in 1.5.0
     "isolatedModules": unstable,
+    "importsNotUsedAsValues": if unstable { "error" } else { "remove" },
     "jsx": "react",
     "module": "esnext",
     "sourceMap": true,

--- a/std/tsconfig_test.json
+++ b/std/tsconfig_test.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "isolatedModules": true
+    "isolatedModules": true,
+    "importsNotUsedAsValues": "error"
   }
 }


### PR DESCRIPTION
It seems that `"isolatedModules": true` does not catch all errors that can occur with a `--nocheck` emit. It looks like `"importsNotUsedAsValues": "error"` is also needed because `isolatedModules` does not catch `import { MyType } from "./file.ts";`, only type re-exports.

cc @kitsonk 