### PR TITLE
fix: bring back Deno.Signal to unstable props

### DIFF
--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -57,6 +57,7 @@ const UNSTABLE_DENO_PROPS: &[&str] = &[
   "resolveDns",
   "setRaw",
   "shutdown",
+  "Signal",
   "signal",
   "signals",
   "sleepSync",


### PR DESCRIPTION
Erroneously removed in https://github.com/denoland/deno/pull/11909/files