### PR TITLE
A `Request` whose URL is a revoked blob URL should still fetch

### DIFF
--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -19,6 +19,7 @@
   const { mixinBody, extractBody } = window.__bootstrap.fetchBody;
   const { getLocationHref } = window.__bootstrap.location;
   const mimesniff = window.__bootstrap.mimesniff;
+  const { blobFromObjectUrl } = window.__bootstrap.file;
   const {
     headersFromHeaderList,
     headerListFromHeaders,
@@ -59,6 +60,7 @@
    * @property {number} redirectCount
    * @property {string[]} urlList
    * @property {number | null} clientRid NOTE: non standard extension for `Deno.HttpClient`.
+   * @property {Blob | null} blobUrlEntry
    */
 
   const defaultInnerRequest = {
@@ -81,11 +83,16 @@
    * @returns
    */
   function newInnerRequest(method, url, headerList = [], body = null) {
+    let blobUrlEntry = null;
+    if (url.startsWith("blob:")) {
+      blobUrlEntry = blobFromObjectUrl(url);
+    }
     return {
       method: method,
       headerList,
       body,
       urlList: [url],
+      blobUrlEntry,
       ...defaultInnerRequest,
     };
   }
@@ -118,6 +125,7 @@
       redirectCount: request.redirectCount,
       urlList: request.urlList,
       clientRid: request.clientRid,
+      blobUrlEntry: request.blobUrlEntry,
     };
   }
 

--- a/ext/web/internal.d.ts
+++ b/ext/web/internal.d.ts
@@ -73,6 +73,7 @@ declare namespace globalThis {
     };
 
     declare var file: {
+      blobFromObjectUrl(url: string): Blob | null;
       getParts(blob: Blob): string[];
       Blob: typeof Blob;
       File: typeof File;

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -29,6 +29,7 @@ use std::usize;
 
 use crate::blob::op_blob_create_object_url;
 use crate::blob::op_blob_create_part;
+use crate::blob::op_blob_from_object_url;
 use crate::blob::op_blob_read_part;
 use crate::blob::op_blob_remove_part;
 use crate::blob::op_blob_revoke_object_url;
@@ -88,6 +89,7 @@ pub fn init(blob_store: BlobStore, maybe_location: Option<Url>) -> Extension {
         "op_blob_revoke_object_url",
         op_sync(op_blob_revoke_object_url),
       ),
+      ("op_blob_from_object_url", op_sync(op_blob_from_object_url)),
       (
         "op_message_port_create_entangled",
         op_sync(op_message_port_create_entangled),

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -13987,9 +13987,7 @@
     "fileReader.any.html": true,
     "url": {
       "url-format.any.html": true,
-      "url-with-fetch.any.html": [
-        "Revoke blob URL after creating Request, will fetch"
-      ]
+      "url-with-fetch.any.html": true
     },
     "reading-data-section": {
       "Determining-Encoding.any.html": true,


### PR DESCRIPTION
In the spec, a URL record has an associated "blob URL entry", which for `blob:` URLs is populated during parsing to contain a reference to the `Blob` object that backs that object URL. It is this blob URL entry that the `fetch` API uses to resolve an object URL.

Therefore, since the `Request` constructor parses URL inputs, it will have an associated blob URL entry which will be used when fetching, even if the object URL has been revoked since the construction of the `Request` object. (The `Request` constructor takes the URL as a string and parses it, so the object URL must be live at the time it is called.)

This PR adds a new `blobFromObjectUrl` JS function (backed by a new `op_blob_from_object_url` op) that, if the URL is a valid object URL, returns a new `Blob` object whose parts are references to the same Rust `BlobPart`s used by the original `Blob` object. It uses this function to add a new `blobUrlEntry` field to inner requests, which will be `null` or such a `Blob`, and then uses `Blob.prototype.stream()` as the response's body. As a result of this, the `blob:` URL resolution from `op_fetch` is now useless, and has been removed.

Fixes #11817.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
