### PR TITLE
fix(core): don't panic on stdout/stderr write failures

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -3158,6 +3158,29 @@ console.log("finish");
     util::test_pty(args, output, input);
   }
 
+  #[test]
+  fn broken_stdout() {
+    let (reader, writer) = os_pipe::pipe().unwrap();
+    // drop the reader to create a broken pipe
+    drop(reader);
+
+    let output = util::deno_cmd()
+      .current_dir(util::root_path())
+      .arg("eval")
+      .arg("console.log(3.14)")
+      .stdout(writer)
+      .stderr(std::process::Stdio::piped())
+      .spawn()
+      .unwrap()
+      .wait_with_output()
+      .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = std::str::from_utf8(output.stderr.as_ref()).unwrap().trim();
+    assert!(stderr.contains("Uncaught BrokenPipe"));
+    assert!(!stderr.contains("panic"));
+  }
+
   itest!(_091_use_define_for_class_fields {
     args: "run 091_use_define_for_class_fields.ts",
     output: "091_use_define_for_class_fields.ts.out",

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -61,10 +61,10 @@ pub fn op_print(
   is_err: bool,
 ) -> Result<(), AnyError> {
   if is_err {
-    eprint!("{}", msg);
+    stderr().write_all(msg.as_bytes())?;
     stderr().flush().unwrap();
   } else {
-    print!("{}", msg);
+    stdout().write_all(msg.as_bytes())?;
     stdout().flush().unwrap();
   }
   Ok(())


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Closes #10764

### Steps to reproduce
```bash
echo "console.log(123)" > log.ts
touch 404
chmod +x ./404
```

### Old behavior

```bash
$ deno run log.ts | ./404
Failed to execute process './404'. Reason:
exec: Exec format error
The file './404' is marked as an executable but could not be run by the operating system.
thread 'main' panicked at 'failed printing to stdout: Broken pipe (os error 32)', library/std/src/io/stdio.rs:940:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
fish: Process 843852, “deno” “deno run log.ts | ./404” terminated by signal SIGABRT (Abort)
```

### New Behavior 
```bash
$ ./target/debug/deno run log.ts | ./404
Failed to execute process './404'. Reason:
exec: Exec format error
The file './404' is marked as an executable but could not be run by the operating system.
error: Uncaught BrokenPipe: Broken pipe (os error 32)
console.log(123);
        ^
    at deno:core/core.js:86:46
    at unwrapOpResult (deno:core/core.js:106:13)
    at opSync (deno:core/core.js:120:12)
    at Object.print (deno:core/core.js:132:5)
    at Console.<anonymous> (deno:runtime/js/99_main.js:324:40)
    at console.log (deno:extensions/console/02_console.js:1495:22)
    at file:///home/charlie/Code/deno/log.ts:3:9
```