### PR TITLE
fix(op_crates/webgpu): move non-null op buffer arg check when needed

### DIFF
--- a/op_crates/webgpu/bundle.rs
+++ b/op_crates/webgpu/bundle.rs
@@ -138,8 +138,6 @@ pub fn op_webgpu_render_bundle_encoder_set_bind_group(
   args: RenderBundleEncoderSetBindGroupArgs,
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<WebGpuResult, AnyError> {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
-
   let bind_group_resource = state
     .resource_table
     .get::<super::binding::WebGpuBindGroup>(args.bind_group)
@@ -165,6 +163,7 @@ pub fn op_webgpu_render_bundle_encoder_set_bind_group(
       );
     },
     None => {
+      let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
       let (prefix, data, suffix) = unsafe { zero_copy.align_to::<u32>() };
       assert!(prefix.is_empty());
       assert!(suffix.is_empty());

--- a/op_crates/webgpu/render_pass.rs
+++ b/op_crates/webgpu/render_pass.rs
@@ -327,7 +327,6 @@ pub fn op_webgpu_render_pass_set_bind_group(
   args: RenderPassSetBindGroupArgs,
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<WebGpuResult, AnyError> {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let bind_group_resource = state
     .resource_table
     .get::<super::binding::WebGpuBindGroup>(args.bind_group)
@@ -353,6 +352,7 @@ pub fn op_webgpu_render_pass_set_bind_group(
       );
     },
     None => {
+      let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
       let (prefix, data, suffix) = unsafe { zero_copy.align_to::<u32>() };
       assert!(prefix.is_empty());
       assert!(suffix.is_empty());


### PR DESCRIPTION
Due to this, currently a few webgpu examples dont work. Was introduced in #9944