### PR TITLE
fix(doc): Fix rustdoc bare_urls warning

### DIFF
--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 //! This module is meant to eventually implement HTTP cache
-//! as defined in RFC 7234 (https://tools.ietf.org/html/rfc7234).
+//! as defined in RFC 7234 (<https://tools.ietf.org/html/rfc7234>).
 //! Currently it's a very simplified version to fulfill Deno needs
 //! at hand.
 use crate::fs_util;

--- a/cli/import_map.rs
+++ b/cli/import_map.rs
@@ -160,7 +160,7 @@ impl ImportMap {
 
   /// Parse provided key as import map specifier.
   ///
-  /// Specifiers must be valid URLs (eg. "https://deno.land/x/std/testing/asserts.ts")
+  /// Specifiers must be valid URLs (eg. "`https://deno.land/x/std/testing/asserts.ts`")
   /// or "bare" specifiers (eg. "moment").
   fn normalize_specifier_key(
     specifier_key: &str,

--- a/cli/lsp/urls.rs
+++ b/cli/lsp/urls.rs
@@ -20,7 +20,7 @@ lazy_static::lazy_static! {
 /// Matches the `encodeURIComponent()` encoding from JavaScript, which matches
 /// the component percent encoding set.
 ///
-/// See: https://url.spec.whatwg.org/#component-percent-encode-set
+/// See: <https://url.spec.whatwg.org/#component-percent-encode-set>
 ///
 // TODO(@kitsonk) - refactor when #9934 is landed.
 const COMPONENT: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS

--- a/cli/text_encoding.rs
+++ b/cli/text_encoding.rs
@@ -29,7 +29,7 @@ pub fn detect_charset(bytes: &'_ [u8]) -> &'static str {
 ///
 /// Supports all encodings supported by the encoding_rs crate, which includes
 /// all encodings specified in the WHATWG Encoding Standard, and only those
-/// encodings (see: https://encoding.spec.whatwg.org/).
+/// encodings (see: <https://encoding.spec.whatwg.org/>).
 pub fn convert_to_utf8<'a>(
   bytes: &'a [u8],
   charset: &'_ str,

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -89,7 +89,7 @@ pub async fn format(
   Ok(())
 }
 
-/// Formats markdown (using https://github.com/dprint/dprint-plugin-markdown) and its code blocks
+/// Formats markdown (using <https://github.com/dprint/dprint-plugin-markdown>) and its code blocks
 /// (ts/tsx, js/jsx).
 fn format_markdown(
   file_text: &str,
@@ -144,8 +144,8 @@ fn format_markdown(
 }
 
 /// Formats JSON and JSONC using the rules provided by .deno()
-/// of configuration builder of https://github.com/dprint/dprint-plugin-json.
-/// See https://git.io/Jt4ht for configuration.
+/// of configuration builder of <https://github.com/dprint/dprint-plugin-json>.
+/// See <https://git.io/Jt4ht> for configuration.
 fn format_json(file_text: &str) -> Result<String, String> {
   let json_config = get_json_config();
   dprint_plugin_json::format_text(file_text, &json_config)

--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -1,8 +1,8 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 //! The documentation for the inspector API is sparse, but these are helpful:
-//! https://chromedevtools.github.io/devtools-protocol/
-//! https://hyperandroid.com/2020/02/12/v8-inspector-from-an-embedder-standpoint/
+//! <https://chromedevtools.github.io/devtools-protocol/>
+//! <https://hyperandroid.com/2020/02/12/v8-inspector-from-an-embedder-standpoint/>
 
 use crate::error::generic_error;
 use crate::error::AnyError;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -101,7 +101,7 @@ pub fn v8_version() -> &'static str {
 /// A helper macro that will return a call site in Rust code. Should be
 /// used when executing internal one-line scripts for JsRuntime lifecycle.
 ///
-/// Returns a string in form of: "[deno:<filename>:<line>:<column>]"
+/// Returns a string in form of: "`[deno:<filename>:<line>:<column>]`"
 #[macro_export]
 macro_rules! located_script_name {
   () => {

--- a/core/module_specifier.rs
+++ b/core/module_specifier.rs
@@ -54,7 +54,7 @@ impl fmt::Display for ModuleResolutionError {
 pub type ModuleSpecifier = Url;
 
 /// Resolves module using this algorithm:
-/// https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier
+/// <https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier>
 pub fn resolve_import(
   specifier: &str,
   base: &str,

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -41,8 +41,8 @@ pub type ModuleLoadId = i32;
 ///
 /// Found module URL might be different from specified URL
 /// used for loading due to redirections (like HTTP 303).
-/// Eg. Both "https://example.com/a.ts" and
-/// "https://example.com/b.ts" may point to "https://example.com/c.ts"
+/// Eg. Both "`https://example.com/a.ts`" and
+/// "`https://example.com/b.ts`" may point to "`https://example.com/c.ts`"
 /// By keeping track of specified and found URL we can alias modules and avoid
 /// recompiling the same code 3 times.
 // TODO(bartlomieju): I have a strong opinion we should store all redirects
@@ -65,7 +65,7 @@ pub trait ModuleLoader {
   /// Returns an absolute URL.
   /// When implementing an spec-complaint VM, this should be exactly the
   /// algorithm described here:
-  /// https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier
+  /// <https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier>
   ///
   /// `is_main` can be used to resolve from current working directory or
   /// apply import map for child imports.

--- a/core/normalize_path.rs
+++ b/core/normalize_path.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 /// Similar to `fs::canonicalize()` but doesn't resolve symlinks.
 ///
 /// Taken from Cargo
-/// https://github.com/rust-lang/cargo/blob/af307a38c20a753ec60f0ad18be5abed3db3c9ac/src/cargo/util/paths.rs#L60-L85
+/// <https://github.com/rust-lang/cargo/blob/af307a38c20a753ec60f0ad18be5abed3db3c9ac/src/cargo/util/paths.rs#L60-L85>
 pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
   let mut components = path.as_ref().components().peekable();
   let mut ret =


### PR DESCRIPTION
Lint rules: https://doc.rust-lang.org/rustdoc/lints.html?highlight=bare#bare_urls

```
$ cargo doc --open
warning: unresolved link to `deno:<filename>:<line>:<column>`
   --> core/lib.rs:104:36
    |
104 | /// Returns a string in form of: "[deno:<filename>:<line>:<column>]"
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ has invalid path separator
    |
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
warning: this URL is not a hyperlink
 --> core/inspector.rs:4:5
  |
4 | //! https://chromedevtools.github.io/devtools-protocol/
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://chromedevtools.github.io/devtools-protocol/>`
  |
  = note: `#[warn(rustdoc::bare_urls)]` on by default
  = note: bare URLs are not automatically turned into clickable links
```