### PR TITLE
fix(runtime): fix signal promise API

### DIFF
--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -236,7 +236,15 @@
       f,
       g,
     ) {
-      return this.#pollingPromise.then(() => {}).then(f, g);
+      return this.#pollingPromise.then((done) => {
+        if (done) {
+          // If pollingPromise returns true, then
+          // this signal stream is finished and the promise API
+          // should never be resolved.
+          return new Promise(() => {});
+        }
+        return;
+      }).then(f, g);
     }
 
     async next() {


### PR DESCRIPTION
This PR fixes the wrong detection of signal event in Promise API when disposing the signal stream.

closes #9806