### PR TITLE
Revert "feat(unstable): enable importsNotUsedAsValues by default (#7413)"

### DIFF
--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -505,7 +505,6 @@ impl TsCompiler {
       "inlineSourceMap": true,
       // TODO(lucacasonato): enable this by default in 1.5.0
       "isolatedModules": unstable,
-      "importsNotUsedAsValues": if unstable { "error" } else { "remove" },
       "jsx": "react",
       "lib": lib,
       "module": "esnext",
@@ -1110,7 +1109,6 @@ pub async fn runtime_compile(
     "esModuleInterop": true,
     // TODO(lucacasonato): enable this by default in 1.5.0
     "isolatedModules": unstable,
-    "importsNotUsedAsValues": if unstable { "error" } else { "remove" },
     "jsx": "react",
     "module": "esnext",
     "sourceMap": true,

--- a/std/tsconfig_test.json
+++ b/std/tsconfig_test.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "isolatedModules": true,
-    "importsNotUsedAsValues": "error"
+    "isolatedModules": true
   }
 }


### PR DESCRIPTION
This reverts commit fbb18d40d3cfd0d24262e8e73b97f22770734572.

Ref #7413.

As discussed, the `--no-check` incompatiblity we were seeing with `import { MyType } from "./file.ts";` was a symptom of https://github.com/swc-project/swc/issues/1065 which is now fixed. The rule ~~is no longer~~ was never really needed.