### PR TITLE
feat(cli/coverage): add json coverage reporter

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -72,6 +72,7 @@ pub enum DenoSubcommand {
     include: Option<Vec<String>>,
     filter: Option<String>,
     coverage: bool,
+    json: bool,
   },
   Types,
   Upgrade {
@@ -584,6 +585,7 @@ fn test_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   let quiet = matches.is_present("quiet");
   let filter = matches.value_of("filter").map(String::from);
   let coverage = matches.is_present("coverage");
+  let json = matches.is_present("json");
 
   // Coverage implies `--inspect`
   if coverage {
@@ -608,6 +610,7 @@ fn test_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     filter,
     allow_none,
     coverage,
+    json,
   };
 }
 
@@ -1182,6 +1185,13 @@ fn test_subcommand<'a, 'b>() -> App<'a, 'b> {
         .conflicts_with("inspect")
         .conflicts_with("inspect-brk")
         .help("Collect coverage information"),
+    )
+    .arg(
+      Arg::with_name("json")
+        .long("json")
+        .takes_value(false)
+        .requires("coverage")
+        .help("Output coverage result in JSON format")
     )
     .arg(
       Arg::with_name("files")

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -56,7 +56,6 @@ mod web_worker;
 pub mod worker;
 
 use crate::coverage::CoverageCollector;
-use crate::coverage::PrettyCoverageReporter;
 use crate::file_fetcher::SourceFile;
 use crate::file_fetcher::SourceFileFetcher;
 use crate::file_fetcher::TextDocument;
@@ -536,6 +535,7 @@ async fn test_command(
   allow_none: bool,
   filter: Option<String>,
   coverage: bool,
+  json: bool,
 ) -> Result<(), AnyError> {
   let global_state = GlobalState::new(flags.clone())?;
   let cwd = std::env::current_dir().expect("No current directory");
@@ -610,10 +610,7 @@ async fn test_command(
       test_modules,
     );
 
-    let pretty_coverage_reporter =
-      PrettyCoverageReporter::new(filtered_coverage);
-    let report = pretty_coverage_reporter.get_report();
-    print!("{}", report)
+    coverage::report_coverages(filtered_coverage, json);
   }
 
   Ok(())
@@ -733,8 +730,9 @@ pub fn main() {
       allow_none,
       filter,
       coverage,
+      json,
     } => test_command(
-      flags, include, fail_fast, quiet, allow_none, filter, coverage,
+      flags, include, fail_fast, quiet, allow_none, filter, coverage, json,
     )
     .boxed_local(),
     DenoSubcommand::Completions { buf } => {


### PR DESCRIPTION
This adds a json coverage reporter which dumps the script coverage as read from the runtime along with the source the runtime saw it for accurate reconstruction.

(WIP; couple of moving parts in flight at the same time so ignore for now)