### PR TITLE
fix(cli/test): don't use reserved symbol `:` in specifier

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -18,8 +18,6 @@ use tempfile::TempDir;
 use test_util as util;
 use tokio::task::LocalSet;
 
-// TODO(caspervonb): investiate why this fails on Windows.
-#[cfg(unix)]
 #[test]
 fn typecheck_declarations_ns() {
   let status = util::deno_cmd()
@@ -33,8 +31,6 @@ fn typecheck_declarations_ns() {
   assert!(status.success());
 }
 
-// TODO(caspervonb): investiate why this fails on Windows.
-#[cfg(unix)]
 #[test]
 fn typecheck_declarations_unstable() {
   let status = util::deno_cmd()

--- a/cli/tests/test/doc.out
+++ b/cli/tests/test/doc.out
@@ -2,4 +2,4 @@ Check [WILDCARD]/doc.ts:2-7
 error: TS2367 [ERROR]: This condition will always return 'false' since the types 'string' and 'number' have no overlap.
 console.assert(example() == 42);
                ~~~~~~~~~~~~~~~
-    at [WILDCARD]/doc.ts:2-7.ts:3:16
+    at [WILDCARD]/doc.ts$2-7.ts:3:16

--- a/cli/tests/test/doc.out
+++ b/cli/tests/test/doc.out
@@ -1,4 +1,4 @@
-Check [WILDCARD]/doc.ts:2-7
+Check [WILDCARD]/doc.ts$2-7
 error: TS2367 [ERROR]: This condition will always return 'false' since the types 'string' and 'number' have no overlap.
 console.assert(example() == 42);
                ~~~~~~~~~~~~~~~

--- a/cli/tools/test_runner.rs
+++ b/cli/tools/test_runner.rs
@@ -379,7 +379,7 @@ pub async fn run_tests(
           let location = parsed_module.get_location(&span);
 
           let specifier = deno_core::resolve_url_or_path(&format!(
-            "{}:{}-{}",
+            "{}${}-{}",
             location.filename,
             location.line,
             location.line + element.as_str().split('\n').count(),


### PR DESCRIPTION
Colon is reserved in windows so it cannot be in the file-path (see https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#file_and_directory_names).

This replaces `:` with `$` resulting in slightly uglier stack-traces in the short term until source maps are applied.

Closes https://github.com/denoland/deno/issues/10730