### PR TITLE
chore(tests): improve unit tests using `deferred`

### DIFF
--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -394,8 +394,6 @@ unitTest(
 unitTest(
   { perms: { net: true } },
   async function netTcpListenIteratorBreakClosesResource() {
-    const promise = deferred();
-
     async function iterate(listener: Deno.Listener) {
       let i = 0;
 
@@ -407,13 +405,11 @@ unitTest(
           break;
         }
       }
-
-      promise.resolve();
     }
 
     const addr = { hostname: "127.0.0.1", port: 8888 };
     const listener = Deno.listen(addr);
-    iterate(listener);
+    const iteratePromise = iterate(listener);
 
     await delay(100);
     const conn1 = await Deno.connect(addr);
@@ -421,7 +417,7 @@ unitTest(
     const conn2 = await Deno.connect(addr);
     conn2.close();
 
-    await promise;
+    await iteratePromise;
   },
 );
 

--- a/cli/tests/unit/performance_test.ts
+++ b/cli/tests/unit/performance_test.ts
@@ -11,12 +11,14 @@ import {
 unitTest({ perms: { hrtime: false } }, async function performanceNow() {
   const resolvable = deferred();
   const start = performance.now();
+  let totalTime = 0;
   setTimeout(() => {
     const end = performance.now();
-    assert(end - start >= 10);
+    totalTime = end - start;
     resolvable.resolve();
   }, 10);
   await resolvable;
+  assert(totalTime >= 10);
 });
 
 unitTest(function performanceMark() {

--- a/cli/tests/unit/timers_test.ts
+++ b/cli/tests/unit/timers_test.ts
@@ -86,11 +86,10 @@ unitTest(async function timeoutEvalNoScopeLeak() {
 unitTest(async function timeoutArgs() {
   const promise = deferred();
   const arg = 1;
+  let capturedArgs: unknown[] = [];
   setTimeout(
-    (a, b, c) => {
-      assertEquals(a, arg);
-      assertEquals(b, arg.toString());
-      assertEquals(c, [arg]);
+    function () {
+      capturedArgs = [...arguments];
       promise.resolve();
     },
     10,
@@ -99,6 +98,11 @@ unitTest(async function timeoutArgs() {
     [arg],
   );
   await promise;
+  assertEquals(capturedArgs, [
+    arg,
+    arg.toString(),
+    [arg],
+  ]);
 });
 
 unitTest(async function timeoutCancelSuccess() {
@@ -214,14 +218,16 @@ unitTest(async function fireCallbackImmediatelyWhenDelayOverMaxValue() {
 
 unitTest(async function timeoutCallbackThis() {
   const promise = deferred();
+  let capturedThis: unknown;
   const obj = {
     foo() {
-      assertEquals(this, window);
+      capturedThis = this;
       promise.resolve();
     },
   };
   setTimeout(obj.foo, 1);
   await promise;
+  assertEquals(capturedThis, window);
 });
 
 unitTest(async function timeoutBindThis() {


### PR DESCRIPTION
This PR improves the unit tests to not hang if an error or assertion failure occurs before resolving a `deferred`.