### PR TITLE
refactor(core): move op cache sync responsibility to rust space

### DIFF
--- a/bench_util/src/js_runtime.rs
+++ b/bench_util/src/js_runtime.rs
@@ -16,13 +16,7 @@ pub fn create_js_runtime(setup: impl FnOnce(&mut JsRuntime)) -> JsRuntime {
   setup(&mut rt);
 
   // Init ops
-  rt.execute(
-    "init",
-    r#"
-      Deno.core.ops();
-    "#,
-  )
-  .unwrap();
+  rt.sync_ops_cache();
 
   rt
 }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -210,6 +210,8 @@ fn create_compiler_snapshot(
       }
     }),
   );
+  js_runtime.sync_ops_cache();
+
   create_snapshot(js_runtime, snapshot_path, files);
 }
 

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2122,6 +2122,7 @@ pub fn start(debug: bool) -> Result<JsRuntime, AnyError> {
   runtime.register_op("op_respond", op(respond));
   runtime.register_op("op_script_names", op(script_names));
   runtime.register_op("op_script_version", op(script_version));
+  runtime.sync_ops_cache();
 
   let init_config = json!({ "debug": debug });
   let init_src = format!("globalThis.serverInit({});", init_config);

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -148,6 +148,7 @@ fn create_web_worker_callback(
       if args.use_deno_namespace {
         ops::runtime_compiler::init(js_runtime);
       }
+      js_runtime.sync_ops_cache();
     }
     worker.bootstrap(&options);
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -218,6 +218,7 @@ pub fn create_main_worker(
     // above
     ops::errors::init(js_runtime);
     ops::runtime_compiler::init(js_runtime);
+    js_runtime.sync_ops_cache();
   }
   worker.bootstrap(&options);
 

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -496,6 +496,7 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
   runtime.register_op("op_load", op(load));
   runtime.register_op("op_resolve", op(resolve));
   runtime.register_op("op_respond", op(respond));
+  runtime.sync_ops_cache();
 
   let startup_source = "globalThis.startup({ legacyFlag: false })";
   let request_value = json!({

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -778,7 +778,6 @@ delete Object.prototype.__proto__;
     }
     hasStarted = true;
     languageService = ts.createLanguageService(host);
-    core.ops();
     setLogDebug(debugFlag, "TSLS");
     debug("serverInit()");
   }
@@ -793,12 +792,8 @@ delete Object.prototype.__proto__;
       throw new Error("The compiler runtime already started.");
     }
     hasStarted = true;
-    core.ops();
     setLogDebug(!!debugFlag, "TS");
   }
-
-  // Setup the compiler runtime during the build process.
-  core.ops();
 
   // A build time only op that provides some setup information that is used to
   // ensure the snapshot is setup properly.

--- a/core/benches/op_baseline.rs
+++ b/core/benches/op_baseline.rs
@@ -20,16 +20,7 @@ fn create_js_runtime() -> JsRuntime {
   runtime.register_op("nop", |state, _, _| {
     Op::Sync(serialize_op_result(Ok(9), state))
   });
-
-  // Init ops
-  runtime
-    .execute(
-      "init",
-      r#"
-      Deno.core.ops();
-    "#,
-    )
-    .unwrap();
+  runtime.sync_ops_cache();
 
   runtime
 }

--- a/core/core.js
+++ b/core/core.js
@@ -60,10 +60,12 @@
   }
 
   function ops() {
-    // op id 0 is a special value to retrieve the map of registered ops.
-    const newOpsCache = Object.fromEntries(opcall(0));
-    opsCache = Object.freeze(newOpsCache);
     return opsCache;
+  }
+
+  function syncOpsCache() {
+    // op id 0 is a special value to retrieve the map of registered ops.
+    opsCache = Object.freeze(Object.fromEntries(opcall(0)));
   }
 
   function handleAsyncMsgFromRust() {
@@ -130,5 +132,6 @@
     resources,
     registerErrorClass,
     handleAsyncMsgFromRust,
+    syncOpsCache,
   });
 })(this);

--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -56,6 +56,7 @@ fn main() {
       Ok(sum)
     }),
   );
+  runtime.sync_ops_cache();
 
   // Now we see how to invoke the ops we just defined. The runtime automatically
   // contains a Deno.core object with several functions for interacting with it.
@@ -64,11 +65,7 @@ fn main() {
     .execute(
       "<init>",
       r#"
-// First we initialize the ops cache.
-// This maps op names to their id's.
-Deno.core.ops();
-
-// Then we define a print function that uses
+// Define a print function that uses
 // our op_print op to display the stringified argument.
 const _newline = new Uint8Array([10]);
 function print(value) {

--- a/core/examples/http_bench_json_ops.js
+++ b/core/examples/http_bench_json_ops.js
@@ -54,8 +54,6 @@ async function serve(rid) {
 }
 
 async function main() {
-  Deno.core.ops();
-
   const listenerRid = listen();
   Deno.core.print(`http_bench_ops listening on http://127.0.0.1:4544/\n`);
 

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -116,6 +116,7 @@ fn create_js_runtime() -> JsRuntime {
   runtime.register_op("accept", deno_core::op_async(op_accept));
   runtime.register_op("read", deno_core::op_async(op_read));
   runtime.register_op("write", deno_core::op_async(op_write));
+  runtime.sync_ops_cache();
   runtime
 }
 

--- a/core/ops_json.rs
+++ b/core/ops_json.rs
@@ -25,15 +25,15 @@ use std::rc::Rc;
 /// ```ignore
 /// let mut runtime = JsRuntime::new(...);
 /// runtime.register_op("hello", deno_core::op_sync(Self::hello_op));
+/// runtime.sync_ops_cache();
 /// ```
 ///
 /// ...it can be invoked from JS using the provided name, for example:
 /// ```js
-/// Deno.core.ops();
 /// let result = Deno.core.opSync("function_name", args);
 /// ```
 ///
-/// The `Deno.core.ops()` statement is needed once before any op calls, for initialization.
+/// `runtime.sync_ops_cache()` must be called after registering new ops
 /// A more complete example is available in the examples directory.
 pub fn op_sync<F, V, R>(op_fn: F) -> Box<OpFn>
 where
@@ -63,15 +63,15 @@ where
 /// ```ignore
 /// let mut runtime = JsRuntime::new(...);
 /// runtime.register_op("hello", deno_core::op_async(Self::hello_op));
+/// runtime.sync_ops_cache();
 /// ```
 ///
 /// ...it can be invoked from JS using the provided name, for example:
 /// ```js
-/// Deno.core.ops();
 /// let future = Deno.core.opAsync("function_name", args);
 /// ```
 ///
-/// The `Deno.core.ops()` statement is needed once before any op calls, for initialization.
+/// `runtime.sync_ops_cache()` must be called after registering new ops
 /// A more complete example is available in the examples directory.
 pub fn op_async<F, V, R, RV>(op_fn: F) -> Box<OpFn>
 where
@@ -116,13 +116,11 @@ mod tests {
     }
 
     runtime.register_op("op_throw", op_async(op_throw));
+    runtime.sync_ops_cache();
     runtime
       .execute(
         "<init>",
         r#"
-    // First we initialize the ops cache. This maps op names to their id's.
-    Deno.core.ops();
-
     async function f1() {
       await Deno.core.opAsync('op_throw', 'hello');
     }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -372,7 +372,7 @@ impl JsRuntime {
   /// Ensures core.js has the latest op-name to op-id mappings
   pub fn sync_ops_cache(&mut self) {
     self
-      .execute("deno:core/internals", "Deno.core.syncOpsCache()")
+      .execute("<anon>", "Deno.core.syncOpsCache()")
       .unwrap()
   }
 

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -369,6 +369,13 @@ impl JsRuntime {
     state.js_recv_cb.replace(v8::Global::new(scope, cb));
   }
 
+  /// Ensures core.js has the latest op-name to op-id mappings
+  pub fn sync_ops_cache(&mut self) {
+    self
+      .execute("deno:core/internals", "Deno.core.syncOpsCache()")
+      .unwrap()
+  }
+
   /// Returns the runtime's op state, which can be used to maintain ops
   /// and access resources between op calls.
   pub fn op_state(&mut self) -> Rc<RefCell<OpState>> {
@@ -2140,6 +2147,7 @@ pub mod tests {
         module_loader: Some(loader),
         ..Default::default()
       });
+      runtime.sync_ops_cache();
       runtime
         .execute(
           "file:///dyn_import3.js",
@@ -2149,8 +2157,6 @@ pub mod tests {
             if (mod.b() !== 'b') {
               throw Error("bad");
             }
-            // Now do any op
-            Deno.core.ops();
           })();
           "#,
         )

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -371,9 +371,7 @@ impl JsRuntime {
 
   /// Ensures core.js has the latest op-name to op-id mappings
   pub fn sync_ops_cache(&mut self) {
-    self
-      .execute("<anon>", "Deno.core.syncOpsCache()")
-      .unwrap()
+    self.execute("<anon>", "Deno.core.syncOpsCache()").unwrap()
   }
 
   /// Returns the runtime's op state, which can be used to maintain ops

--- a/op_crates/url/benches/url_ops.rs
+++ b/op_crates/url/benches/url_ops.rs
@@ -15,6 +15,7 @@ fn create_js_runtime() -> JsRuntime {
     "op_url_stringify_search_params",
     op_sync(deno_url::op_url_stringify_search_params),
   );
+  runtime.sync_ops_cache();
 
   runtime
     .execute(
@@ -23,14 +24,6 @@ fn create_js_runtime() -> JsRuntime {
     )
     .unwrap();
   deno_url::init(&mut runtime);
-  runtime
-    .execute(
-      "init",
-      r#"
-      Deno.core.ops();
-    "#,
-    )
-    .unwrap();
   runtime
     .execute("setup", "const { URL } = globalThis.__bootstrap.url;")
     .unwrap();

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -142,8 +142,6 @@ delete Object.prototype.__proto__;
   }
 
   function runtimeStart(runtimeOptions, source) {
-    core.ops();
-
     core.setMacrotaskCallback(timers.handleTimerMacrotask);
     version.setVersions(
       runtimeOptions.denoVersion,

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -284,6 +284,7 @@ impl WebWorker {
           t.add(stream);
         }
       }
+      js_runtime.sync_ops_cache();
 
       worker
     }

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -171,6 +171,7 @@ impl MainWorker {
         t.add(stream);
       }
     }
+    js_runtime.sync_ops_cache();
 
     worker
   }


### PR DESCRIPTION
Even if bootstrapping the JS runtime is low level, it's an abstraction leak of core to require users to call `Deno.core.ops()` in JS space.

So instead we're introducing a `JsRuntime::sync_ops_cache()` method, once we have runtime extensions a new runtime will ensure the ops cache is setup (for the provided extensions) and then loading/unloading plugins should be the only operations that require op cache syncs.

This also splits `Deno.core.ops()` into `Deno.core.syncOpsCache()` and `Deno.core.ops()`, which respectively sync the ops cache and return the ops cache without syncing it (useful for debugging or testing)