### PR TITLE
docs: add Deno security model conference video link

### DIFF
--- a/docs/getting_started/permissions.md
+++ b/docs/getting_started/permissions.md
@@ -84,3 +84,9 @@ Allow net calls to any host/url:
 ```shell
 deno run --allow-net fetch.ts
 ```
+
+### Conference
+
+Ryan Dahl. (September 25, 2020).
+[The Deno security model](https://www.youtube.com/watch?v=r5F6dekUmdE#t=34m57).
+Speakeasy JS.


### PR DESCRIPTION
Conference website: https://speakeasyjs.com/
Markdown: https://github.com/trivikr/deno/blob/add-speakeasy-js-conf-link/docs/getting_started/permissions.md