### PR TITLE
fix(cli): retain path based test mode inference

### DIFF
--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -67,6 +67,12 @@ itest!(doc {
   output: "test/doc.out",
 });
 
+itest!(doc_only {
+  args: "test --doc --allow-all test/doc_only",
+  exit_code: 0,
+  output: "test/doc_only.out",
+});
+
 itest!(markdown {
   args: "test --doc --allow-all test/markdown.md",
   exit_code: 1,

--- a/cli/tests/testdata/test/doc_only.out
+++ b/cli/tests/testdata/test/doc_only.out
@@ -1,0 +1,5 @@
+Check [WILDCARD]/test/doc_only/mod.ts$2-5.ts
+running 0 tests from [WILDCARD]/test/doc_only/mod.ts
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+

--- a/cli/tests/testdata/test/doc_only/mod.ts
+++ b/cli/tests/testdata/test/doc_only/mod.ts
@@ -3,6 +3,8 @@
  * import "./mod.ts";
  * ```
  */
-Deno.test("unreachable", function() {
-  throw new Error("modules that don't end with _test are scanned for documentation tests only should not be executed");
+Deno.test("unreachable", function () {
+  throw new Error(
+    "modules that don't end with _test are scanned for documentation tests only should not be executed",
+  );
 });

--- a/cli/tests/testdata/test/doc_only/mod.ts
+++ b/cli/tests/testdata/test/doc_only/mod.ts
@@ -1,0 +1,8 @@
+/**
+ * ```ts
+ * import "./mod.ts";
+ * ```
+ */
+Deno.test("unreachable", function() {
+  throw new Error("modules that don't end with _test are scanned for documentation tests only should not be executed");
+});

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -757,9 +757,7 @@ async fn fetch_specifiers_with_test_mode(
       .fetch(specifier, &mut Permissions::allow_all())
       .await?;
 
-    if file.media_type != MediaType::Unknown {
-      *mode = TestMode::Both
-    } else {
+    if file.media_type == MediaType::Unknown {
       *mode = TestMode::Documentation
     }
   }


### PR DESCRIPTION
Collection keeps track of what is what depending on the predicate used (`collect_specifiers_with_test_mode`).

But seems I added an else branch that sets them all to TestMode::Both in the `fetch_specifiers_with_test_mode` (this shouldn't have been here) which is a secondary pass that is supposed to reduce unknown media types (like README.md) down to `TestMode::Documentation` so that no attempts to execute are made if invoked as `deno test README.md`.

Fixes https://github.com/denoland/deno_std/pull/1171#issuecomment-908409163