### PR TITLE
refactor(cli/tools/coverage): strongly type inspector values

### DIFF
--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -27,6 +27,53 @@ use std::path::PathBuf;
 use swc_common::Span;
 use uuid::Uuid;
 
+// TODO(caspervonb) all of these structs can and should be made private, possibly moved to
+// inspector::protocol.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CoverageRange {
+  pub start_offset: usize,
+  pub end_offset: usize,
+  pub count: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FunctionCoverage {
+  pub function_name: String,
+  pub ranges: Vec<CoverageRange>,
+  pub is_block_coverage: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ScriptCoverage {
+  pub script_id: String,
+  pub url: String,
+  pub functions: Vec<FunctionCoverage>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartPreciseCoverageParameters {
+  pub call_count: bool,
+  pub detailed: bool,
+  pub allow_triggered_updates: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartPreciseCoverageReturnObject {
+  pub timestamp: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TakePreciseCoverageReturnObject {
+  pub result: Vec<ScriptCoverage>,
+  pub timestamp: f64,
+}
+
 pub struct CoverageCollector {
   pub dir: PathBuf,
   session: LocalInspectorSession,
@@ -122,53 +169,6 @@ impl CoverageCollector {
 
     Ok(())
   }
-}
-
-// TODO(caspervonb) all of these structs can and should be made private, possibly moved to
-// inspector::protocol.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct CoverageRange {
-  pub start_offset: usize,
-  pub end_offset: usize,
-  pub count: usize,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct FunctionCoverage {
-  pub function_name: String,
-  pub ranges: Vec<CoverageRange>,
-  pub is_block_coverage: bool,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct ScriptCoverage {
-  pub script_id: String,
-  pub url: String,
-  pub functions: Vec<FunctionCoverage>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StartPreciseCoverageParameters {
-  pub call_count: bool,
-  pub detailed: bool,
-  pub allow_triggered_updates: bool,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StartPreciseCoverageReturnObject {
-  pub timestamp: f64,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TakePreciseCoverageReturnObject {
-  pub result: Vec<ScriptCoverage>,
-  pub timestamp: f64,
 }
 
 pub enum CoverageReporterKind {

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -65,9 +65,10 @@ impl CoverageCollector {
     &mut self,
     parameters: StartPreciseCoverageParameters,
   ) -> Result<StartPreciseCoverageReturnObject, AnyError> {
+    let parameters_value = serde_json::to_value(parameters)?;
     let return_value = self
       .session
-      .post_message("Profiler.startPreciseCoverage", Some(json!(parameters)))
+      .post_message("Profiler.startPreciseCoverage", Some(parameters_value))
       .await?;
 
     let return_object = serde_json::from_value(return_value)?;

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -11,7 +11,6 @@ use crate::program_state::ProgramState;
 use crate::source_maps::SourceMapGetter;
 use deno_core::error::AnyError;
 use deno_core::serde_json;
-use deno_core::serde_json::json;
 use deno_core::url::Url;
 use deno_core::LocalInspectorSession;
 use deno_runtime::permissions::Permissions;


### PR DESCRIPTION
This adds local methods and types for the rest of the messages, parameters and return objects that coverage uses as a first pass towards a fully typed unified inspector client interface.
