### PR TITLE
feat: os util

### DIFF
--- a/std/_util/os.ts
+++ b/std/_util/os.ts
@@ -1,0 +1,14 @@
+export const osType = (() => {
+  if (globalThis.Deno != null) {
+    return Deno.build.os;
+  }
+
+  const navigator = (globalThis as any).navigator;
+  if (navigator?.appVersion?.includes?.("Win") ?? false) {
+    return "windows";
+  }
+
+  return "linux";
+})();
+
+export const isWindows = osType === "windows";

--- a/std/_util/os.ts
+++ b/std/_util/os.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
 export const osType = (() => {

--- a/std/_util/os.ts
+++ b/std/_util/os.ts
@@ -3,6 +3,7 @@ export const osType = (() => {
     return Deno.build.os;
   }
 
+  // deno-lint-ignore no-explicit-any
   const navigator = (globalThis as any).navigator;
   if (navigator?.appVersion?.includes?.("Win") ?? false) {
     return "windows";

--- a/std/_util/os.ts
+++ b/std/_util/os.ts
@@ -1,3 +1,5 @@
+// This module is browser compatible.
+
 export const osType = (() => {
   if (globalThis.Deno != null) {
     return Deno.build.os;

--- a/std/fs/copy.ts
+++ b/std/fs/copy.ts
@@ -3,8 +3,7 @@ import * as path from "../path/mod.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { getFileInfoType, isSubdir } from "./_util.ts";
 import { assert } from "../_util/assert.ts";
-
-const isWindows = Deno.build.os === "windows";
+import { isWindows } from "../_util/os.ts";
 
 export interface CopyOptions {
   /**

--- a/std/fs/ensure_symlink.ts
+++ b/std/fs/ensure_symlink.ts
@@ -3,8 +3,7 @@ import * as path from "../path/mod.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { exists, existsSync } from "./exists.ts";
 import { getFileInfoType } from "./_util.ts";
-
-const isWindows = Deno.build.os == "windows";
+import { isWindows } from "../_util/os.ts";
 
 /**
  * Ensures that the link exists.

--- a/std/fs/expand_glob.ts
+++ b/std/fs/expand_glob.ts
@@ -16,8 +16,7 @@ import {
   walkSync,
 } from "./walk.ts";
 import { assert } from "../_util/assert.ts";
-
-const isWindows = Deno.build.os == "windows";
+import { isWindows } from "../_util/os.ts";
 
 export interface ExpandGlobOptions extends Omit<GlobOptions, "os"> {
   root?: string;

--- a/std/node/_url.ts
+++ b/std/node/_url.ts
@@ -26,8 +26,7 @@ import {
   CHAR_LOWERCASE_Z,
 } from "../path/_constants.ts";
 import * as path from "./path.ts";
-
-const isWindows = Deno.build.os === "windows";
+import { isWindows } from "../_util/os.ts";
 
 const forwardSlashRegEx = /\//g;
 const percentRegEx = /%/g;

--- a/std/node/module.ts
+++ b/std/node/module.ts
@@ -34,12 +34,11 @@ import * as nodeUtil from "./util.ts";
 import * as path from "../path/mod.ts";
 import { assert } from "../_util/assert.ts";
 import { fileURLToPath, pathToFileURL } from "./url.ts";
+import { isWindows } from "../_util/os.ts";
 
 const CHAR_FORWARD_SLASH = "/".charCodeAt(0);
 const CHAR_BACKWARD_SLASH = "\\".charCodeAt(0);
 const CHAR_COLON = ":".charCodeAt(0);
-
-const isWindows = Deno.build.os == "windows";
 
 const relativeResolveCache = Object.create(null);
 

--- a/std/path/_constants.ts
+++ b/std/path/_constants.ts
@@ -46,17 +46,3 @@ export const CHAR_EQUAL = 61; /* = */
 // Digits
 export const CHAR_0 = 48; /* 0 */
 export const CHAR_9 = 57; /* 9 */
-
-let NATIVE_OS: typeof Deno.build.os = "linux";
-// deno-lint-ignore no-explicit-any
-const navigator = (globalThis as any).navigator;
-if (globalThis.Deno != null) {
-  NATIVE_OS = Deno.build.os;
-} else if (navigator?.appVersion?.includes?.("Win") ?? false) {
-  NATIVE_OS = "windows";
-}
-// TODO(nayeemrmn): Improve OS detection in browsers beyond Windows.
-
-export const isWindows = NATIVE_OS == "windows";
-
-export { NATIVE_OS };

--- a/std/path/glob.ts
+++ b/std/path/glob.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { NATIVE_OS } from "./_constants.ts";
+import { osType } from "../_util/os.ts";
 import { join, normalize } from "./mod.ts";
 import { SEP, SEP_PATTERN } from "./separator.ts";
 
@@ -80,7 +80,7 @@ const rangeEscapeChars = ["-", "\\", "]"];
  *   the group occurs not nested at the end of the segment. */
 export function globToRegExp(
   glob: string,
-  { extended = true, globstar: globstarOption = true, os = NATIVE_OS }:
+  { extended = true, globstar: globstarOption = true, os = osType }:
     GlobToRegExpOptions = {},
 ): RegExp {
   if (glob == "") {

--- a/std/path/mod.ts
+++ b/std/path/mod.ts
@@ -2,7 +2,7 @@
 // Ported mostly from https://github.com/browserify/path-browserify/
 /** This module is browser compatible. */
 
-import { isWindows } from "./_constants.ts";
+import { isWindows } from "../_util/os.ts";
 import * as _win32 from "./win32.ts";
 import * as _posix from "./posix.ts";
 

--- a/std/path/separator.ts
+++ b/std/path/separator.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 /** This module is browser compatible. */
 
-import { isWindows } from "./_constants.ts";
+import { isWindows } from "../_util/os.ts";
 
 export const SEP = isWindows ? "\\" : "/";
 export const SEP_PATTERN = isWindows ? /[\\/]+/ : /\/+/;


### PR DESCRIPTION
We had a lot of `const isWindows = Deno.build.os === "windows";` so I removed all and use `os` util