### PR TITLE
chore(ext/net): improve embedder friendliness

### DIFF
--- a/ext/net/ops_tls.rs
+++ b/ext/net/ops_tls.rs
@@ -699,9 +699,8 @@ where
 
   let unsafely_ignore_certificate_errors = state
     .borrow()
-    .borrow::<UnsafelyIgnoreCertificateErrors>()
-    .0
-    .clone();
+    .try_borrow::<UnsafelyIgnoreCertificateErrors>()
+    .and_then(|it| it.0.clone());
 
   // TODO(@justinmchase): Ideally the certificate store is created once
   // and not cloned. The store should be wrapped in Arc<T> to reduce
@@ -768,9 +767,8 @@ where
   let cert_file = args.cert_file.as_deref();
   let unsafely_ignore_certificate_errors = state
     .borrow()
-    .borrow::<UnsafelyIgnoreCertificateErrors>()
-    .0
-    .clone();
+    .try_borrow::<UnsafelyIgnoreCertificateErrors>()
+    .and_then(|it| it.0.clone());
 
   if args.cert_chain.is_some() {
     super::check_unstable2(&state, "ConnectTlsOptions.certChain");

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -224,9 +224,8 @@ where
 
   let unsafely_ignore_certificate_errors = state
     .borrow()
-    .borrow::<UnsafelyIgnoreCertificateErrors>()
-    .0
-    .clone();
+    .try_borrow::<UnsafelyIgnoreCertificateErrors>()
+    .and_then(|it| it.0.clone());
   let root_cert_store = state.borrow().borrow::<WsRootStore>().0.clone();
   let user_agent = state.borrow().borrow::<WsUserAgent>().0.clone();
   let uri: Uri = args.url.parse()?;


### PR DESCRIPTION
Default to None if UnsafelyIgnoreCertificateErrors is not present in the
OpState.

Embedders may not have a need for restricting outgoing TLS connections
and having them hunt through the source code for the magic incantation
that makes the borrow panics go away, is less user friendly.

<hr>

It'd be nice if this pattern was adopted more broadly (hint, hint.)