### PR TITLE
fix(ci): fix windows ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: "2.7"
+          python-version: "3.8"
           architecture: x64
 
       - name: Install Node
@@ -232,7 +232,7 @@ jobs:
       - name: Configure hosts file for WPT (windows)
         if: runner.os == 'Windows'
         working-directory: test_util/wpt/
-        run: python wpt --py2 make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts -Encoding ascii -Append
+        run: python.exe wpt --py3 make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts -Encoding ascii -Append
 
       - name: Test release
         if: matrix.kind == 'test_release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Configure hosts file for WPT (windows)
         if: runner.os == 'Windows'
         working-directory: test_util/wpt/
-        run: python wpt make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts -Encoding ascii -Append
+        run: python wpt --py2 make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts -Encoding ascii -Append
 
       - name: Test release
         if: matrix.kind == 'test_release'

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -5311,6 +5311,7 @@ fn web_platform_tests() {
   let mut proc = Command::new(python)
     .current_dir(util::wpt_path())
     .arg("wpt.py")
+    .arg("--py2")
     .arg("serve")
     .stderr(std::process::Stdio::piped())
     .spawn()


### PR DESCRIPTION
An alternative to https://github.com/denoland/deno/pull/9254

This PR tries to avoid windows CI error by passing `--py2` option to wpt util script. ref: https://github.com/web-platform-tests/wpt/blob/61d85c8/wpt#L10