### PR TITLE
Fix error in DiagnosticMessageChain interface

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -155,7 +155,7 @@ declare namespace Deno {
   }
 
   export interface DiagnosticMessageChain {
-    message: string;
+    messageText: string;
     category: DiagnosticCategory;
     code: number;
     next?: DiagnosticMessageChain[];


### PR DESCRIPTION
The types are currently inconsistent with the data presented.

```
{
  category: 1,
  code: 2322,
  start: { line: 42, character: 2 },
  end: { line: 42, character: 77 },
  messageText: null,
  messageChain: {
    messageText: "Type 'Promise<unknown>' is not assignable to type 'Promise<X>'.",
    category: 1,
    code: 2322,
    next: [
      {
        messageText: "Type 'unknown' is not assignable to type 'X'.",
        category: 1,
        code: 2322,
        next: [Array]
      }
    ]
  },
  source: null,
  sourceLine: "  return (p instanceof Promise ? p as Promise<unknown> : Promise.resolve(p));",
  fileName: "file:///Users/sebastienfilion/Developer/i-y.land/web-component/library/utilities.ts",
  relatedInformation: null
}
```

I've run the tests and got a few errors; but I'm not sure how they relate to this issue, I would need guidance.