### PR TITLE
fix(cli): do not write tsbuildinfo when diagnostics are emitted

### DIFF
--- a/cli/tests/module_graph/file_tests-c-mod.ts
+++ b/cli/tests/module_graph/file_tests-c-mod.ts
@@ -1,0 +1,1 @@
+export const c = "c";

--- a/cli/tests/module_graph/file_tests-diag.ts
+++ b/cli/tests/module_graph/file_tests-diag.ts
@@ -1,0 +1,4 @@
+import * as c from "./c/mod.ts";
+
+// deno-lint-ignore no-undef
+consol.log(c);


### PR DESCRIPTION
Fixes #8309