### PR TITLE
fix(std/wasi): disallow multiple starts

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -294,6 +294,7 @@ export default class Context {
   fds: FileDescriptor[];
 
   exports: Record<string, WebAssembly.ImportValue>;
+  #started: boolean;
 
   constructor(options: ContextOptions) {
     this.args = options.args ?? [];
@@ -1571,6 +1572,8 @@ export default class Context {
         return ERRNO_NOSYS;
       }),
     };
+
+    this.#started = false;
   }
 
   /**
@@ -1585,6 +1588,12 @@ export default class Context {
    * thrown.
    */
   start(instance: WebAssembly.Instance) {
+    if (this.#started) {
+      throw new Error("WebAssembly.Instance has already started");
+    }
+
+    this.#started = true;
+
     const { _start, _initialize, memory } = instance.exports;
 
     if (!(memory instanceof WebAssembly.Memory)) {
@@ -1618,6 +1627,12 @@ export default class Context {
    * thrown.
    */
   initialize(instance: WebAssembly.Instance) {
+    if (this.#started) {
+      throw new Error("WebAssembly.Instance has already started");
+    }
+
+    this.#started = true;
+
     const { _start, _initialize, memory } = instance.exports;
 
     if (!(memory instanceof WebAssembly.Memory)) {

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -197,6 +197,23 @@ Deno.test("context_start", function () {
     assert(err instanceof ExitStatus);
     assertEquals(err.code, 0);
   }
+
+  assertThrows(
+    () => {
+      const context = new Context({});
+      context.start({
+        exports: {
+          memory: new WebAssembly.Memory({ initial: 1 }),
+          _start() {},
+        },
+      });
+      context.start({
+        exports: {},
+      });
+    },
+    Error,
+    "WebAssembly.Instance has already started",
+  );
 });
 
 Deno.test("context_initialize", function () {
@@ -238,5 +255,21 @@ Deno.test("context_initialize", function () {
     },
     TypeError,
     "export _initialize must be a function",
+  );
+  assertThrows(
+    () => {
+      const context = new Context({});
+      context.initialize({
+        exports: {
+          memory: new WebAssembly.Memory({ initial: 1 }),
+          _initialize() {},
+        },
+      });
+      context.initialize({
+        exports: {},
+      });
+    },
+    Error,
+    "WebAssembly.Instance has already started",
   );
 });


### PR DESCRIPTION
This disallows start and initialize from being called multiple times with the same, or different instances.

Once a context has started, it is bound to that context forever and calls to start/initialize needs to reflect this.

Also; had a look at Node's implementation and this mimicks their start/initialize semantics.