### PR TITLE
fix: jsonOpAsync for non object args

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -216,7 +216,7 @@ SharedQueue Binary Layout
     setAsyncHandler(opsCache[opName], jsonOpAsyncHandler);
 
     const promiseId = nextPromiseId++;
-    const argsBuf = encodeJson({ promiseId , args });
+    const argsBuf = encodeJson({ promiseId, args });
     const res = dispatch(opName, argsBuf, ...zeroCopy);
     if (res) processResponse(res);
     let resolve, reject;

--- a/core/core.js
+++ b/core/core.js
@@ -215,8 +215,10 @@ SharedQueue Binary Layout
   async function jsonOpAsync(opName, args = {}, ...zeroCopy) {
     setAsyncHandler(opsCache[opName], jsonOpAsyncHandler);
 
-    const argsBuf = encodeJson({ promiseId: nextPromiseId++, args });
-    processResponse(dispatch(opName, argsBuf, ...zeroCopy));
+    const promiseId = nextPromiseId++;
+    const argsBuf = encodeJson({ promiseId , args });
+    const res = dispatch(opName, argsBuf, ...zeroCopy);
+    if (res) processResponse(res);
     let resolve, reject;
     const promise = new Promise((resolve_, reject_) => {
       resolve = resolve_;
@@ -224,7 +226,7 @@ SharedQueue Binary Layout
     });
     promise.resolve = resolve;
     promise.reject = reject;
-    promiseTable[args.promiseId] = promise;
+    promiseTable[promiseId] = promise;
     return processResponse(await promise);
   }
 

--- a/core/core.js
+++ b/core/core.js
@@ -216,7 +216,7 @@ SharedQueue Binary Layout
     setAsyncHandler(opsCache[opName], jsonOpAsyncHandler);
 
     const promiseId = nextPromiseId++;
-    const argsBuf = encodeJson({ promiseId, args });
+    const argsBuf = encodeJson([promiseId, args]);
     const res = dispatch(opName, argsBuf, ...zeroCopy);
     if (res) processResponse(res);
     let resolve, reject;

--- a/core/examples/http_bench_json_ops.js
+++ b/core/examples/http_bench_json_ops.js
@@ -11,13 +11,13 @@ const responseBuf = new Uint8Array(
 
 /** Listens on 0.0.0.0:4500, returns rid. */
 function listen() {
-  const { rid } = Deno.core.jsonOpSync("listen", {});
+  const { rid } = Deno.core.jsonOpSync("listen");
   return rid;
 }
 
 /** Accepts a connection, returns rid. */
 async function accept(serverRid) {
-  const { rid } = await Deno.core.jsonOpAsync("accept", { rid: serverRid });
+  const { rid } = await Deno.core.jsonOpAsync("accept", serverRid);
   return rid;
 }
 
@@ -26,18 +26,18 @@ async function accept(serverRid) {
  * Returns bytes read.
  */
 async function read(rid, data) {
-  const { nread } = await Deno.core.jsonOpAsync("read", { rid }, data);
+  const { nread } = await Deno.core.jsonOpAsync("read", rid, data);
   return nread;
 }
 
 /** Writes a fixed HTTP response to the socket rid. Returns bytes written. */
 async function write(rid, data) {
-  const { nwritten } = await Deno.core.jsonOpAsync("write", { rid }, data);
+  const { nwritten } = await Deno.core.jsonOpAsync("write", rid, data);
   return nwritten;
 }
 
 function close(rid) {
-  Deno.core.jsonOpSync("close", { rid });
+  Deno.core.jsonOpSync("close", rid);
 }
 
 async function serve(rid) {

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -143,11 +143,7 @@ fn op_close(
   args: Value,
   _buf: &mut [ZeroCopyBuf],
 ) -> Result<Value, AnyError> {
-  let rid: u32 = args
-    .as_u64()
-    .unwrap()
-    .try_into()
-    .unwrap();
+  let rid: u32 = args.as_u64().unwrap().try_into().unwrap();
   debug!("close rid={}", rid);
   state
     .resource_table
@@ -161,11 +157,7 @@ async fn op_accept(
   args: Value,
   _bufs: BufVec,
 ) -> Result<Value, AnyError> {
-  let rid: u32 = args
-    .as_u64()
-    .unwrap()
-    .try_into()
-    .unwrap();
+  let rid: u32 = args.as_u64().unwrap().try_into().unwrap();
   debug!("accept rid={}", rid);
 
   let listener = state
@@ -184,11 +176,7 @@ async fn op_read(
   mut bufs: BufVec,
 ) -> Result<Value, AnyError> {
   assert_eq!(bufs.len(), 1, "Invalid number of arguments");
-  let rid: u32 = args
-    .as_u64()
-    .unwrap()
-    .try_into()
-    .unwrap();
+  let rid: u32 = args.as_u64().unwrap().try_into().unwrap();
   debug!("read rid={}", rid);
 
   let stream = state
@@ -206,11 +194,7 @@ async fn op_write(
   bufs: BufVec,
 ) -> Result<Value, AnyError> {
   assert_eq!(bufs.len(), 1, "Invalid number of arguments");
-  let rid: u32 = args
-    .as_u64()
-    .unwrap()
-    .try_into()
-    .unwrap();
+  let rid: u32 = args.as_u64().unwrap().try_into().unwrap();
   debug!("write rid={}", rid);
 
   let stream = state

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -144,8 +144,6 @@ fn op_close(
   _buf: &mut [ZeroCopyBuf],
 ) -> Result<Value, AnyError> {
   let rid: u32 = args
-    .get("rid")
-    .unwrap()
     .as_u64()
     .unwrap()
     .try_into()
@@ -164,8 +162,6 @@ async fn op_accept(
   _bufs: BufVec,
 ) -> Result<Value, AnyError> {
   let rid: u32 = args
-    .get("rid")
-    .unwrap()
     .as_u64()
     .unwrap()
     .try_into()
@@ -189,8 +185,6 @@ async fn op_read(
 ) -> Result<Value, AnyError> {
   assert_eq!(bufs.len(), 1, "Invalid number of arguments");
   let rid: u32 = args
-    .get("rid")
-    .unwrap()
     .as_u64()
     .unwrap()
     .try_into()
@@ -213,8 +207,6 @@ async fn op_write(
 ) -> Result<Value, AnyError> {
   assert_eq!(bufs.len(), 1, "Invalid number of arguments");
   let rid: u32 = args
-    .get("rid")
-    .unwrap()
     .as_u64()
     .unwrap()
     .try_into()

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -10,7 +10,6 @@ use crate::BufVec;
 use crate::ZeroCopyBuf;
 use futures::Future;
 use indexmap::IndexMap;
-use serde::Deserialize;
 use serde_json::json;
 use serde_json::Value;
 use std::cell::RefCell;
@@ -219,19 +218,12 @@ where
   F: Fn(Rc<RefCell<OpState>>, Value, BufVec) -> R + 'static,
   R: Future<Output = Result<Value, AnyError>> + 'static,
 {
-  #[derive(Deserialize)]
-  #[serde(rename_all = "camelCase")]
-  struct Params {
-    promise_id: u64,
-    args: Value,
-  }
   let try_dispatch_op =
     move |state: Rc<RefCell<OpState>>, bufs: BufVec| -> Result<Op, AnyError> {
-      let params: Params = serde_json::from_slice(&bufs[0])?;
-      let promise_id = params.promise_id;
+      let (promise_id, args): (u64, Value) = serde_json::from_slice(&bufs[0])?;
       let bufs = bufs[1..].into();
       use crate::futures::FutureExt;
-      let fut = op_fn(state.clone(), params.args, bufs).map(move |result| {
+      let fut = op_fn(state.clone(), args, bufs).map(move |result| {
         json_serialize_op_result(
           Some(promise_id),
           result,


### PR DESCRIPTION
This fixes two bugs:

1. errors in the synchronous part of jsonOpAsync on the rust side were not propagated to JS correctly
2. only JS objects could be used as arguments. Now primitives like string, number, boolean, or array are also supported

cc @cab @bartlomieju
