### PR TITLE
fix(runtime/tls): handle invalid host for connectTls/startTls

### DIFF
--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -20,6 +20,24 @@ unitTest(async function connectTLSNoPerm(): Promise<void> {
   }, Deno.errors.PermissionDenied);
 });
 
+unitTest(
+  { perms: { read: true, net: true } },
+  async function connectTLSInvalidHost(): Promise<void> {
+    const listener = await Deno.listenTls({
+      hostname: "localhost",
+      port: 3567,
+      certFile: "cli/tests/tls/localhost.crt",
+      keyFile: "cli/tests/tls/localhost.key",
+    });
+
+    await assertThrowsAsync(async () => {
+      await Deno.connectTls({ hostname: "127.0.0.1", port: 3567 });
+    }, Error);
+
+    listener.close();
+  },
+);
+
 unitTest(async function connectTLSCertFileNoReadPerm(): Promise<void> {
   await assertThrowsAsync(async () => {
     await Deno.connectTls({

--- a/runtime/ops/tls.rs
+++ b/runtime/ops/tls.rs
@@ -140,8 +140,8 @@ async fn op_start_tls(
   }
 
   let tls_connector = TlsConnector::from(Arc::new(config));
-  let dnsname =
-    DNSNameRef::try_from_ascii_str(&domain).expect("Invalid DNS lookup");
+  let dnsname = DNSNameRef::try_from_ascii_str(&domain)
+    .map_err(|_| generic_error("Invalid DNS lookup"))?;
   let tls_stream = tls_connector.connect(dnsname, tcp_stream).await?;
 
   let rid = {
@@ -202,8 +202,8 @@ async fn op_connect_tls(
     config.root_store.add_pem_file(reader).unwrap();
   }
   let tls_connector = TlsConnector::from(Arc::new(config));
-  let dnsname =
-    DNSNameRef::try_from_ascii_str(&domain).expect("Invalid DNS lookup");
+  let dnsname = DNSNameRef::try_from_ascii_str(&domain)
+    .map_err(|_| generic_error("Invalid DNS lookup"))?;
   let tls_stream = tls_connector.connect(dnsname, tcp_stream).await?;
   let rid = {
     let mut state_ = state.borrow_mut();


### PR DESCRIPTION
Tiny fix, converts a process-killing panic into a standard runtime error.

Before: 
``` console
> await Deno.connectTls({hostname: '8.8.8.8', port: 443})
thread 'main' panicked at 'Invalid DNS lookup: InvalidDNSNameError', runtime/ops/tls.rs:208:45
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Object({"id": Number(2), "error": Object({"code": Number(-32000), "message": String("Execution context was destroyed.")})})', runtime/inspector.rs:978:8
stack backtrace:
...
```

After:
```
> await Deno.connectTls({hostname: '8.8.8.8', port: 443})
Uncaught Error: Invalid DNS lookup
    at processResponse (deno:core/core.js:213:11)
    at Object.jsonOpAsync (deno:core/core.js:230:12)
    at async Object.connectTls (deno:runtime/js/40_tls.js:32:17)
    at async <anonymous>:2:1
```

Fixes #9452.