### PR TITLE
feat(runtime-js.performance) - add timeOrigin

### DIFF
--- a/extensions/timers/02_performance.js
+++ b/extensions/timers/02_performance.js
@@ -8,6 +8,8 @@
   const customInspect = Symbol.for("Deno.customInspect");
   let performanceEntries = [];
 
+  const timeOrigin = opNow();
+
   function findMostRecent(
     name,
     type,
@@ -211,6 +213,10 @@
       if (key != illegalConstructorKey) {
         throw new TypeError("Illegal constructor.");
       }
+    }
+
+    get timeOrigin() {
+      return timeOrigin;
     }
 
     clearMarks(markName) {

--- a/extensions/timers/02_performance.js
+++ b/extensions/timers/02_performance.js
@@ -2,13 +2,12 @@
 "use strict";
 
 ((window) => {
+  const { timeSinceEpoch } = window;
   const { webidl, structuredClone } = window.__bootstrap;
   const { opNow } = window.__bootstrap.timers;
   const illegalConstructorKey = Symbol("illegalConstructorKey");
   const customInspect = Symbol.for("Deno.customInspect");
   let performanceEntries = [];
-
-  const timeOrigin = opNow();
 
   function findMostRecent(
     name,
@@ -216,7 +215,7 @@
     }
 
     get timeOrigin() {
-      return timeOrigin;
+      return timeSinceEpoch;
     }
 
     clearMarks(markName) {

--- a/extensions/timers/02_performance.js
+++ b/extensions/timers/02_performance.js
@@ -7,6 +7,11 @@
   const illegalConstructorKey = Symbol("illegalConstructorKey");
   const customInspect = Symbol.for("Deno.customInspect");
   let performanceEntries = [];
+  let timeSinceEpoch;
+
+  function setTimeOrigin(timestamp) {
+    timeSinceEpoch = timestamp;
+  }
 
   function findMostRecent(
     name,
@@ -364,5 +369,6 @@
     PerformanceMeasure,
     Performance,
     performance,
+    setTimeOrigin,
   };
 })(this);

--- a/extensions/timers/02_performance.js
+++ b/extensions/timers/02_performance.js
@@ -2,7 +2,6 @@
 "use strict";
 
 ((window) => {
-  const { timeSinceEpoch } = window;
   const { webidl, structuredClone } = window.__bootstrap;
   const { opNow } = window.__bootstrap.timers;
   const illegalConstructorKey = Symbol("illegalConstructorKey");

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -428,6 +428,8 @@ delete Object.prototype.__proto__;
     if (hasBootstrapped) {
       throw new Error("Worker runtime already bootstrapped");
     }
+
+    performance.setTimeOrigin(Date.now());
     // Remove bootstrapping data from the global scope
     delete globalThis.__bootstrap;
     delete globalThis.bootstrap;
@@ -475,7 +477,6 @@ delete Object.prototype.__proto__;
       resources: core.resources,
       close: core.close,
       memoryUsage: core.memoryUsage,
-      timeSinceEpoch: new Date(),
       ...denoNs,
     };
     Object.defineProperties(finalDenoNs, {

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -475,6 +475,7 @@ delete Object.prototype.__proto__;
       resources: core.resources,
       close: core.close,
       memoryUsage: core.memoryUsage,
+      timeSinceEpoch: new Date(),
       ...denoNs,
     };
     Object.defineProperties(finalDenoNs, {

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -242,7 +242,6 @@
       "Performance interface: attribute timeOrigin",
       "Performance interface: operation toJSON()",
       "Stringification of performance",
-      "Performance interface: performance must inherit property \"timeOrigin\" with the proper type",
       "Performance interface: performance must inherit property \"toJSON()\" with the proper type",
       "Performance interface: default toJSON operation on performance",
       "Window interface: attribute performance"


### PR DESCRIPTION
Resolves: #10837

Currently this is a naive timestamp while the browser will inject a `HighResTimestamp` would this be better achieved by using something like [`SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html) and have it as an `op_sync` call?