### PR TITLE
chore: Instructive message when running the tests and forgetting to build first

### DIFF
--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -132,6 +132,15 @@ pub fn test_server_path() -> PathBuf {
   p
 }
 
+fn ensure_test_server_built() {
+  // if the test server doesn't exist then remind the developer to build first
+  if !test_server_path().exists() {
+    panic!(
+      "Test server not found. Please cargo build before running the tests."
+    );
+  }
+}
+
 /// Benchmark server that just serves "hello world" responses.
 async fn hyper_hello(port: u16) {
   println!("hyper hello");
@@ -1043,6 +1052,7 @@ impl Drop for HttpServerGuard {
 /// last instance of the HttpServerGuard is dropped, the subprocess will be
 /// killed.
 pub fn http_server() -> HttpServerGuard {
+  ensure_test_server_built();
   let mut g = lock_http_server();
   g.inc();
   HttpServerGuard {}


### PR DESCRIPTION
I was doing...

```
> cargo build
> cargo test
> wsl
$ cargo test
```

...then wondering why I was getting this...

```
---- file_fetcher::tests::test_fetch_cache_only stdout ----
test_server starting...
thread 'file_fetcher::tests::test_fetch_cache_only' panicked at 'failed to execute test_server: Os { code: 2, kind: NotFound, message: "The system cannot find the file specified." }', test_util\src\lib.rs:975:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- file_fetcher::tests::test_fetch_complex stdout ----
thread 'file_fetcher::tests::test_fetch_complex' panicked at 'assertion failed: `(left == right)`
  left: `2`,
 right: `1`', test_util\src\lib.rs:968:7

---- file_fetcher::tests::test_fetch_multiple_redirects stdout ----
thread 'file_fetcher::tests::test_fetch_multiple_redirects' panicked at 'assertion failed: `(left == right)`
  left: `3`,
 right: `1`', test_util\src\lib.rs:968:7

---- file_fetcher::tests::test_fetch_no_remote stdout ----
thread 'file_fetcher::tests::test_fetch_no_remote' panicked at 'assertion failed: `(left == right)`
  left: `4`,
 right: `1`', test_util\src\lib.rs:968:7

---- file_fetcher::tests::test_fetch_redirected stdout ----
thread 'file_fetcher::tests::test_fetch_redirected' panicked at 'assertion failed: `(left == right)`
  left: `5`,
 right: `1`', test_util\src\lib.rs:968:7

---- file_fetcher::tests::test_fetch_remote_javascript_with_types stdout ----
thread 'file_fetcher::tests::test_fetch_remote_javascript_with_types' panicked at 'assertion failed: `(left == right)`
  left: `6`,
 right: `1`', test_util\src\lib.rs:968:7

...etc....
```

...after a few minutes of investigation, I figured out it's because I forgot to `cargo build` after switching to WSL. I think I might make this mistake in the future as I sometimes clean out the `target` folder. To help my future self along with other people, this will now display the following:

```
---- file_fetcher::tests::test_fetch_cache_only stdout ----
thread 'file_fetcher::tests::test_fetch_cache_only' panicked at 'Test server not found. Please cargo build before running the tests.', test_util\src\lib.rs:138:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- file_fetcher::tests::test_fetch_multiple_redirects stdout ----
thread 'file_fetcher::tests::test_fetch_multiple_redirects' panicked at 'Test server not found. Please cargo build before running the tests.', test_util\src\lib.rs:138:5

---- file_fetcher::tests::test_fetch_complex stdout ----
thread 'file_fetcher::tests::test_fetch_complex' panicked at 'Test server not found. Please cargo build before running the tests.', test_util\src\lib.rs:138:5

---- file_fetcher::tests::test_fetch_no_remote stdout ----
thread 'file_fetcher::tests::test_fetch_no_remote' panicked at 'Test server not found. Please cargo build before running the tests.', test_util\src\lib.rs:138:5

---- file_fetcher::tests::test_fetch_redirected stdout ----
thread 'file_fetcher::tests::test_fetch_redirected' panicked at 'Test server not found. Please cargo build before running the tests.', test_util\src\lib.rs:138:5

---- file_fetcher::tests::test_fetch_remote_javascript_with_types stdout ----
thread 'file_fetcher::tests::test_fetch_remote_javascript_with_types' panicked at 'Test server not found. Please cargo build before running the tests.', test_util\src\lib.rs:138:5

---- file_fetcher::tests::test_fetch_remote_jsx_with_types stdout ----
thread 'file_fetcher::tests::test_fetch_remote_jsx_with_types' panicked at 'Test server not found. Please cargo build before running the tests.', test_util\src\lib.rs:138:5

---- file_fetcher::tests::test_fetch_remote_typescript_with_types stdout ----
thread 'file_fetcher::tests::test_fetch_remote_typescript_with_types' panicked at 'Test server not found. Please cargo build before running the tests.', test_util\src\lib.rs:138:5

---- file_fetcher::tests::test_fetch_remote_utf16_be stdout ----
thread 'file_fetcher::tests::test_fetch_remote_utf16_be' panicked at 'Test server not found. Please cargo build before running the tests.', test_util\src\lib.rs:138:5

...etc....
```