### PR TITLE
refactor(core): move macrotask to JS & intro asyncTick

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -25,9 +25,6 @@ lazy_static::lazy_static! {
         function: opcall.map_fn_to()
       },
       v8::ExternalReference {
-        function: set_macrotask_callback.map_fn_to()
-      },
-      v8::ExternalReference {
         function: eval_context.map_fn_to()
       },
       v8::ExternalReference {
@@ -115,12 +112,6 @@ pub fn initialize_context<'s>(
 
   // Bind functions to Deno.core.*
   set_func(scope, core_val, "opcall", opcall);
-  set_func(
-    scope,
-    core_val,
-    "setMacrotaskCallback",
-    set_macrotask_callback,
-  );
   set_func(scope, core_val, "evalContext", eval_context);
   set_func(scope, core_val, "encode", encode);
   set_func(scope, core_val, "decode", decode);
@@ -346,32 +337,6 @@ fn opcall<'s>(
       throw_type_error(scope, format!("Unknown op id: {}", op_id));
     }
   }
-}
-
-fn set_macrotask_callback(
-  scope: &mut v8::HandleScope,
-  args: v8::FunctionCallbackArguments,
-  _rv: v8::ReturnValue,
-) {
-  let state_rc = JsRuntime::state(scope);
-  let mut state = state_rc.borrow_mut();
-
-  let cb = match v8::Local::<v8::Function>::try_from(args.get(0)) {
-    Ok(cb) => cb,
-    Err(err) => return throw_type_error(scope, err.to_string()),
-  };
-
-  let slot = match &mut state.js_macrotask_cb {
-    slot @ None => slot,
-    _ => {
-      return throw_type_error(
-        scope,
-        "Deno.core.setMacrotaskCallback() already called",
-      );
-    }
-  };
-
-  slot.replace(v8::Global::new(scope, cb));
 }
 
 fn eval_context(


### PR DESCRIPTION
This simplifies the macrotask implementation, moving it from Rust to JS.

It also consolidates async-op handling & macrotasks into `asyncTick()` so JsRuntime's event loop only calls into JS once (simpler & possibly more efficient) and removes yet another binding

This also fixes a potential bug that would have prevented snapshotting after calling `setMacrotaskCallback`