### PR TITLE
fix(cli/tools/repl): dont highlight candidate when completion is list

### DIFF
--- a/cli/tools/repl.rs
+++ b/cli/tools/repl.rs
@@ -290,9 +290,13 @@ impl Highlighter for EditorHelper {
   fn highlight_candidate<'c>(
     &self,
     candidate: &'c str,
-    _completion: rustyline::CompletionType,
+    completion: rustyline::CompletionType,
   ) -> Cow<'c, str> {
-    self.highlight(candidate, 0)
+    if completion == CompletionType::List {
+      candidate.into()
+    } else {
+      self.highlight(candidate, 0)
+    }
   }
 
   fn highlight_char(&self, line: &str, _: usize) -> bool {


### PR DESCRIPTION
This disables any highlighting when the completion mode is set to list.

Fixes https://github.com/denoland/deno/issues/10998