### PR TITLE
docs(manual/wasm): add more example code.

### DIFF
--- a/docs/getting_started/webassembly.md
+++ b/docs/getting_started/webassembly.md
@@ -20,3 +20,19 @@ const wasmInstance = new WebAssembly.Instance(wasmModule);
 const main = wasmInstance.exports.main as CallableFunction
 console.log(main().toString());
 ```
+
+And for files:
+
+<!-- deno-fmt-ignore -->
+
+```ts
+import { readAll } from "https://deno.land/std@0.93.0/io/util.ts";
+
+const file = await Deno.open("main.wasm");
+const wasmCode = await readAll(file);
+Deno.close(file.rid);
+const wasmModule = new WebAssembly.Module(wasmCode);
+const wasmInstance = new WebAssembly.Instance(wasmModule);
+const main = wasmInstance.exports.main as CallableFunction
+console.log(main().toString());
+```

--- a/docs/getting_started/webassembly.md
+++ b/docs/getting_started/webassembly.md
@@ -23,8 +23,6 @@ console.log(main().toString());
 
 And for files:
 
-<!-- deno-fmt-ignore -->
-
 ```ts
 import { readAll } from "https://deno.land/std@0.93.0/io/util.ts";
 

--- a/docs/getting_started/webassembly.md
+++ b/docs/getting_started/webassembly.md
@@ -24,11 +24,7 @@ console.log(main().toString());
 And for files:
 
 ```ts
-import { readAll } from "https://deno.land/std@0.93.0/io/util.ts";
-
-const file = await Deno.open("main.wasm");
-const wasmCode = await readAll(file);
-Deno.close(file.rid);
+const wasmCode = await Deno.readFile("main.wasm");
 const wasmModule = new WebAssembly.Module(wasmCode);
 const wasmInstance = new WebAssembly.Instance(wasmModule);
 const main = wasmInstance.exports.main as CallableFunction;

--- a/docs/getting_started/webassembly.md
+++ b/docs/getting_started/webassembly.md
@@ -31,6 +31,6 @@ const wasmCode = await readAll(file);
 Deno.close(file.rid);
 const wasmModule = new WebAssembly.Module(wasmCode);
 const wasmInstance = new WebAssembly.Instance(wasmModule);
-const main = wasmInstance.exports.main as CallableFunction
+const main = wasmInstance.exports.main as CallableFunction;
 console.log(main().toString());
 ```


### PR DESCRIPTION
Adds example code for how to use deno with .wasm files.

Not sure if something else is preffered over `readAll()` from `io/util.ts`, but it's what worked for me.

