### PR TITLE
Fix docs link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ for await (const req of s) {
 You can find a more in depth introduction, examples, and environment setup
 guides in the [manual](https://deno.land/manual).
 
-More in-depth info can be found in the runtime [documentation](doc.deno.land).
+More in-depth info can be found in the runtime [documentation](https://doc.deno.land).
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ for await (const req of s) {
 You can find a more in depth introduction, examples, and environment setup
 guides in the [manual](https://deno.land/manual).
 
-More in-depth info can be found in the runtime [documentation](https://doc.deno.land).
+More in-depth info can be found in the runtime 
+[documentation](https://doc.deno.land).
 
 ### Contributing
 


### PR DESCRIPTION
The docs link in the readme is currently pointing to a relative GitHub link instead of [doc.deno.land](https://doc.deno.land)