### PR TITLE
feat(cli/fmt): make fmt output more readable

### DIFF
--- a/cli/colors.rs
+++ b/cli/colors.rs
@@ -85,6 +85,12 @@ pub fn white_on_green(s: &str) -> impl fmt::Display {
   style(&s, style_spec)
 }
 
+pub fn black_on_green(s: &str) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_bg(Some(Green)).set_fg(Some(Black));
+  style(&s, style_spec)
+}
+
 pub fn yellow(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Yellow));

--- a/cli/diff.rs
+++ b/cli/diff.rs
@@ -14,7 +14,7 @@ fn fmt_add_text(x: &str) -> String {
 }
 
 fn fmt_add_text_highlight(x: &str) -> String {
-  format!("{}", colors::white_on_green(x))
+  format!("{}", colors::black_on_green(x))
 }
 
 fn fmt_rem() -> String {
@@ -41,9 +41,9 @@ fn write_line_diff(
   for (i, s) in split {
     write!(
       diff,
-      "{:0width$}{} ",
+      "{:width$}{} ",
       *orig_line + i,
-      colors::gray("|"),
+      colors::gray(" |"),
       width = line_number_width
     )?;
     write!(diff, "{}", fmt_rem())?;
@@ -55,9 +55,9 @@ fn write_line_diff(
   for (i, s) in split {
     write!(
       diff,
-      "{:0width$}{} ",
+      "{:width$}{} ",
       *edit_line + i,
-      colors::gray("|"),
+      colors::gray(" |"),
       width = line_number_width
     )?;
     write!(diff, "{}", fmt_add())?;

--- a/cli/diff.rs
+++ b/cli/diff.rs
@@ -160,13 +160,13 @@ fn test_diff() {
     colors::strip_ansi_codes(
       &diff(simple_console_log_unfmt, simple_console_log_fmt).unwrap()
     ),
-    "1| -console.log('Hello World')\n1| +console.log(\"Hello World\");\n"
+    "1 | -console.log('Hello World')\n1 | +console.log(\"Hello World\");\n"
   );
 
   let line_number_unfmt = "\n\n\n\nconsole.log(\n'Hello World'\n)";
   let line_number_fmt = "console.log(\n\"Hello World\"\n);";
   assert_eq!(
     colors::strip_ansi_codes(&diff(line_number_unfmt, line_number_fmt).unwrap()),
-    "1| -\n2| -\n3| -\n4| -\n5| -console.log(\n1| +console.log(\n6| -'Hello World'\n2| +\"Hello World\"\n7| -)\n3| +);\n"
+    "1 | -\n2 | -\n3 | -\n4 | -\n5 | -console.log(\n1 | +console.log(\n6 | -'Hello World'\n2 | +\"Hello World\"\n7 | -)\n3 | +);\n"
   )
 }


### PR DESCRIPTION
## Dark Terminal

Before:

![before on dark](https://user-images.githubusercontent.com/17216317/93435455-13736c80-f8fc-11ea-9786-e053ced81b6d.png)

After:

![after on dark](https://user-images.githubusercontent.com/17216317/93435503-22f2b580-f8fc-11ea-9278-b25c4dd2741a.png)

## Light Terminal

Before:

![before on light](https://user-images.githubusercontent.com/17216317/93435679-5cc3bc00-f8fc-11ea-9ff6-d63936793acf.png)

After:

![after on light](https://user-images.githubusercontent.com/17216317/93435730-6d743200-f8fc-11ea-9f88-8b61e7e366c8.png)

