### PR TITLE
fix(cli/ast): Exclude dynamic imports from static dep analysis

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -27,6 +27,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
+use swc_ecmascript::dep_graph::analyze_dependencies as swc_analyze_dependencies;
 
 lazy_static::lazy_static! {
   /// Diagnostic error codes which actually are the same, and so when grouping
@@ -287,7 +288,11 @@ pub fn analyze_dependencies(
   }
 
   // Parse ES and type only imports
-  let descriptors = parsed_module.analyze_dependencies();
+  let descriptors = swc_analyze_dependencies(
+    &parsed_module.module,
+    &parsed_module.source_map,
+    &parsed_module.comments,
+  );
   for desc in descriptors.into_iter().filter(|desc| {
     desc.kind != swc_ecmascript::dep_graph::DependencyKind::Require
   }) {

--- a/cli/tests/092_import_map_no_dynamic_dependency_analysis.ts
+++ b/cli/tests/092_import_map_no_dynamic_dependency_analysis.ts
@@ -1,0 +1,3 @@
+if (eval("false")) {
+  await import("foo");
+}

--- a/cli/tests/error_016_dynamic_import_permissions2.out
+++ b/cli/tests/error_016_dynamic_import_permissions2.out
@@ -1,4 +1,5 @@
 [WILDCARD]
-error: Remote modules are not allowed to import local modules.  Consider using a dynamic import instead.
+error: Uncaught (in promise) TypeError: Remote modules are not allowed to import local modules.  Consider using a dynamic import instead.
   Importing: file:///c:/etc/passwd
     at http://localhost:4545/cli/tests/subdir/evil_remote_import.js:3:0
+[WILDCARD]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2907,6 +2907,12 @@ console.log("finish");
     exit_code: 1,
   });
 
+  // Regression test for https://github.com/denoland/deno/issues/10168.
+  itest!(_092_import_map_no_dynamic_dependency_analysis {
+    args: "run --import-map import_maps/import_map.json 092_import_map_no_dynamic_dependency_analysis.ts",
+    output_str: Some("[WILDCARD]"),
+  });
+
   itest!(js_import_detect {
     args: "run --quiet --reload js_import_detect.ts",
     output: "js_import_detect.ts.out",

--- a/cli/tests/single_compile_with_reload.ts.out
+++ b/cli/tests/single_compile_with_reload.ts.out
@@ -1,4 +1,5 @@
 Check [WILDCARD]single_compile_with_reload.ts
+Check [WILDCARD]single_compile_with_reload_dyn.ts
 Hello
 1
 2


### PR DESCRIPTION
Closes #10168. I've excluded the LSP from this change, please comment.