### PR TITLE
fix(cli): make output of deno info --json deterministic

### DIFF
--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -41,8 +41,8 @@ use regex::Regex;
 use serde::Deserialize;
 use serde::Deserializer;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::{BTreeSet, HashMap};
 use std::error::Error;
 use std::fmt;
 use std::path::PathBuf;
@@ -1098,7 +1098,7 @@ impl Graph {
       .modules
       .iter()
       .map(|(specifier, module)| {
-        let mut deps = HashSet::new();
+        let mut deps = BTreeSet::new();
         for (_, dep) in module.dependencies.iter() {
           if let Some(code_dep) = &dep.maybe_code {
             deps.insert(code_dep.clone());

--- a/cli/tests/076_info_json_deps_order.out
+++ b/cli/tests/076_info_json_deps_order.out
@@ -1,0 +1,42 @@
+{
+  "compiled": null,
+  "depCount": 4,
+  "fileType": "TypeScript",
+  "files": {
+    "[WILDCARD]cli/tests/076_info_json_deps_order.ts": {
+      "deps": [
+        "[WILDCARD]cli/tests/recursive_imports/A.ts"
+      ],
+      "size": 96
+    },
+    "[WILDCARD]cli/tests/recursive_imports/A.ts": {
+      "deps": [
+        "[WILDCARD]cli/tests/recursive_imports/B.ts",
+        "[WILDCARD]cli/tests/recursive_imports/common.ts"
+      ],
+      "size": 114
+    },
+    "[WILDCARD]cli/tests/recursive_imports/B.ts": {
+      "deps": [
+        "[WILDCARD]cli/tests/recursive_imports/C.ts",
+        "[WILDCARD]cli/tests/recursive_imports/common.ts"
+      ],
+      "size": 114
+    },
+    "[WILDCARD]cli/tests/recursive_imports/C.ts": {
+      "deps": [
+        "[WILDCARD]cli/tests/recursive_imports/A.ts",
+        "[WILDCARD]cli/tests/recursive_imports/common.ts"
+      ],
+      "size": 132
+    },
+    "[WILDCARD]cli/tests/recursive_imports/common.ts": {
+      "deps": [],
+      "size": 34
+    }
+  },
+  "local": "/home/wperron/github.com/wperron/deno/cli/tests/076_info_json_deps_order.ts",
+  "map": null,
+  "module": "[WILDCARD]cli/tests/076_info_json_deps_order.ts",
+  "totalSize": 490
+}

--- a/cli/tests/076_info_json_deps_order.out
+++ b/cli/tests/076_info_json_deps_order.out
@@ -7,36 +7,32 @@
       "deps": [
         "[WILDCARD]cli/tests/recursive_imports/A.ts"
       ],
-      "size": 96
+      "size": [WILDCARD]
     },
     "[WILDCARD]cli/tests/recursive_imports/A.ts": {
       "deps": [
         "[WILDCARD]cli/tests/recursive_imports/B.ts",
         "[WILDCARD]cli/tests/recursive_imports/common.ts"
       ],
-      "size": 114
+      "size": [WILDCARD]
     },
     "[WILDCARD]cli/tests/recursive_imports/B.ts": {
       "deps": [
         "[WILDCARD]cli/tests/recursive_imports/C.ts",
         "[WILDCARD]cli/tests/recursive_imports/common.ts"
       ],
-      "size": 114
+      "size": [WILDCARD]
     },
     "[WILDCARD]cli/tests/recursive_imports/C.ts": {
       "deps": [
         "[WILDCARD]cli/tests/recursive_imports/A.ts",
         "[WILDCARD]cli/tests/recursive_imports/common.ts"
       ],
-      "size": 132
+      "size": [WILDCARD]
     },
     "[WILDCARD]cli/tests/recursive_imports/common.ts": {
       "deps": [],
-      "size": 34
+      "size": [WILDCARD]
     }
   },
-  "local": "/home/wperron/github.com/wperron/deno/cli/tests/076_info_json_deps_order.ts",
-  "map": null,
-  "module": "[WILDCARD]cli/tests/076_info_json_deps_order.ts",
-  "totalSize": 490
-}
+[WILDCARD]

--- a/cli/tests/076_info_json_deps_order.ts
+++ b/cli/tests/076_info_json_deps_order.ts
@@ -1,0 +1,1 @@
+import { A } from "./recursive_imports/A.ts";

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2423,6 +2423,11 @@ itest!(_075_import_local_query_hash {
   output: "075_import_local_query_hash.ts.out",
 });
 
+itest!(_076_info_json_deps_order {
+  args: "info --unstable --json 076_info_json_deps_order.ts",
+  output: "076_info_json_deps_order.out",
+});
+
 itest!(js_import_detect {
   args: "run --quiet --reload js_import_detect.ts",
   output: "js_import_detect.ts.out",

--- a/core/module_specifier.rs
+++ b/core/module_specifier.rs
@@ -16,7 +16,6 @@ pub enum ModuleResolutionError {
   InvalidPath(PathBuf),
   ImportPrefixMissing(String, Option<String>),
 }
-use std::cmp::Ordering;
 use ModuleResolutionError::*;
 
 impl Error for ModuleResolutionError {
@@ -49,7 +48,9 @@ impl fmt::Display for ModuleResolutionError {
   }
 }
 
-#[derive(Debug, Clone, Eq, Hash, PartialEq, serde::Serialize)]
+#[derive(
+  Debug, Clone, Eq, Hash, PartialEq, serde::Serialize, Ord, PartialOrd,
+)]
 /// Resolved module specifier
 pub struct ModuleSpecifier(Url);
 
@@ -205,18 +206,6 @@ impl From<Url> for ModuleSpecifier {
 impl PartialEq<String> for ModuleSpecifier {
   fn eq(&self, other: &String) -> bool {
     &self.to_string() == other
-  }
-}
-
-impl Ord for ModuleSpecifier {
-  fn cmp(&self, other: &Self) -> Ordering {
-    self.0.cmp(&other.0)
-  }
-}
-
-impl PartialOrd for ModuleSpecifier {
-  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-    Some(self.cmp(other))
   }
 }
 

--- a/core/module_specifier.rs
+++ b/core/module_specifier.rs
@@ -16,6 +16,7 @@ pub enum ModuleResolutionError {
   InvalidPath(PathBuf),
   ImportPrefixMissing(String, Option<String>),
 }
+use std::cmp::Ordering;
 use ModuleResolutionError::*;
 
 impl Error for ModuleResolutionError {
@@ -204,6 +205,18 @@ impl From<Url> for ModuleSpecifier {
 impl PartialEq<String> for ModuleSpecifier {
   fn eq(&self, other: &String) -> bool {
     &self.to_string() == other
+  }
+}
+
+impl Ord for ModuleSpecifier {
+  fn cmp(&self, other: &Self) -> Ordering {
+    self.0.cmp(&other.0)
+  }
+}
+
+impl PartialOrd for ModuleSpecifier {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
   }
 }
 


### PR DESCRIPTION
changed the HashSet used to build the ModuleInfoMap for a BTreeSet to keep the items sorted

Fixes #8458

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
