### PR TITLE
fix(#10200): weaken  types so non-breaking

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1726,18 +1726,20 @@ declare namespace Deno {
    * Requires `allow-write` permission. */
   export function truncate(name: string, len?: number): Promise<void>;
 
-  export interface NetAddr {
+  export interface Addr {
+    transport: string;
+  }
+
+  export interface NetAddr extends Addr {
     transport: "tcp" | "udp";
     hostname: string;
     port: number;
   }
 
-  export interface UnixAddr {
+  export interface UnixAddr extends Addr {
     transport: "unix" | "unixpacket";
     path: string;
   }
-
-  export type Addr = NetAddr | UnixAddr;
 
   /** A generic network listener for stream-oriented protocols. */
   export interface Listener<Address extends Addr = Addr>

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1000,7 +1000,7 @@ declare namespace Deno {
    * Requires `allow-net` permission.
    */
   export function startTls(
-    conn: Conn<NetAddr>,
+    conn: Conn,
     options?: StartTlsOptions,
   ): Promise<Conn<NetAddr>>;
 

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -874,23 +874,26 @@ declare namespace Deno {
   /** **UNSTABLE**: new API, yet to be vetted.
    *
    * A generic transport listener for message-oriented protocols. */
-  export interface DatagramConn extends AsyncIterable<[Uint8Array, Addr]> {
+  export interface DatagramConn<Address extends Addr = Addr>
+    extends AsyncIterable<[Uint8Array, Address]> {
     /** **UNSTABLE**: new API, yet to be vetted.
      *
      * Waits for and resolves to the next message to the `UDPConn`. */
-    receive(p?: Uint8Array): Promise<[Uint8Array, Addr]>;
+    receive(p?: Uint8Array): Promise<[Uint8Array, Address]>;
     /** UNSTABLE: new API, yet to be vetted.
      *
      * Sends a message to the target. */
-    send(p: Uint8Array, addr: Addr): Promise<number>;
+    send(p: Uint8Array, addr: Address): Promise<number>;
     /** UNSTABLE: new API, yet to be vetted.
      *
      * Close closes the socket. Any pending message promises will be rejected
      * with errors. */
     close(): void;
     /** Return the address of the `UDPConn`. */
-    readonly addr: Addr;
-    [Symbol.asyncIterator](): AsyncIterableIterator<[Uint8Array, Addr]>;
+    readonly addr: Address;
+    [Symbol.asyncIterator](): AsyncIterableIterator<
+      [Uint8Array, Address]
+    >;
   }
 
   export interface UnixListenOptions {
@@ -930,7 +933,7 @@ declare namespace Deno {
    * Requires `allow-net` permission. */
   export function listenDatagram(
     options: ListenOptions & { transport: "udp" },
-  ): DatagramConn;
+  ): DatagramConn<NetAddr>;
 
   /** **UNSTABLE**: new API, yet to be vetted
    *
@@ -946,7 +949,7 @@ declare namespace Deno {
    * Requires `allow-read` and `allow-write` permission. */
   export function listenDatagram(
     options: UnixListenOptions & { transport: "unixpacket" },
-  ): DatagramConn;
+  ): DatagramConn<UnixAddr>;
 
   export interface UnixConnectOptions {
     transport: "unix";

--- a/runtime/js/40_tls.js
+++ b/runtime/js/40_tls.js
@@ -68,6 +68,12 @@
     conn,
     { hostname = "127.0.0.1", certFile } = {},
   ) {
+    if (
+      !(conn.localAddr.transport === "tcp" ||
+        conn.localAddr.transport === "udp")
+    ) {
+      throw new TypeError(`conn is not a valid network connection`);
+    }
     const res = await opStartTls({
       rid: conn.rid,
       hostname,


### PR DESCRIPTION
Fixes #10200 by widening the type accepted by `Deno.startTls()`.  There is an extra runtime guard to compensate for the weakend types.