### PR TITLE
chore: upgrade dlint and run `prefer-primordials`

### DIFF
--- a/.dlint.json
+++ b/.dlint.json
@@ -4,6 +4,8 @@
     "include": [
       "ban-untagged-todo"
     ],
-    "exclude": []
+    "exclude": [
+      "no-invalid-triple-slash-reference"
+    ]
   }
 }

--- a/ext/websocket/02_websocketstream.js
+++ b/ext/websocket/02_websocketstream.js
@@ -22,6 +22,7 @@
     PromisePrototypeCatch,
     Uint8Array,
     TypeError,
+    Error,
   } = window.__bootstrap.primordials;
 
   webidl.converters.WebSocketStreamOptions = webidl.createDictionaryConverter(

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -22,6 +22,7 @@ delete Object.prototype.__proto__;
     SymbolFor,
     SymbolIterator,
     PromisePrototypeThen,
+    TypeError,
   } = window.__bootstrap.primordials;
   const util = window.__bootstrap.util;
   const eventTarget = window.__bootstrap.eventTarget;
@@ -228,6 +229,7 @@ delete Object.prototype.__proto__;
     } else {
       prepareStackTrace = core.createPrepareStackTrace();
     }
+    // deno-lint-ignore prefer-primordials
     Error.prepareStackTrace = prepareStackTrace;
   }
 

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -51,6 +51,9 @@ async function dlint() {
   }
 }
 
+// `prefer-primordials` has to apply only to files related to bootstrapping,
+// which is different from other lint rules. This is why this dedicated function
+// is needed.
 async function dlintPreferPrimordials() {
   const execPath = getPrebuiltToolPath("dlint");
   console.log("prefer-primordials");

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -38,19 +38,7 @@ async function dlint() {
     return;
   }
 
-  const MAX_COMMAND_LEN = 30000;
-  const preCommand = [execPath, "run"];
-  const chunks = [[]];
-  let cmdLen = preCommand.join(" ").length;
-  for (const f of sourceFiles) {
-    if (cmdLen + f.length > MAX_COMMAND_LEN) {
-      chunks.push([f]);
-      cmdLen = preCommand.join(" ").length;
-    } else {
-      chunks[chunks.length - 1].push(f);
-      cmdLen = preCommand.join(" ").length;
-    }
-  }
+  const chunks = splitToChunks(sourceFiles, `${execPath} run`.length);
   for (const chunk of chunks) {
     const p = Deno.run({
       cmd: [execPath, "run", "--config=" + configFile, ...chunk],
@@ -61,6 +49,50 @@ async function dlint() {
     }
     p.close();
   }
+}
+
+async function dlintPreferPrimordials() {
+  const execPath = getPrebuiltToolPath("dlint");
+  console.log("prefer-primordials");
+
+  const sourceFiles = await getSources(ROOT_PATH, [
+    "runtime/**/*.js",
+    "ext/**/*.js",
+    "core/**/*.js",
+    ":!:core/examples/**",
+  ]);
+
+  if (!sourceFiles.length) {
+    return;
+  }
+
+  const chunks = splitToChunks(sourceFiles, `${execPath} run`.length);
+  for (const chunk of chunks) {
+    const p = Deno.run({
+      cmd: [execPath, "run", "--rule", "prefer-primordials", ...chunk],
+    });
+    const { success } = await p.status();
+    if (!success) {
+      throw new Error("prefer-primordials failed");
+    }
+    p.close();
+  }
+}
+
+function splitToChunks(paths, initCmdLen) {
+  let cmdLen = initCmdLen;
+  const MAX_COMMAND_LEN = 30000;
+  const chunks = [[]];
+  for (const p of paths) {
+    if (cmdLen + p.length > MAX_COMMAND_LEN) {
+      chunks.push([p]);
+      cmdLen = initCmdLen;
+    } else {
+      chunks[chunks.length - 1].push(p);
+      cmdLen += p.length;
+    }
+  }
+  return chunks;
 }
 
 async function clippy() {
@@ -90,6 +122,7 @@ async function main() {
 
   if (Deno.args.includes("--js")) {
     await dlint();
+    await dlintPreferPrimordials();
     didLint = true;
   }
 
@@ -100,6 +133,7 @@ async function main() {
 
   if (!didLint) {
     await dlint();
+    await dlintPreferPrimordials();
     await clippy();
   }
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

This PR upgrades `third_party` submodule to the latest to get dlint 0.12.0, and applies `prefer-primordials` to the files under runtime, ext, and core.

