### PR TITLE
Fix deno_std dead link

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -15,8 +15,8 @@ It's built on V8, Rust, and Tokio.
   formatter (`deno fmt`).
 - Has
   [a set of reviewed (audited) standard
-  modules](https://github.com/denoland/deno_std) that are guaranteed
-  to work with Deno.
+  modules](https://github.com/denoland/deno_std) that are guaranteed to work
+  with Deno.
 - Scripts can be bundled into a single JavaScript file.
 
 ## Philosophy

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -15,7 +15,7 @@ It's built on V8, Rust, and Tokio.
   formatter (`deno fmt`).
 - Has
   [a set of reviewed (audited) standard
-  modules](https://github.com/denoland/deno/tree/master/std) that are guaranteed
+  modules](https://github.com/denoland/deno_std) that are guaranteed
   to work with Deno.
 - Scripts can be bundled into a single JavaScript file.
 


### PR DESCRIPTION
Hi, noticed a dead link when browsing the manual.