### PR TITLE
feat(lsp): add internal debugging logging

### DIFF
--- a/cli/logger.rs
+++ b/cli/logger.rs
@@ -1,0 +1,100 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+use std::io::Write;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+struct CliLogger {
+  logger: env_logger::Logger,
+  lsp_debug_flag: Arc<AtomicBool>,
+}
+
+impl CliLogger {
+  pub fn new(
+    logger: env_logger::Logger,
+    lsp_debug_flag: Arc<AtomicBool>,
+  ) -> Self {
+    Self {
+      logger,
+      lsp_debug_flag,
+    }
+  }
+
+  pub fn filter(&self) -> log::LevelFilter {
+    self.logger.filter()
+  }
+}
+
+impl log::Log for CliLogger {
+  fn enabled(&self, metadata: &log::Metadata) -> bool {
+    if metadata.target() == "deno::lsp::performance"
+      && metadata.level() == log::Level::Debug
+    {
+      self.lsp_debug_flag.load(Ordering::Relaxed)
+    } else {
+      self.logger.enabled(metadata)
+    }
+  }
+
+  fn log(&self, record: &log::Record) {
+    if self.enabled(record.metadata()) {
+      self.logger.log(record);
+    }
+  }
+
+  fn flush(&self) {
+    self.logger.flush();
+  }
+}
+
+pub(crate) fn init(
+  maybe_level: Option<log::Level>,
+  lsp_debug_flag: Arc<AtomicBool>,
+) {
+  let log_level = maybe_level.unwrap_or(log::Level::Info);
+  let logger = env_logger::Builder::from_env(
+    env_logger::Env::default()
+      .default_filter_or(log_level.to_level_filter().to_string()),
+  )
+  // https://github.com/denoland/deno/issues/6641
+  .filter_module("rustyline", log::LevelFilter::Off)
+  // wgpu crates (gfx_backend), have a lot of useless INFO and WARN logs
+  .filter_module("wgpu", log::LevelFilter::Error)
+  .filter_module("gfx", log::LevelFilter::Error)
+  // used to make available the lsp_debug which is then filtered out at runtime
+  // in the cli logger
+  .filter_module("deno::lsp::performance", log::LevelFilter::Debug)
+  .format(|buf, record| {
+    let mut target = record.target().to_string();
+    if let Some(line_no) = record.line() {
+      target.push(':');
+      target.push_str(&line_no.to_string());
+    }
+    if record.level() <= log::Level::Info
+      || (record.target() == "deno::lsp::performance"
+        && record.level() == log::Level::Debug)
+    {
+      // Print ERROR, WARN, INFO and lsp_debug logs as they are
+      writeln!(buf, "{}", record.args())
+    } else {
+      // Add prefix to DEBUG or TRACE logs
+      writeln!(
+        buf,
+        "{} RS - {} - {}",
+        record.level(),
+        target,
+        record.args()
+      )
+    }
+  })
+  .build();
+
+  let cli_logger = CliLogger::new(logger, lsp_debug_flag);
+  let max_level = cli_logger.filter();
+  let r = log::set_boxed_logger(Box::new(cli_logger));
+  if r.is_ok() {
+    log::set_max_level(max_level);
+  }
+  r.expect("Could not install logger.");
+}

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -114,9 +114,11 @@ pub struct WorkspaceSettings {
   #[serde(default)]
   pub code_lens: CodeLensSettings,
 
-  /// A flag that indicates if linting is enabled for the workspace.
+  /// A flag that indicates if internal debug logging should be made available.
+  #[serde(default)]
   pub internal_debug: bool,
 
+  /// A flag that indicates if linting is enabled for the workspace.
   #[serde(default)]
   pub lint: bool,
 

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -113,17 +113,18 @@ pub struct WorkspaceSettings {
   /// Code lens specific settings for the workspace.
   #[serde(default)]
   pub code_lens: CodeLensSettings,
-  #[serde(default)]
-
-  /// Suggestion (auto-completion) settings for the workspace.
-  pub suggest: CompletionSettings,
 
   /// A flag that indicates if linting is enabled for the workspace.
+  pub internal_debug: bool,
+
   #[serde(default)]
   pub lint: bool,
 
   /// A flag that indicates if Dene should validate code against the unstable
   /// APIs for the workspace.
+  #[serde(default)]
+  pub suggest: CompletionSettings,
+
   #[serde(default)]
   pub unstable: bool,
 }

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -127,7 +127,9 @@ async fn update_diagnostics(
 
   let ts = async {
     let collection = collection.clone();
-    let mark = snapshot.performance.mark("update_diagnostics_ts", None::<()>);
+    let mark = snapshot
+      .performance
+      .mark("update_diagnostics_ts", None::<()>);
     let diagnostics =
       generate_ts_diagnostics(snapshot.clone(), collection.clone(), ts_server)
         .await
@@ -153,7 +155,9 @@ async fn update_diagnostics(
 
   let deps = async {
     let collection = collection.clone();
-    let mark = snapshot.performance.mark("update_diagnostics_deps", None::<()>);
+    let mark = snapshot
+      .performance
+      .mark("update_diagnostics_deps", None::<()>);
     let diagnostics =
       generate_dependency_diagnostics(snapshot.clone(), collection.clone())
         .await

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -98,13 +98,13 @@ async fn update_diagnostics(
   snapshot: &language_server::StateSnapshot,
   ts_server: &tsc::TsServer,
 ) {
-  let mark = snapshot.performance.mark("update_diagnostics");
+  let mark = snapshot.performance.mark("update_diagnostics", None::<()>);
   let lint_enabled = snapshot.config.workspace_settings.lint;
 
   let lint = async {
     let collection = collection.clone();
     if lint_enabled {
-      let mark = snapshot.performance.mark("update_diagnostics_lint");
+      let mark = snapshot.performance.mark("update_diagnostics_lint", None::<()>);
       let diagnostics =
         generate_lint_diagnostics(snapshot.clone(), collection.clone()).await;
       {
@@ -125,7 +125,7 @@ async fn update_diagnostics(
 
   let ts = async {
     let collection = collection.clone();
-    let mark = snapshot.performance.mark("update_diagnostics_ts");
+    let mark = snapshot.performance.mark("update_diagnostics_ts", None::<()>);
     let diagnostics =
       generate_ts_diagnostics(snapshot.clone(), collection.clone(), ts_server)
         .await
@@ -151,7 +151,7 @@ async fn update_diagnostics(
 
   let deps = async {
     let collection = collection.clone();
-    let mark = snapshot.performance.mark("update_diagnostics_deps");
+    let mark = snapshot.performance.mark("update_diagnostics_deps", None::<()>);
     let diagnostics =
       generate_dependency_diagnostics(snapshot.clone(), collection.clone())
         .await

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -104,7 +104,9 @@ async fn update_diagnostics(
   let lint = async {
     let collection = collection.clone();
     if lint_enabled {
-      let mark = snapshot.performance.mark("update_diagnostics_lint", None::<()>);
+      let mark = snapshot
+        .performance
+        .mark("update_diagnostics_lint", None::<()>);
       let diagnostics =
         generate_lint_diagnostics(snapshot.clone(), collection.clone()).await;
       {

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -674,7 +674,9 @@ impl Inner {
     &mut self,
     params: DidChangeConfigurationParams,
   ) {
-    let mark = self.performance.mark("did_change_configuration", Some(&params));
+    let mark = self
+      .performance
+      .mark("did_change_configuration", Some(&params));
 
     if self.config.client_capabilities.workspace_configuration {
       let specifiers: Vec<ModuleSpecifier> =
@@ -1870,7 +1872,9 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("prepare_call_hierarchy", Some(&params));
+    let mark = self
+      .performance
+      .mark("prepare_call_hierarchy", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
@@ -2124,7 +2128,9 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("semantic_tokens_range", Some(&params));
+    let mark = self
+      .performance
+      .mark("semantic_tokens_range", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -198,7 +198,9 @@ impl Inner {
     &mut self,
     specifier: ModuleSpecifier,
   ) -> Result<LineIndex, AnyError> {
-    let mark = self.performance.mark("get_line_index");
+    let mark = self
+      .performance
+      .mark("get_line_index", Some(json!({ "specifier": specifier })));
     let result = if specifier.scheme() == "asset" {
       if let Some(asset) = self.get_asset(&specifier).await? {
         Ok(asset.line_index)
@@ -222,7 +224,10 @@ impl Inner {
     &self,
     specifier: &ModuleSpecifier,
   ) -> Option<LineIndex> {
-    let mark = self.performance.mark("get_line_index_sync");
+    let mark = self.performance.mark(
+      "get_line_index_sync",
+      Some(json!({ "specifier": specifier })),
+    );
     let maybe_line_index = if specifier.scheme() == "asset" {
       if let Some(Some(asset)) = self.assets.get(specifier) {
         Some(asset.line_index.clone())
@@ -264,7 +269,10 @@ impl Inner {
     &mut self,
     specifier: &ModuleSpecifier,
   ) -> Result<tsc::NavigationTree, AnyError> {
-    let mark = self.performance.mark("get_navigation_tree");
+    let mark = self.performance.mark(
+      "get_navigation_tree",
+      Some(json!({ "specifier": specifier })),
+    );
     if let Some(navigation_tree) = self.navigation_trees.get(specifier) {
       self.performance.measure(mark);
       Ok(navigation_tree.clone())
@@ -297,7 +305,7 @@ impl Inner {
   }
 
   pub async fn update_import_map(&mut self) -> Result<(), AnyError> {
-    let mark = self.performance.mark("update_import_map");
+    let mark = self.performance.mark("update_import_map", None::<()>);
     let (maybe_import_map, maybe_root_uri) = {
       let config = &self.config;
       (
@@ -346,8 +354,14 @@ impl Inner {
     Ok(())
   }
 
+  pub fn update_performance(&mut self) {
+    self
+      .performance
+      .do_logging(self.config.workspace_settings.internal_debug);
+  }
+
   async fn update_registries(&mut self) -> Result<(), AnyError> {
-    let mark = self.performance.mark("update_registries");
+    let mark = self.performance.mark("update_registries", None::<()>);
     for (registry, enabled) in
       self.config.workspace_settings.suggest.imports.hosts.iter()
     {
@@ -364,7 +378,7 @@ impl Inner {
   }
 
   async fn update_tsconfig(&mut self) -> Result<(), AnyError> {
-    let mark = self.performance.mark("update_tsconfig");
+    let mark = self.performance.mark("update_tsconfig", None::<()>);
     let mut tsconfig = TsConfig::new(json!({
       "allowJs": true,
       "esModuleInterop": true,
@@ -458,7 +472,7 @@ impl Inner {
     params: InitializeParams,
   ) -> LspResult<InitializeResult> {
     info!("Starting Deno language server...");
-    let mark = self.performance.mark("initialize");
+    let mark = self.performance.mark("initialize", Some(&params));
 
     let capabilities = capabilities::server_capabilities(&params.capabilities);
 
@@ -492,6 +506,7 @@ impl Inner {
       config.update_capabilities(&params.capabilities);
     }
 
+    self.update_performance();
     if let Err(err) = self.update_tsconfig().await {
       warn!("Updating tsconfig has errored: {}", err);
     }
@@ -568,7 +583,7 @@ impl Inner {
   }
 
   async fn did_open(&mut self, params: DidOpenTextDocumentParams) {
-    let mark = self.performance.mark("did_open");
+    let mark = self.performance.mark("did_open", Some(&params));
     let specifier = self.url_map.normalize_url(&params.text_document.uri);
 
     // we only query the individual resource file if the client supports it
@@ -612,7 +627,7 @@ impl Inner {
   }
 
   async fn did_change(&mut self, params: DidChangeTextDocumentParams) {
-    let mark = self.performance.mark("did_change");
+    let mark = self.performance.mark("did_change", Some(&params));
     let specifier = self.url_map.normalize_url(&params.text_document.uri);
     match self.documents.change(
       &specifier,
@@ -631,7 +646,7 @@ impl Inner {
   }
 
   async fn did_close(&mut self, params: DidCloseTextDocumentParams) {
-    let mark = self.performance.mark("did_close");
+    let mark = self.performance.mark("did_close", Some(&params));
     if params.text_document.uri.scheme() == "deno" {
       // we can ignore virtual text documents opening, as they don't need to
       // be tracked in memory, as they are static assets that won't change
@@ -652,7 +667,7 @@ impl Inner {
     &mut self,
     params: DidChangeConfigurationParams,
   ) {
-    let mark = self.performance.mark("did_change_configuration");
+    let mark = self.performance.mark("did_change_configuration", Some(&params));
 
     if self.config.client_capabilities.workspace_configuration {
       let specifiers: Vec<ModuleSpecifier> =
@@ -723,7 +738,9 @@ impl Inner {
     &mut self,
     params: DidChangeWatchedFilesParams,
   ) {
-    let mark = self.performance.mark("did_change_watched_files");
+    let mark = self
+      .performance
+      .mark("did_change_watched_files", Some(&params));
     // if the current import map has changed, we need to reload it
     if let Some(import_map_uri) = &self.maybe_import_map_uri {
       if params.changes.iter().any(|fe| *import_map_uri == fe.uri) {
@@ -757,7 +774,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("document_symbol");
+    let mark = self.performance.mark("document_symbol", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
@@ -796,7 +813,7 @@ impl Inner {
     &self,
     params: DocumentFormattingParams,
   ) -> LspResult<Option<Vec<TextEdit>>> {
-    let mark = self.performance.mark("formatting");
+    let mark = self.performance.mark("formatting", Some(&params));
     let specifier = self.url_map.normalize_url(&params.text_document.uri);
     let file_text = self
       .documents
@@ -855,7 +872,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("hover");
+    let mark = self.performance.mark("hover", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
@@ -897,7 +914,7 @@ impl Inner {
       return Ok(None);
     }
 
-    let mark = self.performance.mark("code_action");
+    let mark = self.performance.mark("code_action", Some(&params));
     let fixable_diagnostics: Vec<&Diagnostic> = params
       .context
       .diagnostics
@@ -1003,7 +1020,7 @@ impl Inner {
     &mut self,
     params: CodeAction,
   ) -> LspResult<CodeAction> {
-    let mark = self.performance.mark("code_action_resolve");
+    let mark = self.performance.mark("code_action_resolve", Some(&params));
     let result = if let Some(data) = params.data.clone() {
       let code_action_data: CodeActionData =
         from_value(data).map_err(|err| {
@@ -1055,7 +1072,7 @@ impl Inner {
       return Ok(None);
     }
 
-    let mark = self.performance.mark("code_lens");
+    let mark = self.performance.mark("code_lens", Some(&params));
     let line_index = self.get_line_index_sync(&specifier).unwrap();
     let navigation_tree =
       self.get_navigation_tree(&specifier).await.map_err(|err| {
@@ -1177,7 +1194,7 @@ impl Inner {
     &mut self,
     params: CodeLens,
   ) -> LspResult<CodeLens> {
-    let mark = self.performance.mark("code_lens_resolve");
+    let mark = self.performance.mark("code_lens_resolve", Some(&params));
     if let Some(data) = params.data.clone() {
       let code_lens_data: CodeLensData = serde_json::from_value(data)
         .map_err(|err| LspError::invalid_params(err.to_string()))?;
@@ -1366,7 +1383,7 @@ impl Inner {
       return Ok(None);
     }
 
-    let mark = self.performance.mark("document_highlight");
+    let mark = self.performance.mark("document_highlight", Some(&params));
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
         line_index
@@ -1415,7 +1432,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("references");
+    let mark = self.performance.mark("references", Some(&params));
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
         line_index
@@ -1470,7 +1487,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("goto_definition");
+    let mark = self.performance.mark("goto_definition", Some(&params));
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
         line_index
@@ -1513,7 +1530,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("completion");
+    let mark = self.performance.mark("completion", Some(&params));
     // Import specifiers are something wholly internal to Deno, so for
     // completions, we will use internal logic and if there are completions
     // for imports, we will return those and not send a message into tsc, where
@@ -1583,7 +1600,7 @@ impl Inner {
     &mut self,
     params: CompletionItem,
   ) -> LspResult<CompletionItem> {
-    let mark = self.performance.mark("completion_resolve");
+    let mark = self.performance.mark("completion_resolve", Some(&params));
     let completion_item = if let Some(data) = &params.data {
       let data: completions::CompletionItemData =
         serde_json::from_value(data.clone()).map_err(|err| {
@@ -1629,7 +1646,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("goto_implementation");
+    let mark = self.performance.mark("goto_implementation", Some(&params));
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
         line_index
@@ -1677,7 +1694,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("folding_range");
+    let mark = self.performance.mark("folding_range", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
@@ -1734,7 +1751,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("incoming_calls");
+    let mark = self.performance.mark("incoming_calls", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
@@ -1788,7 +1805,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("outgoing_calls");
+    let mark = self.performance.mark("outgoing_calls", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
@@ -1845,7 +1862,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("prepare_call_hierarchy");
+    let mark = self.performance.mark("prepare_call_hierarchy", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
@@ -1922,7 +1939,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("rename");
+    let mark = self.performance.mark("rename", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
@@ -2010,7 +2027,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("selection_range");
+    let mark = self.performance.mark("selection_range", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
@@ -2052,7 +2069,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("semantic_tokens_full");
+    let mark = self.performance.mark("semantic_tokens_full", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
@@ -2099,7 +2116,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("semantic_tokens_range");
+    let mark = self.performance.mark("semantic_tokens_range", Some(&params));
 
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
@@ -2147,7 +2164,7 @@ impl Inner {
     if !self.config.specifier_enabled(&specifier) {
       return Ok(None);
     }
-    let mark = self.performance.mark("signature_help");
+    let mark = self.performance.mark("signature_help", Some(&params));
     let line_index =
       if let Some(line_index) = self.get_line_index_sync(&specifier) {
         line_index
@@ -2427,7 +2444,7 @@ impl Inner {
   /// Similar to `deno cache` on the command line, where modules will be cached
   /// in the Deno cache, including any of their dependencies.
   async fn cache(&mut self, params: CacheParams) -> LspResult<Option<Value>> {
-    let mark = self.performance.mark("cache");
+    let mark = self.performance.mark("cache", Some(&params));
     let referrer = self.url_map.normalize_url(&params.referrer.uri);
     if !params.uris.is_empty() {
       for identifier in &params.uris {
@@ -2495,7 +2512,9 @@ impl Inner {
     &mut self,
     params: VirtualTextDocumentParams,
   ) -> LspResult<Option<String>> {
-    let mark = self.performance.mark("virtual_text_document");
+    let mark = self
+      .performance
+      .mark("virtual_text_document", Some(&params));
     let specifier = self.url_map.normalize_url(&params.text_document.uri);
     let contents = if specifier.as_str() == "deno:/status.md" {
       let mut contents = String::new();

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
 use deno_core::error::AnyError;
 use lspower::LspService;
 use lspower::Server;

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -3,8 +3,6 @@
 use deno_core::error::AnyError;
 use lspower::LspService;
 use lspower::Server;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 
 mod analysis;
 mod capabilities;
@@ -22,13 +20,12 @@ mod text;
 mod tsc;
 mod urls;
 
-pub async fn start(lsp_debug_flag: Arc<AtomicBool>) -> Result<(), AnyError> {
+pub async fn start() -> Result<(), AnyError> {
   let stdin = tokio::io::stdin();
   let stdout = tokio::io::stdout();
 
-  let (service, messages) = LspService::new(|client| {
-    language_server::LanguageServer::new(client, lsp_debug_flag)
-  });
+  let (service, messages) =
+    LspService::new(language_server::LanguageServer::new);
   Server::new(stdin, stdout)
     .interleave(messages)
     .serve(service)

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2520,6 +2520,7 @@ pub fn request(
   state_snapshot: StateSnapshot,
   method: RequestMethod,
 ) -> Result<Value, AnyError> {
+  let performance = state_snapshot.performance.clone();
   let id = {
     let op_state = runtime.op_state();
     let mut op_state = op_state.borrow_mut();
@@ -2529,6 +2530,7 @@ pub fn request(
     state.last_id
   };
   let request_params = method.to_value(id);
+  let mark = performance.mark("request", Some(request_params.clone()));
   let request_src = format!("globalThis.serverRequest({});", request_params);
   runtime.execute("[native_code]", &request_src)?;
 
@@ -2536,6 +2538,7 @@ pub fn request(
   let mut op_state = op_state.borrow_mut();
   let state = op_state.borrow_mut::<State>();
 
+  performance.measure(mark);
   if let Some(response) = state.response.clone() {
     state.response = None;
     Ok(response.data)

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1832,7 +1832,7 @@ where
   })
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SourceSnapshotArgs {
   specifier: String,
@@ -1846,14 +1846,17 @@ fn op_dispose(
   state: &mut State,
   args: SourceSnapshotArgs,
 ) -> Result<bool, AnyError> {
-  let mark = state.state_snapshot.performance.mark("op_dispose");
+  let mark = state
+    .state_snapshot
+    .performance
+    .mark("op_dispose", Some(&args));
   let specifier = resolve_url(&args.specifier)?;
   state.snapshots.remove(&(specifier, args.version.into()));
   state.state_snapshot.performance.measure(mark);
   Ok(true)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct GetChangeRangeArgs {
   specifier: String,
@@ -1868,7 +1871,10 @@ fn op_get_change_range(
   state: &mut State,
   args: GetChangeRangeArgs,
 ) -> Result<Value, AnyError> {
-  let mark = state.state_snapshot.performance.mark("op_get_change_range");
+  let mark = state
+    .state_snapshot
+    .performance
+    .mark("op_get_change_range", Some(&args));
   let specifier = resolve_url(&args.specifier)?;
   cache_snapshot(state, &specifier, args.version.clone())?;
   if let Some(current) = state
@@ -1912,7 +1918,10 @@ fn op_get_length(
   state: &mut State,
   args: SourceSnapshotArgs,
 ) -> Result<usize, AnyError> {
-  let mark = state.state_snapshot.performance.mark("op_get_length");
+  let mark = state
+    .state_snapshot
+    .performance
+    .mark("op_get_length", Some(&args));
   let specifier = resolve_url(&args.specifier)?;
   if let Some(Some(asset)) = state.state_snapshot.assets.get(&specifier) {
     Ok(asset.length)
@@ -1927,7 +1936,7 @@ fn op_get_length(
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct GetTextArgs {
   specifier: String,
@@ -1940,7 +1949,10 @@ fn op_get_text(
   state: &mut State,
   args: GetTextArgs,
 ) -> Result<String, AnyError> {
-  let mark = state.state_snapshot.performance.mark("op_get_text");
+  let mark = state
+    .state_snapshot
+    .performance
+    .mark("op_get_text", Some(&args));
   let specifier = resolve_url(&args.specifier)?;
   let content =
     if let Some(Some(content)) = state.state_snapshot.assets.get(&specifier) {
@@ -1961,7 +1973,10 @@ fn op_resolve(
   state: &mut State,
   args: ResolveArgs,
 ) -> Result<Vec<Option<(String, String)>>, AnyError> {
-  let mark = state.state_snapshot.performance.mark("op_resolve");
+  let mark = state
+    .state_snapshot
+    .performance
+    .mark("op_resolve", Some(&args));
   let mut resolved = Vec::new();
   let referrer = resolve_url(&args.base)?;
   let sources = &mut state.state_snapshot.sources;
@@ -2069,7 +2084,7 @@ fn op_script_names(
   )
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ScriptVersionArgs {
   specifier: String,
@@ -2079,7 +2094,10 @@ fn op_script_version(
   state: &mut State,
   args: ScriptVersionArgs,
 ) -> Result<Option<String>, AnyError> {
-  let mark = state.state_snapshot.performance.mark("op_script_version");
+  let mark = state
+    .state_snapshot
+    .performance
+    .mark("op_script_version", Some(&args));
   let specifier = resolve_url(&args.specifier)?;
   if specifier.scheme() == "asset" {
     return if state.state_snapshot.assets.contains_key(&specifier) {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -21,6 +21,7 @@ mod http_util;
 mod import_map;
 mod info;
 mod lockfile;
+mod logger;
 mod lsp;
 mod media_type;
 mod module_graph;
@@ -67,8 +68,6 @@ use deno_runtime::worker::MainWorker;
 use deno_runtime::worker::WorkerOptions;
 use log::debug;
 use log::info;
-use log::Level;
-use log::LevelFilter;
 use std::collections::HashSet;
 use std::env;
 use std::io::Read;
@@ -77,6 +76,7 @@ use std::iter::once;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::Mutex;
 use tools::test_runner;
@@ -442,8 +442,8 @@ async fn install_command(
   tools::installer::install(flags, &module_url, args, name, root, force)
 }
 
-async fn lsp_command() -> Result<(), AnyError> {
-  lsp::start().await
+async fn lsp_command(lsp_debug_flag: Arc<AtomicBool>) -> Result<(), AnyError> {
+  lsp::start(lsp_debug_flag).await
 }
 
 async fn lint_command(
@@ -1170,45 +1170,9 @@ fn init_v8_flags(v8_flags: &[String]) {
   }
 }
 
-fn init_logger(maybe_level: Option<Level>) {
-  let log_level = match maybe_level {
-    Some(level) => level,
-    None => Level::Info, // Default log level
-  };
-  env_logger::Builder::from_env(
-    env_logger::Env::default()
-      .default_filter_or(log_level.to_level_filter().to_string()),
-  )
-  // https://github.com/denoland/deno/issues/6641
-  .filter_module("rustyline", LevelFilter::Off)
-  // wgpu crates (gfx_backend), have a lot of useless INFO and WARN logs
-  .filter_module("wgpu", LevelFilter::Error)
-  .filter_module("gfx", LevelFilter::Error)
-  .format(|buf, record| {
-    let mut target = record.target().to_string();
-    if let Some(line_no) = record.line() {
-      target.push(':');
-      target.push_str(&line_no.to_string());
-    }
-    if record.level() <= Level::Info {
-      // Print ERROR, WARN, INFO logs as they are
-      writeln!(buf, "{}", record.args())
-    } else {
-      // Add prefix to DEBUG or TRACE logs
-      writeln!(
-        buf,
-        "{} RS - {} - {}",
-        record.level(),
-        target,
-        record.args()
-      )
-    }
-  })
-  .init();
-}
-
 fn get_subcommand(
   flags: Flags,
+  lsp_debug_flag: Arc<AtomicBool>,
 ) -> Pin<Box<dyn Future<Output = Result<(), AnyError>>>> {
   match flags.clone().subcommand {
     DenoSubcommand::Bundle {
@@ -1261,7 +1225,7 @@ fn get_subcommand(
     } => {
       install_command(flags, module_url, args, name, root, force).boxed_local()
     }
-    DenoSubcommand::Lsp => lsp_command().boxed_local(),
+    DenoSubcommand::Lsp => lsp_command(lsp_debug_flag).boxed_local(),
     DenoSubcommand::Lint {
       files,
       rules,
@@ -1363,7 +1327,12 @@ pub fn main() {
   if !flags.v8_flags.is_empty() {
     init_v8_flags(&*flags.v8_flags);
   }
-  init_logger(flags.log_level);
 
-  unwrap_or_exit(tokio_util::run_basic(get_subcommand(flags)));
+  // when this flag is set to `true`, the process will log specific diagnostic
+  // debug information,
+  let lsp_debug_flag = Arc::new(AtomicBool::new(false));
+
+  logger::init(flags.log_level, lsp_debug_flag.clone());
+
+  unwrap_or_exit(tokio_util::run_basic(get_subcommand(flags, lsp_debug_flag)));
 }

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -13,6 +13,7 @@ use deno_core::error::Context;
 use deno_core::op_sync;
 use deno_core::resolve_url_or_path;
 use deno_core::serde::Deserialize;
+use deno_core::serde::Serialize;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
@@ -350,7 +351,7 @@ fn op_load(state: &mut State, args: Value) -> Result<Value, AnyError> {
   )
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolveArgs {
   /// The base specifier that the supplied specifier strings should be resolved


### PR DESCRIPTION
Ref: #10368

The lsp would respect a setting which will log all the marks and measures to stderr along with their arguments which can be used to investigate certain issues (as well as more easily generate test cases).  This requires a client which can pass the configuration option (see: denoland/vscode_deno#406).
