### PR TITLE
perf: make bench script more efficient

### DIFF
--- a/cli/bench/deno_http_native.js
+++ b/cli/bench/deno_http_native.js
@@ -6,12 +6,13 @@ const listener = Deno.listen({ hostname, port: Number(port) });
 console.log("Server listening on", addr);
 
 const body = Deno.core.encode("Hello World");
+const response = new Response(body);
 
 for await (const conn of listener) {
   (async () => {
     const requests = Deno.serveHttp(conn);
     for await (const { respondWith } of requests) {
-      respondWith(new Response(body));
+      respondWith(response);
     }
   })();
 }

--- a/cli/bench/node_http.js
+++ b/cli/bench/node_http.js
@@ -2,8 +2,9 @@
 const http = require("http");
 const port = process.argv[2] || "4544";
 console.log("port", port);
+const body = "Hello World";
 http
   .Server((req, res) => {
-    res.end("Hello World");
+    res.end(body);
   })
   .listen(port);


### PR DESCRIPTION
This only creates one response that is used to respond to all incoming
requests in the benchmark. This would break for streaming responses, but
this is not a streaming response, so who gives :shrug:.
