### PR TITLE
ci: do not include branch name in cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,9 +178,7 @@ jobs:
             ~/.cargo/git
             ~/.cargo/registry
             ./target
-          key: cache3-${{ github.ref }}-${{ matrix.os }}-${{ matrix.kind }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            cache3-refs/heads/main-${{ matrix.os }}-${{ matrix.kind }}-${{ hashFiles('Cargo.lock') }}
+          key: cache4-${{ matrix.os }}-${{ matrix.kind }}-${{ hashFiles('Cargo.lock') }}
 
       - name: test_format.js
         if: matrix.kind == 'lint'


### PR DESCRIPTION
Cache service often returns 429 response at Post cache step. ref [1](https://github.com/denoland/deno/pull/9376/checks?check_run_id=2302579454), [2](https://github.com/denoland/deno/pull/10078/checks?check_run_id=2302563352), [3](https://github.com/denoland/deno/runs/2302591438) (GitHub Actions cache now has 5GB limit for a single repository. Probably we exceed this limit.)

This change prevents creating new cache on every PR branch.