### PR TITLE
fix(cli/rt/error_stack): Improve message line formatting

### DIFF
--- a/cli/rt/40_error_stack.js
+++ b/cli/rt/40_error_stack.js
@@ -221,12 +221,18 @@
       formattedCallSites.push(formatCallSite(callSite));
     }
     Object.freeze(error.__callSiteEvals);
-    return (
-      `${error.name}: ${error.message}\n` +
-      formattedCallSites
-        .map((s) => `    at ${s}`)
-        .join("\n")
-    );
+    const message = error.message !== undefined ? error.message : "";
+    const name = error.name !== undefined ? error.name : "Error";
+    let messageLine;
+    if (name != "" && message != "") {
+      messageLine = `${name}: ${message}`;
+    } else if ((name || message) != "") {
+      messageLine = name || message;
+    } else {
+      messageLine = "";
+    }
+    return messageLine +
+      formattedCallSites.map((s) => `\n    at ${s}`).join("");
   }
 
   function setPrepareStackTrace(ErrorConstructor) {

--- a/cli/tests/error_014_catch_dynamic_import_error.js.out
+++ b/cli/tests/error_014_catch_dynamic_import_error.js.out
@@ -1,9 +1,7 @@
 Caught direct dynamic import error.
 TypeError: relative import path "does not exist" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/error_014_catch_dynamic_import_error.js"
-
 Caught indirect direct dynamic import error.
 TypeError: relative import path "does not exist either" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/indirect_import_error.js"
-
 Caught error thrown by dynamically imported module.
 Error: An error
     at file:///[WILDCARD]tests/subdir/throws.js:6:7

--- a/cli/tests/unit/error_stack_test.ts
+++ b/cli/tests/unit/error_stack_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals, unitTest } from "./test_util.ts";
+import { assert, assertEquals, assertMatch, unitTest } from "./test_util.ts";
 
 // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
 const { setPrepareStackTrace } = Deno[Deno.internal];
@@ -81,6 +81,46 @@ function getMockCallSite(
     },
   };
 }
+
+unitTest(function errorStackMessageLine(): void {
+  const e1 = new Error();
+  e1.name = "Foo";
+  e1.message = "bar";
+  assertMatch(e1.stack!, /^Foo: bar\n/);
+
+  const e2 = new Error();
+  e2.name = "";
+  e2.message = "bar";
+  assertMatch(e2.stack!, /^bar\n/);
+
+  const e3 = new Error();
+  e3.name = "Foo";
+  e3.message = "";
+  assertMatch(e3.stack!, /^Foo\n/);
+
+  const e4 = new Error();
+  e4.name = "";
+  e4.message = "";
+  assertMatch(e4.stack!, /^\n/);
+
+  const e5 = new Error();
+  // deno-lint-ignore ban-ts-comment
+  // @ts-expect-error
+  e5.name = undefined;
+  // deno-lint-ignore ban-ts-comment
+  // @ts-expect-error
+  e5.message = undefined;
+  assertMatch(e5.stack!, /^Error\n/);
+
+  const e6 = new Error();
+  // deno-lint-ignore ban-ts-comment
+  // @ts-expect-error
+  e6.name = null;
+  // deno-lint-ignore ban-ts-comment
+  // @ts-expect-error
+  e6.message = null;
+  assertMatch(e6.stack!, /^null: null\n/);
+});
 
 // FIXME(bartlomieju): no longer works after migrating
 // to JavaScript runtime code

--- a/core/error.rs
+++ b/core/error.rs
@@ -174,14 +174,24 @@ impl JsError {
 
       // Get the message by formatting error.name and error.message.
       let name = get_property(scope, exception, "name")
+        .filter(|v| !v.is_undefined())
         .and_then(|m| m.to_string(scope))
         .map(|s| s.to_rust_string_lossy(scope))
-        .unwrap_or_else(|| "undefined".to_string());
+        .unwrap_or_else(|| "Error".to_string());
       let message_prop = get_property(scope, exception, "message")
+        .filter(|v| !v.is_undefined())
         .and_then(|m| m.to_string(scope))
         .map(|s| s.to_rust_string_lossy(scope))
-        .unwrap_or_else(|| "undefined".to_string());
-      let message = format!("Uncaught {}: {}", name, message_prop);
+        .unwrap_or_else(|| "".to_string());
+      let message = if name != "" && message_prop != "" {
+        format!("Uncaught {}: {}", name, message_prop)
+      } else if name != "" {
+        format!("Uncaught {}", name)
+      } else if message_prop != "" {
+        format!("Uncaught {}", message_prop)
+      } else {
+        "Uncaught".to_string()
+      };
 
       // Access error.stack to ensure that prepareStackTrace() has been called.
       // This should populate error.__callSiteEvals.


### PR DESCRIPTION
Matches browsers.

Example:
```ts
const error = new Error();
error.name = undefined;
error.message = undefined;
console.log(error.stack);

// Before:
// undefined: undefined
//     at ...

// After:
// Error
//     at ...
```