### PR TITLE
fix(cli/repl): use a default referrer when empty

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -430,6 +430,7 @@ async fn run_repl(flags: Flags) -> Result<(), AnyError> {
     ModuleSpecifier::resolve_url_or_path("./$deno$repl.ts").unwrap();
   let global_state = GlobalState::new(flags)?;
   let mut worker = MainWorker::new(&global_state, main_module.clone());
+  (&mut *worker).await?;
 
   let inspector = worker
     .inspector

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -430,7 +430,6 @@ async fn run_repl(flags: Flags) -> Result<(), AnyError> {
     ModuleSpecifier::resolve_url_or_path("./$deno$repl.ts").unwrap();
   let global_state = GlobalState::new(flags)?;
   let mut worker = MainWorker::new(&global_state, main_module.clone());
-  (&mut *worker).await?;
 
   let inspector = worker
     .inspector

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -46,10 +46,23 @@ impl CliModuleLoader {
 impl ModuleLoader for CliModuleLoader {
   fn resolve(
     &self,
+    op_state: Rc<RefCell<OpState>>,
     specifier: &str,
     referrer: &str,
     is_main: bool,
   ) -> Result<ModuleSpecifier, AnyError> {
+    let global_state = {
+      let state = op_state.borrow();
+      state.borrow::<Arc<GlobalState>>().clone()
+    };
+
+    // FIXME(bartlomieju): hacky way to provide compatibility with repl
+    let referrer = if referrer.is_empty() && global_state.flags.repl {
+      "<unknown>"
+    } else {
+      referrer
+    };
+
     if !is_main {
       if let Some(import_map) = &self.import_map {
         let result = import_map.resolve(specifier, referrer)?;
@@ -58,6 +71,7 @@ impl ModuleLoader for CliModuleLoader {
         }
       }
     }
+
     let module_specifier =
       ModuleSpecifier::resolve_import(specifier, referrer)?;
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1253,6 +1253,18 @@ fn repl_test_multiline() {
 }
 
 #[test]
+fn repl_test_await_import() {
+  let (out, _) = util::run_and_collect_output(
+    true,
+    "repl",
+    Some(vec!["import('./subdir/auto_print_hello.ts')"]),
+    Some(vec![("NO_COLOR".to_owned(), "1".to_owned())]),
+    false,
+  );
+  assert!(out.contains("hello!\n"));
+}
+
+#[test]
 fn repl_test_eval_unterminated() {
   let (out, err) = util::run_and_collect_output(
     true,

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1253,7 +1253,7 @@ fn repl_test_multiline() {
 }
 
 #[test]
-fn repl_test_await_import() {
+fn repl_test_import() {
   let (out, _) = util::run_and_collect_output(
     true,
     "repl",

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -609,7 +609,7 @@ impl JsRuntimeState {
     let referrer = self.modules.get_name(referrer_id).unwrap();
     let specifier = self
       .loader
-      .resolve(specifier, referrer, false)
+      .resolve(self.op_state.clone(), specifier, referrer, false)
       .expect("Module should have been already resolved");
     self.modules.get_id(specifier.as_str()).unwrap_or(0)
   }
@@ -814,8 +814,12 @@ impl JsRuntime {
       let import_specifier =
         module.get_module_request(i).to_rust_string_lossy(tc_scope);
       let state = state_rc.borrow();
-      let module_specifier =
-        state.loader.resolve(&import_specifier, name, false)?;
+      let module_specifier = state.loader.resolve(
+        state.op_state.clone(),
+        &import_specifier,
+        name,
+        false,
+      )?;
       import_specifiers.push(module_specifier);
     }
 
@@ -1918,6 +1922,7 @@ pub mod tests {
     impl ModuleLoader for ModsLoader {
       fn resolve(
         &self,
+        _op_state: Rc<RefCell<OpState>>,
         specifier: &str,
         referrer: &str,
         _is_main: bool,
@@ -2030,6 +2035,7 @@ pub mod tests {
     impl ModuleLoader for DynImportErrLoader {
       fn resolve(
         &self,
+        _op_state: Rc<RefCell<OpState>>,
         specifier: &str,
         referrer: &str,
         _is_main: bool,
@@ -2092,6 +2098,7 @@ pub mod tests {
   impl ModuleLoader for DynImportOkLoader {
     fn resolve(
       &self,
+      _op_state: Rc<RefCell<OpState>>,
       specifier: &str,
       referrer: &str,
       _is_main: bool,
@@ -2220,6 +2227,7 @@ pub mod tests {
     impl ModuleLoader for ModsLoader {
       fn resolve(
         &self,
+        _op_state: Rc<RefCell<OpState>>,
         specifier: &str,
         referrer: &str,
         _is_main: bool,


### PR DESCRIPTION
This makes use of a default referrer when its empty in repl mode so that dynamic imports work in the global evaluation context.