### PR TITLE
fix(cli/web): fix atob to throw DOMException

### DIFF
--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -50,6 +50,16 @@ unitTest(function atobThrows2(): void {
   assert(threw);
 });
 
+unitTest(function atobThrows3(): void {
+  let threw = true;
+  try {
+    atob("foobar!!");
+  } catch (DOMException) {
+    threw = true;
+  }
+  assert(threw);
+})
+
 unitTest(function btoaFailed(): void {
   const text = "你好";
   assertThrows(() => {

--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -51,14 +51,14 @@ unitTest(function atobThrows2(): void {
 });
 
 unitTest(function atobThrows3(): void {
-  let threw = true;
+  let threw = false;
   try {
     atob("foobar!!");
   } catch (DOMException) {
     threw = true;
   }
   assert(threw);
-})
+});
 
 unitTest(function btoaFailed(): void {
   const text = "你好";

--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -54,8 +54,10 @@ unitTest(function atobThrows3(): void {
   let threw = false;
   try {
     atob("foobar!!");
-  } catch (DOMException) {
-    threw = true;
+  } catch (e) {
+    if (e instanceof DOMException && e.toString().startsWith("DOMException:")) {
+      threw = true;
+    }
   }
   assert(threw);
 });

--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -55,7 +55,10 @@ unitTest(function atobThrows3(): void {
   try {
     atob("foobar!!");
   } catch (e) {
-    if (e instanceof DOMException && e.toString().startsWith("InvalidCharacterError:")) {
+    if (
+      e instanceof DOMException &&
+      e.toString().startsWith("InvalidCharacterError:")
+    ) {
       threw = true;
     }
   }

--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -55,7 +55,7 @@ unitTest(function atobThrows3(): void {
   try {
     atob("foobar!!");
   } catch (e) {
-    if (e instanceof DOMException && e.toString().startsWith("DOMException:")) {
+    if (e instanceof DOMException && e.toString().startsWith("InvalidCharacterError:")) {
       threw = true;
     }
   }

--- a/op_crates/web/08_text_encoding.js
+++ b/op_crates/web/08_text_encoding.js
@@ -105,7 +105,7 @@
     if (rem === 1 || /[^+/0-9A-Za-z]/.test(s)) {
       throw new DOMException(
         "The string to be decoded is not correctly encoded",
-        "DOMException",
+        "InvalidCharacterError",
       );
     }
 

--- a/op_crates/web/08_text_encoding.js
+++ b/op_crates/web/08_text_encoding.js
@@ -105,7 +105,7 @@
     if (rem === 1 || /[^+/0-9A-Za-z]/.test(s)) {
       throw new DOMException(
         "The string to be decoded is not correctly encoded",
-        "DataDecodeError",
+        "DOMException",
       );
     }
 


### PR DESCRIPTION
fix #8795 

atob('foobar!!') returns a DOMException in chrome, but it returns a DataDecodeError in Deno.
I fixed atob function to throw DOMException instead of DataDecodeError.