### PR TITLE
feat(plugins): wrapped plugin ops, register_json_op_sync and register_json_op_async

### DIFF
--- a/core/ops.rs
+++ b/core/ops.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::error::bad_resource_id;
 use crate::error::type_error;

--- a/core/plugin_api.rs
+++ b/core/plugin_api.rs
@@ -14,8 +14,8 @@ pub use crate::ZeroCopyBuf;
 
 pub type InitFn = fn(&mut dyn Interface);
 
-pub type DispatchOpFn = fn(&mut dyn Interface, &mut [ZeroCopyBuf]) -> Op;
+pub type DispatchOpFn = dyn Fn(&mut dyn Interface, &mut [ZeroCopyBuf]) -> Op;
 
 pub trait Interface {
-  fn register_op(&mut self, name: &str, dispatcher: DispatchOpFn) -> OpId;
+  fn register_op(&mut self, name: &str, dispatcher: Box<DispatchOpFn>) -> OpId;
 }

--- a/core/plugin_api.rs
+++ b/core/plugin_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // This file defines the public interface for dynamically loaded plugins.
 
@@ -12,10 +12,34 @@ pub use crate::Op;
 pub use crate::OpId;
 pub use crate::ZeroCopyBuf;
 
+use crate::error::AnyError;
+use futures::Future;
+use serde_json::Value;
+
 pub type InitFn = fn(&mut dyn Interface);
 
 pub type DispatchOpFn = dyn Fn(&mut dyn Interface, &mut [ZeroCopyBuf]) -> Op;
+pub type JsonOpSync = dyn Fn(
+  &mut dyn Interface,
+  Value,
+  &mut [ZeroCopyBuf],
+) -> Result<Value, AnyError>;
+pub type JsonOpAsync = dyn Fn(
+  &mut dyn Interface,
+  Value,
+  &mut [ZeroCopyBuf],
+) -> (dyn Future<Output = Result<Value, AnyError>>);
 
 pub trait Interface {
   fn register_op(&mut self, name: &str, dispatcher: Box<DispatchOpFn>) -> OpId;
+  fn register_json_op_sync(
+    &mut self,
+    name: &str,
+    dispatcher: Box<JsonOpSync>,
+  ) -> OpId;
+  fn register_json_op_async(
+    &mut self,
+    name: &str,
+    dispatcher: Box<JsonOpAsync>,
+  ) -> OpId;
 }

--- a/runtime/ops/plugin.rs
+++ b/runtime/ops/plugin.rs
@@ -109,7 +109,7 @@ impl<'a> plugin_api::Interface for PluginInterface<'a> {
   fn register_op(
     &mut self,
     name: &str,
-    dispatch_op_fn: plugin_api::DispatchOpFn,
+    dispatch_op_fn: Box<plugin_api::DispatchOpFn>,
   ) -> OpId {
     let plugin_lib = self.plugin_lib.clone();
     let plugin_op_fn = move |state_rc: Rc<RefCell<OpState>>,

--- a/test_plugin/src/lib.rs
+++ b/test_plugin/src/lib.rs
@@ -1,5 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-
+use deno_core::plugin_api::DispatchOpFn;
 use deno_core::plugin_api::Interface;
 use deno_core::plugin_api::Op;
 use deno_core::plugin_api::ZeroCopyBuf;
@@ -7,8 +6,9 @@ use futures::future::FutureExt;
 
 #[no_mangle]
 pub fn deno_plugin_init(interface: &mut dyn Interface) {
-  interface.register_op("testSync", op_test_sync);
-  interface.register_op("testAsync", op_test_async);
+  interface.register_op("testSync", Box::new(op_test_sync));
+  interface.register_op("testAsync", Box::new(op_test_async));
+  interface.register_op("testWrapped", wrap_op(op_wrapped));
 }
 
 fn op_test_sync(
@@ -37,6 +37,47 @@ fn op_test_async(
   }
   let zero_copy = zero_copy.to_vec();
   let fut = async move {
+    for (idx, buf) in zero_copy.iter().enumerate() {
+      let buf_str = std::str::from_utf8(&buf[..]).unwrap();
+      println!("zero_copy[{}]: {}", idx, buf_str);
+    }
+    let (tx, rx) = futures::channel::oneshot::channel::<Result<(), ()>>();
+    std::thread::spawn(move || {
+      std::thread::sleep(std::time::Duration::from_secs(1));
+      tx.send(Ok(())).unwrap();
+    });
+    assert!(rx.await.is_ok());
+    let result = b"test";
+    let result_box: Box<[u8]> = Box::new(*result);
+    result_box
+  };
+
+  Op::Async(fut.boxed())
+}
+
+fn wrap_op<D>(d: D) -> Box<DispatchOpFn>
+where
+  D: Fn(&mut dyn Interface, String, &mut [ZeroCopyBuf]) -> Op + 'static,
+{
+  Box::new(
+    move |i: &mut dyn Interface, zero_copy: &mut [ZeroCopyBuf]| {
+      let first_buf_str = std::str::from_utf8(&zero_copy[0][..]).unwrap();
+      d(i, first_buf_str.to_string(), &mut zero_copy[1..])
+    },
+  )
+}
+
+fn op_wrapped(
+  _interface: &mut dyn Interface,
+  first_buf_str: String,
+  zero_copy: &mut [ZeroCopyBuf],
+) -> Op {
+  if !zero_copy.is_empty() {
+    println!("Hello from wrapped op.");
+  }
+  let zero_copy = zero_copy.to_vec();
+  let fut = async move {
+    println!("first_buf: {}", first_buf_str);
     for (idx, buf) in zero_copy.iter().enumerate() {
       let buf_str = std::str::from_utf8(&buf[..]).unwrap();
       println!("zero_copy[{}]: {}", idx, buf_str);

--- a/test_plugin/tests/integration_tests.rs
+++ b/test_plugin/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // To run this test manually:
 //   cd test_plugin
 //   ../target/debug/deno run --unstable --allow-plugin tests/test.js debug
@@ -37,7 +37,7 @@ fn basic() {
     println!("stderr {}", stderr);
   }
   assert!(output.status.success());
-  let expected = "Hello from plugin.\nzero_copy[0]: test\nzero_copy[1]: 123\nzero_copy[2]: cba\nPlugin Sync Response: test\nHello from plugin.\nzero_copy[0]: test\nzero_copy[1]: 123\nPlugin Async Response: test\n";
+  let expected = "Hello from plugin.\nzero_copy[0]: test\nzero_copy[1]: 123\nzero_copy[2]: cba\nPlugin Sync Response: test\nHello from plugin.\nzero_copy[0]: test\nzero_copy[1]: 123\nPlugin Async Response: test\nHello from wrapped op.\nfirst_buf: test\nzero_copy[0]: 123\nPlugin Wrapped Response: test\n";
   assert_eq!(stdout, expected);
   assert_eq!(stderr, "");
 }


### PR DESCRIPTION
Adds support for wrapped plugins, and adds two new methods to the `PluginInterface`: `register_json_op_sync` and `register_json_op_async`.

Todo:
- [x] wrapped ops
- [ ] tests
- [ ] `register_json_op_async` currently throws an error which needs to be fixed