### PR TITLE
fix(prompt): prompt works with windows eol and eof (#8146)

### DIFF
--- a/cli/rt/41_prompt.js
+++ b/cli/rt/41_prompt.js
@@ -3,6 +3,7 @@
   const { stdin, stdout } = window.__bootstrap.files;
   const { isatty } = window.__bootstrap.tty;
   const LF = "\n".charCodeAt(0);
+  const CR = "\r".charCodeAt(0);
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
 
@@ -50,7 +51,20 @@
 
     while (true) {
       const n = stdin.readSync(c);
-      if (n === 0 || c[0] === LF) {
+      if (n === null || n === 0) {
+        break;
+      }
+      if (c[0] === CR) {
+        const n = stdin.readSync(c);
+        if (c[0] === LF) {
+          break;
+        }
+        buf.push(CR);
+        if (n === null || n === 0) {
+          break;
+        }
+      }
+      if (c[0] === LF) {
         break;
       }
       buf.push(c[0]);

--- a/cli/tests/066_prompt.ts
+++ b/cli/tests/066_prompt.ts
@@ -12,6 +12,10 @@ const answer2 = confirm("Question 2"); // Answer with yes (returns false)
 console.log(`Your answer is ${answer2}`);
 const answer3 = confirm(); // Answer with default
 console.log(`Your answer is ${answer3}`);
+const windows = prompt("What is Windows EOL?");
+console.log(`Your answer is ${JSON.stringify(windows)}`);
 alert("Hi");
 alert();
 console.log("The end of test");
+const eof = prompt("What is EOF?");
+console.log(`Your answer is ${JSON.stringify(eof)}`);

--- a/cli/tests/066_prompt.ts.out
+++ b/cli/tests/066_prompt.ts.out
@@ -5,4 +5,6 @@ Question 0 [y/N] Your answer is true
 Question 1 [y/N] Your answer is false
 Question 2 [y/N] Your answer is false
 Confirm [y/N] Your answer is false
+What is Windows EOL? Your answer is "windows"
 Hi [Enter] Alert [Enter] The end of test
+What is EOF? Your answer is null

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2133,7 +2133,7 @@ fn _066_prompt() {
   let args = "run --unstable 066_prompt.ts";
   let output = "066_prompt.ts.out";
   // These are answers to prompt, confirm, and alert calls.
-  let input = b"John Doe\n\nfoo\nY\nN\nyes\n\n\n\n";
+  let input = b"John Doe\n\nfoo\nY\nN\nyes\n\nwindows\r\n\n\n";
 
   util::test_pty(args, output, input);
 }


### PR DESCRIPTION
Fixes issue #8146

The test case seems to check the Windows EOL "\r\n", however this is an illusion because somehow the test runner already translates the Windows into Unix EOL. Have tested the functionality interactively and had to remove the `isatty` return null to do so.
