### PR TITLE
feat(lsp): add implementations code lens

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -290,6 +290,8 @@ pub fn analyze_dependencies(
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum CodeLensSource {
+  #[serde(rename = "implementations")]
+  Implementations,
   #[serde(rename = "references")]
   References,
 }

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -18,7 +18,10 @@ pub struct ClientCapabilities {
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeLensSettings {
-  /// Flag for providing reference code lens.
+  /// Flag for providing implementation code lenses.
+  #[serde(default)]
+  pub implementations: bool,
+  /// Flag for providing reference code lenses.
   #[serde(default)]
   pub references: bool,
   /// Flag for providing reference code lens on all functions.  For this to have
@@ -47,7 +50,15 @@ impl WorkspaceSettings {
   pub fn enabled_code_lens(&self) -> bool {
     if let Some(code_lens) = &self.code_lens {
       // This should contain all the "top level" code lens references
-      code_lens.references
+      code_lens.implementations || code_lens.references
+    } else {
+      false
+    }
+  }
+
+  pub fn enabled_code_lens_implementations(&self) -> bool {
+    if let Some(code_lens) = &self.code_lens {
+      code_lens.implementations
     } else {
       false
     }

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -501,13 +501,11 @@ impl NavigationTree {
   ) -> lsp::CodeLens {
     let range = if let Some(name_span) = &self.name_span {
       name_span.to_range(line_index)
+    } else if !self.spans.is_empty() {
+      let span = &self.spans[0];
+      span.to_range(line_index)
     } else {
-      if !self.spans.is_empty() {
-        let span = &self.spans[0];
-        span.to_range(line_index)
-      } else {
-        lsp::Range::default()
-      }
+      lsp::Range::default()
     };
     lsp::CodeLens {
       range,

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -499,8 +499,18 @@ impl NavigationTree {
     specifier: &ModuleSpecifier,
     source: &CodeLensSource,
   ) -> lsp::CodeLens {
+    let range = if let Some(name_span) = &self.name_span {
+      name_span.to_range(line_index)
+    } else {
+      if !self.spans.is_empty() {
+        let span = &self.spans[0];
+        span.to_range(line_index)
+      } else {
+        lsp::Range::default()
+      }
+    };
     lsp::CodeLens {
-      range: self.name_span.clone().unwrap().to_range(line_index),
+      range,
       command: None,
       data: Some(json!({
         "specifier": specifier,
@@ -542,6 +552,17 @@ pub struct ImplementationLocation {
   // ImplementationLocation props
   kind: ScriptElementKind,
   display_parts: Vec<SymbolDisplayPart>,
+}
+
+impl ImplementationLocation {
+  pub fn to_location(&self, line_index: &LineIndex) -> lsp::Location {
+    let uri =
+      utils::normalize_file_name(&self.document_span.file_name).unwrap();
+    lsp::Location {
+      uri,
+      range: self.document_span.text_span.to_range(line_index),
+    }
+  }
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/tests/lsp/code_lens_resolve_request_impl.json
+++ b/cli/tests/lsp/code_lens_resolve_request_impl.json
@@ -1,0 +1,21 @@
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "codeLens/resolve",
+  "params": {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 10
+      },
+      "end": {
+        "line": 0,
+        "character": 11
+      }
+    },
+    "data": {
+      "specifier": "file:///a/file.ts",
+      "source": "implementations"
+    }
+  }
+}

--- a/cli/tests/lsp/did_open_notification_cl_impl.json
+++ b/cli/tests/lsp/did_open_notification_cl_impl.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/didOpen",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts",
+      "languageId": "typescript",
+      "version": 1,
+      "text": "interface A {\n  b(): void;\n}\n\nclass B implements A {\n  b() {\n    console.log(\"b\");\n  }\n}\n"
+    }
+  }
+}

--- a/cli/tests/lsp/initialize_request.json
+++ b/cli/tests/lsp/initialize_request.json
@@ -12,6 +12,7 @@
     "initializationOptions": {
       "enable": true,
       "codeLens": {
+        "implementations": true,
         "references": true
       },
       "lint": true,


### PR DESCRIPTION
Requires a client that provides a configuration with the `codeLens.implementations` set to `true` (e.g. denoland/vscode_deno#319)
