### PR TITLE
ci: fix 'Skip save cache' step in windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,7 @@ jobs:
       # Skips saving cache in PR branches
       - name: Skip save cache (PR)
         run: echo "CACHE_SKIP_SAVE=true" >> $GITHUB_ENV
+        shell: bash
         if: github.ref != 'refs/heads/main'
 
       - name: Apply and update mtime cache


### PR DESCRIPTION
In #10560, `shell` property wasn't set in `Skip save cache (PR)` step. So it's run in powershell in windows and `$GITHUB_ENV` part doesn't work, and therefore `Post Cache build output (PR)` step is not skipped in window. ex. https://github.com/denoland/deno/pull/10703/checks?check_run_id=2618387702

This PR fixes it by specifying `shell: bash`.

`Post Cache build output (PR)` step usually takes 4+ mins. So this fix should reduces typical windows CI time 4 mins.