### PR TITLE
feat: ArrayBuffer in structured clone transfer

### DIFF
--- a/ext/web/internal.d.ts
+++ b/ext/web/internal.d.ts
@@ -88,6 +88,9 @@ declare namespace globalThis {
       declare type Transferable = {
         kind: "messagePort";
         data: number;
+      } | {
+        kind: "arrayBuffer";
+        data: number;
       };
       declare interface MessageData {
         data: Uint8Array;

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -284,11 +284,11 @@
       while (!this.terminated) {
         const data = await hostRecvMessage(this.#id);
         if (data === null) break;
-        let message, transfer;
+        let message, transferables;
         try {
           const v = deserializeJsMessageData(data);
           message = v[0];
-          transfer = v[1];
+          transferables = v[1];
         } catch (err) {
           const event = new MessageEvent("messageerror", {
             cancelable: false,
@@ -300,7 +300,7 @@
         const event = new MessageEvent("message", {
           cancelable: false,
           data: message,
-          ports: transfer,
+          ports: transferables.filter((t) => t instanceof MessagePort),
         });
         this.dispatchEvent(event);
       }

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -135,12 +135,12 @@ delete Object.prototype.__proto__;
       if (data === null) break;
       const v = deserializeJsMessageData(data);
       const message = v[0];
-      const transfer = v[1];
+      const transferables = v[1];
 
       const msgEvent = new MessageEvent("message", {
         cancelable: false,
         data: message,
-        ports: transfer,
+        ports: transferables.filter((t) => t instanceof MessagePort),
       });
 
       try {

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -16195,8 +16195,7 @@
           "Blob paired surrogates (invalid utf-8)",
           "Blob empty",
           "Blob NUL",
-          "File basic",
-          "ArrayBuffer"
+          "File basic"
         ]
       }
     }

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -16251,7 +16251,7 @@
     "message-channels": {
       "basics.any.html": true,
       "close.any.html": true,
-      "dictionary-transferrable.any.html": false,
+      "dictionary-transferrable.any.html": true,
       "implied-start.any.html": true,
       "no-start.any.html": true,
       "user-activation.tentative.any.html": false,


### PR DESCRIPTION
Adds support for transfering ArrayBuffers in structured clone, as used by
Web Workers and `self.structuredClone`.

Closes #11303