### PR TITLE
build: use shallow clone of third_party

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "deno_third_party"]
 	path = third_party
 	url = https://github.com/denoland/deno_third_party.git
+	shallow = true
 [submodule "std/wasi/testdata"]
 	path = std/wasi/testdata
 	url = https://github.com/khronosproject/wasi-test-suite.git


### PR DESCRIPTION
`third_party/` is a git submodule pointing to `deno_third_party` repository. The git history of that repo is quite heavy as it historically contained `typescript`, `node_modules` and `python_packages` directories, but now there are only 11 binaries in there. Setting this attribute should speed up fresh clones.