### PR TITLE
feat(runtime): allow URL for permissions

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2149,7 +2149,7 @@ declare namespace Deno {
      *      "github.com"
      *      "deno.land:8080"
      */
-    host?: string;
+    host?: string | URL;
   }
 
   export interface EnvPermissionDescriptor {

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2129,17 +2129,17 @@ declare namespace Deno {
 
   export interface RunPermissionDescriptor {
     name: "run";
-    command?: string;
+    command?: string | URL;
   }
 
   export interface ReadPermissionDescriptor {
     name: "read";
-    path?: string;
+    path?: string | URL;
   }
 
   export interface WritePermissionDescriptor {
     name: "write";
-    path?: string;
+    path?: string | URL;
   }
 
   export interface NetPermissionDescriptor {

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1033,7 +1033,7 @@ declare namespace Deno {
       * });
       * ```
       */
-      net?: "inherit" | boolean | string[];
+      net?: "inherit" | boolean | Array<string | URL>;
 
       /** Specifies if the `plugin` permission should be requested or revoked.
       * If set to `"inherit"`, the current `plugin` permission will be inherited.
@@ -1121,17 +1121,17 @@ declare interface WorkerOptions {
     namespace?: boolean;
     /** Set to `"none"` to disable all the permissions in the worker. */
     permissions?: "inherit" | "none" | {
-      env?: "inherit" | boolean;
+      env?: "inherit" | boolean | string[];
       hrtime?: "inherit" | boolean;
       /** The format of the net access list must be `hostname[:port]`
        * in order to be resolved.
        *
        * For example: `["https://deno.land", "localhost:8080"]`.
        */
-      net?: "inherit" | boolean | string[];
+      net?: "inherit" | boolean | Array<string | URL>;
       plugin?: "inherit" | boolean;
       read?: "inherit" | boolean | Array<string | URL>;
-      run?: "inherit" | boolean;
+      run?: "inherit" | boolean | Array<string | URL>;
       write?: "inherit" | boolean | Array<string | URL>;
     };
   };

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -951,7 +951,7 @@ declare namespace Deno {
       *
       * Defaults to "inherit".
       */
-      env?: "inherit" | boolean;
+      env?: "inherit" | boolean | string[];
 
       /** Specifies if the `hrtime` permission should be requested or revoked.
       * If set to `"inherit"`, the current `hrtime` permission will be inherited.
@@ -1062,7 +1062,7 @@ declare namespace Deno {
       *
       * Defaults to "inherit".
       */
-      run?: "inherit" | boolean;
+      run?: "inherit" | boolean | Array<string | URL>;
 
       /** Specifies if the `write` permission should be requested or revoked.
       * If set to `"inherit"`, the current `write` permission will be inherited.

--- a/cli/tests/unit/permissions_test.ts
+++ b/cli/tests/unit/permissions_test.ts
@@ -57,3 +57,22 @@ unitTest(function permissionStatusIllegalConstructor() {
   );
   assertEquals(Deno.PermissionStatus.length, 0);
 });
+
+unitTest(async function permissionURL() {
+  await Deno.permissions.query({
+    name: "read",
+    path: new URL(".", import.meta.url),
+  });
+  await Deno.permissions.query({
+    name: "write",
+    path: new URL(".", import.meta.url),
+  });
+  await Deno.permissions.query({
+    name: "run",
+    command: new URL(".", import.meta.url),
+  });
+  await Deno.permissions.query({
+    name: "net",
+    host: new URL("https://deno.land/foo"),
+  });
+});

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -93,7 +93,16 @@
     } else if (ArrayIsArray(value)) {
       value = ArrayPrototypeMap(value, (route) => {
         if (route instanceof URL) {
-          route = pathFromURL(route);
+          if (permission === "net") {
+            route = route.host;
+          }
+          if (permission === "env") {
+            throw new Error(
+              `Expected 'string' for env permission, received 'URL'`,
+            );
+          } else {
+            route = pathFromURL(route);
+          }
         }
         return route;
       });
@@ -115,12 +124,12 @@
     write = "inherit",
   }) {
     return {
-      env: parseUnitPermission(env, "env"),
+      env: parseArrayPermission(env, "env"),
       hrtime: parseUnitPermission(hrtime, "hrtime"),
       net: parseArrayPermission(net, "net"),
       plugin: parseUnitPermission(plugin, "plugin"),
       read: parseArrayPermission(read, "read"),
-      run: parseUnitPermission(run, "run"),
+      run: parseArrayPermission(run, "run"),
       write: parseArrayPermission(write, "write"),
     };
   }

--- a/runtime/js/40_permissions.js
+++ b/runtime/js/40_permissions.js
@@ -8,6 +8,7 @@
     Deno: { core },
     __bootstrap: { webUtil: { illegalConstructorKey } },
   } = window;
+  const { pathFromURL } = window.__bootstrap.util;
   const {
     ArrayPrototypeIncludes,
     Map,
@@ -161,6 +162,13 @@
           ),
         );
       }
+
+      if (desc.name === "read" || desc.name === "write") {
+        desc.path = pathFromURL(desc.path);
+      } else if (desc.name === "run") {
+        desc.command = pathFromURL(desc.command);
+      }
+
       const state = opQuery(desc);
       return PromiseResolve(cache(desc, state));
     }
@@ -173,6 +181,13 @@
           ),
         );
       }
+
+      if (desc.name === "read" || desc.name === "write") {
+        desc.path = pathFromURL(desc.path);
+      } else if (desc.name === "run") {
+        desc.command = pathFromURL(desc.command);
+      }
+
       const state = opRevoke(desc);
       return PromiseResolve(cache(desc, state));
     }
@@ -185,6 +200,13 @@
           ),
         );
       }
+
+      if (desc.name === "read" || desc.name === "write") {
+        desc.path = pathFromURL(desc.path);
+      } else if (desc.name === "run") {
+        desc.command = pathFromURL(desc.command);
+      }
+
       const state = opRequest(desc);
       return PromiseResolve(cache(desc, state));
     }

--- a/runtime/js/40_permissions.js
+++ b/runtime/js/40_permissions.js
@@ -167,6 +167,10 @@
         desc.path = pathFromURL(desc.path);
       } else if (desc.name === "run") {
         desc.command = pathFromURL(desc.command);
+      } else if (desc.name === "net") {
+        if (desc.host instanceof URL) {
+          desc.host = desc.host.host;
+        }
       }
 
       const state = opQuery(desc);
@@ -186,6 +190,10 @@
         desc.path = pathFromURL(desc.path);
       } else if (desc.name === "run") {
         desc.command = pathFromURL(desc.command);
+      } else if (desc.name === "net") {
+        if (desc.host instanceof URL) {
+          desc.host = desc.host.host;
+        }
       }
 
       const state = opRevoke(desc);
@@ -205,6 +213,10 @@
         desc.path = pathFromURL(desc.path);
       } else if (desc.name === "run") {
         desc.command = pathFromURL(desc.command);
+      } else if (desc.name === "net") {
+        if (desc.host instanceof URL) {
+          desc.host = desc.host.host;
+        }
       }
 
       const state = opRequest(desc);


### PR DESCRIPTION
Closes #11036
not only for `Deno.permissions`, but worker & test permissions as well.