### PR TITLE
docs(tools): add documentation for deno compile cmd

### DIFF
--- a/docs/toc.json
+++ b/docs/toc.json
@@ -69,6 +69,7 @@
       "formatter": "Formatter",
       "repl": "Read-eval-print-loop",
       "bundler": "Bundler",
+      "compiler": "Compiling executables",
       "documentation_generator": "Documentation generator",
       "dependency_inspector": "Dependency inspector",
       "linter": "Linter"

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,6 +4,7 @@ Deno provides some built in tooling that is useful when working with JavaScript
 and TypeScript:
 
 - [bundler (`deno bundle`)](./tools/bundler.md)
+- [compiling executables (`deno compile`)](./tools/compiler.md)
 - [dependency inspector (`deno info`)](./tools/dependency_inspector.md)
 - [documentation generator (`deno doc`)](./tools/documentation_generator.md)
 - [formatter (`deno fmt`)](./tools/formatter.md)

--- a/docs/tools/compiler.md
+++ b/docs/tools/compiler.md
@@ -1,14 +1,17 @@
 ## Compiling Executables
 
-> Since the compile functionality is relatively new, the `--unstable` flag has to be set in order for the command to work.
+> Since the compile functionality is relatively new, the `--unstable` flag has
+> to be set in order for the command to work.
 
-`deno compile [SRC] [OUT]` will compile the script into a self contained executable.
+`deno compile [SRC] [OUT]` will compile the script into a self contained
+executable.
 
 ```
 > deno compile --unstable https://deno.land/std/http/file_server.ts
 ```
 
-If you omit the `OUT` parameter, the name of the executable file will be inferred.
+If you omit the `OUT` parameter, the name of the executable file will be
+inferred.
 
 ### Cross Compilation
 

--- a/docs/tools/compiler.md
+++ b/docs/tools/compiler.md
@@ -1,0 +1,15 @@
+## Compiling Executables
+
+> Since the compile functionality is relatively new, the `--unstable` flag has to be set in order for the command to work.
+
+`deno compile [SRC] [OUT]` will compile the script into a self contained executable.
+
+```
+> deno compile --unstable https://deno.land/std/http/file_server.ts
+```
+
+If you omit the `OUT` parameter, the name of the executable file will be inferred.
+
+### Cross Compilation
+
+Cross compiling binaries for different platforms is not currently possible.


### PR DESCRIPTION
This PR adds documentation for the new `deno compile` command introduced in PR #8539 and discussed in #986
