### PR TITLE
fix: Response.arrayBuffer() doesn't return promise

### DIFF
--- a/cli/tests/unit/response_test.ts
+++ b/cli/tests/unit/response_test.ts
@@ -1,0 +1,49 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import { unitTest, assert, assertEquals } from "./test_util.ts";
+
+unitTest(async function responseText() {
+  const response = new Response("hello world");
+  const textPromise = response.text();
+  assert(textPromise instanceof Promise);
+  const text = await textPromise;
+  assert(typeof text === "string");
+  assertEquals(text, "hello world");
+});
+
+unitTest(async function responseArrayBuffer() {
+  const response = new Response(new Uint8Array([1, 2, 3]));
+  const arrayBufferPromise = response.arrayBuffer();
+  assert(arrayBufferPromise instanceof Promise);
+  const arrayBuffer = await arrayBufferPromise;
+  assert(arrayBuffer instanceof ArrayBuffer);
+  assertEquals(new Uint8Array(arrayBuffer), new Uint8Array([1, 2, 3]));
+});
+
+unitTest(async function responseJson() {
+  const response = new Response('{"hello": "world"}');
+  const jsonPromise = response.json();
+  assert(jsonPromise instanceof Promise);
+  const json = await jsonPromise;
+  assert(json instanceof Object);
+  assertEquals(json, { hello: "world" });
+});
+
+unitTest(async function responseBlob() {
+  const response = new Response(new Uint8Array([1, 2, 3]));
+  const blobPromise = response.blob();
+  assert(blobPromise instanceof Promise);
+  const blob = await blobPromise;
+  assert(blob instanceof Blob);
+  assertEquals(blob, new Blob([new Uint8Array([1, 2, 3])]));
+});
+
+unitTest(async function responseBlob() {
+  const input = new FormData();
+  input.append("hello", "world");
+  const response = new Response(input);
+  const formDataPromise = response.formData();
+  assert(formDataPromise instanceof Promise);
+  const formData = await formDataPromise;
+  assert(formData instanceof FormData);
+  assertEquals(formData, input);
+});

--- a/cli/tests/unit/response_test.ts
+++ b/cli/tests/unit/response_test.ts
@@ -37,10 +37,12 @@ unitTest(async function responseBlob() {
   assertEquals(blob, new Blob([new Uint8Array([1, 2, 3])]));
 });
 
-unitTest(async function responseBlob() {
+unitTest(async function responseFormData() {
   const input = new FormData();
   input.append("hello", "world");
-  const response = new Response(input);
+  const response = new Response(input, {
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+  });
   const formDataPromise = response.formData();
   assert(formDataPromise instanceof Promise);
   const formData = await formDataPromise;

--- a/cli/tests/unit/unit_tests.ts
+++ b/cli/tests/unit/unit_tests.ts
@@ -54,6 +54,7 @@ import "./remove_test.ts";
 import "./rename_test.ts";
 import "./request_test.ts";
 import "./resources_test.ts";
+import "./response_test.ts";
 import "./signal_test.ts";
 import "./stat_test.ts";
 import "./stdio_test.ts";

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -865,7 +865,7 @@
       return JSON.parse(raw);
     }
 
-    arrayBuffer() {
+    async arrayBuffer() {
       if (this._bodySource instanceof ReadableStream) {
         return bufferFromStream(this._bodySource.getReader(), this.#size);
       }

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -865,15 +865,11 @@
       return JSON.parse(raw);
     }
 
-    async arrayBuffer() {
+    arrayBuffer() {
       if (this._bodySource instanceof ReadableStream) {
-        const buffer = await bufferFromStream(
-          this._bodySource.getReader(),
-          this.#size,
-        );
-        return buffer;
+        return bufferFromStream(this._bodySource.getReader(), this.#size);
       }
-      return bodyToArrayBuffer(this._bodySource);
+      return Promise.resolve(bodyToArrayBuffer(this._bodySource));
     }
   }
 

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -867,7 +867,11 @@
 
     async arrayBuffer() {
       if (this._bodySource instanceof ReadableStream) {
-        return bufferFromStream(this._bodySource.getReader(), this.#size);
+        const buffer = await bufferFromStream(
+          this._bodySource.getReader(),
+          this.#size,
+        );
+        return buffer;
       }
       return bodyToArrayBuffer(this._bodySource);
     }


### PR DESCRIPTION
Added tests to make sure all response methods return promises, not literal values. We didn't catch this, because `await` on a non promise works fine. This is a bug TypeScript would have caught :-/