### PR TITLE
fix: check cached versions during transpile

### DIFF
--- a/cli/graph.rs
+++ b/cli/graph.rs
@@ -792,23 +792,23 @@ mod tests {
   fn test_get_version() {
     let doc_a =
       TextDocument::new(b"console.log(42);".to_vec(), Option::<&str>::None);
-    let a = get_version(&doc_a, "1.2.3", &None);
+    let version_a = get_version(&doc_a, "1.2.3", &None);
     let doc_b =
       TextDocument::new(b"console.log(42);".to_vec(), Option::<&str>::None);
-    let b = get_version(&doc_b, "1.2.3", &None);
-    assert_eq!(a, b);
+    let version_b = get_version(&doc_b, "1.2.3", &None);
+    assert_eq!(version_a, version_b);
 
-    let c = get_version(&doc_a, "1.2.3", &Some(b"options".to_vec()));
-    assert_ne!(a, c);
+    let version_c = get_version(&doc_a, "1.2.3", &Some(b"options".to_vec()));
+    assert_ne!(version_a, version_c);
 
-    let d = get_version(&doc_b, "1.2.3", &Some(b"options".to_vec()));
-    assert_eq!(c, d);
+    let version_d = get_version(&doc_b, "1.2.3", &Some(b"options".to_vec()));
+    assert_eq!(version_c, version_d);
 
-    let e = get_version(&doc_a, "1.2.4", &None);
-    assert_ne!(a, e);
+    let version_e = get_version(&doc_a, "1.2.4", &None);
+    assert_ne!(version_a, version_e);
 
-    let f = get_version(&doc_b, "1.2.4", &None);
-    assert_eq!(e, f);
+    let version_f = get_version(&doc_b, "1.2.4", &None);
+    assert_eq!(version_e, version_f);
   }
 
   #[test]

--- a/cli/graph.rs
+++ b/cli/graph.rs
@@ -16,6 +16,7 @@ use crate::specifier_handler::FetchFuture;
 use crate::specifier_handler::SpecifierHandler;
 use crate::tsc_config::IgnoredCompilerOptions;
 use crate::tsc_config::TsConfig;
+use crate::version;
 use crate::AnyError;
 
 use deno_core::futures::stream::FuturesUnordered;
@@ -163,6 +164,28 @@ fn parse_deno_types(comment: &str) -> Option<String> {
   }
 }
 
+/// A hashing function that takes the source code, version and optionally a
+/// user provided config and generates a string hash which can be stored to
+/// determine if the cached emit is valid or not.
+fn get_version(
+  source: &TextDocument,
+  version: &str,
+  maybe_config: &Option<Vec<u8>>,
+) -> String {
+  if let Some(config) = maybe_config {
+    crate::checksum::gen(&[
+      source.to_str().unwrap().as_bytes(),
+      version.as_bytes(),
+      config,
+    ])
+  } else {
+    crate::checksum::gen(&[
+      source.to_str().unwrap().as_bytes(),
+      version.as_bytes(),
+    ])
+  }
+}
+
 /// A logical representation of a module within a graph.
 #[derive(Debug, Clone)]
 struct Module {
@@ -174,6 +197,7 @@ struct Module {
   maybe_import_map: Option<Rc<RefCell<ImportMap>>>,
   maybe_parsed_module: Option<ParsedModule>,
   maybe_types: Option<(String, ModuleSpecifier)>,
+  maybe_version: Option<String>,
   media_type: MediaType,
   specifier: ModuleSpecifier,
   source: TextDocument,
@@ -190,6 +214,7 @@ impl Default for Module {
       maybe_import_map: None,
       maybe_parsed_module: None,
       maybe_types: None,
+      maybe_version: None,
       media_type: MediaType::Unknown,
       specifier: ModuleSpecifier::resolve_url("https://deno.land/x/").unwrap(),
       source: TextDocument::new(Vec::new(), Option::<&str>::None),
@@ -206,6 +231,16 @@ impl Module {
       specifier,
       maybe_import_map,
       ..Module::default()
+    }
+  }
+
+  /// Return `true` if the current hash of the module matches the stored
+  /// version.
+  pub fn emit_valid(&self, maybe_config: &Option<Vec<u8>>) -> bool {
+    if let Some(version) = self.maybe_version.clone() {
+      version == get_version(&self.source, version::DENO, maybe_config)
+    } else {
+      false
     }
   }
 
@@ -230,6 +265,7 @@ impl Module {
     };
     self.is_dirty = false;
     self.emits = cached_module.emits;
+    self.maybe_version = cached_module.maybe_version;
     self.is_hydrated = true;
   }
 
@@ -351,6 +387,12 @@ impl Module {
 
     Ok(specifier)
   }
+
+  /// Calculate the hashed version of the module and update the `maybe_version`.
+  pub fn set_version(&mut self, maybe_config: &Option<Vec<u8>>) {
+    self.maybe_version =
+      Some(get_version(&self.source, version::DENO, maybe_config))
+  }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -428,6 +470,9 @@ impl Graph {
           maybe_map.clone(),
         )?;
         module.is_dirty = false;
+        if let Some(version) = &module.maybe_version {
+          handler.set_version(&module.specifier, version.clone())?;
+        }
       }
     }
     for root_specifier in self.roots.iter() {
@@ -508,12 +553,12 @@ impl Graph {
 
     let mut emit_count: u128 = 0;
     for (_, module) in self.modules.iter_mut() {
+      // TODO(kitsonk) a lot of this logic should be refactored into `Module` as
+      // we start to support other methods on the graph.  Especially managing
+      // the dirty state is something the module itself should "own".
+
       // if the module is a Dts file we should skip it
       if module.media_type == MediaType::Dts {
-        continue;
-      }
-      // skip modules that already have a valid emit
-      if module.emits.contains_key(&emit_type) {
         continue;
       }
       // if we don't have check_js enabled, we won't touch non TypeScript
@@ -524,6 +569,12 @@ impl Graph {
       {
         continue;
       }
+      // skip modules that already have a valid emit
+      if module.emit_valid(&ts_config.maybe_user_config)
+        && module.emits.contains_key(&emit_type)
+      {
+        continue;
+      }
       if module.maybe_parsed_module.is_none() {
         module.parse()?;
       }
@@ -531,6 +582,7 @@ impl Graph {
       let emit = parsed_module.transpile(&emit_options)?;
       emit_count += 1;
       module.emits.insert(emit_type.clone(), emit);
+      module.set_version(&ts_config.maybe_user_config);
       module.is_dirty = true;
     }
     self.flush(&emit_type)?;
@@ -735,6 +787,86 @@ mod tests {
   use std::env;
   use std::path::PathBuf;
   use std::sync::Mutex;
+
+  #[test]
+  fn test_get_version() {
+    let doc_a =
+      TextDocument::new(b"console.log(42);".to_vec(), Option::<&str>::None);
+    let a = get_version(&doc_a, "1.2.3", &None);
+    let doc_b =
+      TextDocument::new(b"console.log(42);".to_vec(), Option::<&str>::None);
+    let b = get_version(&doc_b, "1.2.3", &None);
+    assert_eq!(a, b);
+
+    let c = get_version(&doc_a, "1.2.3", &Some(b"options".to_vec()));
+    assert_ne!(a, c);
+
+    let d = get_version(&doc_b, "1.2.3", &Some(b"options".to_vec()));
+    assert_eq!(c, d);
+
+    let e = get_version(&doc_a, "1.2.4", &None);
+    assert_ne!(a, e);
+
+    let f = get_version(&doc_b, "1.2.4", &None);
+    assert_eq!(e, f);
+  }
+
+  #[test]
+  fn test_module_emit_valid() {
+    let source =
+      TextDocument::new(b"console.log(42);".to_vec(), Option::<&str>::None);
+    let maybe_version = Some(get_version(&source, version::DENO, &None));
+    let module = Module {
+      source,
+      maybe_version,
+      ..Module::default()
+    };
+    assert!(module.emit_valid(&None));
+
+    let source =
+      TextDocument::new(b"console.log(42);".to_vec(), Option::<&str>::None);
+    let old_source =
+      TextDocument::new(b"console.log(43);".to_vec(), Option::<&str>::None);
+    let maybe_version = Some(get_version(&old_source, version::DENO, &None));
+    let module = Module {
+      source,
+      maybe_version,
+      ..Module::default()
+    };
+    assert!(!module.emit_valid(&None));
+
+    let source =
+      TextDocument::new(b"console.log(42);".to_vec(), Option::<&str>::None);
+    let maybe_version = Some(get_version(&source, "0.0.0", &None));
+    let module = Module {
+      source,
+      maybe_version,
+      ..Module::default()
+    };
+    assert!(!module.emit_valid(&None));
+
+    let source =
+      TextDocument::new(b"console.log(42);".to_vec(), Option::<&str>::None);
+    let module = Module {
+      source,
+      ..Module::default()
+    };
+    assert!(!module.emit_valid(&None));
+  }
+
+  #[test]
+  fn test_module_set_version() {
+    let source =
+      TextDocument::new(b"console.log(42);".to_vec(), Option::<&str>::None);
+    let expected = Some(get_version(&source, version::DENO, &None));
+    let mut module = Module {
+      source,
+      ..Module::default()
+    };
+    assert!(module.maybe_version.is_none());
+    module.set_version(&None);
+    assert_eq!(module.maybe_version, expected);
+  }
 
   #[tokio::test]
   async fn test_graph_builder() {

--- a/cli/graph.rs
+++ b/cli/graph.rs
@@ -570,8 +570,8 @@ impl Graph {
         continue;
       }
       // skip modules that already have a valid emit
-      if module.emit_valid(&ts_config.maybe_user_config)
-        && module.emits.contains_key(&emit_type)
+      if module.emits.contains_key(&emit_type)
+        && module.emit_valid(&ts_config.maybe_user_config)
       {
         continue;
       }

--- a/cli/specifier_handler.rs
+++ b/cli/specifier_handler.rs
@@ -20,15 +20,12 @@ use std::env;
 use std::error::Error;
 use std::fmt;
 use std::pin::Pin;
-use std::result;
 use std::sync::Arc;
-
-type Result<V> = result::Result<V, AnyError>;
 
 pub type DependencyMap = HashMap<String, Dependency>;
 pub type EmitMap = HashMap<EmitType, (TextDocument, Option<TextDocument>)>;
 pub type FetchFuture =
-  Pin<Box<(dyn Future<Output = Result<CachedModule>> + 'static)>>;
+  Pin<Box<(dyn Future<Output = Result<CachedModule, AnyError>> + 'static)>>;
 
 #[derive(Debug, Clone)]
 pub struct CachedModule {
@@ -89,7 +86,7 @@ pub struct Dependency {
 
 pub trait SpecifierHandler {
   /// Instructs the handler to fetch a specifier or retrieve its value from the
-  /// cache if there is a valid cached version.
+  /// cache.
   fn fetch(&mut self, specifier: ModuleSpecifier) -> FetchFuture;
 
   /// Get the optional build info from the cache for a given module specifier.
@@ -101,7 +98,7 @@ pub trait SpecifierHandler {
     &self,
     specifier: &ModuleSpecifier,
     emit_type: &EmitType,
-  ) -> Result<Option<TextDocument>>;
+  ) -> Result<Option<TextDocument>, AnyError>;
 
   /// Set the emitted code (and maybe map) for a given module specifier.  The
   /// cache type indicates what form the emit is related to.
@@ -111,7 +108,7 @@ pub trait SpecifierHandler {
     emit_type: &EmitType,
     code: TextDocument,
     maybe_map: Option<TextDocument>,
-  ) -> Result<()>;
+  ) -> Result<(), AnyError>;
 
   /// When parsed out of a JavaScript module source, the triple slash reference
   /// to the types should be stored in the cache.
@@ -119,7 +116,7 @@ pub trait SpecifierHandler {
     &mut self,
     specifier: &ModuleSpecifier,
     types: String,
-  ) -> Result<()>;
+  ) -> Result<(), AnyError>;
 
   /// Set the build info for a module specifier, also providing the cache type.
   fn set_build_info(
@@ -127,22 +124,22 @@ pub trait SpecifierHandler {
     specifier: &ModuleSpecifier,
     emit_type: &EmitType,
     build_info: TextDocument,
-  ) -> Result<()>;
+  ) -> Result<(), AnyError>;
 
   /// Set the graph dependencies for a given module specifier.
   fn set_deps(
     &mut self,
     specifier: &ModuleSpecifier,
     dependencies: DependencyMap,
-  ) -> Result<()>;
+  ) -> Result<(), AnyError>;
 
   /// Set the version of the source for a given module, which is used to help
-  /// determine if a module needs to be re-type-checked.
+  /// determine if a module needs to be re-emitted.
   fn set_version(
     &mut self,
     specifier: &ModuleSpecifier,
     version: String,
-  ) -> Result<()>;
+  ) -> Result<(), AnyError>;
 }
 
 impl fmt::Debug for dyn SpecifierHandler {
@@ -185,11 +182,12 @@ pub struct CompiledFileMetadata {
 }
 
 impl CompiledFileMetadata {
-  pub fn from_json_string(metadata_string: &str) -> Result<Self> {
+  pub fn from_bytes(bytes: &[u8]) -> Result<Self, AnyError> {
+    let metadata_string = std::str::from_utf8(bytes)?;
     serde_json::from_str::<Self>(metadata_string).map_err(|e| e.into())
   }
 
-  pub fn to_json_string(&self) -> Result<String> {
+  pub fn to_json_string(&self) -> Result<String, AnyError> {
     serde_json::to_string(self).map_err(|e| e.into())
   }
 }
@@ -207,7 +205,7 @@ impl FetchHandler {
   pub fn new(
     global_state: &Arc<GlobalState>,
     permissions: Permissions,
-  ) -> Result<Self> {
+  ) -> Result<Self, AnyError> {
     let custom_root = env::var("DENO_DIR").map(String::into).ok();
     let deno_dir = DenoDir::new(custom_root)?;
     let disk_cache = deno_dir.gen_cache;
@@ -234,14 +232,10 @@ impl SpecifierHandler for FetchHandler {
       let url = source_file.url;
       let filename = disk_cache.get_cache_filename_with_extension(&url, "meta");
       let maybe_version = if let Ok(bytes) = disk_cache.get(&filename) {
-        if let Ok(metadata_string) = std::str::from_utf8(&bytes) {
-          if let Ok(compiled_file_metadata) =
-            CompiledFileMetadata::from_json_string(metadata_string)
-          {
-            Some(compiled_file_metadata.version_hash)
-          } else {
-            None
-          }
+        if let Ok(compiled_file_metadata) =
+          CompiledFileMetadata::from_bytes(&bytes)
+        {
+          Some(compiled_file_metadata.version_hash)
         } else {
           None
         }
@@ -280,7 +274,7 @@ impl SpecifierHandler for FetchHandler {
     &self,
     specifier: &ModuleSpecifier,
     emit_type: &EmitType,
-  ) -> Result<Option<TextDocument>> {
+  ) -> Result<Option<TextDocument>, AnyError> {
     if emit_type != &EmitType::Cli {
       return Err(UnsupportedEmitType(emit_type.clone()).into());
     }
@@ -299,7 +293,7 @@ impl SpecifierHandler for FetchHandler {
     specifier: &ModuleSpecifier,
     emit_type: &EmitType,
     build_info: TextDocument,
-  ) -> Result<()> {
+  ) -> Result<(), AnyError> {
     if emit_type != &EmitType::Cli {
       return Err(UnsupportedEmitType(emit_type.clone()).into());
     }
@@ -318,7 +312,7 @@ impl SpecifierHandler for FetchHandler {
     emit_type: &EmitType,
     code: TextDocument,
     maybe_map: Option<TextDocument>,
-  ) -> Result<()> {
+  ) -> Result<(), AnyError> {
     if emit_type != &EmitType::Cli {
       return Err(UnsupportedEmitType(emit_type.clone()).into());
     }
@@ -341,7 +335,7 @@ impl SpecifierHandler for FetchHandler {
     &mut self,
     _specifier: &ModuleSpecifier,
     _dependencies: DependencyMap,
-  ) -> Result<()> {
+  ) -> Result<(), AnyError> {
     // file_fetcher doesn't have the concept of caching dependencies
     Ok(())
   }
@@ -350,7 +344,7 @@ impl SpecifierHandler for FetchHandler {
     &mut self,
     _specifier: &ModuleSpecifier,
     _types: String,
-  ) -> Result<()> {
+  ) -> Result<(), AnyError> {
     // file_fetcher doesn't have the concept of caching of the types
     Ok(())
   }
@@ -359,7 +353,7 @@ impl SpecifierHandler for FetchHandler {
     &mut self,
     specifier: &ModuleSpecifier,
     version_hash: String,
-  ) -> Result<()> {
+  ) -> Result<(), AnyError> {
     let compiled_file_metadata = CompiledFileMetadata { version_hash };
     let filename = self
       .disk_cache
@@ -408,7 +402,10 @@ pub mod tests {
   impl MockSpecifierHandler {}
 
   impl MockSpecifierHandler {
-    fn get_cache(&self, specifier: ModuleSpecifier) -> Result<CachedModule> {
+    fn get_cache(
+      &self,
+      specifier: ModuleSpecifier,
+    ) -> Result<CachedModule, AnyError> {
       let specifier_text = specifier
         .to_string()
         .replace(":///", "_")
@@ -449,7 +446,7 @@ pub mod tests {
       &self,
       specifier: &ModuleSpecifier,
       _cache_type: &EmitType,
-    ) -> Result<Option<TextDocument>> {
+    ) -> Result<Option<TextDocument>, AnyError> {
       Ok(self.build_info.get(specifier).cloned())
     }
     fn set_cache(
@@ -458,7 +455,7 @@ pub mod tests {
       cache_type: &EmitType,
       code: TextDocument,
       maybe_map: Option<TextDocument>,
-    ) -> Result<()> {
+    ) -> Result<(), AnyError> {
       self.cache_calls.push((
         specifier.clone(),
         cache_type.clone(),
@@ -471,7 +468,7 @@ pub mod tests {
       &mut self,
       specifier: &ModuleSpecifier,
       types: String,
-    ) -> Result<()> {
+    ) -> Result<(), AnyError> {
       self.types_calls.push((specifier.clone(), types));
       Ok(())
     }
@@ -480,7 +477,7 @@ pub mod tests {
       specifier: &ModuleSpecifier,
       cache_type: &EmitType,
       build_info: TextDocument,
-    ) -> Result<()> {
+    ) -> Result<(), AnyError> {
       self
         .build_info
         .insert(specifier.clone(), build_info.clone());
@@ -495,7 +492,7 @@ pub mod tests {
       &mut self,
       specifier: &ModuleSpecifier,
       dependencies: DependencyMap,
-    ) -> Result<()> {
+    ) -> Result<(), AnyError> {
       self.deps_calls.push((specifier.clone(), dependencies));
       Ok(())
     }
@@ -503,7 +500,7 @@ pub mod tests {
       &mut self,
       specifier: &ModuleSpecifier,
       version: String,
-    ) -> Result<()> {
+    ) -> Result<(), AnyError> {
       self.version_calls.push((specifier.clone(), version));
       Ok(())
     }

--- a/cli/tsc_config.rs
+++ b/cli/tsc_config.rs
@@ -202,20 +202,16 @@ pub fn parse_config(
 
 /// A structure for managing the configuration of TypeScript
 #[derive(Debug, Clone)]
-pub struct TsConfig {
-  value: Value,
-  /// The bytes of any user config, which is used in generating hashes of
-  /// emitted files for cache invalidation purposes.
-  pub maybe_user_config: Option<Vec<u8>>,
-}
+pub struct TsConfig(Value);
 
 impl TsConfig {
   /// Create a new `TsConfig` with the base being the `value` supplied.
   pub fn new(value: Value) -> Self {
-    TsConfig {
-      value,
-      maybe_user_config: None,
-    }
+    TsConfig(value)
+  }
+
+  pub fn as_bytes(&self) -> Vec<u8> {
+    self.0.to_string().as_bytes().to_owned()
   }
 
   /// Take an optional string representing a user provided TypeScript config file
@@ -245,8 +241,7 @@ impl TsConfig {
       let config_text = std::str::from_utf8(&config_bytes)?;
       let (value, maybe_ignored_options) =
         parse_config(&config_text, &config_path)?;
-      json_merge(&mut self.value, &value);
-      self.maybe_user_config = Some(config_bytes);
+      json_merge(&mut self.0, &value);
 
       Ok(maybe_ignored_options)
     } else {
@@ -259,7 +254,7 @@ impl TsConfig {
     &self,
   ) -> Result<TranspileConfigOptions, AnyError> {
     let options: TranspileConfigOptions =
-      serde_json::from_value(self.value.clone())?;
+      serde_json::from_value(self.0.clone())?;
     Ok(options)
   }
 }
@@ -270,7 +265,7 @@ impl Serialize for TsConfig {
   where
     S: Serializer,
   {
-    Serialize::serialize(&self.value, serializer)
+    Serialize::serialize(&self.0, serializer)
   }
 }
 


### PR DESCRIPTION
Fixes #7759

This also includes a few other refactors that will make it easier to move other functions over to the new graph.