### PR TITLE
feat(cli/dts/lib.deno.shared_globals): Add WorkerOptions

### DIFF
--- a/cli/tests/workers_test.ts
+++ b/cli/tests/workers_test.ts
@@ -113,9 +113,10 @@ Deno.test({
   name: "worker globals",
   fn: async function (): Promise<void> {
     const promise = deferred();
+    const workerOptions: WorkerOptions = { type: "module" };
     const w = new Worker(
       new URL("workers/worker_globals.ts", import.meta.url).href,
-      { type: "module" },
+      workerOptions,
     );
     w.onmessage = (e): void => {
       assertEquals(e.data, "true, true, true");


### PR DESCRIPTION
Not sure why this was missing, as mentioned on discord it makes accessing things like `Exclude<WorkerOptions["deno"], undefined | true>` easier.