### PR TITLE
refactor(std/hash): make SHA uppercase

### DIFF
--- a/cli/tests/hash.ts
+++ b/cli/tests/hash.ts
@@ -3,10 +3,10 @@
 const { args } = Deno;
 import { createHash, SupportedAlgorithm } from "../../std/hash/mod.ts";
 import { Md5 } from "../../std/hash/md5.ts";
-import { Sha1 } from "../../std/hash/sha1.ts";
-import { Sha256 } from "../../std/hash/sha256.ts";
-import { Sha512 } from "../../std/hash/sha512.ts";
-import { Sha3_224, Sha3_256, Sha3_384, Sha3_512 } from "../../std/hash/sha3.ts";
+import { SHA1 } from "../../std/hash/sha1.ts";
+import { SHA256 } from "../../std/hash/sha256.ts";
+import { SHA512 } from "../../std/hash/sha512.ts";
+import { SHA3_225, SHA3_256, SHA3_384, SHA3_512 } from "../../std/hash/sha3.ts";
 
 if (args.length < 3) Deno.exit(0);
 
@@ -19,21 +19,21 @@ function getJsHash(alg: string): any {
     case "md5":
       return new Md5();
     case "sha1":
-      return new Sha1();
+      return new SHA1();
     case "sha224":
-      return new Sha256(true);
+      return new SHA256(true);
     case "sha256":
-      return new Sha256();
+      return new SHA256();
     case "sha3-224":
-      return new Sha3_224();
+      return new SHA3_225();
     case "sha3-256":
-      return new Sha3_256();
+      return new SHA3_256();
     case "sha3-384":
-      return new Sha3_384();
+      return new SHA3_384();
     case "sha3-512":
-      return new Sha3_512();
+      return new SHA3_512();
     case "sha512":
-      return new Sha512();
+      return new SHA512();
     default:
       return null;
   }

--- a/std/hash/_sha3/sha3.ts
+++ b/std/hash/_sha3/sha3.ts
@@ -4,7 +4,7 @@ import { Sponge } from "./sponge.ts";
 import { keccakf } from "./keccakf.ts";
 
 /** Sha3-224 hash */
-export class Sha3_224 extends Sponge {
+export class SHA3_225 extends Sponge {
   constructor() {
     super({
       bitsize: 224,
@@ -16,7 +16,7 @@ export class Sha3_224 extends Sponge {
 }
 
 /** Sha3-256 hash */
-export class Sha3_256 extends Sponge {
+export class SHA3_256 extends Sponge {
   constructor() {
     super({
       bitsize: 256,
@@ -28,7 +28,7 @@ export class Sha3_256 extends Sponge {
 }
 
 /** Sha3-384 hash */
-export class Sha3_384 extends Sponge {
+export class SHA3_384 extends Sponge {
   constructor() {
     super({
       bitsize: 384,
@@ -40,7 +40,7 @@ export class Sha3_384 extends Sponge {
 }
 
 /** Sha3-512 hash */
-export class Sha3_512 extends Sponge {
+export class SHA3_512 extends Sponge {
   constructor() {
     super({
       bitsize: 512,

--- a/std/hash/sha1.ts
+++ b/std/hash/sha1.ts
@@ -16,7 +16,7 @@ const SHIFT = [24, 16, 8, 0] as const;
 
 const blocks: number[] = [];
 
-export class Sha1 {
+export class SHA1 {
   #blocks!: number[];
   #block!: number;
   #start!: number;

--- a/std/hash/sha1_test.ts
+++ b/std/hash/sha1_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../testing/asserts.ts";
-import { Message, Sha1 } from "./sha1.ts";
+import { Message, SHA1 } from "./sha1.ts";
 import { dirname, fromFileUrl, join, resolve } from "../path/mod.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
@@ -72,7 +72,7 @@ for (const method of methods) {
       Deno.test({
         name: `sha1.${method}() - ${name} - #${i++}`,
         fn() {
-          const algorithm = new Sha1();
+          const algorithm = new SHA1();
           algorithm.update(message);
           const actual = method === "hex"
             ? algorithm[method]()
@@ -91,7 +91,7 @@ for (const method of methods) {
       Deno.test({
         name: `sha1.${method}() - ${name} - #${i++}`,
         fn() {
-          const algorithm = new Sha1(true);
+          const algorithm = new SHA1(true);
           algorithm.update(message);
           const actual = method === "hex"
             ? algorithm[method]()
@@ -106,6 +106,6 @@ for (const method of methods) {
 Deno.test("[hash/sha1] test Uint8Array from Reader", async () => {
   const data = await Deno.readFile(join(testdataDir, "hashtest"));
 
-  const hash = new Sha1().update(data).hex();
+  const hash = new SHA1().update(data).hex();
   assertEquals(hash, "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3");
 });

--- a/std/hash/sha256.ts
+++ b/std/hash/sha256.ts
@@ -32,7 +32,7 @@ const K = [
 
 const blocks: number[] = [];
 
-export class Sha256 {
+export class SHA256 {
   #block!: number;
   #blocks!: number[];
   #bytes!: number;
@@ -467,7 +467,7 @@ export class Sha256 {
   }
 }
 
-export class HmacSha256 extends Sha256 {
+export class HmacSha256 extends SHA256 {
   #inner: boolean;
   #is224: boolean;
   #oKeyPad: number[];
@@ -511,7 +511,7 @@ export class HmacSha256 extends Sha256 {
     }
 
     if (key.length > 64) {
-      key = new Sha256(is224, true).update(key).array();
+      key = new SHA256(is224, true).update(key).array();
     }
 
     const oKeyPad: number[] = [];

--- a/std/hash/sha256_test.ts
+++ b/std/hash/sha256_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { HmacSha256, Message, Sha256 } from "./sha256.ts";
+import { HmacSha256, Message, SHA256 } from "./sha256.ts";
 import { assertEquals } from "../testing/asserts.ts";
 import { dirname, fromFileUrl, join, resolve } from "../path/mod.ts";
 
@@ -217,7 +217,7 @@ for (const method of methods) {
       Deno.test({
         name: `sha256.${method}() - ${name} - #${i++}`,
         fn() {
-          const algorithm = new Sha256();
+          const algorithm = new SHA256();
           algorithm.update(message);
           const actual = method === "hex"
             ? algorithm[method]()
@@ -236,7 +236,7 @@ for (const method of methods) {
       Deno.test({
         name: `sha224.${method}() - ${name} - #${i++}`,
         fn() {
-          const algorithm = new Sha256(true);
+          const algorithm = new SHA256(true);
           algorithm.update(message);
           const actual = method === "hex"
             ? algorithm[method]()
@@ -289,7 +289,7 @@ for (const method of methods) {
 Deno.test("[hash/sha256] test Uint8Array from Reader", async () => {
   const data = await Deno.readFile(join(testdataDir, "hashtest"));
 
-  const hash = new Sha256().update(data).hex();
+  const hash = new SHA256().update(data).hex();
   assertEquals(
     hash,
     "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",

--- a/std/hash/sha3.ts
+++ b/std/hash/sha3.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-export { Sha3_224, Sha3_256, Sha3_384, Sha3_512 } from "./_sha3/sha3.ts";
+export { SHA3_225, SHA3_256, SHA3_384, SHA3_512 } from "./_sha3/sha3.ts";
 export { Keccak224, Keccak256, Keccak384, Keccak512 } from "./_sha3/keccak.ts";
 export { Shake128, Shake256 } from "./_sha3/shake.ts";

--- a/std/hash/sha3_test.ts
+++ b/std/hash/sha3_test.ts
@@ -6,10 +6,10 @@ import {
   Keccak256,
   Keccak384,
   Keccak512,
-  Sha3_224,
-  Sha3_256,
-  Sha3_384,
-  Sha3_512,
+  SHA3_225,
+  SHA3_256,
+  SHA3_384,
+  SHA3_512,
   Shake128,
   Shake256,
 } from "./sha3.ts";
@@ -261,7 +261,7 @@ function s2b(data: string): Uint8Array {
 
 Deno.test("[hash/sha3] testSha3-224Raw", () => {
   const sha3sum = (data: ArrayBuffer): ArrayBuffer => {
-    const sha3 = new Sha3_224();
+    const sha3 = new SHA3_225();
     return sha3.update(data).digest();
   };
 
@@ -273,7 +273,7 @@ Deno.test("[hash/sha3] testSha3-224Raw", () => {
 
 Deno.test("[hash/sha3] testSha3-224String", () => {
   const sha3sum = (data: string): string => {
-    const sha3 = new Sha3_224();
+    const sha3 = new SHA3_225();
     return sha3.update(data).toString();
   };
 
@@ -284,7 +284,7 @@ Deno.test("[hash/sha3] testSha3-224String", () => {
 
 Deno.test("[hash/sha3] testSha3-256Raw", () => {
   const sha3sum = (data: ArrayBuffer): ArrayBuffer => {
-    const sha3 = new Sha3_256();
+    const sha3 = new SHA3_256();
     return sha3.update(data).digest();
   };
 
@@ -296,7 +296,7 @@ Deno.test("[hash/sha3] testSha3-256Raw", () => {
 
 Deno.test("[hash/sha3] testSha3-256String", () => {
   const sha3sum = (data: string): string => {
-    const sha3 = new Sha3_256();
+    const sha3 = new SHA3_256();
     return sha3.update(data).toString();
   };
 
@@ -307,7 +307,7 @@ Deno.test("[hash/sha3] testSha3-256String", () => {
 
 Deno.test("[hash/sha3] testSha3-384Raw", () => {
   const sha3sum = (data: ArrayBuffer): ArrayBuffer => {
-    const sha3 = new Sha3_384();
+    const sha3 = new SHA3_384();
     return sha3.update(data).digest();
   };
 
@@ -319,7 +319,7 @@ Deno.test("[hash/sha3] testSha3-384Raw", () => {
 
 Deno.test("[hash/sha3] testSha3-384String", () => {
   const sha3sum = (data: string): string => {
-    const sha3 = new Sha3_384();
+    const sha3 = new SHA3_384();
     return sha3.update(data).toString();
   };
 
@@ -330,7 +330,7 @@ Deno.test("[hash/sha3] testSha3-384String", () => {
 
 Deno.test("[hash/sha3] testSha3-512Raw", () => {
   const sha3sum = (data: ArrayBuffer): ArrayBuffer => {
-    const sha3 = new Sha3_512();
+    const sha3 = new SHA3_512();
     return sha3.update(data).digest();
   };
 
@@ -342,7 +342,7 @@ Deno.test("[hash/sha3] testSha3-512Raw", () => {
 
 Deno.test("[hash/sha3] testSha3-512String", () => {
   const sha3sum = (data: string): string => {
-    const sha3 = new Sha3_512();
+    const sha3 = new SHA3_512();
     return sha3.update(data).toString();
   };
 
@@ -545,7 +545,7 @@ Deno.test("[hash/sha3] testSHAKE-256-512", () => {
 });
 
 Deno.test("[hash/sha3] testSha3-256Chain", () => {
-  const sha3 = new Sha3_256();
+  const sha3 = new SHA3_256();
   const output = sha3
     .update(s2b("a"))
     .update(s2b("b"))
@@ -561,7 +561,7 @@ Deno.test("[hash/sha3] testSha3-256Chain", () => {
 Deno.test("[hash/sha3] testSha3UpdateFinalized", () => {
   assertThrows(
     () => {
-      const sha3 = new Sha3_256();
+      const sha3 = new SHA3_256();
       const hash = sha3.update(s2b("a")).digest();
       const hash2 = sha3.update(s2b("a")).digest();
       assertEquals(hash, hash2);

--- a/std/hash/sha512.ts
+++ b/std/hash/sha512.ts
@@ -39,7 +39,7 @@ const K = [
 const blocks: number[] = [];
 
 // deno-fmt-ignore
-export class Sha512 {
+export class SHA512 {
   #blocks!: number[];
   #block!: number;
   #bits!: number;
@@ -718,7 +718,7 @@ export class Sha512 {
   }
 }
 
-export class HmacSha512 extends Sha512 {
+export class HmacSha512 extends SHA512 {
   #inner: boolean;
   #bits: number;
   #oKeyPad: number[];
@@ -761,7 +761,7 @@ export class HmacSha512 extends Sha512 {
       key = secretKey;
     }
     if (key.length > 128) {
-      key = new Sha512(bits, true).update(key).array();
+      key = new SHA512(bits, true).update(key).array();
     }
     const oKeyPad: number[] = [];
     const iKeyPad: number[] = [];

--- a/std/hash/sha512_test.ts
+++ b/std/hash/sha512_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { HmacSha512, Message, Sha512 } from "./sha512.ts";
+import { HmacSha512, Message, SHA512 } from "./sha512.ts";
 import { assertEquals } from "../testing/asserts.ts";
 import { dirname, fromFileUrl, join, resolve } from "../path/mod.ts";
 
@@ -283,7 +283,7 @@ for (const method of methods) {
       Deno.test({
         name: `sha512/224.${method}() - ${name} - #${i++}`,
         fn() {
-          const algorithm = new Sha512(224);
+          const algorithm = new SHA512(224);
           algorithm.update(message);
           const actual = method === "hex"
             ? algorithm[method]()
@@ -302,7 +302,7 @@ for (const method of methods) {
       Deno.test({
         name: `sha512/256.${method}() - ${name} - #${i++}`,
         fn() {
-          const algorithm = new Sha512(256);
+          const algorithm = new SHA512(256);
           algorithm.update(message);
           const actual = method === "hex"
             ? algorithm[method]()
@@ -321,7 +321,7 @@ for (const method of methods) {
       Deno.test({
         name: `sha512.${method}() - ${name} - #${i++}`,
         fn() {
-          const algorithm = new Sha512();
+          const algorithm = new SHA512();
           algorithm.update(message);
           const actual = method === "hex"
             ? algorithm[method]()
@@ -392,7 +392,7 @@ for (const method of methods) {
 
 Deno.test("[hash/sha512] test Uint8Array from Reader", async () => {
   const data = await Deno.readFile(join(testdataDir, "hashtest"));
-  const hash = new Sha512().update(data).hex();
+  const hash = new SHA512().update(data).hex();
   assertEquals(
     hash,
     "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff",

--- a/std/uuid/v5.ts
+++ b/std/uuid/v5.ts
@@ -5,7 +5,7 @@ import {
   stringToBytes,
   uuidToBytes,
 } from "./_common.ts";
-import { Sha1 } from "../hash/sha1.ts";
+import { SHA1 } from "../hash/sha1.ts";
 import { assert } from "../_util/assert.ts";
 
 const UUID_RE =
@@ -42,7 +42,7 @@ export function generate(
   );
 
   const content = (namespace as number[]).concat(value as number[]);
-  const bytes = new Sha1().update(createBuffer(content)).digest();
+  const bytes = new SHA1().update(createBuffer(content)).digest();
 
   bytes[6] = (bytes[6] & 0x0f) | 0x50;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;

--- a/std/ws/mod.ts
+++ b/std/ws/mod.ts
@@ -3,7 +3,7 @@ import { decode, encode } from "../encoding/utf8.ts";
 import { hasOwnProperty } from "../_util/has_own_property.ts";
 import { BufReader, BufWriter } from "../io/bufio.ts";
 import { readLong, readShort, sliceLongToBytes } from "../io/ioutil.ts";
-import { Sha1 } from "../hash/sha1.ts";
+import { SHA1 } from "../hash/sha1.ts";
 import { writeResponse } from "../http/_io.ts";
 import { TextProtoReader } from "../textproto/mod.ts";
 import { Deferred, deferred } from "../async/deferred.ts";
@@ -403,7 +403,7 @@ const kGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 /** Create sec-websocket-accept header value with given nonce */
 export function createSecAccept(nonce: string): string {
-  const sha1 = new Sha1();
+  const sha1 = new SHA1();
   sha1.update(nonce + kGUID);
   const bytes = sha1.digest();
   return btoa(String.fromCharCode(...bytes));


### PR DESCRIPTION
Rename `Sha_*` algorithms to use uppercase

This change is dictated by `deno lint` failing on non-camelcase identifiers.

Closes https://github.com/denoland/deno/issues/7739