### PR TITLE
fix(lsp): respect enable flag for requests

### DIFF
--- a/cli/tests/lsp/initialize_request_disabled.json
+++ b/cli/tests/lsp/initialize_request_disabled.json
@@ -10,7 +10,7 @@
     },
     "rootUri": null,
     "initializationOptions": {
-      "enable": true,
+      "enable": false,
       "lint": true,
       "importMap": null,
       "unstable": false


### PR DESCRIPTION
This PR fixes situations with the lsp, where the extension is disable, but on hover and other requests, there are duplicate values reported to vscode.
