### PR TITLE
fix(workers): Silently ignore non-existent worker IDs

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1160,6 +1160,11 @@ itest!(worker_event_handler_test {
   output: "worker_event_handler_test.js.out",
 });
 
+itest!(worker_close_race {
+  args: "run --quiet --reload --allow-read worker_close_race.js",
+  output: "worker_close_race.js.out",
+});
+
 #[test]
 fn no_validate_asm() {
   let output = util::deno_cmd()

--- a/cli/tests/worker_close_race.js
+++ b/cli/tests/worker_close_race.js
@@ -1,0 +1,14 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+// https://github.com/denoland/deno/issues/11416
+// Test for a race condition between a worker's `close()` and the main thread's
+// `Worker.prototype.terminate()`.
+
+const worker = new Worker(
+  new URL("./workers/close_race_worker.js", import.meta.url),
+  { type: "module" },
+);
+
+worker.onmessage = () => {
+  worker.terminate();
+};

--- a/cli/tests/workers/close_race_worker.js
+++ b/cli/tests/workers/close_race_worker.js
@@ -1,0 +1,6 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+setTimeout(() => {
+  self.postMessage("");
+  self.close();
+}, 500);


### PR DESCRIPTION
The `op_host_terminate_worker` and `op_host_post_message` ops used to panic when called with a non-existent worker ID, since it would indicate an error in the JS side. However, #11416 shows that race conditions between a worker's `close()` function and the corresponding `Worker.prototype.terminate()` can lead to the JS side performing ops on the worker before being notified that the worker has terminated. As such, this change silently ignores non-existent worker IDs in those ops. 

Fixes #11416.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
