### PR TITLE
fix(lsp): properly cache built in assets

### DIFF
--- a/cli/lsp/assets.rs
+++ b/cli/lsp/assets.rs
@@ -1,0 +1,36 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+use deno_core::ModuleSpecifier;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use super::text::LineIndex;
+
+/// An lsp representation of an asset in memory, that has either been retrieved
+/// from static assets built into Rust, or static assets built into tsc.
+#[derive(Debug, Clone)]
+pub struct AssetDocument {
+  pub text: String,
+  pub line_index: LineIndex,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Assets(Arc<Mutex<HashMap<ModuleSpecifier, Option<AssetDocument>>>>);
+
+impl Assets {
+  pub fn get(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<Option<AssetDocument>> {
+    self.0.lock().unwrap().get(specifier).cloned()
+  }
+
+  pub fn insert(
+    &self,
+    specifier: ModuleSpecifier,
+    maybe_asset: Option<AssetDocument>,
+  ) -> Option<Option<AssetDocument>> {
+    self.0.lock().unwrap().insert(specifier, maybe_asset)
+  }
+}

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1963,7 +1963,7 @@ mod tests {
       ("initialize_request_disabled.json", LspResponse::RequestAny),
       ("initialized_notification.json", LspResponse::None),
       ("did_open_notification.json", LspResponse::None),
-      ("hover_request.json", LspResponse::Request(4, json!(null))),
+      ("hover_request.json", LspResponse::Request(2, json!(null))),
       (
         "shutdown_request.json",
         LspResponse::Request(3, json!(null)),

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -4,6 +4,7 @@ use lspower::LspService;
 use lspower::Server;
 
 mod analysis;
+mod assets;
 mod capabilities;
 mod config;
 mod diagnostics;

--- a/cli/tests/lsp/did_open_notification_asset.json
+++ b/cli/tests/lsp/did_open_notification_asset.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/didOpen",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts",
+      "languageId": "typescript",
+      "version": 1,
+      "text": "console.log(Date.now());\n"
+    }
+  }
+}

--- a/cli/tests/lsp/hover_request_asset_01.json
+++ b/cli/tests/lsp/hover_request_asset_01.json
@@ -1,0 +1,14 @@
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "textDocument/hover",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts"
+    },
+    "position": {
+      "line": 0,
+      "character": 12
+    }
+  }
+}

--- a/cli/tests/lsp/hover_request_asset_02.json
+++ b/cli/tests/lsp/hover_request_asset_02.json
@@ -1,0 +1,14 @@
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "textDocument/hover",
+  "params": {
+    "textDocument": {
+      "uri": "deno:/asset//lib.es2015.symbol.wellknown.d.ts"
+    },
+    "position": {
+      "line": 109,
+      "character": 13
+    }
+  }
+}

--- a/cli/tests/lsp/virtual_text_document_request.json
+++ b/cli/tests/lsp/virtual_text_document_request.json
@@ -1,0 +1,10 @@
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "deno/virtualTextDocument",
+  "params": {
+    "textDocument": {
+      "uri": "deno:/asset//lib.es2015.symbol.wellknown.d.ts"
+    }
+  }
+}


### PR DESCRIPTION
When we migrated away from all the locks, there was a regression that was not caught immediately.  The `tsc::get_asset()` would attempt to modify the snapshot, but the problem was that the snapshot was a `.clone()` of the inner language server's assets, which meant that modifications to that where lost.  When we then attempted to do a hover on those assets, the inner language servers assets didn't have the retrieved asset, and therefore would throw an error.

Trying to modify the assets within the inner language server struct causes a lot of challenges with mutability.

This PR follows the same strategy we have for `Sources` which wraps the assets in an arc mutex and deals with the locking opaquely.  Also adds a test which failed before the patch to help ensure we don't regress again.