### PR TITLE
build: add wpt epoch/daily run

### DIFF
--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -64,5 +64,8 @@ jobs:
           deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts run --binary=(which deno) --quiet --release --json=wpt.json --wptreport=wptreport.json || true
 
       - name: Upload wpt results to wpt.fyi
+        env:
+          WPT_FYI_STAGING_USER: ${{ secrets.WPT_FYI_STAGING_USER }}
+          WPT_FYI_STAGING_PW: ${{ secrets.WPT_FYI_STAGING_PW }}
         run: |
           deno run -A ./tools/upload_wptfyi.js wptreport.json --from-raw-file

--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -1,0 +1,68 @@
+# This CI job runs every night and tests all versions of Deno (canary and latest
+# stable) across all OSes we support against the `epochs/daily` branch of WPT.
+
+name: wpt_epoch
+
+on:
+  schedule:
+    # Every night at 0:30 UTC. This is 20 minutes after `epochs/daily` branch is
+    # triggered to be created in WPT repo.
+    - cron: 30 0 * * *
+
+jobs:
+  wpt:
+    name: wpt / ${{ matrix.os }} / ${{ matrix.deno-version }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        deno-version: [v1.x, canary]
+        os: [macOS-latest, ubuntu-latest-xl, windows-2019]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: ${{ matrix.deno-version }}
+
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.8"
+          architecture: x64
+
+      - name: Log versions
+        run: |
+          python --version
+          deno --version
+
+      - name: Switch WPT submodule to epochs/daily
+        working-directory: test_util/wpt/
+        run: git reset origin/epochs/daily --hard
+
+      - name: Configure hosts file for WPT (unix)
+        if: runner.os != 'Windows'
+        working-directory: test_util/wpt/
+        run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
+
+      - name: Configure hosts file for WPT (windows)
+        if: runner.os == 'Windows'
+        working-directory: test_util/wpt/
+        run: python wpt make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts -Encoding ascii -Append
+
+      - name: Run web platform tests
+        shell: bash
+        run: |
+          deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts setup
+          deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts run --binary=(which deno) --quiet --release --json=wpt.json --wptreport=wptreport.json || true
+
+      - name: Upload wpt results to wpt.fyi
+        run: |
+          deno run -A ./tools/upload_wptfyi.js wptreport.json --from-raw-file

--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -8,6 +8,7 @@ on:
     # Every night at 0:30 UTC. This is 20 minutes after `epochs/daily` branch is
     # triggered to be created in WPT repo.
     - cron: 30 0 * * *
+  workflow_dispatch:
 
 jobs:
   wpt:
@@ -64,8 +65,5 @@ jobs:
           deno run --unstable --allow-write --allow-read --allow-net --allow-env --allow-run ./tools/wpt.ts run --binary=(which deno) --quiet --release --json=wpt.json --wptreport=wptreport.json || true
 
       - name: Upload wpt results to wpt.fyi
-        env:
-          WPT_FYI_STAGING_USER: ${{ secrets.WPT_FYI_STAGING_USER }}
-          WPT_FYI_STAGING_PW: ${{ secrets.WPT_FYI_STAGING_PW }}
         run: |
           deno run -A ./tools/upload_wptfyi.js wptreport.json --from-raw-file

--- a/tools/wpt/runner.ts
+++ b/tools/wpt/runner.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { delay, join, readLines, ROOT_PATH, toFileUrl } from "../util.js";
-import { assert, ManifestTestOptions, release, runPy } from "./utils.ts";
+import { assert, denoBinary, ManifestTestOptions, runPy } from "./utils.ts";
 import { DOMParser } from "https://deno.land/x/deno_dom@v0.1.3-alpha2/deno-dom-wasm.ts";
 
 export async function runWithTestUtil<T>(
@@ -88,7 +88,7 @@ export async function runSingleTest(
 
   const proc = Deno.run({
     cmd: [
-      join(ROOT_PATH, `./target/${release ? "release" : "debug"}/deno`),
+      denoBinary(),
       "run",
       "-A",
       "--unstable",

--- a/tools/wpt/utils.ts
+++ b/tools/wpt/utils.ts
@@ -12,13 +12,19 @@ export const {
   rebuild,
   ["--"]: rest,
   ["auto-config"]: autoConfig,
+  binary,
 } = parse(Deno.args, {
   "--": true,
   boolean: ["quiet", "release", "no-interactive"],
-  string: ["json", "wptreport"],
+  string: ["json", "wptreport", "binary"],
 });
 
-/// PAGE ROOT
+export function denoBinary() {
+  if (binary) {
+    return binary;
+  }
+  return join(ROOT_PATH, `./target/${release ? "release" : "debug"}/deno`);
+}
 
 /// WPT TEST MANIFEST
 
@@ -164,11 +170,7 @@ export async function generateRunInfo(): Promise<unknown> {
   const revision = (new TextDecoder().decode(await proc.output())).trim();
   proc.close();
   const proc2 = Deno.run({
-    cmd: [
-      join(ROOT_PATH, `./target/${release ? "release" : "debug"}/deno`),
-      "eval",
-      "console.log(JSON.stringify(Deno.version))",
-    ],
+    cmd: [denoBinary(), "eval", "console.log(JSON.stringify(Deno.version))"],
     cwd: join(ROOT_PATH, "test_util", "wpt"),
     stdout: "piped",
   });


### PR DESCRIPTION
This adds a daily scheduled CI pipeline that runs WPT tests against
the most recent epochs/daily every night. Results are uploaded to
wpt.fyi.

WPTs are run on all supported platforms, on both stable and canary.
