### PR TITLE
perf(core): avoid extra alloc in Deno.core.encode()

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -655,9 +655,8 @@ fn encode(
     }
   };
   let text_str = text.to_rust_string_lossy(scope);
-  let text_bytes = text_str.as_bytes().to_vec().into_boxed_slice();
+  let zbuf: ZeroCopyBuf = text_str.into_bytes().into();
 
-  let zbuf: ZeroCopyBuf = text_bytes.into();
   rv.set(to_v8(scope, zbuf).unwrap())
 }
 


### PR DESCRIPTION
An optimization to the `encode()` binding, avoiding an extra alloc & copy, extracted from https://github.com/denoland/deno/pull/10532

Will likely need a lower level `encode/decode` benchmark to measure the delta of this change