### PR TITLE
fix(runtime/cli): Remove double '.' from temporary archive extension on upgrade

### DIFF
--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -184,7 +184,7 @@ pub fn unpack(
   // to the newly uncompressed file without fear of the tempdir being deleted.
   let temp_dir = TempDir::new()?.into_path();
   let exe_ext = if is_windows { "exe" } else { "" };
-  let archive_path = temp_dir.join(exe_name).with_extension(".zip");
+  let archive_path = temp_dir.join(exe_name).with_extension("zip");
   let exe_path = temp_dir.join(exe_name).with_extension(exe_ext);
   assert!(!exe_path.exists());
 


### PR DESCRIPTION
This very tiny PR just fixes a minor annoyance that has irked me (admittedly more than it should) when doing a `deno upgrade`:
```
Looking up latest version
Found latest version 1.9.1
Checking https://github.com/denoland/deno/releases/download/v1.9.1/deno-x86_64-unknown-linux-gnu.zip
Download has been found
Deno is upgrading to version 1.9.1
Archive:  /tmp/.tmp17l6Z9/deno..zip
  inflating: deno                    
Upgraded successfully
```

Note that the archive path is `/tmp/.tmp17l6Z9/deno..zip` with `..zip` :scream:.

This is simply because [`PathBuf::with_extension`](https://doc.rust-lang.org/std/path/struct.Path.html#method.with_extension) expects the extension to not be prefixed by `.`. Other usages in the codebase (such as `.with_extension(exe_ext)` on the line below) already do this correctly.