### PR TITLE
chore: make all tests annotated with `#[cfg(test)]`

### DIFF
--- a/cli/diff.rs
+++ b/cli/diff.rs
@@ -146,22 +146,27 @@ pub fn diff(orig_text: &str, edit_text: &str) -> String {
   diff
 }
 
-#[test]
-fn test_diff() {
-  let simple_console_log_unfmt = "console.log('Hello World')";
-  let simple_console_log_fmt = "console.log(\"Hello World\");";
-  assert_eq!(
-    colors::strip_ansi_codes(&diff(
-      simple_console_log_unfmt,
-      simple_console_log_fmt
-    )),
-    "1 | -console.log('Hello World')\n1 | +console.log(\"Hello World\");\n"
-  );
+#[cfg(test)]
+mod tests {
+  use super::*;
 
-  let line_number_unfmt = "\n\n\n\nconsole.log(\n'Hello World'\n)";
-  let line_number_fmt = "console.log(\n\"Hello World\"\n);";
-  assert_eq!(
-    colors::strip_ansi_codes(&diff(line_number_unfmt, line_number_fmt)),
-    "1 | -\n2 | -\n3 | -\n4 | -\n5 | -console.log(\n1 | +console.log(\n6 | -'Hello World'\n2 | +\"Hello World\"\n7 | -)\n3 | +);\n"
-  )
+  #[test]
+  fn test_diff() {
+    let simple_console_log_unfmt = "console.log('Hello World')";
+    let simple_console_log_fmt = "console.log(\"Hello World\");";
+    assert_eq!(
+      colors::strip_ansi_codes(&diff(
+        simple_console_log_unfmt,
+        simple_console_log_fmt
+      )),
+      "1 | -console.log('Hello World')\n1 | +console.log(\"Hello World\");\n"
+    );
+
+    let line_number_unfmt = "\n\n\n\nconsole.log(\n'Hello World'\n)";
+    let line_number_fmt = "console.log(\n\"Hello World\"\n);";
+    assert_eq!(
+      colors::strip_ansi_codes(&diff(line_number_unfmt, line_number_fmt)),
+      "1 | -\n2 | -\n3 | -\n4 | -\n5 | -console.log(\n1 | +console.log(\n6 | -'Hello World'\n2 | +\"Hello World\"\n7 | -)\n3 | +);\n"
+    );
+  }
 }

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -351,8 +351,13 @@ fn source_map_from_code(code: String) -> Option<Vec<u8>> {
   }
 }
 
-#[test]
-fn thread_safe() {
-  fn f<S: Send + Sync>(_: S) {}
-  f(ProgramState::mock(vec![], None));
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn thread_safe() {
+    fn f<S: Send + Sync>(_: S) {}
+    f(ProgramState::mock(vec![], None));
+  }
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -78,7 +78,12 @@ pub fn v8_version() -> &'static str {
   v8::V8::get_version()
 }
 
-#[test]
-fn test_v8_version() {
-  assert!(v8_version().len() > 3);
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_v8_version() {
+    assert!(v8_version().len() > 3);
+  }
 }

--- a/runtime/js.rs
+++ b/runtime/js.rs
@@ -11,21 +11,26 @@ pub fn deno_isolate_init() -> Snapshot {
   Snapshot::Static(data)
 }
 
-#[test]
-fn cli_snapshot() {
-  let mut js_runtime = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
-    startup_snapshot: Some(deno_isolate_init()),
-    ..Default::default()
-  });
-  js_runtime
-    .execute(
-      "<anon>",
-      r#"
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn cli_snapshot() {
+    let mut js_runtime = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
+      startup_snapshot: Some(deno_isolate_init()),
+      ..Default::default()
+    });
+    js_runtime
+      .execute(
+        "<anon>",
+        r#"
       if (!(bootstrap.mainRuntime && bootstrap.workerRuntime)) {
         throw Error("bad");
       }
       console.log("we have console.log!!!");
     "#,
-    )
-    .unwrap();
+      )
+      .unwrap();
+  }
 }

--- a/runtime/ops/dispatch_minimal.rs
+++ b/runtime/ops/dispatch_minimal.rs
@@ -75,23 +75,6 @@ impl Into<Box<[u8]>> for ErrorRecord {
   }
 }
 
-#[test]
-fn test_error_record() {
-  let expected = vec![
-    1, 0, 0, 0, 255, 255, 255, 255, 11, 0, 0, 0, 66, 97, 100, 82, 101, 115,
-    111, 117, 114, 99, 101, 69, 114, 114, 111, 114,
-  ];
-  let err_record = ErrorRecord {
-    promise_id: 1,
-    arg: -1,
-    error_len: 11,
-    error_class: b"BadResource",
-    error_message: b"Error".to_vec(),
-  };
-  let buf: Box<[u8]> = err_record.into();
-  assert_eq!(buf, expected.into_boxed_slice());
-}
-
 pub fn parse_min_record(bytes: &[u8]) -> Option<Record> {
   if bytes.len() % std::mem::size_of::<i32>() != 0 {
     return None;
@@ -111,25 +94,6 @@ pub fn parse_min_record(bytes: &[u8]) -> Option<Record> {
     arg: ints[1],
     result: ints[2],
   })
-}
-
-#[test]
-fn test_parse_min_record() {
-  let buf = vec![1, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0];
-  assert_eq!(
-    parse_min_record(&buf),
-    Some(Record {
-      promise_id: 1,
-      arg: 3,
-      result: 4
-    })
-  );
-
-  let buf = vec![];
-  assert_eq!(parse_min_record(&buf), None);
-
-  let buf = vec![5];
-  assert_eq!(parse_min_record(&buf), None);
 }
 
 pub fn minimal_op<F>(op_fn: F) -> Box<OpFn>
@@ -202,4 +166,45 @@ where
       }
     }
   })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_error_record() {
+    let expected = vec![
+      1, 0, 0, 0, 255, 255, 255, 255, 11, 0, 0, 0, 66, 97, 100, 82, 101, 115,
+      111, 117, 114, 99, 101, 69, 114, 114, 111, 114,
+    ];
+    let err_record = ErrorRecord {
+      promise_id: 1,
+      arg: -1,
+      error_len: 11,
+      error_class: b"BadResource",
+      error_message: b"Error".to_vec(),
+    };
+    let buf: Box<[u8]> = err_record.into();
+    assert_eq!(buf, expected.into_boxed_slice());
+  }
+
+  #[test]
+  fn test_parse_min_record() {
+    let buf = vec![1, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0];
+    assert_eq!(
+      parse_min_record(&buf),
+      Some(Record {
+        promise_id: 1,
+        arg: 3,
+        result: 4
+      })
+    );
+
+    let buf = vec![];
+    assert_eq!(parse_min_record(&buf), None);
+
+    let buf = vec![5];
+    assert_eq!(parse_min_record(&buf), None);
+  }
 }


### PR DESCRIPTION
This PR annotates the tests that are not annotated currently with  `#[cfg(test)]`.

Tests in Rust work fine so long as they are annotated with `#[test]`, but adding `#[cfg(test)]` attributes to them is more desirable for the reasons described [here](https://doc.rust-lang.org/book/ch11-03-test-organization.html).

<!--
- it's a widely-accepted convention (so people will get less confused)
- save compile time
- reduce the size of the resulting artifact
-->

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
