### PR TITLE
fix(lsp): reload import registries should not error when the module registries directory does not exist

### DIFF
--- a/cli/fs_util.rs
+++ b/cli/fs_util.rs
@@ -161,6 +161,16 @@ where
   Ok(target_files)
 }
 
+// Asynchronously removes a directory and all its descendants, but does not error
+// when the directory does not exist.
+pub async fn remove_dir_all_if_not_exists(path: &Path) -> std::io::Result<()> {
+  let result = tokio::fs::remove_dir_all(path).await;
+  match result {
+    Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+    _ => result,
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/cli/fs_util.rs
+++ b/cli/fs_util.rs
@@ -163,7 +163,7 @@ where
 
 // Asynchronously removes a directory and all its descendants, but does not error
 // when the directory does not exist.
-pub async fn remove_dir_all_if_not_exists(path: &Path) -> std::io::Result<()> {
+pub async fn remove_dir_all_if_exists(path: &Path) -> std::io::Result<()> {
   let result = tokio::fs::remove_dir_all(path).await;
   match result {
     Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -54,6 +54,7 @@ use super::urls;
 use crate::config_file::ConfigFile;
 use crate::config_file::TsConfig;
 use crate::deno_dir;
+use crate::fs_util;
 use crate::import_map::ImportMap;
 use crate::logger;
 use crate::media_type::MediaType;
@@ -2410,7 +2411,7 @@ impl Inner {
   }
 
   async fn reload_import_registries(&mut self) -> LspResult<Option<Value>> {
-    fs::remove_dir_all(&self.module_registries_location)
+    fs_util::remove_dir_all_if_not_exists(&self.module_registries_location)
       .await
       .map_err(|err| {
         error!("Unable to remove registries cache: {}", err);

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -2411,7 +2411,7 @@ impl Inner {
   }
 
   async fn reload_import_registries(&mut self) -> LspResult<Option<Value>> {
-    fs_util::remove_dir_all_if_not_exists(&self.module_registries_location)
+    fs_util::remove_dir_all_if_exists(&self.module_registries_location)
       .await
       .map_err(|err| {
         error!("Unable to remove registries cache: {}", err);


### PR DESCRIPTION
The `remove_dir_all` function will error when the directory does not exist. This is the cause of https://github.com/denoland/vscode_deno/issues/394

Classic bug 😊