### PR TITLE
fix(cli/runtime_compiler): Check permissions for Deno.emit()

### DIFF
--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -66,9 +66,9 @@ async fn op_emit(
   let mut is_dynamic = false;
   let handler: Arc<Mutex<dyn SpecifierHandler>> =
     if let Some(sources) = args.sources {
-      is_dynamic = true;
       Arc::new(Mutex::new(MemoryHandler::new(sources)))
     } else {
+      is_dynamic = true;
       Arc::new(Mutex::new(FetchHandler::new(
         &program_state,
         runtime_permissions,

--- a/cli/tests/080_deno_emit_permissions.ts
+++ b/cli/tests/080_deno_emit_permissions.ts
@@ -1,0 +1,1 @@
+await Deno.emit(new URL("001_hello.js", import.meta.url).href);

--- a/cli/tests/080_deno_emit_permissions.ts.out
+++ b/cli/tests/080_deno_emit_permissions.ts.out
@@ -1,0 +1,2 @@
+[WILDCARD]error: Uncaught (in promise) PermissionDenied: read access to "[WILDCARD]001_hello.js", run again with the --allow-read flag
+[WILDCARD]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2653,7 +2653,7 @@ itest!(_078_unload_on_exit {
 
 itest!(_079_location_authentication {
   args: "run --location https://foo:bar@baz/qux 079_location_authentication.ts",
-  output: "079_location_authentication.ts.out",heck permissions for Deno.emit()
+  output: "079_location_authentication.ts.out",
 });
 
 itest!(_080_deno_emit_permissions {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2653,7 +2653,13 @@ itest!(_078_unload_on_exit {
 
 itest!(_079_location_authentication {
   args: "run --location https://foo:bar@baz/qux 079_location_authentication.ts",
-  output: "079_location_authentication.ts.out",
+  output: "079_location_authentication.ts.out",heck permissions for Deno.emit()
+});
+
+itest!(_080_deno_emit_permissions {
+  args: "run --unstable 080_deno_emit_permissions.ts",
+  output: "080_deno_emit_permissions.ts.out",
+  exit_code: 1,
 });
 
 itest!(js_import_detect {


### PR DESCRIPTION
`await Deno.emit("std/examples/welcome.ts")` doesn't require permissions.

cc @kitsonk 