### PR TITLE
fix(runtime/testing): format aggregate errors

### DIFF
--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -180,3 +180,9 @@ itest!(shuffle_with_seed {
   exit_code: 0,
   output: "test/shuffle.out",
 });
+
+itest!(aggregate_error {
+  args: "test test/aggregate_error.ts",
+  exit_code: 1,
+  output: "test/aggregate_error.out",
+});

--- a/cli/tests/testdata/test/aggregate_error.out
+++ b/cli/tests/testdata/test/aggregate_error.out
@@ -12,3 +12,10 @@ Error: Error 2
     at [WILDCARD]/testdata/test/aggregate_error.ts:3:18
     [WILDCARD]
 
+failures:
+
+	aggregate
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+error: Test failed

--- a/cli/tests/testdata/test/aggregate_error.out
+++ b/cli/tests/testdata/test/aggregate_error.out
@@ -13,12 +13,7 @@ AggregateError
         at [WILDCARD]/testdata/test/aggregate_error.ts:3:18
         [WILDCARD]
     at [WILDCARD]/testdata/test/aggregate_error.ts:5:9
-    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
-    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
-    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
-    at runTest (deno:runtime/js/40_testing.js:230:13)
-    at Object.runTests (deno:runtime/js/40_testing.js:315:28)
-    at [deno:cli/tools/test.rs:302:6]:1:21
+    at [WILDCARD]
 
 failures:
 

--- a/cli/tests/testdata/test/aggregate_error.out
+++ b/cli/tests/testdata/test/aggregate_error.out
@@ -5,12 +5,20 @@ test aggregate ... FAILED ([WILDCARD])
 failures:
 
 aggregate
-Error: Error 1
-    at [WILDCARD]/testdata/test/aggregate_error.ts:2:18
-    [WILDCARD]
-Error: Error 2
-    at [WILDCARD]/testdata/test/aggregate_error.ts:3:18
-    [WILDCARD]
+AggregateError
+    Error: Error 1
+        at [WILDCARD]/testdata/test/aggregate_error.ts:2:18
+        [WILDCARD]
+    Error: Error 2
+        at [WILDCARD]/testdata/test/aggregate_error.ts:3:18
+        [WILDCARD]
+    at [WILDCARD]/testdata/test/aggregate_error.ts:5:9
+    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
+    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
+    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
+    at runTest (deno:runtime/js/40_testing.js:230:13)
+    at Object.runTests (deno:runtime/js/40_testing.js:315:28)
+    at [deno:cli/tools/test.rs:302:6]:1:21
 
 failures:
 

--- a/cli/tests/testdata/test/aggregate_error.out
+++ b/cli/tests/testdata/test/aggregate_error.out
@@ -1,0 +1,14 @@
+Check [WILDCARD]/testdata/test/aggregate_error.ts
+running 1 test from [WILDCARD]/testdata/test/aggregate_error.ts
+test aggregate ... FAILED ([WILDCARD])
+
+failures:
+
+aggregate
+Error: Error 1
+    at [WILDCARD]/testdata/test/aggregate_error.ts:2:18
+    [WILDCARD]
+Error: Error 2
+    at [WILDCARD]/testdata/test/aggregate_error.ts:3:18
+    [WILDCARD]
+

--- a/cli/tests/testdata/test/aggregate_error.ts
+++ b/cli/tests/testdata/test/aggregate_error.ts
@@ -1,0 +1,6 @@
+Deno.test("aggregate", function () {
+  const error1 = new Error("Error 1");
+  const error2 = new Error("Error 2");
+
+  throw new AggregateError([error1, error2]);
+});

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -188,8 +188,13 @@ finishing test case.`;
 
   function formatFailure(error) {
     if (error.errors) {
+      const message = error
+        .errors
+        .map((error) => inspectArgs([error]).replace(/^(?!\s*$)/gm, " ".repeat(4)))
+        .join("\n");
+
       return {
-        failed: error.errors.map((error) => inspectArgs([error])).join("\n"),
+        failed: error.name + "\n" + message + error.stack,
       };
     }
 

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -190,7 +190,9 @@ finishing test case.`;
     if (error.errors) {
       const message = error
         .errors
-        .map((error) => inspectArgs([error]).replace(/^(?!\s*$)/gm, " ".repeat(4)))
+        .map((error) =>
+          inspectArgs([error]).replace(/^(?!\s*$)/gm, " ".repeat(4))
+        )
         .join("\n");
 
       return {

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -186,6 +186,16 @@ finishing test case.`;
     ArrayPrototypePush(tests, testDef);
   }
 
+  function formatFailure(error) {
+    if (error.errors) {
+      return {
+        failed: error.errors.map((error) => inspectArgs([error])).join("\n"),
+      };
+    }
+
+    return { failed: inspectArgs([error]) };
+  }
+
   function createTestFilter(filter) {
     return (def) => {
       if (filter) {
@@ -213,10 +223,11 @@ finishing test case.`;
 
     try {
       await fn();
-      return "ok";
     } catch (error) {
-      return { "failed": inspectArgs([error]) };
+      return formatFailure(error);
     }
+
+    return "ok";
   }
 
   function getTestOrigin() {


### PR DESCRIPTION
Prints out the actual errors contained in aggregate errors rather than just stating that an aggregate error occured.

Before:

```
test aggregate ... FAILED (11ms)

failures:

aggregate
AggregateError
    at file:///home/caspervonb/deno/cli/tests/testdata/test/aggregate_error.ts:5:9
    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
    at runTest (deno:runtime/js/40_testing.js:215:13)
    at Object.runTests (deno:runtime/js/40_testing.js:283:28)
    at file:///home/caspervonb/deno/a4959e45-e14a-4088-9481-1767fec6e3e4$deno$test.js:4:27

failures:

	aggregate
```

After:

```
test aggregate ... FAILED (23ms)

failures:

aggregate
Error: Error 1
    at file:///home/caspervonb/deno/cli/tests/testdata/test/aggregate_error.ts:2:18
    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
    at runTest (deno:runtime/js/40_testing.js:223:13)
    at Object.runTests (deno:runtime/js/40_testing.js:308:28)
    at [deno:cli/tools/test.rs:302:6]:1:21
Error: Error 2
    at file:///home/caspervonb/deno/cli/tests/testdata/test/aggregate_error.ts:3:18
    at asyncOpSanitizer (deno:runtime/js/40_testing.js:35:15)
    at resourceSanitizer (deno:runtime/js/40_testing.js:72:13)
    at exitSanitizer (deno:runtime/js/40_testing.js:99:15)
    at runTest (deno:runtime/js/40_testing.js:223:13)
    at Object.runTests (deno:runtime/js/40_testing.js:308:28)
    at [deno:cli/tools/test.rs:302:6]:1:21

failures:

	aggregate
```