### PR TITLE
docs(std/node/querystring): add missing JSDoc

### DIFF
--- a/std/node/querystring.ts
+++ b/std/node/querystring.ts
@@ -148,7 +148,7 @@ export function stringify(
   return final.join(sep);
 }
 
-/** Alias of querystring.parse()  */
+/** Alias of querystring.parse() */
 export const decode = parse;
 /** Alias of querystring.stringify() */
 export const encode = stringify;

--- a/std/node/querystring.ts
+++ b/std/node/querystring.ts
@@ -119,7 +119,7 @@ export function encodeStr(
 
 /**
  * Produces a URL query string from a given obj by iterating through the object's "own properties".
- * @param obj  The object to serialize into a URL query string.
+ * @param obj The object to serialize into a URL query string.
  * @param sep The substring used to delimit key and value pairs in the query string. Default: '&'.
  * @param eq The substring used to delimit keys and values in the query string. Default: '='.
  * @param options The stringify options

--- a/std/node/querystring.ts
+++ b/std/node/querystring.ts
@@ -1,14 +1,24 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 interface ParseOptions {
+  /** The function to use when decoding percent-encoded characters in the query string. */
   decodeURIComponent?: (string: string) => string;
+  /** Specifies the maximum number of keys to parse. */
   maxKeys?: number;
 }
+
 export const hexTable = new Array(256);
 for (let i = 0; i < 256; ++i) {
   hexTable[i] = "%" + ((i < 16 ? "0" : "") + i.toString(16)).toUpperCase();
 }
 
+/**
+ * Parses a URL query string into a collection of key and value pairs.
+ * @param str The URL query string to parse
+ * @param sep The substring used to delimit key and value pairs in the query string. Default: '&'.
+ * @param eq The substring used to delimit keys and values in the query string. Default: '='.
+ * @param options The parse options
+ */
 export function parse(
   str: string,
   sep = "&",
@@ -44,6 +54,7 @@ export function parse(
 }
 
 interface StringifyOptions {
+  /** The function to use when converting URL-unsafe characters to percent-encoding in the query string. */
   encodeURIComponent?: (string: string) => string;
 }
 
@@ -106,6 +117,13 @@ export function encodeStr(
   return out;
 }
 
+/**
+ * Produces a URL query string from a given obj by iterating through the object's "own properties".
+ * @param obj  The object to serialize into a URL query string.
+ * @param sep The substring used to delimit key and value pairs in the query string. Default: '&'.
+ * @param eq The substring used to delimit keys and values in the query string. Default: '='.
+ * @param options The stringify options
+ */
 export function stringify(
   // deno-lint-ignore no-explicit-any
   obj: Record<string, any>,
@@ -130,7 +148,9 @@ export function stringify(
   return final.join(sep);
 }
 
+/** Alias of querystring.parse()  */
 export const decode = parse;
+/** Alias of querystring.stringify() */
 export const encode = stringify;
 export const unescape = decodeURIComponent;
 export const escape = encodeURIComponent;


### PR DESCRIPTION
Add missing JSDoc for `std/node/querystring.ts`

Related: #7487 