### PR TITLE
docs(import_maps): Add trailing slash to ./src example

### DIFF
--- a/docs/linking_to_external_code/import_maps.md
+++ b/docs/linking_to_external_code/import_maps.md
@@ -65,7 +65,7 @@ You may map a different directory: (eg. src)
 
 {
   "imports": {
-    "/": "./src"
+    "/": "./src/"
   }
 }
 ```


### PR DESCRIPTION
Update docs to reflect current behavior. If trailing slash is not provided, `deno run` will throw error: `Package address targets must end with "/"`.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
