### PR TITLE
feat(extensions/webstorage): Allow user to specify the amount of space to use for `webstorage`

### DIFF
--- a/extensions/webstorage/01_webstorage.js
+++ b/extensions/webstorage/01_webstorage.js
@@ -30,6 +30,10 @@
       return core.opSync("op_webstorage_key", index, this[_persistent]);
     }
 
+    setLimitStorage(size) {
+      this.size = size;
+    }
+
     setItem(key, value) {
       webidl.assertBranded(this, Storage);
       const prefix = "Failed to execute 'setItem' on 'Storage'";
@@ -43,10 +47,15 @@
         context: "Argument 2",
       });
 
-      core.opSync("op_webstorage_set", {
-        keyName: key,
-        keyValue: value,
-      }, this[_persistent]);
+      const sizeLimit = this.size || 500000;
+
+      core.opSync("op_webstorage_set",{
+            keyName: key,
+            keyValue: value,
+            keyLimitStorage: sizeLimit,
+          },
+           this[_persistent]
+      );
     }
 
     getItem(key) {

--- a/extensions/webstorage/01_webstorage.js
+++ b/extensions/webstorage/01_webstorage.js
@@ -49,13 +49,11 @@
 
       const sizeLimit = this.size || 500000;
 
-      core.opSync("op_webstorage_set",{
-            keyName: key,
-            keyValue: value,
-            keyLimitStorage: sizeLimit,
-          },
-           this[_persistent]
-      );
+      core.opSync("op_webstorage_set", {
+        keyName: key,
+        keyValue: value,
+        keyLimitStorage: sizeLimit,
+      }, this[_persistent]);
     }
 
     getItem(key) {

--- a/extensions/webstorage/lib.deno_webstorage.d.ts
+++ b/extensions/webstorage/lib.deno_webstorage.d.ts
@@ -33,6 +33,12 @@ interface Storage {
    * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set. (Setting could fail if, e.g., the user has disabled storage for the site, or if the quota has been exceeded.)
    */
   setItem(key: string, value: string): void;
+
+  /**
+   * Sets the storage limits. By default deno takes 5MB.
+   */
+  setLimitStorage(size: number): void;
+
   [name: string]: any;
 }
 

--- a/extensions/webstorage/lib.rs
+++ b/extensions/webstorage/lib.rs
@@ -123,7 +123,7 @@ pub fn op_webstorage_key(
 pub struct SetArgs {
   key_name: String,
   key_value: String,
-  key_limit_storage: u32
+  key_limit_storage: u32,
 }
 
 pub fn op_webstorage_set(
@@ -131,7 +131,6 @@ pub fn op_webstorage_set(
   args: SetArgs,
   persistent: bool,
 ) -> Result<(), AnyError> {
-
   let conn = get_webstorage(state, persistent)?;
 
   let mut stmt =

--- a/extensions/webstorage/lib.rs
+++ b/extensions/webstorage/lib.rs
@@ -123,6 +123,7 @@ pub fn op_webstorage_key(
 pub struct SetArgs {
   key_name: String,
   key_value: String,
+  key_limit_storage: u32
 }
 
 pub fn op_webstorage_set(
@@ -130,16 +131,17 @@ pub fn op_webstorage_set(
   args: SetArgs,
   persistent: bool,
 ) -> Result<(), AnyError> {
+
   let conn = get_webstorage(state, persistent)?;
 
   let mut stmt =
     conn.prepare("SELECT SUM(pgsize) FROM dbstat WHERE name = 'data'")?;
   let size: u32 = stmt.query_row(params![], |row| row.get(0))?;
 
-  if size >= 5000000 {
+  if size >= args.key_limit_storage {
     return Err(
       deno_web::DomExceptionQuotaExceededError::new(
-        "Exceeded maximum storage size",
+        "Exceeded maximum storage size ",
       )
       .into(),
     );


### PR DESCRIPTION
I think it would be a good idea to let the user specify how much space they want to reserve,
By default deno take `5MB`.

## Example:

```ts
localStorage.setLimitStorage(80000);
```