### PR TITLE
cleanup(core): flatten print's op args

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -129,7 +129,7 @@
   }
 
   function print(str, isErr = false) {
-    opSync("op_print", [str, isErr]);
+    opSync("op_print", str, isErr);
   }
 
   // Provide bootstrap namespace

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -57,10 +57,9 @@ pub fn op_close(
 /// Builtin utility to print to stdout/stderr
 pub fn op_print(
   _state: &mut OpState,
-  args: (String, bool),
-  _: (),
+  msg: String,
+  is_err: bool,
 ) -> Result<(), AnyError> {
-  let (msg, is_err) = args;
   if is_err {
     eprint!("{}", msg);
     stderr().flush().unwrap();


### PR DESCRIPTION
Following #10448, flattening op args when possible is a best practice (since opcalls should conceptually be thought of as plain function calls)