### PR TITLE
fix(tsc): add .at() types manually to tsc, update to tsc v4.3.5

### DIFF
--- a/cli/dts/lib.esnext.array.d.ts
+++ b/cli/dts/lib.esnext.array.d.ts
@@ -1,0 +1,120 @@
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions
+and limitations under the License.
+***************************************************************************** */
+
+/// <reference no-default-lib="true"/>
+
+interface Array<T> {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): T | undefined;
+}
+
+interface ReadonlyArray<T> {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): T | undefined;
+}
+
+interface Int8Array {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): number | undefined;
+}
+
+interface Uint8Array {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): number | undefined;
+}
+
+interface Uint8ClampedArray {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): number | undefined;
+}
+
+interface Int16Array {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): number | undefined;
+}
+
+interface Uint16Array {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): number | undefined;
+}
+
+interface Int32Array {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): number | undefined;
+}
+
+interface Uint32Array {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): number | undefined;
+}
+
+interface Float32Array {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): number | undefined;
+}
+
+interface Float64Array {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): number | undefined;
+}
+
+interface BigInt64Array {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): bigint | undefined;
+}
+
+interface BigUint64Array {
+  /**
+   * Access item by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): bigint | undefined;
+}

--- a/cli/dts/lib.esnext.d.ts
+++ b/cli/dts/lib.esnext.d.ts
@@ -19,4 +19,6 @@ and limitations under the License.
 
 
 /// <reference lib="es2021" />
+/// <reference lib="esnext.array" />
 /// <reference lib="esnext.intl" />
+/// <reference lib="esnext.string" />

--- a/cli/dts/lib.esnext.string.d.ts
+++ b/cli/dts/lib.esnext.string.d.ts
@@ -13,23 +13,12 @@ See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
 
-
-
 /// <reference no-default-lib="true"/>
 
-
 interface String {
-    /**
-     * Replace all instances of a substring in a string, using a regular expression or search string.
-     * @param searchValue A string to search for.
-     * @param replaceValue A string containing the text to replace for every successful match of searchValue in this string.
-     */
-    replaceAll(searchValue: string | RegExp, replaceValue: string): string;
-
-    /**
-     * Replace all instances of a substring in a string, using a regular expression or search string.
-     * @param searchValue A string to search for.
-     * @param replacer A function that returns the replacement text.
-     */
-    replaceAll(searchValue: string | RegExp, replacer: (substring: string, ...args: any[]) => string): string;
+  /**
+   * Access string by relative indexing.
+   * @param index index to access.
+   */
+  at(index: number): string | undefined;
 }

--- a/cli/dts/typescript.d.ts
+++ b/cli/dts/typescript.d.ts
@@ -5205,6 +5205,7 @@ declare namespace ts {
          * writeFileCallback
          */
         writeFile?(path: string, data: string, writeByteOrderMark?: boolean): void;
+        getCustomTransformers?: (project: string) => CustomTransformers | undefined;
         getModifiedTime(fileName: string): Date | undefined;
         setModifiedTime(fileName: string, date: Date): void;
         deleteFile(fileName: string): void;

--- a/cli/tests/unit/esnext_test.ts
+++ b/cli/tests/unit/esnext_test.ts
@@ -1,0 +1,12 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { assertEquals, unitTest } from "./test_util.ts";
+
+// TODO(@kitsonk) remove when we are no longer patching TypeScript to have
+// these types available.
+
+unitTest(function typeCheckingEsNextArrayString() {
+  const a = "abcdef";
+  assertEquals(a.at(-1), "f");
+  const b = ["a", "b", "c", "d", "e", "f"];
+  assertEquals(b.at(-1), "f");
+});


### PR DESCRIPTION
Fixes: #11441

This manually adds the types for `.at()` types to arrays and strings.  It is a bit "hacky", but essentially the same way we add `"dom.asynciterable"` to TypeScript.

Something we should revert once in a released version of TypeScript (but will likely just overwrite when it is finally included).

Added a simply js_unit test which validates that it should pass type checking.

Also updated to the latest release version of TypeScript (4.3.2 -> 4.3.5).