### PR TITLE
cleanup(bench/deno_http_native): don't use Deno.core funcs

### DIFF
--- a/cli/bench/deno_http_native.js
+++ b/cli/bench/deno_http_native.js
@@ -5,7 +5,8 @@ const [hostname, port] = addr.split(":");
 const listener = Deno.listen({ hostname, port: Number(port) });
 console.log("Server listening on", addr);
 
-const body = Deno.core.encode("Hello World");
+const encoder = new TextEncoder();
+const body = encoder.encode("Hello World");
 
 for await (const conn of listener) {
   (async () => {


### PR DESCRIPTION
`Deno.core.*` is unstable and not fit for public consumption, although this is a somewhat internal bench some people may use it as reference code and start using `Deno.core.encode()` in their own code