### PR TITLE
feat(lsp): ability to set DENO_DIR via settings

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -139,6 +139,9 @@ pub struct Flags {
   pub allow_write: Option<Vec<PathBuf>>,
   pub ca_file: Option<String>,
   pub cache_blocklist: Vec<String>,
+  /// This is not exposed as an option in the CLI, it is used internally when
+  /// the language server is configured with an explicit cache option.
+  pub cache_path: Option<PathBuf>,
   pub cached_only: bool,
   pub config_path: Option<String>,
   pub coverage_dir: Option<String>,

--- a/cli/lsp/README.md
+++ b/cli/lsp/README.md
@@ -19,6 +19,7 @@ methods that the client calls via the Language Server RPC protocol.
 There are several settings that the language server supports for a workspace:
 
 - `deno.enable`
+- `deno.cache`
 - `deno.config`
 - `deno.importMap`
 - `deno.codeLens.implementations`

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -148,6 +148,10 @@ pub struct WorkspaceSettings {
   #[serde(default)]
   pub enable: bool,
 
+  /// An option that points to a path string of the path to utilise as the
+  /// cache/DENO_DIR for the language server.
+  pub cache: Option<String>,
+
   /// An option that points to a path string of the config file to apply to
   /// code within the workspace.
   pub config: Option<String>,
@@ -475,6 +479,7 @@ mod tests {
       config.get_workspace_settings(),
       WorkspaceSettings {
         enable: false,
+        cache: None,
         config: None,
         import_map: None,
         code_lens: CodeLensSettings {

--- a/cli/lsp/registries.rs
+++ b/cli/lsp/registries.rs
@@ -254,8 +254,10 @@ pub struct ModuleRegistry {
 
 impl Default for ModuleRegistry {
   fn default() -> Self {
-    let custom_root = std::env::var("DENO_DIR").map(String::into).ok();
-    let dir = deno_dir::DenoDir::new(custom_root).unwrap();
+    // This only gets used when creating the tsc runtime and for testing, and so
+    // it shouldn't ever actually access the DenoDir, so it doesn't support a
+    // custom root.
+    let dir = deno_dir::DenoDir::new(None).unwrap();
     let location = dir.root.join("registries");
     let http_cache = HttpCache::new(&location);
     let cache_setting = CacheSetting::Use;

--- a/cli/lsp/sources.rs
+++ b/cli/lsp/sources.rs
@@ -9,6 +9,7 @@ use crate::config_file::ConfigFile;
 use crate::file_fetcher::get_source_from_bytes;
 use crate::file_fetcher::map_content_type;
 use crate::file_fetcher::SUPPORTED_SCHEMES;
+use crate::flags::Flags;
 use crate::http_cache;
 use crate::http_cache::HttpCache;
 use crate::import_map::ImportMap;
@@ -36,8 +37,15 @@ pub async fn cache(
   specifier: &ModuleSpecifier,
   maybe_import_map: &Option<ImportMap>,
   maybe_config_file: &Option<ConfigFile>,
+  maybe_cache_path: &Option<PathBuf>,
 ) -> Result<(), AnyError> {
-  let program_state = Arc::new(ProgramState::build(Default::default()).await?);
+  let program_state = Arc::new(
+    ProgramState::build(Flags {
+      cache_path: maybe_cache_path.clone(),
+      ..Default::default()
+    })
+    .await?,
+  );
   let handler = Arc::new(Mutex::new(FetchHandler::new(
     &program_state,
     Permissions::allow_all(),

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -61,8 +61,11 @@ pub struct ProgramState {
 
 impl ProgramState {
   pub async fn build(flags: flags::Flags) -> Result<Arc<Self>, AnyError> {
-    let custom_root = env::var("DENO_DIR").map(String::into).ok();
-    let dir = deno_dir::DenoDir::new(custom_root)?;
+    let maybe_custom_root = flags
+      .cache_path
+      .clone()
+      .or_else(|| env::var("DENO_DIR").map(String::into).ok());
+    let dir = deno_dir::DenoDir::new(maybe_custom_root)?;
     let deps_cache_location = dir.root.join("deps");
     let http_cache = http_cache::HttpCache::new(&deps_cache_location);
     let ca_file = flags.ca_file.clone().or_else(|| env::var("DENO_CERT").ok());

--- a/cli/specifier_handler.rs
+++ b/cli/specifier_handler.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::ast::Location;
-use crate::deno_dir::DenoDir;
 use crate::disk_cache::DiskCache;
 use crate::file_fetcher::FileFetcher;
 use crate::media_type::MediaType;
@@ -19,7 +18,6 @@ use deno_core::serde_json;
 use deno_core::ModuleSpecifier;
 use log::debug;
 use std::collections::HashMap;
-use std::env;
 use std::fmt;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -236,9 +234,7 @@ impl FetchHandler {
     root_permissions: Permissions,
     dynamic_permissions: Permissions,
   ) -> Result<Self, AnyError> {
-    let custom_root = env::var("DENO_DIR").map(String::into).ok();
-    let deno_dir = DenoDir::new(custom_root)?;
-    let disk_cache = deno_dir.gen_cache;
+    let disk_cache = program_state.dir.gen_cache.clone();
     let file_fetcher = program_state.file_fetcher.clone();
 
     Ok(FetchHandler {
@@ -571,10 +567,12 @@ impl SpecifierHandler for MemoryHandler {
 #[cfg(test)]
 pub mod tests {
   use super::*;
+  use crate::deno_dir::DenoDir;
   use crate::file_fetcher::CacheSetting;
   use crate::http_cache::HttpCache;
   use deno_core::resolve_url_or_path;
   use deno_runtime::deno_web::BlobStore;
+  use std::env;
   use tempfile::TempDir;
 
   macro_rules! map (

--- a/cli/tests/lsp/initialize_params.json
+++ b/cli/tests/lsp/initialize_params.json
@@ -7,6 +7,7 @@
   "rootUri": null,
   "initializationOptions": {
     "enable": true,
+    "cache": null,
     "codeLens": {
       "implementations": true,
       "references": true,

--- a/cli/tests/lsp/initialize_params_bad_config_option.json
+++ b/cli/tests/lsp/initialize_params_bad_config_option.json
@@ -7,6 +7,7 @@
   "rootUri": null,
   "initializationOptions": {
     "enable": true,
+    "cache": null,
     "codeLens": {
       "implementations": true,
       "references": true,

--- a/cli/tests/lsp/initialize_params_code_lens_test.json
+++ b/cli/tests/lsp/initialize_params_code_lens_test.json
@@ -7,6 +7,7 @@
   "rootUri": null,
   "initializationOptions": {
     "enable": true,
+    "cache": null,
     "importMap": null,
     "lint": true,
     "suggest": {

--- a/cli/tests/lsp/initialize_params_code_lens_test_disabled.json
+++ b/cli/tests/lsp/initialize_params_code_lens_test_disabled.json
@@ -7,6 +7,7 @@
   "rootUri": null,
   "initializationOptions": {
     "enable": true,
+    "cache": null,
     "codeLens": {
       "implementations": true,
       "references": true,

--- a/cli/tests/lsp/initialize_params_did_config_change.json
+++ b/cli/tests/lsp/initialize_params_did_config_change.json
@@ -7,6 +7,7 @@
   "rootUri": null,
   "initializationOptions": {
     "enable": true,
+    "cache": null,
     "codeLens": {
       "implementations": true,
       "references": true

--- a/cli/tests/lsp/initialize_params_disabled.json
+++ b/cli/tests/lsp/initialize_params_disabled.json
@@ -7,6 +7,7 @@
   "rootUri": null,
   "initializationOptions": {
     "enable": false,
+    "cache": null,
     "codeLens": {
       "implementations": true,
       "references": true

--- a/cli/tests/lsp/initialize_params_registry.json
+++ b/cli/tests/lsp/initialize_params_registry.json
@@ -7,6 +7,7 @@
   "rootUri": null,
   "initializationOptions": {
     "enable": true,
+    "cache": null,
     "codeLens": {
       "implementations": true,
       "references": true

--- a/cli/tests/lsp/initialize_params_unstable.json
+++ b/cli/tests/lsp/initialize_params_unstable.json
@@ -7,6 +7,7 @@
   "rootUri": null,
   "initializationOptions": {
     "enable": true,
+    "cache": null,
     "codeLens": {
       "implementations": true,
       "references": true

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -207,6 +207,7 @@ pub fn compile_to_runtime_flags(
     allow_write: flags.allow_write,
     ca_file: flags.ca_file,
     cache_blocklist: vec![],
+    cache_path: None,
     cached_only: false,
     config_path: None,
     coverage_dir: flags.coverage_dir,


### PR DESCRIPTION
Ref: denoland/vscode_deno#287

Add the ability to specify an override for the DENO_DIR via the language server configuration.  Previously the language server would have to be executed in an environment with the `DENO_DIR` environment setting, which makes it difficult to manage and customise per workspace.