### PR TITLE
docs(getting_started/first_steps): Mention top-level await

### DIFF
--- a/docs/getting_started/first_steps.md
+++ b/docs/getting_started/first_steps.md
@@ -8,6 +8,8 @@ you might want to follow a guide
 [on the basics of JavaScript](https://developer.mozilla.org/en-US/docs/Learn/JavaScript)
 before attempting to start with Deno.
 
+**NOTE**: Deno supports the [`top-level await` ECMAScript proposal](https://github.com/tc39/proposal-top-level-await) which "_enables modules to act as big async functions_", allowing `await` to be used outside an `async` function at the top level.
+
 ### Hello World
 
 Deno is a runtime for JavaScript/TypeScript which tries to be web compatible and


### PR DESCRIPTION
Started getting into JS again after many years, so read through the linked MDN resource, but was baffled that `await` is being used on it's own. Assumed that it is implicitly wrapped in an `async` function by Deno's runtime, but [this Stackoverflow thread](https://stackoverflow.com/questions/61816979/await-without-async-in-deno-framwork) confirmed it.

The wording is only a suggestion, but something along those lines would've helped. Thanks!