### PR TITLE
[WIP] new bundler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +320,15 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
+]
 
 [[package]]
 name = "crc32fast"
@@ -430,6 +445,7 @@ dependencies = [
  "semver-parser 0.9.0",
  "serde",
  "sourcemap",
+ "swc_bundler",
  "swc_common",
  "swc_ecmascript",
  "sys-info",
@@ -468,8 +484,6 @@ dependencies = [
 [[package]]
 name = "deno_doc"
 version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc8ec78c69a1c3c4310c62fed6b8eb28e84915ad8dabe74adc41ad4dd805829"
 dependencies = [
  "futures",
  "lazy_static",
@@ -494,8 +508,6 @@ dependencies = [
 [[package]]
 name = "deno_lint"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a1f1ce708693fa6955a279ceee3a348a17c9942e8719f1e3e1086a5776ad84"
 dependencies = [
  "lazy_static",
  "log",
@@ -576,8 +588,6 @@ dependencies = [
 [[package]]
 name = "dprint-plugin-typescript"
 version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019571bd3c744547768ce0e90afd388cd834551399aacc0bea9a354e645fa5ba"
 dependencies = [
  "dprint-core",
  "serde",
@@ -659,6 +669,12 @@ dependencies = [
  "redox_syscall",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
@@ -1475,6 +1491,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1662,12 @@ checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2 1.0.21",
 ]
+
+[[package]]
+name = "radix_fmt"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce082a9940a7ace2ad4a8b7d0b1eac6aa378895f18be598230c5f2284ac05426"
 
 [[package]]
 name = "rand"
@@ -1826,6 +1858,12 @@ name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+
+[[package]]
+name = "relative-path"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65aff7c83039e88c1c0b4bedf8dfa93d6ec84d5fc2945b37c1fa4186f46c5f94"
 
 [[package]]
 name = "remove_dir_all"
@@ -2225,6 +2263,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_bundler"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec070c46884aa3a64ab4c9bdb722e15e98178ded3e056f35952a30c5e5e6298"
+dependencies = [
+ "anyhow",
+ "crc",
+ "is-macro",
+ "log",
+ "once_cell",
+ "petgraph",
+ "radix_fmt",
+ "relative-path",
+ "retain_mut",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+]
+
+[[package]]
 name = "swc_common"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38a7010276884ac0b22603e61c217d44a1c3485b56e31225360da36218c5622"
+checksum = "bfc801558c8c8276a15e079afdfb938b78602c5cbb2a9d9439d5d9001e194ea6"
 dependencies = [
  "Inflector",
  "arrayvec",
@@ -2411,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92c80da630ab670496c5daa726292aa6b0b01058681433b9331c0cef3e90a42"
+checksum = "e17ad3ce5f916fd5d03cb70623f88e657ee2abc1f82c6670feff2777f0f33f93"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,8 @@ dependencies = [
 [[package]]
 name = "deno_doc"
 version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc8ec78c69a1c3c4310c62fed6b8eb28e84915ad8dabe74adc41ad4dd805829"
 dependencies = [
  "futures",
  "lazy_static",
@@ -508,6 +510,8 @@ dependencies = [
 [[package]]
 name = "deno_lint"
 version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a1f1ce708693fa6955a279ceee3a348a17c9942e8719f1e3e1086a5776ad84"
 dependencies = [
  "lazy_static",
  "log",
@@ -588,6 +592,8 @@ dependencies = [
 [[package]]
 name = "dprint-plugin-typescript"
 version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "019571bd3c744547768ce0e90afd388cd834551399aacc0bea9a354e645fa5ba"
 dependencies = [
  "dprint-core",
  "serde",
@@ -2474,9 +2480,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17ad3ce5f916fd5d03cb70623f88e657ee2abc1f82c6670feff2777f0f33f93"
+checksum = "d92c80da630ab670496c5daa726292aa6b0b01058681433b9331c0cef3e90a42"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,8 +30,8 @@ winapi = "0.3.9"
 
 [dependencies]
 deno_core = { path = "../core", version = "0.61.0" }
-deno_doc = { path = "../../deno_doc", version = "0.1.10" }
-deno_lint = { path = "../../deno_lint", version = "0.2.2", features = ["json"] }
+deno_doc = "0.1.10"
+deno_lint = { version = "0.2.2", features = ["json"] }
 deno_web = { path = "../op_crates/web", version = "0.13.0" }
 deno_fetch = { path = "../op_crates/fetch", version = "0.5.0" }
 
@@ -43,7 +43,7 @@ clap = "2.33.3"
 dissimilar = "1.0.2"
 dlopen = "0.1.8"
 encoding_rs = "0.8.24"
-dprint-plugin-typescript = { path = "../../dprint-plugin-typescript", version = "0.32.2" }
+dprint-plugin-typescript = "0.32.2"
 filetime = "0.2.12"
 http = "0.2.1"
 indexmap = "1.6.0"
@@ -63,7 +63,7 @@ sys-info = "0.7.0"
 sourcemap = "6.0.1"
 swc_bundler = "0.9.1"
 swc_common = { version = "=0.10.3", features = ["sourcemap"] }
-swc_ecmascript = { version = "=0.8.4", features = ["codegen", "dep_graph", "parser", "react", "transforms", "visit"] }
+swc_ecmascript = { version = "=0.8.3", features = ["codegen", "dep_graph", "parser", "react", "transforms", "visit"] }
 tempfile = "3.1.0"
 termcolor = "1.1.0"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,8 +30,8 @@ winapi = "0.3.9"
 
 [dependencies]
 deno_core = { path = "../core", version = "0.61.0" }
-deno_doc = "0.1.10"
-deno_lint = { version = "0.2.2", features = ["json"] }
+deno_doc = { path = "../../deno_doc", version = "0.1.10" }
+deno_lint = { path = "../../deno_lint", version = "0.2.2", features = ["json"] }
 deno_web = { path = "../op_crates/web", version = "0.13.0" }
 deno_fetch = { path = "../op_crates/fetch", version = "0.5.0" }
 
@@ -43,7 +43,7 @@ clap = "2.33.3"
 dissimilar = "1.0.2"
 dlopen = "0.1.8"
 encoding_rs = "0.8.24"
-dprint-plugin-typescript = "0.32.2"
+dprint-plugin-typescript = { path = "../../dprint-plugin-typescript", version = "0.32.2" }
 filetime = "0.2.12"
 http = "0.2.1"
 indexmap = "1.6.0"
@@ -61,8 +61,9 @@ rustyline-derive = "0.3.1"
 serde = { version = "1.0.116", features = ["derive"] }
 sys-info = "0.7.0"
 sourcemap = "6.0.1"
+swc_bundler = "0.9.1"
 swc_common = { version = "=0.10.3", features = ["sourcemap"] }
-swc_ecmascript = { version = "=0.8.3", features = ["codegen", "dep_graph", "parser", "react", "transforms", "visit"] }
+swc_ecmascript = { version = "=0.8.4", features = ["codegen", "dep_graph", "parser", "react", "transforms", "visit"] }
 tempfile = "3.1.0"
 termcolor = "1.1.0"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/cli/checksum.rs
+++ b/cli/checksum.rs
@@ -1,9 +1,9 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-pub fn gen(v: &[&[u8]]) -> String {
+pub fn gen(v: &[impl AsRef<[u8]>]) -> String {
   let mut ctx = ring::digest::Context::new(&ring::digest::SHA256);
   for src in v {
-    ctx.update(src);
+    ctx.update(src.as_ref());
   }
   let digest = ctx.finish();
   let out: Vec<String> = digest

--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -127,7 +127,7 @@ fn format_message(msg: &str, code: &u64) -> String {
   }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DiagnosticCategory {
   Warning,
   Error,
@@ -172,7 +172,7 @@ impl From<i64> for DiagnosticCategory {
   }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticMessageChain {
   message_text: String,
@@ -199,26 +199,26 @@ impl DiagnosticMessageChain {
   }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Position {
   pub line: u64,
   pub character: u64,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Diagnostic {
-  category: DiagnosticCategory,
-  code: u64,
-  start: Option<Position>,
-  end: Option<Position>,
-  message_text: Option<String>,
-  message_chain: Option<DiagnosticMessageChain>,
-  source: Option<String>,
-  source_line: Option<String>,
-  file_name: Option<String>,
-  related_information: Option<Vec<Diagnostic>>,
+  pub category: DiagnosticCategory,
+  pub code: u64,
+  pub start: Option<Position>,
+  pub end: Option<Position>,
+  pub message_text: Option<String>,
+  pub message_chain: Option<DiagnosticMessageChain>,
+  pub source: Option<String>,
+  pub source_line: Option<String>,
+  pub file_name: Option<String>,
+  pub related_information: Option<Vec<Diagnostic>>,
 }
 
 impl Diagnostic {
@@ -346,7 +346,7 @@ impl fmt::Display for Diagnostic {
   }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Diagnostics(pub Vec<Diagnostic>);
 
 impl<'de> Deserialize<'de> for Diagnostics {

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -407,14 +407,7 @@ fn install_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 }
 
 fn bundle_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
-  // TODO(nayeemrmn): Replace the next couple lines with `compile_args_parse()`
-  // once `deno bundle --no-check` is supported.
-  importmap_arg_parse(flags, matches);
-  no_remote_arg_parse(flags, matches);
-  config_arg_parse(flags, matches);
-  reload_arg_parse(flags, matches);
-  lock_args_parse(flags, matches);
-  ca_file_arg_parse(flags, matches);
+  compile_args_parse(flags, matches);
 
   let source_file = matches.value_of("source_file").unwrap().to_string();
 
@@ -788,6 +781,7 @@ fn bundle_subcommand<'a, 'b>() -> App<'a, 'b> {
     // TODO(nayeemrmn): Replace the next couple lines with `compile_args()` once
     // `deno bundle --no-check` is supported.
     .arg(importmap_arg())
+    .arg(no_check_arg())
     .arg(no_remote_arg())
     .arg(config_arg())
     .arg(reload_arg())
@@ -2350,6 +2344,23 @@ mod tests {
       r.unwrap(),
       Flags {
         reload: true,
+        subcommand: DenoSubcommand::Bundle {
+          source_file: "source.ts".to_string(),
+          out_file: None,
+        },
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn bundle_with_no_check() {
+    let r =
+      flags_from_vec_safe(svec!["deno", "bundle", "--no-check", "source.ts"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        no_check: true,
         subcommand: DenoSubcommand::Bundle {
           source_file: "source.ts".to_string(),
           out_file: None,

--- a/cli/graph.rs
+++ b/cli/graph.rs
@@ -513,7 +513,7 @@ fn check_bundle(
     } else {
       None
     }
-  } else if result.emitted_files.len() == 0 {
+  } else if result.emitted_files.is_empty() {
     None
   } else {
     return Err(UnexpectedEmit.into());

--- a/cli/graph.rs
+++ b/cli/graph.rs
@@ -64,8 +64,8 @@ lazy_static! {
 
 // TODO(@kitsonk) these can be removed when we no longer are using tsc to emit
 // bundles.
-const SYSTEM_LOADER: &'static str = include_str!("system_loader.js");
-const SYSTEM_LOADER_ES5: &'static str = include_str!("system_loader_es5.js");
+const SYSTEM_LOADER: &str = include_str!("system_loader.js");
+const SYSTEM_LOADER_ES5: &str = include_str!("system_loader_es5.js");
 
 /// A group of errors that represent errors that can occur when interacting with
 /// a module graph.
@@ -617,18 +617,16 @@ impl Graph {
           } else {
             format!("\n__instantiate(\"{}\", false);\n", root_specifier_str)
           }
+        } else if top_level_await {
+          format!(
+            "\nvar __exp = await __instantiate(\"{}\", true);\n",
+            root_specifier_str
+          )
         } else {
-          if top_level_await {
-            format!(
-              "\nvar __exp = await __instantiate(\"{}\", true);\n",
-              root_specifier_str
-            )
-          } else {
-            format!(
-              "\nvar __exp = __instantiate(\"{}\", false);\n",
-              root_specifier_str
-            )
-          }
+          format!(
+            "\nvar __exp = __instantiate(\"{}\", false);\n",
+            root_specifier_str
+          )
         };
         for named_export in exports.iter() {
           let export_statement = match named_export.as_str() {

--- a/cli/js.rs
+++ b/cli/js.rs
@@ -57,7 +57,7 @@ fn compiler_snapshot() {
     .execute(
       "<anon>",
       r#"
-    if (!(bootstrapCompilerRuntime)) {
+    if (!(startup)) {
         throw Error("bad");
       }
       console.log(`ts version: ${ts.version}`);

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -66,6 +66,7 @@ use crate::global_state::GlobalState;
 use crate::inspector::InspectorSession;
 use crate::media_type::MediaType;
 use crate::permissions::Permissions;
+use crate::specifier_handler::FetchHandler;
 use crate::worker::MainWorker;
 use deno_core::error::AnyError;
 use deno_core::futures::future::FutureExt;
@@ -82,12 +83,14 @@ use flags::Flags;
 use global_state::exit_unstable;
 use log::Level;
 use log::LevelFilter;
+use std::cell::RefCell;
 use std::env;
 use std::io::Read;
 use std::io::Write;
 use std::iter::once;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::sync::Arc;
 use upgrade::upgrade_command;
 
@@ -290,7 +293,7 @@ async fn bundle_command(
   let module_specifier = ModuleSpecifier::resolve_url_or_path(&source_file)?;
 
   debug!(">>>>> bundle START");
-  let global_state = GlobalState::new(flags)?;
+  let global_state = GlobalState::new(flags.clone())?;
 
   info!(
     "{} {}",
@@ -298,10 +301,35 @@ async fn bundle_command(
     module_specifier.to_string()
   );
 
-  let output = global_state
-    .ts_compiler
-    .bundle(&global_state, module_specifier)
-    .await?;
+  let output = if flags.no_check {
+    let handler = Rc::new(RefCell::new(FetchHandler::new(
+      &global_state,
+      Permissions::allow_all(),
+    )?));
+    let mut builder =
+      graph::GraphBuilder::new(handler, global_state.maybe_import_map.clone());
+    builder.insert(&module_specifier).await?;
+    let graph = builder.get_graph(&global_state.lockfile)?;
+
+    let (s, stats, maybe_ignored_options) =
+      graph.bundle(graph::BundleOptions {
+        check: false,
+        debug: flags.log_level == Some(Level::Debug),
+        maybe_config_path: flags.config_path,
+      })?;
+
+    debug!("{}", stats);
+    if let Some(ignored_options) = maybe_ignored_options {
+      println!("{}", ignored_options);
+    }
+
+    s
+  } else {
+    global_state
+      .ts_compiler
+      .bundle(&global_state, module_specifier)
+      .await?
+  };
 
   debug!(">>>>> bundle END");
 

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -469,10 +469,13 @@ impl ModuleGraphLoader {
           url: module_specifier.to_string(),
           redirect: Some(source_file.url.to_string()),
           filename: source_file.filename.to_str().unwrap().to_string(),
-          version_hash: checksum::gen(&[
-            &source_file.source_code.as_bytes(),
-            version::DENO.as_bytes(),
-          ]),
+          version_hash: checksum::gen(
+            [
+              &source_file.source_code.as_bytes(),
+              version::DENO.as_bytes(),
+            ]
+            .as_ref(),
+          ),
           media_type: source_file.media_type,
           source_code: "".to_string(),
           imports: vec![],
@@ -485,10 +488,13 @@ impl ModuleGraphLoader {
     }
 
     let module_specifier = ModuleSpecifier::from(source_file.url.clone());
-    let version_hash = checksum::gen(&[
-      &source_file.source_code.as_bytes(),
-      version::DENO.as_bytes(),
-    ]);
+    let version_hash = checksum::gen(
+      [
+        &source_file.source_code.as_bytes(),
+        version::DENO.as_bytes(),
+      ]
+      .as_ref(),
+    );
     let source_code = source_file.source_code.to_string()?;
 
     if SUPPORTED_MEDIA_TYPES.contains(&source_file.media_type) {

--- a/cli/tests/bundle.test.out
+++ b/cli/tests/bundle.test.out
@@ -1,22 +1,23 @@
 [WILDCARD]
-let System, __instantiate;
-(() => {
-[WILDCARD]
-})();
-
-System.register("print_hello", [], function (exports_1, context_1) {
-[WILDCARD]
-});
-System.register("subdir2/mod2", ["print_hello"], function (exports_2, context_2) {
-[WILDCARD]
-});
-System.register("mod1", ["subdir2/mod2"], function (exports_3, context_3) {
-[WILDCARD]
-});
-
-const __exp = __instantiate("mod1", false);
-export const returnsHi = __exp["returnsHi"];
-export const returnsFoo2 = __exp["returnsFoo2"];
-export const printHello3 = __exp["printHello3"];
-export const throwsError = __exp["throwsError"];
+function printHello() {
+    console.log("Hello");
+}
+function returnsFoo() {
+    return "Foo";
+}
+function printHello2() {
+    printHello();
+}
+export function returnsHi() {
+    return "Hi";
+}
+export function returnsFoo2() {
+    return returnsFoo();
+}
+export function printHello3() {
+    printHello2();
+}
+export function throwsError() {
+    throw Error("exception from mod1");
+}
 [WILDCARD]

--- a/cli/tests/bundle.test.out
+++ b/cli/tests/bundle.test.out
@@ -1,23 +1,7 @@
 [WILDCARD]
-function printHello() {
-    console.log("Hello");
-}
-function returnsFoo() {
-    return "Foo";
-}
-function printHello2() {
-    printHello();
-}
-export function returnsHi() {
-    return "Hi";
-}
-export function returnsFoo2() {
-    return returnsFoo();
-}
-export function printHello3() {
-    printHello2();
-}
-export function throwsError() {
-    throw Error("exception from mod1");
-}
+var __exp = __instantiate("[WILDCARD]/tests/subdir/mod1.ts", false);
+export var returnsHi = __exp["returnsHi"];
+export var returnsFoo2 = __exp["returnsFoo2"];
+export var printHello3 = __exp["printHello3"];
+export var throwsError = __exp["throwsError"];
 [WILDCARD]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -838,38 +838,37 @@ fn bundle_exports() {
   assert_eq!(output.stderr, b"");
 }
 
-// TODO (@kitsonk) https://github.com/swc-project/swc/issues/1139
-// #[test]
-// fn bundle_circular() {
-//   // First we have to generate a bundle of some module that has exports.
-//   let circular1 = util::root_path().join("cli/tests/subdir/circular1.ts");
-//   assert!(circular1.is_file());
-//   let t = TempDir::new().expect("tempdir fail");
-//   let bundle = t.path().join("circular1.bundle.js");
-//   let mut deno = util::deno_cmd()
-//     .current_dir(util::root_path())
-//     .arg("bundle")
-//     .arg(circular1)
-//     .arg(&bundle)
-//     .spawn()
-//     .expect("failed to spawn script");
-//   let status = deno.wait().expect("failed to wait for the child process");
-//   assert!(status.success());
-//   assert!(bundle.is_file());
+#[test]
+fn bundle_circular() {
+  // First we have to generate a bundle of some module that has exports.
+  let circular1 = util::root_path().join("cli/tests/subdir/circular1.ts");
+  assert!(circular1.is_file());
+  let t = TempDir::new().expect("tempdir fail");
+  let bundle = t.path().join("circular1.bundle.js");
+  let mut deno = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("bundle")
+    .arg(circular1)
+    .arg(&bundle)
+    .spawn()
+    .expect("failed to spawn script");
+  let status = deno.wait().expect("failed to wait for the child process");
+  assert!(status.success());
+  assert!(bundle.is_file());
 
-//   let output = util::deno_cmd()
-//     .current_dir(util::root_path())
-//     .arg("run")
-//     .arg(&bundle)
-//     .output()
-//     .expect("failed to spawn script");
-//   // check the output of the the bundle program.
-//   assert!(std::str::from_utf8(&output.stdout)
-//     .unwrap()
-//     .trim()
-//     .ends_with("f1\nf2"));
-//   assert_eq!(output.stderr, b"");
-// }
+  let output = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("run")
+    .arg(&bundle)
+    .output()
+    .expect("failed to spawn script");
+  // check the output of the the bundle program.
+  assert!(std::str::from_utf8(&output.stdout)
+    .unwrap()
+    .trim()
+    .ends_with("f1\nf2"));
+  assert_eq!(output.stderr, b"");
+}
 
 #[test]
 fn bundle_single_module() {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -838,37 +838,38 @@ fn bundle_exports() {
   assert_eq!(output.stderr, b"");
 }
 
-#[test]
-fn bundle_circular() {
-  // First we have to generate a bundle of some module that has exports.
-  let circular1 = util::root_path().join("cli/tests/subdir/circular1.ts");
-  assert!(circular1.is_file());
-  let t = TempDir::new().expect("tempdir fail");
-  let bundle = t.path().join("circular1.bundle.js");
-  let mut deno = util::deno_cmd()
-    .current_dir(util::root_path())
-    .arg("bundle")
-    .arg(circular1)
-    .arg(&bundle)
-    .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
-  assert!(status.success());
-  assert!(bundle.is_file());
+// TODO (@kitsonk) https://github.com/swc-project/swc/issues/1139
+// #[test]
+// fn bundle_circular() {
+//   // First we have to generate a bundle of some module that has exports.
+//   let circular1 = util::root_path().join("cli/tests/subdir/circular1.ts");
+//   assert!(circular1.is_file());
+//   let t = TempDir::new().expect("tempdir fail");
+//   let bundle = t.path().join("circular1.bundle.js");
+//   let mut deno = util::deno_cmd()
+//     .current_dir(util::root_path())
+//     .arg("bundle")
+//     .arg(circular1)
+//     .arg(&bundle)
+//     .spawn()
+//     .expect("failed to spawn script");
+//   let status = deno.wait().expect("failed to wait for the child process");
+//   assert!(status.success());
+//   assert!(bundle.is_file());
 
-  let output = util::deno_cmd()
-    .current_dir(util::root_path())
-    .arg("run")
-    .arg(&bundle)
-    .output()
-    .expect("failed to spawn script");
-  // check the output of the the bundle program.
-  assert!(std::str::from_utf8(&output.stdout)
-    .unwrap()
-    .trim()
-    .ends_with("f1\nf2"));
-  assert_eq!(output.stderr, b"");
-}
+//   let output = util::deno_cmd()
+//     .current_dir(util::root_path())
+//     .arg("run")
+//     .arg(&bundle)
+//     .output()
+//     .expect("failed to spawn script");
+//   // check the output of the the bundle program.
+//   assert!(std::str::from_utf8(&output.stdout)
+//     .unwrap()
+//     .trim()
+//     .ends_with("f1\nf2"));
+//   assert_eq!(output.stderr, b"");
+// }
 
 #[test]
 fn bundle_single_module() {
@@ -974,37 +975,38 @@ fn bundle_js() {
   assert_eq!(output.stderr, b"");
 }
 
-#[test]
-fn bundle_dynamic_import() {
-  let dynamic_import =
-    util::root_path().join("cli/tests/subdir/subdir2/dynamic_import.ts");
-  assert!(dynamic_import.is_file());
-  let t = TempDir::new().expect("tempdir fail");
-  let bundle = t.path().join("dynamic_import.bundle.js");
-  let mut deno = util::deno_cmd()
-    .current_dir(util::root_path())
-    .arg("bundle")
-    .arg(dynamic_import)
-    .arg(&bundle)
-    .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
-  assert!(status.success());
-  assert!(bundle.is_file());
+// TODO(@kitsonk) working as designed, but change in behaviour
+// #[test]
+// fn bundle_dynamic_import() {
+//   let dynamic_import =
+//     util::root_path().join("cli/tests/subdir/subdir2/dynamic_import.ts");
+//   assert!(dynamic_import.is_file());
+//   let t = TempDir::new().expect("tempdir fail");
+//   let bundle = t.path().join("dynamic_import.bundle.js");
+//   let mut deno = util::deno_cmd()
+//     .current_dir(util::root_path())
+//     .arg("bundle")
+//     .arg(dynamic_import)
+//     .arg(&bundle)
+//     .spawn()
+//     .expect("failed to spawn script");
+//   let status = deno.wait().expect("failed to wait for the child process");
+//   assert!(status.success());
+//   assert!(bundle.is_file());
 
-  let output = util::deno_cmd()
-    .current_dir(util::root_path())
-    .arg("run")
-    .arg(&bundle)
-    .output()
-    .expect("failed to spawn script");
-  // check the output of the test.ts program.
-  assert!(std::str::from_utf8(&output.stdout)
-    .unwrap()
-    .trim()
-    .ends_with("Hello"));
-  assert_eq!(output.stderr, b"");
-}
+//   let output = util::deno_cmd()
+//     .current_dir(util::root_path())
+//     .arg("run")
+//     .arg(&bundle)
+//     .output()
+//     .expect("failed to spawn script");
+//   // check the output of the test.ts program.
+//   assert!(std::str::from_utf8(&output.stdout)
+//     .unwrap()
+//     .trim()
+//     .ends_with("Hello"));
+//   assert_eq!(output.stderr, b"");
+// }
 
 #[test]
 fn bundle_import_map() {
@@ -1972,7 +1974,7 @@ itest!(lock_check_err2 {
 itest!(lock_check_err_with_bundle {
   args: "bundle --lock=lock_check_err_with_bundle.json http://127.0.0.1:4545/cli/tests/subdir/mod1.ts",
   output: "lock_check_err_with_bundle.out",
-  exit_code: 10,
+  exit_code: 1,
   http_server: true,
 });
 

--- a/cli/tests/lock_check_err_with_bundle.out
+++ b/cli/tests/lock_check_err_with_bundle.out
@@ -1,3 +1,4 @@
 [WILDCARD]
-Subresource integrity check failed --lock=lock_check_err_with_bundle.json
-http://127.0.0.1:4545/cli/tests/subdir/subdir2/mod2.ts
+error: The source code is invalid, as it does not match the expected hash in the lock file.
+  Specifier: http://127.0.0.1:4545/cli/tests/subdir/subdir2/mod2.ts
+  Lock file: lock_check_err_with_bundle.json

--- a/cli/tests/module_graph/file_tests-bundle.ts
+++ b/cli/tests/module_graph/file_tests-bundle.ts
@@ -1,0 +1,6 @@
+import { a } from "https://deno.land/x/lib/a.ts";
+import * as b from "https://deno.land/x/lib/b.js";
+
+console.log(a, b);
+
+export const c = { a, b };

--- a/cli/tests/module_graph/file_tests-rexport.js
+++ b/cli/tests/module_graph/file_tests-rexport.js
@@ -1,0 +1,2 @@
+import * as mod from "https://deno.land/x/rexport/mod.ts";
+console.log(mod);

--- a/cli/tests/module_graph/https_deno.land-x-rexport-a.ts
+++ b/cli/tests/module_graph/https_deno.land-x-rexport-a.ts
@@ -1,0 +1,2 @@
+export default class A {}
+export const a = "a";

--- a/cli/tests/module_graph/https_deno.land-x-rexport-b.ts
+++ b/cli/tests/module_graph/https_deno.land-x-rexport-b.ts
@@ -1,0 +1,2 @@
+export default class B {}
+export const b = new B();

--- a/cli/tests/module_graph/https_deno.land-x-rexport-c.js
+++ b/cli/tests/module_graph/https_deno.land-x-rexport-c.js
@@ -1,0 +1,1 @@
+export const c = "c";

--- a/cli/tests/module_graph/https_deno.land-x-rexport-mod.ts
+++ b/cli/tests/module_graph/https_deno.land-x-rexport-mod.ts
@@ -1,0 +1,3 @@
+export * from "./a.ts";
+export * as b from "./b.ts";
+export { c } from "./c.js";

--- a/cli/ts_checker.rs
+++ b/cli/ts_checker.rs
@@ -1,0 +1,624 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+use crate::diagnostics::Diagnostics;
+use crate::file_fetcher::TextDocument;
+use crate::graph::ModuleProvider;
+use crate::graph::Stats;
+use crate::media_type::MediaType;
+use crate::tsc_config::TsConfig;
+
+use deno_core::error::anyhow;
+use deno_core::error::bail;
+use deno_core::error::AnyError;
+use deno_core::error::Context;
+use deno_core::json_op_sync;
+use deno_core::serde_json;
+use deno_core::serde_json::json;
+use deno_core::serde_json::Value;
+use deno_core::JsRuntime;
+use deno_core::ModuleSpecifier;
+use deno_core::OpFn;
+use deno_core::RuntimeOptions;
+use deno_core::Snapshot;
+use serde::Deserialize;
+use serde::Serialize;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct EmittedFile {
+  data: String,
+  maybe_specifier: Option<ModuleSpecifier>,
+  media_type: MediaType,
+}
+
+pub struct CheckerState {
+  hash_data: Vec<Vec<u8>>,
+  emitted_files: Vec<EmittedFile>,
+  maybe_build_info: Option<TextDocument>,
+  maybe_result: Option<CheckerResult>,
+  provider: Rc<RefCell<dyn ModuleProvider>>,
+}
+
+impl CheckerState {
+  pub fn new(
+    provider: Rc<RefCell<dyn ModuleProvider>>,
+    hash_data: Vec<Vec<u8>>,
+    maybe_build_info: Option<TextDocument>,
+  ) -> Self {
+    CheckerState {
+      hash_data,
+      emitted_files: Vec::new(),
+      maybe_build_info,
+      maybe_result: None,
+      provider,
+    }
+  }
+}
+
+fn checker_op<F>(op_fn: F) -> Box<OpFn>
+where
+  F: Fn(&mut CheckerState, Value) -> Result<Value, AnyError> + 'static,
+{
+  json_op_sync(move |s, args, _bufs| {
+    let state = s.borrow_mut::<CheckerState>();
+    op_fn(state, args)
+  })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateHashArgs {
+  /// The string data to be used to generate the hash.  This will be mixed with
+  /// other state data in Deno to derive the final hash.
+  data: String,
+}
+
+fn op_create_hash(
+  state: &mut CheckerState,
+  args: Value,
+) -> Result<Value, AnyError> {
+  let v: CreateHashArgs = serde_json::from_value(args)
+    .context("Invalid request from JavaScript for \"op_create_hash\".")?;
+  let mut data = vec![v.data.as_bytes().to_owned()];
+  data.extend_from_slice(&state.hash_data);
+  let hash = crate::checksum::gen(&data);
+
+  Ok(json!({ "hash": hash }))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EmitArgs {
+  /// The text data/contents of the file.
+  data: String,
+  /// The _internal_ filename for the file.  This will be used to determine how
+  /// the file is cached and stored.
+  file_name: String,
+  /// A string representation of the specifier that was associated with a
+  /// module.  This should be present on every module that represents a module
+  /// that was requested to be transformed.
+  maybe_specifier: Option<String>,
+}
+
+fn op_emit(state: &mut CheckerState, args: Value) -> Result<Value, AnyError> {
+  let v: EmitArgs = serde_json::from_value(args)
+    .context("Invalid request from JavaScript for \"op_emit\".")?;
+  match v.file_name.as_ref() {
+    "cache:///.tsbuildinfo" => {
+      state.maybe_build_info = Some(TextDocument::new(
+        v.data.as_bytes().to_owned(),
+        Option::<&str>::None,
+      ))
+    }
+    _ => state.emitted_files.push(EmittedFile {
+      data: v.data,
+      maybe_specifier: if let Some(specifier) = &v.maybe_specifier {
+        Some(ModuleSpecifier::resolve_url_or_path(specifier).context(
+          "Error converting a string module specifier for \"op_emit\".",
+        )?)
+      } else {
+        None
+      },
+      media_type: MediaType::from(&v.file_name),
+    }),
+  }
+
+  Ok(json!(true))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResolveArgs {
+  /// The base specifier that the supplied specifier strings should be resolved
+  /// relative to.
+  base: String,
+  /// A list of specifiers that should be resolved.
+  specifiers: Vec<String>,
+}
+
+fn op_resolve(
+  state: &mut CheckerState,
+  args: Value,
+) -> Result<Value, AnyError> {
+  let provider = state.provider.borrow();
+  let v: ResolveArgs = serde_json::from_value(args)
+    .context("Invalid request from JavaScript for \"op_resolve\".")?;
+  let mut resolved: Vec<(String, String)> = Vec::new();
+  let referrer = ModuleSpecifier::resolve_url_or_path(&v.base).context(
+    "Error converting a string module specifier for \"op_resolve\".",
+  )?;
+  for specifier in &v.specifiers {
+    if specifier.starts_with("asset:///") {
+      resolved.push((
+        specifier.clone(),
+        MediaType::from(specifier).as_ts_extension().to_string(),
+      ));
+    } else {
+      let resolved_specifier = provider.resolve(specifier, &referrer)?;
+      let media_type = if let Some(media_type) =
+        provider.get_media_type(&resolved_specifier)
+      {
+        media_type
+      } else {
+        bail!(
+          "Unable to resolve media type for specifier: \"{}\"",
+          resolved_specifier
+        )
+      };
+      resolved.push((
+        resolved_specifier.to_string(),
+        media_type.as_ts_extension().to_string(),
+      ));
+    }
+  }
+
+  Ok(json!(resolved))
+}
+
+#[derive(Debug, Deserialize)]
+struct LoadArgs {
+  /// The fully qualified specifier that should be loaded.
+  specifier: String,
+}
+
+fn op_load(state: &mut CheckerState, args: Value) -> Result<Value, AnyError> {
+  let provider = state.provider.borrow();
+  let v: LoadArgs = serde_json::from_value(args)
+    .context("Invalid request from JavaScript for \"op_load\".")?;
+  let specifier = ModuleSpecifier::resolve_url_or_path(&v.specifier)
+    .context("Error converting a string module specifier for \"op_load\".")?;
+  let mut hash: Option<String> = None;
+  let data = if &v.specifier == "cache:///.tsbuildinfo" {
+    if let Some(build_info) = &state.maybe_build_info {
+      Some(build_info.to_string()?)
+    } else {
+      None
+    }
+  } else {
+    let maybe_source = provider.get_source(&specifier);
+    if let Some(source) = &maybe_source {
+      let mut data = vec![source.as_bytes().to_owned()];
+      data.extend_from_slice(&state.hash_data);
+      hash = Some(crate::checksum::gen(&data));
+    }
+    maybe_source
+  };
+
+  Ok(json!({ "data": data, "hash": hash }))
+}
+
+/// An internal structure that contains the final values from a request.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CheckerResult {
+  pub diagnostics: Diagnostics,
+  pub emit_skipped: bool,
+  pub stats: Stats,
+}
+
+fn op_set_result(
+  state: &mut CheckerState,
+  args: Value,
+) -> Result<Value, AnyError> {
+  let v: CheckerResult = serde_json::from_value(args)
+    .context("Error converting the result for \"op_set_result\".")?;
+  state.maybe_result = Some(v);
+  Ok(json!(true))
+}
+
+#[derive(Debug)]
+pub struct ExecResult {
+  /// Any diagnostics that have been returned from the checker.
+  pub diagnostics: Diagnostics,
+  /// Any files that were emitted during the check.
+  pub emitted_files: Vec<EmittedFile>,
+  /// If there was any build info associated with the exec request.
+  pub maybe_build_info: Option<TextDocument>,
+  /// Statistics from the check.
+  pub stats: Stats,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Request<'a> {
+  /// The compiler configuration, as a JSON value, that should be passed to the
+  /// checker.
+  pub config: &'a TsConfig,
+  /// A flag which is passed to the runtime which indicates if debug messages
+  /// should be logged or not.
+  pub debug: bool,
+  /// A list of root files that should be type checked.
+  pub root_names: &'a Vec<String>,
+}
+
+/// Process a request to type check modules, based on the passed modules. The
+/// check result will be returned.
+pub fn exec<'a>(
+  request: Request<'a>,
+  snapshot: Snapshot,
+  provider: Rc<RefCell<dyn ModuleProvider>>,
+  hash_data: Vec<Vec<u8>>,
+  maybe_build_info: Option<TextDocument>,
+) -> Result<ExecResult, AnyError> {
+  let mut checker_runtime = JsRuntime::new(RuntimeOptions {
+    startup_snapshot: Some(snapshot),
+    ..Default::default()
+  });
+
+  {
+    // Add the checker state to `op_state`
+    let op_state = checker_runtime.op_state();
+    let mut op_state = op_state.borrow_mut();
+    op_state.put(CheckerState::new(provider, hash_data, maybe_build_info));
+  }
+
+  // Register the ops for the runtime
+  checker_runtime.register_op("op_create_hash", checker_op(op_create_hash));
+  checker_runtime.register_op("op_emit", checker_op(op_emit));
+  checker_runtime.register_op("op_load", checker_op(op_load));
+  checker_runtime.register_op("op_resolve", checker_op(op_resolve));
+  checker_runtime.register_op("op_set_result", checker_op(op_set_result));
+
+  let startup_source = "globalThis.startup({ legacy: false })";
+  let req_str = serde_json::to_string(&request)
+    .context("Could not serialize request before execution.")?;
+  let exec_source = format!("globalThis.exec({})", req_str);
+
+  checker_runtime
+    .execute("[native code]", startup_source)
+    .context("failed to bootstrap the checker isolate")?;
+  checker_runtime
+    .execute("[native code]", &exec_source)
+    .context("failed to execute a request to the checker isolate")?;
+
+  let op_state = checker_runtime.op_state();
+  let mut op_state = op_state.borrow_mut();
+  let state = op_state.take::<CheckerState>();
+
+  if let Some(result) = state.maybe_result {
+    let diagnostics = result.diagnostics;
+    let emitted_files = state.emitted_files;
+    let maybe_build_info = state.maybe_build_info;
+    let stats = result.stats;
+    Ok(ExecResult {
+      diagnostics,
+      emitted_files,
+      maybe_build_info,
+      stats,
+    })
+  } else {
+    Err(anyhow!("Checker result was not set."))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::diagnostics::Diagnostic;
+  use crate::diagnostics::DiagnosticCategory;
+  use crate::graph::tests::MockModuleProvider;
+  use crate::graph::Stat;
+  use crate::js;
+  use std::collections::HashMap;
+
+  #[test]
+  fn test_op_create_hash() {
+    let provider = Rc::new(RefCell::new(MockModuleProvider::default()));
+    let hash_data = vec![b"something".to_vec()];
+    let mut state = CheckerState::new(provider, hash_data, None);
+    let actual = op_create_hash(
+      &mut state,
+      json!({
+        "data": "some sort of content"
+      }),
+    )
+    .expect("should have returned");
+    assert_eq!(
+      actual,
+      json!({
+        "hash": "ae92df8f104748768838916857a1623b6a3c593110131b0a00f81ad9dac16511"
+      })
+    );
+  }
+
+  #[test]
+  fn test_op_emit() {
+    let provider = Rc::new(RefCell::new(MockModuleProvider::default()));
+    let mut state = CheckerState::new(provider, Vec::new(), None);
+    op_emit(
+      &mut state,
+      json!({
+        "data": "some file content",
+        "fileName": "cache:///some/file.js",
+        "maybeSpecifier": "file:///some/file.ts"
+      }),
+    )
+    .expect("should have not errored");
+    assert_eq!(state.emitted_files.len(), 1);
+    assert!(state.maybe_build_info.is_none());
+    assert_eq!(
+      state.emitted_files[0],
+      EmittedFile {
+        data: "some file content".to_string(),
+        maybe_specifier: Some(
+          ModuleSpecifier::resolve_url_or_path("file:///some/file.ts").unwrap()
+        ),
+        media_type: MediaType::JavaScript,
+      }
+    );
+  }
+
+  #[test]
+  fn test_op_emit_build_info() {
+    let provider = Rc::new(RefCell::new(MockModuleProvider::default()));
+    let mut state = CheckerState::new(provider, Vec::new(), None);
+    op_emit(
+      &mut state,
+      json!({
+        "data": "some file content",
+        "fileName": "cache:///.tsbuildinfo",
+      }),
+    )
+    .expect("should not have errored");
+    assert_eq!(state.emitted_files.len(), 0);
+    assert_eq!(
+      state.maybe_build_info,
+      Some(TextDocument::new(
+        b"some file content".to_vec(),
+        Option::<&str>::None
+      ))
+    );
+  }
+
+  #[test]
+  fn test_op_load() {
+    let mut sources = HashMap::new();
+    sources.insert(
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/mod.ts")
+        .unwrap(),
+      "some file content".to_string(),
+    );
+    let provider = Rc::new(RefCell::new(MockModuleProvider {
+      sources,
+      ..Default::default()
+    }));
+    let mut state = CheckerState::new(provider, Vec::new(), None);
+    let actual = op_load(
+      &mut state,
+      json!({
+        "specifier": "https://deno.land/x/mod.ts"
+      }),
+    )
+    .expect("op should not have errored");
+    assert_eq!(
+      actual,
+      json!({
+        "data": "some file content",
+        "hash": "b05ffa4eea8fb5609d576a68c1066be3f99e4dc53d365a0ac2a78259b2dd91f9"
+      })
+    );
+  }
+
+  #[test]
+  fn test_op_load_buildinfo() {
+    let provider = Rc::new(RefCell::new(MockModuleProvider::default()));
+    let mut state = CheckerState::new(
+      provider,
+      Vec::new(),
+      Some(TextDocument::new(
+        b"some build info".to_vec(),
+        Option::<&str>::None,
+      )),
+    );
+    let actual = op_load(
+      &mut state,
+      json!({
+        "specifier": "cache:///.tsbuildinfo"
+      }),
+    )
+    .expect("op should not have errored");
+    assert_eq!(
+      actual,
+      json!({
+        "data": "some build info",
+        "hash": null
+      })
+    );
+  }
+
+  #[test]
+  fn test_op_load_error() {
+    let provider = Rc::new(RefCell::new(MockModuleProvider::default()));
+    let mut state = CheckerState::new(provider, Vec::new(), None);
+    let actual = op_load(
+      &mut state,
+      json!({
+        "specifier": "https://deno.land/x/mod.ts"
+      }),
+    )
+    .expect("should not have errored");
+    assert_eq!(
+      actual,
+      json!({
+        "data": null,
+        "hash": null
+      })
+    );
+  }
+
+  #[test]
+  fn test_op_resolve() {
+    let mut main_deps = HashMap::new();
+    main_deps.insert(
+      "./a.ts".to_string(),
+      ModuleSpecifier::resolve_url_or_path("file:///a.ts").unwrap(),
+    );
+    let mut resolution_map = HashMap::new();
+    resolution_map.insert(
+      ModuleSpecifier::resolve_url_or_path("file:///main.ts").unwrap(),
+      main_deps,
+    );
+    let mut media_types = HashMap::new();
+    media_types.insert(
+      ModuleSpecifier::resolve_url_or_path("file:///a.ts").unwrap(),
+      MediaType::TypeScript,
+    );
+    let provider = Rc::new(RefCell::new(MockModuleProvider {
+      resolution_map,
+      media_types,
+      ..Default::default()
+    }));
+    let mut state = CheckerState::new(provider, Vec::new(), None);
+    let actual = op_resolve(
+      &mut state,
+      json!({
+        "base": "file:///main.ts",
+        "specifiers": [ "./a.ts" ],
+      }),
+    )
+    .expect("should have resolved");
+    assert_eq!(actual, json!([["file:///a.ts", ".ts"]]));
+  }
+
+  #[test]
+  fn test_op_resolve_error() {
+    let provider = Rc::new(RefCell::new(MockModuleProvider::default()));
+    let mut state = CheckerState::new(provider, Vec::new(), None);
+    op_resolve(
+      &mut state,
+      json!({
+        "base": "file:///main.ts",
+        "specifiers": ["./a.ts"]
+      }),
+    )
+    .expect_err("should have failed");
+  }
+
+  #[test]
+  fn test_op_set_result() {
+    let provider = Rc::new(RefCell::new(MockModuleProvider::default()));
+    let mut state = CheckerState::new(provider, Vec::new(), None);
+    op_set_result(
+      &mut state,
+      json!({
+        "diagnostics": [
+          {
+            "messageText": "Unknown compiler option 'invalid'.",
+            "category": 1,
+            "code": 5023
+          }
+        ],
+        "emitSkipped": false,
+        "stats": [["a", 12]]
+      }),
+    )
+    .expect("should not error");
+    assert_eq!(
+      state.maybe_result,
+      Some(CheckerResult {
+        diagnostics: Diagnostics(vec![Diagnostic {
+          category: DiagnosticCategory::Error,
+          code: 5023,
+          start: None,
+          end: None,
+          message_text: Some(
+            "Unknown compiler option \'invalid\'.".to_string()
+          ),
+          message_chain: None,
+          source: None,
+          source_line: None,
+          file_name: None,
+          related_information: None,
+        }]),
+        emit_skipped: false,
+        stats: Stats(vec![Stat::new("a".to_string(), 12)])
+      })
+    );
+  }
+
+  #[test]
+  fn test_exec() {
+    let mut sources = HashMap::new();
+    sources.insert(
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/mod.ts")
+        .unwrap(),
+      "import * as a from \"./a.ts\";\n\nconsole.log(a);".to_string(),
+    );
+    sources.insert(
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/a.ts").unwrap(),
+      "export const a = \"a\";\n".to_string(),
+    );
+    let mut mod_deps = HashMap::new();
+    mod_deps.insert(
+      "./a.ts".to_string(),
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/a.ts").unwrap(),
+    );
+    let mut resolution_map = HashMap::new();
+    resolution_map.insert(
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/mod.ts")
+        .unwrap(),
+      mod_deps,
+    );
+    let mut media_types = HashMap::new();
+    media_types.insert(
+      ModuleSpecifier::resolve_url_or_path("https://deno.land/x/a.ts").unwrap(),
+      MediaType::TypeScript,
+    );
+    let provider = Rc::new(RefCell::new(MockModuleProvider {
+      resolution_map,
+      sources,
+      media_types,
+    }));
+    let hash_data = vec![b"{}".to_vec(), b"1.2.3".to_vec()];
+    let config = &TsConfig::new(json!({
+      "allowJs": true,
+      "esModuleInterop": true,
+      "incremental": true,
+      "isolatedModules": true,
+      "lib": ["deno.window"],
+      "module": "esnext",
+      "noEmit": true,
+      "outDir": "deno:///",
+      "sourceMap": true,
+      "strict": true,
+      "target": "esnext",
+      "tsBuildInfoFile": "cache:///.tsbuildinfo",
+    }));
+    let actual = exec(
+      Request {
+        config,
+        debug: false,
+        root_names: &vec!["https://deno.land/x/mod.ts".to_string()],
+      },
+      js::compiler_isolate_init(),
+      provider,
+      hash_data,
+      None,
+    )
+    .expect("should not have errored");
+    assert_eq!(actual.stats.0.len(), 12);
+    assert_eq!(actual.diagnostics.0.len(), 0);
+    assert!(actual.maybe_build_info.is_some());
+  }
+}

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -422,16 +422,14 @@ delete Object.prototype.__proto__;
       if (legacy) {
         legacyHostState.writeFile(fileName, data, sourceFiles);
       } else {
-        let maybeSpecifier;
+        let maybeSpecifiers;
         if (sourceFiles) {
-          assert(sourceFiles.length === 1, "unexpected number of source files");
-          const [sourceFile] = sourceFiles;
-          maybeSpecifier = sourceFile.moduleName;
-          debug(`  specifier: ${maybeSpecifier}`);
+          maybeSpecifiers = sourceFiles.map((sf) => sf.moduleName);
+          debug(`  specifiers: ${maybeSpecifiers.join(", ")}`);
         }
         return core.jsonOpSync(
           "op_emit",
-          { maybeSpecifier, fileName, data },
+          { maybeSpecifiers, fileName, data },
         );
       }
     },

--- a/cli/tsc_config.rs
+++ b/cli/tsc_config.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+use crate::ast;
+
 use deno_core::error::AnyError;
 use deno_core::serde_json;
 use deno_core::serde_json::Value;
@@ -248,13 +250,17 @@ impl TsConfig {
     }
   }
 
-  /// Return the current configuration as a `TranspileConfigOptions` structure.
-  pub fn as_transpile_config(
-    &self,
-  ) -> Result<TranspileConfigOptions, AnyError> {
+  pub fn as_emit_options(&self) -> Result<ast::EmitOptions, AnyError> {
     let options: TranspileConfigOptions =
       serde_json::from_value(self.0.clone())?;
-    Ok(options)
+    Ok(ast::EmitOptions {
+      check_js: options.check_js,
+      emit_metadata: options.emit_decorator_metadata,
+      inline_source_map: true,
+      jsx_factory: options.jsx_factory,
+      jsx_fragment_factory: options.jsx_fragment_factory,
+      transform_jsx: options.jsx == "react",
+    })
   }
 }
 

--- a/core/error.rs
+++ b/core/error.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+pub use anyhow::anyhow;
 pub use anyhow::bail;
 pub use anyhow::Context;
 use rusty_v8 as v8;

--- a/core/error.rs
+++ b/core/error.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+pub use anyhow::bail;
+pub use anyhow::Context;
 use rusty_v8 as v8;
 use std::borrow::Cow;
 use std::convert::TryFrom;


### PR DESCRIPTION
This PR is the WIP for the way of bundling.  It does the following:

- Builds on the new module graph that was introduced.
- Uses swc_bundler to emit the bundle.
- Uses a refactoring of `tsc` called `ts_checker` which does a type check only.

Like currently, `deno bundle` does a type check, but it now supports the incremental build for bundles, which make subsequent type checks faster.  It also supports `deno bundle --no-check` as well.  In all cases it uses `swc_bundler` which emits a single file "flat" ES module.

Things going on:

- This builds on #7669, but I would like to land #7669 separately when we get the majority of the bugs addressed, and then use this PR to replace the the emit from `deno bundle` with swc.
- swc leaves dynamic imports untouched.  This is a significant change in behaviour from `deno bundle`, where if a dynamic import could be statically identified, it would be included in the bundle.  This isn't a big deal with absolute URLs, but if users are importing something relative and locally, then this becomes a bit of an issue, as it doesn't make the bundle very portable.  We might want to consider ways of dealing with this (like maybe warning on dynamic import).  Also, this is a significant change in behaviour, and some could argue a breaking change.
- This is a net add of ~1100 lines...  I am not totally happy about that, but again, this is a transition period... Not all of the lines could be dropped in tsc because of the other dependent capabilities.  I believe at the end of this journey we will drop a lot of code and have a set of code that is a lot more maintainable.