### PR TITLE
fix(cli/rt/console): fix inspection of Function

### DIFF
--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -195,8 +195,13 @@
         return String(value[customInspect]());
       } catch {}
     }
-    // Might be Function/AsyncFunction/GeneratorFunction
-    const cstrName = Object.getPrototypeOf(value).constructor.name;
+    // Might be Function/AsyncFunction/GeneratorFunction/AsyncGeneratorFunction
+    let cstrName = Object.getPrototypeOf(value)?.constructor?.name;
+    if (!cstrName) {
+      // If prototype is removed or broken,
+      // use generic 'Function' instead.
+      cstrName = "Function";
+    }
     if (value.name && value.name !== "anonymous") {
       // from MDN spec
       return `[${cstrName}: ${value.name}]`;

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -347,6 +347,21 @@ unitTest(function consoleTestStringifyCircular(): void {
 });
 /* eslint-enable @typescript-eslint/explicit-function-return-type */
 
+unitTest(function consoleTestStringifyFunctionWithPrototypeRemoved(): void {
+  const f = function f() {};
+  Reflect.setPrototypeOf(f, null);
+  assertEquals(stringify(f), "[Function: f]");
+  const af = async function af() {};
+  Reflect.setPrototypeOf(af, null);
+  assertEquals(stringify(af), "[Function: af]");
+  const gf = function gf() {};
+  Reflect.setPrototypeOf(gf, null);
+  assertEquals(stringify(gf), "[Function: gf]");
+  const agf = function agf() {};
+  Reflect.setPrototypeOf(agf, null);
+  assertEquals(stringify(agf), "[Function: agf]");
+});
+
 unitTest(function consoleTestStringifyWithDepth(): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const nestedObj: any = { a: { b: { c: { d: { e: { f: 42 } } } } } };


### PR DESCRIPTION
This PR fixes the inspection of functions. The current implementation gets the name of the type of the function from `f.__proto__.constructor.name`, and it throws when the prototype is set to null as described in #7633. This PR checks the prototype before accessing its constructor name and uses the generic name 'Function' if the prototype is not available.

fixes #7633