### PR TITLE
docs(tools): add a little note about cargo run

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -23,3 +23,10 @@ To run linting:
 ```sh
 deno run --allow-read --allow-write --allow-run --unstable ./tools/lint.js
 ```
+
+Tip: You can also use cargo to run the current or pending build of the deno
+executable
+
+```sh
+cargo run -- run --allow-read --allow-write --allow-run --unstable ./tools/<script>
+```


### PR DESCRIPTION
This adds a quick little note about using cargo run to run deno, which I believe would be the preferred way in most cases to ensure up to date linting rules etc.