### PR TITLE
fix(op_crates/fetch): fetch should use Request._bodySource

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -1085,3 +1085,23 @@ unitTest(
     assertEquals(actual, expected);
   },
 );
+
+unitTest(
+  { perms: { net: true } },
+  async function fetchInitRequest(): Promise<void> {
+    const data = "param1=value1&param2=value2";
+    const params = new URLSearchParams(data);
+    const request = new Request("http://localhost:4545/echo_server", {
+      method: "POST",
+      body: params,
+    });
+    const response = await fetch(request);
+    const text = await response.text();
+    assertEquals(text, data);
+    assert(
+      response.headers
+        .get("content-type")!
+        .startsWith("application/x-www-form-urlencoded"),
+    );
+  },
+);

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -1306,6 +1306,11 @@
 
       if (input.body) {
         body = input.body;
+      } else if (input instanceof Request && input._bodySource) {
+        if (input.bodyUsed) {
+          throw TypeError(BodyUsedError);
+        }
+        body = input._bodySource;
       }
     }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

### `fetch` with plain `init`

Code:

```ts
fetch('https://httpbin.org/post', {
  method: 'POST',
  body: new URLSearchParams({ foo: 'bar' }),
})
  .then((response) => response.json())
  .then(console.log)
```

Output:

```
{
  args: {},
  data: "",
  files: {},
  form: { foo: "bar" },
  headers: {
    Accept: "*/*",
    "Accept-Encoding": "gzip, br",
    "Content-Length": "7",
    "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
    Host: "httpbin.org",
    "User-Agent": "Deno/1.6.0",
    "X-Amzn-Trace-Id": "Root=1-6009940f-5e2601b071c845eb615fdb98"
  },
  json: null,
  origin: "...",
  url: "https://httpbin.org/post"
}
```

### `fetch` with `Request`

Code:

```ts
fetch(new Request('https://httpbin.org/post', {
  method: 'POST',
  body: new URLSearchParams({ foo: 'bar' }),
}))
  .then((response) => response.json())
  .then(console.log)
```

Output:

```
{
  args: {},
  data: "foo=bar",
  files: {},
  form: {},
  headers: {
    Accept: "*/*",
    "Accept-Encoding": "gzip, br",
    "Content-Length": "7",
    Host: "httpbin.org",
    "User-Agent": "Deno/1.6.0",
    "X-Amzn-Trace-Id": "Root=1-60099422-689fcf400010ef276be3236f"
  },
  json: null,
  origin: "...",
  url: "https://httpbin.org/post"
}
```

Notice that `"Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"` is absent from the output, which is because `fetch` doesn't process the body at all.