### PR TITLE
fix(build): add generated coverage files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ gclient_config.py_entries
 # compiled wasm files
 std/wasi/testdata/snapshot_preview1/
 
+# generated v8 coverage files
+cli/tests/.test_coverage/
+
 # MacOS generated files
 .DS_Store
 .DS_Store?


### PR DESCRIPTION
Hot fix for #8861

Preferably this would just write to a temporary directory, `itest` doesn't really want to roll that so I'll follow up with a PR to address the coverage tests as a whole.