### PR TITLE
fix: Use $deno$test.ts instead of .deno.test.ts

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -559,7 +559,7 @@ async fn test_command(
     return Ok(());
   }
 
-  let test_file_path = cwd.join(".deno.test.ts");
+  let test_file_path = cwd.join("$deno$test.ts");
   let test_file_url =
     Url::from_file_path(&test_file_path).expect("Should be valid file url");
   let test_file = test_runner::render_test_file(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -222,7 +222,7 @@ stdout. In the future there will be support for `lcov` output too.
 $ git clone git@github.com:denosaurs/deno_brotli.git && cd deno_brotli
 $ deno test --coverage --unstable
 Debugger listening on ws://127.0.0.1:9229/ws/5a593019-d185-478b-a928-ebc33e5834be
-Check file:///home/deno/deno_brotli/.deno.test.ts
+Check file:///home/deno/deno_brotli/$deno$test.ts
 running 2 tests
 test compress ... ok (26ms)
 test decompress ... ok (13ms)


### PR DESCRIPTION
Missed in #7430.