### PR TITLE
refactor(core): remove ZeroCopyBuf's dep on the bindings mod

### DIFF
--- a/core/zero_copy_buf.rs
+++ b/core/zero_copy_buf.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use crate::bindings;
 use rusty_v8 as v8;
+use std::cell::Cell;
 use std::ops::Deref;
 use std::ops::DerefMut;
 
@@ -45,7 +45,7 @@ impl Deref for ZeroCopyBuf {
   type Target = [u8];
   fn deref(&self) -> &[u8] {
     unsafe {
-      bindings::get_backing_store_slice(
+      get_backing_store_slice(
         &self.backing_store,
         self.byte_offset,
         self.byte_length,
@@ -57,7 +57,7 @@ impl Deref for ZeroCopyBuf {
 impl DerefMut for ZeroCopyBuf {
   fn deref_mut(&mut self) -> &mut [u8] {
     unsafe {
-      bindings::get_backing_store_slice_mut(
+      get_backing_store_slice_mut(
         &self.backing_store,
         self.byte_offset,
         self.byte_length,
@@ -76,4 +76,27 @@ impl AsMut<[u8]> for ZeroCopyBuf {
   fn as_mut(&mut self) -> &mut [u8] {
     &mut *self
   }
+}
+
+unsafe fn get_backing_store_slice(
+  backing_store: &v8::SharedRef<v8::BackingStore>,
+  byte_offset: usize,
+  byte_length: usize,
+) -> &[u8] {
+  let cells: *const [Cell<u8>] =
+    &backing_store[byte_offset..byte_offset + byte_length];
+  let bytes = cells as *const [u8];
+  &*bytes
+}
+
+#[allow(clippy::mut_from_ref)]
+unsafe fn get_backing_store_slice_mut(
+  backing_store: &v8::SharedRef<v8::BackingStore>,
+  byte_offset: usize,
+  byte_length: usize,
+) -> &mut [u8] {
+  let cells: *const [Cell<u8>] =
+    &backing_store[byte_offset..byte_offset + byte_length];
+  let bytes = cells as *const _ as *mut [u8];
+  &mut *bytes
 }


### PR DESCRIPTION
Also cleanup `bindings::deserialize()/decode()` so they use the `ZeroCopyBuf` abstraction rather than reimplementing it

This cleanup will facilitate moving `ZeroCopyBuf` to `serde_v8` since it's now self contained and there are no other `get_backing_store_slice()` callers