### PR TITLE
Fix.  Replaced legacy chrome-devtools:// scheme.

### DIFF
--- a/cli/inspector.rs
+++ b/cli/inspector.rs
@@ -116,7 +116,7 @@ impl InspectorInfo {
 
   fn get_frontend_url(&self) -> String {
     format!(
-      "chrome-devtools://devtools/bundled/inspector.html?v8only=true&ws={}/ws/{}",
+      "devtools://devtools/bundled/inspector.html?v8only=true&ws={}/ws/{}",
       &self.host, &self.uuid
     )
   }


### PR DESCRIPTION
The legacy chrome-devtools:// scheme was removed from the Chromium codebase.  The new scheme is simply "devtools://"

https://chromium-review.googlesource.com/c/chromium/src/+/2088335
https://chromium.googlesource.com/chromium/src/+/6700d12448f76712c62a6d2372a95b97a26d4779

