### PR TITLE
ci: create cache always in main, skip saving cache in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,13 +190,36 @@ jobs:
           key:
             a-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
 
-      - name: Cache build output
-        uses: actions/cache@v2
+      # In main branch, always creates fresh cache
+      - name: Cache build output (main)
+        # TODO(kt3k): Change the version to the released version
+        # when https://github.com/actions/cache/pull/489 (or 571) is merged.
+        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        if: github.ref == 'refs/heads/main'
         with:
           path: |
             ./target
-          key:
-            a-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ hashFiles('Cargo.lock') }}
+          key: |
+            a-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}
+
+      # Restores cache from the latest main branch's Cache
+      - name: Cache build output (PR)
+        # TODO(kt3k): Change the version to the released version
+        # when https://github.com/actions/cache/pull/489 (or 571) is merged.
+        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        if: github.ref != 'refs/heads/main'
+        with:
+          path: |
+            ./target
+          key: |
+            dummy # Cache never be created for this key.
+          restore-keys: |
+            a-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ hashFiles('Cargo.lock') }}-
+
+      # Skips saving cache in PR branches
+      - name: Skip save cache (PR)
+        run: echo "CACHE_SKIP_SAVE=true" >> $GITHUB_ENV
+        if: github.ref != 'refs/heads/main'
 
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache


### PR DESCRIPTION
This PR improves the CI cache in the following ways:

- main branch always creates fresh `./target` cache (The cache key has `github.sha` at the end)
- PR branch uses the latest main branch cache.

With this change, main branch always creates fresh cache and PR branches can use the latest one. So the PR branch's build amount should be consistently minimal.

---

Note1: This change prevents the false detection of stale files, which, for example, happened in this run https://github.com/denoland/deno/runs/2462335233 where only one markdown file was changed, but 45 files were considered 'stale' at mtime restore step.

Note2: This PR uses `actions/cache@03e00da99d75a2204924908e1cca7902cafce66b` which is the merge head of https://github.com/actions/cache/pull/489 . cf `git ls-remote https://github.com/actions/cache.git | grep 489/merge`