### PR TITLE
fix(cli/tests): Execute Windows binary in run permission test

### DIFF
--- a/cli/tests/permission_test.ts
+++ b/cli/tests/permission_test.ts
@@ -17,10 +17,9 @@ const test: { [key: string]: (...args: any[]) => void | Promise<void> } = {
   },
   runRequired(): void {
     const p = Deno.run({
-      cmd:
-        Deno.build.os === "windows"
-          ? ["cmd.exe", "/c", "echo hello"]
-          : ["printf", "hello"],
+      cmd: Deno.build.os === "windows"
+        ? ["cmd.exe", "/c", "echo hello"]
+        : ["printf", "hello"],
     });
     p.close();
   },

--- a/cli/tests/permission_test.ts
+++ b/cli/tests/permission_test.ts
@@ -17,7 +17,10 @@ const test: { [key: string]: (...args: any[]) => void | Promise<void> } = {
   },
   runRequired(): void {
     const p = Deno.run({
-      cmd: ["printf", "hello"],
+      cmd:
+        Deno.build.os === "windows"
+          ? ["cmd.exe", "/c", "echo hello"]
+          : ["printf", "hello"],
     });
     p.close();
   },


### PR DESCRIPTION
See #8397.

There's no `printf.exe` on Windows (nor `echo.exe` - `echo` is a built-in command in `cmd.exe` and an alias for the `Write-Output` cmdlet in `powershell.exe`).
