### PR TITLE
test(std/http): make tests runnable from any directory

### DIFF
--- a/std/http/file_server_test.ts
+++ b/std/http/file_server_test.ts
@@ -4,9 +4,13 @@ import { BufReader } from "../io/bufio.ts";
 import { TextProtoReader } from "../textproto/mod.ts";
 import { ServerRequest } from "./server.ts";
 import { serveFile, FileServerArgs } from "./file_server.ts";
+import { resolve, dirname, join, fromFileUrl } from "../path/mod.ts";
 let fileServer: Deno.Process<Deno.RunOptions & { stdout: "piped" }>;
 
 type FileServerCfg = Omit<FileServerArgs, "_"> & { target?: string };
+
+const moduleDir = dirname(fromFileUrl(import.meta.url));
+const testdataDir = resolve(moduleDir, "testdata");
 
 async function startFileServer({
   target = ".",
@@ -19,13 +23,14 @@ async function startFileServer({
       "run",
       "--allow-read",
       "--allow-net",
-      "http/file_server.ts",
+      "file_server.ts",
       target,
       "--cors",
       "-p",
       `${port}`,
       `${dirListing ? "" : "--no-dir-listing"}`,
     ],
+    cwd: moduleDir,
     stdout: "piped",
     stderr: "null",
   });
@@ -43,8 +48,9 @@ async function startFileServerAsLibrary({}: FileServerCfg = {}): Promise<void> {
       "run",
       "--allow-read",
       "--allow-net",
-      "http/testdata/file_server_as_library.ts",
+      "testdata/file_server_as_library.ts",
     ],
+    cwd: moduleDir,
     stdout: "piped",
     stderr: "null",
   });
@@ -67,7 +73,7 @@ async function killFileServer(): Promise<void> {
 }
 
 Deno.test(
-  "file_server serveFile in ./",
+  "file_server serveFile",
   async (): Promise<void> => {
     await startFileServer();
     try {
@@ -77,7 +83,7 @@ Deno.test(
       assertEquals(res.headers.get("content-type"), "text/markdown");
       const downloadedFile = await res.text();
       const localFile = new TextDecoder().decode(
-        await Deno.readFile("README.md"),
+        await Deno.readFile(join(moduleDir, "README.md")),
       );
       assertEquals(downloadedFile, localFile);
     } finally {
@@ -87,17 +93,17 @@ Deno.test(
 );
 
 Deno.test(
-  "file_server serveFile in ./http",
+  "file_server serveFile in testdata",
   async (): Promise<void> => {
-    await startFileServer({ target: "./http" });
+    await startFileServer({ target: "./testdata" });
     try {
-      const res = await fetch("http://localhost:4507/README.md");
+      const res = await fetch("http://localhost:4507/hello.html");
       assert(res.headers.has("access-control-allow-origin"));
       assert(res.headers.has("access-control-allow-headers"));
-      assertEquals(res.headers.get("content-type"), "text/markdown");
+      assertEquals(res.headers.get("content-type"), "text/html");
       const downloadedFile = await res.text();
       const localFile = new TextDecoder().decode(
-        await Deno.readFile("./http/README.md"),
+        await Deno.readFile(join(testdataDir, "hello.html")),
       );
       assertEquals(downloadedFile, localFile);
     } finally {
@@ -144,12 +150,12 @@ Deno.test("serveFallback", async function (): Promise<void> {
 Deno.test("serveWithUnorthodoxFilename", async function (): Promise<void> {
   await startFileServer();
   try {
-    let res = await fetch("http://localhost:4507/http/testdata/%");
+    let res = await fetch("http://localhost:4507/testdata/%");
     assert(res.headers.has("access-control-allow-origin"));
     assert(res.headers.has("access-control-allow-headers"));
     assertEquals(res.status, 200);
     let _ = await res.text();
-    res = await fetch("http://localhost:4507/http/testdata/test%20file.txt");
+    res = await fetch("http://localhost:4507/testdata/test%20file.txt");
     assert(res.headers.has("access-control-allow-origin"));
     assert(res.headers.has("access-control-allow-headers"));
     assertEquals(res.status, 200);
@@ -167,9 +173,10 @@ Deno.test("printHelp", async function (): Promise<void> {
       // TODO(ry) It ought to be possible to get the help output without
       // --allow-read.
       "--allow-read",
-      "http/file_server.ts",
+      "file_server.ts",
       "--help",
     ],
+    cwd: moduleDir,
     stdout: "piped",
   });
   assert(helpProcess.stdout != null);
@@ -182,7 +189,7 @@ Deno.test("printHelp", async function (): Promise<void> {
 
 Deno.test("contentType", async () => {
   const request = new ServerRequest();
-  const response = await serveFile(request, "http/testdata/hello.html");
+  const response = await serveFile(request, join(testdataDir, "hello.html"));
   const contentType = response.headers!.get("content-type");
   assertEquals(contentType, "text/html");
   (response.body as Deno.File).close();
@@ -208,18 +215,19 @@ async function startTlsFileServer({
       "run",
       "--allow-read",
       "--allow-net",
-      "http/file_server.ts",
+      "file_server.ts",
       target,
       "--host",
       "localhost",
       "--cert",
-      "./http/testdata/tls/localhost.crt",
+      "./testdata/tls/localhost.crt",
       "--key",
-      "./http/testdata/tls/localhost.key",
+      "./testdata/tls/localhost.key",
       "--cors",
       "-p",
       `${port}`,
     ],
+    cwd: moduleDir,
     stdout: "piped",
     stderr: "null",
   });
@@ -237,12 +245,12 @@ Deno.test("serveDirectory TLS", async function (): Promise<void> {
     const conn = await Deno.connectTls({
       hostname: "localhost",
       port: 4577,
-      certFile: "./http/testdata/tls/RootCA.pem",
+      certFile: join(testdataDir, "tls/RootCA.pem"),
     });
 
     await Deno.writeAll(
       conn,
-      new TextEncoder().encode("GET /http HTTP/1.0\r\n\r\n"),
+      new TextEncoder().encode("GET / HTTP/1.0\r\n\r\n"),
     );
     const res = new Uint8Array(128 * 1024);
     const nread = await conn.read(res);
@@ -262,15 +270,16 @@ Deno.test("partial TLS arguments fail", async function (): Promise<void> {
       "run",
       "--allow-read",
       "--allow-net",
-      "http/file_server.ts",
+      "file_server.ts",
       ".",
       "--host",
       "localhost",
       "--cert",
-      "./http/testdata/tls/localhost.crt",
+      "./testdata/g/tls/localhost.crt",
       "-p",
       `4578`,
     ],
+    cwd: moduleDir,
     stdout: "piped",
     stderr: "null",
   });

--- a/std/http/file_server_test.ts
+++ b/std/http/file_server_test.ts
@@ -275,7 +275,7 @@ Deno.test("partial TLS arguments fail", async function (): Promise<void> {
       "--host",
       "localhost",
       "--cert",
-      "./testdata/g/tls/localhost.crt",
+      "./testdata/tls/localhost.crt",
       "-p",
       `4578`,
     ],

--- a/std/http/racing_server_test.ts
+++ b/std/http/racing_server_test.ts
@@ -1,11 +1,15 @@
 import { assert, assertEquals } from "../testing/asserts.ts";
 import { BufReader, BufWriter } from "../io/bufio.ts";
 import { TextProtoReader } from "../textproto/mod.ts";
+import { dirname, fromFileUrl } from "../path/mod.ts";
+
+const moduleDir = dirname(fromFileUrl(import.meta.url));
 
 let server: Deno.Process<Deno.RunOptions & { stdout: "piped" }>;
 async function startServer(): Promise<void> {
   server = Deno.run({
-    cmd: [Deno.execPath(), "run", "-A", "http/racing_server.ts"],
+    cmd: [Deno.execPath(), "run", "-A", "racing_server.ts"],
+    cwd: moduleDir,
     stdout: "piped",
   });
   // Once racing server is ready it will write to its stdout.

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -25,6 +25,10 @@ import { BufReader, BufWriter } from "../io/bufio.ts";
 import { delay } from "../async/delay.ts";
 import { encode, decode } from "../encoding/utf8.ts";
 import { mockConn } from "./_mock_conn.ts";
+import { resolve, dirname, join, fromFileUrl } from "../path/mod.ts";
+
+const moduleDir = dirname(fromFileUrl(import.meta.url));
+const testdataDir = resolve(moduleDir, "testdata");
 
 interface ResponseTest {
   response: Response;
@@ -367,8 +371,9 @@ Deno.test({
         Deno.execPath(),
         "run",
         "--allow-net",
-        "http/testdata/simple_server.ts",
+        "testdata/simple_server.ts",
       ],
+      cwd: moduleDir,
       stdout: "piped",
     });
 
@@ -412,8 +417,9 @@ Deno.test({
         "run",
         "--allow-net",
         "--allow-read",
-        "http/testdata/simple_https_server.ts",
+        "testdata/simple_https_server.ts",
       ],
+      cwd: moduleDir,
       stdout: "piped",
     });
 
@@ -436,7 +442,7 @@ Deno.test({
       const conn = await Deno.connectTls({
         hostname: "localhost",
         port: 4503,
-        certFile: "http/testdata/tls/RootCA.pem",
+        certFile: join(testdataDir, "tls/RootCA.pem"),
       });
       await Deno.writeAll(
         conn,
@@ -570,8 +576,8 @@ Deno.test({
     const tlsOptions = {
       hostname: "localhost",
       port,
-      certFile: "./http/testdata/tls/localhost.crt",
-      keyFile: "./http/testdata/tls/localhost.key",
+      certFile: join(testdataDir, "tls/localhost.crt"),
+      keyFile: join(testdataDir, "tls/localhost.key"),
     };
     const server = serveTLS(tlsOptions);
     const p = iteratorReq(server);
@@ -593,7 +599,7 @@ Deno.test({
       const conn = await Deno.connectTls({
         hostname: "localhost",
         port,
-        certFile: "http/testdata/tls/RootCA.pem",
+        certFile: join(testdataDir, "tls/RootCA.pem"),
       });
 
       await Deno.writeAll(

--- a/std/http/testdata/file_server_as_library.ts
+++ b/std/http/testdata/file_server_as_library.ts
@@ -3,10 +3,10 @@ import { serveFile } from "../file_server.ts";
 
 const server = serve({ port: 8000 });
 
-console.log('Server running...');
+console.log("Server running...");
 
 for await (const req of server) {
-  serveFile(req, './http/testdata/hello.html').then(response => {
+  serveFile(req, "./testdata/hello.html").then((response) => {
     req.respond(response);
   });
 }

--- a/std/http/testdata/simple_https_server.ts
+++ b/std/http/testdata/simple_https_server.ts
@@ -5,12 +5,12 @@ import { serveTLS } from "../server.ts";
 const tlsOptions = {
   hostname: "localhost",
   port: 4503,
-  certFile: "./http/testdata/tls/localhost.crt",
-  keyFile: "./http/testdata/tls/localhost.key"
+  certFile: "./testdata/tls/localhost.crt",
+  keyFile: "./testdata/tls/localhost.key",
 };
 const s = serveTLS(tlsOptions);
 console.log(
-  `Simple HTTPS server listening on ${tlsOptions.hostname}:${tlsOptions.port}`
+  `Simple HTTPS server listening on ${tlsOptions.hostname}:${tlsOptions.port}`,
 );
 const body = new TextEncoder().encode("Hello HTTPS");
 for await (const req of s) {


### PR DESCRIPTION
This makes std/http tests runnable from any directory by spawning test processes in the module directory resolved from import.meta.url and resolving test data relative to the same module directory.