### PR TITLE
quickfix(ci): only run "Build product size info" on main/tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,7 +545,7 @@ jobs:
       - name: Build product size info
         if: matrix.job != 'lint' && matrix.profile != 'fastci' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         run: |
           du -hd1 "./target/${{ matrix.profile }}"
           du -ha  "./target/${{ matrix.profile }}/deno"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,7 +543,9 @@ jobs:
           git push origin gh-pages
 
       - name: Build product size info
-        if: matrix.job != 'lint' && matrix.profile != 'fastci'
+        if: matrix.job != 'lint' && matrix.profile != 'fastci' &&
+          github.repository == 'denoland/deno' &&
+          startsWith(github.ref, 'refs/tags/')
         run: |
           du -hd1 "./target/${{ matrix.profile }}"
           du -ha  "./target/${{ matrix.profile }}/deno"


### PR DESCRIPTION
Quickfix follow up to #11884, will cleanup and refactor CI jobs later to better separate PR & Main jobs