### PR TITLE
chore(docker): add `Dockerfile` to build `deno` from source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+
+.dockerignore
+docker-bake.hcl
+Dockerfile
+
+deno

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ cli/tests/.test_coverage/
 # WPT generated cert files
 /tools/wpt/certs/index.txt*
 /tools/wpt/certs/serial*
+
+deno

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1.3
+
+ARG RUST_VERSION=1.54.0
+
+
+FROM rust:${RUST_VERSION} AS deps
+
+WORKDIR /src
+
+RUN --mount=type=bind,target=.,rw \
+  --mount=type=cache,target=/usr/local/cargo/registry \
+  cargo fetch
+
+
+FROM deps AS build
+
+RUN --mount=type=bind,target=.,rw \
+  --mount=type=cache,target=./target \
+  --mount=type=cache,target=/usr/local/cargo/registry \
+  cargo build --release \
+  && mkdir -p /out && cp -Rf target /out/
+
+WORKDIR /out
+
+
+FROM scratch AS bin
+
+COPY --from=build /out/target/release/deno /deno
+
+
+FROM debian:latest AS debian
+
+COPY --from=bin /deno /usr/local/bin/deno
+
+CMD [ "deno", "run", "https://deno.land/std/examples/welcome.ts" ]
+
+
+# debian is the default
+FROM debian
+
+
+FROM ubuntu:latest AS ubuntu
+
+COPY --from=bin /deno /usr/local/bin/deno
+
+CMD [ "deno", "run", "https://deno.land/std/examples/welcome.ts" ]
+
+
+FROM alpine:latest AS alpine
+
+COPY --from=bin /deno /usr/local/bin/deno
+
+CMD [ "deno", "run", "https://deno.land/std/examples/welcome.ts" ]
+
+
+FROM centos:latest AS centos
+
+COPY --from=bin /deno /usr/local/bin/deno
+
+CMD [ "deno", "run", "https://deno.land/std/examples/welcome.ts" ]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,46 @@
+variable "IMAGE_NAME" {
+  default = "denoland/deno"
+}
+
+group "default" {
+  targets = ["debian"]
+}
+
+group "all" {
+  targets = ["debian", "ubuntu", "alpine", "centos"]
+}
+
+target "base" {
+  context = "."
+}
+
+target "debian" {
+  inherits = ["base"]
+  tags = ["${IMAGE_NAME}:latest", "${IMAGE_NAME}:debian"]
+}
+
+target "ubuntu" {
+  inherits = ["base"]
+  tags = ["${IMAGE_NAME}:ubuntu"]
+}
+
+target "alpine" {
+  inherits = ["base"]
+  tags = ["${IMAGE_NAME}:alpine"]
+}
+
+target "centos" {
+  inherits = ["base"]
+  tags = ["${IMAGE_NAME}:centos"]
+}
+
+target "bin" {
+  inherits = ["base"]
+  tags = ["denoland/deno:bin"]
+  target = "bin"
+}
+
+target "export-bin" {
+  inherits = ["bin"]
+  output = ["."]
+}


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

I am sending this PR as a PoC for opening the discussion -- it's not yet ready. The goal is to bring a more cloud-native build approach for the main `deno` repository. I have some experience with docker and I would like to contribute, and made a couple of PRs to the `deno_docker` repository as well (https://github.com/denoland/deno_docker/pull/158 and https://github.com/denoland/deno_docker/pull/159).

In the state this PR is, the benefits it brings is:

- Anyone can build the `deno` **docker** image from source **having the repository cloned** by running `docker buildx bake`.
- Anyone can build the `deno` **binary** from source **having the repository cloned** by running `docker buildx bake export-bin` (it will place the `deno` binary in the current dir).
- Anyone can build the `deno` **docker** image from source **without** having the repository cloned by running `docker buildx build git://github.com/denoland/deno`
- Anyone can build the `deno` **docker** binary from source **without** having the repository cloned by running `docker buildx build --target bin --output . git://github.com/denoland/deno#main` or `#v1.13.2` to build a given version.

But this pattern could be further applied to other areas, such as building the releases artifacts (with the benefit of docker providing isolation and environment awareness builds).

Ultimately, I believe the `deno_docker` could be moved to the main `deno` repository, thus keeping the files closer and making it easier to handle the release of new versions (a single commit to rule them all).

## Test:

```
docker buildx build --target bin --output . git://github.com/felipecrs/deno
```

## Demo

[![asciicast](https://asciinema.org/a/KqoSafTl5G5NCKH7wNe2sxY68.svg)](https://asciinema.org/a/KqoSafTl5G5NCKH7wNe2sxY68)