### PR TITLE
fix(std/bufio): Remove '\r' at the end of Windows lines

### DIFF
--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -706,5 +706,15 @@ export async function* readStringDelim(
 export async function* readLines(
   reader: Reader,
 ): AsyncIterableIterator<string> {
-  yield* readStringDelim(reader, "\n");
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  for await (let chunk of readDelim(reader, encoder.encode("\n"))) {
+    // Finding a CR at the end of the line is evidence of a
+    // "\r\n" at the end of the line. The "\r" part should be
+    // removed too.
+    if (chunk[chunk.length - 1] == CR) {
+      chunk = chunk.slice(0, chunk.length - 1);
+    }
+    yield decoder.decode(chunk);
+  }
 }

--- a/std/io/bufio.ts
+++ b/std/io/bufio.ts
@@ -706,15 +706,13 @@ export async function* readStringDelim(
 export async function* readLines(
   reader: Reader,
 ): AsyncIterableIterator<string> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-  for await (let chunk of readDelim(reader, encoder.encode("\n"))) {
+  for await (let chunk of readStringDelim(reader, "\n")) {
     // Finding a CR at the end of the line is evidence of a
     // "\r\n" at the end of the line. The "\r" part should be
     // removed too.
-    if (chunk[chunk.length - 1] == CR) {
-      chunk = chunk.slice(0, chunk.length - 1);
+    if (chunk.endsWith("\r")) {
+      chunk = chunk.slice(0, -1);
     }
-    yield decoder.decode(chunk);
+    yield chunk;
   }
 }

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -436,12 +436,24 @@ Deno.test("readStringDelimAndLines", async function (): Promise<void> {
   assertEquals(chunks_, ["Hello World", "Hello World 2", "Hello World 3"]);
 
   const linesData = new Deno.Buffer(enc.encode("0\n1\n2\n3\n4\n5\n6\n7\n8\n9"));
+  // consider data with windows newlines too
+  const linesDataWindows = new Deno.Buffer(
+    enc.encode("0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9"),
+  );
   const lines_ = [];
 
   for await (const l of readLines(linesData)) {
     lines_.push(l);
   }
 
+  assertEquals(lines_.length, 10);
+  assertEquals(lines_, ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]);
+
+  // Now test for "windows" lines
+  lines_.length = 0;
+  for await (const l of readLines(linesDataWindows)) {
+    lines_.push(l);
+  }
   assertEquals(lines_.length, 10);
   assertEquals(lines_, ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]);
 });


### PR DESCRIPTION
Fix #7093

Removes "\r" from the end of lines when using `readLines`.

For example for a file containing `"A\r\nB\r\nC"`:
```javascript
let fr = await Deno.open("./file.txt");
for await (let line of readLines(fr)) {
  console.log([line]);
}

/* 
Before:
[ "A\r" ]
[ "B\r" ]
[ "C" ]

Now:
[ "A" ]
[ "B" ]
[ "C" ]
*/
```