### PR TITLE
feat(cli/console): allow noColor in Deno.inspect()

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1954,6 +1954,8 @@ declare namespace Deno {
     iterableLimit?: number;
     /** Show a Proxy's target and handler. Defaults to false. */
     showProxy?: boolean;
+    /** Print output without ANSI color escapes. Defaults to the value of `Deno.noColor`. */
+    noColor?: boolean;
   }
 
   /** Converts the input into a string that has the same format as printed by


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
This PR introduces an ability to explicitly disable ANSI color output from `Deno.inspect(...)`:
```js
const object = { this: { is: { a: "object" } } };
Deno.inspect(object, { noColor: true }); // { this: { is: { a: "object" } } }

Deno.inspect(object); // assuming Deno.noColor === false; { this: { is: { a: \x1b[32m"object"\x1b[39m } } }
```

Things to consider/to do :
- [ ] Pick a sensible default for `noColor` - should the `Deno.inspect(...)` call return the inspected string with ANSI escape codes regardless of `Deno.noColor`?<br>Currently, `{ noColor: false }` respects the `Deno.noColor` value - maybe use `noColor = inspectOptions.noColor ?? globalThis.Deno?.noColor ?? true`?
