### PR TITLE
fix(std/node): replace uses of `window` with `globalThis`

### DIFF
--- a/std/node/module.ts
+++ b/std/node/module.ts
@@ -1021,7 +1021,7 @@ const CircularRequirePrototypeWarningProxy = new Proxy(
 
 // Object.prototype and ObjectProtoype refer to our 'primordials' versions
 // and are not identical to the versions on the global object.
-const PublicObjectPrototype = window.Object.prototype;
+const PublicObjectPrototype = globalThis.Object.prototype;
 
 // deno-lint-ignore no-explicit-any
 function getExportsForCircularRequire(module: Module): any {

--- a/std/node/timers.ts
+++ b/std/node/timers.ts
@@ -1,17 +1,17 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // TODO(bartlomieju): implement the 'NodeJS.Timeout' and 'NodeJS.Immediate' versions of the timers.
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1163ead296d84e7a3c80d71e7c81ecbd1a130e9a/types/node/v12/globals.d.ts#L1120-L1131
-export const setTimeout = window.setTimeout;
-export const clearTimeout = window.clearTimeout;
-export const setInterval = window.setInterval;
-export const clearInterval = window.clearInterval;
+export const setTimeout = globalThis.setTimeout;
+export const clearTimeout = globalThis.clearTimeout;
+export const setInterval = globalThis.setInterval;
+export const clearInterval = globalThis.clearInterval;
 export const setImmediate = (
   // deno-lint-ignore no-explicit-any
   cb: (...args: any[]) => void,
   // deno-lint-ignore no-explicit-any
   ...args: any[]
-): number => window.setTimeout(cb, 0, ...args);
-export const clearImmediate = window.clearTimeout;
+): number => globalThis.setTimeout(cb, 0, ...args);
+export const clearImmediate = globalThis.clearTimeout;
 
 export default {
   setTimeout,


### PR DESCRIPTION
`module.ts` and `timers.ts` wouldn't previously work in workers, since `window` isn't defined.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
