### PR TITLE
docs: export EmitOptions and EmitResult from d.ts

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -434,7 +434,12 @@ declare namespace Deno {
     scopes?: Record<string, Record<string, string>>;
   }
 
-  interface EmitOptions {
+  /**
+   * **UNSTABLE**: new API, yet to be vetted.
+   *
+   * The options for `Deno.emit()` API.
+   */
+  export interface EmitOptions {
     /** Indicate that the source code should be emitted to a single file
      * JavaScript bundle that is a single ES module (`"esm"`) or a single file
      * self contained script we executes in an immediately invoked function
@@ -467,7 +472,12 @@ declare namespace Deno {
     sources?: Record<string, string>;
   }
 
-  interface EmitResult {
+  /**
+   * **UNSTABLE**: new API, yet to be vetted.
+   *
+   * The result of `Deno.emit()` API.
+   */
+  export interface EmitResult {
     /** Diagnostic messages returned from the type checker (`tsc`). */
     diagnostics: Diagnostic[];
     /** Any emitted files.  If bundled, then the JavaScript will have the


### PR DESCRIPTION
EmitOptions and EmitResult are not available in `deno doc` command because these are not exported in d.ts file. With this change we can see the docs by the following commands:

```
deno doc --unstable --builtin Deno.EmitOptions
deno doc --unstable --builtin Deno.EmitResult
```