### PR TITLE
fix(op_crates/fetch): type check Request init

### DIFF
--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -1217,7 +1217,7 @@
         headers,
         body
       }) = new Request(input, init);
-    } catch(e) {
+    } catch {
       // prefer WorkerGlobalScope over more specific scope, such as DedicatedWorkerGlobalScope, which is what the [Symbol.toStringTag] may yield
       // may need refinement
       const scope = self[Symbol.toStringTag] === "Window" ? "Window" : "WorkerGlobalScope";

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -933,6 +933,7 @@
           throw new TypeError("Failed to construct 'Request': cannot convert to dictionary.");
         }
         case "undefined":
+          /* falls through */
         case "object": {
           // may be null
           init ??= {};

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -1,27 +1,38 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+// @ts-check
+/// <reference path="../../core/lib.deno_core.d.ts" />
+/// <reference path="../web/internal.d.ts" />
+/// <reference path="../web/lib.deno_web.d.ts" />
+/// <reference path="./11_streams_types.d.ts" />
+/// <reference path="./internal.d.ts" />
+/// <reference path="./lib.deno_fetch.d.ts" />
+/// <reference lib="esnext" />
+"use strict";
 
 ((window) => {
   const core = window.Deno.core;
 
   // provided by "deno_web"
   const { URLSearchParams } = window.__bootstrap.url;
+  const { getLocationHref } = window.__bootstrap.location;
 
   const { requiredArguments } = window.__bootstrap.fetchUtil;
   const { ReadableStream, isReadableStreamDisturbed } =
     window.__bootstrap.streams;
   const { DomIterableMixin } = window.__bootstrap.domIterable;
   const { Headers } = window.__bootstrap.headers;
-
-  // FIXME(bartlomieju): stubbed out, needed in blob
-  const build = {
-    os: "",
-  };
+  const { Blob, _byteSequence, File } = window.__bootstrap.file;
 
   const MAX_SIZE = 2 ** 32 - 2;
 
-  // `off` is the offset into `dst` where it will at which to begin writing values
-  // from `src`.
-  // Returns the number of bytes copied.
+  /**
+   * @param {Uint8Array} src 
+   * @param {Uint8Array} dst 
+   * @param {number} off the offset into `dst` where it will at which to begin writing values from `src`
+   * 
+   * @returns {number} number of bytes copied
+   */
   function copyBytes(src, dst, off = 0) {
     const r = dst.byteLength - off;
     if (src.byteLength > r) {
@@ -32,9 +43,11 @@
   }
 
   class Buffer {
-    #buf = null; // contents are the bytes buf[off : len(buf)]
+    /** @type {Uint8Array} */
+    #buf; // contents are the bytes buf[off : len(buf)]
     #off = 0; // read at buf[off], write at buf[buf.byteLength]
 
+    /** @param {ArrayBuffer} [ab] */
     constructor(ab) {
       if (ab == null) {
         this.#buf = new Uint8Array(0);
@@ -44,28 +57,47 @@
       this.#buf = new Uint8Array(ab);
     }
 
+    /**
+     * @returns {Uint8Array}
+     */
     bytes(options = { copy: true }) {
       if (options.copy === false) return this.#buf.subarray(this.#off);
       return this.#buf.slice(this.#off);
     }
 
+    /**
+     * @returns {boolean}
+     */
     empty() {
       return this.#buf.byteLength <= this.#off;
     }
 
+    /**
+     * @returns {number}
+     */
     get length() {
       return this.#buf.byteLength - this.#off;
     }
 
+    /**
+     * @returns {number}
+     */
     get capacity() {
       return this.#buf.buffer.byteLength;
     }
 
+    /**
+     * @returns {void}
+     */
     reset() {
       this.#reslice(0);
       this.#off = 0;
     }
 
+    /**
+     * @param {number} n
+     * @returns {number}
+     */
     #tryGrowByReslice = (n) => {
       const l = this.#buf.byteLength;
       if (n <= this.capacity - l) {
@@ -75,6 +107,10 @@
       return -1;
     };
 
+    /**
+     * @param {number} len
+     * @returns {void}
+     */
     #reslice = (len) => {
       if (!(len <= this.#buf.buffer.byteLength)) {
         throw new Error("assert");
@@ -82,16 +118,28 @@
       this.#buf = new Uint8Array(this.#buf.buffer, 0, len);
     };
 
+    /**
+     * @param {Uint8Array} p
+     * @returns {number}
+     */
     writeSync(p) {
       const m = this.#grow(p.byteLength);
       return copyBytes(p, this.#buf, m);
     }
 
+    /**
+     * @param {Uint8Array} p
+     * @returns {Promise<number>}
+     */
     write(p) {
       const n = this.writeSync(p);
       return Promise.resolve(n);
     }
 
+    /** 
+     * @param {number} n
+     * @returns {number}
+     */
     #grow = (n) => {
       const m = this.length;
       // If buffer is empty, reset to recover space.
@@ -124,6 +172,10 @@
       return m;
     };
 
+    /** 
+     * @param {number} n
+     * @returns {void}
+     */
     grow(n) {
       if (n < 0) {
         throw Error("Buffer.grow: negative count");
@@ -133,15 +185,29 @@
     }
   }
 
+  /** 
+   * @param {unknown} x
+   * @returns {x is ArrayBufferView}
+   */
   function isTypedArray(x) {
     return ArrayBuffer.isView(x) && !(x instanceof DataView);
   }
 
+  /** 
+   * @param {string} s
+   * @param {string} value
+   * @returns {boolean}
+   */
   function hasHeaderValueOf(s, value) {
-    return new RegExp(`^${value}[\t\s]*;?`).test(s);
+    return new RegExp(`^${value}(?:[\\s;]|$)`).test(s);
   }
 
+  /**
+   * @param {string} value
+   * @returns {Map<string, string>}
+   */
   function getHeaderValueParams(value) {
+    /** @type {Map<string, string>} */
     const params = new Map();
     // Forced to do so for some Map constructor param mismatch
     value
@@ -160,243 +226,20 @@
   const LF = "\n".charCodeAt(0);
 
   const dataSymbol = Symbol("data");
-  const bytesSymbol = Symbol("bytes");
 
-  function containsOnlyASCII(str) {
-    if (typeof str !== "string") {
-      return false;
-    }
-    // deno-lint-ignore no-control-regex
-    return /^[\x00-\x7F]*$/.test(str);
-  }
-
-  function convertLineEndingsToNative(s) {
-    const nativeLineEnd = build.os == "windows" ? "\r\n" : "\n";
-
-    let position = 0;
-
-    let collectionResult = collectSequenceNotCRLF(s, position);
-
-    let token = collectionResult.collected;
-    position = collectionResult.newPosition;
-
-    let result = token;
-
-    while (position < s.length) {
-      const c = s.charAt(position);
-      if (c == "\r") {
-        result += nativeLineEnd;
-        position++;
-        if (position < s.length && s.charAt(position) == "\n") {
-          position++;
-        }
-      } else if (c == "\n") {
-        position++;
-        result += nativeLineEnd;
-      }
-
-      collectionResult = collectSequenceNotCRLF(s, position);
-
-      token = collectionResult.collected;
-      position = collectionResult.newPosition;
-
-      result += token;
-    }
-
-    return result;
-  }
-
-  function collectSequenceNotCRLF(
-    s,
-    position,
-  ) {
-    const start = position;
-    for (
-      let c = s.charAt(position);
-      position < s.length && !(c == "\r" || c == "\n");
-      c = s.charAt(++position)
-    );
-    return { collected: s.slice(start, position), newPosition: position };
-  }
-
-  function toUint8Arrays(
-    blobParts,
-    doNormalizeLineEndingsToNative,
-  ) {
-    const ret = [];
-    const enc = new TextEncoder();
-    for (const element of blobParts) {
-      if (typeof element === "string") {
-        let str = element;
-        if (doNormalizeLineEndingsToNative) {
-          str = convertLineEndingsToNative(element);
-        }
-        ret.push(enc.encode(str));
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      } else if (element instanceof Blob) {
-        ret.push(element[bytesSymbol]);
-      } else if (element instanceof Uint8Array) {
-        ret.push(element);
-      } else if (element instanceof Uint16Array) {
-        const uint8 = new Uint8Array(element.buffer);
-        ret.push(uint8);
-      } else if (element instanceof Uint32Array) {
-        const uint8 = new Uint8Array(element.buffer);
-        ret.push(uint8);
-      } else if (ArrayBuffer.isView(element)) {
-        // Convert view to Uint8Array.
-        const uint8 = new Uint8Array(element.buffer);
-        ret.push(uint8);
-      } else if (element instanceof ArrayBuffer) {
-        // Create a new Uint8Array view for the given ArrayBuffer.
-        const uint8 = new Uint8Array(element);
-        ret.push(uint8);
-      } else {
-        ret.push(enc.encode(String(element)));
-      }
-    }
-    return ret;
-  }
-
-  function processBlobParts(
-    blobParts,
-    options,
-  ) {
-    const normalizeLineEndingsToNative = options.ending === "native";
-    // ArrayBuffer.transfer is not yet implemented in V8, so we just have to
-    // pre compute size of the array buffer and do some sort of static allocation
-    // instead of dynamic allocation.
-    const uint8Arrays = toUint8Arrays(blobParts, normalizeLineEndingsToNative);
-    const byteLength = uint8Arrays
-      .map((u8) => u8.byteLength)
-      .reduce((a, b) => a + b, 0);
-    const ab = new ArrayBuffer(byteLength);
-    const bytes = new Uint8Array(ab);
-    let courser = 0;
-    for (const u8 of uint8Arrays) {
-      bytes.set(u8, courser);
-      courser += u8.byteLength;
-    }
-
-    return bytes;
-  }
-
-  function getStream(blobBytes) {
-    // TODO: Align to spec https://fetch.spec.whatwg.org/#concept-construct-readablestream
-    return new ReadableStream({
-      type: "bytes",
-      start: (controller) => {
-        controller.enqueue(blobBytes);
-        controller.close();
-      },
-    });
-  }
-
-  async function readBytes(
-    reader,
-  ) {
-    const chunks = [];
-    while (true) {
-      const { done, value } = await reader.read();
-      if (!done && value instanceof Uint8Array) {
-        chunks.push(value);
-      } else if (done) {
-        const size = chunks.reduce((p, i) => p + i.byteLength, 0);
-        const bytes = new Uint8Array(size);
-        let offs = 0;
-        for (const chunk of chunks) {
-          bytes.set(chunk, offs);
-          offs += chunk.byteLength;
-        }
-        return bytes.buffer;
-      } else {
-        throw new TypeError("Invalid reader result.");
-      }
-    }
-  }
-
-  // A WeakMap holding blob to byte array mapping.
-  // Ensures it does not impact garbage collection.
-  // const blobBytesWeakMap = new WeakMap();
-
-  class Blob {
-    constructor(blobParts, options) {
-      if (arguments.length === 0) {
-        this[bytesSymbol] = new Uint8Array();
-        return;
-      }
-
-      const { ending = "transparent", type = "" } = options ?? {};
-      // Normalize options.type.
-      let normalizedType = type;
-      if (!containsOnlyASCII(type)) {
-        normalizedType = "";
-      } else {
-        if (type.length) {
-          for (let i = 0; i < type.length; ++i) {
-            const char = type[i];
-            if (char < "\u0020" || char > "\u007E") {
-              normalizedType = "";
-              break;
-            }
-          }
-          normalizedType = type.toLowerCase();
-        }
-      }
-      const bytes = processBlobParts(blobParts, { ending, type });
-      // Set Blob object's properties.
-      this[bytesSymbol] = bytes;
-      this.size = bytes.byteLength;
-      this.type = normalizedType;
-    }
-
-    slice(start, end, contentType) {
-      return new Blob([this[bytesSymbol].slice(start, end)], {
-        type: contentType || this.type,
-      });
-    }
-
-    stream() {
-      return getStream(this[bytesSymbol]);
-    }
-
-    async text() {
-      const reader = getStream(this[bytesSymbol]).getReader();
-      const decoder = new TextDecoder();
-      return decoder.decode(await readBytes(reader));
-    }
-
-    arrayBuffer() {
-      return readBytes(getStream(this[bytesSymbol]).getReader());
-    }
-  }
-
-  class DomFile extends Blob {
-    constructor(
-      fileBits,
-      fileName,
-      options,
-    ) {
-      const { lastModified = Date.now(), ...blobPropertyBag } = options ?? {};
-      super(fileBits, blobPropertyBag);
-
-      // 4.1.2.1 Replace any "/" character (U+002F SOLIDUS)
-      // with a ":" (U + 003A COLON)
-      this.name = String(fileName).replace(/\u002F/g, "\u003A");
-      // 4.1.3.3 If lastModified is not provided, set lastModified to the current
-      // date and time represented in number of milliseconds since the Unix Epoch.
-      this.lastModified = lastModified;
-    }
-  }
-
+  /**
+   * @param {Blob | string} value 
+   * @param {string | undefined} filename
+   * @returns {FormDataEntryValue}
+   */
   function parseFormDataValue(value, filename) {
-    if (value instanceof DomFile) {
-      return new DomFile([value], filename || value.name, {
+    if (value instanceof File) {
+      return new File([value], filename || value.name, {
         type: value.type,
         lastModified: value.lastModified,
       });
     } else if (value instanceof Blob) {
-      return new DomFile([value], filename || "blob", {
+      return new File([value], filename || "blob", {
         type: value.type,
       });
     } else {
@@ -405,14 +248,25 @@
   }
 
   class FormDataBase {
+    /** @type {[name: string, entry: FormDataEntryValue][]} */
     [dataSymbol] = [];
 
+    /**
+     * @param {string} name 
+     * @param {string | Blob} value 
+     * @param {string} [filename] 
+     * @returns {void}
+     */
     append(name, value, filename) {
       requiredArguments("FormData.append", arguments.length, 2);
       name = String(name);
       this[dataSymbol].push([name, parseFormDataValue(value, filename)]);
     }
 
+    /**
+     * @param {string} name 
+     * @returns {void}
+     */
     delete(name) {
       requiredArguments("FormData.delete", arguments.length, 1);
       name = String(name);
@@ -426,6 +280,10 @@
       }
     }
 
+    /**
+     * @param {string} name 
+     * @returns {FormDataEntryValue[]}
+     */
     getAll(name) {
       requiredArguments("FormData.getAll", arguments.length, 1);
       name = String(name);
@@ -439,6 +297,10 @@
       return values;
     }
 
+    /**
+     * @param {string} name 
+     * @returns {FormDataEntryValue | null}
+     */
     get(name) {
       requiredArguments("FormData.get", arguments.length, 1);
       name = String(name);
@@ -451,12 +313,22 @@
       return null;
     }
 
+    /**
+     * @param {string} name 
+     * @returns {boolean}
+     */
     has(name) {
       requiredArguments("FormData.has", arguments.length, 1);
       name = String(name);
       return this[dataSymbol].some((entry) => entry[0] === name);
     }
 
+    /**
+     * @param {string} name 
+     * @param {string | Blob} value 
+     * @param {string} [filename] 
+     * @returns {void}
+     */
     set(name, value, filename) {
       requiredArguments("FormData.set", arguments.length, 2);
       name = String(name);
@@ -492,19 +364,29 @@
   class FormData extends DomIterableMixin(FormDataBase, dataSymbol) {}
 
   class MultipartBuilder {
+    /**
+     * @param {FormData} formData 
+     * @param {string} [boundary] 
+     */
     constructor(formData, boundary) {
       this.formData = formData;
       this.boundary = boundary ?? this.#createBoundary();
       this.writer = new Buffer();
     }
 
+    /** 
+     * @returns {string}
+     */
     getContentType() {
       return `multipart/form-data; boundary=${this.boundary}`;
     }
 
+    /** 
+     * @returns {Uint8Array}
+     */
     getBody() {
       for (const [fieldName, fieldValue] of this.formData.entries()) {
-        if (fieldValue instanceof DomFile) {
+        if (fieldValue instanceof File) {
           this.#writeFile(fieldName, fieldValue);
         } else this.#writeField(fieldName, fieldValue);
       }
@@ -523,6 +405,10 @@
       );
     };
 
+    /** 
+     * @param {[string, string][]} headers
+     * @returns {void}
+     */
     #writeHeaders = (headers) => {
       let buf = this.writer.empty() ? "" : "\r\n";
 
@@ -532,15 +418,21 @@
       }
       buf += `\r\n`;
 
-      // FIXME(Bartlomieju): this should use `writeSync()`
-      this.writer.write(encoder.encode(buf));
+      this.writer.writeSync(encoder.encode(buf));
     };
 
+    /** 
+     * @param {string} field
+     * @param {string} filename
+     * @param {string} [type]
+     * @returns {void}
+     */
     #writeFileHeaders = (
       field,
       filename,
       type,
     ) => {
+      /** @type {[string, string][]} */
       const headers = [
         [
           "Content-Disposition",
@@ -551,23 +443,42 @@
       return this.#writeHeaders(headers);
     };
 
+    /**
+     * @param {string} field
+     * @returns {void}
+     */
     #writeFieldHeaders = (field) => {
+      /** @type {[string, string][]} */
       const headers = [["Content-Disposition", `form-data; name="${field}"`]];
       return this.#writeHeaders(headers);
     };
 
+    /**
+     * @param {string} field
+     * @param {string} value
+     * @returns {void}
+     */
     #writeField = (field, value) => {
       this.#writeFieldHeaders(field);
       this.writer.writeSync(encoder.encode(value));
     };
 
+    /**
+     * @param {string} field
+     * @param {File} value
+     * @returns {void}
+     */
     #writeFile = (field, value) => {
       this.#writeFileHeaders(field, value.name, value.type);
-      this.writer.writeSync(value[bytesSymbol]);
+      this.writer.writeSync(value[_byteSequence]);
     };
   }
 
   class MultipartParser {
+    /**
+     * @param {Uint8Array} body 
+     * @param {string | undefined} boundary 
+     */
     constructor(body, boundary) {
       if (!boundary) {
         throw new TypeError("multipart/form-data must provide a boundary");
@@ -578,6 +489,10 @@
       this.boundaryChars = encoder.encode(this.boundary);
     }
 
+    /**
+     * @param {string} headersText
+     * @returns {{ headers: Headers, disposition: Map<string, string> }}
+     */
     #parseHeaders = (headersText) => {
       const headers = new Headers();
       const rawHeaders = headersText.split("\r\n");
@@ -599,6 +514,9 @@
       };
     };
 
+    /**
+     * @returns {FormData}
+     */
     parse() {
       const formData = new FormData();
       let headerText = "";
@@ -673,7 +591,11 @@
     }
   }
 
-  function validateBodyType(owner, bodySource) {
+  /**
+   * @param {string} name 
+   * @param {BodyInit | null} bodySource 
+   */
+  function validateBodyType(name, bodySource) {
     if (isTypedArray(bodySource)) {
       return true;
     } else if (bodySource instanceof ArrayBuffer) {
@@ -689,11 +611,15 @@
     } else if (!bodySource) {
       return true; // null body is fine
     }
-    throw new Error(
-      `Bad ${owner.constructor.name} body type: ${bodySource.constructor.name}`,
+    throw new TypeError(
+      `Bad ${name} body type: ${bodySource.constructor.name}`,
     );
   }
 
+  /**
+   * @param {ReadableStreamReader<Uint8Array>} stream 
+   * @param {number} [size] 
+   */
   async function bufferFromStream(
     stream,
     size,
@@ -727,6 +653,9 @@
     return buffer.bytes().buffer;
   }
 
+  /**
+   * @param {Exclude<BodyInit, ReadableStream> | null} bodySource 
+   */
   function bodyToArrayBuffer(bodySource) {
     if (isTypedArray(bodySource)) {
       return bodySource.buffer;
@@ -735,10 +664,6 @@
     } else if (typeof bodySource === "string") {
       const enc = new TextEncoder();
       return enc.encode(bodySource).buffer;
-    } else if (bodySource instanceof ReadableStream) {
-      throw new Error(
-        `Can't convert stream to ArrayBuffer (try bufferFromStream)`,
-      );
     } else if (
       bodySource instanceof FormData ||
       bodySource instanceof URLSearchParams
@@ -756,44 +681,85 @@
   const BodyUsedError =
     "Failed to execute 'clone' on 'Body': body is already used";
 
+  const teeBody = Symbol("Body#tee");
+
+  // fastBody and dontValidateUrl allow users to opt out of certain behaviors
+  const fastBody = Symbol("Body#fast");
+  const dontValidateUrl = Symbol("dontValidateUrl");
+
   class Body {
     #contentType = "";
-    #size = undefined;
+    #size;
+    /** @type {BodyInit | null} */
+    #bodySource;
+    /** @type {ReadableStream<Uint8Array> | null} */
+    #stream = null;
 
-    constructor(_bodySource, meta) {
-      validateBodyType(this, _bodySource);
-      this._bodySource = _bodySource;
+    /**
+     * @param {BodyInit| null} bodySource 
+     * @param {{contentType: string, size?: number}} meta 
+     */
+    constructor(bodySource, meta) {
+      validateBodyType(this.constructor.name, bodySource);
+      this.#bodySource = bodySource;
       this.#contentType = meta.contentType;
       this.#size = meta.size;
-      this._stream = null;
     }
 
     get body() {
-      if (this._stream) {
-        return this._stream;
-      }
+      if (!this.#stream) {
+        if (!this.#bodySource) {
+          return null;
+        } else if (this.#bodySource instanceof ReadableStream) {
+          this.#stream = this.#bodySource;
+        } else {
+          const buf = bodyToArrayBuffer(this.#bodySource);
+          if (!(buf instanceof ArrayBuffer)) {
+            throw new Error(
+              `Expected ArrayBuffer from body`,
+            );
+          }
 
-      if (!this._bodySource) {
-        return null;
-      } else if (this._bodySource instanceof ReadableStream) {
-        this._stream = this._bodySource;
-      } else {
-        const buf = bodyToArrayBuffer(this._bodySource);
-        if (!(buf instanceof ArrayBuffer)) {
-          throw new Error(
-            `Expected ArrayBuffer from body`,
-          );
+          this.#stream = new ReadableStream({
+            /**
+             * @param {ReadableStreamDefaultController<Uint8Array>} controller 
+             */
+            start(controller) {
+              controller.enqueue(new Uint8Array(buf));
+              controller.close();
+            },
+          });
         }
-
-        this._stream = new ReadableStream({
-          start(controller) {
-            controller.enqueue(new Uint8Array(buf));
-            controller.close();
-          },
-        });
       }
 
-      return this._stream;
+      return this.#stream;
+    }
+
+    // Optimization that allows caller to bypass expensive ReadableStream.
+    [fastBody]() {
+      if (!this.#bodySource) {
+        return null;
+      } else if (!(this.#bodySource instanceof ReadableStream)) {
+        return bodyToArrayBuffer(this.#bodySource);
+      } else {
+        return this.body;
+      }
+    }
+
+    /** @returns {BodyInit | null} */
+    [teeBody]() {
+      if (this.#stream || this.#bodySource instanceof ReadableStream) {
+        const body = this.body;
+        if (body) {
+          const [stream1, stream2] = body.tee();
+          this.#stream = stream1;
+          return stream2;
+        } else {
+          return null;
+        }
+      }
+
+      return this.#bodySource;
     }
 
     get bodyUsed() {
@@ -803,6 +769,11 @@
       return false;
     }
 
+    set bodyUsed(_) {
+      // this is a noop per spec
+    }
+
+    /** @returns {Promise<Blob>} */
     async blob() {
       return new Blob([await this.arrayBuffer()], {
         type: this.#contentType,
@@ -810,6 +781,7 @@
     }
 
     // ref: https://fetch.spec.whatwg.org/#body-mixin
+    /** @returns {Promise<FormData>} */
     async formData() {
       const formData = new FormData();
       if (hasHeaderValueOf(this.#contentType, "multipart/form-data")) {
@@ -834,12 +806,15 @@
             .forEach((bytes) => {
               if (bytes) {
                 const split = bytes.split("=");
-                const name = split.shift().replace(/\+/g, " ");
-                const value = split.join("=").replace(/\+/g, " ");
-                formData.append(
-                  decodeURIComponent(name),
-                  decodeURIComponent(value),
-                );
+                if (split.length >= 2) {
+                  // @ts-expect-error this is safe because of the above check
+                  const name = split.shift().replace(/\+/g, " ");
+                  const value = split.join("=").replace(/\+/g, " ");
+                  formData.append(
+                    decodeURIComponent(name),
+                    decodeURIComponent(value),
+                  );
+                }
               }
             });
         } catch (e) {
@@ -851,9 +826,10 @@
       }
     }
 
+    /** @returns {Promise<string>} */
     async text() {
-      if (typeof this._bodySource === "string") {
-        return this._bodySource;
+      if (typeof this.#bodySource === "string") {
+        return this.#bodySource;
       }
 
       const ab = await this.arrayBuffer();
@@ -861,28 +837,35 @@
       return decoder.decode(ab);
     }
 
+    /** @returns {Promise<any>} */
     async json() {
       const raw = await this.text();
       return JSON.parse(raw);
     }
 
+    /** @returns {Promise<ArrayBuffer>} */
     arrayBuffer() {
-      if (this._bodySource instanceof ReadableStream) {
-        return bufferFromStream(this._bodySource.getReader(), this.#size);
+      if (this.#bodySource instanceof ReadableStream) {
+        const body = this.body;
+        if (!body) throw new TypeError("Unreachable state (no body)");
+        return bufferFromStream(body.getReader(), this.#size);
       }
-      return Promise.resolve(bodyToArrayBuffer(this._bodySource));
+      return Promise.resolve(bodyToArrayBuffer(this.#bodySource));
     }
   }
 
+  /**
+   * @param {Deno.CreateHttpClientOptions} options
+   * @returns {HttpClient}
+   */
   function createHttpClient(options) {
-    return new HttpClient(opCreateHttpClient(options));
-  }
-
-  function opCreateHttpClient(args) {
-    return core.jsonOpSync("op_create_http_client", args);
+    return new HttpClient(core.jsonOpSync("op_create_http_client", options));
   }
 
   class HttpClient {
+    /**
+     * @param {number} rid 
+     */
     constructor(rid) {
       this.rid = rid;
     }
@@ -891,24 +874,58 @@
     }
   }
 
+  /**
+   * @param {{ headers: [string,string][], method: string, url: string, baseUrl: string | null, clientRid: number | null, hasBody: boolean }} args 
+   * @param {Uint8Array | null} body 
+   * @returns {{requestRid: number, requestBodyRid: number | null}}
+   */
   function opFetch(args, body) {
     let zeroCopy;
     if (body != null) {
       zeroCopy = new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
     }
+    return core.jsonOpSync("op_fetch", args, ...(zeroCopy ? [zeroCopy] : []));
+  }
 
-    return core.jsonOpAsync("op_fetch", args, ...(zeroCopy ? [zeroCopy] : []));
+  /**
+   * @param {{rid: number}} args
+   * @returns {Promise<{status: number, statusText: string, headers: Record<string,string[]>, url: string, responseRid: number}>}
+   */
+  function opFetchSend(args) {
+    return core.jsonOpAsync("op_fetch_send", args);
+  }
+
+  /**
+   * @param {{rid: number}} args 
+   * @param {Uint8Array} body 
+   * @returns {Promise<void>}
+   */
+  function opFetchRequestWrite(args, body) {
+    const zeroCopy = new Uint8Array(
+      body.buffer,
+      body.byteOffset,
+      body.byteLength,
+    );
+    return core.jsonOpAsync("op_fetch_request_write", args, zeroCopy);
   }
 
   const NULL_BODY_STATUS = [101, 204, 205, 304];
   const REDIRECT_STATUS = [301, 302, 303, 307, 308];
 
+  /**
+   * @param {string} s
+   * @returns {string}
+   */
   function byteUpperCase(s) {
     return String(s).replace(/[a-z]/g, function byteUpperCaseReplace(c) {
       return c.toUpperCase();
     });
   }
 
+  /**
+   * @param {string} m
+   * @returns {string}
+   */
   function normalizeMethod(m) {
     const u = byteUpperCase(m);
     if (
@@ -925,21 +942,27 @@
   }
 
   class Request extends Body {
-    constructor(input, init) {
-      requiredArguments("Request", arguments.length, 1); // is there a specialization of `requiredArguments` for constructors?
+    /** @type {string} */
+    #method = "GET";
+    /** @type {string} */
+    #url = "";
+    /** @type {Headers} */
+    #headers;
+    /** @type {"include" | "omit" | "same-origin" | undefined} */
+    #credentials = "omit";
 
-      switch (typeof init) {
-        default: {
-          throw new TypeError("Failed to construct 'Request': cannot convert to dictionary.");
-        }
-        case "undefined":
-          /* falls through */
-        case "object": {
-          // may be null
-          init ??= {};
-          break;
-        }
-        case "function": // nop
+    /**
+     * @param {RequestInfo} input 
+     * @param {RequestInit} init 
+     */
+    // @ts-expect-error because the use of super in this constructor is valid.
+    constructor(input, init) {
+      if (arguments.length < 1) {
+        throw TypeError("Not enough arguments");
+      }
+
+      if (!init) {
+        init = {};
       }
 
       let b;
@@ -947,14 +970,14 @@
       // prefer body from init
       if (init.body) {
         b = init.body;
-      } else if (input instanceof Request && input._bodySource) {
+      } else if (input instanceof Request) {
         if (input.bodyUsed) {
-          throw new TypeError(BodyUsedError);
+          throw TypeError(BodyUsedError);
         }
-        b = input._bodySource;
+        b = input[teeBody]();
       } else if (typeof input === "object" && "body" in input && input.body) {
         if (input.bodyUsed) {
-          throw new TypeError(BodyUsedError);
+          throw TypeError(BodyUsedError);
         }
         b = input.body;
       } else {
@@ -962,7 +985,6 @@
       }
 
       let headers;
-
       // prefer headers from init
       if (init.headers) {
         headers = new Headers(init.headers);
@@ -974,33 +996,31 @@
 
       const contentType = headers.get("content-type") || "";
       super(b, { contentType });
-      this.headers = headers;
-
-      // readonly attribute ByteString method;
-      this.method = "GET";
-
-      // readonly attribute USVString url;
-      this.url = "";
-
-      // readonly attribute RequestCredentials credentials;
-      this.credentials = "omit";
+      this.#headers = headers;
 
       if (input instanceof Request) {
         if (input.bodyUsed) {
-          throw new TypeError(BodyUsedError);
+          throw TypeError(BodyUsedError);
         }
-        this.method = input.method;
-        this.url = input.url;
-        this.headers = new Headers(input.headers);
-        this.credentials = input.credentials;
-        this._stream = input._stream;
+        this.#method = input.method;
+        this.#url = input.url;
+        this.#headers = new Headers(input.headers);
+        this.#credentials = input.credentials;
       } else {
-        // TODO(nayeemrmn): Base from `--location` when implemented and set.
-        this.url = new URL(String(input)).href;
+        // Constructing a URL just for validation is known to be expensive.
+        // dontValidateUrl allows one to opt out.
+        if (init[dontValidateUrl]) {
+          this.#url = input;
+        } else {
+          const baseUrl = getLocationHref();
+          this.#url = baseUrl != null
+            ? new URL(String(input), baseUrl).href
+            : new URL(String(input)).href;
+        }
       }
 
       if (init && "method" in init && init.method) {
-        this.method = normalizeMethod(init.method);
+        this.#method = normalizeMethod(init.method);
       }
 
       if (
@@ -1015,7 +1035,7 @@
 
     clone() {
       if (this.bodyUsed) {
-        throw new TypeError(BodyUsedError);
+        throw TypeError(BodyUsedError);
       }
 
       const iterators = this.headers.entries();
@@ -1024,25 +1044,55 @@
         headersList.push(header);
       }
 
-      let body2 = this._bodySource;
-
-      if (this._bodySource instanceof ReadableStream) {
-        const tees = this._bodySource.tee();
-        this._stream = this._bodySource = tees[0];
-        body2 = tees[1];
-      }
+      const body = this[teeBody]();
 
       return new Request(this.url, {
-        body: body2,
+        body,
         method: this.method,
         headers: new Headers(headersList),
         credentials: this.credentials,
       });
     }
+
+    get method() {
+      return this.#method;
+    }
+
+    set method(_) {
+      // can not set method
+    }
+
+    get url() {
+      return this.#url;
+    }
+
+    set url(_) {
+      // can not set url
+    }
+
+    get headers() {
+      return this.#headers;
+    }
+
+    set headers(_) {
+      // can not set headers
+    }
+
+    get credentials() {
+      return this.#credentials;
+    }
+
+    set credentials(_) {
+      // can not set credentials
+    }
   }
 
   const responseData = new WeakMap();
   class Response extends Body {
+    /** 
+     * @param {BodyInit | null} body 
+     * @param {ResponseInit} [init]
+     */
     constructor(body = null, init) {
       init = init ?? {};
 
@@ -1145,7 +1195,7 @@
 
     clone() {
       if (this.bodyUsed) {
-        throw new TypeError(BodyUsedError);
+        throw TypeError(BodyUsedError);
       }
 
       const iterators = this.headers.entries();
@@ -1154,22 +1204,20 @@
         headersList.push(header);
       }
 
-      let resBody = this._bodySource;
+      const body = this[teeBody]();
 
-      if (this._bodySource instanceof ReadableStream) {
-        const tees = this._bodySource.tee();
-        this._stream = this._bodySource = tees[0];
-        resBody = tees[1];
-      }
-
-      return new Response(resBody, {
+      return new Response(body, {
         status: this.status,
         statusText: this.statusText,
         headers: new Headers(headersList),
       });
     }
 
-    static redirect(url, status) {
+    /**
+     * @param {string } url 
+     * @param {number} status
+     */
+    static redirect(url, status = 302) {
       if (![301, 302, 303, 307, 308].includes(status)) {
         throw new RangeError(
           "The redirection status must be one of 301, 302, 303, 307 and 308.",
@@ -1178,88 +1226,133 @@
       return new Response(null, {
         status,
         statusText: "",
-        headers: [["Location", typeof url === "string" ? url : url.toString()]],
+        headers: [["Location", String(url)]],
       });
     }
   }
 
-  function sendFetchReq(url, method, headers, body, clientRid) {
+  /** @type {string | null} */
+  let baseUrl = null;
+
+  /** @param {string} href */
+  function setBaseUrl(href) {
+    baseUrl = href;
+  }
+
+  /**
+   * @param {string} url 
+   * @param {string} method 
+   * @param {Headers} headers 
+   * @param {ReadableStream<Uint8Array> | ArrayBufferView | undefined} body 
+   * @param {number | null} clientRid
+   * @returns {Promise<{status: number, statusText: string, headers: Record<string,string[]>, url: string, responseRid: number}>}
+   */
+  async function sendFetchReq(url, method, headers, body, clientRid) {
+    /** @type {[string, string][]} */
     let headerArray = [];
     if (headers) {
       headerArray = Array.from(headers.entries());
     }
 
-    const args = {
-      method,
-      url,
-      headers: headerArray,
-      clientRid,
-    };
+    const { requestRid, requestBodyRid } = opFetch(
+      {
+        method,
+        url,
+        baseUrl,
+        headers: headerArray,
+        clientRid,
+        hasBody: !!body,
+      },
+      body instanceof Uint8Array ? body : null,
+    );
+    if (requestBodyRid) {
+      if (!(body instanceof ReadableStream)) {
+        throw new TypeError("Unreachable state (body is not ReadableStream).");
+      }
+      const writer = new WritableStream({
+        /**
+         * @param {Uint8Array} chunk 
+         * @param {WritableStreamDefaultController} controller 
+         */
+        async write(chunk, controller) {
+          try {
+            await opFetchRequestWrite({ rid: requestBodyRid }, chunk);
+          } catch (err) {
+            controller.error(err);
+          }
+        },
+        close() {
+          core.close(requestBodyRid);
+        },
+      });
+      body.pipeTo(writer);
+    }
 
-    return opFetch(args, body);
+    return await opFetchSend({ rid: requestRid });
   }
 
+  /**
+   * @param {Request | URL | string} input 
+   * @param {RequestInit & {client: Deno.HttpClient}} [init] 
+   * @returns {Promise<Response>}
+   */
   async function fetch(input, init) {
-    requiredArguments("fetch", arguments.length, 1);
-
+    /** @type {string | null} */
     let url;
     let method = null;
     let headers = null;
     let body;
     let clientRid = null;
     let redirected = false;
-    let remRedirectCount = 20; // TODO: use a better way to handle
+    let remRedirectCount = 20; // TODO(bartlomieju): use a better way to handle
 
-    try {
-      ({
-        method,
-        url,
-        headers,
-        body
-      }) = new Request(input, init);
-    } catch {
-      // prefer WorkerGlobalScope over more specific scope, such as DedicatedWorkerGlobalScope, which is what the [Symbol.toStringTag] may yield
-      // may need refinement
-      const scope = self[Symbol.toStringTag] === "Window" ? "Window" : "WorkerGlobalScope";
-
-      throw new TypeError(`Failed to execute 'fetch' on '${scope}': cannot convert to dictionary.`);
-    }
-
-    if (typeof input === "string" || input instanceof URL || input instanceof String) {
+    if (typeof input === "string" || input instanceof URL) {
+      url = typeof input === "string" ? input : input.href;
       if (init != null) {
+        method = init.method || null;
+        if (init.headers) {
+          headers = init.headers instanceof Headers
+            ? init.headers
+            : new Headers(init.headers);
+        } else {
+          headers = null;
+        }
+
         // ref: https://fetch.spec.whatwg.org/#body-mixin
         // Body should have been a mixin
         // but we are treating it as a separate class
-        if (body) {
+        if (init.body) {
+          if (!headers) {
+            headers = new Headers();
+          }
           let contentType = "";
-          if (typeof body === "string") {
-            body = new TextEncoder().encode(body);
+          if (typeof init.body === "string") {
+            body = new TextEncoder().encode(init.body);
             contentType = "text/plain;charset=UTF-8";
-          } else if (isTypedArray(body)) {
-            // nop
+          } else if (isTypedArray(init.body)) {
+            body = init.body;
           } else if (init.body instanceof ArrayBuffer) {
-            body = new Uint8Array(body);
+            body = new Uint8Array(init.body);
           } else if (init.body instanceof URLSearchParams) {
-            body = new TextEncoder().encode(body.toString());
+            body = new TextEncoder().encode(init.body.toString());
             contentType = "application/x-www-form-urlencoded;charset=UTF-8";
           } else if (init.body instanceof Blob) {
-            body = body[bytesSymbol];
-            contentType = body.type;
-          } else if (body instanceof FormData) {
+            body = init.body[_byteSequence];
+            contentType = init.body.type;
+          } else if (init.body instanceof FormData) {
             let boundary;
             if (headers.has("content-type")) {
               const params = getHeaderValueParams("content-type");
               boundary = params.get("boundary");
             }
             const multipartBuilder = new MultipartBuilder(
-              body,
+              init.body,
               boundary,
             );
             body = multipartBuilder.getBody();
             contentType = multipartBuilder.getContentType();
-          } else {
-            // TODO: ReadableStream
-            throw new Error("Not implemented");
+          } else if (init.body instanceof ReadableStream) {
+            body = init.body;
           }
           if (contentType && !headers.has("content-type")) {
             headers.set("content-type", contentType);
@@ -1275,44 +1368,52 @@
       method = input.method;
       headers = input.headers;
 
-      if (input._bodySource) {
-        body = new DataView(await input.arrayBuffer());
+      if (input.body) {
+        body = input.body;
       }
     }
 
     let responseBody;
     let responseInit = {};
     while (remRedirectCount) {
-      const fetchResponse = await sendFetchReq(
+      const fetchResp = await sendFetchReq(
         url,
-        method,
-        headers,
+        method ?? "GET",
+        headers ?? new Headers(),
         body,
         clientRid,
       );
-      const rid = fetchResponse.bodyRid;
+      const rid = fetchResp.responseRid;
 
       if (
-        NULL_BODY_STATUS.includes(fetchResponse.status) ||
-        REDIRECT_STATUS.includes(fetchResponse.status)
+        NULL_BODY_STATUS.includes(fetchResp.status) ||
+        REDIRECT_STATUS.includes(fetchResp.status)
       ) {
         // We won't use body of received response, so close it now
         // otherwise it will be kept in resource table.
-        core.close(fetchResponse.bodyRid);
+        core.close(rid);
         responseBody = null;
       } else {
         responseBody = new ReadableStream({
           type: "bytes",
+          /** @param {ReadableStreamDefaultController<Uint8Array>} controller */
           async pull(controller) {
             try {
-              const result = await core.jsonOpAsync("op_fetch_read", { rid });
-              if (!result || !result.chunk) {
+              const chunk = new Uint8Array(16 * 1024 + 256);
+              const { read } = await core.jsonOpAsync(
+                "op_fetch_response_read",
+                { rid },
+                chunk,
+              );
+              if (read != 0) {
+                if (chunk.length == read) {
+                  controller.enqueue(chunk);
+                } else {
+                  controller.enqueue(chunk.subarray(0, read));
+                }
+              } else {
                 controller.close();
                 core.close(rid);
-              } else {
-                // TODO(ry) This is terribly inefficient. Make this zero-copy.
-                const chunk = new Uint8Array(result.chunk);
-                controller.enqueue(chunk);
               }
             } catch (e) {
               controller.error(e);
@@ -1329,20 +1430,20 @@
 
       responseInit = {
         status: 200,
-        statusText: fetchResponse.statusText,
-        headers: fetchResponse.headers,
+        statusText: fetchResp.statusText,
+        headers: fetchResp.headers,
       };
 
       responseData.set(responseInit, {
         redirected,
-        rid: fetchResponse.bodyRid,
-        status: fetchResponse.status,
-        url,
+        rid: fetchResp.responseRid,
+        status: fetchResp.status,
+        url: fetchResp.url,
       });
 
       const response = new Response(responseBody, responseInit);
 
-      if (REDIRECT_STATUS.includes(fetchResponse.status)) {
+      if (REDIRECT_STATUS.includes(fetchResp.status)) {
         // We're in a redirect status
         switch ((init && init.redirect) || "follow") {
           case "error":
@@ -1360,6 +1461,7 @@
           case "follow":
           // fallthrough
           default: {
+            /** @type {string | null} */
             let redirectUrl = response.headers.get("Location");
             if (redirectUrl == null) {
               return response; // Unspecified
@@ -1368,7 +1470,7 @@
               !redirectUrl.startsWith("http://") &&
               !redirectUrl.startsWith("https://")
             ) {
-              redirectUrl = new URL(redirectUrl, url).href;
+              redirectUrl = new URL(redirectUrl, fetchResp.url).href;
             }
             url = redirectUrl;
             redirected = true;
@@ -1390,13 +1492,14 @@
   }
 
   window.__bootstrap.fetch = {
-    Blob,
-    DomFile,
     FormData,
+    setBaseUrl,
     fetch,
     Request,
     Response,
     HttpClient,
     createHttpClient,
+    fastBody,
+    dontValidateUrl,
   };
 })(this);

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -926,7 +926,7 @@
 
   class Request extends Body {
     constructor(input, init) {
-      requiredArguments("Request", arguments.length, 1); // may need a specialization of requiredArguments for constructors
+      requiredArguments("Request", arguments.length, 1); // is there a specialization of `requiredArguments` for constructors?
 
       switch (typeof init) {
         default: {
@@ -937,6 +937,7 @@
         case "object": {
           // may be null
           init ??= {};
+          break;
         }
         case "function": // nop
       }

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -939,9 +939,7 @@
           // may be null
           init ??= {};
         }
-        case "function": {
-          break; // nop
-        }
+        case "function": // nop
       }
 
       let b;
@@ -1209,6 +1207,17 @@
     let clientRid = null;
     let redirected = false;
     let remRedirectCount = 20; // TODO: use a better way to handle
+
+
+    try {
+      const request = new Request(input, init);
+      url = request.url;
+      // TODO
+    } catch(e) {
+      if (e instanceof TypeError && e.message.includes("dictionary")) {
+        throw TypeError(`Failed to execute 'fetch' on '${import.meta.main ? "Window" : "WorkerGlobalScope"}': cannot convert to dictionary.`);
+      }
+    }
 
     if (typeof input === "string" || input instanceof URL) {
       url = typeof input === "string" ? input : input.href;

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -930,8 +930,18 @@
         throw TypeError("Not enough arguments");
       }
 
-      if (!init) {
-        init = {};
+      switch (typeof init) {
+        default: {
+          throw TypeError(`Failed to execute 'fetch' on '${this[Symbol.toStringTag].toLowerCase()}': cannot convert to dictionary.`);
+        }
+        case "undefined":
+        case "object": {
+          // may be null
+          init ??= {};
+        }
+        case "function": {
+          break; // nop
+        }
       }
 
       let b;

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -932,7 +932,7 @@
 
       switch (typeof init) {
         default: {
-          throw TypeError(`Failed to execute 'fetch' on '${this[Symbol.toStringTag].toLowerCase()}': cannot convert to dictionary.`);
+          throw TypeError("Failed to construct 'Request': cannot convert to dictionary.");
         }
         case "undefined":
         case "object": {


### PR DESCRIPTION
Checks the Request initializer parameter for its type (and value).
Mimics Chromium implementation.

If the init is null or undefined, it would be replaced with an object, if it is a function, nothing is done, anything else results in a type error being thrown.

Fixes <https://github.com/denoland/deno/issues/8565>.

Also updates `fetch` to call the `Request` constructor, and to use its results.

If the Request construction fails, the error is propagated to the callee, as defined in the spec.