### PR TITLE
fix(cli): dispatch unload on exit

### DIFF
--- a/cli/tests/078_unload_on_exit.ts
+++ b/cli/tests/078_unload_on_exit.ts
@@ -1,0 +1,4 @@
+window.onunload = () => {
+  console.log("onunload is called");
+};
+Deno.exit(0);

--- a/cli/tests/078_unload_on_exit.ts.out
+++ b/cli/tests/078_unload_on_exit.ts.out
@@ -1,0 +1,1 @@
+[WILDCARD]onunload is called

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2632,7 +2632,7 @@ itest!(_077_fetch_empty {
 });
 
 itest!(_078_unload_on_exit {
-  args: "run -A 078_unload_on_exit.ts",
+  args: "run 078_unload_on_exit.ts",
   output: "078_unload_on_exit.ts.out",
 });
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2631,6 +2631,11 @@ itest!(_077_fetch_empty {
   exit_code: 1,
 });
 
+itest!(_078_unload_on_exit {
+  args: "run -A 078_unload_on_exit.ts",
+  output: "078_unload_on_exit.ts.out",
+});
+
 itest!(js_import_detect {
   args: "run --quiet --reload js_import_detect.ts",
   output: "js_import_detect.ts.out",

--- a/runtime/js/30_os.js
+++ b/runtime/js/30_os.js
@@ -24,6 +24,9 @@
   }
 
   function exit(code = 0) {
+    // Invokes the `unload` hooks before exiting
+    // ref: https://github.com/denoland/deno/issues/3603
+    window.dispatchEvent(new Event("unload"));
     core.jsonOpSync("op_exit", { code });
     throw new Error("Code not reachable");
   }


### PR DESCRIPTION
This PR adds the dispatching of `unload` event before sending op_exit. Closes #3603.

(The issue also suggests it should call `unload` hooks at signals like `SIGINT`, etc, but that seems very difficult (complex) to implement because if the process attach something to signal, the default behavior is lost. So we need to simulate the default behavior for each signal to do that, but that seems unreasonably complex to implement and maintain.)
