### PR TITLE
fix(std/http/file_server): File server should ignore query params

### DIFF
--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -321,6 +321,21 @@ function html(strings: TemplateStringsArray, ...values: unknown[]): string {
   return html;
 }
 
+function normalizeURL(url: string): string {
+  let normalizedUrl = posix.normalize(url);
+  try {
+    normalizedUrl = decodeURIComponent(normalizedUrl);
+  } catch (e) {
+    if (!(e instanceof URIError)) {
+      throw e;
+    }
+  }
+  const startOfParams = normalizedUrl.indexOf("?");
+  return startOfParams > -1
+    ? normalizedUrl.slice(0, startOfParams)
+    : normalizedUrl;
+}
+
 function main(): void {
   const CORSEnabled = serverArgs.cors ? true : false;
   const port = serverArgs.port ?? serverArgs.p ?? 4507;
@@ -362,14 +377,7 @@ function main(): void {
   }
 
   const handler = async (req: ServerRequest): Promise<void> => {
-    let normalizedUrl = posix.normalize(req.url);
-    try {
-      normalizedUrl = decodeURIComponent(normalizedUrl);
-    } catch (e) {
-      if (!(e instanceof URIError)) {
-        throw e;
-      }
-    }
+    const normalizedUrl = normalizeURL(req.url);
     const fsPath = posix.join(target, normalizedUrl);
 
     let response: Response | undefined;

--- a/std/http/file_server_test.ts
+++ b/std/http/file_server_test.ts
@@ -206,6 +206,21 @@ Deno.test("file_server running as library", async function (): Promise<void> {
   }
 });
 
+Deno.test("file_server should ignore query params", async () => {
+  await startFileServer();
+  try {
+    const res = await fetch("http://localhost:4507/README.md?key=value");
+    assertEquals(res.status, 200);
+    const downloadedFile = await res.text();
+    const localFile = new TextDecoder().decode(
+      await Deno.readFile(join(moduleDir, "README.md")),
+    );
+    assertEquals(downloadedFile, localFile);
+  } finally {
+    await killFileServer();
+  }
+});
+
 async function startTlsFileServer({
   target = ".",
   port = 4577,


### PR DESCRIPTION
This PR fixes #8115.