### PR TITLE
fix(core/error) Fix incorrect index in Promise.all error reporting

### DIFF
--- a/cli/tests/error_024_stack_promise_all.ts
+++ b/cli/tests/error_024_stack_promise_all.ts
@@ -1,4 +1,5 @@
 const p = Promise.all([
+  Promise.resolve(),
   (async (): Promise<never> => {
     await Promise.resolve();
     throw new Error("Promise.all()");

--- a/cli/tests/error_024_stack_promise_all.ts.out
+++ b/cli/tests/error_024_stack_promise_all.ts.out
@@ -1,8 +1,8 @@
 [WILDCARD]Error: Promise.all()
     at [WILDCARD]tests/error_024_stack_promise_all.ts:[WILDCARD]
-    at async Promise.all (index 0)
+    at async Promise.all (index 1)
     at async [WILDCARD]tests/error_024_stack_promise_all.ts:[WILDCARD]
 error: Uncaught Error: Promise.all()
     at [WILDCARD]tests/error_024_stack_promise_all.ts:[WILDCARD]
-    at async Promise.all (index 0)
+    at async Promise.all (index 1)
     at async [WILDCARD]tests/error_024_stack_promise_all.ts:[WILDCARD]

--- a/core/error.rs
+++ b/core/error.rs
@@ -293,7 +293,7 @@ impl JsError {
               .unwrap();
           let is_promise_all = is_promise_all.is_true();
           let promise_index: Option<v8::Local<v8::Integer>> =
-            get_property(scope, call_site, "columnNumber")
+            get_property(scope, call_site, "promiseIndex")
               .unwrap()
               .try_into()
               .ok();


### PR DESCRIPTION
fixes #8871

There was a small bug where we were reporting the wrong index for the failing promise in a `Promise.all` call.
The `error_024_stack_promise_all` test was not robust enough to catch this (more details in #8871).

This PR fixes the bug and updates the test so that the failing promise is at index 1 instead of 0.
