### PR TITLE
build: use split-debuginfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ exclude = [
   "std/hash/_wasm"
 ]
 
+[profile.dev]
+split-debuginfo = "unpacked"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Stumbled upon in https://jakedeichert.com/blog/reducing-rust-incremental-compilation-times-on-macos-by-70-percent/

It lowers incremental debug build from about 1m10s to 30s on my machine.