### PR TITLE
fix(lsp): remove Sources mutex

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use super::text::LineIndex;
+use super::language_server;
 use super::tsc;
 
 use crate::ast;
@@ -13,7 +13,6 @@ use crate::tools::lint::create_linter;
 
 use deno_core::error::custom_error;
 use deno_core::error::AnyError;
-use deno_core::futures::Future;
 use deno_core::serde::Deserialize;
 use deno_core::serde::Serialize;
 use deno_core::serde_json::json;
@@ -353,21 +352,14 @@ fn is_preferred(
 
 /// Convert changes returned from a TypeScript quick fix action into edits
 /// for an LSP CodeAction.
-pub async fn ts_changes_to_edit<F, Fut, V>(
+pub(crate) async fn ts_changes_to_edit(
   changes: &[tsc::FileTextChanges],
-  index_provider: &F,
-  version_provider: &V,
-) -> Result<Option<lsp::WorkspaceEdit>, AnyError>
-where
-  F: Fn(ModuleSpecifier) -> Fut + Clone,
-  Fut: Future<Output = Result<LineIndex, AnyError>>,
-  V: Fn(ModuleSpecifier) -> Option<i32>,
-{
+  language_server: &mut language_server::Inner,
+) -> Result<Option<lsp::WorkspaceEdit>, AnyError> {
   let mut text_document_edits = Vec::new();
   for change in changes {
-    let text_document_edit = change
-      .to_text_document_edit(index_provider, version_provider)
-      .await?;
+    let text_document_edit =
+      change.to_text_document_edit(language_server).await?;
     text_document_edits.push(text_document_edit);
   }
   Ok(Some(lsp::WorkspaceEdit {
@@ -392,18 +384,12 @@ pub struct CodeActionCollection {
 
 impl CodeActionCollection {
   /// Add a TypeScript code fix action to the code actions collection.
-  pub async fn add_ts_fix_action<F, Fut, V>(
+  pub(crate) async fn add_ts_fix_action(
     &mut self,
     action: &tsc::CodeFixAction,
     diagnostic: &lsp::Diagnostic,
-    index_provider: &F,
-    version_provider: &V,
-  ) -> Result<(), AnyError>
-  where
-    F: Fn(ModuleSpecifier) -> Fut + Clone,
-    Fut: Future<Output = Result<LineIndex, AnyError>>,
-    V: Fn(ModuleSpecifier) -> Option<i32>,
-  {
+    language_server: &mut language_server::Inner,
+  ) -> Result<(), AnyError> {
     if action.commands.is_some() {
       // In theory, tsc can return actions that require "commands" to be applied
       // back into TypeScript.  Currently there is only one command, `install
@@ -417,9 +403,7 @@ impl CodeActionCollection {
         "The action returned from TypeScript is unsupported.",
       ));
     }
-    let edit =
-      ts_changes_to_edit(&action.changes, index_provider, version_provider)
-        .await?;
+    let edit = ts_changes_to_edit(&action.changes, language_server).await?;
     let code_action = lsp::CodeAction {
       title: action.description.clone(),
       kind: Some(lsp::CodeActionKind::QUICKFIX),
@@ -502,7 +486,7 @@ impl CodeActionCollection {
     &self,
     action: &tsc::CodeFixAction,
     diagnostic: &lsp::Diagnostic,
-    file_diagnostics: &[&lsp::Diagnostic],
+    file_diagnostics: &[lsp::Diagnostic],
   ) -> bool {
     // If the action does not have a fix id (indicating it can be "bundled up")
     // or if the collection already contains a "bundled" action return false
@@ -517,7 +501,7 @@ impl CodeActionCollection {
       // other diagnostics that could be bundled together in a "fix all" code
       // action
       file_diagnostics.iter().any(|d| {
-        if d == &diagnostic || d.code.is_none() || diagnostic.code.is_none() {
+        if d == diagnostic || d.code.is_none() || diagnostic.code.is_none() {
           false
         } else {
           d.code == diagnostic.code

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1935,6 +1935,51 @@ mod tests {
   }
 
   #[tokio::test]
+  async fn test_hover_asset() {
+    let mut harness = LspTestHarness::new(vec![
+      ("initialize_request.json", LspResponse::RequestAny),
+      ("initialized_notification.json", LspResponse::None),
+      ("did_open_notification_asset.json", LspResponse::None),
+      ("hover_request_asset_01.json", LspResponse::RequestAny),
+      (
+        "virtual_text_document_request.json",
+        LspResponse::RequestAny,
+      ),
+      (
+        "hover_request_asset_02.json",
+        LspResponse::Request(
+          4,
+          json!({
+            "contents": [
+              {
+                "language": "typescript",
+                "value": "interface Date",
+              },
+              "Enables basic storage and retrieval of dates and times."
+            ],
+            "range": {
+              "start": {
+                "line": 109,
+                "character": 10,
+              },
+              "end": {
+                "line": 109,
+                "character": 14,
+              }
+            }
+          }),
+        ),
+      ),
+      (
+        "shutdown_request.json",
+        LspResponse::Request(3, json!(null)),
+      ),
+      ("exit_notification.json", LspResponse::None),
+    ]);
+    harness.run().await;
+  }
+
+  #[tokio::test]
   async fn test_hover_disabled() {
     let mut harness = LspTestHarness::new(vec![
       ("initialize_request_disabled.json", LspResponse::RequestAny),

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2,6 +2,7 @@
 
 use super::analysis::CodeLensSource;
 use super::analysis::ResolvedDependency;
+use super::language_server;
 use super::language_server::StateSnapshot;
 use super::text;
 use super::text::LineIndex;
@@ -16,7 +17,6 @@ use crate::tsc_config::TsConfig;
 use deno_core::error::anyhow;
 use deno_core::error::custom_error;
 use deno_core::error::AnyError;
-use deno_core::futures::Future;
 use deno_core::json_op_sync;
 use deno_core::serde::Deserialize;
 use deno_core::serde::Serialize;
@@ -443,18 +443,16 @@ pub struct DocumentSpan {
 }
 
 impl DocumentSpan {
-  pub async fn to_link<F, Fut>(
+  pub(crate) async fn to_link(
     &self,
     line_index: &LineIndex,
-    index_provider: F,
-  ) -> Option<lsp::LocationLink>
-  where
-    F: Fn(ModuleSpecifier) -> Fut,
-    Fut: Future<Output = Result<LineIndex, AnyError>>,
-  {
+    language_server: &mut language_server::Inner,
+  ) -> Option<lsp::LocationLink> {
     let target_specifier =
       ModuleSpecifier::resolve_url(&self.file_name).unwrap();
-    if let Ok(target_line_index) = index_provider(target_specifier).await {
+    if let Ok(target_line_index) =
+      language_server.get_line_index(target_specifier).await
+    {
       let target_uri = utils::normalize_file_name(&self.file_name).unwrap();
       let (target_range, target_selection_range) =
         if let Some(context_span) = &self.context_span {
@@ -559,17 +557,11 @@ pub struct RenameLocations {
 }
 
 impl RenameLocations {
-  pub async fn into_workspace_edit<F, Fut, V>(
+  pub(crate) async fn into_workspace_edit(
     self,
     new_name: &str,
-    index_provider: F,
-    version_provider: V,
-  ) -> Result<lsp::WorkspaceEdit, AnyError>
-  where
-    F: Fn(ModuleSpecifier) -> Fut,
-    Fut: Future<Output = Result<LineIndex, AnyError>>,
-    V: Fn(ModuleSpecifier) -> Option<i32>,
-  {
+    language_server: &mut language_server::Inner,
+  ) -> Result<lsp::WorkspaceEdit, AnyError> {
     let mut text_document_edit_map: HashMap<Url, lsp::TextDocumentEdit> =
       HashMap::new();
     for location in self.locations.iter() {
@@ -584,7 +576,7 @@ impl RenameLocations {
           lsp::TextDocumentEdit {
             text_document: lsp::OptionalVersionedTextDocumentIdentifier {
               uri: uri.clone(),
-              version: version_provider(specifier.clone()),
+              version: language_server.document_version(specifier.clone()),
             },
             edits:
               Vec::<lsp::OneOf<lsp::TextEdit, lsp::AnnotatedTextEdit>>::new(),
@@ -598,7 +590,7 @@ impl RenameLocations {
         range: location
           .document_span
           .text_span
-          .to_range(&index_provider(specifier.clone()).await?),
+          .to_range(&language_server.get_line_index(specifier.clone()).await?),
         new_text: new_name.to_string(),
       }));
     }
@@ -655,22 +647,16 @@ pub struct DefinitionInfoAndBoundSpan {
 }
 
 impl DefinitionInfoAndBoundSpan {
-  pub async fn to_definition<F, Fut>(
+  pub(crate) async fn to_definition(
     &self,
     line_index: &LineIndex,
-    index_provider: F,
-  ) -> Option<lsp::GotoDefinitionResponse>
-  where
-    F: Fn(ModuleSpecifier) -> Fut + Clone,
-    Fut: Future<Output = Result<LineIndex, AnyError>>,
-  {
+    language_server: &mut language_server::Inner,
+  ) -> Option<lsp::GotoDefinitionResponse> {
     if let Some(definitions) = &self.definitions {
       let mut location_links = Vec::<lsp::LocationLink>::new();
       for di in definitions {
-        if let Some(link) = di
-          .document_span
-          .to_link(line_index, index_provider.clone())
-          .await
+        if let Some(link) =
+          di.document_span.to_link(line_index, language_server).await
         {
           location_links.push(link);
         }
@@ -739,18 +725,12 @@ pub struct FileTextChanges {
 }
 
 impl FileTextChanges {
-  pub async fn to_text_document_edit<F, Fut, V>(
+  pub(crate) async fn to_text_document_edit(
     &self,
-    index_provider: &F,
-    version_provider: &V,
-  ) -> Result<lsp::TextDocumentEdit, AnyError>
-  where
-    F: Fn(ModuleSpecifier) -> Fut + Clone,
-    Fut: Future<Output = Result<LineIndex, AnyError>>,
-    V: Fn(ModuleSpecifier) -> Option<i32>,
-  {
+    language_server: &mut language_server::Inner,
+  ) -> Result<lsp::TextDocumentEdit, AnyError> {
     let specifier = ModuleSpecifier::resolve_url(&self.file_name)?;
-    let line_index = index_provider(specifier.clone()).await?;
+    let line_index = language_server.get_line_index(specifier.clone()).await?;
     let edits = self
       .text_changes
       .iter()
@@ -759,7 +739,7 @@ impl FileTextChanges {
     Ok(lsp::TextDocumentEdit {
       text_document: lsp::OptionalVersionedTextDocumentIdentifier {
         uri: specifier.as_url().clone(),
-        version: version_provider(specifier),
+        version: language_server.document_version(specifier),
       },
       edits,
     })
@@ -1043,7 +1023,7 @@ fn get_length(state: &mut State, args: Value) -> Result<Value, AnyError> {
       .unwrap();
     Ok(json!(content.encode_utf16().count()))
   } else {
-    let sources = &state.state_snapshot.sources;
+    let sources = &mut state.state_snapshot.sources;
     Ok(json!(sources.get_length_utf16(&specifier).unwrap()))
   }
 }
@@ -1068,7 +1048,7 @@ fn get_text(state: &mut State, args: Value) -> Result<Value, AnyError> {
       .unwrap()
       .clone()
   } else {
-    let sources = &state.state_snapshot.sources;
+    let sources = &mut state.state_snapshot.sources;
     sources.get_text(&specifier).unwrap()
   };
   Ok(json!(text::slice(&content, v.start..v.end)))
@@ -1078,7 +1058,7 @@ fn resolve(state: &mut State, args: Value) -> Result<Value, AnyError> {
   let v: ResolveArgs = serde_json::from_value(args)?;
   let mut resolved = Vec::<Option<(String, String)>>::new();
   let referrer = ModuleSpecifier::resolve_url(&v.base)?;
-  let sources = &state.state_snapshot.sources;
+  let sources = &mut state.state_snapshot.sources;
 
   if state.state_snapshot.documents.contains(&referrer) {
     if let Some(dependencies) =
@@ -1172,7 +1152,7 @@ fn script_version(state: &mut State, args: Value) -> Result<Value, AnyError> {
   if let Some(version) = state.state_snapshot.documents.version(&specifier) {
     return Ok(json!(version.to_string()));
   } else {
-    let sources = &state.state_snapshot.sources;
+    let sources = &mut state.state_snapshot.sources;
     if let Some(version) = sources.get_script_version(&specifier) {
       return Ok(json!(version));
     }

--- a/cli/tests/lsp/did_open_notification_asset.json
+++ b/cli/tests/lsp/did_open_notification_asset.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/didOpen",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts",
+      "languageId": "typescript",
+      "version": 1,
+      "text": "console.log(Date.now());\n"
+    }
+  }
+}

--- a/cli/tests/lsp/hover_request_asset_01.json
+++ b/cli/tests/lsp/hover_request_asset_01.json
@@ -1,0 +1,14 @@
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "textDocument/hover",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts"
+    },
+    "position": {
+      "line": 0,
+      "character": 12
+    }
+  }
+}

--- a/cli/tests/lsp/hover_request_asset_02.json
+++ b/cli/tests/lsp/hover_request_asset_02.json
@@ -1,0 +1,14 @@
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "textDocument/hover",
+  "params": {
+    "textDocument": {
+      "uri": "deno:/asset//lib.es2015.symbol.wellknown.d.ts"
+    },
+    "position": {
+      "line": 109,
+      "character": 13
+    }
+  }
+}

--- a/cli/tests/lsp/virtual_text_document_request.json
+++ b/cli/tests/lsp/virtual_text_document_request.json
@@ -1,0 +1,10 @@
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "deno/virtualTextDocument",
+  "params": {
+    "textDocument": {
+      "uri": "deno:/asset//lib.es2015.symbol.wellknown.d.ts"
+    }
+  }
+}


### PR DESCRIPTION
The mutex was used to hide the fact that the Sources object mutates
itself when it's queried. Be honest about that and mark everything that
directly or indirectly mutates it as `mut`.

This is a follow-up to commit 2828690fc7bb510c3248dda7b1cda8793e789ca6
from last month ("fix(lsp): fix deadlocks, use one big mutex (#9271)")

Refs #9406.