### PR TITLE
chore: release scripts should update Cargo.lock file when bumping versions

### DIFF
--- a/tools/release/01_bump_dependency_crate_versions.ts
+++ b/tools/release/01_bump_dependency_crate_versions.ts
@@ -8,5 +8,4 @@ for (const crate of workspace.getDependencyCrates()) {
   await crate.increment("minor");
 }
 
-// update Cargo.lock and ensure it still builds
-await workspace.build();
+await workspace.updateLockFile();

--- a/tools/release/01_bump_dependency_crate_versions.ts
+++ b/tools/release/01_bump_dependency_crate_versions.ts
@@ -7,3 +7,6 @@ const workspace = await DenoWorkspace.load();
 for (const crate of workspace.getDependencyCrates()) {
   await crate.increment("minor");
 }
+
+// update Cargo.lock and ensure it still builds
+await workspace.build();

--- a/tools/release/03_bump_cli_version.ts
+++ b/tools/release/03_bump_cli_version.ts
@@ -14,6 +14,9 @@ const originalVersion = cliCrate.version;
 // increment the version
 await cliCrate.increment(getVersionIncrement());
 
+// update Cargo.lock
+await workspace.build();
+
 // output the Releases.md markdown text
 console.log(
   "You may use the following as a template for updating Releases.md:\n",

--- a/tools/release/03_bump_cli_version.ts
+++ b/tools/release/03_bump_cli_version.ts
@@ -13,9 +13,7 @@ const originalVersion = cliCrate.version;
 
 // increment the version
 await cliCrate.increment(getVersionIncrement());
-
-// update Cargo.lock
-await workspace.build();
+await workspace.updateLockFile();
 
 // output the Releases.md markdown text
 console.log(

--- a/tools/release/helpers/cargo.ts
+++ b/tools/release/helpers/cargo.ts
@@ -46,3 +46,17 @@ export async function publishCrate(directory: string) {
     throw new Error("Failed");
   }
 }
+
+export async function build(directory: string) {
+  const p = Deno.run({
+    cwd: directory,
+    cmd: ["cargo", "build", "-vv"],
+    stderr: "inherit",
+    stdout: "inherit",
+  });
+
+  const status = await p.status();
+  if (!status.success) {
+    throw new Error("Failed");
+  }
+}

--- a/tools/release/helpers/cargo.ts
+++ b/tools/release/helpers/cargo.ts
@@ -33,24 +33,34 @@ export async function getMetadata(directory: string) {
   return JSON.parse(result!) as CargoMetadata;
 }
 
-export async function publishCrate(directory: string) {
-  const p = Deno.run({
-    cwd: directory,
-    cmd: ["cargo", "publish"],
-    stderr: "inherit",
-    stdout: "inherit",
+export function publishCrate(directory: string) {
+  return runCargoSubCommand({
+    directory,
+    args: ["publish"],
   });
-
-  const status = await p.status();
-  if (!status.success) {
-    throw new Error("Failed");
-  }
 }
 
-export async function build(directory: string) {
+export function build(directory: string) {
+  return runCargoSubCommand({
+    directory,
+    args: ["build", "-vv"],
+  });
+}
+
+export function check(directory: string) {
+  return runCargoSubCommand({
+    directory,
+    args: ["check"],
+  });
+}
+
+async function runCargoSubCommand(params: {
+  args: string[];
+  directory: string;
+}) {
   const p = Deno.run({
-    cwd: directory,
-    cmd: ["cargo", "build", "-vv"],
+    cwd: params.directory,
+    cmd: ["cargo", ...params.args],
     stderr: "inherit",
     stdout: "inherit",
   });

--- a/tools/release/helpers/deno_workspace.ts
+++ b/tools/release/helpers/deno_workspace.ts
@@ -83,6 +83,10 @@ export class DenoWorkspace {
   build() {
     return cargo.build(DenoWorkspace.rootDirPath);
   }
+
+  updateLockFile() {
+    return cargo.check(DenoWorkspace.rootDirPath);
+  }
 }
 
 export class DenoWorkspaceCrate {
@@ -152,6 +156,10 @@ export class DenoWorkspaceCrate {
 
   build() {
     return cargo.build(this.directoryPath);
+  }
+
+  updateLockFile() {
+    return cargo.check(this.directoryPath);
   }
 
   increment(part: "major" | "minor" | "patch") {

--- a/tools/release/helpers/deno_workspace.ts
+++ b/tools/release/helpers/deno_workspace.ts
@@ -2,12 +2,7 @@
 
 import * as path from "https://deno.land/std@0.105.0/path/mod.ts";
 import * as semver from "https://deno.land/x/semver@v1.4.0/mod.ts";
-import {
-  CargoMetadata,
-  CargoPackageMetadata,
-  getMetadata,
-  publishCrate,
-} from "./cargo.ts";
+import * as cargo from "./cargo.ts";
 import { getCratesIoMetadata } from "./crates_io.ts";
 import { withRetries } from "./helpers.ts";
 
@@ -21,10 +16,12 @@ export class DenoWorkspace {
   }
 
   static async load(): Promise<DenoWorkspace> {
-    return new DenoWorkspace(await getMetadata(DenoWorkspace.rootDirPath));
+    return new DenoWorkspace(
+      await cargo.getMetadata(DenoWorkspace.rootDirPath),
+    );
   }
 
-  private constructor(metadata: CargoMetadata) {
+  private constructor(metadata: cargo.CargoMetadata) {
     const crates = [];
     for (const memberId of metadata.workspace_members) {
       const pkg = metadata.packages.find((pkg) => pkg.id === memberId);
@@ -82,14 +79,18 @@ export class DenoWorkspace {
     }
     return crate;
   }
+
+  build() {
+    return cargo.build(DenoWorkspace.rootDirPath);
+  }
 }
 
 export class DenoWorkspaceCrate {
   #workspace: DenoWorkspace;
-  #pkg: CargoPackageMetadata;
+  #pkg: cargo.CargoPackageMetadata;
   #isUpdatingManifest = false;
 
-  constructor(workspace: DenoWorkspace, pkg: CargoPackageMetadata) {
+  constructor(workspace: DenoWorkspace, pkg: cargo.CargoPackageMetadata) {
     this.#workspace = workspace;
     this.#pkg = pkg;
   }
@@ -141,12 +142,16 @@ export class DenoWorkspaceCrate {
     // times before failing hard.
     return await withRetries({
       action: async () => {
-        await publishCrate(this.directoryPath);
+        await cargo.publishCrate(this.directoryPath);
         return true;
       },
       retryCount: 3,
       retryDelaySeconds: 10,
     });
+  }
+
+  build() {
+    return cargo.build(this.directoryPath);
   }
 
   increment(part: "major" | "minor" | "patch") {


### PR DESCRIPTION
I was showing Ryan the release scripts and he pointed out that we need to update the lock file when bumping the versions.

I looked into using `cargo generate-lockfile` (https://doc.rust-lang.org/cargo/commands/cargo-generate-lockfile.html) but it updated too much in the lockfile. Instead the solution is to just build, which is probably something we want to do anyway as it ensures it still builds.