### PR TITLE
fix(lsp): fix parent process checker to not output to stderr before exiting

### DIFF
--- a/cli/lsp/parent_process_checker.rs
+++ b/cli/lsp/parent_process_checker.rs
@@ -12,7 +12,6 @@ pub fn start(parent_process_id: u32) {
       sleep(Duration::from_secs(30)).await;
 
       if !is_process_active(parent_process_id) {
-        eprintln!("Parent process lost. Exiting.");
         std::process::exit(1);
       }
     }


### PR DESCRIPTION
This change causes the parent process checker to actually exit on Mac and it seems some distros of linux.