### PR TITLE
fix(cli/console): quote non-alphanumeric symbols

### DIFF
--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -414,7 +414,7 @@
       case "undefined": // undefined is dim
         return dim(String(value));
       case "symbol": // Symbols are green
-        return green(String(value));
+        return green(maybeQuoteSymbol(value));
       case "bigint": // Bigints are yellow
         return yellow(`${value}n`);
       case "function": // Function string is cyan

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -106,6 +106,32 @@ unitTest(
     );
     assertEquals(
       stringify(
+        [
+          Symbol(),
+          Symbol(""),
+          Symbol("foo\b"),
+          Symbol("foo\f"),
+          Symbol("foo\n"),
+          Symbol("foo\r"),
+          Symbol("foo\t"),
+          Symbol("foo\v"),
+          Symbol("foo\0"),
+        ],
+      ),
+      `[
+  Symbol(),
+  Symbol(""),
+  Symbol("foo\\b"),
+  Symbol("foo\\f"),
+  Symbol("foo\\n"),
+  Symbol("foo\\r"),
+  Symbol("foo\\t"),
+  Symbol("foo\\v"),
+  Symbol("foo\\x00")
+]`,
+    );
+    assertEquals(
+      stringify(
         { "foo\b": "bar\n", "bar\r": "baz\t", "qux\0": "qux\0" },
       ),
       `{ "foo\\b": "bar\\n", "bar\\r": "baz\\t", "qux\\x00": "qux\\x00" }`,
@@ -247,7 +273,7 @@ unitTest(function consoleTestStringifyCircular(): void {
   );
   assertEquals(stringify(new WeakSet()), "WeakSet { [items unknown] }");
   assertEquals(stringify(new WeakMap()), "WeakMap { [items unknown] }");
-  assertEquals(stringify(Symbol(1)), "Symbol(1)");
+  assertEquals(stringify(Symbol(1)), `Symbol("1")`);
   assertEquals(stringify(null), "null");
   assertEquals(stringify(undefined), "undefined");
   assertEquals(stringify(new Extended()), "Extended { a: 1, b: 2 }");


### PR DESCRIPTION
This quotes and escapes symbol descriptions that contains characters outside of the basic alpha-numeric identifier range.

Fixes an issue brought up in #7551 
