### PR TITLE
test(cli): ensure clear timeout doesn't trigger sanitizers

### DIFF
--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -97,6 +97,12 @@ itest!(exit_sanitizer {
   exit_code: 1,
 });
 
+itest!(clear_timeout {
+  args: "test test/clear_timeout.ts",
+  exit_code: 0,
+  output: "test/clear_timeout.out",
+});
+
 itest!(finally_timeout {
   args: "test test/finally_timeout.ts",
   exit_code: 1,

--- a/cli/tests/test/clear_timeout.out
+++ b/cli/tests/test/clear_timeout.out
@@ -1,0 +1,8 @@
+Check [WILDCARD]/test/clear_timeout.ts
+running 3 tests from [WILDCARD]/test/clear_timeout.ts
+test test 1 ... ok ([WILDCARD])
+test test 2 ... ok ([WILDCARD])
+test test 3 ... ok ([WILDCARD])
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+

--- a/cli/tests/test/clear_timeout.ts
+++ b/cli/tests/test/clear_timeout.ts
@@ -1,0 +1,5 @@
+clearTimeout(setTimeout(() => { }, 1000));
+
+Deno.test("test 1", () => { });
+Deno.test("test 2", () => { });
+Deno.test("test 3", () => { });

--- a/cli/tests/test/clear_timeout.ts
+++ b/cli/tests/test/clear_timeout.ts
@@ -1,5 +1,5 @@
-clearTimeout(setTimeout(() => { }, 1000));
+clearTimeout(setTimeout(() => {}, 1000));
 
-Deno.test("test 1", () => { });
-Deno.test("test 2", () => { });
-Deno.test("test 3", () => { });
+Deno.test("test 1", () => {});
+Deno.test("test 2", () => {});
+Deno.test("test 3", () => {});


### PR DESCRIPTION
This adds a regression test case for https://github.com/denoland/deno/issues/7844