### PR TITLE
fix(op_crates/web): define abort event handler on prototype

### DIFF
--- a/op_crates/web/abort_controller_test.js
+++ b/op_crates/web/abort_controller_test.js
@@ -95,6 +95,12 @@ function abortSignalEventOrder() {
   assertEquals(arr[1], 2);
   assertEquals(arr[2], 3);
 }
+function abortSignalHandlerLocation() {
+  const controller = new AbortController();
+  const { signal } = controller;
+  const abortHandler = Object.getOwnPropertyDescriptor(signal, "onabort");
+  assertEquals(abortHandler, undefined);
+}
 function main() {
   basicAbortController();
   signalCallsOnabort();
@@ -103,6 +109,7 @@ function main() {
   controllerHasProperToString();
   abortSignalIllegalConstructor();
   abortSignalEventOrder();
+  abortSignalHandlerLocation();
 }
 
 main();


### PR DESCRIPTION
Currently, AbortSignal implements onabort in a non spec-compliant way

Event handlers need to be defined on the protoype, this is also applies to other event handlers in Deno (like workers/sockets onmessage/messageerror etc).

I tried extracting the logic to a function so it's easier to reuse in the future, but I have no idea how to `import` things into the file (init makes a snapshot of these but in that flow web_util doesn't load first), I noticed other code is simply duplicated and decided I am not familiar enough in the code to change how JS loads :D 

So I just fixed this in AbortSignal (and added a test).

cc @kitsonk :]