### PR TITLE
feat(core/runtime): Feature gate ICU

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,10 @@ repository = "https://github.com/denoland/deno"
 [lib]
 path = "lib.rs"
 
+[features]
+no_icu = []
+default = []
+
 [dependencies]
 anyhow = "1.0.40"
 futures = "0.3.13"

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -199,11 +199,14 @@ impl JsRuntime {
   pub fn new(mut options: RuntimeOptions) -> Self {
     static DENO_INIT: Once = Once::new();
     DENO_INIT.call_once(|| {
-      // Include 10MB ICU data file.
-      #[repr(C, align(16))]
-      struct IcuData([u8; 10413584]);
-      static ICU_DATA: IcuData = IcuData(*include_bytes!("icudtl.dat"));
-      v8::icu::set_common_data(&ICU_DATA.0).unwrap();
+      #[cfg(not(feature = "no_icu"))]
+      {
+        // Include 10MB ICU data file.
+        #[repr(C, align(16))]
+        struct IcuData([u8; 10413584]);
+        static ICU_DATA: IcuData = IcuData(*include_bytes!("icudtl.dat"));
+        v8::icu::set_common_data(&ICU_DATA.0).unwrap();
+      }
       unsafe { v8_init() };
     });
 


### PR DESCRIPTION
Leverages cargo features to feature gate ICU initialization. By default, the feature is enabled but can be disabled with `features = ["no_icu"]`

Use case: I'm using Deno for [embedding purposes](https://github.com/littledivy/deno_compile) and would like to not inlcude ICU data by default into binaries.