### PR TITLE
chore: use parking_lot instead of std::sync for locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "parking_lot",
  "pin-project",
  "rusty_v8",
  "serde",

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -17,6 +17,7 @@ use deno_core::error::uri_error;
 use deno_core::error::AnyError;
 use deno_core::futures;
 use deno_core::futures::future::FutureExt;
+use deno_core::parking_lot::Mutex;
 use deno_core::ModuleSpecifier;
 use deno_runtime::deno_fetch::reqwest;
 use deno_runtime::deno_web::BlobStore;
@@ -32,7 +33,6 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::Mutex;
 
 static DENO_AUTH_TOKENS: &str = "DENO_AUTH_TOKENS";
 pub const SUPPORTED_SCHEMES: [&str; 5] =
@@ -64,12 +64,12 @@ struct FileCache(Arc<Mutex<HashMap<ModuleSpecifier, File>>>);
 
 impl FileCache {
   pub fn get(&self, specifier: &ModuleSpecifier) -> Option<File> {
-    let cache = self.0.lock().unwrap();
+    let cache = self.0.lock();
     cache.get(specifier).cloned()
   }
 
   pub fn insert(&self, specifier: ModuleSpecifier, file: File) -> Option<File> {
-    let mut cache = self.0.lock().unwrap();
+    let mut cache = self.0.lock();
     cache.insert(specifier, file)
   }
 }

--- a/cli/file_watcher.rs
+++ b/cli/file_watcher.rs
@@ -4,6 +4,7 @@ use crate::colors;
 use deno_core::error::AnyError;
 use deno_core::futures::stream::{Stream, StreamExt};
 use deno_core::futures::Future;
+use deno_core::parking_lot::Mutex;
 use log::info;
 use notify::event::Event as NotifyEvent;
 use notify::event::EventKind;
@@ -17,7 +18,6 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
@@ -54,7 +54,7 @@ impl Stream for Debounce {
     self: Pin<&mut Self>,
     cx: &mut Context,
   ) -> Poll<Option<Self::Item>> {
-    let mut changed_paths = self.changed_paths.lock().unwrap();
+    let mut changed_paths = self.changed_paths.lock();
     if changed_paths.len() > 0 {
       Poll::Ready(Some(changed_paths.drain().collect()))
     } else {
@@ -232,7 +232,7 @@ fn new_watcher(
             .paths
             .iter()
             .filter_map(|path| path.canonicalize().ok());
-          let mut changed_paths = changed_paths.lock().unwrap();
+          let mut changed_paths = changed_paths.lock();
           changed_paths.extend(paths);
         }
       }

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -4,6 +4,7 @@ use crate::tokio_util::create_basic_runtime;
 
 use deno_core::error::anyhow;
 use deno_core::error::AnyError;
+use deno_core::parking_lot::RwLock;
 use deno_core::serde::Deserialize;
 use deno_core::serde_json;
 use deno_core::serde_json::Value;
@@ -15,7 +16,6 @@ use lspower::lsp;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::RwLock;
 use std::thread;
 use tokio::sync::mpsc;
 
@@ -241,7 +241,7 @@ impl Config {
                 Vec<(ModuleSpecifier, ModuleSpecifier)>,
                 Vec<lsp::ConfigurationItem>,
               ) = {
-                let settings = settings_ref.read().unwrap();
+                let settings = settings_ref.read();
                 (
                   settings
                     .specifiers
@@ -259,7 +259,7 @@ impl Config {
                 )
               };
               if let Ok(configs) = client.configuration(items).await {
-                let mut settings = settings_ref.write().unwrap();
+                let mut settings = settings_ref.write();
                 for (i, value) in configs.into_iter().enumerate() {
                   match serde_json::from_value::<SpecifierSettings>(value) {
                     Ok(specifier_settings) => {
@@ -276,12 +276,7 @@ impl Config {
               }
             }
             Some(ConfigRequest::Specifier(specifier, uri)) => {
-              if settings_ref
-                .read()
-                .unwrap()
-                .specifiers
-                .contains_key(&specifier)
-              {
+              if settings_ref.read().specifiers.contains_key(&specifier) {
                 continue;
               }
               if let Ok(value) = client
@@ -297,7 +292,6 @@ impl Config {
                   Ok(specifier_settings) => {
                     settings_ref
                       .write()
-                      .unwrap()
                       .specifiers
                       .insert(specifier, (uri, specifier_settings));
                   }
@@ -327,14 +321,14 @@ impl Config {
   }
 
   pub fn get_workspace_settings(&self) -> WorkspaceSettings {
-    self.settings.read().unwrap().workspace.clone()
+    self.settings.read().workspace.clone()
   }
 
   /// Set the workspace settings directly, which occurs during initialization
   /// and when the client does not support workspace configuration requests
   pub fn set_workspace_settings(&self, value: Value) -> Result<(), AnyError> {
     let workspace_settings = serde_json::from_value(value)?;
-    self.settings.write().unwrap().workspace = workspace_settings;
+    self.settings.write().workspace = workspace_settings;
     Ok(())
   }
 
@@ -345,14 +339,14 @@ impl Config {
       settings: self
         .settings
         .try_read()
-        .map_err(|_| anyhow!("Error reading settings."))?
+        .ok_or_else(|| anyhow!("Error reading settings."))?
         .clone(),
       workspace_folders: self.workspace_folders.clone(),
     })
   }
 
   pub fn specifier_enabled(&self, specifier: &ModuleSpecifier) -> bool {
-    let settings = self.settings.read().unwrap();
+    let settings = self.settings.read();
     settings
       .specifiers
       .get(specifier)
@@ -361,7 +355,7 @@ impl Config {
   }
 
   pub fn specifier_code_lens_test(&self, specifier: &ModuleSpecifier) -> bool {
-    let settings = self.settings.read().unwrap();
+    let settings = self.settings.read();
     let value = settings
       .specifiers
       .get(specifier)

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -19,6 +19,7 @@ use crate::text_encoding;
 
 use deno_core::error::anyhow;
 use deno_core::error::AnyError;
+use deno_core::parking_lot::Mutex;
 use deno_core::serde_json;
 use deno_core::ModuleSpecifier;
 use deno_runtime::permissions::Permissions;
@@ -27,7 +28,6 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::time::SystemTime;
 use tsc::NavigationTree;
 
@@ -174,57 +174,57 @@ impl Sources {
   }
 
   pub fn contains_key(&self, specifier: &ModuleSpecifier) -> bool {
-    self.0.lock().unwrap().contains_key(specifier)
+    self.0.lock().contains_key(specifier)
   }
 
   pub fn get_line_index(
     &self,
     specifier: &ModuleSpecifier,
   ) -> Option<LineIndex> {
-    self.0.lock().unwrap().get_line_index(specifier)
+    self.0.lock().get_line_index(specifier)
   }
 
   pub fn get_maybe_types(
     &self,
     specifier: &ModuleSpecifier,
   ) -> Option<analysis::ResolvedDependency> {
-    self.0.lock().unwrap().get_maybe_types(specifier)
+    self.0.lock().get_maybe_types(specifier)
   }
 
   pub fn get_maybe_warning(
     &self,
     specifier: &ModuleSpecifier,
   ) -> Option<String> {
-    self.0.lock().unwrap().get_maybe_warning(specifier)
+    self.0.lock().get_maybe_warning(specifier)
   }
 
   pub fn get_media_type(
     &self,
     specifier: &ModuleSpecifier,
   ) -> Option<MediaType> {
-    self.0.lock().unwrap().get_media_type(specifier)
+    self.0.lock().get_media_type(specifier)
   }
 
   pub fn get_navigation_tree(
     &self,
     specifier: &ModuleSpecifier,
   ) -> Option<tsc::NavigationTree> {
-    self.0.lock().unwrap().get_navigation_tree(specifier)
+    self.0.lock().get_navigation_tree(specifier)
   }
 
   pub fn get_script_version(
     &self,
     specifier: &ModuleSpecifier,
   ) -> Option<String> {
-    self.0.lock().unwrap().get_script_version(specifier)
+    self.0.lock().get_script_version(specifier)
   }
 
   pub fn get_source(&self, specifier: &ModuleSpecifier) -> Option<String> {
-    self.0.lock().unwrap().get_source(specifier)
+    self.0.lock().get_source(specifier)
   }
 
   pub fn len(&self) -> usize {
-    self.0.lock().unwrap().metadata.len()
+    self.0.lock().metadata.len()
   }
 
   pub fn resolve_import(
@@ -232,11 +232,11 @@ impl Sources {
     specifier: &str,
     referrer: &ModuleSpecifier,
   ) -> Option<(ModuleSpecifier, MediaType)> {
-    self.0.lock().unwrap().resolve_import(specifier, referrer)
+    self.0.lock().resolve_import(specifier, referrer)
   }
 
   pub fn specifiers(&self) -> Vec<ModuleSpecifier> {
-    self.0.lock().unwrap().metadata.keys().cloned().collect()
+    self.0.lock().metadata.keys().cloned().collect()
   }
 
   pub fn set_navigation_tree(
@@ -247,7 +247,6 @@ impl Sources {
     self
       .0
       .lock()
-      .unwrap()
       .set_navigation_tree(specifier, navigation_tree)
   }
 }
@@ -660,7 +659,7 @@ mod tests {
     let (sources, _) = setup();
     let specifier =
       resolve_url("foo://a/b/c.ts").expect("could not create specifier");
-    let sources = sources.0.lock().unwrap();
+    let sources = sources.0.lock();
     let mut redirects = sources.redirects.clone();
     let http_cache = sources.http_cache.clone();
     let actual = resolve_specifier(&specifier, &mut redirects, &http_cache);

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -56,6 +56,7 @@ use deno_core::error::AnyError;
 use deno_core::futures::future::FutureExt;
 use deno_core::futures::Future;
 use deno_core::located_script_name;
+use deno_core::parking_lot::Mutex;
 use deno_core::resolve_url_or_path;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
@@ -78,7 +79,6 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::sync::Mutex;
 use tools::test_runner;
 
 fn create_web_worker_callback(

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -13,6 +13,7 @@ use deno_core::error::generic_error;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::error::Context;
+use deno_core::parking_lot::Mutex;
 use deno_core::resolve_url_or_path;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
@@ -24,7 +25,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::sync::Mutex;
 
 pub fn init(rt: &mut deno_core::JsRuntime) {
   super::reg_async(rt, "op_emit", op_emit);

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -24,6 +24,7 @@ use deno_core::error::anyhow;
 use deno_core::error::get_custom_error_class;
 use deno_core::error::AnyError;
 use deno_core::error::Context;
+use deno_core::parking_lot::Mutex;
 use deno_core::resolve_url;
 use deno_core::url::Url;
 use deno_core::ModuleSource;
@@ -35,7 +36,6 @@ use std::collections::HashSet;
 use std::env;
 use std::fs::read;
 use std::sync::Arc;
-use std::sync::Mutex;
 
 /// This structure represents state of single "deno" program.
 ///
@@ -180,7 +180,7 @@ impl ProgramState {
     let debug = self.flags.log_level == Some(log::Level::Debug);
     let maybe_config_file = self.maybe_config_file.clone();
     let reload_exclusions = {
-      let modules = self.modules.lock().unwrap();
+      let modules = self.modules.lock();
       modules.keys().cloned().collect::<HashSet<_>>()
     };
 
@@ -216,11 +216,11 @@ impl ProgramState {
       result_info.loadable_modules
     };
 
-    let mut loadable_modules = self.modules.lock().unwrap();
+    let mut loadable_modules = self.modules.lock();
     loadable_modules.extend(result_modules);
 
     if let Some(ref lockfile) = self.lockfile {
-      let g = lockfile.lock().unwrap();
+      let g = lockfile.lock();
       g.write()?;
     }
 
@@ -254,7 +254,7 @@ impl ProgramState {
     let debug = self.flags.log_level == Some(log::Level::Debug);
     let maybe_config_file = self.maybe_config_file.clone();
     let reload_exclusions = {
-      let modules = self.modules.lock().unwrap();
+      let modules = self.modules.lock();
       modules.keys().cloned().collect::<HashSet<_>>()
     };
 
@@ -290,11 +290,11 @@ impl ProgramState {
       result_info.loadable_modules
     };
 
-    let mut loadable_modules = self.modules.lock().unwrap();
+    let mut loadable_modules = self.modules.lock();
     loadable_modules.extend(result_modules);
 
     if let Some(ref lockfile) = self.lockfile {
-      let g = lockfile.lock().unwrap();
+      let g = lockfile.lock();
       g.write()?;
     }
 
@@ -306,7 +306,7 @@ impl ProgramState {
     specifier: ModuleSpecifier,
     maybe_referrer: Option<ModuleSpecifier>,
   ) -> Result<ModuleSource, AnyError> {
-    let modules = self.modules.lock().unwrap();
+    let modules = self.modules.lock();
     modules
       .get(&specifier)
       .map(|r| match r {

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -14,6 +14,7 @@ use crate::write_to_stdout_ignore_sigpipe;
 use deno_core::error::AnyError;
 use deno_core::futures::future::FutureExt;
 use deno_core::futures::Future;
+use deno_core::parking_lot::Mutex;
 use deno_core::resolve_url_or_path;
 use deno_doc as doc;
 use deno_doc::parser::DocFileLoader;
@@ -21,7 +22,6 @@ use deno_runtime::permissions::Permissions;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::Mutex;
 use swc_ecmascript::parser::Syntax;
 
 type DocResult = Result<(Syntax, String), doc::DocError>;

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -317,8 +317,8 @@ fn is_in_path(dir: &Path) -> bool {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use deno_core::parking_lot::Mutex;
   use std::process::Command;
-  use std::sync::Mutex;
   use tempfile::TempDir;
   use test_util::tests_path;
 
@@ -401,7 +401,7 @@ mod tests {
 
   #[test]
   fn install_basic() {
-    let _guard = ENV_LOCK.lock().ok();
+    let _guard = ENV_LOCK.lock();
     let temp_dir = TempDir::new().expect("tempdir fail");
     let temp_dir_str = temp_dir.path().to_string_lossy().to_string();
     // NOTE: this test overrides environmental variables
@@ -591,7 +591,7 @@ mod tests {
 
   #[test]
   fn install_custom_dir_env_var() {
-    let _guard = ENV_LOCK.lock().ok();
+    let _guard = ENV_LOCK.lock();
     let temp_dir = TempDir::new().expect("tempdir fail");
     let bin_dir = temp_dir.path().join("bin");
     std::fs::create_dir(&bin_dir).unwrap();

--- a/cli/tools/repl.rs
+++ b/cli/tools/repl.rs
@@ -9,6 +9,7 @@ use crate::media_type::MediaType;
 use crate::program_state::ProgramState;
 use deno_core::error::AnyError;
 use deno_core::futures::FutureExt;
+use deno_core::parking_lot::Mutex;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::LocalInspectorSession;
@@ -28,7 +29,6 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::Mutex;
 use swc_ecmascript::parser::token::{Token, Word};
 use tokio::sync::mpsc::channel;
 use tokio::sync::mpsc::unbounded_channel;
@@ -324,21 +324,17 @@ impl ReplEditor {
   }
 
   pub fn readline(&self) -> Result<String, ReadlineError> {
-    self.inner.lock().unwrap().readline("> ")
+    self.inner.lock().readline("> ")
   }
 
   pub fn add_history_entry(&self, entry: String) {
-    self.inner.lock().unwrap().add_history_entry(entry);
+    self.inner.lock().add_history_entry(entry);
   }
 
   pub fn save_history(&self) -> Result<(), AnyError> {
     std::fs::create_dir_all(self.history_file_path.parent().unwrap())?;
 
-    self
-      .inner
-      .lock()
-      .unwrap()
-      .save_history(&self.history_file_path)?;
+    self.inner.lock().save_history(&self.history_file_path)?;
     Ok(())
   }
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@ indexmap = "1.6.2"
 lazy_static = "1.4.0"
 libc = "0.2.93"
 log = "0.4.14"
+parking_lot = "0.11.1"
 pin-project = "1.0.6"
 rusty_v8 = "0.25.0"
 serde = { version = "1.0.125", features = ["derive"] }

--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -23,6 +23,7 @@ use crate::serde_json;
 use crate::serde_json::json;
 use crate::serde_json::Value;
 use crate::v8;
+use parking_lot::Mutex;
 use std::cell::BorrowMutError;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -35,7 +36,6 @@ use std::ptr;
 use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::thread;
 
 /// If first argument is `None` then it's a notification, otherwise
@@ -452,7 +452,7 @@ impl InspectorWaker {
   where
     F: FnOnce(&mut InspectorWakerInner) -> R,
   {
-    let mut g = self.0.lock().unwrap();
+    let mut g = self.0.lock();
     update_fn(&mut g)
   }
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -18,6 +18,7 @@ mod runtime;
 
 // Re-exports
 pub use futures;
+pub use parking_lot;
 pub use rusty_v8 as v8;
 pub use serde;
 pub use serde_json;

--- a/extensions/broadcast_channel/in_memory_broadcast_channel.rs
+++ b/extensions/broadcast_channel/in_memory_broadcast_channel.rs
@@ -3,8 +3,8 @@
 use crate::BroadcastChannel;
 use async_trait::async_trait;
 use deno_core::error::AnyError;
+use deno_core::parking_lot::Mutex;
 use std::sync::Arc;
-use std::sync::Mutex;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -41,7 +41,7 @@ impl BroadcastChannel for InMemoryBroadcastChannel {
 
   fn subscribe(&self) -> Result<Self::Resource, AnyError> {
     let (cancel_tx, cancel_rx) = mpsc::unbounded_channel();
-    let broadcast_rx = self.0.lock().unwrap().subscribe();
+    let broadcast_rx = self.0.lock().subscribe();
     let rx = tokio::sync::Mutex::new((broadcast_rx, cancel_rx));
     let uuid = Uuid::new_v4();
     Ok(Self::Resource {
@@ -64,7 +64,7 @@ impl BroadcastChannel for InMemoryBroadcastChannel {
     let name = Arc::new(name);
     let data = Arc::new(data);
     let uuid = resource.uuid;
-    self.0.lock().unwrap().send(Message { name, data, uuid })?;
+    self.0.lock().send(Message { name, data, uuid })?;
     Ok(())
   }
 

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -5,6 +5,8 @@ use crate::fs_util::resolve_from_cwd;
 use deno_core::error::custom_error;
 use deno_core::error::uri_error;
 use deno_core::error::AnyError;
+#[cfg(test)]
+use deno_core::parking_lot::Mutex;
 use deno_core::serde::Deserialize;
 use deno_core::serde::Serialize;
 use deno_core::url;
@@ -21,8 +23,6 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 #[cfg(test)]
 use std::sync::atomic::Ordering;
-#[cfg(test)]
-use std::sync::Mutex;
 
 const PERMISSION_EMOJI: &str = "⚠️";
 
@@ -1502,7 +1502,7 @@ mod tests {
     let mut perms: Permissions = Default::default();
     #[rustfmt::skip]
     {
-      let _guard = PERMISSION_PROMPT_GUARD.lock().unwrap();
+      let _guard = PERMISSION_PROMPT_GUARD.lock();
       set_prompt_result(true);
       assert_eq!(perms.read.request(Some(&Path::new("/foo"))), PermissionState::Granted);
       assert_eq!(perms.read.query(None), PermissionState::Prompt);
@@ -1599,7 +1599,7 @@ mod tests {
       hrtime: Permissions::new_hrtime(false, true),
     };
 
-    let _guard = PERMISSION_PROMPT_GUARD.lock().unwrap();
+    let _guard = PERMISSION_PROMPT_GUARD.lock();
 
     set_prompt_result(true);
     assert!(perms.read.check(&Path::new("/foo")).is_ok());
@@ -1652,7 +1652,7 @@ mod tests {
       hrtime: Permissions::new_hrtime(false, true),
     };
 
-    let _guard = PERMISSION_PROMPT_GUARD.lock().unwrap();
+    let _guard = PERMISSION_PROMPT_GUARD.lock();
 
     set_prompt_result(false);
     assert!(perms.read.check(&Path::new("/foo")).is_err());


### PR DESCRIPTION
We're already using parking_lot extensively, but transitvely in dependencies. For example, parking_lot is used by tokio instead of std::sync for locks as a performance optimization. It might be good for us to also use it as it uses less memory, is faster, and has more features (I've used it in my projects and the API is a bit better).

Relates to #3429.

From https://crates.io/crates/parking_lot

> When tested on x86_64 Linux, parking_lot::Mutex was found to be 1.5x faster than std::sync::Mutex when uncontended, and up to 5x faster when contended from multiple threads. The numbers for RwLock vary depending on the number of reader and writer threads, but are almost always faster than the standard library RwLock, and even up to 50x faster in some cases.