### PR TITLE
refactor(FormData/Serializer): Early fix for supporting async blob source

### DIFF
--- a/extensions/fetch/21_formdata.js
+++ b/extensions/fetch/21_formdata.js
@@ -13,7 +13,7 @@
 ((window) => {
   const core = window.Deno.core;
   const webidl = globalThis.__bootstrap.webidl;
-  const { Blob, File, _byteSequence } = globalThis.__bootstrap.file;
+  const { Blob, File } = globalThis.__bootstrap.file;
 
   const entryList = Symbol("entry list");
 
@@ -25,10 +25,10 @@
    */
   function createEntry(name, value, filename) {
     if (value instanceof Blob && !(value instanceof File)) {
-      value = new File([value[_byteSequence]], "blob", { type: value.type });
+      value = new File([value], "blob", { type: value.type });
     }
     if (value instanceof File && filename !== undefined) {
-      value = new File([value[_byteSequence]], filename, {
+      value = new File([value], filename, {
         type: value.type,
         lastModified: value.lastModified,
       });

--- a/extensions/fetch/21_formdata.js
+++ b/extensions/fetch/21_formdata.js
@@ -242,170 +242,40 @@
 
   webidl.configurePrototype(FormData);
 
-  class MultipartBuilder {
-    /**
-     * @param {FormData} formData
-     */
-    constructor(formData) {
-      this.entryList = formData[entryList];
-      this.boundary = this.#createBoundary();
-      /** @type {Uint8Array[]} */
-      this.chunks = [];
-    }
-
-    /**
-     * @returns {string}
-     */
-    getContentType() {
-      return `multipart/form-data; boundary=${this.boundary}`;
-    }
-
-    /**
-     * @returns {Uint8Array}
-     */
-    getBody() {
-      for (const { name, value } of this.entryList) {
-        if (value instanceof File) {
-          this.#writeFile(name, value);
-        } else this.#writeField(name, value);
-      }
-
-      this.chunks.push(core.encode(`\r\n--${this.boundary}--`));
-
-      let totalLength = 0;
-      for (const chunk of this.chunks) {
-        totalLength += chunk.byteLength;
-      }
-
-      const finalBuffer = new Uint8Array(totalLength);
-      let i = 0;
-      for (const chunk of this.chunks) {
-        finalBuffer.set(chunk, i);
-        i += chunk.byteLength;
-      }
-
-      return finalBuffer;
-    }
-
-    #createBoundary() {
-      return (
-        "----------" +
-        Array.from(Array(32))
-          .map(() => Math.random().toString(36)[2] || 0)
-          .join("")
-      );
-    }
-
-    /**
-     * @param {[string, string][]} headers
-     * @returns {void}
-     */
-    #writeHeaders(headers) {
-      let buf = (this.chunks.length === 0) ? "" : "\r\n";
-
-      buf += `--${this.boundary}\r\n`;
-      for (const [key, value] of headers) {
-        buf += `${key}: ${value}\r\n`;
-      }
-      buf += `\r\n`;
-
-      this.chunks.push(core.encode(buf));
-    }
-
-    /**
-     * @param {string} field
-     * @param {string} filename
-     * @param {string} [type]
-     * @returns {void}
-     */
-    #writeFileHeaders(
-      field,
-      filename,
-      type,
-    ) {
-      const escapedField = this.#headerEscape(field);
-      const escapedFilename = this.#headerEscape(filename, true);
-      /** @type {[string, string][]} */
-      const headers = [
-        [
-          "Content-Disposition",
-          `form-data; name="${escapedField}"; filename="${escapedFilename}"`,
-        ],
-        ["Content-Type", type || "application/octet-stream"],
-      ];
-      return this.#writeHeaders(headers);
-    }
-
-    /**
-     * @param {string} field
-     * @returns {void}
-     */
-    #writeFieldHeaders(field) {
-      /** @type {[string, string][]} */
-      const headers = [[
-        "Content-Disposition",
-        `form-data; name="${this.#headerEscape(field)}"`,
-      ]];
-      return this.#writeHeaders(headers);
-    }
-
-    /**
-     * @param {string} field
-     * @param {string} value
-     * @returns {void}
-     */
-    #writeField(field, value) {
-      this.#writeFieldHeaders(field);
-      this.chunks.push(core.encode(this.#normalizeNewlines(value)));
-    }
-
-    /**
-     * @param {string} field
-     * @param {File} value
-     * @returns {void}
-     */
-    #writeFile(field, value) {
-      this.#writeFileHeaders(field, value.name, value.type);
-      this.chunks.push(value[_byteSequence]);
-    }
-
-    /**
-     * @param {string} string
-     * @returns {string}
-     */
-    #normalizeNewlines(string) {
-      return string.replace(/\r(?!\n)|(?<!\r)\n/g, "\r\n");
-    }
-
-    /**
-     * Performs the percent-escaping and the normalization required for field
-     * names and filenames in Content-Disposition headers.
-     * @param {string} name
-     * @param {boolean} isFilename Whether we are encoding a filename. This
-     * skips the newline normalization that takes place for field names.
-     * @returns {string}
-     */
-    #headerEscape(name, isFilename = false) {
-      if (!isFilename) {
-        name = this.#normalizeNewlines(name);
-      }
-      return name
-        .replaceAll("\n", "%0A")
-        .replaceAll("\r", "%0D")
-        .replaceAll('"', "%22");
-    }
-  }
+  const escape = (str) =>
+    str.replace(/\n/g, "%0A").replace(/\r/g, "%0D").replace(/"/g, "%22");
 
   /**
-   * @param {FormData} formdata
-   * @returns {{body: Uint8Array, contentType: string}}
+   * convert FormData to a Blob synchronous without reading all of the files
+   * @param {globalThis.FormData} formData
    */
-  function encodeFormData(formdata) {
-    const builder = new MultipartBuilder(formdata);
-    return {
-      body: builder.getBody(),
-      contentType: builder.getContentType(),
-    };
+  function formDataToBlob(formData) {
+    const boundary = `${Math.random()}${Math.random()}`
+      .replaceAll(".", "").slice(-28).padStart(32, "-");
+    const chunks = [];
+    const prefix = `--${boundary}\r\nContent-Disposition: form-data; name="`;
+
+    for (const [name, value] of formData) {
+      if (typeof value === "string") {
+        chunks.push(
+          prefix + escape(name) + '"' + CRLF + CRLF +
+            value.replace(/\r(?!\n)|(?<!\r)\n/g, CRLF) + CRLF,
+        );
+      } else {
+        chunks.push(
+          prefix + escape(name) + `"; filename="${escape(value.name)}"` + CRLF +
+            `Content-Type: ${value.type || "application/octet-stream"}\r\n\r\n`,
+          value,
+          CRLF,
+        );
+      }
+    }
+
+    chunks.push(`--${boundary}--`);
+
+    return new Blob(chunks, {
+      type: "multipart/form-data; boundary=" + boundary,
+    });
   }
 
   /**
@@ -426,8 +296,9 @@
     return params;
   }
 
-  const LF = "\n".codePointAt(0);
-  const CR = "\r".codePointAt(0);
+  const CRLF = "\r\n";
+  const LF = CRLF.codePointAt(1);
+  const CR = CRLF.codePointAt(0);
 
   class MultipartParser {
     /**
@@ -575,7 +446,7 @@
 
   globalThis.__bootstrap.formData = {
     FormData,
-    encodeFormData,
+    formDataToBlob,
     parseFormData,
     formDataFromEntries,
   };

--- a/extensions/fetch/21_formdata.js
+++ b/extensions/fetch/21_formdata.js
@@ -242,8 +242,11 @@
 
   webidl.configurePrototype(FormData);
 
-  const escape = (str) =>
-    str.replace(/\n/g, "%0A").replace(/\r/g, "%0D").replace(/"/g, "%22");
+  const escape = (str, isFilename) =>
+    (isFilename ? str : str.replace(/\r?\n|\r/g, "\r\n"))
+    .replace(/\n/g, "%0A")
+    .replace(/\r/g, "%0D")
+    .replace(/"/g, "%22");
 
   /**
    * convert FormData to a Blob synchronous without reading all of the files
@@ -263,7 +266,7 @@
         );
       } else {
         chunks.push(
-          prefix + escape(name) + `"; filename="${escape(value.name)}"` + CRLF +
+          prefix + escape(name) + `"; filename="${escape(value.name, true)}"` + CRLF +
             `Content-Type: ${value.type || "application/octet-stream"}\r\n\r\n`,
           value,
           CRLF,

--- a/extensions/fetch/21_formdata.js
+++ b/extensions/fetch/21_formdata.js
@@ -244,9 +244,9 @@
 
   const escape = (str, isFilename) =>
     (isFilename ? str : str.replace(/\r?\n|\r/g, "\r\n"))
-    .replace(/\n/g, "%0A")
-    .replace(/\r/g, "%0D")
-    .replace(/"/g, "%22");
+      .replace(/\n/g, "%0A")
+      .replace(/\r/g, "%0D")
+      .replace(/"/g, "%22");
 
   /**
    * convert FormData to a Blob synchronous without reading all of the files
@@ -266,7 +266,8 @@
         );
       } else {
         chunks.push(
-          prefix + escape(name) + `"; filename="${escape(value.name, true)}"` + CRLF +
+          prefix + escape(name) + `"; filename="${escape(value.name, true)}"` +
+            CRLF +
             `Content-Type: ${value.type || "application/octet-stream"}\r\n\r\n`,
           value,
           CRLF,

--- a/extensions/fetch/22_body.js
+++ b/extensions/fetch/22_body.js
@@ -16,7 +16,7 @@
   const core = window.Deno.core;
   const webidl = globalThis.__bootstrap.webidl;
   const { parseUrlEncoded } = globalThis.__bootstrap.url;
-  const { parseFormData, formDataFromEntries, encodeFormData } =
+  const { parseFormData, formDataFromEntries, formDataToBlob } =
     globalThis.__bootstrap.formData;
   const mimesniff = globalThis.__bootstrap.mimesniff;
   const { isReadableStreamDisturbed, errorReadableStream } =
@@ -311,11 +311,11 @@
       const copy = u8.slice(0, u8.byteLength);
       source = copy;
     } else if (object instanceof FormData) {
-      const res = encodeFormData(object);
-      stream = { body: res.body, consumed: false };
-      source = object;
-      length = res.body.byteLength;
-      contentType = res.contentType;
+      const res = formDataToBlob(object);
+      stream = res.stream();
+      source = res;
+      length = res.size;
+      contentType = res.type;
     } else if (object instanceof URLSearchParams) {
       source = core.encode(object.toString());
       contentType = "application/x-www-form-urlencoded;charset=UTF-8";

--- a/extensions/fetch/internal.d.ts
+++ b/extensions/fetch/internal.d.ts
@@ -41,10 +41,9 @@ declare namespace globalThis {
 
     declare namespace formData {
       declare type FormData = typeof FormData;
-      declare function encodeFormData(formdata: FormData): {
-        body: Uint8Array;
-        contentType: string;
-      };
+      declare function formDataToBlob(
+        formData: globalThis.FormData,
+      ): Blob;
       declare function parseFormData(
         body: Uint8Array,
         boundary: string | undefined,


### PR DESCRIPTION
This new FormData Serializer takes a FormData and converts it into a new Blob with other preexisting Blob parts 

The benefits
- Less code
- Don't need to calculate the byte length (Content-Length) - you get it from the new blob instead
- Don't have to read the content of the File entries or keeping any of the File entry content in memory until it's necessary to read them after `blob.stream()` is called, hence more RAM friendly
- Still synchronous
  - Good for when you eg have to clone a Response `new Response(new FormData()).clone()`? but why would you? have have no idea, still a valid case?
- partially solves a blocker of async blob sources (#10969)

#### Other considerations/possible solutions: 
Returning a ReadableStream or async iterator... Converting it to a blob seems to be the most easiest.
I have used this formdata-to-blob technique in my [formdata-polyfill](https://github.com/jimmywarting/FormData) for years by converting it into a blob since IE9 was a thing in the past

---

The old Serializer did read the content from File Entries using `_byteSequence`. That is no longer going to be supported once we have async blob sources that can originate from the filesystem and don't hold the data in memory