### PR TITLE
fix(test): return error when awaiting unresolved promise

### DIFF
--- a/cli/test_runner.rs
+++ b/cli/test_runner.rs
@@ -82,11 +82,12 @@ pub fn render_test_file(
     json!({ "failFast": fail_fast, "reportToConsole": !quiet, "disableLog": quiet })
   };
 
-  let run_tests_cmd = format!(
-    "// @ts-ignore\nDeno[Deno.internal].runTests({});\n",
+  test_file.push_str("// @ts-ignore\n");
+
+  test_file.push_str(&format!(
+    "await Deno[Deno.internal].runTests({});\n",
     options
-  );
-  test_file.push_str(&run_tests_cmd);
+  ));
 
   test_file
 }

--- a/cli/tests/deno_test_unresolved_promise.out
+++ b/cli/tests/deno_test_unresolved_promise.out
@@ -1,0 +1,4 @@
+Check [WILDCARD]
+running 2 tests
+test unresolved promise ... in promise
+error: Module evaluation is still pending but there are no pending ops or dynamic imports. This situation is often caused by unresolved promise.

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1646,6 +1646,12 @@ itest!(deno_test_no_check {
   output: "deno_test.out",
 });
 
+itest!(deno_test_unresolved_promise {
+  args: "test test_unresolved_promise.js",
+  exit_code: 1,
+  output: "deno_test_unresolved_promise.out",
+});
+
 #[test]
 fn timeout_clear() {
   // https://github.com/denoland/deno/issues/7599

--- a/cli/tests/test_unresolved_promise.js
+++ b/cli/tests/test_unresolved_promise.js
@@ -1,0 +1,15 @@
+Deno.test({
+  name: "unresolved promise",
+  fn() {
+    return new Promise((_resolve, _reject) => {
+      console.log("in promise");
+    });
+  },
+});
+
+Deno.test({
+  name: "ok",
+  fn() {
+    console.log("ok test");
+  },
+});


### PR DESCRIPTION
This commit fixes test runner by awaitning "Deno.runTests()" call,
which ensures proper error is returned when there's an unresolved
promise that's being awaited.

Fixes https://github.com/denoland/deno/issues/7088