### PR TITLE
fix(cli/console): only inspect getters with option

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1956,6 +1956,8 @@ declare namespace Deno {
     sorted?: boolean;
     /** Add a trailing comma for multiline collections. Defaults to false. */
     trailingComma?: boolean;
+    /*** Evaluate the result of calling getters. Defaults to false. */
+    getters?: boolean;
   }
 
   /** Converts the input into a string that has the same format as printed by

--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -157,6 +157,7 @@
     iterableLimit: 100,
     showProxy: false,
     colors: false,
+    getters: false,
   };
 
   const DEFAULT_INDENT = "  "; // Default indent string
@@ -765,31 +766,73 @@
     const red = maybeColor(colors.red, inspectOptions);
 
     for (const key of stringKeys) {
-      let propertyValue;
-      let error = null;
-      try {
-        propertyValue = value[key];
-      } catch (error_) {
-        error = error_;
+      if (inspectOptions.getters) {
+        let propertyValue;
+        let error = null;
+        try {
+          propertyValue = value[key];
+        } catch (error_) {
+          error = error_;
+        }
+        const inspectedValue = error == null
+          ? inspectValueWithQuotes(
+            propertyValue,
+            ctx,
+            level + 1,
+            inspectOptions,
+          )
+          : red(`[Thrown ${error.name}: ${error.message}]`);
+        entries.push(`${maybeQuoteString(key)}: ${inspectedValue}`);
+      } else {
+        let descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (descriptor.get !== undefined && descriptor.set !== undefined) {
+          entries.push(`${maybeQuoteString(key)}: [Getter/Setter]`);
+        } else if (descriptor.get !== undefined) {
+          entries.push(`${maybeQuoteString(key)}: [Getter]`);
+        } else {
+          entries.push(
+            `${maybeQuoteString(key)}: ${
+              inspectValueWithQuotes(value[key], ctx, level + 1, inspectOptions)
+            }`,
+          );
+        }
       }
-      const inspectedValue = error == null
-        ? inspectValueWithQuotes(propertyValue, ctx, level + 1, inspectOptions)
-        : red(`[Thrown ${error.name}: ${error.message}]`);
-      entries.push(`${maybeQuoteString(key)}: ${inspectedValue}`);
     }
+
     for (const key of symbolKeys) {
-      let propertyValue;
-      let error;
-      try {
-        propertyValue = value[key];
-      } catch (error_) {
-        error = error_;
+      if (inspectOptions.getters) {
+        let propertyValue;
+        let error;
+        try {
+          propertyValue = value[key];
+        } catch (error_) {
+          error = error_;
+        }
+        const inspectedValue = error == null
+          ? inspectValueWithQuotes(
+            propertyValue,
+            ctx,
+            level + 1,
+            inspectOptions,
+          )
+          : red(`Thrown ${error.name}: ${error.message}`);
+        entries.push(`[${maybeQuoteSymbol(key)}]: ${inspectedValue}`);
+      } else {
+        let descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (descriptor.get !== undefined && descriptor.set !== undefined) {
+          entries.push(`[${maybeQuoteSymbol(key)}]: [Getter/Setter]`);
+        } else if (descriptor.get !== undefined) {
+          entries.push(`[${maybeQuoteSymbol(key)}]: [Getter]`);
+        } else {
+          entries.push(
+            `[${maybeQuoteSymbol(key)}]: ${
+              inspectValueWithQuotes(value[key], ctx, level + 1, inspectOptions)
+            }`,
+          );
+        }
       }
-      const inspectedValue = error == null
-        ? inspectValueWithQuotes(propertyValue, ctx, level + 1, inspectOptions)
-        : red(`Thrown ${error.name}: ${error.message}`);
-      entries.push(`[${maybeQuoteSymbol(key)}]: ${inspectedValue}`);
     }
+
     // Making sure color codes are ignored when calculating the total length
     const totalLength = entries.length + level +
       colors.stripColor(entries.join("")).length;

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1498,14 +1498,32 @@ unitTest(function inspectString(): void {
   );
 });
 
-unitTest(function inspectGetterError(): void {
+unitTest(function inspectGetters(): void {
+  assertEquals(
+    stripColor(Deno.inspect({
+      get foo() {
+        return 0;
+      },
+    })),
+    "{ foo: [Getter] }",
+  );
+
+  assertEquals(
+    stripColor(Deno.inspect({
+      get foo() {
+        return 0;
+      },
+    }, { getters: true })),
+    "{ foo: 0 }",
+  );
+
   assertEquals(
     Deno.inspect({
       // deno-lint-ignore getter-return
       get foo() {
         throw new Error("bar");
       },
-    }),
+    }, { getters: true }),
     "{ foo: [Thrown Error: bar] }",
   );
 });


### PR DESCRIPTION
This makes evaluation of getters an explicit option called `getters` exposed via InspectOptions.
This option defaults to false fixing the current bad behaviour of inspecting getters which has the potential to cause side effects, when it is false a getter is simply reported as `[Getter]` or `[Getter/Setter]` if its a get/set pair.

Fixes https://github.com/denoland/deno/issues/7153
