### PR TITLE
chore(runtime): deprecate `Deno.copy`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install Deno
         if: matrix.kind == 'lint'
         run: |
-          curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.7.2
+          curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.11.3
           echo "$HOME/.deno/bin" >> $GITHUB_PATH
 
       - name: Install Python

--- a/cli/bench/deno_tcp_proxy.ts
+++ b/cli/bench/deno_tcp_proxy.ts
@@ -2,6 +2,7 @@
 // Used for benchmarking Deno's tcp proxy performance.
 const addr = Deno.args[0] || "127.0.0.1:4500";
 const originAddr = Deno.args[1] || "127.0.0.1:4501";
+import { copy } from "../../test_util/std/io/util.ts"
 
 const [hostname, port] = addr.split(":");
 const [originHostname, originPort] = originAddr.split(":");
@@ -14,7 +15,7 @@ async function handle(conn: Deno.Conn): Promise<void> {
     port: Number(originPort),
   });
   try {
-    await Promise.all([Deno.copy(conn, origin), Deno.copy(origin, conn)]);
+    await Promise.all([copy(conn, origin), copy(origin, conn)]);
   } catch (e) {
     if (
       !(e instanceof Deno.errors.BrokenPipe) &&

--- a/cli/bench/deno_tcp_proxy.ts
+++ b/cli/bench/deno_tcp_proxy.ts
@@ -1,8 +1,9 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Used for benchmarking Deno's tcp proxy performance.
+import { copy } from "../../test_util/std/io/util.ts";
+
 const addr = Deno.args[0] || "127.0.0.1:4500";
 const originAddr = Deno.args[1] || "127.0.0.1:4501";
-import { copy } from "../../test_util/std/io/util.ts";
 
 const [hostname, port] = addr.split(":");
 const [originHostname, originPort] = originAddr.split(":");

--- a/cli/bench/deno_tcp_proxy.ts
+++ b/cli/bench/deno_tcp_proxy.ts
@@ -2,7 +2,7 @@
 // Used for benchmarking Deno's tcp proxy performance.
 const addr = Deno.args[0] || "127.0.0.1:4500";
 const originAddr = Deno.args[1] || "127.0.0.1:4501";
-import { copy } from "../../test_util/std/io/util.ts"
+import { copy } from "../../test_util/std/io/util.ts";
 
 const [hostname, port] = addr.split(":");
 const [originHostname, originPort] = originAddr.split(":");

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -431,9 +431,9 @@ declare namespace Deno {
    *
    * ```ts
    * const source = await Deno.open("my_file.txt");
-   * const bytesCopied1 = await copy(source, Deno.stdout);
+   * const bytesCopied1 = await Deno.copy(source, Deno.stdout);
    * const destination = await Deno.create("my_file_2.txt");
-   * const bytesCopied2 = await copy(source, destination);
+   * const bytesCopied2 = await Deno.copy(source, destination);
    * ```
    *
    * @param src The source to copy from

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -421,15 +421,19 @@ declare namespace Deno {
     seekSync(offset: number, whence: SeekMode): number;
   }
 
-  /** Copies from `src` to `dst` until either EOF (`null`) is read from `src` or
+  /**
+   * @deprecated Use `copy` from https://deno.land/std/io/util.ts instead.
+   * `Deno.copy` will be removed in Deno 2.0.
+   *
+   * Copies from `src` to `dst` until either EOF (`null`) is read from `src` or
    * an error occurs. It resolves to the number of bytes copied or rejects with
    * the first error encountered while copying.
    *
    * ```ts
    * const source = await Deno.open("my_file.txt");
-   * const bytesCopied1 = await Deno.copy(source, Deno.stdout);
+   * const bytesCopied1 = await copy(source, Deno.stdout);
    * const destination = await Deno.create("my_file_2.txt");
-   * const bytesCopied2 = await Deno.copy(source, destination);
+   * const bytesCopied2 = await copy(source, destination);
    * ```
    *
    * @param src The source to copy from

--- a/cli/tests/cat.ts
+++ b/cli/tests/cat.ts
@@ -1,8 +1,9 @@
+import { copy } from "../../test_util/std/io/util.ts"
 async function main(): Promise<void> {
   for (let i = 1; i < Deno.args.length; i++) {
     const filename = Deno.args[i];
     const file = await Deno.open(filename);
-    await Deno.copy(file, Deno.stdout);
+    await copy(file, Deno.stdout);
   }
 }
 

--- a/cli/tests/cat.ts
+++ b/cli/tests/cat.ts
@@ -1,4 +1,4 @@
-import { copy } from "../../test_util/std/io/util.ts"
+import { copy } from "../../test_util/std/io/util.ts";
 async function main(): Promise<void> {
   for (let i = 1; i < Deno.args.length; i++) {
     const filename = Deno.args[i];

--- a/cli/tests/echo_server.ts
+++ b/cli/tests/echo_server.ts
@@ -1,4 +1,4 @@
-import { copy } from "../../test_util/std/io/util.ts"
+import { copy } from "../../test_util/std/io/util.ts";
 const addr = Deno.args[0] || "0.0.0.0:4544";
 const [hostname, port] = addr.split(":");
 const listener = Deno.listen({ hostname, port: Number(port) });

--- a/cli/tests/echo_server.ts
+++ b/cli/tests/echo_server.ts
@@ -1,10 +1,11 @@
+import { copy } from "../../test_util/std/io/util.ts"
 const addr = Deno.args[0] || "0.0.0.0:4544";
 const [hostname, port] = addr.split(":");
 const listener = Deno.listen({ hostname, port: Number(port) });
 console.log("listening on", addr);
 listener.accept().then(
   async (conn): Promise<void> => {
-    console.log("received bytes:", await Deno.copy(conn, conn));
+    console.log("received bytes:", await copy(conn, conn));
     conn.close();
     listener.close();
   },

--- a/cli/tests/unit/files_test.ts
+++ b/cli/tests/unit/files_test.ts
@@ -8,6 +8,7 @@ import {
   assertThrowsAsync,
   unitTest,
 } from "./test_util.ts";
+import { copy } from "../../../test_util/std/io/util.ts"
 
 unitTest(function filesStdioFileDescriptors(): void {
   assertEquals(Deno.stdin.rid, 0);
@@ -21,7 +22,7 @@ unitTest({ perms: { read: true } }, async function filesCopyToStdout(): Promise<
   const filename = "cli/tests/fixture.json";
   const file = await Deno.open(filename);
   assert(file.rid > 2);
-  const bytesWritten = await Deno.copy(file, Deno.stdout);
+  const bytesWritten = await copy(file, Deno.stdout);
   const fileSize = Deno.statSync(filename).size;
   assertEquals(bytesWritten, fileSize);
   file.close();

--- a/cli/tests/unit/files_test.ts
+++ b/cli/tests/unit/files_test.ts
@@ -8,7 +8,7 @@ import {
   assertThrowsAsync,
   unitTest,
 } from "./test_util.ts";
-import { copy } from "../../../test_util/std/io/util.ts"
+import { copy } from "../../../test_util/std/io/util.ts";
 
 unitTest(function filesStdioFileDescriptors(): void {
   assertEquals(Deno.stdin.rid, 0);

--- a/cli/tests/unit/io_test.ts
+++ b/cli/tests/unit/io_test.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, unitTest } from "./test_util.ts";
 import { Buffer } from "../../../test_util/std/io/buffer.ts";
+import { copy } from "../../../test_util/std/bytes/mod.ts";
 
 const DEFAULT_BUF_SIZE = 32 * 1024;
 
@@ -35,7 +36,7 @@ unitTest(async function copyWithDefaultBufferSize() {
 
   const readSpy = spyRead(reader);
 
-  const n = await Deno.copy(reader, write);
+  const n = await copy(reader, write);
 
   assertEquals(n, xBytes.length);
   assertEquals(write.length, xBytes.length);
@@ -50,7 +51,7 @@ unitTest(async function copyWithCustomBufferSize() {
 
   const readSpy = spyRead(reader);
 
-  const n = await Deno.copy(reader, write, { bufSize });
+  const n = await copy(reader, write, { bufSize });
 
   assertEquals(n, xBytes.length);
   assertEquals(write.length, xBytes.length);
@@ -65,7 +66,7 @@ unitTest({ perms: { write: true } }, async function copyBufferToFile() {
   const reader = new Buffer(xBytes.buffer as ArrayBuffer);
   const write = await Deno.open(filePath, { write: true, create: true });
 
-  const n = await Deno.copy(reader, write, { bufSize });
+  const n = await copy(reader, write, { bufSize });
 
   assertEquals(n, xBytes.length);
 

--- a/cli/tests/unit/io_test.ts
+++ b/cli/tests/unit/io_test.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, unitTest } from "./test_util.ts";
 import { Buffer } from "../../../test_util/std/io/buffer.ts";
-import { copy } from "../../../test_util/std/bytes/mod.ts";
 
 const DEFAULT_BUF_SIZE = 32 * 1024;
 
@@ -36,7 +35,7 @@ unitTest(async function copyWithDefaultBufferSize() {
 
   const readSpy = spyRead(reader);
 
-  const n = await copy(reader, write);
+  const n = await Deno.copy(reader, write);
 
   assertEquals(n, xBytes.length);
   assertEquals(write.length, xBytes.length);
@@ -51,7 +50,7 @@ unitTest(async function copyWithCustomBufferSize() {
 
   const readSpy = spyRead(reader);
 
-  const n = await copy(reader, write, { bufSize });
+  const n = await Deno.copy(reader, write, { bufSize });
 
   assertEquals(n, xBytes.length);
   assertEquals(write.length, xBytes.length);
@@ -66,7 +65,7 @@ unitTest({ perms: { write: true } }, async function copyBufferToFile() {
   const reader = new Buffer(xBytes.buffer as ArrayBuffer);
   const write = await Deno.open(filePath, { write: true, create: true });
 
-  const n = await copy(reader, write, { bufSize });
+  const n = await Deno.copy(reader, write, { bufSize });
 
   assertEquals(n, xBytes.length);
 

--- a/docs/examples/tcp_echo.md
+++ b/docs/examples/tcp_echo.md
@@ -4,8 +4,9 @@
 
 - Listening for TCP port connections with
   [Deno.listen](https://doc.deno.land/builtin/stable#Deno.listen).
-- Use [Deno.copy](https://doc.deno.land/builtin/stable#Deno.copy) to take
-  inbound data and redirect it to be outbound data.
+- Use
+  [copy](https://doc.deno.land/https/deno.land/std@$STD_VERSION/io/util.ts#copy)
+  to take inbound data and redirect it to be outbound data.
 
 ## Example
 
@@ -16,10 +17,11 @@ returns to the client anything it sends.
 /**
  * echo_server.ts
  */
+import { copy } from "https://deno.land/std@$STD_VERSION/io/util.ts";
 const listener = Deno.listen({ port: 8080 });
 console.log("listening on 0.0.0.0:8080");
 for await (const conn of listener) {
-  Deno.copy(conn, conn).finally(() => conn.close());
+  copy(conn, conn).finally(() => conn.close());
 }
 ```
 

--- a/docs/examples/unix_cat.md
+++ b/docs/examples/unix_cat.md
@@ -7,8 +7,8 @@
   command line arguments.
 - [Deno.open](https://doc.deno.land/builtin/stable#Deno.open) is used to get a
   handle to a file.
-- [Deno.copy](https://doc.deno.land/builtin/stable#Deno.copy) is used to
-  transfer data from the file to the output stream.
+- [copy](https://doc.deno.land/https/deno.land/std@$STD_VERSION/io/util.ts#copy)
+  is used to transfer data from the file to the output stream.
 - Files should be closed when you are finished with them
 - Modules can be run directly from remote URLs.
 
@@ -21,9 +21,10 @@ is opened, and printed to stdout (e.g. the console).
 /**
  * cat.ts
  */
+import { copy } from "https://deno.land/std@$STD_VERSION/io/util.ts";
 for (const filename of Deno.args) {
   const file = await Deno.open(filename);
-  await Deno.copy(file, Deno.stdout);
+  await copy(file, Deno.stdout);
   file.close();
 }
 ```

--- a/docs/getting_started/first_steps.md
+++ b/docs/getting_started/first_steps.md
@@ -86,10 +86,11 @@ In this program each command-line argument is assumed to be a filename, the file
 is opened, and printed to stdout.
 
 ```ts
+import { copy } from "https://deno.land/std@$STD_VERSION/io/util.ts";
 const filenames = Deno.args;
 for (const filename of filenames) {
   const file = await Deno.open(filename);
-  await Deno.copy(file, Deno.stdout);
+  await copy(file, Deno.stdout);
   file.close();
 }
 ```
@@ -111,12 +112,13 @@ This is an example of a server which accepts connections on port 8080, and
 returns to the client anything it sends.
 
 ```ts
+import { copy } from "https://deno.land/std@$STD_VERSION/io/util.ts";
 const hostname = "0.0.0.0";
 const port = 8080;
 const listener = Deno.listen({ hostname, port });
 console.log(`Listening on ${hostname}:${port}`);
 for await (const conn of listener) {
-  Deno.copy(conn, conn);
+  copy(conn, conn);
 }
 ```
 


### PR DESCRIPTION
Towards #9795
