### PR TITLE
fix(cli/repl): keyboard interrupt should continue

### DIFF
--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -308,7 +308,7 @@ pub async fn run(
         editor.lock().unwrap().add_history_entry(line.as_str());
       }
       Err(ReadlineError::Interrupted) => {
-        break;
+        continue;
       }
       Err(ReadlineError::Eof) => {
         break;

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -308,6 +308,7 @@ pub async fn run(
         editor.lock().unwrap().add_history_entry(line.as_str());
       }
       Err(ReadlineError::Interrupted) => {
+        println!("exit using ctrl+d or close()");
         continue;
       }
       Err(ReadlineError::Eof) => {


### PR DESCRIPTION
This changes the behavior of keyboard interrupts (ctrl+c) to continue, clearing the current line instead of exiting.

Exit can still be done with ctrl+d or by calling close().