### PR TITLE
feat(tcp tls): Added sni property to conn object.

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1255,6 +1255,24 @@ declare namespace Deno {
    * ```
    */
   export function sleepSync(millis: number): Promise<void>;
+  export interface Conn {
+    /** The local address of the connection. */
+    readonly localAddr: Addr;
+    /** The remote address of the connection. */
+    readonly remoteAddr: Addr;
+    /** The resource ID of the connection. */
+    readonly rid: number;
+    /** **UNSTABLE**: yet to be vetted.
+     * The SNI the client sent to the server during the TLS handshake. If the
+     * connection was not made over TLS, or the client did not send the SNI
+     * during the [client hello](https://tools.ietf.org/html/rfc5246#section-7.4.1.2)
+     * message this property will be undefined.
+     */
+    readonly sni?: string;
+    /** Shuts down (`shutdown(2)`) the writing side of the TCP connection. Most
+     * callers should just use `close()`. */
+    closeWrite(): void;
+  }
 }
 
 declare function fetch(

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1266,9 +1266,9 @@ declare namespace Deno {
      * The SNI the client sent to the server during the TLS handshake. If the
      * connection was not made over TLS, or the client did not send the SNI
      * during the [client hello](https://tools.ietf.org/html/rfc5246#section-7.4.1.2)
-     * message this property will be undefined.
+     * message this property will be `null`.
      */
-    readonly sni?: string;
+    readonly sni: string | null;
     /** Shuts down (`shutdown(2)`) the writing side of the TCP connection. Most
      * callers should just use `close()`. */
     closeWrite(): void;

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -261,7 +261,7 @@ unitTest(
 
     const incoming = await incomingPromise;
 
-    assertEquals((incoming as Deno.Conn & { sni?: string }).sni, hostname);
+    assertEquals(incoming.sni, hostname);
     listener.close();
     incoming.close();
   },

--- a/runtime/js/30_net.js
+++ b/runtime/js/30_net.js
@@ -38,7 +38,7 @@
     #remoteAddr = null;
     #localAddr = null;
     #sni = null;
-    constructor(rid, remoteAddr, localAddr, sni) {
+    constructor(rid, remoteAddr, localAddr, sni = null) {
       this.#rid = rid;
       this.#remoteAddr = remoteAddr;
       this.#localAddr = localAddr;

--- a/runtime/js/30_net.js
+++ b/runtime/js/30_net.js
@@ -37,10 +37,12 @@
     #rid = 0;
     #remoteAddr = null;
     #localAddr = null;
-    constructor(rid, remoteAddr, localAddr) {
+    #sni = null;
+    constructor(rid, remoteAddr, localAddr, sni) {
       this.#rid = rid;
       this.#remoteAddr = remoteAddr;
       this.#localAddr = localAddr;
+      this.#sni = sni;
     }
 
     get rid() {
@@ -53,6 +55,10 @@
 
     get localAddr() {
       return this.#localAddr;
+    }
+
+    get sni() {
+      return this.#sni;
     }
 
     write(p) {

--- a/runtime/js/40_tls.js
+++ b/runtime/js/40_tls.js
@@ -40,7 +40,7 @@
   class TLSListener extends Listener {
     async accept() {
       const res = await opAcceptTLS(this.rid);
-      return new Conn(res.rid, res.remoteAddr, res.localAddr);
+      return new Conn(res.rid, res.remoteAddr, res.localAddr, res.sni);
     }
   }
 

--- a/runtime/ops/tls.rs
+++ b/runtime/ops/tls.rs
@@ -398,13 +398,11 @@ async fn op_accept_tls(
     .try_or_cancel(cancel)
     .await?;
 
-  let sni = {
-    tls_stream
+  let sni = tls_stream
       .get_ref()
       .1
       .get_sni_hostname()
-      .map(str::to_string)
-  };
+      .map(str::to_string);
   
   let rid = {
     let mut state_ = state.borrow_mut();

--- a/runtime/ops/tls.rs
+++ b/runtime/ops/tls.rs
@@ -398,6 +398,13 @@ async fn op_accept_tls(
     .try_or_cancel(cancel)
     .await?;
 
+  let sni = tls_stream
+    .get_ref()
+    .1
+    .get_sni_hostname()
+    .unwrap()
+    .to_owned();
+
   let rid = {
     let mut state_ = state.borrow_mut();
     state_
@@ -407,6 +414,7 @@ async fn op_accept_tls(
 
   Ok(json!({
     "rid": rid,
+    "sni": sni,
     "localAddr": {
       "transport": "tcp",
       "hostname": local_addr.ip().to_string(),

--- a/runtime/ops/tls.rs
+++ b/runtime/ops/tls.rs
@@ -398,13 +398,14 @@ async fn op_accept_tls(
     .try_or_cancel(cancel)
     .await?;
 
-  let sni = tls_stream
-    .get_ref()
-    .1
-    .get_sni_hostname()
-    .unwrap()
-    .to_owned();
-
+  let sni = {
+    tls_stream
+      .get_ref()
+      .1
+      .get_sni_hostname()
+      .map(str::to_string)
+  };
+  
   let rid = {
     let mut state_ = state.borrow_mut();
     state_

--- a/std/http/_mock_conn.ts
+++ b/std/http/_mock_conn.ts
@@ -14,6 +14,7 @@ export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
       port: 0,
     },
     rid: -1,
+    sni: null,
     closeWrite: (): void => {},
     read: (): Promise<number | null> => {
       return Promise.resolve(0);

--- a/std/ws/test.ts
+++ b/std/ws/test.ts
@@ -283,6 +283,7 @@ Deno.test("[ws] ws.close() should use 1000 as close code", async () => {
 function dummyConn(r: Deno.Reader, w: Deno.Writer): Deno.Conn {
   return {
     rid: -1,
+    sni: null,
     closeWrite: (): void => {},
     read: (x: Uint8Array): Promise<number | null> => r.read(x),
     write: (x: Uint8Array): Promise<number> => w.write(x),


### PR DESCRIPTION
Added a `sni` property to the `Conn` object. The `sni` property will be `undefined` if the SNI wasn't included in the TLS handshake, or if the TLS protocol wasn't used at all.

The `sni` property will be passed by `op_accept_tls`.