### PR TITLE
chore: fix repl_with_eval_flag test

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -2780,7 +2780,7 @@ mod tests {
         allow_run: Some(vec![]),
         allow_read: Some(vec![]),
         allow_write: Some(vec![]),
-        allow_plugin: true,
+        allow_ffi: Some(vec![]),
         allow_hrtime: true,
         ..Flags::default()
       }


### PR DESCRIPTION
Fixes main. Occurred because merges happened one after the other after both CIs had run.