### PR TITLE
test(std/node): ensure process.env case doesn't rely on unset variables

### DIFF
--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -132,8 +132,14 @@ Deno.test({
 Deno.test({
   name: "process.env",
   fn() {
-    assertEquals(typeof process.env.PATH, "string");
-    assertEquals(typeof env.PATH, "string");
+    Deno.env.set("HELLO", "WORLD");
+
+    assertEquals(typeof (process.env.HELLO), "string");
+    assertEquals(process.env.HELLO, "WORLD");
+
+    // TODO(caspervonb) test the globals in a different setting (they're broken)
+    // assertEquals(typeof env.HELLO, "string");
+    // assertEquals(env.HELLO, "WORLD");
   },
 });
 


### PR DESCRIPTION
While PATH is commonly defined there is no guarantee that it will be defined and turns out it is undefined with GitHub's runner on Windows.

Came up when preparing the workflow for https://github.com/denoland/deno/issues/9029 with @bartlomieju 