### PR TITLE
Revert "ci: don't install python (#8961)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,11 +87,25 @@ jobs:
           curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.5.1
           echo "$HOME/.deno/bin" >> $env:GITHUB_PATH
 
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "2.7"
+          architecture: x64
+
       - name: Install Node
         uses: actions/setup-node@v2
         with:
           node-version: "14"
           check-latest: true
+
+      - name: Remove unused versions of Python
+        if: startsWith(matrix.os, 'windows')
+        run: |-
+          $env:PATH -split ";" |
+            Where-Object { Test-Path "$_\python.exe" } |
+            Select-Object -Skip 1 |
+            ForEach-Object { Move-Item "$_" "$_.disabled" }
 
       - name: Setup gcloud (unix)
         if: |


### PR DESCRIPTION
gcloud still depends on python - https://github.com/denoland/deno/runs/1636936462

This reverts commit 5937ee3fba24dac6be99c8cb0b4c9709d4656f71.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
