### PR TITLE
refactor(ops): return BadResource errors in ResourceTable calls

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -611,10 +611,11 @@ fn wasm_streaming_feed(
     let state = state_rc.borrow();
     // If message_type is not Bytes, we'll be consuming the WasmStreaming
     // instance, so let's also remove it from the resource table.
-    let wasm_streaming: Result<Rc<WasmStreamingResource>, AnyError> = match message_type {
-      MessageType::Bytes => state.op_state.borrow().resource_table.get(rid),
-      _ => state.op_state.borrow_mut().resource_table.take(rid),
-    };
+    let wasm_streaming: Result<Rc<WasmStreamingResource>, AnyError> =
+      match message_type {
+        MessageType::Bytes => state.op_state.borrow().resource_table.get(rid),
+        _ => state.op_state.borrow_mut().resource_table.take(rid),
+      };
     match wasm_streaming {
       Ok(wasm_streaming) => wasm_streaming,
       Err(e) => return throw_type_error(scope, e.to_string()),

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -611,13 +611,13 @@ fn wasm_streaming_feed(
     let state = state_rc.borrow();
     // If message_type is not Bytes, we'll be consuming the WasmStreaming
     // instance, so let's also remove it from the resource table.
-    let wasm_streaming: Option<Rc<WasmStreamingResource>> = match message_type {
+    let wasm_streaming: Result<Rc<WasmStreamingResource>, AnyError> = match message_type {
       MessageType::Bytes => state.op_state.borrow().resource_table.get(rid),
       _ => state.op_state.borrow_mut().resource_table.take(rid),
     };
     match wasm_streaming {
-      Some(wasm_streaming) => wasm_streaming,
-      None => return throw_type_error(scope, "Invalid resource ID."),
+      Ok(wasm_streaming) => wasm_streaming,
+      Err(e) => return throw_type_error(scope, e.to_string()),
     }
   };
 

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -144,7 +144,6 @@ fn op_close(
     .resource_table
     .close(rid)
     .map(|_| ())
-    .ok_or_else(bad_resource_id)
 }
 
 async fn op_accept(
@@ -157,8 +156,7 @@ async fn op_accept(
   let listener = state
     .borrow()
     .resource_table
-    .get::<TcpListener>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<TcpListener>(rid)?;
   let stream = listener.accept().await?;
   let rid = state.borrow_mut().resource_table.add(stream);
   Ok(rid)
@@ -175,8 +173,7 @@ async fn op_read(
   let stream = state
     .borrow()
     .resource_table
-    .get::<TcpStream>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<TcpStream>(rid)?;
   let nread = stream.read(&mut buf).await?;
   Ok(nread)
 }
@@ -192,8 +189,7 @@ async fn op_write(
   let stream = state
     .borrow()
     .resource_table
-    .get::<TcpStream>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<TcpStream>(rid)?;
   let nwritten = stream.write(&buf).await?;
   Ok(nwritten)
 }

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -139,10 +139,7 @@ fn op_close(
   _: (),
 ) -> Result<(), AnyError> {
   log::debug!("close rid={}", rid);
-  state
-    .resource_table
-    .close(rid)
-    .map(|_| ())
+  state.resource_table.close(rid).map(|_| ())
 }
 
 async fn op_accept(
@@ -152,10 +149,7 @@ async fn op_accept(
 ) -> Result<ResourceId, AnyError> {
   log::debug!("accept rid={}", rid);
 
-  let listener = state
-    .borrow()
-    .resource_table
-    .get::<TcpListener>(rid)?;
+  let listener = state.borrow().resource_table.get::<TcpListener>(rid)?;
   let stream = listener.accept().await?;
   let rid = state.borrow_mut().resource_table.add(stream);
   Ok(rid)
@@ -169,10 +163,7 @@ async fn op_read(
   let mut buf = buf.ok_or_else(null_opbuf)?;
   log::debug!("read rid={}", rid);
 
-  let stream = state
-    .borrow()
-    .resource_table
-    .get::<TcpStream>(rid)?;
+  let stream = state.borrow().resource_table.get::<TcpStream>(rid)?;
   let nread = stream.read(&mut buf).await?;
   Ok(nread)
 }
@@ -185,10 +176,7 @@ async fn op_write(
   let buf = buf.ok_or_else(null_opbuf)?;
   log::debug!("write rid={}", rid);
 
-  let stream = state
-    .borrow()
-    .resource_table
-    .get::<TcpStream>(rid)?;
+  let stream = state.borrow().resource_table.get::<TcpStream>(rid)?;
   let nwritten = stream.write(&buf).await?;
   Ok(nwritten)
 }

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
-use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
 use deno_core::AsyncRefCell;

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -46,9 +46,7 @@ pub fn op_close(
 ) -> Result<(), AnyError> {
   // TODO(@AaronO): drop Option after improving type-strictness balance in serde_v8
   let rid = rid.ok_or_else(|| type_error("missing or invalid `rid`"))?;
-  state
-    .resource_table
-    .close(rid)?;
+  state.resource_table.close(rid)?;
 
   Ok(())
 }

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -1,4 +1,3 @@
-use crate::error::bad_resource_id;
 use crate::error::type_error;
 use crate::error::AnyError;
 use crate::include_js_files;

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -49,8 +49,7 @@ pub fn op_close(
   let rid = rid.ok_or_else(|| type_error("missing or invalid `rid`"))?;
   state
     .resource_table
-    .close(rid)
-    .ok_or_else(bad_resource_id)?;
+    .close(rid)?;
 
   Ok(())
 }

--- a/core/resources.rs
+++ b/core/resources.rs
@@ -117,14 +117,21 @@ impl ResourceTable {
   }
 
   pub fn get_any(&self, rid: ResourceId) -> Result<Rc<dyn Resource>, AnyError> {
-    self.index.get(&rid).map(Clone::clone).ok_or_else(bad_resource_id)
+    self
+      .index
+      .get(&rid)
+      .map(Clone::clone)
+      .ok_or_else(bad_resource_id)
   }
 
   /// Removes a resource of type `T` from the resource table and returns it.
   /// If a resource with the given `rid` exists but its type does not match `T`,
   /// it is not removed from the resource table. Note that the resource's
   /// `close()` method is *not* called.
-  pub fn take<T: Resource>(&mut self, rid: ResourceId) -> Result<Rc<T>, AnyError> {
+  pub fn take<T: Resource>(
+    &mut self,
+    rid: ResourceId,
+  ) -> Result<Rc<T>, AnyError> {
     let resource = self.get::<T>(rid)?;
     self.index.remove(&rid);
     Ok(resource)
@@ -132,7 +139,10 @@ impl ResourceTable {
 
   /// Removes a resource from the resource table and returns it. Note that the
   /// resource's `close()` method is *not* called.
-  pub fn take_any(&mut self, rid: ResourceId) -> Result<Rc<dyn Resource>, AnyError> {
+  pub fn take_any(
+    &mut self,
+    rid: ResourceId,
+  ) -> Result<Rc<dyn Resource>, AnyError> {
     self.index.remove(&rid).ok_or_else(bad_resource_id)
   }
 
@@ -143,7 +153,11 @@ impl ResourceTable {
   /// may implement the `close()` method to perform clean-ups such as canceling
   /// ops.
   pub fn close(&mut self, rid: ResourceId) -> Result<(), AnyError> {
-    self.index.remove(&rid).ok_or_else(bad_resource_id).map(|resource| resource.close())
+    self
+      .index
+      .remove(&rid)
+      .ok_or_else(bad_resource_id)
+      .map(|resource| resource.close())
   }
 
   /// Returns an iterator that yields a `(id, name)` pair for every resource

--- a/core/resources.rs
+++ b/core/resources.rs
@@ -6,6 +6,8 @@
 // resources. Resources may or may not correspond to a real operating system
 // file descriptor (hence the different name).
 
+use crate::error::bad_resource_id;
+use crate::error::AnyError;
 use std::any::type_name;
 use std::any::Any;
 use std::any::TypeId;
@@ -105,32 +107,33 @@ impl ResourceTable {
   /// Returns a reference counted pointer to the resource of type `T` with the
   /// given `rid`. If `rid` is not present or has a type different than `T`,
   /// this function returns `None`.
-  pub fn get<T: Resource>(&self, rid: ResourceId) -> Option<Rc<T>> {
+  pub fn get<T: Resource>(&self, rid: ResourceId) -> Result<Rc<T>, AnyError> {
     self
       .index
       .get(&rid)
       .and_then(|rc| rc.downcast_rc::<T>())
       .map(Clone::clone)
+      .ok_or_else(bad_resource_id)
   }
 
-  pub fn get_any(&self, rid: ResourceId) -> Option<Rc<dyn Resource>> {
-    self.index.get(&rid).map(Clone::clone)
+  pub fn get_any(&self, rid: ResourceId) -> Result<Rc<dyn Resource>, AnyError> {
+    self.index.get(&rid).map(Clone::clone).ok_or_else(bad_resource_id)
   }
 
   /// Removes a resource of type `T` from the resource table and returns it.
   /// If a resource with the given `rid` exists but its type does not match `T`,
   /// it is not removed from the resource table. Note that the resource's
   /// `close()` method is *not* called.
-  pub fn take<T: Resource>(&mut self, rid: ResourceId) -> Option<Rc<T>> {
+  pub fn take<T: Resource>(&mut self, rid: ResourceId) -> Result<Rc<T>, AnyError> {
     let resource = self.get::<T>(rid)?;
     self.index.remove(&rid);
-    Some(resource)
+    Ok(resource)
   }
 
   /// Removes a resource from the resource table and returns it. Note that the
   /// resource's `close()` method is *not* called.
-  pub fn take_any(&mut self, rid: ResourceId) -> Option<Rc<dyn Resource>> {
-    self.index.remove(&rid)
+  pub fn take_any(&mut self, rid: ResourceId) -> Result<Rc<dyn Resource>, AnyError> {
+    self.index.remove(&rid).ok_or_else(bad_resource_id)
   }
 
   /// Removes the resource with the given `rid` from the resource table. If the
@@ -139,8 +142,8 @@ impl ResourceTable {
   /// counted, therefore pending ops are not automatically cancelled. A resource
   /// may implement the `close()` method to perform clean-ups such as canceling
   /// ops.
-  pub fn close(&mut self, rid: ResourceId) -> Option<()> {
-    self.index.remove(&rid).map(|resource| resource.close())
+  pub fn close(&mut self, rid: ResourceId) -> Result<(), AnyError> {
+    self.index.remove(&rid).ok_or_else(bad_resource_id).map(|resource| resource.close())
   }
 
   /// Returns an iterator that yields a `(id, name)` pair for every resource

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -70,8 +70,7 @@ pub fn op_broadcast_unsubscribe<BC: BroadcastChannel + 'static>(
 ) -> Result<(), AnyError> {
   let resource = state
     .resource_table
-    .get::<BC::Resource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<BC::Resource>(rid)?;
   let bc = state.borrow::<BC>();
   bc.unsubscribe(&resource)
 }
@@ -84,8 +83,7 @@ pub async fn op_broadcast_send<BC: BroadcastChannel + 'static>(
   let resource = state
     .borrow()
     .resource_table
-    .get::<BC::Resource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<BC::Resource>(rid)?;
   let bc = state.borrow().borrow::<BC>().clone();
   bc.send(&resource, name, buf.to_vec()).await
 }
@@ -98,8 +96,7 @@ pub async fn op_broadcast_recv<BC: BroadcastChannel + 'static>(
   let resource = state
     .borrow()
     .resource_table
-    .get::<BC::Resource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<BC::Resource>(rid)?;
   let bc = state.borrow().borrow::<BC>().clone();
   bc.recv(&resource).await
 }

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -67,9 +67,7 @@ pub fn op_broadcast_unsubscribe<BC: BroadcastChannel + 'static>(
   rid: ResourceId,
   _buf: (),
 ) -> Result<(), AnyError> {
-  let resource = state
-    .resource_table
-    .get::<BC::Resource>(rid)?;
+  let resource = state.resource_table.get::<BC::Resource>(rid)?;
   let bc = state.borrow::<BC>();
   bc.unsubscribe(&resource)
 }
@@ -79,10 +77,7 @@ pub async fn op_broadcast_send<BC: BroadcastChannel + 'static>(
   (rid, name): (ResourceId, String),
   buf: ZeroCopyBuf,
 ) -> Result<(), AnyError> {
-  let resource = state
-    .borrow()
-    .resource_table
-    .get::<BC::Resource>(rid)?;
+  let resource = state.borrow().resource_table.get::<BC::Resource>(rid)?;
   let bc = state.borrow().borrow::<BC>().clone();
   bc.send(&resource, name, buf.to_vec()).await
 }
@@ -92,10 +87,7 @@ pub async fn op_broadcast_recv<BC: BroadcastChannel + 'static>(
   rid: ResourceId,
   _buf: (),
 ) -> Result<Option<Message>, AnyError> {
-  let resource = state
-    .borrow()
-    .resource_table
-    .get::<BC::Resource>(rid)?;
+  let resource = state.borrow().resource_table.get::<BC::Resource>(rid)?;
   let bc = state.borrow().borrow::<BC>().clone();
   bc.recv(&resource).await
 }

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -5,7 +5,6 @@ mod in_memory_broadcast_channel;
 pub use in_memory_broadcast_channel::InMemoryBroadcastChannel;
 
 use async_trait::async_trait;
-use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::include_js_files;
 use deno_core::op_async;

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -162,9 +162,7 @@ where
   FP: FetchPermissions + 'static,
 {
   let client = if let Some(rid) = args.client_rid {
-    let r = state
-      .resource_table
-      .get::<HttpClientResource>(rid)?;
+    let r = state.resource_table.get::<HttpClientResource>(rid)?;
     r.client.clone()
   } else {
     let client = state.borrow::<reqwest::Client>();

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -165,8 +165,7 @@ where
   let client = if let Some(rid) = args.client_rid {
     let r = state
       .resource_table
-      .get::<HttpClientResource>(rid)
-      .ok_or_else(bad_resource_id)?;
+      .get::<HttpClientResource>(rid)?;
     r.client.clone()
   } else {
     let client = state.borrow::<reqwest::Client>();
@@ -345,8 +344,7 @@ pub async fn op_fetch_send(
   let request = state
     .borrow_mut()
     .resource_table
-    .take::<FetchRequestResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .take::<FetchRequestResource>(rid)?;
 
   let request = Rc::try_unwrap(request)
     .ok()
@@ -402,8 +400,7 @@ pub async fn op_fetch_request_write(
   let resource = state
     .borrow()
     .resource_table
-    .get::<FetchRequestBodyResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<FetchRequestBodyResource>(rid)?;
   let body = RcRef::map(&resource, |r| &r.body).borrow_mut().await;
   let cancel = RcRef::map(resource, |r| &r.cancel);
   body.send(Ok(buf)).or_cancel(cancel).await?.map_err(|_| {
@@ -423,8 +420,7 @@ pub async fn op_fetch_response_read(
   let resource = state
     .borrow()
     .resource_table
-    .get::<FetchResponseBodyResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<FetchResponseBodyResource>(rid)?;
   let mut reader = RcRef::map(&resource, |r| &r.reader).borrow_mut().await;
   let cancel = RcRef::map(resource, |r| &r.cancel);
   let mut buf = data.clone();

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use data_url::DataUrl;
-use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -329,8 +329,7 @@ fn op_ffi_call(
 ) -> Result<Value, AnyError> {
   let resource = state
     .resource_table
-    .get::<DynamicLibraryResource>(args.rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<DynamicLibraryResource>(args.rid)?;
 
   let symbol = resource
     .symbols

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -441,7 +441,7 @@ async fn op_http_response(
 
   poll_fn(|cx| match conn_resource.poll(cx) {
     Poll::Ready(x) => {
-      state.borrow_mut().resource_table.close(conn_rid);
+      state.borrow_mut().resource_table.close(conn_rid).ok();
       Poll::Ready(x)
     }
     Poll::Pending => Poll::Ready(Ok(())),

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -175,8 +175,7 @@ async fn op_http_request_next(
   let conn_resource = state
     .borrow()
     .resource_table
-    .get::<ConnResource>(conn_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<ConnResource>(conn_rid)?;
 
   let cancel = RcRef::map(conn_resource.clone(), |r| &r.cancel);
 
@@ -395,8 +394,7 @@ async fn op_http_response(
   let response_sender = state
     .borrow_mut()
     .resource_table
-    .take::<ResponseSenderResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .take::<ResponseSenderResource>(rid)?;
   let response_sender = Rc::try_unwrap(response_sender)
     .ok()
     .expect("multiple op_http_respond ongoing");
@@ -406,8 +404,7 @@ async fn op_http_response(
   let conn_resource = state
     .borrow()
     .resource_table
-    .get::<ConnResource>(conn_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<ConnResource>(conn_rid)?;
 
   let mut builder = Response::builder().status(status);
 
@@ -465,14 +462,12 @@ async fn op_http_response_close(
   let resource = state
     .borrow_mut()
     .resource_table
-    .take::<ResponseBodyResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .take::<ResponseBodyResource>(rid)?;
 
   let conn_resource = state
     .borrow()
     .resource_table
-    .get::<ConnResource>(resource.conn_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<ConnResource>(resource.conn_rid)?;
   drop(resource);
 
   let r = poll_fn(|cx| match conn_resource.poll(cx) {
@@ -494,14 +489,12 @@ async fn op_http_request_read(
   let resource = state
     .borrow()
     .resource_table
-    .get::<RequestResource>(rid as u32)
-    .ok_or_else(bad_resource_id)?;
+    .get::<RequestResource>(rid as u32)?;
 
   let conn_resource = state
     .borrow()
     .resource_table
-    .get::<ConnResource>(resource.conn_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<ConnResource>(resource.conn_rid)?;
 
   let mut inner = RcRef::map(resource.clone(), |r| &r.inner)
     .borrow_mut()
@@ -547,14 +540,12 @@ async fn op_http_response_write(
   let resource = state
     .borrow()
     .resource_table
-    .get::<ResponseBodyResource>(rid as u32)
-    .ok_or_else(bad_resource_id)?;
+    .get::<ResponseBodyResource>(rid as u32)?;
 
   let conn_resource = state
     .borrow()
     .resource_table
-    .get::<ConnResource>(resource.conn_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<ConnResource>(resource.conn_rid)?;
 
   let mut body = RcRef::map(&resource, |r| &r.body).borrow_mut().await;
 
@@ -598,8 +589,7 @@ async fn op_http_upgrade_websocket(
   let req_resource = state
     .borrow_mut()
     .resource_table
-    .take::<RequestResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .take::<RequestResource>(rid)?;
 
   let mut inner = RcRef::map(&req_resource, |r| &r.inner).borrow_mut().await;
 

--- a/ext/net/io.rs
+++ b/ext/net/io.rs
@@ -172,8 +172,7 @@ async fn op_read_async(
   let resource = state
     .borrow()
     .resource_table
-    .get_any(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get_any(rid)?;
   let nread = if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {
     s.read(buf).await?
   } else if let Some(s) = resource.downcast_rc::<TlsStreamResource>() {
@@ -195,8 +194,7 @@ async fn op_write_async(
   let resource = state
     .borrow()
     .resource_table
-    .get_any(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get_any(rid)?;
   let nwritten = if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {
     s.write(buf).await?
   } else if let Some(s) = resource.downcast_rc::<TlsStreamResource>() {
@@ -217,8 +215,7 @@ async fn op_shutdown(
   let resource = state
     .borrow()
     .resource_table
-    .get_any(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get_any(rid)?;
   if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {
     s.shutdown().await?;
   } else if let Some(s) = resource.downcast_rc::<TlsStreamResource>() {

--- a/ext/net/io.rs
+++ b/ext/net/io.rs
@@ -3,7 +3,7 @@
 use crate::ops_tls as tls;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
-use deno_core::error::{bad_resource_id, not_supported};
+use deno_core::error::not_supported;
 use deno_core::op_async;
 use deno_core::AsyncMutFuture;
 use deno_core::AsyncRefCell;

--- a/ext/net/io.rs
+++ b/ext/net/io.rs
@@ -1,9 +1,9 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::ops_tls as tls;
+use deno_core::error::not_supported;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
-use deno_core::error::not_supported;
 use deno_core::op_async;
 use deno_core::AsyncMutFuture;
 use deno_core::AsyncRefCell;
@@ -169,10 +169,7 @@ async fn op_read_async(
   buf: Option<ZeroCopyBuf>,
 ) -> Result<u32, AnyError> {
   let buf = &mut buf.ok_or_else(null_opbuf)?;
-  let resource = state
-    .borrow()
-    .resource_table
-    .get_any(rid)?;
+  let resource = state.borrow().resource_table.get_any(rid)?;
   let nread = if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {
     s.read(buf).await?
   } else if let Some(s) = resource.downcast_rc::<TlsStreamResource>() {
@@ -191,10 +188,7 @@ async fn op_write_async(
   buf: Option<ZeroCopyBuf>,
 ) -> Result<u32, AnyError> {
   let buf = &buf.ok_or_else(null_opbuf)?;
-  let resource = state
-    .borrow()
-    .resource_table
-    .get_any(rid)?;
+  let resource = state.borrow().resource_table.get_any(rid)?;
   let nwritten = if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {
     s.write(buf).await?
   } else if let Some(s) = resource.downcast_rc::<TlsStreamResource>() {
@@ -212,10 +206,7 @@ async fn op_shutdown(
   rid: ResourceId,
   _: (),
 ) -> Result<(), AnyError> {
-  let resource = state
-    .borrow()
-    .resource_table
-    .get_any(rid)?;
+  let resource = state.borrow().resource_table.get_any(rid)?;
   if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {
     s.shutdown().await?;
   } else if let Some(s) = resource.downcast_rc::<TlsStreamResource>() {

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -266,9 +266,7 @@ where
         .borrow()
         .resource_table
         .get::<net_unix::UnixDatagramResource>(rid)
-        .map_err(|_| {
-          custom_error("NotConnected", "Socket has been closed")
-        })?;
+        .map_err(|_| custom_error("NotConnected", "Socket has been closed"))?;
       let socket = RcRef::map(&resource, |r| &r.socket)
         .try_borrow_mut()
         .ok_or_else(|| custom_error("Busy", "Socket already in use"))?;

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -107,7 +107,7 @@ async fn accept_tcp(
     .borrow()
     .resource_table
     .get::<TcpListenerResource>(rid)
-    .ok_or_else(|| bad_resource("Listener has been closed"))?;
+    .map_err(|_| bad_resource("Listener has been closed"))?;
   let listener = RcRef::map(&resource, |r| &r.listener)
     .try_borrow_mut()
     .ok_or_else(|| custom_error("Busy", "Another accept task is ongoing"))?;
@@ -178,7 +178,7 @@ async fn receive_udp(
     .borrow_mut()
     .resource_table
     .get::<UdpSocketResource>(rid)
-    .ok_or_else(|| bad_resource("Socket has been closed"))?;
+    .map_err(|_| bad_resource("Socket has been closed"))?;
   let socket = RcRef::map(&resource, |r| &r.socket).borrow().await;
   let cancel_handle = RcRef::map(&resource, |r| &r.cancel);
   let (size, remote_addr) = socket
@@ -246,7 +246,7 @@ where
         .borrow_mut()
         .resource_table
         .get::<UdpSocketResource>(rid)
-        .ok_or_else(|| bad_resource("Socket has been closed"))?;
+        .map_err(|_| bad_resource("Socket has been closed"))?;
       let socket = RcRef::map(&resource, |r| &r.socket).borrow().await;
       let byte_length = socket.send_to(&zero_copy, &addr).await?;
       Ok(byte_length)
@@ -266,7 +266,7 @@ where
         .borrow()
         .resource_table
         .get::<net_unix::UnixDatagramResource>(rid)
-        .ok_or_else(|| {
+        .map_err(|_| {
           custom_error("NotConnected", "Socket has been closed")
         })?;
       let socket = RcRef::map(&resource, |r| &r.socket)

--- a/ext/net/ops_tls.rs
+++ b/ext/net/ops_tls.rs
@@ -717,8 +717,7 @@ where
   let resource_rc = state
     .borrow_mut()
     .resource_table
-    .take::<TcpStreamResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .take::<TcpStreamResource>(rid)?;
   let resource = Rc::try_unwrap(resource_rc)
     .expect("Only a single use of this resource should happen");
   let (read_half, write_half) = resource.into_inner();
@@ -1019,7 +1018,7 @@ async fn op_accept_tls(
     .borrow()
     .resource_table
     .get::<TlsListenerResource>(rid)
-    .ok_or_else(|| bad_resource("Listener has been closed"))?;
+    .map_err(|_| bad_resource("Listener has been closed"))?;
 
   let cancel_handle = RcRef::map(&resource, |r| &r.cancel_handle);
   let tcp_listener = RcRef::map(&resource, |r| &r.tcp_listener)

--- a/ext/net/ops_tls.rs
+++ b/ext/net/ops_tls.rs
@@ -11,7 +11,6 @@ use crate::DefaultTlsOptions;
 use crate::NetPermissions;
 use crate::UnsafelyIgnoreCertificateErrors;
 use deno_core::error::bad_resource;
-use deno_core::error::bad_resource_id;
 use deno_core::error::custom_error;
 use deno_core::error::generic_error;
 use deno_core::error::invalid_hostname;

--- a/ext/net/ops_unix.rs
+++ b/ext/net/ops_unix.rs
@@ -87,7 +87,7 @@ pub(crate) async fn accept_unix(
     .borrow()
     .resource_table
     .get::<UnixListenerResource>(rid)
-    .ok_or_else(|| bad_resource("Listener has been closed"))?;
+    .map_err(|_| bad_resource("Listener has been closed"))?;
   let listener = RcRef::map(&resource, |r| &r.listener)
     .try_borrow_mut()
     .ok_or_else(|| custom_error("Busy", "Listener already in use"))?;
@@ -124,7 +124,7 @@ pub(crate) async fn receive_unix_packet(
     .borrow()
     .resource_table
     .get::<UnixDatagramResource>(rid)
-    .ok_or_else(|| bad_resource("Socket has been closed"))?;
+    .map_err(|_| bad_resource("Socket has been closed"))?;
   let socket = RcRef::map(&resource, |r| &r.socket)
     .try_borrow_mut()
     .ok_or_else(|| custom_error("Busy", "Socket already in use"))?;

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -239,9 +239,7 @@ fn op_encoding_decode(
 ) -> Result<String, AnyError> {
   let DecodeOptions { rid, stream } = options;
 
-  let resource = state
-    .resource_table
-    .get::<TextDecoderResource>(rid)?;
+  let resource = state.resource_table.get::<TextDecoderResource>(rid)?;
 
   let mut decoder = resource.decoder.borrow_mut();
   let fatal = resource.fatal;

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -3,7 +3,6 @@
 mod blob;
 mod message_port;
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::range_error;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -242,8 +242,7 @@ fn op_encoding_decode(
 
   let resource = state
     .resource_table
-    .get::<TextDecoderResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<TextDecoderResource>(rid)?;
 
   let mut decoder = resource.decoder.borrow_mut();
   let fatal = resource.fatal;

--- a/ext/web/message_port.rs
+++ b/ext/web/message_port.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::ZeroCopyBuf;

--- a/ext/web/message_port.rs
+++ b/ext/web/message_port.rs
@@ -191,9 +191,7 @@ pub fn op_message_port_post_message(
     }
   }
 
-  let resource = state
-    .resource_table
-    .get::<MessagePortResource>(rid)?;
+  let resource = state.resource_table.get::<MessagePortResource>(rid)?;
 
   resource.port.send(state, data)
 }

--- a/ext/webgpu/binding.rs
+++ b/ext/webgpu/binding.rs
@@ -84,8 +84,7 @@ pub fn op_webgpu_create_bind_group_layout(
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
-    .get::<super::WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
 
   let mut entries = vec![];
@@ -217,8 +216,7 @@ pub fn op_webgpu_create_pipeline_layout(
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
-    .get::<super::WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
 
   let mut bind_group_layouts = vec![];
@@ -226,8 +224,7 @@ pub fn op_webgpu_create_pipeline_layout(
   for rid in &args.bind_group_layouts {
     let bind_group_layout = state
       .resource_table
-      .get::<WebGpuBindGroupLayout>(*rid)
-      .ok_or_else(bad_resource_id)?;
+      .get::<WebGpuBindGroupLayout>(*rid)?;
     bind_group_layouts.push(bind_group_layout.0);
   }
 
@@ -271,8 +268,7 @@ pub fn op_webgpu_create_bind_group(
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
-    .get::<super::WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
 
   let mut entries = vec![];
@@ -284,15 +280,13 @@ pub fn op_webgpu_create_bind_group(
         "GPUSampler" => {
           let sampler_resource = state
             .resource_table
-            .get::<super::sampler::WebGpuSampler>(entry.resource)
-            .ok_or_else(bad_resource_id)?;
+            .get::<super::sampler::WebGpuSampler>(entry.resource)?;
           wgpu_core::binding_model::BindingResource::Sampler(sampler_resource.0)
         }
         "GPUTextureView" => {
           let texture_view_resource = state
             .resource_table
-            .get::<super::texture::WebGpuTextureView>(entry.resource)
-            .ok_or_else(bad_resource_id)?;
+            .get::<super::texture::WebGpuTextureView>(entry.resource)?;
           wgpu_core::binding_model::BindingResource::TextureView(
             texture_view_resource.0,
           )
@@ -300,8 +294,7 @@ pub fn op_webgpu_create_bind_group(
         "GPUBufferBinding" => {
           let buffer_resource = state
             .resource_table
-            .get::<super::buffer::WebGpuBuffer>(entry.resource)
-            .ok_or_else(bad_resource_id)?;
+            .get::<super::buffer::WebGpuBuffer>(entry.resource)?;
           wgpu_core::binding_model::BindingResource::Buffer(
             wgpu_core::binding_model::BufferBinding {
               buffer_id: buffer_resource.0,
@@ -318,8 +311,7 @@ pub fn op_webgpu_create_bind_group(
 
   let bind_group_layout = state
     .resource_table
-    .get::<WebGpuBindGroupLayout>(args.layout)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuBindGroupLayout>(args.layout)?;
 
   let descriptor = wgpu_core::binding_model::BindGroupDescriptor {
     label: args.label.map(Cow::from),

--- a/ext/webgpu/binding.rs
+++ b/ext/webgpu/binding.rs
@@ -221,9 +221,8 @@ pub fn op_webgpu_create_pipeline_layout(
   let mut bind_group_layouts = vec![];
 
   for rid in &args.bind_group_layouts {
-    let bind_group_layout = state
-      .resource_table
-      .get::<WebGpuBindGroupLayout>(*rid)?;
+    let bind_group_layout =
+      state.resource_table.get::<WebGpuBindGroupLayout>(*rid)?;
     bind_group_layouts.push(bind_group_layout.0);
   }
 
@@ -277,23 +276,26 @@ pub fn op_webgpu_create_bind_group(
       binding: entry.binding,
       resource: match entry.kind.as_str() {
         "GPUSampler" => {
-          let sampler_resource = state
-            .resource_table
-            .get::<super::sampler::WebGpuSampler>(entry.resource)?;
+          let sampler_resource =
+            state
+              .resource_table
+              .get::<super::sampler::WebGpuSampler>(entry.resource)?;
           wgpu_core::binding_model::BindingResource::Sampler(sampler_resource.0)
         }
         "GPUTextureView" => {
-          let texture_view_resource = state
-            .resource_table
-            .get::<super::texture::WebGpuTextureView>(entry.resource)?;
+          let texture_view_resource =
+            state
+              .resource_table
+              .get::<super::texture::WebGpuTextureView>(entry.resource)?;
           wgpu_core::binding_model::BindingResource::TextureView(
             texture_view_resource.0,
           )
         }
         "GPUBufferBinding" => {
-          let buffer_resource = state
-            .resource_table
-            .get::<super::buffer::WebGpuBuffer>(entry.resource)?;
+          let buffer_resource =
+            state
+              .resource_table
+              .get::<super::buffer::WebGpuBuffer>(entry.resource)?;
           wgpu_core::binding_model::BindingResource::Buffer(
             wgpu_core::binding_model::BufferBinding {
               buffer_id: buffer_resource.0,

--- a/ext/webgpu/binding.rs
+++ b/ext/webgpu/binding.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::ResourceId;
 use deno_core::{OpState, Resource};

--- a/ext/webgpu/buffer.rs
+++ b/ext/webgpu/buffer.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;

--- a/ext/webgpu/buffer.rs
+++ b/ext/webgpu/buffer.rs
@@ -50,8 +50,7 @@ pub fn op_webgpu_create_buffer(
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
-    .get::<super::WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
 
   let descriptor = wgpu_core::resource::BufferDescriptor {
@@ -92,13 +91,11 @@ pub async fn op_webgpu_buffer_get_map_async(
     let instance = state_.borrow::<super::Instance>();
     let buffer_resource = state_
       .resource_table
-      .get::<WebGpuBuffer>(args.buffer_rid)
-      .ok_or_else(bad_resource_id)?;
+      .get::<WebGpuBuffer>(args.buffer_rid)?;
     let buffer = buffer_resource.0;
     let device_resource = state_
       .resource_table
-      .get::<super::WebGpuDevice>(args.device_rid)
-      .ok_or_else(bad_resource_id)?;
+      .get::<super::WebGpuDevice>(args.device_rid)?;
     device = device_resource.0;
 
     let boxed_sender = Box::new(sender);
@@ -182,8 +179,7 @@ pub fn op_webgpu_buffer_get_mapped_range(
   let instance = state.borrow::<super::Instance>();
   let buffer_resource = state
     .resource_table
-    .get::<WebGpuBuffer>(args.buffer_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuBuffer>(args.buffer_rid)?;
   let buffer = buffer_resource.0;
 
   let (slice_pointer, range_size) =
@@ -220,13 +216,11 @@ pub fn op_webgpu_buffer_unmap(
 ) -> Result<WebGpuResult, AnyError> {
   let mapped_resource = state
     .resource_table
-    .take::<WebGpuBufferMapped>(args.mapped_rid)
-    .ok_or_else(bad_resource_id)?;
+    .take::<WebGpuBufferMapped>(args.mapped_rid)?;
   let instance = state.borrow::<super::Instance>();
   let buffer_resource = state
     .resource_table
-    .get::<WebGpuBuffer>(args.buffer_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuBuffer>(args.buffer_rid)?;
   let buffer = buffer_resource.0;
 
   let slice_pointer = mapped_resource.0;

--- a/ext/webgpu/buffer.rs
+++ b/ext/webgpu/buffer.rs
@@ -88,9 +88,8 @@ pub async fn op_webgpu_buffer_get_map_async(
   {
     let state_ = state.borrow();
     let instance = state_.borrow::<super::Instance>();
-    let buffer_resource = state_
-      .resource_table
-      .get::<WebGpuBuffer>(args.buffer_rid)?;
+    let buffer_resource =
+      state_.resource_table.get::<WebGpuBuffer>(args.buffer_rid)?;
     let buffer = buffer_resource.0;
     let device_resource = state_
       .resource_table
@@ -176,9 +175,8 @@ pub fn op_webgpu_buffer_get_mapped_range(
 ) -> Result<WebGpuResult, AnyError> {
   let mut zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let instance = state.borrow::<super::Instance>();
-  let buffer_resource = state
-    .resource_table
-    .get::<WebGpuBuffer>(args.buffer_rid)?;
+  let buffer_resource =
+    state.resource_table.get::<WebGpuBuffer>(args.buffer_rid)?;
   let buffer = buffer_resource.0;
 
   let (slice_pointer, range_size) =
@@ -217,9 +215,8 @@ pub fn op_webgpu_buffer_unmap(
     .resource_table
     .take::<WebGpuBufferMapped>(args.mapped_rid)?;
   let instance = state.borrow::<super::Instance>();
-  let buffer_resource = state
-    .resource_table
-    .get::<WebGpuBuffer>(args.buffer_rid)?;
+  let buffer_resource =
+    state.resource_table.get::<WebGpuBuffer>(args.buffer_rid)?;
   let buffer = buffer_resource.0;
 
   let slice_pointer = mapped_resource.0;

--- a/ext/webgpu/bundle.rs
+++ b/ext/webgpu/bundle.rs
@@ -96,9 +96,10 @@ pub fn op_webgpu_render_bundle_encoder_finish(
   args: RenderBundleEncoderFinishArgs,
   _: (),
 ) -> Result<WebGpuResult, AnyError> {
-  let render_bundle_encoder_resource = state
-    .resource_table
-    .take::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
+  let render_bundle_encoder_resource =
+    state
+      .resource_table
+      .take::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
   let render_bundle_encoder = Rc::try_unwrap(render_bundle_encoder_resource)
     .ok()
     .expect("unwrapping render_bundle_encoder_resource should succeed")
@@ -131,12 +132,14 @@ pub fn op_webgpu_render_bundle_encoder_set_bind_group(
   args: RenderBundleEncoderSetBindGroupArgs,
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<WebGpuResult, AnyError> {
-  let bind_group_resource = state
-    .resource_table
-    .get::<super::binding::WebGpuBindGroup>(args.bind_group)?;
-  let render_bundle_encoder_resource = state
-    .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
+  let bind_group_resource =
+    state
+      .resource_table
+      .get::<super::binding::WebGpuBindGroup>(args.bind_group)?;
+  let render_bundle_encoder_resource =
+    state
+      .resource_table
+      .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   // I know this might look like it can be easily deduplicated, but it can not
   // be due to the lifetime of the args.dynamic_offsets_data slice. Because we
@@ -185,9 +188,10 @@ pub fn op_webgpu_render_bundle_encoder_push_debug_group(
   args: RenderBundleEncoderPushDebugGroupArgs,
   _: (),
 ) -> Result<WebGpuResult, AnyError> {
-  let render_bundle_encoder_resource = state
-    .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
+  let render_bundle_encoder_resource =
+    state
+      .resource_table
+      .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   unsafe {
     let label = std::ffi::CString::new(args.group_label).unwrap();
@@ -211,9 +215,10 @@ pub fn op_webgpu_render_bundle_encoder_pop_debug_group(
   args: RenderBundleEncoderPopDebugGroupArgs,
   _: (),
 ) -> Result<WebGpuResult, AnyError> {
-  let render_bundle_encoder_resource = state
-    .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
+  let render_bundle_encoder_resource =
+    state
+      .resource_table
+      .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_pop_debug_group(
     &mut render_bundle_encoder_resource.0.borrow_mut(),
@@ -234,9 +239,10 @@ pub fn op_webgpu_render_bundle_encoder_insert_debug_marker(
   args: RenderBundleEncoderInsertDebugMarkerArgs,
   _: (),
 ) -> Result<WebGpuResult, AnyError> {
-  let render_bundle_encoder_resource = state
-    .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
+  let render_bundle_encoder_resource =
+    state
+      .resource_table
+      .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   unsafe {
     let label = std::ffi::CString::new(args.marker_label).unwrap();
@@ -261,12 +267,14 @@ pub fn op_webgpu_render_bundle_encoder_set_pipeline(
   args: RenderBundleEncoderSetPipelineArgs,
   _: (),
 ) -> Result<WebGpuResult, AnyError> {
-  let render_pipeline_resource = state
-    .resource_table
-    .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)?;
-  let render_bundle_encoder_resource = state
-    .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
+  let render_pipeline_resource =
+    state
+      .resource_table
+      .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)?;
+  let render_bundle_encoder_resource =
+    state
+      .resource_table
+      .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_pipeline(
     &mut render_bundle_encoder_resource.0.borrow_mut(),
@@ -294,9 +302,10 @@ pub fn op_webgpu_render_bundle_encoder_set_index_buffer(
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.buffer)?;
-  let render_bundle_encoder_resource = state
-    .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
+  let render_bundle_encoder_resource =
+    state
+      .resource_table
+      .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   render_bundle_encoder_resource
     .0
@@ -329,9 +338,10 @@ pub fn op_webgpu_render_bundle_encoder_set_vertex_buffer(
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.buffer)?;
-  let render_bundle_encoder_resource = state
-    .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
+  let render_bundle_encoder_resource =
+    state
+      .resource_table
+      .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_vertex_buffer(
     &mut render_bundle_encoder_resource.0.borrow_mut(),
@@ -359,9 +369,10 @@ pub fn op_webgpu_render_bundle_encoder_draw(
   args: RenderBundleEncoderDrawArgs,
   _: (),
 ) -> Result<WebGpuResult, AnyError> {
-  let render_bundle_encoder_resource = state
-    .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
+  let render_bundle_encoder_resource =
+    state
+      .resource_table
+      .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw(
     &mut render_bundle_encoder_resource.0.borrow_mut(),
@@ -390,9 +401,10 @@ pub fn op_webgpu_render_bundle_encoder_draw_indexed(
   args: RenderBundleEncoderDrawIndexedArgs,
   _: (),
 ) -> Result<WebGpuResult, AnyError> {
-  let render_bundle_encoder_resource = state
-    .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
+  let render_bundle_encoder_resource =
+    state
+      .resource_table
+      .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indexed(
     &mut render_bundle_encoder_resource.0.borrow_mut(),
@@ -422,9 +434,10 @@ pub fn op_webgpu_render_bundle_encoder_draw_indirect(
   let buffer_resource = state
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)?;
-  let render_bundle_encoder_resource = state
-    .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
+  let render_bundle_encoder_resource =
+    state
+      .resource_table
+      .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indirect(
     &mut render_bundle_encoder_resource.0.borrow_mut(),

--- a/ext/webgpu/bundle.rs
+++ b/ext/webgpu/bundle.rs
@@ -47,8 +47,7 @@ pub fn op_webgpu_create_render_bundle_encoder(
 ) -> Result<WebGpuResult, AnyError> {
   let device_resource = state
     .resource_table
-    .get::<super::WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
 
   let mut color_formats = vec![];
@@ -100,8 +99,7 @@ pub fn op_webgpu_render_bundle_encoder_finish(
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
-    .take::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .take::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
   let render_bundle_encoder = Rc::try_unwrap(render_bundle_encoder_resource)
     .ok()
     .expect("unwrapping render_bundle_encoder_resource should succeed")
@@ -136,12 +134,10 @@ pub fn op_webgpu_render_bundle_encoder_set_bind_group(
 ) -> Result<WebGpuResult, AnyError> {
   let bind_group_resource = state
     .resource_table
-    .get::<super::binding::WebGpuBindGroup>(args.bind_group)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::binding::WebGpuBindGroup>(args.bind_group)?;
   let render_bundle_encoder_resource = state
     .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   // I know this might look like it can be easily deduplicated, but it can not
   // be due to the lifetime of the args.dynamic_offsets_data slice. Because we
@@ -192,8 +188,7 @@ pub fn op_webgpu_render_bundle_encoder_push_debug_group(
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   unsafe {
     let label = std::ffi::CString::new(args.group_label).unwrap();
@@ -219,8 +214,7 @@ pub fn op_webgpu_render_bundle_encoder_pop_debug_group(
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_pop_debug_group(
     &mut render_bundle_encoder_resource.0.borrow_mut(),
@@ -243,8 +237,7 @@ pub fn op_webgpu_render_bundle_encoder_insert_debug_marker(
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   unsafe {
     let label = std::ffi::CString::new(args.marker_label).unwrap();
@@ -271,12 +264,10 @@ pub fn op_webgpu_render_bundle_encoder_set_pipeline(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pipeline_resource = state
     .resource_table
-    .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)?;
   let render_bundle_encoder_resource = state
     .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_pipeline(
     &mut render_bundle_encoder_resource.0.borrow_mut(),
@@ -303,12 +294,10 @@ pub fn op_webgpu_render_bundle_encoder_set_index_buffer(
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.buffer)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.buffer)?;
   let render_bundle_encoder_resource = state
     .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   render_bundle_encoder_resource
     .0
@@ -340,12 +329,10 @@ pub fn op_webgpu_render_bundle_encoder_set_vertex_buffer(
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.buffer)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.buffer)?;
   let render_bundle_encoder_resource = state
     .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_vertex_buffer(
     &mut render_bundle_encoder_resource.0.borrow_mut(),
@@ -375,8 +362,7 @@ pub fn op_webgpu_render_bundle_encoder_draw(
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw(
     &mut render_bundle_encoder_resource.0.borrow_mut(),
@@ -407,8 +393,7 @@ pub fn op_webgpu_render_bundle_encoder_draw_indexed(
 ) -> Result<WebGpuResult, AnyError> {
   let render_bundle_encoder_resource = state
     .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indexed(
     &mut render_bundle_encoder_resource.0.borrow_mut(),
@@ -437,12 +422,10 @@ pub fn op_webgpu_render_bundle_encoder_draw_indirect(
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)?;
   let render_bundle_encoder_resource = state
     .resource_table
-    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderBundleEncoder>(args.render_bundle_encoder_rid)?;
 
   wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indirect(
     &mut render_bundle_encoder_resource.0.borrow_mut(),

--- a/ext/webgpu/bundle.rs
+++ b/ext/webgpu/bundle.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
 use deno_core::ResourceId;

--- a/ext/webgpu/command_encoder.rs
+++ b/ext/webgpu/command_encoder.rs
@@ -53,8 +53,7 @@ pub fn op_webgpu_create_command_encoder(
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
-    .get::<super::WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
 
   let descriptor = wgpu_types::CommandEncoderDescriptor {
@@ -109,16 +108,14 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
 ) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
-    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
 
   let mut color_attachments = vec![];
 
   for color_attachment in args.color_attachments {
     let texture_view_resource = state
       .resource_table
-      .get::<super::texture::WebGpuTextureView>(color_attachment.view)
-      .ok_or_else(bad_resource_id)?;
+      .get::<super::texture::WebGpuTextureView>(color_attachment.view)?;
 
     let attachment = wgpu_core::command::RenderPassColorAttachment {
       view: texture_view_resource.0,
@@ -128,7 +125,6 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
           state
             .resource_table
             .get::<super::texture::WebGpuTextureView>(rid)
-            .ok_or_else(bad_resource_id)
         })
         .transpose()?
         .map(|texture| texture.0),
@@ -169,8 +165,7 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
   if let Some(attachment) = args.depth_stencil_attachment {
     let texture_view_resource = state
       .resource_table
-      .get::<super::texture::WebGpuTextureView>(attachment.view)
-      .ok_or_else(bad_resource_id)?;
+      .get::<super::texture::WebGpuTextureView>(attachment.view)?;
 
     depth_stencil_attachment =
       Some(wgpu_core::command::RenderPassDepthStencilAttachment {
@@ -242,8 +237,7 @@ pub fn op_webgpu_command_encoder_begin_compute_pass(
 ) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
-    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
 
   let descriptor = wgpu_core::command::ComputePassDescriptor {
     label: args.label.map(Cow::from),
@@ -282,18 +276,15 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_buffer(
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
-    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
   let source_buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.source)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.source)?;
   let source_buffer = source_buffer_resource.0;
   let destination_buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.destination)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.destination)?;
   let destination_buffer = destination_buffer_resource.0;
 
   gfx_ok!(command_encoder => instance.command_encoder_copy_buffer_to_buffer(
@@ -349,17 +340,14 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_texture(
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
-    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
   let source_buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.source.buffer)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.source.buffer)?;
   let destination_texture_resource = state
     .resource_table
-    .get::<super::texture::WebGpuTexture>(args.destination.texture)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::texture::WebGpuTexture>(args.destination.texture)?;
 
   let source = wgpu_core::command::ImageCopyBuffer {
     buffer: source_buffer_resource.0,
@@ -410,17 +398,14 @@ pub fn op_webgpu_command_encoder_copy_texture_to_buffer(
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
-    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
   let source_texture_resource = state
     .resource_table
-    .get::<super::texture::WebGpuTexture>(args.source.texture)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::texture::WebGpuTexture>(args.source.texture)?;
   let destination_buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.destination.buffer)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.destination.buffer)?;
 
   let source = wgpu_core::command::ImageCopyTexture {
     texture: source_texture_resource.0,
@@ -474,17 +459,14 @@ pub fn op_webgpu_command_encoder_copy_texture_to_texture(
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
-    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
   let source_texture_resource = state
     .resource_table
-    .get::<super::texture::WebGpuTexture>(args.source.texture)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::texture::WebGpuTexture>(args.source.texture)?;
   let destination_texture_resource = state
     .resource_table
-    .get::<super::texture::WebGpuTexture>(args.destination.texture)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::texture::WebGpuTexture>(args.destination.texture)?;
 
   let source = wgpu_core::command::ImageCopyTexture {
     texture: source_texture_resource.0,
@@ -536,8 +518,7 @@ pub fn op_webgpu_command_encoder_push_debug_group(
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
-    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
 
   gfx_ok!(command_encoder => instance
@@ -558,8 +539,7 @@ pub fn op_webgpu_command_encoder_pop_debug_group(
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
-    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
 
   gfx_ok!(command_encoder => instance.command_encoder_pop_debug_group(command_encoder))
@@ -580,8 +560,7 @@ pub fn op_webgpu_command_encoder_insert_debug_marker(
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
-    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
 
   gfx_ok!(command_encoder => instance.command_encoder_insert_debug_marker(
@@ -606,13 +585,11 @@ pub fn op_webgpu_command_encoder_write_timestamp(
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
-    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
   let query_set_resource = state
     .resource_table
-    .get::<super::WebGpuQuerySet>(args.query_set)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuQuerySet>(args.query_set)?;
 
   gfx_ok!(command_encoder => instance.command_encoder_write_timestamp(
     command_encoder,
@@ -640,17 +617,14 @@ pub fn op_webgpu_command_encoder_resolve_query_set(
   let instance = state.borrow::<super::Instance>();
   let command_encoder_resource = state
     .resource_table
-    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
   let query_set_resource = state
     .resource_table
-    .get::<super::WebGpuQuerySet>(args.query_set)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuQuerySet>(args.query_set)?;
   let destination_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.destination)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.destination)?;
 
   gfx_ok!(command_encoder => instance.command_encoder_resolve_query_set(
     command_encoder,
@@ -676,8 +650,7 @@ pub fn op_webgpu_command_encoder_finish(
 ) -> Result<WebGpuResult, AnyError> {
   let command_encoder_resource = state
     .resource_table
-    .take::<WebGpuCommandEncoder>(args.command_encoder_rid)
-    .ok_or_else(bad_resource_id)?;
+    .take::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
   let instance = state.borrow::<super::Instance>();
 

--- a/ext/webgpu/command_encoder.rs
+++ b/ext/webgpu/command_encoder.rs
@@ -112,9 +112,10 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
   let mut color_attachments = vec![];
 
   for color_attachment in args.color_attachments {
-    let texture_view_resource = state
-      .resource_table
-      .get::<super::texture::WebGpuTextureView>(color_attachment.view)?;
+    let texture_view_resource =
+      state
+        .resource_table
+        .get::<super::texture::WebGpuTextureView>(color_attachment.view)?;
 
     let attachment = wgpu_core::command::RenderPassColorAttachment {
       view: texture_view_resource.0,
@@ -162,9 +163,10 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
   let mut depth_stencil_attachment = None;
 
   if let Some(attachment) = args.depth_stencil_attachment {
-    let texture_view_resource = state
-      .resource_table
-      .get::<super::texture::WebGpuTextureView>(attachment.view)?;
+    let texture_view_resource =
+      state
+        .resource_table
+        .get::<super::texture::WebGpuTextureView>(attachment.view)?;
 
     depth_stencil_attachment =
       Some(wgpu_core::command::RenderPassDepthStencilAttachment {
@@ -277,13 +279,15 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_buffer(
     .resource_table
     .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
-  let source_buffer_resource = state
-    .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.source)?;
+  let source_buffer_resource =
+    state
+      .resource_table
+      .get::<super::buffer::WebGpuBuffer>(args.source)?;
   let source_buffer = source_buffer_resource.0;
-  let destination_buffer_resource = state
-    .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.destination)?;
+  let destination_buffer_resource =
+    state
+      .resource_table
+      .get::<super::buffer::WebGpuBuffer>(args.destination)?;
   let destination_buffer = destination_buffer_resource.0;
 
   gfx_ok!(command_encoder => instance.command_encoder_copy_buffer_to_buffer(
@@ -341,12 +345,14 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_texture(
     .resource_table
     .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
-  let source_buffer_resource = state
-    .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.source.buffer)?;
-  let destination_texture_resource = state
-    .resource_table
-    .get::<super::texture::WebGpuTexture>(args.destination.texture)?;
+  let source_buffer_resource =
+    state
+      .resource_table
+      .get::<super::buffer::WebGpuBuffer>(args.source.buffer)?;
+  let destination_texture_resource =
+    state
+      .resource_table
+      .get::<super::texture::WebGpuTexture>(args.destination.texture)?;
 
   let source = wgpu_core::command::ImageCopyBuffer {
     buffer: source_buffer_resource.0,
@@ -399,12 +405,14 @@ pub fn op_webgpu_command_encoder_copy_texture_to_buffer(
     .resource_table
     .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
-  let source_texture_resource = state
-    .resource_table
-    .get::<super::texture::WebGpuTexture>(args.source.texture)?;
-  let destination_buffer_resource = state
-    .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.destination.buffer)?;
+  let source_texture_resource =
+    state
+      .resource_table
+      .get::<super::texture::WebGpuTexture>(args.source.texture)?;
+  let destination_buffer_resource =
+    state
+      .resource_table
+      .get::<super::buffer::WebGpuBuffer>(args.destination.buffer)?;
 
   let source = wgpu_core::command::ImageCopyTexture {
     texture: source_texture_resource.0,
@@ -460,12 +468,14 @@ pub fn op_webgpu_command_encoder_copy_texture_to_texture(
     .resource_table
     .get::<WebGpuCommandEncoder>(args.command_encoder_rid)?;
   let command_encoder = command_encoder_resource.0;
-  let source_texture_resource = state
-    .resource_table
-    .get::<super::texture::WebGpuTexture>(args.source.texture)?;
-  let destination_texture_resource = state
-    .resource_table
-    .get::<super::texture::WebGpuTexture>(args.destination.texture)?;
+  let source_texture_resource =
+    state
+      .resource_table
+      .get::<super::texture::WebGpuTexture>(args.source.texture)?;
+  let destination_texture_resource =
+    state
+      .resource_table
+      .get::<super::texture::WebGpuTexture>(args.destination.texture)?;
 
   let source = wgpu_core::command::ImageCopyTexture {
     texture: source_texture_resource.0,

--- a/ext/webgpu/command_encoder.rs
+++ b/ext/webgpu/command_encoder.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::ResourceId;
 use deno_core::{OpState, Resource};

--- a/ext/webgpu/compute_pass.rs
+++ b/ext/webgpu/compute_pass.rs
@@ -32,9 +32,10 @@ pub fn op_webgpu_compute_pass_set_pipeline(
   args: ComputePassSetPipelineArgs,
   _: (),
 ) -> Result<WebGpuResult, AnyError> {
-  let compute_pipeline_resource = state
-    .resource_table
-    .get::<super::pipeline::WebGpuComputePipeline>(args.pipeline)?;
+  let compute_pipeline_resource =
+    state
+      .resource_table
+      .get::<super::pipeline::WebGpuComputePipeline>(args.pipeline)?;
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)?;
@@ -199,8 +200,8 @@ pub fn op_webgpu_compute_pass_end_pass(
   let command_encoder_resource = state
     .resource_table
     .get::<super::command_encoder::WebGpuCommandEncoder>(
-      args.command_encoder_rid,
-    )?;
+    args.command_encoder_rid,
+  )?;
   let command_encoder = command_encoder_resource.0;
   let compute_pass_resource = state
     .resource_table
@@ -230,9 +231,10 @@ pub fn op_webgpu_compute_pass_set_bind_group(
   args: ComputePassSetBindGroupArgs,
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<WebGpuResult, AnyError> {
-  let bind_group_resource = state
-    .resource_table
-    .get::<super::binding::WebGpuBindGroup>(args.bind_group)?;
+  let bind_group_resource =
+    state
+      .resource_table
+      .get::<super::binding::WebGpuBindGroup>(args.bind_group)?;
   let compute_pass_resource = state
     .resource_table
     .get::<WebGpuComputePass>(args.compute_pass_rid)?;

--- a/ext/webgpu/compute_pass.rs
+++ b/ext/webgpu/compute_pass.rs
@@ -35,12 +35,10 @@ pub fn op_webgpu_compute_pass_set_pipeline(
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pipeline_resource = state
     .resource_table
-    .get::<super::pipeline::WebGpuComputePipeline>(args.pipeline)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::pipeline::WebGpuComputePipeline>(args.pipeline)?;
   let compute_pass_resource = state
     .resource_table
-    .get::<WebGpuComputePass>(args.compute_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuComputePass>(args.compute_pass_rid)?;
 
   wgpu_core::command::compute_ffi::wgpu_compute_pass_set_pipeline(
     &mut compute_pass_resource.0.borrow_mut(),
@@ -66,8 +64,7 @@ pub fn op_webgpu_compute_pass_dispatch(
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
-    .get::<WebGpuComputePass>(args.compute_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuComputePass>(args.compute_pass_rid)?;
 
   wgpu_core::command::compute_ffi::wgpu_compute_pass_dispatch(
     &mut compute_pass_resource.0.borrow_mut(),
@@ -94,12 +91,10 @@ pub fn op_webgpu_compute_pass_dispatch_indirect(
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)?;
   let compute_pass_resource = state
     .resource_table
-    .get::<WebGpuComputePass>(args.compute_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuComputePass>(args.compute_pass_rid)?;
 
   wgpu_core::command::compute_ffi::wgpu_compute_pass_dispatch_indirect(
     &mut compute_pass_resource.0.borrow_mut(),
@@ -125,12 +120,10 @@ pub fn op_webgpu_compute_pass_begin_pipeline_statistics_query(
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
-    .get::<WebGpuComputePass>(args.compute_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuComputePass>(args.compute_pass_rid)?;
   let query_set_resource = state
     .resource_table
-    .get::<super::WebGpuQuerySet>(args.query_set)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuQuerySet>(args.query_set)?;
 
   wgpu_core::command::compute_ffi::wgpu_compute_pass_begin_pipeline_statistics_query(
     &mut compute_pass_resource.0.borrow_mut(),
@@ -154,8 +147,7 @@ pub fn op_webgpu_compute_pass_end_pipeline_statistics_query(
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
-    .get::<WebGpuComputePass>(args.compute_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuComputePass>(args.compute_pass_rid)?;
 
   wgpu_core::command::compute_ffi::wgpu_compute_pass_end_pipeline_statistics_query(
     &mut compute_pass_resource.0.borrow_mut(),
@@ -179,12 +171,10 @@ pub fn op_webgpu_compute_pass_write_timestamp(
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
-    .get::<WebGpuComputePass>(args.compute_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuComputePass>(args.compute_pass_rid)?;
   let query_set_resource = state
     .resource_table
-    .get::<super::WebGpuQuerySet>(args.query_set)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuQuerySet>(args.query_set)?;
 
   wgpu_core::command::compute_ffi::wgpu_compute_pass_write_timestamp(
     &mut compute_pass_resource.0.borrow_mut(),
@@ -211,13 +201,11 @@ pub fn op_webgpu_compute_pass_end_pass(
     .resource_table
     .get::<super::command_encoder::WebGpuCommandEncoder>(
       args.command_encoder_rid,
-    )
-    .ok_or_else(bad_resource_id)?;
+    )?;
   let command_encoder = command_encoder_resource.0;
   let compute_pass_resource = state
     .resource_table
-    .take::<WebGpuComputePass>(args.compute_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .take::<WebGpuComputePass>(args.compute_pass_rid)?;
   let compute_pass = &compute_pass_resource.0.borrow();
   let instance = state.borrow::<super::Instance>();
 
@@ -245,12 +233,10 @@ pub fn op_webgpu_compute_pass_set_bind_group(
 ) -> Result<WebGpuResult, AnyError> {
   let bind_group_resource = state
     .resource_table
-    .get::<super::binding::WebGpuBindGroup>(args.bind_group)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::binding::WebGpuBindGroup>(args.bind_group)?;
   let compute_pass_resource = state
     .resource_table
-    .get::<WebGpuComputePass>(args.compute_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuComputePass>(args.compute_pass_rid)?;
 
   unsafe {
     wgpu_core::command::compute_ffi::wgpu_compute_pass_set_bind_group(
@@ -288,8 +274,7 @@ pub fn op_webgpu_compute_pass_push_debug_group(
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
-    .get::<WebGpuComputePass>(args.compute_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuComputePass>(args.compute_pass_rid)?;
 
   unsafe {
     let label = std::ffi::CString::new(args.group_label).unwrap();
@@ -316,8 +301,7 @@ pub fn op_webgpu_compute_pass_pop_debug_group(
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
-    .get::<WebGpuComputePass>(args.compute_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuComputePass>(args.compute_pass_rid)?;
 
   wgpu_core::command::compute_ffi::wgpu_compute_pass_pop_debug_group(
     &mut compute_pass_resource.0.borrow_mut(),
@@ -340,8 +324,7 @@ pub fn op_webgpu_compute_pass_insert_debug_marker(
 ) -> Result<WebGpuResult, AnyError> {
   let compute_pass_resource = state
     .resource_table
-    .get::<WebGpuComputePass>(args.compute_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuComputePass>(args.compute_pass_rid)?;
 
   unsafe {
     let label = std::ffi::CString::new(args.marker_label).unwrap();

--- a/ext/webgpu/compute_pass.rs
+++ b/ext/webgpu/compute_pass.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
 use deno_core::ResourceId;

--- a/ext/webgpu/lib.rs
+++ b/ext/webgpu/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::AnyError;
 use deno_core::error::not_supported;
+use deno_core::error::AnyError;
 use deno_core::include_js_files;
 use deno_core::op_async;
 use deno_core::op_sync;
@@ -532,9 +532,8 @@ pub fn op_webgpu_create_query_set(
   args: CreateQuerySetArgs,
   _: (),
 ) -> Result<WebGpuResult, AnyError> {
-  let device_resource = state
-    .resource_table
-    .get::<WebGpuDevice>(args.device_rid)?;
+  let device_resource =
+    state.resource_table.get::<WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
   let instance = &state.borrow::<Instance>();
 

--- a/ext/webgpu/lib.rs
+++ b/ext/webgpu/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::AnyError;
-use deno_core::error::{bad_resource_id, not_supported};
+use deno_core::error::not_supported;
 use deno_core::include_js_files;
 use deno_core::op_async;
 use deno_core::op_sync;

--- a/ext/webgpu/lib.rs
+++ b/ext/webgpu/lib.rs
@@ -398,8 +398,7 @@ pub async fn op_webgpu_request_device(
   let mut state = state.borrow_mut();
   let adapter_resource = state
     .resource_table
-    .get::<WebGpuAdapter>(args.adapter_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuAdapter>(args.adapter_rid)?;
   let adapter = adapter_resource.0;
   let instance = state.borrow::<Instance>();
 
@@ -535,8 +534,7 @@ pub fn op_webgpu_create_query_set(
 ) -> Result<WebGpuResult, AnyError> {
   let device_resource = state
     .resource_table
-    .get::<WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
   let instance = &state.borrow::<Instance>();
 

--- a/ext/webgpu/pipeline.rs
+++ b/ext/webgpu/pipeline.rs
@@ -173,15 +173,13 @@ pub fn op_webgpu_create_compute_pipeline(
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
-    .get::<super::WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
 
   let pipeline_layout = if let Some(rid) = args.layout {
     let id = state
       .resource_table
-      .get::<WebGpuPipelineLayout>(rid)
-      .ok_or_else(bad_resource_id)?;
+      .get::<WebGpuPipelineLayout>(rid)?;
     Some(id.0)
   } else {
     None
@@ -189,8 +187,7 @@ pub fn op_webgpu_create_compute_pipeline(
 
   let compute_shader_module_resource = state
     .resource_table
-    .get::<super::shader::WebGpuShaderModule>(args.compute.module)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::shader::WebGpuShaderModule>(args.compute.module)?;
 
   let descriptor = wgpu_core::pipeline::ComputePipelineDescriptor {
     label: args.label.map(Cow::from),
@@ -246,8 +243,7 @@ pub fn op_webgpu_compute_pipeline_get_bind_group_layout(
   let instance = state.borrow::<super::Instance>();
   let compute_pipeline_resource = state
     .resource_table
-    .get::<WebGpuComputePipeline>(args.compute_pipeline_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuComputePipeline>(args.compute_pipeline_rid)?;
   let compute_pipeline = compute_pipeline_resource.0;
 
   let (bind_group_layout, maybe_err) = gfx_select!(compute_pipeline => instance.compute_pipeline_get_bind_group_layout(compute_pipeline, args.index, std::marker::PhantomData));
@@ -464,15 +460,13 @@ pub fn op_webgpu_create_render_pipeline(
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
-    .get::<super::WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
 
   let layout = if let Some(rid) = args.layout {
     let pipeline_layout_resource = state
       .resource_table
-      .get::<WebGpuPipelineLayout>(rid)
-      .ok_or_else(bad_resource_id)?;
+      .get::<WebGpuPipelineLayout>(rid)?;
     Some(pipeline_layout_resource.0)
   } else {
     None
@@ -480,8 +474,7 @@ pub fn op_webgpu_create_render_pipeline(
 
   let vertex_shader_module_resource = state
     .resource_table
-    .get::<super::shader::WebGpuShaderModule>(args.vertex.module)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::shader::WebGpuShaderModule>(args.vertex.module)?;
 
   let descriptor = wgpu_core::pipeline::RenderPipelineDescriptor {
     label: args.label.map(Cow::from),
@@ -601,7 +594,6 @@ pub fn op_webgpu_create_render_pipeline(
       let fragment_shader_module_resource = state
         .resource_table
         .get::<super::shader::WebGpuShaderModule>(fragment.module)
-        .ok_or_else(bad_resource_id)
         .unwrap();
 
       wgpu_core::pipeline::FragmentState {
@@ -666,8 +658,7 @@ pub fn op_webgpu_render_pipeline_get_bind_group_layout(
   let instance = state.borrow::<super::Instance>();
   let render_pipeline_resource = state
     .resource_table
-    .get::<WebGpuRenderPipeline>(args.render_pipeline_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPipeline>(args.render_pipeline_rid)?;
   let render_pipeline = render_pipeline_resource.0;
 
   let (bind_group_layout, maybe_err) = gfx_select!(render_pipeline => instance.render_pipeline_get_bind_group_layout(render_pipeline, args.index, std::marker::PhantomData));

--- a/ext/webgpu/pipeline.rs
+++ b/ext/webgpu/pipeline.rs
@@ -176,17 +176,16 @@ pub fn op_webgpu_create_compute_pipeline(
   let device = device_resource.0;
 
   let pipeline_layout = if let Some(rid) = args.layout {
-    let id = state
-      .resource_table
-      .get::<WebGpuPipelineLayout>(rid)?;
+    let id = state.resource_table.get::<WebGpuPipelineLayout>(rid)?;
     Some(id.0)
   } else {
     None
   };
 
-  let compute_shader_module_resource = state
-    .resource_table
-    .get::<super::shader::WebGpuShaderModule>(args.compute.module)?;
+  let compute_shader_module_resource =
+    state
+      .resource_table
+      .get::<super::shader::WebGpuShaderModule>(args.compute.module)?;
 
   let descriptor = wgpu_core::pipeline::ComputePipelineDescriptor {
     label: args.label.map(Cow::from),
@@ -463,17 +462,17 @@ pub fn op_webgpu_create_render_pipeline(
   let device = device_resource.0;
 
   let layout = if let Some(rid) = args.layout {
-    let pipeline_layout_resource = state
-      .resource_table
-      .get::<WebGpuPipelineLayout>(rid)?;
+    let pipeline_layout_resource =
+      state.resource_table.get::<WebGpuPipelineLayout>(rid)?;
     Some(pipeline_layout_resource.0)
   } else {
     None
   };
 
-  let vertex_shader_module_resource = state
-    .resource_table
-    .get::<super::shader::WebGpuShaderModule>(args.vertex.module)?;
+  let vertex_shader_module_resource =
+    state
+      .resource_table
+      .get::<super::shader::WebGpuShaderModule>(args.vertex.module)?;
 
   let descriptor = wgpu_core::pipeline::RenderPipelineDescriptor {
     label: args.label.map(Cow::from),

--- a/ext/webgpu/pipeline.rs
+++ b/ext/webgpu/pipeline.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::ResourceId;
 use deno_core::{OpState, Resource};

--- a/ext/webgpu/queue.rs
+++ b/ext/webgpu/queue.rs
@@ -2,7 +2,6 @@
 
 use std::num::NonZeroU32;
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
 use deno_core::OpState;

--- a/ext/webgpu/queue.rs
+++ b/ext/webgpu/queue.rs
@@ -29,8 +29,7 @@ pub fn op_webgpu_queue_submit(
   let instance = state.borrow::<super::Instance>();
   let queue_resource = state
     .resource_table
-    .get::<WebGpuQueue>(args.queue_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuQueue>(args.queue_rid)?;
   let queue = queue_resource.0;
 
   let mut ids = vec![];
@@ -38,8 +37,7 @@ pub fn op_webgpu_queue_submit(
   for rid in args.command_buffers {
     let buffer_resource = state
       .resource_table
-      .get::<super::command_encoder::WebGpuCommandBuffer>(rid)
-      .ok_or_else(bad_resource_id)?;
+      .get::<super::command_encoder::WebGpuCommandBuffer>(rid)?;
     ids.push(buffer_resource.0);
   }
 
@@ -76,13 +74,11 @@ pub fn op_webgpu_write_buffer(
   let instance = state.borrow::<super::Instance>();
   let buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.buffer)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.buffer)?;
   let buffer = buffer_resource.0;
   let queue_resource = state
     .resource_table
-    .get::<WebGpuQueue>(args.queue_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuQueue>(args.queue_rid)?;
   let queue = queue_resource.0;
 
   let data = match args.size {
@@ -118,12 +114,10 @@ pub fn op_webgpu_write_texture(
   let instance = state.borrow::<super::Instance>();
   let texture_resource = state
     .resource_table
-    .get::<super::texture::WebGpuTexture>(args.destination.texture)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::texture::WebGpuTexture>(args.destination.texture)?;
   let queue_resource = state
     .resource_table
-    .get::<WebGpuQueue>(args.queue_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuQueue>(args.queue_rid)?;
   let queue = queue_resource.0;
 
   let destination = wgpu_core::command::ImageCopyTexture {

--- a/ext/webgpu/queue.rs
+++ b/ext/webgpu/queue.rs
@@ -26,17 +26,17 @@ pub fn op_webgpu_queue_submit(
   _: (),
 ) -> Result<WebGpuResult, AnyError> {
   let instance = state.borrow::<super::Instance>();
-  let queue_resource = state
-    .resource_table
-    .get::<WebGpuQueue>(args.queue_rid)?;
+  let queue_resource =
+    state.resource_table.get::<WebGpuQueue>(args.queue_rid)?;
   let queue = queue_resource.0;
 
   let mut ids = vec![];
 
   for rid in args.command_buffers {
-    let buffer_resource = state
-      .resource_table
-      .get::<super::command_encoder::WebGpuCommandBuffer>(rid)?;
+    let buffer_resource =
+      state
+        .resource_table
+        .get::<super::command_encoder::WebGpuCommandBuffer>(rid)?;
     ids.push(buffer_resource.0);
   }
 
@@ -75,9 +75,8 @@ pub fn op_webgpu_write_buffer(
     .resource_table
     .get::<super::buffer::WebGpuBuffer>(args.buffer)?;
   let buffer = buffer_resource.0;
-  let queue_resource = state
-    .resource_table
-    .get::<WebGpuQueue>(args.queue_rid)?;
+  let queue_resource =
+    state.resource_table.get::<WebGpuQueue>(args.queue_rid)?;
   let queue = queue_resource.0;
 
   let data = match args.size {
@@ -114,9 +113,8 @@ pub fn op_webgpu_write_texture(
   let texture_resource = state
     .resource_table
     .get::<super::texture::WebGpuTexture>(args.destination.texture)?;
-  let queue_resource = state
-    .resource_table
-    .get::<WebGpuQueue>(args.queue_rid)?;
+  let queue_resource =
+    state.resource_table.get::<WebGpuQueue>(args.queue_rid)?;
   let queue = queue_resource.0;
 
   let destination = wgpu_core::command::ImageCopyTexture {

--- a/ext/webgpu/render_pass.rs
+++ b/ext/webgpu/render_pass.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;

--- a/ext/webgpu/render_pass.rs
+++ b/ext/webgpu/render_pass.rs
@@ -41,8 +41,7 @@ pub fn op_webgpu_render_pass_set_viewport(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_set_viewport(
     &mut render_pass_resource.0.borrow_mut(),
@@ -74,8 +73,7 @@ pub fn op_webgpu_render_pass_set_scissor_rect(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_set_scissor_rect(
     &mut render_pass_resource.0.borrow_mut(),
@@ -111,8 +109,7 @@ pub fn op_webgpu_render_pass_set_blend_constant(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_set_blend_constant(
     &mut render_pass_resource.0.borrow_mut(),
@@ -141,8 +138,7 @@ pub fn op_webgpu_render_pass_set_stencil_reference(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_set_stencil_reference(
     &mut render_pass_resource.0.borrow_mut(),
@@ -167,12 +163,10 @@ pub fn op_webgpu_render_pass_begin_pipeline_statistics_query(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
   let query_set_resource = state
     .resource_table
-    .get::<super::WebGpuQuerySet>(args.query_set)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuQuerySet>(args.query_set)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_begin_pipeline_statistics_query(
     &mut render_pass_resource.0.borrow_mut(),
@@ -196,8 +190,7 @@ pub fn op_webgpu_render_pass_end_pipeline_statistics_query(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_end_pipeline_statistics_query(
     &mut render_pass_resource.0.borrow_mut(),
@@ -221,12 +214,10 @@ pub fn op_webgpu_render_pass_write_timestamp(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
   let query_set_resource = state
     .resource_table
-    .get::<super::WebGpuQuerySet>(args.query_set)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuQuerySet>(args.query_set)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_write_timestamp(
     &mut render_pass_resource.0.borrow_mut(),
@@ -254,15 +245,13 @@ pub fn op_webgpu_render_pass_execute_bundles(
   for rid in &args.bundles {
     let render_bundle_resource = state
       .resource_table
-      .get::<super::bundle::WebGpuRenderBundle>(*rid)
-      .ok_or_else(bad_resource_id)?;
+      .get::<super::bundle::WebGpuRenderBundle>(*rid)?;
     render_bundle_ids.push(render_bundle_resource.0);
   }
 
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   unsafe {
     wgpu_core::command::render_ffi::wgpu_render_pass_execute_bundles(
@@ -291,13 +280,11 @@ pub fn op_webgpu_render_pass_end_pass(
     .resource_table
     .get::<super::command_encoder::WebGpuCommandEncoder>(
       args.command_encoder_rid,
-    )
-    .ok_or_else(bad_resource_id)?;
+    )?;
   let command_encoder = command_encoder_resource.0;
   let render_pass_resource = state
     .resource_table
-    .take::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .take::<WebGpuRenderPass>(args.render_pass_rid)?;
   let render_pass = &render_pass_resource.0.borrow();
   let instance = state.borrow::<super::Instance>();
 
@@ -322,12 +309,10 @@ pub fn op_webgpu_render_pass_set_bind_group(
 ) -> Result<WebGpuResult, AnyError> {
   let bind_group_resource = state
     .resource_table
-    .get::<super::binding::WebGpuBindGroup>(args.bind_group)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::binding::WebGpuBindGroup>(args.bind_group)?;
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   // I know this might look like it can be easily deduplicated, but it can not
   // be due to the lifetime of the args.dynamic_offsets_data slice. Because we
@@ -378,8 +363,7 @@ pub fn op_webgpu_render_pass_push_debug_group(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   unsafe {
     let label = std::ffi::CString::new(args.group_label).unwrap();
@@ -406,8 +390,7 @@ pub fn op_webgpu_render_pass_pop_debug_group(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_pop_debug_group(
     &mut render_pass_resource.0.borrow_mut(),
@@ -430,8 +413,7 @@ pub fn op_webgpu_render_pass_insert_debug_marker(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   unsafe {
     let label = std::ffi::CString::new(args.marker_label).unwrap();
@@ -459,12 +441,10 @@ pub fn op_webgpu_render_pass_set_pipeline(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pipeline_resource = state
     .resource_table
-    .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)?;
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_set_pipeline(
     &mut render_pass_resource.0.borrow_mut(),
@@ -491,12 +471,10 @@ pub fn op_webgpu_render_pass_set_index_buffer(
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.buffer)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.buffer)?;
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   let size = if let Some(size) = args.size {
     Some(
@@ -534,12 +512,10 @@ pub fn op_webgpu_render_pass_set_vertex_buffer(
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.buffer)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.buffer)?;
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   let size = if let Some(size) = args.size {
     Some(
@@ -578,8 +554,7 @@ pub fn op_webgpu_render_pass_draw(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_draw(
     &mut render_pass_resource.0.borrow_mut(),
@@ -610,8 +585,7 @@ pub fn op_webgpu_render_pass_draw_indexed(
 ) -> Result<WebGpuResult, AnyError> {
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_draw_indexed(
     &mut render_pass_resource.0.borrow_mut(),
@@ -640,12 +614,10 @@ pub fn op_webgpu_render_pass_draw_indirect(
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)?;
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_draw_indirect(
     &mut render_pass_resource.0.borrow_mut(),
@@ -671,12 +643,10 @@ pub fn op_webgpu_render_pass_draw_indexed_indirect(
 ) -> Result<WebGpuResult, AnyError> {
   let buffer_resource = state
     .resource_table
-    .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::buffer::WebGpuBuffer>(args.indirect_buffer)?;
   let render_pass_resource = state
     .resource_table
-    .get::<WebGpuRenderPass>(args.render_pass_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuRenderPass>(args.render_pass_rid)?;
 
   wgpu_core::command::render_ffi::wgpu_render_pass_draw_indexed_indirect(
     &mut render_pass_resource.0.borrow_mut(),

--- a/ext/webgpu/render_pass.rs
+++ b/ext/webgpu/render_pass.rs
@@ -242,9 +242,10 @@ pub fn op_webgpu_render_pass_execute_bundles(
   let mut render_bundle_ids = vec![];
 
   for rid in &args.bundles {
-    let render_bundle_resource = state
-      .resource_table
-      .get::<super::bundle::WebGpuRenderBundle>(*rid)?;
+    let render_bundle_resource =
+      state
+        .resource_table
+        .get::<super::bundle::WebGpuRenderBundle>(*rid)?;
     render_bundle_ids.push(render_bundle_resource.0);
   }
 
@@ -278,8 +279,8 @@ pub fn op_webgpu_render_pass_end_pass(
   let command_encoder_resource = state
     .resource_table
     .get::<super::command_encoder::WebGpuCommandEncoder>(
-      args.command_encoder_rid,
-    )?;
+    args.command_encoder_rid,
+  )?;
   let command_encoder = command_encoder_resource.0;
   let render_pass_resource = state
     .resource_table
@@ -306,9 +307,10 @@ pub fn op_webgpu_render_pass_set_bind_group(
   args: RenderPassSetBindGroupArgs,
   zero_copy: Option<ZeroCopyBuf>,
 ) -> Result<WebGpuResult, AnyError> {
-  let bind_group_resource = state
-    .resource_table
-    .get::<super::binding::WebGpuBindGroup>(args.bind_group)?;
+  let bind_group_resource =
+    state
+      .resource_table
+      .get::<super::binding::WebGpuBindGroup>(args.bind_group)?;
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)?;
@@ -438,9 +440,10 @@ pub fn op_webgpu_render_pass_set_pipeline(
   args: RenderPassSetPipelineArgs,
   _: (),
 ) -> Result<WebGpuResult, AnyError> {
-  let render_pipeline_resource = state
-    .resource_table
-    .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)?;
+  let render_pipeline_resource =
+    state
+      .resource_table
+      .get::<super::pipeline::WebGpuRenderPipeline>(args.pipeline)?;
   let render_pass_resource = state
     .resource_table
     .get::<WebGpuRenderPass>(args.render_pass_rid)?;

--- a/ext/webgpu/sampler.rs
+++ b/ext/webgpu/sampler.rs
@@ -84,8 +84,7 @@ pub fn op_webgpu_create_sampler(
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
-    .get::<super::WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
 
   let descriptor = wgpu_core::resource::SamplerDescriptor {

--- a/ext/webgpu/sampler.rs
+++ b/ext/webgpu/sampler.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::ResourceId;
 use deno_core::{OpState, Resource};

--- a/ext/webgpu/shader.rs
+++ b/ext/webgpu/shader.rs
@@ -35,8 +35,7 @@ pub fn op_webgpu_create_shader_module(
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
-    .get::<super::WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
 
   let source = match args.code {

--- a/ext/webgpu/shader.rs
+++ b/ext/webgpu/shader.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
 use deno_core::ResourceId;

--- a/ext/webgpu/texture.rs
+++ b/ext/webgpu/texture.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::AnyError;
 use deno_core::error::not_supported;
+use deno_core::error::AnyError;
 use deno_core::ResourceId;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;

--- a/ext/webgpu/texture.rs
+++ b/ext/webgpu/texture.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::error::AnyError;
-use deno_core::error::{bad_resource_id, not_supported};
+use deno_core::error::not_supported;
 use deno_core::ResourceId;
 use deno_core::{OpState, Resource};
 use serde::Deserialize;

--- a/ext/webgpu/texture.rs
+++ b/ext/webgpu/texture.rs
@@ -149,8 +149,7 @@ pub fn op_webgpu_create_texture(
   let instance = state.borrow::<super::Instance>();
   let device_resource = state
     .resource_table
-    .get::<super::WebGpuDevice>(args.device_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<super::WebGpuDevice>(args.device_rid)?;
   let device = device_resource.0;
 
   let descriptor = wgpu_core::resource::TextureDescriptor {
@@ -204,8 +203,7 @@ pub fn op_webgpu_create_texture_view(
   let instance = state.borrow::<super::Instance>();
   let texture_resource = state
     .resource_table
-    .get::<WebGpuTexture>(args.texture_rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WebGpuTexture>(args.texture_rid)?;
   let texture = texture_resource.0;
 
   let descriptor = wgpu_core::resource::TextureViewDescriptor {

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -272,8 +272,7 @@ where
       let r = state
         .borrow_mut()
         .resource_table
-        .get::<WsCancelResource>(cancel_rid)
-        .ok_or_else(bad_resource_id)?;
+        .get::<WsCancelResource>(cancel_rid)?;
       client
         .or_cancel(r.0.to_owned())
         .await
@@ -343,8 +342,7 @@ pub async fn op_ws_send(
   let resource = state
     .borrow_mut()
     .resource_table
-    .get::<WsStreamResource>(args.rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WsStreamResource>(args.rid)?;
   resource.send(msg).await?;
   Ok(())
 }
@@ -374,8 +372,7 @@ pub async fn op_ws_close(
   let resource = state
     .borrow_mut()
     .resource_table
-    .get::<WsStreamResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WsStreamResource>(rid)?;
   resource.send(msg).await?;
   Ok(())
 }
@@ -400,8 +397,7 @@ pub async fn op_ws_next_event(
   let resource = state
     .borrow_mut()
     .resource_table
-    .get::<WsStreamResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<WsStreamResource>(rid)?;
 
   let cancel = RcRef::map(&resource, |r| &r.cancel);
   let val = resource.next_message(cancel).await?;

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::bad_resource_id;
 use deno_core::error::invalid_hostname;
 use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -287,7 +287,7 @@ where
     })?;
 
   if let Some(cancel_rid) = args.cancel_handle {
-    state.borrow_mut().resource_table.close(cancel_rid);
+    state.borrow_mut().resource_table.close(cancel_rid).ok();
   }
 
   let (ws_tx, ws_rx) = stream.split();

--- a/runtime/ops/fs.rs
+++ b/runtime/ops/fs.rs
@@ -230,8 +230,7 @@ async fn op_seek_async(
   let resource = state
     .borrow_mut()
     .resource_table
-    .get::<StdFileResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<StdFileResource>(rid)?;
 
   if resource.fs_file.is_none() {
     return Err(bad_resource_id());
@@ -265,8 +264,7 @@ async fn op_fdatasync_async(
   let resource = state
     .borrow_mut()
     .resource_table
-    .get::<StdFileResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<StdFileResource>(rid)?;
 
   if resource.fs_file.is_none() {
     return Err(bad_resource_id());
@@ -300,8 +298,7 @@ async fn op_fsync_async(
   let resource = state
     .borrow_mut()
     .resource_table
-    .get::<StdFileResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<StdFileResource>(rid)?;
 
   if resource.fs_file.is_none() {
     return Err(bad_resource_id());
@@ -335,8 +332,7 @@ async fn op_fstat_async(
   let resource = state
     .borrow_mut()
     .resource_table
-    .get::<StdFileResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<StdFileResource>(rid)?;
 
   if resource.fs_file.is_none() {
     return Err(bad_resource_id());
@@ -1298,8 +1294,7 @@ async fn op_ftruncate_async(
   let resource = state
     .borrow_mut()
     .resource_table
-    .get::<StdFileResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<StdFileResource>(rid)?;
 
   if resource.fs_file.is_none() {
     return Err(bad_resource_id());
@@ -1580,8 +1575,7 @@ async fn op_futime_async(
   let resource = state
     .borrow_mut()
     .resource_table
-    .get::<StdFileResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<StdFileResource>(rid)?;
 
   if resource.fs_file.is_none() {
     return Err(bad_resource_id());

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::permissions::Permissions;
-use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::parking_lot::Mutex;
 use deno_core::AsyncRefCell;

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -134,10 +134,7 @@ async fn op_fs_events_poll(
   rid: ResourceId,
   _: (),
 ) -> Result<Option<FsEvent>, AnyError> {
-  let resource = state
-    .borrow()
-    .resource_table
-    .get::<FsEventsResource>(rid)?;
+  let resource = state.borrow().resource_table.get::<FsEventsResource>(rid)?;
   let mut receiver = RcRef::map(&resource, |r| &r.receiver).borrow_mut().await;
   let cancel = RcRef::map(resource, |r| &r.cancel);
   let maybe_result = receiver.recv().or_cancel(cancel).await?;

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -138,8 +138,7 @@ async fn op_fs_events_poll(
   let resource = state
     .borrow()
     .resource_table
-    .get::<FsEventsResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<FsEventsResource>(rid)?;
   let mut receiver = RcRef::map(&resource, |r| &r.receiver).borrow_mut().await;
   let cancel = RcRef::map(resource, |r| &r.cancel);
   let maybe_result = receiver.recv().or_cancel(cancel).await?;

--- a/runtime/ops/http.rs
+++ b/runtime/ops/http.rs
@@ -20,7 +20,7 @@ fn op_http_start(
   tcp_stream_rid: ResourceId,
   _: (),
 ) -> Result<ResourceId, AnyError> {
-  if let Some(resource_rc) = state
+  if let Ok(resource_rc) = state
     .resource_table
     .take::<TcpStreamResource>(tcp_stream_rid)
   {
@@ -32,7 +32,7 @@ fn op_http_start(
     return deno_http::start_http(state, tcp_stream, addr, "http");
   }
 
-  if let Some(resource_rc) = state
+  if let Ok(resource_rc) = state
     .resource_table
     .take::<TlsStreamResource>(tcp_stream_rid)
   {

--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -1,9 +1,9 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+use deno_core::error::not_supported;
 use deno_core::error::null_opbuf;
 use deno_core::error::resource_unavailable;
 use deno_core::error::AnyError;
-use deno_core::error::not_supported;
 use deno_core::op_async;
 use deno_core::op_sync;
 use deno_core::AsyncMutFuture;
@@ -334,9 +334,7 @@ impl StdFileResource {
     F: FnMut(Result<&mut std::fs::File, ()>) -> Result<R, AnyError>,
   {
     // First we look up the rid in the resource table.
-    let resource = state
-      .resource_table
-      .get::<StdFileResource>(rid)?;
+    let resource = state.resource_table.get::<StdFileResource>(rid)?;
 
     // Sync write only works for FsFile. It doesn't make sense to do this
     // for non-blocking sockets. So we error out if not FsFile.
@@ -407,10 +405,7 @@ async fn op_read_async(
   buf: Option<ZeroCopyBuf>,
 ) -> Result<u32, AnyError> {
   let buf = &mut buf.ok_or_else(null_opbuf)?;
-  let resource = state
-    .borrow()
-    .resource_table
-    .get_any(rid)?;
+  let resource = state.borrow().resource_table.get_any(rid)?;
   let nread = if let Some(s) = resource.downcast_rc::<ChildStdoutResource>() {
     s.read(buf).await?
   } else if let Some(s) = resource.downcast_rc::<ChildStderrResource>() {
@@ -450,10 +445,7 @@ async fn op_write_async(
   buf: Option<ZeroCopyBuf>,
 ) -> Result<u32, AnyError> {
   let buf = &buf.ok_or_else(null_opbuf)?;
-  let resource = state
-    .borrow()
-    .resource_table
-    .get_any(rid)?;
+  let resource = state.borrow().resource_table.get_any(rid)?;
   let nwritten = if let Some(s) = resource.downcast_rc::<ChildStdinResource>() {
     s.write(buf).await?
   } else if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {
@@ -475,10 +467,7 @@ async fn op_shutdown(
   rid: ResourceId,
   _: (),
 ) -> Result<(), AnyError> {
-  let resource = state
-    .borrow()
-    .resource_table
-    .get_any(rid)?;
+  let resource = state.borrow().resource_table.get_any(rid)?;
   if let Some(s) = resource.downcast_rc::<ChildStdinResource>() {
     s.shutdown().await?;
   } else if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {

--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -336,8 +336,7 @@ impl StdFileResource {
     // First we look up the rid in the resource table.
     let resource = state
       .resource_table
-      .get::<StdFileResource>(rid)
-      .ok_or_else(bad_resource_id)?;
+      .get::<StdFileResource>(rid)?;
 
     // Sync write only works for FsFile. It doesn't make sense to do this
     // for non-blocking sockets. So we error out if not FsFile.
@@ -411,8 +410,7 @@ async fn op_read_async(
   let resource = state
     .borrow()
     .resource_table
-    .get_any(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get_any(rid)?;
   let nread = if let Some(s) = resource.downcast_rc::<ChildStdoutResource>() {
     s.read(buf).await?
   } else if let Some(s) = resource.downcast_rc::<ChildStderrResource>() {
@@ -455,8 +453,7 @@ async fn op_write_async(
   let resource = state
     .borrow()
     .resource_table
-    .get_any(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get_any(rid)?;
   let nwritten = if let Some(s) = resource.downcast_rc::<ChildStdinResource>() {
     s.write(buf).await?
   } else if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {
@@ -481,8 +478,7 @@ async fn op_shutdown(
   let resource = state
     .borrow()
     .resource_table
-    .get_any(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get_any(rid)?;
   if let Some(s) = resource.downcast_rc::<ChildStdinResource>() {
     s.shutdown().await?;
   } else if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {

--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -3,7 +3,7 @@
 use deno_core::error::null_opbuf;
 use deno_core::error::resource_unavailable;
 use deno_core::error::AnyError;
-use deno_core::error::{bad_resource_id, not_supported};
+use deno_core::error::not_supported;
 use deno_core::op_async;
 use deno_core::op_sync;
 use deno_core::AsyncMutFuture;

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -212,8 +212,7 @@ async fn op_run_status(
   let resource = state
     .borrow_mut()
     .resource_table
-    .get::<ChildResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<ChildResource>(rid)?;
   let mut child = resource.borrow_mut().await;
   let run_status = child.wait().await?;
   let code = run_status.code();

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -96,9 +96,7 @@ pub fn op_signal_unbind(
   _: (),
 ) -> Result<(), AnyError> {
   super::check_unstable(state, "Deno.signal");
-  state
-    .resource_table
-    .close(rid)?;
+  state.resource_table.close(rid)?;
   Ok(())
 }
 

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -8,8 +8,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 #[cfg(unix)]
-use deno_core::error::bad_resource_id;
-#[cfg(unix)]
 use deno_core::AsyncRefCell;
 #[cfg(unix)]
 use deno_core::CancelFuture;

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -81,8 +81,7 @@ async fn op_signal_poll(
   let resource = state
     .borrow_mut()
     .resource_table
-    .get::<SignalStreamResource>(rid)
-    .ok_or_else(bad_resource_id)?;
+    .get::<SignalStreamResource>(rid)?;
   let cancel = RcRef::map(&resource, |r| &r.cancel);
   let mut signal = RcRef::map(&resource, |r| &r.signal).borrow_mut().await;
 
@@ -101,8 +100,7 @@ pub fn op_signal_unbind(
   super::check_unstable(state, "Deno.signal");
   state
     .resource_table
-    .close(rid)
-    .ok_or_else(bad_resource_id)?;
+    .close(rid)?;
   Ok(())
 }
 

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -91,8 +91,7 @@ fn op_set_raw(
 
     let resource = state
       .resource_table
-      .get::<StdFileResource>(rid)
-      .ok_or_else(bad_resource_id)?;
+      .get::<StdFileResource>(rid)?;
 
     if cbreak {
       return Err(not_supported());
@@ -158,8 +157,7 @@ fn op_set_raw(
 
     let resource = state
       .resource_table
-      .get::<StdFileResource>(rid)
-      .ok_or_else(bad_resource_id)?;
+      .get::<StdFileResource>(rid)?;
 
     if resource.fs_file.is_none() {
       return Err(not_supported());

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -89,9 +89,7 @@ fn op_set_raw(
     use winapi::shared::minwindef::FALSE;
     use winapi::um::{consoleapi, handleapi};
 
-    let resource = state
-      .resource_table
-      .get::<StdFileResource>(rid)?;
+    let resource = state.resource_table.get::<StdFileResource>(rid)?;
 
     if cbreak {
       return Err(not_supported());
@@ -155,9 +153,7 @@ fn op_set_raw(
   {
     use std::os::unix::io::AsRawFd;
 
-    let resource = state
-      .resource_table
-      .get::<StdFileResource>(rid)?;
+    let resource = state.resource_table.get::<StdFileResource>(rid)?;
 
     if resource.fs_file.is_none() {
       return Err(not_supported());


### PR DESCRIPTION
Instead of relying on callers to map Options to Results via `.ok_or_else(bad_resource_id)` at over 176 different call sites ...