### PR TITLE
fix(coverage): report partial lines as uncovered

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3315,6 +3315,12 @@ itest!(deno_test_coverage {
   exit_code: 0,
 });
 
+itest!(deno_test_branch_coverage {
+  args: "test --coverage --unstable test_branch_coverage.ts",
+  output: "test_branch_coverage.out",
+  exit_code: 0,
+});
+
 itest!(deno_test_coverage_explicit {
   args: "test --coverage=.test_coverage --unstable test_coverage.ts",
   output: "test_coverage.out",

--- a/cli/tests/subdir/branch.ts
+++ b/cli/tests/subdir/branch.ts
@@ -1,4 +1,4 @@
-export function branch(condition: boolean) : boolean {
+export function branch(condition: boolean): boolean {
   if (condition) {
     return true;
   } else {

--- a/cli/tests/subdir/branch.ts
+++ b/cli/tests/subdir/branch.ts
@@ -1,0 +1,7 @@
+export function branch(condition: boolean) : boolean {
+  if (condition) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/cli/tests/test_branch_coverage.out
+++ b/cli/tests/test_branch_coverage.out
@@ -1,0 +1,10 @@
+Check [WILDCARD]/tests/$deno$test.ts
+running 1 tests
+test branch ... ok ([WILDCARD])
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+cover [WILDCARD]/tests/subdir/branch.ts ... 66.667% (6/9)
+   5 |     else {
+   6 |         return false;
+   7 |     }

--- a/cli/tests/test_branch_coverage.ts
+++ b/cli/tests/test_branch_coverage.ts
@@ -1,0 +1,5 @@
+import { branch } from "./subdir/branch.ts";
+
+Deno.test("branch", function () {
+  branch(true);
+});


### PR DESCRIPTION
Had a little off by one error where new line was not being taken into account for line offsets. In turn this was hiding the fact that partial lines don't get reported as uncovered.

This fixes both issues.