### PR TITLE
ci: use gnu tar on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,13 @@ jobs:
       - name: Restore timestamps
         run: python ./tools/restore_mtime.py
 
+      # Work around https://github.com/actions/cache/issues/403 by using GNU tar
+      # instead of BSD tar.
+      - name: Install GNU tar
+        if: matrix.os == 'macos-10.15'
+        run: |
+          brew install gnu-tar
+
       - name: Cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This PR installs and uses GNU tar for extracting cache in macos runner of CI. (`actions/cache` step automatically picks gtar if it's available).

According to https://github.com/actions/cache/issues/403 BSD tar causes corruption of certain files such as `libserde_derive.dylib`. (see also https://github.com/rust-lang/cargo/issues/8603

This workaround should prevent this error https://github.com/denoland/deno/runs/2297003519