### PR TITLE
chore: reference dprint config file in format script

### DIFF
--- a/.dprintrc.json
+++ b/.dprintrc.json
@@ -13,6 +13,7 @@
   "includes": ["**/*.{ts,tsx,js,jsx,json,md}"],
   "excludes": [
     ".cargo_home",
+    ".git",
     "cli/dts/lib.d.ts",
     "cli/dts/lib.dom*",
     "cli/dts/lib.es*",

--- a/tools/format.js
+++ b/tools/format.js
@@ -3,10 +3,11 @@
 import { getPrebuiltToolPath, getSources, join, ROOT_PATH } from "./util.js";
 
 async function dprint() {
+  const configFile = join(ROOT_PATH, ".dprintrc.json");
   const execPath = getPrebuiltToolPath("dprint");
   console.log("dprint");
   const p = Deno.run({
-    cmd: [execPath, "fmt"],
+    cmd: [execPath, "fmt", "--config=" + configFile],
   });
   const { success } = await p.status();
   if (!success) {


### PR DESCRIPTION
Explicitly pass path to config while when invoking `dprint` in `tools/format.js`.
This is completely cosmetic change. Done because `.dprintrc.json` wasn't
referenced anywhere, unlike `.rustfmt.toml` which can also be picked up
automatically.