### PR TITLE
fix: hang in op_http_next_request

### DIFF
--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -339,3 +339,37 @@ unitTest(
     await promise;
   },
 );
+
+unitTest(
+  { perms: { net: true } },
+  async function httpServerNextRequestResolvesOnClose() {
+    const delay = (n: number) =>
+      new Promise((resolve) => setTimeout(resolve, n));
+    const httpConnList: Deno.HttpConn[] = [];
+
+    async function serve(l: Deno.Listener) {
+      for await (const conn of l) {
+        (async () => {
+          const c = Deno.serveHttp(conn);
+          httpConnList.push(c);
+          for await (const { respondWith } of c) {
+            respondWith(new Response("hello"));
+          }
+        })();
+      }
+    }
+
+    const l = Deno.listen({ port: 4500 });
+    serve(l);
+
+    await delay(300);
+    let res = await fetch("http://localhost:4500/");
+    const _text = await res.text();
+
+    // Close connection and listener.
+    httpConnList.forEach((conn) => conn.close());
+    l.close();
+
+    await delay(300);
+  },
+);

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -363,7 +363,7 @@ unitTest(
     serve(l);
 
     await delay(300);
-    let res = await fetch("http://localhost:4500/");
+    const res = await fetch("http://localhost:4500/");
     const _text = await res.text();
 
     // Close connection and listener.

--- a/runtime/ops/http.rs
+++ b/runtime/ops/http.rs
@@ -505,8 +505,7 @@ async fn op_http_response_write(
 
     send_data_fut.poll_unpin(cx).map_err(AnyError::from)
   })
-  .await
-  .unwrap(); // panic on send_data error
+  .await?;
 
   Ok(())
 }


### PR DESCRIPTION
This commit adds "CancelHandle" to "ConnResource" and changes
"op_http_next_request" to await for the cancel signal. In turn
when async iterating over "Deno.HttpConn" the iterator breaks
upon closing of the resource.

Ref https://github.com/denoland/deno/issues/10508