### PR TITLE
docs(unstable/emit): Note that for emit, Deno.formatDiagnostics can be used

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -483,7 +483,7 @@ declare namespace Deno {
    */
   export interface EmitResult {
     /** Diagnostic messages returned from the type checker (`tsc`).
-     * 
+     *
      * Can be used with `Deno.formatDiagnostics` to display a user
      * friendly string. */
     diagnostics: Diagnostic[];

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -518,7 +518,7 @@ declare namespace Deno {
    *
    * @returns The result of the emit. If diagnostics are found, they can be used
    * with `Deno.formatDiagnostics` to construct a user friendly string, which
-   * has the same format/result `tsc` will provide.
+   * has the same format as CLI diagnostics.
    */
   export function emit(
     rootSpecifier: string | URL,

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -206,8 +206,8 @@ declare namespace Deno {
   /** **UNSTABLE**: new API, yet to be vetted.
    *
    * Format an array of diagnostic items and return them as a single string in a
-   * user friendly format. If the diagnostic items is an empty array, it will
-   * return an empty string.
+   * user friendly format. If there are no diagnostics then it will return an
+   * empty string.
    *
    * ```ts
    * const { diagnostics } = await Deno.emit("file_with_compile_issues.ts");

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -482,9 +482,10 @@ declare namespace Deno {
    * The result of `Deno.emit()` API.
    */
   export interface EmitResult {
-    /** Diagnostic messages returned from the type checker (`tsc`). Can
-     * be used with `Deno.formatDiagnostics` to display a user friendly
-     * string. */
+    /** Diagnostic messages returned from the type checker (`tsc`).
+     * 
+     * Can be used with `Deno.formatDiagnostics` to display a user
+     * friendly string. */
     diagnostics: Diagnostic[];
     /** Any emitted files.  If bundled, then the JavaScript will have the
      * key of `deno:///bundle.js` with an optional map (based on

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -213,7 +213,7 @@ declare namespace Deno {
    * const { diagnostics } = await Deno.emit("file_with_compile_issues.ts");
    * console.table(diagnostics);  // Prints raw diagnostic data
    * console.log(Deno.formatDiagnostics(diagnostics));  // User friendly output of diagnostics
-   * console.log(Deno.formatDiagnostics([])) // ""
+   * console.log(Deno.formatDiagnostics([]));  // ""
    * ```
    *
    * @param diagnostics An array of diagnostic items to format
@@ -482,7 +482,9 @@ declare namespace Deno {
    * The result of `Deno.emit()` API.
    */
   export interface EmitResult {
-    /** Diagnostic messages returned from the type checker (`tsc`). Can be used with `Deno.formatDiagnostics` to display a user friendly string. */
+    /** Diagnostic messages returned from the type checker (`tsc`). Can
+     * be used with `Deno.formatDiagnostics` to display a user friendly
+     * string. */
     diagnostics: Diagnostic[];
     /** Any emitted files.  If bundled, then the JavaScript will have the
      * key of `deno:///bundle.js` with an optional map (based on
@@ -512,7 +514,7 @@ declare namespace Deno {
    *                      `deno run`. If sources are provided, it should match
    *                      one of the names of the sources.
    * @param options  A set of options to be used with the emit.
-   * 
+   *
    * @returns The result of the emit. If diagnostics are found, they can be used
    * with `Deno.formatDiagnostics` to construct a user friendly string, which
    * has the same format/result `tsc` will provide.

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -213,7 +213,7 @@ declare namespace Deno {
    * const { diagnostics } = await Deno.emit("file_with_compile_issues.ts");
    * console.table(diagnostics);  // Prints raw diagnostic data
    * console.log(Deno.formatDiagnostics(diagnostics));  // User friendly output of diagnostics
-   * console.log(Deno.formatDiagnostics([]));  // ""
+   * console.log(Deno.formatDiagnostics([]));  // An empty string
    * ```
    *
    * @param diagnostics An array of diagnostic items to format

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -206,12 +206,14 @@ declare namespace Deno {
   /** **UNSTABLE**: new API, yet to be vetted.
    *
    * Format an array of diagnostic items and return them as a single string in a
-   * user friendly format.
+   * user friendly format. If the diagnostic items is an empty array, it will
+   * return an empty string.
    *
    * ```ts
    * const { diagnostics } = await Deno.emit("file_with_compile_issues.ts");
    * console.table(diagnostics);  // Prints raw diagnostic data
    * console.log(Deno.formatDiagnostics(diagnostics));  // User friendly output of diagnostics
+   * console.log(Deno.formatDiagnostics([])) // ""
    * ```
    *
    * @param diagnostics An array of diagnostic items to format
@@ -480,7 +482,7 @@ declare namespace Deno {
    * The result of `Deno.emit()` API.
    */
   export interface EmitResult {
-    /** Diagnostic messages returned from the type checker (`tsc`). */
+    /** Diagnostic messages returned from the type checker (`tsc`). Can be used with `Deno.formatDiagnostics` to display a user friendly string. */
     diagnostics: Diagnostic[];
     /** Any emitted files.  If bundled, then the JavaScript will have the
      * key of `deno:///bundle.js` with an optional map (based on
@@ -510,6 +512,10 @@ declare namespace Deno {
    *                      `deno run`. If sources are provided, it should match
    *                      one of the names of the sources.
    * @param options  A set of options to be used with the emit.
+   * 
+   * @returns The result of the emit. If diagnostics are found, they can be used
+   * with `Deno.formatDiagnostics` to construct a user friendly string, which
+   * has the same format/result `tsc` will provide.
    */
   export function emit(
     rootSpecifier: string | URL,


### PR DESCRIPTION
Fixes #10919 

The main goal of this PR is to make it very clear to users, that they don't have to write a format function themselves, they would be well aware of `.formatDoagnostics`. Unfortunately, for a while I was using a custom function to create an error message based on each diagnostic.

Also included a note about what would happen if you try format an empty array. Because I was unsure myself: "What if i try format the diagnostics, but no errors were found so the parameter i pass is an empty array?"
