### PR TITLE
fix(cli/repl): put the thread to sleep when idle

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -447,7 +447,9 @@ async fn run_repl(flags: Flags) -> Result<(), AnyError> {
       result = &mut repl => {
           return result;
       }
-      _ = &mut *worker => {}
+      _ = &mut *worker => {
+          tokio::time::delay_for(tokio::time::Duration::from_millis(10)).await;
+      }
     }
   }
 }


### PR DESCRIPTION
This adds a thread sleep when the worker idles to avoid spinning at 100%, brings it down to a nice and cool ~0.5%.

Fixes #7799