### PR TITLE
feat: Support Deno.beforeEach to run a function before each of the tests

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -168,6 +168,16 @@ declare namespace Deno {
    * */
   export function test(name: string, fn: () => void | Promise<void>): void;
 
+  /** Runs a function before each of the tests in this file runs.
+   * `fn` can be async if required.
+   *
+   * ```ts
+   * Deno.beforeEach(function(): void {
+   * });
+   * ```
+   */
+  export function beforeEach(fn: () => void | Promise<void>): void;
+
   /** Exit the Deno process with optional exit code. If no exit code is supplied
    * then Deno will exit with return code of 0.
    *
@@ -422,7 +432,7 @@ declare namespace Deno {
     dst: Writer,
     options?: {
       bufSize?: number;
-    },
+    }
   ): Promise<number>;
 
   /**
@@ -461,7 +471,7 @@ declare namespace Deno {
     r: Reader,
     options?: {
       bufSize?: number;
-    },
+    }
   ): AsyncIterableIterator<Uint8Array>;
 
   /**
@@ -500,7 +510,7 @@ declare namespace Deno {
     r: ReaderSync,
     options?: {
       bufSize?: number;
-    },
+    }
   ): IterableIterator<Uint8Array>;
 
   /** Synchronously open a file and return an instance of `Deno.File`.  The
@@ -532,8 +542,11 @@ declare namespace Deno {
    * Requires `allow-read` and/or `allow-write` permissions depending on options.
    */
   export function open(
+
     path: string | URL,
-    options?: OpenOptions,
+
+       options?: OpenOptions
+
   ): Promise<File>;
 
   /** Creates a file if none exists or truncates an existing file and returns
@@ -677,9 +690,13 @@ declare namespace Deno {
    * ```
    */
   export function seekSync(
+
     rid: number,
-    offset: number,
-    whence: SeekMode,
+
+       offset: number,
+
+       whence: SeekMode
+
   ): number;
 
   /** Seek a resource ID (`rid`) to the given `offset` under mode given by `whence`.
@@ -714,9 +731,13 @@ declare namespace Deno {
    * ```
    */
   export function seek(
+
     rid: number,
-    offset: number,
-    whence: SeekMode,
+
+       offset: number,
+
+       whence: SeekMode
+
   ): Promise<number>;
 
   /**
@@ -786,7 +807,8 @@ declare namespace Deno {
       WriterSync,
       Seeker,
       SeekerSync,
-      Closer {
+      Closer
+  {
     readonly rid: number;
     constructor(rid: number);
     write(p: Uint8Array): Promise<number>;
@@ -1088,8 +1110,11 @@ declare namespace Deno {
    *
    * Requires `allow-write` permission. */
   export function mkdir(
+
     path: string | URL,
-    options?: MkdirOptions,
+
+    options?: MkdirOptions
+
   ): Promise<void>;
 
   export interface MakeTempOptions {
@@ -1248,7 +1273,7 @@ declare namespace Deno {
   export function chownSync(
     path: string | URL,
     uid: number | null,
-    gid: number | null,
+    gid: number | null
   ): void;
 
   /** Change owner of a regular file or directory. This functionality
@@ -1269,7 +1294,7 @@ declare namespace Deno {
   export function chown(
     path: string | URL,
     uid: number | null,
-    gid: number | null,
+    gid: number | null
   ): Promise<void>;
 
   export interface RemoveOptions {
@@ -1303,8 +1328,11 @@ declare namespace Deno {
    *
    * Requires `allow-write` permission. */
   export function remove(
+
     path: string | URL,
-    options?: RemoveOptions,
+
+    options?: RemoveOptions
+
   ): Promise<void>;
 
   /** Synchronously renames (moves) `oldpath` to `newpath`. Paths may be files or
@@ -1532,8 +1560,11 @@ declare namespace Deno {
    * Requires `allow-read` permission on fromPath.
    * Requires `allow-write` permission on toPath. */
   export function copyFileSync(
+
     fromPath: string | URL,
-    toPath: string | URL,
+
+    toPath: string | URL
+
   ): void;
 
   /** Copies the contents and permissions of one file to another specified path,
@@ -1548,7 +1579,7 @@ declare namespace Deno {
    * Requires `allow-write` permission on toPath. */
   export function copyFile(
     fromPath: string | URL,
-    toPath: string | URL,
+    toPath: string | URL
   ): Promise<void>;
 
   /** Returns the full path destination of the named symbolic link.
@@ -1655,7 +1686,7 @@ declare namespace Deno {
   export function writeFileSync(
     path: string | URL,
     data: Uint8Array,
-    options?: WriteFileOptions,
+    options?: WriteFileOptions
   ): void;
 
   /** Write `data` to the given `path`, by default creating a new file if needed,
@@ -1675,7 +1706,7 @@ declare namespace Deno {
   export function writeFile(
     path: string | URL,
     data: Uint8Array,
-    options?: WriteFileOptions,
+    options?: WriteFileOptions
   ): Promise<void>;
 
   /** Synchronously write string `data` to the given `path`, by default creating a new file if needed,
@@ -1690,7 +1721,7 @@ declare namespace Deno {
   export function writeTextFileSync(
     path: string | URL,
     data: string,
-    options?: WriteFileOptions,
+    options?: WriteFileOptions
   ): void;
 
   /** Asynchronously write string `data` to the given `path`, by default creating a new file if needed,
@@ -1705,7 +1736,7 @@ declare namespace Deno {
   export function writeTextFile(
     path: string | URL,
     data: string,
-    options?: WriteFileOptions,
+    options?: WriteFileOptions
   ): Promise<void>;
 
   /** Synchronously truncates or extends the specified file, to reach the
@@ -1805,7 +1836,9 @@ declare namespace Deno {
    *
    * Requires `allow-net` permission. */
   export function listen(
-    options: ListenOptions & { transport?: "tcp" },
+
+    options: ListenOptions & { transport?: "tcp" }
+
   ): Listener;
 
   export interface ListenTlsOptions extends ListenOptions {
@@ -1985,17 +2018,20 @@ declare namespace Deno {
    */
   export function watchFs(
     paths: string | string[],
-    options?: { recursive: boolean },
+    options?: { recursive: boolean }
   ): AsyncIterableIterator<FsEvent>;
 
   export class Process<T extends RunOptions = RunOptions> {
     readonly rid: number;
     readonly pid: number;
-    readonly stdin: T["stdin"] extends "piped" ? Writer & Closer
+    readonly stdin: T["stdin"] extends "piped"
+      ? Writer & Closer
       : (Writer & Closer) | null;
-    readonly stdout: T["stdout"] extends "piped" ? Reader & Closer
+    readonly stdout: T["stdout"] extends "piped"
+      ? Reader & Closer
       : (Reader & Closer) | null;
-    readonly stderr: T["stderr"] extends "piped" ? Reader & Closer
+    readonly stderr: T["stderr"] extends "piped"
+      ? Reader & Closer
       : (Reader & Closer) | null;
     /** Wait for the process to exit and return its exit status.
      *
@@ -2046,15 +2082,15 @@ declare namespace Deno {
 
   export type ProcessStatus =
     | {
-      success: true;
-      code: 0;
-      signal?: undefined;
-    }
+        success: true;
+        code: 0;
+        signal?: undefined;
+      }
     | {
-      success: false;
-      code: number;
-      signal?: number;
-    };
+        success: false;
+        code: number;
+        signal?: number;
+      };
 
   export interface RunOptions {
     /** Arguments to pass. Note, the first element needs to be a path to the
@@ -2224,7 +2260,7 @@ declare namespace Deno {
     | HrtimePermissionDescriptor;
 
   export interface PermissionStatusEventMap {
-    "change": Event;
+    change: Event;
   }
 
   export class PermissionStatus extends EventTarget {
@@ -2235,27 +2271,27 @@ declare namespace Deno {
       type: K,
       listener: (
         this: PermissionStatus,
-        ev: PermissionStatusEventMap[K],
+        ev: PermissionStatusEventMap[K]
       ) => any,
-      options?: boolean | AddEventListenerOptions,
+      options?: boolean | AddEventListenerOptions
     ): void;
     addEventListener(
       type: string,
       listener: EventListenerOrEventListenerObject,
-      options?: boolean | AddEventListenerOptions,
+      options?: boolean | AddEventListenerOptions
     ): void;
     removeEventListener<K extends keyof PermissionStatusEventMap>(
       type: K,
       listener: (
         this: PermissionStatus,
-        ev: PermissionStatusEventMap[K],
+        ev: PermissionStatusEventMap[K]
       ) => any,
-      options?: boolean | EventListenerOptions,
+      options?: boolean | EventListenerOptions
     ): void;
     removeEventListener(
       type: string,
       listener: EventListenerOrEventListenerObject,
-      options?: boolean | EventListenerOptions,
+      options?: boolean | EventListenerOptions
     ): void;
   }
 
@@ -2358,7 +2394,7 @@ declare namespace Deno {
   export function symlinkSync(
     oldpath: string,
     newpath: string,
-    options?: SymlinkOptions,
+    options?: SymlinkOptions
   ): void;
 
   /**
@@ -2375,7 +2411,7 @@ declare namespace Deno {
   export function symlink(
     oldpath: string,
     newpath: string,
-    options?: SymlinkOptions,
+    options?: SymlinkOptions
   ): Promise<void>;
 
   /**

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -432,7 +432,7 @@ declare namespace Deno {
     dst: Writer,
     options?: {
       bufSize?: number;
-    }
+    },
   ): Promise<number>;
 
   /**
@@ -471,7 +471,7 @@ declare namespace Deno {
     r: Reader,
     options?: {
       bufSize?: number;
-    }
+    },
   ): AsyncIterableIterator<Uint8Array>;
 
   /**
@@ -510,7 +510,7 @@ declare namespace Deno {
     r: ReaderSync,
     options?: {
       bufSize?: number;
-    }
+    },
   ): IterableIterator<Uint8Array>;
 
   /** Synchronously open a file and return an instance of `Deno.File`.  The
@@ -542,11 +542,8 @@ declare namespace Deno {
    * Requires `allow-read` and/or `allow-write` permissions depending on options.
    */
   export function open(
-
     path: string | URL,
-
-       options?: OpenOptions
-
+    options?: OpenOptions,
   ): Promise<File>;
 
   /** Creates a file if none exists or truncates an existing file and returns
@@ -690,13 +687,9 @@ declare namespace Deno {
    * ```
    */
   export function seekSync(
-
     rid: number,
-
-       offset: number,
-
-       whence: SeekMode
-
+    offset: number,
+    whence: SeekMode,
   ): number;
 
   /** Seek a resource ID (`rid`) to the given `offset` under mode given by `whence`.
@@ -731,13 +724,9 @@ declare namespace Deno {
    * ```
    */
   export function seek(
-
     rid: number,
-
-       offset: number,
-
-       whence: SeekMode
-
+    offset: number,
+    whence: SeekMode,
   ): Promise<number>;
 
   /**
@@ -807,8 +796,7 @@ declare namespace Deno {
       WriterSync,
       Seeker,
       SeekerSync,
-      Closer
-  {
+      Closer {
     readonly rid: number;
     constructor(rid: number);
     write(p: Uint8Array): Promise<number>;
@@ -1110,11 +1098,8 @@ declare namespace Deno {
    *
    * Requires `allow-write` permission. */
   export function mkdir(
-
     path: string | URL,
-
-    options?: MkdirOptions
-
+    options?: MkdirOptions,
   ): Promise<void>;
 
   export interface MakeTempOptions {
@@ -1273,7 +1258,7 @@ declare namespace Deno {
   export function chownSync(
     path: string | URL,
     uid: number | null,
-    gid: number | null
+    gid: number | null,
   ): void;
 
   /** Change owner of a regular file or directory. This functionality
@@ -1294,7 +1279,7 @@ declare namespace Deno {
   export function chown(
     path: string | URL,
     uid: number | null,
-    gid: number | null
+    gid: number | null,
   ): Promise<void>;
 
   export interface RemoveOptions {
@@ -1328,11 +1313,8 @@ declare namespace Deno {
    *
    * Requires `allow-write` permission. */
   export function remove(
-
     path: string | URL,
-
-    options?: RemoveOptions
-
+    options?: RemoveOptions,
   ): Promise<void>;
 
   /** Synchronously renames (moves) `oldpath` to `newpath`. Paths may be files or
@@ -1560,11 +1542,8 @@ declare namespace Deno {
    * Requires `allow-read` permission on fromPath.
    * Requires `allow-write` permission on toPath. */
   export function copyFileSync(
-
     fromPath: string | URL,
-
-    toPath: string | URL
-
+    toPath: string | URL,
   ): void;
 
   /** Copies the contents and permissions of one file to another specified path,
@@ -1579,7 +1558,7 @@ declare namespace Deno {
    * Requires `allow-write` permission on toPath. */
   export function copyFile(
     fromPath: string | URL,
-    toPath: string | URL
+    toPath: string | URL,
   ): Promise<void>;
 
   /** Returns the full path destination of the named symbolic link.
@@ -1686,7 +1665,7 @@ declare namespace Deno {
   export function writeFileSync(
     path: string | URL,
     data: Uint8Array,
-    options?: WriteFileOptions
+    options?: WriteFileOptions,
   ): void;
 
   /** Write `data` to the given `path`, by default creating a new file if needed,
@@ -1706,7 +1685,7 @@ declare namespace Deno {
   export function writeFile(
     path: string | URL,
     data: Uint8Array,
-    options?: WriteFileOptions
+    options?: WriteFileOptions,
   ): Promise<void>;
 
   /** Synchronously write string `data` to the given `path`, by default creating a new file if needed,
@@ -1721,7 +1700,7 @@ declare namespace Deno {
   export function writeTextFileSync(
     path: string | URL,
     data: string,
-    options?: WriteFileOptions
+    options?: WriteFileOptions,
   ): void;
 
   /** Asynchronously write string `data` to the given `path`, by default creating a new file if needed,
@@ -1736,7 +1715,7 @@ declare namespace Deno {
   export function writeTextFile(
     path: string | URL,
     data: string,
-    options?: WriteFileOptions
+    options?: WriteFileOptions,
   ): Promise<void>;
 
   /** Synchronously truncates or extends the specified file, to reach the
@@ -1836,9 +1815,7 @@ declare namespace Deno {
    *
    * Requires `allow-net` permission. */
   export function listen(
-
-    options: ListenOptions & { transport?: "tcp" }
-
+    options: ListenOptions & { transport?: "tcp" },
   ): Listener;
 
   export interface ListenTlsOptions extends ListenOptions {
@@ -2018,20 +1995,17 @@ declare namespace Deno {
    */
   export function watchFs(
     paths: string | string[],
-    options?: { recursive: boolean }
+    options?: { recursive: boolean },
   ): AsyncIterableIterator<FsEvent>;
 
   export class Process<T extends RunOptions = RunOptions> {
     readonly rid: number;
     readonly pid: number;
-    readonly stdin: T["stdin"] extends "piped"
-      ? Writer & Closer
+    readonly stdin: T["stdin"] extends "piped" ? Writer & Closer
       : (Writer & Closer) | null;
-    readonly stdout: T["stdout"] extends "piped"
-      ? Reader & Closer
+    readonly stdout: T["stdout"] extends "piped" ? Reader & Closer
       : (Reader & Closer) | null;
-    readonly stderr: T["stderr"] extends "piped"
-      ? Reader & Closer
+    readonly stderr: T["stderr"] extends "piped" ? Reader & Closer
       : (Reader & Closer) | null;
     /** Wait for the process to exit and return its exit status.
      *
@@ -2082,15 +2056,15 @@ declare namespace Deno {
 
   export type ProcessStatus =
     | {
-        success: true;
-        code: 0;
-        signal?: undefined;
-      }
+      success: true;
+      code: 0;
+      signal?: undefined;
+    }
     | {
-        success: false;
-        code: number;
-        signal?: number;
-      };
+      success: false;
+      code: number;
+      signal?: number;
+    };
 
   export interface RunOptions {
     /** Arguments to pass. Note, the first element needs to be a path to the
@@ -2271,27 +2245,27 @@ declare namespace Deno {
       type: K,
       listener: (
         this: PermissionStatus,
-        ev: PermissionStatusEventMap[K]
+        ev: PermissionStatusEventMap[K],
       ) => any,
-      options?: boolean | AddEventListenerOptions
+      options?: boolean | AddEventListenerOptions,
     ): void;
     addEventListener(
       type: string,
       listener: EventListenerOrEventListenerObject,
-      options?: boolean | AddEventListenerOptions
+      options?: boolean | AddEventListenerOptions,
     ): void;
     removeEventListener<K extends keyof PermissionStatusEventMap>(
       type: K,
       listener: (
         this: PermissionStatus,
-        ev: PermissionStatusEventMap[K]
+        ev: PermissionStatusEventMap[K],
       ) => any,
-      options?: boolean | EventListenerOptions
+      options?: boolean | EventListenerOptions,
     ): void;
     removeEventListener(
       type: string,
       listener: EventListenerOrEventListenerObject,
-      options?: boolean | EventListenerOptions
+      options?: boolean | EventListenerOptions,
     ): void;
   }
 
@@ -2394,7 +2368,7 @@ declare namespace Deno {
   export function symlinkSync(
     oldpath: string,
     newpath: string,
-    options?: SymlinkOptions
+    options?: SymlinkOptions,
   ): void;
 
   /**
@@ -2411,7 +2385,7 @@ declare namespace Deno {
   export function symlink(
     oldpath: string,
     newpath: string,
-    options?: SymlinkOptions
+    options?: SymlinkOptions,
   ): Promise<void>;
 
   /**

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -42,7 +42,7 @@ After:
   - completed: ${post.opsCompletedAsync}
 
 Make sure to await all promises returned from Deno APIs before
-finishing test case.`
+finishing test case.`,
       );
     };
   }
@@ -75,7 +75,7 @@ finishing test case.`;
       setExitHandler((exitCode) => {
         assert(
           false,
-          `Test case attempted to exit with exit code: ${exitCode}`
+          `Test case attempted to exit with exit code: ${exitCode}`,
         );
       });
 
@@ -171,7 +171,7 @@ finishing test case.`;
   function pledgeTestPermissions(permissions) {
     return core.opSync(
       "op_pledge_test_permissions",
-      parsePermissions(permissions)
+      parsePermissions(permissions),
     );
   }
 
@@ -236,7 +236,7 @@ finishing test case.`;
 
     const only = tests.filter((test) => test.only);
     const pending = (only.length > 0 ? only : tests).filter(
-      createTestFilter(filter)
+      createTestFilter(filter),
     );
     postTestMessage("plan", {
       filtered: tests.length - pending.length,

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -5,6 +5,7 @@
   const __bootstrap = window.__bootstrap;
   __bootstrap.denoNs = {
     test: __bootstrap.testing.test,
+    beforeEach: __bootstrap.testing.beforeEach,
     metrics: __bootstrap.metrics.metrics,
     Process: __bootstrap.process.Process,
     run: __bootstrap.process.run,


### PR DESCRIPTION
## Description

Runs a function before each of the tests in this file runs. If the function returns a promise, Deno waits for that promise to resolve before running the test.

```ts
Deno.beforeEach(function(): void {
  // 
});
```

```ts
Deno.test("Hello Test", () => {
  assert("Hello");
});
```

## Motivation

Most times you have setup work that has to happen before the tests run. For example consider when you have several tests interact with a database of cities. You have a method initializeCityDatabase() that has to be called before each of these tests
Deno provides helper functions `Deno.beforeEach` to handle this.

```ts
beforeEach(() => {
  initializeCityDatabase();
});

Deno.test("city database has Casablanca", () => {
  assert(isCity("Casablanca"));
});

```