### PR TITLE
docs: update location of unit tests folder

### DIFF
--- a/docs/contributing/development_tools.md
+++ b/docs/contributing/development_tools.md
@@ -8,7 +8,7 @@ Test `deno`:
 # Run the whole suite:
 cargo test
 
-# Only test cli/js/:
+# Only test cli/tests/unit/:
 cargo test js_unit_tests
 ```
 


### PR DESCRIPTION
The unit tests now lie in `cli/tests/unit` and not `cli/js`

Refs: https://github.com/denoland/deno/tree/master/cli/tests/unit

https://github.com/denoland/deno/blob/5cd29b37f7946ac05783bae777be8503182a8b8e/cli/tests/integration_tests.rs#L685-L693
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
