### PR TITLE
Revert "feat(install): bundle before installation (#5276)"

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -201,7 +201,14 @@ async fn install_command(
   root: Option<PathBuf>,
   force: bool,
 ) -> Result<(), AnyError> {
-  installer::install(flags, &module_url, args, name, root, force).await
+  // First, fetch and compile the module; this step ensures that the module exists.
+  let mut fetch_flags = flags.clone();
+  fetch_flags.reload = true;
+  let global_state = GlobalState::new(fetch_flags)?;
+  let main_module = ModuleSpecifier::resolve_url_or_path(&module_url)?;
+  let mut worker = MainWorker::create(&global_state, main_module.clone())?;
+  worker.preload_module(&main_module).await?;
+  installer::install(flags, &module_url, args, name, root, force)
 }
 
 async fn lint_command(


### PR DESCRIPTION
This reverts the changes introduced by PR #5276, which made
`deno install «script»` automatically bundle the script's dependencies.
It broke the `deno install` command for a large number of scripts.

This reverts commit 34e98fa59cd70f7ce64e587bef41fac536a3076b.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
