### PR TITLE
chore: add `FinalizationRegistry` and `WeakRef` to primordials

### DIFF
--- a/core/00_primordials.js
+++ b/core/00_primordials.js
@@ -206,8 +206,7 @@
     "Date",
     "Error",
     "EvalError",
-    // TODO(lucacasonato): not present in snapshots. Why?
-    // "FinalizationRegistry",
+    "FinalizationRegistry",
     "Float32Array",
     "Float64Array",
     "Function",
@@ -231,8 +230,7 @@
     "Uint8Array",
     "Uint8ClampedArray",
     "WeakMap",
-    // TODO(lucacasonato): not present in snapshots. Why?
-    // "WeakRef",
+    "WeakRef",
     "WeakSet",
   ].forEach((name) => {
     const original = globalThis[name];
@@ -410,25 +408,23 @@
     },
   );
 
-  // TODO(lucacasonato): not present in snapshots. Why?
-  // primordials.SafeFinalizationRegistry = makeSafe(
-  //   FinalizationRegistry,
-  //   class SafeFinalizationRegistry extends FinalizationRegistry {
-  //     constructor(cleanupCallback) {
-  //       super(cleanupCallback);
-  //     }
-  //   },
-  // );
+  primordials.SafeFinalizationRegistry = makeSafe(
+    FinalizationRegistry,
+    class SafeFinalizationRegistry extends FinalizationRegistry {
+      constructor(cleanupCallback) {
+        super(cleanupCallback);
+      }
+    },
+  );
 
-  // TODO(lucacasonato): not present in snapshots. Why?
-  // primordials.SafeWeakRef = makeSafe(
-  //   WeakRef,
-  //   class SafeWeakRef extends WeakRef {
-  //     constructor(target) {
-  //       super(target);
-  //     }
-  //   },
-  // );
+  primordials.SafeWeakRef = makeSafe(
+    WeakRef,
+    class SafeWeakRef extends WeakRef {
+      constructor(target) {
+        super(target);
+      }
+    },
+  );
 
   const SafePromise = makeSafe(
     Promise,


### PR DESCRIPTION
Because it was possible to disable those with a runtime flag, they were not available through primordials. The flag has since been removed upstream.

Refs: https://github.com/v8/v8/commit/d59db06bf5425ddb388fb5a576f4bf39bdcc0f8f

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
