### PR TITLE
feat(lsp): add deno cache code actions

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -434,7 +434,6 @@ pub struct DenoFixData {
 
 #[derive(Debug, Clone)]
 enum CodeActionKind {
-  #[allow(unused)]
   Deno(lsp::CodeAction),
   Tsc(lsp::CodeAction, tsc::CodeFixAction),
 }

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -11,6 +11,7 @@ use crate::media_type::MediaType;
 
 use deno_core::error::AnyError;
 use deno_core::serde_json;
+use deno_core::serde_json::json;
 use deno_core::ModuleSpecifier;
 use lspower::lsp;
 use std::collections::HashMap;
@@ -279,14 +280,14 @@ pub async fn generate_dependency_diagnostics(
               &dependency.maybe_code_specifier_range,
             ) {
               match code.clone() {
-                ResolvedDependency::Err(err) => {
+                ResolvedDependency::Err(dependency_err) => {
                   diagnostic_list.push(lsp::Diagnostic {
                     range: *range,
                     severity: Some(lsp::DiagnosticSeverity::Error),
-                    code: None,
+                    code: Some(dependency_err.as_code()),
                     code_description: None,
                     source: Some("deno".to_string()),
-                    message: format!("{}", err),
+                    message: format!("{}", dependency_err),
                     related_information: None,
                     tags: None,
                     data: None,
@@ -295,20 +296,23 @@ pub async fn generate_dependency_diagnostics(
                 ResolvedDependency::Resolved(specifier) => {
                   if !(state_snapshot.documents.contains(&specifier) || sources.contains(&specifier)) {
                     let is_local = specifier.as_url().scheme() == "file";
+                    let (code, message) = if is_local {
+                      (Some(lsp::NumberOrString::String("no-local".to_string())), format!("Unable to load a local module: \"{}\".\n  Please check the file path.", specifier))
+                    } else {
+                      (Some(lsp::NumberOrString::String("no-cache".to_string())), format!("Unable to load the remote module: \"{}\".", specifier))
+                    };
                     diagnostic_list.push(lsp::Diagnostic {
                       range: *range,
                       severity: Some(lsp::DiagnosticSeverity::Error),
-                      code: None,
+                      code,
                       code_description: None,
                       source: Some("deno".to_string()),
-                      message: if is_local {
-                        format!("Unable to load a local module: \"{}\".\n  Please check the file path.", specifier)
-                      } else {
-                        format!("Unable to load the module: \"{}\".\n  If the module exists, running `deno cache {}` should resolve this error.", specifier, specifier)
-                      },
+                      message,
                       related_information: None,
                       tags: None,
-                      data: None,
+                      data: Some(json!({
+                        "specifier": specifier
+                      })),
                     })
                   }
                 },

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -937,7 +937,7 @@ impl Inner {
     for diagnostic in &fixable_diagnostics {
       match diagnostic.source.as_deref() {
         Some("deno-ts") => {
-          let code = match &diagnostic.code.clone().unwrap() {
+          let code = match diagnostic.code.as_ref().unwrap() {
             NumberOrString::String(code) => code.to_string(),
             NumberOrString::Number(code) => code.to_string(),
           };

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -149,14 +149,6 @@ impl Inner {
         if dep.maybe_type.is_none() {
           if let Some(ResolvedDependency::Resolved(resolved)) = &dep.maybe_code
           {
-            let maybe_type = self.sources.get_maybe_types(resolved);
-            if let Some(ResolvedDependency::Resolved(maybe_type_specifier)) =
-              &maybe_type
-            {
-              // this hydrates the sources for the `maybe_types` specifier, as it
-              // might not have been retrieved yet
-              self.sources.contains(maybe_type_specifier);
-            }
             dep.maybe_type = self.sources.get_maybe_types(resolved);
           }
         }
@@ -199,7 +191,7 @@ impl Inner {
   /// Only searches already cached assets and documents for a line index.  If
   /// the line index cannot be found, `None` is returned.
   fn get_line_index_sync(
-    &mut self,
+    &self,
     specifier: &ModuleSpecifier,
   ) -> Option<LineIndex> {
     let mark = self.performance.mark("get_line_index_sync");
@@ -524,7 +516,7 @@ impl Inner {
   }
 
   pub(crate) fn document_version(
-    &mut self,
+    &self,
     specifier: ModuleSpecifier,
   ) -> Option<i32> {
     self.documents.version(&specifier)
@@ -861,7 +853,7 @@ impl Inner {
     }
   }
 
-  async fn hover(&mut self, params: HoverParams) -> LspResult<Option<Hover>> {
+  async fn hover(&self, params: HoverParams) -> LspResult<Option<Hover>> {
     if !self.enabled() {
       return Ok(None);
     }
@@ -1367,7 +1359,7 @@ impl Inner {
   }
 
   async fn document_highlight(
-    &mut self,
+    &self,
     params: DocumentHighlightParams,
   ) -> LspResult<Option<Vec<DocumentHighlight>>> {
     if !self.enabled() {
@@ -1505,7 +1497,7 @@ impl Inner {
   }
 
   async fn completion(
-    &mut self,
+    &self,
     params: CompletionParams,
   ) -> LspResult<Option<CompletionResponse>> {
     if !self.enabled() {

--- a/cli/lsp/performance.rs
+++ b/cli/lsp/performance.rs
@@ -129,7 +129,7 @@ impl Performance {
   /// measurement to the internal buffer.
   pub fn measure(&self, mark: PerformanceMark) -> Duration {
     let measure = PerformanceMeasure::from(mark);
-    let duration = measure.duration.clone();
+    let duration = measure.duration;
     let mut measures = self.measures.lock().unwrap();
     measures.push_back(measure);
     while measures.len() > self.max_size {

--- a/cli/lsp/performance.rs
+++ b/cli/lsp/performance.rs
@@ -49,7 +49,7 @@ impl From<PerformanceMark> for PerformanceMeasure {
 ///
 /// The structure will limit the size of measurements to the most recent 1000,
 /// and will roll off when that limit is reached.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Performance {
   counts: Arc<Mutex<HashMap<String, u32>>>,
   max_size: usize,
@@ -127,13 +127,15 @@ impl Performance {
   /// A function which accepts a previously created performance mark which will
   /// be used to finalize the duration of the span being measured, and add the
   /// measurement to the internal buffer.
-  pub fn measure(&self, mark: PerformanceMark) {
+  pub fn measure(&self, mark: PerformanceMark) -> Duration {
     let measure = PerformanceMeasure::from(mark);
+    let duration = measure.duration.clone();
     let mut measures = self.measures.lock().unwrap();
     measures.push_back(measure);
     while measures.len() > self.max_size {
       measures.pop_front();
     }
+    duration
   }
 }
 

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -314,18 +314,16 @@ impl Inner {
     specifier: &ModuleSpecifier,
   ) -> Option<String> {
     let path = self.get_path(specifier)?;
-    if let Ok(metadata) = fs::metadata(path) {
-      if let Ok(modified) = metadata.modified() {
-        return if let Ok(n) = modified.duration_since(SystemTime::UNIX_EPOCH) {
-          Some(format!("{}", n.as_millis()))
-        } else {
-          Some("1".to_string())
-        };
+    let metadata = fs::metadata(path).ok()?;
+    if let Ok(modified) = metadata.modified() {
+      if let Ok(n) = modified.duration_since(SystemTime::UNIX_EPOCH) {
+        Some(format!("{}", n.as_millis()))
       } else {
-        return Some("1".to_string());
+        Some("1".to_string())
       }
+    } else {
+      Some("1".to_string())
     }
-    None
   }
 
   fn get_text(&mut self, specifier: &ModuleSpecifier) -> Option<String> {

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -51,7 +51,7 @@ struct Metadata {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct Sources {
+struct Inner {
   http_cache: HttpCache,
   maybe_import_map: Option<ImportMap>,
   metadata: HashMap<ModuleSpecifier, Metadata>,
@@ -59,15 +59,80 @@ pub struct Sources {
   remotes: HashMap<ModuleSpecifier, PathBuf>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct Sources(Arc<Mutex<Inner>>);
+
 impl Sources {
   pub fn new(location: &Path) -> Self {
+    Self(Arc::new(Mutex::new(Inner::new(location))))
+  }
+
+  pub fn contains(&self, specifier: &ModuleSpecifier) -> bool {
+    self.0.lock().unwrap().contains(specifier)
+  }
+
+  pub fn get_length_utf16(&self, specifier: &ModuleSpecifier) -> Option<usize> {
+    self.0.lock().unwrap().get_length_utf16(specifier)
+  }
+
+  pub fn get_line_index(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<LineIndex> {
+    self.0.lock().unwrap().get_line_index(specifier)
+  }
+
+  pub fn get_maybe_types(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<analysis::ResolvedDependency> {
+    self.0.lock().unwrap().get_maybe_types(specifier)
+  }
+
+  pub fn get_media_type(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<MediaType> {
+    self.0.lock().unwrap().get_media_type(specifier)
+  }
+
+  pub fn get_script_version(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<String> {
+    self.0.lock().unwrap().get_script_version(specifier)
+  }
+
+  pub fn get_text(&self, specifier: &ModuleSpecifier) -> Option<String> {
+    self.0.lock().unwrap().get_text(specifier)
+  }
+
+  pub fn resolve_import(
+    &self,
+    specifier: &str,
+    referrer: &ModuleSpecifier,
+  ) -> Option<(ModuleSpecifier, MediaType)> {
+    self.0.lock().unwrap().resolve_import(specifier, referrer)
+  }
+
+  #[cfg(test)]
+  fn resolve_specifier(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<ModuleSpecifier> {
+    self.0.lock().unwrap().resolve_specifier(specifier)
+  }
+}
+
+impl Inner {
+  fn new(location: &Path) -> Self {
     Self {
       http_cache: HttpCache::new(location),
       ..Default::default()
     }
   }
 
-  pub fn contains(&mut self, specifier: &ModuleSpecifier) -> bool {
+  fn contains(&mut self, specifier: &ModuleSpecifier) -> bool {
     if let Some(specifier) = self.resolve_specifier(specifier) {
       if self.get_metadata(&specifier, true).is_some() {
         return true;
@@ -80,16 +145,13 @@ impl Sources {
   /// match the behavior of JavaScript, where strings are stored effectively as
   /// `&[u16]` and when counting "chars" we need to represent the string as a
   /// UTF-16 string in Rust.
-  pub fn get_length_utf16(
-    &mut self,
-    specifier: &ModuleSpecifier,
-  ) -> Option<usize> {
+  fn get_length_utf16(&mut self, specifier: &ModuleSpecifier) -> Option<usize> {
     let specifier = self.resolve_specifier(specifier)?;
     let metadata = self.get_metadata(&specifier, false)?;
     Some(metadata.source.encode_utf16().count())
   }
 
-  pub fn get_line_index(
+  fn get_line_index(
     &mut self,
     specifier: &ModuleSpecifier,
   ) -> Option<LineIndex> {
@@ -98,7 +160,7 @@ impl Sources {
     Some(metadata.line_index)
   }
 
-  pub fn get_maybe_types(
+  fn get_maybe_types(
     &mut self,
     specifier: &ModuleSpecifier,
   ) -> Option<analysis::ResolvedDependency> {
@@ -106,7 +168,7 @@ impl Sources {
     metadata.maybe_types
   }
 
-  pub fn get_media_type(
+  fn get_media_type(
     &mut self,
     specifier: &ModuleSpecifier,
   ) -> Option<MediaType> {
@@ -260,7 +322,7 @@ impl Sources {
     None
   }
 
-  pub fn get_script_version(
+  fn get_script_version(
     &mut self,
     specifier: &ModuleSpecifier,
   ) -> Option<String> {
@@ -279,7 +341,7 @@ impl Sources {
     None
   }
 
-  pub fn get_text(&mut self, specifier: &ModuleSpecifier) -> Option<String> {
+  fn get_text(&mut self, specifier: &ModuleSpecifier) -> Option<String> {
     let specifier = self.resolve_specifier(specifier)?;
     let metadata = self.get_metadata(&specifier, true)?;
     Some(metadata.source)
@@ -299,7 +361,7 @@ impl Sources {
     Some((resolved_specifier, media_type))
   }
 
-  pub fn resolve_import(
+  fn resolve_import(
     &mut self,
     specifier: &str,
     referrer: &ModuleSpecifier,
@@ -395,7 +457,7 @@ mod tests {
 
   #[test]
   fn test_sources_get_script_version() {
-    let (mut sources, _) = setup();
+    let (sources, _) = setup();
     let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let tests = c.join("tests");
     let specifier = ModuleSpecifier::resolve_path(
@@ -408,7 +470,7 @@ mod tests {
 
   #[test]
   fn test_sources_get_text() {
-    let (mut sources, _) = setup();
+    let (sources, _) = setup();
     let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let tests = c.join("tests");
     let specifier = ModuleSpecifier::resolve_path(
@@ -423,7 +485,7 @@ mod tests {
 
   #[test]
   fn test_sources_get_length_utf16() {
-    let (mut sources, _) = setup();
+    let (sources, _) = setup();
     let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let tests = c.join("tests");
     let specifier = ModuleSpecifier::resolve_path(
@@ -438,7 +500,7 @@ mod tests {
 
   #[test]
   fn test_sources_resolve_specifier_non_supported_schema() {
-    let (mut sources, _) = setup();
+    let (sources, _) = setup();
     let specifier = ModuleSpecifier::resolve_url("foo://a/b/c.ts")
       .expect("could not create specifier");
     let actual = sources.resolve_specifier(&specifier);

--- a/cli/tests/lsp/code_action_request_cache.json
+++ b/cli/tests/lsp/code_action_request_cache.json
@@ -1,0 +1,46 @@
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "textDocument/codeAction",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts"
+    },
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 19
+      },
+      "end": {
+        "line": 0,
+        "character": 49
+      }
+    },
+    "context": {
+      "diagnostics": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 19
+            },
+            "end": {
+              "line": 0,
+              "character": 49
+            }
+          },
+          "severity": 1,
+          "code": "no-cache",
+          "source": "deno",
+          "message": "Unable to load the remote module: \"https://deno.land/x/a/mod.ts\".",
+          "data": {
+            "specifier": "https://deno.land/x/a/mod.ts"
+          }
+        }
+      ],
+      "only": [
+        "quickfix"
+      ]
+    }
+  }
+}

--- a/cli/tests/lsp/code_action_response_cache.json
+++ b/cli/tests/lsp/code_action_response_cache.json
@@ -1,0 +1,36 @@
+[
+  {
+    "title": "Cache \"https://deno.land/x/a/mod.ts\" and its dependencies.",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 19
+          },
+          "end": {
+            "line": 0,
+            "character": 49
+          }
+        },
+        "severity": 1,
+        "code": "no-cache",
+        "source": "deno",
+        "message": "Unable to load the remote module: \"https://deno.land/x/a/mod.ts\".",
+        "data": {
+          "specifier": "https://deno.land/x/a/mod.ts"
+        }
+      }
+    ],
+    "command": {
+      "title": "",
+      "command": "deno.cache",
+      "arguments": [
+        [
+          "https://deno.land/x/a/mod.ts"
+        ]
+      ]
+    }
+  }
+]

--- a/cli/tests/lsp/did_open_notification_cache.json
+++ b/cli/tests/lsp/did_open_notification_cache.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/didOpen",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts",
+      "languageId": "typescript",
+      "version": 1,
+      "text": "import * as a from \"https://deno.land/x/a/mod.ts\";\n\nconsole.log(a);\n"
+    }
+  }
+}


### PR DESCRIPTION
This PR also fixes a performance regression when accessing cached modules by creating an inner lock on the `Sources` struct.

It also instruments the tsc ops (which helped isolate the performance regression).

@bnoordhuis I tried to figure any easy way to not introduce an arc mutex for sources, but I really can't see a way.  We can't pass a clone of the arc mutex of the language server for the "snapshot" and I also tried just arc mutex'ing parts of sources, but I quickly ended up in deadlocks, it seems that only locking an inner in sources is the only way to avoid it.

Trying to chase down all the places where we might modify/hydrate the data in sources is really difficult, because we might become "aware" of needing to look in the Deno cache at several different points, and actually it is far more efficient to lazily hydrate that cache at the point where the module needs to be accessed.