### PR TITLE
feat(process) support AbortSignal in run

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2020,6 +2020,11 @@ declare namespace Deno {
     stdout?: "inherit" | "piped" | "null" | number;
     stderr?: "inherit" | "piped" | "null" | number;
     stdin?: "inherit" | "piped" | "null" | number;
+    /**
+     * An AbortSignal that allows closing the process using the corresponding
+     * AbortController by sending the process a SIGTERM signal.
+     */
+    signal?: AbortSignal;
   }
 
   /** Spawns new subprocess.  RunOptions must contain at a minimum the `opt.cmd`,

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -510,3 +510,23 @@ unitTest({ perms: { run: true, read: true } }, function killFailed(): void {
 
   p.close();
 });
+
+unitTest(
+  { perms: { run: true, read: true } },
+  async function runAbortSignal(): Promise<void> {
+    const ac = new AbortController();
+    const p = Deno.run({
+      cmd: [
+        Deno.execPath(),
+        "eval",
+        "setTimeout(console.log, 1e8)",
+      ],
+      signal: ac.signal,
+    });
+    queueMicrotask(() => ac.abort());
+    const status = await p.status();
+    assertEquals(status.success, false);
+    assertEquals(status.code, 143);
+    assertEquals(status.signal, "SIGTERM");
+  },
+);

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -528,5 +528,6 @@ unitTest(
     assertEquals(status.success, false);
     assertEquals(status.code, 143);
     assertEquals(status.signal, Deno.Signal.SIGTERM);
+    p.close();
   },
 );

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -527,6 +527,6 @@ unitTest(
     const status = await p.status();
     assertEquals(status.success, false);
     assertEquals(status.code, 143);
-    assertEquals(status.signal, "SIGTERM");
+    assertEquals(status.signal, Deno.Signal.SIGTERM);
   },
 );

--- a/runtime/js/40_process.js
+++ b/runtime/js/40_process.js
@@ -104,6 +104,7 @@
     stdout = "inherit",
     stderr = "inherit",
     stdin = "inherit",
+    signal,
   }) {
     if (cmd[0] != null) {
       cmd[0] = pathFromURL(cmd[0]);
@@ -119,7 +120,17 @@
       stdoutRid: isRid(stdout) ? stdout : 0,
       stderrRid: isRid(stderr) ? stderr : 0,
     });
-    return new Process(res);
+    const p = new Process(res);
+    if (signal) {
+      const stopper = () => {
+        p.kill(Deno.Signal.SIGTERM);
+      };
+      signal.addEventListener("abort", stopper);
+      p.status().then(() => {
+        signal.removeEventListener("abort", stopper);
+      });
+    }
+    return p;
   }
 
   window.__bootstrap.process = {


### PR DESCRIPTION
Support AbortSignal in `Deno.run`

This continues the work in #10943 and adds AbortSignal support to `Deno.run`. Closes #11574

cc @lucacasonato @bartlomieju 