### PR TITLE
chore: move ProgressEvent type to deno.web lib

### DIFF
--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -643,12 +643,6 @@ interface PostMessageOptions {
   transfer?: any[];
 }
 
-interface ProgressEventInit extends EventInit {
-  lengthComputable?: boolean;
-  loaded?: number;
-  total?: number;
-}
-
 interface AbstractWorkerEventMap {
   "error": ErrorEvent;
 }
@@ -838,17 +832,6 @@ declare class PerformanceMark extends PerformanceEntry {
 declare class PerformanceMeasure extends PerformanceEntry {
   readonly detail: any;
   readonly entryType: "measure";
-}
-
-/** Events measuring progress of an underlying process, like an HTTP request
- * (for an XMLHttpRequest, or the loading of the underlying resource of an
- * <img>, <audio>, <video>, <style> or <link>). */
-declare class ProgressEvent<T extends EventTarget = EventTarget> extends Event {
-  constructor(type: string, eventInitDict?: ProgressEventInit);
-  readonly lengthComputable: boolean;
-  readonly loaded: number;
-  readonly target: T | null;
-  readonly total: number;
 }
 
 declare interface CustomEventInit<T = any> extends EventInit {

--- a/op_crates/web/lib.deno_web.d.ts
+++ b/op_crates/web/lib.deno_web.d.ts
@@ -148,6 +148,23 @@ interface EventListenerOptions {
   capture?: boolean;
 }
 
+interface ProgressEventInit extends EventInit {
+  lengthComputable?: boolean;
+  loaded?: number;
+  total?: number;
+}
+
+/** Events measuring progress of an underlying process, like an HTTP request
+ * (for an XMLHttpRequest, or the loading of the underlying resource of an
+ * <img>, <audio>, <video>, <style> or <link>). */
+declare class ProgressEvent<T extends EventTarget = EventTarget> extends Event {
+  constructor(type: string, eventInitDict?: ProgressEventInit);
+  readonly lengthComputable: boolean;
+  readonly loaded: number;
+  readonly target: T | null;
+  readonly total: number;
+}
+
 /** Decodes a string of data which has been encoded using base-64 encoding.
  *
  *     console.log(atob("aGVsbG8gd29ybGQ=")); // outputs 'hello world'


### PR DESCRIPTION
`ProgressEvent` is a global that is defined in the web op crate, and used there (including in the TS typings), but the type definition was part of `lib.deno.shared_globals`. This corrects this.