### PR TITLE
Fix default value of "lib"

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -73,7 +73,7 @@
           "description": "Specify a set of bundled library declaration files that describe the target runtime environment.",
           "type": "array",
           "uniqueItems": true,
-          "default": "deno.window",
+          "default": ["deno.window"],
           "items": {
             "type": "string"
           },


### PR DESCRIPTION
Changed it from `"deno.window"` to `["deno.window"]`