### PR TITLE
feat: only define Node.js globals when loading std/node/global

### DIFF
--- a/std/node/buffer.ts
+++ b/std/node/buffer.ts
@@ -599,10 +599,3 @@ export default class Buffer extends Uint8Array {
 }
 
 export { Buffer };
-
-Object.defineProperty(globalThis, "Buffer", {
-  value: Buffer,
-  enumerable: false,
-  writable: true,
-  configurable: true,
-});

--- a/std/node/global.ts
+++ b/std/node/global.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+import process from "./process.ts";
+import { Buffer as buffer } from "./buffer.ts";
 
 Object.defineProperty(globalThis, Symbol.toStringTag, {
   value: "global",
@@ -9,5 +11,28 @@ Object.defineProperty(globalThis, Symbol.toStringTag, {
 
 // deno-lint-ignore no-explicit-any
 (globalThis as any)["global"] = globalThis;
+
+// Define the type for the global declration
+type Process = typeof process;
+type Buffer = typeof buffer;
+
+Object.defineProperty(globalThis, "process", {
+  value: process,
+  enumerable: false,
+  writable: true,
+  configurable: true,
+});
+
+declare global {
+  const process: Process;
+  const Buffer: Buffer;
+}
+
+Object.defineProperty(globalThis, "Buffer", {
+  value: buffer,
+  enumerable: false,
+  writable: true,
+  configurable: true,
+});
 
 export {};

--- a/std/node/process.ts
+++ b/std/node/process.ts
@@ -142,23 +142,9 @@ export const env = new Proxy(process.env, {});
 // import process from './std/node/process.ts'
 export default process;
 
-// Define the type for the global declration
-type Process = typeof process;
-
 Object.defineProperty(process, Symbol.toStringTag, {
   enumerable: false,
   writable: true,
   configurable: false,
   value: "process",
 });
-
-Object.defineProperty(globalThis, "process", {
-  value: process,
-  enumerable: false,
-  writable: true,
-  configurable: true,
-});
-
-declare global {
-  const process: Process;
-}


### PR DESCRIPTION
This updates the Node.js `process` and `Buffer` shims to only define their global names when importing `std/node/global`.

This makes it possible to import these libraries without causing global mutations.

I have left the `import './global.ts'` in `module.ts` though as that makes sense to keep for the `createRequire` use cases for now and to avoid a breaking change for those use cases.

This is a breaking change for importers that only import buffer or process though.