### PR TITLE
chore: temporarily disable flaky single_compile_with_reload test

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1010,7 +1010,7 @@ itest!(jsx_import_from_ts {
   output: "jsx_import_from_ts.ts.out",
 });
 
-// flaky... re-enable when #11128 is resolved
+// TODO(#11128): Flaky. Re-enable later.
 // itest!(single_compile_with_reload {
 //   args: "run --reload --allow-read single_compile_with_reload.ts",
 //   output: "single_compile_with_reload.ts.out",

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1010,10 +1010,11 @@ itest!(jsx_import_from_ts {
   output: "jsx_import_from_ts.ts.out",
 });
 
-itest!(single_compile_with_reload {
-  args: "run --reload --allow-read single_compile_with_reload.ts",
-  output: "single_compile_with_reload.ts.out",
-});
+// flaky... re-enable when #11128 is resolved
+// itest!(single_compile_with_reload {
+//   args: "run --reload --allow-read single_compile_with_reload.ts",
+//   output: "single_compile_with_reload.ts.out",
+// });
 
 itest!(proto_exploit {
   args: "run proto_exploit.js",


### PR DESCRIPTION
A large number of my PR runs fail because of this flaky test. Let's just disable it temporarily until #11128 is resolved.