### PR TITLE
fix(test_util): make hyper server single-threaded

### DIFF
--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -722,7 +722,10 @@ async fn wrap_main_https_server() {
   }
 }
 
-#[tokio::main]
+// Use the single-threaded scheduler. The hyper server is used as a point of
+// comparison for the (single-threaded!) benchmarks in cli/bench. We're not
+// comparing apples to apples if we use the default multi-threaded scheduler.
+#[tokio::main(basic_scheduler)]
 pub async fn run_all_servers() {
   if let Some(port) = env::args().nth(1) {
     return hyper_hello(port.parse::<u16>().unwrap()).await;


### PR DESCRIPTION
Use Tokio's single-threaded scheduler. The hyper server is used as a
point of comparison for the (single-threaded!) benchmarks in cli/bench.

We're not comparing apples to apples if we use the default
multi-threaded scheduler.

This drops the requests/sec from 284k to 130k on my 12 core Ryzen 5
system. That still leaves a 50k gap for us to close. Working on it!

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
