### PR TITLE
fix(lsp): handle  cached type dependencies properly

### DIFF
--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -67,7 +67,7 @@ impl DiskCache {
           out.push(path_seg);
         }
       }
-      "http" | "https" | "data" => out = url_to_filename(url),
+      "http" | "https" | "data" => out = url_to_filename(url)?,
       "file" => {
         let path = match url.to_file_path() {
           Ok(path) => path,

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -338,7 +338,12 @@ impl FileFetcher {
     bytes: Vec<u8>,
     headers: &HashMap<String, String>,
   ) -> Result<File, AnyError> {
-    let local = self.http_cache.get_cache_filename(specifier.as_url());
+    let local = self
+      .http_cache
+      .get_cache_filename(specifier.as_url())
+      .ok_or(generic_error(
+        "Cannot convert specifier to cached filename.",
+      ))?;
     let maybe_content_type = headers.get("content-type").cloned();
     let (media_type, maybe_charset) =
       map_content_type(specifier, maybe_content_type);
@@ -416,7 +421,12 @@ impl FileFetcher {
 
     let (source, media_type, content_type) =
       get_source_from_data_url(specifier)?;
-    let local = self.http_cache.get_cache_filename(specifier.as_url());
+    let local = self
+      .http_cache
+      .get_cache_filename(specifier.as_url())
+      .ok_or(generic_error(
+        "Cannot convert specifier to cached filename.",
+      ))?;
     let mut headers = HashMap::new();
     headers.insert("content-type".to_string(), content_type);
     self
@@ -995,7 +1005,8 @@ mod tests {
 
     let cache_filename = file_fetcher
       .http_cache
-      .get_cache_filename(specifier.as_url());
+      .get_cache_filename(specifier.as_url())
+      .unwrap();
     let mut metadata =
       crate::http_cache::Metadata::read(&cache_filename).unwrap();
     metadata.headers = HashMap::new();
@@ -1079,7 +1090,8 @@ mod tests {
     .unwrap();
     let cache_filename = file_fetcher_01
       .http_cache
-      .get_cache_filename(specifier.as_url());
+      .get_cache_filename(specifier.as_url())
+      .unwrap();
 
     let result = file_fetcher_01
       .fetch(&specifier, &Permissions::allow_all())
@@ -1128,14 +1140,16 @@ mod tests {
     .unwrap();
     let cached_filename = file_fetcher
       .http_cache
-      .get_cache_filename(specifier.as_url());
+      .get_cache_filename(specifier.as_url())
+      .unwrap();
     let redirected_specifier = ModuleSpecifier::resolve_url(
       "http://localhost:4545/cli/tests/subdir/redirects/redirect1.js",
     )
     .unwrap();
     let redirected_cached_filename = file_fetcher
       .http_cache
-      .get_cache_filename(redirected_specifier.as_url());
+      .get_cache_filename(redirected_specifier.as_url())
+      .unwrap();
 
     let result = file_fetcher
       .fetch(&specifier, &Permissions::allow_all())
@@ -1179,21 +1193,24 @@ mod tests {
     .unwrap();
     let cached_filename = file_fetcher
       .http_cache
-      .get_cache_filename(specifier.as_url());
+      .get_cache_filename(specifier.as_url())
+      .unwrap();
     let redirected_01_specifier = ModuleSpecifier::resolve_url(
       "http://localhost:4546/cli/tests/subdir/redirects/redirect1.js",
     )
     .unwrap();
     let redirected_01_cached_filename = file_fetcher
       .http_cache
-      .get_cache_filename(redirected_01_specifier.as_url());
+      .get_cache_filename(redirected_01_specifier.as_url())
+      .unwrap();
     let redirected_02_specifier = ModuleSpecifier::resolve_url(
       "http://localhost:4545/cli/tests/subdir/redirects/redirect1.js",
     )
     .unwrap();
     let redirected_02_cached_filename = file_fetcher
       .http_cache
-      .get_cache_filename(redirected_02_specifier.as_url());
+      .get_cache_filename(redirected_02_specifier.as_url())
+      .unwrap();
 
     let result = file_fetcher
       .fetch(&specifier, &Permissions::allow_all())
@@ -1265,7 +1282,8 @@ mod tests {
     .unwrap();
     let redirected_cache_filename = file_fetcher_01
       .http_cache
-      .get_cache_filename(redirected_specifier.as_url());
+      .get_cache_filename(redirected_specifier.as_url())
+      .unwrap();
 
     let result = file_fetcher_01
       .fetch(&specifier, &Permissions::allow_all())
@@ -1340,14 +1358,16 @@ mod tests {
     .unwrap();
     let cached_filename = file_fetcher
       .http_cache
-      .get_cache_filename(specifier.as_url());
+      .get_cache_filename(specifier.as_url())
+      .unwrap();
     let redirected_specifier = ModuleSpecifier::resolve_url(
       "http://localhost:4550/cli/tests/subdir/redirects/redirect1.js",
     )
     .unwrap();
     let redirected_cached_filename = file_fetcher
       .http_cache
-      .get_cache_filename(redirected_specifier.as_url());
+      .get_cache_filename(redirected_specifier.as_url())
+      .unwrap();
 
     let result = file_fetcher
       .fetch(&specifier, &Permissions::allow_all())

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -341,9 +341,9 @@ impl FileFetcher {
     let local = self
       .http_cache
       .get_cache_filename(specifier.as_url())
-      .ok_or(generic_error(
-        "Cannot convert specifier to cached filename.",
-      ))?;
+      .ok_or_else(|| {
+        generic_error("Cannot convert specifier to cached filename.")
+      })?;
     let maybe_content_type = headers.get("content-type").cloned();
     let (media_type, maybe_charset) =
       map_content_type(specifier, maybe_content_type);
@@ -424,9 +424,9 @@ impl FileFetcher {
     let local = self
       .http_cache
       .get_cache_filename(specifier.as_url())
-      .ok_or(generic_error(
-        "Cannot convert specifier to cached filename.",
-      ))?;
+      .ok_or_else(|| {
+        generic_error("Cannot convert specifier to cached filename.")
+      })?;
     let mut headers = HashMap::new();
     headers.insert("content-type".to_string(), content_type);
     self

--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -142,7 +142,7 @@ impl HttpCache {
   pub fn get(&self, url: &Url) -> Result<(File, HeadersMap), AnyError> {
     let cache_filename = self.location.join(
       url_to_filename(url)
-        .ok_or(generic_error("Can't convert url to filename."))?,
+        .ok_or_else(|| generic_error("Can't convert url to filename."))?,
     );
     let metadata_filename = Metadata::filename(&cache_filename);
     let file = File::open(cache_filename)?;
@@ -159,7 +159,7 @@ impl HttpCache {
   ) -> Result<(), AnyError> {
     let cache_filename = self.location.join(
       url_to_filename(url)
-        .ok_or(generic_error("Can't convert url to filename."))?,
+        .ok_or_else(|| generic_error("Can't convert url to filename."))?,
     );
     // Create parent directory
     let parent_filename = cache_filename

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1946,8 +1946,8 @@ impl Inner {
           }
         }
         _ => {
-          if let Some(text) = self.sources.get_text(&specifier) {
-            Some(text)
+          if let Some(source) = self.sources.get_source(&specifier) {
+            Some(source)
           } else {
             error!("The cached sources was not found: {}", specifier);
             None

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -493,15 +493,38 @@ mod tests {
   fn test_resolve_dependency_types() {
     let (sources, location) = setup();
     let cache = HttpCache::new(&location);
-    let specifier_dep = ModuleSpecifier::resolve_url("https://deno.land/x/mod.ts").unwrap();
-    cache.set(specifier_dep.as_url(), Default::default(), b"export * from \"https://deno.land/x/lib.js\";").unwrap();
-    let specifier_code = ModuleSpecifier::resolve_url("https://deno.land/x/lib.js").unwrap();
+    let specifier_dep =
+      ModuleSpecifier::resolve_url("https://deno.land/x/mod.ts").unwrap();
+    cache
+      .set(
+        specifier_dep.as_url(),
+        Default::default(),
+        b"export * from \"https://deno.land/x/lib.js\";",
+      )
+      .unwrap();
+    let specifier_code =
+      ModuleSpecifier::resolve_url("https://deno.land/x/lib.js").unwrap();
     let mut headers_code = HashMap::new();
-    headers_code.insert("x-typescript-types".to_string(), "./lib.d.ts".to_string());
-    cache.set(specifier_code.as_url(), headers_code, b"export const a = 1;").unwrap();
-    let specifier_type = ModuleSpecifier::resolve_url("https://deno.land/x/lib.d.ts").unwrap();
-    cache.set(specifier_type.as_url(), Default::default(), b"export const a: number;").unwrap();
-    let actual = sources.resolve_import("https://deno.land/x/lib.js", &specifier_dep);
+    headers_code
+      .insert("x-typescript-types".to_string(), "./lib.d.ts".to_string());
+    cache
+      .set(
+        specifier_code.as_url(),
+        headers_code,
+        b"export const a = 1;",
+      )
+      .unwrap();
+    let specifier_type =
+      ModuleSpecifier::resolve_url("https://deno.land/x/lib.d.ts").unwrap();
+    cache
+      .set(
+        specifier_type.as_url(),
+        Default::default(),
+        b"export const a: number;",
+      )
+      .unwrap();
+    let actual =
+      sources.resolve_import("https://deno.land/x/lib.js", &specifier_dep);
     assert_eq!(actual, Some((specifier_type, MediaType::Dts)))
   }
 

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -490,6 +490,22 @@ mod tests {
   }
 
   #[test]
+  fn test_resolve_dependency_types() {
+    let (sources, location) = setup();
+    let cache = HttpCache::new(&location);
+    let specifier_dep = ModuleSpecifier::resolve_url("https://deno.land/x/mod.ts").unwrap();
+    cache.set(specifier_dep.as_url(), Default::default(), b"export * from \"https://deno.land/x/lib.js\";").unwrap();
+    let specifier_code = ModuleSpecifier::resolve_url("https://deno.land/x/lib.js").unwrap();
+    let mut headers_code = HashMap::new();
+    headers_code.insert("x-typescript-types".to_string(), "./lib.d.ts".to_string());
+    cache.set(specifier_code.as_url(), headers_code, b"export const a = 1;").unwrap();
+    let specifier_type = ModuleSpecifier::resolve_url("https://deno.land/x/lib.d.ts").unwrap();
+    cache.set(specifier_type.as_url(), Default::default(), b"export const a: number;").unwrap();
+    let actual = sources.resolve_import("https://deno.land/x/lib.js", &specifier_dep);
+    assert_eq!(actual, Some((specifier_type, MediaType::Dts)))
+  }
+
+  #[test]
   fn test_sources_resolve_specifier_non_supported_schema() {
     let (sources, _) = setup();
     let specifier = ModuleSpecifier::resolve_url("foo://a/b/c.ts")

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1117,8 +1117,7 @@ fn get_text(state: &mut State, args: Value) -> Result<Value, AnyError> {
         .unwrap()
         .clone()
     } else {
-      let sources = &mut state.state_snapshot.sources;
-      sources.get_text(&specifier).unwrap()
+      state.state_snapshot.sources.get_source(&specifier).unwrap()
     };
   state.state_snapshot.performance.measure(mark);
   Ok(json!(text::slice(&content, v.start..v.end)))
@@ -1208,6 +1207,7 @@ fn resolve(state: &mut State, args: Value) -> Result<Value, AnyError> {
     ));
   }
 
+  info!("{} {}", referrer, json!(resolved));
   state.state_snapshot.performance.measure(mark);
   Ok(json!(resolved))
 }

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1207,7 +1207,6 @@ fn resolve(state: &mut State, args: Value) -> Result<Value, AnyError> {
     ));
   }
 
-  info!("{} {}", referrer, json!(resolved));
   state.state_snapshot.performance.measure(mark);
   Ok(json!(resolved))
 }


### PR DESCRIPTION
@lucacasonato this fixes the issue you have encountered where transitive type dependencies are not handled properly, causing incorrect diagnostics until the affected dependency is opened in the editor.

I still need to work on a test, though it is actually quite complicated to recreate in the test harness.