### PR TITLE
fix(ext/crypto): fix copying buffersource

### DIFF
--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -142,8 +142,8 @@
       const idlValue = normalizedAlgorithm[member];
       // 3.
       if (idlType === "BufferSource" && idlValue) {
-        normalizedAlgorithm[member] = new Uint8Array(
-          TypedArrayPrototypeSlice(
+        normalizedAlgorithm[member] = TypedArrayPrototypeSlice(
+          new Uint8Array(
             (ArrayBufferIsView(idlValue) ? idlValue.buffer : idlValue),
             idlValue.byteOffset ?? 0,
             idlValue.byteLength,


### PR DESCRIPTION
`%TypedArray%.prototype.slice` cannot be called on `ArrayBuffer`. This code was unreachable so it never threw, noticed while working on #11642 