### PR TITLE
Re-export deno_core::url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
- "url",
  "uuid",
  "walkdir",
  "warp",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,7 +41,7 @@ dissimilar = "1.0.2"
 dlopen = "0.1.8"
 encoding_rs = "0.8.24"
 dprint-plugin-typescript = "0.31.3"
-futures = "0.3.5"
+futures = "0.3.5" # TODO(ry) Remove and use deno_core::futures
 filetime = "0.2.12"
 http = "0.2.1"
 idna = "0.2.0"
@@ -58,7 +58,7 @@ reqwest = { version = "0.10.8", default-features = false, features = ["rustls-tl
 ring = "0.16.15"
 rustyline = { version = "6.3.0", default-features = false }
 serde = { version = "1.0.116", features = ["derive"] }
-serde_json = { version = "1.0.57", features = [ "preserve_order" ] }
+serde_json = { version = "1.0.57", features = [ "preserve_order" ] } # TODO(ry) Remove and use deno_core::serde_json
 sys-info = "0.7.0"
 sourcemap = "6.0.1"
 swc_common = { version = "=0.10.2", features = ["sourcemap"] }
@@ -69,7 +69,6 @@ tokio = { version = "0.2.22", features = ["full"] }
 tokio-rustls = "0.14.1"
 # Keep in-sync with warp.
 tokio-tungstenite = "0.11.0"
-url = "2.1.1"
 webpki = "0.21.3"
 webpki-roots = "=0.19.0" # Pinned to v0.19.0 to match 'reqwest'. 
 walkdir = "2.3.1"

--- a/cli/coverage.rs
+++ b/cli/coverage.rs
@@ -7,6 +7,7 @@ use crate::inspector::DenoInspector;
 use crate::permissions::Permissions;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
+use deno_core::url::Url;
 use deno_core::v8;
 use deno_core::ModuleSpecifier;
 use serde::Deserialize;
@@ -16,7 +17,6 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 use std::ptr;
 use std::sync::Arc;
-use deno_core::url::Url;
 
 pub struct CoverageCollector {
   v8_channel: v8::inspector::ChannelBase,

--- a/cli/coverage.rs
+++ b/cli/coverage.rs
@@ -16,7 +16,7 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 use std::ptr;
 use std::sync::Arc;
-use url::Url;
+use deno_core::url::Url;
 
 pub struct CoverageCollector {
   v8_channel: v8::inspector::ChannelBase,

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::path::Prefix;
 use std::str;
-use url::{Host, Url};
+use deno_core::url::{Host, Url};
 
 #[derive(Clone)]
 pub struct DiskCache {

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -1,5 +1,6 @@
 use crate::fs as deno_fs;
 use crate::http_cache::url_to_filename;
+use deno_core::url::{Host, Url};
 use std::ffi::OsStr;
 use std::fs;
 use std::io;
@@ -8,7 +9,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::path::Prefix;
 use std::str;
-use deno_core::url::{Host, Url};
 
 #[derive(Clone)]
 pub struct DiskCache {

--- a/cli/errors.rs
+++ b/cli/errors.rs
@@ -12,6 +12,7 @@
 use crate::ast::DiagnosticBuffer;
 use crate::import_map::ImportMapError;
 use deno_core::error::AnyError;
+use deno_core::url;
 use deno_core::ModuleResolutionError;
 use rustyline::error::ReadlineError;
 use std::env;

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -12,6 +12,8 @@ use deno_core::error::custom_error;
 use deno_core::error::generic_error;
 use deno_core::error::uri_error;
 use deno_core::error::AnyError;
+use deno_core::url;
+use deno_core::url::Url;
 use deno_core::ModuleSpecifier;
 use futures::future::FutureExt;
 use log::info;
@@ -27,7 +29,6 @@ use std::result::Result;
 use std::str;
 use std::sync::Arc;
 use std::sync::Mutex;
-use url::Url;
 
 /// Structure representing a text document.
 #[derive(Debug, Clone)]

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1525,7 +1525,7 @@ fn permission_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 // TODO(ry) move this to utility module and add test.
 /// Strips fragment part of URL. Panics on bad URL.
 pub fn resolve_urls(urls: Vec<String>) -> Vec<String> {
-  use url::Url;
+  use deno_core::url::Url;
   let mut out: Vec<String> = vec![];
   for urlstr in urls.iter() {
     use std::str::FromStr;

--- a/cli/flags_allow_net.rs
+++ b/cli/flags_allow_net.rs
@@ -1,6 +1,6 @@
+use deno_core::url::Url;
 use std::net::IpAddr;
 use std::str::FromStr;
-use deno_core::url::Url;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ParsePortError(String);

--- a/cli/flags_allow_net.rs
+++ b/cli/flags_allow_net.rs
@@ -1,6 +1,6 @@
 use std::net::IpAddr;
 use std::str::FromStr;
-use url::Url;
+use deno_core::url::Url;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ParsePortError(String);

--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -7,6 +7,7 @@
 use crate::fs as deno_fs;
 use crate::http_util::HeadersMap;
 use deno_core::error::AnyError;
+use deno_core::url::Url;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fs;
@@ -14,7 +15,6 @@ use std::fs::File;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
-use deno_core::url::Url;
 
 /// Turn base of url (scheme, hostname, port) into a valid filename.
 /// This method replaces port part with a special string token (because

--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -14,7 +14,7 @@ use std::fs::File;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
-use url::Url;
+use deno_core::url::Url;
 
 /// Turn base of url (scheme, hostname, port) into a valid filename.
 /// This method replaces port part with a special string token (because

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -23,7 +23,7 @@ use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 use tokio::io::AsyncRead;
-use url::Url;
+use deno_core::url::Url;
 
 /// Create new instance of async reqwest::Client. This client supports
 /// proxies and doesn't follow redirects.

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -4,6 +4,7 @@ use crate::version;
 use bytes::Bytes;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
+use deno_core::url::Url;
 use reqwest::header::HeaderMap;
 use reqwest::header::HeaderValue;
 use reqwest::header::IF_NONE_MATCH;
@@ -23,7 +24,6 @@ use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 use tokio::io::AsyncRead;
-use deno_core::url::Url;
 
 /// Create new instance of async reqwest::Client. This client supports
 /// proxies and doesn't follow redirects.

--- a/cli/import_map.rs
+++ b/cli/import_map.rs
@@ -1,4 +1,5 @@
 use deno_core::error::AnyError;
+use deno_core::url::Url;
 use deno_core::ModuleSpecifier;
 use indexmap::IndexMap;
 use serde_json::Map;
@@ -8,7 +9,6 @@ use std::error::Error;
 use std::fmt;
 use std::fs;
 use std::io;
-use url::Url;
 
 #[derive(Debug)]
 pub struct ImportMapError {

--- a/cli/info.rs
+++ b/cli/info.rs
@@ -408,6 +408,7 @@ mod test {
   use crate::ast::Location;
   use crate::media_type::MediaType;
   use crate::module_graph::ImportDescriptor;
+  use deno_core::url::Url;
 
   #[test]
   fn human_size_test() {
@@ -441,9 +442,8 @@ mod test {
     imports: Vec<ModuleSpecifier>,
     redirect: Option<ModuleSpecifier>,
   ) -> (ModuleGraphFile, ModuleSpecifier) {
-    let spec = ModuleSpecifier::from(
-      url::Url::parse(&format!("http://{}", name)).unwrap(),
-    );
+    let spec =
+      ModuleSpecifier::from(Url::parse(&format!("http://{}", name)).unwrap());
     let file = ModuleGraphFile {
       filename: "name".to_string(),
       imports: imports

--- a/cli/installer.rs
+++ b/cli/installer.rs
@@ -13,7 +13,7 @@ use std::io::Write;
 #[cfg(not(windows))]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
-use url::Url;
+use deno_core::url::Url;
 
 lazy_static! {
     static ref EXEC_NAME_RE: Regex = RegexBuilder::new(

--- a/cli/installer.rs
+++ b/cli/installer.rs
@@ -3,6 +3,7 @@
 use crate::flags::Flags;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
+use deno_core::url::Url;
 use log::Level;
 use regex::{Regex, RegexBuilder};
 use std::env;
@@ -13,7 +14,6 @@ use std::io::Write;
 #[cfg(not(windows))]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
-use deno_core::url::Url;
 
 lazy_static! {
     static ref EXEC_NAME_RE: Regex = RegexBuilder::new(

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -66,6 +66,8 @@ use crate::media_type::MediaType;
 use crate::permissions::Permissions;
 use crate::worker::MainWorker;
 use deno_core::error::AnyError;
+use deno_core::futures;
+use deno_core::url::Url;
 use deno_core::v8_set_flags;
 use deno_core::ModuleSpecifier;
 use deno_doc as doc;
@@ -84,7 +86,6 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 use upgrade::upgrade_command;
-use url::Url;
 
 fn write_to_stdout_ignore_sigpipe(bytes: &[u8]) -> Result<(), std::io::Error> {
   use std::io::ErrorKind;

--- a/cli/ops/fetch.rs
+++ b/cli/ops/fetch.rs
@@ -7,6 +7,7 @@ use crate::http_util::HttpBody;
 use deno_core::error::bad_resource_id;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
+use deno_core::url;
 use deno_core::BufVec;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;

--- a/cli/ops/os.rs
+++ b/cli/ops/os.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::env;
-use url::Url;
+use deno_core::url::Url;
 
 pub fn init(rt: &mut deno_core::JsRuntime) {
   super::reg_json_sync(rt, "op_exit", op_exit);

--- a/cli/ops/os.rs
+++ b/cli/ops/os.rs
@@ -1,13 +1,13 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::AnyError;
+use deno_core::url::Url;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::env;
-use deno_core::url::Url;
 
 pub fn init(rt: &mut deno_core::JsRuntime) {
   super::reg_json_sync(rt, "op_exit", op_exit);

--- a/cli/ops/websocket.rs
+++ b/cli/ops/websocket.rs
@@ -4,6 +4,7 @@ use core::task::Poll;
 use deno_core::error::bad_resource_id;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
+use deno_core::url;
 use deno_core::BufVec;
 use deno_core::OpState;
 use futures::future::poll_fn;

--- a/cli/permissions.rs
+++ b/cli/permissions.rs
@@ -6,6 +6,7 @@ use crate::fs::resolve_from_cwd;
 use deno_core::error::custom_error;
 use deno_core::error::uri_error;
 use deno_core::error::AnyError;
+use deno_core::url;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::env::current_dir;
@@ -20,7 +21,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 #[cfg(test)]
 use std::sync::Mutex;
-use url::Url;
 
 const PERMISSION_EMOJI: &str = "⚠️";
 
@@ -259,7 +259,7 @@ impl Permissions {
     }
     let url: &str = url.unwrap();
     // If url is invalid, then throw a TypeError.
-    let parsed = Url::parse(url)?;
+    let parsed = url::Url::parse(url)?;
     // The url may be parsed correctly but still lack a host, i.e. "localhost:235" or "mailto:someone@somewhere.com" or "file:/1.txt"
     // Note that host:port combos are parsed as scheme:path
     if parsed.host().is_none() {

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -9,6 +9,7 @@ use crate::permissions::Permissions;
 use crate::tsc::TargetLib;
 use crate::web_worker::WebWorkerHandle;
 use deno_core::error::AnyError;
+use deno_core::url;
 use deno_core::ModuleLoadId;
 use deno_core::ModuleLoader;
 use deno_core::ModuleSpecifier;

--- a/cli/test_runner.rs
+++ b/cli/test_runner.rs
@@ -3,9 +3,9 @@
 use crate::fs as deno_fs;
 use crate::installer::is_remote_url;
 use deno_core::error::AnyError;
+use deno_core::url::Url;
 use std::path::Path;
 use std::path::PathBuf;
-use deno_core::url::Url;
 
 fn is_supported(p: &Path) -> bool {
   use std::path::Component;

--- a/cli/test_runner.rs
+++ b/cli/test_runner.rs
@@ -5,7 +5,7 @@ use crate::installer::is_remote_url;
 use deno_core::error::AnyError;
 use std::path::Path;
 use std::path::PathBuf;
-use url::Url;
+use deno_core::url::Url;
 
 fn is_supported(p: &Path) -> bool {
   use std::path::Component;

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1,4 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+use deno_core::url;
 use futures::prelude::*;
 use std::io::{BufRead, Write};
 use std::process::Command;
@@ -2421,7 +2422,7 @@ itest!(info_type_import {
 
 #[test]
 fn cafile_env_fetch() {
-  use url::Url;
+  use deno_core::url::Url;
   let _g = util::http_server();
   let deno_dir = TempDir::new().expect("tempdir fail");
   let module_url =
@@ -2441,7 +2442,7 @@ fn cafile_env_fetch() {
 
 #[test]
 fn cafile_fetch() {
-  use url::Url;
+  use deno_core::url::Url;
   let _g = util::http_server();
   let deno_dir = TempDir::new().expect("tempdir fail");
   let module_url =

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -25,6 +25,7 @@ use crate::worker::Worker;
 use core::task::Context;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
+use deno_core::url::Url;
 use deno_core::ModuleSpecifier;
 use futures::future::Future;
 use futures::future::FutureExt;
@@ -56,7 +57,6 @@ use std::task::Poll;
 use swc_common::comments::Comment;
 use swc_common::comments::CommentKind;
 use swc_ecmascript::dep_graph;
-use url::Url;
 
 pub const AVAILABLE_LIBS: &[&str] = &[
   "deno.ns",

--- a/cli/upgrade.rs
+++ b/cli/upgrade.rs
@@ -10,6 +10,7 @@ use crate::http_util::fetch_once;
 use crate::http_util::FetchOnceResult;
 use crate::AnyError;
 use deno_core::error::custom_error;
+use deno_core::url::Url;
 use futures::FutureExt;
 use regex::Regex;
 use reqwest::{redirect::Policy, Client};
@@ -25,7 +26,6 @@ use std::process::Command;
 use std::process::Stdio;
 use std::string::String;
 use tempfile::TempDir;
-use deno_core::url::Url;
 
 // TODO(ry) Auto detect target triples for the uploaded files.
 #[cfg(windows)]

--- a/cli/upgrade.rs
+++ b/cli/upgrade.rs
@@ -25,7 +25,7 @@ use std::process::Command;
 use std::process::Stdio;
 use std::string::String;
 use tempfile::TempDir;
-use url::Url;
+use deno_core::url::Url;
 
 // TODO(ry) Auto detect target triples for the uploaded files.
 #[cfg(windows)]

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use tokio::sync::Mutex as AsyncMutex;
-use url::Url;
+use deno_core::url::Url;
 
 /// Events that are sent to host from child
 /// worker.

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -8,6 +8,7 @@ use crate::ops;
 use crate::ops::io::get_stdio;
 use crate::state::CliState;
 use deno_core::error::AnyError;
+use deno_core::url::Url;
 use deno_core::JsRuntime;
 use deno_core::ModuleId;
 use deno_core::ModuleSpecifier;
@@ -27,7 +28,6 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use tokio::sync::Mutex as AsyncMutex;
-use deno_core::url::Url;
 
 /// Events that are sent to host from child
 /// worker.

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-extern crate futures;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -20,7 +19,11 @@ mod runtime;
 mod shared_queue;
 mod zero_copy_buf;
 
+// Re-exports
+pub use futures;
 pub use rusty_v8 as v8;
+pub use serde_json;
+pub use url;
 
 pub use crate::flags::v8_set_flags;
 pub use crate::module_specifier::ModuleResolutionError;
@@ -49,7 +52,6 @@ pub use crate::runtime::RuntimeOptions;
 pub use crate::runtime::Snapshot;
 pub use crate::zero_copy_buf::BufVec;
 pub use crate::zero_copy_buf::ZeroCopyBuf;
-pub use serde_json;
 
 pub fn v8_version() -> &'static str {
   v8::V8::get_version()


### PR DESCRIPTION
Also re-exports deno_core::futures and deno_core::serde_json but these are not yet used in the CLI.
