### PR TITLE
fix(op_crates/fetch): ensure Request.method to use the default value if not defined

### DIFF
--- a/cli/tests/unit/request_test.ts
+++ b/cli/tests/unit/request_test.ts
@@ -41,6 +41,10 @@ unitTest(function requestNonString(): void {
   assertEquals(new Request(nonString).url, "http://foo/");
 });
 
+unitTest(function methodNonString(): void {
+  assertEquals(new Request("http://foo/", { method: undefined }).method, "GET");
+});
+
 unitTest(function requestRelativeUrl(): void {
   // TODO(nayeemrmn): Base from `--location` when implemented and set.
   assertThrows(() => new Request("relative-url"), TypeError, "Invalid URL.");

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -990,7 +990,7 @@
         this.url = new URL(String(input)).href;
       }
 
-      if (init && "method" in init) {
+      if (init && "method" in init && init.method) {
         this.method = normalizeMethod(init.method);
       }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.py` passes without changing files.
6. Ensure `./tools/lint.py` passes.
-->

Ensure `Request.method` to be the default value (`GET`) if `init.method` is not defined, which follows browser's behavior.

Originally sindresorhus/ky#292

```ts
// Before this PR
console.log(new Request('', { method:undefined }).method) // undefined

// After this PR
console.log(new Request('', { method:undefined }).method) // 'GET'
```