### PR TITLE
fix(repl): don't hang on unpaired braces

### DIFF
--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -171,11 +171,10 @@ impl Validator for Helper {
               left
             ))))
           }
-          (None, c) => {
-            return Ok(ValidationResult::Invalid(Some(format!(
-              "Mismatched pairs: {:?} is unpaired",
-              c
-            ))))
+          (None, _) => {
+            // While technically invalid when unpaired, it should be V8's task to output error instead.
+            // Thus marked as valid with no info.
+            return Ok(ValidationResult::Valid(None));
           }
         },
         _ => {}

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1268,6 +1268,40 @@ fn repl_test_pty_multiline() {
   }
 }
 
+#[cfg(unix)]
+#[test]
+fn repl_test_pty_unpaired_braces() {
+  use std::io::Read;
+  use util::pty::fork::*;
+
+  let tests_path = util::tests_path();
+  let fork = Fork::from_ptmx().unwrap();
+  if let Ok(mut master) = fork.is_parent() {
+    master.write_all(b")\n").unwrap();
+    master.write_all(b"]\n").unwrap();
+    master.write_all(b"}\n").unwrap();
+    master.write_all(b"close();\n").unwrap();
+
+    let mut output = String::new();
+    master.read_to_string(&mut output).unwrap();
+
+    assert!(output.contains("Unexpected token ')'"));
+    assert!(output.contains("Unexpected token ']'"));
+    assert!(output.contains("Unexpected token '}'"));
+
+    fork.wait().unwrap();
+  } else {
+    util::deno_cmd()
+      .current_dir(tests_path)
+      .env("NO_COLOR", "1")
+      .arg("repl")
+      .spawn()
+      .unwrap()
+      .wait()
+      .unwrap();
+  }
+}
+
 #[test]
 fn run_watch_with_importmap_and_relative_paths() {
   fn create_relative_tmp_file(

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1518,7 +1518,7 @@ fn repl_test_eval_unterminated() {
 
 #[test]
 fn repl_test_unpaired_braces() {
-  for right_brace in vec![")", "]", "}"] {
+  for right_brace in &[")", "]", "}"] {
     let (out, err) = util::run_and_collect_output(
       true,
       "repl",

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1517,6 +1517,21 @@ fn repl_test_eval_unterminated() {
 }
 
 #[test]
+fn repl_test_unpaired_braces() {
+  for right_brace in vec![")", "]", "}"] {
+    let (out, err) = util::run_and_collect_output(
+      true,
+      "repl",
+      Some(vec![right_brace]),
+      None,
+      false,
+    );
+    assert!(out.contains("Unexpected token"));
+    assert!(err.is_empty());
+  }
+}
+
+#[test]
 fn repl_test_reference_error() {
   let (out, err) = util::run_and_collect_output(
     true,


### PR DESCRIPTION
Fixes #8150

Previously, entering a single ']' would cause repl to forever accepting new lines, due to that `ValidationResult::Invalid` would actually be consumed by the editor itself while continue building the lines. Instead we should mark it as `Valid` and send the bad input for evaluation to get the proper error from V8.

* Before:

```
> ]
(you can keep entering new line here, and it will never consume input
until you Ctrl-C)
```

* After:

```
> ]
Uncaught SyntaxError: Unexpected token ']'
>
```

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.py` passes without changing files.
6. Ensure `./tools/lint.py` passes.
-->
