### PR TITLE
ci: touch diff from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,10 @@ jobs:
       - name: Restore timestamps
         run: python ./tools/restore_mtime.py
 
+      - name: Touch diff from main
+        shell: bash
+        run: git diff --name-only main HEAD | tee /dev/stderr | xargs touch
+
       # Work around https://github.com/actions/cache/issues/403 by using GNU tar
       # instead of BSD tar.
       - name: Install GNU tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,13 @@ jobs:
 
       - name: Touch diff from main
         shell: bash
-        run: git diff --name-only main HEAD | tee /dev/stderr | xargs touch
+        run: |
+          if git diff --name-only origin/main HEAD --exit-code > diff.txt; then
+            echo No diff from main branch
+          else
+            cat diff.txt
+            cat diff.txt | xargs touch
+          fi
 
       # Work around https://github.com/actions/cache/issues/403 by using GNU tar
       # instead of BSD tar.


### PR DESCRIPTION
The current CI cache has problem with detection of newer source files. If build cache is created after any of branch's commit, cargo failed to detect newer source files, and it causes false negative rebuilding.

To avoid above problem, this workaround touches all files changed from main (`git diff --name-only origin/main HEAD`).

I tested this script in #9376, which once caused the above problem in https://github.com/denoland/deno/runs/2314683208, but fixed with this script in https://github.com/denoland/deno/runs/2316199508 (the build time of windows job took reasonable amount of time, 20 min, about a half of full build.

(alternative approach to https://github.com/denoland/deno/pull/10110)