### PR TITLE
fix(lsp): do not rename in strings and comments

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1769,8 +1769,8 @@ impl Inner {
     let req = tsc::RequestMethod::FindRenameLocations((
       specifier,
       line_index.offset_tsc(params.text_document_position.position)?,
-      true,
-      true,
+      false,
+      false,
       false,
     ));
 

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1766,13 +1766,14 @@ impl Inner {
         )));
       };
 
-    let req = tsc::RequestMethod::FindRenameLocations((
+    let req = tsc::RequestMethod::FindRenameLocations {
       specifier,
-      line_index.offset_tsc(params.text_document_position.position)?,
-      false,
-      false,
-      false,
-    ));
+      position: line_index
+        .offset_tsc(params.text_document_position.position)?,
+      find_in_strings: false,
+      find_in_comments: false,
+      provide_prefix_and_suffix_text_for_rename: false,
+    };
 
     let maybe_locations: Option<Vec<tsc::RenameLocation>> = self
       .ts_server

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2319,7 +2319,13 @@ pub enum RequestMethod {
   /// Configure the compilation settings for the server.
   Configure(TsConfig),
   /// Get rename locations at a given position.
-  FindRenameLocations((ModuleSpecifier, u32, bool, bool, bool)),
+  FindRenameLocations {
+    specifier: ModuleSpecifier,
+    position: u32,
+    find_in_strings: bool,
+    find_in_comments: bool,
+    provide_prefix_and_suffix_text_for_rename: bool,
+  },
   /// Retrieve the text of an assets that exists in memory in the isolate.
   GetAsset(ModuleSpecifier),
   /// Retrieve code fixes for a range of a file with the provided error codes.
@@ -2370,13 +2376,13 @@ impl RequestMethod {
         "method": "configure",
         "compilerOptions": config,
       }),
-      RequestMethod::FindRenameLocations((
+      RequestMethod::FindRenameLocations {
         specifier,
         position,
         find_in_strings,
         find_in_comments,
         provide_prefix_and_suffix_text_for_rename,
-      )) => {
+      } => {
         json!({
           "id": id,
           "method": "findRenameLocations",

--- a/cli/tests/integration_tests_lsp.rs
+++ b/cli/tests/integration_tests_lsp.rs
@@ -957,7 +957,8 @@ fn lsp_rename() {
         "uri": "file:///a/file.ts",
         "languageId": "typescript",
         "version": 1,
-        "text": "let variable = 'a';\nconsole.log(variable);"
+        // this should not rename in comments and strings
+        "text": "let variable = 'a'; // variable\nconsole.log(variable);\n\"variable\";\n"
       }
     }),
   );


### PR DESCRIPTION
Fixes https://github.com/denoland/vscode_deno/issues/450

This functionality is not the default with TypeScript so I believe this is a bug and we shouldn't do it.