### PR TITLE
core/bindings: simplify heapStats() by using serde_v8

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -875,64 +875,13 @@ fn heap_stats(
   _args: v8::FunctionCallbackArguments,
   mut rv: v8::ReturnValue,
 ) {
-  fn set_prop(
-    scope: &mut v8::HandleScope,
-    obj: v8::Local<v8::Object>,
-    name: &'static str,
-    value: usize,
-  ) {
-    let key = v8::String::new(scope, name).unwrap();
-    let val = v8::Number::new(scope, value as f64);
-    obj.set(scope, key.into(), val.into());
-  }
-
-  let s = get_heap_stats(scope);
-
-  // TODO: use serde for this once we have serde_v8
-  let obj = v8::Object::new(scope);
-  set_prop(scope, obj, "totalHeapSize", s.total_heap_size);
-  set_prop(
-    scope,
-    obj,
-    "totalHeapSizexecutable",
-    s.total_heap_size_executable,
-  );
-  set_prop(scope, obj, "totalPhysicalSize", s.total_physical_size);
-  set_prop(scope, obj, "totalAvailableSize", s.total_available_size);
-  set_prop(
-    scope,
-    obj,
-    "totalGlobalHandlesSize",
-    s.total_global_handles_size,
-  );
-  set_prop(
-    scope,
-    obj,
-    "usedGlobalHandlesSize",
-    s.used_global_handles_size,
-  );
-  set_prop(scope, obj, "usedHeapSize", s.used_heap_size);
-  set_prop(scope, obj, "heapSizeLimit", s.heap_size_limit);
-  set_prop(scope, obj, "mallocedMemory", s.malloced_memory);
-  set_prop(scope, obj, "externalMemory", s.external_memory);
-  set_prop(scope, obj, "peakMallocedMemory", s.peak_malloced_memory);
-  set_prop(
-    scope,
-    obj,
-    "numberOfNativeContexts",
-    s.number_of_native_contexts,
-  );
-  set_prop(
-    scope,
-    obj,
-    "numberOfDetachedContexts",
-    s.number_of_detached_contexts,
-  );
-
-  rv.set(obj.into());
+  let stats = get_heap_stats(scope);
+  rv.set(to_v8(scope, stats).unwrap());
 }
 
 // HeapStats stores values from a isolate.get_heap_statistics() call
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct HeapStats {
   total_heap_size: usize,
   total_heap_size_executable: usize,


### PR DESCRIPTION
This uses `serde_v8` to serialize our `HeapStats` data instead of the previous "manual" serialization. This is less verbose and `serde` handles mapping keys to camelCase so the rust code is strongly typed and less prone to typos

This is a follow-up anticipated in https://github.com/denoland/deno/pull/9659, as per [this TODO comment](https://github.com/denoland/deno/pull/9659/files#diff-5b84637fa51710dd4ffc2f2370fb6bb77301603caac646be8184da12eedd7433R949)