### PR TITLE
fix(cli/repl): interpret object literals as expressions

### DIFF
--- a/cli/rt/40_repl.js
+++ b/cli/rt/40_repl.js
@@ -59,7 +59,7 @@
       // statement rather than an object literal so we interpret it as an expression statement
       // to match the behavior found in a typical prompt including browser developer tools.
       code = code.trim();
-      if (code.startsWith("{")) {
+      if (code.startsWith("{") && !code.endsWith(";")) {
         code = `(${code})`;
       }
     }

--- a/cli/rt/40_repl.js
+++ b/cli/rt/40_repl.js
@@ -56,8 +56,9 @@
     // It is a bit unexpected that { "foo": "bar" } is interpreted as a block
     // statement rather than an object literal so we interpret it as an expression statement
     // to match the behavior found in a typical prompt including browser developer tools.
+    code = code.trim();
     if (code.startsWith("{") && code.endsWith("}")) {
-      code = `(${code.trim()})`;
+      code = `(${code})`;
     }
 
     // each evalContext is a separate function body, and we want strict mode to

--- a/cli/rt/40_repl.js
+++ b/cli/rt/40_repl.js
@@ -53,6 +53,12 @@
   // Returns true if code is consumed (no error/irrecoverable error).
   // Returns false if error is recoverable
   function evaluate(code) {
+    // It is a bit unexpected that { "foo": "bar" } is interpreted as a block
+    // statement rather than an object literal so we interpret it as an expression statement.
+    if (code.startsWith("{") && code.endsWith("}")) {
+      code = `(${code.trim()})`;
+    }
+
     // each evalContext is a separate function body, and we want strict mode to
     // work, so we should ensure that the code starts with "use strict"
     const [result, errInfo] = core.evalContext(`"use strict";\n\n${code}`);

--- a/cli/rt/40_repl.js
+++ b/cli/rt/40_repl.js
@@ -54,7 +54,8 @@
   // Returns false if error is recoverable
   function evaluate(code) {
     // It is a bit unexpected that { "foo": "bar" } is interpreted as a block
-    // statement rather than an object literal so we interpret it as an expression statement.
+    // statement rather than an object literal so we interpret it as an expression statement
+    // to match the behavior found in a typical prompt including browser developer tools.
     if (code.startsWith("{") && code.endsWith("}")) {
       code = `(${code.trim()})`;
     }

--- a/cli/rt/40_repl.js
+++ b/cli/rt/40_repl.js
@@ -58,8 +58,7 @@
       // It is a bit unexpected that { "foo": "bar" } is interpreted as a block
       // statement rather than an object literal so we interpret it as an expression statement
       // to match the behavior found in a typical prompt including browser developer tools.
-      code = code.trim();
-      if (code.startsWith("{") && !code.endsWith(";")) {
+      if (code.trimLeft().startsWith("{") && !code.trimRight().endsWith(";")) {
         code = `(${code})`;
       }
     }
@@ -77,7 +76,7 @@
       if (!isCloseCalled()) {
         replLog("%o", lastEvalResult);
       }
-    } else if (errInfo.isCompileError && preprocess) {
+    } else if (errInfo.isCompileError && code.length != rawCode.length) {
       return evaluate(rawCode, false);
     } else if (errInfo.isCompileError && isRecoverableError(errInfo.thrown)) {
       // Recoverable compiler error

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1062,13 +1062,27 @@ fn repl_test_object_literal() {
   let (out, err) = util::run_and_collect_output(
     true,
     "repl",
-    Some(vec!["{ foo: 'bar' }"]),
+    Some(vec!["{}", "{ foo: 'bar' }"]),
     Some(vec![("NO_COLOR".to_owned(), "1".to_owned())]),
     false,
   );
-  assert!(out.ends_with("{ foo: \"bar\" }\n"));
+  assert!(out.ends_with("{}\n{ foo: \"bar\" }\n"));
   assert!(err.is_empty());
 }
+
+#[test]
+fn repl_test_block_expression() {
+  let (out, err) = util::run_and_collect_output(
+    true,
+    "repl",
+    Some(vec!["{};", "{\"\"}"]),
+    Some(vec![("NO_COLOR".to_owned(), "1".to_owned())]),
+    false,
+  );
+  assert!(out.ends_with("undefined\n\"\"\n"));
+  assert!(err.is_empty());
+}
+
 
 #[test]
 fn repl_cwd() {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1058,6 +1058,19 @@ fn repl_test_console_log() {
 }
 
 #[test]
+fn repl_test_object_literal() {
+  let (out, err) = util::run_and_collect_output(
+    true,
+    "repl",
+    Some(vec!["{ foo: 'bar' }"]),
+    Some(vec![("NO_COLOR".to_owned(), "1".to_owned())]),
+    false,
+  );
+  assert!(out.ends_with("{ foo: \"bar\" }\n"));
+  assert!(err.is_empty());
+}
+
+#[test]
 fn repl_cwd() {
   let (_out, err) = util::run_and_collect_output(
     true,

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1083,7 +1083,6 @@ fn repl_test_block_expression() {
   assert!(err.is_empty());
 }
 
-
 #[test]
 fn repl_cwd() {
   let (_out, err) = util::run_and_collect_output(


### PR DESCRIPTION
This wraps object literals in parenthesis so that they're interpreted as expressions rather than block statements which matches the behaviour of Node and web-browsers.

Fixes #1421