### PR TITLE
chore: Upgrade Tokio to 1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,9 +3666,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
+checksum = "570c2eb13b3ab38208130eccd41be92520388791207fde783bda7c1e8ace28d4"
 dependencies = [
  "autocfg",
  "bytes",

--- a/bench_util/Cargo.toml
+++ b/bench_util/Cargo.toml
@@ -15,7 +15,7 @@ publish = true
 [dependencies]
 bencher = "0.1"
 deno_core = { version = "0.92.0", path = "../core" }
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 
 [[bench]]
 name = "op_baseline"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -84,7 +84,7 @@ swc_ecmascript = { version = "0.44.0", features = ["codegen", "dep_graph", "pars
 tempfile = "3.2.0"
 termcolor = "1.1.2"
 text-size = "1.1.0"
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 tokio-rustls = "0.22.0"
 uuid = { version = "0.8.2", features = ["v4", "serde"] }
 walkdir = "2.3.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,4 +32,4 @@ path = "examples/http_bench_json_ops.rs"
 
 # These dependencies are only used for the 'http_bench_*_ops' examples.
 [dev-dependencies]
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }

--- a/extensions/broadcast_channel/Cargo.toml
+++ b/extensions/broadcast_channel/Cargo.toml
@@ -16,5 +16,5 @@ path = "lib.rs"
 [dependencies]
 async-trait = "0.1"
 deno_core = { version = "0.92.0", path = "../../core" }
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 uuid = { version = "0.8.2", features = ["v4"] }

--- a/extensions/crypto/Cargo.toml
+++ b/extensions/crypto/Cargo.toml
@@ -16,7 +16,7 @@ path = "lib.rs"
 [dependencies]
 deno_core = { version = "0.92.0", path = "../../core" }
 deno_web = { version = "0.41.1", path = "../web" }
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 rand = "0.8.3"
 ring = "0.16.20"
 uuid = { version = "0.8.2", features = ["v4"] }

--- a/extensions/fetch/Cargo.toml
+++ b/extensions/fetch/Cargo.toml
@@ -21,6 +21,6 @@ deno_web = { version = "0.41.1", path = "../web" }
 http = "0.2.4"
 reqwest = { version = "0.11.3", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli"] }
 serde = { version = "1.0.125", features = ["derive"] }
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 tokio-stream = "0.1.5"
 tokio-util = "0.6.7"

--- a/extensions/net/Cargo.toml
+++ b/extensions/net/Cargo.toml
@@ -23,7 +23,7 @@ http = "0.2.3"
 hyper = { version = "0.14.9", features = ["server", "stream", "http1", "http2", "runtime"] }
 rustls = "0.19.0"
 serde = { version = "1.0.125", features = ["derive"] }
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 tokio-util = { version = "0.6", features = ["io"] }
 webpki = "0.21.4"
 webpki-roots = "0.21.1"

--- a/extensions/timers/Cargo.toml
+++ b/extensions/timers/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 deno_core = { version = "0.92.0", path = "../../core" }
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 
 [dev-dependencies]
 deno_bench_util = { version = "0.4.0", path = "../../bench_util" }

--- a/extensions/web/Cargo.toml
+++ b/extensions/web/Cargo.toml
@@ -18,7 +18,7 @@ base64 = "0.13.0"
 deno_core = { version = "0.92.0", path = "../../core" }
 encoding_rs = "0.8.28"
 serde = "1.0"
-tokio = "1.7"
+tokio = "1.8.0"
 uuid = { version = "0.8.2", features = ["v4"] }
 
 [dev-dependencies]

--- a/extensions/webgpu/Cargo.toml
+++ b/extensions/webgpu/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 deno_core = { version = "0.92.0", path = "../../core" }
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 serde = { version = "1.0.125", features = ["derive"] }
 wgpu-core = { version = "0.8.1", features = ["trace"] }
 wgpu-types = "0.8.0"

--- a/extensions/websocket/Cargo.toml
+++ b/extensions/websocket/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 deno_core = { version = "0.92.0", path = "../../core" }
 http = "0.2.3"
 serde = { version = "1.0.125", features = ["derive"] }
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 tokio-rustls = "0.22.0"
 tokio-tungstenite = { version = "0.14.0", features = ["rustls-tls"] }
 webpki = "0.21.4"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -68,7 +68,7 @@ ring = "0.16.20"
 serde = { version = "1.0.125", features = ["derive"] }
 sys-info = "0.9.0"
 termcolor = "1.1.2"
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -23,7 +23,7 @@ regex = "1.4.3"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 tempfile = "3.2.0"
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 tokio-rustls = "0.22.0"
 tokio-tungstenite = "0.14.0"
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Tokio 1.8.0 has  been released. https://github.com/tokio-rs/tokio/releases/tag/tokio-1.8.0