### PR TITLE
tests: run wpt scripts with Deno.core.evalContext

### DIFF
--- a/tools/util.js
+++ b/tools/util.js
@@ -3,10 +3,11 @@ import {
   dirname,
   fromFileUrl,
   join,
+  toFileUrl,
 } from "https://deno.land/std@0.84.0/path/mod.ts";
-export { dirname, join };
+export { dirname, fromFileUrl, join, toFileUrl };
 export { existsSync } from "https://deno.land/std@0.84.0/fs/mod.ts";
-export { readLines } from "https://deno.land/std@0.84.0/io/mod.ts";
+export { readLines } from "https://deno.land/std@0.97.0/io/mod.ts";
 export { delay } from "https://deno.land/std@0.84.0/async/delay.ts";
 
 export const ROOT_PATH = dirname(dirname(fromFileUrl(import.meta.url)));

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -634,7 +634,7 @@
     "jsapi": {
       "constructor": {
         "compile.any.html": true,
-        "instantiate-bad-imports.any.html": false,
+        "instantiate-bad-imports.any.html": true,
         "instantiate.any.html": [
           "Synchronous options handling: Buffer argument"
         ],
@@ -653,21 +653,15 @@
         "Table interface: operation set(unsigned long, optional any)"
       ],
       "instance": {
-        "constructor-bad-imports.any.html": false,
+        "constructor-bad-imports.any.html": true,
         "constructor-caching.any.html": true,
         "constructor.any.html": true,
-        "exports.any.html": [
-          "Setting (sloppy mode)"
-        ],
+        "exports.any.html": true,
         "toString.any.html": true
       },
-      "interface.any.html": [
-        "WebAssembly: property descriptor"
-      ],
+      "interface.any.html": true,
       "memory": {
-        "buffer.any.html": [
-          "Setting (sloppy mode)"
-        ],
+        "buffer.any.html": true,
         "constructor.any.html": true,
         "grow.any.html": true,
         "toString.any.html": true,
@@ -687,9 +681,7 @@
         "constructor.any.html": true,
         "get-set.any.html": true,
         "grow.any.html": true,
-        "length.any.html": [
-          "Setting (sloppy mode)"
-        ],
+        "length.any.html": true,
         "toString.any.html": true,
         "constructor-reftypes.tentative.any.html": [
           "initialize externref table with default value",

--- a/tools/wpt/runner.ts
+++ b/tools/wpt/runner.ts
@@ -134,9 +134,10 @@ async function generateBundle(location: URL): Promise<string> {
     } else if (src) {
       const url = new URL(src, location);
       const res = await fetch(url);
-      if (!res.ok) throw new TypeError("Failed to bundle!");
-      const contents = await res.text();
-      scriptContents.push([url.href, contents]);
+      if (res.ok) {
+        const contents = await res.text();
+        scriptContents.push([url.href, contents]);
+      }
     } else {
       const url = new URL(`#${inlineScriptCount}`, location);
       inlineScriptCount++;

--- a/tools/wpt/runner.ts
+++ b/tools/wpt/runner.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
-import { delay, join, readLines, ROOT_PATH } from "../util.js";
+import { delay, join, readLines, ROOT_PATH, toFileUrl } from "../util.js";
 import { assert, ManifestTestOptions, release, runPy } from "./utils.ts";
 import { DOMParser } from "https://deno.land/x/deno_dom@v0.1.3-alpha2/deno-dom-wasm.ts";
 
@@ -122,20 +122,31 @@ async function generateBundle(location: URL): Promise<string> {
   assert(doc, "document should have been parsed");
   const scripts = doc.getElementsByTagName("script");
   const scriptContents = [];
+  let inlineScriptCount = 0;
   for (const script of scripts) {
     const src = script.getAttribute("src");
     if (src === "/resources/testharnessreport.js") {
-      scriptContents.push(
-        await Deno.readTextFile(
-          join(ROOT_PATH, "./tools/wpt/testharnessreport.js"),
-        ),
+      const url = toFileUrl(
+        join(ROOT_PATH, "./tools/wpt/testharnessreport.js"),
       );
+      const contents = await Deno.readTextFile(url);
+      scriptContents.push([url.href, contents]);
     } else if (src) {
-      const res = await fetch(new URL(src, location));
-      scriptContents.push(await res.text());
+      const url = new URL(src, location);
+      const res = await fetch(url);
+      if (!res.ok) throw new TypeError("Failed to bundle!");
+      const contents = await res.text();
+      scriptContents.push([url.href, contents]);
     } else {
-      scriptContents.push(script.textContent);
+      const url = new URL(`#${inlineScriptCount}`, location);
+      inlineScriptCount++;
+      scriptContents.push([url.href, script.textContent]);
     }
   }
-  return scriptContents.join("\n");
+
+  return scriptContents.map(([url, contents]) =>
+    `Deno.core.evalContext(${JSON.stringify(contents)}, ${
+      JSON.stringify(url)
+    });`
+  ).join("\n");
 }


### PR DESCRIPTION
This means scripts are now run in script context, and there are better
stack traces.

Also fixes a panic in core related to `Deno.core.evalContext`.