### PR TITLE
fix(#10603): revert minimal changes to resolve deadlock bug

### DIFF
--- a/cli/bench/lsp.rs
+++ b/cli/bench/lsp.rs
@@ -184,6 +184,7 @@ impl LspClient {
     }
   }
 
+  #[allow(unused)]
   fn read_request<R>(&mut self) -> Result<(u64, String, Option<R>), AnyError>
   where
     R: de::DeserializeOwned,
@@ -238,6 +239,7 @@ impl LspClient {
     }
   }
 
+  #[allow(unused)]
   fn write_response<V>(&mut self, id: u64, result: V) -> Result<(), AnyError>
   where
     V: Serialize,
@@ -294,15 +296,16 @@ fn bench_big_file_edits(deno_exe: &Path) -> Result<Duration, AnyError> {
     }),
   )?;
 
-  let (id, method, _): (u64, String, Option<Value>) = client.read_request()?;
-  assert_eq!(method, "workspace/configuration");
+  // TODO(@kitsonk) work around https://github.com/denoland/deno/issues/10603
+  // let (id, method, _): (u64, String, Option<Value>) = client.read_request()?;
+  // assert_eq!(method, "workspace/configuration");
 
-  client.write_response(
-    id,
-    json!({
-      "enable": true
-    }),
-  )?;
+  // client.write_response(
+  //   id,
+  //   json!({
+  //     "enable": true
+  //   }),
+  // )?;
 
   let (method, _): (String, Option<Value>) = client.read_notification()?;
   assert_eq!(method, "textDocument/publishDiagnostics");
@@ -366,15 +369,16 @@ fn bench_startup_shutdown(deno_exe: &Path) -> Result<Duration, AnyError> {
     }),
   )?;
 
-  let (id, method, _): (u64, String, Option<Value>) = client.read_request()?;
-  assert_eq!(method, "workspace/configuration");
+  // TODO(@kitsonk) work around https://github.com/denoland/deno/issues/10603
+  // let (id, method, _): (u64, String, Option<Value>) = client.read_request()?;
+  // assert_eq!(method, "workspace/configuration");
 
-  client.write_response(
-    id,
-    json!({
-      "enable": true
-    }),
-  )?;
+  // client.write_response(
+  //   id,
+  //   json!({
+  //     "enable": true
+  //   }),
+  // )?;
 
   let (method, _): (String, Option<Value>) = client.read_notification()?;
   assert_eq!(method, "textDocument/publishDiagnostics");

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -148,6 +148,7 @@ pub struct Config {
 }
 
 impl Config {
+  #[allow(unused)]
   pub fn contains(&self, specifier: &ModuleSpecifier) -> bool {
     self.specifier_settings.contains_key(specifier)
   }

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -594,25 +594,26 @@ impl Inner {
     let specifier = self.url_map.normalize_url(&params.text_document.uri);
 
     // we only query the individual resource file if the client supports it
-    if self.config.client_capabilities.workspace_configuration
-      && !self.config.contains(&specifier)
-    {
-      if let Ok(value) = self
-        .client
-        .configuration(vec![ConfigurationItem {
-          scope_uri: Some(params.text_document.uri.clone()),
-          section: Some(SETTINGS_SECTION.to_string()),
-        }])
-        .await
-      {
-        if let Err(err) = self
-          .config
-          .update_specifier(specifier.clone(), value[0].clone())
-        {
-          warn!("Error updating specifier configuration: {}", err);
-        }
-      }
-    }
+    // TODO(@kitsonk) workaround https://github.com/denoland/deno/issues/10603
+    // if self.config.client_capabilities.workspace_configuration
+    //   && !self.config.contains(&specifier)
+    // {
+    //   if let Ok(value) = self
+    //     .client
+    //     .configuration(vec![ConfigurationItem {
+    //       scope_uri: Some(params.text_document.uri.clone()),
+    //       section: Some(SETTINGS_SECTION.to_string()),
+    //     }])
+    //     .await
+    //   {
+    //     if let Err(err) = self
+    //       .config
+    //       .update_specifier(specifier.clone(), value[0].clone())
+    //     {
+    //       warn!("Error updating specifier configuration: {}", err);
+    //     }
+    //   }
+    // }
 
     if params.text_document.uri.scheme() == "deno" {
       // we can ignore virtual text documents opening, as they don't need to


### PR DESCRIPTION
This disables the workspace folder configuration functionality to work-around the deadlock issue introduced in #10488.