### PR TITLE
fix: fix panics in Deno.emit

### DIFF
--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -94,19 +94,24 @@ async fn op_emit(
   let mut builder = GraphBuilder::new(handler, maybe_import_map, None);
   let root_specifier =
     ModuleSpecifier::resolve_url_or_path(&args.root_specifier)?;
-  builder.add(&root_specifier, is_dynamic).await?;
+  builder
+    .add(&root_specifier, is_dynamic)
+    .await
+    .map_err(|e| generic_error(format!("{}", e)))?;
   let bundle_type = match args.bundle {
     Some(RuntimeBundleType::Esm) => BundleType::Esm,
     _ => BundleType::None,
   };
   let graph = builder.get_graph();
   let debug = program_state.flags.log_level == Some(log::Level::Debug);
-  let (files, result_info) = graph.emit(EmitOptions {
-    bundle_type,
-    check: args.check.unwrap_or(true),
-    debug,
-    maybe_user_config: args.compiler_options,
-  })?;
+  let (files, result_info) = graph
+    .emit(EmitOptions {
+      bundle_type,
+      check: args.check.unwrap_or(true),
+      debug,
+      maybe_user_config: args.compiler_options,
+    })
+    .map_err(|e| generic_error(format!("{}", e)))?;
 
   Ok(json!({
     "diagnostics": result_info.diagnostics,

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -12,6 +12,7 @@ use crate::specifier_handler::SpecifierHandler;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
 use deno_core::error::Context;
+use deno_core::error::JsError;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
@@ -111,7 +112,13 @@ async fn op_emit(
       debug,
       maybe_user_config: args.compiler_options,
     })
-    .map_err(|e| generic_error(format!("{}", e)))?;
+    .map_err(|e| {
+      if e.is::<JsError>() {
+        generic_error(format!("{}", e))
+      } else {
+        e
+      }
+    })?;
 
   Ok(json!({
     "diagnostics": result_info.diagnostics,

--- a/cli/tests/compiler_api_test.ts
+++ b/cli/tests/compiler_api_test.ts
@@ -292,3 +292,23 @@ Deno.test({
     assert(diagnostics[0].messageText.includes("This import is never used"));
   },
 });
+
+Deno.test({
+  name: "Deno.emit() - some custom scheme specifiers do not panic",
+  async fn() {
+    await assertThrowsAsync(async () => {
+      await Deno.emit("custom://a.ts", {
+        sources: {
+          "custom://a.ts": `export const a: string = 'a';`,
+        },
+      });
+    });
+    await assertThrowsAsync(async () => {
+      await Deno.emit("custom://a//a.ts", {
+        sources: {
+          "custom://a//a.ts": `export const a: string = 'a';`,
+        },
+      });
+    });
+  },
+});


### PR DESCRIPTION
Deno.emit panics with the specifier `custom://a.ts` and `custom://a//a.ts` as input. This PR maps these 2 panics to JavaScript errors.

fixes #9277 