### PR TITLE
BREAKING(std/datetime): fix typo miliseconds -> milliseconds

### DIFF
--- a/std/datetime/mod.ts
+++ b/std/datetime/mod.ts
@@ -133,7 +133,7 @@ export function isLeap(year: Date | number): boolean {
 }
 
 export type Unit =
-  | "miliseconds"
+  | "milliseconds"
   | "seconds"
   | "minutes"
   | "hours"
@@ -167,7 +167,7 @@ export function difference(
   options?: DifferenceOptions,
 ): DifferenceFormat {
   const uniqueUnits = options?.units ? [...new Set(options?.units)] : [
-    "miliseconds",
+    "milliseconds",
     "seconds",
     "minutes",
     "hours",
@@ -186,8 +186,8 @@ export function difference(
 
   for (const uniqueUnit of uniqueUnits) {
     switch (uniqueUnit) {
-      case "miliseconds":
-        differences.miliseconds = differenceInMs;
+      case "milliseconds":
+        differences.milliseconds = differenceInMs;
         break;
       case "seconds":
         differences.seconds = Math.floor(differenceInMs / SECOND);

--- a/std/datetime/test.ts
+++ b/std/datetime/test.ts
@@ -284,9 +284,9 @@ Deno.test({
     const birth = new Date("1998/2/23 10:10:10");
     const old = new Date("1998/2/23 11:11:11");
     difference = datetime.difference(birth, old, {
-      units: ["miliseconds", "minutes", "seconds", "hours"],
+      units: ["milliseconds", "minutes", "seconds", "hours"],
     });
-    assertEquals(difference.miliseconds, 3661000);
+    assertEquals(difference.milliseconds, 3661000);
     assertEquals(difference.seconds, 3661);
     assertEquals(difference.minutes, 61);
     assertEquals(difference.hours, 1);

--- a/std/encoding/_yaml/type/timestamp.ts
+++ b/std/encoding/_yaml/type/timestamp.ts
@@ -70,7 +70,7 @@ function constructYamlTimestamp(data: string): Date {
   if (match[9]) {
     const tzHour = +match[10];
     const tzMinute = +(match[11] || 0);
-    delta = (tzHour * 60 + tzMinute) * 60000; // delta in mili-seconds
+    delta = (tzHour * 60 + tzMinute) * 60000; // delta in milli-seconds
     if (match[9] === "-") delta = -delta;
   }
 


### PR DESCRIPTION
## Summary

This PR fixes typo in time unit (miliseconds -> milliseconds)
The original issue is #7460 by @tgfrerer 

All existing tests in `cargo test` passed.

## Breaking changes
### type
 - [std/datetime] Unit
 - [std/datetime] DifferenceFormat
 - [std/datetime] DifferenceOptions
### function
 - [std/datetime] difference

## Impacted test
 - [std/datetime] difference ( `std/datetime/test.ts` )
