### PR TITLE
fix(runtime/js/timers): Use (0, eval) instead of eval()

### DIFF
--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -21,6 +21,7 @@ export {
   unreachable,
 } from "../../../test_util/std/testing/asserts.ts";
 export { deferred } from "../../../test_util/std/async/deferred.ts";
+export type { Deferred } from "../../../test_util/std/async/deferred.ts";
 export { readLines } from "../../../test_util/std/io/bufio.ts";
 export { parse as parseArgs } from "../../../test_util/std/flags/mod.ts";
 

--- a/runtime/js/11_timers.js
+++ b/runtime/js/11_timers.js
@@ -442,7 +442,7 @@
     if ("function" === typeof callback) {
       callback();
     } else {
-      eval(callback);
+      (0, eval)(callback);
     }
   }
 


### PR DESCRIPTION
Fixes #10091.