### PR TITLE
refactor(cli/flags): use an optional non zero usize for `fail-fast`

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -6,7 +6,6 @@ use clap::Arg;
 use clap::ArgMatches;
 use clap::ArgSettings;
 use clap::SubCommand;
-use std::num::NonZeroUsize;
 use deno_core::serde::Deserialize;
 use deno_core::serde::Serialize;
 use deno_core::url::Url;
@@ -14,6 +13,7 @@ use deno_runtime::permissions::PermissionsOptions;
 use log::debug;
 use log::Level;
 use std::net::SocketAddr;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::str::FromStr;
 

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -3642,6 +3642,9 @@ mod tests {
         ..Flags::default()
       }
     );
+
+    let r = flags_from_vec(svec!["deno", "test", "--fail-fast=0"]);
+    assert!(r.is_err());
   }
 
   #[test]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -76,6 +76,7 @@ use std::env;
 use std::io::Read;
 use std::io::Write;
 use std::iter::once;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
@@ -1003,7 +1004,7 @@ async fn test_command(
   include: Option<Vec<String>>,
   no_run: bool,
   doc: bool,
-  fail_fast: Option<usize>,
+  fail_fast: Option<NonZeroUsize>,
   quiet: bool,
   allow_none: bool,
   filter: Option<String>,

--- a/cli/tools/test_runner.rs
+++ b/cli/tools/test_runner.rs
@@ -26,6 +26,7 @@ use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use regex::Regex;
 use serde::Deserialize;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::mpsc::channel;
 use std::sync::mpsc::Sender;
@@ -468,7 +469,7 @@ pub async fn run_tests(
   doc_modules: Vec<ModuleSpecifier>,
   test_modules: Vec<ModuleSpecifier>,
   no_run: bool,
-  fail_fast: Option<usize>,
+  fail_fast: Option<NonZeroUsize>,
   quiet: bool,
   allow_none: bool,
   filter: Option<String>,
@@ -620,7 +621,7 @@ pub async fn run_tests(
         }
 
         if let Some(x) = fail_fast {
-          if summary.failed >= x {
+          if summary.failed >= x.get() {
             break;
           }
         }


### PR DESCRIPTION
Changes the type of the `fail_fast` flag from `Option<usize>` to `Option<NonZeroUsize>` as an optional value of zero isn't sound.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
