### PR TITLE
fix: Big{U|}Int64Array in crypto.getRandomValues

### DIFF
--- a/extensions/crypto/00_crypto.js
+++ b/extensions/crypto/00_crypto.js
@@ -776,11 +776,13 @@
         !(
           arrayBufferView instanceof Int8Array ||
           arrayBufferView instanceof Uint8Array ||
+          arrayBufferView instanceof Uint8ClampedArray ||
           arrayBufferView instanceof Int16Array ||
           arrayBufferView instanceof Uint16Array ||
           arrayBufferView instanceof Int32Array ||
           arrayBufferView instanceof Uint32Array ||
-          arrayBufferView instanceof Uint8ClampedArray
+          arrayBufferView instanceof BigInt64Array ||
+          arrayBufferView instanceof BigUint64Array
         )
       ) {
         throw new DOMException(

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1962,7 +1962,7 @@
       "wrapKey_unwrapKey.https.any.html": false
     },
     "randomUUID.any.html": true,
-    "getRandomValues-bigint.tentative.any.html": false
+    "getRandomValues-bigint.tentative.any.html": true
   },
   "console": {
     "console-is-a-namespace.any.html": true,


### PR DESCRIPTION
Relevant spec change: https://github.com/w3c/webcrypto/pull/266

Closes #11445