### PR TITLE
Use workaround for serde_derive CI issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            .cargo_home
             target/*/.*
             target/*/build
             target/*/deps


### PR DESCRIPTION
Experiencing CI issues: https://github.com/denoland/deno/runs/2099314334

See also https://github.com/actions-rs/cargo/issues/111, https://github.com/denoland/rusty_v8/commit/8e35aaf6ad0f996285275196f6d0e4a65763544f