### PR TITLE
fix: propagate top level thrown errors in WPT

### DIFF
--- a/tools/wpt/runner.ts
+++ b/tools/wpt/runner.ts
@@ -168,9 +168,13 @@ async function generateBundle(location: URL): Promise<string> {
     }
   }
 
-  return scriptContents.map(([url, contents]) =>
-    `Deno.core.evalContext(${JSON.stringify(contents)}, ${
-      JSON.stringify(url)
-    });`
-  ).join("\n");
+  return scriptContents.map(([url, contents]) => `
+(function() {
+  const [_,err] = Deno.core.evalContext(${JSON.stringify(contents)}, ${
+    JSON.stringify(url)
+  });
+  if (err !== null) {
+    throw err?.thrown;
+  }
+})();`).join("\n");
 }

--- a/tools/wpt/testharnessreport.js
+++ b/tools/wpt/testharnessreport.js
@@ -18,5 +18,5 @@ window.add_completion_callback((_tests, harnessStatus) => {
   while (bytesWritten < data.byteLength) {
     bytesWritten += Deno.stderr.writeSync(data.subarray(bytesWritten));
   }
-  Deno.exit(0);
+  Deno.exit(harnessStatus.status === 0 ? 0 : 1);
 });


### PR DESCRIPTION
Previously top level errors were swallowed.

Closes #10930