### PR TITLE
fix: improve http client builder error message

### DIFF
--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -34,8 +34,9 @@ pub fn create_http_client(
 
   builder
     .build()
-    .map_err(|_| generic_error("Unable to build http client"))
+    .map_err(|e| generic_error(format!("Unable to build http client: {}", e)))
 }
+
 /// Construct the next uri based on base uri and location header fragment
 /// See <https://tools.ietf.org/html/rfc3986#section-4.2>
 fn resolve_url_from_location(base_url: &Url, location: &str) -> Url {

--- a/op_crates/fetch/lib.rs
+++ b/op_crates/fetch/lib.rs
@@ -3,6 +3,7 @@
 #![deny(warnings)]
 
 use deno_core::error::bad_resource_id;
+use deno_core::error::generic_error;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::futures::Future;
@@ -433,5 +434,5 @@ fn create_http_client(
   }
   builder
     .build()
-    .map_err(|_| deno_core::error::generic_error("Unable to build http client"))
+    .map_err(|e| generic_error(format!("Unable to build http client: {}", e)))
 }

--- a/runtime/http_util.rs
+++ b/runtime/http_util.rs
@@ -28,7 +28,7 @@ pub fn create_http_client(
 
   builder
     .build()
-    .map_err(|_| generic_error("Unable to build http client"))
+    .map_err(|e| generic_error(format!("Unable to build http client: {}", e)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Include the lower-level error message in the generic error message.

No test because I can't actually make it fail by passing it bad PEM.
I checked and `reqwest::Certificate::from_pem()` always returns `Ok()`.

Fixes #9364.