### PR TITLE
fix(repl): higlight `async` and `of` in REPL

### DIFF
--- a/cli/tools/repl.rs
+++ b/cli/tools/repl.rs
@@ -238,6 +238,8 @@ impl Highlighter for LineHighlighter {
                   colors::gray(&line[span]).to_string()
                 } else if ident == *"Infinity" || ident == *"NaN" {
                   colors::yellow(&line[span]).to_string()
+                } else if ident == *"async" || ident == *"of" {
+                  colors::cyan(&line[span]).to_string()
                 } else {
                   line[span].to_string()
                 }


### PR DESCRIPTION
Resolves #8568.

This just highlights them unconditionally; since they can technically be used as identifiers, the 'correct' way would check for that, but that would pretty much require a full parser.