### PR TITLE
fix(op_crates): Don't use `Deno.inspect` in op crates

### DIFF
--- a/cli/tests/084_worker_custom_inspect.ts
+++ b/cli/tests/084_worker_custom_inspect.ts
@@ -1,0 +1,4 @@
+new Worker(
+  new URL("084_worker_custom_inspect_worker.ts", import.meta.url).href,
+  { type: "module" },
+);

--- a/cli/tests/084_worker_custom_inspect.ts.out
+++ b/cli/tests/084_worker_custom_inspect.ts.out
@@ -1,0 +1,2 @@
+[WILDCARD]ReadableStream { locked: false }
+[WILDCARD]

--- a/cli/tests/084_worker_custom_inspect_worker.ts
+++ b/cli/tests/084_worker_custom_inspect_worker.ts
@@ -1,0 +1,2 @@
+console.log(new ReadableStream());
+close();

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2685,6 +2685,11 @@ console.log("finish");
     assert_eq!(out, "");
   }
 
+  itest!(_084_worker_custom_inspect {
+    args: "run 084_worker_custom_inspect.ts",
+    output: "084_worker_custom_inspect.ts.out",
+  });
+
   itest!(js_import_detect {
     args: "run --quiet --reload js_import_detect.ts",
     output: "js_import_detect.ts.out",

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2686,7 +2686,7 @@ console.log("finish");
   }
 
   itest!(_084_worker_custom_inspect {
-    args: "run 084_worker_custom_inspect.ts",
+    args: "run --allow-read 084_worker_custom_inspect.ts",
     output: "084_worker_custom_inspect.ts.out",
   });
 

--- a/cli/tests/unit/event_test.ts
+++ b/cli/tests/unit/event_test.ts
@@ -124,9 +124,6 @@ unitTest(function eventInspectOutput(): void {
   ];
 
   for (const [event, outputProvider] of cases) {
-    assertEquals(
-      event[Symbol.for("Deno.customInspect")](),
-      outputProvider(event),
-    );
+    assertEquals(Deno.inspect(event), outputProvider(event));
   }
 });

--- a/op_crates/fetch/11_streams.js
+++ b/op_crates/fetch/11_streams.js
@@ -7,8 +7,6 @@
 "use strict";
 
 ((window) => {
-  const customInspect = Symbol.for("Deno.customInspect");
-
   class AssertionError extends Error {
     constructor(msg) {
       super(msg);
@@ -3224,10 +3222,8 @@
       return iterator;
     }
 
-    [customInspect]() {
-      return `${this.constructor.name} ${
-        Deno.inspect({ locked: this.locked })
-      }`;
+    [Symbol.for("Deno.customInspect")](inspect) {
+      return `${this.constructor.name} ${inspect({ locked: this.locked })}`;
     }
   }
 
@@ -3308,8 +3304,8 @@
       readableStreamReaderGenericRelease(this);
     }
 
-    [customInspect]() {
-      return `${this.constructor.name} { closed: ${String(this.closed)} }`;
+    [Symbol.for("Deno.customInspect")](inspect) {
+      return `${this.constructor.name} ${inspect({ closed: this.closed })}`;
     }
   }
 
@@ -3597,12 +3593,9 @@
       return this[_writable];
     }
 
-    [customInspect]() {
+    [Symbol.for("Deno.customInspect")](inspect) {
       return `${this.constructor.name} ${
-        Deno.inspect(
-          { readable: this.readable, writable: this.writable },
-          { depth: 1 },
-        )
+        inspect({ readable: this.readable, writable: this.writable })
       }`;
     }
   }
@@ -3736,10 +3729,8 @@
       return acquireWritableStreamDefaultWriter(this);
     }
 
-    [customInspect]() {
-      return `${this.constructor.name} ${
-        Deno.inspect({ locked: this.locked })
-      }`;
+    [Symbol.for("Deno.customInspect")](inspect) {
+      return `${this.constructor.name} ${inspect({ locked: this.locked })}`;
     }
   }
 

--- a/op_crates/web/01_event.js
+++ b/op_crates/web/01_event.js
@@ -143,8 +143,8 @@
       });
     }
 
-    [Symbol.for("Deno.customInspect")]() {
-      return buildCustomInspectOutput(this, EVENT_PROPS);
+    [Symbol.for("Deno.customInspect")](inspect) {
+      return buildCustomInspectOutput(this, EVENT_PROPS, inspect);
     }
 
     get bubbles() {
@@ -387,14 +387,9 @@
     }
   }
 
-  function buildCustomInspectOutput(obj, props) {
-    const inspectObj = {};
-
-    for (const prop of props) {
-      inspectObj[prop] = obj[prop];
-    }
-
-    return `${obj.constructor.name} ${Deno.inspect(inspectObj)}`;
+  function buildCustomInspectOutput(object, keys, inspect) {
+    const inspectObject = Object.fromEntries(keys.map((k) => [k, object[k]]));
+    return `${object.constructor.name} ${inspect(inspectObject)}`;
   }
 
   function defineEnumerableProps(
@@ -1041,7 +1036,7 @@
       return "ErrorEvent";
     }
 
-    [Symbol.for("Deno.customInspect")]() {
+    [Symbol.for("Deno.customInspect")](inspect) {
       return buildCustomInspectOutput(this, [
         ...EVENT_PROPS,
         "message",
@@ -1049,7 +1044,7 @@
         "lineno",
         "colno",
         "error",
-      ]);
+      ], inspect);
     }
   }
 
@@ -1095,13 +1090,13 @@
       this.#reason = reason;
     }
 
-    [Symbol.for("Deno.customInspect")]() {
+    [Symbol.for("Deno.customInspect")](inspect) {
       return buildCustomInspectOutput(this, [
         ...EVENT_PROPS,
         "wasClean",
         "code",
         "reason",
-      ]);
+      ], inspect);
     }
   }
 
@@ -1118,13 +1113,13 @@
       this.lastEventId = eventInitDict?.lastEventId ?? "";
     }
 
-    [Symbol.for("Deno.customInspect")]() {
+    [Symbol.for("Deno.customInspect")](inspect) {
       return buildCustomInspectOutput(this, [
         ...EVENT_PROPS,
         "data",
         "origin",
         "lastEventId",
-      ]);
+      ], inspect);
     }
   }
 
@@ -1146,11 +1141,11 @@
       return "CustomEvent";
     }
 
-    [Symbol.for("Deno.customInspect")]() {
+    [Symbol.for("Deno.customInspect")](inspect) {
       return buildCustomInspectOutput(this, [
         ...EVENT_PROPS,
         "detail",
-      ]);
+      ], inspect);
     }
   }
 
@@ -1169,13 +1164,13 @@
       this.total = eventInitDict?.total ?? 0;
     }
 
-    [Symbol.for("Deno.customInspect")]() {
+    [Symbol.for("Deno.customInspect")](inspect) {
       return buildCustomInspectOutput(this, [
         ...EVENT_PROPS,
         "lengthComputable",
         "loaded",
         "total",
-      ]);
+      ], inspect);
     }
   }
 

--- a/op_crates/web/11_url.js
+++ b/op_crates/web/11_url.js
@@ -522,7 +522,7 @@
   class URL {
     #searchParams = null;
 
-    [Symbol.for("Deno.customInspect")]() {
+    [Symbol.for("Deno.customInspect")](inspect) {
       const object = {
         href: this.href,
         origin: this.origin,
@@ -536,12 +536,7 @@
         hash: this.hash,
         search: this.search,
       };
-      if (typeof globalThis?.Deno?.inspect == "function") {
-        return `URL ${Deno.inspect(object)}`;
-      }
-      return `URL { ${
-        Object.entries(object).map(([k, v]) => `${k}: ${v}`).join(", ")
-      } }`;
+      return `${this.constructor.name} ${inspect(object)}`;
     }
 
     #updateSearchParams = () => {

--- a/op_crates/web/12_location.js
+++ b/op_crates/web/12_location.js
@@ -166,7 +166,7 @@
           enumerable: true,
         },
         [Symbol.for("Deno.customInspect")]: {
-          value: function () {
+          value: function (inspect) {
             const object = {
               hash: this.hash,
               host: this.host,
@@ -178,12 +178,7 @@
               protocol: this.protocol,
               search: this.search,
             };
-            if (typeof globalThis?.Deno?.inspect == "function") {
-              return `Location ${Deno.inspect(object)}`;
-            }
-            return `Location { ${
-              Object.entries(object).map(([k, v]) => `${k}: ${v}`).join(", ")
-            } }`;
+            return `${this.constructor.name} ${inspect(object)}`;
           },
         },
       });
@@ -328,7 +323,7 @@
       configurable: true,
     },
     [Symbol.for("Deno.customInspect")]: {
-      value: function () {
+      value: function (inspect) {
         const object = {
           hash: this.hash,
           host: this.host,
@@ -340,12 +335,7 @@
           protocol: this.protocol,
           search: this.search,
         };
-        if (typeof globalThis?.Deno?.inspect == "function") {
-          return `WorkerLocation ${Deno.inspect(object)}`;
-        }
-        return `WorkerLocation { ${
-          Object.entries(object).map(([k, v]) => `${k}: ${v}`).join(", ")
-        } }`;
+        return `${this.constructor.name} ${inspect(object)}`;
       },
     },
   });

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -873,7 +873,7 @@
       nonUniqueCustomInspect in value &&
       typeof value[nonUniqueCustomInspect] === "function"
     ) {
-      return String(value[nonUniqueCustomInspect]());
+      return String(value[nonUniqueCustomInspect](inspect));
     }
     if (value instanceof Error) {
       return String(value.stack);

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -873,6 +873,10 @@
       nonUniqueCustomInspect in value &&
       typeof value[nonUniqueCustomInspect] === "function"
     ) {
+      // TODO(nayeemrmn): `inspect` is passed as an argument because custom
+      // inspect implementations in `op_crates` need it, but may not have access
+      // to the `Deno` namespace in web workers. Remove when the `Deno`
+      // namespace is always enabled.
       return String(value[nonUniqueCustomInspect](inspect));
     }
     if (value instanceof Error) {


### PR DESCRIPTION
Pass `Deno.inspect()` as an arg to the internal custom inspect implementations.

Fixes #9446.