### PR TITLE
fix(cli): use rid getter for stdio

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -710,11 +710,11 @@ declare namespace Deno {
   }
 
   /** A handle for `stdin`. */
-  export const stdin: Reader & ReaderSync & Closer & { rid: number };
+  export const stdin: Reader & ReaderSync & Closer & { readonly rid: number };
   /** A handle for `stdout`. */
-  export const stdout: Writer & WriterSync & Closer & { rid: number };
+  export const stdout: Writer & WriterSync & Closer & { readonly rid: number };
   /** A handle for `stderr`. */
-  export const stderr: Writer & WriterSync & Closer & { rid: number };
+  export const stderr: Writer & WriterSync & Closer & { readonly rid: number };
 
   export interface OpenOptions {
     /** Sets the option for read access. This option, when `true`, means that the

--- a/cli/rt/30_files.js
+++ b/cli/rt/30_files.js
@@ -109,7 +109,10 @@
 
   class Stdin {
     constructor() {
-      this.rid = 0;
+    }
+
+    get rid() {
+      return 0;
     }
 
     read(p) {
@@ -127,7 +130,10 @@
 
   class Stdout {
     constructor() {
-      this.rid = 1;
+    }
+
+    get rid() {
+      return 1;
     }
 
     write(p) {
@@ -145,7 +151,10 @@
 
   class Stderr {
     constructor() {
-      this.rid = 2;
+    }
+
+    get rid() {
+      return 2;
     }
 
     write(p) {


### PR DESCRIPTION
This changes the rid of Deno.stdin, Deno.stdout, Deno.stderr from a mutable property into a getter to match the rid semantics of Deno.File.