### PR TITLE
fix(permissions): don't panic when no input is given (#9633)

### DIFF
--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -697,7 +697,7 @@ fn permission_prompt(message: &str) -> bool {
     };
     let ch = match input.chars().next() {
       None => return false,
-      Some(v) => v
+      Some(v) => v,
     };
     match ch.to_ascii_lowercase() {
       'g' => return true,

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -695,7 +695,10 @@ fn permission_prompt(message: &str) -> bool {
     if result.is_err() {
       return false;
     };
-    let ch = input.chars().next().unwrap();
+    let ch = match input.chars().next() {
+      None => return false,
+      Some(v) => v
+    };
     match ch.to_ascii_lowercase() {
       'g' => return true,
       'd' => return false,


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
```js
// test.js
await Deno.permissions.request({ name: `env` });
 ```
 
     1. Run `deno run test.js`
 
    2. When the prompt comes up, press `ctrl-d`

    3. See following panic:

```
RUST_BACKTRACE=1 cargo run run test.js
    Finished dev [unoptimized + debuginfo] target(s) in 0.56s
     Running `target/debug/deno run test.js`
⚠️  ️Deno requests access to environment variables. Grant? [g/d (g = grant, d = deny)] thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', runtime/permissions.rs:698:35
stack backtrace:
   0: rust_begin_unwind
             at /rustc/e1884a8e3c3e813aada8254edfa120e85bf5ffca/library/std/src/panicking.rs:495:5
   1: core::panicking::panic_fmt
             at /rustc/e1884a8e3c3e813aada8254edfa120e85bf5ffca/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/e1884a8e3c3e813aada8254edfa120e85bf5ffca/library/core/src/panicking.rs:50:5
   3: core::option::Option<T>::unwrap
             at /Users/upadhyu/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/option.rs:386:21
   4: deno_runtime::permissions::permission_prompt
             at ./runtime/permissions.rs:698:14
   5: deno_runtime::permissions::UnitPermission::request
             at ./runtime/permissions.rs:86:10
   6: deno_runtime::ops::permissions::op_request_permission
             at ./runtime/ops/permissions.rs:107:14
   7: core::ops::function::Fn::call
             at /Users/upadhyu/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:70:5
   8: deno_core::ops_json::json_op_sync::{{closure}}::{{closure}}
             at ./core/ops_json.rs:67:24
   9: core::result::Result<T,E>::and_then
             at /Users/upadhyu/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/result.rs:708:22
  10: deno_core::ops_json::json_op_sync::{{closure}}
             at ./core/ops_json.rs:65:18
  11: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /Users/upadhyu/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1321:9
  12: deno_runtime::metrics::metrics_op::{{closure}}
             at ./runtime/metrics.rs:124:14
  13: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /Users/upadhyu/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1321:9
  14: deno_core::ops::OpTable::route_op
             at ./core/ops.rs:101:20
  15: deno_core::bindings::send
             at ./core/bindings.rs:412:12
  16: core::ops::function::Fn::call
             at /Users/upadhyu/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:70:5
  17: rusty_v8::function::<impl rusty_v8::support::MapFnFrom<F> for extern "C" fn(*const rusty_v8::function::FunctionCallbackInfo)>::mapping::{{closure}}
             at /Users/upadhyu/.cargo/registry/src/github.com-1ecc6299db9ec823/rusty_v8-0.21.0/src/function.rs:280:7
  18: <extern "C" fn(A0) .> R as rusty_v8::support::CFnFrom<F>>::mapping::c_fn
             at /Users/upadhyu/.cargo/registry/src/github.com-1ecc6299db9ec823/rusty_v8-0.21.0/src/support.rs:722:11
  19: Call
             at ./../../../../v8/src/api/api-arguments-inl.h:158:3
  20: HandleApiCallHelper<false>
             at ./../../../../v8/src/builtins/builtins-api.cc:113:36
  21: Builtin_Impl_HandleApiCall
             at ./../../../../v8/src/builtins/builtins-api.cc:143:5
  22: Builtin_HandleApiCall
             at ./../../../../v8/src/builtins/builtins-api.cc:131:1
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
fatal runtime error: failed to initiate panic, error 5 
[1]    68738 abort      RUST_BACKTRACE=1 cargo run run test.js
~                                                                                                
```
Now after the fix the output is:
```
deno git/main  
❯ cargo run run test.js                 
   Compiling deno_runtime v0.10.0 (/Users/upadhyu/Desktop/mac/private/deno/runtime)
   Compiling deno v1.8.2 (/Users/upadhyu/Desktop/mac/private/deno/cli)
    Finished dev [unoptimized + debuginfo] target(s) in 3m 36s
     Running `target/debug/deno run test.js`
⚠️  ️Deno requests access to environment variables. Grant? [g/d (g = grant, d = deny)] %                                                                                                                                                                      
deno git/main*  233s
```

