### PR TITLE
fix(cli): fix panic of Deno.emit

### DIFF
--- a/cli/tests/compiler_api_test.ts
+++ b/cli/tests/compiler_api_test.ts
@@ -292,3 +292,20 @@ Deno.test({
     assert(diagnostics[0].messageText.includes("This import is never used"));
   },
 });
+
+// See https://github.com/denoland/deno/issues/9277
+Deno.test({
+  name: "Deno.emit() - invalid specifier does not panic",
+  async fn() {
+    await assertThrowsAsync(async () => {
+      // The below specifier is parsed as:
+      // scheme=custom, host=a.ts, pathname=(empty)
+      // and because the pathname is empty, this specifier is invalid.
+      await Deno.emit("custom://a.ts", {
+        sources: {
+          "custom://a.ts": `let foo: string = "foo";`,
+        },
+      });
+    });
+  },
+});

--- a/cli/tests/compiler_api_test.ts
+++ b/cli/tests/compiler_api_test.ts
@@ -293,17 +293,13 @@ Deno.test({
   },
 });
 
-// See https://github.com/denoland/deno/issues/9277
 Deno.test({
-  name: "Deno.emit() - invalid specifier does not panic",
+  name: "Deno.emit() - Unknown media type does not panic",
   async fn() {
     await assertThrowsAsync(async () => {
-      // The below specifier is parsed as:
-      // scheme=custom, host=a.ts, pathname=(empty)
-      // and because the pathname is empty, this specifier is invalid.
-      await Deno.emit("custom://a.ts", {
+      await Deno.emit("https://example.com/foo", {
         sources: {
-          "custom://a.ts": `let foo: string = "foo";`,
+          "https://example.com/foo": `let foo: string = "foo";`,
         },
       });
     });


### PR DESCRIPTION
This PR fixes the panic of Deno.emit when called with an module specifier with unknown media type, and improves the error message.

~~partially addresses #9277~~

This doesn't address the original issue, but I think this is still a fix for a different problem.