### PR TITLE
docs: Remove outdated information about third_party/ directory

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -45,14 +45,6 @@ Examples of bad PR title:
 5. Ensure `./tools/format.js` passes without changing files.
 6. Ensure `./tools/lint.js` passes.
 
-## Changes to `third_party`
-
-[`deno_third_party`](https://github.com/denoland/deno_third_party) contains most
-of the external code that Deno depends on, so that we know exactly what we are
-executing at any given time. It is carefully maintained with a mixture of manual
-labor and private scripts. It's likely you will need help from @ry or
-@piscisaureus to make changes.
-
 ## Adding Ops (aka bindings)
 
 We are very concerned about making mistakes when adding new APIs. When adding an

--- a/std/encoding/testdata/cargo.toml
+++ b/std/encoding/testdata/cargo.toml
@@ -1,9 +1,5 @@
 # Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 # Dummy package info required by `cargo fetch`.
-# Use tools/sync_third_party.py to install deps after editing this file.
-# Deno does not build with cargo. Deno uses a build system called gn.
-# See build_extra/rust/BUILD.gn for the manually built configuration of rust
-# crates.
 
 [workspace]
 members = [


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Quick PR to remove was seems to be obsolete information regarding `third_party`.