### PR TITLE
fix(lint): add links to help at lint.deno.land

### DIFF
--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -127,7 +127,7 @@ pub fn print_rules_list(json: bool) {
     println!("Available rules:");
     for rule in lint_rules {
       println!(" - {}", rule.code());
-      println!("   https://lint.deno.land/#{}", rule.code());
+      println!("   help: https://lint.deno.land/#{}", rule.code());
       println!();
     }
   }

--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -127,6 +127,8 @@ pub fn print_rules_list(json: bool) {
     println!("Available rules:");
     for rule in lint_rules {
       println!(" - {}", rule.code());
+      println!("   https://lint.deno.land/#{}", rule.code());
+      println!();
     }
   }
 }
@@ -231,6 +233,7 @@ impl LintReporter for PrettyLintReporter {
       format!("({}) {}", colors::gray(&d.code), d.message.clone());
 
     let message = format_diagnostic(
+      &d.code,
       &pretty_message,
       &source_lines,
       d.range.clone(),
@@ -266,6 +269,7 @@ impl LintReporter for PrettyLintReporter {
 }
 
 pub fn format_diagnostic(
+  diagnostic_code: &str,
   message_line: &str,
   source_lines: &[&str],
   range: deno_lint::diagnostic::Range,
@@ -300,19 +304,23 @@ pub fn format_diagnostic(
 
   if let Some(hint) = maybe_hint {
     format!(
-      "{}\n{}\n    at {}\n\n    {} {}",
+      "{}\n{}\n    at {}\n\n    {} {}\n    {} for further information visit https://lint.deno.land/#{}",
       message_line,
       lines.join("\n"),
       formatted_location,
       colors::gray("hint:"),
       hint,
+      colors::gray("help:"),
+      diagnostic_code,
     )
   } else {
     format!(
-      "{}\n{}\n    at {}",
+      "{}\n{}\n    at {}\n\n    {} for further information visit https://lint.deno.land/#{}",
       message_line,
       lines.join("\n"),
-      formatted_location
+      formatted_location,
+      colors::gray("help:"),
+      diagnostic_code,
     )
   }
 }


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/8227

Before:
```
$ deno lint --rules
Available rules:
 - adjacent-overload-signatures
 - ban-ts-comment
 - ban-types
...
```

After:
```
Available rules:
 - adjacent-overload-signatures
   help: https://lint.deno.land/#adjacent-overload-signatures

 - ban-ts-comment
   help: https://lint.deno.land/#ban-ts-comment

 - ban-types
   help: https://lint.deno.land/#ban-types

 - ban-unknown-rule-code
   help: https://lint.deno.land/#ban-unknown-rule-code
...
```

Before:
```
(adjacent-overload-signatures) All `foo` signatures should be adjacent
  foo(sn: string | number): void;
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    at /Users/biwanczuk/dev/deno/foo.ts:5:2

    hint: Make sure all overloaded signatures are grouped together

Found 1 problem
Checked 1 file
```

After:
```
(adjacent-overload-signatures) All `foo` signatures should be adjacent
  foo(sn: string | number): void;
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    at /Users/biwanczuk/dev/deno/foo.ts:5:2

    hint: Make sure all overloaded signatures are grouped together
    help: for further information visit https://lint.deno.land/#adjacent-overload-signatures

Found 1 problem
Checked 1 file

```

CC @magurotuna 