### PR TITLE
fix(runtime/js) use DOMException in Performance#measure for WPT testing

### DIFF
--- a/cli/tests/wpt.jsonc
+++ b/cli/tests/wpt.jsonc
@@ -209,16 +209,7 @@
     "mark-errors",
     "mark-measure-return-objects",
     "mark.any",
-    {
-      "name": "measure_syntax_err",
-      "expectFail": [
-        // TODO(lucacasonato): re-enable when #9009 is fixed.
-        "self.performance.measure(\"measure\", \"mark\"), where \"mark\" is a non-existent mark, throws a SyntaxError exception.",
-        "self.performance.measure(\"measure\", \"mark\", \"existing_mark\"), where \"mark\" is a non-existent mark, throws a SyntaxError exception.",
-        "self.performance.measure(\"measure\", \"existing_mark\", \"mark\"), where \"mark\" is a non-existent mark, throws a SyntaxError exception.",
-        "self.performance.measure(\"measure\", \"mark\", \"mark\"), where \"mark\" is a non-existent mark, throws a SyntaxError exception."
-      ]
-    },
+    "measure_syntax_err",
     "measure-l3",
     "structured-serialize-detail",
     "user_timing_exists"

--- a/runtime/js/40_performance.js
+++ b/runtime/js/40_performance.js
@@ -21,7 +21,10 @@
     if (typeof mark === "string") {
       const entry = findMostRecent(mark, "mark");
       if (!entry) {
-        throw new DOMException(`Failed to execute 'measure' on 'Performance': The mark '${mark}' does not exist.`, "SyntaxError");
+        throw new DOMException(
+          `Failed to execute 'measure' on 'Performance': The mark '${mark}' does not exist.`,
+          "SyntaxError",
+        );
       }
       return entry.startTime;
     }

--- a/runtime/js/40_performance.js
+++ b/runtime/js/40_performance.js
@@ -23,7 +23,7 @@
       const entry = findMostRecent(mark, "mark");
       if (!entry) {
         throw new DOMException(
-          `Failed to execute 'measure' on 'Performance': The mark '${mark}' does not exist.`,
+          `Cannot find mark: "${mark}".`,
           "SyntaxError",
         );
       }
@@ -118,6 +118,15 @@
       options = {},
     ) {
       requiredArguments("PerformanceMark", arguments.length, 1);
+      {
+        const option_type = typeof options;
+        if (
+          option_type !== "object" && option_type !== "function" &&
+          option_type !== "undefined"
+        ) {
+          throw new TypeError("Invalid options");
+        }
+      }
       const { detail = null, startTime = now() } = options ?? {};
 
       super(name, "mark", startTime, 0, illegalConstructorKey);

--- a/runtime/js/40_performance.js
+++ b/runtime/js/40_performance.js
@@ -21,7 +21,7 @@
     if (typeof mark === "string") {
       const entry = findMostRecent(mark, "mark");
       if (!entry) {
-        throw new SyntaxError(`Cannot find mark: "${mark}".`);
+        throw new DOMException(`Failed to execute 'measure' on 'Performance': The mark '${mark}' does not exist.`, "SyntaxError");
       }
       return entry.startTime;
     }
@@ -115,6 +115,7 @@
       name,
       options = {},
     ) {
+      // add args length >= 1 assertion here
       if (typeof options !== "object") {
         throw new TypeError("Invalid options");
       }

--- a/runtime/js/40_performance.js
+++ b/runtime/js/40_performance.js
@@ -118,15 +118,19 @@
       options = {},
     ) {
       requiredArguments("PerformanceMark", arguments.length, 1);
-      {
-        const option_type = typeof options;
-        if (
-          option_type !== "object" && option_type !== "function" &&
-          option_type !== "undefined"
-        ) {
+
+      // ensure options is object-ish, or null-ish
+      switch (typeof options) {
+        case "object": // includes null
+        case "function":
+        case "undefined": {
+          break;
+        }
+        default: {
           throw new TypeError("Invalid options");
         }
       }
+
       const { detail = null, startTime = now() } = options ?? {};
 
       super(name, "mark", startTime, 0, illegalConstructorKey);

--- a/runtime/js/40_performance.js
+++ b/runtime/js/40_performance.js
@@ -45,9 +45,7 @@
     );
   }
 
-  function now() {
-    return opNow();
-  }
+  const now = opNow;
 
   class PerformanceEntry {
     #name = "";
@@ -118,11 +116,9 @@
       name,
       options = {},
     ) {
-      // add args length >= 1 assertion here
-      if (typeof options !== "object") {
-        throw new TypeError("Invalid options");
-      }
-      const { detail = null, startTime = now() } = options;
+      requiredArguments("PerformanceMark", arguments.length, 1);
+      const { detail = null, startTime = now() } = options ?? {};
+
       super(name, "mark", startTime, 0, illegalConstructorKey);
       if (startTime < 0) {
         throw new TypeError("startTime cannot be negative");

--- a/runtime/js/40_performance.js
+++ b/runtime/js/40_performance.js
@@ -3,6 +3,7 @@
 ((window) => {
   const { opNow } = window.__bootstrap.timers;
   const { cloneValue, illegalConstructorKey } = window.__bootstrap.webUtil;
+  const { requiredArguments } = window.__bootstrap.webUtil;
 
   const customInspect = Symbol.for("Deno.customInspect");
   let performanceEntries = [];


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/9009.

Does anything else need to be changed?

Also, Chromium has an argument length check,
> ```
> TypeError: Failed to construct 'PerformanceMark': 1 argument required, but only 0 present.
> ```
Should that be added too?

Update, I did it anyway.