### PR TITLE
fix(#10125): remove documents when closed in the lsp

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -124,10 +124,7 @@ impl DocumentCache {
   }
 
   pub fn close(&mut self, specifier: &ModuleSpecifier) {
-    if let Some(mut doc) = self.docs.get_mut(specifier) {
-      doc.version = None;
-      doc.dependencies = None;
-    }
+    self.docs.remove(specifier);
   }
 
   pub fn contains_key(&self, specifier: &ModuleSpecifier) -> bool {


### PR DESCRIPTION
Fixes #10125

This was a "simple" fix, but creating a test that fails meant I had to restructure the test harness to be able to pass a fixture that is "dynamic", which was a lot more complex.