### PR TITLE
fix: --location flag panic on unsupported protocol

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -941,7 +941,7 @@ The executable name is inferred by default:
     and the path has no parent, take the file name of the parent path. Otherwise
     settle with the generic name.
   - If the resulting name has an '@...' suffix, strip it.
-  
+
 This commands supports cross-compiling to different target architectures using `--target` flag.
 On the first invocation with deno will download proper binary and cache it in $DENO_DIR. The
 aarch64-apple-darwin target is not supported in canary.
@@ -1475,11 +1475,11 @@ fn location_arg<'a, 'b>() -> Arg<'a, 'b> {
         return Err("Failed to parse URL".to_string());
       }
       let mut url = url.unwrap();
-      url.set_username("").unwrap();
-      url.set_password(None).unwrap();
       if !["http", "https"].contains(&url.scheme()) {
         return Err("Expected protocol \"http\" or \"https\"".to_string());
       }
+      url.set_username("").unwrap();
+      url.set_password(None).unwrap();
       Ok(())
     })
     .help("Value of 'globalThis.location' used by some web APIs")

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2691,6 +2691,12 @@ itest!(_082_prepare_stack_trace_throw {
   exit_code: 1,
 });
 
+itest!(location_invalid_protocol {
+  args: "run --location file:///Users/alice/test.ts test.ts",
+  output_str: Some("error: Invalid value for '--location <HREF>': Expected protocol \"http\" or \"https\"\n"),
+  exit_code: 1,
+});
+
 itest!(js_import_detect {
   args: "run --quiet --reload js_import_detect.ts",
   output: "js_import_detect.ts.out",


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

The `--location` flag panics on an unsupported protocol, this PR fixes that.

Before:
```
➜ deno run --location file:///Users/sr/test.ts test.ts
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ()', cli/flags.rs:1478:28
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:
```
➜ ./target/debug/deno run --location file:///Users/sr/test.ts test.ts    
error: Invalid value for '--location <HREF>': Expected protocol "http" or "https"
```
