### PR TITLE
fix(cli/program_state): Remove redundant compiler warning

### DIFF
--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -207,12 +207,6 @@ impl ProgramState {
         && maybe_referrer.is_none()
         && specifier.as_url().scheme() == "file")
     {
-      let message = if let Some(referrer) = maybe_referrer {
-        format!("Compiled module not found \"{}\"\n  From: {}\n    If the source module contains only types, use `import type` and `export type` to import it instead.", module_specifier, referrer)
-      } else {
-        format!("Compiled module not found \"{}\"\n  If the source module contains only types, use `import type` and `export type` to import it instead.", module_specifier)
-      };
-      info!("{}: {}", crate::colors::yellow("warning"), message);
       CompiledModule {
         code: "".to_string(),
         name: specifier.as_url().to_string(),

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -192,31 +192,30 @@ impl ProgramState {
       .expect("Cached source file doesn't exist");
 
     let specifier = out.specifier.clone();
-    let compiled_module = if let Some((code, _)) =
-      self.get_emit(&specifier.as_url())
-    {
-      CompiledModule {
-        code: String::from_utf8(code).unwrap(),
-        name: specifier.as_url().to_string(),
-      }
-    // We expect a compiled source for any non-JavaScript files, except for
-    // local files that have an unknown media type and no referrer (root modules
-    // that do not have an extension.)
-    } else if out.media_type != MediaType::JavaScript
-      && !(out.media_type == MediaType::Unknown
-        && maybe_referrer.is_none()
-        && specifier.as_url().scheme() == "file")
-    {
-      CompiledModule {
-        code: "".to_string(),
-        name: specifier.as_url().to_string(),
-      }
-    } else {
-      CompiledModule {
-        code: out.source,
-        name: specifier.as_url().to_string(),
-      }
-    };
+    let compiled_module =
+      if let Some((code, _)) = self.get_emit(&specifier.as_url()) {
+        CompiledModule {
+          code: String::from_utf8(code).unwrap(),
+          name: specifier.as_url().to_string(),
+        }
+      // We expect a compiled source for any non-JavaScript files, except for
+      // local files that have an unknown media type and no referrer (root modules
+      // that do not have an extension.)
+      } else if out.media_type != MediaType::JavaScript
+        && !(out.media_type == MediaType::Unknown
+          && maybe_referrer.is_none()
+          && specifier.as_url().scheme() == "file")
+      {
+        CompiledModule {
+          code: "".to_string(),
+          name: specifier.as_url().to_string(),
+        }
+      } else {
+        CompiledModule {
+          code: out.source,
+          name: specifier.as_url().to_string(),
+        }
+      };
 
     Ok(compiled_module)
   }

--- a/cli/tests/ts_type_only_import.ts.out
+++ b/cli/tests/ts_type_only_import.ts.out
@@ -1,4 +1,1 @@
 Check [WILDCARD]ts_type_only_import.ts
-warning: Compiled module not found "[WILDCARD]ts_type_only_import.d.ts"
-  From: [WILDCARD]ts_type_only_import.ts
-    If the source module contains only types, use `import type` and `export type` to import it instead.


### PR DESCRIPTION
As I see it, #6760 introduced a valid fix for a strictly internal quirk where type-only modules used to cause problems. But the accompanying warning isn't necessary because it affects valid user code.