### PR TITLE
chore: fix new linting errors flagged by Rust 1.53

### DIFF
--- a/cli/lsp/parent_process_checker.rs
+++ b/cli/lsp/parent_process_checker.rs
@@ -62,9 +62,9 @@ mod test {
     let mut child = Command::new(deno_exe_path()).arg("lsp").spawn().unwrap();
 
     let pid = child.id();
-    assert_eq!(is_process_active(pid), true);
+    assert!(is_process_active(pid));
     child.kill().unwrap();
     child.wait().unwrap();
-    assert_eq!(is_process_active(pid), false);
+    assert!(!is_process_active(pid));
   }
 }


### PR DESCRIPTION
Funny that all the new linting errors were in the code I just committed.