### PR TITLE
feat(inspector): improve inspector prompt in Chrome Devtools

### DIFF
--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -360,7 +360,11 @@ impl WebWorker {
       let inspector = js_runtime.inspector();
       let session_sender = inspector.get_session_sender();
       let deregister_rx = inspector.add_deregister_handler();
-      server.register_inspector(session_sender, deregister_rx);
+      server.register_inspector(
+        session_sender,
+        deregister_rx,
+        main_module.to_string(),
+      );
     }
 
     let (internal_handle, external_handle) = {

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -115,7 +115,7 @@ impl MainWorker {
       // Metrics
       metrics::init(),
       // Runtime ops
-      ops::runtime::init(main_module),
+      ops::runtime::init(main_module.clone()),
       ops::worker_host::init(options.create_web_worker_cb.clone()),
       ops::fs_events::init(),
       ops::fs::init(),
@@ -145,7 +145,11 @@ impl MainWorker {
       let inspector = js_runtime.inspector();
       let session_sender = inspector.get_session_sender();
       let deregister_rx = inspector.add_deregister_handler();
-      server.register_inspector(session_sender, deregister_rx);
+      server.register_inspector(
+        session_sender,
+        deregister_rx,
+        main_module.to_string(),
+      );
     }
 
     Self {


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/11135

This commit improves how Deno inspector presents itself in Chrome Devtools.

Before:
![123501615-768dee80-d646-11eb-8625-71f749b1ebb6](https://user-images.githubusercontent.com/13602871/123893206-456e3080-d95c-11eb-9b9b-b0dc1b547a90.png)

After:
![Screenshot 2021-06-30 at 04 31 36](https://user-images.githubusercontent.com/13602871/123893223-4dc66b80-d95c-11eb-9c7c-5ed69029e0ec.png)


For comparison here's Node's prompt:
![123501616-7988df00-d646-11eb-8e07-b2f27bad417b](https://user-images.githubusercontent.com/13602871/123893269-633b9580-d95c-11eb-8e17-dfd5f05291ab.png)
