### PR TITLE
feat(runtime/js/testing)Add parameters option to Deno.test

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -95,8 +95,8 @@ declare namespace Deno {
    * See: https://no-color.org/ */
   export const noColor: boolean;
 
-  export interface TestDefinition {
-    fn: () => void | Promise<void>;
+  export interface TestDefinition<T = void> {
+    fn: (() => void) | ((parameter: T) => void) | Promise<void>;
     name: string;
     ignore?: boolean;
     /** If at least one test has `only` set to true, only run tests that have
@@ -109,10 +109,12 @@ declare namespace Deno {
      * after the test has exactly the same contents as before the test. Defaults
      * to true. */
     sanitizeResources?: boolean;
-
     /** Ensure the test case does not prematurely cause the process to exit,
      * for example via a call to `Deno.exit`. Defaults to true. */
     sanitizeExit?: boolean;
+    /** Execute a single test method multiple times with different parameters.
+     * Defaults to []. */
+    parameters?: Array<T>;
   }
 
   /** Register a test which will be run when `deno test` is used on the command
@@ -144,9 +146,18 @@ declare namespace Deno {
    *     assertEquals(decoder.decode(data), "Hello world");
    *   }
    * });
+   *
+   * Deno.test({
+   *   name: "object test",
+   *   parameters: [{ data: 1, except: 2 }, { data: 2, except: 4 }],
+   *   fn(parameter: { data: number; except: number }) {
+   *     assertEquals(parameter.data * 2, parameter.except);
+   *   },
+   * });
+   *
    * ```
    */
-  export function test(t: TestDefinition): void;
+  export function test<T = void>(t: TestDefinition<T>): void;
 
   /** Register a test which will be run when `deno test` is used on the command
    * line and the containing module looks like a test module.

--- a/cli/tests/test/deno_test_parameters.ts
+++ b/cli/tests/test/deno_test_parameters.ts
@@ -1,0 +1,17 @@
+import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
+
+Deno.test({
+  name: "object parameters test",
+  parameters: [{ data: 1, except: 2 }, { data: 2, except: 4 }],
+  fn(parameter: { data: number; except: number }) {
+    assertEquals(parameter.data * 2, parameter.except);
+  },
+});
+
+Deno.test({
+  name: "single string parameters test",
+  parameters: ["hello", "hello"],
+  fn(parameter: string) {
+    assertEquals(parameter, "hello");
+  },
+});


### PR DESCRIPTION
I think that Deno.test should add a parameters test that executes a single test method multiple times with different parameters.

I tried to support it as follows.
I have supported it by adding a parameters argument as an option. Parameters can be received as arguments of fn in the list order of the parameters.

``` ts
import { assertEquals } from "../../../test_util/std/testing/asserts.ts";

Deno.test({
  name: "object parameters test",
  parameters: [{ data: 1, except: 2 }, { data: 2, except: 4 }],
  fn(parameter: { data: number; except: number }) {
    assertEquals(parameter.data * 2, parameter.except);
  },
});

Deno.test({
  name: "single string parameters test",
  parameters: ["hello", "hello"],
  fn(parameter: string) {
    assertEquals(parameter, "hello");
  },
});

```

Result 

Outputs which parameter was executed.

```
test object parameters test {"data":1,"except":2} ... ok (8ms)
test object parameters test {"data":2,"except":4} ... ok (2ms)
test single string parameters test "hello" ... ok (3ms)
test single string parameters test "hello" ... ok (2ms)

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (112ms)
```

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
