### PR TITLE
feat: allow running on 32 bits 

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -160,8 +160,12 @@ pub async fn write_standalone_binary(
     let mut output_file = File::open(&output)?;
     // This seek may fail because the file is too small to possibly be
     // `deno compile` output.
-    if output_file.seek(SeekFrom::End(-24)).is_ok() {
-      let mut trailer = [0; 24];
+    let pointer_size = std::mem::size_of::<usize>();
+    if output_file
+      .seek(SeekFrom::End(-((8 + pointer_size * 2) as i64)))
+      .is_ok()
+    {
+      let mut trailer = vec![0; 8 + pointer_size * 2];
       output_file.read_exact(&mut trailer)?;
       let (magic_trailer, _) = trailer.split_at(8);
       has_trailer = magic_trailer == MAGIC_TRAILER;


### PR DESCRIPTION
I find current rusty_v8 is able to compile in 32bits. It would be good to add supports in 32 bit.
Only tested in Windows currently.

For reference:
https://github.com/denoland/rusty_v8/issues/426#issuecomment-678696428

---
AaronO leaves a good review on the direction of this pull request.
https://github.com/denoland/serde_v8/pull/16#pullrequestreview-728458540

We need more platform tests on this issue if we want to release in 32 bits. If not, it should be okay to provide a way compiling to 32 bits also.
Currently tested in my Windows desktop and Linux VM.