### PR TITLE
fix(cli/repl): respect the value of Deno.noColor

### DIFF
--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -378,7 +378,7 @@ pub async fn run(
             "Runtime.callFunctionOn",
             Some(json!({
               "executionContextId": context_id,
-              "functionDeclaration": "function (object) { return Deno[Deno.internal].inspectArgs(['%o', object], { colors: true}); }",
+              "functionDeclaration": "function (object) { return Deno[Deno.internal].inspectArgs(['%o', object], { colors: !Deno.noColor }); }",
               "arguments": [
                 evaluate_result,
               ],


### PR DESCRIPTION
This sets the value of colors during the inspectArgs call to !Deno.noColor.

Should make https://github.com/denoland/deno/pull/7778 landable.