### PR TITLE
fix(coverage): use source maps when printing pretty reports

### DIFF
--- a/cli/tests/test_branch_coverage.out
+++ b/cli/tests/test_branch_coverage.out
@@ -5,6 +5,6 @@ test branch ... ok ([WILDCARD])
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
 cover [WILDCARD]/tests/subdir/branch.ts ... 66.667% (6/9)
-   5 |     else {
-   6 |         return false;
-   7 |     }
+   4 |   } else {
+   5 |     return false;
+   6 |   }

--- a/cli/tests/test_coverage.out
+++ b/cli/tests/test_coverage.out
@@ -4,22 +4,23 @@ test returnsFooSuccess ... ok ([WILDCARD])
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
-cover [WILDCARD]/cli/tests/subdir/mod1.ts ... 35.714% (5/14)
-   2 | export function returnsHi() {
-   3 |     return "Hi";
-   4 | }
+cover [WILDCARD]/tests/subdir/mod1.ts ... 35.714% (5/14)
+   3 | export function returnsHi(): string {
+   4 |   return "Hi";
+   5 | }
 -----|-----
-   8 | export function printHello3() {
-   9 |     printHello2();
-  10 | }
-  11 | export function throwsError() {
-  12 |     throw Error("exception from mod1");
+  11 | export function printHello3(): void {
+  12 |   printHello2();
   13 | }
-cover [WILDCARD]/cli/tests/subdir/print_hello.ts ... 25.000% (1/4)
-   1 | export function printHello() {
-   2 |     console.log("Hello");
+-----|-----
+  15 | export function throwsError(): void {
+  16 |   throw Error("exception from mod1");
+  17 | }
+cover [WILDCARD]/tests/subdir/print_hello.ts ... 25.000% (1/4)
+   1 | export function printHello(): void {
+   2 |   console.log("Hello");
    3 | }
-cover [WILDCARD]/cli/tests/subdir/subdir2/mod2.ts ... 62.500% (5/8)
-   5 | export function printHello2() {
-   6 |     printHello();
-   7 | }
+cover [WILDCARD]/tests/subdir/subdir2/mod2.ts ... 62.500% (5/8)
+   7 | export function printHello2(): void {
+   8 |   printHello();
+   9 | }

--- a/cli/tests/test_run_combined_coverage.out
+++ b/cli/tests/test_run_combined_coverage.out
@@ -14,18 +14,19 @@ test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WIL
 
 cover [WILDCARD]/tests/run_coverage.ts ... 100.000% (3/3)
 cover [WILDCARD]/tests/subdir/mod1.ts ... 57.143% (8/14)
-   8 | export function printHello3() {
-   9 |     printHello2();
-  10 | }
-  11 | export function throwsError() {
-  12 |     throw Error("exception from mod1");
+  11 | export function printHello3(): void {
+  12 |   printHello2();
   13 | }
+-----|-----
+  15 | export function throwsError(): void {
+  16 |   throw Error("exception from mod1");
+  17 | }
 cover [WILDCARD]/tests/subdir/print_hello.ts ... 25.000% (1/4)
-   1 | export function printHello() {
-   2 |     console.log("Hello");
+   1 | export function printHello(): void {
+   2 |   console.log("Hello");
    3 | }
 cover [WILDCARD]/tests/subdir/subdir2/mod2.ts ... 62.500% (5/8)
-   5 | export function printHello2() {
-   6 |     printHello();
-   7 | }
+   7 | export function printHello2(): void {
+   8 |   printHello();
+   9 | }
 cover [WILDCARD]/tests/test_coverage.ts ... 100.000% (5/5)

--- a/cli/tests/test_run_run_coverage.out
+++ b/cli/tests/test_run_run_coverage.out
@@ -7,23 +7,26 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WIL
 
 cover [WILDCARD]/tests/run_coverage.ts ... 100.000% (3/3)
 cover [WILDCARD]/tests/subdir/mod1.ts ... 35.714% (5/14)
-   5 | export function returnsFoo2() {
-   6 |     return returnsFoo();
-   7 | }
-   8 | export function printHello3() {
-   9 |     printHello2();
-  10 | }
-  11 | export function throwsError() {
-  12 |     throw Error("exception from mod1");
+   7 | export function returnsFoo2(): string {
+   8 |   return returnsFoo();
+   9 | }
+-----|-----
+  11 | export function printHello3(): void {
+  12 |   printHello2();
   13 | }
+-----|-----
+  15 | export function throwsError(): void {
+  16 |   throw Error("exception from mod1");
+  17 | }
 cover [WILDCARD]/tests/subdir/print_hello.ts ... 25.000% (1/4)
-   1 | export function printHello() {
-   2 |     console.log("Hello");
+   1 | export function printHello(): void {
+   2 |   console.log("Hello");
    3 | }
 cover [WILDCARD]/tests/subdir/subdir2/mod2.ts ... 25.000% (2/8)
-   2 | export function returnsFoo() {
-   3 |     return "Foo";
-   4 | }
-   5 | export function printHello2() {
-   6 |     printHello();
-   7 | }
+   3 | export function returnsFoo(): string {
+   4 |   return "Foo";
+   5 | }
+-----|-----
+   7 | export function printHello2(): void {
+   8 |   printHello();
+   9 | }

--- a/cli/tests/test_run_test_coverage.out
+++ b/cli/tests/test_run_test_coverage.out
@@ -1,6 +1,6 @@
-Check [WILDCARD]/$deno$test.ts
+Check [WILDCARD]/tests/$deno$test.ts
 running 1 tests
-test spawn test ... Check [WILDCARD]/$deno$test.ts
+test spawn test ... Check [WILDCARD]/tests/$deno$test.ts
 running 1 tests
 test returnsFooSuccess ... ok ([WILDCARD])
 
@@ -10,23 +10,24 @@ ok ([WILDCARD])
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
-cover [WILDCARD]/subdir/mod1.ts ... 35.714% (5/14)
-   2 | export function returnsHi() {
-   3 |     return "Hi";
-   4 | }
+cover [WILDCARD]/tests/subdir/mod1.ts ... 35.714% (5/14)
+   3 | export function returnsHi(): string {
+   4 |   return "Hi";
+   5 | }
 -----|-----
-   8 | export function printHello3() {
-   9 |     printHello2();
-  10 | }
-  11 | export function throwsError() {
-  12 |     throw Error("exception from mod1");
+  11 | export function printHello3(): void {
+  12 |   printHello2();
   13 | }
-cover [WILDCARD]/subdir/print_hello.ts ... 25.000% (1/4)
-   1 | export function printHello() {
-   2 |     console.log("Hello");
+-----|-----
+  15 | export function throwsError(): void {
+  16 |   throw Error("exception from mod1");
+  17 | }
+cover [WILDCARD]/tests/subdir/print_hello.ts ... 25.000% (1/4)
+   1 | export function printHello(): void {
+   2 |   console.log("Hello");
    3 | }
-cover [WILDCARD]/subdir/subdir2/mod2.ts ... 62.500% (5/8)
-   5 | export function printHello2() {
-   6 |     printHello();
-   7 | }
-cover [WILDCARD]/test_coverage.ts ... 100.000% (5/5)
+cover [WILDCARD]/tests/subdir/subdir2/mod2.ts ... 62.500% (5/8)
+   7 | export function printHello2(): void {
+   8 |   printHello();
+   9 | }
+cover [WILDCARD]/tests/test_coverage.ts ... 100.000% (5/5)

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -242,11 +242,9 @@ impl PrettyCoverageReporter {
         let mut indices = uncovered_lines
           .iter()
           .map(|i| {
-            let line = *i as u32;
-
             source_map
               .tokens()
-              .filter(move |token| token.get_dst_line() == line.clone())
+              .filter(move |token| token.get_dst_line() as usize == *i)
               .map(|token| token.get_src_line() as usize)
           })
           .flatten()

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -239,6 +239,10 @@ impl PrettyCoverageReporter {
         };
 
       let output_indices = if let Some(source_map) = maybe_source_map.as_ref() {
+        // The compiled executable source lines have to be mapped to all the original source lines that they
+        // came from; this happens in a couple of emit scenarios, the most common example being function
+        // declarations where the compiled JavaScript code only takes a line but the original
+        // TypeScript source spans 10 lines.
         let mut indices = uncovered_lines
           .iter()
           .map(|i| {

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -238,15 +238,18 @@ impl PrettyCoverageReporter {
           lines
         };
 
-      let output_indices = if let Some(source_map) = maybe_source_map {
+      let output_indices = if let Some(source_map) = maybe_source_map.as_ref() {
         let mut indices = uncovered_lines
           .iter()
           .map(|i| {
+            let line = *i as u32;
+
             source_map
-              .lookup_token(*i as u32, 16)
-              .unwrap()
-              .get_src_line() as usize
+              .tokens()
+              .filter(move |token| token.get_dst_line() == line.clone())
+              .map(|token| token.get_src_line() as usize)
           })
+          .flatten()
           .collect::<Vec<usize>>();
 
         indices.sort_unstable();

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -238,19 +238,29 @@ impl PrettyCoverageReporter {
           lines
         };
 
+      let output_indices = if let Some(source_map) = maybe_source_map {
+        let mut indices = uncovered_lines
+          .iter()
+          .map(|i| {
+            source_map
+              .lookup_token(*i as u32, 0)
+              .unwrap()
+              .get_src_line() as usize
+          })
+          .collect::<Vec<usize>>();
+
+          indices.sort();
+          indices.dedup();
+
+          indices
+      } else {
+        uncovered_lines
+      };
+
       let mut last_line = None;
-      for line_index in uncovered_lines {
+      for line_index in output_indices {
         const WIDTH: usize = 4;
         const SEPERATOR: &str = "|";
-
-        let line_index = if let Some(source_map) = maybe_source_map.as_ref() {
-          source_map
-            .lookup_token(line_index as u32, 0)
-            .unwrap()
-            .get_src_line() as usize
-        } else {
-          line_index
-        };
 
         // Put a horizontal separator between disjoint runs of lines
         if let Some(last_line) = last_line {

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -233,7 +233,7 @@ impl PrettyCoverageReporter {
 
       let output_lines =
         if let Some(original_source) = maybe_original_source.as_ref() {
-          original_source.split("\n").collect::<Vec<_>>()
+          original_source.split('\n').collect::<Vec<_>>()
         } else {
           lines
         };
@@ -249,7 +249,7 @@ impl PrettyCoverageReporter {
           })
           .collect::<Vec<usize>>();
 
-        indices.sort();
+        indices.sort_unstable();
         indices.dedup();
 
         indices

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -243,7 +243,7 @@ impl PrettyCoverageReporter {
           .iter()
           .map(|i| {
             source_map
-              .lookup_token(*i as u32, 0)
+              .lookup_token(*i as u32, 16)
               .unwrap()
               .get_src_line() as usize
           })

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -249,10 +249,10 @@ impl PrettyCoverageReporter {
           })
           .collect::<Vec<usize>>();
 
-          indices.sort();
-          indices.dedup();
+        indices.sort();
+        indices.dedup();
 
-          indices
+        indices
       } else {
         uncovered_lines
       };


### PR DESCRIPTION
This makes use of source maps and the original source when printing lacking line coverage in the pretty printer.

Only the executable lines are checked as before (as non-executable lines will always be ignored anyways).
The lines then mapped to the appropriate source line when a source map is present.

Closes #8923 