### PR TITLE
feat(core): allow async opcalls in snapshots

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -305,9 +305,7 @@ impl JsRuntime {
     if !has_startup_snapshot {
       js_runtime.js_init();
     }
-    if !options.will_snapshot {
-      js_runtime.init_recv_cb();
-    }
+    js_runtime.init_recv_cb();
 
     js_runtime
   }
@@ -432,7 +430,9 @@ impl JsRuntime {
     // TODO(piscisaureus): The rusty_v8 type system should enforce this.
     state.borrow_mut().global_context.take();
 
+    // Drop v8::Global handles before snapshotting
     std::mem::take(&mut state.borrow_mut().module_map);
+    std::mem::take(&mut state.borrow_mut().js_recv_cb);
 
     let snapshot_creator = self.snapshot_creator.as_mut().unwrap();
     let snapshot = snapshot_creator


### PR DESCRIPTION
## Rationale

We previously made a strong distinction between isolates created for snapshotting and those not. I'm not sure that distinction is meaningful/useful anymore. We store relatively minimal shared state now, without the shared queue.

In Deno CLI we only create "opless" JsRuntimes when snapshotting, but I think removing that disparity would make them less of an edge-case and could allow interesting use-cases for end-users & embedders. We're also somewhat underusing snapshots, essentially "only" using them to preload builtin JS code and the initial JS bootstrap.

One could easily imagine how this could allow snapshots to be used with `deno compile` and enable users to do relatively heavy & complex init using regular Deno code (e.g: reading in files, prefetching network data, etc... at "compile time"). Enabling complex `deno compile`d apps to have very fast startup times.

## Conclusion

Having full fledged JsRuntimes at snapshot time could be powerful and enable users to pre-compute a more meaningful initial state for their apps. But this can naturally allow users to shoot themselves in the foot with tricky bugs due o this statefulness.

I would still argue it's useful to expose in `deno_core` whether it should be fully exposed to Deno CLI users is undecided.

## Changes

- [x] Init `js_recv_cb` even when snapshotting, so async ops are possible
- [ ] Maybe add a `reset()` in `core.js` to reset internal state
(e.g: emptying promise ring/table, not absolutely necessary IMO, since there's no hard requirement that promise IDs start at 1 and JsRuntimes should only be snapshotted after being fully polled and thus emptied of pending promises)
- [ ] Maybe init ops in to-be-snapshotted JsRuntimes (or do that after we land JsRuntime Extensions)

## Follow-ups

- Figure out to expose this to `deno compile` users