### PR TITLE
feat(unstable): provide ops details for ops sanitizer failures

### DIFF
--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -133,6 +133,12 @@ itest!(allow_none {
   output: "test/allow_none.out",
 });
 
+itest!(ops_sanitizer_unstable {
+  args: "test --unstable test/ops_sanitizer_unstable.ts",
+  exit_code: 1,
+  output: "test/ops_sanitizer_unstable.out",
+});
+
 itest!(exit_sanitizer {
   args: "test test/exit_sanitizer.ts",
   output: "test/exit_sanitizer.out",

--- a/cli/tests/testdata/test/ops_sanitizer_unstable.out
+++ b/cli/tests/testdata/test/ops_sanitizer_unstable.out
@@ -1,0 +1,40 @@
+Check [WILDCARD]/testdata/test/ops_sanitizer_unstable.ts
+running 2 tests from [WILDCARD]/testdata/test/ops_sanitizer_unstable.ts
+test no-op ... ok ([WILDCARD])
+test leak interval ... FAILED ([WILDCARD])
+
+failures:
+
+leak interval
+AssertionError: Test case is leaking async ops.
+Before:
+  - dispatched: 1
+  - completed: 1
+After:
+  - dispatched: 3
+  - completed: 2
+Ops:
+  op_global_timer:
+    Before:
+      - dispatched: 1
+      - completed: 1
+    After:
+      - dispatched: 3
+      - completed: 2
+
+Make sure to await all promises returned from Deno APIs before
+finishing test case.
+    at assert (deno:runtime/js/06_util.js:41:13)
+    at asyncOpSanitizer (deno:runtime/js/40_testing.js:85:7)
+    at async resourceSanitizer (deno:runtime/js/40_testing.js:100:7)
+    at async exitSanitizer (deno:runtime/js/40_testing.js:127:9)
+    at async runTest (deno:runtime/js/40_testing.js:243:7)
+    at async Object.runTests (deno:runtime/js/40_testing.js:327:22)
+
+failures:
+
+	leak interval
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+error: Test failed

--- a/cli/tests/testdata/test/ops_sanitizer_unstable.ts
+++ b/cli/tests/testdata/test/ops_sanitizer_unstable.ts
@@ -1,0 +1,4 @@
+Deno.test("no-op", function() {});
+Deno.test("leak interval", function() {
+  setInterval(function() {});
+});

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -41,22 +41,50 @@
       }
 
       const post = metrics();
+
       // We're checking diff because one might spawn HTTP server in the background
       // that will be a pending async op before test starts.
       const dispatchedDiff = post.opsDispatchedAsync - pre.opsDispatchedAsync;
       const completedDiff = post.opsCompletedAsync - pre.opsCompletedAsync;
-      assert(
-        dispatchedDiff === completedDiff,
-        `Test case is leaking async ops.
+
+      const details = [];
+      for (const key in post.ops) {
+        const dispatchedDiff = Number(
+          post.ops[key]?.opsDispatchedAsync -
+            (pre.ops[key]?.opsDispatchedAsync ?? 0),
+        );
+        const completedDiff = Number(
+          post.ops[key]?.opsCompletedAsync -
+            (pre.ops[key]?.opsCompletedAsync ?? 0),
+        );
+
+        if (dispatchedDiff !== completedDiff) {
+          details.push(`
+  ${key}:
+    Before:
+      - dispatched: ${pre.ops[key]?.opsDispatchedAsync ?? 0}
+      - completed: ${pre.ops[key]?.opsCompletedAsync ?? 0}
+    After:
+      - dispatched: ${post.ops[key].opsDispatchedAsync}
+      - completed: ${post.ops[key].opsCompletedAsync}`);
+        }
+      }
+
+      const message = `Test case is leaking async ops.
 Before:
   - dispatched: ${pre.opsDispatchedAsync}
   - completed: ${pre.opsCompletedAsync}
 After:
   - dispatched: ${post.opsDispatchedAsync}
   - completed: ${post.opsCompletedAsync}
+${details.length > 0 ? "Ops:" + details.join("") : ""}
 
 Make sure to await all promises returned from Deno APIs before
-finishing test case.`,
+finishing test case.`;
+
+      assert(
+        dispatchedDiff === completedDiff,
+        message,
       );
     };
   }


### PR DESCRIPTION
This adds an additional section to ops sanitizer failures with containing op names along with before and after counts.
This is only available in unstable as `Deno.metrics().ops` is only in unstable.

Closes #12142 