### PR TITLE
chore(lsp): Add `--parent-pid <pid>` flag

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -85,7 +85,7 @@ pub enum DenoSubcommand {
     force: bool,
   },
   Lsp {
-    parent_pid: Option<usize>,
+    parent_pid: Option<u32>,
   },
   Lint {
     files: Vec<PathBuf>,

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -84,7 +84,9 @@ pub enum DenoSubcommand {
     root: Option<PathBuf>,
     force: bool,
   },
-  Lsp,
+  Lsp {
+    parent_pid: Option<usize>,
+  },
   Lint {
     files: Vec<PathBuf>,
     ignore: Vec<PathBuf>,
@@ -876,6 +878,16 @@ go-to-definition support and automatic code formatting.
 
 How to connect various editors and IDEs to 'deno lsp':
 https://deno.land/manual/getting_started/setup_your_environment#editors-and-ides")
+    .arg(
+      Arg::with_name("parent-pid")
+        .long("parent-pid")
+        .help("The parent process id to periodically check for the existence of or exit")
+        .takes_value(true)
+        .validator(|val: String| match val.parse::<usize>() {
+          Ok(_) => Ok(()),
+          Err(_) => Err("parent-pid should be a number".to_string()),
+        }),
+    )
 }
 
 fn lint_subcommand<'a, 'b>() -> App<'a, 'b> {
@@ -1621,8 +1633,11 @@ fn install_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   };
 }
 
-fn lsp_parse(flags: &mut Flags, _matches: &clap::ArgMatches) {
-  flags.subcommand = DenoSubcommand::Lsp;
+fn lsp_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
+  let parent_pid = matches
+    .value_of("parent-pid")
+    .map(|val| val.parse().unwrap());
+  flags.subcommand = DenoSubcommand::Lsp { parent_pid };
 }
 
 fn lint_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
@@ -2308,10 +2323,24 @@ mod tests {
     assert_eq!(
       r.unwrap(),
       Flags {
-        subcommand: DenoSubcommand::Lsp,
+        subcommand: DenoSubcommand::Lsp { parent_pid: None },
         ..Flags::default()
       }
     );
+
+    let r = flags_from_vec(svec!["deno", "lsp", "--parent-pid", "5"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Lsp {
+          parent_pid: Some(5),
+        },
+        ..Flags::default()
+      }
+    );
+
+    let r = flags_from_vec(svec!["deno", "lsp", "--parent-pid", "invalid-arg"]);
+    assert!(r.is_err());
   }
 
   #[test]

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -13,6 +13,7 @@ mod diagnostics;
 mod documents;
 pub(crate) mod language_server;
 mod lsp_custom;
+mod parent_process_checker;
 mod path_to_regex;
 mod performance;
 mod registries;
@@ -22,9 +23,13 @@ mod text;
 mod tsc;
 mod urls;
 
-pub async fn start() -> Result<(), AnyError> {
+pub async fn start(parent_pid: Option<usize>) -> Result<(), AnyError> {
   let stdin = tokio::io::stdin();
   let stdout = tokio::io::stdout();
+
+  if let Some(parent_pid) = parent_pid {
+    parent_process_checker::start(parent_pid);
+  }
 
   let (service, messages) =
     LspService::new(language_server::LanguageServer::new);

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -23,7 +23,7 @@ mod text;
 mod tsc;
 mod urls;
 
-pub async fn start(parent_pid: Option<usize>) -> Result<(), AnyError> {
+pub async fn start(parent_pid: Option<u32>) -> Result<(), AnyError> {
   let stdin = tokio::io::stdin();
   let stdout = tokio::io::stdout();
 

--- a/cli/lsp/parent_process_checker.rs
+++ b/cli/lsp/parent_process_checker.rs
@@ -22,8 +22,8 @@ pub fn start(parent_process_id: u32) {
 #[cfg(unix)]
 fn is_process_active(process_id: u32) -> bool {
   unsafe {
-    let kill_result = libc::kill(process_id as i32, 0);
-    kill_result == 0
+    // signal of 0 checks for the existence of the process id
+    libc::kill(process_id as i32, 0) == 0
   }
 }
 

--- a/cli/lsp/parent_process_checker.rs
+++ b/cli/lsp/parent_process_checker.rs
@@ -32,24 +32,18 @@ fn is_process_active(process_id: u32) -> bool {
   use winapi::shared::minwindef::DWORD;
   use winapi::shared::minwindef::FALSE;
   use winapi::shared::ntdef::NULL;
+  use winapi::shared::winerror::WAIT_TIMEOUT;
   use winapi::um::handleapi::CloseHandle;
-  use winapi::um::minwinbase::STILL_ACTIVE;
-  use winapi::um::processthreadsapi::GetExitCodeProcess;
   use winapi::um::processthreadsapi::OpenProcess;
-  use winapi::um::winnt::PROCESS_QUERY_INFORMATION;
+  use winapi::um::synchapi::WaitForSingleObject;
+  use winapi::um::winnt::SYNCHRONIZE;
 
   unsafe {
-    let process =
-      OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, process_id as DWORD);
+    let process = OpenProcess(SYNCHRONIZE, FALSE, process_id as DWORD);
     let result = if process == NULL {
       false
     } else {
-      let mut exit_code = 0;
-      if GetExitCodeProcess(process, &mut exit_code) != FALSE {
-        exit_code == STILL_ACTIVE
-      } else {
-        false
-      }
+      WaitForSingleObject(process, 0) == WAIT_TIMEOUT
     };
     CloseHandle(process);
     result

--- a/cli/lsp/parent_process_checker.rs
+++ b/cli/lsp/parent_process_checker.rs
@@ -74,6 +74,7 @@ mod test {
     let pid = child.id() as usize;
     assert_eq!(is_process_active(pid), true);
     child.kill().unwrap();
+    child.wait().unwrap();
     assert_eq!(is_process_active(pid), false);
   }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -470,8 +470,8 @@ async fn install_command(
   tools::installer::install(flags, &module_url, args, name, root, force)
 }
 
-async fn lsp_command() -> Result<(), AnyError> {
-  lsp::start().await
+async fn lsp_command(parent_pid: Option<usize>) -> Result<(), AnyError> {
+  lsp::start(parent_pid).await
 }
 
 async fn lint_command(
@@ -1264,7 +1264,7 @@ fn get_subcommand(
     } => {
       install_command(flags, module_url, args, name, root, force).boxed_local()
     }
-    DenoSubcommand::Lsp => lsp_command().boxed_local(),
+    DenoSubcommand::Lsp { parent_pid } => lsp_command(parent_pid).boxed_local(),
     DenoSubcommand::Lint {
       files,
       rules,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -470,7 +470,7 @@ async fn install_command(
   tools::installer::install(flags, &module_url, args, name, root, force)
 }
 
-async fn lsp_command(parent_pid: Option<usize>) -> Result<(), AnyError> {
+async fn lsp_command(parent_pid: Option<u32>) -> Result<(), AnyError> {
   lsp::start(parent_pid).await
 }
 


### PR DESCRIPTION
This PR adds a new `--parent-pid <pid>` flag to `deno lsp` that when provided starts a task that checks for the existence of the provided process id (ex. vscode's) every 30 seconds. If the process doesn't exist (meaning the deno process has nothing interacting with it), then it terminates itself.

I am  not familiar with what the best way to check if a process is running on linux/mac. I am also not that familiar with win api. Please let me know if there is a better way of doing what's done in here.

Closes #11019