### PR TITLE
fix: change inflection depending on number of pending tests

### DIFF
--- a/cli/tests/test/deno_test_only.ts.out
+++ b/cli/tests/test/deno_test_only.ts.out
@@ -1,5 +1,5 @@
 [WILDCARD]
-running 1 tests from [WILDCARD]
+running 1 test from [WILDCARD]
 test def ... ok ([WILDCARD])
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out ([WILDCARD])

--- a/cli/tests/test/quiet_test.out
+++ b/cli/tests/test/quiet_test.out
@@ -1,4 +1,4 @@
-running 1 tests from [WILDCARD]
+running 1 test from [WILDCARD]
 test log ... ok [WILDCARD]
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out [WILDCARD]

--- a/cli/tools/test_runner.rs
+++ b/cli/tools/test_runner.rs
@@ -100,7 +100,12 @@ impl TestReporter for PrettyTestReporter {
         filtered,
         only: _,
       } => {
-        println!("running {} tests from {}", pending, event.origin);
+        if *pending == 1 {
+          println!("running {} test from {}", pending, event.origin);
+        } else {
+          println!("running {} tests from {}", pending, event.origin);
+        }
+
         self.pending += pending;
         self.filtered_out += filtered;
       }


### PR DESCRIPTION
Before:

```
running 1 tests from file://...
```

After:

```
running 1 test from file://...
```