### PR TITLE
doc: use $STD_VERSION in std lib import comment

### DIFF
--- a/docs/standard_library.md
+++ b/docs/standard_library.md
@@ -26,7 +26,7 @@ instead, used a version of the std library which is immutable and will not
 change:
 
 ```typescript
-// imports from v0.50.0 of std, never changes
+// imports from v$STD_VERSION of std, never changes
 import { copy } from "https://deno.land/std@$STD_VERSION/fs/copy.ts";
 ```
 


### PR DESCRIPTION
Fixes difference between the version imported in the example, and one mentioned in the comment.

<details>
<summary>Screenshot of the issue</summary>

![Screenshot from 2020-09-26 13-58-40](https://user-images.githubusercontent.com/16024985/94350194-c7fa4600-0000-11eb-8b88-fbaefb8a8f8f.png)

</details>

Manual: https://deno.land/manual/standard_library