### PR TITLE
chore(lsp): switch to use lsp to get parent process id

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -84,9 +84,7 @@ pub enum DenoSubcommand {
     root: Option<PathBuf>,
     force: bool,
   },
-  Lsp {
-    parent_pid: Option<u32>,
-  },
+  Lsp,
   Lint {
     files: Vec<PathBuf>,
     ignore: Vec<PathBuf>,
@@ -878,16 +876,6 @@ go-to-definition support and automatic code formatting.
 
 How to connect various editors and IDEs to 'deno lsp':
 https://deno.land/manual/getting_started/setup_your_environment#editors-and-ides")
-    .arg(
-      Arg::with_name("parent-pid")
-        .long("parent-pid")
-        .help("The parent process id to periodically check for the existence of or exit")
-        .takes_value(true)
-        .validator(|val: String| match val.parse::<usize>() {
-          Ok(_) => Ok(()),
-          Err(_) => Err("parent-pid should be a number".to_string()),
-        }),
-    )
 }
 
 fn lint_subcommand<'a, 'b>() -> App<'a, 'b> {
@@ -1633,11 +1621,8 @@ fn install_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   };
 }
 
-fn lsp_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
-  let parent_pid = matches
-    .value_of("parent-pid")
-    .map(|val| val.parse().unwrap());
-  flags.subcommand = DenoSubcommand::Lsp { parent_pid };
+fn lsp_parse(flags: &mut Flags, _matches: &clap::ArgMatches) {
+  flags.subcommand = DenoSubcommand::Lsp;
 }
 
 fn lint_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
@@ -2315,32 +2300,6 @@ mod tests {
         ..Flags::default()
       }
     );
-  }
-
-  #[test]
-  fn lsp() {
-    let r = flags_from_vec(svec!["deno", "lsp"]);
-    assert_eq!(
-      r.unwrap(),
-      Flags {
-        subcommand: DenoSubcommand::Lsp { parent_pid: None },
-        ..Flags::default()
-      }
-    );
-
-    let r = flags_from_vec(svec!["deno", "lsp", "--parent-pid", "5"]);
-    assert_eq!(
-      r.unwrap(),
-      Flags {
-        subcommand: DenoSubcommand::Lsp {
-          parent_pid: Some(5),
-        },
-        ..Flags::default()
-      }
-    );
-
-    let r = flags_from_vec(svec!["deno", "lsp", "--parent-pid", "invalid-arg"]);
-    assert!(r.is_err());
   }
 
   #[test]

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -39,6 +39,7 @@ use super::diagnostics::DiagnosticSource;
 use super::documents::DocumentCache;
 use super::documents::LanguageId;
 use super::lsp_custom;
+use super::parent_process_checker;
 use super::performance::Performance;
 use super::registries;
 use super::sources;
@@ -529,6 +530,11 @@ impl Inner {
   ) -> LspResult<InitializeResult> {
     info!("Starting Deno language server...");
     let mark = self.performance.mark("initialize", Some(&params));
+
+    // exit this process when the parent is lost
+    if let Some(parent_pid) = params.process_id {
+      parent_process_checker::start(parent_pid)
+    }
 
     let capabilities = capabilities::server_capabilities(&params.capabilities);
 

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -23,13 +23,9 @@ mod text;
 mod tsc;
 mod urls;
 
-pub async fn start(parent_pid: Option<u32>) -> Result<(), AnyError> {
+pub async fn start() -> Result<(), AnyError> {
   let stdin = tokio::io::stdin();
   let stdout = tokio::io::stdout();
-
-  if let Some(parent_pid) = parent_pid {
-    parent_process_checker::start(parent_pid);
-  }
 
   let (service, messages) =
     LspService::new(language_server::LanguageServer::new);

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -467,8 +467,8 @@ async fn install_command(
   tools::installer::install(flags, &module_url, args, name, root, force)
 }
 
-async fn lsp_command(parent_pid: Option<u32>) -> Result<(), AnyError> {
-  lsp::start(parent_pid).await
+async fn lsp_command() -> Result<(), AnyError> {
+  lsp::start().await
 }
 
 async fn lint_command(
@@ -1295,7 +1295,7 @@ fn get_subcommand(
     } => {
       install_command(flags, module_url, args, name, root, force).boxed_local()
     }
-    DenoSubcommand::Lsp { parent_pid } => lsp_command(parent_pid).boxed_local(),
+    DenoSubcommand::Lsp => lsp_command().boxed_local(),
     DenoSubcommand::Lint {
       files,
       rules,


### PR DESCRIPTION
After seeing the vscode PR, @kitsonk pointed out we should use some custom messaging in the lsp to pass the parent process id and this made sense to me as the `--parent-pid <pid>` flag was inconvenient because it required us to version sniff to ensure we didn't pass it to old versions of the executable (something I hadn't considered).

While investigating moving it to the LSP, I discovered that the parent PID is already passed to us for free (https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#initializeParams) 🙈

This will be much better and doesn't require any changes in vscode_deno. It's unfortunate we didn't notice this earlier for the patch release yesterday though.