### PR TITLE
chore(lsp): temporarily reparse AST for linting

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -139,7 +139,11 @@ pub fn get_lint_references(
   let syntax = deno_ast::get_syntax(parsed_source.media_type());
   let lint_rules = rules::get_recommended_rules();
   let linter = create_linter(syntax, lint_rules);
-  let lint_diagnostics = linter.lint_with_ast(parsed_source);
+  // TODO(dsherret): do not re-parse here again
+  let (_, lint_diagnostics) = linter.lint(
+    parsed_source.specifier().to_string(),
+    parsed_source.source().text_str().to_string(),
+  )?;
 
   Ok(
     lint_diagnostics


### PR DESCRIPTION
Since we re-used the AST in deno lint there have been some reports on canary of false positives with the "cannot redeclare block-scoped variable" rule (https://discord.com/channels/684898665143206084/775366479143108608/886145809521967124).

This is because when deno lint parses an AST it, it does some post processing on the file:

https://github.com/denoland/deno_lint/blob/7825cb95115bfdffc62c076c8f458b3424f7190c/src/ast_parser.rs#L116

I really dislike this post processing and we should look into hopefully not needing to do it somehow then turning this back on.