### PR TITLE
chore: upgrade tokio to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,9 +3039,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efab2086f17abcddb8f756117665c958feee6b2e39974c2f1600592ab3a4195"
+checksum = "6714d663090b6b0acb0fa85841c6d66233d150cdb2602c8f9b8abb03370beb3f"
 dependencies = [
  "autocfg",
  "bytes",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -75,7 +75,7 @@ swc_ecmascript = { version = "0.18.4", features = ["codegen", "dep_graph", "pars
 tempfile = "3.2.0"
 termcolor = "1.1.2"
 text-size = "1.1.0"
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.1.1", features = ["full"] }
 tokio-rustls = "0.22.0"
 uuid = { version = "0.8.2", features = ["v4"] }
 walkdir = "2.3.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,4 +36,4 @@ path = "examples/http_bench_json_ops.rs"
 
 # These dependencies are only used for the 'http_bench_*_ops' examples.
 [dev-dependencies]
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.1.1", features = ["full"] }

--- a/op_crates/fetch/Cargo.toml
+++ b/op_crates/fetch/Cargo.toml
@@ -18,6 +18,6 @@ bytes = "1.0.1"
 deno_core = { version = "0.77.1", path = "../../core" }
 reqwest = { version = "0.11.0", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli"] }
 serde = { version = "1.0.121", features = ["derive"] }
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.1.1", features = ["full"] }
 tokio-stream = "0.1.2"
 tokio-util = "0.6.2"

--- a/op_crates/websocket/Cargo.toml
+++ b/op_crates/websocket/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 deno_core = { version = "0.77.1", path = "../../core" }
 http = "0.2.3"
 serde = { version = "1.0.121", features = ["derive"] }
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.1.1", features = ["full"] }
 tokio-rustls = "0.22.0"
 tokio-tungstenite = "0.13.0"
 webpki = "0.21.4"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -56,7 +56,7 @@ serde = { version = "1.0.121", features = ["derive"] }
 shell-escape = "0.1.5"
 sys-info = "0.7.0"
 termcolor = "1.1.2"
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.1.1", features = ["full"] }
 tokio-rustls = "0.22.0"
 uuid = { version = "0.8.2", features = ["v4"] }
 webpki = "0.21.4"

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -21,7 +21,7 @@ os_pipe = "0.9.2"
 regex = "1.4.3"
 serde = { version = "1.0.116", features = ["derive"] }
 tempfile = "3.1.0"
-tokio = { version = "1.0.1", features = ["full"] }
+tokio = { version = "1.1.1", features = ["full"] }
 tokio-rustls = "0.22.0"
 tokio-tungstenite = "0.13.0"
 


### PR DESCRIPTION
This upgrades Tokio to 1.1.1.
https://github.com/tokio-rs/tokio/releases/tag/tokio-1.1.1

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
