### PR TITLE
refactor(cli): rename fmt_errors::JsError to PrettyJsError

### DIFF
--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -228,7 +228,8 @@ fn format_maybe_source_line(
   format!("\n{}{}\n{}{}", indent, source_line, indent, color_underline)
 }
 
-/// Wrapper around deno_core::JsError which provides color to_string.
+/// Wrapper around deno_core::JsError which provides colorful
+/// string representation.
 #[derive(Debug)]
 pub struct PrettyJsError(JsError);
 

--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -233,9 +233,9 @@ fn format_maybe_source_line(
 
 /// Wrapper around deno_core::JsError which provides color to_string.
 #[derive(Debug)]
-pub struct JsError(CoreJsError);
+pub struct PrettyJsError(CoreJsError);
 
-impl JsError {
+impl PrettyJsError {
   pub fn create(
     core_js_error: CoreJsError,
     source_map_getter: Arc<impl SourceMapGetter>,
@@ -246,14 +246,14 @@ impl JsError {
   }
 }
 
-impl Deref for JsError {
+impl Deref for PrettyJsError {
   type Target = CoreJsError;
   fn deref(&self) -> &Self::Target {
     &self.0
   }
 }
 
-impl fmt::Display for JsError {
+impl fmt::Display for PrettyJsError {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     let mut frames = self.0.frames.clone();
 
@@ -290,7 +290,7 @@ impl fmt::Display for JsError {
   }
 }
 
-impl Error for JsError {}
+impl Error for PrettyJsError {}
 
 #[cfg(test)]
 mod tests {

--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -1,13 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 //! This mod provides DenoError to unify errors across Deno.
 use crate::colors;
-use crate::source_maps::apply_source_map;
-use crate::source_maps::SourceMapGetter;
 use deno_core::error::{AnyError, JsError as CoreJsError, JsStackFrame};
 use std::error::Error;
 use std::fmt;
 use std::ops::Deref;
-use std::sync::Arc;
 
 const SOURCE_ABBREV_THRESHOLD: usize = 150;
 
@@ -236,11 +233,7 @@ fn format_maybe_source_line(
 pub struct PrettyJsError(CoreJsError);
 
 impl PrettyJsError {
-  pub fn create(
-    core_js_error: CoreJsError,
-    source_map_getter: Arc<impl SourceMapGetter>,
-  ) -> AnyError {
-    let core_js_error = apply_source_map(&core_js_error, source_map_getter);
+  pub fn create(core_js_error: CoreJsError) -> AnyError {
     let js_error = Self(core_js_error);
     js_error.into()
   }

--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 //! This mod provides DenoError to unify errors across Deno.
 use crate::colors;
-use deno_core::error::{AnyError, JsError as CoreJsError, JsStackFrame};
+use deno_core::error::{AnyError, JsError, JsStackFrame};
 use std::error::Error;
 use std::fmt;
 use std::ops::Deref;
@@ -230,17 +230,17 @@ fn format_maybe_source_line(
 
 /// Wrapper around deno_core::JsError which provides color to_string.
 #[derive(Debug)]
-pub struct PrettyJsError(CoreJsError);
+pub struct PrettyJsError(JsError);
 
 impl PrettyJsError {
-  pub fn create(core_js_error: CoreJsError) -> AnyError {
-    let js_error = Self(core_js_error);
-    js_error.into()
+  pub fn create(js_error: JsError) -> AnyError {
+    let pretty_js_error = Self(js_error);
+    pretty_js_error.into()
   }
 }
 
 impl Deref for PrettyJsError {
-  type Target = CoreJsError;
+  type Target = JsError;
   fn deref(&self) -> &Self::Target {
     &self.0
   }

--- a/cli/ops/worker_host.rs
+++ b/cli/ops/worker_host.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
-use crate::fmt_errors::JsError;
+use crate::fmt_errors::PrettyJsError;
 use crate::ops::io::get_stdio;
 use crate::permissions::Permissions;
 use crate::program_state::ProgramState;
@@ -301,7 +301,7 @@ fn serialize_worker_event(event: WorkerEvent) -> Value {
         }
       });
 
-      if let Ok(js_error) = error.downcast::<JsError>() {
+      if let Ok(js_error) = error.downcast::<PrettyJsError>() {
         serialized_error = json!({
           "type": "terminalError",
           "error": {
@@ -323,7 +323,7 @@ fn serialize_worker_event(event: WorkerEvent) -> Value {
         }
       });
 
-      if let Ok(js_error) = error.downcast::<JsError>() {
+      if let Ok(js_error) = error.downcast::<PrettyJsError>() {
         serialized_error = json!({
           "type": "error",
           "error": {

--- a/cli/source_maps.rs
+++ b/cli/source_maps.rs
@@ -2,7 +2,7 @@
 
 //! This mod provides functions to remap a `JsError` based on a source map.
 
-use deno_core::error::JsError as CoreJsError;
+use deno_core::error::JsError;
 use sourcemap::SourceMap;
 use std::collections::HashMap;
 use std::str;
@@ -26,9 +26,9 @@ pub type CachedMaps = HashMap<String, Option<SourceMap>>;
 /// file names and line/column numbers point to the location in the original
 /// source, rather than the transpiled source code.
 pub fn apply_source_map<G: SourceMapGetter>(
-  js_error: &CoreJsError,
+  js_error: &JsError,
   getter: Arc<G>,
-) -> CoreJsError {
+) -> JsError {
   // Note that js_error.frames has already been source mapped in
   // prepareStackTrace().
   let mut mappings_map: CachedMaps = HashMap::new();
@@ -71,7 +71,7 @@ pub fn apply_source_map<G: SourceMapGetter>(
     _ => js_error.source_line.clone(),
   };
 
-  CoreJsError {
+  JsError {
     message: js_error.message.clone(),
     source_line,
     script_resource_name,
@@ -198,7 +198,7 @@ mod tests {
 
   #[test]
   fn apply_source_map_line() {
-    let e = CoreJsError {
+    let e = JsError {
       message: "TypeError: baz".to_string(),
       source_line: Some("foo".to_string()),
       script_resource_name: Some("foo_bar.ts".to_string()),

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -11,6 +11,7 @@ use crate::ops;
 use crate::ops::io::get_stdio;
 use crate::permissions::Permissions;
 use crate::program_state::ProgramState;
+use crate::source_maps::apply_source_map;
 use deno_core::error::AnyError;
 use deno_core::futures::channel::mpsc;
 use deno_core::futures::future::poll_fn;
@@ -121,7 +122,9 @@ impl Worker {
       module_loader: Some(module_loader),
       startup_snapshot: Some(startup_snapshot),
       js_error_create_fn: Some(Box::new(move |core_js_error| {
-        PrettyJsError::create(core_js_error, global_state_.clone())
+        let source_mapped_error =
+          apply_source_map(&core_js_error, global_state_.clone());
+        PrettyJsError::create(source_mapped_error)
       })),
       ..Default::default()
     });

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
-use crate::fmt_errors::JsError;
+use crate::fmt_errors::PrettyJsError;
 use crate::inspector::DenoInspector;
 use crate::inspector::InspectorSession;
 use crate::js;
@@ -121,7 +121,7 @@ impl Worker {
       module_loader: Some(module_loader),
       startup_snapshot: Some(startup_snapshot),
       js_error_create_fn: Some(Box::new(move |core_js_error| {
-        JsError::create(core_js_error, global_state_.clone())
+        PrettyJsError::create(core_js_error, global_state_.clone())
       })),
       ..Default::default()
     });


### PR DESCRIPTION
This commit renames "fmt_errors::JsError" to "PrettyJsError"
to avoid confusion with "deno_core::JsError".

Consequently "CoreJsError" aliases to "deno_core::JsError"
were removed.

Additionally source mapping step has been removed from
"PrettyJsError::create" to better separate domains.