### PR TITLE
fix(test): ensure coverage dir exists

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -925,6 +925,7 @@ async fn test_command(
   concurrent_jobs: usize,
 ) -> Result<(), AnyError> {
   if let Some(ref coverage_dir) = flags.coverage_dir {
+    std::fs::create_dir_all(&coverage_dir)?;
     env::set_var(
       "DENO_UNSTABLE_COVERAGE_DIR",
       PathBuf::from(coverage_dir).canonicalize()?,

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -4427,12 +4427,13 @@ console.log("finish");
     #[test]
     fn branch() {
       let tempdir = TempDir::new().expect("tempdir fail");
+      let tempdir = tempdir.path().join("cov");
       let status = util::deno_cmd()
         .current_dir(util::root_path())
         .arg("test")
         .arg("--quiet")
         .arg("--unstable")
-        .arg(format!("--coverage={}", tempdir.path().to_str().unwrap()))
+        .arg(format!("--coverage={}", tempdir.to_str().unwrap()))
         .arg("cli/tests/coverage/branch_test.ts")
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::inherit())
@@ -4446,7 +4447,7 @@ console.log("finish");
         .arg("coverage")
         .arg("--quiet")
         .arg("--unstable")
-        .arg(format!("{}/", tempdir.path().to_str().unwrap()))
+        .arg(format!("{}/", tempdir.to_str().unwrap()))
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::inherit())
         .output()
@@ -4475,7 +4476,7 @@ console.log("finish");
         .arg("--quiet")
         .arg("--unstable")
         .arg("--lcov")
-        .arg(format!("{}/", tempdir.path().to_str().unwrap()))
+        .arg(format!("{}/", tempdir.to_str().unwrap()))
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::inherit())
         .output()


### PR DESCRIPTION
closes #10716 

This PR ensures the coverage dir exists when --coverage options is specified, and fixes panic of `deno test --coverage=<div>` when `<div>` doesn't exist.

Note: `PathBuf::from(coverage_dir).canonicalize()` returns error when the path doesn't exist.
