### PR TITLE
test(cli): refactor the usages of delay

### DIFF
--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -8,6 +8,7 @@ import {
   assertEquals,
   assertThrowsAsync,
   deferred,
+  delay,
   unitTest,
 } from "./test_util.ts";
 
@@ -375,8 +376,6 @@ unitTest(
 unitTest(
   { perms: { net: true } },
   async function httpServerNextRequestResolvesOnClose() {
-    const delay = (n: number) =>
-      new Promise((resolve) => setTimeout(resolve, n));
     const httpConnList: Deno.HttpConn[] = [];
 
     async function serve(l: Deno.Listener) {

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -6,6 +6,7 @@ import {
   assertThrows,
   assertThrowsAsync,
   deferred,
+  delay,
   unitTest,
 } from "./test_util.ts";
 
@@ -409,9 +410,7 @@ unitTest(
     const listener = Deno.listen(addr);
     iterate(listener);
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 100);
-    });
+    await delay(100);
     const conn1 = await Deno.connect(addr);
     conn1.close();
     const conn2 = await Deno.connect(addr);

--- a/cli/tests/unit/signal_test.ts
+++ b/cli/tests/unit/signal_test.ts
@@ -4,14 +4,9 @@ import {
   assertEquals,
   assertThrows,
   deferred,
+  delay,
   unitTest,
 } from "./test_util.ts";
-
-function defer(n: number): Promise<void> {
-  return new Promise((resolve: () => void, _) => {
-    setTimeout(resolve, n);
-  });
-}
 
 unitTest(
   { ignore: Deno.build.os !== "windows" },
@@ -113,11 +108,11 @@ unitTest(
     let c = 0;
     const sig = Deno.signal(Deno.Signal.SIGUSR1);
     setTimeout(async () => {
-      await defer(20);
+      await delay(20);
       for (const _ of Array(3)) {
         // Sends SIGUSR1 3 times.
         Deno.kill(Deno.pid, Deno.Signal.SIGUSR1);
-        await defer(20);
+        await delay(20);
       }
       sig.dispose();
       resolvable.resolve();

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -22,6 +22,7 @@ export {
 } from "../../../test_util/std/testing/asserts.ts";
 export { deferred } from "../../../test_util/std/async/deferred.ts";
 export type { Deferred } from "../../../test_util/std/async/deferred.ts";
+export { delay } from "../../../test_util/std/async/delay.ts";
 export { readLines } from "../../../test_util/std/io/bufio.ts";
 export { parse as parseArgs } from "../../../test_util/std/flags/mod.ts";
 

--- a/cli/tests/unit/timers_test.ts
+++ b/cli/tests/unit/timers_test.ts
@@ -5,12 +5,9 @@ import {
   assertNotEquals,
   Deferred,
   deferred,
+  delay,
   unitTest,
 } from "./test_util.ts";
-
-function waitForMs(ms: number): Promise<void> {
-  return new Promise((resolve): number => setTimeout(resolve, ms));
-}
 
 unitTest(async function functionParameterBindingSuccess(): Promise<void> {
   const promise = deferred();
@@ -111,7 +108,7 @@ unitTest(async function timeoutCancelSuccess(): Promise<void> {
   }, 1);
   // Cancelled, count should not increment
   clearTimeout(id);
-  await waitForMs(600);
+  await delay(600);
   assertEquals(count, 0);
 });
 
@@ -137,7 +134,7 @@ unitTest(async function timeoutCancelMultiple(): Promise<void> {
   clearTimeout(t4);
 
   // Sleep until we're certain that the cancelled timers aren't gonna fire.
-  await waitForMs(50);
+  await delay(50);
 });
 
 unitTest(async function timeoutCancelInvalidSilentFail(): Promise<void> {
@@ -172,7 +169,7 @@ unitTest(async function intervalSuccess(): Promise<void> {
   assertEquals(count, 1);
   // Similar false async leaking alarm.
   // Force next round of polling.
-  await waitForMs(0);
+  await delay(0);
 });
 
 unitTest(async function intervalCancelSuccess(): Promise<void> {
@@ -181,7 +178,7 @@ unitTest(async function intervalCancelSuccess(): Promise<void> {
     count++;
   }, 1);
   clearInterval(id);
-  await waitForMs(500);
+  await delay(500);
   assertEquals(count, 0);
 });
 
@@ -197,7 +194,7 @@ unitTest(async function intervalOrdering(): Promise<void> {
   for (let i = 0; i < 10; i++) {
     timers[i] = setTimeout(onTimeout, 1);
   }
-  await waitForMs(500);
+  await delay(500);
   assertEquals(timeouts, 1);
 });
 
@@ -213,7 +210,7 @@ unitTest(async function fireCallbackImmediatelyWhenDelayOverMaxValue(): Promise<
   setTimeout((): void => {
     count++;
   }, 2 ** 31);
-  await waitForMs(1);
+  await delay(1);
   assertEquals(count, 1);
 });
 
@@ -341,7 +338,7 @@ unitTest(async function timerMaxCpuBug(): Promise<void> {
   // We can check this by counting how many ops have triggered in the interim.
   // Certainly less than 10 ops should have been dispatched in next 100 ms.
   const { opsDispatched } = Deno.metrics();
-  await waitForMs(100);
+  await delay(100);
   const opsDispatched_ = Deno.metrics().opsDispatched;
   assert(opsDispatched_ - opsDispatched < 10);
 });
@@ -459,7 +456,7 @@ unitTest(
     const long = 10;
 
     const start = perf.now();
-    const p = sleepAsync(short).then(() => {
+    const p = delay(short).then(() => {
       const after = perf.now();
       // pending promises should resolve after the main thread comes out of sleep
       assert(after - start >= long);
@@ -478,7 +475,7 @@ unitTest(
     const long = 10;
 
     const start = perf.now();
-    const p = sleepAsync(long).then(() => {
+    const p = delay(long).then(() => {
       const after = perf.now();
       // sleeping for less than the duration of a promise should have no impact
       // on the resolution of that promise
@@ -489,9 +486,3 @@ unitTest(
     await p;
   },
 );
-
-function sleepAsync(delay: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(() => resolve(), delay);
-  });
-}


### PR DESCRIPTION
This PR refactors the usages of `delay` utility in js unit testing. The same utiliy is defined in several places with different names. This PR replaces those usages with the one provided in `std/async/delay.ts` to improve the readability and consistency of test code.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
