### PR TITLE
fix(cli/dts): Use var instead of let and const for globals

### DIFF
--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -222,8 +222,6 @@ interface DOMStringList {
 
 type BufferSource = ArrayBufferView | ArrayBuffer;
 
-declare const isConsoleInstance: unique symbol;
-
 declare interface Console {
   assert(condition?: boolean, ...data: any[]): void;
   clear(): void;
@@ -584,7 +582,7 @@ declare class Performance {
   now(): number;
 }
 
-declare const performance: Performance;
+declare var performance: Performance;
 
 declare interface PerformanceMarkOptions {
   /** Metadata to be included in the mark. */

--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -17,9 +17,9 @@ declare interface Window extends EventTarget {
   Deno: typeof Deno;
 }
 
-declare const window: Window & typeof globalThis;
-declare const self: Window & typeof globalThis;
-declare const onload: ((this: Window, ev: Event) => any) | null;
-declare const onunload: ((this: Window, ev: Event) => any) | null;
+declare var window: Window & typeof globalThis;
+declare var self: Window & typeof globalThis;
+declare var onload: ((this: Window, ev: Event) => any) | null;
+declare var onunload: ((this: Window, ev: Event) => any) | null;
 
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/cli/dts/lib.deno.worker.d.ts
+++ b/cli/dts/lib.deno.worker.d.ts
@@ -18,9 +18,9 @@ declare interface DedicatedWorkerGlobalScope {
   Deno: typeof Deno;
 }
 
-declare const self: DedicatedWorkerGlobalScope & typeof globalThis;
-declare let onmessage: ((e: { data: any }) => Promise<void> | void) | undefined;
-declare let onerror:
+declare var self: DedicatedWorkerGlobalScope & typeof globalThis;
+declare var onmessage: ((e: { data: any }) => Promise<void> | void) | undefined;
+declare var onerror:
   | ((
     msg: string,
     source: string,
@@ -29,9 +29,9 @@ declare let onerror:
     e: Event,
   ) => boolean | void)
   | undefined;
-declare const close: typeof __workerMain.close;
-declare const name: typeof __workerMain.name;
-declare const postMessage: typeof __workerMain.postMessage;
+declare var close: typeof __workerMain.close;
+declare var name: typeof __workerMain.name;
+declare var postMessage: typeof __workerMain.postMessage;
 
 declare namespace __workerMain {
   export let onmessage: (e: { data: any }) => void;

--- a/cli/tests/types.out
+++ b/cli/tests/types.out
@@ -1,4 +1,4 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 [WILDCARD]
 declare namespace Deno [WILDCARD]
-declare const window: Window [WILDCARD]
+declare var window: Window [WILDCARD]

--- a/op_crates/fetch/lib.deno_fetch.d.ts
+++ b/op_crates/fetch/lib.deno_fetch.d.ts
@@ -142,7 +142,7 @@ interface ReadableStream<R = any> {
   }): AsyncIterableIterator<R>;
 }
 
-declare const ReadableStream: {
+declare var ReadableStream: {
   prototype: ReadableStream;
   new (
     underlyingSource: UnderlyingByteSource,

--- a/op_crates/web/lib.deno_web.d.ts
+++ b/op_crates/web/lib.deno_web.d.ts
@@ -231,7 +231,7 @@ interface AbortSignal extends EventTarget {
   ): void;
 }
 
-declare const AbortSignal: {
+declare var AbortSignal: {
   prototype: AbortSignal;
   new (): AbortSignal;
 };


### PR DESCRIPTION
Fixes type errors for `deno eval -T "globalThis.performance"`, etc.

Using `let` and `const` in declaration files treats the symbols as injected local variables. We don't want that for globals.