### PR TITLE
build: cargo-deny integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,22 @@ name: ci
 on: [push, pull_request]
 
 jobs:
+  cargo-deny:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check ${{ matrix.checks }}
   build:
     name: ${{ matrix.kind }} ${{ matrix.os }}
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   cargo-deny:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         checks:

--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,7 @@ targets = [
 # The lint level for security vulnerabilities
 vulnerability = "deny"
 # The lint level for unmaintained crates
-unmaintained = "warn"
+unmaintained = "deny"
 # The lint level for crates that have been yanked from their source registry
 yanked = "deny"
 # The lint level for crates with security notices. Note that as of
@@ -55,7 +55,7 @@ license-files = [
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 # Lint level for when multiple versions of the same crate are detected
-multiple-versions = "deny"
+multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
 wildcards = "allow"
 # The graph highlighting used when creating dotgraphs for crates

--- a/deny.toml
+++ b/deny.toml
@@ -11,11 +11,11 @@ vulnerability = "deny"
 # The lint level for unmaintained crates
 unmaintained = "warn"
 # The lint level for crates that have been yanked from their source registry
-yanked = "warn"
+yanked = "deny"
 # The lint level for crates with security notices. Note that as of
 # 2019-12-17 there are no security notice advisories in
 # https://github.com/rustsec/advisory-db
-notice = "warn"
+notice = "deny"
 
 [licenses]
 # The lint level for crates which do not have a detectable license
@@ -30,16 +30,32 @@ confidence-threshold = 0.8
 # List of explictly allowed licenses
 allow = [
   "Apache-2.0",
+  "BSD-2-Clause",
+  "CC0-1.0",
+  "ISC",
   "MIT",
   "MPL-2.0",
-  "ISC",
-  "BSD-2-Clause",
+  "OpenSSL",
+]
+[[licenses.clarify]]
+name = "ring"
+# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
+# https://spdx.org/licenses/OpenSSL.html
+# ISC - Both BoringSSL and ring use this for their new files
+# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
+# license, for third_party/fiat, which, unlike other third_party directories, is
+# compiled into non-test libraries, is included below."
+# OpenSSL - Obviously
+# Reference:  https://github.com/EmbarkStudios/cargo-deny/issues/110
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [
+  {path = "LICENSE", hash = 0xbd0eed23},
 ]
 
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 # Lint level for when multiple versions of the same crate are detected
-multiple-versions = "warn"
+multiple-versions = "deny"
 # Lint level for when a crate version requirement is `*`
 wildcards = "allow"
 # The graph highlighting used when creating dotgraphs for crates
@@ -49,10 +65,10 @@ highlight = "all"
 [sources]
 # Lint level for what to happen when a crate from a crate registry that is not
 # in the allow list is encountered
-unknown-registry = "warn"
+unknown-registry = "deny"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
-unknown-git = "warn"
+unknown-git = "deny"
 # List of URLs for allowed crate registries. Defaults to the crates.io index
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,60 @@
+targets = [
+  {triple = "x86_64-unknown-linux-gnu"},
+  {triple = "x86_64-apple-darwin"},
+  {triple = "x86_64-pc-windows-msvc"},
+]
+
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The lint level for security vulnerabilities
+vulnerability = "deny"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+allow-osi-fsf-free = "both"
+# Lint level for licenses considered copyleft
+copyleft = "warn"
+# The confidence threshold for detecting a license from license text.
+# We want really high confidence when inferring licenses
+confidence-threshold = 0.8
+# List of explictly allowed licenses
+allow = [
+  "Apache-2.0",
+  "MIT",
+  "MPL-2.0",
+  "ISC",
+  "BSD-2-Clause",
+]
+
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+highlight = "all"
+
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []

--- a/test_plugin/Cargo.toml
+++ b/test_plugin/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "test_plugin"
 version = "0.0.1"
+license = "MIT"
 authors = ["the deno authors"]
 edition = "2018"
 publish = false

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "test_util"
 version = "0.1.0"
+license = "MIT"
 authors = ["the Deno authors"]
 edition = "2018"
 publish = false


### PR DESCRIPTION
This pull request tries to solve the #5006 

Continuing the discussion from thread:
> Could you point out which crates are unlicensed

internal crates test_util and test_plugin are unlicensed according to cargo-check. attaching log of `cargo check` on license:
https://del.dog/dimerastoj.log

will push other changes to severity soon