### PR TITLE
fix(std): Flush individual chunks in HTTP chunked encoding

### DIFF
--- a/std/http/_io.ts
+++ b/std/http/_io.ts
@@ -171,21 +171,21 @@ function parseTrailer(field: string | null): Headers | undefined {
 }
 
 export async function writeChunkedBody(
-  w: Deno.Writer,
+  w: BufWriter,
   r: Deno.Reader,
 ): Promise<void> {
-  const writer = BufWriter.create(w);
   for await (const chunk of Deno.iter(r)) {
     if (chunk.byteLength <= 0) continue;
     const start = encoder.encode(`${chunk.byteLength.toString(16)}\r\n`);
     const end = encoder.encode("\r\n");
-    await writer.write(start);
-    await writer.write(chunk);
-    await writer.write(end);
+    await w.write(start);
+    await w.write(chunk);
+    await w.write(end);
+    await w.flush();
   }
 
   const endChunk = encoder.encode("0\r\n\r\n");
-  await writer.write(endChunk);
+  await w.write(endChunk);
 }
 
 /** Write trailer headers to writer. It should mostly should be called after


### PR DESCRIPTION
Fixes #8339.

`writeChunkedBody` requires flushing the writer after each written chunk. This was not possible with the previous function signature that required a `Deno.Writer` which does not have a `.flush` method. Since `writeChunkedBody` was called with a `BufWriter` (which implements `Deno.Writer`), the function signature was updated to require a `BufWriter` instead. It is also no longer necessary to wrap the existing `BufWriter` `w` in another `BufWriter` `writer = BufWriter.create(w)`.

A minimal reproduction may be found here: https://github.com/denoland/deno/issues/8339#issuecomment-725601429