### PR TITLE
feat(lsp): add workspace config to status page

### DIFF
--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -6,6 +6,7 @@ use deno_core::error::anyhow;
 use deno_core::error::AnyError;
 use deno_core::parking_lot::RwLock;
 use deno_core::serde::Deserialize;
+use deno_core::serde::Serialize;
 use deno_core::serde_json;
 use deno_core::serde_json::Value;
 use deno_core::url::Url;
@@ -33,7 +34,7 @@ fn is_true() -> bool {
   true
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeLensSettings {
   /// Flag for providing implementation code lenses.
@@ -78,7 +79,7 @@ impl Default for CodeLensSpecifierSettings {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionSettings {
   #[serde(default)]
@@ -105,7 +106,7 @@ impl Default for CompletionSettings {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ImportCompletionSettings {
   /// A flag that indicates if non-explicitly set origins should be checked for
@@ -140,7 +141,7 @@ pub struct SpecifierSettings {
 }
 
 /// Deno language server specific settings that are applied to a workspace.
-#[derive(Debug, Default, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceSettings {
   /// A flag that indicates if Deno is enabled for the workspace.

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -2441,9 +2441,18 @@ impl Inner {
       let mut sources_specifiers = self.sources.specifiers();
       sources_specifiers.sort();
       let measures = self.performance.to_vec();
+      let workspace_settings = self.config.get_workspace_settings();
 
       contents.push_str(&format!(
         r#"# Deno Language Server Status
+
+## Workspace Settings
+
+```json
+{}
+```
+
+## Workspace Details
 
   - <details><summary>Documents in memory: {}</summary>
 
@@ -2463,6 +2472,7 @@ impl Inner {
 
   </details>
 "#,
+        serde_json::to_string_pretty(&workspace_settings).unwrap(),
         self.documents.len(),
         documents_specifiers
           .into_iter()


### PR DESCRIPTION
This add a representation of what the language server thinks are the current settings to the language server status page.

We have had several issues that have been difficult to diagnose because we don't know how workspace and global settings in vscode have had an impact on the lsp and this provides exactly what the LSP thinks things are.