### PR TITLE
Change release build flags to optimize for performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ exclude = [
 [profile.release]
 codegen-units = 1
 lto = true
-opt-level = 'z' # Optimize for size
+opt-level = 3 # Optimize for performance
 
 [profile.bench]
 codegen-units = 1
 lto = true
-opt-level = 'z' # Optimize for size
+opt-level = 3 # Optimize for performance


### PR DESCRIPTION
improves perf of deno ops/core calls that are not i/o bound at the cost of release build time
haven't tested on other platforms but on macOS arm deno cli is ~900kb larger and denort is 1mb smaller

last change to opt-level #6907