### PR TITLE
fix(std/encoding/csv) Correct readme formatting due to dprint issues

### DIFF
--- a/std/encoding/README.md
+++ b/std/encoding/README.md
@@ -102,31 +102,32 @@ function is as follows:
 
   `DataItem: Record<string, unknown> | unknown[]`
 
-      ```ts
-      const data = [
-        {
-          name: "Deno",
-          repo: { org: "denoland", name: "deno" },
-          runsOn: ["Rust", "TypeScript"],
-        },
-      ];
-      ```
+  ```ts
+  const data = [
+    {
+      name: "Deno",
+      repo: { org: "denoland", name: "deno" },
+      runsOn: ["Rust", "TypeScript"],
+    },
+  ];
+  ```
 
 - **`columns`** is a list of instructions for how to target and transform the
   data for each column of output. This is also where you can provide an explicit
   header name for the column.
 
   `Column`:
+
   - The most essential aspect of a column is accessing the property holding the
     data for that column on each object in the data array. If that member is at
     the top level, `Column` can simply be a property accessor, which is either a
     `string` (if it's a plain object) or a `number` (if it's an array).
 
-        ```ts
-        const columns = [
-          "name",
-        ];
-        ```
+    ```ts
+    const columns = [
+      "name",
+    ];
+    ```
 
     Each property accessor will be used as the header for the column:
 
@@ -138,12 +139,12 @@ function is as follows:
     objects/arrays), then a simple property accessor won't work, so an array of
     them will be required.
 
-        ```ts
-        const columns = [
-          ["repo", "name"],
-          ["repo", "org"],
-        ];
-        ```
+    ```ts
+    const columns = [
+      ["repo", "name"],
+      ["repo", "org"],
+    ];
+    ```
 
     When using arrays of property accessors, the header names inherit the value
     of the last accessor in each array:
@@ -158,27 +159,29 @@ function is as follows:
 
     - **`fn?: (value: any) => string | Promise<string>`** is an optional
       function to transform the targeted data into the desired format
+
     - **`header?: string`** is the optional value to use for the column header
       name
+
     - **`prop: PropertyAccessor | PropertyAccessor[]`** is the property accessor
       (`string` or `number`) or array of property accessors used to access the
       data on each object
 
-          ```ts
-          const columns = [
-            "name",
-            {
-              prop: ["runsOn", 0],
-              header: "language 1",
-              fn: (str: string) => str.toLowerCase(),
-            },
-            {
-              prop: ["runsOn", 1],
-              header: "language 2",
-              fn: (str: string) => str.toLowerCase(),
-            },
-          ];
-          ```
+    ```ts
+    const columns = [
+      "name",
+      {
+        prop: ["runsOn", 0],
+        header: "language 1",
+        fn: (str: string) => str.toLowerCase(),
+      },
+      {
+        prop: ["runsOn", 1],
+        header: "language 2",
+        fn: (str: string) => str.toLowerCase(),
+      },
+    ];
+    ```
 
     | name | language 1 | language 2 |
     | :--: | :--------: | :--------: |


### PR DESCRIPTION
Ref: https://github.com/denoland/deno/pull/8408#issuecomment-733755022:

> > assuming [05e0760](https://github.com/denoland/deno/commit/05e07600b7b4f3a21052fad89d1655acd489e6a1) is the proper result
> 
> @dsherret @bartlomieju It is not the proper result.
> 
> It breaks the code blocks (includes literal triple ticks in the code bocks), and also improperly nests some code blocks in unrelated list items.
> 
> Visually compare [the intended version](https://github.com/denoland/deno/blob/703aed6a8059646504c17c428cc1cd68d53731be/std/encoding/README.md#stringify) ([703aed6](https://github.com/denoland/deno/commit/703aed6a8059646504c17c428cc1cd68d53731be)) to [the auto-formatted version](https://github.com/denoland/deno/blob/05e07600b7b4f3a21052fad89d1655acd489e6a1/std/encoding/README.md#stringify) ([05e0760](https://github.com/denoland/deno/commit/05e07600b7b4f3a21052fad89d1655acd489e6a1)).

