### PR TITLE
fix(op_crates/web) correct filereader event handler order

### DIFF
--- a/cli/tests/unit/filereader_test.ts
+++ b/cli/tests/unit/filereader_test.ts
@@ -218,3 +218,25 @@ unitTest(async function fileReaderLoadBlobAbort(): Promise<void> {
     fr.abort();
   });
 });
+
+unitTest(
+  async function fileReaderDispatchesEventsInCorrectOrder(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      const fr = new FileReader();
+      const b1 = new Blob(["Hello World"]);
+      let out = "";
+      fr.addEventListener("loadend", () => {
+        out += "1";
+      });
+      fr.onloadend = (ev): void => {
+        out += "2";
+      };
+      fr.addEventListener("loadend", () => {
+        assertEquals(out, "12");
+        resolve();
+      });
+
+      fr.readAsDataURL(b1);
+    });
+  },
+);


### PR DESCRIPTION
Just like AbortSignal, WebSocket and Worker the event handler order of `FileReader` is currently incorrect in Deno.

This is the same fix as https://github.com/denoland/deno/pull/8334 but for FileReader's events :]

As a bonus, FileReader objects are now smaller (though I doubt FileReader is Deno's performant File API anyway :])