### PR TITLE
fix(cli): ModuleGraph2 properly handles redirects

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -32,9 +32,6 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 /// Structure representing local or remote file.
-///
-/// In case of remote file `url` might be different than originally requested URL, if so
-/// `redirect_source_url` will contain original URL and `url` will be equal to final location.
 #[derive(Debug, Clone)]
 pub struct SourceFile {
   pub url: Url,

--- a/cli/module_graph2.rs
+++ b/cli/module_graph2.rs
@@ -161,7 +161,6 @@ fn get_version(source: &str, version: &str, config: &[u8]) -> String {
 struct Module {
   dependencies: DependencyMap,
   is_dirty: bool,
-  is_hydrated: bool,
   is_parsed: bool,
   maybe_emit: Option<Emit>,
   maybe_emit_path: Option<(PathBuf, Option<PathBuf>)>,
@@ -180,7 +179,6 @@ impl Default for Module {
     Module {
       dependencies: HashMap::new(),
       is_dirty: false,
-      is_hydrated: false,
       is_parsed: false,
       maybe_emit: None,
       maybe_emit_path: None,
@@ -189,7 +187,7 @@ impl Default for Module {
       maybe_types: None,
       maybe_version: None,
       media_type: MediaType::Unknown,
-      specifier: ModuleSpecifier::resolve_url("https://deno.land/x/").unwrap(),
+      specifier: ModuleSpecifier::resolve_url("file:///example.js").unwrap(),
       source: "".to_string(),
       source_path: PathBuf::new(),
     }
@@ -198,14 +196,39 @@ impl Default for Module {
 
 impl Module {
   pub fn new(
-    specifier: ModuleSpecifier,
+    cached_module: CachedModule,
     maybe_import_map: Option<Rc<RefCell<ImportMap>>>,
   ) -> Self {
-    Module {
-      specifier,
-      maybe_import_map,
-      ..Module::default()
+    let mut module = Module {
+      specifier: cached_module.specifier,
+      maybe_import_map: maybe_import_map,
+      media_type: cached_module.media_type,
+      source: cached_module.source,
+      source_path: cached_module.source_path,
+      maybe_emit: cached_module.maybe_emit,
+      maybe_emit_path: cached_module.maybe_emit_path,
+      maybe_version: cached_module.maybe_version,
+      is_dirty: false,
+      ..Self::default()
+    };
+    if module.maybe_import_map.is_none() {
+      if let Some(dependencies) = cached_module.maybe_dependencies {
+        module.dependencies = dependencies;
+        module.is_parsed = true;
+      }
     }
+    module.maybe_types = if let Some(ref specifier) = cached_module.maybe_types
+    {
+      Some((
+        specifier.clone(),
+        module
+          .resolve_import(&specifier, None)
+          .expect("could not resolve module"),
+      ))
+    } else {
+      None
+    };
+    module
   }
 
   /// Return `true` if the current hash of the module matches the stored
@@ -216,33 +239,6 @@ impl Module {
     } else {
       false
     }
-  }
-
-  pub fn hydrate(&mut self, cached_module: CachedModule) {
-    self.media_type = cached_module.media_type;
-    self.source = cached_module.source;
-    self.source_path = cached_module.source_path;
-    self.maybe_emit = cached_module.maybe_emit;
-    self.maybe_emit_path = cached_module.maybe_emit_path;
-    if self.maybe_import_map.is_none() {
-      if let Some(dependencies) = cached_module.maybe_dependencies {
-        self.dependencies = dependencies;
-        self.is_parsed = true;
-      }
-    }
-    self.maybe_types = if let Some(ref specifier) = cached_module.maybe_types {
-      Some((
-        specifier.clone(),
-        self
-          .resolve_import(&specifier, None)
-          .expect("could not resolve module"),
-      ))
-    } else {
-      None
-    };
-    self.maybe_version = cached_module.maybe_version;
-    self.is_dirty = false;
-    self.is_hydrated = true;
   }
 
   pub fn parse(&mut self) -> Result<(), AnyError> {
@@ -415,6 +411,7 @@ pub struct Graph2 {
   handler: Rc<RefCell<dyn SpecifierHandler>>,
   maybe_ts_build_info: Option<String>,
   modules: HashMap<ModuleSpecifier, Module>,
+  redirects: HashMap<ModuleSpecifier, ModuleSpecifier>,
   roots: Vec<ModuleSpecifier>,
 }
 
@@ -429,8 +426,14 @@ impl Graph2 {
       handler,
       maybe_ts_build_info: None,
       modules: HashMap::new(),
+      redirects: HashMap::new(),
       roots: Vec::new(),
     }
+  }
+
+  fn contains_module(&self, specifier: &ModuleSpecifier) -> bool {
+    let s = self.resolve_specifier(specifier);
+    self.modules.contains_key(s)
   }
 
   fn get_info(
@@ -440,7 +443,7 @@ impl Graph2 {
     totals: &mut HashMap<ModuleSpecifier, usize>,
   ) -> ModuleInfo {
     let not_seen = seen.insert(specifier.clone());
-    let module = self.modules.get(specifier).unwrap();
+    let module = self.get_module(specifier).unwrap();
     let mut deps = Vec::new();
     let mut total_size = None;
 
@@ -520,7 +523,7 @@ impl Graph2 {
     }
 
     let module = self.roots[0].clone();
-    let m = self.modules.get(&module).unwrap();
+    let m = self.get_module(&module).unwrap();
 
     let mut seen = HashSet::new();
     let mut totals = HashMap::new();
@@ -576,17 +579,22 @@ impl Graph2 {
     &self,
     specifier: &ModuleSpecifier,
   ) -> Option<MediaType> {
-    if let Some(module) = self.modules.get(specifier) {
+    if let Some(module) = self.get_module(specifier) {
       Some(module.media_type)
     } else {
       None
     }
   }
 
+  fn get_module(&self, specifier: &ModuleSpecifier) -> Option<&Module> {
+    let s = self.resolve_specifier(specifier);
+    self.modules.get(s)
+  }
+
   /// Get the source for a given module specifier.  If the module is not part
   /// of the graph, the result will be `None`.
   pub fn get_source(&self, specifier: &ModuleSpecifier) -> Option<String> {
-    if let Some(module) = self.modules.get(specifier) {
+    if let Some(module) = self.get_module(specifier) {
       Some(module.source.clone())
     } else {
       None
@@ -624,10 +632,10 @@ impl Graph2 {
     specifier: &str,
     referrer: &ModuleSpecifier,
   ) -> Result<ModuleSpecifier, AnyError> {
-    if !self.modules.contains_key(referrer) {
+    if !self.contains_module(referrer) {
       return Err(MissingSpecifier(referrer.to_owned()).into());
     }
-    let module = self.modules.get(referrer).unwrap();
+    let module = self.get_module(referrer).unwrap();
     if !module.dependencies.contains_key(specifier) {
       return Err(
         MissingDependency(referrer.to_owned(), specifier.to_owned()).into(),
@@ -647,13 +655,13 @@ impl Graph2 {
           MissingDependency(referrer.to_owned(), specifier.to_owned()).into(),
         );
       };
-    if !self.modules.contains_key(&resolved_specifier) {
+    if !self.contains_module(&resolved_specifier) {
       return Err(
         MissingDependency(referrer.to_owned(), resolved_specifier.to_string())
           .into(),
       );
     }
-    let dep_module = self.modules.get(&resolved_specifier).unwrap();
+    let dep_module = self.get_module(&resolved_specifier).unwrap();
     // In the case that there is a X-TypeScript-Types or a triple-slash types,
     // then the `maybe_types` specifier will be populated and we should use that
     // instead.
@@ -664,6 +672,21 @@ impl Graph2 {
     };
 
     Ok(result)
+  }
+
+  fn resolve_specifier<'a>(
+    &'a self,
+    specifier: &'a ModuleSpecifier,
+  ) -> &'a ModuleSpecifier {
+    let mut s = specifier;
+    loop {
+      if let Some(redirect) = self.redirects.get(s) {
+        s = redirect;
+      } else {
+        break;
+      }
+    }
+    s
   }
 
   /// Transpile (only transform) the graph, updating any emitted modules
@@ -794,9 +817,8 @@ impl GraphBuilder2 {
   /// module into the graph.
   fn visit(&mut self, cached_module: CachedModule) -> Result<(), AnyError> {
     let specifier = cached_module.specifier.clone();
-    let mut module =
-      Module::new(specifier.clone(), self.maybe_import_map.clone());
-    module.hydrate(cached_module);
+    let requested_specifier = cached_module.requested_specifier.clone();
+    let mut module = Module::new(cached_module, self.maybe_import_map.clone());
     if !module.is_parsed {
       let has_types = module.maybe_types.is_some();
       module.parse()?;
@@ -820,6 +842,12 @@ impl GraphBuilder2 {
     }
     if let Some((_, specifier)) = module.maybe_types.as_ref() {
       self.fetch(specifier)?;
+    }
+    if specifier != requested_specifier {
+      self
+        .graph
+        .redirects
+        .insert(requested_specifier, specifier.clone());
     }
     self.graph.modules.insert(specifier, module);
 
@@ -921,6 +949,7 @@ pub mod tests {
 
       Ok(CachedModule {
         source,
+        requested_specifier: specifier.clone(),
         source_path,
         specifier,
         media_type,

--- a/cli/module_graph2.rs
+++ b/cli/module_graph2.rs
@@ -679,12 +679,8 @@ impl Graph2 {
     specifier: &'a ModuleSpecifier,
   ) -> &'a ModuleSpecifier {
     let mut s = specifier;
-    loop {
-      if let Some(redirect) = self.redirects.get(s) {
-        s = redirect;
-      } else {
-        break;
-      }
+    while let Some(redirect) = self.redirects.get(s) {
+      s = redirect;
     }
     s
   }

--- a/cli/tests/017_import_redirect_info.out
+++ b/cli/tests/017_import_redirect_info.out
@@ -1,0 +1,6 @@
+local: [WILDCARD]017_import_redirect.ts
+type: TypeScript
+deps: 1 unique (total [WILDCARD]B)
+
+file:///[WILDCARD]cli/tests/017_import_redirect.ts ([WILDCARD])
+└── http://gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts ([WILDCARD])

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1572,6 +1572,16 @@ itest!(_017_import_redirect {
   output: "017_import_redirect.ts.out",
 });
 
+itest!(_017_import_redirect_nocheck {
+  args: "run --quiet --reload --no-check 017_import_redirect.ts",
+  output: "017_import_redirect.ts.out",
+});
+
+itest!(_017_import_redirect_info {
+  args: "info --quiet --reload 017_import_redirect.ts",
+  output: "017_import_redirect_info.out",
+});
+
 itest!(_018_async_catch {
   args: "run --quiet --reload 018_async_catch.ts",
   output: "018_async_catch.ts.out",


### PR DESCRIPTION
Fixes issues where both `--no-check` and `deno info` do not currently handle redirects.