### PR TITLE
fix(cli): Added markdown description to `fmt --help`

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -793,7 +793,7 @@ fn fmt_subcommand<'a, 'b>() -> App<'a, 'b> {
   SubCommand::with_name("fmt")
     .about("Format source files")
     .long_about(
-      "Auto-format JavaScript/TypeScript source code.
+      "Auto-format JavaScript, TypeScript and Markdown files.
   deno fmt
   deno fmt myfile1.ts myfile2.ts
   deno fmt --check


### PR DESCRIPTION
Closes: #9267 

> Running deno fmt --helpsays: Auto-format JavaScript/TypeScript source code.
In #8887 markdown support was added.
So the describtion should be also saying something like:
Auto-format JavaScript, TypeScript and Markdown files.