### PR TITLE
chore(cli/flags): Rename --failfast to --fail-fast

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -574,7 +574,7 @@ fn test_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   runtime_args_parse(flags, matches, true);
 
   let no_run = matches.is_present("no-run");
-  let failfast = matches.is_present("failfast");
+  let fail_fast = matches.is_present("fail-fast");
   let allow_none = matches.is_present("allow-none");
   let quiet = matches.is_present("quiet");
   let filter = matches.value_of("filter").map(String::from);
@@ -609,7 +609,7 @@ fn test_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 
   flags.subcommand = DenoSubcommand::Test {
     no_run,
-    fail_fast: failfast,
+    fail_fast,
     quiet,
     include,
     filter,
@@ -1158,8 +1158,9 @@ fn test_subcommand<'a, 'b>() -> App<'a, 'b> {
         .requires("unstable"),
     )
     .arg(
-      Arg::with_name("failfast")
-        .long("failfast")
+      Arg::with_name("fail-fast")
+        .long("fail-fast")
+        .alias("failfast")
         .help("Stop on first error")
         .takes_value(false),
     )

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1887,7 +1887,7 @@ itest!(deno_test {
 });
 
 itest!(deno_test_fail_fast {
-  args: "test --failfast test_runner_test.ts",
+  args: "test --fail-fast test_runner_test.ts",
   exit_code: 1,
   output: "deno_test_fail_fast.out",
 });

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -199,10 +199,10 @@ Deno.test({
 ## Failing fast
 
 If you have a long running test suite and wish for it to stop on the first
-failure, you can specify the `--failfast` flag when running the suite.
+failure, you can specify the `--fail-fast` flag when running the suite.
 
 ```shell
-deno test --failfast
+deno test --fail-fast
 ```
 
 ## Test coverage


### PR DESCRIPTION
Closes #8455.