### PR TITLE
optimize(core): move internal js src off heap

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -424,8 +424,10 @@ impl JsRuntime {
 
     let scope = &mut v8::HandleScope::with_context(self.v8_isolate(), context);
 
-    let source = v8::String::new_external_onebyte_static(scope, js_source).unwrap();
-    let name = v8::String::new_external_onebyte_static(scope, js_filename).unwrap();
+    let source =
+      v8::String::new_external_onebyte_static(scope, js_source).unwrap();
+    let name =
+      v8::String::new_external_onebyte_static(scope, js_filename).unwrap();
     let origin = bindings::script_origin(scope, name);
 
     let tc_scope = &mut v8::TryCatch::new(scope);

--- a/op_crates/crypto/lib.rs
+++ b/op_crates/crypto/lib.rs
@@ -22,7 +22,7 @@ pub fn init(isolate: &mut JsRuntime) {
     include_str!("01_crypto.js"),
   )];
   for (url, source_code) in files {
-    isolate.execute(url, source_code).unwrap();
+    isolate.execute_static(url, source_code).unwrap();
   }
 }
 

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -333,7 +333,7 @@
       requiredArguments("FormData.set", arguments.length, 2);
       name = String(name);
 
-      // If there are any entries in the context object’s entry list whose name
+      // If there are any entries in the context object's entry list whose name
       // is name, replace the first such entry with entry and remove the others
       let found = false;
       let i = 0;
@@ -350,7 +350,7 @@
         i++;
       }
 
-      // Otherwise, append entry to the context object’s entry list.
+      // Otherwise, append entry to the context object's entry list.
       if (!found) {
         this[dataSymbol].push([name, parseFormDataValue(value, filename)]);
       }

--- a/op_crates/fetch/lib.rs
+++ b/op_crates/fetch/lib.rs
@@ -77,7 +77,7 @@ pub fn init(isolate: &mut JsRuntime) {
     ),
   ];
   for (url, source_code) in files {
-    isolate.execute(url, source_code).unwrap();
+    isolate.execute_static(url, source_code).unwrap();
   }
 }
 

--- a/op_crates/web/02_event.js
+++ b/op_crates/web/02_event.js
@@ -916,7 +916,7 @@
           // If signal is not null and its aborted flag is set, then return.
           return;
         } else {
-          // If listener’s signal is not null, then add the following abort
+          // If listener's signal is not null, then add the following abort
           // abort steps to it: Remove an event listener.
           signal.addEventListener("abort", () => {
             this.removeEventListener(type, callback, options);

--- a/op_crates/web/21_filereader.js
+++ b/op_crates/web/21_filereader.js
@@ -10,18 +10,18 @@
 
     fr.aborting = false;
 
-    // 1. If fr’s state is "loading", throw an InvalidStateError DOMException.
+    // 1. If fr's state is "loading", throw an InvalidStateError DOMException.
     if (fr.readyState === FileReader.LOADING) {
       throw new DOMException(
         "Invalid FileReader state.",
         "InvalidStateError",
       );
     }
-    // 2. Set fr’s state to "loading".
+    // 2. Set fr's state to "loading".
     fr.readyState = FileReader.LOADING;
-    // 3. Set fr’s result to null.
+    // 3. Set fr's result to null.
     fr.result = null;
-    // 4. Set fr’s error to null.
+    // 4. Set fr's error to null.
     fr.error = null;
 
     // 5. Let stream be the result of calling get stream on blob.
@@ -79,9 +79,9 @@
               return;
             }
 
-            // 1. Set fr’s state to "done".
+            // 1. Set fr's state to "done".
             fr.readyState = FileReader.DONE;
-            // 2. Let result be the result of package data given bytes, type, blob’s type, and encodingName.
+            // 2. Let result be the result of package data given bytes, type, blob's type, and encodingName.
             const size = chunks.reduce((p, i) => p + i.byteLength, 0);
             const bytes = new Uint8Array(size);
             let offs = 0;
@@ -115,7 +115,7 @@
               fr.dispatchEvent(ev);
             }
 
-            // 5. If fr’s state is not "loading", fire a progress event called loadend at the fr.
+            // 5. If fr's state is not "loading", fire a progress event called loadend at the fr.
             //Note: Event handler for the load or error events could have started another load, if that happens the loadend event for this load is not fired.
             if (fr.readyState !== FileReader.LOADING) {
               const ev = new ProgressEvent("loadend", {
@@ -143,7 +143,7 @@
           fr.dispatchEvent(ev);
         }
 
-        //If fr’s state is not "loading", fire a progress event called loadend at fr.
+        //If fr's state is not "loading", fire a progress event called loadend at fr.
         //Note: Event handler for the error event could have started another load, if that happens the loadend event for this load is not fired.
         if (fr.readyState !== FileReader.LOADING) {
           const ev = new ProgressEvent("loadend", {});

--- a/op_crates/web/lib.deno_web.d.ts
+++ b/op_crates/web/lib.deno_web.d.ts
@@ -102,7 +102,7 @@ declare class EventTarget {
      *
      * When set to true, options's passive indicates that the callback will not
      * cancel the event by invoking preventDefault(). This is used to enable
-     * performance optimizations described in § 2.8 Observing event listeners.
+     * performance optimizations described in section 2.8 Observing event listeners.
      *
      * When set to true, options's once indicates that the callback will only be
      * invoked once after which the event listener will be removed.

--- a/op_crates/web/lib.rs
+++ b/op_crates/web/lib.rs
@@ -55,7 +55,7 @@ pub fn init(isolate: &mut JsRuntime) {
     ),
   ];
   for (url, source_code) in files {
-    isolate.execute(url, source_code).unwrap();
+    isolate.execute_static(url, source_code).unwrap();
   }
 }
 

--- a/op_crates/webgpu/lib.rs
+++ b/op_crates/webgpu/lib.rs
@@ -104,7 +104,7 @@ pub fn init(isolate: &mut deno_core::JsRuntime) {
     ),
   ];
   for (url, source_code) in files {
-    isolate.execute(url, source_code).unwrap();
+    isolate.execute_static(url, source_code).unwrap();
   }
 }
 

--- a/op_crates/websocket/lib.rs
+++ b/op_crates/websocket/lib.rs
@@ -343,7 +343,7 @@ pub async fn op_ws_next_event(
 /// Load and execute the javascript code.
 pub fn init(isolate: &mut JsRuntime) {
   isolate
-    .execute(
+    .execute_static(
       "deno:op_crates/websocket/01_websocket.js",
       include_str!("01_websocket.js"),
     )

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -35,21 +35,22 @@
     return ArrayBuffer.isView(x) && !(x instanceof DataView);
   }
 
-  const tableChars = {
-    middleMiddle: "─",
-    rowMiddle: "┼",
-    topRight: "┐",
-    topLeft: "┌",
-    leftMiddle: "├",
-    topMiddle: "┬",
-    bottomRight: "┘",
-    bottomLeft: "└",
-    bottomMiddle: "┴",
-    rightMiddle: "┤",
-    left: "│ ",
-    right: " │",
-    middle: " │ ",
-  };
+  // Strings are escaped so all JS source is ASCII
+  var tableChars = {
+    bottomLeft: "\u2514",
+    bottomMiddle: "\u2534",
+    bottomRight: "\u2518",
+    left: "\u2502 ",
+    leftMiddle: "\u251c",
+    middle: " \u2502 ",
+    middleMiddle: "\u2500",
+    right: " \u2502",
+    rightMiddle: "\u2524",
+    rowMiddle: "\u253c",
+    topLeft: "\u250c",
+    topMiddle: "\u252c",
+    topRight: "\u2510",
+};
 
   function isFullWidthCodePoint(code) {
     // Code points are partially derived from:

--- a/runtime/js/02_console.js
+++ b/runtime/js/02_console.js
@@ -50,7 +50,7 @@
     topLeft: "\u250c",
     topMiddle: "\u252c",
     topRight: "\u2510",
-};
+  };
 
   function isFullWidthCodePoint(code) {
     // Code points are partially derived from:


### PR DESCRIPTION
This PR explores moving the internal JS code (bundled in `deno`) off the heap, as suggested by https://github.com/denoland/deno/issues/9675

## Impact

Reduce per-isolate heap by `~1MB`, reducing overall memory usage (especially with many workers), with no real downside or compromise.

This should also reduce snapshot sizes, resulting in faster snapshot restores and a smaller `deno` binary (these will likely be minor and weren't the core motivation)

## Subtasks

- [ ] ASCII JS code
  - [x] Ensure internal JS files are ASCII
  - [ ] Add a lint / CI test check to ensure files remain ASCII
- [x] Allow executing JS code via external `v8::String`s
  - [x] Implement external strings in `rusty_v8` (https://github.com/denoland/rusty_v8/pull/641)
  - [x] Implement `JsRuntime::execute_static`
- [ ] Work with snapshots
  - [ ] Implement support for string `ExternalReferences` in v8, so they can be captured and restored in snapshots
  - [ ] Register internal src references with the snapshot creator (maybe as they're passed through `execute_static` ?)

## Notes

Non-ASCII files found with (ignores test and example files):
```
find core runtime op_crates -name "*.[jt]s" | grep -v "examples" | grep -v "_test" | xargs file | grep -v ASCII
```

Non-ASCII characters in each file were then found with this regex: `[^\x00-\x7F]`

Non-ASCII files and context:
- `runtime/js/02_console.js`: the non-ASCII chars are the tableChars (L38)
- `op_crates/web/02_event.js`: there's a single utf8 apostrophe `’` vs `'` in comments (L919)
- `op_crates/web/21_filereader.js`: there are multiple utf8 apostrophes in comments (same as above)
- `op_crates/fetch/26_fetch.js`: same deal, same apostrophes
- `op_crates/web/lib.deno_web.d.ts`: used `§` in comment