### PR TITLE
refactor(std/wasi): prefer nullish coalescing

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -296,8 +296,8 @@ export default class Context {
   exports: Record<string, WebAssembly.ImportValue>;
 
   constructor(options: ContextOptions) {
-    this.args = options.args ? options.args : [];
-    this.env = options.env ? options.env : {};
+    this.args = options.args ?? [];
+    this.env = options.env ?? {};
     this.exitOnReturn = options.exitOnReturn ?? true;
     this.memory = null!;
 


### PR DESCRIPTION
This replaces the ternaries in the context constructor with nullish coalescing which is ever so slightly more readable.