### PR TITLE
bench(deno_common): track new Request()

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -71,6 +71,10 @@ function benchRead128k() {
   );
 }
 
+function benchRequestNew() {
+  return benchSync("request_new", 5e5, () => new Request("https://deno.land"));
+}
+
 async function main() {
   // v8 builtin that's close to the upper bound non-NOPs
   benchDateNow();
@@ -83,5 +87,6 @@ async function main() {
   benchReadZero();
   benchWriteNull();
   await benchRead128k();
+  benchRequestNew();
 }
 await main();


### PR DESCRIPTION
Indirectly measures:
- url parsing
- abort signal no-ops
- webidl & other overhead

## Baseline

```
request_new:         	n = 500000, dt = 1.296s, r = 385802/s, t = 2592ns/op
```