### PR TITLE
fix(lsp): cannot read config option in windows

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -441,7 +441,15 @@ impl Inner {
         ))
       }?;
 
-      let config_file = ConfigFile::read(config_url.path())?;
+      let config_file = {
+        let buffer = config_url
+          .to_file_path()
+          .map_err(|_| anyhow!("Bad uri: \"{}\"", config_url))?;
+        let path = buffer
+          .to_str()
+          .ok_or_else(|| anyhow!("Bad uri: \"{}\"", config_url))?;
+        ConfigFile::read(path)?
+      };
       let (value, maybe_ignored_options) = config_file.as_compiler_options()?;
       tsconfig.merge(&value);
       self.maybe_config_uri = Some(config_url);

--- a/cli/tests/lsp/lib.tsconfig.json
+++ b/cli/tests/lsp/lib.tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "lib": ["deno.ns", "deno.unstable", "dom"]
+  }
+}


### PR DESCRIPTION
Currently lsp can't read correct --config option in windows. It is a regression because 1.7 didn't have this problem.

Close #10747.