### PR TITLE
fix(ext/fetch): fix error message of Request constructor

### DIFF
--- a/extensions/fetch/23_request.js
+++ b/extensions/fetch/23_request.js
@@ -273,7 +273,7 @@
         ((init.body !== undefined && init.body !== null) ||
           inputBody !== null)
       ) {
-        throw new TypeError("HEAD or GET request cannot have a body.");
+        throw new TypeError("Request with GET/HEAD method cannot have body.");
       }
 
       // 34.

--- a/extensions/fetch/23_request.js
+++ b/extensions/fetch/23_request.js
@@ -273,7 +273,7 @@
         ((init.body !== undefined && init.body !== null) ||
           inputBody !== null)
       ) {
-        throw new TypeError("HEAD and GET requests may not have a body.");
+        throw new TypeError("HEAD or GET request cannot have a body.");
       }
 
       // 34.


### PR DESCRIPTION
This PR improves the type error message of Request constructor, which occurs when it's constructed with non null body and GET or HEAD method.

The browsers implements this message as:
- Chrome:  `Request with GET/HEAD method cannot have body.`
- Firefox: `HEAD or GET Request cannot have a body.`
- Safari: `Request has method 'GET' and cannot have a body`
