### PR TITLE
ffi continue

### DIFF
--- a/cli/rt/40_ffi_unstable.js
+++ b/cli/rt/40_ffi_unstable.js
@@ -1,0 +1,90 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+((window) => {
+
+  const { sendSync } = window.__bootstrap.dispatchJson;
+
+  function bufferStart(buffer) {
+    // TODO how to implement this with op?
+  }
+
+  /*
+    @param
+      start: bigint
+    @return SharedArrayBuffer
+  */
+  function bufferFromPointer(
+    start,
+    length
+  ) {
+    // TODO how to implement this with op?
+  }
+
+
+  class ForeignLibrary {
+    #rid = 0;
+    constructor(rid) {
+      this.#rid = rid;
+    }
+    get rid() {
+      return this.#rid;
+    }
+
+    lookup(symbol) {
+      const addr = sendSync("op_dlsym", { rid, symbol });
+      return BigInt(addr);
+    }
+
+    close() {
+      close(this.rid);
+    }
+  }
+
+  class ForeignFunction  {
+    #rid = 0;
+    constructor(rid) {
+      this.#rid = rid;
+    }
+    get rid() {
+      return this.#rid;
+    }
+    call(...args) {
+      // TODO BigInt can't fit in JSON
+      return sendSync("op_ffi_call", {
+       rid,
+       args,
+      });
+    }
+
+    close() {
+      close(this.rid);
+    }
+  }
+
+  function loadForeignLibrary(path) {
+    const rid = sendSync("op_ffi_dlopen", { path });
+    return new ForeignLibrary(rid);
+  }
+
+  function loadForeignFunctionSync(
+    addr,
+    abi,
+    info
+  ) {
+    return sendSync("op_ffi_prep", { addr, abi, ...info })
+  }
+
+  function listForeignAbiSync() {
+    return sendSync("op_ffi_list_abi");
+  }
+
+  window.__bootstrap.ffiUnstable = {
+    ForeignLibrary,
+    ForeignFunction,
+    loadForeignLibrary,
+    loadForeignFunction,
+    listForeignAbiSync,
+    bufferStart,
+    bufferFromPointer
+  };
+})(this);


### PR DESCRIPTION
This is a pursue of https://github.com/denoland/deno/pull/5566

I wanna implement the JS version first and then add the TSD files

The std FFI implementation in rust
https://doc.rust-lang.org/std/ffi/index.html

design reference

JNR-FFI for Java(https://github.com/jnr/jnr-ffi)
```java
package helloworld;

import jnr.ffi.LibraryLoader;

public class HelloWorld {
    public static interface LibC {
        int puts(String s);
    }

    public static void main(String[] args) {
        LibC libc = LibraryLoader.create(LibC.class).load("c");

        libc.puts("Hello, World");
    }
}
```
I am curios if we can leverage the type information, so we can create a ffi library like jnr ffi does

Mozilla js-ctypes(https://developer.mozilla.org/en-US/docs/Mozilla/js-ctypes)
```js

Components.utils.import("resource://gre/modules/ctypes.jsm");

var kernel = ctypes.open("kernel32.dll");
var HMODULE = ctypes.uint32_t;
var HWND = ctypes.uint32_t;
var LPCTSTR = ctypes.jschar.ptr;
var LPCSTR = ctypes.char.ptr;
var LoadLibrary = kernel.declare("LoadLibraryW", ctypes.winapi_abi, HMODULE, LPCTSTR);
var GetProcAddress = kernel.declare("GetProcAddress", ctypes.winapi_abi, ctypes.void_t.ptr, HMODULE, LPCSTR);

var hUser = LoadLibrary("user32");
var funcPtr = GetProcAddress(hUser, "MessageBoxW");

// Now we have a pointer to a function, let's cast it to the right type
var MessageBoxType = ctypes.FunctionType(ctypes.winapi_abi, ctypes.int32_t, [HWND, LPCTSTR, LPCTSTR, ctypes.uint32_t]);
funcPtr = ctypes.cast(funcPtr, MessageBoxType.ptr);
funcPtr(0, "Test1", "Test2", 0);
```

Node (thrid-party [node-ffi](https://github.com/node-ffi/node-ffi)):
```js
var ffi = require('ffi');

var libm = ffi.Library('libm', {
  'ceil': [ 'double', [ 'double' ] ]
});
libm.ceil(1.5); // 2

// You can also access just functions in the current process by passing a null
var current = ffi.Library(null, {
  'atoi': [ 'int', [ 'string' ] ]
});
current.atoi('1234'); // 1234
```

[LuaJIT](https://luajit.org/ext_ffi.html):
```lua
local ffi = require("ffi")
ffi.cdef[[
int printf(const char *fmt, ...);
]]
ffi.C.printf("Hello %s!", "world")
```

[Python](https://docs.python.org/3/library/ctypes.html):
```python
from ctypes import cdll
library = cdll.LoadLibrary("libraylib.so")
library.BeginDrawing()

from ctypes import windll
print(windll.kernel32)  
```
[Go](https://golang.org/cmd/cgo/#hdr-Go_references_to_C):
```go
package main

// typedef int (*intFunc) ();
//
// int
// bridge_int_func(intFunc f)
// {
//		return f();
// }
//
// int fortytwo()
// {
//	    return 42;
// }
import "C"
import "fmt"

func main() {
	f := C.intFunc(C.fortytwo)
	fmt.Println(int(C.bridge_int_func(f)))
	// Output: 42
}
```