### PR TITLE
test(std): make test output less noisy

### DIFF
--- a/std/examples/cat_test.ts
+++ b/std/examples/cat_test.ts
@@ -10,6 +10,7 @@ Deno.test("[examples/cat] print multiple files", async () => {
     cmd: [
       Deno.execPath(),
       "run",
+      "--quiet",
       "--allow-read",
       "cat.ts",
       "testdata/cat/hello.txt",

--- a/std/examples/catj_test.ts
+++ b/std/examples/catj_test.ts
@@ -82,7 +82,14 @@ function catj(
   ...files: string[]
 ): Deno.Process<Deno.RunOptions & { stdin: "piped"; stdout: "piped" }> {
   return Deno.run({
-    cmd: [Deno.execPath(), "run", "--allow-read", "catj.ts", ...files],
+    cmd: [
+      Deno.execPath(),
+      "run",
+      "--quiet",
+      "--allow-read",
+      "catj.ts",
+      ...files,
+    ],
     cwd: moduleDir,
     stdin: "piped",
     stdout: "piped",

--- a/std/examples/chat/server_test.ts
+++ b/std/examples/chat/server_test.ts
@@ -14,6 +14,7 @@ async function startServer(): Promise<
     cmd: [
       Deno.execPath(),
       "run",
+      "--quiet",
       "--allow-net",
       "--allow-read",
       "server.ts",

--- a/std/examples/colors_test.ts
+++ b/std/examples/colors_test.ts
@@ -7,7 +7,7 @@ const moduleDir = dirname(fromFileUrl(import.meta.url));
 Deno.test("[examples/colors] print a colored text", async () => {
   const decoder = new TextDecoder();
   const process = Deno.run({
-    cmd: [Deno.execPath(), "run", "colors.ts"],
+    cmd: [Deno.execPath(), "run", "--quiet", "colors.ts"],
     cwd: moduleDir,
     stdout: "piped",
   });

--- a/std/examples/curl_test.ts
+++ b/std/examples/curl_test.ts
@@ -20,6 +20,7 @@ Deno.test({
       cmd: [
         Deno.execPath(),
         "run",
+        "--quiet",
         "--allow-net",
         "curl.ts",
         "http://localhost:8081",

--- a/std/examples/echo_server_test.ts
+++ b/std/examples/echo_server_test.ts
@@ -9,7 +9,7 @@ Deno.test("[examples/echo_server]", async () => {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   const process = Deno.run({
-    cmd: [Deno.execPath(), "run", "--allow-net", "echo_server.ts"],
+    cmd: [Deno.execPath(), "run", "--quiet", "--allow-net", "echo_server.ts"],
     cwd: moduleDir,
     stdout: "piped",
   });

--- a/std/examples/test.ts
+++ b/std/examples/test.ts
@@ -19,6 +19,7 @@ Deno.test("catSmoke", async function (): Promise<void> {
     cmd: [
       Deno.execPath(),
       "run",
+      "--quiet",
       "--allow-read",
       relative(Deno.cwd(), resolve(moduleDir, "cat.ts")),
       relative(Deno.cwd(), resolve(moduleDir, "..", "README.md")),

--- a/std/examples/welcome_test.ts
+++ b/std/examples/welcome_test.ts
@@ -7,7 +7,7 @@ const moduleDir = dirname(fromFileUrl(import.meta.url));
 Deno.test("[examples/welcome] print a welcome message", async () => {
   const decoder = new TextDecoder();
   const process = Deno.run({
-    cmd: [Deno.execPath(), "run", "welcome.ts"],
+    cmd: [Deno.execPath(), "run", "--quiet", "welcome.ts"],
     cwd: moduleDir,
     stdout: "piped",
   });

--- a/std/examples/xeval_test.ts
+++ b/std/examples/xeval_test.ts
@@ -38,6 +38,7 @@ Deno.test({
       cmd: [
         Deno.execPath(),
         "run",
+        "--quiet",
         xevalPath,
         "--replvar=abc",
         "console.log(abc)",
@@ -58,7 +59,7 @@ Deno.test({
 
 Deno.test("xevalCliSyntaxError", async function (): Promise<void> {
   const p = Deno.run({
-    cmd: [Deno.execPath(), "run", xevalPath, "("],
+    cmd: [Deno.execPath(), "run", "--quiet", xevalPath, "("],
     cwd: moduleDir,
     stdin: "null",
     stdout: "piped",

--- a/std/fs/empty_dir_test.ts
+++ b/std/fs/empty_dir_test.ts
@@ -204,7 +204,7 @@ for (const s of scenes) {
       );
 
       try {
-        const args = [Deno.execPath(), "run"];
+        const args = [Deno.execPath(), "run", "--quiet"];
 
         if (s.read) {
           args.push("--allow-read");

--- a/std/fs/exists_test.ts
+++ b/std/fs/exists_test.ts
@@ -113,7 +113,7 @@ for (const s of scenes) {
   let title = `test ${s.async ? "exists" : "existsSync"}("testdata/${s.file}")`;
   title += ` ${s.read ? "with" : "without"} --allow-read`;
   Deno.test(`[fs] existsPermission ${title}`, async function (): Promise<void> {
-    const args = [Deno.execPath(), "run"];
+    const args = [Deno.execPath(), "run", "--quiet"];
 
     if (s.read) {
       args.push("--allow-read");

--- a/std/fs/expand_glob_test.ts
+++ b/std/fs/expand_glob_test.ts
@@ -119,7 +119,13 @@ Deno.test("expandGlobIncludeDirs", async function (): Promise<void> {
 Deno.test("expandGlobPermError", async function (): Promise<void> {
   const exampleUrl = new URL("testdata/expand_wildcard.js", import.meta.url);
   const p = Deno.run({
-    cmd: [Deno.execPath(), "run", "--unstable", exampleUrl.toString()],
+    cmd: [
+      Deno.execPath(),
+      "run",
+      "--quiet",
+      "--unstable",
+      exampleUrl.toString(),
+    ],
     stdin: "null",
     stdout: "piped",
     stderr: "piped",

--- a/std/http/file_server_test.ts
+++ b/std/http/file_server_test.ts
@@ -25,6 +25,7 @@ async function startFileServer({
     cmd: [
       Deno.execPath(),
       "run",
+      "--quiet",
       "--allow-read",
       "--allow-net",
       "file_server.ts",
@@ -50,6 +51,7 @@ async function startFileServerAsLibrary({}: FileServerCfg = {}): Promise<void> {
     cmd: [
       Deno.execPath(),
       "run",
+      "--quiet",
       "--allow-read",
       "--allow-net",
       "testdata/file_server_as_library.ts",
@@ -205,6 +207,7 @@ Deno.test("printHelp", async function (): Promise<void> {
     cmd: [
       Deno.execPath(),
       "run",
+      "--quiet",
       // TODO(ry) It ought to be possible to get the help output without
       // --allow-read.
       "--allow-read",
@@ -264,6 +267,7 @@ async function startTlsFileServer({
     cmd: [
       Deno.execPath(),
       "run",
+      "--quiet",
       "--allow-read",
       "--allow-net",
       "file_server.ts",
@@ -319,6 +323,7 @@ Deno.test("partial TLS arguments fail", async function (): Promise<void> {
     cmd: [
       Deno.execPath(),
       "run",
+      "--quiet",
       "--allow-read",
       "--allow-net",
       "file_server.ts",

--- a/std/http/racing_server_test.ts
+++ b/std/http/racing_server_test.ts
@@ -9,7 +9,7 @@ const moduleDir = dirname(fromFileUrl(import.meta.url));
 let server: Deno.Process<Deno.RunOptions & { stdout: "piped" }>;
 async function startServer(): Promise<void> {
   server = Deno.run({
-    cmd: [Deno.execPath(), "run", "-A", "racing_server.ts"],
+    cmd: [Deno.execPath(), "run", "--quiet", "-A", "racing_server.ts"],
     cwd: moduleDir,
     stdout: "piped",
   });

--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -370,6 +370,7 @@ Deno.test({
       cmd: [
         Deno.execPath(),
         "run",
+        "--quiet",
         "--allow-net",
         "testdata/simple_server.ts",
       ],
@@ -415,6 +416,7 @@ Deno.test({
       cmd: [
         Deno.execPath(),
         "run",
+        "--quiet",
         "--allow-net",
         "--allow-read",
         "testdata/simple_https_server.ts",


### PR DESCRIPTION
This commit makes output of std/ tests less noisy
by passing "--quiet" flag to Deno subprocesses run
as part of test suite.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
