### PR TITLE
chore: add benchmarks for large files in fetch

### DIFF
--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -96,21 +96,17 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
   ),
   (
     "fetch_single_large_file",
-    &[
-      "run",
-      "--allow-net",
-      "cli/tests/fetch_single_large_file.ts"
-    ],
-    None
+    &["run", "--allow-net", "cli/tests/fetch_single_large_file.ts"],
+    None,
   ),
   (
     "fetch_multiple_large_files",
     &[
       "run",
       "--allow-net",
-      "cli/tests/fetch_multiple_large_files.ts"
+      "cli/tests/fetch_multiple_large_files.ts",
     ],
-    None
+    None,
   ),
   (
     "check",

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -95,6 +95,24 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
     None,
   ),
   (
+    "fetch_single_large_file",
+    &[
+      "run",
+      "--allow-net",
+      "cli/tests/fetch_single_large_file.ts"
+    ],
+    None
+  ),
+  (
+    "fetch_multiple_large_files",
+    &[
+      "run",
+      "--allow-net",
+      "cli/tests/fetch_multiple_large_files.ts"
+    ],
+    None
+  ),
+  (
     "check",
     &[
       "cache",

--- a/cli/tests/fetch_multiple_small_files.ts
+++ b/cli/tests/fetch_multiple_small_files.ts
@@ -1,0 +1,16 @@
+await Promise.all((() => {
+	const reqs = [];
+	for(let i = 0; i < 100; ++i) {
+		reqs.push(fetch('http://localhost:4545/single-small-file'));
+	}
+	return reqs.map(async req => {
+    const resp = await req;
+    const buff = await resp.arrayBuffer();
+    if(buff.byteLength === 1_000_000) {
+      return;
+    } else {
+      throw new Error("Downloaded file size is not the same from original");
+    }
+  });
+})());
+Deno.exit(0);

--- a/cli/tests/fetch_multiple_small_files.ts
+++ b/cli/tests/fetch_multiple_small_files.ts
@@ -1,12 +1,12 @@
 await Promise.all((() => {
-	const reqs = [];
-	for(let i = 0; i < 100; ++i) {
-		reqs.push(fetch('http://localhost:4545/single-small-file'));
-	}
-	return reqs.map(async req => {
+  const reqs = [];
+  for (let i = 0; i < 100; ++i) {
+    reqs.push(fetch("http://localhost:4545/single-small-file"));
+  }
+  return reqs.map(async (req) => {
     const resp = await req;
     const buff = await resp.arrayBuffer();
-    if(buff.byteLength === 1_000_000) {
+    if (buff.byteLength === 1_000_000) {
       return;
     } else {
       throw new Error("Downloaded file size is not the same from original");

--- a/cli/tests/fetch_single_large_file.ts
+++ b/cli/tests/fetch_single_large_file.ts
@@ -1,6 +1,6 @@
 const resp = await fetch("http://localhost:4545/single-large-file");
 const buff = await resp.arrayBuffer();
-if(buff.byteLength !== 100_000_000){
-	throw new Error("Downloaded file size is not the same from original");
+if (buff.byteLength !== 100_000_000) {
+  throw new Error("Downloaded file size is not the same from original");
 }
-Deno.exit(0)
+Deno.exit(0);

--- a/cli/tests/fetch_single_large_file.ts
+++ b/cli/tests/fetch_single_large_file.ts
@@ -1,0 +1,6 @@
+const resp = await fetch("http://localhost:4545/single-large-file");
+const buff = await resp.arrayBuffer();
+if(buff.byteLength !== 100_000_000){
+	throw new Error("Downloaded file size is not the same from original");
+}
+Deno.exit(0)

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.41"
 async-stream = "0.3.2"
 bytes = "1.0.1"
 futures = "0.3.15"
-hyper = { version = "0.14.10", features = ["server", "http1", "runtime"] }
+hyper = { version = "0.14.10", features = ["server", "http1", "runtime", "stream"] }
 lazy_static = "1.4.0"
 os_pipe = "0.9.2"
 regex = "1.4.3"

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -648,14 +648,18 @@ async fn main_server(req: Request<Body>) -> hyper::Result<Response<Body>> {
       } else {
         Ok(Response::new(Body::empty()))
       }
-    },
+    }
     (_, "/single-large-file") => {
-      let stream = futures::stream::repeat::<std::result::Result<_, &str>>(Ok("0")).take(100_000_000);
+      let stream =
+        futures::stream::repeat::<std::result::Result<_, &str>>(Ok("0"))
+          .take(100_000_000);
       let res = Response::new(Body::wrap_stream(stream));
       Ok(res)
-    },
+    }
     (_, "/single-small-file") => {
-      let stream = futures::stream::repeat::<std::result::Result<_, &str>>(Ok("0")).take(1_000_000);
+      let stream =
+        futures::stream::repeat::<std::result::Result<_, &str>>(Ok("0"))
+          .take(1_000_000);
       let res = Response::new(Body::wrap_stream(stream));
       Ok(res)
     }

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -648,6 +648,16 @@ async fn main_server(req: Request<Body>) -> hyper::Result<Response<Body>> {
       } else {
         Ok(Response::new(Body::empty()))
       }
+    },
+    (_, "/single-large-file") => {
+      let stream = futures::stream::repeat::<std::result::Result<_, &str>>(Ok("0")).take(100_000_000);
+      let res = Response::new(Body::wrap_stream(stream));
+      Ok(res)
+    },
+    (_, "/single-small-file") => {
+      let stream = futures::stream::repeat::<std::result::Result<_, &str>>(Ok("0")).take(1_000_000);
+      let res = Response::new(Body::wrap_stream(stream));
+      Ok(res)
     }
     _ => {
       let mut file_path = root_path();


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
Add two tests:
1. download 1 single file that size is 100mB (100_000_000 Bytes)
2. download 100 files that size is 1mB(1_000_000 Bytes) at the same time


fix #8787