### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ dependencies = [
  "sourcemap",
  "swc_bundler",
  "swc_common",
- "swc_ecmascript 0.31.0",
+ "swc_ecmascript",
  "tempfile",
  "termcolor",
  "test_util",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86809f54ca37af41e06fd071a8d5dec31360589f47dfbcbe2540cc994c58a65c"
+checksum = "7f730996cae351f72bbf49675f7277e98f6adf45a8dc073c80f0ac7e105ae8f3"
 dependencies = [
  "futures",
  "lazy_static",
@@ -606,7 +606,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_common",
- "swc_ecmascript 0.24.1",
+ "swc_ecmascript",
  "termcolor",
 ]
 
@@ -648,7 +648,7 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecmascript 0.31.0",
+ "swc_ecmascript",
 ]
 
 [[package]]
@@ -842,7 +842,7 @@ dependencies = [
  "fnv",
  "serde",
  "swc_common",
- "swc_ecmascript 0.31.0",
+ "swc_ecmascript",
 ]
 
 [[package]]
@@ -856,7 +856,7 @@ dependencies = [
  "num-bigint",
  "swc_atoms",
  "swc_common",
- "swc_ecmascript 0.31.0",
+ "swc_ecmascript",
 ]
 
 [[package]]
@@ -2969,12 +2969,12 @@ dependencies = [
  "retain_mut",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
+ "swc_ecma_ast",
  "swc_ecma_codegen",
- "swc_ecma_parser 0.54.0",
+ "swc_ecma_parser",
  "swc_ecma_transforms",
  "swc_ecma_utils",
- "swc_ecma_visit 0.29.0",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -3003,20 +3003,6 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b73b90f45238ac4b29e264591cfb34b0df32fb336f74a12a369678c7d5e906b"
-dependencies = [
- "is-macro",
- "num-bigint",
- "serde",
- "string_enum",
- "swc_atoms",
- "swc_common",
-]
-
-[[package]]
-name = "swc_ecma_ast"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12bc9116a900cf73b81d5aca412a8a988c4935967bcbd0b7e94bfb1f906209bb"
@@ -3040,9 +3026,9 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
+ "swc_ecma_ast",
  "swc_ecma_codegen_macros",
- "swc_ecma_parser 0.54.0",
+ "swc_ecma_parser",
 ]
 
 [[package]]
@@ -3066,28 +3052,8 @@ checksum = "04f77d8bc8cc621382062e3d813fc52f807c8e4f91649a715c2c4e360b279c80"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
- "swc_ecma_visit 0.29.0",
-]
-
-[[package]]
-name = "swc_ecma_parser"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9070f184ca5724d67325dbc4a9d6e8e18c27a0439c95e088e246a3404ef2f05f"
-dependencies = [
- "either",
- "enum_kind",
- "fxhash",
- "log",
- "num-bigint",
- "serde",
- "smallvec",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.40.0",
- "swc_ecma_visit 0.26.0",
- "unicode-xid 0.2.1",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -3105,8 +3071,8 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
- "swc_ecma_visit 0.29.0",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
  "unicode-xid 0.2.1",
 ]
 
@@ -3118,15 +3084,15 @@ checksum = "de54db3535bc7fb7eb9c64b9ba87e246ee19d4cece8ca238fb15df5a82452214"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
- "swc_ecma_parser 0.54.0",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
  "swc_ecma_utils",
- "swc_ecma_visit 0.29.0",
+ "swc_ecma_visit",
  "unicode-xid 0.2.1",
 ]
 
@@ -3143,10 +3109,10 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
- "swc_ecma_parser 0.54.0",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_ecma_utils",
- "swc_ecma_visit 0.29.0",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -3164,11 +3130,11 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
- "swc_ecma_parser 0.54.0",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit 0.29.0",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -3183,11 +3149,11 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
- "swc_ecma_parser 0.54.0",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit 0.29.0",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -3206,11 +3172,11 @@ dependencies = [
  "string_enum",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
- "swc_ecma_parser 0.54.0",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit 0.29.0",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -3223,11 +3189,11 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
- "swc_ecma_parser 0.54.0",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit 0.29.0",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -3240,22 +3206,9 @@ dependencies = [
  "scoped-tls",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
- "swc_ecma_visit 0.29.0",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
  "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "swc_ecma_visit"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd01a0c58d20627f2fa29f44c5c6f68ae7d2ca6e2de0447429f2db65e4482a4e"
-dependencies = [
- "num-bigint",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.40.0",
- "swc_visit",
 ]
 
 [[package]]
@@ -3267,18 +3220,8 @@ dependencies = [
  "num-bigint",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.43.0",
+ "swc_ecma_ast",
  "swc_visit",
-]
-
-[[package]]
-name = "swc_ecmascript"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54da8566eb8035ea784b7297e16db45525242a7c955d8b9b3a5895d5694abbe"
-dependencies = [
- "swc_ecma_ast 0.40.0",
- "swc_ecma_parser 0.49.0",
 ]
 
 [[package]]
@@ -3287,13 +3230,13 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d35c0d2519155e1a4a9b9bcd6c869c75f0fe2db5a65ca4af6a36c42c18d302d7"
 dependencies = [
- "swc_ecma_ast 0.43.0",
+ "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_dep_graph",
- "swc_ecma_parser 0.54.0",
+ "swc_ecma_parser",
  "swc_ecma_transforms",
  "swc_ecma_utils",
- "swc_ecma_visit 0.29.0",
+ "swc_ecma_visit",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ dependencies = [
  "sourcemap",
  "swc_bundler",
  "swc_common",
- "swc_ecmascript",
+ "swc_ecmascript 0.31.0",
  "tempfile",
  "termcolor",
  "test_util",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.1.23"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91967783675550e9550963c6c0e0309fa2279ad1dd5248cc13380e1f288659e9"
+checksum = "86809f54ca37af41e06fd071a8d5dec31360589f47dfbcbe2540cc994c58a65c"
 dependencies = [
  "futures",
  "lazy_static",
@@ -606,7 +606,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_common",
- "swc_ecmascript",
+ "swc_ecmascript 0.24.1",
  "termcolor",
 ]
 
@@ -633,12 +633,14 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.2.20"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a5b29a5c4e875fe52dba484389ac54fba61454d0adf4f0cec2b62c2eab0a2"
+checksum = "bacc285c5888bc383b56da4df36bb0f9ce17a47c2c5749bd74f3efb44cf6a446"
 dependencies = [
  "anyhow",
  "derive_more",
+ "dprint-swc-ecma-ast-view",
+ "if_chain",
  "log",
  "once_cell",
  "regex",
@@ -646,7 +648,7 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecmascript",
+ "swc_ecmascript 0.31.0",
 ]
 
 [[package]]
@@ -831,30 +833,30 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.41.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ec89eed06671390db8e6d29b98ee97c43caf52e2b481211665837677eb690b"
+checksum = "a0980c5558a569da878cf383f2a0b9886e8103a617575475369541c27fc8162f"
 dependencies = [
  "dprint-core",
  "dprint-swc-ecma-ast-view",
  "fnv",
  "serde",
  "swc_common",
- "swc_ecmascript",
+ "swc_ecmascript 0.31.0",
 ]
 
 [[package]]
 name = "dprint-swc-ecma-ast-view"
-version = "0.10.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b495385633bb59f360775a5278327c294c42484e5256288c80e591db334227e"
+checksum = "1a58a42bc0f1fe40953a1dd865ee739bf71758c00420a1274bf679681e0e2f5a"
 dependencies = [
  "bumpalo",
  "fnv",
  "num-bigint",
  "swc_atoms",
  "swc_common",
- "swc_ecmascript",
+ "swc_ecmascript 0.31.0",
 ]
 
 [[package]]
@@ -2950,9 +2952,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.25.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c04b87655ffe30fef7e22c0fdb0321d8ae0136f66155aac2acf3c8b7498669"
+checksum = "465a390452a184024d55fbe9e76f99441dc4c304525c15717ba14f707e6e934f"
 dependencies = [
  "ahash 0.7.2",
  "anyhow",
@@ -2967,19 +2969,19 @@ dependencies = [
  "retain_mut",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.43.0",
  "swc_ecma_codegen",
- "swc_ecma_parser",
+ "swc_ecma_parser 0.54.0",
  "swc_ecma_transforms",
  "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_visit 0.29.0",
 ]
 
 [[package]]
 name = "swc_common"
-version = "0.10.14"
+version = "0.10.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a9838352657cf36b1acf52e10e9b219a3a42ad8a3c227f8d597c89b1b03eaa"
+checksum = "83d405e6dc4cdde5122631268c749c7d1ddb2258be318d8d68b5d0c76f70ff6c"
 dependencies = [
  "ast_node",
  "cfg-if 0.1.10",
@@ -3014,19 +3016,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_codegen"
-version = "0.47.0"
+name = "swc_ecma_ast"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2604a8c27ea2b549ada2f1218a73029a7abb3507ba3b00491884f93e0efd65"
+checksum = "12bc9116a900cf73b81d5aca412a8a988c4935967bcbd0b7e94bfb1f906209bb"
+dependencies = [
+ "is-macro",
+ "num-bigint",
+ "serde",
+ "string_enum",
+ "swc_atoms",
+ "swc_common",
+]
+
+[[package]]
+name = "swc_ecma_codegen"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8695bc182816ca040661dac396edf50ed17c62c66cb1b3818db043a0b56824"
 dependencies = [
  "bitflags",
  "num-bigint",
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.43.0",
  "swc_ecma_codegen_macros",
- "swc_ecma_parser",
+ "swc_ecma_parser 0.54.0",
 ]
 
 [[package]]
@@ -3044,14 +3060,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_dep_graph"
-version = "0.17.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95be4b111fd000832fb164feb22d0e4d1c7c4f43c458b98a85218da9b90e0cdd"
+checksum = "04f77d8bc8cc621382062e3d813fc52f807c8e4f91649a715c2c4e360b279c80"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.43.0",
+ "swc_ecma_visit 0.29.0",
 ]
 
 [[package]]
@@ -3069,36 +3085,56 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.40.0",
+ "swc_ecma_visit 0.26.0",
+ "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2259963223076f0e14ebdca0c3ea91cf7bf632b86bcbcd20d06f3e99467e442"
+dependencies = [
+ "either",
+ "enum_kind",
+ "fxhash",
+ "log",
+ "num-bigint",
+ "serde",
+ "smallvec",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.43.0",
+ "swc_ecma_visit 0.29.0",
  "unicode-xid 0.2.1",
 ]
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.38.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2fa7fa6a8ab3b65767e01efae34d5079c7e964826074ce7b1f10cb66175d9d3"
+checksum = "de54db3535bc7fb7eb9c64b9ba87e246ee19d4cece8ca238fb15df5a82452214"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.43.0",
+ "swc_ecma_parser 0.54.0",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
  "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_visit 0.29.0",
  "unicode-xid 0.2.1",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.6.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21db046d7e79ba05a42292c905740a47b1da241e71d55c5adc75a0a5418576b6"
+checksum = "228118dce83fcc2dcb9542476b2f419446fc73f0d83391e81c5b6430e0b1ab5f"
 dependencies = [
  "fxhash",
  "once_cell",
@@ -3107,17 +3143,17 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.43.0",
+ "swc_ecma_parser 0.54.0",
  "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_visit 0.29.0",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.8.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37075edc6b900b710e8b1776531fcb3d2cae831bcba2667ccd3153115f17e76e"
+checksum = "1f6b283cbb47821b34219a2a8f005c9669cff6441be37cd939b50dd7d37e897c"
 dependencies = [
  "dashmap",
  "fxhash",
@@ -3128,18 +3164,18 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.43.0",
+ "swc_ecma_parser 0.54.0",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_visit 0.29.0",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.7.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff697ca49cff569dccc6e8d405c805163c202c033b9e7213def7ea3aef228b5"
+checksum = "681d69cc545e02f1c690b4717d1fe2fc23c60ee3fdc55243cb2ff94f167f1b8e"
 dependencies = [
  "either",
  "fxhash",
@@ -3147,62 +3183,65 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.43.0",
+ "swc_ecma_parser 0.54.0",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_visit 0.29.0",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.8.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4712a2afc3dddc591b2214b329e00312ff6d1f212479ee2942779c32e41d5515"
+checksum = "57311c3cb3fe19e205ff907ace2ec15c0b047d587c4edcbb50644c30ab7003d3"
 dependencies = [
+ "base64 0.13.0",
  "dashmap",
+ "indexmap",
  "once_cell",
  "regex",
  "serde",
+ "sha-1",
  "string_enum",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.43.0",
+ "swc_ecma_parser 0.54.0",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_visit 0.29.0",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.7.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fd91b6d6bc8885d40a5d6f2d54f061d4319a0e337ca29e45c065c69a74c2bb"
+checksum = "f9b55d8d04b79100342b9de3f804dbca3d9394a4bdcc1af648eaccc50a270495"
 dependencies = [
  "fxhash",
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.43.0",
+ "swc_ecma_parser 0.54.0",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_visit 0.29.0",
 ]
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d1e28b7c0c0a463c0b565af98cd1d241313990568e657bb2f1bd4468892d93"
+checksum = "de8d88b09ee9726ba431ebb14a60a304ff37f6b4c4ea56b59f6fc5d527a577c4"
 dependencies = [
  "once_cell",
  "scoped-tls",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.43.0",
+ "swc_ecma_visit 0.29.0",
  "unicode-xid 0.2.1",
 ]
 
@@ -3215,7 +3254,20 @@ dependencies = [
  "num-bigint",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.40.0",
+ "swc_visit",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea12f9daba61bedf9ef548493403a02ac3109db477ec863c806ddb80089c40c"
+dependencies = [
+ "num-bigint",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.43.0",
  "swc_visit",
 ]
 
@@ -3225,13 +3277,23 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e54da8566eb8035ea784b7297e16db45525242a7c955d8b9b3a5895d5694abbe"
 dependencies = [
- "swc_ecma_ast",
+ "swc_ecma_ast 0.40.0",
+ "swc_ecma_parser 0.49.0",
+]
+
+[[package]]
+name = "swc_ecmascript"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d35c0d2519155e1a4a9b9bcd6c869c75f0fe2db5a65ca4af6a36c42c18d302d7"
+dependencies = [
+ "swc_ecma_ast 0.43.0",
  "swc_ecma_codegen",
  "swc_ecma_dep_graph",
- "swc_ecma_parser",
+ "swc_ecma_parser 0.54.0",
  "swc_ecma_transforms",
  "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_visit 0.29.0",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,7 +35,7 @@ winres = "0.1.11"
 
 [dependencies]
 deno_core = { path = "../core", version = "0.83.0" }
-deno_doc = "0.2.0"
+deno_doc = "0.2.1"
 deno_lint = "0.3.0"
 deno_runtime = { path = "../runtime", version = "0.10.1" }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,8 +35,8 @@ winres = "0.1.11"
 
 [dependencies]
 deno_core = { path = "../core", version = "0.83.0" }
-deno_doc = "0.1.23"
-deno_lint = "0.2.20"
+deno_doc = "0.2.0"
+deno_lint = "0.3.0"
 deno_runtime = { path = "../runtime", version = "0.10.1" }
 
 atty = "0.2.14"
@@ -46,7 +46,7 @@ clap = "2.33.3"
 dissimilar = "1.0.2"
 dprint-plugin-json = "0.10.1"
 dprint-plugin-markdown = "0.6.2"
-dprint-plugin-typescript = "0.41.0"
+dprint-plugin-typescript = "0.44.0"
 encoding_rs = "0.8.28"
 env_logger = "0.8.3"
 fancy-regex = "0.5.0"
@@ -69,9 +69,9 @@ semver-parser = "0.10.2"
 serde = { version = "1.0.125", features = ["derive"] }
 shell-escape = "0.1.5"
 sourcemap = "6.0.1"
-swc_bundler = "0.25.1"
-swc_common = { version = "0.10.14", features = ["sourcemap"] }
-swc_ecmascript = { version = "0.24.1", features = ["codegen", "dep_graph", "parser", "proposal", "react", "transforms", "typescript", "visit"] }
+swc_bundler = "0.32.0"
+swc_common = { version = "0.10.15", features = ["sourcemap"] }
+swc_ecmascript = { version = "0.31.0", features = ["codegen", "dep_graph", "parser", "proposal", "react", "transforms", "typescript", "visit"] }
 tempfile = "3.2.0"
 termcolor = "1.1.2"
 text-size = "1.1.0"

--- a/cli/ast.rs
+++ b/cli/ast.rs
@@ -254,20 +254,21 @@ impl From<tsc_config::TsConfig> for EmitOptions {
 fn strip_config_from_emit_options(
   options: &EmitOptions,
 ) -> typescript::strip::Config {
-  let mut config = typescript::strip::Config::default();
-  config.import_not_used_as_values = match options.imports_not_used_as_values {
-    ImportsNotUsedAsValues::Remove => {
-      typescript::strip::ImportsNotUsedAsValues::Remove
-    }
-    ImportsNotUsedAsValues::Preserve => {
-      typescript::strip::ImportsNotUsedAsValues::Preserve
-    }
-    // `Error` only affects the type-checking stage. Fall back to `Remove` here.
-    ImportsNotUsedAsValues::Error => {
-      typescript::strip::ImportsNotUsedAsValues::Remove
-    }
-  };
-  config
+  typescript::strip::Config {
+    import_not_used_as_values: match options.imports_not_used_as_values {
+      ImportsNotUsedAsValues::Remove => {
+        typescript::strip::ImportsNotUsedAsValues::Remove
+      }
+      ImportsNotUsedAsValues::Preserve => {
+        typescript::strip::ImportsNotUsedAsValues::Preserve
+      }
+      // `Error` only affects the type-checking stage. Fall back to `Remove` here.
+      ImportsNotUsedAsValues::Error => {
+        typescript::strip::ImportsNotUsedAsValues::Remove
+      }
+    },
+    ..Default::default()
+  }
 }
 
 /// A logical structure to hold the value of a parsed module for further

--- a/cli/ast.rs
+++ b/cli/ast.rs
@@ -257,14 +257,14 @@ fn strip_config_from_emit_options(
   let mut config = typescript::strip::Config::default();
   config.import_not_used_as_values = match options.imports_not_used_as_values {
     ImportsNotUsedAsValues::Remove => {
-      typescript::strip::ImportNotUsedAsValues::Remove
+      typescript::strip::ImportsNotUsedAsValues::Remove
     }
     ImportsNotUsedAsValues::Preserve => {
-      typescript::strip::ImportNotUsedAsValues::Preserve
+      typescript::strip::ImportsNotUsedAsValues::Preserve
     }
     // `Error` only affects the type-checking stage. Fall back to `Remove` here.
     ImportsNotUsedAsValues::Error => {
-      typescript::strip::ImportNotUsedAsValues::Remove
+      typescript::strip::ImportsNotUsedAsValues::Remove
     }
   };
   config

--- a/cli/tests/bundle/fixture13.out
+++ b/cli/tests/bundle/fixture13.out
@@ -9,9 +9,11 @@ function d() {
     return Object.assign(promise, methods);
 }
 class A {
-    s = d();
     a() {
         this.s.resolve();
+    }
+    constructor(){
+        this.s = d();
     }
 }
 new A();

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -4024,14 +4024,14 @@ console.log("finish");
 
     itest!(stdin {
       args: "lint --unstable -",
-      input: Some("let a: any;"),
+      input: Some("let _a: any;"),
       output: "lint/expected_from_stdin.out",
       exit_code: 1,
     });
 
     itest!(stdin_json {
       args: "lint --unstable --json -",
-      input: Some("let a: any;"),
+      input: Some("let _a: any;"),
       output: "lint/expected_from_stdin_json.out",
       exit_code: 1,
     });

--- a/cli/tests/lint/expected_from_stdin_json.out
+++ b/cli/tests/lint/expected_from_stdin_json.out
@@ -4,13 +4,13 @@
       "range": {
         "start": {
           "line": 1,
-          "col": 7,
-          "bytePos": 7
+          "col": 8,
+          "bytePos": 8
         },
         "end": {
           "line": 1,
-          "col": 10,
-          "bytePos": 10
+          "col": 11,
+          "bytePos": 11
         }
       },
       "filename": "_stdin.ts",

--- a/cli/tests/lint/expected_json.out
+++ b/cli/tests/lint/expected_json.out
@@ -40,13 +40,13 @@
       "range": {
         "start": {
           "line": 3,
-          "col": 12,
-          "bytePos": 56
+          "col": 13,
+          "bytePos": 57
         },
         "end": {
           "line": 3,
-          "col": 14,
-          "bytePos": 58
+          "col": 15,
+          "bytePos": 59
         }
       },
       "filename": "[WILDCARD]file2.ts",

--- a/cli/tests/lint/file2.ts
+++ b/cli/tests/lint/file2.ts
@@ -1,6 +1,6 @@
 try {
   await Deno.open("./some/file.txt");
-} catch (e) {}
+} catch (_e) {}
 
 // deno-lint-ignore no-explicit-any
-function foo(): any {}
+function _foo(): any {}

--- a/cli/tests/unit/buffer_test.ts
+++ b/cli/tests/unit/buffer_test.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-deprecated-deno-api
+
 // This code has been ported almost directly from Go's src/bytes/buffer_test.go
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.
 // https://github.com/golang/go/blob/master/LICENSE

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -853,7 +853,7 @@ unitTest(async function consoleTestStringifyPromises(): Promise<void> {
       rej(Error("Whoops"));
     });
     await rejectedPromise;
-  } catch (err) {
+  } catch (_err) {
     // pass
   }
   const strLines = stringify(rejectedPromise).split("\n");
@@ -1478,7 +1478,7 @@ unitTest(function consoleLogShouldNotThrowError(): void {
     try {
       console.log(new Error("foo"));
       result = 1;
-    } catch (e) {
+    } catch (_e) {
       result = 2;
     }
     assertEquals(result, 1);

--- a/cli/tests/unit/dispatch_bin_test.ts
+++ b/cli/tests/unit/dispatch_bin_test.ts
@@ -15,7 +15,6 @@ unitTest(async function sendAsyncStackTrace() {
 });
 
 declare global {
-  // deno-lint-ignore no-namespace
   namespace Deno {
     // deno-lint-ignore no-explicit-any
     var core: any; // eslint-disable-line no-var

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -35,7 +35,7 @@ function findClosedPortInRange(
       const listener = Deno.listen({ port });
       listener.close();
       return port;
-    } catch (e) {
+    } catch (_e) {
       port++;
     }
   }
@@ -792,7 +792,7 @@ unitTest(
       fail(
         "Response.text() didn't throw on a filtered response without a body (type error)",
       );
-    } catch (e) {
+    } catch (_e) {
       return;
     }
   },

--- a/cli/tests/unit/filereader_test.ts
+++ b/cli/tests/unit/filereader_test.ts
@@ -228,7 +228,7 @@ unitTest(
       fr.addEventListener("loadend", () => {
         out += "1";
       });
-      fr.onloadend = (ev): void => {
+      fr.onloadend = (_ev): void => {
         out += "2";
       };
       fr.addEventListener("loadend", () => {

--- a/cli/tests/unit/files_test.ts
+++ b/cli/tests/unit/files_test.ts
@@ -1,4 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-deprecated-deno-api
+
 import {
   assert,
   assertEquals,
@@ -477,7 +480,7 @@ unitTest(
     try {
       const buf = new Uint8Array(20);
       await file.read(buf);
-    } catch (e) {
+    } catch (_e) {
       thrown = true;
     } finally {
       assert(thrown, "'w' mode shouldn't allow to read file");

--- a/cli/tests/unit/globals_test.ts
+++ b/cli/tests/unit/globals_test.ts
@@ -71,7 +71,6 @@ unitTest(function webAssemblyExists(): void {
 });
 
 declare global {
-  // deno-lint-ignore no-namespace
   namespace Deno {
     // deno-lint-ignore no-explicit-any
     var core: any;

--- a/cli/tests/unit/headers_test.ts
+++ b/cli/tests/unit/headers_test.ts
@@ -24,7 +24,7 @@ unitTest(function newHeaderTest(): void {
   try {
     // deno-lint-ignore no-explicit-any
     new Headers(null as any);
-  } catch (e) {
+  } catch (_e) {
     assertEquals(
       e.message,
       "Failed to construct 'Headers'; The provided value was not valid",
@@ -196,48 +196,48 @@ unitTest(function headerIllegalReject(): void {
   let errorCount = 0;
   try {
     new Headers({ "He y": "ok" });
-  } catch (e) {
+  } catch (_e) {
     errorCount++;
   }
   try {
     new Headers({ "Hé-y": "ok" });
-  } catch (e) {
+  } catch (_e) {
     errorCount++;
   }
   try {
     new Headers({ "He-y": "ăk" });
-  } catch (e) {
+  } catch (_e) {
     errorCount++;
   }
   const headers = new Headers();
   try {
     headers.append("Hé-y", "ok");
-  } catch (e) {
+  } catch (_e) {
     errorCount++;
   }
   try {
     headers.delete("Hé-y");
-  } catch (e) {
+  } catch (_e) {
     errorCount++;
   }
   try {
     headers.get("Hé-y");
-  } catch (e) {
+  } catch (_e) {
     errorCount++;
   }
   try {
     headers.has("Hé-y");
-  } catch (e) {
+  } catch (_e) {
     errorCount++;
   }
   try {
     headers.set("Hé-y", "ok");
-  } catch (e) {
+  } catch (_e) {
     errorCount++;
   }
   try {
     headers.set("", "ok");
-  } catch (e) {
+  } catch (_e) {
     errorCount++;
   }
   assertEquals(errorCount, 9);

--- a/cli/tests/unit/headers_test.ts
+++ b/cli/tests/unit/headers_test.ts
@@ -24,7 +24,7 @@ unitTest(function newHeaderTest(): void {
   try {
     // deno-lint-ignore no-explicit-any
     new Headers(null as any);
-  } catch (_e) {
+  } catch (e) {
     assertEquals(
       e.message,
       "Failed to construct 'Headers'; The provided value was not valid",

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -5,8 +5,6 @@ import {
   assertThrowsAsync,
   unitTest,
 } from "./test_util.ts";
-import { BufReader, BufWriter } from "../../../test_util/std/io/bufio.ts";
-import { TextProtoReader } from "../../../test_util/std/textproto/mod.ts";
 
 unitTest({ perms: { net: true } }, async function httpServerBasic() {
   const promise = (async () => {
@@ -178,7 +176,7 @@ unitTest(
       const httpConn = Deno.serveHttp(conn);
       const evt = await httpConn.nextRequest();
       assert(evt);
-      const { request, respondWith } = evt;
+      const { respondWith } = evt;
       await respondWith(new Response("Hello World"));
 
       // TODO(ry) If we don't call httpConn.nextRequest() here we get "error sending

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -298,7 +298,7 @@ unitTest(
     const sendLen = await socket.send(sendBuf, socket.addr);
     assertEquals(sendLen, 3);
 
-    const [recvBuf, recvAddr] = await recvPromise;
+    const [recvBuf, _recvAddr] = await recvPromise;
     assertEquals(recvBuf.length, 3);
     assertEquals(1, recvBuf[0]);
     assertEquals(2, recvBuf[1]);
@@ -375,7 +375,7 @@ unitTest(
     const sendLen = await socket.send(sendBuf, socket.addr);
     assertEquals(sendLen, 3);
 
-    const [recvBuf, recvAddr] = await recvPromise;
+    const [recvBuf, _recvAddr] = await recvPromise;
     assertEquals(recvBuf.length, 3);
     assertEquals(1, recvBuf[0]);
     assertEquals(2, recvBuf[1]);

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -228,6 +228,7 @@ export async function reportToConn(
 ): Promise<void> {
   const line = serializeTestMessage(message);
   const encodedMsg = encoder.encode(line + (message.end == null ? "\n" : ""));
+  // deno-lint-ignore no-deprecated-deno-api
   await Deno.writeAll(conn, encodedMsg);
   if (message.end != null) {
     conn.closeWrite();

--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -34,7 +34,7 @@ unitTest(function atobThrows(): void {
   let threw = false;
   try {
     atob("aGVsbG8gd29ybGQ==");
-  } catch (e) {
+  } catch (_e) {
     threw = true;
   }
   assert(threw);
@@ -44,7 +44,7 @@ unitTest(function atobThrows2(): void {
   let threw = false;
   try {
     atob("aGVsbG8gd29ybGQ===");
-  } catch (e) {
+  } catch (_e) {
     threw = true;
   }
   assert(threw);

--- a/cli/tests/unit/timers_test.ts
+++ b/cli/tests/unit/timers_test.ts
@@ -122,6 +122,7 @@ unitTest(async function timeoutCancelInvalidSilentFail(): Promise<void> {
   // Expect no panic
   const promise = deferred();
   let count = 0;
+  // deno-lint-ignore no-unused-vars
   const id = setTimeout((): void => {
     count++;
     // Should have no effect


### PR DESCRIPTION
Upgrades:
- swc_ecmascript
- swc_bundler
- deno_doc
- deno_lint
- dprint-plugin-typescript