### PR TITLE
fix(fmt,lint): do not print number of checked files when quiet option is enabled

### DIFF
--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -78,13 +78,13 @@ async fn check_source_files(
             let _g = output_lock.lock().unwrap();
             match diff(&file_text, &formatted_text) {
               Ok(diff) => {
-                println!();
-                println!(
+                info!("");
+                info!(
                   "{} {}:",
                   colors::bold("from"),
                   file_path.display().to_string()
                 );
-                println!("{}", diff);
+                info!("{}", diff);
               }
               Err(e) => {
                 eprintln!(
@@ -113,7 +113,7 @@ async fn check_source_files(
   let checked_files_str =
     format!("{} {}", checked_files_count, files_str(checked_files_count));
   if not_formatted_files_count == 0 {
-    println!("Checked {}", checked_files_str);
+    info!("Checked {}", checked_files_str);
     Ok(())
   } else {
     let not_formatted_files_str = files_str(not_formatted_files_count);
@@ -151,7 +151,7 @@ async fn format_source_files(
             )?;
             formatted_files_count.fetch_add(1, Ordering::Relaxed);
             let _g = output_lock.lock().unwrap();
-            println!("{}", file_path.to_string_lossy());
+            info!("{}", file_path.to_string_lossy());
           }
         }
         Err(e) => {
@@ -173,7 +173,7 @@ async fn format_source_files(
   );
 
   let checked_files_count = checked_files_count.load(Ordering::Relaxed);
-  println!(
+  info!(
     "Checked {} {}",
     checked_files_count,
     files_str(checked_files_count)
@@ -211,7 +211,7 @@ fn format_stdin(check: bool) -> Result<(), AnyError> {
 }
 
 fn files_str(len: usize) -> &'static str {
-  if len == 1 {
+  if len <= 1 {
     "file"
   } else {
     "files"

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -105,6 +105,8 @@ pub async fn lint_files(
 pub fn print_rules_list() {
   let lint_rules = rules::get_recommended_rules();
 
+  // The rules should still be printed even if `--quiet` option is enabled,
+  // so use `println!` here instead of `info!`.
   println!("Available rules:");
   for rule in lint_rules {
     println!(" - {}", rule.code());
@@ -237,15 +239,15 @@ impl LintReporter for PrettyLintReporter {
 
   fn close(&mut self, check_count: usize) {
     match self.lint_count {
-      1 => eprintln!("Found 1 problem"),
-      n if n > 1 => eprintln!("Found {} problems", self.lint_count),
+      1 => info!("Found 1 problem"),
+      n if n > 1 => info!("Found {} problems", self.lint_count),
       _ => (),
     }
 
     match check_count {
-      1 => println!("Checked 1 file"),
-      n if n > 1 => println!("Checked {} files", n),
-      _ => (),
+      n if n <= 1 => info!("Checked {} file", n),
+      n if n > 1 => info!("Checked {} files", n),
+      _ => unreachable!(),
     }
   }
 }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1787,6 +1787,12 @@ itest!(fmt_check_tests_dir {
   exit_code: 1,
 });
 
+itest!(fmt_quiet_check_fmt_dir {
+  args: "fmt --check --quiet fmt/",
+  output_str: Some(""),
+  exit_code: 0,
+});
+
 itest!(fmt_check_formatted_files {
   args: "fmt --check fmt/formatted1.js fmt/formatted2.ts",
   output: "fmt/expected_fmt_check_formatted_files.out",
@@ -2354,6 +2360,12 @@ itest!(deno_lint {
   exit_code: 1,
 });
 
+itest!(deno_lint_quiet {
+  args: "lint --unstable --quiet lint/file1.js",
+  output: "lint/expected_quiet.out",
+  exit_code: 1,
+});
+
 itest!(deno_lint_json {
   args:
     "lint --unstable --json lint/file1.js lint/file2.ts lint/ignored_file.ts lint/malformed.js",
@@ -2385,6 +2397,19 @@ itest!(deno_lint_from_stdin_json {
   input: Some("let a: any;"),
   output: "lint/expected_from_stdin_json.out",
   exit_code: 1,
+});
+
+itest!(deno_lint_rules {
+  args: "lint --unstable --rules",
+  output: "lint/expected_rules.out",
+  exit_code: 0,
+});
+
+// Make sure that the rules are printed if quiet option is enabled.
+itest!(deno_lint_rules_quiet {
+  args: "lint --unstable --rules -q",
+  output: "lint/expected_rules.out",
+  exit_code: 0,
 });
 
 itest!(deno_doc_builtin {
@@ -3540,7 +3565,7 @@ fn lint_ignore_unexplicit_files() {
     .wait_with_output()
     .unwrap();
   assert!(output.status.success());
-  assert!(output.stderr.is_empty());
+  assert_eq!(output.stderr, b"Checked 0 file\n");
 }
 
 #[test]
@@ -3557,5 +3582,5 @@ fn fmt_ignore_unexplicit_files() {
     .wait_with_output()
     .unwrap();
   assert!(output.status.success());
-  assert!(output.stderr.is_empty());
+  assert_eq!(output.stderr, b"Checked 0 file\n");
 }

--- a/cli/tests/lint/expected_quiet.out
+++ b/cli/tests/lint/expected_quiet.out
@@ -1,0 +1,10 @@
+(ban-untagged-ignore) Ignore directive requires lint rule code
+// deno-lint-ignore
+^^^^^^^^^^^^^^^^^^^
+    at [WILDCARD]file1.js:1:0
+
+(no-empty) Empty block statement
+while (false) {}
+              ^^
+    at [WILDCARD]file1.js:2:14
+

--- a/cli/tests/lint/expected_rules.out
+++ b/cli/tests/lint/expected_rules.out
@@ -1,0 +1,2 @@
+Available rules:
+[WILDCARD]


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

This is separated PR of #7501, which directly fixes #7463 
The implementation detail is described in the original PR.

CC @bartlomieju 