### PR TITLE
cleanup(ext/fetch): drop redundant webidl converters in fetch()

### DIFF
--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -412,15 +412,6 @@
     const p = new Promise((resolve, reject) => {
       const prefix = "Failed to call 'fetch'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      input = webidl.converters["RequestInfo"](input, {
-        prefix,
-        context: "Argument 1",
-      });
-      init = webidl.converters["RequestInit"](init, {
-        prefix,
-        context: "Argument 2",
-      });
-
       // 2.
       const requestObject = new Request(input, init);
       // 3.


### PR DESCRIPTION
Since those inputs are passed to `new Request(...)` which applies webidl converters