### PR TITLE
fix(cli): add lib dom.asynciterable

### DIFF
--- a/cli/dts/lib.dom.asynciterable.d.ts
+++ b/cli/dts/lib.dom.asynciterable.d.ts
@@ -1,0 +1,9 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/// <reference no-default-lib="true"/>
+
+interface ReadableStream<R = any> {
+  [Symbol.asyncIterator](options?: {
+    preventCancel?: boolean;
+  }): AsyncIterableIterator<R>;
+}

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3070,6 +3070,11 @@ itest!(runtime_decorators {
   output: "runtime_decorators.ts.out",
 });
 
+itest!(lib_dom_asynciterable {
+  args: "run --quiet --unstable --reload lib_dom_asynciterable.ts",
+  output: "lib_dom_asynciterable.ts.out",
+});
+
 itest!(lib_ref {
   args: "run --quiet --unstable --reload lib_ref.ts",
   output: "lib_ref.ts.out",

--- a/cli/tests/lib_dom_asynciterable.ts
+++ b/cli/tests/lib_dom_asynciterable.ts
@@ -1,0 +1,23 @@
+const { diagnostics, files } = await Deno.emit("/main.ts", {
+  compilerOptions: {
+    target: "esnext",
+    lib: ["esnext", "dom", "dom.iterable", "dom.asynciterable"],
+  },
+  sources: {
+    "/main.ts": `const rs = new ReadableStream<string>({
+      start(c) {
+        c.enqueue("hello");
+        c.enqueue("deno");
+        c.close();
+      }
+    });
+    
+    for await (const s of rs) {
+      console.log("s");
+    }
+    `,
+  },
+});
+
+console.log(diagnostics);
+console.log(Object.keys(files).sort());

--- a/cli/tests/lib_dom_asynciterable.ts.out
+++ b/cli/tests/lib_dom_asynciterable.ts.out
@@ -1,2 +1,2 @@
 []
-[ "file:///main.ts.js", "file:///main.ts.js.map" ]
+[ "[WILDCARD]/main.ts.js", "[WILDCARD]/main.ts.js.map" ]

--- a/cli/tests/lib_dom_asynciterable.ts.out
+++ b/cli/tests/lib_dom_asynciterable.ts.out
@@ -1,0 +1,2 @@
+[]
+[ "file:///main.ts.js", "file:///main.ts.js.map" ]

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -52,6 +52,7 @@ pub fn get_asset(asset: &str) -> Option<&'static str> {
     };
   }
   match asset {
+    "lib.dom.asynciterable.d.ts" => inc!("lib.dom.asynciterable.d.ts"),
     "lib.dom.d.ts" => inc!("lib.dom.d.ts"),
     "lib.dom.iterable.d.ts" => inc!("lib.dom.iterable.d.ts"),
     "lib.es6.d.ts" => inc!("lib.es6.d.ts"),


### PR DESCRIPTION
Fixes #9218

Introduces a new lib `dom.asynciterable` to complement `dom` and `dom.iterable` until TypeScript fixes the issue upstream.

If you are using a `"lib"` option in a `tsconfig.json` or with `Deno.emit()` you would want to make it look something like this:

```json
{
  "compilerOptions": {
    "lib": [ "esnext", "dom", "dom.iterable", "dom.asynciterable" ]
  }
}
```
