### PR TITLE
fix(websocket) correct DOM handler order

### DIFF
--- a/cli/rt/27_websocket.js
+++ b/cli/rt/27_websocket.js
@@ -2,7 +2,7 @@
 
 ((window) => {
   const core = window.Deno.core;
-  const { requiredArguments } = window.__bootstrap.webUtil;
+  const { requiredArguments, defineEventHandler } = window.__bootstrap.webUtil;
   const CONNECTING = 0;
   const OPEN = 1;
   const CLOSING = 2;
@@ -63,12 +63,10 @@
 
               const errEvent = new ErrorEvent("error");
               errEvent.target = this;
-              this.onerror?.(errEvent);
               this.dispatchEvent(errEvent);
 
               const event = new CloseEvent("close");
               event.target = this;
-              this.onclose?.(event);
               this.dispatchEvent(event);
               core.close(this.#rid);
             });
@@ -76,7 +74,6 @@
             this.#readyState = OPEN;
             const event = new Event("open");
             event.target = this;
-            this.onopen?.(event);
             this.dispatchEvent(event);
 
             this.#eventLoop();
@@ -86,12 +83,10 @@
 
           const errEvent = new ErrorEvent("error");
           errEvent.target = this;
-          this.onerror?.(errEvent);
           this.dispatchEvent(errEvent);
 
           const closeEvent = new CloseEvent("close");
           closeEvent.target = this;
-          this.onclose?.(closeEvent);
           this.dispatchEvent(closeEvent);
         }
       }).catch((err) => {
@@ -102,12 +97,10 @@
           { error: err, message: err.toString() },
         );
         errorEv.target = this;
-        this.onerror?.(errorEv);
         this.dispatchEvent(errorEv);
 
         const closeEv = new CloseEvent("close");
         closeEv.target = this;
-        this.onclose?.(closeEv);
         this.dispatchEvent(closeEv);
       });
     }
@@ -158,11 +151,6 @@
     get url() {
       return this.#url;
     }
-
-    onopen = () => {};
-    onerror = () => {};
-    onclose = () => {};
-    onmessage = () => {};
 
     send(data) {
       requiredArguments("WebSocket.send", arguments.length, 1);
@@ -241,7 +229,6 @@
             reason,
           });
           event.target = this;
-          this.onclose?.(event);
           this.dispatchEvent(event);
           core.close(this.#rid);
         });
@@ -272,7 +259,6 @@
             origin: this.#url,
           });
           event.target = this;
-          this.onmessage?.(event);
           this.dispatchEvent(event);
 
           this.#eventLoop();
@@ -284,20 +270,17 @@
             reason: message.reason,
           });
           event.target = this;
-          this.onclose?.(event);
           this.dispatchEvent(event);
         } else if (message.type === "error") {
           this.#readyState = CLOSED;
 
           const errorEv = new ErrorEvent("error");
           errorEv.target = this;
-          this.onerror?.(errorEv);
           this.dispatchEvent(errorEv);
 
           this.#readyState = CLOSED;
           const closeEv = new CloseEvent("close");
           closeEv.target = this;
-          this.onclose?.(closeEv);
           this.dispatchEvent(closeEv);
         }
       }
@@ -319,6 +302,10 @@
     },
   });
 
+  defineEventHandler(WebSocket.prototype, "message");
+  defineEventHandler(WebSocket.prototype, "error");
+  defineEventHandler(WebSocket.prototype, "close");
+  defineEventHandler(WebSocket.prototype, "open");
   window.__bootstrap.webSocket = {
     WebSocket,
   };

--- a/op_crates/web/02_abort_signal.js
+++ b/op_crates/web/02_abort_signal.js
@@ -75,6 +75,7 @@
     wrappedHandler.handler = handler;
     return wrappedHandler;
   }
+  // TODO(benjamingr) reuse this here and websocket where possible
   function defineEventHandler(emitter, name) {
     // HTML specification section 8.1.5.1
     Object.defineProperty(emitter, `on${name}`, {


### PR DESCRIPTION
This fix is similar to https://github.com/denoland/deno/pull/8230 but for `WebSocket`, just like `AbortSignal`s websocket's `onmessage/onclose/onerror/onopen` are HTML "event handlers" which means they have very particular order requirements.

Before this PRs event handlers were always fired before event listeners. Now they are fired in the correct order according to the spec and a test was added to ensure that for `onmessage`. I am happy to add more tests if you want but I didn't want to add lots of I/O causing tests.

I'm trying to keep my PRs small - but I'd like to follow up on this with a similar fix for workers and with unit tests for `web_utils`.