### PR TITLE
WIP: try split ci into multiple steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,27 +4,15 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: ${{ matrix.kind }} ${{ matrix.os }}
-    if: |
-      github.event_name == 'push' ||
-      !startsWith(github.event.pull_request.head.label, 'denoland:')
+    name: build-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       matrix:
         include:
           - os: macos-10.15
-            kind: test_release
           - os: windows-2019
-            kind: test_release
-          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest' || 'ubuntu-18.04' }}
-            kind: test_release
-          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest' || 'ubuntu-18.04' }}
-            kind: test_debug
-          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest' || 'ubuntu-18.04' }}
-            kind: bench
-          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest' || 'ubuntu-18.04' }}
-            kind: lint
+          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
 
       # Always run master branch builds to completion. This allows the cache to
       # stay mostly up-to-date in situations where a single job fails due to
@@ -33,9 +21,7 @@ jobs:
       # prevented if 'cargo publish' fails (which can be a false negative).
       fail-fast: ${{ github.event_name == 'pull_request' || (github.ref !=
         'refs/heads/master' && !startsWith(github.ref, 'refs/tags/')) }}
-
     env:
-      CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: full
       CARGO_TERM_COLOR: always
 
@@ -52,291 +38,384 @@ jobs:
           fetch-depth: 5
           submodules: true
 
-      - name: Create source tarballs (release, linux)
-        if: |
-          startsWith(matrix.os, 'ubuntu') &&
-          matrix.kind == 'test_release' &&
-          github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/') &&
-          !startsWith(github.ref, 'refs/tags/std/')
+      - name: Log versions
         run: |
-          mkdir -p target/release
-          tar --exclude=.cargo_home --exclude=".git*" --exclude=target --exclude=third_party/prebuilt -czvf target/release/deno_src.tar.gz -C .. deno
+          rustc --version
+          cargo --version
 
       - name: Install rust
         uses: hecrj/setup-rust-action@v1
         with:
           rust-version: 1.49.0
 
-      - name: Install clippy and rustfmt
-        if: matrix.kind == 'lint'
-        run: |
-          rustup component add clippy
-          rustup component add rustfmt
-
-      - name: Install Deno
-        if: |
-          !startsWith(matrix.os, 'windows')
-        run: |-
-          curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.5.1
-          echo "$HOME/.deno/bin" >> $GITHUB_PATH
-
-      - name: Install Deno (Windows)
-        if: startsWith(matrix.os, 'windows')
-        run: |-
-          curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.5.1
-          echo "$HOME/.deno/bin" >> $env:GITHUB_PATH
-
-      - name: Install Python
-        uses: actions/setup-python@v1
+      - name: Cache
+        uses: actions/cache@v2
         with:
-          python-version: "3.8"
-          architecture: x64
-
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14"
-          check-latest: true
-
-      - name: Remove unused versions of Python
-        if: startsWith(matrix.os, 'windows')
-        run: |-
-          $env:PATH -split ";" |
-            Where-Object { Test-Path "$_\python.exe" } |
-            Select-Object -Skip 1 |
-            ForEach-Object { Move-Item "$_" "$_.disabled" }
-
-      - name: Setup gcloud (unix)
-        if: |
-          runner.os != 'Windows' &&
-          matrix.kind == 'test_release' &&
-          github.repository == 'denoland/deno' &&
-          (github.ref == 'refs/heads/master' ||
-          startsWith(github.ref, 'refs/tags/') &&
-          !startsWith(github.ref, 'refs/tags/std/'))
-        uses: google-github-actions/setup-gcloud@master
-        with:
-          project_id: denoland
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
-      - name: Setup gcloud (windows)
-        if: |
-          runner.os == 'Windows' &&
-          matrix.kind == 'test_release' &&
-          github.repository == 'denoland/deno' &&
-          (github.ref == 'refs/heads/master' ||
-          startsWith(github.ref, 'refs/tags/') &&
-          !startsWith(github.ref, 'refs/tags/std/'))
-        uses: google-github-actions/setup-gcloud@master
-        env:
-          CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
-        with:
-          project_id: denoland
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            .cargo_home
+            target/*/.*
+            target/*/build
+            target/*/deps
+          key: build-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: build-${{ runner.os }}-
 
       - name: Configure canary build
         if: |
-          matrix.kind == 'test_release' &&
           github.repository == 'denoland/deno' &&
           github.ref == 'refs/heads/master'
         shell: bash
         run: |
           echo "DENO_CANARY=true" >> $GITHUB_ENV
 
-      - name: Log versions
-        run: |
-          node -v
-          python --version
-          rustc --version
-          cargo --version
-          deno --version
-
-      - name: lint.js
-        if: matrix.kind == 'lint'
-        run: deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js
-
-      - name: test_format.js
-        if: matrix.kind == 'lint'
-        run: deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check
-
       - name: Build release
-        if: |
-          matrix.kind == 'test_release' ||
-          matrix.kind == 'bench'
         run: cargo build --release --locked --all-targets -vv
 
-      - name: Build debug
-        if: matrix.kind == 'test_debug'
-        run: cargo build --locked --all-targets
-
-      - name: Pre-release (linux)
-        if: |
-          startsWith(matrix.os, 'ubuntu') &&
-          matrix.kind == 'test_release'
-        run: |
-          cd target/release
-          zip -r deno-x86_64-unknown-linux-gnu.zip deno
-          zip -r denort-x86_64-unknown-linux-gnu.zip denort
-          ./deno types > lib.deno.d.ts
-
-      - name: Pre-release (mac)
-        if: |
-          startsWith(matrix.os, 'macOS') &&
-          matrix.kind == 'test_release'
-        run: |
-          cd target/release
-          zip -r deno-x86_64-apple-darwin.zip deno
-          zip -r denort-x86_64-apple-darwin.zip denort
-
-      - name: Pre-release (windows)
-        if: |
-          startsWith(matrix.os, 'windows') &&
-          matrix.kind == 'test_release'
-        run: |
-          Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip
-          Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-x86_64-pc-windows-msvc.zip
-
-      - name: Upload canary to dl.deno.land (unix)
-        if: |
-          runner.os != 'Windows' &&
-          matrix.kind == 'test_release' &&
-          github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/master'
-        run: |
-          gsutil cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/
-          echo $(git rev-parse HEAD) > canary-latest.txt
-          gsutil cp canary-latest.txt gs://dl.deno.land/canary-latest.txt
-
-      - name: Upload canary to dl.deno.land (windows)
-        if: |
-          runner.os == 'Windows' &&
-          matrix.kind == 'test_release' &&
-          github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/master'
-        env:
-          CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
-        shell: bash
-        run: |
-          gsutil cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/
-          echo $(git rev-parse HEAD) > canary-latest.txt
-          gsutil cp canary-latest.txt gs://dl.deno.land/canary-latest.txt
-
-      - name: Test release
-        if: matrix.kind == 'test_release'
-        run: cargo test --release --locked --all-targets
-
-      - name: Test debug
-        if: matrix.kind == 'test_debug'
-        run: |
-          cargo test --locked --doc
-          cargo test --locked --all-targets
-
-      - name: Configure hosts file for WPT (unix)
-        if: runner.os != 'Windows'
-        run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
-        working-directory: test_util/wpt/
-
-      - name: Configure hosts file for WPT (windows)
-        if: runner.os == 'Windows'
-        working-directory: test_util/wpt/
-        run: python wpt make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts -Encoding ascii -Append
-
-      - name: Run web platform tests (release)
-        if: matrix.kind == 'test_release'
-        run: |
-          deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts setup
-          deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts run --quiet --release
-
-      - name: Run web platform tests (debug)
-        if: matrix.kind == 'test_debug'
-        run: |
-          deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts setup
-          deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts run --quiet
-
-      - name: Run Benchmarks
-        if: matrix.kind == 'bench'
-        run: cargo bench
-
-      - name: Post Benchmarks
-        if: |
-          matrix.kind == 'bench' &&
-          github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/master'
-        env:
-          DENOBOT_PAT: ${{ secrets.DENOBOT_PAT }}
-        run: |
-          git clone --depth 1 -b gh-pages https://${DENOBOT_PAT}@github.com/denoland/benchmark_data.git gh-pages
-          deno run --unstable -A ./tools/build_benchmark_jsons.js --release
-          cd gh-pages
-          git config user.email "propelml@gmail.com"
-          git config user.name "denobot"
-          git add .
-          git commit --message "Update benchmarks"
-          git push origin gh-pages
-
-      - name: Worker info
-        if: matrix.kind == 'bench'
-        run: |
-          cat /proc/cpuinfo
-          cat /proc/meminfo
-
-      - name: Upload release to dl.deno.land (unix)
-        if: |
-          runner.os != 'Windows' &&
-          matrix.kind == 'test_release' &&
-          github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/') &&
-          !startsWith(github.ref, 'refs/tags/std/')
-        run: |
-          gsutil cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/
-          echo ${GITHUB_REF#refs/*/} > release-latest.txt
-          gsutil cp release-latest.txt gs://dl.deno.land/release-latest.txt
-
-      - name: Upload release to dl.deno.land (windows)
-        if: |
-          runner.os == 'Windows' &&
-          matrix.kind == 'test_release' &&
-          github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/') &&
-          !startsWith(github.ref, 'refs/tags/std/')
-        env:
-          CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
-        shell: bash
-        run: |
-          gsutil cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/
-          echo ${GITHUB_REF#refs/*/} > release-latest.txt
-          gsutil cp release-latest.txt gs://dl.deno.land/release-latest.txt
-
-      - name: Upload release to GitHub
-        uses: softprops/action-gh-release@v1
-        if: |
-          matrix.kind == 'test_release' &&
-          github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/') &&
-          !startsWith(github.ref, 'refs/tags/std/')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v2
         with:
-          files: |
-            target/release/deno-x86_64-pc-windows-msvc.zip
-            target/release/deno-x86_64-unknown-linux-gnu.zip
-            target/release/deno-x86_64-apple-darwin.zip
-            target/release/deno_src.tar.gz
-            target/release/lib.deno.d.ts
-          draft: true
+          name: deno-${{ runner.os }}
+          path: |
+            target/release/deno
+            target/release/denort
+            target/release/deno.exe
+            target/release/denort.exe
+          if-no-files-found: error
 
-      - name: Publish
-        if: |
-          startsWith(matrix.os, 'ubuntu') &&
-          matrix.kind == 'test_release' &&
-          github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/') &&
-          !startsWith(github.ref, 'refs/tags/std/')
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          cd cli
-          cargo publish
+  # build:
+  #   name: ${{ matrix.kind }}
+  #   if: |
+  #     github.event_name == 'push' ||
+  #     !startsWith(github.event.pull_request.head.label, 'denoland:')
+  #   runs-on: ${{ matrix.os }}
+  #   timeout-minutes: 60
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - os: macos-10.15
+  #           kind: test_release
+  #         - os: windows-2019
+  #           kind: test_release
+  #         - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest' || 'ubuntu-18.04' }}
+  #           kind: test_release
+  #         - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest' || 'ubuntu-18.04' }}
+  #           kind: test_debug
+  #         - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest' || 'ubuntu-18.04' }}
+  #           kind: bench
+  #         - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest' || 'ubuntu-18.04' }}
+  #           kind: lint
+
+  #     # Always run master branch builds to completion. This allows the cache to
+  #     # stay mostly up-to-date in situations where a single job fails due to
+  #     # e.g. a flaky test.
+  #     # Don't fast-fail on tag build because publishing binaries shouldn't be
+  #     # prevented if 'cargo publish' fails (which can be a false negative).
+  #     fail-fast: ${{ github.event_name == 'pull_request' || (github.ref !=
+  #       'refs/heads/master' && !startsWith(github.ref, 'refs/tags/')) }}
+
+  #   env:
+  #     CARGO_INCREMENTAL: 0
+  #     RUST_BACKTRACE: full
+  #     CARGO_TERM_COLOR: always
+
+  #   steps:
+  #     - name: Configure git
+  #       run: git config --global core.symlinks true
+
+  #     - name: Clone repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         # Use depth > 1, because sometimes we need to rebuild master and if
+  #         # other commits have landed it will become impossible to rebuild if
+  #         # the checkout is too shallow.
+  #         fetch-depth: 5
+  #         submodules: true
+
+  #     - name: Create source tarballs (release, linux)
+  #       if: |
+  #         startsWith(matrix.os, 'ubuntu') &&
+  #         matrix.kind == 'test_release' &&
+  #         github.repository == 'denoland/deno' &&
+  #         startsWith(github.ref, 'refs/tags/') &&
+  #         !startsWith(github.ref, 'refs/tags/std/')
+  #       run: |
+  #         mkdir -p target/release
+  #         tar --exclude=.cargo_home --exclude=".git*" --exclude=target --exclude=third_party/prebuilt -czvf target/release/deno_src.tar.gz -C .. deno
+
+  #     - name: Install rust
+  #       uses: hecrj/setup-rust-action@v1
+  #       with:
+  #         rust-version: 1.49.0
+
+  #     - name: Install clippy and rustfmt
+  #       if: matrix.kind == 'lint'
+  #       run: |
+  #         rustup component add clippy
+  #         rustup component add rustfmt
+
+  #     - name: Install Deno
+  #       if: |
+  #         !startsWith(matrix.os, 'windows')
+  #       run: |-
+  #         curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.5.1
+  #         echo "$HOME/.deno/bin" >> $GITHUB_PATH
+
+  #     - name: Install Deno (Windows)
+  #       if: startsWith(matrix.os, 'windows')
+  #       run: |-
+  #         curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.5.1
+  #         echo "$HOME/.deno/bin" >> $env:GITHUB_PATH
+
+  #     - name: Install Python
+  #       uses: actions/setup-python@v1
+  #       with:
+  #         python-version: "3.8"
+  #         architecture: x64
+
+  #     - name: Install Node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: "14"
+  #         check-latest: true
+
+  #     - name: Remove unused versions of Python
+  #       if: startsWith(matrix.os, 'windows')
+  #       run: |-
+  #         $env:PATH -split ";" |
+  #           Where-Object { Test-Path "$_\python.exe" } |
+  #           Select-Object -Skip 1 |
+  #           ForEach-Object { Move-Item "$_" "$_.disabled" }
+
+  #     - name: Setup gcloud (unix)
+  #       if: |
+  #         runner.os != 'Windows' &&
+  #         matrix.kind == 'test_release' &&
+  #         github.repository == 'denoland/deno' &&
+  #         (github.ref == 'refs/heads/master' ||
+  #         startsWith(github.ref, 'refs/tags/') &&
+  #         !startsWith(github.ref, 'refs/tags/std/'))
+  #       uses: google-github-actions/setup-gcloud@master
+  #       with:
+  #         project_id: denoland
+  #         service_account_key: ${{ secrets.GCP_SA_KEY }}
+  #         export_default_credentials: true
+
+  #     - name: Setup gcloud (windows)
+  #       if: |
+  #         runner.os == 'Windows' &&
+  #         matrix.kind == 'test_release' &&
+  #         github.repository == 'denoland/deno' &&
+  #         (github.ref == 'refs/heads/master' ||
+  #         startsWith(github.ref, 'refs/tags/') &&
+  #         !startsWith(github.ref, 'refs/tags/std/'))
+  #       uses: google-github-actions/setup-gcloud@master
+  #       env:
+  #         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
+  #       with:
+  #         project_id: denoland
+  #         service_account_key: ${{ secrets.GCP_SA_KEY }}
+  #         export_default_credentials: true
+
+  #     - name: Configure canary build
+  #       if: |
+  #         matrix.kind == 'test_release' &&
+  #         github.repository == 'denoland/deno' &&
+  #         github.ref == 'refs/heads/master'
+  #       shell: bash
+  #       run: |
+  #         echo "DENO_CANARY=true" >> $GITHUB_ENV
+
+  #     - name: Log versions
+  #       run: |
+  #         node -v
+  #         python --version
+  #         rustc --version
+  #         cargo --version
+  #         deno --version
+
+  #     - name: lint.js
+  #       if: matrix.kind == 'lint'
+  #       run: deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js
+
+  #     - name: test_format.js
+  #       if: matrix.kind == 'lint'
+  #       run: deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check
+
+  #     - name: Build release
+  #       if: |
+  #         matrix.kind == 'test_release' ||
+  #         matrix.kind == 'bench'
+  #       run: cargo build --release --locked --all-targets -vv
+
+  #     - name: Build debug
+  #       if: matrix.kind == 'test_debug'
+  #       run: cargo build --locked --all-targets
+
+  #     - name: Pre-release (linux)
+  #       if: |
+  #         startsWith(matrix.os, 'ubuntu') &&
+  #         matrix.kind == 'test_release'
+  #       run: |
+  #         cd target/release
+  #         zip -r deno-x86_64-unknown-linux-gnu.zip deno
+  #         zip -r denort-x86_64-unknown-linux-gnu.zip denort
+  #         ./deno types > lib.deno.d.ts
+
+  #     - name: Pre-release (mac)
+  #       if: |
+  #         startsWith(matrix.os, 'macOS') &&
+  #         matrix.kind == 'test_release'
+  #       run: |
+  #         cd target/release
+  #         zip -r deno-x86_64-apple-darwin.zip deno
+  #         zip -r denort-x86_64-apple-darwin.zip denort
+
+  #     - name: Pre-release (windows)
+  #       if: |
+  #         startsWith(matrix.os, 'windows') &&
+  #         matrix.kind == 'test_release'
+  #       run: |
+  #         Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip
+  #         Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-x86_64-pc-windows-msvc.zip
+
+  #     - name: Upload canary to dl.deno.land (unix)
+  #       if: |
+  #         runner.os != 'Windows' &&
+  #         matrix.kind == 'test_release' &&
+  #         github.repository == 'denoland/deno' &&
+  #         github.ref == 'refs/heads/master'
+  #       run: |
+  #         gsutil cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/
+  #         echo $(git rev-parse HEAD) > canary-latest.txt
+  #         gsutil cp canary-latest.txt gs://dl.deno.land/canary-latest.txt
+
+  #     - name: Upload canary to dl.deno.land (windows)
+  #       if: |
+  #         runner.os == 'Windows' &&
+  #         matrix.kind == 'test_release' &&
+  #         github.repository == 'denoland/deno' &&
+  #         github.ref == 'refs/heads/master'
+  #       env:
+  #         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
+  #       shell: bash
+  #       run: |
+  #         gsutil cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/
+  #         echo $(git rev-parse HEAD) > canary-latest.txt
+  #         gsutil cp canary-latest.txt gs://dl.deno.land/canary-latest.txt
+
+  #     - name: Test release
+  #       if: matrix.kind == 'test_release'
+  #       run: cargo test --release --locked --all-targets
+
+  #     - name: Test debug
+  #       if: matrix.kind == 'test_debug'
+  #       run: |
+  #         cargo test --locked --doc
+  #         cargo test --locked --all-targets
+
+  #     - name: Configure hosts file for WPT (unix)
+  #       if: runner.os != 'Windows'
+  #       run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
+  #       working-directory: test_util/wpt/
+
+  #     - name: Configure hosts file for WPT (windows)
+  #       if: runner.os == 'Windows'
+  #       working-directory: test_util/wpt/
+  #       run: python wpt make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts -Encoding ascii -Append
+
+  #     - name: Run web platform tests (release)
+  #       if: matrix.kind == 'test_release'
+  #       run: |
+  #         deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts setup
+  #         deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts run --quiet --release
+
+  #     - name: Run web platform tests (debug)
+  #       if: matrix.kind == 'test_debug'
+  #       run: |
+  #         deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts setup
+  #         deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts run --quiet
+
+  #     - name: Run Benchmarks
+  #       if: matrix.kind == 'bench'
+  #       run: cargo bench
+
+  #     - name: Post Benchmarks
+  #       if: |
+  #         matrix.kind == 'bench' &&
+  #         github.repository == 'denoland/deno' &&
+  #         github.ref == 'refs/heads/master'
+  #       env:
+  #         DENOBOT_PAT: ${{ secrets.DENOBOT_PAT }}
+  #       run: |
+  #         git clone --depth 1 -b gh-pages https://${DENOBOT_PAT}@github.com/denoland/benchmark_data.git gh-pages
+  #         deno run --unstable -A ./tools/build_benchmark_jsons.js --release
+  #         cd gh-pages
+  #         git config user.email "propelml@gmail.com"
+  #         git config user.name "denobot"
+  #         git add .
+  #         git commit --message "Update benchmarks"
+  #         git push origin gh-pages
+
+  #     - name: Worker info
+  #       if: matrix.kind == 'bench'
+  #       run: |
+  #         cat /proc/cpuinfo
+  #         cat /proc/meminfo
+
+  #     - name: Upload release to dl.deno.land (unix)
+  #       if: |
+  #         runner.os != 'Windows' &&
+  #         matrix.kind == 'test_release' &&
+  #         github.repository == 'denoland/deno' &&
+  #         startsWith(github.ref, 'refs/tags/') &&
+  #         !startsWith(github.ref, 'refs/tags/std/')
+  #       run: |
+  #         gsutil cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/
+  #         echo ${GITHUB_REF#refs/*/} > release-latest.txt
+  #         gsutil cp release-latest.txt gs://dl.deno.land/release-latest.txt
+
+  #     - name: Upload release to dl.deno.land (windows)
+  #       if: |
+  #         runner.os == 'Windows' &&
+  #         matrix.kind == 'test_release' &&
+  #         github.repository == 'denoland/deno' &&
+  #         startsWith(github.ref, 'refs/tags/') &&
+  #         !startsWith(github.ref, 'refs/tags/std/')
+  #       env:
+  #         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
+  #       shell: bash
+  #       run: |
+  #         gsutil cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/
+  #         echo ${GITHUB_REF#refs/*/} > release-latest.txt
+  #         gsutil cp release-latest.txt gs://dl.deno.land/release-latest.txt
+
+  #     - name: Upload release to GitHub
+  #       uses: softprops/action-gh-release@v1
+  #       if: |
+  #         matrix.kind == 'test_release' &&
+  #         github.repository == 'denoland/deno' &&
+  #         startsWith(github.ref, 'refs/tags/') &&
+  #         !startsWith(github.ref, 'refs/tags/std/')
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         files: |
+  #           target/release/deno-x86_64-pc-windows-msvc.zip
+  #           target/release/deno-x86_64-unknown-linux-gnu.zip
+  #           target/release/deno-x86_64-apple-darwin.zip
+  #           target/release/deno_src.tar.gz
+  #           target/release/lib.deno.d.ts
+  #         draft: true
+
+  #     - name: Publish
+  #       if: |
+  #         startsWith(matrix.os, 'ubuntu') &&
+  #         matrix.kind == 'test_release' &&
+  #         github.repository == 'denoland/deno' &&
+  #         startsWith(github.ref, 'refs/tags/') &&
+  #         !startsWith(github.ref, 'refs/tags/std/')
+  #       env:
+  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  #       run: |
+  #         cd cli
+  #         cargo publish


### PR DESCRIPTION
I am attempting to split CI into multiple steps like this:

```
build-macos  -> test-cargo-macos -> [1]
             -> test-wpt-macos   -> [1]
             -> [2]

build-linux  -> test-cargo-linux -> [1]
             -> test-wpt-linux   -> [1]
             -> bench            -> [1]
             -> [2]

build-win    -> test-cargo-win   -> [1]
             -> test-wpt-win     -> [1]
             -> [2]
lint         -> [1]

[1] + tag    -> publish-release
[2] + master -> publish-canary
```

On a PR we would run 11 jobs, on master we run 12, and on release we run 13.