### PR TITLE
fix(cli/console): escape non printable characters in object entries

### DIFF
--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -462,7 +462,8 @@
       .replace(/\n/g, "\\n")
       .replace(/\r/g, "\\r")
       .replace(/\t/g, "\\t")
-      .replace(/\v/g, "\\v");
+      .replace(/\v/g, "\\v")
+      .replace(/\x1b/g, "\\x1b");
   }
 
   // Print strings when they are inside of arrays or objects with quotes

--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -463,7 +463,10 @@
       .replace(/\r/g, "\\r")
       .replace(/\t/g, "\\t")
       .replace(/\v/g, "\\v")
-      .replace(/[\x00-\x1f]/g, c => "\\x" + c.charCodeAt(0).toString(16).padStart(2, '0'));
+      .replace(
+        /[\x00-\x1f]/g,
+        (c) => "\\x" + c.charCodeAt(0).toString(16).padStart(2, "0"),
+      );
   }
 
   // Print strings when they are inside of arrays or objects with quotes

--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -464,7 +464,7 @@
       .replace(/\t/g, "\\t")
       .replace(/\v/g, "\\v")
       .replace(
-        /[\x00-\x1f\x7f-\x99]/g,
+        /[\x00-\x1f\x7f-\x9f]/g,
         (c) => "\\x" + c.charCodeAt(0).toString(16).padStart(2, "0"),
       );
   }

--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -463,7 +463,7 @@
       .replace(/\r/g, "\\r")
       .replace(/\t/g, "\\t")
       .replace(/\v/g, "\\v")
-      .replace(/\x1b/g, "\\x1b");
+      .replace(/[\x00-\x1f]/g, c => "\\x" + c.charCodeAt(0).toString(16).padStart(2, '0'));
   }
 
   // Print strings when they are inside of arrays or objects with quotes

--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -464,7 +464,7 @@
       .replace(/\t/g, "\\t")
       .replace(/\v/g, "\\v")
       .replace(
-        /[\x00-\x1f]/g,
+        /[\x00-\x1f\x7f-\x99]/g,
         (c) => "\\x" + c.charCodeAt(0).toString(16).padStart(2, "0"),
       );
   }

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -102,7 +102,7 @@ unitTest(
       `{ foo\\b: "bar\\n", bar\\r: "baz\\t" }`,
     );
     assertEquals(
-      stringify(new Set(["foo\n", "foo\r", "\x1b[32mfoo\x1b[39m" ])),
+      stringify(new Set(["foo\n", "foo\r", "\x1b[32mfoo\x1b[39m"])),
       `Set { "foo\\n", "foo\\r" , "\\x1b[32mhello\\x1b[39m" }`,
     );
   },

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -99,13 +99,13 @@ unitTest(
     );
     assertEquals(
       stringify(
-        { "foo\b": "bar\n", "bar\r": "baz\t", "\x1b[32mqux\x1b[39m": "qux" },
+        { "foo\b": "bar\n", "bar\r": "baz\t", "qux\0": "qux\0" },
       ),
-      `{ foo\\b: "bar\\n", bar\\r: "baz\\t", \\x1b[32mqux\\x1b[39m: "qux" }`,
+      `{ foo\\b: "bar\\n", bar\\r: "baz\\t", qux\\x00: "qux\\x00" }`,
     );
     assertEquals(
-      stringify(new Set(["foo\n", "foo\r", "\x1b[32mfoo\x1b[39m"])),
-      `Set { "foo\\n", "foo\\r", "\\x1b[32mfoo\\x1b[39m" }`,
+      stringify(new Set(["foo\n", "foo\r", "foo\0"])),
+      `Set { "foo\\n", "foo\\r", "foo\\x00" }`,
     );
   },
 );

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -102,8 +102,8 @@ unitTest(
       `{ foo\\b: "bar\\n", bar\\r: "baz\\t" }`,
     );
     assertEquals(
-      stringify(new Set(["foo\n", "foo\r"])),
-      `Set { "foo\\n", "foo\\r" }`,
+      stringify(new Set(["foo\n", "foo\r", "\x1b[32mfoo\x1b[39m" ])),
+      `Set { "foo\\n", "foo\\r" , "\\x1b[32mhello\\x1b[39m" }`,
     );
   },
 );

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -98,7 +98,9 @@ unitTest(
       `[ "foo\\b", "foo\\f", "foo\\n", "foo\\r", "foo\\t", "foo\\v" ]`,
     );
     assertEquals(
-      stringify({ "foo\b": "bar\n", "bar\r": "baz\t", "\x1b[32mqux\x1b[39m": "qux" }),
+      stringify(
+        { "foo\b": "bar\n", "bar\r": "baz\t", "\x1b[32mqux\x1b[39m": "qux" },
+      ),
       `{ foo\\b: "bar\\n", bar\\r: "baz\\t", \\x1b[32mqux\\x1b[39m: "qux" }`,
     );
     assertEquals(

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -103,7 +103,7 @@ unitTest(
     );
     assertEquals(
       stringify(new Set(["foo\n", "foo\r", "\x1b[32mfoo\x1b[39m"])),
-      `Set { "foo\\n", "foo\\r" , "\\x1b[32mhello\\x1b[39m" }`,
+      `Set { "foo\\n", "foo\\r", "\\x1b[32mfoo\\x1b[39m" }`,
     );
   },
 );

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -98,8 +98,8 @@ unitTest(
       `[ "foo\\b", "foo\\f", "foo\\n", "foo\\r", "foo\\t", "foo\\v" ]`,
     );
     assertEquals(
-      stringify({ "foo\b": "bar\n", "bar\r": "baz\t" }),
-      `{ foo\\b: "bar\\n", bar\\r: "baz\\t" }`,
+      stringify({ "foo\b": "bar\n", "bar\r": "baz\t", "\x1b[32mqux\x1b[39m": "qux" }),
+      `{ foo\\b: "bar\\n", bar\\r: "baz\\t", \\x1b[32mqux\\x1b[39m: "qux" }`,
     );
     assertEquals(
       stringify(new Set(["foo\n", "foo\r", "\x1b[32mfoo\x1b[39m"])),

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -94,8 +94,15 @@ unitTest(function consoleTestStringifyComplexObjects(): void {
 unitTest(
   function consoleTestStringifyComplexObjectsWithEscapedSequences(): void {
     assertEquals(
-      stringify(["foo\b", "foo\f", "foo\n", "foo\r", "foo\t", "foo\v"]),
-      `[ "foo\\b", "foo\\f", "foo\\n", "foo\\r", "foo\\t", "foo\\v" ]`,
+      stringify(
+        ["foo\b", "foo\f", "foo\n", "foo\r", "foo\t", "foo\v", "foo\0"],
+      ),
+      `[
+  "foo\\b",   "foo\\f",
+  "foo\\n",   "foo\\r",
+  "foo\\t",   "foo\\v",
+  "foo\\x00"
+]`,
     );
     assertEquals(
       stringify(


### PR DESCRIPTION
Fixes #7532 