### PR TITLE
fix(core) assertion failure in case of js error

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2053,13 +2053,12 @@ pub mod tests {
           Deno.core.dispatch(1, new Uint8Array([42]));
           Deno.core.dispatch(1, new Uint8Array([42]));
           "#,
-          )
-          .unwrap();
+        )
+        .unwrap();
 
       assert_eq!(dispatch_count.load(Ordering::Relaxed), 2);
-      match poll_until_ready(&mut runtime, 3) {
-        Ok(_) => panic!("Thrown error was not detected!"),
-        Err(_) => {},
+      if poll_until_ready(&mut runtime, 3).is_ok() {
+        panic!("Thrown error was not detected!")
       }
       runtime
         .execute("check.js", "assert(asyncRecv == 1);")

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1433,13 +1433,16 @@ impl JsRuntime {
 
     if shared_queue_size > 0 || overflown_responses_size > 0 {
       js_recv_cb.call(tc_scope, global, args.as_slice());
-      // The other side should have shifted off all the messages.
-      let shared_queue_size = state_rc.borrow().shared.size();
-      assert_eq!(shared_queue_size, 0);
     }
 
     match tc_scope.exception() {
-      None => Ok(()),
+      None => {
+        // The other side should have shifted off all the messages.
+        let shared_queue_size = state_rc.borrow().shared.size();
+        assert_eq!(shared_queue_size, 0);
+
+        Ok(())
+      }
       Some(exception) => exception_to_err_result(tc_scope, exception, false),
     }
   }


### PR DESCRIPTION
Extracted this bugfix from #9457.

In case JavaScript throws an unhandled error, part of the "shared_queue" could be still unprocessed. If this is the case; throw the js runtime error instead of asserting on the queue size not being 0.