### PR TITLE
Documentation: Add async iterator alternative for Deno.serveHttp

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2445,10 +2445,14 @@ declare namespace Deno {
    * Alternatively, you can also use the Async Iterator approach:
    *
    * ```ts
-   * for await (const conn of Deno.listen({ port: 80 })) {
+   * async function handleHttp(conn: Deno.Conn) {
    *   for await (const e of Deno.serveHttp(conn)) {
    *     e.respondWith(new Response("Hello World"));
    *   }
+   * }
+   *
+   * for await (const conn of Deno.listen({ port: 80 })) {
+   *   handleHttp(conn);
    * }
    * ```
    */


### PR DESCRIPTION
Add the async iterator alternative for Deno.serveHttp in the documentation; this is consistent with many examples in the documentation and most of the communication around the feature.

Reference: https://doc.deno.land/builtin/stable#Deno.readDir
  https://doc.deno.land/builtin/stable#Deno.watchFs
Reference: https://deno.com/blog/v1.13