### PR TITLE
feat(lsp):  Implement textDocument/rename

### DIFF
--- a/cli/lsp/capabilities.rs
+++ b/cli/lsp/capabilities.rs
@@ -62,7 +62,7 @@ pub fn server_capabilities(
     document_on_type_formatting_provider: None,
     selection_range_provider: None,
     folding_range_provider: None,
-    rename_provider: None,
+    rename_provider: Some(OneOf::Left(true)),
     document_link_provider: None,
     color_provider: None,
     execute_command_provider: None,

--- a/cli/tests/lsp/rename_did_open_notification.json
+++ b/cli/tests/lsp/rename_did_open_notification.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/didOpen",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts",
+      "languageId": "typescript",
+      "version": 1,
+      "text": "let variable = 'a';\nconsole.log(variable);"
+    }
+  }
+}

--- a/cli/tests/lsp/rename_request.json
+++ b/cli/tests/lsp/rename_request.json
@@ -1,0 +1,15 @@
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "textDocument/rename",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts"
+    },
+    "position": {
+      "line": 5,
+      "character": 19
+    },
+    "newName": "variable_modified"
+  }
+}

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -562,6 +562,18 @@ delete Object.prototype.__proto__;
           ),
         );
       }
+      case "findRenameLocations": {
+        return respond(
+          id,
+          languageService.findRenameLocations(
+            request.specifier,
+            request.position,
+            request.findInStrings,
+            request.findInComments,
+            request.providePrefixAndSuffixTextForRename,
+          ),
+        );
+      }
       default:
         throw new TypeError(
           // @ts-ignore exhausted case statement sets type to never

--- a/cli/tsc/compiler.d.ts
+++ b/cli/tsc/compiler.d.ts
@@ -50,7 +50,8 @@ declare global {
     | GetDocumentHighlightsRequest
     | GetReferencesRequest
     | GetDefinitionRequest
-    | GetCompletionsRequest;
+    | GetCompletionsRequest
+    | FindRenameLocationsRequest;
 
   interface BaseLanguageServerRequest {
     id: number;
@@ -113,5 +114,14 @@ declare global {
     specifier: string;
     position: number;
     preferences: ts.UserPreferences;
+  }
+
+  interface FindRenameLocationsRequest extends BaseLanguageServerRequest {
+    method: "findRenameLocations";
+    specifier: string;
+    position: number;
+    findInStrings: boolean;
+    findInComments: boolean;
+    providePrefixAndSuffixTextForRename: boolean;
   }
 }


### PR DESCRIPTION
Related #8643

Currently, the ConfigureRequest (in `cli/tsc/compiler.d.ts`) does not support `tsconfig.json`'s `include/exclude` field.
So the tsserver will rename symbols in only the opened text document or explicitly dependent text document.

