### PR TITLE
feat(bench/deno_common): track Date.now() as upper bound

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -20,8 +20,14 @@ function benchUrlParse() {
   });
 }
 
-function benchNow() {
-  benchSync("now", 5e5, () => {
+function benchDateNow() {
+  benchSync("date_now", 5e5, () => {
+    Date.now();
+  });
+}
+
+function benchPerfNow() {
+  benchSync("perf_now", 5e5, () => {
     performance.now();
   });
 }
@@ -46,9 +52,15 @@ function benchReadZero() {
 }
 
 function main() {
+  // v8 builtin that's close to the upper bound non-NOPs
+  benchDateNow();
+  // A very lightweight op, that should be highly optimizable
+  benchPerfNow();
+  // A common "language feature", that should be fast
+  // also a decent representation of a non-trivial JSON-op
   benchUrlParse();
-  benchNow();
-  benchWriteNull();
+  // IO ops
   benchReadZero();
+  benchWriteNull();
 }
 main();


### PR DESCRIPTION
This is another simple extension of the `cli/bench/deno_common.js` "benchsuite".

It benches `Date.now()` (a v8 builtin) to provide an indication of the upper bound for non-NOP ops.
(This should be our practical upper bound for all ops, even with v8 Fast API)

## Benches as of 1.8.2

On my M1 Air:

```
❯ deno -V; deno run --unstable -A ./cli/bench/deno_common.js
deno 1.8.2
date_now:            	n = 500000, dt = 0.021s, r = 23809524/s, t = 42ns/op
perf_now:            	n = 500000, dt = 0.700s, r = 714286/s, t = 1400ns/op
url_parse:           	n = 50000, dt = 0.712s, r = 70225/s, t = 14240ns/op
read_zero:           	n = 500000, dt = 0.758s, r = 659631/s, t = 1516ns/op
write_null:          	n = 500000, dt = 0.739s, r = 676590/s, t = 1478ns/op
```