### PR TITLE
fix(inspector): Deno.inspect should inspect the object the proxy represents rather than the target

### DIFF
--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1737,15 +1737,39 @@ unitTest(function inspectIterableLimit(): void {
 unitTest(function inspectProxy(): void {
   assertEquals(
     stripColor(Deno.inspect(
-      new Proxy([1, 2, 3], { get(): void {} }),
+      new Proxy([1, 2, 3], {}),
     )),
     "[ 1, 2, 3 ]",
   );
   assertEquals(
     stripColor(Deno.inspect(
-      new Proxy({ key: "value" }, { get(): void {} }),
+      new Proxy({ key: "value" }, {}),
     )),
     `{ key: "value" }`,
+  );
+  assertEquals(
+    stripColor(Deno.inspect(
+      new Proxy({}, {
+        get(_target, key) {
+          if (key === Symbol.toStringTag) {
+            return "MyProxy";
+          } else {
+            return 5;
+          }
+        },
+        getOwnPropertyDescriptor() {
+          return {
+            enumerable: true,
+            configurable: true,
+            value: 5,
+          };
+        },
+        ownKeys() {
+          return ["prop1", "prop2"];
+        },
+      }),
+    )),
+    `MyProxy { prop1: 5, prop2: 5 }`,
   );
   assertEquals(
     stripColor(Deno.inspect(

--- a/extensions/console/02_console.js
+++ b/extensions/console/02_console.js
@@ -429,10 +429,8 @@
     inspectOptions,
   ) {
     const proxyDetails = core.getProxyDetails(value);
-    if (proxyDetails != null) {
-      return inspectOptions.showProxy
-        ? inspectProxy(proxyDetails, level, inspectOptions)
-        : inspectValue(proxyDetails[0], level, inspectOptions);
+    if (proxyDetails != null && inspectOptions.showProxy) {
+      return inspectProxy(proxyDetails, level, inspectOptions);
     }
 
     const green = maybeColor(colors.green, inspectOptions);


### PR DESCRIPTION
I was so confused why proxies weren't working in the inspector when working on a different fix.

Closes #10975.

Note: Target is the first argument provided to the constructor of `Proxy`