### PR TITLE
perf(ext/fetch): Use the WebIDL conversion to DOMString rather than USVString for Response constructor

### DIFF
--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -112,6 +112,11 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
     None,
   ),
   (
+    "response_string",
+    &["run", "cli/tests/testdata/response_string_perf.js"],
+    None,
+  ),
+  (
     "check",
     &[
       "cache",

--- a/cli/tests/testdata/response_string_perf.js
+++ b/cli/tests/testdata/response_string_perf.js
@@ -1,0 +1,34 @@
+const mixed = "@Ā๐😀";
+
+function generateRandom(bytes) {
+  let result = "";
+  let i = 0;
+  while (i < bytes) {
+    const toAdd = Math.floor(Math.random() * Math.min(4, bytes - i));
+    switch (toAdd) {
+      case 0:
+        result += mixed[0];
+        i++;
+        break;
+      case 1:
+        result += mixed[1];
+        i++;
+        break;
+      case 2:
+        result += mixed[2];
+        i++;
+        break;
+      case 3:
+        result += mixed[3];
+        result += mixed[4];
+        i += 2;
+        break;
+    }
+  }
+  return result;
+}
+
+const randomData = generateRandom(1024);
+for (let i = 0; i < 10_000; i++) { 
+  new Response(randomData);
+}

--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -393,7 +393,7 @@
         return webidl.converters["ArrayBufferView"](V, opts);
       }
     }
-    return webidl.converters["USVString"](V, opts);
+    return webidl.converters["DOMString"](V, opts);
   };
   webidl.converters["BodyInit?"] = webidl.createNullableConverter(
     webidl.converters["BodyInit"],


### PR DESCRIPTION
Fixes performance issue https://github.com/denoland/deno/issues/12090

Added benchmark `response_string` which produced the following results before and after the change:

* using USVString:
```
Benchmark #13: /home/luismalheiro/projects/deno_pr/target/release/deno run cli/tests/testdata/response_string_perf.js 
  Time (mean ± σ):     432.9 ms ±  26.8 ms    [User: 308.8 ms, System: 192.8 ms]
  Range (min … max):   409.5 ms … 485.4 ms    10 runs
```
* using DOMString:
```
Benchmark #13: /home/luismalheiro/projects/deno_pr/target/release/deno run cli/tests/testdata/response_string_perf.js 
  Time (mean ± σ):     175.8 ms ±  17.6 ms    [User: 168.6 ms, System: 73.9 ms]
  Range (min … max):   147.3 ms … 211.6 ms    18 runs
```

Notice that the difference will increase non-linearly for large strings.