### PR TITLE
refactor(lsp): make loop async + tsc on aux thread

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -260,7 +260,7 @@ async fn install_command(
 }
 
 async fn language_server_command() -> Result<(), AnyError> {
-  lsp::start()
+  lsp::start().await
 }
 
 async fn lint_command(


### PR DESCRIPTION
This is still WIP.

This PR makes the main loop in the LSP async. This is to support the second thing this PR does: move tsc into a seperate thread.

This PR is just to try out if this is possible. I am going to extract the async LSP loop into a seperate PR, and will clean it up. I think a lot of the LSP loop can be simplified by using a Futures based model, instead of rebuilding all of this like the LSP does now.
