### PR TITLE
fix(op_crates/web): Expose event properties in console output

### DIFF
--- a/cli/rt/27_websocket.js
+++ b/cli/rt/27_websocket.js
@@ -61,7 +61,7 @@
             }).then(() => {
               this.#readyState = CLOSED;
 
-              const errEvent = new Event("error");
+              const errEvent = new ErrorEvent("error");
               errEvent.target = this;
               this.onerror?.(errEvent);
               this.dispatchEvent(errEvent);
@@ -84,7 +84,7 @@
         } else {
           this.#readyState = CLOSED;
 
-          const errEvent = new Event("error");
+          const errEvent = new ErrorEvent("error");
           errEvent.target = this;
           this.onerror?.(errEvent);
           this.dispatchEvent(errEvent);
@@ -289,7 +289,7 @@
         } else if (message.type === "error") {
           this.#readyState = CLOSED;
 
-          const errorEv = new Event("error");
+          const errorEv = new ErrorEvent("error");
           errorEv.target = this;
           this.onerror?.(errorEv);
           this.dispatchEvent(errorEv);

--- a/cli/tests/unit/event_test.ts
+++ b/cli/tests/unit/event_test.ts
@@ -92,3 +92,41 @@ unitTest(function eventIsTrusted(): void {
 
   assertEquals(desc1!.get, desc2!.get);
 });
+
+unitTest(function eventInspectOutput(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cases: Array<[any, (event: any) => string]> = [
+    [
+      new Event("test"),
+      (event: Event) =>
+        `Event {\n  bubbles: false,\n  cancelable: false,\n  composed: false,\n  currentTarget: null,\n  defaultPrevented: false,\n  eventPhase: 0,\n  target: null,\n  timeStamp: ${event.timeStamp},\n  type: "test"\n}`,
+    ],
+    [
+      new ErrorEvent("error"),
+      (event: Event) =>
+        `ErrorEvent {\n  bubbles: false,\n  cancelable: false,\n  composed: false,\n  currentTarget: null,\n  defaultPrevented: false,\n  eventPhase: 0,\n  target: null,\n  timeStamp: ${event.timeStamp},\n  type: "error",\n  message: "",\n  filename: "",\n  lineno: 0,\n  colno: 0,\n  error: null\n}`,
+    ],
+    [
+      new CloseEvent("close"),
+      (event: Event) =>
+        `CloseEvent {\n  bubbles: false,\n  cancelable: false,\n  composed: false,\n  currentTarget: null,\n  defaultPrevented: false,\n  eventPhase: 0,\n  target: null,\n  timeStamp: ${event.timeStamp},\n  type: "close",\n  wasClean: false,\n  code: 0,\n  reason: ""\n}`,
+    ],
+    [
+      new CustomEvent("custom"),
+      (event: Event) =>
+        `CustomEvent {\n  bubbles: false,\n  cancelable: false,\n  composed: false,\n  currentTarget: null,\n  defaultPrevented: false,\n  eventPhase: 0,\n  target: null,\n  timeStamp: ${event.timeStamp},\n  type: "custom",\n  detail: undefined\n}`,
+    ],
+    [
+      new ProgressEvent("progress"),
+      (event: Event) =>
+        `ProgressEvent {\n  bubbles: false,\n  cancelable: false,\n  composed: false,\n  currentTarget: null,\n  defaultPrevented: false,\n  eventPhase: 0,\n  target: null,\n  timeStamp: ${event.timeStamp},\n  type: "progress",\n  lengthComputable: false,\n  loaded: 0,\n  total: 0\n}`,
+    ],
+  ];
+
+  for (const [event, outputProvider] of cases) {
+    assertEquals(
+      event[Symbol.for("Deno.customInspect")](),
+      outputProvider(event),
+    );
+  }
+});

--- a/op_crates/web/01_event.js
+++ b/op_crates/web/01_event.js
@@ -384,7 +384,7 @@
       inspectObj[prop] = obj[prop];
     }
 
-    return Deno.inspect(inspectObj);
+    return `${obj.constructor.name} ${Deno.inspect(inspectObj)}`;
   }
 
   function defineEnumerableProps(

--- a/op_crates/web/01_event.js
+++ b/op_crates/web/01_event.js
@@ -133,6 +133,10 @@
       });
     }
 
+    [Symbol.for("Deno.customInspect")]() {
+      return buildCustomInspectOutput(this, EVENT_PROPS);
+    }
+
     get bubbles() {
       return this.#attributes.bubbles;
     }
@@ -373,6 +377,16 @@
     }
   }
 
+  function buildCustomInspectOutput(obj, props) {
+    const inspectObj = {};
+
+    for (const prop of props) {
+      inspectObj[prop] = obj[prop];
+    }
+
+    return Deno.inspect(inspectObj);
+  }
+
   function defineEnumerableProps(
     Ctor,
     props,
@@ -382,7 +396,7 @@
     }
   }
 
-  defineEnumerableProps(Event, [
+  const EVENT_PROPS = [
     "bubbles",
     "cancelable",
     "composed",
@@ -392,7 +406,9 @@
     "target",
     "timeStamp",
     "type",
-  ]);
+  ];
+
+  defineEnumerableProps(Event, EVENT_PROPS);
 
   // This is currently the only node type we are using, so instead of implementing
   // the whole of the Node interface at the moment, this just gives us the one
@@ -1001,6 +1017,17 @@
     get [Symbol.toStringTag]() {
       return "ErrorEvent";
     }
+
+    [Symbol.for("Deno.customInspect")]() {
+      return buildCustomInspectOutput(this, [
+        ...EVENT_PROPS,
+        "message",
+        "filename",
+        "lineno",
+        "colno",
+        "error",
+      ]);
+    }
   }
 
   defineEnumerableProps(ErrorEvent, [
@@ -1044,6 +1071,15 @@
       this.#code = code;
       this.#reason = reason;
     }
+
+    [Symbol.for("Deno.customInspect")]() {
+      return buildCustomInspectOutput(this, [
+        ...EVENT_PROPS,
+        "wasClean",
+        "code",
+        "reason",
+      ]);
+    }
   }
 
   class MessageEvent extends Event {
@@ -1057,6 +1093,15 @@
       this.data = eventInitDict?.data ?? null;
       this.origin = eventInitDict?.origin ?? "";
       this.lastEventId = eventInitDict?.lastEventId ?? "";
+    }
+
+    [Symbol.for("Deno.customInspect")]() {
+      return buildCustomInspectOutput(this, [
+        ...EVENT_PROPS,
+        "data",
+        "origin",
+        "lastEventId",
+      ]);
     }
   }
 
@@ -1077,6 +1122,13 @@
     get [Symbol.toStringTag]() {
       return "CustomEvent";
     }
+
+    [Symbol.for("Deno.customInspect")]() {
+      return buildCustomInspectOutput(this, [
+        ...EVENT_PROPS,
+        "detail",
+      ]);
+    }
   }
 
   Reflect.defineProperty(CustomEvent.prototype, "detail", {
@@ -1092,6 +1144,15 @@
       this.lengthComputable = eventInitDict?.lengthComputable ?? false;
       this.loaded = eventInitDict?.loaded ?? 0;
       this.total = eventInitDict?.total ?? 0;
+    }
+
+    [Symbol.for("Deno.customInspect")]() {
+      return buildCustomInspectOutput(this, [
+        ...EVENT_PROPS,
+        "lengthComputable",
+        "loaded",
+        "total",
+      ]);
     }
   }
 


### PR DESCRIPTION
Fixes #8073 

New output using the example in the issue:

```js
ErrorEvent {
  bubbles: false,
  cancelable: false,
  composed: false,
  currentTarget: null,
  defaultPrevented: false,
  eventPhase: 0,
  target: null,
  timeStamp: 1603532762591,
  type: "error",
  message: "",
  filename: "",
  lineno: 0,
  colno: 0,
  error: null
}
```