### PR TITLE
feat: blob URL support in fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ dependencies = [
  "bytes",
  "data-url",
  "deno_core",
+ "deno_file",
  "http",
  "reqwest",
  "serde",

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -475,7 +475,7 @@ impl FileFetcher {
     }
 
     let blob_url_storage = self.blob_url_store.borrow();
-    let blob = blob_url_storage.get(specifier)?.ok_or_else(|| {
+    let blob = blob_url_storage.get(specifier.clone())?.ok_or_else(|| {
       custom_error(
         "NotFound",
         format!("Blob URL not found: \"{}\".", specifier),

--- a/op_crates/fetch/Cargo.toml
+++ b/op_crates/fetch/Cargo.toml
@@ -17,6 +17,7 @@ path = "lib.rs"
 bytes = "1.0.1"
 data-url = "0.1.0"
 deno_core = { version = "0.83.0", path = "../../core" }
+deno_file = { version = "0.1.0", path = "../file" }
 http = "0.2.3"
 reqwest = { version = "0.11.2", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli"] }
 serde = { version = "1.0.125", features = ["derive"] }

--- a/op_crates/file/lib.rs
+++ b/op_crates/file/lib.rs
@@ -24,9 +24,10 @@ pub struct Location(pub Url);
 pub struct BlobUrlStore(Arc<Mutex<HashMap<Url, Blob>>>);
 
 impl BlobUrlStore {
-  pub fn get(&self, url: &ModuleSpecifier) -> Result<Option<Blob>, AnyError> {
+  pub fn get(&self, mut url: Url) -> Result<Option<Blob>, AnyError> {
     let blob_store = self.0.lock().unwrap();
-    Ok(blob_store.get(url).cloned())
+    url.set_fragment(None);
+    Ok(blob_store.get(&url).cloned())
   }
 
   pub fn insert(&self, blob: Blob, maybe_location: Option<Url>) -> Url {

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -793,7 +793,10 @@
     },
     "fileReader.any.js": true,
     "url": {
-      "url-format.any.js": true
+      "url-format.any.js": true,
+      "url-with-fetch.any.js": [
+        "Revoke blob URL after creating Request, will fetch"
+      ]
     },
     "reading-data-section": {
       "Determining-Encoding.any.js": true,


### PR DESCRIPTION
This commit adds blob URL support in `fetch`. Tested via WPT. This is
the first op_crate to have a rust dependency on a different op_crate.
