### PR TITLE
fix(op_crates/web): TextEncoder error message with original input

### DIFF
--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -104,10 +104,10 @@ unitTest(function textDecoderASCII(): void {
 unitTest(function textDecoderErrorEncoding(): void {
   let didThrow = false;
   try {
-    new TextDecoder("foo");
+    new TextDecoder("Foo");
   } catch (e) {
     didThrow = true;
-    assertEquals(e.message, "The encoding label provided ('foo') is invalid.");
+    assertEquals(e.message, "The encoding label provided ('Foo') is invalid.");
   }
   assert(didThrow);
 });

--- a/op_crates/web/08_text_encoding.js
+++ b/op_crates/web/08_text_encoding.js
@@ -973,8 +973,8 @@
       if (options.fatal) {
         this.fatal = true;
       }
-      label = String(label).trim().toLowerCase();
-      const encoding = encodings.get(label);
+      const _label = String(label).trim().toLowerCase();
+      const encoding = encodings.get(_label);
       if (!encoding) {
         throw new RangeError(
           `The encoding label provided ('${label}') is invalid.`,

--- a/op_crates/web/text_encoding_test.js
+++ b/op_crates/web/text_encoding_test.js
@@ -163,10 +163,10 @@ function textDecoderASCII() {
 function textDecoderErrorEncoding() {
   let didThrow = false;
   try {
-    new TextDecoder("foo");
+    new TextDecoder("Foo");
   } catch (e) {
     didThrow = true;
-    assert(e.message === "The encoding label provided ('foo') is invalid.");
+    assert(e.message === "The encoding label provided ('Foo') is invalid.");
   }
   assert(didThrow);
 }


### PR DESCRIPTION
Instead of modifying input, return error message with original input.
Edited original test case for TextDecoder a little.

Closes #8003