### PR TITLE
feat(core) support AbortSignal in Deno.listen

### DIFF
--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -598,3 +598,20 @@ unitTest(
     listener.close();
   },
 );
+
+unitTest({ perms: { net: true } }, function netTcpListenCloseSignal(): void {
+  const ac = new AbortController();
+  const listener = Deno.listen({
+    hostname: "127.0.0.1",
+    port: 3500,
+    signal: ac.signal,
+  });
+  ac.abort();
+  await assertThrowsAsync(
+    async (): Promise<void> => {
+      await listener.accept();
+    },
+    Deno.errors.BadResource,
+    "Listener has been closed",
+  );
+});

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -599,7 +599,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, function netTcpListenCloseSignal(): void {
+unitTest({ perms: { net: true } }, async function netTcpListenCloseSignal(): void {
   const ac = new AbortController();
   const listener = Deno.listen({
     hostname: "127.0.0.1",

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -608,10 +608,11 @@ unitTest(
       port: 3500,
       signal: ac.signal,
     });
+    const p = listener.accept();
     ac.abort();
     await assertThrowsAsync(
       async (): Promise<void> => {
-        await listener.accept();
+        await p;
       },
       Deno.errors.BadResource,
       "Listener has been closed",

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -599,19 +599,22 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, async function netTcpListenCloseSignal(): void {
-  const ac = new AbortController();
-  const listener = Deno.listen({
-    hostname: "127.0.0.1",
-    port: 3500,
-    signal: ac.signal,
-  });
-  ac.abort();
-  await assertThrowsAsync(
-    async (): Promise<void> => {
-      await listener.accept();
-    },
-    Deno.errors.BadResource,
-    "Listener has been closed",
-  );
-});
+unitTest(
+  { perms: { net: true } },
+  async function netTcpListenCloseSignal(): void {
+    const ac = new AbortController();
+    const listener = Deno.listen({
+      hostname: "127.0.0.1",
+      port: 3500,
+      signal: ac.signal,
+    });
+    ac.abort();
+    await assertThrowsAsync(
+      async (): Promise<void> => {
+        await listener.accept();
+      },
+      Deno.errors.BadResource,
+      "Listener has been closed",
+    );
+  },
+);

--- a/extensions/net/01_net.js
+++ b/extensions/net/01_net.js
@@ -207,7 +207,16 @@
       ...options,
     });
 
-    return new Listener(res.rid, res.localAddr);
+    const listener = new Listener(res.rid, res.localAddr);
+    if (options?.signal) {
+      // TODO(benjamingr) there is memory leak potential here if the signal outlives the
+      // server significantly it can retain it. Ideally Deno would have internal weak
+      // event listener like Node does *or* it would have an event for the server closing.
+      options?.signal?.addEventListener("abort", () => listener.close(), {
+        once: true,
+      });
+    }
+    return listener;
   }
 
   async function connect(options) {

--- a/extensions/net/02_tls.js
+++ b/extensions/net/02_tls.js
@@ -52,6 +52,7 @@
     hostname = "0.0.0.0",
     transport = "tcp",
     alpnProtocols,
+    signal,
   }) {
     const res = opListenTls({
       port,
@@ -60,12 +61,11 @@
       hostname,
       transport,
       alpnProtocols,
-      signal,
     });
     const listener = new TLSListener(res.rid, res.localAddr);
     if (signal) {
       // TODO(benjamingr) there is memory leak potential here. See comment in 01_net.js
-      options?.signal?.addEventListener("abort", () => listener.close(), {
+      signal.addEventListener("abort", () => listener.close(), {
         once: true,
       });
     }

--- a/extensions/net/02_tls.js
+++ b/extensions/net/02_tls.js
@@ -60,8 +60,16 @@
       hostname,
       transport,
       alpnProtocols,
+      signal,
     });
-    return new TLSListener(res.rid, res.localAddr);
+    const listener = new TLSListener(res.rid, res.localAddr);
+    if (signal) {
+      // TODO(benjamingr) there is memory leak potential here. See comment in 01_net.js
+      options?.signal?.addEventListener("abort", () => listener.close(), {
+        once: true,
+      });
+    }
+    return listener;
   }
 
   async function startTls(

--- a/extensions/net/lib.deno_net.d.ts
+++ b/extensions/net/lib.deno_net.d.ts
@@ -51,6 +51,8 @@ declare namespace Deno {
     /** A literal IP address or host name that can be resolved to an IP address.
    * If not specified, defaults to `0.0.0.0`. */
     hostname?: string;
+    // Allows closing the server by aborting the associated AbortController
+    signal?: AbortSignal;
   }
 
   /** Listen announces on the local transport address.


### PR DESCRIPTION
Refs #10181

This continues the work in #10943 and #11568 adds AbortSignal support to Deno.listen (and since it uses the same infrastructure writeTextFile)

There shouldn't be a `DOMException` here for AbortError looking at the guidance at WHATWG (the guidance is about the signature and errors of methods returning promises which isn't really the case here). I opted to do the same thing we did for Node.js

In all likelihood there _should_ be weak event listeners (internal) in Deno core but that's a bigger refactor and honestly the event_target implementation is kind of a mess.
