### PR TITLE
perf(wpt/crypto): optimize num-bigint-dig for debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,11 @@ incremental = true
 lto = true
 opt-level = 'z' # Optimize for size
 
+# Key generation is too slow on `debug`
+# 
+[profile.dev.package.num-bigint-dig]
+opt-level = 3
+
 # Optimize these packages for performance.
 # NB: the `bench` and `release` profiles must remain EXACTLY the same.
 [profile.bench.package.rand]
@@ -60,6 +65,8 @@ opt-level = 3
 [profile.bench.package.deno_http]
 opt-level = 3
 [profile.bench.package.deno_net]
+opt-level = 3
+[profile.bench.package.num-bigint-dig]
 opt-level = 3
 [profile.bench.package.rusty_v8]
 opt-level = 3
@@ -88,6 +95,8 @@ opt-level = 3
 [profile.release.package.deno_http]
 opt-level = 3
 [profile.release.package.deno_net]
+opt-level = 3
+[profile.release.package.num-bigint-dig]
 opt-level = 3
 [profile.release.package.rusty_v8]
 opt-level = 3


### PR DESCRIPTION
Closes #11301

![bench_rsa](https://user-images.githubusercontent.com/34997667/129314395-b7c97f88-e826-4b43-8e9d-a32253214d98.png)

```javascript
// bench_rsa.js
import {
  bench,
  runBenchmarks,
} from "https://deno.land/std@0.104.0/testing/bench.ts";

bench(async function iter10RSA4096(b){
  b.start();
  for (let i = 0; i < 10; i++) {
    await crypto.subtle.generateKey({ name: "RSA-PSS", hash: "SHA-256", publicExponent: new Uint8Array([1,0,1]), modulusLength: 2048 }, true, ["sign"]);
  };
  b.stop();
});

runBenchmarks();
```
