### PR TITLE
chore: refactor `netHangsOnClose` test to not use `deferred`

### DIFF
--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -573,7 +573,7 @@ unitTest(
 
     const addr = { hostname: "127.0.0.1", port: 3500 };
     const listener = Deno.listen(addr);
-    const listnerPromise = iteratorReq(listener);
+    const listenerPromise = iteratorReq(listener);
     const connectionPromise = (async () => {
       const conn = await Deno.connect(addr);
       await conn.write(new Uint8Array([1, 2, 3, 4]));
@@ -585,7 +585,7 @@ unitTest(
     })();
 
     await Promise.all([
-      listnerPromise,
+      listenerPromise,
       connectionPromise,
     ]);
   },

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -551,7 +551,6 @@ unitTest(
   },
   async function netHangsOnClose() {
     let acceptedConn: Deno.Conn;
-    const resolvable = deferred();
 
     async function iteratorReq(listener: Deno.Listener): Promise<void> {
       const p = new Uint8Array(10);
@@ -570,21 +569,25 @@ unitTest(
         assert(!!err);
         assert(err instanceof Deno.errors.BadResource);
       }
-
-      resolvable.resolve();
     }
 
     const addr = { hostname: "127.0.0.1", port: 3500 };
     const listener = Deno.listen(addr);
-    iteratorReq(listener);
-    const conn = await Deno.connect(addr);
-    await conn.write(new Uint8Array([1, 2, 3, 4]));
-    const buf = new Uint8Array(10);
-    await conn.read(buf);
-    conn!.close();
-    acceptedConn!.close();
-    listener.close();
-    await resolvable;
+    const listnerPromise = iteratorReq(listener);
+    const connectionPromise = (async () => {
+      const conn = await Deno.connect(addr);
+      await conn.write(new Uint8Array([1, 2, 3, 4]));
+      const buf = new Uint8Array(10);
+      await conn.read(buf);
+      conn!.close();
+      acceptedConn!.close();
+      listener.close();
+    })();
+
+    await Promise.all([
+      listnerPromise,
+      connectionPromise,
+    ]);
   },
 );
 


### PR DESCRIPTION
This does not solve #11580, but it makes it so that when an assertion fails it will not happen in an unawaited promise.