### PR TITLE
fix(ext/crypto): exportKey() for HMAC

### DIFF
--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -191,5 +191,5 @@ unitTest(async function subtleCryptoHmacImportExport() {
   );
 
   const exportedKey = await crypto.subtle.exportKey("raw", key);
-  assertEquals(exportedKey, rawKey);
+  assertEquals(new Uint8Array(exportedKey), rawKey);
 });

--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -160,7 +160,7 @@ unitTest(async function testSignRSASSAKey() {
   assert(signature);
 });
 
-unitTest(async function subtleCryptoHmacImport() {
+unitTest(async function subtleCryptoHmacImportExport() {
   // deno-fmt-ignore
   const rawKey = new Uint8Array([
     1, 2, 3, 4, 5, 6, 7, 8,
@@ -189,4 +189,7 @@ unitTest(async function subtleCryptoHmacImport() {
     new Uint8Array(actual),
     expected,
   );
+
+  const exportedKey = await crypto.subtle.exportKey("raw", key);
+  assertEquals(exportedKey, rawKey);
 });

--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -577,16 +577,17 @@
 
       const handle = key[_handle];
       // 2.
-      const bits = WeakMapPrototypeGet(KEY_STORE, handle);
+      const innerKey = WeakMapPrototypeGet(KEY_STORE, handle);
 
       switch (key[_algorithm].name) {
         case "HMAC": {
-          if (bits == null) {
+          if (innerKey == null) {
             throw new DOMException("Key is not available", "OperationError");
           }
           switch (format) {
             // 3.
             case "raw": {
+              const bits = innerKey.data;
               for (let _i = 7 & (8 - bits.length % 8); _i > 0; _i--) {
                 bits.push(0);
               }

--- a/ext/crypto/lib.deno_crypto.d.ts
+++ b/ext/crypto/lib.deno_crypto.d.ts
@@ -107,6 +107,7 @@ interface SubtleCrypto {
     extractable: boolean,
     keyUsages: KeyUsage[],
   ): Promise<CryptoKey>;
+  exportKey(format: "raw", key: CryptoKey): Promise<ArrayBuffer>;
   sign(
     algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams,
     key: CryptoKey,


### PR DESCRIPTION
My bad! Ref https://github.com/denoland/deno/pull/11367#issuecomment-899994010

Thanks @iugo for reporting this

Fixes typings and innerKey processing (WPT doesn't test `exportKey` for HMAC so this wasn't caught earlier).