### PR TITLE
perf: improve localStorage throughput

### DIFF
--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+// NOTE to all: use **cached** prepared statements when interfacing with SQLite.
+
 use deno_core::error::AnyError;
 use deno_core::include_js_files;
 use deno_core::op_sync;
@@ -64,11 +66,12 @@ fn get_webstorage(
       })?;
       std::fs::create_dir_all(&path.0)?;
       let conn = Connection::open(path.0.join("local_storage"))?;
-      conn.execute(
-        "CREATE TABLE IF NOT EXISTS data (key VARCHAR UNIQUE, value VARCHAR)",
-        params![],
-      )?;
-
+      {
+        let mut stmt = conn.prepare_cached(
+          "CREATE TABLE IF NOT EXISTS data (key VARCHAR UNIQUE, value VARCHAR)",
+        )?;
+        let _ = stmt.query(params![])?;
+      }
       state.put(LocalStorage(conn));
     }
 
@@ -76,11 +79,12 @@ fn get_webstorage(
   } else {
     if state.try_borrow::<SessionStorage>().is_none() {
       let conn = Connection::open_in_memory()?;
-      conn.execute(
-        "CREATE TABLE data (key VARCHAR UNIQUE, value VARCHAR)",
-        params![],
-      )?;
-
+      {
+        let mut stmt = conn.prepare_cached(
+          "CREATE TABLE data (key VARCHAR UNIQUE, value VARCHAR)",
+        )?;
+        let _ = stmt.query(params![])?;
+      }
       state.put(SessionStorage(conn));
     }
 
@@ -97,8 +101,7 @@ pub fn op_webstorage_length(
 ) -> Result<u32, AnyError> {
   let conn = get_webstorage(state, persistent)?;
 
-  let mut stmt = conn.prepare("SELECT COUNT(*) FROM data")?;
-
+  let mut stmt = conn.prepare_cached("SELECT COUNT(*) FROM data")?;
   let length: u32 = stmt.query_row(params![], |row| row.get(0))?;
 
   Ok(length)
@@ -111,7 +114,8 @@ pub fn op_webstorage_key(
 ) -> Result<Option<String>, AnyError> {
   let conn = get_webstorage(state, persistent)?;
 
-  let mut stmt = conn.prepare("SELECT key FROM data LIMIT 1 OFFSET ?")?;
+  let mut stmt =
+    conn.prepare_cached("SELECT key FROM data LIMIT 1 OFFSET ?")?;
 
   let key: Option<String> = stmt
     .query_row(params![index], |row| row.get(0))
@@ -134,8 +138,8 @@ pub fn op_webstorage_set(
 ) -> Result<(), AnyError> {
   let conn = get_webstorage(state, persistent)?;
 
-  let mut stmt =
-    conn.prepare("SELECT SUM(pgsize) FROM dbstat WHERE name = 'data'")?;
+  let mut stmt = conn
+    .prepare_cached("SELECT SUM(pgsize) FROM dbstat WHERE name = 'data'")?;
   let size: u32 = stmt.query_row(params![], |row| row.get(0))?;
 
   if size >= MAX_STORAGE_BYTES {
@@ -147,10 +151,9 @@ pub fn op_webstorage_set(
     );
   }
 
-  conn.execute(
-    "INSERT OR REPLACE INTO data (key, value) VALUES (?, ?)",
-    params![args.key_name, args.key_value],
-  )?;
+  let mut stmt = conn
+    .prepare_cached("INSERT OR REPLACE INTO data (key, value) VALUES (?, ?)")?;
+  let _ = stmt.query(params![args.key_name, args.key_value])?;
 
   Ok(())
 }
@@ -162,8 +165,7 @@ pub fn op_webstorage_get(
 ) -> Result<Option<String>, AnyError> {
   let conn = get_webstorage(state, persistent)?;
 
-  let mut stmt = conn.prepare("SELECT value FROM data WHERE key = ?")?;
-
+  let mut stmt = conn.prepare_cached("SELECT value FROM data WHERE key = ?")?;
   let val = stmt
     .query_row(params![key_name], |row| row.get(0))
     .optional()?;
@@ -178,7 +180,8 @@ pub fn op_webstorage_remove(
 ) -> Result<(), AnyError> {
   let conn = get_webstorage(state, persistent)?;
 
-  conn.execute("DELETE FROM data WHERE key = ?", params![key_name])?;
+  let mut stmt = conn.prepare_cached("DELETE FROM data WHERE key = ?")?;
+  let _ = stmt.query(params![key_name])?;
 
   Ok(())
 }
@@ -190,11 +193,12 @@ pub fn op_webstorage_clear(
 ) -> Result<(), AnyError> {
   let conn = get_webstorage(state, persistent)?;
 
-  conn.execute("DROP TABLE data", params![])?;
-  conn.execute(
-    "CREATE TABLE data (key VARCHAR UNIQUE, value VARCHAR)",
-    params![],
-  )?;
+  let mut stmt = conn.prepare_cached("DROP TABLE data")?;
+  let _ = stmt.query(params![])?;
+
+  let mut stmt = conn
+    .prepare_cached("CREATE TABLE data (key VARCHAR UNIQUE, value VARCHAR)")?;
+  let _ = stmt.query(params![])?;
 
   Ok(())
 }
@@ -206,8 +210,7 @@ pub fn op_webstorage_iterate_keys(
 ) -> Result<Vec<String>, AnyError> {
   let conn = get_webstorage(state, persistent)?;
 
-  let mut stmt = conn.prepare("SELECT key FROM data")?;
-
+  let mut stmt = conn.prepare_cached("SELECT key FROM data")?;
   let keys = stmt
     .query_map(params![], |row| row.get::<_, String>(0))?
     .map(|r| r.unwrap())


### PR DESCRIPTION
This PR improves localStorage write throughput by around 150x by caching
the prepared statements for SQLite.

Script to measure perf:

```js
const start = performance.now();
for (let i = 0; i < 100; i++) {
  localStorage[i.toString()] = i.toString();
}
console.log(`${performance.now() - start}ms`);
```

```
/m/s/P/g/d/deno ❯❯❯ deno run --location https://deno.land test.js
1978ms
/m/s/P/g/d/deno ❯❯❯ cargo run run --location https://deno.land test.js
   Compiling deno_runtime v0.22.2 (/mnt/starship/Projects/github.com/denoland/deno/runtime)
   Compiling deno v1.13.0 (/mnt/starship/Projects/github.com/denoland/deno/cli)
    Finished dev [unoptimized + debuginfo] target(s) in 31.73s
     Running `target/debug/deno run --location 'https://deno.land' test.js`
14ms
```

