### PR TITLE
fix(cli): only use tsbuildinfo with valid emit

### DIFF
--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -134,6 +134,11 @@ impl DiskCache {
     }
   }
 
+  pub fn is_file(&self, filename: &Path) -> bool {
+    let path = self.location.join(filename);
+    path.is_file()
+  }
+
   pub fn get(&self, filename: &Path) -> std::io::Result<Vec<u8>> {
     let path = self.location.join(filename);
     fs::read(&path)


### PR DESCRIPTION
I think this fixes the problem that @lucacasonato and others have had when moving from a cache from 1.4 to 1.5 and having some of the emitted sources missing, maybe, but since we can't reliably reproduce it, it is hard to tell if this fixes it.  Basically if we don't have something emitted, we won't load a `.tsbuildinfo` because it can't be possible "correct".