### PR TITLE
chore: surface import map JSON parse error to user

### DIFF
--- a/cli/import_map.rs
+++ b/cli/import_map.rs
@@ -65,10 +65,11 @@ impl ImportMap {
   ) -> Result<Self, ImportMapError> {
     let v: Value = match serde_json::from_str(json_string) {
       Ok(v) => v,
-      Err(_) => {
-        return Err(ImportMapError::Other(
-          "Unable to parse import map JSON".to_string(),
-        ));
+      Err(err) => {
+        return Err(ImportMapError::Other(format!(
+          "Unable to parse import map JSON: {}",
+          err.to_string()
+        )));
       }
     };
 
@@ -741,6 +742,14 @@ mod tests {
     for non_object in non_object_strings.to_vec() {
       assert!(ImportMap::from_json(base_url, non_object).is_err());
     }
+
+    // invalid JSON message test
+    assert_eq!(
+      ImportMap::from_json(base_url, "{\"a\":1,}")
+        .unwrap_err()
+        .to_string(),
+      "Unable to parse import map JSON: trailing comma at line 1 column 8",
+    );
 
     // invalid schema: 'imports' is non-object
     for non_object in non_object_strings.to_vec() {

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -228,7 +228,7 @@ fn op_isatty(
       {
         use winapi::um::consoleapi;
 
-        let handle = get_windows_handle(&std_file)?;
+        let handle = get_windows_handle(std_file)?;
         let mut test_mode: DWORD = 0;
         // If I cannot get mode out of console, it is not a console.
         Ok(unsafe { consoleapi::GetConsoleMode(handle, &mut test_mode) != 0 })


### PR DESCRIPTION
I wrote an import map with a trailing comma and spent too long trying to figure out what was wrong. Would be better if the CLI told me what was wrong.