### PR TITLE
perf(ext/http): faster req_url string assembly

### DIFF
--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -283,7 +283,7 @@ fn req_url(
     Cow::Owned(addr.to_string())
   };
   let path = req.uri().path_and_query().map_or("/", |p| p.as_str());
-  Ok(format!("{}://{}{}", scheme, host, path))
+  Ok([scheme, "://", &host, path].concat())
 }
 
 fn req_headers(


### PR DESCRIPTION
This stood out on a flamegraph, it took up ~1% of a profiled loadtest of `cli/bench/deno_http_native.js`
(1% of total program time is not huge but not insignificant when optimizing this HTTP hot path)

You can see string concat benches here: https://github.com/hoodie/concatenation_benchmarks-rs, ran locally (M1 Air):
```
test array_concat                                 ... bench:          33 ns/iter (+/- 0)
test array_join                                   ... bench:          30 ns/iter (+/- 0)
test array_join_long                              ... bench:          33 ns/iter (+/- 0)
test collect_from_array_to_string                 ... bench:          66 ns/iter (+/- 0)
test collect_from_vec_to_string                   ... bench:          67 ns/iter (+/- 1)
test format_macro                                 ... bench:          76 ns/iter (+/- 2)
test from_bytes                                   ... bench:           0 ns/iter (+/- 0)
test mut_string_push_str                          ... bench:          59 ns/iter (+/- 0)
test mut_string_push_string                       ... bench:         131 ns/iter (+/- 1)
test mut_string_with_capacity_push_str            ... bench:          23 ns/iter (+/- 0)
test mut_string_with_capacity_push_str_char       ... bench:          24 ns/iter (+/- 0)
test mut_string_with_too_little_capacity_push_str ... bench:          75 ns/iter (+/- 13)
test mut_string_with_too_much_capacity_push_str   ... bench:          23 ns/iter (+/- 0)
test string_from_all                              ... bench:         104 ns/iter (+/- 9)
test string_from_plus_op                          ... bench:          56 ns/iter (+/- 7)
test to_owned_plus_op                             ... bench:          56 ns/iter (+/- 0)
test to_string_plus_op                            ... bench:          56 ns/iter (+/- 1)
```

**Note:** we could further (micro-)optimize this by pre-assembling `scheme + "://"` 