### PR TITLE
feat(op_crates/web) EventTarget signal support

### DIFF
--- a/op_crates/web/01_event.js
+++ b/op_crates/web/01_event.js
@@ -693,7 +693,7 @@
     for (let i = 0; i < handlers.length; i++) {
       const listener = handlers[i];
 
-      let capture, once, passive;
+      let capture, once, passive, signal;
       if (typeof listener.options === "boolean") {
         capture = listener.options;
         once = false;
@@ -895,7 +895,19 @@
           return;
         }
       }
-
+      if (options?.signal) {
+        const signal = options?.signal;
+        if (signal.aborted) {
+          // If signal is not null and its aborted flag is set, then return.
+          return;
+        } else {
+          // If listener’s signal is not null, then add the following abort
+          // abort steps to it: Remove an event listener.
+          signal.addEventListener("abort", () => {
+            this.removeEventListener(type, callback, options);
+          });
+        }
+      }
       listeners[type].push({ callback, options });
     }
 

--- a/op_crates/web/event_test.js
+++ b/op_crates/web/event_test.js
@@ -106,6 +106,25 @@ function eventIsTrustedGetterName() {
     assert(e.message.includes("not a constructor"));
   }
 }
+function eventAbortSignal() {
+  let count = 0;
+  function handler() {
+    count++;
+  }
+  const et = new EventTarget();
+  const controller = new AbortController();
+  et.addEventListener("test", handler, { signal: controller.signal });
+  et.dispatchEvent(new Event("test"));
+  assert(count === 1);
+  et.dispatchEvent(new Event("test"));
+  assert(count === 2);
+  controller.abort();
+  et.dispatchEvent(new Event("test"));
+  assert(count === 2);
+  et.addEventListener("test", handler, { signal: controller.signal });
+  et.dispatchEvent(new Event("test"));
+  assert(count === 2);
+}
 function main() {
   eventInitializedWithType();
   eventInitializedWithTypeAndDict();
@@ -116,6 +135,7 @@ function main() {
   eventInitializedWithNonStringType();
   eventIsTrusted();
   eventIsTrustedGetterName();
+  eventAbortSignal();
 }
 
 main();


### PR DESCRIPTION
Hey, per the request in https://github.com/denoland/deno/issues/8606

This is this feature https://github.com/whatwg/dom/issues/911 I've implemented the spec I worked on in https://github.com/whatwg/dom/pull/919 and ported one WPT from https://github.com/web-platform-tests/wpt/pull/26472 

Is there a standard/easy way to port/run WPTs in Deno? If not - should I just add them in a separate file?

Fixes: https://github.com/denoland/deno/issues/8606

P.S.
I didn't forget the REPL or promise hooks bug - I've been sick, I feel better and I intend to pick those up (hopefully even tomorrow :])