### PR TITLE
chore: upgrade third_party for dprint 0.17

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -1,6 +1,4 @@
 {
-  "$schema": "https://dprint.dev/schemas/v0.json",
-  "projectType": "openSource",
   "incremental": true,
   "typescript": {
     "deno": true


### PR DESCRIPTION
We were on dprint 0.13 and the plugin cache has differed for a while so whenever I would run `./tools/format.js` it would clear my plugin cache and cause a redownload. This change upgrades to the latest dprint 0.17.