### PR TITLE
refactor(lsp): don't hold inner state lock

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -402,14 +402,14 @@ fn is_preferred(
 
 /// Convert changes returned from a TypeScript quick fix action into edits
 /// for an LSP CodeAction.
-pub(crate) async fn ts_changes_to_edit(
+pub(crate) fn ts_changes_to_edit(
   changes: &[tsc::FileTextChanges],
-  language_server: &mut language_server::Inner,
+  state: &language_server::LanguageServerState,
 ) -> Result<Option<lsp::WorkspaceEdit>, AnyError> {
   let mut text_document_edits = Vec::new();
   for change in changes {
     let text_document_edit =
-      change.to_text_document_edit(language_server).await?;
+      change.to_text_document_edit(state)?;
     text_document_edits.push(text_document_edit);
   }
   Ok(Some(lsp::WorkspaceEdit {
@@ -482,11 +482,11 @@ impl CodeActionCollection {
   }
 
   /// Add a TypeScript code fix action to the code actions collection.
-  pub(crate) async fn add_ts_fix_action(
+  pub(crate) fn add_ts_fix_action(
     &mut self,
     action: &tsc::CodeFixAction,
     diagnostic: &lsp::Diagnostic,
-    language_server: &mut language_server::Inner,
+    state: &language_server::LanguageServerState,
   ) -> Result<(), AnyError> {
     if action.commands.is_some() {
       // In theory, tsc can return actions that require "commands" to be applied
@@ -501,7 +501,7 @@ impl CodeActionCollection {
         "The action returned from TypeScript is unsupported.",
       ));
     }
-    let edit = ts_changes_to_edit(&action.changes, language_server).await?;
+    let edit = ts_changes_to_edit(&action.changes, state)?;
     let code_action = lsp::CodeAction {
       title: action.description.clone(),
       kind: Some(lsp::CodeActionKind::QUICKFIX),

--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -408,8 +408,7 @@ pub(crate) fn ts_changes_to_edit(
 ) -> Result<Option<lsp::WorkspaceEdit>, AnyError> {
   let mut text_document_edits = Vec::new();
   for change in changes {
-    let text_document_edit =
-      change.to_text_document_edit(state)?;
+    let text_document_edit = change.to_text_document_edit(state)?;
     text_document_edits.push(text_document_edit);
   }
   Ok(Some(lsp::WorkspaceEdit {

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -15,7 +15,7 @@ pub struct ClientCapabilities {
   pub workspace_did_change_watched_files: bool,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeLensSettings {
   /// Flag for providing implementation code lenses.
@@ -30,7 +30,7 @@ pub struct CodeLensSettings {
   pub references_all_functions: bool,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceSettings {
   pub enable: bool,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -539,7 +539,7 @@ impl LanguageServerState {
     let mark = self.performance.mark("get_line_index");
     let maybe_line_index = if specifier.scheme() == "asset" {
       if let Some(asset) = self.assets.get(specifier) {
-        Some(asset.line_index.clone())
+        Some(asset.line_index)
       } else {
         None
       }
@@ -1914,14 +1914,15 @@ impl lspower::LanguageServer for LanguageServer {
         Some(Ok(params)) => {
           let state = self.state.lock().unwrap();
           Ok(Some(
-            serde_json::to_value(state.virtual_text_document(params)?)
-              .map_err(|err| {
+            serde_json::to_value(state.virtual_text_document(params)).map_err(
+              |err| {
                 error!(
                   "Failed to serialize virtual_text_document response: {}",
                   err
                 );
                 LspError::internal_error()
-              })?,
+              },
+            )?,
           ))
         }
         Some(Err(err)) => Err(LspError::invalid_params(err.to_string())),
@@ -2021,7 +2022,7 @@ impl LanguageServerState {
   fn virtual_text_document(
     &self,
     params: VirtualTextDocumentParams,
-  ) -> LspResult<Option<String>> {
+  ) -> Option<String> {
     let mark = self.performance.mark("virtual_text_document");
     let specifier = self.url_map.normalize_url(&params.text_document.uri);
     let contents = if specifier.as_str() == "deno:/status.md" {
@@ -2063,7 +2064,7 @@ impl LanguageServerState {
       }
     };
     self.performance.measure(mark);
-    Ok(contents)
+    contents
   }
 }
 

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1189,7 +1189,7 @@ fn get_text(state: &mut State, args: Value) -> Result<Value, AnyError> {
   let specifier = resolve_url(&v.specifier)?;
   let content =
     if let Some(content) = state.state_snapshot.assets.get(&specifier) {
-      content.text.clone()
+      content.text
     } else if state.state_snapshot.documents.contains_key(&specifier) {
       cache_snapshot(state, v.specifier.clone(), v.version.clone())?;
       state

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -577,7 +577,7 @@ impl ImplementationLocation {
     }
   }
 
-  pub(crate) async fn to_link(
+  pub(crate) fn to_link(
     &self,
     line_index: &LineIndex,
     state: &mut language_server::LanguageServerState,
@@ -691,7 +691,7 @@ pub struct DefinitionInfoAndBoundSpan {
 }
 
 impl DefinitionInfoAndBoundSpan {
-  pub(crate) async fn to_definition(
+  pub(crate) fn to_definition(
     &self,
     line_index: &LineIndex,
     state: &mut language_server::LanguageServerState,

--- a/cli/tsc/compiler.d.ts
+++ b/cli/tsc/compiler.d.ts
@@ -43,7 +43,7 @@ declare global {
   type LanguageServerRequest =
     | ConfigureRequest
     | FindRenameLocationsRequest
-    | GetAsset
+    | GetAssets
     | GetCodeFixes
     | GetCombinedCodeFix
     | GetCompletionsRequest
@@ -77,9 +77,8 @@ declare global {
     providePrefixAndSuffixTextForRename: boolean;
   }
 
-  interface GetAsset extends BaseLanguageServerRequest {
-    method: "getAsset";
-    specifier: string;
+  interface GetAssets extends BaseLanguageServerRequest {
+    method: "getAssets";
   }
 
   interface GetCodeFixes extends BaseLanguageServerRequest {


### PR DESCRIPTION
This PR aims to make the LSP fully asynchronous again by no longer holding a
global mutex for the entire duration of a request, and instead holding that
mutex only while the inner data needs to be accessed. We retain the single mutex
for all state though, because we want to prevent the lsp from deadlocking if
multiple operations try to lock a set of mutexes in a different order.

This PR is split into three commits for your reviewing pleasure:

- **refactor(lsp): hydrate assets cache on startup**
  This commit replaces the on demand hydration of the assets cache with a
  single hydration when the LSP is started. This results in slightly increased
  baseline memory usage (a few MB), but it makes `get_line_index` synchronous
  which greatly simplifies the next commit.

- **refactor(lsp): don't hold inner state lock**
  This commit splits the LSP into two very distinct parts: the `LanguageServer`
  struct which holds the LSP client, the TS Server, and an arc mutex of the
  `LanguageServerState`. The `LanguageServerState` contains all of the LSP's
  state. It should only be accessed from one thread at once, and should not be
  held across await points. If you need a `Send`able version of the state, you
  need to use `StateSnapshot`. This PR refactors a lot of code to hold the
  conform with the model that `LanguageServerState` should not be held across
  await points anymore (to not hold the lock during async tasks).
  
- **refactor(lsp): switch to std::sync::Mutex**
  This final commit moves from a `tokio::sync::Mutex` to a `std::sync::Mutex`.
  This enforces the above rule that `LanguageServerState` (or more precisely the
  `MutexGuard`) may not be held across await points. This makes sure we don't
  fall back to this behaviour in the future.
