### PR TITLE
fix(cli): improve worker types

### DIFF
--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -324,19 +324,6 @@ interface VoidFunction {
  */
 declare function queueMicrotask(func: VoidFunction): void;
 
-/** Registers an event listener in the global scope, which will be called
- * synchronously whenever the event `type` is dispatched.
- *
- *     addEventListener('unload', () => { console.log('All finished!'); });
- *     ...
- *     dispatchEvent(new Event('unload'));
- */
-declare function addEventListener(
-  type: string,
-  callback: EventListenerOrEventListenerObject | null,
-  options?: boolean | AddEventListenerOptions | undefined,
-): void;
-
 /** Dispatches an event in the global scope, synchronously invoking any
  * registered event listeners for this event in the appropriate order. Returns
  * false if event is cancelable and at least one of the event handlers which
@@ -345,18 +332,6 @@ declare function addEventListener(
  *     dispatchEvent(new Event('unload'));
  */
 declare function dispatchEvent(event: Event): boolean;
-
-/** Remove a previously registered event listener from the global scope
- *
- *     const lstnr = () => { console.log('hello'); };
- *     addEventListener('load', lstnr);
- *     removeEventListener('load', lstnr);
- */
-declare function removeEventListener(
-  type: string,
-  callback: EventListenerOrEventListenerObject | null,
-  options?: boolean | EventListenerOptions | undefined,
-): void;
 
 interface DOMStringList {
   /** Returns the number of strings in strings. */

--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -67,6 +67,31 @@ declare function confirm(message?: string): boolean;
  */
 declare function prompt(message?: string, defaultValue?: string): string | null;
 
+/** Registers an event listener in the global scope, which will be called
+ * synchronously whenever the event `type` is dispatched.
+ *
+ *     addEventListener('unload', () => { console.log('All finished!'); });
+ *     ...
+ *     dispatchEvent(new Event('unload'));
+ */
+declare function addEventListener(
+  type: string,
+  callback: EventListenerOrEventListenerObject | null,
+  options?: boolean | AddEventListenerOptions | undefined,
+): void;
+
+/** Remove a previously registered event listener from the global scope
+ *
+ *     const lstnr = () => { console.log('hello'); };
+ *     addEventListener('load', lstnr);
+ *     removeEventListener('load', lstnr);
+ */
+declare function removeEventListener(
+  type: string,
+  callback: EventListenerOrEventListenerObject | null,
+  options?: boolean | EventListenerOptions | undefined,
+): void;
+
 // TODO(nayeemrmn): Move this to `extensions/web` where its implementation is.
 // The types there must first be split into window, worker and global types.
 /** The location (URL) of the object it is linked to. Changes done on it are

--- a/cli/dts/lib.deno.worker.d.ts
+++ b/cli/dts/lib.deno.worker.d.ts
@@ -6,34 +6,45 @@
 /// <reference lib="deno.webgpu" />
 /// <reference lib="esnext" />
 
-declare class WorkerGlobalScope {
-  new(): WorkerGlobalScope;
-  self: WorkerGlobalScope & typeof globalThis;
-  onmessage:
-    | ((
-      this: WorkerGlobalScope & typeof globalThis,
-      ev: MessageEvent,
-    ) => any)
-    | null;
-  onmessageerror:
-    | ((
-      this: WorkerGlobalScope & typeof globalThis,
-      ev: MessageEvent,
-    ) => any)
-    | null;
-  onerror:
-    | ((
-      this: WorkerGlobalScope & typeof globalThis,
-      ev: ErrorEvent,
-    ) => any)
-    | null;
-  close: () => void;
-  postMessage: (message: any) => void;
+interface WorkerGlobalScopeEventMap {
+  "error": ErrorEvent;
+}
+
+declare class WorkerGlobalScope extends EventTarget {
+  readonly location: WorkerLocation;
+  readonly navigator: WorkerNavigator;
+  onerror: ((this: WorkerGlobalScope, ev: ErrorEvent) => any) | null;
+
+  readonly self: WorkerGlobalScope & typeof globalThis;
+
+  addEventListener<K extends keyof WorkerGlobalScopeEventMap>(
+    type: K,
+    listener: (
+      this: WorkerGlobalScope,
+      ev: WorkerGlobalScopeEventMap[K],
+    ) => any,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener<K extends keyof WorkerGlobalScopeEventMap>(
+    type: K,
+    listener: (
+      this: WorkerGlobalScope,
+      ev: WorkerGlobalScopeEventMap[K],
+    ) => any,
+    options?: boolean | EventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions,
+  ): void;
+
   Deno: typeof Deno;
-  WorkerNavigator: typeof WorkerNavigator;
-  navigator: WorkerNavigator;
-  WorkerLocation: typeof WorkerLocation;
-  location: WorkerLocation;
 }
 
 declare class WorkerNavigator {
@@ -43,33 +54,93 @@ declare class WorkerNavigator {
 
 declare var navigator: WorkerNavigator;
 
-declare class DedicatedWorkerGlobalScope extends WorkerGlobalScope {
-  new(): DedicatedWorkerGlobalScope;
-  name: string;
+interface DedicatedWorkerGlobalScopeEventMap extends WorkerGlobalScope {
+  "message": MessageEvent;
+  "messageerror": MessageEvent;
 }
 
-declare var self: WorkerGlobalScope & typeof globalThis;
+declare class DedicatedWorkerGlobalScope extends WorkerGlobalScope {
+  readonly name: string;
+  onmessage:
+    | ((this: DedicatedWorkerGlobalScope, ev: MessageEvent) => any)
+    | null;
+  onmessageerror:
+    | ((this: DedicatedWorkerGlobalScope, ev: MessageEvent) => any)
+    | null;
+  close(): void;
+  postMessage(message: any): void;
+  addEventListener<K extends keyof DedicatedWorkerGlobalScopeEventMap>(
+    type: K,
+    listener: (
+      this: DedicatedWorkerGlobalScope,
+      ev: DedicatedWorkerGlobalScopeEventMap[K],
+    ) => any,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener<K extends keyof DedicatedWorkerGlobalScopeEventMap>(
+    type: K,
+    listener: (
+      this: DedicatedWorkerGlobalScope,
+      ev: DedicatedWorkerGlobalScopeEventMap[K],
+    ) => any,
+    options?: boolean | EventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions,
+  ): void;
+}
+
+declare var name: string;
 declare var onmessage:
-  | ((
-    this: WorkerGlobalScope & typeof globalThis,
-    ev: MessageEvent,
-  ) => any)
+  | ((this: DedicatedWorkerGlobalScope, ev: MessageEvent) => any)
   | null;
 declare var onmessageerror:
-  | ((
-    this: WorkerGlobalScope & typeof globalThis,
-    ev: MessageEvent,
-  ) => any)
+  | ((this: DedicatedWorkerGlobalScope, ev: MessageEvent) => any)
   | null;
+declare function close(): void;
+declare function postMessage(message: any): void;
+declare var navigator: WorkerNavigator;
 declare var onerror:
-  | ((
-    this: WorkerGlobalScope & typeof globalThis,
-    ev: ErrorEvent,
-  ) => any)
+  | ((this: DedicatedWorkerGlobalScope, ev: ErrorEvent) => any)
   | null;
-declare var close: () => void;
-declare var name: string;
-declare var postMessage: (message: any) => void;
+declare var self: WorkerGlobalScope & typeof globalThis;
+declare function addEventListener<
+  K extends keyof DedicatedWorkerGlobalScopeEventMap,
+>(
+  type: K,
+  listener: (
+    this: DedicatedWorkerGlobalScope,
+    ev: DedicatedWorkerGlobalScopeEventMap[K],
+  ) => any,
+  options?: boolean | AddEventListenerOptions,
+): void;
+declare function addEventListener(
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+  options?: boolean | AddEventListenerOptions,
+): void;
+declare function removeEventListener<
+  K extends keyof DedicatedWorkerGlobalScopeEventMap,
+>(
+  type: K,
+  listener: (
+    this: DedicatedWorkerGlobalScope,
+    ev: DedicatedWorkerGlobalScopeEventMap[K],
+  ) => any,
+  options?: boolean | EventListenerOptions,
+): void;
+declare function removeEventListener(
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+  options?: boolean | EventListenerOptions,
+): void;
 
 // TODO(nayeemrmn): Move this to `extensions/web` where its implementation is.
 // The types there must first be split into window, worker and global types.

--- a/cli/dts/lib.deno.worker.d.ts
+++ b/cli/dts/lib.deno.worker.d.ts
@@ -54,7 +54,7 @@ declare class WorkerNavigator {
 
 declare var navigator: WorkerNavigator;
 
-interface DedicatedWorkerGlobalScopeEventMap extends WorkerGlobalScope {
+interface DedicatedWorkerGlobalScopeEventMap extends WorkerGlobalScopeEventMap {
   "message": MessageEvent;
   "messageerror": MessageEvent;
 }


### PR DESCRIPTION
This fixes issues with the Deno built-in types that prevented the appropriate type checking of web workers when using `addEventListener("message", /* ... */);` plus a few other improvements to align it more to the TypeScript libs.