### PR TITLE
fix(ext/http): fortify "is websocket?" check

### DIFF
--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -22,6 +22,10 @@ use deno_core::Resource;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use hyper::body::HttpBody;
+use hyper::header::CONNECTION;
+use hyper::header::SEC_WEBSOCKET_KEY;
+use hyper::header::SEC_WEBSOCKET_VERSION;
+use hyper::header::UPGRADE;
 use hyper::http;
 use hyper::server::conn::Http;
 use hyper::service::Service as HyperService;
@@ -312,20 +316,23 @@ fn req_headers(
 }
 
 fn is_websocket_request(req: &hyper::Request<hyper::Body>) -> bool {
-  req_header_contains(req, hyper::header::CONNECTION, "upgrade")
-    && req_header_contains(req, hyper::header::UPGRADE, "websocket")
+  req.version() == hyper::Version::HTTP_11
+    && req.method() == hyper::Method::GET
+    && req.headers().contains_key(&SEC_WEBSOCKET_KEY)
+    && header(req.headers(), &SEC_WEBSOCKET_VERSION) == b"13"
+    && header(req.headers(), &UPGRADE).eq_ignore_ascii_case(b"websocket")
+    && header(req.headers(), &CONNECTION)
+      .split(|c| *c == b' ' || *c == b',')
+      .any(|token| token.eq_ignore_ascii_case(b"upgrade"))
 }
 
-fn req_header_contains(
-  req: &hyper::Request<hyper::Body>,
-  key: impl hyper::header::AsHeaderName,
-  value: &str,
-) -> bool {
-  req.headers().get_all(key).iter().any(|v| {
-    v.to_str()
-      .map(|s| s.to_lowercase().contains(value))
-      .unwrap_or(false)
-  })
+fn header<'a>(
+  h: &'a hyper::http::HeaderMap,
+  name: &hyper::header::HeaderName,
+) -> &'a [u8] {
+  h.get(name)
+    .map(hyper::header::HeaderValue::as_bytes)
+    .unwrap_or_default()
 }
 
 fn should_ignore_error(e: &AnyError) -> bool {


### PR DESCRIPTION
Check for expected headers more rigorously and, notably, check that
it's a HTTP/1.1 GET request. Hyper panics if you try to upgrade HTTP/2
connections.

This mirrors what Deno Deploy and the tungstenite crate do, with the
caveat that tungstenite supports multiple Connection header tokens
(e.g. "Connection: upgrade, foo") whereas Deploy does not.

I'm reasonably sure no reasonable client sends multiple tokens when it
also sends "Upgrade: websocket" so I opted to leave that out.

The presence of "Sec-Websocket-Version: 13" is now also enforced.
I don't expect that to break anything: conforming clients already send
it and tungstenite can't talk to older clients anyway.

The new code is more efficient due to heap-allocating less.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
