### PR TITLE
fix: incorrect type for Env.toObject

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -218,7 +218,7 @@ declare namespace Deno {
      * ```
      *
      * Requires `allow-env` permission. */
-    toObject(): { [index: string]: string };
+    toObject(): { [index: string]: string | undefined };
   };
 
   /**


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Since an object is returned it's possible that for a given key there could be no value:

<img width="310" alt="image" src="https://user-images.githubusercontent.com/1379888/114311731-d06f2580-9ae7-11eb-98cf-c5cac6629620.png">
