### PR TITLE
Don't drop messages from workers that have already been closed

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1177,6 +1177,11 @@ itest!(worker_close_race {
   output: "worker_close_race.js.out",
 });
 
+itest!(worker_message_before_close {
+  args: "run --quiet --reload --allow-read worker_message_before_close.js",
+  output: "worker_message_before_close.js.out",
+});
+
 #[test]
 fn no_validate_asm() {
   let output = util::deno_cmd()

--- a/cli/tests/testdata/worker_message_before_close.js
+++ b/cli/tests/testdata/worker_message_before_close.js
@@ -1,0 +1,16 @@
+for (let i = 0; i < 4; i++) {
+  const worker = new Worker(
+    new URL("./workers/message_before_close.js", import.meta.url).href,
+    { type: "module", name: String(i) },
+  );
+
+  worker.addEventListener("message", (message) => {
+    // Only print responses after all reception logs.
+    setTimeout(() => {
+      console.log("response from worker %d received", message.data);
+    }, 500);
+  });
+  worker.postMessage(i);
+}
+
+export {};

--- a/cli/tests/testdata/worker_message_before_close.js.out
+++ b/cli/tests/testdata/worker_message_before_close.js.out
@@ -1,0 +1,8 @@
+message received in worker 0
+message received in worker 1
+message received in worker 2
+message received in worker 3
+response from worker 0 received
+response from worker 1 received
+response from worker 2 received
+response from worker 3 received

--- a/cli/tests/testdata/workers/message_before_close.js
+++ b/cli/tests/testdata/workers/message_before_close.js
@@ -1,0 +1,6 @@
+self.onmessage = (params) => {
+  const workerId = params.data;
+  console.log("message received in worker %d", workerId);
+  self.postMessage(workerId);
+  self.close();
+};


### PR DESCRIPTION
When `worker.terminate()` is called, the spec requires that the corresponding port message queue is emptied, so no messages can be received after the call, even if they were sent from the worker before it was terminated.

The spec doesn't require this of `self.close()`, and since Deno uses different channels to send messages and to notify that the worker was closed, messages might still arrive after the worker is known to be closed, which are currently being dropped. This change fixes that.

The fix involves two parts: one on the JS side and one on the Rust side. The JS side was using the `#terminated` flag to keep track of whether the worker is known to be closed, without distinguishing whether further messages should be dropped or not. This PR changes that flag to an enum `#state`, which can be one of `"RUNNING"`, `"CLOSED"` or `"TERMINATED"`.

The Rust side was removing the `WorkerThread` struct from the workers table when a close control was received, regardless of whether there were any messages left to read, which made any subsequent calls to `op_host_recv_message` to return `Ok(None)`, as if there were no more mesasges. This change instead waits for both a close control and for the message channel's sender to be closed before the worker thread is removed from the table.

Fixes #11526.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
