### PR TITLE
refactor(std/wasi): prefer explicit encoder/decoder names

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -341,7 +341,7 @@ export default class Context {
         argvBufferOffset: number,
       ): number => {
         const args = this.args;
-        const text = new TextEncoder();
+        const textEncoder = new TextEncoder();
         const memoryData = new Uint8Array(this.memory.buffer);
         const memoryView = new DataView(this.memory.buffer);
 
@@ -349,7 +349,7 @@ export default class Context {
           memoryView.setUint32(argvOffset, argvBufferOffset, true);
           argvOffset += 4;
 
-          const data = text.encode(`${arg}\0`);
+          const data = textEncoder.encode(`${arg}\0`);
           memoryData.set(data, argvBufferOffset);
           argvBufferOffset += data.length;
         }
@@ -362,14 +362,14 @@ export default class Context {
         argvBufferSizeOffset: number,
       ): number => {
         const args = this.args;
-        const text = new TextEncoder();
+        const textEncoder = new TextEncoder();
         const memoryView = new DataView(this.memory.buffer);
 
         memoryView.setUint32(argcOffset, args.length, true);
         memoryView.setUint32(
           argvBufferSizeOffset,
           args.reduce(function (acc, arg) {
-            return acc + text.encode(`${arg}\0`).length;
+            return acc + textEncoder.encode(`${arg}\0`).length;
           }, 0),
           true,
         );
@@ -382,7 +382,7 @@ export default class Context {
         environBufferOffset: number,
       ): number => {
         const entries = Object.entries(this.env);
-        const text = new TextEncoder();
+        const textEncoder = new TextEncoder();
         const memoryData = new Uint8Array(this.memory.buffer);
         const memoryView = new DataView(this.memory.buffer);
 
@@ -390,7 +390,7 @@ export default class Context {
           memoryView.setUint32(environOffset, environBufferOffset, true);
           environOffset += 4;
 
-          const data = text.encode(`${key}=${value}\0`);
+          const data = textEncoder.encode(`${key}=${value}\0`);
           memoryData.set(data, environBufferOffset);
           environBufferOffset += data.length;
         }
@@ -403,14 +403,14 @@ export default class Context {
         environBufferSizeOffset: number,
       ): number => {
         const entries = Object.entries(this.env);
-        const text = new TextEncoder();
+        const textEncoder = new TextEncoder();
         const memoryView = new DataView(this.memory.buffer);
 
         memoryView.setUint32(environcOffset, entries.length, true);
         memoryView.setUint32(
           environBufferSizeOffset,
           entries.reduce(function (acc, [key, value]) {
-            return acc + text.encode(`${key}=${value}\0`).length;
+            return acc + textEncoder.encode(`${key}=${value}\0`).length;
           }, 0),
           true,
         );
@@ -1021,9 +1021,9 @@ export default class Context {
           return ERRNO_INVAL;
         }
 
-        const text = new TextDecoder();
+        const textDecoder = new TextDecoder();
         const data = new Uint8Array(this.memory.buffer, pathOffset, pathLength);
-        const path = resolve(entry.path!, text.decode(data));
+        const path = resolve(entry.path!, textDecoder.decode(data));
 
         Deno.mkdirSync(path);
 
@@ -1046,9 +1046,9 @@ export default class Context {
           return ERRNO_INVAL;
         }
 
-        const text = new TextDecoder();
+        const textDecoder = new TextDecoder();
         const data = new Uint8Array(this.memory.buffer, pathOffset, pathLength);
-        const path = resolve(entry.path!, text.decode(data));
+        const path = resolve(entry.path!, textDecoder.decode(data));
 
         const memoryView = new DataView(this.memory.buffer);
 
@@ -1140,9 +1140,9 @@ export default class Context {
           return ERRNO_INVAL;
         }
 
-        const text = new TextDecoder();
+        const textDecoder = new TextDecoder();
         const data = new Uint8Array(this.memory.buffer, pathOffset, pathLength);
-        const path = resolve(entry.path!, text.decode(data));
+        const path = resolve(entry.path!, textDecoder.decode(data));
 
         if ((fstflags & FSTFLAGS_ATIM_NOW) == FSTFLAGS_ATIM_NOW) {
           atim = BigInt(Date.now()) * BigInt(1e6);
@@ -1176,19 +1176,19 @@ export default class Context {
           return ERRNO_INVAL;
         }
 
-        const text = new TextDecoder();
+        const textDecoder = new TextDecoder();
         const oldData = new Uint8Array(
           this.memory.buffer,
           oldPathOffset,
           oldPathLength,
         );
-        const oldPath = resolve(oldEntry.path!, text.decode(oldData));
+        const oldPath = resolve(oldEntry.path!, textDecoder.decode(oldData));
         const newData = new Uint8Array(
           this.memory.buffer,
           newPathOffset,
           newPathLength,
         );
-        const newPath = resolve(newEntry.path!, text.decode(newData));
+        const newPath = resolve(newEntry.path!, textDecoder.decode(newData));
 
         Deno.linkSync(oldPath, newPath);
 
@@ -1392,9 +1392,9 @@ export default class Context {
           return ERRNO_INVAL;
         }
 
-        const text = new TextDecoder();
+        const textDecoder = new TextDecoder();
         const data = new Uint8Array(this.memory.buffer, pathOffset, pathLength);
-        const path = resolve(entry.path!, text.decode(data));
+        const path = resolve(entry.path!, textDecoder.decode(data));
 
         if (!Deno.statSync(path).isDirectory) {
           return ERRNO_NOTDIR;
@@ -1423,19 +1423,19 @@ export default class Context {
           return ERRNO_INVAL;
         }
 
-        const text = new TextDecoder();
+        const textDecoder = new TextDecoder();
         const oldData = new Uint8Array(
           this.memory.buffer,
           oldPathOffset,
           oldPathLength,
         );
-        const oldPath = resolve(oldEntry.path!, text.decode(oldData));
+        const oldPath = resolve(oldEntry.path!, textDecoder.decode(oldData));
         const newData = new Uint8Array(
           this.memory.buffer,
           newPathOffset,
           newPathLength,
         );
-        const newPath = resolve(newEntry.path!, text.decode(newData));
+        const newPath = resolve(newEntry.path!, textDecoder.decode(newData));
 
         Deno.renameSync(oldPath, newPath);
 
@@ -1458,19 +1458,19 @@ export default class Context {
           return ERRNO_INVAL;
         }
 
-        const text = new TextDecoder();
+        const textDecoder = new TextDecoder();
         const oldData = new Uint8Array(
           this.memory.buffer,
           oldPathOffset,
           oldPathLength,
         );
-        const oldPath = text.decode(oldData);
+        const oldPath = textDecoder.decode(oldData);
         const newData = new Uint8Array(
           this.memory.buffer,
           newPathOffset,
           newPathLength,
         );
-        const newPath = resolve(entry.path!, text.decode(newData));
+        const newPath = resolve(entry.path!, textDecoder.decode(newData));
 
         Deno.symlinkSync(oldPath, newPath);
 
@@ -1491,9 +1491,9 @@ export default class Context {
           return ERRNO_INVAL;
         }
 
-        const text = new TextDecoder();
+        const textDecoder = new TextDecoder();
         const data = new Uint8Array(this.memory.buffer, pathOffset, pathLength);
-        const path = resolve(entry.path!, text.decode(data));
+        const path = resolve(entry.path!, textDecoder.decode(data));
 
         Deno.removeSync(path);
 


### PR DESCRIPTION
This renames a couple of identifiers from the ambiguous name "text" to the more explicit textEncoder and textDecoder depending on what they are.

Should have been done in the initial pass to camelCase all the identifiers.