### PR TITLE
refactor(cli/inspector): use &str for post_message

### DIFF
--- a/cli/coverage.rs
+++ b/cli/coverage.rs
@@ -20,15 +20,9 @@ impl CoverageCollector {
   }
 
   pub async fn start_collecting(&mut self) -> Result<(), AnyError> {
-    self
-      .session
-      .post_message("Debugger.enable", None)
-      .await?;
+    self.session.post_message("Debugger.enable", None).await?;
 
-    self
-      .session
-      .post_message("Profiler.enable", None)
-      .await?;
+    self.session.post_message("Profiler.enable", None).await?;
 
     self
       .session
@@ -79,14 +73,8 @@ impl CoverageCollector {
       .session
       .post_message("Profiler.stopPreciseCoverage", None)
       .await?;
-    self
-      .session
-      .post_message("Profiler.disable", None)
-      .await?;
-    self
-      .session
-      .post_message("Debugger.disable", None)
-      .await?;
+    self.session.post_message("Profiler.disable", None).await?;
+    self.session.post_message("Debugger.disable", None).await?;
 
     Ok(())
   }

--- a/cli/coverage.rs
+++ b/cli/coverage.rs
@@ -22,18 +22,18 @@ impl CoverageCollector {
   pub async fn start_collecting(&mut self) -> Result<(), AnyError> {
     self
       .session
-      .post_message("Debugger.enable".to_string(), None)
+      .post_message("Debugger.enable", None)
       .await?;
 
     self
       .session
-      .post_message("Profiler.enable".to_string(), None)
+      .post_message("Profiler.enable", None)
       .await?;
 
     self
       .session
       .post_message(
-        "Profiler.startPreciseCoverage".to_string(),
+        "Profiler.startPreciseCoverage",
         Some(json!({"callCount": true, "detailed": true})),
       )
       .await?;
@@ -44,7 +44,7 @@ impl CoverageCollector {
   pub async fn collect(&mut self) -> Result<Vec<Coverage>, AnyError> {
     let result = self
       .session
-      .post_message("Profiler.takePreciseCoverage".to_string(), None)
+      .post_message("Profiler.takePreciseCoverage", None)
       .await?;
 
     let take_coverage_result: TakePreciseCoverageResult =
@@ -55,7 +55,7 @@ impl CoverageCollector {
       let result = self
         .session
         .post_message(
-          "Debugger.getScriptSource".to_string(),
+          "Debugger.getScriptSource",
           Some(json!({
               "scriptId": script_coverage.script_id,
           })),
@@ -77,15 +77,15 @@ impl CoverageCollector {
   pub async fn stop_collecting(&mut self) -> Result<(), AnyError> {
     self
       .session
-      .post_message("Profiler.stopPreciseCoverage".to_string(), None)
+      .post_message("Profiler.stopPreciseCoverage", None)
       .await?;
     self
       .session
-      .post_message("Profiler.disable".to_string(), None)
+      .post_message("Profiler.disable", None)
       .await?;
     self
       .session
-      .post_message("Debugger.disable".to_string(), None)
+      .post_message("Debugger.disable", None)
       .await?;
 
     Ok(())

--- a/cli/inspector.rs
+++ b/cli/inspector.rs
@@ -901,7 +901,7 @@ impl InspectorSession {
 
   pub async fn post_message(
     &mut self,
-    method: String,
+    method: &str,
     params: Option<serde_json::Value>,
   ) -> Result<serde_json::Value, AnyError> {
     let id = self.next_message_id;

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -38,7 +38,7 @@ async fn post_message_and_poll(
   method: &str,
   params: Option<Value>,
 ) -> Result<Value, AnyError> {
-  let response = session.post_message(method.to_string(), params);
+  let response = session.post_message(method, params);
   tokio::pin!(response);
 
   loop {


### PR DESCRIPTION
This changes the signature of InspectorSession.post_message to take a `&str` rather than a `String` avoiding the need call `str.to_string` at each call site.