### PR TITLE
feat(std/fs): Re-enable "followSymlinks" option in "walk()" API

### DIFF
--- a/std/fs/walk.ts
+++ b/std/fs/walk.ts
@@ -106,17 +106,16 @@ export async function* walk(
     return;
   }
   for await (const entry of Deno.readDir(root)) {
+    assert(entry.name != null);
+    let path = join(root, entry.name);
+
     if (entry.isSymlink) {
       if (followSymlinks) {
-        // TODO(ry) Re-enable followSymlinks.
-        throw new Error("unimplemented");
+        path = await Deno.realPath(path);
       } else {
         continue;
       }
     }
-
-    assert(entry.name != null);
-    const path = join(root, entry.name);
 
     if (entry.isFile) {
       if (includeFiles && include(path, exts, match, skip)) {
@@ -159,16 +158,16 @@ export function* walkSync(
     return;
   }
   for (const entry of Deno.readDirSync(root)) {
+    assert(entry.name != null);
+    let path = join(root, entry.name);
+
     if (entry.isSymlink) {
       if (followSymlinks) {
-        throw new Error("unimplemented");
+        path = Deno.realPathSync(path);
       } else {
         continue;
       }
     }
-
-    assert(entry.name != null);
-    const path = join(root, entry.name);
 
     if (entry.isFile) {
       if (includeFiles && include(path, exts, match, skip)) {

--- a/std/fs/walk_test.ts
+++ b/std/fs/walk_test.ts
@@ -252,12 +252,11 @@ testWalk(
   async function symlink(): Promise<void> {
     assertReady(6);
     const files = await walkArray("a");
-    assertEquals(files.length, 2);
+    assertEquals(files.length, 3);
     assert(!files.includes("a/bb/z"));
 
     const arr = await walkArray("a", { followSymlinks: true });
-    assertEquals(arr.length, 3);
+    assertEquals(arr.length, 5);
     assert(arr.some((f): boolean => f.endsWith("/b/z")));
   },
-  true,
 );


### PR DESCRIPTION
Fixes #8076
