### PR TITLE
ci: disable ./target/ cache temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,42 +190,6 @@ jobs:
           key:
             a-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
 
-      # In main branch, always creates fresh cache
-      - name: Cache build output (main)
-        # TODO(kt3k): Change the version to the released version
-        # when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
-        if: github.ref == 'refs/heads/main'
-        with:
-          path: |
-            ./target
-          key: |
-            a-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}
-
-      # Restores cache from the latest main branch's Cache
-      - name: Cache build output (PR)
-        # TODO(kt3k): Change the version to the released version
-        # when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
-        if: github.ref != 'refs/heads/main'
-        with:
-          path: |
-            ./target
-          key: |
-            dummy # Cache never be created for this key.
-          restore-keys: |
-            a-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ hashFiles('Cargo.lock') }}-
-
-      # Skips saving cache in PR branches
-      - name: Skip save cache (PR)
-        run: echo "CACHE_SKIP_SAVE=true" >> $GITHUB_ENV
-        if: github.ref != 'refs/heads/main'
-
-      - name: Apply and update mtime cache
-        uses: ./.github/mtime_cache
-        with:
-          cache-path: ./target
-
       - name: test_format.js
         if: matrix.kind == 'lint'
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check
@@ -396,12 +360,3 @@ jobs:
             target/release/deno_src.tar.gz
             target/release/lib.deno.d.ts
           draft: true
-
-      - name: Clean before cache
-        shell: bash
-        run: |
-          rm -f target/*/deno target/*/test_server
-          rm -rf target/*/examples/
-          rm -rf target/*/gn_out/
-          rm -rf target/*/*.zip
-


### PR DESCRIPTION
Rust team (temporarily) disabled the entire incremental build feature at 1.52.1 (ref: https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html ). So after #10583, incremental build doesn't work and `target/` cache is waste of CI time. This PR disable it and saves 1~2 minutes of CI time.

Note: This change should be reverted when the above issue is fixed in upstream.

Please merge on approval.