### PR TITLE
test: run deno test --watch test only on unix

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1012,6 +1012,7 @@ mod integration {
       temp_directory.close().unwrap();
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_watch() {
       macro_rules! assert_contains {


### PR DESCRIPTION
Disabling `deno test --watch` test on Windows as it is flaky; failures:
- https://github.com/denoland/deno/pull/10481/checks?check_run_id=2543043090
- https://github.com/denoland/deno/runs/2542717077

CC @Liamolucko 