### PR TITLE
perf(serde_v8): introduce Serializable boxable object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,6 @@ version = "0.83.0"
 dependencies = [
  "anyhow",
  "bencher",
- "erased-serde",
  "futures",
  "indexmap",
  "lazy_static",
@@ -895,15 +894,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "erased-serde"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0465971a8cc1fa2455c8465aaa377131e1f1cf4983280f474a13e68793aa770c"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,6 @@ path = "lib.rs"
 
 [dependencies]
 anyhow = "1.0.38"
-erased-serde = "0.3.13"
 futures = "0.3.12"
 indexmap = "1.6.1"
 lazy_static = "1.4.0"

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -438,7 +438,7 @@ fn send<'s>(
   match op {
     Op::Sync(resp) => match resp {
       OpResponse::Value(v) => {
-        rv.set(to_v8(scope, v).unwrap());
+        rv.set(v.to_v8(scope).unwrap());
       }
       OpResponse::Buffer(buf) => {
         rv.set(boxed_slice_to_uint8array(scope, buf).into());

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -14,6 +14,7 @@ mod ops_json;
 pub mod plugin_api;
 mod resources;
 mod runtime;
+mod v8_serializable;
 mod zero_copy_buf;
 
 // Re-exports
@@ -65,7 +66,6 @@ pub use crate::ops::OpResponse;
 pub use crate::ops::OpState;
 pub use crate::ops::OpTable;
 pub use crate::ops::PromiseId;
-pub use crate::ops::Serializable;
 pub use crate::ops_bin::bin_op_async;
 pub use crate::ops_bin::bin_op_sync;
 pub use crate::ops_bin::ValueOrVector;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -14,7 +14,6 @@ mod ops_json;
 pub mod plugin_api;
 mod resources;
 mod runtime;
-mod v8_serializable;
 mod zero_copy_buf;
 
 // Re-exports

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -6,7 +6,6 @@ use crate::error::AnyError;
 use crate::gotham_state::GothamState;
 use crate::resources::ResourceTable;
 use crate::runtime::GetErrorClassFn;
-use crate::v8_serializable::V8Serializable;
 use crate::ZeroCopyBuf;
 use futures::Future;
 use indexmap::IndexMap;
@@ -60,7 +59,7 @@ impl<'a, 'b, 'c> OpPayload<'a, 'b, 'c> {
 }
 
 pub enum OpResponse {
-  Value(Box<dyn V8Serializable>),
+  Value(Box<dyn serde_v8::Serializable>),
   Buffer(Box<[u8]>),
 }
 

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -6,6 +6,7 @@ use crate::error::AnyError;
 use crate::gotham_state::GothamState;
 use crate::resources::ResourceTable;
 use crate::runtime::GetErrorClassFn;
+use crate::v8_serializable::V8Serializable;
 use crate::ZeroCopyBuf;
 use futures::Future;
 use indexmap::IndexMap;
@@ -22,7 +23,6 @@ use std::ops::DerefMut;
 use std::pin::Pin;
 use std::rc::Rc;
 
-pub use erased_serde::Serialize as Serializable;
 pub type PromiseId = u64;
 pub type OpAsyncFuture = Pin<Box<dyn Future<Output = OpResponse>>>;
 pub type OpFn =
@@ -60,7 +60,7 @@ impl<'a, 'b, 'c> OpPayload<'a, 'b, 'c> {
 }
 
 pub enum OpResponse {
-  Value(Box<dyn Serializable>),
+  Value(Box<dyn V8Serializable>),
   Buffer(Box<[u8]>),
 }
 

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1419,7 +1419,7 @@ impl JsRuntime {
       let (promise_id, resp) = overflown_response;
       args.push(v8::Integer::new(scope, promise_id as i32).into());
       args.push(match resp {
-        OpResponse::Value(value) => serde_v8::to_v8(scope, value).unwrap(),
+        OpResponse::Value(value) => value.to_v8(scope).unwrap(),
         OpResponse::Buffer(buf) => {
           bindings::boxed_slice_to_uint8array(scope, buf).into()
         }

--- a/core/v8_serializable.rs
+++ b/core/v8_serializable.rs
@@ -1,0 +1,22 @@
+use rusty_v8 as v8;
+
+/// V8Serializable exists to allow boxing values as "objects" to be serialized later,
+/// this is particularly useful for async op-responses. This trait is a more efficient
+/// replacement for erased-serde that makes less allocations, since it's specific to serde_v8
+/// (and thus doesn't have to have generic outputs, etc...)
+pub trait V8Serializable {
+  fn to_v8<'a>(
+    &self,
+    scope: &mut v8::HandleScope<'a>,
+  ) -> Result<v8::Local<'a, v8::Value>, serde_v8::Error>;
+}
+
+/// Allows all implementors of `serde::Serialize` to implement V8Serializable
+impl<T: serde::Serialize> V8Serializable for T {
+  fn to_v8<'a>(
+    &self,
+    scope: &mut v8::HandleScope<'a>,
+  ) -> Result<v8::Local<'a, v8::Value>, serde_v8::Error> {
+    serde_v8::to_v8(scope, self)
+  }
+}

--- a/serde_v8/src/lib.rs
+++ b/serde_v8/src/lib.rs
@@ -5,6 +5,7 @@ mod keys;
 mod magic;
 mod payload;
 mod ser;
+mod serializable;
 pub mod utils;
 
 pub use de::{from_v8, from_v8_cached, Deserializer};
@@ -12,3 +13,4 @@ pub use error::{Error, Result};
 pub use keys::KeyCache;
 pub use magic::Value;
 pub use ser::{to_v8, Serializer};
+pub use serializable::Serializable;

--- a/serde_v8/src/serializable.rs
+++ b/serde_v8/src/serializable.rs
@@ -1,22 +1,22 @@
 use rusty_v8 as v8;
 
-/// V8Serializable exists to allow boxing values as "objects" to be serialized later,
+/// Serializable exists to allow boxing values as "objects" to be serialized later,
 /// this is particularly useful for async op-responses. This trait is a more efficient
 /// replacement for erased-serde that makes less allocations, since it's specific to serde_v8
 /// (and thus doesn't have to have generic outputs, etc...)
-pub trait V8Serializable {
+pub trait Serializable {
   fn to_v8<'a>(
     &self,
     scope: &mut v8::HandleScope<'a>,
-  ) -> Result<v8::Local<'a, v8::Value>, serde_v8::Error>;
+  ) -> Result<v8::Local<'a, v8::Value>, crate::Error>;
 }
 
-/// Allows all implementors of `serde::Serialize` to implement V8Serializable
-impl<T: serde::Serialize> V8Serializable for T {
+/// Allows all implementors of `serde::Serialize` to implement Serializable
+impl<T: serde::Serialize> Serializable for T {
   fn to_v8<'a>(
     &self,
     scope: &mut v8::HandleScope<'a>,
-  ) -> Result<v8::Local<'a, v8::Value>, serde_v8::Error> {
-    serde_v8::to_v8(scope, self)
+  ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
+    crate::to_v8(scope, self)
   }
 }


### PR DESCRIPTION
A more efficient replacement for `erased-serde` to box our async op returns.

It improves our op-baseline by ~60ns/op across all op-categories, which is a strong gain across the board, 20% of the current sync op baseline which is quite significant.

## Benches

```
Before:
test bench_op_async   ... bench:     772,851 ns/iter (+/- 55,538)
test bench_op_nop     ... bench:     265,945 ns/iter (+/- 13,634)
test bench_op_pi_bin  ... bench:     291,033 ns/iter (+/- 16,716)
test bench_op_pi_json ... bench:     285,994 ns/iter (+/- 7,377)

After:
test bench_op_async   ... bench:     710,543 ns/iter (+/- 28,573)
test bench_op_nop     ... bench:     210,362 ns/iter (+/- 3,354)
test bench_op_pi_bin  ... bench:     238,992 ns/iter (+/- 20,449)
test bench_op_pi_json ... bench:     223,458 ns/iter (+/- 3,186)
```

## Changes

- [x] Introduce `V8Serializable` trait
- [x] Drop `erased-serde` dependency
- [x] Maybe move `V8Serializable` to `serde_v8/`