### PR TITLE
test(std/node): avoid project directories for cwd case

### DIFF
--- a/std/node/process_test.ts
+++ b/std/node/process_test.ts
@@ -38,17 +38,16 @@ Deno.test({
   fn() {
     assertEquals(process.cwd(), Deno.cwd());
 
-    const currentDir = Deno.cwd(); // to unchange current directory after this test
+    const currentDir = Deno.cwd();
 
-    const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
-    process.chdir(path.resolve(moduleDir, ".."));
+    const tempDir = Deno.makeTempDirSync();
+    process.chdir(tempDir);
+    assertEquals(
+      Deno.realPathSync(process.cwd()),
+      Deno.realPathSync(tempDir),
+    );
 
-    assert(process.cwd().match(/\Wstd$/));
-    process.chdir("node");
-    assert(process.cwd().match(/\Wnode$/));
-    process.chdir("..");
-    assert(process.cwd().match(/\Wstd$/));
-    process.chdir(currentDir); // to unchange current directory after this test
+    process.chdir(currentDir);
   },
 });
 


### PR DESCRIPTION
The process.cwd test relies on std being in a nested directory within the top level deno project; this makes it use temporary directories instead.

Came up when preparing the workflow for #9029 with @bartlomieju