### PR TITLE
fix(cli/fmt): Strip "\\?\" prefix when displaying Windows paths

### DIFF
--- a/cli/fmt.rs
+++ b/cli/fmt.rs
@@ -80,17 +80,13 @@ async fn check_source_files(
             match diff(&file_text, &formatted_text) {
               Ok(diff) => {
                 info!("");
-                info!(
-                  "{} {}:",
-                  colors::bold("from"),
-                  file_path.display().to_string()
-                );
+                info!("{} {}:", colors::bold("from"), display_path(&file_path));
                 info!("{}", diff);
               }
               Err(e) => {
                 eprintln!(
                   "Error generating diff: {}",
-                  file_path.to_string_lossy()
+                  display_path(&file_path)
                 );
                 eprintln!("   {}", e);
               }
@@ -99,7 +95,7 @@ async fn check_source_files(
         }
         Err(e) => {
           let _g = output_lock.lock().unwrap();
-          eprintln!("Error checking: {}", file_path.to_string_lossy());
+          eprintln!("Error checking: {}", display_path(&file_path));
           eprintln!("   {}", e);
         }
       }
@@ -152,12 +148,12 @@ async fn format_source_files(
             )?;
             formatted_files_count.fetch_add(1, Ordering::Relaxed);
             let _g = output_lock.lock().unwrap();
-            info!("{}", file_path.to_string_lossy());
+            info!("{}", display_path(&file_path));
           }
         }
         Err(e) => {
           let _g = output_lock.lock().unwrap();
-          eprintln!("Error formatting: {}", file_path.to_string_lossy());
+          eprintln!("Error formatting: {}", display_path(&file_path));
           eprintln!("   {}", e);
         }
       }
@@ -209,6 +205,14 @@ fn format_stdin(check: bool) -> Result<(), AnyError> {
     }
   }
   Ok(())
+}
+
+fn display_path(path: &PathBuf) -> String {
+  let mut path_string = path.display().to_string();
+  if cfg!(windows) {
+    path_string = path_string.trim_start_matches("\\\\?\\").to_string();
+  }
+  path_string
 }
 
 fn files_str(len: usize) -> &'static str {

--- a/cli/installer.rs
+++ b/cli/installer.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 use crate::flags::Flags;
+use crate::fs::canonicalize_path;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
 use deno_core::url::Url;
@@ -84,7 +85,7 @@ deno {} "$@"
 fn get_installer_root() -> Result<PathBuf, io::Error> {
   if let Ok(env_dir) = env::var("DENO_INSTALL_ROOT") {
     if !env_dir.is_empty() {
-      return PathBuf::from(env_dir).canonicalize();
+      return canonicalize_path(&PathBuf::from(env_dir));
     }
   }
   // Note: on Windows, the $HOME environment variable may be set by users or by
@@ -127,7 +128,7 @@ pub fn install(
   force: bool,
 ) -> Result<(), AnyError> {
   let root = if let Some(root) = root {
-    root.canonicalize()?
+    canonicalize_path(&root)?
   } else {
     get_installer_root()?
   };

--- a/cli/ops/fs.rs
+++ b/cli/ops/fs.rs
@@ -2,6 +2,7 @@
 // Some deserializer fields are only used on Unix and Windows build fails without it
 use super::io::std_file_resource;
 use super::io::{FileMetadata, StreamResource, StreamResourceHolder};
+use crate::fs::canonicalize_path;
 use crate::permissions::Permissions;
 use deno_core::error::custom_error;
 use deno_core::error::type_error;
@@ -934,11 +935,8 @@ fn op_realpath_sync(
   debug!("op_realpath_sync {}", path.display());
   // corresponds to the realpath on Unix and
   // CreateFile and GetFinalPathNameByHandle on Windows
-  let realpath = std::fs::canonicalize(&path)?;
-  let mut realpath_str = into_string(realpath.into_os_string())?;
-  if cfg!(windows) {
-    realpath_str = realpath_str.trim_start_matches("\\\\?\\").to_string();
-  }
+  let realpath = canonicalize_path(&path)?;
+  let realpath_str = into_string(realpath.into_os_string())?;
   Ok(json!(realpath_str))
 }
 
@@ -963,11 +961,8 @@ async fn op_realpath_async(
     debug!("op_realpath_async {}", path.display());
     // corresponds to the realpath on Unix and
     // CreateFile and GetFinalPathNameByHandle on Windows
-    let realpath = std::fs::canonicalize(&path)?;
-    let mut realpath_str = into_string(realpath.into_os_string())?;
-    if cfg!(windows) {
-      realpath_str = realpath_str.trim_start_matches("\\\\?\\").to_string();
-    }
+    let realpath = canonicalize_path(&path)?;
+    let realpath_str = into_string(realpath.into_os_string())?;
     Ok(json!(realpath_str))
   })
   .await

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -7,6 +7,7 @@ use crate::disk_cache::DiskCache;
 use crate::file_fetcher::SourceFile;
 use crate::file_fetcher::SourceFileFetcher;
 use crate::flags::Flags;
+use crate::fs::canonicalize_path;
 use crate::js;
 use crate::media_type::MediaType;
 use crate::module_graph::ModuleGraph;
@@ -174,7 +175,7 @@ impl CompilerConfig {
 
     // Convert the PathBuf to a canonicalized string.  This is needed by the
     // compiler to properly deal with the configuration.
-    let config_path = config_file.canonicalize().map_err(|_| {
+    let config_path = canonicalize_path(&config_file).map_err(|_| {
       io::Error::new(
         io::ErrorKind::InvalidInput,
         format!(

--- a/cli/tsc_config.rs
+++ b/cli/tsc_config.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+use crate::fs::canonicalize_path;
 use deno_core::error::AnyError;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
@@ -262,7 +263,7 @@ impl TsConfig {
     if let Some(path) = maybe_path {
       let cwd = std::env::current_dir()?;
       let config_file = cwd.join(path);
-      let config_path = config_file.canonicalize().map_err(|_| {
+      let config_path = canonicalize_path(&config_file).map_err(|_| {
         std::io::Error::new(
           std::io::ErrorKind::InvalidInput,
           format!(


### PR DESCRIPTION
Fixes https://discord.com/channels/684898665143206084/689420767620104201/770329467436400710.

We strip this prefix for `Deno.realPath()`, no reason not to do it for pretty diagnostics.