### PR TITLE
feat(lsp): improve diagnostic status page

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -202,6 +202,10 @@ impl DocumentCache {
     }
   }
 
+  pub fn specifiers(&self) -> Vec<ModuleSpecifier> {
+    self.docs.keys().map(|s| s.clone()).collect()
+  }
+
   pub fn version(&self, specifier: &ModuleSpecifier) -> Option<i32> {
     self.docs.get(specifier).and_then(|doc| doc.version)
   }

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -203,7 +203,7 @@ impl DocumentCache {
   }
 
   pub fn specifiers(&self) -> Vec<ModuleSpecifier> {
-    self.docs.keys().map(|s| s.clone()).collect()
+    self.docs.keys().cloned().collect()
   }
 
   pub fn version(&self, specifier: &ModuleSpecifier) -> Option<i32> {

--- a/cli/lsp/performance.rs
+++ b/cli/lsp/performance.rs
@@ -11,12 +11,18 @@ use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PerformanceAverage {
   pub name: String,
   pub count: u32,
   pub average_duration: u32,
+}
+
+impl PartialOrd for PerformanceAverage {
+  fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+    Some(self.cmp(other))
+  }
 }
 
 impl Ord for PerformanceAverage {
@@ -154,7 +160,7 @@ impl Performance {
 
   pub fn to_vec(&self) -> Vec<PerformanceMeasure> {
     let measures = self.measures.lock().unwrap();
-    measures.iter().map(|m| m.clone()).collect()
+    measures.iter().cloned().collect()
   }
 }
 

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -197,6 +197,10 @@ impl Sources {
     self.0.lock().unwrap().get_source(specifier)
   }
 
+  pub fn len(&self) -> usize {
+    self.0.lock().unwrap().metadata.len()
+  }
+
   pub fn resolve_import(
     &self,
     specifier: &str,
@@ -211,8 +215,8 @@ impl Sources {
       .lock()
       .unwrap()
       .metadata
-      .iter()
-      .map(|(s, _)| s.clone())
+      .keys()
+      .map(|s| s.clone())
       .collect()
   }
 }

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -210,14 +210,7 @@ impl Sources {
   }
 
   pub fn specifiers(&self) -> Vec<ModuleSpecifier> {
-    self
-      .0
-      .lock()
-      .unwrap()
-      .metadata
-      .keys()
-      .map(|s| s.clone())
-      .collect()
+    self.0.lock().unwrap().metadata.keys().cloned().collect()
   }
 }
 


### PR DESCRIPTION
This PR improves the output of the LSP's diagnostic status page, which will help try to narrow down some issue that have been occurring.  The status page now looks something like this:

![Preview_status_md_—_oak](https://user-images.githubusercontent.com/1282577/115184856-07fe5300-a122-11eb-9f0e-5141dde055cd.png)

It provides an expandable list of the files "open", cached sources, and performance measures.  It also provides the averages of measurements in a table format now.