### PR TITLE
feat: add FsWatcher interface (deprecates .return(), adds .close() instead)

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1949,6 +1949,25 @@ declare namespace Deno {
     paths: string[];
   }
 
+  /**
+   * FsWatcher is returned by `Deno.watchFs` function when you start watching
+   * the file system. You can iterate over this interface to get the file
+   * system events, and also You can stop watching the file system by calling
+   * `.close()` method.
+   */
+  export interface FsWatcher extends AsyncIterable<FsEvent> {
+    /** The rid of the `FsWatcher`. */
+    readonly rid: number;
+    /** Stops watching filesystem and closes the watcher resource. */
+    close(): void;
+    /** @deprecated
+     * Stops watching filesystem and closes the watcher resource.
+     * Will be removed at 2.0.
+     */
+    return?(value?: any): Promise<IteratorResult<FsEvent>>;
+    [Symbol.asyncIterator](): AsyncIterableIterator<FsEvent>;
+  }
+
   /** Watch for file system events against one or more `paths`, which can be files
    * or directories.  These paths must exist already.  One user action (e.g.
    * `touch test.file`) can  generate multiple file system events.  Likewise,
@@ -1967,15 +1986,13 @@ declare namespace Deno {
    *
    * Requires `allow-read` permission.
    *
-   * Call `watcher.return()` to stop watching.
+   * Call `watcher.close()` to stop watching.
    *
    * ```ts
    * const watcher = Deno.watchFs("/");
    *
    * setTimeout(() => {
-   *   if (watcher.return) {
-   *     watcher.return();
-   *   }
+   *   watcher.close();
    * }, 5000);
    *
    * for await (const event of watcher) {
@@ -1986,7 +2003,7 @@ declare namespace Deno {
   export function watchFs(
     paths: string | string[],
     options?: { recursive: boolean },
-  ): AsyncIterableIterator<FsEvent>;
+  ): FsWatcher;
 
   export class Process<T extends RunOptions = RunOptions> {
     readonly rid: number;

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1952,16 +1952,16 @@ declare namespace Deno {
   /**
    * FsWatcher is returned by `Deno.watchFs` function when you start watching
    * the file system. You can iterate over this interface to get the file
-   * system events, and also You can stop watching the file system by calling
+   * system events, and also you can stop watching the file system by calling
    * `.close()` method.
    */
   export interface FsWatcher extends AsyncIterable<FsEvent> {
-    /** The rid of the `FsWatcher`. */
+    /** The resource id of the `FsWatcher`. */
     readonly rid: number;
-    /** Stops watching filesystem and closes the watcher resource. */
+    /** Stops watching the file system and closes the watcher resource. */
     close(): void;
     /** @deprecated
-     * Stops watching filesystem and closes the watcher resource.
+     * Stops watching the file system and closes the watcher resource.
      * Will be removed at 2.0.
      */
     return?(value?: any): Promise<IteratorResult<FsEvent>>;

--- a/runtime/js/40_fs_events.js
+++ b/runtime/js/40_fs_events.js
@@ -33,9 +33,15 @@
       }
     }
 
+    // TODO(kt3k): This is deprecated. Will be removed in v2.0.
+    // See https://github.com/denoland/deno/issues/10577 for details
     return(value) {
       core.close(this.rid);
       return Promise.resolve({ value, done: true });
+    }
+
+    close() {
+      core.close(this.rid);
     }
 
     [Symbol.asyncIterator]() {


### PR DESCRIPTION
This PR adds `FsWatcher` interface to stable builtin APIs as suggested in #10577. This deprecates `.return?()` method of FsWatcher and instead adds `.close()`. The purpose of this change is to align the API design to other async iterable APIs such as .listen(), listenDatagram() .serveHttp(), .signal().
