### PR TITLE
fix(runtime): Fix runtime panic caused by Deno.env.set("", "")

### DIFF
--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -32,6 +32,14 @@ unitTest({ perms: { env: true } }, function avoidEmptyNamedEnv(): void {
   assertThrows(() => Deno.env.set("a=a", "v"), TypeError);
   assertThrows(() => Deno.env.set("a\0a", "v"), TypeError);
   assertThrows(() => Deno.env.set("TEST_VAR", "v\0v"), TypeError);
+
+  assertThrows(() => Deno.env.get(""), TypeError);
+  assertThrows(() => Deno.env.get("a=a"), TypeError);
+  assertThrows(() => Deno.env.get("a\0a"), TypeError);
+
+  assertThrows(() => Deno.env.delete(""), TypeError);
+  assertThrows(() => Deno.env.delete("a=a"), TypeError);
+  assertThrows(() => Deno.env.delete("a\0a"), TypeError);
 });
 
 unitTest(function envPermissionDenied1(): void {

--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -27,6 +27,14 @@ unitTest({ perms: { env: true } }, function deleteEnv(): void {
   assertEquals(Deno.env.get("TEST_VAR"), undefined);
 });
 
+unitTest({ perms: { env: true } }, function avoidEmptyNamedEnv(): void {
+  Deno.env.set("", "v");
+  Deno.env.set("a=a", "v");
+  Deno.env.set("a\0a", "v");
+  Deno.env.set("TEST_VAR", "v\0v");
+  assertEquals(Deno.env.get("TEST_VAR"), undefined);
+});
+
 unitTest(function envPermissionDenied1(): void {
   assertThrows(() => {
     Deno.env.toObject();

--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -28,11 +28,10 @@ unitTest({ perms: { env: true } }, function deleteEnv(): void {
 });
 
 unitTest({ perms: { env: true } }, function avoidEmptyNamedEnv(): void {
-  Deno.env.set("", "v");
-  Deno.env.set("a=a", "v");
-  Deno.env.set("a\0a", "v");
-  Deno.env.set("TEST_VAR", "v\0v");
-  assertEquals(Deno.env.get("TEST_VAR"), undefined);
+  assertThrows(() => Deno.env.set("", "v"), TypeError);
+  assertThrows(() => Deno.env.set("a=a", "v"), TypeError);
+  assertThrows(() => Deno.env.set("a\0a", "v"), TypeError);
+  assertThrows(() => Deno.env.set("TEST_VAR", "v\0v"), TypeError);
 });
 
 unitTest(function envPermissionDenied1(): void {

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -57,7 +57,7 @@ fn op_set_env(
   state.borrow::<Permissions>().check_env()?;
   let invalid_key =
     args.key.is_empty() || args.key.contains(&['=', '\0'] as &[char]);
-  let invalid_value = args.value.contains('\x00');
+  let invalid_value = args.value.contains('\0');
   if invalid_key || invalid_value {
     return Err(type_error("Key or value contains invalid characters."));
   }

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -8,7 +8,6 @@ use deno_core::serde_json::Value;
 use deno_core::url::Url;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
-use regex::Regex;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
@@ -88,6 +87,9 @@ fn op_get_env(
 ) -> Result<Value, AnyError> {
   let args: GetEnv = serde_json::from_value(args)?;
   state.borrow::<Permissions>().check_env()?;
+  if args.key.is_empty() || args.key.contains(&['=', '\0'] as &[char]) {
+    return Err(type_error("Key contains invalid characters."));
+  }
   let r = match env::var(args.key) {
     Err(env::VarError::NotPresent) => json!([]),
     v => json!([v?]),
@@ -107,6 +109,9 @@ fn op_delete_env(
 ) -> Result<Value, AnyError> {
   let args: DeleteEnv = serde_json::from_value(args)?;
   state.borrow::<Permissions>().check_env()?;
+  if args.key.is_empty() || args.key.contains(&['=', '\0'] as &[char]) {
+    return Err(type_error("Key contains invalid characters."));
+  }
   env::remove_var(args.key);
   Ok(json!({}))
 }

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -56,9 +56,8 @@ fn op_set_env(
 ) -> Result<Value, AnyError> {
   let args: SetEnv = serde_json::from_value(args)?;
   state.borrow::<Permissions>().check_env()?;
-  let key_not_support_re = Regex::new(r"=|\x00").unwrap();
   let invalid_key =
-    args.key.is_empty() || key_not_support_re.is_match(&args.key);
+    args.key.is_empty() || args.key.contains(&['=', '\0'] as &[char]);
   let invalid_value = args.value.contains('\x00');
   if invalid_key || invalid_value {
     return Err(type_error("Key or value contains invalid characters."));

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -59,7 +59,7 @@ fn op_set_env(
   let key_not_support_re = Regex::new(r"=|\x00").unwrap();
   let is_valid_key =
     !args.key.is_empty() && !key_not_support_re.is_match(&args.key);
-  let is_valid_value = !args.value.contains("\x00");
+  let is_valid_value = !args.value.contains('\x00');
   if is_valid_key && is_valid_value {
     env::set_var(args.key, args.value);
   }

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -61,7 +61,7 @@ fn op_set_env(
     args.key.is_empty() || key_not_support_re.is_match(&args.key);
   let invalid_value = args.value.contains('\x00');
   if invalid_key || invalid_value {
-    return Err(type_error("Key or value contains unsupported charactors"));
+    return Err(type_error("Key or value contains invalid characters."));
   }
   env::set_var(args.key, args.value);
   Ok(json!({}))


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Fixes #9558

This PR added the validation for `std::env::set_var`. According to [doc](https://doc.rust-lang.org/std/env/fn.set_var.html#panics), the key doesn't support `""`, `"="`, and `"\0"` and the value also doesn't support `"\0"`. Therefore `Deno.env.set("", "")` is causing panics.

And also added the same validatoins to `env::var` and `env::remove_var`.