### PR TITLE
feat(core): re-export useful parts of anyhow

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -1,5 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+pub use anyhow::bail;
+pub use anyhow::Context;
+pub use anyhow::Result;
 use rusty_v8 as v8;
 use std::borrow::Cow;
 use std::convert::TryFrom;


### PR DESCRIPTION
In order to use `.context()` with a result, you need to have `anyhow::Context` in scope, in addition, `anyhow::Result` and `anyhow::bail` are super useful when using anyhow.
