### PR TITLE
feat(config): Prototype for a configuration file for Deno lint and fmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "tokio 0.2.22",
  "tokio-rustls",
  "tokio-tungstenite",
+ "toml",
  "uuid",
  "walkdir",
  "winapi 0.3.9",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,6 +71,7 @@ tempfile = "3.1.0"
 termcolor = "1.1.0"
 tokio = { version = "0.2.22", features = ["full"] }
 tokio-rustls = "0.14.1"
+toml = "0.5.6"
 uuid = { version = "0.8.1", features = ["v4"] }
 walkdir = "2.3.1"
 

--- a/cli/config.rs
+++ b/cli/config.rs
@@ -1,0 +1,49 @@
+use deno_core::error::AnyError;
+
+use serde::Deserialize;
+use std::default::Default;
+use std::fs::read_to_string;
+use std::path::Path;
+use std::path::PathBuf;
+use toml::from_str;
+
+#[derive(Deserialize)]
+struct ProjectConfig {
+  deno: Option<Config>,
+}
+
+#[derive(Default, Deserialize)]
+pub struct Config {
+  pub fmt: Option<FormatConfig>,
+  pub lint: Option<LintConfig>,
+}
+
+#[derive(Deserialize)]
+pub struct FormatConfig {
+  #[serde(default)]
+  pub ignore: Vec<String>,
+}
+
+#[derive(Deserialize)]
+pub struct LintConfig {
+  #[serde(default)]
+  pub ignore: Vec<String>,
+}
+
+pub fn load(path: &str) -> Result<Config, AnyError> {
+  from_str(&read_to_string(path)?)
+    .map(|c: ProjectConfig| c.deno.unwrap_or_default())
+    .map_err(AnyError::new)
+}
+
+pub fn relative_paths(config: &str, paths: &[String]) -> Vec<PathBuf> {
+  let base_path = Path::new(config).parent().unwrap();
+  paths
+    .iter()
+    .map(|p| {
+      let mut new_path = base_path.to_path_buf();
+      new_path.push(p);
+      new_path
+    })
+    .collect()
+}

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
+use crate::program_state::exit_unstable;
+
 use clap::App;
 use clap::AppSettings;
 use clap::Arg;
@@ -116,6 +118,7 @@ pub struct Flags {
   pub lock: Option<PathBuf>,
   pub lock_write: bool,
   pub log_level: Option<Level>,
+  pub meta: Option<String>,
   pub net_allowlist: Vec<String>,
   pub no_check: bool,
   pub no_prompts: bool,
@@ -257,6 +260,12 @@ pub fn flags_from_vec_safe(args: Vec<String>) -> clap::Result<Flags> {
   if matches.is_present("unstable") {
     flags.unstable = true;
   }
+  if matches.is_present("meta") {
+    if !flags.unstable {
+      exit_unstable("meta");
+    }
+    flags.meta = matches.value_of("meta").map(ToOwned::to_owned);
+  }
   if matches.is_present("log-level") {
     flags.log_level = match matches.value_of("log-level").unwrap() {
       "debug" => Some(Level::Debug),
@@ -324,6 +333,14 @@ fn clap_root<'a, 'b>(version: &'b str) -> App<'a, 'b> {
       Arg::with_name("unstable")
         .long("unstable")
         .help("Enable unstable features and APIs")
+        .global(true),
+    )
+    .arg(
+      Arg::with_name("meta")
+        .short("M")
+        .long("meta")
+        .help("Path of the Deno project configuration")
+        .takes_value(true)
         .global(true),
     )
     .arg(


### PR DESCRIPTION
Currently there are lots of discussions about whether to add a configuration file to Deno.

To aid discoverability and allow for easier discussion of the topic,
this PR provides a rudimentary prototype of how a configuration could look like
and how it could be implemented.

Nothing in this initial state is definitive and thus open for discussion.

Topics of interest might be:
- What file format to use
- What configuration to allow
  - for the linter
  - for the formatter
  - for other tools
 - Should the file be "magically" found
 - What should the flag be called

The basis for this PR was [this](https://gist.github.com/SyrupThinker/45535bdc53e8bd5ff505a86a1d3e7e97) sketch-up of what a configuration could look like.

This initial implementation would be used like this:
https://asciinema.org/a/Szwxu2i3qaqEfXHvddcxIT9Wo

Tests should be implemented *after* discussions has taken place.