### PR TITLE
fix(cli): properly handle type checking root modules with type defini…

### DIFF
--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -1154,11 +1154,21 @@ impl Graph {
       .roots
       .iter()
       .map(|ms| {
+        // if the root module has a types specifier, we should be sending that
+        // to tsc instead of the original specifier
+        let specifier = self.resolve_specifier(ms);
+        let module = self.get_module(specifier).unwrap();
+        println!("module: {:?}", module);
+        let specifier = if let Some((_, types_specifier)) = &module.maybe_types {
+          self.resolve_specifier(types_specifier)
+        } else {
+          specifier
+        };
         (
           // root modules can be redirects, so before we pass it to tsc we need
           // to resolve the redirect
-          self.resolve_specifier(ms).clone(),
-          self.get_media_type(ms).unwrap(),
+          specifier.clone(),
+          self.get_media_type(specifier).unwrap(),
         )
       })
       .collect()
@@ -1932,6 +1942,21 @@ pub mod tests {
     let h = handler.borrow();
     assert_eq!(h.cache_calls.len(), 0);
     assert_eq!(h.tsbuildinfo_calls.len(), 1);
+  }
+
+  #[tokio::test]
+  async fn fix_graph_check_types_root() {
+    let specifier = ModuleSpecifier::resolve_url_or_path("file:///typesref.js").expect("could not resolve module");
+    let (graph, _) = setup(specifier).await;
+    let result_info = graph.check(CheckOptions {
+      debug: false,
+      emit: false,
+      lib: TypeLib::DenoWindow,
+      maybe_config_path: None,
+      reload: false
+    })
+    .expect("should have checked");
+    assert!(result_info.diagnostics.is_empty());
   }
 
   #[tokio::test]

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -1158,8 +1158,8 @@ impl Graph {
         // to tsc instead of the original specifier
         let specifier = self.resolve_specifier(ms);
         let module = self.get_module(specifier).unwrap();
-        println!("module: {:?}", module);
-        let specifier = if let Some((_, types_specifier)) = &module.maybe_types {
+        let specifier = if let Some((_, types_specifier)) = &module.maybe_types
+        {
           self.resolve_specifier(types_specifier)
         } else {
           specifier
@@ -1946,16 +1946,18 @@ pub mod tests {
 
   #[tokio::test]
   async fn fix_graph_check_types_root() {
-    let specifier = ModuleSpecifier::resolve_url_or_path("file:///typesref.js").expect("could not resolve module");
+    let specifier = ModuleSpecifier::resolve_url_or_path("file:///typesref.js")
+      .expect("could not resolve module");
     let (graph, _) = setup(specifier).await;
-    let result_info = graph.check(CheckOptions {
-      debug: false,
-      emit: false,
-      lib: TypeLib::DenoWindow,
-      maybe_config_path: None,
-      reload: false
-    })
-    .expect("should have checked");
+    let result_info = graph
+      .check(CheckOptions {
+        debug: false,
+        emit: false,
+        lib: TypeLib::DenoWindow,
+        maybe_config_path: None,
+        reload: false,
+      })
+      .expect("should have checked");
     assert!(result_info.diagnostics.is_empty());
   }
 

--- a/cli/tests/module_graph/file_typesref.d.ts
+++ b/cli/tests/module_graph/file_typesref.d.ts
@@ -1,0 +1,1 @@
+export const a: "a";

--- a/cli/tests/module_graph/file_typesref.js
+++ b/cli/tests/module_graph/file_typesref.js
@@ -1,0 +1,3 @@
+/// <reference types="./typesref.d.ts" />
+
+export const a = "a";


### PR DESCRIPTION
While working on another bug I found this one, where if the root module for `deno run` or `deno cache` has an `X-TypeScript-Types` header or `/// <reference types="..." />` it won't be properly type checked.