### PR TITLE
`cargo publish` step has been removed. So remove the redundant config of fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,7 @@ jobs:
       # Always run master branch builds to completion. This allows the cache to
       # stay mostly up-to-date in situations where a single job fails due to
       # e.g. a flaky test.
-      # Don't fast-fail on tag build because publishing binaries shouldn't be
-      # prevented if 'cargo publish' fails (which can be a false negative).
-      fail-fast: ${{ github.event_name == 'pull_request' || (github.ref !=
-        'refs/heads/master' && !startsWith(github.ref, 'refs/tags/')) }}
+      fail-fast: ${{ github.event_name == 'pull_request' }}
 
     env:
       CARGO_INCREMENTAL: 0


### PR DESCRIPTION
`cargo publish` has been removed in https://github.com/denoland/deno/commit/46d5843f753548415c87f3c8a868bba49c203b92#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f