### PR TITLE
fix(cli/module_graph): Set useDefineForClassFields to true

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -314,6 +314,7 @@ impl Inner {
       "noEmit": true,
       "strict": true,
       "target": "esnext",
+      "useDefineForClassFields": true,
     }));
     let (maybe_config, maybe_root_uri) = {
       let config = &self.config;

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -809,6 +809,7 @@ impl Graph {
       "strict": true,
       "target": "esnext",
       "tsBuildInfoFile": "deno:///.tsbuildinfo",
+      "useDefineForClassFields": true,
     }));
     if options.emit {
       config.merge(&json!({
@@ -954,6 +955,7 @@ impl Graph {
       "module": "esnext",
       "strict": true,
       "target": "esnext",
+      "useDefineForClassFields": true,
     }));
     let opts = match options.bundle_type {
       BundleType::Esm | BundleType::Iife => json!({

--- a/cli/tests/088_use_define_for_class_fields.ts
+++ b/cli/tests/088_use_define_for_class_fields.ts
@@ -1,0 +1,4 @@
+class A {
+  b = this.a;
+  constructor(public a: unknown) {}
+}

--- a/cli/tests/088_use_define_for_class_fields.ts.out
+++ b/cli/tests/088_use_define_for_class_fields.ts.out
@@ -1,0 +1,4 @@
+[WILDCARD]error: TS2729 [ERROR]: Property 'a' is used before its initialization.
+  b = this.a;
+           ^
+[WILDCARD]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2841,6 +2841,12 @@ console.log("finish");
     output: "087_no_check_imports_not_used_as_values.ts.out",
   });
 
+  itest!(_088_use_define_for_class_fields {
+    args: "run 088_use_define_for_class_fields.ts",
+    output: "088_use_define_for_class_fields.ts.out",
+    exit_code: 1,
+  });
+
   itest!(js_import_detect {
     args: "run --quiet --reload js_import_detect.ts",
     output: "js_import_detect.ts.out",

--- a/cli/tsc_config.rs
+++ b/cli/tsc_config.rs
@@ -130,6 +130,7 @@ pub const IGNORED_RUNTIME_COMPILER_OPTIONS: &[&str] = &[
   "traceResolution",
   "tsBuildInfoFile",
   "typeRoots",
+  "useDefineForClassFields",
   "version",
   "watch",
 ];


### PR DESCRIPTION
We decided to do this around https://github.com/denoland/deno/issues/7148#issuecomment-678754613, added `"useDefineForClassFields"` to the set of ignored compiler options in #7228 and documented it as set to true in #9196. Unless there was a regression, I don't think we ever actually set it to true.

Fixes #9773 (the example now produces an intuitive type error).