### PR TITLE
cleanup(cli): use runtime's reg_sync() and reg_async()

### DIFF
--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -3,30 +3,4 @@
 pub mod errors;
 pub mod runtime_compiler;
 
-use deno_core::error::AnyError;
-use deno_core::op_async;
-use deno_core::op_sync;
-use deno_core::serde_json::Value;
-use deno_core::JsRuntime;
-use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
-use deno_runtime::metrics::metrics_op;
-use std::cell::RefCell;
-use std::future::Future;
-use std::rc::Rc;
-
-pub fn reg_async<F, R>(rt: &mut JsRuntime, name: &'static str, op_fn: F)
-where
-  F: Fn(Rc<RefCell<OpState>>, Value, Option<ZeroCopyBuf>) -> R + 'static,
-  R: Future<Output = Result<Value, AnyError>> + 'static,
-{
-  rt.register_op(name, metrics_op(name, op_async(op_fn)));
-}
-
-pub fn reg_sync<F>(rt: &mut JsRuntime, name: &'static str, op_fn: F)
-where
-  F: Fn(&mut OpState, Value, Option<ZeroCopyBuf>) -> Result<Value, AnyError>
-    + 'static,
-{
-  rt.register_op(name, metrics_op(name, op_sync(op_fn)));
-}
+pub use deno_runtime::ops::{reg_async, reg_sync};


### PR DESCRIPTION
These functions were unnecessarily duplicated