### PR TITLE
fix(core/error): Handle prepareStackTrace() throws

### DIFF
--- a/cli/tests/082_prepare_stack_trace_throw.js
+++ b/cli/tests/082_prepare_stack_trace_throw.js
@@ -1,0 +1,6 @@
+Error.prepareStackTrace = () => {
+  console.trace();
+  throw new Error("foo");
+};
+
+new Error("bar").stack;

--- a/cli/tests/082_prepare_stack_trace_throw.js.out
+++ b/cli/tests/082_prepare_stack_trace_throw.js.out
@@ -1,0 +1,2 @@
+[WILDCARD]error: Uncaught Error: foo
+[WILDCARD]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2684,6 +2684,12 @@ itest!(_081_location_relative_fetch_redirect {
   http_server: true,
 });
 
+itest!(_082_prepare_stack_trace_throw {
+  args: "run 082_prepare_stack_trace_throw.js",
+  output: "082_prepare_stack_trace_throw.js.out",
+  exit_code: 1,
+});
+
 itest!(js_import_detect {
   args: "run --quiet --reload js_import_detect.ts",
   output: "js_import_detect.ts.out",

--- a/core/error.rs
+++ b/core/error.rs
@@ -193,11 +193,9 @@ impl JsError {
 
       // Access error.stack to ensure that prepareStackTrace() has been called.
       // This should populate error.__callSiteEvals.
+      let stack = get_property(scope, exception, "stack");
       let stack: Option<v8::Local<v8::String>> =
-        get_property(scope, exception, "stack")
-          .unwrap()
-          .try_into()
-          .ok();
+        stack.and_then(|s| s.try_into().ok());
       let stack = stack.map(|s| s.to_rust_string_lossy(scope));
 
       // Read an array of structured frames from error.__callSiteEvals.


### PR DESCRIPTION
Fixes #9206.

@00ff0000red A reminder that user assignment of `Error.prepareStackTrace` isn't supported by Deno yet. This fixes the panic, but don't expect error stacks to work completely/correctly.