### PR TITLE
chore: update copyright to 2021

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+# Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 max_width = 80
 tab_spaces = 2
 edition = "2018"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+# Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 [package]
 name = "deno"

--- a/cli/ast.rs
+++ b/cli/ast.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::media_type::MediaType;
 use crate::tsc_config;

--- a/cli/bench/deno_http_proxy.ts
+++ b/cli/bench/deno_http_proxy.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { serve, ServerRequest } from "../std/http/server.ts";
 
 const addr = Deno.args[0] || "127.0.0.1:4500";

--- a/cli/bench/deno_tcp.ts
+++ b/cli/bench/deno_tcp.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Used for benchmarking Deno's networking.
 // TODO Replace this with a real HTTP server once
 // https://github.com/denoland/deno/issues/726 is completed.

--- a/cli/bench/deno_tcp_proxy.ts
+++ b/cli/bench/deno_tcp_proxy.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Used for benchmarking Deno's tcp proxy performance.
 const addr = Deno.args[0] || "127.0.0.1:4500";
 const originAddr = Deno.args[1] || "127.0.0.1:4501";

--- a/cli/bench/http.rs
+++ b/cli/bench/http.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use super::Result;
 use std::{

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::serde_json::{self, map::Map, Number, Value};
 use std::{

--- a/cli/bench/node_http.js
+++ b/cli/bench/node_http.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 const http = require("http");
 const port = process.argv[2] || "4544";
 console.log("port", port);

--- a/cli/bench/node_http_proxy.js
+++ b/cli/bench/node_http_proxy.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 const http = require("http");
 const port = process.argv[2] || "4544";
 const originPort = process.argv[3] || "4545";

--- a/cli/bench/node_tcp.js
+++ b/cli/bench/node_tcp.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Note: this is a keep-alive server.
 const { Server } = require("net");
 const port = process.argv[2] || "4544";

--- a/cli/bench/node_tcp_promise.js
+++ b/cli/bench/node_tcp_promise.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Note: this is a keep-alive server.
 const { Server } = require("net");
 const port = process.argv[2] || "4544";

--- a/cli/bench/node_tcp_proxy.js
+++ b/cli/bench/node_tcp_proxy.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 const net = require("net");
 
 process.on("uncaughtException", function (error) {

--- a/cli/bench/throughput.rs
+++ b/cli/bench/throughput.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use super::Result;
 use deno_core::serde_json::{Number, Value};

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::custom_error;
 use deno_core::json_op_sync;

--- a/cli/checksum.rs
+++ b/cli/checksum.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use ring::digest::Context;
 use ring::digest::SHA256;

--- a/cli/colors.rs
+++ b/cli/colors.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // allow(dead_code) because denort does not use this.
 #![allow(dead_code)]

--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::disk_cache::DiskCache;
 use std::path::PathBuf;

--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
 

--- a/cli/diff.rs
+++ b/cli/diff.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
 use dissimilar::{diff as difference, Chunk};

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::fs_util;
 use crate::http_cache::url_to_filename;

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />

--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // Documentation partially adapted from [MDN](https://developer.mozilla.org/),
 // by Mozilla Contributors, which is licensed under CC-BY-SA 2.5.

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 /// <reference no-default-lib="true" />
 /// <reference lib="deno.ns" />

--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 /// <reference no-default-lib="true" />
 /// <reference lib="deno.ns" />

--- a/cli/dts/lib.deno.worker.d.ts
+++ b/cli/dts/lib.deno.worker.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 /// <reference no-default-lib="true" />
 /// <reference lib="deno.ns" />

--- a/cli/errors.rs
+++ b/cli/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 //! There are many types of errors in Deno:
 //! - AnyError: a generic wrapper that can encapsulate any type of error.

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
 use crate::http_cache::HttpCache;

--- a/cli/file_watcher.rs
+++ b/cli/file_watcher.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
 use core::task::{Context, Poll};

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use clap::App;
 use clap::AppSettings;

--- a/cli/flags_allow_net.rs
+++ b/cli/flags_allow_net.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::url::Url;
 use std::net::IpAddr;

--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 //! This mod provides DenoError to unify errors across Deno.
 use crate::colors;
 use deno_core::error::{AnyError, JsError, JsStackFrame};

--- a/cli/fs_util.rs
+++ b/cli/fs_util.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::AnyError;
 pub use deno_core::normalize_path;

--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 /// This module is meant to eventually implement HTTP cache
 /// as defined in RFC 7234 (https://tools.ietf.org/html/rfc7234).

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;

--- a/cli/import_map.rs
+++ b/cli/import_map.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::AnyError;
 use deno_core::serde_json;

--- a/cli/info.rs
+++ b/cli/info.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
 use crate::media_type::serialize_media_type;

--- a/cli/lockfile.rs
+++ b/cli/lockfile.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::serde_json;
 use deno_core::serde_json::json;

--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::ast;
 use crate::import_map::ImportMap;

--- a/cli/lsp/capabilities.rs
+++ b/cli/lsp/capabilities.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ///!
 ///! Provides information about what capabilities that are supported by the

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::serde::Deserialize;
 use deno_core::serde_json;

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use super::analysis::get_lint_references;
 use super::analysis::references_to_diagnostics;

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::anyhow;
 use deno_core::error::AnyError;

--- a/cli/lsp/memory_cache.rs
+++ b/cli/lsp/memory_cache.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::AnyError;
 use deno_core::ModuleSpecifier;

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 use deno_core::error::AnyError;
 use lspower::LspService;
 use lspower::Server;

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use super::analysis;
 use super::text;

--- a/cli/lsp/text.rs
+++ b/cli/lsp/text.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use super::analysis::ResolvedDependency;
 use super::language_server::StateSnapshot;

--- a/cli/lsp/utils.rs
+++ b/cli/lsp/utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::AnyError;
 use deno_core::url::Position;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 #![deny(warnings)]
 

--- a/cli/main_runtime.rs
+++ b/cli/main_runtime.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 #![deny(warnings)]
 

--- a/cli/media_type.rs
+++ b/cli/media_type.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::ModuleSpecifier;
 use serde::Serialize;

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::ast;
 use crate::ast::parse;

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::import_map::ImportMap;
 use crate::module_graph::TypeLib;

--- a/cli/ops/errors.rs
+++ b/cli/ops/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::diagnostics::Diagnostics;
 use crate::program_state::ProgramState;

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 pub mod errors;
 pub mod runtime_compiler;

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::import_map::ImportMap;
 use crate::module_graph::BundleType;

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::deno_dir;
 use crate::file_fetcher::CacheSetting;

--- a/cli/source_maps.rs
+++ b/cli/source_maps.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 //! This mod provides functions to remap a `JsError` based on a source map.
 

--- a/cli/specifier_handler.rs
+++ b/cli/specifier_handler.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::ast::Location;
 use crate::deno_dir::DenoDir;

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
 use crate::version;

--- a/cli/tests/045_proxy_client.ts
+++ b/cli/tests/045_proxy_client.ts
@@ -1,3 +1,3 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 const res = await fetch("http://localhost:4545/std/examples/colors.ts");
 console.log(`Response http: ${await res.text()}`);

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { serve, ServerRequest } from "../../std/http/server.ts";
 import { assertEquals } from "../../std/testing/asserts.ts";
 

--- a/cli/tests/compiler_api_test.ts
+++ b/cli/tests/compiler_api_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/hash.ts
+++ b/cli/tests/hash.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 const { args } = Deno;
 import { createHash, SupportedAlgorithm } from "../../std/hash/mod.ts";

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 use deno_core::futures;
 use deno_core::futures::prelude::*;
 use deno_core::serde_json;

--- a/cli/tests/test_runner_test.ts
+++ b/cli/tests/test_runner_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 import { assert } from "../../std/testing/asserts.ts";
 

--- a/cli/tests/types.out
+++ b/cli/tests/types.out
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 [WILDCARD]
 declare namespace Deno [WILDCARD]
 declare var window: Window [WILDCARD]

--- a/cli/tests/unit/blob_test.ts
+++ b/cli/tests/unit/blob_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, unitTest } from "./test_util.ts";
 import { concat } from "../../../std/bytes/mod.ts";
 import { decode } from "../../../std/encoding/utf8.ts";

--- a/cli/tests/unit/body_test.ts
+++ b/cli/tests/unit/body_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, unitTest } from "./test_util.ts";
 
 // just a hack to get a body object

--- a/cli/tests/unit/buffer_test.ts
+++ b/cli/tests/unit/buffer_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // This code has been ported almost directly from Go's src/bytes/buffer_test.go
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.

--- a/cli/tests/unit/build_test.ts
+++ b/cli/tests/unit/build_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, unitTest } from "./test_util.ts";
 
 unitTest(function buildInfo(): void {

--- a/cli/tests/unit/chmod_test.ts
+++ b/cli/tests/unit/chmod_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/chown_test.ts
+++ b/cli/tests/unit/chown_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assertEquals,
   assertThrows,

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // TODO(ry) The unit test functions in this module are too coarse. They should
 // be broken up into smaller bits.

--- a/cli/tests/unit/copy_file_test.ts
+++ b/cli/tests/unit/copy_file_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assertEquals,
   assertThrows,

--- a/cli/tests/unit/custom_event_test.ts
+++ b/cli/tests/unit/custom_event_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(function customEventInitializedWithDetail(): void {

--- a/cli/tests/unit/dir_test.ts
+++ b/cli/tests/unit/dir_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertThrows, unitTest } from "./test_util.ts";
 
 unitTest({ perms: { read: true } }, function dirCwdNotNull(): void {

--- a/cli/tests/unit/dom_exception_test.ts
+++ b/cli/tests/unit/dom_exception_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(function testDomError() {

--- a/cli/tests/unit/dom_iterable_test.ts
+++ b/cli/tests/unit/dom_iterable_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 /* TODO https://github.com/denoland/deno/issues/7540
 import { unitTest, assert, assertEquals } from "./test_util.ts";

--- a/cli/tests/unit/error_stack_test.ts
+++ b/cli/tests/unit/error_stack_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertMatch, unitTest } from "./test_util.ts";
 
 unitTest(function errorStackMessageLine(): void {

--- a/cli/tests/unit/event_target_test.ts
+++ b/cli/tests/unit/event_target_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(function addEventListenerTest(): void {

--- a/cli/tests/unit/event_test.ts
+++ b/cli/tests/unit/event_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(function eventInitializedWithType(): void {

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/file_test.ts
+++ b/cli/tests/unit/file_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, unitTest } from "./test_util.ts";
 
 // deno-lint-ignore no-explicit-any

--- a/cli/tests/unit/filereader_test.ts
+++ b/cli/tests/unit/filereader_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(function fileReaderConstruct(): void {

--- a/cli/tests/unit/files_test.ts
+++ b/cli/tests/unit/files_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/form_data_test.ts
+++ b/cli/tests/unit/form_data_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/format_error_test.ts
+++ b/cli/tests/unit/format_error_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, unitTest } from "./test_util.ts";
 
 unitTest(function formatDiagnosticBasic() {

--- a/cli/tests/unit/get_random_values_test.ts
+++ b/cli/tests/unit/get_random_values_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertNotEquals, assertStrictEquals, unitTest } from "./test_util.ts";
 
 unitTest(function getRandomValuesInt8Array(): void {

--- a/cli/tests/unit/globals_test.ts
+++ b/cli/tests/unit/globals_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, unitTest } from "./test_util.ts";
 
 unitTest(function globalThisExists(): void {

--- a/cli/tests/unit/headers_test.ts
+++ b/cli/tests/unit/headers_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/internals_test.ts
+++ b/cli/tests/unit/internals_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, unitTest } from "./test_util.ts";
 
 unitTest(function internalsExists(): void {

--- a/cli/tests/unit/io_test.ts
+++ b/cli/tests/unit/io_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, unitTest } from "./test_util.ts";
 
 const DEFAULT_BUF_SIZE = 32 * 1024;

--- a/cli/tests/unit/link_test.ts
+++ b/cli/tests/unit/link_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertThrows, unitTest } from "./test_util.ts";
 
 unitTest(

--- a/cli/tests/unit/make_temp_test.ts
+++ b/cli/tests/unit/make_temp_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/metrics_test.ts
+++ b/cli/tests/unit/metrics_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, unitTest } from "./test_util.ts";
 
 unitTest(async function metrics(): Promise<void> {

--- a/cli/tests/unit/mkdir_test.ts
+++ b/cli/tests/unit/mkdir_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/performance_test.ts
+++ b/cli/tests/unit/performance_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/permissions_test.ts
+++ b/cli/tests/unit/permissions_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assertEquals,
   assertThrows,

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/progressevent_test.ts
+++ b/cli/tests/unit/progressevent_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(function progressEventConstruct(): void {

--- a/cli/tests/unit/read_dir_test.ts
+++ b/cli/tests/unit/read_dir_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/read_file_test.ts
+++ b/cli/tests/unit/read_file_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/read_link_test.ts
+++ b/cli/tests/unit/read_link_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assertEquals,
   assertThrows,

--- a/cli/tests/unit/real_path_test.ts
+++ b/cli/tests/unit/real_path_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertMatch,

--- a/cli/tests/unit/remove_test.ts
+++ b/cli/tests/unit/remove_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertThrows,

--- a/cli/tests/unit/rename_test.ts
+++ b/cli/tests/unit/rename_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertThrows, unitTest } from "./test_util.ts";
 
 function assertMissing(path: string): void {

--- a/cli/tests/unit/request_test.ts
+++ b/cli/tests/unit/request_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(function fromInit(): void {

--- a/cli/tests/unit/resources_test.ts
+++ b/cli/tests/unit/resources_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertThrows, unitTest } from "./test_util.ts";
 
 unitTest(function resourcesCloseBadArgs(): void {

--- a/cli/tests/unit/response_test.ts
+++ b/cli/tests/unit/response_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(async function responseText() {

--- a/cli/tests/unit/signal_test.ts
+++ b/cli/tests/unit/signal_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/stat_test.ts
+++ b/cli/tests/unit/stat_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/stdio_test.ts
+++ b/cli/tests/unit/stdio_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(async function stdioStdinRead() {

--- a/cli/tests/unit/streams_internal_test.ts
+++ b/cli/tests/unit/streams_internal_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertThrows, unitTest } from "./test_util.ts";
 
 unitTest(function streamReadableHwmError() {

--- a/cli/tests/unit/streams_piping_test.ts
+++ b/cli/tests/unit/streams_piping_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, unitTest } from "./test_util.ts";
 import { assertThrowsAsync } from "../../../std/testing/asserts.ts";
 

--- a/cli/tests/unit/streams_transform_test.ts
+++ b/cli/tests/unit/streams_transform_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/streams_writable_test.ts
+++ b/cli/tests/unit/streams_writable_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertThrows, unitTest } from "./test_util.ts";
 
 unitTest(function writableStreamDesiredSizeOnReleasedWriter() {

--- a/cli/tests/unit/symlink_test.ts
+++ b/cli/tests/unit/symlink_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertThrows, unitTest } from "./test_util.ts";
 
 unitTest(

--- a/cli/tests/unit/sync_test.ts
+++ b/cli/tests/unit/sync_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 import { assert, assertEquals } from "../../../std/testing/asserts.ts";
 import * as colors from "../../../std/fmt/colors.ts";

--- a/cli/tests/unit/testing_test.ts
+++ b/cli/tests/unit/testing_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertThrows, unitTest } from "./test_util.ts";
 
 unitTest(function testFnOverloading(): void {

--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertThrows, unitTest } from "./test_util.ts";
 
 unitTest(function btoaSuccess(): void {

--- a/cli/tests/unit/timers_test.ts
+++ b/cli/tests/unit/timers_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/unit/truncate_test.ts
+++ b/cli/tests/unit/truncate_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assertEquals,
   assertThrows,

--- a/cli/tests/unit/tty_test.ts
+++ b/cli/tests/unit/tty_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertThrows, unitTest } from "./test_util.ts";
 
 // Note tests for Deno.setRaw is in integration tests.

--- a/cli/tests/unit/umask_test.ts
+++ b/cli/tests/unit/umask_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(

--- a/cli/tests/unit/unit_test_runner.ts
+++ b/cli/tests/unit/unit_test_runner.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S deno run --reload --allow-run
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import "./unit_tests.ts";
 import {
   colors,

--- a/cli/tests/unit/unit_tests.ts
+++ b/cli/tests/unit/unit_tests.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // This test is executed as part of unit test suite.
 //

--- a/cli/tests/unit/url_search_params_test.ts
+++ b/cli/tests/unit/url_search_params_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(function urlSearchParamsWithMultipleSpaces(): void {

--- a/cli/tests/unit/url_test.ts
+++ b/cli/tests/unit/url_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertThrows, unitTest } from "./test_util.ts";
 
 unitTest(function urlParsing(): void {

--- a/cli/tests/unit/utime_test.ts
+++ b/cli/tests/unit/utime_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assertEquals,
   assertThrows,

--- a/cli/tests/unit/websocket_test.ts
+++ b/cli/tests/unit/websocket_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertThrows, unitTest } from "./test_util.ts";
 
 unitTest(function websocketPermissionless() {

--- a/cli/tests/unit/worker_types.ts
+++ b/cli/tests/unit/worker_types.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, unitTest } from "./test_util.ts";
 
 unitTest(

--- a/cli/tests/unit/write_file_test.ts
+++ b/cli/tests/unit/write_file_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assertEquals,
   assertThrows,

--- a/cli/tests/websocket_test.ts
+++ b/cli/tests/websocket_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/cli/tests/workers_test.ts
+++ b/cli/tests/workers_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // Requires to be run with `--allow-net` flag
 

--- a/cli/text_encoding.rs
+++ b/cli/text_encoding.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use encoding_rs::*;
 use std::{

--- a/cli/tokio_util.rs
+++ b/cli/tokio_util.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 pub fn create_basic_runtime() -> tokio::runtime::Runtime {
   tokio::runtime::Builder::new()

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
 use crate::module_graph::TypeLib;

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 //! This module provides file formatting utilities using
 //! [`dprint-plugin-typescript`](https://github.com/dprint/dprint-plugin-typescript).

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::flags::Flags;
 use crate::fs_util::canonicalize_path;

--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 //! This module provides file formating utilities using
 //! [`deno_lint`](https://github.com/denoland/deno_lint).

--- a/cli/tools/mod.rs
+++ b/cli/tools/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 pub mod coverage;
 pub mod fmt;

--- a/cli/tools/repl.rs
+++ b/cli/tools/repl.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::ast;
 use crate::ast::TokenOrComment;

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::flags::DenoSubcommand;
 use crate::flags::Flags;

--- a/cli/tools/test_runner.rs
+++ b/cli/tools/test_runner.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::fs_util;
 use crate::tools::installer::is_remote_url;

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 //! This module provides feature to upgrade deno executable
 

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::diagnostics::Diagnostics;
 use crate::media_type::MediaType;

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // @ts-check
 /// <reference path="./compiler.d.ts" />

--- a/cli/tsc/compiler.d.ts
+++ b/cli/tsc/compiler.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // Contains types that can be used to validate and check `99_main_compiler.js`
 

--- a/cli/tsc_config.rs
+++ b/cli/tsc_config.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::fs_util::canonicalize_path;
 use deno_core::error::AnyError;

--- a/cli/version.rs
+++ b/cli/version.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 pub const GIT_COMMIT_HASH: &str = env!("GIT_COMMIT_HASH");
 pub const TYPESCRIPT: &str = env!("TS_VERSION");

--- a/docs/contributing/style_guide.md
+++ b/docs/contributing/style_guide.md
@@ -5,7 +5,7 @@
 Most modules in the repository should have the following copyright header:
 
 ```ts
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 ```
 
 If the code originates elsewhere, ensure that the file has the proper copyright

--- a/op_crates/crypto/01_crypto.js
+++ b/op_crates/crypto/01_crypto.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/op_crates/crypto/Cargo.toml
+++ b/op_crates/crypto/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+# Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 [package]
 name = "deno_crypto"

--- a/op_crates/crypto/lib.rs
+++ b/op_crates/crypto/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 #![deny(warnings)]
 

--- a/op_crates/fetch/01_fetch_util.js
+++ b/op_crates/fetch/01_fetch_util.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   function requiredArguments(

--- a/op_crates/fetch/03_dom_iterable.js
+++ b/op_crates/fetch/03_dom_iterable.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const { requiredArguments } = window.__bootstrap.fetchUtil;

--- a/op_crates/fetch/11_streams.js
+++ b/op_crates/fetch/11_streams.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // This code closely follows the WHATWG Stream Specification
 // See: https://streams.spec.whatwg.org/

--- a/op_crates/fetch/20_headers.js
+++ b/op_crates/fetch/20_headers.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const { DomIterableMixin } = window.__bootstrap.domIterable;

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/op_crates/fetch/Cargo.toml
+++ b/op_crates/fetch/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+# Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 [package]
 name = "deno_fetch"

--- a/op_crates/fetch/lib.deno_fetch.d.ts
+++ b/op_crates/fetch/lib.deno_fetch.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // deno-lint-ignore-file no-explicit-any
 

--- a/op_crates/fetch/lib.rs
+++ b/op_crates/fetch/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 #![deny(warnings)]
 

--- a/op_crates/web/00_dom_exception.js
+++ b/op_crates/web/00_dom_exception.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const nameToCodeMapping = Object.create(

--- a/op_crates/web/01_event.js
+++ b/op_crates/web/01_event.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // This module follows most of the WHATWG Living Standard for the DOM logic.
 // Many parts of the DOM are not implemented in Deno, but the logic for those

--- a/op_crates/web/02_abort_signal.js
+++ b/op_crates/web/02_abort_signal.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const { setIsTrusted } = window.__bootstrap.event;

--- a/op_crates/web/08_text_encoding.js
+++ b/op_crates/web/08_text_encoding.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // The following code is based off of text-encoding at:
 // https://github.com/inexorabletash/text-encoding

--- a/op_crates/web/11_url.js
+++ b/op_crates/web/11_url.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/op_crates/web/12_location.js
+++ b/op_crates/web/12_location.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const { URL } = window.__bootstrap.url;

--- a/op_crates/web/21_filereader.js
+++ b/op_crates/web/21_filereader.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const base64 = window.__bootstrap.base64;

--- a/op_crates/web/Cargo.toml
+++ b/op_crates/web/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+# Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 [package]
 name = "deno_web"

--- a/op_crates/web/abort_controller_test.js
+++ b/op_crates/web/abort_controller_test.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 function assert(cond) {
   if (!cond) {
     throw Error("assert");

--- a/op_crates/web/event_target_test.js
+++ b/op_crates/web/event_target_test.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 function assert(cond) {
   if (!cond) {
     throw Error("assert");

--- a/op_crates/web/event_test.js
+++ b/op_crates/web/event_test.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 function assert(cond) {
   if (!cond) {
     throw Error("assert");

--- a/op_crates/web/lib.deno_web.d.ts
+++ b/op_crates/web/lib.deno_web.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // deno-lint-ignore-file no-explicit-any
 

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::uri_error;
 use deno_core::error::AnyError;

--- a/op_crates/web/text_encoding_test.js
+++ b/op_crates/web/text_encoding_test.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 function assert(cond) {
   if (!cond) {
     throw Error("assert");

--- a/op_crates/websocket/01_websocket.js
+++ b/op_crates/websocket/01_websocket.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/op_crates/websocket/Cargo.toml
+++ b/op_crates/websocket/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+# Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 [package]
 name = "deno_websocket"

--- a/op_crates/websocket/lib.deno_websocket.d.ts
+++ b/op_crates/websocket/lib.deno_websocket.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // deno-lint-ignore-file no-explicit-any
 

--- a/op_crates/websocket/lib.rs
+++ b/op_crates/websocket/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::bad_resource_id;
 use deno_core::error::type_error;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+# Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 [package]
 name = "deno_runtime"

--- a/runtime/inspector.rs
+++ b/runtime/inspector.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 //! The documentation for the inspector API is sparse, but these are helpful:
 //! https://chromedevtools.github.io/devtools-protocol/

--- a/runtime/js.rs
+++ b/runtime/js.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::Snapshot;
 

--- a/runtime/js/00_bootstrap_namespace.js
+++ b/runtime/js/00_bootstrap_namespace.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // The only purpose of this file is to set up "globalThis.__bootstrap" namespace,
 // that is used by scripts in this directory to reference exports between

--- a/runtime/js/01_build.js
+++ b/runtime/js/01_build.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const build = {

--- a/runtime/js/01_colors.js
+++ b/runtime/js/01_colors.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   function code(open, close) {

--- a/runtime/js/01_internals.js
+++ b/runtime/js/01_internals.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const internalSymbol = Symbol("Deno.internal");

--- a/runtime/js/01_version.js
+++ b/runtime/js/01_version.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const version = {

--- a/runtime/js/01_web_util.js
+++ b/runtime/js/01_web_util.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const illegalConstructorKey = Symbol("illegalConstructorKey");

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/06_util.js
+++ b/runtime/js/06_util.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const { build } = window.__bootstrap.build;

--- a/runtime/js/10_dispatch_minimal.js
+++ b/runtime/js/10_dispatch_minimal.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/11_timers.js
+++ b/runtime/js/11_timers.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const assert = window.__bootstrap.util.assert;

--- a/runtime/js/12_io.js
+++ b/runtime/js/12_io.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // Interfaces 100% copied from Go.
 // Documentation liberally lifted from them too.

--- a/runtime/js/13_buffer.js
+++ b/runtime/js/13_buffer.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // This code has been ported almost directly from Go's src/bytes/buffer.go
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.

--- a/runtime/js/30_files.js
+++ b/runtime/js/30_files.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/30_fs.js
+++ b/runtime/js/30_fs.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/30_metrics.js
+++ b/runtime/js/30_metrics.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/30_net.js
+++ b/runtime/js/30_net.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/30_os.js
+++ b/runtime/js/30_os.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/40_compiler_api.js
+++ b/runtime/js/40_compiler_api.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // @ts-check
 

--- a/runtime/js/40_diagnostics.js
+++ b/runtime/js/40_diagnostics.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // Diagnostic provides an abstraction for advice/errors received from a
 // compiler, which is strongly influenced by the format of TypeScript

--- a/runtime/js/40_error_stack.js
+++ b/runtime/js/40_error_stack.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/40_fs_events.js
+++ b/runtime/js/40_fs_events.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/40_net_unstable.js
+++ b/runtime/js/40_net_unstable.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const net = window.__bootstrap.net;

--- a/runtime/js/40_performance.js
+++ b/runtime/js/40_performance.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const { opNow } = window.__bootstrap.timers;

--- a/runtime/js/40_permissions.js
+++ b/runtime/js/40_permissions.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/40_plugins.js
+++ b/runtime/js/40_plugins.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/40_process.js
+++ b/runtime/js/40_process.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/40_read_file.js
+++ b/runtime/js/40_read_file.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const { open, openSync } = window.__bootstrap.files;

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/40_tls.js
+++ b/runtime/js/40_tls.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const core = window.Deno.core;

--- a/runtime/js/40_write_file.js
+++ b/runtime/js/40_write_file.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 ((window) => {
   const { stat, statSync, chmod, chmodSync } = window.__bootstrap.fs;
   const { open, openSync } = window.__bootstrap.files;

--- a/runtime/js/41_prompt.js
+++ b/runtime/js/41_prompt.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 ((window) => {
   const { stdin } = window.__bootstrap.files;
   const { isatty } = window.__bootstrap.tty;

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 ((window) => {
   const __bootstrap = window.__bootstrap;

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Removes the `__proto__` for security reasons.  This intentionally makes
 // Deno non compliant with ECMA-262 Annex B.2.2.1
 //

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
 use crate::inspector::DenoInspector;

--- a/std/fs/_util.ts
+++ b/std/fs/_util.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import * as path from "../path/mod.ts";
 
 /**

--- a/std/fs/copy.ts
+++ b/std/fs/copy.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import * as path from "../path/mod.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { getFileInfoType, isSubdir } from "./_util.ts";

--- a/std/fs/copy_test.ts
+++ b/std/fs/copy_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/std/fs/empty_dir.ts
+++ b/std/fs/empty_dir.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { join } from "../path/mod.ts";
 
 /**

--- a/std/fs/empty_dir_test.ts
+++ b/std/fs/empty_dir_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
   assertEquals,

--- a/std/fs/ensure_dir.ts
+++ b/std/fs/ensure_dir.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { getFileInfoType } from "./_util.ts";
 
 /**

--- a/std/fs/ensure_dir_test.ts
+++ b/std/fs/ensure_dir_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertThrows, assertThrowsAsync } from "../testing/asserts.ts";
 import * as path from "../path/mod.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";

--- a/std/fs/ensure_file.ts
+++ b/std/fs/ensure_file.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import * as path from "../path/mod.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { getFileInfoType } from "./_util.ts";

--- a/std/fs/ensure_file_test.ts
+++ b/std/fs/ensure_file_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertThrows, assertThrowsAsync } from "../testing/asserts.ts";
 import * as path from "../path/mod.ts";
 import { ensureFile, ensureFileSync } from "./ensure_file.ts";

--- a/std/fs/ensure_link.ts
+++ b/std/fs/ensure_link.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import * as path from "../path/mod.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { exists, existsSync } from "./exists.ts";

--- a/std/fs/ensure_link_test.ts
+++ b/std/fs/ensure_link_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // TODO(axetroy): Add test for Windows once symlink is implemented for Windows.
 import {
   assertEquals,

--- a/std/fs/ensure_symlink.ts
+++ b/std/fs/ensure_symlink.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import * as path from "../path/mod.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { exists, existsSync } from "./exists.ts";

--- a/std/fs/ensure_symlink_test.ts
+++ b/std/fs/ensure_symlink_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // TODO(axetroy): Add test for Windows once symlink is implemented for Windows.
 import {
   assertEquals,

--- a/std/fs/eol.ts
+++ b/std/fs/eol.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 /** EndOfLine character enum */
 export enum EOL {

--- a/std/fs/eol_test.ts
+++ b/std/fs/eol_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../testing/asserts.ts";
 import { detect, EOL, format } from "./eol.ts";
 

--- a/std/fs/exists.ts
+++ b/std/fs/exists.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 /**
  * Test whether or not the given path exists by checking with the file system
  */

--- a/std/fs/exists_test.ts
+++ b/std/fs/exists_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertStringIncludes } from "../testing/asserts.ts";
 import * as path from "../path/mod.ts";
 import { exists, existsSync } from "./exists.ts";

--- a/std/fs/expand_glob.ts
+++ b/std/fs/expand_glob.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   GlobOptions,
   globToRegExp,

--- a/std/fs/expand_glob_test.ts
+++ b/std/fs/expand_glob_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { decode } from "../encoding/utf8.ts";
 import {
   assert,

--- a/std/fs/mod.ts
+++ b/std/fs/mod.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 export * from "./empty_dir.ts";
 export * from "./ensure_dir.ts";
 export * from "./ensure_file.ts";

--- a/std/fs/move.ts
+++ b/std/fs/move.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { exists, existsSync } from "./exists.ts";
 import { isSubdir } from "./_util.ts";
 

--- a/std/fs/move_test.ts
+++ b/std/fs/move_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assertEquals,
   assertThrows,

--- a/std/fs/test.ts
+++ b/std/fs/test.ts
@@ -1,2 +1,2 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import "./mod.ts";

--- a/std/fs/walk_test.ts
+++ b/std/fs/walk_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { walk, WalkEntry, WalkOptions, walkSync } from "./walk.ts";
 import { assert, assertEquals, assertThrowsAsync } from "../testing/asserts.ts";
 

--- a/std/signal/mod.ts
+++ b/std/signal/mod.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { MuxAsyncIterator } from "../async/mux_async_iterator.ts";
 
 export type Disposable = { dispose: () => void };

--- a/std/signal/test.ts
+++ b/std/signal/test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertThrows } from "../testing/asserts.ts";
 import { delay } from "../async/delay.ts";
 import { onSignal, signal } from "./mod.ts";

--- a/std/uuid/_common.ts
+++ b/std/uuid/_common.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 /**
  * Converts the byte array to a UUID string
  * @param bytes Used to convert Byte to Hex

--- a/std/uuid/mod.ts
+++ b/std/uuid/mod.ts
@@ -1,6 +1,6 @@
 // Based on https://github.com/kelektiv/node-uuid -> https://www.ietf.org/rfc/rfc4122.txt
 // Supporting Support for RFC4122 version 1, 4, and 5 UUIDs
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import * as v1 from "./v1.ts";
 import * as v4 from "./v4.ts";
 import * as v5 from "./v5.ts";

--- a/std/uuid/test.ts
+++ b/std/uuid/test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert } from "../testing/asserts.ts";
 import { isNil, NIL_UUID } from "./mod.ts";
 

--- a/std/uuid/v1.ts
+++ b/std/uuid/v1.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { bytesToUuid } from "./_common.ts";
 
 const UUID_RE = new RegExp(

--- a/std/uuid/v1_test.ts
+++ b/std/uuid/v1_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals } from "../testing/asserts.ts";
 import { generate, validate } from "./v1.ts";
 

--- a/std/uuid/v4.ts
+++ b/std/uuid/v4.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { bytesToUuid } from "./_common.ts";
 
 const UUID_RE = new RegExp(

--- a/std/uuid/v4_test.ts
+++ b/std/uuid/v4_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals } from "../testing/asserts.ts";
 import { generate, validate } from "./v4.ts";
 

--- a/std/uuid/v5.ts
+++ b/std/uuid/v5.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   bytesToUuid,
   createBuffer,

--- a/std/uuid/v5_test.ts
+++ b/std/uuid/v5_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals } from "../testing/asserts.ts";
 import { generate, validate } from "./v5.ts";
 

--- a/std/wasi/snapshot_preview1.ts
+++ b/std/wasi/snapshot_preview1.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 import { relative, resolve } from "../path/mod.ts";
 

--- a/std/wasi/snapshot_preview1_test.ts
+++ b/std/wasi/snapshot_preview1_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import Context from "./snapshot_preview1.ts";
 import { assert, assertEquals, assertThrows } from "../testing/asserts.ts";
 import { copy } from "../fs/mod.ts";

--- a/std/ws/README.md
+++ b/std/ws/README.md
@@ -7,7 +7,7 @@ WebSockets, use the
 ## Usage
 
 ```ts
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
 import {
   acceptWebSocket,

--- a/std/ws/example_server.ts
+++ b/std/ws/example_server.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { serve } from "../http/server.ts";
 import {
   acceptWebSocket,

--- a/std/ws/example_test.ts
+++ b/std/ws/example_test.ts
@@ -1,2 +1,2 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import "./example_server.ts";

--- a/std/ws/mod.ts
+++ b/std/ws/mod.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { decode, encode } from "../encoding/utf8.ts";
 import { hasOwnProperty } from "../_util/has_own_property.ts";
 import { BufReader, BufWriter } from "../io/bufio.ts";

--- a/std/ws/test.ts
+++ b/std/ws/test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { BufReader, BufWriter } from "../io/bufio.ts";
 import {
   assert,

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+# Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 [package]
 name = "test_util"

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Usage: provide a port as argument to run hyper_hello benchmark server
 // otherwise this starts multiple servers on many ports for test endpoints.
 

--- a/test_util/src/test_server.rs
+++ b/test_util/src/test_server.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 fn main() {
   test_util::run_all_servers();


### PR DESCRIPTION
There are a number of files whose copyright wasn't updated in #9081. 
This PR deals with such files.