### PR TITLE
fix(cli): ignore x-typescript-types header when media type is not js/jsx

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -328,8 +328,10 @@ impl FileFetcher {
       map_content_type(specifier, maybe_content_type);
     let source = strip_shebang(get_source_from_bytes(bytes, maybe_charset)?);
     let maybe_types = match media_type {
-      MediaType::JavaScript | MediaType::Jsx => headers.get("x-typescript-types").cloned(),
-      _ => None
+      MediaType::JavaScript | MediaType::Jsx => {
+        headers.get("x-typescript-types").cloned()
+      }
+      _ => None,
     };
 
     Ok(File {
@@ -1609,12 +1611,10 @@ mod tests {
   #[tokio::test]
   async fn test_fetch_remote_jsx_with_types() {
     let specifier =
-      resolve_url_or_path("http://127.0.0.1:4545/xTypeScriptTypes.jsx").unwrap();
+      resolve_url_or_path("http://127.0.0.1:4545/xTypeScriptTypes.jsx")
+        .unwrap();
     let (file, _) = test_fetch_remote(&specifier).await;
-    assert_eq!(
-      file.media_type,
-      MediaType::Jsx,
-    );
+    assert_eq!(file.media_type, MediaType::Jsx,);
     assert_eq!(
       file.maybe_types,
       Some("./xTypeScriptTypes.d.ts".to_string())
@@ -1626,10 +1626,7 @@ mod tests {
     let specifier =
       resolve_url_or_path("http://127.0.0.1:4545/xTypeScriptTypes.ts").unwrap();
     let (file, _) = test_fetch_remote(&specifier).await;
-    assert_eq!(
-      file.maybe_types,
-      None
-    );
+    assert_eq!(file.maybe_types, None);
   }
 
   #[tokio::test]

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -327,7 +327,10 @@ impl FileFetcher {
     let (media_type, maybe_charset) =
       map_content_type(specifier, maybe_content_type);
     let source = strip_shebang(get_source_from_bytes(bytes, maybe_charset)?);
-    let maybe_types = headers.get("x-typescript-types").cloned();
+    let maybe_types = match media_type {
+      MediaType::JavaScript | MediaType::Jsx => headers.get("x-typescript-types").cloned(),
+      _ => None
+    };
 
     Ok(File {
       local,
@@ -1593,13 +1596,39 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn test_fetch_remote_with_types() {
+  async fn test_fetch_remote_javascript_with_types() {
     let specifier =
       resolve_url_or_path("http://127.0.0.1:4545/xTypeScriptTypes.js").unwrap();
     let (file, _) = test_fetch_remote(&specifier).await;
     assert_eq!(
       file.maybe_types,
       Some("./xTypeScriptTypes.d.ts".to_string())
+    );
+  }
+
+  #[tokio::test]
+  async fn test_fetch_remote_jsx_with_types() {
+    let specifier =
+      resolve_url_or_path("http://127.0.0.1:4545/xTypeScriptTypes.jsx").unwrap();
+    let (file, _) = test_fetch_remote(&specifier).await;
+    assert_eq!(
+      file.media_type,
+      MediaType::Jsx,
+    );
+    assert_eq!(
+      file.maybe_types,
+      Some("./xTypeScriptTypes.d.ts".to_string())
+    );
+  }
+
+  #[tokio::test]
+  async fn test_fetch_remote_typescript_with_types() {
+    let specifier =
+      resolve_url_or_path("http://127.0.0.1:4545/xTypeScriptTypes.ts").unwrap();
+    let (file, _) = test_fetch_remote(&specifier).await;
+    assert_eq!(
+      file.maybe_types,
+      None
     );
   }
 

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -497,6 +497,30 @@ async fn main_server(req: Request<Body>) -> hyper::Result<Response<Body>> {
       );
       Ok(res)
     }
+    (_, "/xTypeScriptTypes.jsx") => {
+      let mut res = Response::new(Body::from("export const foo = 'foo';"));
+      res.headers_mut().insert(
+        "Content-type",
+        HeaderValue::from_static("text/jsx"),
+      );
+      res.headers_mut().insert(
+        "X-TypeScript-Types",
+        HeaderValue::from_static("./xTypeScriptTypes.d.ts"),
+      );
+      Ok(res)
+    }
+    (_, "/xTypeScriptTypes.ts") => {
+      let mut res = Response::new(Body::from("export const foo: string = 'foo';"));
+      res.headers_mut().insert(
+        "Content-type",
+        HeaderValue::from_static("application/typescript"),
+      );
+      res.headers_mut().insert(
+        "X-TypeScript-Types",
+        HeaderValue::from_static("./xTypeScriptTypes.d.ts"),
+      );
+      Ok(res)
+    }
     (_, "/xTypeScriptTypes.d.ts") => {
       let mut res = Response::new(Body::from("export const foo: 'foo';"));
       res.headers_mut().insert(

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -499,10 +499,9 @@ async fn main_server(req: Request<Body>) -> hyper::Result<Response<Body>> {
     }
     (_, "/xTypeScriptTypes.jsx") => {
       let mut res = Response::new(Body::from("export const foo = 'foo';"));
-      res.headers_mut().insert(
-        "Content-type",
-        HeaderValue::from_static("text/jsx"),
-      );
+      res
+        .headers_mut()
+        .insert("Content-type", HeaderValue::from_static("text/jsx"));
       res.headers_mut().insert(
         "X-TypeScript-Types",
         HeaderValue::from_static("./xTypeScriptTypes.d.ts"),
@@ -510,7 +509,8 @@ async fn main_server(req: Request<Body>) -> hyper::Result<Response<Body>> {
       Ok(res)
     }
     (_, "/xTypeScriptTypes.ts") => {
-      let mut res = Response::new(Body::from("export const foo: string = 'foo';"));
+      let mut res =
+        Response::new(Body::from("export const foo: string = 'foo';"));
       res.headers_mut().insert(
         "Content-type",
         HeaderValue::from_static("application/typescript"),


### PR DESCRIPTION
This PR changes the behavior of file_fetcher. Now file_fetcher doesn't follow the dts script referenced from `x-typescript-types` header when the script is not javascript or jsx.

Currently deno fetches dts file in x-typescript-types even when the script is typescript (you can check the behavior with this repro url `https://no-cache-script-repro-bf1c801d.deno.dev/foo.ts`), but dts only makes sense for javascript and jsx. So this PR prevents such redundant dts loading.

closes https://github.com/denoland/deno/issues/10279