### PR TITLE
chore: update deno_file to use deno_webidl

### DIFF
--- a/op_crates/file/03_blob_url.js
+++ b/op_crates/file/03_blob_url.js
@@ -15,7 +15,7 @@
 
 ((window) => {
   const core = Deno.core;
-  // const webidl = window.__bootstrap.webidl;
+  const webidl = window.__bootstrap.webidl;
   const { _byteSequence } = window.__bootstrap.file;
   const { URL } = window.__bootstrap.url;
 
@@ -24,12 +24,12 @@
    * @returns {string}
    */
   function createObjectURL(blob) {
-    // const prefix = "Failed to execute 'createObjectURL' on 'URL'";
-    // webidl.requiredArguments(arguments.length, 1, { prefix });
-    // blob = webidl.converters["Blob"](blob, {
-    //   context: "Argument 1",
-    //   prefix,
-    // });
+    const prefix = "Failed to execute 'createObjectURL' on 'URL'";
+    webidl.requiredArguments(arguments.length, 1, { prefix });
+    blob = webidl.converters["Blob"](blob, {
+      context: "Argument 1",
+      prefix,
+    });
 
     const url = core.jsonOpSync(
       "op_file_create_object_url",
@@ -45,12 +45,12 @@
    * @returns {void}
    */
   function revokeObjectURL(url) {
-    // const prefix = "Failed to execute 'revokeObjectURL' on 'URL'";
-    // webidl.requiredArguments(arguments.length, 1, { prefix });
-    // url = webidl.converters["DOMString"](url, {
-    //   context: "Argument 1",
-    //   prefix,
-    // });
+    const prefix = "Failed to execute 'revokeObjectURL' on 'URL'";
+    webidl.requiredArguments(arguments.length, 1, { prefix });
+    url = webidl.converters["DOMString"](url, {
+      context: "Argument 1",
+      prefix,
+    });
 
     core.jsonOpSync(
       "op_file_revoke_object_url",

--- a/op_crates/webidl/00_webidl.js
+++ b/op_crates/webidl/00_webidl.js
@@ -615,6 +615,14 @@
   }
 
   function createDictionaryConverter(name, ...dictionaries) {
+    const allMembers = [];
+    for (const members of dictionaries) {
+      for (const member of members) {
+        allMembers.push(member);
+      }
+    }
+    allMembers.sort((a, b) => a.key.localeCompare(b.key));
+
     return function (V, opts = {}) {
       const typeV = type(V);
       switch (typeV) {
@@ -633,39 +641,37 @@
 
       const idlDict = {};
 
-      for (const members of dictionaries) {
-        for (const member of members) {
-          const key = member.key;
+      for (const member of allMembers) {
+        const key = member.key;
 
-          let esMemberValue;
-          if (typeV === "Undefined" || typeV === "Null") {
-            esMemberValue = undefined;
-          } else {
-            esMemberValue = esDict[key];
-          }
+        let esMemberValue;
+        if (typeV === "Undefined" || typeV === "Null") {
+          esMemberValue = undefined;
+        } else {
+          esMemberValue = esDict[key];
+        }
 
-          const context = `'${key}' of '${name}'${
-            opts.context ? ` (${opts.context})` : ""
-          }`;
+        const context = `'${key}' of '${name}'${
+          opts.context ? ` (${opts.context})` : ""
+        }`;
 
-          if (esMemberValue !== undefined) {
-            const converter = member.converter;
-            const idlMemberValue = converter(esMemberValue, {
-              ...opts,
-              context,
-            });
-            idlDict[key] = idlMemberValue;
-          } else if ("defaultValue" in member) {
-            const defaultValue = member.defaultValue;
-            const idlMemberValue = defaultValue;
-            idlDict[key] = idlMemberValue;
-          } else if (member.required) {
-            throw makeException(
-              TypeError,
-              `can not be converted to '${name}' because '${key}' is required in '${name}'.`,
-              { ...opts },
-            );
-          }
+        if (esMemberValue !== undefined) {
+          const converter = member.converter;
+          const idlMemberValue = converter(esMemberValue, {
+            ...opts,
+            context,
+          });
+          idlDict[key] = idlMemberValue;
+        } else if ("defaultValue" in member) {
+          const defaultValue = member.defaultValue;
+          const idlMemberValue = defaultValue;
+          idlDict[key] = idlMemberValue;
+        } else if (member.required) {
+          throw makeException(
+            TypeError,
+            `can not be converted to '${name}' because '${key}' is required in '${name}'.`,
+            { ...opts },
+          );
         }
       }
 

--- a/op_crates/webidl/00_webidl.js
+++ b/op_crates/webidl/00_webidl.js
@@ -621,7 +621,12 @@
         allMembers.push(member);
       }
     }
-    allMembers.sort((a, b) => a.key.localeCompare(b.key));
+    allMembers.sort((a, b) => {
+      if (a.key == b.key) {
+        return 0;
+      }
+      return a.key < b.key ? -1 : 1;
+    });
 
     return function (V, opts = {}) {
       const typeV = type(V);

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -784,7 +784,10 @@
     "file": {
       "File-constructor.any.js": true
     },
-    "fileReader.any.js": true
+    "fileReader.any.js": true,
+    "url": {
+      "url-format.any.js": true
+    }
   },
   "html": {
     "webappapis": {

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -776,7 +776,6 @@
       "Blob-stream.any.js": true,
       "Blob-text.any.js": true,
       "Blob-constructor.any.js": [
-        "Blob interface object",
         "Passing a FrozenArray as the blobParts array should work (FrozenArray<MessagePort>)."
       ],
       "Blob-slice-overflow.any.js": true,


### PR DESCRIPTION
This changes the custom input converters in deno_file to use deno_webidl
converters.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
