### PR TITLE
feat(cli/coverage): print lines with no coverage to stdout

### DIFF
--- a/cli/coverage.rs
+++ b/cli/coverage.rs
@@ -240,35 +240,23 @@ pub struct GetScriptSourceResult {
 }
 
 pub struct PrettyCoverageReporter {
-  coverages: Vec<Coverage>,
+  quiet: bool,
 }
 
 // TODO(caspervonb) add support for lcov output (see geninfo(1) for format spec).
 impl PrettyCoverageReporter {
-  pub fn new(coverages: Vec<Coverage>) -> PrettyCoverageReporter {
-    PrettyCoverageReporter { coverages }
+  pub fn new(quiet: bool) -> PrettyCoverageReporter {
+    PrettyCoverageReporter { quiet }
   }
 
-  pub fn get_report(&self) -> String {
-    let mut report = String::from("test coverage:\n");
+  pub fn visit_coverage(&mut self, coverage: &Coverage) {
+    let lines = coverage.script_source.lines().collect::<Vec<_>>();
 
-    for coverage in &self.coverages {
-      if let Some(coverage_report) = Self::get_coverage_report(coverage) {
-        report.push_str(&format!("{}\n", coverage_report))
-      }
-    }
+    let mut covered_lines: Vec<usize> = Vec::new();
+    let mut uncovered_lines: Vec<usize> = Vec::new();
 
-    report
-  }
-
-  fn get_coverage_report(coverage: &Coverage) -> Option<String> {
-    let mut total_lines = 0;
-    let mut covered_lines = 0;
-
-    let mut line_offset = 0;
-
-    for line in coverage.script_source.lines() {
-      let line_start_offset = line_offset;
+    let mut line_start_offset = 0;
+    for (index, line) in lines.iter().enumerate() {
       let line_end_offset = line_start_offset + line.len();
 
       let mut count = 0;
@@ -277,48 +265,53 @@ impl PrettyCoverageReporter {
           if range.start_offset <= line_start_offset
             && range.end_offset >= line_end_offset
           {
-            count += range.count;
             if range.count == 0 {
               count = 0;
               break;
             }
+
+            count += range.count;
           }
         }
-      }
 
+        line_start_offset = line_end_offset;
+      }
       if count > 0 {
-        covered_lines += 1;
+        covered_lines.push(index);
+      } else {
+        uncovered_lines.push(index);
       }
-
-      total_lines += 1;
-      line_offset += line.len();
     }
 
-    let line_ratio = covered_lines as f32 / total_lines as f32;
-    let line_coverage = format!("{:.3}%", line_ratio * 100.0);
+    if !self.quiet {
+      print!("cover {} ... ", coverage.script_coverage.url);
 
-    let line = if line_ratio >= 0.9 {
-      format!(
-        "{} {}",
-        coverage.script_coverage.url,
-        colors::green(&line_coverage)
-      )
-    } else if line_ratio >= 0.75 {
-      format!(
-        "{} {}",
-        coverage.script_coverage.url,
-        colors::yellow(&line_coverage)
-      )
-    } else {
-      format!(
-        "{} {}",
-        coverage.script_coverage.url,
-        colors::red(&line_coverage)
-      )
-    };
+      let line_coverage_ratio = covered_lines.len() as f32 / lines.len() as f32;
+      let line_coverage = format!(
+        "{:.3}% ({}/{})",
+        line_coverage_ratio * 100.0,
+        covered_lines.len(),
+        lines.len()
+      );
 
-    Some(line)
+      if line_coverage_ratio >= 0.9 {
+        println!("{}", colors::green(&line_coverage));
+      } else if line_coverage_ratio >= 0.75 {
+        println!("{}", colors::yellow(&line_coverage));
+      } else {
+        println!("{}", colors::red(&line_coverage));
+      }
+
+      for line_index in uncovered_lines {
+        let line =
+          format!("{:width$} {}", line_index + 1, lines[line_index], width = 4);
+
+        println!("{}", colors::red(&line));
+      }
+    }
   }
+
+  pub fn close(&self) {}
 }
 
 fn new_box_with<T>(new_fn: impl FnOnce(*mut T) -> T) -> Box<T> {

--- a/cli/coverage.rs
+++ b/cli/coverage.rs
@@ -303,7 +303,12 @@ impl PrettyCoverageReporter {
       }
 
       for line_index in uncovered_lines {
-        println!("{:width$} {}", line_index + 1, colors::red(&lines[line_index]), width = 4);
+        println!(
+          "{:width$} {}",
+          line_index + 1,
+          colors::red(&lines[line_index]),
+          width = 4
+        );
       }
     }
   }

--- a/cli/coverage.rs
+++ b/cli/coverage.rs
@@ -311,7 +311,6 @@ impl PrettyCoverageReporter {
     }
   }
 
-  pub fn close(&self) {}
 }
 
 fn new_box_with<T>(new_fn: impl FnOnce(*mut T) -> T) -> Box<T> {

--- a/cli/coverage.rs
+++ b/cli/coverage.rs
@@ -303,10 +303,7 @@ impl PrettyCoverageReporter {
       }
 
       for line_index in uncovered_lines {
-        let line =
-          format!("{:width$} {}", line_index + 1, lines[line_index], width = 4);
-
-        println!("{}", colors::red(&line));
+        println!("{:width$} {}", line_index + 1, colors::red(&lines[line_index]), width = 4);
       }
     }
   }

--- a/cli/coverage.rs
+++ b/cli/coverage.rs
@@ -310,7 +310,6 @@ impl PrettyCoverageReporter {
       }
     }
   }
-
 }
 
 fn new_box_with<T>(new_fn: impl FnOnce(*mut T) -> T) -> Box<T> {

--- a/cli/coverage.rs
+++ b/cli/coverage.rs
@@ -304,8 +304,9 @@ impl PrettyCoverageReporter {
 
       for line_index in uncovered_lines {
         println!(
-          "{:width$} {}",
+          "{:width$}{} {}",
           line_index + 1,
+          colors::gray(" |"),
           colors::red(&lines[line_index]),
           width = 4
         );

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -601,19 +601,18 @@ async fn test_command(
   (&mut *worker).await?;
 
   if let Some(coverage_collector) = maybe_coverage_collector.as_mut() {
-    let script_coverage = coverage_collector.collect().await?;
+    let coverages = coverage_collector.collect().await?;
     coverage_collector.stop_collecting().await?;
 
-    let filtered_coverage = coverage::filter_script_coverages(
-      script_coverage,
-      test_file_url,
-      test_modules,
-    );
+    let filtered_coverages =
+      coverage::filter_script_coverages(coverages, test_file_url, test_modules);
 
-    let pretty_coverage_reporter =
-      PrettyCoverageReporter::new(filtered_coverage);
-    let report = pretty_coverage_reporter.get_report();
-    print!("{}", report)
+    let mut coverage_reporter = PrettyCoverageReporter::new(quiet);
+    for coverage in filtered_coverages {
+      coverage_reporter.visit_coverage(&coverage);
+    }
+
+    coverage_reporter.close();
   }
 
   Ok(())

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -612,7 +612,6 @@ async fn test_command(
       coverage_reporter.visit_coverage(&coverage);
     }
 
-    coverage_reporter.close();
   }
 
   Ok(())

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -611,7 +611,6 @@ async fn test_command(
     for coverage in filtered_coverages {
       coverage_reporter.visit_coverage(&coverage);
     }
-
   }
 
   Ok(())

--- a/cli/tests/test_coverage.out
+++ b/cli/tests/test_coverage.out
@@ -4,7 +4,24 @@ test returnsHiSuccess ... ok ([WILDCARD])
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
-test coverage:
-file://[WILDCARD]/cli/tests/subdir/mod1.ts 57.143%
-file://[WILDCARD]/cli/tests/subdir/subdir2/mod2.ts 50.000%
-file://[WILDCARD]/cli/tests/subdir/print_hello.ts 50.000%
+cover [WILDCARD]/cli/tests/subdir/mod1.ts ... 35.714% (5/14)
+   5 export function returnsFoo2() {
+   6     return returnsFoo();
+   7 }
+   8 export function printHello3() {
+   9     printHello2();
+  10 }
+  11 export function throwsError() {
+  12     throw Error("exception from mod1");
+  13 }
+cover [WILDCARD]/cli/tests/subdir/subdir2/mod2.ts ... 25.000% (2/8)
+   2 export function returnsFoo() {
+   3     return "Foo";
+   4 }
+   5 export function printHello2() {
+   6     printHello();
+   7 }
+cover [WILDCARD]/cli/tests/subdir/print_hello.ts ... 25.000% (1/4)
+   1 export function printHello() {
+   2     console.log("Hello");
+   3 }

--- a/cli/tests/test_coverage.out
+++ b/cli/tests/test_coverage.out
@@ -5,23 +5,23 @@ test returnsHiSuccess ... ok ([WILDCARD])
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
 cover [WILDCARD]/cli/tests/subdir/mod1.ts ... 35.714% (5/14)
-   5 export function returnsFoo2() {
-   6     return returnsFoo();
-   7 }
-   8 export function printHello3() {
-   9     printHello2();
-  10 }
-  11 export function throwsError() {
-  12     throw Error("exception from mod1");
-  13 }
+   5 | export function returnsFoo2() {
+   6 |     return returnsFoo();
+   7 | }
+   8 | export function printHello3() {
+   9 |     printHello2();
+  10 | }
+  11 | export function throwsError() {
+  12 |     throw Error("exception from mod1");
+  13 | }
 cover [WILDCARD]/cli/tests/subdir/subdir2/mod2.ts ... 25.000% (2/8)
-   2 export function returnsFoo() {
-   3     return "Foo";
-   4 }
-   5 export function printHello2() {
-   6     printHello();
-   7 }
+   2 | export function returnsFoo() {
+   3 |     return "Foo";
+   4 | }
+   5 | export function printHello2() {
+   6 |     printHello();
+   7 | }
 cover [WILDCARD]/cli/tests/subdir/print_hello.ts ... 25.000% (1/4)
-   1 export function printHello() {
-   2     console.log("Hello");
-   3 }
+   1 | export function printHello() {
+   2 |     console.log("Hello");
+   3 | }


### PR DESCRIPTION
This pretty prints uncovered lines as red text with line numbers to stdout with the coverage report.

![Screenshot 2020-09-23 at 2 18 39 PM](https://user-images.githubusercontent.com/157787/93974064-da2d7780-fda7-11ea-8ad4-f3f8ba1bf960.png)
