### PR TITLE
fix(http/ws): case insensitive connection header

### DIFF
--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -642,7 +642,7 @@ unitTest({ perms: { net: true } }, async function httpServerWebSocket() {
       const {
         response,
         websocket,
-      } = await Deno.upgradeWebSocket(request);
+      } = Deno.upgradeWebSocket(request);
       websocket.onerror = () => fail();
       websocket.onmessage = (m) => {
         websocket.send(m.data);
@@ -661,6 +661,36 @@ unitTest({ perms: { net: true } }, async function httpServerWebSocket() {
   ws.onopen = () => ws.send("foo");
   await def;
   await promise;
+});
+
+unitTest(function httpUpgradeWebSocket() {
+  const request = new Request("https://deno.land/", {
+    headers: {
+      connection: "Upgrade",
+      upgrade: "websocket",
+      "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+    },
+  });
+  const { response } = Deno.upgradeWebSocket(request);
+  assertEquals(response.status, 101);
+  assertEquals(response.headers.get("connection"), "Upgrade");
+  assertEquals(response.headers.get("upgrade"), "websocket");
+  assertEquals(
+    response.headers.get("sec-websocket-accept"),
+    "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+  );
+});
+
+unitTest(function httpUpgradeWebSocketLowercaseUpgradeHeader() {
+  const request = new Request("https://deno.land/", {
+    headers: {
+      connection: "upgrade",
+      upgrade: "websocket",
+      "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+    },
+  });
+  const { response } = Deno.upgradeWebSocket(request);
+  assertEquals(response.status, 101);
 });
 
 unitTest({ perms: { net: true } }, async function httpCookieConcatenation() {

--- a/extensions/http/01_http.js
+++ b/extensions/http/01_http.js
@@ -321,7 +321,7 @@
       );
     }
 
-    if (request.headers.get("connection") !== "Upgrade") {
+    if (request.headers.get("connection")?.toLowerCase() !== "upgrade") {
       throw new TypeError(
         "Invalid Header: 'connection' header must be 'Upgrade'",
       );


### PR DESCRIPTION
The "connection" header should be case insensitive:
https://datatracker.ietf.org/doc/html/rfc7230#section-6.1

Fixes #11487