### PR TITLE
fix(cli/rt): handle URL paths in mkdir

### DIFF
--- a/cli/rt/30_fs.js
+++ b/cli/rt/30_fs.js
@@ -77,7 +77,7 @@
   }
 
   function mkdirArgs(path, options) {
-    const args = { path, recursive: false };
+    const args = { path: pathFromURL(path), recursive: false };
     if (options != null) {
       if (typeof options.recursive == "boolean") {
         args.recursive = options.recursive;

--- a/cli/tests/unit/mkdir_test.ts
+++ b/cli/tests/unit/mkdir_test.ts
@@ -4,6 +4,7 @@ import {
   assertEquals,
   assertThrows,
   assertThrowsAsync,
+  pathToAbsoluteFileUrl,
   unitTest,
 } from "./test_util.ts";
 
@@ -200,12 +201,12 @@ unitTest(
 
 unitTest(
   { perms: { read: true, write: true } },
-  function mkdirSyncRelative(): void {
+  function mkdirSyncRelativeUrlPath(): void {
     const testDir = Deno.makeTempDirSync();
     const nestedDir = testDir + "/nested";
-    const path = nestedDir + "../dir";
+    // Add trailing slash so base path is treated as a directory. pathToAbsoluteFileUrl removes trailing slashes.
+    const path = new URL("../dir", pathToAbsoluteFileUrl(nestedDir) + "/");
 
-    Deno.mkdirSync(testDir);
     Deno.mkdirSync(nestedDir);
     Deno.mkdirSync(path);
 
@@ -215,12 +216,12 @@ unitTest(
 
 unitTest(
   { perms: { read: true, write: true } },
-  async function mkdirRelative(): Promise<void> {
+  async function mkdirRelativeUrlPath(): Promise<void> {
     const testDir = Deno.makeTempDirSync();
     const nestedDir = testDir + "/nested";
-    const path = nestedDir + "../dir";
+    // Add trailing slash so base path is treated as a directory. pathToAbsoluteFileUrl removes trailing slashes.
+    const path = new URL("../dir", pathToAbsoluteFileUrl(nestedDir) + "/");
 
-    await Deno.mkdir(testDir);
     await Deno.mkdir(nestedDir);
     await Deno.mkdir(path);
 

--- a/cli/tests/unit/mkdir_test.ts
+++ b/cli/tests/unit/mkdir_test.ts
@@ -197,3 +197,33 @@ unitTest(
     }
   },
 );
+
+unitTest(
+  { perms: { read: true, write: true } },
+  function mkdirSyncRelative(): void {
+    const testDir = Deno.makeTempDirSync();
+    const nestedDir = testDir + "/nested";
+    const path = nestedDir + "../dir";
+
+    Deno.mkdirSync(testDir);
+    Deno.mkdirSync(nestedDir);
+    Deno.mkdirSync(path);
+
+    assertDirectory(testDir + "/dir");
+  },
+);
+
+unitTest(
+  { perms: { read: true, write: true } },
+  async function mkdirRelative(): Promise<void> {
+    const testDir = Deno.makeTempDirSync();
+    const nestedDir = testDir + "/nested";
+    const path = nestedDir + "../dir";
+
+    await Deno.mkdir(testDir);
+    await Deno.mkdir(nestedDir);
+    await Deno.mkdir(path);
+
+    assertDirectory(testDir + "/dir");
+  },
+);


### PR DESCRIPTION
fixes #8036 

Ensure paths created by `URL('../path')` are handled in `mkdir`.

