### PR TITLE
fix(cil/eval): Fix eval command

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -506,8 +506,6 @@ async fn eval_command(
   // Save our fake file into file fetcher cache
   // to allow module access by TS compiler.
   program_state.file_fetcher.insert_cached(file);
-
-
   debug!("main_module {}", &main_module);
   worker.execute_module(&main_module).await?;
   worker.execute("window.dispatchEvent(new Event('load'))")?;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -496,8 +496,6 @@ async fn eval_command(
       MediaType::TypeScript
     } else if ext.as_str() == "tsx" {
       MediaType::TSX
-    } else if ext.as_str() == "js" {
-      MediaType::JavaScript
     } else {
       MediaType::JSX
     },
@@ -508,6 +506,8 @@ async fn eval_command(
   // Save our fake file into file fetcher cache
   // to allow module access by TS compiler.
   program_state.file_fetcher.insert_cached(file);
+
+
   debug!("main_module {}", &main_module);
   worker.execute_module(&main_module).await?;
   worker.execute("window.dispatchEvent(new Event('load'))")?;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -496,8 +496,10 @@ async fn eval_command(
       MediaType::TypeScript
     } else if ext.as_str() == "tsx" {
       MediaType::TSX
-    } else {
+    } else if ext.as_str() == "jsx" || ext.as_str() == "js" {
       MediaType::JSX
+    } else {
+      MediaType::Unknown
     },
     source: String::from_utf8(source_code)?,
     specifier: main_module.clone(),


### PR DESCRIPTION
fix #9733

I remove `MediaType::JavaScript`because As a result of checking, only `MediaType::JavaScript` cannot confirm that the code has been changed.

Screenshot (fix): 
![image](https://user-images.githubusercontent.com/71239005/110816741-f7f78600-82ce-11eb-840a-60179cb7fb5d.png)
