### PR TITLE
fix: do not panic on not found cwd

### DIFF
--- a/cli/fs_util.rs
+++ b/cli/fs_util.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::AnyError;
+use deno_core::error::Context;
 pub use deno_core::normalize_path;
 use deno_runtime::deno_crypto::rand;
 use std::env::current_dir;
@@ -81,7 +82,8 @@ pub fn resolve_from_cwd(path: &Path) -> Result<PathBuf, AnyError> {
   let resolved_path = if path.is_absolute() {
     path.to_owned()
   } else {
-    let cwd = current_dir().unwrap();
+    let cwd =
+      current_dir().context("Failed to get current working directory")?;
     cwd.join(path)
   };
 

--- a/cli/tests/dont_panic_not_found_cwd.ts
+++ b/cli/tests/dont_panic_not_found_cwd.ts
@@ -1,0 +1,3 @@
+const dir = Deno.makeTempDirSync();
+Deno.chdir(dir);
+Deno.removeSync(dir);

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -5138,6 +5138,25 @@ console.log("finish");
     assert!(stderr.contains("BadResource"));
   }
 
+  #[cfg(not(windows))]
+  #[test]
+  fn should_not_panic_on_not_found_cwd() {
+    let output = util::deno_cmd()
+      .current_dir(util::root_path())
+      .arg("run")
+      .arg("--allow-write")
+      .arg("--allow-read")
+      .arg("cli/tests/dont_panic_not_found_cwd.ts")
+      .stderr(std::process::Stdio::piped())
+      .spawn()
+      .unwrap()
+      .wait_with_output()
+      .unwrap();
+    assert!(!output.status.success());
+    let stderr = std::str::from_utf8(&output.stderr).unwrap().trim();
+    assert!(stderr.contains("Failed to get current working directory"));
+  }
+
   #[cfg(windows)]
   // Clippy suggests to remove the `NoStd` prefix from all variants. I disagree.
   #[allow(clippy::enum_variant_names)]

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -3,6 +3,7 @@ use crate::flags::Flags;
 use crate::fs_util::canonicalize_path;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
+use deno_core::error::Context;
 use deno_core::url::Url;
 use log::Level;
 use regex::Regex;
@@ -175,7 +176,8 @@ pub fn install(
     let module_path = if module_path.is_absolute() {
       module_path
     } else {
-      let cwd = env::current_dir().unwrap();
+      let cwd = env::current_dir()
+        .context("Failed to get current working directory")?;
       cwd.join(module_path)
     };
     Url::from_file_path(module_path).expect("Path should be absolute")

--- a/runtime/fs_util.rs
+++ b/runtime/fs_util.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::AnyError;
+use deno_core::error::Context;
 pub use deno_core::normalize_path;
 use std::env::current_dir;
 use std::io::Error;
@@ -24,7 +25,8 @@ pub fn resolve_from_cwd(path: &Path) -> Result<PathBuf, AnyError> {
   let resolved_path = if path.is_absolute() {
     path.to_owned()
   } else {
-    let cwd = current_dir().unwrap();
+    let cwd =
+      current_dir().context("Failed to get current working directory")?;
     cwd.join(path)
   };
 

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -5,6 +5,7 @@ use crate::metrics::RuntimeMetrics;
 use crate::ops::UnstableChecker;
 use crate::permissions::Permissions;
 use deno_core::error::AnyError;
+use deno_core::error::Context;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::ModuleSpecifier;
@@ -29,7 +30,9 @@ fn op_main_module(
   let main = state.borrow::<ModuleSpecifier>().to_string();
   let main_url = deno_core::resolve_url_or_path(&main)?;
   if main_url.scheme() == "file" {
-    let main_path = std::env::current_dir().unwrap().join(main_url.to_string());
+    let main_path = std::env::current_dir()
+      .context("Failed to get current working directory")?
+      .join(main_url.to_string());
     state
       .borrow_mut::<Permissions>()
       .read

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -8,6 +8,7 @@ use crate::ops;
 use crate::permissions::Permissions;
 use crate::tokio_util::create_basic_runtime;
 use deno_core::error::AnyError;
+use deno_core::error::Context as ErrorContext;
 use deno_core::futures::channel::mpsc;
 use deno_core::futures::future::poll_fn;
 use deno_core::futures::future::FutureExt;
@@ -311,7 +312,9 @@ impl WebWorker {
 
   /// Same as execute2() but the filename defaults to "$CWD/__anonymous__".
   pub fn execute(&mut self, js_source: &str) -> Result<(), AnyError> {
-    let path = env::current_dir().unwrap().join("__anonymous__");
+    let path = env::current_dir()
+      .context("Failed to get current working directory")?
+      .join("__anonymous__");
     let url = Url::from_file_path(path).unwrap();
     self.js_runtime.execute(url.as_str(), js_source)
   }

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -8,6 +8,7 @@ use crate::metrics::RuntimeMetrics;
 use crate::ops;
 use crate::permissions::Permissions;
 use deno_core::error::AnyError;
+use deno_core::error::Context as ErrorContext;
 use deno_core::futures::future::poll_fn;
 use deno_core::futures::future::FutureExt;
 use deno_core::futures::stream::StreamExt;
@@ -201,7 +202,9 @@ impl MainWorker {
 
   /// Same as execute2() but the filename defaults to "$CWD/__anonymous__".
   pub fn execute(&mut self, js_source: &str) -> Result<(), AnyError> {
-    let path = env::current_dir().unwrap().join("__anonymous__");
+    let path = env::current_dir()
+      .context("Failed to get current working directory")?
+      .join("__anonymous__");
     let url = Url::from_file_path(path).unwrap();
     self.js_runtime.execute(url.as_str(), js_source)
   }


### PR DESCRIPTION
This PR replaces all instances of `current_dir().unwrap()` with `current_dir()?` except the ones in the tests and `core/module_sepcifier.rs`.

Closes https://github.com/denoland/deno/issues/9840
