### PR TITLE
chore: add no_check_hello benchmark

### DIFF
--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -42,6 +42,11 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
     None,
   ),
   (
+    "no_check_hello",
+    &["run", "--reload", "--no-check", "cli/tests/002_hello.ts"],
+    None,
+  ),
+  (
     "workers_startup",
     &["run", "--allow-read", "cli/tests/workers_startup_bench.ts"],
     None,


### PR DESCRIPTION
While we have the _TypeScript Performance_ section in the benchmarks, it does make it slightly challenging to compare the "raw" situation of what the delta is between `"hello"`, `"cold_hello"` with the `--no-check` option.  This PR adds the `"no_check_hello"` benchmark to be able to make the comparison.