### PR TITLE
chore: ensure cache is 'valid' during benchmarks

### DIFF
--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -24,13 +24,9 @@ fn write_json(filename: &str, value: &Value) -> Result<()> {
 
 /// The list of the tuples of the benchmark name, arguments and return code
 const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
-  ("hello", &["run", "cli/tests/002_hello.ts"], None),
-  (
-    "relative_import",
-    &["run", "cli/tests/003_relative_import.ts"],
-    None,
-  ),
-  ("error_001", &["run", "cli/tests/error_001.ts"], Some(1)),
+  // we need to run the cold_* benchmarks before the _warm_ ones as they ensure
+  // the cache is properly populated, instead of other tests possibly
+  // invalidating that cache.
   (
     "cold_hello",
     &["run", "--reload", "cli/tests/002_hello.ts"],
@@ -41,6 +37,13 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
     &["run", "--reload", "cli/tests/003_relative_import.ts"],
     None,
   ),
+  ("hello", &["run", "cli/tests/002_hello.ts"], None),
+  (
+    "relative_import",
+    &["run", "cli/tests/003_relative_import.ts"],
+    None,
+  ),
+  ("error_001", &["run", "cli/tests/error_001.ts"], Some(1)),
   (
     "no_check_hello",
     &["run", "--reload", "--no-check", "cli/tests/002_hello.ts"],

--- a/cli/tsc_config.rs
+++ b/cli/tsc_config.rs
@@ -237,8 +237,7 @@ impl TsConfig {
           ),
         )
       })?;
-      let config_bytes = std::fs::read(config_path.clone())?;
-      let config_text = std::str::from_utf8(&config_bytes)?;
+      let config_text = std::fs::read_to_string(config_path.clone())?;
       let (value, maybe_ignored_options) =
         parse_config(&config_text, &config_path)?;
       json_merge(&mut self.0, &value);


### PR DESCRIPTION
This fixes the [strange results observed in the benchmarks we are seeing](https://github.com/denoland/deno/pull/7760#issuecomment-701724435).