### PR TITLE
fix(compile): panic when cross-compiling between windows and unix

### DIFF
--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -48,7 +48,11 @@ pub async fn get_base_binary(
   }
 
   let archive_data = tokio::fs::read(binary_path).await?;
-  let base_binary_path = crate::tools::upgrade::unpack(archive_data, exe_name)?;
+  let base_binary_path = crate::tools::upgrade::unpack(
+    archive_data,
+    exe_name,
+    target.contains("windows"),
+  )?;
   let base_binary = tokio::fs::read(base_binary_path).await?;
   Ok(base_binary)
 }

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -177,13 +177,13 @@ async fn download_package(
 pub fn unpack(
   archive_data: Vec<u8>,
   exe_name: &str,
-  windows: bool,
+  is_windows: bool,
 ) -> Result<PathBuf, std::io::Error> {
   // We use into_path so that the tempdir is not automatically deleted. This is
   // useful for debugging upgrade, but also so this function can return a path
   // to the newly uncompressed file without fear of the tempdir being deleted.
   let temp_dir = TempDir::new()?.into_path();
-  let exe_ext = if windows { "exe" } else { "" };
+  let exe_ext = if is_windows { "exe" } else { "" };
   let archive_path = temp_dir.join(exe_name).with_extension(".zip");
   let exe_path = temp_dir.join(exe_name).with_extension(exe_ext);
   assert!(!exe_path.exists());

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -109,7 +109,7 @@ pub async fn upgrade_command(
   println!("Deno is upgrading to version {}", &install_version);
 
   let old_exe_path = std::env::current_exe()?;
-  let new_exe_path = unpack(archive_data, "deno")?;
+  let new_exe_path = unpack(archive_data, "deno", cfg!(windows))?;
   let permissions = fs::metadata(&old_exe_path)?.permissions();
   fs::set_permissions(&new_exe_path, permissions)?;
   check_exe(&new_exe_path)?;
@@ -177,12 +177,13 @@ async fn download_package(
 pub fn unpack(
   archive_data: Vec<u8>,
   exe_name: &str,
+  windows: bool,
 ) -> Result<PathBuf, std::io::Error> {
   // We use into_path so that the tempdir is not automatically deleted. This is
   // useful for debugging upgrade, but also so this function can return a path
   // to the newly uncompressed file without fear of the tempdir being deleted.
   let temp_dir = TempDir::new()?.into_path();
-  let exe_ext = if cfg!(windows) { "exe" } else { "" };
+  let exe_ext = if windows { "exe" } else { "" };
   let archive_path = temp_dir.join(exe_name).with_extension(".zip");
   let exe_path = temp_dir.join(exe_name).with_extension(exe_ext);
   assert!(!exe_path.exists());


### PR DESCRIPTION
The zip unpacker was assuming the extension would be the same as the host platform (using `cfg!(windows)`), which worked fine for `upgrade` but not cross-compilation.

Fixes #9194.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
