### PR TITLE
refactor(runtime): return iterator from resolve_addr

### DIFF
--- a/runtime/ops/net.rs
+++ b/runtime/ops/net.rs
@@ -202,7 +202,10 @@ async fn op_datagram_send(
         s.borrow::<Permissions>()
           .check_net(&args.hostname, args.port)?;
       }
-      let addr = resolve_addr(&args.hostname, args.port).await?;
+      let addr = resolve_addr(&args.hostname, args.port)
+        .await?
+        .next()
+        .ok_or_else(|| generic_error("No resolved address found"))?;
 
       let resource = state
         .borrow_mut()
@@ -267,7 +270,10 @@ async fn op_connect(
           .borrow::<Permissions>()
           .check_net(&args.hostname, args.port)?;
       }
-      let addr = resolve_addr(&args.hostname, args.port).await?;
+      let addr = resolve_addr(&args.hostname, args.port)
+        .await?
+        .next()
+        .ok_or_else(|| generic_error("No resolved address found"))?;
       let tcp_stream = TcpStream::connect(&addr).await?;
       let local_addr = tcp_stream.local_addr()?;
       let remote_addr = tcp_stream.peer_addr()?;
@@ -469,7 +475,9 @@ fn op_listen(
         }
         permissions.check_net(&args.hostname, args.port)?;
       }
-      let addr = resolve_addr_sync(&args.hostname, args.port)?;
+      let addr = resolve_addr_sync(&args.hostname, args.port)?
+        .next()
+        .ok_or_else(|| generic_error("No resolved address found"))?;
       let (rid, local_addr) = if transport == "tcp" {
         listen_tcp(state, addr)?
       } else {


### PR DESCRIPTION
This PR does refactoring for `runtime/resolve_addr.rs`.
At first I did it in the other PR (#8790) but I have extracted it as a separate PR to allow #8790 to focus on `Deno.resolveDns` API.

The changes in this PR are:

- to let `resolve_addr` and `resolve_addr_sync` return iterators of `SocketAddr`, not just a single `SocketAddr`. These functions previously called `.next()` on an iterator internally, and returned it, so the callers of these functions had no way of handling other items than the first item in the iterator.  This change allows the caller to decide how to use the returned iterator.
- to use `generic_error` in deno_core instead of `anyhow::Context`. When I worked on #8743, I didn't know there were utility error functions like `generic_error`. 

See also https://github.com/denoland/deno/pull/8790#discussion_r546851138

CC @bartlomieju 

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
