### PR TITLE
revert: "fix(op_crates/web): align encoding type definitions to spec"

### DIFF
--- a/op_crates/web/lib.deno_web.d.ts
+++ b/op_crates/web/lib.deno_web.d.ts
@@ -178,84 +178,32 @@ declare function atob(s: string): string;
  */
 declare function btoa(s: string): string;
 
-/** A decoder for a specific method, that is a specific character encoding, like utf-8, iso-8859-2, koi8, cp1261, gbk, etc. A decoder takes a stream of bytes as input and emits a stream of code points. For a more scalable, non-native library, see StringView – a C-like representation of strings based on typed arrays. */
-interface TextDecoder extends TextDecoderCommon {
-  /**
-     * Returns the result of running encoding's decoder. The method can be invoked zero or more times with options's stream set to true, and then once without options's stream (or set to false), to process a fragmented input. If the invocation without options's stream (or set to false) has no input, it's clearest to omit both arguments.
-     *
-     * ```
-     * var string = "", decoder = new TextDecoder(encoding), buffer;
-     * while(buffer = next_chunk()) {
-     *   string += decoder.decode(buffer, {stream:true});
-     * }
-     * string += decoder.decode(); // end-of-queue
-     * ```
-     *
-     * If the error mode is "fatal" and encoding's decoder returns error, throws a TypeError.
-     */
-  decode(input?: BufferSource, options?: TextDecodeOptions): string;
-}
-
-declare var TextDecoder: {
-  prototype: TextDecoder;
-  new (label?: string, options?: TextDecoderOptions): TextDecoder;
-};
-
-interface TextDecoderCommon {
-  /**
-     * Returns encoding's name, lowercased.
-     */
+declare class TextDecoder {
+  /** Returns encoding's name, lowercased. */
   readonly encoding: string;
-  /**
-     * Returns true if error mode is "fatal", otherwise false.
-     */
+  /** Returns `true` if error mode is "fatal", and `false` otherwise. */
   readonly fatal: boolean;
-  /**
-     * Returns the value of ignore BOM.
-     */
-  readonly ignoreBOM: boolean;
+  /** Returns `true` if ignore BOM flag is set, and `false` otherwise. */
+  readonly ignoreBOM = false;
+  constructor(
+    label?: string,
+    options?: { fatal?: boolean; ignoreBOM?: boolean },
+  );
+  /** Returns the result of running encoding's decoder. */
+  decode(input?: BufferSource, options?: { stream?: false }): string;
+  readonly [Symbol.toStringTag]: string;
 }
 
-interface TextDecodeOptions {
-  // TODO(caspervonb) support streaming.
-  stream?: false;
-}
-
-interface TextDecoderOptions {
-  fatal?: boolean;
-  ignoreBOM?: boolean;
-}
-
-interface TextEncoderEncodeIntoResult {
-  read?: number;
-  written?: number;
-}
-
-/** TextEncoder takes a stream of code points as input and emits a stream of bytes. For a more scalable, non-native library, see StringView – a C-like representation of strings based on typed arrays. */
-interface TextEncoder extends TextEncoderCommon {
-  /**
-     * Returns the result of running UTF-8's encoder.
-     */
+declare class TextEncoder {
+  /** Returns "utf-8". */
+  readonly encoding = "utf-8";
+  /** Returns the result of running UTF-8's encoder. */
   encode(input?: string): Uint8Array;
-  /**
-     * Runs the UTF-8 encoder on source, stores the result of that operation into destination, and returns the progress made as an object wherein read is the number of converted code units of source and written is the number of bytes modified in destination.
-     */
   encodeInto(
-    source: string,
-    destination: Uint8Array,
-  ): TextEncoderEncodeIntoResult;
-}
-
-declare var TextEncoder: {
-  prototype: TextEncoder;
-  new (): TextEncoder;
-};
-
-interface TextEncoderCommon {
-  /**
-     * Returns "utf-8".
-     */
-  readonly encoding: string;
+    input: string,
+    dest: Uint8Array,
+  ): { read: number; written: number };
+  readonly [Symbol.toStringTag]: string;
 }
 
 /** A controller object that allows you to abort one or more DOM requests as and


### PR DESCRIPTION
Reverts denoland/deno#9782

This breaks `std` and could have further breaking changes with downstream users... need to reland later in 1.9 in a non-breaking way.