### PR TITLE
BREAKING(std/wasi): return exit code from start

### DIFF
--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -270,7 +270,7 @@ interface FileDescriptor {
   entries?: Deno.DirEntry[];
 }
 
-export class ExitStatus {
+class ExitStatus {
   code: number;
 
   constructor(code: number) {
@@ -1656,7 +1656,7 @@ export default class Context {
    * which will be used as the address space, if it does not an error will be
    * thrown.
    */
-  start(instance: WebAssembly.Instance) {
+  start(instance: WebAssembly.Instance): null | number | never {
     if (this.#started) {
       throw new Error("WebAssembly.Instance has already started");
     }
@@ -1683,7 +1683,17 @@ export default class Context {
       );
     }
 
-    _start();
+    try {
+      _start();
+    } catch (err) {
+      if (err instanceof ExitStatus) {
+        return err.code;
+      }
+
+      throw err;
+    }
+
+    return null;
   }
 
   /**

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import Context, { ExitStatus } from "./snapshot_preview1.ts";
+import Context from "./snapshot_preview1.ts";
 import { assert, assertEquals, assertThrows } from "../testing/asserts.ts";
 import { copy } from "../fs/mod.ts";
 import * as path from "../path/mod.ts";
@@ -181,11 +181,25 @@ Deno.test("context_start", function () {
     "export _start must be a function",
   );
 
-  try {
+  {
     const context = new Context({
       exitOnReturn: false,
     });
-    context.start({
+    const exitCode = context.start({
+      exports: {
+        _start() {
+        },
+        memory: new WebAssembly.Memory({ initial: 1 }),
+      },
+    });
+    assertEquals(exitCode, null);
+  }
+
+  {
+    const context = new Context({
+      exitOnReturn: false,
+    });
+    const exitCode = context.start({
       exports: {
         _start() {
           const exit = context.exports["proc_exit"] as CallableFunction;
@@ -194,9 +208,7 @@ Deno.test("context_start", function () {
         memory: new WebAssembly.Memory({ initial: 1 }),
       },
     });
-  } catch (err) {
-    assert(err instanceof ExitStatus);
-    assertEquals(err.code, 0);
+    assertEquals(exitCode, 0);
   }
 
   assertThrows(


### PR DESCRIPTION
This returns the exit code directly from the start entry point instead of throwing it and making the user handle that specific kind of error which is a bit too convoluted.

As a result the exit status is an implementation detail and has been made internal.