### PR TITLE
docs: Add Support and Conferences section

### DIFF
--- a/docs/community/conference.md
+++ b/docs/community/conference.md
@@ -3,10 +3,14 @@
 Conferences dedicated to the discussion of Deno and the Deno ecosystem.
 
 - Ryan Dahl. (May 27, 2020).
-  [An interesting case with Deno](https://www.youtube.com/watch?v=1b7FoBwxc7E) - Deno Israel.
+  [An interesting case with Deno](https://www.youtube.com/watch?v=1b7FoBwxc7E) -
+  Deno Israel.
 - Kitson P. Kelly. (Oct 6, 2020).
-  [Deno, and The Future of JavaScript Runtimes](https://www.youtube.com/watch?v=2eRyZpX4qvI) - CityJS Conf 2020.
+  [Deno, and The Future of JavaScript
+  Runtimes](https://www.youtube.com/watch?v=2eRyZpX4qvI) - CityJS Conf 2020.
 - Bartek Iwańczuk. (Oct 6, 2020).
-  [Deno internals - how modern JS/TS runtime is built](https://www.youtube.com/watch?v=AOvg_GbnsbA&t=35m13s) - Paris Deno.
+  [Deno internals - how modern JS/TS runtime is
+  built](https://www.youtube.com/watch?v=AOvg_GbnsbA&t=35m13s) - Paris Deno.
 - Ryan Dahl. (June 6, 2018)
-  [Things I regret about Node.js](https://www.youtube.com/watch?v=M3BM9TB-8yA) - JSConf EU.
+  [Things I regret about Node.js](https://www.youtube.com/watch?v=M3BM9TB-8yA) -
+  JSConf EU.

--- a/docs/community/conference.md
+++ b/docs/community/conference.md
@@ -1,0 +1,12 @@
+# Conference
+
+Conferences dedicated to the discussion of Deno and the Deno ecosystem.
+
+- Ryan Dahl. (May 27, 2020).
+  [An interesting case with Deno](https://www.youtube.com/watch?v=1b7FoBwxc7E) - Deno Israel.
+- Kitson P. Kelly. (Oct 6, 2020).
+  [Deno, and The Future of JavaScript Runtimes](https://www.youtube.com/watch?v=2eRyZpX4qvI) - CityJS Conf 2020.
+- Bartek Iwańczuk. (Oct 6, 2020).
+  [Deno internals - how modern JS/TS runtime is built](https://www.youtube.com/watch?v=AOvg_GbnsbA&t=35m13s) - Paris Deno.
+- Ryan Dahl. (June 6, 2018)
+  [Things I regret about Node.js](https://www.youtube.com/watch?v=M3BM9TB-8yA) - JSConf EU.

--- a/docs/community/support.md
+++ b/docs/community/support.md
@@ -1,0 +1,18 @@
+# Where To Get Help
+
+Stuck? Lost? Get Help from the Community.
+
+### [Stack Overflow](https://stackoverflow.com/questions/tagged/deno)
+
+Stack Overflow is a popular forum to ask code-level questions or if you’re stuck
+with a specific error.
+[ask your own!](https://stackoverflow.com/questions/ask?tags=deno)
+
+### [Community Discord](https://discord.gg/deno)
+
+Ask questions and chat with community members in real-time.
+
+### [DEV's Deno Community](https://dev.to/t/deno)
+
+A great place to find interesting articles about best practices, application
+architecture and new learnings. Post your articles with the tag `deno`.

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -53,5 +53,3 @@ Metrics is Deno's internal counter for various statistics.
 ### Schematic diagram
 
 ![architectural schematic](https://deno.land/images/schematic_v0.2.png)
-
-

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -54,11 +54,4 @@ Metrics is Deno's internal counter for various statistics.
 
 ![architectural schematic](https://deno.land/images/schematic_v0.2.png)
 
-### Conference
 
-- Ryan Dahl. (May 27, 2020).
-  [An interesting case with Deno](https://www.youtube.com/watch?v=1b7FoBwxc7E).
-  Deno Israel.
-- Bartek Iwańczuk. (Oct 6, 2020).
-  [Deno internals - how modern JS/TS runtime is
-  built](https://www.youtube.com/watch?v=AOvg_GbnsbA&t=35m13s). Paris Deno.

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -90,8 +90,12 @@
   "embedding_deno": {
     "name": "Embedding Deno"
   },
-  "help": {
-    "name": "Help"
+  "community": {
+    "name": "Community",
+    "children": {
+      "support": "support",
+      "conference": "conference"
+    }
   },
   "contributing": {
     "name": "Contributing",


### PR DESCRIPTION
- Add Conferences dedicated to the discussion of Deno and the Deno ecosystem.
- Move `Help` to `Community/support`.