### PR TITLE
chore(core): optional args for registerErrorClass

### DIFF
--- a/cli/tests/059_fs_relative_path_perm.ts.out
+++ b/cli/tests/059_fs_relative_path_perm.ts.out
@@ -1,4 +1,4 @@
 [WILDCARD]error: Uncaught PermissionDenied: read access to "non-existent", run again with the --allow-read flag
-    throw new ErrorClass(res.err.message);
+    throw new ErrorClass(res.err.message, ...args);
           ^
     at [WILDCARD]

--- a/cli/tsc/compiler.d.ts
+++ b/cli/tsc/compiler.d.ts
@@ -37,7 +37,12 @@ declare global {
     jsonOpSync<T>(name: string, params: T): any;
     ops(): void;
     print(msg: string, code?: number): void;
-    registerErrorClass(name: string, Ctor: typeof Error): void;
+    registerErrorClass(
+      name: string,
+      Ctor: typeof Error,
+      // deno-lint-ignore no-explicit-any
+      ...args: any[]
+    ): void;
   }
 
   type LanguageServerRequest =

--- a/core/core.js
+++ b/core/core.js
@@ -174,15 +174,15 @@ SharedQueue Binary Layout
     return send(opsCache[opName], control, ...zeroCopy);
   }
 
-  function registerErrorClass(errorName, className) {
+  function registerErrorClass(errorName, className, args) {
     if (typeof errorMap[errorName] !== "undefined") {
       throw new TypeError(`Error class for "${errorName}" already registered`);
     }
-    errorMap[errorName] = className;
+    errorMap[errorName] = [className, args ?? []];
   }
 
-  function getErrorClass(errorName) {
-    return errorMap[errorName];
+  function getErrorClassAndArgs(errorName) {
+    return errorMap[errorName] ?? [undefined, []];
   }
 
   // Returns Uint8Array
@@ -203,13 +203,13 @@ SharedQueue Binary Layout
     if ("ok" in res) {
       return res.ok;
     }
-    const ErrorClass = getErrorClass(res.err.className);
+    const [ErrorClass, args] = getErrorClassAndArgs(res.err.className);
     if (!ErrorClass) {
       throw new Error(
         `Unregistered error class: "${res.err.className}"\n  ${res.err.message}\n  Classes of errors returned from ops should be registered via Deno.core.registerErrorClass().`,
       );
     }
-    throw new ErrorClass(res.err.message);
+    throw new ErrorClass(res.err.message, ...args);
   }
 
   async function jsonOpAsync(opName, args = null, ...zeroCopy) {
@@ -262,7 +262,7 @@ SharedQueue Binary Layout
     close,
     resources,
     registerErrorClass,
-    getErrorClass,
+    getErrorClassAndArgs,
     sharedQueueInit: init,
     // sharedQueue is private but exposed for testing.
     sharedQueue: {

--- a/runtime/js/10_dispatch_minimal.js
+++ b/runtime/js/10_dispatch_minimal.js
@@ -51,13 +51,13 @@
 
   function unwrapResponse(res) {
     if (res.err != null) {
-      const ErrorClass = core.getErrorClass(res.err.className);
+      const [ErrorClass, args] = core.getErrorClassAndArgs(res.err.className);
       if (!ErrorClass) {
         throw new Error(
           `Unregistered error class: "${res.err.className}"\n  ${res.err.message}\n  Classes of errors returned from ops should be registered via Deno.core.registerErrorClass().`,
         );
       }
-      throw new ErrorClass(res.err.message);
+      throw new ErrorClass(res.err.message, ...args);
     }
     return res.result;
   }


### PR DESCRIPTION
This is needed for WebGPU, where many errors are DOMExceptions that
take two parameters, the message and the error type. Currently we have
no way to create errors that take more than one paramterer.
