### PR TITLE
refactor: store header keys lower case internally

### DIFF
--- a/extensions/fetch/20_headers.js
+++ b/extensions/fetch/20_headers.js
@@ -95,13 +95,7 @@
 
     // 7.
     const list = headers[_headerList];
-    const lowercaseName = byteLowerCase(name);
-    for (let i = 0; i < list.length; i++) {
-      if (byteLowerCase(list[i][0]) === lowercaseName) {
-        name = list[i][0];
-        break;
-      }
-    }
+    name = byteLowerCase(name);
     list.push([name, value]);
   }
 
@@ -112,9 +106,9 @@
    */
   function getHeader(list, name) {
     const lowercaseName = byteLowerCase(name);
-    const entries = list.filter((entry) =>
-      byteLowerCase(entry[0]) === lowercaseName
-    ).map((entry) => entry[1]);
+    const entries = list
+      .filter((entry) => entry[0] === lowercaseName)
+      .map((entry) => entry[1]);
     if (entries.length === 0) {
       return null;
     } else {
@@ -182,7 +176,7 @@
       const headers = {};
       const cookies = [];
       for (const entry of list) {
-        const name = byteLowerCase(entry[0]);
+        const name = entry[0];
         const value = entry[1];
         if (value === null) throw new TypeError("Unreachable");
         // The following if statement is not spec compliant.
@@ -270,9 +264,9 @@
       }
 
       const list = this[_headerList];
-      const lowercaseName = byteLowerCase(name);
+      name = byteLowerCase(name);
       for (let i = 0; i < list.length; i++) {
-        if (byteLowerCase(list[i][0]) === lowercaseName) {
+        if (list[i][0] === name) {
           list.splice(i, 1);
           i--;
         }
@@ -314,9 +308,9 @@
       }
 
       const list = this[_headerList];
-      const lowercaseName = byteLowerCase(name);
+      name = byteLowerCase(name);
       for (let i = 0; i < list.length; i++) {
-        if (byteLowerCase(list[i][0]) === lowercaseName) {
+        if (list[i][0] === name) {
           return true;
         }
       }
@@ -358,10 +352,10 @@
       }
 
       const list = this[_headerList];
-      const lowercaseName = byteLowerCase(name);
+      name = byteLowerCase(name);
       let added = false;
       for (let i = 0; i < list.length; i++) {
-        if (byteLowerCase(list[i][0]) === lowercaseName) {
+        if (list[i][0] === name) {
           if (!added) {
             list[i][1] = value;
             added = true;

--- a/extensions/fetch/23_request.js
+++ b/extensions/fetch/23_request.js
@@ -152,10 +152,8 @@
       let charset = null;
       let essence = null;
       let mimeType = null;
-      const values = getDecodeSplitHeader(
-        headerListFromHeaders(this[_headers]),
-        "Content-Type",
-      );
+      const headerList = headerListFromHeaders(this[_headers]);
+      const values = getDecodeSplitHeader(headerList, "content-type");
       if (values === null) return null;
       for (const value of values) {
         const temporaryMimeType = mimesniff.parseMimeType(value);

--- a/extensions/fetch/23_response.js
+++ b/extensions/fetch/23_response.js
@@ -148,10 +148,8 @@
       let charset = null;
       let essence = null;
       let mimeType = null;
-      const values = getDecodeSplitHeader(
-        headerListFromHeaders(this[_headers]),
-        "Content-Type",
-      );
+      const headerList = headerListFromHeaders(this[_headers]);
+      const values = getDecodeSplitHeader(headerList, "content-type");
       if (values === null) return null;
       for (const value of values) {
         const temporaryMimeType = mimesniff.parseMimeType(value);
@@ -220,7 +218,7 @@
       }
       const inner = newInnerResponse(status);
       inner.type = "default";
-      inner.headerList.push(["Location", parsedURL.href]);
+      inner.headerList.push(["location", parsedURL.href]);
       const response = webidl.createBranded(Response);
       response[_response] = inner;
       response[_headers] = headersFromHeaderList(

--- a/extensions/fetch/26_fetch.js
+++ b/extensions/fetch/26_fetch.js
@@ -14,7 +14,6 @@
 ((window) => {
   const core = window.Deno.core;
   const webidl = window.__bootstrap.webidl;
-  const { byteLowerCase } = window.__bootstrap.infra;
   const { errorReadableStream } = window.__bootstrap.streams;
   const { InnerBody, extractBody } = window.__bootstrap.fetchBody;
   const {

--- a/extensions/fetch/26_fetch.js
+++ b/extensions/fetch/26_fetch.js
@@ -290,9 +290,8 @@
    * @returns {Promise<InnerResponse>}
    */
   function httpRedirectFetch(request, response, terminator) {
-    const locationHeaders = response.headerList.filter((entry) =>
-      byteLowerCase(entry[0]) === "location"
-    );
+    const locationHeaders = response.headerList
+      .filter((entry) => entry[0] === "location");
     if (locationHeaders.length === 0) {
       return response;
     }
@@ -327,11 +326,7 @@
       request.method = "GET";
       request.body = null;
       for (let i = 0; i < request.headerList.length; i++) {
-        if (
-          REQUEST_BODY_HEADER_NAMES.includes(
-            byteLowerCase(request.headerList[i][0]),
-          )
-        ) {
+        if (REQUEST_BODY_HEADER_NAMES.includes(request.headerList[i][0])) {
           request.headerList.splice(i, 1);
           i--;
         }
@@ -384,8 +379,8 @@
       }
       requestObject.signal[abortSignal.add](onabort);
 
-      if (!requestObject.headers.has("Accept")) {
-        request.headerList.push(["Accept", "*/*"]);
+      if (!requestObject.headers.has("accept")) {
+        request.headerList.push(["accept", "*/*"]);
       }
 
       // 12.


### PR DESCRIPTION
This is a minor optimization that removes some header key lowercasing
that previously happened on access, instead moving it to write.

