### PR TITLE
feat(web): Implement DOMException#code

### DIFF
--- a/cli/tests/unit/dom_exception_test.ts
+++ b/cli/tests/unit/dom_exception_test.ts
@@ -6,4 +6,13 @@ unitTest(function testDomError() {
   assert(de);
   assertEquals(de.message, "foo");
   assertEquals(de.name, "bar");
+  assertEquals(de.code, 0);
+});
+
+unitTest(function testKnownDomException() {
+  const de = new DOMException("foo", "SyntaxError");
+  assert(de);
+  assertEquals(de.message, "foo");
+  assertEquals(de.name, "SyntaxError");
+  assertEquals(de.code, 12);
 });

--- a/cli/tests/wpt.jsonc
+++ b/cli/tests/wpt.jsonc
@@ -170,14 +170,7 @@
       ]
     },
     "measure-l3",
-    {
-      "name": "structured-serialize-detail",
-      "expectFail": [
-        // TODO(lucacasonato): re-enable when we use real structured clone.
-        "Mark: Throw an exception when the detail property cannot be structured-serialized.",
-        "Measure: Throw an exception when the detail property cannot be structured-serialized."
-      ]
-    },
+    "structured-serialize-detail",
     "user_timing_exists"
   ]
 }

--- a/op_crates/web/00_dom_exception.js
+++ b/op_crates/web/00_dom_exception.js
@@ -1,29 +1,32 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
-  const nameToCodeMapping = Object.create(null);
-  nameToCodeMapping.IndexSizeError = 1;
-  nameToCodeMapping.HierarchyRequestError = 3;
-  nameToCodeMapping.WrongDocumentError = 4;
-  nameToCodeMapping.InvalidCharacterError = 5;
-  nameToCodeMapping.NoModificationAllowedError = 7;
-  nameToCodeMapping.NotFoundError = 8;
-  nameToCodeMapping.NotSupportedError = 9;
-  nameToCodeMapping.InvalidStateError = 11;
-  nameToCodeMapping.SyntaxError = 12;
-  nameToCodeMapping.InvalidModificationError = 13;
-  nameToCodeMapping.NamespaceError = 14;
-  nameToCodeMapping.InvalidAccessError = 15;
-  nameToCodeMapping.TypeMismatchError = 17;
-  nameToCodeMapping.SecurityError = 18;
-  nameToCodeMapping.NetworkError = 19;
-  nameToCodeMapping.AbortError = 20;
-  nameToCodeMapping.URLMismatchError = 21;
-  nameToCodeMapping.QuotaExceededError = 22;
-  nameToCodeMapping.TimeoutError = 23;
-  nameToCodeMapping.InvalidNodeTypeError = 24;
-  nameToCodeMapping.DataCloneError = 25;
-
+  const nameToCodeMapping = Object.create(
+    null,
+    {
+      IndexSizeError: { value: 1 },
+      HierarchyRequestError: { value: 3 },
+      WrongDocumentError: { value: 4 },
+      InvalidCharacterError: { value: 5 },
+      NoModificationAllowedError: { value: 7 },
+      NotFoundError: { value: 8 },
+      NotSupportedError: { value: 9 },
+      InvalidStateError: { value: 11 },
+      SyntaxError: { value: 12 },
+      InvalidModificationError: { value: 13 },
+      NamespaceError: { value: 14 },
+      InvalidAccessError: { value: 15 },
+      TypeMismatchError: { value: 17 },
+      SecurityError: { value: 18 },
+      NetworkError: { value: 19 },
+      AbortError: { value: 20 },
+      URLMismatchError: { value: 21 },
+      QuotaExceededError: { value: 22 },
+      TimeoutError: { value: 23 },
+      InvalidNodeTypeError: { value: 24 },
+      DataCloneError: { value: 25 },
+    },
+  );
   class DOMException extends Error {
     #name = "";
     #code = 0;

--- a/op_crates/web/00_dom_exception.js
+++ b/op_crates/web/00_dom_exception.js
@@ -1,15 +1,50 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-class DOMException extends Error {
-  #name = "";
+((window) => {
+  const nameToCodeMapping = new Map(
+    Object.entries({
+      IndexSizeError: 1,
+      HierarchyRequestError: 3,
+      WrongDocumentError: 4,
+      InvalidCharacterError: 5,
+      NoModificationAllowedError: 7,
+      NotFoundError: 8,
+      NotSupportedError: 9,
+      InvalidStateError: 11,
+      SyntaxError: 12,
+      InvalidModificationError: 13,
+      NamespaceError: 14,
+      InvalidAccessError: 15,
+      TypeMismatchError: 17,
+      SecurityError: 18,
+      NetworkError: 19,
+      AbortError: 20,
+      URLMismatchError: 21,
+      QuotaExceededError: 22,
+      TimeoutError: 23,
+      InvalidNodeTypeError: 24,
+      DataCloneError: 25,
+    }),
+  );
 
-  constructor(message = "", name = "Error") {
-    super(message);
-    this.#name = name;
+  class DOMException extends Error {
+    #name = "";
+    #code = 0;
+
+    constructor(message = "", name = "Error") {
+      super(message);
+      this.#name = name;
+      this.#code = nameToCodeMapping.get(name) ?? 0;
+    }
+
+    get name() {
+      return this.#name;
+    }
+
+    get code() {
+      return this.#code;
+    }
   }
 
-  get name() {
-    return this.#name;
-  }
-}
+  window.DOMException = DOMException;
+})(this);

--- a/op_crates/web/00_dom_exception.js
+++ b/op_crates/web/00_dom_exception.js
@@ -2,7 +2,7 @@
 
 ((window) => {
   const nameToCodeMapping = Object.create(null);
-  nameToCodeMatting.IndexSizeError = 1;
+  nameToCodeMapping.IndexSizeError = 1;
   nameToCodeMapping.HierarchyRequestError = 3;
   nameToCodeMapping.WrongDocumentError = 4;
   nameToCodeMapping.InvalidCharacterError = 5;

--- a/op_crates/web/00_dom_exception.js
+++ b/op_crates/web/00_dom_exception.js
@@ -1,31 +1,28 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
-  const nameToCodeMapping = new Map(
-    Object.entries({
-      IndexSizeError: 1,
-      HierarchyRequestError: 3,
-      WrongDocumentError: 4,
-      InvalidCharacterError: 5,
-      NoModificationAllowedError: 7,
-      NotFoundError: 8,
-      NotSupportedError: 9,
-      InvalidStateError: 11,
-      SyntaxError: 12,
-      InvalidModificationError: 13,
-      NamespaceError: 14,
-      InvalidAccessError: 15,
-      TypeMismatchError: 17,
-      SecurityError: 18,
-      NetworkError: 19,
-      AbortError: 20,
-      URLMismatchError: 21,
-      QuotaExceededError: 22,
-      TimeoutError: 23,
-      InvalidNodeTypeError: 24,
-      DataCloneError: 25,
-    }),
-  );
+  const nameToCodeMapping = Object.create(null);
+  nameToCodeMatting.IndexSizeError = 1;
+  nameToCodeMapping.HierarchyRequestError = 3;
+  nameToCodeMapping.WrongDocumentError = 4;
+  nameToCodeMapping.InvalidCharacterError = 5;
+  nameToCodeMapping.NoModificationAllowedError = 7;
+  nameToCodeMapping.NotFoundError = 8;
+  nameToCodeMapping.NotSupportedError = 9;
+  nameToCodeMapping.InvalidStateError = 11;
+  nameToCodeMapping.SyntaxError = 12;
+  nameToCodeMapping.InvalidModificationError = 13;
+  nameToCodeMapping.NamespaceError = 14;
+  nameToCodeMapping.InvalidAccessError = 15;
+  nameToCodeMapping.TypeMismatchError = 17;
+  nameToCodeMapping.SecurityError = 18;
+  nameToCodeMapping.NetworkError = 19;
+  nameToCodeMapping.AbortError = 20;
+  nameToCodeMapping.URLMismatchError = 21;
+  nameToCodeMapping.QuotaExceededError = 22;
+  nameToCodeMapping.TimeoutError = 23;
+  nameToCodeMapping.InvalidNodeTypeError = 24;
+  nameToCodeMapping.DataCloneError = 25;
 
   class DOMException extends Error {
     #name = "";
@@ -34,7 +31,7 @@
     constructor(message = "", name = "Error") {
       super(message);
       this.#name = name;
-      this.#code = nameToCodeMapping.get(name) ?? 0;
+      this.#code = nameToCodeMapping[name] ?? 0;
     }
 
     get name() {

--- a/op_crates/web/lib.deno_web.d.ts
+++ b/op_crates/web/lib.deno_web.d.ts
@@ -9,6 +9,7 @@ declare class DOMException extends Error {
   constructor(message?: string, name?: string);
   readonly name: string;
   readonly message: string;
+  readonly code: number;
 }
 
 interface EventInit {


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Adds the `code` property to the class `DOMException`. It is pseudo-deprecated, as in new types of `DOMException` set it to zero. It is recommended for code to not rely on that value.
However, tests in the recently included web-platform-tests assert the value of the code, so we are forced to implement it. Issue #9009 highlights an example of such a test that rely on `code`.

Source of the values for each error type: https://developer.mozilla.org/en-US/docs/Web/API/DOMException#Error_names

cc @lucacasonato