### PR TITLE
refactor(runtime): use Extensions

### DIFF
--- a/runtime/ops/fs.rs
+++ b/runtime/ops/fs.rs
@@ -8,6 +8,9 @@ use deno_core::error::bad_resource_id;
 use deno_core::error::custom_error;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
+use deno_core::op_async;
+use deno_core::op_sync;
+use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::ResourceId;
@@ -33,80 +36,60 @@ use deno_core::error::generic_error;
 #[cfg(not(unix))]
 use deno_core::error::not_supported;
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_sync(rt, "op_open_sync", op_open_sync);
-  super::reg_async(rt, "op_open_async", op_open_async);
-
-  super::reg_sync(rt, "op_seek_sync", op_seek_sync);
-  super::reg_async(rt, "op_seek_async", op_seek_async);
-
-  super::reg_sync(rt, "op_fdatasync_sync", op_fdatasync_sync);
-  super::reg_async(rt, "op_fdatasync_async", op_fdatasync_async);
-
-  super::reg_sync(rt, "op_fsync_sync", op_fsync_sync);
-  super::reg_async(rt, "op_fsync_async", op_fsync_async);
-
-  super::reg_sync(rt, "op_fstat_sync", op_fstat_sync);
-  super::reg_async(rt, "op_fstat_async", op_fstat_async);
-
-  super::reg_sync(rt, "op_umask", op_umask);
-  super::reg_sync(rt, "op_chdir", op_chdir);
-
-  super::reg_sync(rt, "op_mkdir_sync", op_mkdir_sync);
-  super::reg_async(rt, "op_mkdir_async", op_mkdir_async);
-
-  super::reg_sync(rt, "op_chmod_sync", op_chmod_sync);
-  super::reg_async(rt, "op_chmod_async", op_chmod_async);
-
-  super::reg_sync(rt, "op_chown_sync", op_chown_sync);
-  super::reg_async(rt, "op_chown_async", op_chown_async);
-
-  super::reg_sync(rt, "op_remove_sync", op_remove_sync);
-  super::reg_async(rt, "op_remove_async", op_remove_async);
-
-  super::reg_sync(rt, "op_copy_file_sync", op_copy_file_sync);
-  super::reg_async(rt, "op_copy_file_async", op_copy_file_async);
-
-  super::reg_sync(rt, "op_stat_sync", op_stat_sync);
-  super::reg_async(rt, "op_stat_async", op_stat_async);
-
-  super::reg_sync(rt, "op_realpath_sync", op_realpath_sync);
-  super::reg_async(rt, "op_realpath_async", op_realpath_async);
-
-  super::reg_sync(rt, "op_read_dir_sync", op_read_dir_sync);
-  super::reg_async(rt, "op_read_dir_async", op_read_dir_async);
-
-  super::reg_sync(rt, "op_rename_sync", op_rename_sync);
-  super::reg_async(rt, "op_rename_async", op_rename_async);
-
-  super::reg_sync(rt, "op_link_sync", op_link_sync);
-  super::reg_async(rt, "op_link_async", op_link_async);
-
-  super::reg_sync(rt, "op_symlink_sync", op_symlink_sync);
-  super::reg_async(rt, "op_symlink_async", op_symlink_async);
-
-  super::reg_sync(rt, "op_read_link_sync", op_read_link_sync);
-  super::reg_async(rt, "op_read_link_async", op_read_link_async);
-
-  super::reg_sync(rt, "op_ftruncate_sync", op_ftruncate_sync);
-  super::reg_async(rt, "op_ftruncate_async", op_ftruncate_async);
-
-  super::reg_sync(rt, "op_truncate_sync", op_truncate_sync);
-  super::reg_async(rt, "op_truncate_async", op_truncate_async);
-
-  super::reg_sync(rt, "op_make_temp_dir_sync", op_make_temp_dir_sync);
-  super::reg_async(rt, "op_make_temp_dir_async", op_make_temp_dir_async);
-
-  super::reg_sync(rt, "op_make_temp_file_sync", op_make_temp_file_sync);
-  super::reg_async(rt, "op_make_temp_file_async", op_make_temp_file_async);
-
-  super::reg_sync(rt, "op_cwd", op_cwd);
-
-  super::reg_sync(rt, "op_futime_sync", op_futime_sync);
-  super::reg_async(rt, "op_futime_async", op_futime_async);
-
-  super::reg_sync(rt, "op_utime_sync", op_utime_sync);
-  super::reg_async(rt, "op_utime_async", op_utime_async);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![
+      ("op_open_sync", op_sync(op_open_sync)),
+      ("op_open_async", op_async(op_open_async)),
+      ("op_seek_sync", op_sync(op_seek_sync)),
+      ("op_seek_async", op_async(op_seek_async)),
+      ("op_fdatasync_sync", op_sync(op_fdatasync_sync)),
+      ("op_fdatasync_async", op_async(op_fdatasync_async)),
+      ("op_fsync_sync", op_sync(op_fsync_sync)),
+      ("op_fsync_async", op_async(op_fsync_async)),
+      ("op_fstat_sync", op_sync(op_fstat_sync)),
+      ("op_fstat_async", op_async(op_fstat_async)),
+      ("op_umask", op_sync(op_umask)),
+      ("op_chdir", op_sync(op_chdir)),
+      ("op_mkdir_sync", op_sync(op_mkdir_sync)),
+      ("op_mkdir_async", op_async(op_mkdir_async)),
+      ("op_chmod_sync", op_sync(op_chmod_sync)),
+      ("op_chmod_async", op_async(op_chmod_async)),
+      ("op_chown_sync", op_sync(op_chown_sync)),
+      ("op_chown_async", op_async(op_chown_async)),
+      ("op_remove_sync", op_sync(op_remove_sync)),
+      ("op_remove_async", op_async(op_remove_async)),
+      ("op_copy_file_sync", op_sync(op_copy_file_sync)),
+      ("op_copy_file_async", op_async(op_copy_file_async)),
+      ("op_stat_sync", op_sync(op_stat_sync)),
+      ("op_stat_async", op_async(op_stat_async)),
+      ("op_realpath_sync", op_sync(op_realpath_sync)),
+      ("op_realpath_async", op_async(op_realpath_async)),
+      ("op_read_dir_sync", op_sync(op_read_dir_sync)),
+      ("op_read_dir_async", op_async(op_read_dir_async)),
+      ("op_rename_sync", op_sync(op_rename_sync)),
+      ("op_rename_async", op_async(op_rename_async)),
+      ("op_link_sync", op_sync(op_link_sync)),
+      ("op_link_async", op_async(op_link_async)),
+      ("op_symlink_sync", op_sync(op_symlink_sync)),
+      ("op_symlink_async", op_async(op_symlink_async)),
+      ("op_read_link_sync", op_sync(op_read_link_sync)),
+      ("op_read_link_async", op_async(op_read_link_async)),
+      ("op_ftruncate_sync", op_sync(op_ftruncate_sync)),
+      ("op_ftruncate_async", op_async(op_ftruncate_async)),
+      ("op_truncate_sync", op_sync(op_truncate_sync)),
+      ("op_truncate_async", op_async(op_truncate_async)),
+      ("op_make_temp_dir_sync", op_sync(op_make_temp_dir_sync)),
+      ("op_make_temp_dir_async", op_async(op_make_temp_dir_async)),
+      ("op_make_temp_file_sync", op_sync(op_make_temp_file_sync)),
+      ("op_make_temp_file_async", op_async(op_make_temp_file_async)),
+      ("op_cwd", op_sync(op_cwd)),
+      ("op_futime_sync", op_sync(op_futime_sync)),
+      ("op_futime_async", op_async(op_futime_async)),
+      ("op_utime_sync", op_sync(op_utime_sync)),
+      ("op_utime_async", op_async(op_utime_async)),
+    ])
+    .build()
 }
 
 #[derive(Deserialize)]

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -12,6 +12,9 @@ use deno_core::Resource;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 
+use deno_core::op_async;
+use deno_core::op_sync;
+use deno_core::Extension;
 use notify::event::Event as NotifyEvent;
 use notify::Error as NotifyError;
 use notify::EventKind;
@@ -27,9 +30,13 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use tokio::sync::mpsc;
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_sync(rt, "op_fs_events_open", op_fs_events_open);
-  super::reg_async(rt, "op_fs_events_poll", op_fs_events_poll);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![
+      ("op_fs_events_open", op_sync(op_fs_events_open)),
+      ("op_fs_events_poll", op_async(op_fs_events_poll)),
+    ])
+    .build()
 }
 
 struct FsEventsResource {

--- a/runtime/ops/http.rs
+++ b/runtime/ops/http.rs
@@ -10,10 +10,13 @@ use deno_core::futures::future::poll_fn;
 use deno_core::futures::FutureExt;
 use deno_core::futures::Stream;
 use deno_core::futures::StreamExt;
+use deno_core::op_async;
+use deno_core::op_sync;
 use deno_core::AsyncRefCell;
 use deno_core::CancelFuture;
 use deno_core::CancelHandle;
 use deno_core::CancelTryFuture;
+use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
@@ -43,15 +46,17 @@ use tokio::sync::oneshot;
 use tokio_rustls::server::TlsStream;
 use tokio_util::io::StreamReader;
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_sync(rt, "op_http_start", op_http_start);
-
-  super::reg_async(rt, "op_http_request_next", op_http_request_next);
-  super::reg_async(rt, "op_http_request_read", op_http_request_read);
-
-  super::reg_async(rt, "op_http_response", op_http_response);
-  super::reg_async(rt, "op_http_response_write", op_http_response_write);
-  super::reg_async(rt, "op_http_response_close", op_http_response_close);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![
+      ("op_http_start", op_sync(op_http_start)),
+      ("op_http_request_next", op_async(op_http_request_next)),
+      ("op_http_request_read", op_async(op_http_request_read)),
+      ("op_http_response", op_async(op_http_response)),
+      ("op_http_response_write", op_async(op_http_response_write)),
+      ("op_http_response_close", op_async(op_http_response_close)),
+    ])
+    .build()
 }
 
 struct ServiceInner {

--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -11,7 +11,6 @@ use deno_core::AsyncRefCell;
 use deno_core::CancelHandle;
 use deno_core::CancelTryFuture;
 use deno_core::Extension;
-use deno_core::JsRuntime;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
@@ -111,19 +110,22 @@ pub fn init() -> Extension {
 }
 
 pub fn init_stdio() -> Extension {
-  Extension::builder().state(|state| {
-    let t = &mut state.resource_table;
-    let (stdin, stdout, stderr) = ops::io::get_stdio();
-    if let Some(stream) = stdin {
-      t.add(stream);
-    }
-    if let Some(stream) = stdout {
-      t.add(stream);
-    }
-    if let Some(stream) = stderr {
-      t.add(stream);
-    }
-  })
+  Extension::builder()
+    .state(|state| {
+      let t = &mut state.resource_table;
+      let (stdin, stdout, stderr) = get_stdio();
+      if let Some(stream) = stdin {
+        t.add(stream);
+      }
+      if let Some(stream) = stdout {
+        t.add(stream);
+      }
+      if let Some(stream) = stderr {
+        t.add(stream);
+      }
+      Ok(())
+    })
+    .build()
 }
 
 pub fn get_stdio() -> (

--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -4,10 +4,13 @@ use deno_core::error::null_opbuf;
 use deno_core::error::resource_unavailable;
 use deno_core::error::AnyError;
 use deno_core::error::{bad_resource_id, not_supported};
+use deno_core::op_async;
+use deno_core::op_sync;
 use deno_core::AsyncMutFuture;
 use deno_core::AsyncRefCell;
 use deno_core::CancelHandle;
 use deno_core::CancelTryFuture;
+use deno_core::Extension;
 use deno_core::JsRuntime;
 use deno_core::OpState;
 use deno_core::RcRef;
@@ -95,14 +98,32 @@ lazy_static::lazy_static! {
   };
 }
 
-pub fn init(rt: &mut JsRuntime) {
-  super::reg_async(rt, "op_read_async", op_read_async);
-  super::reg_async(rt, "op_write_async", op_write_async);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![
+      ("op_read_async", op_async(op_read_async)),
+      ("op_write_async", op_async(op_write_async)),
+      ("op_read_sync", op_sync(op_read_sync)),
+      ("op_write_sync", op_sync(op_write_sync)),
+      ("op_shutdown", op_async(op_shutdown)),
+    ])
+    .build()
+}
 
-  super::reg_sync(rt, "op_read_sync", op_read_sync);
-  super::reg_sync(rt, "op_write_sync", op_write_sync);
-
-  super::reg_async(rt, "op_shutdown", op_shutdown);
+pub fn init_stdio() -> Extension {
+  Extension::builder().state(|state| {
+    let t = &mut state.resource_table;
+    let (stdin, stdout, stderr) = ops::io::get_stdio();
+    if let Some(stream) = stdin {
+      t.add(stream);
+    }
+    if let Some(stream) = stdout {
+      t.add(stream);
+    }
+    if let Some(stream) = stderr {
+      t.add(stream);
+    }
+  })
 }
 
 pub fn get_stdio() -> (

--- a/runtime/ops/net.rs
+++ b/runtime/ops/net.rs
@@ -9,9 +9,12 @@ use deno_core::error::generic_error;
 use deno_core::error::null_opbuf;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
+use deno_core::op_async;
+use deno_core::op_sync;
 use deno_core::AsyncRefCell;
 use deno_core::CancelHandle;
 use deno_core::CancelTryFuture;
+use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
@@ -42,13 +45,17 @@ use crate::ops::io::UnixStreamResource;
 #[cfg(unix)]
 use std::path::Path;
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_async(rt, "op_accept", op_accept);
-  super::reg_async(rt, "op_connect", op_connect);
-  super::reg_sync(rt, "op_listen", op_listen);
-  super::reg_async(rt, "op_datagram_receive", op_datagram_receive);
-  super::reg_async(rt, "op_datagram_send", op_datagram_send);
-  super::reg_async(rt, "op_dns_resolve", op_dns_resolve);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![
+      ("op_accept", op_async(op_accept)),
+      ("op_connect", op_async(op_connect)),
+      ("op_listen", op_sync(op_listen)),
+      ("op_datagram_receive", op_async(op_datagram_receive)),
+      ("op_datagram_send", op_async(op_datagram_send)),
+      ("op_dns_resolve", op_async(op_dns_resolve)),
+    ])
+    .build()
 }
 
 #[derive(Serialize)]

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -3,7 +3,9 @@
 use super::utils::into_string;
 use crate::permissions::Permissions;
 use deno_core::error::{type_error, AnyError};
+use deno_core::op_sync;
 use deno_core::url::Url;
+use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
@@ -11,18 +13,22 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::env;
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_sync(rt, "op_exit", op_exit);
-  super::reg_sync(rt, "op_env", op_env);
-  super::reg_sync(rt, "op_exec_path", op_exec_path);
-  super::reg_sync(rt, "op_set_env", op_set_env);
-  super::reg_sync(rt, "op_get_env", op_get_env);
-  super::reg_sync(rt, "op_delete_env", op_delete_env);
-  super::reg_sync(rt, "op_hostname", op_hostname);
-  super::reg_sync(rt, "op_loadavg", op_loadavg);
-  super::reg_sync(rt, "op_os_release", op_os_release);
-  super::reg_sync(rt, "op_system_memory_info", op_system_memory_info);
-  super::reg_sync(rt, "op_system_cpu_info", op_system_cpu_info);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![
+      ("op_exit", op_sync(op_exit)),
+      ("op_env", op_sync(op_env)),
+      ("op_exec_path", op_sync(op_exec_path)),
+      ("op_set_env", op_sync(op_set_env)),
+      ("op_get_env", op_sync(op_get_env)),
+      ("op_delete_env", op_sync(op_delete_env)),
+      ("op_hostname", op_sync(op_hostname)),
+      ("op_loadavg", op_sync(op_loadavg)),
+      ("op_os_release", op_sync(op_os_release)),
+      ("op_system_memory_info", op_sync(op_system_memory_info)),
+      ("op_system_cpu_info", op_sync(op_system_cpu_info)),
+    ])
+    .build()
 }
 
 fn op_exec_path(

--- a/runtime/ops/permissions.rs
+++ b/runtime/ops/permissions.rs
@@ -4,16 +4,22 @@ use crate::permissions::Permissions;
 use deno_core::error::custom_error;
 use deno_core::error::uri_error;
 use deno_core::error::AnyError;
+use deno_core::op_sync;
 use deno_core::url;
+use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use std::path::Path;
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_sync(rt, "op_query_permission", op_query_permission);
-  super::reg_sync(rt, "op_revoke_permission", op_revoke_permission);
-  super::reg_sync(rt, "op_request_permission", op_request_permission);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![
+      ("op_query_permission", op_sync(op_query_permission)),
+      ("op_revoke_permission", op_sync(op_revoke_permission)),
+      ("op_request_permission", op_sync(op_request_permission)),
+    ])
+    .build()
 }
 
 #[derive(Deserialize)]

--- a/runtime/ops/plugin.rs
+++ b/runtime/ops/plugin.rs
@@ -3,7 +3,9 @@ use crate::metrics::metrics_op;
 use crate::permissions::Permissions;
 use deno_core::error::AnyError;
 use deno_core::futures::prelude::*;
+use deno_core::op_sync;
 use deno_core::plugin_api;
+use deno_core::Extension;
 use deno_core::JsRuntime;
 use deno_core::Op;
 use deno_core::OpAsyncFuture;
@@ -22,8 +24,10 @@ use std::rc::Rc;
 use std::task::Context;
 use std::task::Poll;
 
-pub fn init(rt: &mut JsRuntime) {
-  super::reg_sync(rt, "op_open_plugin", op_open_plugin);
+pub fn init(rt: &mut JsRuntime) -> Extension {
+  Extension::builder()
+    .ops(vec![("op_open_plugin", op_sync(op_open_plugin))])
+    .build()
 }
 
 pub fn op_open_plugin(

--- a/runtime/ops/plugin.rs
+++ b/runtime/ops/plugin.rs
@@ -6,7 +6,6 @@ use deno_core::futures::prelude::*;
 use deno_core::op_sync;
 use deno_core::plugin_api;
 use deno_core::Extension;
-use deno_core::JsRuntime;
 use deno_core::Op;
 use deno_core::OpAsyncFuture;
 use deno_core::OpFn;
@@ -24,7 +23,7 @@ use std::rc::Rc;
 use std::task::Context;
 use std::task::Poll;
 
-pub fn init(rt: &mut JsRuntime) -> Extension {
+pub fn init() -> Extension {
   Extension::builder()
     .ops(vec![("op_open_plugin", op_sync(op_open_plugin))])
     .build()

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -8,8 +8,11 @@ use crate::permissions::Permissions;
 use deno_core::error::bad_resource_id;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
+use deno_core::op_async;
+use deno_core::op_sync;
 use deno_core::AsyncMutFuture;
 use deno_core::AsyncRefCell;
+use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
@@ -25,10 +28,14 @@ use tokio::process::Command;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_sync(rt, "op_run", op_run);
-  super::reg_async(rt, "op_run_status", op_run_status);
-  super::reg_sync(rt, "op_kill", op_kill);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![
+      ("op_run", op_sync(op_run)),
+      ("op_run_status", op_async(op_run_status)),
+      ("op_kill", op_sync(op_kill)),
+    ])
+    .build()
 }
 
 fn clone_file(

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -3,17 +3,20 @@
 use crate::permissions::Permissions;
 use deno_core::error::AnyError;
 use deno_core::error::Context;
+use deno_core::op_sync;
+use deno_core::Extension;
 use deno_core::ModuleSpecifier;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
 
-pub fn init(rt: &mut deno_core::JsRuntime, main_module: ModuleSpecifier) {
-  {
-    let op_state = rt.op_state();
-    let mut state = op_state.borrow_mut();
-    state.put::<ModuleSpecifier>(main_module);
-  }
-  super::reg_sync(rt, "op_main_module", op_main_module);
+pub fn init(main_module: ModuleSpecifier) -> Extension {
+  Extension::builder()
+    .ops(vec![("op_main_module", op_sync(op_main_module))])
+    .state(move |state| {
+      state.put::<ModuleSpecifier>(main_module);
+      Ok(())
+    })
+    .build()
 }
 
 fn op_main_module(

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -13,7 +13,7 @@ pub fn init(main_module: ModuleSpecifier) -> Extension {
   Extension::builder()
     .ops(vec![("op_main_module", op_sync(op_main_module))])
     .state(move |state| {
-      state.put::<ModuleSpecifier>(main_module);
+      state.put::<ModuleSpecifier>(main_module.clone());
       Ok(())
     })
     .build()

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -1,5 +1,8 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 use deno_core::error::AnyError;
+use deno_core::op_async;
+use deno_core::op_sync;
+use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
 use std::cell::RefCell;
@@ -24,10 +27,14 @@ use std::borrow::Cow;
 #[cfg(unix)]
 use tokio::signal::unix::{signal, Signal, SignalKind};
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_sync(rt, "op_signal_bind", op_signal_bind);
-  super::reg_sync(rt, "op_signal_unbind", op_signal_unbind);
-  super::reg_async(rt, "op_signal_poll", op_signal_poll);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![
+      ("op_signal_bind", op_sync(op_signal_bind)),
+      ("op_signal_unbind", op_sync(op_signal_unbind)),
+      ("op_signal_poll", op_async(op_signal_poll)),
+    ])
+    .build()
 }
 
 #[cfg(unix)]

--- a/runtime/ops/tls.rs
+++ b/runtime/ops/tls.rs
@@ -15,9 +15,12 @@ use deno_core::error::custom_error;
 use deno_core::error::generic_error;
 use deno_core::error::invalid_hostname;
 use deno_core::error::AnyError;
+use deno_core::op_async;
+use deno_core::op_sync;
 use deno_core::AsyncRefCell;
 use deno_core::CancelHandle;
 use deno_core::CancelTryFuture;
+use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
@@ -71,11 +74,15 @@ impl StoresClientSessions for ClientSessionMemoryCache {
   }
 }
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_async(rt, "op_start_tls", op_start_tls);
-  super::reg_async(rt, "op_connect_tls", op_connect_tls);
-  super::reg_sync(rt, "op_listen_tls", op_listen_tls);
-  super::reg_async(rt, "op_accept_tls", op_accept_tls);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![
+      ("op_start_tls", op_async(op_start_tls)),
+      ("op_connect_tls", op_async(op_connect_tls)),
+      ("op_listen_tls", op_sync(op_listen_tls)),
+      ("op_accept_tls", op_async(op_accept_tls)),
+    ])
+    .build()
 }
 
 #[derive(Deserialize)]

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -45,7 +45,7 @@ fn get_windows_handle(
   Ok(handle)
 }
 
-pub fn init() -> Exntension {
+pub fn init() -> Extension {
   Extension::builder()
     .ops(vec![
       ("op_set_raw", op_sync(op_set_raw)),

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -5,6 +5,8 @@ use deno_core::error::bad_resource_id;
 use deno_core::error::not_supported;
 use deno_core::error::resource_unavailable;
 use deno_core::error::AnyError;
+use deno_core::op_sync;
+use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::ResourceId;
@@ -43,10 +45,14 @@ fn get_windows_handle(
   Ok(handle)
 }
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_sync(rt, "op_set_raw", op_set_raw);
-  super::reg_sync(rt, "op_isatty", op_isatty);
-  super::reg_sync(rt, "op_console_size", op_console_size);
+pub fn init() -> Exntension {
+  Extension::builder()
+    .ops(vec![
+      ("op_set_raw", op_sync(op_set_raw)),
+      ("op_isatty", op_sync(op_isatty)),
+      ("op_console_size", op_sync(op_console_size)),
+    ])
+    .build()
 }
 
 #[derive(Deserialize)]

--- a/runtime/ops/web_worker.rs
+++ b/runtime/ops/web_worker.rs
@@ -4,34 +4,41 @@ use crate::web_worker::WebWorkerHandle;
 use crate::web_worker::WorkerEvent;
 use deno_core::error::null_opbuf;
 use deno_core::futures::channel::mpsc;
+use deno_core::op_sync;
+use deno_core::Extension;
 
 pub fn init(
-  rt: &mut deno_core::JsRuntime,
   sender: mpsc::Sender<WorkerEvent>,
   handle: WebWorkerHandle,
-) {
+) -> Extension {
   // Post message to host as guest worker.
   let sender_ = sender.clone();
-  super::reg_sync(
-    rt,
-    "op_worker_post_message",
-    move |_state, _args: (), buf| {
-      let buf = buf.ok_or_else(null_opbuf)?;
-      let msg_buf: Box<[u8]> = (*buf).into();
-      sender_
-        .clone()
-        .try_send(WorkerEvent::Message(msg_buf))
-        .expect("Failed to post message to host");
-      Ok(())
-    },
-  );
 
-  // Notify host that guest worker closes.
-  super::reg_sync(rt, "op_worker_close", move |_state, _args: (), _bufs| {
-    // Notify parent that we're finished
-    sender.clone().close_channel();
-    // Terminate execution of current worker
-    handle.terminate();
-    Ok(())
-  });
+  Extension::builder()
+    .ops(vec![
+      (
+        "op_worker_post_message",
+        op_sync(move |_state, _args: (), buf| {
+          let buf = buf.ok_or_else(null_opbuf)?;
+          let msg_buf: Box<[u8]> = (*buf).into();
+          sender_
+            .clone()
+            .try_send(WorkerEvent::Message(msg_buf))
+            .expect("Failed to post message to host");
+          Ok(())
+        }),
+      ),
+      // Notify host that guest worker closes.
+      (
+        "op_worker_close",
+        op_sync(move |_state, _args: (), _bufs| {
+          // Notify parent that we're finished
+          sender.clone().close_channel();
+          // Terminate execution of current worker
+          handle.terminate();
+          Ok(())
+        }),
+      ),
+    ])
+    .build()
 }

--- a/runtime/ops/web_worker.rs
+++ b/runtime/ops/web_worker.rs
@@ -15,9 +15,8 @@ pub fn init() -> Extension {
         op_sync(move |state, _args: (), buf| {
           let buf = buf.ok_or_else(null_opbuf)?;
           let msg_buf: Box<[u8]> = (*buf).into();
-          let sender = state.borrow::<mpsc::Sender<WorkerEvent>>().clone();
+          let mut sender = state.borrow::<mpsc::Sender<WorkerEvent>>().clone();
           sender
-            .clone()
             .try_send(WorkerEvent::Message(msg_buf))
             .expect("Failed to post message to host");
           Ok(())
@@ -28,8 +27,8 @@ pub fn init() -> Extension {
         "op_worker_close",
         op_sync(move |state, _args: (), _bufs| {
           // Notify parent that we're finished
-          let sender = state.borrow::<mpsc::Sender<WorkerEvent>>().clone();
-          sender.clone().close_channel();
+          let mut sender = state.borrow::<mpsc::Sender<WorkerEvent>>().clone();
+          sender.close_channel();
           // Terminate execution of current worker
           let handle = state.borrow::<WebWorkerHandle>();
           handle.terminate();

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -21,12 +21,15 @@ use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
 use deno_core::error::JsError;
 use deno_core::futures::channel::mpsc;
+use deno_core::op_async;
+use deno_core::op_sync;
 use deno_core::serde::de;
 use deno_core::serde::de::SeqAccess;
 use deno_core::serde::Deserialize;
 use deno_core::serde::Deserializer;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::Extension;
 use deno_core::ModuleSpecifier;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
@@ -69,37 +72,42 @@ pub type WorkersTable = HashMap<u32, WorkerThread>;
 pub type WorkerId = u32;
 
 pub fn init(
-  rt: &mut deno_core::JsRuntime,
   sender: Option<mpsc::Sender<WorkerEvent>>,
   create_web_worker_cb: Arc<CreateWebWorkerCb>,
-) {
-  {
-    let op_state = rt.op_state();
-    let mut state = op_state.borrow_mut();
-    state.put::<WorkersTable>(WorkersTable::default());
-    state.put::<WorkerId>(WorkerId::default());
+) -> Extension {
+  Extension::builder()
+    .state(move |state| {
+      state.put::<WorkersTable>(WorkersTable::default());
+      state.put::<WorkerId>(WorkerId::default());
 
-    let create_module_loader = CreateWebWorkerCbHolder(create_web_worker_cb);
-    state.put::<CreateWebWorkerCbHolder>(create_module_loader);
-  }
-  super::reg_sync(rt, "op_create_worker", op_create_worker);
-  super::reg_sync(rt, "op_host_terminate_worker", op_host_terminate_worker);
-  super::reg_sync(rt, "op_host_post_message", op_host_post_message);
-  super::reg_async(rt, "op_host_get_message", op_host_get_message);
-  super::reg_sync(
-    rt,
-    "op_host_unhandled_error",
-    move |_state, message: String, _zero_copy| {
-      if let Some(mut sender) = sender.clone() {
-        sender
-          .try_send(WorkerEvent::Error(generic_error(message)))
-          .expect("Failed to propagate error event to parent worker");
-        Ok(true)
-      } else {
-        Err(generic_error("Cannot be called from main worker."))
-      }
-    },
-  );
+      let create_module_loader = CreateWebWorkerCbHolder(create_web_worker_cb);
+      state.put::<CreateWebWorkerCbHolder>(create_module_loader);
+
+      Ok(())
+    })
+    .ops(vec![
+      ("op_create_worker", op_sync(op_create_worker)),
+      (
+        "op_host_terminate_worker",
+        op_sync(op_host_terminate_worker),
+      ),
+      ("op_host_post_message", op_sync(op_host_post_message)),
+      ("op_host_get_message", op_async(op_host_get_message)),
+      (
+        "op_host_unhandled_error",
+        op_sync(move |_, message: String, _| {
+          if let Some(mut sender) = sender.clone() {
+            sender
+              .try_send(WorkerEvent::Error(generic_error(message)))
+              .expect("Failed to propagate error event to parent worker");
+            Ok(true)
+          } else {
+            Err(generic_error("Cannot be called from main worker."))
+          }
+        }),
+      ),
+    ])
+    .build()
 }
 
 fn merge_boolean_permission(

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -263,31 +263,19 @@ impl WebWorker {
       ops::io::init(js_runtime);
 
       if options.use_deno_namespace {
-        ops::fs_events::init(js_runtime);
-        ops::fs::init(js_runtime);
-        ops::net::init(js_runtime);
-        ops::os::init(js_runtime);
-        ops::http::init(js_runtime);
-        ops::permissions::init(js_runtime);
-        ops::plugin::init(js_runtime);
-        ops::process::init(js_runtime);
-        ops::signal::init(js_runtime);
-        ops::tls::init(js_runtime);
-        ops::tty::init(js_runtime);
+        ops::fs_events::init();
+        ops::fs::init();
+        ops::net::init();
+        ops::os::init();
+        ops::http::init();
+        ops::permissions::init();
+        ops::plugin::init();
+        ops::process::init();
+        ops::signal::init();
+        ops::tls::init();
+        ops::tty::init();
 
-        let op_state = js_runtime.op_state();
-        let mut op_state = op_state.borrow_mut();
-        let t = &mut op_state.resource_table;
-        let (stdin, stdout, stderr) = ops::io::get_stdio();
-        if let Some(stream) = stdin {
-          t.add(stream);
-        }
-        if let Some(stream) = stdout {
-          t.add(stream);
-        }
-        if let Some(stream) = stderr {
-          t.add(stream);
-        }
+        ops::io::init_stdio();
       }
       js_runtime.sync_ops_cache();
 

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -280,7 +280,7 @@ impl WebWorker {
       terminate_rx,
       handle,
       use_deno_namespace: options.use_deno_namespace,
-      main_module: main_module.clone(),
+      main_module,
     };
 
     // Setup worker-dependant OpState and return worker
@@ -293,7 +293,7 @@ impl WebWorker {
 
       // Required by runtime::ops::worker_host/web_worker
       op_state.put(handle);
-      op_state.put(sender.clone());
+      op_state.put(sender);
 
       worker
     }

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -177,6 +177,17 @@ impl WebWorker {
     worker_id: u32,
     options: &WebWorkerOptions,
   ) -> Self {
+    // Permissions: many ops depend on this
+    let perm_ext = Extension::builder()
+      .state(move |state| {
+        state.put::<Permissions>(permissions);
+        state.put(ops::UnstableChecker {
+          unstable: options.unstable,
+        });
+        Ok(())
+      })
+      .build();
+
     let extensions: Vec<Extension> = vec![
       // Web APIs
       deno_webidl::init(),
@@ -200,7 +211,44 @@ impl WebWorker {
       deno_timers::init::<Permissions>(),
       // Metrics
       metrics::init(),
+      // Permissions ext (worker specific state)
+      perm_ext,
     ];
+
+    // Runtime ops that are always initialized for WebWorkers
+    let runtime_exts = vec![
+      ops::web_worker::init(sender.clone(), handle),
+      ops::runtime::init(main_module),
+      ops::worker_host::init(
+        Some(sender),
+        options.create_web_worker_cb.clone(),
+      ),
+      ops::io::init(),
+    ];
+
+    // Extensions providing Deno.* features
+    let deno_ns_exts = if options.use_deno_namespace {
+      vec![
+        ops::fs_events::init(),
+        ops::fs::init(),
+        ops::net::init(),
+        ops::os::init(),
+        ops::http::init(),
+        ops::permissions::init(),
+        ops::plugin::init(),
+        ops::process::init(),
+        ops::signal::init(),
+        ops::tls::init(),
+        ops::tty::init(),
+        ops::io::init_stdio(),
+      ]
+    } else {
+      vec![]
+    };
+
+    // Append exts
+    extensions.extend(runtime_exts);
+    extensions.extend(deno_ns_exts); // May be empty
 
     let mut js_runtime = JsRuntime::new(RuntimeOptions {
       module_loader: Some(options.module_loader.clone()),
@@ -239,45 +287,17 @@ impl WebWorker {
       main_module: main_module.clone(),
     };
 
+    // Setup worker-dependant OpState and return worker
     {
       let handle = worker.thread_safe_handle();
       let sender = worker.internal_channels.sender.clone();
       let js_runtime = &mut worker.js_runtime;
-      // All ops registered in this function depend on these
-      {
-        let op_state = js_runtime.op_state();
-        let mut op_state = op_state.borrow_mut();
-        op_state.put::<Permissions>(permissions);
-        op_state.put(ops::UnstableChecker {
-          unstable: options.unstable,
-        });
-      }
+      let op_state = js_runtime.op_state();
+      let mut op_state = op_state.borrow_mut();
 
-      ops::web_worker::init(js_runtime, sender.clone(), handle);
-      ops::runtime::init(js_runtime, main_module);
-      ops::worker_host::init(
-        js_runtime,
-        Some(sender),
-        options.create_web_worker_cb.clone(),
-      );
-      ops::io::init(js_runtime);
-
-      if options.use_deno_namespace {
-        ops::fs_events::init();
-        ops::fs::init();
-        ops::net::init();
-        ops::os::init();
-        ops::http::init();
-        ops::permissions::init();
-        ops::plugin::init();
-        ops::process::init();
-        ops::signal::init();
-        ops::tls::init();
-        ops::tty::init();
-
-        ops::io::init_stdio();
-      }
-      js_runtime.sync_ops_cache();
+      // Required by runtime::ops::worker_host/web_worker
+      op_state.put(handle);
+      op_state.put(sender.clone());
 
       worker
     }

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -150,13 +150,11 @@ impl MainWorker {
     let should_break_on_first_statement =
       inspector.is_some() && options.should_break_on_first_statement;
 
-    let worker = Self {
+    Self {
       inspector,
       js_runtime,
       should_break_on_first_statement,
-    };
-
-    worker
+    }
   }
 
   pub fn bootstrap(&mut self, options: &WorkerOptions) {

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -70,6 +70,7 @@ pub struct WorkerOptions {
   pub get_error_class_fn: Option<GetErrorClassFn>,
   pub location: Option<Url>,
   pub blob_url_store: BlobUrlStore,
+  pub will_snapshot: bool,
 }
 
 impl MainWorker {
@@ -78,6 +79,17 @@ impl MainWorker {
     permissions: Permissions,
     options: &WorkerOptions,
   ) -> Self {
+    // Permissions: all ops registered in this function depend on these
+    let perm_ext = Extension::builder()
+      .state(move |state| {
+        state.put::<Permissions>(permissions);
+        state.put(ops::UnstableChecker {
+          unstable: options.unstable,
+        });
+        Ok(())
+      })
+      .build();
+
     // Internal modules
     let extensions: Vec<Extension> = vec![
       // Web APIs
@@ -99,6 +111,24 @@ impl MainWorker {
       deno_timers::init::<Permissions>(),
       // Metrics
       metrics::init(),
+      // Runtime ops
+      ops::runtime::init(main_module),
+      ops::worker_host::init(None, options.create_web_worker_cb.clone()),
+      ops::fs_events::init(),
+      ops::fs::init(),
+      ops::http::init(),
+      ops::io::init(),
+      ops::io::init_stdio(),
+      ops::net::init(),
+      ops::os::init(),
+      ops::permissions::init(),
+      ops::plugin::init(),
+      ops::process::init(),
+      ops::signal::init(),
+      ops::tls::init(),
+      ops::tty::init(),
+      // Permissions ext (worker specific state)
+      perm_ext,
     ];
 
     let mut js_runtime = JsRuntime::new(RuntimeOptions {
@@ -129,51 +159,6 @@ impl MainWorker {
     };
 
     let js_runtime = &mut worker.js_runtime;
-    {
-      // All ops registered in this function depend on these
-      {
-        let op_state = js_runtime.op_state();
-        let mut op_state = op_state.borrow_mut();
-        op_state.put::<Permissions>(permissions);
-        op_state.put(ops::UnstableChecker {
-          unstable: options.unstable,
-        });
-      }
-
-      ops::runtime::init(js_runtime, main_module);
-      ops::worker_host::init(
-        js_runtime,
-        None,
-        options.create_web_worker_cb.clone(),
-      );
-      ops::fs_events::init(js_runtime);
-      ops::fs::init(js_runtime);
-      ops::http::init(js_runtime);
-      ops::io::init(js_runtime);
-      ops::net::init(js_runtime);
-      ops::os::init(js_runtime);
-      ops::permissions::init(js_runtime);
-      ops::plugin::init(js_runtime);
-      ops::process::init(js_runtime);
-      ops::signal::init(js_runtime);
-      ops::tls::init(js_runtime);
-      ops::tty::init(js_runtime);
-    }
-    {
-      let op_state = js_runtime.op_state();
-      let mut op_state = op_state.borrow_mut();
-      let t = &mut op_state.resource_table;
-      let (stdin, stdout, stderr) = ops::io::get_stdio();
-      if let Some(stream) = stdin {
-        t.add(stream);
-      }
-      if let Some(stream) = stdout {
-        t.add(stream);
-      }
-      if let Some(stream) = stderr {
-        t.add(stream);
-      }
-    }
     js_runtime.sync_ops_cache();
 
     worker

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -79,7 +79,7 @@ impl MainWorker {
     permissions: Permissions,
     options: &WorkerOptions,
   ) -> Self {
-    // Permissions: all ops registered in this function depend on these
+    // Permissions: many ops depend on this
     let perm_ext = Extension::builder()
       .state(move |state| {
         state.put::<Permissions>(permissions);
@@ -157,9 +157,6 @@ impl MainWorker {
       js_runtime,
       should_break_on_first_statement,
     };
-
-    let js_runtime = &mut worker.js_runtime;
-    js_runtime.sync_ops_cache();
 
     worker
   }


### PR DESCRIPTION
Refactors `runtime/` to use the new `JsRuntime` `Extension`s landed in #9800, paves a first path for a more modular `runtime/` and streamlines worker init logic (having both web `extensions/` and `runtime/` init'd declaratively instead of imperatively)

## Changes

- [x] Refactor `runtime::ops::*::init` to return `Extension`s
- [x] Refactor workers to init runtime ops with extensions
- [x] Move `WebWorkerHandle`/`sender` to `OpState`

## Notes

- This refactoring doesn't include the runtime JS in Extensions, that will require more work, to avoid bugs and duplicating logic with snapshots
- For now we depend on `runtime/`'s JS to be provided via the snapshot, no different than in `main`
- However I think we should clean this up & decouple it, so we can boot a `Worker` without depending on that snapshot