### PR TITLE
fix(lsp): reduce deadlocks with in memory documents

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -58,7 +58,7 @@ pub struct LanguageServer {
 #[derive(Debug, Clone, Default)]
 pub struct StateSnapshot {
   pub assets: Arc<Mutex<HashMap<ModuleSpecifier, Option<AssetDocument>>>>,
-  pub documents: Arc<Mutex<DocumentCache>>,
+  pub documents: DocumentCache,
   pub sources: Arc<Mutex<Sources>>,
 }
 
@@ -289,7 +289,7 @@ impl LanguageServer {
   pub fn snapshot(&self) -> StateSnapshot {
     StateSnapshot {
       assets: self.assets.clone(),
-      documents: self.documents.clone(),
+      documents: self.documents.lock().unwrap().clone(),
       sources: self.sources.clone(),
     }
   }


### PR DESCRIPTION
I was still running into a few hangs while using the lsp.  Looking back at rust_analyzer, the in memory docs during the snapshot are simply cloned and not modifiable.  We were already in a situation where our in memory documents wouldn't be written with a snapshot, but we were still locking, and those locks I believe were causing some deadlocks when things like formatting and TypeScript diagnostics were happening in different threads at the same time.