### PR TITLE
fix(extensions/file): re-enable File wpt and update File constructor

### DIFF
--- a/cli/tests/unit/file_test.ts
+++ b/cli/tests/unit/file_test.ts
@@ -89,7 +89,7 @@ unitTest(function fileUsingFileName(): void {
 });
 
 unitTest(function fileUsingSpecialCharacterInFileName(): void {
-  testSecondArgument("dummy/foo", "dummy:foo");
+  testSecondArgument("dummy/foo", "dummy/foo");
 });
 
 unitTest(function fileUsingNullFileName(): void {

--- a/extensions/file/01_file.js
+++ b/extensions/file/01_file.js
@@ -370,7 +370,7 @@
       super(fileBits, options);
 
       /** @type {string} */
-      this[_Name] = fileName.replaceAll("/", ":");
+      this[_Name] = fileName;
       if (options.lastModified === undefined) {
         /** @type {number} */
         this[_LastModfied] = new Date().getTime();

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -392,61 +392,7 @@
         "ReadableStream with byte source: reading into a zero-length view on a non-zero-length buffer rejects"
       ],
       "construct-byob-request.any.js": false,
-      "general.any.js": [
-        "getReader({mode: \"byob\"}) throws on non-bytes streams",
-        "ReadableStream with byte source can be constructed with no errors",
-        "getReader({mode}) must perform ToString()",
-        "ReadableStream with byte source: autoAllocateChunkSize cannot be 0",
-        "ReadableStreamBYOBReader can be constructed directly",
-        "ReadableStreamBYOBReader constructor requires a ReadableStream argument",
-        "ReadableStreamBYOBReader constructor requires an unlocked ReadableStream",
-        "ReadableStreamBYOBReader constructor requires a ReadableStream with type \"bytes\"",
-        "ReadableStream with byte source: getReader() with mode set to byob, then releaseLock()",
-        "ReadableStream with byte source: Test that closing a stream does not release a BYOB reader automatically",
-        "ReadableStream with byte source: Test that erroring a stream does not release a BYOB reader automatically",
-        "ReadableStream with byte source: autoAllocateChunkSize",
-        "ReadableStream with byte source: Mix of auto allocate and BYOB",
-        "ReadableStream with byte source: enqueue(), read(view) partially, then read()",
-        "ReadableStream with byte source: Respond to pull() by enqueue()",
-        "ReadableStream with byte source: Respond to pull() by enqueue() asynchronously",
-        "ReadableStream with byte source: Respond to multiple pull() by separate enqueue()",
-        "ReadableStream with byte source: read(view), then respond()",
-        "ReadableStream with byte source: read(view), then respond() with a transferred ArrayBuffer",
-        "ReadableStream with byte source: read(view), then respond() with too big value",
-        "ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array enqueues the 1 byte remainder",
-        "ReadableStream with byte source: enqueue(), getReader(), then read(view)",
-        "ReadableStream with byte source: enqueue(), getReader(), then cancel() (mode = BYOB)",
-        "ReadableStream with byte source: getReader(), read(view), then cancel()",
-        "ReadableStream with byte source: cancel() with partially filled pending pull() request",
-        "ReadableStream with byte source: enqueue(), getReader(), then read(view) where view.buffer is not fully covered by view",
-        "ReadableStream with byte source: Multiple enqueue(), getReader(), then read(view)",
-        "ReadableStream with byte source: enqueue(), getReader(), then read(view) with a bigger view",
-        "ReadableStream with byte source: enqueue(), getReader(), then read(view) with smaller views",
-        "ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array",
-        "ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array",
-        "ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail",
-        "ReadableStream with byte source: A stream must be errored if close()-d before fulfilling read(view) with Uint16Array",
-        "ReadableStream with byte source: read(view), then respond() and close() in pull()",
-        "ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls",
-        "ReadableStream with byte source: read() twice, then enqueue() twice",
-        "ReadableStream with byte source: Multiple read(view), close() and respond()",
-        "ReadableStream with byte source: Multiple read(view), big enqueue()",
-        "ReadableStream with byte source: Multiple read(view) and multiple enqueue()",
-        "ReadableStream with byte source: read(view) with passing undefined as view must fail",
-        "ReadableStream with byte source: read(view) with passing an empty object as view must fail",
-        "ReadableStream with byte source: Even read(view) with passing ArrayBufferView like object as view must fail",
-        "ReadableStream with byte source: read(view) on an errored stream",
-        "ReadableStream with byte source: read(view), then error()",
-        "ReadableStream with byte source: Throwing in pull function must error the stream",
-        "ReadableStream with byte source: Throwing in pull in response to read() must be ignored if the stream is errored in it",
-        "ReadableStream with byte source: Throwing in pull in response to read(view) function must error the stream",
-        "ReadableStream with byte source: Throwing in pull in response to read(view) must be ignored if the stream is errored in it",
-        "calling respond() twice on the same byobRequest should throw",
-        "calling respondWithNewView() twice on the same byobRequest should throw",
-        "calling respond(0) twice on the same byobRequest should throw even when closed",
-        "pull() resolving should not make releaseLock() possible",
-        "ReadableStream with byte source: default reader + autoAllocateChunkSize + byobRequest interaction"
-      ]
+      "general.any.js": false
     },
     "readable-streams": {
       "async-iterator.any.js": [
@@ -482,9 +428,7 @@
       "patched-global.any.js": true,
       "reentrant-strategies.any.js": true,
       "tee.any.js": false,
-      "templated.any.js": [
-        "ReadableStream (empty) reader: canceling via the stream should fail"
-      ]
+      "templated.any.js": false
     },
     "transform-streams": {
       "backpressure.any.js": true,
@@ -1037,7 +981,7 @@
       "Blob-slice.any.js": true
     },
     "file": {
-      "File-constructor.any.js": true
+      "File-constructor.any.js": false
     },
     "fileReader.any.js": true,
     "url": {
@@ -1078,10 +1022,10 @@
       "timers": {
         "cleartimeout-clearinterval.any.js": true,
         "missing-timeout-setinterval.any.js": true,
-        "negative-setinterval.any.js": true,
-        "negative-settimeout.any.js": true,
-        "type-long-setinterval.any.js": true,
-        "type-long-settimeout.any.js": true
+        "negative-setinterval.any.js": false,
+        "negative-settimeout.any.js": false,
+        "type-long-setinterval.any.js": false,
+        "type-long-settimeout.any.js": false
       },
       "microtask-queuing": {
         "queue-microtask-exceptions.any.js": true,

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -981,7 +981,7 @@
       "Blob-slice.any.js": true
     },
     "file": {
-      "File-constructor.any.js": false
+      "File-constructor.any.js": true
     },
     "fileReader.any.js": true,
     "url": {

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -449,7 +449,6 @@
     "writable-streams": {
       "aborting.any.js": false,
       "bad-strategies.any.js": [
-        "reject any non-function value for strategy.size",
         "Writable stream: invalid size beats invalid highWaterMark"
       ],
       "bad-underlying-sinks.any.js": true,
@@ -457,8 +456,6 @@
       "close.any.js": false,
       "constructor.any.js": [
         "underlyingSink argument should be converted after queuingStrategy argument",
-        "WritableStreamDefaultController constructor should throw",
-        "WritableStreamDefaultController constructor should throw when passed an initialised WritableStream",
         "WritableStreamDefaultWriter should throw unless passed a WritableStream"
       ],
       "count-queuing-strategy.any.js": true,
@@ -488,9 +485,7 @@
       "Performance interface: operation mark(DOMString, optional PerformanceMarkOptions)",
       "Performance interface: operation clearMarks(optional DOMString)",
       "Performance interface: operation measure(DOMString, optional (DOMString or PerformanceMeasureOptions), optional DOMString)",
-      "Performance interface: operation clearMeasures(optional DOMString)",
-      "Performance interface: calling mark(DOMString, optional PerformanceMarkOptions) on performance with too few arguments must throw TypeError",
-      "Performance interface: calling measure(DOMString, optional (DOMString or PerformanceMeasureOptions), optional DOMString) on performance with too few arguments must throw TypeError"
+      "Performance interface: operation clearMeasures(optional DOMString)"
     ],
     "mark-entry-constructor.any.js": true,
     "mark-errors.any.js": true,
@@ -549,7 +544,10 @@
         "toString.any.js": true,
         "type.tentative.any.js": false,
         "constructor-shared.tentative.any.js": true,
-        "constructor-types.tentative.any.js": false
+        "constructor-types.tentative.any.js": [
+          "Zero minimum",
+          "Non-zero minimum"
+        ]
       },
       "module": {
         "constructor.any.js": true,
@@ -569,10 +567,12 @@
         "toString.any.js": true,
         "constructor-reftypes.tentative.any.js": [
           "initialize externref table with default value",
-          "initialize anyfunc table with default value",
-          "initialize anyfunc table with a bad default value"
+          "initialize anyfunc table with default value"
         ],
-        "constructor-types.tentative.any.js": false,
+        "constructor-types.tentative.any.js": [
+          "Zero minimum",
+          "Non-zero minimum"
+        ],
         "grow-reftypes.tentative.any.js": false,
         "set-reftypes.tentative.any.js": false,
         "type.tentative.any.js": false
@@ -640,6 +640,7 @@
       "URL interface: attribute searchParams",
       "URL interface: attribute hash",
       "URL interface: operation toJSON()",
+      "URL interface: legacy window alias",
       "Stringification of new URL(\"http://foo\")",
       "URLSearchParams interface: operation append(USVString, USVString)",
       "URLSearchParams interface: operation delete(USVString)",
@@ -655,12 +656,6 @@
     "url-constructor.any.js": [
       "Parsing: <https://x/�?�#�> against <about:blank>",
       "Parsing: <http://example.com/\ud800𐟾\udfff﷐﷏﷯ﷰ￾￿?\ud800𐟾\udfff﷐﷏﷯ﷰ￾￿> against <about:blank>",
-      "Parsing: <file://%43%7C> against <about:blank>",
-      "Parsing: <file://%43|> against <about:blank>",
-      "Parsing: <file://C%7C> against <about:blank>",
-      "Parsing: <file://%43%7C/> against <about:blank>",
-      "Parsing: <https://%43%7C/> against <about:blank>",
-      "Parsing: <asdf://%43|/> against <about:blank>",
       "Parsing: </> against <file://h/C:/a/b>",
       "Parsing: <file:\\\\//> against <about:blank>",
       "Parsing: <file:\\\\\\\\> against <about:blank>",
@@ -759,11 +754,7 @@
     "api": {
       "request": {
         "request-init-002.any.js": true,
-        "request-init-stream.any.js": [
-          "Constructing a Request with a Request on which body.getReader() is called",
-          "Constructing a Request with a Request on which body.getReader().read() is called",
-          "Constructing a Request with a Request on which read() and releaseLock() are called"
-        ],
+        "request-init-stream.any.js": true,
         "request-consume-empty.any.js": [
           "Consume empty FormData request body as text"
         ],
@@ -957,7 +948,6 @@
         "Response interface: operation formData()",
         "Response interface: operation json()",
         "Response interface: operation text()",
-        "Response interface: calling redirect(USVString, optional unsigned short) on new Response() with too few arguments must throw TypeError",
         "Window interface: calling fetch(RequestInfo, optional RequestInit) on window with too few arguments must throw TypeError",
         "Window interface: operation fetch(RequestInfo, optional RequestInit)"
       ]

--- a/tools/wpt/testharnessreport.js
+++ b/tools/wpt/testharnessreport.js
@@ -20,7 +20,7 @@ globalThis.document = {
   // document.body shim for FileAPI/file/File-constructor.any.js test
   body: {
     toString() {
-      return '[object HTMLBodyElement]';
-    }
-  }
+      return "[object HTMLBodyElement]";
+    },
+  },
 };

--- a/tools/wpt/testharnessreport.js
+++ b/tools/wpt/testharnessreport.js
@@ -15,3 +15,12 @@ window.add_completion_callback((tests, harnessStatus) => {
   Deno.exit(0);
 });
 */
+
+globalThis.document = {
+  // document.body shim for FileAPI/file/File-constructor.any.js test
+  body: {
+    toString() {
+      return '[object HTMLBodyElement]';
+    }
+  }
+};

--- a/tools/wpt/testharnessreport.js
+++ b/tools/wpt/testharnessreport.js
@@ -8,6 +8,10 @@ window.add_result_callback(({ message, name, stack, status }) => {
   );
 });
 
+// TODO(kt3k): Enable the below hook and timers test when #10445 is fixed
+// ref: https://github.com/denoland/deno/issues/10445
+/*
 window.add_completion_callback((tests, harnessStatus) => {
   Deno.exit(0);
 });
+*/


### PR DESCRIPTION
depends on #10454

This PR re-enables File wpt and update File constructor (This removes the replacement of `/` -> `:` in the file name, which is updated in the upstream spec (ref: https://github.com/w3c/FileAPI/pull/171)
