### PR TITLE
feat(lsp): Implement completionItem/resolve

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -379,6 +379,15 @@ mod tests {
 
     let mut tests =
       Vec::<(ModuleSpecifier, fn(&ModuleSpecifier) -> bool, &str, &str)>::new();
+    // should not convert if the text has no import statement.
+    tests.push((
+      ModuleSpecifier::resolve_url_or_path("./a.ts").unwrap(),
+      |s| s.eq(&ModuleSpecifier::resolve_path("./b.js").unwrap()),
+      "const A = B;",
+      "const A = B;",
+    ));
+
+    // should not convert if the import statement is already valid.
     tests.push((
       ModuleSpecifier::resolve_url_or_path("./a.ts").unwrap(),
       |s| s.eq(&ModuleSpecifier::resolve_path("./b.js").unwrap()),
@@ -386,6 +395,15 @@ mod tests {
       "import { A } from './b.js'",
     ));
 
+    // should not convert if the actual file has no js/ts extension.
+    tests.push((
+      ModuleSpecifier::resolve_url_or_path("./a.ts").unwrap(),
+      |s| s.eq(&ModuleSpecifier::resolve_path("./b.json").unwrap()),
+      "import { A } from './b.js'",
+      "import { A } from './b.js'",
+    ));
+
+    // should convert if the import statement's extension is wrong.
     tests.push((
       ModuleSpecifier::resolve_url_or_path("./a.ts").unwrap(),
       |s| s.eq(&ModuleSpecifier::resolve_path("./b.ts").unwrap()),
@@ -393,6 +411,7 @@ mod tests {
       "import { A } from './b.ts'",
     ));
 
+    // should not convert when the import statement has http scheme (via literal).
     tests.push((
       ModuleSpecifier::resolve_url_or_path("./a.ts").unwrap(),
       |s| {
@@ -405,6 +424,7 @@ mod tests {
       "import { A } from 'https://example/path/to/jquery.ts'",
     ));
 
+    // should not convert when the import statement has http scheme (via import_map).
     tests.push((
       ModuleSpecifier::resolve_url_or_path("./a.ts").unwrap(),
       |s| {

--- a/cli/lsp/capabilities.rs
+++ b/cli/lsp/capabilities.rs
@@ -41,7 +41,7 @@ pub fn server_capabilities(
         "<".to_string(),
         "#".to_string(),
       ]),
-      resolve_provider: None,
+      resolve_provider: Some(true),
       work_done_progress_options: WorkDoneProgressOptions {
         work_done_progress: None,
       },

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -541,6 +541,19 @@ delete Object.prototype.__proto__;
           ),
         );
       }
+      case "getCompletionEntryDetails": {
+        return respond(
+          id,
+          languageService.getCompletionEntryDetails(
+            request.specifier,
+            request.position,
+            request.entryName,
+            request.formatOptions,
+            request.source,
+            request.preferences,
+          ),
+        );
+      }
       case "getDocumentHighlights": {
         return respond(
           id,

--- a/cli/tsc/compiler.d.ts
+++ b/cli/tsc/compiler.d.ts
@@ -49,6 +49,7 @@ declare global {
     | GetReferencesRequest
     | GetDefinitionRequest
     | GetCompletionsRequest
+    | GetCompletionEntryDetails
     | FindRenameLocationsRequest;
 
   interface BaseLanguageServerRequest {
@@ -101,6 +102,16 @@ declare global {
     method: "getCompletions";
     specifier: string;
     position: number;
+    preferences: ts.UserPreferences;
+  }
+
+  interface GetCompletionEntryDetails extends BaseLanguageServerRequest {
+    method: "getCompletionEntryDetails";
+    specifier: string;
+    position: number;
+    entryName: string;
+    formatOptions: ts.FormatCodeSettings;
+    source: string;
     preferences: ts.UserPreferences;
   }
 


### PR DESCRIPTION
Related #8643

This PR aims to support auto-importing and completionItem's documentation.

Currently, I didn't add tests because the test will depend `textDocument/completion` response.

If maintainers need tests, I can add it.
