### PR TITLE
quickfix #9903 by moving assert into async match branches

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -412,18 +412,19 @@ fn send<'s>(
   };
 
   let op = OpTable::route_op(op_id, state.op_state.clone(), bufs);
-  assert_eq!(state.shared.size(), 0);
   match op {
     Op::Sync(buf) if !buf.is_empty() => {
       rv.set(boxed_slice_to_uint8array(scope, buf).into());
     }
     Op::Sync(_) => {}
     Op::Async(fut) => {
+      assert_eq!(state.shared.size(), 0);
       let fut2 = fut.map(move |buf| (op_id, buf));
       state.pending_ops.push(fut2.boxed_local());
       state.have_unpolled_ops = true;
     }
     Op::AsyncUnref(fut) => {
+      assert_eq!(state.shared.size(), 0);
       let fut2 = fut.map(move |buf| (op_id, buf));
       state.pending_unref_ops.push(fut2.boxed_local());
       state.have_unpolled_ops = true;


### PR DESCRIPTION
This is a quickfix for #9903. It moves the assert into the async branches.

However the shared queue should be dropped very soon and will also fix this issue.