### PR TITLE
test(core): type aliases in OpState

### DIFF
--- a/core/gotham_state.rs
+++ b/core/gotham_state.rs
@@ -94,6 +94,9 @@ mod tests {
     value: &'static str,
   }
 
+  type Alias1 = String;
+  type Alias2 = String;
+
   #[test]
   fn put_borrow1() {
     let mut state = GothamState::default();
@@ -164,5 +167,15 @@ mod tests {
     assert!(state.try_take::<MyStruct>().is_none());
     assert!(state.try_borrow_mut::<MyStruct>().is_none());
     assert!(state.try_borrow::<MyStruct>().is_none());
+  }
+
+  #[test]
+  fn type_alias() {
+    let mut state = GothamState::default();
+    state.put::<Alias1>("alias1".to_string());
+    state.put::<Alias2>("alias2".to_string());
+    assert_eq!(state.take::<Alias1>(), "alias2");
+    assert!(state.try_take::<Alias1>().is_none());
+    assert!(state.try_take::<Alias2>().is_none());
   }
 }


### PR DESCRIPTION
This commit adds a test case to core/gotham_state.rs that shows
that type aliases can't be used reliably. Instead wrapper types
should be used.