### PR TITLE
bench(url): basic url_ops bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
 name = "deno_url"
 version = "0.3.0"
 dependencies = [
+ "bench_util",
  "deno_core",
  "idna",
  "serde",

--- a/op_crates/url/Cargo.toml
+++ b/op_crates/url/Cargo.toml
@@ -17,3 +17,10 @@ path = "lib.rs"
 deno_core = { version = "0.84.0", path = "../../core" }
 idna = "0.2.2"
 serde = { version = "1.0.125", features = ["derive"] }
+
+[dev-dependencies]
+bench_util = { version = "0.0.0", path = "../../bench_util" }
+
+[[bench]]
+name = "url_ops"
+harness = false

--- a/op_crates/url/benches/url_ops.rs
+++ b/op_crates/url/benches/url_ops.rs
@@ -1,0 +1,29 @@
+use deno_core::op_sync;
+use deno_core::JsRuntime;
+
+use bench_util::bench_js_sync;
+use bench_util::bench_or_profile;
+use bench_util::bencher::{benchmark_group, Bencher};
+
+fn setup(rt: &mut JsRuntime) {
+  rt.register_op("op_url_parse", op_sync(deno_url::op_url_parse));
+  rt.register_op(
+    "op_url_parse_search_params",
+    op_sync(deno_url::op_url_parse_search_params),
+  );
+  rt.register_op(
+    "op_url_stringify_search_params",
+    op_sync(deno_url::op_url_stringify_search_params),
+  );
+
+  deno_url::init(rt);
+  rt.execute("setup", "const { URL } = globalThis.__bootstrap.url;")
+    .unwrap();
+}
+
+fn bench_url_parse(b: &mut Bencher) {
+  bench_js_sync(b, r#"new URL(`http://www.google.com/${i}`);"#, setup);
+}
+
+benchmark_group!(benches, bench_url_parse,);
+bench_or_profile!(benches);


### PR DESCRIPTION
This PR adds url parsing benches in `op_crates/url` named `url_ops`, which allow for scoped & fast iteration on url parsing performance (since the builds take ~30x less time to build than full deno bins).

This does a decent job at showcasing `bench_util` (#10223) outside of `op_baseline` and how in ~30 lines you can put together benches to track op performance that also generate clean profiles when `flamebench`'d.

## Sample output

```
test bench_url_parse ... bench:   5,822,207 ns/iter (+/- 231,035)
```

**Note:** this follows the same convention of 1000 real iters per bench iter as `op_baseline`, so just right shift 3 digits when reading these results.

As a sanity check we can see that these benches ~match the output of `deno_common`:

```
url_parse:           	n = 50000, dt = 0.290s, r = 172414/s, t = 5799ns/op
```