### PR TITLE
[DRAFT] feat: skip type checking by default

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -146,6 +146,7 @@ pub struct Flags {
   /// the language server is configured with an explicit cache option.
   pub cache_path: Option<PathBuf>,
   pub cached_only: bool,
+  pub check: bool,
   pub config_path: Option<String>,
   pub coverage_dir: Option<String>,
   pub enable_testing_features: bool,
@@ -829,6 +830,7 @@ TypeScript compiler cache: Subdirectory containing TS compiler output.",
         .conflicts_with("file")
         .help("Show files used for origin bound APIs like the Web Storage API when running a script with '--location=<HREF>'")
     )
+    .arg(check_arg())
     // TODO(lucacasonato): remove for 2.0
     .arg(no_check_arg().hidden(true))
     .arg(import_map_arg())
@@ -1200,6 +1202,7 @@ fn compile_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
     .arg(import_map_arg())
     .arg(no_remote_arg())
     .arg(config_arg())
+    .arg(check_arg())
     .arg(no_check_arg())
     .arg(reload_arg())
     .arg(lock_arg())
@@ -1462,10 +1465,24 @@ Only local files from entry point module graph are watched.",
     )
 }
 
+fn check_arg<'a, 'b>() -> Arg<'a, 'b> {
+  Arg::with_name("check")
+    .long("check")
+    .help("Type check modules")
+    .long_help(
+      "Type check modules.
+If there are type checking diagnostics they are displayed and the command line exits."
+    )
+}
+
 fn no_check_arg<'a, 'b>() -> Arg<'a, 'b> {
   Arg::with_name("no-check")
     .long("no-check")
-    .help("Skip type checking modules")
+    .help("DEPRECATED: Skip type checking modules")
+    .long_help(
+      "DEPRECATED: Skip type checking modules.
+This is now the default behavior and the flag is no longer needed.",
+    )
 }
 
 fn script_arg<'a, 'b>() -> Arg<'a, 'b> {
@@ -1884,6 +1901,7 @@ fn compile_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   import_map_arg_parse(flags, matches);
   no_remote_arg_parse(flags, matches);
   config_arg_parse(flags, matches);
+  check_arg_parse(flags, matches);
   no_check_arg_parse(flags, matches);
   reload_arg_parse(flags, matches);
   lock_args_parse(flags, matches);
@@ -2060,9 +2078,20 @@ fn seed_arg_parse(flags: &mut Flags, matches: &ArgMatches) {
   }
 }
 
+fn check_arg_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
+  if matches.is_present("check") {
+    flags.check = true;
+  }
+}
+
 fn no_check_arg_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   if matches.is_present("no-check") {
     flags.no_check = true;
+    // the logger is not setup at this point, so we will just print to stderr
+    eprintln!(
+      "{}: The flag --no-check is deprecated and will be removed in the future.",
+      crate::colors::yellow("warning")
+    );
   }
 }
 
@@ -2683,7 +2712,7 @@ mod tests {
   #[test]
   fn eval_with_flags() {
     #[rustfmt::skip]
-    let r = flags_from_vec(svec!["deno", "eval", "--import-map", "import_map.json", "--no-remote", "--config", "tsconfig.json", "--no-check", "--reload", "--lock", "lock.json", "--lock-write", "--cert", "example.crt", "--cached-only", "--location", "https:foo", "--v8-flags=--help", "--seed", "1", "--inspect=127.0.0.1:9229", "42"]);
+    let r = flags_from_vec(svec!["deno", "eval", "--import-map", "import_map.json", "--no-remote", "--config", "tsconfig.json", "--check", "--no-check", "--reload", "--lock", "lock.json", "--lock-write", "--cert", "example.crt", "--cached-only", "--location", "https:foo", "--v8-flags=--help", "--seed", "1", "--inspect=127.0.0.1:9229", "42"]);
     assert_eq!(
       r.unwrap(),
       Flags {
@@ -2695,6 +2724,7 @@ mod tests {
         import_map_path: Some("import_map.json".to_string()),
         no_remote: true,
         config_path: Some("tsconfig.json".to_string()),
+        check: true,
         no_check: true,
         reload: true,
         lock: Some(PathBuf::from("lock.json")),
@@ -2771,7 +2801,7 @@ mod tests {
   #[test]
   fn repl_with_flags() {
     #[rustfmt::skip]
-    let r = flags_from_vec(svec!["deno", "repl", "--import-map", "import_map.json", "--no-remote", "--config", "tsconfig.json", "--no-check", "--reload", "--lock", "lock.json", "--lock-write", "--cert", "example.crt", "--cached-only", "--location", "https:foo", "--v8-flags=--help", "--seed", "1", "--inspect=127.0.0.1:9229"]);
+    let r = flags_from_vec(svec!["deno", "repl", "--import-map", "import_map.json", "--no-remote", "--config", "tsconfig.json", "--check", "--no-check", "--reload", "--lock", "lock.json", "--lock-write", "--cert", "example.crt", "--cached-only", "--location", "https:foo", "--v8-flags=--help", "--seed", "1", "--inspect=127.0.0.1:9229"]);
     assert_eq!(
       r.unwrap(),
       Flags {
@@ -2780,6 +2810,7 @@ mod tests {
         import_map_path: Some("import_map.json".to_string()),
         no_remote: true,
         config_path: Some("tsconfig.json".to_string()),
+        check: true,
         no_check: true,
         reload: true,
         lock: Some(PathBuf::from("lock.json")),
@@ -3037,6 +3068,23 @@ mod tests {
   }
 
   #[test]
+  fn bundle_check() {
+    let r =
+      flags_from_vec(svec!["deno", "bundle", "--check", "script.ts"]).unwrap();
+    assert_eq!(
+      r,
+      Flags {
+        subcommand: DenoSubcommand::Bundle {
+          source_file: "script.ts".to_string(),
+          out_file: None,
+        },
+        check: true,
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
   fn bundle_nocheck() {
     let r = flags_from_vec(svec!["deno", "bundle", "--no-check", "script.ts"])
       .unwrap();
@@ -3232,7 +3280,7 @@ mod tests {
   #[test]
   fn install_with_flags() {
     #[rustfmt::skip]
-    let r = flags_from_vec(svec!["deno", "install", "--import-map", "import_map.json", "--no-remote", "--config", "tsconfig.json", "--no-check", "--unsafely-ignore-certificate-errors", "--reload", "--lock", "lock.json", "--lock-write", "--cert", "example.crt", "--cached-only", "--allow-read", "--allow-net", "--v8-flags=--help", "--seed", "1", "--inspect=127.0.0.1:9229", "--name", "file_server", "--root", "/foo", "--force", "https://deno.land/std/http/file_server.ts", "foo", "bar"]);
+    let r = flags_from_vec(svec!["deno", "install", "--import-map", "import_map.json", "--check", "--no-remote", "--config", "tsconfig.json", "--no-check", "--unsafely-ignore-certificate-errors", "--reload", "--lock", "lock.json", "--lock-write", "--cert", "example.crt", "--cached-only", "--allow-read", "--allow-net", "--v8-flags=--help", "--seed", "1", "--inspect=127.0.0.1:9229", "--name", "file_server", "--root", "/foo", "--force", "https://deno.land/std/http/file_server.ts", "foo", "bar"]);
     assert_eq!(
       r.unwrap(),
       Flags {
@@ -3246,6 +3294,7 @@ mod tests {
         import_map_path: Some("import_map.json".to_string()),
         no_remote: true,
         config_path: Some("tsconfig.json".to_string()),
+        check: true,
         no_check: true,
         reload: true,
         lock: Some(PathBuf::from("lock.json")),
@@ -3384,6 +3433,21 @@ mod tests {
         ..Flags::default()
       }
     );
+  }
+
+  #[test]
+  fn check() {
+    let r = flags_from_vec(svec!["deno", "run", "--check", "script.ts"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Run {
+          script: "script.ts".to_string(),
+        },
+        check: true,
+        ..Flags::default()
+      }
+    )
   }
 
   #[test]
@@ -3927,7 +3991,7 @@ mod tests {
   #[test]
   fn compile_with_flags() {
     #[rustfmt::skip]
-    let r = flags_from_vec(svec!["deno", "compile", "--import-map", "import_map.json", "--no-remote", "--config", "tsconfig.json", "--no-check", "--unsafely-ignore-certificate-errors", "--reload", "--lock", "lock.json", "--lock-write", "--cert", "example.crt", "--cached-only", "--location", "https:foo", "--allow-read", "--allow-net", "--v8-flags=--help", "--seed", "1", "--output", "colors", "https://deno.land/std/examples/colors.ts", "foo", "bar"]);
+    let r = flags_from_vec(svec!["deno", "compile", "--import-map", "import_map.json", "--no-remote", "--config", "tsconfig.json", "--check", "--no-check", "--unsafely-ignore-certificate-errors", "--reload", "--lock", "lock.json", "--lock-write", "--cert", "example.crt", "--cached-only", "--location", "https:foo", "--allow-read", "--allow-net", "--v8-flags=--help", "--seed", "1", "--output", "colors", "https://deno.land/std/examples/colors.ts", "foo", "bar"]);
     assert_eq!(
       r.unwrap(),
       Flags {
@@ -3940,6 +4004,7 @@ mod tests {
         import_map_path: Some("import_map.json".to_string()),
         no_remote: true,
         config_path: Some("tsconfig.json".to_string()),
+        check: true,
         no_check: true,
         reload: true,
         lock: Some(PathBuf::from("lock.json")),

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -613,7 +613,7 @@ async fn create_module_graph_and_maybe_check(
     .await?;
   let module_graph = builder.get_graph();
 
-  if !program_state.flags.no_check {
+  if program_state.flags.check || !program_state.flags.no_check {
     // TODO(@kitsonk) support bundling for workers
     let lib = if program_state.flags.unstable {
       module_graph::TypeLib::UnstableDenoWindow

--- a/cli/tests/integration/bundle_tests.rs
+++ b/cli/tests/integration/bundle_tests.rs
@@ -363,6 +363,12 @@ itest!(bundle_jsx {
   output: "bundle_jsx.out",
 });
 
+itest!(bundle_check {
+  args: "bundle --check bundle_check.ts",
+  output: "bundle_check.ts.out",
+  exit_code: 1,
+});
+
 itest!(error_027_bundle_with_bare_import {
   args: "bundle error_027_bundle_with_bare_import.ts",
   output: "error_027_bundle_with_bare_import.ts.out",

--- a/cli/tests/integration/bundle_tests.rs
+++ b/cli/tests/integration/bundle_tests.rs
@@ -14,6 +14,7 @@ fn bundle_exports() {
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
     .arg("bundle")
+    .arg("--check")
     .arg(mod1)
     .arg(&bundle)
     .spawn()

--- a/cli/tests/integration/cache_tests.rs
+++ b/cli/tests/integration/cache_tests.rs
@@ -45,6 +45,6 @@ itest!(redirect_cache {
 
 itest!(ignore_require {
   args: "cache --reload --no-check ignore_require.js",
-  output_str: Some(""),
+  output_str: Some("warning: The flag --no-check is deprecated and will be removed in the future.\n"),
   exit_code: 0,
 });

--- a/cli/tests/integration/mod.rs
+++ b/cli/tests/integration/mod.rs
@@ -163,7 +163,8 @@ fn cache_test() {
 
   let str_output = std::str::from_utf8(&output.stdout).unwrap();
 
-  let module_output_path = util::testdata_path().join("006_url_imports.ts.out");
+  let module_output_path =
+    util::testdata_path().join("006_url_imports.std.out");
   let mut module_output = String::new();
   let mut module_output_file = fs::File::open(module_output_path).unwrap();
   module_output_file

--- a/cli/tests/testdata/006_url_imports.std.out
+++ b/cli/tests/testdata/006_url_imports.std.out
@@ -1,3 +1,2 @@
-[WILDCARD]
 Hello
 success

--- a/cli/tests/testdata/017_import_redirect.ts.out
+++ b/cli/tests/testdata/017_import_redirect.ts.out
@@ -1,1 +1,2 @@
+[WILDCARD]
 Hello

--- a/cli/tests/testdata/bundle_check.ts
+++ b/cli/tests/testdata/bundle_check.ts
@@ -1,0 +1,1 @@
+export const a: number = "a";

--- a/cli/tests/testdata/bundle_check.ts.out
+++ b/cli/tests/testdata/bundle_check.ts.out
@@ -1,0 +1,5 @@
+[WILDCARD]
+error: TS2322 [ERROR]: Type 'string' is not assignable to type 'number'.
+export const a: number = "a";
+             ^
+    at [WILDCARD]bundle_check.ts:1:14

--- a/cli/tests/testdata/byte_order_mark.out
+++ b/cli/tests/testdata/byte_order_mark.out
@@ -1,1 +1,2 @@
+[WILDCARD]
 Hello World

--- a/cli/tests/testdata/error_no_check.ts.out
+++ b/cli/tests/testdata/error_no_check.ts.out
@@ -1,2 +1,3 @@
+[WILDCARD]
 error: Uncaught SyntaxError: The requested module './subdir/type_and_code.ts' does not provide an export named 'AnInterface'
 [WILDCARD]

--- a/cli/tests/testdata/no_check_decorators.ts.out
+++ b/cli/tests/testdata/no_check_decorators.ts.out
@@ -1,3 +1,4 @@
+warning: The flag --no-check is deprecated and will be removed in the future.
 a(): evaluated
 a(): called
 method

--- a/cli/tests/testdata/runtime_decorators.ts.out
+++ b/cli/tests/testdata/runtime_decorators.ts.out
@@ -1,3 +1,4 @@
+[WILDCARD]
 @A evaluated
 @B evaluated
 @B called

--- a/cli/tests/testdata/test/no_check.out
+++ b/cli/tests/testdata/test/no_check.out
@@ -1,3 +1,4 @@
+warning: The flag --no-check is deprecated and will be removed in the future.
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -216,6 +216,10 @@ pub fn install(
     }
   }
 
+  if flags.check {
+    executable_args.push("--check".to_string());
+  }
+
   if flags.no_check {
     executable_args.push("--no-check".to_string());
   }
@@ -636,7 +640,7 @@ mod tests {
       Flags {
         allow_net: Some(vec![]),
         allow_read: Some(vec![]),
-        no_check: true,
+        check: true,
         log_level: Some(Level::Error),
         ..Flags::default()
       },
@@ -656,9 +660,9 @@ mod tests {
     assert!(file_path.exists());
     let content = fs::read_to_string(file_path).unwrap();
     if cfg!(windows) {
-      assert!(content.contains(r#""run" "--allow-read" "--allow-net" "--quiet" "--no-check" "http://localhost:4545/echo_server.ts" "--foobar""#));
+      assert!(content.contains(r#""run" "--allow-read" "--allow-net" "--quiet" "--check" "http://localhost:4545/echo_server.ts" "--foobar""#));
     } else {
-      assert!(content.contains(r#"run --allow-read --allow-net --quiet --no-check 'http://localhost:4545/echo_server.ts' --foobar"#));
+      assert!(content.contains(r#"run --allow-read --allow-net --quiet --check 'http://localhost:4545/echo_server.ts' --foobar"#));
     }
   }
 

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -225,6 +225,7 @@ pub fn compile_to_runtime_flags(
     lock_write: false,
     lock: None,
     log_level: flags.log_level,
+    check: false,
     no_check: false,
     unsafely_ignore_certificate_errors: flags
       .unsafely_ignore_certificate_errors,

--- a/tools/format.js
+++ b/tools/format.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --unstable --allow-write --allow-read --allow-run
+#!/usr/bin/env -S deno run --unstable --allow-write --allow-read --allow-run --check
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { getPrebuiltToolPath, getSources, join, ROOT_PATH } from "./util.js";
 


### PR DESCRIPTION
Closes: #11340

This PR:

- adds the `--check` flag
- deprecates the `--no-check` flag
- does not type check code by default on subcommands
- logs a warning to stderr that the behaviour has changed and indicates that `--check` can be used to type check

The tests still need to be updated for not type checking by default.

A couple of points of discussion:

- Right now, `deno test` does not type check by default.  It be more logical to implicitly enable `--check` for `deno test`. This does mean this subcommand would differ in default flags than other subcommands, and we would not remote `--no-check` for `deno test`.
- The behavior of `deno cache` reflects the others, skipping type checking by default. We need to determine how it all relates to #11786 (`deno check`).  I don't think `deno check` would replace the use of `--check` flag, as there are lots of subcommands where people would not want to have to invoke 2 subcommands just to check their documents, as well as there is the challenge that we implicitly type check worker scripts contextually, so unless we add flags to `deno check` for the type of code it is checking, some code will fail.
- The way I am managing the `warn_check` flag in `ProgramState` feels hacky to me, but I don't have any great ideas how better to manage it.  We need it, as there are certain commands where the methods get called > 1 times, causing multiple warnings to be printed if we don't have a flag.

