### PR TITLE
docs(style_guide/TS): prefer `interface` over `type` for object typings

### DIFF
--- a/docs/contributing/style_guide.md
+++ b/docs/contributing/style_guide.md
@@ -99,7 +99,7 @@ When designing function interfaces, stick to the following rules.
 export function resolve(
   hostname: string,
   family?: "ipv4" | "ipv6",
-  timeout?: number,
+  timeout?: number
 ): IPAddress[] {}
 
 // GOOD.
@@ -109,7 +109,7 @@ export interface ResolveOptions {
 }
 export function resolve(
   hostname: string,
-  options: ResolveOptions = {},
+  options: ResolveOptions = {}
 ): IPAddress[] {}
 ```
 
@@ -128,7 +128,7 @@ export interface RunShellOptions {
 }
 export function runShellWithEnv(
   cmdline: string,
-  options: RunShellOptions,
+  options: RunShellOptions
 ): string {}
 ```
 
@@ -138,7 +138,7 @@ export function renameSync(
   oldname: string,
   newname: string,
   replaceExisting?: boolean,
-  followLinks?: boolean,
+  followLinks?: boolean
 ) {}
 
 // GOOD.
@@ -149,7 +149,7 @@ interface RenameOptions {
 export function renameSync(
   oldname: string,
   newname: string,
-  options: RenameOptions = {},
+  options: RenameOptions = {}
 ) {}
 ```
 
@@ -160,7 +160,7 @@ export function pwrite(
   buffer: TypedArray,
   offset: number,
   length: number,
-  position: number,
+  position: number
 ) {}
 
 // BETTER.
@@ -172,6 +172,37 @@ export interface PWrite {
   position: number;
 }
 export function pwrite(options: PWrite) {}
+```
+
+### Use `interface` over `type` for creating object typings
+
+Let's say, for example, you want to create an options object that must match a
+specific TypeScript object shape for your `walkDir` function. Instead of using the
+TypeScript `type` declaration like the following:
+
+```ts
+// BAD: Using `type` keyword!
+export type WalkDirOptions = {
+  recursive?: boolean;
+};
+
+export async function walkDir(directory: string, options: WalkDirOptions) {
+  /* ... */
+}
+```
+
+You should be defining `WalkDirOptions` with the `interface` keyword like in
+this code example:
+
+```ts
+// GOOD: Using `interface` keyword!
+export interface WalkDirOptions {
+  recursive?: boolean;
+}
+
+export async function walkDir(directory: string, options: WalkDirOptions) {
+  /* ... */
+}
 ```
 
 ### Export all interfaces that are used as parameters to an exported member


### PR DESCRIPTION
closes #9369 