### PR TITLE
ci: separate cache for cargo home and build output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key:
-            a-cargo-home-${{ hashFiles('Cargo.lock') }}
+            a-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Cache build output
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,17 +167,24 @@ jobs:
           brew install gnu-tar
           echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
 
-      - name: Cache
+      - name: Cache Cargo home
+        uses: actions/cache@v2
+        with:
+          # See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key:
+            a-cargo-home-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache build output
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cargo/git
-            ~/.cargo/registry
             ./target
           key:
-            d-${{ matrix.os }}-${{ matrix.kind }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            d-${{ matrix.os }}-${{ matrix.kind }}-
+            d-${{ matrix.os }}-${{ matrix.kind }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache


### PR DESCRIPTION
This PR tries to separate CI cache into 2 pieces: one for Cargo home (~/.cargo) and one for build output (./target). And inside cargo home this change only caches necessary part of it.