### PR TITLE
refactor(cli/unix_utils): raise fd limit in O(1) time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,7 @@ dependencies = [
  "rand 0.8.4",
  "regex",
  "ring",
+ "rlimit",
  "rustyline",
  "rustyline-derive",
  "semver-parser 0.10.2",
@@ -2868,6 +2869,15 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee7d411d8191b944415ac6abba8556b562be0667f20905d3de427553d74106e2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,6 +74,7 @@ percent-encoding = "2.1.0"
 pin-project = "1.0.7"
 regex = "1.4.3"
 rand = { version = "0.8.4", features = [ "small_rng" ] }
+rlimit = "0.6.1"
 ring = "0.16.20"
 rustyline = { version = "8.2.0", default-features = false }
 rustyline-derive = "0.4.0"

--- a/cli/unix_util.rs
+++ b/cli/unix_util.rs
@@ -3,41 +3,6 @@
 /// Raise soft file descriptor limit to hard file descriptor limit.
 /// This is the difference between `ulimit -n` and `ulimit -n -H`.
 pub fn raise_fd_limit() {
-  #[cfg(unix)]
-  unsafe {
-    let mut limits = libc::rlimit {
-      rlim_cur: 0,
-      rlim_max: 0,
-    };
-
-    if 0 != libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) {
-      return;
-    }
-
-    if limits.rlim_cur == libc::RLIM_INFINITY {
-      return;
-    }
-
-    // No hard limit? Do a binary search for the effective soft limit.
-    if limits.rlim_max == libc::RLIM_INFINITY {
-      let mut min = limits.rlim_cur;
-      let mut max = 1 << 20;
-
-      while min + 1 < max {
-        limits.rlim_cur = min + (max - min) / 2;
-        match libc::setrlimit(libc::RLIMIT_NOFILE, &limits) {
-          0 => min = limits.rlim_cur,
-          _ => max = limits.rlim_cur,
-        }
-      }
-
-      return;
-    }
-
-    // Raise the soft limit to the hard limit.
-    if limits.rlim_cur < limits.rlim_max {
-      limits.rlim_cur = limits.rlim_max;
-      libc::setrlimit(libc::RLIMIT_NOFILE, &limits);
-    }
-  }
+  // as high as possible
+  rlimit::utils::increase_nofile_limit(u64::MAX).ok();
 }


### PR DESCRIPTION
Binary search is unnecessary. We can raise fd limit directly.
Note that there is another strict limit (`kern.maxfilesperproc`) on macOS and other BSDs. 
The tool in `rlimit` crate detects this limit and tries to increase `RLIMIT_NOFILE` soft limit as high as possible.
