### PR TITLE
test(std/node): fix `assertStats` and `assertStatsBigInt` if atime, mtime or birthtime are null

### DIFF
--- a/std/node/_fs/_fs_stat_test.ts
+++ b/std/node/_fs/_fs_stat_test.ts
@@ -17,9 +17,9 @@ export function assertStats(actual: Stats, expected: Deno.FileInfo) {
   assertEquals(actual.atime?.getTime(), expected.atime?.getTime());
   assertEquals(actual.mtime?.getTime(), expected.mtime?.getTime());
   assertEquals(actual.birthtime?.getTime(), expected.birthtime?.getTime());
-  assertEquals(actual.atimeMs, expected.atime?.getTime());
-  assertEquals(actual.mtimeMs, expected.mtime?.getTime());
-  assertEquals(actual.birthtimeMs, expected.birthtime?.getTime());
+  assertEquals(actual.atimeMs ?? undefined, expected.atime?.getTime());
+  assertEquals(actual.mtimeMs ?? undefined, expected.mtime?.getTime());
+  assertEquals(actual.birthtimeMs ?? undefined, expected.birthtime?.getTime());
   assertEquals(actual.isFile(), expected.isFile);
   assertEquals(actual.isDirectory(), expected.isDirectory);
   assertEquals(actual.isSymbolicLink(), expected.isSymlink);
@@ -48,9 +48,18 @@ export function assertStatsBigInt(
   assertEquals(actual.atime?.getTime(), expected.atime?.getTime());
   assertEquals(actual.mtime?.getTime(), expected.mtime?.getTime());
   assertEquals(actual.birthtime?.getTime(), expected.birthtime?.getTime());
-  assertEquals(Number(actual.atimeMs), expected.atime?.getTime());
-  assertEquals(Number(actual.mtimeMs), expected.mtime?.getTime());
-  assertEquals(Number(actual.birthtimeMs), expected.birthtime?.getTime());
+  assertEquals(
+    actual.atimeMs === null ? undefined : Number(actual.atimeMs),
+    expected.atime?.getTime(),
+  );
+  assertEquals(
+    actual.mtimeMs === null ? undefined : Number(actual.mtimeMs),
+    expected.mtime?.getTime(),
+  );
+  assertEquals(
+    actual.birthtimeMs === null ? undefined : Number(actual.birthtimeMs),
+    expected.birthtime?.getTime(),
+  );
   assertEquals(actual.atimeNs === null, actual.atime === null);
   assertEquals(actual.mtimeNs === null, actual.mtime === null);
   assertEquals(actual.birthtimeNs === null, actual.birthtime === null);


### PR DESCRIPTION
All the tests related to `std/node` `stat()` and `lstat()` would previously fail if `atime`, `mtime` or `birthtime` were null. This was because optional chaining always returns `undefined` (so `null?.foo === undefined`) and `Number(null) === 0`.

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
