### PR TITLE
 feat(cli): Set Timeout per test using --timeout flag default `500ms`

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -992,6 +992,7 @@ async fn test_command(
   allow_none: bool,
   filter: Option<String>,
   shuffle: Option<u64>,
+  timeout: Option<usize>,
   concurrent_jobs: usize,
 ) -> Result<(), AnyError> {
   if let Some(ref coverage_dir) = flags.coverage_dir {
@@ -1208,6 +1209,7 @@ async fn test_command(
           quiet,
           true,
           filter.clone(),
+          timeout,
           shuffle,
           concurrent_jobs,
         )
@@ -1246,6 +1248,7 @@ async fn test_command(
       quiet,
       allow_none,
       filter,
+      timeout,
       shuffle,
       concurrent_jobs,
     )
@@ -1355,6 +1358,7 @@ fn get_subcommand(
       allow_none,
       filter,
       shuffle,
+      timeout,
       concurrent_jobs,
     } => test_command(
       flags,
@@ -1366,6 +1370,7 @@ fn get_subcommand(
       allow_none,
       filter,
       shuffle,
+      timeout,
       concurrent_jobs,
     )
     .boxed_local(),

--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -61,6 +61,12 @@ itest!(fail_fast {
   output: "test/fail_fast.out",
 });
 
+itest!(timeout {
+  args: "test --timeout=2 test/timeout.ts",
+  exit_code: 1,
+  output: "test/timeout.out",
+});
+
 itest!(only {
   args: "test test/only.ts",
   exit_code: 1,

--- a/cli/tests/test/timeout.out
+++ b/cli/tests/test/timeout.out
@@ -1,0 +1,5 @@
+running 1 test from [WILDCARD]/test/timeout.ts
+test test 1 ...
+Exceeded timeout of [WILDCARD]. Use --timeout to increase the timeout value
+
+test result: FAILED. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])

--- a/cli/tests/test/timeout.ts
+++ b/cli/tests/test/timeout.ts
@@ -1,0 +1,3 @@
+Deno.test("test 1", () => {
+  throw new Error();
+});


### PR DESCRIPTION
### Syntax:  `--timeout=<number>`
Default timeout of a test in milliseconds. Default value: `500ms`.

### Example

```sh
deno test --timeout=600 store_data_test.ts
```

### Use Cases

Let's say we want to store some data into some database provider. So in some case it could take a lot time, probably due to some network issue. So it would be helpful if we can exit the test after `X` time.
### Motivation

- Applications aren’t responding with lightning speed on user actions and while creating the `E2E` tests this fact should be considered. 
- Using these set timeout will allow you to create more stable tests and control your test flow even more precisely