### PR TITLE
test: re-enable test watch tests and mark as flaky

### DIFF
--- a/cli/tests/integration/watcher_tests.rs
+++ b/cli/tests/integration/watcher_tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+use flaky_test::flaky_test;
 use std::io::BufRead;
 use tempfile::TempDir;
 use test_util as util;
@@ -427,9 +428,7 @@ fn run_watch_with_import_map_and_relative_paths() {
   temp_directory.close().unwrap();
 }
 
-// TODO(bartlomieju): flaky (https://github.com/denoland/deno/issues/10552)
-#[ignore]
-#[test]
+#[flaky_test]
 fn test_watch() {
   macro_rules! assert_contains {
         ($string:expr, $($test:expr),+) => {
@@ -596,9 +595,7 @@ fn test_watch() {
   drop(t);
 }
 
-// TODO(bartlomieju): flaky (https://github.com/denoland/deno/issues/10552)
-#[ignore]
-#[test]
+#[flaky_test]
 fn test_watch_doc() {
   macro_rules! assert_contains {
         ($string:expr, $($test:expr),+) => {

--- a/cli/tests/integration/watcher_tests.rs
+++ b/cli/tests/integration/watcher_tests.rs
@@ -461,9 +461,10 @@ fn test_watch() {
   let mut stderr_lines =
     std::io::BufReader::new(stderr).lines().map(|r| r.unwrap());
 
+  assert_eq!(stdout_lines.next().unwrap(), "");
   assert_contains!(
     stdout_lines.next().unwrap(),
-    "No matching test modules found"
+    "0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out"
   );
   wait_for_process_finished("Test", &mut stderr_lines);
 
@@ -486,6 +487,7 @@ fn test_watch() {
   )
   .expect("error writing file");
 
+  assert_eq!(stdout_lines.next().unwrap(), "");
   assert_contains!(stdout_lines.next().unwrap(), "running 1 test");
   assert_contains!(stdout_lines.next().unwrap(), "foo", "bar");
   assert_contains!(stdout_lines.next().unwrap(), "running 1 test");
@@ -628,11 +630,11 @@ fn test_watch_doc() {
   let mut stderr_lines =
     std::io::BufReader::new(stderr).lines().map(|r| r.unwrap());
 
+  assert_eq!(stdout_lines.next().unwrap(), "");
   assert_contains!(
     stdout_lines.next().unwrap(),
-    "No matching test modules found"
+    "0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out"
   );
-
   wait_for_process_finished("Test", &mut stderr_lines);
 
   let foo_file = t.path().join("foo.ts");


### PR DESCRIPTION
This marks test watcher tests as flaky tests.
They still need to be re-worked as they are very flaky.

See https://github.com/denoland/deno/issues/10552