### PR TITLE
bench: fix off-by-one error in thread_count

### DIFF
--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -340,7 +340,7 @@ fn run_strace_benchmarks(
     file.as_file_mut().read_to_string(&mut output)?;
 
     let strace_result = test_util::parse_strace_output(&output);
-    let clone = strace_result.get("clone").map(|d| d.calls).unwrap_or(0);
+    let clone = strace_result.get("clone").map(|d| d.calls).unwrap_or(0) + 1;
     let total = strace_result.get("total").unwrap().calls;
     thread_count.insert(name.to_string(), clone);
     syscall_count.insert(name.to_string(), total);


### PR DESCRIPTION
Fixes error introduced here https://github.com/denoland/deno/pull/9115/files#diff-8ea5cb8bf751f09968db92ba08d43368d2040b29c3cf0630c76afa15af39d25cL367
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
