### PR TITLE
feat(lsp): add cache command

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -398,7 +398,7 @@ impl FileFetcher {
       .boxed();
     }
 
-    info!("{} {}", colors::green("Download").to_string(), specifier);
+    info!("{} {}", colors::green("Download"), specifier);
 
     let file_fetcher = self.clone();
     let cached_etag = match self.http_cache.get(specifier.as_url()) {

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -276,7 +276,6 @@ pub struct FileFetcher {
   cache_setting: CacheSetting,
   http_cache: HttpCache,
   http_client: reqwest::Client,
-  use_color: bool,
 }
 
 impl FileFetcher {
@@ -285,7 +284,6 @@ impl FileFetcher {
     cache_setting: CacheSetting,
     allow_remote: bool,
     maybe_ca_file: Option<&str>,
-    use_color: bool,
   ) -> Result<Self, AnyError> {
     Ok(Self {
       allow_remote,
@@ -293,7 +291,6 @@ impl FileFetcher {
       cache_setting,
       http_cache,
       http_client: create_http_client(get_user_agent(), maybe_ca_file)?,
-      use_color,
     })
   }
 
@@ -401,15 +398,7 @@ impl FileFetcher {
       .boxed();
     }
 
-    info!(
-      "{} {}",
-      if self.use_color {
-        colors::green("Download").to_string()
-      } else {
-        "Download".to_string()
-      },
-      specifier
-    );
+    info!("{} {}", colors::green("Download").to_string(), specifier);
 
     let file_fetcher = self.clone();
     let cached_etag = match self.http_cache.get(specifier.as_url()) {

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -517,14 +517,9 @@ mod tests {
       Rc::new(TempDir::new().expect("failed to create temp directory"))
     });
     let location = temp_dir.path().join("deps");
-    let file_fetcher = FileFetcher::new(
-      HttpCache::new(&location),
-      cache_setting,
-      true,
-      None,
-      true,
-    )
-    .expect("setup failed");
+    let file_fetcher =
+      FileFetcher::new(HttpCache::new(&location), cache_setting, true, None)
+        .expect("setup failed");
     (file_fetcher, temp_dir)
   }
 
@@ -906,7 +901,6 @@ mod tests {
       CacheSetting::ReloadAll,
       true,
       None,
-      true,
     )
     .expect("setup failed");
     let result = file_fetcher
@@ -933,7 +927,6 @@ mod tests {
       CacheSetting::Use,
       true,
       None,
-      true,
     )
     .expect("could not create file fetcher");
     let specifier = ModuleSpecifier::resolve_url(
@@ -961,7 +954,6 @@ mod tests {
       CacheSetting::Use,
       true,
       None,
-      true,
     )
     .expect("could not create file fetcher");
     let result = file_fetcher_02
@@ -1117,7 +1109,6 @@ mod tests {
       CacheSetting::Use,
       true,
       None,
-      true,
     )
     .expect("could not create file fetcher");
     let specifier = ModuleSpecifier::resolve_url(
@@ -1149,7 +1140,6 @@ mod tests {
       CacheSetting::Use,
       true,
       None,
-      true,
     )
     .expect("could not create file fetcher");
     let result = file_fetcher_02
@@ -1257,7 +1247,6 @@ mod tests {
       CacheSetting::Use,
       false,
       None,
-      true,
     )
     .expect("could not create file fetcher");
     let specifier = ModuleSpecifier::resolve_url(
@@ -1286,7 +1275,6 @@ mod tests {
       CacheSetting::Only,
       true,
       None,
-      true,
     )
     .expect("could not create file fetcher");
     let file_fetcher_02 = FileFetcher::new(
@@ -1294,7 +1282,6 @@ mod tests {
       CacheSetting::Use,
       true,
       None,
-      true,
     )
     .expect("could not create file fetcher");
     let specifier = ModuleSpecifier::resolve_url(

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -364,25 +364,25 @@ impl FileFetcher {
     specifier: &ModuleSpecifier,
     permissions: &Permissions,
     redirect_limit: i64,
-  ) -> Pin<Box<dyn Future<Output = Result<File, AnyError>>>> {
+  ) -> Pin<Box<dyn Future<Output = Result<File, AnyError>> + Send>> {
     debug!("FileFetcher::fetch_remote() - specifier: {}", specifier);
     if redirect_limit < 0 {
       return futures::future::err(custom_error("Http", "Too many redirects."))
-        .boxed_local();
+        .boxed();
     }
 
     if let Err(err) = permissions.check_specifier(specifier) {
-      return futures::future::err(err).boxed_local();
+      return futures::future::err(err).boxed();
     }
 
     if self.cache_setting.should_use(specifier) {
       match self.fetch_cached(specifier, redirect_limit) {
         Ok(Some(file)) => {
-          return futures::future::ok(file).boxed_local();
+          return futures::future::ok(file).boxed();
         }
         Ok(None) => {}
         Err(err) => {
-          return futures::future::err(err).boxed_local();
+          return futures::future::err(err).boxed();
         }
       }
     }
@@ -395,7 +395,7 @@ impl FileFetcher {
           specifier
         ),
       ))
-      .boxed_local();
+      .boxed();
     }
 
     info!("{} {}", colors::green("Download"), specifier);
@@ -436,7 +436,7 @@ impl FileFetcher {
         }
       }
     }
-    .boxed_local()
+    .boxed()
   }
 
   /// Fetch a source file and asynchronously return it.

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -276,6 +276,7 @@ pub struct FileFetcher {
   cache_setting: CacheSetting,
   http_cache: HttpCache,
   http_client: reqwest::Client,
+  use_color: bool,
 }
 
 impl FileFetcher {
@@ -284,6 +285,7 @@ impl FileFetcher {
     cache_setting: CacheSetting,
     allow_remote: bool,
     maybe_ca_file: Option<&str>,
+    use_color: bool,
   ) -> Result<Self, AnyError> {
     Ok(Self {
       allow_remote,
@@ -291,6 +293,7 @@ impl FileFetcher {
       cache_setting,
       http_cache,
       http_client: create_http_client(get_user_agent(), maybe_ca_file)?,
+      use_color,
     })
   }
 
@@ -398,7 +401,15 @@ impl FileFetcher {
       .boxed();
     }
 
-    info!("{} {}", colors::green("Download"), specifier);
+    info!(
+      "{} {}",
+      if self.use_color {
+        colors::green("Download").to_string()
+      } else {
+        "Download".to_string()
+      },
+      specifier
+    );
 
     let file_fetcher = self.clone();
     let cached_etag = match self.http_cache.get(specifier.as_url()) {
@@ -517,9 +528,14 @@ mod tests {
       Rc::new(TempDir::new().expect("failed to create temp directory"))
     });
     let location = temp_dir.path().join("deps");
-    let file_fetcher =
-      FileFetcher::new(HttpCache::new(&location), cache_setting, true, None)
-        .expect("setup failed");
+    let file_fetcher = FileFetcher::new(
+      HttpCache::new(&location),
+      cache_setting,
+      true,
+      None,
+      true,
+    )
+    .expect("setup failed");
     (file_fetcher, temp_dir)
   }
 
@@ -901,6 +917,7 @@ mod tests {
       CacheSetting::ReloadAll,
       true,
       None,
+      true,
     )
     .expect("setup failed");
     let result = file_fetcher
@@ -927,6 +944,7 @@ mod tests {
       CacheSetting::Use,
       true,
       None,
+      true,
     )
     .expect("could not create file fetcher");
     let specifier = ModuleSpecifier::resolve_url(
@@ -954,6 +972,7 @@ mod tests {
       CacheSetting::Use,
       true,
       None,
+      true,
     )
     .expect("could not create file fetcher");
     let result = file_fetcher_02
@@ -1109,6 +1128,7 @@ mod tests {
       CacheSetting::Use,
       true,
       None,
+      true,
     )
     .expect("could not create file fetcher");
     let specifier = ModuleSpecifier::resolve_url(
@@ -1140,6 +1160,7 @@ mod tests {
       CacheSetting::Use,
       true,
       None,
+      true,
     )
     .expect("could not create file fetcher");
     let result = file_fetcher_02
@@ -1247,6 +1268,7 @@ mod tests {
       CacheSetting::Use,
       false,
       None,
+      true,
     )
     .expect("could not create file fetcher");
     let specifier = ModuleSpecifier::resolve_url(
@@ -1275,6 +1297,7 @@ mod tests {
       CacheSetting::Only,
       true,
       None,
+      true,
     )
     .expect("could not create file fetcher");
     let file_fetcher_02 = FileFetcher::new(
@@ -1282,6 +1305,7 @@ mod tests {
       CacheSetting::Use,
       true,
       None,
+      true,
     )
     .expect("could not create file fetcher");
     let specifier = ModuleSpecifier::resolve_url(

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -60,6 +60,10 @@ impl DiagnosticCollection {
     self.versions.get(file_id).cloned()
   }
 
+  pub fn invalidate(&mut self, file_id: &FileId) {
+    self.versions.remove(file_id);
+  }
+
   pub fn take_changes(&mut self) -> Option<HashSet<FileId>> {
     if self.changes.is_empty() {
       return None;

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -9,8 +9,8 @@ use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::ModuleSpecifier;
 use dprint_plugin_typescript as dprint;
-use lspower::jsonrpc::Error as LSPError;
-use lspower::jsonrpc::Result as LSPResult;
+use lspower::jsonrpc::Error as LspError;
+use lspower::jsonrpc::Result as LspResult;
 use lspower::lsp_types::*;
 use lspower::Client;
 use std::collections::HashMap;
@@ -361,7 +361,7 @@ impl lspower::LanguageServer for LanguageServer {
   async fn initialize(
     &self,
     params: InitializeParams,
-  ) -> LSPResult<InitializeResult> {
+  ) -> LspResult<InitializeResult> {
     info!("Starting Deno language server...");
 
     let capabilities = capabilities::server_capabilities(&params.capabilities);
@@ -439,7 +439,7 @@ impl lspower::LanguageServer for LanguageServer {
     info!("Server ready.");
   }
 
-  async fn shutdown(&self) -> LSPResult<()> {
+  async fn shutdown(&self) -> LspResult<()> {
     Ok(())
   }
 
@@ -586,7 +586,7 @@ impl lspower::LanguageServer for LanguageServer {
   async fn formatting(
     &self,
     params: DocumentFormattingParams,
-  ) -> LSPResult<Option<Vec<TextEdit>>> {
+  ) -> LspResult<Option<Vec<TextEdit>>> {
     let specifier = utils::normalize_url(params.text_document.uri.clone());
     let file_text = {
       let file_cache = self.file_cache.read().unwrap();
@@ -631,7 +631,7 @@ impl lspower::LanguageServer for LanguageServer {
     }
   }
 
-  async fn hover(&self, params: HoverParams) -> LSPResult<Option<Hover>> {
+  async fn hover(&self, params: HoverParams) -> LspResult<Option<Hover>> {
     if !self.enabled() {
       return Ok(None);
     }
@@ -662,7 +662,7 @@ impl lspower::LanguageServer for LanguageServer {
   async fn document_highlight(
     &self,
     params: DocumentHighlightParams,
-  ) -> LSPResult<Option<Vec<DocumentHighlight>>> {
+  ) -> LspResult<Option<Vec<DocumentHighlight>>> {
     if !self.enabled() {
       return Ok(None);
     }
@@ -702,7 +702,7 @@ impl lspower::LanguageServer for LanguageServer {
   async fn references(
     &self,
     params: ReferenceParams,
-  ) -> LSPResult<Option<Vec<Location>>> {
+  ) -> LspResult<Option<Vec<Location>>> {
     if !self.enabled() {
       return Ok(None);
     }
@@ -743,7 +743,7 @@ impl lspower::LanguageServer for LanguageServer {
   async fn goto_definition(
     &self,
     params: GotoDefinitionParams,
-  ) -> LSPResult<Option<GotoDefinitionResponse>> {
+  ) -> LspResult<Option<GotoDefinitionResponse>> {
     if !self.enabled() {
       return Ok(None);
     }
@@ -779,7 +779,7 @@ impl lspower::LanguageServer for LanguageServer {
   async fn completion(
     &self,
     params: CompletionParams,
-  ) -> LSPResult<Option<CompletionResponse>> {
+  ) -> LspResult<Option<CompletionResponse>> {
     if !self.enabled() {
       return Ok(None);
     }
@@ -885,17 +885,17 @@ impl lspower::LanguageServer for LanguageServer {
     &self,
     method: &str,
     params: Option<Value>,
-  ) -> LSPResult<Option<Value>> {
+  ) -> LspResult<Option<Value>> {
     match method {
       "deno/cache" => match params.map(serde_json::from_value) {
         Some(Ok(params)) => Ok(Some(
           serde_json::to_value(self.cache(params).await?).map_err(|err| {
             error!("Failed to serialize cache response: {:#?}", err);
-            LSPError::internal_error()
+            LspError::internal_error()
           })?,
         )),
-        Some(Err(err)) => Err(LSPError::invalid_params(err.to_string())),
-        None => Err(LSPError::invalid_params("Missing parameters")),
+        Some(Err(err)) => Err(LspError::invalid_params(err.to_string())),
+        None => Err(LspError::invalid_params("Missing parameters")),
       },
       "deno/virtualTextDocument" => match params.map(serde_json::from_value) {
         Some(Ok(params)) => Ok(Some(
@@ -905,15 +905,15 @@ impl lspower::LanguageServer for LanguageServer {
                 "Failed to serialize virtual_text_document response: {:#?}",
                 err
               );
-              LSPError::internal_error()
+              LspError::internal_error()
             })?,
         )),
-        Some(Err(err)) => Err(LSPError::invalid_params(err.to_string())),
-        None => Err(LSPError::invalid_params("Missing parameters")),
+        Some(Err(err)) => Err(LspError::invalid_params(err.to_string())),
+        None => Err(LspError::invalid_params("Missing parameters")),
       },
       _ => {
         error!("Got a {} request, but no handler is defined", method);
-        Err(LSPError::method_not_found())
+        Err(LspError::method_not_found())
       }
     }
   }
@@ -932,22 +932,33 @@ pub struct VirtualTextDocumentParams {
 }
 
 impl LanguageServer {
-  async fn cache(&self, params: CacheParams) -> LSPResult<bool> {
+  async fn cache(&self, params: CacheParams) -> LspResult<bool> {
     let specifier = utils::normalize_url(params.text_document.uri);
     let maybe_import_map = self.maybe_import_map.read().unwrap().clone();
-    sources::cache(specifier, maybe_import_map)
+    sources::cache(specifier.clone(), maybe_import_map)
       .await
       .map_err(|err| {
         error!("{}", err);
-        LSPError::internal_error()
+        LspError::internal_error()
       })?;
+    {
+      let file_cache = self.file_cache.read().unwrap();
+      if let Some(file_id) = file_cache.lookup(&specifier) {
+        let mut diagnostics_collection = self.diagnostics.write().unwrap();
+        diagnostics_collection.invalidate(&file_id);
+      }
+    }
+    self.prepare_diagnostics().await.map_err(|err| {
+      error!("{}", err);
+      LspError::internal_error()
+    })?;
     Ok(true)
   }
 
   async fn virtual_text_document(
     &self,
     params: VirtualTextDocumentParams,
-  ) -> LSPResult<Option<String>> {
+  ) -> LspResult<Option<String>> {
     let specifier = utils::normalize_url(params.text_document.uri);
     let url = specifier.as_url();
     let contents = if url.as_str() == "deno:/status.md" {
@@ -967,7 +978,7 @@ impl LanguageServer {
           if let Some(text) =
             tsc::get_asset(&specifier, &self.ts_server, &state_snapshot)
               .await
-              .map_err(|_| LSPError::internal_error())?
+              .map_err(|_| LspError::internal_error())?
           {
             Some(text)
           } else {

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -812,7 +812,7 @@ impl lspower::LanguageServer for LanguageServer {
   async fn rename(
     &self,
     params: RenameParams,
-  ) -> LSPResult<Option<WorkspaceEdit>> {
+  ) -> LspResult<Option<WorkspaceEdit>> {
     if !self.enabled() {
       return Ok(None);
     }
@@ -827,7 +827,7 @@ impl lspower::LanguageServer for LanguageServer {
         .await
         .map_err(|err| {
           error!("Failed to get line_index {:#?}", err);
-          LSPError::internal_error()
+          LspError::internal_error()
         })?;
 
     let req = tsc::RequestMethod::FindRenameLocations((
@@ -844,7 +844,7 @@ impl lspower::LanguageServer for LanguageServer {
       .await
       .map_err(|err| {
         error!("Failed to request to tsserver {:#?}", err);
-        LSPError::invalid_request()
+        LspError::invalid_request()
       })?;
 
     let maybe_locations = serde_json::from_value::<
@@ -855,7 +855,7 @@ impl lspower::LanguageServer for LanguageServer {
         "Failed to deserialize tsserver response to Vec<RenameLocation> {:#?}",
         err
       );
-      LSPError::internal_error()
+      LspError::internal_error()
     })?;
 
     match maybe_locations {
@@ -873,7 +873,7 @@ impl lspower::LanguageServer for LanguageServer {
               "Failed to convert tsc::RenameLocations to WorkspaceEdit {:#?}",
               err
             );
-            LSPError::internal_error()
+            LspError::internal_error()
           })?;
         Ok(Some(workpace_edits))
       }

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -31,7 +31,7 @@ pub async fn cache(
   specifier: ModuleSpecifier,
   maybe_import_map: Option<ImportMap>,
 ) -> Result<(), AnyError> {
-  let program_state = Arc::new(ProgramState::new(Default::default())?);
+  let program_state = Arc::new(ProgramState::new(Default::default(), false)?);
   let handler = Arc::new(RwLock::new(FetchHandler::new(
     &program_state,
     Permissions::allow_all(),

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -10,15 +10,35 @@ use crate::http_cache;
 use crate::http_cache::HttpCache;
 use crate::import_map::ImportMap;
 use crate::media_type::MediaType;
+use crate::module_graph::GraphBuilder;
+use crate::program_state::ProgramState;
+use crate::specifier_handler::FetchHandler;
 use crate::text_encoding;
+use crate::Permissions;
 
+use deno_core::error::AnyError;
 use deno_core::serde_json;
 use deno_core::ModuleSpecifier;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::SystemTime;
+
+pub async fn cache(
+  specifier: ModuleSpecifier,
+  maybe_import_map: Option<ImportMap>,
+) -> Result<(), AnyError> {
+  let program_state = Arc::new(ProgramState::new(Default::default())?);
+  let handler = Arc::new(RwLock::new(FetchHandler::new(
+    &program_state,
+    Permissions::allow_all(),
+  )?));
+  let mut builder = GraphBuilder::new(handler, maybe_import_map, None);
+  builder.add(&specifier, false).await
+}
 
 #[derive(Debug, Clone, Default)]
 struct Metadata {

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -24,7 +24,7 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::RwLock;
+use std::sync::Mutex;
 use std::time::SystemTime;
 
 pub async fn cache(
@@ -32,7 +32,7 @@ pub async fn cache(
   maybe_import_map: Option<ImportMap>,
 ) -> Result<(), AnyError> {
   let program_state = Arc::new(ProgramState::new(Default::default())?);
-  let handler = Arc::new(RwLock::new(FetchHandler::new(
+  let handler = Arc::new(Mutex::new(FetchHandler::new(
     &program_state,
     Permissions::allow_all(),
   )?));

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -31,7 +31,7 @@ pub async fn cache(
   specifier: ModuleSpecifier,
   maybe_import_map: Option<ImportMap>,
 ) -> Result<(), AnyError> {
-  let program_state = Arc::new(ProgramState::new(Default::default(), false)?);
+  let program_state = Arc::new(ProgramState::new(Default::default())?);
   let handler = Arc::new(RwLock::new(FetchHandler::new(
     &program_state,
     Permissions::allow_all(),

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -303,7 +303,7 @@ async fn compile_command(
   let debug = flags.log_level == Some(log::Level::Debug);
 
   let module_specifier = ModuleSpecifier::resolve_url_or_path(&source_file)?;
-  let program_state = ProgramState::new(flags.clone())?;
+  let program_state = ProgramState::new(flags.clone(), true)?;
 
   let output = output.or_else(|| {
     infer_name_from_url(module_specifier.as_url()).map(PathBuf::from)
@@ -346,7 +346,7 @@ async fn info_command(
   if json && !flags.unstable {
     exit_unstable("--json");
   }
-  let program_state = ProgramState::new(flags)?;
+  let program_state = ProgramState::new(flags, true)?;
   if let Some(specifier) = maybe_specifier {
     let specifier = ModuleSpecifier::resolve_url_or_path(&specifier)?;
     let handler = Arc::new(RwLock::new(specifier_handler::FetchHandler::new(
@@ -388,7 +388,7 @@ async fn install_command(
   preload_flags.inspect = None;
   preload_flags.inspect_brk = None;
   let permissions = Permissions::from_options(&preload_flags.clone().into());
-  let program_state = ProgramState::new(preload_flags)?;
+  let program_state = ProgramState::new(preload_flags, true)?;
   let main_module = ModuleSpecifier::resolve_url_or_path(&module_url)?;
   let mut worker =
     create_main_worker(&program_state, main_module.clone(), permissions);
@@ -429,7 +429,7 @@ async fn cache_command(
   } else {
     module_graph::TypeLib::DenoWindow
   };
-  let program_state = ProgramState::new(flags)?;
+  let program_state = ProgramState::new(flags, true)?;
 
   for file in files {
     let specifier = ModuleSpecifier::resolve_url_or_path(&file)?;
@@ -457,7 +457,7 @@ async fn eval_command(
   let main_module =
     ModuleSpecifier::resolve_url_or_path("./$deno$eval.ts").unwrap();
   let permissions = Permissions::from_options(&flags.clone().into());
-  let program_state = ProgramState::new(flags)?;
+  let program_state = ProgramState::new(flags, true)?;
   let mut worker =
     create_main_worker(&program_state, main_module.clone(), permissions);
   let main_module_url = main_module.as_url().to_owned();
@@ -575,7 +575,7 @@ async fn bundle_command(
         ModuleSpecifier::resolve_url_or_path(&source_file1)?;
 
       debug!(">>>>> bundle START");
-      let program_state = ProgramState::new(flags.clone())?;
+      let program_state = ProgramState::new(flags.clone(), true)?;
 
       info!(
         "{} {}",
@@ -721,7 +721,7 @@ async fn doc_command(
   maybe_filter: Option<String>,
   private: bool,
 ) -> Result<(), AnyError> {
-  let program_state = ProgramState::new(flags.clone())?;
+  let program_state = ProgramState::new(flags.clone(), true)?;
   let source_file = source_file.unwrap_or_else(|| "--builtin".to_string());
 
   let loader = Box::new(DocLoader {
@@ -800,7 +800,7 @@ async fn run_repl(flags: Flags) -> Result<(), AnyError> {
   let main_module =
     ModuleSpecifier::resolve_url_or_path("./$deno$repl.ts").unwrap();
   let permissions = Permissions::from_options(&flags.clone().into());
-  let program_state = ProgramState::new(flags)?;
+  let program_state = ProgramState::new(flags, true)?;
   let mut worker =
     create_main_worker(&program_state, main_module.clone(), permissions);
   worker.run_event_loop().await?;
@@ -809,7 +809,7 @@ async fn run_repl(flags: Flags) -> Result<(), AnyError> {
 }
 
 async fn run_from_stdin(flags: Flags) -> Result<(), AnyError> {
-  let program_state = ProgramState::new(flags.clone())?;
+  let program_state = ProgramState::new(flags.clone(), true)?;
   let permissions = Permissions::from_options(&flags.clone().into());
   let main_module =
     ModuleSpecifier::resolve_url_or_path("./$deno$stdin.ts").unwrap();
@@ -849,7 +849,7 @@ async fn run_with_watch(flags: Flags, script: String) -> Result<(), AnyError> {
     let flags = flags.clone();
     async move {
       let main_module = ModuleSpecifier::resolve_url_or_path(&script1)?;
-      let program_state = ProgramState::new(flags)?;
+      let program_state = ProgramState::new(flags, true)?;
       let handler = Arc::new(RwLock::new(FetchHandler::new(
         &program_state,
         Permissions::allow_all(),
@@ -894,7 +894,7 @@ async fn run_with_watch(flags: Flags, script: String) -> Result<(), AnyError> {
     let permissions = Permissions::from_options(&flags.clone().into());
     async move {
       let main_module = main_module.clone();
-      let program_state = ProgramState::new(flags)?;
+      let program_state = ProgramState::new(flags, true)?;
       let mut worker =
         create_main_worker(&program_state, main_module.clone(), permissions);
       debug!("main_module {}", main_module);
@@ -926,7 +926,7 @@ async fn run_command(flags: Flags, script: String) -> Result<(), AnyError> {
   }
 
   let main_module = ModuleSpecifier::resolve_url_or_path(&script)?;
-  let program_state = ProgramState::new(flags.clone())?;
+  let program_state = ProgramState::new(flags.clone(), true)?;
   let permissions = Permissions::from_options(&flags.clone().into());
   let mut worker =
     create_main_worker(&program_state, main_module.clone(), permissions);
@@ -967,7 +967,7 @@ async fn test_command(
   allow_none: bool,
   filter: Option<String>,
 ) -> Result<(), AnyError> {
-  let program_state = ProgramState::new(flags.clone())?;
+  let program_state = ProgramState::new(flags.clone(), true)?;
   let permissions = Permissions::from_options(&flags.clone().into());
   let cwd = std::env::current_dir().expect("No current directory");
   let include = include.unwrap_or_else(|| vec![".".to_string()]);

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -303,7 +303,7 @@ async fn compile_command(
   let debug = flags.log_level == Some(log::Level::Debug);
 
   let module_specifier = ModuleSpecifier::resolve_url_or_path(&source_file)?;
-  let program_state = ProgramState::new(flags.clone(), true)?;
+  let program_state = ProgramState::new(flags.clone())?;
 
   let output = output.or_else(|| {
     infer_name_from_url(module_specifier.as_url()).map(PathBuf::from)
@@ -346,7 +346,7 @@ async fn info_command(
   if json && !flags.unstable {
     exit_unstable("--json");
   }
-  let program_state = ProgramState::new(flags, true)?;
+  let program_state = ProgramState::new(flags)?;
   if let Some(specifier) = maybe_specifier {
     let specifier = ModuleSpecifier::resolve_url_or_path(&specifier)?;
     let handler = Arc::new(RwLock::new(specifier_handler::FetchHandler::new(
@@ -388,7 +388,7 @@ async fn install_command(
   preload_flags.inspect = None;
   preload_flags.inspect_brk = None;
   let permissions = Permissions::from_options(&preload_flags.clone().into());
-  let program_state = ProgramState::new(preload_flags, true)?;
+  let program_state = ProgramState::new(preload_flags)?;
   let main_module = ModuleSpecifier::resolve_url_or_path(&module_url)?;
   let mut worker =
     create_main_worker(&program_state, main_module.clone(), permissions);
@@ -429,7 +429,7 @@ async fn cache_command(
   } else {
     module_graph::TypeLib::DenoWindow
   };
-  let program_state = ProgramState::new(flags, true)?;
+  let program_state = ProgramState::new(flags)?;
 
   for file in files {
     let specifier = ModuleSpecifier::resolve_url_or_path(&file)?;
@@ -457,7 +457,7 @@ async fn eval_command(
   let main_module =
     ModuleSpecifier::resolve_url_or_path("./$deno$eval.ts").unwrap();
   let permissions = Permissions::from_options(&flags.clone().into());
-  let program_state = ProgramState::new(flags, true)?;
+  let program_state = ProgramState::new(flags)?;
   let mut worker =
     create_main_worker(&program_state, main_module.clone(), permissions);
   let main_module_url = main_module.as_url().to_owned();
@@ -575,7 +575,7 @@ async fn bundle_command(
         ModuleSpecifier::resolve_url_or_path(&source_file1)?;
 
       debug!(">>>>> bundle START");
-      let program_state = ProgramState::new(flags.clone(), true)?;
+      let program_state = ProgramState::new(flags.clone())?;
 
       info!(
         "{} {}",
@@ -721,7 +721,7 @@ async fn doc_command(
   maybe_filter: Option<String>,
   private: bool,
 ) -> Result<(), AnyError> {
-  let program_state = ProgramState::new(flags.clone(), true)?;
+  let program_state = ProgramState::new(flags.clone())?;
   let source_file = source_file.unwrap_or_else(|| "--builtin".to_string());
 
   let loader = Box::new(DocLoader {
@@ -800,7 +800,7 @@ async fn run_repl(flags: Flags) -> Result<(), AnyError> {
   let main_module =
     ModuleSpecifier::resolve_url_or_path("./$deno$repl.ts").unwrap();
   let permissions = Permissions::from_options(&flags.clone().into());
-  let program_state = ProgramState::new(flags, true)?;
+  let program_state = ProgramState::new(flags)?;
   let mut worker =
     create_main_worker(&program_state, main_module.clone(), permissions);
   worker.run_event_loop().await?;
@@ -809,7 +809,7 @@ async fn run_repl(flags: Flags) -> Result<(), AnyError> {
 }
 
 async fn run_from_stdin(flags: Flags) -> Result<(), AnyError> {
-  let program_state = ProgramState::new(flags.clone(), true)?;
+  let program_state = ProgramState::new(flags.clone())?;
   let permissions = Permissions::from_options(&flags.clone().into());
   let main_module =
     ModuleSpecifier::resolve_url_or_path("./$deno$stdin.ts").unwrap();
@@ -849,7 +849,7 @@ async fn run_with_watch(flags: Flags, script: String) -> Result<(), AnyError> {
     let flags = flags.clone();
     async move {
       let main_module = ModuleSpecifier::resolve_url_or_path(&script1)?;
-      let program_state = ProgramState::new(flags, true)?;
+      let program_state = ProgramState::new(flags)?;
       let handler = Arc::new(RwLock::new(FetchHandler::new(
         &program_state,
         Permissions::allow_all(),
@@ -894,7 +894,7 @@ async fn run_with_watch(flags: Flags, script: String) -> Result<(), AnyError> {
     let permissions = Permissions::from_options(&flags.clone().into());
     async move {
       let main_module = main_module.clone();
-      let program_state = ProgramState::new(flags, true)?;
+      let program_state = ProgramState::new(flags)?;
       let mut worker =
         create_main_worker(&program_state, main_module.clone(), permissions);
       debug!("main_module {}", main_module);
@@ -926,7 +926,7 @@ async fn run_command(flags: Flags, script: String) -> Result<(), AnyError> {
   }
 
   let main_module = ModuleSpecifier::resolve_url_or_path(&script)?;
-  let program_state = ProgramState::new(flags.clone(), true)?;
+  let program_state = ProgramState::new(flags.clone())?;
   let permissions = Permissions::from_options(&flags.clone().into());
   let mut worker =
     create_main_worker(&program_state, main_module.clone(), permissions);
@@ -967,7 +967,7 @@ async fn test_command(
   allow_none: bool,
   filter: Option<String>,
 ) -> Result<(), AnyError> {
-  let program_state = ProgramState::new(flags.clone(), true)?;
+  let program_state = ProgramState::new(flags.clone())?;
   let permissions = Permissions::from_options(&flags.clone().into());
   let cwd = std::env::current_dir().expect("No current directory");
   let include = include.unwrap_or_else(|| vec![".".to_string()]);

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -84,7 +84,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::sync::RwLock;
+use std::sync::Mutex;
 
 fn create_web_worker_callback(
   program_state: Arc<ProgramState>,
@@ -349,7 +349,7 @@ async fn info_command(
   let program_state = ProgramState::new(flags)?;
   if let Some(specifier) = maybe_specifier {
     let specifier = ModuleSpecifier::resolve_url_or_path(&specifier)?;
-    let handler = Arc::new(RwLock::new(specifier_handler::FetchHandler::new(
+    let handler = Arc::new(Mutex::new(specifier_handler::FetchHandler::new(
       &program_state,
       // info accesses dynamically imported modules just for their information
       // so we allow access to all of them.
@@ -497,7 +497,7 @@ async fn create_module_graph_and_maybe_check(
   program_state: Arc<ProgramState>,
   debug: bool,
 ) -> Result<module_graph::Graph, AnyError> {
-  let handler = Arc::new(RwLock::new(FetchHandler::new(
+  let handler = Arc::new(Mutex::new(FetchHandler::new(
     &program_state,
     // when bundling, dynamic imports are only access for their type safety,
     // therefore we will allow the graph to access any module.
@@ -850,7 +850,7 @@ async fn run_with_watch(flags: Flags, script: String) -> Result<(), AnyError> {
     async move {
       let main_module = ModuleSpecifier::resolve_url_or_path(&script1)?;
       let program_state = ProgramState::new(flags)?;
-      let handler = Arc::new(RwLock::new(FetchHandler::new(
+      let handler = Arc::new(Mutex::new(FetchHandler::new(
         &program_state,
         Permissions::allow_all(),
       )?));

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -76,7 +76,6 @@ use deno_runtime::worker::MainWorker;
 use deno_runtime::worker::WorkerOptions;
 use log::Level;
 use log::LevelFilter;
-use std::cell::RefCell;
 use std::env;
 use std::io::Read;
 use std::io::Write;
@@ -85,6 +84,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::sync::RwLock;
 
 fn create_web_worker_callback(
   program_state: Arc<ProgramState>,
@@ -349,7 +349,7 @@ async fn info_command(
   let program_state = ProgramState::new(flags)?;
   if let Some(specifier) = maybe_specifier {
     let specifier = ModuleSpecifier::resolve_url_or_path(&specifier)?;
-    let handler = Rc::new(RefCell::new(specifier_handler::FetchHandler::new(
+    let handler = Arc::new(RwLock::new(specifier_handler::FetchHandler::new(
       &program_state,
       // info accesses dynamically imported modules just for their information
       // so we allow access to all of them.
@@ -497,7 +497,7 @@ async fn create_module_graph_and_maybe_check(
   program_state: Arc<ProgramState>,
   debug: bool,
 ) -> Result<module_graph::Graph, AnyError> {
-  let handler = Rc::new(RefCell::new(FetchHandler::new(
+  let handler = Arc::new(RwLock::new(FetchHandler::new(
     &program_state,
     // when bundling, dynamic imports are only access for their type safety,
     // therefore we will allow the graph to access any module.
@@ -850,7 +850,7 @@ async fn run_with_watch(flags: Flags, script: String) -> Result<(), AnyError> {
     async move {
       let main_module = ModuleSpecifier::resolve_url_or_path(&script1)?;
       let program_state = ProgramState::new(flags)?;
-      let handler = Rc::new(RefCell::new(FetchHandler::new(
+      let handler = Arc::new(RwLock::new(FetchHandler::new(
         &program_state,
         Permissions::allow_all(),
       )?));

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -27,7 +27,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::sync::RwLock;
+use std::sync::Mutex;
 
 pub fn init(rt: &mut deno_core::JsRuntime) {
   super::reg_json_async(rt, "op_compile", op_compile);
@@ -59,11 +59,11 @@ async fn op_compile(
     let state = state.borrow();
     state.borrow::<Permissions>().clone()
   };
-  let handler: Arc<RwLock<dyn SpecifierHandler>> =
+  let handler: Arc<Mutex<dyn SpecifierHandler>> =
     if let Some(sources) = args.sources {
-      Arc::new(RwLock::new(MemoryHandler::new(sources)))
+      Arc::new(Mutex::new(MemoryHandler::new(sources)))
     } else {
-      Arc::new(RwLock::new(FetchHandler::new(
+      Arc::new(Mutex::new(FetchHandler::new(
         &program_state,
         runtime_permissions,
       )?))

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -11,8 +11,6 @@ use crate::specifier_handler::FetchHandler;
 use crate::specifier_handler::MemoryHandler;
 use crate::specifier_handler::SpecifierHandler;
 use crate::tsc_config;
-use deno_runtime::permissions::Permissions;
-use std::sync::Arc;
 
 use deno_core::error::AnyError;
 use deno_core::error::Context;
@@ -23,10 +21,13 @@ use deno_core::serde_json::Value;
 use deno_core::BufVec;
 use deno_core::ModuleSpecifier;
 use deno_core::OpState;
+use deno_runtime::permissions::Permissions;
 use serde::Deserialize;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::RwLock;
 
 pub fn init(rt: &mut deno_core::JsRuntime) {
   super::reg_json_async(rt, "op_compile", op_compile);
@@ -58,11 +59,11 @@ async fn op_compile(
     let state = state.borrow();
     state.borrow::<Permissions>().clone()
   };
-  let handler: Rc<RefCell<dyn SpecifierHandler>> =
+  let handler: Arc<RwLock<dyn SpecifierHandler>> =
     if let Some(sources) = args.sources {
-      Rc::new(RefCell::new(MemoryHandler::new(sources)))
+      Arc::new(RwLock::new(MemoryHandler::new(sources)))
     } else {
-      Rc::new(RefCell::new(FetchHandler::new(
+      Arc::new(RwLock::new(FetchHandler::new(
         &program_state,
         runtime_permissions,
       )?))

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -23,12 +23,11 @@ use deno_core::error::AnyError;
 use deno_core::url::Url;
 use deno_core::ModuleSource;
 use deno_core::ModuleSpecifier;
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::env;
-use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::RwLock;
 
 pub fn exit_unstable(api_name: &str) {
   eprintln!(
@@ -144,7 +143,7 @@ impl ProgramState {
       runtime_permissions.check_specifier(&specifier)?;
     }
     let handler =
-      Rc::new(RefCell::new(FetchHandler::new(self, runtime_permissions)?));
+      Arc::new(RwLock::new(FetchHandler::new(self, runtime_permissions)?));
     let mut builder =
       GraphBuilder::new(handler, maybe_import_map, self.lockfile.clone());
     builder.add(&specifier, is_dynamic).await?;

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -54,7 +54,10 @@ pub struct ProgramState {
 }
 
 impl ProgramState {
-  pub fn new(flags: flags::Flags) -> Result<Arc<Self>, AnyError> {
+  pub fn new(
+    flags: flags::Flags,
+    use_color: bool,
+  ) -> Result<Arc<Self>, AnyError> {
     let custom_root = env::var("DENO_DIR").map(String::into).ok();
     let dir = deno_dir::DenoDir::new(custom_root)?;
     let deps_cache_location = dir.root.join("deps");
@@ -76,6 +79,7 @@ impl ProgramState {
       cache_usage,
       !flags.no_remote,
       ca_file.as_deref(),
+      use_color,
     )?;
 
     let lockfile = if let Some(filename) = &flags.lock {
@@ -275,10 +279,13 @@ impl ProgramState {
     argv: Vec<String>,
     maybe_flags: Option<flags::Flags>,
   ) -> Arc<ProgramState> {
-    ProgramState::new(flags::Flags {
-      argv,
-      ..maybe_flags.unwrap_or_default()
-    })
+    ProgramState::new(
+      flags::Flags {
+        argv,
+        ..maybe_flags.unwrap_or_default()
+      },
+      true,
+    )
     .unwrap()
   }
 }

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -56,7 +56,6 @@ pub struct ProgramState {
 impl ProgramState {
   pub fn new(
     flags: flags::Flags,
-    use_color: bool,
   ) -> Result<Arc<Self>, AnyError> {
     let custom_root = env::var("DENO_DIR").map(String::into).ok();
     let dir = deno_dir::DenoDir::new(custom_root)?;
@@ -79,7 +78,6 @@ impl ProgramState {
       cache_usage,
       !flags.no_remote,
       ca_file.as_deref(),
-      use_color,
     )?;
 
     let lockfile = if let Some(filename) = &flags.lock {

--- a/cli/specifier_handler.rs
+++ b/cli/specifier_handler.rs
@@ -592,6 +592,7 @@ pub mod tests {
       CacheSetting::Use,
       true,
       None,
+      true,
     )
     .expect("could not setup");
     let disk_cache = deno_dir.gen_cache;

--- a/cli/specifier_handler.rs
+++ b/cli/specifier_handler.rs
@@ -592,7 +592,6 @@ pub mod tests {
       CacheSetting::Use,
       true,
       None,
-      true,
     )
     .expect("could not setup");
     let disk_cache = deno_dir.gen_cache;

--- a/cli/specifier_handler.rs
+++ b/cli/specifier_handler.rs
@@ -28,7 +28,8 @@ pub type DependencyMap = HashMap<String, Dependency>;
 pub type FetchFuture = Pin<
   Box<
     (dyn Future<Output = Result<CachedModule, (ModuleSpecifier, AnyError)>>
-       + 'static),
+       + 'static
+       + Send),
   >,
 >;
 
@@ -129,7 +130,7 @@ impl Dependency {
   }
 }
 
-pub trait SpecifierHandler {
+pub trait SpecifierHandler: Sync + Send {
   /// Instructs the handler to fetch a specifier or retrieve its value from the
   /// cache.
   fn fetch(
@@ -361,7 +362,7 @@ impl SpecifierHandler for FetchHandler {
         specifier: source_file.specifier,
       })
     }
-    .boxed_local()
+    .boxed()
   }
 
   fn get_tsbuildinfo(

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -23,7 +23,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::RwLock;
+use std::sync::Mutex;
 
 /// Provide static assets that are not preloaded in the compiler snapshot.
 pub fn get_asset(asset: &str) -> Option<&'static str> {
@@ -115,7 +115,7 @@ pub struct Request {
   pub config: TsConfig,
   /// Indicates to the tsc runtime if debug logging should occur.
   pub debug: bool,
-  pub graph: Arc<RwLock<Graph>>,
+  pub graph: Arc<Mutex<Graph>>,
   pub hash_data: Vec<Vec<u8>>,
   pub maybe_tsbuildinfo: Option<String>,
   /// A vector of strings that represent the root/entry point modules for the
@@ -138,7 +138,7 @@ pub struct Response {
 struct State {
   hash_data: Vec<Vec<u8>>,
   emitted_files: Vec<EmittedFile>,
-  graph: Arc<RwLock<Graph>>,
+  graph: Arc<Mutex<Graph>>,
   maybe_tsbuildinfo: Option<String>,
   maybe_response: Option<RespondArgs>,
   root_map: HashMap<String, ModuleSpecifier>,
@@ -146,7 +146,7 @@ struct State {
 
 impl State {
   pub fn new(
-    graph: Arc<RwLock<Graph>>,
+    graph: Arc<Mutex<Graph>>,
     hash_data: Vec<Vec<u8>>,
     maybe_tsbuildinfo: Option<String>,
     root_map: HashMap<String, ModuleSpecifier>,
@@ -260,7 +260,7 @@ fn load(state: &mut State, args: Value) -> Result<Value, AnyError> {
     media_type = MediaType::from(&v.specifier);
     maybe_source
   } else {
-    let graph = state.graph.read().unwrap();
+    let graph = state.graph.lock().unwrap();
     let specifier =
       if let Some(remapped_specifier) = state.root_map.get(&v.specifier) {
         remapped_specifier.clone()
@@ -310,7 +310,7 @@ fn resolve(state: &mut State, args: Value) -> Result<Value, AnyError> {
         MediaType::from(specifier).as_ts_extension().to_string(),
       ));
     } else {
-      let graph = state.graph.read().unwrap();
+      let graph = state.graph.lock().unwrap();
       match graph.resolve(specifier, &referrer, true) {
         Ok(resolved_specifier) => {
           let media_type = if let Some(media_type) =
@@ -448,7 +448,7 @@ mod tests {
   use crate::tsc_config::TsConfig;
   use std::env;
   use std::path::PathBuf;
-  use std::sync::RwLock;
+  use std::sync::Mutex;
 
   async fn setup(
     maybe_specifier: Option<ModuleSpecifier>,
@@ -461,7 +461,7 @@ mod tests {
     let hash_data = maybe_hash_data.unwrap_or_else(|| vec![b"".to_vec()]);
     let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let fixtures = c.join("tests/tsc2");
-    let handler = Arc::new(RwLock::new(MockSpecifierHandler {
+    let handler = Arc::new(Mutex::new(MockSpecifierHandler {
       fixtures,
       ..MockSpecifierHandler::default()
     }));
@@ -470,7 +470,7 @@ mod tests {
       .add(&specifier, false)
       .await
       .expect("module not inserted");
-    let graph = Arc::new(RwLock::new(builder.get_graph()));
+    let graph = Arc::new(Mutex::new(builder.get_graph()));
     State::new(graph, hash_data, maybe_tsbuildinfo, HashMap::new())
   }
 
@@ -480,13 +480,13 @@ mod tests {
     let hash_data = vec![b"something".to_vec()];
     let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let fixtures = c.join("tests/tsc2");
-    let handler = Arc::new(RwLock::new(MockSpecifierHandler {
+    let handler = Arc::new(Mutex::new(MockSpecifierHandler {
       fixtures,
       ..Default::default()
     }));
     let mut builder = GraphBuilder::new(handler.clone(), None, None);
     builder.add(&specifier, false).await?;
-    let graph = Arc::new(RwLock::new(builder.get_graph()));
+    let graph = Arc::new(Mutex::new(builder.get_graph()));
     let config = TsConfig::new(json!({
       "allowJs": true,
       "checkJs": false,


### PR DESCRIPTION
This adds a command to allow caching of files in the lsp.  For example in VSCode, a command can be created that will effectively do a `deno cache` on the currently open file, fetching all of its dependencies, including using any import map that is configured for the project.

![_Extension_Development_Host__-_mod_ts_—_plugin_test_workspace_and_commands_ts_—_vscode_deno](https://user-images.githubusercontent.com/1282577/103254678-63250200-49da-11eb-82cc-58dbf4105d1d.png)

There are a couple things that need to be done with the PR, before landing but raising for visibility.
