### PR TITLE
chore(test): improve flaky `lsp_diagnostics_refresh_dependents` test to give more info

### DIFF
--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -2935,7 +2935,7 @@ fn lsp_diagnostics_refresh_dependents() {
     if queue_len - i <= 3 {
       assert!(maybe_params.is_some());
       let params = maybe_params.unwrap();
-      assert!(params.diagnostics.is_empty());
+      assert_eq!(params.diagnostics, Vec::with_capacity(0));
     }
   }
   assert!(client.queue_is_empty());


### PR DESCRIPTION
This test was failing on the CI with `'assertion failed: params.diagnostics.is_empty()'`. This change makes it so that the CI gives us a little more information about what's going on.