### PR TITLE
refactor: Removed Deno.File constructor from types

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -699,7 +699,6 @@ declare namespace Deno {
       SeekerSync,
       Closer {
     readonly rid: number;
-    constructor(rid: number);
     write(p: Uint8Array): Promise<number>;
     writeSync(p: Uint8Array): number;
     read(p: Uint8Array): Promise<number | null>;


### PR DESCRIPTION
Remove `Deno.File` constructor from types, as it is just an implementation detail.
This closes denoland#7462.