### PR TITLE
perf(cargo): build core packages at opt-3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,11 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.brotli-decompressor]
 opt-level = 3
+[profile.release.package.deno_core]
+opt-level = 3
+[profile.release.package.rusty_v8]
+opt-level = 3
+[profile.release.package.serde_v8]
+opt-level = 3
+[profile.release.package.serde]
+opt-level = 3


### PR DESCRIPTION
Specifically: deno_core, rusty_v8, serde_v8, serde, since they are central to op baseline performance.

**Impact:** gets us sub 100ns sync ops 🎉, and cuts async ops' baseline by ~70ns or 10%

## Benches

Measured on the `op_baseline` bench:

```
Before:
test bench_op_async   ... bench:     608,301 ns/iter (+/- 16,057)
test bench_op_nop     ... bench:     112,457 ns/iter (+/- 2,073)
test bench_op_pi_bin  ... bench:     137,527 ns/iter (+/- 6,679)
test bench_op_pi_json ... bench:     128,126 ns/iter (+/- 2,241)

After:
test bench_op_async   ... bench:     536,888 ns/iter (+/- 13,096)
test bench_op_nop     ... bench:      71,331 ns/iter (+/- 2,728)
test bench_op_pi_bin  ... bench:      85,746 ns/iter (+/- 1,959)
test bench_op_pi_json ... bench:      87,541 ns/iter (+/- 6,453)
```

## Binary size

Optimizing these core libs for release only increases binary size by ~7kb, making it a no-brainer tradeoff:
- Before: 80256513
- After: 80263585

## Notes

- This might increase CI time, we can compare this PR's CI time to `main` to get the delta (unless there's a lot of variance)