### PR TITLE
feat(std) support AbortSignal in writeFile

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1714,6 +1714,12 @@ declare namespace Deno {
     create?: boolean;
     /** Permissions always applied to file. */
     mode?: number;
+    /**
+     * An abort signal to allow cancellation of the file write operation.
+     * If the signal becomes aborted the writeFile operation will be stopped
+     * and the promise returned will be rejected with an AbortError.
+     */
+    signal?: AbortSignal;
   }
 
   /** Synchronously write `data` to the given `path`, by default creating a new

--- a/cli/tests/unit/write_file_test.ts
+++ b/cli/tests/unit/write_file_test.ts
@@ -273,7 +273,8 @@ unitTest(
       assertEquals(e.name, "AbortError");
     }
     try {
-      const stat = Deno.statSync(filename);
+      Deno.statSync(filename);
+      throw new Error('should not get here');
     } catch (e) {
       assert(e instanceof Deno.errors.NotFound);
     }

--- a/cli/tests/unit/write_file_test.ts
+++ b/cli/tests/unit/write_file_test.ts
@@ -274,7 +274,7 @@ unitTest(
     }
     try {
       Deno.statSync(filename);
-      throw new Error('should not get here');
+      throw new Error("should not get here");
     } catch (e) {
       assert(e instanceof Deno.errors.NotFound);
     }

--- a/cli/tests/unit/write_file_test.ts
+++ b/cli/tests/unit/write_file_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
-  assert,
   assertEquals,
   assertThrows,
   assertThrowsAsync,

--- a/cli/tests/unit/write_file_test.ts
+++ b/cli/tests/unit/write_file_test.ts
@@ -272,11 +272,7 @@ unitTest(
     } catch (e) {
       assertEquals(e.name, "AbortError");
     }
-    try {
-      Deno.statSync(filename);
-      throw new Error("should not get here");
-    } catch (e) {
-      assert(e instanceof Deno.errors.NotFound);
-    }
+    const stat = Deno.statSync(filename);
+    assertEquals(stat.size, 0);
   },
 );

--- a/runtime/js/40_write_file.js
+++ b/runtime/js/40_write_file.js
@@ -13,6 +13,9 @@
     data,
     options = {},
   ) {
+    if (options?.signal?.aborted) {
+      throw new DOMException("The write operation was aborted.", "AbortError");
+    }
     if (options.create !== undefined) {
       const create = !!options.create;
       if (!create) {
@@ -68,12 +71,17 @@
       await chmod(path, options.mode);
     }
 
+    const signal = options?.signal ?? null;
     let nwritten = 0;
-    while (nwritten < data.length) {
+    while (!signal?.aborted && nwritten < data.length) {
       nwritten += await file.write(TypedArrayPrototypeSubarray(data, nwritten));
     }
 
     file.close();
+
+    if (signal?.aborted) {
+      throw new DOMException("The write operation was aborted.", "AbortError");
+    }
   }
 
   function writeTextFileSync(


### PR DESCRIPTION
Refs #10181 

This continues the work in https://github.com/denoland/deno/pull/10943 and adds AbortSignal support to `writeFile` (and since it uses the same infrastructure `writeTextFile`)

cc @lucacasonato and @ry who reviewed the last one :)