### PR TITLE
refactor(deno_http_native): pass string directly to Response

### DIFF
--- a/cli/bench/deno_http_native.js
+++ b/cli/bench/deno_http_native.js
@@ -5,13 +5,11 @@ const [hostname, port] = addr.split(":");
 const listener = Deno.listen({ hostname, port: Number(port) });
 console.log("Server listening on", addr);
 
-const body = Deno.core.encode("Hello World");
-
 for await (const conn of listener) {
   (async () => {
     const requests = Deno.serveHttp(conn);
     for await (const { respondWith } of requests) {
-      respondWith(new Response(body));
+      respondWith(new Response("Hello World"));
     }
   })();
 }


### PR DESCRIPTION
We can pass a string as a body to [`new Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response). This PR updates the deno_http_native.js script under cli/bench.