### PR TITLE
perf(core): add op_baseline bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bencher"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
+
+[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +564,7 @@ name = "deno_core"
 version = "0.82.0"
 dependencies = [
  "anyhow",
+ "bencher",
  "futures",
  "indexmap",
  "lazy_static",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,3 +38,8 @@ path = "examples/http_bench_json_ops.rs"
 # These dependencies are only used for the 'http_bench_*_ops' examples.
 [dev-dependencies]
 tokio = { version = "1.4.0", features = ["full"] }
+bencher = "0.1"
+
+[[bench]]
+name = "op_baseline"
+harness = false

--- a/core/benches/op_baseline.rs
+++ b/core/benches/op_baseline.rs
@@ -1,0 +1,70 @@
+use bencher::{benchmark_group, benchmark_main, Bencher};
+
+use deno_core::bin_op_sync;
+use deno_core::json_op_sync;
+use deno_core::v8;
+use deno_core::JsRuntime;
+use deno_core::Op;
+
+fn create_js_runtime() -> JsRuntime {
+  let mut runtime = JsRuntime::new(Default::default());
+  runtime.register_op("pi_bin", bin_op_sync(|_, _, _| Ok(314159)));
+  runtime.register_op("pi_json", json_op_sync(|_, _: (), _| Ok(314159)));
+  runtime.register_op("nop", |_, _| Op::Sync(Box::new(9_u64.to_le_bytes())));
+
+  // Init ops
+  runtime
+    .execute(
+      "init",
+      r#"
+      Deno.core.ops();
+      Deno.core.registerErrorClass('Error', Error);
+      const nopBuffer = new ArrayBuffer(10);
+      const nopView = new DataView(nopBuffer);
+    "#,
+    )
+    .unwrap();
+
+  runtime
+}
+
+pub fn bench_runtime_js(b: &mut Bencher, src: &str) {
+  let mut runtime = create_js_runtime();
+  let context = runtime.global_context();
+  let scope = &mut v8::HandleScope::with_context(runtime.v8_isolate(), context);
+  let code = v8::String::new(scope, src).unwrap();
+  let script = v8::Script::compile(scope, code, None).unwrap();
+  b.iter(|| {
+    script.run(scope).unwrap();
+  });
+}
+
+fn bench_op_pi_bin(b: &mut Bencher) {
+  bench_runtime_js(
+    b,
+    r#"for(let i=0; i < 1e3; i++) {
+      Deno.core.binOpSync("pi_bin", 0);
+    }"#,
+  );
+}
+
+fn bench_op_pi_json(b: &mut Bencher) {
+  bench_runtime_js(
+    b,
+    r#"for(let i=0; i < 1e3; i++) {
+      Deno.core.jsonOpSync("pi_json", null);
+    }"#,
+  );
+}
+
+fn bench_op_nop(b: &mut Bencher) {
+  bench_runtime_js(
+    b,
+    r#"for(let i=0; i < 1e3; i++) {
+      Deno.core.dispatchByName("nop", nopView);
+    }"#,
+  );
+}
+
+benchmark_group!(benches, bench_op_pi_bin, bench_op_pi_json, bench_op_nop);
+benchmark_main!(benches);


### PR DESCRIPTION
This PR introduces a benchmark that serves to measure the baseline-overhead of ops (or the per-category upper bound).

This should also serve to:
- Measure gains from https://github.com/denoland/deno/pull/9843 and follow-up PRs
- Prevent regressions

## Output

```
~/git/deno/core bench/op-baseline
❯ cargo bench

...

running 3 tests
test bench_op_nop     ... bench:     603,784 ns/iter (+/- 102,433)
test bench_op_pi_bin  ... bench:     873,331 ns/iter (+/- 39,010)
test bench_op_pi_json ... bench:   3,210,314 ns/iter (+/- 290,248)

test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured
```