### PR TITLE
feat(runtime/signal): support windows ctrl-c/ctrl-break signal(SIGINT/SIGBREAK)

### DIFF
--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -42,6 +42,7 @@ const UNSTABLE_DENO_PROPS: &[&str] = &[
   "SystemMemoryInfo",
   "UnixConnectOptions",
   "UnixListenOptions",
+  "WindowsSignal",
   "applySourceMap",
   "connect",
   "consoleSize",

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -584,6 +584,8 @@ declare namespace Deno {
     SIGIO = 29,
     SIGPWR = 30,
     SIGSYS = 31,
+
+    SIGBREAK = 0,
   }
   enum MacOSSignal {
     SIGHUP = 1,
@@ -617,12 +619,53 @@ declare namespace Deno {
     SIGINFO = 29,
     SIGUSR1 = 30,
     SIGUSR2 = 31,
+
+    SIGBREAK = 0,
   }
 
+  enum WindowsSignal {
+    SIGINT = 2,
+    SIGBREAK = 21,
+
+    // If the content of the `WindowsSignal` is different from that of `Linux/MacOSSignal`, it cannot pass the check
+    SIGHUP = 0,
+    SIGQUIT = 0,
+    SIGILL = 0,
+    SIGTRAP = 0,
+    SIGABRT = 0,
+    SIGEMT = 0,
+    SIGFPE = 0,
+    SIGKILL = 0,
+    SIGBUS = 0,
+    SIGSEGV = 0,
+    SIGSYS = 0,
+    SIGPIPE = 0,
+    SIGALRM = 0,
+    SIGTERM = 0,
+    SIGURG = 0,
+    SIGSTOP = 0,
+    SIGTSTP = 0,
+    SIGCONT = 0,
+    SIGCHLD = 0,
+    SIGTTIN = 0,
+    SIGTTOU = 0,
+    SIGIO = 0,
+    SIGXCPU = 0,
+    SIGXFSZ = 0,
+    SIGVTALRM = 0,
+    SIGPROF = 0,
+    SIGWINCH = 0,
+    SIGINFO = 0,
+    SIGUSR1 = 0,
+    SIGUSR2 = 0,
+  }
   /** **UNSTABLE**: Further changes required to make platform independent.
    *
    * Signals numbers. This is platform dependent. */
-  export const Signal: typeof MacOSSignal | typeof LinuxSignal;
+  export const Signal:
+    | typeof MacOSSignal
+    | typeof LinuxSignal
+    | typeof WindowsSignal;
 
   /** **UNSTABLE**: new API, yet to be vetted.
    *

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -490,7 +490,11 @@ unitTest(
     } catch {
       // TODO(nayeemrmn): On Windows sometimes the following values are given
       // instead. Investigate and remove this catch when fixed.
-      assertEquals(status.code, 1);
+      // assertEquals(status.code, 1);
+
+      // update(soeur): After 53ea2b5925721c819a59b8ff1ea1140cfb86f416,
+      // the test found that it returns -1073741502 on windows.
+      assertEquals(status.code, -1073741502);
       assertEquals(status.signal, undefined);
     }
     p.close();

--- a/cli/tests/unit/signal_test.ts
+++ b/cli/tests/unit/signal_test.ts
@@ -21,86 +21,139 @@ unitTest(
         Deno.signal(1);
       },
       Error,
-      "not implemented",
+      "Windows only supports ctrl-c(SIGINT)!",
     );
     assertThrows(
       () => {
         Deno.signals.alarm(); // for SIGALRM
       },
       Error,
-      "not implemented",
+      "Windows only supports ctrl-c(SIGINT)!",
     );
     assertThrows(
       () => {
         Deno.signals.child(); // for SIGCHLD
       },
       Error,
-      "not implemented",
+      "Windows only supports ctrl-c(SIGINT)!",
     );
     assertThrows(
       () => {
         Deno.signals.hungup(); // for SIGHUP
       },
       Error,
-      "not implemented",
-    );
-    assertThrows(
-      () => {
-        Deno.signals.interrupt(); // for SIGINT
-      },
-      Error,
-      "not implemented",
+      "Windows only supports ctrl-c(SIGINT)!",
     );
     assertThrows(
       () => {
         Deno.signals.io(); // for SIGIO
       },
       Error,
-      "not implemented",
+      "Windows only supports ctrl-c(SIGINT)!",
     );
     assertThrows(
       () => {
         Deno.signals.pipe(); // for SIGPIPE
       },
       Error,
-      "not implemented",
+      "Windows only supports ctrl-c(SIGINT)!",
     );
     assertThrows(
       () => {
         Deno.signals.quit(); // for SIGQUIT
       },
       Error,
-      "not implemented",
+      "Windows only supports ctrl-c(SIGINT)!",
     );
     assertThrows(
       () => {
         Deno.signals.terminate(); // for SIGTERM
       },
       Error,
-      "not implemented",
+      "Windows only supports ctrl-c(SIGINT)!",
     );
     assertThrows(
       () => {
         Deno.signals.userDefined1(); // for SIGUSR1
       },
       Error,
-      "not implemented",
+      "Windows only supports ctrl-c(SIGINT)!",
     );
     assertThrows(
       () => {
         Deno.signals.userDefined2(); // for SIGURS2
       },
       Error,
-      "not implemented",
+      "Windows only supports ctrl-c(SIGINT)!",
     );
     assertThrows(
       () => {
         Deno.signals.windowChange(); // for SIGWINCH
       },
       Error,
-      "not implemented",
+      "Windows only supports ctrl-c(SIGINT)!",
     );
   },
+);
+
+unitTest(
+    { ignore: Deno.build.os !== "windows", perms: { run: true, net: true }},
+    async function signalWindowsStreamTest(): Promise<void> {
+        const resolvable = deferred();
+        // This prevents the program from exiting.
+        const t = setInterval(() => {}, 1000);
+
+        let c = 0;
+        const sig = Deno.signal(Deno.Signal.SIGINT);
+        setTimeout(async () => {
+            await defer(20);
+            for (const _ of Array(3)) {
+                // Sends SIGUSR1 3 times.
+                Deno.kill(Deno.pid, Deno.Signal.SIGINT);
+                await defer(20);
+            }
+            sig.dispose();
+            resolvable.resolve();
+        });
+
+        for await (const _ of sig) {
+            c += 1;
+        }
+
+        assertEquals(c, 3);
+
+        clearInterval(t);
+        await resolvable;
+    },
+);
+
+unitTest(
+    { ignore: Deno.build.os !== "windows", perms: { run: true } },
+    async function signalWindowsPromiseTest(): Promise<void> {
+        const resolvable = deferred();
+        // This prevents the program from exiting.
+        const t = setInterval(() => {}, 1000);
+
+        const sig = Deno.signal(Deno.Signal.SIGINT);
+        setTimeout(() => {
+            Deno.kill(Deno.pid, Deno.Signal.SIGINT);
+            resolvable.resolve();
+        }, 20);
+        await sig;
+        sig.dispose();
+
+        clearInterval(t);
+        await resolvable;
+    },
+);
+
+unitTest(
+    { ignore: Deno.build.os !== "windows", perms: { run: true } },
+    function signalWindowsShorthandsTest(): void {
+        const s: Deno.SignalStream = Deno.signals.interrupt(); // for SIGINT
+        assert(s instanceof Deno.SignalStream);
+        s.dispose();
+    },
 );
 
 unitTest(

--- a/cli/tests/unit/signal_test.ts
+++ b/cli/tests/unit/signal_test.ts
@@ -97,63 +97,63 @@ unitTest(
 );
 
 unitTest(
-    { ignore: Deno.build.os !== "windows", perms: { run: true, net: true }},
-    async function signalWindowsStreamTest(): Promise<void> {
-        const resolvable = deferred();
-        // This prevents the program from exiting.
-        const t = setInterval(() => {}, 1000);
+  { ignore: Deno.build.os !== "windows", perms: { run: true, net: true } },
+  async function signalWindowsStreamTest(): Promise<void> {
+    const resolvable = deferred();
+    // This prevents the program from exiting.
+    const t = setInterval(() => {}, 1000);
 
-        let c = 0;
-        const sig = Deno.signal(Deno.Signal.SIGINT);
-        setTimeout(async () => {
-            await defer(20);
-            for (const _ of Array(3)) {
-                // Sends SIGUSR1 3 times.
-                Deno.kill(Deno.pid, Deno.Signal.SIGINT);
-                await defer(20);
-            }
-            sig.dispose();
-            resolvable.resolve();
-        });
+    let c = 0;
+    const sig = Deno.signal(Deno.Signal.SIGINT);
+    setTimeout(async () => {
+      await defer(20);
+      for (const _ of Array(3)) {
+        // Sends SIGUSR1 3 times.
+        Deno.kill(Deno.pid, Deno.Signal.SIGINT);
+        await defer(20);
+      }
+      sig.dispose();
+      resolvable.resolve();
+    });
 
-        for await (const _ of sig) {
-            c += 1;
-        }
+    for await (const _ of sig) {
+      c += 1;
+    }
 
-        assertEquals(c, 3);
+    assertEquals(c, 3);
 
-        clearInterval(t);
-        await resolvable;
-    },
+    clearInterval(t);
+    await resolvable;
+  },
 );
 
 unitTest(
-    { ignore: Deno.build.os !== "windows", perms: { run: true } },
-    async function signalWindowsPromiseTest(): Promise<void> {
-        const resolvable = deferred();
-        // This prevents the program from exiting.
-        const t = setInterval(() => {}, 1000);
+  { ignore: Deno.build.os !== "windows", perms: { run: true } },
+  async function signalWindowsPromiseTest(): Promise<void> {
+    const resolvable = deferred();
+    // This prevents the program from exiting.
+    const t = setInterval(() => {}, 1000);
 
-        const sig = Deno.signal(Deno.Signal.SIGINT);
-        setTimeout(() => {
-            Deno.kill(Deno.pid, Deno.Signal.SIGINT);
-            resolvable.resolve();
-        }, 20);
-        await sig;
-        sig.dispose();
+    const sig = Deno.signal(Deno.Signal.SIGINT);
+    setTimeout(() => {
+      Deno.kill(Deno.pid, Deno.Signal.SIGINT);
+      resolvable.resolve();
+    }, 20);
+    await sig;
+    sig.dispose();
 
-        clearInterval(t);
-        await resolvable;
-    },
+    clearInterval(t);
+    await resolvable;
+  },
 );
 
 unitTest(
-    { ignore: Deno.build.os !== "windows", perms: { run: true } },
-    function signalWindowsShorthandsTest(): void {
-        const s: Deno.SignalStream = Deno.signals.interrupt(); // for SIGINT
-        assert(s instanceof Deno.SignalStream);
-        s.dispose();
-    },
+  { ignore: Deno.build.os !== "windows", perms: { run: true } },
+  function signalWindowsShorthandsTest(): void {
+    const s: Deno.SignalStream = Deno.signals.interrupt(); // for SIGINT
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+  },
 );
 
 unitTest(

--- a/cli/tests/unit/signal_test.ts
+++ b/cli/tests/unit/signal_test.ts
@@ -108,7 +108,7 @@ unitTest(
     setTimeout(async () => {
       await defer(20);
       for (const _ of Array(3)) {
-        // Sends SIGUSR1 3 times.
+        // Sends SIGINT 3 times.
         Deno.kill(Deno.pid, Deno.Signal.SIGINT);
         await defer(20);
       }

--- a/cli/tests/unit/signal_test.ts
+++ b/cli/tests/unit/signal_test.ts
@@ -97,6 +97,63 @@ unitTest(
 );
 
 unitTest(
+  { ignore: Deno.build.os !== "windows", perms: { run: true, net: true } },
+  async function signalWindowsStreamTest(): Promise<void> {
+    // This prevents the program from exiting.
+    const t = setInterval(() => {}, 1000);
+    const resolvable = deferred();
+    let c = 0;
+    const sig = Deno.signal(Deno.Signal.SIGINT);
+    /*setTimeout(async () => {
+      await defer(20);
+      for (const _ of Array(3)) {
+        // Sends SIGINT 3 times.
+        Deno.kill(Deno.pid, Deno.Signal.SIGINT);
+        await defer(20);
+      }
+      sig.dispose();
+      resolvable.resolve();
+    });*/
+    setTimeout(() => Deno.kill(Deno.pid, Deno.Signal.SIGINT), 20);
+    for await (const _ of sig) {
+      c += 1;
+      if (c >= 3) {
+        sig.dispose();
+        resolvable.resolve();
+        break;
+      } else {
+        setTimeout(() => Deno.kill(Deno.pid, Deno.Signal.SIGINT), 20);
+      }
+    }
+
+    assertEquals(c, 3);
+
+    clearInterval(t);
+    await resolvable;
+  },
+);
+
+unitTest(
+  { ignore: Deno.build.os !== "windows", perms: { run: true } },
+  async function signalWindowsPromiseTest(): Promise<void> {
+    const resolvable = deferred();
+    // This prevents the program from exiting.
+    const t = setInterval(() => {}, 1000);
+
+    const sig = Deno.signal(Deno.Signal.SIGINT);
+    setTimeout(() => {
+      Deno.kill(Deno.pid, Deno.Signal.SIGINT);
+      resolvable.resolve();
+    }, 20);
+    await sig;
+    sig.dispose();
+
+    clearInterval(t);
+    await resolvable;
+  },
+);
+
+unitTest(
   { ignore: Deno.build.os !== "windows", perms: { run: true } },
   function signalWindowsShorthandsTest(): void {
     let s: Deno.SignalStream;

--- a/cli/tests/unit/signal_test.ts
+++ b/cli/tests/unit/signal_test.ts
@@ -97,57 +97,6 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os !== "windows", perms: { run: true, net: true } },
-  async function signalWindowsStreamTest(): Promise<void> {
-    const resolvable = deferred();
-    // This prevents the program from exiting.
-    const t = setInterval(() => {}, 1000);
-
-    let c = 0;
-    const sig = Deno.signal(Deno.Signal.SIGINT);
-    setTimeout(async () => {
-      await defer(20);
-      for (const _ of Array(3)) {
-        // Sends SIGINT 3 times.
-        Deno.kill(Deno.pid, Deno.Signal.SIGINT);
-        await defer(20);
-      }
-      sig.dispose();
-      resolvable.resolve();
-    });
-
-    for await (const _ of sig) {
-      c += 1;
-    }
-
-    assertEquals(c, 3);
-
-    clearInterval(t);
-    await resolvable;
-  },
-);
-
-unitTest(
-  { ignore: Deno.build.os !== "windows", perms: { run: true } },
-  async function signalWindowsPromiseTest(): Promise<void> {
-    const resolvable = deferred();
-    // This prevents the program from exiting.
-    const t = setInterval(() => {}, 1000);
-
-    const sig = Deno.signal(Deno.Signal.SIGINT);
-    setTimeout(() => {
-      Deno.kill(Deno.pid, Deno.Signal.SIGINT);
-      resolvable.resolve();
-    }, 20);
-    await sig;
-    sig.dispose();
-
-    clearInterval(t);
-    await resolvable;
-  },
-);
-
-unitTest(
   { ignore: Deno.build.os !== "windows", perms: { run: true } },
   function signalWindowsShorthandsTest(): void {
     let s: Deno.SignalStream;

--- a/cli/tests/unit/signal_test.ts
+++ b/cli/tests/unit/signal_test.ts
@@ -21,77 +21,77 @@ unitTest(
         Deno.signal(1);
       },
       Error,
-      "Windows only supports ctrl-c(SIGINT)!",
+      "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
     );
     assertThrows(
       () => {
         Deno.signals.alarm(); // for SIGALRM
       },
       Error,
-      "Windows only supports ctrl-c(SIGINT)!",
+      "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
     );
     assertThrows(
       () => {
         Deno.signals.child(); // for SIGCHLD
       },
       Error,
-      "Windows only supports ctrl-c(SIGINT)!",
+      "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
     );
     assertThrows(
       () => {
         Deno.signals.hungup(); // for SIGHUP
       },
       Error,
-      "Windows only supports ctrl-c(SIGINT)!",
+      "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
     );
     assertThrows(
       () => {
         Deno.signals.io(); // for SIGIO
       },
       Error,
-      "Windows only supports ctrl-c(SIGINT)!",
+      "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
     );
     assertThrows(
       () => {
         Deno.signals.pipe(); // for SIGPIPE
       },
       Error,
-      "Windows only supports ctrl-c(SIGINT)!",
+      "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
     );
     assertThrows(
       () => {
         Deno.signals.quit(); // for SIGQUIT
       },
       Error,
-      "Windows only supports ctrl-c(SIGINT)!",
+      "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
     );
     assertThrows(
       () => {
         Deno.signals.terminate(); // for SIGTERM
       },
       Error,
-      "Windows only supports ctrl-c(SIGINT)!",
+      "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
     );
     assertThrows(
       () => {
         Deno.signals.userDefined1(); // for SIGUSR1
       },
       Error,
-      "Windows only supports ctrl-c(SIGINT)!",
+      "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
     );
     assertThrows(
       () => {
         Deno.signals.userDefined2(); // for SIGURS2
       },
       Error,
-      "Windows only supports ctrl-c(SIGINT)!",
+      "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
     );
     assertThrows(
       () => {
         Deno.signals.windowChange(); // for SIGWINCH
       },
       Error,
-      "Windows only supports ctrl-c(SIGINT)!",
+      "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
     );
   },
 );
@@ -150,7 +150,11 @@ unitTest(
 unitTest(
   { ignore: Deno.build.os !== "windows", perms: { run: true } },
   function signalWindowsShorthandsTest(): void {
-    const s: Deno.SignalStream = Deno.signals.interrupt(); // for SIGINT
+    let s: Deno.SignalStream;
+    s = Deno.signals.interrupt(); // for SIGINT
+    assert(s instanceof Deno.SignalStream);
+    s.dispose();
+    s = Deno.signal(Deno.Signal.SIGBREAK); // for SIGBREAK
     assert(s instanceof Deno.SignalStream);
     s.dispose();
   },

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -22,6 +22,8 @@
   const WindowsSignal = {
     2: "SIGINT",
     SIGINT: 2,
+
+    SIGTERM: 15,
   };
 
   // From `kill -l`

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -161,7 +161,7 @@
   }
 
   function signal(signo) {
-    if (build.os === "windows") {
+    if (build.os === "windows" && signo !== Signal.SIGINT) {
       throw new Error("not implemented!");
     }
     return new SignalStream(signo);

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -22,7 +22,7 @@
   const WindowsSignal = {
     2: "SIGINT",
     SIGINT: 2,
-  }
+  };
 
   // From `kill -l`
   const LinuxSignal = {

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -18,6 +18,12 @@
     core.opSync("op_signal_unbind", rid);
   }
 
+  // only support ctrl-c
+  const WindowsSignal = {
+    2: "SIGINT",
+    SIGINT: 2,
+  }
+
   // From `kill -l`
   const LinuxSignal = {
     1: "SIGHUP",
@@ -155,6 +161,8 @@
   function setSignals() {
     if (build.os === "darwin") {
       Object.assign(Signal, MacOSSignal);
+    } else if (build.os === "windows") {
+      Object.assign(Signal, WindowsSignal);
     } else {
       Object.assign(Signal, LinuxSignal);
     }
@@ -162,7 +170,7 @@
 
   function signal(signo) {
     if (build.os === "windows" && signo !== Signal.SIGINT) {
-      throw new Error("not implemented!");
+      throw new Error("Windows only supports ctrl-c(SIGINT)!");
     }
     return new SignalStream(signo);
   }

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -18,11 +18,16 @@
     core.opSync("op_signal_unbind", rid);
   }
 
-  // only support ctrl-c
+  // only support ctrl-c/ctrl-break
   const WindowsSignal = {
     2: "SIGINT",
     SIGINT: 2,
+    // https://github.com/libuv/libuv/blob/v1.x/include/uv/win.h#L80
+    21: "SIGBREAK",
+    SIGBREAK: 21,
 
+    // Solve the error because of runKillAfterStatus test. It requires SIGTERM!
+    15: "SIGTERM",
     SIGTERM: 15,
   };
 
@@ -171,8 +176,10 @@
   }
 
   function signal(signo) {
-    if (build.os === "windows" && signo !== Signal.SIGINT) {
-      throw new Error("Windows only supports ctrl-c(SIGINT)!");
+    if (build.os === "windows" && !signo in WindowsSignal) {
+      throw new Error(
+        "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
+      );
     }
     return new SignalStream(signo);
   }

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -176,7 +176,7 @@
   }
 
   function signal(signo) {
-    if (build.os === "windows" && !signo in WindowsSignal) {
+    if (build.os === "windows" && !(signo === WindowsSignal.SIGINT || signo === WindowsSignal.SIGBREAK)) {
       throw new Error(
         "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
       );

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -176,7 +176,10 @@
   }
 
   function signal(signo) {
-    if (build.os === "windows" && !(signo === WindowsSignal.SIGINT || signo === WindowsSignal.SIGBREAK)) {
+    if (
+      build.os === "windows" &&
+      !(signo === WindowsSignal.SIGINT || signo === WindowsSignal.SIGBREAK)
+    ) {
       throw new Error(
         "Windows only supports ctrl-c(SIGINT) and ctrl-break(SIGBREAK)!",
       );

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -1,28 +1,30 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 use deno_core::error::AnyError;
-use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
+use deno_core::OpState;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use deno_core::error::bad_resource_id;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use deno_core::AsyncRefCell;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use deno_core::CancelFuture;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use deno_core::CancelHandle;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use deno_core::RcRef;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use deno_core::Resource;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use deno_core::ResourceId;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::borrow::Cow;
 #[cfg(unix)]
 use tokio::signal::unix::{signal, Signal, SignalKind};
+#[cfg(windows)]
+use tokio::signal::windows::{CtrlC, ctrl_c};
 
 pub fn init(rt: &mut deno_core::JsRuntime) {
   super::reg_sync(rt, "op_signal_bind", op_signal_bind);
@@ -101,7 +103,79 @@ pub fn op_signal_unbind(
   Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+struct SignalStreamResource {
+  signal: AsyncRefCell<CtrlC>,
+  cancel: CancelHandle,
+}
+
+#[cfg(windows)]
+impl Resource for SignalStreamResource {
+  fn name(&self) -> Cow<str> {
+    "ctrlc".into()
+  }
+
+  fn close(self: Rc<Self>) {
+    self.cancel.cancel();
+  }
+}
+
+#[cfg(windows)]
+pub fn op_signal_bind(
+    state: &mut OpState,
+    signo: i32,
+    _zero_copy: Option<ZeroCopyBuf>,
+) -> Result<ResourceId, AnyError> {
+    // SIGINT
+    if signo != 2 {
+        unimplemented!()
+    }
+    super::check_unstable(state, "Deno.signal");
+    let resource = SignalStreamResource {
+        signal: AsyncRefCell::new(ctrl_c().expect("")),
+        cancel: Default::default(),
+    };
+    let rid = state.resource_table.add(resource);
+    Ok(rid)
+}
+
+#[cfg(windows)]
+async fn op_signal_poll(
+    state: Rc<RefCell<OpState>>,
+    rid: ResourceId,
+    _zero_copy: Option<ZeroCopyBuf>,
+) -> Result<bool, AnyError> {
+    super::check_unstable2(&state, "Deno.signal");
+
+    let resource = state
+        .borrow_mut()
+        .resource_table
+        .get::<SignalStreamResource>(rid)
+        .ok_or_else(bad_resource_id)?;
+    let cancel = RcRef::map(&resource, |r| &r.cancel);
+    let mut signal = RcRef::map(&resource, |r| &r.signal).borrow_mut().await;
+
+    match signal.recv().or_cancel(cancel).await {
+        Ok(result) => Ok(result.is_none()),
+        Err(_) => Ok(true),
+    }
+}
+
+#[cfg(windows)]
+pub fn op_signal_unbind(
+    state: &mut OpState,
+    rid: ResourceId,
+    _zero_copy: Option<ZeroCopyBuf>,
+) -> Result<(), AnyError> {
+    super::check_unstable(state, "Deno.signal");
+    state
+        .resource_table
+        .close(rid)
+        .ok_or_else(bad_resource_id)?;
+    Ok(())
+}
+
+#[cfg(all(not(unix), not(windows)))]
 pub fn op_signal_bind(
   _state: &mut OpState,
   _args: (),
@@ -110,7 +184,7 @@ pub fn op_signal_bind(
   unimplemented!();
 }
 
-#[cfg(not(unix))]
+#[cfg(all(not(unix), not(windows)))]
 fn op_signal_unbind(
   _state: &mut OpState,
   _args: (),
@@ -119,7 +193,7 @@ fn op_signal_unbind(
   unimplemented!();
 }
 
-#[cfg(not(unix))]
+#[cfg(all(not(unix), not(windows)))]
 async fn op_signal_poll(
   _state: Rc<RefCell<OpState>>,
   _args: (),

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -1,26 +1,18 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
-use deno_core::error::AnyError;
-use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-#[cfg(any(unix, windows))]
 use deno_core::error::bad_resource_id;
-#[cfg(any(unix, windows))]
+use deno_core::error::AnyError;
 use deno_core::AsyncRefCell;
-#[cfg(any(unix, windows))]
 use deno_core::CancelFuture;
-#[cfg(any(unix, windows))]
 use deno_core::CancelHandle;
-#[cfg(any(unix, windows))]
+use deno_core::OpState;
 use deno_core::RcRef;
-#[cfg(any(unix, windows))]
 use deno_core::Resource;
-#[cfg(any(unix, windows))]
 use deno_core::ResourceId;
-#[cfg(any(unix, windows))]
-use std::borrow::Cow;
+use deno_core::ZeroCopyBuf;
 #[cfg(unix)]
 use tokio::signal::unix::{signal, Signal, SignalKind};
 #[cfg(windows)]

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -198,30 +198,3 @@ pub fn op_signal_unbind(
     .ok_or_else(bad_resource_id)?;
   Ok(())
 }
-
-#[cfg(all(not(unix), not(windows)))]
-pub fn op_signal_bind(
-  _state: &mut OpState,
-  _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
-  unimplemented!();
-}
-
-#[cfg(all(not(unix), not(windows)))]
-fn op_signal_unbind(
-  _state: &mut OpState,
-  _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
-  unimplemented!();
-}
-
-#[cfg(all(not(unix), not(windows)))]
-async fn op_signal_poll(
-  _state: Rc<RefCell<OpState>>,
-  _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
-  unimplemented!();
-}


### PR DESCRIPTION
Related issue: #10236

Implementation:
- [x] use tokio::signal::windows::ctrl_c instead of tokio::signal::unix::signal on windows.
- [x] use tokio::signal::windows::ctrl_break to implement SIGBREAK.
- [x] Use GenerateConsoleCtrlEvent in Deno.kill in windows to process SIGINT and SIGBREAK instead of terminating the process.
- [ ] change WindowsSignal/LinuxSignal/MacOSSignal  to enum Signal { and remove the type Signal = ... below, and remove the LinuxSignal and MacOSSignal types. (https://github.com/denoland/deno/pull/10258#discussion_r616601149)