### PR TITLE
refactor: remove Metrics::resolve_count

### DIFF
--- a/cli/metrics.rs
+++ b/cli/metrics.rs
@@ -12,7 +12,6 @@ pub struct Metrics {
   pub bytes_sent_control: u64,
   pub bytes_sent_data: u64,
   pub bytes_received: u64,
-  pub resolve_count: u64,
 }
 
 impl Metrics {

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -87,8 +87,6 @@ impl ModuleLoader for CliState {
     _is_dyn_import: bool,
   ) -> Pin<Box<deno_core::ModuleSourceFuture>> {
     let module_specifier = module_specifier.to_owned();
-    // TODO(bartlomieju): incrementing resolve_count here has no sense...
-    self.metrics.borrow_mut().resolve_count += 1;
     let module_url_specified = module_specifier.to_string();
     let global_state = self.global_state.clone();
 

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -381,7 +381,6 @@ mod tests {
         panic!("Future got unexpected error: {:?}", e);
       }
     });
-    assert_eq!(state.metrics.borrow().resolve_count, 2);
     // Check that we didn't start the compiler.
     assert_eq!(state.global_state.compiler_starts.load(Ordering::SeqCst), 0);
   }
@@ -446,7 +445,6 @@ mod tests {
     if let Err(e) = (&mut *worker).await {
       panic!("Future got unexpected error: {:?}", e);
     }
-    assert_eq!(state.metrics.borrow().resolve_count, 3);
     // Check that we've only invoked the compiler once.
     assert_eq!(state.global_state.compiler_starts.load(Ordering::SeqCst), 1);
   }


### PR DESCRIPTION
Required for https://github.com/denoland/deno/pull/7558

This field was used only in two tests and had no sense...