### PR TITLE
ensureSymlunk(fs): removed unnecessary `await`

### DIFF
--- a/std/fs/ensure_symlink.ts
+++ b/std/fs/ensure_symlink.ts
@@ -14,9 +14,6 @@ const isWindows = Deno.build.os == "windows";
  * @param dest the destination link path
  */
 export async function ensureSymlink(src: string, dest: string): Promise<void> {
-  const srcStatInfo = await Deno.lstat(src);
-  const srcFilePathType = getFileInfoType(srcStatInfo);
-
   if (await exists(dest)) {
     const destStatInfo = await Deno.lstat(dest);
     const destFilePathType = getFileInfoType(destStatInfo);
@@ -29,14 +26,14 @@ export async function ensureSymlink(src: string, dest: string): Promise<void> {
   }
 
   await ensureDir(path.dirname(dest));
+  
+  const srcStatInfo = await Deno.lstat(src);
+  if(isWindows) {
+    const srcFilePathType = getFileInfoType(srcStatInfo);
+    await Deno.symlink(src, dest, srcFilePathType);
+  }
 
-  const options: Deno.SymlinkOptions | undefined = isWindows
-    ? {
-      type: srcFilePathType === "dir" ? "dir" : "file",
-    }
-    : undefined;
-
-  await Deno.symlink(src, dest, options);
+  await Deno.symlink(src, dest);
 }
 
 /**
@@ -47,9 +44,6 @@ export async function ensureSymlink(src: string, dest: string): Promise<void> {
  * @param dest the destination link path
  */
 export function ensureSymlinkSync(src: string, dest: string): void {
-  const srcStatInfo = Deno.lstatSync(src);
-  const srcFilePathType = getFileInfoType(srcStatInfo);
-
   if (existsSync(dest)) {
     const destStatInfo = Deno.lstatSync(dest);
     const destFilePathType = getFileInfoType(destStatInfo);
@@ -62,12 +56,12 @@ export function ensureSymlinkSync(src: string, dest: string): void {
   }
 
   ensureDirSync(path.dirname(dest));
-
-  const options: Deno.SymlinkOptions | undefined = isWindows
-    ? {
-      type: srcFilePathType === "dir" ? "dir" : "file",
-    }
-    : undefined;
-
-  Deno.symlinkSync(src, dest, options);
+  
+  const srcStatInfo = Deno.lstatSync(src);
+  if (isWindows) {
+    const srcFilePathType = getFileInfoType(srcStatInfo);
+    Deno.symlinkSync(src, dest, srcFilePathType);
+  }
+  
+  Deno.symlinkSync(src, dest);
 }


### PR DESCRIPTION
Removed unnecessary await,Also removed unnecessary synchronous waiting from `ensureSymlinkSync`.

oops. I just realized. I forget to return instead of `await`!
```js
  if(isWindows) {
    const srcFilePathType = getFileInfoType(srcStatInfo);
   // await Deno.symlink(src, dest, srcFilePathType);
    return Deno.symlink(src, dest, srcFilePathType); // it should be return  instead of await. My mistake!
  }
```
Update those change