### PR TITLE
test(std/wasi): re-enable clock_time_get tests

### DIFF
--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -41,9 +41,7 @@ const tests = [
   "testdata/wasi_sched_yield.wasm",
 ];
 
-const ignore = [
-  "testdata/wasi_clock_time_get.wasm",
-];
+const ignore = [];
 
 // TODO(caspervonb) investigate why these tests are failing on windows and fix
 // them.


### PR DESCRIPTION
This brings in revised tests for clock_time_get from upstream and re-enables them.

This revision of these tests allow for lower precision clocks (we only provide millisecond precision, and that is conformant but my previous tests for this in the upstream test suite were a bit more aggressive).