### PR TITLE
ci: experiment mac & windows debug builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
           CARGO_PROFILE_RELEASE_LTO: false
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
           CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
-          CARGO_PROFILE_BENCH_INCREMENTAL: true
+          CARGO_PROFILE_RELEASE_INCREMENTAL: true
 
       - name: Build release
         if: |
@@ -425,7 +425,7 @@ jobs:
           CARGO_PROFILE_RELEASE_LTO: false
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
           CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
-          CARGO_PROFILE_BENCH_INCREMENTAL: true
+          CARGO_PROFILE_RELEASE_INCREMENTAL: true
 
       - name: Test release
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: full
       RUSTC_FORCE_INCREMENTAL: 1
-      RUSTFLAGS_FASTCI: "-C codegen-units=256 -C incremental=true -C debuginfo=0 -C opt-level=0"
+      RUSTFLAGS_FASTCI: "-C codegen-units=256 -C debuginfo=0 -C opt-level=0"
 
     steps:
       - name: Configure git
@@ -146,11 +146,11 @@ jobs:
       - name: Error on warning
         # TODO(piscisaureus): enable this on Windows again.
         if: "!matrix.use_sysroot && !startsWith(matrix.os, 'windows')"
-        run: echo "RUSTFLAGS=$RUSTFLAGS -D warnings" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=${{ env.RUSTFLAGS }} -D warnings" >> $GITHUB_ENV
       
       - name: Fast CI Rust flags
         if: "matrix.fast_ci"
-        run: echo "RUSTFLAGS=$RUSTFLAGS ${{ env.RUSTFLAGS_FASTCI }}" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=${{ env.RUSTFLAGS }} ${{ env.RUSTFLAGS_FASTCI }}" >> $GITHUB_ENV
 
       - name: Configure canary build
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,12 +338,9 @@ jobs:
     
       - name: Build fastci
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
-        run: cargo build --release --locked --all-targets
+        run: cargo build --locked --all-targets
         env:
-          CARGO_PROFILE_RELEASE_LTO: false
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
-          CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
-          CARGO_PROFILE_RELEASE_INCREMENTAL: true
+          CARGO_PROFILE_DEV_DEBUG: 0
 
       - name: Build release
         if: |
@@ -420,12 +417,9 @@ jobs:
 
       - name: Test fastci
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
-        run: cargo test --release --locked
+        run: cargo test --locked
         env:
-          CARGO_PROFILE_RELEASE_LTO: false
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
-          CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
-          CARGO_PROFILE_RELEASE_INCREMENTAL: true
+          CARGO_PROFILE_DEV_DEBUG: 0
 
       - name: Test release
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,7 +539,7 @@ jobs:
           git push origin gh-pages
 
       - name: Build product size info
-        if: matrix.job != 'lint'
+        if: matrix.job != 'lint' && matrix.profile != 'fastci'
         run: |
           du -hd1 "./target/${{ matrix.profile }}"
           du -ha  "./target/${{ matrix.profile }}/deno"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,9 @@ jobs:
       - name: Build release
         if: |
           (matrix.job == 'test' || matrix.job == 'bench') &&
-          matrix.profile == 'release' && !matrix.use_sysroot
+          matrix.profile == 'release' && !matrix.use_sysroot &&
+          github.repository == 'denoland/deno' &&
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         run: cargo build --release --locked --all-targets
 
       - name: Build release (in sysroot)
@@ -371,7 +373,9 @@ jobs:
         if: |
           startsWith(matrix.os, 'macOS') &&
           matrix.job == 'test' &&
-          matrix.profile == 'release'
+          matrix.profile == 'release' &&
+          github.repository == 'denoland/deno' &&
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         run: |
           cd target/release
           zip -r deno-x86_64-apple-darwin.zip deno
@@ -380,7 +384,9 @@ jobs:
         if: |
           startsWith(matrix.os, 'windows') &&
           matrix.job == 'test' &&
-          matrix.profile == 'release'
+          matrix.profile == 'release' &&
+          github.repository == 'denoland/deno' &&
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         run: |
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip
 
@@ -424,7 +430,9 @@ jobs:
       - name: Test release
         if: |
           matrix.job == 'test' && matrix.profile == 'release' &&
-          !matrix.use_sysroot
+          !matrix.use_sysroot &&
+          github.repository == 'denoland/deno' &&
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         run: cargo test --release --locked
 
       - name: Test release (in sysroot)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,11 @@ jobs:
           - os: macos-10.15
             job: test
             profile: release
-          - os: macos-10.15
-            job: test
-            profile: debug
+            fast_ci: true
           - os: windows-2019
             job: test
             profile: release
-          - os: windows-2019
-            job: test
-            profile: debug
+            fast_ci: true
           - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
             job: test
             profile: release
@@ -53,7 +49,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: full
       RUSTC_FORCE_INCREMENTAL: 1
-      RUSTFLAGS: "-C debuginfo=0"
+      RUSTFLAGS_FASTCI: "-C codegen-units=256 -C incremental=true -C debuginfo=0 -C opt-level=0"
 
     steps:
       - name: Configure git
@@ -150,7 +146,11 @@ jobs:
       - name: Error on warning
         # TODO(piscisaureus): enable this on Windows again.
         if: "!matrix.use_sysroot && !startsWith(matrix.os, 'windows')"
-        run: echo "RUSTFLAGS=-D warnings" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=$RUSTFLAGS -D warnings" >> $GITHUB_ENV
+      
+      - name: Fast CI Rust flags
+        if: "matrix.fast_ci"
+        run: echo "RUSTFLAGS=$RUSTFLAGS ${{ env.RUSTFLAGS_FASTCI }}" >> $GITHUB_ENV
 
       - name: Configure canary build
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,8 @@ jobs:
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
         run: cargo build --release --locked --all-targets
         env:
-          RUSTFLAGS: "-C codegen-units=256 -C lto=thin -C debuginfo=0 -C opt-level=0"
+          RUSTFLAGS: "-C codegen-units=256 -C debuginfo=0 -C opt-level=0"
+          CARGO_PROFILE_RELEASE_LTO: false
 
       - name: Build release
         if: |
@@ -419,7 +420,8 @@ jobs:
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
         run: cargo test --release --locked
         env:
-          RUSTFLAGS: "-C codegen-units=256 -C lto=thin -C debuginfo=0 -C opt-level=0"
+          RUSTFLAGS: "-C codegen-units=256 -C debuginfo=0 -C opt-level=0"
+          CARGO_PROFILE_RELEASE_LTO: false
 
       - name: Test release
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
         run: cargo build --release --locked --all-targets
         env:
-          RUSTFLAGS: "-C codegen-units=256 -C lto=off -C debuginfo=0 -C opt-level=0"
+          RUSTFLAGS: "-C codegen-units=256 -C lto=thin -C debuginfo=0 -C opt-level=0"
 
       - name: Build release
         if: |
@@ -419,7 +419,7 @@ jobs:
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
         run: cargo test --release --locked
         env:
-          RUSTFLAGS: "-C codegen-units=256 -C lto=off -C debuginfo=0 -C opt-level=0"
+          RUSTFLAGS: "-C codegen-units=256 -C lto=thin -C debuginfo=0 -C opt-level=0"
 
       - name: Test release
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,16 @@ jobs:
         include:
           - os: macos-10.15
             job: test
+            profile: fastci
+          - os: macos-10.15
+            job: test
             profile: release
-            fast_ci: true
+          - os: windows-2019
+            job: test
+            profile: fastci
           - os: windows-2019
             job: test
             profile: release
-            fast_ci: true
           - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
             job: test
             profile: release
@@ -49,7 +53,6 @@ jobs:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: full
       RUSTC_FORCE_INCREMENTAL: 1
-      RUSTFLAGS_FASTCI: "-C codegen-units=256 -C debuginfo=0 -C opt-level=0"
 
     steps:
       - name: Configure git
@@ -336,6 +339,11 @@ jobs:
           (matrix.job == 'test' || matrix.job == 'bench') &&
           matrix.profile == 'debug' && !matrix.use_sysroot
         run: cargo build --locked --all-targets
+    
+      - name: Build fastci
+        if: (matrix.job == 'test' && matrix.profile == 'fastci')
+        env:
+          RUSTFLAGS: "-C codegen-units=256 -C lto=false -C debuginfo=0 -C opt-level=0"
 
       - name: Build release
         if: |
@@ -409,6 +417,11 @@ jobs:
         run: |
           cargo test --locked --doc
           cargo test --locked
+
+      - name: Test fastci
+        if: (matrix.job == 'test' && matrix.profile == 'fastci')
+        env:
+          RUSTFLAGS: "-C codegen-units=256 -C lto=false -C debuginfo=0 -C opt-level=0"
 
       - name: Test release
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,6 @@ jobs:
         # TODO(piscisaureus): enable this on Windows again.
         if: "!matrix.use_sysroot && !startsWith(matrix.os, 'windows')"
         run: echo "RUSTFLAGS=${{ env.RUSTFLAGS }} -D warnings" >> $GITHUB_ENV
-      
-      - name: Fast CI Rust flags
-        if: "matrix.fast_ci"
-        run: echo "RUSTFLAGS=${{ env.RUSTFLAGS }} ${{ env.RUSTFLAGS_FASTCI }}" >> $GITHUB_ENV
 
       - name: Configure canary build
         if: |
@@ -342,6 +338,7 @@ jobs:
     
       - name: Build fastci
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
+        run: cargo build --release --locked --all-targets
         env:
           RUSTFLAGS: "-C codegen-units=256 -C lto=false -C debuginfo=0 -C opt-level=0"
 
@@ -420,6 +417,7 @@ jobs:
 
       - name: Test fastci
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
+        run: cargo test --release --locked
         env:
           RUSTFLAGS: "-C codegen-units=256 -C lto=false -C debuginfo=0 -C opt-level=0"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,13 @@ jobs:
         include:
           - os: macos-10.15
             job: test
+            profile: release
+          - os: macos-10.15
+            job: test
             profile: debug
+          - os: windows-2019
+            job: test
+            profile: release
           - os: windows-2019
             job: test
             profile: debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,8 +340,9 @@ jobs:
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
         run: cargo build --release --locked --all-targets
         env:
-          RUSTFLAGS: "-C codegen-units=256 -C debuginfo=0 -C opt-level=0"
           CARGO_PROFILE_RELEASE_LTO: false
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
 
       - name: Build release
         if: |
@@ -420,8 +421,9 @@ jobs:
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
         run: cargo test --release --locked
         env:
-          RUSTFLAGS: "-C codegen-units=256 -C debuginfo=0 -C opt-level=0"
           CARGO_PROFILE_RELEASE_LTO: false
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
 
       - name: Test release
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,7 @@ jobs:
           CARGO_PROFILE_RELEASE_LTO: false
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
           CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
+          CARGO_PROFILE_BENCH_INCREMENTAL: true
 
       - name: Build release
         if: |
@@ -424,6 +425,7 @@ jobs:
           CARGO_PROFILE_RELEASE_LTO: false
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
           CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
+          CARGO_PROFILE_BENCH_INCREMENTAL: true
 
       - name: Test release
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Error on warning
         # TODO(piscisaureus): enable this on Windows again.
         if: "!matrix.use_sysroot && !startsWith(matrix.os, 'windows')"
-        run: echo "RUSTFLAGS=${{ env.RUSTFLAGS }} -D warnings" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=-D warnings" >> $GITHUB_ENV
 
       - name: Configure canary build
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         include:
           - os: macos-10.15
             job: test
-            profile: release
+            profile: debug
           - os: windows-2019
             job: test
-            profile: release
+            profile: debug
           - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
             job: test
             profile: release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: full
       RUSTC_FORCE_INCREMENTAL: 1
+      RUSTFLAGS: "-C debuginfo=false"
 
     steps:
       - name: Configure git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: full
       RUSTC_FORCE_INCREMENTAL: 1
-      RUSTFLAGS: "-C debuginfo=false"
+      RUSTFLAGS: "-C debuginfo=0"
 
     steps:
       - name: Configure git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
         run: cargo build --release --locked --all-targets
         env:
-          RUSTFLAGS: "-C codegen-units=256 -C lto=false -C debuginfo=0 -C opt-level=0"
+          RUSTFLAGS: "-C codegen-units=256 -C lto=off -C debuginfo=0 -C opt-level=0"
 
       - name: Build release
         if: |
@@ -419,7 +419,7 @@ jobs:
         if: (matrix.job == 'test' && matrix.profile == 'fastci')
         run: cargo test --release --locked
         env:
-          RUSTFLAGS: "-C codegen-units=256 -C lto=false -C debuginfo=0 -C opt-level=0"
+          RUSTFLAGS: "-C codegen-units=256 -C lto=off -C debuginfo=0 -C opt-level=0"
 
       - name: Test release
         if: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,3 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.url]
 opt-level = 3
-
-[patch.crates-io]
-rusty_v8 = { git = 'https://github.com/AaronO/rusty_v8', branch = 'default-to-release-builds' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,3 +113,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.url]
 opt-level = 3
+
+[patch.crates-io]
+rusty_v8 = { git = 'https://github.com/AaronO/rusty_v8', branch = 'default-to-release-builds' }


### PR DESCRIPTION
This experiment evaluates reducing total CI time, by using debug mac/windows build on PR CI.

CI checks in aggregate are as slow as the slowest check, which is windows (& macOS 2nd) in our case.

## Data

- [macOS](https://github.com/denoland/deno/pull/11884/checks?check_run_id=3472067920): ~31mn (~11mn build, ~18mn test)
- [windows](https://github.com/denoland/deno/pull/11884/checks?check_run_id=3472067939): ~23mn (~14mn build, ~7mn test)

## Baselines

Currently total PR CI time is ~40mn (since it has to wait for the slowest job, windows), currently:
- macOS: ~30mn
- windows: ~40mn

## Notes

- The data measured here is **without cargo cache** (whereas release builds currently do use cargo cache)
- CI time is variable, depending mainly on what needs to be rebuilt, changes deeper in the dependency tree naturally require more crates to be rebuilt

## Conclusion

We could reduce our PR CI time from **~40mn to ~20-25mn**, by using debug builds for mac/windows (with cargo cache).

## Assumptions

- PR CI time is currently painful and slows iteration (at ~40mn total CI time)
- CI time for `main` is less sensitive (though this proposal wouldn't increase it)
- It's unlikely that a specific platform would be broken in a way that debug builds pass but release don't
- In the eventuality that happens, those would be caught by CI on `main`