### PR TITLE
refactor(core): specialize ops on serde_v8

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -13,6 +13,7 @@ mod ops_json;
 pub mod plugin_api;
 mod resources;
 mod runtime;
+mod serialized_value;
 mod zero_copy_buf;
 
 // Re-exports

--- a/core/ops_json.rs
+++ b/core/ops_json.rs
@@ -6,8 +6,6 @@ use crate::Op;
 use crate::OpFn;
 use crate::OpState;
 use crate::ZeroCopyBuf;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use std::cell::RefCell;
 use std::future::Future;
 use std::rc::Rc;
@@ -38,8 +36,8 @@ use std::rc::Rc;
 pub fn op_sync<F, V, R>(op_fn: F) -> Box<OpFn>
 where
   F: Fn(&mut OpState, V, Option<ZeroCopyBuf>) -> Result<R, AnyError> + 'static,
-  V: DeserializeOwned,
-  R: Serialize + 'static,
+  V: serde_v8::Deserializable,
+  R: serde_v8::Serializable + 'static,
 {
   Box::new(move |state, payload, buf| -> Op {
     let result = payload
@@ -76,9 +74,9 @@ where
 pub fn op_async<F, V, R, RV>(op_fn: F) -> Box<OpFn>
 where
   F: Fn(Rc<RefCell<OpState>>, V, Option<ZeroCopyBuf>) -> R + 'static,
-  V: DeserializeOwned,
+  V: serde_v8::Deserializable,
   R: Future<Output = Result<RV, AnyError>> + 'static,
-  RV: Serialize + 'static,
+  RV: serde_v8::Serializable + 'static,
 {
   Box::new(move |state, payload, buf| -> Op {
     let pid = payload.promise_id;

--- a/core/serialized_value.rs
+++ b/core/serialized_value.rs
@@ -1,0 +1,76 @@
+use rusty_v8 as v8;
+use std::cell::RefCell;
+
+pub struct SerializedValue {
+  pub buf: RefCell<Vec<u8>>
+}
+
+impl serde_v8::Deserializable for SerializedValue {
+  fn from_v8(
+    scope: &mut v8::HandleScope,
+    value: v8::Local<v8::Value>,
+  ) -> Result<Self, serde_v8::Error> {
+    // TODO: error handling
+    let buf = RefCell::new(match serialize(scope, value) {
+      Some(buf) => buf,
+      None => vec![],
+    });
+    Ok(Self { buf })
+  }
+}
+
+impl serde_v8::Serializable for SerializedValue {
+  fn to_v8<'a>(
+    &self,
+    scope: &mut v8::HandleScope<'a>,
+  ) -> Result<v8::Local<'a, v8::Value>, serde_v8::Error> {
+    let buf = self.buf.take();
+    let val = deserialize(scope, buf);
+    
+    match val {
+      Some(val) => Ok(val),
+      None => Err(serde_v8::Error::Message("invalid SerializedValue".to_string()))
+    }
+  }
+}
+
+struct SerializeDeserialize {}
+
+impl v8::ValueSerializerImpl for SerializeDeserialize {
+  #[allow(unused_variables)]
+  fn throw_data_clone_error<'s>(
+    &mut self,
+    scope: &mut v8::HandleScope<'s>,
+    message: v8::Local<'s, v8::String>,
+  ) {
+    let error = v8::Exception::error(scope, message);
+    scope.throw_exception(error);
+  }
+}
+
+impl v8::ValueDeserializerImpl for SerializeDeserialize {}
+
+// essentially from_v8
+fn serialize(
+  scope: &mut v8::HandleScope,
+  value: v8::Local<v8::Value>,
+) -> Option<Vec<u8>> {
+  let sd = Box::new(SerializeDeserialize {});
+  let mut vs = v8::ValueSerializer::new(scope, sd);
+  
+  match vs.write_value(scope.get_current_context(), value) {
+    Some(true) => Some(vs.release()),
+    _ => None
+  }
+}
+
+// essentially to_v8
+fn deserialize<'a>(
+  scope: &mut v8::HandleScope<'a>,
+  buf: Vec<u8>,
+) -> Option<v8::Local<'a, v8::Value>> {
+  let sd = Box::new(SerializeDeserialize {});
+  let mut vd = v8::ValueDeserializer::new(scope, sd, &buf);
+  
+  vd.read_value(scope.get_current_context())
+}

--- a/core/serialized_value.rs
+++ b/core/serialized_value.rs
@@ -2,7 +2,7 @@ use rusty_v8 as v8;
 use std::cell::RefCell;
 
 pub struct SerializedValue {
-  pub buf: RefCell<Vec<u8>>
+  pub buf: RefCell<Vec<u8>>,
 }
 
 impl serde_v8::Deserializable for SerializedValue {
@@ -26,10 +26,12 @@ impl serde_v8::Serializable for SerializedValue {
   ) -> Result<v8::Local<'a, v8::Value>, serde_v8::Error> {
     let buf = self.buf.take();
     let val = deserialize(scope, buf);
-    
+
     match val {
       Some(val) => Ok(val),
-      None => Err(serde_v8::Error::Message("invalid SerializedValue".to_string()))
+      None => Err(serde_v8::Error::Message(
+        "invalid SerializedValue".to_string(),
+      )),
     }
   }
 }
@@ -57,10 +59,10 @@ fn serialize(
 ) -> Option<Vec<u8>> {
   let sd = Box::new(SerializeDeserialize {});
   let mut vs = v8::ValueSerializer::new(scope, sd);
-  
+
   match vs.write_value(scope.get_current_context(), value) {
     Some(true) => Some(vs.release()),
-    _ => None
+    _ => None,
   }
 }
 
@@ -71,6 +73,6 @@ fn deserialize<'a>(
 ) -> Option<v8::Local<'a, v8::Value>> {
   let sd = Box::new(SerializeDeserialize {});
   let mut vd = v8::ValueDeserializer::new(scope, sd, &buf);
-  
+
   vd.read_value(scope.get_current_context())
 }

--- a/serde_v8/src/deserializable.rs
+++ b/serde_v8/src/deserializable.rs
@@ -3,7 +3,10 @@ use rusty_v8 as v8;
 
 /// Deserializable allows custom v8 deserializables beyond `serde::Deserializable`s,
 /// enabling things such as deserializing `v8::Value`s to value serialized buffers
-pub trait Deserializable where Self: Sized {
+pub trait Deserializable
+where
+  Self: Sized,
+{
   fn from_v8(
     scope: &mut v8::HandleScope,
     value: v8::Local<v8::Value>,

--- a/serde_v8/src/deserializable.rs
+++ b/serde_v8/src/deserializable.rs
@@ -1,0 +1,21 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+use rusty_v8 as v8;
+
+/// Deserializable allows custom v8 deserializables beyond `serde::Deserializable`s,
+/// enabling things such as deserializing `v8::Value`s to value serialized buffers
+pub trait Deserializable where Self: Sized {
+  fn from_v8(
+    scope: &mut v8::HandleScope,
+    value: v8::Local<v8::Value>,
+  ) -> Result<Self, crate::Error>;
+}
+
+/// Allows all implementors of `serde::Deserialize` to implement Deserializable
+impl<T: serde::de::DeserializeOwned> Deserializable for T {
+  fn from_v8(
+    scope: &mut v8::HandleScope,
+    value: v8::Local<v8::Value>,
+  ) -> Result<T, crate::Error> {
+    crate::from_v8(scope, value)
+  }
+}

--- a/serde_v8/src/lib.rs
+++ b/serde_v8/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 mod de;
+mod deserializable;
 mod error;
 mod keys;
 mod magic;
@@ -9,6 +10,7 @@ mod serializable;
 pub mod utils;
 
 pub use de::{from_v8, from_v8_cached, Deserializer};
+pub use deserializable::Deserializable;
 pub use error::{Error, Result};
 pub use keys::KeyCache;
 pub use magic::Value;

--- a/serde_v8/src/serializable.rs
+++ b/serde_v8/src/serializable.rs
@@ -83,7 +83,7 @@ impl serde::Serialize for Primitive {
   }
 }
 
-impl<T: serde::Serialize + 'static> From<T> for SerializablePkg {
+impl<T: Serializable + 'static> From<T> for SerializablePkg {
   fn from(x: T) -> Self {
     let tid = TypeId::of::<T>();
 


### PR DESCRIPTION
This PR further specializes the op-layer on `serde_v8`, in short it allows ops to receive & return `serde_v8` De/Serializables of which regular `serde` De/Serializables are a subset, allowing to encode/decode v8 serialized values in the op-layer.

This allows moving `core.serialize` and `core.deserialize` from bindings to ops (as a general rule we want prefer to use ops when possible).

But it's important to keep in mind that this change somewhat leaks v8 into the op-layer since implementors can now implement their own `to_v8`/`from_v8` methods and capture v8 scopes and values which ultimately are isolate references.

That leak is minimal but it's important to be aware that it's there. If we want to avoid this abstraction leak, we would have to move `SerializedValue` support from `core` to `serde_v8` but I know @inteon wanted the optionality to control v8 serialization in core since this will evolve as our message passing between workers becomes more sophisticated.

## Changes

- [x] Add `serde_v8::Deserializable` (previously only had `serde_v8::Serializable`)
- [x] Specialize ops serialization code to these serializable traits (instead of plain serde serializables)
- [x] Implement `SerializedValue` type in `core/`