### PR TITLE
feat(cli/console): inspect with colors regardless of Deno.noColor

### DIFF
--- a/cli/rt/01_colors.js
+++ b/cli/rt/01_colors.js
@@ -70,6 +70,10 @@
     return string.replace(ANSI_PATTERN, "");
   }
 
+  function maybeColor(fn) {
+    return !(globalThis.Deno?.noColor ?? true) ? fn : (s) => s;
+  }
+
   window.__bootstrap.colors = {
     bold,
     italic,
@@ -83,5 +87,6 @@
     magenta,
     dim,
     stripColor,
+    maybeColor,
   };
 })(this);

--- a/cli/rt/01_colors.js
+++ b/cli/rt/01_colors.js
@@ -10,9 +10,7 @@
   }
 
   function run(str, code) {
-    return !globalThis || !globalThis.Deno || globalThis.Deno.noColor
-      ? str
-      : `${code.open}${str.replace(code.regexp, code.open)}${code.close}`;
+    return `${code.open}${str.replace(code.regexp, code.open)}${code.close}`;
   }
 
   function bold(str) {

--- a/cli/rt/01_colors.js
+++ b/cli/rt/01_colors.js
@@ -71,7 +71,7 @@
   }
 
   function maybeColor(fn) {
-    return !(globalThis.Deno?.noColor ?? true) ? fn : (s) => s;
+    return !(globalThis.Deno?.noColor ?? false) ? fn : (s) => s;
   }
 
   window.__bootstrap.colors = {

--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -1343,7 +1343,7 @@
   function getConsoleInspectOptions() {
     return {
       ...DEFAULT_INSPECT_OPTIONS,
-      colors: !globalThis.Deno?.noColor,
+      colors: !(globalThis.Deno?.noColor ?? true),
     };
   }
 

--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -1343,7 +1343,7 @@
   function getConsoleInspectOptions() {
     return {
       ...DEFAULT_INSPECT_OPTIONS,
-      colors: !(globalThis.Deno?.noColor ?? true),
+      colors: !(globalThis.Deno?.noColor ?? false),
     };
   }
 

--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -1340,10 +1340,12 @@
   const timerMap = new Map();
   const isConsoleInstance = Symbol("isConsoleInstance");
 
-  const CONSOLE_INSPECT_OPTIONS = {
-    ...DEFAULT_INSPECT_OPTIONS,
-    colors: true,
-  };
+  function getConsoleInspectOptions() {
+    return {
+      ...DEFAULT_INSPECT_OPTIONS,
+      colors: !globalThis.Deno?.noColor,
+    };
+  }
 
   class Console {
     #printFunc = null;
@@ -1366,7 +1368,7 @@
     log = (...args) => {
       this.#printFunc(
         inspectArgs(args, {
-          ...CONSOLE_INSPECT_OPTIONS,
+          ...getConsoleInspectOptions(),
           indentLevel: this.indentLevel,
         }) + "\n",
         false,
@@ -1378,7 +1380,8 @@
 
     dir = (obj, options = {}) => {
       this.#printFunc(
-        inspectArgs([obj], { ...CONSOLE_INSPECT_OPTIONS, ...options }) + "\n",
+        inspectArgs([obj], { ...getConsoleInspectOptions(), ...options }) +
+          "\n",
         false,
       );
     };
@@ -1388,7 +1391,7 @@
     warn = (...args) => {
       this.#printFunc(
         inspectArgs(args, {
-          ...CONSOLE_INSPECT_OPTIONS,
+          ...getConsoleInspectOptions(),
           indentLevel: this.indentLevel,
         }) + "\n",
         true,
@@ -1594,7 +1597,7 @@
     trace = (...args) => {
       const message = inspectArgs(
         args,
-        { ...CONSOLE_INSPECT_OPTIONS, indentLevel: 0 },
+        { ...getConsoleInspectOptions(), indentLevel: 0 },
       );
       const err = {
         name: "Trace",

--- a/cli/rt/40_testing.js
+++ b/cli/rt/40_testing.js
@@ -2,7 +2,7 @@
 
 ((window) => {
   const core = window.Deno.core;
-  const { gray, green, italic, red, yellow } = window.__bootstrap.colors;
+  const colors = window.__bootstrap.colors;
   const { exit } = window.__bootstrap.os;
   const { Console, inspectArgs } = window.__bootstrap.console;
   const { stdout } = window.__bootstrap.files;
@@ -12,6 +12,10 @@
 
   const disabledConsole = new Console(() => {});
 
+  function maybeColor(fn) {
+    return !globalThis.Deno?.noColor ? fn : (s) => s;
+  }
+
   function delay(ms) {
     return new Promise((resolve) => {
       setTimeout(resolve, ms);
@@ -19,6 +23,8 @@
   }
 
   function formatDuration(time = 0) {
+    const gray = maybeColor(colors.gray);
+    const italic = maybeColor(colors.italic);
     const timeStr = `(${time}ms)`;
     return gray(italic(timeStr));
   }
@@ -139,6 +145,9 @@ finishing test case.`;
   }
 
   function reportToConsole(message) {
+    const green = maybeColor(colors.green);
+    const red = maybeColor(colors.red);
+    const yellow = maybeColor(colors.yellow);
     const redFailed = red("FAILED");
     const greenOk = green("ok");
     const yellowIgnored = yellow("ignored");

--- a/cli/rt/40_testing.js
+++ b/cli/rt/40_testing.js
@@ -12,10 +12,6 @@
 
   const disabledConsole = new Console(() => {});
 
-  function maybeColor(fn) {
-    return !globalThis.Deno?.noColor ? fn : (s) => s;
-  }
-
   function delay(ms) {
     return new Promise((resolve) => {
       setTimeout(resolve, ms);
@@ -23,8 +19,8 @@
   }
 
   function formatDuration(time = 0) {
-    const gray = maybeColor(colors.gray);
-    const italic = maybeColor(colors.italic);
+    const gray = colors.maybeColor(colors.gray);
+    const italic = colors.maybeColor(colors.italic);
     const timeStr = `(${time}ms)`;
     return gray(italic(timeStr));
   }
@@ -145,9 +141,9 @@ finishing test case.`;
   }
 
   function reportToConsole(message) {
-    const green = maybeColor(colors.green);
-    const red = maybeColor(colors.red);
-    const yellow = maybeColor(colors.yellow);
+    const green = colors.maybeColor(colors.green);
+    const red = colors.maybeColor(colors.red);
+    const yellow = colors.maybeColor(colors.yellow);
     const redFailed = red("FAILED");
     const greenOk = green("ok");
     const yellowIgnored = yellow("ignored");


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
This PR adds the ability for users to inspect items stylized with ANSI colors regardless of the value of `Deno.noColor` - for example,
```js
// Assumes that Deno.noColor is "true"
// Old behavior
Deno.inspect({ that: "is a object" }, { colors: true }) // { that: "is a object" }

// New behavior
Deno.inspect({ that: "is a object" }, { colors: true }) // { that: \x1b[32m"is a object"\x1b[39m }
```

Considerations:
- [x] Until `Deno.noColor` gets initted, should we assume the user accepts colors in their terminal?<br>(currently as it is, `colors.maybeColor` assumes that terminal colors shouldn't be present)