### PR TITLE
fix: specify AbortSignal for native http Request

### DIFF
--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -56,9 +56,12 @@ unitTest({ perms: { net: true } }, async function httpServerBasic() {
   const resp = await fetch("http://127.0.0.1:4501/", {
     headers: { "connection": "close" },
   });
+  const clone = resp.clone();
   const text = await resp.text();
   assertEquals(text, "Hello World");
   assertEquals(resp.headers.get("foo"), "bar");
+  const cloneText = await clone.text();
+  assertEquals(cloneText, "Hello World");
   await promise;
 });
 

--- a/runtime/js/40_http.js
+++ b/runtime/js/40_http.js
@@ -8,6 +8,7 @@
   const errors = window.__bootstrap.errors.errors;
   const core = window.Deno.core;
   const { ReadableStream } = window.__bootstrap.streams;
+  const abortSignal = window.__bootstrap.abortSignal;
 
   function serveHttp(conn) {
     const rid = Deno.core.opSync("op_http_start", conn.rid);
@@ -72,7 +73,8 @@
         headersList,
         body !== null ? new InnerBody(body) : null,
       );
-      const request = fromInnerRequest(innerRequest, null, "immutable");
+      const signal = abortSignal.newSignal();
+      const request = fromInnerRequest(innerRequest, signal, "immutable");
 
       const respondWith = createRespondWith(this, responseSenderRid);
 


### PR DESCRIPTION
Fixes #11116
