### PR TITLE
fix: panic on invalid file:// module specifier

### DIFF
--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -292,7 +292,12 @@ mod tests {
 
     let cache = DiskCache::new(&cache_location);
 
-    let test_cases = vec!["file://", "file:///", "unknown://localhost/test.ts"];
+    let mut test_cases = vec!["unknown://localhost/test.ts"];
+
+    if cfg!(target_os = "windows") {
+      test_cases.push("file://");
+      test_cases.push("file:///");
+    }
 
     for test_case in &test_cases {
       let cache_filename =

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -281,4 +281,23 @@ mod tests {
       )
     }
   }
+
+  #[test]
+  fn test_get_cache_filename_invalid_urls() {
+    let cache_location = if cfg!(target_os = "windows") {
+      PathBuf::from(r"C:\deno_dir\")
+    } else {
+      PathBuf::from("/deno_dir/")
+    };
+
+    let cache = DiskCache::new(&cache_location);
+
+    let test_cases = vec!["file://", "file:///", "unknown://localhost/test.ts"];
+
+    for test_case in &test_cases {
+      let cache_filename =
+        cache.get_cache_filename(&Url::parse(test_case).unwrap());
+      assert_eq!(cache_filename, None);
+    }
+  }
 }

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -69,7 +69,10 @@ impl DiskCache {
       }
       "http" | "https" => out = url_to_filename(url),
       "file" => {
-        let path = url.to_file_path().unwrap();
+        let path = match url.to_file_path() {
+          Ok(path) => path,
+          Err(_) => return None,
+        };
         let mut path_components = path.components();
 
         if cfg!(target_os = "windows") {

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -583,13 +583,10 @@ impl Permissions {
     if url.scheme() == "file" {
       match url.to_file_path() {
         Ok(path) => self.check_read(&path),
-        Err(_) => Err(
-          std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Invalid module URL",
-          )
-          .into(),
-        ),
+        Err(_) => Err(uri_error(format!(
+          "Invalid file path.\n  Specifier: {}",
+          specifier
+        ))),
       }
     } else {
       self.check_net_url(url)

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -948,6 +948,24 @@ mod tests {
   }
 
   #[test]
+  fn check_invalid_specifiers() {
+    let perms = Permissions::allow_all();
+
+    let mut test_cases = vec![];
+
+    if cfg!(target_os = "windows") {
+      test_cases.push("file://");
+      test_cases.push("file:///");
+    }
+
+    for url in test_cases {
+      assert!(perms
+        .check_specifier(&ModuleSpecifier::resolve_url_or_path(url).unwrap())
+        .is_err());
+    }
+  }
+
+  #[test]
   fn test_deserialize_perms() {
     let json_perms = r#"
     {

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -581,8 +581,16 @@ impl Permissions {
   ) -> Result<(), AnyError> {
     let url = specifier.as_url();
     if url.scheme() == "file" {
-      let path = url.to_file_path().unwrap();
-      self.check_read(&path)
+      match url.to_file_path() {
+        Ok(path) => self.check_read(&path),
+        Err(_) => Err(
+          std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Invalid module URL",
+          )
+          .into(),
+        ),
+      }
     } else {
       self.check_net_url(url)
     }

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -956,6 +956,8 @@ mod tests {
     if cfg!(target_os = "windows") {
       test_cases.push("file://");
       test_cases.push("file:///");
+    } else {
+      test_cases.push("file://remotehost/");
     }
 
     for url in test_cases {


### PR DESCRIPTION
Fixes #8958 
- `permissions.rs`: `check_specifier` no longer assumes a local-file specifier is valid
- `disk_cache.rs`: `get_cache_filename` gracefully handles invalid local-file specifiers

Working on tests now