### PR TITLE
fix(op_crates/fetch): `redirect: "manual"` fetch should return `type: "default"` response

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -693,18 +693,10 @@ unitTest(
     const response = await fetch("http://localhost:4546/", {
       redirect: "manual",
     }); // will redirect to http://localhost:4545/
-    assertEquals(response.status, 0);
-    assertEquals(response.statusText, "");
-    assertEquals(response.url, "");
-    assertEquals(response.type, "opaqueredirect");
-    try {
-      await response.text();
-      fail(
-        "Reponse.text() didn't throw on a filtered response without a body (type opaqueredirect)",
-      );
-    } catch (e) {
-      return;
-    }
+    assertEquals(response.status, 301);
+    assertEquals(response.url, "http://localhost:4546/");
+    assertEquals(response.type, "default");
+    assertEquals(response.headers.get("Location"), "http://localhost:4545/");
   },
 );
 

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -1342,15 +1342,11 @@
             });
             return new Response(null, responseInit);
           case "manual":
-            responseInit = {};
-            responseData.set(responseInit, {
-              type: "opaqueredirect",
-              redirected: false,
-              url: "",
-            });
-            return new Response(null, responseInit);
+            // On the web this would return a `opaqueredirect` response, but
+            // those don't make sense server side. See denoland/deno#8351.
+            return response;
           case "follow":
-            // fallthrough
+          // fallthrough
           default: {
             let redirectUrl = response.headers.get("Location");
             if (redirectUrl == null) {


### PR DESCRIPTION
This intentionally breaks from spec (but aligns to other server side implementations of `fetch` like Cloudflare Workers).

Closes #8351
Closes #4389