### PR TITLE
docs: remove wasm and wasi as prerequisites

### DIFF
--- a/docs/contributing/building_from_source.md
+++ b/docs/contributing/building_from_source.md
@@ -36,13 +36,6 @@ rustc -V
 cargo -V
 ```
 
-### Setup rust targets and components
-
-```shell
-rustup target add wasm32-unknown-unknown
-rustup target add wasm32-wasi
-```
-
 ### Building Deno
 
 The easiest way to build Deno is by using a precompiled version of V8:


### PR DESCRIPTION
This removes wasm and wasi as prerequisites, as they haven't been since
we stopped building the wasi test suite from source which dates back
quite some time now.

I removed it from the CI back then but forgot to update the docs.

ref: #7512