### PR TITLE
fix(runtime): handle race condition in postMessage where worker has terminated but termination message has not been recieved

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2497,6 +2497,12 @@ console.log("finish");
     exit_code: 1,
   });
 
+  itest!(nonexistent_worker {
+    args: "run --allow-read workers/nonexistent_worker.ts",
+    output: "workers/nonexistent_worker.out",
+    exit_code: 1,
+  });
+
   #[test]
   fn compiler_api() {
     let status = util::deno_cmd()

--- a/cli/tests/workers/nonexistent_worker.out
+++ b/cli/tests/workers/nonexistent_worker.out
@@ -1,0 +1,3 @@
+[WILDCARD]error: Uncaught (in worker "") Cannot resolve module "file:///[WILDCARD]cli/tests/workers/doesnt_exist.js".
+error: Uncaught (in promise) Error: Unhandled error event reached main worker.
+    at Worker.#poll ([WILDCARD])

--- a/cli/tests/workers/nonexistent_worker.ts
+++ b/cli/tests/workers/nonexistent_worker.ts
@@ -1,0 +1,5 @@
+const w = new Worker(new URL("doesnt_exist.js", import.meta.url).href, {
+  type: "module",
+});
+
+w.postMessage("hello");

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -67,6 +67,14 @@ impl WebWorkerHandle {
   /// Post message to worker as a host.
   pub fn post_message(&self, buf: Box<[u8]>) -> Result<(), AnyError> {
     let mut sender = self.sender.clone();
+    // If the channel is closed,
+    // the worker must have terminated but the termination message has not yet been recieved.
+    //
+    // Therefore just treat it as if the worker has terminated and return.
+    if sender.is_closed() {
+      self.terminated.store(true, Ordering::SeqCst);
+      return Ok(());
+    }
     sender.try_send(buf)?;
     Ok(())
   }


### PR DESCRIPTION
Fixes #10235

The panic was caused by the lack of an error class mapping for `futures::channel::TrySendError`, but it shouldn't have been throwing an error in the first place - when a worker has terminated, `postMessage` should just return. The issue was that the termination message hadn't yet been recieved, so it was carrying on with trying to send the message. This adds another check on the Rust side for if the channel is closed, and if it is the worker is treated as terminated.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
