### PR TITLE
lint(cli/lsp): fix 2 lint errors

### DIFF
--- a/cli/lsp/registries.rs
+++ b/cli/lsp/registries.rs
@@ -493,8 +493,8 @@ impl ModuleRegistry {
                               label,
                               kind,
                               detail,
-                              filter_text,
                               sort_text,
+                              filter_text,
                               text_edit,
                               command,
                               ..Default::default()
@@ -958,7 +958,7 @@ mod tests {
     let actual = parse_replacement_variables(
       "https://deno.land/_vsc1/modules/${module}/v/${{version}}",
     );
-    assert_eq!(actual.iter().count(), 2);
+    assert_eq!(actual.len(), 2);
     assert!(actual.contains(&"module".to_owned()));
     assert!(actual.contains(&"version".to_owned()));
   }


### PR DESCRIPTION
1. error: called `.iter().count()` on a `Vec`
  (https://rust-lang.github.io/rust-clippy/master/index.html#iter_count)
2. error: inconsistent struct constructor
  (https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor)