### PR TITLE
refactor(lint): show hint for lint errors

### DIFF
--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -222,6 +222,7 @@ impl LintReporter for PrettyLintReporter {
       &pretty_message,
       &source_lines,
       d.range.clone(),
+      d.hint.as_ref(),
       &fmt_errors::format_location(&JsStackFrame::from_location(
         Some(d.filename.clone()),
         Some(d.range.start.line as i64),
@@ -256,6 +257,7 @@ pub fn format_diagnostic(
   message_line: &str,
   source_lines: &[&str],
   range: deno_lint::diagnostic::Range,
+  maybe_hint: Option<&String>,
   formatted_location: &str,
 ) -> String {
   let mut lines = vec![];
@@ -284,12 +286,23 @@ pub fn format_diagnostic(
     }
   }
 
-  format!(
-    "{}\n{}\n    at {}",
-    message_line,
-    lines.join("\n"),
-    formatted_location
-  )
+  if let Some(hint) = maybe_hint {
+    format!(
+      "{}\n{}\n    at {}\n\n    {} {}",
+      message_line,
+      lines.join("\n"),
+      formatted_location,
+      colors::gray("hint:"),
+      hint,
+    )
+  } else {
+    format!(
+      "{}\n{}\n    at {}",
+      message_line,
+      lines.join("\n"),
+      formatted_location
+    )
+  }
 }
 
 #[derive(Serialize)]

--- a/cli/tests/lint/expected_quiet.out
+++ b/cli/tests/lint/expected_quiet.out
@@ -3,6 +3,8 @@
 ^^^^^^^^^^^^^^^^^^^
     at [WILDCARD]file1.js:1:0
 
+    hint: [WILDCARD]
+
 (no-empty) Empty block statement
 while (false) {}
               ^^


### PR DESCRIPTION
After upgrading deno_lint to 0.2.4, there are hints in some rules that should be displayed alongside the error.

![Screenshot 2020-10-18 at 15 47 26](https://user-images.githubusercontent.com/13602871/96369315-6b023380-1159-11eb-817b-da75d4b8e7ae.png)

Ref https://github.com/denoland/deno_lint/pull/411

CC @magurotuna 