### PR TITLE
fix(cli/lint): don't use gray in diagnostics output for visibility

### DIFF
--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -301,27 +301,25 @@ pub fn format_diagnostic(
     }
   }
 
-  if let Some(hint) = maybe_hint {
-    format!(
-      "{}\n{}\n    at {}\n\n    {} {}\n    {} for further information visit https://lint.deno.land/#{}",
-      message_line,
-      lines.join("\n"),
-      formatted_location,
-      colors::cyan("hint:"),
-      hint,
-      colors::cyan("help:"),
-      diagnostic_code,
-    )
+  let hint = if let Some(hint) = maybe_hint {
+    format!("    {} {}\n", colors::cyan("hint:"), hint)
   } else {
-    format!(
-      "{}\n{}\n    at {}\n\n    {} for further information visit https://lint.deno.land/#{}",
-      message_line,
-      lines.join("\n"),
-      formatted_location,
-      colors::cyan("help:"),
-      diagnostic_code,
-    )
-  }
+    "".to_string()
+  };
+  let help = format!(
+    "    {} for further information visit https://lint.deno.land/#{}",
+    colors::cyan("help:"),
+    diagnostic_code
+  );
+
+  format!(
+    "{message_line}\n{snippets}\n    at {formatted_location}\n\n{hint}{help}",
+    message_line = message_line,
+    snippets = lines.join("\n"),
+    formatted_location = formatted_location,
+    hint = hint,
+    help = help
+  )
 }
 
 #[derive(Serialize)]

--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -229,8 +229,7 @@ impl LintReporter for PrettyLintReporter {
   fn visit_diagnostic(&mut self, d: &LintDiagnostic, source_lines: Vec<&str>) {
     self.lint_count += 1;
 
-    let pretty_message =
-      format!("({}) {}", colors::gray(&d.code), d.message.clone());
+    let pretty_message = format!("({}) {}", colors::red(&d.code), &d.message);
 
     let message = format_diagnostic(
       &d.code,
@@ -308,9 +307,9 @@ pub fn format_diagnostic(
       message_line,
       lines.join("\n"),
       formatted_location,
-      colors::gray("hint:"),
+      colors::cyan("hint:"),
       hint,
-      colors::gray("help:"),
+      colors::cyan("help:"),
       diagnostic_code,
     )
   } else {
@@ -319,7 +318,7 @@ pub fn format_diagnostic(
       message_line,
       lines.join("\n"),
       formatted_location,
-      colors::gray("help:"),
+      colors::cyan("help:"),
       diagnostic_code,
     )
   }


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

This commit changes output color of the linter to not use gray for visibility on dark backgrounds.

Fixes https://github.com/denoland/deno_lint/issues/788


