### PR TITLE
fix(encoding): make textencoder work with forced non-strings

### DIFF
--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -212,12 +212,14 @@ unitTest(function toStringShouldBeWebCompatibility(): void {
 });
 unitTest(function textEncoderShouldCoerceToString(): void {
   const encoder = new TextEncoder();
-  const fixutreText = "text"; 
+  const fixutreText = "text";
   const fixture = {
-    toString() { return fixutreText; }
-  }
-  
-  let bytes = encoder.encode(fixture as unknown as string);
+    toString() {
+      return fixutreText;
+    },
+  };
+
+  const bytes = encoder.encode(fixture as unknown as string);
   const decoder = new TextDecoder();
   const decoded = decoder.decode(bytes);
   assertEquals(decoded, fixutreText);

--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -210,3 +210,15 @@ unitTest(function toStringShouldBeWebCompatibility(): void {
   const decoder = new TextDecoder();
   assertEquals(decoder.toString(), "[object TextDecoder]");
 });
+unitTest(function textEncoderShouldCoerceToString(): void {
+  const encoder = new TextEncoder();
+  const fixutreText = "text"; 
+  const fixture = {
+    toString() { return fixutreText; }
+  }
+  
+  let bytes = encoder.encode(fixture as unknown as string);
+  const decoder = new TextDecoder();
+  const decoded = decoder.decode(bytes);
+  assertEquals(decoded, fixutreText);
+});

--- a/op_crates/web/08_text_encoding.js
+++ b/op_crates/web/08_text_encoding.js
@@ -1061,6 +1061,7 @@
   class TextEncoder {
     encoding = "utf-8";
     encode(input = "") {
+      input = String(input);
       // Deno.core.encode() provides very efficient utf-8 encoding
       if (this.encoding === "utf-8") {
         return core.encode(input);


### PR DESCRIPTION
Make TextEncoder behave like the browser's TextEncoder if the user passed a non-string and add a test for it, uses the fix 
suggested by @kitsonk

Fixes: https://github.com/denoland/deno/issues/8201

As with https://github.com/denoland/deno/pull/8205 please be "brutal" with me and give me any feedback that will make future contributions easier from the project's side :]