### PR TITLE
ci: touch build.rs files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,12 @@ jobs:
       - name: Restore timestamps
         run: python ./tools/restore_mtime.py
 
+      # Touches build.rs files because cargo doesn't seem handling
+      # dependencies correctly which are created from build.rs.
+      - name: Touch build.rs
+        shell: bash
+        run: git ls-files | grep build\.rs\$ | xargs touch
+
       # Work around https://github.com/actions/cache/issues/403 by using GNU tar
       # instead of BSD tar.
       - name: Install GNU tar


### PR DESCRIPTION
The current CI settings seem having trouble with branches which only include .js & .ts changes. If a branch only includes changes of .js and .ts it doesn't trigger rebuild of anything. (example: https://github.com/denoland/deno/runs/2304805006

This workaround updates the modified times of build.rs files and force rebuild the dependencies which are created from build.rs scripts.