### PR TITLE
Revert "fix(cli/http_utils): accept a single key-multiple values headers (#7375)

### DIFF
--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -215,14 +215,11 @@ mod tests {
     let cache = HttpCache::new(dir.path());
     let url = Url::parse("https://deno.land/x/welcome.ts").unwrap();
     let mut headers = HashMap::new();
-    headers
-      .entry("content-type".to_string())
-      .or_insert_with(Vec::new)
-      .push("application/javascript".to_string());
-    headers
-      .entry("etag".to_string())
-      .or_insert_with(Vec::new)
-      .push("as5625rqdsfb".to_string());
+    headers.insert(
+      "content-type".to_string(),
+      "application/javascript".to_string(),
+    );
+    headers.insert("etag".to_string(), "as5625rqdsfb".to_string());
     let content = b"Hello world";
     let r = cache.set(&url, headers, content);
     eprintln!("result {:?}", r);
@@ -234,18 +231,10 @@ mod tests {
     file.read_to_string(&mut content).unwrap();
     assert_eq!(content, "Hello world");
     assert_eq!(
-      headers
-        .get("content-type")
-        .unwrap()
-        .first()
-        .unwrap()
-        .as_str(),
+      headers.get("content-type").unwrap(),
       "application/javascript"
     );
-    assert_eq!(
-      headers.get("etag").unwrap().first().unwrap().as_str(),
-      "as5625rqdsfb"
-    );
+    assert_eq!(headers.get("etag").unwrap(), "as5625rqdsfb");
     assert_eq!(headers.get("foobar"), None);
   }
 

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -76,7 +76,10 @@ fn resolve_url_from_location(base_url: &Url, location: &str) -> Url {
   }
 }
 
-pub type HeadersMap = HashMap<String, Vec<String>>;
+// TODO(ry) HTTP headers are not unique key, value pairs. There may be more than
+// one header line with the same key. This should be changed to something like
+// Vec<(String, String)>
+pub type HeadersMap = HashMap<String, String>;
 
 #[derive(Debug, PartialEq)]
 pub enum FetchOnceResult {
@@ -109,7 +112,7 @@ pub async fn fetch_once(
     return Ok(FetchOnceResult::NotModified);
   }
 
-  let mut headers_: HashMap<String, Vec<String>> = HashMap::new();
+  let mut headers_: HashMap<String, String> = HashMap::new();
   let headers = response.headers();
 
   if let Some(warning) = headers.get("X-Deno-Warning") {
@@ -128,10 +131,7 @@ pub async fn fetch_once(
       .map(|e| e.to_str().unwrap().to_string())
       .collect::<Vec<String>>()
       .join(",");
-    headers_
-      .entry(key_str)
-      .or_insert_with(Vec::new)
-      .push(values_str);
+    headers_.insert(key_str, values_str);
   }
 
   if response.status().is_redirection() {
@@ -248,15 +248,7 @@ mod tests {
     let result = fetch_once(client, &url, None).await;
     if let Ok(FetchOnceResult::Code(body, headers)) = result {
       assert!(!body.is_empty());
-      assert_eq!(
-        headers
-          .get("content-type")
-          .unwrap()
-          .first()
-          .unwrap()
-          .as_str(),
-        "application/json"
-      );
+      assert_eq!(headers.get("content-type").unwrap(), "application/json");
       assert_eq!(headers.get("etag"), None);
       assert_eq!(headers.get("x-typescript-types"), None);
     } else {
@@ -277,12 +269,7 @@ mod tests {
     if let Ok(FetchOnceResult::Code(body, headers)) = result {
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('gzip')");
       assert_eq!(
-        headers
-          .get("content-type")
-          .unwrap()
-          .first()
-          .unwrap()
-          .as_str(),
+        headers.get("content-type").unwrap(),
         "application/javascript"
       );
       assert_eq!(headers.get("etag"), None);
@@ -302,18 +289,10 @@ mod tests {
       assert!(!body.is_empty());
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('etag')");
       assert_eq!(
-        headers
-          .get("content-type")
-          .unwrap()
-          .first()
-          .unwrap()
-          .as_str(),
+        headers.get("content-type").unwrap(),
         "application/typescript"
       );
-      assert_eq!(
-        headers.get("etag").unwrap().first().unwrap().as_str(),
-        "33a64df551425fcc55e"
-      );
+      assert_eq!(headers.get("etag").unwrap(), "33a64df551425fcc55e");
     } else {
       panic!();
     }
@@ -337,12 +316,7 @@ mod tests {
       assert!(!body.is_empty());
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('brotli');");
       assert_eq!(
-        headers
-          .get("content-type")
-          .unwrap()
-          .first()
-          .unwrap()
-          .as_str(),
+        headers.get("content-type").unwrap(),
         "application/javascript"
       );
       assert_eq!(headers.get("etag"), None);
@@ -425,15 +399,7 @@ mod tests {
     let result = fetch_once(client, &url, None).await;
     if let Ok(FetchOnceResult::Code(body, headers)) = result {
       assert!(!body.is_empty());
-      assert_eq!(
-        headers
-          .get("content-type")
-          .unwrap()
-          .first()
-          .unwrap()
-          .as_str(),
-        "application/json"
-      );
+      assert_eq!(headers.get("content-type").unwrap(), "application/json");
       assert_eq!(headers.get("etag"), None);
       assert_eq!(headers.get("x-typescript-types"), None);
     } else {
@@ -460,12 +426,7 @@ mod tests {
     if let Ok(FetchOnceResult::Code(body, headers)) = result {
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('gzip')");
       assert_eq!(
-        headers
-          .get("content-type")
-          .unwrap()
-          .first()
-          .unwrap()
-          .as_str(),
+        headers.get("content-type").unwrap(),
         "application/javascript"
       );
       assert_eq!(headers.get("etag"), None);
@@ -491,18 +452,10 @@ mod tests {
       assert!(!body.is_empty());
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('etag')");
       assert_eq!(
-        headers
-          .get("content-type")
-          .unwrap()
-          .first()
-          .unwrap()
-          .as_str(),
+        headers.get("content-type").unwrap(),
         "application/typescript"
       );
-      assert_eq!(
-        headers.get("etag").unwrap().first().unwrap().as_str(),
-        "33a64df551425fcc55e"
-      );
+      assert_eq!(headers.get("etag").unwrap(), "33a64df551425fcc55e");
       assert_eq!(headers.get("x-typescript-types"), None);
     } else {
       panic!();
@@ -533,12 +486,7 @@ mod tests {
       assert!(!body.is_empty());
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('brotli');");
       assert_eq!(
-        headers
-          .get("content-type")
-          .unwrap()
-          .first()
-          .unwrap()
-          .as_str(),
+        headers.get("content-type").unwrap(),
         "application/javascript"
       );
       assert_eq!(headers.get("etag"), None);


### PR DESCRIPTION
This reverts commit f5c84920c225579af9c249bdac4a59a046ef8683.

CC @tokiedokie 

This patch caused failures in `deno info`
```
▶ cargo run info --unstable https://deno.land/x/oak@v6.1.0/types.d.ts
   Compiling deno_core v0.57.0 (/Users/biwanczuk/dev/deno/core)
   Compiling deno_web v0.8.0 (/Users/biwanczuk/dev/deno/op_crates/web)
   Compiling deno v1.4.0 (/Users/biwanczuk/dev/deno/cli)
    Finished dev [unoptimized + debuginfo] target(s) in 57.31s
     Running `target/debug/deno info --unstable 'https://deno.land/x/oak@v6.1.0/types.d.ts'`
error: invalid type: string "Mon, 31 Aug 2020 04:12:40 GMT", expected a sequence at line 3 column 52
```

Probable cause: storing list of header values in `headers.json` file instead of a single value.