### PR TITLE
feat: add alert, confirm, and prompt

### DIFF
--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -977,3 +977,24 @@ declare class WebSocket extends EventTarget {
 }
 
 type BinaryType = "arraybuffer" | "blob";
+
+/**
+ * Shows the given message and waits for the enter key pressed.
+ * @param message
+ */
+declare function alert(message?: string): void;
+
+/**
+ * Shows the given message and waits for the answer. Returns the user's answer as boolean.
+ * @param message
+ */
+declare function confirm(message?: string): boolean;
+
+/**
+ * Shows the given message and waits for the user's input. Returns the user's input as string.
+ * If the default value is given and the user inputs the empty string, then it returns the given
+ * default value.
+ * @param message
+ * @param defaultValue
+ */
+declare function prompt(message?: string, defaultValue?: string): string;

--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -997,4 +997,4 @@ declare function confirm(message?: string): boolean;
  * @param message
  * @param defaultValue
  */
-declare function prompt(message?: string, defaultValue?: string): string;
+declare function prompt(message?: string, defaultValue?: string): string | null;

--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -977,24 +977,3 @@ declare class WebSocket extends EventTarget {
 }
 
 type BinaryType = "arraybuffer" | "blob";
-
-/**
- * Shows the given message and waits for the enter key pressed.
- * @param message
- */
-declare function alert(message?: string): void;
-
-/**
- * Shows the given message and waits for the answer. Returns the user's answer as boolean.
- * @param message
- */
-declare function confirm(message?: string): boolean;
-
-/**
- * Shows the given message and waits for the user's input. Returns the user's input as string.
- * If the default value is given and the user inputs the empty string, then it returns the given
- * default value.
- * @param message
- * @param defaultValue
- */
-declare function prompt(message?: string, defaultValue?: string): string | null;

--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -28,12 +28,14 @@ declare var onunload: ((this: Window, ev: Event) => any) | null;
 
 /**
  * Shows the given message and waits for the enter key pressed.
+ * If the stdin is not interactive, it does nothing.
  * @param message
  */
 declare function alert(message?: string): void;
 
 /**
  * Shows the given message and waits for the answer. Returns the user's answer as boolean.
+ * If the stdin is not interactive, it returns false.
  * @param message
  */
 declare function confirm(message?: string): boolean;
@@ -42,6 +44,8 @@ declare function confirm(message?: string): boolean;
  * Shows the given message and waits for the user's input. Returns the user's input as string.
  * If the default value is given and the user inputs the empty string, then it returns the given
  * default value.
+ * If the default value is not given and the user inputs the empty string, it returns null.
+ * If the stdin is not interactive, it returns null.
  * @param message
  * @param defaultValue
  */

--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -17,7 +17,7 @@ declare class Window extends EventTarget {
   readonly closed: boolean;
   alert: (message?: string) => void;
   confirm: (message?: string) => boolean;
-  prompt: (message?: string, defaultValue?: string) => string;
+  prompt: (message?: string, defaultValue?: string) => string | null;
   Deno: typeof Deno;
 }
 

--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -15,6 +15,9 @@ declare class Window extends EventTarget {
   onunload: ((this: Window, ev: Event) => any) | null;
   close: () => void;
   readonly closed: boolean;
+  alert: (message?: string) => void;
+  confirm: (message?: string) => boolean;
+  prompt: (message?: string, defaultValue?: string) => string;
   Deno: typeof Deno;
 }
 

--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -26,4 +26,25 @@ declare var self: Window & typeof globalThis;
 declare var onload: ((this: Window, ev: Event) => any) | null;
 declare var onunload: ((this: Window, ev: Event) => any) | null;
 
+/**
+ * Shows the given message and waits for the enter key pressed.
+ * @param message
+ */
+declare function alert(message?: string): void;
+
+/**
+ * Shows the given message and waits for the answer. Returns the user's answer as boolean.
+ * @param message
+ */
+declare function confirm(message?: string): boolean;
+
+/**
+ * Shows the given message and waits for the user's input. Returns the user's input as string.
+ * If the default value is given and the user inputs the empty string, then it returns the given
+ * default value.
+ * @param message
+ * @param defaultValue
+ */
+declare function prompt(message?: string, defaultValue?: string): string | null;
+
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -35,6 +35,7 @@ declare function alert(message?: string): void;
 
 /**
  * Shows the given message and waits for the answer. Returns the user's answer as boolean.
+ * Only `y` and `Y` are considered as true.
  * If the stdin is not interactive, it returns false.
  * @param message
  */

--- a/cli/rt/41_prompt.js
+++ b/cli/rt/41_prompt.js
@@ -32,7 +32,7 @@
     defaultValue ??= null;
 
     if (!isatty(stdin.rid)) {
-      return defaultValue;
+      return null;
     }
 
     stdout.writeSync(encoder.encode(`${message} `));

--- a/cli/rt/41_prompt.js
+++ b/cli/rt/41_prompt.js
@@ -6,50 +6,36 @@
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
 
-  function alert(message) {
+  function alert(message = "Alert") {
     if (!isatty(stdin.rid)) {
-      throw new Error(
-        "stdin is not interactive. 'alert' needs stdin to be interactive.",
-      );
+      return;
     }
 
-    if (message) {
-      stdout.writeSync(encoder.encode(message));
-    }
+    stdout.writeSync(encoder.encode(`${message} [Enter] `));
 
     readLineFromStdinSync();
   }
 
-  function confirm(message) {
+  function confirm(message = "Confirm") {
     if (!isatty(stdin.rid)) {
-      throw new Error(
-        "stdin is not interactive. 'confirm' needs stdin to be interactive.",
-      );
+      return false;
     }
 
-    if (message) {
-      stdout.writeSync(encoder.encode(message));
-    }
-
-    stdout.writeSync(encoder.encode(" [y/N] "));
+    stdout.writeSync(encoder.encode(`${message} [y/N] `));
 
     const answer = readLineFromStdinSync();
 
     return answer === "Y" || answer === "y";
   }
 
-  function prompt(message, defaultValue = "") {
+  function prompt(message = "Prompt", defaultValue) {
+    defaultValue ??= null;
+
     if (!isatty(stdin.rid)) {
-      throw new Error(
-        "stdin is not interactive. 'prompt' needs stdin to be interactive.",
-      );
+      return defaultValue;
     }
 
-    if (message) {
-      stdout.writeSync(encoder.encode(message));
-    }
-
-    stdout.writeSync(encoder.encode(" "));
+    stdout.writeSync(encoder.encode(`${message} `));
 
     if (defaultValue) {
       stdout.writeSync(encoder.encode(`[${defaultValue}] `));

--- a/cli/rt/41_prompt.js
+++ b/cli/rt/41_prompt.js
@@ -1,0 +1,80 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+((window) => {
+  const { stdin, stdout } = window.__bootstrap.files;
+  const { isatty } = window.__bootstrap.tty;
+  const LF = "\n".charCodeAt(0);
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  function alert(message) {
+    if (!isatty(stdin.rid)) {
+      throw new Error(
+        "stdin is not interactive. 'alert' needs stdin to be interactive.",
+      );
+    }
+
+    if (message) {
+      stdout.writeSync(encoder.encode(message));
+    }
+
+    readLineFromStdinSync();
+  }
+
+  function confirm(message) {
+    if (!isatty(stdin.rid)) {
+      throw new Error(
+        "stdin is not interactive. 'confirm' needs stdin to be interactive.",
+      );
+    }
+
+    if (message) {
+      stdout.writeSync(encoder.encode(message));
+    }
+
+    stdout.writeSync(encoder.encode(" [y/N] "));
+
+    const answer = readLineFromStdinSync();
+
+    return answer === "Y" || answer === "y";
+  }
+
+  function prompt(message, defaultValue = "") {
+    if (!isatty(stdin.rid)) {
+      throw new Error(
+        "stdin is not interactive. 'prompt' needs stdin to be interactive.",
+      );
+    }
+
+    if (message) {
+      stdout.writeSync(encoder.encode(message));
+    }
+
+    stdout.writeSync(encoder.encode(" "));
+
+    if (defaultValue) {
+      stdout.writeSync(encoder.encode(`[${defaultValue}] `));
+    }
+
+    return readLineFromStdinSync() || defaultValue;
+  }
+
+  function readLineFromStdinSync() {
+    const c = new Uint8Array(1);
+    const buf = [];
+
+    while (true) {
+      const n = stdin.readSync(c);
+      if (n === 0 || c[0] === LF) {
+        break;
+      }
+      buf.push(c[0]);
+    }
+    return decoder.decode(new Uint8Array(buf));
+  }
+
+  window.__bootstrap.prompt = {
+    alert,
+    confirm,
+    prompt,
+  };
+})(this);

--- a/cli/rt/99_main.js
+++ b/cli/rt/99_main.js
@@ -27,6 +27,7 @@ delete Object.prototype.__proto__;
   const fileReader = window.__bootstrap.fileReader;
   const webSocket = window.__bootstrap.webSocket;
   const fetch = window.__bootstrap.fetch;
+  const prompt = window.__bootstrap.prompt;
   const denoNs = window.__bootstrap.denoNs;
   const denoNsUnstable = window.__bootstrap.denoNsUnstable;
   const errors = window.__bootstrap.errors.errors;
@@ -285,6 +286,9 @@ delete Object.prototype.__proto__;
     onunload: util.writable(null),
     close: util.writable(windowClose),
     closed: util.getterOnly(() => windowIsClosing),
+    alert: util.writable(prompt.alert),
+    confirm: util.writable(prompt.confirm),
+    prompt: util.writable(prompt.prompt),
   };
 
   const workerRuntimeGlobalProperties = {

--- a/cli/tests/066_prompt.ts
+++ b/cli/tests/066_prompt.ts
@@ -1,0 +1,12 @@
+const name0 = prompt("What is your name?", "Jane Doe"); // Answer John Doe
+console.log(`Your name is ${name0}.`);
+const name1 = prompt("What is your name?", "Jane Doe"); // Answer with default
+console.log(`Your name is ${name1}.`);
+const answer0 = confirm("Question 0"); // Answer y
+console.log(`Your answer is ${answer0}`);
+const answer1 = confirm("Question 1"); // Answer n
+console.log(`Your answer is ${answer1}`);
+const answer2 = confirm("Question 2"); // Answer with default
+console.log(`Your answer is ${answer2}`);
+alert("Hi"); // Requires the enter key pressed
+console.log("The end of test");

--- a/cli/tests/066_prompt.ts
+++ b/cli/tests/066_prompt.ts
@@ -8,7 +8,7 @@ const answer0 = confirm("Question 0"); // Answer y
 console.log(`Your answer is ${answer0}`);
 const answer1 = confirm("Question 1"); // Answer n
 console.log(`Your answer is ${answer1}`);
-const answer2 = confirm("Question 2"); // Answer with default
+const answer2 = confirm("Question 2"); // Answer with yes (returns false)
 console.log(`Your answer is ${answer2}`);
 const answer3 = confirm(); // Answer with default
 console.log(`Your answer is ${answer3}`);

--- a/cli/tests/066_prompt.ts
+++ b/cli/tests/066_prompt.ts
@@ -2,11 +2,16 @@ const name0 = prompt("What is your name?", "Jane Doe"); // Answer John Doe
 console.log(`Your name is ${name0}.`);
 const name1 = prompt("What is your name?", "Jane Doe"); // Answer with default
 console.log(`Your name is ${name1}.`);
+const input = prompt(); // Answer foo
+console.log(`Your input is ${input}.`);
 const answer0 = confirm("Question 0"); // Answer y
 console.log(`Your answer is ${answer0}`);
 const answer1 = confirm("Question 1"); // Answer n
 console.log(`Your answer is ${answer1}`);
 const answer2 = confirm("Question 2"); // Answer with default
 console.log(`Your answer is ${answer2}`);
-alert("Hi"); // Requires the enter key pressed
+const answer3 = confirm(); // Answer with default
+console.log(`Your answer is ${answer3}`);
+alert("Hi");
+alert();
 console.log("The end of test");

--- a/cli/tests/066_prompt.ts.out
+++ b/cli/tests/066_prompt.ts.out
@@ -1,6 +1,8 @@
 [WILDCARD]What is your name? [Jane Doe] Your name is John Doe.
 What is your name? [Jane Doe] Your name is Jane Doe.
+Prompt Your input is foo.
 Question 0 [y/N] Your answer is true
 Question 1 [y/N] Your answer is false
 Question 2 [y/N] Your answer is false
-HiThe end of test
+Confirm [y/N] Your answer is false
+Hi [Enter] Alert [Enter] The end of test

--- a/cli/tests/066_prompt.ts.out
+++ b/cli/tests/066_prompt.ts.out
@@ -1,0 +1,6 @@
+[WILDCARD]What is your name? [Jane Doe] Your name is John Doe.
+What is your name? [Jane Doe] Your name is Jane Doe.
+Question 0 [y/N] Your answer is true
+Question 1 [y/N] Your answer is false
+Question 2 [y/N] Your answer is false
+HiThe end of test

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1923,7 +1923,7 @@ fn _066_prompt() {
   let args = "run --unstable 066_prompt.ts";
   let output = "066_prompt.ts.out";
   // These are answers to prompt, confirm, and alert calls.
-  let input = b"John Doe\n\nfoo\nY\nN\n\n\n\n\n";
+  let input = b"John Doe\n\nfoo\nY\nN\nyes\n\n\n\n";
 
   util::test_pty(args, output, input);
 }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1917,6 +1917,17 @@ itest!(_065_import_map_info {
   output: "065_import_map_info.out",
 });
 
+#[cfg(unix)]
+#[test]
+fn _066_prompt() {
+  let args = "run --unstable 066_prompt.ts";
+  let output = "066_prompt.ts.out";
+  // These are answers to prompt, confirm, and alert calls.
+  let input = b"John Doe\n\nY\nN\n\n\n";
+
+  util::test_pty(args, output, input);
+}
+
 itest!(js_import_detect {
   args: "run --quiet --reload js_import_detect.ts",
   output: "js_import_detect.ts.out",

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1923,7 +1923,7 @@ fn _066_prompt() {
   let args = "run --unstable 066_prompt.ts";
   let output = "066_prompt.ts.out";
   // These are answers to prompt, confirm, and alert calls.
-  let input = b"John Doe\n\nY\nN\n\n\n";
+  let input = b"John Doe\n\nfoo\nY\nN\n\n\n\n\n";
 
   util::test_pty(args, output, input);
 }


### PR DESCRIPTION
This PR adds `alert`, `confirm`, and `prompt` functions from [web standards](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#user-prompts).

You can write simple interaction script like the below with this change.

```ts
const name = prompt('What is your name?');
console.log(`Hello ${name}!`);
```

```console
$ ./target/debug/deno run test.ts
What is your name? John
Hello John!
```

Maybe these features are not so important for advanced users, but I think these could be very helpful for beginners of Deno or learners of the language.

---
closes #4257