### PR TITLE
test(std/wasi): run test runner with --no-check

### DIFF
--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -90,6 +90,7 @@ for (const pathname of tests) {
             "--quiet",
             "--unstable",
             "--allow-all",
+            "--no-check",
             path.resolve(rootdir, "snapshot_preview1_test_runner.ts"),
             prelude,
             path.resolve(rootdir, pathname),


### PR DESCRIPTION
This runs the test runner with --no-check which shaves the time taken down from a bit over 1 minute to 5 seconds.

We still import "snapshot_preview1" file in the test file that prepares the test runner invocations so we still get type checking there, just omitting it in the runner.