### PR TITLE
fix(core/runtime): Indicate exceptions in promises

### DIFF
--- a/cli/tests/044_bad_resource.ts
+++ b/cli/tests/044_bad_resource.ts
@@ -1,7 +1,3 @@
-async function main(): Promise<void> {
-  const file = await Deno.open("044_bad_resource.ts", { read: true });
-  file.close();
-  await file.seek(10, 0);
-}
-
-main();
+const file = await Deno.open("044_bad_resource.ts", { read: true });
+file.close();
+await file.seek(10, 0);

--- a/cli/tests/044_bad_resource.ts.out
+++ b/cli/tests/044_bad_resource.ts.out
@@ -1,3 +1,2 @@
-[WILDCARD]error: Uncaught BadResource: Bad resource ID
+[WILDCARD]error: Uncaught (in promise) BadResource: Bad resource ID
 [WILDCARD]
-    at async main ([WILDCARD]tests/044_bad_resource.ts:[WILDCARD])

--- a/cli/tests/073_worker_error.ts.out
+++ b/cli/tests/073_worker_error.ts.out
@@ -1,5 +1,5 @@
 [WILDCARD]error: Uncaught (in worker "bar") Error: foo[WILDCARD]
     at foo ([WILDCARD])
     at [WILDCARD]
-error: Uncaught Error: Unhandled error event reached main worker.
+error: Uncaught (in promise) Error: Unhandled error event reached main worker.
     at Worker.#poll ([WILDCARD])

--- a/cli/tests/074_worker_nested_error.ts.out
+++ b/cli/tests/074_worker_nested_error.ts.out
@@ -1,5 +1,5 @@
 [WILDCARD]error: Uncaught (in worker "bar") Error: foo[WILDCARD]
     at foo ([WILDCARD])
     at [WILDCARD]
-error: Uncaught Error: Unhandled error event reached main worker.
+error: Uncaught (in promise) Error: Unhandled error event reached main worker.
     at Worker.#poll ([WILDCARD])

--- a/cli/tests/async_error.ts.out
+++ b/cli/tests/async_error.ts.out
@@ -1,7 +1,7 @@
 [WILDCARD]hello
 before error
 world
-error: Uncaught Error: error
+error: Uncaught (in promise) Error: error
   throw Error("error");
         ^
     at foo ([WILDCARD]tests/async_error.ts:5:9)

--- a/cli/tests/compiler_js_error.ts.out
+++ b/cli/tests/compiler_js_error.ts.out
@@ -1,4 +1,4 @@
 Check [WILDCARD]compiler_js_error.ts
-error: Uncaught Error: Error in TS compiler:
+error: Uncaught (in promise) Error: Error in TS compiler:
 AssertionError: Unexpected skip of the emit.
 [WILDCARD]

--- a/cli/tests/error_012_bad_dynamic_import_specifier.ts.out
+++ b/cli/tests/error_012_bad_dynamic_import_specifier.ts.out
@@ -1,2 +1,2 @@
 Check [WILDCARD]error_012_bad_dynamic_import_specifier.ts
-error: Uncaught TypeError: relative import path "bad-module.ts" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/error_012_bad_dynamic_import_specifier.ts"
+error: Uncaught (in promise) TypeError: relative import path "bad-module.ts" not prefixed with / or ./ or ../ Imported from "[WILDCARD]/error_012_bad_dynamic_import_specifier.ts"

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -352,7 +352,7 @@ impl JsRuntime {
       Some(script) => script,
       None => {
         let exception = tc_scope.exception().unwrap();
-        return exception_to_err_result(tc_scope, exception);
+        return exception_to_err_result(tc_scope, exception, false);
       }
     };
 
@@ -361,7 +361,7 @@ impl JsRuntime {
       None => {
         assert!(tc_scope.has_caught());
         let exception = tc_scope.exception().unwrap();
-        exception_to_err_result(tc_scope, exception)
+        exception_to_err_result(tc_scope, exception, false)
       }
     }
   }
@@ -587,6 +587,7 @@ impl JsRuntimeState {
 pub(crate) fn exception_to_err_result<'s, T>(
   scope: &mut v8::HandleScope<'s>,
   exception: v8::Local<v8::Value>,
+  in_promise: bool,
 ) -> Result<T, AnyError> {
   // TODO(piscisaureus): in rusty_v8, `is_execution_terminating()` should
   // also be implemented on `struct Isolate`.
@@ -608,7 +609,13 @@ pub(crate) fn exception_to_err_result<'s, T>(
     }
   }
 
-  let js_error = JsError::from_v8_exception(scope, exception);
+  let mut js_error = JsError::from_v8_exception(scope, exception);
+  if in_promise {
+    js_error.message = format!(
+      "Uncaught (in promise) {}",
+      js_error.message.trim_start_matches("Uncaught ")
+    );
+  }
 
   let state_rc = JsRuntime::state(scope);
   let state = state_rc.borrow();
@@ -652,7 +659,7 @@ impl JsRuntime {
     if tc_scope.has_caught() {
       assert!(maybe_module.is_none());
       let e = tc_scope.exception().unwrap();
-      return exception_to_err_result(tc_scope, e);
+      return exception_to_err_result(tc_scope, e, false);
     }
 
     let module = maybe_module.unwrap();
@@ -704,7 +711,7 @@ impl JsRuntime {
     drop(state);
 
     if module.get_status() == v8::ModuleStatus::Errored {
-      exception_to_err_result(tc_scope, module.get_exception())?
+      exception_to_err_result(tc_scope, module.get_exception(), false)?
     }
 
     let result =
@@ -713,7 +720,7 @@ impl JsRuntime {
       Some(_) => Ok(()),
       None => {
         let exception = tc_scope.exception().unwrap();
-        exception_to_err_result(tc_scope, exception)
+        exception_to_err_result(tc_scope, exception, false)
       }
     }
   }
@@ -1107,7 +1114,7 @@ impl JsRuntime {
             state.pending_mod_evaluate.take();
             drop(state);
             scope.perform_microtask_checkpoint();
-            let err1 = exception_to_err_result::<()>(scope, exception)
+            let err1 = exception_to_err_result::<()>(scope, exception, false)
               .map_err(|err| attach_handle_to_error(scope, err, exception))
               .unwrap_err();
             sender.try_send(Err(err1)).unwrap();
@@ -1155,7 +1162,7 @@ impl JsRuntime {
             v8::PromiseState::Fulfilled => Some(Ok((dyn_import_id, module_id))),
             v8::PromiseState::Rejected => {
               let exception = promise.result(scope);
-              let err1 = exception_to_err_result::<()>(scope, exception)
+              let err1 = exception_to_err_result::<()>(scope, exception, false)
                 .map_err(|err| attach_handle_to_error(scope, err, exception))
                 .unwrap_err();
               Some(Err((dyn_import_id, err1)))
@@ -1371,7 +1378,7 @@ impl JsRuntime {
     let scope = &mut v8::HandleScope::with_context(self.v8_isolate(), context);
 
     let exception = v8::Local::new(scope, handle);
-    exception_to_err_result(scope, exception)
+    exception_to_err_result(scope, exception, true)
   }
 
   // Respond using shared queue and optionally overflown response
@@ -1422,7 +1429,7 @@ impl JsRuntime {
 
     match tc_scope.exception() {
       None => Ok(()),
-      Some(exception) => exception_to_err_result(tc_scope, exception),
+      Some(exception) => exception_to_err_result(tc_scope, exception, false),
     }
   }
 
@@ -1448,7 +1455,7 @@ impl JsRuntime {
       let is_done = js_macrotask_cb.call(tc_scope, global, &[]);
 
       if let Some(exception) = tc_scope.exception() {
-        return exception_to_err_result(tc_scope, exception);
+        return exception_to_err_result(tc_scope, exception, false);
       }
 
       let is_done = is_done.unwrap();

--- a/std/examples/xeval_test.ts
+++ b/std/examples/xeval_test.ts
@@ -66,6 +66,6 @@ Deno.test("xevalCliSyntaxError", async function (): Promise<void> {
   });
   assertEquals(await p.status(), { code: 1, success: false });
   assertEquals(decode(await p.output()), "");
-  assertStringContains(decode(await p.stderrOutput()), "Uncaught SyntaxError");
+  assertStringContains(decode(await p.stderrOutput()), "SyntaxError");
   p.close();
 });


### PR DESCRIPTION
Closes #4879.

```ts
Promise.reject(new Error("foo"));

// Before:
// Uncaught Error: foo
// ...

// After:
// Uncaught (in promise) Error: foo
// ...
```
![image](https://user-images.githubusercontent.com/29990554/97122706-cf0b9580-171f-11eb-8278-ee58b7bdf519.png)
