### PR TITLE
feat(cli/ops): add the sleep_sync op

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1312,6 +1312,17 @@ declare namespace Deno {
     atime: number | Date,
     mtime: number | Date,
   ): Promise<void>;
+
+  /** *UNSTABLE**: new API, yet to be vetted.
+   *
+   * SleepSync puts the main thread to sleep synchronously for a given amount of
+   * time in milliseconds.
+   *
+   * ```ts
+   * Deno.sleepSync(10);
+   * ```
+   */
+  export function sleepSync(millis: number): Promise<void>;
 }
 
 declare function fetch(

--- a/cli/ops/timers.rs
+++ b/cli/ops/timers.rs
@@ -25,6 +25,7 @@ use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::thread::sleep;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -77,6 +78,7 @@ pub fn init(rt: &mut deno_core::JsRuntime) {
   super::reg_json_sync(rt, "op_global_timer_start", op_global_timer_start);
   super::reg_json_async(rt, "op_global_timer", op_global_timer);
   super::reg_json_sync(rt, "op_now", op_now);
+  super::reg_json_sync(rt, "op_sleep_sync", op_sleep_sync);
 }
 
 fn op_global_timer_stop(
@@ -156,4 +158,20 @@ fn op_now(
     "seconds": seconds,
     "subsecNanos": subsec_nanos,
   }))
+}
+
+#[derive(Deserialize)]
+struct SleepArgs {
+  millis: u64,
+}
+
+fn op_sleep_sync(
+  state: &mut OpState,
+  args: Value,
+  _zero_copy: &mut [ZeroCopyBuf],
+) -> Result<Value, AnyError> {
+  super::check_unstable(state, "Deno.sleepSync");
+  let args: SleepArgs = serde_json::from_value(args)?;
+  sleep(Duration::from_millis(args.millis));
+  Ok(json!({}))
 }

--- a/cli/rt/11_timers.js
+++ b/cli/rt/11_timers.js
@@ -20,6 +20,10 @@
     return core.jsonOpSync("op_now");
   }
 
+  function sleepSync(millis = 0) {
+    return core.jsonOpSync("op_sleep_sync", { millis });
+  }
+
   // Derived from https://github.com/vadimg/js_bintrees. MIT Licensed.
 
   class RBNode {
@@ -545,5 +549,6 @@
     opStopGlobalTimer,
     opStartGlobalTimer,
     opNow,
+    sleepSync,
   };
 })(this);

--- a/cli/rt/90_deno_ns.js
+++ b/cli/rt/90_deno_ns.js
@@ -80,6 +80,7 @@ __bootstrap.denoNs = {
   listen: __bootstrap.net.listen,
   connectTls: __bootstrap.tls.connectTls,
   listenTls: __bootstrap.tls.listenTls,
+  sleepSync: __bootstrap.timers.sleepSync,
 };
 
 __bootstrap.denoNsUnstable = {


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.py` passes without changing files.
6. Ensure `./tools/lint.py` passes.
-->
As discussed in the Discord server, this adds the `sleepSync` op to the `Deno` namespace.