### PR TITLE
Improve release build link time by disabling LTO, codegen-units = 1, opt-level = 'z' 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,6 @@ exclude = [
   "std/hash/_wasm"
 ]
 
-
-[profile.release]
-codegen-units = 1
-lto = true
-opt-level = 'z' # Optimize for size
-
-[profile.bench]
-codegen-units = 1
-lto = true
-opt-level = 'z' # Optimize for size
-
 # Optimize these packages for perf
 [profile.release.package.rand]
 opt-level = 3


### PR DESCRIPTION
|        | incremental build (release) | full build (release) | binary size (release) |
|--------|-----------------------------|----------------------|-----------------------|
| main   | 4m 21s                      | 6m 24s               | 72M                   |
| #10039 | 1m 45s                      | 5m 28s               | 80M                   |


*incremental build is measured using `touch core/runtime.rs; cargo build --release`