### PR TITLE
chore(core): error builder instead of error class

### DIFF
--- a/cli/tests/059_fs_relative_path_perm.ts.out
+++ b/cli/tests/059_fs_relative_path_perm.ts.out
@@ -1,4 +1,4 @@
 [WILDCARD]error: Uncaught PermissionDenied: read access to "non-existent", run again with the --allow-read flag
-    throw new ErrorClass(res.err.message);
-          ^
+      (msg) => new errors.PermissionDenied(msg),
+               ^
     at [WILDCARD]

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -729,7 +729,7 @@ delete Object.prototype.__proto__;
 
   // Setup the compiler runtime during the build process.
   core.ops();
-  core.registerErrorClass("Error", Error);
+  core.registerErrorBuilder("Error", (msg) => new Error(msg));
 
   // A build time only op that provides some setup information that is used to
   // ensure the snapshot is setup properly.

--- a/cli/tsc/compiler.d.ts
+++ b/cli/tsc/compiler.d.ts
@@ -37,7 +37,7 @@ declare global {
     jsonOpSync<T>(name: string, params: T): any;
     ops(): void;
     print(msg: string, code?: number): void;
-    registerErrorClass(name: string, Ctor: typeof Error): void;
+    registerErrorBuilder(name: string, builder: (msg: string) => any): void;
   }
 
   type LanguageServerRequest =

--- a/cli/tsc/compiler.d.ts
+++ b/cli/tsc/compiler.d.ts
@@ -37,6 +37,7 @@ declare global {
     jsonOpSync<T>(name: string, params: T): any;
     ops(): void;
     print(msg: string, code?: number): void;
+    // deno-lint-ignore no-explicit-any
     registerErrorBuilder(name: string, builder: (msg: string) => any): void;
   }
 

--- a/core/core.js
+++ b/core/core.js
@@ -174,14 +174,14 @@ SharedQueue Binary Layout
     return send(opsCache[opName], control, ...zeroCopy);
   }
 
-  function registerErrorClass(errorName, className) {
+  function registerErrorBuilder(errorName, builder) {
     if (typeof errorMap[errorName] !== "undefined") {
-      throw new TypeError(`Error class for "${errorName}" already registered`);
+      throw new TypeError(`Error builder for "${errorName}" already registered`);
     }
-    errorMap[errorName] = className;
+    errorMap[errorName] = builder;
   }
 
-  function getErrorClass(errorName) {
+  function getErrorBuilder(errorName) {
     return errorMap[errorName];
   }
 
@@ -203,13 +203,13 @@ SharedQueue Binary Layout
     if ("ok" in res) {
       return res.ok;
     }
-    const ErrorClass = getErrorClass(res.err.className);
-    if (!ErrorClass) {
+    const errorBuilder = getErrorBuilder(res.err.className);
+    if (!errorBuilder) {
       throw new Error(
-        `Unregistered error class: "${res.err.className}"\n  ${res.err.message}\n  Classes of errors returned from ops should be registered via Deno.core.registerErrorClass().`,
+        `Unregistered error builder: "${res.err.className}"\n  ${res.err.message}\n  Builders for errors returned from ops should be registered via Deno.core.registerErrorBuilder().`,
       );
     }
-    throw new ErrorClass(res.err.message);
+    throw errorBuilder(res.err.message);
   }
 
   async function jsonOpAsync(opName, args = null, ...zeroCopy) {
@@ -261,8 +261,8 @@ SharedQueue Binary Layout
     ops,
     close,
     resources,
-    registerErrorClass,
-    getErrorClass,
+    registerErrorBuilder,
+    getErrorBuilder,
     sharedQueueInit: init,
     // sharedQueue is private but exposed for testing.
     sharedQueue: {

--- a/core/core.js
+++ b/core/core.js
@@ -176,7 +176,9 @@ SharedQueue Binary Layout
 
   function registerErrorBuilder(errorName, builder) {
     if (typeof errorMap[errorName] !== "undefined") {
-      throw new TypeError(`Error builder for "${errorName}" already registered`);
+      throw new TypeError(
+        `Error builder for "${errorName}" already registered`,
+      );
     }
     errorMap[errorName] = builder;
   }

--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -81,9 +81,9 @@ function print(value) {
   Deno.core.dispatchByName('op_print', Deno.core.encode(value.toString()), _newline);
 }
 
-// Finally we register the error class used by op_sum
-// so that it throws the correct class.
-Deno.core.registerErrorClass('Error', Error);
+// Finally we register the error builder used by op_sum
+// so that it throws the correct error class.
+Deno.core.registerErrorBuilder('Error', (msg) => new Error(msg));
 "#,
   ).unwrap();
 

--- a/core/examples/http_bench_json_ops.js
+++ b/core/examples/http_bench_json_ops.js
@@ -57,7 +57,7 @@ async function serve(rid) {
 
 async function main() {
   Deno.core.ops();
-  Deno.core.registerErrorClass("Error", Error);
+  Deno.core.registerErrorBuilder("Error", (msg) => new Error(msg));
 
   const listenerRid = listen();
   Deno.core.print(`http_bench_json_ops listening on http://127.0.0.1:4544/\n`);

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -71,7 +71,7 @@ pub use crate::ops::OpTable;
 pub use crate::resources::Resource;
 pub use crate::resources::ResourceId;
 pub use crate::resources::ResourceTable;
-pub use crate::runtime::GetErrorClassFn;
+pub use crate::runtime::GetErrorBuilderFn;
 pub use crate::runtime::JsErrorCreateFn;
 pub use crate::runtime::JsRuntime;
 pub use crate::runtime::RuntimeOptions;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -5,7 +5,7 @@ use crate::error::type_error;
 use crate::error::AnyError;
 use crate::gotham_state::GothamState;
 use crate::resources::ResourceTable;
-use crate::runtime::GetErrorClassFn;
+use crate::runtime::GetErrorBuilderFn;
 use crate::BufVec;
 use crate::ZeroCopyBuf;
 use futures::Future;
@@ -40,7 +40,7 @@ pub enum Op {
 pub struct OpState {
   pub resource_table: ResourceTable,
   pub op_table: OpTable,
-  pub get_error_class_fn: GetErrorClassFn,
+  pub get_error_class_fn: GetErrorBuilderFn,
   gotham_state: GothamState,
 }
 
@@ -221,7 +221,7 @@ where
 fn json_serialize_op_result<R: Serialize>(
   promise_id: Option<u64>,
   result: Result<R, AnyError>,
-  get_error_class_fn: crate::runtime::GetErrorClassFn,
+  get_error_class_fn: crate::runtime::GetErrorBuilderFn,
 ) -> Box<[u8]> {
   let value = match result {
     Ok(v) => serde_json::json!({ "ok": v, "promiseId": promise_id }),

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -54,7 +54,7 @@ pub enum Snapshot {
 
 pub type JsErrorCreateFn = dyn Fn(JsError) -> AnyError;
 
-pub type GetErrorClassFn =
+pub type GetErrorBuilderFn =
   &'static dyn for<'e> Fn(&'e AnyError) -> &'static str;
 
 /// Objects that need to live as long as the isolate
@@ -171,7 +171,7 @@ pub struct RuntimeOptions {
 
   /// Allows to map error type to a string "class" used to represent
   /// error in JavaScript.
-  pub get_error_class_fn: Option<GetErrorClassFn>,
+  pub get_error_class_fn: Option<GetErrorBuilderFn>,
 
   /// Implementation of `ModuleLoader` which will be
   /// called when V8 requests to load ES modules.

--- a/runtime/js/10_dispatch_minimal.js
+++ b/runtime/js/10_dispatch_minimal.js
@@ -51,13 +51,13 @@
 
   function unwrapResponse(res) {
     if (res.err != null) {
-      const ErrorClass = core.getErrorClass(res.err.className);
-      if (!ErrorClass) {
+      const errorBuilder = core.getErrorBuilder(res.err.className);
+      if (!errorBuilder) {
         throw new Error(
-          `Unregistered error class: "${res.err.className}"\n  ${res.err.message}\n  Classes of errors returned from ops should be registered via Deno.core.registerErrorClass().`,
+          `Unregistered error builder: "${res.err.className}"\n  ${res.err.message}\n  Builders for errors returned from ops should be registered via Deno.core.registerErrorBuilder().`,
         );
       }
-      throw new ErrorClass(res.err.message);
+      throw errorBuilder(res.err.message);
     }
     return res.result;
   }

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -170,31 +170,73 @@ delete Object.prototype.__proto__;
   }
 
   function registerErrors() {
-    core.registerErrorClass("NotFound", errors.NotFound);
-    core.registerErrorClass("PermissionDenied", errors.PermissionDenied);
-    core.registerErrorClass("ConnectionRefused", errors.ConnectionRefused);
-    core.registerErrorClass("ConnectionReset", errors.ConnectionReset);
-    core.registerErrorClass("ConnectionAborted", errors.ConnectionAborted);
-    core.registerErrorClass("NotConnected", errors.NotConnected);
-    core.registerErrorClass("AddrInUse", errors.AddrInUse);
-    core.registerErrorClass("AddrNotAvailable", errors.AddrNotAvailable);
-    core.registerErrorClass("BrokenPipe", errors.BrokenPipe);
-    core.registerErrorClass("AlreadyExists", errors.AlreadyExists);
-    core.registerErrorClass("InvalidData", errors.InvalidData);
-    core.registerErrorClass("TimedOut", errors.TimedOut);
-    core.registerErrorClass("Interrupted", errors.Interrupted);
-    core.registerErrorClass("WriteZero", errors.WriteZero);
-    core.registerErrorClass("UnexpectedEof", errors.UnexpectedEof);
-    core.registerErrorClass("BadResource", errors.BadResource);
-    core.registerErrorClass("Http", errors.Http);
-    core.registerErrorClass("Busy", errors.Busy);
-    core.registerErrorClass("NotSupported", errors.NotSupported);
-    core.registerErrorClass("Error", Error);
-    core.registerErrorClass("RangeError", RangeError);
-    core.registerErrorClass("ReferenceError", ReferenceError);
-    core.registerErrorClass("SyntaxError", SyntaxError);
-    core.registerErrorClass("TypeError", TypeError);
-    core.registerErrorClass("URIError", URIError);
+    core.registerErrorBuilder("NotFound", (msg) => new errors.NotFound(msg));
+    core.registerErrorBuilder(
+      "PermissionDenied",
+      (msg) => new errors.PermissionDenied(msg),
+    );
+    core.registerErrorBuilder(
+      "ConnectionRefused",
+      (msg) => new errors.ConnectionRefused(msg),
+    );
+    core.registerErrorBuilder(
+      "ConnectionReset",
+      (msg) => new errors.ConnectionReset(),
+    );
+    core.registerErrorBuilder(
+      "ConnectionAborted",
+      (msg) => new errors.ConnectionAborted(),
+    );
+    core.registerErrorBuilder(
+      "NotConnected",
+      (msg) => new errors.NotConnected(),
+    );
+    core.registerErrorBuilder("AddrInUse", (msg) => new errors.AddrInUse(msg));
+    core.registerErrorBuilder(
+      "AddrNotAvailable",
+      (msg) => new errors.AddrNotAvailable(msg),
+    );
+    core.registerErrorBuilder(
+      "BrokenPipe",
+      (msg) => new errors.BrokenPipe(msg),
+    );
+    core.registerErrorBuilder(
+      "AlreadyExists",
+      (msg) => new errors.AlreadyExists(msg),
+    );
+    core.registerErrorBuilder(
+      "InvalidData",
+      (msg) => new errors.InvalidData(msg),
+    );
+    core.registerErrorBuilder("TimedOut", (msg) => new errors.TimedOut(msg));
+    core.registerErrorBuilder(
+      "Interrupted",
+      (msg) => new errors.Interrupted(msg),
+    );
+    core.registerErrorBuilder("WriteZero", (msg) => new errors.WriteZero(msg));
+    core.registerErrorBuilder(
+      "UnexpectedEof",
+      (msg) => new errors.UnexpectedEof(msg),
+    );
+    core.registerErrorBuilder(
+      "BadResource",
+      (msg) => new errors.BadResource(msg),
+    );
+    core.registerErrorBuilder("Http", (msg) => new errors.Http(msg));
+    core.registerErrorBuilder("Busy", (msg) => new errors.Busy(msg));
+    core.registerErrorBuilder(
+      "NotSupported",
+      (msg) => new errors.NotSupported(msg),
+    );
+    core.registerErrorBuilder("Error", (msg) => new Error(msg));
+    core.registerErrorBuilder("RangeError", (msg) => new RangeError(msg));
+    core.registerErrorBuilder(
+      "ReferenceError",
+      (msg) => new ReferenceError(msg),
+    );
+    core.registerErrorBuilder("SyntaxError", (msg) => new SyntaxError(msg));
+    core.registerErrorBuilder("TypeError", (msg) => new TypeError(msg));
+    core.registerErrorBuilder("URIError", (msg) => new URIError(msg));
   }
 
   // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -18,7 +18,7 @@ use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::url::Url;
 use deno_core::v8;
-use deno_core::GetErrorClassFn;
+use deno_core::GetErrorBuilderFn;
 use deno_core::JsErrorCreateFn;
 use deno_core::JsRuntime;
 use deno_core::ModuleLoader;
@@ -154,7 +154,7 @@ pub struct WebWorkerOptions {
   pub ts_version: String,
   /// Sets `Deno.noColor` in JS runtime.
   pub no_color: bool,
-  pub get_error_class_fn: Option<GetErrorClassFn>,
+  pub get_error_class_fn: Option<GetErrorBuilderFn>,
 }
 
 impl WebWorker {

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -13,7 +13,7 @@ use deno_core::futures::future::FutureExt;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::url::Url;
-use deno_core::GetErrorClassFn;
+use deno_core::GetErrorBuilderFn;
 use deno_core::JsErrorCreateFn;
 use deno_core::JsRuntime;
 use deno_core::ModuleId;
@@ -62,7 +62,7 @@ pub struct WorkerOptions {
   pub ts_version: String,
   /// Sets `Deno.noColor` in JS runtime.
   pub no_color: bool,
-  pub get_error_class_fn: Option<GetErrorClassFn>,
+  pub get_error_class_fn: Option<GetErrorBuilderFn>,
   pub location: Option<Url>,
 }
 


### PR DESCRIPTION
This PR moves core away from the concept of error classes, towards a
concept of error builders. These builders are simple functions that can
return any error value. This is needed for WebGPU, where many errors
are `DOMExceptions` that take two parameters, the message and the error
type. Currently we have no way to create errors that take more than one
paramterer.
