### PR TITLE
fix(op_crates/web/url): Apply backslash replacement to the pathname setter

### DIFF
--- a/cli/tests/unit/url_test.ts
+++ b/cli/tests/unit/url_test.ts
@@ -192,6 +192,8 @@ unitTest(function urlModifyPathname(): void {
   // deno-lint-ignore no-self-assign
   url.pathname = url.pathname;
   assertEquals(url.pathname, "/baz%23qat%20qux");
+  url.pathname = "\\a\\b\\c";
+  assertEquals(url.pathname, "/a/b/c");
 });
 
 unitTest(function urlModifyHash(): void {

--- a/op_crates/web/11_url.js
+++ b/op_crates/web/11_url.js
@@ -378,7 +378,7 @@
       return null;
     }
     [parts.path, restUrl] = takePattern(restUrl, /^([^?#]*)/);
-    parts.path = encodePathname(parts.path.replace(/\\/g, "/"));
+    parts.path = encodePathname(parts.path);
     if (usedNonBase) {
       parts.path = normalizePath(parts.path, parts.protocol == "file");
     } else {
@@ -870,7 +870,9 @@
   }
 
   function encodePathname(s) {
-    return [...s].map((c) => (charInPathSet(c) ? encodeChar(c) : c)).join("");
+    return [...s.replace(/\\/g, "/")].map((
+      c,
+    ) => (charInPathSet(c) ? encodeChar(c) : c)).join("");
   }
 
   function encodeSearch(s, isSpecial) {


### PR DESCRIPTION
Moves this step to `encodePathname()` so it affect the setter as well. I'm solidifying this encoder before I look at #7929.