### PR TITLE
Improve Deno.version type declaration

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2058,7 +2058,7 @@ declare namespace Deno {
   export const version: {
     /** Deno's version. For example: `"1.0.0"` */
     deno: string;
-    /** The v8 version used by Deno. For example: `"8.0.0.0"` */
+    /** The V8 version used by Deno. For example: `"8.0.0.0"` */
     v8: string;
     /** The TypeScript version used by Deno. For example: `"4.0.0"` */
     typescript: string;

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2054,13 +2054,15 @@ declare namespace Deno {
     env?: string;
   };
 
-  interface Version {
-    deno: string;
-    v8: string;
-    typescript: string;
-  }
   /** Version related information. */
-  export const version: Version;
+  export const version: {
+    /** Deno's version. For example: `"1.0.0"` */
+    deno: string;
+    /** The v8 version used by Deno. For example: `"8.0.0.0"` */
+    v8: string;
+    /** The TypeScript version used by Deno. For example: `"4.0.0"` */
+    typescript: string;
+  };
 
   /** Returns the script arguments to the program. If for example we run a
    * program:


### PR DESCRIPTION
I noticed that the `Version` interface was not exported. Thus, https://doc.deno.land/builtin/stable#Deno.version would not show its properties.

![Bildschirmfoto am 2020-11-15 um 18 33 53](https://user-images.githubusercontent.com/7062160/99192289-66d62f80-2772-11eb-8b34-52af649eddfb.png)

Since the interface `Version` is only used a single time, I inlined the properties - similar to [`Deno.build`](https://doc.deno.land/builtin/stable#Deno.build).

Also added documentation for the properties.
