### PR TITLE
feat(std/http): Add HTTP server error event

### DIFF
--- a/std/http/file_server.ts
+++ b/std/http/file_server.ts
@@ -471,7 +471,7 @@ function main(): void {
         evt.error,
       );
     } else {
-    console.error(evt.error);
+      console.error(evt.error);
     }
   });
   serveRequests();


### PR DESCRIPTION
This PR allows the user to handle/log the error from the listener and the request reader.

Before:
The HTTP server rethrows the error from the listener if the error type is unknown, and causes an uncaught error. Also, it ignores all errors while reading requests.

After:
The `Server` class is now inherited from `EventTarget`. It will pass the error to the `error` event. The user can handle it after adding an event listener to the server.

Related issue: #8499 (not closing it because I don't know where did the ENOTCONN come from)

Usage:
```ts
const server = serve({ port: 8000 });
server.addEventListener('error', (evt) => {
  if (evt.origin == "request") {
    console.warn("Error reading request", evt.connection, evt.error);
    // The server will send "400 Bad Request" and close the connection
    // unless `evt.preventDefault()` is called.
  } else if (evt.origin == "listener") {
    console.warn("Error accepting connection", evt.error);
    // The server will continue to accept connections
    // unless `evt.preventDefault()` is called.
  }
})
for await (const req of server) {
  req.respond({ body: "Hello World\n" });
}
```

This PR also changes `file_server` to add event listener to print errors.