### PR TITLE
test(cli): add wpt url tests

### DIFF
--- a/cli/tests/wpt.jsonc
+++ b/cli/tests/wpt.jsonc
@@ -173,5 +173,26 @@
     "measure-l3",
     "structured-serialize-detail",
     "user_timing_exists"
+  ],
+  "url": [
+    // TODO(kt3k): enable the commented out tests
+    // "percent-encoding.window",
+    // "toascii.window",
+    // "url-constructor.any",
+    // "url-origin.any",
+    // "url-searchparams.any",
+    // "url-setters-stripping.any",
+    "url-tojson.any",
+    // "urlencoded-parser.any",
+    "urlsearchparams-append.any",
+    // "urlsearchparams-constructor.any",
+    "urlsearchparams-delete.any",
+    // "urlsearchparams-foreach.any",
+    "urlsearchparams-get.any",
+    "urlsearchparams-getall.any",
+    "urlsearchparams-has.any",
+    "urlsearchparams-set.any",
+    "urlsearchparams-sort.any",
+    "urlsearchparams-stringifier.any"
   ]
 }


### PR DESCRIPTION
This PR adds web platform "url" tests. Commented out test cases which cause error when loading the test harness (`percent-encoding.window`, `toascii.window`, `url-constructor.any`, etc). `urlencoded-parser.any` and `url-setters-stripping.any` have many test failures. Probably we need to fix actual bugs of the current URL implementation to pass these in future.

ref: #9001