### PR TITLE
feat(cli): add a REPL option for module imports

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -725,7 +725,7 @@ pub fn main() {
       ignore,
       json,
     } => lint_command(flags, files, rules, ignore, json).boxed_local(),
-    DenoSubcommand::Repl => run_repl(flags).boxed_local(),
+    DenoSubcommand::Repl { .. } => run_repl(flags).boxed_local(),
     DenoSubcommand::Run { script } => run_command(flags, script).boxed_local(),
     DenoSubcommand::Test {
       fail_fast,

--- a/cli/ops/runtime.rs
+++ b/cli/ops/runtime.rs
@@ -24,8 +24,17 @@ fn op_start(
 ) -> Result<Value, AnyError> {
   let gs = &super::cli_state(state).global_state;
 
+  let repl = match gs.flags.subcommand {
+    DenoSubcommand::Repl { ref imports } => json!({
+      "enabled": true,
+      "imports": imports.clone(),
+    }),
+    _ => json!({
+      "enabled": false,
+    }),
+  };
+
   Ok(json!({
-    // TODO(bartlomieju): `cwd` field is not used in JS, remove?
     "args": gs.flags.argv.clone(),
     "cwd": &env::current_dir().unwrap(),
     "debugFlag": gs.flags.log_level.map_or(false, |l| l == log::Level::Debug),
@@ -33,7 +42,7 @@ fn op_start(
     "noColor": !colors::use_color(),
     "pid": std::process::id(),
     "ppid": ppid(),
-    "repl": gs.flags.subcommand == DenoSubcommand::Repl,
+    "repl": repl,
     "target": env!("TARGET"),
     "tsVersion": version::TYPESCRIPT,
     "unstableFlag": gs.flags.unstable,

--- a/cli/rt/40_repl.js
+++ b/cli/rt/40_repl.js
@@ -80,7 +80,11 @@
     return true;
   }
 
-  async function replLoop() {
+  async function replLoop(cwd, imports) {
+    for ([name, url] of imports) {
+      globalThis[name] = await import(new URL(url, `file://${cwd}/`));
+    }
+
     const { console } = globalThis;
 
     const historyFile = "deno_history.txt";

--- a/cli/rt/99_main.js
+++ b/cli/rt/99_main.js
@@ -329,8 +329,9 @@ delete Object.prototype.__proto__;
     util.log("cwd", cwd);
     util.log("args", args);
 
-    if (repl) {
-      replLoop();
+    if (repl.enabled) {
+      util.log("repl imports", repl.imports);
+      replLoop(cwd, repl.imports);
     }
   }
 


### PR DESCRIPTION
This is a work-in-progress implementation of #7425. It supports the examples in that issue exactly as written.

The general idea is `deno repl -i a=url,b=url -i c=url` gives you a list of pairs `[("a", "url"), ("b", "url"), ("c", "url")]` that the REPL implementation will resolve before starting up. Both comma-separation and flag repetition are built-in `clap` features. The `--allow-read` (and similar) flags accept only the comma-separated form, but I think it's convenient to allow multiple flags here, so if someone has an alias `foo` to `deno repl -i foo=url` they can easily run `foo -i bar=url` to add an additional import.

**TODO**:
* [ ] **Open questions**: See #7425 - the **Permissions** section is especially important.
* [ ] **Documentation**: Should this be added to the manual and/or release notes, not just the CLI help?
* [ ] **Tests**: Do we have support for tests of interactive things like the REPL?

Regarding `cargo test`, I currently can't run every test because some of them download and run a `deno` binary from the internet, which doesn't work on NixOS without a `patchelf` step.

Regarding the implementation, I wanted some advice:
1. Should I use a more semantic type than `Vec<(String, String)>` for the `imports` field?
2. Should I hide the imports feature behind `--unstable`?
3. Should we use `globalThis`? I looked into the possibility of injecting `let`/`const`/`import`-like local bindings with V8, but it currently seems quite difficult. @nayeemrmn suggested `globalThis` would be okay.
4. I'm not sure if `file://${cwd}/` is the right approach to the URL base, but it seems to make both `https://` URLs and local file paths (both absolute and relative) work perfectly, so you can do things like `deno repl -i local=./local.ts` instead of `deno repl -i "local=file://$(pwd)/local.ts"`.