### PR TITLE
fix(op_crate/fetch): infinite loop on fill headers

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -449,6 +449,21 @@ unitTest(
 
 unitTest(
   { perms: { net: true } },
+  async function fetchSeparateInit(): Promise<void> {
+    // related to: https://github.com/denoland/deno/issues/10396
+    const req = new Request("http://localhost:4545/cli/tests/001_hello.js");
+    const init = {
+      method: "GET",
+    };
+    req.headers.set("foo", "bar");
+    const res = await fetch(req, init);
+    assertEquals(res.status, 200);
+    await res.text();
+  },
+);
+
+unitTest(
+  { perms: { net: true } },
   async function fetchInitTypedArrayBody(): Promise<void> {
     const data = "Hello World";
     const response = await fetch("http://localhost:4545/echo_server", {

--- a/op_crates/fetch/23_request.js
+++ b/op_crates/fetch/23_request.js
@@ -247,11 +247,14 @@
 
       // 31.
       if (Object.keys(init).length > 0) {
-        let headers = headerListFromHeaders(this[_headers]);
+        let headers = headerListFromHeaders(this[_headers]).slice(
+          0,
+          headerListFromHeaders(this[_headers]).length,
+        );
         if (init.headers !== undefined) {
           headers = init.headers;
         }
-        headerListFromHeaders(this[_headers]).slice(
+        headerListFromHeaders(this[_headers]).splice(
           0,
           headerListFromHeaders(this[_headers]).length,
         );


### PR DESCRIPTION
Fixes a pesky bug in the fetch implementation where if the init part is
specified in `fetch` instead of the `Request` constructor, the
fillHeaders function receives two references to the same object, causing
it to append to the same list being iterated over.

Fixes #10396 
