### PR TITLE
fix(core): prevent include_js_files print "cargo:rerun" on release build

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -126,6 +126,7 @@ macro_rules! include_js_files {
         Box::new(|| {
           let c = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
           let path = c.join($file);
+          #[cfg(debug_assertions)]
           println!("cargo:rerun-if-changed={}", path.display());
           let src = std::fs::read_to_string(path)?;
           Ok(src)


### PR DESCRIPTION
Resolves #11030

This PR changes `include_js_files` to only print `cargo:rerun` on debug build, since the cargo statement shouldn't be needed in release build.