### PR TITLE
chore(wpt/webcrypto): remove irrelevant wpt for non-secure contexts

### DIFF
--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -70,7 +70,6 @@
       "successes_RSASSA-PKCS1-v1_5.https.any.html?21-30": false,
       "successes_RSASSA-PKCS1-v1_5.https.any.html?31-last": false
     },
-    "historical.any.html": true,
     "idlharness.https.any.html": [
       "Crypto interface: existence and properties of interface object",
       "Crypto interface object length",


### PR DESCRIPTION
Disables `WebCryptoAPI/historical.any.html`. It was passing on main because of the missing SubtleCrypto implementation.

But fails WPT tests in #9614 

```
 "/WebCryptoAPI/historical.any.html - Non-secure context window does not have access to crypto.subtle"
 "/WebCryptoAPI/historical.any.html - Non-secure context window does not have access to CryptoKey"
```