### PR TITLE
Change Deno.connect to Deno.listen in documentation for Deno.serveHttp

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2431,7 +2431,7 @@ declare namespace Deno {
    * Services HTTP requests given a TCP or TLS socket.
    *
    * ```ts
-   * const conn = await Deno.connect({ port: 80, hostname: "127.0.0.1" });
+   * const conn = await Deno.listen({ port: 80, hostname: "127.0.0.1" });
    * const httpConn = Deno.serveHttp(conn);
    * const e = await httpConn.nextRequest();
    * if (e) {


### PR DESCRIPTION
The documentation for `Deno.serveHttp` says to create a connection with `Deno.connect`; I believe that `Deno.connect` is used to connect to other resource and that this should use `Deno.listen`. This is consistent with the blog post: https://deno.com/blog/v1.13