### PR TITLE
fix(cli/console): enclose symbol keys in brackets

### DIFF
--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -747,7 +747,7 @@
     }
     for (const key of symbolKeys) {
       entries.push(
-        `${maybeQuoteSymbol(key)}: ${
+        `[${maybeQuoteSymbol(key)}]: ${
           inspectValueWithQuotes(
             value[key],
             ctx,

--- a/cli/tests/041_dyn_import_eval.out
+++ b/cli/tests/041_dyn_import_eval.out
@@ -1,1 +1,1 @@
-Module { isMod4: true, Symbol(Symbol.toStringTag): "Module" }
+Module { isMod4: true, [Symbol(Symbol.toStringTag)]: "Module" }

--- a/cli/tests/042_dyn_import_evalcontext.ts.out
+++ b/cli/tests/042_dyn_import_evalcontext.ts.out
@@ -1,1 +1,1 @@
-Module { isMod4: true, Symbol(Symbol.toStringTag): "Module" }
+Module { isMod4: true, [Symbol(Symbol.toStringTag)]: "Module" }

--- a/cli/tests/fix_js_imports.ts.out
+++ b/cli/tests/fix_js_imports.ts.out
@@ -1,1 +1,1 @@
-Module { Symbol(Symbol.toStringTag): "Module" }
+Module { [Symbol(Symbol.toStringTag)]: "Module" }

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -121,11 +121,11 @@ unitTest(
         },
       ),
       `{
-  Symbol("foo\\b"): 'Symbol("foo\\n\")',
-  Symbol("bar\\n"): 'Symbol("bar\\n\")',
-  Symbol("bar\\r"): 'Symbol("bar\\r\")',
-  Symbol("baz\\t"): 'Symbol("baz\\t\")',
-  Symbol("qux\\x00"): 'Symbol(\"qux\\x00")'
+  [Symbol("foo\\b")]: 'Symbol("foo\\n\")',
+  [Symbol("bar\\n")]: 'Symbol("bar\\n\")',
+  [Symbol("bar\\r")]: 'Symbol("bar\\r\")',
+  [Symbol("baz\\t")]: 'Symbol("baz\\t\")',
+  [Symbol("qux\\x00")]: 'Symbol(\"qux\\x00")'
 }`,
     );
     assertEquals(
@@ -277,7 +277,10 @@ unitTest(function consoleTestStringifyCircular(): void {
     "{ a: { b: { c: { d: [Set] } } } }",
   );
   assertEquals(stringify(nestedObj), nestedObjExpected);
-  assertEquals(stringify(JSON), 'JSON { Symbol(Symbol.toStringTag): "JSON" }');
+  assertEquals(
+    stringify(JSON),
+    'JSON { [Symbol(Symbol.toStringTag)]: "JSON" }',
+  );
   assertEquals(
     stringify(console),
     `{
@@ -301,12 +304,12 @@ unitTest(function consoleTestStringifyCircular(): void {
   clear: [Function: clear],
   trace: [Function: trace],
   indentLevel: 0,
-  Symbol(isConsoleInstance): true
+  [Symbol(isConsoleInstance)]: true
 }`,
   );
   assertEquals(
     stringify({ str: 1, [Symbol.for("sym")]: 2, [Symbol.toStringTag]: "TAG" }),
-    'TAG { str: 1, Symbol(sym): 2, Symbol(Symbol.toStringTag): "TAG" }',
+    'TAG { str: 1, [Symbol(sym)]: 2, [Symbol(Symbol.toStringTag)]: "TAG" }',
   );
   // test inspect is working the same
   assertEquals(stripColor(Deno.inspect(nestedObj)), nestedObjExpected);
@@ -798,7 +801,7 @@ unitTest(function consoleTestWithCustomInspectorError(): void {
   assertEquals(stringify(new B({ a: "a" })), "a");
   assertEquals(
     stringify(B.prototype),
-    "{ Symbol(Deno.customInspect): [Function: [Deno.customInspect]] }",
+    "{ [Symbol(Deno.customInspect)]: [Function: [Deno.customInspect]] }",
   );
 });
 


### PR DESCRIPTION
This encloses symbol keys when used in objects with brackets (e.g `[Symbol("Symbol.iterator")]`).

Fixes an issue brought up in #7551 