### PR TITLE
cleanup(cli): prefix all op functions with op_

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1842,7 +1842,7 @@ struct SourceSnapshotArgs {
 /// The language service is dropping a reference to a source file snapshot, and
 /// we can drop our version of that document.
 #[allow(clippy::unnecessary_wraps)]
-fn dispose(
+fn op_dispose(
   state: &mut State,
   args: SourceSnapshotArgs,
 ) -> Result<bool, AnyError> {
@@ -1864,7 +1864,7 @@ struct GetChangeRangeArgs {
 
 /// The language service wants to compare an old snapshot with a new snapshot to
 /// determine what source has changed.
-fn get_change_range(
+fn op_get_change_range(
   state: &mut State,
   args: GetChangeRangeArgs,
 ) -> Result<Value, AnyError> {
@@ -1908,7 +1908,7 @@ fn get_change_range(
   }
 }
 
-fn get_length(
+fn op_get_length(
   state: &mut State,
   args: SourceSnapshotArgs,
 ) -> Result<usize, AnyError> {
@@ -1936,7 +1936,10 @@ struct GetTextArgs {
   end: usize,
 }
 
-fn get_text(state: &mut State, args: GetTextArgs) -> Result<String, AnyError> {
+fn op_get_text(
+  state: &mut State,
+  args: GetTextArgs,
+) -> Result<String, AnyError> {
   let mark = state.state_snapshot.performance.mark("op_get_text");
   let specifier = resolve_url(&args.specifier)?;
   let content =
@@ -1954,7 +1957,7 @@ fn get_text(state: &mut State, args: GetTextArgs) -> Result<String, AnyError> {
   Ok(text::slice(&content, args.start..args.end).to_string())
 }
 
-fn resolve(
+fn op_resolve(
   state: &mut State,
   args: ResolveArgs,
 ) -> Result<Vec<Option<(String, String)>>, AnyError> {
@@ -2045,13 +2048,13 @@ fn resolve(
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn respond(state: &mut State, args: Response) -> Result<bool, AnyError> {
+fn op_respond(state: &mut State, args: Response) -> Result<bool, AnyError> {
   state.response = Some(args);
   Ok(true)
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn script_names(
+fn op_script_names(
   state: &mut State,
   _args: Value,
 ) -> Result<Vec<ModuleSpecifier>, AnyError> {
@@ -2072,7 +2075,7 @@ struct ScriptVersionArgs {
   specifier: String,
 }
 
-fn script_version(
+fn op_script_version(
   state: &mut State,
   args: ScriptVersionArgs,
 ) -> Result<Option<String>, AnyError> {
@@ -2114,14 +2117,14 @@ pub fn start(debug: bool) -> Result<JsRuntime, AnyError> {
     op_state.put(State::new(StateSnapshot::default()));
   }
 
-  runtime.register_op("op_dispose", op(dispose));
-  runtime.register_op("op_get_change_range", op(get_change_range));
-  runtime.register_op("op_get_length", op(get_length));
-  runtime.register_op("op_get_text", op(get_text));
-  runtime.register_op("op_resolve", op(resolve));
-  runtime.register_op("op_respond", op(respond));
-  runtime.register_op("op_script_names", op(script_names));
-  runtime.register_op("op_script_version", op(script_version));
+  runtime.register_op("op_dispose", op(op_dispose));
+  runtime.register_op("op_get_change_range", op(op_get_change_range));
+  runtime.register_op("op_get_length", op(op_get_length));
+  runtime.register_op("op_get_text", op(op_get_text));
+  runtime.register_op("op_resolve", op(op_resolve));
+  runtime.register_op("op_respond", op(op_respond));
+  runtime.register_op("op_script_names", op(op_script_names));
+  runtime.register_op("op_script_version", op(op_script_version));
   runtime.sync_ops_cache();
 
   let init_config = json!({ "debug": debug });

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -241,7 +241,7 @@ struct CreateHashArgs {
   data: String,
 }
 
-fn create_hash(state: &mut State, args: Value) -> Result<Value, AnyError> {
+fn op_create_hash(state: &mut State, args: Value) -> Result<Value, AnyError> {
   let v: CreateHashArgs = serde_json::from_value(args)
     .context("Invalid request from JavaScript for \"op_create_hash\".")?;
   let mut data = vec![v.data.as_bytes().to_owned()];
@@ -264,7 +264,7 @@ struct EmitArgs {
   maybe_specifiers: Option<Vec<String>>,
 }
 
-fn emit(state: &mut State, args: Value) -> Result<Value, AnyError> {
+fn op_emit(state: &mut State, args: Value) -> Result<Value, AnyError> {
   let v: EmitArgs = serde_json::from_value(args)
     .context("Invalid request from JavaScript for \"op_emit\".")?;
   match v.file_name.as_ref() {
@@ -301,7 +301,7 @@ struct LoadArgs {
   specifier: String,
 }
 
-fn load(state: &mut State, args: Value) -> Result<Value, AnyError> {
+fn op_load(state: &mut State, args: Value) -> Result<Value, AnyError> {
   let v: LoadArgs = serde_json::from_value(args)
     .context("Invalid request from JavaScript for \"op_load\".")?;
   let specifier = resolve_url_or_path(&v.specifier)
@@ -358,7 +358,7 @@ pub struct ResolveArgs {
   pub specifiers: Vec<String>,
 }
 
-fn resolve(state: &mut State, args: Value) -> Result<Value, AnyError> {
+fn op_resolve(state: &mut State, args: Value) -> Result<Value, AnyError> {
   let v: ResolveArgs = serde_json::from_value(args)
     .context("Invalid request from JavaScript for \"op_resolve\".")?;
   let mut resolved: Vec<(String, String)> = Vec::new();
@@ -432,7 +432,7 @@ struct RespondArgs {
   pub stats: Stats,
 }
 
-fn respond(state: &mut State, args: Value) -> Result<Value, AnyError> {
+fn op_respond(state: &mut State, args: Value) -> Result<Value, AnyError> {
   let v: RespondArgs = serde_json::from_value(args)
     .context("Error converting the result for \"op_respond\".")?;
   state.maybe_response = Some(v);
@@ -491,11 +491,11 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
     ));
   }
 
-  runtime.register_op("op_create_hash", op(create_hash));
-  runtime.register_op("op_emit", op(emit));
-  runtime.register_op("op_load", op(load));
-  runtime.register_op("op_resolve", op(resolve));
-  runtime.register_op("op_respond", op(respond));
+  runtime.register_op("op_create_hash", op(op_create_hash));
+  runtime.register_op("op_emit", op(op_emit));
+  runtime.register_op("op_load", op(op_load));
+  runtime.register_op("op_resolve", op(op_resolve));
+  runtime.register_op("op_respond", op(op_respond));
   runtime.sync_ops_cache();
 
   let startup_source = "globalThis.startup({ legacyFlag: false })";
@@ -638,7 +638,7 @@ mod tests {
   async fn test_create_hash() {
     let mut state = setup(None, Some(vec![b"something".to_vec()]), None).await;
     let actual =
-      create_hash(&mut state, json!({ "data": "some sort of content" }))
+      op_create_hash(&mut state, json!({ "data": "some sort of content" }))
         .expect("could not invoke op");
     assert_eq!(
       actual,
@@ -679,7 +679,7 @@ mod tests {
   #[tokio::test]
   async fn test_emit() {
     let mut state = setup(None, None, None).await;
-    let actual = emit(
+    let actual = op_emit(
       &mut state,
       json!({
         "data": "some file content",
@@ -707,7 +707,7 @@ mod tests {
   #[tokio::test]
   async fn test_emit_tsbuildinfo() {
     let mut state = setup(None, None, None).await;
-    let actual = emit(
+    let actual = op_emit(
       &mut state,
       json!({
         "data": "some file content",
@@ -731,7 +731,7 @@ mod tests {
       Some("some content".to_string()),
     )
     .await;
-    let actual = load(
+    let actual = op_load(
       &mut state,
       json!({ "specifier": "https://deno.land/x/mod.ts"}),
     )
@@ -763,7 +763,7 @@ mod tests {
     )
     .await;
     let value =
-      load(&mut state, json!({ "specifier": "asset:///lib.dom.d.ts" }))
+      op_load(&mut state, json!({ "specifier": "asset:///lib.dom.d.ts" }))
         .expect("should have invoked op");
     let actual: LoadResponse =
       serde_json::from_value(value).expect("failed to deserialize");
@@ -782,7 +782,7 @@ mod tests {
     )
     .await;
     let actual =
-      load(&mut state, json!({ "specifier": "deno:///.tsbuildinfo"}))
+      op_load(&mut state, json!({ "specifier": "deno:///.tsbuildinfo"}))
         .expect("should have invoked op");
     assert_eq!(
       actual,
@@ -797,7 +797,7 @@ mod tests {
   #[tokio::test]
   async fn test_load_missing_specifier() {
     let mut state = setup(None, None, None).await;
-    let actual = load(
+    let actual = op_load(
       &mut state,
       json!({ "specifier": "https://deno.land/x/mod.ts"}),
     )
@@ -820,7 +820,7 @@ mod tests {
       None,
     )
     .await;
-    let actual = resolve(
+    let actual = op_resolve(
       &mut state,
       json!({ "base": "https://deno.land/x/a.ts", "specifiers": [ "./b.ts" ]}),
     )
@@ -836,7 +836,7 @@ mod tests {
       None,
     )
     .await;
-    let actual = resolve(
+    let actual = op_resolve(
       &mut state,
       json!({ "base": "https://deno.land/x/a.ts", "specifiers": [ "./bad.ts" ]}),
     ).expect("should have not errored");
@@ -849,7 +849,7 @@ mod tests {
   #[tokio::test]
   async fn test_respond() {
     let mut state = setup(None, None, None).await;
-    let actual = respond(
+    let actual = op_respond(
       &mut state,
       json!({
         "diagnostics": [


### PR DESCRIPTION
Makes the codebase more searchable and helps distinguish op functions from helper functions

Besides tests/examples/benches this convention appears to be followed everywhere else in the codebase