### PR TITLE
fix(extensions/net): http.Server doesn't expose randomly selected port

### DIFF
--- a/extensions/net/01_net.js
+++ b/extensions/net/01_net.js
@@ -206,7 +206,9 @@
       hostname: typeof hostname === "undefined" ? "0.0.0.0" : hostname,
       ...options,
     });
-
+    if (options.port === 0) {
+      console.log("Listining on " + res.localAddr.port);
+    }
     return new Listener(res.rid, res.localAddr);
   }
 


### PR DESCRIPTION
If you specify port 0, as serve({ port: 0 }) the library works correctly and automatically selects a port. However, the port is accessible to the process cannot advertise where it is listening on.
See https://github.com/denoland/deno_std/issues/1036