### PR TITLE
fix(std/fs): mark createWalkEntry(Sync) as internal

### DIFF
--- a/std/fs/expand_glob.ts
+++ b/std/fs/expand_glob.ts
@@ -10,8 +10,8 @@ import {
 } from "../path/mod.ts";
 import {
   WalkEntry,
-  createWalkEntry,
-  createWalkEntrySync,
+  _createWalkEntry,
+  _createWalkEntrySync,
   walk,
   walkSync,
 } from "./walk.ts";
@@ -104,7 +104,7 @@ export async function* expandGlob(
 
   let fixedRootInfo: WalkEntry;
   try {
-    fixedRootInfo = await createWalkEntry(fixedRoot);
+    fixedRootInfo = await _createWalkEntry(fixedRoot);
   } catch (error) {
     return throwUnlessNotFound(error);
   }
@@ -119,7 +119,7 @@ export async function* expandGlob(
       const parentPath = joinGlobs([walkInfo.path, ".."], globOptions);
       try {
         if (shouldInclude(parentPath)) {
-          return yield await createWalkEntry(parentPath);
+          return yield await _createWalkEntry(parentPath);
         }
       } catch (error) {
         throwUnlessNotFound(error);
@@ -211,7 +211,7 @@ export function* expandGlobSync(
 
   let fixedRootInfo: WalkEntry;
   try {
-    fixedRootInfo = createWalkEntrySync(fixedRoot);
+    fixedRootInfo = _createWalkEntrySync(fixedRoot);
   } catch (error) {
     return throwUnlessNotFound(error);
   }
@@ -226,7 +226,7 @@ export function* expandGlobSync(
       const parentPath = joinGlobs([walkInfo.path, ".."], globOptions);
       try {
         if (shouldInclude(parentPath)) {
-          return yield createWalkEntrySync(parentPath);
+          return yield _createWalkEntrySync(parentPath);
         }
       } catch (error) {
         throwUnlessNotFound(error);

--- a/std/fs/walk.ts
+++ b/std/fs/walk.ts
@@ -4,7 +4,7 @@
 import { assert } from "../_util/assert.ts";
 import { basename, join, normalize } from "../path/mod.ts";
 
-export function createWalkEntrySync(path: string): WalkEntry {
+export function _createWalkEntrySync(path: string): WalkEntry {
   path = normalize(path);
   const name = basename(path);
   const info = Deno.statSync(path);
@@ -17,7 +17,7 @@ export function createWalkEntrySync(path: string): WalkEntry {
   };
 }
 
-export async function createWalkEntry(path: string): Promise<WalkEntry> {
+export async function _createWalkEntry(path: string): Promise<WalkEntry> {
   path = normalize(path);
   const name = basename(path);
   const info = await Deno.stat(path);
@@ -98,7 +98,7 @@ export async function* walk(
     return;
   }
   if (includeDirs && include(root, exts, match, skip)) {
-    yield await createWalkEntry(root);
+    yield await _createWalkEntry(root);
   }
   if (maxDepth < 1 || !include(root, undefined, undefined, skip)) {
     return;
@@ -151,7 +151,7 @@ export function* walkSync(
     return;
   }
   if (includeDirs && include(root, exts, match, skip)) {
-    yield createWalkEntrySync(root);
+    yield _createWalkEntrySync(root);
   }
   if (maxDepth < 1 || !include(root, undefined, undefined, skip)) {
     return;


### PR DESCRIPTION
This marks createWalkEntry and createWalkEntry in std/fs as internal via an underscore prefix.
These were showing up on the docs website.

Fixes #7572 