### PR TITLE
fix(ops/net): fix panic in op_dns_resolve

### DIFF
--- a/cli/tests/resolve_dns.ts
+++ b/cli/tests/resolve_dns.ts
@@ -34,3 +34,9 @@ console.log(JSON.stringify(srv));
 
 console.log("TXT");
 console.log(JSON.stringify(txt));
+
+try {
+  await Deno.resolveDns("not-found-example.com", "A", nameServer);
+} catch (e) {
+  console.log("Error thrown for not-found-example.com");
+}

--- a/cli/tests/resolve_dns.ts.out
+++ b/cli/tests/resolve_dns.ts.out
@@ -14,3 +14,4 @@ SRV
 [{"priority":0,"weight":100,"port":1234,"target":"srv.com."}]
 TXT
 [["foo","bar"]]
+Error thrown for not-found-example.com

--- a/runtime/ops/net.rs
+++ b/runtime/ops/net.rs
@@ -629,7 +629,8 @@ async fn op_dns_resolve(
 
   let results: Vec<DnsReturnRecord> = resolver
     .lookup(query, record_type, Default::default())
-    .await?
+    .await
+    .map_err(|e| generic_error(format!("{}", e)))?
     .iter()
     .filter_map(rdata_to_return_record(record_type))
     .collect();


### PR DESCRIPTION
Deno.resolveDns() panics with non registered dns record. This PR changes it to JS error.

```shellsession
$ ./target/debug/deno run --unstable -A https://deno.land/posts/v1.7/dig.ts not-found-example.com
error: Uncaught (in promise) Error: no record found for name: not-found-example.com.local. type: A class: IN
    throw new ErrorClass(res.err.message);
          ^
    at processResponse (deno:core/core.js:212:11)
    at Object.jsonOpAsync (deno:core/core.js:229:12)
    at async https://deno.land/posts/v1.7/dig.ts:6:17
```

closes #9186