### PR TITLE
fix: Worker accepts specifier as URL

### DIFF
--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -405,7 +405,7 @@ declare class Worker extends EventTarget {
   onmessage?: (e: MessageEvent) => void;
   onmessageerror?: (e: MessageEvent) => void;
   constructor(
-    specifier: string,
+    specifier: string | URL,
     options?: WorkerOptions,
   );
   postMessage(message: any, transfer: ArrayBuffer[]): void;

--- a/cli/tests/workers/test.ts
+++ b/cli/tests/workers/test.ts
@@ -161,7 +161,7 @@ Deno.test({
     const promise = deferred();
 
     const busyWorker = new Worker(
-      new URL("busy_worker.js", import.meta.url).href,
+      new URL("busy_worker.js", import.meta.url),
       { type: "module" },
     );
 
@@ -194,7 +194,7 @@ Deno.test({
     const promise = deferred();
 
     const racyWorker = new Worker(
-      new URL("racy_worker.js", import.meta.url).href,
+      new URL("racy_worker.js", import.meta.url),
       { type: "module" },
     );
 
@@ -219,7 +219,7 @@ Deno.test({
     const promise2 = deferred();
 
     const worker = new Worker(
-      new URL("event_worker.js", import.meta.url).href,
+      new URL("event_worker.js", import.meta.url),
       { type: "module" },
     );
 
@@ -263,7 +263,7 @@ Deno.test({
     const promise1 = deferred();
 
     const worker = new Worker(
-      new URL("event_worker_scope.js", import.meta.url).href,
+      new URL("event_worker_scope.js", import.meta.url),
       { type: "module" },
     );
 
@@ -292,11 +292,11 @@ Deno.test({
     const promise2 = deferred();
 
     const regularWorker = new Worker(
-      new URL("non_deno_worker.js", import.meta.url).href,
+      new URL("non_deno_worker.js", import.meta.url),
       { type: "module" },
     );
     const denoWorker = new Worker(
-      new URL("deno_worker.ts", import.meta.url).href,
+      new URL("deno_worker.ts", import.meta.url),
       {
         type: "module",
         deno: {


### PR DESCRIPTION
This commit updates type declarations for Worker to accept specifiers
as either strings or URL, bringing it in line with TypeScript
declarations and browser behavior.

Fixes https://github.com/denoland/deno/issues/11037