### PR TITLE
fix(core): handle unregistered errors in core better

### DIFF
--- a/cli/rt/10_dispatch_minimal.js
+++ b/cli/rt/10_dispatch_minimal.js
@@ -53,7 +53,7 @@
       const ErrorClass = core.getErrorClass(res.err.className);
       if (!ErrorClass) {
         throw new Error(
-          `Unregistered Deno core error class: ${res.err.className}\n  ${res.err.message}`,
+          `Unregistered error class: "${res.err.className}"\n  ${res.err.message}\n  Classes of errors returned from ops should be registered via Deno.core.registerErrorClass().`,
         );
       }
       throw new ErrorClass(res.err.message);

--- a/cli/rt/10_dispatch_minimal.js
+++ b/cli/rt/10_dispatch_minimal.js
@@ -50,7 +50,13 @@
 
   function unwrapResponse(res) {
     if (res.err != null) {
-      throw new (core.getErrorClass(res.err.className))(res.err.message);
+      const ErrorClass = core.getErrorClass(res.err.className);
+      if (!ErrorClass) {
+        throw new Error(
+          `Unregistered Deno core error class: ${res.err.className}\n  ${res.err.message}`,
+        );
+      }
+      throw new ErrorClass(res.err.message);
     }
     return res.result;
   }

--- a/core/core.js
+++ b/core/core.js
@@ -213,6 +213,20 @@ SharedQueue Binary Layout
   let nextPromiseId = 1;
   const promiseTable = {};
 
+  function processResponse(res) {
+    if ("ok" in res) {
+      return res.ok;
+    } else {
+      const ErrorClass = getErrorClass(res.err.className);
+      if (!ErrorClass) {
+        throw new Error(
+          `Unregistered error class: "${res.err.className}"\n  ${res.err.message}\n  Classes of errors returned from ops should be registered via Deno.core.registerErrorClass().`,
+        );
+      }
+      throw new ErrorClass(res.err.message);
+    }
+  }
+
   async function jsonOpAsync(opName, args = {}, ...zeroCopy) {
     setAsyncHandler(opsCache[opName], jsonOpAsyncHandler);
 
@@ -227,35 +241,13 @@ SharedQueue Binary Layout
     promise.resolve = resolve;
     promise.reject = reject;
     promiseTable[args.promiseId] = promise;
-    const res = await promise;
-    if ("ok" in res) {
-      return res.ok;
-    } else {
-      const ErrorClass = getErrorClass(res.err.className);
-      if (!ErrorClass) {
-        throw new Error(
-          `Unregistered Deno core error class: ${res.err.className}\n  ${res.err.message}`,
-        );
-      }
-      throw new ErrorClass(res.err.message);
-    }
+    return processResponse(await promise);
   }
 
   function jsonOpSync(opName, args = {}, ...zeroCopy) {
     const argsBuf = encodeJson(args);
     const res = dispatch(opName, argsBuf, ...zeroCopy);
-    const r = decodeJson(res);
-    if ("ok" in r) {
-      return r.ok;
-    } else {
-      const ErrorClass = getErrorClass(res.err.className);
-      if (!ErrorClass) {
-        throw new Error(
-          `Unregistered Deno core error class: ${res.err.className}\n  ${res.err.message}`,
-        );
-      }
-      throw new ErrorClass(res.err.message);
-    }
+    return processResponse(decodeJson(res));
   }
 
   function jsonOpAsyncHandler(buf) {

--- a/core/core.js
+++ b/core/core.js
@@ -196,9 +196,7 @@ SharedQueue Binary Layout
   }
 
   function getErrorClass(errorName) {
-    const className = errorMap[errorName];
-    assert(className);
-    return className;
+    return errorMap[errorName];
   }
 
   // Returns Uint8Array
@@ -233,7 +231,13 @@ SharedQueue Binary Layout
     if ("ok" in res) {
       return res.ok;
     } else {
-      throw new (getErrorClass(res.err.className))(res.err.message);
+      const ErrorClass = getErrorClass(res.err.className);
+      if (!ErrorClass) {
+        throw new Error(
+          `Unregistered Deno core error class: ${res.err.className}\n  ${res.err.message}`,
+        );
+      }
+      throw new ErrorClass(res.err.message);
     }
   }
 
@@ -244,7 +248,13 @@ SharedQueue Binary Layout
     if ("ok" in r) {
       return r.ok;
     } else {
-      throw new (getErrorClass(r.err.className))(r.err.message);
+      const ErrorClass = getErrorClass(res.err.className);
+      if (!ErrorClass) {
+        throw new Error(
+          `Unregistered Deno core error class: ${res.err.className}\n  ${res.err.message}`,
+        );
+      }
+      throw new ErrorClass(res.err.message);
     }
   }
 


### PR DESCRIPTION
If for some reason a `res.err.className` is not registered, we are throwing a totally non-sensical assertion error, even though we had valid information about the error which we could provide, since there errors get raised when reading the results of an Op, it is much better to err on the side of the user and go ahead and raise an error, indicating that the error class was not registered and provide the error message returned from the Rust op.