### PR TITLE
perf: Use the WebIDL conversion to DOMString rather than USVString for TextEncoder

### DIFF
--- a/extensions/web/08_text_encoding.js
+++ b/extensions/web/08_text_encoding.js
@@ -141,7 +141,9 @@
     encode(input = "") {
       webidl.assertBranded(this, TextEncoder);
       const prefix = "Failed to execute 'encode' on 'TextEncoder'";
-      input = webidl.converters.USVString(input, {
+      // The WebIDL type of `input` is `USVString`, but `core.encode` already
+      // converts lone surrogates to the replacement character.
+      input = webidl.converters.DOMString(input, {
         prefix,
         context: "Argument 1",
       });
@@ -156,7 +158,9 @@
     encodeInto(source, destination) {
       webidl.assertBranded(this, TextEncoder);
       const prefix = "Failed to execute 'encodeInto' on 'TextEncoder'";
-      source = webidl.converters.USVString(source, {
+      // The WebIDL type of `source` is `USVString`, but the ops bindings
+      // already convert lone surrogates to the replacement character.
+      source = webidl.converters.DOMString(source, {
         prefix,
         context: "Argument 1",
       });


### PR DESCRIPTION
This works since both `core.encode` and the ops bindings to a Rust `String` will already replace any lone surrogates with the replacement character.

Part of #10978.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
