### PR TITLE
refactor(cli/flags): change allow_read/write/net types from bool to Option<Vec<T>>

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -101,11 +101,11 @@ pub struct Flags {
 
   pub allow_env: bool,
   pub allow_hrtime: bool,
-  pub allow_net: bool,
+  pub allow_net: Option<Vec<String>>,
   pub allow_plugin: bool,
-  pub allow_read: bool,
+  pub allow_read: Option<Vec<PathBuf>>,
   pub allow_run: bool,
-  pub allow_write: bool,
+  pub allow_write: Option<Vec<PathBuf>>,
   pub cache_blocklist: Vec<String>,
   pub ca_file: Option<String>,
   pub cached_only: bool,
@@ -118,11 +118,9 @@ pub struct Flags {
   pub lock: Option<PathBuf>,
   pub lock_write: bool,
   pub log_level: Option<Level>,
-  pub net_allowlist: Vec<String>,
   pub no_check: bool,
   pub no_prompts: bool,
   pub no_remote: bool,
-  pub read_allowlist: Vec<PathBuf>,
   pub reload: bool,
   pub repl: bool,
   pub seed: Option<u64>,
@@ -130,7 +128,6 @@ pub struct Flags {
   pub v8_flags: Vec<String>,
   pub version: bool,
   pub watch: bool,
-  pub write_allowlist: Vec<PathBuf>,
 }
 
 fn join_paths(allowlist: &[PathBuf], d: &str) -> String {
@@ -147,32 +144,37 @@ impl Flags {
   pub fn to_permission_args(&self) -> Vec<String> {
     let mut args = vec![];
 
-    if !self.read_allowlist.is_empty() {
-      let s = format!("--allow-read={}", join_paths(&self.read_allowlist, ","));
-      args.push(s);
+    match &self.allow_read {
+      Some(read_allowlist) if read_allowlist.is_empty() => {
+        args.push("--allow-read".to_string());
+      }
+      Some(read_allowlist) => {
+        let s = format!("--allow-read={}", join_paths(read_allowlist, ","));
+        args.push(s);
+      }
+      _ => {}
     }
 
-    if self.allow_read {
-      args.push("--allow-read".to_string());
+    match &self.allow_write {
+      Some(write_allowlist) if write_allowlist.is_empty() => {
+        args.push("--allow-write".to_string());
+      }
+      Some(write_allowlist) => {
+        let s = format!("--allow-write={}", join_paths(write_allowlist, ","));
+        args.push(s);
+      }
+      _ => {}
     }
 
-    if !self.write_allowlist.is_empty() {
-      let s =
-        format!("--allow-write={}", join_paths(&self.write_allowlist, ","));
-      args.push(s);
-    }
-
-    if self.allow_write {
-      args.push("--allow-write".to_string());
-    }
-
-    if !self.net_allowlist.is_empty() {
-      let s = format!("--allow-net={}", self.net_allowlist.join(","));
-      args.push(s);
-    }
-
-    if self.allow_net {
-      args.push("--allow-net".to_string());
+    match &self.allow_net {
+      Some(net_allowlist) if net_allowlist.is_empty() => {
+        args.push("--allow-net".to_string());
+      }
+      Some(net_allowlist) => {
+        let s = format!("--allow-net={}", net_allowlist.join(","));
+        args.push(s);
+      }
+      _ => {}
     }
 
     if self.allow_env {
@@ -205,9 +207,6 @@ impl From<Flags> for PermissionsOptions {
       allow_read: flags.allow_read,
       allow_run: flags.allow_run,
       allow_write: flags.allow_write,
-      net_allowlist: flags.net_allowlist,
-      read_allowlist: flags.read_allowlist,
-      write_allowlist: flags.write_allowlist,
     }
   }
 }
@@ -455,7 +454,7 @@ fn bundle_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   let source_file = matches.value_of("source_file").unwrap().to_string();
 
   let out_file = if let Some(out_file) = matches.value_of("out_file") {
-    flags.allow_write = true;
+    flags.allow_write = Some(vec![]);
     Some(PathBuf::from(out_file))
   } else {
     None
@@ -487,22 +486,22 @@ fn repl_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   runtime_args_parse(flags, matches, false);
   flags.repl = true;
   flags.subcommand = DenoSubcommand::Repl;
-  flags.allow_net = true;
+  flags.allow_net = Some(vec![]);
   flags.allow_env = true;
   flags.allow_run = true;
-  flags.allow_read = true;
-  flags.allow_write = true;
+  flags.allow_read = Some(vec![]);
+  flags.allow_write = Some(vec![]);
   flags.allow_plugin = true;
   flags.allow_hrtime = true;
 }
 
 fn eval_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   runtime_args_parse(flags, matches, false);
-  flags.allow_net = true;
+  flags.allow_net = Some(vec![]);
   flags.allow_env = true;
   flags.allow_run = true;
-  flags.allow_read = true;
-  flags.allow_write = true;
+  flags.allow_read = Some(vec![]);
+  flags.allow_write = Some(vec![]);
   flags.allow_plugin = true;
   flags.allow_hrtime = true;
   let as_typescript = matches.is_present("ts");
@@ -1597,34 +1596,20 @@ fn no_remote_arg_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 fn permission_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   if let Some(read_wl) = matches.values_of("allow-read") {
     let read_allowlist: Vec<PathBuf> = read_wl.map(PathBuf::from).collect();
-
-    if read_allowlist.is_empty() {
-      flags.allow_read = true;
-    } else {
-      flags.read_allowlist = read_allowlist;
-    }
+    flags.allow_read = Some(read_allowlist);
   }
 
   if let Some(write_wl) = matches.values_of("allow-write") {
     let write_allowlist: Vec<PathBuf> = write_wl.map(PathBuf::from).collect();
-
-    if write_allowlist.is_empty() {
-      flags.allow_write = true;
-    } else {
-      flags.write_allowlist = write_allowlist;
-    }
+    flags.allow_write = Some(write_allowlist);
   }
 
   if let Some(net_wl) = matches.values_of("allow-net") {
-    let raw_net_allowlist: Vec<String> =
-      net_wl.map(ToString::to_string).collect();
-    if raw_net_allowlist.is_empty() {
-      flags.allow_net = true;
-    } else {
-      flags.net_allowlist =
-        crate::flags_allow_net::parse(raw_net_allowlist).unwrap();
-      debug!("net allowlist: {:#?}", &flags.net_allowlist);
-    }
+    let net_allowlist: Vec<String> =
+      crate::flags_allow_net::parse(net_wl.map(ToString::to_string).collect())
+        .unwrap();
+    flags.allow_net = Some(net_allowlist);
+    debug!("net allowlist: {:#?}", &flags.allow_net);
   }
 
   if matches.is_present("allow-env") {
@@ -1640,12 +1625,11 @@ fn permission_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     flags.allow_hrtime = true;
   }
   if matches.is_present("allow-all") {
-    flags.allow_read = true;
+    flags.allow_read = Some(vec![]);
     flags.allow_env = true;
-    flags.allow_net = true;
+    flags.allow_net = Some(vec![]);
     flags.allow_run = true;
-    flags.allow_read = true;
-    flags.allow_write = true;
+    flags.allow_write = Some(vec![]);
     flags.allow_plugin = true;
     flags.allow_hrtime = true;
   }
@@ -1786,7 +1770,7 @@ mod tests {
         subcommand: DenoSubcommand::Run {
           script: "script.ts".to_string(),
         },
-        allow_write: true,
+        allow_write: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -1841,7 +1825,7 @@ mod tests {
           script: "gist.ts".to_string(),
         },
         argv: svec!["--title", "X"],
-        allow_net: true,
+        allow_net: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -1856,11 +1840,11 @@ mod tests {
         subcommand: DenoSubcommand::Run {
           script: "gist.ts".to_string(),
         },
-        allow_net: true,
+        allow_net: Some(vec![]),
         allow_env: true,
         allow_run: true,
-        allow_read: true,
-        allow_write: true,
+        allow_read: Some(vec![]),
+        allow_write: Some(vec![]),
         allow_plugin: true,
         allow_hrtime: true,
         ..Flags::default()
@@ -1878,7 +1862,7 @@ mod tests {
         subcommand: DenoSubcommand::Run {
           script: "gist.ts".to_string(),
         },
-        allow_read: true,
+        allow_read: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -1921,7 +1905,7 @@ mod tests {
           script: "script.ts".to_string(),
         },
         argv: svec!["--", "-D", "--allow-net"],
-        allow_write: true,
+        allow_write: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -2232,11 +2216,11 @@ mod tests {
           code: "'console.log(\"hello\")'".to_string(),
           as_typescript: false,
         },
-        allow_net: true,
+        allow_net: Some(vec![]),
         allow_env: true,
         allow_run: true,
-        allow_read: true,
-        allow_write: true,
+        allow_read: Some(vec![]),
+        allow_write: Some(vec![]),
         allow_plugin: true,
         allow_hrtime: true,
         ..Flags::default()
@@ -2255,11 +2239,11 @@ mod tests {
           code: "1+2".to_string(),
           as_typescript: false,
         },
-        allow_net: true,
+        allow_net: Some(vec![]),
         allow_env: true,
         allow_run: true,
-        allow_read: true,
-        allow_write: true,
+        allow_read: Some(vec![]),
+        allow_write: Some(vec![]),
         allow_plugin: true,
         allow_hrtime: true,
         ..Flags::default()
@@ -2283,11 +2267,11 @@ mod tests {
           code: "'console.log(\"hello\")'".to_string(),
           as_typescript: true,
         },
-        allow_net: true,
+        allow_net: Some(vec![]),
         allow_env: true,
         allow_run: true,
-        allow_read: true,
-        allow_write: true,
+        allow_read: Some(vec![]),
+        allow_write: Some(vec![]),
         allow_plugin: true,
         allow_hrtime: true,
         ..Flags::default()
@@ -2320,11 +2304,11 @@ mod tests {
         v8_flags: svec!["--help", "--random-seed=1"],
         seed: Some(1),
         inspect: Some("127.0.0.1:9229".parse().unwrap()),
-        allow_net: true,
+        allow_net: Some(vec![]),
         allow_env: true,
         allow_run: true,
-        allow_read: true,
-        allow_write: true,
+        allow_read: Some(vec![]),
+        allow_write: Some(vec![]),
         allow_plugin: true,
         allow_hrtime: true,
         ..Flags::default()
@@ -2350,11 +2334,11 @@ mod tests {
           as_typescript: false,
         },
         argv: svec!["arg1", "arg2"],
-        allow_net: true,
+        allow_net: Some(vec![]),
         allow_env: true,
         allow_run: true,
-        allow_read: true,
-        allow_write: true,
+        allow_read: Some(vec![]),
+        allow_write: Some(vec![]),
         allow_plugin: true,
         allow_hrtime: true,
         ..Flags::default()
@@ -2370,11 +2354,11 @@ mod tests {
       Flags {
         repl: true,
         subcommand: DenoSubcommand::Repl,
-        allow_net: true,
+        allow_net: Some(vec![]),
         allow_env: true,
         allow_run: true,
-        allow_read: true,
-        allow_write: true,
+        allow_read: Some(vec![]),
+        allow_write: Some(vec![]),
         allow_plugin: true,
         allow_hrtime: true,
         ..Flags::default()
@@ -2404,11 +2388,11 @@ mod tests {
         v8_flags: svec!["--help", "--random-seed=1"],
         seed: Some(1),
         inspect: Some("127.0.0.1:9229".parse().unwrap()),
-        allow_net: true,
+        allow_net: Some(vec![]),
         allow_env: true,
         allow_run: true,
-        allow_read: true,
-        allow_write: true,
+        allow_read: Some(vec![]),
+        allow_write: Some(vec![]),
         allow_plugin: true,
         allow_hrtime: true,
         ..Flags::default()
@@ -2430,8 +2414,7 @@ mod tests {
     assert_eq!(
       r.unwrap(),
       Flags {
-        allow_read: false,
-        read_allowlist: vec![PathBuf::from("."), temp_dir],
+        allow_read: Some(vec![PathBuf::from("."), temp_dir]),
         subcommand: DenoSubcommand::Run {
           script: "script.ts".to_string(),
         },
@@ -2454,8 +2437,7 @@ mod tests {
     assert_eq!(
       r.unwrap(),
       Flags {
-        allow_write: false,
-        write_allowlist: vec![PathBuf::from("."), temp_dir],
+        allow_write: Some(vec![PathBuf::from("."), temp_dir]),
         subcommand: DenoSubcommand::Run {
           script: "script.ts".to_string(),
         },
@@ -2478,8 +2460,7 @@ mod tests {
         subcommand: DenoSubcommand::Run {
           script: "script.ts".to_string(),
         },
-        allow_net: false,
-        net_allowlist: svec!["127.0.0.1"],
+        allow_net: Some(svec!["127.0.0.1"]),
         ..Flags::default()
       }
     );
@@ -2518,7 +2499,7 @@ mod tests {
           source_file: "source.ts".to_string(),
           out_file: Some(PathBuf::from("bundle.js")),
         },
-        allow_write: true,
+        allow_write: Some(vec![]),
         no_remote: true,
         config_path: Some("tsconfig.json".to_owned()),
         ..Flags::default()
@@ -2537,7 +2518,7 @@ mod tests {
           source_file: "source.ts".to_string(),
           out_file: Some(PathBuf::from("bundle.js")),
         },
-        allow_write: true,
+        allow_write: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -2820,8 +2801,8 @@ mod tests {
         v8_flags: svec!["--help", "--random-seed=1"],
         seed: Some(1),
         inspect: Some("127.0.0.1:9229".parse().unwrap()),
-        allow_net: true,
-        allow_read: true,
+        allow_net: Some(vec![]),
+        allow_read: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -2908,7 +2889,7 @@ mod tests {
         subcommand: DenoSubcommand::Run {
           script: "script.ts".to_string(),
         },
-        allow_read: true,
+        allow_read: Some(vec![]),
         argv: svec!["--allow-net", "-r", "--help", "--foo", "bar"],
         ..Flags::default()
       }
@@ -3014,7 +2995,7 @@ mod tests {
         subcommand: DenoSubcommand::Run {
           script: "script.ts".to_string(),
         },
-        net_allowlist: svec![
+        allow_net: Some(svec![
           "deno.land",
           "0.0.0.0:8000",
           "127.0.0.1:8000",
@@ -3022,7 +3003,7 @@ mod tests {
           "0.0.0.0:4545",
           "127.0.0.1:4545",
           "localhost:4545"
-        ],
+        ]),
         ..Flags::default()
       }
     );
@@ -3042,7 +3023,7 @@ mod tests {
         subcommand: DenoSubcommand::Run {
           script: "script.ts".to_string(),
         },
-        net_allowlist: svec![
+        allow_net: Some(svec![
           "deno.land",
           "deno.land:80",
           "::",
@@ -3053,7 +3034,7 @@ mod tests {
           "127.0.0.1:5678",
           "localhost:5678",
           "[::1]:8080"
-        ],
+        ]),
         ..Flags::default()
       }
     );
@@ -3098,7 +3079,7 @@ mod tests {
         },
         unstable: true,
         coverage_dir: Some("cov".to_string()),
-        allow_net: true,
+        allow_net: Some(vec![]),
         argv: svec!["arg1", "arg2"],
         ..Flags::default()
       }

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -6,6 +6,7 @@ use clap::Arg;
 use clap::ArgMatches;
 use clap::ArgSettings;
 use clap::SubCommand;
+use deno_runtime::permissions::PermissionsOptions;
 use log::Level;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -191,6 +192,23 @@ impl Flags {
     }
 
     args
+  }
+}
+
+impl From<Flags> for PermissionsOptions {
+  fn from(flags: Flags) -> Self {
+    Self {
+      allow_env: flags.allow_env,
+      allow_hrtime: flags.allow_hrtime,
+      allow_net: flags.allow_net,
+      allow_plugin: flags.allow_plugin,
+      allow_read: flags.allow_read,
+      allow_run: flags.allow_run,
+      allow_write: flags.allow_write,
+      net_allowlist: flags.net_allowlist,
+      read_allowlist: flags.read_allowlist,
+      write_allowlist: flags.write_allowlist,
+    }
   }
 }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -70,7 +70,6 @@ use deno_doc as doc;
 use deno_doc::parser::DocFileLoader;
 use deno_runtime::ops::worker_host::CreateWebWorkerCb;
 use deno_runtime::permissions::Permissions;
-use deno_runtime::permissions::PermissionsOptions;
 use deno_runtime::web_worker::WebWorker;
 use deno_runtime::web_worker::WebWorkerOptions;
 use deno_runtime::worker::MainWorker;
@@ -86,23 +85,6 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
-
-impl From<Flags> for PermissionsOptions {
-  fn from(flags: Flags) -> Self {
-    Self {
-      allow_env: flags.allow_env,
-      allow_hrtime: flags.allow_hrtime,
-      allow_net: flags.allow_net,
-      allow_plugin: flags.allow_plugin,
-      allow_read: flags.allow_read,
-      allow_run: flags.allow_run,
-      allow_write: flags.allow_write,
-      net_allowlist: flags.net_allowlist,
-      read_allowlist: flags.read_allowlist,
-      write_allowlist: flags.write_allowlist,
-    }
-  }
-}
 
 fn create_web_worker_callback(
   program_state: Arc<ProgramState>,

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -632,8 +632,8 @@ mod tests {
 
     install(
       Flags {
-        allow_net: true,
-        allow_read: true,
+        allow_net: Some(vec![]),
+        allow_read: Some(vec![]),
         no_check: true,
         log_level: Some(Level::Error),
         ..Flags::default()


### PR DESCRIPTION
This PR refactors `cli/flags.rs` and `runtime/permissions.rs ` so that `allow_read`, `allow_write` and `allow_net` themselves will have allowlists.

In the current implementation, the allowlist for the `net` flag is stored in `net_allowlist: Vec<String>` and the presence of `allow-net` flag is stored in `allow_net: bool`. However, if we run deno with `deno run --allow-net=example.com`, `allow_net` will be `false` even though `allow-net` flag is present - which looks confusing to me. The relation between them is as follows:

|command|allow_net|net_allowlist|
|-------|---------|-------------|
|`deno run foo.ts`|`false`|`vec![]`|
|`deno run --allow-net foo.ts`|`true`|`vec![]`|
|`deno run --allow-net=example.com foo.ts`|`false`|`vec!["example.com"]`|


So in this PR, `net_allowlist` is removed and the type of `allow_net` is changed to `Option<Vec<String>>`. In this way, both the presence of the flag and allowlist values can be stored well and simply like:

|command|allow_net|
|-------|---------|
|`deno run foo.ts`|`None`|
|`deno run --allow-net foo.ts`|`Some(vec![])`|
|`deno run --allow-net=example.com foo.ts`|`Some(vec!["example.com"])`|


<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
