### PR TITLE
core: fix http_bench_json_ops, register Error

### DIFF
--- a/core/examples/http_bench_json_ops.js
+++ b/core/examples/http_bench_json_ops.js
@@ -57,6 +57,7 @@ async function serve(rid) {
 
 async function main() {
   Deno.core.ops();
+  Deno.core.registerErrorClass('Error', Error);
 
   const listenerRid = listen();
   Deno.core.print(`http_bench_json_ops listening on http://127.0.0.1:4544/\n`);

--- a/core/examples/http_bench_json_ops.js
+++ b/core/examples/http_bench_json_ops.js
@@ -57,7 +57,7 @@ async function serve(rid) {
 
 async function main() {
   Deno.core.ops();
-  Deno.core.registerErrorClass('Error', Error);
+  Deno.core.registerErrorClass("Error", Error);
 
   const listenerRid = listen();
   Deno.core.print(`http_bench_json_ops listening on http://127.0.0.1:4544/\n`);


### PR DESCRIPTION
Fixes the following runtime error for me when benchmarking:

    thread 'main' panicked at 'called `Result::unwrap()` on an `Err`
    value: Error: Unregistered error class: "Error"
      Connection reset by peer (os error 104)
      Classes of errors returned from ops should be registered via
      Deno.core.registerErrorClass().
        at processResponse (deno:core/core.js:219:13)
        at Object.jsonOpAsync (deno:core/core.js:240:12)
        at async read (http_bench_json_ops.js:29:21)
        at async serve (http_bench_json_ops.js:45:19)',
        core/examples/http_bench_json_ops.rs:260:28

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
