### PR TITLE
fix(webgpu): ShaderModuleDescriptor code type

### DIFF
--- a/op_crates/webgpu/lib.deno_webgpu.d.ts
+++ b/op_crates/webgpu/lib.deno_webgpu.d.ts
@@ -460,7 +460,7 @@ declare class GPUShaderModule implements GPUObjectBase {
 }
 
 declare interface GPUShaderModuleDescriptor extends GPUObjectDescriptorBase {
-  code: string;
+  code: string | Uint32Array;
   sourceMap?: any;
 }
 


### PR DESCRIPTION
Add Uint32Array type for `code` in `ShaderModuleDescriptor`, for which support was fixed in #9698