### PR TITLE
fix(watcher): keep working even when imported files has invalid syntax

### DIFF
--- a/cli/file_watcher.rs
+++ b/cli/file_watcher.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
 use core::task::{Context, Poll};

--- a/cli/file_watcher.rs
+++ b/cli/file_watcher.rs
@@ -172,7 +172,7 @@ where
   let mut debounce = Debounce::new();
   // Store previous data. If module resolution fails at some point, the watcher will try to
   // continue watching files using these data.
-  let mut paths;
+  let mut paths = Vec::new();
   let mut module = None;
 
   loop {
@@ -185,7 +185,10 @@ where
         module = Some(module_info);
       }
       ModuleResolutionResult::Fail { source_path, error } => {
-        paths = vec![source_path];
+        if paths.is_empty() {
+          paths = vec![source_path];
+        }
+
         if module.is_none() {
           eprintln!("{}: {}", colors::red_bold("error"), error);
         }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 use deno_core::futures;
 use deno_core::futures::prelude::*;
 use deno_core::serde_json;

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1488,7 +1488,7 @@ fn wait_for_process_finished(
 }
 
 #[test]
-//#[ignore]
+#[ignore]
 fn run_watch() {
   let t = TempDir::new().expect("tempdir fail");
   let file_to_watch = t.path().join("file_to_watch.js");


### PR DESCRIPTION
Fixes #9008 

In this PR, I have added a test that works fine on my machine. But unfortunately, because the test cases related to watcher functionality are quite flaky (ref #8571),  this test is marked as `#[ignore]`. This means the test I added here won't be executed in CI.