### PR TITLE
refactor(cli/repl): tightly integrate event loop

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -63,7 +63,6 @@ use crate::file_fetcher::SourceFileFetcher;
 use crate::file_fetcher::TextDocument;
 use crate::fs as deno_fs;
 use crate::global_state::GlobalState;
-use crate::inspector::InspectorSession;
 use crate::media_type::MediaType;
 use crate::permissions::Permissions;
 use crate::worker::MainWorker;
@@ -432,26 +431,7 @@ async fn run_repl(flags: Flags) -> Result<(), AnyError> {
   let mut worker = MainWorker::new(&global_state, main_module.clone());
   (&mut *worker).await?;
 
-  let inspector = worker
-    .inspector
-    .as_mut()
-    .expect("Inspector is not created.");
-
-  let inspector_session = InspectorSession::new(&mut **inspector);
-  let repl = repl::run(&global_state, inspector_session);
-
-  tokio::pin!(repl);
-
-  loop {
-    tokio::select! {
-      result = &mut repl => {
-          return result;
-      }
-      _ = &mut *worker => {
-          tokio::time::delay_for(tokio::time::Duration::from_millis(10)).await;
-      }
-    }
-  }
+  repl::run(&global_state, worker).await
 }
 
 async fn run_from_stdin(flags: Flags) -> Result<(), AnyError> {

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -63,12 +63,18 @@ async fn read_line_and_poll(
 
   let mut poll_worker = true;
   loop {
+    let mut timeout =
+      tokio::time::delay_for(tokio::time::Duration::from_millis(1000));
+
     tokio::select! {
       result = &mut line => {
         return result.unwrap();
       }
       _ = &mut *worker, if poll_worker => {
-          poll_worker = false;
+        poll_worker = false;
+      }
+      _ = &mut timeout => {
+          poll_worker = true
       }
     }
   }

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -61,13 +61,14 @@ async fn read_line_and_poll(
   let mut line =
     tokio::task::spawn_blocking(move || editor.lock().unwrap().readline("> "));
 
+  let mut poll_worker = true;
   loop {
     tokio::select! {
       result = &mut line => {
         return result.unwrap();
       }
-      _ = &mut *worker => {
-        tokio::time::delay_for(tokio::time::Duration::from_millis(0)).await;
+      _ = &mut *worker, if poll_worker => {
+          poll_worker = false;
       }
     }
   }

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -48,6 +48,9 @@ async fn post_message_and_poll(
       }
 
       _ = &mut *worker => {
+        // A zero delay is long enough to yield the thread in order to prevent the loop from
+        // running hot for messages that are taking longer to resolve like for example an
+        // evaluation of top level await.
         tokio::time::delay_for(tokio::time::Duration::from_millis(0)).await;
       }
     }
@@ -63,6 +66,8 @@ async fn read_line_and_poll(
 
   let mut poll_worker = true;
   loop {
+    // Because an inspector websocket client may choose to connect at anytime when we have an
+    // inspector server we need to keep polling the worker to pick up new connections.
     let mut timeout =
       tokio::time::delay_for(tokio::time::Duration::from_millis(1000));
 

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -89,7 +89,7 @@ pub async fn run(
 
   let history_file = global_state.dir.root.join("deno_history.txt");
 
-  post_message_and_poll(&mut session, "Runtime.enable", None, &mut *worker)
+  post_message_and_poll(&mut *worker, &mut session, "Runtime.enable", None)
     .await?;
 
   let helper = Helper {

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -145,13 +145,14 @@ pub async fn run(
     });
   "#;
 
-  session
-    .post_message(
+  post_message_and_poll(
+      &mut session,
       "Runtime.evaluate".to_string(),
       Some(json!({
         "expression": prelude,
         "contextId": context_id,
       })),
+      &mut *worker,
     )
     .await?;
 

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -226,48 +226,48 @@ pub async fn run(
 
         if evaluate_exception_details.is_some() {
           post_message_and_poll(
-                  &mut *worker,
-                  &mut session,
-                  "Runtime.callFunctionOn",
-                  Some(json!({
-                    "executionContextId": context_id,
-                    "functionDeclaration": "function (object) { Deno[Deno.internal].lastThrownError = object; }",
-                    "arguments": [
-                      evaluate_result,
-                    ],
-                  })),
-                ).await?;
+            &mut *worker,
+            &mut session,
+            "Runtime.callFunctionOn",
+            Some(json!({
+              "executionContextId": context_id,
+              "functionDeclaration": "function (object) { Deno[Deno.internal].lastThrownError = object; }",
+              "arguments": [
+                evaluate_result,
+              ],
+            })),
+          ).await?;
         } else {
           post_message_and_poll(
-                  &mut *worker,
-                  &mut session,
-                  "Runtime.callFunctionOn",
-                  Some(json!({
-                    "executionContextId": context_id,
-                    "functionDeclaration": "function (object) { Deno[Deno.internal].lastEvalResult = object; }",
-                    "arguments": [
-                      evaluate_result,
-                    ],
-                  })),
-                ).await?;
+            &mut *worker,
+            &mut session,
+            "Runtime.callFunctionOn",
+            Some(json!({
+              "executionContextId": context_id,
+              "functionDeclaration": "function (object) { Deno[Deno.internal].lastEvalResult = object; }",
+              "arguments": [
+                evaluate_result,
+              ],
+            })),
+          ).await?;
         }
 
         // TODO(caspervonb) we should investigate using previews here but to keep things
         // consistent with the previous implementation we just get the preview result from
         // Deno.inspectArgs.
         let inspect_response =
-                post_message_and_poll(
-                  &mut *worker,
-                  &mut session,
-                  "Runtime.callFunctionOn",
-                  Some(json!({
-                    "executionContextId": context_id,
-                    "functionDeclaration": "function (object) { return Deno[Deno.internal].inspectArgs(['%o', object], { colors: true}); }",
-                    "arguments": [
-                      evaluate_result,
-                    ],
-                  })),
-                  ).await?;
+          post_message_and_poll(
+            &mut *worker,
+            &mut session,
+            "Runtime.callFunctionOn",
+            Some(json!({
+              "executionContextId": context_id,
+              "functionDeclaration": "function (object) { return Deno[Deno.internal].inspectArgs(['%o', object], { colors: true}); }",
+              "arguments": [
+                evaluate_result,
+              ],
+            })),
+          ).await?;
 
         let inspect_result = inspect_response.get("result").unwrap();
 

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -2,8 +2,11 @@
 
 use crate::global_state::GlobalState;
 use crate::inspector::InspectorSession;
+use crate::worker::MainWorker;
+use crate::worker::Worker;
 use deno_core::error::AnyError;
 use deno_core::serde_json::json;
+use deno_core::serde_json::Value;
 use rustyline::error::ReadlineError;
 use rustyline::validate::MatchingBracketValidator;
 use rustyline::validate::ValidationContext;
@@ -29,18 +32,70 @@ impl Validator for Helper {
   }
 }
 
+async fn post_message_and_poll(
+  session: &mut InspectorSession,
+  method: String,
+  params: Option<Value>,
+  worker: &mut Worker,
+) -> Result<Value, AnyError> {
+  let response = session.post_message(method, params);
+  tokio::pin!(response);
+
+  loop {
+    tokio::select! {
+      result = &mut response => {
+        return result
+      }
+
+      _ = &mut *worker => {
+        tokio::time::delay_for(tokio::time::Duration::from_millis(0)).await;
+      }
+    }
+  }
+}
+
+async fn read_line_and_poll(
+  editor: Arc<Mutex<Editor<Helper>>>,
+  worker: &mut Worker,
+) -> Result<String, ReadlineError> {
+  let mut line =
+    tokio::task::spawn_blocking(move || editor.lock().unwrap().readline("> "));
+
+  loop {
+    tokio::select! {
+      result = &mut line => {
+        return result.unwrap();
+      }
+      _ = &mut *worker => {
+        return line.await.unwrap();
+      }
+    }
+  }
+}
+
 pub async fn run(
   global_state: &GlobalState,
-  mut session: Box<InspectorSession>,
+  mut worker: MainWorker,
 ) -> Result<(), AnyError> {
   // Our inspector is unable to default to the default context id so we have to specify it here.
   let context_id: u32 = 1;
 
+  let inspector = worker
+    .inspector
+    .as_mut()
+    .expect("Inspector is not created.");
+
+  let mut session = InspectorSession::new(&mut **inspector);
+
   let history_file = global_state.dir.root.join("deno_history.txt");
 
-  session
-    .post_message("Runtime.enable".to_string(), None)
-    .await?;
+  post_message_and_poll(
+    &mut session,
+    "Runtime.enable".to_string(),
+    None,
+    &mut *worker,
+  )
+  .await?;
 
   let helper = Helper {
     validator: MatchingBracketValidator::new(),
@@ -101,12 +156,7 @@ pub async fn run(
     .await?;
 
   loop {
-    let editor2 = editor.clone();
-    let line = tokio::task::spawn_blocking(move || {
-      editor2.lock().unwrap().readline("> ")
-    })
-    .await?;
-
+    let line = read_line_and_poll(editor.clone(), &mut *worker).await;
     match line {
       Ok(line) => {
         // It is a bit unexpected that { "foo": "bar" } is interpreted as a block
@@ -120,16 +170,17 @@ pub async fn run(
           line.clone()
         };
 
-        let evaluate_response = session
-          .post_message(
-            "Runtime.evaluate".to_string(),
-            Some(json!({
-              "expression": format!("'use strict'; void 0;\n{}", &wrapped_line),
-              "contextId": context_id,
-              "replMode": true,
-            })),
-          )
-          .await?;
+        let evaluate_response = post_message_and_poll(
+          &mut session,
+          "Runtime.evaluate".to_string(),
+          Some(json!({
+            "expression": format!("'use strict'; void 0;\n{}", &wrapped_line),
+            "contextId": context_id,
+            "replMode": true,
+          })),
+          &mut *worker,
+        )
+        .await?;
 
         // If that fails, we retry it without wrapping in parens letting the error bubble up to the
         // user if it is still an error.
@@ -137,35 +188,37 @@ pub async fn run(
           if evaluate_response.get("exceptionDetails").is_some()
             && wrapped_line != line
           {
-            session
-              .post_message(
-                "Runtime.evaluate".to_string(),
-                Some(json!({
-                  "expression": format!("'use strict'; void 0;\n{}", &line),
-                  "contextId": context_id,
-                  "replMode": true,
-                })),
-              )
-              .await?
+            post_message_and_poll(
+              &mut session,
+              "Runtime.evaluate".to_string(),
+              Some(json!({
+                "expression": format!("'use strict'; void 0;\n{}", &line),
+                "contextId": context_id,
+                "replMode": true,
+              })),
+              &mut *worker,
+            )
+            .await?
           } else {
             evaluate_response
           };
 
-        let is_closing = session
-          .post_message(
-            "Runtime.evaluate".to_string(),
-            Some(json!({
-              "expression": "(globalThis.closed)",
-              "contextId": context_id,
-            })),
-          )
-          .await?
-          .get("result")
-          .unwrap()
-          .get("value")
-          .unwrap()
-          .as_bool()
-          .unwrap();
+        let is_closing = post_message_and_poll(
+          &mut session,
+          "Runtime.evaluate".to_string(),
+          Some(json!({
+            "expression": "(globalThis.closed)",
+            "contextId": context_id,
+          })),
+          &mut *worker,
+        )
+        .await?
+        .get("result")
+        .unwrap()
+        .get("value")
+        .unwrap()
+        .as_bool()
+        .unwrap();
 
         if is_closing {
           break;
@@ -176,42 +229,47 @@ pub async fn run(
           evaluate_response.get("exceptionDetails");
 
         if evaluate_exception_details.is_some() {
-          session
-            .post_message(
-            "Runtime.callFunctionOn".to_string(),
-            Some(json!({
-              "executionContextId": context_id,
-              "functionDeclaration": "function (object) { Deno[Deno.internal].lastThrownError = object; }",
-              "arguments": [
-                evaluate_result,
-              ],
-            }))).await?;
+          post_message_and_poll(
+                  &mut session,
+                  "Runtime.callFunctionOn".to_string(),
+                  Some(json!({
+                    "executionContextId": context_id,
+                    "functionDeclaration": "function (object) { Deno[Deno.internal].lastThrownError = object; }",
+                    "arguments": [
+                      evaluate_result,
+                    ],
+                  })),
+                  &mut *worker,
+                ).await?;
         } else {
-          session
-            .post_message(
-            "Runtime.callFunctionOn".to_string(),
-            Some(json!({
-              "executionContextId": context_id,
-              "functionDeclaration": "function (object) { Deno[Deno.internal].lastEvalResult = object; }",
-              "arguments": [
-                evaluate_result,
-              ],
-            }))).await?;
+          post_message_and_poll(
+                  &mut session,
+                  "Runtime.callFunctionOn".to_string(),
+                  Some(json!({
+                    "executionContextId": context_id,
+                    "functionDeclaration": "function (object) { Deno[Deno.internal].lastEvalResult = object; }",
+                    "arguments": [
+                      evaluate_result,
+                    ],
+                  })),
+                  &mut *worker,
+                ).await?;
         }
 
         // TODO(caspervonb) we should investigate using previews here but to keep things
         // consistent with the previous implementation we just get the preview result from
         // Deno.inspectArgs.
-        let inspect_response = session
-          .post_message(
-            "Runtime.callFunctionOn".to_string(),
-            Some(json!({
-              "executionContextId": context_id,
-              "functionDeclaration": "function (object) { return Deno[Deno.internal].inspectArgs(['%o', object], { colors: true}); }",
-              "arguments": [
-                evaluate_result,
-              ],
-            }))).await?;
+        let inspect_response =
+                post_message_and_poll(&mut session,
+                  "Runtime.callFunctionOn".to_string(),
+                  Some(json!({
+                    "executionContextId": context_id,
+                    "functionDeclaration": "function (object) { return Deno[Deno.internal].inspectArgs(['%o', object], { colors: true}); }",
+                    "arguments": [
+                      evaluate_result,
+                    ],
+                  })),
+                  &mut *worker).await?;
 
         let inspect_result = inspect_response.get("result").unwrap();
 

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -67,7 +67,7 @@ async fn read_line_and_poll(
         return result.unwrap();
       }
       _ = &mut *worker => {
-        return line.await.unwrap();
+        tokio::time::delay_for(tokio::time::Duration::from_millis(0)).await;
       }
     }
   }


### PR DESCRIPTION
This tightly integrates the event loop into the repl event loop for more control over it so it doesn't have to spin wildly outside of the inner loop for us to get the inspector to pump.