### PR TITLE
doc(test): add --location to unit test command

### DIFF
--- a/cli/tests/unit/README.md
+++ b/cli/tests/unit/README.md
@@ -30,10 +30,10 @@ There are two ways to run `unit_test_runner.ts`:
 
 ```sh
 # Run all tests.
-target/debug/deno test --allow-all --unstable cli/tests/unit/
+target/debug/deno test --allow-all --unstable --location=http://js-unit-tests/foo/bar cli/tests/unit/
 
 # Run a specific test module
-target/debug/deno test --allow-all --unstable cli/tests/unit/files_test.ts
+target/debug/deno test --allow-all --unstable --location=http://js-unit-tests/foo/bar cli/tests/unit/files_test.ts
 ```
 
 ### Http server


### PR DESCRIPTION
Some unit test depend the `--location=http://js-unit-tests/foo/bar` to work，if run unit test without specify the `--location` some unit test will fail. 

Take `cli/tests/unit/request_test.ts` as a example:

```
% target/debug/deno test --allow-all --unstable  cli/tests/unit/request_test.ts running 6 tests from file:///Users/feng/Projects/deno/cli/tests/unit/request_test.ts
test fromInit ... ok (107ms)
test requestNonString ... ok (14ms)
test methodNonString ... ok (11ms)
test requestRelativeUrl ... FAILED (103ms)
test cloneRequestBodyStream ... ok (20ms)
test customInspectFunction ... ok (19ms)

failures:

requestRelativeUrl
TypeError: Invalid URL
    at deno:core/01_core.js:106:46
    at unwrapOpResult (deno:core/01_core.js:126:13)
    at Object.opSync (deno:core/01_core.js:140:12)
    at opUrlParse (deno:ext/url/00_url.js:48:27)
    at new URL (deno:ext/url/00_url.js:324:20)
    at new Request (deno:ext/fetch/23_request.js:235:27)
    at requestRelativeUrl (file://deno/cli/tests/unit/request_test.ts:35:5)
    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)

failures:

        requestRelativeUrl

test result: FAILED. 5 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out (1053ms)

error: Test failed
```

Related test code:
```
unitTest(function requestRelativeUrl() {
  assertEquals(
    new Request("relative-url").url,
    "http://js-unit-tests/foo/relative-url",
  );
});
```