### PR TITLE
docs(typescript): Implied tsconfig uses "useDefineForClassFields"

### DIFF
--- a/docs/typescript/configuration.md
+++ b/docs/typescript/configuration.md
@@ -89,7 +89,8 @@ this:
     "lib": ["deno.window"],
     "module": "esnext",
     "strict": true,
-    "target": "esnext"
+    "target": "esnext",
+    "useDefineForClassFields": true
   }
 }
 ```


### PR DESCRIPTION
Deno hard-codes `"useDefineForClassFields": true`

Updating the docs to reflect this.
