### PR TITLE
cleanup(ops): remove unused ZeroCopyBuf arg-types

### DIFF
--- a/cli/ops/errors.rs
+++ b/cli/ops/errors.rs
@@ -9,7 +9,6 @@ use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -30,7 +29,7 @@ struct ApplySourceMap {
 fn op_apply_source_map(
   state: &mut OpState,
   args: Value,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Value, AnyError> {
   let args: ApplySourceMap = serde_json::from_value(args)?;
 
@@ -56,7 +55,7 @@ fn op_apply_source_map(
 fn op_format_diagnostic(
   _state: &mut OpState,
   args: Value,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Value, AnyError> {
   let diagnostic: Diagnostics = serde_json::from_value(args)?;
   Ok(json!(diagnostic.to_string()))

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -18,7 +18,6 @@ use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
 use deno_runtime::permissions::Permissions;
 use serde::Deserialize;
 use std::cell::RefCell;
@@ -54,7 +53,7 @@ struct EmitArgs {
 async fn op_emit(
   state: Rc<RefCell<OpState>>,
   args: Value,
-  _data: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Value, AnyError> {
   deno_runtime::ops::check_unstable2(&state, "Deno.emit");
   let args: EmitArgs = serde_json::from_value(args)?;

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -8,7 +8,6 @@ use deno_core::serde_json::Value;
 use deno_core::JsRuntime;
 use deno_core::ModuleSpecifier;
 use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
 use deno_runtime::ops::worker_host::create_worker_permissions;
 use deno_runtime::ops::worker_host::PermissionsArg;
 use deno_runtime::permissions::Permissions;
@@ -32,7 +31,7 @@ struct PermissionsHolder(Uuid, Permissions);
 pub fn op_pledge_test_permissions(
   state: &mut OpState,
   args: Value,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Uuid, AnyError> {
   deno_runtime::ops::check_unstable(state, "Deno.test.permissions");
 
@@ -54,7 +53,7 @@ pub fn op_pledge_test_permissions(
 pub fn op_restore_test_permissions(
   state: &mut OpState,
   token: Uuid,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   deno_runtime::ops::check_unstable(state, "Deno.test.permissions");
 
@@ -80,7 +79,7 @@ struct PostTestMessageArgs {
 fn op_post_test_message(
   state: &mut OpState,
   args: Value,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Value, AnyError> {
   let args: PostTestMessageArgs = serde_json::from_value(args)?;
   let origin = state.borrow::<ModuleSpecifier>().to_string();

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -123,7 +123,7 @@ fn create_js_runtime() -> JsRuntime {
 fn op_listen(
   state: &mut OpState,
   _args: (),
-  _bufs: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<ResourceId, AnyError> {
   log::debug!("listen");
   let addr = "127.0.0.1:4544".parse::<SocketAddr>().unwrap();
@@ -137,7 +137,7 @@ fn op_listen(
 fn op_close(
   state: &mut OpState,
   rid: ResourceId,
-  _buf: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   log::debug!("close rid={}", rid);
   state
@@ -150,7 +150,7 @@ fn op_close(
 async fn op_accept(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _buf: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<ResourceId, AnyError> {
   log::debug!("accept rid={}", rid);
 

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -6,7 +6,6 @@ use crate::op_sync;
 use crate::resources::ResourceId;
 use crate::Extension;
 use crate::OpState;
-use crate::ZeroCopyBuf;
 use std::io::{stderr, stdout, Write};
 
 pub(crate) fn init_builtins() -> Extension {
@@ -29,7 +28,7 @@ pub(crate) fn init_builtins() -> Extension {
 pub fn op_resources(
   state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Vec<(ResourceId, String)>, AnyError> {
   let serialized_resources = state
     .resource_table
@@ -43,7 +42,7 @@ pub fn op_resources(
 pub fn op_close(
   state: &mut OpState,
   rid: Option<ResourceId>,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   // TODO(@AaronO): drop Option after improving type-strictness balance in serde_v8
   let rid = rid.ok_or_else(|| type_error("missing or invalid `rid`"))?;
@@ -59,7 +58,7 @@ pub fn op_close(
 pub fn op_print(
   _state: &mut OpState,
   args: (String, bool),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let (msg, is_err) = args;
   if is_err {

--- a/extensions/fetch/lib.rs
+++ b/extensions/fetch/lib.rs
@@ -274,7 +274,7 @@ pub struct FetchResponse {
 pub async fn op_fetch_send(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _data: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<FetchResponse, AnyError> {
   let request = state
     .borrow_mut()
@@ -434,7 +434,7 @@ pub struct CreateHttpClientOptions {
 pub fn op_create_http_client<FP>(
   state: &mut OpState,
   args: CreateHttpClientOptions,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<ResourceId, AnyError>
 where
   FP: FetchPermissions + 'static,

--- a/extensions/file/lib.rs
+++ b/extensions/file/lib.rs
@@ -76,7 +76,7 @@ pub fn op_file_create_object_url(
 pub fn op_file_revoke_object_url(
   state: &mut deno_core::OpState,
   url: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let url = Url::parse(&url)?;
   let blob_store = state.borrow::<BlobUrlStore>();

--- a/extensions/timers/lib.rs
+++ b/extensions/timers/lib.rs
@@ -18,7 +18,6 @@ use deno_core::op_async;
 use deno_core::op_sync;
 use deno_core::Extension;
 use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
 use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
@@ -104,7 +103,7 @@ impl GlobalTimer {
 pub fn op_global_timer_stop(
   state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let global_timer = state.borrow_mut::<GlobalTimer>();
   global_timer.cancel();
@@ -122,7 +121,7 @@ pub fn op_global_timer_stop(
 pub fn op_global_timer_start(
   state: &mut OpState,
   timeout: u64,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let deadline = Instant::now() + Duration::from_millis(timeout);
   let global_timer = state.borrow_mut::<GlobalTimer>();
@@ -133,7 +132,7 @@ pub fn op_global_timer_start(
 pub async fn op_global_timer(
   state: Rc<RefCell<OpState>>,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let maybe_timer_fut = {
     let mut s = state.borrow_mut();
@@ -154,7 +153,7 @@ pub async fn op_global_timer(
 pub fn op_now<TP>(
   state: &mut OpState,
   _argument: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<f64, AnyError>
 where
   TP: TimersPermission + 'static,
@@ -180,7 +179,7 @@ where
 pub fn op_sleep_sync<TP>(
   state: &mut OpState,
   millis: u64,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError>
 where
   TP: TimersPermission + 'static,

--- a/extensions/url/lib.rs
+++ b/extensions/url/lib.rs
@@ -74,7 +74,7 @@ pub struct UrlParts {
 pub fn op_url_parse(
   _state: &mut deno_core::OpState,
   args: UrlParseArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<UrlParts, AnyError> {
   let base_url = args
     .base_href
@@ -160,7 +160,7 @@ pub fn op_url_parse_search_params(
 pub fn op_url_stringify_search_params(
   _state: &mut deno_core::OpState,
   args: Vec<(String, String)>,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let search = form_urlencoded::Serializer::new(String::new())
     .extend_pairs(args)

--- a/extensions/webgpu/binding.rs
+++ b/extensions/webgpu/binding.rs
@@ -3,7 +3,6 @@
 use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -80,7 +79,7 @@ pub struct CreateBindGroupLayoutArgs {
 pub fn op_webgpu_create_bind_group_layout(
   state: &mut OpState,
   args: CreateBindGroupLayoutArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
@@ -213,7 +212,7 @@ pub struct CreatePipelineLayoutArgs {
 pub fn op_webgpu_create_pipeline_layout(
   state: &mut OpState,
   args: CreatePipelineLayoutArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
@@ -267,7 +266,7 @@ pub struct CreateBindGroupArgs {
 pub fn op_webgpu_create_bind_group(
   state: &mut OpState,
   args: CreateBindGroupArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state

--- a/extensions/webgpu/buffer.rs
+++ b/extensions/webgpu/buffer.rs
@@ -44,7 +44,7 @@ pub struct CreateBufferArgs {
 pub fn op_webgpu_create_buffer(
   state: &mut OpState,
   args: CreateBufferArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
@@ -80,7 +80,7 @@ pub struct BufferGetMapAsyncArgs {
 pub async fn op_webgpu_buffer_get_map_async(
   state: Rc<RefCell<OpState>>,
   args: BufferGetMapAsyncArgs,
-  _bufs: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let (sender, receiver) = oneshot::channel::<Result<(), AnyError>>();
 

--- a/extensions/webgpu/bundle.rs
+++ b/extensions/webgpu/bundle.rs
@@ -43,7 +43,7 @@ pub struct CreateRenderBundleEncoderArgs {
 pub fn op_webgpu_create_render_bundle_encoder(
   state: &mut OpState,
   args: CreateRenderBundleEncoderArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let device_resource = state
     .resource_table
@@ -96,7 +96,7 @@ pub struct RenderBundleEncoderFinishArgs {
 pub fn op_webgpu_render_bundle_encoder_finish(
   state: &mut OpState,
   args: RenderBundleEncoderFinishArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
@@ -188,7 +188,7 @@ pub struct RenderBundleEncoderPushDebugGroupArgs {
 pub fn op_webgpu_render_bundle_encoder_push_debug_group(
   state: &mut OpState,
   args: RenderBundleEncoderPushDebugGroupArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
@@ -215,7 +215,7 @@ pub struct RenderBundleEncoderPopDebugGroupArgs {
 pub fn op_webgpu_render_bundle_encoder_pop_debug_group(
   state: &mut OpState,
   args: RenderBundleEncoderPopDebugGroupArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
@@ -239,7 +239,7 @@ pub struct RenderBundleEncoderInsertDebugMarkerArgs {
 pub fn op_webgpu_render_bundle_encoder_insert_debug_marker(
   state: &mut OpState,
   args: RenderBundleEncoderInsertDebugMarkerArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
@@ -267,7 +267,7 @@ pub struct RenderBundleEncoderSetPipelineArgs {
 pub fn op_webgpu_render_bundle_encoder_set_pipeline(
   state: &mut OpState,
   args: RenderBundleEncoderSetPipelineArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pipeline_resource = state
     .resource_table
@@ -299,7 +299,7 @@ pub struct RenderBundleEncoderSetIndexBufferArgs {
 pub fn op_webgpu_render_bundle_encoder_set_index_buffer(
   state: &mut OpState,
   args: RenderBundleEncoderSetIndexBufferArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
@@ -336,7 +336,7 @@ pub struct RenderBundleEncoderSetVertexBufferArgs {
 pub fn op_webgpu_render_bundle_encoder_set_vertex_buffer(
   state: &mut OpState,
   args: RenderBundleEncoderSetVertexBufferArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
@@ -371,7 +371,7 @@ pub struct RenderBundleEncoderDrawArgs {
 pub fn op_webgpu_render_bundle_encoder_draw(
   state: &mut OpState,
   args: RenderBundleEncoderDrawArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
@@ -403,7 +403,7 @@ pub struct RenderBundleEncoderDrawIndexedArgs {
 pub fn op_webgpu_render_bundle_encoder_draw_indexed(
   state: &mut OpState,
   args: RenderBundleEncoderDrawIndexedArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
@@ -433,7 +433,7 @@ pub struct RenderBundleEncoderDrawIndirectArgs {
 pub fn op_webgpu_render_bundle_encoder_draw_indirect(
   state: &mut OpState,
   args: RenderBundleEncoderDrawIndirectArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table

--- a/extensions/webgpu/command_encoder.rs
+++ b/extensions/webgpu/command_encoder.rs
@@ -3,7 +3,6 @@
 use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -49,7 +48,7 @@ pub struct CreateCommandEncoderArgs {
 pub fn op_webgpu_create_command_encoder(
   state: &mut OpState,
   args: CreateCommandEncoderArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
@@ -106,7 +105,7 @@ pub struct CommandEncoderBeginRenderPassArgs {
 pub fn op_webgpu_command_encoder_begin_render_pass(
   state: &mut OpState,
   args: CommandEncoderBeginRenderPassArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
@@ -239,7 +238,7 @@ pub struct CommandEncoderBeginComputePassArgs {
 pub fn op_webgpu_command_encoder_begin_compute_pass(
   state: &mut OpState,
   args: CommandEncoderBeginComputePassArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
@@ -278,7 +277,7 @@ pub struct CommandEncoderCopyBufferToBufferArgs {
 pub fn op_webgpu_command_encoder_copy_buffer_to_buffer(
   state: &mut OpState,
   args: CommandEncoderCopyBufferToBufferArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
@@ -345,7 +344,7 @@ pub struct CommandEncoderCopyBufferToTextureArgs {
 pub fn op_webgpu_command_encoder_copy_buffer_to_texture(
   state: &mut OpState,
   args: CommandEncoderCopyBufferToTextureArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
@@ -406,7 +405,7 @@ pub struct CommandEncoderCopyTextureToBufferArgs {
 pub fn op_webgpu_command_encoder_copy_texture_to_buffer(
   state: &mut OpState,
   args: CommandEncoderCopyTextureToBufferArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
@@ -470,7 +469,7 @@ pub struct CommandEncoderCopyTextureToTextureArgs {
 pub fn op_webgpu_command_encoder_copy_texture_to_texture(
   state: &mut OpState,
   args: CommandEncoderCopyTextureToTextureArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
@@ -532,7 +531,7 @@ pub struct CommandEncoderPushDebugGroupArgs {
 pub fn op_webgpu_command_encoder_push_debug_group(
   state: &mut OpState,
   args: CommandEncoderPushDebugGroupArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
@@ -554,7 +553,7 @@ pub struct CommandEncoderPopDebugGroupArgs {
 pub fn op_webgpu_command_encoder_pop_debug_group(
   state: &mut OpState,
   args: CommandEncoderPopDebugGroupArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
@@ -576,7 +575,7 @@ pub struct CommandEncoderInsertDebugMarkerArgs {
 pub fn op_webgpu_command_encoder_insert_debug_marker(
   state: &mut OpState,
   args: CommandEncoderInsertDebugMarkerArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
@@ -602,7 +601,7 @@ pub struct CommandEncoderWriteTimestampArgs {
 pub fn op_webgpu_command_encoder_write_timestamp(
   state: &mut OpState,
   args: CommandEncoderWriteTimestampArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
@@ -636,7 +635,7 @@ pub struct CommandEncoderResolveQuerySetArgs {
 pub fn op_webgpu_command_encoder_resolve_query_set(
   state: &mut OpState,
   args: CommandEncoderResolveQuerySetArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
@@ -673,7 +672,7 @@ pub struct CommandEncoderFinishArgs {
 pub fn op_webgpu_command_encoder_finish(
   state: &mut OpState,
   args: CommandEncoderFinishArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table

--- a/extensions/webgpu/compute_pass.rs
+++ b/extensions/webgpu/compute_pass.rs
@@ -31,7 +31,7 @@ pub struct ComputePassSetPipelineArgs {
 pub fn op_webgpu_compute_pass_set_pipeline(
   state: &mut OpState,
   args: ComputePassSetPipelineArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pipeline_resource = state
     .resource_table
@@ -62,7 +62,7 @@ pub struct ComputePassDispatchArgs {
 pub fn op_webgpu_compute_pass_dispatch(
   state: &mut OpState,
   args: ComputePassDispatchArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
@@ -90,7 +90,7 @@ pub struct ComputePassDispatchIndirectArgs {
 pub fn op_webgpu_compute_pass_dispatch_indirect(
   state: &mut OpState,
   args: ComputePassDispatchIndirectArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
@@ -121,7 +121,7 @@ pub struct ComputePassBeginPipelineStatisticsQueryArgs {
 pub fn op_webgpu_compute_pass_begin_pipeline_statistics_query(
   state: &mut OpState,
   args: ComputePassBeginPipelineStatisticsQueryArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
@@ -150,7 +150,7 @@ pub struct ComputePassEndPipelineStatisticsQueryArgs {
 pub fn op_webgpu_compute_pass_end_pipeline_statistics_query(
   state: &mut OpState,
   args: ComputePassEndPipelineStatisticsQueryArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
@@ -175,7 +175,7 @@ pub struct ComputePassWriteTimestampArgs {
 pub fn op_webgpu_compute_pass_write_timestamp(
   state: &mut OpState,
   args: ComputePassWriteTimestampArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
@@ -205,7 +205,7 @@ pub struct ComputePassEndPassArgs {
 pub fn op_webgpu_compute_pass_end_pass(
   state: &mut OpState,
   args: ComputePassEndPassArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
@@ -284,7 +284,7 @@ pub struct ComputePassPushDebugGroupArgs {
 pub fn op_webgpu_compute_pass_push_debug_group(
   state: &mut OpState,
   args: ComputePassPushDebugGroupArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
@@ -312,7 +312,7 @@ pub struct ComputePassPopDebugGroupArgs {
 pub fn op_webgpu_compute_pass_pop_debug_group(
   state: &mut OpState,
   args: ComputePassPopDebugGroupArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
@@ -336,7 +336,7 @@ pub struct ComputePassInsertDebugMarkerArgs {
 pub fn op_webgpu_compute_pass_insert_debug_marker(
   state: &mut OpState,
   args: ComputePassInsertDebugMarkerArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table

--- a/extensions/webgpu/lib.rs
+++ b/extensions/webgpu/lib.rs
@@ -10,7 +10,6 @@ use deno_core::OpFn;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use serde::Serialize;
 use std::borrow::Cow;
@@ -229,7 +228,7 @@ pub struct GpuAdapterDevice {
 pub async fn op_webgpu_request_adapter(
   state: Rc<RefCell<OpState>>,
   args: RequestAdapterArgs,
-  _bufs: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<GpuAdapterDeviceOrErr, AnyError> {
   let mut state = state.borrow_mut();
   check_unstable(&state, "navigator.gpu.requestAdapter");
@@ -367,7 +366,7 @@ pub struct RequestDeviceArgs {
 pub async fn op_webgpu_request_device(
   state: Rc<RefCell<OpState>>,
   args: RequestDeviceArgs,
-  _bufs: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<GpuAdapterDevice, AnyError> {
   let mut state = state.borrow_mut();
   let adapter_resource = state
@@ -503,7 +502,7 @@ pub struct CreateQuerySetArgs {
 pub fn op_webgpu_create_query_set(
   state: &mut OpState,
   args: CreateQuerySetArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let device_resource = state
     .resource_table

--- a/extensions/webgpu/pipeline.rs
+++ b/extensions/webgpu/pipeline.rs
@@ -3,7 +3,6 @@
 use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use serde::Serialize;
@@ -168,7 +167,7 @@ pub struct CreateComputePipelineArgs {
 pub fn op_webgpu_create_compute_pipeline(
   state: &mut OpState,
   args: CreateComputePipelineArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
@@ -240,7 +239,7 @@ pub struct PipelineLayout {
 pub fn op_webgpu_compute_pipeline_get_bind_group_layout(
   state: &mut OpState,
   args: ComputePipelineGetBindGroupLayoutArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<PipelineLayout, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let compute_pipeline_resource = state
@@ -458,7 +457,7 @@ pub struct CreateRenderPipelineArgs {
 pub fn op_webgpu_create_render_pipeline(
   state: &mut OpState,
   args: CreateRenderPipelineArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
@@ -660,7 +659,7 @@ pub struct RenderPipelineGetBindGroupLayoutArgs {
 pub fn op_webgpu_render_pipeline_get_bind_group_layout(
   state: &mut OpState,
   args: RenderPipelineGetBindGroupLayoutArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<PipelineLayout, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let render_pipeline_resource = state

--- a/extensions/webgpu/queue.rs
+++ b/extensions/webgpu/queue.rs
@@ -24,7 +24,7 @@ pub struct QueueSubmitArgs {
 pub fn op_webgpu_queue_submit(
   state: &mut OpState,
   args: QueueSubmitArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let queue_resource = state

--- a/extensions/webgpu/render_pass.rs
+++ b/extensions/webgpu/render_pass.rs
@@ -36,7 +36,7 @@ pub struct RenderPassSetViewportArgs {
 pub fn op_webgpu_render_pass_set_viewport(
   state: &mut OpState,
   args: RenderPassSetViewportArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -69,7 +69,7 @@ pub struct RenderPassSetScissorRectArgs {
 pub fn op_webgpu_render_pass_set_scissor_rect(
   state: &mut OpState,
   args: RenderPassSetScissorRectArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -106,7 +106,7 @@ pub struct RenderPassSetBlendConstantArgs {
 pub fn op_webgpu_render_pass_set_blend_constant(
   state: &mut OpState,
   args: RenderPassSetBlendConstantArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -136,7 +136,7 @@ pub struct RenderPassSetStencilReferenceArgs {
 pub fn op_webgpu_render_pass_set_stencil_reference(
   state: &mut OpState,
   args: RenderPassSetStencilReferenceArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -162,7 +162,7 @@ pub struct RenderPassBeginPipelineStatisticsQueryArgs {
 pub fn op_webgpu_render_pass_begin_pipeline_statistics_query(
   state: &mut OpState,
   args: RenderPassBeginPipelineStatisticsQueryArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -191,7 +191,7 @@ pub struct RenderPassEndPipelineStatisticsQueryArgs {
 pub fn op_webgpu_render_pass_end_pipeline_statistics_query(
   state: &mut OpState,
   args: RenderPassEndPipelineStatisticsQueryArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -216,7 +216,7 @@ pub struct RenderPassWriteTimestampArgs {
 pub fn op_webgpu_render_pass_write_timestamp(
   state: &mut OpState,
   args: RenderPassWriteTimestampArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -246,7 +246,7 @@ pub struct RenderPassExecuteBundlesArgs {
 pub fn op_webgpu_render_pass_execute_bundles(
   state: &mut OpState,
   args: RenderPassExecuteBundlesArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let mut render_bundle_ids = vec![];
 
@@ -284,7 +284,7 @@ pub struct RenderPassEndPassArgs {
 pub fn op_webgpu_render_pass_end_pass(
   state: &mut OpState,
   args: RenderPassEndPassArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
@@ -373,7 +373,7 @@ pub struct RenderPassPushDebugGroupArgs {
 pub fn op_webgpu_render_pass_push_debug_group(
   state: &mut OpState,
   args: RenderPassPushDebugGroupArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -401,7 +401,7 @@ pub struct RenderPassPopDebugGroupArgs {
 pub fn op_webgpu_render_pass_pop_debug_group(
   state: &mut OpState,
   args: RenderPassPopDebugGroupArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -425,7 +425,7 @@ pub struct RenderPassInsertDebugMarkerArgs {
 pub fn op_webgpu_render_pass_insert_debug_marker(
   state: &mut OpState,
   args: RenderPassInsertDebugMarkerArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -454,7 +454,7 @@ pub struct RenderPassSetPipelineArgs {
 pub fn op_webgpu_render_pass_set_pipeline(
   state: &mut OpState,
   args: RenderPassSetPipelineArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pipeline_resource = state
     .resource_table
@@ -486,7 +486,7 @@ pub struct RenderPassSetIndexBufferArgs {
 pub fn op_webgpu_render_pass_set_index_buffer(
   state: &mut OpState,
   args: RenderPassSetIndexBufferArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
@@ -520,7 +520,7 @@ pub struct RenderPassSetVertexBufferArgs {
 pub fn op_webgpu_render_pass_set_vertex_buffer(
   state: &mut OpState,
   args: RenderPassSetVertexBufferArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
@@ -555,7 +555,7 @@ pub struct RenderPassDrawArgs {
 pub fn op_webgpu_render_pass_draw(
   state: &mut OpState,
   args: RenderPassDrawArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -587,7 +587,7 @@ pub struct RenderPassDrawIndexedArgs {
 pub fn op_webgpu_render_pass_draw_indexed(
   state: &mut OpState,
   args: RenderPassDrawIndexedArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
@@ -617,7 +617,7 @@ pub struct RenderPassDrawIndirectArgs {
 pub fn op_webgpu_render_pass_draw_indirect(
   state: &mut OpState,
   args: RenderPassDrawIndirectArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
@@ -648,7 +648,7 @@ pub struct RenderPassDrawIndexedIndirectArgs {
 pub fn op_webgpu_render_pass_draw_indexed_indirect(
   state: &mut OpState,
   args: RenderPassDrawIndexedIndirectArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table

--- a/extensions/webgpu/sampler.rs
+++ b/extensions/webgpu/sampler.rs
@@ -3,7 +3,6 @@
 use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -80,7 +79,7 @@ pub struct CreateSamplerArgs {
 pub fn op_webgpu_create_sampler(
   state: &mut OpState,
   args: CreateSamplerArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state

--- a/extensions/webgpu/texture.rs
+++ b/extensions/webgpu/texture.rs
@@ -3,7 +3,6 @@
 use deno_core::error::AnyError;
 use deno_core::error::{bad_resource_id, not_supported};
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -145,7 +144,7 @@ pub struct CreateTextureArgs {
 pub fn op_webgpu_create_texture(
   state: &mut OpState,
   args: CreateTextureArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
@@ -200,7 +199,7 @@ pub struct CreateTextureViewArgs {
 pub fn op_webgpu_create_texture_view(
   state: &mut OpState,
   args: CreateTextureViewArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
   let texture_resource = state

--- a/extensions/websocket/lib.rs
+++ b/extensions/websocket/lib.rs
@@ -87,7 +87,7 @@ impl WsStreamResource {}
 pub fn op_ws_check_permission<WP>(
   state: &mut OpState,
   url: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError>
 where
   WP: WebSocketPermissions + 'static,
@@ -117,7 +117,7 @@ pub struct CreateResponse {
 pub async fn op_ws_create<WP>(
   state: Rc<RefCell<OpState>>,
   args: CreateArgs,
-  _bufs: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<CreateResponse, AnyError>
 where
   WP: WebSocketPermissions + 'static,
@@ -250,7 +250,7 @@ pub struct CloseArgs {
 pub async fn op_ws_close(
   state: Rc<RefCell<OpState>>,
   args: CloseArgs,
-  _bufs: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let rid = args.rid;
   let msg = Message::Close(args.code.map(|c| CloseFrame {
@@ -286,7 +286,7 @@ pub enum NextEventResponse {
 pub async fn op_ws_next_event(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _bufs: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<NextEventResponse, AnyError> {
   let resource = state
     .borrow_mut()

--- a/runtime/metrics.rs
+++ b/runtime/metrics.rs
@@ -7,7 +7,6 @@ use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::Extension;
 use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
 
 pub fn init() -> Extension {
   Extension::builder()
@@ -30,7 +29,7 @@ struct MetricsReturn {
 fn op_metrics(
   state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<MetricsReturn, AnyError> {
   let m = state.borrow::<RuntimeMetrics>();
   let combined = m.combined_metrics();

--- a/runtime/ops/fs.rs
+++ b/runtime/ops/fs.rs
@@ -14,7 +14,6 @@ use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 use deno_crypto::rand::thread_rng;
 use deno_crypto::rand::Rng;
 use log::debug;
@@ -157,7 +156,7 @@ fn open_helper(
 fn op_open_sync(
   state: &mut OpState,
   args: OpenArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<ResourceId, AnyError> {
   let (path, open_options) = open_helper(state, args)?;
   let std_file = open_options.open(path)?;
@@ -170,7 +169,7 @@ fn op_open_sync(
 async fn op_open_async(
   state: Rc<RefCell<OpState>>,
   args: OpenArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<ResourceId, AnyError> {
   let (path, open_options) = open_helper(&mut state.borrow_mut(), args)?;
   let tokio_file = tokio::fs::OpenOptions::from(open_options)
@@ -209,7 +208,7 @@ fn seek_helper(args: SeekArgs) -> Result<(u32, SeekFrom), AnyError> {
 fn op_seek_sync(
   state: &mut OpState,
   args: SeekArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<u64, AnyError> {
   let (rid, seek_from) = seek_helper(args)?;
   let pos = StdFileResource::with(state, rid, |r| match r {
@@ -224,7 +223,7 @@ fn op_seek_sync(
 async fn op_seek_async(
   state: Rc<RefCell<OpState>>,
   args: SeekArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<u64, AnyError> {
   let (rid, seek_from) = seek_helper(args)?;
 
@@ -249,7 +248,7 @@ async fn op_seek_async(
 fn op_fdatasync_sync(
   state: &mut OpState,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   StdFileResource::with(state, rid, |r| match r {
     Ok(std_file) => std_file.sync_data().map_err(AnyError::from),
@@ -261,7 +260,7 @@ fn op_fdatasync_sync(
 async fn op_fdatasync_async(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let resource = state
     .borrow_mut()
@@ -284,7 +283,7 @@ async fn op_fdatasync_async(
 fn op_fsync_sync(
   state: &mut OpState,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   StdFileResource::with(state, rid, |r| match r {
     Ok(std_file) => std_file.sync_all().map_err(AnyError::from),
@@ -296,7 +295,7 @@ fn op_fsync_sync(
 async fn op_fsync_async(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let resource = state
     .borrow_mut()
@@ -319,7 +318,7 @@ async fn op_fsync_async(
 fn op_fstat_sync(
   state: &mut OpState,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<FsStat, AnyError> {
   let metadata = StdFileResource::with(state, rid, |r| match r {
     Ok(std_file) => std_file.metadata().map_err(AnyError::from),
@@ -331,7 +330,7 @@ fn op_fstat_sync(
 async fn op_fstat_async(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<FsStat, AnyError> {
   let resource = state
     .borrow_mut()
@@ -355,7 +354,7 @@ async fn op_fstat_async(
 fn op_umask(
   state: &mut OpState,
   mask: Option<u32>,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<u32, AnyError> {
   super::check_unstable(state, "Deno.umask");
   // TODO implement umask for Windows
@@ -387,7 +386,7 @@ fn op_umask(
 fn op_chdir(
   state: &mut OpState,
   directory: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let d = PathBuf::from(&directory);
   state.borrow_mut::<Permissions>().read.check(&d)?;
@@ -406,7 +405,7 @@ pub struct MkdirArgs {
 fn op_mkdir_sync(
   state: &mut OpState,
   args: MkdirArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let path = Path::new(&args.path).to_path_buf();
   let mode = args.mode.unwrap_or(0o777) & 0o777;
@@ -426,7 +425,7 @@ fn op_mkdir_sync(
 async fn op_mkdir_async(
   state: Rc<RefCell<OpState>>,
   args: MkdirArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let path = Path::new(&args.path).to_path_buf();
   let mode = args.mode.unwrap_or(0o777) & 0o777;
@@ -462,7 +461,7 @@ pub struct ChmodArgs {
 fn op_chmod_sync(
   state: &mut OpState,
   args: ChmodArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let path = Path::new(&args.path).to_path_buf();
   let mode = args.mode & 0o777;
@@ -488,7 +487,7 @@ fn op_chmod_sync(
 async fn op_chmod_async(
   state: Rc<RefCell<OpState>>,
   args: ChmodArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let path = Path::new(&args.path).to_path_buf();
   let mode = args.mode & 0o777;
@@ -530,7 +529,7 @@ pub struct ChownArgs {
 fn op_chown_sync(
   state: &mut OpState,
   args: ChownArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let path = Path::new(&args.path).to_path_buf();
   state.borrow_mut::<Permissions>().write.check(&path)?;
@@ -558,7 +557,7 @@ fn op_chown_sync(
 async fn op_chown_async(
   state: Rc<RefCell<OpState>>,
   args: ChownArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let path = Path::new(&args.path).to_path_buf();
 
@@ -600,7 +599,7 @@ pub struct RemoveArgs {
 fn op_remove_sync(
   state: &mut OpState,
   args: RemoveArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let path = PathBuf::from(&args.path);
   let recursive = args.recursive;
@@ -642,7 +641,7 @@ fn op_remove_sync(
 async fn op_remove_async(
   state: Rc<RefCell<OpState>>,
   args: RemoveArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let path = PathBuf::from(&args.path);
   let recursive = args.recursive;
@@ -698,7 +697,7 @@ pub struct CopyFileArgs {
 fn op_copy_file_sync(
   state: &mut OpState,
   args: CopyFileArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let from = PathBuf::from(&args.from);
   let to = PathBuf::from(&args.to);
@@ -723,7 +722,7 @@ fn op_copy_file_sync(
 async fn op_copy_file_async(
   state: Rc<RefCell<OpState>>,
   args: CopyFileArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let from = PathBuf::from(&args.from);
   let to = PathBuf::from(&args.to);
@@ -838,7 +837,7 @@ pub struct StatArgs {
 fn op_stat_sync(
   state: &mut OpState,
   args: StatArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<FsStat, AnyError> {
   let path = PathBuf::from(&args.path);
   let lstat = args.lstat;
@@ -855,7 +854,7 @@ fn op_stat_sync(
 async fn op_stat_async(
   state: Rc<RefCell<OpState>>,
   args: StatArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<FsStat, AnyError> {
   let path = PathBuf::from(&args.path);
   let lstat = args.lstat;
@@ -881,7 +880,7 @@ async fn op_stat_async(
 fn op_realpath_sync(
   state: &mut OpState,
   path: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let path = PathBuf::from(&path);
 
@@ -902,7 +901,7 @@ fn op_realpath_sync(
 async fn op_realpath_async(
   state: Rc<RefCell<OpState>>,
   path: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let path = PathBuf::from(&path);
 
@@ -939,7 +938,7 @@ pub struct DirEntry {
 fn op_read_dir_sync(
   state: &mut OpState,
   path: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Vec<DirEntry>, AnyError> {
   let path = PathBuf::from(&path);
 
@@ -975,7 +974,7 @@ fn op_read_dir_sync(
 async fn op_read_dir_async(
   state: Rc<RefCell<OpState>>,
   path: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Vec<DirEntry>, AnyError> {
   let path = PathBuf::from(&path);
   {
@@ -1023,7 +1022,7 @@ pub struct RenameArgs {
 fn op_rename_sync(
   state: &mut OpState,
   args: RenameArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let oldpath = PathBuf::from(&args.oldpath);
   let newpath = PathBuf::from(&args.newpath);
@@ -1040,7 +1039,7 @@ fn op_rename_sync(
 async fn op_rename_async(
   state: Rc<RefCell<OpState>>,
   args: RenameArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let oldpath = PathBuf::from(&args.oldpath);
   let newpath = PathBuf::from(&args.newpath);
@@ -1074,7 +1073,7 @@ pub struct LinkArgs {
 fn op_link_sync(
   state: &mut OpState,
   args: LinkArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let oldpath = PathBuf::from(&args.oldpath);
   let newpath = PathBuf::from(&args.newpath);
@@ -1093,7 +1092,7 @@ fn op_link_sync(
 async fn op_link_async(
   state: Rc<RefCell<OpState>>,
   args: LinkArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let oldpath = PathBuf::from(&args.oldpath);
   let newpath = PathBuf::from(&args.newpath);
@@ -1135,7 +1134,7 @@ pub struct SymlinkOptions {
 fn op_symlink_sync(
   state: &mut OpState,
   args: SymlinkArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let oldpath = PathBuf::from(&args.oldpath);
   let newpath = PathBuf::from(&args.newpath);
@@ -1184,7 +1183,7 @@ fn op_symlink_sync(
 async fn op_symlink_async(
   state: Rc<RefCell<OpState>>,
   args: SymlinkArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let oldpath = PathBuf::from(&args.oldpath);
   let newpath = PathBuf::from(&args.newpath);
@@ -1236,7 +1235,7 @@ async fn op_symlink_async(
 fn op_read_link_sync(
   state: &mut OpState,
   path: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let path = PathBuf::from(&path);
 
@@ -1251,7 +1250,7 @@ fn op_read_link_sync(
 async fn op_read_link_async(
   state: Rc<RefCell<OpState>>,
   path: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let path = PathBuf::from(&path);
   {
@@ -1278,7 +1277,7 @@ pub struct FtruncateArgs {
 fn op_ftruncate_sync(
   state: &mut OpState,
   args: FtruncateArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let rid = args.rid;
   let len = args.len as u64;
@@ -1292,7 +1291,7 @@ fn op_ftruncate_sync(
 async fn op_ftruncate_async(
   state: Rc<RefCell<OpState>>,
   args: FtruncateArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let rid = args.rid;
   let len = args.len as u64;
@@ -1325,7 +1324,7 @@ pub struct TruncateArgs {
 fn op_truncate_sync(
   state: &mut OpState,
   args: TruncateArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let path = PathBuf::from(&args.path);
   let len = args.len;
@@ -1341,7 +1340,7 @@ fn op_truncate_sync(
 async fn op_truncate_async(
   state: Rc<RefCell<OpState>>,
   args: TruncateArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let path = PathBuf::from(&args.path);
   let len = args.len;
@@ -1415,7 +1414,7 @@ pub struct MakeTempArgs {
 fn op_make_temp_dir_sync(
   state: &mut OpState,
   args: MakeTempArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let dir = args.dir.map(|s| PathBuf::from(&s));
   let prefix = args.prefix.map(String::from);
@@ -1444,7 +1443,7 @@ fn op_make_temp_dir_sync(
 async fn op_make_temp_dir_async(
   state: Rc<RefCell<OpState>>,
   args: MakeTempArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let dir = args.dir.map(|s| PathBuf::from(&s));
   let prefix = args.prefix.map(String::from);
@@ -1478,7 +1477,7 @@ async fn op_make_temp_dir_async(
 fn op_make_temp_file_sync(
   state: &mut OpState,
   args: MakeTempArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let dir = args.dir.map(|s| PathBuf::from(&s));
   let prefix = args.prefix.map(String::from);
@@ -1507,7 +1506,7 @@ fn op_make_temp_file_sync(
 async fn op_make_temp_file_async(
   state: Rc<RefCell<OpState>>,
   args: MakeTempArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let dir = args.dir.map(|s| PathBuf::from(&s));
   let prefix = args.prefix.map(String::from);
@@ -1549,7 +1548,7 @@ pub struct FutimeArgs {
 fn op_futime_sync(
   state: &mut OpState,
   args: FutimeArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   super::check_unstable(state, "Deno.futimeSync");
   let rid = args.rid;
@@ -1572,7 +1571,7 @@ fn op_futime_sync(
 async fn op_futime_async(
   state: Rc<RefCell<OpState>>,
   args: FutimeArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   super::check_unstable2(&state, "Deno.futime");
   let rid = args.rid;
@@ -1621,7 +1620,7 @@ pub struct UtimeArgs {
 fn op_utime_sync(
   state: &mut OpState,
   args: UtimeArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   super::check_unstable(state, "Deno.utime");
 
@@ -1637,7 +1636,7 @@ fn op_utime_sync(
 async fn op_utime_async(
   state: Rc<RefCell<OpState>>,
   args: UtimeArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   super::check_unstable(&state.borrow(), "Deno.utime");
 
@@ -1659,11 +1658,7 @@ async fn op_utime_async(
   .unwrap()
 }
 
-fn op_cwd(
-  state: &mut OpState,
-  _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<String, AnyError> {
+fn op_cwd(state: &mut OpState, _args: (), _: ()) -> Result<String, AnyError> {
   let path = current_dir()?;
   state
     .borrow_mut::<Permissions>()

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -10,7 +10,6 @@ use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 
 use deno_core::op_async;
 use deno_core::op_sync;
@@ -97,7 +96,7 @@ pub struct OpenArgs {
 fn op_fs_events_open(
   state: &mut OpState,
   args: OpenArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<ResourceId, AnyError> {
   let (sender, receiver) = mpsc::channel::<Result<FsEvent, AnyError>>(16);
   let sender = std::sync::Mutex::new(sender);
@@ -133,7 +132,7 @@ fn op_fs_events_open(
 async fn op_fs_events_poll(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Option<FsEvent>, AnyError> {
   let resource = state
     .borrow()

--- a/runtime/ops/http.rs
+++ b/runtime/ops/http.rs
@@ -145,7 +145,7 @@ struct NextRequestResponse(
 async fn op_http_request_next(
   state: Rc<RefCell<OpState>>,
   conn_rid: ResourceId,
-  _data: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Option<NextRequestResponse>, AnyError> {
   let conn_resource = state
     .borrow()
@@ -278,7 +278,7 @@ fn should_ignore_error(e: &AnyError) -> bool {
 fn op_http_start(
   state: &mut OpState,
   tcp_stream_rid: ResourceId,
-  _data: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<ResourceId, AnyError> {
   let deno_service = Service::default();
 
@@ -407,7 +407,7 @@ async fn op_http_response(
 async fn op_http_response_close(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _data: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let resource = state
     .borrow_mut()

--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -633,7 +633,7 @@ async fn op_write_async(
 async fn op_shutdown(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let resource = state
     .borrow()

--- a/runtime/ops/mod.rs
+++ b/runtime/ops/mod.rs
@@ -27,25 +27,29 @@ use deno_core::serde::de::DeserializeOwned;
 use deno_core::serde::Serialize;
 use deno_core::JsRuntime;
 use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
 use std::cell::RefCell;
 use std::future::Future;
 use std::rc::Rc;
 
-pub fn reg_async<F, V, R, RV>(rt: &mut JsRuntime, name: &'static str, op_fn: F)
-where
-  F: Fn(Rc<RefCell<OpState>>, V, Option<ZeroCopyBuf>) -> R + 'static,
-  V: DeserializeOwned,
+pub fn reg_async<F, A, B, R, RV>(
+  rt: &mut JsRuntime,
+  name: &'static str,
+  op_fn: F,
+) where
+  F: Fn(Rc<RefCell<OpState>>, A, B) -> R + 'static,
+  A: DeserializeOwned,
+  B: DeserializeOwned,
   R: Future<Output = Result<RV, AnyError>> + 'static,
   RV: Serialize + 'static,
 {
   rt.register_op(name, metrics_op(name, op_async(op_fn)));
 }
 
-pub fn reg_sync<F, V, R>(rt: &mut JsRuntime, name: &'static str, op_fn: F)
+pub fn reg_sync<F, A, B, R>(rt: &mut JsRuntime, name: &'static str, op_fn: F)
 where
-  F: Fn(&mut OpState, V, Option<ZeroCopyBuf>) -> Result<R, AnyError> + 'static,
-  V: DeserializeOwned,
+  F: Fn(&mut OpState, A, B) -> Result<R, AnyError> + 'static,
+  A: DeserializeOwned,
+  B: DeserializeOwned,
   R: Serialize + 'static,
 {
   rt.register_op(name, metrics_op(name, op_sync(op_fn)));

--- a/runtime/ops/net.rs
+++ b/runtime/ops/net.rs
@@ -100,7 +100,7 @@ pub(crate) struct AcceptArgs {
 async fn accept_tcp(
   state: Rc<RefCell<OpState>>,
   args: AcceptArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<OpConn, AnyError> {
   let rid = args.rid;
 
@@ -145,12 +145,12 @@ async fn accept_tcp(
 async fn op_accept(
   state: Rc<RefCell<OpState>>,
   args: AcceptArgs,
-  _buf: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<OpConn, AnyError> {
   match args.transport.as_str() {
-    "tcp" => accept_tcp(state, args, _buf).await,
+    "tcp" => accept_tcp(state, args, ()).await,
     #[cfg(unix)]
-    "unix" => net_unix::accept_unix(state, args, _buf).await,
+    "unix" => net_unix::accept_unix(state, args, ()).await,
     other => Err(bad_transport(other)),
   }
 }
@@ -288,7 +288,7 @@ struct ConnectArgs {
 async fn op_connect(
   state: Rc<RefCell<OpState>>,
   args: ConnectArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<OpConn, AnyError> {
   match args {
     ConnectArgs {
@@ -454,7 +454,7 @@ fn listen_udp(
 fn op_listen(
   state: &mut OpState,
   args: ListenArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<OpConn, AnyError> {
   match args {
     ListenArgs {
@@ -595,7 +595,7 @@ pub struct NameServer {
 async fn op_dns_resolve(
   state: Rc<RefCell<OpState>>,
   args: ResolveAddrArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Vec<DnsReturnRecord>, AnyError> {
   let ResolveAddrArgs {
     query,

--- a/runtime/ops/net_unix.rs
+++ b/runtime/ops/net_unix.rs
@@ -72,7 +72,7 @@ pub struct UnixListenArgs {
 pub(crate) async fn accept_unix(
   state: Rc<RefCell<OpState>>,
   args: AcceptArgs,
-  _bufs: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<OpConn, AnyError> {
   let rid = args.rid;
 

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -7,7 +7,6 @@ use deno_core::op_sync;
 use deno_core::url::Url;
 use deno_core::Extension;
 use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -34,7 +33,7 @@ pub fn init() -> Extension {
 fn op_exec_path(
   state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let current_exe = env::current_exe().unwrap();
   state
@@ -58,7 +57,7 @@ pub struct SetEnv {
 fn op_set_env(
   state: &mut OpState,
   args: SetEnv,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   state.borrow_mut::<Permissions>().env.check(&args.key)?;
   let invalid_key =
@@ -74,7 +73,7 @@ fn op_set_env(
 fn op_env(
   state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<HashMap<String, String>, AnyError> {
   state.borrow_mut::<Permissions>().env.check_all()?;
   Ok(env::vars().collect())
@@ -83,7 +82,7 @@ fn op_env(
 fn op_get_env(
   state: &mut OpState,
   key: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Option<String>, AnyError> {
   state.borrow_mut::<Permissions>().env.check(&key)?;
   if key.is_empty() || key.contains(&['=', '\0'] as &[char]) {
@@ -99,7 +98,7 @@ fn op_get_env(
 fn op_delete_env(
   state: &mut OpState,
   key: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   state.borrow_mut::<Permissions>().env.check(&key)?;
   if key.is_empty() || key.contains(&['=', '\0'] as &[char]) {
@@ -109,18 +108,14 @@ fn op_delete_env(
   Ok(())
 }
 
-fn op_exit(
-  _state: &mut OpState,
-  code: i32,
-  _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+fn op_exit(_state: &mut OpState, code: i32, _: ()) -> Result<(), AnyError> {
   std::process::exit(code)
 }
 
 fn op_loadavg(
   state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(f64, f64, f64), AnyError> {
   super::check_unstable(state, "Deno.loadavg");
   state.borrow_mut::<Permissions>().env.check_all()?;
@@ -133,7 +128,7 @@ fn op_loadavg(
 fn op_hostname(
   state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   super::check_unstable(state, "Deno.hostname");
   state.borrow_mut::<Permissions>().env.check_all()?;
@@ -144,7 +139,7 @@ fn op_hostname(
 fn op_os_release(
   state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   super::check_unstable(state, "Deno.osRelease");
   state.borrow_mut::<Permissions>().env.check_all()?;
@@ -168,7 +163,7 @@ struct MemInfo {
 fn op_system_memory_info(
   state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Option<MemInfo>, AnyError> {
   super::check_unstable(state, "Deno.systemMemoryInfo");
   state.borrow_mut::<Permissions>().env.check_all()?;
@@ -195,7 +190,7 @@ struct CpuInfo {
 fn op_system_cpu_info(
   state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<CpuInfo, AnyError> {
   super::check_unstable(state, "Deno.systemCpuInfo");
   state.borrow_mut::<Permissions>().env.check_all()?;

--- a/runtime/ops/permissions.rs
+++ b/runtime/ops/permissions.rs
@@ -8,7 +8,6 @@ use deno_core::op_sync;
 use deno_core::url;
 use deno_core::Extension;
 use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -34,7 +33,7 @@ pub struct PermissionArgs {
 pub fn op_query_permission(
   state: &mut OpState,
   args: PermissionArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let permissions = state.borrow::<Permissions>();
   let path = args.path.as_deref();
@@ -65,7 +64,7 @@ pub fn op_query_permission(
 pub fn op_revoke_permission(
   state: &mut OpState,
   args: PermissionArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let permissions = state.borrow_mut::<Permissions>();
   let path = args.path.as_deref();
@@ -96,7 +95,7 @@ pub fn op_revoke_permission(
 pub fn op_request_permission(
   state: &mut OpState,
   args: PermissionArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let permissions = state.borrow_mut::<Permissions>();
   let path = args.path.as_deref();

--- a/runtime/ops/plugin.rs
+++ b/runtime/ops/plugin.rs
@@ -6,7 +6,6 @@ use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 use dlopen::symbor::Library;
 use log::debug;
 use std::borrow::Cow;
@@ -32,7 +31,7 @@ pub fn init() -> Extension {
 pub fn op_open_plugin(
   state: &mut OpState,
   filename: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<ResourceId, AnyError> {
   let filename = PathBuf::from(&filename);
 

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -17,7 +17,6 @@ use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use serde::Serialize;
 use std::borrow::Cow;
@@ -101,7 +100,7 @@ struct RunInfo {
 fn op_run(
   state: &mut OpState,
   run_args: RunArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<RunInfo, AnyError> {
   let args = run_args.cmd;
   state.borrow_mut::<Permissions>().run.check(&args[0])?;
@@ -202,7 +201,7 @@ struct RunStatus {
 async fn op_run_status(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<RunStatus, AnyError> {
   let resource = state
     .borrow_mut()
@@ -287,11 +286,7 @@ struct KillArgs {
   signo: i32,
 }
 
-fn op_kill(
-  state: &mut OpState,
-  args: KillArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
-) -> Result<(), AnyError> {
+fn op_kill(state: &mut OpState, args: KillArgs, _: ()) -> Result<(), AnyError> {
   super::check_unstable(state, "Deno.kill");
   state.borrow_mut::<Permissions>().run.check_all()?;
 

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -7,7 +7,6 @@ use deno_core::op_sync;
 use deno_core::Extension;
 use deno_core::ModuleSpecifier;
 use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
 
 pub fn init(main_module: ModuleSpecifier) -> Extension {
   Extension::builder()
@@ -22,7 +21,7 @@ pub fn init(main_module: ModuleSpecifier) -> Extension {
 fn op_main_module(
   state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   let main = state.borrow::<ModuleSpecifier>().to_string();
   let main_url = deno_core::resolve_url_or_path(&main)?;

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -4,7 +4,6 @@ use deno_core::op_async;
 use deno_core::op_sync;
 use deno_core::Extension;
 use deno_core::OpState;
-use deno_core::ZeroCopyBuf;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -61,7 +60,7 @@ impl Resource for SignalStreamResource {
 fn op_signal_bind(
   state: &mut OpState,
   signo: i32,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<ResourceId, AnyError> {
   super::check_unstable(state, "Deno.signal");
   let resource = SignalStreamResource {
@@ -76,7 +75,7 @@ fn op_signal_bind(
 async fn op_signal_poll(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<bool, AnyError> {
   super::check_unstable2(&state, "Deno.signal");
 
@@ -98,7 +97,7 @@ async fn op_signal_poll(
 pub fn op_signal_unbind(
   state: &mut OpState,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   super::check_unstable(state, "Deno.signal");
   state
@@ -112,7 +111,7 @@ pub fn op_signal_unbind(
 pub fn op_signal_bind(
   _state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   unimplemented!();
 }
@@ -121,7 +120,7 @@ pub fn op_signal_bind(
 fn op_signal_unbind(
   _state: &mut OpState,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   unimplemented!();
 }
@@ -130,7 +129,7 @@ fn op_signal_unbind(
 async fn op_signal_poll(
   _state: Rc<RefCell<OpState>>,
   _args: (),
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   unimplemented!();
 }

--- a/runtime/ops/tls.rs
+++ b/runtime/ops/tls.rs
@@ -25,7 +25,6 @@ use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -105,7 +104,7 @@ struct StartTlsArgs {
 async fn op_start_tls(
   state: Rc<RefCell<OpState>>,
   args: StartTlsArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<OpConn, AnyError> {
   let rid = args.rid;
 
@@ -173,7 +172,7 @@ async fn op_start_tls(
 async fn op_connect_tls(
   state: Rc<RefCell<OpState>>,
   args: ConnectTlsArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<OpConn, AnyError> {
   assert_eq!(args.transport, "tcp");
 
@@ -314,7 +313,7 @@ pub struct ListenTlsArgs {
 fn op_listen_tls(
   state: &mut OpState,
   args: ListenTlsArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<OpConn, AnyError> {
   assert_eq!(args.transport, "tcp");
 
@@ -364,7 +363,7 @@ fn op_listen_tls(
 async fn op_accept_tls(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<OpConn, AnyError> {
   let resource = state
     .borrow()

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -10,7 +10,6 @@ use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::ResourceId;
-use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use serde::Serialize;
 use std::io::Error;
@@ -71,7 +70,7 @@ pub struct SetRawArgs {
 fn op_set_raw(
   state: &mut OpState,
   args: SetRawArgs,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   super::check_unstable(state, "Deno.setRaw");
 
@@ -221,7 +220,7 @@ fn op_set_raw(
 fn op_isatty(
   state: &mut OpState,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<bool, AnyError> {
   let isatty: bool = StdFileResource::with(state, rid, move |r| match r {
     Ok(std_file) => {
@@ -255,7 +254,7 @@ struct ConsoleSize {
 fn op_console_size(
   state: &mut OpState,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<ConsoleSize, AnyError> {
   super::check_unstable(state, "Deno.consoleSize");
 

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -449,7 +449,7 @@ pub struct CreateWorkerArgs {
 fn op_create_worker(
   state: &mut OpState,
   args: CreateWorkerArgs,
-  _data: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<WorkerId, AnyError> {
   let specifier = args.specifier.clone();
   let maybe_source_code = if args.has_source_code {
@@ -532,7 +532,7 @@ fn op_create_worker(
 fn op_host_terminate_worker(
   state: &mut OpState,
   id: WorkerId,
-  _data: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<(), AnyError> {
   let worker_thread = state
     .borrow_mut::<WorkersTable>()
@@ -607,7 +607,7 @@ fn try_remove_and_close(state: Rc<RefCell<OpState>>, id: u32) {
 async fn op_host_get_message(
   state: Rc<RefCell<OpState>>,
   id: WorkerId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<Value, AnyError> {
   let worker_handle = {
     let s = state.borrow();

--- a/test_plugin/src/lib.rs
+++ b/test_plugin/src/lib.rs
@@ -80,7 +80,7 @@ impl Resource for TestResource {
 fn op_test_resource_table_add(
   state: &mut OpState,
   text: String,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<u32, AnyError> {
   println!("Hello from resource_table.add plugin op.");
 
@@ -90,7 +90,7 @@ fn op_test_resource_table_add(
 fn op_test_resource_table_get(
   state: &mut OpState,
   rid: ResourceId,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<String, AnyError> {
   println!("Hello from resource_table.get plugin op.");
 


### PR DESCRIPTION
This removes the `ZeroCopyBuf` arg-type and import when they're not needed in ops (which is quite frequent)

Follow up to https://github.com/denoland/deno/pull/10448