### PR TITLE
feat(std/node/fs): allow appendFileSync to accept Uint8Array as type for data

### DIFF
--- a/std/node/_fs/_fs_appendFile.ts
+++ b/std/node/_fs/_fs_appendFile.ts
@@ -15,7 +15,7 @@ import { fromFileUrl } from "../path.ts";
  */
 export function appendFile(
   pathOrRid: string | number | URL,
-  data: string,
+  data: string | Uint8Array,
   optionsOrCallback: Encodings | WriteFileOptions | CallbackWithError,
   callback?: CallbackWithError,
 ): void {
@@ -30,7 +30,9 @@ export function appendFile(
 
   validateEncoding(options);
   let rid = -1;
-  const buffer: Uint8Array = new TextEncoder().encode(data);
+  const buffer: Uint8Array = data instanceof Uint8Array
+    ? data
+    : new TextEncoder().encode(data);
   new Promise((resolve, reject) => {
     if (typeof pathOrRid === "number") {
       rid = pathOrRid;
@@ -79,7 +81,7 @@ function closeRidIfNecessary(isPathString: boolean, rid: number): void {
  */
 export function appendFileSync(
   pathOrRid: string | number | URL,
-  data: string,
+  data: string | Uint8Array,
   options?: Encodings | WriteFileOptions,
 ): void {
   let rid = -1;
@@ -107,7 +109,9 @@ export function appendFileSync(
       rid = file.rid;
     }
 
-    const buffer: Uint8Array = new TextEncoder().encode(data);
+    const buffer: Uint8Array = data instanceof Uint8Array
+      ? data
+      : new TextEncoder().encode(data);
 
     Deno.writeSync(rid, buffer);
   } finally {

--- a/std/node/_fs/_fs_appendFile_test.ts
+++ b/std/node/_fs/_fs_appendFile_test.ts
@@ -206,3 +206,41 @@ Deno.test({
     Deno.removeSync(tempFile);
   },
 });
+
+Deno.test({
+  name: "Sync: Data is written in Uint8Array to passed in file path",
+  fn() {
+    const openResourcesBeforeAppend: Deno.ResourceMap = Deno.resources();
+    const test_data = new TextEncoder().encode("hello world");
+    appendFileSync("_fs_appendFile_test_file_sync.txt", test_data);
+    assertEquals(Deno.resources(), openResourcesBeforeAppend);
+    const data = Deno.readFileSync("_fs_appendFile_test_file_sync.txt");
+    assertEquals(data, test_data);
+    Deno.removeSync("_fs_appendFile_test_file_sync.txt");
+  },
+});
+
+Deno.test({
+  name: "Async: Data is written in Uint8Array to passed in file path",
+  async fn() {
+    const openResourcesBeforeAppend: Deno.ResourceMap = Deno.resources();
+    const test_data = new TextEncoder().encode("hello world");
+    await new Promise((resolve, reject) => {
+      appendFile("_fs_appendFile_test_file.txt", test_data, (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    })
+      .then(async () => {
+        assertEquals(Deno.resources(), openResourcesBeforeAppend);
+        const data = await Deno.readFile("_fs_appendFile_test_file.txt");
+        assertEquals(data, test_data);
+      })
+      .catch((err) => {
+        fail("No error was expected: " + err);
+      })
+      .finally(async () => {
+        await Deno.remove("_fs_appendFile_test_file.txt");
+      });
+  },
+});


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
this makes appendFileSync to accept Uint8Array as type for data