### PR TITLE
feat(core): add a `resolve_value` method

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1708,7 +1708,11 @@ pub mod tests {
     let value_global = runtime
       .execute_script("a.js", "new Promise(resolve => {})")
       .unwrap();
-    let error_string = runtime.resolve_value(value_global).await.unwrap_err().to_string();
+    let error_string = runtime
+      .resolve_value(value_global)
+      .await
+      .unwrap_err()
+      .to_string();
     assert_eq!(
       "Promise resolution is still pending but the event loop has already resolved.",
       error_string,

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -648,6 +648,38 @@ impl JsRuntime {
     scope.perform_microtask_checkpoint();
   }
 
+  /// Waits for the given value to resolve while polling the event loop.
+  ///
+  pub async fn resolve_value(
+    &mut self,
+    global: v8::Global<v8::Value>,
+  ) -> Result<v8::Global<v8::Value>, AnyError> {
+    poll_fn(|cx| {
+      self.poll_event_loop(cx, false);
+      let mut scope = self.handle_scope();
+      let local = v8::Local::<v8::Value>::new(&mut scope, &global);
+
+      if let Ok(promise) = v8::Local::<v8::Promise>::try_from(local) {
+        match promise.state() {
+          v8::PromiseState::Pending => Poll::Pending,
+          v8::PromiseState::Fulfilled => {
+            let value = promise.result(&mut scope);
+            let value_handle = v8::Global::new(&mut scope, value);
+            Poll::Ready(Ok(value_handle))
+          }
+          v8::PromiseState::Rejected => {
+            let exception = promise.result(&mut scope);
+            Poll::Ready(exception_to_err_result(&mut scope, exception, false))
+          }
+        }
+      } else {
+        let value_handle = v8::Global::new(&mut scope, local);
+        Poll::Ready(Ok(value_handle))
+      }
+    })
+    .await
+  }
+
   /// Runs event loop to completion
   ///
   /// This future resolves when:
@@ -1627,6 +1659,42 @@ pub mod tests {
         "foobar"
       );
     }
+  }
+
+  #[tokio::test]
+  async fn test_resolve_value() {
+    let mut runtime = JsRuntime::new(Default::default());
+    let value_global = runtime
+      .execute_script("a.js", "Promise.resolve(1 + 2)")
+      .unwrap();
+    let result_global = runtime.resolve_value(value_global).await.unwrap();
+    {
+      let scope = &mut runtime.handle_scope();
+      let value = result_global.get(scope);
+      assert_eq!(value.integer_value(scope).unwrap(), 3);
+    }
+
+    let value_global = runtime
+      .execute_script(
+        "a.js",
+        "Promise.resolve(new Promise(resolve => resolve(2 + 2)))",
+      )
+      .unwrap();
+    let result_global = runtime.resolve_value(value_global).await.unwrap();
+    {
+      let scope = &mut runtime.handle_scope();
+      let value = result_global.get(scope);
+      assert_eq!(value.integer_value(scope).unwrap(), 4);
+    }
+
+    let value_global = runtime
+      .execute_script("a.js", "Promise.reject(new Error('fail'))")
+      .unwrap();
+    let err = runtime.resolve_value(value_global).await.unwrap_err();
+    assert_eq!(
+      "Uncaught Error: fail",
+      err.downcast::<JsError>().unwrap().message
+    );
   }
 
   #[test]

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1704,6 +1704,15 @@ pub mod tests {
       "Uncaught Error: fail",
       err.downcast::<JsError>().unwrap().message
     );
+
+    let value_global = runtime
+      .execute_script("a.js", "new Promise(resolve => {})")
+      .unwrap();
+    let error_string = runtime.resolve_value(value_global).await.unwrap_err().to_string();
+    assert_eq!(
+      "Promise resolution is still pending but the event loop has already resolved.",
+      error_string,
+    );
   }
 
   #[test]


### PR DESCRIPTION
This adds a `resolve_value` function which will return wait for a value to resolve and return it.
If the value is a promise and it rejects, that is returned as the error.