### PR TITLE
[fix]: std/node/events - Fix event extendability

### DIFF
--- a/std/node/events.ts
+++ b/std/node/events.ts
@@ -227,12 +227,7 @@ export default class EventEmitter {
    * listener will result in the listener being added, and called, multiple
    * times.
    */
-  public on(
-    eventName: string | symbol,
-    listener: GenericFunction | WrappedFunction,
-  ): this {
-    return this.addListener(eventName, listener);
-  }
+  on = this.addListener;
 
   /**
    * Adds a one-time listener function for the event named eventName. The next

--- a/std/node/events.ts
+++ b/std/node/events.ts
@@ -227,7 +227,12 @@ export default class EventEmitter {
    * listener will result in the listener being added, and called, multiple
    * times.
    */
-  on = this.addListener;
+  public on(
+    eventName: string | symbol,
+    listener: GenericFunction | WrappedFunction,
+  ): this {
+    return this._addListener(eventName, listener, false);
+  }
 
   /**
    * Adds a one-time listener function for the event named eventName. The next

--- a/std/node/events_test.ts
+++ b/std/node/events_test.ts
@@ -667,3 +667,21 @@ Deno.test({
     assertEquals(ee.listenerCount("error"), 0);
   },
 });
+
+// Event emitter's `on` previously referenced addListener internally, so overriding addListener
+// would cause a deadlock
+// This is a regression test
+Deno.test("Elements that extend EventEmitter listener alias don't end up in a deadlock", () => {
+  class X extends EventEmitter {
+    addListener(eventName: string, listener: () => void) {
+      return super.on(eventName, listener);
+    }
+  }
+
+  const x = new X();
+  try {
+    x.on("x", () => {});
+  } catch (e) {
+    fail();
+  }
+});


### PR DESCRIPTION
Previous implementation caused an extensability issue in which classes that inherited from EventEmitter and overwrote the method `on` and `addListener` would get stuck in an infinite loop since `on` calls `addListener` internally instead of being an alias for it.

Long story short, this is fixed.

![image](https://user-images.githubusercontent.com/42647963/99327543-2943d600-2848-11eb-83da-090ce76ac3eb.png)
