### PR TITLE
refactor(core): always attach inspector to isolate

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -91,8 +91,6 @@ fn create_web_worker_callback(
       PrettyJsError::create(source_mapped_error)
     });
 
-    let attach_inspector = program_state.maybe_inspector_server.is_some()
-      || program_state.coverage_dir.is_some();
     let maybe_inspector_server = program_state.maybe_inspector_server.clone();
 
     let module_loader = CliModuleLoader::new_for_worker(
@@ -117,7 +115,6 @@ fn create_web_worker_callback(
       create_web_worker_cb,
       js_error_create_fn: Some(js_error_create_fn),
       use_deno_namespace: args.use_deno_namespace,
-      attach_inspector,
       maybe_inspector_server,
       runtime_version: version::deno(),
       ts_version: version::TYPESCRIPT.to_string(),
@@ -173,9 +170,6 @@ pub fn create_main_worker(
     PrettyJsError::create(source_mapped_error)
   });
 
-  let attach_inspector = program_state.maybe_inspector_server.is_some()
-    || program_state.flags.repl
-    || program_state.coverage_dir.is_some();
   let maybe_inspector_server = program_state.maybe_inspector_server.clone();
   let should_break_on_first_statement =
     program_state.flags.inspect_brk.is_some();
@@ -195,7 +189,6 @@ pub fn create_main_worker(
     seed: program_state.flags.seed,
     js_error_create_fn: Some(js_error_create_fn),
     create_web_worker_cb,
-    attach_inspector,
     maybe_inspector_server,
     should_break_on_first_statement,
     module_loader,

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -236,7 +236,6 @@ pub async fn run(
     seed: metadata.seed,
     js_error_create_fn: None,
     create_web_worker_cb,
-    attach_inspector: false,
     maybe_inspector_server: None,
     should_break_on_first_statement: false,
     module_loader,

--- a/runtime/examples/hello_runtime.rs
+++ b/runtime/examples/hello_runtime.rs
@@ -32,7 +32,6 @@ async fn main() -> Result<(), AnyError> {
     seed: None,
     js_error_create_fn: None,
     create_web_worker_cb,
-    attach_inspector: false,
     maybe_inspector_server: None,
     should_break_on_first_statement: false,
     module_loader,


### PR DESCRIPTION
This commit changes "deno_core::JsRuntime" to always create
"deno_core::JsRuntimeInspector" instance.

<s>__Need to check if this commit has impact on startup and memory benchmarks__</s>

Seems there is no visible impact, however if benchmarks tank after this PR is merged, I will revert it.