### PR TITLE
fix: getBindGroupLayout always illegal invocation

### DIFF
--- a/op_crates/webgpu/01_webgpu.js
+++ b/op_crates/webgpu/01_webgpu.js
@@ -2315,7 +2315,7 @@
      * @returns {GPUBindGroupLayout}
      */
     getBindGroupLayout(index) {
-      webidl.assertBranded(this, GPURenderPipeline);
+      webidl.assertBranded(this, GPUComputePipeline);
       const prefix =
         "Failed to execute 'getBindGroupLayout' on 'GPUComputePipeline'";
       webidl.requiredArguments(arguments.length, 1, { prefix });


### PR DESCRIPTION
Reported by @DjDeveloper.

Will be tested by WebGPU CTS in the future.
