### PR TITLE
refactor: rename isolate to js_runtime

### DIFF
--- a/cli/inspector.rs
+++ b/cli/inspector.rs
@@ -390,11 +390,11 @@ impl DenoInspector {
   const CONTEXT_GROUP_ID: i32 = 1;
 
   pub fn new(
-    isolate: &mut deno_core::JsRuntime,
+    js_runtime: &mut deno_core::JsRuntime,
     server: Option<Arc<InspectorServer>>,
   ) -> Box<Self> {
-    let context = isolate.global_context();
-    let scope = &mut v8::HandleScope::new(isolate.v8_isolate());
+    let context = js_runtime.global_context();
+    let scope = &mut v8::HandleScope::new(js_runtime.v8_isolate());
 
     let (new_websocket_tx, new_websocket_rx) =
       mpsc::unbounded::<WebSocketProxy>();

--- a/cli/js.rs
+++ b/cli/js.rs
@@ -30,11 +30,11 @@ pub fn compiler_isolate_init() -> Snapshot {
 
 #[test]
 fn cli_snapshot() {
-  let mut isolate = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
+  let mut js_runtime = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
     startup_snapshot: Some(deno_isolate_init()),
     ..Default::default()
   });
-  isolate
+  js_runtime
     .execute(
       "<anon>",
       r#"
@@ -49,11 +49,11 @@ fn cli_snapshot() {
 
 #[test]
 fn compiler_snapshot() {
-  let mut isolate = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
+  let mut js_runtime = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
     startup_snapshot: Some(compiler_isolate_init()),
     ..Default::default()
   });
-  isolate
+  js_runtime
     .execute(
       "<anon>",
       r#"

--- a/cli/ops/worker_host.rs
+++ b/cli/ops/worker_host.rs
@@ -62,7 +62,7 @@ fn create_web_worker(
   );
 
   if has_deno_namespace {
-    let state = worker.isolate.op_state();
+    let state = worker.js_runtime.op_state();
     let mut state = state.borrow_mut();
     let (stdin, stdout, stderr) = get_stdio();
     if let Some(stream) = stdin {

--- a/core/examples/http_bench_bin_ops.rs
+++ b/core/examples/http_bench_bin_ops.rs
@@ -76,14 +76,14 @@ impl From<Record> for RecordBuf {
   }
 }
 
-fn create_isolate() -> JsRuntime {
-  let mut isolate = JsRuntime::new(Default::default());
-  register_op_bin_sync(&mut isolate, "listen", op_listen);
-  register_op_bin_sync(&mut isolate, "close", op_close);
-  register_op_bin_async(&mut isolate, "accept", op_accept);
-  register_op_bin_async(&mut isolate, "read", op_read);
-  register_op_bin_async(&mut isolate, "write", op_write);
-  isolate
+fn create_js_runtime() -> JsRuntime {
+  let mut js_runtime = JsRuntime::new(Default::default());
+  register_op_bin_sync(&mut js_runtime, "listen", op_listen);
+  register_op_bin_sync(&mut js_runtime, "close", op_close);
+  register_op_bin_async(&mut js_runtime, "accept", op_accept);
+  register_op_bin_async(&mut js_runtime, "read", op_read);
+  register_op_bin_async(&mut js_runtime, "write", op_write);
+  js_runtime
 }
 
 fn op_listen(
@@ -172,7 +172,7 @@ fn op_write(
 }
 
 fn register_op_bin_sync<F>(
-  isolate: &mut JsRuntime,
+  js_runtime: &mut JsRuntime,
   name: &'static str,
   op_fn: F,
 ) where
@@ -193,11 +193,11 @@ fn register_op_bin_sync<F>(
     Op::Sync(buf)
   };
 
-  isolate.register_op(name, base_op_fn);
+  js_runtime.register_op(name, base_op_fn);
 }
 
 fn register_op_bin_async<F, R>(
-  isolate: &mut JsRuntime,
+  js_runtime: &mut JsRuntime,
   name: &'static str,
   op_fn: F,
 ) where
@@ -227,7 +227,7 @@ fn register_op_bin_async<F, R>(
     Op::Async(fut.boxed_local())
   };
 
-  isolate.register_op(name, base_op_fn);
+  js_runtime.register_op(name, base_op_fn);
 }
 
 fn bad_resource_id() -> Error {
@@ -246,7 +246,7 @@ fn main() {
   // NOTE: `--help` arg will display V8 help and exit
   deno_core::v8_set_flags(env::args().collect());
 
-  let mut isolate = create_isolate();
+  let mut js_runtime = create_js_runtime();
   let mut runtime = runtime::Builder::new()
     .basic_scheduler()
     .enable_all()
@@ -254,13 +254,13 @@ fn main() {
     .unwrap();
 
   let future = async move {
-    isolate
+    js_runtime
       .execute(
         "http_bench_bin_ops.js",
         include_str!("http_bench_bin_ops.js"),
       )
       .unwrap();
-    isolate.await
+    js_runtime.await
   };
   runtime.block_on(future).unwrap();
 }

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -41,7 +41,7 @@ impl log::Log for Logger {
   fn flush(&self) {}
 }
 
-fn create_isolate() -> JsRuntime {
+fn create_js_runtime() -> JsRuntime {
   let mut runtime = JsRuntime::new(Default::default());
   runtime.register_op("listen", deno_core::json_op_sync(op_listen));
   runtime.register_op("close", deno_core::json_op_sync(op_close));
@@ -179,7 +179,7 @@ fn main() {
   // NOTE: `--help` arg will display V8 help and exit
   deno_core::v8_set_flags(env::args().collect());
 
-  let mut isolate = create_isolate();
+  let mut js_runtime = create_js_runtime();
   let mut runtime = runtime::Builder::new()
     .basic_scheduler()
     .enable_all()
@@ -187,13 +187,13 @@ fn main() {
     .unwrap();
 
   let future = async move {
-    isolate
+    js_runtime
       .execute(
         "http_bench_json_ops.js",
         include_str!("http_bench_json_ops.js"),
       )
       .unwrap();
-    isolate.await
+    js_runtime.await
   };
   runtime.block_on(future).unwrap();
 }


### PR DESCRIPTION
This commit renames occurrences of "isolate" variable name
to "js_runtime". This was outstanding debt after renaming
deno_core::CoreIsolate to JsRuntime.

Ref https://github.com/denoland/deno/pull/7853#discussion_r500921719
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.py` passes without changing files.
6. Ensure `./tools/lint.py` passes.
-->
