### PR TITLE
fix(lsp): support data urls in `deno.importMap` option

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -509,10 +509,6 @@ impl Inner {
           )
         })?
       };
-      // TODO(@satyarohith): if import_map_url is a data url and import_map_json contains relative
-      // paths, we will get an Invalid address error in the logs because of the base_url not
-      // being a valid path. We should somehow support relative paths in import
-      // maps that are data urls.
       let import_map =
         ImportMap::from_json(&import_map_url.to_string(), &import_map_json)?;
       self.maybe_import_map_uri = Some(import_map_url);

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -1,16 +1,12 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
-use crate::file_fetcher::get_source_from_bytes;
-use crate::file_fetcher::strip_shebang;
+use crate::file_fetcher::get_source_from_data_url;
 use crate::flags::Flags;
 use crate::ops;
 use crate::program_state::ProgramState;
 use crate::version;
-use data_url::DataUrl;
-use deno_core::error::anyhow;
 use deno_core::error::type_error;
-use deno_core::error::uri_error;
 use deno_core::error::AnyError;
 use deno_core::error::Context;
 use deno_core::futures::FutureExt;
@@ -123,19 +119,6 @@ fn read_string_slice(
   Ok(string)
 }
 
-fn get_source_from_data_url(
-  specifier: &ModuleSpecifier,
-) -> Result<String, AnyError> {
-  let data_url = DataUrl::process(specifier.as_str())
-    .map_err(|e| uri_error(format!("{:?}", e)))?;
-  let mime = data_url.mime_type();
-  let charset = mime.get_parameter("charset").map(|v| v.to_string());
-  let (bytes, _) = data_url
-    .decode_to_vec()
-    .map_err(|e| uri_error(format!("{:?}", e)))?;
-  Ok(strip_shebang(get_source_from_bytes(bytes, charset)?))
-}
-
 const SPECIFIER: &str = "file://$deno$/bundle.js";
 
 struct EmbeddedModuleLoader(String);
@@ -169,7 +152,7 @@ impl ModuleLoader for EmbeddedModuleLoader {
   ) -> Pin<Box<deno_core::ModuleSourceFuture>> {
     let module_specifier = module_specifier.clone();
     let is_data_uri = get_source_from_data_url(&module_specifier).ok();
-    let code = if let Some(ref source) = is_data_uri {
+    let code = if let Some((ref source, _)) = is_data_uri {
       source.to_string()
     } else {
       self.0.to_string()

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -6,6 +6,7 @@ use crate::flags::Flags;
 use crate::ops;
 use crate::program_state::ProgramState;
 use crate::version;
+use deno_core::error::anyhow;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::error::Context;

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -317,6 +317,32 @@ fn lsp_import_map() {
 }
 
 #[test]
+fn lsp_import_map_data_url() {
+  let mut client = init("initialize_params_import_map.json");
+  let diagnostics = did_open(
+    &mut client,
+    json!({
+      "textDocument": {
+        "uri": "file:///a/file.ts",
+        "languageId": "typescript",
+        "version": 1,
+        "text": "import example from \"example\";\n"
+      }
+    }),
+  );
+
+  let mut diagnostics = diagnostics.into_iter().flat_map(|x| x.diagnostics);
+  // This indicates that the import map from initialize_params_import_map.json
+  // is applied correctly.
+  assert!(diagnostics.any(|diagnostic| diagnostic.code
+    == Some(lsp::NumberOrString::String("no-cache".to_string()))
+    && diagnostic
+      .message
+      .contains("https://deno.land/x/example/mod.ts")));
+  shutdown(&mut client);
+}
+
+#[test]
 fn lsp_hover() {
   let mut client = init("initialize_params.json");
   did_open(

--- a/cli/tests/testdata/lsp/initialize_params_import_map.json
+++ b/cli/tests/testdata/lsp/initialize_params_import_map.json
@@ -1,0 +1,62 @@
+{
+  "processId": 0,
+  "clientInfo": {
+    "name": "test-harness",
+    "version": "1.0.0"
+  },
+  "rootUri": null,
+  "initializationOptions": {
+    "enable": true,
+    "codeLens": {
+      "implementations": true,
+      "references": true
+    },
+    "importMap": "data:application/json;utf8,{\"imports\": { \"example\": \"https://deno.land/x/example/mod.ts\" }}",
+    "lint": true,
+    "suggest": {
+      "autoImports": true,
+      "completeFunctionCalls": false,
+      "names": true,
+      "paths": true,
+      "imports": {
+        "hosts": {
+          "http://localhost:4545/": false
+        }
+      }
+    },
+    "unstable": false
+  },
+  "capabilities": {
+    "textDocument": {
+      "codeAction": {
+        "codeActionLiteralSupport": {
+          "codeActionKind": {
+            "valueSet": [
+              "quickfix"
+            ]
+          }
+        },
+        "isPreferredSupport": true,
+        "dataSupport": true,
+        "resolveSupport": {
+          "properties": [
+            "edit"
+          ]
+        }
+      },
+      "foldingRange": {
+        "lineFoldingOnly": true
+      },
+      "synchronization": {
+        "dynamicRegistration": true,
+        "willSave": true,
+        "willSaveWaitUntil": true,
+        "didSave": true
+      }
+    },
+    "workspace": {
+      "configuration": true,
+      "workspaceFolders": true
+    }
+  }
+}


### PR DESCRIPTION
The second commit contains the actual implementation. Even though this PR adds support for data URLs, we can't support relative paths in data URLs as we won't have a valid base path. For example, the following won't work:

```json
{
  "deno.importMap": "data:application/json;utf8,{\"imports\": { \"a\": \"./a.ts\" }}",
}
```
Closes #11392 