### PR TITLE
test(cli): ensure await Promise.all does not race

### DIFF
--- a/cli/tests/stdout_write_all.out
+++ b/cli/tests/stdout_write_all.out
@@ -1,3 +1,1 @@
-done
-done
-complete
+Hello, world!

--- a/cli/tests/stdout_write_all.ts
+++ b/cli/tests/stdout_write_all.ts
@@ -1,8 +1,8 @@
 const encoder = new TextEncoder();
 const pending = [
-  Deno.stdout.write(encoder.encode("done\n")),
-  Deno.stdout.write(encoder.encode("done\n")),
+  Deno.stdout.write(encoder.encode("Hello, ")),
+  Deno.stdout.write(encoder.encode("world!")),
 ];
 
 await Promise.all(pending);
-await Deno.stdout.write(encoder.encode("complete\n"));
+await Deno.stdout.write(encoder.encode("\n"));


### PR DESCRIPTION
Revisits the test case added in #8802 to be order sensitive.

See @piscisaureus's comment https://github.com/denoland/deno/pull/8802#issuecomment-749333750