### PR TITLE
fix(cli): normalize test command errors

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1235,7 +1235,7 @@ async fn test_command(
       tools::test_runner::is_supported,
     )?;
 
-    let failed = test_runner::run_tests(
+    test_runner::run_tests(
       program_state.clone(),
       permissions,
       lib,
@@ -1250,10 +1250,6 @@ async fn test_command(
       concurrent_jobs,
     )
     .await?;
-
-    if failed {
-      std::process::exit(1);
-    }
   }
 
   Ok(())

--- a/cli/tests/test/exit_sanitizer.out
+++ b/cli/tests/test/exit_sanitizer.out
@@ -32,4 +32,4 @@ failures:
 
 test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
-error: test failed
+error: Test failed

--- a/cli/tests/test/exit_sanitizer.out
+++ b/cli/tests/test/exit_sanitizer.out
@@ -32,3 +32,4 @@ failures:
 
 test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
+error: test failed

--- a/cli/tests/test/fail.out
+++ b/cli/tests/test/fail.out
@@ -78,3 +78,4 @@ failures:
 
 test result: FAILED. 0 passed; 10 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
+error: test failed

--- a/cli/tests/test/fail.out
+++ b/cli/tests/test/fail.out
@@ -78,4 +78,4 @@ failures:
 
 test result: FAILED. 0 passed; 10 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
-error: test failed
+error: Test failed

--- a/cli/tests/test/fail_fast.out
+++ b/cli/tests/test/fail_fast.out
@@ -15,3 +15,4 @@ failures:
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
+error: test failed

--- a/cli/tests/test/fail_fast.out
+++ b/cli/tests/test/fail_fast.out
@@ -15,4 +15,4 @@ failures:
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
-error: test failed
+error: Test failed

--- a/cli/tests/test/finally_timeout.out
+++ b/cli/tests/test/finally_timeout.out
@@ -16,4 +16,4 @@ failures:
 
 test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
-error: test failed
+error: Test failed

--- a/cli/tests/test/finally_timeout.out
+++ b/cli/tests/test/finally_timeout.out
@@ -16,3 +16,4 @@ failures:
 
 test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 
+error: test failed

--- a/cli/tests/test/only.out
+++ b/cli/tests/test/only.out
@@ -4,5 +4,4 @@ test only ... ok ([WILDCARD])
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out ([WILDCARD])
 
-FAILED because the "only" option was used
-
+error: test failed because the "only" option was used

--- a/cli/tests/test/only.out
+++ b/cli/tests/test/only.out
@@ -4,4 +4,4 @@ test only ... ok ([WILDCARD])
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out ([WILDCARD])
 
-error: test failed because the "only" option was used
+error: Test failed because the "only" option was used

--- a/cli/tools/test_runner.rs
+++ b/cli/tools/test_runner.rs
@@ -509,30 +509,24 @@ pub async fn run_tests(
   let handler = {
     tokio::task::spawn_blocking(move || {
       let mut used_only = false;
-      let mut planned = 0;
-      let mut reported = 0;
       let mut failed = 0;
 
       for event in receiver.iter() {
         match event.message.clone() {
           TestMessage::Plan {
-            pending,
+            pending: _,
             filtered: _,
             only,
           } => {
             if only {
               used_only = true;
             }
-
-            planned += pending;
           }
           TestMessage::Result {
             name: _,
             duration: _,
             result,
           } => {
-            reported += 1;
-
             if let TestResult::Failed(_) = result {
               failed += 1;
             }

--- a/cli/tools/test_runner.rs
+++ b/cli/tools/test_runner.rs
@@ -337,7 +337,7 @@ pub async fn run_tests(
   concurrent_jobs: usize,
 ) -> Result<(), AnyError> {
   if !allow_none && doc_modules.is_empty() && test_modules.is_empty() {
-    return Err(generic_error("no test modules found"));
+    return Err(generic_error("No test modules found"));
   }
 
   let test_modules = if let Some(seed) = shuffle {
@@ -550,12 +550,12 @@ pub async fn run_tests(
 
       if used_only {
         return Err(generic_error(
-          "test failed because the \"only\" option was used",
+          "Test failed because the \"only\" option was used",
         ));
       }
 
       if summary.failed > 0 {
-        return Err(generic_error("test failed"));
+        return Err(generic_error("Test failed"));
       }
 
       Ok(())


### PR DESCRIPTION
This normalises the test command from the bottom up to return errors all the way down the chain rather than calling `process::exit` at arbritary places.