### PR TITLE
refactor(lsp): minor improvements to handling closed documents

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -75,6 +75,9 @@ delete Object.prototype.__proto__;
   /** @type {Map<string, ts.SourceFile>} */
   const sourceFileCache = new Map();
 
+  /** @type {string[]=} */
+  let scriptFileNamesCache;
+
   /** @type {Map<string, string>} */
   const scriptVersionCache = new Map();
 
@@ -370,7 +373,12 @@ delete Object.prototype.__proto__;
     },
     getScriptFileNames() {
       debug("host.getScriptFileNames()");
-      return core.opSync("op_script_names", undefined);
+      // tsc requests the script file names multiple times even though it can't
+      // possibly have changed, so we will memoize it on a per request basis.
+      if (scriptFileNamesCache) {
+        return scriptFileNamesCache;
+      }
+      return scriptFileNamesCache = core.opSync("op_script_names", undefined);
     },
     getScriptVersion(specifier) {
       debug(`host.getScriptVersion("${specifier}")`);
@@ -378,9 +386,8 @@ delete Object.prototype.__proto__;
       if (sourceFile) {
         return sourceFile.version ?? "1";
       }
-      // tsc neurotically requests the script version multiple times even though
-      // it can't possibly have changed, so we will memoize it on a per request
-      // basis.
+      // tsc requests the script version multiple times even though it can't
+      // possibly have changed, so we will memoize it on a per request basis.
       if (scriptVersionCache.has(specifier)) {
         return scriptVersionCache.get(specifier);
       }
@@ -543,6 +550,8 @@ delete Object.prototype.__proto__;
    */
   function serverRequest({ id, ...request }) {
     debug(`serverRequest()`, { id, ...request });
+    // reset all memoized source files names
+    scriptFileNamesCache = undefined;
     // evict all memoized source file versions
     scriptVersionCache.clear();
     switch (request.method) {


### PR DESCRIPTION
This improves #10897 but doesn't completely resolve it.

The problem is that when a document with the same name of another document is re-opened, and that version of the document happened to not be changed, the version is both `"1"` and so tsc things nothing has changed and provides the diagnostics it provided before in response.  This means:

- If you open a document, but don't edit it.
- You rename or delete that document.
- You then rename another document to that original document.
- That "new" document will have the diagnostics for the previous file up until the file is edited.

I looked at how vscode handles this situation with the built in TypeScript language server and they have a complex buffer system where the re-calculate all the diagnostics.  I will look into it further down the road, but these changes are the best that can be done right now.