### PR TITLE
test(cli): add test case for 'deno test --watch'

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -3475,6 +3475,29 @@ mod tests {
   }
 
   #[test]
+  fn test_watch() {
+    let r = flags_from_vec(svec!["deno", "test", "--watch"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Test {
+          no_run: false,
+          doc: false,
+          fail_fast: None,
+          filter: None,
+          allow_none: false,
+          quiet: false,
+          shuffle: None,
+          include: None,
+          concurrent_jobs: 1,
+        },
+        watch: true,
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
   fn bundle_with_cafile() {
     let r = flags_from_vec(svec![
       "deno",


### PR DESCRIPTION
This PR adds a test case for checking the fix #11433, prevents #11432 happening again in the future.