### PR TITLE
chores: enforce type ResourceId across codebase

### DIFF
--- a/core/examples/http_bench_bin_ops.rs
+++ b/core/examples/http_bench_bin_ops.rs
@@ -12,6 +12,7 @@ use deno_core::Op;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use futures::future::FutureExt;
 use futures::future::TryFuture;
@@ -122,7 +123,7 @@ impl From<tokio::net::TcpStream> for TcpStream {
 #[derive(Copy, Clone, Debug, PartialEq)]
 struct Record {
   promise_id: u32,
-  rid: u32,
+  rid: ResourceId,
   result: i32,
 }
 
@@ -162,7 +163,7 @@ fn create_js_runtime() -> JsRuntime {
 
 fn op_listen(
   state: &mut OpState,
-  _rid: u32,
+  _rid: ResourceId,
   _bufs: &mut [ZeroCopyBuf],
 ) -> Result<u32, Error> {
   debug!("listen");
@@ -176,7 +177,7 @@ fn op_listen(
 
 fn op_close(
   state: &mut OpState,
-  rid: u32,
+  rid: ResourceId,
   _bufs: &mut [ZeroCopyBuf],
 ) -> Result<u32, Error> {
   debug!("close rid={}", rid);
@@ -189,7 +190,7 @@ fn op_close(
 
 async fn op_accept(
   state: Rc<RefCell<OpState>>,
-  rid: u32,
+  rid: ResourceId,
   _bufs: BufVec,
 ) -> Result<u32, Error> {
   debug!("accept rid={}", rid);
@@ -206,7 +207,7 @@ async fn op_accept(
 
 async fn op_read(
   state: Rc<RefCell<OpState>>,
-  rid: u32,
+  rid: ResourceId,
   mut bufs: BufVec,
 ) -> Result<usize, Error> {
   assert_eq!(bufs.len(), 1, "Invalid number of arguments");
@@ -222,7 +223,7 @@ async fn op_read(
 
 async fn op_write(
   state: Rc<RefCell<OpState>>,
-  rid: u32,
+  rid: ResourceId,
   bufs: BufVec,
 ) -> Result<usize, Error> {
   assert_eq!(bufs.len(), 1, "Invalid number of arguments");

--- a/op_crates/fetch/lib.rs
+++ b/op_crates/fetch/lib.rs
@@ -21,6 +21,7 @@ use deno_core::JsRuntime;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 
 use reqwest::header::HeaderMap;
@@ -210,7 +211,7 @@ where
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FetchSendArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 pub async fn op_fetch_send(
@@ -278,7 +279,7 @@ pub async fn op_fetch_send(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FetchRequestWriteArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 pub async fn op_fetch_request_write(
@@ -308,7 +309,7 @@ pub async fn op_fetch_request_write(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FetchResponseReadArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 pub async fn op_fetch_response_read(

--- a/op_crates/webgpu/binding.rs
+++ b/op_crates/webgpu/binding.rs
@@ -4,6 +4,7 @@ use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
@@ -73,7 +74,7 @@ struct GPUBindGroupLayoutEntry {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateBindGroupLayoutArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   label: Option<String>,
   entries: Vec<GPUBindGroupLayoutEntry>,
 }
@@ -215,7 +216,7 @@ pub fn op_webgpu_create_bind_group_layout(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreatePipelineLayoutArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   label: Option<String>,
   bind_group_layouts: Vec<u32>,
 }
@@ -277,7 +278,7 @@ struct GPUBindGroupEntry {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateBindGroupArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   label: Option<String>,
   layout: u32,
   entries: Vec<GPUBindGroupEntry>,

--- a/op_crates/webgpu/buffer.rs
+++ b/op_crates/webgpu/buffer.rs
@@ -6,6 +6,7 @@ use deno_core::futures::channel::oneshot;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::OpState;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{BufVec, Resource};
 use serde::Deserialize;
@@ -34,7 +35,7 @@ impl Resource for WebGPUBufferMapped {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateBufferArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   label: Option<String>,
   size: u64,
   usage: u32,
@@ -77,8 +78,8 @@ pub fn op_webgpu_create_buffer(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BufferGetMapAsyncArgs {
-  buffer_rid: u32,
-  device_rid: u32,
+  buffer_rid: ResourceId,
+  device_rid: ResourceId,
   mode: u32,
   offset: u64,
   size: u64,
@@ -168,7 +169,7 @@ pub async fn op_webgpu_buffer_get_map_async(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BufferGetMappedRangeArgs {
-  buffer_rid: u32,
+  buffer_rid: ResourceId,
   offset: u64,
   size: u64,
 }
@@ -209,8 +210,8 @@ pub fn op_webgpu_buffer_get_mapped_range(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BufferUnmapArgs {
-  buffer_rid: u32,
-  mapped_rid: u32,
+  buffer_rid: ResourceId,
+  mapped_rid: ResourceId,
 }
 
 pub fn op_webgpu_buffer_unmap(

--- a/op_crates/webgpu/bundle.rs
+++ b/op_crates/webgpu/bundle.rs
@@ -4,6 +4,7 @@ use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
@@ -33,7 +34,7 @@ impl Resource for WebGPURenderBundle {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateRenderBundleEncoderArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   label: Option<String>,
   color_formats: Vec<String>,
   depth_stencil_format: Option<String>,
@@ -92,7 +93,7 @@ pub fn op_webgpu_create_render_bundle_encoder(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderBundleEncoderFinishArgs {
-  render_bundle_encoder_rid: u32,
+  render_bundle_encoder_rid: ResourceId,
   label: Option<String>,
 }
 
@@ -131,7 +132,7 @@ pub fn op_webgpu_render_bundle_encoder_finish(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderBundleEncoderSetBindGroupArgs {
-  render_bundle_encoder_rid: u32,
+  render_bundle_encoder_rid: ResourceId,
   index: u32,
   bind_group: u32,
   dynamic_offsets_data: Option<Vec<u32>>,
@@ -190,7 +191,7 @@ pub fn op_webgpu_render_bundle_encoder_set_bind_group(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderBundleEncoderPushDebugGroupArgs {
-  render_bundle_encoder_rid: u32,
+  render_bundle_encoder_rid: ResourceId,
   group_label: String,
 }
 
@@ -218,7 +219,7 @@ pub fn op_webgpu_render_bundle_encoder_push_debug_group(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderBundleEncoderPopDebugGroupArgs {
-  render_bundle_encoder_rid: u32,
+  render_bundle_encoder_rid: ResourceId,
 }
 
 pub fn op_webgpu_render_bundle_encoder_pop_debug_group(
@@ -243,7 +244,7 @@ pub fn op_webgpu_render_bundle_encoder_pop_debug_group(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderBundleEncoderInsertDebugMarkerArgs {
-  render_bundle_encoder_rid: u32,
+  render_bundle_encoder_rid: ResourceId,
   marker_label: String,
 }
 
@@ -271,7 +272,7 @@ pub fn op_webgpu_render_bundle_encoder_insert_debug_marker(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderBundleEncoderSetPipelineArgs {
-  render_bundle_encoder_rid: u32,
+  render_bundle_encoder_rid: ResourceId,
   pipeline: u32,
 }
 
@@ -300,7 +301,7 @@ pub fn op_webgpu_render_bundle_encoder_set_pipeline(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderBundleEncoderSetIndexBufferArgs {
-  render_bundle_encoder_rid: u32,
+  render_bundle_encoder_rid: ResourceId,
   buffer: u32,
   index_format: String,
   offset: u64,
@@ -337,7 +338,7 @@ pub fn op_webgpu_render_bundle_encoder_set_index_buffer(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderBundleEncoderSetVertexBufferArgs {
-  render_bundle_encoder_rid: u32,
+  render_bundle_encoder_rid: ResourceId,
   slot: u32,
   buffer: u32,
   offset: u64,
@@ -372,7 +373,7 @@ pub fn op_webgpu_render_bundle_encoder_set_vertex_buffer(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderBundleEncoderDrawArgs {
-  render_bundle_encoder_rid: u32,
+  render_bundle_encoder_rid: ResourceId,
   vertex_count: u32,
   instance_count: u32,
   first_vertex: u32,
@@ -403,7 +404,7 @@ pub fn op_webgpu_render_bundle_encoder_draw(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderBundleEncoderDrawIndexedArgs {
-  render_bundle_encoder_rid: u32,
+  render_bundle_encoder_rid: ResourceId,
   index_count: u32,
   instance_count: u32,
   first_index: u32,
@@ -436,7 +437,7 @@ pub fn op_webgpu_render_bundle_encoder_draw_indexed(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderBundleEncoderDrawIndirectArgs {
-  render_bundle_encoder_rid: u32,
+  render_bundle_encoder_rid: ResourceId,
   indirect_buffer: u32,
   indirect_offset: u64,
 }

--- a/op_crates/webgpu/command_encoder.rs
+++ b/op_crates/webgpu/command_encoder.rs
@@ -4,6 +4,7 @@ use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
@@ -41,7 +42,7 @@ fn serialize_store_op(store_op: String) -> wgpu_core::command::StoreOp {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateCommandEncoderArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   label: Option<String>,
   _measure_execution_time: Option<bool>, // not yet implemented
 }
@@ -105,7 +106,7 @@ struct GPURenderPassDepthStencilAttachment {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderBeginRenderPassArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
   label: Option<String>,
   color_attachments: Vec<GPURenderPassColorAttachment>,
   depth_stencil_attachment: Option<GPURenderPassDepthStencilAttachment>,
@@ -243,7 +244,7 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderBeginComputePassArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
   label: Option<String>,
 }
 
@@ -280,7 +281,7 @@ pub fn op_webgpu_command_encoder_begin_compute_pass(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderCopyBufferToBufferArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
   source: u32,
   source_offset: u64,
   destination: u32,
@@ -351,7 +352,7 @@ pub struct GPUImageCopyTexture {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderCopyBufferToTextureArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
   source: GPUImageCopyBuffer,
   destination: GPUImageCopyTexture,
   copy_size: super::texture::GPUExtent3D,
@@ -414,7 +415,7 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_texture(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderCopyTextureToBufferArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
   source: GPUImageCopyTexture,
   destination: GPUImageCopyBuffer,
   copy_size: super::texture::GPUExtent3D,
@@ -476,7 +477,7 @@ pub fn op_webgpu_command_encoder_copy_texture_to_buffer(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderCopyTextureToTextureArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
   source: GPUImageCopyTexture,
   destination: GPUImageCopyTexture,
   copy_size: super::texture::GPUExtent3D,
@@ -542,7 +543,7 @@ pub fn op_webgpu_command_encoder_copy_texture_to_texture(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderPushDebugGroupArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
   group_label: String,
 }
 
@@ -568,7 +569,7 @@ pub fn op_webgpu_command_encoder_push_debug_group(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderPopDebugGroupArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
 }
 
 pub fn op_webgpu_command_encoder_pop_debug_group(
@@ -591,7 +592,7 @@ pub fn op_webgpu_command_encoder_pop_debug_group(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderInsertDebugMarkerArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
   marker_label: String,
 }
 
@@ -618,7 +619,7 @@ pub fn op_webgpu_command_encoder_insert_debug_marker(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderWriteTimestampArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
   query_set: u32,
   query_index: u32,
 }
@@ -653,7 +654,7 @@ pub fn op_webgpu_command_encoder_write_timestamp(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderResolveQuerySetArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
   query_set: u32,
   first_query: u32,
   query_count: u32,
@@ -698,7 +699,7 @@ pub fn op_webgpu_command_encoder_resolve_query_set(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandEncoderFinishArgs {
-  command_encoder_rid: u32,
+  command_encoder_rid: ResourceId,
   label: Option<String>,
 }
 

--- a/op_crates/webgpu/compute_pass.rs
+++ b/op_crates/webgpu/compute_pass.rs
@@ -4,6 +4,7 @@ use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
@@ -24,7 +25,7 @@ impl Resource for WebGPUComputePass {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePassSetPipelineArgs {
-  compute_pass_rid: u32,
+  compute_pass_rid: ResourceId,
   pipeline: u32,
 }
 
@@ -53,7 +54,7 @@ pub fn op_webgpu_compute_pass_set_pipeline(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePassDispatchArgs {
-  compute_pass_rid: u32,
+  compute_pass_rid: ResourceId,
   x: u32,
   y: u32,
   z: u32,
@@ -82,7 +83,7 @@ pub fn op_webgpu_compute_pass_dispatch(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePassDispatchIndirectArgs {
-  compute_pass_rid: u32,
+  compute_pass_rid: ResourceId,
   indirect_buffer: u32,
   indirect_offset: u64,
 }
@@ -113,7 +114,7 @@ pub fn op_webgpu_compute_pass_dispatch_indirect(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePassBeginPipelineStatisticsQueryArgs {
-  compute_pass_rid: u32,
+  compute_pass_rid: ResourceId,
   query_set: u32,
   query_index: u32,
 }
@@ -146,7 +147,7 @@ pub fn op_webgpu_compute_pass_begin_pipeline_statistics_query(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePassEndPipelineStatisticsQueryArgs {
-  compute_pass_rid: u32,
+  compute_pass_rid: ResourceId,
 }
 
 pub fn op_webgpu_compute_pass_end_pipeline_statistics_query(
@@ -171,7 +172,7 @@ pub fn op_webgpu_compute_pass_end_pipeline_statistics_query(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePassWriteTimestampArgs {
-  compute_pass_rid: u32,
+  compute_pass_rid: ResourceId,
   query_set: u32,
   query_index: u32,
 }
@@ -204,8 +205,8 @@ pub fn op_webgpu_compute_pass_write_timestamp(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePassEndPassArgs {
-  command_encoder_rid: u32,
-  compute_pass_rid: u32,
+  command_encoder_rid: ResourceId,
+  compute_pass_rid: ResourceId,
 }
 
 pub fn op_webgpu_compute_pass_end_pass(
@@ -240,7 +241,7 @@ pub fn op_webgpu_compute_pass_end_pass(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePassSetBindGroupArgs {
-  compute_pass_rid: u32,
+  compute_pass_rid: ResourceId,
   index: u32,
   bind_group: u32,
   dynamic_offsets_data: Option<Vec<u32>>,
@@ -286,7 +287,7 @@ pub fn op_webgpu_compute_pass_set_bind_group(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePassPushDebugGroupArgs {
-  compute_pass_rid: u32,
+  compute_pass_rid: ResourceId,
   group_label: String,
 }
 
@@ -315,7 +316,7 @@ pub fn op_webgpu_compute_pass_push_debug_group(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePassPopDebugGroupArgs {
-  compute_pass_rid: u32,
+  compute_pass_rid: ResourceId,
 }
 
 pub fn op_webgpu_compute_pass_pop_debug_group(
@@ -338,7 +339,7 @@ pub fn op_webgpu_compute_pass_pop_debug_group(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePassInsertDebugMarkerArgs {
-  compute_pass_rid: u32,
+  compute_pass_rid: ResourceId,
   marker_label: String,
 }
 

--- a/op_crates/webgpu/lib.rs
+++ b/op_crates/webgpu/lib.rs
@@ -7,6 +7,7 @@ use deno_core::error::{bad_resource_id, not_supported};
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::OpState;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{BufVec, Resource};
 use serde::Deserialize;
@@ -280,7 +281,7 @@ struct GPULimits {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RequestDeviceArgs {
-  adapter_rid: u32,
+  adapter_rid: ResourceId,
   label: Option<String>,
   non_guaranteed_features: Option<Vec<String>>,
   non_guaranteed_limits: Option<GPULimits>,
@@ -451,7 +452,7 @@ pub async fn op_webgpu_request_device(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateQuerySetArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   _label: Option<String>, // not yet implemented
   #[serde(rename = "type")]
   kind: String,

--- a/op_crates/webgpu/pipeline.rs
+++ b/op_crates/webgpu/pipeline.rs
@@ -6,6 +6,7 @@ use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
+use deno_core::ResourceId;
 use serde::Deserialize;
 use std::borrow::Cow;
 
@@ -152,7 +153,7 @@ struct GPUProgrammableStage {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateComputePipelineArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   label: Option<String>,
   layout: Option<u32>,
   compute: GPUProgrammableStage,
@@ -221,7 +222,7 @@ pub fn op_webgpu_create_compute_pipeline(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComputePipelineGetBindGroupLayoutArgs {
-  compute_pipeline_rid: u32,
+  compute_pipeline_rid: ResourceId,
   index: u32,
 }
 
@@ -352,7 +353,7 @@ struct GPUFragmentState {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateRenderPipelineArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   label: Option<String>,
   layout: Option<u32>,
   vertex: GPUVertexState,
@@ -611,7 +612,7 @@ pub fn op_webgpu_create_render_pipeline(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPipelineGetBindGroupLayoutArgs {
-  render_pipeline_rid: u32,
+  render_pipeline_rid: ResourceId,
   index: u32,
 }
 

--- a/op_crates/webgpu/pipeline.rs
+++ b/op_crates/webgpu/pipeline.rs
@@ -4,9 +4,9 @@ use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
-use deno_core::ResourceId;
 use serde::Deserialize;
 use std::borrow::Cow;
 

--- a/op_crates/webgpu/queue.rs
+++ b/op_crates/webgpu/queue.rs
@@ -5,6 +5,7 @@ use deno_core::error::AnyError;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::OpState;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 
@@ -15,7 +16,7 @@ type WebGPUQueue = super::WebGPUDevice;
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueueSubmitArgs {
-  queue_rid: u32,
+  queue_rid: ResourceId,
   command_buffers: Vec<u32>,
 }
 
@@ -58,7 +59,7 @@ struct GPUImageDataLayout {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueueWriteBufferArgs {
-  queue_rid: u32,
+  queue_rid: ResourceId,
   buffer: u32,
   buffer_offset: u64,
   data_offset: usize,
@@ -100,7 +101,7 @@ pub fn op_webgpu_write_buffer(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueueWriteTextureArgs {
-  queue_rid: u32,
+  queue_rid: ResourceId,
   destination: super::command_encoder::GPUImageCopyTexture,
   data_layout: GPUImageDataLayout,
   size: super::texture::GPUExtent3D,

--- a/op_crates/webgpu/render_pass.rs
+++ b/op_crates/webgpu/render_pass.rs
@@ -4,6 +4,7 @@ use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
@@ -24,7 +25,7 @@ impl Resource for WebGPURenderPass {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassSetViewportArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   x: f32,
   y: f32,
   width: f32,
@@ -59,7 +60,7 @@ pub fn op_webgpu_render_pass_set_viewport(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassSetScissorRectArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   x: u32,
   y: u32,
   width: u32,
@@ -99,7 +100,7 @@ pub struct GPUColor {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassSetBlendColorArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   color: GPUColor,
 }
 
@@ -129,7 +130,7 @@ pub fn op_webgpu_render_pass_set_blend_color(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassSetStencilReferenceArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   reference: u32,
 }
 
@@ -154,7 +155,7 @@ pub fn op_webgpu_render_pass_set_stencil_reference(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassBeginPipelineStatisticsQueryArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   query_set: u32,
   query_index: u32,
 }
@@ -187,7 +188,7 @@ pub fn op_webgpu_render_pass_begin_pipeline_statistics_query(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassEndPipelineStatisticsQueryArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
 }
 
 pub fn op_webgpu_render_pass_end_pipeline_statistics_query(
@@ -212,7 +213,7 @@ pub fn op_webgpu_render_pass_end_pipeline_statistics_query(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassWriteTimestampArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   query_set: u32,
   query_index: u32,
 }
@@ -245,7 +246,7 @@ pub fn op_webgpu_render_pass_write_timestamp(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassExecuteBundlesArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   bundles: Vec<u32>,
 }
 
@@ -283,8 +284,8 @@ pub fn op_webgpu_render_pass_execute_bundles(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassEndPassArgs {
-  command_encoder_rid: u32,
-  render_pass_rid: u32,
+  command_encoder_rid: ResourceId,
+  render_pass_rid: ResourceId,
 }
 
 pub fn op_webgpu_render_pass_end_pass(
@@ -314,7 +315,7 @@ pub fn op_webgpu_render_pass_end_pass(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassSetBindGroupArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   index: u32,
   bind_group: u32,
   dynamic_offsets_data: Option<Vec<u32>>,
@@ -373,7 +374,7 @@ pub fn op_webgpu_render_pass_set_bind_group(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassPushDebugGroupArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   group_label: String,
 }
 
@@ -402,7 +403,7 @@ pub fn op_webgpu_render_pass_push_debug_group(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassPopDebugGroupArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
 }
 
 pub fn op_webgpu_render_pass_pop_debug_group(
@@ -425,7 +426,7 @@ pub fn op_webgpu_render_pass_pop_debug_group(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassInsertDebugMarkerArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   marker_label: String,
 }
 
@@ -454,7 +455,7 @@ pub fn op_webgpu_render_pass_insert_debug_marker(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassSetPipelineArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   pipeline: u32,
 }
 
@@ -483,7 +484,7 @@ pub fn op_webgpu_render_pass_set_pipeline(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassSetIndexBufferArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   buffer: u32,
   index_format: String,
   offset: u64,
@@ -517,7 +518,7 @@ pub fn op_webgpu_render_pass_set_index_buffer(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassSetVertexBufferArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   slot: u32,
   buffer: u32,
   offset: u64,
@@ -552,7 +553,7 @@ pub fn op_webgpu_render_pass_set_vertex_buffer(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassDrawArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   vertex_count: u32,
   instance_count: u32,
   first_vertex: u32,
@@ -583,7 +584,7 @@ pub fn op_webgpu_render_pass_draw(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassDrawIndexedArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   index_count: u32,
   instance_count: u32,
   first_index: u32,
@@ -616,7 +617,7 @@ pub fn op_webgpu_render_pass_draw_indexed(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassDrawIndirectArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   indirect_buffer: u32,
   indirect_offset: u64,
 }
@@ -647,7 +648,7 @@ pub fn op_webgpu_render_pass_draw_indirect(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderPassDrawIndexedIndirectArgs {
-  render_pass_rid: u32,
+  render_pass_rid: ResourceId,
   indirect_buffer: u32,
   indirect_offset: u64,
 }

--- a/op_crates/webgpu/sampler.rs
+++ b/op_crates/webgpu/sampler.rs
@@ -4,6 +4,7 @@ use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
@@ -64,7 +65,7 @@ pub fn serialize_compare_function(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateSamplerArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   label: Option<String>,
   address_mode_u: Option<String>,
   address_mode_v: Option<String>,

--- a/op_crates/webgpu/shader.rs
+++ b/op_crates/webgpu/shader.rs
@@ -4,6 +4,7 @@ use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
@@ -21,7 +22,7 @@ impl Resource for WebGPUShaderModule {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateShaderModuleArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   label: Option<String>,
   code: Option<String>,
   _source_map: Option<()>, // not yet implemented

--- a/op_crates/webgpu/texture.rs
+++ b/op_crates/webgpu/texture.rs
@@ -4,6 +4,7 @@ use deno_core::error::AnyError;
 use deno_core::error::{bad_resource_id, not_supported};
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
@@ -133,7 +134,7 @@ pub struct GPUExtent3D {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateTextureArgs {
-  device_rid: u32,
+  device_rid: ResourceId,
   label: Option<String>,
   size: GPUExtent3D,
   mip_level_count: Option<u32>,
@@ -194,7 +195,7 @@ pub fn op_webgpu_create_texture(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateTextureViewArgs {
-  texture_rid: u32,
+  texture_rid: ResourceId,
   label: Option<String>,
   format: Option<String>,
   dimension: Option<String>,

--- a/op_crates/websocket/lib.rs
+++ b/op_crates/websocket/lib.rs
@@ -18,6 +18,7 @@ use deno_core::JsRuntime;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 
 use http::{Method, Request, Uri};
@@ -214,7 +215,7 @@ where
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SendArgs {
-  rid: u32,
+  rid: ResourceId,
   kind: String,
   text: Option<String>,
 }
@@ -245,7 +246,7 @@ pub async fn op_ws_send(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CloseArgs {
-  rid: u32,
+  rid: ResourceId,
   code: Option<u16>,
   reason: Option<String>,
 }
@@ -277,7 +278,7 @@ pub async fn op_ws_close(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NextEventArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 pub async fn op_ws_next_event(

--- a/runtime/ops/fs.rs
+++ b/runtime/ops/fs.rs
@@ -13,6 +13,7 @@ use deno_core::serde_json::Value;
 use deno_core::BufVec;
 use deno_core::OpState;
 use deno_core::RcRef;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_crypto::rand::thread_rng;
 use deno_crypto::rand::Rng;
@@ -208,7 +209,7 @@ async fn op_open_async(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SeekArgs {
-  rid: u32,
+  rid: ResourceId,
   offset: i64,
   whence: i32,
 }
@@ -273,7 +274,7 @@ async fn op_seek_async(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FdatasyncArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 fn op_fdatasync_sync(
@@ -317,7 +318,7 @@ async fn op_fdatasync_async(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FsyncArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 fn op_fsync_sync(
@@ -361,7 +362,7 @@ async fn op_fsync_async(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FstatArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 fn op_fstat_sync(
@@ -1313,7 +1314,7 @@ async fn op_read_link_async(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FtruncateArgs {
-  rid: u32,
+  rid: ResourceId,
   len: i32,
 }
 
@@ -1585,7 +1586,7 @@ async fn op_make_temp_file_async(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FutimeArgs {
-  rid: u32,
+  rid: ResourceId,
   atime: (i64, u32),
   mtime: (i64, u32),
 }

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -12,7 +12,9 @@ use deno_core::CancelHandle;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
+
 use notify::event::Event as NotifyEvent;
 use notify::Error as NotifyError;
 use notify::EventKind;
@@ -126,7 +128,7 @@ fn op_fs_events_open(
 
 #[derive(Deserialize)]
 pub struct PollArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 async fn op_fs_events_poll(

--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -14,6 +14,7 @@ use deno_core::JsRuntime;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -459,7 +460,7 @@ impl StdFileResource {
 
   pub fn with<F, R>(
     state: &mut OpState,
-    rid: u32,
+    rid: ResourceId,
     mut f: F,
   ) -> Result<R, AnyError>
   where
@@ -521,7 +522,7 @@ impl Resource for StdFileResource {
 
 fn op_read_sync(
   state: &mut OpState,
-  rid: u32,
+  rid: ResourceId,
   bufs: &mut [ZeroCopyBuf],
 ) -> Result<u32, AnyError> {
   StdFileResource::with(state, rid, move |r| match r {
@@ -535,7 +536,7 @@ fn op_read_sync(
 
 async fn op_read_async(
   state: Rc<RefCell<OpState>>,
-  rid: u32,
+  rid: ResourceId,
   mut bufs: BufVec,
 ) -> Result<u32, AnyError> {
   let buf = &mut bufs[0];
@@ -566,7 +567,7 @@ async fn op_read_async(
 
 fn op_write_sync(
   state: &mut OpState,
-  rid: u32,
+  rid: ResourceId,
   bufs: &mut [ZeroCopyBuf],
 ) -> Result<u32, AnyError> {
   StdFileResource::with(state, rid, move |r| match r {
@@ -580,7 +581,7 @@ fn op_write_sync(
 
 async fn op_write_async(
   state: Rc<RefCell<OpState>>,
-  rid: u32,
+  rid: ResourceId,
   bufs: BufVec,
 ) -> Result<u32, AnyError> {
   let buf = &bufs[0];
@@ -609,7 +610,7 @@ async fn op_write_async(
 
 #[derive(Deserialize)]
 struct ShutdownArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 async fn op_shutdown(

--- a/runtime/ops/net.rs
+++ b/runtime/ops/net.rs
@@ -19,6 +19,7 @@ use deno_core::CancelTryFuture;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use serde::Serialize;
@@ -55,7 +56,7 @@ pub fn init(rt: &mut deno_core::JsRuntime) {
 
 #[derive(Deserialize)]
 pub(crate) struct AcceptArgs {
-  pub rid: u32,
+  pub rid: ResourceId,
   pub transport: String,
 }
 
@@ -125,7 +126,7 @@ async fn op_accept(
 
 #[derive(Deserialize)]
 pub(crate) struct ReceiveArgs {
-  pub rid: u32,
+  pub rid: ResourceId,
   pub transport: String,
 }
 
@@ -181,7 +182,7 @@ async fn op_datagram_receive(
 
 #[derive(Deserialize)]
 struct SendArgs {
-  rid: u32,
+  rid: ResourceId,
   transport: String,
   #[serde(flatten)]
   transport_args: ArgsEnum,

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -16,6 +16,7 @@ use deno_core::BufVec;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -34,7 +35,7 @@ pub fn init(rt: &mut deno_core::JsRuntime) {
 
 fn clone_file(
   state: &mut OpState,
-  rid: u32,
+  rid: ResourceId,
 ) -> Result<std::fs::File, AnyError> {
   StdFileResource::with(state, rid, move |r| match r {
     Ok(std_file) => std_file.try_clone().map_err(AnyError::from),
@@ -60,9 +61,9 @@ pub struct RunArgs {
   stdin: String,
   stdout: String,
   stderr: String,
-  stdin_rid: u32,
-  stdout_rid: u32,
-  stderr_rid: u32,
+  stdin_rid: ResourceId,
+  stdout_rid: ResourceId,
+  stderr_rid: ResourceId,
 }
 
 struct ChildResource {
@@ -178,7 +179,7 @@ fn op_run(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunStatusArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 async fn op_run_status(

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -4,6 +4,7 @@ use deno_core::error::AnyError;
 use deno_core::serde_json::Value;
 use deno_core::BufVec;
 use deno_core::OpState;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -63,7 +64,7 @@ pub struct BindSignalArgs {
 #[cfg(unix)]
 #[derive(Deserialize)]
 pub struct SignalArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 #[cfg(unix)]

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -3,7 +3,6 @@ use deno_core::error::AnyError;
 use deno_core::serde_json::Value;
 use deno_core::BufVec;
 use deno_core::OpState;
-use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -63,7 +62,7 @@ pub struct BindSignalArgs {
 #[cfg(unix)]
 #[derive(Deserialize)]
 pub struct SignalArgs {
-  rid: ResourceId,
+  rid: u32,
 }
 
 #[cfg(unix)]

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
-
 use deno_core::error::AnyError;
 use deno_core::serde_json::Value;
 use deno_core::BufVec;

--- a/runtime/ops/tls.rs
+++ b/runtime/ops/tls.rs
@@ -20,6 +20,7 @@ use deno_core::CancelTryFuture;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -88,7 +89,7 @@ pub struct ConnectTLSArgs {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct StartTLSArgs {
-  rid: u32,
+  rid: ResourceId,
   cert_file: Option<String>,
   hostname: String,
 }
@@ -350,7 +351,7 @@ fn op_listen_tls(
 
 #[derive(Deserialize)]
 pub struct AcceptTlsArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 async fn op_accept_tls(

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -9,6 +9,7 @@ use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::OpState;
 use deno_core::RcRef;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use serde::Serialize;
@@ -58,7 +59,7 @@ pub struct SetRawOptions {
 
 #[derive(Deserialize)]
 pub struct SetRawArgs {
-  rid: u32,
+  rid: ResourceId,
   mode: bool,
   options: SetRawOptions,
 }
@@ -215,7 +216,7 @@ fn op_set_raw(
 
 #[derive(Deserialize)]
 pub struct IsattyArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 fn op_isatty(
@@ -250,7 +251,7 @@ fn op_isatty(
 
 #[derive(Deserialize)]
 pub struct ConsoleSizeArgs {
-  rid: u32,
+  rid: ResourceId,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
The type declared was hardly used earlier. This PR enforces its use across op args.