### PR TITLE
feat(core): Strongly typed deserialization of JSON ops

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -8,6 +8,7 @@ use deno_core::JsRuntime;
 use deno_core::RuntimeOptions;
 use regex::Regex;
 use serde::Deserialize;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::env;
 use std::path::Path;
@@ -142,7 +143,7 @@ fn create_compiler_snapshot(
   });
   js_runtime.register_op(
     "op_build_info",
-    json_op_sync(move |_state, _args, _bufs| {
+    json_op_sync(move |_state, _args: Value, _bufs| {
       Ok(json!({
         "buildSpecifier": build_specifier,
         "libs": build_libs,

--- a/cli/tests/unit/dispatch_json_test.ts
+++ b/cli/tests/unit/dispatch_json_test.ts
@@ -34,9 +34,10 @@ unitTest(function invalidPromiseId(): void {
       createNew: false,
     },
   };
-  const argsText = JSON.stringify([promiseId, argsObj]);
-  const argsBuf = new TextEncoder().encode(argsText);
-  const resBuf = Deno.core.send(opId, argsBuf);
+  const argsText = JSON.stringify(argsObj);
+  const reqText = JSON.stringify([promiseId, argsText]);
+  const reqBuf = new TextEncoder().encode(reqText);
+  const resBuf = Deno.core.send(opId, reqBuf);
   const resText = new TextDecoder().decode(resBuf);
   const resObj = JSON.parse(resText);
   console.error(resText);

--- a/cli/tests/unit/dispatch_json_test.ts
+++ b/cli/tests/unit/dispatch_json_test.ts
@@ -21,8 +21,8 @@ unitTest(function malformedJsonControlBuffer(): void {
 
 unitTest(function invalidPromiseId(): void {
   const opId = Deno.core.ops()["op_open_async"];
+  const promiseId = "1. NEIN!";
   const argsObj = {
-    promiseId: "1. NEIN!",
     path: "/tmp/P.I.S.C.I.X/yeah",
     mode: 0o666,
     options: {
@@ -34,7 +34,7 @@ unitTest(function invalidPromiseId(): void {
       createNew: false,
     },
   };
-  const argsText = JSON.stringify(argsObj);
+  const argsText = JSON.stringify([promiseId, argsObj]);
   const argsBuf = new TextEncoder().encode(argsText);
   const resBuf = Deno.core.send(opId, argsBuf);
   const resText = new TextDecoder().decode(resBuf);

--- a/cli/tests/unit/dispatch_json_test.ts
+++ b/cli/tests/unit/dispatch_json_test.ts
@@ -21,22 +21,7 @@ unitTest(function malformedJsonControlBuffer(): void {
 
 unitTest(function invalidPromiseId(): void {
   const opId = Deno.core.ops()["op_open_async"];
-  const promiseId = "1. NEIN!";
-  const argsObj = {
-    path: "/tmp/P.I.S.C.I.X/yeah",
-    mode: 0o666,
-    options: {
-      read: true,
-      write: true,
-      create: true,
-      truncate: false,
-      append: false,
-      createNew: false,
-    },
-  };
-  const argsText = JSON.stringify(argsObj);
-  const reqText = JSON.stringify([promiseId, argsText]);
-  const reqBuf = new TextEncoder().encode(reqText);
+  const reqBuf = new Uint8Array([0, 0, 0, 0, 0, 0, 0]);
   const resBuf = Deno.core.send(opId, reqBuf);
   const resText = new TextDecoder().decode(resBuf);
   const resObj = JSON.parse(resText);

--- a/core/core.js
+++ b/core/core.js
@@ -213,11 +213,11 @@ SharedQueue Binary Layout
     throw new ErrorClass(res.err.message);
   }
 
-  async function jsonOpAsync(opName, args = {}, ...zeroCopy) {
+  async function jsonOpAsync(opName, args = null, ...zeroCopy) {
     setAsyncHandler(opsCache[opName], jsonOpAsyncHandler);
 
-    args.promiseId = nextPromiseId++;
-    const argsBuf = encodeJson(args);
+    const promiseId = nextPromiseId++;
+    const argsBuf = encodeJson([ promiseId, args ]);
     dispatch(opName, argsBuf, ...zeroCopy);
     let resolve, reject;
     const promise = new Promise((resolve_, reject_) => {
@@ -226,11 +226,11 @@ SharedQueue Binary Layout
     });
     promise.resolve = resolve;
     promise.reject = reject;
-    promiseTable[args.promiseId] = promise;
+    promiseTable[promiseId] = promise;
     return processResponse(await promise);
   }
 
-  function jsonOpSync(opName, args = {}, ...zeroCopy) {
+  function jsonOpSync(opName, args = null, ...zeroCopy) {
     const argsBuf = encodeJson(args);
     const res = dispatch(opName, argsBuf, ...zeroCopy);
     return processResponse(decodeJson(res));

--- a/core/core.js
+++ b/core/core.js
@@ -217,7 +217,7 @@ SharedQueue Binary Layout
     setAsyncHandler(opsCache[opName], jsonOpAsyncHandler);
 
     const promiseId = nextPromiseId++;
-    const argsBuf = encodeJson([ promiseId, args ]);
+    const argsBuf = encodeJson([promiseId, args]);
     dispatch(opName, argsBuf, ...zeroCopy);
     let resolve, reject;
     const promise = new Promise((resolve_, reject_) => {

--- a/core/core.js
+++ b/core/core.js
@@ -217,8 +217,9 @@ SharedQueue Binary Layout
     setAsyncHandler(opsCache[opName], jsonOpAsyncHandler);
 
     const promiseId = nextPromiseId++;
-    const argsBuf = encodeJson([promiseId, args]);
-    dispatch(opName, argsBuf, ...zeroCopy);
+    const argsText = JSON.stringify(args);
+    const reqBuf = encodeJson([promiseId, argsText]);
+    dispatch(opName, reqBuf, ...zeroCopy);
     let resolve, reject;
     const promise = new Promise((resolve_, reject_) => {
       resolve = resolve_;

--- a/core/core.js
+++ b/core/core.js
@@ -217,8 +217,8 @@ SharedQueue Binary Layout
     setAsyncHandler(opsCache[opName], jsonOpAsyncHandler);
 
     const promiseId = nextPromiseId++;
-    const argsText = JSON.stringify(args);
-    const reqBuf = encodeJson([promiseId, argsText]);
+    const reqBuf = core.encode("\0".repeat(8) + JSON.stringify(args));
+    new DataView(reqBuf.buffer).setBigUint64(0, BigInt(promiseId));
     dispatch(opName, reqBuf, ...zeroCopy);
     let resolve, reject;
     const promise = new Promise((resolve_, reject_) => {

--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -56,9 +56,7 @@ fn main() {
         Err(anyhow!("Expected exactly one argument"))
       } else {
         // And if we did, do our actual task
-        let sum = json
-          .iter()
-          .fold(0.0, |a, v| a + v);
+        let sum = json.iter().fold(0.0, |a, v| a + v);
 
         // Finally we return a JSON value
         Ok(Value::from(sum))

--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -50,27 +50,15 @@ fn main() {
     // The json_op_sync function automatically deserializes
     // the first ZeroCopyBuf and serializes the return value
     // to reduce boilerplate
-    json_op_sync(|_state, json, zero_copy| {
-      // We check that we only got the JSON value,
-      // and that it's of the right type.
+    json_op_sync(|_state, json: Vec<f64>, zero_copy| {
+      // We check that we only got the JSON value.
       if !zero_copy.is_empty() {
         Err(anyhow!("Expected exactly one argument"))
-      } else if !json.is_array() {
-        Err(anyhow!("Argument is not of type array"))
-      } else if !json
-        .as_array()
-        .unwrap()
-        .iter()
-        .all(|value| value.is_number())
-      {
-        Err(anyhow!("Argument is not array of numbers"))
       } else {
-        // And if everything checks out we do our actual task
+        // And if we did, do our actual task
         let sum = json
-          .as_array()
-          .unwrap()
           .iter()
-          .fold(0.0, |a, v| a + v.as_f64().unwrap());
+          .fold(0.0, |a, v| a + v);
 
         // Finally we return a JSON value
         Ok(Value::from(sum))

--- a/core/examples/http_bench_json_ops.js
+++ b/core/examples/http_bench_json_ops.js
@@ -11,7 +11,7 @@ const responseBuf = new Uint8Array(
 
 /** Listens on 0.0.0.0:4500, returns rid. */
 function listen() {
-  const { rid } = Deno.core.jsonOpSync("listen", {});
+  const { rid } = Deno.core.jsonOpSync("listen");
   return rid;
 }
 

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -127,7 +127,7 @@ fn create_js_runtime() -> JsRuntime {
 
 #[derive(Deserialize, Serialize)]
 struct ResourceId {
-  rid: u32
+  rid: u32,
 }
 
 fn op_listen(

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -10,14 +10,14 @@ declare namespace Deno {
     /** Send a JSON op to Rust, and synchronously recieve the result. */
     function jsonOpSync(
       opName: string,
-      args: any,
+      args?: any,
       ...zeroCopy: Uint8Array[]
     ): any;
 
     /** Send a JSON op to Rust, and asynchronously recieve the result. */
     function jsonOpAsync(
       opName: string,
-      args: any,
+      args?: any,
       ...zeroCopy: Uint8Array[]
     ): Promise<any>;
 

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -10,9 +10,9 @@ use crate::BufVec;
 use crate::ZeroCopyBuf;
 use futures::Future;
 use indexmap::IndexMap;
+use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
-use serde::de::DeserializeOwned;
 use serde_json::json;
 use serde_json::Value;
 use std::cell::RefCell;
@@ -143,8 +143,7 @@ impl Default for OpTable {
 pub fn json_op_sync<V, F, R>(op_fn: F) -> Box<OpFn>
 where
   V: DeserializeOwned,
-  F: Fn(&mut OpState, V, &mut [ZeroCopyBuf]) -> Result<R, AnyError>
-    + 'static,
+  F: Fn(&mut OpState, V, &mut [ZeroCopyBuf]) -> Result<R, AnyError> + 'static,
   R: Serialize,
 {
   Box::new(move |state: Rc<RefCell<OpState>>, mut bufs: BufVec| -> Op {


### PR DESCRIPTION
(from #9422)

This PR makes json_op_sync/async generic to all Deserialize/Serialize types instead of the loosely-typed serde_json::Value. Since serde_json::Value implements Deserialize/Serialize, very little existing code needs to be updated, however as json_op_sync/async are now generic, type inference is broken in some cases (see [cli/build.rs:146](https://github.com/denoland/deno/pull/9423/commits/5e3143e76c0c9020cf8b7ab3db83d6471a44e40f#diff-fa76844bfec3519648a2d7493933ff3317fa3250dd913cc26d0e86b3b5d4465aR146)). I've found this reduces a good bit of boilerplate, as seen in the updated [deno_core examples](https://github.com/denoland/deno/commit/4782f3ec8d0232cd14222ab67dead9f94f0e4f28).

This change may also reduce serialization and deserialization overhead as serde has a better idea of what types it is working with. I am currently working on benchmarks to confirm this and I will update this PR with my findings.