### PR TITLE
feat: add FsWatcher type

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1925,6 +1925,12 @@ declare namespace Deno {
    */
   export function resources(): ResourceMap;
 
+  export class FsWatcher implements AsyncIterableIterator<FsEvent> {
+    readonly rid: number;
+    next(): Promise<IteratorResult<FsEvent>>;
+    [Symbol.asyncIterator](): AsyncIterableIterator<FsEvent>;
+  }
+
   export interface FsEvent {
     kind: "any" | "access" | "create" | "modify" | "remove";
     paths: string[];
@@ -1947,11 +1953,21 @@ declare namespace Deno {
    *```
    *
    * Requires `allow-read` permission.
+   *
+   * Call `Deno.close(watcher.rid)` to stop watching.
+   *
+   * ```ts
+   * const watcher = Deno.watchFs("/");
+   * setTimeout(() => { Deno.close(watcher.rid); }, 5000);
+   * for await (const event of watcher) {
+   *    console.log(">>>> event", event);
+   * }
+   * ```
    */
   export function watchFs(
     paths: string | string[],
     options?: { recursive: boolean },
-  ): AsyncIterableIterator<FsEvent>;
+  ): FsWatcher;
 
   export class Process<T extends RunOptions = RunOptions> {
     readonly rid: number;


### PR DESCRIPTION
In the type definition `Deno.watchFs` returns `AsyncIterableIterator<FsEvent>`, but it actually returns `FsWatcher` class and has more feature than `AsyncIterableIterator` (for example, it supports closing the watcher).

This PR add FsWatcher type in `lib.deno.ns.d.ts` to fix this situation, and also documents how to close the watcher.

closes #9399