### PR TITLE
fix: bundle loader returns exported value

### DIFF
--- a/cli/system_loader.js
+++ b/cli/system_loader.js
@@ -44,14 +44,15 @@ let System, __instantiate;
 
   function gE(exp) {
     return (id, v) => {
-      v = typeof id === "string" ? { [id]: v } : id;
-      for (const [id, value] of Object.entries(v)) {
+      const e = typeof id === "string" ? { [id]: v } : id;
+      for (const [id, value] of Object.entries(e)) {
         Object.defineProperty(exp, id, {
           value,
           writable: true,
           enumerable: true,
         });
       }
+      return v;
     };
   }
 

--- a/cli/system_loader_es5.js
+++ b/cli/system_loader_es5.js
@@ -94,8 +94,8 @@ var System, __instantiate;
   function gE(exp) {
     return function (id, v) {
       var _a;
-      v = typeof id === "string" ? ((_a = {}), (_a[id] = v), _a) : id;
-      for (var _i = 0, _b = Object.entries(v); _i < _b.length; _i++) {
+      var e = typeof id === "string" ? ((_a = {}), (_a[id] = v), _a) : id;
+      for (var _i = 0, _b = Object.entries(e); _i < _b.length; _i++) {
         var _c = _b[_i],
           id_1 = _c[0],
           value = _c[1];
@@ -105,6 +105,7 @@ var System, __instantiate;
           enumerable: true,
         });
       }
+      return v;
     };
   }
   function rF(main) {


### PR DESCRIPTION
Fixes #7761

In certain cases, when TypeScript output to System module format, it expects the `export` function of the module to return the exported value to be used elsewhere in the module.  Our System loader didn't have the behaviour, therefore causing issues in bundling some modules.