### PR TITLE
feat(repl): strip exports in the REPL

### DIFF
--- a/cli/ast/mod.rs
+++ b/cli/ast/mod.rs
@@ -314,6 +314,7 @@ impl ParsedModule {
     let mut passes = chain!(
       Optional::new(jsx_pass, options.transform_jsx),
       Optional::new(transforms::DownlevelImportsFolder, options.repl_imports),
+      Optional::new(transforms::StripExportsFolder, options.repl_imports),
       proposals::decorators::decorators(proposals::decorators::Config {
         legacy: true,
         emit_metadata: options.emit_metadata

--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -423,6 +423,19 @@ fn import_declarations() {
 }
 
 #[test]
+fn exports_stripped() {
+  let (out, err) = util::run_and_collect_output(
+    true,
+    "repl",
+    Some(vec!["export default 5;", "export class Test {}"]),
+    Some(vec![("NO_COLOR".to_owned(), "1".to_owned())]),
+    false,
+  );
+  assert!(out.contains("5\n"));
+  assert!(err.is_empty());
+}
+
+#[test]
 fn eval_unterminated() {
   let (out, err) = util::run_and_collect_output(
     true,


### PR DESCRIPTION
Just thought about this a bit more and I think it's useful. It does the following transforms in the REPL:

```ts
export class Test {}
----
class Test {}
```

```ts
export default class Test {}
----
class Test {}
```

```ts
export default class {}
----
;
```

```ts
export default 5;
----
5;
```

```ts
export * from "./test.ts";
----
await import("./test.ts");
```

```ts
export { test } from "./test.ts";
----
await import("./test.ts");
```

```ts
export { test };
----
;
```

This will help with usability and allow people to more easily copy and paste code into the repl.