### PR TITLE
fix(cli/repl): enable colors on inspected values

### DIFF
--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -207,7 +207,7 @@ pub async fn run(
             "Runtime.callFunctionOn".to_string(),
             Some(json!({
               "executionContextId": context_id,
-              "functionDeclaration": "function (object) { return Deno[Deno.internal].inspectArgs(['%o', object]); }",
+              "functionDeclaration": "function (object) { return Deno[Deno.internal].inspectArgs(['%o', object], { colors: true}); }",
               "arguments": [
                 evaluate_result,
               ],


### PR DESCRIPTION
This enables colors on the inspected values before writing them to their output streams.

Fixes https://github.com/denoland/deno/issues/7797 