### PR TITLE
refactor(cli/flags): Remove Flags::repl

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -120,7 +120,6 @@ pub struct Flags {
   pub no_remote: bool,
   pub read_allowlist: Vec<PathBuf>,
   pub reload: bool,
-  pub repl: bool,
   pub seed: Option<u64>,
   pub unstable: bool,
   pub v8_flags: Option<Vec<String>>,
@@ -448,7 +447,6 @@ fn completions_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 
 fn repl_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   runtime_args_parse(flags, matches, false);
-  flags.repl = true;
   flags.subcommand = DenoSubcommand::Repl;
   flags.allow_net = true;
   flags.allow_env = true;
@@ -2144,7 +2142,6 @@ mod tests {
     assert_eq!(
       r.unwrap(),
       Flags {
-        repl: true,
         subcommand: DenoSubcommand::Repl,
         allow_net: true,
         allow_env: true,
@@ -2165,7 +2162,6 @@ mod tests {
     assert_eq!(
       r.unwrap(),
       Flags {
-        repl: true,
         subcommand: DenoSubcommand::Repl,
         unstable: true,
         import_map_path: Some("import_map.json".to_string()),

--- a/cli/state.rs
+++ b/cli/state.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+use crate::flags::DenoSubcommand;
 use crate::global_state::GlobalState;
 use crate::import_map::ImportMap;
 use crate::permissions::Permissions;
@@ -57,7 +58,9 @@ impl ModuleLoader for CliModuleLoader {
     };
 
     // FIXME(bartlomieju): hacky way to provide compatibility with repl
-    let referrer = if referrer.is_empty() && global_state.flags.repl {
+    let referrer = if referrer.is_empty()
+      && matches!(global_state.flags.subcommand, DenoSubcommand::Repl)
+    {
       "<unknown>"
     } else {
       referrer

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+use crate::flags::DenoSubcommand;
 use crate::fmt_errors::JsError;
 use crate::global_state::GlobalState;
 use crate::inspector::DenoInspector;
@@ -136,7 +137,9 @@ impl Worker {
           &mut js_runtime,
           Some(inspector_server.clone()),
         ))
-      } else if global_state.flags.coverage || global_state.flags.repl {
+      } else if global_state.flags.coverage
+        || matches!(global_state.flags.subcommand, DenoSubcommand::Repl)
+      {
         Some(DenoInspector::new(&mut js_runtime, None))
       } else {
         None


### PR DESCRIPTION
Use `matches!(flags.subcommand, DenoSubcommand::Repl)` instead.