### PR TITLE
feat(op_crates/crypto): Introduce Web Crypto API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "chrono",
  "clap",
  "deno_core",
+ "deno_crypto",
  "deno_doc",
  "deno_fetch",
  "deno_lint",
@@ -483,6 +484,10 @@ version = "0.13.0"
 dependencies = [
  "deno_core",
  "rand 0.8.3",
+ "ring",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,6 +28,7 @@ deno_core = { path = "../core", version = "0.79.0" }
 deno_fetch = { path = "../op_crates/fetch", version = "0.22.0" }
 deno_web = { path = "../op_crates/web", version = "0.30.0" }
 deno_websocket = { path = "../op_crates/websocket", version = "0.5.0" }
+deno_crypto = { path = "../op_crates/crypto", version = "0.13.0" }
 regex = "1.4.3"
 serde = { version = "1.0.123", features = ["derive"] }
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -59,6 +59,7 @@ fn create_compiler_snapshot(
   op_crate_libs.insert("deno.web", deno_web::get_declaration());
   op_crate_libs.insert("deno.fetch", deno_fetch::get_declaration());
   op_crate_libs.insert("deno.websocket", deno_websocket::get_declaration());
+  op_crate_libs.insert("deno.crypto", deno_crypto::get_declaration());
 
   // ensure we invalidate the build properly.
   for (_, path) in op_crate_libs.iter() {
@@ -258,6 +259,10 @@ fn main() {
   println!(
     "cargo:rustc-env=DENO_WEBSOCKET_LIB_PATH={}",
     deno_websocket::get_declaration().display()
+  );
+  println!(
+    "cargo:rustc-env=DENO_CRYPTO_LIB_PATH={}",
+    deno_crypto::get_declaration().display()
   );
 
   println!("cargo:rustc-env=TARGET={}", env::var("TARGET").unwrap());

--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -8,6 +8,7 @@
 /// <reference lib="deno.web" />
 /// <reference lib="deno.fetch" />
 /// <reference lib="deno.websocket" />
+/// <reference lib="deno.crypto" />
 
 declare namespace WebAssembly {
   /**
@@ -415,26 +416,6 @@ declare interface Console {
 }
 
 declare var console: Console;
-
-declare interface Crypto {
-  readonly subtle: null;
-  getRandomValues<
-    T extends
-      | Int8Array
-      | Int16Array
-      | Int32Array
-      | Uint8Array
-      | Uint16Array
-      | Uint32Array
-      | Uint8ClampedArray
-      | Float32Array
-      | Float64Array
-      | DataView
-      | null,
-  >(
-    array: T,
-  ): T;
-}
 
 interface MessageEventInit<T = any> extends EventInit {
   data?: T;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -280,11 +280,12 @@ fn print_cache_info(
 
 fn get_types(unstable: bool) -> String {
   let mut types = format!(
-    "{}\n{}\n{}\n{}\n{}\n{}",
+    "{}\n{}\n{}\n{}\n{}\n{}\n{}",
     crate::tsc::DENO_NS_LIB,
     crate::tsc::DENO_WEB_LIB,
     crate::tsc::DENO_FETCH_LIB,
     crate::tsc::DENO_WEBSOCKET_LIB,
+    crate::tsc::DENO_CRYPTO_LIB,
     crate::tsc::SHARED_GLOBALS_LIB,
     crate::tsc::WINDOW_LIB,
   );

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -33,6 +33,7 @@ pub static DENO_WEB_LIB: &str = include_str!(env!("DENO_WEB_LIB_PATH"));
 pub static DENO_FETCH_LIB: &str = include_str!(env!("DENO_FETCH_LIB_PATH"));
 pub static DENO_WEBSOCKET_LIB: &str =
   include_str!(env!("DENO_WEBSOCKET_LIB_PATH"));
+pub static DENO_CRYPTO_LIB: &str = include_str!(env!("DENO_CRYPTO_LIB_PATH"));
 pub static SHARED_GLOBALS_LIB: &str =
   include_str!("dts/lib.deno.shared_globals.d.ts");
 pub static WINDOW_LIB: &str = include_str!("dts/lib.deno.window.d.ts");

--- a/op_crates/crypto/01_crypto.js
+++ b/op_crates/crypto/01_crypto.js
@@ -1,6 +1,8 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 "use strict";
 
+// Implements https://www.w3.org/TR/WebCryptoAPI
+
 ((window) => {
   const core = window.Deno.core;
 
@@ -41,11 +43,145 @@
     return arrayBufferView;
   }
 
+  // Algorithm normalization, which involves storing the expected data for
+  // each pair of algorithm and crypto operation, is done on the JS side because
+  // it is convenient.
+  // Shall it stay that way, or are we better to move it on the Rust side?
+
+  // We need this method after initialization, anytime we need to normalize
+  // a provided algorithm. We store it here to prevent prototype pollution.
+  const toUpperCase = String.prototype.toUpperCase;
+
+  class RegisteredAlgorithmsContainer {
+    #nameIndex;
+    #definitions;
+
+    constructor(definitions) {
+      this.#nameIndex = Object.create(null);
+      this.#definitions = Object.create(null);
+      for (const [name, definition] of Object.entries(definitions)) {
+        this.#nameIndex[name.toUpperCase()] = name;
+        this.#definitions[name] = definition;
+      }
+    }
+
+    /**
+     * A definition is an object whose keys are the keys that the input must
+     * have and whose values are validation functions for the associate value.
+     * The validation function will either return the value if it valid, or
+     * throw an error that must be forwarded.
+     */
+    getDefinition(name) {
+      return this.#definitions[name];
+    }
+
+    normalizeName(providedName) {
+      const upperCaseName = toUpperCase.call(providedName);
+      return this.#nameIndex[upperCaseName];
+    }
+  }
+
+  const supportedAlgorithms = {};
+
+  function normalizeAlgorithm(algorithm, registeredAlgorithms) {
+    let alg;
+    if (typeof algorithm === "string") {
+      alg = { name: algorithm };
+    } else if (typeof algorithm === "object" && algorithm !== null) {
+      if (typeof algorithm.name !== "string") {
+        throw new TypeError("Algorithm name is missing or not a string");
+      }
+      alg = { ...algorithm };
+    } else {
+      throw new TypeError("Argument 1 must be an object or a string");
+    }
+    const algorithmName = registeredAlgorithms.normalizeName(alg.name);
+    if (algorithmName === undefined) {
+      throw new DOMException(
+        "Unrecognized algorithm name",
+        "NotSupportedError",
+      );
+    }
+    const definition = registeredAlgorithms.getDefinition(algorithmName);
+    for (const [propertyName, validate] of Object.entries(definition)) {
+      alg[propertyName] = validate(algorithm[propertyName]);
+    }
+    alg.name = algorithmName;
+    return alg;
+  }
+
+  const subtle = {
+    async decrypt(algorithm, key, data) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+    async deriveBits(algorithm, baseKey, length) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+    async deriveKey(
+      algorithm,
+      baseKey,
+      derivedKeyType,
+      extractable,
+      keyUsages,
+    ) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+    async digest(algorithm, data) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+    async encrypt(algorithm, key, data) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+    async exportKey(format, key) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+    async generateKey(algorithm, extractable, keyUsages) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+    async importKey(format, keyData, algorithm, extractable, keyUsages) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+    async sign(algorithm, key, data) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+    async unwrapKey(
+      format,
+      wrappedKey,
+      unwrappingKey,
+      unwrapAlgorithm,
+      unwrappedKeyAlgorithm,
+      extractable,
+      keyUsages,
+    ) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+    async verify(algorithm, key, signature, data) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+    async wrapKey(format, key, wrappingKey, wrapAlgorithm) {
+      await Promise.resolve();
+      throw new Error("Not implemented");
+    },
+  };
+
   window.crypto = {
     getRandomValues,
+    subtle,
   };
   window.__bootstrap = window.__bootstrap || {};
   window.__bootstrap.crypto = {
     getRandomValues,
+    subtle,
   };
 })(this);

--- a/op_crates/crypto/Cargo.toml
+++ b/op_crates/crypto/Cargo.toml
@@ -16,4 +16,7 @@ path = "lib.rs"
 [dependencies]
 deno_core = { version = "0.79.0", path = "../../core" }
 rand = "0.8.3"
-
+ring = "0.16.19"
+tokio = { version = "1.1.1", features = ["full"] }
+serde_json = { version = "1.0.62", features = ["preserve_order"] }
+serde = { version = "1.0.123", features = ["derive"] }

--- a/op_crates/crypto/lib.deno_crypto.d.ts
+++ b/op_crates/crypto/lib.deno_crypto.d.ts
@@ -1,0 +1,573 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file camelcase
+
+/// <reference no-default-lib="true" />
+/// <reference lib="esnext" />
+
+declare interface Crypto {
+  readonly subtle: SubtleCrypto;
+  getRandomValues<
+    T extends
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Uint8ClampedArray
+      | Float32Array
+      | Float64Array
+      | DataView
+      | null,
+  >(
+    array: T,
+  ): T;
+}
+
+declare interface SubtleCrypto {
+  decrypt(
+    algorithm:
+      | AlgorithmIdentifier
+      | RsaOaepParams
+      | AesCtrParams
+      | AesCbcParams
+      | AesCmacParams
+      | AesGcmParams
+      | AesCfbParams,
+    key: CryptoKey,
+    data:
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Uint8ClampedArray
+      | Float32Array
+      | Float64Array
+      | DataView
+      | ArrayBuffer,
+  ): Promise<ArrayBuffer>;
+  deriveBits(
+    algorithm:
+      | AlgorithmIdentifier
+      | EcdhKeyDeriveParams
+      | DhKeyDeriveParams
+      | ConcatParams
+      | HkdfParams
+      | Pbkdf2Params,
+    baseKey: CryptoKey,
+    length: number,
+  ): Promise<ArrayBuffer>;
+  deriveKey(
+    algorithm:
+      | AlgorithmIdentifier
+      | EcdhKeyDeriveParams
+      | DhKeyDeriveParams
+      | ConcatParams
+      | HkdfParams
+      | Pbkdf2Params,
+    baseKey: CryptoKey,
+    derivedKeyType:
+      | string
+      | AesDerivedKeyParams
+      | HmacImportParams
+      | ConcatParams
+      | HkdfParams
+      | Pbkdf2Params,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKey>;
+  digest(
+    algorithm: AlgorithmIdentifier,
+    data:
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Uint8ClampedArray
+      | Float32Array
+      | Float64Array
+      | DataView
+      | ArrayBuffer,
+  ): Promise<ArrayBuffer>;
+  encrypt(
+    algorithm:
+      | AlgorithmIdentifier
+      | RsaOaepParams
+      | AesCtrParams
+      | AesCbcParams
+      | AesCmacParams
+      | AesGcmParams
+      | AesCfbParams,
+    key: CryptoKey,
+    data:
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Uint8ClampedArray
+      | Float32Array
+      | Float64Array
+      | DataView
+      | ArrayBuffer,
+  ): Promise<ArrayBuffer>;
+  exportKey(format: "jwk", key: CryptoKey): Promise<JsonWebKey>;
+  exportKey(
+    format: "raw" | "pkcs8" | "spki",
+    key: CryptoKey,
+  ): Promise<ArrayBuffer>;
+  exportKey(format: string, key: CryptoKey): Promise<JsonWebKey | ArrayBuffer>;
+  generateKey(
+    algorithm: RsaHashedKeyGenParams | EcKeyGenParams | DhKeyGenParams,
+    extractable: boolean,
+    keyUsages: Iterable<KeyUsage>,
+  ): Promise<CryptoKeyPair>;
+  generateKey(
+    algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params,
+    extractable: boolean,
+    keyUsages: Iterable<KeyUsage>,
+  ): Promise<CryptoKey>;
+  generateKey(
+    algorithm: AlgorithmIdentifier,
+    extractable: boolean,
+    keyUsages: Iterable<KeyUsage>,
+  ): Promise<CryptoKeyPair | CryptoKey>;
+  importKey(
+    format: "jwk",
+    keyData: JsonWebKey,
+    algorithm:
+      | AlgorithmIdentifier
+      | RsaHashedImportParams
+      | EcKeyImportParams
+      | HmacImportParams
+      | DhImportKeyParams
+      | AesKeyAlgorithm,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKey>;
+  importKey(
+    format: "raw" | "pkcs8" | "spki",
+    keyData:
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Uint8ClampedArray
+      | Float32Array
+      | Float64Array
+      | DataView
+      | ArrayBuffer,
+    algorithm:
+      | AlgorithmIdentifier
+      | RsaHashedImportParams
+      | EcKeyImportParams
+      | HmacImportParams
+      | DhImportKeyParams
+      | AesKeyAlgorithm,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKey>;
+  importKey(
+    format: string,
+    keyData:
+      | JsonWebKey
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Uint8ClampedArray
+      | Float32Array
+      | Float64Array
+      | DataView
+      | ArrayBuffer,
+    algorithm:
+      | AlgorithmIdentifier
+      | RsaHashedImportParams
+      | EcKeyImportParams
+      | HmacImportParams
+      | DhImportKeyParams
+      | AesKeyAlgorithm,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKey>;
+  sign(
+    algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams | AesCmacParams,
+    key: CryptoKey,
+    data:
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Uint8ClampedArray
+      | Float32Array
+      | Float64Array
+      | DataView
+      | ArrayBuffer,
+  ): Promise<ArrayBuffer>;
+  unwrapKey(
+    format: "raw" | "pkcs8" | "spki" | "jwk" | string,
+    wrappedKey:
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Uint8ClampedArray
+      | Float32Array
+      | Float64Array
+      | DataView
+      | ArrayBuffer,
+    unwrappingKey: CryptoKey,
+    unwrapAlgorithm:
+      | AlgorithmIdentifier
+      | RsaOaepParams
+      | AesCtrParams
+      | AesCbcParams
+      | AesCmacParams
+      | AesGcmParams
+      | AesCfbParams,
+    unwrappedKeyAlgorithm:
+      | AlgorithmIdentifier
+      | RsaHashedImportParams
+      | EcKeyImportParams
+      | HmacImportParams
+      | DhImportKeyParams
+      | AesKeyAlgorithm,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKey>;
+  verify(
+    algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams | AesCmacParams,
+    key: CryptoKey,
+    signature:
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Uint8ClampedArray
+      | Float32Array
+      | Float64Array
+      | DataView
+      | ArrayBuffer,
+    data:
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Uint8ClampedArray
+      | Float32Array
+      | Float64Array
+      | DataView
+      | ArrayBuffer,
+  ): Promise<boolean>;
+  wrapKey(
+    format: "raw" | "pkcs8" | "spki" | "jwk" | string,
+    key: CryptoKey,
+    wrappingKey: CryptoKey,
+    wrapAlgorithm:
+      | AlgorithmIdentifier
+      | RsaOaepParams
+      | AesCtrParams
+      | AesCbcParams
+      | AesCmacParams
+      | AesGcmParams
+      | AesCfbParams,
+  ): Promise<ArrayBuffer>;
+}
+
+type AlgorithmIdentifier = string | Algorithm;
+
+type HashAlgorithmIdentifier = AlgorithmIdentifier;
+
+type KeyType = "private" | "public" | "secret";
+
+type KeyUsage =
+  | "decrypt"
+  | "deriveBits"
+  | "deriveKey"
+  | "encrypt"
+  | "sign"
+  | "unwrapKey"
+  | "verify"
+  | "wrapKey";
+
+interface CryptoKey {
+  readonly algorithm: Algorithm;
+  readonly extractable: boolean;
+  readonly type: KeyType;
+  readonly usages: KeyUsage[];
+}
+
+interface CryptoKeyPair {
+  privateKey?: CryptoKey;
+  publicKey?: CryptoKey;
+}
+
+interface JsonWebKey {
+  alg?: string;
+  crv?: string;
+  d?: string;
+  dp?: string;
+  dq?: string;
+  e?: string;
+  ext?: boolean;
+  k?: string;
+  key_ops?: string[];
+  kty?: string;
+  n?: string;
+  oth?: RsaOtherPrimesInfo[];
+  p?: string;
+  q?: string;
+  qi?: string;
+  use?: string;
+  x?: string;
+  y?: string;
+}
+
+interface Algorithm {
+  name: string;
+}
+
+interface RsaHashedImportParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+}
+
+interface RsaHashedKeyGenParams extends RsaKeyGenParams {
+  hash: HashAlgorithmIdentifier;
+}
+
+interface RsaKeyGenParams extends Algorithm {
+  modulusLength: number;
+  publicExponent: Uint8Array;
+}
+
+interface RsaOaepParams extends Algorithm {
+  label?:
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | ArrayBuffer;
+}
+
+interface RsaOtherPrimesInfo {
+  d?: string;
+  r?: string;
+  t?: string;
+}
+
+interface RsaPssParams extends Algorithm {
+  saltLength: number;
+}
+
+interface AesCbcParams extends Algorithm {
+  iv:
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | ArrayBuffer;
+}
+
+interface AesCtrParams extends Algorithm {
+  counter:
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | ArrayBuffer;
+  length: number;
+}
+
+interface AesDerivedKeyParams extends Algorithm {
+  length: number;
+}
+
+interface AesGcmParams extends Algorithm {
+  additionalData?:
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | ArrayBuffer;
+  iv:
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | ArrayBuffer;
+  tagLength?: number;
+}
+
+interface AesKeyAlgorithm extends Algorithm {
+  length: number;
+}
+
+interface AesKeyGenParams extends Algorithm {
+  length: number;
+}
+
+interface AesCfbParams extends Algorithm {
+  iv:
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | ArrayBuffer;
+}
+
+interface AesCmacParams extends Algorithm {
+  length: number;
+}
+
+interface EcKeyGenParams extends Algorithm {
+  namedCurve: string;
+}
+
+interface EcKeyImportParams extends Algorithm {
+  namedCurve: string;
+}
+
+interface EcdhKeyDeriveParams extends Algorithm {
+  public: CryptoKey;
+}
+
+interface EcdsaParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+}
+
+interface DhImportKeyParams extends Algorithm {
+  generator: Uint8Array;
+  prime: Uint8Array;
+}
+
+interface DhKeyAlgorithm extends Algorithm {
+  generator: Uint8Array;
+  prime: Uint8Array;
+}
+
+interface DhKeyDeriveParams extends Algorithm {
+  public: CryptoKey;
+}
+
+interface DhKeyGenParams extends Algorithm {
+  generator: Uint8Array;
+  prime: Uint8Array;
+}
+
+interface ConcatParams extends Algorithm {
+  algorithmId: Uint8Array;
+  hash?: string | Algorithm;
+  partyUInfo: Uint8Array;
+  partyVInfo: Uint8Array;
+  privateInfo?: Uint8Array;
+  publicInfo?: Uint8Array;
+}
+
+interface HkdfParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  info:
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | ArrayBuffer;
+  salt:
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | ArrayBuffer;
+}
+
+interface HmacImportParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  length?: number;
+}
+
+interface HmacKeyGenParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  length?: number;
+}
+
+interface Pbkdf2Params extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  iterations: number;
+  salt:
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | ArrayBuffer;
+}

--- a/op_crates/crypto/lib.rs
+++ b/op_crates/crypto/lib.rs
@@ -11,6 +11,7 @@ use deno_core::ZeroCopyBuf;
 use rand::rngs::StdRng;
 use rand::thread_rng;
 use rand::Rng;
+use std::path::PathBuf;
 
 pub use rand; // Re-export rand
 
@@ -40,4 +41,8 @@ pub fn op_crypto_get_random_values(
   }
 
   Ok(json!({}))
+}
+
+pub fn get_declaration() -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("lib.deno_crypto.d.ts")
 }

--- a/runtime/ops/crypto.rs
+++ b/runtime/ops/crypto.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
-use deno_crypto::op_crypto_get_random_values;
+
 use deno_crypto::rand::rngs::StdRng;
 use deno_crypto::rand::SeedableRng;
 
@@ -13,6 +13,6 @@ pub fn init(rt: &mut deno_core::JsRuntime, maybe_seed: Option<u64>) {
   super::reg_json_sync(
     rt,
     "op_crypto_get_random_values",
-    op_crypto_get_random_values,
+    deno_crypto::op_crypto_get_random_values,
   );
 }


### PR DESCRIPTION
First step to solve #1891.

This PR adds the common code for the Web Crypto API, i.e.:
- TypeScript Type definitions
- Core logic in the JS wrapper related to algorithm normalisation

# Progress

We document progress on solving #1891 here:

- [x] Type definitions (#8984)
- [ ] JS wrapper
  - [x] Algorithm normalization (#8984)
  - [ ] Serialising `keyUsages`
- [x] Tests
  - [x] Add wpt (@lucacasonato #8990)
  - [x] Make wpt run `.worker.js` test suites (#9065)
- [x] Pick a crypto library (starting with [ring](https://docs.rs/ring/0.16.19/ring/index.html), then will complement with others for missing operations)
- [ ] Implementations
  - [ ] `decrypt()`
  - [ ] `deriveBits()`
  - [ ] `deriveKey()`
  - [x] `digest()` (#9069)
  - [ ] `encrypt()`
  - [ ] `exportKey()`
  - [ ] `generateKey()`
  - [ ] `importKey()`
  - [ ] `sign()`
  - [ ] `unwrapKey()`
  - [ ] `verify()`
  - [ ] `wrapKey()`
- [ ] Various fixes
  - [x] Make `getRandomValues()` spec-compliant (#9016)
  - [x] Rename `op_get_random_values` to `op_crypto_get_random_values` (#9067)
  
# Design

## Type definitions

The type definitions have been taken from https://github.com/microsoft/TypeScript/blob/2428ade1a91248e847f3e1561e31a9426650efee/src/lib/webworker.generated.d.ts#L3060.
They are consistent with the [W3C recommendation](https://www.w3.org/TR/WebCryptoAPI/).
I made a slight change regarding the `keyUsages` parameters by giving them the type `Iterable<KeyUsage>` instead of `KeyUsage[]`. Indeed, Chrome, Firefox and Safari all accept iterables of strings, not just arrays (the specs don't specify the exact type; they just mention "sequences").

## JavaScript wrapper

### crypto.subtle

I went with a simple literal object for `crypto.subtle`, as we had with `crypto` itself. It's not how Chrome, Firefox and Safari do it: they expose the "classes" `Crypto` and `SubtleCrypto`, which can't be instantiated. The methods of `crypto` and `crypto.subtle` aren't in the object itself but on the respective prototype.
Let me know if you want me to mirror that behaviour in Deno.

### JS side vs. Rust side

The validation logic and the dictionary of algorithms are handled on the JS side because:
- It more convenient for me. I wouldn't know how to do the same thing with Rust without some research.
- Building a new object that we control before serialising it for Rust is probably faster and safer than serialising whatever the caller provides directly. If the caller provides an object with circular references and a lot of data, this won't impact performance as we only serialise what we need.

### Returning buffers

We instantiate buffers on the JS side as `ArrayBuffer`, pass them wrapped in an `Uint8Array` to the Rust side as zero-copy buffers, then fill them with the data that is supposed to be returned.
That way, we don't have to serialise the data returned by the underlying crypto library when it is large.

However, this assumes that we know in advance the size of the `ArrayBuffer` on the JS side. So far, this hasn't been a big issue, but it does add complexity.

It would be handy if we could instantiate an `ArrayBuffer` directly on the Rust side and return a handle to the JS side.

## Underlying crypto library

<details>
  <summary>Deliberating which crypto library to pick</summary>

   It's not clear which crypto library I should use to implement the Rust ops.
- [ring](https://briansmith.org/rustdoc/ring/) seems to be the go-to crypto library in Rust, but it doesn't support RSA key generation (see https://github.com/briansmith/ring/issues/219). Someone attempted a pull request a while back (see https://github.com/briansmith/ring/pull/733) but the maintainer seemed unresponsive and it stalled. I find that a bit concerning, so I don't know if I should go with ring.
- Firefox relies on [NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS) for the Web Crypto API. Sadly there are no up-to-date crate with bindings for it.
- Safari and Chrome seem to mostly rely on OpenSSL. That would be the safe choice, but integrating OpenSSL has some [non-trivial requirements](https://docs.rs/openssl/0.10.32/openssl/). I'm too green on Deno to understand the implications and determine whether this would be a benign change or something to avoid.

I require some guidance as to which library should be included. Once it's decided, I expect the implementations to be rather easy.

</details>

We will go for [ring](https://docs.rs/ring/0.16.19/ring/index.html), as [per @lucacasonato's recommendation](https://github.com/denoland/deno/pull/8984#issuecomment-754352264). It won't be enough to implement all operations, but we'll see when that comes up.

## Testing

Chrome, Firefox and Safari all share the same test suite for the Web Crypto API, as they just vendored the relevant tests from [web-platform-tests](https://github.com/web-platform-tests/wpt). I figured that the safest and easiest way to test the Web Crypto API on deno would be to do the same.

However, web-platform-tests are meant to run in browsers. There is a heavy reliance on a DOM, and scripts are assumed to be running in the global scope. To be able to run those tests unchanged in Deno, we would need to reimplement their [JavaScript test harness](https://github.com/web-platform-tests/wpt/blob/master/resources/testharness.js) from scratch.

~I deemed this not worth the effort, and settled on rewriting the tests so that they can directly run as unit tests in Deno. It has the advantage of making the test suite more idiomatic (and arguably easier to read as it's in modern TypeScript, as opposed to ES5). However it makes it all the more challenging to follow upstream. I don't think it's a big deal given the very slow rate of changes there, but it ought to be mentioned.~

@lucacasonato added the the web-platform-tests as part of #8990.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
