### PR TITLE
fix(ext/web): Preserve stack traces for DOMExceptions

### DIFF
--- a/cli/tests/testdata/dom_exception_formatting.ts.out
+++ b/cli/tests/testdata/dom_exception_formatting.ts.out
@@ -1,2 +1,3 @@
 [WILDCARD]error: Uncaught SyntaxError: foo
 [WILDCARD]
+    at file:///[WILDCARD]/dom_exception_formatting.ts:[WILDCARD]

--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -11,6 +11,8 @@
 
 ((window) => {
   const {
+    ArrayPrototypeSlice,
+    Error,
     ErrorPrototype,
     ObjectDefineProperty,
     ObjectEntries,
@@ -94,6 +96,16 @@
         context: "Argument 2",
       });
       this.#code = nameToCodeMapping[this.#name] ?? 0;
+
+      // `DOMException` does not have `.stack`, so `Error.prepareStackTrace()`
+      // is not called on it, meaning our structured stack trace hack doesn't
+      // apply. This patches it in.
+      const error = new Error();
+      error.stack;
+      ObjectDefineProperty(this, "__callSiteEvals", {
+        value: ArrayPrototypeSlice(error.__callSiteEvals, 1),
+        configurable: true,
+      });
     }
 
     get message() {


### PR DESCRIPTION
```ts
throw new DOMException("foo", "SyntaxError");
```
`v1.13.2`:
```
error: Uncaught
```
`main` (as of #11834)
```
error: Uncaught SyntaxError: foo
```
This PR:
```
error: Uncaught SyntaxError: foo
throw new DOMException("foo", "SyntaxError");
      ^
    at file:///home/nayeem/projects/deno/temp.js:1:7
```