### PR TITLE
perf(runtime/fs): optimize readFile by using a single large buffer

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -71,26 +71,17 @@ function benchRead128k() {
   );
 }
 
-function benchRead128kSync() {
-  return benchAsync(
-    "read_128k_sync",
-    5e4,
-    () => Deno.readFileSync("./cli/bench/fixtures/128k.bin"),
-  );
-}
-
 async function main() {
   // v8 builtin that's close to the upper bound non-NOPs
-  // benchDateNow();
-  // // A very lightweight op, that should be highly optimizable
-  // benchPerfNow();
-  // // A common "language feature", that should be fast
-  // // also a decent representation of a non-trivial JSON-op
-  // benchUrlParse();
-  // // IO ops
-  // benchReadZero();
-  // benchWriteNull();
-  benchRead128kSync();
+  benchDateNow();
+  // A very lightweight op, that should be highly optimizable
+  benchPerfNow();
+  // A common "language feature", that should be fast
+  // also a decent representation of a non-trivial JSON-op
+  benchUrlParse();
+  // IO ops
+  benchReadZero();
+  benchWriteNull();
   await benchRead128k();
 }
 await main();

--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -71,17 +71,26 @@ function benchRead128k() {
   );
 }
 
+function benchRead128kSync() {
+  return benchAsync(
+    "read_128k_sync",
+    5e4,
+    () => Deno.readFileSync("./cli/bench/fixtures/128k.bin"),
+  );
+}
+
 async function main() {
   // v8 builtin that's close to the upper bound non-NOPs
-  benchDateNow();
-  // A very lightweight op, that should be highly optimizable
-  benchPerfNow();
-  // A common "language feature", that should be fast
-  // also a decent representation of a non-trivial JSON-op
-  benchUrlParse();
-  // IO ops
-  benchReadZero();
-  benchWriteNull();
+  // benchDateNow();
+  // // A very lightweight op, that should be highly optimizable
+  // benchPerfNow();
+  // // A common "language feature", that should be fast
+  // // also a decent representation of a non-trivial JSON-op
+  // benchUrlParse();
+  // // IO ops
+  // benchReadZero();
+  // benchWriteNull();
+  benchRead128kSync();
   await benchRead128k();
 }
 await main();

--- a/runtime/js/12_io.js
+++ b/runtime/js/12_io.js
@@ -191,10 +191,8 @@
     if (cursor > size) {
       // Read remaining and concat
       return concatBuffers([buf, readAllSync(r)]);
-    } else if (cursor < size) {
-      return buf.subarray(0, cursor);
     } else { // cursor == size
-      return buf;
+      return buf.subarray(0, cursor);
     }
   }
 
@@ -220,10 +218,8 @@
     if (cursor > size) {
       // Read remaining and concat
       return concatBuffers([buf, await readAllInner(r, options)]);
-    } else if (cursor < size) {
+    } else {
       return buf.subarray(0, cursor);
-    } else { // cursor == size
-      return buf;
     }
   }
 

--- a/runtime/js/12_io.js
+++ b/runtime/js/12_io.js
@@ -186,12 +186,12 @@
         break;
       }
     }
-    
+
     // Handle truncated or extended files during read
     if (cursor > size) {
       // Read remaining and concat
       return concatBuffers([buf, readAllSync(r)]);
-    } else if(cursor < size) {
+    } else if (cursor < size) {
       return buf.subarray(0, cursor);
     } else { // cursor == size
       return buf;
@@ -215,12 +215,12 @@
     if (signal?.aborted) {
       throw new DOMException("The read operation was aborted.", "AbortError");
     }
-    
+
     // Handle truncated or extended files during read
     if (cursor > size) {
       // Read remaining and concat
       return concatBuffers([buf, await readAllInner(r, options)]);
-    } else if(cursor < size) {
+    } else if (cursor < size) {
       return buf.subarray(0, cursor);
     } else { // cursor == size
       return buf;

--- a/runtime/js/12_io.js
+++ b/runtime/js/12_io.js
@@ -11,6 +11,7 @@
   const {
     Uint8Array,
     ArrayPrototypePush,
+    MathMin,
     TypedArrayPrototypeSubarray,
     TypedArrayPrototypeSet,
   } = window.__bootstrap.primordials;
@@ -116,7 +117,7 @@
 
   const READ_PER_ITER = 16 * 1024; // 16kb, see https://github.com/denoland/deno/issues/10157
 
-  async function readAll(r) {
+  function readAll(r) {
     return readAllInner(r);
   }
   async function readAllInner(r, options) {
@@ -176,7 +177,7 @@
     let cursor = 0;
 
     while (cursor < size) {
-      const sliceEnd = Math.min(size, cursor + READ_PER_ITER);
+      const sliceEnd = MathMin(size, cursor + READ_PER_ITER);
       const slice = buf.subarray(cursor, sliceEnd);
       const read = r.readSync(slice);
       if (typeof read == "number") {
@@ -194,7 +195,7 @@
     let cursor = 0;
     const signal = options?.signal ?? null;
     while (!signal?.aborted && cursor < size) {
-      const sliceEnd = Math.min(size, cursor + READ_PER_ITER);
+      const sliceEnd = MathMin(size, cursor + READ_PER_ITER);
       const slice = buf.subarray(cursor, sliceEnd);
       const read = await r.read(slice);
       if (typeof read == "number") {

--- a/runtime/js/40_read_file.js
+++ b/runtime/js/40_read_file.js
@@ -4,13 +4,14 @@
 ((window) => {
   const core = window.Deno.core;
   const { open, openSync } = window.__bootstrap.files;
-  const { readAllInner, readAllSync } = window.__bootstrap.io;
+  const { readAllInner, readAllSync, readAllSyncSized, readAllInnerSized } =
+    window.__bootstrap.io;
 
   function readFileSync(path) {
     const file = openSync(path);
     try {
-      const contents = readAllSync(file);
-      return contents;
+      const { size } = file.statSync();
+      return readAllSyncSized(file, size);
     } finally {
       file.close();
     }
@@ -19,31 +20,19 @@
   async function readFile(path, options) {
     const file = await open(path);
     try {
-      const contents = await readAllInner(file, options);
-      return contents;
+      const { size } = await file.stat();
+      return await readAllInnerSized(file, size, options);
     } finally {
       file.close();
     }
   }
 
   function readTextFileSync(path) {
-    const file = openSync(path);
-    try {
-      const contents = readAllSync(file);
-      return core.decode(contents);
-    } finally {
-      file.close();
-    }
+    return core.decode(readFileSync(path));
   }
 
   async function readTextFile(path, options) {
-    const file = await open(path);
-    try {
-      const contents = await readAllInner(file, options);
-      return core.decode(contents);
-    } finally {
-      file.close();
-    }
+    return core.decode(await readFile(path, options));
   }
 
   window.__bootstrap.readFile = {

--- a/runtime/js/40_read_file.js
+++ b/runtime/js/40_read_file.js
@@ -4,8 +4,7 @@
 ((window) => {
   const core = window.Deno.core;
   const { open, openSync } = window.__bootstrap.files;
-  const { readAllInner, readAllSync, readAllSyncSized, readAllInnerSized } =
-    window.__bootstrap.io;
+  const { readAllSyncSized, readAllInnerSized } = window.__bootstrap.io;
 
   function readFileSync(path) {
     const file = openSync(path);


### PR DESCRIPTION
This avoids allocating N buffers when reading entire files and copying when concatenating them.

## Benchmarks

```
# Before
❯ deno run -A ./cli/bench/deno_common.js
read_128k_sync:      	n = 50000, dt = 1.941s, r = 25760/s, t = 38820ns/op
read_128k:           	n = 50000, dt = 9.613s, r = 5201/s, t = 192259ns/op

# After
❯ ./target/release/deno run -A ./cli/bench/deno_common.js
read_128k_sync:      	n = 50000, dt = 1.746s, r = 28637/s, t = 34920ns/op
read_128k:           	n = 50000, dt = 8.865s, r = 5640/s, t = 177300ns/op
```

## Notes

- The improvements to `read_128k_sync` are somewhat reduced here by the extra cwd lookups caused by the `stat`, so https://github.com/denoland/deno/pull/12056 will work hand in hand with this change to improve file reads
- This operates under the assumption that files won't change (truncated or extended) whilst being read, which isn't guaranteed but seems fair IMO
- Also simplifies implementation of `readTextFile` / `readTextFileSync`