### PR TITLE
docs(runtime): fix link to API docs

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,8 +1,7 @@
 # Runtime
 
 Documentation for all runtime functions (Web APIs + `Deno` global) can be found
-on
-[`doc.deno.land`](https://doc.deno.land/builtin/stable).
+on [`doc.deno.land`](https://doc.deno.land/builtin/stable).
 
 ## Web Platform APIs
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -2,7 +2,7 @@
 
 Documentation for all runtime functions (Web APIs + `Deno` global) can be found
 on
-[`doc.deno.land`](https://doc.deno.land/https/github.com/denoland/deno/releases/latest/download/lib.deno.d.ts).
+[`doc.deno.land`](https://doc.deno.land/builtin/stable).
 
 ## Web Platform APIs
 


### PR DESCRIPTION
fixes https://github.com/denoland/doc_website/issues/214