### PR TITLE
perf(ext/fetch): skip USVString webidl conv on string constructor

### DIFF
--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -220,10 +220,6 @@
     constructor(input, init = {}) {
       const prefix = "Failed to construct 'Request'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      input = webidl.converters["RequestInfo"](input, {
-        prefix,
-        context: "Argument 1",
-      });
       init = webidl.converters["RequestInit"](init, {
         prefix,
         context: "Argument 2",
@@ -243,7 +239,10 @@
         const parsedURL = new URL(input, baseURL);
         request = newInnerRequest("GET", parsedURL.href, [], null);
       } else { // 6.
-        if (!(input instanceof Request)) throw new TypeError("Unreachable");
+        input = webidl.converters["Request"](input, {
+          prefix,
+          context: "Argument 1",
+        });
         request = input[_request];
         signal = input[_signal];
       }
@@ -424,15 +423,6 @@
     "Request",
     Request,
   );
-  webidl.converters["RequestInfo"] = (V, opts) => {
-    // Union for (Request or USVString)
-    if (typeof V == "object") {
-      if (V instanceof Request) {
-        return webidl.converters["Request"](V, opts);
-      }
-    }
-    return webidl.converters["USVString"](V, opts);
-  };
   webidl.converters["RequestRedirect"] = webidl.createEnumConverter(
     "RequestRedirect",
     [

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -431,7 +431,8 @@
         return webidl.converters["Request"](V, opts);
       }
     }
-    return webidl.converters["USVString"](V, opts);
+    // Passed to new URL(...) which implictly converts DOMString -> USVString
+    return webidl.converters["DOMString"](V, opts);
   };
   webidl.converters["RequestRedirect"] = webidl.createEnumConverter(
     "RequestRedirect",

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -220,6 +220,10 @@
     constructor(input, init = {}) {
       const prefix = "Failed to construct 'Request'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
+      input = webidl.converters["RequestInfo"](input, {
+        prefix,
+        context: "Argument 1",
+      });
       init = webidl.converters["RequestInit"](init, {
         prefix,
         context: "Argument 2",
@@ -239,10 +243,7 @@
         const parsedURL = new URL(input, baseURL);
         request = newInnerRequest("GET", parsedURL.href, [], null);
       } else { // 6.
-        input = webidl.converters["Request"](input, {
-          prefix,
-          context: "Argument 1",
-        });
+        if (!(input instanceof Request)) throw new TypeError("Unreachable");
         request = input[_request];
         signal = input[_signal];
       }
@@ -423,6 +424,15 @@
     "Request",
     Request,
   );
+  webidl.converters["RequestInfo"] = (V, opts) => {
+    // Union for (Request or USVString)
+    if (typeof V == "object") {
+      if (V instanceof Request) {
+        return webidl.converters["Request"](V, opts);
+      }
+    }
+    return webidl.converters["USVString"](V, opts);
+  };
   webidl.converters["RequestRedirect"] = webidl.createEnumConverter(
     "RequestRedirect",
     [

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -220,7 +220,7 @@
     constructor(input, init = {}) {
       const prefix = "Failed to construct 'Request'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
-      input = webidl.converters["RequestInfo"](input, {
+      input = webidl.converters["RequestInfo_DOMString"](input, {
         prefix,
         context: "Argument 1",
       });
@@ -424,7 +424,7 @@
     "Request",
     Request,
   );
-  webidl.converters["RequestInfo"] = (V, opts) => {
+  webidl.converters["RequestInfo_DOMString"] = (V, opts) => {
     // Union for (Request or USVString)
     if (typeof V == "object") {
       if (V instanceof Request) {


### PR DESCRIPTION
Since URL parsing will effectively normalize it, this is essentially another redundant webidl conversion

Assumes #12167