### PR TITLE
fix(op_crates/fetch): check fetch() argument length 

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -9,6 +9,16 @@ import {
 } from "./test_util.ts";
 import { Buffer } from "../../../test_util/std/io/buffer.ts";
 
+unitTest(
+  { perms: { net: true } },
+  async function fetchRequiresOneArgument(): Promise<void> {
+    await assertThrowsAsync(
+      fetch as unknown as () => Promise<void>,
+      TypeError,
+    );
+  },
+);
+
 unitTest({ perms: { net: true } }, async function fetchProtocolError(): Promise<
   void
 > {

--- a/extensions/fetch/26_fetch.js
+++ b/extensions/fetch/26_fetch.js
@@ -273,6 +273,7 @@
    */
   async function fetch(input, init = {}) {
     const prefix = "Failed to call 'fetch'";
+    webidl.requiredArguments(arguments.length, 1, { prefix });
     input = webidl.converters["RequestInfo"](input, {
       prefix,
       context: "Argument 1",

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1014,7 +1014,6 @@
         "Response interface: operation json()",
         "Response interface: operation text()",
         "Response interface: calling redirect(USVString, optional unsigned short) on new Response() with too few arguments must throw TypeError",
-        "Window interface: calling fetch(RequestInfo, optional RequestInit) on window with too few arguments must throw TypeError",
         "Window interface: operation fetch(RequestInfo, optional RequestInit)"
       ]
     },


### PR DESCRIPTION
Related to https://github.com/denoland/deno/pull/10203

Checks that fetch receives at least one arguement.

Relevant WebIDL:
```
partial interface mixin WindowOrWorkerGlobalScope {
  [NewObject] Promise<Response> fetch(RequestInfo input, optional RequestInit init = {});
};
```
\- https://fetch.spec.whatwg.org/#fetch-method

`input` must be present.

cc @lucacasonato