### PR TITLE
docs(std/encoding): missing JSDocs for std/encoding

### DIFF
--- a/std/encoding/hex.ts
+++ b/std/encoding/hex.ts
@@ -7,6 +7,10 @@
 
 const hextable = new TextEncoder().encode("0123456789abcdef");
 
+/**
+ * ErrInvalidByte takes an invalid byte and returns an Error.
+ * @param byte
+ */
 export function errInvalidByte(byte: number): Error {
   return new Error(
     "encoding/hex: invalid byte: " +
@@ -14,6 +18,9 @@ export function errInvalidByte(byte: number): Error {
   );
 }
 
+/**
+ * ErrLength returns an error about odd string length.
+ */
 export function errLength(): Error {
   return new Error("encoding/hex: odd length hex string");
 }

--- a/std/encoding/hex.ts
+++ b/std/encoding/hex.ts
@@ -18,9 +18,7 @@ export function errInvalidByte(byte: number): Error {
   );
 }
 
-/**
- * ErrLength returns an error about odd string length.
- */
+/** ErrLength returns an error about odd string length. */
 export function errLength(): Error {
   return new Error("encoding/hex: odd length hex string");
 }

--- a/std/encoding/toml.ts
+++ b/std/encoding/toml.ts
@@ -636,10 +636,18 @@ class Dumper {
   }
 }
 
+/**
+ * Stringify dumps source object into TOML string and returns it.
+ * @param srcObj
+ */
 export function stringify(srcObj: Record<string, unknown>): string {
   return new Dumper(srcObj).dump().join("\n");
 }
 
+/**
+ * Parse parses TOML string into an object.
+ * @param tomlString
+ */
 export function parse(tomlString: string): Record<string, unknown> {
   // File is potentially using EOL CRLF
   tomlString = tomlString.replace(/\r\n/g, "\n").replace(/\\\n/g, "\n");


### PR DESCRIPTION
I added JSdoc for std/encoding/toml.ts and std/encoding/hex.ts (#7487)