### PR TITLE
fix(tests) - fix fetchConnectionError test if port 4000 is in use 

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -5,6 +5,7 @@ import {
   assertThrows,
   assertThrowsAsync,
   fail,
+  unimplemented,
   unitTest,
 } from "./test_util.ts";
 
@@ -20,35 +21,40 @@ unitTest({ perms: { net: true } }, async function fetchProtocolError(): Promise<
   );
 });
 
+function findClosedPortInRange(
+  minPort: number,
+  maxPort: number,
+): number | never {
+  let port = minPort;
+
+  // If we hit the return statement of this loop
+  // that means that we did not throw an
+  // AddrInUse error when we executed Deno.listen.
+  while (port < maxPort) {
+    try {
+      const listener = Deno.listen({ port });
+      listener.close();
+      return port;
+    } catch (e) {
+      port++;
+    }
+  }
+
+  unimplemented(
+    `No available ports between ${minPort} and ${maxPort} to test fetch`,
+  );
+}
+
 unitTest(
   { perms: { net: true } },
   async function fetchConnectionError(): Promise<void> {
-    const initialPort = 4000;
-    const maxPort = 9999;
-    let port = initialPort;
-    let portFound = false;
-
-    while (port < maxPort) {
-      try {
-        const listener = Deno.listen({ port });
-        await assertThrowsAsync(
-          async (): Promise<void> => {
-            listener.close();
-            await fetch(`http://localhost:${port}`);
-          },
-          TypeError,
-          "error trying to connect",
-        );
-        portFound = true;
-        break;
-      } catch (e) {
-        port++;
-      }
-    }
-
-    assert(
-      portFound,
-      `No available ports between ${initialPort} and ${maxPort} to test fetch`,
+    const port = findClosedPortInRange(4000, 9999);
+    await assertThrowsAsync(
+      async (): Promise<void> => {
+        await fetch(`http://localhost:${port}`);
+      },
+      TypeError,
+      "error trying to connect",
     );
   },
 );

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -23,12 +23,32 @@ unitTest({ perms: { net: true } }, async function fetchProtocolError(): Promise<
 unitTest(
   { perms: { net: true } },
   async function fetchConnectionError(): Promise<void> {
-    await assertThrowsAsync(
-      async (): Promise<void> => {
-        await fetch("http://localhost:4000");
-      },
-      TypeError,
-      "error trying to connect",
+    const initialPort = 4000;
+    const maxPort = 9999;
+    let port = initialPort;
+    let portFound = false;
+
+    while (port < maxPort) {
+      try {
+        const listener = Deno.listen({ port });
+        await assertThrowsAsync(
+          async (): Promise<void> => {
+            listener.close();
+            await fetch(`http://localhost:${port}`);
+          },
+          TypeError,
+          "error trying to connect",
+        );
+        portFound = true;
+        break;
+      } catch (e) {
+        port++;
+      }
+    }
+
+    assert(
+      portFound,
+      `No available ports between ${initialPort} and ${maxPort} to test fetch`,
     );
   },
 );

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -17,6 +17,7 @@ export {
   assertThrows,
   assertThrowsAsync,
   fail,
+  unimplemented,
   unreachable,
 } from "../../../test_util/std/testing/asserts.ts";
 export { deferred } from "../../../test_util/std/async/deferred.ts";


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/9379

As outlined in that issue, test `fetchConnectionError` assumes that nothing is listening on port 4000. Some users may have something listening on port 4000. To improve test reliability, we check if port 4000 is available by attempting to listen on it. If its not available, we will try the next port up until we find one that is available, or until we hit the maximum port we are willing to try. 

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
