### PR TITLE
fix(op_crates/fetch): correct regexp for fetch header

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -251,6 +251,27 @@ unitTest(
 
 unitTest(
   { perms: { net: true } },
+  async function fetchMultipartFormBadContentType(): Promise<void> {
+    const response = await fetch(
+      "http://localhost:4545/multipart_form_bad_content_type",
+    );
+    assert(response.body !== null);
+
+    try {
+      const formData = await response.formData();
+      fail(
+        "Response.formData() didn't throw on a incorrect multipart content type",
+      );
+    } catch (e) {
+      assertEquals(e.message, "Invalid form data");
+      assert(e instanceof TypeError);
+    }
+    await response.body.cancel();
+  },
+);
+
+unitTest(
+  { perms: { net: true } },
   async function fetchURLEncodedFormDataSuccess(): Promise<void> {
     const response = await fetch(
       "http://localhost:4545/cli/tests/subdir/form_urlencoded.txt",

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -257,15 +257,13 @@ unitTest(
     );
     assert(response.body !== null);
 
-    try {
-      const formData = await response.formData();
-      fail(
-        "Response.formData() didn't throw on a incorrect multipart content type",
-      );
-    } catch (e) {
-      assertEquals(e.message, "Invalid form data");
-      assert(e instanceof TypeError);
-    }
+    await assertThrowsAsync(
+      async (): Promise<void> => {
+        await response.formData();
+      },
+      TypeError,
+      "Invalid form data",
+    );
     await response.body.cancel();
   },
 );

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -138,7 +138,7 @@
   }
 
   function hasHeaderValueOf(s, value) {
-    return new RegExp(`^${value}[\t\s]*;?`).test(s);
+    return new RegExp(`^${value}(?:[\\s;]|$)`).test(s);
   }
 
   function getHeaderValueParams(value) {

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -391,6 +391,27 @@ async fn main_server(req: Request<Body>) -> hyper::Result<Response<Body>> {
       );
       Ok(res)
     }
+    (_, "/multipart_form_bad_content_type") => {
+      let b = "Preamble\r\n\
+             --boundary\t \r\n\
+             Content-Disposition: form-data; name=\"field_1\"\r\n\
+             \r\n\
+             value_1 \r\n\
+             \r\n--boundary\r\n\
+             Content-Disposition: form-data; name=\"field_2\";\
+             filename=\"file.js\"\r\n\
+             Content-Type: text/javascript\r\n\
+             \r\n\
+             console.log(\"Hi\")\
+             \r\n--boundary--\r\n\
+             Epilogue";
+      let mut res = Response::new(Body::from(b));
+      res.headers_mut().insert(
+        "content-type",
+        HeaderValue::from_static("multipart/form-datatststs;boundary=boundary"),
+      );
+      Ok(res)
+    }
     (_, "/bad_redirect") => {
       let mut res = Response::new(Body::empty());
       *res.status_mut() = StatusCode::FOUND;


### PR DESCRIPTION
Fix bug in regular expression and make the regular expression more
strict.

In a string passed to new RegExp(), '[\t\s]' is identical to '[ts]' and
not `/[\t\s]/`. For that, the backslash needs to be escaped in the
string. Futhermore, `\t` is the tab character and is included in the
special regexp value `\s` so is unnecessary.

That would reduce the RegExp to new RegExp(`^${value}\\s*;?`) but
there's no point in matching 0 or more space characters followed by 0 or
one semi-colons as that will match no matter what follows `value`.

To make it more strict, require one of space, semicolon, or
end-of-string after value.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
