### PR TITLE
refactor(core): Turn the `wasm_streaming_feed` binding into ops

### DIFF
--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -56,25 +56,18 @@ declare namespace Deno {
      * (`WebAssembly.compileStreaming` and `WebAssembly.instantiateStreaming`)
      * are called in order to feed the source's bytes to the wasm compiler.
      * The callback is called with the source argument passed to the streaming
-     * APIs and an rid to use with `Deno.core.wasmStreamingFeed`.
+     * APIs and an rid to use with the wasm streaming ops.
+     *
+     * The callback should eventually invoke the following ops:
+     *   - `op_wasm_streaming_feed`. Feeds bytes from the wasm resource to the
+     *     compiler. Takes the rid and a `Uint8Array`.
+     *   - `op_wasm_streaming_abort`. Aborts the wasm compilation. Takes the rid
+     *     and an exception. Invalidates the resource.
+     *   - To indicate the end of the resource, use `Deno.core.close()` with the
+     *     rid.
      */
     function setWasmStreamingCallback(
       cb: (source: any, rid: number) => void,
     ): void;
-
-    /**
-     * Affect the state of the WebAssembly streaming compiler, by either passing
-     * it bytes, aborting it, or indicating that all bytes were received.
-     * `rid` must be a resource ID that was passed to the callback set with
-     * `Deno.core.setWasmStreamingCallback`. Calling this function with `type`
-     * set to either "abort" or "finish" invalidates the rid.
-     */
-    function wasmStreamingFeed(
-      rid: number,
-      type: "bytes",
-      bytes: Uint8Array,
-    ): void;
-    function wasmStreamingFeed(rid: number, type: "abort", error: any): void;
-    function wasmStreamingFeed(rid: number, type: "finish"): void;
   }
 }

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -7,6 +7,8 @@ use crate::Extension;
 use crate::OpState;
 use std::io::{stderr, stdout, Write};
 
+pub(crate) use wasm::WasmStreamingResource;
+
 pub(crate) fn init_builtins() -> Extension {
   Extension::builder()
     .js(include_js_files!(
@@ -20,6 +22,14 @@ pub(crate) fn init_builtins() -> Extension {
       ("op_try_close", op_sync(op_try_close)),
       ("op_print", op_sync(op_print)),
       ("op_resources", op_sync(op_resources)),
+      (
+        "op_wasm_streaming_feed",
+        op_sync(wasm::op_wasm_streaming_feed),
+      ),
+      (
+        "op_wasm_streaming_abort",
+        op_sync(wasm::op_wasm_streaming_abort),
+      ),
     ])
     .build()
 }
@@ -80,4 +90,63 @@ pub fn op_print(
     stdout().flush().unwrap();
   }
   Ok(())
+}
+
+// Ops related to streaming WebAssembly
+mod wasm {
+  use rusty_v8 as v8;
+
+  use crate::error::AnyError;
+  use crate::resources::ResourceId;
+  use crate::{OpState, Resource, ZeroCopyBuf};
+  use std::cell::RefCell;
+  use std::rc::Rc;
+
+  pub struct WasmStreamingResource(pub RefCell<v8::WasmStreaming>);
+
+  impl Resource for WasmStreamingResource {
+    fn close(self: Rc<Self>) {
+      // At this point there are no clones of Rc<WasmStreamingResource> on the
+      // resource table, and no one should own a reference outside of the stack.
+      // Therefore, we can be sure `self` is the only reference.
+      if let Ok(wsr) = Rc::try_unwrap(self) {
+        wsr.0.into_inner().finish();
+      } else {
+        panic!("Couldn't consume WasmStreamingResource.");
+      }
+    }
+  }
+
+  pub fn op_wasm_streaming_feed(
+    state: &mut OpState,
+    rid: ResourceId,
+    bytes: ZeroCopyBuf,
+  ) -> Result<(), AnyError> {
+    let wasm_streaming =
+      state.resource_table.get::<WasmStreamingResource>(rid)?;
+
+    wasm_streaming.0.borrow_mut().on_bytes_received(&bytes);
+
+    Ok(())
+  }
+
+  pub fn op_wasm_streaming_abort(
+    state: &mut OpState,
+    rid: ResourceId,
+    exception: serde_v8::Value,
+  ) -> Result<(), AnyError> {
+    let wasm_streaming =
+      state.resource_table.take::<WasmStreamingResource>(rid)?;
+
+    // At this point there are no clones of Rc<WasmStreamingResource> on the
+    // resource table, and no one should own a reference because we're never
+    // cloning them. So we can be sure `wasm_streaming` is the only reference.
+    if let Ok(wsr) = Rc::try_unwrap(wasm_streaming) {
+      wsr.0.into_inner().abort(Some(exception.v8_value));
+    } else {
+      panic!("Couldn't consume WasmStreamingResource.");
+    }
+
+    Ok(())
+  }
 }

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -5,9 +5,11 @@ use crate::op_sync;
 use crate::resources::ResourceId;
 use crate::Extension;
 use crate::OpState;
+use crate::Resource;
+use crate::ZeroCopyBuf;
+use std::cell::RefCell;
 use std::io::{stderr, stdout, Write};
-
-pub(crate) use wasm::WasmStreamingResource;
+use std::rc::Rc;
 
 pub(crate) fn init_builtins() -> Extension {
   Extension::builder()
@@ -22,14 +24,8 @@ pub(crate) fn init_builtins() -> Extension {
       ("op_try_close", op_sync(op_try_close)),
       ("op_print", op_sync(op_print)),
       ("op_resources", op_sync(op_resources)),
-      (
-        "op_wasm_streaming_feed",
-        op_sync(wasm::op_wasm_streaming_feed),
-      ),
-      (
-        "op_wasm_streaming_abort",
-        op_sync(wasm::op_wasm_streaming_abort),
-      ),
+      ("op_wasm_streaming_feed", op_sync(op_wasm_streaming_feed)),
+      ("op_wasm_streaming_abort", op_sync(op_wasm_streaming_abort)),
     ])
     .build()
 }
@@ -92,61 +88,52 @@ pub fn op_print(
   Ok(())
 }
 
-// Ops related to streaming WebAssembly
-mod wasm {
-  use rusty_v8 as v8;
+pub struct WasmStreamingResource(pub(crate) RefCell<rusty_v8::WasmStreaming>);
 
-  use crate::error::AnyError;
-  use crate::resources::ResourceId;
-  use crate::{OpState, Resource, ZeroCopyBuf};
-  use std::cell::RefCell;
-  use std::rc::Rc;
-
-  pub struct WasmStreamingResource(pub RefCell<v8::WasmStreaming>);
-
-  impl Resource for WasmStreamingResource {
-    fn close(self: Rc<Self>) {
-      // At this point there are no clones of Rc<WasmStreamingResource> on the
-      // resource table, and no one should own a reference outside of the stack.
-      // Therefore, we can be sure `self` is the only reference.
-      if let Ok(wsr) = Rc::try_unwrap(self) {
-        wsr.0.into_inner().finish();
-      } else {
-        panic!("Couldn't consume WasmStreamingResource.");
-      }
-    }
-  }
-
-  pub fn op_wasm_streaming_feed(
-    state: &mut OpState,
-    rid: ResourceId,
-    bytes: ZeroCopyBuf,
-  ) -> Result<(), AnyError> {
-    let wasm_streaming =
-      state.resource_table.get::<WasmStreamingResource>(rid)?;
-
-    wasm_streaming.0.borrow_mut().on_bytes_received(&bytes);
-
-    Ok(())
-  }
-
-  pub fn op_wasm_streaming_abort(
-    state: &mut OpState,
-    rid: ResourceId,
-    exception: serde_v8::Value,
-  ) -> Result<(), AnyError> {
-    let wasm_streaming =
-      state.resource_table.take::<WasmStreamingResource>(rid)?;
-
+impl Resource for WasmStreamingResource {
+  fn close(self: Rc<Self>) {
     // At this point there are no clones of Rc<WasmStreamingResource> on the
-    // resource table, and no one should own a reference because we're never
-    // cloning them. So we can be sure `wasm_streaming` is the only reference.
-    if let Ok(wsr) = Rc::try_unwrap(wasm_streaming) {
-      wsr.0.into_inner().abort(Some(exception.v8_value));
+    // resource table, and no one should own a reference outside of the stack.
+    // Therefore, we can be sure `self` is the only reference.
+    if let Ok(wsr) = Rc::try_unwrap(self) {
+      wsr.0.into_inner().finish();
     } else {
       panic!("Couldn't consume WasmStreamingResource.");
     }
-
-    Ok(())
   }
+}
+
+/// Feed bytes to WasmStreamingResource.
+pub fn op_wasm_streaming_feed(
+  state: &mut OpState,
+  rid: ResourceId,
+  bytes: ZeroCopyBuf,
+) -> Result<(), AnyError> {
+  let wasm_streaming =
+    state.resource_table.get::<WasmStreamingResource>(rid)?;
+
+  wasm_streaming.0.borrow_mut().on_bytes_received(&bytes);
+
+  Ok(())
+}
+
+/// Abort a WasmStreamingResource.
+pub fn op_wasm_streaming_abort(
+  state: &mut OpState,
+  rid: ResourceId,
+  exception: serde_v8::Value,
+) -> Result<(), AnyError> {
+  let wasm_streaming =
+    state.resource_table.take::<WasmStreamingResource>(rid)?;
+
+  // At this point there are no clones of Rc<WasmStreamingResource> on the
+  // resource table, and no one should own a reference because we're never
+  // cloning them. So we can be sure `wasm_streaming` is the only reference.
+  if let Ok(wsr) = Rc::try_unwrap(wasm_streaming) {
+    wsr.0.into_inner().abort(Some(exception.v8_value));
+  } else {
+    panic!("Couldn't consume WasmStreamingResource.");
+  }
+
+  Ok(())
 }

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -488,8 +488,8 @@
    *
    * @param {any} source The source parameter that the WebAssembly
    * streaming API was called with.
-   * @param {number} rid An rid that can be used with
-   * `Deno.core.wasmStreamingFeed`.
+   * @param {number} rid An rid that represents the wasm streaming
+   * resource.
    */
   function handleWasmStreaming(source, rid) {
     // This implements part of

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -526,15 +526,15 @@
           while (true) {
             const { value: chunk, done } = await reader.read();
             if (done) break;
-            core.wasmStreamingFeed(rid, "bytes", chunk);
+            core.opSync("op_wasm_streaming_feed", rid, chunk);
           }
         }
 
         // 2.7.
-        core.wasmStreamingFeed(rid, "finish");
+        core.close(rid);
       } catch (err) {
         // 2.8 and 3
-        core.wasmStreamingFeed(rid, "abort", err);
+        core.opSync("op_wasm_streaming_abort", rid, err);
       }
     })();
   }


### PR DESCRIPTION
Async WebAssembly compilation was implemented in #11200 by adding two bindings: `set_wasm_streaming_callback`, which registered a callback to be called whenever a streaming wasm compilation was started, and `wasm_streaming_feed`, which let the JS callback modify the state of the v8 wasm compiler.

`set_wasm_streaming_callback` cannot currently be implemented as anything other than a binding, but `wasm_streaming_feed` does not really need to use anything specific to bindings, and could indeed be implemented as one or more ops. This PR does that, resulting in a simplification of the relevant code.

There are three operations on the state of the v8 wasm compiler that `wasm_streaming_feed` allowed: feeding new bytes into the compiler, letting it know that there are no more bytes coming from the network, and aborting the compilation. This PR provides `op_wasm_streaming_feed` to feed new bytes into the compiler, and `op_wasm_streaming_abort` to abort the compilation. It doesn't provide an op to let v8 know that the response is finished, but closing the resource with `Deno.core.close()` will achieve that.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
