### PR TITLE
ci: use repository and ref as part of the cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
             ~/.cargo/git
             ~/.cargo/registry
             ./target
-          key: cache-1-${{ matrix.os }}-${{ matrix.kind }}-${{ hashFiles('Cargo.lock') }}
+          key: cache-${{ github.repository }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.kind }}-${{ hashFiles('Cargo.lock') }}
 
       - name: test_format.js
         if: matrix.kind == 'lint'


### PR DESCRIPTION
This adds the repository and ref to the cache key, making it scoped on an origin/branch pair basis to avoid clashes.