### PR TITLE
refactor(core): cleanup module implementation

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -246,7 +246,7 @@ pub extern "C" fn host_initialize_import_meta_object_callback(
 
   let module_global = v8::Global::new(scope, module);
   let info = state
-    .modules
+    .module_map
     .get_info(&module_global)
     .expect("Module not found");
 
@@ -794,7 +794,7 @@ pub fn module_resolve_callback<'s>(
 
   let referrer_global = v8::Global::new(scope, referrer);
   let referrer_info = state
-    .modules
+    .module_map
     .get_info(&referrer_global)
     .expect("ModuleInfo not found");
   let referrer_name = referrer_info.name.to_string();
@@ -811,8 +811,8 @@ pub fn module_resolve_callback<'s>(
     )
     .expect("Module should have been already resolved");
 
-  if let Some(id) = state.modules.get_id(resolved_specifier.as_str()) {
-    if let Some(handle) = state.modules.get_handle(id) {
+  if let Some(id) = state.module_map.get_id(resolved_specifier.as_str()) {
+    if let Some(handle) = state.module_map.get_handle(id) {
       return Some(v8::Local::new(scope, handle));
     }
   }

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -419,6 +419,8 @@ impl ModuleMap {
     }
   }
 
+  /// Get module id, following all aliases in case of module specifier
+  /// that had been redirected.
   pub fn get_id(&self, name: &str) -> Option<ModuleId> {
     let mut mod_name = name;
     loop {

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -400,7 +400,7 @@ enum SymbolicModule {
 
 /// A collection of JS modules.
 #[derive(Default)]
-pub struct Modules {
+pub struct ModuleMap {
   ids_by_handle: HashMap<v8::Global<v8::Module>, ModuleId>,
   handles_by_id: HashMap<ModuleId, v8::Global<v8::Module>>,
   info: HashMap<ModuleId, ModuleInfo>,
@@ -408,8 +408,8 @@ pub struct Modules {
   next_module_id: ModuleId,
 }
 
-impl Modules {
-  pub fn new() -> Modules {
+impl ModuleMap {
+  pub fn new() -> ModuleMap {
     Self {
       handles_by_id: HashMap::new(),
       ids_by_handle: HashMap::new(),
@@ -699,7 +699,7 @@ mod tests {
 
     let state_rc = JsRuntime::state(runtime.v8_isolate());
     let state = state_rc.borrow();
-    let modules = &state.modules;
+    let modules = &state.module_map;
     assert_eq!(modules.get_id("file:///a.js"), Some(a_id));
     let b_id = modules.get_id("file:///b.js").unwrap();
     let c_id = modules.get_id("file:///c.js").unwrap();
@@ -766,7 +766,7 @@ mod tests {
 
       let state_rc = JsRuntime::state(runtime.v8_isolate());
       let state = state_rc.borrow();
-      let modules = &state.modules;
+      let modules = &state.module_map;
 
       assert_eq!(modules.get_id("file:///circular1.js"), Some(circular1_id));
       let circular2_id = modules.get_id("file:///circular2.js").unwrap();
@@ -838,7 +838,7 @@ mod tests {
 
       let state_rc = JsRuntime::state(runtime.v8_isolate());
       let state = state_rc.borrow();
-      let modules = &state.modules;
+      let modules = &state.module_map;
 
       assert_eq!(modules.get_id("file:///redirect1.js"), Some(redirect1_id));
 
@@ -984,7 +984,7 @@ mod tests {
 
     let state_rc = JsRuntime::state(runtime.v8_isolate());
     let state = state_rc.borrow();
-    let modules = &state.modules;
+    let modules = &state.module_map;
 
     assert_eq!(modules.get_id("file:///main_with_code.js"), Some(main_id));
     let b_id = modules.get_id("file:///b.js").unwrap();

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -734,15 +734,11 @@ impl JsRuntime {
   /// `AnyError` can be downcast to a type that exposes additional information
   /// about the V8 exception. By default this type is `JsError`, however it may
   /// be a different type if `RuntimeOptions::js_error_create_fn` has been set.
-  fn mod_instantiate(
-    &mut self,
-    id: ModuleId,
-  ) -> Result<(), AnyError> {
+  fn mod_instantiate(&mut self, id: ModuleId) -> Result<(), AnyError> {
     let state_rc = Self::state(self.v8_isolate());
     let context = self.global_context();
 
-    let scope =
-        &mut v8::HandleScope::with_context(self.v8_isolate(), context);
+    let scope = &mut v8::HandleScope::with_context(self.v8_isolate(), context);
     let tc_scope = &mut v8::TryCatch::new(scope);
 
     let module = state_rc
@@ -757,8 +753,8 @@ impl JsRuntime {
       exception_to_err_result(tc_scope, exception, false)
         .map_err(|err| attach_handle_to_error(tc_scope, err, exception))
     } else {
-      let instantiate_result = module
-        .instantiate_module(tc_scope, bindings::module_resolve_callback);
+      let instantiate_result =
+        module.instantiate_module(tc_scope, bindings::module_resolve_callback);
       match instantiate_result {
         Some(_) => Ok(()),
         None => {
@@ -846,10 +842,6 @@ impl JsRuntime {
       } else {
         assert!(status == v8::ModuleStatus::Errored);
       }
-    }
-
-    if status == v8::ModuleStatus::Evaluated {
-      self.dyn_import_done(load_id, id);
     }
 
     Ok(())


### PR DESCRIPTION
* remove "ModuleNameMap", instead define that map inline inside "Modules" struct
* remove "dyn_import_id" argument from "mod_instantiate"
* rename "Modules" struct to "ModuleMap"
* rename "JsRuntime::modules" to "JsRuntime::module_map"

More PRs to follow