### PR TITLE
WIP: fix http resource leak when underlying listener is closed

### DIFF
--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -272,3 +272,23 @@ unitTest(
     await promise;
   },
 );
+
+unitTest(
+  { perms: { net: true } },
+  async function httpServerRegressionResourceLeak() {
+    const promise = (async () => {
+      const listener = Deno.listen({ port: 4501 });
+      const conn = await listener.accept();
+      const httpConn = Deno.serveHttp(conn);
+      const event = await httpConn.nextRequest();
+      assert(event);
+      await event.respondWith(new Response("response"));
+      listener.close();
+    })();
+
+    // We don't need additional assertions as the resource
+    // leaks are reported by the test runner.
+    const _resp = await fetch("http://127.0.0.1:4501/");
+    await promise;
+  },
+);


### PR DESCRIPTION
I added a failing test case to demonstrate the bug. I'm not yet sure about how to cancel the ConnResource when the underlying listener is closed.

You can run the test with:
```
target/debug/deno test --allow-all --unstable cli/tests/unit/http_test.ts
```
Possibly fixes https://github.com/denoland/deno/issues/10508
