### PR TITLE
fix(op_crates/fetch): Body.body should be stream of Uint8Array

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -133,6 +133,7 @@ unitTest({ perms: { net: true } }, async function fetchAsyncIterator(): Promise<
   assert(response.body !== null);
   let total = 0;
   for await (const chunk of response.body) {
+    assert(chunk instanceof Uint8Array);
     total += chunk.length;
   }
 
@@ -145,12 +146,13 @@ unitTest({ perms: { net: true } }, async function fetchBodyReader(): Promise<
   const response = await fetch("http://localhost:4545/cli/tests/fixture.json");
   const headers = response.headers;
   assert(response.body !== null);
-  const reader = await response.body.getReader();
+  const reader = response.body.getReader();
   let total = 0;
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
     assert(value);
+    assert(value instanceof Uint8Array);
     total += value.length;
   }
 

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -786,7 +786,7 @@
 
         this._stream = new ReadableStream({
           start(controller) {
-            controller.enqueue(buf);
+            controller.enqueue(new Uint8Array(buf));
             controller.close();
           },
         });


### PR DESCRIPTION
Currently Body.body is implemented as `ReadableStream<ArrayBuffer>` but according to spec it should be `ReadableStream<Uint8Array>`. This fixes that. This error would have likely been caught by TypeScript (of tsc using JSDoc).
