### PR TITLE
refactor(core): provide builtins as an Extension

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -305,6 +305,11 @@ impl JsRuntime {
       waker: AtomicWaker::new(),
     })));
 
+    // Add builtins extension
+    options
+      .extensions
+      .insert(0, crate::ops_builtin::init_builtins());
+
     let mut js_runtime = Self {
       v8_isolate: Some(isolate),
       snapshot_creator: maybe_snapshot_creator,
@@ -316,7 +321,6 @@ impl JsRuntime {
     // TODO(@AaronO): diff extensions inited in snapshot and those provided
     // for now we assume that snapshot and extensions always match
     if !has_startup_snapshot {
-      js_runtime.js_init();
       js_runtime.init_extension_js().unwrap();
     }
     // Init extension ops
@@ -358,18 +362,6 @@ impl JsRuntime {
   pub(crate) fn state(isolate: &v8::Isolate) -> Rc<RefCell<JsRuntimeState>> {
     let s = isolate.get_slot::<Rc<RefCell<JsRuntimeState>>>().unwrap();
     s.clone()
-  }
-
-  /// Executes a JavaScript code to provide Deno.core and error reporting.
-  ///
-  /// This function can be called during snapshotting.
-  fn js_init(&mut self) {
-    self
-      .execute("deno:core/core.js", include_str!("core.js"))
-      .unwrap();
-    self
-      .execute("deno:core/error.js", include_str!("error.js"))
-      .unwrap();
   }
 
   /// Initializes JS of provided Extensions

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1584,7 +1584,8 @@ pub mod tests {
       dispatch_count: dispatch_count.clone(),
     });
 
-    runtime.register_op("test", dispatch);
+    runtime.register_op("op_test", dispatch);
+    runtime.sync_ops_cache();
 
     runtime
       .execute(
@@ -1610,9 +1611,9 @@ pub mod tests {
         "filename.js",
         r#"
         let control = 42;
-        Deno.core.opcall(1, null, control);
+        Deno.core.opAsync("op_test", control);
         async function main() {
-          Deno.core.opcall(1, null, control);
+          Deno.core.opAsync("op_test", control);
         }
         main();
         "#,
@@ -1628,7 +1629,7 @@ pub mod tests {
       .execute(
         "filename.js",
         r#"
-        Deno.core.opcall(1);
+        Deno.core.opAsync("op_test");
         "#,
       )
       .unwrap();
@@ -1643,7 +1644,7 @@ pub mod tests {
         "filename.js",
         r#"
         let zero_copy_a = new Uint8Array([0]);
-        Deno.core.opcall(1, null, null, zero_copy_a);
+        Deno.core.opAsync("op_test", null, zero_copy_a);
         "#,
       )
       .unwrap();
@@ -1946,7 +1947,8 @@ pub mod tests {
       module_loader: Some(loader),
       ..Default::default()
     });
-    runtime.register_op("test", dispatcher);
+    runtime.register_op("op_test", dispatcher);
+    runtime.sync_ops_cache();
 
     runtime
       .execute(
@@ -1972,7 +1974,7 @@ pub mod tests {
         import { b } from './b.js'
         if (b() != 'b') throw Error();
         let control = 42;
-        Deno.core.opcall(1, null, control);
+        Deno.core.opAsync("op_test", control);
       "#,
       )
       .unwrap();

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -260,8 +260,6 @@ impl WebWorker {
         Some(sender),
         options.create_web_worker_cb.clone(),
       );
-      ops::reg_sync(js_runtime, "op_close", deno_core::op_close);
-      ops::reg_sync(js_runtime, "op_resources", deno_core::op_resources);
       ops::io::init(js_runtime);
 
       if options.use_deno_namespace {

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -146,8 +146,6 @@ impl MainWorker {
         None,
         options.create_web_worker_cb.clone(),
       );
-      ops::reg_sync(js_runtime, "op_close", deno_core::op_close);
-      ops::reg_sync(js_runtime, "op_resources", deno_core::op_resources);
       ops::fs_events::init(js_runtime);
       ops::fs::init(js_runtime);
       ops::http::init(js_runtime);


### PR DESCRIPTION
Treats builtin ops (`op_resources`, `op_close`) and js (`core.js`, `error.js`) as a regular `JsRuntime` `Extension` that's always loaded (first, see the `.insert(0 ...`)

This guarantees that `op_close`, `op_resources` (and `op_print` with #10436) are ready to use after `JsRuntime::new`

Though builtins are special, they're not "that special", streamlining them will simplify things like moving JS src off heap generically for all extension provided JS without having to treat `core.js`, `error.js` as edge cases

## Notes

- Now that the builtin ops are registered by default, the first op registered by the user after `JsRuntime::new` will no longer have an `OpId` of 1 since those builtin ops will have taken those slots. I fixed the tests that relied on that assumption and in general it's strongly discouraged to rely on specific OpIds