### PR TITLE
Revert "Improve incremental build time (#10039)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,17 @@ exclude = [
   "std/hash/_wasm"
 ]
 
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = 'z' # Optimize for size
+
+[profile.bench]
+codegen-units = 1
+lto = true
+opt-level = 'z' # Optimize for size
+
 # Optimize these packages for perf
 [profile.release.package.rand]
 opt-level = 3


### PR DESCRIPTION
This reverts commit a87da4b19a6da67dde15d1d0ceefaad2bdad1637.


Although the binary size increase was known in advance, I'm having second thoughts after seeing the benchmarks page:

![image](https://user-images.githubusercontent.com/80/114195612-9dc60100-991e-11eb-9841-09eb5e6ad747.png)
