### PR TITLE
docs(tools): Move setup environment's community paragraph back

### DIFF
--- a/docs/getting_started/setup_your_environment.md
+++ b/docs/getting_started/setup_your_environment.md
@@ -168,10 +168,6 @@ command = "deno"
 args = ["lsp"]
 ```
 
-If you don't see your favorite IDE on this list, maybe you can develop an
-extension. Our [community Discord group](https://discord.gg/deno) can give you
-some pointers on where to get started.
-
 ##### Example for Vim/Neovim
 
 After installing the [`vim-lsp`](https://github.com/prabirshrestha/vim-lsp) LSP
@@ -191,3 +187,7 @@ if executable("deno")
   augroup END
 endif
 ```
+
+If you don't see your favorite IDE on this list, maybe you can develop an
+extension. Our [community Discord group](https://discord.gg/deno) can give you
+some pointers on where to get started.


### PR DESCRIPTION
Accidentally moved in a54ede099d58e8783c6511ff351aefba160b39d9.

Oops, we missed that.
