### PR TITLE
fix(op_crates/web) let TextEncoder#encodeInto accept detached ArrayBuffers

### DIFF
--- a/op_crates/web/08_text_encoding.js
+++ b/op_crates/web/08_text_encoding.js
@@ -1134,14 +1134,16 @@
       return new Uint8Array(output);
     }
     encodeInto(input, dest) {
-      const encoder = new UTF8Encoder();
-      const inputStream = new Stream(stringToCodePoints(input));
-
       if (!(dest instanceof Uint8Array)) {
         throw new TypeError(
           "2nd argument to TextEncoder.encodeInto must be Uint8Array",
         );
       }
+      if (dest.byteLength === 0) {
+        return { read: 0, written: 0 };
+      }
+      const encoder = new UTF8Encoder();
+      const inputStream = new Stream(stringToCodePoints(input));
 
       let written = 0;
       let read = 0;

--- a/op_crates/web/text_encoding_test.js
+++ b/op_crates/web/text_encoding_test.js
@@ -243,6 +243,22 @@ function textEncodeInto3() {
   assertArrayEquals(Array.from(bytes), [0xf0, 0x9d, 0x93, 0xbd, 0x00]);
 }
 
+function textEncodeIntoDetachedBuffer() {
+  const fixture = "𝓽𝓮𝔁𝓽";
+  const encoder = new TextEncoder();
+  const memory = new WebAssembly.Memory({
+    initial: 1,
+    maximum: 1,
+    shared: false,
+  });
+  const bytes = new Uint8Array(memory.buffer, 0, 100);
+  memory.grow(0); // detaches memory.buffer
+  const result = encoder.encodeInto(fixture, bytes);
+  assert(result.read === 0);
+  assert(result.written === 0);
+  assertArrayEquals(Array.from(bytes), [0xf0, 0x9d, 0x93, 0xbd, 0x00]);
+}
+
 function textDecoderSharedUint8Array() {
   const ab = new SharedArrayBuffer(6);
   const dataView = new DataView(ab);
@@ -1209,6 +1225,7 @@ function main() {
   textEncodeInto();
   textEncodeInto2();
   textEncodeInto3();
+  textEncodeIntoDetachedBuffer();
   textDecoderSharedUint8Array();
   textDecoderSharedInt32Array();
   toStringShouldBeWebCompatibility();

--- a/op_crates/web/text_encoding_test.js
+++ b/op_crates/web/text_encoding_test.js
@@ -254,9 +254,9 @@ function textEncodeIntoDetachedBuffer() {
   const bytes = new Uint8Array(memory.buffer, 0, 100);
   memory.grow(0); // detaches memory.buffer
   const result = encoder.encodeInto(fixture, bytes);
+  assert(bytes.byteLength === 0);
   assert(result.read === 0);
   assert(result.written === 0);
-  assertArrayEquals(Array.from(bytes), [0xf0, 0x9d, 0x93, 0xbd, 0x00]);
 }
 
 function textDecoderSharedUint8Array() {


### PR DESCRIPTION
Fixes what I had found, that I posted [in a comment](https://github.com/denoland/deno/issues/9006#issuecomment-761876048).

Currently, `TextEncoder#encodeInto` lets an exception propograte to the callee when called with a detached JS ArrayBuffer.

Detached array buffers have zero bytes, there is otherwise no way in JS (without V8 intrinsics) to determine whether or not an ArrayBuffer is detached.

As a side-effect, this optimizes the case when passing an empty ArrayBuffer that isn't detached into `TextEncoder#encodeInto`.