### PR TITLE
cleanup(ext/web/BlobStore): avoid redundant alloc

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -968,7 +968,7 @@ mod tests {
     let specifier = blob_store.insert_object_url(
       Blob {
         media_type: "application/typescript".to_string(),
-        parts: vec![Arc::new(Box::new(InMemoryBlobPart::from(bytes)))],
+        parts: vec![Arc::new(InMemoryBlobPart::from(bytes))],
       },
       None,
     );


### PR DESCRIPTION
`Arc<T>` is already on the heap so `Arc<Box<T>>` is unnecessary, see: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation