### PR TITLE
feat(cli): collect coverage from the run command

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3322,6 +3322,12 @@ itest!(deno_test_run_test_coverage {
   exit_code: 0,
 });
 
+itest!(deno_test_run_run_coverage {
+  args: "test --allow-all --coverage --unstable test_run_run_coverage.ts",
+  output: "test_run_run_coverage.out",
+  exit_code: 0,
+});
+
 itest!(deno_lint {
   args: "lint --unstable lint/file1.js lint/file2.ts lint/ignored_file.ts",
   output: "lint/expected.out",

--- a/cli/tests/run_coverage.ts
+++ b/cli/tests/run_coverage.ts
@@ -1,0 +1,3 @@
+import { returnsFoo2 } from "./subdir/mod1.ts";
+
+returnsFoo2();

--- a/cli/tests/test_run_run_coverage.out
+++ b/cli/tests/test_run_run_coverage.out
@@ -1,0 +1,27 @@
+Check [WILDCARD]/$deno$test.ts
+running 1 tests
+test spawn test ... Check [WILDCARD]/run_coverage.ts
+ok ([WILDCARD])
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+cover [WILDCARD]/tests/run_coverage.ts ... 100.000% (3/3)
+cover [WILDCARD]/tests/subdir/mod1.ts ... 35.714% (5/14)
+   2 | export function returnsHi() {
+   3 |     return "Hi";
+   4 | }
+-----|-----
+   8 | export function printHello3() {
+   9 |     printHello2();
+  10 | }
+  11 | export function throwsError() {
+  12 |     throw Error("exception from mod1");
+  13 | }
+cover [WILDCARD]/tests/subdir/print_hello.ts ... 25.000% (1/4)
+   1 | export function printHello() {
+   2 |     console.log("Hello");
+   3 | }
+cover [WILDCARD]/tests/subdir/subdir2/mod2.ts ... 62.500% (5/8)
+   5 | export function printHello2() {
+   6 |     printHello();
+   7 | }

--- a/cli/tests/test_run_run_coverage.ts
+++ b/cli/tests/test_run_run_coverage.ts
@@ -1,0 +1,14 @@
+Deno.test("spawn test", async function () {
+  const process = Deno.run({
+    cmd: [
+      Deno.execPath(),
+      "run",
+      "--allow-all",
+      "--unstable",
+      "run_coverage.ts",
+    ],
+  });
+
+  await process.status();
+  process.close();
+});


### PR DESCRIPTION
This adds implicit coverage collection to the run command when a coverage collection directory is set (via an environment variable).