### PR TITLE
docs(core): concepts around runtime, ops and resources

### DIFF
--- a/core/ops.rs
+++ b/core/ops.rs
@@ -31,6 +31,7 @@ pub enum Op {
   NotFound,
 }
 
+/// Maintains the resources and ops inside a JS runtime.
 pub struct OpState {
   pub resource_table: crate::ResourceTable,
   pub op_table: OpTable,
@@ -151,6 +152,29 @@ fn op_table() {
   )
 }
 
+/// Creates an op that passes data synchronously using JSON.
+///
+/// The provided function `op_fn` has the following parameters:
+/// * `&mut OpState`: the op state, can be used to read/write resources in the runtime from an op.
+/// * `Value`: the JSON value that is passed to the Rust function.
+/// * `&mut [ZeroCopyBuf]`: raw bytes passed along, usually not needed if the JSON value is used.
+///
+/// `op_fn` returns a JSON value, which is directly returned to JavaScript.
+///
+/// When registering an op like this...
+/// ```ignore
+/// let mut runtime = JsRuntime::new(...);
+/// runtime.register_op("hello", deno_core::json_op_sync(Self::hello_op));
+/// ```
+///
+/// ...it can be invoked from JS using the provided name, for example:
+/// ```js
+/// Deno.core.ops();
+/// let result = Deno.core.jsonOpSync("function_name", args);
+/// ```
+///
+/// The `Deno.core.ops()` statement is needed once before any op calls, for initialization.
+/// A more complete example is available in the examples directory.
 pub fn json_op_sync<F>(op_fn: F) -> Box<OpFn>
 where
   F: Fn(&mut OpState, Value, &mut [ZeroCopyBuf]) -> Result<Value, AnyError>
@@ -166,6 +190,30 @@ where
   })
 }
 
+/// Creates an op that passes data asynchronously using JSON.
+///
+/// The provided function `op_fn` has the following parameters:
+/// * `Rc<RefCell<OpState>`: the op state, can be used to read/write resources in the runtime from an op.
+/// * `Value`: the JSON value that is passed to the Rust function.
+/// * `BufVec`: raw bytes passed along, usually not needed if the JSON value is used.
+///
+/// `op_fn` returns a future, whose output is a JSON value. This value will be asynchronously
+/// returned to JavaScript.
+///
+/// When registering an op like this...
+/// ```ignore
+/// let mut runtime = JsRuntime::new(...);
+/// runtime.register_op("hello", deno_core::json_op_async(Self::hello_op));
+/// ```
+///
+/// ...it can be invoked from JS using the provided name, for example:
+/// ```js
+/// Deno.core.ops();
+/// let future = Deno.core.jsonOpAsync("function_name", args);
+/// ```
+///
+/// The `Deno.core.ops()` statement is needed once before any op calls, for initialization.
+/// A more complete example is available in the examples directory.
 pub fn json_op_async<F, R>(op_fn: F) -> Box<OpFn>
 where
   F: Fn(Rc<RefCell<OpState>>, Value, BufVec) -> R + 'static,


### PR DESCRIPTION
A while ago I started using `deno_core` and struggled with the lack of documentation. Fortunately I got excellent explanations from the developers on Discord, so I thought it might be a good time to contribute back.

I focused the documentation on the parts that I considered important to get a basic example in `deno_core` working. So there are still more APIs to be documented, but at this time I don't have enough knowledge to do that.

There are probably quite a few concepts that can be worded/explained better, so feel free to give feedback!

-----

By the way, I had some trouble running the Python scripts `format.py` and `lint.py` on Windows.
<details>
  <summary>Python</summary>
 
First issue:
```
Traceback (most recent call last):
  File "format.py", line 89, in <module>
    sys.exit(main())
  File "format.py", line 51, in main
    dprint()
  File "format.py", line 59, in dprint
    run(command, shell=False, quiet=True)
  File "C:\Rust\deno\tools\util.py", line 62, in run
    rc = subprocess.call(args, cwd=cwd, env=env, shell=shell)
  File "C:\...\Python38\lib\subprocess.py", line 340, in call
    with Popen(*popenargs, **kwargs) as p:
  File "C:\...\Python38\lib\subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\...\Python38\lib\subprocess.py", line 1307, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
FileNotFoundError: [WinError 2] The system cannot find the specified file.
```
It turned out that the `dprint` command failed, which I found out only by inserting manual debug statements. I realized that there was a Git submodule to be cloned, so I did that.

After getting the 2nd error, I gave up:
```
Traceback (most recent call last):
  File "format.py", line 89, in <module>
    sys.exit(main())
  File "format.py", line 52, in main
    yapf()
  File "format.py", line 64, in yapf
    source_files = get_sources(root_path, ["*.py"])
  File "format.py", line 31, in get_sources
    return getter(*args)
  File "C:\Rust\deno\tools\util.py", line 186, in git_ls_files
    os.path.normpath(os.path.join(base_dir, f)) for f in output.split("\0")
TypeError: a bytes-like object is required, not 'str'
```
Something with binary/text encoding or wrong Python version.
</details>

I'm aware the Python scripts are not the focus of this project. However, since it's expected that every Pull Requester run them, would it make sense to improve the error messages a bit?