### PR TITLE
fix(cli/tools/test_runner): side-load test modules

### DIFF
--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -19,6 +19,12 @@ fn no_color() {
   assert!(out.contains("test result: FAILED. 1 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out"));
 }
 
+itest!(meta {
+  args: "test test/meta.ts",
+  exit_code: 0,
+  output: "test/meta.out",
+});
+
 itest!(pass {
   args: "test test/pass.ts",
   exit_code: 0,

--- a/cli/tests/test/meta.out
+++ b/cli/tests/test/meta.out
@@ -1,0 +1,7 @@
+Check [WILDCARD]/test/meta.ts
+import.meta.main: false
+import.meta.url: [WILDCARD]/test/meta.ts
+running 0 tests from [WILDCARD]/test/meta.ts
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+

--- a/cli/tests/test/meta.ts
+++ b/cli/tests/test/meta.ts
@@ -1,0 +1,2 @@
+console.log("import.meta.main: %s", import.meta.main);
+console.log("import.meta.url: %s", import.meta.url);

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -653,7 +653,7 @@ fn filter_coverages(
     .filter(|e| {
       let is_internal = e.url.starts_with("deno:")
         || e.url.ends_with("__anonymous__")
-        || e.url.ends_with("$deno$test.ts");
+        || e.url.ends_with("$deno$test.js");
 
       let is_included = include.iter().any(|p| p.is_match(&e.url));
       let is_excluded = exclude.iter().any(|p| p.is_match(&e.url));

--- a/cli/tools/test_runner.rs
+++ b/cli/tools/test_runner.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 use swc_common::comments::CommentKind;
+use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -262,10 +263,38 @@ where
 pub async fn run_test_file(
   program_state: Arc<ProgramState>,
   main_module: ModuleSpecifier,
-  test_module: ModuleSpecifier,
   permissions: Permissions,
+  quiet: bool,
+  filter: Option<String>,
+  shuffle: Option<u64>,
   channel: Sender<TestEvent>,
 ) -> Result<(), AnyError> {
+  let test_module =
+    deno_core::resolve_path(&format!("{}$deno$test.js", Uuid::new_v4()))?;
+  let test_source = format!(
+    r#"
+      import "{}";
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await Deno[Deno.internal].runTests({});
+  "#,
+    main_module,
+    json!({
+        "disableLog": quiet,
+        "filter": filter,
+        "shuffle": shuffle,
+    })
+  );
+
+  let test_file = File {
+    local: test_module.to_file_path().unwrap(),
+    maybe_types: None,
+    media_type: MediaType::JavaScript,
+    source: test_source.clone(),
+    specifier: test_module.clone(),
+  };
+
+  program_state.file_fetcher.insert_cached(test_file);
+
   let mut worker =
     create_main_worker(&program_state, main_module.clone(), permissions, true);
 
@@ -291,8 +320,6 @@ pub async fn run_test_file(
   } else {
     None
   };
-
-  worker.execute_module(&main_module).await?;
 
   worker.execute_script(
     &located_script_name!(),
@@ -446,34 +473,13 @@ pub async fn run_tests(
     return Ok(false);
   }
 
-  // Because scripts, and therefore worker.execute cannot detect unresolved promises at the moment
-  // we generate a module for the actual test execution.
-  let test_options = json!({
-      "disableLog": quiet,
-      "filter": filter,
-      "shuffle": shuffle,
-  });
-
-  let test_module = deno_core::resolve_path("$deno$test.js")?;
-  let test_source =
-    format!("await Deno[Deno.internal].runTests({});", test_options);
-  let test_file = File {
-    local: test_module.to_file_path().unwrap(),
-    maybe_types: None,
-    media_type: MediaType::JavaScript,
-    source: test_source.clone(),
-    specifier: test_module.clone(),
-  };
-
-  program_state.file_fetcher.insert_cached(test_file);
-
   let (sender, receiver) = channel::<TestEvent>();
 
   let join_handles = test_modules.iter().map(move |main_module| {
     let program_state = program_state.clone();
     let main_module = main_module.clone();
-    let test_module = test_module.clone();
     let permissions = permissions.clone();
+    let filter = filter.clone();
     let sender = sender.clone();
 
     tokio::task::spawn_blocking(move || {
@@ -481,8 +487,10 @@ pub async fn run_tests(
         let future = run_test_file(
           program_state,
           main_module,
-          test_module,
           permissions,
+          quiet,
+          filter,
+          shuffle,
           sender,
         );
 


### PR DESCRIPTION
This fixes a regression introduced in 1.9 where test modules became main modules.

This is undesirable as it will cause executables to start running when they're guarded with `import.meta.main`.

We now side load (import) the module being tested in a generated module but still mark it as the main module in places where it could be visible like the inspector (effectively everywhere but the import.meta.main flag).

Closes #11504