### PR TITLE
docs: Use JSONC code block for commenting

### DIFF
--- a/docs/getting_started/setup_your_environment.md
+++ b/docs/getting_started/setup_your_environment.md
@@ -167,7 +167,7 @@ page, first `npm install --save-dev typescript-deno-plugin typescript` in your
 project (`npm init -y` as necessary), then add the following block to your
 `tsconfig.json` and you are off to the races!
 
-```json
+```jsonc
 {
   "compilerOptions": {
     "plugins": [
@@ -238,7 +238,7 @@ endif
   syntax highlighting
 - Add the following `.sublime-project` file to your project folder
 
-```json
+```jsonc
 {
   "settings": {
     "LSP": {

--- a/docs/linking_to_external_code/import_maps.md
+++ b/docs/linking_to_external_code/import_maps.md
@@ -42,9 +42,9 @@ $ deno run --import-map=import_map.json --unstable color.ts
 
 To use starting directory for absolute imports:
 
-```json
-// import_map.json
+**import_map.json**
 
+```jsonc
 {
   "imports": {
     "/": "./"
@@ -52,17 +52,17 @@ To use starting directory for absolute imports:
 }
 ```
 
-```ts
-// main.ts
+**main.ts**
 
+```ts
 import { MyUtil } from "/util.ts";
 ```
 
 You may map a different directory: (eg. src)
 
-```json
-// import_map.json
+**import_map.json**
 
+```jsonc
 {
   "imports": {
     "/": "./src/"


### PR DESCRIPTION
I found that some code blocks on docs are rendered as invalid syntax because of commenting to JSON.
For example [this one](https://github.com/denoland/deno/blob/master/docs/getting_started/setup_your_environment.md#emacs).

I marked those blocks as ~JSON5~ JSONC for better syntax highlighting.