### PR TITLE
Reland #9774: Set useDefineForClassFields to true

### DIFF
--- a/cli/ast.rs
+++ b/cli/ast.rs
@@ -267,6 +267,7 @@ fn strip_config_from_emit_options(
         typescript::strip::ImportsNotUsedAsValues::Remove
       }
     },
+    use_define_for_class_fields: true,
     ..Default::default()
   }
 }

--- a/cli/ast.rs
+++ b/cli/ast.rs
@@ -268,7 +268,6 @@ fn strip_config_from_emit_options(
       }
     },
     use_define_for_class_fields: true,
-    ..Default::default()
   }
 }
 

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -372,6 +372,7 @@ impl Inner {
       "noEmit": true,
       "strict": true,
       "target": "esnext",
+      "useDefineForClassFields": true,
     }));
     let (maybe_config, maybe_root_uri) = {
       let config = &self.config;

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -803,6 +803,7 @@ impl Graph {
       "strict": true,
       "target": "esnext",
       "tsBuildInfoFile": "deno:///.tsbuildinfo",
+      "useDefineForClassFields": true,
     }));
     if options.emit {
       config.merge(&json!({
@@ -948,6 +949,7 @@ impl Graph {
       "module": "esnext",
       "strict": true,
       "target": "esnext",
+      "useDefineForClassFields": true,
     }));
     let opts = match options.bundle_type {
       BundleType::Esm | BundleType::Iife => json!({

--- a/cli/tests/091_use_define_for_class_fields.ts
+++ b/cli/tests/091_use_define_for_class_fields.ts
@@ -1,0 +1,4 @@
+class A {
+  b = this.a;
+  constructor(public a: unknown) {}
+}

--- a/cli/tests/091_use_define_for_class_fields.ts.out
+++ b/cli/tests/091_use_define_for_class_fields.ts.out
@@ -1,0 +1,4 @@
+[WILDCARD]error: TS2729 [ERROR]: Property 'a' is used before its initialization.
+  b = this.a;
+           ^
+[WILDCARD]

--- a/cli/tests/bundle/fixture13.out
+++ b/cli/tests/bundle/fixture13.out
@@ -9,11 +9,9 @@ function d() {
     return Object.assign(promise, methods);
 }
 class A {
+    s = d();
     a() {
         this.s.resolve();
-    }
-    constructor(){
-        this.s = d();
     }
 }
 new A();

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2867,6 +2867,12 @@ console.log("finish");
     util::test_pty(args, output, input);
   }
 
+  itest!(_091_use_define_for_class_fields {
+    args: "run 091_use_define_for_class_fields.ts",
+    output: "091_use_define_for_class_fields.ts.out",
+    exit_code: 1,
+  });
+
   itest!(js_import_detect {
     args: "run --quiet --reload js_import_detect.ts",
     output: "js_import_detect.ts.out",

--- a/cli/tsc_config.rs
+++ b/cli/tsc_config.rs
@@ -128,6 +128,7 @@ pub const IGNORED_RUNTIME_COMPILER_OPTIONS: &[&str] = &[
   "traceResolution",
   "tsBuildInfoFile",
   "typeRoots",
+  "useDefineForClassFields",
   "version",
   "watch",
 ];


### PR DESCRIPTION
#9774. The option is now also passed to swc, which supports it as of recently.