### PR TITLE
feat(cli/repl): use completion candidate as hint

### DIFF
--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -64,9 +64,9 @@ impl Hinter for Helper {
       if candidates.len() > 0 {
         let word_offset = pos - pos2;
         if word_offset == 0 {
-            None
+          None
         } else {
-            Some(candidates[0][word_offset..].to_string())
+          Some(candidates[0][word_offset..].to_string())
         }
       } else {
         None

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -61,7 +61,7 @@ fn is_word_boundary(c: char) -> bool {
 impl Hinter for Helper {
   fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
     if let Ok((pos2, candidates)) = self.complete(line, pos, ctx) {
-      if candidates.len() > 0 {
+      if !candidates.is_empty() {
         let word_offset = pos - pos2;
         if word_offset == 0 {
           None


### PR DESCRIPTION
This shows the first completion candidate as a hint, which is rendered as gray text to the right of the cursor.