### PR TITLE
refactor(lsp): remove unused code

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1339,8 +1339,6 @@ struct Response {
 }
 
 struct State<'a> {
-  #[allow(unused)]
-  asset: Option<String>,
   last_id: usize,
   response: Option<Response>,
   state_snapshot: StateSnapshot,
@@ -1350,7 +1348,6 @@ struct State<'a> {
 impl<'a> State<'a> {
   fn new(state_snapshot: StateSnapshot) -> Self {
     Self {
-      asset: None,
       last_id: 1,
       response: None,
       state_snapshot,
@@ -1668,18 +1665,6 @@ fn script_version(
   Ok(None)
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct SetAssetArgs {
-  text: Option<String>,
-}
-
-#[allow(clippy::unnecessary_wraps)]
-fn set_asset(state: &mut State, args: SetAssetArgs) -> Result<bool, AnyError> {
-  state.asset = args.text;
-  Ok(true)
-}
-
 /// Create and setup a JsRuntime based on a snapshot. It is expected that the
 /// supplied snapshot is an isolate that contains the TypeScript language
 /// server.
@@ -1703,7 +1688,6 @@ pub fn start(debug: bool) -> Result<JsRuntime, AnyError> {
   runtime.register_op("op_respond", op(respond));
   runtime.register_op("op_script_names", op(script_names));
   runtime.register_op("op_script_version", op(script_version));
-  runtime.register_op("op_set_asset", op(set_asset));
 
   let init_config = json!({ "debug": debug });
   let init_src = format!("globalThis.serverInit({});", init_config);


### PR DESCRIPTION
This patch removes the `asset` field of `State` because it seems to be unused.

Taking a glance at the commit history, this field was introduced in https://github.com/denoland/deno/pull/8771, and at that time the field value was used in [the `request_asset` function](https://github.com/denoland/deno/pull/8771/files#diff-5425491838b4e06f099e33c0663a61d3b088c0c193a5a484a9b797c2f4ee099bR1125).
After that, in https://github.com/denoland/deno/pull/8727, both `request_asset` and invoking `op_set_asset` from JS were removed:
- [`request_asset` was removed](https://github.com/denoland/deno/pull/8727/files#diff-5425491838b4e06f099e33c0663a61d3b088c0c193a5a484a9b797c2f4ee099bL1104)
- [invoking `op_set_asset` was removed](https://github.com/denoland/deno/pull/8727/files#diff-917b74af14d03b69b9948cd2366a51c6af8c6582309a4913377fdb0a82993f96L495)

So since then, the `asset` field of `State` struct has seemed to be unused. I wonder why "unused" warning didn't emerge at that time though. (`#[allow(unused)]` was added today in https://github.com/denoland/deno/pull/9895)