### PR TITLE
docs(ext/net): add note about listening 0.0.0.0

### DIFF
--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -49,7 +49,12 @@ declare namespace Deno {
     /** The port to listen on. */
     port: number;
     /** A literal IP address or host name that can be resolved to an IP address.
-     * If not specified, defaults to `0.0.0.0`. */
+     * If not specified, defaults to `0.0.0.0`.
+     *
+     * __Note about 0.0.0.0__ While listeninig 0.0.0.0 works on all platforms,
+     * the browsers on Windows don't work with the address 0.0.0.0.
+     * You should show the message like `server running on localhost:8080` instead of
+     * `server running on 0.0.0.0:8080` if your program supports Windows. */
     hostname?: string;
   }
 

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -51,8 +51,8 @@ declare namespace Deno {
     /** A literal IP address or host name that can be resolved to an IP address.
      * If not specified, defaults to `0.0.0.0`.
      *
-     * __Note about 0.0.0.0__ While listeninig 0.0.0.0 works on all platforms,
-     * the browsers on Windows don't work with the address 0.0.0.0.
+     * __Note about `0.0.0.0`__ While listening `0.0.0.0` works on all platforms,
+     * the browsers on Windows don't work with the address `0.0.0.0`.
      * You should show the message like `server running on localhost:8080` instead of
      * `server running on 0.0.0.0:8080` if your program supports Windows. */
     hostname?: string;


### PR DESCRIPTION
This PR adds a side note about the default address (0.0.0.0) of Deno.listen().

Listening this address works for all platforms, but the browsers on windows don't work with the address 0.0.0.0, and that's been causing the confusions to Windows users of several tools (ref: https://github.com/denoland/deno_std/issues/1165 https://github.com/denoland/deployctl/issues/63 https://github.com/kt3k/packup/issues/10

This side note tries to warn the tool authors about the above situation.

closes https://github.com/denoland/deno_std/issues/1165