### PR TITLE
chore: add bundle_no_check benchmark

### DIFF
--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -93,6 +93,11 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
     &["bundle", "std/examples/chat/server_test.ts"],
     None,
   ),
+  (
+    "bundle_no_check",
+    &["bundle", "--no-check", "std/examples/chat/server_test.ts"],
+    None,
+  ),
 ];
 
 const RESULT_KEYS: &[&str] =

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -304,7 +304,7 @@ fn run_strace_benchmarks(
   for (name, args, _) in EXEC_TIME_BENCHMARKS {
     let mut file = tempfile::NamedTempFile::new()?;
 
-    let status = Command::new("strace")
+    Command::new("strace")
       .args(&[
         "-c",
         "-f",

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -313,7 +313,7 @@ fn run_strace_benchmarks(
         deno_exe.to_str().unwrap(),
       ])
       .args(args.iter())
-      .stdout(Stdio::null())
+      .stdout(Stdio::inherit())
       .spawn()?
       .wait()?;
 

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -304,7 +304,7 @@ fn run_strace_benchmarks(
   for (name, args, _) in EXEC_TIME_BENCHMARKS {
     let mut file = tempfile::NamedTempFile::new()?;
 
-    Command::new("strace")
+    let status = Command::new("strace")
       .args(&[
         "-c",
         "-f",
@@ -320,7 +320,12 @@ fn run_strace_benchmarks(
     let mut output = String::new();
     file.as_file_mut().read_to_string(&mut output)?;
 
+    println!("output {}", output);
+
+    assert!(status.success());
+
     let strace_result = test_util::parse_strace_output(&output);
+    println!("strace_result {:#?}", strace_result);
     thread_count.insert(
       name.to_string(),
       Value::Number(Number::from(

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -320,12 +320,9 @@ fn run_strace_benchmarks(
     let mut output = String::new();
     file.as_file_mut().read_to_string(&mut output)?;
 
-    println!("output {}", output);
-
     assert!(status.success());
 
     let strace_result = test_util::parse_strace_output(&output);
-    println!("strace_result {:#?}", strace_result);
     thread_count.insert(
       name.to_string(),
       Value::Number(Number::from(

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -320,8 +320,6 @@ fn run_strace_benchmarks(
     let mut output = String::new();
     file.as_file_mut().read_to_string(&mut output)?;
 
-    assert!(status.success());
-
     let strace_result = test_util::parse_strace_output(&output);
     thread_count.insert(
       name.to_string(),

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -329,7 +329,7 @@ fn run_strace_benchmarks(
     thread_count.insert(
       name.to_string(),
       Value::Number(Number::from(
-        strace_result.get("clone").unwrap().calls + 1,
+        strace_result.get("clone").map(|d| d.calls).unwrap_or(0) + 1,
       )),
     );
     syscall_count.insert(

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1041,6 +1041,7 @@ pub fn parse_wrk_output(output: &str) -> WrkOutput {
   }
 }
 
+#[derive(Debug)]
 pub struct StraceOutput {
   pub percent_time: f64,
   pub seconds: f64,


### PR DESCRIPTION
This adds a `deno bundle --no-check` benchmark that can be compared with the `bundle` benchmark.
