### PR TITLE
chore(std/async): remove redundant export in test

### DIFF
--- a/std/async/delay_test.ts
+++ b/std/async/delay_test.ts
@@ -10,5 +10,3 @@ Deno.test("[async] delay", async function (): Promise<void> {
   assert(result === undefined);
   assert(diff >= 100);
 });
-
-export {};


### PR DESCRIPTION
This removes a redundant export in delay_test that was introduced in #7671
