### PR TITLE
refactor(std): moved isCopyFolder to options

### DIFF
--- a/std/fs/copy.ts
+++ b/std/fs/copy.ts
@@ -161,9 +161,10 @@ async function copyDir(
   dest: string,
   options: CopyOptions,
 ): Promise<void> {
-  options.isFolder = true;
-
-  const destStat = await ensureValidCopy(src, dest, options);
+  const destStat = await ensureValidCopy(src, dest, {
+    ...options,
+    isFolder: true,
+  });
 
   if (!destStat) {
     await ensureDir(dest);
@@ -191,9 +192,10 @@ async function copyDir(
 
 /* copy folder from src to dest synchronously */
 function copyDirSync(src: string, dest: string, options: CopyOptions): void {
-  options.isFolder = true;
-
-  const destStat = ensureValidCopySync(src, dest, options);
+  const destStat = ensureValidCopySync(src, dest, {
+    ...options,
+    isFolder: true,
+  });
 
   if (!destStat) {
     ensureDirSync(dest);

--- a/std/fs/copy.ts
+++ b/std/fs/copy.ts
@@ -98,7 +98,11 @@ async function copyFile(
   }
 }
 /* copy file to dest synchronously */
-function copyFileSync(src: string, dest: string, options: InternalCopyOptions): void {
+function copyFileSync(
+  src: string,
+  dest: string,
+  options: InternalCopyOptions,
+): void {
   ensureValidCopySync(src, dest, options);
   Deno.copyFileSync(src, dest);
   if (options.preserveTimestamps) {

--- a/std/fs/copy.ts
+++ b/std/fs/copy.ts
@@ -21,7 +21,7 @@ export interface CopyOptions {
   /**
    * default is `false`
    */
-  isFolder?: boolean
+  isFolder?: boolean;
 }
 
 async function ensureValidCopy(

--- a/std/fs/copy.ts
+++ b/std/fs/copy.ts
@@ -18,13 +18,16 @@ export interface CopyOptions {
    * Default is `false`.
    */
   preserveTimestamps?: boolean;
+  /**
+   * default is `false`
+   */
+  isFolder?: boolean
 }
 
 async function ensureValidCopy(
   src: string,
   dest: string,
   options: CopyOptions,
-  isCopyFolder = false,
 ): Promise<Deno.FileInfo | undefined> {
   let destStat: Deno.FileInfo;
 
@@ -37,7 +40,7 @@ async function ensureValidCopy(
     throw err;
   }
 
-  if (isCopyFolder && !destStat.isDirectory) {
+  if (options.isFolder && !destStat.isDirectory) {
     throw new Error(
       `Cannot overwrite non-directory '${dest}' with directory '${src}'.`,
     );
@@ -53,7 +56,6 @@ function ensureValidCopySync(
   src: string,
   dest: string,
   options: CopyOptions,
-  isCopyFolder = false,
 ): Deno.FileInfo | undefined {
   let destStat: Deno.FileInfo;
   try {
@@ -65,7 +67,7 @@ function ensureValidCopySync(
     throw err;
   }
 
-  if (isCopyFolder && !destStat.isDirectory) {
+  if (options.isFolder && !destStat.isDirectory) {
     throw new Error(
       `Cannot overwrite non-directory '${dest}' with directory '${src}'.`,
     );
@@ -159,7 +161,9 @@ async function copyDir(
   dest: string,
   options: CopyOptions,
 ): Promise<void> {
-  const destStat = await ensureValidCopy(src, dest, options, true);
+  options.isFolder = true;
+
+  const destStat = await ensureValidCopy(src, dest, options);
 
   if (!destStat) {
     await ensureDir(dest);
@@ -187,7 +191,9 @@ async function copyDir(
 
 /* copy folder from src to dest synchronously */
 function copyDirSync(src: string, dest: string, options: CopyOptions): void {
-  const destStat = ensureValidCopySync(src, dest, options, true);
+  options.isFolder = true;
+
+  const destStat = ensureValidCopySync(src, dest, options);
 
   if (!destStat) {
     ensureDirSync(dest);

--- a/std/fs/copy.ts
+++ b/std/fs/copy.ts
@@ -18,6 +18,9 @@ export interface CopyOptions {
    * Default is `false`.
    */
   preserveTimestamps?: boolean;
+}
+
+interface InternalCopyOptions extends CopyOptions {
   /**
    * default is `false`
    */
@@ -27,7 +30,7 @@ export interface CopyOptions {
 async function ensureValidCopy(
   src: string,
   dest: string,
-  options: CopyOptions,
+  options: InternalCopyOptions,
 ): Promise<Deno.FileInfo | undefined> {
   let destStat: Deno.FileInfo;
 
@@ -55,7 +58,7 @@ async function ensureValidCopy(
 function ensureValidCopySync(
   src: string,
   dest: string,
-  options: CopyOptions,
+  options: InternalCopyOptions,
 ): Deno.FileInfo | undefined {
   let destStat: Deno.FileInfo;
   try {
@@ -83,7 +86,7 @@ function ensureValidCopySync(
 async function copyFile(
   src: string,
   dest: string,
-  options: CopyOptions,
+  options: InternalCopyOptions,
 ): Promise<void> {
   await ensureValidCopy(src, dest, options);
   await Deno.copyFile(src, dest);
@@ -95,7 +98,7 @@ async function copyFile(
   }
 }
 /* copy file to dest synchronously */
-function copyFileSync(src: string, dest: string, options: CopyOptions): void {
+function copyFileSync(src: string, dest: string, options: InternalCopyOptions): void {
   ensureValidCopySync(src, dest, options);
   Deno.copyFileSync(src, dest);
   if (options.preserveTimestamps) {
@@ -110,7 +113,7 @@ function copyFileSync(src: string, dest: string, options: CopyOptions): void {
 async function copySymLink(
   src: string,
   dest: string,
-  options: CopyOptions,
+  options: InternalCopyOptions,
 ): Promise<void> {
   await ensureValidCopy(src, dest, options);
   const originSrcFilePath = await Deno.readLink(src);
@@ -134,7 +137,7 @@ async function copySymLink(
 function copySymlinkSync(
   src: string,
   dest: string,
-  options: CopyOptions,
+  options: InternalCopyOptions,
 ): void {
   ensureValidCopySync(src, dest, options);
   const originSrcFilePath = Deno.readLinkSync(src);


### PR DESCRIPTION
By the Deno [style guide](https://github.com/denoland/deno/blob/master/docs/contributing/style_guide.md)

I moved 4th arg of `ensureValidCopy` and `ensureValidCopySync` to options arg