### PR TITLE
docs(introduction): Improve wording and capitalization

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -319,7 +319,7 @@ declare namespace Deno {
      * [tslib](https://www.npmjs.com/package/tslib). */
     importHelpers?: boolean;
     /** This flag controls how `import` works, there are 3 different options:
-     * 
+     *
      * - `remove`: The default behavior of dropping import statements which only
      *   reference types.
      * - `preserve`: Preserves all `import` statements whose values or types are
@@ -328,7 +328,7 @@ declare namespace Deno {
      *   but will error when a value import is only used as a type. This might
      *   be useful if you want to ensure no values are being accidentally
      *   imported, but still make side-effect imports explicit.
-     * 
+     *
      * This flag works because you can use `import type` to explicitly create an
      * `import` statement which should never be emitted into JavaScript. */
     importsNotUsedAsValues?: "remove" | "preserve" | "error";
@@ -1041,7 +1041,7 @@ declare namespace Deno {
    * identified by `pid`.
    *
    *      const p = Deno.run({
-   *        cmd: ["python", "-c", "from time import sleep; sleep(10000)"]
+   *        cmd: ["sleep", "10000"]
    *      });
    *
    *      Deno.kill(p.pid, Deno.Signal.SIGINT);

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,7 +5,7 @@ developer experience.
 
 It's built on V8, Rust, and Tokio.
 
-## Feature Highlights
+## Feature highlights
 
 - Secure by default. No file, network, or environment access (unless explicitly
   enabled).
@@ -31,21 +31,22 @@ Deno explicitly takes on the role of both runtime and package manager. It uses a
 standard browser-compatible protocol for loading modules: URLs.
 
 Among other things, Deno is a great replacement for utility scripts that may
-have been historically written with bash or python.
+have been historically written with Bash or Python.
 
 ## Goals
 
 - Only ship a single executable (`deno`).
-- Provide Secure Defaults.
+- Provide secure defaults.
   - Unless specifically allowed, scripts can't access files, the environment, or
     the network.
-- Browser compatible: The subset of Deno programs which are written completely
-  in JavaScript and do not use the global `Deno` namespace (or feature test for
-  it), ought to also be able to be run in a modern web browser without change.
-- Provide built-in tooling like unit testing, code formatting, and linting to
-  improve developer experience.
-- Does not leak V8 concepts into user land.
-- Be able to serve HTTP efficiently.
+- Be browser-compatible.
+  - The subset of Deno programs which are written completely in JavaScript and
+    do not use the global `Deno` namespace (or feature test for it), ought to
+    also be able to be run in a modern web browser without change.
+- Provide built-in tooling to improve developer experience.
+  - E.g. unit testing, code formatting, and linting.
+- Not leak V8 concepts into user land.
+- Serve HTTP efficiently.
 
 ## Comparison to Node.js
 


### PR DESCRIPTION
- Improve capitalization in various places
- ~Remove unnecessary line break before long link~ (turns out this is enforced by `dprint`)
- Rework Goals section for grammatical and structural consistency

Also simplify docstring of `kill()` to use `sleep` directly instead of via Python, as initially suggested [here](https://github.com/denoland/deno/issues/8254#issuecomment-749100681).
