### PR TITLE
github(probot): Set specific comment for stale PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -20,3 +20,9 @@ markComment: >
   This issue has been [automatically marked as stale](https://probot.github.io/apps/stale/#how-it-works)
   because it has not had recent activity. It will be closed in 7 days if no
   further activity occurs. Thank you for your contributions.
+
+pulls:
+  markComment: >
+    This pull request has been [automatically marked as stale](https://probot.github.io/apps/stale/#how-it-works)
+    because it has not had recent activity. It will be closed in 7 days if no
+    further activity occurs. Thank you for your contributions.


### PR DESCRIPTION
This makes [stale bot](https://probot.github.io/apps/stale) comment with a different message on pull requests.

Before, it commented with _This **issue** has been automatically marked as stale_ which is wrong in the context of a pull request.