### PR TITLE
refactor(cli/http_utils): accept a single key-multiple values headers

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -14,6 +14,7 @@ use deno_core::error::uri_error;
 use deno_core::error::AnyError;
 use deno_core::futures;
 use deno_core::futures::future::FutureExt;
+use deno_core::serde_json;
 use deno_core::url;
 use deno_core::url::Url;
 use deno_core::ModuleSpecifier;

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -396,6 +396,11 @@ impl SourceFileFetcher {
     let result = self.http_cache.get(&module_url);
     let result = match result {
       Err(e) => {
+        if let Some(e) = e.downcast_ref::<serde_json::Error>() {
+          if e.to_string().starts_with("invalid type: string") {
+            return Ok(None);
+          }
+        }
         if let Some(e) = e.downcast_ref::<std::io::Error>() {
           if e.kind() == std::io::ErrorKind::NotFound {
             return Ok(None);

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -407,7 +407,7 @@ impl SourceFileFetcher {
     };
 
     let (mut source_file, headers) = result;
-    if let Some(redirect_to) = headers.get("location") {
+    if let Some(redirect_to) = headers.get("location").and_then(|e| e.first()) {
       let redirect_url = match Url::parse(redirect_to) {
         Ok(redirect_url) => redirect_url,
         Err(url::ParseError::RelativeUrlWithoutBase) => {
@@ -430,9 +430,15 @@ impl SourceFileFetcher {
     let fake_filepath = PathBuf::from(module_url.path());
     let (media_type, charset) = map_content_type(
       &fake_filepath,
-      headers.get("content-type").map(|e| e.as_str()),
+      headers
+        .get("content-type")
+        .and_then(|e| e.first())
+        .map(|e| e.as_str()),
     );
-    let types_header = headers.get("x-typescript-types").map(|e| e.to_string());
+    let types_header = headers
+      .get("x-typescript-types")
+      .and_then(|e| e.first())
+      .map(|e| e.to_string());
     Ok(Some(SourceFile {
       url: module_url.clone(),
       filename: cache_filename,
@@ -496,7 +502,10 @@ impl SourceFileFetcher {
     let dir = self.clone();
     let module_url = module_url.clone();
     let module_etag = match self.http_cache.get(&module_url) {
-      Ok((_, headers)) => headers.get("etag").map(String::from),
+      Ok((_, headers)) => headers
+        .get("etag")
+        .and_then(|e| e.first())
+        .map(|e| e.to_string()),
       Err(_) => None,
     };
     let permissions = permissions.clone();
@@ -535,11 +544,16 @@ impl SourceFileFetcher {
           let fake_filepath = PathBuf::from(module_url.path());
           let (media_type, charset) = map_content_type(
             &fake_filepath,
-            headers.get("content-type").map(String::as_str),
+            headers
+              .get("content-type")
+              .and_then(|e| e.first())
+              .map(|e| e.as_str()),
           );
 
-          let types_header =
-            headers.get("x-typescript-types").map(String::to_string);
+          let types_header = headers
+            .get("x-typescript-types")
+            .and_then(|e| e.first())
+            .map(|e| e.to_string());
 
           let source_file = SourceFile {
             url: module_url.clone(),
@@ -811,7 +825,9 @@ mod tests {
     metadata.headers = HashMap::new();
     metadata
       .headers
-      .insert("content-type".to_string(), "text/javascript".to_string());
+      .entry("content-type".to_string())
+      .or_insert_with(Vec::new)
+      .push("text/javascript".to_string());
     metadata.write(&cache_filename).unwrap();
 
     let result2 = fetcher_1
@@ -834,13 +850,23 @@ mod tests {
     assert_eq!(&(r2.media_type), &MediaType::JavaScript);
     let (_, headers) = fetcher_2.http_cache.get(&module_url_1).unwrap();
 
-    assert_eq!(headers.get("content-type").unwrap(), "text/javascript");
+    assert_eq!(
+      headers
+        .get("content-type")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_str(),
+      "text/javascript"
+    );
 
     // Modify .headers.json again, but the other way around
     metadata.headers = HashMap::new();
     metadata
       .headers
-      .insert("content-type".to_string(), "application/json".to_string());
+      .entry("content-type".to_string())
+      .or_insert_with(Vec::new)
+      .push("application/json".to_string());
     metadata.write(&cache_filename).unwrap();
 
     let result3 = fetcher_2
@@ -863,7 +889,13 @@ mod tests {
     assert_eq!(&(r3.media_type), &MediaType::Json);
     let metadata = crate::http_cache::Metadata::read(&cache_filename).unwrap();
     assert_eq!(
-      metadata.headers.get("content-type").unwrap(),
+      metadata
+        .headers
+        .get("content-type")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_str(),
       "application/json"
     );
 
@@ -913,7 +945,15 @@ mod tests {
     assert_eq!(r.source_code.bytes, expected);
     assert_eq!(&(r.media_type), &MediaType::JavaScript);
     let (_, headers) = fetcher.http_cache.get(&module_url).unwrap();
-    assert_eq!(headers.get("content-type").unwrap(), "text/javascript");
+    assert_eq!(
+      headers
+        .get("content-type")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_str(),
+      "text/javascript"
+    );
 
     // Modify .headers.json
     let mut metadata =
@@ -921,7 +961,9 @@ mod tests {
     metadata.headers = HashMap::new();
     metadata
       .headers
-      .insert("content-type".to_string(), "text/typescript".to_string());
+      .entry("content-type".to_string())
+      .or_insert_with(Vec::new)
+      .push("text/typescript".to_string());
     metadata.write(&cache_filename).unwrap();
 
     let result2 = fetcher
@@ -943,7 +985,13 @@ mod tests {
     assert_eq!(&(r2.media_type), &MediaType::TypeScript);
     let metadata = crate::http_cache::Metadata::read(&cache_filename).unwrap();
     assert_eq!(
-      metadata.headers.get("content-type").unwrap(),
+      metadata
+        .headers
+        .get("content-type")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_str(),
       "text/typescript"
     );
 
@@ -967,7 +1015,15 @@ mod tests {
     // (due to http fetch)
     assert_eq!(&(r3.media_type), &MediaType::JavaScript);
     let (_, headers) = fetcher.http_cache.get(&module_url).unwrap();
-    assert_eq!(headers.get("content-type").unwrap(), "text/javascript");
+    assert_eq!(
+      headers
+        .get("content-type")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_str(),
+      "text/javascript"
+    );
   }
 
   #[tokio::test]
@@ -1053,7 +1109,7 @@ mod tests {
     assert_eq!(fs::read_to_string(&redirect_source_filename).unwrap(), "");
     let (_, headers) = fetcher.http_cache.get(&redirect_module_url).unwrap();
     assert_eq!(
-      headers.get("location").unwrap(),
+      headers.get("location").unwrap().first().unwrap().as_str(),
       "http://localhost:4545/cli/tests/subdir/redirects/redirect1.js"
     );
     // The target of redirection is downloaded instead.
@@ -1106,10 +1162,16 @@ mod tests {
     assert_eq!(fs::read_to_string(&redirect_path).unwrap(), "");
 
     let (_, headers) = fetcher.http_cache.get(&double_redirect_url).unwrap();
-    assert_eq!(headers.get("location").unwrap(), &redirect_url.to_string());
+    assert_eq!(
+      headers.get("location").unwrap().first().unwrap(),
+      &redirect_url.to_string()
+    );
 
     let (_, headers) = fetcher.http_cache.get(&redirect_url).unwrap();
-    assert_eq!(headers.get("location").unwrap(), &target_url.to_string());
+    assert_eq!(
+      headers.get("location").unwrap().first().unwrap(),
+      &target_url.to_string()
+    );
 
     // The target of redirection is downloaded instead.
     assert_eq!(
@@ -1262,7 +1324,7 @@ mod tests {
     assert_eq!(fs::read_to_string(&redirect_source_filename).unwrap(), "");
     let (_, headers) = fetcher.http_cache.get(&redirect_module_url).unwrap();
     assert_eq!(
-      headers.get("location").unwrap(),
+      headers.get("location").unwrap().first().unwrap().as_str(),
       "/cli/tests/subdir/redirects/redirect1.js"
     );
     // The target of redirection is downloaded instead.
@@ -1376,7 +1438,9 @@ mod tests {
     metadata.headers = HashMap::new();
     metadata
       .headers
-      .insert("content-type".to_string(), "text/javascript".to_string());
+      .entry("content-type".to_string())
+      .or_insert_with(Vec::new)
+      .push("text/javascript".to_string());
     metadata.write(&cache_filename).unwrap();
 
     let result2 = fetcher.fetch_cached_remote_source(&module_url, 1);
@@ -1407,7 +1471,15 @@ mod tests {
     assert_eq!(r.source_code.bytes, b"export const loaded = true;\n");
     assert_eq!(&(r.media_type), &MediaType::TypeScript);
     let (_, headers) = fetcher.http_cache.get(module_url).unwrap();
-    assert_eq!(headers.get("content-type").unwrap(), "text/typescript");
+    assert_eq!(
+      headers
+        .get("content-type")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_str(),
+      "text/typescript"
+    );
   }
 
   #[tokio::test]
@@ -1431,7 +1503,15 @@ mod tests {
     assert_eq!(r2.source_code.bytes, b"export const loaded = true;\n");
     assert_eq!(&(r2.media_type), &MediaType::JavaScript);
     let (_, headers) = fetcher.http_cache.get(module_url).unwrap();
-    assert_eq!(headers.get("content-type").unwrap(), "text/javascript");
+    assert_eq!(
+      headers
+        .get("content-type")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_str(),
+      "text/javascript"
+    );
   }
 
   #[tokio::test]
@@ -1455,7 +1535,15 @@ mod tests {
     assert_eq!(r3.source_code.bytes, b"export const loaded = true;\n");
     assert_eq!(&(r3.media_type), &MediaType::TypeScript);
     let (_, headers) = fetcher.http_cache.get(module_url).unwrap();
-    assert_eq!(headers.get("content-type").unwrap(), "text/typescript");
+    assert_eq!(
+      headers
+        .get("content-type")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_str(),
+      "text/typescript"
+    );
   }
 
   #[tokio::test]
@@ -1811,7 +1899,10 @@ mod tests {
     assert_eq!(&(source.media_type), &MediaType::TypeScript);
 
     let (_, headers) = fetcher.http_cache.get(&module_url).unwrap();
-    assert_eq!(headers.get("etag").unwrap(), "33a64df551425fcc55e");
+    assert_eq!(
+      headers.get("etag").unwrap().first().unwrap().as_str(),
+      "33a64df551425fcc55e"
+    );
 
     let metadata_path = crate::http_cache::Metadata::filename(
       &fetcher.http_cache.get_cache_filename(&module_url),
@@ -1936,7 +2027,12 @@ mod tests {
 
     let (_, headers) = fetcher.http_cache.get(&module_url).unwrap();
     assert_eq!(
-      headers.get("content-type").unwrap(),
+      headers
+        .get("content-type")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_str(),
       &format!("application/typescript;charset={}", charset)
     );
   }

--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -216,11 +216,14 @@ mod tests {
     let cache = HttpCache::new(dir.path());
     let url = Url::parse("https://deno.land/x/welcome.ts").unwrap();
     let mut headers = HashMap::new();
-    headers.insert(
-      "content-type".to_string(),
-      "application/javascript".to_string(),
-    );
-    headers.insert("etag".to_string(), "as5625rqdsfb".to_string());
+    headers
+      .entry("content-type".to_string())
+      .or_insert_with(Vec::new)
+      .push("application/javascript".to_string());
+    headers
+      .entry("etag".to_string())
+      .or_insert_with(Vec::new)
+      .push("as5625rqdsfb".to_string());
     let content = b"Hello world";
     let r = cache.set(&url, headers, content);
     eprintln!("result {:?}", r);
@@ -232,10 +235,18 @@ mod tests {
     file.read_to_string(&mut content).unwrap();
     assert_eq!(content, "Hello world");
     assert_eq!(
-      headers.get("content-type").unwrap(),
+      headers
+        .get("content-type")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_str(),
       "application/javascript"
     );
-    assert_eq!(headers.get("etag").unwrap(), "as5625rqdsfb");
+    assert_eq!(
+      headers.get("etag").unwrap().first().unwrap().as_str(),
+      "as5625rqdsfb"
+    );
     assert_eq!(headers.get("foobar"), None);
   }
 

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -127,7 +127,10 @@ pub async fn fetch_once(
     let values = headers.get_all(key);
     for value in values.iter() {
       let value = value.to_str().unwrap().to_string();
-      headers_.entry(key_str.clone()).or_insert_with(Vec::new).push(value);
+      headers_
+        .entry(key_str.clone())
+        .or_insert_with(Vec::new)
+        .push(value);
     }
   }
 

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -78,10 +78,7 @@ fn resolve_url_from_location(base_url: &Url, location: &str) -> Url {
   }
 }
 
-// TODO(ry) HTTP headers are not unique key, value pairs. There may be more than
-// one header line with the same key. This should be changed to something like
-// Vec<(String, String)>
-pub type HeadersMap = HashMap<String, String>;
+pub type HeadersMap = HashMap<String, Vec<String>>;
 
 #[derive(Debug, PartialEq)]
 pub enum FetchOnceResult {
@@ -114,7 +111,7 @@ pub async fn fetch_once(
     return Ok(FetchOnceResult::NotModified);
   }
 
-  let mut headers_: HashMap<String, String> = HashMap::new();
+  let mut headers_: HashMap<String, Vec<String>> = HashMap::new();
   let headers = response.headers();
 
   if let Some(warning) = headers.get("X-Deno-Warning") {
@@ -133,7 +130,10 @@ pub async fn fetch_once(
       .map(|e| e.to_str().unwrap().to_string())
       .collect::<Vec<String>>()
       .join(",");
-    headers_.insert(key_str, values_str);
+    headers_
+      .entry(key_str)
+      .or_insert_with(Vec::new)
+      .push(values_str);
   }
 
   if response.status().is_redirection() {
@@ -250,7 +250,15 @@ mod tests {
     let result = fetch_once(client, &url, None).await;
     if let Ok(FetchOnceResult::Code(body, headers)) = result {
       assert!(!body.is_empty());
-      assert_eq!(headers.get("content-type").unwrap(), "application/json");
+      assert_eq!(
+        headers
+          .get("content-type")
+          .unwrap()
+          .first()
+          .unwrap()
+          .as_str(),
+        "application/json"
+      );
       assert_eq!(headers.get("etag"), None);
       assert_eq!(headers.get("x-typescript-types"), None);
     } else {
@@ -271,7 +279,12 @@ mod tests {
     if let Ok(FetchOnceResult::Code(body, headers)) = result {
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('gzip')");
       assert_eq!(
-        headers.get("content-type").unwrap(),
+        headers
+          .get("content-type")
+          .unwrap()
+          .first()
+          .unwrap()
+          .as_str(),
         "application/javascript"
       );
       assert_eq!(headers.get("etag"), None);
@@ -291,10 +304,18 @@ mod tests {
       assert!(!body.is_empty());
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('etag')");
       assert_eq!(
-        headers.get("content-type").unwrap(),
+        headers
+          .get("content-type")
+          .unwrap()
+          .first()
+          .unwrap()
+          .as_str(),
         "application/typescript"
       );
-      assert_eq!(headers.get("etag").unwrap(), "33a64df551425fcc55e");
+      assert_eq!(
+        headers.get("etag").unwrap().first().unwrap().as_str(),
+        "33a64df551425fcc55e"
+      );
     } else {
       panic!();
     }
@@ -318,7 +339,12 @@ mod tests {
       assert!(!body.is_empty());
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('brotli');");
       assert_eq!(
-        headers.get("content-type").unwrap(),
+        headers
+          .get("content-type")
+          .unwrap()
+          .first()
+          .unwrap()
+          .as_str(),
         "application/javascript"
       );
       assert_eq!(headers.get("etag"), None);
@@ -401,7 +427,15 @@ mod tests {
     let result = fetch_once(client, &url, None).await;
     if let Ok(FetchOnceResult::Code(body, headers)) = result {
       assert!(!body.is_empty());
-      assert_eq!(headers.get("content-type").unwrap(), "application/json");
+      assert_eq!(
+        headers
+          .get("content-type")
+          .unwrap()
+          .first()
+          .unwrap()
+          .as_str(),
+        "application/json"
+      );
       assert_eq!(headers.get("etag"), None);
       assert_eq!(headers.get("x-typescript-types"), None);
     } else {
@@ -428,7 +462,12 @@ mod tests {
     if let Ok(FetchOnceResult::Code(body, headers)) = result {
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('gzip')");
       assert_eq!(
-        headers.get("content-type").unwrap(),
+        headers
+          .get("content-type")
+          .unwrap()
+          .first()
+          .unwrap()
+          .as_str(),
         "application/javascript"
       );
       assert_eq!(headers.get("etag"), None);
@@ -454,10 +493,18 @@ mod tests {
       assert!(!body.is_empty());
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('etag')");
       assert_eq!(
-        headers.get("content-type").unwrap(),
+        headers
+          .get("content-type")
+          .unwrap()
+          .first()
+          .unwrap()
+          .as_str(),
         "application/typescript"
       );
-      assert_eq!(headers.get("etag").unwrap(), "33a64df551425fcc55e");
+      assert_eq!(
+        headers.get("etag").unwrap().first().unwrap().as_str(),
+        "33a64df551425fcc55e"
+      );
       assert_eq!(headers.get("x-typescript-types"), None);
     } else {
       panic!();
@@ -488,7 +535,12 @@ mod tests {
       assert!(!body.is_empty());
       assert_eq!(String::from_utf8(body).unwrap(), "console.log('brotli');");
       assert_eq!(
-        headers.get("content-type").unwrap(),
+        headers
+          .get("content-type")
+          .unwrap()
+          .first()
+          .unwrap()
+          .as_str(),
         "application/javascript"
       );
       assert_eq!(headers.get("etag"), None);

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -125,15 +125,10 @@ pub async fn fetch_once(
   for key in headers.keys() {
     let key_str = key.to_string();
     let values = headers.get_all(key);
-    let values_str = values
-      .iter()
-      .map(|e| e.to_str().unwrap().to_string())
-      .collect::<Vec<String>>()
-      .join(",");
-    headers_
-      .entry(key_str)
-      .or_insert_with(Vec::new)
-      .push(values_str);
+    for value in values.iter() {
+      let value = value.to_str().unwrap().to_string();
+      headers_.entry(key_str.clone()).or_insert_with(Vec::new).push(value);
+    }
   }
 
   if response.status().is_redirection() {

--- a/cli/tests/info_compatible.metadata.json
+++ b/cli/tests/info_compatible.metadata.json
@@ -1,0 +1,10 @@
+{
+  "headers": {
+    "content-type": "application/javascript",
+    "accept-ranges": "bytes",
+    "content-length": "28",
+    "last-modified": "Thu, 27 Aug 2020 14:28:55 GMT",
+    "date": "Fri, 18 Sep 2020 02:05:24 GMT"
+  },
+  "url": "http://127.0.0.1:4545/cli/tests/001_hello.js"
+}

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3655,3 +3655,42 @@ fn fmt_ignore_unexplicit_files() {
   assert!(output.status.success());
   assert_eq!(output.stderr, b"Checked 0 file\n");
 }
+
+#[test]
+fn info_compatible() {
+  let tmp_dir = TempDir::new().unwrap();
+
+  //copy cache and metadata file
+  let target_dir_path = tmp_dir.path()
+    .join("deps")
+    .join("http")
+    .join("127.0.0.1_PORT4545");
+  std::fs::create_dir_all(&target_dir_path).unwrap();
+  let metadata_path = target_dir_path
+    .join("e1633cbe03bb09239afc9fe0cf376c91c8d41384ef7407feebdec69f45bb4c11.metadata.json");
+  let cache_path = target_dir_path
+    .join("e1633cbe03bb09239afc9fe0cf376c91c8d41384ef7407feebdec69f45bb4c11");
+  std::fs::File::create(&metadata_path).unwrap();
+  std::fs::copy(
+    util::tests_path().join("info_compatible.metadata.json"),
+    &metadata_path,
+  )
+  .unwrap();
+  std::fs::copy(
+    util::tests_path().join("001_hello.js"),
+    &cache_path,
+  )
+  .unwrap();
+
+  let output = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("info")
+    .arg("--unstable")
+    .arg("http://127.0.0.1:4545/cli/tests/001_hello.js")
+    .env("DENO_DIR", tmp_dir.path().to_str().unwrap())
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+  assert!(output.status.success());
+}

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3658,6 +3658,7 @@ fn fmt_ignore_unexplicit_files() {
 
 #[test]
 fn info_compatible() {
+  let _g = util::http_server();
   let tmp_dir = TempDir::new().unwrap();
 
   //copy cache and metadata file

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3661,7 +3661,8 @@ fn info_compatible() {
   let tmp_dir = TempDir::new().unwrap();
 
   //copy cache and metadata file
-  let target_dir_path = tmp_dir.path()
+  let target_dir_path = tmp_dir
+    .path()
     .join("deps")
     .join("http")
     .join("127.0.0.1_PORT4545");

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3678,11 +3678,7 @@ fn info_compatible() {
     &metadata_path,
   )
   .unwrap();
-  std::fs::copy(
-    util::tests_path().join("001_hello.js"),
-    &cache_path,
-  )
-  .unwrap();
+  std::fs::copy(util::tests_path().join("001_hello.js"), &cache_path).unwrap();
 
   let output = util::deno_cmd()
     .current_dir(util::root_path())

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3657,7 +3657,7 @@ fn fmt_ignore_unexplicit_files() {
 }
 
 #[test]
-fn info_compatible() {
+fn metadata_json_compatible() {
   let _g = util::http_server();
   let tmp_dir = TempDir::new().unwrap();
 


### PR DESCRIPTION
fix TODO comments

> // TODO(ry) HTTP headers are not unique key, value pairs. There may be more than
> // one header line with the same key. This should be changed to something like
> // Vec<(String, String)>

I use HashMap<String, Vec> to store key-value pairs because it is easier to search values using HashMap

This PR changes *.metadata.json to contains single key-multiple values headers like this

```
"headers": {
    "x-content-type-options": [
      "nosniff"
    ],
    "cache-control": [
      "max-age=300"
    ],
```

ref: #7515

---

TODO
- [x] add a test
