### PR TITLE
chore: add flag to v8

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -158,6 +158,7 @@ pub unsafe fn v8_init() {
     // See https://github.com/denoland/deno/issues/2544
     "--no-wasm-async-compilation".to_string(),
     "--harmony-top-level-await".to_string(),
+    "--harmony-import-assertions".to_string(),
     "--no-validate-asm".to_string(),
   ];
   v8::V8::set_flags_from_command_line(argv);


### PR DESCRIPTION
When upgrading `rusty_v8` I forgot to slip proper flag 🤦  it's surprising that it didn't panic without it