### PR TITLE
serde_v8: restore ser/de benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,6 +2750,7 @@ dependencies = [
 name = "serde_v8"
 version = "0.1.0"
 dependencies = [
+ "bencher",
  "rusty_v8",
  "serde",
  "serde_json",

--- a/serde_v8/Cargo.toml
+++ b/serde_v8/Cargo.toml
@@ -14,6 +14,15 @@ rusty_v8 = "0.21.0"
 
 [dev-dependencies]
 serde_json = "1.0.62"
+bencher = "0.1"
 
 [[example]]
 name = "basic"
+
+[[bench]]
+name = "de"
+harness = false
+
+[[bench]]
+name = "ser"
+harness = false

--- a/serde_v8/benches/de.rs
+++ b/serde_v8/benches/de.rs
@@ -1,0 +1,161 @@
+use bencher::{benchmark_group, benchmark_main, Bencher};
+
+use rusty_v8 as v8;
+use serde_json;
+use serde_v8;
+use std::convert::TryFrom;
+
+use serde::Deserialize;
+
+use serde_v8::utils::{js_exec, v8_do};
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct MathOp {
+  arg1: u64,
+  arg2: u64,
+  operator: Option<String>,
+}
+
+fn dedo(
+  code: &str,
+  f: impl FnOnce(&mut v8::HandleScope, v8::Local<v8::Value>),
+) {
+  v8_do(|| {
+    let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
+    let handle_scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(handle_scope);
+    let scope = &mut v8::ContextScope::new(handle_scope, context);
+    let v = js_exec(scope, code);
+
+    f(scope, v);
+  })
+}
+
+fn dedo_json(code: &str, f: impl FnOnce(String)) {
+  let code = format!("JSON.stringify({})", code);
+  dedo(&code[..], |scope, v| {
+    let s: String = serde_v8::from_v8(scope, v).unwrap();
+    f(s);
+  })
+}
+
+fn de_struct_v8(b: &mut Bencher) {
+  dedo("({arg1: 10, arg2: 123 })", |scope, obj| {
+    let mut total = 0;
+    b.iter(move || {
+      let op: MathOp = serde_v8::from_v8(scope, obj).unwrap();
+      total = total + op.arg1 + op.arg2;
+    });
+  });
+}
+
+fn de_struct_v8_opt(b: &mut Bencher) {
+  dedo("({arg1: 10, arg2: 123 })", |scope, v| {
+    let k_arg1 = v8::String::new(scope, "arg1").unwrap().into();
+    let k_arg2 = v8::String::new(scope, "arg2").unwrap().into();
+    let obj = v8::Local::<v8::Object>::try_from(v).unwrap();
+    let mut total = 0;
+    b.iter(move || {
+      let v_arg1 = obj.get(scope, k_arg1).unwrap();
+      let v_arg2 = obj.get(scope, k_arg2).unwrap();
+      let op = MathOp {
+        arg1: serde_v8::from_v8(scope, v_arg1).unwrap(),
+        arg2: serde_v8::from_v8(scope, v_arg2).unwrap(),
+        operator: None,
+      };
+      total = total + op.arg1 + op.arg2;
+    });
+  });
+}
+
+fn de_struct_json(b: &mut Bencher) {
+  dedo_json("({arg1: 10, arg2: 123 })", |s| {
+    let mut total = 0;
+    b.iter(move || {
+      let op: MathOp = serde_json::from_str(&s).unwrap();
+      total = total + op.arg1 + op.arg2;
+    });
+  });
+}
+
+fn de_struct_json_deopt(b: &mut Bencher) {
+  // JSON.stringify() in loop (semi-simulating ABI loop)
+  dedo("({arg1: 10, arg2: 123 })", |scope, obj| {
+    let mut total = 0;
+    b.iter(move || {
+      let mut scope = v8::HandleScope::new(scope);
+      let s = v8::json::stringify(&mut scope, obj).unwrap();
+      let rs = s.to_rust_string_lossy(&mut scope);
+      let op: MathOp = serde_json::from_str(&rs).unwrap();
+      total = total + op.arg1 + op.arg2;
+    });
+  });
+}
+
+macro_rules! dualbench {
+  ($v8_fn:ident, $json_fn:ident, $src:expr, $t:ty) => {
+    fn $v8_fn(b: &mut Bencher) {
+      dedo($src, |scope, v| {
+        b.iter(move || {
+          let _: $t = serde_v8::from_v8(scope, v).unwrap();
+        });
+      });
+    }
+
+    fn $json_fn(b: &mut Bencher) {
+      dedo_json($src, |s| {
+        b.iter(move || {
+          let _: $t = serde_json::from_str(&s).unwrap();
+        });
+      });
+    }
+  };
+}
+
+dualbench!(de_bool_v8, de_bool_json, "true", bool);
+dualbench!(de_int_v8, de_int_json, "12345", u32);
+dualbench!(
+  de_array_v8,
+  de_array_json,
+  "[1,2,3,4,5,6,7,8,9,10]",
+  Vec<u32>
+);
+dualbench!(de_str_v8, de_str_json, "'hello world'", String);
+dualbench!(de_tuple_v8, de_tuple_json, "[1,false]", (u8, bool));
+
+fn de_tuple_v8_opt(b: &mut Bencher) {
+  dedo("[1,false]", |scope, obj| {
+    let arr = v8::Local::<v8::Array>::try_from(obj).unwrap();
+    let obj = v8::Local::<v8::Object>::from(arr);
+
+    b.iter(move || {
+      let v1 = obj.get_index(scope, 0).unwrap();
+      let v2 = obj.get_index(scope, 1).unwrap();
+      let _: (u8, bool) = (
+        serde_v8::from_v8(scope, v1).unwrap(),
+        serde_v8::from_v8(scope, v2).unwrap(),
+      );
+    });
+  });
+}
+
+benchmark_group!(
+  benches,
+  de_struct_v8,
+  de_struct_v8_opt,
+  de_struct_json,
+  de_struct_json_deopt,
+  de_bool_v8,
+  de_bool_json,
+  de_int_v8,
+  de_int_json,
+  de_array_v8,
+  de_array_json,
+  de_str_v8,
+  de_str_json,
+  de_tuple_v8,
+  de_tuple_json,
+  de_tuple_v8_opt,
+);
+
+benchmark_main!(benches);

--- a/serde_v8/benches/de.rs
+++ b/serde_v8/benches/de.rs
@@ -1,8 +1,6 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
 
 use rusty_v8 as v8;
-use serde_json;
-use serde_v8;
 use std::convert::TryFrom;
 
 use serde::Deserialize;

--- a/serde_v8/benches/ser.rs
+++ b/serde_v8/benches/ser.rs
@@ -1,0 +1,108 @@
+use bencher::{benchmark_group, benchmark_main, Bencher};
+
+use rusty_v8 as v8;
+use serde_v8;
+
+use serde::Serialize;
+
+use serde_v8::utils::v8_do;
+
+#[derive(Serialize)]
+struct MathOp {
+  arg1: u64,
+  arg2: u64,
+  operator: Option<String>,
+}
+
+fn serdo(f: impl FnOnce(&mut v8::HandleScope)) {
+  v8_do(|| {
+    let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
+    let handle_scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(handle_scope);
+    let scope = &mut v8::ContextScope::new(handle_scope, context);
+
+    f(scope);
+  })
+}
+
+macro_rules! dualbench {
+  ($v8_fn:ident, $json_fn:ident, $src:expr) => {
+    fn $v8_fn(b: &mut Bencher) {
+      serdo(|scope| {
+        let v = $src;
+        b.iter(move || {
+          let _ = serde_v8::to_v8(scope, &v).unwrap();
+        });
+      });
+    }
+
+    fn $json_fn(b: &mut Bencher) {
+      let v = $src;
+      b.iter(move || {
+        let _ = serde_json::to_string(&v).unwrap();
+      });
+    }
+  };
+}
+
+dualbench!(
+  ser_struct_v8,
+  ser_struct_json,
+  MathOp {
+    arg1: 10,
+    arg2: 123,
+    operator: None
+  }
+);
+dualbench!(ser_bool_v8, ser_bool_json, true);
+dualbench!(ser_int_v8, ser_int_json, 12345);
+dualbench!(
+  ser_array_v8,
+  ser_array_json,
+  vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+);
+dualbench!(ser_str_v8, ser_str_json, "hello world");
+dualbench!(ser_tuple_v8, ser_tuple_json, (1, false));
+
+fn ser_struct_v8_manual(b: &mut Bencher) {
+  serdo(|scope| {
+    let v = MathOp {
+      arg1: 10,
+      arg2: 123,
+      operator: None,
+    };
+    b.iter(|| {
+      let obj = v8::Object::new(scope);
+      let k1 = v8::String::new(scope, "arg1").unwrap();
+      let k2 = v8::String::new(scope, "arg2").unwrap();
+      let k3 = v8::String::new(scope, "operator").unwrap();
+      //    let k1 = v8::String::new_from_utf8(scope, "arg1".as_ref(), v8::NewStringType::Internalized).unwrap();
+      //    let k2 = v8::String::new_from_utf8(scope, "arg2".as_ref(), v8::NewStringType::Internalized).unwrap();
+      //    let k3 = v8::String::new_from_utf8(scope, "operator".as_ref(), v8::NewStringType::Internalized).unwrap();
+      let v1 = v8::Number::new(scope, v.arg1 as f64);
+      let v2 = v8::Number::new(scope, v.arg2 as f64);
+      let v3 = v8::null(scope);
+      obj.set(scope, k1.into(), v1.into()).unwrap();
+      obj.set(scope, k2.into(), v2.into()).unwrap();
+      obj.set(scope, k3.into(), v3.into()).unwrap();
+    });
+  });
+}
+
+benchmark_group!(
+  benches,
+  ser_struct_v8,
+  ser_struct_json,
+  ser_bool_v8,
+  ser_bool_json,
+  ser_int_v8,
+  ser_int_json,
+  ser_array_v8,
+  ser_array_json,
+  ser_str_v8,
+  ser_str_json,
+  ser_tuple_v8,
+  ser_tuple_json,
+  ser_struct_v8_manual,
+);
+benchmark_main!(benches);

--- a/serde_v8/benches/ser.rs
+++ b/serde_v8/benches/ser.rs
@@ -1,7 +1,6 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
 
 use rusty_v8 as v8;
-use serde_v8;
 
 use serde::Serialize;
 


### PR DESCRIPTION
This restores the `serde_v8` benches from the original repo, using `bencher` like `core/benches/op_baseline`.

## Notes

The original benches were compared to `serde_json` working on existing strings. Whilst useful, these `_json` benches can be misleading and lead people to believe that `serde_v8` is slower than using JSON for the op-layer, forgetting that using JSON requires the extra steps of `JSON.parse()/.stringify()` and co, not measured here.

Since they can't be meaningfully compared in absolute, it might make sense to remove them

## Output

```
running 15 tests
test de_array_json        ... bench:         488 ns/iter (+/- 9)
test de_array_v8          ... bench:         601 ns/iter (+/- 19)
test de_bool_json         ... bench:          21 ns/iter (+/- 1)
test de_bool_v8           ... bench:           7 ns/iter (+/- 0)
test de_int_json          ... bench:          43 ns/iter (+/- 2)
test de_int_v8            ... bench:           7 ns/iter (+/- 1)
test de_str_json          ... bench:          49 ns/iter (+/- 5)
test de_str_v8            ... bench:          79 ns/iter (+/- 3)
test de_struct_json       ... bench:         142 ns/iter (+/- 3)
test de_struct_json_deopt ... bench:         466 ns/iter (+/- 15)
test de_struct_v8         ... bench:         231 ns/iter (+/- 11)
test de_struct_v8_opt     ... bench:          97 ns/iter (+/- 3)
test de_tuple_json        ... bench:          57 ns/iter (+/- 3)
test de_tuple_v8          ... bench:          69 ns/iter (+/- 0)
test de_tuple_v8_opt      ... bench:          68 ns/iter (+/- 9)

test result: ok. 0 passed; 0 failed; 0 ignored; 15 measured

     Running target/release/deps/ser-7e48eeb04c97e76a

running 13 tests
test ser_array_json       ... bench:         171 ns/iter (+/- 5)
test ser_array_v8         ... bench:         459 ns/iter (+/- 37)
test ser_bool_json        ... bench:          32 ns/iter (+/- 0)
test ser_bool_v8          ... bench:          60 ns/iter (+/- 1)
test ser_int_json         ... bench:          35 ns/iter (+/- 1)
test ser_int_v8           ... bench:          61 ns/iter (+/- 1)
test ser_str_json         ... bench:          48 ns/iter (+/- 1)
test ser_str_v8           ... bench:         119 ns/iter (+/- 2)
test ser_struct_json      ... bench:         155 ns/iter (+/- 1)
test ser_struct_v8        ... bench:         459 ns/iter (+/- 61)
test ser_struct_v8_manual ... bench:         538 ns/iter (+/- 90)
test ser_tuple_json       ... bench:          57 ns/iter (+/- 3)
test ser_tuple_v8         ... bench:         217 ns/iter (+/- 12)
```