### PR TITLE
docs: fix doc to not use removed function `Deno.dir`

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1143,7 +1143,7 @@ declare namespace Deno {
      * ```ts
      * const status = await Deno.permissions.request({ name: "env" });
      * if (status.state === "granted") {
-     *   console.log(Deno.dir("home"));
+     *   console.log(Deno.env.get("HOME"));
      * } else {
      *   console.log("'env' permission is denied.");
      * }


### PR DESCRIPTION
This PR fix #8682 .
It describe to use `Deno.env.get`.