### PR TITLE
chore: fix clippy warning in serde_v8

### DIFF
--- a/serde_v8/tests/de.rs
+++ b/serde_v8/tests/de.rs
@@ -33,7 +33,7 @@ macro_rules! detest {
     fn $fn_name() {
       dedo($src, |scope, v| {
         let rt = serde_v8::from_v8(scope, v);
-        assert!(rt.is_ok(), format!("from_v8(\"{}\"): {:?}", $src, rt.err()));
+        assert!(rt.is_ok(), "from_v8(\"{}\"): {:?}", $src, rt.err());
         let t: $t = rt.unwrap();
         assert_eq!(t, $rust);
       });

--- a/serde_v8/tests/ser.rs
+++ b/serde_v8/tests/ser.rs
@@ -59,7 +59,9 @@ macro_rules! sertest {
     fn $fn_name() {
       assert!(
         sercheck($rust, $src),
-        format!("Expected: {} where x={:?}", $src, $rust),
+        "Expected: {} where x={:?}",
+        $src,
+        $rust,
       );
     }
   };


### PR DESCRIPTION
Fixes compiler warnings for serde_v8 tests. (Discovered while debugging the CI for #9614)