### PR TITLE
feat(info): Add module specifier to info json output

### DIFF
--- a/cli/info.rs
+++ b/cli/info.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ModuleDepInfo {
+  module: String,
   local: String,
   file_type: String,
   compiled: Option<String>,
@@ -70,6 +71,7 @@ impl ModuleDepInfo {
     let files = FileInfoDepFlatGraph::new(&module_graph);
 
     let info = Self {
+      module: module_specifier.to_string(),
       local: local_filename,
       file_type,
       compiled: compiled_filename,

--- a/cli/tests/055_info_file_json.out
+++ b/cli/tests/055_info_file_json.out
@@ -1,4 +1,5 @@
 {
+  "module": "file://[WILDCARD]005_more_imports.ts",
   "local": "[WILDCARD]005_more_imports.ts",
   "fileType": "TypeScript",
   "compiled": null,


### PR DESCRIPTION
Currently the `deno info --json` output requires the consumer to resolve input paths to a module specifier
in order to associate the correct `"files"` entry with the root module.

```json
> deno info --unstable --json ./deps.ts 
{
  "local": "/home/syrup/projects/deno/docuraptor/deps.ts",
  "fileType": "TypeScript",
  "compiled": "/home/syrup/.cache/deno/gen/file/home/syrup/projects/deno/docuraptor/deps.ts.js",
  "map": null,
  "depCount": 26,
  "totalSize": 159212,
  "files": {
    "file:///home/syrup/projects/deno/docuraptor/deps.ts": {
      "size": 338,
      "deps": [
        "https://deno.land/std@0.69.0/testing/asserts.ts",
        "https://deno.land/std@0.69.0/flags/mod.ts",
        "https://deno.land/std@0.69.0/http/server.ts",
        "https://deno.land/std@0.69.0/path/mod.ts"
      ]
    },
    "https://deno.land/std@0.69.0/_util/assert.ts": {
      "size": 405,
      "deps": []
    },
    "[omitted]": "..."
  }
}
```

This PR adds a `"module"` field containing the module specifier as used in the `"files"` object.

```json
{ 
  "module": "file:///home/syrup/projects/deno/docuraptor/deps.ts",
  "...": "..."
}
```