### PR TITLE
ci: fallback to main's cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,9 @@ jobs:
             ~/.cargo/git
             ~/.cargo/registry
             ./target
-          key: cache-${{ github.repository }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.kind }}-${{ hashFiles('Cargo.lock') }}
+          key: cache-${{ github.ref }}-${{ matrix.os }}-${{ matrix.kind }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cache-refs/heads/main-${{ matrix.os }}-${{ matrix.kind }}-${{ hashFiles('Cargo.lock') }}
 
       - name: test_format.js
         if: matrix.kind == 'lint'


### PR DESCRIPTION
Creates cache for each branch to prevent the cache conflict. Uses main's cache for the first run in the branch.

related #10067 