### PR TITLE
Reland feat(cli/console): inspect with colors regardless of Deno.noColor

### DIFF
--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -378,7 +378,7 @@ pub async fn run(
             "Runtime.callFunctionOn",
             Some(json!({
               "executionContextId": context_id,
-              "functionDeclaration": "function (object) { return Deno[Deno.internal].inspectArgs(['%o', object], { colors: true}); }",
+              "functionDeclaration": "function (object) { return Deno[Deno.internal].inspectArgs(['%o', object], { colors: !Deno.noColor }); }",
               "arguments": [
                 evaluate_result,
               ],

--- a/cli/rt/01_colors.js
+++ b/cli/rt/01_colors.js
@@ -10,9 +10,7 @@
   }
 
   function run(str, code) {
-    return !globalThis || !globalThis.Deno || globalThis.Deno.noColor
-      ? str
-      : `${code.open}${str.replace(code.regexp, code.open)}${code.close}`;
+    return `${code.open}${str.replace(code.regexp, code.open)}${code.close}`;
   }
 
   function bold(str) {
@@ -72,6 +70,10 @@
     return string.replace(ANSI_PATTERN, "");
   }
 
+  function maybeColor(fn) {
+    return !(globalThis.Deno?.noColor ?? false) ? fn : (s) => s;
+  }
+
   window.__bootstrap.colors = {
     bold,
     italic,
@@ -85,5 +87,6 @@
     magenta,
     dim,
     stripColor,
+    maybeColor,
   };
 })(this);

--- a/cli/rt/02_console.js
+++ b/cli/rt/02_console.js
@@ -1425,10 +1425,12 @@
   const timerMap = new Map();
   const isConsoleInstance = Symbol("isConsoleInstance");
 
-  const CONSOLE_INSPECT_OPTIONS = {
-    ...DEFAULT_INSPECT_OPTIONS,
-    colors: true,
-  };
+  function getConsoleInspectOptions() {
+    return {
+      ...DEFAULT_INSPECT_OPTIONS,
+      colors: !(globalThis.Deno?.noColor ?? false),
+    };
+  }
 
   class Console {
     #printFunc = null;
@@ -1451,7 +1453,7 @@
     log = (...args) => {
       this.#printFunc(
         inspectArgs(args, {
-          ...CONSOLE_INSPECT_OPTIONS,
+          ...getConsoleInspectOptions(),
           indentLevel: this.indentLevel,
         }) + "\n",
         false,
@@ -1463,7 +1465,8 @@
 
     dir = (obj, options = {}) => {
       this.#printFunc(
-        inspectArgs([obj], { ...CONSOLE_INSPECT_OPTIONS, ...options }) + "\n",
+        inspectArgs([obj], { ...getConsoleInspectOptions(), ...options }) +
+          "\n",
         false,
       );
     };
@@ -1473,7 +1476,7 @@
     warn = (...args) => {
       this.#printFunc(
         inspectArgs(args, {
-          ...CONSOLE_INSPECT_OPTIONS,
+          ...getConsoleInspectOptions(),
           indentLevel: this.indentLevel,
         }) + "\n",
         true,
@@ -1679,7 +1682,7 @@
     trace = (...args) => {
       const message = inspectArgs(
         args,
-        { ...CONSOLE_INSPECT_OPTIONS, indentLevel: 0 },
+        { ...getConsoleInspectOptions(), indentLevel: 0 },
       );
       const err = {
         name: "Trace",

--- a/cli/rt/40_testing.js
+++ b/cli/rt/40_testing.js
@@ -2,7 +2,7 @@
 
 ((window) => {
   const core = window.Deno.core;
-  const { gray, green, italic, red, yellow } = window.__bootstrap.colors;
+  const colors = window.__bootstrap.colors;
   const { exit } = window.__bootstrap.os;
   const { Console, inspectArgs } = window.__bootstrap.console;
   const { stdout } = window.__bootstrap.files;
@@ -19,6 +19,8 @@
   }
 
   function formatDuration(time = 0) {
+    const gray = colors.maybeColor(colors.gray);
+    const italic = colors.maybeColor(colors.italic);
     const timeStr = `(${time}ms)`;
     return gray(italic(timeStr));
   }
@@ -139,6 +141,9 @@ finishing test case.`;
   }
 
   function reportToConsole(message) {
+    const green = colors.maybeColor(colors.green);
+    const red = colors.maybeColor(colors.red);
+    const yellow = colors.maybeColor(colors.yellow);
     const redFailed = red("FAILED");
     const greenOk = green("ok");
     const yellowIgnored = yellow("ignored");


### PR DESCRIPTION
Originally landed in https://github.com/denoland/deno/pull/7778
Reverted in #7973

Fix from #7975

