### PR TITLE
fix(cli/source_map): Don't use file names from source maps

### DIFF
--- a/cli/source_maps.rs
+++ b/cli/source_maps.rs
@@ -110,12 +110,8 @@ pub fn get_orig_position<G: SourceMapGetter>(
   getter: Arc<G>,
 ) -> (String, i64, i64, Option<String>) {
   let maybe_source_map = get_mappings(&file_name, mappings_map, getter.clone());
-  let default_pos = (
-    file_name.clone(),
-    line_number,
-    column_number,
-    source_line.clone(),
-  );
+  let default_pos =
+    (file_name.clone(), line_number, column_number, source_line);
 
   // Lookup expects 0-based line and column numbers, but ours are 1-based.
   let line_number = line_number - 1;

--- a/cli/source_maps.rs
+++ b/cli/source_maps.rs
@@ -3,6 +3,7 @@
 //! This mod provides functions to remap a `JsError` based on a source map.
 
 use deno_core::error::JsError;
+use deno_core::ModuleSpecifier;
 use sourcemap::SourceMap;
 use std::collections::HashMap;
 use std::str;
@@ -109,8 +110,12 @@ pub fn get_orig_position<G: SourceMapGetter>(
   getter: Arc<G>,
 ) -> (String, i64, i64, Option<String>) {
   let maybe_source_map = get_mappings(&file_name, mappings_map, getter.clone());
-  let default_pos =
-    (file_name, line_number, column_number, source_line.clone());
+  let default_pos = (
+    file_name.clone(),
+    line_number,
+    column_number,
+    source_line.clone(),
+  );
 
   // Lookup expects 0-based line and column numbers, but ours are 1-based.
   let line_number = line_number - 1;
@@ -123,7 +128,16 @@ pub fn get_orig_position<G: SourceMapGetter>(
         None => default_pos,
         Some(token) => match token.get_source() {
           None => default_pos,
-          Some(original) => {
+          Some(source_file_name) => {
+            // The `source_file_name` written by tsc in the source map is
+            // sometimes only the basename of the URL, or has unwanted `<`/`>`
+            // around it. Use the `file_name` we get from V8 if
+            // `source_file_name` does not parse as a URL.
+            let file_name = match ModuleSpecifier::resolve_url(source_file_name)
+            {
+              Ok(m) => m.to_string(),
+              Err(_) => file_name,
+            };
             let maybe_source_line =
               if let Some(source_view) = token.get_source_view() {
                 source_view.get_line(token.get_src_line())
@@ -133,18 +147,16 @@ pub fn get_orig_position<G: SourceMapGetter>(
 
             let source_line = if let Some(source_line) = maybe_source_line {
               Some(source_line.to_string())
-            } else if let Some(source_line) = getter.get_source_line(
-              original,
-              // Getter expects 0-based line numbers, but ours are 1-based.
-              token.get_src_line() as usize,
-            ) {
+            } else if let Some(source_line) =
+              getter.get_source_line(&file_name, token.get_src_line() as usize)
+            {
               Some(source_line)
             } else {
-              source_line
+              None
             };
 
             (
-              original.to_string(),
+              file_name,
               i64::from(token.get_src_line()) + 1,
               i64::from(token.get_src_col()) + 1,
               source_line,

--- a/cli/tests/error_026_remote_import_error.ts
+++ b/cli/tests/error_026_remote_import_error.ts
@@ -1,0 +1,1 @@
+import "http://localhost:4545/cli/tests/error_001.ts";

--- a/cli/tests/error_026_remote_import_error.ts.out
+++ b/cli/tests/error_026_remote_import_error.ts.out
@@ -1,0 +1,7 @@
+[WILDCARD]error: Uncaught Error: bad
+  throw Error("bad");
+        ^
+    at foo (http://localhost:4545/cli/tests/error_001.ts:2:9)
+    at bar (http://localhost:4545/cli/tests/error_001.ts:6:3)
+    at http://localhost:4545/cli/tests/error_001.ts:9:1
+[WILDCARD]

--- a/cli/tests/import_data_url_error_stack.ts.out
+++ b/cli/tests/import_data_url_error_stack.ts.out
@@ -1,5 +1,6 @@
-error: Uncaught Error: Hello 2
-    throw new Error(`Hello ${A.C}`);
+[WILDCARD]error: Uncaught Error: Hello 2
+   throw new Error(`Hello ${A.C}`);
          ^
-    at a (72554b3efdc211ba4aa0b62629589f048e7d4afe7b0576f35ff340ce0ea8f9b8.ts:8:10)
-    at import_data_url_error_stack.ts:3:1
+    at a (data:application/typescript;base64,ZW51bSBBIHsKICBBLAogIEIsCiAgQywKIH0KIAogZXhwb3J0IGZ1bmN0aW9uIGEoKSB7CiAgIHRocm93IG5ldyBFcnJvcihgSGVsbG8gJHtBLkN9YCk7CiB9CiA=:8:10)
+    at file:///[WILDCARD]/cli/tests/import_data_url_error_stack.ts:3:1
+[WILDCARD]

--- a/cli/tests/inline_js_source_map_2.js.out
+++ b/cli/tests/inline_js_source_map_2.js.out
@@ -1,4 +1,2 @@
 error: Uncaught Error: Hello world!
-throw new Error("Hello world!");
-      ^
     at http://localhost:4545/cli/tests/inline_js_source_map_2.ts:6:7

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3012,6 +3012,13 @@ console.log("finish");
     exit_code: 1,
   });
 
+  itest!(error_026_remote_import_error {
+    args: "run error_026_remote_import_error.ts",
+    output: "error_026_remote_import_error.ts.out",
+    exit_code: 1,
+    http_server: true,
+  });
+
   itest!(error_missing_module_named_import {
     args: "run --reload error_missing_module_named_import.ts",
     output: "error_missing_module_named_import.ts.out",


### PR DESCRIPTION
Fixes #6542.
Fixes #6965 (again).
Fixes #9443.

`deno run cli/tests/error_026_remote_import_error.ts`

Before:
```
error: Uncaught Error: bad
    throw Error("bad");
        ^
    at foo (error_001.ts:2:9)
    at bar (error_001.ts:6:3)
    at error_001.ts:9:1
```

After:
```
error: Uncaught Error: bad
  throw Error("bad");
        ^
    at foo (http://localhost:4545/cli/tests/error_001.ts:2:9)
    at bar (http://localhost:4545/cli/tests/error_001.ts:6:3)
    at http://localhost:4545/cli/tests/error_001.ts:9:1
```