### PR TITLE
docs: update github doc links to use $CLI_VERSION

### DIFF
--- a/docs/getting_started/typescript.md
+++ b/docs/getting_started/typescript.md
@@ -33,7 +33,7 @@ To export a type in a different file use
 `import type` and `export type` where necessary by setting the `isolatedModules`
 TypeScript compiler option to `true`, and the `importsNotUsedAsValues` to
 `error`. You can see an example `tsconfig.json` with this option
-[in the standard library](https://github.com/denoland/deno/blob/master/std/tsconfig_test.json).
+[in the standard library](https://github.com/denoland/deno/blob/$CLI_VERSION/std/tsconfig_test.json).
 These settings will be enabled by default in the future. They are already the
 default in Deno 1.4 or above when using `--unstable`.
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -13,16 +13,16 @@ The detailed documentation for implemented Web APIs can be found on
 [doc.deno.land](https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/dts/lib.deno.shared_globals.d.ts).
 Additionally, a full list of the Web APIs which Deno implements is also
 available
-[in the repository](https://github.com/denoland/deno/blob/master/cli/rt/README.md).
+[in the repository](https://github.com/denoland/deno/blob/$CLI_VERSION/cli/rt/README.md).
 
 The TypeScript definitions for the implemented web APIs can be found in the
-[`lib.deno.shared_globals.d.ts`](https://github.com/denoland/deno/blob/master/cli/dts/lib.deno.shared_globals.d.ts)
+[`lib.deno.shared_globals.d.ts`](https://github.com/denoland/deno/blob/$CLI_VERSION/cli/dts/lib.deno.shared_globals.d.ts)
 and
-[`lib.deno.window.d.ts`](https://github.com/denoland/deno/blob/master/cli/dts/lib.deno.window.d.ts)
+[`lib.deno.window.d.ts`](https://github.com/denoland/deno/blob/$CLI_VERSION/cli/dts/lib.deno.window.d.ts)
 files.
 
 Definitions that are specific to workers can be found in the
-[`lib.deno.worker.d.ts`](https://github.com/denoland/deno/blob/master/cli/dts/lib.deno.worker.d.ts)
+[`lib.deno.worker.d.ts`](https://github.com/denoland/deno/blob/$CLI_VERSION/cli/dts/lib.deno.worker.d.ts)
 file.
 
 ## `Deno` global
@@ -32,7 +32,7 @@ It has the APIs for reading from files, opening TCP sockets, and executing
 subprocesses, etc.
 
 The TypeScript definitions for the Deno namespaces can be found in the
-[`lib.deno.ns.d.ts`](https://github.com/denoland/deno/blob/master/cli/dts/lib.deno.ns.d.ts)
+[`lib.deno.ns.d.ts`](https://github.com/denoland/deno/blob/$CLI_VERSION/cli/dts/lib.deno.ns.d.ts)
 file.
 
 The documentation for all of the Deno specific APIs can be found on

--- a/docs/standard_library.md
+++ b/docs/standard_library.md
@@ -69,7 +69,7 @@ deno run --allow-read --allow-write --unstable main.ts
 ```
 
 To make sure that API producing error is unstable check
-[`lib.deno.unstable.d.ts`](https://github.com/denoland/deno/blob/master/cli/dts/lib.deno.unstable.d.ts)
+[`lib.deno.unstable.d.ts`](https://github.com/denoland/deno/blob/$CLI_VERSION/cli/dts/lib.deno.unstable.d.ts)
 declaration.
 
 This problem should be fixed in the near future. Feel free to omit the flag if


### PR DESCRIPTION
Ref: https://github.com/denoland/deno_website2/pull/1528

The issue with this fix is that the code links will not be browse-able from markdown files.