### PR TITLE
fix(ext/ffi): don't panic on invalid enum values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4f2cada3839890da94bb176e26bb61e6577862d443b03848b5c2bded30ed0a"
+checksum = "f5ce7662cda194ff443bddf146c952e83075889590838cd41df768fba7d152d0"
 dependencies = [
  "rusty_v8",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bf7bf03d60f6c5098d2d1867404ff50695435f638c34e4a95b8b3631cb4900"
+checksum = "3c4f2cada3839890da94bb176e26bb61e6577862d443b03848b5c2bded30ed0a"
 dependencies = [
  "rusty_v8",
  "serde",

--- a/cli/tests/unit/ffi_test.ts
+++ b/cli/tests/unit/ffi_test.ts
@@ -1,0 +1,25 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { assertThrows, unitTest } from "./test_util.ts";
+
+unitTest(function dlopenInvalidArguments() {
+  const filename = "/usr/lib/libc.so.6";
+  assertThrows(() => {
+    // @ts-expect-error: ForeignFunction cannot be null
+    Deno.dlopen(filename, { malloc: null });
+  }, TypeError);
+  assertThrows(() => {
+    Deno.dlopen(filename, {
+      // @ts-expect-error: invalid NativeType
+      malloc: { parameters: ["a"], result: "b" },
+    });
+  }, TypeError);
+  assertThrows(() => {
+    // @ts-expect-error: DynamicLibrary symbols cannot be null
+    Deno.dlopen(filename, null);
+  }, TypeError);
+  assertThrows(() => {
+    // @ts-expect-error: require 2 arguments
+    Deno.dlopen(filename);
+  }, TypeError);
+});

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ pin-project = "1.0.7"
 rusty_v8 = "0.26.0"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
-serde_v8 = { version = "0.9.0" }
+serde_v8 = { version = "0.9.2" }
 url = { version = "2.2.2", features = ["serde"] }
 
 [[example]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ pin-project = "1.0.7"
 rusty_v8 = "0.26.0"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
-serde_v8 = { version = "0.9.2" }
+serde_v8 = { version = "0.9.3" }
 url = { version = "2.2.2", features = ["serde"] }
 
 [[example]]


### PR DESCRIPTION
This fixes #11741. It is an alternative to #11791 that doesn't add webidl things to Deno namespace APIs.
