### PR TITLE
refactor(op_crates/web): Remove unused code path in TextEncoder

### DIFF
--- a/op_crates/web/08_text_encoding.js
+++ b/op_crates/web/08_text_encoding.js
@@ -4212,25 +4212,8 @@
   class TextEncoder {
     encoding = "utf-8";
     encode(input = "") {
-      input = String(input);
       // Deno.core.encode() provides very efficient utf-8 encoding
-      if (this.encoding === "utf-8") {
-        return core.encode(input);
-      }
-
-      const encoder = new UTF8Encoder();
-      const inputStream = new Stream(stringToCodePoints(input));
-      const output = [];
-
-      while (true) {
-        const result = encoder.handler(inputStream.read());
-        if (result === "finished") {
-          break;
-        }
-        output.push(...result);
-      }
-
-      return new Uint8Array(output);
+      return core.encode(String(input));
     }
     encodeInto(input, dest) {
       if (!(dest instanceof Uint8Array)) {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder, TextEncoder should ignore the "encoding" parameter and always use "utf-8". It seems the current implementation already uses "utf-8" unconditionally.

Even if it didn't, a JS implementation of UTF-8 encoding is used, so it is better to leave only the rust implementation which is more efficient.
