### PR TITLE
Revert "ci: build only lib and bins (#10401)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
           path: |
             ./target
           key:
-            b-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ hashFiles('Cargo.lock') }}
+            a-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
@@ -213,16 +213,12 @@ jobs:
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js
 
       - name: Build release
-        if: (matrix.kind == 'test') && matrix.profile == 'release'
-        run: cargo build --release --locked --bin deno --bin test_server -vv
-
-      - name: Build bench release
-        if: (matrix.kind == 'bench') && matrix.profile == 'release'
-        run: cargo build --release --locked --all-targets
+        if: (matrix.kind == 'test' || matrix.kind == 'bench') && matrix.profile == 'release'
+        run: cargo build --release --locked --all-targets -vv
 
       - name: Build debug
-        if: (matrix.kind == 'test') && matrix.profile == 'debug'
-        run: cargo build --locked --bin deno --bin test_server --tests
+        if: (matrix.kind == 'test' || matrix.kind == 'bench') && matrix.profile == 'debug'
+        run: cargo build --locked --all-targets
 
       - name: Pre-release (linux)
         if: |
@@ -280,13 +276,13 @@ jobs:
 
       - name: Test release
         if: matrix.kind == 'test' && matrix.profile == 'release'
-        run: cargo test --release --locked --bins --lib --tests
+        run: cargo test --release --locked --all-targets
 
       - name: Test debug
         if: matrix.kind == 'test' && matrix.profile == 'debug'
         run: |
           cargo test --locked --doc
-          cargo test --locked --bins --lib --tests
+          cargo test --locked --all-targets
 
       # TODO(ry) Because CI is so slow on for OSX and Windows, we currently only run WPT on Linux.
       - name: Configure hosts file for WPT (linux)


### PR DESCRIPTION
This reverts commit 48659c374d769b877905827362387da48cf57a9c.


50 minute mac build on docs-only change https://github.com/denoland/deno/runs/2462335233 

Notice 14m "test release" build. If you know how to avoid without reverting, please raise a PR to correct and close this one.

Merge on approval