### PR TITLE
fix(installer): pass cached-only to executable_args

### DIFF
--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -246,7 +246,7 @@ pub fn install(
   }
 
   if flags.cached_only {
-    executable_args.push("--cached_only".to_string());
+    executable_args.push("--cached-only".to_string());
   }
 
   if !flags.v8_flags.is_empty() {


### PR DESCRIPTION
Fixes #9168.

In `cli/tools/installer.rs` `--cached_only` is being passed as an executable arg instead of `--cached-only`

This pull request fixes that.
