### PR TITLE
feat(std/testing): Add support for object assertion against object subset 

### DIFF
--- a/std/testing/README.md
+++ b/std/testing/README.md
@@ -25,6 +25,8 @@ pretty-printed diff of failing assertion.
   `expected`.
 - `assertArrayContains()` - Make an assertion that `actual` array contains the
   `expected` values.
+- `assertObjectMatch()` - Make an assertion that `actual` object match
+  `expected` subset object
 - `assertThrows()` - Expects the passed `fn` to throw. If `fn` does not throw,
   this function does. Also compares any errors thrown to an optional expected
   `Error` class and checks that the error `.message` includes an optional

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -434,10 +434,10 @@ export function assertNotMatch(
  * If not, then throw.
  */
 export function assertObjectMatch(
-  actual: { [key: string]: unknown },
-  expected: { [key: string]: unknown },
+  actual: Record<string | symbol, unknown>,
+  expected: Record<string | symbol, unknown>,
 ): void {
-  type loose = { [key: string]: unknown };
+  type loose = Record<string | symbol, unknown>;
   const seen = new WeakMap();
   return assertEquals(
     (function filter(a: loose, b: loose): loose {

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -434,12 +434,13 @@ export function assertNotMatch(
  * If not, then throw.
  */
 export function assertObjectMatch(
-  actual: object,
-  expected: object,
+  actual: { [key: string]: unknown },
+  expected: { [key: string]: unknown },
 ): void {
+  type loose = { [key: string]: unknown };
   const seen = new WeakMap();
   return assertEquals(
-    (function filter(a: object, b: object): object {
+    (function filter(a: loose, b: loose): loose {
       // Prevent infinite loop with circular references with same filter
       if ((seen.has(a)) && (seen.get(a) === b)) {
         return a;
@@ -447,14 +448,14 @@ export function assertObjectMatch(
       seen.set(a, b);
       // Iterate through keys present in both actual and expected
       // and filter recursively on object references
-      const filtered = {} as { [key: string]: unknown };
+      const filtered = {} as loose;
       for (
         const [key, value] of Object.entries(a).filter(([key]) => key in b)
       ) {
         if (typeof value === "object") {
-          const subset = (b as { [key: string]: unknown })[key];
+          const subset = (b as loose)[key];
           if ((typeof subset === "object") && (subset)) {
-            filtered[key] = filter(value, subset);
+            filtered[key] = filter(value as loose, subset as loose);
             continue;
           }
         }

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -261,12 +261,14 @@ Deno.test("testingAssertStringNotMatchingThrows", function (): void {
 });
 
 Deno.test("testingAssertObjectMatching", function (): void {
+  const sym = Symbol("foo");
   const a = { foo: true, bar: false };
   const b = { ...a, baz: a };
   const c = { ...b, qux: b };
   const d = { corge: c, grault: c };
   const e = { foo: true } as { [key: string]: unknown };
   e.bar = e;
+  const f = { [sym]: true, bar: false };
   // Simple subset
   assertObjectMatch(a, {
     foo: true,
@@ -306,6 +308,10 @@ Deno.test("testingAssertObjectMatching", function (): void {
       },
     },
   });
+  // Subset with same symbol
+  assertObjectMatch(f, {
+    [sym]: true
+  })
   // Missing key
   {
     let didThrow;
@@ -404,6 +410,20 @@ Deno.test("testingAssertObjectMatching", function (): void {
             },
           },
         },
+      });
+      didThrow = false;
+    } catch (e) {
+      assert(e instanceof AssertionError);
+      didThrow = true;
+    }
+    assertEquals(didThrow, true);
+  }
+  // Subset with symbol key but with string key subset
+  {
+    let didThrow;
+    try {
+      assertObjectMatch(f, {
+        foo: true,
       });
       didThrow = false;
     } catch (e) {

--- a/std/testing/asserts_test.ts
+++ b/std/testing/asserts_test.ts
@@ -310,8 +310,8 @@ Deno.test("testingAssertObjectMatching", function (): void {
   });
   // Subset with same symbol
   assertObjectMatch(f, {
-    [sym]: true
-  })
+    [sym]: true,
+  });
   // Missing key
   {
     let didThrow;


### PR DESCRIPTION
<!--
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.py` passes without changing files.
6. Ensure `./tools/lint.py` passes.
-->

This add supports for a new assertion function `assertObjectMatch` which allows to test an `actual` object against an `expected` object subset (i.e. inclusivity, not equality)

**Why ?**

It's often useful to test an object partly without testing the remaining properties (like for web api response, where you might want to only check a few fields).

This function filters out `actual` object with `expected` object subsets keys before calling `assertEquals` (so it's actually a wrapper which acts as a syntaxic sugar).

```ts
const a  = {
   foo: true,
   bar: true,
   baz: {
     qux: true
   }
}

// Simple assertions
assertObjectMatch(a, {foo: true})  // OK 
assertObjectMatch(a, {bar: true})  // OK
assertObjectMatch(a, {foo: false}) // KO 

// Nested assertions
assertObjectMatch(a, {baz: {qux: true}}) // OK
assertObjectMatch(a, {baz: {qux:null}})  // KO
```