### PR TITLE
Revert "feat(runtime): support URL overloads for `Deno.realPath` and `Deno.realPathSync`"

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1467,7 +1467,7 @@ declare namespace Deno {
    * Requires `allow-read` permission for the target path.
    * Also requires `allow-read` permission for the CWD if the target path is
    * relative.*/
-  export function realPathSync(path: string | URL): string;
+  export function realPathSync(path: string): string;
 
   /** Resolves to the absolute normalized path, with symbolic links resolved.
    *
@@ -1483,7 +1483,7 @@ declare namespace Deno {
    * Requires `allow-read` permission for the target path.
    * Also requires `allow-read` permission for the CWD if the target path is
    * relative.*/
-  export function realPath(path: string | URL): Promise<string>;
+  export function realPath(path: string): Promise<string>;
 
   export interface DirEntry {
     name: string;

--- a/cli/tests/unit/real_path_test.ts
+++ b/cli/tests/unit/real_path_test.ts
@@ -1,11 +1,9 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
   assert,
-  assertEquals,
   assertMatch,
   assertThrows,
   assertThrowsAsync,
-  pathToAbsoluteFileUrl,
   unitTest,
 } from "./test_util.ts";
 
@@ -19,12 +17,6 @@ unitTest({ perms: { read: true } }, function realPathSyncSuccess(): void {
     assertMatch(realPath, /^[A-Z]:\\/);
     assert(realPath.endsWith(relative.replace(/\//g, "\\")));
   }
-});
-
-unitTest({ perms: { read: true } }, function realPathSyncUrl(): void {
-  const relative = "cli/tests/fixture.json";
-  const url = pathToAbsoluteFileUrl(relative);
-  assertEquals(Deno.realPathSync(relative), Deno.realPathSync(url));
 });
 
 unitTest(
@@ -73,15 +65,6 @@ unitTest({ perms: { read: true } }, async function realPathSuccess(): Promise<
     assert(realPath.endsWith(relativePath.replace(/\//g, "\\")));
   }
 });
-
-unitTest(
-  { perms: { read: true } },
-  async function realPathUrl(): Promise<void> {
-    const relative = "cli/tests/fixture.json";
-    const url = pathToAbsoluteFileUrl(relative);
-    assertEquals(await Deno.realPath(relative), await Deno.realPath(url));
-  },
-);
 
 unitTest(
   {

--- a/runtime/js/30_fs.js
+++ b/runtime/js/30_fs.js
@@ -128,11 +128,11 @@
   }
 
   function realPathSync(path) {
-    return core.opSync("op_realpath_sync", pathFromURL(path));
+    return core.opSync("op_realpath_sync", path);
   }
 
   function realPath(path) {
-    return core.opAsync("op_realpath_async", pathFromURL(path));
+    return core.opAsync("op_realpath_async", path);
   }
 
   function removeSync(


### PR DESCRIPTION
Reverts denoland/deno#10626

Merge window for 1.11 is not open yet and this is a feature.