### PR TITLE
chore(cli): remove dead code

### DIFF
--- a/cli/colors.rs
+++ b/cli/colors.rs
@@ -4,9 +4,7 @@ use regex::Regex;
 use std::env;
 use std::fmt;
 use std::io::Write;
-use termcolor::Color::{
-  Ansi256, Black, Blue, Cyan, Green, Red, White, Yellow,
-};
+use termcolor::Color::{Ansi256, Black, Blue, Cyan, Green, Red, White, Yellow};
 use termcolor::{Ansi, ColorSpec, WriteColor};
 
 #[cfg(windows)]

--- a/cli/colors.rs
+++ b/cli/colors.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::fmt;
 use std::io::Write;
 use termcolor::Color::{
-  Ansi256, Black, Blue, Cyan, Green, Magenta, Red, White, Yellow,
+  Ansi256, Black, Blue, Cyan, Green, Red, White, Yellow,
 };
 use termcolor::{Ansi, ColorSpec, WriteColor};
 
@@ -24,6 +24,7 @@ lazy_static! {
 }
 
 /// Helper function to strip ansi codes.
+#[cfg(test)]
 pub fn strip_ansi_codes(s: &str) -> std::borrow::Cow<str> {
   STRIP_ANSI_RE.replace_all(s, "")
 }
@@ -67,21 +68,9 @@ pub fn italic_bold(s: &str) -> impl fmt::Display {
   style(&s, style_spec)
 }
 
-pub fn black_on_white(s: &str) -> impl fmt::Display {
-  let mut style_spec = ColorSpec::new();
-  style_spec.set_bg(Some(White)).set_fg(Some(Black));
-  style(&s, style_spec)
-}
-
 pub fn white_on_red(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bg(Some(Red)).set_fg(Some(White));
-  style(&s, style_spec)
-}
-
-pub fn white_on_green(s: &str) -> impl fmt::Display {
-  let mut style_spec = ColorSpec::new();
-  style_spec.set_bg(Some(Green)).set_fg(Some(White));
   style(&s, style_spec)
 }
 
@@ -115,12 +104,6 @@ pub fn green(s: &str) -> impl fmt::Display {
   style(&s, style_spec)
 }
 
-pub fn magenta(s: &str) -> impl fmt::Display {
-  let mut style_spec = ColorSpec::new();
-  style_spec.set_fg(Some(Magenta));
-  style(&s, style_spec)
-}
-
 pub fn bold(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bold(true);
@@ -130,12 +113,6 @@ pub fn bold(s: &str) -> impl fmt::Display {
 pub fn gray(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(8)));
-  style(&s, style_spec)
-}
-
-pub fn italic_gray(s: &str) -> impl fmt::Display {
-  let mut style_spec = ColorSpec::new();
-  style_spec.set_fg(Some(Ansi256(8))).set_italic(true);
   style(&s, style_spec)
 }
 

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -147,11 +147,6 @@ impl DiskCache {
     deno_fs::write_file(&path, data, 0o666)
       .map_err(|e| with_io_context(&e, format!("{:#?}", &path)))
   }
-
-  pub fn remove(&self, filename: &Path) -> std::io::Result<()> {
-    let path = self.location.join(filename);
-    fs::remove_file(path)
-  }
 }
 
 #[cfg(test)]

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -43,7 +43,6 @@ pub enum DenoSubcommand {
     files: Vec<String>,
     ignore: Vec<String>,
   },
-  Help,
   Info {
     json: bool,
     file: Option<String>,

--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -89,6 +89,7 @@ impl Metadata {
     Ok(())
   }
 
+  #[cfg(test)]
   pub fn read(cache_filename: &Path) -> Result<Metadata, AnyError> {
     let metadata_filename = Metadata::filename(&cache_filename);
     let metadata = fs::read_to_string(metadata_filename)?;
@@ -143,14 +144,6 @@ impl HttpCache {
     let metadata = fs::read_to_string(metadata_filename)?;
     let metadata: Metadata = serde_json::from_str(&metadata)?;
     Ok((file, metadata.headers))
-  }
-
-  pub fn get_metadata(&self, url: &Url) -> Result<Metadata, AnyError> {
-    let cache_filename = self.location.join(url_to_filename(url));
-    let metadata_filename = Metadata::filename(&cache_filename);
-    let metadata = fs::read_to_string(metadata_filename)?;
-    let metadata: Metadata = serde_json::from_str(&metadata)?;
-    Ok(metadata)
   }
 
   pub fn set(

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -170,16 +170,6 @@ pub struct HttpBody {
   pos: usize,
 }
 
-impl HttpBody {
-  pub fn from(body: Response) -> Self {
-    Self {
-      response: body,
-      chunk: None,
-      pos: 0,
-    }
-  }
-}
-
 impl AsyncRead for HttpBody {
   fn poll_read(
     self: Pin<&mut Self>,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -9,28 +9,28 @@ extern crate log;
 
 mod ast;
 mod checksum;
-pub mod colors;
+mod colors;
 mod coverage;
-pub mod deno_dir;
-pub mod diagnostics;
+mod deno_dir;
+mod diagnostics;
 mod diff;
 mod disk_cache;
-pub mod errors;
+mod errors;
 mod file_fetcher;
 mod file_watcher;
-pub mod flags;
+mod flags;
 mod flags_allow_net;
 mod fmt;
-pub mod fmt_errors;
+mod fmt_errors;
 mod fs;
-pub mod global_state;
+mod global_state;
 mod global_timer;
-pub mod http_cache;
+mod http_cache;
 mod http_util;
 mod import_map;
 mod info;
 mod inspector;
-pub mod installer;
+mod installer;
 mod js;
 mod lint;
 mod lockfile;
@@ -39,22 +39,22 @@ mod metrics;
 mod module_graph;
 mod module_graph2;
 mod op_fetch_asset;
-pub mod ops;
-pub mod permissions;
+mod ops;
+mod permissions;
 mod repl;
-pub mod resolve_addr;
-pub mod signal;
-pub mod source_maps;
+mod resolve_addr;
+mod signal;
+mod source_maps;
 mod specifier_handler;
-pub mod state;
+mod state;
 mod test_runner;
 mod text_encoding;
 mod tokio_util;
 mod tsc;
 mod tsc_config;
 mod upgrade;
-pub mod version;
-pub mod worker;
+mod version;
+mod worker;
 
 use crate::coverage::CoverageCollector;
 use crate::coverage::PrettyCoverageReporter;
@@ -783,7 +783,6 @@ pub fn main() {
     } => {
       upgrade_command(dry_run, force, version, output, ca_file).boxed_local()
     }
-    _ => unreachable!(),
   };
 
   let result = tokio_util::run_basic(fut);

--- a/cli/media_type.rs
+++ b/cli/media_type.rs
@@ -19,7 +19,6 @@ pub enum MediaType {
   TSX = 4,
   Json = 5,
   Wasm = 6,
-  BuildInfo = 7,
   Unknown = 8,
 }
 
@@ -33,7 +32,6 @@ impl fmt::Display for MediaType {
       MediaType::TSX => "TSX",
       MediaType::Json => "Json",
       MediaType::Wasm => "Wasm",
-      MediaType::BuildInfo => "BuildInfo",
       MediaType::Unknown => "Unknown",
     };
     write!(f, "{}", value)
@@ -75,30 +73,6 @@ impl MediaType {
       },
     }
   }
-
-  /// Convert a MediaType to a `ts.Extension`.
-  ///
-  /// *NOTE* This is defined in TypeScript as a string based enum.  Changes to
-  /// that enum in TypeScript should be reflected here.
-  pub fn as_ts_extension(&self) -> &str {
-    match self {
-      MediaType::JavaScript => ".js",
-      MediaType::JSX => ".jsx",
-      MediaType::TypeScript => ".ts",
-      MediaType::Dts => ".d.ts",
-      MediaType::TSX => ".tsx",
-      MediaType::Json => ".json",
-      // TypeScript doesn't have an "unknown", so we will treat WASM as JS for
-      // mapping purposes, though in reality, it is unlikely to ever be passed
-      // to the compiler.
-      MediaType::Wasm => ".js",
-      MediaType::BuildInfo => ".tsbuildinfo",
-      // TypeScript doesn't have an "unknown", so we will treat WASM as JS for
-      // mapping purposes, though in reality, it is unlikely to ever be passed
-      // to the compiler.
-      MediaType::Unknown => ".js",
-    }
-  }
 }
 
 impl Serialize for MediaType {
@@ -114,7 +88,6 @@ impl Serialize for MediaType {
       MediaType::TSX => 4 as i32,
       MediaType::Json => 5 as i32,
       MediaType::Wasm => 6 as i32,
-      MediaType::BuildInfo => 7 as i32,
       MediaType::Unknown => 8 as i32,
     };
     Serialize::serialize(&value, serializer)
@@ -175,7 +148,6 @@ mod tests {
     assert_eq!(json!(MediaType::TSX), json!(4));
     assert_eq!(json!(MediaType::Json), json!(5));
     assert_eq!(json!(MediaType::Wasm), json!(6));
-    assert_eq!(json!(MediaType::BuildInfo), json!(7));
     assert_eq!(json!(MediaType::Unknown), json!(8));
   }
 
@@ -188,7 +160,6 @@ mod tests {
     assert_eq!(format!("{}", MediaType::TSX), "TSX");
     assert_eq!(format!("{}", MediaType::Json), "Json");
     assert_eq!(format!("{}", MediaType::Wasm), "Wasm");
-    assert_eq!(format!("{}", MediaType::BuildInfo), "BuildInfo");
     assert_eq!(format!("{}", MediaType::Unknown), "Unknown");
   }
 }

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -244,12 +244,6 @@ pub struct ModuleGraphFile {
   pub source_code: String,
 }
 
-impl ModuleGraphFile {
-  pub fn size(&self) -> usize {
-    self.source_code.as_bytes().len()
-  }
-}
-
 type SourceFileFuture = Pin<
   Box<dyn Future<Output = Result<(ModuleSpecifier, SourceFile), AnyError>>>,
 >;

--- a/cli/ops/tty.rs
+++ b/cli/ops/tty.rs
@@ -90,7 +90,6 @@ fn op_set_raw(
 
     // For now, only stdin.
     let handle = match &mut resource_holder.resource {
-      StreamResource::Stdin(..) => std::io::stdin().as_raw_handle(),
       StreamResource::FsFile(ref mut option_file_metadata) => {
         if let Some((tokio_file, metadata)) = option_file_metadata.take() {
           match tokio_file.try_into_std() {

--- a/cli/ops/tty.rs
+++ b/cli/ops/tty.rs
@@ -156,9 +156,6 @@ fn op_set_raw(
     if is_raw {
       let (raw_fd, maybe_tty_mode) =
         match &mut resource_holder.unwrap().resource {
-          StreamResource::Stdin(_, ref mut metadata) => {
-            (std::io::stdin().as_raw_fd(), &mut metadata.mode)
-          }
           StreamResource::FsFile(Some((f, ref mut metadata))) => {
             (f.as_raw_fd(), &mut metadata.tty.mode)
           }
@@ -198,9 +195,6 @@ fn op_set_raw(
       // Try restore saved mode.
       let (raw_fd, maybe_tty_mode) =
         match &mut resource_holder.unwrap().resource {
-          StreamResource::Stdin(_, ref mut metadata) => {
-            (std::io::stdin().as_raw_fd(), &mut metadata.mode)
-          }
           StreamResource::FsFile(Some((f, ref mut metadata))) => {
             (f.as_raw_fd(), &mut metadata.tty.mode)
           }
@@ -253,7 +247,6 @@ fn op_isatty(
       }
     }
     Err(StreamResource::FsFile(_)) => unreachable!(),
-    Err(StreamResource::Stdin(..)) => Ok(atty::is(atty::Stream::Stdin)),
     _ => Ok(false),
   })?;
   Ok(json!(isatty))

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -194,21 +194,6 @@ impl Worker {
     self.js_runtime.mod_evaluate(id)
   }
 
-  /// Loads, instantiates and executes provided source code
-  /// as module.
-  pub async fn execute_module_from_code(
-    &mut self,
-    module_specifier: &ModuleSpecifier,
-    code: String,
-  ) -> Result<(), AnyError> {
-    let id = self
-      .js_runtime
-      .load_module(module_specifier, Some(code))
-      .await?;
-    self.wait_for_inspector_session();
-    self.js_runtime.mod_evaluate(id)
-  }
-
   /// Returns a way to communicate with the Worker from other threads.
   pub fn thread_safe_handle(&self) -> WorkerHandle {
     self.external_channels.clone()


### PR DESCRIPTION
I noticed that several modules in `cli/main.rs` where `pub` when we don't currently expect anyone to consume the cli crate at the moment.  Removing those public modules resulted in exposing a lot of dead code that was be obfuscated by the public modules.  That code has been removed in this PR.