### PR TITLE
perf(runtime): optimize PermissionState::check

### DIFF
--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -34,6 +34,37 @@ pub enum PermissionState {
 }
 
 impl PermissionState {
+  #[inline(always)]
+  fn log_perm_access(name: &str, info: Option<&str>) {
+    debug!(
+      "{}",
+      colors::bold(&format!(
+        "{}️  Granted {}",
+        PERMISSION_EMOJI,
+        Self::fmt_access(name, info)
+      ))
+    );
+  }
+
+  fn fmt_access(name: &str, info: Option<&str>) -> String {
+    format!(
+      "{} access{}",
+      name,
+      info.map_or(String::new(), |info| { format!(" to {}", info) }),
+    )
+  }
+
+  fn error(name: &str, info: Option<&str>) -> AnyError {
+    custom_error(
+      "PermissionDenied",
+      format!(
+        "Requires {}, run again with the --allow-{} flag",
+        Self::fmt_access(name, info),
+        name
+      ),
+    )
+  }
+
   /// Check the permission state. bool is whether a prompt was issued.
   fn check(
     self,
@@ -41,28 +72,22 @@ impl PermissionState {
     info: Option<&str>,
     prompt: bool,
   ) -> (Result<(), AnyError>, bool) {
-    let access = format!(
-      "{} access{}",
-      name,
-      info.map_or(String::new(), |info| { format!(" to {}", info) }),
-    );
-    let result = if self == PermissionState::Granted
-      || (prompt
-        && self == PermissionState::Prompt
-        && permission_prompt(&access))
-    {
-      log_perm_access(&access);
-      Ok(())
-    } else {
-      Err(custom_error(
-        "PermissionDenied",
-        format!(
-          "Requires {}, run again with the --allow-{} flag",
-          access, name
-        ),
-      ))
-    };
-    (result, prompt && self == PermissionState::Prompt)
+    match self {
+      PermissionState::Granted => {
+        Self::log_perm_access(name, info);
+        (Ok(()), false)
+      }
+      PermissionState::Prompt if prompt => {
+        let msg = Self::fmt_access(name, info);
+        if permission_prompt(&msg) {
+          Self::log_perm_access(name, info);
+          (Ok(()), true)
+        } else {
+          (Err(Self::error(name, info)), true)
+        }
+      }
+      _ => (Err(Self::error(name, info)), false),
+    }
   }
 }
 
@@ -818,13 +843,6 @@ impl deno_websocket::WebSocketPermissions for Permissions {
   fn check_net_url(&mut self, url: &url::Url) -> Result<(), AnyError> {
     self.net.check_url(url)
   }
-}
-
-fn log_perm_access(message: &str) {
-  debug!(
-    "{}",
-    colors::bold(&format!("{}️  Granted {}", PERMISSION_EMOJI, message))
-  );
 }
 
 fn boolean_permission_from_flag_bool(


### PR DESCRIPTION
By converting `log_perm_access()` to a macro, so the message sub-expression is dropped at compile time in release mode. Otherwise it made allocations and added substantial overhead to opcalls.

## Benches

Measured on `perf_now` (`op_now`) from `deno_common`:

```
Before:
perf_now:                n = 5000000, dt = 2.429s, r = 2058460/s, t = 485ns/op

After:
perf_now:                n = 5000000, dt = 1.773s, r = 2820079/s, t = 354ns/op
```

## Flamegraph views

### Before:
![image](https://user-images.githubusercontent.com/949223/113495774-e8491700-94f3-11eb-91f2-8fc3fa3a129b.png)


### After

![image](https://user-images.githubusercontent.com/949223/113495792-07e03f80-94f4-11eb-9e15-70a6421c626a.png)

