### PR TITLE
fix(core/error): Remove extra newline from JsError::fmt()

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -364,11 +364,11 @@ impl Display for JsError {
     if let Some(stack) = &self.stack {
       let stack_lines = stack.lines();
       if stack_lines.count() > 1 {
-        return writeln!(f, "{}", stack);
+        return write!(f, "{}", stack);
       }
     }
 
-    writeln!(f, "{}", self.message)?;
+    write!(f, "{}", self.message)?;
     if let Some(script_resource_name) = &self.script_resource_name {
       if self.line_number.is_some() && self.start_column.is_some() {
         let source_loc = format_source_loc(
@@ -376,7 +376,7 @@ impl Display for JsError {
           self.line_number.unwrap(),
           self.start_column.unwrap(),
         );
-        writeln!(f, "    at {}", source_loc)?;
+        write!(f, "\n    at {}", source_loc)?;
       }
     }
     Ok(())

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1775,7 +1775,7 @@ pub mod tests {
     match isolate.execute("infinite_loop.js", "for(;;) {}") {
       Ok(_) => panic!("execution should be terminated"),
       Err(e) => {
-        assert_eq!(e.to_string(), "Uncaught Error: execution terminated\n")
+        assert_eq!(e.to_string(), "Uncaught Error: execution terminated")
       }
     };
 
@@ -2518,8 +2518,7 @@ main();
 "#,
     );
     let expected_error = r#"Uncaught SyntaxError: Invalid or unexpected token
-    at error_without_stack.js:3:14
-"#;
+    at error_without_stack.js:3:14"#;
     assert_eq!(result.unwrap_err().to_string(), expected_error);
   }
 
@@ -2545,8 +2544,7 @@ main();
     let expected_error = r#"Error: assert
     at assert (error_stack.js:4:11)
     at main (error_stack.js:9:3)
-    at error_stack.js:12:1
-"#;
+    at error_stack.js:12:1"#;
     assert_eq!(result.unwrap_err().to_string(), expected_error);
   }
 
@@ -2577,8 +2575,7 @@ main();
       let expected_error = r#"Error: async
     at error_async_stack.js:5:13
     at async error_async_stack.js:4:5
-    at async error_async_stack.js:10:5
-"#;
+    at async error_async_stack.js:10:5"#;
 
       match runtime.poll_event_loop(cx) {
         Poll::Ready(Err(e)) => {


### PR DESCRIPTION
The display is for debug primarily, not writing to a file or something.