### PR TITLE
fix(core/print): flush stderr

### DIFF
--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -7,7 +7,7 @@ use crate::resources::ResourceId;
 use crate::Extension;
 use crate::OpState;
 use crate::ZeroCopyBuf;
-use std::io::{stdout, stderr, Write};
+use std::io::{stderr, stdout, Write};
 
 pub(crate) fn init_builtins() -> Extension {
   Extension::builder()

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -7,7 +7,7 @@ use crate::resources::ResourceId;
 use crate::Extension;
 use crate::OpState;
 use crate::ZeroCopyBuf;
-use std::io::{stdout, Write};
+use std::io::{stdout, stderr, Write};
 
 pub(crate) fn init_builtins() -> Extension {
   Extension::builder()
@@ -64,7 +64,7 @@ pub fn op_print(
   let (msg, is_err) = args;
   if is_err {
     eprint!("{}", msg);
-    stdout().flush().unwrap();
+    stderr().flush().unwrap();
   } else {
     print!("{}", msg);
     stdout().flush().unwrap();


### PR DESCRIPTION
Stderr is unbuffered on Linux/macOS (so doesn't need to be flushed), but I think it's undefined on Windows

Follow up to https://github.com/denoland/deno/pull/10436#pullrequestreview-650053348