### PR TITLE
fix(web): make onabort event handler web compatible

### DIFF
--- a/op_crates/web/02_abort_signal.js
+++ b/op_crates/web/02_abort_signal.js
@@ -36,12 +36,23 @@
         throw new TypeError("Illegal constructor.");
       }
       super();
-      this.onabort = null;
-      this.addEventListener("abort", (evt) => {
-        const { onabort } = this;
-        if (typeof onabort === "function") {
-          onabort.call(this, evt);
-        }
+      // HTML specification section 8.1.5.1
+      let eventHandler = null;
+      Object.defineProperty(this, "onabort", {
+        get() {
+          return eventHandler;
+        },
+        set(value) {
+          if (eventHandler) {
+            this.removeEventListener("abort", eventHandler);
+          }
+          eventHandler = value;
+          if (typeof eventHandler === "function") {
+            this.addEventListener("abort", value);
+          }
+        },
+        configurable: true,
+        enumerable: true,
       });
     }
 

--- a/op_crates/web/abort_controller_test.js
+++ b/op_crates/web/abort_controller_test.js
@@ -23,7 +23,7 @@ function assertThrows(fn) {
 }
 
 function basicAbortController() {
-  controller = new AbortController();
+  const controller = new AbortController();
   assert(controller);
   const { signal } = controller;
   assert(signal);
@@ -83,6 +83,18 @@ function abortSignalIllegalConstructor() {
   assertEquals(error.message, "Illegal constructor.");
 }
 
+function abortSignalEventOrder() {
+  const arr = [];
+  const controller = new AbortController();
+  const { signal } = controller;
+  signal.addEventListener("abort", () => arr.push(1));
+  signal.onabort = () => arr.push(2);
+  signal.addEventListener("abort", () => arr.push(3));
+  controller.abort();
+  assertEquals(arr[0], 1);
+  assertEquals(arr[1], 2);
+  assertEquals(arr[2], 3);
+}
 function main() {
   basicAbortController();
   signalCallsOnabort();
@@ -90,6 +102,7 @@ function main() {
   onlyAbortsOnce();
   controllerHasProperToString();
   abortSignalIllegalConstructor();
+  abortSignalEventOrder();
 }
 
 main();


### PR DESCRIPTION
Currently, `AbortSignal` implements `onabort` in a non spec-compliant way 
.
This causes a timing bug as event listeners can be added in arbitrary orders.

This PR reuses the existing listeners machinery rather than the ad-hoc event handler process - fixing the timing bug.

I have included a test - though the tests for AbortController are weird and in a different format from the EventTarget tests.

(I have a few more ideas of things to fix, but I'll try to take this a few at a time - since the first two PRs I made were merged and the promise hooks one will probably take a bit since it's bigger - I figured I'd follow up with 1-2 more at a time :])