### PR TITLE
feat: deno compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,11 +162,11 @@ jobs:
         if: matrix.kind == 'test_debug'
         run: cargo build --locked --all-targets
 
+      # TODO(lucacasonato): remove deno compile before landing
       - name: Test release
         if: matrix.kind == 'test_release'
         run: |
           cargo test --release --locked --all-targets
-        # TODO(lucacasonato): remove before landing
           ./target/release/deno compile https://deno.land/std/http/file_server.ts file_server
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,19 +162,9 @@ jobs:
         if: matrix.kind == 'test_debug'
         run: cargo build --locked --all-targets
 
-      # TODO(lucacasonato): remove deno compile before landing
       - name: Test release
         if: matrix.kind == 'test_release'
-        run: |
-          cargo test --release --locked --all-targets
-          ./target/release/deno compile https://deno.land/std/http/file_server.ts file_server
-
-      - uses: actions/upload-artifact@v2
-        with:	
-          name: 'file_server_${{ runner.os }}'	
-          path: |
-            file_server
-            file_server.exe
+        run: cargo test --release --locked --all-targets
 
       - name: Test debug
         if: matrix.kind == 'test_debug'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,17 @@ jobs:
 
       - name: Test release
         if: matrix.kind == 'test_release'
-        run: cargo test --release --locked --all-targets
+        run: |
+          cargo test --release --locked --all-targets
+        # TODO(lucacasonato): remove before landing
+          ./target/release/deno compile https://deno.land/std/http/file_server.ts file_server
+
+      - uses: actions/upload-artifact@v2
+        with:	
+          name: 'file_server_${{ runner.os }}'	
+          path: |
+            file_server
+            file_server.exe
 
       - name: Test debug
         if: matrix.kind == 'test_debug'

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -22,6 +22,10 @@ pub enum DenoSubcommand {
     source_file: String,
     out_file: Option<PathBuf>,
   },
+  Compile {
+    source_file: String,
+    out_file: String,
+  },
   Completions {
     buf: Box<[u8]>,
   },
@@ -291,6 +295,8 @@ pub fn flags_from_vec_safe(args: Vec<String>) -> clap::Result<Flags> {
     doc_parse(&mut flags, m);
   } else if let Some(m) = matches.subcommand_matches("lint") {
     lint_parse(&mut flags, m);
+  } else if let Some(m) = matches.subcommand_matches("compile") {
+    compile_parse(&mut flags, m);
   } else {
     repl_parse(&mut flags, &matches);
   }
@@ -340,6 +346,7 @@ If the flag is set, restrict these messages to errors.",
     )
     .subcommand(bundle_subcommand())
     .subcommand(cache_subcommand())
+    .subcommand(compile_subcommand())
     .subcommand(completions_subcommand())
     .subcommand(doc_subcommand())
     .subcommand(eval_subcommand())
@@ -404,6 +411,18 @@ fn install_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     args,
     root,
     force,
+  };
+}
+
+fn compile_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
+  compile_args_parse(flags, matches);
+
+  let source_file = matches.value_of("source_file").unwrap().to_string();
+  let out_file = matches.value_of("out_file").unwrap().to_string();
+
+  flags.subcommand = DenoSubcommand::Compile {
+    source_file,
+    out_file,
   };
 }
 
@@ -787,6 +806,22 @@ The installation root is determined, in order of precedence:
   - $HOME/.deno
 
 These must be added to the path manually if required.")
+}
+
+fn compile_subcommand<'a, 'b>() -> App<'a, 'b> {
+  compile_args(SubCommand::with_name("compile"))
+    .arg(
+      Arg::with_name("source_file")
+        .takes_value(true)
+        .required(true),
+    )
+    .arg(Arg::with_name("out_file").takes_value(true).required(true))
+    .about("Compile the script into a self contained executable")
+    .long_about(
+      "Compiles the given script into a self contained executable.
+  deno compile https://deno.land/std/http/file_server.ts file_server
+  deno compile https://deno.land/std/examples/colors.ts colors",
+    )
 }
 
 fn bundle_subcommand<'a, 'b>() -> App<'a, 'b> {

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -819,8 +819,8 @@ fn compile_subcommand<'a, 'b>() -> App<'a, 'b> {
     .about("Compile the script into a self contained executable")
     .long_about(
       "Compiles the given script into a self contained executable.
-  deno compile https://deno.land/std/http/file_server.ts file_server
-  deno compile https://deno.land/std/examples/colors.ts colors",
+  deno compile --unstable https://deno.land/std/http/file_server.ts file_server
+  deno compile --unstable https://deno.land/std/examples/colors.ts colors",
     )
 }
 

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -820,7 +820,9 @@ fn compile_subcommand<'a, 'b>() -> App<'a, 'b> {
     .long_about(
       "Compiles the given script into a self contained executable.
   deno compile --unstable https://deno.land/std/http/file_server.ts file_server
-  deno compile --unstable https://deno.land/std/examples/colors.ts colors",
+  deno compile --unstable https://deno.land/std/examples/colors.ts colors
+  
+Cross compiling binaries for different platforms is not currently possible.",
     )
 }
 

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -3179,4 +3179,49 @@ mod tests {
       }
     );
   }
+
+  #[test]
+  fn compile() {
+    let r = flags_from_vec_safe(svec![
+      "deno",
+      "compile",
+      "https://deno.land/std/examples/colors.ts",
+      "colors"
+    ]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Compile {
+          source_file: "https://deno.land/std/examples/colors.ts".to_string(),
+          out_file: "colors".to_string()
+        },
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn compile_with_flags() {
+    #[rustfmt::skip]
+    let r = flags_from_vec_safe(svec!["deno", "compile", "--unstable", "--import-map", "import_map.json", "--no-remote", "--config", "tsconfig.json", "--no-check", "--reload", "--lock", "lock.json", "--lock-write", "--cert", "example.crt", "https://deno.land/std/examples/colors.ts", "colors"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Compile {
+          source_file: "https://deno.land/std/examples/colors.ts".to_string(),
+          out_file: "colors".to_string()
+        },
+        unstable: true,
+        import_map_path: Some("import_map.json".to_string()),
+        no_remote: true,
+        config_path: Some("tsconfig.json".to_string()),
+        no_check: true,
+        reload: true,
+        lock: Some(PathBuf::from("lock.json")),
+        lock_write: true,
+        ca_file: Some("example.crt".to_string()),
+        ..Flags::default()
+      }
+    );
+  }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -52,11 +52,16 @@ mod worker;
 use crate::file_fetcher::File;
 use crate::file_fetcher::FileFetcher;
 use crate::file_watcher::ModuleResolutionResult;
+use crate::flags::DenoSubcommand;
+use crate::flags::Flags;
+use crate::import_map::ImportMap;
 use crate::media_type::MediaType;
 use crate::permissions::Permissions;
+use crate::program_state::exit_unstable;
 use crate::program_state::ProgramState;
 use crate::specifier_handler::FetchHandler;
 use crate::standalone::create_standalone_binary;
+use crate::tools::installer::infer_name_from_url;
 use crate::worker::MainWorker;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
@@ -68,12 +73,8 @@ use deno_core::v8_set_flags;
 use deno_core::ModuleSpecifier;
 use deno_doc as doc;
 use deno_doc::parser::DocFileLoader;
-use flags::DenoSubcommand;
-use flags::Flags;
-use import_map::ImportMap;
 use log::Level;
 use log::LevelFilter;
-use program_state::exit_unstable;
 use std::cell::RefCell;
 use std::env;
 use std::io::Read;
@@ -83,7 +84,6 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
-use tools::installer::infer_name_from_url;
 
 fn write_to_stdout_ignore_sigpipe(bytes: &[u8]) -> Result<(), std::io::Error> {
   use std::io::ErrorKind;
@@ -194,7 +194,10 @@ async fn compile_command(
     colors::green("Compile"),
     module_specifier.to_string()
   );
-  create_standalone_binary(bundle_str.as_bytes().to_vec(), out_file).await?;
+  create_standalone_binary(bundle_str.as_bytes().to_vec(), out_file.clone())
+    .await?;
+
+  info!("{} {}", colors::green("Emit"), out_file);
 
   Ok(())
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -155,6 +155,10 @@ async fn compile_command(
   source_file: String,
   out_file: String,
 ) -> Result<(), AnyError> {
+  if !flags.unstable {
+    exit_unstable("compile");
+  }
+
   let debug = flags.log_level == Some(log::Level::Debug);
 
   let module_specifier = ModuleSpecifier::resolve_url_or_path(&source_file)?;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -238,6 +238,11 @@ async fn compile_command(
   final_bin.append(&mut bundle);
   final_bin.append(&mut magic_trailer);
 
+  let out_file = if cfg!(windows) && !out_file.ends_with(".exe") {
+    format!("{}.exe", out_file)
+  } else {
+    out_file
+  };
   tokio::fs::write(out_file, final_bin).await?;
 
   Ok(())

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1079,7 +1079,7 @@ pub fn main() {
   colors::enable_ansi(); // For Windows 10
 
   let args: Vec<String> = env::args().collect();
-  if let Err(err) = standalone::try_run_standalone_binary() {
+  if let Err(err) = standalone::try_run_standalone_binary(args.clone()) {
     eprintln!("{}: {}", colors::red_bold("error"), err.to_string());
     std::process::exit(1);
   }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -243,8 +243,13 @@ async fn compile_command(
   } else {
     out_file
   };
-  tokio::fs::write(out_file, final_bin).await?;
-
+  tokio::fs::write(&out_file, final_bin).await?;
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(0o777);
+    tokio::fs::set_permissions(out_file, perms).await?;
+  }
   Ok(())
 }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -56,6 +56,7 @@ use crate::media_type::MediaType;
 use crate::permissions::Permissions;
 use crate::program_state::ProgramState;
 use crate::specifier_handler::FetchHandler;
+use crate::standalone::create_standalone_binary;
 use crate::worker::MainWorker;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
@@ -164,96 +165,27 @@ async fn compile_command(
   let module_specifier = ModuleSpecifier::resolve_url_or_path(&source_file)?;
   let program_state = ProgramState::new(flags.clone())?;
 
+  let module_graph = create_module_graph_and_maybe_check(
+    module_specifier.clone(),
+    program_state.clone(),
+    debug,
+  )
+  .await?;
+
   info!(
     "{} {}",
     colors::green("Bundle"),
     module_specifier.to_string()
   );
-
-  let handler = Rc::new(RefCell::new(FetchHandler::new(
-    &program_state,
-    // when bundling, dynamic imports are only access for their type safety,
-    // therefore we will allow the graph to access any module.
-    Permissions::allow_all(),
-  )?));
-  let mut builder = module_graph::GraphBuilder::new(
-    handler,
-    program_state.maybe_import_map.clone(),
-    program_state.lockfile.clone(),
-  );
-  builder.add(&module_specifier, false).await?;
-  let module_graph = builder.get_graph();
-
-  if !flags.no_check {
-    // TODO(@kitsonk) support bundling for workers
-    let lib = if flags.unstable {
-      module_graph::TypeLib::UnstableDenoWindow
-    } else {
-      module_graph::TypeLib::DenoWindow
-    };
-    let result_info =
-      module_graph.clone().check(module_graph::CheckOptions {
-        debug,
-        emit: false,
-        lib,
-        maybe_config_path: flags.config_path.clone(),
-        reload: flags.reload,
-      })?;
-
-    debug!("{}", result_info.stats);
-    if let Some(ignored_options) = result_info.maybe_ignored_options {
-      eprintln!("{}", ignored_options);
-    }
-    if !result_info.diagnostics.is_empty() {
-      return Err(generic_error(result_info.diagnostics.to_string()));
-    }
-  }
-
-  let (bundle_str, stats, maybe_ignored_options) =
-    module_graph.bundle(module_graph::BundleOptions {
-      debug,
-      maybe_config_path: flags.config_path,
-    })?;
-
-  match maybe_ignored_options {
-    Some(ignored_options) if flags.no_check => {
-      eprintln!("{}", ignored_options);
-    }
-    _ => {}
-  }
-  debug!("{}", stats);
+  let bundle_str = bundle_module_graph(module_graph, flags, debug)?;
 
   info!(
     "{} {}",
     colors::green("Compile"),
     module_specifier.to_string()
   );
-  let original_binary_path = std::env::current_exe()?;
-  let mut original_bin = tokio::fs::read(original_binary_path).await?;
+  create_standalone_binary(bundle_str.as_bytes().to_vec(), out_file).await?;
 
-  let mut bundle = bundle_str.as_bytes().to_vec();
-
-  let mut magic_trailer = b"D3N0".to_vec();
-  magic_trailer.write_all(&original_bin.len().to_be_bytes())?;
-
-  let mut final_bin =
-    Vec::with_capacity(original_bin.len() + bundle.len() + 12);
-  final_bin.append(&mut original_bin);
-  final_bin.append(&mut bundle);
-  final_bin.append(&mut magic_trailer);
-
-  let out_file = if cfg!(windows) && !out_file.ends_with(".exe") {
-    format!("{}.exe", out_file)
-  } else {
-    out_file
-  };
-  tokio::fs::write(&out_file, final_bin).await?;
-  #[cfg(unix)]
-  {
-    use std::os::unix::fs::PermissionsExt;
-    let perms = std::fs::Permissions::from_mode(0o777);
-    tokio::fs::set_permissions(out_file, perms).await?;
-  }
   Ok(())
 }
 
@@ -407,6 +339,73 @@ async fn eval_command(
   Ok(())
 }
 
+async fn create_module_graph_and_maybe_check(
+  module_specifier: ModuleSpecifier,
+  program_state: Arc<ProgramState>,
+  debug: bool,
+) -> Result<module_graph::Graph, AnyError> {
+  let handler = Rc::new(RefCell::new(FetchHandler::new(
+    &program_state,
+    // when bundling, dynamic imports are only access for their type safety,
+    // therefore we will allow the graph to access any module.
+    Permissions::allow_all(),
+  )?));
+  let mut builder = module_graph::GraphBuilder::new(
+    handler,
+    program_state.maybe_import_map.clone(),
+    program_state.lockfile.clone(),
+  );
+  builder.add(&module_specifier, false).await?;
+  let module_graph = builder.get_graph();
+
+  if !program_state.flags.no_check {
+    // TODO(@kitsonk) support bundling for workers
+    let lib = if program_state.flags.unstable {
+      module_graph::TypeLib::UnstableDenoWindow
+    } else {
+      module_graph::TypeLib::DenoWindow
+    };
+    let result_info =
+      module_graph.clone().check(module_graph::CheckOptions {
+        debug,
+        emit: false,
+        lib,
+        maybe_config_path: program_state.flags.config_path.clone(),
+        reload: program_state.flags.reload,
+      })?;
+
+    debug!("{}", result_info.stats);
+    if let Some(ignored_options) = result_info.maybe_ignored_options {
+      eprintln!("{}", ignored_options);
+    }
+    if !result_info.diagnostics.is_empty() {
+      return Err(generic_error(result_info.diagnostics.to_string()));
+    }
+  }
+
+  Ok(module_graph)
+}
+
+fn bundle_module_graph(
+  module_graph: module_graph::Graph,
+  flags: Flags,
+  debug: bool,
+) -> Result<String, AnyError> {
+  let (bundle, stats, maybe_ignored_options) =
+    module_graph.bundle(module_graph::BundleOptions {
+      debug,
+      maybe_config_path: flags.config_path,
+    })?;
+  match maybe_ignored_options {
+    Some(ignored_options) if flags.no_check => {
+      eprintln!("{}", ignored_options);
+    }
+    _ => {}
+  }
+  debug!("{}", stats);
+  Ok(bundle)
+}
+
 async fn bundle_command(
   flags: Flags,
   source_file: String,
@@ -431,44 +430,12 @@ async fn bundle_command(
         module_specifier.to_string()
       );
 
-      let handler = Rc::new(RefCell::new(FetchHandler::new(
-        &program_state,
-        // when bundling, dynamic imports are only access for their type safety,
-        // therefore we will allow the graph to access any module.
-        Permissions::allow_all(),
-      )?));
-      let mut builder = module_graph::GraphBuilder::new(
-        handler,
-        program_state.maybe_import_map.clone(),
-        program_state.lockfile.clone(),
-      );
-      builder.add(&module_specifier, false).await?;
-      let module_graph = builder.get_graph();
-
-      if !flags.no_check {
-        // TODO(@kitsonk) support bundling for workers
-        let lib = if flags.unstable {
-          module_graph::TypeLib::UnstableDenoWindow
-        } else {
-          module_graph::TypeLib::DenoWindow
-        };
-        let result_info =
-          module_graph.clone().check(module_graph::CheckOptions {
-            debug,
-            emit: false,
-            lib,
-            maybe_config_path: flags.config_path.clone(),
-            reload: flags.reload,
-          })?;
-
-        debug!("{}", result_info.stats);
-        if let Some(ignored_options) = result_info.maybe_ignored_options {
-          eprintln!("{}", ignored_options);
-        }
-        if !result_info.diagnostics.is_empty() {
-          return Err(generic_error(result_info.diagnostics.to_string()));
-        }
-      }
+      let module_graph = create_module_graph_and_maybe_check(
+        module_specifier,
+        program_state.clone(),
+        debug,
+      )
+      .await?;
 
       let mut paths_to_watch: Vec<PathBuf> = module_graph
         .get_modules()
@@ -500,19 +467,7 @@ async fn bundle_command(
     let flags = flags.clone();
     let out_file = out_file.clone();
     async move {
-      let (output, stats, maybe_ignored_options) =
-        module_graph.bundle(module_graph::BundleOptions {
-          debug,
-          maybe_config_path: flags.config_path,
-        })?;
-
-      match maybe_ignored_options {
-        Some(ignored_options) if flags.no_check => {
-          eprintln!("{}", ignored_options);
-        }
-        _ => {}
-      }
-      debug!("{}", stats);
+      let output = bundle_module_graph(module_graph, flags, debug)?;
 
       debug!(">>>>> bundle END");
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -233,7 +233,7 @@ async fn compile_command(
 
   let mut bundle = bundle_str.as_bytes().to_vec();
 
-  let mut magic_trailer = b"DENO".to_vec();
+  let mut magic_trailer = b"D3N0".to_vec();
   magic_trailer.write_all(&original_bin.len().to_be_bytes())?;
 
   let mut final_bin =
@@ -1079,7 +1079,10 @@ pub fn main() {
   colors::enable_ansi(); // For Windows 10
 
   let args: Vec<String> = env::args().collect();
-  standalone::standalone();
+  if let Err(err) = standalone::try_run_standalone_binary() {
+    eprintln!("{}: {}", colors::red_bold("error"), err.to_string());
+    std::process::exit(1);
+  }
 
   let flags = flags::flags_from_vec(args);
   if let Some(ref v8_flags) = flags.v8_flags {

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -21,7 +21,7 @@ use std::io::Write;
 use std::pin::Pin;
 use std::rc::Rc;
 
-const MAGIC_TRAILER: &'static [u8; 4] = b"D3N0";
+const MAGIC_TRAILER: &[u8; 4] = b"D3N0";
 
 /// This function will try to run this binary as a standalone binary
 /// produced by `deno compile`. It determines if this is a stanalone
@@ -133,7 +133,7 @@ pub async fn create_standalone_binary(
   let original_binary_path = std::env::current_exe()?;
   let mut original_bin = tokio::fs::read(original_binary_path).await?;
 
-  let mut magic_trailer = b"D3N0".to_vec();
+  let mut magic_trailer = MAGIC_TRAILER.to_vec();
   magic_trailer.write_all(&original_bin.len().to_be_bytes())?;
 
   let mut final_bin =

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -1,0 +1,114 @@
+use crate::colors;
+use crate::flags::Flags;
+use crate::permissions::Permissions;
+use crate::program_state::ProgramState;
+use crate::tokio_util;
+use crate::worker::MainWorker;
+use deno_core::error::AnyError;
+use deno_core::futures::FutureExt;
+use deno_core::ModuleLoader;
+use deno_core::ModuleSpecifier;
+use deno_core::OpState;
+use std::cell::RefCell;
+use std::convert::TryInto;
+use std::env::current_exe;
+use std::fs::File;
+use std::io::Read;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::pin::Pin;
+use std::rc::Rc;
+
+pub fn standalone() {
+  let current_exe_path =
+    current_exe().expect("expect current exe path to be known");
+
+  let mut current_exe = File::open(current_exe_path)
+    .expect("expected to be able to open current exe");
+  let magic_trailer_pos = current_exe
+    .seek(SeekFrom::End(-12))
+    .expect("expected to be able to seek to magic trailer in current exe");
+  let mut magic_trailer = [0; 12];
+  current_exe
+    .read_exact(&mut magic_trailer)
+    .expect("expected to be able to read magic trailer from current exe");
+  let (magic_trailer, bundle_pos) = magic_trailer.split_at(4);
+  if magic_trailer == b"DENO" {
+    let bundle_pos_arr: &[u8; 8] =
+      bundle_pos.try_into().expect("slice with incorrect length");
+    let bundle_pos = u64::from_be_bytes(*bundle_pos_arr);
+    current_exe
+      .seek(SeekFrom::Start(bundle_pos))
+      .expect("expected to be able to seek to bundle pos in current exe");
+
+    let bundle_len = magic_trailer_pos - bundle_pos;
+    let mut bundle = String::new();
+    current_exe
+      .take(bundle_len)
+      .read_to_string(&mut bundle)
+      .expect("expected to be able to read bundle from current exe");
+    // TODO: check amount of bytes read
+
+    let result = tokio_util::run_basic(run(bundle));
+    if let Err(err) = result {
+      eprintln!("{}: {}", colors::red_bold("error"), err.to_string());
+      std::process::exit(1);
+    }
+    std::process::exit(0);
+  }
+}
+
+const SPECIFIER: &str = "file://$deno$/bundle.js";
+
+struct EmbeddedModuleLoader(String);
+
+impl ModuleLoader for EmbeddedModuleLoader {
+  fn resolve(
+    &self,
+    _op_state: Rc<RefCell<OpState>>,
+    specifier: &str,
+    _referrer: &str,
+    _is_main: bool,
+  ) -> Result<ModuleSpecifier, AnyError> {
+    assert_eq!(specifier, SPECIFIER);
+    Ok(ModuleSpecifier::resolve_url(specifier)?)
+  }
+
+  fn load(
+    &self,
+    _op_state: Rc<RefCell<OpState>>,
+    module_specifier: &ModuleSpecifier,
+    _maybe_referrer: Option<ModuleSpecifier>,
+    _is_dynamic: bool,
+  ) -> Pin<Box<deno_core::ModuleSourceFuture>> {
+    let module_specifier = module_specifier.clone();
+    let code = self.0.to_string();
+    async move {
+      Ok(deno_core::ModuleSource {
+        code,
+        module_url_specified: module_specifier.to_string(),
+        module_url_found: module_specifier.to_string(),
+      })
+    }
+    .boxed_local()
+  }
+}
+
+async fn run(source_code: String) -> Result<(), AnyError> {
+  let flags = Flags::default();
+  let main_module = ModuleSpecifier::resolve_url(SPECIFIER)?;
+  let program_state = ProgramState::new(flags.clone())?;
+  let permissions = Permissions::allow_all();
+  let module_loader = Rc::new(EmbeddedModuleLoader(source_code));
+  let mut worker = MainWorker::from_options(
+    &program_state,
+    main_module.clone(),
+    permissions,
+    module_loader,
+  );
+  worker.execute_module(&main_module).await?;
+  worker.execute("window.dispatchEvent(new Event('load'))")?;
+  worker.run_event_loop().await?;
+  worker.execute("window.dispatchEvent(new Event('unload'))")?;
+  Ok(())
+}

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -4509,7 +4509,6 @@ fn compile() {
     .arg("compile")
     .arg("--unstable")
     .arg("./std/examples/welcome.ts")
-    .arg(&exe)
     .stdout(std::process::Stdio::piped())
     .spawn()
     .unwrap()

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -4509,6 +4509,7 @@ fn compile() {
     .arg("compile")
     .arg("--unstable")
     .arg("./std/examples/welcome.ts")
+    .arg(&exe)
     .stdout(std::process::Stdio::piped())
     .spawn()
     .unwrap()

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -4471,13 +4471,14 @@ fn fmt_ignore_unexplicit_files() {
 fn compile() {
   let dir = TempDir::new().expect("tempdir fail");
   let exe = if cfg!(windows) {
-    dir.path().join("./welcome.exe")
+    dir.path().join("welcome.exe")
   } else {
-    dir.path().join("./welcome")
+    dir.path().join("welcome")
   };
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("compile")
+    .arg("--unstable")
     .arg("./std/examples/welcome.ts")
     .arg(&exe)
     .stdout(std::process::Stdio::piped())
@@ -4500,13 +4501,14 @@ fn compile() {
 fn compile_args() {
   let dir = TempDir::new().expect("tempdir fail");
   let exe = if cfg!(windows) {
-    dir.path().join("./args.exe")
+    dir.path().join("args.exe")
   } else {
-    dir.path().join("./args")
+    dir.path().join("args")
   };
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("compile")
+    .arg("--unstable")
     .arg("./cli/tests/028_args.ts")
     .arg(&exe)
     .stdout(std::process::Stdio::piped())

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -4468,7 +4468,7 @@ fn fmt_ignore_unexplicit_files() {
 }
 
 #[test]
-fn deno_compile_test() {
+fn compile() {
   let dir = TempDir::new().expect("tempdir fail");
   let exe = if cfg!(windows) {
     dir.path().join("./welcome.exe")
@@ -4494,4 +4494,36 @@ fn deno_compile_test() {
     .unwrap();
   assert!(output.status.success());
   assert_eq!(output.stdout, "Welcome to Deno 🦕\n".as_bytes());
+}
+
+#[test]
+fn compile_args() {
+  let dir = TempDir::new().expect("tempdir fail");
+  let exe = if cfg!(windows) {
+    dir.path().join("./args.exe")
+  } else {
+    dir.path().join("./args")
+  };
+  let output = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("compile")
+    .arg("./cli/tests/028_args.ts")
+    .arg(&exe)
+    .stdout(std::process::Stdio::piped())
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+  assert!(output.status.success());
+  let output = Command::new(exe)
+    .arg("foo")
+    .arg("--bar")
+    .arg("--unstable")
+    .stdout(std::process::Stdio::piped())
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+  assert!(output.status.success());
+  assert_eq!(output.stdout, "foo\n--bar\n--unstable\n".as_bytes());
 }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -4527,5 +4527,5 @@ fn compile_args() {
     .wait_with_output()
     .unwrap();
   assert!(output.status.success());
-  assert_eq!(output.stdout, "foo\n--bar\n--unstable\n".as_bytes());
+  assert_eq!(output.stdout, b"foo\n--bar\n--unstable\n");
 }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -98,7 +98,6 @@ fn eval_p() {
 }
 
 #[test]
-
 fn run_from_stdin() {
   let mut deno = util::deno_cmd()
     .current_dir(util::root_path())
@@ -4466,4 +4465,33 @@ fn fmt_ignore_unexplicit_files() {
     .unwrap();
   assert!(output.status.success());
   assert_eq!(output.stderr, b"Checked 0 file\n");
+}
+
+#[test]
+fn deno_compile_test() {
+  let dir = TempDir::new().expect("tempdir fail");
+  let exe = if cfg!(windows) {
+    dir.path().join("./welcome.exe")
+  } else {
+    dir.path().join("./welcome")
+  };
+  let output = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("compile")
+    .arg("./std/examples/welcome.ts")
+    .arg(&exe)
+    .stdout(std::process::Stdio::piped())
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+  assert!(output.status.success());
+  let output = Command::new(exe)
+    .stdout(std::process::Stdio::piped())
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+  assert!(output.status.success());
+  assert_eq!(output.stdout, "Welcome to Deno 🦕\n".as_bytes());
 }

--- a/cli/tests/standalone_import.ts
+++ b/cli/tests/standalone_import.ts
@@ -1,0 +1,2 @@
+console.log("start");
+await import("./001_hello.js");

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -108,7 +108,7 @@ fn get_installer_root() -> Result<PathBuf, io::Error> {
   Ok(home_path)
 }
 
-fn infer_name_from_url(url: &Url) -> Option<String> {
+pub fn infer_name_from_url(url: &Url) -> Option<String> {
   let path = PathBuf::from(url.path());
   let mut stem = match path.file_stem() {
     Some(stem) => stem.to_string_lossy().to_string(),

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -17,9 +17,11 @@ use deno_core::futures::future::FutureExt;
 use deno_core::url::Url;
 use deno_core::JsRuntime;
 use deno_core::ModuleId;
+use deno_core::ModuleLoader;
 use deno_core::ModuleSpecifier;
 use deno_core::RuntimeOptions;
 use std::env;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
@@ -45,6 +47,16 @@ impl MainWorker {
   ) -> Self {
     let module_loader =
       CliModuleLoader::new(program_state.maybe_import_map.clone());
+
+    Self::from_options(program_state, main_module, permissions, module_loader)
+  }
+
+  pub fn from_options(
+    program_state: &Arc<ProgramState>,
+    main_module: ModuleSpecifier,
+    permissions: Permissions,
+    module_loader: Rc<dyn ModuleLoader>,
+  ) -> Self {
     let global_state_ = program_state.clone();
 
     let js_error_create_fn = Box::new(move |core_js_error| {


### PR DESCRIPTION
Closes #986 

This implements the `deno compile` subcommand. It works be generating a new standalone binary, by appending a bundle of the source file and magic trailer from the current binary. If we find a magic trailer at the end of the the binary, we try to load the bundle that is embedded in the binary, and run it.

```
~/p/g/d/deno ❯❯❯ ./target/debug/deno compile https://deno.land/std/http/file_server.ts file_server
Bundle https://deno.land/std/http/file_server.ts
Check https://deno.land/std/http/file_server.ts
Compile https://deno.land/std/http/file_server.ts
~/p/g/d/deno ❯❯❯ ./file_server 
HTTP server listening on http://0.0.0.0:4507/
```