### PR TITLE
Revert "feat(lint): stabilize "deno lint" subcommand (#8075)"

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1000,18 +1000,18 @@ fn lint_subcommand<'a, 'b>() -> App<'a, 'b> {
     .about("Lint source files")
     .long_about(
       "Lint JavaScript/TypeScript source code.
-  deno lint
-  deno lint myfile1.ts myfile2.js
+  deno lint --unstable
+  deno lint --unstable myfile1.ts myfile2.js
 
 Print result as JSON:
   deno lint --unstable --json
 
 Read from stdin:
-  cat file.ts | deno lint -
+  cat file.ts | deno lint --unstable -
   cat file.ts | deno lint --unstable --json -
 
 List available rules:
-  deno lint --rules
+  deno lint --unstable --rules
 
 Ignore diagnostics on the next line by preceding it with an ignore comment and
 rule name:
@@ -1036,6 +1036,7 @@ Ignore linting a file by adding an ignore comment at the top of the file:
     .arg(
       Arg::with_name("ignore")
         .long("ignore")
+        .requires("unstable")
         .takes_value(true)
         .use_delimiter(true)
         .require_equals(true)
@@ -1045,7 +1046,6 @@ Ignore linting a file by adding an ignore comment at the top of the file:
       Arg::with_name("json")
         .long("json")
         .help("Output lint result in JSON format")
-        .requires("unstable")
         .takes_value(false),
     )
     .arg(
@@ -1834,8 +1834,13 @@ mod tests {
 
   #[test]
   fn lint() {
-    let r =
-      flags_from_vec_safe(svec!["deno", "lint", "script_1.ts", "script_2.ts"]);
+    let r = flags_from_vec_safe(svec![
+      "deno",
+      "lint",
+      "--unstable",
+      "script_1.ts",
+      "script_2.ts"
+    ]);
     assert_eq!(
       r.unwrap(),
       Flags {
@@ -1848,6 +1853,7 @@ mod tests {
           json: false,
           ignore: vec![],
         },
+        unstable: true,
         ..Flags::default()
       }
     );
@@ -1855,6 +1861,7 @@ mod tests {
     let r = flags_from_vec_safe(svec![
       "deno",
       "lint",
+      "--unstable",
       "--ignore=script_1.ts,script_2.ts"
     ]);
     assert_eq!(
@@ -1869,11 +1876,12 @@ mod tests {
             PathBuf::from("script_2.ts")
           ],
         },
+        unstable: true,
         ..Flags::default()
       }
     );
 
-    let r = flags_from_vec_safe(svec!["deno", "lint", "--rules"]);
+    let r = flags_from_vec_safe(svec!["deno", "lint", "--unstable", "--rules"]);
     assert_eq!(
       r.unwrap(),
       Flags {
@@ -1883,6 +1891,7 @@ mod tests {
           json: false,
           ignore: vec![],
         },
+        unstable: true,
         ..Flags::default()
       }
     );

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -220,12 +220,16 @@ async fn install_command(
 }
 
 async fn lint_command(
-  _flags: Flags,
+  flags: Flags,
   files: Vec<PathBuf>,
   list_rules: bool,
   ignore: Vec<PathBuf>,
   json: bool,
 ) -> Result<(), AnyError> {
+  if !flags.unstable {
+    exit_unstable("lint");
+  }
+
   if list_rules {
     lint::print_rules_list();
     return Ok(());

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -33,6 +33,7 @@ fn std_tests() {
 fn std_lint() {
   let status = util::deno_cmd()
     .arg("lint")
+    .arg("--unstable")
     .arg(format!(
       "--ignore={}",
       util::root_path().join("std/node/tests").to_string_lossy()
@@ -2847,13 +2848,13 @@ itest!(deno_test_coverage {
 });
 
 itest!(deno_lint {
-  args: "lint lint/file1.js lint/file2.ts lint/ignored_file.ts",
+  args: "lint --unstable lint/file1.js lint/file2.ts lint/ignored_file.ts",
   output: "lint/expected.out",
   exit_code: 1,
 });
 
 itest!(deno_lint_quiet {
-  args: "lint --quiet lint/file1.js",
+  args: "lint --unstable --quiet lint/file1.js",
   output: "lint/expected_quiet.out",
   exit_code: 1,
 });
@@ -2866,19 +2867,19 @@ itest!(deno_lint_json {
 });
 
 itest!(deno_lint_ignore {
-  args: "lint --ignore=lint/file1.js,lint/malformed.js lint/",
+  args: "lint --unstable --ignore=lint/file1.js,lint/malformed.js lint/",
   output: "lint/expected_ignore.out",
   exit_code: 1,
 });
 
 itest!(deno_lint_glob {
-  args: "lint --ignore=lint/malformed.js lint/",
+  args: "lint --unstable --ignore=lint/malformed.js lint/",
   output: "lint/expected_glob.out",
   exit_code: 1,
 });
 
 itest!(deno_lint_from_stdin {
-  args: "lint -",
+  args: "lint --unstable -",
   input: Some("let a: any;"),
   output: "lint/expected_from_stdin.out",
   exit_code: 1,
@@ -2892,14 +2893,14 @@ itest!(deno_lint_from_stdin_json {
 });
 
 itest!(deno_lint_rules {
-  args: "lint --rules",
+  args: "lint --unstable --rules",
   output: "lint/expected_rules.out",
   exit_code: 0,
 });
 
 // Make sure that the rules are printed if quiet option is enabled.
 itest!(deno_lint_rules_quiet {
-  args: "lint --rules -q",
+  args: "lint --unstable --rules -q",
   output: "lint/expected_rules.out",
   exit_code: 0,
 });
@@ -4060,6 +4061,7 @@ fn lint_ignore_unexplicit_files() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("lint")
+    .arg("--unstable")
     .arg("--ignore=./")
     .stderr(std::process::Stdio::piped())
     .spawn()

--- a/docs/tools/linter.md
+++ b/docs/tools/linter.md
@@ -2,15 +2,18 @@
 
 Deno ships with a built in code linter for JavaScript and TypeScript.
 
+**Note: linter is a new feature and still unstable thus it requires `--unstable`
+flag**
+
 ```shell
 # lint all JS/TS files in the current directory and subdirectories
-deno lint
+deno lint --unstable
 # lint specific files
-deno lint myfile1.ts myfile2.ts
-# read from stdin
-cat file.ts | deno lint -
-# print result as JSON (output is subject to change hence --unstable flag)
+deno lint --unstable myfile1.ts myfile2.ts
+# print result as JSON
 deno lint --unstable --json
+# read from stdin
+cat file.ts | deno lint --unstable -
 ```
 
 For more detail, run `deno lint --help`.


### PR DESCRIPTION
This reverts commit c5c48f845a4d25f064c4388fcdd4295317edf155.

Reverts #8075, after further discussion we've decided that linter shouldn't be stabilised yet. We'll try to stabilise it for `1.6.0`.