### PR TITLE
ci: only run WPT on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,24 +281,20 @@ jobs:
           cargo test --locked --doc
           cargo test --locked --all-targets
 
-      - name: Configure hosts file for WPT (unix)
-        if: runner.os != 'Windows'
+      # TODO(ry) Because CI is so slow on for OSX and Windows, we currently only run WPT on Linux.
+      - name: Configure hosts file for WPT (linux)
+        if: startsWith(matrix.os, 'ubuntu')
         run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
         working-directory: test_util/wpt/
 
-      - name: Configure hosts file for WPT (windows)
-        if: runner.os == 'Windows'
-        working-directory: test_util/wpt/
-        run: python wpt make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts -Encoding ascii -Append
-
       - name: Run web platform tests (release)
-        if: matrix.kind == 'test' && matrix.profile == 'release'
+        if: startsWith(matrix.os, 'ubuntu') && matrix.kind == 'test' && matrix.profile == 'release'
         run: |
           deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts setup
           deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts run --quiet --release
 
       - name: Run web platform tests (debug)
-        if: matrix.kind == 'test' && matrix.profile == 'debug'
+        if: startsWith(matrix.os, 'ubuntu') && matrix.kind == 'test' && matrix.profile == 'debug'
         run: |
           deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts setup
           deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts run --quiet


### PR DESCRIPTION
 Because CI is so slow on for OSX and Windows, we should only run WPT on Linux.