### PR TITLE
perf(serde_v8): drop need for EscapableHandleScope

### DIFF
--- a/serde_v8/src/ser.rs
+++ b/serde_v8/src/ser.rs
@@ -12,19 +12,16 @@ use crate::magic;
 type JsValue<'s> = v8::Local<'s, v8::Value>;
 type JsResult<'s> = Result<JsValue<'s>>;
 
-type ScopePtr<'a, 'b, 'c> = &'c RefCell<v8::EscapableHandleScope<'a, 'b>>;
+type ScopePtr<'a, 'b, 'c> = &'c RefCell<&'b mut v8::HandleScope<'a>>;
 
 pub fn to_v8<'a, T>(scope: &mut v8::HandleScope<'a>, input: T) -> JsResult<'a>
 where
   T: Serialize,
 {
-  let subscope = v8::EscapableHandleScope::new(scope);
-  let scopeptr = RefCell::new(subscope);
+  let scopeptr = RefCell::new(scope);
   let serializer = Serializer::new(&scopeptr);
-  let x = input.serialize(serializer)?;
-  let x = scopeptr.borrow_mut().escape(x);
-
-  Ok(x)
+  
+  input.serialize(serializer)
 }
 
 /// Wraps other serializers into an enum tagged variant form.

--- a/serde_v8/src/ser.rs
+++ b/serde_v8/src/ser.rs
@@ -20,7 +20,7 @@ where
 {
   let scopeptr = RefCell::new(scope);
   let serializer = Serializer::new(&scopeptr);
-  
+
   input.serialize(serializer)
 }
 


### PR DESCRIPTION
This is another improvement to `serde_v8`'s serialization code, it drops the need for creating a `v8::EscapableHandleScope` or "subscope". It's a simplication and optimization similar in nature to #9987.

This is very exciting since sub 100ns/op for sync-ops appears to be within reach ! (at least on my machine, M1 Air)

## Benches

Using our trusty `op_baseline` bench to compare with `main`:
(Note that the before and after of these benches integrates changes from #9983)

```
Before:
test bench_op_async   ... bench:     647,272 ns/iter (+/- 57,528)
test bench_op_nop     ... bench:     157,173 ns/iter (+/- 2,096)
test bench_op_pi_bin  ... bench:     179,239 ns/iter (+/- 4,354)
test bench_op_pi_json ... bench:     175,075 ns/iter (+/- 1,814)

After:
test bench_op_async   ... bench:     564,882 ns/iter (+/- 12,229)
test bench_op_nop     ... bench:     114,117 ns/iter (+/- 2,489)
test bench_op_pi_bin  ... bench:     139,160 ns/iter (+/- 6,047)
test bench_op_pi_json ... bench:     129,266 ns/iter (+/- 2,938)
```