### PR TITLE
refactor(cli): use PathBuf instead of String for lint and fmt subcommands

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -40,8 +40,8 @@ pub enum DenoSubcommand {
   },
   Fmt {
     check: bool,
-    files: Vec<String>,
-    ignore: Vec<String>,
+    files: Vec<PathBuf>,
+    ignore: Vec<PathBuf>,
   },
   Info {
     json: bool,
@@ -55,8 +55,8 @@ pub enum DenoSubcommand {
     force: bool,
   },
   Lint {
-    files: Vec<String>,
-    ignore: Vec<String>,
+    files: Vec<PathBuf>,
+    ignore: Vec<PathBuf>,
     rules: bool,
     json: bool,
   },
@@ -106,7 +106,7 @@ pub struct Flags {
   pub cached_only: bool,
   pub config_path: Option<String>,
   pub coverage: bool,
-  pub ignore: Vec<String>,
+  pub ignore: Vec<PathBuf>,
   pub import_map_path: Option<String>,
   pub inspect: Option<SocketAddr>,
   pub inspect_brk: Option<SocketAddr>,
@@ -357,11 +357,11 @@ fn types_parse(flags: &mut Flags, _matches: &clap::ArgMatches) {
 
 fn fmt_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   let files = match matches.values_of("files") {
-    Some(f) => f.map(String::from).collect(),
+    Some(f) => f.map(PathBuf::from).collect(),
     None => vec![],
   };
   let ignore = match matches.values_of("ignore") {
-    Some(f) => f.map(String::from).collect(),
+    Some(f) => f.map(PathBuf::from).collect(),
     None => vec![],
   };
   flags.subcommand = DenoSubcommand::Fmt {
@@ -650,11 +650,11 @@ fn doc_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 
 fn lint_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   let files = match matches.values_of("files") {
-    Some(f) => f.map(String::from).collect(),
+    Some(f) => f.map(PathBuf::from).collect(),
     None => vec![],
   };
   let ignore = match matches.values_of("ignore") {
-    Some(f) => f.map(String::from).collect(),
+    Some(f) => f.map(PathBuf::from).collect(),
     None => vec![],
   };
   let rules = matches.is_present("rules");
@@ -1803,7 +1803,10 @@ mod tests {
         subcommand: DenoSubcommand::Fmt {
           ignore: vec![],
           check: false,
-          files: vec!["script_1.ts".to_string(), "script_2.ts".to_string()],
+          files: vec![
+            PathBuf::from("script_1.ts"),
+            PathBuf::from("script_2.ts")
+          ],
         },
         ..Flags::default()
       }
@@ -1849,7 +1852,10 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Lint {
-          files: vec!["script_1.ts".to_string(), "script_2.ts".to_string()],
+          files: vec![
+            PathBuf::from("script_1.ts"),
+            PathBuf::from("script_2.ts")
+          ],
           rules: false,
           json: false,
           ignore: vec![],
@@ -1872,7 +1878,10 @@ mod tests {
           files: vec![],
           rules: false,
           json: false,
-          ignore: svec!["script_1.ts", "script_2.ts"],
+          ignore: vec![
+            PathBuf::from("script_1.ts"),
+            PathBuf::from("script_2.ts")
+          ],
         },
         unstable: true,
         ..Flags::default()
@@ -1905,7 +1914,7 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Lint {
-          files: vec!["script_1.ts".to_string()],
+          files: vec![PathBuf::from("script_1.ts")],
           rules: false,
           json: true,
           ignore: vec![],

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -32,11 +32,11 @@ const BOM_CHAR: char = '\u{FEFF}';
 /// First argument and ignore supports globs, and if it is `None`
 /// then the current directory is recursively walked.
 pub async fn format(
-  args: Vec<String>,
+  args: Vec<PathBuf>,
   check: bool,
-  exclude: Vec<String>,
+  exclude: Vec<PathBuf>,
 ) -> Result<(), AnyError> {
-  if args.len() == 1 && args[0] == "-" {
+  if args.len() == 1 && args.get(0).unwrap().to_str().unwrap() == "-" {
     return format_stdin(check);
   }
   // collect all files provided.
@@ -232,7 +232,7 @@ fn is_supported(path: &Path) -> bool {
 }
 
 pub fn collect_files(
-  files: Vec<String>,
+  files: Vec<PathBuf>,
 ) -> Result<Vec<PathBuf>, std::io::Error> {
   let mut target_files: Vec<PathBuf> = vec![];
 
@@ -242,12 +242,12 @@ pub fn collect_files(
       is_supported,
     ));
   } else {
-    for arg in files {
-      let p = PathBuf::from(arg);
-      if p.is_dir() {
-        target_files.extend(files_in_subtree(p.canonicalize()?, is_supported));
+    for file in files {
+      if file.is_dir() {
+        target_files
+          .extend(files_in_subtree(file.canonicalize()?, is_supported));
       } else {
-        target_files.push(p.canonicalize()?);
+        target_files.push(file.canonicalize()?);
       };
     }
   }

--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -36,7 +36,7 @@ pub async fn format(
   check: bool,
   exclude: Vec<PathBuf>,
 ) -> Result<(), AnyError> {
-  if args.len() == 1 && args.get(0).unwrap().to_str().unwrap() == "-" {
+  if args.len() == 1 && args[0].to_string_lossy() == "-" {
     return format_stdin(check);
   }
   // collect all files provided.

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -44,7 +44,7 @@ pub async fn lint_files(
   ignore: Vec<PathBuf>,
   json: bool,
 ) -> Result<(), AnyError> {
-  if args.len() == 1 && args.get(0).unwrap().to_str().unwrap() == "-" {
+  if args.len() == 1 && args[0].to_string_lossy() == "-" {
     // TODO don't use unwrap here
     return lint_stdin(json);
   }

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -45,7 +45,6 @@ pub async fn lint_files(
   json: bool,
 ) -> Result<(), AnyError> {
   if args.len() == 1 && args[0].to_string_lossy() == "-" {
-    // TODO don't use unwrap here
     return lint_stdin(json);
   }
   let mut target_files = collect_files(args)?;

--- a/cli/lint.rs
+++ b/cli/lint.rs
@@ -40,11 +40,12 @@ fn create_reporter(kind: LintReporterKind) -> Box<dyn LintReporter + Send> {
 }
 
 pub async fn lint_files(
-  args: Vec<String>,
-  ignore: Vec<String>,
+  args: Vec<PathBuf>,
+  ignore: Vec<PathBuf>,
   json: bool,
 ) -> Result<(), AnyError> {
-  if args.len() == 1 && args[0] == "-" {
+  if args.len() == 1 && args.get(0).unwrap().to_str().unwrap() == "-" {
+    // TODO don't use unwrap here
     return lint_stdin(json);
   }
   let mut target_files = collect_files(args)?;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -213,9 +213,9 @@ async fn install_command(
 
 async fn lint_command(
   flags: Flags,
-  files: Vec<String>,
+  files: Vec<PathBuf>,
   list_rules: bool,
-  ignore: Vec<String>,
+  ignore: Vec<PathBuf>,
   json: bool,
 ) -> Result<(), AnyError> {
   if !flags.unstable {


### PR DESCRIPTION
There was not really a need for this PR but it was a pain to work with files with `String`s as you have to convert them every time you need to use them. So I went ahead and replaced the `String`s with `PathBuf`s (for the Lint and Fmt subcommands)