### PR TITLE
docs: use one code block per truncate example

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2365,7 +2365,9 @@ declare namespace Deno {
    * // truncate the entire file
    * const file = Deno.openSync("my_file.txt", { read: true, write: true, truncate: true, create: true });
    * Deno.ftruncateSync(file.rid);
+   * ```
    *
+   * ```ts
    * // truncate part of the file
    * const file = Deno.openSync("my_file.txt", { read: true, write: true, create: true });
    * Deno.writeSync(file.rid, new TextEncoder().encode("Hello World"));
@@ -2391,7 +2393,9 @@ declare namespace Deno {
    * // truncate the entire file
    * const file = Deno.open("my_file.txt", { read: true, write: true, create: true });
    * await Deno.ftruncate(file.rid);
+   * ```
    *
+   * ```ts
    * // truncate part of the file
    * const file = Deno.open("my_file.txt", { read: true, write: true, create: true });
    * await Deno.write(file.rid, new TextEncoder().encode("Hello World"));


### PR DESCRIPTION
Truncate examples are using const and re-declaring in a single code block with multiple examples.
This splits them into using one code blocks per example program.