### PR TITLE
doc: use APA citation style for listing conference talks

### DIFF
--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -50,5 +50,6 @@ Metrics is Deno's internal counter for various statistics.
 
 ### Conference
 
-Ryan Dahl. (May 27, 2020). [An interesting case with
-Deno](https://www.youtube.com/watch?v=1b7FoBwxc7E). Deno Israel.
+Ryan Dahl. (May 27, 2020).
+[An interesting case with Deno](https://www.youtube.com/watch?v=1b7FoBwxc7E).
+Deno Israel.

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -50,5 +50,5 @@ Metrics is Deno's internal counter for various statistics.
 
 ### Conference
 
-[Ryan Dahl - An interesting case with
-Deno](https://www.youtube.com/watch?v=1b7FoBwxc7E) - Deno Israel - May 27, 2020
+Ryan Dahl. (May 27, 2020). [An interesting case with
+Deno](https://www.youtube.com/watch?v=1b7FoBwxc7E). Deno Israel.

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -51,4 +51,4 @@ Metrics is Deno's internal counter for various statistics.
 ### Conference
 
 [Ryan Dahl - An interesting case with
-Deno](https://www.youtube.com/watch?v=1b7FoBwxc7E)
+Deno](https://www.youtube.com/watch?v=1b7FoBwxc7E) - Deno Israel - May 27, 2020


### PR DESCRIPTION
This style provides information about the author, date and conference where the talk was given.
 
APA citation style details: https://pitt.libguides.com/citationhelp/apa7
Markdown after edit: https://github.com/trivikr/deno/blob/patch-1/docs/contributing/architecture.md#conference