### PR TITLE
refactor(cli/fmt_errors): Color stack traces in Rust

### DIFF
--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -12,8 +12,7 @@ use crate::fmt::collect_files;
 use crate::fmt::run_parallelized;
 use crate::fmt_errors;
 use crate::media_type::MediaType;
-use deno_core::error::generic_error;
-use deno_core::error::AnyError;
+use deno_core::error::{generic_error, AnyError, JsStackFrame};
 use deno_core::serde_json;
 use deno_lint::diagnostic::LintDiagnostic;
 use deno_lint::linter::Linter;
@@ -223,11 +222,11 @@ impl LintReporter for PrettyLintReporter {
       &pretty_message,
       &source_lines,
       d.range.clone(),
-      &fmt_errors::format_location(
-        &d.filename,
-        d.range.start.line as i64,
-        d.range.start.col as i64,
-      ),
+      &fmt_errors::format_location(&JsStackFrame::from_location(
+        Some(d.filename.clone()),
+        Some(d.range.start.line as i64),
+        Some(d.range.start.col as i64),
+      )),
     );
 
     eprintln!("{}\n", message);

--- a/cli/rt/40_error_stack.js
+++ b/cli/rt/40_error_stack.js
@@ -4,7 +4,6 @@
   // Some of the code here is adapted directly from V8 and licensed under a BSD
   // style license available here: https://github.com/v8/v8/blob/24886f2d1c565287d33d71e4109a53bf0b54b75c/LICENSE.v8
   const core = window.Deno.core;
-  const colors = window.__bootstrap.colors;
   const assert = window.__bootstrap.util.assert;
   const internals = window.__bootstrap.internals;
 
@@ -74,81 +73,42 @@
     };
   }
 
-  function getMethodCall(callSite) {
-    let result = "";
-
-    const typeName = callSite.getTypeName();
-    const methodName = callSite.getMethodName();
-    const functionName = callSite.getFunctionName();
-
-    if (functionName) {
-      if (typeName) {
-        const startsWithTypeName = functionName.startsWith(typeName);
-        if (!startsWithTypeName) {
-          result += `${typeName}.`;
-        }
-      }
-      result += functionName;
-
-      if (methodName) {
-        if (!functionName.endsWith(methodName)) {
-          result += ` [as ${methodName}]`;
-        }
-      }
-    } else {
-      if (typeName) {
-        result += `${typeName}.`;
-      }
-      if (methodName) {
-        result += methodName;
-      } else {
-        result += "<anonymous>";
-      }
-    }
-
-    return result;
-  }
-
-  function getFileLocation(callSite, internal = false) {
-    const cyan = internal ? colors.gray : colors.cyan;
-    const yellow = internal ? colors.gray : colors.yellow;
-    const black = internal ? colors.gray : (s) => s;
+  // Keep in sync with `cli/fmt_errors.rs`.
+  function formatLocation(callSite) {
     if (callSite.isNative()) {
-      return cyan("native");
+      return "native";
     }
 
     let result = "";
 
     const fileName = callSite.getFileName();
-    if (!fileName && callSite.isEval()) {
-      const evalOrigin = callSite.getEvalOrigin();
-      assert(evalOrigin != null);
-      result += cyan(`${evalOrigin}, `);
-    }
 
     if (fileName) {
-      result += cyan(fileName);
+      result += fileName;
     } else {
-      result += cyan("<anonymous>");
+      if (callSite.isEval()) {
+        const evalOrigin = callSite.getEvalOrigin();
+        assert(evalOrigin != null);
+        result += `${evalOrigin}, `;
+      }
+      result += "<anonymous>";
     }
 
     const lineNumber = callSite.getLineNumber();
     if (lineNumber != null) {
-      result += `${black(":")}${yellow(lineNumber.toString())}`;
+      result += `:${lineNumber}`;
 
       const columnNumber = callSite.getColumnNumber();
       if (columnNumber != null) {
-        result += `${black(":")}${yellow(columnNumber.toString())}`;
+        result += `:${columnNumber}`;
       }
     }
 
     return result;
   }
 
-  function callSiteToString(callSite, internal = false) {
-    const cyan = internal ? colors.gray : colors.cyan;
-    const black = internal ? colors.gray : (s) => s;
-
+  // Keep in sync with `cli/fmt_errors.rs`.
+  function formatCallSite(callSite) {
     let result = "";
     const functionName = callSite.getFunctionName();
 
@@ -159,35 +119,53 @@
     const isMethodCall = !(isTopLevel || isConstructor);
 
     if (isAsync) {
-      result += colors.gray("async ");
+      result += "async ";
     }
     if (isPromiseAll) {
-      result += colors.bold(
-        colors.italic(
-          black(`Promise.all (index ${callSite.getPromiseIndex()})`),
-        ),
-      );
+      result += `Promise.all (index ${callSite.getPromiseIndex()})`;
       return result;
     }
     if (isMethodCall) {
-      result += colors.bold(colors.italic(black(getMethodCall(callSite))));
-    } else if (isConstructor) {
-      result += colors.gray("new ");
+      const typeName = callSite.getTypeName();
+      const methodName = callSite.getMethodName();
+
       if (functionName) {
-        result += colors.bold(colors.italic(black(functionName)));
+        if (typeName) {
+          if (!functionName.startsWith(typeName)) {
+            result += `${typeName}.`;
+          }
+        }
+        result += functionName;
+        if (methodName) {
+          if (!functionName.endsWith(methodName)) {
+            result += ` [as ${methodName}]`;
+          }
+        }
       } else {
-        result += cyan("<anonymous>");
+        if (typeName) {
+          result += `${typeName}.`;
+        }
+        if (methodName) {
+          result += methodName;
+        } else {
+          result += "<anonymous>";
+        }
+      }
+    } else if (isConstructor) {
+      result += "new ";
+      if (functionName) {
+        result += functionName;
+      } else {
+        result += "<anonymous>";
       }
     } else if (functionName) {
-      result += colors.bold(colors.italic(black(functionName)));
+      result += functionName;
     } else {
-      result += getFileLocation(callSite, internal);
+      result += formatLocation(callSite);
       return result;
     }
 
-    result += ` ${black("(")}${getFileLocation(callSite, internal)}${
-      black(")")
-    }`;
+    result += ` (${formatLocation(callSite)})`;
     return result;
   }
 
@@ -236,19 +214,17 @@
     );
     Object.defineProperties(error, {
       __callSiteEvals: { value: [], configurable: true },
-      __formattedFrames: { value: [], configurable: true },
     });
+    const formattedCallSites = [];
     for (const callSite of mappedCallSites) {
       error.__callSiteEvals.push(Object.freeze(evaluateCallSite(callSite)));
-      const isInternal = callSite.getFileName()?.startsWith("deno:") ?? false;
-      error.__formattedFrames.push(callSiteToString(callSite, isInternal));
+      formattedCallSites.push(formatCallSite(callSite));
     }
     Object.freeze(error.__callSiteEvals);
-    Object.freeze(error.__formattedFrames);
     return (
       `${error.name}: ${error.message}\n` +
-      error.__formattedFrames
-        .map((s) => `    at ${colors.stripColor(s)}`)
+      formattedCallSites
+        .map((s) => `    at ${s}`)
         .join("\n")
     );
   }

--- a/cli/source_maps.rs
+++ b/cli/source_maps.rs
@@ -78,7 +78,6 @@ pub fn apply_source_map<G: SourceMapGetter>(
     start_column,
     end_column,
     frames: js_error.frames.clone(),
-    formatted_frames: js_error.formatted_frames.clone(),
   }
 }
 
@@ -205,7 +204,6 @@ mod tests {
       start_column: Some(16),
       end_column: None,
       frames: vec![],
-      formatted_frames: vec![],
     };
     let getter = MockSourceMapGetter {};
     let actual = apply_source_map(&e, &getter);

--- a/cli/tsc/40_error_stack.js
+++ b/cli/tsc/40_error_stack.js
@@ -5,19 +5,6 @@
   // style license available here: https://github.com/v8/v8/blob/24886f2d1c565287d33d71e4109a53bf0b54b75c/LICENSE.v8
   const assert = window.__bootstrap.util.assert;
 
-  // https://github.com/chalk/ansi-regex/blob/2b56fb0c7a07108e5b54241e8faec160d393aedb/index.js
-  const ANSI_PATTERN = new RegExp(
-    [
-      "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
-      "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))",
-    ].join("|"),
-    "g",
-  );
-
-  function stripColor(string) {
-    return string.replace(ANSI_PATTERN, "");
-  }
-
   function patchCallSite(callSite, location) {
     return {
       getThis() {
@@ -71,42 +58,8 @@
     };
   }
 
-  function getMethodCall(callSite) {
-    let result = "";
-
-    const typeName = callSite.getTypeName();
-    const methodName = callSite.getMethodName();
-    const functionName = callSite.getFunctionName();
-
-    if (functionName) {
-      if (typeName) {
-        const startsWithTypeName = functionName.startsWith(typeName);
-        if (!startsWithTypeName) {
-          result += `${typeName}.`;
-        }
-      }
-      result += functionName;
-
-      if (methodName) {
-        if (!functionName.endsWith(methodName)) {
-          result += ` [as ${methodName}]`;
-        }
-      }
-    } else {
-      if (typeName) {
-        result += `${typeName}.`;
-      }
-      if (methodName) {
-        result += methodName;
-      } else {
-        result += "<anonymous>";
-      }
-    }
-
-    return result;
-  }
-
-  function getFileLocation(callSite) {
+  // Keep in sync with `cli/fmt_errors.rs`.
+  function formatLocation(callSite) {
     if (callSite.isNative()) {
       return "native";
     }
@@ -114,32 +67,33 @@
     let result = "";
 
     const fileName = callSite.getFileName();
-    if (!fileName && callSite.isEval()) {
-      const evalOrigin = callSite.getEvalOrigin();
-      assert(evalOrigin != null);
-      result += `${evalOrigin}, `;
-    }
 
     if (fileName) {
       result += fileName;
     } else {
+      if (callSite.isEval()) {
+        const evalOrigin = callSite.getEvalOrigin();
+        assert(evalOrigin != null);
+        result += `${evalOrigin}, `;
+      }
       result += "<anonymous>";
     }
 
     const lineNumber = callSite.getLineNumber();
     if (lineNumber != null) {
-      result += `:${lineNumber.toString()}`;
+      result += `:${lineNumber}`;
 
       const columnNumber = callSite.getColumnNumber();
       if (columnNumber != null) {
-        result += `:${columnNumber.toString()}`;
+        result += `:${columnNumber}`;
       }
     }
 
     return result;
   }
 
-  function callSiteToString(callSite) {
+  // Keep in sync with `cli/fmt_errors.rs`.
+  function formatCallSite(callSite) {
     let result = "";
     const functionName = callSite.getFunctionName();
 
@@ -157,7 +111,31 @@
       return result;
     }
     if (isMethodCall) {
-      result += getMethodCall(callSite);
+      const typeName = callSite.getTypeName();
+      const methodName = callSite.getMethodName();
+
+      if (functionName) {
+        if (typeName) {
+          if (!functionName.startsWith(typeName)) {
+            result += `${typeName}.`;
+          }
+        }
+        result += functionName;
+        if (methodName) {
+          if (!functionName.endsWith(methodName)) {
+            result += ` [as ${methodName}]`;
+          }
+        }
+      } else {
+        if (typeName) {
+          result += `${typeName}.`;
+        }
+        if (methodName) {
+          result += methodName;
+        } else {
+          result += "<anonymous>";
+        }
+      }
     } else if (isConstructor) {
       result += "new ";
       if (functionName) {
@@ -168,11 +146,11 @@
     } else if (functionName) {
       result += functionName;
     } else {
-      result += getFileLocation(callSite);
+      result += formatLocation(callSite);
       return result;
     }
 
-    result += ` (${getFileLocation(callSite)})`;
+    result += ` (${formatLocation(callSite)})`;
     return result;
   }
 
@@ -209,11 +187,11 @@
         if (fileName && lineNumber != null && columnNumber != null) {
           return patchCallSite(
             callSite,
-            {
+            opApplySourceMap({
               fileName,
               lineNumber,
               columnNumber,
-            },
+            }),
           );
         }
         return callSite;
@@ -221,18 +199,17 @@
     );
     Object.defineProperties(error, {
       __callSiteEvals: { value: [], configurable: true },
-      __formattedFrames: { value: [], configurable: true },
     });
+    const formattedCallSites = [];
     for (const callSite of mappedCallSites) {
       error.__callSiteEvals.push(Object.freeze(evaluateCallSite(callSite)));
-      error.__formattedFrames.push(callSiteToString(callSite));
+      formattedCallSites.push(formatCallSite(callSite));
     }
     Object.freeze(error.__callSiteEvals);
-    Object.freeze(error.__formattedFrames);
     return (
       `${error.name}: ${error.message}\n` +
-      error.__formattedFrames
-        .map((s) => `    at ${stripColor(s)}`)
+      formattedCallSites
+        .map((s) => `    at ${s}`)
         .join("\n")
     );
   }

--- a/cli/tsc/40_error_stack.js
+++ b/cli/tsc/40_error_stack.js
@@ -187,11 +187,11 @@
         if (fileName && lineNumber != null && columnNumber != null) {
           return patchCallSite(
             callSite,
-            opApplySourceMap({
+            {
               fileName,
               lineNumber,
               columnNumber,
-            }),
+            },
           );
         }
         return callSite;


### PR DESCRIPTION
This duplicates formatting logic from `prepareStackTrace()` to `cli/fmt_errors` and removes colouring logic from `prepareStackTrace()`. In return, there's no `JsStackFrame::formatted_frames`, error formatting as a whole is greatly simplified and partially moving `prepareStackTrace()`  to core should be easier.

cc @bartlomieju 