### PR TITLE
fix(cli/program_state): Check for inline source maps before external ones

### DIFF
--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -296,12 +296,8 @@ impl SourceMapGetter for ProgramState {
   fn get_source_map(&self, file_name: &str) -> Option<Vec<u8>> {
     if let Ok(specifier) = ModuleSpecifier::resolve_url(file_name) {
       if let Some((code, maybe_map)) = self.get_emit(&specifier.as_url()) {
-        if maybe_map.is_some() {
-          maybe_map
-        } else {
-          let code = String::from_utf8(code).unwrap();
-          source_map_from_code(code)
-        }
+        let code = String::from_utf8(code).unwrap();
+        source_map_from_code(code).or(maybe_map)
       } else if let Ok(source) = self.load(specifier, None) {
         source_map_from_code(source.code)
       } else {

--- a/cli/tests/083_legacy_external_source_map.ts
+++ b/cli/tests/083_legacy_external_source_map.ts
@@ -1,0 +1,2 @@
+// -
+throw new Error("foo");


### PR DESCRIPTION
Fixes #6965.

I don't know if or where external source maps are still used, I guess that cleanup would be part of @kitsonk's TODOs here.