### PR TITLE
fix(lsp): better handling of languageId

### DIFF
--- a/cli/lsp/README.md
+++ b/cli/lsp/README.md
@@ -22,6 +22,7 @@ There are several settings that the language server supports for a workspace:
 - `deno.cache`
 - `deno.config`
 - `deno.importMap`
+- `deno.internalDebug`
 - `deno.codeLens.implementations`
 - `deno.codeLens.references`
 - `deno.codeLens.referencesAllFunctions`
@@ -159,3 +160,21 @@ client:
     suggestions: boolean;
   }
   ```
+
+## Language IDs
+
+The language server supports diagnostics and formatting for the following
+language IDs:
+
+- `"javascript"`
+- `"javascriptreact"`
+- `"jsx"` _non standard_
+- `"typescript"`
+- `"typescriptreact"`
+- `"tsx"` _non standard_
+
+The language server supports only formatting for the following language IDs:
+
+- `"json"`
+- `"jsonc"`
+- `"markdown"`

--- a/cli/lsp/README.md
+++ b/cli/lsp/README.md
@@ -164,14 +164,14 @@ client:
 ## Language IDs
 
 The language server supports diagnostics and formatting for the following
-language IDs:
+[text document language IDs](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentItem):
 
 - `"javascript"`
 - `"javascriptreact"`
-- `"jsx"` _non standard_
+- `"jsx"` _non standard, same as `javascriptreact`_
 - `"typescript"`
 - `"typescriptreact"`
-- `"tsx"` _non standard_
+- `"tsx"` _non standard, same as `typescriptreact`_
 
 The language server supports only formatting for the following language IDs:
 

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -772,13 +772,21 @@ impl Inner {
       // already managed by the language service
       return;
     }
-    let language_id = match params.text_document.language_id.parse() {
-      Ok(language_id) => language_id,
-      Err(err) => {
-        error!("{}", err);
-        LanguageId::TypeScript
-      }
-    };
+    let language_id =
+      params
+        .text_document
+        .language_id
+        .parse()
+        .unwrap_or_else(|err| {
+          error!("{}", err);
+          LanguageId::Unknown
+        });
+    if language_id == LanguageId::Unknown {
+      warn!(
+        "Unsupported language id \"{}\" received for document \"{}\".",
+        params.text_document.language_id, params.text_document.uri
+      );
+    }
     let media_type = MediaType::from(&language_id);
     self.documents.open(
       specifier.clone(),


### PR DESCRIPTION
This adds a `LanguageId::Unknown` which better aligns to mapping to `MediaType`.  Also we were defaulting to `LanguageId::TypeScript` when we encountered an unknown/unsupported language id.  This cause diagnostics to appear in the file from tsc, even though it should have been considered "undiagnosable".

This also adds support for `"jsx"` and `"tsx"` language IDs.

Fixes #11521
Fixes #11742
