### PR TITLE
inspector: leverage Chrome DevTools' builtin support for NodeJS

### DIFF
--- a/runtime/inspector.rs
+++ b/runtime/inspector.rs
@@ -112,7 +112,7 @@ impl InspectorInfo {
       "faviconUrl": "https://deno.land/favicon.ico",
       "id": self.uuid.to_string(),
       "title": self.get_title(),
-      "type": "deno",
+      "type": "node",
       // TODO(ry): "url": "file://",
       "webSocketDebuggerUrl": self.get_websocket_debugger_url(),
     })
@@ -124,7 +124,7 @@ impl InspectorInfo {
 
   fn get_frontend_url(&self) -> String {
     format!(
-      "devtools://devtools/bundled/inspector.html?v8only=true&ws={}/ws/{}",
+      "devtools://devtools/bundled/js_app.html?ws={}/ws/{}&experiments=true&v8only=true",
       &self.host, &self.uuid
     )
   }


### PR DESCRIPTION
This partially fixes https://github.com/denoland/deno/issues/10113, by allowing Deno to use Chrome's builtin support for debugging NodeJS processes. Longterm we'll want to add first-class Deno support in devtools & chromium.

## Impact

Users are shown a significantly more relevant DevTools view when clicking `inspect` (see screenshots below) and can also use `Open dedicated DevTools for Node` which will open a DevTools window (with relevant views) that auto-attaches to newly spawned inspectable (deno) processes, which is nice.

## Comparison of DevTools views

This compares the view users get when they go to `chrome://inspect` and click on `inspect`.

### Before

You'll notice this view includes web specific tabs such as Elements (DOM), Lighthouse, Application, etc...

![image](https://user-images.githubusercontent.com/949223/114275913-9ab53880-9a24-11eb-8e79-df7539489563.png)

### After

This view now contains only the relevant tabs and (CPU) `Profiler` instead of `Performance`

![image](https://user-images.githubusercontent.com/949223/114275990-039cb080-9a25-11eb-94d3-17c0a09f3094.png)
