### PR TITLE
fix(cli/repl): enable await and let re-declarations

### DIFF
--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -126,9 +126,7 @@ pub async fn run(
             Some(json!({
               "expression": format!("'use strict'; void 0;\n{}", &wrapped_line),
               "contextId": context_id,
-              // TODO(caspervonb) set repl mode to true to enable const redeclarations and top
-              // level await
-              "replMode": false,
+              "replMode": true,
             })),
           )
           .await?;
@@ -145,9 +143,7 @@ pub async fn run(
                 Some(json!({
                   "expression": format!("'use strict'; void 0;\n{}", &line),
                   "contextId": context_id,
-                  // TODO(caspervonb) set repl mode to true to enable const redeclarations and top
-                  // level await
-                  "replMode": false,
+                  "replMode": true,
                 })),
               )
               .await?

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1167,6 +1167,45 @@ fn repl_test_block_expression() {
 }
 
 #[test]
+fn repl_test_await_resolve() {
+  let (out, err) = util::run_and_collect_output(
+    true,
+    "repl",
+    Some(vec!["await Promise.resolve('done')"]),
+    Some(vec![("NO_COLOR".to_owned(), "1".to_owned())]),
+    false,
+  );
+  assert!(out.ends_with("\"done\"\n"));
+  assert!(err.is_empty());
+}
+
+#[test]
+fn repl_test_await_timeout() {
+  let (out, err) = util::run_and_collect_output(
+    true,
+    "repl",
+    Some(vec!["await new Promise((r) => setTimeout(r, 0, 'done'))"]),
+    Some(vec![("NO_COLOR".to_owned(), "1".to_owned())]),
+    false,
+  );
+  assert!(out.ends_with("\"done\"\n"));
+  assert!(err.is_empty());
+}
+
+#[test]
+fn repl_test_let_redeclaration() {
+  let (out, err) = util::run_and_collect_output(
+    true,
+    "repl",
+    Some(vec!["let foo = 0;", "foo", "let foo = 1;", "foo"]),
+    Some(vec![("NO_COLOR".to_owned(), "1".to_owned())]),
+    false,
+  );
+  assert!(out.ends_with("undefined\n0\nundefined\n1\n"));
+  assert!(err.is_empty());
+}
+
+#[test]
 fn repl_cwd() {
   let (_out, err) = util::run_and_collect_output(
     true,


### PR DESCRIPTION
This enables `replMode` during evaluations which allows for top level  await and let re-declarations.

Fixes https://github.com/denoland/deno/issues/3700 https://github.com/denoland/deno/issues/3029