### PR TITLE
fix: enforce webgpu resource inheritance

### DIFF
--- a/op_crates/webgpu/01_webgpu.js
+++ b/op_crates/webgpu/01_webgpu.js
@@ -1656,7 +1656,6 @@
         "op_webgpu_buffer_get_map_async",
         {
           bufferRid,
-          deviceRid: device.rid,
           mode,
           offset,
           size: rangeSize,
@@ -3529,13 +3528,12 @@
         prefix,
         context: "encoder referenced by this",
       });
-      const commandEncoderRid = assertResource(this[_encoder], {
+      assertResource(this[_encoder], {
         prefix,
         context: "encoder referenced by this",
       });
       const renderPassRid = assertResource(this, { prefix, context: "this" });
       const { err } = core.jsonOpSync("op_webgpu_render_pass_end_pass", {
-        commandEncoderRid,
         renderPassRid,
       });
       device.pushError(err);
@@ -4261,13 +4259,12 @@
         prefix,
         context: "encoder referenced by this",
       });
-      const commandEncoderRid = assertResource(this[_encoder], {
+      assertResource(this[_encoder], {
         prefix,
         context: "encoder referenced by this",
       });
       const computePassRid = assertResource(this, { prefix, context: "this" });
       const { err } = core.jsonOpSync("op_webgpu_compute_pass_end_pass", {
-        commandEncoderRid,
         computePassRid,
       });
       device.pushError(err);

--- a/op_crates/webgpu/sampler.rs
+++ b/op_crates/webgpu/sampler.rs
@@ -9,13 +9,31 @@ use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
+use std::rc::Rc;
+
+use crate::Instance;
 
 use super::error::WebGpuError;
 
-pub(crate) struct WebGpuSampler(pub(crate) wgpu_core::id::SamplerId);
+pub(crate) struct WebGpuSampler {
+  instance: Rc<Instance>,
+  _device: Rc<wgpu_core::id::DeviceId>,
+  pub sampler: Rc<wgpu_core::id::SamplerId>,
+}
 impl Resource for WebGpuSampler {
   fn name(&self) -> Cow<str> {
     "webGPUSampler".into()
+  }
+
+  fn close(self: Rc<Self>) {
+    let resource = Rc::try_unwrap(self)
+      .map_err(|_| "closed webGPUSampler while in use")
+      .unwrap();
+    let instance = resource.instance;
+    let sampler = Rc::try_unwrap(resource.sampler)
+      .map_err(|_| "closed webGPUSampler while it still had children")
+      .unwrap();
+    gfx_select!(sampler => instance.sampler_drop(sampler));
   }
 }
 
@@ -84,12 +102,12 @@ pub fn op_webgpu_create_sampler(
   args: CreateSamplerArgs,
   _zero_copy: &mut [ZeroCopyBuf],
 ) -> Result<Value, AnyError> {
-  let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
     .get::<super::WebGpuDevice>(args.device_rid)
     .ok_or_else(bad_resource_id)?;
-  let device = device_resource.0;
+  let instance = device_resource.instance.clone();
+  let device = device_resource.device.clone();
 
   let descriptor = wgpu_core::resource::SamplerDescriptor {
     label: args.label.map(Cow::from),
@@ -116,12 +134,16 @@ pub fn op_webgpu_create_sampler(
   };
 
   let (sampler, maybe_err) = gfx_select!(device => instance.device_create_sampler(
-    device,
+    *device,
     &descriptor,
     std::marker::PhantomData
   ));
 
-  let rid = state.resource_table.add(WebGpuSampler(sampler));
+  let rid = state.resource_table.add(WebGpuSampler {
+    instance,
+    _device: device,
+    sampler: Rc::new(sampler),
+  });
 
   Ok(json!({
     "rid": rid,


### PR DESCRIPTION
This commit changes the resources in WebGPU to enforce inhertiance.
This is done using a tree of `Rc`'s, and only letting resources be
closed if at most one strong reference remains.

This is a precursor to safely being able to share buffers between WebGPU
and V8.
