### PR TITLE
docs(webassembly): add a link to mdn documentation

### DIFF
--- a/docs/getting_started/webassembly.md
+++ b/docs/getting_started/webassembly.md
@@ -1,6 +1,8 @@
 ## WebAssembly support
 
-Deno can execute [WebAssembly](https://webassembly.org/) binaries.
+Deno can execute [WebAssembly](https://webassembly.org/) modules with the same
+interfaces that
+[browsers provide](https://developer.mozilla.org/en-US/docs/WebAssembly).
 
 <!-- dprint-ignore -->
 


### PR DESCRIPTION
Minor incremental improvement, adds a link back to the relevant section on MDN.