### PR TITLE
test(cli): ensure await all on stdout does not deadlock

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2105,6 +2105,11 @@ fn deno_test_no_color() {
   assert!(out.contains("test result: FAILED. 1 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out"));
 }
 
+itest!(stdout_write_all {
+  args: "run --quiet stdout_write_all.ts",
+  output: "stdout_write_all.out",
+});
+
 itest!(_001_hello {
   args: "run --reload 001_hello.js",
   output: "001_hello.js.out",

--- a/cli/tests/stdout_write_all.out
+++ b/cli/tests/stdout_write_all.out
@@ -1,0 +1,1 @@
+Hello, world!

--- a/cli/tests/stdout_write_all.out
+++ b/cli/tests/stdout_write_all.out
@@ -1,1 +1,3 @@
-Hello, world!
+done
+done
+complete

--- a/cli/tests/stdout_write_all.ts
+++ b/cli/tests/stdout_write_all.ts
@@ -1,0 +1,8 @@
+const encoder = new TextEncoder();
+const pending = [
+  Deno.stdout.write(encoder.encode("Hello, ")),
+  Deno.stdout.write(encoder.encode("world!")),
+];
+
+await Promise.all(pending);
+await Deno.stdout.write(encoder.encode("\n"));

--- a/cli/tests/stdout_write_all.ts
+++ b/cli/tests/stdout_write_all.ts
@@ -1,8 +1,8 @@
 const encoder = new TextEncoder();
 const pending = [
-  Deno.stdout.write(encoder.encode("Hello, ")),
-  Deno.stdout.write(encoder.encode("world!")),
+  Deno.stdout.write(encoder.encode("done\n")),
+  Deno.stdout.write(encoder.encode("done\n")),
 ];
 
 await Promise.all(pending);
-await Deno.stdout.write(encoder.encode("\n"));
+await Deno.stdout.write(encoder.encode("complete\n"));


### PR DESCRIPTION
This adds an "await all writes" case that would previously dead-lock that has been solved with the new resource table as a regression test (https://github.com/denoland/deno/issues/6840#issuecomment-662569644).

Closes #6840 