### PR TITLE
BREAKING(std/uuid): remove stub implementation of v3

### DIFF
--- a/std/uuid/mod.ts
+++ b/std/uuid/mod.ts
@@ -10,16 +10,4 @@ export function isNil(val: string): boolean {
   return val === NIL_UUID;
 }
 
-const NOT_IMPLEMENTED = {
-  generate(): never {
-    throw new Error("Not implemented");
-  },
-  validate(): never {
-    throw new Error("Not implemented");
-  },
-};
-
-// TODO Implement
-export const v3 = NOT_IMPLEMENTED;
-
 export { v1, v4, v5 };


### PR DESCRIPTION
This removes a "not implemented" stub of uuid v3.