### PR TITLE
chore: add tests for assertion error when file contains only triple slash references

### DIFF
--- a/cli/tests/info/data_null_error/data_null_error.out
+++ b/cli/tests/info/data_null_error/data_null_error.out
@@ -1,0 +1,6 @@
+local: [WILDCARD]mod.ts
+type: TypeScript
+dependencies: 1 unique (total [WILDCARD])
+
+file://[WILDCARD]/mod.ts ([WILDCARD])
+└── file://[WILDCARD]/types.d.ts ([WILDCARD])

--- a/cli/tests/info/data_null_error/mod.ts
+++ b/cli/tests/info/data_null_error/mod.ts
@@ -1,0 +1,1 @@
+/// <reference path="./types.d.ts" />

--- a/cli/tests/info/data_null_error/types.d.ts
+++ b/cli/tests/info/data_null_error/types.d.ts
@@ -1,0 +1,1 @@
+declare class Test {}

--- a/cli/tests/integration/info_tests.rs
+++ b/cli/tests/integration/info_tests.rs
@@ -111,3 +111,10 @@ itest!(_054_info_local_imports {
   output: "054_info_local_imports.out",
   exit_code: 0,
 });
+
+// Tests for AssertionError where "data" is unexpectedly null when
+// a file contains only triple slash references (#11196)
+itest!(data_null_error {
+  args: "info info/data_null_error/mod.ts",
+  output: "info/data_null_error/data_null_error.out",
+});


### PR DESCRIPTION
Closes #11196.

This was fixed in swc (#11284). This just adds a test to ensure the issue doesn't happen in the future.