### PR TITLE
fix(std/testing) : Make equal function handle correctly symbols properties

### DIFF
--- a/cli/tests/unit/response_test.ts
+++ b/cli/tests/unit/response_test.ts
@@ -41,7 +41,7 @@ unitTest(async function responseFormData() {
   const input = new FormData();
   input.append("hello", "world");
   const response = new Response(input, {
-    headers: { "content-type": "application/x-www-form-urlencoded" },
+    headers: { "content-type": "multipart/form-data" },
   });
   const formDataPromise = response.formData();
   assert(formDataPromise instanceof Promise);

--- a/cli/tests/unit/response_test.ts
+++ b/cli/tests/unit/response_test.ts
@@ -41,7 +41,7 @@ unitTest(async function responseFormData() {
   const input = new FormData();
   input.append("hello", "world");
   const response = new Response(input, {
-    headers: { "content-type": "multipart/form-data" },
+    headers: { "content-type": "application/x-www-form-urlencoded" },
   });
   const formDataPromise = response.formData();
   assert(formDataPromise instanceof Promise);

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -869,6 +869,15 @@
       if (this._bodySource instanceof ReadableStream) {
         return bufferFromStream(this._bodySource.getReader(), this.#size);
       }
+      if (this._bodySource instanceof FormData) {
+        const params = getHeaderValueParams(this.#contentType);
+        const boundary = params.get("boundary");
+        const multipartBuilder = new MultipartBuilder(
+          this._bodySource,
+          boundary,
+        );
+        return Promise.resolve(bodyToArrayBuffer(multipartBuilder.getBody()));
+      }
       return Promise.resolve(bodyToArrayBuffer(this._bodySource));
     }
   }

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -133,7 +133,12 @@ export function equal(c: unknown, d: unknown): boolean {
         return unmatchedEntries === 0;
       }
       const merged = { ...a, ...b };
-      for (const key in merged) {
+      for (
+        const key of [
+          ...Object.getOwnPropertyNames(merged),
+          ...Object.getOwnPropertySymbols(merged),
+        ]
+      ) {
         type Key = keyof typeof merged;
         if (!compare(a && a[key as Key], b && b[key as Key])) {
           return false;


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.py` passes without changing files.
6. Ensure `./tools/lint.py` passes.
-->

Currently `symbol`s are not properly handled in `std/testing/asserts` because of the way objects are iterated in [equality function](https://github.com/denoland/deno/blob/master/std/testing/asserts.ts#L136).

**Example**
```typescript
import { assertEquals } from "https://deno.land/std/testing/asserts.ts"
const foo = Symbol("foo")
Deno.test("symbol1", () => assertEquals({[foo]:"bar"}, {[foo]:"bar"}))
Deno.test("symbol2", () => assertEquals({[foo]:"bar"}, {[Symbol("foo")]:"bar"}))
```
**Expected**
```
running 2 tests
test symbol1 ... ok (3ms)
test symbol2 ... FAILED (2ms)

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out (5ms)
```
**Actual**
```
running 2 tests
test symbol1 ... ok (2ms)
test symbol2 ... ok (1ms)

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (4ms)
```
In the second test, since symbols are not the same, it should throws.