### PR TITLE
fix(cli/rt/websockets): Only add Sec-WebSocket-Protocol if it's not empty

### DIFF
--- a/cli/ops/websocket.rs
+++ b/cli/ops/websocket.rs
@@ -68,11 +68,15 @@ pub async fn op_ws_create(
     cli_state.flags.ca_file.clone()
   };
   let uri: Uri = args.url.parse()?;
-  let request = Request::builder()
+  let mut request = Request::builder()
     .method(Method::GET)
-    .uri(&uri)
-    .header("Sec-WebSocket-Protocol", args.protocols)
-    .body(())?;
+    .uri(&uri);
+
+  if !args.protocols.is_empty() {
+    request = request.header("Sec-WebSocket-Protocol", args.protocols);
+  }
+  
+  let request = request.body(())?;
   let domain = &uri.host().unwrap().to_string();
   let port = &uri.port_u16().unwrap_or(match uri.scheme_str() {
     Some("wss") => 443,

--- a/cli/ops/websocket.rs
+++ b/cli/ops/websocket.rs
@@ -68,14 +68,12 @@ pub async fn op_ws_create(
     cli_state.flags.ca_file.clone()
   };
   let uri: Uri = args.url.parse()?;
-  let mut request = Request::builder()
-    .method(Method::GET)
-    .uri(&uri);
+  let mut request = Request::builder().method(Method::GET).uri(&uri);
 
   if !args.protocols.is_empty() {
     request = request.header("Sec-WebSocket-Protocol", args.protocols);
   }
-  
+
   let request = request.body(())?;
   let domain = &uri.host().unwrap().to_string();
   let port = &uri.port_u16().unwrap_or(match uri.scheme_str() {

--- a/cli/rt/27_websocket.js
+++ b/cli/rt/27_websocket.js
@@ -48,7 +48,7 @@
 
       core.jsonOpAsync("op_ws_create", {
         url: wsURL.href,
-        protocols: protocols.join("; "),
+        protocols: protocols.join(", "),
       }).then((create) => {
         if (create.success) {
           this.#rid = create.rid;


### PR DESCRIPTION
This PR fixes #7935 . The `WebSocket` will only add the header if it's not empty.