### PR TITLE
chore(lsp): use pretty_assertions in e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,7 +350,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim 0.8.0",
@@ -476,6 +485,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+dependencies = [
+ "quote 1.0.9",
+ "syn 1.0.65",
+]
+
+[[package]]
 name = "d3d12"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +622,7 @@ dependencies = [
  "os_pipe",
  "percent-encoding",
  "pin-project",
+ "pretty_assertions",
  "rand 0.8.4",
  "regex",
  "ring",
@@ -1004,6 +1024,12 @@ dependencies = [
  "rustc_version 0.3.3",
  "syn 1.0.65",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
@@ -2346,6 +2372,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +2575,18 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+dependencies = [
+ "ansi_term 0.12.1",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-error"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -107,6 +107,7 @@ test_util = { path = "../test_util" }
 tower-test = "0.4.0"
 trust-dns-client = "0.20.3"
 trust-dns-server = "0.20.3"
+pretty_assertions = "0.7.2"
 
 [target.'cfg(unix)'.dev-dependencies]
 exec = "0.3.1" # Used in test_raw_tty

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -103,11 +103,11 @@ winapi = { version = "0.3.9", features = ["knownfolders", "mswsock", "objbase", 
 chrono = "0.4.19"
 flaky_test = "0.1.0"
 os_pipe = "0.9.2"
+pretty_assertions = "0.7.2"
 test_util = { path = "../test_util" }
 tower-test = "0.4.0"
 trust-dns-client = "0.20.3"
 trust-dns-server = "0.20.3"
-pretty_assertions = "0.7.2"
 
 [target.'cfg(unix)'.dev-dependencies]
 exec = "0.3.1" # Used in test_raw_tty

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -7,6 +7,7 @@ use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::url::Url;
 use lspower::lsp;
+use pretty_assertions::assert_eq;
 use std::fs;
 use tempfile::TempDir;
 use test_util::deno_exe_path;


### PR DESCRIPTION
Improves lsp developer experience by 10x.

Before:
<img width="852" alt="CleanShot 2021-09-15 at 14 09 38@2x" src="https://user-images.githubusercontent.com/29819102/133400452-5f7753e4-454c-4fa5-8694-0c6828df2323.png">

After:

<img width="486" alt="CleanShot 2021-09-15 at 14 07 06@2x" src="https://user-images.githubusercontent.com/29819102/133400065-c9853e4f-bbaf-472a-8b34-f9fab537b624.png">