### PR TITLE
Revert "tests: parallelize test runs in wpt"

### DIFF
--- a/tools/wpt.ts
+++ b/tools/wpt.ts
@@ -31,7 +31,6 @@ import {
 } from "./wpt/utils.ts";
 import { blue, bold, green, red, yellow } from "../test_util/std/fmt/colors.ts";
 import { writeAll, writeAllSync } from "../test_util/std/io/util.ts";
-import { pooledMap } from "../test_util/std/async/pool.ts";
 import { saveExpectation } from "./wpt/utils.ts";
 
 const command = Deno.args[0];
@@ -153,29 +152,17 @@ async function run() {
   console.log(`Going to run ${tests.length} test files.`);
 
   const results = await runWithTestUtil(false, async () => {
-    const results: { test: TestToRun; result: TestResult }[] = [];
+    const results = [];
 
-    const cores = Deno.systemCpuInfo().cores ?? 4;
-    const inParallel = !(cores === 1 || tests.length === 1);
-
-    const iter = pooledMap(cores, tests, async (test) => {
-      if (!inParallel) {
-        console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
-      }
+    for (const test of tests) {
+      console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
       const result = await runSingleTest(
         test.url,
         test.options,
-        inParallel ? () => {} : createReportTestCase(test.expectation),
+        createReportTestCase(test.expectation),
       );
       results.push({ test, result });
-      if (inParallel) {
-        console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
-      }
       reportVariation(result, test.expectation);
-    });
-
-    for await (const _ of iter) {
-      // do nothing
     }
 
     return results;


### PR DESCRIPTION
Reverts denoland/deno#11306

This made a test flaky:

```
expected test failures that passed:

        "/fetch/api/basic/request-upload.any.html - Fetch with POST with ReadableStream containing number"

final result: failed. 634 passed; 1 failed; 11 expected failure; total 635
```