### PR TITLE
fix(cli): pretty print coverage files

### DIFF
--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -20,6 +20,9 @@ use serde::Deserialize;
 use serde::Serialize;
 use sourcemap::SourceMap;
 use std::fs;
+use std::fs::File;
+use std::io::BufWriter;
+use std::io::Write;
 use std::path::PathBuf;
 use swc_common::Span;
 use uuid::Uuid;
@@ -61,8 +64,12 @@ impl CoverageCollector {
     let script_coverages = take_coverage_result.result;
     for script_coverage in script_coverages {
       let filename = format!("{}.json", Uuid::new_v4());
-      let json = serde_json::to_string(&script_coverage)?;
-      fs::write(self.dir.join(filename), &json)?;
+      let filepath = self.dir.join(filename);
+
+      let mut out = BufWriter::new(File::create(filepath)?);
+      serde_json::to_writer_pretty(&mut out, &script_coverage)?;
+      out.write(b"\n")?;
+      out.flush()?;
     }
 
     self.session.post_message("Profiler.disable", None).await?;

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -68,7 +68,7 @@ impl CoverageCollector {
 
       let mut out = BufWriter::new(File::create(filepath)?);
       serde_json::to_writer_pretty(&mut out, &script_coverage)?;
-      out.write(b"\n")?;
+      out.write_all(b"\n")?;
       out.flush()?;
     }
 


### PR DESCRIPTION
This pretty prints the intermediary coverage files avoiding having to format them to make them human readable.