### PR TITLE
test(std/wasi): reduce test duplication

### DIFF
--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -4,77 +4,51 @@ import { copy } from "../fs/mod.ts";
 import * as path from "../path/mod.ts";
 
 const tests = [
-  "testdata/std_env_args_none.wasm",
-  "testdata/std_env_args_some.wasm",
-  "testdata/std_env_vars_none.wasm",
-  "testdata/std_env_vars_some.wasm",
-  "testdata/std_fs_create_dir_absolute.wasm",
-  "testdata/std_fs_create_dir_relative.wasm",
-  "testdata/std_fs_file_create_absolute.wasm",
-  "testdata/std_fs_file_create_relative.wasm",
-  "testdata/std_fs_file_metadata_absolute.wasm",
-  "testdata/std_fs_file_metadata_relative.wasm",
-  "testdata/std_fs_file_seek_absolute.wasm",
-  "testdata/std_fs_file_seek_relative.wasm",
-  "testdata/std_fs_file_set_len_absolute.wasm",
-  "testdata/std_fs_file_set_len_relative.wasm",
-  "testdata/std_fs_file_sync_all_absolute.wasm",
-  "testdata/std_fs_file_sync_all_relative.wasm",
-  "testdata/std_fs_file_sync_data_absolute.wasm",
-  "testdata/std_fs_file_sync_data_relative.wasm",
-  "testdata/std_fs_hard_link_absolute.wasm",
-  "testdata/std_fs_hard_link_relative.wasm",
-  "testdata/std_fs_metadata_absolute.wasm",
-  "testdata/std_fs_metadata_relative.wasm",
-  "testdata/std_fs_read_absolute.wasm",
-  "testdata/std_fs_read_dir_absolute.wasm",
-  "testdata/std_fs_read_dir_relative.wasm",
-  "testdata/std_fs_read_relative.wasm",
-  "testdata/std_fs_remove_dir_all_absolute.wasm",
-  "testdata/std_fs_remove_dir_all_relative.wasm",
-  "testdata/std_fs_rename_absolute.wasm",
-  "testdata/std_fs_rename_relative.wasm",
-  "testdata/std_fs_symlink_metadata_absolute.wasm",
-  "testdata/std_fs_symlink_metadata_relative.wasm",
-  "testdata/std_fs_write_absolute.wasm",
-  "testdata/std_fs_write_relative.wasm",
+  "testdata/std_env_args.wasm",
+  "testdata/std_env_vars.wasm",
+  "testdata/std_fs_create_dir.wasm",
+  "testdata/std_fs_file_create.wasm",
+  "testdata/std_fs_file_metadata.wasm",
+  "testdata/std_fs_file_seek.wasm",
+  "testdata/std_fs_file_set_len.wasm",
+  "testdata/std_fs_file_sync_all.wasm",
+  "testdata/std_fs_file_sync_data.wasm",
+  "testdata/std_fs_hard_link.wasm",
+  "testdata/std_fs_metadata.wasm",
+  "testdata/std_fs_read.wasm",
+  "testdata/std_fs_read_dir.wasm",
+  "testdata/std_fs_remove_dir_all.wasm",
+  "testdata/std_fs_rename.wasm",
+  "testdata/std_fs_symlink_metadata.wasm",
+  "testdata/std_fs_write.wasm",
   "testdata/std_io_stderr.wasm",
   "testdata/std_io_stdin.wasm",
   "testdata/std_io_stdout.wasm",
   "testdata/std_process_exit.wasm",
-  "testdata/wasi_clock_res_get_monotonic.wasm",
-  "testdata/wasi_clock_res_get_process.wasm",
-  "testdata/wasi_clock_res_get_realtime.wasm",
-  "testdata/wasi_clock_res_get_thread.wasm",
-  "testdata/wasi_clock_time_get_monotonic.wasm",
-  "testdata/wasi_clock_time_get_process.wasm",
-  "testdata/wasi_clock_time_get_realtime.wasm",
-  "testdata/wasi_clock_time_get_thread.wasm",
-  "testdata/wasi_fd_fdstat_get_stderr.wasm",
-  "testdata/wasi_fd_fdstat_get_stdin.wasm",
-  "testdata/wasi_fd_fdstat_get_stdout.wasm",
+  "testdata/wasi_clock_res_get.wasm",
+  "testdata/wasi_clock_time_get.wasm",
+  "testdata/wasi_fd_fdstat_get.wasm",
+  "testdata/wasi_fd_fdstat_get.wasm",
+  "testdata/wasi_fd_fdstat_get.wasm",
   "testdata/wasi_fd_renumber.wasm",
   "testdata/wasi_fd_tell_file.wasm",
   "testdata/wasi_fd_write_file.wasm",
   "testdata/wasi_fd_write_stderr.wasm",
   "testdata/wasi_fd_write_stdout.wasm",
-  "testdata/wasi_proc_exit_one.wasm",
-  "testdata/wasi_proc_exit_zero.wasm",
+  "testdata/wasi_proc_exit.wasm",
   "testdata/wasi_random_get.wasm",
   "testdata/wasi_sched_yield.wasm",
 ];
 
 const ignore = [
-  "testdata/wasi_clock_time_get_realtime.wasm",
+  "testdata/wasi_clock_time_get.wasm",
 ];
 
 // TODO(caspervonb) investigate why these tests are failing on windows and fix
 // them.
 if (Deno.build.os == "windows") {
-  ignore.push("testdata/std_fs_metadata_absolute.wasm");
-  ignore.push("testdata/std_fs_metadata_relative.wasm");
-  ignore.push("testdata/std_fs_read_dir_absolute.wasm");
-  ignore.push("testdata/std_fs_read_dir_relative.wasm");
+  ignore.push("testdata/std_fs_metadata.wasm");
+  ignore.push("testdata/std_fs_read_dir.wasm");
 }
 
 const rootdir = path.dirname(path.fromFileUrl(import.meta.url));


### PR DESCRIPTION
This fast-forwards wasi-test-suite a couple of commits.

- Removed duplicate, or near duplicate tests with not much additional value.
- Other tests have been merged to reduce the number of modules to make tests topical to the syscall that is being tested.