### PR TITLE
feat(lsp): add performance measurements

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1411,13 +1411,15 @@ mod tests {
     RequestAssert(V),
   }
 
+  type LspTestHarnessRequest = (&'static str, LspResponse<fn(Value)>);
+
   struct LspTestHarness {
-    requests: Vec<(&'static str, LspResponse<fn(Value)>)>,
+    requests: Vec<LspTestHarnessRequest>,
     service: Spawn<LspService>,
   }
 
   impl LspTestHarness {
-    pub fn new(requests: Vec<(&'static str, LspResponse<fn(Value)>)>) -> Self {
+    pub fn new(requests: Vec<LspTestHarnessRequest>) -> Self {
       let (service, _) = LspService::new(LanguageServer::new);
       let service = Spawn::new(service);
       Self { requests, service }

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -171,9 +171,7 @@ impl Inner {
     let lint = async {
       let mut diagnostics = None;
       if lint_enabled {
-        let mark = self
-          .performance
-          .mark("prepare_diagnostics_lint");
+        let mark = self.performance.mark("prepare_diagnostics_lint");
         diagnostics = Some(
           diagnostics::generate_lint_diagnostics(
             self.snapshot(),
@@ -189,9 +187,7 @@ impl Inner {
     let ts = async {
       let mut diagnostics = None;
       if enabled {
-        let mark = self
-          .performance
-          .mark("prepare_diagnostics_ts");
+        let mark = self.performance.mark("prepare_diagnostics_ts");
         diagnostics = Some(
           diagnostics::generate_ts_diagnostics(
             self.snapshot(),
@@ -208,9 +204,7 @@ impl Inner {
     let deps = async {
       let mut diagnostics = None;
       if enabled {
-        let mark = self
-          .performance
-          .mark("prepare_diagnostics_deps");
+        let mark = self.performance.mark("prepare_diagnostics_deps");
         diagnostics = Some(
           diagnostics::generate_dependency_diagnostics(
             self.snapshot(),
@@ -617,9 +611,7 @@ impl Inner {
     &mut self,
     params: DidChangeConfigurationParams,
   ) {
-    let mark = self
-      .performance
-      .mark("did_change_configuration");
+    let mark = self.performance.mark("did_change_configuration");
     let config = if self.config.client_capabilities.workspace_configuration {
       self
         .client

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1403,7 +1403,7 @@ mod tests {
 
   enum LspResponse<V>
   where
-    V: FnOnce(Value) -> (),
+    V: FnOnce(Value),
   {
     None,
     RequestAny,
@@ -1412,14 +1412,12 @@ mod tests {
   }
 
   struct LspTestHarness {
-    requests: Vec<(&'static str, LspResponse<fn(Value) -> ()>)>,
+    requests: Vec<(&'static str, LspResponse<fn(Value)>)>,
     service: Spawn<LspService>,
   }
 
   impl LspTestHarness {
-    pub fn new(
-      requests: Vec<(&'static str, LspResponse<fn(Value) -> ()>)>,
-    ) -> Self {
+    pub fn new(requests: Vec<(&'static str, LspResponse<fn(Value)>)>) -> Self {
       let (service, _) = LspService::new(LanguageServer::new);
       let service = Spawn::new(service);
       Self { requests, service }

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -9,6 +9,7 @@ mod config;
 mod diagnostics;
 mod documents;
 mod language_server;
+mod performance;
 mod sources;
 mod text;
 mod tsc;

--- a/cli/lsp/performance.rs
+++ b/cli/lsp/performance.rs
@@ -1,0 +1,179 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::time::Duration;
+use std::time::Instant;
+
+/// A structure which serves as a start of a measurement span.
+#[derive(Debug)]
+pub struct PerformanceMark {
+  name: String,
+  count: u32,
+  start: Instant,
+}
+
+/// A structure which holds the information about the measured span.
+#[derive(Debug)]
+pub struct PerformanceMeasure {
+  pub name: String,
+  pub count: u32,
+  pub duration: Duration,
+}
+
+impl From<PerformanceMark> for PerformanceMeasure {
+  fn from(value: PerformanceMark) -> Self {
+    Self {
+      name: value.name,
+      count: value.count,
+      duration: value.start.elapsed(),
+    }
+  }
+}
+
+/// A simple structure for marking a start of something to measure the duration
+/// of and measuring that duration.  Each measurement is identified by a string
+/// name and a counter is incremented each time a new measurement is marked.
+///
+/// The structure will limit the size of measurements to the most recent 1000,
+/// and will roll off when that limit is reached.
+#[derive(Debug)]
+pub struct Performance {
+  counts: HashMap<String, u32>,
+  measures: VecDeque<PerformanceMeasure>,
+  size: usize,
+}
+
+impl Default for Performance {
+  fn default() -> Self {
+    Self {
+      counts: Default::default(),
+      measures: Default::default(),
+      size: 1_000,
+    }
+  }
+}
+
+impl Performance {
+  /// Return the count and average duration of a measurement identified by name.
+  #[allow(unused)]
+  pub fn average(&self, name: &str) -> (usize, Duration) {
+    let mut items = Vec::new();
+    for measure in &self.measures {
+      if measure.name == name {
+        items.push(measure.duration);
+      }
+    }
+    let len = items.len();
+    let average = if len > 0 {
+      items.into_iter().sum::<Duration>() / len as u32
+    } else {
+      Duration::default()
+    };
+    (len, average)
+  }
+
+  /// Return an iterator which provides the names, count, and average duration
+  /// of each measurement.
+  pub fn averages(&self) -> impl Iterator<Item = (String, usize, Duration)> {
+    let mut averages: HashMap<String, Vec<Duration>> = HashMap::new();
+    for measure in &self.measures {
+      averages
+        .entry(measure.name.clone())
+        .or_default()
+        .push(measure.duration);
+    }
+    averages.into_iter().map(|(k, d)| {
+      let a = d.clone().into_iter().sum::<Duration>() / d.len() as u32;
+      (k.clone(), d.len(), a)
+    })
+  }
+
+  /// Returns an iterator which provides each performance measure currently in
+  /// memory.
+  #[allow(unused)]
+  pub fn get_measures(&self) -> impl Iterator<Item = &PerformanceMeasure> {
+    self.measures.iter()
+  }
+
+  /// Returns an iterator which provides all the instances of a particular
+  /// measure identified by name that are currently in memory.
+  #[allow(unused)]
+  pub fn get_measures_by_name<'a>(
+    &'a self,
+    name: &'a str,
+  ) -> impl Iterator<Item = &'a PerformanceMeasure> {
+    self.measures.iter().filter(move |m| m.name == name)
+  }
+
+  /// Marks the start of a measurement which returns a performance mark
+  /// structure, which is then passed to `.measure()` to finalize the duration
+  /// and add it to the internal buffer.
+  pub fn mark<S: AsRef<str>>(&mut self, name: S) -> PerformanceMark {
+    let name = name.as_ref();
+    let count = self.counts.entry(name.to_string()).or_insert(0);
+    *count += 1;
+    PerformanceMark {
+      name: name.to_string(),
+      count: count.clone(),
+      start: Instant::now(),
+    }
+  }
+
+  /// A function which accepts a previously created performance mark which will
+  /// be used to finalize the duration of the span being measured, and add the
+  /// measurement to the internal buffer.
+  pub fn measure(&mut self, mark: PerformanceMark) {
+    let measure = PerformanceMeasure::from(mark);
+    self.measures.push_back(measure);
+    while self.measures.len() > self.size {
+      self.measures.pop_front();
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_measure() {
+    let mut performance = Performance::default();
+    let mark = performance.mark("a");
+    performance.measure(mark);
+    assert_eq!(performance.get_measures_by_name("a").count(), 1);
+    let measure = performance.get_measures().take(1).next().unwrap();
+    assert_eq!(measure.name, "a");
+    assert_eq!(measure.count, 1);
+  }
+
+  #[test]
+  fn test_average() {
+    let mut performance = Performance::default();
+    let mark1 = performance.mark("a");
+    let mark2 = performance.mark("a");
+    let mark3 = performance.mark("b");
+    performance.measure(mark2);
+    performance.measure(mark1);
+    performance.measure(mark3);
+    let (count, _) = performance.average("a");
+    assert_eq!(count, 2);
+    let (count, _) = performance.average("b");
+    assert_eq!(count, 1);
+    let (count, _) = performance.average("c");
+    assert_eq!(count, 0);
+  }
+
+  #[test]
+  fn test_averages() {
+    let mut performance = Performance::default();
+    let mark1 = performance.mark("a");
+    let mark2 = performance.mark("a");
+    performance.measure(mark2);
+    performance.measure(mark1);
+    let averages: Vec<(String, usize, Duration)> =
+      performance.averages().collect();
+    assert_eq!(averages.len(), 1);
+    assert_eq!(averages[0].1, 2);
+  }
+}

--- a/cli/lsp/performance.rs
+++ b/cli/lsp/performance.rs
@@ -85,7 +85,7 @@ impl Performance {
     }
     averages.into_iter().map(|(k, d)| {
       let a = d.clone().into_iter().sum::<Duration>() / d.len() as u32;
-      (k.clone(), d.len(), a)
+      (k, d.len(), a)
     })
   }
 
@@ -115,7 +115,7 @@ impl Performance {
     *count += 1;
     PerformanceMark {
       name: name.to_string(),
-      count: count.clone(),
+      count: *count,
       start: Instant::now(),
     }
   }

--- a/cli/lsp/performance.rs
+++ b/cli/lsp/performance.rs
@@ -1,9 +1,19 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+use deno_core::serde::Deserialize;
+use deno_core::serde::Serialize;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::time::Duration;
 use std::time::Instant;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PerformanceAverage {
+  pub name: String,
+  pub count: u32,
+  pub average_duration: u32,
+}
 
 /// A structure which serves as a start of a measurement span.
 #[derive(Debug)]

--- a/cli/lsp/performance.rs
+++ b/cli/lsp/performance.rs
@@ -69,7 +69,7 @@ impl Default for Performance {
 impl Performance {
   /// Return the count and average duration of a measurement identified by name.
   #[cfg(test)]
-  pub fn average(&self, name: &str) -> (usize, Duration) {
+  pub fn average(&self, name: &str) -> Option<(usize, Duration)> {
     let mut items = Vec::new();
     for measure in self.measures.lock().unwrap().iter() {
       if measure.name == name {
@@ -77,12 +77,13 @@ impl Performance {
       }
     }
     let len = items.len();
-    let average = if len > 0 {
-      items.into_iter().sum::<Duration>() / len as u32
+
+    if len > 0 {
+      let average = items.into_iter().sum::<Duration>() / len as u32;
+      Some((len, average))
     } else {
-      unreachable!("unexpected empty items key");
-    };
-    (len, average)
+      None
+    }
   }
 
   /// Return an iterator which provides the names, count, and average duration
@@ -149,12 +150,11 @@ mod tests {
     performance.measure(mark2);
     performance.measure(mark1);
     performance.measure(mark3);
-    let (count, _) = performance.average("a");
+    let (count, _) = performance.average("a").expect("should have had value");
     assert_eq!(count, 2);
-    let (count, _) = performance.average("b");
+    let (count, _) = performance.average("b").expect("should have had value");
     assert_eq!(count, 1);
-    let (count, _) = performance.average("c");
-    assert_eq!(count, 0);
+    assert!(performance.average("c").is_none());
   }
 
   #[test]

--- a/cli/tests/lsp/did_change_notification_large_02.json
+++ b/cli/tests/lsp/did_change_notification_large_02.json
@@ -1,0 +1,25 @@
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/didChange",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts",
+      "version": 2
+    },
+    "contentChanges": [
+      {
+        "range": {
+          "start": {
+            "line": 445,
+            "character": 4
+          },
+          "end": {
+            "line": 445,
+            "character": 4
+          }
+        },
+        "text": "// "
+      }
+    ]
+  }
+}

--- a/cli/tests/lsp/did_change_notification_large_03.json
+++ b/cli/tests/lsp/did_change_notification_large_03.json
@@ -1,0 +1,25 @@
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/didChange",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts",
+      "version": 2
+    },
+    "contentChanges": [
+      {
+        "range": {
+          "start": {
+            "line": 477,
+            "character": 4
+          },
+          "end": {
+            "line": 477,
+            "character": 9
+          }
+        },
+        "text": "error"
+      }
+    ]
+  }
+}

--- a/cli/tests/lsp/hover_request_large_01.json
+++ b/cli/tests/lsp/hover_request_large_01.json
@@ -1,0 +1,14 @@
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "textDocument/hover",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts"
+    },
+    "position": {
+      "line": 421,
+      "character": 30
+    }
+  }
+}

--- a/cli/tests/lsp/hover_request_large_02.json
+++ b/cli/tests/lsp/hover_request_large_02.json
@@ -1,0 +1,14 @@
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "textDocument/hover",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts"
+    },
+    "position": {
+      "line": 444,
+      "character": 6
+    }
+  }
+}

--- a/cli/tests/lsp/hover_request_large_03.json
+++ b/cli/tests/lsp/hover_request_large_03.json
@@ -1,0 +1,14 @@
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "textDocument/hover",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts"
+    },
+    "position": {
+      "line": 461,
+      "character": 34
+    }
+  }
+}

--- a/cli/tests/lsp/performance_request.json
+++ b/cli/tests/lsp/performance_request.json
@@ -1,0 +1,6 @@
+{
+  "jsonrpc": "2.0",
+  "id": 99,
+  "method": "deno/performance",
+  "params": {}
+}


### PR DESCRIPTION
This PR adds performance measurements to the internals of the LSP, which are then available via the language services virtual status document.  In VSCode the output looks something like this:

![Cursor_and_status_md_—_oak](https://user-images.githubusercontent.com/1282577/105285690-03043300-5c09-11eb-8274-d8ca63a15d35.png)

This will help us better determine the performance of the lsp and any bottlenecks. It is only instrumented in the language server, and not into the internals of the TypeScript integration for example.