### PR TITLE
fix(cli/console): Catch and format getter errors

### DIFF
--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -762,29 +762,33 @@
       );
     }
 
+    const red = maybeColor(colors.red, inspectOptions);
+
     for (const key of stringKeys) {
-      entries.push(
-        `${maybeQuoteString(key)}: ${
-          inspectValueWithQuotes(
-            value[key],
-            ctx,
-            level + 1,
-            inspectOptions,
-          )
-        }`,
-      );
+      let propertyValue;
+      let error = null;
+      try {
+        propertyValue = value[key];
+      } catch (error_) {
+        error = error_;
+      }
+      const inspectedValue = error == null
+        ? inspectValueWithQuotes(propertyValue, ctx, level + 1, inspectOptions)
+        : red(`[Thrown ${error.name}: ${error.message}]`);
+      entries.push(`${maybeQuoteString(key)}: ${inspectedValue}`);
     }
     for (const key of symbolKeys) {
-      entries.push(
-        `[${maybeQuoteSymbol(key)}]: ${
-          inspectValueWithQuotes(
-            value[key],
-            ctx,
-            level + 1,
-            inspectOptions,
-          )
-        }`,
-      );
+      let propertyValue;
+      let error;
+      try {
+        propertyValue = value[key];
+      } catch (error_) {
+        error = error_;
+      }
+      const inspectedValue = error == null
+        ? inspectValueWithQuotes(propertyValue, ctx, level + 1, inspectOptions)
+        : red(`Thrown ${error.name}: ${error.message}`);
+      entries.push(`[${maybeQuoteSymbol(key)}]: ${inspectedValue}`);
     }
     // Making sure color codes are ignored when calculating the total length
     const totalLength = entries.length + level +

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1498,6 +1498,17 @@ unitTest(function inspectString(): void {
   );
 });
 
+unitTest(function inspectGetterError(): void {
+  assertEquals(
+    Deno.inspect({
+      get foo() {
+        throw new Error("bar");
+      },
+    }),
+    "{ foo: [Thrown Error: bar] }",
+  );
+});
+
 unitTest(function inspectSorted(): void {
   assertEquals(
     stripColor(Deno.inspect({ b: 2, a: 1 }, { sorted: true })),


### PR DESCRIPTION
```js
console.log({
  get location() {
    throw new ReferenceError(
      `Access to "location", run again with "--location <href>".`,
    );
  },
});
```

Before:
<kbd>![image](https://user-images.githubusercontent.com/29990554/94680304-7233df80-0319-11eb-867f-ff0a270a4f13.png)</kbd>

After:
<kbd>![image](https://user-images.githubusercontent.com/29990554/94680335-824bbf00-0319-11eb-8ca7-bb8da9a4ff55.png)</kbd>

~~Note that Node doesn't evaluate getters by default. Due to heavy use of getters in our runtime structures, this would lead to really annoying formatting for us, so let's continue the way we are.~~
