### PR TITLE
fix(cli): return error from `coverage_command`

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -966,8 +966,7 @@ async fn coverage_command(
   lcov: bool,
 ) -> Result<(), AnyError> {
   if files.is_empty() {
-    println!("No matching coverage profiles found");
-    std::process::exit(1);
+    return Err(generic_error("no matching coverage profiles found"));
   }
 
   tools::coverage::cover_files(

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -966,7 +966,7 @@ async fn coverage_command(
   lcov: bool,
 ) -> Result<(), AnyError> {
   if files.is_empty() {
-    return Err(generic_error("no matching coverage profiles found"));
+    return Err(generic_error("No matching coverage profiles found"));
   }
 
   tools::coverage::cover_files(


### PR DESCRIPTION
This propagates errors for the coverage command all the way down to `main` rather than having ad-hoc `process::exit(1)` calls in the middle of the call chain.