### PR TITLE
docs(runtime): fix fetch API usage of HTTP server

### DIFF
--- a/docs/runtime/http_server_apis.md
+++ b/docs/runtime/http_server_apis.md
@@ -204,9 +204,11 @@ object. Responding with a basic "hello world" would look like this:
 async function handle(conn: Deno.Conn) {
   const httpConn = Deno.serveHttp(conn);
   for await (const requestEvent of httpConn) {
-    await requestEvent.respondWith(new Response("hello world"), {
-      status: 200,
-    });
+    await requestEvent.respondWith(
+      new Response("hello world", {
+        status: 200,
+      }),
+    );
   }
 }
 ```


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

I got an error when I was trying to run following code from https://deno.land/manual/runtime/http_server_apis.

```ts
async function handle(conn: Deno.Conn) {
  const httpConn = Deno.serveHttp(conn);
  for await (const requestEvent of httpConn) {
    await requestEvent.respondWith(new Response("hello world"), {
      status: 200,
    });
  }
}
```

```
error: TS2554 [ERROR]: Expected 1 arguments, but got 2.
    await requestEvent.respondWith(new Response("hello world"), {
                                                                ^
    at path/to/file.ts:4:65
```

According to the fetch and service worker specs, `{ status: 200 }` is a second argument of [`Response` constructor](https://fetch.spec.whatwg.org/#response-class
) instead of [`respondWith` function](https://w3c.github.io/ServiceWorker/#fetchevent-interface). Following snippet works fine with deno 1.10.1.

```ts
async function handle(conn: Deno.Conn) {
  const httpConn = Deno.serveHttp(conn);
  for await (const requestEvent of httpConn) {
    await requestEvent.respondWith(
      new Response("hello world", {
        status: 200,
      }),
    );
  }
}
```

If you don’t mind, please incorporate this fix to make the manual more friendly. If I missed something, please let me know.