### PR TITLE
cleanup(core): rename handleAsyncMsgFromRust() to opresolve()

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -88,7 +88,7 @@
     opsCache = ObjectFreeze(ObjectFromEntries(opcall(0)));
   }
 
-  function handleAsyncMsgFromRust() {
+  function opresolve() {
     for (let i = 0; i < arguments.length; i += 2) {
       const promiseId = arguments[i];
       const res = arguments[i + 1];
@@ -179,7 +179,7 @@
     resources,
     registerErrorBuilder,
     registerErrorClass,
-    handleAsyncMsgFromRust,
+    opresolve,
     syncOpsCache,
     BadResource,
     Interrupted,

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -461,13 +461,12 @@ impl JsRuntime {
     Ok(())
   }
 
-  /// Grabs a reference to core.js' handleAsyncMsgFromRust
+  /// Grabs a reference to core.js' opresolve
   fn init_recv_cb(&mut self) {
     let scope = &mut self.handle_scope();
 
-    // Get Deno.core.handleAsyncMsgFromRust
-    let code =
-      v8::String::new(scope, "Deno.core.handleAsyncMsgFromRust").unwrap();
+    // Get Deno.core.opresolve
+    let code = v8::String::new(scope, "Deno.core.opresolve").unwrap();
     let script = v8::Script::compile(scope, code, None).unwrap();
     let v8_value = script.run(scope).unwrap();
 


### PR DESCRIPTION
No user impact, but is simpler and aligns with `opcall()`