### PR TITLE
docs(std/wasi): mark sched_yield as implemented

### DIFF
--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -46,7 +46,7 @@ This module provides an implementation of the WebAssembly System Interface.
 - [x] poll_oneoff
 - [x] proc_exit
 - [ ] proc_raise
-- [ ] sched_yield
+- [x] sched_yield
 - [x] random_get
 - [ ] sock_recv
 - [ ] sock_send


### PR DESCRIPTION
This marks sched_yield as implemented, it is a no-op but will probably always be and we have passing tests for it.