### PR TITLE
fix(cli): don't walk the subdirectory twice when using the `--ignore` flag

### DIFF
--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -253,19 +253,15 @@ pub fn collect_files(
     }
   } else {
     for file in files {
-      if file.is_dir() {
-        for entry in WalkDir::new(file)
-          .into_iter()
-          .filter_entry(|e| !ignore.iter().any(|i| e.path().starts_with(i)))
-        {
-          let entry_clone = entry?.clone();
-          if is_supported(entry_clone.path()) {
-            target_files.push(entry_clone.into_path().canonicalize()?)
-          }
+      for entry in WalkDir::new(file)
+        .into_iter()
+        .filter_entry(|e| !ignore.iter().any(|i| e.path().starts_with(i)))
+      {
+        let entry_clone = entry?.clone();
+        if is_supported(entry_clone.path()) {
+          target_files.push(entry_clone.into_path().canonicalize()?)
         }
-      } else {
-        target_files.push(file.canonicalize()?);
-      };
+      }
     }
   }
 

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -227,14 +227,16 @@ fn is_supported(path: &Path) -> bool {
 
 pub fn collect_files(
   files: Vec<PathBuf>,
-  ignore: Vec<PathBuf>,
+  mut ignore: Vec<PathBuf>,
 ) -> Result<Vec<PathBuf>, std::io::Error> {
   let mut target_files: Vec<PathBuf> = vec![];
+
+  // retain only the paths which exist and ignore the rest
+  ignore.retain(|i| i.exists());
 
   if files.is_empty() {
     for entry in WalkDir::new(std::env::current_dir()?)
       .into_iter()
-      // FIXME the unwrap here panicks when we add a ignore file/folder which doesn't exist
       .filter_entry(|e| {
         !ignore.iter().any(|i| {
           e.path()

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -10,7 +10,7 @@
 use crate::colors;
 use crate::diff::diff;
 use crate::fs::canonicalize_path;
-use crate::fs::files_in_subtree;
+// use crate::fs::files_in_subtree;
 use crate::text_encoding;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
@@ -25,6 +25,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use walkdir::WalkDir;
 
 const BOM_CHAR: char = '\u{FEFF}';
 
@@ -41,13 +42,13 @@ pub async fn format(
     return format_stdin(check);
   }
   // collect all files provided.
-  let mut target_files = collect_files(args)?;
-  if !exclude.is_empty() {
+  let target_files = collect_files(args, exclude)?;
+  // if !exclude.is_empty() {
     // collect all files to be ignored
     // and retain only files that should be formatted.
-    let ignore_files = collect_files(exclude)?;
-    target_files.retain(|f| !ignore_files.contains(&f));
-  }
+    // let ignore_files = collect_files(exclude, exclude)?;
+    // target_files.retain(|f| !ignore_files.contains(&f));
+  // }
   let config = get_config();
   if check {
     check_source_files(config, target_files).await
@@ -233,25 +234,34 @@ fn is_supported(path: &Path) -> bool {
 }
 
 pub fn collect_files(
-  files: Vec<PathBuf>,
+  _files: Vec<PathBuf>,
+  ignore: Vec<PathBuf>
 ) -> Result<Vec<PathBuf>, std::io::Error> {
   let mut target_files: Vec<PathBuf> = vec![];
 
-  if files.is_empty() {
-    target_files.extend(files_in_subtree(
-      canonicalize_path(&std::env::current_dir()?)?,
-      is_supported,
-    ));
-  } else {
-    for file in files {
-      if file.is_dir() {
-        target_files
-          .extend(files_in_subtree(canonicalize_path(&file)?, is_supported));
-      } else {
-        target_files.push(canonicalize_path(&file)?);
-      };
+  for entry in WalkDir::new(std::env::current_dir()?.canonicalize()?).into_iter().filter_entry(|e| !ignore.contains(&e.clone().into_path())) {
+    if is_supported(entry?.path()) {
+      target_files.push(entry?.into_path())
     }
   }
+
+  dbg!(&target_files);
+
+  // if files.is_empty() {
+  //   target_files.extend(files_in_subtree(
+  //     std::env::current_dir()?.canonicalize()?,
+  //     is_supported,
+  //   ));
+  // } else {
+  //   for file in files {
+  //     if file.is_dir() {
+  //       target_files
+  //         .extend(files_in_subtree(file.canonicalize()?, is_supported));
+  //     } else {
+  //       target_files.push(file.canonicalize()?);
+  //     };
+  //   }
+  // }
 
   Ok(target_files)
 }

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -48,13 +48,13 @@ pub async fn lint_files(
   if args.len() == 1 && args[0].to_string_lossy() == "-" {
     return lint_stdin(json);
   }
-  let mut target_files = collect_files(args)?;
-  if !ignore.is_empty() {
+  let target_files = collect_files(args, ignore)?;
+  // if !ignore.is_empty() {
     // collect all files to be ignored
     // and retain only files that should be linted.
-    let ignore_files = collect_files(ignore)?;
-    target_files.retain(|f| !ignore_files.contains(&f));
-  }
+    // let ignore_files = collect_files(ignore)?;
+    // target_files.retain(|f| !ignore_files.contains(&f));
+  // }
   debug!("Found {} files", target_files.len());
   let target_files_len = target_files.len();
 

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -49,12 +49,6 @@ pub async fn lint_files(
     return lint_stdin(json);
   }
   let target_files = collect_files(args, ignore)?;
-  // if !ignore.is_empty() {
-    // collect all files to be ignored
-    // and retain only files that should be linted.
-    // let ignore_files = collect_files(ignore)?;
-    // target_files.retain(|f| !ignore_files.contains(&f));
-  // }
   debug!("Found {} files", target_files.len());
   let target_files_len = target_files.len();
 


### PR DESCRIPTION
Fixes #7736 