### PR TITLE
refactor(core): kill recv() and init()

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -26,9 +26,6 @@ lazy_static::lazy_static! {
         function: print.map_fn_to()
       },
       v8::ExternalReference {
-        function: recv.map_fn_to()
-      },
-      v8::ExternalReference {
         function: send.map_fn_to()
       },
       v8::ExternalReference {
@@ -122,7 +119,6 @@ pub fn initialize_context<'s>(
 
   // Bind functions to Deno.core.*
   set_func(scope, core_val, "print", print);
-  set_func(scope, core_val, "recv", recv);
   set_func(scope, core_val, "send", send);
   set_func(
     scope,
@@ -319,27 +315,6 @@ fn print(
     print!("{}", str_.to_rust_string_lossy(tc_scope));
     stdout().flush().unwrap();
   }
-}
-
-fn recv(
-  scope: &mut v8::HandleScope,
-  args: v8::FunctionCallbackArguments,
-  _rv: v8::ReturnValue,
-) {
-  let state_rc = JsRuntime::state(scope);
-  let mut state = state_rc.borrow_mut();
-
-  let cb = match v8::Local::<v8::Function>::try_from(args.get(0)) {
-    Ok(cb) => cb,
-    Err(err) => return throw_type_error(scope, err.to_string()),
-  };
-
-  let slot = match &mut state.js_recv_cb {
-    slot @ None => slot,
-    _ => return throw_type_error(scope, "Deno.core.recv() already called"),
-  };
-
-  slot.replace(v8::Global::new(scope, cb));
 }
 
 fn send<'s>(

--- a/core/core.js
+++ b/core/core.js
@@ -3,8 +3,7 @@
 
 ((window) => {
   // Available on start due to bindings.
-  const core = window.Deno.core;
-  const { recv, send } = core;
+  const { send } = window.Deno.core;
 
   let opsCache = {};
   const errorMap = {};

--- a/core/core.js
+++ b/core/core.js
@@ -14,10 +14,6 @@
   const NO_PROMISE = null; // Alias to null is faster than plain nulls
   const promiseRing = new Array(RING_SIZE).fill(NO_PROMISE);
 
-  function init() {
-    recv(handleAsyncMsgFromRust);
-  }
-
   function setPromise(promiseId) {
     const idx = promiseId % RING_SIZE;
     // Move old promise from ring to map
@@ -131,6 +127,6 @@
     close,
     resources,
     registerErrorClass,
-    init,
+    handleAsyncMsgFromRust,
   });
 })(this);

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -305,10 +305,7 @@ impl JsRuntime {
     if !has_startup_snapshot {
       js_runtime.js_init();
     }
-
-    if !options.will_snapshot {
-      js_runtime.core_js_init();
-    }
+    js_runtime.init_recv_cb();
 
     js_runtime
   }
@@ -352,14 +349,22 @@ impl JsRuntime {
       .unwrap();
   }
 
-  /// Executes JavaScript code to initialize core.js,
-  /// specifically the js_recv_cb setter
-  ///
-  /// This function mustn't be called during snapshotting.
-  fn core_js_init(&mut self) {
-    self
-      .execute("deno:core/init.js", "Deno.core.init()")
-      .unwrap();
+  /// Grabs a reference to core.js' handleAsyncMsgFromRust
+  fn init_recv_cb(&mut self) {
+    let context = self.global_context();
+    let scope = &mut v8::HandleScope::with_context(self.v8_isolate(), context);
+
+    // Get Deno.core.handleAsyncMsgFromRust
+    let code =
+      v8::String::new(scope, "Deno.core.handleAsyncMsgFromRust").unwrap();
+    let script = v8::Script::compile(scope, code, None).unwrap();
+    let v8_value = script.run(scope).unwrap();
+
+    // Put global handle in state.js_recv_cb
+    let state_rc = JsRuntime::state(scope);
+    let mut state = state_rc.borrow_mut();
+    let cb = v8::Local::<v8::Function>::try_from(v8_value).unwrap();
+    state.js_recv_cb.replace(v8::Global::new(scope, cb));
   }
 
   /// Returns the runtime's op state, which can be used to maintain ops

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -305,7 +305,9 @@ impl JsRuntime {
     if !has_startup_snapshot {
       js_runtime.js_init();
     }
-    js_runtime.init_recv_cb();
+    if !options.will_snapshot {
+      js_runtime.init_recv_cb();
+    }
 
     js_runtime
   }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1398,14 +1398,7 @@ impl JsRuntime {
       return Ok(());
     }
 
-    // FIXME(bartlomieju): without check above this call would panic
-    // because of lazy initialization in core.js. It seems this lazy initialization
-    // hides unnecessary complexity.
-    let js_recv_cb_handle = state_rc
-      .borrow()
-      .js_recv_cb
-      .clone()
-      .expect("Deno.core.recv has not been called.");
+    let js_recv_cb_handle = state_rc.borrow().js_recv_cb.clone().unwrap();
 
     let context = self.global_context();
     let scope = &mut v8::HandleScope::with_context(self.v8_isolate(), context);


### PR DESCRIPTION
`init()` was previously needed to init the shared queue, but now that it's gone `init()` is only used to setup JsRuntime's `js_recv_cb`.

## Changes

- [x] Replace `JsRuntime::core_js_init()` with `::init_recv_cb()`
- [x] Remove `recv` binding
- [x] Cleanup misc stuff regarding `recv` (`FIXME` in `core/runtime.rs`, ...)