### PR TITLE
fix(WebSocket): throw DOMException in case of protocol & fragments error

### DIFF
--- a/op_crates/websocket/01_websocket.js
+++ b/op_crates/websocket/01_websocket.js
@@ -72,14 +72,14 @@
       if (wsURL.protocol !== "ws:" && wsURL.protocol !== "wss:") {
         throw new DOMException(
           "Only ws & wss schemes are allowed in a WebSocket URL.",
-          "SyntaxError",
+          "DOMException",
         );
       }
 
       if (wsURL.hash !== "" || wsURL.href.endsWith("#")) {
         throw new DOMException(
           "Fragments are not allowed in a WebSocket URL.",
-          "SyntaxError",
+          "DOMException",
         );
       }
 


### PR DESCRIPTION
`WebSocket` in chrome throws `DOMException` in case of:
1. Invalid protocol passed
2. Fragments issue

Whereas we throw `SyntaxError` in the string (though the instance is of `DOMException` only)

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
