### PR TITLE
perf(serde_v8): build with `codegen-units=1`

### DIFF
--- a/serde_v8/Cargo.toml
+++ b/serde_v8/Cargo.toml
@@ -19,6 +19,9 @@ bencher = "0.1"
 [[example]]
 name = "basic"
 
+[profile.release]
+codegen-units = 1
+
 [[bench]]
 name = "de"
 harness = false


### PR DESCRIPTION
Lets LLVM optimize code better. Decreases ~160ns from `ser_struct_v8_manual` bench. Build time impact is negligible.