### PR TITLE
fix(lsp): re-enable the per resource configuration without a deadlock

### DIFF
--- a/cli/bench/lsp.rs
+++ b/cli/bench/lsp.rs
@@ -144,7 +144,7 @@ fn bench_startup_shutdown(deno_exe: &Path) -> Result<Duration, AnyError> {
     }),
   )?;
 
-  let (id, method, _): (u64, String, Option<Value>) = client.read_request()?;
+  let (id, method, _) = client.read_request::<Value>()?;
   assert_eq!(method, "workspace/configuration");
 
   client.write_response(

--- a/cli/bench/lsp.rs
+++ b/cli/bench/lsp.rs
@@ -5,6 +5,8 @@ use deno_core::serde::Deserialize;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::url::Url;
+use lspower::lsp;
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
@@ -121,13 +123,108 @@ fn bench_big_file_edits(deno_exe: &Path) -> Result<Duration, AnyError> {
   Ok(client.duration())
 }
 
+fn bench_find_replace(deno_exe: &Path) -> Result<Duration, AnyError> {
+  let mut client = LspClient::new(deno_exe)?;
+
+  let params: Value = serde_json::from_slice(FIXTURE_INIT_JSON)?;
+  let (_, maybe_err) =
+    client.write_request::<_, _, Value>("initialize", params)?;
+  assert!(maybe_err.is_none());
+  client.write_notification("initialized", json!({}))?;
+
+  for i in 0..10 {
+    client.write_notification(
+      "textDocument/didOpen",
+      json!({
+        "textDocument": {
+          "uri": format!("file:///a/file_{}.ts", i),
+          "languageId": "typescript",
+          "version": 1,
+          "text": "console.log(\"000\");\n"
+        }
+      }),
+    )?;
+  }
+
+  for _ in 0..10 {
+    let (id, method, _) = client.read_request::<Value>()?;
+    assert_eq!(method, "workspace/configuration");
+    client.write_response(id, json!({ "enable": true }))?;
+  }
+
+  for _ in 0..3 {
+    let (method, _): (String, Option<Value>) = client.read_notification()?;
+    assert_eq!(method, "textDocument/publishDiagnostics");
+  }
+
+  for i in 0..10 {
+    let file_name = format!("file:///a/file_{}.ts", i);
+    client.write_notification(
+      "textDocument/didChange",
+      lsp::DidChangeTextDocumentParams {
+        text_document: lsp::VersionedTextDocumentIdentifier {
+          uri: Url::parse(&file_name).unwrap(),
+          version: 2,
+        },
+        content_changes: vec![lsp::TextDocumentContentChangeEvent {
+          range: Some(lsp::Range {
+            start: lsp::Position {
+              line: 0,
+              character: 13,
+            },
+            end: lsp::Position {
+              line: 0,
+              character: 16,
+            },
+          }),
+          range_length: None,
+          text: "111".to_string(),
+        }],
+      },
+    )?;
+  }
+
+  for i in 0..10 {
+    let file_name = format!("file:///a/file_{}.ts", i);
+    let (maybe_res, maybe_err) = client.write_request::<_, _, Value>(
+      "textDocument/formatting",
+      lsp::DocumentFormattingParams {
+        text_document: lsp::TextDocumentIdentifier {
+          uri: Url::parse(&file_name).unwrap(),
+        },
+        options: lsp::FormattingOptions {
+          tab_size: 2,
+          insert_spaces: true,
+          ..Default::default()
+        },
+        work_done_progress_params: Default::default(),
+      },
+    )?;
+    assert!(maybe_err.is_none());
+    assert!(maybe_res.is_some());
+  }
+
+  for _ in 0..3 {
+    let (method, _): (String, Option<Value>) = client.read_notification()?;
+    assert_eq!(method, "textDocument/publishDiagnostics");
+  }
+
+  let (_, response_error): (Option<Value>, Option<LspResponseError>) =
+    client.write_request("shutdown", json!(null))?;
+  assert!(response_error.is_none());
+
+  client.write_notification("exit", json!(null))?;
+
+  Ok(client.duration())
+}
+
 /// A test that starts up the LSP, opens a single line document, and exits.
 fn bench_startup_shutdown(deno_exe: &Path) -> Result<Duration, AnyError> {
   let mut client = LspClient::new(deno_exe)?;
 
   let params: Value = serde_json::from_slice(FIXTURE_INIT_JSON)?;
-  let (_, response_error): (Option<Value>, Option<LspResponseError>) =
-    client.write_request("initialize", params)?;
+  let (_, response_error) =
+    client.write_request::<_, _, Value>("initialize", params)?;
   assert!(response_error.is_none());
 
   client.write_notification("initialized", json!({}))?;
@@ -196,6 +293,16 @@ pub(crate) fn benchmarks(
     (times.iter().sum::<Duration>() / times.len() as u32).as_millis() as u64;
   println!("      ({} runs, mean: {}ms)", times.len(), mean);
   exec_times.insert("big_file_edits".to_string(), mean);
+
+  println!("   - Find/Replace");
+  let mut times = Vec::new();
+  for _ in 0..10 {
+    times.push(bench_find_replace(deno_exe)?);
+  }
+  let mean =
+    (times.iter().sum::<Duration>() / times.len() as u32).as_millis() as u64;
+  println!("      ({} runs, mean: {}ms)", times.len(), mean);
+  exec_times.insert("find_replace".to_string(), mean);
 
   println!("<- End benchmarking lsp");
 

--- a/cli/bench/lsp.rs
+++ b/cli/bench/lsp.rs
@@ -62,16 +62,15 @@ fn bench_big_file_edits(deno_exe: &Path) -> Result<Duration, AnyError> {
     }),
   )?;
 
-  // TODO(@kitsonk) work around https://github.com/denoland/deno/issues/10603
-  // let (id, method, _): (u64, String, Option<Value>) = client.read_request()?;
-  // assert_eq!(method, "workspace/configuration");
+  let (id, method, _): (u64, String, Option<Value>) = client.read_request()?;
+  assert_eq!(method, "workspace/configuration");
 
-  // client.write_response(
-  //   id,
-  //   json!({
-  //     "enable": true
-  //   }),
-  // )?;
+  client.write_response(
+    id,
+    json!({
+      "enable": true
+    }),
+  )?;
 
   let (method, _): (String, Option<Value>) = client.read_notification()?;
   assert_eq!(method, "textDocument/publishDiagnostics");
@@ -145,16 +144,15 @@ fn bench_startup_shutdown(deno_exe: &Path) -> Result<Duration, AnyError> {
     }),
   )?;
 
-  // TODO(@kitsonk) work around https://github.com/denoland/deno/issues/10603
-  // let (id, method, _): (u64, String, Option<Value>) = client.read_request()?;
-  // assert_eq!(method, "workspace/configuration");
+  let (id, method, _): (u64, String, Option<Value>) = client.read_request()?;
+  assert_eq!(method, "workspace/configuration");
 
-  // client.write_response(
-  //   id,
-  //   json!({
-  //     "enable": true
-  //   }),
-  // )?;
+  client.write_response(
+    id,
+    json!({
+      "enable": true
+    }),
+  )?;
 
   let (method, _): (String, Option<Value>) = client.read_notification()?;
   assert_eq!(method, "textDocument/publishDiagnostics");

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -170,7 +170,7 @@ impl DiagnosticsServer {
               dirty = false;
               debounce_timer.as_mut().reset(Instant::now() + NEVER);
 
-              let snapshot = language_server.lock().await.snapshot();
+              let snapshot = language_server.lock().await.snapshot().unwrap();
               update_diagnostics(
                 &client,
                 collection.clone(),

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -314,7 +314,7 @@ async fn generate_lint_diagnostics(
   collection: Arc<Mutex<DiagnosticCollection>>,
 ) -> Result<DiagnosticVec, AnyError> {
   let documents = snapshot.documents.clone();
-  let workspace_settings = snapshot.config.workspace_settings.clone();
+  let workspace_settings = snapshot.config.settings.workspace.clone();
   tokio::task::spawn(async move {
     let mut diagnostics_vec = Vec::new();
     if workspace_settings.lint {
@@ -487,7 +487,7 @@ async fn publish_diagnostics(
   if let Some(changes) = collection.take_changes() {
     for specifier in changes {
       let mut diagnostics: Vec<lsp::Diagnostic> =
-        if snapshot.config.workspace_settings.lint {
+        if snapshot.config.settings.workspace.lint {
           collection
             .get(&specifier, DiagnosticSource::DenoLint)
             .cloned()

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -416,7 +416,7 @@ impl Inner {
         });
         tsconfig.merge(&unstable_libs);
       }
-      (workspace_settings.config.clone(), config.root_uri.clone())
+      (workspace_settings.config, config.root_uri.clone())
     };
     if let Some(config_str) = &maybe_config {
       info!("Updating TypeScript configuration from: \"{}\"", config_str);

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -601,10 +601,10 @@ impl Inner {
     let mark = self.performance.mark("did_open", Some(&params));
     let specifier = self.url_map.normalize_url(&params.text_document.uri);
 
-    info!("did_open {} {}", specifier, params.text_document.uri);
     self
       .config
-      .update_specifier_settings(&specifier, &params.text_document.uri);
+      .update_specifier_settings(&specifier, &params.text_document.uri)
+      .await;
 
     if params.text_document.uri.scheme() == "deno" {
       // we can ignore virtual text documents opening, as they don't need to
@@ -671,7 +671,7 @@ impl Inner {
       .mark("did_change_configuration", Some(&params));
 
     if self.config.client_capabilities.workspace_configuration {
-      self.config.update_workspace_settings();
+      self.config.update_workspace_settings().await;
     } else if let Some(config) = params
       .settings
       .as_object()

--- a/cli/tests/integration_tests_lsp.rs
+++ b/cli/tests/integration_tests_lsp.rs
@@ -38,6 +38,13 @@ where
   client
     .write_notification("textDocument/didOpen", params)
     .unwrap();
+
+  let (id, method, _) = client.read_request::<Value>().unwrap();
+  assert_eq!(method, "workspace/configuration");
+  client
+    .write_response(id, json!({ "enable": true }))
+    .unwrap();
+
   let (method, _) = client.read_notification::<Value>().unwrap();
   assert_eq!(method, "textDocument/publishDiagnostics");
   let (method, _) = client.read_notification::<Value>().unwrap();
@@ -209,6 +216,13 @@ fn lsp_hover_disabled() {
       }),
     )
     .unwrap();
+
+  let (id, method, _) = client.read_request::<Value>().unwrap();
+  assert_eq!(method, "workspace/configuration");
+  client
+    .write_response(id, json!({ "enable": false }))
+    .unwrap();
+
   let (maybe_res, maybe_err) = client
     .write_request(
       "textDocument/hover",
@@ -453,6 +467,12 @@ fn lsp_hover_closed_document() {
       }),
     )
     .unwrap();
+  let (id, method, _) = client.read_request::<Value>().unwrap();
+  assert_eq!(method, "workspace/configuration");
+  client
+    .write_response(id, json!({ "enable": true }))
+    .unwrap();
+
   client
     .write_notification(
       "textDocument/didOpen",
@@ -466,6 +486,12 @@ fn lsp_hover_closed_document() {
       }),
     )
     .unwrap();
+  let (id, method, _) = client.read_request::<Value>().unwrap();
+  assert_eq!(method, "workspace/configuration");
+  client
+    .write_response(id, json!({ "enable": true }))
+    .unwrap();
+
   let (method, _) = client.read_notification::<Value>().unwrap();
   assert_eq!(method, "textDocument/publishDiagnostics");
   let (method, _) = client.read_notification::<Value>().unwrap();

--- a/cli/tests/lsp/initialize_params.json
+++ b/cli/tests/lsp/initialize_params.json
@@ -51,6 +51,10 @@
         "willSaveWaitUntil": true,
         "didSave": true
       }
+    },
+    "workspace": {
+      "configuration": true,
+      "workspaceFolders": true
     }
   }
 }

--- a/cli/tests/lsp/initialize_params_disabled.json
+++ b/cli/tests/lsp/initialize_params_disabled.json
@@ -51,6 +51,10 @@
         "willSaveWaitUntil": true,
         "didSave": true
       }
+    },
+    "workspace": {
+      "configuration": true,
+      "workspaceFolders": true
     }
   }
 }

--- a/cli/tests/lsp/initialize_params_registry.json
+++ b/cli/tests/lsp/initialize_params_registry.json
@@ -53,6 +53,10 @@
         "willSaveWaitUntil": true,
         "didSave": true
       }
+    },
+    "workspace": {
+      "configuration": true,
+      "workspaceFolders": true
     }
   }
 }

--- a/cli/tests/lsp/initialize_params_unstable.json
+++ b/cli/tests/lsp/initialize_params_unstable.json
@@ -51,6 +51,10 @@
         "willSaveWaitUntil": true,
         "didSave": true
       }
+    },
+    "workspace": {
+      "configuration": true,
+      "workspaceFolders": true
     }
   }
 }


### PR DESCRIPTION
This PR rewrites the way per resource configuration is handled in the language server.

There isn't specifically a test that tests for this deadlock yet, as I need to refactor the language server integration tests to a new structure that supports 2 way communication, which we have in the benchmark harness, but need to share with the integration tests.