### PR TITLE
fix(prompt): fix prompt output of non-ascii characters on windows

### DIFF
--- a/cli/rt/41_prompt.js
+++ b/cli/rt/41_prompt.js
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 ((window) => {
-  const { stdin, stdout } = window.__bootstrap.files;
+  const { stdin } = window.__bootstrap.files;
   const { isatty } = window.__bootstrap.tty;
   const LF = "\n".charCodeAt(0);
   const CR = "\r".charCodeAt(0);
-  const encoder = new TextEncoder();
   const decoder = new TextDecoder();
+  const core = window.Deno.core;
 
   function alert(message = "Alert") {
     if (!isatty(stdin.rid)) {
       return;
     }
 
-    stdout.writeSync(encoder.encode(`${message} [Enter] `));
+    core.print(`${message} [Enter] `, false);
 
     readLineFromStdinSync();
   }
@@ -22,7 +22,7 @@
       return false;
     }
 
-    stdout.writeSync(encoder.encode(`${message} [y/N] `));
+    core.print(`${message} [y/N] `, false);
 
     const answer = readLineFromStdinSync();
 
@@ -36,10 +36,10 @@
       return null;
     }
 
-    stdout.writeSync(encoder.encode(`${message} `));
+    core.print(`${message} `, false);
 
     if (defaultValue) {
-      stdout.writeSync(encoder.encode(`[${defaultValue}] `));
+      core.print(`[${defaultValue}] `, false);
     }
 
     return readLineFromStdinSync() || defaultValue;

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -11,6 +11,7 @@ use futures::future::FutureExt;
 use rusty_v8 as v8;
 use std::cell::Cell;
 use std::convert::TryFrom;
+use std::io::{stdout, Write};
 use std::option::Option;
 use url::Url;
 use v8::MapFnTo;
@@ -352,8 +353,10 @@ fn print(
   };
   if is_err {
     eprint!("{}", str_.to_rust_string_lossy(tc_scope));
+    stdout().flush().unwrap();
   } else {
     print!("{}", str_.to_rust_string_lossy(tc_scope));
+    stdout().flush().unwrap();
   }
 }
 


### PR DESCRIPTION
`Deno.stdout.writeSync(new TextEncoder().encode(str))` doesn't seem working for non-ascii characters on windows, but `Deno.core.print(str)` does seem working. See the comment https://github.com/denoland/deno/issues/8179#issuecomment-719431130 .

So this causes the issue #8179.

This PR replaced the use of `Deno.stdout.writeSync` in prompt with `Deno.core.print` and avoided the issue.

I checked the fix on window server 2019 machine.
<img width="542" alt="スクリーンショット 2020-10-30 23 55 05" src="https://user-images.githubusercontent.com/613956/97720266-69e2e600-1b0b-11eb-9e1c-d41117b30553.png">

fixes #8179