### PR TITLE
feat(lsp): add test code lens

### DIFF
--- a/cli/lsp/README.md
+++ b/cli/lsp/README.md
@@ -24,6 +24,7 @@ There are several settings that the language server supports for a workspace:
 - `deno.codeLens.implementations`
 - `deno.codeLens.references`
 - `deno.codeLens.referencesAllFunctions`
+- `deno.codeLens.test`
 - `deno.suggest.completeFunctionCalls`
 - `deno.suggest.names`
 - `deno.suggest.paths`
@@ -33,10 +34,11 @@ There are several settings that the language server supports for a workspace:
 - `deno.lint`
 - `deno.unstable`
 
-There are settings that are support on a per resource basis by the language
+There are settings that are supported on a per resource basis by the language
 server:
 
 - `deno.enable`
+- `deno.codeLens.test`
 
 There are several points in the process where Deno analyzes these settings.
 First, when the `initialize` request from the client, the
@@ -68,7 +70,24 @@ settings.
 If the client does not have the `workspaceConfiguration` capability, the
 language server will assume the workspace setting applies to all resources.
 
-## Custom requests
+## Commands
+
+There are several commands that might be issued by the language server to the
+client, which the client is expected to implement:
+
+- `deno.cache` - This is sent as a resolution code action when there is an
+  un-cached module specifier that is being imported into a module. It will be
+  sent with and argument that contains the resolved specifier as a string to be
+  cached.
+- `deno.showReferences` - This is sent as the command on some code lenses to
+  show locations of references. The arguments contain the specifier that is the
+  subject of the command, the start position of the target and the locations of
+  the references to show.
+- `deno.test` - This is sent as part of a test code lens to, of which the client
+  is expected to run a test based on the arguments, which are the specifier the
+  test is contained in and the name of the test to filter the tests on.
+
+## Requests
 
 The LSP currently supports the following custom requests. A client should
 implement these in order to have a fully functioning client that integrates well
@@ -115,9 +134,9 @@ with Deno:
   }
   ```
 
-## Custom notifications
+## Notifications
 
-There is currently one custom notification that is send from the server to the
+There is currently one custom notification that is sent from the server to the
 client:
 
 - `deno/registryStatus` - when `deno.suggest.imports.autoDiscover` is `true` and

--- a/cli/lsp/code_lens.rs
+++ b/cli/lsp/code_lens.rs
@@ -369,7 +369,6 @@ pub(crate) async fn collect(
   specifier: &ModuleSpecifier,
   language_server: &mut language_server::Inner,
 ) -> Result<Vec<lsp::CodeLens>, AnyError> {
-  log::info!("collect: {}", specifier);
   let mut code_lenses = collect_test(specifier, language_server)?;
   code_lenses.extend(collect_tsc(specifier, language_server).await?);
 

--- a/cli/lsp/code_lens.rs
+++ b/cli/lsp/code_lens.rs
@@ -369,6 +369,7 @@ pub(crate) async fn collect(
   specifier: &ModuleSpecifier,
   language_server: &mut language_server::Inner,
 ) -> Result<Vec<lsp::CodeLens>, AnyError> {
+  log::info!("collect: {}", specifier);
   let mut code_lenses = collect_test(specifier, language_server)?;
   code_lenses.extend(collect_tsc(specifier, language_server).await?);
 

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1113,7 +1113,8 @@ impl Inner {
     let specifier = self.url_map.normalize_url(&params.text_document.uri);
     if !self.documents.is_diagnosable(&specifier)
       || !self.config.specifier_enabled(&specifier)
-      || !self.config.get_workspace_settings().enabled_code_lens()
+      || !(self.config.get_workspace_settings().enabled_code_lens()
+        || self.config.specifier_code_lens_test(&specifier))
     {
       return Ok(None);
     }

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -243,7 +243,10 @@ impl Inner {
   // moment
   /// Searches already cached assets and documents and returns its text
   /// content. If not found, `None` is returned.
-  fn get_text_content(&self, specifier: &ModuleSpecifier) -> Option<String> {
+  pub(crate) fn get_text_content(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<String> {
     if specifier.scheme() == "asset" {
       self
         .assets
@@ -253,6 +256,17 @@ impl Inner {
       self.documents.content(specifier).unwrap()
     } else {
       self.sources.get_source(specifier)
+    }
+  }
+
+  pub(crate) fn get_media_type(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<MediaType> {
+    if specifier.scheme() == "asset" || self.documents.contains_key(specifier) {
+      Some(MediaType::from(specifier))
+    } else {
+      self.sources.get_media_type(specifier)
     }
   }
 
@@ -1105,9 +1119,8 @@ impl Inner {
     }
 
     let mark = self.performance.mark("code_lens", Some(&params));
-    let code_lenses = code_lens::tsc_code_lenses(&specifier, self)
-      .await
-      .map_err(|err| {
+    let code_lenses =
+      code_lens::collect(&specifier, self).await.map_err(|err| {
         error!("Error getting code lenses for \"{}\": {}", specifier, err);
         LspError::internal_error()
       })?;

--- a/cli/tests/integration_tests_lsp.rs
+++ b/cli/tests/integration_tests_lsp.rs
@@ -45,7 +45,15 @@ where
   let (id, method, _) = client.read_request::<Value>().unwrap();
   assert_eq!(method, "workspace/configuration");
   client
-    .write_response(id, json!({ "enable": true }))
+    .write_response(
+      id,
+      json!({
+        "enable": true,
+        "codeLens": {
+          "test": true
+        }
+      }),
+    )
     .unwrap();
 
   let mut diagnostics = vec![];
@@ -1226,6 +1234,76 @@ fn lsp_code_lens_impl() {
       }
     }))
   );
+  shutdown(&mut client);
+}
+
+#[test]
+fn lsp_code_lens_test() {
+  let mut client = init("initialize_params.json");
+  did_open(
+    &mut client,
+    load_fixture("did_open_params_test_code_lens.json"),
+  );
+  let (maybe_res, maybe_err) = client
+    .write_request(
+      "textDocument/codeLens",
+      json!({
+        "textDocument": {
+          "uri": "file:///a/file.ts"
+        }
+      }),
+    )
+    .unwrap();
+  assert!(maybe_err.is_none());
+  assert_eq!(
+    maybe_res,
+    Some(load_fixture("code_lens_response_test.json"))
+  );
+  shutdown(&mut client);
+}
+
+#[test]
+fn lsp_code_lens_test_disabled() {
+  let mut client = init("initialize_params_code_lens_test_disabled.json");
+  client
+    .write_notification(
+      "textDocument/didOpen",
+      load_fixture("did_open_params_test_code_lens.json"),
+    )
+    .unwrap();
+
+  let (id, method, _) = client.read_request::<Value>().unwrap();
+  assert_eq!(method, "workspace/configuration");
+  client
+    .write_response(
+      id,
+      json!({
+        "enable": true,
+        "codeLens": {
+          "test": false
+        }
+      }),
+    )
+    .unwrap();
+
+  let (method, _) = client.read_notification::<Value>().unwrap();
+  assert_eq!(method, "textDocument/publishDiagnostics");
+  let (method, _) = client.read_notification::<Value>().unwrap();
+  assert_eq!(method, "textDocument/publishDiagnostics");
+  let (method, _) = client.read_notification::<Value>().unwrap();
+  assert_eq!(method, "textDocument/publishDiagnostics");
+  let (maybe_res, maybe_err) = client
+    .write_request(
+      "textDocument/codeLens",
+      json!({
+        "textDocument": {
+          "uri": "file:///a/file.ts"
+        }
+      }),
+    )
+    .unwrap();
+  assert!(maybe_err.is_none());
+  assert_eq!(maybe_res, Some(json!([])));
   shutdown(&mut client);
 }
 

--- a/cli/tests/integration_tests_lsp.rs
+++ b/cli/tests/integration_tests_lsp.rs
@@ -1239,7 +1239,7 @@ fn lsp_code_lens_impl() {
 
 #[test]
 fn lsp_code_lens_test() {
-  let mut client = init("initialize_params.json");
+  let mut client = init("initialize_params_code_lens_test.json");
   did_open(
     &mut client,
     load_fixture("did_open_params_test_code_lens.json"),

--- a/cli/tests/lsp/code_lens_response_test.json
+++ b/cli/tests/lsp/code_lens_response_test.json
@@ -1,0 +1,162 @@
+[
+  {
+    "range": {
+      "start": {
+        "line": 4,
+        "character": 5
+      },
+      "end": {
+        "line": 4,
+        "character": 9
+      }
+    },
+    "command": {
+      "title": "▶︎ Run Test",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test a"
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 5,
+        "character": 5
+      },
+      "end": {
+        "line": 5,
+        "character": 9
+      }
+    },
+    "command": {
+      "title": "▶︎ Run Test",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test b"
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 9,
+        "character": 0
+      },
+      "end": {
+        "line": 9,
+        "character": 4
+      }
+    },
+    "command": {
+      "title": "▶︎ Run Test",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test c"
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 13,
+        "character": 0
+      },
+      "end": {
+        "line": 13,
+        "character": 4
+      }
+    },
+    "command": {
+      "title": "▶︎ Run Test",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test d"
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 14,
+        "character": 0
+      },
+      "end": {
+        "line": 14,
+        "character": 5
+      }
+    },
+    "command": {
+      "title": "▶︎ Run Test",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test e"
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 18,
+        "character": 0
+      },
+      "end": {
+        "line": 18,
+        "character": 5
+      }
+    },
+    "command": {
+      "title": "▶︎ Run Test",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test f"
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 19,
+        "character": 0
+      },
+      "end": {
+        "line": 19,
+        "character": 5
+      }
+    },
+    "command": {
+      "title": "▶︎ Run Test",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test g"
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 23,
+        "character": 0
+      },
+      "end": {
+        "line": 23,
+        "character": 5
+      }
+    },
+    "command": {
+      "title": "▶︎ Run Test",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test h"
+      ]
+    }
+  }
+]

--- a/cli/tests/lsp/did_open_params_test_code_lens.json
+++ b/cli/tests/lsp/did_open_params_test_code_lens.json
@@ -1,0 +1,8 @@
+{
+  "textDocument": {
+    "uri": "file:///a/file.ts",
+    "languageId": "typescript",
+    "version": 1,
+    "text": "const { test } = Deno;\nconst { test: test2 } = Deno;\nconst test3 = Deno.test;\n\nDeno.test(\"test a\", () => {});\nDeno.test({\n  name: \"test b\",\n  fn() {},\n});\ntest({\n  name: \"test c\",\n  fn() {},\n});\ntest(\"test d\", () => {});\ntest2({\n  name: \"test e\",\n  fn() {},\n});\ntest2(\"test f\", () => {});\ntest3({\n  name: \"test g\",\n  fn() {},\n});\ntest3(\"test h\", () => {});\n"
+  }
+}

--- a/cli/tests/lsp/initialize_params_code_lens_test.json
+++ b/cli/tests/lsp/initialize_params_code_lens_test.json
@@ -1,0 +1,56 @@
+{
+  "processId": 0,
+  "clientInfo": {
+    "name": "test-harness",
+    "version": "1.0.0"
+  },
+  "rootUri": null,
+  "initializationOptions": {
+    "enable": true,
+    "importMap": null,
+    "lint": true,
+    "suggest": {
+      "autoImports": true,
+      "completeFunctionCalls": false,
+      "names": true,
+      "paths": true,
+      "imports": {
+        "hosts": {}
+      }
+    },
+    "unstable": false
+  },
+  "capabilities": {
+    "textDocument": {
+      "codeAction": {
+        "codeActionLiteralSupport": {
+          "codeActionKind": {
+            "valueSet": [
+              "quickfix"
+            ]
+          }
+        },
+        "isPreferredSupport": true,
+        "dataSupport": true,
+        "resolveSupport": {
+          "properties": [
+            "edit"
+          ]
+        }
+      },
+      "foldingRange": {
+        "lineFoldingOnly": true
+      },
+      "synchronization": {
+        "dynamicRegistration": true,
+        "willSave": true,
+        "willSaveWaitUntil": true,
+        "didSave": true
+      }
+    },
+    "workspace": {
+      "configuration": true,
+      "workspaceFolders": true
+    }
+  }
+}

--- a/cli/tests/lsp/initialize_params_code_lens_test_disabled.json
+++ b/cli/tests/lsp/initialize_params_code_lens_test_disabled.json
@@ -10,7 +10,7 @@
     "codeLens": {
       "implementations": true,
       "references": true,
-      "test": true
+      "test": false
     },
     "importMap": null,
     "lint": true,


### PR DESCRIPTION
This PR add support for test code lenses, which allow clients to be able to launch the Deno CLI executing specific tests identified in the IDE.

![_Extension_Development_Host__-_test_ts_—_vs_test](https://user-images.githubusercontent.com/1282577/120959389-fc7fed80-c79c-11eb-9df7-7c872e4a88f2.png)
