### PR TITLE
fix: flaky worker test

### DIFF
--- a/cli/tests/workers/http_worker.js
+++ b/cli/tests/workers/http_worker.js
@@ -1,5 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
-const listener = Deno.listen({ hostname: "127.0.0.1", port: 4500 });
+const listener = Deno.listen({ hostname: "127.0.0.1", port: 4506 });
 postMessage("ready");
 for await (const conn of listener) {
   (async () => {

--- a/cli/tests/workers/test.ts
+++ b/cli/tests/workers/test.ts
@@ -729,7 +729,7 @@ Deno.test({
     await result;
 
     assert(worker);
-    const response = await fetch("http://localhost:4500");
+    const response = await fetch("http://localhost:4506");
     assert(await response.arrayBuffer());
     worker.terminate();
   },


### PR DESCRIPTION
The test was flaky because it was using port number that a lot of other tests are using as well.