### PR TITLE
docs: Update --config flag help text

### DIFF
--- a/cli/config_file.rs
+++ b/cli/config_file.rs
@@ -315,7 +315,7 @@ pub struct FmtConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ConfigFileJson {
   pub compiler_options: Option<Value>,
   pub lint: Option<Value>,
@@ -458,6 +458,34 @@ mod tests {
         "e": false,
       })
     );
+  }
+
+  #[test]
+  fn test_parse_config_with_unknown_fields() {
+    let config_text = r#"{
+      "compilerOptions": {
+        "build": true,
+        // comments are allowed
+        "strict": true
+      },
+      "lint": {
+        "files": {
+          "include": ["src/"],
+          "exclude": ["src/testdata/"]
+        }
+      },
+      "fmt": {
+        "files": {
+          "include": ["src/"],
+          "exclude": ["src/testdata/"]
+        }
+      },
+      "unknownField": {},
+      "unknownField2": {}
+    }"#;
+    let config_path = PathBuf::from("/deno/deno.json");
+    let config_file_result = ConfigFile::new(config_text, &config_path);
+    assert!(config_file_result.is_err());
   }
 
   #[test]

--- a/cli/config_file.rs
+++ b/cli/config_file.rs
@@ -315,7 +315,7 @@ pub struct FmtConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct ConfigFileJson {
   pub compiler_options: Option<Value>,
   pub lint: Option<Value>,
@@ -458,34 +458,6 @@ mod tests {
         "e": false,
       })
     );
-  }
-
-  #[test]
-  fn test_parse_config_with_unknown_fields() {
-    let config_text = r#"{
-      "compilerOptions": {
-        "build": true,
-        // comments are allowed
-        "strict": true
-      },
-      "lint": {
-        "files": {
-          "include": ["src/"],
-          "exclude": ["src/testdata/"]
-        }
-      },
-      "fmt": {
-        "files": {
-          "include": ["src/"],
-          "exclude": ["src/testdata/"]
-        }
-      },
-      "unknownField": {},
-      "unknownField2": {}
-    }"#;
-    let config_path = PathBuf::from("/deno/deno.json");
-    let config_file_result = ConfigFile::new(config_text, &config_path);
-    assert!(config_file_result.is_err());
   }
 
   #[test]

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1581,7 +1581,17 @@ fn config_arg<'a, 'b>() -> Arg<'a, 'b> {
     .short("c")
     .long("config")
     .value_name("FILE")
-    .help("Load tsconfig.json configuration file")
+    .help("Load configuration file")
+    .long_help(
+      "Load configuration file.
+Before 1.14 Deno only supported loading tsconfig.json that allowed
+to customise TypeScript compiler settings. 
+
+Starting with 1.14 configuration file can be used to configure different 
+subcommands like `deno lint` or `deno fmt`. 
+
+It's recommended to use `deno.json` or `deno.jsonc` as a filename.",
+    )
     .takes_value(true)
 }
 


### PR DESCRIPTION
This commit changes parsing of configuration file provided with
"--config" strict, ie. if the file contains unknown fields it will
refuse to parse.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
