### PR TITLE
feat(repl): add --eval flag for evaluating code when the repl starts

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -91,7 +91,9 @@ pub enum DenoSubcommand {
     rules: bool,
     json: bool,
   },
-  Repl,
+  Repl {
+    eval: Option<String>,
+  },
   Run {
     script: String,
   },
@@ -119,7 +121,7 @@ pub enum DenoSubcommand {
 
 impl Default for DenoSubcommand {
   fn default() -> DenoSubcommand {
-    DenoSubcommand::Repl
+    DenoSubcommand::Repl { eval: None }
   }
 }
 
@@ -948,6 +950,13 @@ Ignore linting a file by adding an ignore comment at the top of the file:
 fn repl_subcommand<'a, 'b>() -> App<'a, 'b> {
   runtime_args(SubCommand::with_name("repl"), false, true)
     .about("Read Eval Print Loop")
+    .arg(
+      Arg::with_name("eval")
+        .long("eval")
+        .help("Evaluates the provided code when the REPL starts.")
+        .takes_value(true)
+        .value_name("code"),
+    )
 }
 
 fn run_subcommand<'a, 'b>() -> App<'a, 'b> {
@@ -1690,7 +1699,9 @@ fn lint_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 fn repl_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   runtime_args_parse(flags, matches, false, true);
   flags.repl = true;
-  flags.subcommand = DenoSubcommand::Repl;
+  flags.subcommand = DenoSubcommand::Repl {
+    eval: matches.value_of("eval").map(ToOwned::to_owned),
+  };
   flags.allow_net = Some(vec![]);
   flags.allow_env = Some(vec![]);
   flags.allow_run = Some(vec![]);
@@ -2692,7 +2703,7 @@ mod tests {
       r.unwrap(),
       Flags {
         repl: true,
-        subcommand: DenoSubcommand::Repl,
+        subcommand: DenoSubcommand::Repl { eval: None },
         allow_net: Some(vec![]),
         allow_env: Some(vec![]),
         allow_run: Some(vec![]),
@@ -2713,7 +2724,7 @@ mod tests {
       r.unwrap(),
       Flags {
         repl: true,
-        subcommand: DenoSubcommand::Repl,
+        subcommand: DenoSubcommand::Repl { eval: None },
         import_map_path: Some("import_map.json".to_string()),
         no_remote: true,
         config_path: Some("tsconfig.json".to_string()),
@@ -2727,6 +2738,29 @@ mod tests {
         v8_flags: svec!["--help", "--random-seed=1"],
         seed: Some(1),
         inspect: Some("127.0.0.1:9229".parse().unwrap()),
+        allow_net: Some(vec![]),
+        allow_env: Some(vec![]),
+        allow_run: Some(vec![]),
+        allow_read: Some(vec![]),
+        allow_write: Some(vec![]),
+        allow_plugin: true,
+        allow_hrtime: true,
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn repl_with_eval_flag() {
+    #[rustfmt::skip]
+    let r = flags_from_vec(svec!["deno", "repl", "--eval", "console.log('hello');"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        repl: true,
+        subcommand: DenoSubcommand::Repl {
+          eval: Some("console.log('hello');".to_string()),
+        },
         allow_net: Some(vec![]),
         allow_env: Some(vec![]),
         allow_run: Some(vec![]),

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -774,7 +774,10 @@ async fn format_command(
   Ok(())
 }
 
-async fn run_repl(flags: Flags) -> Result<(), AnyError> {
+async fn run_repl(
+  flags: Flags,
+  maybe_eval: Option<String>,
+) -> Result<(), AnyError> {
   let main_module = resolve_url_or_path("./$deno$repl.ts").unwrap();
   let permissions = Permissions::from_options(&flags.clone().into());
   let program_state = ProgramState::build(flags).await?;
@@ -782,7 +785,7 @@ async fn run_repl(flags: Flags) -> Result<(), AnyError> {
     create_main_worker(&program_state, main_module.clone(), permissions, false);
   worker.run_event_loop(false).await?;
 
-  tools::repl::run(&program_state, worker).await
+  tools::repl::run(&program_state, worker, maybe_eval).await
 }
 
 async fn run_from_stdin(flags: Flags) -> Result<(), AnyError> {
@@ -1341,7 +1344,7 @@ fn get_subcommand(
       ignore,
       json,
     } => lint_command(flags, files, rules, ignore, json).boxed_local(),
-    DenoSubcommand::Repl => run_repl(flags).boxed_local(),
+    DenoSubcommand::Repl { eval } => run_repl(flags, eval).boxed_local(),
     DenoSubcommand::Run { script } => run_command(flags, script).boxed_local(),
     DenoSubcommand::Test {
       no_run,

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1143,9 +1143,25 @@ pub fn run_and_collect_output(
   envs: Option<Vec<(String, String)>>,
   need_http_server: bool,
 ) -> (String, String) {
+  run_and_collect_output_with_args(
+    expect_success,
+    args.split_whitespace().collect(),
+    input,
+    envs,
+    need_http_server,
+  )
+}
+
+pub fn run_and_collect_output_with_args(
+  expect_success: bool,
+  args: Vec<&str>,
+  input: Option<Vec<&str>>,
+  envs: Option<Vec<(String, String)>>,
+  need_http_server: bool,
+) -> (String, String) {
   let mut deno_process_builder = deno_cmd();
   deno_process_builder
-    .args(args.split_whitespace())
+    .args(args)
     .current_dir(&tests_path())
     .stdin(Stdio::piped())
     .stdout(Stdio::piped())


### PR DESCRIPTION
Closes #3173

At the moment, this only adds support for an `--eval <code>` flag to provide some code to execute on startup.

For example:

```bash
deno repl --eval 'import * as hash from "https://deno.land/std@0.77.0/hash#stdhash"'
```

1. On success, the result of running the script will not be outputted, but still assigned to _.
2. On thrown error, the error will be displayed to the user and assigned to _error (unless it's a parse error). The REPL will not fail to start in order to not block the user allowing them to ignore any setup errors and just use the REPL.

We will consider adding support for URL and file paths in the future, but for now this is a first step.