### PR TITLE
fix(core): Adds type errors to invalid arguments for print

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -326,7 +326,7 @@ fn print(
   if arg_len == 2 {
     let int_val = match is_err_arg.integer_value(scope) {
       Some(v) => v,
-      None => return throw_type_error(scope, "Arugment 2 is invalid."),
+      None => return throw_type_error(scope, "Invalid arugment. Argument 2 should indicate wheter or not to print to stderr."),
     };
     is_err = int_val != 0;
   };

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -315,16 +315,19 @@ fn print(
   _rv: v8::ReturnValue,
 ) {
   let arg_len = args.length();
-  assert!((0..=2).contains(&arg_len));
+  if !(0..=2).contains(&arg_len) {
+    return throw_type_error(scope, "Expected a maximum of 2 arguments.");
+  }
 
   let obj = args.get(0);
   let is_err_arg = args.get(1);
 
   let mut is_err = false;
   if arg_len == 2 {
-    let int_val = is_err_arg
-      .integer_value(scope)
-      .expect("Unable to convert to integer");
+    let int_val = match is_err_arg.integer_value(scope) {
+      Some(v) => v,
+      None => return throw_type_error(scope, "Arugment 2 is invalid."),
+    };
     is_err = int_val != 0;
   };
   let tc_scope = &mut v8::TryCatch::new(scope);


### PR DESCRIPTION
Resolves #9812 . 

Will now throw type error when too many arguments are passed or the second argument can't be parsed into an integer. Had some trouble figuring out how to test the core changes. Would be great to get some direction if possible and a test is required. 