### PR TITLE
refactor: move fields from CliState to OpState

### DIFF
--- a/cli/global_timer.rs
+++ b/cli/global_timer.rs
@@ -20,10 +20,6 @@ pub struct GlobalTimer {
 }
 
 impl GlobalTimer {
-  pub fn new() -> Self {
-    Self { tx: None }
-  }
-
   pub fn cancel(&mut self) {
     if let Some(tx) = self.tx.take() {
       tx.send(()).ok();

--- a/cli/metrics.rs
+++ b/cli/metrics.rs
@@ -92,9 +92,9 @@ pub fn metrics_op(op_fn: Box<OpFn>) -> Box<OpFn> {
 
     let op = (op_fn)(op_state.clone(), bufs);
 
-    let cli_state = crate::ops::cli_state2(&op_state);
-    let cli_state_ = cli_state.clone();
-    let mut metrics = cli_state.metrics.borrow_mut();
+    let op_state_ = op_state.clone();
+    let mut s = op_state.borrow_mut();
+    let metrics = s.borrow_mut::<Metrics>();
 
     use futures::future::FutureExt;
 
@@ -107,7 +107,8 @@ pub fn metrics_op(op_fn: Box<OpFn>) -> Box<OpFn> {
         metrics.op_dispatched_async(bytes_sent_control, bytes_sent_data);
         let fut = fut
           .inspect(move |buf| {
-            let mut metrics = cli_state_.metrics.borrow_mut();
+            let mut s = op_state_.borrow_mut();
+            let metrics = s.borrow_mut::<Metrics>();
             metrics.op_completed_async(buf.len());
           })
           .boxed_local();
@@ -117,7 +118,8 @@ pub fn metrics_op(op_fn: Box<OpFn>) -> Box<OpFn> {
         metrics.op_dispatched_async_unref(bytes_sent_control, bytes_sent_data);
         let fut = fut
           .inspect(move |buf| {
-            let mut metrics = cli_state_.metrics.borrow_mut();
+            let mut s = op_state_.borrow_mut();
+            let metrics = s.borrow_mut::<Metrics>();
             metrics.op_completed_async_unref(buf.len());
           })
           .boxed_local();

--- a/cli/metrics.rs
+++ b/cli/metrics.rs
@@ -12,7 +12,6 @@ pub struct Metrics {
   pub bytes_sent_control: u64,
   pub bytes_sent_data: u64,
   pub bytes_received: u64,
-  pub resolve_count: u64,
 }
 
 impl Metrics {

--- a/cli/ops/random.rs
+++ b/cli/ops/random.rs
@@ -7,7 +7,6 @@ use rand::rngs::StdRng;
 use rand::thread_rng;
 use rand::Rng;
 use serde_json::Value;
-use std::cell::RefCell;
 
 pub fn init(rt: &mut deno_core::JsRuntime) {
   super::reg_json_sync(rt, "op_get_random_values", op_get_random_values);
@@ -19,9 +18,9 @@ fn op_get_random_values(
   zero_copy: &mut [ZeroCopyBuf],
 ) -> Result<Value, AnyError> {
   assert_eq!(zero_copy.len(), 1);
-  let maybe_seeded_rng = state.try_borrow_mut::<RefCell<StdRng>>();
+  let maybe_seeded_rng = state.try_borrow_mut::<StdRng>();
   if let Some(seeded_rng) = maybe_seeded_rng {
-    seeded_rng.borrow_mut().fill(&mut *zero_copy[0]);
+    seeded_rng.fill(&mut *zero_copy[0]);
   } else {
     let mut rng = thread_rng();
     rng.fill(&mut *zero_copy[0]);

--- a/cli/ops/random.rs
+++ b/cli/ops/random.rs
@@ -3,9 +3,11 @@
 use deno_core::error::AnyError;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
+use rand::rngs::StdRng;
 use rand::thread_rng;
 use rand::Rng;
 use serde_json::Value;
+use std::cell::RefCell;
 
 pub fn init(rt: &mut deno_core::JsRuntime) {
   super::reg_json_sync(rt, "op_get_random_values", op_get_random_values);
@@ -17,8 +19,8 @@ fn op_get_random_values(
   zero_copy: &mut [ZeroCopyBuf],
 ) -> Result<Value, AnyError> {
   assert_eq!(zero_copy.len(), 1);
-  let cli_state = super::cli_state(state);
-  if let Some(seeded_rng) = &cli_state.seeded_rng {
+  let maybe_seeded_rng = state.try_borrow_mut::<RefCell<StdRng>>();
+  if let Some(seeded_rng) = maybe_seeded_rng {
     seeded_rng.borrow_mut().fill(&mut *zero_copy[0]);
   } else {
     let mut rng = thread_rng();

--- a/cli/ops/runtime.rs
+++ b/cli/ops/runtime.rs
@@ -1,8 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
-use crate::version;
 use crate::metrics::Metrics;
+use crate::version;
 use crate::DenoSubcommand;
 use deno_core::error::AnyError;
 use deno_core::ModuleSpecifier;

--- a/cli/ops/runtime.rs
+++ b/cli/ops/runtime.rs
@@ -2,6 +2,7 @@
 
 use crate::colors;
 use crate::version;
+use crate::metrics::Metrics;
 use crate::DenoSubcommand;
 use deno_core::error::AnyError;
 use deno_core::ModuleSpecifier;
@@ -61,8 +62,7 @@ fn op_metrics(
   _args: Value,
   _zero_copy: &mut [ZeroCopyBuf],
 ) -> Result<Value, AnyError> {
-  let cli_state = super::cli_state(state);
-  let m = &cli_state.metrics.borrow();
+  let m = state.borrow::<Metrics>();
 
   Ok(json!({
     "opsDispatched": m.ops_dispatched,

--- a/cli/ops/timers.rs
+++ b/cli/ops/timers.rs
@@ -24,7 +24,7 @@ fn op_global_timer_stop(
   _args: Value,
   _zero_copy: &mut [ZeroCopyBuf],
 ) -> Result<Value, AnyError> {
-  let global_timer = state.borrow::<RefCell<GlobalTimer>>();
+  let global_timer = state.borrow::<GlobalTimer>();
   global_timer.borrow_mut().cancel();
   Ok(json!({}))
 }

--- a/cli/ops/timers.rs
+++ b/cli/ops/timers.rs
@@ -24,8 +24,8 @@ fn op_global_timer_stop(
   _args: Value,
   _zero_copy: &mut [ZeroCopyBuf],
 ) -> Result<Value, AnyError> {
-  let global_timer = state.borrow::<GlobalTimer>();
-  global_timer.borrow_mut().cancel();
+  let global_timer = state.borrow_mut::<GlobalTimer>();
+  global_timer.cancel();
   Ok(json!({}))
 }
 

--- a/cli/ops/timers.rs
+++ b/cli/ops/timers.rs
@@ -46,9 +46,7 @@ async fn op_global_timer(
   let timer_fut = {
     let s = state.borrow();
     let mut global_timer = s.borrow::<RefCell<GlobalTimer>>().borrow_mut();
-    global_timer
-      .new_timeout(deadline)
-      .boxed_local()
+    global_timer.new_timeout(deadline).boxed_local()
   };
   let _ = timer_fut.await;
   Ok(json!({}))

--- a/cli/ops/timers.rs
+++ b/cli/ops/timers.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+use crate::global_timer::GlobalTimer;
 use deno_core::error::AnyError;
 use deno_core::BufVec;
 use deno_core::OpState;
@@ -23,8 +24,8 @@ fn op_global_timer_stop(
   _args: Value,
   _zero_copy: &mut [ZeroCopyBuf],
 ) -> Result<Value, AnyError> {
-  let cli_state = super::cli_state(state);
-  cli_state.global_timer.borrow_mut().cancel();
+  let global_timer = state.borrow::<RefCell<GlobalTimer>>();
+  global_timer.borrow_mut().cancel();
   Ok(json!({}))
 }
 
@@ -43,9 +44,9 @@ async fn op_global_timer(
 
   let deadline = Instant::now() + Duration::from_millis(val);
   let timer_fut = {
-    super::cli_state2(&state)
-      .global_timer
-      .borrow_mut()
+    let s = state.borrow();
+    let mut global_timer = s.borrow::<RefCell<GlobalTimer>>().borrow_mut();
+    global_timer
       .new_timeout(deadline)
       .boxed_local()
   };

--- a/cli/ops/timers.rs
+++ b/cli/ops/timers.rs
@@ -44,8 +44,8 @@ async fn op_global_timer(
 
   let deadline = Instant::now() + Duration::from_millis(val);
   let timer_fut = {
-    let s = state.borrow();
-    let mut global_timer = s.borrow::<RefCell<GlobalTimer>>().borrow_mut();
+    let mut s = state.borrow_mut();
+    let global_timer = s.borrow_mut::<GlobalTimer>();
     global_timer.new_timeout(deadline).boxed_local()
   };
   let _ = timer_fut.await;

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -82,8 +82,6 @@ impl ModuleLoader for CliState {
     _is_dyn_import: bool,
   ) -> Pin<Box<deno_core::ModuleSourceFuture>> {
     let module_specifier = module_specifier.to_owned();
-    // TODO(bartlomieju): incrementing resolve_count here has no sense...
-    self.metrics.borrow_mut().resolve_count += 1;
     let module_url_specified = module_specifier.to_string();
     let global_state = self.global_state.clone();
 

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -14,8 +14,6 @@ use deno_core::ModuleLoader;
 use deno_core::ModuleSpecifier;
 use futures::future::FutureExt;
 use futures::Future;
-use rand::rngs::StdRng;
-use rand::SeedableRng;
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -43,7 +41,6 @@ pub struct CliState {
   pub workers: RefCell<HashMap<u32, (JoinHandle<()>, WebWorkerHandle)>>,
   pub next_worker_id: Cell<u32>,
   pub start_time: Instant,
-  pub seeded_rng: Option<RefCell<StdRng>>,
   pub target_lib: TargetLib,
   pub is_main: bool,
   pub is_internal: bool,
@@ -161,7 +158,6 @@ impl CliState {
     maybe_import_map: Option<ImportMap>,
     is_internal: bool,
   ) -> Result<Rc<Self>, AnyError> {
-    let fl = &global_state.flags;
     let state = CliState {
       global_state: global_state.clone(),
       main_module,
@@ -173,7 +169,6 @@ impl CliState {
       workers: Default::default(),
       next_worker_id: Default::default(),
       start_time: Instant::now(),
-      seeded_rng: fl.seed.map(|v| StdRng::seed_from_u64(v).into()),
       target_lib: TargetLib::Main,
       is_main: true,
       is_internal,
@@ -187,7 +182,6 @@ impl CliState {
     shared_permissions: Option<Permissions>,
     main_module: ModuleSpecifier,
   ) -> Result<Rc<Self>, AnyError> {
-    let fl = &global_state.flags;
     let state = CliState {
       global_state: global_state.clone(),
       main_module,
@@ -199,7 +193,6 @@ impl CliState {
       workers: Default::default(),
       next_worker_id: Default::default(),
       start_time: Instant::now(),
-      seeded_rng: fl.seed.map(|v| StdRng::seed_from_u64(v).into()),
       target_lib: TargetLib::Worker,
       is_main: false,
       is_internal: false,

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -3,7 +3,6 @@
 use crate::file_fetcher::SourceFileFetcher;
 use crate::global_state::GlobalState;
 use crate::import_map::ImportMap;
-use crate::metrics::Metrics;
 use crate::permissions::Permissions;
 use crate::tsc::TargetLib;
 use crate::web_worker::WebWorkerHandle;
@@ -37,7 +36,6 @@ pub struct CliState {
   /// When flags contains a `.import_map_path` option, the content of the
   /// import map file will be resolved and set.
   pub import_map: Option<ImportMap>,
-  pub metrics: RefCell<Metrics>,
   pub workers: RefCell<HashMap<u32, (JoinHandle<()>, WebWorkerHandle)>>,
   pub next_worker_id: Cell<u32>,
   pub start_time: Instant,
@@ -163,7 +161,6 @@ impl CliState {
         .unwrap_or_else(|| global_state.permissions.clone())
         .into(),
       import_map: maybe_import_map,
-      metrics: Default::default(),
       workers: Default::default(),
       next_worker_id: Default::default(),
       start_time: Instant::now(),
@@ -187,7 +184,6 @@ impl CliState {
         .unwrap_or_else(|| global_state.permissions.clone())
         .into(),
       import_map: None,
-      metrics: Default::default(),
       workers: Default::default(),
       next_worker_id: Default::default(),
       start_time: Instant::now(),

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -2,7 +2,6 @@
 
 use crate::file_fetcher::SourceFileFetcher;
 use crate::global_state::GlobalState;
-use crate::global_timer::GlobalTimer;
 use crate::import_map::ImportMap;
 use crate::metrics::Metrics;
 use crate::permissions::Permissions;
@@ -41,7 +40,6 @@ pub struct CliState {
   /// import map file will be resolved and set.
   pub import_map: Option<ImportMap>,
   pub metrics: RefCell<Metrics>,
-  pub global_timer: RefCell<GlobalTimer>,
   pub workers: RefCell<HashMap<u32, (JoinHandle<()>, WebWorkerHandle)>>,
   pub next_worker_id: Cell<u32>,
   pub start_time: Instant,
@@ -172,7 +170,6 @@ impl CliState {
         .into(),
       import_map: maybe_import_map,
       metrics: Default::default(),
-      global_timer: Default::default(),
       workers: Default::default(),
       next_worker_id: Default::default(),
       start_time: Instant::now(),
@@ -199,7 +196,6 @@ impl CliState {
         .into(),
       import_map: None,
       metrics: Default::default(),
-      global_timer: Default::default(),
       workers: Default::default(),
       next_worker_id: Default::default(),
       start_time: Instant::now(),

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -7,6 +7,7 @@ use crate::js;
 use crate::ops;
 use crate::ops::io::get_stdio;
 use crate::state::CliState;
+use crate::global_timer::GlobalTimer;
 use deno_core::error::AnyError;
 use deno_core::url::Url;
 use deno_core::JsRuntime;
@@ -28,6 +29,7 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use tokio::sync::Mutex as AsyncMutex;
+use std::cell::RefCell;
 
 /// Events that are sent to host from child
 /// worker.
@@ -126,6 +128,9 @@ impl Worker {
       let ca_file = global_state.flags.ca_file.as_deref();
       let client = crate::http_util::create_http_client(ca_file).unwrap();
       op_state.put(client);
+
+      let global_timer = RefCell::new(GlobalTimer::default());
+      op_state.put(global_timer);
     }
     let inspector = {
       let global_state = &state.global_state;

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -390,7 +390,6 @@ mod tests {
         panic!("Future got unexpected error: {:?}", e);
       }
     });
-    assert_eq!(state.metrics.borrow().resolve_count, 2);
     // Check that we didn't start the compiler.
     assert_eq!(state.global_state.compiler_starts.load(Ordering::SeqCst), 0);
   }
@@ -455,7 +454,6 @@ mod tests {
     if let Err(e) = (&mut *worker).await {
       panic!("Future got unexpected error: {:?}", e);
     }
-    assert_eq!(state.metrics.borrow().resolve_count, 3);
     // Check that we've only invoked the compiler once.
     assert_eq!(state.global_state.compiler_starts.load(Ordering::SeqCst), 1);
   }

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -3,6 +3,7 @@
 use crate::fmt_errors::JsError;
 use crate::global_state::GlobalState;
 use crate::global_timer::GlobalTimer;
+use crate::metrics::Metrics;
 use crate::inspector::DenoInspector;
 use crate::js;
 use crate::ops;
@@ -135,6 +136,8 @@ impl Worker {
       if let Some(seed) = global_state.flags.seed {
         op_state.put(StdRng::seed_from_u64(seed));
       }
+
+      op_state.put(Metrics::default());
     }
     let inspector = {
       let global_state = &state.global_state;

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -3,9 +3,9 @@
 use crate::fmt_errors::JsError;
 use crate::global_state::GlobalState;
 use crate::global_timer::GlobalTimer;
-use crate::metrics::Metrics;
 use crate::inspector::DenoInspector;
 use crate::js;
+use crate::metrics::Metrics;
 use crate::ops;
 use crate::ops::io::get_stdio;
 use crate::state::CliState;

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -21,7 +21,6 @@ use futures::stream::StreamExt;
 use futures::task::AtomicWaker;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use std::cell::RefCell;
 use std::env;
 use std::future::Future;
 use std::ops::Deref;
@@ -131,12 +130,10 @@ impl Worker {
       let client = crate::http_util::create_http_client(ca_file).unwrap();
       op_state.put(client);
 
-      let global_timer = RefCell::new(GlobalTimer::default());
-      op_state.put(global_timer);
+      op_state.put(GlobalTimer::default());
 
       if let Some(seed) = global_state.flags.seed {
-        let rng = StdRng::seed_from_u64(seed);
-        op_state.put(RefCell::new(rng));
+        op_state.put(StdRng::seed_from_u64(seed));
       }
     }
     let inspector = {


### PR DESCRIPTION
- move rng to `OpState`
- move `GlobalTimer` to `OpState`
- move `Metrics` to `OpState`