### PR TITLE
perf(runtime): cache cwd lookups

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -71,6 +71,18 @@ function benchRead128k() {
   );
 }
 
+function benchRead128kSync() {
+  return benchAsync(
+    "read_128k_sync",
+    5e4,
+    () => Deno.readFileSync("./cli/bench/fixtures/128k.bin"),
+  );
+}
+
+function benchCwd() {
+  return benchSync("cwd", 5e4, () => Deno.cwd());
+}
+
 async function main() {
   // v8 builtin that's close to the upper bound non-NOPs
   benchDateNow();
@@ -82,6 +94,8 @@ async function main() {
   // IO ops
   benchReadZero();
   benchWriteNull();
+  benchCwd();
+  benchRead128kSync();
   await benchRead128k();
 }
 await main();

--- a/runtime/fs_util.rs
+++ b/runtime/fs_util.rs
@@ -34,7 +34,7 @@ pub fn cached_cwd() -> Result<PathBuf, AnyError> {
   })
 }
 
-pub fn cached_chdir(cwd: &PathBuf) -> Result<(), AnyError> {
+pub fn cached_chdir(cwd: &Path) -> Result<(), AnyError> {
   std::env::set_current_dir(cwd)?;
   CACHED_CWD.with(|cached| cached.take());
   Ok(())
@@ -55,6 +55,7 @@ pub fn resolve_from_cwd(path: &Path) -> Result<PathBuf, AnyError> {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::env::current_dir;
 
   #[test]
   fn resolve_from_cwd_child() {


### PR DESCRIPTION
This caches CWD lookups, `Deno.cwd()` is ~5x faster and shaves off ~20% of `read_128k_sync`.

This is a first PR of a series to optimize sync file reads, optimizing `cwd` not only helps `Deno.cwd()` but it also optimizes all file IO permission checks

## Bench results

```
# Before
cwd:                 	n = 50000, dt = 0.389s, r = 128535/s, t = 7780ns/op
read_128k_sync:      	n = 50000, dt = 1.922s, r = 26015/s, t = 38440ns/op

# After
cwd:                 	n = 50000, dt = 0.073s, r = 684932/s, t = 1460ns/op
read_128k_sync:      	n = 50000, dt = 1.591s, r = 31427/s, t = 31819ns/op
```