### PR TITLE
docs(testing): Add assertObjectMatch example

### DIFF
--- a/docs/testing/assertions.md
+++ b/docs/testing/assertions.md
@@ -139,7 +139,8 @@ Deno.test("Test Assert Not Match", () => {
 
 ### Object
 
-Use `assertObjectMatch` to check that a JavaScript object matches a subset of the properties of an object.
+Use `assertObjectMatch` to check that a JavaScript object matches a subset of
+the properties of an object.
 
 ```js
 // Simple subset
@@ -147,7 +148,7 @@ assertObjectMatch(
   { foo: true, bar: false },
   {
     foo: true,
-  }
+  },
 );
 ```
 
@@ -174,7 +175,7 @@ Deno.test("Test Assert Throws", () => {
       throw new Error("Panic!");
     },
     Error,
-    "Panic!"
+    "Panic!",
   );
 });
 ```
@@ -192,7 +193,7 @@ Deno.test("Test Assert Throws Async", () => {
       });
     },
     Error,
-    "Panic! Threw Error"
+    "Panic! Threw Error",
   );
 
   assertThrowsAsync(
@@ -200,7 +201,7 @@ Deno.test("Test Assert Throws Async", () => {
       return Promise.reject(new Error("Panic! Reject Error"));
     },
     Error,
-    "Panic! Reject Error"
+    "Panic! Reject Error",
   );
 });
 ```

--- a/docs/testing/assertions.md
+++ b/docs/testing/assertions.md
@@ -22,6 +22,7 @@ The assertions module provides 10 assertions:
 - `assertArrayIncludes(actual: unknown[], expected: unknown[], msg?: string): void`
 - `assertMatch(actual: string, expected: RegExp, msg?: string): void`
 - `assertNotMatch(actual: string, expected: RegExp, msg?: string): void`
+- `assertObjectMatch( actual: Record<PropertyKey, unknown>, expected: Record<PropertyKey, unknown>): void`
 - `assertThrows(fn: () => void, ErrorClass?: Constructor, msgIncludes = "", msg?: string): Error`
 - `assertThrowsAsync(fn: () => Promise<void>, ErrorClass?: Constructor, msgIncludes = "", msg?: string): Promise<Error>`
 
@@ -136,6 +137,20 @@ Deno.test("Test Assert Not Match", () => {
 });
 ```
 
+### Object
+
+Use `assertObjectMatch` to check that a JavaScript object matches a subset of the properties of an object.
+
+```js
+// Simple subset
+assertObjectMatch(
+  { foo: true, bar: false },
+  {
+    foo: true,
+  }
+);
+```
+
 ### Throws
 
 There are two ways to assert whether something throws an error in Deno,
@@ -159,7 +174,7 @@ Deno.test("Test Assert Throws", () => {
       throw new Error("Panic!");
     },
     Error,
-    "Panic!",
+    "Panic!"
   );
 });
 ```
@@ -177,7 +192,7 @@ Deno.test("Test Assert Throws Async", () => {
       });
     },
     Error,
-    "Panic! Threw Error",
+    "Panic! Threw Error"
   );
 
   assertThrowsAsync(
@@ -185,7 +200,7 @@ Deno.test("Test Assert Throws Async", () => {
       return Promise.reject(new Error("Panic! Reject Error"));
     },
     Error,
-    "Panic! Reject Error",
+    "Panic! Reject Error"
   );
 });
 ```


### PR DESCRIPTION
Adding `assertObjectMatch` example.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
