### PR TITLE
fix(cli/repl): Fixing syntax highlighting

### DIFF
--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -228,6 +228,7 @@ impl LineHighlighter {
       (?P<null>\b(?:null)\b) |
       (?P<undefined>\b(?:undefined)\b) |
       (?P<keyword>\b(?:await|async|var|let|for|if|else|in|of|class|const|function|yield|return|with|case|break|switch|import|export|new|while|do|throw|catch|this)\b) |
+      (?P<classes>\b(?:Math|console|Number|RegExp|String|Boolean|BigInt)\b)
       "#,
       )
       .unwrap();
@@ -259,6 +260,8 @@ impl Highlighter for LineHighlighter {
           format!("{}", colors::cyan(cap.as_str()))
         } else if let Some(cap) = caps.name("infinity") {
           format!("{}", colors::yellow(cap.as_str()))
+        } else if let Some(cap) = caps.name("classes") {
+          format!("{}", colors::green_bold(cap.as_str()))
         } else {
           caps[0].to_string()
         }

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -222,13 +222,15 @@ impl LineHighlighter {
       (?P<comment>(?:/\*[\s\S]*?\*/|//[^\n]*)) |
       (?P<string>(?:"([^"\\]|\\.)*"|'([^'\\]|\\.)*'|`([^`\\]|\\.)*`)) |
       (?P<regexp>/(?:(?:\\/|[^\n/]))*?/[gimsuy]*) |
-      (?P<number>\d+(?:\.\d+)?(?:e[+-]?\d+)*n?) |
-      (?P<infinity>\b(?:Infinity)\b) |
+      (?P<number>\b\d+(?:\.\d+)?(?:e[+-]?\d+)*n?\b) |
+      (?P<infinity>\b(?:Infinity|NaN)\b) |
+      (?P<hexnumber>\b0x[a-fA-F0-9]+\b) |
+      (?P<octalnumber>\b0o[0-7]+\b) |
+      (?P<binarynumber>\b0b[01]+\b) |
       (?P<boolean>\b(?:true|false)\b) |
       (?P<null>\b(?:null)\b) |
       (?P<undefined>\b(?:undefined)\b) |
       (?P<keyword>\b(?:await|async|var|let|for|if|else|in|of|class|const|function|yield|return|with|case|break|switch|import|export|new|while|do|throw|catch|this)\b) |
-      (?P<classes>\b(?:Math|console|Number|RegExp|String|Boolean|BigInt)\b)
       "#,
       )
       .unwrap();
@@ -262,6 +264,12 @@ impl Highlighter for LineHighlighter {
           format!("{}", colors::yellow(cap.as_str()))
         } else if let Some(cap) = caps.name("classes") {
           format!("{}", colors::green_bold(cap.as_str()))
+        } else if let Some(cap) = caps.name("hexnumber") {
+          format!("{}", colors::yellow(cap.as_str()))
+        } else if let Some(cap) = caps.name("octalnumber") {
+          format!("{}", colors::yellow(cap.as_str()))
+        } else if let Some(cap) = caps.name("binarynumber") {
+          format!("{}", colors::yellow(cap.as_str()))
         } else {
           caps[0].to_string()
         }

--- a/cli/repl.rs
+++ b/cli/repl.rs
@@ -222,11 +222,12 @@ impl LineHighlighter {
       (?P<comment>(?:/\*[\s\S]*?\*/|//[^\n]*)) |
       (?P<string>(?:"([^"\\]|\\.)*"|'([^'\\]|\\.)*'|`([^`\\]|\\.)*`)) |
       (?P<regexp>/(?:(?:\\/|[^\n/]))*?/[gimsuy]*) |
-      (?P<number>\d+(?:\.\d+)*(?:e[+-]?\d+)*n?) |
+      (?P<number>\d+(?:\.\d+)?(?:e[+-]?\d+)*n?) |
+      (?P<infinity>\b(?:Infinity)\b) |
       (?P<boolean>\b(?:true|false)\b) |
       (?P<null>\b(?:null)\b) |
       (?P<undefined>\b(?:undefined)\b) |
-      (?P<keyword>\b(?:await|async|var|let|for|if|else|in|of|class|const|function|yield|return|with|case|break|switch|import|export|new|while|do|throw|catch)\b) |
+      (?P<keyword>\b(?:await|async|var|let|for|if|else|in|of|class|const|function|yield|return|with|case|break|switch|import|export|new|while|do|throw|catch|this)\b) |
       "#,
       )
       .unwrap();
@@ -256,6 +257,8 @@ impl Highlighter for LineHighlighter {
           format!("{}", colors::gray(cap.as_str()))
         } else if let Some(cap) = caps.name("keyword") {
           format!("{}", colors::cyan(cap.as_str()))
+        } else if let Some(cap) = caps.name("infinity") {
+          format!("{}", colors::yellow(cap.as_str()))
         } else {
           caps[0].to_string()
         }


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.py` passes without changing files.
6. Ensure `./tools/lint.py` passes.
-->

this pull request fixes syntax highlighting by doing so:
1. doesn't highlight numbers between letters like `Uint8Array`
1. highlight binary numbes like `0b10001` and don't highlight invalid ones
1. highlight octal numbes like `0o707` and don't highlight invalid ones
1. highlight hexadecimal numbes like `0xfff` and don't highlight invalid ones
1. highlight keywords `this`, `NaN` & `Infinity`

before:
![before](https://user-images.githubusercontent.com/48116123/97754830-dad0d080-1b00-11eb-8156-2514c974c69c.png)

after:
![after](https://user-images.githubusercontent.com/48116123/97754827-d99fa380-1b00-11eb-90f4-4865e662c446.png)