### PR TITLE
cleanup(bench_util): use Extensions for setup

### DIFF
--- a/bench_util/benches/op_baseline.rs
+++ b/bench_util/benches/op_baseline.rs
@@ -14,17 +14,16 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 fn setup() -> Vec<Extension> {
-  vec![
-    Extension::builder()
+  vec![Extension::builder()
     .ops(vec![
       ("pi_json", op_sync(|_, _: (), _: ()| Ok(314159))),
       ("pi_async", op_async(op_pi_async)),
-      ("nop", Box::new(|state, _| {
-        Op::Sync(serialize_op_result(Ok(9), state))
-      })),
+      (
+        "nop",
+        Box::new(|state, _| Op::Sync(serialize_op_result(Ok(9), state))),
+      ),
     ])
-    .build()
-  ]
+    .build()]
 }
 
 // this is a function since async closures aren't stable

--- a/bench_util/benches/op_baseline.rs
+++ b/bench_util/benches/op_baseline.rs
@@ -6,20 +6,25 @@ use deno_core::error::AnyError;
 use deno_core::op_async;
 use deno_core::op_sync;
 use deno_core::serialize_op_result;
-use deno_core::JsRuntime;
+use deno_core::Extension;
 use deno_core::Op;
 use deno_core::OpState;
 
 use std::cell::RefCell;
 use std::rc::Rc;
 
-fn setup(runtime: &mut JsRuntime) {
-  runtime.register_op("pi_json", op_sync(|_, _: (), _: ()| Ok(314159)));
-  runtime.register_op("pi_async", op_async(op_pi_async));
-  runtime.register_op("nop", |state, _| {
-    Op::Sync(serialize_op_result(Ok(9), state))
-  });
-  runtime.sync_ops_cache();
+fn setup() -> Vec<Extension> {
+  vec![
+    Extension::builder()
+    .ops(vec![
+      ("pi_json", op_sync(|_, _: (), _: ()| Ok(314159))),
+      ("pi_async", op_async(op_pi_async)),
+      ("nop", Box::new(|state, _| {
+        Op::Sync(serialize_op_result(Ok(9), state))
+      })),
+    ])
+    .build()
+  ]
 }
 
 // this is a function since async closures aren't stable

--- a/bench_util/src/js_runtime.rs
+++ b/bench_util/src/js_runtime.rs
@@ -1,14 +1,14 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 use bencher::Bencher;
 use deno_core::v8;
+use deno_core::Extension;
 use deno_core::JsRuntime;
 use deno_core::RuntimeOptions;
-use deno_core::Extension;
 
 use crate::profiling::is_profiling;
 
 pub fn create_js_runtime(setup: impl FnOnce() -> Vec<Extension>) -> JsRuntime {
-  JsRuntime::new(RuntimeOptions{
+  JsRuntime::new(RuntimeOptions {
     extensions: setup(),
     ..Default::default()
   })

--- a/extensions/url/benches/url_ops.rs
+++ b/extensions/url/benches/url_ops.rs
@@ -7,10 +7,12 @@ use deno_core::Extension;
 fn setup() -> Vec<Extension> {
   vec![
     deno_url::init(),
-    Extension::builder().js(vec![
-      ("setup", "const { URL } = globalThis.__bootstrap.url;")
-    ])
-    .build(),
+    Extension::builder()
+      .js(vec![(
+        "setup",
+        "const { URL } = globalThis.__bootstrap.url;",
+      )])
+      .build(),
   ]
 }
 

--- a/extensions/url/benches/url_ops.rs
+++ b/extensions/url/benches/url_ops.rs
@@ -2,22 +2,16 @@ use deno_bench_util::bench_js_sync;
 use deno_bench_util::bench_or_profile;
 use deno_bench_util::bencher::{benchmark_group, Bencher};
 
-use deno_core::JsRuntime;
+use deno_core::Extension;
 
-fn setup(runtime: &mut JsRuntime) {
-  // TODO(@AaronO): support caller provided extensions in deno_bench_util
-  let mut ext = deno_url::init();
-
-  for (name, op_fn) in ext.init_ops().unwrap() {
-    runtime.register_op(name, op_fn);
-  }
-  for (filename, src) in ext.init_js() {
-    runtime.execute(filename, src).unwrap();
-  }
-
-  runtime
-    .execute("setup", "const { URL } = globalThis.__bootstrap.url;")
-    .unwrap();
+fn setup() -> Vec<Extension> {
+  vec![
+    deno_url::init(),
+    Extension::builder().js(vec![
+      ("setup", "const { URL } = globalThis.__bootstrap.url;")
+    ])
+    .build(),
+  ]
 }
 
 fn bench_url_parse(b: &mut Bencher) {


### PR DESCRIPTION
Since #9800, Extensions are the preferred way to init JsRuntimes