### PR TITLE
feat(cli): Exit the test suite immediately upon `n` number of failing test suite

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1020,6 +1020,7 @@ fn test_subcommand<'a, 'b>() -> App<'a, 'b> {
     .arg(
       Arg::with_name("bail")
       .long("bail")
+      .short("b")
       .help("Exit the test suite immediately upon n number of failing test suite")
       .min_values(1)
     )

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1019,10 +1019,12 @@ fn test_subcommand<'a, 'b>() -> App<'a, 'b> {
     )
     .arg(
       Arg::with_name("bail")
-      .long("bail")
-      .short("b")
-      .help("Exit the test suite immediately upon n number of failing test suite")
-      .min_values(1)
+        .long("bail")
+        .short("b")
+        .help(
+          "Exit the test suite immediately upon n number of failing test suite",
+        )
+        .min_values(1),
     )
     .arg(
       Arg::with_name("coverage")
@@ -1699,7 +1701,7 @@ fn test_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   let bail = if matches.is_present("bail") {
     if let Some(value) = matches.value_of("bail") {
       value.parse().unwrap()
-    }else {
+    } else {
       0
     }
   } else {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -985,7 +985,6 @@ async fn test_command(
   concurrent_jobs: usize,
   bail: usize,
 ) -> Result<(), AnyError> {
-
   if let Some(ref coverage_dir) = flags.coverage_dir {
     std::fs::create_dir_all(&coverage_dir)?;
     env::set_var(
@@ -1317,7 +1316,7 @@ fn get_subcommand(
       allow_none,
       filter,
       concurrent_jobs,
-      bail
+      bail,
     } => test_command(
       flags,
       include,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -983,7 +983,9 @@ async fn test_command(
   allow_none: bool,
   filter: Option<String>,
   concurrent_jobs: usize,
+  bail: usize,
 ) -> Result<(), AnyError> {
+
   if let Some(ref coverage_dir) = flags.coverage_dir {
     std::fs::create_dir_all(&coverage_dir)?;
     env::set_var(
@@ -1171,6 +1173,7 @@ async fn test_command(
           true,
           filter.clone(),
           concurrent_jobs,
+          bail,
         )
         .map(|res| res.map(|_| ()))
       },
@@ -1206,6 +1209,7 @@ async fn test_command(
       allow_none,
       filter,
       concurrent_jobs,
+      bail,
     )
     .await?;
 
@@ -1313,6 +1317,7 @@ fn get_subcommand(
       allow_none,
       filter,
       concurrent_jobs,
+      bail
     } => test_command(
       flags,
       include,
@@ -1323,6 +1328,7 @@ fn get_subcommand(
       allow_none,
       filter,
       concurrent_jobs,
+      bail,
     )
     .boxed_local(),
     DenoSubcommand::Completions { buf } => {

--- a/cli/tools/test_runner.rs
+++ b/cli/tools/test_runner.rs
@@ -346,7 +346,6 @@ pub async fn run_tests(
   concurrent_jobs: usize,
   bail: usize,
 ) -> Result<bool, AnyError> {
-
   if !doc_modules.is_empty() {
     let mut test_programs = Vec::new();
 
@@ -530,7 +529,6 @@ pub async fn run_tests(
               failed += 1;
               has_error = true;
             }
-
           }
           _ => {}
         }


### PR DESCRIPTION
Alias: `-b`. Exit the test suite immediately upon `n` number of failing test suite. Minimum value is `1`.

Example :

```sh
deno test fetcher_test.ts --bail 3
```

Short style 

```
deno test fetcher_test.ts --b 3
```
