### PR TITLE
feat(test): separator between disjoint lines for coverage report

### DIFF
--- a/cli/tests/test_coverage.out
+++ b/cli/tests/test_coverage.out
@@ -1,23 +1,21 @@
 Check [WILDCARD]/$deno$test.ts
 running 1 tests
-test returnsHiSuccess ... ok ([WILDCARD])
+test returnsFooSuccess ... ok ([WILDCARD])
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
 cover [WILDCARD]/cli/tests/subdir/mod1.ts ... 35.714% (5/14)
-   5 | export function returnsFoo2() {
-   6 |     return returnsFoo();
-   7 | }
+   2 | export function returnsHi() {
+   3 |     return "Hi";
+   4 | }
+-----|-----
    8 | export function printHello3() {
    9 |     printHello2();
   10 | }
   11 | export function throwsError() {
   12 |     throw Error("exception from mod1");
   13 | }
-cover [WILDCARD]/cli/tests/subdir/subdir2/mod2.ts ... 25.000% (2/8)
-   2 | export function returnsFoo() {
-   3 |     return "Foo";
-   4 | }
+cover [WILDCARD]/cli/tests/subdir/subdir2/mod2.ts ... 62.500% (5/8)
    5 | export function printHello2() {
    6 |     printHello();
    7 | }

--- a/cli/tests/test_coverage.ts
+++ b/cli/tests/test_coverage.ts
@@ -1,5 +1,5 @@
-import { returnsHi } from "./subdir/mod1.ts";
+import { returnsFoo2 } from "./subdir/mod1.ts";
 
-Deno.test("returnsHiSuccess", function () {
-  returnsHi();
+Deno.test("returnsFooSuccess", function () {
+  returnsFoo2();
 });

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -185,14 +185,28 @@ impl PrettyCoverageReporter {
         println!("{}", colors::red(&line_coverage));
       }
 
+      let mut last_line = None;
       for line_index in uncovered_lines {
+        const WIDTH: usize = 4;
+        const SEPERATOR: &str = "|";
+
+        // Put a horizontal separator between disjoint runs of lines
+        if let Some(last_line) = last_line {
+          if last_line + 1 != line_index {
+            let dash = colors::gray(&"-".repeat(WIDTH + 1));
+            println!("{}{}{}", dash, colors::gray(SEPERATOR), dash);
+          }
+        }
+
         println!(
-          "{:width$}{} {}",
+          "{:width$} {} {}",
           line_index + 1,
-          colors::gray(" |"),
+          colors::gray(SEPERATOR),
           colors::red(&lines[line_index]),
-          width = 4
+          width = WIDTH
         );
+
+        last_line = Some(line_index);
       }
     }
   }


### PR DESCRIPTION
Places a newline between non-consecutive lines to improve readability.
Goes towards #7652.
