### PR TITLE
fix(op_crates/fetch): support non-ascii response headers value

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -689,6 +689,18 @@ unitTest(
   {
     perms: { net: true },
   },
+  async function fetchWithNonAsciiRedirection(): Promise<void> {
+    const response = await fetch("http://localhost:4545/non_ascii_redirect");
+    assertEquals(response.status, 404);
+    assertEquals(response.url, "http://localhost:4545/%C2%AE");
+    await response.text();
+  }
+)
+
+unitTest(
+  {
+    perms: { net: true },
+  },
   async function fetchWithManualRedirection(): Promise<void> {
     const response = await fetch("http://localhost:4546/", {
       redirect: "manual",

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -694,8 +694,8 @@ unitTest(
     assertEquals(response.status, 404);
     assertEquals(response.url, "http://localhost:4545/%C2%AE");
     await response.text();
-  }
-)
+  },
+);
 
 unitTest(
   {

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -690,9 +690,11 @@ unitTest(
     perms: { net: true },
   },
   async function fetchWithNonAsciiRedirection(): Promise<void> {
-    const response = await fetch("http://localhost:4545/non_ascii_redirect");
-    assertEquals(response.status, 404);
-    assertEquals(response.url, "http://localhost:4545/%C2%AE");
+    const response = await fetch("http://localhost:4545/non_ascii_redirect", {
+      redirect: "manual",
+    });
+    assertEquals(response.status, 301);
+    assertEquals(response.headers.get("location"), "/redirect®");
     await response.text();
   },
 );

--- a/op_crates/fetch/lib.rs
+++ b/op_crates/fetch/lib.rs
@@ -158,7 +158,9 @@ where
   for (key, val) in res.headers().iter() {
     let key_string = key.to_string();
 
-    if key_string == "location" {
+    if val.as_bytes().is_ascii() {
+      res_headers.push((key_string, val.to_str().unwrap().to_owned()))
+    } else {
       res_headers.push((
         key_string,
         val
@@ -167,8 +169,6 @@ where
           .map(|&c| c as char)
           .collect::<String>(),
       ));
-    } else {
-      res_headers.push((key_string, val.to_str().unwrap().to_owned()))
     }
   }
 

--- a/op_crates/fetch/lib.rs
+++ b/op_crates/fetch/lib.rs
@@ -29,6 +29,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::str::from_utf8;
 
 pub use reqwest; // Re-export reqwest
 
@@ -156,7 +157,10 @@ where
   let status = res.status();
   let mut res_headers = Vec::new();
   for (key, val) in res.headers().iter() {
-    res_headers.push((key.to_string(), val.to_str().unwrap().to_owned()));
+    res_headers.push((
+      key.to_string(),
+      from_utf8(val.as_bytes()).unwrap().to_owned(),
+    ));
   }
 
   let rid = state

--- a/op_crates/fetch/lib.rs
+++ b/op_crates/fetch/lib.rs
@@ -29,7 +29,6 @@ use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::str::from_utf8;
 
 pub use reqwest; // Re-export reqwest
 
@@ -157,10 +156,20 @@ where
   let status = res.status();
   let mut res_headers = Vec::new();
   for (key, val) in res.headers().iter() {
-    res_headers.push((
-      key.to_string(),
-      from_utf8(val.as_bytes()).unwrap().to_owned(),
-    ));
+    let key_string = key.to_string();
+
+    if key_string == "location" {
+      res_headers.push((
+        key_string,
+        val
+          .as_bytes()
+          .iter()
+          .map(|&c| c as char)
+          .collect::<String>(),
+      ));
+    } else {
+      res_headers.push((key_string, val.to_str().unwrap().to_owned()))
+    }
   }
 
   let rid = state

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -290,6 +290,15 @@ pub async fn run_all_servers() {
     *res.status_mut() = StatusCode::FOUND;
     Box::new(res)
   });
+  let non_ascii_redirect = warp::path("non_ascii_redirect").map(|| -> Box<dyn Reply> {
+    let mut res = Response::new(Body::empty());
+    *res.status_mut() = StatusCode::MOVED_PERMANENTLY;
+    res.headers_mut().insert(
+      "location",
+      HeaderValue::from_bytes(b"/\xc2\xae").unwrap(),
+    );
+    Box::new(res)
+  });
 
   let etag_script = warp::path!("etag_script.ts")
     .and(warp::header::optional::<String>("if-none-match"))
@@ -444,7 +453,8 @@ pub async fn run_all_servers() {
     .or(echo_server)
     .or(echo_multipart_file)
     .or(multipart_form_data)
-    .or(bad_redirect);
+    .or(bad_redirect)
+    .or(non_ascii_redirect);
 
   let http_fut =
     warp::serve(content_type_handler.clone()).bind(([127, 0, 0, 1], PORT));

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -294,9 +294,10 @@ pub async fn run_all_servers() {
     warp::path("non_ascii_redirect").map(|| -> Box<dyn Reply> {
       let mut res = Response::new(Body::empty());
       *res.status_mut() = StatusCode::MOVED_PERMANENTLY;
-      res
-        .headers_mut()
-        .insert("location", HeaderValue::from_bytes(b"/\xc2\xae").unwrap());
+      res.headers_mut().insert(
+        "location",
+        HeaderValue::from_bytes(b"/redirect\xae").unwrap(),
+      );
       Box::new(res)
     });
 

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -290,15 +290,15 @@ pub async fn run_all_servers() {
     *res.status_mut() = StatusCode::FOUND;
     Box::new(res)
   });
-  let non_ascii_redirect = warp::path("non_ascii_redirect").map(|| -> Box<dyn Reply> {
-    let mut res = Response::new(Body::empty());
-    *res.status_mut() = StatusCode::MOVED_PERMANENTLY;
-    res.headers_mut().insert(
-      "location",
-      HeaderValue::from_bytes(b"/\xc2\xae").unwrap(),
-    );
-    Box::new(res)
-  });
+  let non_ascii_redirect =
+    warp::path("non_ascii_redirect").map(|| -> Box<dyn Reply> {
+      let mut res = Response::new(Body::empty());
+      *res.status_mut() = StatusCode::MOVED_PERMANENTLY;
+      res
+        .headers_mut()
+        .insert("location", HeaderValue::from_bytes(b"/\xc2\xae").unwrap());
+      Box::new(res)
+    });
 
   let etag_script = warp::path!("etag_script.ts")
     .and(warp::header::optional::<String>("if-none-match"))


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Fixes #8576

This issue is related to the case where the fetch response header value is a non-ascii string.
As with the HTTP 301 response, some headers value can contain UTF-8 strings.

So, I simply changed the value as utf-8 string.

If you have a better idea, please give me feedback. :smile_cat: 