### PR TITLE
perf(js/http): avoid v8 deopt in async iterator

### DIFF
--- a/runtime/js/40_http.js
+++ b/runtime/js/40_http.js
@@ -81,6 +81,7 @@
       return {
         async next() {
           const reqEvt = await httpConn.nextRequest();
+          // Change with caution, current form avoids a v8 deopt
           return { value: reqEvt, done: reqEvt === null };
         },
       };

--- a/runtime/js/40_http.js
+++ b/runtime/js/40_http.js
@@ -81,8 +81,7 @@
       return {
         async next() {
           const reqEvt = await httpConn.nextRequest();
-          if (reqEvt === null) return { value: undefined, done: true };
-          return { value: reqEvt, done: false };
+          return { value: reqEvt, done: reqEvt === null };
         },
       };
     }


### PR DESCRIPTION
## Previous bailout reason

```
[bailout (kind: deopt-soft, reason: Insufficient type feedback for generic named access): begin. deoptimizing 0x21fa08605435 <JSFunction next (sfi = 0x21fa0840e5e5)>, opt id 10, bytecode offset 76, deopt exit 2, FP to SP delta 64, caller SP 0x00016b5902b8, pc 0x21fa000901bc]
            ;;; deoptimize at <deno:runtime/js/40_http.js:84:48>
```

## Notes

- There's still at least another v8 deopt in the http callstack, that I haven't optimized yet