### PR TITLE
ci(mac): remove gnu tar installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,14 +169,6 @@ jobs:
           cargo --version
           deno --version
 
-      # Work around https://github.com/actions/cache/issues/403 by using GNU tar
-      # instead of BSD tar.
-      - name: Install GNU tar
-        if: matrix.os == 'macos-10.15'
-        run: |
-          brew install gnu-tar
-          echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
-
       - name: Cache Cargo home
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
`gnu tar` is now pre-installed on mac runners. No need of explicit installation step anymore.

CI log shows this:
```
Warning: gnu-tar 1.34 is already installed and up-to-date.
To reinstall 1.34, run:
  brew reinstall gnu-tar
```
ref: https://github.com/denoland/deno/runs/2728417623

Merge on approval