### PR TITLE
feat(doc): Added uptime function for Deno

### DIFF
--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -81,6 +81,7 @@ const UNSTABLE_DENO_PROPS: &[&str] = &[
   "umask",
   "utime",
   "utimeSync",
+  "uptime",
 ];
 
 lazy_static! {

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -115,6 +115,8 @@ declare namespace Deno {
    */
   export function loadavg(): number[];
 
+  export function uptime(): { uptime: number };
+
   /** **Unstable** new API. yet to be vetted. Under consideration to possibly move to
    * Deno.build or Deno.versions and if it should depend sys-info, which may not
    * be desireable.

--- a/cli/ops/os.rs
+++ b/cli/ops/os.rs
@@ -14,6 +14,7 @@ use std::env;
 
 pub fn init(rt: &mut deno_core::JsRuntime) {
   super::reg_json_sync(rt, "op_exit", op_exit);
+  super::reg_json_sync(rt, "op_uptime", op_uptime);
   super::reg_json_sync(rt, "op_env", op_env);
   super::reg_json_sync(rt, "op_exec_path", op_exec_path);
   super::reg_json_sync(rt, "op_set_env", op_set_env);
@@ -128,6 +129,22 @@ fn op_loadavg(
   match sys_info::loadavg() {
     Ok(loadavg) => Ok(json!([loadavg.one, loadavg.five, loadavg.fifteen])),
     Err(_) => Ok(json!([0f64, 0f64, 0f64])),
+  }
+}
+
+fn op_uptime(
+  state: &mut OpState,
+  _args: Value,
+  _zero_copy: &mut [ZeroCopyBuf],
+) -> Result<Value, AnyError> {
+  super::check_unstable(state, "Deno.uptime");
+  state.borrow::<Permissions>().check_env()?;
+
+  match sys_info::boottime() {
+    Ok(uptime) => Ok(json!({
+      "uptime": uptime.tv_sec
+    })),
+    Err(_) => Ok(json!({})),
   }
 }
 

--- a/cli/rt/30_os.js
+++ b/cli/rt/30_os.js
@@ -7,6 +7,10 @@
     return core.jsonOpSync("op_loadavg");
   }
 
+  function uptime() {
+    return core.jsonOpSync("op_uptime");
+  }
+
   function hostname() {
     return core.jsonOpSync("op_hostname");
   }
@@ -62,5 +66,6 @@
     systemCpuInfo,
     hostname,
     loadavg,
+    uptime,
   };
 })(this);

--- a/cli/rt/90_deno_ns.js
+++ b/cli/rt/90_deno_ns.js
@@ -127,6 +127,7 @@
     linkSync: __bootstrap.fs.linkSync,
     futime: __bootstrap.fs.futime,
     futimeSync: __bootstrap.fs.futimeSync,
+    uptime: __bootstrap.os.uptime,
     utime: __bootstrap.fs.utime,
     utimeSync: __bootstrap.fs.utimeSync,
     symlink: __bootstrap.fs.symlink,


### PR DESCRIPTION
Provides uptime function for issue #3802 . I haven't added tests yet, because I'm not sure how to test uptime. For example, the test loadavgSuccess merely checks whether an array of 3 is given by Deno.loadavg; it doesn't actually check the loadtimes. 

As it turns out in issue #8357 , heim is NOT needed to implement uptime. sysinfo already provides a function that can give the uptime called boottime, as I found in this [issue](https://github.com/FillZpp/sys-info-rs/issues/8#issue-199626066). 

Note: this is still a WIP, even though it should hopefully be mostly done.