### PR TITLE
BREAKING(std): add entry point

### DIFF
--- a/std/archive/mod.ts
+++ b/std/archive/mod.ts
@@ -1,0 +1,1 @@
+export * from "./tar.ts";

--- a/std/fmt/mod.ts
+++ b/std/fmt/mod.ts
@@ -1,0 +1,2 @@
+export * from "./colors.ts";
+export * from "./printf.ts";

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -3,7 +3,7 @@
  * for AssertionError messages in browsers. */
 
 import { red, green, white, gray, bold, stripColor } from "../fmt/colors.ts";
-import diff, { DiffType, DiffResult } from "./diff.ts";
+import { diff, DiffType, DiffResult } from "./diff.ts";
 
 const CAN_NOT_DISPLAY = "[Cannot display]";
 

--- a/std/testing/diff.ts
+++ b/std/testing/diff.ts
@@ -36,7 +36,7 @@ function createCommon<T>(A: T[], B: T[], reverse?: boolean): T[] {
   return common;
 }
 
-export default function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
+export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
   const prefixCommon = createCommon(A, B);
   const suffixCommon = createCommon(
     A.slice(prefixCommon.length),

--- a/std/testing/diff_test.ts
+++ b/std/testing/diff_test.ts
@@ -1,4 +1,4 @@
-import diff from "./diff.ts";
+import { diff } from "./diff.ts";
 import { assertEquals } from "../testing/asserts.ts";
 
 Deno.test({

--- a/std/testing/mod.ts
+++ b/std/testing/mod.ts
@@ -1,0 +1,3 @@
+export * from "./asserts.ts";
+export * from "./bench.ts";
+export * from "./diff.ts";


### PR DESCRIPTION
This PR creates entry point mod.ts for std which has no entry point

---

## BREAKING

changes default export diff to not be defalt in `std/testing/diff.ts`