### PR TITLE
fix(op_crates/fetch): Prevent throwing when inspecting a request

### DIFF
--- a/cli/tests/unit/request_test.ts
+++ b/cli/tests/unit/request_test.ts
@@ -53,3 +53,17 @@ unitTest(async function cloneRequestBodyStream(): Promise<void> {
 
   assertEquals(b1, b2);
 });
+
+unitTest(function customInspectFunction(): void {
+  const request = new Request("https://example.com");
+  assertEquals(
+    Deno.inspect(request),
+    `Request {
+  bodyUsed: false,
+  headers: Headers {},
+  method: "GET",
+  redirect: "follow",
+  url: "https://example.com/"
+}`,
+  );
+});

--- a/op_crates/fetch/23_request.js
+++ b/op_crates/fetch/23_request.js
@@ -392,7 +392,7 @@
         headers: this.headers,
         method: this.method,
         redirect: this.redirect,
-        url: this.url(),
+        url: this.url,
       };
       return `Request ${inspect(inner)}`;
     }


### PR DESCRIPTION
Fixes #10334

If there is any contextual data to change, please let me know if I missed it.