### PR TITLE
fix: add support for module es2020 to Deno.emit

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -325,6 +325,7 @@ declare namespace Deno {
       | "umd"
       | "es6"
       | "es2015"
+      | "es2020"
       | "esnext";
     /** Do not generate custom helper functions like `__extends` in compiled
      * output. Defaults to `false`. */


### PR DESCRIPTION
This was added in TypeScript 4.3 but we neglected to reflect it in the `Deno.CompilerOptions` interface.