### PR TITLE
doc: end sentences with a period in examples

### DIFF
--- a/docs/examples/fetch_data.md
+++ b/docs/examples/fetch_data.md
@@ -5,8 +5,8 @@
 - Like browsers, Deno implements web standard APIs such as
   [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 - Deno is secure by default, meaning explicit permission must be granted to
-  access the network
-- See also: Deno's [permissions](../getting_started/permissions.md) model
+  access the network.
+- See also: Deno's [permissions](../getting_started/permissions.md) model.
 
 ## Overview
 

--- a/docs/examples/file_server.md
+++ b/docs/examples/file_server.md
@@ -4,9 +4,9 @@
 
 - Use the Deno standard library
   [file_server.ts](https://deno.land/std@$STD_VERSION/http/file_server.ts) to
-  run your own file server and access your files from your web browser
+  run your own file server and access your files from your web browser.
 - Run [Deno install](../tools/script_installer.md) to install the file server
-  locally
+  locally.
 
 ## Example
 

--- a/docs/examples/file_system_events.md
+++ b/docs/examples/file_system_events.md
@@ -3,8 +3,8 @@
 ## Concepts
 
 - Use [Deno.watchFs](https://doc.deno.land/builtin/stable#Deno.watchFs) to watch
-  for file system events
-- Results may vary between operating systems
+  for file system events.
+- Results may vary between operating systems.
 
 ## Example
 

--- a/docs/examples/hello_world.md
+++ b/docs/examples/hello_world.md
@@ -3,7 +3,7 @@
 ## Concepts
 
 - Deno can run JavaScript or TypeScript out of the box with no additional tools
-  or config required
+  or config required.
 
 ## Overview
 

--- a/docs/examples/http_server.md
+++ b/docs/examples/http_server.md
@@ -3,7 +3,7 @@
 ## Concepts
 
 - Use the std library [http module](https://deno.land/std@$STD_VERSION/http) to
-  run your own web server
+  run your own web server.
 
 ## Overview
 
@@ -12,11 +12,11 @@ over the response status, request headers and more.
 
 ## Sample web server
 
-In this example, the user-agent of the client is returned to the client
+In this example, the user-agent of the client is returned to the client:
 
 ```typescript
-/** 
- * webserver.ts 
+/**
+ * webserver.ts
  */
 import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
 

--- a/docs/examples/import_export.md
+++ b/docs/examples/import_export.md
@@ -5,10 +5,10 @@
 - [import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)
   allows you to include and use modules held elsewhere, on your local file
   system or remotely.
-- Imports are URLs or file system paths
+- Imports are URLs or file system paths.
 - [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export)
   allows you to specify which parts of your module are accessible to users who
-  import your module
+  import your module.
 
 ## Overview
 

--- a/docs/examples/manage_dependencies.md
+++ b/docs/examples/manage_dependencies.md
@@ -2,7 +2,7 @@
 
 ## Concepts
 
-- Deno uses URLs for dependency management
+- Deno uses URLs for dependency management.
 - One convention places all these dependent URLs into a local `deps.ts` file.
   Functionality is then exported out of `deps.ts` for use by local modules.
 - Continuing this convention, dev only dependencies can be kept in a

--- a/docs/examples/module_metadata.md
+++ b/docs/examples/module_metadata.md
@@ -3,22 +3,22 @@
 ## Concepts
 
 - [import.meta](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import.meta)
-  can provide information on the context of the module
+  can provide information on the context of the module.
 - The boolean
   [import.meta.main](https://doc.deno.land/builtin/stable#ImportMeta) will let
-  you know if the current module is the program entry point
+  you know if the current module is the program entry point.
 - The string [import.meta.url](https://doc.deno.land/builtin/stable#ImportMeta)
-  will give you the URL of the current module
+  will give you the URL of the current module.
 - The string
   [Deno.mainModule](https://doc.deno.land/builtin/stable#Deno.mainModule) will
   give you the URL of the main module entry point, i.e. the module invoked by
-  the deno runtime
+  the deno runtime.
 
 ## Example
 
 The example below uses two modules to show the difference between
 `import.meta.url`, `import.meta.main` and `Deno.mainModule`. In this example,
-`module_a.ts` is the main module entry point
+`module_a.ts` is the main module entry point:
 
 ```ts
 /**

--- a/docs/examples/os_signals.md
+++ b/docs/examples/os_signals.md
@@ -5,12 +5,12 @@
 
 ## Concepts
 
-- Use the `--unstable` flag to access new or unstable features in Deno
+- Use the `--unstable` flag to access new or unstable features in Deno.
 - [Deno.signal](https://doc.deno.land/builtin/unstable#Deno.signal) can be used
-  to capture and monitor OS signals
+  to capture and monitor OS signals.
 - Use the `dispose()` function of the Deno.signal
   [SignalStream](https://doc.deno.land/builtin/unstable#Deno.SignalStream) to
-  stop watching the signal
+  stop watching the signal.
 
 ## Async iterator example
 

--- a/docs/examples/read_write_files.md
+++ b/docs/examples/read_write_files.md
@@ -6,13 +6,13 @@
   [Deno.readTextFile](https://doc.deno.land/builtin/stable#Deno.readTextFile)
   and
   [Deno.writeTextFile](https://doc.deno.land/builtin/stable#Deno.writeTextFile)
-  asynchronous functions for reading and writing entire text files
+  asynchronous functions for reading and writing entire text files.
 - Like many of Deno's APIs, synchronous alternatives are also available. See
   [Deno.readTextFileSync](https://doc.deno.land/builtin/stable#Deno.readTextFileSync)
   and
-  [Deno.writeTextFileSync](https://doc.deno.land/builtin/stable#Deno.writeTextFileSync)
+  [Deno.writeTextFileSync](https://doc.deno.land/builtin/stable#Deno.writeTextFileSync).
 - Use `--allow-read` and `--allow-write` permissions to gain access to the file
-  system
+  system.
 
 ## Overview
 

--- a/docs/examples/subprocess.md
+++ b/docs/examples/subprocess.md
@@ -3,13 +3,13 @@
 ## Concepts
 
 - Deno is capable of spawning a subprocess via
-  [Deno.run](https://doc.deno.land/builtin/stable#Deno.run)
-- `--allow-run` permission is required to spawn a subprocess
-- Spawned subprocesses do not run in a security sandbox
+  [Deno.run](https://doc.deno.land/builtin/stable#Deno.run).
+- `--allow-run` permission is required to spawn a subprocess.
+- Spawned subprocesses do not run in a security sandbox.
 - Communicate with the subprocess via the
   [stdin](https://doc.deno.land/builtin/stable#Deno.stdin),
   [stdout](https://doc.deno.land/builtin/stable#Deno.stdout) and
-  [stderr](https://doc.deno.land/builtin/stable#Deno.stderr) streams
+  [stderr](https://doc.deno.land/builtin/stable#Deno.stderr) streams.
 
 ## Simple example
 

--- a/docs/examples/tcp_echo.md
+++ b/docs/examples/tcp_echo.md
@@ -3,9 +3,9 @@
 ## Concepts
 
 - Listening for TCP port connections with
-  [Deno.listen](https://doc.deno.land/builtin/stable#Deno.listen)
+  [Deno.listen](https://doc.deno.land/builtin/stable#Deno.listen).
 - Use [Deno.copy](https://doc.deno.land/builtin/stable#Deno.copy) to take
-  inbound data and redirect it to be outbound data
+  inbound data and redirect it to be outbound data.
 
 ## Example
 

--- a/docs/examples/unix_cat.md
+++ b/docs/examples/unix_cat.md
@@ -2,15 +2,15 @@
 
 ## Concepts
 
-- Use the Deno runtime API to output the contents of a file to the console
+- Use the Deno runtime API to output the contents of a file to the console.
 - [Deno.args](https://doc.deno.land/builtin/stable#Deno.args) accesses the
-  command line arguments
+  command line arguments.
 - [Deno.open](https://doc.deno.land/builtin/stable#Deno.open) is used to get a
-  handle to a file
+  handle to a file.
 - [Deno.copy](https://doc.deno.land/builtin/stable#Deno.copy) is used to
-  transfer data from the file to the output stream
+  transfer data from the file to the output stream.
 - Files should be closed when you are finished with them
-- Modules can be run directly from remote URLs
+- Modules can be run directly from remote URLs.
 
 ## Example
 


### PR DESCRIPTION
[Deno Style Guide](https://github.com/denoland/deno/blob/master/docs/contributing/style_guide.md) doesn't explicitly mention about ending sentences with period, but have been informally following it.
[Rust RFCs style guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md#comments) recommends using periods for comments.

Also recommended by:
* Microsoft docs style guide for [periods](https://docs.microsoft.com/en-us/style-guide/punctuation/periods).
* Google developer documentation style guide for [periods](https://developers.google.com/style/periods).