### PR TITLE
chore: upgrade tokio to 1.4.0, tokio-stream to 0.1.5, tokio-util to 0.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3414,9 +3414,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3456,9 +3456,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
+checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3493,9 +3493,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "5143d049e85af7fbc36f5454d990e62c2df705b3589f123b71f441b6b59f443f"
 dependencies = [
  "bytes",
  "futures-core",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,7 +74,7 @@ swc_ecmascript = { version = "0.24.1", features = ["codegen", "dep_graph", "pars
 tempfile = "3.2.0"
 termcolor = "1.1.2"
 text-size = "1.1.0"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.4.0", features = ["full"] }
 tokio-rustls = "0.22.0"
 uuid = { version = "0.8.2", features = ["v4"] }
 walkdir = "2.3.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,4 +36,4 @@ path = "examples/http_bench_json_ops.rs"
 
 # These dependencies are only used for the 'http_bench_*_ops' examples.
 [dev-dependencies]
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.4.0", features = ["full"] }

--- a/op_crates/fetch/Cargo.toml
+++ b/op_crates/fetch/Cargo.toml
@@ -18,6 +18,6 @@ bytes = "1.0.1"
 deno_core = { version = "0.81.0", path = "../../core" }
 reqwest = { version = "0.11.0", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli"] }
 serde = { version = "1.0.123", features = ["derive"] }
-tokio = { version = "1.3.0", features = ["full"] }
-tokio-stream = "0.1.3"
-tokio-util = "0.6.2"
+tokio = { version = "1.4.0", features = ["full"] }
+tokio-stream = "0.1.5"
+tokio-util = "0.6.5"

--- a/op_crates/webgpu/Cargo.toml
+++ b/op_crates/webgpu/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 deno_core = { version = "0.81.0", path = "../../core" }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.4.0", features = ["full"] }
 serde = { version = "1.0.123", features = ["derive"] }
 wgpu-core = { version = "0.7.0", features = ["trace"] }
 wgpu-types = "0.7.0"

--- a/op_crates/websocket/Cargo.toml
+++ b/op_crates/websocket/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 deno_core = { version = "0.81.0", path = "../../core" }
 http = "0.2.3"
 serde = { version = "1.0.123", features = ["derive"] }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.4.0", features = ["full"] }
 tokio-rustls = "0.22.0"
 tokio-tungstenite = "0.13.0"
 webpki = "0.21.4"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -60,7 +60,7 @@ ring = "0.16.20"
 serde = { version = "1.0.123", features = ["derive"] }
 sys-info = "0.8.0"
 termcolor = "1.1.2"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.4.0", features = ["full"] }
 tokio-rustls = "0.22.0"
 uuid = { version = "0.8.2", features = ["v4"] }
 webpki = "0.21.4"

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -21,7 +21,7 @@ os_pipe = "0.9.2"
 regex = "1.4.3"
 serde = { version = "1.0.123", features = ["derive"] }
 tempfile = "3.2.0"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.4.0", features = ["full"] }
 tokio-rustls = "0.22.0"
 tokio-tungstenite = "0.13.0"
 


### PR DESCRIPTION

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

This PR upgrades tokio, tokio-stream, tokio-util to their latest version.

- [tokio 1.4.0](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.4.0)
- [tokio-stream 0.1.5](https://github.com/tokio-rs/tokio/releases/tag/tokio-stream-0.1.5)
- [tokio-util 0.6.5](https://github.com/tokio-rs/tokio/releases/tag/tokio-util-0.6.5)