### PR TITLE
ci: remove wasm target installation step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,6 @@ jobs:
         with:
           rust-version: 1.46.0
 
-      - name: Install rust targets
-        run: |
-          # Necessary for the std/wasi tests
-          rustup target add wasm32-unknown-unknown
-          rustup target add wasm32-wasi
-
       - name: Install clippy and rustfmt
         if: matrix.config.kind == 'lint'
         run: |


### PR DESCRIPTION
This removes the wasm targets from the workflow as they are no longer used for test runs.