### PR TITLE
fix: make --watch and --inspect conflicting args

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1380,6 +1380,8 @@ fn watch_arg<'a, 'b>() -> Arg<'a, 'b> {
   Arg::with_name("watch")
     .requires("unstable")
     .long("watch")
+    .conflicts_with("inspect")
+    .conflicts_with("inspect-brk")
     .help("Watch for file changes and restart process automatically")
     .long_help(
       "Watch for file changes and restart process automatically.


### PR DESCRIPTION
--watch and --inspect don't really work together right now. When the watcher restarts the script, the inspector needs to be reconnected.

I think if we ever do allow this we should have the inspector automatically reconnect, and reinitialize itself (if that is possible). That would mean you connect to one inspector, and stay connected, even if the watcher restarts.