### PR TITLE
chore: fix failing netTcpListenCloseWhileIterating test on some machines

### DIFF
--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -423,7 +423,7 @@ unitTest(
 unitTest(
   { perms: { net: true } },
   async function netTcpListenCloseWhileIterating(): Promise<void> {
-    const listener = Deno.listen({ port: 8000 });
+    const listener = Deno.listen({ port: 8001 });
     const nextWhileClosing = listener[Symbol.asyncIterator]().next();
     listener.close();
     assertEquals(await nextWhileClosing, { value: undefined, done: true });


### PR DESCRIPTION
Was failing every time on my machine because the port was in use. I just bumped it up one port number.