### PR TITLE
fix(extensions/web): Aborting a FileReader object should not affect later reads

### DIFF
--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -2794,7 +2794,7 @@
     "reading-data-section": {
       "Determining-Encoding.any.html": true,
       "FileReader-event-handler-attributes.any.html": true,
-      "FileReader-multiple-reads.any.html": false,
+      "FileReader-multiple-reads.any.html": true,
       "filereader_abort.any.html": true,
       "filereader_error.any.html": true,
       "filereader_events.any.html": false,


### PR DESCRIPTION
Currently, calling the `abort()` method on a `FileReader` object aborts any current read operation, but it also prevents any read operation started at some later point from starting. The File API instead specifies that calling `abort()` should reset the `FileReader`'s state and result, as well as removing any queued tasks from the current operation that haven't yet run.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
