### PR TITLE
feat: expose setPromiseHook support

### DIFF
--- a/cli/tests/unit/promise_hook_test.ts
+++ b/cli/tests/unit/promise_hook_test.ts
@@ -1,0 +1,74 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals, unitTest } from "./test_util.ts";
+
+const twoAwaitResolveThenRejectWithCatch = [
+  0,
+  0,
+  1,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  2,
+  0,
+  1,
+  0,
+  1,
+  3,
+  2,
+  0,
+  1,
+  0,
+  1,
+  1,
+  3,
+  2,
+  1,
+  3,
+  2,
+];
+unitTest(function promiseHookConstants() {
+  assertEquals(Deno.core.setPromiseHook.INIT, 0);
+  assertEquals(Deno.core.setPromiseHook.RESOLVE, 1);
+  assertEquals(Deno.core.setPromiseHook.BEFORE, 2);
+  assertEquals(Deno.core.setPromiseHook.AFTER, 3);
+});
+unitTest(async function promiseHookBasic() {
+  const hookResults: number[] = [];
+  Deno.core.setPromiseHook((type: number) => {
+    hookResults.push(type);
+  });
+
+  async function asyncFn() {
+    await Promise.resolve(15);
+    await Promise.resolve(20);
+    Promise.reject(new Error()).catch(() => {});
+  }
+  await asyncFn();
+  assertEquals(hookResults, twoAwaitResolveThenRejectWithCatch);
+});
+
+unitTest(async function promiseHookMultipleConsumers() {
+  const hookResultsFirstConsumer: number[] = [];
+  const hookResultsSecondConsumer: number[] = [];
+  Deno.core.setPromiseHook((type: number) => {
+    hookResultsFirstConsumer.push(type);
+  });
+  Deno.core.setPromiseHook((type: number) => {
+    hookResultsSecondConsumer.push(type);
+  });
+
+  async function asyncFn() {
+    await Promise.resolve(15);
+    await Promise.resolve(20);
+    Promise.reject(new Error()).catch(() => {});
+  }
+  await asyncFn();
+  assertEquals(
+    hookResultsFirstConsumer,
+    hookResultsSecondConsumer,
+  );
+});

--- a/cli/tests/unit/unit_tests.ts
+++ b/cli/tests/unit/unit_tests.ts
@@ -79,3 +79,4 @@ import "./write_file_test.ts";
 import "./write_text_file_test.ts";
 import "./performance_test.ts";
 import "./version_test.ts";
+import "./promise_hook_test.ts";

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -105,6 +105,7 @@ pub(crate) struct JsRuntimeState {
   pub(crate) js_macrotask_cb: Option<v8::Global<v8::Function>>,
   pub(crate) pending_promise_exceptions:
     HashMap<v8::Global<v8::Promise>, v8::Global<v8::Value>>,
+  pub(crate) js_promise_hook_cb: Vec<v8::Global<v8::Function>>,
   pending_dyn_mod_evaluate: HashMap<ModuleLoadId, DynImportModEvaluate>,
   pending_mod_evaluate: Option<ModEvaluate>,
   pub(crate) js_error_create_fn: Box<JsErrorCreateFn>,
@@ -263,6 +264,7 @@ impl JsRuntime {
       pending_mod_evaluate: None,
       shared_ab: None,
       js_recv_cb: None,
+      js_promise_hook_cb: [].to_vec(),
       js_macrotask_cb: None,
       js_error_create_fn,
       shared: SharedQueue::new(RECOMMENDED_SIZE),


### PR DESCRIPTION
This is a draft PR to expose promise hooks enabling APMs. 

**My rust is bad, I haven't used it in ±2 years, any criticism and feedback about the code below is very appreciated**.

Still missing and need to do:

 - [ ] Document `Deno.core.setPromiseHook` 
 - [x] Refactor to use [js_recv_obj](https://github.com/denoland/deno/issues/5638#issuecomment-719939722) to avoid the global (currently exposed).
 - [x] Expose the constants used by the promise hooks (INIT, RESOLVE, BEFORE, AFTER)
 - [x] Add tests (copy the Node or V8 promise tests probably?):
   - Test `then`ables
   - Test an async function
   - Test a "raw" promise
   - Test a promise subclass
 - [ ] Get APM vendor feedback in order to ensure this API "looks good".
 - [x] Run formatter and linter

Nice to have in the future but out of scope:
 - Shim `async_hooks` using this in deno_std
 - Guide on how async hooks work