### PR TITLE
chore(runtime): re-export deno_timers like all other deno crates

### DIFF
--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -4,6 +4,7 @@ pub use deno_console;
 pub use deno_crypto;
 pub use deno_fetch;
 pub use deno_file;
+pub use deno_timers;
 pub use deno_url;
 pub use deno_web;
 pub use deno_webgpu;


### PR DESCRIPTION
Very small change, I guess this is a minor "regression" that happened when we refactored timers out to its own crate.