### PR TITLE
BREAKING(unstable): Rename Deno.emit() bundle options to "module" and "classic"

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -441,10 +441,10 @@ declare namespace Deno {
    */
   export interface EmitOptions {
     /** Indicate that the source code should be emitted to a single file
-     * JavaScript bundle that is a single ES module (`"esm"`) or a single file
-     * self contained script we executes in an immediately invoked function
-     * when loaded (`"iife"`). */
-    bundle?: "esm" | "iife";
+     * JavaScript bundle that is a single ES module (`"module"`) or a single
+     * file self contained script we executes in an immediately invoked function
+     * when loaded (`"classic"`). */
+    bundle?: "module" | "classic";
     /** If `true` then the sources will be typed checked, returning any
      * diagnostic errors in the result.  If `false` type checking will be
      * skipped.  Defaults to `true`.

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -33,10 +33,10 @@ pub fn init(rt: &mut deno_core::JsRuntime) {
 
 #[derive(Debug, Deserialize)]
 enum RuntimeBundleType {
-  #[serde(rename = "esm")]
-  Esm,
-  #[serde(rename = "iife")]
-  Iife,
+  #[serde(rename = "module")]
+  Module,
+  #[serde(rename = "classic")]
+  Classic,
 }
 
 #[derive(Debug, Deserialize)]
@@ -108,8 +108,8 @@ async fn op_emit(
       ))
     })?;
   let bundle_type = match args.bundle {
-    Some(RuntimeBundleType::Esm) => BundleType::Esm,
-    Some(RuntimeBundleType::Iife) => BundleType::Iife,
+    Some(RuntimeBundleType::Module) => BundleType::Module,
+    Some(RuntimeBundleType::Classic) => BundleType::Classic,
     None => BundleType::None,
   };
   let graph = builder.get_graph();

--- a/cli/tests/compiler_api_test.ts
+++ b/cli/tests/compiler_api_test.ts
@@ -173,12 +173,12 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Deno.emit() - bundle esm - with sources",
+  name: "Deno.emit() - bundle as module script - with sources",
   async fn() {
     const { diagnostics, files, ignoredOptions, stats } = await Deno.emit(
       "/foo.ts",
       {
-        bundle: "esm",
+        bundle: "module",
         sources: {
           "/foo.ts": `export * from "./bar.ts";\n`,
           "/bar.ts": `export const bar = "bar";\n`,
@@ -194,12 +194,12 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Deno.emit() - bundle esm - no sources",
+  name: "Deno.emit() - bundle as module script - no sources",
   async fn() {
     const { diagnostics, files, ignoredOptions, stats } = await Deno.emit(
       "./subdir/mod1.ts",
       {
-        bundle: "esm",
+        bundle: "module",
       },
     );
     assertEquals(diagnostics.length, 0);
@@ -211,12 +211,12 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Deno.emit() - bundle esm - include js modules",
+  name: "Deno.emit() - bundle as module script - include js modules",
   async fn() {
     const { diagnostics, files, ignoredOptions, stats } = await Deno.emit(
       "/foo.js",
       {
-        bundle: "esm",
+        bundle: "module",
         sources: {
           "/foo.js": `export * from "./bar.js";\n`,
           "/bar.js": `export const bar = "bar";\n`,
@@ -321,10 +321,10 @@ Deno.test({
 });
 
 Deno.test({
-  name: `Deno.emit() - bundle supports iife`,
+  name: `Deno.emit() - bundle as classic script iife`,
   async fn() {
     const { diagnostics, files } = await Deno.emit("/a.ts", {
-      bundle: "iife",
+      bundle: "classic",
       sources: {
         "/a.ts": `import { b } from "./b.ts";
           console.log(b);`,

--- a/docs/typescript/runtime.md
+++ b/docs/typescript/runtime.md
@@ -23,10 +23,10 @@ The emit options are defined in the `Deno` namespace as:
 ```ts
 interface EmitOptions {
   /** Indicate that the source code should be emitted to a single file
-    * JavaScript bundle that is a single ES module (`"esm"`) or a single file
-    * self contained script we executes in an immediately invoked function
-    * when loaded (`"iife"`). */
-  bundle?: "esm" | "iife";
+    * JavaScript bundle that is a single ES module (`"module"`) or a single
+    * file self contained script we executes in an immediately invoked function
+    * when loaded (`"classic"`). */
+  bundle?: "module" | "classic";
   /** If `true` then the sources will be typed checked, returning any
     * diagnostic errors in the result.  If `false` type checking will be
     * skipped.  Defaults to `true`.
@@ -181,13 +181,13 @@ if (diagnostics.length) {
 ### Bundling
 
 `Deno.emit()` is also capable of providing output similar to `deno bundle` on
-the command line. This is enabled by setting the _bundle_ option to `"esm"` or
-`"iife"`. Currently Deno supports bundling as a single file ES module (`"esm"`)
-or a single file self contained legacy script (`"iife"`).
+the command line. This is enabled by setting the _bundle_ option to `"module"`
+or `"classic"`. Currently Deno supports bundling as a single file ES module
+(`"module"`) or a single file self contained legacy script (`"classic"`).
 
 ```ts
 const { files, diagnostics } = await Deno.emit("./mod.ts", {
-  bundle: "esm",
+  bundle: "module",
 });
 ```
 
@@ -215,7 +215,7 @@ version of _lodash_ I am using with my project. I could do the following:
 
 ```ts
 const { files } = await Deno.emit("mod.ts", {
-  bundle: "esm",
+  bundle: "module",
   importMap: {
     imports: {
       "lodash": "https://deno.land/x/lodash",

--- a/runtime/js/40_compiler_api.js
+++ b/runtime/js/40_compiler_api.js
@@ -17,7 +17,7 @@
 
   /**
    * @typedef {object} OpEmitRequest
-   * @property {"esm"=} bundle
+   * @property {"module" | "classic"=} bundle
    * @property {boolean=} check
    * @property {Record<string, any>=} compilerOptions
    * @property {ImportMap=} importMap
@@ -35,7 +35,7 @@
    */
 
   /**
-   * @param {OpEmitRequest} request 
+   * @param {OpEmitRequest} request
    * @returns {Promise<OpEmitResponse>}
    */
   function opEmit(request) {
@@ -43,7 +43,7 @@
   }
 
   /**
-   * @param {string} specifier 
+   * @param {string} specifier
    * @returns {string}
    */
   function checkRelative(specifier) {
@@ -54,7 +54,7 @@
 
   /**
    * @typedef {object} EmitOptions
-   * @property {"esm"=} bundle
+   * @property {"module" | "classic"=} bundle
    * @property {boolean=} check
    * @property {Record<string, any>=} compilerOptions
    * @property {ImportMap=} importMap
@@ -63,9 +63,9 @@
    */
 
   /**
-   * @param {string | URL} rootSpecifier 
+   * @param {string | URL} rootSpecifier
    * @param {EmitOptions=} options
-   * @returns {Promise<OpEmitResponse>} 
+   * @returns {Promise<OpEmitResponse>}
    */
   function emit(rootSpecifier, options = {}) {
     util.log(`Deno.emit`, { rootSpecifier });


### PR DESCRIPTION
Closes #10288.