### PR TITLE
fix(runtime): add http op to webworker

### DIFF
--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -259,6 +259,7 @@ impl WebWorker {
         ops::signal::init(js_runtime);
         ops::tls::init(js_runtime);
         ops::tty::init(js_runtime);
+        ops::http::init(js_runtime);
 
         let op_state = js_runtime.op_state();
         let mut op_state = op_state.borrow_mut();


### PR DESCRIPTION
Fixes #10192 
Seeing two tests fail:

> failures:
>     tools::installer::tests::install_unicode
>     tools::test_runner::tests::supports_dirs

but also failing on main so might be something with my vm.
To test I ran the provided example and curled the port and saw the `Hello world` response.

P.S. Just getting feet wet with Rust and open source :) 
