### PR TITLE
chore(cli/coverage): remove unused runtime domain

### DIFF
--- a/cli/coverage.rs
+++ b/cli/coverage.rs
@@ -129,10 +129,6 @@ impl CoverageCollector {
       .await?;
 
     self
-      .post_message("Runtime.enable".to_string(), None)
-      .await?;
-
-    self
       .post_message("Profiler.enable".to_string(), None)
       .await?;
 
@@ -183,9 +179,6 @@ impl CoverageCollector {
       .await?;
     self
       .post_message("Profiler.disable".to_string(), None)
-      .await?;
-    self
-      .post_message("Runtime.disable".to_string(), None)
       .await?;
     self
       .post_message("Debugger.disable".to_string(), None)


### PR DESCRIPTION
Previously when we used the websocket to talk to the inspector we used the runtime domain to send a "runIfWaitingForDebugger" message.

However this is not required since we now talk to the inspector directly and no longer send said message so this removes the enabling of the domain entirely.
