### PR TITLE
fix(#10815): lsp only responds to formatting for md, json, jsonc

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -178,33 +178,7 @@ pub fn map_content_type(
   if let Some(content_type) = maybe_content_type {
     let mut content_types = content_type.split(';');
     let content_type = content_types.next().unwrap();
-    let media_type = match content_type.trim().to_lowercase().as_ref() {
-      "application/typescript"
-      | "text/typescript"
-      | "video/vnd.dlna.mpeg-tts"
-      | "video/mp2t"
-      | "application/x-typescript" => {
-        map_js_like_extension(specifier, MediaType::TypeScript)
-      }
-      "application/javascript"
-      | "text/javascript"
-      | "application/ecmascript"
-      | "text/ecmascript"
-      | "application/x-javascript"
-      | "application/node" => {
-        map_js_like_extension(specifier, MediaType::JavaScript)
-      }
-      "text/jsx" => MediaType::Jsx,
-      "text/tsx" => MediaType::Tsx,
-      "application/json" | "text/json" => MediaType::Json,
-      "application/wasm" => MediaType::Wasm,
-      // Handle plain and possibly webassembly
-      "text/plain" | "application/octet-stream" => MediaType::from(specifier),
-      _ => {
-        debug!("unknown content type: {}", content_type);
-        MediaType::Unknown
-      }
-    };
+    let media_type = MediaType::from_content_type(specifier, content_type);
     let charset = content_types
       .map(str::trim)
       .find_map(|s| s.strip_prefix("charset="))
@@ -213,55 +187,6 @@ pub fn map_content_type(
     (media_type, charset)
   } else {
     (MediaType::from(specifier), None)
-  }
-}
-
-/// Used to augment media types by using the path part of a module specifier to
-/// resolve to a more accurate media type.
-fn map_js_like_extension(
-  specifier: &ModuleSpecifier,
-  default: MediaType,
-) -> MediaType {
-  let path = if specifier.scheme() == "file" {
-    if let Ok(path) = specifier.to_file_path() {
-      path
-    } else {
-      PathBuf::from(specifier.path())
-    }
-  } else {
-    PathBuf::from(specifier.path())
-  };
-  match path.extension() {
-    None => default,
-    Some(os_str) => match os_str.to_str() {
-      None => default,
-      Some("jsx") => MediaType::Jsx,
-      Some("tsx") => MediaType::Tsx,
-      // Because DTS files do not have a separate media type, or a unique
-      // extension, we have to "guess" at those things that we consider that
-      // look like TypeScript, and end with `.d.ts` are DTS files.
-      Some("ts") => {
-        if default == MediaType::TypeScript {
-          match path.file_stem() {
-            None => default,
-            Some(os_str) => {
-              if let Some(file_stem) = os_str.to_str() {
-                if file_stem.ends_with(".d") {
-                  MediaType::Dts
-                } else {
-                  default
-                }
-              } else {
-                default
-              }
-            }
-          }
-        } else {
-          default
-        }
-      }
-      Some(_) => default,
-    },
   }
 }
 

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -559,6 +559,7 @@ mod tests {
   use crate::http_cache::HttpCache;
   use crate::lsp::analysis;
   use crate::lsp::documents::DocumentCache;
+  use crate::lsp::documents::LanguageId;
   use crate::lsp::sources::Sources;
   use crate::media_type::MediaType;
   use deno_core::resolve_url;
@@ -567,15 +568,15 @@ mod tests {
   use tempfile::TempDir;
 
   fn mock_state_snapshot(
-    fixtures: &[(&str, &str, i32)],
+    fixtures: &[(&str, &str, i32, LanguageId)],
     source_fixtures: &[(&str, &str)],
     location: &Path,
   ) -> language_server::StateSnapshot {
     let mut documents = DocumentCache::default();
-    for (specifier, source, version) in fixtures {
+    for (specifier, source, version, language_id) in fixtures {
       let specifier =
         resolve_url(specifier).expect("failed to create specifier");
-      documents.open(specifier.clone(), *version, source);
+      documents.open(specifier.clone(), *version, language_id.clone(), source);
       let media_type = MediaType::from(&specifier);
       let parsed_module =
         analysis::parse_module(&specifier, source, &media_type).unwrap();
@@ -608,7 +609,7 @@ mod tests {
   }
 
   fn setup(
-    documents: &[(&str, &str, i32)],
+    documents: &[(&str, &str, i32, LanguageId)],
     sources: &[(&str, &str)],
   ) -> language_server::StateSnapshot {
     let temp_dir = TempDir::new().expect("could not create temp dir");
@@ -885,8 +886,13 @@ mod tests {
     };
     let state_snapshot = setup(
       &[
-        ("file:///a/b/c.ts", "import * as d from \"h\"", 1),
-        ("file:///a/c.ts", r#""#, 1),
+        (
+          "file:///a/b/c.ts",
+          "import * as d from \"h\"",
+          1,
+          LanguageId::TypeScript,
+        ),
+        ("file:///a/c.ts", r#""#, 1, LanguageId::TypeScript),
       ],
       &[("https://deno.land/x/a/b/c.ts", "console.log(1);\n")],
     );

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -3,6 +3,7 @@
 use super::analysis;
 use super::text::LineIndex;
 
+use deno_core::error::anyhow;
 use deno_core::error::custom_error;
 use deno_core::error::AnyError;
 use deno_core::error::Context;
@@ -10,6 +11,37 @@ use deno_core::ModuleSpecifier;
 use lspower::lsp::TextDocumentContentChangeEvent;
 use std::collections::HashMap;
 use std::ops::Range;
+use std::str::FromStr;
+
+/// A representation of the language id sent from the LSP client, which is used
+/// to determine how the document is handled within the language server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LanguageId {
+  JavaScript,
+  Jsx,
+  TypeScript,
+  Tsx,
+  Json,
+  JsonC,
+  Markdown,
+}
+
+impl FromStr for LanguageId {
+  type Err = AnyError;
+
+  fn from_str(s: &str) -> Result<Self, AnyError> {
+    match s {
+      "javascript" => Ok(Self::JavaScript),
+      "javascriptreact" => Ok(Self::Jsx),
+      "typescript" => Ok(Self::TypeScript),
+      "typescriptreact" => Ok(Self::Tsx),
+      "json" => Ok(Self::Json),
+      "jsonc" => Ok(Self::JsonC),
+      "markdown" => Ok(Self::Markdown),
+      _ => Err(anyhow!("Unsupported language id: {}", s)),
+    }
+  }
+}
 
 #[derive(Debug, PartialEq, Eq)]
 enum IndexValid {
@@ -29,6 +61,7 @@ impl IndexValid {
 #[derive(Debug, Clone)]
 pub struct DocumentData {
   bytes: Option<Vec<u8>>,
+  language_id: LanguageId,
   line_index: Option<LineIndex>,
   specifier: ModuleSpecifier,
   dependencies: Option<HashMap<String, analysis::Dependency>>,
@@ -36,9 +69,15 @@ pub struct DocumentData {
 }
 
 impl DocumentData {
-  pub fn new(specifier: ModuleSpecifier, version: i32, source: &str) -> Self {
+  pub fn new(
+    specifier: ModuleSpecifier,
+    version: i32,
+    language_id: LanguageId,
+    source: &str,
+  ) -> Self {
     Self {
       bytes: Some(source.as_bytes().to_owned()),
+      language_id,
       line_index: Some(LineIndex::new(source)),
       specifier,
       dependencies: None,
@@ -150,6 +189,27 @@ impl DocumentCache {
     doc.dependencies.clone()
   }
 
+  /// Determines if the specifier should be processed for diagnostics and other
+  /// related language server features.
+  pub fn is_diagnosable(&self, specifier: &ModuleSpecifier) -> bool {
+    if let Some(doc_data) = self.docs.get(specifier) {
+      matches!(
+        doc_data.language_id,
+        LanguageId::JavaScript
+          | LanguageId::Jsx
+          | LanguageId::TypeScript
+          | LanguageId::Tsx
+      )
+    } else {
+      false
+    }
+  }
+
+  /// Determines if the specifier can be processed for formatting.
+  pub fn is_formattable(&self, specifier: &ModuleSpecifier) -> bool {
+    self.docs.contains_key(specifier)
+  }
+
   pub fn len(&self) -> usize {
     self.docs.len()
   }
@@ -159,10 +219,16 @@ impl DocumentCache {
     doc.line_index.clone()
   }
 
-  pub fn open(&mut self, specifier: ModuleSpecifier, version: i32, text: &str) {
+  pub fn open(
+    &mut self,
+    specifier: ModuleSpecifier,
+    version: i32,
+    language_id: LanguageId,
+    source: &str,
+  ) {
     self.docs.insert(
       specifier.clone(),
-      DocumentData::new(specifier, version, text),
+      DocumentData::new(specifier, version, language_id, source),
     );
   }
 
@@ -219,7 +285,12 @@ mod tests {
     let mut document_cache = DocumentCache::default();
     let specifier = resolve_url("file:///a/b.ts").unwrap();
     let missing_specifier = resolve_url("file:///a/c.ts").unwrap();
-    document_cache.open(specifier.clone(), 1, "console.log(\"Hello Deno\");\n");
+    document_cache.open(
+      specifier.clone(),
+      1,
+      LanguageId::TypeScript,
+      "console.log(\"Hello Deno\");\n",
+    );
     assert!(document_cache.contains_key(&specifier));
     assert!(!document_cache.contains_key(&missing_specifier));
   }
@@ -228,7 +299,12 @@ mod tests {
   fn test_document_cache_change() {
     let mut document_cache = DocumentCache::default();
     let specifier = resolve_url("file:///a/b.ts").unwrap();
-    document_cache.open(specifier.clone(), 1, "console.log(\"Hello deno\");\n");
+    document_cache.open(
+      specifier.clone(),
+      1,
+      LanguageId::TypeScript,
+      "console.log(\"Hello deno\");\n",
+    );
     document_cache
       .change(
         &specifier,
@@ -259,7 +335,12 @@ mod tests {
   fn test_document_cache_change_utf16() {
     let mut document_cache = DocumentCache::default();
     let specifier = resolve_url("file:///a/b.ts").unwrap();
-    document_cache.open(specifier.clone(), 1, "console.log(\"Hello 🦕\");\n");
+    document_cache.open(
+      specifier.clone(),
+      1,
+      LanguageId::TypeScript,
+      "console.log(\"Hello 🦕\");\n",
+    );
     document_cache
       .change(
         &specifier,

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -194,7 +194,17 @@ impl DocumentCache {
   /// Determines if the specifier should be processed for diagnostics and other
   /// related language server features.
   pub fn is_diagnosable(&self, specifier: &ModuleSpecifier) -> bool {
-    if let Some(doc_data) = self.docs.get(specifier) {
+    if specifier.scheme() != "file" {
+      // otherwise we look at the media type for the specifier.
+      matches!(
+        MediaType::from(specifier),
+        MediaType::JavaScript
+          | MediaType::Jsx
+          | MediaType::TypeScript
+          | MediaType::Tsx
+          | MediaType::Dts
+      )
+    } else if let Some(doc_data) = self.docs.get(specifier) {
       // if the document is in the document cache, then use the client provided
       // language id to determine if the specifier is diagnosable.
       matches!(
@@ -205,15 +215,7 @@ impl DocumentCache {
           | LanguageId::Tsx
       )
     } else {
-      // otherwise we look at the media type for the specifier.
-      matches!(
-        MediaType::from(specifier),
-        MediaType::JavaScript
-          | MediaType::Jsx
-          | MediaType::TypeScript
-          | MediaType::Tsx
-          | MediaType::Dts
-      )
+      false
     }
   }
 

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2566,6 +2566,7 @@ mod tests {
   use crate::http_util::HeadersMap;
   use crate::lsp::analysis;
   use crate::lsp::documents::DocumentCache;
+  use crate::lsp::documents::LanguageId;
   use crate::lsp::sources::Sources;
   use crate::lsp::text::LineIndex;
   use std::path::Path;
@@ -2573,14 +2574,14 @@ mod tests {
   use tempfile::TempDir;
 
   fn mock_state_snapshot(
-    fixtures: &[(&str, &str, i32)],
+    fixtures: &[(&str, &str, i32, LanguageId)],
     location: &Path,
   ) -> StateSnapshot {
     let mut documents = DocumentCache::default();
-    for (specifier, source, version) in fixtures {
+    for (specifier, source, version, language_id) in fixtures {
       let specifier =
         resolve_url(specifier).expect("failed to create specifier");
-      documents.open(specifier.clone(), *version, source);
+      documents.open(specifier.clone(), *version, language_id.clone(), source);
       let media_type = MediaType::from(&specifier);
       if let Ok(parsed_module) =
         analysis::parse_module(&specifier, source, &media_type)
@@ -2605,7 +2606,7 @@ mod tests {
   fn setup(
     debug: bool,
     config: Value,
-    sources: &[(&str, &str, i32)],
+    sources: &[(&str, &str, i32, LanguageId)],
   ) -> (JsRuntime, StateSnapshot, PathBuf) {
     let temp_dir = TempDir::new().expect("could not create temp dir");
     let location = temp_dir.path().join("deps");
@@ -2688,7 +2689,12 @@ mod tests {
         "module": "esnext",
         "noEmit": true,
       }),
-      &[("file:///a.ts", r#"console.log("hello deno");"#, 1)],
+      &[(
+        "file:///a.ts",
+        r#"console.log("hello deno");"#,
+        1,
+        LanguageId::TypeScript,
+      )],
     );
     let specifier = resolve_url("file:///a.ts").expect("could not resolve url");
     let result = request(
@@ -2733,7 +2739,12 @@ mod tests {
         "lib": ["esnext", "dom", "deno.ns"],
         "noEmit": true,
       }),
-      &[("file:///a.ts", r#"console.log(document.location);"#, 1)],
+      &[(
+        "file:///a.ts",
+        r#"console.log(document.location);"#,
+        1,
+        LanguageId::TypeScript,
+      )],
     );
     let specifier = resolve_url("file:///a.ts").expect("could not resolve url");
     let result = request(
@@ -2766,6 +2777,7 @@ mod tests {
         console.log(b);
       "#,
         1,
+        LanguageId::TypeScript,
       )],
     );
     let specifier = resolve_url("file:///a.ts").expect("could not resolve url");
@@ -2795,6 +2807,7 @@ mod tests {
         import { A } from ".";
         "#,
         1,
+        LanguageId::TypeScript,
       )],
     );
     let specifier = resolve_url("file:///a.ts").expect("could not resolve url");
@@ -2848,6 +2861,7 @@ mod tests {
         console.log(b);
       "#,
         1,
+        LanguageId::TypeScript,
       )],
     );
     let specifier = resolve_url("file:///a.ts").expect("could not resolve url");
@@ -2884,6 +2898,7 @@ mod tests {
         import * as test from
       "#,
         1,
+        LanguageId::TypeScript,
       )],
     );
     let specifier = resolve_url("file:///a.ts").expect("could not resolve url");
@@ -2941,7 +2956,12 @@ mod tests {
         "lib": ["deno.ns", "deno.window"],
         "noEmit": true,
       }),
-      &[("file:///a.ts", r#"const url = new URL("b.js", import."#, 1)],
+      &[(
+        "file:///a.ts",
+        r#"const url = new URL("b.js", import."#,
+        1,
+        LanguageId::TypeScript,
+      )],
     );
     let specifier = resolve_url("file:///a.ts").expect("could not resolve url");
     let result = request(
@@ -2998,6 +3018,7 @@ mod tests {
           }
         "#,
         1,
+        LanguageId::TypeScript,
       )],
     );
     let cache = HttpCache::new(&location);
@@ -3099,7 +3120,7 @@ mod tests {
         "lib": ["deno.ns", "deno.window"],
         "noEmit": true,
       }),
-      &[("file:///a.ts", fixture, 1)],
+      &[("file:///a.ts", fixture, 1, LanguageId::TypeScript)],
     );
     let specifier = resolve_url("file:///a.ts").expect("could not resolve url");
     let result = request(

--- a/cli/tests/integration_tests_lsp.rs
+++ b/cli/tests/integration_tests_lsp.rs
@@ -2119,6 +2119,56 @@ fn lsp_format_json() {
 }
 
 #[test]
+fn lsp_json_no_diagnostics() {
+  let mut client = init("initialize_params.json");
+  client
+    .write_notification(
+      "textDocument/didOpen",
+      json!({
+        "textDocument": {
+          "uri": "file:///a/file.json",
+          "languageId": "json",
+          "version": 1,
+          "text": "{\"key\":\"value\"}"
+        }
+      }),
+    )
+    .unwrap();
+
+  let (maybe_res, maybe_err) = client
+    .write_request(
+      "textDocument/semanticTokens/full",
+      json!({
+        "textDocument": {
+          "uri": "file:///a/file.json"
+        }
+      }),
+    )
+    .unwrap();
+  assert!(maybe_err.is_none());
+  assert_eq!(maybe_res, Some(json!(null)));
+
+  let (maybe_res, maybe_err) = client
+    .write_request::<_, _, Value>(
+      "textDocument/hover",
+      json!({
+        "textDocument": {
+          "uri": "file:///a/file.json"
+        },
+        "position": {
+          "line": 0,
+          "character": 3
+        }
+      }),
+    )
+    .unwrap();
+  assert!(maybe_err.is_none());
+  assert_eq!(maybe_res, Some(json!(null)));
+
+  shutdown(&mut client);
+}
+
+#[test]
 fn lsp_format_markdown() {
   let mut client = init("initialize_params.json");
   client
@@ -2170,6 +2220,56 @@ fn lsp_format_markdown() {
       }
     ]))
   );
+  shutdown(&mut client);
+}
+
+#[test]
+fn lsp_markdown_no_diagnostics() {
+  let mut client = init("initialize_params.json");
+  client
+    .write_notification(
+      "textDocument/didOpen",
+      json!({
+        "textDocument": {
+          "uri": "file:///a/file.md",
+          "languageId": "markdown",
+          "version": 1,
+          "text": "# Hello World"
+        }
+      }),
+    )
+    .unwrap();
+
+  let (maybe_res, maybe_err) = client
+    .write_request(
+      "textDocument/semanticTokens/full",
+      json!({
+        "textDocument": {
+          "uri": "file:///a/file.md"
+        }
+      }),
+    )
+    .unwrap();
+  assert!(maybe_err.is_none());
+  assert_eq!(maybe_res, Some(json!(null)));
+
+  let (maybe_res, maybe_err) = client
+    .write_request::<_, _, Value>(
+      "textDocument/hover",
+      json!({
+        "textDocument": {
+          "uri": "file:///a/file.md"
+        },
+        "position": {
+          "line": 0,
+          "character": 3
+        }
+      }),
+    )
+    .unwrap();
+  assert!(maybe_err.is_none());
+  assert_eq!(maybe_res, Some(json!(null)));
+
   shutdown(&mut client);
 }
 


### PR DESCRIPTION
Fixes #10815

This refactors how we determine if we respond to diagnostics, using what is provided by the language server client and doesn't respond for "diagnostic" related APIs for markdown JSON, JSONC.

ping @satyarohith 