### PR TITLE
perf(ext/url): optimize UrlParts op serialization

### DIFF
--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -40,9 +40,41 @@
   const SET_SEARCH = 8;
   const SET_USERNAME = 9;
 
-  // Helper function
+  // Helper functions
   function opUrlReparse(href, setter, value) {
-    return core.opSync("op_url_reparse", href, [setter, value]);
+    return _urlParts(core.opSync("op_url_reparse", href, [setter, value]));
+  }
+  function opUrlParse(href, maybeBase) {
+    return _urlParts(core.opSync("op_url_parse", href, maybeBase));
+  }
+  function _urlParts(internalParts) {
+    // WARNING: must match UrlParts serialization rust's url_result()
+    const {
+      0: href,
+      1: hash,
+      2: host,
+      3: hostname,
+      4: origin,
+      5: password,
+      6: pathname,
+      7: port,
+      8: protocol,
+      9: search,
+      10: username,
+    } = internalParts.split("\n");
+    return {
+      href,
+      hash,
+      host,
+      hostname,
+      origin,
+      password,
+      pathname,
+      port,
+      protocol,
+      search,
+      username,
+    };
   }
 
   class URLSearchParams {
@@ -289,7 +321,7 @@
         });
       }
       this[webidl.brand] = webidl.brand;
-      this[_url] = core.opSync("op_url_parse", url, base);
+      this[_url] = opUrlParse(url, base);
     }
 
     [SymbolFor("Deno.privateCustomInspect")](inspect) {
@@ -401,7 +433,7 @@
         prefix,
         context: "Argument 1",
       });
-      this[_url] = core.opSync("op_url_parse", value);
+      this[_url] = opUrlParse(value);
       this.#updateSearchParams();
     }
 


### PR DESCRIPTION
Marshalling it across the op-layer by joining the substrings into a single "fat" newline-joined string, then splitting JS side.

This shaves off a little over a 1/3 of the overhead per call:
`main` (after merging https://github.com/denoland/deno/pull/11763)
```
bench:   3,726,203 ns/iter (+/- 177,656)
```
this PR:
```
bench:   2,400,289 ns/iter (+/- 53,911)
```

So with this PR and #11763 that's a combined improvement of over 2x ! (~5000ns/call => ~2400ns/call)

Whilst this might appear counterintuitive and "hacky", it works because:
- We have 11 string values to return
- Marshalling them in a struct creates an obj + 11 optimized/internalized strings (the keys) + 11 unoptimized "normal" strings (the values) + 11 owned strings in Rust
- This approach creates 1 fat owned string in rust, then resplitting it in JS creates 11 efficient substrings (that aren't individually allocated and refer to the fat string)
- `\n` is a safe separator because it's not allowed in URLs, technically could have used any control char but `\n` works and is familiar