### PR TITLE
docs: Update instructions on how to setup development environment with Vim/Neovim

### DIFF
--- a/docs/getting_started/setup_your_environment.md
+++ b/docs/getting_started/setup_your_environment.md
@@ -182,7 +182,12 @@ if executable("deno")
     \ "name": "deno lsp",
     \ "cmd": {server_info -> ["deno", "lsp"]},
     \ "root_uri": {server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), "tsconfig.json"))},
-    \ "whitelist": ["typescript", "typescript.tsx"],
+    \ "allowlist": ["typescript", "typescript.tsx"],
+    \ "initialization_options": {
+    \     "enable": v:true,
+    \     "lint": v:true,
+    \     "unstable": v:true,
+    \   },
     \ })
   augroup END
 endif


### PR DESCRIPTION
The setup instructions for Vim/Neovim worked with Deno v1.6.0, but not with v1.6.2. :cry: This PR fixes the documentation so that it also works with Deno v1.6.2.