### PR TITLE
fix(bench_util): correctly run async benches in tokio context

### DIFF
--- a/bench_util/src/js_runtime.rs
+++ b/bench_util/src/js_runtime.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 use bencher::Bencher;
-use deno_core::futures::future::poll_fn;
 use deno_core::v8;
 use deno_core::JsRuntime;
 
@@ -76,5 +75,5 @@ pub fn bench_js_async(
 
 async fn inner_async(src: &str, runtime: &mut JsRuntime) {
   runtime.execute("inner_loop", src).unwrap();
-  poll_fn(|cx| runtime.poll_event_loop(cx)).await.unwrap();
+  runtime.run_event_loop().await.unwrap();
 }


### PR DESCRIPTION
Running code in `bench_js_async` with ops that called into `tokio` would previously fail with:
```
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```