### PR TITLE
fix(repl): fix inconsistent integration test

### DIFF
--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -14,9 +14,9 @@ fn pty_multiline() {
     master.write_all(b"'{'\n").unwrap();
     master.write_all(b"'('\n").unwrap();
     master.write_all(b"'['\n").unwrap();
-    master.write_all(b"/{/'\n").unwrap();
-    master.write_all(b"/(/'\n").unwrap();
-    master.write_all(b"/[/'\n").unwrap();
+    master.write_all(b"/{/\n").unwrap();
+    master.write_all(b"/\\(/\n").unwrap();
+    master.write_all(b"/\\[/\n").unwrap();
     master.write_all(b"console.log(\"{test1} abc {test2} def {{test3}}\".match(/{([^{].+?)}/));\n").unwrap();
     master.write_all(b"close();\n").unwrap();
 
@@ -31,8 +31,8 @@ fn pty_multiline() {
     assert!(output.contains("\"(\""));
     assert!(output.contains("\"[\""));
     assert!(output.contains("/{/"));
-    assert!(output.contains("/(/"));
-    assert!(output.contains("/{/"));
+    assert!(output.contains("/\\(/"));
+    assert!(output.contains("/\\[/"));
     assert!(output.contains("[ \"{test1}\", \"test1\" ]"));
   });
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Reason of this PR
---
I'm working on #11291 and found there is a weird integration test in `repl_tests.rs`.
In the test `pty_multiline`, some test inputs produce errors like below
```
> /{/'
parse error: Unexpected eof at 1:4
> /(/'
parse error: Unexpected eof at 1:4
> /[/'
parse error: Unterminated regexp literal at 1:0
```
I think this is a normal system test and these inputs should not be here.

I git-blamed but I couldn't figure out what the author add these inputs. There is similar test like `'('`, `'{'`, and `'['`, so I think this is a kind of typo.

What I did
---
I replaced them into the normal input.