### PR TITLE
feat(cli): represent type dependencies in info

### DIFF
--- a/cli/colors.rs
+++ b/cli/colors.rs
@@ -39,95 +39,107 @@ pub fn enable_ansi() {
   BufferWriter::stdout(ColorChoice::AlwaysAnsi);
 }
 
-fn style(s: &str, colorspec: ColorSpec) -> impl fmt::Display {
+fn style<S: AsRef<str>>(s: S, colorspec: ColorSpec) -> impl fmt::Display {
   if !use_color() {
-    return String::from(s);
+    return String::from(s.as_ref());
   }
   let mut v = Vec::new();
   let mut ansi_writer = Ansi::new(&mut v);
   ansi_writer.set_color(&colorspec).unwrap();
-  ansi_writer.write_all(s.as_bytes()).unwrap();
+  ansi_writer.write_all(s.as_ref().as_bytes()).unwrap();
   ansi_writer.reset().unwrap();
   String::from_utf8_lossy(&v).into_owned()
 }
 
-pub fn red_bold(s: &str) -> impl fmt::Display {
+pub fn red_bold<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Red)).set_bold(true);
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn green_bold(s: &str) -> impl fmt::Display {
+pub fn green_bold<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Green)).set_bold(true);
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn italic_bold(s: &str) -> impl fmt::Display {
+pub fn italic<S: AsRef<str>>(s: S) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_italic(true);
+  style(s, style_spec)
+}
+
+pub fn italic_gray<S: AsRef<str>>(s: S) -> impl fmt::Display {
+  let mut style_spec = ColorSpec::new();
+  style_spec.set_fg(Some(Ansi256(8))).set_italic(true);
+  style(s, style_spec)
+}
+
+pub fn italic_bold<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bold(true).set_italic(true);
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn white_on_red(s: &str) -> impl fmt::Display {
+pub fn white_on_red<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bg(Some(Red)).set_fg(Some(White));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn black_on_green(s: &str) -> impl fmt::Display {
+pub fn black_on_green<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bg(Some(Green)).set_fg(Some(Black));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn yellow(s: &str) -> impl fmt::Display {
+pub fn yellow<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Yellow));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn cyan(s: &str) -> impl fmt::Display {
+pub fn cyan<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Cyan));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn red(s: &str) -> impl fmt::Display {
+pub fn red<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Red));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn green(s: &str) -> impl fmt::Display {
+pub fn green<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Green));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn bold(s: &str) -> impl fmt::Display {
+pub fn bold<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bold(true);
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn gray(s: &str) -> impl fmt::Display {
+pub fn gray<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(8)));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn italic_bold_gray(s: &str) -> impl fmt::Display {
+pub fn italic_bold_gray<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec
     .set_fg(Some(Ansi256(8)))
     .set_bold(true)
     .set_italic(true);
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
-pub fn intense_blue(s: &str) -> impl fmt::Display {
+pub fn intense_blue<S: AsRef<str>>(s: S) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Blue)).set_intense(true);
-  style(&s, style_spec)
+  style(s, style_spec)
 }

--- a/cli/info.rs
+++ b/cli/info.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
-use crate::media_type::serialize_media_type2;
+use crate::media_type::serialize_media_type;
 use crate::media_type::MediaType;
 
 use deno_core::resolve_url;
@@ -72,7 +72,7 @@ pub struct ModuleGraphInfoMod {
   pub size: Option<usize>,
   #[serde(
     skip_serializing_if = "Option::is_none",
-    serialize_with = "serialize_media_type2"
+    serialize_with = "serialize_media_type"
   )]
   pub media_type: Option<MediaType>,
   #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/info.rs
+++ b/cli/info.rs
@@ -36,7 +36,7 @@ impl ModuleGraphInfoDep {
     f: &mut fmt::Formatter,
     prefix: S,
     last: bool,
-    modules: &Vec<ModuleGraphInfoMod>,
+    modules: &[ModuleGraphInfoMod],
     seen: &mut HashSet<ModuleSpecifier>,
   ) -> fmt::Result {
     let maybe_code = self
@@ -110,7 +110,7 @@ impl ModuleGraphInfoMod {
     prefix: S,
     last: bool,
     type_dep: bool,
-    modules: &Vec<ModuleGraphInfoMod>,
+    modules: &[ModuleGraphInfoMod],
     seen: &mut HashSet<ModuleSpecifier>,
   ) -> fmt::Result {
     let was_seen = seen.contains(&self.specifier);

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -385,11 +385,11 @@ async fn info_command(
     let info = graph.info()?;
 
     if json {
-      write_json_to_stdout(&json!(info))?;
+      write_json_to_stdout(&json!(info))
     } else {
-      write_to_stdout_ignore_sigpipe(info.to_string().as_bytes())?;
+      write_to_stdout_ignore_sigpipe(info.to_string().as_bytes())
+        .map_err(|err| err.into())
     }
-    Ok(())
   } else {
     // If it was just "deno info" print location of caches and exit
     print_cache_info(&program_state, json)

--- a/cli/media_type.rs
+++ b/cli/media_type.rs
@@ -184,14 +184,7 @@ impl Serialize for MediaType {
 /// serialization for media types is and integer.
 ///
 /// TODO(@kitsonk) remove this once we stop sending MediaType into tsc.
-// pub fn serialize_media_type<S>(mt: &MediaType, s: S) -> Result<S::Ok, S::Error>
-// where
-//   S: Serializer,
-// {
-//   s.serialize_str(&mt.to_string())
-// }
-
-pub fn serialize_media_type2<S>(
+pub fn serialize_media_type<S>(
   mmt: &Option<MediaType>,
   s: S,
 ) -> Result<S::Ok, S::Error>

--- a/cli/media_type.rs
+++ b/cli/media_type.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 // Update carefully!
 #[allow(non_camel_case_types)]
 #[repr(i32)]
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub enum MediaType {
   JavaScript = 0,
   JSX = 1,
@@ -184,11 +184,24 @@ impl Serialize for MediaType {
 /// serialization for media types is and integer.
 ///
 /// TODO(@kitsonk) remove this once we stop sending MediaType into tsc.
-pub fn serialize_media_type<S>(mt: &MediaType, s: S) -> Result<S::Ok, S::Error>
+// pub fn serialize_media_type<S>(mt: &MediaType, s: S) -> Result<S::Ok, S::Error>
+// where
+//   S: Serializer,
+// {
+//   s.serialize_str(&mt.to_string())
+// }
+
+pub fn serialize_media_type2<S>(
+  mmt: &Option<MediaType>,
+  s: S,
+) -> Result<S::Ok, S::Error>
 where
   S: Serializer,
 {
-  s.serialize_str(&mt.to_string())
+  match *mmt {
+    Some(ref mt) => s.serialize_some(&mt.to_string()),
+    None => s.serialize_none(),
+  }
 }
 
 #[cfg(test)]

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -6,13 +6,11 @@ use crate::ast::transpile_module;
 use crate::ast::BundleHook;
 use crate::ast::Location;
 use crate::ast::ParsedModule;
+use crate::checksum;
 use crate::colors;
 use crate::diagnostics::Diagnostics;
 use crate::import_map::ImportMap;
-use crate::info::ModuleGraphInfo;
-use crate::info::ModuleInfo;
-use crate::info::ModuleInfoMap;
-use crate::info::ModuleInfoMapItem;
+use crate::info;
 use crate::lockfile::Lockfile;
 use crate::media_type::MediaType;
 use crate::specifier_handler::CachedModule;
@@ -44,8 +42,8 @@ use deno_core::ModuleResolutionError;
 use deno_core::ModuleSource;
 use deno_core::ModuleSpecifier;
 use regex::Regex;
+use std::collections::HashMap;
 use std::collections::HashSet;
-use std::collections::{BTreeSet, HashMap};
 use std::error::Error;
 use std::fmt;
 use std::path::PathBuf;
@@ -1193,95 +1191,6 @@ impl Graph {
     Ok(())
   }
 
-  fn get_info(
-    &self,
-    specifier: &ModuleSpecifier,
-    seen: &mut HashSet<ModuleSpecifier>,
-    totals: &mut HashMap<ModuleSpecifier, usize>,
-  ) -> ModuleInfo {
-    let not_seen = seen.insert(specifier.clone());
-    let module = match self.get_module(specifier) {
-      ModuleSlot::Module(module) => module,
-      ModuleSlot::Err(err) => {
-        error!("{}: {}", colors::red_bold("error"), err.to_string());
-        std::process::exit(1);
-      }
-      _ => unreachable!(),
-    };
-    let mut deps = Vec::new();
-    let mut total_size = None;
-
-    if not_seen {
-      let mut seen_deps = HashSet::new();
-      // TODO(@kitsonk) https://github.com/denoland/deno/issues/7927
-      for (_, dep) in module.dependencies.iter() {
-        // Check the runtime code dependency
-        if let Some(code_dep) = &dep.maybe_code {
-          if seen_deps.insert(code_dep.clone()) {
-            deps.push(self.get_info(code_dep, seen, totals));
-          }
-        }
-      }
-      deps.sort();
-      total_size = if let Some(total) = totals.get(specifier) {
-        Some(total.to_owned())
-      } else {
-        let mut total = deps
-          .iter()
-          .map(|d| {
-            if let Some(total_size) = d.total_size {
-              total_size
-            } else {
-              0
-            }
-          })
-          .sum();
-        total += module.size();
-        totals.insert(specifier.clone(), total);
-        Some(total)
-      };
-    }
-
-    ModuleInfo {
-      deps,
-      name: specifier.clone(),
-      size: module.size(),
-      total_size,
-    }
-  }
-
-  fn get_info_map(&self) -> ModuleInfoMap {
-    let map = self
-      .modules
-      .iter()
-      .filter_map(|(specifier, module_slot)| {
-        if let ModuleSlot::Module(module) = module_slot {
-          let mut deps = BTreeSet::new();
-          for (_, dep) in module.dependencies.iter() {
-            if let Some(code_dep) = &dep.maybe_code {
-              deps.insert(code_dep.clone());
-            }
-            if let Some(type_dep) = &dep.maybe_type {
-              deps.insert(type_dep.clone());
-            }
-          }
-          if let Some((_, types_dep)) = &module.maybe_types {
-            deps.insert(types_dep.clone());
-          }
-          let item = ModuleInfoMapItem {
-            deps: deps.into_iter().collect(),
-            size: module.size(),
-          };
-          Some((specifier.clone(), item))
-        } else {
-          None
-        }
-      })
-      .collect();
-
-    ModuleInfoMap::new(map)
-  }
-
   /// Retrieve a map that contains a representation of each module in the graph
   /// which can be used to provide code to a module loader without holding all
   /// the state to be able to operate on the graph.
@@ -1425,51 +1334,75 @@ impl Graph {
   /// Return a structure which provides information about the module graph and
   /// the relationship of the modules in the graph.  This structure is used to
   /// provide information for the `info` subcommand.
-  pub fn info(&self) -> Result<ModuleGraphInfo, AnyError> {
+  pub fn info(&self) -> Result<info::ModuleGraphInfo, AnyError> {
     if self.roots.is_empty() || self.roots.len() > 1 {
       return Err(GraphError::NotSupported(format!("Info is only supported when there is a single root module in the graph.  Found: {}", self.roots.len())).into());
     }
 
-    let module = self.roots[0].clone();
-    let m = if let ModuleSlot::Module(module) = self.get_module(&module) {
-      module
-    } else {
-      return Err(GraphError::MissingSpecifier(module.clone()).into());
-    };
-
-    let mut seen = HashSet::new();
-    let mut totals = HashMap::new();
-    let info = self.get_info(&module, &mut seen, &mut totals);
-
-    let files = self.get_info_map();
-    let total_size = totals.get(&module).unwrap_or(&m.size()).to_owned();
-    let (compiled, map) =
-      if let Some((emit_path, maybe_map_path)) = &m.maybe_emit_path {
-        (Some(emit_path.clone()), maybe_map_path.clone())
-      } else {
-        (None, None)
-      };
-
-    let dep_count = self
+    let root = self.resolve_specifier(&self.roots[0]).clone();
+    let mut modules: Vec<info::ModuleGraphInfoMod> = self
       .modules
       .iter()
-      .filter_map(|(_, m)| match m {
-        ModuleSlot::Module(_) => Some(1),
+      .filter_map(|(sp, sl)| match sl {
+        ModuleSlot::Module(module) => {
+          let mut dependencies: Vec<info::ModuleGraphInfoDep> = module
+            .dependencies
+            .iter()
+            .map(|(k, v)| info::ModuleGraphInfoDep {
+              specifier: k.clone(),
+              is_dynamic: v.is_dynamic,
+              maybe_code: v
+                .maybe_code
+                .clone()
+                .map(|s| self.resolve_specifier(&s).clone()),
+              maybe_type: v
+                .maybe_type
+                .clone()
+                .map(|s| self.resolve_specifier(&s).clone()),
+            })
+            .collect();
+          dependencies.sort();
+          let (emit, map) =
+            if let Some((emit, maybe_map)) = &module.maybe_emit_path {
+              (Some(emit.clone()), maybe_map.clone())
+            } else {
+              (None, None)
+            };
+          Some(info::ModuleGraphInfoMod {
+            specifier: sp.clone(),
+            dependencies,
+            size: Some(module.size()),
+            media_type: Some(module.media_type.clone()),
+            local: Some(module.source_path.clone()),
+            checksum: Some(checksum::gen(&[module.source.as_bytes()])),
+            emit,
+            map,
+            ..Default::default()
+          })
+        }
+        ModuleSlot::Err(err) => Some(info::ModuleGraphInfoMod {
+          specifier: sp.clone(),
+          error: Some(err.to_string()),
+          ..Default::default()
+        }),
         _ => None,
       })
-      .count()
-      - 1;
+      .collect();
 
-    Ok(ModuleGraphInfo {
-      compiled,
-      dep_count,
-      file_type: m.media_type,
-      files,
-      info,
-      local: m.source_path.clone(),
-      map,
-      module,
-      total_size,
+    modules.sort();
+
+    let size = modules.iter().fold(0_usize, |acc, m| {
+      if let Some(size) = &m.size {
+        acc + size
+      } else {
+        acc
+      }
+    });
+
+    Ok(info::ModuleGraphInfo {
+      root,
+      modules,
+      size,
     })
   }
 
@@ -2510,24 +2443,24 @@ pub mod tests {
     assert!(emitted_files.contains_key("file:///b.ts.d.ts"));
   }
 
-  #[tokio::test]
-  async fn test_graph_info() {
-    let specifier = resolve_url_or_path("file:///tests/main.ts")
-      .expect("could not resolve module");
-    let (graph, _) = setup(specifier).await;
-    let info = graph.info().expect("could not get info");
-    assert!(info.compiled.is_none());
-    assert_eq!(info.dep_count, 6);
-    assert_eq!(info.file_type, MediaType::TypeScript);
-    assert_eq!(info.files.0.len(), 7);
-    assert!(info.local.to_string_lossy().ends_with("file_tests-main.ts"));
-    assert!(info.map.is_none());
-    assert_eq!(
-      info.module,
-      resolve_url_or_path("file:///tests/main.ts").unwrap()
-    );
-    assert_eq!(info.total_size, 344);
-  }
+  // #[tokio::test]
+  // async fn test_graph_info() {
+  //   let specifier = resolve_url_or_path("file:///tests/main.ts")
+  //     .expect("could not resolve module");
+  //   let (graph, _) = setup(specifier).await;
+  //   let info = graph.info().expect("could not get info");
+  //   assert!(info.compiled.is_none());
+  //   assert_eq!(info.dep_count, 6);
+  //   assert_eq!(info.file_type, MediaType::TypeScript);
+  //   assert_eq!(info.files.0.len(), 7);
+  //   assert!(info.local.to_string_lossy().ends_with("file_tests-main.ts"));
+  //   assert!(info.map.is_none());
+  //   assert_eq!(
+  //     info.module,
+  //     resolve_url_or_path("file:///tests/main.ts").unwrap()
+  //   );
+  //   assert_eq!(info.total_size, 344);
+  // }
 
   #[tokio::test]
   async fn test_graph_import_json() {

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -1372,7 +1372,7 @@ impl Graph {
             specifier: sp.clone(),
             dependencies,
             size: Some(module.size()),
-            media_type: Some(module.media_type.clone()),
+            media_type: Some(module.media_type),
             local: Some(module.source_path.clone()),
             checksum: Some(checksum::gen(&[module.source.as_bytes()])),
             emit,

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -2443,24 +2443,16 @@ pub mod tests {
     assert!(emitted_files.contains_key("file:///b.ts.d.ts"));
   }
 
-  // #[tokio::test]
-  // async fn test_graph_info() {
-  //   let specifier = resolve_url_or_path("file:///tests/main.ts")
-  //     .expect("could not resolve module");
-  //   let (graph, _) = setup(specifier).await;
-  //   let info = graph.info().expect("could not get info");
-  //   assert!(info.compiled.is_none());
-  //   assert_eq!(info.dep_count, 6);
-  //   assert_eq!(info.file_type, MediaType::TypeScript);
-  //   assert_eq!(info.files.0.len(), 7);
-  //   assert!(info.local.to_string_lossy().ends_with("file_tests-main.ts"));
-  //   assert!(info.map.is_none());
-  //   assert_eq!(
-  //     info.module,
-  //     resolve_url_or_path("file:///tests/main.ts").unwrap()
-  //   );
-  //   assert_eq!(info.total_size, 344);
-  // }
+  #[tokio::test]
+  async fn test_graph_info() {
+    let specifier = resolve_url_or_path("file:///tests/main.ts")
+      .expect("could not resolve module");
+    let (graph, _) = setup(specifier.clone()).await;
+    let info = graph.info().expect("could not get info");
+    assert_eq!(info.root, specifier);
+    assert_eq!(info.modules.len(), 7);
+    assert_eq!(info.size, 518);
+  }
 
   #[tokio::test]
   async fn test_graph_import_json() {

--- a/cli/tests/017_import_redirect_info.out
+++ b/cli/tests/017_import_redirect_info.out
@@ -1,6 +1,6 @@
 local: [WILDCARD]017_import_redirect.ts
 type: TypeScript
-deps: 1 unique (total [WILDCARD]B)
+dependencies: 1 unique (total 278B)
 
 file:///[WILDCARD]cli/tests/017_import_redirect.ts ([WILDCARD])
-└── http://gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts ([WILDCARD])
+└── https://gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts ([WILDCARD])

--- a/cli/tests/022_info_flag_script.out
+++ b/cli/tests/022_info_flag_script.out
@@ -1,7 +1,7 @@
 [WILDCARD]
 local: [WILDCARD]http[WILDCARD]127.0.0.1_PORT4545[WILDCARD]
 type: TypeScript
-deps: 8 unique (total [WILDCARD])
+dependencies: 8 unique (total [WILDCARD])
 
 http://127.0.0.1:4545/cli/tests/019_media_types.ts ([WILDCARD])
 ├── http://localhost:4545/cli/tests/subdir/mt_application_ecmascript.j2.js ([WILDCARD])

--- a/cli/tests/031_info_ts_error.out
+++ b/cli/tests/031_info_ts_error.out
@@ -1,5 +1,5 @@
 [WILDCARD]
 local: [WILDCARD]031_info_ts_error.ts
 type: TypeScript
-deps: 0 unique (total [WILDCARD])
+dependencies: 0 unique (total [WILDCARD])
 [WILDCARD]031_info_ts_error.ts ([WILDCARD])

--- a/cli/tests/049_info_flag_script_jsx.out
+++ b/cli/tests/049_info_flag_script_jsx.out
@@ -1,7 +1,7 @@
 [WILDCARD]
 local: [WILDCARD]http[WILDCARD]127.0.0.1_PORT4545[WILDCARD]
 type: TypeScript
-deps: 8 unique (total [WILDCARD])
+dependencies: 8 unique (total [WILDCARD])
 
 http://127.0.0.1:4545/cli/tests/048_media_types_jsx.ts ([WILDCARD])
 ├── http://localhost:4545/cli/tests/subdir/mt_application_ecmascript_jsx.j2.jsx ([WILDCARD])

--- a/cli/tests/054_info_local_imports.out
+++ b/cli/tests/054_info_local_imports.out
@@ -1,6 +1,6 @@
 local: [WILDCARD]005_more_imports.ts
 type: TypeScript
-deps: 3 unique (total [WILDCARD])
+dependencies: 3 unique (total [WILDCARD])
 
 file://[WILDCARD]/005_more_imports.ts ([WILDCARD])
 └─┬ file://[WILDCARD]/subdir/mod1.ts ([WILDCARD])

--- a/cli/tests/055_info_file_json.out
+++ b/cli/tests/055_info_file_json.out
@@ -48,7 +48,7 @@
       ],
       "size": 163,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]subdir2/mod2.ts",
+      "local": "[WILDCARD]mod2.ts",
       [WILDCARD]
     }
   ],

--- a/cli/tests/055_info_file_json.out
+++ b/cli/tests/055_info_file_json.out
@@ -1,33 +1,56 @@
 {
-  "compiled": null,
-  "depCount": 3,
-  "fileType": "TypeScript",
-  "files": {
-    "file:///[WILDCARD]/cli/tests/005_more_imports.ts": {
-      "deps": [
-        "file:///[WILDCARD]/cli/tests/subdir/mod1.ts"
+  "root": "file://[WILDCARD]/cli/tests/005_more_imports.ts",
+  "modules": [
+    {
+      "specifier": "file://[WILDCARD]/cli/tests/005_more_imports.ts",
+      "dependencies": [
+        {
+          "specifier": "./subdir/mod1.ts",
+          "isDynamic": false,
+          "code": "file://[WILDCARD]/cli/tests/subdir/mod1.ts"
+        }
       ],
-      "size": 211
+      "size": 211,
+      "mediaType": "TypeScript",
+      "local": "[WILDCARD]/cli/tests/005_more_imports.ts",
+      [WILDCARD]
     },
-    "file:///[WILDCARD]/cli/tests/subdir/mod1.ts": {
-      "deps": [
-        "file:///[WILDCARD]/cli/tests/subdir/subdir2/mod2.ts"
+    {
+      "specifier": "file://[WILDCARD]/cli/tests/subdir/mod1.ts",
+      "dependencies": [
+        {
+          "specifier": "./subdir2/mod2.ts",
+          "isDynamic": false,
+          "code": "file://[WILDCARD]/cli/tests/subdir/subdir2/mod2.ts"
+        }
       ],
-      "size": 320
+      "size": 320,
+      "mediaType": "TypeScript",
+      "local": "[WILDCARD]/cli/tests/subdir/mod1.ts",
+      [WILDCARD]
     },
-    "file:///[WILDCARD]/cli/tests/subdir/print_hello.ts": {
-      "deps": [],
-      "size": 63
+    {
+      "specifier": "file://[WILDCARD]/cli/tests/subdir/print_hello.ts",
+      "dependencies": [],
+      "size": 63,
+      "mediaType": "TypeScript",
+      "local": "[WILDCARD]/cli/tests/subdir/print_hello.ts",
+      [WILDCARD]
     },
-    "file:///[WILDCARD]/cli/tests/subdir/subdir2/mod2.ts": {
-      "deps": [
-        "file:///[WILDCARD]/cli/tests/subdir/print_hello.ts"
+    {
+      "specifier": "file://[WILDCARD]/cli/tests/subdir/subdir2/mod2.ts",
+      "dependencies": [
+        {
+          "specifier": "../print_hello.ts",
+          "isDynamic": false,
+          "code": "file://[WILDCARD]/cli/tests/subdir/print_hello.ts"
+        }
       ],
-      "size": 163
+      "size": 163,
+      "mediaType": "TypeScript",
+      "local": "[WILDCARD]/cli/tests/subdir/subdir2/mod2.ts",
+      [WILDCARD]
     }
-  },
-  "local": "[WILDCARD]005_more_imports.ts",
-  "map": null,
-  "module": "file:///[WILDCARD]/cli/tests/005_more_imports.ts",
-  "totalSize": 757
+  ],
+  "size": 757
 }

--- a/cli/tests/055_info_file_json.out
+++ b/cli/tests/055_info_file_json.out
@@ -12,7 +12,7 @@
       ],
       "size": 211,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]/cli/tests/005_more_imports.ts",
+      "local": "[WILDCARD]005_more_imports.ts",
       [WILDCARD]
     },
     {
@@ -26,7 +26,7 @@
       ],
       "size": 320,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]/cli/tests/subdir/mod1.ts",
+      "local": "[WILDCARD]mod1.ts",
       [WILDCARD]
     },
     {
@@ -34,7 +34,7 @@
       "dependencies": [],
       "size": 63,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]/cli/tests/subdir/print_hello.ts",
+      "local": "[WILDCARD]print_hello.ts",
       [WILDCARD]
     },
     {
@@ -48,7 +48,7 @@
       ],
       "size": 163,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]/cli/tests/subdir/subdir2/mod2.ts",
+      "local": "[WILDCARD]subdir2/mod2.ts",
       [WILDCARD]
     }
   ],

--- a/cli/tests/065_import_map_info.out
+++ b/cli/tests/065_import_map_info.out
@@ -1,5 +1,5 @@
 [WILDCARD]
 local: [WILDCARD]test.ts
 type: TypeScript
-deps: 7 unique (total [WILDCARD])
+dependencies: 7 unique (total [WILDCARD])
 [WILDCARD]

--- a/cli/tests/076_info_json_deps_order.out
+++ b/cli/tests/076_info_json_deps_order.out
@@ -1,38 +1,85 @@
 {
-  "compiled": null,
-  "depCount": 4,
-  "fileType": "TypeScript",
-  "files": {
-    "[WILDCARD]cli/tests/076_info_json_deps_order.ts": {
-      "deps": [
-        "[WILDCARD]cli/tests/recursive_imports/A.ts"
+  "root": "file://[WILDCARD]/cli/tests/076_info_json_deps_order.ts",
+  "modules": [
+    {
+      "specifier": "file://[WILDCARD]/cli/tests/076_info_json_deps_order.ts",
+      "dependencies": [
+        {
+          "specifier": "./recursive_imports/A.ts",
+          "isDynamic": false,
+          "code": "file://[WILDCARD]/cli/tests/recursive_imports/A.ts"
+        }
       ],
-      "size": [WILDCARD]
+      "size": 46,
+      "mediaType": "TypeScript",
+      "local": "[WILDCARD]/cli/tests/076_info_json_deps_order.ts",
+      "checksum": "88b144f362d31ac42263648aadef727dd36d039d3b8ac0248fdaff25d4de415a"
     },
-    "[WILDCARD]cli/tests/recursive_imports/A.ts": {
-      "deps": [
-        "[WILDCARD]cli/tests/recursive_imports/B.ts",
-        "[WILDCARD]cli/tests/recursive_imports/common.ts"
+    {
+      "specifier": "file://[WILDCARD]/cli/tests/recursive_imports/A.ts",
+      "dependencies": [
+        {
+          "specifier": "./B.ts",
+          "isDynamic": false,
+          "code": "file://[WILDCARD]/cli/tests/recursive_imports/B.ts"
+        },
+        {
+          "specifier": "./common.ts",
+          "isDynamic": false,
+          "code": "file://[WILDCARD]/cli/tests/recursive_imports/common.ts"
+        }
       ],
-      "size": [WILDCARD]
+      "size": 114,
+      "mediaType": "TypeScript",
+      "local": "[WILDCARD]/cli/tests/recursive_imports/A.ts",
+      "checksum": "da204c16d3114763810864083af8891a887d65fbe34e4c8b5bf985dbc8f0b01f"
     },
-    "[WILDCARD]cli/tests/recursive_imports/B.ts": {
-      "deps": [
-        "[WILDCARD]cli/tests/recursive_imports/C.ts",
-        "[WILDCARD]cli/tests/recursive_imports/common.ts"
+    {
+      "specifier": "file://[WILDCARD]/cli/tests/recursive_imports/B.ts",
+      "dependencies": [
+        {
+          "specifier": "./C.ts",
+          "isDynamic": false,
+          "code": "file://[WILDCARD]/cli/tests/recursive_imports/C.ts"
+        },
+        {
+          "specifier": "./common.ts",
+          "isDynamic": false,
+          "code": "file://[WILDCARD]/cli/tests/recursive_imports/common.ts"
+        }
       ],
-      "size": [WILDCARD]
+      "size": 114,
+      "mediaType": "TypeScript",
+      "local": "[WILDCARD]/cli/tests/recursive_imports/B.ts",
+      "checksum": "060ef62435d7e3a3276e8894307b19cf17772210a20dd091d24a670fadec6b83"
     },
-    "[WILDCARD]cli/tests/recursive_imports/C.ts": {
-      "deps": [
-        "[WILDCARD]cli/tests/recursive_imports/A.ts",
-        "[WILDCARD]cli/tests/recursive_imports/common.ts"
+    {
+      "specifier": "file://[WILDCARD]/cli/tests/recursive_imports/C.ts",
+      "dependencies": [
+        {
+          "specifier": "./A.ts",
+          "isDynamic": false,
+          "code": "file://[WILDCARD]/cli/tests/recursive_imports/A.ts"
+        },
+        {
+          "specifier": "./common.ts",
+          "isDynamic": false,
+          "code": "file://[WILDCARD]/cli/tests/recursive_imports/common.ts"
+        }
       ],
-      "size": [WILDCARD]
+      "size": 132,
+      "mediaType": "TypeScript",
+      "local": "[WILDCARD]/cli/tests/recursive_imports/C.ts",
+      "checksum": "5190563583617a69f190f1cc76e6552df878df278cfaa5d5e30ebe0938cf5e0b"
     },
-    "[WILDCARD]cli/tests/recursive_imports/common.ts": {
-      "deps": [],
-      "size": [WILDCARD]
+    {
+      "specifier": "file://[WILDCARD]/cli/tests/recursive_imports/common.ts",
+      "dependencies": [],
+      "size": 34,
+      "mediaType": "TypeScript",
+      "local": "[WILDCARD]/cli/tests/recursive_imports/common.ts",
+      "checksum": "01b595d69514bfd001ba2cf421feabeaef559513f10697bf1a22781f8a8ed7f0"
     }
-  },
-[WILDCARD]
+  ],
+  "size": 440
+}

--- a/cli/tests/076_info_json_deps_order.out
+++ b/cli/tests/076_info_json_deps_order.out
@@ -12,7 +12,7 @@
       ],
       "size": 46,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]/cli/tests/076_info_json_deps_order.ts",
+      "local": "[WILDCARD]076_info_json_deps_order.ts",
       "checksum": "88b144f362d31ac42263648aadef727dd36d039d3b8ac0248fdaff25d4de415a"
     },
     {
@@ -31,7 +31,7 @@
       ],
       "size": 114,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]/cli/tests/recursive_imports/A.ts",
+      "local": "[WILDCARD]recursive_imports/A.ts",
       "checksum": "da204c16d3114763810864083af8891a887d65fbe34e4c8b5bf985dbc8f0b01f"
     },
     {
@@ -50,7 +50,7 @@
       ],
       "size": 114,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]/cli/tests/recursive_imports/B.ts",
+      "local": "[WILDCARD]recursive_imports/B.ts",
       "checksum": "060ef62435d7e3a3276e8894307b19cf17772210a20dd091d24a670fadec6b83"
     },
     {
@@ -69,7 +69,7 @@
       ],
       "size": 132,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]/cli/tests/recursive_imports/C.ts",
+      "local": "[WILDCARD]recursive_imports/C.ts",
       "checksum": "5190563583617a69f190f1cc76e6552df878df278cfaa5d5e30ebe0938cf5e0b"
     },
     {
@@ -77,7 +77,7 @@
       "dependencies": [],
       "size": 34,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]/cli/tests/recursive_imports/common.ts",
+      "local": "[WILDCARD]recursive_imports/common.ts",
       "checksum": "01b595d69514bfd001ba2cf421feabeaef559513f10697bf1a22781f8a8ed7f0"
     }
   ],

--- a/cli/tests/076_info_json_deps_order.out
+++ b/cli/tests/076_info_json_deps_order.out
@@ -31,7 +31,7 @@
       ],
       "size": 114,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]recursive_imports/A.ts",
+      "local": "[WILDCARD]A.ts",
       "checksum": "da204c16d3114763810864083af8891a887d65fbe34e4c8b5bf985dbc8f0b01f"
     },
     {
@@ -50,7 +50,7 @@
       ],
       "size": 114,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]recursive_imports/B.ts",
+      "local": "[WILDCARD]B.ts",
       "checksum": "060ef62435d7e3a3276e8894307b19cf17772210a20dd091d24a670fadec6b83"
     },
     {
@@ -69,7 +69,7 @@
       ],
       "size": 132,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]recursive_imports/C.ts",
+      "local": "[WILDCARD]C.ts",
       "checksum": "5190563583617a69f190f1cc76e6552df878df278cfaa5d5e30ebe0938cf5e0b"
     },
     {
@@ -77,7 +77,7 @@
       "dependencies": [],
       "size": 34,
       "mediaType": "TypeScript",
-      "local": "[WILDCARD]recursive_imports/common.ts",
+      "local": "[WILDCARD]common.ts",
       "checksum": "01b595d69514bfd001ba2cf421feabeaef559513f10697bf1a22781f8a8ed7f0"
     }
   ],

--- a/cli/tests/info_missing_module.out
+++ b/cli/tests/info_missing_module.out
@@ -1,4 +1,4 @@
-local: [WILDCARD]/cli/tests/error_009_missing_js_module.js
+local: [WILDCARD]error_009_missing_js_module.js
 type: JavaScript
 dependencies: 1 unique (total 26B)
 

--- a/cli/tests/info_missing_module.out
+++ b/cli/tests/info_missing_module.out
@@ -1,2 +1,6 @@
-error: Cannot resolve module "file://[WILDCARD]/bad-module.js" from "file://[WILDCARD]/error_009_missing_js_module.js".
-    at file://[WILDCARD]/error_009_missing_js_module.js:1:0
+local: [WILDCARD]/cli/tests/error_009_missing_js_module.js
+type: JavaScript
+dependencies: 1 unique (total 26B)
+
+file://[WILDCARD]/cli/tests/error_009_missing_js_module.js (26B)
+└── file://[WILDCARD]/cli/tests/bad-module.js (error)

--- a/cli/tests/info_recursive_imports_test.out
+++ b/cli/tests/info_recursive_imports_test.out
@@ -1,12 +1,12 @@
 local: [WILDCARD]info_recursive_imports_test.ts
 type: TypeScript
-deps: 4 unique (total [WILDCARD])
+dependencies: 4 unique (total [WILDCARD])
 
 file://[WILDCARD]cli/tests/info_recursive_imports_test.ts ([WILDCARD])
 └─┬ file://[WILDCARD]cli/tests/recursive_imports/A.ts ([WILDCARD])
   ├─┬ file://[WILDCARD]cli/tests/recursive_imports/B.ts ([WILDCARD])
   │ ├─┬ file://[WILDCARD]cli/tests/recursive_imports/C.ts ([WILDCARD])
   │ │ ├── file://[WILDCARD]cli/tests/recursive_imports/A.ts *
-  │ │ └── file://[WILDCARD]cli/tests/recursive_imports/common.ts [WILDCARD]
-  │ └── file://[WILDCARD]cli/tests/recursive_imports/common.ts [WILDCARD]
-  └── file://[WILDCARD]cli/tests/recursive_imports/common.ts [WILDCARD]
+  │ │ └── file://[WILDCARD]cli/tests/recursive_imports/common.ts ([WILDCARD])
+  │ └── file://[WILDCARD]cli/tests/recursive_imports/common.ts *
+  └── file://[WILDCARD]cli/tests/recursive_imports/common.ts *

--- a/cli/tests/info_type_import.out
+++ b/cli/tests/info_type_import.out
@@ -1,5 +1,5 @@
 local: [WILDCARD]info_type_import.ts
 type: TypeScript
-deps: 1 unique (total [WILDCARD])
+dependencies: 1 unique (total [WILDCARD])
 [WILDCARD]info_type_import.ts ([WILDCARD])
 └── [WILDCARD]type_and_code.ts ([WILDCARD])

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1734,7 +1734,7 @@ mod integration {
     let str_output = std::str::from_utf8(&output.stdout).unwrap().trim();
     eprintln!("{}", str_output);
     // check the output of the test.ts program.
-    assert!(str_output.contains("compiled: "));
+    assert!(str_output.contains("emit: "));
     assert_eq!(output.stderr, b"");
   }
 
@@ -3722,7 +3722,6 @@ console.log("finish");
   itest!(info_missing_module {
     args: "info error_009_missing_js_module.js",
     output: "info_missing_module.out",
-    exit_code: 1,
   });
 
   itest!(info_recursive_modules {

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -521,7 +521,7 @@ impl CoverageReporter for PrettyCoverageReporter {
       // Put a horizontal separator between disjoint runs of lines
       if let Some(last_line) = last_line {
         if last_line + 1 != line_index {
-          let dash = colors::gray(&"-".repeat(WIDTH + 1));
+          let dash = colors::gray("-".repeat(WIDTH + 1));
           println!("{}{}{}", dash, colors::gray(SEPERATOR), dash);
         }
       }

--- a/docs/schemas/module-graph.json
+++ b/docs/schemas/module-graph.json
@@ -1,0 +1,116 @@
+{
+  "$id": "https://deno.land/schemas/module-graph.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "description": "A JSON representation of a Deno module dependency graph.",
+  "required": [
+    "root",
+    "modules",
+    "size"
+  ],
+  "title": "Deno Dependency Graph Schema",
+  "type": "object",
+  "properties": {
+    "root": {
+      "default": "",
+      "description": "The root specifier for the graph.",
+      "examples": [
+        "https://deno.land/x/mod.ts"
+      ],
+      "type": "string"
+    },
+    "modules": {
+      "default": [],
+      "description": "The modules that are part of the graph.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/module"
+      }
+    },
+    "size": {
+      "type": "integer",
+      "description": "The total size of all the unique dependencies in the graph in bytes.",
+      "default": 0
+    }
+  },
+  "definitions": {
+    "module": {
+      "type": "object",
+      "required": [
+        "specifier"
+      ],
+      "properties": {
+        "specifier": {
+          "type": "string",
+          "description": "The fully qualified module specifier (URL) for the module."
+        },
+        "dependencies": {
+          "type": "array",
+          "description": "An array of dependencies of the module.",
+          "items": {
+            "$ref": "#/definitions/dependency"
+          }
+        },
+        "size": {
+          "type": "integer",
+          "description": "The size of the module on disk in bytes."
+        },
+        "mediaType": {
+          "type": "string",
+          "description": "How the file is treated within Deno.  All the possible media types that Deno considers are listed here, but in practice, several of them would never appear in a module graph.",
+          "enum": [
+            "JavaScript",
+            "TypeScript",
+            "JSX",
+            "TSX",
+            "Dts",
+            "Json",
+            "Wasm",
+            "TsBuildInfo",
+            "SourceMap",
+            "Unknown"
+          ]
+        },
+        "local": {
+          "type": "string",
+          "description": "The path to the local file. For local modules this will be the local file path, for remote modules and data URLs, this would be the path to the file in the Deno cache."
+        },
+        "checksum": {
+          "type": "string",
+          "description": "The checksum of the local source file. This can be used to validate if the current on disk version matches the version described here."
+        },
+        "emit": {
+          "type": "string",
+          "description": "The path to an emitted version of the module, if the module requires transpilation to be loaded into the Deno runtime."
+        },
+        "map": {
+          "type": "string",
+          "description": "The path to an optionally emitted source map between the original and emitted version of the file."
+        },
+        "error": {
+          "type": "string",
+          "description": "If when resolving the module, Deno encountered an error and the module is unavailable, the text of that error will be indicated here."
+        }
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "required": [
+        "specifier"
+      ],
+      "properties": {
+        "specifier": {
+          "type": "string",
+          "description": "The specifier provided from within the module."
+        },
+        "code": {
+          "type": "string",
+          "description": "The fully qualified module specifier (URL) for the code dependency."
+        },
+        "type": {
+          "type": "string",
+          "description": "The fully qualified module specifier (URL) for the type only dependency."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #7927

This PR provides better output for `deno info` and `deno info --unstable --json`.  Specifically it handles type only dependencies properly and for the JSON output, significantly restructures it to make it more usable and consumable down stream, effectively giving the user the same view as the module graph has.  There is a JSON Schema which describes this output, which is located in `/docs/schemas/module-graph.json` (which ideally we should serve up at `https://deno.land/x/schemas/module-graph.json`).

For example, the output for a circular dependency modules:

```json
{
  "root": "file:///Users/kitsonk/github/deno/cli/tests/info_recursive_imports_test.ts",
  "modules": [
    {
      "specifier": "file:///Users/kitsonk/github/deno/cli/tests/info_recursive_imports_test.ts",
      "dependencies": [
        {
          "specifier": "./recursive_imports/A.ts",
          "isDynamic": false,
          "code": "file:///Users/kitsonk/github/deno/cli/tests/recursive_imports/A.ts"
        }
      ],
      "size": 87,
      "mediaType": "TypeScript",
      "local": "/Users/kitsonk/github/deno/cli/tests/info_recursive_imports_test.ts",
      "checksum": "83117c39c47d62e39f470bdc686e1d4061262da42c12cca5808d6b86ac61cf89"
    },
    {
      "specifier": "file:///Users/kitsonk/github/deno/cli/tests/recursive_imports/A.ts",
      "dependencies": [
        {
          "specifier": "./B.ts",
          "isDynamic": false,
          "code": "file:///Users/kitsonk/github/deno/cli/tests/recursive_imports/B.ts"
        },
        {
          "specifier": "./common.ts",
          "isDynamic": false,
          "code": "file:///Users/kitsonk/github/deno/cli/tests/recursive_imports/common.ts"
        }
      ],
      "size": 114,
      "mediaType": "TypeScript",
      "local": "/Users/kitsonk/github/deno/cli/tests/recursive_imports/A.ts",
      "checksum": "da204c16d3114763810864083af8891a887d65fbe34e4c8b5bf985dbc8f0b01f"
    },
    {
      "specifier": "file:///Users/kitsonk/github/deno/cli/tests/recursive_imports/B.ts",
      "dependencies": [
        {
          "specifier": "./C.ts",
          "isDynamic": false,
          "code": "file:///Users/kitsonk/github/deno/cli/tests/recursive_imports/C.ts"
        },
        {
          "specifier": "./common.ts",
          "isDynamic": false,
          "code": "file:///Users/kitsonk/github/deno/cli/tests/recursive_imports/common.ts"
        }
      ],
      "size": 114,
      "mediaType": "TypeScript",
      "local": "/Users/kitsonk/github/deno/cli/tests/recursive_imports/B.ts",
      "checksum": "060ef62435d7e3a3276e8894307b19cf17772210a20dd091d24a670fadec6b83"
    },
    {
      "specifier": "file:///Users/kitsonk/github/deno/cli/tests/recursive_imports/C.ts",
      "dependencies": [
        {
          "specifier": "./A.ts",
          "isDynamic": false,
          "code": "file:///Users/kitsonk/github/deno/cli/tests/recursive_imports/A.ts"
        },
        {
          "specifier": "./common.ts",
          "isDynamic": false,
          "code": "file:///Users/kitsonk/github/deno/cli/tests/recursive_imports/common.ts"
        }
      ],
      "size": 132,
      "mediaType": "TypeScript",
      "local": "/Users/kitsonk/github/deno/cli/tests/recursive_imports/C.ts",
      "checksum": "5190563583617a69f190f1cc76e6552df878df278cfaa5d5e30ebe0938cf5e0b"
    },
    {
      "specifier": "file:///Users/kitsonk/github/deno/cli/tests/recursive_imports/common.ts",
      "dependencies": [],
      "size": 34,
      "mediaType": "TypeScript",
      "local": "/Users/kitsonk/github/deno/cli/tests/recursive_imports/common.ts",
      "checksum": "01b595d69514bfd001ba2cf421feabeaef559513f10697bf1a22781f8a8ed7f0"
    }
  ],
  "size": 481
}
```

In addition the output to the console is improved so that type only dependencies are display and display in _italics_ and previously seen dependencies appear totally in grey, giving better visual indication of something already being accounted for.

![kitsonk_—_-zsh_—_120×72](https://user-images.githubusercontent.com/1282577/109457678-6e1a1280-7aaf-11eb-9bd4-6ac126bcd98d.png)

Also, instead of erroring out when there was an error with a module in the module graph, `deno info` completes and provides a visual indication that there was an error loading a module.  This gives end users a better indication of where module graph errors are occurring (and can display multiple errors in the same invocation):

![deno_—_-zsh_—_120×72](https://user-images.githubusercontent.com/1282577/109457545-2c896780-7aaf-11eb-8959-bd3179f703a8.png)
