### PR TITLE
fix(cli/dts): sleepSync doesn't return a Promise

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1124,7 +1124,7 @@ declare namespace Deno {
    * Deno.sleepSync(10);
    * ```
    */
-  export function sleepSync(millis: number): Promise<void>;
+  export function sleepSync(millis: number): void;
 
   export interface Metrics extends OpMetrics {
     ops: Record<string, OpMetrics>;


### PR DESCRIPTION
Per its name it's synchronous for the current thread