### PR TITLE
refactor(cli): remove Option from Flags.v8_flags

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -11,11 +11,6 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-/// Creates vector of strings, Vec<String>
-macro_rules! svec {
-    ($($x:expr),*) => (vec![$($x.to_string()),*]);
-}
-
 #[derive(Clone, Debug, PartialEq)]
 pub enum DenoSubcommand {
   Bundle {
@@ -129,7 +124,7 @@ pub struct Flags {
   pub repl: bool,
   pub seed: Option<u64>,
   pub unstable: bool,
-  pub v8_flags: Option<Vec<String>>,
+  pub v8_flags: Vec<String>,
   pub version: bool,
   pub watch: bool,
   pub write_allowlist: Vec<PathBuf>,
@@ -1465,8 +1460,7 @@ fn v8_flags_arg<'a, 'b>() -> Arg<'a, 'b> {
 
 fn v8_flags_arg_parse(flags: &mut Flags, matches: &ArgMatches) {
   if let Some(v8_flags) = matches.values_of("v8-flags") {
-    let s: Vec<String> = v8_flags.map(String::from).collect();
-    flags.v8_flags = Some(s);
+    flags.v8_flags = v8_flags.map(String::from).collect();
   }
 }
 
@@ -1501,16 +1495,7 @@ fn seed_arg_parse(flags: &mut Flags, matches: &ArgMatches) {
     let seed = seed_string.parse::<u64>().unwrap();
     flags.seed = Some(seed);
 
-    let v8_seed_flag = format!("--random-seed={}", seed);
-
-    match flags.v8_flags {
-      Some(ref mut v8_flags) => {
-        v8_flags.push(v8_seed_flag);
-      }
-      None => {
-        flags.v8_flags = Some(svec![v8_seed_flag]);
-      }
-    }
+    flags.v8_flags.push(format!("--random-seed={}", seed));
   }
 }
 
@@ -1630,6 +1615,11 @@ pub fn resolve_urls(urls: Vec<String>) -> Vec<String> {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  /// Creates vector of strings, Vec<String>
+  macro_rules! svec {
+    ($($x:expr),*) => (vec![$($x.to_string()),*]);
+}
 
   #[test]
   fn global_flags() {
@@ -1752,7 +1742,7 @@ mod tests {
         subcommand: DenoSubcommand::Run {
           script: "_".to_string(),
         },
-        v8_flags: Some(svec!["--help"]),
+        v8_flags: svec!["--help"],
         ..Flags::default()
       }
     );
@@ -1769,7 +1759,7 @@ mod tests {
         subcommand: DenoSubcommand::Run {
           script: "script.ts".to_string(),
         },
-        v8_flags: Some(svec!["--expose-gc", "--gc-stats=1"]),
+        v8_flags: svec!["--expose-gc", "--gc-stats=1"],
         ..Flags::default()
       }
     );
@@ -2256,7 +2246,7 @@ mod tests {
         lock_write: true,
         ca_file: Some("example.crt".to_string()),
         cached_only: true,
-        v8_flags: Some(svec!["--help", "--random-seed=1"]),
+        v8_flags: svec!["--help", "--random-seed=1"],
         seed: Some(1),
         inspect: Some("127.0.0.1:9229".parse().unwrap()),
         allow_net: true,
@@ -2340,7 +2330,7 @@ mod tests {
         lock_write: true,
         ca_file: Some("example.crt".to_string()),
         cached_only: true,
-        v8_flags: Some(svec!["--help", "--random-seed=1"]),
+        v8_flags: svec!["--help", "--random-seed=1"],
         seed: Some(1),
         inspect: Some("127.0.0.1:9229".parse().unwrap()),
         allow_net: true,
@@ -2681,7 +2671,7 @@ mod tests {
           script: "script.ts".to_string(),
         },
         seed: Some(250_u64),
-        v8_flags: Some(svec!["--random-seed=250"]),
+        v8_flags: svec!["--random-seed=250"],
         ..Flags::default()
       }
     );
@@ -2704,7 +2694,7 @@ mod tests {
           script: "script.ts".to_string(),
         },
         seed: Some(250_u64),
-        v8_flags: Some(svec!["--expose-gc", "--random-seed=250"]),
+        v8_flags: svec!["--expose-gc", "--random-seed=250"],
         ..Flags::default()
       }
     );
@@ -2756,7 +2746,7 @@ mod tests {
         lock_write: true,
         ca_file: Some("example.crt".to_string()),
         cached_only: true,
-        v8_flags: Some(svec!["--help", "--random-seed=1"]),
+        v8_flags: svec!["--help", "--random-seed=1"],
         seed: Some(1),
         inspect: Some("127.0.0.1:9229".parse().unwrap()),
         allow_net: true,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1051,8 +1051,8 @@ pub fn main() {
   }
 
   let flags = flags::flags_from_vec(args);
-  if let Some(ref v8_flags) = flags.v8_flags {
-    init_v8_flags(v8_flags);
+  if !flags.v8_flags.is_empty() {
+    init_v8_flags(&*flags.v8_flags);
   }
   init_logger(flags.log_level);
 

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -227,8 +227,8 @@ pub fn install(
     executable_args.push("--cached_only".to_string());
   }
 
-  if let Some(v8_flags) = flags.v8_flags {
-    executable_args.push(format!("--v8-flags={}", v8_flags.join(",")));
+  if !flags.v8_flags.is_empty() {
+    executable_args.push(format!("--v8-flags={}", flags.v8_flags.join(",")));
   }
 
   if let Some(seed) = flags.seed {


### PR DESCRIPTION
Currently `Flags.v8_flags` is `Option<Vec<String>>`, but this can be simplified to just `Vec<String>` and checking for `is_empty()`