### PR TITLE
BREAKING(unstable): Structure Deno.emit() output, add Deno.emitBundle()

### DIFF
--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -6,9 +6,7 @@ use deno_core::serde::Deserialize;
 use deno_core::serde::Deserializer;
 use deno_core::serde::Serialize;
 use deno_core::serde::Serializer;
-use deno_core::ModuleSpecifier;
 use regex::Regex;
-use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 
@@ -230,14 +228,13 @@ impl Diagnostic {
       _ => "",
     };
 
-    let code = if self.code >= 900001 {
-      "".to_string()
-    } else {
-      colors::bold(format!("TS{} ", self.code)).to_string()
-    };
-
     if !category.is_empty() {
-      write!(f, "{}[{}]: ", code, category)
+      write!(
+        f,
+        "{} [{}]: ",
+        colors::bold(&format!("TS{}", self.code)),
+        category
+      )
     } else {
       Ok(())
     }
@@ -355,24 +352,6 @@ impl Diagnostics {
   #[cfg(test)]
   pub fn new(diagnostics: Vec<Diagnostic>) -> Self {
     Diagnostics(diagnostics)
-  }
-
-  pub fn extend_graph_errors(
-    &mut self,
-    errors: HashMap<ModuleSpecifier, String>,
-  ) {
-    self.0.extend(errors.into_iter().map(|(s, e)| Diagnostic {
-      category: DiagnosticCategory::Error,
-      code: 900001,
-      start: None,
-      end: None,
-      message_text: Some(e),
-      message_chain: None,
-      source: None,
-      source_line: None,
-      file_name: Some(s.to_string()),
-      related_information: None,
-    }));
   }
 
   pub fn is_empty(&self) -> bool {

--- a/cli/specifier_handler.rs
+++ b/cli/specifier_handler.rs
@@ -34,10 +34,10 @@ pub type FetchFuture = Pin<
 
 /// A group of errors that represent errors that can occur with an
 /// an implementation of `SpecifierHandler`.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug)]
 pub enum HandlerError {
   /// A fetch error, where we have a location associated with it.
-  FetchErrorWithLocation(String, Location),
+  FetchErrorWithLocation(AnyError, Location),
 }
 
 impl fmt::Display for HandlerError {
@@ -294,8 +294,7 @@ impl SpecifierHandler for FetchHandler {
             if !location.specifier.contains("$deno$") {
               (
                 requested_specifier.clone(),
-                HandlerError::FetchErrorWithLocation(err.to_string(), location)
-                  .into(),
+                HandlerError::FetchErrorWithLocation(err, location).into(),
               )
             } else {
               (requested_specifier.clone(), err)

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -267,7 +267,6 @@ itest!(_079_location_authentication {
 itest!(_080_deno_emit_permissions {
   args: "run --unstable 080_deno_emit_permissions.ts",
   output: "080_deno_emit_permissions.ts.out",
-  exit_code: 1,
 });
 
 itest!(_081_location_relative_fetch_redirect {
@@ -355,6 +354,22 @@ itest!(_092_import_map_unmapped_bare_specifier {
   args: "run --import-map import_maps/import_map.json 092_import_map_unmapped_bare_specifier.ts",
   output: "092_import_map_unmapped_bare_specifier.ts.out",
   exit_code: 1,
+});
+
+itest!(_093_emit_permission_error {
+  args: "run --unstable --allow-read 093_emit_permission_error.ts",
+  output: "093_emit_permission_error.ts.out",
+});
+
+itest!(_094_emit_bundle_permission_error {
+  args: "run --unstable --allow-read 094_emit_bundle_permission_error.ts",
+  output: "094_emit_bundle_permission_error.ts.out",
+  exit_code: 1,
+});
+
+itest!(_096_emit_with_bare_import {
+  args: "run --unstable --allow-read 096_emit_with_bare_import.ts",
+  output: "096_emit_with_bare_import.ts.out",
 });
 
 itest!(js_import_detect {

--- a/cli/tests/testdata/080_deno_emit_permissions.ts
+++ b/cli/tests/testdata/080_deno_emit_permissions.ts
@@ -1,1 +1,3 @@
-await Deno.emit(new URL("001_hello.js", import.meta.url).href);
+console.log(
+  (await Deno.emit(new URL("001_hello.js", import.meta.url))).modules,
+);

--- a/cli/tests/testdata/080_deno_emit_permissions.ts.out
+++ b/cli/tests/testdata/080_deno_emit_permissions.ts.out
@@ -1,2 +1,6 @@
-[WILDCARD]error: Uncaught (in promise) PermissionDenied: Requires read access to "[WILDCARD]001_hello.js", run again with the --allow-read flag
-[WILDCARD]
+[WILDCARD][
+  {
+    specifier: "file:///[WILDCARD]/001_hello.js",
+    error: 'Requires read access to "[WILDCARD]001_hello.js"[WILDCARD]'
+  }
+]

--- a/cli/tests/testdata/093_emit_permission_error.ts
+++ b/cli/tests/testdata/093_emit_permission_error.ts
@@ -1,0 +1,1 @@
+console.log((await Deno.emit(new URL("093_root.ts", import.meta.url))).modules);

--- a/cli/tests/testdata/093_emit_permission_error.ts.out
+++ b/cli/tests/testdata/093_emit_permission_error.ts.out
@@ -1,0 +1,12 @@
+[WILDCARD][
+  {
+    specifier: "file:///[WILDCARD]/093_root.ts",
+    code: [WILDCARD],
+    map: '[WILDCARD]',
+    declaration: null
+  },
+  {
+    specifier: "https://deno.land/std@0.97.0/testing/asserts.ts",
+    error: 'Requires net access to "deno.land"[WILDCARD]'
+  }
+]

--- a/cli/tests/testdata/093_root.ts
+++ b/cli/tests/testdata/093_root.ts
@@ -1,0 +1,1 @@
+import "https://deno.land/std@0.97.0/testing/asserts.ts";

--- a/cli/tests/testdata/094_emit_bundle_permission_error.ts
+++ b/cli/tests/testdata/094_emit_bundle_permission_error.ts
@@ -1,0 +1,1 @@
+await Deno.emitBundle(new URL("093_root.ts", import.meta.url));

--- a/cli/tests/testdata/094_emit_bundle_permission_error.ts.out
+++ b/cli/tests/testdata/094_emit_bundle_permission_error.ts.out
@@ -1,0 +1,5 @@
+[WILDCARD]error: Uncaught (in promise) PermissionDenied: Requires net access to "deno.land", run again with the --allow-net flag
+    at [WILDCARD]
+await Deno.emitBundle(new URL("093_root.ts", import.meta.url));
+^
+    at [WILDCARD]

--- a/cli/tests/testdata/096_emit_with_bare_import.ts
+++ b/cli/tests/testdata/096_emit_with_bare_import.ts
@@ -1,0 +1,4 @@
+console.log(
+  (await Deno.emit(new URL("095_cache_with_bare_import.ts", import.meta.url)))
+    .modules,
+);

--- a/cli/tests/testdata/096_emit_with_bare_import.ts.out
+++ b/cli/tests/testdata/096_emit_with_bare_import.ts.out
@@ -1,0 +1,12 @@
+[WILDCARD][
+  {
+    specifier: "file:///[WILDCARD]/095_cache_with_bare_import.ts",
+    code: [WILDCARD],
+    map: '[WILDCARD]',
+    declaration: null
+  },
+  {
+    specifier: "foo",
+    error: 'Relative import path "foo" not prefixed with / or ./ or ../ from [WILDCARD]'
+  }
+]

--- a/cli/tests/testdata/lib_dom_asynciterable.ts
+++ b/cli/tests/testdata/lib_dom_asynciterable.ts
@@ -1,4 +1,4 @@
-const { diagnostics, files } = await Deno.emit("/main.ts", {
+const { diagnostics, modules } = await Deno.emit("/main.ts", {
   compilerOptions: {
     target: "esnext",
     lib: ["esnext", "dom", "dom.iterable", "dom.asynciterable"],
@@ -11,7 +11,7 @@ const { diagnostics, files } = await Deno.emit("/main.ts", {
         c.close();
       }
     });
-    
+
     for await (const s of rs) {
       console.log("s");
     }
@@ -20,4 +20,4 @@ const { diagnostics, files } = await Deno.emit("/main.ts", {
 });
 
 console.log(diagnostics);
-console.log(Object.keys(files).sort());
+console.log(modules);

--- a/cli/tests/testdata/lib_dom_asynciterable.ts.out
+++ b/cli/tests/testdata/lib_dom_asynciterable.ts.out
@@ -1,2 +1,9 @@
 []
-[ "[WILDCARD]/main.ts.js", "[WILDCARD]/main.ts.js.map" ]
+[
+  {
+    specifier: "file:///[WILDCARD]main.ts",
+    code: [WILDCARD],
+    map: '[WILDCARD]',
+    declaration: null
+  }
+]

--- a/cli/tests/testdata/lib_ref.ts
+++ b/cli/tests/testdata/lib_ref.ts
@@ -1,4 +1,4 @@
-const { diagnostics, files } = await Deno.emit(
+const { diagnostics, modules } = await Deno.emit(
   "/main.ts",
   {
     sources: {
@@ -13,4 +13,4 @@ const { diagnostics, files } = await Deno.emit(
 );
 
 console.log(diagnostics);
-console.log(Object.keys(files).sort());
+console.log(modules);

--- a/cli/tests/testdata/lib_ref.ts.out
+++ b/cli/tests/testdata/lib_ref.ts.out
@@ -1,2 +1,9 @@
 []
-[ "file:///[WILDCARD]main.ts.js", "file:///[WILDCARD]main.ts.js.map" ]
+[
+  {
+    specifier: "file:///[WILDCARD]main.ts",
+    code: [WILDCARD],
+    map: '[WILDCARD]',
+    declaration: null
+  }
+]

--- a/cli/tests/testdata/lib_runtime_api.ts
+++ b/cli/tests/testdata/lib_runtime_api.ts
@@ -1,4 +1,4 @@
-const { diagnostics, files } = await Deno.emit(
+const { diagnostics, modules } = await Deno.emit(
   "/main.ts",
   {
     sources: {
@@ -11,4 +11,4 @@ const { diagnostics, files } = await Deno.emit(
 );
 
 console.log(diagnostics);
-console.log(Object.keys(files).sort());
+console.log(modules);

--- a/cli/tests/testdata/lib_runtime_api.ts.out
+++ b/cli/tests/testdata/lib_runtime_api.ts.out
@@ -1,2 +1,9 @@
 []
-[ "file:///[WILDCARD]main.ts.js", "file:///[WILDCARD]main.ts.js.map" ]
+[
+  {
+    specifier: "file:///[WILDCARD]main.ts",
+    code: [WILDCARD],
+    map: '[WILDCARD]',
+    declaration: null
+  }
+]

--- a/cli/tests/testdata/standalone_compiler_ops.ts
+++ b/cli/tests/testdata/standalone_compiler_ops.ts
@@ -1,5 +1,5 @@
-const { files } = await Deno.emit("/mod.ts", {
-  bundle: "classic",
+const { code } = await Deno.emitBundle("/mod.ts", {
+  type: "classic",
   sources: {
     "/mod.ts": `import { hello } from "/hello.ts"; console.log(hello);`,
     "/hello.ts": `export const hello: string = "Hello, Compiler API!"`,
@@ -9,4 +9,4 @@ const { files } = await Deno.emit("/mod.ts", {
   },
 });
 
-eval(files["deno:///bundle.js"]);
+eval(code);

--- a/runtime/js/40_compiler_api.js
+++ b/runtime/js/40_compiler_api.js
@@ -76,7 +76,7 @@
   function emitBundle(rootSpecifier, options = {}) {
     util.log(`Deno.emit`, { rootSpecifier });
     if (!rootSpecifier) {
-      return Promise.reject(
+      return PromiseReject(
         new TypeError("A root specifier must be supplied."),
       );
     }

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -110,6 +110,7 @@
     Signal: __bootstrap.signals.Signal,
     SignalStream: __bootstrap.signals.SignalStream,
     emit: __bootstrap.compilerApi.emit,
+    emitBundle: __bootstrap.compilerApi.emitBundle,
     kill: __bootstrap.process.kill,
     setRaw: __bootstrap.tty.setRaw,
     consoleSize: __bootstrap.tty.consoleSize,


### PR DESCRIPTION
Closes #10770.
Fixes #11141.
Fixes #11206.

Makes `Deno.emit()` output code, source maps, declaration files etc. as a list of structured module entries instead of a dictionary of magical file names. Breaks out `Deno.emitBundle()` as a new API, since it has a different output structure.

---

### `Deno.emit()`

```ts
console.log(
  await Deno.emit("https://deno.land/std@0.97.0/testing/asserts.ts", {
    compilerOptions: { declaration: true },
  }),
);
```
Before:
```js
{
  files: {
    "https://deno.land/std@0.97.0/testing/_diff.ts.js.map": '{"version":3,"file":"_diff.js","sourceRoot":"","sources":["https://deno.land/std@0.97.0/testing/_dif...',
    "https://deno.land/std@0.97.0/testing/_diff.ts.js": 'export var DiffType;\n(function (DiffType) {\n    DiffType["removed"] = "removed";\n    DiffType["commo...',
    "https://deno.land/std@0.97.0/fmt/colors.ts.js.map": '{"version":3,"file":"colors.js","sourceRoot":"","sources":["https://deno.land/std@0.97.0/fmt/colors....',
    "https://deno.land/std@0.97.0/testing/asserts.ts.d.ts": '/// <amd-module name="https://deno.land/std@0.97.0/testing/asserts.ts" />\ninterface Constructor {\n  ...',
    "https://deno.land/std@0.97.0/testing/asserts.ts.js": 'import { bold, gray, green, red, stripColor, white } from "../fmt/colors.ts";\nimport { diff, DiffTyp...',
    "https://deno.land/std@0.97.0/fmt/colors.ts.d.ts": '/// <amd-module name="https://deno.land/std@0.97.0/fmt/colors.ts" />\ninterface Rgb {\n    r: number;\n...',
    "https://deno.land/std@0.97.0/fmt/colors.ts.js": "const noColor = globalThis.Deno?.noColor ?? true;\nlet enabled = !noColor;\nexport function setColorEn...",
    "https://deno.land/std@0.97.0/testing/asserts.ts.js.map": '{"version":3,"file":"asserts.js","sourceRoot":"","sources":["https://deno.land/std@0.97.0/testing/as...',
    "https://deno.land/std@0.97.0/testing/_diff.ts.d.ts": '/// <amd-module name="https://deno.land/std@0.97.0/testing/_diff.ts" />\nexport declare enum DiffType...'
  },
  // ...
}
```
After:
```js
{
  modules: [
    {
      specifier: "https://deno.land/std@0.97.0/fmt/colors.ts",
      code: "const noColor = globalThis.Deno?.noColor ?? true;\nlet enabled = !noColor;\nexport function setColorEn...",
      map: '{"version":3,"file":"colors.js","sourceRoot":"","sources":["https://deno.land/std@0.97.0/fmt/colors....',
      declaration: '/// <amd-module name="https://deno.land/std@0.97.0/fmt/colors.ts" />\ninterface Rgb {\n    r: number;\n...'
    },
    {
      specifier: "https://deno.land/std@0.97.0/testing/asserts.ts",
      code: 'import { bold, gray, green, red, stripColor, white } from "../fmt/colors.ts";\nimport { diff, DiffTyp...',
      map: '{"version":3,"file":"asserts.js","sourceRoot":"","sources":["https://deno.land/std@0.97.0/testing/as...',
      declaration: '/// <amd-module name="https://deno.land/std@0.97.0/testing/asserts.ts" />\ninterface Constructor {\n  ...'
    },
    {
      specifier: "https://deno.land/std@0.97.0/testing/_diff.ts",
      code: 'export var DiffType;\n(function (DiffType) {\n    DiffType["removed"] = "removed";\n    DiffType["commo...',
      map: '{"version":3,"file":"_diff.js","sourceRoot":"","sources":["https://deno.land/std@0.97.0/testing/_dif...',
      declaration: '/// <amd-module name="https://deno.land/std@0.97.0/testing/_diff.ts" />\nexport declare enum DiffType...'
    }
  ],
  // ...
}
```

---

### `Deno.emitBundle()`

Before:
```ts
console.log(
  await Deno.emit("https://deno.land/std@0.97.0/testing/asserts.ts", {
    bundle: "module",
  }),
);
```
```js
{
  files: {
    "deno:///bundle.js.map": '{"version":3,"sources":["<https://deno.land/std@0.97.0/fmt/colors.ts>","<https://deno.land/std@0.97....',
    "deno:///bundle.js": "const noColor = globalThis.Deno?.noColor ?? true;\nlet enabled = !noColor;\nfunction code(open, close)..."
  },
  // ...
}
```
After:
```ts
console.log(
  await Deno.emitBundle("https://deno.land/std@0.97.0/testing/asserts.ts"),
);
```
```js
{
  code: "const noColor = globalThis.Deno?.noColor ?? true;\nlet enabled = !noColor;\nfunction code(open, close)...",
  map: '{"version":3,"sources":["<https://deno.land/std@0.97.0/fmt/colors.ts>","<https://deno.land/std@0.97....',
  // ...
}
```
---
cc @kitsonk. This redoes #10767 with errors reported on the module entries instead of as diagnostics.