### PR TITLE
docs(examples): Close connections in TCP echo server

### DIFF
--- a/docs/examples/tcp_echo.md
+++ b/docs/examples/tcp_echo.md
@@ -19,7 +19,7 @@ returns to the client anything it sends.
 const listener = Deno.listen({ port: 8080 });
 console.log("listening on 0.0.0.0:8080");
 for await (const conn of listener) {
-  Deno.copy(conn, conn);
+  Deno.copy(conn, conn).finally(() => conn.close());
 }
 ```
 


### PR DESCRIPTION
Based on discussion with @lucacasonato in the #help chat.

I was confused at first and thought connections were automatically closed, since the TCP echo server example did not explicitly call `conn.close()`. But I understand now the example is wrong and leaks resources. This should fix it.