### PR TITLE
revert: allow URL for permissions

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2159,7 +2159,7 @@ declare namespace Deno {
      *      "github.com"
      *      "deno.land:8080"
      */
-    host?: string | URL;
+    host?: string;
   }
 
   export interface EnvPermissionDescriptor {

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1041,7 +1041,7 @@ declare namespace Deno {
       * });
       * ```
       */
-      net?: "inherit" | boolean | Array<string | URL>;
+      net?: "inherit" | boolean | string[];
 
       /** Specifies if the `plugin` permission should be requested or revoked.
       * If set to `"inherit"`, the current `plugin` permission will be inherited.
@@ -1136,7 +1136,7 @@ declare interface WorkerOptions {
        *
        * For example: `["https://deno.land", "localhost:8080"]`.
        */
-      net?: "inherit" | boolean | Array<string | URL>;
+      net?: "inherit" | boolean | string[];
       plugin?: "inherit" | boolean;
       read?: "inherit" | boolean | Array<string | URL>;
       run?: "inherit" | boolean | Array<string | URL>;

--- a/cli/tests/unit/permissions_test.ts
+++ b/cli/tests/unit/permissions_test.ts
@@ -71,8 +71,4 @@ unitTest(async function permissionURL() {
     name: "run",
     command: new URL(".", import.meta.url),
   });
-  await Deno.permissions.query({
-    name: "net",
-    host: new URL("https://deno.land/foo"),
-  });
 });

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+  // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 "use strict";
 
 ((window) => {
@@ -93,9 +93,6 @@
     } else if (ArrayIsArray(value)) {
       value = ArrayPrototypeMap(value, (route) => {
         if (route instanceof URL) {
-          if (permission === "net") {
-            route = route.host;
-          }
           if (permission === "env") {
             throw new Error(
               `Expected 'string' for env permission, received 'URL'`,
@@ -124,12 +121,12 @@
     write = "inherit",
   }) {
     return {
-      env: parseArrayPermission(env, "env"),
+      env: parseUnitPermission(env, "env"),
       hrtime: parseUnitPermission(hrtime, "hrtime"),
       net: parseArrayPermission(net, "net"),
       plugin: parseUnitPermission(plugin, "plugin"),
       read: parseArrayPermission(read, "read"),
-      run: parseArrayPermission(run, "run"),
+      run: parseUnitPermission(run, "run"),
       write: parseArrayPermission(write, "write"),
     };
   }

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -1,4 +1,4 @@
-  // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 "use strict";
 
 ((window) => {

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -93,7 +93,11 @@
     } else if (ArrayIsArray(value)) {
       value = ArrayPrototypeMap(value, (route) => {
         if (route instanceof URL) {
-          if (permission === "env") {
+          if (permission === "net") {
+            throw new Error(
+              `Expected 'string' for net permission, received 'URL'`,
+            );
+          } else if (permission === "env") {
             throw new Error(
               `Expected 'string' for env permission, received 'URL'`,
             );

--- a/runtime/js/40_permissions.js
+++ b/runtime/js/40_permissions.js
@@ -167,10 +167,6 @@
         desc.path = pathFromURL(desc.path);
       } else if (desc.name === "run") {
         desc.command = pathFromURL(desc.command);
-      } else if (desc.name === "net") {
-        if (desc.host instanceof URL) {
-          desc.host = desc.host.host;
-        }
       }
 
       const state = opQuery(desc);
@@ -190,10 +186,6 @@
         desc.path = pathFromURL(desc.path);
       } else if (desc.name === "run") {
         desc.command = pathFromURL(desc.command);
-      } else if (desc.name === "net") {
-        if (desc.host instanceof URL) {
-          desc.host = desc.host.host;
-        }
       }
 
       const state = opRevoke(desc);
@@ -213,10 +205,6 @@
         desc.path = pathFromURL(desc.path);
       } else if (desc.name === "run") {
         desc.command = pathFromURL(desc.command);
-      } else if (desc.name === "net") {
-        if (desc.host instanceof URL) {
-          desc.host = desc.host.host;
-        }
       }
 
       const state = opRequest(desc);


### PR DESCRIPTION
Revert changes to "net" permissions in regards to handling URLs.

Introduced in https://github.com/denoland/deno/pull/11578

Reverting due to @lucacasonato comment: https://github.com/denoland/deno/pull/11578#issuecomment-894315667