### PR TITLE
cleanup(runtime): remove last references to Deno.core.sharedQueue

### DIFF
--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -526,7 +526,6 @@ delete Object.prototype.__proto__;
     // `Deno` with `Deno` namespace from "./deno.ts".
     ObjectDefineProperty(globalThis, "Deno", util.readOnly(finalDenoNs));
     ObjectFreeze(globalThis.Deno.core);
-    ObjectFreeze(globalThis.Deno.core.sharedQueue);
     signals.setSignals();
 
     util.log("args", args);
@@ -599,7 +598,6 @@ delete Object.prototype.__proto__;
       util.immutableDefine(globalThis, "Deno", finalDenoNs);
       ObjectFreeze(globalThis.Deno);
       ObjectFreeze(globalThis.Deno.core);
-      ObjectFreeze(globalThis.Deno.core.sharedQueue);
       signals.setSignals();
     } else {
       delete globalThis.Deno;


### PR DESCRIPTION
`Deno.core.sharedQueue` was killed in #9843