### PR TITLE
perf(ext/url): use DOMString webidl instead of USVString 

### DIFF
--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -313,9 +313,9 @@
      */
     constructor(url, base = undefined) {
       const prefix = "Failed to construct 'URL'";
-      url = webidl.converters.USVString(url, { prefix, context: "Argument 1" });
+      url = webidl.converters.DOMString(url, { prefix, context: "Argument 1" });
       if (base !== undefined) {
-        base = webidl.converters.USVString(base, {
+        base = webidl.converters.DOMString(base, {
           prefix,
           context: "Argument 2",
         });
@@ -363,7 +363,7 @@
       webidl.assertBranded(this, URL);
       const prefix = "Failed to set 'hash' on 'URL'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      value = webidl.converters.USVString(value, {
+      value = webidl.converters.DOMString(value, {
         prefix,
         context: "Argument 1",
       });
@@ -385,7 +385,7 @@
       webidl.assertBranded(this, URL);
       const prefix = "Failed to set 'host' on 'URL'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      value = webidl.converters.USVString(value, {
+      value = webidl.converters.DOMString(value, {
         prefix,
         context: "Argument 1",
       });
@@ -407,7 +407,7 @@
       webidl.assertBranded(this, URL);
       const prefix = "Failed to set 'hostname' on 'URL'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      value = webidl.converters.USVString(value, {
+      value = webidl.converters.DOMString(value, {
         prefix,
         context: "Argument 1",
       });
@@ -429,7 +429,7 @@
       webidl.assertBranded(this, URL);
       const prefix = "Failed to set 'href' on 'URL'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      value = webidl.converters.USVString(value, {
+      value = webidl.converters.DOMString(value, {
         prefix,
         context: "Argument 1",
       });
@@ -454,7 +454,7 @@
       webidl.assertBranded(this, URL);
       const prefix = "Failed to set 'password' on 'URL'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      value = webidl.converters.USVString(value, {
+      value = webidl.converters.DOMString(value, {
         prefix,
         context: "Argument 1",
       });
@@ -476,7 +476,7 @@
       webidl.assertBranded(this, URL);
       const prefix = "Failed to set 'pathname' on 'URL'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      value = webidl.converters.USVString(value, {
+      value = webidl.converters.DOMString(value, {
         prefix,
         context: "Argument 1",
       });
@@ -498,7 +498,7 @@
       webidl.assertBranded(this, URL);
       const prefix = "Failed to set 'port' on 'URL'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      value = webidl.converters.USVString(value, {
+      value = webidl.converters.DOMString(value, {
         prefix,
         context: "Argument 1",
       });
@@ -520,7 +520,7 @@
       webidl.assertBranded(this, URL);
       const prefix = "Failed to set 'protocol' on 'URL'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      value = webidl.converters.USVString(value, {
+      value = webidl.converters.DOMString(value, {
         prefix,
         context: "Argument 1",
       });
@@ -542,7 +542,7 @@
       webidl.assertBranded(this, URL);
       const prefix = "Failed to set 'search' on 'URL'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      value = webidl.converters.USVString(value, {
+      value = webidl.converters.DOMString(value, {
         prefix,
         context: "Argument 1",
       });
@@ -565,7 +565,7 @@
       webidl.assertBranded(this, URL);
       const prefix = "Failed to set 'username' on 'URL'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      value = webidl.converters.USVString(value, {
+      value = webidl.converters.DOMString(value, {
         prefix,
         context: "Argument 1",
       });


### PR DESCRIPTION
Improves url parsing by ~20%:
- before: `~2450ns/parse`
- after: `~1950ns/parse`

This is safe since all these string values are immediately sent to the op-layer that uses `v8::String::to_rust_string_lossy()` with `REPLACE_INVALID_UTF8` effectively doing the same transform as our `USVString` webidl converter