### PR TITLE
fix(cli/repl): ignore pair matching inside literals

### DIFF
--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -33,7 +33,33 @@ impl Validator for Helper {
     ctx: &mut ValidationContext,
   ) -> Result<ValidationResult, ReadlineError> {
     let mut stack: Vec<char> = Vec::new();
+    let mut literal: Option<char> = None;
+    let mut escape: bool = false;
+
     for c in ctx.input().chars() {
+      if escape {
+        escape = false;
+        continue;
+      }
+
+      if c == '\\' {
+        escape = true;
+        continue;
+      }
+
+      if let Some(v) = literal {
+        if c == v {
+          literal = None
+        }
+
+        continue;
+      } else {
+        literal = match c {
+          '`' | '"' | '/' | '\'' => Some(c),
+          _ => None,
+        };
+      }
+
       match c {
         '(' | '[' | '{' => stack.push(c),
         ')' | ']' | '}' => match (stack.pop(), c) {
@@ -51,19 +77,15 @@ impl Validator for Helper {
             ))))
           }
         },
-        '`' => {
-          if stack.is_empty() || stack.last().unwrap() != &c {
-            stack.push(c);
-          } else {
-            stack.pop();
-          }
-        }
-
         _ => {}
       }
     }
 
     if !stack.is_empty() {
+      return Ok(ValidationResult::Incomplete);
+    }
+
+    if literal == Some('`') {
       return Ok(ValidationResult::Incomplete);
     }
 

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -81,11 +81,7 @@ impl Validator for Helper {
       }
     }
 
-    if !stack.is_empty() {
-      return Ok(ValidationResult::Incomplete);
-    }
-
-    if literal == Some('`') {
+    if !stack.is_empty() || literal == Some('`') {
       return Ok(ValidationResult::Incomplete);
     }
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1146,6 +1146,7 @@ fn repl_test_pty_multiline() {
     master.write_all(b"/{/'\n").unwrap();
     master.write_all(b"/(/'\n").unwrap();
     master.write_all(b"/[/'\n").unwrap();
+    master.write_all(b"console.log(\"{test1} abc {test2} def {{test3}}\".match(/{([^{].+?)}/));\n").unwrap();
     master.write_all(b"close();\n").unwrap();
 
     let mut output = String::new();
@@ -1161,6 +1162,7 @@ fn repl_test_pty_multiline() {
     assert!(output.contains("/{/"));
     assert!(output.contains("/(/"));
     assert!(output.contains("/{/"));
+    assert!(output.contains("[ \"{test1}\", \"test1\" ]"));
 
     fork.wait().unwrap();
   } else {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1139,6 +1139,13 @@ fn repl_test_pty_multiline() {
     master.write_all(b"(\n1 + 2\n)\n").unwrap();
     master.write_all(b"{\nfoo: \"foo\"\n}\n").unwrap();
     master.write_all(b"`\nfoo\n`\n").unwrap();
+    master.write_all(b"`\n\\`\n`\n").unwrap();
+    master.write_all(b"'{'\n").unwrap();
+    master.write_all(b"'('\n").unwrap();
+    master.write_all(b"'['\n").unwrap();
+    master.write_all(b"/{/'\n").unwrap();
+    master.write_all(b"/(/'\n").unwrap();
+    master.write_all(b"/[/'\n").unwrap();
     master.write_all(b"close();\n").unwrap();
 
     let mut output = String::new();
@@ -1147,6 +1154,13 @@ fn repl_test_pty_multiline() {
     assert!(output.contains('3'));
     assert!(output.contains("{ foo: \"foo\" }"));
     assert!(output.contains("\"\\nfoo\\n\""));
+    assert!(output.contains("\"\\n`\\n\""));
+    assert!(output.contains("\"{\""));
+    assert!(output.contains("\"(\""));
+    assert!(output.contains("\"[\""));
+    assert!(output.contains("/{/"));
+    assert!(output.contains("/(/"));
+    assert!(output.contains("/{/"));
 
     fork.wait().unwrap();
   } else {


### PR DESCRIPTION
This ignores brace pairs until a literal sequence has been finished when validating readline input.

Fixes #7978 
Fixes #8034