### PR TITLE
refactor(runtime): Use `util.nonEnumerable` to define `console`

### DIFF
--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -418,7 +418,7 @@ delete Object.prototype.__proto__;
     btoa: util.writable(base64.btoa),
     clearInterval: util.writable(timers.clearInterval),
     clearTimeout: util.writable(timers.clearTimeout),
-    console: util.writable(
+    console: util.nonEnumerable(
       new Console((msg, level) => core.print(msg, level > 1)),
     ),
     crypto: util.readOnly(crypto.crypto),
@@ -467,11 +467,6 @@ delete Object.prototype.__proto__;
     GPUOutOfMemoryError: util.nonEnumerable(webgpu.GPUOutOfMemoryError),
     GPUValidationError: util.nonEnumerable(webgpu.GPUValidationError),
   };
-
-  // The console seems to be the only one that should be writable and non-enumerable
-  // thus we don't have a unique helper for it. If other properties follow the same
-  // structure, it might be worth it to define a helper in `util`
-  windowOrWorkerGlobalScope.console.enumerable = false;
 
   const mainRuntimeGlobalProperties = {
     Location: location.locationConstructorDescriptor,


### PR DESCRIPTION
refactor(runtime): Use `util.nonEnumerable` to define `console`

A comment in `runtime.js` reads that `console` seems to be "the only one that should be writable and non-enumerable", which explains why it is declared with `util.writable` but then has its property descriptor's `enumerable` key changed to false.

But it is not in fact true that `console` is the only global property for which this holds, and it wasn't even when this behavior was introduced in denoland#9013. All WebIDL interfaces are also writable and non-enumerable – the only difference here being that `console` is a namespace rather than an interface.

Since WebIDL interfaces are defined with `util.nonEnumerable`, and `console` uses the same descriptor keys, this PR changes the definition of `console` to use `util.nonEnumerable` as well.

--------------------------

<details>
<summary>Here's the original commit message:</summary>
<p>

A comment in `runtime.js` reads that `console` seems to be "the only one that should be writable and non-enumerable", which explains why it is declared with `util.writable` to then have the property descriptor's `enumerable` key changed to false.

That is not in fact true, and it wasn't even in #9013, when that behavior was introduced. In fact all WebIDL interfaces are writable and non-enumerable, declared with `util.nonEnumerable` – the difference here being that `console` is a namespace / object.

WebIDL, however, treats namespaces and interfaces similarly, and defines them with the same descriptor keys, so this PR changes the definition of `console` to use `util.nonEnumerable`.
</details>

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
