### PR TITLE
fix(op_crates/fetch): uppercase specific methods

### DIFF
--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -1254,18 +1254,6 @@
       headerArray = Array.from(headers.entries());
     }
 
-    const sensitiveMethods = [
-      "DELETE",
-      "GET",
-      "HEAD",
-      "OPTIONS",
-      "POST",
-      "PUT",
-    ];
-    if (sensitiveMethods.includes(method.toUpperCase())) {
-      method = method.toUpperCase();
-    }
-
     const { requestRid, requestBodyRid } = opFetch(
       {
         method,

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -1254,6 +1254,18 @@
       headerArray = Array.from(headers.entries());
     }
 
+    const sensitiveMethods = [
+      "DELETE",
+      "GET",
+      "HEAD",
+      "OPTIONS",
+      "POST",
+      "PUT",
+    ];
+    if (sensitiveMethods.includes(method.toUpperCase())) {
+      method = method.toUpperCase();
+    }
+
     const { requestRid, requestBodyRid } = opFetch(
       {
         method,

--- a/op_crates/fetch/lib.rs
+++ b/op_crates/fetch/lib.rs
@@ -143,7 +143,15 @@ where
   };
 
   let method = match args.method {
-    Some(method_str) => Method::from_bytes(method_str.as_bytes())?,
+    Some(mut method_str) => {
+      if matches!(
+        method_str.to_uppercase().as_ref(),
+        "DELETE" | "GET" | "HEAD" | "OPTIONS" | "POST" | "PUT"
+      ) {
+        method_str = method_str.to_uppercase();
+      }
+      Method::from_bytes(method_str.as_bytes())?
+    }
     None => Method::GET,
   };
 


### PR DESCRIPTION
Closes #10088 
ref: https://fetch.spec.whatwg.org/#methods
> To normalize a method, if it is a byte-case-insensitive match for `DELETE`, `GET`, `HEAD`, `OPTIONS`, `POST`, or `PUT`, byte-uppercase it. 