### PR TITLE
docs(std/wasi): remove outdated testing section

### DIFF
--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -86,13 +86,3 @@ if (start instanceof Function) {
   );
 }
 ```
-
-## Testing
-
-The test suite for this module spawns rustc processes to compile various example
-Rust programs. You must have wasm targets enabled:
-
-```
-rustup target add wasm32-wasi
-rustup target add wasm32-unknown-unknown
-```


### PR DESCRIPTION
Tests are brought in as pre-compiled binaries via a submodule leaving the testing section out of date.

This removes it as it's no longer relevant.