### PR TITLE
core: js errors as unions vs tuples to reduce allocs

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -45,17 +45,18 @@
 
   function processResponse(res) {
     // const [ok, err] = res;
-    if (res[1] === null) {
+    if (!res.$err_class_name) {
       return res[0];
     }
-    throw processErr(res[1]);
+    throw processErr(res);
   }
 
   function processErr(err) {
-    const [ErrorClass, args] = getErrorClassAndArgs(err.className);
+    const className = err.$err_class_name;
+    const [ErrorClass, args] = getErrorClassAndArgs(className);
     if (!ErrorClass) {
       return new Error(
-        `Unregistered error class: "${err.className}"\n  ${err.message}\n  Classes of errors returned from ops should be registered via Deno.core.registerErrorClass().`,
+        `Unregistered error class: "${className}"\n  ${err.message}\n  Classes of errors returned from ops should be registered via Deno.core.registerErrorClass().`,
       );
     }
     return new ErrorClass(err.message, ...args);

--- a/core/core.js
+++ b/core/core.js
@@ -44,7 +44,7 @@
   }
 
   function processResponse(res) {
-    // const [ok, err] = res;
+    // .$err_class_name is a special key that should only exist on errors
     if (!res.$err_class_name) {
       return res;
     }

--- a/core/core.js
+++ b/core/core.js
@@ -45,10 +45,14 @@
 
   function processResponse(res) {
     // .$err_class_name is a special key that should only exist on errors
-    if (!res.$err_class_name) {
+    if (!isErr(res)) {
       return res;
     }
     throw processErr(res);
+  }
+
+  function isErr(res) {
+    return !!(res && res.$err_class_name);
   }
 
   function processErr(err) {
@@ -86,10 +90,10 @@
     // const [ok, err] = res;
     const promise = promiseTable.get(promiseId);
     promiseTable.delete(promiseId);
-    if (!res[1]) {
-      promise.resolve(res[0]);
+    if (!isErr(res)) {
+      promise.resolve(res);
     } else {
-      promise.reject(processErr(res[1]));
+      promise.reject(processErr(res));
     }
   }
 

--- a/core/core.js
+++ b/core/core.js
@@ -44,13 +44,13 @@
   }
 
   function processResponse(res) {
-    // .$err_class_name is a special key that should only exist on errors
     if (!isErr(res)) {
       return res;
     }
     throw processErr(res);
   }
 
+  // .$err_class_name is a special key that should only exist on errors
   function isErr(res) {
     return !!(res && res.$err_class_name);
   }
@@ -87,7 +87,6 @@
   }
 
   function opAsyncHandler(promiseId, res) {
-    // const [ok, err] = res;
     const promise = promiseTable.get(promiseId);
     promiseTable.delete(promiseId);
     if (!isErr(res)) {

--- a/core/core.js
+++ b/core/core.js
@@ -46,7 +46,7 @@
   function processResponse(res) {
     // const [ok, err] = res;
     if (!res.$err_class_name) {
-      return res[0];
+      return res;
     }
     throw processErr(res);
   }


### PR DESCRIPTION
This is an op-layer optimization follow-up to #9843.

It shaves off `~350ns/op` of baseline overhead, making them over 2x faster by reducing allocs.

Instead of returning JS results as tuples of `(Option<T>, Option<Err>)` it returns them as a conceptual union type, avoiding allocating the wrapping array. We then use a "special" key name to recognize errors.

So far I've picked the error-key to be `$err_class_name`, but this can be easily changed or adjusted.

## Results

Op-baseline benches:
```
Before:
test bench_op_nop     ... bench:     321,740 ns/iter (+/- 39,892)
test bench_op_pi_bin  ... bench:     786,395 ns/iter (+/- 23,765)
test bench_op_pi_json ... bench:     681,285 ns/iter (+/- 26,579)

After:
test bench_op_nop     ... bench:     318,910 ns/iter (+/- 16,233)
test bench_op_pi_bin  ... bench:     402,301 ns/iter (+/- 28,707)
test bench_op_pi_json ... bench:     294,627 ns/iter (+/- 14,079)
```