### PR TITLE
fix test_raw_tty hang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,7 @@ dependencies = [
  "dprint-plugin-typescript",
  "encoding_rs",
  "env_logger",
+ "exec",
  "filetime",
  "fwdansi",
  "http",
@@ -701,6 +702,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
+dependencies = [
+ "gcc",
+ "libc",
+]
+
+[[package]]
+name = "exec"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615"
+dependencies = [
+ "errno 0.2.7",
+ "libc",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +940,12 @@ checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -1775,7 +1813,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50f3d255966981eb4e4c5df3e983e6f7d163221f547406d83b6a460ff5c5ee8"
 dependencies = [
- "errno",
+ "errno 0.1.8",
  "libc",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -93,9 +93,7 @@ nix = "0.18.0"
 chrono = "0.4.15"
 os_pipe = "0.9.2"
 test_util = { path = "../test_util" }
-exec = "0.3.1"
-
-
+exec = "0.3.1" # Used in test_raw_tty
 
 [package.metadata.winres]
 # This section defines the metadata that appears in the deno.exe PE header.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -93,6 +93,9 @@ nix = "0.18.0"
 chrono = "0.4.15"
 os_pipe = "0.9.2"
 test_util = { path = "../test_util" }
+exec = "0.3.1"
+
+
 
 [package.metadata.winres]
 # This section defines the metadata that appears in the deno.exe PE header.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -93,6 +93,8 @@ nix = "0.18.0"
 chrono = "0.4.15"
 os_pipe = "0.9.2"
 test_util = { path = "../test_util" }
+
+[target.'cfg(unix)'.dev-dependencies]
 exec = "0.3.1" # Used in test_raw_tty
 
 [package.metadata.winres]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -183,32 +183,17 @@ pub fn test_raw_tty() {
 
   if let Ok(mut master) = fork.is_parent() {
     let mut obytes: [u8; 100] = [0; 100];
-
-    println!("read S");
     let mut nread = master.read(&mut obytes).unwrap();
     assert_eq!(String::from_utf8_lossy(&obytes[0..nread]), "S");
-
-    println!("write a");
     master.write_all(b"a").unwrap();
-
-    println!("read A");
     nread = master.read(&mut obytes).unwrap();
     assert_eq!(String::from_utf8_lossy(&obytes[0..nread]), "A");
-
-    println!("write b");
     master.write_all(b"b").unwrap();
-
-    println!("read B");
     nread = master.read(&mut obytes).unwrap();
     assert_eq!(String::from_utf8_lossy(&obytes[0..nread]), "B");
-
-    println!("write c");
     master.write_all(b"c").unwrap();
-
-    println!("read C");
     nread = master.read(&mut obytes).unwrap();
     assert_eq!(String::from_utf8_lossy(&obytes[0..nread]), "C");
-
     fork.wait().unwrap();
   } else {
     use nix::sys::termios;


### PR DESCRIPTION
On OSX and linux I can reproduce the hang reliably by running:

    while true; do cargo test -p deno  tty -- --nocapture; done

Sometimes you have to wait a bit, but it shows up eventually.

I never see the hang when running

    while true; do cargo test -p deno test_raw_tty  -- --nocapture; done

Therefore I think its related to fork / test runner.


Edit: working now.

Closes #4262