### PR TITLE
chore: upgrade Tokio to 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3557,9 +3557,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
 dependencies = [
  "autocfg",
  "bytes",

--- a/bench_util/Cargo.toml
+++ b/bench_util/Cargo.toml
@@ -15,4 +15,4 @@ publish = false
 [dependencies]
 bencher = "0.1"
 deno_core = { version = "0.87.0", path = "../core" }
-tokio = { version = "1.4.0", features = ["full"] }
+tokio = { version = "1.6.0", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -73,7 +73,7 @@ swc_ecmascript = { version = "0.33.0", features = ["codegen", "dep_graph", "pars
 tempfile = "3.2.0"
 termcolor = "1.1.2"
 text-size = "1.1.0"
-tokio = { version = "1.4.0", features = ["full"] }
+tokio = { version = "1.6.0", features = ["full"] }
 tokio-rustls = "0.22.0"
 uuid = { version = "0.8.2", features = ["v4", "serde"] }
 walkdir = "2.3.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,7 +33,7 @@ path = "examples/http_bench_json_ops.rs"
 
 # These dependencies are only used for the 'http_bench_*_ops' examples.
 [dev-dependencies]
-tokio = { version = "1.4.0", features = ["full"] }
+tokio = { version = "1.6.0", features = ["full"] }
 bencher = "0.1"
 
 [[bench]]

--- a/extensions/fetch/Cargo.toml
+++ b/extensions/fetch/Cargo.toml
@@ -21,6 +21,6 @@ deno_file = { version = "0.5.0", path = "../file" }
 http = "0.2.3"
 reqwest = { version = "0.11.2", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli"] }
 serde = { version = "1.0.125", features = ["derive"] }
-tokio = { version = "1.4.0", features = ["full"] }
+tokio = { version = "1.6.0", features = ["full"] }
 tokio-stream = "0.1.5"
 tokio-util = "0.6.5"

--- a/extensions/timers/Cargo.toml
+++ b/extensions/timers/Cargo.toml
@@ -15,4 +15,4 @@ path = "lib.rs"
 
 [dependencies]
 deno_core = { version = "0.87.0", path = "../../core" }
-tokio = { version = "1.4.0", features = ["full"] }
+tokio = { version = "1.6.0", features = ["full"] }

--- a/extensions/webgpu/Cargo.toml
+++ b/extensions/webgpu/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 deno_core = { version = "0.87.0", path = "../../core" }
-tokio = { version = "1.4.0", features = ["full"] }
+tokio = { version = "1.6.0", features = ["full"] }
 serde = { version = "1.0.125", features = ["derive"] }
 wgpu-core = { version = "0.8.0", features = ["trace"] }
 wgpu-types = "0.8.0"

--- a/extensions/websocket/Cargo.toml
+++ b/extensions/websocket/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 deno_core = { version = "0.87.0", path = "../../core" }
 http = "0.2.3"
 serde = { version = "1.0.125", features = ["derive"] }
-tokio = { version = "1.4.0", features = ["full"] }
+tokio = { version = "1.6.0", features = ["full"] }
 tokio-rustls = "0.22.0"
 tokio-tungstenite = { version = "0.14.0", features = ["rustls-tls"] }
 webpki = "0.21.4"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -68,7 +68,7 @@ rustls = "0.19.0"
 serde = { version = "1.0.125", features = ["derive"] }
 sys-info = "0.9.0"
 termcolor = "1.1.2"
-tokio = { version = "1.4.0", features = ["full"] }
+tokio = { version = "1.6.0", features = ["full"] }
 tokio-util = { version = "0.6", features = ["io"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 webpki = "0.21.4"

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -21,7 +21,7 @@ os_pipe = "0.9.2"
 regex = "1.4.3"
 serde = { version = "1.0.125", features = ["derive"] }
 tempfile = "3.2.0"
-tokio = { version = "1.4.0", features = ["full"] }
+tokio = { version = "1.6.0", features = ["full"] }
 tokio-rustls = "0.22.0"
 tokio-tungstenite = "0.14.0"
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Tokio 1.6.0 was released with various improvements, so upgrades it from 1.4.0 to 1.6.0.

release notes:
- [1.5.0](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.5.0)
- [1.6.0](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.6.0)
