### PR TITLE
feat: CLI features don't require --unstable flag

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1285,7 +1285,7 @@ fn test_subcommand<'a, 'b>() -> App<'a, 'b> {
       Arg::with_name("no-run")
         .long("no-run")
         .help("Cache test modules, but don't run tests")
-        .takes_value(false)
+        .takes_value(false),
     )
     .arg(
       Arg::with_name("fail-fast")

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -341,7 +341,7 @@ fn clap_root<'a, 'b>(version: &'b str) -> App<'a, 'b> {
     .arg(
       Arg::with_name("unstable")
         .long("unstable")
-        .help("Enable unstable features and APIs")
+        .help("Enable unstable APIs")
         .global(true),
     )
     .arg(
@@ -787,7 +787,7 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
         .takes_value(true)
         .use_delimiter(true)
         .require_equals(true)
-        .help("Ignore formatting particular source files. Use with --unstable"),
+        .help("Ignore formatting particular source files."),
     )
     .arg(
       Arg::with_name("files")
@@ -875,8 +875,8 @@ fn compile_subcommand<'a, 'b>() -> App<'a, 'b> {
     .about("Compile the script into a self contained executable")
     .long_about(
       "Compiles the given script into a self contained executable.
-  deno compile --unstable https://deno.land/std/http/file_server.ts
-  deno compile --unstable --output /usr/local/bin/color_util https://deno.land/std/examples/colors.ts
+  deno compile https://deno.land/std/http/file_server.ts
+  deno compile --output /usr/local/bin/color_util https://deno.land/std/examples/colors.ts
 
 The executable name is inferred by default:
   - Attempt to take the file stem of the URL path. The above example would
@@ -1134,18 +1134,18 @@ fn lint_subcommand<'a, 'b>() -> App<'a, 'b> {
     .about("Lint source files")
     .long_about(
       "Lint JavaScript/TypeScript source code.
-  deno lint --unstable
-  deno lint --unstable myfile1.ts myfile2.js
+  deno lint
+  deno lint myfile1.ts myfile2.js
 
 Print result as JSON:
-  deno lint --unstable --json
+  deno lint --json
 
 Read from stdin:
-  cat file.ts | deno lint --unstable -
-  cat file.ts | deno lint --unstable --json -
+  cat file.ts | deno lint -
+  cat file.ts | deno lint --json -
 
 List available rules:
-  deno lint --unstable --rules
+  deno lint --rules
 
 Ignore diagnostics on the next line by preceding it with an ignore comment and
 rule name:
@@ -1167,7 +1167,6 @@ Ignore linting a file by adding an ignore comment at the top of the file:
     .arg(
       Arg::with_name("ignore")
         .long("ignore")
-        .requires("unstable")
         .takes_value(true)
         .use_delimiter(true)
         .require_equals(true)
@@ -1287,7 +1286,6 @@ fn test_subcommand<'a, 'b>() -> App<'a, 'b> {
         .long("no-run")
         .help("Cache test modules, but don't run tests")
         .takes_value(false)
-        .requires("unstable"),
     )
     .arg(
       Arg::with_name("fail-fast")
@@ -1316,7 +1314,6 @@ fn test_subcommand<'a, 'b>() -> App<'a, 'b> {
         .max_values(1)
         .require_equals(true)
         .takes_value(true)
-        .requires("unstable")
         .conflicts_with("inspect")
         .conflicts_with("inspect-brk")
         .help("Collect coverage information"),
@@ -1493,11 +1490,9 @@ fn import_map_arg<'a, 'b>() -> Arg<'a, 'b> {
     .long("import-map")
     .alias("importmap")
     .value_name("FILE")
-    .requires("unstable")
-    .help("UNSTABLE: Load import map file")
+    .help("Load import map file")
     .long_help(
-      "UNSTABLE:
-Load import map file
+      "Load import map file
 Docs: https://deno.land/manual/linking_to_external_code/import_maps
 Specification: https://wicg.github.io/import-maps/
 Examples: https://github.com/WICG/import-maps#the-import-map",
@@ -1526,7 +1521,6 @@ fn v8_flags_arg_parse(flags: &mut Flags, matches: &ArgMatches) {
 
 fn watch_arg<'a, 'b>() -> Arg<'a, 'b> {
   Arg::with_name("watch")
-    .requires("unstable")
     .long("watch")
     .help("Watch for file changes and restart process automatically")
     .long_help(

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -2003,13 +2003,8 @@ mod tests {
 
   #[test]
   fn lint() {
-    let r = flags_from_vec_safe(svec![
-      "deno",
-      "lint",
-      "--unstable",
-      "script_1.ts",
-      "script_2.ts"
-    ]);
+    let r =
+      flags_from_vec_safe(svec!["deno", "lint", "script_1.ts", "script_2.ts"]);
     assert_eq!(
       r.unwrap(),
       Flags {
@@ -2022,7 +2017,6 @@ mod tests {
           json: false,
           ignore: vec![],
         },
-        unstable: true,
         ..Flags::default()
       }
     );
@@ -2030,7 +2024,6 @@ mod tests {
     let r = flags_from_vec_safe(svec![
       "deno",
       "lint",
-      "--unstable",
       "--ignore=script_1.ts,script_2.ts"
     ]);
     assert_eq!(
@@ -2045,12 +2038,11 @@ mod tests {
             PathBuf::from("script_2.ts")
           ],
         },
-        unstable: true,
         ..Flags::default()
       }
     );
 
-    let r = flags_from_vec_safe(svec!["deno", "lint", "--unstable", "--rules"]);
+    let r = flags_from_vec_safe(svec!["deno", "lint", "--rules"]);
     assert_eq!(
       r.unwrap(),
       Flags {
@@ -2060,18 +2052,11 @@ mod tests {
           json: false,
           ignore: vec![],
         },
-        unstable: true,
         ..Flags::default()
       }
     );
 
-    let r = flags_from_vec_safe(svec![
-      "deno",
-      "lint",
-      "--unstable",
-      "--json",
-      "script_1.ts"
-    ]);
+    let r = flags_from_vec_safe(svec!["deno", "lint", "--json", "script_1.ts"]);
     assert_eq!(
       r.unwrap(),
       Flags {
@@ -2081,7 +2066,6 @@ mod tests {
           json: true,
           ignore: vec![],
         },
-        unstable: true,
         ..Flags::default()
       }
     );

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -52,7 +52,6 @@ use crate::fmt_errors::PrettyJsError;
 use crate::import_map::ImportMap;
 use crate::media_type::MediaType;
 use crate::module_loader::CliModuleLoader;
-use crate::program_state::exit_unstable;
 use crate::program_state::ProgramState;
 use crate::source_maps::apply_source_map;
 use crate::specifier_handler::FetchHandler;
@@ -395,7 +394,7 @@ async fn language_server_command() -> Result<(), AnyError> {
 }
 
 async fn lint_command(
-  flags: Flags,
+  _flags: Flags,
   files: Vec<PathBuf>,
   list_rules: bool,
   ignore: Vec<PathBuf>,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -296,10 +296,6 @@ async fn compile_command(
   source_file: String,
   output: Option<PathBuf>,
 ) -> Result<(), AnyError> {
-  if !flags.unstable {
-    exit_unstable("compile");
-  }
-
   let debug = flags.log_level == Some(log::Level::Debug);
 
   let module_specifier = ModuleSpecifier::resolve_url_or_path(&source_file)?;
@@ -343,9 +339,6 @@ async fn info_command(
   maybe_specifier: Option<String>,
   json: bool,
 ) -> Result<(), AnyError> {
-  if json && !flags.unstable {
-    exit_unstable("--json");
-  }
   let program_state = ProgramState::new(flags)?;
   if let Some(specifier) = maybe_specifier {
     let specifier = ModuleSpecifier::resolve_url_or_path(&specifier)?;
@@ -408,10 +401,6 @@ async fn lint_command(
   ignore: Vec<PathBuf>,
   json: bool,
 ) -> Result<(), AnyError> {
-  if !flags.unstable {
-    exit_unstable("lint");
-  }
-
   if list_rules {
     tools::lint::print_rules_list(json);
     return Ok(());

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -988,6 +988,10 @@ async fn test_command(
   program_state.file_fetcher.insert_cached(source_file);
 
   if no_run {
+    eprintln!(
+      "{} deno test --no-run is unstable feature",
+      crate::colors::yellow("Warning")
+    );
     let lib = if flags.unstable {
       module_graph::TypeLib::UnstableDenoWindow
     } else {

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -28,14 +28,6 @@ use std::env;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-pub fn exit_unstable(api_name: &str) {
-  eprintln!(
-    "Unstable API '{}'. The --unstable flag must be provided.",
-    api_name
-  );
-  std::process::exit(70);
-}
-
 /// This structure represents state of single "deno" program.
 ///
 /// It is shared by all created workers (thus V8 isolates).
@@ -87,9 +79,7 @@ impl ProgramState {
     let maybe_import_map: Option<ImportMap> =
       match flags.import_map_path.as_ref() {
         None => None,
-        Some(file_path) => {
-          Some(ImportMap::load(file_path)?)
-        }
+        Some(file_path) => Some(ImportMap::load(file_path)?),
       };
 
     let maybe_inspect_host = flags.inspect.or(flags.inspect_brk);

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -79,7 +79,13 @@ impl ProgramState {
     let maybe_import_map: Option<ImportMap> =
       match flags.import_map_path.as_ref() {
         None => None,
-        Some(file_path) => Some(ImportMap::load(file_path)?),
+        Some(file_path) => {
+          eprintln!(
+            "{} Import map is unstable feature",
+            crate::colors::yellow("Warning")
+          );
+          Some(ImportMap::load(file_path)?)
+        }
       };
 
     let maybe_inspect_host = flags.inspect.or(flags.inspect_brk);

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -88,9 +88,6 @@ impl ProgramState {
       match flags.import_map_path.as_ref() {
         None => None,
         Some(file_path) => {
-          if !flags.unstable {
-            exit_unstable("--import-map")
-          }
           Some(ImportMap::load(file_path)?)
         }
       };

--- a/cli/tests/import_map_no_unstable.out
+++ b/cli/tests/import_map_no_unstable.out
@@ -1,1 +1,0 @@
-Unstable API '--import-map'. The --unstable flag must be provided.

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2537,7 +2537,7 @@ fn _066_prompt() {
 }
 
 itest!(_067_test_no_run_type_error {
-  args: "test --unstable --no-run test_type_error",
+  args: "test --no-run test_type_error",
   output: "067_test_no_run_type_error.out",
   exit_code: 1,
 });
@@ -2560,7 +2560,7 @@ itest!(_075_import_local_query_hash {
 });
 
 itest!(_076_info_json_deps_order {
-  args: "info --unstable --json 076_info_json_deps_order.ts",
+  args: "info --json 076_info_json_deps_order.ts",
   output: "076_info_json_deps_order.out",
 });
 
@@ -3323,65 +3323,65 @@ itest!(deno_test_run_test_coverage {
 });
 
 itest!(deno_test_run_run_coverage {
-  args: "test --allow-all --coverage --unstable test_run_run_coverage.ts",
+  args: "test --allow-all --coverage test_run_run_coverage.ts",
   output: "test_run_run_coverage.out",
   exit_code: 0,
 });
 
 itest!(deno_lint {
-  args: "lint --unstable lint/file1.js lint/file2.ts lint/ignored_file.ts",
+  args: "lint lint/file1.js lint/file2.ts lint/ignored_file.ts",
   output: "lint/expected.out",
   exit_code: 1,
 });
 
 itest!(deno_lint_quiet {
-  args: "lint --unstable --quiet lint/file1.js",
+  args: "lint --quiet lint/file1.js",
   output: "lint/expected_quiet.out",
   exit_code: 1,
 });
 
 itest!(deno_lint_json {
   args:
-    "lint --unstable --json lint/file1.js lint/file2.ts lint/ignored_file.ts lint/malformed.js",
+    "lint --json lint/file1.js lint/file2.ts lint/ignored_file.ts lint/malformed.js",
   output: "lint/expected_json.out",
   exit_code: 1,
 });
 
 itest!(deno_lint_ignore {
-  args: "lint --unstable --ignore=lint/file1.js,lint/malformed.js lint/",
+  args: "lint --ignore=lint/file1.js,lint/malformed.js lint/",
   output: "lint/expected_ignore.out",
   exit_code: 1,
 });
 
 itest!(deno_lint_glob {
-  args: "lint --unstable --ignore=lint/malformed.js lint/",
+  args: "lint --ignore=lint/malformed.js lint/",
   output: "lint/expected_glob.out",
   exit_code: 1,
 });
 
 itest!(deno_lint_from_stdin {
-  args: "lint --unstable -",
+  args: "lint -",
   input: Some("let a: any;"),
   output: "lint/expected_from_stdin.out",
   exit_code: 1,
 });
 
 itest!(deno_lint_from_stdin_json {
-  args: "lint --unstable --json -",
+  args: "lint --json -",
   input: Some("let a: any;"),
   output: "lint/expected_from_stdin_json.out",
   exit_code: 1,
 });
 
 itest!(deno_lint_rules {
-  args: "lint --unstable --rules",
+  args: "lint --rules",
   output: "lint/expected_rules.out",
   exit_code: 0,
 });
 
 // Make sure that the rules are printed if quiet option is enabled.
 itest!(deno_lint_rules_quiet {
-  args: "lint --unstable --rules -q",
+  args: "lint --rules -q",
   output: "lint/expected_rules.out",
   exit_code: 0,
 });
@@ -3397,7 +3397,7 @@ itest!(deno_doc {
 });
 
 itest!(deno_doc_import_map {
-  args: "doc --unstable --import-map=doc/import_map.json doc/use_import_map.js",
+  args: "doc --import-map=doc/import_map.json doc/use_import_map.js",
   output: "doc/use_import_map.out",
 });
 
@@ -4547,7 +4547,6 @@ fn lint_ignore_unexplicit_files() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("lint")
-    .arg("--unstable")
     .arg("--ignore=./")
     .stderr(std::process::Stdio::piped())
     .spawn()
@@ -4585,7 +4584,6 @@ fn compile() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("compile")
-    .arg("--unstable")
     .arg("--output")
     .arg(&exe)
     .arg("./std/examples/welcome.ts")
@@ -4616,7 +4614,6 @@ fn standalone_args() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("compile")
-    .arg("--unstable")
     .arg("--output")
     .arg(&exe)
     .arg("./cli/tests/028_args.ts")
@@ -4650,7 +4647,6 @@ fn standalone_error() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("compile")
-    .arg("--unstable")
     .arg("--output")
     .arg(&exe)
     .arg("./cli/tests/standalone_error.ts")
@@ -4686,7 +4682,6 @@ fn standalone_no_module_load() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("compile")
-    .arg("--unstable")
     .arg("--output")
     .arg(&exe)
     .arg("./cli/tests/standalone_import.ts")
@@ -4722,7 +4717,6 @@ fn compile_with_directory_exists_error() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("compile")
-    .arg("--unstable")
     .arg("./cli/tests/028_args.ts")
     .arg("--output")
     .arg(&exe)
@@ -4751,7 +4745,6 @@ fn compile_with_conflict_file_exists_error() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("compile")
-    .arg("--unstable")
     .arg("./cli/tests/028_args.ts")
     .arg("--output")
     .arg(&exe)
@@ -4781,7 +4774,6 @@ fn compile_and_overwrite_file() {
   let output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("compile")
-    .arg("--unstable")
     .arg("./cli/tests/028_args.ts")
     .arg("--output")
     .arg(&exe)
@@ -4796,7 +4788,6 @@ fn compile_and_overwrite_file() {
   let recompile_output = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("compile")
-    .arg("--unstable")
     .arg("./cli/tests/028_args.ts")
     .arg("--output")
     .arg(&exe)

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -44,7 +44,6 @@ fn std_tests() {
 fn std_lint() {
   let status = util::deno_cmd()
     .arg("lint")
-    .arg("--unstable")
     .arg(format!(
       "--ignore={}",
       util::root_path().join("std/node/tests").to_string_lossy()
@@ -61,7 +60,6 @@ fn std_lint() {
 fn unit_test_lint() {
   let status = util::deno_cmd()
     .arg("lint")
-    .arg("--unstable")
     .arg(util::root_path().join("cli/tests/unit"))
     .spawn()
     .unwrap()
@@ -543,7 +541,6 @@ fn fmt_watch_test() {
     .arg("fmt")
     .arg(&badly_formatted)
     .arg("--watch")
-    .arg("--unstable")
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped())
     .spawn()
@@ -1196,7 +1193,6 @@ fn bundle_import_map() {
     .arg("bundle")
     .arg("--import-map")
     .arg(import_map_path)
-    .arg("--unstable")
     .arg(import)
     .arg(&bundle)
     .spawn()
@@ -1242,7 +1238,6 @@ fn bundle_import_map_no_check() {
     .arg("--no-check")
     .arg("--importmap")
     .arg(import_map_path)
-    .arg("--unstable")
     .arg(import)
     .arg(&bundle)
     .spawn()
@@ -1293,7 +1288,6 @@ fn bundle_js_watch() {
     .arg(&file_to_watch)
     .arg(&bundle)
     .arg("--watch")
-    .arg("--unstable")
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped())
     .spawn()
@@ -1360,7 +1354,6 @@ fn bundle_watch_not_exit() {
     .arg(&file_to_watch)
     .arg(&target_file)
     .arg("--watch")
-    .arg("--unstable")
     .env("NO_COLOR", "1")
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped())
@@ -1457,7 +1450,6 @@ fn run_watch() {
     .current_dir(util::root_path())
     .arg("run")
     .arg("--watch")
-    .arg("--unstable")
     .arg(&file_to_watch)
     .env("NO_COLOR", "1")
     .stdout(std::process::Stdio::piped())
@@ -1549,7 +1541,6 @@ fn run_watch_not_exit() {
     .current_dir(util::root_path())
     .arg("run")
     .arg("--watch")
-    .arg("--unstable")
     .arg(&file_to_watch)
     .env("NO_COLOR", "1")
     .stdout(std::process::Stdio::piped())
@@ -1714,7 +1705,6 @@ fn run_watch_with_importmap_and_relative_paths() {
   let mut child = util::deno_cmd()
     .current_dir(util::root_path())
     .arg("run")
-    .arg("--unstable")
     .arg("--watch")
     .arg("--importmap")
     .arg(&import_map_path)
@@ -2357,7 +2347,7 @@ itest!(_031_info_ts_error {
 
 itest!(_033_import_map {
   args:
-    "run --quiet --reload --import-map=import_maps/import_map.json --unstable import_maps/test.ts",
+    "run --quiet --reload --import-map=import_maps/import_map.json import_maps/test.ts",
   output: "033_import_map.out",
 });
 
@@ -2376,7 +2366,7 @@ itest!(_035_cached_only_flag {
 
 itest!(_036_import_map_fetch {
   args:
-    "cache --quiet --reload --import-map=import_maps/import_map.json --unstable import_maps/test.ts",
+    "cache --quiet --reload --import-map=import_maps/import_map.json import_maps/test.ts",
   output: "036_import_map_fetch.out",
 });
 
@@ -2404,7 +2394,7 @@ itest!(_041_info_flag {
 });
 
 itest!(info_json {
-  args: "info --json --unstable",
+  args: "info --json",
   output: "info_json.out",
 });
 
@@ -2462,7 +2452,7 @@ itest!(_054_info_local_imports {
 });
 
 itest!(_055_info_file_json {
-  args: "info --quiet --json --unstable 005_more_imports.ts",
+  args: "info --quiet --json 005_more_imports.ts",
   output: "055_info_file_json.out",
   exit_code: 0,
 });
@@ -3305,19 +3295,19 @@ itest!(redirect_cache {
 });
 
 itest!(deno_test_coverage {
-  args: "test --coverage --unstable test_coverage.ts",
+  args: "test --coverage test_coverage.ts",
   output: "test_coverage.out",
   exit_code: 0,
 });
 
 itest!(deno_test_coverage_explicit {
-  args: "test --coverage=.test_coverage --unstable test_coverage.ts",
+  args: "test --coverage=.test_coverage test_coverage.ts",
   output: "test_coverage.out",
   exit_code: 0,
 });
 
 itest!(deno_test_run_test_coverage {
-  args: "test --allow-all --coverage --unstable test_run_test_coverage.ts",
+  args: "test --allow-all --coverage test_run_test_coverage.ts",
   output: "test_run_test_coverage.out",
   exit_code: 0,
 });
@@ -4353,7 +4343,6 @@ fn websocket() {
   let root_ca = util::tests_path().join("tls/RootCA.pem");
   let status = util::deno_cmd()
     .arg("test")
-    .arg("--unstable")
     .arg("--allow-net")
     .arg("--cert")
     .arg(root_ca)

--- a/docs/contributing/development_tools.md
+++ b/docs/contributing/development_tools.md
@@ -23,13 +23,13 @@ cargo test std_tests
 Lint the code:
 
 ```shell
-deno run -A --unstable ./tools/lint.js
+deno run -A ./tools/lint.js
 ```
 
 Format the code:
 
 ```shell
-deno run -A --unstable ./tools/format.js
+deno run -A ./tools/format.js
 ```
 
 ### Profiling

--- a/docs/getting_started/command_line_interface.md
+++ b/docs/getting_started/command_line_interface.md
@@ -94,11 +94,8 @@ watcher. When Deno starts up with this flag it watches the entrypoint, and all
 local files the entrypoint statically imports. Whenever one of these files is
 changed on disk, the program will automatically be restarted.
 
-**Note: file watcher is a new feature and still unstable thus it requires
-`--unstable` flag**
-
 ```
-deno run --watch --unstable main.ts
+deno run --watch main.ts
 ```
 
 ### Integrity flags
@@ -122,7 +119,7 @@ resolution, compilation configuration etc.
 
 ```
 --config <FILE>               Load tsconfig.json configuration file
---import-map <FILE>           UNSTABLE: Load import map file
+--import-map <FILE>           Load import map file
 --no-remote                   Do not resolve remote modules
 --reload=<CACHE_BLOCKLIST>    Reload source code cache (recompile TypeScript)
 --unstable                    Enable unstable APIs

--- a/docs/linking_to_external_code/import_maps.md
+++ b/docs/linking_to_external_code/import_maps.md
@@ -37,7 +37,7 @@ console.log(red("hello world"));
 Then:
 
 ```shell
-$ deno run --import-map=import_map.json --unstable color.ts
+$ deno run --import-map=import_map.json color.ts
 ```
 
 To use starting directory for absolute imports:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -222,7 +222,7 @@ stdout. In the future there will be support for `lcov` output too.
 
 ```
 $ git clone git@github.com:denosaurs/deno_brotli.git && cd deno_brotli
-$ deno test --coverage --unstable
+$ deno test --coverage
 Debugger listening on ws://127.0.0.1:9229/ws/5a593019-d185-478b-a928-ebc33e5834be
 Check file:///home/deno/deno_brotli/$deno$test.ts
 running 2 tests

--- a/docs/tools/compiler.md
+++ b/docs/tools/compiler.md
@@ -1,13 +1,10 @@
 ## Compiling Executables
 
-> Since the compile functionality is relatively new, the `--unstable` flag has
-> to be set in order for the command to work.
-
 `deno compile [SRC] [OUT]` will compile the script into a self contained
 executable.
 
 ```
-> deno compile --unstable https://deno.land/std/http/file_server.ts
+> deno compile https://deno.land/std/http/file_server.ts
 ```
 
 If you omit the `OUT` parameter, the name of the executable file will be

--- a/docs/tools/linter.md
+++ b/docs/tools/linter.md
@@ -2,18 +2,15 @@
 
 Deno ships with a built in code linter for JavaScript and TypeScript.
 
-**Note: linter is a new feature and still unstable thus it requires `--unstable`
-flag**
-
 ```shell
 # lint all JS/TS files in the current directory and subdirectories
-deno lint --unstable
+deno lint
 # lint specific files
-deno lint --unstable myfile1.ts myfile2.ts
+deno lint myfile1.ts myfile2.ts
 # print result as JSON
-deno lint --unstable --json
+deno lint --json
 # read from stdin
-cat file.ts | deno lint --unstable -
+cat file.ts | deno lint -
 ```
 
 For more detail, run `deno lint --help`.

--- a/runtime/ops/mod.rs
+++ b/runtime/ops/mod.rs
@@ -66,7 +66,6 @@ impl UnstableChecker {
   ///
   /// This is intentionally a non-recoverable check so that people cannot probe
   /// for unstable APIs from stable programs.
-  // NOTE(bartlomieju): keep in sync with `cli/program_state.rs`
   pub fn check_unstable(&self, api_name: &str) {
     if !self.unstable {
       eprintln!(


### PR DESCRIPTION
This commit removes requirement for `--unstable` flag
for CLI features. Using unstable `Deno` APIs still requires
passing that flag.

This change impacts following subcommands:
- `deno compile`
- `deno lint`
- `deno test --no-run`
- `deno test --coverage`
- `--import-map` flag in various subcommands
- `--watch` flag in various subcommands

Closes #8934