### PR TITLE
fix(cli): default to num cpus when no value is given to `--jobs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ dependencies = [
  "lspower",
  "nix",
  "notify",
+ "num_cpus",
  "os_pipe",
  "percent-encoding",
  "pin-project",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -56,6 +56,7 @@ libc = "0.2.93"
 log = { version = "0.4.14", features = ["serde"] }
 lspower = "1.0.0"
 notify = "5.0.0-pre.7"
+num_cpus = "1.13.0"
 percent-encoding = "2.1.0"
 pin-project = "1.0.6"
 regex = "1.4.3"

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1683,9 +1683,8 @@ fn test_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     if let Some(value) = matches.value_of("jobs") {
       value.parse().unwrap()
     } else {
-      // TODO(caspervonb) when no value is given use
-      // https://doc.rust-lang.org/std/thread/fn.available_concurrency.html
-      2
+      // TODO(caspervonb) drop the dependency on num_cpus when https://doc.rust-lang.org/std/thread/fn.available_concurrency.html becomes stable.
+      num_cpus::get()
     }
   } else {
     1


### PR DESCRIPTION
This defaults to num_cpu's when no value is given for jobs, matching most implementations of -j, --jobs in the wild.

I had this hardcoded to two because there's a nightly function in std for getting the number of hardware threads, but nightlies can take forever to be stable so added a dependency on num_cpu's in the meantime.