### PR TITLE
chore: optimize USVString webidl converters

### DIFF
--- a/extensions/webidl/00_webidl.js
+++ b/extensions/webidl/00_webidl.js
@@ -331,29 +331,28 @@
   converters.USVString = (V, opts) => {
     const S = converters.DOMString(V, opts);
     const n = S.length;
-    const U = [];
+    let U = "";
     for (let i = 0; i < n; ++i) {
       const c = S.charCodeAt(i);
       if (c < 0xd800 || c > 0xdfff) {
-        U.push(String.fromCodePoint(c));
+        U += String.fromCodePoint(c);
       } else if (0xdc00 <= c && c <= 0xdfff) {
-        U.push(String.fromCodePoint(0xfffd));
+        U += String.fromCodePoint(0xfffd);
       } else if (i === n - 1) {
-        U.push(String.fromCodePoint(0xfffd));
+        U += String.fromCodePoint(0xfffd);
       } else {
         const d = S.charCodeAt(i + 1);
         if (0xdc00 <= d && d <= 0xdfff) {
           const a = c & 0x3ff;
           const b = d & 0x3ff;
-          U.push(String.fromCodePoint((2 << 15) + (2 << 9) * a + b));
+          U += String.fromCodePoint((2 << 15) + (2 << 9) * a + b);
           ++i;
         } else {
-          U.push(String.fromCodePoint(0xfffd));
+          U += String.fromCodePoint(0xfffd);
         }
       }
     }
-
-    return U.join("");
+    return U;
   };
 
   converters.object = (V, opts) => {


### PR DESCRIPTION
This commit optimizes the USVString WebIDL converter. This should solve some of
the perf issue in TextEncoder that the move to encoding in Rust created.
