### PR TITLE
feat(cli/tools/test): imply media type from doc attribute

### DIFF
--- a/cli/tests/test/doc.out
+++ b/cli/tests/test/doc.out
@@ -1,5 +1,10 @@
-Check [WILDCARD]/doc.ts$2-7
+Check [WILDCARD]/doc.ts$2-5.ts
+Check [WILDCARD]/doc.ts$6-9.js
+Check [WILDCARD]/doc.ts$10-13.jsx
+Check [WILDCARD]/doc.ts$14-17.ts
+Check [WILDCARD]/doc.ts$18-21.tsx
+Check [WILDCARD]/doc.ts$30-35.ts
 error: TS2367 [ERROR]: This condition will always return 'false' since the types 'string' and 'number' have no overlap.
-console.assert(example() == 42);
-               ~~~~~~~~~~~~~~~
-    at [WILDCARD]/doc.ts$2-7.ts:3:16
+console.assert(check() == 42);
+               ~~~~~~~~~~~~~
+    at [WILDCARD]/doc.ts$30-35.ts:3:16

--- a/cli/tests/test/doc.ts
+++ b/cli/tests/test/doc.ts
@@ -1,10 +1,38 @@
 /**
  * ```
- * import { example } from "./doc.ts";
+ * import * as doc from "./doc.ts";
+ * ```
  *
- * console.assert(example() == 42);
+ * ```js
+ * import * as doc from "./doc.ts";
+ * ```
+ *
+ * ```jsx
+ * import * as doc from "./doc.ts";
+ * ```
+ *
+ * ```ts
+ * import * as doc from "./doc.ts";
+ * ```
+ *
+ * ```tsx
+ * import * as doc from "./doc.ts";
+ * ```
+ *
+ * ```text
+ * import * as doc from "./doc.ts";
+ * ```
+ *
+ * @module doc
+ */
+
+/**
+ * ```
+ * import { check } from "./doc.ts";
+ *
+ * console.assert(check() == 42);
  * ```
  */
-export function example(): string {
-  return "example";
+export function check(): string {
+  return "check";
 }

--- a/cli/tools/test_runner.rs
+++ b/cli/tools/test_runner.rs
@@ -375,6 +375,24 @@ pub async fn run_tests(
         }
 
         for block in blocks_regex.captures_iter(&comment.text) {
+          let maybe_attributes = block.get(1).map(|m| m.as_str().split(' '));
+          let media_type = if let Some(mut attributes) = maybe_attributes {
+            match attributes.next() {
+              Some("js") => MediaType::JavaScript,
+              Some("jsx") => MediaType::Jsx,
+              Some("ts") => MediaType::TypeScript,
+              Some("tsx") => MediaType::Tsx,
+              Some("") => file.media_type,
+              _ => MediaType::Unknown,
+            }
+          } else {
+            file.media_type
+          };
+
+          if media_type == MediaType::Unknown {
+            continue;
+          }
+
           let body = block.get(2).unwrap();
           let text = body.as_str();
 
@@ -394,16 +412,17 @@ pub async fn run_tests(
           let location = parsed_module.get_location(&span);
 
           let specifier = deno_core::resolve_url_or_path(&format!(
-            "{}${}-{}",
+            "{}${}-{}{}",
             location.filename,
             location.line,
             location.line + element.as_str().split('\n').count(),
+            media_type.as_ts_extension(),
           ))?;
 
           let file = File {
             local: specifier.to_file_path().unwrap(),
             maybe_types: None,
-            media_type: MediaType::TypeScript, // media_type.clone(),
+            media_type,
             source: source.clone(),
             specifier: specifier.clone(),
           };


### PR DESCRIPTION
This augments the doc test feature to use the first attribute in markdown blocks as the media type and extension for the extracted example.