### PR TITLE
perf(web): optimize AbortController

### DIFF
--- a/ext/web/03_abort_signal.js
+++ b/ext/web/03_abort_signal.js
@@ -21,13 +21,12 @@
   const add = Symbol("add");
   const signalAbort = Symbol("signalAbort");
   const remove = Symbol("remove");
+  const aborted = Symbol("aborted");
+  const abortAlgos = Symbol("abortAlgos");
 
   const illegalConstructorKey = Symbol("illegalConstructorKey");
 
   class AbortSignal extends EventTarget {
-    #aborted = false;
-    #abortAlgorithms = new Set();
-
     static abort() {
       const signal = new AbortSignal(illegalConstructorKey);
       signal[signalAbort]();
@@ -35,25 +34,30 @@
     }
 
     [add](algorithm) {
-      SetPrototypeAdd(this.#abortAlgorithms, algorithm);
+      if (this[abortAlgos] === null) {
+        this[abortAlgos] = new Set();
+      }
+      SetPrototypeAdd(this[abortAlgos], algorithm);
     }
 
     [signalAbort]() {
-      if (this.#aborted) {
+      if (this[aborted]) {
         return;
       }
-      this.#aborted = true;
-      for (const algorithm of this.#abortAlgorithms) {
-        algorithm();
+      this[aborted] = true;
+      if (this[abortAlgos] !== null) {  
+        for (const algorithm of this[abortAlgos]) {
+          algorithm();
+        }
+        this[abortAlgos] = null;
       }
-      SetPrototypeClear(this.#abortAlgorithms);
       const event = new Event("abort");
       setIsTrusted(event, true);
       this.dispatchEvent(event);
     }
 
     [remove](algorithm) {
-      SetPrototypeDelete(this.#abortAlgorithms, algorithm);
+      this[abortAlgos] && SetPrototypeDelete(this[abortAlgos], algorithm);
     }
 
     constructor(key = null) {
@@ -61,11 +65,13 @@
         throw new TypeError("Illegal constructor.");
       }
       super();
+      this[aborted] = false;
+      this[abortAlgos] = null;
       this[webidl.brand] = webidl.brand;
     }
 
     get aborted() {
-      return Boolean(this.#aborted);
+      return Boolean(this[aborted]);
     }
 
     get [SymbolToStringTag]() {

--- a/ext/web/03_abort_signal.js
+++ b/ext/web/03_abort_signal.js
@@ -11,7 +11,6 @@
     Boolean,
     Set,
     SetPrototypeAdd,
-    SetPrototypeClear,
     SetPrototypeDelete,
     Symbol,
     SymbolToStringTag,
@@ -45,7 +44,7 @@
         return;
       }
       this[aborted] = true;
-      if (this[abortAlgos] !== null) {  
+      if (this[abortAlgos] !== null) {
         for (const algorithm of this[abortAlgos]) {
           algorithm();
         }


### PR DESCRIPTION
- Use regular class constructor and symbol "private" attributes
- Lazy init Set of follower signals

Some benchmark data on class init:
```
class_member_private:    n = 1000000, dt = 0.076s, r = 13157895/s, t = 75ns/op
class_member:            n = 1000000, dt = 0.091s, r = 10989011/s, t = 91ns/op
class_constructor:       n = 1000000, dt = 0.008s, r = 125000000/s, t = 8ns/op
class_symbol_x:          n = 1000000, dt = 0.006s, r = 166666667/s, t = 6ns/op
class_symbol_anon:       n = 1000000, dt = 0.007s, r = 142857143/s, t = 7ns/op
```