### PR TITLE
fix(cli/tools/coverage): ignore `$deno$test.js`

### DIFF
--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -596,7 +596,8 @@ fn filter_coverages(
     .filter(|e| {
       let is_internal = e.url.starts_with("deno:")
         || e.url.ends_with("__anonymous__")
-        || e.url.ends_with("$deno$test.ts");
+        || e.url.ends_with("$deno$test.ts")
+        || e.url.ends_with("$deno$test.js");
 
       let is_included = include.iter().any(|p| p.is_match(&e.url));
       let is_excluded = exclude.iter().any(|p| p.is_match(&e.url));


### PR DESCRIPTION
I changed the temporary test runner module url from `$deno$test.ts` to `$deno$test.js` but forgot to add it to the list of ignores when coverage filters out special names.

This adds `$deno$test.js` to that list of ignores.