### PR TITLE
refactor(ops): first pass at op best practices

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -185,7 +185,7 @@ declare namespace Deno {
      * console.log(Deno.env.get("MADE_UP_VAR"));  // outputs "Undefined"
      * ```
      * Requires `allow-env` permission. */
-    get(key: string): string | undefined;
+    get(key: string): string | null;
 
     /** Set the value of an environment variable.
      *

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -185,7 +185,7 @@ declare namespace Deno {
      * console.log(Deno.env.get("MADE_UP_VAR"));  // outputs "Undefined"
      * ```
      * Requires `allow-env` permission. */
-    get(key: string): string | null;
+    get(key: string): string | undefined;
 
     /** Set the value of an environment variable.
      *

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -123,9 +123,9 @@ declare namespace Deno {
 
   export interface SystemCpuInfo {
     /** Total number of logical cpus in the system */
-    cores: number | null;
+    cores: number | undefined;
     /** The speed of the cpu measured in MHz */
-    speed: number | null;
+    speed: number | undefined;
   }
 
   /** **UNSTABLE**: new API, yet to be vetted.

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -123,9 +123,9 @@ declare namespace Deno {
 
   export interface SystemCpuInfo {
     /** Total number of logical cpus in the system */
-    cores: number | undefined;
+    cores: number | null;
     /** The speed of the cpu measured in MHz */
-    speed: number | undefined;
+    speed: number | null;
   }
 
   /** **UNSTABLE**: new API, yet to be vetted.

--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -17,14 +17,14 @@ unitTest({ perms: { env: true } }, function envSuccess(): void {
 
 unitTest({ perms: { env: true } }, function envNotFound(): void {
   const r = Deno.env.get("env_var_does_not_exist!");
-  assertEquals(r, null);
+  assertEquals(r, undefined);
 });
 
 unitTest({ perms: { env: true } }, function deleteEnv(): void {
   Deno.env.set("TEST_VAR", "A");
   assertEquals(Deno.env.get("TEST_VAR"), "A");
   assertEquals(Deno.env.delete("TEST_VAR"), undefined);
-  assertEquals(Deno.env.get("TEST_VAR"), null);
+  assertEquals(Deno.env.get("TEST_VAR"), undefined);
 });
 
 unitTest({ perms: { env: true } }, function avoidEmptyNamedEnv(): void {
@@ -206,6 +206,6 @@ unitTest({ perms: { env: true } }, function systemMemoryInfo(): void {
 
 unitTest({ perms: { env: true } }, function systemCpuInfo(): void {
   const { cores, speed } = Deno.systemCpuInfo();
-  assert(cores === null || cores > 0);
-  assert(speed === null || speed > 0);
+  assert(cores === undefined || cores > 0);
+  assert(speed === undefined || speed > 0);
 });

--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -17,14 +17,14 @@ unitTest({ perms: { env: true } }, function envSuccess(): void {
 
 unitTest({ perms: { env: true } }, function envNotFound(): void {
   const r = Deno.env.get("env_var_does_not_exist!");
-  assertEquals(r, undefined);
+  assertEquals(r, null);
 });
 
 unitTest({ perms: { env: true } }, function deleteEnv(): void {
   Deno.env.set("TEST_VAR", "A");
   assertEquals(Deno.env.get("TEST_VAR"), "A");
-  assertEquals(Deno.env.delete("TEST_VAR"), undefined);
-  assertEquals(Deno.env.get("TEST_VAR"), undefined);
+  assertEquals(Deno.env.delete("TEST_VAR"), null);
+  assertEquals(Deno.env.get("TEST_VAR"), null);
 });
 
 unitTest({ perms: { env: true } }, function avoidEmptyNamedEnv(): void {
@@ -206,6 +206,6 @@ unitTest({ perms: { env: true } }, function systemMemoryInfo(): void {
 
 unitTest({ perms: { env: true } }, function systemCpuInfo(): void {
   const { cores, speed } = Deno.systemCpuInfo();
-  assert(cores === undefined || cores > 0);
-  assert(speed === undefined || speed > 0);
+  assert(cores === null || cores > 0);
+  assert(speed === null || speed > 0);
 });

--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -23,7 +23,7 @@ unitTest({ perms: { env: true } }, function envNotFound(): void {
 unitTest({ perms: { env: true } }, function deleteEnv(): void {
   Deno.env.set("TEST_VAR", "A");
   assertEquals(Deno.env.get("TEST_VAR"), "A");
-  assertEquals(Deno.env.delete("TEST_VAR"), null);
+  assertEquals(Deno.env.delete("TEST_VAR"), undefined);
   assertEquals(Deno.env.get("TEST_VAR"), null);
 });
 

--- a/op_crates/crypto/01_crypto.js
+++ b/op_crates/crypto/01_crypto.js
@@ -37,7 +37,7 @@
       arrayBufferView.byteOffset,
       arrayBufferView.byteLength,
     );
-    core.jsonOpSync("op_crypto_get_random_values", {}, ui8);
+    core.jsonOpSync("op_crypto_get_random_values", null, ui8);
     return arrayBufferView;
   }
 

--- a/op_crates/crypto/lib.rs
+++ b/op_crates/crypto/lib.rs
@@ -4,8 +4,6 @@
 
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::JsRuntime;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
@@ -29,9 +27,9 @@ pub fn init(isolate: &mut JsRuntime) {
 
 pub fn op_crypto_get_random_values(
   state: &mut OpState,
-  _args: Value,
+  _args: (),
   zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let mut zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let maybe_seeded_rng = state.try_borrow_mut::<StdRng>();
   if let Some(seeded_rng) = maybe_seeded_rng {
@@ -41,7 +39,7 @@ pub fn op_crypto_get_random_values(
     rng.fill(&mut *zero_copy);
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 pub fn get_declaration() -> PathBuf {

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -888,25 +888,25 @@
   }
 
   /**
-   * @param {{rid: number}} args
+   * @param {number} rid
    * @returns {Promise<{status: number, statusText: string, headers: Record<string,string[]>, url: string, responseRid: number}>}
    */
-  function opFetchSend(args) {
-    return core.jsonOpAsync("op_fetch_send", args);
+  function opFetchSend(rid) {
+    return core.jsonOpAsync("op_fetch_send", rid);
   }
 
   /**
-   * @param {{rid: number}} args 
+   * @param {number} rid 
    * @param {Uint8Array} body 
    * @returns {Promise<void>}
    */
-  function opFetchRequestWrite(args, body) {
+  function opFetchRequestWrite(rid, body) {
     const zeroCopy = new Uint8Array(
       body.buffer,
       body.byteOffset,
       body.byteLength,
     );
-    return core.jsonOpAsync("op_fetch_request_write", args, zeroCopy);
+    return core.jsonOpAsync("op_fetch_request_write", rid, zeroCopy);
   }
 
   const NULL_BODY_STATUS = [101, 204, 205, 304];
@@ -1276,7 +1276,7 @@
          */
         async write(chunk, controller) {
           try {
-            await opFetchRequestWrite({ rid: requestBodyRid }, chunk);
+            await opFetchRequestWrite(requestBodyRid, chunk);
           } catch (err) {
             controller.error(err);
           }
@@ -1288,7 +1288,7 @@
       body.pipeTo(writer);
     }
 
-    return await opFetchSend({ rid: requestRid });
+    return await opFetchSend(requestRid);
   }
 
   /**
@@ -1400,9 +1400,9 @@
           async pull(controller) {
             try {
               const chunk = new Uint8Array(16 * 1024 + 256);
-              const { read } = await core.jsonOpAsync(
+              const read = await core.jsonOpAsync(
                 "op_fetch_response_read",
-                { rid },
+                rid,
                 chunk,
               );
               if (read != 0) {

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -884,7 +884,7 @@
     if (body != null) {
       zeroCopy = new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
     }
-    return core.jsonOpSync("op_fetch", args, ...(zeroCopy ? [zeroCopy] : []));
+    return core.jsonOpSync("op_fetch", args, zeroCopy);
   }
 
   /**

--- a/op_crates/fetch/lib.rs
+++ b/op_crates/fetch/lib.rs
@@ -10,8 +10,6 @@ use deno_core::error::AnyError;
 use deno_core::futures::Future;
 use deno_core::futures::Stream;
 use deno_core::futures::StreamExt;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::url::Url;
 use deno_core::AsyncRefCell;
 use deno_core::CancelFuture;
@@ -34,6 +32,7 @@ use reqwest::Client;
 use reqwest::Method;
 use reqwest::Response;
 use serde::Deserialize;
+use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::convert::From;
@@ -121,11 +120,18 @@ pub struct FetchArgs {
   has_body: bool,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchReturn {
+  request_rid: ResourceId,
+  request_body_rid: Option<ResourceId>,
+}
+
 pub fn op_fetch<FP>(
   state: &mut OpState,
   args: FetchArgs,
   data: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError>
+) -> Result<FetchReturn, AnyError>
 where
   FP: FetchPermissions + 'static,
 {
@@ -164,7 +170,7 @@ where
 
   let mut request = client.request(method, url);
 
-  let maybe_request_body_rid = if args.has_body {
+  let request_body_rid = if args.has_body {
     match data {
       None => {
         // If no body is passed, we return a writer for streaming the body.
@@ -201,17 +207,27 @@ where
     .resource_table
     .add(FetchRequestResource(Box::pin(fut)));
 
-  Ok(json!({
-    "requestRid": request_rid,
-    "requestBodyRid": maybe_request_body_rid
-  }))
+  Ok(FetchReturn {
+    request_rid,
+    request_body_rid,
+  })
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchResponse {
+  status: u16,
+  status_text: String,
+  headers: Vec<(String, String)>,
+  url: String,
+  response_rid: ResourceId,
 }
 
 pub async fn op_fetch_send(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
   _data: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<FetchResponse, AnyError> {
   let request = state
     .borrow_mut()
     .resource_table
@@ -260,13 +276,13 @@ pub async fn op_fetch_send(
       cancel: CancelHandle::default(),
     });
 
-  Ok(json!({
-    "status": status.as_u16(),
-    "statusText": status.canonical_reason().unwrap_or(""),
-    "headers": res_headers,
-    "url": url,
-    "responseRid": rid,
-  }))
+  Ok(FetchResponse {
+    status: status.as_u16(),
+    status_text: status.canonical_reason().unwrap_or("").to_string(),
+    headers: res_headers,
+    url,
+    response_rid: rid,
+  })
 }
 
 pub async fn op_fetch_request_write(

--- a/op_crates/url/lib.rs
+++ b/op_crates/url/lib.rs
@@ -4,8 +4,6 @@ use deno_core::error::generic_error;
 use deno_core::error::type_error;
 use deno_core::error::uri_error;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::url::form_urlencoded;
 use deno_core::url::quirks;
 use deno_core::url::Url;
@@ -34,13 +32,28 @@ pub struct UrlParseArgs {
   set_username: Option<String>,
 }
 
+#[derive(Serialize)]
+pub struct UrlParts {
+  href: String,
+  hash: String,
+  host: String,
+  hostname: String,
+  origin: String,
+  password: String,
+  pathname: String,
+  port: String,
+  protocol: String,
+  search: String,
+  username: String,
+}
+
 /// Parse `UrlParseArgs::href` with an optional `UrlParseArgs::base_href`, or an
 /// optional part to "set" after parsing. Return `UrlParts`.
 pub fn op_url_parse(
   _state: &mut deno_core::OpState,
   args: UrlParseArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<UrlParts, AnyError> {
   let base_url = args
     .base_href
     .as_ref()
@@ -75,20 +88,6 @@ pub fn op_url_parse(
       .map_err(|_| uri_error("Invalid username"))?;
   }
 
-  #[derive(Serialize)]
-  struct UrlParts<'a> {
-    href: &'a str,
-    hash: &'a str,
-    host: &'a str,
-    hostname: &'a str,
-    origin: &'a str,
-    password: &'a str,
-    pathname: &'a str,
-    port: &'a str,
-    protocol: &'a str,
-    search: &'a str,
-    username: &'a str,
-  }
   // TODO(nayeemrmn): Panic that occurs in rust-url for the `non-spec:`
   // url-constructor wpt tests: https://github.com/servo/rust-url/issues/670.
   let username = catch_unwind(|| quirks::username(&url)).map_err(|_| {
@@ -102,41 +101,42 @@ pub fn op_url_parse(
         .unwrap_or_default()
     ))
   })?;
-  Ok(json!(UrlParts {
-    href: quirks::href(&url),
-    hash: quirks::hash(&url),
-    host: quirks::host(&url),
-    hostname: quirks::hostname(&url),
-    origin: &quirks::origin(&url),
-    password: quirks::password(&url),
-    pathname: quirks::pathname(&url),
-    port: quirks::port(&url),
-    protocol: quirks::protocol(&url),
-    search: quirks::search(&url),
-    username,
-  }))
+  Ok(UrlParts {
+    href: quirks::href(&url).to_string(),
+    hash: quirks::hash(&url).to_string(),
+    host: quirks::host(&url).to_string(),
+    hostname: quirks::hostname(&url).to_string(),
+    origin: quirks::origin(&url),
+    password: quirks::password(&url).to_string(),
+    pathname: quirks::pathname(&url).to_string(),
+    port: quirks::port(&url).to_string(),
+    protocol: quirks::protocol(&url).to_string(),
+    search: quirks::search(&url).to_string(),
+    username: username.to_string(),
+  })
 }
 
 pub fn op_url_parse_search_params(
   _state: &mut deno_core::OpState,
   args: String,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<Vec<(String, String)>, AnyError> {
   let search_params: Vec<_> = form_urlencoded::parse(args.as_bytes())
     .into_iter()
+    .map(|(k, v)| (k.as_ref().to_owned(), v.as_ref().to_owned()))
     .collect();
-  Ok(json!(search_params))
+  Ok(search_params)
 }
 
 pub fn op_url_stringify_search_params(
   _state: &mut deno_core::OpState,
   args: Vec<(String, String)>,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<String, AnyError> {
   let search = form_urlencoded::Serializer::new(String::new())
     .extend_pairs(args)
     .finish();
-  Ok(json!(search))
+  Ok(search)
 }
 
 /// Load and execute the javascript code.

--- a/op_crates/webgpu/binding.rs
+++ b/op_crates/webgpu/binding.rs
@@ -8,7 +8,7 @@ use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
 
-use super::error::{WebGpuError, WebGpuResult};
+use super::error::WebGpuResult;
 
 pub(crate) struct WebGpuBindGroupLayout(
   pub(crate) wgpu_core::id::BindGroupLayoutId,
@@ -205,10 +205,7 @@ pub fn op_webgpu_create_bind_group_layout(
     .resource_table
     .add(WebGpuBindGroupLayout(bind_group_layout));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -257,10 +254,7 @@ pub fn op_webgpu_create_pipeline_layout(
     .resource_table
     .add(super::pipeline::WebGpuPipelineLayout(pipeline_layout));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -354,8 +348,5 @@ pub fn op_webgpu_create_bind_group(
 
   let rid = state.resource_table.add(WebGpuBindGroup(bind_group));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }

--- a/op_crates/webgpu/binding.rs
+++ b/op_crates/webgpu/binding.rs
@@ -205,7 +205,7 @@ pub fn op_webgpu_create_bind_group_layout(
     .resource_table
     .add(WebGpuBindGroupLayout(bind_group_layout));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -254,7 +254,7 @@ pub fn op_webgpu_create_pipeline_layout(
     .resource_table
     .add(super::pipeline::WebGpuPipelineLayout(pipeline_layout));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -348,5 +348,5 @@ pub fn op_webgpu_create_bind_group(
 
   let rid = state.resource_table.add(WebGpuBindGroup(bind_group));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }

--- a/op_crates/webgpu/binding.rs
+++ b/op_crates/webgpu/binding.rs
@@ -2,15 +2,13 @@
 
 use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
 
-use super::error::WebGpuError;
+use super::error::{WebGpuError, WebGpuResult};
 
 pub(crate) struct WebGpuBindGroupLayout(
   pub(crate) wgpu_core::id::BindGroupLayoutId,
@@ -83,7 +81,7 @@ pub fn op_webgpu_create_bind_group_layout(
   state: &mut OpState,
   args: CreateBindGroupLayoutArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
@@ -207,10 +205,10 @@ pub fn op_webgpu_create_bind_group_layout(
     .resource_table
     .add(WebGpuBindGroupLayout(bind_group_layout));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from)
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }
 
 #[derive(Deserialize)]
@@ -225,7 +223,7 @@ pub fn op_webgpu_create_pipeline_layout(
   state: &mut OpState,
   args: CreatePipelineLayoutArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
@@ -259,10 +257,10 @@ pub fn op_webgpu_create_pipeline_layout(
     .resource_table
     .add(super::pipeline::WebGpuPipelineLayout(pipeline_layout));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from)
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }
 
 #[derive(Deserialize)]
@@ -288,7 +286,7 @@ pub fn op_webgpu_create_bind_group(
   state: &mut OpState,
   args: CreateBindGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
@@ -356,8 +354,8 @@ pub fn op_webgpu_create_bind_group(
 
   let rid = state.resource_table.add(WebGpuBindGroup(bind_group));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from)
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }

--- a/op_crates/webgpu/buffer.rs
+++ b/op_crates/webgpu/buffer.rs
@@ -17,7 +17,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use super::error::DomExceptionOperationError;
-use super::error::{WebGpuError, WebGpuResult};
+use super::error::WebGpuResult;
 
 pub(crate) struct WebGpuBuffer(pub(crate) wgpu_core::id::BufferId);
 impl Resource for WebGpuBuffer {
@@ -70,10 +70,7 @@ pub fn op_webgpu_create_buffer(
 
   let rid = state.resource_table.add(WebGpuBuffer(buffer));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }
 
 #[derive(Deserialize)]

--- a/op_crates/webgpu/buffer.rs
+++ b/op_crates/webgpu/buffer.rs
@@ -85,7 +85,7 @@ pub async fn op_webgpu_buffer_get_map_async(
   state: Rc<RefCell<OpState>>,
   args: BufferGetMapAsyncArgs,
   _bufs: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let (sender, receiver) = oneshot::channel::<Result<(), AnyError>>();
 
   let device;
@@ -159,7 +159,7 @@ pub async fn op_webgpu_buffer_get_map_async(
 
   tokio::try_join!(device_poll_fut, receiver_fut)?;
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]

--- a/op_crates/webgpu/buffer.rs
+++ b/op_crates/webgpu/buffer.rs
@@ -4,8 +4,6 @@ use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
 use deno_core::futures::channel::oneshot;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ResourceId;
@@ -70,7 +68,7 @@ pub fn op_webgpu_create_buffer(
 
   let rid = state.resource_table.add(WebGpuBuffer(buffer));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -176,7 +174,7 @@ pub fn op_webgpu_buffer_get_mapped_range(
   state: &mut OpState,
   args: BufferGetMappedRangeArgs,
   zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let mut zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let instance = state.borrow::<super::Instance>();
   let buffer_resource = state
@@ -201,9 +199,7 @@ pub fn op_webgpu_buffer_get_mapped_range(
     .resource_table
     .add(WebGpuBufferMapped(slice_pointer, args.size as usize));
 
-  Ok(json!({
-    "rid": rid,
-  }))
+  Ok(WebGpuResult::rid(rid))
 }
 
 #[derive(Deserialize)]

--- a/op_crates/webgpu/bundle.rs
+++ b/op_crates/webgpu/bundle.rs
@@ -137,7 +137,7 @@ pub fn op_webgpu_render_bundle_encoder_set_bind_group(
   state: &mut OpState,
   args: RenderBundleEncoderSetBindGroupArgs,
   zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
 
   let bind_group_resource = state
@@ -180,7 +180,7 @@ pub fn op_webgpu_render_bundle_encoder_set_bind_group(
     }
   };
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -194,7 +194,7 @@ pub fn op_webgpu_render_bundle_encoder_push_debug_group(
   state: &mut OpState,
   args: RenderBundleEncoderPushDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
     .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
@@ -208,7 +208,7 @@ pub fn op_webgpu_render_bundle_encoder_push_debug_group(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -221,7 +221,7 @@ pub fn op_webgpu_render_bundle_encoder_pop_debug_group(
   state: &mut OpState,
   args: RenderBundleEncoderPopDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
     .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
@@ -233,7 +233,7 @@ pub fn op_webgpu_render_bundle_encoder_pop_debug_group(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -247,7 +247,7 @@ pub fn op_webgpu_render_bundle_encoder_insert_debug_marker(
   state: &mut OpState,
   args: RenderBundleEncoderInsertDebugMarkerArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
     .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
@@ -261,7 +261,7 @@ pub fn op_webgpu_render_bundle_encoder_insert_debug_marker(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -275,7 +275,7 @@ pub fn op_webgpu_render_bundle_encoder_set_pipeline(
   state: &mut OpState,
   args: RenderBundleEncoderSetPipelineArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pipeline_resource = state
     .resource_table
     .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)
@@ -290,7 +290,7 @@ pub fn op_webgpu_render_bundle_encoder_set_pipeline(
     render_pipeline_resource.0,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -307,7 +307,7 @@ pub fn op_webgpu_render_bundle_encoder_set_index_buffer(
   state: &mut OpState,
   args: RenderBundleEncoderSetIndexBufferArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.buffer)
@@ -327,7 +327,7 @@ pub fn op_webgpu_render_bundle_encoder_set_index_buffer(
       std::num::NonZeroU64::new(args.size),
     );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -344,7 +344,7 @@ pub fn op_webgpu_render_bundle_encoder_set_vertex_buffer(
   state: &mut OpState,
   args: RenderBundleEncoderSetVertexBufferArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.buffer)
@@ -362,7 +362,7 @@ pub fn op_webgpu_render_bundle_encoder_set_vertex_buffer(
     std::num::NonZeroU64::new(args.size),
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -379,7 +379,7 @@ pub fn op_webgpu_render_bundle_encoder_draw(
   state: &mut OpState,
   args: RenderBundleEncoderDrawArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
     .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
@@ -393,7 +393,7 @@ pub fn op_webgpu_render_bundle_encoder_draw(
     args.first_instance,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -411,7 +411,7 @@ pub fn op_webgpu_render_bundle_encoder_draw_indexed(
   state: &mut OpState,
   args: RenderBundleEncoderDrawIndexedArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
     .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
@@ -426,7 +426,7 @@ pub fn op_webgpu_render_bundle_encoder_draw_indexed(
     args.first_instance,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -441,7 +441,7 @@ pub fn op_webgpu_render_bundle_encoder_draw_indirect(
   state: &mut OpState,
   args: RenderBundleEncoderDrawIndirectArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
@@ -457,5 +457,5 @@ pub fn op_webgpu_render_bundle_encoder_draw_indirect(
     args.indirect_offset,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }

--- a/op_crates/webgpu/bundle.rs
+++ b/op_crates/webgpu/bundle.rs
@@ -124,10 +124,7 @@ pub fn op_webgpu_render_bundle_encoder_finish(
 
   let rid = state.resource_table.add(WebGpuRenderBundle(render_bundle));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }
 
 #[derive(Deserialize)]

--- a/op_crates/webgpu/bundle.rs
+++ b/op_crates/webgpu/bundle.rs
@@ -3,8 +3,6 @@
 use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
@@ -13,7 +11,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use super::error::{WebGpuError, WebGpuResult};
+use super::error::WebGpuResult;
 use super::texture::serialize_texture_format;
 
 struct WebGpuRenderBundleEncoder(
@@ -46,7 +44,7 @@ pub fn op_webgpu_create_render_bundle_encoder(
   state: &mut OpState,
   args: CreateRenderBundleEncoderArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let device_resource = state
     .resource_table
     .get::<super::WebGpuDevice>(args.device_rid)
@@ -85,10 +83,7 @@ pub fn op_webgpu_create_render_bundle_encoder(
       render_bundle_encoder,
     )));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from),
-  }))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -124,7 +119,7 @@ pub fn op_webgpu_render_bundle_encoder_finish(
 
   let rid = state.resource_table.add(WebGpuRenderBundle(render_bundle));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }
 
 #[derive(Deserialize)]

--- a/op_crates/webgpu/bundle.rs
+++ b/op_crates/webgpu/bundle.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use super::error::WebGpuError;
+use super::error::{WebGpuError, WebGpuResult};
 use super::texture::serialize_texture_format;
 
 struct WebGpuRenderBundleEncoder(
@@ -102,7 +102,7 @@ pub fn op_webgpu_render_bundle_encoder_finish(
   state: &mut OpState,
   args: RenderBundleEncoderFinishArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
     .take::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
@@ -124,10 +124,10 @@ pub fn op_webgpu_render_bundle_encoder_finish(
 
   let rid = state.resource_table.add(WebGpuRenderBundle(render_bundle));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from)
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }
 
 #[derive(Deserialize)]
@@ -145,7 +145,7 @@ pub fn op_webgpu_render_bundle_encoder_set_bind_group(
   state: &mut OpState,
   args: RenderBundleEncoderSetBindGroupArgs,
   zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
 
   let bind_group_resource = state
@@ -188,7 +188,7 @@ pub fn op_webgpu_render_bundle_encoder_set_bind_group(
     }
   };
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -202,7 +202,7 @@ pub fn op_webgpu_render_bundle_encoder_push_debug_group(
   state: &mut OpState,
   args: RenderBundleEncoderPushDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
     .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
@@ -216,7 +216,7 @@ pub fn op_webgpu_render_bundle_encoder_push_debug_group(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -229,7 +229,7 @@ pub fn op_webgpu_render_bundle_encoder_pop_debug_group(
   state: &mut OpState,
   args: RenderBundleEncoderPopDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
     .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
@@ -241,7 +241,7 @@ pub fn op_webgpu_render_bundle_encoder_pop_debug_group(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -255,7 +255,7 @@ pub fn op_webgpu_render_bundle_encoder_insert_debug_marker(
   state: &mut OpState,
   args: RenderBundleEncoderInsertDebugMarkerArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
     .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
@@ -269,7 +269,7 @@ pub fn op_webgpu_render_bundle_encoder_insert_debug_marker(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -283,7 +283,7 @@ pub fn op_webgpu_render_bundle_encoder_set_pipeline(
   state: &mut OpState,
   args: RenderBundleEncoderSetPipelineArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pipeline_resource = state
     .resource_table
     .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)
@@ -298,7 +298,7 @@ pub fn op_webgpu_render_bundle_encoder_set_pipeline(
     render_pipeline_resource.0,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -315,7 +315,7 @@ pub fn op_webgpu_render_bundle_encoder_set_index_buffer(
   state: &mut OpState,
   args: RenderBundleEncoderSetIndexBufferArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.buffer)
@@ -335,7 +335,7 @@ pub fn op_webgpu_render_bundle_encoder_set_index_buffer(
       std::num::NonZeroU64::new(args.size),
     );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -352,7 +352,7 @@ pub fn op_webgpu_render_bundle_encoder_set_vertex_buffer(
   state: &mut OpState,
   args: RenderBundleEncoderSetVertexBufferArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.buffer)
@@ -370,7 +370,7 @@ pub fn op_webgpu_render_bundle_encoder_set_vertex_buffer(
     std::num::NonZeroU64::new(args.size),
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -387,7 +387,7 @@ pub fn op_webgpu_render_bundle_encoder_draw(
   state: &mut OpState,
   args: RenderBundleEncoderDrawArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
     .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
@@ -401,7 +401,7 @@ pub fn op_webgpu_render_bundle_encoder_draw(
     args.first_instance,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -419,7 +419,7 @@ pub fn op_webgpu_render_bundle_encoder_draw_indexed(
   state: &mut OpState,
   args: RenderBundleEncoderDrawIndexedArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
     .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
@@ -434,7 +434,7 @@ pub fn op_webgpu_render_bundle_encoder_draw_indexed(
     args.first_instance,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -449,7 +449,7 @@ pub fn op_webgpu_render_bundle_encoder_draw_indirect(
   state: &mut OpState,
   args: RenderBundleEncoderDrawIndirectArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
@@ -465,5 +465,5 @@ pub fn op_webgpu_render_bundle_encoder_draw_indirect(
     args.indirect_offset,
   );
 
-  Ok(json!({}))
+  Ok(())
 }

--- a/op_crates/webgpu/command_encoder.rs
+++ b/op_crates/webgpu/command_encoder.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
 
-use super::error::WebGpuError;
+use super::error::{WebGpuError, WebGpuResult};
 
 pub(crate) struct WebGpuCommandEncoder(
   pub(crate) wgpu_core::id::CommandEncoderId,
@@ -51,7 +51,7 @@ pub fn op_webgpu_create_command_encoder(
   state: &mut OpState,
   args: CreateCommandEncoderArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
@@ -73,10 +73,10 @@ pub fn op_webgpu_create_command_encoder(
     .resource_table
     .add(WebGpuCommandEncoder(command_encoder));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from),
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }
 
 #[derive(Deserialize)]
@@ -293,7 +293,7 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_buffer(
   state: &mut OpState,
   args: CommandEncoderCopyBufferToBufferArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
@@ -320,7 +320,7 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_buffer(
     args.size
   )).err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -362,7 +362,7 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_texture(
   state: &mut OpState,
   args: CommandEncoderCopyBufferToTextureArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
@@ -409,7 +409,7 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_texture(
     }
   )).err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -425,7 +425,7 @@ pub fn op_webgpu_command_encoder_copy_texture_to_buffer(
   state: &mut OpState,
   args: CommandEncoderCopyTextureToBufferArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
@@ -471,7 +471,7 @@ pub fn op_webgpu_command_encoder_copy_texture_to_buffer(
     }
   )).err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -487,7 +487,7 @@ pub fn op_webgpu_command_encoder_copy_texture_to_texture(
   state: &mut OpState,
   args: CommandEncoderCopyTextureToTextureArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
@@ -537,7 +537,7 @@ pub fn op_webgpu_command_encoder_copy_texture_to_texture(
     }
   )).err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -551,7 +551,7 @@ pub fn op_webgpu_command_encoder_push_debug_group(
   state: &mut OpState,
   args: CommandEncoderPushDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
@@ -563,7 +563,7 @@ pub fn op_webgpu_command_encoder_push_debug_group(
     .command_encoder_push_debug_group(command_encoder, &args.group_label))
   .err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -576,7 +576,7 @@ pub fn op_webgpu_command_encoder_pop_debug_group(
   state: &mut OpState,
   args: CommandEncoderPopDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
@@ -586,7 +586,7 @@ pub fn op_webgpu_command_encoder_pop_debug_group(
 
   let maybe_err =  gfx_select!(command_encoder => instance.command_encoder_pop_debug_group(command_encoder)).err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -600,7 +600,7 @@ pub fn op_webgpu_command_encoder_insert_debug_marker(
   state: &mut OpState,
   args: CommandEncoderInsertDebugMarkerArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
@@ -613,7 +613,7 @@ pub fn op_webgpu_command_encoder_insert_debug_marker(
     &args.marker_label
   )).err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -628,7 +628,7 @@ pub fn op_webgpu_command_encoder_write_timestamp(
   state: &mut OpState,
   args: CommandEncoderWriteTimestampArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
@@ -648,7 +648,7 @@ pub fn op_webgpu_command_encoder_write_timestamp(
     ))
     .err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -666,7 +666,7 @@ pub fn op_webgpu_command_encoder_resolve_query_set(
   state: &mut OpState,
   args: CommandEncoderResolveQuerySetArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
@@ -693,7 +693,7 @@ pub fn op_webgpu_command_encoder_resolve_query_set(
     ))
     .err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -707,7 +707,7 @@ pub fn op_webgpu_command_encoder_finish(
   state: &mut OpState,
   args: CommandEncoderFinishArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
     .take::<WebGpuCommandEncoder>(args.command_encoder_rid)
@@ -728,8 +728,8 @@ pub fn op_webgpu_command_encoder_finish(
     .resource_table
     .add(WebGpuCommandBuffer(command_buffer));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from)
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }

--- a/op_crates/webgpu/command_encoder.rs
+++ b/op_crates/webgpu/command_encoder.rs
@@ -2,8 +2,6 @@
 
 use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
@@ -73,7 +71,7 @@ pub fn op_webgpu_create_command_encoder(
     .resource_table
     .add(WebGpuCommandEncoder(command_encoder));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -114,7 +112,7 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
   state: &mut OpState,
   args: CommandEncoderBeginRenderPassArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
     .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
@@ -233,9 +231,7 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
       render_pass,
     )));
 
-  Ok(json!({
-    "rid": rid,
-  }))
+  Ok(WebGpuResult::rid(rid))
 }
 
 #[derive(Deserialize)]
@@ -249,7 +245,7 @@ pub fn op_webgpu_command_encoder_begin_compute_pass(
   state: &mut OpState,
   args: CommandEncoderBeginComputePassArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
     .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
@@ -270,9 +266,7 @@ pub fn op_webgpu_command_encoder_begin_compute_pass(
       compute_pass,
     )));
 
-  Ok(json!({
-    "rid": rid,
-  }))
+  Ok(WebGpuResult::rid(rid))
 }
 
 #[derive(Deserialize)]
@@ -725,5 +719,5 @@ pub fn op_webgpu_command_encoder_finish(
     .resource_table
     .add(WebGpuCommandBuffer(command_buffer));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }

--- a/op_crates/webgpu/command_encoder.rs
+++ b/op_crates/webgpu/command_encoder.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
 
-use super::error::{WebGpuError, WebGpuResult};
+use super::error::WebGpuResult;
 
 pub(crate) struct WebGpuCommandEncoder(
   pub(crate) wgpu_core::id::CommandEncoderId,
@@ -73,10 +73,7 @@ pub fn op_webgpu_create_command_encoder(
     .resource_table
     .add(WebGpuCommandEncoder(command_encoder));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -728,8 +725,5 @@ pub fn op_webgpu_command_encoder_finish(
     .resource_table
     .add(WebGpuCommandBuffer(command_buffer));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }

--- a/op_crates/webgpu/compute_pass.rs
+++ b/op_crates/webgpu/compute_pass.rs
@@ -3,8 +3,6 @@
 use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
@@ -12,7 +10,7 @@ use serde::Deserialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
 
-use super::error::WebGpuError;
+use super::error::WebGpuResult;
 
 pub(crate) struct WebGpuComputePass(
   pub(crate) RefCell<wgpu_core::command::ComputePass>,
@@ -34,7 +32,7 @@ pub fn op_webgpu_compute_pass_set_pipeline(
   state: &mut OpState,
   args: ComputePassSetPipelineArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let compute_pipeline_resource = state
     .resource_table
     .get::<super::pipeline::WebGpuComputePipeline>(args.pipeline)
@@ -49,7 +47,7 @@ pub fn op_webgpu_compute_pass_set_pipeline(
     compute_pipeline_resource.0,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -65,7 +63,7 @@ pub fn op_webgpu_compute_pass_dispatch(
   state: &mut OpState,
   args: ComputePassDispatchArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -78,7 +76,7 @@ pub fn op_webgpu_compute_pass_dispatch(
     args.z,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -93,7 +91,7 @@ pub fn op_webgpu_compute_pass_dispatch_indirect(
   state: &mut OpState,
   args: ComputePassDispatchIndirectArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
@@ -109,7 +107,7 @@ pub fn op_webgpu_compute_pass_dispatch_indirect(
     args.indirect_offset,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -124,7 +122,7 @@ pub fn op_webgpu_compute_pass_begin_pipeline_statistics_query(
   state: &mut OpState,
   args: ComputePassBeginPipelineStatisticsQueryArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -142,7 +140,7 @@ pub fn op_webgpu_compute_pass_begin_pipeline_statistics_query(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -155,7 +153,7 @@ pub fn op_webgpu_compute_pass_end_pipeline_statistics_query(
   state: &mut OpState,
   args: ComputePassEndPipelineStatisticsQueryArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -167,7 +165,7 @@ pub fn op_webgpu_compute_pass_end_pipeline_statistics_query(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -182,7 +180,7 @@ pub fn op_webgpu_compute_pass_write_timestamp(
   state: &mut OpState,
   args: ComputePassWriteTimestampArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -200,7 +198,7 @@ pub fn op_webgpu_compute_pass_write_timestamp(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -214,7 +212,7 @@ pub fn op_webgpu_compute_pass_end_pass(
   state: &mut OpState,
   args: ComputePassEndPassArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
     .get::<super::command_encoder::WebGpuCommandEncoder>(
@@ -236,7 +234,7 @@ pub fn op_webgpu_compute_pass_end_pass(
     ))
     .err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -254,7 +252,7 @@ pub fn op_webgpu_compute_pass_set_bind_group(
   state: &mut OpState,
   args: ComputePassSetBindGroupArgs,
   zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let bind_group_resource = state
     .resource_table
     .get::<super::binding::WebGpuBindGroup>(args.bind_group)
@@ -283,7 +281,7 @@ pub fn op_webgpu_compute_pass_set_bind_group(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -297,7 +295,7 @@ pub fn op_webgpu_compute_pass_push_debug_group(
   state: &mut OpState,
   args: ComputePassPushDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -312,7 +310,7 @@ pub fn op_webgpu_compute_pass_push_debug_group(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -325,7 +323,7 @@ pub fn op_webgpu_compute_pass_pop_debug_group(
   state: &mut OpState,
   args: ComputePassPopDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -335,7 +333,7 @@ pub fn op_webgpu_compute_pass_pop_debug_group(
     &mut compute_pass_resource.0.borrow_mut(),
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -349,7 +347,7 @@ pub fn op_webgpu_compute_pass_insert_debug_marker(
   state: &mut OpState,
   args: ComputePassInsertDebugMarkerArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -364,5 +362,5 @@ pub fn op_webgpu_compute_pass_insert_debug_marker(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }

--- a/op_crates/webgpu/compute_pass.rs
+++ b/op_crates/webgpu/compute_pass.rs
@@ -32,7 +32,7 @@ pub fn op_webgpu_compute_pass_set_pipeline(
   state: &mut OpState,
   args: ComputePassSetPipelineArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let compute_pipeline_resource = state
     .resource_table
     .get::<super::pipeline::WebGpuComputePipeline>(args.pipeline)
@@ -47,7 +47,7 @@ pub fn op_webgpu_compute_pass_set_pipeline(
     compute_pipeline_resource.0,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -63,7 +63,7 @@ pub fn op_webgpu_compute_pass_dispatch(
   state: &mut OpState,
   args: ComputePassDispatchArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -76,7 +76,7 @@ pub fn op_webgpu_compute_pass_dispatch(
     args.z,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -91,7 +91,7 @@ pub fn op_webgpu_compute_pass_dispatch_indirect(
   state: &mut OpState,
   args: ComputePassDispatchIndirectArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
@@ -107,7 +107,7 @@ pub fn op_webgpu_compute_pass_dispatch_indirect(
     args.indirect_offset,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -122,7 +122,7 @@ pub fn op_webgpu_compute_pass_begin_pipeline_statistics_query(
   state: &mut OpState,
   args: ComputePassBeginPipelineStatisticsQueryArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -140,7 +140,7 @@ pub fn op_webgpu_compute_pass_begin_pipeline_statistics_query(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -153,7 +153,7 @@ pub fn op_webgpu_compute_pass_end_pipeline_statistics_query(
   state: &mut OpState,
   args: ComputePassEndPipelineStatisticsQueryArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -165,7 +165,7 @@ pub fn op_webgpu_compute_pass_end_pipeline_statistics_query(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -180,7 +180,7 @@ pub fn op_webgpu_compute_pass_write_timestamp(
   state: &mut OpState,
   args: ComputePassWriteTimestampArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -198,7 +198,7 @@ pub fn op_webgpu_compute_pass_write_timestamp(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -252,7 +252,7 @@ pub fn op_webgpu_compute_pass_set_bind_group(
   state: &mut OpState,
   args: ComputePassSetBindGroupArgs,
   zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let bind_group_resource = state
     .resource_table
     .get::<super::binding::WebGpuBindGroup>(args.bind_group)
@@ -281,7 +281,7 @@ pub fn op_webgpu_compute_pass_set_bind_group(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -295,7 +295,7 @@ pub fn op_webgpu_compute_pass_push_debug_group(
   state: &mut OpState,
   args: ComputePassPushDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -310,7 +310,7 @@ pub fn op_webgpu_compute_pass_push_debug_group(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -323,7 +323,7 @@ pub fn op_webgpu_compute_pass_pop_debug_group(
   state: &mut OpState,
   args: ComputePassPopDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -333,7 +333,7 @@ pub fn op_webgpu_compute_pass_pop_debug_group(
     &mut compute_pass_resource.0.borrow_mut(),
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -347,7 +347,7 @@ pub fn op_webgpu_compute_pass_insert_debug_marker(
   state: &mut OpState,
   args: ComputePassInsertDebugMarkerArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)
@@ -362,5 +362,5 @@ pub fn op_webgpu_compute_pass_insert_debug_marker(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }

--- a/op_crates/webgpu/error.rs
+++ b/op_crates/webgpu/error.rs
@@ -31,15 +31,22 @@ use wgpu_core::resource::CreateTextureViewError;
 
 #[derive(Serialize)]
 pub struct WebGpuResult {
-  pub rid: ResourceId,
+  pub rid: Option<ResourceId>,
   pub err: Option<WebGpuError>,
 }
 
 impl WebGpuResult {
-  pub fn maybe_err<T: Into<WebGpuError>>(maybe_err: Option<T>) -> Self {
+  pub fn rid<T: Into<WebGpuError>>(rid: ResourceId, err: Option<T>) -> Self {
     Self {
-      rid: 0, // NOTE: callers shouldn't use/need this field
-      err: maybe_err.map(|e| e.into()),
+      rid: Some(rid),
+      err: err.map(|e| e.into()),
+    }
+  }
+
+  pub fn maybe_err<T: Into<WebGpuError>>(err: Option<T>) -> Self {
+    Self {
+      rid: None,
+      err: err.map(|e| e.into()),
     }
   }
 }

--- a/op_crates/webgpu/error.rs
+++ b/op_crates/webgpu/error.rs
@@ -36,7 +36,17 @@ pub struct WebGpuResult {
 }
 
 impl WebGpuResult {
-  pub fn rid<T: Into<WebGpuError>>(rid: ResourceId, err: Option<T>) -> Self {
+  pub fn rid(rid: ResourceId) -> Self {
+    Self {
+      rid: Some(rid),
+      err: None,
+    }
+  }
+
+  pub fn rid_err<T: Into<WebGpuError>>(
+    rid: ResourceId,
+    err: Option<T>,
+  ) -> Self {
     Self {
       rid: Some(rid),
       err: err.map(|e| e.into()),

--- a/op_crates/webgpu/error.rs
+++ b/op_crates/webgpu/error.rs
@@ -59,6 +59,13 @@ impl WebGpuResult {
       err: err.map(|e| e.into()),
     }
   }
+
+  pub fn empty() -> Self {
+    Self {
+      rid: None,
+      err: None,
+    }
+  }
 }
 
 #[derive(Serialize)]

--- a/op_crates/webgpu/error.rs
+++ b/op_crates/webgpu/error.rs
@@ -1,6 +1,8 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 use deno_core::error::AnyError;
+use deno_core::ResourceId;
 use serde::Serialize;
+use std::convert::From;
 use std::fmt;
 use wgpu_core::binding_model::CreateBindGroupError;
 use wgpu_core::binding_model::CreateBindGroupLayoutError;
@@ -26,6 +28,21 @@ use wgpu_core::resource::CreateQuerySetError;
 use wgpu_core::resource::CreateSamplerError;
 use wgpu_core::resource::CreateTextureError;
 use wgpu_core::resource::CreateTextureViewError;
+
+#[derive(Serialize)]
+pub struct WebGpuResult {
+  pub rid: ResourceId,
+  pub err: Option<WebGpuError>,
+}
+
+impl WebGpuResult {
+  pub fn maybe_err<T: Into<WebGpuError>>(maybe_err: Option<T>) -> Self {
+    Self {
+      rid: 0, // NOTE: callers shouldn't use/need this field
+      err: maybe_err.map(|e| e.into()),
+    }
+  }
+}
 
 #[derive(Serialize)]
 #[serde(tag = "type", content = "value")]

--- a/op_crates/webgpu/lib.rs
+++ b/op_crates/webgpu/lib.rs
@@ -19,7 +19,7 @@ pub use wgpu_core;
 pub use wgpu_types;
 
 use error::DomExceptionOperationError;
-use error::{WebGpuError, WebGpuResult};
+use error::WebGpuResult;
 
 #[macro_use]
 mod macros {
@@ -544,8 +544,5 @@ pub fn op_webgpu_create_query_set(
 
   let rid = state.resource_table.add(WebGpuQuerySet(query_set));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }

--- a/op_crates/webgpu/lib.rs
+++ b/op_crates/webgpu/lib.rs
@@ -112,75 +112,73 @@ pub fn get_declaration() -> PathBuf {
   PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("lib.deno_webgpu.d.ts")
 }
 
-fn deserialize_features(features: &wgpu_types::Features) -> Vec<String> {
-  let mut return_features: Vec<String> = vec![];
+fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
+  let mut return_features: Vec<&'static str> = vec![];
 
   if features.contains(wgpu_types::Features::DEPTH_CLAMPING) {
-    return_features.push("depth-clamping".to_string());
+    return_features.push("depth-clamping");
   }
   if features.contains(wgpu_types::Features::PIPELINE_STATISTICS_QUERY) {
-    return_features.push("pipeline-statistics-query".to_string());
+    return_features.push("pipeline-statistics-query");
   }
   if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_BC) {
-    return_features.push("texture-compression-bc".to_string());
+    return_features.push("texture-compression-bc");
   }
   if features.contains(wgpu_types::Features::TIMESTAMP_QUERY) {
-    return_features.push("timestamp-query".to_string());
+    return_features.push("timestamp-query");
   }
 
   // extended from spec
   if features.contains(wgpu_types::Features::MAPPABLE_PRIMARY_BUFFERS) {
-    return_features.push("mappable-primary-buffers".to_string());
+    return_features.push("mappable-primary-buffers");
   }
   if features.contains(wgpu_types::Features::SAMPLED_TEXTURE_BINDING_ARRAY) {
-    return_features.push("sampled-texture-binding-array".to_string());
+    return_features.push("sampled-texture-binding-array");
   }
   if features
     .contains(wgpu_types::Features::SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING)
   {
-    return_features.push("sampled-texture-array-dynamic-indexing".to_string());
+    return_features.push("sampled-texture-array-dynamic-indexing");
   }
   if features
     .contains(wgpu_types::Features::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING)
   {
-    return_features
-      .push("sampled-texture-array-non-uniform-indexing".to_string());
+    return_features.push("sampled-texture-array-non-uniform-indexing");
   }
   if features.contains(wgpu_types::Features::UNSIZED_BINDING_ARRAY) {
-    return_features.push("unsized-binding-array".to_string());
+    return_features.push("unsized-binding-array");
   }
   if features.contains(wgpu_types::Features::MULTI_DRAW_INDIRECT) {
-    return_features.push("multi-draw-indirect".to_string());
+    return_features.push("multi-draw-indirect");
   }
   if features.contains(wgpu_types::Features::MULTI_DRAW_INDIRECT_COUNT) {
-    return_features.push("multi-draw-indirect-count".to_string());
+    return_features.push("multi-draw-indirect-count");
   }
   if features.contains(wgpu_types::Features::PUSH_CONSTANTS) {
-    return_features.push("push-constants".to_string());
+    return_features.push("push-constants");
   }
   if features.contains(wgpu_types::Features::ADDRESS_MODE_CLAMP_TO_BORDER) {
-    return_features.push("address-mode-clamp-to-border".to_string());
+    return_features.push("address-mode-clamp-to-border");
   }
   if features.contains(wgpu_types::Features::NON_FILL_POLYGON_MODE) {
-    return_features.push("non-fill-polygon-mode".to_string());
+    return_features.push("non-fill-polygon-mode");
   }
   if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ETC2) {
-    return_features.push("texture-compression-etc2".to_string());
+    return_features.push("texture-compression-etc2");
   }
   if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC_LDR) {
-    return_features.push("texture-compression-astc-ldr".to_string());
+    return_features.push("texture-compression-astc-ldr");
   }
   if features
     .contains(wgpu_types::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES)
   {
-    return_features
-      .push("texture-adapter-specific-format-features".to_string());
+    return_features.push("texture-adapter-specific-format-features");
   }
   if features.contains(wgpu_types::Features::SHADER_FLOAT64) {
-    return_features.push("shader-float64".to_string());
+    return_features.push("shader-float64");
   }
   if features.contains(wgpu_types::Features::VERTEX_ATTRIBUTE_64BIT) {
-    return_features.push("vertex-attribute-64bit".to_string());
+    return_features.push("vertex-attribute-64bit");
   }
 
   return_features
@@ -205,7 +203,7 @@ pub struct GpuAdapterDevice {
   rid: ResourceId,
   name: Option<String>,
   limits: wgpu_types::Limits,
-  features: Vec<String>,
+  features: Vec<&'static str>,
 }
 
 pub async fn op_webgpu_request_adapter(

--- a/op_crates/webgpu/lib.rs
+++ b/op_crates/webgpu/lib.rs
@@ -544,5 +544,5 @@ pub fn op_webgpu_create_query_set(
 
   let rid = state.resource_table.add(WebGpuQuerySet(query_set));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }

--- a/op_crates/webgpu/lib.rs
+++ b/op_crates/webgpu/lib.rs
@@ -19,7 +19,7 @@ pub use wgpu_core;
 pub use wgpu_types;
 
 use error::DomExceptionOperationError;
-use error::WebGpuError;
+use error::{WebGpuError, WebGpuResult};
 
 #[macro_use]
 mod macros {
@@ -473,7 +473,7 @@ pub fn op_webgpu_create_query_set(
   state: &mut OpState,
   args: CreateQuerySetArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let device_resource = state
     .resource_table
     .get::<WebGpuDevice>(args.device_rid)
@@ -544,8 +544,8 @@ pub fn op_webgpu_create_query_set(
 
   let rid = state.resource_table.add(WebGpuQuerySet(query_set));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from),
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }

--- a/op_crates/webgpu/lib.rs
+++ b/op_crates/webgpu/lib.rs
@@ -194,14 +194,14 @@ pub struct RequestAdapterArgs {
 
 #[derive(Serialize)]
 #[serde(untagged)]
-pub enum GpuFeaturesOrErr {
+pub enum GpuAdapterDeviceOrErr {
   Error { err: String },
-  Features(GpuFeatures),
+  Features(GpuAdapterDevice),
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GpuFeatures {
+pub struct GpuAdapterDevice {
   rid: ResourceId,
   name: Option<String>,
   limits: wgpu_types::Limits,
@@ -212,7 +212,7 @@ pub async fn op_webgpu_request_adapter(
   state: Rc<RefCell<OpState>>,
   args: RequestAdapterArgs,
   _bufs: Option<ZeroCopyBuf>,
-) -> Result<GpuFeaturesOrErr, AnyError> {
+) -> Result<GpuAdapterDeviceOrErr, AnyError> {
   let mut state = state.borrow_mut();
   check_unstable(&state, "navigator.gpu.requestAdapter");
   let instance = if let Some(instance) = state.try_borrow::<Instance>() {
@@ -248,7 +248,7 @@ pub async fn op_webgpu_request_adapter(
   let adapter = match res {
     Ok(adapter) => adapter,
     Err(err) => {
-      return Ok(GpuFeaturesOrErr::Error {
+      return Ok(GpuAdapterDeviceOrErr::Error {
         err: err.to_string(),
       })
     }
@@ -262,7 +262,7 @@ pub async fn op_webgpu_request_adapter(
 
   let rid = state.resource_table.add(WebGpuAdapter(adapter));
 
-  Ok(GpuFeaturesOrErr::Features(GpuFeatures {
+  Ok(GpuAdapterDeviceOrErr::Features(GpuAdapterDevice {
     rid,
     name: Some(name),
     features,
@@ -305,7 +305,7 @@ pub async fn op_webgpu_request_device(
   state: Rc<RefCell<OpState>>,
   args: RequestDeviceArgs,
   _bufs: Option<ZeroCopyBuf>,
-) -> Result<GpuFeatures, AnyError> {
+) -> Result<GpuAdapterDevice, AnyError> {
   let mut state = state.borrow_mut();
   let adapter_resource = state
     .resource_table
@@ -445,7 +445,7 @@ pub async fn op_webgpu_request_device(
 
   let rid = state.resource_table.add(WebGpuDevice(device));
 
-  Ok(GpuFeatures {
+  Ok(GpuAdapterDevice {
     rid,
     name: None,
     features,

--- a/op_crates/webgpu/pipeline.rs
+++ b/op_crates/webgpu/pipeline.rs
@@ -213,7 +213,7 @@ pub fn op_webgpu_create_compute_pipeline(
     .resource_table
     .add(WebGpuComputePipeline(compute_pipeline));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -598,7 +598,7 @@ pub fn op_webgpu_create_render_pipeline(
     .resource_table
     .add(WebGpuRenderPipeline(render_pipeline));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }
 
 #[derive(Deserialize)]

--- a/op_crates/webgpu/pipeline.rs
+++ b/op_crates/webgpu/pipeline.rs
@@ -10,7 +10,7 @@ use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
 
-use super::error::WebGpuError;
+use super::error::{WebGpuError, WebGpuResult};
 
 pub(crate) struct WebGpuPipelineLayout(
   pub(crate) wgpu_core::id::PipelineLayoutId,
@@ -163,7 +163,7 @@ pub fn op_webgpu_create_compute_pipeline(
   state: &mut OpState,
   args: CreateComputePipelineArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
@@ -213,10 +213,10 @@ pub fn op_webgpu_create_compute_pipeline(
     .resource_table
     .add(WebGpuComputePipeline(compute_pipeline));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from),
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }
 
 #[derive(Deserialize)]
@@ -367,7 +367,7 @@ pub fn op_webgpu_create_render_pipeline(
   state: &mut OpState,
   args: CreateRenderPipelineArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
@@ -601,10 +601,10 @@ pub fn op_webgpu_create_render_pipeline(
     .resource_table
     .add(WebGpuRenderPipeline(render_pipeline));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from)
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }
 
 #[derive(Deserialize)]

--- a/op_crates/webgpu/pipeline.rs
+++ b/op_crates/webgpu/pipeline.rs
@@ -2,12 +2,11 @@
 
 use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
+use serde::Serialize;
 use std::borrow::Cow;
 
 use super::error::{WebGpuError, WebGpuResult};
@@ -223,11 +222,19 @@ pub struct ComputePipelineGetBindGroupLayoutArgs {
   index: u32,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelineLayout {
+  rid: ResourceId,
+  label: String,
+  err: Option<WebGpuError>,
+}
+
 pub fn op_webgpu_compute_pipeline_get_bind_group_layout(
   state: &mut OpState,
   args: ComputePipelineGetBindGroupLayoutArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<PipelineLayout, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let compute_pipeline_resource = state
     .resource_table
@@ -243,11 +250,11 @@ pub fn op_webgpu_compute_pipeline_get_bind_group_layout(
     .resource_table
     .add(super::binding::WebGpuBindGroupLayout(bind_group_layout));
 
-  Ok(json!({
-    "rid": rid,
-    "label": label,
-    "err": maybe_err.map(WebGpuError::from)
-  }))
+  Ok(PipelineLayout {
+    rid,
+    label,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }
 
 #[derive(Deserialize)]
@@ -612,7 +619,7 @@ pub fn op_webgpu_render_pipeline_get_bind_group_layout(
   state: &mut OpState,
   args: RenderPipelineGetBindGroupLayoutArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<PipelineLayout, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let render_pipeline_resource = state
     .resource_table
@@ -628,9 +635,9 @@ pub fn op_webgpu_render_pipeline_get_bind_group_layout(
     .resource_table
     .add(super::binding::WebGpuBindGroupLayout(bind_group_layout));
 
-  Ok(json!({
-    "rid": rid,
-    "label": label,
-    "err": maybe_err.map(WebGpuError::from),
-  }))
+  Ok(PipelineLayout {
+    rid,
+    label,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }

--- a/op_crates/webgpu/pipeline.rs
+++ b/op_crates/webgpu/pipeline.rs
@@ -213,10 +213,7 @@ pub fn op_webgpu_create_compute_pipeline(
     .resource_table
     .add(WebGpuComputePipeline(compute_pipeline));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -601,10 +598,7 @@ pub fn op_webgpu_create_render_pipeline(
     .resource_table
     .add(WebGpuRenderPipeline(render_pipeline));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }
 
 #[derive(Deserialize)]

--- a/op_crates/webgpu/queue.rs
+++ b/op_crates/webgpu/queue.rs
@@ -3,14 +3,12 @@
 use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::OpState;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 
-use super::error::WebGpuError;
+use super::error::WebGpuResult;
 
 type WebGpuQueue = super::WebGpuDevice;
 
@@ -25,7 +23,7 @@ pub fn op_webgpu_queue_submit(
   state: &mut OpState,
   args: QueueSubmitArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let queue_resource = state
     .resource_table
@@ -46,7 +44,7 @@ pub fn op_webgpu_queue_submit(
   let maybe_err =
     gfx_select!(queue => instance.queue_submit(queue, &ids)).err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -71,7 +69,7 @@ pub fn op_webgpu_write_buffer(
   state: &mut OpState,
   args: QueueWriteBufferArgs,
   zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let instance = state.borrow::<super::Instance>();
   let buffer_resource = state
@@ -97,7 +95,7 @@ pub fn op_webgpu_write_buffer(
   ))
   .err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -113,7 +111,7 @@ pub fn op_webgpu_write_texture(
   state: &mut OpState,
   args: QueueWriteTextureArgs,
   zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let instance = state.borrow::<super::Instance>();
   let texture_resource = state
@@ -157,5 +155,5 @@ pub fn op_webgpu_write_texture(
   ))
   .err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }

--- a/op_crates/webgpu/render_pass.rs
+++ b/op_crates/webgpu/render_pass.rs
@@ -37,7 +37,7 @@ pub fn op_webgpu_render_pass_set_viewport(
   state: &mut OpState,
   args: RenderPassSetViewportArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -53,7 +53,7 @@ pub fn op_webgpu_render_pass_set_viewport(
     args.max_depth,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -70,7 +70,7 @@ pub fn op_webgpu_render_pass_set_scissor_rect(
   state: &mut OpState,
   args: RenderPassSetScissorRectArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -84,7 +84,7 @@ pub fn op_webgpu_render_pass_set_scissor_rect(
     args.height,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -107,7 +107,7 @@ pub fn op_webgpu_render_pass_set_blend_color(
   state: &mut OpState,
   args: RenderPassSetBlendColorArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -123,7 +123,7 @@ pub fn op_webgpu_render_pass_set_blend_color(
     },
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -137,7 +137,7 @@ pub fn op_webgpu_render_pass_set_stencil_reference(
   state: &mut OpState,
   args: RenderPassSetStencilReferenceArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -148,7 +148,7 @@ pub fn op_webgpu_render_pass_set_stencil_reference(
     args.reference,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -163,7 +163,7 @@ pub fn op_webgpu_render_pass_begin_pipeline_statistics_query(
   state: &mut OpState,
   args: RenderPassBeginPipelineStatisticsQueryArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -181,7 +181,7 @@ pub fn op_webgpu_render_pass_begin_pipeline_statistics_query(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -194,7 +194,7 @@ pub fn op_webgpu_render_pass_end_pipeline_statistics_query(
   state: &mut OpState,
   args: RenderPassEndPipelineStatisticsQueryArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -206,7 +206,7 @@ pub fn op_webgpu_render_pass_end_pipeline_statistics_query(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -221,7 +221,7 @@ pub fn op_webgpu_render_pass_write_timestamp(
   state: &mut OpState,
   args: RenderPassWriteTimestampArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -239,7 +239,7 @@ pub fn op_webgpu_render_pass_write_timestamp(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -253,7 +253,7 @@ pub fn op_webgpu_render_pass_execute_bundles(
   state: &mut OpState,
   args: RenderPassExecuteBundlesArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let mut render_bundle_ids = vec![];
 
   for rid in &args.bundles {
@@ -277,7 +277,7 @@ pub fn op_webgpu_render_pass_execute_bundles(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -326,7 +326,7 @@ pub fn op_webgpu_render_pass_set_bind_group(
   state: &mut OpState,
   args: RenderPassSetBindGroupArgs,
   zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let bind_group_resource = state
     .resource_table
@@ -368,7 +368,7 @@ pub fn op_webgpu_render_pass_set_bind_group(
     }
   };
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -382,7 +382,7 @@ pub fn op_webgpu_render_pass_push_debug_group(
   state: &mut OpState,
   args: RenderPassPushDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -397,7 +397,7 @@ pub fn op_webgpu_render_pass_push_debug_group(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -410,7 +410,7 @@ pub fn op_webgpu_render_pass_pop_debug_group(
   state: &mut OpState,
   args: RenderPassPopDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -420,7 +420,7 @@ pub fn op_webgpu_render_pass_pop_debug_group(
     &mut render_pass_resource.0.borrow_mut(),
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -434,7 +434,7 @@ pub fn op_webgpu_render_pass_insert_debug_marker(
   state: &mut OpState,
   args: RenderPassInsertDebugMarkerArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -449,7 +449,7 @@ pub fn op_webgpu_render_pass_insert_debug_marker(
     );
   }
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -463,7 +463,7 @@ pub fn op_webgpu_render_pass_set_pipeline(
   state: &mut OpState,
   args: RenderPassSetPipelineArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pipeline_resource = state
     .resource_table
     .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)
@@ -478,7 +478,7 @@ pub fn op_webgpu_render_pass_set_pipeline(
     render_pipeline_resource.0,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -495,7 +495,7 @@ pub fn op_webgpu_render_pass_set_index_buffer(
   state: &mut OpState,
   args: RenderPassSetIndexBufferArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.buffer)
@@ -512,7 +512,7 @@ pub fn op_webgpu_render_pass_set_index_buffer(
     std::num::NonZeroU64::new(args.size),
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -529,7 +529,7 @@ pub fn op_webgpu_render_pass_set_vertex_buffer(
   state: &mut OpState,
   args: RenderPassSetVertexBufferArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.buffer)
@@ -547,7 +547,7 @@ pub fn op_webgpu_render_pass_set_vertex_buffer(
     std::num::NonZeroU64::new(args.size),
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -564,7 +564,7 @@ pub fn op_webgpu_render_pass_draw(
   state: &mut OpState,
   args: RenderPassDrawArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -578,7 +578,7 @@ pub fn op_webgpu_render_pass_draw(
     args.first_instance,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -596,7 +596,7 @@ pub fn op_webgpu_render_pass_draw_indexed(
   state: &mut OpState,
   args: RenderPassDrawIndexedArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -611,7 +611,7 @@ pub fn op_webgpu_render_pass_draw_indexed(
     args.first_instance,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -626,7 +626,7 @@ pub fn op_webgpu_render_pass_draw_indirect(
   state: &mut OpState,
   args: RenderPassDrawIndirectArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
@@ -642,7 +642,7 @@ pub fn op_webgpu_render_pass_draw_indirect(
     args.indirect_offset,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }
 
 #[derive(Deserialize)]
@@ -657,7 +657,7 @@ pub fn op_webgpu_render_pass_draw_indexed_indirect(
   state: &mut OpState,
   args: RenderPassDrawIndexedIndirectArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
@@ -673,5 +673,5 @@ pub fn op_webgpu_render_pass_draw_indexed_indirect(
     args.indirect_offset,
   );
 
-  Ok(())
+  Ok(WebGpuResult::empty())
 }

--- a/op_crates/webgpu/render_pass.rs
+++ b/op_crates/webgpu/render_pass.rs
@@ -3,8 +3,6 @@
 use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
@@ -12,7 +10,7 @@ use serde::Deserialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
 
-use super::error::WebGpuError;
+use super::error::WebGpuResult;
 
 pub(crate) struct WebGpuRenderPass(
   pub(crate) RefCell<wgpu_core::command::RenderPass>,
@@ -39,7 +37,7 @@ pub fn op_webgpu_render_pass_set_viewport(
   state: &mut OpState,
   args: RenderPassSetViewportArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -55,7 +53,7 @@ pub fn op_webgpu_render_pass_set_viewport(
     args.max_depth,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -72,7 +70,7 @@ pub fn op_webgpu_render_pass_set_scissor_rect(
   state: &mut OpState,
   args: RenderPassSetScissorRectArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -86,7 +84,7 @@ pub fn op_webgpu_render_pass_set_scissor_rect(
     args.height,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -109,7 +107,7 @@ pub fn op_webgpu_render_pass_set_blend_color(
   state: &mut OpState,
   args: RenderPassSetBlendColorArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -125,7 +123,7 @@ pub fn op_webgpu_render_pass_set_blend_color(
     },
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -139,7 +137,7 @@ pub fn op_webgpu_render_pass_set_stencil_reference(
   state: &mut OpState,
   args: RenderPassSetStencilReferenceArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -150,7 +148,7 @@ pub fn op_webgpu_render_pass_set_stencil_reference(
     args.reference,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -165,7 +163,7 @@ pub fn op_webgpu_render_pass_begin_pipeline_statistics_query(
   state: &mut OpState,
   args: RenderPassBeginPipelineStatisticsQueryArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -183,7 +181,7 @@ pub fn op_webgpu_render_pass_begin_pipeline_statistics_query(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -196,7 +194,7 @@ pub fn op_webgpu_render_pass_end_pipeline_statistics_query(
   state: &mut OpState,
   args: RenderPassEndPipelineStatisticsQueryArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -208,7 +206,7 @@ pub fn op_webgpu_render_pass_end_pipeline_statistics_query(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -223,7 +221,7 @@ pub fn op_webgpu_render_pass_write_timestamp(
   state: &mut OpState,
   args: RenderPassWriteTimestampArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -241,7 +239,7 @@ pub fn op_webgpu_render_pass_write_timestamp(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -255,7 +253,7 @@ pub fn op_webgpu_render_pass_execute_bundles(
   state: &mut OpState,
   args: RenderPassExecuteBundlesArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let mut render_bundle_ids = vec![];
 
   for rid in &args.bundles {
@@ -279,7 +277,7 @@ pub fn op_webgpu_render_pass_execute_bundles(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -293,7 +291,7 @@ pub fn op_webgpu_render_pass_end_pass(
   state: &mut OpState,
   args: RenderPassEndPassArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
     .get::<super::command_encoder::WebGpuCommandEncoder>(
@@ -310,7 +308,7 @@ pub fn op_webgpu_render_pass_end_pass(
 
   let maybe_err =  gfx_select!(command_encoder => instance.command_encoder_run_render_pass(command_encoder, render_pass)).err();
 
-  Ok(json!({ "err": maybe_err.map(WebGpuError::from) }))
+  Ok(WebGpuResult::maybe_err(maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -328,7 +326,7 @@ pub fn op_webgpu_render_pass_set_bind_group(
   state: &mut OpState,
   args: RenderPassSetBindGroupArgs,
   zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let bind_group_resource = state
     .resource_table
@@ -370,7 +368,7 @@ pub fn op_webgpu_render_pass_set_bind_group(
     }
   };
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -384,7 +382,7 @@ pub fn op_webgpu_render_pass_push_debug_group(
   state: &mut OpState,
   args: RenderPassPushDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -399,7 +397,7 @@ pub fn op_webgpu_render_pass_push_debug_group(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -412,7 +410,7 @@ pub fn op_webgpu_render_pass_pop_debug_group(
   state: &mut OpState,
   args: RenderPassPopDebugGroupArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -422,7 +420,7 @@ pub fn op_webgpu_render_pass_pop_debug_group(
     &mut render_pass_resource.0.borrow_mut(),
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -436,7 +434,7 @@ pub fn op_webgpu_render_pass_insert_debug_marker(
   state: &mut OpState,
   args: RenderPassInsertDebugMarkerArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -451,7 +449,7 @@ pub fn op_webgpu_render_pass_insert_debug_marker(
     );
   }
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -465,7 +463,7 @@ pub fn op_webgpu_render_pass_set_pipeline(
   state: &mut OpState,
   args: RenderPassSetPipelineArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pipeline_resource = state
     .resource_table
     .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)
@@ -480,7 +478,7 @@ pub fn op_webgpu_render_pass_set_pipeline(
     render_pipeline_resource.0,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -497,7 +495,7 @@ pub fn op_webgpu_render_pass_set_index_buffer(
   state: &mut OpState,
   args: RenderPassSetIndexBufferArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.buffer)
@@ -514,7 +512,7 @@ pub fn op_webgpu_render_pass_set_index_buffer(
     std::num::NonZeroU64::new(args.size),
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -531,7 +529,7 @@ pub fn op_webgpu_render_pass_set_vertex_buffer(
   state: &mut OpState,
   args: RenderPassSetVertexBufferArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.buffer)
@@ -549,7 +547,7 @@ pub fn op_webgpu_render_pass_set_vertex_buffer(
     std::num::NonZeroU64::new(args.size),
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -566,7 +564,7 @@ pub fn op_webgpu_render_pass_draw(
   state: &mut OpState,
   args: RenderPassDrawArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -580,7 +578,7 @@ pub fn op_webgpu_render_pass_draw(
     args.first_instance,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -598,7 +596,7 @@ pub fn op_webgpu_render_pass_draw_indexed(
   state: &mut OpState,
   args: RenderPassDrawIndexedArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)
@@ -613,7 +611,7 @@ pub fn op_webgpu_render_pass_draw_indexed(
     args.first_instance,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -628,7 +626,7 @@ pub fn op_webgpu_render_pass_draw_indirect(
   state: &mut OpState,
   args: RenderPassDrawIndirectArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
@@ -644,7 +642,7 @@ pub fn op_webgpu_render_pass_draw_indirect(
     args.indirect_offset,
   );
 
-  Ok(json!({}))
+  Ok(())
 }
 
 #[derive(Deserialize)]
@@ -659,7 +657,7 @@ pub fn op_webgpu_render_pass_draw_indexed_indirect(
   state: &mut OpState,
   args: RenderPassDrawIndexedIndirectArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
@@ -675,5 +673,5 @@ pub fn op_webgpu_render_pass_draw_indexed_indirect(
     args.indirect_offset,
   );
 
-  Ok(json!({}))
+  Ok(())
 }

--- a/op_crates/webgpu/sampler.rs
+++ b/op_crates/webgpu/sampler.rs
@@ -2,15 +2,13 @@
 
 use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
 
-use super::error::WebGpuError;
+use super::error::{WebGpuError, WebGpuResult};
 
 pub(crate) struct WebGpuSampler(pub(crate) wgpu_core::id::SamplerId);
 impl Resource for WebGpuSampler {
@@ -83,7 +81,7 @@ pub fn op_webgpu_create_sampler(
   state: &mut OpState,
   args: CreateSamplerArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
@@ -123,8 +121,8 @@ pub fn op_webgpu_create_sampler(
 
   let rid = state.resource_table.add(WebGpuSampler(sampler));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from)
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }

--- a/op_crates/webgpu/sampler.rs
+++ b/op_crates/webgpu/sampler.rs
@@ -8,7 +8,7 @@ use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
 
-use super::error::{WebGpuError, WebGpuResult};
+use super::error::WebGpuResult;
 
 pub(crate) struct WebGpuSampler(pub(crate) wgpu_core::id::SamplerId);
 impl Resource for WebGpuSampler {
@@ -121,8 +121,5 @@ pub fn op_webgpu_create_sampler(
 
   let rid = state.resource_table.add(WebGpuSampler(sampler));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }

--- a/op_crates/webgpu/sampler.rs
+++ b/op_crates/webgpu/sampler.rs
@@ -121,5 +121,5 @@ pub fn op_webgpu_create_sampler(
 
   let rid = state.resource_table.add(WebGpuSampler(sampler));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }

--- a/op_crates/webgpu/shader.rs
+++ b/op_crates/webgpu/shader.rs
@@ -3,15 +3,13 @@
 use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
 
-use super::error::WebGpuError;
+use super::error::{WebGpuError, WebGpuResult};
 
 pub(crate) struct WebGpuShaderModule(pub(crate) wgpu_core::id::ShaderModuleId);
 impl Resource for WebGpuShaderModule {
@@ -33,7 +31,7 @@ pub fn op_webgpu_create_shader_module(
   state: &mut OpState,
   args: CreateShaderModuleArgs,
   zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
@@ -77,8 +75,8 @@ pub fn op_webgpu_create_shader_module(
 
   let rid = state.resource_table.add(WebGpuShaderModule(shader_module));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from)
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }

--- a/op_crates/webgpu/shader.rs
+++ b/op_crates/webgpu/shader.rs
@@ -9,7 +9,7 @@ use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
 
-use super::error::{WebGpuError, WebGpuResult};
+use super::error::WebGpuResult;
 
 pub(crate) struct WebGpuShaderModule(pub(crate) wgpu_core::id::ShaderModuleId);
 impl Resource for WebGpuShaderModule {
@@ -75,8 +75,5 @@ pub fn op_webgpu_create_shader_module(
 
   let rid = state.resource_table.add(WebGpuShaderModule(shader_module));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }

--- a/op_crates/webgpu/shader.rs
+++ b/op_crates/webgpu/shader.rs
@@ -75,5 +75,5 @@ pub fn op_webgpu_create_shader_module(
 
   let rid = state.resource_table.add(WebGpuShaderModule(shader_module));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }

--- a/op_crates/webgpu/texture.rs
+++ b/op_crates/webgpu/texture.rs
@@ -8,7 +8,7 @@ use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
 
-use super::error::{WebGpuError, WebGpuResult};
+use super::error::WebGpuResult;
 pub(crate) struct WebGpuTexture(pub(crate) wgpu_core::id::TextureId);
 impl Resource for WebGpuTexture {
   fn name(&self) -> Cow<str> {
@@ -184,10 +184,7 @@ pub fn op_webgpu_create_texture(
 
   let rid = state.resource_table.add(WebGpuTexture(texture));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -248,8 +245,5 @@ pub fn op_webgpu_create_texture_view(
 
   let rid = state.resource_table.add(WebGpuTextureView(texture_view));
 
-  Ok(WebGpuResult {
-    rid,
-    err: maybe_err.map(WebGpuError::from),
-  })
+  Ok(WebGpuResult::rid(rid, maybe_err))
 }

--- a/op_crates/webgpu/texture.rs
+++ b/op_crates/webgpu/texture.rs
@@ -2,15 +2,13 @@
 
 use deno_core::error::AnyError;
 use deno_core::error::{bad_resource_id, not_supported};
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
 
-use super::error::WebGpuError;
+use super::error::{WebGpuError, WebGpuResult};
 pub(crate) struct WebGpuTexture(pub(crate) wgpu_core::id::TextureId);
 impl Resource for WebGpuTexture {
   fn name(&self) -> Cow<str> {
@@ -148,7 +146,7 @@ pub fn op_webgpu_create_texture(
   state: &mut OpState,
   args: CreateTextureArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
@@ -186,10 +184,10 @@ pub fn op_webgpu_create_texture(
 
   let rid = state.resource_table.add(WebGpuTexture(texture));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from)
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }
 
 #[derive(Deserialize)]
@@ -210,7 +208,7 @@ pub fn op_webgpu_create_texture_view(
   state: &mut OpState,
   args: CreateTextureViewArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let texture_resource = state
     .resource_table
@@ -250,8 +248,8 @@ pub fn op_webgpu_create_texture_view(
 
   let rid = state.resource_table.add(WebGpuTextureView(texture_view));
 
-  Ok(json!({
-    "rid": rid,
-    "err": maybe_err.map(WebGpuError::from)
-  }))
+  Ok(WebGpuResult {
+    rid,
+    err: maybe_err.map(WebGpuError::from),
+  })
 }

--- a/op_crates/webgpu/texture.rs
+++ b/op_crates/webgpu/texture.rs
@@ -184,7 +184,7 @@ pub fn op_webgpu_create_texture(
 
   let rid = state.resource_table.add(WebGpuTexture(texture));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -245,5 +245,5 @@ pub fn op_webgpu_create_texture_view(
 
   let rid = state.resource_table.add(WebGpuTextureView(texture_view));
 
-  Ok(WebGpuResult::rid(rid, maybe_err))
+  Ok(WebGpuResult::rid_err(rid, maybe_err))
 }

--- a/op_crates/websocket/01_websocket.js
+++ b/op_crates/websocket/01_websocket.js
@@ -99,9 +99,7 @@
 
       this.#url = wsURL.href;
 
-      core.jsonOpSync("op_ws_check_permission", {
-        url: this.#url,
-      });
+      core.jsonOpSync("op_ws_check_permission", this.#url);
 
       if (protocols && typeof protocols === "string") {
         protocols = [protocols];
@@ -311,7 +309,7 @@
       while (this.#readyState === OPEN) {
         const message = await core.jsonOpAsync(
           "op_ws_next_event",
-          { rid: this.#rid },
+          this.#rid,
         );
 
         switch (message.kind) {

--- a/runtime/js/11_timers.js
+++ b/runtime/js/11_timers.js
@@ -10,7 +10,7 @@
   }
 
   function opStartGlobalTimer(timeout) {
-    return core.jsonOpSync("op_global_timer_start", { timeout });
+    return core.jsonOpSync("op_global_timer_start", timeout);
   }
 
   async function opWaitGlobalTimer() {
@@ -22,7 +22,7 @@
   }
 
   function sleepSync(millis = 0) {
-    return core.jsonOpSync("op_sleep_sync", { millis });
+    return core.jsonOpSync("op_sleep_sync", millis);
   }
 
   // Derived from https://github.com/vadimg/js_bintrees. MIT Licensed.

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -28,15 +28,15 @@
   }
 
   function hostTerminateWorker(id) {
-    core.jsonOpSync("op_host_terminate_worker", { id });
+    core.jsonOpSync("op_host_terminate_worker", id);
   }
 
   function hostPostMessage(id, data) {
-    core.jsonOpSync("op_host_post_message", { id }, data);
+    core.jsonOpSync("op_host_post_message", id, data);
   }
 
   function hostGetMessage(id) {
-    return core.jsonOpAsync("op_host_get_message", { id });
+    return core.jsonOpAsync("op_host_get_message", id);
   }
 
   const encoder = new TextEncoder();

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -197,7 +197,7 @@
         }
       }
 
-      const { id } = createWorker(
+      const id = createWorker(
         specifier,
         hasSourceCode,
         sourceCode,
@@ -270,7 +270,7 @@
             } else {
               core.jsonOpSync(
                 "op_host_unhandled_error",
-                { message: event.error.message },
+                event.error.message,
               );
             }
           }
@@ -289,7 +289,7 @@
             } else {
               core.jsonOpSync(
                 "op_host_unhandled_error",
-                { message: event.error.message },
+                event.error.message,
               );
             }
           }

--- a/runtime/js/30_fs.js
+++ b/runtime/js/30_fs.js
@@ -58,7 +58,7 @@
   }
 
   function chdir(directory) {
-    core.jsonOpSync("op_chdir", { directory });
+    core.jsonOpSync("op_chdir", directory);
   }
 
   function makeTempDirSync(options = {}) {
@@ -101,14 +101,8 @@
     await core.jsonOpAsync("op_mkdir_async", mkdirArgs(path, options));
   }
 
-  function res(response) {
-    return response.entries;
-  }
-
   function readDirSync(path) {
-    return res(
-      core.jsonOpSync("op_read_dir_sync", { path: pathFromURL(path) }),
-    )[
+    return core.jsonOpSync("op_read_dir_sync", pathFromURL(path))[
       Symbol.iterator
     ]();
   }
@@ -116,11 +110,8 @@
   function readDir(path) {
     const array = core.jsonOpAsync(
       "op_read_dir_async",
-      { path: pathFromURL(path) },
-    )
-      .then(
-        res,
-      );
+      pathFromURL(path),
+    );
     return {
       async *[Symbol.asyncIterator]() {
         yield* await array;
@@ -129,19 +120,19 @@
   }
 
   function readLinkSync(path) {
-    return core.jsonOpSync("op_read_link_sync", { path: pathFromURL(path) });
+    return core.jsonOpSync("op_read_link_sync", pathFromURL(path));
   }
 
   function readLink(path) {
-    return core.jsonOpAsync("op_read_link_async", { path: pathFromURL(path) });
+    return core.jsonOpAsync("op_read_link_async", pathFromURL(path));
   }
 
   function realPathSync(path) {
-    return core.jsonOpSync("op_realpath_sync", { path });
+    return core.jsonOpSync("op_realpath_sync", path);
   }
 
   function realPath(path) {
-    return core.jsonOpAsync("op_realpath_async", { path });
+    return core.jsonOpAsync("op_realpath_async", path);
   }
 
   function removeSync(
@@ -198,11 +189,11 @@
   }
 
   function fstatSync(rid) {
-    return parseFileInfo(core.jsonOpSync("op_fstat_sync", { rid }));
+    return parseFileInfo(core.jsonOpSync("op_fstat_sync", rid));
   }
 
   async function fstat(rid) {
-    return parseFileInfo(await core.jsonOpAsync("op_fstat_async", { rid }));
+    return parseFileInfo(await core.jsonOpAsync("op_fstat_async", rid));
   }
 
   async function lstat(path) {
@@ -262,7 +253,7 @@
   }
 
   function umask(mask) {
-    return core.jsonOpSync("op_umask", { mask });
+    return core.jsonOpSync("op_umask", mask);
   }
 
   function linkSync(oldpath, newpath) {
@@ -359,19 +350,19 @@
   }
 
   function fdatasyncSync(rid) {
-    core.jsonOpSync("op_fdatasync_sync", { rid });
+    core.jsonOpSync("op_fdatasync_sync", rid);
   }
 
   async function fdatasync(rid) {
-    await core.jsonOpAsync("op_fdatasync_async", { rid });
+    await core.jsonOpAsync("op_fdatasync_async", rid);
   }
 
   function fsyncSync(rid) {
-    core.jsonOpSync("op_fsync_sync", { rid });
+    core.jsonOpSync("op_fsync_sync", rid);
   }
 
   async function fsync(rid) {
-    await core.jsonOpAsync("op_fsync_async", { rid });
+    await core.jsonOpAsync("op_fsync_async", rid);
   }
 
   window.__bootstrap.fs = {

--- a/runtime/js/30_net.js
+++ b/runtime/js/30_net.js
@@ -7,7 +7,7 @@
   const { read, write } = window.__bootstrap.io;
 
   function shutdown(rid) {
-    return core.jsonOpAsync("op_shutdown", { rid });
+    return core.jsonOpAsync("op_shutdown", rid);
   }
 
   function opAccept(rid, transport) {

--- a/runtime/js/30_os.js
+++ b/runtime/js/30_os.js
@@ -44,7 +44,7 @@
       return;
     }
 
-    core.jsonOpSync("op_exit", { code });
+    core.jsonOpSync("op_exit", code);
     throw new Error("Code not reachable");
   }
 
@@ -53,11 +53,11 @@
   }
 
   function getEnv(key) {
-    return core.jsonOpSync("op_get_env", { key })[0];
+    return core.jsonOpSync("op_get_env", key);
   }
 
   function deleteEnv(key) {
-    core.jsonOpSync("op_delete_env", { key });
+    core.jsonOpSync("op_delete_env", key);
   }
 
   const env = {

--- a/runtime/js/30_os.js
+++ b/runtime/js/30_os.js
@@ -21,7 +21,12 @@
   }
 
   function systemCpuInfo() {
-    return core.jsonOpSync("op_system_cpu_info");
+    const { cores, speed } = core.jsonOpSync("op_system_cpu_info");
+    // Map nulls to undefined for compatibility
+    return {
+      cores: cores ?? undefined,
+      speed: speed ?? undefined,
+    };
   }
 
   // This is an internal only method used by the test harness to override the
@@ -53,7 +58,7 @@
   }
 
   function getEnv(key) {
-    return core.jsonOpSync("op_get_env", key);
+    return core.jsonOpSync("op_get_env", key) ?? undefined;
   }
 
   function deleteEnv(key) {

--- a/runtime/js/40_fs_events.js
+++ b/runtime/js/40_fs_events.js
@@ -19,9 +19,8 @@
 
     async next() {
       try {
-        return await core.jsonOpAsync("op_fs_events_poll", {
-          rid: this.rid,
-        });
+        const value = await core.jsonOpAsync("op_fs_events_poll", this.rid);
+        return value ? { value, done: false } : { value: undefined, done: true };
       } catch (error) {
         if (error instanceof errors.BadResource) {
           return { value: undefined, done: true };

--- a/runtime/js/40_fs_events.js
+++ b/runtime/js/40_fs_events.js
@@ -20,7 +20,9 @@
     async next() {
       try {
         const value = await core.jsonOpAsync("op_fs_events_poll", this.rid);
-        return value ? { value, done: false } : { value: undefined, done: true };
+        return value
+          ? { value, done: false }
+          : { value: undefined, done: true };
       } catch (error) {
         if (error instanceof errors.BadResource) {
           return { value: undefined, done: true };

--- a/runtime/js/40_permissions.js
+++ b/runtime/js/40_permissions.js
@@ -31,7 +31,7 @@
    * @returns {Deno.PermissionState}
    */
   function opQuery(desc) {
-    return core.jsonOpSync("op_query_permission", desc).state;
+    return core.jsonOpSync("op_query_permission", desc);
   }
 
   /**
@@ -39,7 +39,7 @@
    * @returns {Deno.PermissionState}
    */
   function opRevoke(desc) {
-    return core.jsonOpSync("op_revoke_permission", desc).state;
+    return core.jsonOpSync("op_revoke_permission", desc);
   }
 
   /**
@@ -47,7 +47,7 @@
    * @returns {Deno.PermissionState}
    */
   function opRequest(desc) {
-    return core.jsonOpSync("op_request_permission", desc).state;
+    return core.jsonOpSync("op_request_permission", desc);
   }
 
   class PermissionStatus extends EventTarget {

--- a/runtime/js/40_plugins.js
+++ b/runtime/js/40_plugins.js
@@ -5,7 +5,7 @@
   const core = window.Deno.core;
 
   function openPlugin(filename) {
-    return core.jsonOpSync("op_open_plugin", { filename });
+    return core.jsonOpSync("op_open_plugin", filename);
   }
 
   window.__bootstrap.plugins = {

--- a/runtime/js/40_process.js
+++ b/runtime/js/40_process.js
@@ -12,7 +12,7 @@
   }
 
   function opRunStatus(rid) {
-    return core.jsonOpAsync("op_run_status", { rid });
+    return core.jsonOpAsync("op_run_status", rid);
   }
 
   function opRun(request) {

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -7,15 +7,15 @@
   const { errors } = window.__bootstrap.errors;
 
   function bindSignal(signo) {
-    return core.jsonOpSync("op_signal_bind", { signo });
+    return core.jsonOpSync("op_signal_bind", signo);
   }
 
   function pollSignal(rid) {
-    return core.jsonOpAsync("op_signal_poll", { rid });
+    return core.jsonOpAsync("op_signal_poll", rid);
   }
 
   function unbindSignal(rid) {
-    core.jsonOpSync("op_signal_unbind", { rid });
+    core.jsonOpSync("op_signal_unbind", rid);
   }
 
   // From `kill -l`
@@ -209,21 +209,21 @@
     #rid = 0;
 
     constructor(signo) {
-      this.#rid = bindSignal(signo).rid;
+      this.#rid = bindSignal(signo);
       this.#loop();
     }
 
     #pollSignal = async () => {
-      let res;
+      let done;
       try {
-        res = await pollSignal(this.#rid);
+        done = await pollSignal(this.#rid);
       } catch (error) {
         if (error instanceof errors.BadResource) {
           return true;
         }
         throw error;
       }
-      return res.done;
+      return done;
     };
 
     #loop = async () => {

--- a/runtime/js/40_tls.js
+++ b/runtime/js/40_tls.js
@@ -12,7 +12,7 @@
   }
 
   function opAcceptTLS(rid) {
-    return core.jsonOpAsync("op_accept_tls", { rid });
+    return core.jsonOpAsync("op_accept_tls", rid);
   }
 
   function opListenTls(args) {

--- a/runtime/js/40_tty.js
+++ b/runtime/js/40_tty.js
@@ -5,11 +5,11 @@
   const core = window.Deno.core;
 
   function consoleSize(rid) {
-    return core.jsonOpSync("op_console_size", { rid });
+    return core.jsonOpSync("op_console_size", rid);
   }
 
   function isatty(rid) {
-    return core.jsonOpSync("op_isatty", { rid });
+    return core.jsonOpSync("op_isatty", rid);
   }
 
   const DEFAULT_SET_RAW_OPTIONS = {

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -129,7 +129,7 @@ delete Object.prototype.__proto__;
   }
 
   function opPostMessage(data) {
-    core.jsonOpSync("op_worker_post_message", {}, data);
+    core.jsonOpSync("op_worker_post_message", null, data);
   }
 
   function opCloseWorker() {

--- a/runtime/ops/fs.rs
+++ b/runtime/ops/fs.rs
@@ -391,7 +391,7 @@ fn op_umask(
   // and https://docs.microsoft.com/fr-fr/cpp/c-runtime-library/reference/umask?view=vs-2019
   #[cfg(not(unix))]
   {
-    let _ = args.mask; // avoid unused warning.
+    let _ = mask; // avoid unused warning.
     Err(not_supported())
   }
   #[cfg(unix)]

--- a/runtime/ops/net.rs
+++ b/runtime/ops/net.rs
@@ -9,7 +9,6 @@ use deno_core::error::generic_error;
 use deno_core::error::null_opbuf;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
-use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::AsyncRefCell;
@@ -109,10 +108,9 @@ async fn accept_tcp(
 
 async fn op_accept(
   state: Rc<RefCell<OpState>>,
-  args: Value,
+  args: AcceptArgs,
   _buf: Option<ZeroCopyBuf>,
 ) -> Result<Value, AnyError> {
-  let args: AcceptArgs = serde_json::from_value(args)?;
   match args.transport.as_str() {
     "tcp" => accept_tcp(state, args, _buf).await,
     #[cfg(unix)]
@@ -163,10 +161,9 @@ async fn receive_udp(
 
 async fn op_datagram_receive(
   state: Rc<RefCell<OpState>>,
-  args: Value,
+  args: ReceiveArgs,
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<Value, AnyError> {
-  let args: ReceiveArgs = serde_json::from_value(args)?;
   match args.transport.as_str() {
     "udp" => receive_udp(state, args, zero_copy).await,
     #[cfg(unix)]
@@ -188,13 +185,13 @@ struct SendArgs {
 
 async fn op_datagram_send(
   state: Rc<RefCell<OpState>>,
-  args: Value,
+  args: SendArgs,
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<Value, AnyError> {
   let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let zero_copy = zero_copy.clone();
 
-  match serde_json::from_value(args)? {
+  match args {
     SendArgs {
       rid,
       transport,
@@ -257,10 +254,10 @@ struct ConnectArgs {
 
 async fn op_connect(
   state: Rc<RefCell<OpState>>,
-  args: Value,
+  args: ConnectArgs,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<Value, AnyError> {
-  match serde_json::from_value(args)? {
+  match args {
     ConnectArgs {
       transport,
       transport_args: ArgsEnum::Ip(args),
@@ -421,11 +418,11 @@ fn listen_udp(
 
 fn op_listen(
   state: &mut OpState,
-  args: Value,
+  args: ListenArgs,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<Value, AnyError> {
   let permissions = state.borrow::<Permissions>();
-  match serde_json::from_value(args)? {
+  match args {
     ListenArgs {
       transport,
       transport_args: ArgsEnum::Ip(args),

--- a/runtime/ops/net_unix.rs
+++ b/runtime/ops/net_unix.rs
@@ -17,6 +17,7 @@ use deno_core::RcRef;
 use deno_core::Resource;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
+use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fs::remove_file;
@@ -54,6 +55,12 @@ impl Resource for UnixDatagramResource {
   fn close(self: Rc<Self>) {
     self.cancel.cancel();
   }
+}
+
+#[derive(Serialize)]
+pub struct UnixAddr {
+  pub path: String,
+  pub transport: String,
 }
 
 #[derive(Deserialize)]

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -152,7 +152,7 @@ fn op_os_release(
   Ok(release)
 }
 
-// Copied from sys-info/lib.rs (then tweaked) 
+// Copied from sys-info/lib.rs (then tweaked)
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct MemInfo {

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -152,19 +152,15 @@ fn op_os_release(
   Ok(release)
 }
 
-// Copied from sys-info/lib.rs
+// Copied from sys-info/lib.rs (then tweaked) 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct MemInfo {
-  /// Total physical memory.
   pub total: u64,
   pub free: u64,
-  pub avail: u64,
-
+  pub available: u64,
   pub buffers: u64,
   pub cached: u64,
-
-  /// Total swap memory.
   pub swap_total: u64,
   pub swap_free: u64,
 }
@@ -180,7 +176,7 @@ fn op_system_memory_info(
     Ok(info) => Ok(Some(MemInfo {
       total: info.total,
       free: info.free,
-      avail: info.avail,
+      available: info.avail,
       buffers: info.buffers,
       cached: info.cached,
       swap_total: info.swap_total,

--- a/runtime/ops/permissions.rs
+++ b/runtime/ops/permissions.rs
@@ -4,8 +4,6 @@ use crate::permissions::Permissions;
 use deno_core::error::custom_error;
 use deno_core::error::uri_error;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::url;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
@@ -29,7 +27,7 @@ pub fn op_query_permission(
   state: &mut OpState,
   args: PermissionArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<String, AnyError> {
   let permissions = state.borrow::<Permissions>();
   let path = args.path.as_deref();
   let perm = match args.name.as_ref() {
@@ -53,14 +51,14 @@ pub fn op_query_permission(
       ))
     }
   };
-  Ok(json!({ "state": perm.to_string() }))
+  Ok(perm.to_string())
 }
 
 pub fn op_revoke_permission(
   state: &mut OpState,
   args: PermissionArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<String, AnyError> {
   let permissions = state.borrow_mut::<Permissions>();
   let path = args.path.as_deref();
   let perm = match args.name.as_ref() {
@@ -84,14 +82,14 @@ pub fn op_revoke_permission(
       ))
     }
   };
-  Ok(json!({ "state": perm.to_string() }))
+  Ok(perm.to_string())
 }
 
 pub fn op_request_permission(
   state: &mut OpState,
   args: PermissionArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<String, AnyError> {
   let permissions = state.borrow_mut::<Permissions>();
   let path = args.path.as_deref();
   let perm = match args.name.as_ref() {
@@ -115,7 +113,7 @@ pub fn op_request_permission(
       ))
     }
   };
-  Ok(json!({ "state": perm.to_string() }))
+  Ok(perm.to_string())
 }
 
 fn parse_host(host_str: &str) -> Result<(String, Option<u16>), AnyError> {

--- a/runtime/ops/plugin.rs
+++ b/runtime/ops/plugin.rs
@@ -4,8 +4,6 @@ use crate::permissions::Permissions;
 use deno_core::error::AnyError;
 use deno_core::futures::prelude::*;
 use deno_core::plugin_api;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::JsRuntime;
 use deno_core::Op;
 use deno_core::OpAsyncFuture;
@@ -13,10 +11,10 @@ use deno_core::OpFn;
 use deno_core::OpId;
 use deno_core::OpState;
 use deno_core::Resource;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use dlopen::symbor::Library;
 use log::debug;
-use serde::Deserialize;
 use std::borrow::Cow;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -28,18 +26,12 @@ pub fn init(rt: &mut JsRuntime) {
   super::reg_json_sync(rt, "op_open_plugin", op_open_plugin);
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OpenPluginArgs {
-  filename: String,
-}
-
 pub fn op_open_plugin(
   state: &mut OpState,
-  args: OpenPluginArgs,
+  filename: String,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
-  let filename = PathBuf::from(&args.filename);
+) -> Result<ResourceId, AnyError> {
+  let filename = PathBuf::from(&filename);
 
   super::check_unstable(state, "Deno.openPlugin");
   let permissions = state.borrow::<Permissions>();
@@ -67,7 +59,7 @@ pub fn op_open_plugin(
   let mut interface = PluginInterface::new(state, &plugin_lib);
   deno_plugin_init(&mut interface);
 
-  Ok(json!(rid))
+  Ok(rid)
 }
 
 struct PluginResource {

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -8,8 +8,6 @@ use crate::permissions::Permissions;
 use deno_core::error::bad_resource_id;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
-use deno_core::serde_json::json;
-use deno_core::serde_json::Value;
 use deno_core::AsyncMutFuture;
 use deno_core::AsyncRefCell;
 use deno_core::OpState;
@@ -18,6 +16,7 @@ use deno_core::Resource;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
+use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -81,11 +80,22 @@ impl ChildResource {
   }
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+// TODO(@AaronO): maybe find a more descriptive name or a convention for return structs
+struct RunInfo {
+  rid: ResourceId,
+  pid: Option<u32>,
+  stdin_rid: Option<ResourceId>,
+  stdout_rid: Option<ResourceId>,
+  stderr_rid: Option<ResourceId>,
+}
+
 fn op_run(
   state: &mut OpState,
   run_args: RunArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<RunInfo, AnyError> {
   state.borrow::<Permissions>().run.check()?;
 
   let args = run_args.cmd;
@@ -166,28 +176,28 @@ fn op_run(
   };
   let child_rid = state.resource_table.add(child_resource);
 
-  Ok(json!({
-    "rid": child_rid,
-    "pid": pid,
-    "stdinRid": stdin_rid,
-    "stdoutRid": stdout_rid,
-    "stderrRid": stderr_rid,
-  }))
+  Ok(RunInfo {
+    rid: child_rid,
+    pid,
+    stdin_rid,
+    stdout_rid,
+    stderr_rid,
+  })
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RunStatusArgs {
-  rid: ResourceId,
+struct RunStatus {
+  got_signal: bool,
+  exit_code: i32,
+  exit_signal: i32,
 }
 
 async fn op_run_status(
   state: Rc<RefCell<OpState>>,
-  args: RunStatusArgs,
+  rid: ResourceId,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
-  let rid = args.rid;
-
+) -> Result<RunStatus, AnyError> {
   {
     let s = state.borrow();
     s.borrow::<Permissions>().run.check()?;
@@ -212,11 +222,11 @@ async fn op_run_status(
     .expect("Should have either an exit code or a signal.");
   let got_signal = signal.is_some();
 
-  Ok(json!({
-     "gotSignal": got_signal,
-     "exitCode": code.unwrap_or(-1),
-     "exitSignal": signal.unwrap_or(-1),
-  }))
+  Ok(RunStatus {
+    got_signal,
+    exit_code: code.unwrap_or(-1),
+    exit_signal: signal.unwrap_or(-1),
+  })
 }
 
 #[cfg(unix)]
@@ -280,10 +290,10 @@ fn op_kill(
   state: &mut OpState,
   args: KillArgs,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   super::check_unstable(state, "Deno.kill");
   state.borrow::<Permissions>().run.check()?;
 
   kill(args.pid, args.signo)?;
-  Ok(json!({}))
+  Ok(())
 }

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 use deno_core::error::AnyError;
-use deno_core::serde_json::Value;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
 use std::cell::RefCell;
@@ -8,8 +7,6 @@ use std::rc::Rc;
 
 #[cfg(unix)]
 use deno_core::error::bad_resource_id;
-#[cfg(unix)]
-use deno_core::serde_json::json;
 #[cfg(unix)]
 use deno_core::AsyncRefCell;
 #[cfg(unix)]
@@ -21,7 +18,7 @@ use deno_core::RcRef;
 #[cfg(unix)]
 use deno_core::Resource;
 #[cfg(unix)]
-use serde::Deserialize;
+use deno_core::ResourceId;
 #[cfg(unix)]
 use std::borrow::Cow;
 #[cfg(unix)]
@@ -53,45 +50,28 @@ impl Resource for SignalStreamResource {
 }
 
 #[cfg(unix)]
-#[derive(Deserialize)]
-pub struct BindSignalArgs {
-  signo: i32,
-}
-
-#[cfg(unix)]
-#[derive(Deserialize)]
-pub struct SignalArgs {
-  rid: u32,
-}
-
-#[cfg(unix)]
 #[allow(clippy::unnecessary_wraps)]
 fn op_signal_bind(
   state: &mut OpState,
-  args: BindSignalArgs,
+  signo: i32,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<ResourceId, AnyError> {
   super::check_unstable(state, "Deno.signal");
   let resource = SignalStreamResource {
-    signal: AsyncRefCell::new(
-      signal(SignalKind::from_raw(args.signo)).expect(""),
-    ),
+    signal: AsyncRefCell::new(signal(SignalKind::from_raw(signo)).expect("")),
     cancel: Default::default(),
   };
   let rid = state.resource_table.add(resource);
-  Ok(json!({
-    "rid": rid,
-  }))
+  Ok(rid)
 }
 
 #[cfg(unix)]
 async fn op_signal_poll(
   state: Rc<RefCell<OpState>>,
-  args: SignalArgs,
+  rid: ResourceId,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<bool, AnyError> {
   super::check_unstable2(&state, "Deno.signal");
-  let rid = args.rid;
 
   let resource = state
     .borrow_mut()
@@ -102,49 +82,48 @@ async fn op_signal_poll(
   let mut signal = RcRef::map(&resource, |r| &r.signal).borrow_mut().await;
 
   match signal.recv().or_cancel(cancel).await {
-    Ok(result) => Ok(json!({ "done": result.is_none() })),
-    Err(_) => Ok(json!({ "done": true })),
+    Ok(result) => Ok(result.is_none()),
+    Err(_) => Ok(true),
   }
 }
 
 #[cfg(unix)]
 pub fn op_signal_unbind(
   state: &mut OpState,
-  args: SignalArgs,
+  rid: ResourceId,
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   super::check_unstable(state, "Deno.signal");
-  let rid = args.rid;
   state
     .resource_table
     .close(rid)
     .ok_or_else(bad_resource_id)?;
-  Ok(json!({}))
+  Ok(())
 }
 
 #[cfg(not(unix))]
 pub fn op_signal_bind(
   _state: &mut OpState,
-  _args: Value,
+  _args: (),
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   unimplemented!();
 }
 
 #[cfg(not(unix))]
 fn op_signal_unbind(
   _state: &mut OpState,
-  _args: Value,
+  _args: (),
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   unimplemented!();
 }
 
 #[cfg(not(unix))]
 async fn op_signal_poll(
   _state: Rc<RefCell<OpState>>,
-  _args: Value,
+  _args: (),
   _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<Value, AnyError> {
+) -> Result<(), AnyError> {
   unimplemented!();
 }

--- a/runtime/ops/tls.rs
+++ b/runtime/ops/tls.rs
@@ -348,18 +348,11 @@ fn op_listen_tls(
   }))
 }
 
-#[derive(Deserialize)]
-pub struct AcceptTlsArgs {
-  rid: ResourceId,
-}
-
 async fn op_accept_tls(
   state: Rc<RefCell<OpState>>,
-  args: AcceptTlsArgs,
+  rid: ResourceId,
   _zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<Value, AnyError> {
-  let rid = args.rid;
-
   let resource = state
     .borrow()
     .resource_table

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -145,7 +145,7 @@ fn op_set_raw(
       return Err(Error::last_os_error().into());
     }
 
-    Ok(json!({}))
+    Ok(())
   }
   #[cfg(unix)]
   {

--- a/runtime/ops/web_worker.rs
+++ b/runtime/ops/web_worker.rs
@@ -16,14 +16,14 @@ pub fn init(
   super::reg_json_sync(
     rt,
     "op_worker_post_message",
-    move |_state, _args: Value, buf| {
+    move |_state, _args: (), buf| {
       let buf = buf.ok_or_else(null_opbuf)?;
       let msg_buf: Box<[u8]> = (*buf).into();
       sender_
         .clone()
         .try_send(WorkerEvent::Message(msg_buf))
         .expect("Failed to post message to host");
-      Ok(json!({}))
+      Ok(())
     },
   );
 

--- a/runtime/ops/web_worker.rs
+++ b/runtime/ops/web_worker.rs
@@ -4,7 +4,6 @@ use crate::web_worker::WebWorkerHandle;
 use crate::web_worker::WorkerEvent;
 use deno_core::error::null_opbuf;
 use deno_core::futures::channel::mpsc;
-use deno_core::serde_json::{json, Value};
 
 pub fn init(
   rt: &mut deno_core::JsRuntime,
@@ -31,12 +30,12 @@ pub fn init(
   super::reg_json_sync(
     rt,
     "op_worker_close",
-    move |_state, _args: Value, _bufs| {
+    move |_state, _args: (), _bufs| {
       // Notify parent that we're finished
       sender.clone().close_channel();
       // Terminate execution of current worker
       handle.terminate();
-      Ok(json!({}))
+      Ok(())
     },
   );
 }


### PR DESCRIPTION
This PR is a follow-up to #9843 and tweaks most ops across the codebase to follow our best practices for ops.

It's also important to move away from `serde_json::Value` to fully realize the perf gains of `serde_v8` (since it otherwise does a double serializaiton and it's serialized as a loosely typed map, which is very inefficient, doesn't benefit from `v8_struct_key` optims, etc...)

## Goals

1. More consistent op functions
2. More performant ops (removing overhead of `json!()` and `serde_json::Value` which are loosely typed)
3. Better typed op code (easier to maintain, catch bugs, etc...)

## Changes related to best-practices

1. Remove wrappers for single args (e.g: `{ rid }`)
2. Remove single-keyed structs to deserialize said wrappers
3. Specific return values types instead of general `Result<Value, AnyError>`
4. Empty returns: `Ok(json!({}))` => `Ok(())`
5. Use rust's unit type for ignored/unused args
6. Remove most `serde_json::*` imports and sometimes `serde::Deserialize` (after dropping wrapper structs)
7. Remove pseudo-variadic ZeroCopyBufs in JS

## Steps

- [x] `runtime/`
  - [x] Bulk of modules, with relatively simple changes
  - [ ] Modules like `net` that require introducing new general types
- [x] `op_crates`

## Notes

- Yes, this touches a lot of the code
- This should mostly change rust code, but I've touched JS code to match up the arg-unwrapping
- Some places that are loosely typed or that return HashMaps still use `serde_json::Value`
- This also applies to places where `json!()` offered some "useful" implicit conversions for references (e.g: `&str`, `Cow`, ...) to owned types (that can be returned and serialized), to my understanding there was no (performance) upside to returning refs, since `json!()` would convert them to owned types anyway