### PR TITLE
feat(web): add AbortSignal.abort() static

### DIFF
--- a/cli/tests/unit/abort_controller_test.ts
+++ b/cli/tests/unit/abort_controller_test.ts
@@ -56,6 +56,6 @@ unitTest(function controllerHasProperToString() {
 });
 
 unitTest(function signalHasMethodAbort() {
-  const aborted = AbortSignal.abort();
-  assertEquals(abort.aborted, true);
+  const signal = AbortSignal.abort();
+  assertEquals(signal.aborted, true);
 });

--- a/cli/tests/unit/abort_controller_test.ts
+++ b/cli/tests/unit/abort_controller_test.ts
@@ -54,3 +54,8 @@ unitTest(function controllerHasProperToString() {
   const actual = Object.prototype.toString.call(new AbortController());
   assertEquals(actual, "[object AbortController]");
 });
+
+unitTest(function signalHasMethodAbort() {
+  const aborted = AbortSignal.abort();
+  assertEquals(abort.aborted, true);
+});

--- a/op_crates/web/03_abort_signal.js
+++ b/op_crates/web/03_abort_signal.js
@@ -50,6 +50,12 @@
     get [Symbol.toStringTag]() {
       return "AbortSignal";
     }
+
+    static abort() {
+      const as = new AbortSignal(illegalConstructorKey);
+      as[signalAbort]();
+      return as;
+    }
   }
   defineEventHandler(AbortSignal.prototype, "abort");
   class AbortController {

--- a/op_crates/web/lib.deno_web.d.ts
+++ b/op_crates/web/lib.deno_web.d.ts
@@ -252,6 +252,8 @@ interface AbortSignal extends EventTarget {
 declare var AbortSignal: {
   prototype: AbortSignal;
   new (): AbortSignal;
+
+  abort(): AbortSignal;
 };
 
 interface FileReaderEventMap {


### PR DESCRIPTION
Implements https://github.com/whatwg/dom/pull/960/files in Deno to keep Deno's AbortSignal (relatively) spec compliant :)

Basically this adds a static method that creates an already aborted signal - similarly to `Promise.reject`