### PR TITLE
refactor(lsp): factor out fields to DocumentSpan

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -812,7 +812,7 @@ impl lspower::LanguageServer for LanguageServer {
           continue;
         }
         let reference_specifier =
-          ModuleSpecifier::resolve_url(&reference.file_name).unwrap();
+          ModuleSpecifier::resolve_url(&reference.document_span.file_name).unwrap();
         // TODO(lucacasonato): handle error correctly
         let line_index =
           self.get_line_index(reference_specifier).await.unwrap();

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -812,7 +812,8 @@ impl lspower::LanguageServer for LanguageServer {
           continue;
         }
         let reference_specifier =
-          ModuleSpecifier::resolve_url(&reference.document_span.file_name).unwrap();
+          ModuleSpecifier::resolve_url(&reference.document_span.file_name)
+            .unwrap();
         // TODO(lucacasonato): handle error correctly
         let line_index =
           self.get_line_index(reference_specifier).await.unwrap();

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -500,7 +500,8 @@ impl RenameLocations {
       HashMap::new();
     for location in self.locations.iter() {
       let uri = utils::normalize_file_name(&location.document_span.file_name)?;
-      let specifier = ModuleSpecifier::resolve_url(&location.document_span.file_name)?;
+      let specifier =
+        ModuleSpecifier::resolve_url(&location.document_span.file_name)?;
 
       // ensure TextDocumentEdit for `location.file_name`.
       if text_document_edit_map.get(&uri).is_none() {
@@ -656,7 +657,8 @@ pub struct ReferenceEntry {
 
 impl ReferenceEntry {
   pub fn to_location(&self, line_index: &[u32]) -> lsp_types::Location {
-    let uri = utils::normalize_file_name(&self.document_span.file_name).unwrap();
+    let uri =
+      utils::normalize_file_name(&self.document_span.file_name).unwrap();
     lsp_types::Location {
       uri,
       range: self.document_span.text_span.to_range(line_index),


### PR DESCRIPTION
In #9071 I added `DocumentSpan` and have noticed there are several cases where equivalent fields are hard-coded.
This PR is to replace those fields for `DocumentSpan`.