### PR TITLE
Bug: documentation Examples don't comply with sentence case titles

### DIFF
--- a/docs/examples/fetch_data.md
+++ b/docs/examples/fetch_data.md
@@ -1,4 +1,4 @@
-# Fetch Data
+# Fetch data
 
 ## Concepts
 

--- a/docs/examples/hello_world.md
+++ b/docs/examples/hello_world.md
@@ -1,4 +1,4 @@
-# Hello World
+# Hello world
 
 ## Concepts
 

--- a/docs/examples/import_export.md
+++ b/docs/examples/import_export.md
@@ -1,4 +1,4 @@
-# Import and Export Modules
+# Import and export modules
 
 ## Concepts
 

--- a/docs/examples/manage_dependencies.md
+++ b/docs/examples/manage_dependencies.md
@@ -1,4 +1,4 @@
-# Managing Dependencies
+# Managing dependencies
 
 ## Concepts
 
@@ -30,8 +30,8 @@ clean separation between dev only and production dependencies.
 
 ```ts
 /**
- * deps.ts 
- * 
+ * deps.ts
+ *
  * This module re-exports the required methods from the dependant remote Ramda module.
  **/
 export {

--- a/docs/examples/read_write_files.md
+++ b/docs/examples/read_write_files.md
@@ -1,4 +1,4 @@
-# Read and Write Files
+# Read and write files
 
 ## Concepts
 

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -40,11 +40,11 @@
   "examples": {
     "name": "Examples",
     "children": {
-      "hello_world": "Hello World",
-      "import_export": "Import and Export Modules",
-      "manage_dependencies": "Manage Dependencies",
-      "fetch_data": "Fetch Data",
-      "read_write_files": "Read and Write Files",
+      "hello_world": "Hello world",
+      "import_export": "Import and export modules",
+      "manage_dependencies": "Manage dependencies",
+      "fetch_data": "Fetch data",
+      "read_write_files": "Read and write files",
       "unix_cat": "Unix cat program",
       "http_server": "HTTP web server",
       "file_server": "File server",


### PR DESCRIPTION
Minor bug fix to bring further consistency to the documentation.

The Basic Example titles don't comply with the 'sentence case' formatting for titles which all the other documentation files comply with.