### PR TITLE
fix(web/worker) define event handlers in DOM order

### DIFF
--- a/cli/rt/11_workers.js
+++ b/cli/rt/11_workers.js
@@ -4,6 +4,7 @@
   const core = window.Deno.core;
   const { Window } = window.__bootstrap.globalInterfaces;
   const { log } = window.__bootstrap.util;
+  const { defineEventHandler } = window.__bootstrap.webUtil;
 
   function createWorker(
     specifier,
@@ -87,9 +88,6 @@
           cancelable: false,
           data,
         });
-        if (this.onmessageerror) {
-          this.onmessageerror(msgErrorEvent);
-        }
         return;
       }
 
@@ -97,10 +95,6 @@
         cancelable: false,
         data,
       });
-
-      if (this.onmessage) {
-        this.onmessage(msgEvent);
-      }
 
       this.dispatchEvent(msgEvent);
     };
@@ -116,9 +110,6 @@
       });
 
       let handled = false;
-      if (this.onerror) {
-        this.onerror(event);
-      }
 
       this.dispatchEvent(event);
       if (event.defaultPrevented) {
@@ -204,6 +195,10 @@
       }
     }
   }
+
+  defineEventHandler(Worker.prototype, "error");
+  defineEventHandler(Worker.prototype, "message");
+  defineEventHandler(Worker.prototype, "messageerror");
 
   window.__bootstrap.worker = {
     Worker,


### PR DESCRIPTION
Hey again :]

This is a similar fix to https://github.com/denoland/deno/pull/8320 and https://github.com/denoland/deno/pull/8264 for Workers.

After this - I want to add more tests and find something small to contribute that will force me to write a bit of rust (which as you can probably tell from https://github.com/denoland/deno/pull/8209 I am not great at).

I also want to add some AbortSignal improvements we have in node that improve developer experience and I have some safety concerns regarding cancellation (related to the email we talked in @ry) - though I want to wait for TC39 to meet next week and see if we have something from them first.