### PR TITLE
feat(bench/deno_common): show ns/op

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -7,9 +7,10 @@ function benchSync(name, n, innerLoop) {
   const t2 = Date.now();
   const dt = (t2 - t1) / 1e3;
   const r = n / dt;
+  const ns = Math.floor(dt / n * 1e9);
   console.log(
     `${name}:${" ".repeat(20 - name.length)}\t` +
-      `n = ${n}, dt = ${dt.toFixed(3)}s, r = ${r.toFixed(0)}/s`,
+      `n = ${n}, dt = ${dt.toFixed(3)}s, r = ${r.toFixed(0)}/s, t = ${ns}ns/op`,
   );
 }
 


### PR DESCRIPTION
It's simply the inverse of the rate (ops/s), but it's often useful to look at time per op since it's easier to picture the upper bound and improvable delta.