### PR TITLE
refactor: improve graph and tsc_config

### DIFF
--- a/cli/graph.rs
+++ b/cli/graph.rs
@@ -14,14 +14,12 @@ use crate::specifier_handler::EmitMap;
 use crate::specifier_handler::EmitType;
 use crate::specifier_handler::FetchFuture;
 use crate::specifier_handler::SpecifierHandler;
-use crate::tsc_config::json_merge;
-use crate::tsc_config::parse_config;
 use crate::tsc_config::IgnoredCompilerOptions;
+use crate::tsc_config::TsConfig;
 use crate::AnyError;
 
 use deno_core::futures::stream::FuturesUnordered;
 use deno_core::futures::stream::StreamExt;
-use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::ModuleSpecifier;
 use regex::Regex;
@@ -37,8 +35,6 @@ use std::result;
 use std::sync::Mutex;
 use std::time::Instant;
 use swc_ecmascript::dep_graph::DependencyKind;
-
-type Result<V> = result::Result<V, AnyError>;
 
 pub type BuildInfoMap = HashMap<EmitType, TextDocument>;
 
@@ -123,7 +119,7 @@ pub trait ModuleProvider {
     &self,
     specifier: &str,
     referrer: &ModuleSpecifier,
-  ) -> Result<(ModuleSpecifier, MediaType)>;
+  ) -> Result<(ModuleSpecifier, MediaType), AnyError>;
 }
 
 /// An enum which represents the parsed out values of references in source code.
@@ -237,7 +233,7 @@ impl Module {
     self.is_hydrated = true;
   }
 
-  pub fn parse(&mut self) -> Result<()> {
+  pub fn parse(&mut self) -> Result<(), AnyError> {
     let parsed_module =
       parse(&self.specifier, &self.source.to_str()?, &self.media_type)?;
 
@@ -318,7 +314,7 @@ impl Module {
     &self,
     specifier: &str,
     maybe_location: Option<Location>,
-  ) -> Result<ModuleSpecifier> {
+  ) -> Result<ModuleSpecifier, AnyError> {
     let maybe_resolve = if let Some(import_map) = self.maybe_import_map.clone()
     {
       import_map
@@ -385,22 +381,10 @@ impl fmt::Display for Stats {
 pub struct TranspileOptions {
   /// If `true` then debug logging will be output from the isolate.
   pub debug: bool,
-  /// A string of configuration data that augments the the default configuration
-  /// passed to the TypeScript compiler.  This is typically the contents of a
-  /// user supplied `tsconfig.json`.
-  pub maybe_config: Option<String>,
-}
-
-/// The transpile options that are significant out of a user provided tsconfig
-/// file, that we want to deserialize out of the final config for a transpile.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct TranspileConfigOptions {
-  pub check_js: bool,
-  pub emit_decorator_metadata: bool,
-  pub jsx: String,
-  pub jsx_factory: String,
-  pub jsx_fragment_factory: String,
+  /// An optional string that points to a user supplied TypeScript configuration
+  /// file that augments the the default configuration passed to the TypeScript
+  /// compiler.
+  pub maybe_config_path: Option<String>,
 }
 
 /// A dependency graph of modules, were the modules that have been inserted via
@@ -432,7 +416,7 @@ impl Graph {
 
   /// Update the handler with any modules that are marked as _dirty_ and update
   /// any build info if present.
-  fn flush(&mut self, emit_type: &EmitType) -> Result<()> {
+  fn flush(&mut self, emit_type: &EmitType) -> Result<(), AnyError> {
     let mut handler = self.handler.borrow_mut();
     for (_, module) in self.modules.iter_mut() {
       if module.is_dirty {
@@ -462,7 +446,10 @@ impl Graph {
   /// Verify the subresource integrity of the graph based upon the optional
   /// lockfile, updating the lockfile with any missing resources.  This will
   /// error if any of the resources do not match their lock status.
-  pub fn lock(&self, maybe_lockfile: &Option<Mutex<Lockfile>>) -> Result<()> {
+  pub fn lock(
+    &self,
+    maybe_lockfile: &Option<Mutex<Lockfile>>,
+  ) -> Result<(), AnyError> {
     if let Some(lf) = maybe_lockfile {
       let mut lockfile = lf.lock().unwrap();
       for (ms, module) in self.modules.iter() {
@@ -493,28 +480,22 @@ impl Graph {
   pub fn transpile(
     &mut self,
     options: TranspileOptions,
-  ) -> Result<(Stats, Option<IgnoredCompilerOptions>)> {
+  ) -> Result<(Stats, Option<IgnoredCompilerOptions>), AnyError> {
     let start = Instant::now();
     let emit_type = EmitType::Cli;
-    let mut compiler_options = json!({
+
+    let mut ts_config = TsConfig::new(json!({
       "checkJs": false,
       "emitDecoratorMetadata": false,
       "jsx": "react",
       "jsxFactory": "React.createElement",
       "jsxFragmentFactory": "React.Fragment",
-    });
+    }));
 
-    let maybe_ignored_options = if let Some(config_text) = options.maybe_config
-    {
-      let (user_config, ignored_options) = parse_config(&config_text)?;
-      json_merge(&mut compiler_options, &user_config);
-      ignored_options
-    } else {
-      None
-    };
+    let maybe_ignored_options =
+      ts_config.merge_user_config(options.maybe_config_path)?;
 
-    let compiler_options: TranspileConfigOptions =
-      serde_json::from_value(compiler_options)?;
+    let compiler_options = ts_config.as_transpile_config()?;
     let check_js = compiler_options.check_js;
     let transform_jsx = compiler_options.jsx == "react";
     let emit_options = ast::TranspileOptions {
@@ -581,7 +562,7 @@ impl<'a> ModuleProvider for Graph {
     &self,
     specifier: &str,
     referrer: &ModuleSpecifier,
-  ) -> Result<(ModuleSpecifier, MediaType)> {
+  ) -> Result<(ModuleSpecifier, MediaType), AnyError> {
     if !self.modules.contains_key(referrer) {
       return Err(MissingSpecifier(referrer.to_owned()).into());
     }
@@ -659,7 +640,7 @@ impl GraphBuilder {
 
   /// Request a module to be fetched from the handler and queue up its future
   /// to be awaited to be resolved.
-  fn fetch(&mut self, specifier: &ModuleSpecifier) -> Result<()> {
+  fn fetch(&mut self, specifier: &ModuleSpecifier) -> Result<(), AnyError> {
     if self.fetched.contains(&specifier) {
       return Ok(());
     }
@@ -674,7 +655,7 @@ impl GraphBuilder {
   /// Visit a module that has been fetched, hydrating the module, analyzing its
   /// dependencies if required, fetching those dependencies, and inserting the
   /// module into the graph.
-  fn visit(&mut self, cached_module: CachedModule) -> Result<()> {
+  fn visit(&mut self, cached_module: CachedModule) -> Result<(), AnyError> {
     let specifier = cached_module.specifier.clone();
     let mut module =
       Module::new(specifier.clone(), self.maybe_import_map.clone());
@@ -711,7 +692,10 @@ impl GraphBuilder {
   /// Insert a module into the graph based on a module specifier.  The module
   /// and any dependencies will be fetched from the handler.  The module will
   /// also be treated as a _root_ module in the graph.
-  pub async fn insert(&mut self, specifier: &ModuleSpecifier) -> Result<()> {
+  pub async fn insert(
+    &mut self,
+    specifier: &ModuleSpecifier,
+  ) -> Result<(), AnyError> {
     self.fetch(specifier)?;
 
     loop {
@@ -736,7 +720,7 @@ impl GraphBuilder {
   pub fn get_graph(
     self,
     maybe_lockfile: &Option<Mutex<Lockfile>>,
-  ) -> Result<Graph> {
+  ) -> Result<Graph, AnyError> {
     self.graph.lock(maybe_lockfile)?;
     Ok(self.graph)
   }
@@ -902,7 +886,7 @@ mod tests {
     let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let fixtures = c.join("tests/module_graph");
     let handler = Rc::new(RefCell::new(MockSpecifierHandler {
-      fixtures,
+      fixtures: fixtures.clone(),
       ..MockSpecifierHandler::default()
     }));
     let mut builder = GraphBuilder::new(handler.clone(), None);
@@ -914,21 +898,18 @@ mod tests {
       .await
       .expect("module not inserted");
     let mut graph = builder.get_graph(&None).expect("could not get graph");
-    let config = r#"{
-        "compilerOptions": {
-          "target": "es5",
-          "jsx": "preserve"
-        }
-      }"#;
     let (_, maybe_ignored_options) = graph
       .transpile(TranspileOptions {
         debug: false,
-        maybe_config: Some(config.to_string()),
+        maybe_config_path: Some("tests/module_graph/tsconfig.json".to_string()),
       })
       .unwrap();
     assert_eq!(
       maybe_ignored_options,
-      Some(IgnoredCompilerOptions(vec!["target".to_string()])),
+      Some(IgnoredCompilerOptions {
+        items: vec!["target".to_string()],
+        path: fixtures.join("tsconfig.json"),
+      }),
       "the 'target' options should have been ignored"
     );
     let h = handler.borrow();

--- a/cli/graph.rs
+++ b/cli/graph.rs
@@ -905,11 +905,8 @@ mod tests {
       })
       .unwrap();
     assert_eq!(
-      maybe_ignored_options,
-      Some(IgnoredCompilerOptions {
-        items: vec!["target".to_string()],
-        path: fixtures.join("tsconfig.json"),
-      }),
+      maybe_ignored_options.unwrap().items,
+      vec!["target".to_string()],
       "the 'target' options should have been ignored"
     );
     let h = handler.borrow();

--- a/cli/tests/config.ts.out
+++ b/cli/tests/config.ts.out
@@ -1,4 +1,4 @@
-[WILDCARD]Unsupported compiler options in "[WILDCARD]config.tsconfig.json"
+[WILDCARD]Unsupported compiler options in "[WILDCARD]config.tsconfig.json".
   The following options were ignored:
     module, target
 error: TS2532 [ERROR]: Object is possibly 'undefined'.

--- a/cli/tests/module_graph/tsconfig.json
+++ b/cli/tests/module_graph/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "jsx": "preserve"
+  }
+}


### PR DESCRIPTION
This does three things:

- Introduces `TsConfig` to `tsc_config` to manage configurations and provide an abstraction for the configuration which cleans up the API in the `--no-check`.  It is now super straight-forward:

  ```rust
  let handler =
    Rc::new(RefCell::new(FetchHandler::new(&self.flags, &permissions)?));
  let mut builder = GraphBuilder::new(handler, maybe_import_map);
  builder.insert(&module_specifier).await?;
  let mut graph = builder.get_graph(&self.lockfile)?;

  let (stats, maybe_ignored_options) =
    graph.transpile(TranspileOptions {
      debug: self.flags.log_level == Some(log::Level::Debug),
      maybe_config_path: self.flags.config_path.clone(),
    })?;

  if let Some(ignored_options) = maybe_ignored_options {
    eprintln!("{}", ignored_options);
   }

  debug!("{}", stats);
  ```

- Improves `IgnoredOptions` to "own" the path where the ignored options came from, meaning that it is self contained and can easily be logged out at a higher level without the higher level having to explicitly know about where it came from.
- Reverts some of the `Result<T>` to `Result<T, AnyError>`.

I tried to move `tsc.rs` and the rest of `global_state` over to `TsConfig` but the whole thing is a bit too tangled to easily pull that out, but as we move more over to the new module graph, we should be able to clean all that up.
