### PR TITLE
chore(tools): Fix stdout buffer of launched process getting full causing tools/lint.js to potentially hang

### DIFF
--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -611,11 +611,11 @@ impl UnaryPermission<EnvDescriptor> {
       if state == PermissionState::Prompt {
         if permission_prompt(&format!("env access to \"{}\"", env)) {
           self.granted_list.retain(|env_| env_.0 != env);
-          self.granted_list.insert(EnvDescriptor(env.to_string()));
+          self.granted_list.insert(EnvDescriptor(env));
           PermissionState::Granted
         } else {
           self.denied_list.retain(|env_| env_.0 != env);
-          self.denied_list.insert(EnvDescriptor(env.to_string()));
+          self.denied_list.insert(EnvDescriptor(env));
           self.global_state = PermissionState::Denied;
           PermissionState::Denied
         }

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -605,8 +605,11 @@ impl UnaryPermission<EnvDescriptor> {
 
   pub fn request(&mut self, env: Option<&str>) -> PermissionState {
     if let Some(env) = env {
-      #[cfg(windows)]
-      let env = env.to_uppercase();
+      let env = if cfg!(windows) {
+        env.to_uppercase()
+      } else {
+        env.to_string()
+      };
       let state = self.query(Some(&env));
       if state == PermissionState::Prompt {
         if permission_prompt(&format!("env access to \"{}\"", env)) {

--- a/tools/util.js
+++ b/tools/util.js
@@ -17,12 +17,12 @@ async function getFilesFromGit(baseDir, cmd) {
     cmd,
     stdout: "piped",
   });
+  const output = new TextDecoder().decode(await p.output());
   const { success } = await p.status();
   if (!success) {
     throw new Error("gitLsFiles failed");
   }
 
-  const output = new TextDecoder().decode(await p.output());
   p.close();
 
   const files = output.split("\0").filter((line) => line.length > 0).map(


### PR DESCRIPTION
`./tools/lint.js` was never completing on my machine (was fine on WSL, but not Windows). I believe it is due to the stdout buffer of the launched process getting full when `Deno.run` is called.

Fixed by just always reading the output, then checking the status. ~~Seems like some clippy errors surfaced after doing that as well and those are also fixed.~~ Edit: These were Windows only clippy issues. Will fix them as well.