### PR TITLE
chore: add dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This pr add dependabot for rust automated dependency updates. I am not sure if the automated deps update suits deno, so I post a dicussion here: https://github.com/denoland/deno/discussions/11919

Dependabot creates pull requests to keep your Rust dependencies up-to-date. see introduction page: https://dependabot.com/rust/

The documentation for all configuration options:
https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates