### PR TITLE
docs: fix runtime docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ for await (const req of s) {
 You can find a more in depth introduction, examples, and environment setup
 guides in the [manual](https://deno.land/manual).
 
-More in-depth info can be found in the runtime [documentation](doc.deno.land).
+More in-depth info can be found in the runtime [documentation](https://doc.deno.land).
 
 ### Contributing
 


### PR DESCRIPTION
Fixes main README 404 link to documentation.

(Pardon the small PR, but it's quite glaring.)