### PR TITLE
fix(lsp): support codeAction/resolve

### DIFF
--- a/cli/lsp/capabilities.rs
+++ b/cli/lsp/capabilities.rs
@@ -32,7 +32,7 @@ fn code_action_capabilities(
     .map_or(CodeActionProviderCapability::Simple(true), |_| {
       CodeActionProviderCapability::Options(CodeActionOptions {
         code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
-        resolve_provider: None,
+        resolve_provider: Some(true),
         work_done_progress_options: Default::default(),
       })
     })

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -30,7 +30,9 @@ use crate::import_map::ImportMap;
 use crate::tsc_config::parse_config;
 use crate::tsc_config::TsConfig;
 
+use super::analysis::ts_changes_to_edit;
 use super::analysis::CodeActionCollection;
+use super::analysis::CodeActionData;
 use super::analysis::CodeLensData;
 use super::analysis::CodeLensSource;
 use super::capabilities;
@@ -943,35 +945,7 @@ impl Inner {
           diagnostic,
           &file_diagnostics,
         ) {
-          let req = tsc::RequestMethod::GetCombinedCodeFix((
-            specifier.clone(),
-            json!(action.fix_id.clone().unwrap()),
-          ));
-          let res =
-            self.ts_server.request(self.snapshot(), req).await.map_err(
-              |err| {
-                error!("Unable to get combined fix from TypeScript: {}", err);
-                LspError::internal_error()
-              },
-            )?;
-          let combined_code_actions: tsc::CombinedCodeActions = from_value(res)
-            .map_err(|err| {
-              error!("Cannot decode combined actions from TypeScript: {}", err);
-              LspError::internal_error()
-            })?;
-          code_actions
-            .add_ts_fix_all_action(
-              &action,
-              diagnostic,
-              &combined_code_actions,
-              &|s| self.get_line_index(s),
-              &|s| self.documents.version(&s),
-            )
-            .await
-            .map_err(|err| {
-              error!("Unable to add fix all: {}", err);
-              LspError::internal_error()
-            })?;
+          code_actions.add_ts_fix_all_action(&action, &specifier, diagnostic);
         }
       }
     }
@@ -979,6 +953,59 @@ impl Inner {
     let code_action_response = code_actions.get_response();
     self.performance.measure(mark);
     Ok(Some(code_action_response))
+  }
+
+  async fn code_action_resolve(
+    &self,
+    params: CodeAction,
+  ) -> LspResult<CodeAction> {
+    let mark = self.performance.mark("code_action_resolve");
+    let result =
+      if let Some(data) = params.data.clone() {
+        let code_action_data: CodeActionData =
+          from_value(data).map_err(|err| {
+            error!("Unable to decode code action data: {}", err);
+            LspError::invalid_params("The CodeAction's data is invalid.")
+          })?;
+        let req = tsc::RequestMethod::GetCombinedCodeFix((
+          code_action_data.specifier,
+          json!(code_action_data.fix_id.clone()),
+        ));
+        let res = self.ts_server.request(self.snapshot(), req).await.map_err(
+          |err| {
+            error!("Unable to get combined fix from TypeScript: {}", err);
+            LspError::internal_error()
+          },
+        )?;
+        let combined_code_actions: tsc::CombinedCodeActions =
+          from_value(res).map_err(|err| {
+            error!("Cannot decode combined actions from TypeScript: {}", err);
+            LspError::internal_error()
+          })?;
+        if combined_code_actions.commands.is_some() {
+          error!("Deno does not support code actions with commands.");
+          Err(LspError::invalid_request())
+        } else {
+          let mut code_action = params.clone();
+          code_action.edit = ts_changes_to_edit(
+            &combined_code_actions.changes,
+            &|s| self.get_line_index(s),
+            &|s| self.documents.version(&s),
+          )
+          .await
+          .map_err(|err| {
+            error!("Unable to convert changes to edits: {}", err);
+            LspError::internal_error()
+          })?;
+          Ok(code_action)
+        }
+      } else {
+        Err(LspError::invalid_params(
+          "The CodeAction's data is missing.",
+        ))
+      };
+    self.performance.measure(mark);
+    result
   }
 
   async fn code_lens(
@@ -1606,6 +1633,13 @@ impl lspower::LanguageServer for LanguageServer {
     params: CodeActionParams,
   ) -> LspResult<Option<CodeActionResponse>> {
     self.0.lock().await.code_action(params).await
+  }
+
+  async fn code_action_resolve(
+    &self,
+    params: CodeAction,
+  ) -> LspResult<CodeAction> {
+    self.0.lock().await.code_action_resolve(params).await
   }
 
   async fn code_lens(
@@ -2316,6 +2350,13 @@ mod tests {
       (
         "code_action_request.json",
         LspResponse::RequestFixture(2, "code_action_response.json".to_string()),
+      ),
+      (
+        "code_action_resolve_request.json",
+        LspResponse::RequestFixture(
+          4,
+          "code_action_resolve_request_response.json".to_string(),
+        ),
       ),
       (
         "shutdown_request.json",

--- a/cli/tests/lsp/code_action_resolve_request.json
+++ b/cli/tests/lsp/code_action_resolve_request.json
@@ -1,0 +1,32 @@
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "codeAction/resolve",
+  "params": {
+    "title": "Add all missing 'async' modifiers",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 2
+          },
+          "end": {
+            "line": 1,
+            "character": 7
+          }
+        },
+        "severity": 1,
+        "code": 1308,
+        "source": "deno-ts",
+        "message": "'await' expressions are only allowed within async functions and at the top levels of modules.",
+        "relatedInformation": []
+      }
+    ],
+    "data": {
+      "specifier": "file:///a/file.ts",
+      "fixId": "fixAwaitInSyncFunction"
+    }
+  }
+}

--- a/cli/tests/lsp/code_action_resolve_request_response.json
+++ b/cli/tests/lsp/code_action_resolve_request_response.json
@@ -1,0 +1,91 @@
+{
+  "title": "Add all missing 'async' modifiers",
+  "kind": "quickfix",
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 7
+        }
+      },
+      "severity": 1,
+      "code": 1308,
+      "source": "deno-ts",
+      "message": "'await' expressions are only allowed within async functions and at the top levels of modules.",
+      "relatedInformation": []
+    }
+  ],
+  "edit": {
+    "documentChanges": [
+      {
+        "textDocument": {
+          "uri": "file:///a/file.ts",
+          "version": 1
+        },
+        "edits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 7
+              }
+            },
+            "newText": "async "
+          },
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 21
+              },
+              "end": {
+                "line": 0,
+                "character": 25
+              }
+            },
+            "newText": "Promise<void>"
+          },
+          {
+            "range": {
+              "start": {
+                "line": 4,
+                "character": 7
+              },
+              "end": {
+                "line": 4,
+                "character": 7
+              }
+            },
+            "newText": "async "
+          },
+          {
+            "range": {
+              "start": {
+                "line": 4,
+                "character": 21
+              },
+              "end": {
+                "line": 4,
+                "character": 25
+              }
+            },
+            "newText": "Promise<void>"
+          }
+        ]
+      }
+    ]
+  },
+  "data": {
+    "specifier": "file:///a/file.ts",
+    "fixId": "fixAwaitInSyncFunction"
+  }
+}

--- a/cli/tests/lsp/code_action_response.json
+++ b/cli/tests/lsp/code_action_response.json
@@ -82,69 +82,9 @@
         "relatedInformation": []
       }
     ],
-    "edit": {
-      "documentChanges": [
-        {
-          "textDocument": {
-            "uri": "file:///a/file.ts",
-            "version": 1
-          },
-          "edits": [
-            {
-              "range": {
-                "start": {
-                  "line": 0,
-                  "character": 7
-                },
-                "end": {
-                  "line": 0,
-                  "character": 7
-                }
-              },
-              "newText": "async "
-            },
-            {
-              "range": {
-                "start": {
-                  "line": 0,
-                  "character": 21
-                },
-                "end": {
-                  "line": 0,
-                  "character": 25
-                }
-              },
-              "newText": "Promise<void>"
-            },
-            {
-              "range": {
-                "start": {
-                  "line": 4,
-                  "character": 7
-                },
-                "end": {
-                  "line": 4,
-                  "character": 7
-                }
-              },
-              "newText": "async "
-            },
-            {
-              "range": {
-                "start": {
-                  "line": 4,
-                  "character": 21
-                },
-                "end": {
-                  "line": 4,
-                  "character": 25
-                }
-              },
-              "newText": "Promise<void>"
-            }
-          ]
-        }
-      ]
+    "data": {
+      "specifier": "file:///a/file.ts",
+      "fixId": "fixAwaitInSyncFunction"
     }
   }
 ]


### PR DESCRIPTION
This adds support for `codeAction/resolve` which supports lazily resolving items like "fix all" code actions which should make performance of the lsp slightly better when dealing with "fix all" code actions.

This will require an update to `vscode_deno` to use the 3.16 version of the lsp for the "fix all" code actions to work, which I will be raising soon.