### PR TITLE
refactor(core): JsRuntime is not a Future

### DIFF
--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -240,7 +240,7 @@ impl Future for Worker {
     // We always poll the inspector if it exists.
     let _ = inner.inspector.as_mut().map(|i| i.poll_unpin(cx));
     inner.waker.register(cx.waker());
-    inner.isolate.poll_unpin(cx)
+    inner.isolate.poll_event_loop(cx)
   }
 }
 

--- a/core/README.md
+++ b/core/README.md
@@ -9,9 +9,12 @@ bindings.
 
 This Rust crate contains the essential V8 bindings for Deno's command-line
 interface (Deno CLI). The main abstraction here is the JsRuntime which provides
-a way to execute JavaScript. The JsRuntime is modeled as a
-`Future<Item=(), Error=JsError>` which completes once all of its ops have
-completed.
+a way to execute JavaScript.
+
+The JsRuntime implements an event loop abstraction for the executed code that
+keeps track of all pending tasks (async ops, dynamic module loads). It is user's
+responsibility to drive that loop by using `JsRuntime::run_event_loop` method -
+it must be executed in the context of Rust's future executor (eg. tokio, smol).
 
 In order to bind Rust functions into JavaScript, use the `Deno.core.dispatch()`
 function to trigger the "dispatch" callback in Rust. The user is responsible for

--- a/core/examples/http_bench_bin_ops.rs
+++ b/core/examples/http_bench_bin_ops.rs
@@ -260,7 +260,7 @@ fn main() {
         include_str!("http_bench_bin_ops.js"),
       )
       .unwrap();
-    isolate.await
+    isolate.run_event_loop().await
   };
   runtime.block_on(future).unwrap();
 }

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -193,7 +193,7 @@ fn main() {
         include_str!("http_bench_json_ops.js"),
       )
       .unwrap();
-    isolate.await
+    isolate.run_event_loop().await
   };
   runtime.block_on(future).unwrap();
 }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -477,7 +477,7 @@ impl JsRuntime {
     }
 
     // Top level modules
-    self.poll_mod_evaluate(cx)?;
+    self.evaluate_pending_modules()?;
 
     // Dynamic module loading - ie. modules loaded using "import()"
     {
@@ -487,7 +487,7 @@ impl JsRuntime {
       let poll_imports = self.poll_dyn_imports(cx)?;
       assert!(poll_imports.is_ready());
 
-      self.poll_dyn_imports_evaluate(cx)?;
+      self.evaluate_dyn_imports()?;
 
       self.check_promise_exceptions()?;
     }
@@ -1038,7 +1038,7 @@ impl JsRuntime {
     }
   }
 
-  fn poll_mod_evaluate(&mut self, _cx: &mut Context) -> Result<(), AnyError> {
+  fn evaluate_pending_modules(&mut self) -> Result<(), AnyError> {
     let state_rc = Self::state(self.v8_isolate());
 
     let context = self.global_context();
@@ -1082,10 +1082,7 @@ impl JsRuntime {
     Ok(())
   }
 
-  fn poll_dyn_imports_evaluate(
-    &mut self,
-    _cx: &mut Context,
-  ) -> Result<(), AnyError> {
+  fn evaluate_dyn_imports(&mut self) -> Result<(), AnyError> {
     let state_rc = Self::state(self.v8_isolate());
 
     loop {

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -455,6 +455,10 @@ impl JsRuntime {
   }
 
   /// Runs event loop to completion
+  ///
+  /// This future resolves when:
+  ///  - there are no more pending dynamic imports
+  ///  - there are no more pending ops
   pub async fn run_event_loop(&mut self) -> Result<(), AnyError> {
     poll_fn(|cx| self.poll_event_loop(cx)).await
   }

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -75,7 +75,6 @@ pub fn get_declaration() -> PathBuf {
 mod tests {
   use deno_core::JsRuntime;
   use futures::future::lazy;
-  use futures::future::FutureExt;
   use futures::task::Context;
   use futures::task::Poll;
 
@@ -102,7 +101,7 @@ mod tests {
           include_str!("abort_controller_test.js"),
         )
         .unwrap();
-      if let Poll::Ready(Err(_)) = isolate.poll_unpin(&mut cx) {
+      if let Poll::Ready(Err(_)) = isolate.poll_event_loop(&mut cx) {
         unreachable!();
       }
     });
@@ -115,7 +114,7 @@ mod tests {
       isolate
         .execute("event_test.js", include_str!("event_test.js"))
         .unwrap();
-      if let Poll::Ready(Err(_)) = isolate.poll_unpin(&mut cx) {
+      if let Poll::Ready(Err(_)) = isolate.poll_event_loop(&mut cx) {
         unreachable!();
       }
     });
@@ -134,7 +133,7 @@ mod tests {
       } else {
         unreachable!();
       }
-      if let Poll::Ready(Err(_)) = isolate.poll_unpin(&mut cx) {
+      if let Poll::Ready(Err(_)) = isolate.poll_event_loop(&mut cx) {
         unreachable!();
       }
     });
@@ -147,7 +146,7 @@ mod tests {
       isolate
         .execute("event_target_test.js", include_str!("event_target_test.js"))
         .unwrap();
-      if let Poll::Ready(Err(_)) = isolate.poll_unpin(&mut cx) {
+      if let Poll::Ready(Err(_)) = isolate.poll_event_loop(&mut cx) {
         unreachable!();
       }
     });
@@ -163,7 +162,7 @@ mod tests {
           include_str!("text_encoding_test.js"),
         )
         .unwrap();
-      if let Poll::Ready(Err(_)) = isolate.poll_unpin(&mut cx) {
+      if let Poll::Ready(Err(_)) = isolate.poll_event_loop(&mut cx) {
         unreachable!();
       }
     });


### PR DESCRIPTION
This commit rewrites deno_core::JsRuntime to not implement Future
trait.

Instead there are two separate methods:
- JsRuntime::poll_event_loop() - does single tick of event loop
- JsRuntime::run_event_loop() - runs event loop to completion
