### PR TITLE
fix(cli/tools/lint): output json reports to stdout

### DIFF
--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -350,7 +350,7 @@ impl LintReporter for JsonLintReporter {
   fn close(&mut self, _check_count: usize) {
     sort_diagnostics(&mut self.diagnostics);
     let json = serde_json::to_string_pretty(&self);
-    eprintln!("{}", json.unwrap());
+    println!("{}", json.unwrap());
   }
 }
 


### PR DESCRIPTION
This changes the output stream for `--json` to stdout rather than stderr keeping stderr free for diagnostics output without poisoning the requested json output.