### PR TITLE
fix(core): Log customInspect implementation errors

### DIFF
--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -12,6 +12,7 @@ import {
   assert,
   assertEquals,
   assertStringIncludes,
+  assertThrows,
   unitTest,
 } from "./test_util.ts";
 import { stripColor } from "../../../std/fmt/colors.ts";
@@ -834,7 +835,12 @@ unitTest(function consoleTestWithCustomInspectorError(): void {
     }
   }
 
-  assertEquals(stringify(new A()), "A {}");
+  assertThrows(
+    () => stringify(new A()),
+    Error,
+    "BOOM",
+    "Custom inspect won't attempt to parse if user defined function throws"
+  );
 
   class B {
     constructor(public field: { a: string }) {}

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -841,19 +841,6 @@ unitTest(function consoleTestWithCustomInspectorError(): void {
     "BOOM",
     "Custom inspect won't attempt to parse if user defined function throws",
   );
-
-  class B {
-    constructor(public field: { a: string }) {}
-    [customInspect](): string {
-      return this.field.a;
-    }
-  }
-
-  assertEquals(stringify(new B({ a: "a" })), "a");
-  assertEquals(
-    stringify(B.prototype),
-    "B { [Symbol(Deno.customInspect)]: [Function: [Deno.customInspect]] }",
-  );
 });
 
 unitTest(function consoleTestWithCustomInspectFunction(): void {

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -839,7 +839,7 @@ unitTest(function consoleTestWithCustomInspectorError(): void {
     () => stringify(new A()),
     Error,
     "BOOM",
-    "Custom inspect won't attempt to parse if user defined function throws"
+    "Custom inspect won't attempt to parse if user defined function throws",
   );
 
   class B {

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -4,7 +4,6 @@
   const core = window.Deno.core;
   const exposeForTest = window.__bootstrap.internals.exposeForTest;
   const colors = window.__bootstrap.colors;
-  const { PermissionDenied } = window.__bootstrap.errors;
 
   function isInvalidDate(x) {
     return isNaN(x.getTime());

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -4,6 +4,7 @@
   const core = window.Deno.core;
   const exposeForTest = window.__bootstrap.internals.exposeForTest;
   const colors = window.__bootstrap.colors;
+  const { PermissionDenied } = window.__bootstrap.errors;
 
   function isInvalidDate(x) {
     return isNaN(x.getTime());
@@ -190,11 +191,7 @@
 
   function inspectFunction(value, _ctx) {
     if (customInspect in value && typeof value[customInspect] === "function") {
-      try {
-        return String(value[customInspect]());
-      } catch {
-        // pass
-      }
+      return String(value[customInspect]());
     }
     // Might be Function/AsyncFunction/GeneratorFunction/AsyncGeneratorFunction
     let cstrName = Object.getPrototypeOf(value)?.constructor?.name;
@@ -865,11 +862,7 @@
     inspectOptions,
   ) {
     if (customInspect in value && typeof value[customInspect] === "function") {
-      try {
-        return String(value[customInspect]());
-      } catch {
-        // pass
-      }
+      return String(value[customInspect]());
     }
     // This non-unique symbol is used to support op_crates, ie.
     // in op_crates/web we don't want to depend on unique "Deno.customInspect"
@@ -880,11 +873,7 @@
       nonUniqueCustomInspect in value &&
       typeof value[nonUniqueCustomInspect] === "function"
     ) {
-      try {
-        return String(value[nonUniqueCustomInspect]());
-      } catch {
-        // pass
-      }
+      return String(value[nonUniqueCustomInspect]());
     }
     if (value instanceof Error) {
       return String(value.stack);


### PR DESCRIPTION
Right now, the `customInspect` function in core swallows all errors that are thrown in user defined inspection functions. ~I don't think there is a reason for this behavior to be inforced (in my particular use case this is swallowing Permission errors).~

With this PR, a warning will be appended to the inspected item showing the error thrown in the the inspect function