### PR TITLE
refactor(run): use new module graph for run --watch

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -73,6 +73,7 @@ use deno_core::futures::future::FutureExt;
 use deno_core::futures::Future;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
+use deno_core::url::Url;
 use deno_core::v8_set_flags;
 use deno_core::ModuleSpecifier;
 use deno_doc as doc;
@@ -556,9 +557,10 @@ async fn run_with_watch(flags: Flags, script: String) -> Result<(), AnyError> {
   let mut builder = module_graph2::GraphBuilder2::new(
     handler,
     program_state.maybe_import_map.clone(),
+    program_state.lockfile.clone(),
   );
   builder.add(&main_module, false).await?;
-  let module_graph = builder.get_graph(&program_state.lockfile);
+  let module_graph = builder.get_graph();
 
   // Find all local files in graph
   let mut paths_to_watch: Vec<PathBuf> = module_graph

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -73,7 +73,6 @@ use deno_core::futures::future::FutureExt;
 use deno_core::futures::Future;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
-use deno_core::url::Url;
 use deno_core::v8_set_flags;
 use deno_core::ModuleSpecifier;
 use deno_doc as doc;
@@ -593,22 +592,23 @@ async fn run_with_watch(flags: Flags, script: String) -> Result<(), AnyError> {
   let main_module = ModuleSpecifier::resolve_url_or_path(&script)?;
   let program_state = ProgramState::new(flags.clone())?;
 
-  let mut module_graph_loader = module_graph::ModuleGraphLoader::new(
-    program_state.file_fetcher.clone(),
-    program_state.maybe_import_map.clone(),
+  let handler = Rc::new(RefCell::new(FetchHandler::new(
+    &program_state,
     Permissions::allow_all(),
-    false,
-    false,
+  )?));
+  let mut builder = module_graph2::GraphBuilder2::new(
+    handler,
+    program_state.maybe_import_map.clone(),
   );
-  module_graph_loader.add_to_graph(&main_module, None).await?;
-  let module_graph = module_graph_loader.get_graph();
+  builder.add(&main_module, false).await?;
+  let module_graph = builder.get_graph(&program_state.lockfile);
 
   // Find all local files in graph
   let mut paths_to_watch: Vec<PathBuf> = module_graph
-    .values()
-    .map(|f| Url::parse(&f.url).unwrap())
-    .filter(|url| url.scheme() == "file")
-    .map(|url| url.to_file_path().unwrap())
+    .get_modules()
+    .iter()
+    .filter(|specifier| specifier.as_url().scheme() == "file")
+    .map(|specifier| specifier.as_url().to_file_path().unwrap())
     .collect();
 
   if let Some(import_map) = program_state.flags.import_map_path.clone() {

--- a/cli/module_graph2.rs
+++ b/cli/module_graph2.rs
@@ -694,17 +694,6 @@ impl Graph2 {
     Ok((s, stats, maybe_ignored_options))
   }
 
-  fn contains_module(&self, specifier: &ModuleSpecifier) -> bool {
-    let s = self.resolve_specifier(specifier);
-    self.modules.contains_key(s)
-  }
-
-  /// Consume graph and return list of all module specifiers
-  /// contained in the graph.
-  pub fn get_modules(&self) -> Vec<ModuleSpecifier> {
-    self.modules.keys().map(|s| s.to_owned()).collect()
-  }
-
   /// Type check the module graph, corresponding to the options provided.
   pub fn check(
     self,
@@ -837,6 +826,11 @@ impl Graph2 {
     Ok((response.stats, response.diagnostics, maybe_ignored_options))
   }
 
+  fn contains_module(&self, specifier: &ModuleSpecifier) -> bool {
+    let s = self.resolve_specifier(specifier);
+    self.modules.contains_key(s)
+  }
+
   /// Update the handler with any modules that are marked as _dirty_ and update
   /// any build info if present.
   fn flush(&mut self) -> Result<(), AnyError> {
@@ -953,6 +947,12 @@ impl Graph2 {
   fn get_module(&self, specifier: &ModuleSpecifier) -> Option<&Module> {
     let s = self.resolve_specifier(specifier);
     self.modules.get(s)
+  }
+
+  /// Consume graph and return list of all module specifiers
+  /// contained in the graph.
+  pub fn get_modules(&self) -> Vec<ModuleSpecifier> {
+    self.modules.keys().map(|s| s.to_owned()).collect()
   }
 
   /// Get the source for a given module specifier.  If the module is not part

--- a/cli/module_graph2.rs
+++ b/cli/module_graph2.rs
@@ -692,6 +692,12 @@ impl Graph2 {
     self.modules.contains_key(s)
   }
 
+  /// Consume graph and return list of all module specifiers
+  /// contained in the graph.
+  pub fn get_modules(&self) -> Vec<ModuleSpecifier> {
+    self.modules.keys().map(|s| s.to_owned()).collect()
+  }
+
   /// Type check the module graph, corresponding to the options provided.
   pub fn check(
     self,


### PR DESCRIPTION
This commit changes how "deno run --watch" is implemented
by migrating to use ModuleGraph2.

Closes https://github.com/denoland/deno/issues/8080