### PR TITLE
fix: correct spelling of certificate in `--unsafely-ignore-certificate-errors` warning message

### DIFF
--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -127,7 +127,7 @@ impl ProgramState {
         format!("for: {}", insecure_allowlist.join(", "))
       };
       let msg = format!(
-        "DANGER: TLS ceritificate validation is disabled {}",
+        "DANGER: TLS certificate validation is disabled {}",
         domains
       );
       eprintln!("{}", colors::yellow(msg));

--- a/cli/program_state.rs
+++ b/cli/program_state.rs
@@ -126,10 +126,8 @@ impl ProgramState {
       } else {
         format!("for: {}", insecure_allowlist.join(", "))
       };
-      let msg = format!(
-        "DANGER: TLS certificate validation is disabled {}",
-        domains
-      );
+      let msg =
+        format!("DANGER: TLS certificate validation is disabled {}", domains);
       eprintln!("{}", colors::yellow(msg));
     }
 

--- a/cli/tests/cafile_ts_fetch_unsafe_ssl.ts.out
+++ b/cli/tests/cafile_ts_fetch_unsafe_ssl.ts.out
@@ -1,2 +1,2 @@
-DANGER: TLS ceritificate validation is disabled for all hostnames
+DANGER: TLS certificate validation is disabled for all hostnames
 Hello

--- a/cli/tests/cafile_url_imports_unsafe_ssl.ts.out
+++ b/cli/tests/cafile_url_imports_unsafe_ssl.ts.out
@@ -1,3 +1,3 @@
-DANGER: TLS ceritificate validation is disabled for: localhost
+DANGER: TLS certificate validation is disabled for: localhost
 Hello
 success

--- a/cli/tests/deno_land_unsafe_ssl.ts.out
+++ b/cli/tests/deno_land_unsafe_ssl.ts.out
@@ -1,2 +1,2 @@
-DANGER: TLS ceritificate validation is disabled for: deno.land
+DANGER: TLS certificate validation is disabled for: deno.land
 200

--- a/cli/tests/localhost_unsafe_ssl.ts.out
+++ b/cli/tests/localhost_unsafe_ssl.ts.out
@@ -1,3 +1,3 @@
-DANGER: TLS ceritificate validation is disabled for: deno.land
+DANGER: TLS certificate validation is disabled for: deno.land
 error: error sending request for url (https://localhost:5545/cli/tests/subdir/mod2.ts): error trying to connect: invalid certificate: UnknownIssuer
     at [WILDCARD]tests/cafile_url_imports.ts:1:0


### PR DESCRIPTION
Fixes the spelling of "certificate" in the warning message.