### PR TITLE
perf(core/ops): avoid allocs when returning primitives

### DIFF
--- a/core/benches/op_baseline.rs
+++ b/core/benches/op_baseline.rs
@@ -4,9 +4,9 @@ use deno_core::error::AnyError;
 use deno_core::op_async;
 use deno_core::op_sync;
 use deno_core::v8;
+use deno_core::serialize_op_result;
 use deno_core::JsRuntime;
 use deno_core::Op;
-use deno_core::OpResponse;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
 
@@ -18,7 +18,7 @@ fn create_js_runtime() -> JsRuntime {
   runtime.register_op("pi_json", op_sync(|_, _: (), _| Ok(314159)));
   runtime.register_op("pi_async", op_async(op_pi_async));
   runtime
-    .register_op("nop", |_, _, _| Op::Sync(OpResponse::Value(Box::new(9))));
+    .register_op("nop", |state, _, _| Op::Sync(serialize_op_result(Ok(9), state)));
 
   // Init ops
   runtime

--- a/core/benches/op_baseline.rs
+++ b/core/benches/op_baseline.rs
@@ -3,8 +3,8 @@ use bencher::{benchmark_group, benchmark_main, Bencher};
 use deno_core::error::AnyError;
 use deno_core::op_async;
 use deno_core::op_sync;
-use deno_core::v8;
 use deno_core::serialize_op_result;
+use deno_core::v8;
 use deno_core::JsRuntime;
 use deno_core::Op;
 use deno_core::OpState;
@@ -17,8 +17,9 @@ fn create_js_runtime() -> JsRuntime {
   let mut runtime = JsRuntime::new(Default::default());
   runtime.register_op("pi_json", op_sync(|_, _: (), _| Ok(314159)));
   runtime.register_op("pi_async", op_async(op_pi_async));
-  runtime
-    .register_op("nop", |state, _, _| Op::Sync(serialize_op_result(Ok(9), state)));
+  runtime.register_op("nop", |state, _, _| {
+    Op::Sync(serialize_op_result(Ok(9), state))
+  });
 
   // Init ops
   runtime

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -5,6 +5,7 @@ mod bindings;
 pub mod error;
 mod flags;
 mod gotham_state;
+mod minvalue;
 mod module_specifier;
 mod modules;
 mod normalize_path;

--- a/core/minvalue.rs
+++ b/core/minvalue.rs
@@ -13,7 +13,6 @@ impl SerializablePkg {
     &self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, serde_v8::Error> {
-    
     match &*self {
       Self::MinValue(x) => serde_v8::to_v8(scope, x),
       Self::Serializable(x) => x.to_v8(scope),
@@ -44,27 +43,27 @@ impl serde::Serialize for MinValue {
   where
     S: serde::Serializer,
   {
-      match *self {
-        Self::Unit(_) => serializer.serialize_unit(),
-        Self::Bool(x) => serializer.serialize_bool(x),
-        Self::Int8(x) => serializer.serialize_i8(x),
-        Self::Int16(x) => serializer.serialize_i16(x),
-        Self::Int32(x) => serializer.serialize_i32(x),
-        Self::Int64(x) => serializer.serialize_i64(x),
-        Self::UInt8(x) => serializer.serialize_u8(x),
-        Self::UInt16(x) => serializer.serialize_u16(x),
-        Self::UInt32(x) => serializer.serialize_u32(x),
-        Self::UInt64(x) => serializer.serialize_u64(x),
-        Self::Float32(x) => serializer.serialize_f32(x),
-        Self::Float64(x) => serializer.serialize_f64(x),
-      }
+    match *self {
+      Self::Unit(_) => serializer.serialize_unit(),
+      Self::Bool(x) => serializer.serialize_bool(x),
+      Self::Int8(x) => serializer.serialize_i8(x),
+      Self::Int16(x) => serializer.serialize_i16(x),
+      Self::Int32(x) => serializer.serialize_i32(x),
+      Self::Int64(x) => serializer.serialize_i64(x),
+      Self::UInt8(x) => serializer.serialize_u8(x),
+      Self::UInt16(x) => serializer.serialize_u16(x),
+      Self::UInt32(x) => serializer.serialize_u32(x),
+      Self::UInt64(x) => serializer.serialize_u64(x),
+      Self::Float32(x) => serializer.serialize_f32(x),
+      Self::Float64(x) => serializer.serialize_f64(x),
+    }
   }
 }
 
 impl<T: serde::Serialize + 'static> From<T> for SerializablePkg {
   fn from(x: T) -> Self {
     let tid = TypeId::of::<T>();
-    
+
     if tid == TypeId::of::<()>() {
       Self::MinValue(MinValue::Unit(()))
     } else if tid == TypeId::of::<bool>() {

--- a/core/minvalue.rs
+++ b/core/minvalue.rs
@@ -1,0 +1,94 @@
+use rusty_v8 as v8;
+use std::any::TypeId;
+
+pub enum SerializablePkg {
+  MinValue(MinValue),
+  Serializable(Box<dyn serde_v8::Serializable>),
+}
+
+impl SerializablePkg {
+  pub fn to_v8<'a>(
+    &self,
+    scope: &mut v8::HandleScope<'a>,
+  ) -> Result<v8::Local<'a, v8::Value>, serde_v8::Error> {
+    
+    match &*self {
+      Self::MinValue(x) => serde_v8::to_v8(scope, x),
+      Self::Serializable(x) => x.to_v8(scope),
+    }
+  }
+}
+
+/// MinValue serves as a lightweight serializable wrapper around primitives
+/// so that we can use them for async values
+#[derive(Clone, Copy)]
+pub enum MinValue {
+  Unit(()),
+  Bool(bool),
+  Int8(i8),
+  Int16(i16),
+  Int32(i32),
+  Int64(i64),
+  UInt8(u8),
+  UInt16(u16),
+  UInt32(u32),
+  UInt64(u64),
+  Float32(f32),
+  Float64(f64),
+}
+
+impl serde::Serialize for MinValue {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+      match *self {
+        Self::Unit(_) => serializer.serialize_unit(),
+        Self::Bool(x) => serializer.serialize_bool(x),
+        Self::Int8(x) => serializer.serialize_i8(x),
+        Self::Int16(x) => serializer.serialize_i16(x),
+        Self::Int32(x) => serializer.serialize_i32(x),
+        Self::Int64(x) => serializer.serialize_i64(x),
+        Self::UInt8(x) => serializer.serialize_u8(x),
+        Self::UInt16(x) => serializer.serialize_u16(x),
+        Self::UInt32(x) => serializer.serialize_u32(x),
+        Self::UInt64(x) => serializer.serialize_u64(x),
+        Self::Float32(x) => serializer.serialize_f32(x),
+        Self::Float64(x) => serializer.serialize_f64(x),
+      }
+  }
+}
+
+impl<T: serde::Serialize + 'static> From<T> for SerializablePkg {
+  fn from(x: T) -> Self {
+    let tid = TypeId::of::<T>();
+    
+    if tid == TypeId::of::<()>() {
+      Self::MinValue(MinValue::Unit(()))
+    } else if tid == TypeId::of::<bool>() {
+      Self::MinValue(MinValue::Bool(unsafe { std::mem::transmute_copy(&x) }))
+    } else if tid == TypeId::of::<i8>() {
+      Self::MinValue(MinValue::Int8(unsafe { std::mem::transmute_copy(&x) }))
+    } else if tid == TypeId::of::<i16>() {
+      Self::MinValue(MinValue::Int16(unsafe { std::mem::transmute_copy(&x) }))
+    } else if tid == TypeId::of::<i32>() {
+      Self::MinValue(MinValue::Int32(unsafe { std::mem::transmute_copy(&x) }))
+    } else if tid == TypeId::of::<i64>() {
+      Self::MinValue(MinValue::Int64(unsafe { std::mem::transmute_copy(&x) }))
+    } else if tid == TypeId::of::<u8>() {
+      Self::MinValue(MinValue::UInt8(unsafe { std::mem::transmute_copy(&x) }))
+    } else if tid == TypeId::of::<u16>() {
+      Self::MinValue(MinValue::UInt16(unsafe { std::mem::transmute_copy(&x) }))
+    } else if tid == TypeId::of::<u32>() {
+      Self::MinValue(MinValue::UInt32(unsafe { std::mem::transmute_copy(&x) }))
+    } else if tid == TypeId::of::<u64>() {
+      Self::MinValue(MinValue::UInt64(unsafe { std::mem::transmute_copy(&x) }))
+    } else if tid == TypeId::of::<f32>() {
+      Self::MinValue(MinValue::Float32(unsafe { std::mem::transmute_copy(&x) }))
+    } else if tid == TypeId::of::<f64>() {
+      Self::MinValue(MinValue::Float64(unsafe { std::mem::transmute_copy(&x) }))
+    } else {
+      Self::Serializable(Box::new(x))
+    }
+  }
+}

--- a/core/minvalue.rs
+++ b/core/minvalue.rs
@@ -1,6 +1,8 @@
 use rusty_v8 as v8;
 use std::any::TypeId;
 
+/// SerializablePkg exists to provide a fast path for op returns,
+/// allowing them to avoid boxing primtives (ints/floats/bool/unit/...)
 pub enum SerializablePkg {
   MinValue(MinValue),
   Serializable(Box<dyn serde_v8::Serializable>),

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -85,7 +85,6 @@ impl OpResult {
     &self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, serde_v8::Error> {
-    
     match self {
       Self::Ok(x) => x.to_v8(scope),
       Self::Err(err) => serde_v8::to_v8(scope, err),


### PR DESCRIPTION
This introduces `SerializablePkg` and `MinValue` as a fastpath for ops that return primitives, allowing us to save an alloc/free per opcall. This reduces async-op baseline overhead by ~20% or ~100ns/opcall.

⚠️ **Warning:** This uses `unsafe` code (`std::mem::transmute_copy`) and TypeId checks in lieu of specialization to detect primitives and opt-in to the fast path

## Benches

```
Before:
test bench_op_async   ... bench:     489,671 ns/iter (+/- 8,368)
test bench_op_nop     ... bench:      71,506 ns/iter (+/- 1,612)
test bench_op_pi_json ... bench:      84,846 ns/iter (+/- 1,464)

After:
test bench_op_async   ... bench:     384,175 ns/iter (+/- 7,553)
test bench_op_nop     ... bench:      47,984 ns/iter (+/- 2,083)
test bench_op_pi_json ... bench:      59,100 ns/iter (+/- 1,868)
```