### PR TITLE
docs: end sentences with a period in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Deno is a _simple_, _modern_ and _secure_ runtime for **JavaScript** and
 - Built-in utilities like a dependency inspector (deno info) and a code
   formatter (deno fmt).
 - Set of reviewed standard modules that are guaranteed to work with
-  [Deno](https://deno.land/std/)
+  [Deno](https://deno.land/std/).
 
 ### Install
 
@@ -76,14 +76,14 @@ for await (const req of s) {
 You can find a more in depth introduction, examples, and environment setup
 guides in the [manual](https://deno.land/manual).
 
-More in-depth info can be found in the runtime [documentation](doc.deno.land)
+More in-depth info can be found in the runtime [documentation](doc.deno.land).
 
 ### Contributing
 
 We appreciate your help!
 
 To contribute, please read the our
-[guidelines](https://github.com/denoland/deno/blob/master/docs/contributing/style_guide.md)
+[guidelines](https://github.com/denoland/deno/blob/master/docs/contributing/style_guide.md).
 
 [Build Status - Cirrus]: https://github.com/denoland/deno/workflows/ci/badge.svg?branch=master&event=push
 [Build status]: https://github.com/denoland/deno/actions

--- a/Releases.md
+++ b/Releases.md
@@ -1,9 +1,9 @@
 # Releases
 
-Binary releases can be downloaded manually at
+Binary releases can be downloaded manually at:
 https://github.com/denoland/deno/releases
 
-We also have one-line install commands at
+We also have one-line install commands at:
 https://github.com/denoland/deno_install
 
 ### 1.4.4 / 2020.10.03

--- a/cli/dts/README.md
+++ b/cli/dts/README.md
@@ -5,8 +5,8 @@ currently (unfortunately) have a rather manual process for upgrading TypeScript.
 It works like this currently:
 
 1. Checkout typescript repo in a seperate directory.
-2. Copy typescript.js into Deno repo
-3. Copy d.ts files into dts directory
+2. Copy typescript.js into Deno repo.
+3. Copy d.ts files into dts directory.
 
 So that might look something like this:
 

--- a/cli/rt/README.md
+++ b/cli/rt/README.md
@@ -22,14 +22,14 @@ Some Web APIs are using ops under the hood, eg. `console`, `performance`.
 ## Implemented Web APIs
 
 - [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob): for
-  representing opaque binary data
+  representing opaque binary data.
 - [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console): for
-  logging purposes
+  logging purposes.
 - [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent),
   [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
   and
   [EventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventListener):
-  to work with DOM events
+  to work with DOM events.
   - **Implementation notes:** There is no DOM hierarchy in Deno, so there is no
     tree for Events to bubble/capture through.
 - [fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch),
@@ -37,23 +37,23 @@ Some Web APIs are using ops under the hood, eg. `console`, `performance`.
   [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response),
   [Body](https://developer.mozilla.org/en-US/docs/Web/API/Body) and
   [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers): modern
-  Promise-based HTTP Request API
+  Promise-based HTTP Request API.
 - [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData): access
-  to a `multipart/form-data` serialization
+  to a `multipart/form-data` serialization.
 - [Performance](https://developer.mozilla.org/en-US/docs/Web/API/Performance):
-  retrieving current time with a high precision
+  retrieving current time with a high precision.
 - [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout),
   [setInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval),
   [clearTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout):
   scheduling callbacks in future and
-  [clearInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval)
+  [clearInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval).
 - [Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) for
-  creating, composing, and consuming streams of data
+  creating, composing, and consuming streams of data.
 - [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) and
   [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams):
-  to construct and parse URLSs
+  to construct and parse URLSs.
 - [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker): executing
-  additional code in a separate thread
+  additional code in a separate thread.
   - **Implementation notes:** Blob URLs are not supported, object ownership
     cannot be transferred, posted data is serialized to JSON instead of
     [structured cloning](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).

--- a/cli/tests/unit/README.md
+++ b/cli/tests/unit/README.md
@@ -26,13 +26,13 @@ unitTest({
 `unitTest` is is a wrapper function that enhances `Deno.test()` API in several
 ways:
 
-- ability to conditionally skip tests using `UnitTestOptions.skip`
+- ability to conditionally skip tests using `UnitTestOptions.skip`.
 - ability to register required set of permissions for given test case using
-  `UnitTestOptions.perms`
+  `UnitTestOptions.perms`.
 - sanitization of resources - ensuring that tests close all opened resources
-  preventing interference between tests
+  preventing interference between tests.
 - sanitization of async ops - ensuring that tests don't leak async ops by
-  ensuring that all started async ops are done before test finishes
+  ensuring that all started async ops are done before test finishes.
 
 ## Running tests
 
@@ -50,13 +50,13 @@ There are three ways to run `unit_test_runner.ts`:
 target/debug/deno run -A cli/tests/unit/unit_test_runner.ts --master
 
 # By default all output of worker processes is discarded; for debug purposes
-# the --verbose flag preserves output from the worker
+# the --verbose flag preserves output from the worker.
 target/debug/deno run -A cli/tests/unit/unit_test_runner.ts --master --verbose
 
-# Run subset of tests that don't require any permissions
+# Run subset of tests that don't require any permissions.
 target/debug/deno run --unstable cli/tests/unit/unit_test_runner.ts
 
-# Run subset tests that require "net" and "read" permissions
+# Run subset tests that require "net" and "read" permissions.
 target/debug/deno run --unstable --allow-net --allow-read cli/tests/unit/unit_test_runner.ts
 
 # "worker" mode communicates with parent using TCP socket on provided address;
@@ -64,7 +64,7 @@ target/debug/deno run --unstable --allow-net --allow-read cli/tests/unit/unit_te
 # directly, only be "master" process.
 target/debug/deno run -A cli/tests/unit/unit_test_runner.ts --worker --addr=127.0.0.1:4500 --perms=net,write,run
 
-# Run specific tests
+# Run specific tests.
 target/debug/deno run --unstable --allow-net cli/tests/unit/unit_test_runner.ts -- netTcpListenClose
 
 RUST_BACKTRACE=1 cargo run -- run --unstable --allow-read --allow-write cli/tests/unit/unit_test_runner.ts -- netUnixDialListen

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,7 +25,7 @@ Before submitting, please make sure the following is done:
 1. That there is a related issue and it is referenced in the PR text.
 2. There are tests that cover the changes.
 3. Ensure `cargo test` passes.
-4. Format your code with `./tools/format.py`
+4. Format your code with `./tools/format.py`.
 5. Make sure `./tools/lint.py` passes.
 
 ## Changes to `third_party`
@@ -69,4 +69,4 @@ and are denoted by a leading `/**` before terminating with a `*/`. For example:
 export const FOO = "foo";
 ```
 
-Find more at https://jsdoc.app/
+Find more at: https://jsdoc.app/

--- a/op_crates/web/README.md
+++ b/op_crates/web/README.md
@@ -1,3 +1,3 @@
 # deno web
 
-Op crate that implements Event, TextEncoder, TextDecoder
+Op crate that implements Event, TextEncoder, TextDecoder.

--- a/std/archive/README.md
+++ b/std/archive/README.md
@@ -12,12 +12,12 @@ await tar.append("deno.txt", {
   contentSize: content.byteLength,
 });
 
-// Or specifying a filePath
+// Or specifying a filePath.
 await tar.append("land.txt", {
   filePath: "./land.txt",
 });
 
-// use tar.getReader() to read the contents
+// use tar.getReader() to read the contents.
 
 const writer = await Deno.open("./out.tar", { write: true, create: true });
 await Deno.copy(tar.getReader(), writer);
@@ -53,7 +53,7 @@ for await (const entry of untar) {
 
   await ensureFile(entry.fileName);
   const file = await Deno.open(entry.fileName, { write: true });
-  // <entry> is a reader
+  // <entry> is a reader.
   await Deno.copy(entry, file);
 }
 reader.close();

--- a/std/async/README.md
+++ b/std/async/README.md
@@ -4,11 +4,11 @@ async is a module to provide help with aysncronous tasks.
 
 # usage
 
-The following functions and class are exposed in `mod.ts`
+The following functions and class are exposed in `mod.ts`:
 
 ## deferred
 
-Creates a Promise with the `reject` and `resolve` functions.
+Create a Promise with the `reject` and `resolve` functions.
 
 ```typescript
 import { deferred } from "https://deno.land/std/async/mod.ts";
@@ -20,7 +20,7 @@ p.resolve(42);
 
 ## delay
 
-Resolve a Promise after a given amount of milliseconds
+Resolve a Promise after a given amount of milliseconds.
 
 ```typescript
 import { delay } from "https://deno.land/std/async/mod.ts";

--- a/std/bytes/README.md
+++ b/std/bytes/README.md
@@ -4,7 +4,7 @@ bytes module is made to provide helpers to manipulation of bytes slice.
 
 # usage
 
-All the following functions are exposed in `mod.ts`
+All the following functions are exposed in `mod.ts`.
 
 ## findIndex
 

--- a/std/datetime/README.md
+++ b/std/datetime/README.md
@@ -8,29 +8,29 @@ The following symbols from
 [unicode LDML](http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table)
 are supported:
 
-- `yyyy` - numeric year
-- `yy` - 2-digit year
-- `M` - numeric month
-- `MM` - 2-digit month
-- `d` - numeric day
-- `dd` - 2-digit day
+- `yyyy` - numeric year.
+- `yy` - 2-digit year.
+- `M` - numeric month.
+- `MM` - 2-digit month.
+- `d` - numeric day.
+- `dd` - 2-digit day.
 
-- `H` - numeric hour (0-23 hours)
-- `HH` - 2-digit hour (00-23 hours)
-- `h` - numeric hour (1-12 hours)
-- `hh` - 2-digit hour (01-12 hours)
-- `m` - numeric minute
-- `mm` - 2-digit minute
-- `s` - numeric second
-- `ss` - 2-digit second
-- `S` - 1-digit fractionalSecond
-- `SS` - 2-digit fractionalSecond
-- `SSS` - 3-digit fractionalSecond
+- `H` - numeric hour (0-23 hours).
+- `HH` - 2-digit hour (00-23 hours).
+- `h` - numeric hour (1-12 hours).
+- `hh` - 2-digit hour (01-12 hours).
+- `m` - numeric minute.
+- `mm` - 2-digit minute.
+- `s` - numeric second.
+- `ss` - 2-digit second.
+- `S` - 1-digit fractionalSecond.
+- `SS` - 2-digit fractionalSecond.
+- `SSS` - 3-digit fractionalSecond.
 
-- `a` - dayPeriod, either `AM` or `PM`
+- `a` - dayPeriod, either `AM` or `PM`.
 
-- `'foo'` - quoted literal
-- `./-` - unquoted literal
+- `'foo'` - quoted literal.
+- `./-` - unquoted literal.
 
 ### parse
 
@@ -78,7 +78,7 @@ dayOfYear(new Date("2019-03-11T03:24:00")); // output: 70
 
 ### weekOfYear
 
-Returns the ISO week number of the provided date (1-53)
+Returns the ISO week number of the provided date (1-53).
 
 ```ts
 import { weekOfYear } from "https://deno.land/std/datetime/mod.ts";

--- a/std/encoding/README.md
+++ b/std/encoding/README.md
@@ -70,12 +70,12 @@ function is as follows:
 
 ##### `ReadOptions`
 
-- **`comma?: string;`**: Character which separates values. Default: `','`
-- **`comment?: string;`**: Character to start a comment. Default: `'#'`
+- **`comma?: string;`**: Character which separates values. Default: `','`.
+- **`comment?: string;`**: Character to start a comment. Default: `'#'`.
 - **`trimLeadingSpace?: boolean;`**: Flag to trim the leading space of the
-  value. Default: `false`
+  value. Default: `false`.
 - **`lazyQuotes?: boolean;`**: Allow unquoted quote in a quoted field or non
-  double quoted quotes in quoted field. Default: 'false`
+  double quoted quotes in quoted field. Default: `false`.
 - **`fieldsPerRecord?`**: Enabling the check of fields for each row. If == 0,
   first row is used as referral for the number of fields.
 
@@ -226,9 +226,9 @@ console.log(tomlObject);
 
 ## YAML
 
-YAML parser / dumper for Deno
+YAML parser / dumper for Deno.
 
-Heavily inspired from [js-yaml]
+Heavily inspired from [js-yaml].
 
 ### Basic usage
 
@@ -294,17 +294,17 @@ Serializes `object` as a YAML document.
 
 ### :warning: Limitations
 
-- `binary` type is currently not stable
-- `function`, `regexp`, and `undefined` type are currently not supported
+- `binary` type is currently not stable.
+- `function`, `regexp`, and `undefined` type are currently not supported.
 
 ### More example
 
-See https://github.com/nodeca/js-yaml.
+See: https://github.com/nodeca/js-yaml
 
 ## base32
 
 [RFC4648 base32](https://tools.ietf.org/html/rfc4648#section-6) encoder/decoder
-for Deno
+for Deno.
 
 ### Basic usage
 
@@ -326,7 +326,7 @@ console.log(encode(binaryData));
 
 ## ascii85
 
-Ascii85/base85 encoder and decoder with support for multiple standards
+Ascii85/base85 encoder and decoder with support for multiple standards.
 
 ### Basic usage
 

--- a/std/flags/README.md
+++ b/std/flags/README.md
@@ -1,6 +1,6 @@
 # flags
 
-Command line arguments parser for Deno based on minimist
+Command line arguments parser for Deno based on minimist.
 
 # Example
 
@@ -42,15 +42,15 @@ Any arguments after `'--'` will not be parsed and will end up in `parsedArgs._`.
 options can be:
 
 - `options.string` - a string or array of strings argument names to always treat
-  as strings
+  as strings.
 - `options.boolean` - a boolean, string or array of strings to always treat as
   booleans. if `true` will treat all double hyphenated arguments without equal
-  signs as boolean (e.g. affects `--foo`, not `-f` or `--foo=bar`)
+  signs as boolean (e.g. affects `--foo`, not `-f` or `--foo=bar`).
 - `options.alias` - an object mapping string names to strings or arrays of
-  string argument names to use as aliases
-- `options.default` - an object mapping string argument names to default values
+  string argument names to use as aliases.
+- `options.default` - an object mapping string argument names to default values.
 - `options.stopEarly` - when true, populate `parsedArgs._` with everything after
-  the first non-option
+  the first non-option.
 - `options['--']` - when true, populate `parsedArgs._` with everything before
   the `--` and `parsedArgs['--']` with everything after the `--`. Here's an
   example:

--- a/std/fmt/README.md
+++ b/std/fmt/README.md
@@ -42,14 +42,14 @@ This is very much a work-in-progress. I'm actively soliciting feedback.
 
 - currently contains little in the way of checking for correctness. Conceivably,
   there will be a 'strict' form, e.g. that ensures only Number-ish arguments are
-  passed to %f flags
+  passed to %f flags.
 
 - assembles output using string concatenation instead of utilizing buffers or
   other optimizations. It would be nice to have printf / sprintf / fprintf (etc)
   all in one.
 
 - float formatting is handled by toString() and to `toExponential` along with a
-  mess of Regexp. Would be nice to use fancy match
+  mess of Regexp. Would be nice to use fancy match.
 
 - some flags that are potentially applicable ( POSIX long and unsigned modifiers
   are not likely useful) are missing, namely %q (print quoted), %U (unicode
@@ -70,7 +70,7 @@ list. E.g.:
 
     Hello %s!
 
-applied to the arguments "World" yields "Hello World!"
+applied to the arguments "World" yields "Hello World!".
 
 The meaning of the format string is modelled after [POSIX][1] format strings as
 well as well as [Golang format strings][2]. Both contain elements specific to
@@ -128,7 +128,7 @@ which case the values are obtained from the next args, e.g.:
 
     sprintf("%*.*f", 9, 8, 456.0)
 
-is equivalent to
+is equivalent to:
 
     sprintf("%9.8f", 456.0)
 
@@ -156,7 +156,7 @@ directive:
 The default format used by `%v` is the result of calling `toString()` on the
 relevant argument. If the `#` flags is used, the result of calling `inspect()`
 is interpolated. In this case, the precision, if set is passed to `inspect()` as
-the 'depth' config parameter
+the 'depth' config parameter.
 
 ## Positional arguments
 

--- a/std/fs/README.md
+++ b/std/fs/README.md
@@ -5,7 +5,7 @@ fs module is made to provide helpers to manipulate the filesystem.
 ## Usage
 
 Most the following modules are exposed in `mod.ts` This feature is currently
-<b>unstable</b>. To enable it use `deno run --unstable`
+<b>unstable</b>. To enable it use `deno run --unstable`.
 
 ### emptyDir
 
@@ -23,7 +23,7 @@ emptyDirSync("./foo"); // void
 ### ensureDir
 
 Ensures that the directory exists. If the directory structure does not exist, it
-is created. Like mkdir -p.
+is created. Like `mkdir -p`.
 
 ```ts
 import { ensureDir, ensureDirSync } from "https://deno.land/std/fs/mod.ts";
@@ -83,7 +83,7 @@ format(CRLFinput, EOL.LF); // output "deno\nis not\nnode"
 
 ### exists
 
-Test whether or not the given path exists by checking with the file system
+Test whether or not the given path exists by checking with the file system.
 
 ```ts
 import { exists, existsSync } from "https://deno.land/std/fs/mod.ts";
@@ -94,7 +94,7 @@ existsSync("./foo"); // returns boolean
 
 ### move
 
-Moves a file or directory. Overwrites it if option provided
+Moves a file or directory. Overwrites it if option provided.
 
 ```ts
 import { move, moveSync } from "https://deno.land/std/fs/mod.ts";
@@ -107,7 +107,7 @@ moveSync("./foo", "./existingFolder", { overwrite: true });
 
 ### copy
 
-copy a file or directory. Overwrites it if option provided
+copy a file or directory. Overwrites it if option provided.
 
 ```ts
 import { copy, copySync } from "https://deno.land/std/fs/mod.ts";

--- a/std/hash/README.md
+++ b/std/hash/README.md
@@ -23,7 +23,7 @@ import { createHash } from "https://deno.land/std/hash/mod.ts";
 
 const hash = createHash("md5");
 hash.update("Your data here");
-const final = hash.digest(); // returns ArrayBuffer
+const final = hash.digest(); // returns ArrayBuffer.
 ```
 
 Please note that `digest` invalidates the hash instance's internal state.
@@ -34,8 +34,8 @@ import { createHash } from "https://deno.land/std/hash/mod.ts";
 
 const hash = createHash("md5");
 hash.update("Your data here");
-const final1 = hash.digest(); // returns ArrayBuffer
-const final2 = hash.digest(); // throws Error
+const final1 = hash.digest(); // returns ArrayBuffer.
+const final2 = hash.digest(); // throws Error.
 ```
 
 If you need final hash in string formats, call `toString` method with output

--- a/std/http/README.md
+++ b/std/http/README.md
@@ -11,7 +11,7 @@ for await (const req of server) {
 
 ### File Server
 
-A small program for serving local files over HTTP
+A small program for serving local files over HTTP.
 
 ```sh
 deno run --allow-net --allow-read https://deno.land/std/http/file_server.ts
@@ -35,7 +35,7 @@ console.log("cookies:", cookies);
 // cookies: { full: "of", tasty: "chocolate" }
 ```
 
-To set a `Cookie` you can add `CookieOptions` to properly set your `Cookie`
+To set a `Cookie` you can add `CookieOptions` to properly set your `Cookie`:
 
 ```ts
 import { Response } from "https://deno.land/std/http/server.ts";

--- a/std/io/README.md
+++ b/std/io/README.md
@@ -6,7 +6,7 @@
 
 ### readLines
 
-Read reader[like file], line by line
+Read reader[like file], line by line:
 
 ```ts title="readLines"
 import { readLines } from "https://deno.land/std/io/mod.ts";
@@ -128,7 +128,7 @@ base0123456789
 
 ### fromStreamReader
 
-Creates a `Reader` from a `ReadableStreamDefaultReader`
+Creates a `Reader` from a `ReadableStreamDefaultReader`.
 
 ```ts
 import { fromStreamReader } from "https://deno.land/std/io/mod.ts";
@@ -142,7 +142,7 @@ file.close();
 
 ### fromStreamWriter
 
-Creates a `Writer` from a `WritableStreamDefaultWriter`
+Creates a `Writer` from a `WritableStreamDefaultWriter`.
 
 ```ts
 import { fromStreamWriter } from "https://deno.land/std/io/mod.ts";

--- a/std/log/README.md
+++ b/std/log/README.md
@@ -14,20 +14,20 @@ log.warning(true);
 log.error({ foo: "bar", fizz: "bazz" });
 log.critical("500 Internal server error");
 
-// custom configuration with 2 loggers (the default and `tasks` loggers)
+// custom configuration with 2 loggers (the default and `tasks` loggers).
 await log.setup({
   handlers: {
     console: new log.handlers.ConsoleHandler("DEBUG"),
 
     file: new log.handlers.FileHandler("WARNING", {
       filename: "./log.txt",
-      // you can change format of output message using any keys in `LogRecord`
+      // you can change format of output message using any keys in `LogRecord`.
       formatter: "{levelName} {msg}",
     }),
   },
 
   loggers: {
-    // configure default logger available via short-hand methods above
+    // configure default logger available via short-hand methods above.
     default: {
       level: "DEBUG",
       handlers: ["console", "file"],
@@ -42,19 +42,19 @@ await log.setup({
 
 let logger;
 
-// get default logger
+// get default logger.
 logger = log.getLogger();
-logger.debug("fizz"); // logs to `console`, because `file` handler requires "WARNING" level
-logger.warning(41256); // logs to both `console` and `file` handlers
+logger.debug("fizz"); // logs to `console`, because `file` handler requires "WARNING" level.
+logger.warning(41256); // logs to both `console` and `file` handlers.
 
 // get custom logger
 logger = log.getLogger("tasks");
-logger.debug("fizz"); // won't get output because this logger has "ERROR" level
-logger.error({ productType: "book", value: "126.11" }); // log to `console`
+logger.debug("fizz"); // won't get output because this logger has "ERROR" level.
+logger.error({ productType: "book", value: "126.11" }); // log to `console`.
 
 // if you try to use a logger that hasn't been configured
 // you're good to go, it gets created automatically with level set to 0
-// so no message is logged
+// so no message is logged.
 const unknownLogger = log.getLogger("mystery");
 unknownLogger.info("foobar"); // no-op
 ```
@@ -124,11 +124,11 @@ interface FileHandlerOptions {
 Behavior of the log modes is as follows:
 
 - `'a'` - Default mode. Appends new log messages to the end of an existing log
-  file, or create a new log file if none exists
+  file, or create a new log file if none exists.
 - `'w'` - Upon creation of the handler, any existing log file will be removed
   and a new one created.
 - `'x'` - This will create a new log file and throw an error if one already
-  exists
+  exists.
 
 This handler requires `--allow-write` permission on the log file.
 
@@ -177,7 +177,7 @@ Additional notes on `mode` as described above:
   cause any existing backups (up to `maxBackupCount`) to be deleted on setup
   giving a fully clean slate.
 - `'x'` requires that neither `filename`, nor any backups (up to
-  `maxBackupCount`), exist before setup
+  `maxBackupCount`), exist before setup.
 
 This handler requires both `--allow-read` and `--allow-write` permissions on the
 log files.
@@ -227,16 +227,16 @@ await log.setup({
   }
 })
 
-// calling
+// calling:
 log.debug("Hello, world!", 1, "two", [3, 4, 5]);
 // results in:
-[DEBUG] Hello, world! // output from "stringFmt" handler
-10 Hello, world!, arg0: 1, arg1: two, arg3: [3, 4, 5] // output from "functionFmt" formatter
+[DEBUG] Hello, world! // output from "stringFmt" handler.
+10 Hello, world!, arg0: 1, arg1: two, arg3: [3, 4, 5] // output from "functionFmt" formatter.
 
-// calling
+// calling:
 log.getLogger("dataLogger").error("oh no!");
 // results in:
-[dataLogger] - ERROR oh no! // output from anotherFmt handler
+[dataLogger] - ERROR oh no! // output from anotherFmt handler.
 ```
 
 #### Custom handlers
@@ -278,7 +278,7 @@ log evaluation to prevent the computation taking place if the logger won't log
 the message.
 
 ```ts
-// `expensiveFn(5)` is only evaluated if this logger is configured for debug logging
+// `expensiveFn(5)` is only evaluated if this logger is configured for debug logging.
 logger.debug(() => `this is expensive: ${expensiveFn(5)}`);
 ```
 
@@ -303,7 +303,7 @@ await log.setup({
   },
 });
 
-// not logged, as debug < error
+// not logged, as debug < error.
 const data: string | undefined = logger.debug(() => someExpenseFn(5, true));
 console.log(data); // undefined
 ```

--- a/std/path/README.md
+++ b/std/path/README.md
@@ -18,5 +18,5 @@ globToRegExp("foo/**/*.json", {
   flags: "g",
   extended: true,
   globstar: true,
-}); // returns the regex to find all .json files in the folder foo
+}); // returns the regex to find all .json files in the folder foo.
 ```

--- a/std/signal/README.md
+++ b/std/signal/README.md
@@ -1,10 +1,10 @@
 # signal
 
-signal is a module used to capture and monitor OS signals
+signal is a module used to capture and monitor OS signals.
 
 # usage
 
-The following functions are exposed in `mod.ts`
+The following functions are exposed in `mod.ts`:
 
 ## signal
 
@@ -14,7 +14,7 @@ Generates an AsyncIterable which can be awaited on for one or more signals.
 ```typescript
 import { signal } from "https://deno.land/std/signal/mod.ts";
 const sig = signal(Deno.Signal.SIGUSR1, Deno.Signal.SIGINT);
-setTimeout(() => {}, 5000); // Prevents exiting immediately
+setTimeout(() => {}, 5000); // Prevents exiting immediately.
 
 for await (const _ of sig) {
   // ..
@@ -33,6 +33,6 @@ import { onSignal } from "https://deno.land/std/signal/mod.ts";
 
 const handle = onSignal(Deno.Signal.SIGINT, () => {
   // ...
-  handle.dispose(); // de-register from receiving further events
+  handle.dispose(); // de-register from receiving further events.
 });
 ```

--- a/std/testing/README.md
+++ b/std/testing/README.md
@@ -34,8 +34,8 @@ pretty-printed diff of failing assertion.
   function will throw asynchronously. Also compares any errors thrown to an
   optional expected `Error` class and checks that the error `.message` includes
   an optional string.
-- `unimplemented()` - Use this to stub out methods that will throw when invoked
-- `unreachable()` - Used to assert unreachable code
+- `unimplemented()` - Use this to stub out methods that will throw when invoked.
+- `unreachable()` - Used to assert unreachable code.
 
 Basic usage:
 
@@ -96,7 +96,7 @@ Deno.test("doesThrow", function (): void {
   );
 });
 
-// This test will not pass
+// This test will not pass.
 Deno.test("fails", function (): void {
   assertThrows((): void => {
     console.log("Hello world");
@@ -130,7 +130,7 @@ Deno.test("doesThrow", async function (): Promise<void> {
   );
 });
 
-// This test will not pass
+// This test will not pass.
 Deno.test("fails", async function (): Promise<void> {
   await assertThrowsAsync(
     async (): Promise<void> => {
@@ -199,7 +199,7 @@ runBenchmarks()
     console.log(results);
   })
   .catch((error: Error) => {
-    // ... errors if benchmark was badly constructed
+    // ... errors if benchmark was badly constructed.
   });
 ```
 
@@ -213,7 +213,7 @@ commandline.
 
 ```ts
 runBenchmarks({ silent: true }, (p: BenchmarkRunProgress) => {
-  // initial progress data
+  // initial progress data.
   if (p.state === ProgressState.BenchmarkingStart) {
     console.log(
       `Starting benchmarking. Queued: ${p.queued.length}, filtered: ${p.filtered}`,

--- a/std/uuid/README.md
+++ b/std/uuid/README.md
@@ -7,9 +7,9 @@ Support for version 1, 4, and 5 UUIDs.
 ```ts
 import { v4 } from "https://deno.land/std/uuid/mod.ts";
 
-// Generate a v4 uuid
+// Generate a v4 uuid.
 const myUUID = v4.generate();
 
-// Validate a v4 uuid
+// Validate a v4 uuid.
 const isValid = v4.validate(myUUID);
 ```

--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -1,6 +1,6 @@
 # wasi
 
-This module provides an implementation of the WebAssembly System Interface
+This module provides an implementation of the WebAssembly System Interface.
 
 ## Supported Syscalls
 

--- a/std/ws/README.md
+++ b/std/ws/README.md
@@ -21,18 +21,18 @@ async function handleWs(sock: WebSocket) {
   try {
     for await (const ev of sock) {
       if (typeof ev === "string") {
-        // text message
+        // text message.
         console.log("ws:Text", ev);
         await sock.send(ev);
       } else if (ev instanceof Uint8Array) {
-        // binary message
+        // binary message.
         console.log("ws:Binary", ev);
       } else if (isWebSocketPingEvent(ev)) {
         const [, body] = ev;
-        // ping
+        // ping.
         console.log("ws:Ping", body);
       } else if (isWebSocketCloseEvent(ev)) {
-        // close
+        // close.
         const { code, reason } = ev;
         console.log("ws:Close", code, reason);
       }
@@ -99,7 +99,7 @@ Create mask from the client to the server with random 32bit number.
 
 ### acceptable
 
-Returns true if input headers are usable for WebSocket, otherwise false
+Returns true if input headers are usable for WebSocket, otherwise false.
 
 ### createSecAccept
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,6 @@
 # Tools
 
-Documentation for various tooling in support of Deno development
+Documentation for various tooling in support of Deno development.
 
 ## format.py
 


### PR DESCRIPTION
Refs:
* In examples: https://github.com/denoland/deno/pull/7722
* In docs: https://github.com/denoland/deno/pull/7730

This PR adds period at the end of sentences in all other markdown files.
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
