### PR TITLE
feat: add options to test overload

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -184,7 +184,11 @@ declare namespace Deno {
    * });
    * ```
    * */
-  export function test(name: string, fn: () => void | Promise<void>): void;
+  export function test(
+    name: string,
+    fn: () => void | Promise<void>,
+    options?: Omit<TestDefinition, "name" | "fn">,
+  ): void;
 
   /** Exit the Deno process with optional exit code. If no exit code is supplied
    * then Deno will exit with return code of 0.

--- a/cli/tests/testdata/test/allow_none.ts
+++ b/cli/tests/testdata/test/allow_none.ts
@@ -11,13 +11,11 @@ const permissions: Deno.PermissionName[] = [
 ];
 
 for (const name of permissions) {
-  Deno.test({
-    name,
+  Deno.test(name, function () {
+    unreachable();
+  }, {
     permissions: {
       [name]: true,
-    },
-    fn() {
-      unreachable();
     },
   });
 }

--- a/cli/tests/testdata/test/ignore.ts
+++ b/cli/tests/testdata/test/ignore.ts
@@ -1,4 +1,4 @@
-for (let i = 0; i < 10; i++) {
+for (let i = 0; i < 5; i++) {
   Deno.test({
     name: `test ${i}`,
     ignore: true,
@@ -6,4 +6,10 @@ for (let i = 0; i < 10; i++) {
       throw new Error("unreachable");
     },
   });
+}
+
+for (let i = 5; i < 10; i++) {
+  Deno.test(`test ${i}`, () => {
+    throw new Error("unreachable");
+  }, { ignore: true });
 }

--- a/cli/tests/testdata/test/only.out
+++ b/cli/tests/testdata/test/only.out
@@ -1,7 +1,8 @@
 Check [WILDCARD]/test/only.ts
-running 1 test from [WILDCARD]/test/only.ts
+running 2 tests from [WILDCARD]/test/only.ts
+test only ... ok ([WILDCARD])
 test only ... ok ([WILDCARD])
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out ([WILDCARD])
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out ([WILDCARD])
 
 error: Test failed because the "only" option was used

--- a/cli/tests/testdata/test/only.ts
+++ b/cli/tests/testdata/test/only.ts
@@ -9,6 +9,10 @@ Deno.test({
   fn() {},
 });
 
+Deno.test("only", () => {}, {
+  only: true,
+});
+
 Deno.test({
   name: "after",
   fn() {},

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -135,6 +135,7 @@ finishing test case.`;
   function test(
     t,
     fn,
+    options,
   ) {
     let testDef;
     const defaults = {
@@ -153,7 +154,7 @@ finishing test case.`;
       if (!t) {
         throw new TypeError("The test name can't be empty");
       }
-      testDef = { fn: fn, name: t, ...defaults };
+      testDef = { fn: fn, name: t, ...defaults, ...options };
     } else {
       if (!t.fn) {
         throw new TypeError("Missing test function");


### PR DESCRIPTION
Generally you can't actually use the overloaded version of `Deno.test` because the need to specify permissions or any of the other options.

This adds the remaining options as an optional option bag to the user friendly overloaded version of `Deno.test`.

We punted this back in https://github.com/denoland/deno/pull/10078

Since then we have added more options like permissions making the need much greater.