### PR TITLE
perf(fetch): optimize normalizeMethod()

### DIFF
--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -919,7 +919,7 @@
   function byteUpperCase(s) {
   return String(s).replace(/[a-z]/g, function byteUpperCaseReplace(c) {
     return c.toUpperCase();
-  });
+  };
   
   /**
    * @param {string} m

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -913,6 +913,15 @@
   const REDIRECT_STATUS = [301, 302, 303, 307, 308];
 
   /**
+   * @param {string} s
+   * @returns {string}
+   */
+  function byteUpperCase(s) {
+  return String(s).replace(/[a-z]/g, function byteUpperCaseReplace(c) {
+    return c.toUpperCase();
+  });
+  
+  /**
    * @param {string} m
    * @returns {boolean}
    */
@@ -936,8 +945,8 @@
     if (isKnownMethod(m)) {
       return m;
     }
-    // Normalize lower case
-    const u = m.toUpperCase();
+    // Normalize lower case (slowpath and should be avoided ...)
+    const u = byteUpperCase(m);
     if (isKnownMethod(u)) {
       return u;
     }

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -913,13 +913,18 @@
   const REDIRECT_STATUS = [301, 302, 303, 307, 308];
 
   /**
-   * @param {string} s
-   * @returns {string}
+   * @param {string} m
+   * @returns {boolean}
    */
-  function byteUpperCase(s) {
-    return String(s).replace(/[a-z]/g, function byteUpperCaseReplace(c) {
-      return c.toUpperCase();
-    });
+  function isKnownMethod(m) {
+    return (
+      m === "DELETE" ||
+      m === "GET" ||
+      m === "HEAD" ||
+      m === "OPTIONS" ||
+      m === "POST" ||
+      m === "PUT"
+    );
   }
 
   /**
@@ -927,17 +932,16 @@
    * @returns {string}
    */
   function normalizeMethod(m) {
-    const u = byteUpperCase(m);
-    if (
-      u === "DELETE" ||
-      u === "GET" ||
-      u === "HEAD" ||
-      u === "OPTIONS" ||
-      u === "POST" ||
-      u === "PUT"
-    ) {
+    // Fast path for already valid methods
+    if (isKnownMethod(m)) {
+      return m;
+    }
+    // Normalize lower case
+    const u = m.toUpperCase();
+    if (isKnownMethod(u)) {
       return u;
     }
+    // Otherwise passthrough
     return m;
   }
 

--- a/op_crates/fetch/26_fetch.js
+++ b/op_crates/fetch/26_fetch.js
@@ -917,10 +917,11 @@
    * @returns {string}
    */
   function byteUpperCase(s) {
-  return String(s).replace(/[a-z]/g, function byteUpperCaseReplace(c) {
-    return c.toUpperCase();
-  };
-  
+    return String(s).replace(/[a-z]/g, function byteUpperCaseReplace(c) {
+      return c.toUpperCase();
+    });
+  }
+
   /**
    * @param {string} m
    * @returns {boolean}


### PR DESCRIPTION
Which was unnecessarily wasteful and taking up 5% of the JS CPU time in the `deno_http_native` bench.

It's not clear why `byteUpperCase()` was useful, especially since we only return the uppercased method if it matches a whitelist of unambiguous strings.