### PR TITLE
fix(repl): output error without hanging when input is invalid

### DIFF
--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -73,6 +73,23 @@ fn pty_bad_input() {
 
 #[cfg(unix)]
 #[test]
+fn pty_syntax_error_input() {
+  use std::io::{Read, Write};
+  run_pty_test(|master| {
+    master.write_all(b"('\\u')\n").unwrap();
+    master.write_all(b"('\n").unwrap();
+    master.write_all(b"close();\n").unwrap();
+
+    let mut output = String::new();
+    master.read_to_string(&mut output).unwrap();
+
+    assert!(output.contains("Unterminated string constant"));
+    assert!(output.contains("Unexpected eof"));
+  });
+}
+
+#[cfg(unix)]
+#[test]
 fn pty_complete_symbol() {
   use std::io::{Read, Write};
   run_pty_test(|master| {

--- a/cli/tools/repl.rs
+++ b/cli/tools/repl.rs
@@ -29,6 +29,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::sync::Arc;
+use swc_ecmascript::parser::error::SyntaxError;
 use swc_ecmascript::parser::token::{Token, Word};
 use tokio::sync::mpsc::channel;
 use tokio::sync::mpsc::unbounded_channel;
@@ -252,6 +253,17 @@ impl Validator for EditorHelper {
               }
               (None, _) => {
                 // While technically invalid when unpaired, it should be V8's task to output error instead.
+                // Thus marked as valid with no info.
+                return Ok(ValidationResult::Valid(None));
+              }
+            }
+          }
+          Token::Error(error) => {
+            match error.kind() {
+              // If there is unterminated template, it continues to read input.
+              SyntaxError::UnterminatedTpl => {}
+              _ => {
+                // If it failed parsing, it should be V8's task to output error instead.
                 // Thus marked as valid with no info.
                 return Ok(ValidationResult::Valid(None));
               }


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Reason of this PR
---

Close #11291 

As discussed in #11291, when the input is invalid, repl hangs forever.
This PR makes repl output error instead of hanging when the input is invalid.

What I did
---
Actually, repl looks hanging, but it just continues to read the next input that never end.
The reason is that repl thinks the input might be the middle of the template though the input is invalid.
However it continues to read when obviously it is not in a template.

I changed the condition that determines whether it continues to read or not.
When the error is `SyntaxError::UnterminatedTpl`, it continues to read, otherwise raise error.

When raising error, in the same way as unpaired braces, it marked the input as valid with no info and V8 raise the error instead.