### PR TITLE
chore: upgrade to swc 0.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,8 +679,7 @@ dependencies = [
 [[package]]
 name = "deno_doc"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa1a8ed91c51b04defa8ab3eda64165b1c98f2a083415d40add13b9207b24aa"
+source = "git+https://github.com/denoland/deno_doc#1e431e52d689bc424e1208909892366351cc8d7c"
 dependencies = [
  "futures",
  "lazy_static",
@@ -726,8 +725,7 @@ dependencies = [
 [[package]]
 name = "deno_lint"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0c42c810399f611cfb7fa0a9c25b70351e4724806313bfca98720dd0509650"
+source = "git+https://github.com/denoland/deno_lint#054f1261a02ea8147f882774bc62d4faf9d041df"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -971,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdbbdb7c1661b4b12bc415f5afe55347685fe717733d534e2b3e93d0d7711f8"
+checksum = "905ce2026766bc341bf489819b6ed31973e52f66b285f7f2dcb5040582b765ca"
 dependencies = [
  "dprint-core",
  "dprint-swc-ecma-ast-view",
@@ -985,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-swc-ecma-ast-view"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5de0d5e8bdbbad4f6d71d754164803ba4aef42f50db2e65c8a5ca4185ac69f"
+checksum = "9a9591846b69e7c62879e3f9dc02d5ebd0fcc2868a96ba9bbb9b6bc304e02dee"
 dependencies = [
  "bumpalo",
  "fnv",
@@ -3373,9 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a893fda61ad72583351e97313439b9cdd200ffb6b2ae75f363e03a39df935086"
+checksum = "645abff0d28bf419bbefdeb155a6076ee884bc0a56837e9edde03e7af916fda7"
 dependencies = [
  "ahash 0.7.4",
  "anyhow",
@@ -3402,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.10.23"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c93df65683ec1a001e15ce1de438c7c2c226c0c2462d1cb93fa1bd2a7664170b"
+checksum = "25c6cd455ca59637ff47297c375a7fea1c7d61cc92448421485021ec6c6bf03d"
 dependencies = [
  "ast_node",
  "cfg-if 0.1.10",
@@ -3426,9 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.48.1"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8060c27a8932c57e5a878acc1c64b44371cce1c88eb3af1f3d12a2628d606a6"
+checksum = "033da686d95b9663e6732c4021e002bc23173bef251db87857e1c3c8bfbfe8cb"
 dependencies = [
  "is-macro",
  "num-bigint 0.2.6",
@@ -3440,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.61.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cf22adfb5d4e81e802d5a5440545d24f5532e6d17ec33e97a3fd06836628be"
+checksum = "4f377629e04d7e4c6b17167421072a51015ced9e8cb4d0022a90470d4779c637"
 dependencies = [
  "bitflags",
  "num-bigint 0.2.6",
@@ -3469,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_dep_graph"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb7b19e23073fd3e35590def0d76499aff312b4a8d01a82ddcb2f3444ca83f1"
+checksum = "6c02db368513fa37730d6b2ab7032476c00fd290c3a4b34d55ae613caabe9e0a"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3481,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f29ead99147d145dee8bcd47121eb4c72764e8569132905330e7a12aba6f3a"
+checksum = "ebaaf9edfaf02f2ea697ad35889cfc26d31fbfebd102a20ed52c077bcb512452"
 dependencies = [
  "anyhow",
  "swc_atoms",
@@ -3494,9 +3492,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.62.1"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e9ae66d3e29d21fc1715cb435ce741d40d86c466f9371d4c1cf56932824393"
+checksum = "adb3574984a0ed08f98b75bf6f6f5415f66a837f7722b7ae1ea150a6572253a5"
 dependencies = [
  "either",
  "enum_kind",
@@ -3515,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86a39b5e99c35c298bc1fa61bec4661adb6e4d642452e27bf0320f1dff85b8b"
+checksum = "8f26ceff094df804b17a333056321f6be18e9df5ecd34fddf62971ed465cf6ec"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3535,9 +3533,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.21.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89df1c71ed7be8feed1a5b7c5bc935ca7bd8b3f2605dc365f10e9209b7a8ed93"
+checksum = "7da61dae479b8b2e38b88a34f5931381912436a93fb7d9fee1872da681e69b9f"
 dependencies = [
  "fxhash",
  "once_cell",
@@ -3554,9 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7fc228d4680fb422c228746ccfed3cba076fd273ad844c8637d60f30f84f235"
+checksum = "095e79be05d3804dadda03a0cbc5b8a6fddaf3131b628c5c3e69309d2aa30996"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3568,9 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8ad3a12fbc842ce155ad9645f09299186af90b2663d16f6f5a4de08e2df1b6"
+checksum = "6a9cd8fa1b1f5416a0dd80f7b481cfc126368f0187a5ec2a1eb52e0efd7482fa"
 dependencies = [
  "dashmap",
  "fxhash",
@@ -3590,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df72984fd9487e1338021412239770586ef915ecd6a36f561251cab1134f617"
+checksum = "d301c102ef312c1521c1ac34c1b7844e443277a1e81aafac015dde2f4cc05528"
 dependencies = [
  "either",
  "fxhash",
@@ -3610,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a431f071410b36c29b18540f635e7d25d5a805ea7a0b79c6a18aa7808457d448"
+checksum = "a5ccc76ee3679862035e22d7193091c3c3d8350290b6f265abc7dcd058ceaaf4"
 dependencies = [
  "base64 0.13.0",
  "dashmap",
@@ -3633,9 +3631,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826f8d436506c2bca0210335da5a500cb31da0a544c00d3b8dcc61bb566191ae"
+checksum = "0105d25263e6a203e78443382489832c5ad33b6ae6783debc4a35dd2838ca259"
 dependencies = [
  "fxhash",
  "serde",
@@ -3650,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9f5416db68768751b6ed4e5b1c3a0f1e43b66331cbfc51b89a268fbaecd628"
+checksum = "2027bcfafe634185e597080c9a94e83904ceea41f09372b130cda87222dd4df9"
 dependencies = [
  "once_cell",
  "scoped-tls",
@@ -3665,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5b93c94bd4fca51ad5c2588e34b46dc5a9b1f079c9b1ec595a968eb4ca8acf"
+checksum = "b06818a3a50e6de46a81d3d9f51a46d08624ff0f9eb2b3f30de717b15133858d"
 dependencies = [
  "num-bigint 0.2.6",
  "swc_atoms",
@@ -3678,9 +3676,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fa9b5c685f5694911f36e3b7408803e7e6a0a7fcc0736c972fdf0662e27a6b"
+checksum = "61e2f57a4c2841101208f1d1738cd7739e89ff9f0d59eecaba3f7f7900aa02c7"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,8 +678,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.8.0"
-source = "git+https://github.com/denoland/deno_doc#1e431e52d689bc424e1208909892366351cc8d7c"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44feacb59368823497c094956cb283bf9431d7d87936421ef7737a7adeb4c574"
 dependencies = [
  "futures",
  "lazy_static",
@@ -724,8 +725,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.10.0"
-source = "git+https://github.com/denoland/deno_lint#054f1261a02ea8147f882774bc62d4faf9d041df"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbbc65249044e20cbd7c548bd0424e779e1f32b7082fa5cee49da47fe46c0cc4"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,8 +43,8 @@ winres = "0.1.11"
 
 [dependencies]
 deno_core = { version = "0.93.0", path = "../core" }
-deno_doc = { git = "https://github.com/denoland/deno_doc" }
-deno_lint = { git = "https://github.com/denoland/deno_lint" }
+deno_doc = "0.9.0"
+deno_lint = "0.11.0"
 deno_runtime = { version = "0.19.0", path = "../runtime" }
 
 atty = "0.2.14"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,8 +43,8 @@ winres = "0.1.11"
 
 [dependencies]
 deno_core = { version = "0.93.0", path = "../core" }
-deno_doc = "0.8.0"
-deno_lint = "0.10.0"
+deno_doc = { git = "https://github.com/denoland/deno_doc" }
+deno_lint = { git = "https://github.com/denoland/deno_lint" }
 deno_runtime = { version = "0.19.0", path = "../runtime" }
 
 atty = "0.2.14"
@@ -55,7 +55,7 @@ data-url = "0.1.0"
 dissimilar = "1.0.2"
 dprint-plugin-json = "0.12.1"
 dprint-plugin-markdown = "0.9.2"
-dprint-plugin-typescript = "0.48.0"
+dprint-plugin-typescript = "0.49.0"
 encoding_rs = "0.8.28"
 env_logger = "0.8.4"
 fancy-regex = "0.5.0"
@@ -81,9 +81,9 @@ semver-parser = "0.10.2"
 serde = { version = "1.0.126", features = ["derive"] }
 shell-escape = "0.1.5"
 sourcemap = "6.0.1"
-swc_bundler = "0.45.0"
-swc_common = { version = "0.10.23", features = ["sourcemap"] }
-swc_ecmascript = { version = "0.45.0", features = ["codegen", "dep_graph", "parser", "proposal", "react", "transforms", "typescript", "visit"] }
+swc_bundler = "0.46.0"
+swc_common = { version = "0.11.0", features = ["sourcemap"] }
+swc_ecmascript = { version = "0.46.0", features = ["codegen", "dep_graph", "parser", "proposal", "react", "transforms", "typescript", "visit"] }
 tempfile = "3.2.0"
 termcolor = "1.1.2"
 text-size = "1.1.0"

--- a/cli/ast/mod.rs
+++ b/cli/ast/mod.rs
@@ -615,7 +615,11 @@ mod tests {
           leading_comments: Vec::new(),
           span: Span::new(BytePos(0), BytePos(33), Default::default()),
           specifier: "./test.ts".into(),
-          specifier_span: Span::new(BytePos(21), BytePos(32), Default::default()),
+          specifier_span: Span::new(
+            BytePos(21),
+            BytePos(32),
+            Default::default()
+          ),
           import_assertions: HashMap::default(),
         },
         DependencyDescriptor {
@@ -624,7 +628,11 @@ mod tests {
           leading_comments: Vec::new(),
           span: Span::new(BytePos(52), BytePos(70), Default::default()),
           specifier: "./foo.ts".into(),
-          specifier_span: Span::new(BytePos(59), BytePos(69), Default::default()),
+          specifier_span: Span::new(
+            BytePos(59),
+            BytePos(69),
+            Default::default()
+          ),
           import_assertions: HashMap::default(),
         }
       ]

--- a/cli/ast/mod.rs
+++ b/cli/ast/mod.rs
@@ -259,7 +259,7 @@ impl fmt::Debug for ParsedModule {
 impl ParsedModule {
   /// Return a vector of dependencies for the module.
   pub fn analyze_dependencies(&self) -> Vec<DependencyDescriptor> {
-    analyze_dependencies(&self.module, &self.source_map, &self.comments)
+    analyze_dependencies(&self.module, &self.comments)
   }
 
   /// Get the module's leading comments, where triple slash directives might
@@ -595,14 +595,13 @@ impl swc_bundler::Hook for BundleHook {
 mod tests {
   use super::*;
   use std::collections::HashMap;
+  use swc_common::BytePos;
   use swc_ecmascript::dep_graph::DependencyKind;
 
   #[test]
   fn test_parsed_module_analyze_dependencies() {
     let specifier = resolve_url_or_path("https://deno.land/x/mod.js").unwrap();
-    let source = r#"import * as bar from "./test.ts";
-    const foo = await import("./foo.ts");
-    "#;
+    let source = "import * as bar from './test.ts';\nconst foo = await import('./foo.ts');";
     let parsed_module =
       parse(specifier.as_str(), source, &MediaType::JavaScript)
         .expect("could not parse module");
@@ -614,22 +613,18 @@ mod tests {
           kind: DependencyKind::Import,
           is_dynamic: false,
           leading_comments: Vec::new(),
-          col: 0,
-          line: 1,
+          span: Span::new(BytePos(0), BytePos(33), Default::default()),
           specifier: "./test.ts".into(),
-          specifier_col: 21,
-          specifier_line: 1,
+          specifier_span: Span::new(BytePos(21), BytePos(32), Default::default()),
           import_assertions: HashMap::default(),
         },
         DependencyDescriptor {
           kind: DependencyKind::Import,
           is_dynamic: true,
           leading_comments: Vec::new(),
-          col: 22,
-          line: 2,
+          span: Span::new(BytePos(52), BytePos(70), Default::default()),
           specifier: "./foo.ts".into(),
-          specifier_col: 29,
-          specifier_line: 2,
+          specifier_span: Span::new(BytePos(59), BytePos(69), Default::default()),
           import_assertions: HashMap::default(),
         }
       ]

--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -377,8 +377,12 @@ pub fn analyze_dependencies(
 
     let dep = dependencies.entry(desc.specifier.to_string()).or_default();
     dep.is_dynamic = desc.is_dynamic;
-    let start = parsed_module.source_map.lookup_char_pos(desc.specifier_span.lo);
-    let end = parsed_module.source_map.lookup_char_pos(desc.specifier_span.hi);
+    let start = parsed_module
+      .source_map
+      .lookup_char_pos(desc.specifier_span.lo);
+    let end = parsed_module
+      .source_map
+      .lookup_char_pos(desc.specifier_span.hi);
     let range = Range {
       start: Position {
         line: (start.line - 1) as u32,

--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -377,34 +377,26 @@ pub fn analyze_dependencies(
 
     let dep = dependencies.entry(desc.specifier.to_string()).or_default();
     dep.is_dynamic = desc.is_dynamic;
+    let start = parsed_module.source_map.lookup_char_pos(desc.specifier_span.lo);
+    let end = parsed_module.source_map.lookup_char_pos(desc.specifier_span.hi);
+    let range = Range {
+      start: Position {
+        line: (start.line - 1) as u32,
+        character: start.col_display as u32,
+      },
+      end: Position {
+        line: (end.line - 1) as u32,
+        character: end.col_display as u32,
+      },
+    };
     match desc.kind {
       swc_ecmascript::dep_graph::DependencyKind::ExportType
       | swc_ecmascript::dep_graph::DependencyKind::ImportType => {
-        dep.maybe_type_specifier_range = Some(Range {
-          start: Position {
-            line: (desc.specifier_line - 1) as u32,
-            character: desc.specifier_col as u32,
-          },
-          end: Position {
-            line: (desc.specifier_line - 1) as u32,
-            character: (desc.specifier_col + desc.specifier.chars().count() + 2)
-              as u32,
-          },
-        });
+        dep.maybe_type_specifier_range = Some(range);
         dep.maybe_type = Some(resolved_import)
       }
       _ => {
-        dep.maybe_code_specifier_range = Some(Range {
-          start: Position {
-            line: (desc.specifier_line - 1) as u32,
-            character: desc.specifier_col as u32,
-          },
-          end: Position {
-            line: (desc.specifier_line - 1) as u32,
-            character: (desc.specifier_col + desc.specifier.chars().count() + 2)
-              as u32,
-          },
-        });
+        dep.maybe_code_specifier_range = Some(range);
         dep.maybe_code = Some(resolved_import);
       }
     }

--- a/cli/module_graph.rs
+++ b/cli/module_graph.rs
@@ -386,10 +386,11 @@ impl Module {
     for desc in dependencies.iter().filter(|desc| {
       desc.kind != swc_ecmascript::dep_graph::DependencyKind::Require
     }) {
+      let loc = parsed_module.source_map.lookup_char_pos(desc.span.lo);
       let location = Location {
         filename: self.specifier.to_string(),
-        col: desc.col,
-        line: desc.line,
+        col: loc.col_display,
+        line: loc.line,
       };
 
       // In situations where there is a potential issue with resolving the


### PR DESCRIPTION
This upgrades swc to 0.46. There was a breaking change I did in swc for getting rid of the `source_map` dependency for #11345.