### PR TITLE
feat(std/wasi): add support for initializing reactors

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -1590,7 +1590,13 @@ export default class Context {
   }
 
   /**
+   * Attempt to initialize instance as a reactor by invoking its _initialize() export.
    *
+   * If instance contains a _start() export, then an exception is thrown.
+   *
+   * The instance must also have a WebAssembly.Memory export named "memory"
+   * which will be used as the address space, if it does not an error will be
+   * thrown.
    */
   initialize(start: WebAssembly.Instance) {
     const { _start, _initialize, memory } = instance.exports;

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -1588,4 +1588,31 @@ export default class Context {
 
     _start();
   }
+
+  /**
+   *
+   */
+  initialize(start: WebAssembly.Instance) {
+    const { _start, _initialize, memory } = instance.exports;
+
+    if (!(memory instanceof WebAssembly.Memory)) {
+      throw new TypeError("WebAsembly.instance must provide a memory export");
+    }
+
+    this.memory = memory;
+
+    if (typeof _start == "function") {
+      throw new TypeError(
+        "WebAssembly.Instance export _start must not be a function",
+      );
+    }
+
+    if (typeof _initialize != "function") {
+      throw new TypeError(
+        "WebAsembly.instance export _initialize must be a function",
+      );
+    }
+
+    _initialize();
+  }
 }

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -1598,7 +1598,7 @@ export default class Context {
    * which will be used as the address space, if it does not an error will be
    * thrown.
    */
-  initialize(start: WebAssembly.Instance) {
+  initialize(instance: WebAssembly.Instance) {
     const { _start, _initialize, memory } = instance.exports;
 
     if (!(memory instanceof WebAssembly.Memory)) {

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -180,3 +180,45 @@ Deno.test("context_start", function () {
     "export _start must be a function",
   );
 });
+
+Deno.test("context_initialize", function () {
+  assertThrows(
+    () => {
+      const context = new Context({});
+      context.start({
+        exports: {
+          _initialize() {},
+        },
+      });
+    },
+    TypeError,
+    "must provide a memory export",
+  );
+
+  assertThrows(
+    () => {
+      const context = new Context({});
+      context.start({
+        exports: {
+          _start() {},
+          memory: new WebAssembly.Memory({ initial: 1 }),
+        },
+      });
+    },
+    TypeError,
+    "export _start must not be a function",
+  );
+
+  assertThrows(
+    () => {
+      const context = new Context({});
+      context.start({
+        exports: {
+          memory: new WebAssembly.Memory({ initial: 1 }),
+        },
+      });
+    },
+    TypeError,
+    "export _initialize must be a function",
+  );
+});

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -185,7 +185,7 @@ Deno.test("context_initialize", function () {
   assertThrows(
     () => {
       const context = new Context({});
-      context.start({
+      context.initialize({
         exports: {
           _initialize() {},
         },
@@ -198,7 +198,7 @@ Deno.test("context_initialize", function () {
   assertThrows(
     () => {
       const context = new Context({});
-      context.start({
+      context.initialize({
         exports: {
           _start() {},
           memory: new WebAssembly.Memory({ initial: 1 }),
@@ -212,7 +212,7 @@ Deno.test("context_initialize", function () {
   assertThrows(
     () => {
       const context = new Context({});
-      context.start({
+      context.initialize({
         exports: {
           memory: new WebAssembly.Memory({ initial: 1 }),
         },


### PR DESCRIPTION
This adds another entry point to Context called initialize for spinning up style modules.

Node has a similar API: https://nodejs.org/api/wasi.html#wasi_wasi_initialize_instance

For context, reactors are modules that don't have a main function and basically run forever in the background.