### PR TITLE
fix(std/wasi): remove stray console.log call

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -1219,8 +1219,6 @@ export default class Context {
         ) {
           try {
             path = Deno.realPathSync(resolvedPath);
-
-            console.log("RESOLVED REAL PATH: %s", path);
             if (relative(entry.path, path).startsWith("..")) {
               return ERRNO_NOTCAPABLE;
             }


### PR DESCRIPTION
A stray `console.log` call made it into path_open which should have been reverted in #8078 , it was only meant for debugging on the CI.