### PR TITLE
perf: bench async op baseline

### DIFF
--- a/core/benches/op_baseline.rs
+++ b/core/benches/op_baseline.rs
@@ -1,16 +1,24 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
 
 use deno_core::bin_op_sync;
+use deno_core::error::AnyError;
+use deno_core::json_op_async;
 use deno_core::json_op_sync;
 use deno_core::v8;
+use deno_core::BufVec;
 use deno_core::JsRuntime;
 use deno_core::Op;
 use deno_core::OpResponse;
+use deno_core::OpState;
+
+use std::cell::RefCell;
+use std::rc::Rc;
 
 fn create_js_runtime() -> JsRuntime {
   let mut runtime = JsRuntime::new(Default::default());
   runtime.register_op("pi_bin", bin_op_sync(|_, _, _| Ok(314159)));
   runtime.register_op("pi_json", json_op_sync(|_, _: (), _| Ok(314159)));
+  runtime.register_op("pi_async", json_op_async(op_pi_async));
   runtime
     .register_op("nop", |_, _, _| Op::Sync(OpResponse::Value(Box::new(9))));
 
@@ -30,6 +38,15 @@ fn create_js_runtime() -> JsRuntime {
   runtime
 }
 
+// this is a function since async closures aren't stable
+async fn op_pi_async(
+  _: Rc<RefCell<OpState>>,
+  _: (),
+  _: BufVec,
+) -> Result<i64, AnyError> {
+  Ok(314159)
+}
+
 pub fn bench_runtime_js(b: &mut Bencher, src: &str) {
   let mut runtime = create_js_runtime();
   let context = runtime.global_context();
@@ -38,6 +55,20 @@ pub fn bench_runtime_js(b: &mut Bencher, src: &str) {
   let script = v8::Script::compile(scope, code, None).unwrap();
   b.iter(|| {
     script.run(scope).unwrap();
+  });
+}
+
+pub fn bench_runtime_js_async(b: &mut Bencher, src: &str) {
+  let mut runtime = create_js_runtime();
+  let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .unwrap();
+
+  b.iter(|| {
+    runtime.execute("inner_loop", src).unwrap();
+    let future = runtime.run_event_loop();
+    tokio_runtime.block_on(future).unwrap();
   });
 }
 
@@ -68,5 +99,20 @@ fn bench_op_nop(b: &mut Bencher) {
   );
 }
 
-benchmark_group!(benches, bench_op_pi_bin, bench_op_pi_json, bench_op_nop);
+fn bench_op_async(b: &mut Bencher) {
+  bench_runtime_js_async(
+    b,
+    r#"for(let i=0; i < 1e3; i++) {
+      Deno.core.jsonOpAsync("pi_async", null);
+    }"#,
+  );
+}
+
+benchmark_group!(
+  benches,
+  bench_op_pi_bin,
+  bench_op_pi_json,
+  bench_op_nop,
+  bench_op_async
+);
 benchmark_main!(benches);


### PR DESCRIPTION
This extends the `op_baseline` bench introduced in https://github.com/denoland/deno/pull/9924 to also bench async ops.

Here's a comparison of `main` vs https://github.com/denoland/deno/pull/9947:

```
Before:
test bench_op_async   ... bench:   1,256,422 ns/iter (+/- 27,839)
test bench_op_nop     ... bench:     323,275 ns/iter (+/- 7,916)
test bench_op_pi_bin  ... bench:     810,688 ns/iter (+/- 26,193)
test bench_op_pi_json ... bench:     703,911 ns/iter (+/- 44,627)

After:
test bench_op_async   ... bench:     805,011 ns/iter (+/- 22,248)
test bench_op_nop     ... bench:     318,809 ns/iter (+/- 11,228)
test bench_op_pi_bin  ... bench:     408,557 ns/iter (+/- 21,002)
test bench_op_pi_json ... bench:     315,826 ns/iter (+/- 23,131)
```