### PR TITLE
fix(console) - log function object properties / do not log non-enumerable props by default 

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2012,6 +2012,8 @@ declare namespace Deno {
     trailingComma?: boolean;
     /*** Evaluate the result of calling getters. Defaults to false. */
     getters?: boolean;
+    /** Show an object's non-enumerable properties. Defaults to false. */
+    showNonEnumerable?: boolean;
   }
 
   /** Converts the input into a string that has the same format as printed by

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2013,7 +2013,7 @@ declare namespace Deno {
     /*** Evaluate the result of calling getters. Defaults to false. */
     getters?: boolean;
     /** Show an object's non-enumerable properties. Defaults to false. */
-    showNonEnumerable?: boolean;
+    showHidden?: boolean;
   }
 
   /** Converts the input into a string that has the same format as printed by

--- a/cli/tests/041_dyn_import_eval.out
+++ b/cli/tests/041_dyn_import_eval.out
@@ -1,1 +1,1 @@
-Module { isMod4: true, [Symbol(Symbol.toStringTag)]: "Module" }
+Module { isMod4: true }

--- a/cli/tests/042_dyn_import_evalcontext.ts.out
+++ b/cli/tests/042_dyn_import_evalcontext.ts.out
@@ -1,1 +1,1 @@
-Module { isMod4: true, [Symbol(Symbol.toStringTag)]: "Module" }
+Module { isMod4: true }

--- a/cli/tests/070_location.ts.out
+++ b/cli/tests/070_location.ts.out
@@ -1,5 +1,5 @@
 [WILDCARD][Function: Location]
-Location { [Symbol(Symbol.toStringTag)]: "Location" }
+Location {}
 Location {
   hash: "#bat",
   host: "foo",

--- a/cli/tests/071_location_unset.ts.out
+++ b/cli/tests/071_location_unset.ts.out
@@ -1,4 +1,4 @@
 [WILDCARD][Function: Location]
-Location { [Symbol(Symbol.toStringTag)]: "Location" }
+Location {}
 error: Uncaught ReferenceError: Access to "location", run again with --location <href>.
 [WILDCARD]

--- a/cli/tests/fix_js_imports.ts.out
+++ b/cli/tests/fix_js_imports.ts.out
@@ -1,1 +1,1 @@
-Module { [Symbol(Symbol.toStringTag)]: "Module" }
+Module {}

--- a/cli/tests/top_level_await_loop.out
+++ b/cli/tests/top_level_await_loop.out
@@ -1,5 +1,5 @@
 loading [WILDCARD]a.js
-loaded Module { default: [Function: Foo], [Symbol(Symbol.toStringTag)]: "Module" }
+loaded Module { default: [Function: Foo] }
 loading [WILDCARD]b.js
-loaded Module { default: [Function: Bar], [Symbol(Symbol.toStringTag)]: "Module" }
+loaded Module { default: [Function: Bar] }
 all loaded

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -362,6 +362,21 @@ unitTest(function consoleTestStringifyFunctionWithPrototypeRemoved(): void {
   assertEquals(stringify(agf), "[Function: agf]");
 });
 
+unitTest(function consoleTestStringifyFunctionWithProperties(): void {
+  const f = () => "test";
+  f.x = () => "foo";
+  f.y = 3;
+  f.z = () => "baz";
+  f.b = function bar() {};
+  f.a = new Map();
+  assertEquals(
+    stringify({ f }),
+    `{
+  f: [Function: f] { x: [Function], y: 3, z: [Function], b: [Function: bar], a: Map {} }
+}`,
+  );
+});
+
 unitTest(function consoleTestStringifyWithDepth(): void {
   // deno-lint-ignore no-explicit-any
   const nestedObj: any = { a: { b: { c: { d: { e: { f: 42 } } } } } };

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -400,7 +400,7 @@ unitTest(function consoleTestStringifyFunctionWithProperties(): void {
   );
 
   assertEquals(
-    stripColor(Deno.inspect(Array, { showNonEnumerable: true })),
+    stripColor(Deno.inspect(Array, { showHidden: true })),
     `[Function: Array] { [Symbol(Symbol.species)]: [Getter] }`,
   );
 });

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -375,6 +375,25 @@ unitTest(function consoleTestStringifyFunctionWithProperties(): void {
   f: [Function: f] { x: [Function], y: 3, z: [Function], b: [Function: bar], a: Map {} }
 }`,
   );
+
+  const t = () => {};
+  t.x = f;
+  f.s = f;
+  f.t = t;
+  assertEquals(
+    stringify({ f }),
+    `{
+  f: [Function: f] {
+    x: [Function],
+    y: 3,
+    z: [Function],
+    b: [Function: bar],
+    a: Map {},
+    s: [Circular],
+    t: [Function: t] { x: [Circular] }
+  }
+}`,
+  );
 });
 
 unitTest(function consoleTestStringifyWithDepth(): void {

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -310,7 +310,7 @@ unitTest(function consoleTestStringifyCircular(): void {
   assertEquals(stringify(nestedObj), nestedObjExpected);
   assertEquals(
     stringify(JSON),
-    'JSON { [Symbol(Symbol.toStringTag)]: "JSON" }',
+    "JSON {}",
   );
   assertEquals(
     stringify(console),
@@ -335,7 +335,6 @@ unitTest(function consoleTestStringifyCircular(): void {
   clear: [Function: clear],
   trace: [Function: trace],
   indentLevel: 0,
-  [Symbol(Symbol.toStringTag)]: "console",
   [Symbol(isConsoleInstance)]: true
 }`,
   );
@@ -393,6 +392,16 @@ unitTest(function consoleTestStringifyFunctionWithProperties(): void {
     t: [Function: t] { x: [Circular] }
   }
 }`,
+  );
+
+  assertEquals(
+    stringify(Array),
+    `[Function: Array]`,
+  );
+
+  assertEquals(
+    stripColor(Deno.inspect(Array, { showNonEnumerable: true })),
+    `[Function: Array] { [Symbol(Symbol.species)]: [Getter] }`,
   );
 });
 

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -158,6 +158,7 @@
     showProxy: false,
     colors: false,
     getters: false,
+    showNonEnumerable: false,
   };
 
   const DEFAULT_INDENT = "  "; // Default indent string
@@ -210,10 +211,15 @@
       Object.keys(value).length > 0 ||
       Object.getOwnPropertySymbols(value).length > 0
     ) {
-      ctx.add(value);
       const propString = inspectRawObject(value, ctx, level, inspectOptions);
-      ctx.delete(value);
-      suffix = ` ${propString}`;
+      // Filter out the empty string for the case we only have
+      // non-enumerable symbols.
+      if (
+        propString.length > 0 &&
+        propString !== "{}"
+      ) {
+        suffix = ` ${propString}`;
+      }
     }
 
     if (value.name && value.name !== "anonymous") {
@@ -818,6 +824,13 @@
     }
 
     for (const key of symbolKeys) {
+      if (
+        !inspectOptions.showNonEnumerable &&
+        !value.propertyIsEnumerable(key)
+      ) {
+        continue;
+      }
+
       if (inspectOptions.getters) {
         let propertyValue;
         let error;

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -210,7 +210,9 @@
       Object.keys(value).length > 0 ||
       Object.getOwnPropertySymbols(value).length > 0
     ) {
+      ctx.add(value);
       const propString = inspectRawObject(value, ctx, level, inspectOptions);
+      ctx.delete(value);
       suffix = ` ${propString}`;
     }
 
@@ -443,6 +445,11 @@
       case "bigint": // Bigints are yellow
         return yellow(`${value}n`);
       case "function": // Function string is cyan
+        if (ctx.has(value)) {
+          // Circular string is cyan
+          return cyan("[Circular]");
+        }
+
         return inspectFunction(value, ctx, level, inspectOptions);
       case "object": // null is bold
         if (value === null) {

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -203,17 +203,17 @@
 
     // Our function may have properties, so we want to format those
     // as if our function was an object
-    const propString = inspectRawObject(value, ctx, level, inspectOptions);
     // If we didn't find any properties, we will just append an
     // empty suffix.
-    let suffix = ` ${propString}`;
+    let suffix = ``;
     if (
-      propString === "{}" || propString === "AsyncFunction {}" ||
-      propString === "GeneratorFunction {}" ||
-      propString === "AsyncGeneratorFunction {}"
+      Object.keys(value).length > 0 ||
+      Object.getOwnPropertySymbols(value).length > 0
     ) {
-      suffix = "";
+      const propString = inspectRawObject(value, ctx, level, inspectOptions);
+      suffix = ` ${propString}`;
     }
+
     if (value.name && value.name !== "anonymous") {
       // from MDN spec
       return cyan(`[${cstrName}: ${value.name}]`) + suffix;

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -169,7 +169,7 @@
     showProxy: false,
     colors: false,
     getters: false,
-    showNonEnumerable: false,
+    showHidden: false,
   };
 
   const DEFAULT_INDENT = "  "; // Default indent string
@@ -836,7 +836,7 @@
 
     for (const key of symbolKeys) {
       if (
-        !inspectOptions.showNonEnumerable &&
+        !inspectOptions.showHidden &&
         !propertyIsEnumerable(value, key)
       ) {
         continue;

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -16,6 +16,17 @@
     return Object.prototype.hasOwnProperty.call(obj, v);
   }
 
+  function propertyIsEnumerable(obj, prop) {
+    if (
+      obj == null ||
+      typeof obj.propertyIsEnumerable !== "function"
+    ) {
+      return false;
+    }
+
+    return obj.propertyIsEnumerable(prop);
+  }
+
   // Copyright Joyent, Inc. and other Node contributors. MIT license.
   // Forked from Node's lib/internal/cli_table.js
 
@@ -826,7 +837,7 @@
     for (const key of symbolKeys) {
       if (
         !inspectOptions.showNonEnumerable &&
-        !value.propertyIsEnumerable(key)
+        !propertyIsEnumerable(value, key)
       ) {
         continue;
       }


### PR DESCRIPTION
Addresses https://github.com/denoland/deno/issues/9333 

Running `deno eval "const x=()=>'x'; x.y=()=>'y'; x.z = function z() {return 'z'}; console.log({x});"` now properly logs the function's properties. I've added a basic test for this behavior. 

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
