### PR TITLE
fix(cli/rt/console): Don't require a prototype to detect a class instance

### DIFF
--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -175,18 +175,13 @@
   /* eslint-disable @typescript-eslint/no-use-before-define */
 
   function getClassInstanceName(instance) {
-    if (typeof instance !== "object") {
+    if (typeof instance != "object") {
       return "";
     }
-    if (!instance) {
-      return "";
+    const constructor = instance?.constructor;
+    if (typeof constructor == "function") {
+      return constructor.name ?? "";
     }
-
-    const proto = Object.getPrototypeOf(instance);
-    if (proto && proto.constructor) {
-      return proto.constructor.name; // could be "Object" or "Array"
-    }
-
     return "";
   }
 

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1506,6 +1506,11 @@ unitTest(function inspectGetterError(): void {
   );
 });
 
+unitTest(function inspectPrototype(): void {
+  class A {}
+  assertEquals(Deno.inspect(A.prototype), "A {}");
+});
+
 unitTest(function inspectSorted(): void {
   assertEquals(
     stripColor(Deno.inspect({ b: 2, a: 1 }, { sorted: true })),

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -302,7 +302,7 @@ unitTest(function consoleTestStringifyCircular(): void {
     stringify(new Uint8Array([1, 2, 3])),
     "Uint8Array(3) [ 1, 2, 3 ]",
   );
-  assertEquals(stringify(Uint8Array.prototype), "TypedArray {}");
+  assertEquals(stringify(Uint8Array.prototype), "Uint8Array {}");
   assertEquals(
     stringify({ a: { b: { c: { d: new Set([1]) } } } }),
     "{ a: { b: { c: { d: [Set] } } } }",
@@ -832,7 +832,7 @@ unitTest(function consoleTestWithCustomInspectorError(): void {
   assertEquals(stringify(new B({ a: "a" })), "a");
   assertEquals(
     stringify(B.prototype),
-    "{ [Symbol(Deno.customInspect)]: [Function: [Deno.customInspect]] }",
+    "B { [Symbol(Deno.customInspect)]: [Function: [Deno.customInspect]] }",
   );
 });
 


### PR DESCRIPTION
Matches Node.
```ts
class A {}
console.log(A.prototype);
// Before:
// {}
// After:
// A {}
```