### PR TITLE
docs(runtime): fix HTTP server example

### DIFF
--- a/docs/runtime/http_server_apis.md
+++ b/docs/runtime/http_server_apis.md
@@ -127,10 +127,10 @@ while (true) {
     (async () => {
       const httpConn = Deno.serveHttp(conn);
       while (true) {
-        const requestEvent = await httpConn.nextRequest();
-        if (requestEvent) {
+        try {
+          const requestEvent = await httpConn.nextRequest();
           // ... handle requestEvent ...
-        } else {
+        } catch (err) {
           // the connection has finished
           break;
         }


### PR DESCRIPTION
Follow up on #10497 which seemingly missed one fix.