### PR TITLE
feat(std/wasi): add start method to Context

### DIFF
--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -68,21 +68,4 @@ const instance = await WebAssembly.instantiate(module, {
   "wasi_snapshot_preview1": context.exports,
 });
 
-const {
-  _start: start,
-  _initialize: initialize,
-  memory,
-} = instance.exports;
-
-context.memory = memory as WebAssembly.Memory;
-
-if (start instanceof Function) {
-  start();
-} else if (initialize instanceof Function) {
-  initialize();
-} else {
-  throw new Error(
-    "No '_start' or '_initialize' entry point found in WebAssembly module, make sure to compile with wasm32-wasi as the target.",
-  );
-}
-```
+context.start(instance);

--- a/std/wasi/README.md
+++ b/std/wasi/README.md
@@ -69,3 +69,4 @@ const instance = await WebAssembly.instantiate(module, {
 });
 
 context.start(instance);
+```

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -1578,13 +1578,13 @@ export default class Context {
 
     if (typeof _initialize == "function") {
       throw new TypeError(
-	"WebAsembly.instance export _initialize must not be a function",
+        "WebAsembly.instance export _initialize must not be a function",
       );
     }
 
     if (typeof _start != "function") {
       throw new TypeError(
-	"WebAssembly.Instance export _start must be a function",
+        "WebAssembly.Instance export _start must be a function",
       );
     }
 

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -1570,23 +1570,21 @@ export default class Context {
   start(instance: WebAssembly.Instance) {
     const { _start, _initialize, memory } = instance.exports;
 
-    if (
-      typeof memory === undefined || !(memory instanceof WebAssembly.Memory)
-    ) {
+    if (!(memory instanceof WebAssembly.Memory)) {
       throw new TypeError("WebAsembly.instance must provide a memory export");
     }
 
     this.memory = memory;
 
-    if (typeof _initialize !== "function" && _initialize !== undefined) {
+    if (typeof _initialize == "function") {
       throw new TypeError(
-        "WebAsembly.instance export _initialize must not be defined",
+	"WebAsembly.instance export _initialize must not be a function",
       );
     }
 
-    if (typeof _start !== "function") {
+    if (typeof _start != "function") {
       throw new TypeError(
-        "WebAssembly.Instance export _start must be a function",
+	"WebAssembly.Instance export _start must be a function",
       );
     }
 

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -1562,22 +1562,32 @@ export default class Context {
    *
    * If the instance does not contain a _start() export, or if the instance
    * contains an _initialize export an error will be thrown.
+   *
+   * The instance must also have a WebAssembly.Memory export named "memory"
+   * which will be used as the address space, if it does not an error will be
+   * thrown.
    */
   start(instance: WebAssembly.Instance) {
     const { _start, _initialize, memory } = instance.exports;
 
-    if (typeof memory === undefined || !(memory instanceof WebAssembly.Memory)) {
+    if (
+      typeof memory === undefined || !(memory instanceof WebAssembly.Memory)
+    ) {
       throw new TypeError("WebAsembly.instance must provide a memory export");
     }
 
     this.memory = memory;
 
     if (typeof _initialize !== "function" && _initialize !== undefined) {
-      throw new TypeError("WebAsembly.instance export _initialize must not be defined");
+      throw new TypeError(
+        "WebAsembly.instance export _initialize must not be defined",
+      );
     }
 
     if (typeof _start !== "function") {
-      throw new TypeError("WebAssembly.Instance property _start must be a function");
+      throw new TypeError(
+        "WebAssembly.Instance property _start must be a function",
+      );
     }
 
     _start();

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -1586,7 +1586,7 @@ export default class Context {
 
     if (typeof _start !== "function") {
       throw new TypeError(
-        "WebAssembly.Instance property _start must be a function",
+        "WebAssembly.Instance export _start must be a function",
       );
     }
 

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -160,8 +160,8 @@ Deno.test("context_start", function () {
       const context = new Context({});
       context.start({
         exports: {
-		_initialize() {},
-		memory: new WebAssembly.Memory({ initial: 1 }),
+          _initialize() {},
+          memory: new WebAssembly.Memory({ initial: 1 }),
         },
       });
     },
@@ -174,7 +174,7 @@ Deno.test("context_start", function () {
       const context = new Context({});
       context.start({
         exports: {
-		memory: new WebAssembly.Memory({ initial: 1 }),
+          memory: new WebAssembly.Memory({ initial: 1 }),
         },
       });
     },

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -154,4 +154,31 @@ Deno.test("context_start", function () {
     TypeError,
     "must provide a memory export",
   );
+
+  assertThrows(
+    () => {
+      const context = new Context({});
+      context.start({
+        exports: {
+		_initialize() {},
+		memory: new WebAssembly.Memory({ initial: 1 }),
+        },
+      });
+    },
+    TypeError,
+    "export _initialize must not be a function",
+  );
+
+  assertThrows(
+    () => {
+      const context = new Context({});
+      context.start({
+        exports: {
+		memory: new WebAssembly.Memory({ initial: 1 }),
+        },
+      });
+    },
+    TypeError,
+    "export _start must be a function",
+  );
 });

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import Context from "./snapshot_preview1.ts";
-import { assertThrows, assertEquals } from "../testing/asserts.ts";
+import { assertEquals, assertThrows } from "../testing/asserts.ts";
 import { copy } from "../fs/mod.ts";
 import * as path from "../path/mod.ts";
 
@@ -142,12 +142,16 @@ for (const pathname of tests) {
 }
 
 Deno.test("context_start", function () {
-  assertThrows(() => {
-    const context = new Context({});
-    context.start({
-      exports: {
-	_start() {},
-      },
-    });
-  }, TypeError, "must provide a memory export");
+  assertThrows(
+    () => {
+      const context = new Context({});
+      context.start({
+        exports: {
+          _start() {},
+        },
+      });
+    },
+    TypeError,
+    "must provide a memory export",
+  );
 });

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "../testing/asserts.ts";
+import Context from "./snapshot_preview1.ts";
+import { assertThrows, assertEquals } from "../testing/asserts.ts";
 import { copy } from "../fs/mod.ts";
 import * as path from "../path/mod.ts";
 
@@ -139,3 +140,14 @@ for (const pathname of tests) {
     },
   });
 }
+
+Deno.test("context_start", function () {
+  assertThrows(() => {
+    const context = new Context({});
+    context.start({
+      exports: {
+	_start() {},
+      },
+    });
+  }, TypeError, "must provide a memory export");
+});

--- a/std/wasi/snapshot_preview1_test_runner.ts
+++ b/std/wasi/snapshot_preview1_test_runner.ts
@@ -16,8 +16,4 @@ const instance = new WebAssembly.Instance(module, {
   "wasi_snapshot_preview1": context.exports,
 });
 
-const memory = instance.exports.memory as WebAssembly.Memory;
-context.memory = memory;
-
-const start = instance.exports._start as CallableFunction;
-start();
+context.start(instance);


### PR DESCRIPTION
This adds a start method to the Context to make starting a command less tedious and yield consistent errors.

Manually setting the memory is still valid for more complex scenarios, just undocumented for the time being (haven't decided yet if it will be public or not).
