### PR TITLE
BREAKING(cli/tsc): Enable isolatedModules by default

### DIFF
--- a/cli/module_graph2.rs
+++ b/cli/module_graph2.rs
@@ -698,9 +698,6 @@ impl Graph2 {
     options: CheckOptions,
   ) -> Result<(Stats, Diagnostics, Option<IgnoredCompilerOptions>), AnyError>
   {
-    // TODO(@kitsonk) set to `true` in followup PR
-    let unstable = options.lib == TypeLib::UnstableDenoWindow
-      || options.lib == TypeLib::UnstableDenoWorker;
     let mut config = TsConfig::new(json!({
       "allowJs": true,
       // TODO(@kitsonk) is this really needed?
@@ -708,7 +705,7 @@ impl Graph2 {
       // Enabled by default to align to transpile/swc defaults
       "experimentalDecorators": true,
       "incremental": true,
-      "isolatedModules": unstable,
+      "isolatedModules": true,
       "lib": options.lib,
       "module": "esnext",
       "strict": true,

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -716,8 +716,7 @@ pub async fn runtime_compile(
     "allowNonTsExtensions": true,
     "checkJs": false,
     "esModuleInterop": true,
-    // TODO(lucacasonato): enable this by default in 1.5.0
-    "isolatedModules": unstable,
+    "isolatedModules": true,
     "jsx": "react",
     "module": "esnext",
     "sourceMap": true,

--- a/cli/tsc_config.rs
+++ b/cli/tsc_config.rs
@@ -69,6 +69,7 @@ const IGNORED_COMPILER_OPTIONS: [&str; 61] = [
   "inlineSourceMap",
   "inlineSources",
   "init",
+  // TODO(nayeemrmn): Add "isolatedModules" here for 1.6.0.
   "listEmittedFiles",
   "listFiles",
   "mapRoot",


### PR DESCRIPTION
Closes #7326.

Closes #7947, as code written for stable is once again compatible with `--unstable`. Discussion: I strongly feel we should maintain this property, even if it means going straight to stable for future changes like this. Code written for `--unstable` is by design incompatible with stable -- having incompatibilities going the opposite way as well splits the ecosystem in half, generating a lot of headache and noise. Better to have everyone adapt at once.