### PR TITLE
fix(ext/crypto): don't use core.decode for encoding jwk keys

### DIFF
--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -357,6 +357,30 @@ unitTest(async function subtleCryptoHmacImportExport() {
   assertEquals(exportedKey2, jwk);
 });
 
+// https://github.com/denoland/deno/issues/12085
+unitTest(async function generateImportHmacJwk() {
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "HMAC",
+      hash: "SHA-256",
+    },
+    true,
+    ["sign"],
+  );
+  assert(key);
+  assertEquals(key.type, "secret");
+  assertEquals(key.extractable, true);
+  assertEquals(key.usages, ["sign"]);
+
+  const exportedKey = await crypto.subtle.exportKey("jwk", key);
+  assertEquals(exportedKey.kty, "oct");
+  assertEquals(exportedKey.alg, "HS256");
+  assertEquals(exportedKey.key_ops, ["sign"]);
+  assertEquals(exportedKey.ext, true);
+  assertEquals(typeof exportedKey.k == "string");
+  assertEquals(exportedKey.k.length, 171);
+});
+
 // 2048-bits publicExponent=65537
 const pkcs8TestVectors = [
   // rsaEncryption

--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -362,7 +362,7 @@ unitTest(async function generateImportHmacJwk() {
   const key = await crypto.subtle.generateKey(
     {
       name: "HMAC",
-      hash: "SHA-256",
+      hash: "SHA-512",
     },
     true,
     ["sign"],
@@ -374,10 +374,10 @@ unitTest(async function generateImportHmacJwk() {
 
   const exportedKey = await crypto.subtle.exportKey("jwk", key);
   assertEquals(exportedKey.kty, "oct");
-  assertEquals(exportedKey.alg, "HS256");
+  assertEquals(exportedKey.alg, "HS512");
   assertEquals(exportedKey.key_ops, ["sign"]);
   assertEquals(exportedKey.ext, true);
-  assertEquals(typeof exportedKey.k == "string");
+  assert(typeof exportedKey.k == "string");
   assertEquals(exportedKey.k.length, 171);
 });
 

--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -24,6 +24,7 @@
     StringPrototypeToUpperCase,
     StringPrototypeReplace,
     StringPrototypeCharCodeAt,
+    StringFromCharCode,
     Symbol,
     SymbolFor,
     SymbolToStringTag,
@@ -140,9 +141,11 @@
   }
 
   function unpaddedBase64(bytes) {
-    const binaryString = core.decode(bytes);
+    let binaryString = "";
+    for (let i = 0; i < bytes.length; i++) {
+      binaryString += StringFromCharCode(bytes[i]);
+    }
     const base64String = btoa(binaryString);
-
     return StringPrototypeReplace(base64String, /=/g, "");
   }
 


### PR DESCRIPTION
Fixes #12085 