### PR TITLE
feat(net): allow unix sockets on windows

### DIFF
--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -36,7 +36,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  { perms: { read: true, write: true } },
   function netUnixListenClose(): void {
     const filePath = Deno.makeTempFileSync();
     const socket = Deno.listen({
@@ -50,7 +50,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  { perms: { read: true, write: true } },
   function netUnixPacketListenClose(): void {
     const filePath = Deno.makeTempFileSync();
     const socket = Deno.listenDatagram({
@@ -64,7 +64,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true } },
+  { perms: { read: true } },
   function netUnixListenWritePermission(): void {
     assertThrows(() => {
       const filePath = Deno.makeTempFileSync();
@@ -80,7 +80,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true } },
+  { perms: { read: true } },
   function netUnixPacketListenWritePermission(): void {
     assertThrows(() => {
       const filePath = Deno.makeTempFileSync();
@@ -114,7 +114,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  { perms: { read: true, write: true } },
   async function netUnixCloseWhileAccept(): Promise<void> {
     const filePath = await Deno.makeTempFile();
     const listener = Deno.listen({
@@ -219,7 +219,7 @@ unitTest({ perms: { net: true } }, async function netTcpDialListen(): Promise<
 });
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  { perms: { read: true, write: true } },
   async function netUnixDialListen(): Promise<void> {
     const filePath = await Deno.makeTempFile();
     const listener = Deno.listen({ path: filePath, transport: "unix" });
@@ -324,7 +324,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  { perms: { read: true, write: true } },
   async function netUnixPacketSendReceive(): Promise<void> {
     const filePath = await Deno.makeTempFile();
     const alice = Deno.listenDatagram({
@@ -448,7 +448,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  { perms: { read: true, write: true } },
   async function netUnixListenCloseWhileIterating(): Promise<void> {
     const filePath = Deno.makeTempFileSync();
     const socket = Deno.listen({ path: filePath, transport: "unix" });
@@ -462,7 +462,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  { perms: { read: true, write: true } },
   async function netUnixPacketListenCloseWhileIterating(): Promise<void> {
     const filePath = Deno.makeTempFileSync();
     const socket = Deno.listenDatagram({

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -50,7 +50,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
   function netUnixPacketListenClose(): void {
     const filePath = Deno.makeTempFileSync();
     const socket = Deno.listenDatagram({
@@ -80,7 +80,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true } },
+  { ignore: Deno.build.os === "windows", perms: { read: true } },
   function netUnixPacketListenWritePermission(): void {
     assertThrows(() => {
       const filePath = Deno.makeTempFileSync();
@@ -324,7 +324,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
   async function netUnixPacketSendReceive(): Promise<void> {
     const filePath = await Deno.makeTempFile();
     const alice = Deno.listenDatagram({
@@ -462,7 +462,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
   async function netUnixPacketListenCloseWhileIterating(): Promise<void> {
     const filePath = Deno.makeTempFileSync();
     const socket = Deno.listenDatagram({

--- a/runtime/ops/mod.rs
+++ b/runtime/ops/mod.rs
@@ -8,7 +8,6 @@ pub mod fs_events;
 pub mod http;
 pub mod io;
 pub mod net;
-#[cfg(unix)]
 mod net_unix;
 pub mod os;
 pub mod permissions;

--- a/runtime/ops/net.rs
+++ b/runtime/ops/net.rs
@@ -35,11 +35,8 @@ use trust_dns_resolver::config::ResolverOpts;
 use trust_dns_resolver::system_conf;
 use trust_dns_resolver::AsyncResolver;
 
-#[cfg(unix)]
 use super::net_unix;
-#[cfg(unix)]
 use crate::ops::io::UnixStreamResource;
-#[cfg(unix)]
 use std::path::Path;
 
 pub fn init(rt: &mut deno_core::JsRuntime) {
@@ -64,9 +61,7 @@ pub struct OpConn {
 pub enum OpAddr {
   Tcp(IpAddr),
   Udp(IpAddr),
-  #[cfg(unix)]
   Unix(net_unix::UnixAddr),
-  #[cfg(unix)]
   UnixPacket(net_unix::UnixAddr),
 }
 
@@ -142,7 +137,6 @@ async fn op_accept(
 ) -> Result<OpConn, AnyError> {
   match args.transport.as_str() {
     "tcp" => accept_tcp(state, args, _buf).await,
-    #[cfg(unix)]
     "unix" => net_unix::accept_unix(state, args, _buf).await,
     other => Err(bad_transport(other)),
   }
@@ -195,7 +189,6 @@ async fn op_datagram_receive(
 ) -> Result<OpPacket, AnyError> {
   match args.transport.as_str() {
     "udp" => receive_udp(state, args, zero_copy).await,
-    #[cfg(unix)]
     "unixpacket" => net_unix::receive_unix_packet(state, args, zero_copy).await,
     other => Err(bad_transport(other)),
   }
@@ -243,7 +236,6 @@ async fn op_datagram_send(
       let byte_length = socket.send_to(&zero_copy, &addr).await?;
       Ok(byte_length)
     }
-    #[cfg(unix)]
     SendArgs {
       rid,
       transport,
@@ -319,7 +311,6 @@ async fn op_connect(
         })),
       })
     }
-    #[cfg(unix)]
     ConnectArgs {
       transport,
       transport_args: ArgsEnum::Unix(args),
@@ -399,7 +390,6 @@ struct IpListenArgs {
 #[serde(untagged)]
 enum ArgsEnum {
   Ip(IpListenArgs),
-  #[cfg(unix)]
   Unix(net_unix::UnixListenArgs),
 }
 
@@ -492,7 +482,6 @@ fn op_listen(
         remote_addr: None,
       })
     }
-    #[cfg(unix)]
     ListenArgs {
       transport,
       transport_args: ArgsEnum::Unix(args),
@@ -533,7 +522,6 @@ fn op_listen(
         remote_addr: None,
       })
     }
-    #[cfg(unix)]
     _ => Err(type_error("Wrong argument format!")),
   }
 }


### PR DESCRIPTION
Given that Windows supports unix sockets [since late 2017](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/), this PR simply removes the conditional compilation around unix sockets which should now build and work on all supported platforms.

Should fix #10244

Blocked on `tokio`/`mio` support for Windows UDS https://github.com/tokio-rs/tokio/issues/2201