### PR TITLE
refactor: normalize `is_supported_` check naming

### DIFF
--- a/cli/fs_util.rs
+++ b/cli/fs_util.rs
@@ -112,10 +112,36 @@ pub fn is_supported_ext_fmt(path: &Path) -> bool {
     false
   }
 }
-/// Checks if the path has extension Deno supports.
-/// This function is similar to is_supported_ext but adds additional extensions
-/// supported by `deno test`.
-pub fn is_supported_ext_test(path: &Path) -> bool {
+
+/// Checks if the path has a basename and extension Deno supports for tests.
+pub fn is_supported_test_path(path: &Path) -> bool {
+  use std::path::Component;
+  if let Some(Component::Normal(basename_os_str)) =
+    path.components().next_back()
+  {
+    let basename = basename_os_str.to_string_lossy();
+    basename.ends_with("_test.ts")
+      || basename.ends_with("_test.tsx")
+      || basename.ends_with("_test.js")
+      || basename.ends_with("_test.mjs")
+      || basename.ends_with("_test.jsx")
+      || basename.ends_with(".test.ts")
+      || basename.ends_with(".test.tsx")
+      || basename.ends_with(".test.js")
+      || basename.ends_with(".test.mjs")
+      || basename.ends_with(".test.jsx")
+      || basename == "test.ts"
+      || basename == "test.tsx"
+      || basename == "test.js"
+      || basename == "test.mjs"
+      || basename == "test.jsx"
+  } else {
+    false
+  }
+}
+
+/// Checks if the path has an extension Deno supports for tests.
+pub fn is_supported_test_ext(path: &Path) -> bool {
   if let Some(ext) = get_extension(path) {
     matches!(ext.as_str(), "ts" | "tsx" | "js" | "jsx" | "mjs" | "md")
   } else {
@@ -310,6 +336,56 @@ mod tests {
     assert!(is_supported_ext_fmt(Path::new("foo.JSONC")));
     assert!(is_supported_ext_fmt(Path::new("foo.json")));
     assert!(is_supported_ext_fmt(Path::new("foo.JsON")));
+  }
+
+  #[test]
+  fn test_is_supported_test_ext() {
+    assert!(!is_supported_test_ext(Path::new("tests/subdir/redirects")));
+    assert!(is_supported_test_ext(Path::new("README.md")));
+    assert!(is_supported_test_ext(Path::new("readme.MD")));
+    assert!(is_supported_test_ext(Path::new("lib/typescript.d.ts")));
+    assert!(is_supported_test_ext(Path::new("testdata/001_hello.js")));
+    assert!(is_supported_test_ext(Path::new("testdata/002_hello.ts")));
+    assert!(is_supported_test_ext(Path::new("foo.jsx")));
+    assert!(is_supported_test_ext(Path::new("foo.tsx")));
+    assert!(is_supported_test_ext(Path::new("foo.TS")));
+    assert!(is_supported_test_ext(Path::new("foo.TSX")));
+    assert!(is_supported_test_ext(Path::new("foo.JS")));
+    assert!(is_supported_test_ext(Path::new("foo.JSX")));
+    assert!(is_supported_test_ext(Path::new("foo.mjs")));
+    assert!(!is_supported_test_ext(Path::new("foo.mjsx")));
+    assert!(!is_supported_test_ext(Path::new("foo.jsonc")));
+    assert!(!is_supported_test_ext(Path::new("foo.JSONC")));
+    assert!(!is_supported_test_ext(Path::new("foo.json")));
+    assert!(!is_supported_test_ext(Path::new("foo.JsON")));
+  }
+
+  #[test]
+  fn test_is_supported_test_path() {
+    assert!(is_supported_test_path(Path::new(
+      "tests/subdir/foo_test.ts"
+    )));
+    assert!(is_supported_test_path(Path::new(
+      "tests/subdir/foo_test.tsx"
+    )));
+    assert!(is_supported_test_path(Path::new(
+      "tests/subdir/foo_test.js"
+    )));
+    assert!(is_supported_test_path(Path::new(
+      "tests/subdir/foo_test.jsx"
+    )));
+    assert!(is_supported_test_path(Path::new("bar/foo.test.ts")));
+    assert!(is_supported_test_path(Path::new("bar/foo.test.tsx")));
+    assert!(is_supported_test_path(Path::new("bar/foo.test.js")));
+    assert!(is_supported_test_path(Path::new("bar/foo.test.jsx")));
+    assert!(is_supported_test_path(Path::new("foo/bar/test.js")));
+    assert!(is_supported_test_path(Path::new("foo/bar/test.jsx")));
+    assert!(is_supported_test_path(Path::new("foo/bar/test.ts")));
+    assert!(is_supported_test_path(Path::new("foo/bar/test.tsx")));
+    assert!(!is_supported_test_path(Path::new("README.md")));
+    assert!(!is_supported_test_path(Path::new("lib/typescript.d.ts")));
+    assert!(!is_supported_test_path(Path::new("notatest.js")));
+    assert!(!is_supported_test_path(Path::new("NotAtest.ts")));
   }
 
   #[test]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1041,12 +1041,12 @@ async fn test_command(
       let test_modules_result = if doc {
         fs_util::collect_specifiers(
           include.clone(),
-          fs_util::is_supported_ext_test,
+          fs_util::is_supported_test_ext,
         )
       } else {
         fs_util::collect_specifiers(
           include.clone(),
-          tools::test_runner::is_supported,
+          fs_util::is_supported_test_path,
         )
       };
 
@@ -1180,7 +1180,7 @@ async fn test_command(
         let doc_modules = if doc {
           fs_util::collect_specifiers(
             include.clone(),
-            fs_util::is_supported_ext_test,
+            fs_util::is_supported_test_ext,
           )?
         } else {
           Vec::new()
@@ -1194,7 +1194,7 @@ async fn test_command(
 
         let test_modules = fs_util::collect_specifiers(
           include.clone(),
-          tools::test_runner::is_supported,
+          fs_util::is_supported_test_path,
         )?;
 
         let test_modules_to_reload = test_modules
@@ -1228,7 +1228,7 @@ async fn test_command(
     let doc_modules = if doc {
       fs_util::collect_specifiers(
         include.clone(),
-        fs_util::is_supported_ext_test,
+        fs_util::is_supported_test_ext,
       )?
     } else {
       Vec::new()
@@ -1236,7 +1236,7 @@ async fn test_command(
 
     let test_modules = fs_util::collect_specifiers(
       include.clone(),
-      tools::test_runner::is_supported,
+      fs_util::is_supported_test_path,
     )?;
 
     test_runner::run_tests(

--- a/cli/tools/test_runner.rs
+++ b/cli/tools/test_runner.rs
@@ -25,7 +25,6 @@ use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use regex::Regex;
 use serde::Deserialize;
-use std::path::Path;
 use std::path::PathBuf;
 use std::sync::mpsc::channel;
 use std::sync::mpsc::Sender;
@@ -193,30 +192,6 @@ impl TestReporter for PrettyTestReporter {
 
 fn create_reporter(concurrent: bool) -> Box<dyn TestReporter + Send> {
   Box::new(PrettyTestReporter::new(concurrent))
-}
-
-pub(crate) fn is_supported(p: &Path) -> bool {
-  use std::path::Component;
-  if let Some(Component::Normal(basename_os_str)) = p.components().next_back() {
-    let basename = basename_os_str.to_string_lossy();
-    basename.ends_with("_test.ts")
-      || basename.ends_with("_test.tsx")
-      || basename.ends_with("_test.js")
-      || basename.ends_with("_test.mjs")
-      || basename.ends_with("_test.jsx")
-      || basename.ends_with(".test.ts")
-      || basename.ends_with(".test.tsx")
-      || basename.ends_with(".test.js")
-      || basename.ends_with(".test.mjs")
-      || basename.ends_with(".test.jsx")
-      || basename == "test.ts"
-      || basename == "test.tsx"
-      || basename == "test.js"
-      || basename == "test.mjs"
-      || basename == "test.jsx"
-  } else {
-    false
-  }
 }
 
 pub async fn test_specifier(
@@ -689,29 +664,4 @@ pub async fn run_tests(
   }
 
   Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  #[test]
-  fn test_is_supported() {
-    assert!(is_supported(Path::new("tests/subdir/foo_test.ts")));
-    assert!(is_supported(Path::new("tests/subdir/foo_test.tsx")));
-    assert!(is_supported(Path::new("tests/subdir/foo_test.js")));
-    assert!(is_supported(Path::new("tests/subdir/foo_test.jsx")));
-    assert!(is_supported(Path::new("bar/foo.test.ts")));
-    assert!(is_supported(Path::new("bar/foo.test.tsx")));
-    assert!(is_supported(Path::new("bar/foo.test.js")));
-    assert!(is_supported(Path::new("bar/foo.test.jsx")));
-    assert!(is_supported(Path::new("foo/bar/test.js")));
-    assert!(is_supported(Path::new("foo/bar/test.jsx")));
-    assert!(is_supported(Path::new("foo/bar/test.ts")));
-    assert!(is_supported(Path::new("foo/bar/test.tsx")));
-    assert!(!is_supported(Path::new("README.md")));
-    assert!(!is_supported(Path::new("lib/typescript.d.ts")));
-    assert!(!is_supported(Path::new("notatest.js")));
-    assert!(!is_supported(Path::new("NotAtest.ts")));
-  }
 }


### PR DESCRIPTION
Normalizes the naming of the functions used to determine if a path is a suitable match for the test runner and placed them both in the the fs_util module.

Added a test for `is_supported_test_ext` as-well.