### PR TITLE
fix: remove unnecessary back direction for import

### DIFF
--- a/std/_util/deep_assign.ts
+++ b/std/_util/deep_assign.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { assert } from "../_util/assert.ts";
+import { assert } from "./assert.ts";
 
 export function deepAssign<T, U>(target: T, source: U): T & U;
 export function deepAssign<T, U, V>(


### PR DESCRIPTION
PR title is clear :) 
`assert.ts` is a sibling of `deep_assign.ts`