### PR TITLE
fix(lsp): updates to workspace config are processed sync

### DIFF
--- a/cli/tests/lsp/initialize_params_did_config_change.json
+++ b/cli/tests/lsp/initialize_params_did_config_change.json
@@ -1,0 +1,62 @@
+{
+  "processId": 0,
+  "clientInfo": {
+    "name": "test-harness",
+    "version": "1.0.0"
+  },
+  "rootUri": null,
+  "initializationOptions": {
+    "enable": true,
+    "codeLens": {
+      "implementations": true,
+      "references": true
+    },
+    "importMap": null,
+    "lint": true,
+    "suggest": {
+      "autoImports": true,
+      "completeFunctionCalls": false,
+      "names": true,
+      "paths": true,
+      "imports": {
+        "hosts": {
+          "http://localhost:4545/": false
+        }
+      }
+    },
+    "unstable": false
+  },
+  "capabilities": {
+    "textDocument": {
+      "codeAction": {
+        "codeActionLiteralSupport": {
+          "codeActionKind": {
+            "valueSet": [
+              "quickfix"
+            ]
+          }
+        },
+        "isPreferredSupport": true,
+        "dataSupport": true,
+        "resolveSupport": {
+          "properties": [
+            "edit"
+          ]
+        }
+      },
+      "foldingRange": {
+        "lineFoldingOnly": true
+      },
+      "synchronization": {
+        "dynamicRegistration": true,
+        "willSave": true,
+        "willSaveWaitUntil": true,
+        "didSave": true
+      }
+    },
+    "workspace": {
+      "configuration": true,
+      "workspaceFolders": true
+    }
+  }
+}


### PR DESCRIPTION
When working on a new feature, I discovered a bug where when you make a change to the configuration, some aspects of that change wouldn't be reflected until the server was restarted or the next configuration change.  This was because the workspace configuration was being processed under another thread while the main thread was reading the previous configuration to update features in the LSP.

This now processes the workspace configuration immediately, but processes updates to individual specifier settings in the other thread, which still avoids the deadlock issue which required us breaking it out.