### PR TITLE
build: publish only "deno" crate on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,18 +274,5 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          cd core
-          cargo publish
-          sleep 30
-          cd ../op_crates/web
-          cargo publish
-          sleep 30
-          cd ../fetch
-          cargo publish
-          sleep 30
-          cd ../crypto
-          cargo publish
-          sleep 30
-          cd ../../cli
-          sleep 30
+          cd cli
           cargo publish


### PR DESCRIPTION
This commit updates CI script to publish only "deno"
crate on tags.

Following crates are not automatically published anymore:
- deno_core
- deno_web
- deno_fetch
- deno_crypto

Before this commit creating a new release required to bump
version on all above crates even though in practice they
rarely change.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
