### PR TITLE
refactor(core): simplify error handling

### DIFF
--- a/bench_util/src/js_runtime.rs
+++ b/bench_util/src/js_runtime.rs
@@ -20,7 +20,6 @@ pub fn create_js_runtime(setup: impl FnOnce(&mut JsRuntime)) -> JsRuntime {
     "init",
     r#"
       Deno.core.ops();
-      Deno.core.registerErrorClass('Error', Error);
     "#,
   )
   .unwrap();

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -799,7 +799,6 @@ delete Object.prototype.__proto__;
 
   // Setup the compiler runtime during the build process.
   core.ops();
-  core.registerErrorClass("Error", Error);
 
   // A build time only op that provides some setup information that is used to
   // ensure the snapshot is setup properly.

--- a/core/benches/op_baseline.rs
+++ b/core/benches/op_baseline.rs
@@ -27,7 +27,6 @@ fn create_js_runtime() -> JsRuntime {
       "init",
       r#"
       Deno.core.ops();
-      Deno.core.registerErrorClass('Error', Error);
     "#,
     )
     .unwrap();

--- a/core/core.js
+++ b/core/core.js
@@ -7,7 +7,15 @@
   const { recv, send } = core;
 
   let opsCache = {};
-  const errorMap = {};
+  const errorMap = {
+    // Builtin v8 / JS errors
+    Error,
+    RangeError,
+    ReferenceError,
+    SyntaxError,
+    TypeError,
+    URIError,
+  };
   let nextPromiseId = 1;
   const promiseMap = new Map();
   const RING_SIZE = 4 * 1024;
@@ -76,28 +84,24 @@
     return send(opsCache[opName], promiseId, control, zeroCopy);
   }
 
-  function registerErrorClass(errorName, className, args) {
-    if (typeof errorMap[errorName] !== "undefined") {
-      throw new TypeError(`Error class for "${errorName}" already registered`);
+  function registerErrorClass(className, errorClass) {
+    if (typeof errorMap[className] !== "undefined") {
+      throw new TypeError(`Error class for "${className}" already registered`);
     }
-    errorMap[errorName] = [className, args ?? []];
-  }
-
-  function getErrorClassAndArgs(errorName) {
-    return errorMap[errorName] ?? [undefined, []];
+    errorMap[className] = errorClass;
   }
 
   function unwrapOpResult(res) {
     // .$err_class_name is a special key that should only exist on errors
     if (res?.$err_class_name) {
       const className = res.$err_class_name;
-      const [ErrorClass, args] = getErrorClassAndArgs(className);
+      const ErrorClass = errorMap[className];
       if (!ErrorClass) {
         throw new Error(
           `Unregistered error class: "${className}"\n  ${res.message}\n  Classes of errors returned from ops should be registered via Deno.core.registerErrorClass().`,
         );
       }
-      throw new ErrorClass(res.message, ...args);
+      throw new ErrorClass(res.message);
     }
     return res;
   }

--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -74,10 +74,6 @@ const _newline = new Uint8Array([10]);
 function print(value) {
   Deno.core.dispatchByName('op_print', 0, value.toString(), _newline);
 }
-
-// Finally we register the error class used by op_sum
-// so that it throws the correct class.
-Deno.core.registerErrorClass('Error', Error);
 "#,
     )
     .unwrap();

--- a/core/examples/http_bench_json_ops.js
+++ b/core/examples/http_bench_json_ops.js
@@ -55,7 +55,6 @@ async function serve(rid) {
 
 async function main() {
   Deno.core.ops();
-  Deno.core.registerErrorClass("Error", Error);
 
   const listenerRid = listen();
   Deno.core.print(`http_bench_ops listening on http://127.0.0.1:4544/\n`);

--- a/core/ops_json.rs
+++ b/core/ops_json.rs
@@ -122,8 +122,6 @@ mod tests {
         r#"
     // First we initialize the ops cache. This maps op names to their id's.
     Deno.core.ops();
-    // Register the error class.
-    Deno.core.registerErrorClass('Error', Error);
 
     async function f1() {
       await Deno.core.opAsync('op_throw', 'hello');

--- a/op_crates/url/benches/url_ops.rs
+++ b/op_crates/url/benches/url_ops.rs
@@ -28,7 +28,6 @@ fn create_js_runtime() -> JsRuntime {
       "init",
       r#"
       Deno.core.ops();
-      Deno.core.registerErrorClass('Error', Error);
     "#,
     )
     .unwrap();

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -189,8 +189,8 @@ delete Object.prototype.__proto__;
     core.registerErrorClass(
       "DOMExceptionOperationError",
       function DOMExceptionOperationError(msg) {
-        this = new DOMException(msg, "OperationError")
-      }
+        this = new DOMException(msg, "OperationError");
+      },
     );
   }
 

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -186,16 +186,11 @@ delete Object.prototype.__proto__;
     core.registerErrorClass("Http", errors.Http);
     core.registerErrorClass("Busy", errors.Busy);
     core.registerErrorClass("NotSupported", errors.NotSupported);
-    core.registerErrorClass("Error", Error);
-    core.registerErrorClass("RangeError", RangeError);
-    core.registerErrorClass("ReferenceError", ReferenceError);
-    core.registerErrorClass("SyntaxError", SyntaxError);
-    core.registerErrorClass("TypeError", TypeError);
-    core.registerErrorClass("URIError", URIError);
     core.registerErrorClass(
       "DOMExceptionOperationError",
-      DOMException,
-      "OperationError",
+      function DOMExceptionOperationError(msg) {
+        this = new DOMException(msg, "OperationError")
+      }
     );
   }
 

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -189,7 +189,7 @@ delete Object.prototype.__proto__;
     core.registerErrorClass(
       "DOMExceptionOperationError",
       function DOMExceptionOperationError(msg) {
-        this = new DOMException(msg, "OperationError");
+        DOMException.prototype.constructor.call(this, msg, "OperationError");
       },
     );
   }


### PR DESCRIPTION
This PR simplifies error handling in `core.js`. v8 builtin errors are registered by default so new runtimes no longer need to bootstrap with:
```
Deno.core.registerErrorClass('Error', Error);
```

One less gotcha when bootstrapping runtimes

## Changes
- [x] register builtin v8 errors in `core.js` so consumers don't have to
- [x] remove complexity of error args handling
(consumers must provide a constructor with custom args, core simply provides msg arg)
- [x] Adapt `99_main.js`
- [x] Adapt other runtimes