### PR TITLE
fix(tls): throw meaningful error when hostname is invalid

### DIFF
--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -32,7 +32,7 @@ unitTest(
 
     await assertThrowsAsync(async () => {
       await Deno.connectTls({ hostname: "127.0.0.1", port: 3567 });
-    }, Error);
+    }, TypeError);
 
     listener.close();
   },

--- a/core/error.rs
+++ b/core/error.rs
@@ -36,6 +36,10 @@ pub fn type_error(message: impl Into<Cow<'static, str>>) -> AnyError {
   custom_error("TypeError", message)
 }
 
+pub fn invalid_hostname(hostname: &str) -> AnyError {
+  type_error(format!("Invalid hostname: '{}'", hostname))
+}
+
 pub fn uri_error(message: impl Into<Cow<'static, str>>) -> AnyError {
   custom_error("URIError", message)
 }

--- a/op_crates/websocket/lib.rs
+++ b/op_crates/websocket/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::bad_resource_id;
+use deno_core::error::invalid_hostname;
 use deno_core::error::null_opbuf;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
@@ -175,8 +176,8 @@ where
       }
 
       let tls_connector = TlsConnector::from(Arc::new(config));
-      let dnsname =
-        DNSNameRef::try_from_ascii_str(&domain).expect("Invalid DNS lookup");
+      let dnsname = DNSNameRef::try_from_ascii_str(domain)
+        .map_err(|_| invalid_hostname(domain))?;
       let tls_socket = tls_connector.connect(dnsname, tcp_socket).await?;
       MaybeTlsStream::Rustls(tls_socket)
     }


### PR DESCRIPTION
`InvalidDNSNameError` is thrown when a string is not a valid hostname,
e.g. it contains invalid characters, or starts with a numeric digit. It
does not involve a (failed) DNS lookup.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
