### PR TITLE
feat(extensions/fetch): extend init options

### DIFF
--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -46,6 +46,7 @@ fn create_runtime_snapshot(snapshot_path: &Path, files: Vec<PathBuf>) {
       "".to_owned(),
       None,
       None,
+      None,
     ),
     deno_websocket::init::<deno_websocket::NoWebSocketPermissions>(
       "".to_owned(),

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -301,6 +301,7 @@ impl WebWorker {
         options.user_agent.clone(),
         options.ca_data.clone(),
         None,
+        None,
       ),
       deno_websocket::init::<Permissions>(
         options.user_agent.clone(),

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -101,6 +101,7 @@ impl MainWorker {
         options.user_agent.clone(),
         options.ca_data.clone(),
         None,
+        None,
       ),
       deno_websocket::init::<Permissions>(
         options.user_agent.clone(),


### PR DESCRIPTION
Add a new option named frozen_headers which
can contain headers that cannot be overriden
by end users.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
