### PR TITLE
fix(inspect): fix inspecting event classes

### DIFF
--- a/cli/tests/unit/event_test.ts
+++ b/cli/tests/unit/event_test.ts
@@ -138,17 +138,17 @@ unitTest(function inspectEvent(): void {
   assertEquals(
     Deno.inspect(Event.prototype),
     `Event {
-  bubbles: [Getter/Setter],
-  cancelable: [Getter/Setter],
-  composed: [Getter/Setter],
-  currentTarget: [Getter/Setter],
-  defaultPrevented: [Getter/Setter],
-  eventPhase: [Getter/Setter],
+  bubbles: [Getter],
+  cancelable: [Getter],
+  composed: [Getter],
+  currentTarget: [Getter],
+  defaultPrevented: [Getter],
+  eventPhase: [Getter],
   srcElement: [Getter/Setter],
-  target: [Getter/Setter],
+  target: [Getter],
   returnValue: [Getter/Setter],
-  timeStamp: [Getter/Setter],
-  type: [Getter/Setter]
+  timeStamp: [Getter],
+  type: [Getter]
 }`,
   );
 

--- a/cli/tests/unit/event_test.ts
+++ b/cli/tests/unit/event_test.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals, unitTest } from "./test_util.ts";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+  unitTest,
+} from "./test_util.ts";
 
 unitTest(function eventInitializedWithType(): void {
   const type = "click";
@@ -126,4 +131,31 @@ unitTest(function eventInspectOutput(): void {
   for (const [event, outputProvider] of cases) {
     assertEquals(Deno.inspect(event), outputProvider(event));
   }
+});
+
+unitTest(function inspectEvent(): void {
+  // has a customInspect implementation that previously would throw on a getter
+  assertEquals(
+    Deno.inspect(Event.prototype),
+    `Event {
+  bubbles: [Getter/Setter],
+  cancelable: [Getter/Setter],
+  composed: [Getter/Setter],
+  currentTarget: [Getter/Setter],
+  defaultPrevented: [Getter/Setter],
+  eventPhase: [Getter/Setter],
+  srcElement: [Getter/Setter],
+  target: [Getter/Setter],
+  returnValue: [Getter/Setter],
+  timeStamp: [Getter/Setter],
+  type: [Getter/Setter]
+}`,
+  );
+
+  // ensure this still works
+  assertStringIncludes(
+    Deno.inspect(new Event("test")),
+    // check a substring because one property is a timestamp
+    `Event {\n  bubbles: false,\n  cancelable: false,`,
+  );
 });

--- a/cli/tests/unit/event_test.ts
+++ b/cli/tests/unit/event_test.ts
@@ -138,17 +138,17 @@ unitTest(function inspectEvent(): void {
   assertEquals(
     Deno.inspect(Event.prototype),
     `Event {
-  bubbles: [Getter],
-  cancelable: [Getter],
-  composed: [Getter],
-  currentTarget: [Getter],
-  defaultPrevented: [Getter],
-  eventPhase: [Getter],
+  bubbles: [Getter/Setter],
+  cancelable: [Getter/Setter],
+  composed: [Getter/Setter],
+  currentTarget: [Getter/Setter],
+  defaultPrevented: [Getter/Setter],
+  eventPhase: [Getter/Setter],
   srcElement: [Getter/Setter],
-  target: [Getter],
+  target: [Getter/Setter],
   returnValue: [Getter/Setter],
-  timeStamp: [Getter],
-  type: [Getter]
+  timeStamp: [Getter/Setter],
+  type: [Getter/Setter]
 }`,
   );
 

--- a/extensions/web/02_event.js
+++ b/extensions/web/02_event.js
@@ -150,27 +150,23 @@
     get type() {
       return this[_attributes].type;
     }
-    set type(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get target() {
       return this[_attributes].target;
     }
-    set target(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get srcElement() {
       return null;
     }
+
     set srcElement(_) {
-      // this is a no-op because this member is readonly
+      // this member is deprecated
     }
+
     get currentTarget() {
       return this[_attributes].currentTarget;
     }
-    set currentTarget(_) {
-      // this is a no-op because this member is readonly
-    }
+
     composedPath() {
       const path = this[_path];
       if (path.length === 0) {
@@ -279,67 +275,51 @@
     get NONE() {
       return Event.NONE;
     }
-    set NONE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get CAPTURING_PHASE() {
       return Event.CAPTURING_PHASE;
     }
-    set CAPTURING_PHASE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get AT_TARGET() {
       return Event.AT_TARGET;
     }
-    set AT_TARGET(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get BUBBLING_PHASE() {
       return Event.BUBBLING_PHASE;
     }
-    set BUBBLING_PHASE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     static get NONE() {
       return 0;
     }
-    static set NONE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     static get CAPTURING_PHASE() {
       return 1;
     }
-    static set CAPTURING_PHASE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     static get AT_TARGET() {
       return 2;
     }
-    static set AT_TARGET(_) {
-      // this is a no-op because this member is readonly
-    }
+
     static get BUBBLING_PHASE() {
       return 3;
     }
-    static set BUBBLING_PHASE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get eventPhase() {
       return this[_attributes].eventPhase;
-    }
-    set eventPhase(_) {
-      // this is a no-op because this member is readonly
     }
 
     stopPropagation() {
       this[_stopPropagationFlag] = true;
     }
+
     get cancelBubble() {
       return this[_stopPropagationFlag];
     }
+
     set cancelBubble(value) {
       this[_stopPropagationFlag] = webidl.converters.boolean(value);
     }
+
     stopImmediatePropagation() {
       this[_stopPropagationFlag] = true;
       this[_stopImmediatePropagationFlag] = true;
@@ -348,39 +328,33 @@
     get bubbles() {
       return this[_attributes].bubbles;
     }
-    set bubbles(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get cancelable() {
       return this[_attributes].cancelable;
     }
-    set cancelable(value) {
-      // this is a no-op because this member is readonly
-    }
+
     get returnValue() {
       return !this[_canceledFlag];
     }
+
     set returnValue(value) {
       if (!webidl.converters.boolean(value)) {
         this[_canceledFlag] = true;
       }
     }
+
     preventDefault() {
       if (this[_attributes].cancelable && !this[_inPassiveListener]) {
         this[_canceledFlag] = true;
       }
     }
+
     get defaultPrevented() {
       return this[_canceledFlag];
     }
-    set defaultPrevented(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get composed() {
       return this[_attributes].composed;
-    }
-    set composed(_) {
-      // this is a no-op because this member is readonly
     }
 
     get initialized() {
@@ -389,9 +363,6 @@
 
     get timeStamp() {
       return this[_attributes].timeStamp;
-    }
-    set timeStamp(_) {
-      // this is a no-op because this member is readonly
     }
   }
 

--- a/extensions/web/02_event.js
+++ b/extensions/web/02_event.js
@@ -150,23 +150,27 @@
     get type() {
       return this[_attributes].type;
     }
-
+    set type(_) {
+      // this is a no-op because this member is readonly
+    }
     get target() {
       return this[_attributes].target;
     }
-
+    set target(_) {
+      // this is a no-op because this member is readonly
+    }
     get srcElement() {
       return null;
     }
-
     set srcElement(_) {
-      // this member is deprecated
+      // this is a no-op because this member is readonly
     }
-
     get currentTarget() {
       return this[_attributes].currentTarget;
     }
-
+    set currentTarget(_) {
+      // this is a no-op because this member is readonly
+    }
     composedPath() {
       const path = this[_path];
       if (path.length === 0) {
@@ -275,51 +279,67 @@
     get NONE() {
       return Event.NONE;
     }
-
+    set NONE(_) {
+      // this is a no-op because this member is readonly
+    }
     get CAPTURING_PHASE() {
       return Event.CAPTURING_PHASE;
     }
-
+    set CAPTURING_PHASE(_) {
+      // this is a no-op because this member is readonly
+    }
     get AT_TARGET() {
       return Event.AT_TARGET;
     }
-
+    set AT_TARGET(_) {
+      // this is a no-op because this member is readonly
+    }
     get BUBBLING_PHASE() {
       return Event.BUBBLING_PHASE;
     }
-
+    set BUBBLING_PHASE(_) {
+      // this is a no-op because this member is readonly
+    }
     static get NONE() {
       return 0;
     }
-
+    static set NONE(_) {
+      // this is a no-op because this member is readonly
+    }
     static get CAPTURING_PHASE() {
       return 1;
     }
-
+    static set CAPTURING_PHASE(_) {
+      // this is a no-op because this member is readonly
+    }
     static get AT_TARGET() {
       return 2;
     }
-
+    static set AT_TARGET(_) {
+      // this is a no-op because this member is readonly
+    }
     static get BUBBLING_PHASE() {
       return 3;
     }
-
+    static set BUBBLING_PHASE(_) {
+      // this is a no-op because this member is readonly
+    }
     get eventPhase() {
       return this[_attributes].eventPhase;
+    }
+    set eventPhase(_) {
+      // this is a no-op because this member is readonly
     }
 
     stopPropagation() {
       this[_stopPropagationFlag] = true;
     }
-
     get cancelBubble() {
       return this[_stopPropagationFlag];
     }
-
     set cancelBubble(value) {
       this[_stopPropagationFlag] = webidl.converters.boolean(value);
     }
-
     stopImmediatePropagation() {
       this[_stopPropagationFlag] = true;
       this[_stopImmediatePropagationFlag] = true;
@@ -328,33 +348,39 @@
     get bubbles() {
       return this[_attributes].bubbles;
     }
-
+    set bubbles(_) {
+      // this is a no-op because this member is readonly
+    }
     get cancelable() {
       return this[_attributes].cancelable;
     }
-
+    set cancelable(value) {
+      // this is a no-op because this member is readonly
+    }
     get returnValue() {
       return !this[_canceledFlag];
     }
-
     set returnValue(value) {
       if (!webidl.converters.boolean(value)) {
         this[_canceledFlag] = true;
       }
     }
-
     preventDefault() {
       if (this[_attributes].cancelable && !this[_inPassiveListener]) {
         this[_canceledFlag] = true;
       }
     }
-
     get defaultPrevented() {
       return this[_canceledFlag];
     }
-
+    set defaultPrevented(_) {
+      // this is a no-op because this member is readonly
+    }
     get composed() {
       return this[_attributes].composed;
+    }
+    set composed(_) {
+      // this is a no-op because this member is readonly
     }
 
     get initialized() {
@@ -363,6 +389,9 @@
 
     get timeStamp() {
       return this[_attributes].timeStamp;
+    }
+    set timeStamp(_) {
+      // this is a no-op because this member is readonly
     }
   }
 


### PR DESCRIPTION
Before in REPL:

```
> new Event("")
Event {
  bubbles: false,
  cancelable: false,
  composed: false,
  currentTarget: null,
  defaultPrevented: false,
  eventPhase: 0,
  srcElement: null,
  target: null,
  returnValue: true,
  timeStamp: 1623786515074,
  type: ""
}
> Event.prototype
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', cli\tools\repl.rs:550:49
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:

```
exit using ctrl+d or close()
> new Event("")
Event {
  bubbles: false,
  cancelable: false,
  composed: false,
  currentTarget: null,
  defaultPrevented: false,
  eventPhase: 0,
  srcElement: null,
  target: null,
  returnValue: true,
  timeStamp: 1623786578618,
  type: ""
}
> Event.prototype
Event {
  bubbles: [Getter/Setter],
  cancelable: [Getter/Setter],
  composed: [Getter/Setter],
  currentTarget: [Getter/Setter],
  defaultPrevented: [Getter/Setter],
  eventPhase: [Getter/Setter],
  srcElement: [Getter/Setter],
  target: [Getter/Setter],
  returnValue: [Getter/Setter],
  timeStamp: [Getter/Setter],
  type: [Getter/Setter]
}
>
```

Closes #9880