### PR TITLE
feat(cli): add commit hash and target to long_version output

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -111,10 +111,17 @@ fn git_commit_hash() -> String {
     .arg("HEAD")
     .output()
   {
-    std::str::from_utf8(&output.stdout[..7])
-      .unwrap()
-      .to_string()
+    if output.status.success() {
+      std::str::from_utf8(&output.stdout[..7])
+        .unwrap()
+        .to_string()
+    } else {
+      // When not in git repository
+      // (e.g. when the user install by `cargo install deno`)
+      "UNKNOWN".to_string()
+    }
   } else {
+    // When there is no git command for some reason
     "UNKNOWN".to_string()
   }
 }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -105,15 +105,18 @@ fn ts_version() -> String {
 }
 
 fn git_commit_hash() -> String {
-  let output = std::process::Command::new("git")
+  if let Ok(output) = std::process::Command::new("git")
     .arg("rev-list")
     .arg("-1")
     .arg("HEAD")
     .output()
-    .expect("failed to execute process");
-  std::str::from_utf8(&output.stdout[..7])
-    .unwrap()
-    .to_string()
+  {
+    std::str::from_utf8(&output.stdout[..7])
+      .unwrap()
+      .to_string()
+  } else {
+    "UNKNOWN".to_string()
+  }
 }
 
 fn main() {
@@ -136,10 +139,8 @@ fn main() {
     deno_fetch::get_declaration().display()
   );
 
-  println!(
-    "cargo:rustc-env=TARGET={}",
-    std::env::var("TARGET").unwrap()
-  );
+  println!("cargo:rustc-env=TARGET={}", env::var("TARGET").unwrap());
+  println!("cargo:rustc-env=PROFILE={}", env::var("PROFILE").unwrap());
 
   let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
   let o = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -104,6 +104,18 @@ fn ts_version() -> String {
     .collect::<String>()
 }
 
+fn git_commit_hash() -> String {
+  let output = std::process::Command::new("git")
+    .arg("rev-list")
+    .arg("-1")
+    .arg("HEAD")
+    .output()
+    .expect("failed to execute process");
+  std::str::from_utf8(&output.stdout[..7])
+    .unwrap()
+    .to_string()
+}
+
 fn main() {
   // Don't build V8 if "cargo doc" is being run. This is to support docs.rs.
   if env::var_os("RUSTDOCFLAGS").is_some() {
@@ -114,6 +126,7 @@ fn main() {
   // op_fetch_asset::trace_serializer();
 
   println!("cargo:rustc-env=TS_VERSION={}", ts_version());
+  println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_commit_hash());
   println!(
     "cargo:rustc-env=DENO_WEB_LIB_PATH={}",
     deno_web::get_declaration().display()

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -221,9 +221,9 @@ To evaluate code in the shell:
 
 lazy_static! {
   static ref LONG_VERSION: String = format!(
-    "{} ({})\ntarget {}\nv8 {}\ntypescript {}",
+    "{} ({}, {})\nv8 {}\ntypescript {}",
     crate::version::DENO,
-    crate::version::BUILD,
+    crate::version::GIT_COMMIT_HASH,
     env!("TARGET"),
     crate::version::v8(),
     crate::version::TYPESCRIPT

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -221,8 +221,10 @@ To evaluate code in the shell:
 
 lazy_static! {
   static ref LONG_VERSION: String = format!(
-    "{}\nv8 {}\ntypescript {}",
+    "{} ({})\ntarget {}\nv8 {}\ntypescript {}",
     crate::version::DENO,
+    crate::version::BUILD,
+    env!("TARGET"),
     crate::version::v8(),
     crate::version::TYPESCRIPT
   );

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -221,9 +221,10 @@ To evaluate code in the shell:
 
 lazy_static! {
   static ref LONG_VERSION: String = format!(
-    "{} ({}, {})\nv8 {}\ntypescript {}",
+    "{} ({}, {}, {})\nv8 {}\ntypescript {}",
     crate::version::DENO,
     crate::version::GIT_COMMIT_HASH,
+    env!("PROFILE"),
     env!("TARGET"),
     crate::version::v8(),
     crate::version::TYPESCRIPT

--- a/cli/version.rs
+++ b/cli/version.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 pub const DENO: &str = env!("CARGO_PKG_VERSION");
-pub const BUILD: &str = env!("GIT_COMMIT_HASH");
+pub const GIT_COMMIT_HASH: &str = env!("GIT_COMMIT_HASH");
 pub const TYPESCRIPT: &str = crate::js::TS_VERSION;
 
 pub fn v8() -> &'static str {

--- a/cli/version.rs
+++ b/cli/version.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 pub const DENO: &str = env!("CARGO_PKG_VERSION");
+pub const BUILD: &str = env!("GIT_COMMIT_HASH");
 pub const TYPESCRIPT: &str = crate::js::TS_VERSION;
 
 pub fn v8() -> &'static str {


### PR DESCRIPTION
This PR adds the git commit hash and build target to long version output (`--version`) as suggested in #6037. The output now looks like the below:

```shellsession
$ ./target/debug/deno --version
deno 1.4.6 (0dcdc5e)
target x86_64-apple-darwin
v8 8.7.220.3
typescript 4.0.3
```

---
fixes #6037