### PR TITLE
feat(runtime/tls): Add support for client certificates to connectTls

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1785,7 +1785,8 @@ declare namespace Deno {
     /** A literal IP address or host name that can be resolved to an IP address.
      * If not specified, defaults to `127.0.0.1`. */
     hostname?: string;
-    /** Server certificate file. */
+    /** Path to a file containing a PEM formatted CA certificate. Requires
+     * `--allow-read`. */
     certFile?: string;
   }
 

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1780,7 +1780,7 @@ declare namespace Deno {
   export function connect(options: ConnectOptions): Promise<Conn>;
 
   export interface TlsClientCertificateOptions {
-    /** PEM formatted client certificate chain */
+    /** PEM formatted client certificate chain. */
     chain: string;
     /** PEM formatted (RSA or PKCS8) private key of client certificate. */
     privateKey: string;

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1779,13 +1779,6 @@ declare namespace Deno {
    * Requires `allow-net` permission for "tcp". */
   export function connect(options: ConnectOptions): Promise<Conn>;
 
-  export interface TlsClientCertificateOptions {
-    /** PEM formatted client certificate chain. */
-    chain: string;
-    /** PEM formatted (RSA or PKCS8) private key of client certificate. */
-    privateKey: string;
-  }
-
   export interface ConnectTlsOptions {
     /** The port to connect to. */
     port: number;
@@ -1794,8 +1787,6 @@ declare namespace Deno {
     hostname?: string;
     /** Server certificate file. */
     certFile?: string;
-    /** TLS client certificate options. */
-    clientCert?: TlsClientCertificateOptions;
   }
 
   /** Establishes a secure connection over TLS (transport layer security) using

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1779,6 +1779,13 @@ declare namespace Deno {
    * Requires `allow-net` permission for "tcp". */
   export function connect(options: ConnectOptions): Promise<Conn>;
 
+  export interface TlsClientCertificateOptions {
+    /**  TODO: documentation */
+    chain: string;
+    /**  TODO: documentation */
+    privateKey: string;
+  }
+
   export interface ConnectTlsOptions {
     /** The port to connect to. */
     port: number;
@@ -1787,6 +1794,8 @@ declare namespace Deno {
     hostname?: string;
     /** Server certificate file. */
     certFile?: string;
+    /**  TODO: documentation */
+    clientCert?: TlsClientCertificateOptions;
   }
 
   /** Establishes a secure connection over TLS (transport layer security) using

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1780,9 +1780,9 @@ declare namespace Deno {
   export function connect(options: ConnectOptions): Promise<Conn>;
 
   export interface TlsClientCertificateOptions {
-    /**  TODO: documentation */
+    /** PEM formatted client certificate chain */
     chain: string;
-    /**  TODO: documentation */
+    /** PEM formatted (RSA or PKCS8) private key of client certificate. */
     privateKey: string;
   }
 
@@ -1794,7 +1794,7 @@ declare namespace Deno {
     hostname?: string;
     /** Server certificate file. */
     certFile?: string;
-    /**  TODO: documentation */
+    /** TLS client certificate options. */
     clientCert?: TlsClientCertificateOptions;
   }
 
@@ -1928,10 +1928,10 @@ declare namespace Deno {
      *
      * If `stdout` and/or `stderr` were set to `"piped"`, they must be closed
      * manually before the process can exit.
-     * 
+     *
      * To run process to completion and collect output from both `stdout` and
      * `stderr` use:
-     * 
+     *
      * ```ts
      * const p = Deno.run({ cmd, stderr: 'piped', stdout: 'piped' });
      * const [status, stdout, stderr] = await Promise.all([

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -848,7 +848,7 @@ declare namespace Deno {
     | "TXT";
 
   export interface ResolveDnsOptions {
-    /** The name server to be used for lookups. 
+    /** The name server to be used for lookups.
     * If not specified, defaults to the system configuration e.g. `/etc/resolv.conf` on Unix. */
     nameServer?: {
       /** The IP address of the name server */
@@ -1020,6 +1020,32 @@ declare namespace Deno {
    * Requires `allow-net` permission for "tcp" and `allow-read` for "unix". */
   export function connect(
     options: ConnectOptions | UnixConnectOptions,
+  ): Promise<Conn>;
+
+  export interface ConnectTlsClientCertOptions {
+    /** PEM formatted client certificate chain. */
+    certChain: string;
+    /** PEM formatted (RSA or PKCS8) private key of client certificate. */
+    privateKey: string;
+  }
+
+  /** **UNSTABLE** New API, yet to be vetted.
+   *
+   * Create a TLS connection with an attached client certificate.
+   *
+   * ```ts
+   * const conn = await Deno.connectTls({
+   *   hostname: "deno.land",
+   *   port: 443,
+   *   certChain: "---- BEGIN CERTIFICATE ----\n ...",
+   *   privateKey: "---- BEGIN PRIVATE KEY ----\n ...",
+   * });
+   * ```
+   *
+   * Requires `allow-net` permission.
+   */
+  export function connectTls(
+    options: ConnectTlsOptions & ConnectTlsClientCertOptions,
   ): Promise<Conn>;
 
   export interface StartTlsOptions {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -4695,7 +4695,7 @@ console.log("finish");
 
     let script = util::tests_path().join("tls_test.ts");
     let root_ca = util::tests_path().join("tls/RootCA.pem");
-    let status = util::deno_cmd()
+    let output = util::deno_cmd()
       .arg("test")
       .arg("--unstable")
       .arg("--allow-net")
@@ -4703,12 +4703,19 @@ console.log("finish");
       .arg("--cert")
       .arg(root_ca)
       .arg(script)
+      .stdout(std::process::Stdio::piped())
+      .stderr(std::process::Stdio::piped())
       .spawn()
       .unwrap()
-      .wait()
+      .wait_with_output()
       .unwrap();
 
-    assert!(status.success());
+    let stderr = std::str::from_utf8(&output.stderr).unwrap().trim();
+    eprintln!("stderr: {}", stderr);
+    let stdout = std::str::from_utf8(&output.stdout).unwrap().trim();
+    eprintln!("stdout: {}", stdout);
+
+    assert!(output.status.success());
   }
 
   #[test]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -4690,6 +4690,28 @@ console.log("finish");
   }
 
   #[test]
+  fn tls_integration() {
+    let _g = util::http_server();
+
+    let script = util::tests_path().join("tls_test.ts");
+    let root_ca = util::tests_path().join("tls/RootCA.pem");
+    let status = util::deno_cmd()
+      .arg("test")
+      .arg("--unstable")
+      .arg("--allow-net")
+      .arg("--allow-read")
+      .arg("--cert")
+      .arg(root_ca)
+      .arg(script)
+      .spawn()
+      .unwrap()
+      .wait()
+      .unwrap();
+
+    assert!(status.success());
+  }
+
+  #[test]
   fn exec_path() {
     let output = util::deno_cmd()
       .current_dir(util::root_path())

--- a/cli/tests/tls_test.ts
+++ b/cli/tests/tls_test.ts
@@ -1,0 +1,22 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { assertEquals } from "../../test_util/std/testing/asserts.ts";
+import { BufReader } from "../../test_util/std/io/bufio.ts";
+import { TextProtoReader } from "../../test_util/std/textproto/mod.ts";
+
+Deno.test("connect with client certificate", async () => {
+  const conn = await Deno.connectTls({
+    hostname: "localhost",
+    port: 4244,
+    certChain: await Deno.readTextFile("tests/tls/localhost.crt"),
+    privateKey: await Deno.readTextFile("tests/tls/localhost.key"),
+    certFile: "tests/tls/RootCA.pem",
+  });
+
+  const reader = new TextProtoReader(new BufReader(conn));
+  const result = await reader.readLine() as string;
+
+  // Server will respond with PASS if client authentication was successful.
+  assertEquals(result, "PASS");
+
+  conn.close();
+});

--- a/cli/tests/tls_test.ts
+++ b/cli/tests/tls_test.ts
@@ -6,7 +6,7 @@ import { TextProtoReader } from "../../test_util/std/textproto/mod.ts";
 Deno.test("connect with client certificate", async () => {
   const conn = await Deno.connectTls({
     hostname: "localhost",
-    port: 4244,
+    port: 4551,
     certChain: await Deno.readTextFile("tests/tls/localhost.crt"),
     privateKey: await Deno.readTextFile("tests/tls/localhost.key"),
     certFile: "tests/tls/RootCA.pem",

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -36,10 +36,8 @@ unitTest(
     const conn = await Deno.connectTls({
       hostname: "deno.land",
       port: 443,
-      clientCert: {
-        chain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),
-        privateKey: await Deno.readTextFile("cli/tests/tls/localhost.key"),
-      },
+      certChain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),
+      privateKey: await Deno.readTextFile("cli/tests/tls/localhost.key"),
     });
 
     conn.close();
@@ -53,10 +51,8 @@ unitTest(
       await Deno.connectTls({
         hostname: "deno.land",
         port: 443,
-        clientCert: {
-          chain: "bad data",
-          privateKey: await Deno.readTextFile("cli/tests/tls/localhost.key"),
-        },
+        certChain: "bad data",
+        privateKey: await Deno.readTextFile("cli/tests/tls/localhost.key"),
       });
     }, Deno.errors.InvalidData);
   },
@@ -69,10 +65,8 @@ unitTest(
       await Deno.connectTls({
         hostname: "deno.land",
         port: 443,
-        clientCert: {
-          chain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),
-          privateKey: "bad data",
-        },
+        certChain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),
+        privateKey: "bad data",
       });
     }, Deno.errors.InvalidData);
   },

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -16,14 +16,14 @@ const decoder = new TextDecoder();
 
 unitTest(async function connectTLSNoPerm(): Promise<void> {
   await assertThrowsAsync(async () => {
-    await Deno.connectTls({ hostname: "github.com", port: 443 });
+    await Deno.connectTls({ hostname: "deno.land", port: 443 });
   }, Deno.errors.PermissionDenied);
 });
 
 unitTest(async function connectTLSCertFileNoReadPerm(): Promise<void> {
   await assertThrowsAsync(async () => {
     await Deno.connectTls({
-      hostname: "github.com",
+      hostname: "deno.land",
       port: 443,
       certFile: "cli/tests/tls/RootCA.crt",
     });
@@ -34,7 +34,7 @@ unitTest(
   { perms: { read: true, net: true } },
   async function connectTLSClientCertConnection(): Promise<void> {
     const conn = await Deno.connectTls({
-      hostname: "github.com",
+      hostname: "deno.land",
       port: 443,
       clientCert: {
         chain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),
@@ -51,7 +51,7 @@ unitTest(
   async function connectTLSBadClientCertPrivateKey(): Promise<void> {
     await assertThrowsAsync(async () => {
       await Deno.connectTls({
-        hostname: "github.com",
+        hostname: "deno.land",
         port: 443,
         clientCert: {
           chain: "bad data",
@@ -67,7 +67,7 @@ unitTest(
   async function connectTLSBadClientCertChain(): Promise<void> {
     await assertThrowsAsync(async () => {
       await Deno.connectTls({
-        hostname: "github.com",
+        hostname: "deno.land",
         port: 443,
         clientCert: {
           chain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -32,6 +32,54 @@ unitTest(async function connectTLSCertFileNoReadPerm(): Promise<void> {
 
 unitTest(
   { perms: { read: true, net: true } },
+  async function connectTLSClientCertConnection(): Promise<void> {
+    const conn = await Deno.connectTls({
+      hostname: "github.com",
+      port: 443,
+      clientCert: {
+        chain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),
+        privateKey: await Deno.readTextFile("cli/tests/tls/localhost.key"),
+      },
+    });
+
+    conn.close();
+  },
+);
+
+unitTest(
+  { perms: { read: true, net: true } },
+  async function connectTLSBadClientCertPrivateKey(): Promise<void> {
+    await assertThrowsAsync(async () => {
+      await Deno.connectTls({
+        hostname: "github.com",
+        port: 443,
+        clientCert: {
+          chain: "bad data",
+          privateKey: await Deno.readTextFile("cli/tests/tls/localhost.key"),
+        },
+      });
+    }, Deno.errors.InvalidData);
+  },
+);
+
+unitTest(
+  { perms: { read: true, net: true } },
+  async function connectTLSBadClientCertChain(): Promise<void> {
+    await assertThrowsAsync(async () => {
+      await Deno.connectTls({
+        hostname: "github.com",
+        port: 443,
+        clientCert: {
+          chain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),
+          privateKey: "bad data",
+        },
+      });
+    }, Deno.errors.InvalidData);
+  },
+);
+
+unitTest(
+  { perms: { read: true, net: true } },
   function listenTLSNonExistentCertKeyFiles(): void {
     const options = {
       hostname: "localhost",

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -34,11 +34,18 @@ unitTest(
   { perms: { read: true, net: true } },
   async function connectTLSClientCertConnection(): Promise<void> {
     const conn = await Deno.connectTls({
-      hostname: "deno.land",
-      port: 443,
+      hostname: "localhost",
+      port: 4244,
       certChain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),
       privateKey: await Deno.readTextFile("cli/tests/tls/localhost.key"),
+      certFile: "cli/tests/tls/RootCA.pem",
     });
+
+    const reader = new TextProtoReader(new BufReader(conn));
+    const result = await reader.readLine() as string;
+
+    // Server will respond with PASS if client authentication was successful.
+    assertEquals(result, "PASS");
 
     conn.close();
   },
@@ -49,8 +56,8 @@ unitTest(
   async function connectTLSBadClientCertPrivateKey(): Promise<void> {
     await assertThrowsAsync(async () => {
       await Deno.connectTls({
-        hostname: "deno.land",
-        port: 443,
+        hostname: "localhost",
+        port: 4244,
         certChain: "bad data",
         privateKey: await Deno.readTextFile("cli/tests/tls/localhost.key"),
       });
@@ -63,8 +70,8 @@ unitTest(
   async function connectTLSBadClientCertChain(): Promise<void> {
     await assertThrowsAsync(async () => {
       await Deno.connectTls({
-        hostname: "deno.land",
-        port: 443,
+        hostname: "localhost",
+        port: 4244,
         certChain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),
         privateKey: "bad data",
       });

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -32,32 +32,11 @@ unitTest(async function connectTLSCertFileNoReadPerm(): Promise<void> {
 
 unitTest(
   { perms: { read: true, net: true } },
-  async function connectTLSClientCertConnection(): Promise<void> {
-    const conn = await Deno.connectTls({
-      hostname: "localhost",
-      port: 4244,
-      certChain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),
-      privateKey: await Deno.readTextFile("cli/tests/tls/localhost.key"),
-      certFile: "cli/tests/tls/RootCA.pem",
-    });
-
-    const reader = new TextProtoReader(new BufReader(conn));
-    const result = await reader.readLine() as string;
-
-    // Server will respond with PASS if client authentication was successful.
-    assertEquals(result, "PASS");
-
-    conn.close();
-  },
-);
-
-unitTest(
-  { perms: { read: true, net: true } },
   async function connectTLSBadClientCertPrivateKey(): Promise<void> {
     await assertThrowsAsync(async () => {
       await Deno.connectTls({
-        hostname: "localhost",
-        port: 4244,
+        hostname: "deno.land",
+        port: 443,
         certChain: "bad data",
         privateKey: await Deno.readTextFile("cli/tests/tls/localhost.key"),
       });
@@ -70,8 +49,8 @@ unitTest(
   async function connectTLSBadClientCertChain(): Promise<void> {
     await assertThrowsAsync(async () => {
       await Deno.connectTls({
-        hostname: "localhost",
-        port: 4244,
+        hostname: "deno.land",
+        port: 443,
         certChain: await Deno.readTextFile("cli/tests/tls/localhost.crt"),
         privateKey: "bad data",
       });

--- a/runtime/js/40_tls.js
+++ b/runtime/js/40_tls.js
@@ -28,12 +28,14 @@
     hostname = "127.0.0.1",
     transport = "tcp",
     certFile = undefined,
+    clientCert = undefined,
   }) {
     const res = await opConnectTls({
       port,
       hostname,
       transport,
       certFile,
+      clientCert,
     });
     return new Conn(res.rid, res.remoteAddr, res.localAddr);
   }

--- a/runtime/js/40_tls.js
+++ b/runtime/js/40_tls.js
@@ -28,14 +28,16 @@
     hostname = "127.0.0.1",
     transport = "tcp",
     certFile = undefined,
-    clientCert = undefined,
+    certChain = undefined,
+    privateKey = undefined
   }) {
     const res = await opConnectTls({
       port,
       hostname,
       transport,
       certFile,
-      clientCert,
+      certChain,
+      privateKey
     });
     return new Conn(res.rid, res.remoteAddr, res.localAddr);
   }

--- a/runtime/js/40_tls.js
+++ b/runtime/js/40_tls.js
@@ -29,7 +29,7 @@
     transport = "tcp",
     certFile = undefined,
     certChain = undefined,
-    privateKey = undefined
+    privateKey = undefined,
   }) {
     const res = await opConnectTls({
       port,
@@ -37,7 +37,7 @@
       transport,
       certFile,
       certChain,
-      privateKey
+      privateKey,
     });
     return new Conn(res.rid, res.remoteAddr, res.localAddr);
   }

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -42,9 +42,10 @@ use std::sync::MutexGuard;
 use std::task::Context;
 use std::task::Poll;
 use tempfile::TempDir;
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
-use tokio_rustls::rustls;
+use tokio_rustls::rustls::{self, Session};
 use tokio_rustls::TlsAcceptor;
 use tokio_tungstenite::accept_async;
 
@@ -57,6 +58,7 @@ const REDIRECT_ABSOLUTE_PORT: u16 = 4550;
 const HTTPS_PORT: u16 = 5545;
 const WS_PORT: u16 = 4242;
 const WSS_PORT: u16 = 4243;
+const TLS_CLIENT_AUTH_PORT: u16 = 4244;
 
 pub const PERMISSION_VARIANTS: [&str; 5] =
   ["read", "write", "env", "net", "run"];
@@ -225,18 +227,28 @@ async fn run_ws_server(addr: &SocketAddr) {
 async fn get_tls_config(
   cert: &str,
   key: &str,
+  ca: &str,
 ) -> io::Result<Arc<rustls::ServerConfig>> {
   let mut cert_path = root_path();
   let mut key_path = root_path();
+  let mut ca_path = root_path();
   cert_path.push(cert);
   key_path.push(key);
+  ca_path.push(ca);
 
   let cert_file = std::fs::File::open(cert_path)?;
   let key_file = std::fs::File::open(key_path)?;
+  let ca_file = std::fs::File::open(ca_path)?;
 
   let mut cert_reader = io::BufReader::new(cert_file);
   let cert = rustls::internal::pemfile::certs(&mut cert_reader)
     .expect("Cannot load certificate");
+
+  let mut ca_cert_reader = io::BufReader::new(ca_file);
+  let ca_cert = rustls::internal::pemfile::certs(&mut ca_cert_reader)
+    .expect("Cannot load CA certificate")
+    .remove(0);
+
   let mut key_reader = io::BufReader::new(key_file);
   let key = {
     let pkcs8_key =
@@ -255,7 +267,12 @@ async fn get_tls_config(
 
   match key {
     Some(key) => {
-      let mut config = rustls::ServerConfig::new(rustls::NoClientAuth::new());
+      let mut root_cert_store = rustls::RootCertStore::empty();
+      root_cert_store.add(&ca_cert).unwrap();
+      // Allow (but do not require) client authentication.
+      let allow_client_auth =
+        rustls::AllowAnyAnonymousOrAuthenticatedClient::new(root_cert_store);
+      let mut config = rustls::ServerConfig::new(allow_client_auth);
       config
         .set_single_cert(cert, key)
         .map_err(|e| {
@@ -274,8 +291,11 @@ async fn get_tls_config(
 async fn run_wss_server(addr: &SocketAddr) {
   let cert_file = "cli/tests/tls/localhost.crt";
   let key_file = "cli/tests/tls/localhost.key";
+  let ca_cert_file = "cli/tests/tls/RootCA.pem";
 
-  let tls_config = get_tls_config(cert_file, key_file).await.unwrap();
+  let tls_config = get_tls_config(cert_file, key_file, ca_cert_file)
+    .await
+    .unwrap();
   let tls_acceptor = TlsAcceptor::from(tls_config);
   let listener = TcpListener::bind(addr).await.unwrap();
 
@@ -297,6 +317,42 @@ async fn run_wss_server(addr: &SocketAddr) {
               .await;
           }
         }
+        Err(e) => {
+          eprintln!("TLS accept error: {:?}", e);
+        }
+      }
+    });
+  }
+}
+
+async fn run_tls_client_auth_server(addr: &SocketAddr) {
+  let cert_file = "cli/tests/tls/localhost.crt";
+  let key_file = "cli/tests/tls/localhost.key";
+  let ca_cert_file = "cli/tests/tls/RootCA.pem";
+
+  let tls_config = get_tls_config(cert_file, key_file, ca_cert_file)
+    .await
+    .unwrap();
+  let tls_acceptor = TlsAcceptor::from(tls_config);
+  let listener = TcpListener::bind(addr).await.unwrap();
+
+  while let Ok((stream, _addr)) = listener.accept().await {
+    let acceptor = tls_acceptor.clone();
+    tokio::spawn(async move {
+      match acceptor.accept(stream).await {
+        Ok(mut tls_stream) => {
+          let (_, tls_session) = tls_stream.get_mut();
+
+          // We only need to check for the presence of client certificates
+          // here. Rusttls ensures that they are valid and signed by the CA.
+          let response = match tls_session.get_peer_certificates() {
+            Some(_certs) => b"PASS",
+            None => b"FAIL",
+          };
+
+          tls_stream.write_all(response).await.unwrap();
+        }
+
         Err(e) => {
           eprintln!("TLS accept error: {:?}", e);
         }
@@ -693,7 +749,8 @@ async fn wrap_main_https_server() {
   let main_server_https_addr = SocketAddr::from(([127, 0, 0, 1], HTTPS_PORT));
   let cert_file = "cli/tests/tls/localhost.crt";
   let key_file = "cli/tests/tls/localhost.key";
-  let tls_config = get_tls_config(cert_file, key_file)
+  let ca_cert_file = "cli/tests/tls/RootCA.pem";
+  let tls_config = get_tls_config(cert_file, key_file, ca_cert_file)
     .await
     .expect("Cannot get TLS config");
   loop {
@@ -747,6 +804,11 @@ pub async fn run_all_servers() {
   let wss_addr = SocketAddr::from(([127, 0, 0, 1], WSS_PORT));
   let wss_server_fut = run_wss_server(&wss_addr);
 
+  let tls_client_auth_addr =
+    SocketAddr::from(([127, 0, 0, 1], TLS_CLIENT_AUTH_PORT));
+  let tls_client_auth_server_fut =
+    run_tls_client_auth_server(&tls_client_auth_addr);
+
   let main_server_fut = wrap_main_server();
   let main_server_https_fut = wrap_main_https_server();
 
@@ -755,6 +817,7 @@ pub async fn run_all_servers() {
       redirect_server_fut,
       ws_server_fut,
       wss_server_fut,
+      tls_client_auth_server_fut,
       another_redirect_server_fut,
       inf_redirects_server_fut,
       double_redirects_server_fut,


### PR DESCRIPTION
Allows specifying a client certificate for mutual TLS in calls to `Deno.connectTls()`.

```typescript
await Deno.connectTls({
  hostname: "example.com",
  port: 443,
  certChain: "-----BEGIN CERTIFICATE-----\n...",
  privateKey: "-----BEGIN PRIVATE KEY-----\n...",
});
```

Some implementation notes:

- The existing `ConnectTlsOptions` parameter `certFile` is confusing when combined with client certificate param `certChain`. Should we pull them into a separate object? Prefix the names with `client`? Open to suggestions.
- The certificate chain and private key are passed in as a string rather than a file path for flexibility (as discussed in https://github.com/denoland/deno/issues/5810). This is inconsistent with the behavior of the existing `certFile` param.
- ~I couldn't think of a great way to unit test that the certificates are actually set properly on the underlying connection, since `Deno.Conn` has no way of exposing the peer's client certificate from the other end of the connection.~

Partially implements https://github.com/denoland/deno/issues/6170