### PR TITLE
fix(cli): standalone bin corruption

### DIFF
--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -170,7 +170,7 @@ pub async fn write_standalone_binary(
     if !has_trailer {
       bail!("Could not compile: cannot overwrite {:?}.", &output);
     }
-    
+
     // Remove file if it was indeed a deno compiled binary, to avoid corruption
     // (see https://github.com/denoland/deno/issues/10310)
     std::fs::remove_file(&output)?;

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -170,6 +170,10 @@ pub async fn write_standalone_binary(
     if !has_trailer {
       bail!("Could not compile: cannot overwrite {:?}.", &output);
     }
+    
+    // Remove file if it was indeed a deno compiled binary, to avoid corruption
+    // (see https://github.com/denoland/deno/issues/10310)
+    std::fs::remove_file(&output)?;
   }
   tokio::fs::write(&output, final_bin).await?;
   #[cfg(unix)]


### PR DESCRIPTION
Remove old bin before writing new bin when generating `deno compile` standalone binaries, fixes #10310

## Output of reproducible test

With this PR's fix we no longer see the crash when running #10310's reproducible cases:

```
❯ cat <<EOF | bash
rm ./hello ./hello.js &>/dev/null
echo "console.log('Hello Dev')" > hello.js
./target/debug/deno compile --unstable hello.js
ls -hal ./hello
shasum ./hello
./hello
./target/debug/deno compile --unstable --lite hello.js
ls -hal ./hello
shasum ./hello
./hello
rm ./hello ./hello.js &>/dev/null
EOF
Bundle file:///Users/aaron/git/deno/hello.js
Compile file:///Users/aaron/git/deno/hello.js
Emit hello
-rwxrwxrwx  1 aaron  staff   244M Apr 22 12:06 ./hello
409ba1af12e17141c585d708244a8bb856df9965  ./hello
Hello Dev
Bundle file:///Users/aaron/git/deno/hello.js
Compile file:///Users/aaron/git/deno/hello.js
Archive:  /var/folders/p0/t3q1dqy57fsdfqtvxqgbp04m0000gn/T/.tmpjIlXkI/denort.zip
  inflating: denort
Emit hello
-rwxrwxrwx  1 aaron  staff    50M Apr 22 12:06 ./hello
26ca5e0386d35de001b1ef6bb42da3481a3cc0cd  ./hello
Hello Dev
```