### PR TITLE
fix(cli): print a newline after help and version

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1268,6 +1268,7 @@ pub fn main() {
         || err.kind == clap::ErrorKind::VersionDisplayed =>
     {
       err.write_to(&mut std::io::stdout()).unwrap();
+      std::io::stdout().write(b"\n").unwrap();
       std::process::exit(0);
     }
     Err(err) => unwrap_or_exit(Err(AnyError::from(err))),

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1268,7 +1268,7 @@ pub fn main() {
         || err.kind == clap::ErrorKind::VersionDisplayed =>
     {
       err.write_to(&mut std::io::stdout()).unwrap();
-      std::io::stdout().write(b"\n").unwrap();
+      std::io::stdout().write_all(b"\n").unwrap();
       std::process::exit(0);
     }
     Err(err) => unwrap_or_exit(Err(AnyError::from(err))),


### PR DESCRIPTION
Currently `deno --help` and `deno --version` don't end with a new line, this fixes that.
This regression was introduced in https://github.com/denoland/deno/pull/9064

Closes https://github.com/denoland/deno/issues/9157