### PR TITLE
github(probot): Add context information to stale bot message text

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -16,6 +16,6 @@ exemptMilestones: true
 staleLabel: stale
 
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
+  This issue [has been automatically marked as stale](https://probot.github.io/apps/stale/#how-it-works) because it has not had
+  recent activity. It will be closed in 7 days if no further activity occurs. Thank you
   for your contributions.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -16,6 +16,6 @@ exemptMilestones: true
 staleLabel: stale
 
 markComment: >
-  This issue [has been automatically marked as stale](https://probot.github.io/apps/stale/#how-it-works) because it has not had
-  recent activity. It will be closed in 7 days if no further activity occurs. Thank you
-  for your contributions.
+  This issue [has been automatically marked as stale](https://probot.github.io/apps/stale/#how-it-works)
+  because it has not had recent activity. It will be closed in 7 days if no
+  further activity occurs. Thank you for your contributions.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -16,6 +16,6 @@ exemptMilestones: true
 staleLabel: stale
 
 markComment: >
-  This issue [has been automatically marked as stale](https://probot.github.io/apps/stale/#how-it-works)
+  This issue has been [automatically marked as stale](https://probot.github.io/apps/stale/#how-it-works)
   because it has not had recent activity. It will be closed in 7 days if no
   further activity occurs. Thank you for your contributions.


### PR DESCRIPTION
Closes #9035

This PR adds a bit of contextual information to the message text that the stale bot posts on issues:

Before:

> This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.

After:

> This issue [has been automatically marked as stale](https://probot.github.io/apps/stale/#how-it-works) because it has not had recent activity. It will be closed in 7 days if no further activity occurs. Thank you for your contributions.