### PR TITLE
docs(example/tcp_echo): fix TCP echo leaking resources

### DIFF
--- a/docs/examples/tcp_echo.md
+++ b/docs/examples/tcp_echo.md
@@ -19,7 +19,7 @@ returns to the client anything it sends.
 const listener = Deno.listen({ port: 8080 });
 console.log("listening on 0.0.0.0:8080");
 for await (const conn of listener) {
-  Deno.copy(conn, conn);
+  Deno.copy(conn, conn).finally(() => conn.close());
 }
 ```
 


### PR DESCRIPTION
As pointed out by @mk12 in the this pull request https://github.com/denoland/deno/pull/8991 The TCP echo server leaks resources as it does not close the connection. This fixes that bug. This is done in place of his PR as he is unable / unwilling to attempt get the CLA past his employer. I have no such restrictions. There are no tests to cover this as it's an documentation example.