### PR TITLE
fix(inspector): kill child process after test

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1,7 +1,9 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use deno_core::futures;
 use deno_core::futures::prelude::*;
+use deno_core::serde_json;
 use deno_core::url;
+use deno_runtime::deno_fetch::reqwest;
 use std::io::{BufRead, Write};
 use std::process::Command;
 use tempfile::TempDir;
@@ -4343,6 +4345,64 @@ async fn inspector_runtime_evaluate_does_not_crash() {
 
   drop(stdin);
   child.wait().unwrap();
+}
+
+#[tokio::test]
+async fn inspector_json() {
+  let script = util::tests_path().join("inspector1.js");
+  let mut child = util::deno_cmd()
+    .arg("run")
+    .arg(inspect_flag_with_unique_port("--inspect"))
+    .arg(script)
+    .stderr(std::process::Stdio::piped())
+    .spawn()
+    .unwrap();
+
+  let stderr = child.stderr.as_mut().unwrap();
+  let mut stderr_lines =
+    std::io::BufReader::new(stderr).lines().map(|r| r.unwrap());
+  let ws_url = extract_ws_url_from_stderr(&mut stderr_lines);
+  let mut url = ws_url.clone();
+  let _ = url.set_scheme("http");
+  url.set_path("/json");
+  let resp = reqwest::get(url).await.unwrap();
+  assert_eq!(resp.status(), reqwest::StatusCode::OK);
+  let endpoint_list: Vec<deno_core::serde_json::Value> =
+    serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+  let matching_endpoint = endpoint_list
+    .iter()
+    .find(|e| e["webSocketDebuggerUrl"] == ws_url.as_str());
+  assert!(matching_endpoint.is_some());
+  child.kill().unwrap();
+}
+
+#[tokio::test]
+async fn inspector_json_list() {
+  let script = util::tests_path().join("inspector1.js");
+  let mut child = util::deno_cmd()
+    .arg("run")
+    .arg(inspect_flag_with_unique_port("--inspect"))
+    .arg(script)
+    .stderr(std::process::Stdio::piped())
+    .spawn()
+    .unwrap();
+
+  let stderr = child.stderr.as_mut().unwrap();
+  let mut stderr_lines =
+    std::io::BufReader::new(stderr).lines().map(|r| r.unwrap());
+  let ws_url = extract_ws_url_from_stderr(&mut stderr_lines);
+  let mut url = ws_url.clone();
+  let _ = url.set_scheme("http");
+  url.set_path("/json/list");
+  let resp = reqwest::get(url).await.unwrap();
+  assert_eq!(resp.status(), reqwest::StatusCode::OK);
+  let endpoint_list: Vec<deno_core::serde_json::Value> =
+    serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+  let matching_endpoint = endpoint_list
+    .iter()
+    .find(|e| e["webSocketDebuggerUrl"] == ws_url.as_str());
+  assert!(matching_endpoint.is_some());
+  child.kill().unwrap();
 }
 
 #[test]

--- a/runtime/inspector.rs
+++ b/runtime/inspector.rs
@@ -182,20 +182,21 @@ fn handle_ws_request(
           .status(http::StatusCode::BAD_REQUEST)
           .body("Not a valid Websocket Request".into()),
       });
-    tokio::task::spawn_local(async move {
-      let upgraded = body.on_upgrade().await.unwrap();
-      let websocket = tokio_tungstenite::WebSocketStream::from_raw_socket(
-        upgraded,
-        tungstenite::protocol::Role::Server,
-        None,
-      )
-      .await;
-      let (proxy, pump) = create_websocket_proxy(websocket);
+    if resp.is_ok() {
+      tokio::task::spawn_local(async move {
+        let upgraded = body.on_upgrade().await.unwrap();
+        let websocket = tokio_tungstenite::WebSocketStream::from_raw_socket(
+          upgraded,
+          tungstenite::protocol::Role::Server,
+          None,
+        )
+        .await;
+        let (proxy, pump) = create_websocket_proxy(websocket);
 
-      let _ = new_websocket_tx.unbounded_send(proxy);
-      pump.await;
-    });
-
+        let _ = new_websocket_tx.unbounded_send(proxy);
+        pump.await;
+      });
+    }
     resp
   } else {
     http::Response::builder()
@@ -275,11 +276,14 @@ async fn server(
             (&http::Method::GET, path) if path.starts_with("/ws/") => {
               handle_ws_request(req, inspector_map.clone())
             }
+            (&http::Method::GET, "/json/version") => {
+              handle_json_version_request(json_version_response.clone())
+            }
             (&http::Method::GET, "/json") => {
               handle_json_request(inspector_map.clone())
             }
-            (&http::Method::GET, "/json/version") => {
-              handle_json_version_request(json_version_response.clone())
+            (&http::Method::GET, "/json/list") => {
+              handle_json_request(inspector_map.clone())
             }
             _ => http::Response::builder()
               .status(http::StatusCode::NOT_FOUND)


### PR DESCRIPTION
The child process kept running and printing "hello" to stdout.

This commit also removes the dependency on reqwest and instead
switches to the re-export from the fetch crate.

Refs commit 1a2e7741c33490d2a91147966019853c6b1d6a48.

Closes #8979

cc @lucacasonato @lperlaki