### PR TITLE
docs(std): add missing jsdoc comments to exported functions

### DIFF
--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -112,6 +112,11 @@ function fileLenToString(len: number): string {
   return `${(len / base).toFixed(2)}${suffix[suffixIndex]}`;
 }
 
+/**
+ * Returns an HTTP Response with the requested file as the body
+ * @param req The server request context used to cleanup the file handle
+ * @param filePath Path of the file to serve
+ */
 export async function serveFile(
   req: ServerRequest,
   filePath: string,

--- a/std/testing/_diff.ts
+++ b/std/testing/_diff.ts
@@ -36,6 +36,11 @@ function createCommon<T>(A: T[], B: T[], reverse?: boolean): T[] {
   return common;
 }
 
+/**
+ * Renders the differences between the actual and expected values
+ * @param A Actual value
+ * @param B Expected value
+ */
 export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
   const prefixCommon = createCommon(A, B);
   const suffixCommon = createCommon(

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -19,6 +19,11 @@ export class AssertionError extends Error {
   }
 }
 
+/**
+ * Converts the input into a string. Objects, Sets and Maps are sorted so as to
+ * make tests less flaky
+ * @param v Value to be formatted
+ */
 export function _format(v: unknown): string {
   return globalThis.Deno
     ? Deno.inspect(v, {
@@ -31,6 +36,10 @@ export function _format(v: unknown): string {
     : `"${String(v).replace(/(?=["\\])/g, "\\")}"`;
 }
 
+/**
+ * Colors the output of assertion diffs
+ * @param diffType Difference type, either added or removed
+ */
 function createColor(diffType: DiffType): (s: string) => string {
   switch (diffType) {
     case DiffType.added:
@@ -42,6 +51,10 @@ function createColor(diffType: DiffType): (s: string) => string {
   }
 }
 
+/**
+ * Prefixes `+` or `-` in diff output
+ * @param diffType Difference type, either added or removed
+ */
 function createSign(diffType: DiffType): string {
   switch (diffType) {
     case DiffType.added:
@@ -77,6 +90,11 @@ function isKeyedCollection(x: unknown): x is Set<unknown> {
   return [Symbol.iterator, "size"].every((k) => k in (x as Set<unknown>));
 }
 
+/**
+ * Deep equality comparison used in assertions
+ * @param c actual value
+ * @param d expected value
+ */
 export function equal(c: unknown, d: unknown): boolean {
   const seen = new Map();
   return (function compare(a: unknown, b: unknown): boolean {


### PR DESCRIPTION
includes:
- http/file_server.ts
- testing/_diff.ts
- testing/asserts.ts

Relates to #7487

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
