### PR TITLE
fix: make readonly `Event` properties readonly

### DIFF
--- a/cli/tests/unit/event_test.ts
+++ b/cli/tests/unit/event_test.ts
@@ -138,17 +138,17 @@ unitTest(function inspectEvent(): void {
   assertEquals(
     Deno.inspect(Event.prototype),
     `Event {
-  bubbles: [Getter/Setter],
-  cancelable: [Getter/Setter],
-  composed: [Getter/Setter],
-  currentTarget: [Getter/Setter],
-  defaultPrevented: [Getter/Setter],
-  eventPhase: [Getter/Setter],
+  bubbles: [Getter],
+  cancelable: [Getter],
+  composed: [Getter],
+  currentTarget: [Getter],
+  defaultPrevented: [Getter],
+  eventPhase: [Getter],
   srcElement: [Getter/Setter],
-  target: [Getter/Setter],
+  target: [Getter],
   returnValue: [Getter/Setter],
-  timeStamp: [Getter/Setter],
-  type: [Getter/Setter]
+  timeStamp: [Getter],
+  type: [Getter]
 }`,
   );
 

--- a/extensions/web/02_event.js
+++ b/extensions/web/02_event.js
@@ -150,27 +150,23 @@
     get type() {
       return this[_attributes].type;
     }
-    set type(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get target() {
       return this[_attributes].target;
     }
-    set target(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get srcElement() {
       return null;
     }
+
     set srcElement(_) {
-      // this is a no-op because this member is readonly
+      // this member is deprecated
     }
+
     get currentTarget() {
       return this[_attributes].currentTarget;
     }
-    set currentTarget(_) {
-      // this is a no-op because this member is readonly
-    }
+
     composedPath() {
       const path = this[_path];
       if (path.length === 0) {
@@ -279,67 +275,51 @@
     get NONE() {
       return Event.NONE;
     }
-    set NONE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get CAPTURING_PHASE() {
       return Event.CAPTURING_PHASE;
     }
-    set CAPTURING_PHASE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get AT_TARGET() {
       return Event.AT_TARGET;
     }
-    set AT_TARGET(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get BUBBLING_PHASE() {
       return Event.BUBBLING_PHASE;
     }
-    set BUBBLING_PHASE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     static get NONE() {
       return 0;
     }
-    static set NONE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     static get CAPTURING_PHASE() {
       return 1;
     }
-    static set CAPTURING_PHASE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     static get AT_TARGET() {
       return 2;
     }
-    static set AT_TARGET(_) {
-      // this is a no-op because this member is readonly
-    }
+
     static get BUBBLING_PHASE() {
       return 3;
     }
-    static set BUBBLING_PHASE(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get eventPhase() {
       return this[_attributes].eventPhase;
-    }
-    set eventPhase(_) {
-      // this is a no-op because this member is readonly
     }
 
     stopPropagation() {
       this[_stopPropagationFlag] = true;
     }
+
     get cancelBubble() {
       return this[_stopPropagationFlag];
     }
+
     set cancelBubble(value) {
       this[_stopPropagationFlag] = webidl.converters.boolean(value);
     }
+
     stopImmediatePropagation() {
       this[_stopPropagationFlag] = true;
       this[_stopImmediatePropagationFlag] = true;
@@ -348,39 +328,33 @@
     get bubbles() {
       return this[_attributes].bubbles;
     }
-    set bubbles(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get cancelable() {
       return this[_attributes].cancelable;
     }
-    set cancelable(value) {
-      // this is a no-op because this member is readonly
-    }
+
     get returnValue() {
       return !this[_canceledFlag];
     }
+
     set returnValue(value) {
       if (!webidl.converters.boolean(value)) {
         this[_canceledFlag] = true;
       }
     }
+
     preventDefault() {
       if (this[_attributes].cancelable && !this[_inPassiveListener]) {
         this[_canceledFlag] = true;
       }
     }
+
     get defaultPrevented() {
       return this[_canceledFlag];
     }
-    set defaultPrevented(_) {
-      // this is a no-op because this member is readonly
-    }
+
     get composed() {
       return this[_attributes].composed;
-    }
-    set composed(_) {
-      // this is a no-op because this member is readonly
     }
 
     get initialized() {
@@ -389,9 +363,6 @@
 
     get timeStamp() {
       return this[_attributes].timeStamp;
-    }
-    set timeStamp(_) {
-      // this is a no-op because this member is readonly
     }
   }
 

--- a/extensions/websocket/01_websocket.js
+++ b/extensions/websocket/01_websocket.js
@@ -241,18 +241,15 @@
             this[_readyState] = CLOSED;
 
             const errEvent = new ErrorEvent("error");
-            errEvent.target = this;
             this.dispatchEvent(errEvent);
 
             const event = new CloseEvent("close");
-            event.target = this;
             this.dispatchEvent(event);
             tryClose(this[_rid]);
           });
         } else {
           this[_readyState] = OPEN;
           const event = new Event("open");
-          event.target = this;
           this.dispatchEvent(event);
 
           this.#eventLoop();
@@ -264,11 +261,9 @@
           "error",
           { error: err, message: err.toString() },
         );
-        errorEv.target = this;
         this.dispatchEvent(errorEv);
 
         const closeEv = new CloseEvent("close");
-        closeEv.target = this;
         this.dispatchEvent(closeEv);
       });
     }
@@ -372,7 +367,6 @@
             code: code ?? 1005,
             reason,
           });
-          event.target = this;
           this.dispatchEvent(event);
           tryClose(this[_rid]);
         });
@@ -392,7 +386,6 @@
               data: value,
               origin: this[_url],
             });
-            event.target = this;
             this.dispatchEvent(event);
             break;
           }
@@ -409,7 +402,6 @@
               data,
               origin: this[_url],
             });
-            event.target = this;
             this.dispatchEvent(event);
             break;
           }
@@ -428,7 +420,6 @@
               code: value.code,
               reason: value.reason,
             });
-            event.target = this;
             this.dispatchEvent(event);
             tryClose(this[_rid]);
             break;
@@ -439,11 +430,9 @@
             const errorEv = new ErrorEvent("error", {
               message: value,
             });
-            errorEv.target = this;
             this.dispatchEvent(errorEv);
 
             const closeEv = new CloseEvent("close");
-            closeEv.target = this;
             this.dispatchEvent(closeEv);
             tryClose(this[_rid]);
             break;


### PR DESCRIPTION
Fix the `Event` class so its readonly properties are actually readonly.

Refs:

* https://developer.mozilla.org/en-US/docs/Web/API/Event
* See https://github.com/denoland/deno/pull/10979#discussion_r652105638 for discussion