### PR TITLE
fix(cli/ops/fs): Don't replace Windows path separators

### DIFF
--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -941,10 +941,9 @@ fn op_realpath_sync(
   // corresponds to the realpath on Unix and
   // CreateFile and GetFinalPathNameByHandle on Windows
   let realpath = std::fs::canonicalize(&path)?;
-  let mut realpath_str =
-    into_string(realpath.into_os_string())?.replace("\\", "/");
+  let mut realpath_str = into_string(realpath.into_os_string())?;
   if cfg!(windows) {
-    realpath_str = realpath_str.trim_start_matches("//?/").to_string();
+    realpath_str = realpath_str.trim_start_matches("\\\\?\\").to_string();
   }
   Ok(json!(realpath_str))
 }

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -943,8 +943,6 @@ fn op_realpath_sync(
   let realpath = std::fs::canonicalize(&path)?;
   let mut realpath_str = into_string(realpath.into_os_string())?;
   if cfg!(windows) {
-    // Sometimes forward slashes are returned for Windows paths.
-    realpath_str = realpath_str.replace("/", "\\");
     realpath_str = realpath_str.trim_start_matches("\\\\?\\").to_string();
   }
   Ok(json!(realpath_str))
@@ -972,10 +970,9 @@ async fn op_realpath_async(
     // corresponds to the realpath on Unix and
     // CreateFile and GetFinalPathNameByHandle on Windows
     let realpath = std::fs::canonicalize(&path)?;
-    let mut realpath_str =
-      into_string(realpath.into_os_string())?.replace("\\", "/");
+    let mut realpath_str = into_string(realpath.into_os_string())?;
     if cfg!(windows) {
-      realpath_str = realpath_str.trim_start_matches("//?/").to_string();
+      realpath_str = realpath_str.trim_start_matches("\\\\?\\").to_string();
     }
     Ok(json!(realpath_str))
   })

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -943,6 +943,8 @@ fn op_realpath_sync(
   let realpath = std::fs::canonicalize(&path)?;
   let mut realpath_str = into_string(realpath.into_os_string())?;
   if cfg!(windows) {
+    // Sometimes forward slashes are returned for Windows paths.
+    realpath_str = realpath_str.replace("/", "\\");
     realpath_str = realpath_str.trim_start_matches("\\\\?\\").to_string();
   }
   Ok(json!(realpath_str))

--- a/cli/tests/unit/real_path_test.ts
+++ b/cli/tests/unit/real_path_test.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
+  assertMatch,
   assertThrows,
   assertThrowsAsync,
   unitTest,
@@ -13,7 +14,7 @@ unitTest({ perms: { read: true } }, function realPathSyncSuccess(): void {
     assert(realPath.startsWith("/"));
     assert(realPath.endsWith(relative));
   } else {
-    assert(/^[A-Z]:\\/.test(realPath));
+    assertMatch(realPath, /^[A-Z]:\\/);
     assert(realPath.endsWith(relative.replace(/\//g, "\\")));
   }
 });
@@ -33,7 +34,7 @@ unitTest(
       assert(realPath.startsWith("/"));
       assert(realPath.endsWith("/target"));
     } else {
-      assert(/^[A-Z]:\\/.test(realPath));
+      assertMatch(realPath, /^[A-Z]:\\/);
       assert(realPath.endsWith("\\target"));
     }
   },
@@ -60,7 +61,7 @@ unitTest({ perms: { read: true } }, async function realPathSuccess(): Promise<
     assert(realPath.startsWith("/"));
     assert(realPath.endsWith(relativePath));
   } else {
-    assert(/^[A-Z]:\\/.test(realPath));
+    assertMatch(realPath, /^[A-Z]:\\/);
     assert(realPath.endsWith(relativePath.replace(/\//g, "\\")));
   }
 });
@@ -80,7 +81,7 @@ unitTest(
       assert(realPath.startsWith("/"));
       assert(realPath.endsWith("/target"));
     } else {
-      assert(/^[A-Z]:\\/.test(realPath));
+      assertMatch(realPath, /^[A-Z]:\\/);
       assert(realPath.endsWith("\\target"));
     }
   },

--- a/cli/tests/unit/real_path_test.ts
+++ b/cli/tests/unit/real_path_test.ts
@@ -12,7 +12,7 @@ unitTest({ perms: { read: true } }, function realPathSyncSuccess(): void {
   if (Deno.build.os !== "windows") {
     assert(realPath.startsWith("/"));
   } else {
-    assert(/^[A-Z]/.test(realPath));
+    assert(/^[A-Z]:\\/.test(realPath));
   }
   assert(realPath.endsWith(incompletePath));
 });
@@ -31,7 +31,7 @@ unitTest(
     if (Deno.build.os !== "windows") {
       assert(targetPath.startsWith("/"));
     } else {
-      assert(/^[A-Z]/.test(targetPath));
+      assert(/^[A-Z]:\\/.test(targetPath));
     }
     assert(targetPath.endsWith("/target"));
   },
@@ -57,7 +57,7 @@ unitTest({ perms: { read: true } }, async function realPathSuccess(): Promise<
   if (Deno.build.os !== "windows") {
     assert(realPath.startsWith("/"));
   } else {
-    assert(/^[A-Z]/.test(realPath));
+    assert(/^[A-Z]:\\/.test(realPath));
   }
   assert(realPath.endsWith(incompletePath));
 });
@@ -76,7 +76,7 @@ unitTest(
     if (Deno.build.os !== "windows") {
       assert(targetPath.startsWith("/"));
     } else {
-      assert(/^[A-Z]/.test(targetPath));
+      assert(/^[A-Z]:\\/.test(targetPath));
     }
     assert(targetPath.endsWith("/target"));
   },

--- a/cli/tests/unit/real_path_test.ts
+++ b/cli/tests/unit/real_path_test.ts
@@ -68,8 +68,6 @@ unitTest({ perms: { read: true } }, async function realPathSuccess(): Promise<
 
 unitTest(
   {
-    // TODO(nayeemrmn): Symlinks don't work as expected on Windows.
-    ignore: Deno.build.os === "windows",
     perms: { read: true, write: true },
   },
   async function realPathSymlink(): Promise<void> {

--- a/cli/tests/unit/real_path_test.ts
+++ b/cli/tests/unit/real_path_test.ts
@@ -7,14 +7,15 @@ import {
 } from "./test_util.ts";
 
 unitTest({ perms: { read: true } }, function realPathSyncSuccess(): void {
-  const incompletePath = "cli/tests/fixture.json";
-  const realPath = Deno.realPathSync(incompletePath);
+  const relative = "cli/tests/fixture.json";
+  const realPath = Deno.realPathSync(relative);
   if (Deno.build.os !== "windows") {
     assert(realPath.startsWith("/"));
+    assert(realPath.endsWith(relative));
   } else {
     assert(/^[A-Z]:\\/.test(realPath));
+    assert(realPath.endsWith(relative.replace(/\//g, "\\")));
   }
-  assert(realPath.endsWith(incompletePath));
 });
 
 unitTest(
@@ -27,13 +28,14 @@ unitTest(
     const symlink = testDir + "/symln";
     Deno.mkdirSync(target);
     Deno.symlinkSync(target, symlink);
-    const targetPath = Deno.realPathSync(symlink);
+    const realPath = Deno.realPathSync(symlink);
     if (Deno.build.os !== "windows") {
-      assert(targetPath.startsWith("/"));
+      assert(realPath.startsWith("/"));
+      assert(realPath.endsWith("/target"));
     } else {
-      assert(/^[A-Z]:\\/.test(targetPath));
+      assert(/^[A-Z]:\\/.test(realPath));
+      assert(realPath.endsWith("\\target"));
     }
-    assert(targetPath.endsWith("/target"));
   },
 );
 
@@ -52,14 +54,15 @@ unitTest({ perms: { read: true } }, function realPathSyncNotFound(): void {
 unitTest({ perms: { read: true } }, async function realPathSuccess(): Promise<
   void
 > {
-  const incompletePath = "cli/tests/fixture.json";
-  const realPath = await Deno.realPath(incompletePath);
+  const relativePath = "cli/tests/fixture.json";
+  const realPath = await Deno.realPath(relativePath);
   if (Deno.build.os !== "windows") {
     assert(realPath.startsWith("/"));
+    assert(realPath.endsWith(relativePath));
   } else {
     assert(/^[A-Z]:\\/.test(realPath));
+    assert(realPath.endsWith(relativePath.replace(/\//g, "\\")));
   }
-  assert(realPath.endsWith(incompletePath));
 });
 
 unitTest(
@@ -72,13 +75,14 @@ unitTest(
     const symlink = testDir + "/symln";
     Deno.mkdirSync(target);
     Deno.symlinkSync(target, symlink);
-    const targetPath = await Deno.realPath(symlink);
+    const realPath = await Deno.realPath(symlink);
     if (Deno.build.os !== "windows") {
-      assert(targetPath.startsWith("/"));
+      assert(realPath.startsWith("/"));
+      assert(realPath.endsWith("/target"));
     } else {
-      assert(/^[A-Z]:\\/.test(targetPath));
+      assert(/^[A-Z]:\\/.test(realPath));
+      assert(realPath.endsWith("\\target"));
     }
-    assert(targetPath.endsWith("/target"));
   },
 );
 

--- a/cli/tests/unit/real_path_test.ts
+++ b/cli/tests/unit/real_path_test.ts
@@ -68,6 +68,8 @@ unitTest({ perms: { read: true } }, async function realPathSuccess(): Promise<
 
 unitTest(
   {
+    // TODO(nayeemrmn): Symlinks don't work as expected on Windows.
+    ignore: Deno.build.os === "windows",
     perms: { read: true, write: true },
   },
   async function realPathSymlink(): Promise<void> {


### PR DESCRIPTION
Fixes #5685.
Closes #6073.