### PR TITLE
fix(http/ws): support multiple options in connection header

### DIFF
--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -693,6 +693,18 @@ unitTest(function httpUpgradeWebSocketLowercaseUpgradeHeader() {
   assertEquals(response.status, 101);
 });
 
+unitTest(function httpUpgradeWebSocketMultipleConnectionOptions() {
+  const request = new Request("https://deno.land/", {
+    headers: {
+      connection: "keep-alive, upgrade",
+      upgrade: "websocket",
+      "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+    },
+  });
+  const { response } = Deno.upgradeWebSocket(request);
+  assertEquals(response.status, 101);
+});
+
 unitTest({ perms: { net: true } }, async function httpCookieConcatenation() {
   const promise = (async () => {
     const listener = Deno.listen({ port: 4501 });

--- a/extensions/http/01_http.js
+++ b/extensions/http/01_http.js
@@ -22,8 +22,11 @@
   const {
     ArrayPrototypeIncludes,
     ArrayPrototypePush,
+    ArrayPrototypeSome,
     Promise,
     StringPrototypeIncludes,
+    StringPrototypeToLowerCase,
+    StringPrototypeTrim,
     StringPrototypeSplit,
     Symbol,
     SymbolAsyncIterator,
@@ -321,7 +324,14 @@
       );
     }
 
-    if (request.headers.get("connection")?.toLowerCase() !== "upgrade") {
+    const connection = request.headers.get("connection");
+    const connectionHasUpgradeOption = connection !== null &&
+      ArrayPrototypeSome(
+        StringPrototypeSplit(connection, ","),
+        (option) =>
+          StringPrototypeToLowerCase(StringPrototypeTrim(option)) === "upgrade",
+      );
+    if (!connectionHasUpgradeOption) {
       throw new TypeError(
         "Invalid Header: 'connection' header must be 'Upgrade'",
       );

--- a/extensions/http/01_http.js
+++ b/extensions/http/01_http.js
@@ -26,7 +26,6 @@
     Promise,
     StringPrototypeIncludes,
     StringPrototypeToLowerCase,
-    StringPrototypeTrim,
     StringPrototypeSplit,
     Symbol,
     SymbolAsyncIterator,
@@ -327,9 +326,8 @@
     const connection = request.headers.get("connection");
     const connectionHasUpgradeOption = connection !== null &&
       ArrayPrototypeSome(
-        StringPrototypeSplit(connection, ","),
-        (option) =>
-          StringPrototypeToLowerCase(StringPrototypeTrim(option)) === "upgrade",
+        StringPrototypeSplit(connection, /\s*,\s*/),
+        (option) => StringPrototypeToLowerCase(option) === "upgrade",
       );
     if (!connectionHasUpgradeOption) {
       throw new TypeError(


### PR DESCRIPTION
The "connection" header can have multiple connection-options separated by commas:
https://datatracker.ietf.org/doc/html/rfc7230#section-6.1
https://datatracker.ietf.org/doc/html/rfc7230#section-7

Fixes #11494 