### PR TITLE
feat(op_crates/fetch): add send request hook

### DIFF
--- a/runtime/ops/fetch.rs
+++ b/runtime/ops/fetch.rs
@@ -20,7 +20,7 @@ pub fn init(
       ca_data,
     });
   }
-  super::reg_sync(rt, "op_fetch", deno_fetch::op_fetch::<Permissions>);
+  super::reg_sync(rt, "op_fetch", deno_fetch::op_fetch::<Permissions, ()>);
   super::reg_async(rt, "op_fetch_send", deno_fetch::op_fetch_send);
   super::reg_async(
     rt,


### PR DESCRIPTION
Add a SendRequest::send() hook that gives downstream users of the fetch
crate more control over the HTTP request that's sent out.

<hr>

Conversation starter to collect feedback, maybe someone has a better idea? The problems I'm trying to solve:

1. Add/modify/validate request headers (works)

2. Handle DNS myself instead of delegating it to reqwest (partial)

I can tell `reqwest` what IP address to connect to by changing the request URI but I can't tell it to verify the TLS certificate against a host name instead of the address, even when I plug in a `rustls::ClientConfig` with a custom verifier through `reqwest::ClientBuilder::use_preconfigured_tls()`. 🤷

edit: turns out to be a hyper-rustls shortcoming, it always fails with an "invalid dnsname" when `uri.host()` is an IP address...