### PR TITLE
chore: Fix broken test on Windows

### DIFF
--- a/cli/tests/089_run_allow_list.ts
+++ b/cli/tests/089_run_allow_list.ts
@@ -7,9 +7,7 @@ try {
 }
 
 const proc = Deno.run({
-  cmd: Deno.build.os === "windows"
-    ? ["cmd", "/c", "type", "089_run_allow_list.ts"]
-    : ["cat", "089_run_allow_list.ts"],
+  cmd: ["curl", "--help"],
   stdout: "null",
 });
 console.log((await proc.status()).success);

--- a/cli/tests/089_run_allow_list.ts
+++ b/cli/tests/089_run_allow_list.ts
@@ -7,7 +7,9 @@ try {
 }
 
 const proc = Deno.run({
-  cmd: ["cat", "089_run_allow_list.ts"],
+  cmd: Deno.build.os === "windows"
+    ? ["cmd", "/c", "type", "089_run_allow_list.ts"]
+    : ["cat", "089_run_allow_list.ts"],
   stdout: "null",
 });
 console.log((await proc.status()).success);

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3113,7 +3113,11 @@ console.log("finish");
   });
 
   itest!(_089_run_allow_list {
-    args: "run --allow-run=cat 089_run_allow_list.ts",
+    args: if cfg!(windows) {
+      "run --allow-run=cmd 089_run_allow_list.ts"
+    } else {
+      "run --allow-run=cat 089_run_allow_list.ts"
+    },
     output: "089_run_allow_list.ts.out",
   });
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3113,11 +3113,7 @@ console.log("finish");
   });
 
   itest!(_089_run_allow_list {
-    args: if cfg!(windows) {
-      "run --allow-run=cmd 089_run_allow_list.ts"
-    } else {
-      "run --allow-run=cat 089_run_allow_list.ts"
-    },
+    args: "run --allow-run=curl 089_run_allow_list.ts",
     output: "089_run_allow_list.ts.out",
   });
 

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -76,7 +76,10 @@ lazy_static! {
 }
 
 pub fn root_path() -> PathBuf {
-  PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+  PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR")))
+    .parent()
+    .unwrap()
+    .to_path_buf()
 }
 
 pub fn prebuilt_path() -> PathBuf {


### PR DESCRIPTION
`cat` does not exist by default on Windows. GitHub actions adds a lot of stuff to the Windows runner to make it work, which is why the CI is ok (I'm often surprised at what works in there).