### PR TITLE
fix(cli/compile): do not append .exe depending on target

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -354,7 +354,8 @@ async fn compile_command(
 
   info!("{} {}", colors::green("Emit"), output.display());
 
-  tools::standalone::write_standalone_binary(output.clone(), final_bin).await?;
+  tools::standalone::write_standalone_binary(output.clone(), target, final_bin)
+    .await?;
 
   Ok(())
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -344,7 +344,7 @@ async fn compile_command(
 
   // Select base binary based on `target` and `lite` arguments
   let original_binary =
-    tools::standalone::get_base_binary(deno_dir, target, lite).await?;
+    tools::standalone::get_base_binary(deno_dir, target.clone(), lite).await?;
 
   let final_bin = tools::standalone::create_standalone_binary(
     original_binary,

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -5249,7 +5249,7 @@ console.log("finish");
   // https://github.com/denoland/deno/issues/9667
   fn compile_windows_ext() {
     let dir = TempDir::new().expect("tempdir fail");
-    let exe = dir.path().join("welcome");
+    let exe = dir.path().join("welcome_9667");
     let output = util::deno_cmd()
       .current_dir(util::root_path())
       .arg("compile")

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -5244,6 +5244,37 @@ console.log("finish");
   }
 
   #[test]
+  #[cfg(windows)]
+  // https://github.com/denoland/deno/issues/9667
+  fn compile_windows_ext() {
+    let dir = TempDir::new().expect("tempdir fail");
+    let exe = dir.path().join("welcome");
+    let output = util::deno_cmd()
+      .current_dir(util::root_path())
+      .arg("compile")
+      .arg("--unstable")
+      .arg("--output")
+      .arg(&exe)
+      .arg("--target")
+      .arg("x86_64-unknown-linux-gnu")
+      .arg("./test_util/std/examples/welcome.ts")
+      .stdout(std::process::Stdio::piped())
+      .spawn()
+      .unwrap()
+      .wait_with_output()
+      .unwrap();
+    assert!(output.status.success());
+    let output = Command::new(exe)
+      .stdout(std::process::Stdio::piped())
+      .spawn()
+      .unwrap()
+      .wait_with_output()
+      .unwrap();
+    assert!(output.status.success());
+    assert_eq!(output.stdout, "Welcome to Deno!\n".as_bytes());
+  }
+
+  #[test]
   fn standalone_args() {
     let dir = TempDir::new().expect("tempdir fail");
     let exe = if cfg!(windows) {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -7,6 +7,7 @@ use deno_runtime::deno_fetch::reqwest;
 use deno_runtime::deno_websocket::tokio_tungstenite;
 use std::fs;
 use std::io::{BufRead, Read, Write};
+use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 use test_util as util;
@@ -5264,14 +5265,8 @@ console.log("finish");
       .wait_with_output()
       .unwrap();
     assert!(output.status.success());
-    let output = Command::new(exe)
-      .stdout(std::process::Stdio::piped())
-      .spawn()
-      .unwrap()
-      .wait_with_output()
-      .unwrap();
-    assert!(output.status.success());
-    assert_eq!(output.stdout, "Welcome to Deno!\n".as_bytes());
+    let exists = Path::new(&exe).exists();
+    assert!(exists, true);
   }
 
   #[test]

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -132,21 +132,21 @@ pub async fn write_standalone_binary(
   target: Option<String>,
   final_bin: Vec<u8>,
 ) -> Result<(), AnyError> {
-  let output =
-    if cfg!(windows) && output.extension().unwrap_or_default() != "exe" {
-      match target {
-        Some(target) => {
-          if !target.contains("windows") {
-            output
-          } else {
-            PathBuf::from(output.display().to_string() + ".exe")
-          }
-        }
-        None => PathBuf::from(output.display().to_string() + ".exe"),
+  let output = match target {
+    Some(target) => {
+      if target.contains("windows") {
+        PathBuf::from(output.display().to_string() + ".exe")
+      } else {
+        output
       }
-    } else {
-      output
-    };
+    }
+    None => {
+      if cfg!(windows) && output.extension().unwrap_or_default() != "exe" {
+      } else {
+        output
+      }
+    }
+  };
 
   if output.exists() {
     // If the output is a directory, throw error

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -130,9 +130,15 @@ pub fn create_standalone_binary(
 pub async fn write_standalone_binary(
   output: PathBuf,
   final_bin: Vec<u8>,
+  target: Option<String>,
 ) -> Result<(), AnyError> {
   let output =
     if cfg!(windows) && output.extension().unwrap_or_default() != "exe" {
+      if let Some(target) = target {
+        if !target.contains("windows") {
+          output
+        }
+      }
       PathBuf::from(output.display().to_string() + ".exe")
     } else {
       output

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -129,17 +129,21 @@ pub fn create_standalone_binary(
 /// is not already standalone binary it will return error instead.
 pub async fn write_standalone_binary(
   output: PathBuf,
-  final_bin: Vec<u8>,
   target: Option<String>,
+  final_bin: Vec<u8>,
 ) -> Result<(), AnyError> {
   let output =
     if cfg!(windows) && output.extension().unwrap_or_default() != "exe" {
-      if let Some(target) = target {
-        if !target.contains("windows") {
-          output
+      match target {
+        Some(target) => {
+          if !target.contains("windows") {
+            output
+          } else {
+            PathBuf::from(output.display().to_string() + ".exe")
+          }
         }
+        None => PathBuf::from(output.display().to_string() + ".exe"),
       }
-      PathBuf::from(output.display().to_string() + ".exe")
     } else {
       output
     };

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -142,6 +142,7 @@ pub async fn write_standalone_binary(
     }
     None => {
       if cfg!(windows) && output.extension().unwrap_or_default() != "exe" {
+        PathBuf::from(output.display().to_string() + ".exe")
       } else {
         output
       }


### PR DESCRIPTION
Fixes bug described in https://discord.com/channels/684898665143206084/689420767620104201/816669791359991828

Prevents appending `.exe` extensions on windows based on target.

Fixes #9667 