### PR TITLE
fix(repl): Fix `undefined` result colour in cmd

### DIFF
--- a/extensions/console/01_colors.js
+++ b/extensions/console/01_colors.js
@@ -55,10 +55,6 @@
     return run(str, code(35, 39));
   }
 
-  function dim(str) {
-    return run(str, code(2, 22));
-  }
-
   // https://github.com/chalk/ansi-regex/blob/2b56fb0c7a07108e5b54241e8faec160d393aedb/index.js
   const ANSI_PATTERN = new RegExp(
     [
@@ -87,7 +83,6 @@
     white,
     gray,
     magenta,
-    dim,
     stripColor,
     maybeColor,
   };

--- a/extensions/console/02_console.js
+++ b/extensions/console/02_console.js
@@ -437,7 +437,7 @@
 
     const green = maybeColor(colors.green, inspectOptions);
     const yellow = maybeColor(colors.yellow, inspectOptions);
-    const dim = maybeColor(colors.dim, inspectOptions);
+    const gray = maybeColor(colors.gray, inspectOptions);
     const cyan = maybeColor(colors.cyan, inspectOptions);
     const bold = maybeColor(colors.bold, inspectOptions);
     const red = maybeColor(colors.red, inspectOptions);
@@ -450,8 +450,8 @@
         return yellow(Object.is(value, -0) ? "-0" : `${value}`);
       case "boolean": // booleans are yellow
         return yellow(String(value));
-      case "undefined": // undefined is dim
-        return dim(String(value));
+      case "undefined": // undefined is gray
+        return gray(String(value));
       case "symbol": // Symbols are green
         return green(maybeQuoteSymbol(value));
       case "bigint": // Bigints are yellow
@@ -583,7 +583,7 @@
     level,
     inspectOptions,
   ) {
-    const dim = maybeColor(colors.dim, inspectOptions);
+    const gray = maybeColor(colors.gray, inspectOptions);
     const options = {
       typeName: "Array",
       displayName: "",
@@ -599,7 +599,7 @@
           }
           const emptyItems = i - index;
           const ending = emptyItems > 1 ? "s" : "";
-          return dim(`<${emptyItems} empty item${ending}>`);
+          return gray(`<${emptyItems} empty item${ending}>`);
         } else {
           return inspectValueWithQuotes(val, level, inspectOptions);
         }


### PR DESCRIPTION
**Before**

Command prompt:

![image](https://user-images.githubusercontent.com/1609021/121948981-f1d9d100-cd25-11eb-9e5a-bd0efb1d4ddf.png)

Windows terminal:

![image](https://user-images.githubusercontent.com/1609021/121949080-12a22680-cd26-11eb-94db-0dcddee0c467.png)

**After**

Command prompt:

![image](https://user-images.githubusercontent.com/1609021/121949193-2d749b00-cd26-11eb-9cf4-eaded4fbc8c0.png)

Windows terminal:

![image](https://user-images.githubusercontent.com/1609021/121949266-42e9c500-cd26-11eb-9a64-0ca9be576998.png)

Highlighting for `undefined` in the Rust and JS code now both use "grey" instead of "dim" and "grey".

Fixes #9761