### PR TITLE
tests: generate and upload wptreport.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,8 +177,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key:
-            a-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
+          key: a-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
 
       # In main branch, always creates fresh cache
       - name: Cache build output (main)
@@ -308,7 +307,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu') && matrix.kind == 'test' && matrix.profile == 'release'
         run: |
           deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts setup
-          deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts run --quiet --release --json=wpt.json
+          deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts run --quiet --release --json=wpt.json --wptreport=wptreport.json
 
       - name: Upload wpt results to dl.deno.land
         if: |
@@ -319,6 +318,7 @@ jobs:
           github.ref == 'refs/heads/main'
         run: |
           gsutil cp ./wpt.json gs://dl.deno.land/wpt/$(git rev-parse HEAD).json
+          gsutil cp ./wptreport.json gs://dl.deno.land/wpt/$(git rev-parse HEAD)-wptreport.json
           echo $(git rev-parse HEAD) > wpt-latest.txt
           gsutil cp wpt-latest.txt gs://dl.deno.land/wpt-latest.txt
 
@@ -407,4 +407,3 @@ jobs:
           rm -rf target/*/examples/
           rm -rf target/*/gn_out/
           rm -rf target/*/*.zip
-

--- a/tools/wpt/testharnessreport.js
+++ b/tools/wpt/testharnessreport.js
@@ -10,6 +10,13 @@ window.add_result_callback(({ message, name, stack, status }) => {
   }
 });
 
-window.add_completion_callback((_tests, _harnessStatus) => {
+window.add_completion_callback((_tests, harnessStatus) => {
+  const data = new TextEncoder().encode(
+    `#$#$#${JSON.stringify(harnessStatus)}\n`,
+  );
+  let bytesWritten = 0;
+  while (bytesWritten < data.byteLength) {
+    bytesWritten += Deno.stderr.writeSync(data.subarray(bytesWritten));
+  }
   Deno.exit(0);
 });


### PR DESCRIPTION
These reports can be consumed by tools like `wptreport` or
https://wpt.fyi. The old style report could be removed in a future PR
when wpt.deno.land is updated.
