### PR TITLE
fix(cli/dts): fix futime and futime example

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1131,7 +1131,7 @@ declare namespace Deno {
    * seconds (UNIX epoch time) or as `Date` objects.
    *
    * ```ts
-   * const file = Deno.openSync("file.txt", { create: true });
+   * const file = Deno.openSync("file.txt", { create: true, write: true });
    * Deno.futimeSync(file.rid, 1556495550, new Date());
    * ```
    */
@@ -1148,7 +1148,7 @@ declare namespace Deno {
    * (UNIX epoch time) or as `Date` objects.
    *
    * ```ts
-   * const file = await Deno.open("file.txt", { create: true });
+   * const file = await Deno.open("file.txt", { create: true, write: true });
    * await Deno.futime(file.rid, 1556495550, new Date());
    * ```
    */


### PR DESCRIPTION
I was working on `deno_std` and I saw an example for `futime` and `futimeSync`. as far as I know `Deno.openSync` needs `write` option alongside with `create`/`append` option. so I updated the example. let me know if I'm wrong.

ref: 
https://github.com/denoland/deno/blob/d6d5ced1ab90404d25a87a242ee5b03ca655abe5/cli/dts/lib.deno.ns.d.ts#L812