### PR TITLE
feat(lsp): show hints from `deno_lint` in addition to messages

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -78,13 +78,24 @@ pub struct Reference {
 impl Reference {
   pub fn to_diagnostic(&self) -> lsp::Diagnostic {
     match &self.category {
-      Category::Lint { message, code, .. } => lsp::Diagnostic {
+      Category::Lint {
+        message,
+        code,
+        hint,
+      } => lsp::Diagnostic {
         range: self.range,
         severity: Some(lsp::DiagnosticSeverity::Warning),
         code: Some(lsp::NumberOrString::String(code.to_string())),
         code_description: None,
         source: Some("deno-lint".to_string()),
-        message: message.to_string(),
+        message: {
+          let mut msg = message.to_string();
+          if let Some(hint) = hint {
+            msg.push('\n');
+            msg.push_str(hint);
+          }
+          msg
+        },
         related_information: None,
         tags: None, // we should tag unused code
         data: None,

--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -662,6 +662,64 @@ mod tests {
   use deno_core::resolve_url;
 
   #[test]
+  fn test_reference_to_diagnostic() {
+    let range = Range {
+      start: Position {
+        line: 1,
+        character: 1,
+      },
+      end: Position {
+        line: 2,
+        character: 2,
+      },
+    };
+
+    let test_cases = [
+      (
+        Reference {
+          category: Category::Lint {
+            message: "message1".to_string(),
+            code: "code1".to_string(),
+            hint: None,
+          },
+          range,
+        },
+        lsp::Diagnostic {
+          range,
+          severity: Some(lsp::DiagnosticSeverity::Warning),
+          code: Some(lsp::NumberOrString::String("code1".to_string())),
+          source: Some("deno-lint".to_string()),
+          message: "message1".to_string(),
+          ..Default::default()
+        },
+      ),
+      (
+        Reference {
+          category: Category::Lint {
+            message: "message2".to_string(),
+            code: "code2".to_string(),
+            hint: Some("hint2".to_string()),
+          },
+          range,
+        },
+        lsp::Diagnostic {
+          range,
+          severity: Some(lsp::DiagnosticSeverity::Warning),
+          code: Some(lsp::NumberOrString::String("code2".to_string())),
+          source: Some("deno-lint".to_string()),
+          message: "message2\nhint2".to_string(),
+          ..Default::default()
+        },
+      ),
+    ];
+
+    for (input, expected) in test_cases.iter() {
+      let actual = input.to_diagnostic();
+      assert_eq!(&actual, expected);
+    }
+  }
+
+  #[test]
   fn test_as_lsp_range() {
     let fixture = deno_lint::diagnostic::Range {
       start: deno_lint::diagnostic::Position {

--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -60,6 +60,7 @@ lazy_static::lazy_static! {
 
 /// Category of self-generated diagnostic messages (those not coming from)
 /// TypeScript.
+#[derive(Debug, PartialEq, Eq)]
 pub enum Category {
   /// A lint diagnostic, where the first element is the message.
   Lint {
@@ -70,6 +71,7 @@ pub enum Category {
 }
 
 /// A structure to hold a reference to a diagnostic message.
+#[derive(Debug, PartialEq, Eq)]
 pub struct Reference {
   category: Category,
   range: Range,
@@ -746,6 +748,38 @@ mod tests {
           character: 0,
         },
       }
+    );
+  }
+
+  #[test]
+  fn test_get_lint_references() {
+    let specifier = resolve_url("file:///a.ts").expect("bad specifier");
+    let source = "const foo = 42;";
+    let actual =
+      get_lint_references(&specifier, &MediaType::TypeScript, source).unwrap();
+
+    assert_eq!(
+      actual,
+      vec![Reference {
+        category: Category::Lint {
+          message: "`foo` is never used".to_string(),
+          code: "no-unused-vars".to_string(),
+          hint: Some(
+            "If this is intentional, prefix it with an underscore like `_foo`"
+              .to_string()
+          ),
+        },
+        range: Range {
+          start: Position {
+            line: 0,
+            character: 6,
+          },
+          end: Position {
+            line: 0,
+            character: 9,
+          }
+        }
+      }]
     );
   }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Currently, the LSP returns only messages from `deno_lint`; hints are omitted even when they are.
Some lint rules are very unfriendly in the sense that their diagnostic messages give no information about how the lint errors should be addressed properly without having to suppress them.
One example is `ban-ts-comment` rule, as its message just tells that the directive is disallowed without comment - when seeing this, one may wonder what "comment" is. While the message is very unclear, the hint is so informative that it gives a concrete example of how to address it, like ``Add an in-line comment explaining the reason for using `@ts-expect-error`, like `// @ts-expect-error: <reason>``
Therefore, it would be very nice to show not only messages but also hints from `deno_lint`. This PR appends hints to messages if any.

**before**
![without_hint](https://user-images.githubusercontent.com/23649474/119167207-8b50f280-ba9a-11eb-86b6-f325e0b73a0f.png)

**after**
![with_hint](https://user-images.githubusercontent.com/23649474/119167201-8a1fc580-ba9a-11eb-84ea-e85f1d581312.png)




