### PR TITLE
feat(cli): add support for bundle --no-check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +320,15 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
+]
 
 [[package]]
 name = "crc32fast"
@@ -430,6 +445,7 @@ dependencies = [
  "semver-parser 0.9.0",
  "serde",
  "sourcemap",
+ "swc_bundler",
  "swc_common",
  "swc_ecmascript",
  "sys-info",
@@ -660,6 +676,12 @@ dependencies = [
  "redox_syscall",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
@@ -1476,6 +1498,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1669,12 @@ checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2 1.0.21",
 ]
+
+[[package]]
+name = "radix_fmt"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce082a9940a7ace2ad4a8b7d0b1eac6aa378895f18be598230c5f2284ac05426"
 
 [[package]]
 name = "rand"
@@ -1827,6 +1865,12 @@ name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+
+[[package]]
+name = "relative-path"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65aff7c83039e88c1c0b4bedf8dfa93d6ec84d5fc2945b37c1fa4186f46c5f94"
 
 [[package]]
 name = "remove_dir_all"
@@ -2223,6 +2267,32 @@ checksum = "34d36e046dd23a5b5f7f9d4fd1f9ca0eb07dfd67c87521ecd358dc26c4ad1f42"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
+]
+
+[[package]]
+name = "swc_bundler"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dabc79c5bf47498e16a01134846fbb677dd9c7233c591710587d76bd30cbe02"
+dependencies = [
+ "anyhow",
+ "crc",
+ "indexmap",
+ "is-macro",
+ "log",
+ "once_cell",
+ "petgraph",
+ "radix_fmt",
+ "relative-path",
+ "retain_mut",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -61,6 +61,7 @@ rustyline-derive = "0.3.1"
 serde = { version = "1.0.116", features = ["derive"] }
 sys-info = "0.7.0"
 sourcemap = "6.0.1"
+swc_bundler = "=0.11.3"
 swc_common = { version = "=0.10.4", features = ["sourcemap"] }
 swc_ecmascript = { version = "=0.10.1", features = ["codegen", "dep_graph", "parser", "react", "transforms", "visit"] }
 tempfile = "3.1.0"

--- a/cli/ast.rs
+++ b/cli/ast.rs
@@ -3,7 +3,6 @@
 use crate::media_type::MediaType;
 use crate::tsc_config;
 
-use deno_core::error::bail;
 use deno_core::error::AnyError;
 use deno_core::serde_json;
 use deno_core::ModuleSpecifier;
@@ -422,12 +421,13 @@ pub fn transpile_module(
     Some(&comments),
   );
   let mut parser = swc_ecmascript::parser::Parser::new_from(lexer);
+  let sm = cm.clone();
   let module = parser.parse_module().map_err(move |err| {
     let mut diagnostic = err.into_diagnostic(&handler);
     diagnostic.emit();
 
     DiagnosticBuffer::from_error_buffer(error_buffer, |span| {
-      cm.lookup_char_pos(span.lo)
+      sm.lookup_char_pos(span.lo)
     })
   })?;
   // TODO(@kitsonk) DRY-up with ::transpile()

--- a/cli/ast.rs
+++ b/cli/ast.rs
@@ -1,13 +1,15 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 use crate::media_type::MediaType;
+use crate::module_graph2::Graph2;
 
+use deno_core::error::bail;
 use deno_core::error::AnyError;
+use deno_core::error::Context;
 use deno_core::ModuleSpecifier;
 use std::error::Error;
 use std::fmt;
 use std::rc::Rc;
-use std::result;
 use std::sync::Arc;
 use std::sync::RwLock;
 use swc_common::chain;
@@ -21,10 +23,14 @@ use swc_common::errors::HandlerFlags;
 use swc_common::FileName;
 use swc_common::Globals;
 use swc_common::Loc;
+use swc_common::SourceFile;
 use swc_common::SourceMap;
 use swc_common::Span;
+use swc_ecmascript::ast::Expr;
+use swc_ecmascript::ast::Lit;
 use swc_ecmascript::ast::Module;
 use swc_ecmascript::ast::Program;
+use swc_ecmascript::ast::Str;
 use swc_ecmascript::codegen::text_writer::JsWriter;
 use swc_ecmascript::codegen::Node;
 use swc_ecmascript::dep_graph::analyze_dependencies;
@@ -38,12 +44,10 @@ use swc_ecmascript::parser::TsConfig;
 use swc_ecmascript::transforms::fixer;
 use swc_ecmascript::transforms::helpers;
 use swc_ecmascript::transforms::pass::Optional;
-use swc_ecmascript::transforms::proposals::decorators;
+use swc_ecmascript::transforms::proposals;
 use swc_ecmascript::transforms::react;
 use swc_ecmascript::transforms::typescript;
 use swc_ecmascript::visit::FoldWith;
-
-type Result<V> = result::Result<V, AnyError>;
 
 static TARGET: JscTarget = JscTarget::Es2020;
 
@@ -71,6 +75,27 @@ impl Into<Location> for swc_common::Loc {
     }
   }
 }
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum AstError {
+  /// An unexpected specifier was requested.
+  MissingFilename(FileName),
+}
+use AstError::*;
+
+impl fmt::Display for AstError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      MissingFilename(ref filename) => write!(
+        f,
+        "A missing filename was requested.\n  Filename: {}",
+        filename
+      ),
+    }
+  }
+}
+
+impl Error for AstError {}
 
 /// A buffer for collecting diagnostic messages from the AST parser.
 #[derive(Debug)]
@@ -173,7 +198,10 @@ pub fn get_syntax(media_type: &MediaType) -> Syntax {
 
 /// Options which can be adjusted when transpiling a module.
 #[derive(Debug, Clone)]
-pub struct TranspileOptions {
+pub struct EmitOptions {
+  /// Indicate if JavaScript is being checked/transformed as well, or if it is
+  /// only TypeScript.
+  pub check_js: bool,
   /// When emitting a legacy decorator, also emit experimental decorator meta
   /// data.  Defaults to `false`.
   pub emit_metadata: bool,
@@ -190,9 +218,10 @@ pub struct TranspileOptions {
   pub transform_jsx: bool,
 }
 
-impl Default for TranspileOptions {
+impl Default for EmitOptions {
   fn default() -> Self {
-    TranspileOptions {
+    EmitOptions {
+      check_js: false,
       emit_metadata: false,
       inline_source_map: true,
       jsx_factory: "React.createElement".into(),
@@ -245,8 +274,8 @@ impl ParsedModule {
   /// The result is a tuple of the code and optional source map as strings.
   pub fn transpile(
     self,
-    options: &TranspileOptions,
-  ) -> Result<(String, Option<String>)> {
+    options: &EmitOptions,
+  ) -> Result<(String, Option<String>), AnyError> {
     let program = Program::Module(self.module);
 
     let jsx_pass = react::react(
@@ -263,7 +292,7 @@ impl ParsedModule {
     );
     let mut passes = chain!(
       Optional::new(jsx_pass, options.transform_jsx),
-      decorators::decorators(decorators::Config {
+      proposals::decorators::decorators(proposals::decorators::Config {
         legacy: true,
         emit_metadata: options.emit_metadata
       }),
@@ -329,7 +358,7 @@ pub fn parse(
   specifier: &ModuleSpecifier,
   source: &str,
   media_type: &MediaType,
-) -> Result<ParsedModule> {
+) -> Result<ParsedModule, AnyError> {
   let source_map = SourceMap::default();
   let source_file = source_map.new_source_file(
     FileName::Custom(specifier.to_string()),
@@ -370,6 +399,145 @@ pub fn parse(
     source_map: Rc::new(source_map),
     comments,
   })
+}
+
+pub struct BundleHook;
+
+impl swc_bundler::Hook for BundleHook {
+  fn get_import_meta_url(
+    &self,
+    span: Span,
+    file: &FileName,
+  ) -> Result<Option<Expr>, AnyError> {
+    // we use custom file names, and swc "wraps" these in `<` and `>` so, we
+    // want to strip those back out.
+    let mut value = file.to_string();
+    value.pop();
+    value.remove(0);
+    Ok(Some(Expr::Lit(Lit::Str(Str {
+      span,
+      value: value.into(),
+      has_escape: false,
+    }))))
+  }
+}
+
+pub struct BundleLoader<'a> {
+  emit_options: &'a EmitOptions,
+  cm: Rc<SourceMap>,
+  graph: &'a Graph2,
+}
+
+impl<'a> BundleLoader<'a> {
+  pub fn new(
+    graph: &'a Graph2,
+    cm: Rc<SourceMap>,
+    emit_options: &'a EmitOptions,
+  ) -> Self {
+    BundleLoader {
+      cm,
+      emit_options,
+      graph,
+    }
+  }
+}
+
+impl swc_bundler::Load for BundleLoader<'_> {
+  fn load(
+    &self,
+    file: &FileName,
+  ) -> Result<(Rc<SourceFile>, Module), AnyError> {
+    match file {
+      FileName::Custom(filename) => {
+        let specifier = ModuleSpecifier::resolve_url_or_path(filename)
+          .context("Failed to convert swc FileName to ModuleSpecifier.")?;
+        if let Some(src) = self.graph.get_source(&specifier) {
+          let comments = SingleThreadedComments::default();
+          let media_type = self
+            .graph
+            .get_media_type(&specifier)
+            .context("Failed to lookup media type in BundleLoader")?;
+          let syntax = get_syntax(&media_type);
+          let source_file = self
+            .cm
+            .new_source_file(FileName::Custom(filename.clone()), src);
+          let lexer = Lexer::new(
+            syntax,
+            TARGET,
+            StringInput::from(&*source_file),
+            Some(&comments),
+          );
+          let mut parser = swc_ecmascript::parser::Parser::new_from(lexer);
+          // TODO(@kitsonk) this seems to be a problem with the type of result
+          // from `.parse_module` that cannot be coerced.
+          let module = match parser.parse_module() {
+            Ok(m) => m,
+            Err(err) => bail!("Parsing failed: {:?}", err),
+          };
+
+          // TODO(@kitsonk) DRY-up with ::transpile()
+          let jsx_pass = react::react(
+            self.cm.clone(),
+            Some(&comments),
+            react::Options {
+              pragma: self.emit_options.jsx_factory.clone(),
+              pragma_frag: self.emit_options.jsx_fragment_factory.clone(),
+              // this will use `Object.assign()` instead of the `_extends` helper
+              // when spreading props.
+              use_builtins: true,
+              ..Default::default()
+            },
+          );
+          let mut passes = chain!(
+            Optional::new(jsx_pass, self.emit_options.transform_jsx),
+            proposals::decorators::decorators(proposals::decorators::Config {
+              legacy: true,
+              emit_metadata: self.emit_options.emit_metadata
+            }),
+            typescript::strip(),
+            fixer(Some(&comments)),
+          );
+          let module = module.fold_with(&mut passes);
+
+          Ok((source_file, module))
+        } else {
+          Err(MissingFilename(file.clone()).into())
+        }
+      }
+      _ => unreachable!("Received request for unsupported filename {:?}", file),
+    }
+  }
+}
+
+pub struct BundleResolver<'a> {
+  graph: &'a Graph2,
+}
+
+impl<'a> BundleResolver<'a> {
+  pub fn new(graph: &'a Graph2) -> Self {
+    BundleResolver { graph }
+  }
+}
+
+impl swc_bundler::Resolve for BundleResolver<'_> {
+  fn resolve(
+    &self,
+    referrer: &FileName,
+    specifier: &str,
+  ) -> Result<FileName, AnyError> {
+    let referrer = if let FileName::Custom(referrer) = referrer {
+      ModuleSpecifier::resolve_url_or_path(referrer)
+        .context("Cannot resolve swc FileName to a module specifier")?
+    } else {
+      unreachable!(
+        "An unexpected referrer was passed when bundling: {:?}",
+        referrer
+      )
+    };
+    let specifier = self.graph.resolve(specifier, &referrer)?;
+
+    Ok(FileName::Custom(specifier.to_string()))
+  }
 }
 
 #[cfg(test)]
@@ -436,7 +604,7 @@ mod tests {
     let module = parse(&specifier, source, &MediaType::TypeScript)
       .expect("could not parse module");
     let (code, maybe_map) = module
-      .transpile(&TranspileOptions::default())
+      .transpile(&EmitOptions::default())
       .expect("could not strip types");
     assert!(code.starts_with("var D;\n(function(D) {\n"));
     assert!(
@@ -460,7 +628,7 @@ mod tests {
     let module = parse(&specifier, source, &MediaType::TSX)
       .expect("could not parse module");
     let (code, _) = module
-      .transpile(&TranspileOptions::default())
+      .transpile(&EmitOptions::default())
       .expect("could not strip types");
     assert!(code.contains("React.createElement(\"div\", null"));
   }
@@ -491,7 +659,7 @@ mod tests {
     let module = parse(&specifier, source, &MediaType::TypeScript)
       .expect("could not parse module");
     let (code, _) = module
-      .transpile(&TranspileOptions::default())
+      .transpile(&EmitOptions::default())
       .expect("could not strip types");
     assert!(code.contains("_applyDecoratedDescriptor("));
   }

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -93,6 +93,11 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
     &["bundle", "std/examples/chat/server_test.ts"],
     None,
   ),
+  (
+    "bundle_no_check",
+    &["bundle", "--no-check", "std/examples/chat/server_test.ts"],
+    None,
+  ),
 ];
 
 const RESULT_KEYS: &[&str] =

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -93,11 +93,6 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
     &["bundle", "std/examples/chat/server_test.ts"],
     None,
   ),
-  (
-    "bundle_no_check",
-    &["bundle", "--no-check", "std/examples/chat/server_test.ts"],
-    None,
-  ),
 ];
 
 const RESULT_KEYS: &[&str] =

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -406,14 +406,7 @@ fn install_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 }
 
 fn bundle_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
-  // TODO(nayeemrmn): Replace the next couple lines with `compile_args_parse()`
-  // once `deno bundle --no-check` is supported.
-  importmap_arg_parse(flags, matches);
-  no_remote_arg_parse(flags, matches);
-  config_arg_parse(flags, matches);
-  reload_arg_parse(flags, matches);
-  lock_args_parse(flags, matches);
-  ca_file_arg_parse(flags, matches);
+  compile_args_parse(flags, matches);
 
   let source_file = matches.value_of("source_file").unwrap().to_string();
 
@@ -784,16 +777,7 @@ These must be added to the path manually if required.")
 }
 
 fn bundle_subcommand<'a, 'b>() -> App<'a, 'b> {
-  SubCommand::with_name("bundle")
-    // TODO(nayeemrmn): Replace the next couple lines with `compile_args()` once
-    // `deno bundle --no-check` is supported.
-    .arg(importmap_arg())
-    .arg(no_remote_arg())
-    .arg(config_arg())
-    .arg(reload_arg())
-    .arg(lock_arg())
-    .arg(lock_write_arg())
-    .arg(ca_file_arg())
+  compile_args(SubCommand::with_name("bundle"))
     .arg(
       Arg::with_name("source_file")
         .takes_value(true)
@@ -2355,6 +2339,24 @@ mod tests {
           source_file: "source.ts".to_string(),
           out_file: None,
         },
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn bundle_nocheck() {
+    let r =
+      flags_from_vec_safe(svec!["deno", "bundle", "--no-check", "script.ts"])
+        .unwrap();
+    assert_eq!(
+      r,
+      Flags {
+        subcommand: DenoSubcommand::Bundle {
+          source_file: "script.ts".to_string(),
+          out_file: None,
+        },
+        no_check: true,
         ..Flags::default()
       }
     );

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -65,6 +65,7 @@ use crate::fs as deno_fs;
 use crate::media_type::MediaType;
 use crate::permissions::Permissions;
 use crate::program_state::ProgramState;
+use crate::specifier_handler::FetchHandler;
 use crate::worker::MainWorker;
 use deno_core::error::AnyError;
 use deno_core::futures::future::FutureExt;
@@ -301,7 +302,7 @@ async fn bundle_command(
   let module_specifier = ModuleSpecifier::resolve_url_or_path(&source_file)?;
 
   debug!(">>>>> bundle START");
-  let program_state = ProgramState::new(flags)?;
+  let program_state = ProgramState::new(flags.clone())?;
 
   info!(
     "{} {}",
@@ -309,10 +310,36 @@ async fn bundle_command(
     module_specifier.to_string()
   );
 
-  let output = program_state
-    .ts_compiler
-    .bundle(&program_state, module_specifier)
-    .await?;
+  let output = if flags.no_check {
+    let handler = Rc::new(RefCell::new(FetchHandler::new(
+      &program_state,
+      Permissions::allow_all(),
+    )?));
+    let mut builder = module_graph2::GraphBuilder2::new(
+      handler,
+      program_state.maybe_import_map.clone(),
+    );
+    builder.insert(&module_specifier).await?;
+    let graph = builder.get_graph(&program_state.lockfile)?;
+
+    let (s, stats, maybe_ignored_options) =
+      graph.bundle(module_graph2::BundleOptions {
+        debug: flags.log_level == Some(Level::Debug),
+        maybe_config_path: flags.config_path,
+      })?;
+
+    if let Some(ignored_options) = maybe_ignored_options {
+      eprintln!("{}", ignored_options);
+    }
+    debug!("{}", stats);
+
+    s
+  } else {
+    program_state
+      .ts_compiler
+      .bundle(&program_state, module_specifier)
+      .await?
+  };
 
   debug!(">>>>> bundle END");
 

--- a/cli/tests/bundle/file_tests-fixture01.ts
+++ b/cli/tests/bundle/file_tests-fixture01.ts
@@ -1,0 +1,3 @@
+import * as a from "./subdir/a.ts";
+
+console.log(a);

--- a/cli/tests/bundle/file_tests-fixture02.ts
+++ b/cli/tests/bundle/file_tests-fixture02.ts
@@ -1,0 +1,4 @@
+import * as b from "./subdir/b.ts";
+
+console.log(b.b); // "b"
+console.log(b.c); // { c: "c", default: class C }

--- a/cli/tests/bundle/file_tests-fixture03.ts
+++ b/cli/tests/bundle/file_tests-fixture03.ts
@@ -1,0 +1,3 @@
+import { d } from "./subdir/d.ts";
+
+console.log(d);

--- a/cli/tests/bundle/file_tests-fixture04.ts
+++ b/cli/tests/bundle/file_tests-fixture04.ts
@@ -1,0 +1,3 @@
+const a = await import("./subdir/a.ts");
+
+console.log(a);

--- a/cli/tests/bundle/file_tests-fixture05.ts
+++ b/cli/tests/bundle/file_tests-fixture05.ts
@@ -1,0 +1,3 @@
+import { a } from "./subdir/e.ts";
+
+console.log(a);

--- a/cli/tests/bundle/file_tests-fixture06.ts
+++ b/cli/tests/bundle/file_tests-fixture06.ts
@@ -1,0 +1,4 @@
+import { isMain, modUrl } from "./subdir/f.ts";
+
+console.log(isMain, modUrl);
+console.log(import.meta.main, import.meta.url);

--- a/cli/tests/bundle/file_tests-fixture07.ts
+++ b/cli/tests/bundle/file_tests-fixture07.ts
@@ -1,0 +1,4 @@
+import { G } from "./subdir/g.ts";
+import { H } from "./subdir/h.ts";
+
+console.log(new G(true), new H(true));

--- a/cli/tests/bundle/file_tests-fixture08.ts
+++ b/cli/tests/bundle/file_tests-fixture08.ts
@@ -1,0 +1,1 @@
+export * as a from "./subdir/a.ts";

--- a/cli/tests/bundle/file_tests-fixture09.ts
+++ b/cli/tests/bundle/file_tests-fixture09.ts
@@ -1,0 +1,1 @@
+export { a } from "./subdir/k.ts";

--- a/cli/tests/bundle/file_tests-fixture10.ts
+++ b/cli/tests/bundle/file_tests-fixture10.ts
@@ -1,0 +1,7 @@
+import { a as defaultA } from "./subdir/l.ts";
+
+const o: { a?: string } = {};
+
+const { a = defaultA } = o;
+
+console.log(a);

--- a/cli/tests/bundle/file_tests-fixture11.ts
+++ b/cli/tests/bundle/file_tests-fixture11.ts
@@ -1,0 +1,32 @@
+import { a as defaultA, O } from "./subdir/m.ts";
+export { O } from "./subdir/m.ts";
+
+interface AOptions {
+  a?(): void;
+  c?: O;
+}
+
+class A {
+  #a: () => void;
+  #c?: O;
+  constructor(o: AOptions = {}) {
+    const {
+      a = defaultA,
+      c,
+    } = o;
+    this.#a = a;
+    this.#c = c;
+  }
+
+  a() {
+    this.#a();
+  }
+
+  c() {
+    console.log(this.#c);
+  }
+}
+
+const a = new A();
+a.a();
+a.c();

--- a/cli/tests/bundle/file_tests-fixture12.ts
+++ b/cli/tests/bundle/file_tests-fixture12.ts
@@ -1,0 +1,7 @@
+import { a } from "./subdir/p.ts";
+
+function b() {
+  a();
+}
+
+b();

--- a/cli/tests/bundle/file_tests-fixture13.ts
+++ b/cli/tests/bundle/file_tests-fixture13.ts
@@ -1,0 +1,11 @@
+import { D, d } from "./subdir/q.ts";
+
+class A {
+  private s: D = d();
+
+  a() {
+    this.s.resolve();
+  }
+}
+
+new A();

--- a/cli/tests/bundle/file_tests-fixture14.ts
+++ b/cli/tests/bundle/file_tests-fixture14.ts
@@ -1,0 +1,4 @@
+// @deno-types="https://deno.land/x/lib/mod.d.ts"
+import * as lib from "https://deno.land/x/lib/mod.js";
+
+console.log(lib);

--- a/cli/tests/bundle/file_tests-subdir-a.ts
+++ b/cli/tests/bundle/file_tests-subdir-a.ts
@@ -1,0 +1,1 @@
+export const a = "a";

--- a/cli/tests/bundle/file_tests-subdir-b.ts
+++ b/cli/tests/bundle/file_tests-subdir-b.ts
@@ -1,0 +1,3 @@
+export * as c from "./c.ts";
+
+export const b = "b";

--- a/cli/tests/bundle/file_tests-subdir-c.ts
+++ b/cli/tests/bundle/file_tests-subdir-c.ts
@@ -1,0 +1,2 @@
+export const c = "c";
+export default class C {}

--- a/cli/tests/bundle/file_tests-subdir-d.ts
+++ b/cli/tests/bundle/file_tests-subdir-d.ts
@@ -1,0 +1,3 @@
+import { a } from "./a.ts";
+
+export const d = { a };

--- a/cli/tests/bundle/file_tests-subdir-e.ts
+++ b/cli/tests/bundle/file_tests-subdir-e.ts
@@ -1,0 +1,1 @@
+export * from "./a.ts";

--- a/cli/tests/bundle/file_tests-subdir-f.ts
+++ b/cli/tests/bundle/file_tests-subdir-f.ts
@@ -1,0 +1,2 @@
+export const isMain = import.meta.main;
+export const modUrl = import.meta.url;

--- a/cli/tests/bundle/file_tests-subdir-g.ts
+++ b/cli/tests/bundle/file_tests-subdir-g.ts
@@ -1,0 +1,12 @@
+const g: number[] = [];
+
+export class G {
+  #g!: number[];
+  constructor(shared: boolean) {
+    if (shared) {
+      this.#g = g;
+    } else {
+      this.#g = [];
+    }
+  }
+}

--- a/cli/tests/bundle/file_tests-subdir-h.ts
+++ b/cli/tests/bundle/file_tests-subdir-h.ts
@@ -1,0 +1,12 @@
+const g: number[] = [];
+
+export class H {
+  #g!: number[];
+  constructor(shared: boolean) {
+    if (shared) {
+      this.#g = g;
+    } else {
+      this.#g = [];
+    }
+  }
+}

--- a/cli/tests/bundle/file_tests-subdir-i.ts
+++ b/cli/tests/bundle/file_tests-subdir-i.ts
@@ -1,0 +1,3 @@
+export function a(...d: string[]): string {
+  return d.join(" ");
+}

--- a/cli/tests/bundle/file_tests-subdir-j.ts
+++ b/cli/tests/bundle/file_tests-subdir-j.ts
@@ -1,0 +1,3 @@
+export function a(...d: string[]): string {
+  return d.join("/");
+}

--- a/cli/tests/bundle/file_tests-subdir-k.ts
+++ b/cli/tests/bundle/file_tests-subdir-k.ts
@@ -1,0 +1,11 @@
+import * as _i from "./i.ts";
+import * as _j from "./j.ts";
+
+const k = globalThis.value ? _i : _j;
+
+export const i = _i;
+export const j = _j;
+
+export const {
+  a,
+} = k;

--- a/cli/tests/bundle/file_tests-subdir-l.ts
+++ b/cli/tests/bundle/file_tests-subdir-l.ts
@@ -1,0 +1,1 @@
+export { a } from "./a.ts";

--- a/cli/tests/bundle/file_tests-subdir-m.ts
+++ b/cli/tests/bundle/file_tests-subdir-m.ts
@@ -1,0 +1,2 @@
+export { a } from "./n.ts";
+export { O } from "./o.ts";

--- a/cli/tests/bundle/file_tests-subdir-n.ts
+++ b/cli/tests/bundle/file_tests-subdir-n.ts
@@ -1,0 +1,3 @@
+export function a() {
+  console.log("a");
+}

--- a/cli/tests/bundle/file_tests-subdir-o.ts
+++ b/cli/tests/bundle/file_tests-subdir-o.ts
@@ -1,0 +1,5 @@
+export enum O {
+  A,
+  B,
+  C,
+}

--- a/cli/tests/bundle/file_tests-subdir-p.ts
+++ b/cli/tests/bundle/file_tests-subdir-p.ts
@@ -1,0 +1,1 @@
+export * from "./i.ts";

--- a/cli/tests/bundle/file_tests-subdir-q.ts
+++ b/cli/tests/bundle/file_tests-subdir-q.ts
@@ -1,0 +1,13 @@
+/* eslint-disable */
+export interface D {
+  resolve: any;
+  reject: any;
+}
+
+export function d(): D {
+  let methods;
+  const promise = new Promise((resolve, reject) => {
+    methods = { resolve, reject };
+  });
+  return Object.assign(promise, methods);
+}

--- a/cli/tests/bundle/fixture01.out
+++ b/cli/tests/bundle/fixture01.out
@@ -1,0 +1,7 @@
+const a = function() {
+    const a = "a";
+    return {
+        a
+    };
+}();
+console.log(a);

--- a/cli/tests/bundle/fixture02.out
+++ b/cli/tests/bundle/fixture02.out
@@ -1,0 +1,11 @@
+const c = function() {
+    const c1 = "c";
+    class C {
+    }
+    return {
+        c: c1,
+        default: C
+    };
+}();
+console.log("b");
+console.log(c);

--- a/cli/tests/bundle/fixture03.out
+++ b/cli/tests/bundle/fixture03.out
@@ -1,0 +1,4 @@
+const d = {
+    a: "a"
+};
+console.log(d);

--- a/cli/tests/bundle/fixture04.out
+++ b/cli/tests/bundle/fixture04.out
@@ -1,0 +1,2 @@
+const a = await import("./subdir/a.ts");
+console.log(a);

--- a/cli/tests/bundle/fixture05.out
+++ b/cli/tests/bundle/fixture05.out
@@ -1,0 +1,1 @@
+console.log("a");

--- a/cli/tests/bundle/fixture06.out
+++ b/cli/tests/bundle/fixture06.out
@@ -1,0 +1,2 @@
+console.log(false, "file:///tests/subdir/f.ts");
+console.log(import.meta.main, "file:///tests/fixture06.ts");

--- a/cli/tests/bundle/fixture07.out
+++ b/cli/tests/bundle/fixture07.out
@@ -1,0 +1,23 @@
+const g = [];
+class G {
+    #g;
+    constructor(shared){
+        if (shared) {
+            this.#g = g;
+        } else {
+            this.#g = [];
+        }
+    }
+}
+const g1 = [];
+class H {
+    #g;
+    constructor(shared1){
+        if (shared1) {
+            this.#g = g1;
+        } else {
+            this.#g = [];
+        }
+    }
+}
+console.log(new G(true), new H(true));

--- a/cli/tests/bundle/fixture08.out
+++ b/cli/tests/bundle/fixture08.out
@@ -1,0 +1,7 @@
+const a = function() {
+    const a1 = "a";
+    return {
+        a: a1
+    };
+}();
+export { a };

--- a/cli/tests/bundle/fixture09.out
+++ b/cli/tests/bundle/fixture09.out
@@ -1,0 +1,19 @@
+const _i = function() {
+    function a(...d) {
+        return d.join(" ");
+    }
+    return {
+        a
+    };
+}();
+const _j = function() {
+    function a(...d) {
+        return d.join("/");
+    }
+    return {
+        a
+    };
+}();
+const k = globalThis.value ? _i : _j;
+const { a ,  } = k;
+export { a };

--- a/cli/tests/bundle/fixture10.out
+++ b/cli/tests/bundle/fixture10.out
@@ -1,0 +1,4 @@
+const o = {
+};
+const { a ="a"  } = o;
+console.log(a);

--- a/cli/tests/bundle/fixture11.out
+++ b/cli/tests/bundle/fixture11.out
@@ -1,0 +1,31 @@
+function a() {
+    console.log("a");
+}
+var O;
+(function(O1) {
+    O1[O1["A"] = 0] = "A";
+    O1[O1["B"] = 1] = "B";
+    O1[O1["C"] = 2] = "C";
+})((void 0) || (O = {
+}));
+const O1 = void 0;
+export { O1 as O };
+class A {
+    #a;
+    #c;
+    constructor(o = {
+    }){
+        const { a: a1 = a , c ,  } = o;
+        this.#a = a1;
+        this.#c = c;
+    }
+    a() {
+        this.#a();
+    }
+    c() {
+        console.log(this.#c);
+    }
+}
+const a2 = new A();
+a2.a();
+a2.c();

--- a/cli/tests/bundle/fixture12.out
+++ b/cli/tests/bundle/fixture12.out
@@ -1,0 +1,7 @@
+function a(...d) {
+    return d.join(" ");
+}
+function b() {
+    a();
+}
+b();

--- a/cli/tests/bundle/fixture13.out
+++ b/cli/tests/bundle/fixture13.out
@@ -1,0 +1,17 @@
+function d() {
+    let methods;
+    const promise = new Promise((resolve, reject)=>{
+        methods = {
+            resolve,
+            reject
+        };
+    });
+    return Object.assign(promise, methods);
+}
+class A {
+    s = d();
+    a() {
+        this.s.resolve();
+    }
+}
+new A();

--- a/cli/tests/bundle/fixture14.out
+++ b/cli/tests/bundle/fixture14.out
@@ -1,0 +1,25 @@
+const lib = function() {
+    const a = function() {
+        const a1 = [];
+        return {
+            a: a1
+        };
+    }();
+    const b = function() {
+        const b1 = [];
+        return {
+            b: b1
+        };
+    }();
+    const c = function() {
+        const c1;
+        return {
+            c: c1
+        };
+    }();
+    const mod;
+    return {
+        mod
+    };
+}();
+console.log(lib);

--- a/cli/tests/bundle/https_deno.land-x-lib-a.ts
+++ b/cli/tests/bundle/https_deno.land-x-lib-a.ts
@@ -1,0 +1,1 @@
+export const a: string[] = [];

--- a/cli/tests/bundle/https_deno.land-x-lib-b.js
+++ b/cli/tests/bundle/https_deno.land-x-lib-b.js
@@ -1,0 +1,1 @@
+export const b = [];

--- a/cli/tests/bundle/https_deno.land-x-lib-c.d.ts
+++ b/cli/tests/bundle/https_deno.land-x-lib-c.d.ts
@@ -1,0 +1,1 @@
+export const c: string[];

--- a/cli/tests/bundle/https_deno.land-x-lib-c.js
+++ b/cli/tests/bundle/https_deno.land-x-lib-c.js
@@ -1,0 +1,3 @@
+/// <reference types="./c.d.ts" />
+
+export const c = [];

--- a/cli/tests/bundle/https_deno.land-x-lib-mod.d.ts
+++ b/cli/tests/bundle/https_deno.land-x-lib-mod.d.ts
@@ -1,0 +1,9 @@
+export * as a from "./a.ts";
+export * as b from "./b.js";
+export * as c from "./c.js";
+
+export interface A {
+  a: string;
+}
+
+export const mod: A[];

--- a/cli/tests/bundle/https_deno.land-x-lib-mod.js
+++ b/cli/tests/bundle/https_deno.land-x-lib-mod.js
@@ -1,0 +1,5 @@
+export * as a from "./a.ts";
+export * as b from "./b.js";
+export * as c from "./c.js";
+
+export const mod = [];

--- a/cli/tsc_config.rs
+++ b/cli/tsc_config.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-use crate::ast;
 use deno_core::error::AnyError;
 use deno_core::serde_json;
 use deno_core::serde_json::Value;
@@ -203,7 +202,7 @@ pub fn parse_config(
 
 /// A structure for managing the configuration of TypeScript
 #[derive(Debug, Clone)]
-pub struct TsConfig(Value);
+pub struct TsConfig(pub Value);
 
 impl TsConfig {
   /// Create a new `TsConfig` with the base being the `value` supplied.
@@ -247,19 +246,6 @@ impl TsConfig {
     } else {
       Ok(None)
     }
-  }
-
-  /// Return the current configuration as a `EmitOptions` structure.
-  pub fn as_emit_options(&self) -> Result<ast::EmitOptions, AnyError> {
-    let options: EmitConfigOptions = serde_json::from_value(self.0.clone())?;
-    Ok(ast::EmitOptions {
-      check_js: options.check_js,
-      emit_metadata: options.emit_decorator_metadata,
-      inline_source_map: true,
-      jsx_factory: options.jsx_factory,
-      jsx_fragment_factory: options.jsx_fragment_factory,
-      transform_jsx: options.jsx == "react",
-    })
   }
 }
 

--- a/cli/tsc_config.rs
+++ b/cli/tsc_config.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+use crate::ast;
 use deno_core::error::AnyError;
 use deno_core::serde_json;
 use deno_core::serde_json::Value;
@@ -17,7 +18,7 @@ use std::str::FromStr;
 /// file, that we want to deserialize out of the final config for a transpile.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct TranspileConfigOptions {
+pub struct EmitConfigOptions {
   pub check_js: bool,
   pub emit_decorator_metadata: bool,
   pub jsx: String,
@@ -248,13 +249,17 @@ impl TsConfig {
     }
   }
 
-  /// Return the current configuration as a `TranspileConfigOptions` structure.
-  pub fn as_transpile_config(
-    &self,
-  ) -> Result<TranspileConfigOptions, AnyError> {
-    let options: TranspileConfigOptions =
-      serde_json::from_value(self.0.clone())?;
-    Ok(options)
+  /// Return the current configuration as a `EmitOptions` structure.
+  pub fn as_emit_options(&self) -> Result<ast::EmitOptions, AnyError> {
+    let options: EmitConfigOptions = serde_json::from_value(self.0.clone())?;
+    Ok(ast::EmitOptions {
+      check_js: options.check_js,
+      emit_metadata: options.emit_decorator_metadata,
+      inline_source_map: true,
+      jsx_factory: options.jsx_factory,
+      jsx_fragment_factory: options.jsx_fragment_factory,
+      transform_jsx: options.jsx == "react",
+    })
   }
 }
 


### PR DESCRIPTION
Add support for `deno bundle --no-check`.  This uses swc for the bundling (thanks to a lot of hard work and fixes by @kdy1).  There are some substantial differences from `deno bundle` though:

- The output is a single file ESM file that is a "flattened" version of the input sources.  `deno bundle` uses the System module format and provides a custom loader.  While there might be still some defects, we have tried to do some extensive testing to ensure that that the unbundle code behaviour is preserved when bundled.
- Dynamic imports are left "untouched".  This is a significant change from the current behaviour, where sometimes dynamic imports are included in the bundle if they can be statically determined at bundle time.  It is a double edged sword bundling dynamic imports, as the behaviour might or might not be desired, so it is best to just leave them alone.
- `import.meta.url` and `import.meta.main` work in the bundle, where `import.meta.url` will get "hardcoded" at bundle time and `import.meta.main` will be `false` for any dependent modules, but be preserved in the bundle for the main/entry point module.

We are looking at replacing `deno bundle` with this bundling in a subsequent PR.

Fixes #6686
