### PR TITLE
test(cli): ensure modules can export typed JS files

### DIFF
--- a/cli/tests/tsc2/file_exportc.ts
+++ b/cli/tests/tsc2/file_exportc.ts
@@ -1,0 +1,1 @@
+export * as c from "https://deno.land/x/c.js";

--- a/cli/tests/tsc2/file_reexports.ts
+++ b/cli/tests/tsc2/file_reexports.ts
@@ -1,0 +1,3 @@
+import * as c from "./exportc.ts";
+
+console.log(c.c);

--- a/cli/tests/tsc2/https_deno.land-x-c.d.ts
+++ b/cli/tests/tsc2/https_deno.land-x-c.d.ts
@@ -1,0 +1,1 @@
+export const c: string;

--- a/cli/tests/tsc2/https_deno.land-x-c.js
+++ b/cli/tests/tsc2/https_deno.land-x-c.js
@@ -1,0 +1,1 @@
+export const c = "c";


### PR DESCRIPTION
Adds a test which verifies that #5935 is fixed.