### PR TITLE
refactor(runtime): parse test permissions during test registration

### DIFF
--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -105,6 +105,29 @@ finishing test case.`;
     };
   }
 
+  function withPermissions(fn, permissions) {
+    function pledgePermissions(permissions) {
+      return core.opSync(
+        "op_pledge_test_permissions",
+        parsePermissions(permissions),
+      );
+    }
+
+    function restorePermissions(token) {
+      core.opSync("op_restore_test_permissions", token);
+    }
+
+    return async function applyPermissions() {
+      const token = pledgePermissions(permissions);
+
+      try {
+        await fn();
+      } finally {
+        restorePermissions(token);
+      }
+    };
+  }
+
   const tests = [];
 
   // Main test function provided by Deno, as you can see it merely
@@ -153,6 +176,13 @@ finishing test case.`;
       testDef.fn = assertExit(testDef.fn);
     }
 
+    if (testDef.permissions) {
+      testDef.fn = withPermissions(
+        testDef.fn,
+        parsePermissions(testDef.permissions),
+      );
+    }
+
     ArrayPrototypePush(tests, testDef);
   }
 
@@ -180,37 +210,16 @@ finishing test case.`;
     };
   }
 
-  function pledgeTestPermissions(permissions) {
-    return core.opSync(
-      "op_pledge_test_permissions",
-      parsePermissions(permissions),
-    );
-  }
-
-  function restoreTestPermissions(token) {
-    core.opSync("op_restore_test_permissions", token);
-  }
-
-  async function runTest({ ignore, fn, permissions }) {
+  async function runTest({ ignore, fn }) {
     if (ignore) {
       return "ignored";
     }
 
-    let token = null;
-
     try {
-      if (permissions) {
-        token = pledgeTestPermissions(permissions);
-      }
       await fn();
-
       return "ok";
     } catch (error) {
       return { "failed": inspectArgs([error]) };
-    } finally {
-      if (token) {
-        restoreTestPermissions(token);
-      }
     }
   }
 


### PR DESCRIPTION
This moves the pledging and restoring of test permissions into a wrapper applied during registration with the rest of the wrappers like sanitizers.