### PR TITLE
tests(cli): add event target tests

### DIFF
--- a/cli/tests/unit/event_target_test.ts
+++ b/cli/tests/unit/event_target_test.ts
@@ -223,3 +223,23 @@ unitTest(
     assertEquals(callCount, 2);
   },
 );
+unitTest(function eventTargetDispatchShouldSetTargetNoListener(): void {
+  const target = new EventTarget();
+  const event = new Event("foo");
+  assertEquals(event.target, null);
+  target.dispatchEvent(event);
+  assertEquals(event.target, target);
+});
+
+unitTest(function eventTargetDispatchShouldSetTargetInListener(): void {
+  const target = new EventTarget();
+  const event = new Event("foo");
+  assertEquals(event.target, null);
+  let called = false;
+  target.addEventListener("foo", (e) => {
+    assertEquals(e.target, target);
+    called = true;
+  });
+  target.dispatchEvent(event);
+  assertEquals(called, true);
+});

--- a/op_crates/web/01_event.js
+++ b/op_crates/web/01_event.js
@@ -936,6 +936,7 @@
 
       const listeners = eventTargetData.get(self).listeners;
       if (!(event.type in listeners)) {
+        setTarget(event, this);
         return true;
       }
 


### PR DESCRIPTION
Lint, format and test passes.

This is my first attempt since the rewrite/refactor to contribute code to Deno 🎉 

I want to contribute most of the tests I've been adding in Node and work on some other stuff.

Note that I've found the behaviour of running tests pretty confusing:

 - I couldn't find a document explaining how to run the tests and had to look in CI, clicking "contributing" points to the style guide.
 - When running a single test it failed with an error - it would _probably_ make sense for the deno binary built to add `--unstable` automatically to the unit tests somehow? In Node we have a mechanism where the first line of the file can be a comment indicating what flags to pass like `// --expose-internals`
 - Running the linter/formatter resulted in a weird "OSError: [Errno 2] No such file or directory" error (but exit status code), so I _assume_ it passed but I have no idea. I can investigate this further.
