### PR TITLE
fix(cli/version): canary change pre-release to metadata

### DIFF
--- a/cli/version.rs
+++ b/cli/version.rs
@@ -6,7 +6,7 @@ pub const TYPESCRIPT: &str = crate::js::TS_VERSION;
 pub fn deno() -> String {
   let semver = env!("CARGO_PKG_VERSION");
   option_env!("DENO_CANARY").map_or(semver.to_string(), |_| {
-    format!("{}-{}", semver, GIT_COMMIT_HASH)
+    format!("{}+{}", semver, GIT_COMMIT_HASH)
   })
 }
 


### PR DESCRIPTION
Currently canary versioning is described using a `-` between semver & hash. That's incorrect as `-` is for pre releases whereas `+` is for build metadata (as described on the semver spec), which would be more appropriate for canaries.