### PR TITLE
fix: command examples use outdated default file_server port

### DIFF
--- a/docs/getting_started/debugging_your_code.md
+++ b/docs/getting_started/debugging_your_code.md
@@ -68,7 +68,7 @@ Once our script is running again, let's send a request and inspect it in
 Devtools:
 
 ```
-$ curl http://0.0.0.0:4500/
+$ curl http://0.0.0.0:4507/
 ```
 
 ![Break in request handling](../images/debugger5.jpg)

--- a/std/http/README.md
+++ b/std/http/README.md
@@ -15,7 +15,7 @@ A small program for serving local files over HTTP.
 
 ```sh
 deno run --allow-net --allow-read https://deno.land/std/http/file_server.ts
-> HTTP server listening on http://0.0.0.0:4500/
+> HTTP server listening on http://0.0.0.0:4507/
 ```
 
 ## Cookie


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.py` passes without changing files.
6. Ensure `./tools/lint.py` passes.
-->

https://github.com/denoland/deno/pull/5226 changed `std/http/file_server.ts` default port value from `4500` to `4507`.
https://github.com/denoland/deno/blob/23df1c563efee65e6d549308ed0671a9e2933c05/std/http/file_server.ts#L326
This PR fixes `curl` command example [here](https://deno.land/manual@v1.4.6/getting_started/debugging_your_code#chrome-devtools) and `stdout` output in [std/http/README.md](https://github.com/denoland/deno/tree/master/std/http#file-server)