### PR TITLE
fix(op_crates/web) make isTrusted not constructable

### DIFF
--- a/op_crates/web/01_event.js
+++ b/op_crates/web/01_event.js
@@ -101,8 +101,8 @@
   const isTrusted = Object.getOwnPropertyDescriptor({
     get isTrusted() {
       return eventData.get(this).isTrusted;
-    }
-  }, 'isTrusted').get;
+    },
+  }, "isTrusted").get;
 
   class Event {
     #canceledFlag = false;

--- a/op_crates/web/01_event.js
+++ b/op_crates/web/01_event.js
@@ -98,9 +98,11 @@
     return "relatedTarget" in event;
   }
 
-  function isTrusted() {
-    return eventData.get(this).isTrusted;
-  }
+  const isTrusted = Object.getOwnPropertyDescriptor({
+    get isTrusted() {
+      return eventData.get(this).isTrusted;
+    }
+  }, 'isTrusted').get;
 
   class Event {
     #canceledFlag = false;

--- a/op_crates/web/event_test.js
+++ b/op_crates/web/event_test.js
@@ -96,6 +96,16 @@ function eventIsTrusted() {
   assert(desc1.get === desc2.get);
 }
 
+function eventIsTrustedGetterName() {
+  const { get } = Object.getOwnPropertyDescriptor(new Event("x"), "isTrusted");
+  assert(get.name === 'get isTrusted');
+  try {
+    Reflect.construct(get);
+    throw new Error("Should not have reached here");
+  } catch (e) {
+    assert(e.message.includes('not a constructor'));
+  }
+}
 function main() {
   eventInitializedWithType();
   eventInitializedWithTypeAndDict();
@@ -105,6 +115,7 @@ function main() {
   eventPreventDefaultSuccess();
   eventInitializedWithNonStringType();
   eventIsTrusted();
+  eventIsTrustedGetterName();
 }
 
 main();

--- a/op_crates/web/event_test.js
+++ b/op_crates/web/event_test.js
@@ -98,12 +98,12 @@ function eventIsTrusted() {
 
 function eventIsTrustedGetterName() {
   const { get } = Object.getOwnPropertyDescriptor(new Event("x"), "isTrusted");
-  assert(get.name === 'get isTrusted');
+  assert(get.name === "get isTrusted");
   try {
     Reflect.construct(get);
     throw new Error("Should not have reached here");
   } catch (e) {
-    assert(e.message.includes('not a constructor'));
+    assert(e.message.includes("not a constructor"));
   }
 }
 function main() {


### PR DESCRIPTION
Basically, I wanted to ask myself "What is the most esoteric spec-required property of Event that I know?" and then fixed it in Deno.

Props goes to user Exe-Boss who found this bug in Node (in another, unrelated PR I did) ^^

(Added a test, ran in master and it fails, ran linter formatter etc)