### PR TITLE
feat(cli): add before and after test hooks

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -133,58 +133,62 @@ declare namespace Deno {
     sanitizeExit?: boolean;
   }
 
-  /** Register a test which will be run when `deno test` is used on the command
-   * line and the containing module looks like a test module.
-   * `fn` can be async if required.
-   * ```ts
-   * import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
-   *
-   * Deno.test({
-   *   name: "example test",
-   *   fn(): void {
-   *     assertEquals("world", "world");
-   *   },
-   * });
-   *
-   * Deno.test({
-   *   name: "example ignored test",
-   *   ignore: Deno.build.os === "windows",
-   *   fn(): void {
-   *     // This test is ignored only on Windows machines
-   *   },
-   * });
-   *
-   * Deno.test({
-   *   name: "example async test",
-   *   async fn() {
-   *     const decoder = new TextDecoder("utf-8");
-   *     const data = await Deno.readFile("hello_world.txt");
-   *     assertEquals(decoder.decode(data), "Hello world");
-   *   }
-   * });
-   * ```
-   */
-  export function test(t: TestDefinition): void;
+  export interface TestHarness {
+    /** Register a test which will be run when `deno test` is used on the command
+     * line and the containing module looks like a test module.
+     * `fn` can be async if required.
+     * ```ts
+     * import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
+     *
+     * Deno.test({
+     *   name: "example test",
+     *   fn(): void {
+     *     assertEquals("world", "world");
+     *   },
+     * });
+     *
+     * Deno.test({
+     *   name: "example ignored test",
+     *   ignore: Deno.build.os === "windows",
+     *   fn(): void {
+     *     // This test is ignored only on Windows machines
+     *   },
+     * });
+     *
+     * Deno.test({
+     *   name: "example async test",
+     *   async fn() {
+     *     const decoder = new TextDecoder("utf-8");
+     *     const data = await Deno.readFile("hello_world.txt");
+     *     assertEquals(decoder.decode(data), "Hello world");
+     *   }
+     * });
+     * ```
+     */
+    (t: TestDefinition): void;
 
-  /** Register a test which will be run when `deno test` is used on the command
-   * line and the containing module looks like a test module.
-   * `fn` can be async if required.
-   *
-   * ```ts
-   * import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
-   *
-   * Deno.test("My test description", ():void => {
-   *   assertEquals("hello", "hello");
-   * });
-   *
-   * Deno.test("My async test description", async ():Promise<void> => {
-   *   const decoder = new TextDecoder("utf-8");
-   *   const data = await Deno.readFile("hello_world.txt");
-   *   assertEquals(decoder.decode(data), "Hello world");
-   * });
-   * ```
-   * */
-  export function test(name: string, fn: () => void | Promise<void>): void;
+    /** Register a test which will be run when `deno test` is used on the command
+     * line and the containing module looks like a test module.
+     * `fn` can be async if required.
+     *
+     * ```ts
+     * import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
+     *
+     * Deno.test("My test description", ():void => {
+     *   assertEquals("hello", "hello");
+     * });
+     *
+     * Deno.test("My async test description", async ():Promise<void> => {
+     *   const decoder = new TextDecoder("utf-8");
+     *   const data = await Deno.readFile("hello_world.txt");
+     *   assertEquals(decoder.decode(data), "Hello world");
+     * });
+     * ```
+     * */
+    (name: string, fn: () => void | Promise<void>): void;
+  }
+
+  export var test: TestHarness;
 
   /** Exit the Deno process with optional exit code. If no exit code is supplied
    * then Deno will exit with return code of 0.

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -951,6 +951,37 @@ declare namespace Deno {
     bytesReceived: number;
   }
 
+  /** **UNSTABLE**: New functionality, yet to be vetted. */
+  export interface TestHarness {
+    /** Registers a hook which will be run before any tests are executed.
+     * `fn` can be async if required.
+     * ```
+     * Deno.test.before(function() {
+     *   console.log("This ran before any tests");
+     * });
+     *
+     * Deno.test("example test", function() {
+     *   console.log("This is the test");
+     * });
+     * ```
+     */
+    before(fn: () => void | Promise<void>): void;
+
+    /** Registers a hook which will be run after all tests have been executed.
+     * `fn` can be async if required.
+     * ```
+     * Deno.test.after(function() {
+     *   console.log("This ran after all tests");
+     * });
+     *
+     * Deno.test("example test", function() {
+     *   console.log("This is the test");
+     * });
+     * ```
+     */
+    after(fn: () => void | Promise<void>): void;
+  }
+
   /** **UNSTABLE**: New option, yet to be vetted. */
   export interface TestDefinition {
     /** Specifies the permissions that should be used to run the test.

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -955,7 +955,8 @@ declare namespace Deno {
   export interface TestHarness {
     /** Registers a hook which will be run before any tests are executed.
      * `fn` can be async if required.
-     * ```
+     *
+     * ```ts
      * Deno.test.before(function() {
      *   console.log("This ran before any tests");
      * });
@@ -969,7 +970,8 @@ declare namespace Deno {
 
     /** Registers a hook which will be run after all tests have been executed.
      * `fn` can be async if required.
-     * ```
+     *
+     * ```ts
      * Deno.test.after(function() {
      *   console.log("This ran after all tests");
      * });

--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -55,6 +55,12 @@ itest!(collect {
   output: "test/collect.out",
 });
 
+itest!(before_after {
+  args: "test --unstable test/before_after.ts",
+  exit_code: 0,
+  output: "test/before_after.out",
+});
+
 itest!(load_unload {
   args: "test test/load_unload.ts",
   exit_code: 0,

--- a/cli/tests/testdata/test/before_after.out
+++ b/cli/tests/testdata/test/before_after.out
@@ -1,0 +1,8 @@
+Check [WILDCARD]/test/before_after.ts
+running 3 tests from [WILDCARD]/test/before_after.ts
+test test 1 ... ok ([WILDCARD])
+test test 2 ... ok ([WILDCARD])
+test test 3 ... ok ([WILDCARD])
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+

--- a/cli/tests/testdata/test/before_after.ts
+++ b/cli/tests/testdata/test/before_after.ts
@@ -1,0 +1,72 @@
+import { assertEquals } from "../../../../test_util/std/testing/asserts.ts";
+
+const state: string[] = [];
+
+Deno.test.before(function () {
+  assertEquals(state, []);
+  state.push("before 1");
+});
+
+Deno.test.before(function () {
+  assertEquals(state, ["before 1"]);
+  state.push("before 2");
+});
+
+Deno.test.before(function () {
+  assertEquals(state, ["before 1", "before 2"]);
+  state.push("before 3");
+});
+
+Deno.test("test 1", function () {
+  assertEquals(state, ["before 1", "before 2", "before 3"]);
+  state.push("test 1");
+});
+
+Deno.test("test 2", function () {
+  assertEquals(state, ["before 1", "before 2", "before 3", "test 1"]);
+  state.push("test 2");
+});
+
+Deno.test("test 3", function () {
+  assertEquals(state, ["before 1", "before 2", "before 3", "test 1", "test 2"]);
+  state.push("test 3");
+});
+
+Deno.test.after(function () {
+  assertEquals(state, [
+    "before 1",
+    "before 2",
+    "before 3",
+    "test 1",
+    "test 2",
+    "test 3",
+  ]);
+  state.push("after 1");
+});
+
+Deno.test.after(function () {
+  assertEquals(state, [
+    "before 1",
+    "before 2",
+    "before 3",
+    "test 1",
+    "test 2",
+    "test 3",
+    "after 1",
+  ]);
+  state.push("after 2");
+});
+
+Deno.test.after(function () {
+  assertEquals(state, [
+    "before 1",
+    "before 2",
+    "before 3",
+    "test 1",
+    "test 2",
+    "test 3",
+    "after 1",
+    "after 2",
+  ]);
+  state.push("after 3");
+});


### PR DESCRIPTION
The load and unload events are a good point to do setup and teardown but often not enough when you need to do
something asynchronous like say send a http request to delete restful resources.

This adds before and after hooks which are ran before any tests execute and after all tests have executed.

Prior art:
- https://jestjs.io/docs/setup-teardown#repeating-setup-for-many-tests
- https://github.com/avajs/ava/blob/main/docs/01-writing-tests.md#before--after-hooks
- https://mochajs.org/#hooks
- https://jasmine.github.io/api/edge/global.html#beforeAll
- https://jasmine.github.io/api/edge/global.html#afterAll