### PR TITLE
refactor(cli/tests): rewrite chown_test.ts not to depend on python

### DIFF
--- a/cli/tests/unit/chown_test.ts
+++ b/cli/tests/unit/chown_test.ts
@@ -12,11 +12,11 @@ async function getUidAndGid(): Promise<{ uid: number; gid: number }> {
   // get the user ID and group ID of the current process
   const uidProc = Deno.run({
     stdout: "piped",
-    cmd: ["python", "-c", "import os; print(os.getuid())"],
+    cmd: ["id", "-u"],
   });
   const gidProc = Deno.run({
     stdout: "piped",
-    cmd: ["python", "-c", "import os; print(os.getgid())"],
+    cmd: ["id", "-g"],
   });
 
   assertEquals((await uidProc.status()).code, 0);


### PR DESCRIPTION
Rewrites `chown_test.ts` to use the GNU `id` command instead of python. This won't work on Windows, but these tests aren't currently run on Windows anyway.

Ref #8254

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
