### PR TITLE
refactor(std/example): Inconsistencies in the example tests

### DIFF
--- a/std/examples/cat_test.ts
+++ b/std/examples/cat_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertStrictEquals } from "../../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+import { assertStrictEquals } from "../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
 
-const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
+const moduleDir = dirname(fromFileUrl(import.meta.url));
 
 Deno.test("[examples/cat] print multiple files", async () => {
   const decoder = new TextDecoder();

--- a/std/examples/cat_test.ts
+++ b/std/examples/cat_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertStrictEquals } from "../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
+import { dirname, fromFileUrl } from "../path/mod.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 

--- a/std/examples/catj_test.ts
+++ b/std/examples/catj_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertStrictEquals } from "../../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+import { assertStrictEquals } from "../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
 
-const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
+const moduleDir = dirname(fromFileUrl(import.meta.url));
 
 Deno.test("[examples/catj] print an array", async () => {
   const decoder = new TextDecoder();

--- a/std/examples/catj_test.ts
+++ b/std/examples/catj_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertStrictEquals } from "../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
+import { dirname, fromFileUrl } from "../path/mod.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 

--- a/std/examples/colors_test.ts
+++ b/std/examples/colors_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertStrictEquals } from "../../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+import { assertStrictEquals } from "../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
 
-const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
+const moduleDir = dirname(fromFileUrl(import.meta.url));
 
 Deno.test("[examples/colors] print a colored text", async () => {
   const decoder = new TextDecoder();

--- a/std/examples/colors_test.ts
+++ b/std/examples/colors_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertStrictEquals } from "../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
+import { dirname, fromFileUrl } from "../path/mod.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 

--- a/std/examples/curl_test.ts
+++ b/std/examples/curl_test.ts
@@ -1,9 +1,9 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { serve } from "../../http/server.ts";
-import { assertStrictEquals } from "../../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+import { serve } from "../http/server.ts";
+import { assertStrictEquals } from "../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
 
-const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
+const moduleDir = dirname(fromFileUrl(import.meta.url));
 
 Deno.test({
   name: "[examples/curl] send a request to a specified url",

--- a/std/examples/curl_test.ts
+++ b/std/examples/curl_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { serve } from "../http/server.ts";
 import { assertStrictEquals } from "../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
+import { dirname, fromFileUrl } from "../path/mod.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 

--- a/std/examples/echo_server_test.ts
+++ b/std/examples/echo_server_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertStrictEquals, assertNotEquals } from "../testing/asserts.ts";
 import { BufReader, ReadLineResult } from "../io/bufio.ts";
-import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
+import { dirname, fromFileUrl } from "../path/mod.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 

--- a/std/examples/echo_server_test.ts
+++ b/std/examples/echo_server_test.ts
@@ -1,9 +1,9 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertStrictEquals, assertNotEquals } from "../../testing/asserts.ts";
-import { BufReader, ReadLineResult } from "../../io/bufio.ts";
-import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+import { assertStrictEquals, assertNotEquals } from "../testing/asserts.ts";
+import { BufReader, ReadLineResult } from "../io/bufio.ts";
+import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
 
-const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
+const moduleDir = dirname(fromFileUrl(import.meta.url));
 
 Deno.test("[examples/echo_server]", async () => {
   const encoder = new TextEncoder();

--- a/std/examples/test_test.ts
+++ b/std/examples/test_test.ts
@@ -1,2 +1,2 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import "../test.ts";
+import "./test.ts";

--- a/std/examples/welcome_test.ts
+++ b/std/examples/welcome_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertStrictEquals } from "../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
+import { dirname, fromFileUrl } from "../path/mod.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 

--- a/std/examples/welcome_test.ts
+++ b/std/examples/welcome_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertStrictEquals } from "../../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+import { assertStrictEquals } from "../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
 
-const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
+const moduleDir = dirname(fromFileUrl(import.meta.url));
 
 Deno.test("[examples/welcome] print a welcome message", async () => {
   const decoder = new TextDecoder();

--- a/std/examples/xeval_test.ts
+++ b/std/examples/xeval_test.ts
@@ -7,7 +7,7 @@ import {
   assertStringContains,
   assert,
 } from "../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
+import { dirname, fromFileUrl } from "../path/mod.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 

--- a/std/examples/xeval_test.ts
+++ b/std/examples/xeval_test.ts
@@ -1,15 +1,15 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { xeval } from "../xeval.ts";
-import { StringReader } from "../../io/readers.ts";
-import { decode, encode } from "../../encoding/utf8.ts";
+import { xeval } from "./xeval.ts";
+import { StringReader } from "../io/readers.ts";
+import { decode, encode } from "../encoding/utf8.ts";
 import {
   assertEquals,
   assertStringContains,
   assert,
-} from "../../testing/asserts.ts";
-import { resolve, dirname, fromFileUrl } from "../../path/mod.ts";
+} from "../testing/asserts.ts";
+import { resolve, dirname, fromFileUrl } from "../path/mod.ts";
 
-const moduleDir = resolve(dirname(fromFileUrl(import.meta.url)), "..");
+const moduleDir = dirname(fromFileUrl(import.meta.url));
 
 Deno.test("xevalSuccess", async function (): Promise<void> {
   const chunks: string[] = [];


### PR DESCRIPTION
Other `/std` tests have tests next to the script, but `/std/example` doesn't.