### PR TITLE
docs(core): replaces dispatch references with op

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -16,13 +16,17 @@ keeps track of all pending tasks (async ops, dynamic module loads). It is user's
 responsibility to drive that loop by using `JsRuntime::run_event_loop` method -
 it must be executed in the context of Rust's future executor (eg. tokio, smol).
 
-In order to bind Rust functions into JavaScript, use the `Deno.core.dispatch()`
-function to trigger the "dispatch" callback in Rust. The user is responsible for
-encoding both the request and response into a Uint8Array.
+In order to bind Rust functions into JavaScript, use the `Deno.core.opSync()` 
+and `Deno.core.opAsync()` functions to trigger the "op_fn" callback in 
+`JsRuntime::register_op` on Rust side. A conventional way to handle "op_fn" 
+callbacks is to use the `op_sync` and `op_async` functions. 
 
-Documentation for this crate is thin at the moment. Please see
-[http_bench_json_ops.rs](https://github.com/denoland/deno/blob/main/core/examples/http_bench_json_ops.rs)
-as a simple example of usage.
+Documentation for this crate is thin at the moment. 
+Please see
+[hello_world.rs](https://github.com/denoland/deno/blob/main/core/examples/hello_world.rs) 
+and
+[http_bench_json_ops.rs](https://github.com/denoland/deno/blob/main/core/examples/http_bench_json_ops.rs) 
+as examples of usage.
 
 TypeScript support and lots of other functionality are not available at this
 layer. See the [CLI](https://github.com/denoland/deno/tree/main/cli) for that.

--- a/core/README.md
+++ b/core/README.md
@@ -16,16 +16,15 @@ keeps track of all pending tasks (async ops, dynamic module loads). It is user's
 responsibility to drive that loop by using `JsRuntime::run_event_loop` method -
 it must be executed in the context of Rust's future executor (eg. tokio, smol).
 
-In order to bind Rust functions into JavaScript, use the `Deno.core.opSync()` 
-and `Deno.core.opAsync()` functions to trigger the "op_fn" callback in 
-`JsRuntime::register_op` on Rust side. A conventional way to handle "op_fn" 
-callbacks is to use the `op_sync` and `op_async` functions. 
+In order to bind Rust functions into JavaScript, use the `Deno.core.opSync()`
+and `Deno.core.opAsync()` functions to trigger the "op_fn" callback in
+`JsRuntime::register_op` on Rust side. A conventional way to handle "op_fn"
+callbacks is to use the `op_sync` and `op_async` functions.
 
-Documentation for this crate is thin at the moment. 
-Please see
-[hello_world.rs](https://github.com/denoland/deno/blob/main/core/examples/hello_world.rs) 
+Documentation for this crate is thin at the moment. Please see
+[hello_world.rs](https://github.com/denoland/deno/blob/main/core/examples/hello_world.rs)
 and
-[http_bench_json_ops.rs](https://github.com/denoland/deno/blob/main/core/examples/http_bench_json_ops.rs) 
+[http_bench_json_ops.rs](https://github.com/denoland/deno/blob/main/core/examples/http_bench_json_ops.rs)
 as examples of usage.
 
 TypeScript support and lots of other functionality are not available at this


### PR DESCRIPTION
The README had confused me while I was studying `deno_core` 