### PR TITLE
perf: lazy header instantiation for HTTP requests

### DIFF
--- a/runtime/js/40_http.js
+++ b/runtime/js/40_http.js
@@ -2,7 +2,7 @@
 "use strict";
 
 ((window) => {
-  const { Request, dontValidateUrl, fastBody, Response } =
+  const { Request, dontValidateUrl, lazyHeaders, fastBody, Response } =
     window.__bootstrap.fetch;
   const { Headers } = window.__bootstrap.headers;
   const errors = window.__bootstrap.errors.errors;
@@ -61,8 +61,9 @@
       const request = new Request(url, {
         body,
         method,
-        headers: new Headers(headersList),
+        headers: headersList,
         [dontValidateUrl]: true,
+        [lazyHeaders]: true,
       });
 
       const respondWith = createRespondWith(responseSenderRid, this.#rid);


### PR DESCRIPTION
This commit introduces a performance optimization for the native HTTP
server. From my testing it is about 2-6% faster than `main`. Request
headers in the HTTP servers are now lazilly instatated when they are
accessed, rather than being preemptively wrapped in the `Headers` class.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
