### PR TITLE
fix(runtime): mitigate permission prompt stuffing

### DIFF
--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -641,6 +641,12 @@ fn permission_prompt(message: &str) -> bool {
   if !atty::is(atty::Stream::Stdin) || !atty::is(atty::Stream::Stderr) {
     return false;
   };
+  #[cfg(unix)]
+  unsafe {
+    if -1 == libc::tcflush(libc::STDIN_FILENO, libc::TCIFLUSH) {
+      return false;
+    }
+  }
   let msg = format!(
     "️{}  {}. Grant? [g/d (g = grant, d = deny)] ",
     PERMISSION_EMOJI, message


### PR DESCRIPTION
Flush the tty's input buffer before reading to avoid already typed
characters from being treated as the answer to the permissions prompt.

Fixes #9750.

<hr>

An orthogonal issue is putting the tty into a known-good state (and restoring it afterwards) with `tcsetattr()`.