### PR TITLE
chore(tests): Kill orphaned deno processes spawned during the tests

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -825,6 +825,7 @@ mod integration {
       // the watcher process is still alive
       assert!(deno.try_wait().unwrap().is_none());
 
+      deno.kill().unwrap();
       drop(t);
     }
 
@@ -976,6 +977,7 @@ mod integration {
       // the watcher process is still alive
       assert!(child.try_wait().unwrap().is_none());
 
+      child.kill().unwrap();
       drop(t);
     }
 


### PR DESCRIPTION
Fixes:

```
> (Get-Process "deno").count
0
> cargo test
> (Get-Process "deno").count
2
# make a change to the code
> cargo test # errors
```