### PR TITLE
refactor(lsp): refactor completions and add tests

### DIFF
--- a/cli/lsp/capabilities.rs
+++ b/cli/lsp/capabilities.rs
@@ -55,7 +55,12 @@ pub fn server_capabilities(
     )),
     hover_provider: Some(HoverProviderCapability::Simple(true)),
     completion_provider: Some(CompletionOptions {
-      all_commit_characters: None,
+      all_commit_characters: Some(vec![
+        ".".to_string(),
+        ",".to_string(),
+        ";".to_string(),
+        "(".to_string(),
+      ]),
       trigger_characters: Some(vec![
         ".".to_string(),
         "\"".to_string(),
@@ -66,7 +71,7 @@ pub fn server_capabilities(
         "<".to_string(),
         "#".to_string(),
       ]),
-      resolve_provider: None,
+      resolve_provider: Some(true),
       work_done_progress_options: WorkDoneProgressOptions {
         work_done_progress: None,
       },
@@ -77,7 +82,7 @@ pub fn server_capabilities(
         "(".to_string(),
         "<".to_string(),
       ]),
-      retrigger_characters: None,
+      retrigger_characters: Some(vec![")".to_string()]),
       work_done_progress_options: WorkDoneProgressOptions {
         work_done_progress: None,
       },

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -15,7 +15,7 @@ pub struct ClientCapabilities {
   pub workspace_did_change_watched_files: bool,
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeLensSettings {
   /// Flag for providing implementation code lenses.
@@ -30,13 +30,50 @@ pub struct CodeLensSettings {
   pub references_all_functions: bool,
 }
 
+impl Default for CodeLensSettings {
+  fn default() -> Self {
+    Self {
+      implementations: false,
+      references: false,
+      references_all_functions: false,
+    }
+  }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletionSettings {
+  #[serde(default)]
+  pub complete_function_calls: bool,
+  #[serde(default)]
+  pub names: bool,
+  #[serde(default)]
+  pub paths: bool,
+  #[serde(default)]
+  pub auto_imports: bool,
+}
+
+impl Default for CompletionSettings {
+  fn default() -> Self {
+    Self {
+      complete_function_calls: false,
+      names: true,
+      paths: true,
+      auto_imports: true,
+    }
+  }
+}
+
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceSettings {
   pub enable: bool,
   pub config: Option<String>,
   pub import_map: Option<String>,
-  pub code_lens: Option<CodeLensSettings>,
+  #[serde(default)]
+  pub code_lens: CodeLensSettings,
+  #[serde(default)]
+  pub suggest: CompletionSettings,
 
   #[serde(default)]
   pub lint: bool,
@@ -48,36 +85,7 @@ impl WorkspaceSettings {
   /// Determine if any code lenses are enabled at all.  This allows short
   /// circuiting when there are no code lenses enabled.
   pub fn enabled_code_lens(&self) -> bool {
-    if let Some(code_lens) = &self.code_lens {
-      // This should contain all the "top level" code lens references
-      code_lens.implementations || code_lens.references
-    } else {
-      false
-    }
-  }
-
-  pub fn enabled_code_lens_implementations(&self) -> bool {
-    if let Some(code_lens) = &self.code_lens {
-      code_lens.implementations
-    } else {
-      false
-    }
-  }
-
-  pub fn enabled_code_lens_references(&self) -> bool {
-    if let Some(code_lens) = &self.code_lens {
-      code_lens.references
-    } else {
-      false
-    }
-  }
-
-  pub fn enabled_code_lens_references_all_functions(&self) -> bool {
-    if let Some(code_lens) = &self.code_lens {
-      code_lens.references_all_functions
-    } else {
-      false
-    }
+    self.code_lens.implementations || self.code_lens.references
   }
 }
 

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1110,10 +1110,8 @@ impl CompletionEntry {
   fn get_filter_text(&self) -> Option<String> {
     // TODO(@kitsonk) this is actually quite a bit more complex.
     // See `MyCompletionItem.getFilterText` in vscode completion.ts.
-    if self.name.starts_with("#") {
-      if self.insert_text.is_none() {
-        return Some(self.name.clone());
-      }
+    if self.name.starts_with("#") && self.insert_text.is_none() {
+      return Some(self.name.clone());
     }
 
     if let Some(insert_text) = &self.insert_text {

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1007,7 +1007,7 @@ impl CompletionInfo {
         v.as_object()
           .unwrap()
           .get("isIncomplete")
-          .unwrap_or_else(|| &json!(false))
+          .unwrap_or(&json!(false))
           .as_bool()
           .unwrap()
       })
@@ -1110,7 +1110,7 @@ impl CompletionEntry {
   fn get_filter_text(&self) -> Option<String> {
     // TODO(@kitsonk) this is actually quite a bit more complex.
     // See `MyCompletionItem.getFilterText` in vscode completion.ts.
-    if self.name.starts_with("#") && self.insert_text.is_none() {
+    if self.name.starts_with('#') && self.insert_text.is_none() {
       return Some(self.name.clone());
     }
 
@@ -1118,7 +1118,7 @@ impl CompletionEntry {
       if insert_text.starts_with("this.") {
         return None;
       }
-      if insert_text.starts_with("[") {
+      if insert_text.starts_with('[') {
         let re = Regex::new(r#"^\[['"](.+)['"]\]$"#).unwrap();
         let insert_text = re.replace(insert_text, ".$1").to_string();
         return Some(insert_text);
@@ -1194,7 +1194,7 @@ impl CompletionEntry {
         let range = text_span.to_range(line_index);
         let insert_replace_edit = lsp::InsertReplaceEdit {
           new_text,
-          insert: range.clone(),
+          insert: range,
           replace: range,
         };
         Some(insert_replace_edit.into())

--- a/cli/tests/lsp/completion_request.json
+++ b/cli/tests/lsp/completion_request.json
@@ -1,0 +1,18 @@
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "textDocument/completion",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts"
+    },
+    "position": {
+      "line": 0,
+      "character": 5
+    },
+    "context": {
+      "triggerKind": 2,
+      "triggerCharacter": "."
+    }
+  }
+}

--- a/cli/tests/lsp/completion_resolve_request.json
+++ b/cli/tests/lsp/completion_resolve_request.json
@@ -1,0 +1,17 @@
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "completionItem/resolve",
+  "params": {
+    "label": "build",
+    "kind": 6,
+    "sortText": "1",
+    "insertTextFormat": 1,
+    "data": {
+      "specifier": "file:///a/file.ts",
+      "position": 5,
+      "name": "build",
+      "useCodeSnippet": false
+    }
+  }
+}

--- a/cli/tests/lsp/did_open_notification_completions.json
+++ b/cli/tests/lsp/did_open_notification_completions.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/didOpen",
+  "params": {
+    "textDocument": {
+      "uri": "file:///a/file.ts",
+      "languageId": "typescript",
+      "version": 1,
+      "text": "Deno."
+    }
+  }
+}

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -594,6 +594,22 @@ delete Object.prototype.__proto__;
           ),
         );
       }
+      case "getCompletionDetails": {
+        debug("request", request);
+        return respond(
+          id,
+          languageService.getCompletionEntryDetails(
+            request.args.specifier,
+            request.args.position,
+            request.args.name,
+            undefined,
+            request.args.source,
+            undefined,
+            // @ts-expect-error this exists in 4.3 but not part of the d.ts
+            request.args.data,
+          ),
+        );
+      }
       case "getCompletions": {
         return respond(
           id,

--- a/cli/tsc/compiler.d.ts
+++ b/cli/tsc/compiler.d.ts
@@ -51,6 +51,7 @@ declare global {
     | GetAsset
     | GetCodeFixes
     | GetCombinedCodeFix
+    | GetCompletionDetails
     | GetCompletionsRequest
     | GetDefinitionRequest
     | GetDiagnosticsRequest
@@ -102,11 +103,22 @@ declare global {
     fixId: {};
   }
 
+  interface GetCompletionDetails extends BaseLanguageServerRequest {
+    method: "getCompletionDetails";
+    args: {
+      specifier: string;
+      position: number;
+      name: string;
+      source?: string;
+      data?: unknown;
+    };
+  }
+
   interface GetCompletionsRequest extends BaseLanguageServerRequest {
     method: "getCompletions";
     specifier: string;
     position: number;
-    preferences: ts.UserPreferences;
+    preferences: ts.GetCompletionsAtPositionOptions;
   }
 
   interface GetDiagnosticsRequest extends BaseLanguageServerRequest {


### PR DESCRIPTION
This refactor is to give us a more solid base to build on for import completions.

It refactors some code and adds a completion resolver, plus some tests.