### PR TITLE
A bench "suite" of common Deno functions

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -1,0 +1,53 @@
+// Run with: deno run -A ./cli/bench/deno_common.js
+function benchSync(name, n, innerLoop) {
+  const t1 = Date.now();
+  for (let i = 0; i < n; i++) {
+    innerLoop(i);
+  }
+  const t2 = Date.now();
+  const dt = (t2 - t1) / 1e3;
+  const r = n / dt;
+  console.log(
+    `${name}:${" ".repeat(20 - name.length)}\t` +
+      `n = ${n}, dt = ${dt.toFixed(3)}s, r = ${r.toFixed(0)}/s`,
+  );
+}
+
+function benchUrlParse() {
+  benchSync("url_parse", 5e4, (i) => {
+    new URL(`http://www.google.com/${i}`);
+  });
+}
+
+function benchNow() {
+  benchSync("now", 5e5, () => {
+    performance.now();
+  });
+}
+
+function benchWriteNull() {
+  // Not too large since we want to measure op-overhead not sys IO
+  const dataChunk = new Uint8Array(100);
+  const file = Deno.openSync("/dev/null", { write: true });
+  benchSync("write_null", 5e5, () => {
+    Deno.writeSync(file.rid, dataChunk);
+  });
+  Deno.close(file.rid);
+}
+
+function benchReadZero() {
+  const buf = new Uint8Array(100);
+  const file = Deno.openSync("/dev/zero");
+  benchSync("read_zero", 5e5, () => {
+    Deno.readSync(file.rid, buf);
+  });
+  Deno.close(file.rid);
+}
+
+function main() {
+  benchUrlParse();
+  benchNow();
+  benchWriteNull();
+  benchReadZero();
+}
+main();


### PR DESCRIPTION
## Goal

This PR aims to add a bench "suite" of commonly called deno functions, as a shared reference to track and measure performance regressions or improvements (e.g: following the op-ABI changes).

It's intentionally very simple, so it can easily be backported and tested on older releases or newer branches.

It might make sense to have something more sophisticated down the line, but this should be a fair start

## Currently tracked

It currently tracks:
- URL parsing: since deno is ~25x slower than Node/Chrome (https://github.com/denoland/deno/pull/9276#issuecomment-773865387)
- Basic IO, read/write to `/dev/null` and `/dev/zero`
- `performance.now()/op_now` since it's one of the lightest/fastest ops

## Output

On my m1 Air with `deno@1.8.2`:

```
❯ deno run -A ./cli/bench/deno_common.js
url_parse:           	n = 50000, dt = 0.707s, r = 70721/s
now:                 	n = 500000, dt = 0.687s, r = 727802/s
write_null:          	n = 500000, dt = 0.738s, r = 677507/s
read_zero:           	n = 500000, dt = 0.734s, r = 681199/s
```

## Notes

- It only benches sync ops/funcs for now, will add async (`read/write`) in a future commit or PR
- Not Windows compatible for now since `/dev/null` and `/dev/zero` don't exist on Windows
  (Windows does have a special `nul` file, but nothing standard comparable to `/dev/zero` I believe, WSL should work)
- Really wanting to keep it simple