### PR TITLE
fix(lsp): complete list of unused diagnostics

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -219,7 +219,7 @@ fn ts_json_to_diagnostics(
           ),
           tags: match d.code {
             // These are codes that indicate the variable is unused.
-            6133 | 6192 | 6196 => {
+            2695 | 6133 | 6138 | 6192 | 6196 | 6198 | 6199 | 7027 | 7028 => {
               Some(vec![lsp_types::DiagnosticTag::Unnecessary])
             }
             _ => None,


### PR DESCRIPTION
We were missing a few codes that indicated that a symbol was actually unused.