### PR TITLE
test(integration/test): be more liberal with expectation wildcards

### DIFF
--- a/cli/tests/test/exit_sanitizer.out
+++ b/cli/tests/test/exit_sanitizer.out
@@ -8,42 +8,14 @@ failures:
 
 exit(0)
 AssertionError: Test case attempted to exit with exit code: 0
-    at assert (deno:runtime/js/06_util.js:36:13)
-    at deno:runtime/js/40_testing.js:92:9
-    at Object.exit (deno:runtime/js/30_os.js:52:7)
-    at [WILDCARD]/test/exit_sanitizer.ts:2:8
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at [WILDCARD]/$deno$test.js:1:27
+[WILDCARD]
 
 exit(1)
-AssertionError: Test case attempted to exit with exit code: 1
-    at assert (deno:runtime/js/06_util.js:36:13)
-    at deno:runtime/js/40_testing.js:92:9
-    at Object.exit (deno:runtime/js/30_os.js:52:7)
-    at [WILDCARD]/test/exit_sanitizer.ts:6:8
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at async [WILDCARD]/$deno$test.js:1:1
+[WILDCARD]
 
 exit(2)
 AssertionError: Test case attempted to exit with exit code: 2
-    at assert (deno:runtime/js/06_util.js:36:13)
-    at deno:runtime/js/40_testing.js:92:9
-    at Object.exit (deno:runtime/js/30_os.js:52:7)
-    at [WILDCARD]/test/exit_sanitizer.ts:10:8
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at async [WILDCARD]/$deno$test.js:1:1
+[WILDCARD]
 
 failures:
 

--- a/cli/tests/test/exit_sanitizer.out
+++ b/cli/tests/test/exit_sanitizer.out
@@ -8,14 +8,21 @@ failures:
 
 exit(0)
 AssertionError: Test case attempted to exit with exit code: 0
-[WILDCARD]
+    at [WILDCARD]
+    at [WILDCARD]/test/exit_sanitizer.ts:2:8
+    at [WILDCARD]
 
 exit(1)
-[WILDCARD]
+AssertionError: Test case attempted to exit with exit code: 1
+    at [WILDCARD]
+    at [WILDCARD]/test/exit_sanitizer.ts:6:8
+    at [WILDCARD]
 
 exit(2)
 AssertionError: Test case attempted to exit with exit code: 2
-[WILDCARD]
+    at [WILDCARD]
+    at [WILDCARD]/test/exit_sanitizer.ts:10:8
+    at [WILDCARD]
 
 failures:
 

--- a/cli/tests/test/fail.out
+++ b/cli/tests/test/fail.out
@@ -15,103 +15,43 @@ failures:
 
 test 0
 Error
-    at [WILDCARD]/test/fail.ts:2:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at [WILDCARD]/$deno$test.js:1:27
+[WILDCARD]
 
 test 1
 Error
-    at [WILDCARD]/test/fail.ts:5:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at async [WILDCARD]/$deno$test.js:1:1
+[WILDCARD]
 
 test 2
 Error
-    at [WILDCARD]/test/fail.ts:8:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at async [WILDCARD]/$deno$test.js:1:1
+[WILDCARD]
 
 test 3
 Error
-    at [WILDCARD]/test/fail.ts:11:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at async [WILDCARD]/$deno$test.js:1:1
+[WILDCARD]
 
 test 4
 Error
-    at [WILDCARD]/test/fail.ts:14:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at async [WILDCARD]/$deno$test.js:1:1
+[WILDCARD]
 
 test 5
 Error
-    at [WILDCARD]/test/fail.ts:17:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at async [WILDCARD]/$deno$test.js:1:1
+[WILDCARD]
 
 test 6
 Error
-    at [WILDCARD]/test/fail.ts:20:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at async [WILDCARD]/$deno$test.js:1:1
+[WILDCARD]
 
 test 7
 Error
-    at [WILDCARD]/test/fail.ts:23:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at async [WILDCARD]/$deno$test.js:1:1
+[WILDCARD]
 
 test 8
 Error
-    at [WILDCARD]/test/fail.ts:26:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at async [WILDCARD]/$deno$test.js:1:1
+[WILDCARD]
 
 test 9
 Error
-    at [WILDCARD]/test/fail.ts:29:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at async [WILDCARD]/$deno$test.js:1:1
+[WILDCARD]
 
 failures:
 

--- a/cli/tests/test/fail.out
+++ b/cli/tests/test/fail.out
@@ -15,43 +15,53 @@ failures:
 
 test 0
 Error
-[WILDCARD]
+    at [WILDCARD]/test/fail.ts:2:9
+    at [WILDCARD]
 
 test 1
 Error
-[WILDCARD]
+    at [WILDCARD]/test/fail.ts:5:9
+    at [WILDCARD]
 
 test 2
 Error
-[WILDCARD]
+    at [WILDCARD]/test/fail.ts:8:9
+    at [WILDCARD]
 
 test 3
 Error
-[WILDCARD]
+    at [WILDCARD]/test/fail.ts:11:9
+    at [WILDCARD]
 
 test 4
 Error
-[WILDCARD]
+    at [WILDCARD]/test/fail.ts:14:9
+    at [WILDCARD]
 
 test 5
 Error
-[WILDCARD]
+    at [WILDCARD]/test/fail.ts:17:9
+    at [WILDCARD]
 
 test 6
 Error
-[WILDCARD]
+    at [WILDCARD]/test/fail.ts:20:9
+    at [WILDCARD]
 
 test 7
 Error
-[WILDCARD]
+    at [WILDCARD]/test/fail.ts:23:9
+    at [WILDCARD]
 
 test 8
 Error
-[WILDCARD]
+    at [WILDCARD]/test/fail.ts:26:9
+    at [WILDCARD]
 
 test 9
 Error
-[WILDCARD]
+    at [WILDCARD]/test/fail.ts:29:9
+    at [WILDCARD]
 
 failures:
 

--- a/cli/tests/test/fail_fast.out
+++ b/cli/tests/test/fail_fast.out
@@ -6,13 +6,7 @@ failures:
 
 test 1
 Error
-    at [WILDCARD]/test/fail_fast.ts:2:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at [WILDCARD]/$deno$test.js:1:27
+[WILDCARD]
 
 failures:
 

--- a/cli/tests/test/fail_fast.out
+++ b/cli/tests/test/fail_fast.out
@@ -6,7 +6,8 @@ failures:
 
 test 1
 Error
-[WILDCARD]
+    at [WILDCARD]/test/fail_fast.ts:2:9
+    at [WILDCARD]
 
 failures:
 

--- a/cli/tests/test/finally_timeout.out
+++ b/cli/tests/test/finally_timeout.out
@@ -7,13 +7,7 @@ failures:
 
 error
 Error: fail
-    at [WILDCARD]/test/finally_timeout.ts:4:11
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:206:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:249:28)
-    at [WILDCARD]/$deno$test.js:1:27
+[WILDCARD]
 
 failures:
 

--- a/cli/tests/test/finally_timeout.out
+++ b/cli/tests/test/finally_timeout.out
@@ -7,7 +7,8 @@ failures:
 
 error
 Error: fail
-[WILDCARD]
+    at [WILDCARD]/test/finally_timeout.ts:4:11
+    at [WILDCARD]
 
 failures:
 

--- a/cli/tests/test/no_check.out
+++ b/cli/tests/test/no_check.out
@@ -4,5 +4,4 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WIL
 error: Uncaught TypeError: Cannot read property 'fn' of undefined
 Deno.test();
      ^
-    at Object.test (deno:runtime/js/40_testing.js:135:14)
-    at [WILDCARD]/test/no_check.ts:1:6
+[WILDCARD]

--- a/cli/tests/test/no_check.out
+++ b/cli/tests/test/no_check.out
@@ -4,4 +4,5 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WIL
 error: Uncaught TypeError: Cannot read property 'fn' of undefined
 Deno.test();
      ^
-[WILDCARD]
+    at [WILDCARD]
+    at [WILDCARD]/test/no_check.ts:1:6


### PR DESCRIPTION
Test expectations have gotten a bit too strict to the point where a new line change will break the stack.
This applies more liberal use of wildcards in the stack traces where failures are displayed.