### PR TITLE
fix(lsp): handle type deps properly

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -246,7 +246,7 @@ where
         resolve_import(&desc.specifier, specifier, maybe_import_map);
 
       let maybe_resolved_type_dependency =
-        // Check for `@deno-types` pragmas that effect the import
+        // Check for `@deno-types` pragmas that affect the import
         if let Some(comment) = desc.leading_comments.last() {
           if let Some(deno_types) = parse_deno_types(&comment.text).as_ref() {
             Some(resolve_import(deno_types, specifier, maybe_import_map))

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -279,14 +279,14 @@ pub async fn generate_dependency_diagnostics(
               &dependency.maybe_code_specifier_range,
             ) {
               match code.clone() {
-                ResolvedDependency::Err(message) => {
+                ResolvedDependency::Err(err) => {
                   diagnostic_list.push(lsp::Diagnostic {
                     range: *range,
                     severity: Some(lsp::DiagnosticSeverity::Error),
                     code: None,
                     code_description: None,
                     source: Some("deno".to_string()),
-                    message,
+                    message: format!("{}", err),
                     related_information: None,
                     tags: None,
                     data: None,

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -92,11 +92,15 @@ pub struct DocumentCache {
 }
 
 impl DocumentCache {
-  pub fn analyze_dependencies(
+  pub fn analyze_dependencies<F>(
     &mut self,
     specifier: &ModuleSpecifier,
     maybe_import_map: &Option<ImportMap>,
-  ) -> Result<(), AnyError> {
+    get_maybe_type: &mut F,
+  ) -> Result<(), AnyError>
+  where
+    F: FnMut(&ModuleSpecifier) -> Option<analysis::ResolvedDependency>,
+  {
     if !self.contains(specifier) {
       return Err(custom_error(
         "NotFound",
@@ -114,6 +118,7 @@ impl DocumentCache {
         source,
         &MediaType::from(specifier),
         maybe_import_map,
+        get_maybe_type,
       ) {
         doc.dependencies = Some(dependencies);
       } else {

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -151,14 +151,6 @@ impl DocumentCache {
     doc.line_index.clone()
   }
 
-  pub fn navigation_tree(
-    &self,
-    specifier: &ModuleSpecifier,
-  ) -> Option<NavigationTree> {
-    let doc = self.docs.get(specifier)?;
-    doc.navigation_tree.clone()
-  }
-
   pub fn open(&mut self, specifier: ModuleSpecifier, version: i32, text: &str) {
     self.docs.insert(
       specifier,
@@ -200,22 +192,6 @@ impl DocumentCache {
           "The specifier (\"{}\") does not exist in the document cache.",
           specifier
         ),
-      ))
-    }
-  }
-
-  pub fn set_navigation_tree(
-    &mut self,
-    specifier: &ModuleSpecifier,
-    navigation_tree: NavigationTree,
-  ) -> Result<(), AnyError> {
-    if let Some(mut doc) = self.docs.get_mut(specifier) {
-      doc.navigation_tree = Some(navigation_tree);
-      Ok(())
-    } else {
-      Err(custom_error(
-        "NotFound",
-        "The document \"{}\" was unexpectedly missing.",
       ))
     }
   }

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -82,7 +82,7 @@ pub(crate) struct Inner {
   /// file which will be used by the Deno LSP.
   maybe_config_uri: Option<Url>,
   /// An optional import map which is used to resolve modules.
-  maybe_import_map: Option<ImportMap>,
+  pub maybe_import_map: Option<ImportMap>,
   /// The URL for the import map which is used to determine relative imports.
   maybe_import_map_uri: Option<Url>,
   /// A map of all the cached navigation trees.
@@ -635,10 +635,12 @@ impl Inner {
       params.text_document.version,
       params.text_document.text,
     );
-    if let Err(err) = self
-      .documents
-      .analyze_dependencies(&specifier, &self.maybe_import_map)
-    {
+    let mut sources = self.sources.clone();
+    if let Err(err) = self.documents.analyze_dependencies(
+      &specifier,
+      &self.maybe_import_map,
+      &mut |s| sources.get_maybe_types(s),
+    ) {
       error!("{}", err);
     }
     // there are scenarios where local documents with a nav tree are opened in
@@ -662,10 +664,12 @@ impl Inner {
     ) {
       error!("{}", err);
     }
-    if let Err(err) = self
-      .documents
-      .analyze_dependencies(&specifier, &self.maybe_import_map)
-    {
+    let mut sources = self.sources.clone();
+    if let Err(err) = self.documents.analyze_dependencies(
+      &specifier,
+      &self.maybe_import_map,
+      &mut |s| sources.get_maybe_types(s),
+    ) {
       error!("{}", err);
     }
     self.navigation_trees.remove(&specifier);

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1717,6 +1717,11 @@ impl lspower::LanguageServer for LanguageServer {
     self.0.lock().await.did_change(params).await
   }
 
+  async fn did_save(&self, _params: DidSaveTextDocumentParams) {
+    // We don't need to do anything on save at the moment, but if this isn't
+    // implemented, lspower complains about it not being implemented.
+  }
+
   async fn did_close(&self, params: DidCloseTextDocumentParams) {
     self.0.lock().await.did_close(params).await
   }

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -663,7 +663,7 @@ impl Inner {
     self.documents.open(
       specifier.clone(),
       params.text_document.version,
-      params.text_document.text.clone(),
+      &params.text_document.text,
     );
     self.analyze_dependencies(&specifier, &params.text_document.text);
     self.performance.measure(mark);

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -660,7 +660,6 @@ impl Inner {
       return;
     }
     let specifier = utils::normalize_url(params.text_document.uri);
-    info!("did_open {}", specifier);
     self.documents.open(
       specifier.clone(),
       params.text_document.version,

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -123,6 +123,8 @@ impl Sources {
         }
       }
     }
+    // TODO(@kitsonk) this needs to be refactored, lots of duplicate logic and
+    // is really difficult to follow.
     let version = self.get_script_version(specifier)?;
     let path = self.get_path(specifier)?;
     if let Ok(bytes) = fs::read(path) {
@@ -131,12 +133,13 @@ impl Sources {
         if let Ok(source) = get_source_from_bytes(bytes, Some(charset)) {
           let media_type = MediaType::from(specifier);
           let mut maybe_types = None;
+          let maybe_import_map = self.maybe_import_map.clone();
           let dependencies = if let Some((dependencies, mt)) =
             analysis::analyze_dependencies(
               &specifier,
               &source,
               &media_type,
-              &None,
+              &maybe_import_map,
               &mut |s| self.get_maybe_types(s),
             ) {
             maybe_types = mt;
@@ -174,12 +177,13 @@ impl Sources {
             } else {
               None
             };
+          let maybe_import_map = self.maybe_import_map.clone();
           let dependencies = if let Some((dependencies, mt)) =
             analysis::analyze_dependencies(
               &specifier,
               &source,
               &media_type,
-              &None,
+              &maybe_import_map,
               &mut |s| self.get_maybe_types(s),
             ) {
             if maybe_types.is_none() {

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -140,7 +140,6 @@ impl Sources {
               &source,
               &media_type,
               &maybe_import_map,
-              &mut |s| self.get_maybe_types(s),
             ) {
             maybe_types = mt;
             Some(dependencies)
@@ -184,7 +183,6 @@ impl Sources {
               &source,
               &media_type,
               &maybe_import_map,
-              &mut |s| self.get_maybe_types(s),
             ) {
             if maybe_types.is_none() {
               maybe_types = mt;

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -98,6 +98,14 @@ impl Sources {
     Some(metadata.line_index)
   }
 
+  pub fn get_maybe_types(
+    &mut self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<analysis::ResolvedDependency> {
+    let metadata = self.get_metadata(specifier)?;
+    metadata.maybe_types.clone()
+  }
+
   pub fn get_media_type(
     &mut self,
     specifier: &ModuleSpecifier,
@@ -129,6 +137,7 @@ impl Sources {
               &source,
               &media_type,
               &None,
+              &mut |s| self.get_maybe_types(s),
             ) {
             maybe_types = mt;
             Some(dependencies)
@@ -171,6 +180,7 @@ impl Sources {
               &source,
               &media_type,
               &None,
+              &mut |s| self.get_maybe_types(s),
             ) {
             if maybe_types.is_none() {
               maybe_types = mt;

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -103,7 +103,7 @@ impl Sources {
     specifier: &ModuleSpecifier,
   ) -> Option<analysis::ResolvedDependency> {
     let metadata = self.get_metadata(specifier)?;
-    metadata.maybe_types.clone()
+    metadata.maybe_types
   }
 
   pub fn get_media_type(

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2,6 +2,7 @@
 
 use super::analysis::CodeLensSource;
 use super::analysis::ResolvedDependency;
+use super::analysis::ResolvedDependencyErr;
 use super::language_server;
 use super::language_server::StateSnapshot;
 use super::text;
@@ -1096,7 +1097,7 @@ fn resolve(state: &mut State, args: Value) -> Result<Value, AnyError> {
             } else if let Some(resolved_import) = &dependency.maybe_code {
               resolved_import.clone()
             } else {
-              ResolvedDependency::Err("missing dependency".to_string())
+              ResolvedDependency::Err(ResolvedDependencyErr::Missing)
             };
           if let ResolvedDependency::Resolved(resolved_specifier) =
             resolved_import

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1477,7 +1477,7 @@ mod tests {
     for (specifier, content, version) in sources {
       let specifier = ModuleSpecifier::resolve_url(specifier)
         .expect("failed to create specifier");
-      documents.open(specifier, version, content.to_string());
+      documents.open(specifier, version, content);
     }
     StateSnapshot {
       assets: Default::default(),


### PR DESCRIPTION
Fixes #9425

Once #9408 lands though, we would want to refactor this to just pass the mut ref to the language server to `analyze_dependencies` I suspect in line with other refactors.