### PR TITLE
chore: add missing copyright headers

### DIFF
--- a/op_crates/webgpu/error.rs
+++ b/op_crates/webgpu/error.rs
@@ -1,3 +1,4 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 use deno_core::error::AnyError;
 use serde::Serialize;
 use std::fmt;

--- a/runtime/ops/webgpu.rs
+++ b/runtime/ops/webgpu.rs
@@ -1,3 +1,4 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 use deno_webgpu::*;
 
 pub fn init(rt: &mut deno_core::JsRuntime) {


### PR DESCRIPTION
Complements https://github.com/denoland/deno/pull/9909, cc @bartlomieju 

## Finding files with missing copyright headers

```bash
find . -name "*.rs" | grep -v "./target/" | xargs -I{} bash -c 'cat {} \
    | grep "// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license." \
    &>/dev/null || echo {}'
```
```
./runtime/ops/webgpu.rs
./op_crates/webgpu/error.rs
```