### PR TITLE
docs(runtime): fix HTTP server example

### DIFF
--- a/docs/runtime/http_server_apis.md
+++ b/docs/runtime/http_server_apis.md
@@ -74,10 +74,10 @@ There is also the `.accept()` method on the listener which can be used:
 const server = Deno.listen({ port: 8080 });
 
 while (true) {
-  const conn = await server.accept();
-  if (conn) {
+  try {
+    const conn = await server.accept();
     // ... handle the connection ...
-  } else {
+  } catch (err) {
     // The listener has closed
     break;
   }
@@ -122,8 +122,8 @@ await the next request. It would look something like this:
 const server = Deno.listen({ port: 8080 });
 
 while (true) {
-  const conn = await server.accept();
-  if (conn) {
+  try {
+    const conn = await server.accept();
     (async () => {
       const httpConn = Deno.serveHttp(conn);
       while (true) {
@@ -136,7 +136,7 @@ while (true) {
         }
       }
     })();
-  } else {
+  } catch (err) {
     // The listener has closed
     break;
   }

--- a/docs/runtime/http_server_apis.md
+++ b/docs/runtime/http_server_apis.md
@@ -74,7 +74,7 @@ There is also the `.accept()` method on the listener which can be used:
 const server = Deno.listen({ port: 8080 });
 
 while (true) {
-  const conn = server.accept();
+  const conn = await server.accept();
   if (conn) {
     // ... handle the connection ...
   } else {
@@ -122,7 +122,7 @@ await the next request. It would look something like this:
 const server = Deno.listen({ port: 8080 });
 
 while (true) {
-  const conn = server.accept();
+  const conn = await server.accept();
   if (conn) {
     (async () => {
       const httpConn = Deno.serveHttp(conn);


### PR DESCRIPTION
I'm not sure if I understand it correctly. However, checking a promise in an `if` statement always returns `true` since it's an object. Would make more sense if it's awaited.

Please close if I'm missing anything.