### PR TITLE
feat(workers): Make the `Deno` namespace configurable and unfrozen

### DIFF
--- a/cli/tests/testdata/workers/deno_worker.ts
+++ b/cli/tests/testdata/workers/deno_worker.ts
@@ -1,7 +1,16 @@
+import { assert } from "../../../../test_util/std/testing/asserts.ts";
+
 onmessage = function (e) {
   if (typeof self.Deno === "undefined") {
     throw new Error("Deno namespace not available in worker");
   }
+
+  assert(!Object.isFrozen(self.Deno));
+
+  const desc = Object.getOwnPropertyDescriptor(self, "Deno");
+  assert(desc);
+  assert(desc.configurable);
+  assert(!desc.writable);
 
   postMessage(e.data);
 };

--- a/runtime/js/06_util.js
+++ b/runtime/js/06_util.js
@@ -3,7 +3,6 @@
 
 ((window) => {
   const {
-    ObjectDefineProperty,
     StringPrototypeReplace,
     TypeError,
     Promise,
@@ -53,18 +52,6 @@
     promise.resolve = resolve;
     promise.reject = reject;
     return promise;
-  }
-
-  function immutableDefine(
-    o,
-    p,
-    value,
-  ) {
-    ObjectDefineProperty(o, p, {
-      value,
-      configurable: false,
-      writable: false,
-    });
   }
 
   // Keep in sync with `fromFileUrl()` in `std/path/win32.ts`.
@@ -164,7 +151,6 @@
     createResolvable,
     assert,
     AssertionError,
-    immutableDefine,
     pathFromURL,
     writable,
     nonEnumerable,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -695,8 +695,7 @@ delete Object.prototype.__proto__;
       });
       // Setup `Deno` global - we're actually overriding already
       // existing global `Deno` with `Deno` namespace from "./deno.ts".
-      util.immutableDefine(globalThis, "Deno", finalDenoNs);
-      ObjectFreeze(globalThis.Deno);
+      ObjectDefineProperty(globalThis, "Deno", util.readOnly(finalDenoNs));
       ObjectFreeze(globalThis.Deno.core);
       signals.setSignals();
     } else {


### PR DESCRIPTION
This is the worker counterpart of PR #11062.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
