### PR TITLE
Revert "fix(cli/module_graph): Set useDefineForClassFields to true"

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -314,7 +314,6 @@ impl Inner {
       "noEmit": true,
       "strict": true,
       "target": "esnext",
-      "useDefineForClassFields": true,
     }));
     let (maybe_config, maybe_root_uri) = {
       let config = &self.config;

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -809,7 +809,6 @@ impl Graph {
       "strict": true,
       "target": "esnext",
       "tsBuildInfoFile": "deno:///.tsbuildinfo",
-      "useDefineForClassFields": true,
     }));
     if options.emit {
       config.merge(&json!({
@@ -955,7 +954,6 @@ impl Graph {
       "module": "esnext",
       "strict": true,
       "target": "esnext",
-      "useDefineForClassFields": true,
     }));
     let opts = match options.bundle_type {
       BundleType::Esm | BundleType::Iife => json!({

--- a/cli/tests/088_use_define_for_class_fields.ts
+++ b/cli/tests/088_use_define_for_class_fields.ts
@@ -1,4 +1,0 @@
-class A {
-  b = this.a;
-  constructor(public a: unknown) {}
-}

--- a/cli/tests/088_use_define_for_class_fields.ts.out
+++ b/cli/tests/088_use_define_for_class_fields.ts.out
@@ -1,4 +1,0 @@
-[WILDCARD]error: TS2729 [ERROR]: Property 'a' is used before its initialization.
-  b = this.a;
-           ^
-[WILDCARD]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2841,12 +2841,6 @@ console.log("finish");
     output: "087_no_check_imports_not_used_as_values.ts.out",
   });
 
-  itest!(_088_use_define_for_class_fields {
-    args: "run 088_use_define_for_class_fields.ts",
-    output: "088_use_define_for_class_fields.ts.out",
-    exit_code: 1,
-  });
-
   itest!(js_import_detect {
     args: "run --quiet --reload js_import_detect.ts",
     output: "js_import_detect.ts.out",

--- a/cli/tsc_config.rs
+++ b/cli/tsc_config.rs
@@ -130,7 +130,6 @@ pub const IGNORED_RUNTIME_COMPILER_OPTIONS: &[&str] = &[
   "traceResolution",
   "tsBuildInfoFile",
   "typeRoots",
-  "useDefineForClassFields",
   "version",
   "watch",
 ];


### PR DESCRIPTION
Backwards incompatible change cannot be made in-between patch releases.

This commit broke std tests https://github.com/denoland/deno_std/runs/2112369372

This reverts commit c4709834b37640fd3c9d492123e6add904546573.


cc @nayeemrmn 