### PR TITLE
Feature: coverage threshold

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -876,10 +876,7 @@ async fn coverage_command(
   ignore: Vec<PathBuf>,
   include: Vec<String>,
   exclude: Vec<String>,
-  check: bool,
-  lines: f32,
-  functions: f32,
-  branches: f32,
+  threshold: tools::coverage::CoverageThreshold,
   lcov: bool,
 ) -> Result<(), AnyError> {
   if !flags.unstable {
@@ -897,10 +894,7 @@ async fn coverage_command(
     ignore,
     include,
     exclude,
-    check,
-    lines,
-    functions,
-    branches,
+    threshold,
     lcov,
   )
   .await
@@ -1098,8 +1092,18 @@ fn get_subcommand(
       branches,
       lcov,
     } => coverage_command(
-      flags, files, ignore, include, exclude, check, lines, functions,
-      branches, lcov,
+      flags,
+      files,
+      ignore,
+      include,
+      exclude,
+      tools::coverage::CoverageThreshold {
+        check,
+        lines,
+        functions,
+        branches,
+      },
+      lcov,
     )
     .boxed_local(),
     DenoSubcommand::Fmt {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -876,6 +876,10 @@ async fn coverage_command(
   ignore: Vec<PathBuf>,
   include: Vec<String>,
   exclude: Vec<String>,
+  check: bool,
+  lines: f32,
+  functions: f32,
+  branches: f32,
   lcov: bool,
 ) -> Result<(), AnyError> {
   if !flags.unstable {
@@ -893,6 +897,10 @@ async fn coverage_command(
     ignore,
     include,
     exclude,
+    check,
+    lines,
+    functions,
+    branches,
     lcov,
   )
   .await
@@ -1084,9 +1092,16 @@ fn get_subcommand(
       ignore,
       include,
       exclude,
+      check,
+      lines,
+      functions,
+      branches,
       lcov,
-    } => coverage_command(flags, files, ignore, include, exclude, lcov)
-      .boxed_local(),
+    } => coverage_command(
+      flags, files, ignore, include, exclude, check, lines, functions,
+      branches, lcov,
+    )
+    .boxed_local(),
     DenoSubcommand::Fmt {
       check,
       files,

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -4175,29 +4175,21 @@ console.log("finish");
         .current_dir(util::root_path())
         .arg("coverage")
         .arg("--check")
-        .arg("--lines=70")
-        .arg("--branches=80")
+        .arg("--lines=99")
+        .arg("--branches=99")
         .arg("--unstable")
         .arg("--lcov")
         .arg(format!("{}/", tempdir.path().to_str().unwrap()))
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::inherit())
-        .output()
-        .expect("failed to spawn coverage reporter");
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap()
+        .wait_with_output()
+        .unwrap();
 
-      let actual =
-        util::strip_ansi_codes(std::str::from_utf8(&output.stderr).unwrap())
-          .to_string();
+      assert!(!output.status.success());
+      let stderr = std::str::from_utf8(&output.stderr).unwrap().trim();
 
-      let expected = "The coverage threshold is not met";
-
-      if !util::wildcard_match(&expected, &actual) {
-        println!("OUTPUT\n{}\nOUTPUT", actual);
-        println!("EXPECTED\n{}\nEXPECTED", expected);
-        panic!("pattern match failed");
-      }
-
-      assert!(output.status.success());
+      assert!(stderr.contains("The coverage threshold is not met"));
     }
   }
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -4153,6 +4153,52 @@ console.log("finish");
 
       assert!(output.status.success());
     }
+
+    #[test]
+    fn coverage_threshold() {
+      let tempdir = TempDir::new().expect("tempdir fail");
+      let status = util::deno_cmd()
+        .current_dir(util::root_path())
+        .arg("test")
+        .arg("--quiet")
+        .arg("--unstable")
+        .arg(format!("--coverage={}", tempdir.path().to_str().unwrap()))
+        .arg("cli/tests/coverage/branch_test.ts")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .status()
+        .expect("failed to spawn test runner");
+
+      assert!(status.success());
+
+      let output = util::deno_cmd()
+        .current_dir(util::root_path())
+        .arg("coverage")
+        .arg("--check")
+        .arg("--lines=70")
+        .arg("--branches=80")
+        .arg("--unstable")
+        .arg("--lcov")
+        .arg(format!("{}/", tempdir.path().to_str().unwrap()))
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("failed to spawn coverage reporter");
+
+      let actual =
+        util::strip_ansi_codes(std::str::from_utf8(&output.stderr).unwrap())
+          .to_string();
+
+      let expected = "The coverage threshold is not met";
+
+      if !util::wildcard_match(&expected, &actual) {
+        println!("OUTPUT\n{}\nOUTPUT", actual);
+        println!("EXPECTED\n{}\nEXPECTED", expected);
+        panic!("pattern match failed");
+      }
+
+      assert!(output.status.success());
+    }
   }
 
   mod permissions {

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -25,6 +25,13 @@ use std::path::PathBuf;
 use swc_common::Span;
 use uuid::Uuid;
 
+pub struct CoverageThreshold {
+  pub check: bool,
+  pub lines: f32,
+  pub functions: f32,
+  pub branches: f32,
+}
+
 pub struct CoverageCollector {
   pub dir: PathBuf,
   session: Box<InspectorSession>,
@@ -372,7 +379,7 @@ impl CoverageReporter for LcovCoverageReporter {
 
     println!("end_of_record");
 
-    return TotalVisitCoverage {
+    TotalVisitCoverage {
       lines: Some(CoverageValues {
         hit: lines_hit as f32,
         found: lines_found as f32,
@@ -385,7 +392,7 @@ impl CoverageReporter for LcovCoverageReporter {
         hit: functions_hit as f32,
         found: functions_found as f32,
       }),
-    };
+    }
   }
 
   fn done(&mut self) {}
@@ -563,14 +570,14 @@ impl CoverageReporter for PrettyCoverageReporter {
 
       last_line = Some(line_index);
     }
-    return TotalVisitCoverage {
+    TotalVisitCoverage {
       lines: Some(CoverageValues {
         hit: lines_hit as f32,
         found: lines_found as f32,
       }),
       branches: None,
       functions: None,
-    };
+    }
   }
 
   fn done(&mut self) {}
@@ -667,13 +674,16 @@ pub async fn cover_files(
   ignore: Vec<PathBuf>,
   include: Vec<String>,
   exclude: Vec<String>,
-  check: bool,
-  lines: f32,
-  functions: f32,
-  branches: f32,
+  threshold: CoverageThreshold,
   lcov: bool,
 ) -> Result<(), AnyError> {
   let program_state = ProgramState::build(flags).await?;
+  let CoverageThreshold {
+    check,
+    lines,
+    functions,
+    branches,
+  } = threshold;
   let mut total_coverages = TotalCoverages {
     lines: CoverageValues {
       hit: 0.0,
@@ -801,7 +811,7 @@ pub async fn cover_files(
     if !threshold_met {
       return Err(custom_error(
         "CoverageThreshold",
-        colors::red(format!("The coverage threshold is not met",)).to_string(),
+        "The coverage threshold is not met",
       ));
     }
   }


### PR DESCRIPTION
Closes #9669

This PR adds the possibility to set a threshold to the `deno coverage` command and fail if coverage doesn't meet it.

I have reused the same nomenclature that was proposed in the issue.

![carbon (10)](https://user-images.githubusercontent.com/32459935/111647298-a84f1800-8802-11eb-9aba-e4d0a8b278e1.png)

If the command has the `--lcov` flag, it will check the coverage for `lines`, `branches` and `functions` otherwise it will only check for `lines` as the `PrettyCoverageReporter` doesn't have a way to identify the coverage for `branches` and `functions`.

By default, the threshold is set to **80%**.

If coverage doesn't meet the threshold, it will throw an error and display the coverage elements that are below the threshold.

<p align="center">
<img src="https://user-images.githubusercontent.com/32459935/111647969-39be8a00-8803-11eb-8d36-66e1ba49f763.png" width="600" />
</p>

I would love to get your feedback on what I did and discuss what could be improved 👍

I don't know if the `println` errors are relevant, in case the user does a `deno coverage --unstable cov_profile --lcov > cov_profile.lcov`. He will get the errors `"The coverage threshold..."` in his file.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
