### PR TITLE
fix(cli/test): do not start inspector server when collecting coverage

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -71,7 +71,6 @@ pub enum DenoSubcommand {
     allow_none: bool,
     include: Option<Vec<String>>,
     filter: Option<String>,
-    coverage: bool,
   },
   Types,
   Upgrade {
@@ -607,7 +606,6 @@ fn test_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     include,
     filter,
     allow_none,
-    coverage,
   };
 }
 
@@ -2857,7 +2855,6 @@ mod tests {
           allow_none: true,
           quiet: false,
           include: Some(svec!["dir1/", "dir2/"]),
-          coverage: false,
         },
         allow_net: true,
         ..Flags::default()
@@ -2877,7 +2874,6 @@ mod tests {
           quiet: false,
           filter: Some("foo".to_string()),
           include: Some(svec!["dir1"]),
-          coverage: false,
         },
         ..Flags::default()
       }
@@ -2897,7 +2893,6 @@ mod tests {
           quiet: false,
           filter: Some("- foo".to_string()),
           include: Some(svec!["dir1"]),
-          coverage: false,
         },
         ..Flags::default()
       }
@@ -2922,7 +2917,6 @@ mod tests {
           quiet: false,
           filter: None,
           include: Some(svec!["dir1"]),
-          coverage: true,
         },
         cover: true,
         unstable: true,

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -107,6 +107,7 @@ pub struct Flags {
   pub ca_file: Option<String>,
   pub cached_only: bool,
   pub config_path: Option<String>,
+  pub cover: bool,
   pub ignore: Vec<String>,
   pub import_map_path: Option<String>,
   pub inspect: Option<SocketAddr>,
@@ -585,9 +586,8 @@ fn test_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   let filter = matches.value_of("filter").map(String::from);
   let coverage = matches.is_present("coverage");
 
-  // Coverage implies `--inspect`
   if coverage {
-    flags.inspect = Some("127.0.0.1:9229".parse::<SocketAddr>().unwrap());
+    flags.cover = true;
   }
 
   let include = if matches.is_present("files") {
@@ -2924,7 +2924,7 @@ mod tests {
           include: Some(svec!["dir1"]),
           coverage: true,
         },
-        inspect: Some("127.0.0.1:9229".parse::<SocketAddr>().unwrap()),
+        cover: true,
         unstable: true,
         ..Flags::default()
       }

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -2918,7 +2918,7 @@ mod tests {
           filter: None,
           include: Some(svec!["dir1"]),
         },
-        cover: true,
+        coverage: true,
         unstable: true,
         ..Flags::default()
       }

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -106,7 +106,7 @@ pub struct Flags {
   pub ca_file: Option<String>,
   pub cached_only: bool,
   pub config_path: Option<String>,
-  pub cover: bool,
+  pub coverage: bool,
   pub ignore: Vec<String>,
   pub import_map_path: Option<String>,
   pub inspect: Option<SocketAddr>,
@@ -586,7 +586,7 @@ fn test_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   let coverage = matches.is_present("coverage");
 
   if coverage {
-    flags.cover = true;
+    flags.coverage = true;
   }
 
   let include = if matches.is_present("files") {

--- a/cli/inspector.rs
+++ b/cli/inspector.rs
@@ -438,6 +438,11 @@ impl DenoInspector {
     &self,
     mut invoker_cx: Option<&mut Context>,
   ) -> Result<Poll<()>, BorrowMutError> {
+    // Short-circuit if there is no server
+    if self.server.is_none() {
+      return Ok(Poll::Ready(()));
+    }
+
     // The futures this function uses do not have re-entrant poll() functions.
     // However it is can happpen that poll_sessions() gets re-entered, e.g.
     // when an interrupt request is honored while the inspector future is polled

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -587,7 +587,7 @@ async fn test_command(
     .file_fetcher
     .save_source_file_in_cache(&main_module, source_file);
 
-  let mut maybe_coverage_collector = if flags.cover {
+  let mut maybe_coverage_collector = if flags.coverage {
     let inspector = worker
       .inspector
       .as_mut()

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -544,7 +544,6 @@ async fn test_command(
   quiet: bool,
   allow_none: bool,
   filter: Option<String>,
-  coverage: bool,
 ) -> Result<(), AnyError> {
   let global_state = GlobalState::new(flags.clone())?;
   let cwd = std::env::current_dir().expect("No current directory");
@@ -588,7 +587,7 @@ async fn test_command(
     .file_fetcher
     .save_source_file_in_cache(&main_module, source_file);
 
-  let mut maybe_coverage_collector = if coverage {
+  let mut maybe_coverage_collector = if global_state.flags.cover {
     let inspector = worker
       .inspector
       .as_mut()
@@ -738,11 +737,8 @@ pub fn main() {
       include,
       allow_none,
       filter,
-      coverage,
-    } => test_command(
-      flags, include, fail_fast, quiet, allow_none, filter, coverage,
-    )
-    .boxed_local(),
+    } => test_command(flags, include, fail_fast, quiet, allow_none, filter)
+      .boxed_local(),
     DenoSubcommand::Completions { buf } => {
       if let Err(e) = write_to_stdout_ignore_sigpipe(&buf) {
         eprintln!("{}", e);

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -587,7 +587,7 @@ async fn test_command(
     .file_fetcher
     .save_source_file_in_cache(&main_module, source_file);
 
-  let mut maybe_coverage_collector = if global_state.flags.cover {
+  let mut maybe_coverage_collector = if flags.cover {
     let inspector = worker
       .inspector
       .as_mut()

--- a/cli/tests/test_coverage.out
+++ b/cli/tests/test_coverage.out
@@ -1,4 +1,4 @@
-[WILDCARD]
+Check [WILDCARD]
 running 1 tests
 test returnsHiSuccess ... ok ([WILDCARD])
 

--- a/cli/tests/test_coverage.out
+++ b/cli/tests/test_coverage.out
@@ -1,4 +1,4 @@
-Check [WILDCARD]/test_coverage.ts
+Check [WILDCARD]/$deno$test.ts
 running 1 tests
 test returnsHiSuccess ... ok ([WILDCARD])
 

--- a/cli/tests/test_coverage.out
+++ b/cli/tests/test_coverage.out
@@ -1,4 +1,4 @@
-Check [WILDCARD]
+Check [WILDCARD]/test_coverage.ts
 running 1 tests
 test returnsHiSuccess ... ok ([WILDCARD])
 

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -160,10 +160,7 @@ impl Worker {
           Some(inspector_server.clone()),
         ))
       } else if global_state.flags.cover {
-          Some(DenoInspector::new(
-          &mut isolate,
-          None,
-        ))
+        Some(DenoInspector::new(&mut isolate, None))
       } else {
         None
       };

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -159,6 +159,11 @@ impl Worker {
           &mut isolate,
           Some(inspector_server.clone()),
         ))
+      } else if global_state.flags.cover {
+          Some(DenoInspector::new(
+          &mut isolate,
+          None,
+        ))
       } else {
         None
       };

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -159,7 +159,7 @@ impl Worker {
           &mut isolate,
           Some(inspector_server.clone()),
         ))
-      } else if global_state.flags.cover {
+      } else if global_state.flags.coverage {
         Some(DenoInspector::new(&mut isolate, None))
       } else {
         None


### PR DESCRIPTION
This makes use of a coverage flag to create an inspector without a server for collecting code coverage.
