### PR TITLE
fix(std/async): Make pooledMap() errors catchable

### DIFF
--- a/std/async/pool.ts
+++ b/std/async/pool.ts
@@ -59,11 +59,9 @@ export function pooledMap<T, R>(
           errors.push(result.reason);
         }
       }
-      const p = Promise.reject(
+      writer.write(Promise.reject(
         new AggregateError(errors, "Threw while mapping."),
-      );
-      p.catch(() => {});
-      writer.write(p).catch(() => {});
+      )).catch(() => {});
     }
   })();
   return res.readable[Symbol.asyncIterator]();

--- a/std/async/pool.ts
+++ b/std/async/pool.ts
@@ -4,8 +4,13 @@
  * pooledMap transforms values from an (async) iterable into another async
  * iterable. The transforms are done concurrently, with a max concurrency
  * defined by the poolLimit.
- * 
- * @param poolLimit The maximum count of items being processed concurrently. 
+ *
+ * If an error is thrown from `iterableFn`, no new transformations will begin.
+ * All currently executing transformations are allowed to finish and still
+ * yielded on success. After that, the rejections among them are gathered and
+ * thrown by the iterator in an `AggregateError`.
+ *
+ * @param poolLimit The maximum count of items being processed concurrently.
  * @param array The input array for mapping.
  * @param iteratorFn The function to call for every item of the array.
  */
@@ -27,20 +32,39 @@ export function pooledMap<T, R>(
   (async (): Promise<void> => {
     const writer = res.writable.getWriter();
     const executing: Array<Promise<unknown>> = [];
-    for await (const item of array) {
-      const p = Promise.resolve().then(() => iteratorFn(item));
-      writer.write(p);
-      const e: Promise<unknown> = p.then(() =>
-        executing.splice(executing.indexOf(e), 1)
-      );
-      executing.push(e);
-      if (executing.length >= poolLimit) {
-        await Promise.race(executing);
+    try {
+      for await (const item of array) {
+        const p = Promise.resolve().then(() => iteratorFn(item));
+        // Only write on success. If we `writer.write()` a rejected promise,
+        // that will end the iteration. We don't want that yet. Instead let it
+        // fail the race, taking us to the catch block where all currently
+        // executing jobs are allowed to finish and all rejections among them
+        // can be reported together.
+        p.then((v) => writer.write(Promise.resolve(v))).catch(() => {});
+        const e: Promise<unknown> = p.then(() =>
+          executing.splice(executing.indexOf(e), 1)
+        );
+        executing.push(e);
+        if (executing.length >= poolLimit) {
+          await Promise.race(executing);
+        }
       }
+      // Wait until all ongoing events have processed, then close the writer.
+      await Promise.all(executing);
+      writer.close();
+    } catch {
+      const errors = [];
+      for (const result of await Promise.allSettled(executing)) {
+        if (result.status == "rejected") {
+          errors.push(result.reason);
+        }
+      }
+      const p = Promise.reject(
+        new AggregateError(errors, "Threw while mapping."),
+      );
+      p.catch(() => {});
+      writer.write(p).catch(() => {});
     }
-    // Wait until all ongoing events have processed, then close the writer.
-    await Promise.all(executing);
-    writer.close();
   })();
   return res.readable[Symbol.asyncIterator]();
 }

--- a/std/async/pool_test.ts
+++ b/std/async/pool_test.ts
@@ -1,6 +1,12 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { delay } from "./delay.ts";
 import { pooledMap } from "./pool.ts";
-import { assert } from "../testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+  assertThrowsAsync,
+} from "../testing/asserts.ts";
 
 Deno.test("[async] pooledMap", async function (): Promise<void> {
   const start = new Date();
@@ -17,4 +23,22 @@ Deno.test("[async] pooledMap", async function (): Promise<void> {
   assert(diff < 3000);
 });
 
-export {};
+Deno.test("[async] pooledMap errors", async function (): Promise<void> {
+  async function mapNumber(n: number): Promise<number> {
+    if (n <= 2) {
+      throw new Error(`Bad number: ${n}`);
+    }
+    await delay(100);
+    return n;
+  }
+  const mappedNumbers: number[] = [];
+  const error = await assertThrowsAsync(async () => {
+    for await (const m of pooledMap(3, [1, 2, 3, 4], mapNumber)) {
+      mappedNumbers.push(m);
+    }
+  }, AggregateError) as AggregateError;
+  assertEquals(mappedNumbers, [3]);
+  assertEquals(error.errors.length, 2);
+  assertStringIncludes(error.errors[0].stack, "Error: Bad number: 1");
+  assertStringIncludes(error.errors[1].stack, "Error: Bad number: 2");
+});


### PR DESCRIPTION
Fixes #9070.

cc @lucacasonato 