### PR TITLE
refactor(core): more control over isolate creation

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -48,7 +48,6 @@ pub use crate::ops::OpState;
 pub use crate::ops::OpTable;
 pub use crate::resources::ResourceTable;
 pub use crate::runtime::GetErrorClassFn;
-pub use crate::runtime::HeapLimits;
 pub use crate::runtime::JsRuntime;
 pub use crate::runtime::RuntimeOptions;
 pub use crate::runtime::Snapshot;


### PR DESCRIPTION
Make JSRuntime::new() accept a custom v8::CreateParams object to tune
the v8::Isolate it creates.

Subsumes the functionality of HeapLimits, which I therefore removed.