### PR TITLE
fix(cli): don't ignore diagnostics about for await

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -622,6 +622,12 @@ itest!(error_026_remote_import_error {
   http_server: true,
 });
 
+itest!(error_for_await {
+  args: "run --reload error_for_await.ts",
+  output: "error_for_await.ts.out",
+  exit_code: 1,
+});
+
 itest!(error_missing_module_named_import {
   args: "run --reload error_missing_module_named_import.ts",
   output: "error_missing_module_named_import.ts.out",

--- a/cli/tests/testdata/error_for_await.ts
+++ b/cli/tests/testdata/error_for_await.ts
@@ -1,0 +1,14 @@
+const listener = Deno.listen({ port: 8080 });
+
+for await (const conn of listener) {
+  handleConn(conn);
+}
+
+function handleConn(conn: Deno.Conn) {
+  const httpConn = Deno.serveHttp(conn);
+  for await (const event of httpConn) {
+    event.respondWith(new Response("html", { status: 200 }));
+  }
+}
+
+export {};

--- a/cli/tests/testdata/error_for_await.ts.out
+++ b/cli/tests/testdata/error_for_await.ts.out
@@ -1,0 +1,10 @@
+[WILDCARD]
+error: TS1103 [ERROR]: 'for await' loops are only allowed within async functions and at the top levels of modules.
+  for await (const event of httpConn) {
+      ~~~~~
+    at [WILDCARD]error_for_await.ts:9:7
+
+TS1356 [ERROR]:     Did you mean to mark this function as 'async'?
+    function handleConn(conn: Deno.Conn) {
+             ~~~~~~~~~~
+        at [WILDCARD]error_for_await.ts:7:10

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -148,9 +148,6 @@ delete Object.prototype.__proto__;
     // when that file is a module, but this file has no imports or exports.
     // Consider adding an empty 'export {}' to make this file a module.
     1375,
-    // TS1103: 'for-await-of' statement is only allowed within an async function
-    // or async generator.
-    1103,
     // TS2306: File 'file:///Users/rld/src/deno/cli/tests/testdata/subdir/amd_like.js' is
     // not a module.
     2306,


### PR DESCRIPTION
Fixes #12115
