### PR TITLE
feat(extensions/webstorage): optimize db calls with pragmas

### DIFF
--- a/extensions/webstorage/lib.rs
+++ b/extensions/webstorage/lib.rs
@@ -68,7 +68,7 @@ fn get_webstorage(
       let initial_pragmas = "
         -- enable write-ahead-logging mode
         PRAGMA journal_mode=WAL;
-        pragma temp_store=memory;
+        PRAGMA temp_store=memory;
         PRAGMA page_size=4096;
         PRAGMA mmap_size=6000000;
         PRAGMA optimize;

--- a/extensions/webstorage/lib.rs
+++ b/extensions/webstorage/lib.rs
@@ -68,6 +68,7 @@ fn get_webstorage(
       let initial_pragmas = "
         -- enable write-ahead-logging mode
         PRAGMA journal_mode=WAL;
+        pragma temp_store=memory;
         PRAGMA page_size=4096;
         PRAGMA mmap_size=6000000;
         PRAGMA optimize;


### PR DESCRIPTION
Certain combination of pragmas to optimize database. 

Enables write-ahead-log, memory mapped I/O and re-analyzes database on first connection.

Benchmarks

```
divy@lappy:~/Desktop/gh/deno$ hyperfine --prepare 'rm -rf ~/.cache/deno/location_data/' -m 5 'target/release/deno run --unstable --location=https://a.com bench_localstorage.js' 'deno run --unstable --location=https://a.com bench_localstorage.js'
Benchmark #1: target/release/deno run --unstable --location=https://a.com bench_localstorage.js
  Time (mean ± σ):      3.743 s ±  0.166 s    [User: 45.9 ms, System: 22.0 ms]
  Range (min … max):    3.555 s …  3.984 s    5 runs
 
Benchmark #2: deno run --unstable --location=https://a.com bench_localstorage.js
  Time (mean ± σ):     15.032 s ±  0.557 s    [User: 42.6 ms, System: 70.6 ms]
  Range (min … max):   14.436 s … 15.940 s    5 runs
 
Summary
  'target/release/deno run --unstable --location=https://a.com bench_localstorage.js' ran
    4.02 ± 0.23 times faster than 'deno run --unstable --location=https://a.com bench_localstorage.js'
```
(Note: benchmarks recorded on a "potato" [i7 + HDD] , disk I/O is slow)