### PR TITLE
feat(cli): raise file descriptor limit on startup

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -36,6 +36,7 @@ mod tokio_util;
 mod tools;
 mod tsc;
 mod tsc_config;
+mod unix_util;
 mod version;
 
 use crate::file_fetcher::File;
@@ -1176,6 +1177,7 @@ fn unwrap_or_exit<T>(result: Result<T, AnyError>) -> T {
 pub fn main() {
   #[cfg(windows)]
   colors::enable_ansi(); // For Windows 10
+  unix_util::raise_fd_limit();
 
   let args: Vec<String> = env::args().collect();
   let standalone_res = match standalone::extract_standalone(args.clone()) {

--- a/cli/main_runtime.rs
+++ b/cli/main_runtime.rs
@@ -5,6 +5,7 @@
 mod colors;
 mod standalone;
 mod tokio_util;
+mod unix_util;
 mod version;
 
 use deno_core::error::anyhow;
@@ -14,6 +15,7 @@ use std::env;
 pub fn main() {
   #[cfg(windows)]
   colors::enable_ansi(); // For Windows 10
+  unix_util::raise_fd_limit();
 
   let args: Vec<String> = env::args().collect();
   if let Err(err) = run(args) {

--- a/cli/unix_util.rs
+++ b/cli/unix_util.rs
@@ -1,0 +1,41 @@
+/// Raise soft file descriptor limit to hard file descriptor limit.
+/// This is the difference between `ulimit -n` and `ulimit -n -H`.
+pub fn raise_fd_limit() {
+  #[cfg(unix)]
+  unsafe {
+    let mut limits = libc::rlimit {
+      rlim_cur: 0,
+      rlim_max: 0,
+    };
+
+    if 0 != libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) {
+      return;
+    }
+
+    if limits.rlim_cur == libc::RLIM_INFINITY {
+      return;
+    }
+
+    // No hard limit? Do a binary search for the effective soft limit.
+    if limits.rlim_max == libc::RLIM_INFINITY {
+      let mut min = limits.rlim_cur;
+      let mut max = 1 << 20;
+
+      while min + 1 < max {
+        limits.rlim_cur = min + (max - min) / 2;
+        match libc::setrlimit(libc::RLIMIT_NOFILE, &limits) {
+          0 => min = limits.rlim_cur,
+          _ => max = limits.rlim_cur,
+        }
+      }
+
+      return;
+    }
+
+    // Raise the soft limit to the hard limit.
+    if limits.rlim_cur < limits.rlim_max {
+      limits.rlim_cur = limits.rlim_max;
+      libc::setrlimit(libc::RLIMIT_NOFILE, &limits);
+    }
+  }
+}


### PR DESCRIPTION
Raise the soft limit to the hard limit when possible. This is similar
to what Node.js does to avoid running into "out of file descriptors"
errors too quickly.

On most Linux systems, raises the limit from 1,024 to 1,048,576.
On most macOS systems, raises the limit from 256 to 10,240.

Fixes #10148.