### PR TITLE
refactor(core): accept get_error_class_fn in RuntimeOptions

### DIFF
--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -118,21 +118,19 @@ impl Worker {
   ) -> Self {
     let global_state_ = program_state.clone();
 
+    let js_error_create_fn = Box::new(move |core_js_error| {
+      let source_mapped_error =
+        apply_source_map(&core_js_error, global_state_.clone());
+      PrettyJsError::create(source_mapped_error)
+    });
+
     let mut js_runtime = JsRuntime::new(RuntimeOptions {
       module_loader: Some(module_loader),
       startup_snapshot: Some(startup_snapshot),
-      js_error_create_fn: Some(Box::new(move |core_js_error| {
-        let source_mapped_error =
-          apply_source_map(&core_js_error, global_state_.clone());
-        PrettyJsError::create(source_mapped_error)
-      })),
+      js_error_create_fn: Some(js_error_create_fn),
+      get_error_class_fn: Some(&crate::errors::get_error_class_name),
       ..Default::default()
     });
-    {
-      let op_state = js_runtime.op_state();
-      let mut op_state = op_state.borrow_mut();
-      op_state.get_error_class_fn = &crate::errors::get_error_class_name;
-    }
 
     let inspector =
       if let Some(inspector_server) = &program_state.maybe_inspector_server {

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -170,6 +170,10 @@ pub struct RuntimeOptions {
   /// is set to `JsError::create()`.
   pub js_error_create_fn: Option<Box<JsErrorCreateFn>>,
 
+  /// Allows to map error type to a string "class" used to represent
+  /// error in JavaScript.
+  pub get_error_class_fn: Option<GetErrorClassFn>,
+
   /// Implementation of `ModuleLoader` which will be
   /// called when V8 requests to load ES modules.
   ///
@@ -254,7 +258,11 @@ impl JsRuntime {
     let js_error_create_fn = options
       .js_error_create_fn
       .unwrap_or_else(|| Box::new(JsError::create));
-    let op_state = OpState::default();
+    let mut op_state = OpState::default();
+
+    if let Some(get_error_class_fn) = options.get_error_class_fn {
+      op_state.get_error_class_fn = get_error_class_fn;
+    }
 
     isolate.set_slot(Rc::new(RefCell::new(JsRuntimeState {
       global_context: Some(global_context),


### PR DESCRIPTION
This commit adds "get_error_class_fn" field to "RuntimeOptions"
struct in order to unify configuration of "JsRuntime".

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
