### PR TITLE
docs(std): add some missing JSDoc testing/asserts.ts

### DIFF
--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -66,6 +66,7 @@ function createSign(diffType: DiffType): string {
   }
 }
 
+/** Build assertions into pretty form. */
 function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   const messages: string[] = [];
   messages.push("");
@@ -86,6 +87,7 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   return messages;
 }
 
+/** Returns true if the collection is Keyed, otherwise false. */
 function isKeyedCollection(x: unknown): x is Set<unknown> {
   return [Symbol.iterator, "size"].every((k) => k in (x as Set<unknown>));
 }


### PR DESCRIPTION
Add missing JSDoc for `testing/asserts.ts`

Related to #7487

- [x] deno run -A std/testing/asserts.ts