### PR TITLE
test(cli): align unit test permissions with runtime test permissions

### DIFF
--- a/cli/tests/unit/body_test.ts
+++ b/cli/tests/unit/body_test.ts
@@ -35,7 +35,7 @@ unitTest(async function arrayBufferFromByteArrays() {
 
 //FormData
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function bodyMultipartFormData() {
     const response = await fetch(
       "http://localhost:4545/multipart_form_data.txt",
@@ -54,7 +54,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function bodyURLEncodedFormData() {
     const response = await fetch(
       "http://localhost:4545/subdir/form_urlencoded.txt",
@@ -73,7 +73,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: {} }, async function bodyURLSearchParams() {
+unitTest({ permissions: {} }, async function bodyURLSearchParams() {
   const body = buildBody(new URLSearchParams({ hello: "world" }));
 
   const text = await body.text();

--- a/cli/tests/unit/chmod_test.ts
+++ b/cli/tests/unit/chmod_test.ts
@@ -8,7 +8,10 @@ import {
 } from "./test_util.ts";
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   function chmodSyncSuccess() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -25,7 +28,10 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   function chmodSyncUrl() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -47,7 +53,7 @@ unitTest(
 unitTest(
   {
     ignore: Deno.build.os === "windows",
-    perms: { read: true, write: true },
+    permissions: { read: true, write: true },
   },
   function chmodSyncSymlinkSuccess() {
     const enc = new TextEncoder();
@@ -75,21 +81,24 @@ unitTest(
   },
 );
 
-unitTest({ perms: { write: true } }, function chmodSyncFailure() {
+unitTest({ permissions: { write: true } }, function chmodSyncFailure() {
   assertThrows(() => {
     const filename = "/badfile.txt";
     Deno.chmodSync(filename, 0o777);
   }, Deno.errors.NotFound);
 });
 
-unitTest({ perms: { write: false } }, function chmodSyncPerm() {
+unitTest({ permissions: { write: false } }, function chmodSyncPerm() {
   assertThrows(() => {
     Deno.chmodSync("/somefile.txt", 0o777);
   }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   async function chmodSuccess() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -106,7 +115,10 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   async function chmodUrl() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -129,7 +141,7 @@ unitTest(
 unitTest(
   {
     ignore: Deno.build.os === "windows",
-    perms: { read: true, write: true },
+    permissions: { read: true, write: true },
   },
   async function chmodSymlinkSuccess() {
     const enc = new TextEncoder();
@@ -157,14 +169,14 @@ unitTest(
   },
 );
 
-unitTest({ perms: { write: true } }, async function chmodFailure() {
+unitTest({ permissions: { write: true } }, async function chmodFailure() {
   await assertRejects(async () => {
     const filename = "/badfile.txt";
     await Deno.chmod(filename, 0o777);
   }, Deno.errors.NotFound);
 });
 
-unitTest({ perms: { write: false } }, async function chmodPerm() {
+unitTest({ permissions: { write: false } }, async function chmodPerm() {
   await assertRejects(async () => {
     await Deno.chmod("/somefile.txt", 0o777);
   }, Deno.errors.PermissionDenied);

--- a/cli/tests/unit/chown_test.ts
+++ b/cli/tests/unit/chown_test.ts
@@ -40,7 +40,10 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, write: true }, ignore: Deno.build.os == "windows" },
+  {
+    permissions: { run: true, write: true },
+    ignore: Deno.build.os == "windows",
+  },
   async function chownSyncFileNotExist() {
     const { uid, gid } = await getUidAndGid();
     const filePath = Deno.makeTempDirSync() + "/chown_test_file.txt";
@@ -52,7 +55,10 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, write: true }, ignore: Deno.build.os == "windows" },
+  {
+    permissions: { run: true, write: true },
+    ignore: Deno.build.os == "windows",
+  },
   async function chownFileNotExist() {
     const { uid, gid } = await getUidAndGid();
     const filePath = (await Deno.makeTempDir()) + "/chown_test_file.txt";
@@ -64,7 +70,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true }, ignore: Deno.build.os == "windows" },
+  { permissions: { write: true }, ignore: Deno.build.os == "windows" },
   function chownSyncPermissionDenied() {
     const dirPath = Deno.makeTempDirSync();
     const filePath = dirPath + "/chown_test_file.txt";
@@ -79,7 +85,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true }, ignore: Deno.build.os == "windows" },
+  { permissions: { write: true }, ignore: Deno.build.os == "windows" },
   async function chownPermissionDenied() {
     const dirPath = await Deno.makeTempDir();
     const filePath = dirPath + "/chown_test_file.txt";
@@ -94,7 +100,10 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, write: true }, ignore: Deno.build.os == "windows" },
+  {
+    permissions: { run: true, write: true },
+    ignore: Deno.build.os == "windows",
+  },
   async function chownSyncSucceed() {
     // TODO(bartlomieju): when a file's owner is actually being changed,
     // chown only succeeds if run under priviledged user (root)
@@ -114,7 +123,10 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, write: true }, ignore: Deno.build.os == "windows" },
+  {
+    permissions: { run: true, write: true },
+    ignore: Deno.build.os == "windows",
+  },
   async function chownSyncWithUrl() {
     const { uid, gid } = await getUidAndGid();
     const dirPath = Deno.makeTempDirSync();
@@ -126,7 +138,10 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, write: true }, ignore: Deno.build.os == "windows" },
+  {
+    permissions: { run: true, write: true },
+    ignore: Deno.build.os == "windows",
+  },
   async function chownSucceed() {
     const { uid, gid } = await getUidAndGid();
     const dirPath = await Deno.makeTempDir();
@@ -138,7 +153,10 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, write: true }, ignore: Deno.build.os == "windows" },
+  {
+    permissions: { run: true, write: true },
+    ignore: Deno.build.os == "windows",
+  },
   async function chownUidOnly() {
     const { uid } = await getUidAndGid();
     const dirPath = await Deno.makeTempDir();
@@ -150,7 +168,10 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, write: true }, ignore: Deno.build.os == "windows" },
+  {
+    permissions: { run: true, write: true },
+    ignore: Deno.build.os == "windows",
+  },
   async function chownWithUrl() {
     // TODO(bartlomieju): same as chownSyncSucceed
     const { uid, gid } = await getUidAndGid();

--- a/cli/tests/unit/copy_file_test.ts
+++ b/cli/tests/unit/copy_file_test.ts
@@ -28,7 +28,7 @@ function assertSameContent(
 }
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function copyFileSyncSuccess() {
     const tempDir = Deno.makeTempDirSync();
     const fromFilename = tempDir + "/from.txt";
@@ -45,7 +45,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function copyFileSyncByUrl() {
     const tempDir = Deno.makeTempDirSync();
     const fromUrl = new URL(
@@ -66,7 +66,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   function copyFileSyncFailure() {
     const tempDir = Deno.makeTempDirSync();
     const fromFilename = tempDir + "/from.txt";
@@ -81,7 +81,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true, read: false } },
+  { permissions: { write: true, read: false } },
   function copyFileSyncPerm1() {
     assertThrows(() => {
       Deno.copyFileSync("/from.txt", "/to.txt");
@@ -90,7 +90,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: false, read: true } },
+  { permissions: { write: false, read: true } },
   function copyFileSyncPerm2() {
     assertThrows(() => {
       Deno.copyFileSync("/from.txt", "/to.txt");
@@ -99,7 +99,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function copyFileSyncOverwrite() {
     const tempDir = Deno.makeTempDirSync();
     const fromFilename = tempDir + "/from.txt";
@@ -118,7 +118,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function copyFileSuccess() {
     const tempDir = Deno.makeTempDirSync();
     const fromFilename = tempDir + "/from.txt";
@@ -135,7 +135,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function copyFileByUrl() {
     const tempDir = Deno.makeTempDirSync();
     const fromUrl = new URL(
@@ -156,7 +156,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function copyFileFailure() {
     const tempDir = Deno.makeTempDirSync();
     const fromFilename = tempDir + "/from.txt";
@@ -171,7 +171,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function copyFileOverwrite() {
     const tempDir = Deno.makeTempDirSync();
     const fromFilename = tempDir + "/from.txt";
@@ -190,7 +190,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: false, write: true } },
+  { permissions: { read: false, write: true } },
   async function copyFilePerm1() {
     await assertRejects(async () => {
       await Deno.copyFile("/from.txt", "/to.txt");
@@ -199,7 +199,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: false } },
+  { permissions: { read: true, write: false } },
   async function copyFilePerm2() {
     await assertRejects(async () => {
       await Deno.copyFile("/from.txt", "/to.txt");

--- a/cli/tests/unit/dir_test.ts
+++ b/cli/tests/unit/dir_test.ts
@@ -1,12 +1,12 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertThrows, unitTest } from "./test_util.ts";
 
-unitTest({ perms: { read: true } }, function dirCwdNotNull() {
+unitTest({ permissions: { read: true } }, function dirCwdNotNull() {
   assert(Deno.cwd() != null);
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function dirCwdChdirSuccess() {
     const initialdir = Deno.cwd();
     const path = Deno.makeTempDirSync();
@@ -21,7 +21,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: true, write: true } }, function dirCwdError() {
+unitTest({ permissions: { read: true, write: true } }, function dirCwdError() {
   // excluding windows since it throws resource busy, while removeSync
   if (["linux", "darwin"].includes(Deno.build.os)) {
     const initialdir = Deno.cwd();
@@ -38,7 +38,7 @@ unitTest({ perms: { read: true, write: true } }, function dirCwdError() {
   }
 });
 
-unitTest({ perms: { read: false } }, function dirCwdPermError() {
+unitTest({ permissions: { read: false } }, function dirCwdPermError() {
   assertThrows(
     () => {
       Deno.cwd();
@@ -49,7 +49,7 @@ unitTest({ perms: { read: false } }, function dirCwdPermError() {
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function dirChdirError() {
     const path = Deno.makeTempDirSync() + "test";
     assertThrows(() => {

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -11,7 +11,7 @@ import {
 import { Buffer } from "../../../test_util/std/io/buffer.ts";
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchRequiresOneArgument() {
     await assertRejects(
       fetch as unknown as () => Promise<void>,
@@ -20,7 +20,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, async function fetchProtocolError() {
+unitTest({ permissions: { net: true } }, async function fetchProtocolError() {
   await assertRejects(
     async () => {
       await fetch("file:///");
@@ -55,7 +55,7 @@ function findClosedPortInRange(
 }
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchConnectionError() {
     const port = findClosedPortInRange(4000, 9999);
     await assertRejects(
@@ -69,7 +69,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchDnsError() {
     await assertRejects(
       async () => {
@@ -82,7 +82,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchInvalidUriError() {
     await assertRejects(
       async () => {
@@ -93,7 +93,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, async function fetchJsonSuccess() {
+unitTest({ permissions: { net: true } }, async function fetchJsonSuccess() {
   const response = await fetch("http://localhost:4545/fixture.json");
   const json = await response.json();
   assertEquals(json.name, "deno");
@@ -105,13 +105,13 @@ unitTest(async function fetchPerm() {
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { net: true } }, async function fetchUrl() {
+unitTest({ permissions: { net: true } }, async function fetchUrl() {
   const response = await fetch("http://localhost:4545/fixture.json");
   assertEquals(response.url, "http://localhost:4545/fixture.json");
   const _json = await response.json();
 });
 
-unitTest({ perms: { net: true } }, async function fetchURL() {
+unitTest({ permissions: { net: true } }, async function fetchURL() {
   const response = await fetch(
     new URL("http://localhost:4545/fixture.json"),
   );
@@ -119,14 +119,14 @@ unitTest({ perms: { net: true } }, async function fetchURL() {
   const _json = await response.json();
 });
 
-unitTest({ perms: { net: true } }, async function fetchHeaders() {
+unitTest({ permissions: { net: true } }, async function fetchHeaders() {
   const response = await fetch("http://localhost:4545/fixture.json");
   const headers = response.headers;
   assertEquals(headers.get("Content-Type"), "application/json");
   const _json = await response.json();
 });
 
-unitTest({ perms: { net: true } }, async function fetchBlob() {
+unitTest({ permissions: { net: true } }, async function fetchBlob() {
   const response = await fetch("http://localhost:4545/fixture.json");
   const headers = response.headers;
   const blob = await response.blob();
@@ -135,7 +135,7 @@ unitTest({ perms: { net: true } }, async function fetchBlob() {
 });
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchBodyUsedReader() {
     const response = await fetch(
       "http://localhost:4545/fixture.json",
@@ -153,7 +153,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchBodyUsedCancelStream() {
     const response = await fetch(
       "http://localhost:4545/fixture.json",
@@ -167,7 +167,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, async function fetchAsyncIterator() {
+unitTest({ permissions: { net: true } }, async function fetchAsyncIterator() {
   const response = await fetch("http://localhost:4545/fixture.json");
   const headers = response.headers;
 
@@ -181,7 +181,7 @@ unitTest({ perms: { net: true } }, async function fetchAsyncIterator() {
   assertEquals(total, Number(headers.get("Content-Length")));
 });
 
-unitTest({ perms: { net: true } }, async function fetchBodyReader() {
+unitTest({ permissions: { net: true } }, async function fetchBodyReader() {
   const response = await fetch("http://localhost:4545/fixture.json");
   const headers = response.headers;
   assert(response.body !== null);
@@ -199,7 +199,7 @@ unitTest({ perms: { net: true } }, async function fetchBodyReader() {
 });
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchBodyReaderBigBody() {
     const data = "a".repeat(10 << 10); // 10mb
     const response = await fetch("http://localhost:4545/echo_server", {
@@ -220,7 +220,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, async function responseClone() {
+unitTest({ permissions: { net: true } }, async function responseClone() {
   const response = await fetch("http://localhost:4545/fixture.json");
   const response1 = response.clone();
   assert(response !== response1);
@@ -234,7 +234,7 @@ unitTest({ perms: { net: true } }, async function responseClone() {
 });
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchMultipartFormDataSuccess() {
     const response = await fetch(
       "http://localhost:4545/multipart_form_data.txt",
@@ -251,7 +251,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchMultipartFormBadContentType() {
     const response = await fetch(
       "http://localhost:4545/multipart_form_bad_content_type",
@@ -269,7 +269,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchURLEncodedFormDataSuccess() {
     const response = await fetch(
       "http://localhost:4545/subdir/form_urlencoded.txt",
@@ -283,7 +283,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchInitFormDataBinaryFileBody() {
     // Some random bytes
     // deno-fmt-ignore
@@ -302,7 +302,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchInitFormDataMultipleFilesBody() {
     const files = [
       {
@@ -357,7 +357,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function fetchWithRedirection() {
     const response = await fetch("http://localhost:4546/hello.txt");
@@ -371,7 +371,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function fetchWithRelativeRedirection() {
     const response = await fetch(
@@ -386,7 +386,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function fetchWithRelativeRedirectionUrl() {
     const cases = [
@@ -407,7 +407,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function fetchWithInfRedirection() {
     await assertRejects(
@@ -419,7 +419,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchInitStringBody() {
     const data = "Hello World";
     const response = await fetch("http://localhost:4545/echo_server", {
@@ -433,7 +433,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchRequestInitStringBody() {
     const data = "Hello World";
     const req = new Request("http://localhost:4545/echo_server", {
@@ -447,7 +447,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchSeparateInit() {
     // related to: https://github.com/denoland/deno/issues/10396
     const req = new Request("http://localhost:4545/001_hello.js");
@@ -462,7 +462,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchInitTypedArrayBody() {
     const data = "Hello World";
     const response = await fetch("http://localhost:4545/echo_server", {
@@ -475,7 +475,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchInitArrayBufferBody() {
     const data = "Hello World";
     const response = await fetch("http://localhost:4545/echo_server", {
@@ -488,7 +488,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchInitURLSearchParamsBody() {
     const data = "param1=value1&param2=value2";
     const params = new URLSearchParams(data);
@@ -506,7 +506,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, async function fetchInitBlobBody() {
+unitTest({ permissions: { net: true } }, async function fetchInitBlobBody() {
   const data = "const a = 1";
   const blob = new Blob([data], {
     type: "text/javascript",
@@ -521,7 +521,7 @@ unitTest({ perms: { net: true } }, async function fetchInitBlobBody() {
 });
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchInitFormDataBody() {
     const form = new FormData();
     form.append("field", "value");
@@ -535,7 +535,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchInitFormDataBlobFilenameBody() {
     const form = new FormData();
     form.append("field", "value");
@@ -553,7 +553,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchInitFormDataTextFileBody() {
     const fileContent = "deno land";
     const form = new FormData();
@@ -582,7 +582,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, async function fetchUserAgent() {
+unitTest({ permissions: { net: true } }, async function fetchUserAgent() {
   const data = "Hello World";
   const response = await fetch("http://localhost:4545/echo_server", {
     method: "POST",
@@ -621,7 +621,7 @@ function bufferServer(addr: string): Promise<Buffer> {
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function fetchRequest() {
     const addr = "127.0.0.1:4501";
@@ -653,7 +653,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function fetchPostBodyString() {
     const addr = "127.0.0.1:4502";
@@ -690,7 +690,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function fetchPostBodyTypedArray() {
     const addr = "127.0.0.1:4503";
@@ -727,7 +727,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function fetchWithNonAsciiRedirection() {
     const response = await fetch("http://localhost:4545/non_ascii_redirect", {
@@ -741,7 +741,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function fetchWithManualRedirection() {
     const response = await fetch("http://localhost:4546/", {
@@ -757,7 +757,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function fetchWithErrorRedirection() {
     await assertRejects(
@@ -795,7 +795,7 @@ unitTest(async function responseWithoutBody() {
   });
 });
 
-unitTest({ perms: { net: true } }, async function fetchBodyReadTwice() {
+unitTest({ permissions: { net: true } }, async function fetchBodyReadTwice() {
   const response = await fetch("http://localhost:4545/fixture.json");
 
   // Read body
@@ -817,7 +817,7 @@ unitTest({ perms: { net: true } }, async function fetchBodyReadTwice() {
 });
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchBodyReaderAfterRead() {
     const response = await fetch(
       "http://localhost:4545/fixture.json",
@@ -840,7 +840,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchBodyReaderWithCancelAndNewReader() {
     const data = "a".repeat(1 << 10);
     const response = await fetch("http://localhost:4545/echo_server", {
@@ -868,7 +868,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchBodyReaderWithReadCancelAndNewReader() {
     const data = "a".repeat(1 << 10);
 
@@ -898,7 +898,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchResourceCloseAfterStreamCancel() {
     const res = await fetch("http://localhost:4545/fixture.json");
     assert(res.body !== null);
@@ -916,7 +916,7 @@ unitTest(
 // connection error: An established connection was aborted by
 // the software in your host machine. (os error 10053)
 unitTest(
-  { perms: { net: true }, ignore: Deno.build.os == "windows" },
+  { permissions: { net: true }, ignore: Deno.build.os == "windows" },
   async function fetchNullBodyStatus() {
     const nullBodyStatus = [101, 204, 205, 304];
 
@@ -934,7 +934,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchResponseContentLength() {
     const body = new Uint8Array(2 ** 16);
     const headers = new Headers([["content-type", "application/octet-stream"]]);
@@ -999,7 +999,7 @@ unitTest(function fetchResponseEmptyConstructor() {
 
 // TODO(lucacasonato): reenable this test
 unitTest(
-  { perms: { net: true }, ignore: true },
+  { permissions: { net: true }, ignore: true },
   async function fetchCustomHttpClientParamCertificateSuccess(): Promise<
     void
   > {
@@ -1038,7 +1038,7 @@ MNf4EgWfK+tZMnuqfpfO9740KzfcVoMNo4QJD4yn5YxroUOO/Azi
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchCustomClientUserAgent(): Promise<
     void
   > {
@@ -1060,7 +1060,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function fetchPostBodyReadableStream() {
     const addr = "127.0.0.1:4502";
@@ -1146,7 +1146,7 @@ function returnHostHeaderServer(addr: string): Deno.Listener {
 }
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchFilterOutCustomHostHeader(): Promise<
     void
   > {
@@ -1163,7 +1163,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchNoServerReadableStreamBody() {
     const done = deferred();
     const body = new ReadableStream({
@@ -1184,7 +1184,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchHeadRespBody() {
     const res = await fetch("http://localhost:4545/echo_server", {
       method: "HEAD",
@@ -1194,7 +1194,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function fetchClientCertWrongPrivateKey(): Promise<void> {
     await assertRejects(async () => {
       const client = Deno.createHttpClient({
@@ -1211,7 +1211,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function fetchClientCertBadPrivateKey(): Promise<void> {
     await assertRejects(async () => {
       const client = Deno.createHttpClient({
@@ -1228,7 +1228,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function fetchClientCertNotPrivateKey(): Promise<void> {
     await assertRejects(async () => {
       const client = Deno.createHttpClient({
@@ -1245,7 +1245,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function fetchCustomClientPrivateKey(): Promise<
     void
   > {
@@ -1274,7 +1274,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function fetchAbortWhileUploadStreaming(): Promise<void> {
     const abortController = new AbortController();
     try {

--- a/cli/tests/unit/ffi_test.ts
+++ b/cli/tests/unit/ffi_test.ts
@@ -2,7 +2,7 @@
 
 import { assertThrows, unitTest } from "./test_util.ts";
 
-unitTest({ perms: { ffi: true } }, function dlopenInvalidArguments() {
+unitTest({ permissions: { ffi: true } }, function dlopenInvalidArguments() {
   const filename = "/usr/lib/libc.so.6";
   assertThrows(() => {
     // @ts-expect-error: ForeignFunction cannot be null

--- a/cli/tests/unit/file_test.ts
+++ b/cli/tests/unit/file_test.ts
@@ -101,7 +101,7 @@ unitTest(function fileUsingEmptyStringFileName() {
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function fileTruncateSyncSuccess() {
     const filename = Deno.makeTempDirSync() + "/test_fileTruncateSync.txt";
     const file = Deno.openSync(filename, {
@@ -123,7 +123,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function fileTruncateSuccess() {
     const filename = Deno.makeTempDirSync() + "/test_fileTruncate.txt";
     const file = await Deno.open(filename, {
@@ -144,7 +144,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: true } }, function fileStatSyncSuccess() {
+unitTest({ permissions: { read: true } }, function fileStatSyncSuccess() {
   const file = Deno.openSync("README.md");
   const fileInfo = file.statSync();
   assert(fileInfo.isFile);
@@ -159,7 +159,7 @@ unitTest({ perms: { read: true } }, function fileStatSyncSuccess() {
   file.close();
 });
 
-unitTest({ perms: { read: true } }, async function fileStatSuccess() {
+unitTest({ permissions: { read: true } }, async function fileStatSuccess() {
   const file = await Deno.open("README.md");
   const fileInfo = await file.stat();
   assert(fileInfo.isFile);

--- a/cli/tests/unit/files_test.ts
+++ b/cli/tests/unit/files_test.ts
@@ -11,7 +11,7 @@ unitTest(function filesStdioFileDescriptors() {
   assertEquals(Deno.stderr.rid, 2);
 });
 
-unitTest({ perms: { read: true } }, async function filesCopyToStdout() {
+unitTest({ permissions: { read: true } }, async function filesCopyToStdout() {
   const filename = "cli/tests/testdata/fixture.json";
   const file = await Deno.open(filename);
   assert(file.rid > 2);
@@ -21,7 +21,7 @@ unitTest({ perms: { read: true } }, async function filesCopyToStdout() {
   file.close();
 });
 
-unitTest({ perms: { read: true } }, async function filesIter() {
+unitTest({ permissions: { read: true } }, async function filesIter() {
   const filename = "cli/tests/testdata/hello.txt";
   const file = await Deno.open(filename);
 
@@ -35,7 +35,7 @@ unitTest({ perms: { read: true } }, async function filesIter() {
 });
 
 unitTest(
-  { perms: { read: true } },
+  { permissions: { read: true } },
   async function filesIterCustomBufSize() {
     const filename = "cli/tests/testdata/hello.txt";
     const file = await Deno.open(filename);
@@ -53,7 +53,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: true } }, function filesIterSync() {
+unitTest({ permissions: { read: true } }, function filesIterSync() {
   const filename = "cli/tests/testdata/hello.txt";
   const file = Deno.openSync(filename);
 
@@ -67,7 +67,7 @@ unitTest({ perms: { read: true } }, function filesIterSync() {
 });
 
 unitTest(
-  { perms: { read: true } },
+  { permissions: { read: true } },
   function filesIterSyncCustomBufSize() {
     const filename = "cli/tests/testdata/hello.txt";
     const file = Deno.openSync(filename);
@@ -157,7 +157,7 @@ unitTest(async function readerIterSync() {
 
 unitTest(
   {
-    perms: { read: true, write: true },
+    permissions: { read: true, write: true },
   },
   function openSyncMode() {
     const path = Deno.makeTempDirSync() + "/test_openSync.txt";
@@ -176,7 +176,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { read: true, write: true },
+    permissions: { read: true, write: true },
   },
   async function openMode() {
     const path = (await Deno.makeTempDir()) + "/test_open.txt";
@@ -195,7 +195,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { read: true, write: true },
+    permissions: { read: true, write: true },
   },
   function openSyncUrl() {
     const tempDir = Deno.makeTempDirSync();
@@ -221,7 +221,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { read: true, write: true },
+    permissions: { read: true, write: true },
   },
   async function openUrl() {
     const tempDir = await Deno.makeTempDir();
@@ -246,7 +246,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: false } },
+  { permissions: { write: false } },
   async function writePermFailure() {
     const filename = "tests/hello.txt";
     const openOptions: Deno.OpenOptions[] = [{ write: true }, { append: true }];
@@ -293,14 +293,14 @@ unitTest(async function openOptions() {
   );
 });
 
-unitTest({ perms: { read: false } }, async function readPermFailure() {
+unitTest({ permissions: { read: false } }, async function readPermFailure() {
   await assertRejects(async () => {
     await Deno.open("package.json", { read: true });
   }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
-  { perms: { write: true } },
+  { permissions: { write: true } },
   async function writeNullBufferFailure() {
     const tempDir = Deno.makeTempDirSync();
     const filename = tempDir + "hello.txt";
@@ -324,7 +324,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   async function readNullBufferFailure() {
     const tempDir = Deno.makeTempDirSync();
     const filename = tempDir + "hello.txt";
@@ -352,7 +352,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: false, read: false } },
+  { permissions: { write: false, read: false } },
   async function readWritePermFailure() {
     const filename = "tests/hello.txt";
     await assertRejects(async () => {
@@ -362,7 +362,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function createFile() {
     const tempDir = await Deno.makeTempDir();
     const filename = tempDir + "/test.txt";
@@ -383,7 +383,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function createFileWithUrl() {
     const tempDir = await Deno.makeTempDir();
     const fileUrl = new URL(
@@ -405,7 +405,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function createSyncFile() {
     const tempDir = await Deno.makeTempDir();
     const filename = tempDir + "/test.txt";
@@ -426,7 +426,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function createSyncFileWithUrl() {
     const tempDir = await Deno.makeTempDir();
     const fileUrl = new URL(
@@ -448,7 +448,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function openModeWrite() {
     const tempDir = Deno.makeTempDirSync();
     const encoder = new TextEncoder();
@@ -491,7 +491,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function openModeWriteRead() {
     const tempDir = Deno.makeTempDirSync();
     const encoder = new TextEncoder();
@@ -526,7 +526,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: true } }, async function seekStart() {
+unitTest({ permissions: { read: true } }, async function seekStart() {
   const filename = "cli/tests/testdata/hello.txt";
   const file = await Deno.open(filename);
   const seekPosition = 6;
@@ -543,7 +543,7 @@ unitTest({ perms: { read: true } }, async function seekStart() {
   file.close();
 });
 
-unitTest({ perms: { read: true } }, function seekSyncStart() {
+unitTest({ permissions: { read: true } }, function seekSyncStart() {
   const filename = "cli/tests/testdata/hello.txt";
   const file = Deno.openSync(filename);
   const seekPosition = 6;
@@ -560,7 +560,7 @@ unitTest({ perms: { read: true } }, function seekSyncStart() {
   file.close();
 });
 
-unitTest({ perms: { read: true } }, async function seekCurrent() {
+unitTest({ permissions: { read: true } }, async function seekCurrent() {
   const filename = "cli/tests/testdata/hello.txt";
   const file = await Deno.open(filename);
   // Deliberately move 1 step forward
@@ -577,7 +577,7 @@ unitTest({ perms: { read: true } }, async function seekCurrent() {
   file.close();
 });
 
-unitTest({ perms: { read: true } }, function seekSyncCurrent() {
+unitTest({ permissions: { read: true } }, function seekSyncCurrent() {
   const filename = "cli/tests/testdata/hello.txt";
   const file = Deno.openSync(filename);
   // Deliberately move 1 step forward
@@ -594,7 +594,7 @@ unitTest({ perms: { read: true } }, function seekSyncCurrent() {
   file.close();
 });
 
-unitTest({ perms: { read: true } }, async function seekEnd() {
+unitTest({ permissions: { read: true } }, async function seekEnd() {
   const filename = "cli/tests/testdata/hello.txt";
   const file = await Deno.open(filename);
   const seekPosition = -6;
@@ -608,7 +608,7 @@ unitTest({ perms: { read: true } }, async function seekEnd() {
   file.close();
 });
 
-unitTest({ perms: { read: true } }, function seekSyncEnd() {
+unitTest({ permissions: { read: true } }, function seekSyncEnd() {
   const filename = "cli/tests/testdata/hello.txt";
   const file = Deno.openSync(filename);
   const seekPosition = -6;
@@ -622,7 +622,7 @@ unitTest({ perms: { read: true } }, function seekSyncEnd() {
   file.close();
 });
 
-unitTest({ perms: { read: true } }, async function seekMode() {
+unitTest({ permissions: { read: true } }, async function seekMode() {
   const filename = "cli/tests/testdata/hello.txt";
   const file = await Deno.open(filename);
   await assertRejects(

--- a/cli/tests/unit/flock_test.ts
+++ b/cli/tests/unit/flock_test.ts
@@ -3,14 +3,14 @@ import { assertEquals, unitTest } from "./test_util.ts";
 import { readAll } from "../../../test_util/std/io/util.ts";
 
 unitTest(
-  { perms: { read: true, run: true, hrtime: true } },
+  { permissions: { read: true, run: true, hrtime: true } },
   async function flockFileSync() {
     await runFlockTests({ sync: true });
   },
 );
 
 unitTest(
-  { perms: { read: true, run: true, hrtime: true } },
+  { permissions: { read: true, run: true, hrtime: true } },
   async function flockFileAsync() {
     await runFlockTests({ sync: false });
   },

--- a/cli/tests/unit/fs_events_test.ts
+++ b/cli/tests/unit/fs_events_test.ts
@@ -3,13 +3,13 @@ import { assert, assertEquals, assertThrows, unitTest } from "./test_util.ts";
 
 // TODO(ry) Add more tests to specify format.
 
-unitTest({ perms: { read: false } }, function watchFsPermissions() {
+unitTest({ permissions: { read: false } }, function watchFsPermissions() {
   assertThrows(() => {
     Deno.watchFs(".");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, function watchFsInvalidPath() {
+unitTest({ permissions: { read: true } }, function watchFsInvalidPath() {
   if (Deno.build.os === "windows") {
     assertThrows(
       () => {
@@ -37,7 +37,7 @@ async function getTwoEvents(
 }
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function watchFsBasic() {
     const testDir = await Deno.makeTempDir();
     const iter = Deno.watchFs(testDir);
@@ -64,7 +64,7 @@ unitTest(
 // TODO(kt3k): This test is for the backward compatibility of `.return` method.
 // This should be removed at 2.0
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function watchFsReturn() {
     const testDir = await Deno.makeTempDir();
     const iter = Deno.watchFs(testDir);
@@ -82,7 +82,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function watchFsClose() {
     const testDir = await Deno.makeTempDir();
     const iter = Deno.watchFs(testDir);

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -41,7 +41,7 @@ async function writeRequestAndReadResponse(conn: Deno.Conn): Promise<string> {
   return decoder.decode(dest.bytes());
 }
 
-unitTest({ perms: { net: true } }, async function httpServerBasic() {
+unitTest({ permissions: { net: true } }, async function httpServerBasic() {
   const promise = (async () => {
     const listener = Deno.listen({ port: 4501 });
     for await (const conn of listener) {
@@ -68,7 +68,7 @@ unitTest({ perms: { net: true } }, async function httpServerBasic() {
 });
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function httpServerStreamResponse() {
     const stream = new TransformStream();
     const writer = stream.writable.getWriter();
@@ -97,7 +97,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function httpServerStreamRequest() {
     const stream = new TransformStream();
     const writer = stream.writable.getWriter();
@@ -135,43 +135,46 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, async function httpServerStreamDuplex() {
-  const promise = (async () => {
-    const listener = Deno.listen({ port: 4501 });
-    const conn = await listener.accept();
-    const httpConn = Deno.serveHttp(conn);
-    const evt = await httpConn.nextRequest();
-    assert(evt);
-    const { request, respondWith } = evt;
-    assert(request.body);
-    await respondWith(new Response(request.body));
-    httpConn.close();
-    listener.close();
-  })();
+unitTest(
+  { permissions: { net: true } },
+  async function httpServerStreamDuplex() {
+    const promise = (async () => {
+      const listener = Deno.listen({ port: 4501 });
+      const conn = await listener.accept();
+      const httpConn = Deno.serveHttp(conn);
+      const evt = await httpConn.nextRequest();
+      assert(evt);
+      const { request, respondWith } = evt;
+      assert(request.body);
+      await respondWith(new Response(request.body));
+      httpConn.close();
+      listener.close();
+    })();
 
-  const ts = new TransformStream();
-  const writable = ts.writable.getWriter();
-  const resp = await fetch("http://127.0.0.1:4501/", {
-    method: "POST",
-    body: ts.readable,
-  });
-  assert(resp.body);
-  const reader = resp.body.getReader();
-  await writable.write(new Uint8Array([1]));
-  const chunk1 = await reader.read();
-  assert(!chunk1.done);
-  assertEquals(chunk1.value, new Uint8Array([1]));
-  await writable.write(new Uint8Array([2]));
-  const chunk2 = await reader.read();
-  assert(!chunk2.done);
-  assertEquals(chunk2.value, new Uint8Array([2]));
-  await writable.close();
-  const chunk3 = await reader.read();
-  assert(chunk3.done);
-  await promise;
-});
+    const ts = new TransformStream();
+    const writable = ts.writable.getWriter();
+    const resp = await fetch("http://127.0.0.1:4501/", {
+      method: "POST",
+      body: ts.readable,
+    });
+    assert(resp.body);
+    const reader = resp.body.getReader();
+    await writable.write(new Uint8Array([1]));
+    const chunk1 = await reader.read();
+    assert(!chunk1.done);
+    assertEquals(chunk1.value, new Uint8Array([1]));
+    await writable.write(new Uint8Array([2]));
+    const chunk2 = await reader.read();
+    assert(!chunk2.done);
+    assertEquals(chunk2.value, new Uint8Array([2]));
+    await writable.close();
+    const chunk3 = await reader.read();
+    assert(chunk3.done);
+    await promise;
+  },
+);
 
-unitTest({ perms: { net: true } }, async function httpServerClose() {
+unitTest({ permissions: { net: true } }, async function httpServerClose() {
   const listener = Deno.listen({ port: 4501 });
   const client = await Deno.connect({ port: 4501 });
   const httpConn = Deno.serveHttp(await listener.accept());
@@ -182,25 +185,28 @@ unitTest({ perms: { net: true } }, async function httpServerClose() {
   listener.close();
 });
 
-unitTest({ perms: { net: true } }, async function httpServerInvalidMethod() {
-  const listener = Deno.listen({ port: 4501 });
-  const client = await Deno.connect({ port: 4501 });
-  const httpConn = Deno.serveHttp(await listener.accept());
-  await client.write(new Uint8Array([1, 2, 3]));
-  await assertRejects(
-    async () => {
-      await httpConn.nextRequest();
-    },
-    Deno.errors.Http,
-    "invalid HTTP method parsed",
-  );
-  // Note httpConn is automatically closed when it errors.
-  client.close();
-  listener.close();
-});
+unitTest(
+  { permissions: { net: true } },
+  async function httpServerInvalidMethod() {
+    const listener = Deno.listen({ port: 4501 });
+    const client = await Deno.connect({ port: 4501 });
+    const httpConn = Deno.serveHttp(await listener.accept());
+    await client.write(new Uint8Array([1, 2, 3]));
+    await assertRejects(
+      async () => {
+        await httpConn.nextRequest();
+      },
+      Deno.errors.Http,
+      "invalid HTTP method parsed",
+    );
+    // Note httpConn is automatically closed when it errors.
+    client.close();
+    listener.close();
+  },
+);
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function httpServerWithTls() {
     const hostname = "localhost";
     const port = 4501;
@@ -241,7 +247,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function httpServerRegressionHang() {
     const promise = (async () => {
       const listener = Deno.listen({ port: 4501 });
@@ -268,7 +274,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function httpServerCancelBodyOnResponseFailure() {
     const promise = (async () => {
       const listener = Deno.listen({ port: 4501 });
@@ -313,7 +319,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function httpServerNextRequestErrorExposedInResponse() {
     const promise = (async () => {
       const listener = Deno.listen({ port: 4501 });
@@ -358,7 +364,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function httpServerEmptyBlobResponse() {
     const promise = (async () => {
       const listener = Deno.listen({ port: 4501 });
@@ -380,7 +386,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function httpServerNextRequestResolvesOnClose() {
     const httpConnList: Deno.HttpConn[] = [];
 
@@ -412,7 +418,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   // Issue: https://github.com/denoland/deno/issues/10870
   async function httpServerHang() {
     // Quick and dirty way to make a readable stream from a string. Alternatively,
@@ -458,7 +464,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   // Issue: https://github.com/denoland/deno/issues/10930
   async function httpServerStreamingResponse() {
     // This test enqueues a single chunk for readable
@@ -547,51 +553,54 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, async function httpRequestLatin1Headers() {
-  const promise = (async () => {
-    const listener = Deno.listen({ port: 4501 });
-    for await (const conn of listener) {
-      const httpConn = Deno.serveHttp(conn);
-      for await (const { request, respondWith } of httpConn) {
-        assertEquals(request.headers.get("X-Header-Test"), "á");
-        await respondWith(
-          new Response("", { headers: { "X-Header-Test": "Æ" } }),
-        );
-        httpConn.close();
+unitTest(
+  { permissions: { net: true } },
+  async function httpRequestLatin1Headers() {
+    const promise = (async () => {
+      const listener = Deno.listen({ port: 4501 });
+      for await (const conn of listener) {
+        const httpConn = Deno.serveHttp(conn);
+        for await (const { request, respondWith } of httpConn) {
+          assertEquals(request.headers.get("X-Header-Test"), "á");
+          await respondWith(
+            new Response("", { headers: { "X-Header-Test": "Æ" } }),
+          );
+          httpConn.close();
+        }
+        break;
       }
-      break;
+    })();
+
+    const clientConn = await Deno.connect({ port: 4501 });
+    const requestText =
+      "GET / HTTP/1.1\r\nHost: 127.0.0.1:4501\r\nX-Header-Test: á\r\n\r\n";
+    const requestBytes = new Uint8Array(requestText.length);
+    for (let i = 0; i < requestText.length; i++) {
+      requestBytes[i] = requestText.charCodeAt(i);
     }
-  })();
-
-  const clientConn = await Deno.connect({ port: 4501 });
-  const requestText =
-    "GET / HTTP/1.1\r\nHost: 127.0.0.1:4501\r\nX-Header-Test: á\r\n\r\n";
-  const requestBytes = new Uint8Array(requestText.length);
-  for (let i = 0; i < requestText.length; i++) {
-    requestBytes[i] = requestText.charCodeAt(i);
-  }
-  let written = 0;
-  while (written < requestBytes.byteLength) {
-    written += await clientConn.write(requestBytes.slice(written));
-  }
-
-  let responseText = "";
-  const buf = new Uint8Array(1024);
-  let read;
-  while ((read = await clientConn.read(buf)) !== null) {
-    for (let i = 0; i < read; i++) {
-      responseText += String.fromCharCode(buf[i]);
+    let written = 0;
+    while (written < requestBytes.byteLength) {
+      written += await clientConn.write(requestBytes.slice(written));
     }
-  }
-  clientConn.close();
 
-  assert(/\r\n[Xx]-[Hh]eader-[Tt]est: Æ\r\n/.test(responseText));
+    let responseText = "";
+    const buf = new Uint8Array(1024);
+    let read;
+    while ((read = await clientConn.read(buf)) !== null) {
+      for (let i = 0; i < read; i++) {
+        responseText += String.fromCharCode(buf[i]);
+      }
+    }
+    clientConn.close();
 
-  await promise;
-});
+    assert(/\r\n[Xx]-[Hh]eader-[Tt]est: Æ\r\n/.test(responseText));
+
+    await promise;
+  },
+);
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function httpServerRequestWithoutPath() {
     const promise = (async () => {
       const listener = Deno.listen({ port: 4501 });
@@ -635,7 +644,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, async function httpServerWebSocket() {
+unitTest({ permissions: { net: true } }, async function httpServerWebSocket() {
   const promise = (async () => {
     const listener = Deno.listen({ port: 4501 });
     for await (const conn of listener) {
@@ -752,35 +761,38 @@ unitTest(function httpUpgradeWebSocketWithoutUpgradeHeader() {
   );
 });
 
-unitTest({ perms: { net: true } }, async function httpCookieConcatenation() {
-  const promise = (async () => {
-    const listener = Deno.listen({ port: 4501 });
-    for await (const conn of listener) {
-      const httpConn = Deno.serveHttp(conn);
-      for await (const { request, respondWith } of httpConn) {
-        assertEquals(new URL(request.url).href, "http://127.0.0.1:4501/");
-        assertEquals(await request.text(), "");
-        assertEquals(request.headers.get("cookie"), "foo=bar; bar=foo");
-        respondWith(new Response("ok"));
+unitTest(
+  { permissions: { net: true } },
+  async function httpCookieConcatenation() {
+    const promise = (async () => {
+      const listener = Deno.listen({ port: 4501 });
+      for await (const conn of listener) {
+        const httpConn = Deno.serveHttp(conn);
+        for await (const { request, respondWith } of httpConn) {
+          assertEquals(new URL(request.url).href, "http://127.0.0.1:4501/");
+          assertEquals(await request.text(), "");
+          assertEquals(request.headers.get("cookie"), "foo=bar; bar=foo");
+          respondWith(new Response("ok"));
+        }
+        break;
       }
-      break;
-    }
-  })();
+    })();
 
-  const resp = await fetch("http://127.0.0.1:4501/", {
-    headers: [
-      ["connection", "close"],
-      ["cookie", "foo=bar"],
-      ["cookie", "bar=foo"],
-    ],
-  });
-  const text = await resp.text();
-  assertEquals(text, "ok");
-  await promise;
-});
+    const resp = await fetch("http://127.0.0.1:4501/", {
+      headers: [
+        ["connection", "close"],
+        ["cookie", "foo=bar"],
+        ["cookie", "bar=foo"],
+      ],
+    });
+    const text = await resp.text();
+    assertEquals(text, "ok");
+    await promise;
+  },
+);
 
 // https://github.com/denoland/deno/issues/11651
-unitTest({ perms: { net: true } }, async function httpServerPanic() {
+unitTest({ permissions: { net: true } }, async function httpServerPanic() {
   const listener = Deno.listen({ port: 4501 });
   const client = await Deno.connect({ port: 4501 });
   const conn = await listener.accept();
@@ -801,7 +813,7 @@ unitTest({ perms: { net: true } }, async function httpServerPanic() {
 
 // https://github.com/denoland/deno/issues/11595
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function httpServerIncompleteMessage() {
     const listener = Deno.listen({ port: 4501 });
 
@@ -861,7 +873,7 @@ unitTest(
 
 // https://github.com/denoland/deno/issues/11743
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function httpServerDoesntLeakResources() {
     const listener = Deno.listen({ port: 4505 });
     const [conn, clientConn] = await Promise.all([
@@ -885,7 +897,7 @@ unitTest(
 
 // https://github.com/denoland/deno/issues/11926
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function httpServerDoesntLeakResources2() {
     let listener: Deno.Listener;
     let httpConn: Deno.HttpConn;

--- a/cli/tests/unit/io_test.ts
+++ b/cli/tests/unit/io_test.ts
@@ -59,7 +59,7 @@ unitTest(async function copyWithCustomBufferSize() {
   assertEquals(readSpy.calls, DEFAULT_BUF_SIZE / bufSize + 1);
 });
 
-unitTest({ perms: { write: true } }, async function copyBufferToFile() {
+unitTest({ permissions: { write: true } }, async function copyBufferToFile() {
   const filePath = "test-file.txt";
   // bigger than max File possible buffer 16kb
   const bufSize = 32 * 1024;

--- a/cli/tests/unit/link_test.ts
+++ b/cli/tests/unit/link_test.ts
@@ -2,7 +2,7 @@
 import { assert, assertEquals, assertThrows, unitTest } from "./test_util.ts";
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function linkSyncSuccess() {
     const testDir = Deno.makeTempDirSync();
     const oldData = "Hardlink";
@@ -41,7 +41,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function linkSyncExists() {
     const testDir = Deno.makeTempDirSync();
     const oldName = testDir + "/oldname";
@@ -57,7 +57,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function linkSyncNotFound() {
     const testDir = Deno.makeTempDirSync();
     const oldName = testDir + "/oldname";
@@ -70,7 +70,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: false, write: true } },
+  { permissions: { read: false, write: true } },
   function linkSyncReadPerm() {
     assertThrows(() => {
       Deno.linkSync("oldbaddir", "newbaddir");
@@ -79,7 +79,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: false } },
+  { permissions: { read: true, write: false } },
   function linkSyncWritePerm() {
     assertThrows(() => {
       Deno.linkSync("oldbaddir", "newbaddir");
@@ -88,7 +88,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function linkSuccess() {
     const testDir = Deno.makeTempDirSync();
     const oldData = "Hardlink";

--- a/cli/tests/unit/make_temp_test.ts
+++ b/cli/tests/unit/make_temp_test.ts
@@ -7,7 +7,7 @@ import {
   unitTest,
 } from "./test_util.ts";
 
-unitTest({ perms: { write: true } }, function makeTempDirSyncSuccess() {
+unitTest({ permissions: { write: true } }, function makeTempDirSyncSuccess() {
   const dir1 = Deno.makeTempDirSync({ prefix: "hello", suffix: "world" });
   const dir2 = Deno.makeTempDirSync({ prefix: "hello", suffix: "world" });
   // Check that both dirs are different.
@@ -29,7 +29,7 @@ unitTest({ perms: { write: true } }, function makeTempDirSyncSuccess() {
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function makeTempDirSyncMode() {
     const path = Deno.makeTempDirSync();
     const pathInfo = Deno.statSync(path);
@@ -47,7 +47,7 @@ unitTest(function makeTempDirSyncPerm() {
 });
 
 unitTest(
-  { perms: { write: true } },
+  { permissions: { write: true } },
   async function makeTempDirSuccess() {
     const dir1 = await Deno.makeTempDir({ prefix: "hello", suffix: "world" });
     const dir2 = await Deno.makeTempDir({ prefix: "hello", suffix: "world" });
@@ -71,7 +71,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function makeTempDirMode() {
     const path = await Deno.makeTempDir();
     const pathInfo = Deno.statSync(path);
@@ -81,7 +81,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { write: true } }, function makeTempFileSyncSuccess() {
+unitTest({ permissions: { write: true } }, function makeTempFileSyncSuccess() {
   const file1 = Deno.makeTempFileSync({ prefix: "hello", suffix: "world" });
   const file2 = Deno.makeTempFileSync({ prefix: "hello", suffix: "world" });
   // Check that both dirs are different.
@@ -104,7 +104,7 @@ unitTest({ perms: { write: true } }, function makeTempFileSyncSuccess() {
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function makeTempFileSyncMode() {
     const path = Deno.makeTempFileSync();
     const pathInfo = Deno.statSync(path);
@@ -122,7 +122,7 @@ unitTest(function makeTempFileSyncPerm() {
 });
 
 unitTest(
-  { perms: { write: true } },
+  { permissions: { write: true } },
   async function makeTempFileSuccess() {
     const file1 = await Deno.makeTempFile({ prefix: "hello", suffix: "world" });
     const file2 = await Deno.makeTempFile({ prefix: "hello", suffix: "world" });
@@ -147,7 +147,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function makeTempFileMode() {
     const path = await Deno.makeTempFile();
     const pathInfo = Deno.statSync(path);

--- a/cli/tests/unit/metrics_test.ts
+++ b/cli/tests/unit/metrics_test.ts
@@ -40,7 +40,7 @@ unitTest(async function metrics() {
 });
 
 unitTest(
-  { perms: { write: true } },
+  { permissions: { write: true } },
   function metricsUpdatedIfNoResponseSync() {
     const filename = Deno.makeTempDirSync() + "/test.txt";
 
@@ -54,7 +54,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true } },
+  { permissions: { write: true } },
   async function metricsUpdatedIfNoResponseAsync() {
     const filename = Deno.makeTempDirSync() + "/test.txt";
 

--- a/cli/tests/unit/mkdir_test.ts
+++ b/cli/tests/unit/mkdir_test.ts
@@ -17,7 +17,7 @@ function assertDirectory(path: string, mode?: number) {
 }
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function mkdirSyncSuccess() {
     const path = Deno.makeTempDirSync() + "/dir";
     Deno.mkdirSync(path);
@@ -26,7 +26,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function mkdirSyncMode() {
     const path = Deno.makeTempDirSync() + "/dir";
     Deno.mkdirSync(path, { mode: 0o737 });
@@ -34,14 +34,14 @@ unitTest(
   },
 );
 
-unitTest({ perms: { write: false } }, function mkdirSyncPerm() {
+unitTest({ permissions: { write: false } }, function mkdirSyncPerm() {
   assertThrows(() => {
     Deno.mkdirSync("/baddir");
   }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function mkdirSuccess() {
     const path = Deno.makeTempDirSync() + "/dir";
     await Deno.mkdir(path);
@@ -50,7 +50,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function mkdirMode() {
     const path = Deno.makeTempDirSync() + "/dir";
     await Deno.mkdir(path, { mode: 0o737 });
@@ -58,20 +58,20 @@ unitTest(
   },
 );
 
-unitTest({ perms: { write: true } }, function mkdirErrSyncIfExists() {
+unitTest({ permissions: { write: true } }, function mkdirErrSyncIfExists() {
   assertThrows(() => {
     Deno.mkdirSync(".");
   }, Deno.errors.AlreadyExists);
 });
 
-unitTest({ perms: { write: true } }, async function mkdirErrIfExists() {
+unitTest({ permissions: { write: true } }, async function mkdirErrIfExists() {
   await assertRejects(async () => {
     await Deno.mkdir(".");
   }, Deno.errors.AlreadyExists);
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function mkdirSyncRecursive() {
     const path = Deno.makeTempDirSync() + "/nested/directory";
     Deno.mkdirSync(path, { recursive: true });
@@ -80,7 +80,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function mkdirRecursive() {
     const path = Deno.makeTempDirSync() + "/nested/directory";
     await Deno.mkdir(path, { recursive: true });
@@ -89,7 +89,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function mkdirSyncRecursiveMode() {
     const nested = Deno.makeTempDirSync() + "/nested";
     const path = nested + "/dir";
@@ -100,7 +100,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function mkdirRecursiveMode() {
     const nested = Deno.makeTempDirSync() + "/nested";
     const path = nested + "/dir";
@@ -111,7 +111,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function mkdirSyncRecursiveIfExists() {
     const path = Deno.makeTempDirSync() + "/dir";
     Deno.mkdirSync(path, { mode: 0o737 });
@@ -129,7 +129,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function mkdirRecursiveIfExists() {
     const path = Deno.makeTempDirSync() + "/dir";
     await Deno.mkdir(path, { mode: 0o737 });
@@ -147,7 +147,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function mkdirSyncErrors() {
     const testDir = Deno.makeTempDirSync();
     const emptydir = testDir + "/empty";
@@ -198,7 +198,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function mkdirSyncRelativeUrlPath() {
     const testDir = Deno.makeTempDirSync();
     const nestedDir = testDir + "/nested";
@@ -213,7 +213,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function mkdirRelativeUrlPath() {
     const testDir = Deno.makeTempDirSync();
     const nestedDir = testDir + "/nested";

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -17,7 +17,7 @@ try {
   isCI = true;
 }
 
-unitTest({ perms: { net: true } }, function netTcpListenClose() {
+unitTest({ permissions: { net: true } }, function netTcpListenClose() {
   const listener = Deno.listen({ hostname: "127.0.0.1", port: 3500 });
   assert(listener.addr.transport === "tcp");
   assertEquals(listener.addr.hostname, "127.0.0.1");
@@ -28,7 +28,7 @@ unitTest({ perms: { net: true } }, function netTcpListenClose() {
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   function netUdpListenClose() {
     const socket = Deno.listenDatagram({
@@ -44,7 +44,10 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   function netUnixListenClose() {
     const filePath = Deno.makeTempFileSync();
     const socket = Deno.listen({
@@ -58,7 +61,10 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   function netUnixPacketListenClose() {
     const filePath = Deno.makeTempFileSync();
     const socket = Deno.listenDatagram({
@@ -72,7 +78,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true } },
+  { ignore: Deno.build.os === "windows", permissions: { read: true } },
   function netUnixListenWritePermission() {
     assertThrows(() => {
       const filePath = Deno.makeTempFileSync();
@@ -88,7 +94,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true } },
+  { ignore: Deno.build.os === "windows", permissions: { read: true } },
   function netUnixPacketListenWritePermission() {
     assertThrows(() => {
       const filePath = Deno.makeTempFileSync();
@@ -105,7 +111,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function netTcpCloseWhileAccept() {
     const listener = Deno.listen({ port: 4501 });
@@ -122,7 +128,10 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   async function netUnixCloseWhileAccept() {
     const filePath = await Deno.makeTempFile();
     const listener = Deno.listen({
@@ -142,7 +151,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function netTcpConcurrentAccept() {
     const listener = Deno.listen({ port: 4502 });
     let acceptErrCount = 0;
@@ -166,7 +175,7 @@ unitTest(
 
 // TODO(jsouto): Enable when tokio updates mio to v0.7!
 unitTest(
-  { ignore: true, perms: { read: true, write: true } },
+  { ignore: true, permissions: { read: true, write: true } },
   async function netUnixConcurrentAccept() {
     const filePath = await Deno.makeTempFile();
     const listener = Deno.listen({ transport: "unix", path: filePath });
@@ -189,7 +198,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, async function netTcpDialListen() {
+unitTest({ permissions: { net: true } }, async function netTcpDialListen() {
   const listener = Deno.listen({ port: 3500 });
   listener.accept().then(
     async (conn) => {
@@ -225,7 +234,10 @@ unitTest({ perms: { net: true } }, async function netTcpDialListen() {
 });
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   async function netUnixDialListen() {
     const filePath = await Deno.makeTempFile();
     const listener = Deno.listen({ path: filePath, transport: "unix" });
@@ -261,7 +273,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function netUdpSendReceive() {
     const alice = Deno.listenDatagram({ port: 3500, transport: "udp" });
     assert(alice.addr.transport === "udp");
@@ -291,7 +303,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function netUdpConcurrentSendReceive() {
     const socket = Deno.listenDatagram({ port: 3500, transport: "udp" });
     assert(socket.addr.transport === "udp");
@@ -315,7 +327,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function netUdpBorrowMutError() {
     const socket = Deno.listenDatagram({
       port: 4501,
@@ -330,7 +342,10 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   async function netUnixPacketSendReceive() {
     const filePath = await Deno.makeTempFile();
     const alice = Deno.listenDatagram({
@@ -365,7 +380,7 @@ unitTest(
 
 // TODO(piscisaureus): Enable after Tokio v0.3/v1.0 upgrade.
 unitTest(
-  { ignore: true, perms: { read: true, write: true } },
+  { ignore: true, permissions: { read: true, write: true } },
   async function netUnixPacketConcurrentSendReceive() {
     const filePath = await Deno.makeTempFile();
     const socket = Deno.listenDatagram({
@@ -392,7 +407,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function netTcpListenIteratorBreakClosesResource() {
     async function iterate(listener: Deno.Listener) {
       let i = 0;
@@ -422,7 +437,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function netTcpListenCloseWhileIterating() {
     const listener = Deno.listen({ port: 8001 });
     const nextWhileClosing = listener[Symbol.asyncIterator]().next();
@@ -435,7 +450,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function netUdpListenCloseWhileIterating() {
     const socket = Deno.listenDatagram({ port: 8000, transport: "udp" });
     const nextWhileClosing = socket[Symbol.asyncIterator]().next();
@@ -448,7 +463,10 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   async function netUnixListenCloseWhileIterating() {
     const filePath = Deno.makeTempFileSync();
     const socket = Deno.listen({ path: filePath, transport: "unix" });
@@ -462,7 +480,10 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   async function netUnixPacketListenCloseWhileIterating() {
     const filePath = Deno.makeTempFileSync();
     const socket = Deno.listenDatagram({
@@ -482,7 +503,7 @@ unitTest(
   {
     // FIXME(bartlomieju)
     ignore: true,
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function netListenAsyncIterator() {
     const addr = { hostname: "127.0.0.1", port: 3500 };
@@ -515,7 +536,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function netCloseWriteSuccess() {
     const addr = { hostname: "127.0.0.1", port: 3500 };
@@ -550,7 +571,7 @@ unitTest(
   {
     // https://github.com/denoland/deno/issues/11580
     ignore: Deno.build.os === "darwin" && isCI,
-    perms: { net: true },
+    permissions: { net: true },
   },
   async function netHangsOnClose() {
     let acceptedConn: Deno.Conn;
@@ -596,7 +617,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { net: true },
+    permissions: { net: true },
   },
   function netExplicitUndefinedHostname() {
     const listener = Deno.listen({ hostname: undefined, port: 8080 });

--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -7,7 +7,7 @@ import {
   unitTest,
 } from "./test_util.ts";
 
-unitTest({ perms: { env: true } }, function envSuccess() {
+unitTest({ permissions: { env: true } }, function envSuccess() {
   Deno.env.set("TEST_VAR", "A");
   const env = Deno.env.toObject();
   Deno.env.set("TEST_VAR", "B");
@@ -15,19 +15,19 @@ unitTest({ perms: { env: true } }, function envSuccess() {
   assertNotEquals(Deno.env.get("TEST_VAR"), env["TEST_VAR"]);
 });
 
-unitTest({ perms: { env: true } }, function envNotFound() {
+unitTest({ permissions: { env: true } }, function envNotFound() {
   const r = Deno.env.get("env_var_does_not_exist!");
   assertEquals(r, undefined);
 });
 
-unitTest({ perms: { env: true } }, function deleteEnv() {
+unitTest({ permissions: { env: true } }, function deleteEnv() {
   Deno.env.set("TEST_VAR", "A");
   assertEquals(Deno.env.get("TEST_VAR"), "A");
   assertEquals(Deno.env.delete("TEST_VAR"), undefined);
   assertEquals(Deno.env.get("TEST_VAR"), undefined);
 });
 
-unitTest({ perms: { env: true } }, function avoidEmptyNamedEnv() {
+unitTest({ permissions: { env: true } }, function avoidEmptyNamedEnv() {
   assertThrows(() => Deno.env.set("", "v"), TypeError);
   assertThrows(() => Deno.env.set("a=a", "v"), TypeError);
   assertThrows(() => Deno.env.set("a\0a", "v"), TypeError);
@@ -60,7 +60,7 @@ unitTest(function envPermissionDenied2() {
 unitTest(
   {
     ignore: Deno.build.os !== "windows",
-    perms: { read: true, env: true, run: true },
+    permissions: { read: true, env: true, run: true },
   },
   async function envCaseInsensitive() {
     // Utility function that runs a Deno subprocess with the environment
@@ -131,7 +131,7 @@ unitTest(function osPpid() {
 });
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function osPpidIsEqualToPidOfParentProcess() {
     const decoder = new TextDecoder();
     const process = Deno.run({
@@ -148,11 +148,11 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: true } }, function execPath() {
+unitTest({ permissions: { read: true } }, function execPath() {
   assertNotEquals(Deno.execPath(), "");
 });
 
-unitTest({ perms: { read: false } }, function execPathPerm() {
+unitTest({ permissions: { read: false } }, function execPathPerm() {
   assertThrows(
     () => {
       Deno.execPath();
@@ -162,38 +162,38 @@ unitTest({ perms: { read: false } }, function execPathPerm() {
   );
 });
 
-unitTest({ perms: { env: true } }, function loadavgSuccess() {
+unitTest({ permissions: { env: true } }, function loadavgSuccess() {
   const load = Deno.loadavg();
   assertEquals(load.length, 3);
 });
 
-unitTest({ perms: { env: false } }, function loadavgPerm() {
+unitTest({ permissions: { env: false } }, function loadavgPerm() {
   assertThrows(() => {
     Deno.loadavg();
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { env: true } }, function hostnameDir() {
+unitTest({ permissions: { env: true } }, function hostnameDir() {
   assertNotEquals(Deno.hostname(), "");
 });
 
-unitTest({ perms: { env: false } }, function hostnamePerm() {
+unitTest({ permissions: { env: false } }, function hostnamePerm() {
   assertThrows(() => {
     Deno.hostname();
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { env: true } }, function releaseDir() {
+unitTest({ permissions: { env: true } }, function releaseDir() {
   assertNotEquals(Deno.osRelease(), "");
 });
 
-unitTest({ perms: { env: false } }, function releasePerm() {
+unitTest({ permissions: { env: false } }, function releasePerm() {
   assertThrows(() => {
     Deno.osRelease();
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { env: true } }, function systemMemoryInfo() {
+unitTest({ permissions: { env: true } }, function systemMemoryInfo() {
   const info = Deno.systemMemoryInfo();
   assert(info.total >= 0);
   assert(info.free >= 0);

--- a/cli/tests/unit/performance_test.ts
+++ b/cli/tests/unit/performance_test.ts
@@ -8,7 +8,7 @@ import {
   unitTest,
 } from "./test_util.ts";
 
-unitTest({ perms: { hrtime: false } }, async function performanceNow() {
+unitTest({ permissions: { hrtime: false } }, async function performanceNow() {
   const resolvable = deferred();
   const start = performance.now();
   let totalTime = 0;

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -7,14 +7,14 @@ import {
   unitTest,
 } from "./test_util.ts";
 
-unitTest({ perms: { read: true } }, function runPermissions() {
+unitTest({ permissions: { read: true } }, function runPermissions() {
   assertThrows(() => {
     Deno.run({ cmd: [Deno.execPath(), "eval", "console.log('hello world')"] });
   }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runSuccess() {
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", "console.log('hello world')"],
@@ -31,7 +31,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runUrl() {
     const p = Deno.run({
       cmd: [
@@ -52,7 +52,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runStdinRid0(): Promise<
     void
   > {
@@ -72,7 +72,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   function runInvalidStdio() {
     assertThrows(() =>
       Deno.run({
@@ -99,7 +99,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runCommandFailedWithCode() {
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", "Deno.exit(41 + 1)"],
@@ -116,7 +116,7 @@ unitTest(
   {
     // No signals on windows.
     ignore: Deno.build.os === "windows",
-    perms: { run: true, read: true },
+    permissions: { run: true, read: true },
   },
   async function runCommandFailedWithSignal() {
     const p = Deno.run({
@@ -135,7 +135,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { run: true } }, function runNotFound() {
+unitTest({ permissions: { run: true } }, function runNotFound() {
   let error;
   try {
     Deno.run({ cmd: ["this file hopefully doesn't exist"] });
@@ -147,7 +147,7 @@ unitTest({ perms: { run: true } }, function runNotFound() {
 });
 
 unitTest(
-  { perms: { write: true, run: true, read: true } },
+  { permissions: { write: true, run: true, read: true } },
   async function runWithCwdIsAsync() {
     const enc = new TextEncoder();
     const cwd = await Deno.makeTempDir({ prefix: "deno_command_test" });
@@ -188,7 +188,7 @@ tryExit();
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runStdinPiped(): Promise<
     void
   > {
@@ -219,7 +219,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runStdoutPiped(): Promise<
     void
   > {
@@ -255,7 +255,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runStderrPiped(): Promise<
     void
   > {
@@ -291,7 +291,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runOutput() {
     const p = Deno.run({
       cmd: [
@@ -309,7 +309,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runStderrOutput(): Promise<
     void
   > {
@@ -329,7 +329,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, write: true, read: true } },
+  { permissions: { run: true, write: true, read: true } },
   async function runRedirectStdoutStderr() {
     const tempDir = await Deno.makeTempDir();
     const fileName = tempDir + "/redirected_stdio.txt";
@@ -362,7 +362,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, write: true, read: true } },
+  { permissions: { run: true, write: true, read: true } },
   async function runRedirectStdin() {
     const tempDir = await Deno.makeTempDir();
     const fileName = tempDir + "/redirected_stdio.txt";
@@ -387,7 +387,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runEnv() {
     const p = Deno.run({
       cmd: [
@@ -409,7 +409,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runClose() {
     const p = Deno.run({
       cmd: [
@@ -432,7 +432,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function runKillAfterStatus() {
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", 'console.log("hello")'],
@@ -468,7 +468,7 @@ unitTest(function killPermissions() {
 });
 
 unitTest(
-  { perms: { run: true, read: true } },
+  { permissions: { run: true, read: true } },
   async function killSuccess() {
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", "setTimeout(() => {}, 10000)"],
@@ -494,7 +494,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { run: true, read: true } }, function killFailed() {
+unitTest({ permissions: { run: true, read: true } }, function killFailed() {
   const p = Deno.run({
     cmd: [Deno.execPath(), "eval", "setTimeout(() => {}, 10000)"],
   });
@@ -511,7 +511,7 @@ unitTest({ perms: { run: true, read: true } }, function killFailed() {
 });
 
 unitTest(
-  { perms: { run: true, read: true, env: true } },
+  { permissions: { run: true, read: true, env: true } },
   async function clearEnv(): Promise<void> {
     const p = Deno.run({
       cmd: [
@@ -539,7 +539,10 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true }, ignore: Deno.build.os === "windows" },
+  {
+    permissions: { run: true, read: true },
+    ignore: Deno.build.os === "windows",
+  },
   async function uid(): Promise<void> {
     const p = Deno.run({
       cmd: [
@@ -567,7 +570,10 @@ unitTest(
 );
 
 unitTest(
-  { perms: { run: true, read: true }, ignore: Deno.build.os === "windows" },
+  {
+    permissions: { run: true, read: true },
+    ignore: Deno.build.os === "windows",
+  },
   async function gid(): Promise<void> {
     const p = Deno.run({
       cmd: [

--- a/cli/tests/unit/read_dir_test.ts
+++ b/cli/tests/unit/read_dir_test.ts
@@ -21,37 +21,37 @@ function assertSameContent(files: Deno.DirEntry[]) {
   assertEquals(counter, 1);
 }
 
-unitTest({ perms: { read: true } }, function readDirSyncSuccess() {
+unitTest({ permissions: { read: true } }, function readDirSyncSuccess() {
   const files = [...Deno.readDirSync("cli/tests/testdata")];
   assertSameContent(files);
 });
 
-unitTest({ perms: { read: true } }, function readDirSyncWithUrl() {
+unitTest({ permissions: { read: true } }, function readDirSyncWithUrl() {
   const files = [
     ...Deno.readDirSync(pathToAbsoluteFileUrl("cli/tests/testdata")),
   ];
   assertSameContent(files);
 });
 
-unitTest({ perms: { read: false } }, function readDirSyncPerm() {
+unitTest({ permissions: { read: false } }, function readDirSyncPerm() {
   assertThrows(() => {
     Deno.readDirSync("tests/");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, function readDirSyncNotDir() {
+unitTest({ permissions: { read: true } }, function readDirSyncNotDir() {
   assertThrows(() => {
     Deno.readDirSync("cli/tests/testdata/fixture.json");
   }, Error);
 });
 
-unitTest({ perms: { read: true } }, function readDirSyncNotFound() {
+unitTest({ permissions: { read: true } }, function readDirSyncNotFound() {
   assertThrows(() => {
     Deno.readDirSync("bad_dir_name");
   }, Deno.errors.NotFound);
 });
 
-unitTest({ perms: { read: true } }, async function readDirSuccess() {
+unitTest({ permissions: { read: true } }, async function readDirSuccess() {
   const files = [];
   for await (const dirEntry of Deno.readDir("cli/tests/testdata")) {
     files.push(dirEntry);
@@ -59,7 +59,7 @@ unitTest({ perms: { read: true } }, async function readDirSuccess() {
   assertSameContent(files);
 });
 
-unitTest({ perms: { read: true } }, async function readDirWithUrl() {
+unitTest({ permissions: { read: true } }, async function readDirWithUrl() {
   const files = [];
   for await (
     const dirEntry of Deno.readDir(pathToAbsoluteFileUrl("cli/tests/testdata"))
@@ -69,14 +69,14 @@ unitTest({ perms: { read: true } }, async function readDirWithUrl() {
   assertSameContent(files);
 });
 
-unitTest({ perms: { read: false } }, async function readDirPerm() {
+unitTest({ permissions: { read: false } }, async function readDirPerm() {
   await assertRejects(async () => {
     await Deno.readDir("tests/")[Symbol.asyncIterator]().next();
   }, Deno.errors.PermissionDenied);
 });
 
 unitTest(
-  { perms: { read: true }, ignore: Deno.build.os == "windows" },
+  { permissions: { read: true }, ignore: Deno.build.os == "windows" },
   async function readDirDevFd(): Promise<
     void
   > {
@@ -87,7 +87,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true }, ignore: Deno.build.os == "windows" },
+  { permissions: { read: true }, ignore: Deno.build.os == "windows" },
   function readDirDevFdSync() {
     for (const _ of Deno.readDirSync("/dev/fd")) {
       // We don't actually care whats in here; just that we don't panic on non regular file entries

--- a/cli/tests/unit/read_file_test.ts
+++ b/cli/tests/unit/read_file_test.ts
@@ -8,7 +8,7 @@ import {
   unitTest,
 } from "./test_util.ts";
 
-unitTest({ perms: { read: true } }, function readFileSyncSuccess() {
+unitTest({ permissions: { read: true } }, function readFileSyncSuccess() {
   const data = Deno.readFileSync("cli/tests/testdata/fixture.json");
   assert(data.byteLength > 0);
   const decoder = new TextDecoder("utf-8");
@@ -17,7 +17,7 @@ unitTest({ perms: { read: true } }, function readFileSyncSuccess() {
   assertEquals(pkg.name, "deno");
 });
 
-unitTest({ perms: { read: true } }, function readFileSyncUrl() {
+unitTest({ permissions: { read: true } }, function readFileSyncUrl() {
   const data = Deno.readFileSync(
     pathToAbsoluteFileUrl("cli/tests/testdata/fixture.json"),
   );
@@ -28,19 +28,19 @@ unitTest({ perms: { read: true } }, function readFileSyncUrl() {
   assertEquals(pkg.name, "deno");
 });
 
-unitTest({ perms: { read: false } }, function readFileSyncPerm() {
+unitTest({ permissions: { read: false } }, function readFileSyncPerm() {
   assertThrows(() => {
     Deno.readFileSync("cli/tests/testdata/fixture.json");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, function readFileSyncNotFound() {
+unitTest({ permissions: { read: true } }, function readFileSyncNotFound() {
   assertThrows(() => {
     Deno.readFileSync("bad_filename");
   }, Deno.errors.NotFound);
 });
 
-unitTest({ perms: { read: true } }, async function readFileUrl() {
+unitTest({ permissions: { read: true } }, async function readFileUrl() {
   const data = await Deno.readFile(
     pathToAbsoluteFileUrl("cli/tests/testdata/fixture.json"),
   );
@@ -51,7 +51,7 @@ unitTest({ perms: { read: true } }, async function readFileUrl() {
   assertEquals(pkg.name, "deno");
 });
 
-unitTest({ perms: { read: true } }, async function readFileSuccess() {
+unitTest({ permissions: { read: true } }, async function readFileSuccess() {
   const data = await Deno.readFile("cli/tests/testdata/fixture.json");
   assert(data.byteLength > 0);
   const decoder = new TextDecoder("utf-8");
@@ -60,20 +60,20 @@ unitTest({ perms: { read: true } }, async function readFileSuccess() {
   assertEquals(pkg.name, "deno");
 });
 
-unitTest({ perms: { read: false } }, async function readFilePerm() {
+unitTest({ permissions: { read: false } }, async function readFilePerm() {
   await assertRejects(async () => {
     await Deno.readFile("cli/tests/testdata/fixture.json");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, function readFileSyncLoop() {
+unitTest({ permissions: { read: true } }, function readFileSyncLoop() {
   for (let i = 0; i < 256; i++) {
     Deno.readFileSync("cli/tests/testdata/fixture.json");
   }
 });
 
 unitTest(
-  { perms: { read: true } },
+  { permissions: { read: true } },
   async function readFileDoesNotLeakResources() {
     const resourcesBefore = Deno.resources();
     await assertRejects(async () => await Deno.readFile("cli"));
@@ -82,7 +82,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true } },
+  { permissions: { read: true } },
   function readFileSyncDoesNotLeakResources() {
     const resourcesBefore = Deno.resources();
     assertThrows(() => Deno.readFileSync("cli"));
@@ -91,7 +91,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true } },
+  { permissions: { read: true } },
   async function readFileWithAbortSignal() {
     const ac = new AbortController();
     queueMicrotask(() => ac.abort());
@@ -104,7 +104,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true } },
+  { permissions: { read: true } },
   async function readTextileWithAbortSignal() {
     const ac = new AbortController();
     queueMicrotask(() => ac.abort());

--- a/cli/tests/unit/read_link_test.ts
+++ b/cli/tests/unit/read_link_test.ts
@@ -8,7 +8,7 @@ import {
 } from "./test_util.ts";
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   function readLinkSyncSuccess() {
     const testDir = Deno.makeTempDirSync();
     const target = testDir +
@@ -23,7 +23,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   function readLinkSyncUrlSuccess() {
     const testDir = Deno.makeTempDirSync();
     const target = testDir +
@@ -37,20 +37,20 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: false } }, function readLinkSyncPerm() {
+unitTest({ permissions: { read: false } }, function readLinkSyncPerm() {
   assertThrows(() => {
     Deno.readLinkSync("/symlink");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, function readLinkSyncNotFound() {
+unitTest({ permissions: { read: true } }, function readLinkSyncNotFound() {
   assertThrows(() => {
     Deno.readLinkSync("bad_filename");
   }, Deno.errors.NotFound);
 });
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   async function readLinkSuccess() {
     const testDir = Deno.makeTempDirSync();
     const target = testDir +
@@ -65,7 +65,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   async function readLinkUrlSuccess() {
     const testDir = Deno.makeTempDirSync();
     const target = testDir +
@@ -79,7 +79,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: false } }, async function readLinkPerm() {
+unitTest({ permissions: { read: false } }, async function readLinkPerm() {
   await assertRejects(async () => {
     await Deno.readLink("/symlink");
   }, Deno.errors.PermissionDenied);

--- a/cli/tests/unit/read_text_file_test.ts
+++ b/cli/tests/unit/read_text_file_test.ts
@@ -7,14 +7,14 @@ import {
   unitTest,
 } from "./test_util.ts";
 
-unitTest({ perms: { read: true } }, function readTextFileSyncSuccess() {
+unitTest({ permissions: { read: true } }, function readTextFileSyncSuccess() {
   const data = Deno.readTextFileSync("cli/tests/testdata/fixture.json");
   assert(data.length > 0);
   const pkg = JSON.parse(data);
   assertEquals(pkg.name, "deno");
 });
 
-unitTest({ perms: { read: true } }, function readTextFileSyncByUrl() {
+unitTest({ permissions: { read: true } }, function readTextFileSyncByUrl() {
   const data = Deno.readTextFileSync(
     pathToAbsoluteFileUrl("cli/tests/testdata/fixture.json"),
   );
@@ -23,20 +23,20 @@ unitTest({ perms: { read: true } }, function readTextFileSyncByUrl() {
   assertEquals(pkg.name, "deno");
 });
 
-unitTest({ perms: { read: false } }, function readTextFileSyncPerm() {
+unitTest({ permissions: { read: false } }, function readTextFileSyncPerm() {
   assertThrows(() => {
     Deno.readTextFileSync("cli/tests/testdata/fixture.json");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, function readTextFileSyncNotFound() {
+unitTest({ permissions: { read: true } }, function readTextFileSyncNotFound() {
   assertThrows(() => {
     Deno.readTextFileSync("bad_filename");
   }, Deno.errors.NotFound);
 });
 
 unitTest(
-  { perms: { read: true } },
+  { permissions: { read: true } },
   async function readTextFileSuccess() {
     const data = await Deno.readTextFile("cli/tests/testdata/fixture.json");
     assert(data.length > 0);
@@ -45,7 +45,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: true } }, async function readTextFileByUrl() {
+unitTest({ permissions: { read: true } }, async function readTextFileByUrl() {
   const data = await Deno.readTextFile(
     pathToAbsoluteFileUrl("cli/tests/testdata/fixture.json"),
   );
@@ -54,20 +54,20 @@ unitTest({ perms: { read: true } }, async function readTextFileByUrl() {
   assertEquals(pkg.name, "deno");
 });
 
-unitTest({ perms: { read: false } }, async function readTextFilePerm() {
+unitTest({ permissions: { read: false } }, async function readTextFilePerm() {
   await assertRejects(async () => {
     await Deno.readTextFile("cli/tests/testdata/fixture.json");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, function readTextFileSyncLoop() {
+unitTest({ permissions: { read: true } }, function readTextFileSyncLoop() {
   for (let i = 0; i < 256; i++) {
     Deno.readTextFileSync("cli/tests/testdata/fixture.json");
   }
 });
 
 unitTest(
-  { perms: { read: true } },
+  { permissions: { read: true } },
   async function readTextFileDoesNotLeakResources() {
     const resourcesBefore = Deno.resources();
     await assertRejects(async () => await Deno.readTextFile("cli"));
@@ -76,7 +76,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true } },
+  { permissions: { read: true } },
   function readTextFileSyncDoesNotLeakResources() {
     const resourcesBefore = Deno.resources();
     assertThrows(() => Deno.readTextFileSync("cli"));

--- a/cli/tests/unit/real_path_test.ts
+++ b/cli/tests/unit/real_path_test.ts
@@ -9,7 +9,7 @@ import {
   unitTest,
 } from "./test_util.ts";
 
-unitTest({ perms: { read: true } }, function realPathSyncSuccess() {
+unitTest({ permissions: { read: true } }, function realPathSyncSuccess() {
   const relative = "cli/tests/testdata/fixture.json";
   const realPath = Deno.realPathSync(relative);
   if (Deno.build.os !== "windows") {
@@ -21,7 +21,7 @@ unitTest({ perms: { read: true } }, function realPathSyncSuccess() {
   }
 });
 
-unitTest({ perms: { read: true } }, function realPathSyncUrl() {
+unitTest({ permissions: { read: true } }, function realPathSyncUrl() {
   const relative = "cli/tests/testdata/fixture.json";
   const url = pathToAbsoluteFileUrl(relative);
   assertEquals(Deno.realPathSync(relative), Deno.realPathSync(url));
@@ -29,7 +29,7 @@ unitTest({ perms: { read: true } }, function realPathSyncUrl() {
 
 unitTest(
   {
-    perms: { read: true, write: true },
+    permissions: { read: true, write: true },
   },
   function realPathSyncSymlink() {
     const testDir = Deno.makeTempDirSync();
@@ -48,19 +48,19 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: false } }, function realPathSyncPerm() {
+unitTest({ permissions: { read: false } }, function realPathSyncPerm() {
   assertThrows(() => {
     Deno.realPathSync("some_file");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, function realPathSyncNotFound() {
+unitTest({ permissions: { read: true } }, function realPathSyncNotFound() {
   assertThrows(() => {
     Deno.realPathSync("bad_filename");
   }, Deno.errors.NotFound);
 });
 
-unitTest({ perms: { read: true } }, async function realPathSuccess() {
+unitTest({ permissions: { read: true } }, async function realPathSuccess() {
   const relativePath = "cli/tests/testdata/fixture.json";
   const realPath = await Deno.realPath(relativePath);
   if (Deno.build.os !== "windows") {
@@ -73,7 +73,7 @@ unitTest({ perms: { read: true } }, async function realPathSuccess() {
 });
 
 unitTest(
-  { perms: { read: true } },
+  { permissions: { read: true } },
   async function realPathUrl() {
     const relative = "cli/tests/testdata/fixture.json";
     const url = pathToAbsoluteFileUrl(relative);
@@ -83,7 +83,7 @@ unitTest(
 
 unitTest(
   {
-    perms: { read: true, write: true },
+    permissions: { read: true, write: true },
   },
   async function realPathSymlink() {
     const testDir = Deno.makeTempDirSync();
@@ -102,13 +102,13 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: false } }, async function realPathPerm() {
+unitTest({ permissions: { read: false } }, async function realPathPerm() {
   await assertRejects(async () => {
     await Deno.realPath("some_file");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, async function realPathNotFound() {
+unitTest({ permissions: { read: true } }, async function realPathNotFound() {
   await assertRejects(async () => {
     await Deno.realPath("bad_filename");
   }, Deno.errors.NotFound);

--- a/cli/tests/unit/remove_test.ts
+++ b/cli/tests/unit/remove_test.ts
@@ -4,7 +4,7 @@ import { assert, assertRejects, assertThrows, unitTest } from "./test_util.ts";
 const REMOVE_METHODS = ["remove", "removeSync"] as const;
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   async function removeDirSuccess() {
     for (const method of REMOVE_METHODS) {
       // REMOVE EMPTY DIRECTORY
@@ -22,7 +22,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   async function removeFileSuccess() {
     for (const method of REMOVE_METHODS) {
       // REMOVE FILE
@@ -42,7 +42,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   async function removeFileByUrl() {
     for (const method of REMOVE_METHODS) {
       // REMOVE FILE
@@ -67,7 +67,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   async function removeFail() {
     for (const method of REMOVE_METHODS) {
       // NON-EMPTY DIRECTORY
@@ -94,7 +94,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   async function removeDanglingSymlinkSuccess() {
     for (const method of REMOVE_METHODS) {
       const danglingSymlinkPath = Deno.makeTempDirSync() + "/dangling_symlink";
@@ -116,7 +116,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   async function removeValidSymlinkSuccess() {
     for (const method of REMOVE_METHODS) {
       const encoder = new TextEncoder();
@@ -141,7 +141,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { write: false } }, async function removePerm() {
+unitTest({ permissions: { write: false } }, async function removePerm() {
   for (const method of REMOVE_METHODS) {
     await assertRejects(async () => {
       await Deno[method]("/baddir");
@@ -150,7 +150,7 @@ unitTest({ perms: { write: false } }, async function removePerm() {
 });
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   async function removeAllDirSuccess() {
     for (const method of REMOVE_METHODS) {
       // REMOVE EMPTY DIRECTORY
@@ -187,7 +187,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: true, read: true } },
+  { permissions: { write: true, read: true } },
   async function removeAllFileSuccess() {
     for (const method of REMOVE_METHODS) {
       // REMOVE FILE
@@ -207,7 +207,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { write: true } }, async function removeAllFail() {
+unitTest({ permissions: { write: true } }, async function removeAllFail() {
   for (const method of REMOVE_METHODS) {
     // NON-EXISTENT DIRECTORY/FILE
     await assertRejects(async () => {
@@ -217,7 +217,7 @@ unitTest({ perms: { write: true } }, async function removeAllFail() {
   }
 });
 
-unitTest({ perms: { write: false } }, async function removeAllPerm() {
+unitTest({ permissions: { write: false } }, async function removeAllPerm() {
   for (const method of REMOVE_METHODS) {
     await assertRejects(async () => {
       await Deno[method]("/baddir", { recursive: true });
@@ -228,7 +228,7 @@ unitTest({ perms: { write: false } }, async function removeAllPerm() {
 unitTest(
   {
     ignore: Deno.build.os === "windows",
-    perms: { write: true, read: true },
+    permissions: { write: true, read: true },
   },
   async function removeUnixSocketSuccess() {
     for (const method of REMOVE_METHODS) {
@@ -248,7 +248,7 @@ unitTest(
 
 if (Deno.build.os === "windows") {
   unitTest(
-    { perms: { run: true, write: true, read: true } },
+    { permissions: { run: true, write: true, read: true } },
     async function removeFileSymlink() {
       const symlink = Deno.run({
         cmd: ["cmd", "/c", "mklink", "file_link", "bar"],
@@ -265,7 +265,7 @@ if (Deno.build.os === "windows") {
   );
 
   unitTest(
-    { perms: { run: true, write: true, read: true } },
+    { permissions: { run: true, write: true, read: true } },
     async function removeDirSymlink() {
       const symlink = Deno.run({
         cmd: ["cmd", "/c", "mklink", "/d", "dir_link", "bar"],

--- a/cli/tests/unit/rename_test.ts
+++ b/cli/tests/unit/rename_test.ts
@@ -34,7 +34,7 @@ function assertDirectory(path: string, mode?: number) {
 }
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function renameSyncSuccess() {
     const testDir = Deno.makeTempDirSync();
     const oldpath = testDir + "/oldpath";
@@ -47,7 +47,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function renameSyncWithURL() {
     const testDir = Deno.makeTempDirSync();
     const oldpath = testDir + "/oldpath";
@@ -63,7 +63,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: false, write: true } },
+  { permissions: { read: false, write: true } },
   function renameSyncReadPerm() {
     assertThrows(() => {
       const oldpath = "/oldbaddir";
@@ -74,7 +74,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: false } },
+  { permissions: { read: true, write: false } },
   function renameSyncWritePerm() {
     assertThrows(() => {
       const oldpath = "/oldbaddir";
@@ -85,7 +85,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function renameSuccess() {
     const testDir = Deno.makeTempDirSync();
     const oldpath = testDir + "/oldpath";
@@ -98,7 +98,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function renameWithURL() {
     const testDir = Deno.makeTempDirSync();
     const oldpath = testDir + "/oldpath";
@@ -126,7 +126,10 @@ function writeFileString(filename: string, s: string) {
 }
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   function renameSyncErrorsUnix() {
     const testDir = Deno.makeTempDirSync();
     const oldfile = testDir + "/oldfile";
@@ -201,7 +204,10 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os !== "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os !== "windows",
+    permissions: { read: true, write: true },
+  },
   function renameSyncErrorsWin() {
     const testDir = Deno.makeTempDirSync();
     const oldfile = testDir + "/oldfile";

--- a/cli/tests/unit/resources_test.ts
+++ b/cli/tests/unit/resources_test.ts
@@ -15,7 +15,7 @@ unitTest(function resourcesStdio() {
   assertEquals(res[2], "stderr");
 });
 
-unitTest({ perms: { net: true } }, async function resourcesNet() {
+unitTest({ permissions: { net: true } }, async function resourcesNet() {
   const listener = Deno.listen({ port: 4501 });
   const dialerConn = await Deno.connect({ port: 4501 });
   const listenerConn = await listener.accept();
@@ -35,7 +35,7 @@ unitTest({ perms: { net: true } }, async function resourcesNet() {
   listener.close();
 });
 
-unitTest({ perms: { read: true } }, async function resourcesFile() {
+unitTest({ permissions: { read: true } }, async function resourcesFile() {
   const resourcesBefore = Deno.resources();
   const f = await Deno.open("cli/tests/testdata/hello.txt");
   const resourcesAfter = Deno.resources();

--- a/cli/tests/unit/signal_test.ts
+++ b/cli/tests/unit/signal_test.ts
@@ -99,7 +99,10 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { run: true, net: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { run: true, net: true },
+  },
   async function signalStreamTest() {
     const resolvable = deferred();
     // This prevents the program from exiting.
@@ -131,7 +134,10 @@ unitTest(
 
 // This tests that pending op_signal_poll doesn't block the runtime from exiting the process.
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { run: true, read: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { run: true, read: true },
+  },
   async function signalStreamExitTest() {
     const p = Deno.run({
       cmd: [
@@ -148,7 +154,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { run: true } },
+  { ignore: Deno.build.os === "windows", permissions: { run: true } },
   async function signalPromiseTest() {
     const resolvable = deferred();
     // This prevents the program from exiting.
@@ -169,7 +175,7 @@ unitTest(
 
 // https://github.com/denoland/deno/issues/9806
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { run: true } },
+  { ignore: Deno.build.os === "windows", permissions: { run: true } },
   async function signalPromiseTest2() {
     const resolvable = deferred();
     // This prevents the program from exiting.
@@ -197,7 +203,7 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { run: true } },
+  { ignore: Deno.build.os === "windows", permissions: { run: true } },
   function signalShorthandsTest() {
     let s: Deno.SignalStream;
     s = Deno.signal("SIGALRM");

--- a/cli/tests/unit/stat_test.ts
+++ b/cli/tests/unit/stat_test.ts
@@ -8,7 +8,7 @@ import {
   unitTest,
 } from "./test_util.ts";
 
-unitTest({ perms: { read: true } }, function fstatSyncSuccess() {
+unitTest({ permissions: { read: true } }, function fstatSyncSuccess() {
   const file = Deno.openSync("README.md");
   const fileInfo = Deno.fstatSync(file.rid);
   assert(fileInfo.isFile);
@@ -23,7 +23,7 @@ unitTest({ perms: { read: true } }, function fstatSyncSuccess() {
   Deno.close(file.rid);
 });
 
-unitTest({ perms: { read: true } }, async function fstatSuccess() {
+unitTest({ permissions: { read: true } }, async function fstatSuccess() {
   const file = await Deno.open("README.md");
   const fileInfo = await Deno.fstat(file.rid);
   assert(fileInfo.isFile);
@@ -39,7 +39,7 @@ unitTest({ perms: { read: true } }, async function fstatSuccess() {
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function statSyncSuccess() {
     const readmeInfo = Deno.statSync("README.md");
     assert(readmeInfo.isFile);
@@ -101,19 +101,19 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: false } }, function statSyncPerm() {
+unitTest({ permissions: { read: false } }, function statSyncPerm() {
   assertThrows(() => {
     Deno.statSync("README.md");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, function statSyncNotFound() {
+unitTest({ permissions: { read: true } }, function statSyncNotFound() {
   assertThrows(() => {
     Deno.statSync("bad_file_name");
   }, Deno.errors.NotFound);
 });
 
-unitTest({ perms: { read: true } }, function lstatSyncSuccess() {
+unitTest({ permissions: { read: true } }, function lstatSyncSuccess() {
   const packageInfo = Deno.lstatSync("README.md");
   assert(packageInfo.isFile);
   assert(!packageInfo.isSymlink);
@@ -141,20 +141,20 @@ unitTest({ perms: { read: true } }, function lstatSyncSuccess() {
   assert(!coreInfoByUrl.isSymlink);
 });
 
-unitTest({ perms: { read: false } }, function lstatSyncPerm() {
+unitTest({ permissions: { read: false } }, function lstatSyncPerm() {
   assertThrows(() => {
     Deno.lstatSync("hello.txt");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, function lstatSyncNotFound() {
+unitTest({ permissions: { read: true } }, function lstatSyncNotFound() {
   assertThrows(() => {
     Deno.lstatSync("bad_file_name");
   }, Deno.errors.NotFound);
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function statSuccess() {
     const readmeInfo = await Deno.stat("README.md");
     assert(readmeInfo.isFile);
@@ -219,13 +219,13 @@ unitTest(
   },
 );
 
-unitTest({ perms: { read: false } }, async function statPerm() {
+unitTest({ permissions: { read: false } }, async function statPerm() {
   await assertRejects(async () => {
     await Deno.stat("README.md");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, async function statNotFound() {
+unitTest({ permissions: { read: true } }, async function statNotFound() {
   await assertRejects(
     async () => {
       await Deno.stat("bad_file_name"), Deno.errors.NotFound;
@@ -233,7 +233,7 @@ unitTest({ perms: { read: true } }, async function statNotFound() {
   );
 });
 
-unitTest({ perms: { read: true } }, async function lstatSuccess() {
+unitTest({ permissions: { read: true } }, async function lstatSuccess() {
   const readmeInfo = await Deno.lstat("README.md");
   assert(readmeInfo.isFile);
   assert(!readmeInfo.isSymlink);
@@ -261,20 +261,23 @@ unitTest({ perms: { read: true } }, async function lstatSuccess() {
   assert(!coreInfoByUrl.isSymlink);
 });
 
-unitTest({ perms: { read: false } }, async function lstatPerm() {
+unitTest({ permissions: { read: false } }, async function lstatPerm() {
   await assertRejects(async () => {
     await Deno.lstat("README.md");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { read: true } }, async function lstatNotFound() {
+unitTest({ permissions: { read: true } }, async function lstatNotFound() {
   await assertRejects(async () => {
     await Deno.lstat("bad_file_name");
   }, Deno.errors.NotFound);
 });
 
 unitTest(
-  { ignore: Deno.build.os !== "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os !== "windows",
+    permissions: { read: true, write: true },
+  },
   function statNoUnixFields() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -295,7 +298,10 @@ unitTest(
 );
 
 unitTest(
-  { ignore: Deno.build.os === "windows", perms: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   function statUnixFields() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");

--- a/cli/tests/unit/symlink_test.ts
+++ b/cli/tests/unit/symlink_test.ts
@@ -7,7 +7,7 @@ import {
 } from "./test_util.ts";
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function symlinkSyncSuccess() {
     const testDir = Deno.makeTempDirSync();
     const oldname = testDir + "/oldname";
@@ -22,7 +22,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function symlinkSyncURL() {
     const testDir = Deno.makeTempDirSync();
     const oldname = testDir + "/oldname";
@@ -46,7 +46,7 @@ unitTest(function symlinkSyncPerm() {
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function symlinkSuccess() {
     const testDir = Deno.makeTempDirSync();
     const oldname = testDir + "/oldname";
@@ -61,7 +61,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function symlinkURL() {
     const testDir = Deno.makeTempDirSync();
     const oldname = testDir + "/oldname";

--- a/cli/tests/unit/sync_test.ts
+++ b/cli/tests/unit/sync_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals, unitTest } from "./test_util.ts";
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function fdatasyncSyncSuccess() {
     const filename = Deno.makeTempDirSync() + "/test_fdatasyncSync.txt";
     const file = Deno.openSync(filename, {
@@ -20,7 +20,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function fdatasyncSuccess() {
     const filename = (await Deno.makeTempDir()) + "/test_fdatasync.txt";
     const file = await Deno.open(filename, {
@@ -38,7 +38,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function fsyncSyncSuccess() {
     const filename = Deno.makeTempDirSync() + "/test_fsyncSync.txt";
     const file = Deno.openSync(filename, {
@@ -56,7 +56,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function fsyncSuccess() {
     const filename = (await Deno.makeTempDir()) + "/test_fsync.txt";
     const file = await Deno.open(filename, {

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -27,19 +27,19 @@ export { readLines } from "../../../test_util/std/io/bufio.ts";
 export { parse as parseArgs } from "../../../test_util/std/flags/mod.ts";
 
 interface UnitTestPermissions {
-  read?: boolean;
-  write?: boolean;
-  net?: boolean;
-  env?: boolean;
-  run?: boolean;
-  ffi?: boolean;
-  hrtime?: boolean;
+  env?: "inherit" | boolean | string[];
+  hrtime?: "inherit" | boolean;
+  net?: "inherit" | boolean | string[];
+  ffi?: "inherit" | boolean;
+  read?: "inherit" | boolean | Array<string | URL>;
+  run?: "inherit" | boolean | Array<string | URL>;
+  write?: "inherit" | boolean | Array<string | URL>;
 }
 
 interface UnitTestOptions {
   ignore?: boolean;
   only?: boolean;
-  perms?: UnitTestPermissions;
+  permissions?: UnitTestPermissions;
 }
 
 type TestFunction = () => void | Promise<void>;
@@ -86,7 +86,7 @@ export function unitTest(
       run: false,
       ffi: false,
       hrtime: false,
-    }, options.perms),
+    }, options.permissions),
   };
 
   Deno.test(testDefinition);

--- a/cli/tests/unit/timers_test.ts
+++ b/cli/tests/unit/timers_test.ts
@@ -445,7 +445,7 @@ unitTest(async function timerIgnoresDateOverride() {
   assertEquals(hasThrown, 1);
 });
 
-unitTest({ perms: { hrtime: true } }, function sleepSync() {
+unitTest({ permissions: { hrtime: true } }, function sleepSync() {
   const start = performance.now();
   Deno.sleepSync(10);
   const after = performance.now();
@@ -453,7 +453,7 @@ unitTest({ perms: { hrtime: true } }, function sleepSync() {
 });
 
 unitTest(
-  { perms: { hrtime: true } },
+  { permissions: { hrtime: true } },
   async function sleepSyncShorterPromise() {
     const perf = performance;
     const short = 5;
@@ -472,7 +472,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { hrtime: true } },
+  { permissions: { hrtime: true } },
   async function sleepSyncLongerPromise() {
     const perf = performance;
     const short = 5;

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -32,7 +32,7 @@ unitTest(async function connectTLSNoPerm() {
 });
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function connectTLSInvalidHost() {
     const listener = await Deno.listenTls({
       hostname: "localhost",
@@ -60,7 +60,7 @@ unitTest(async function connectTLSCertFileNoReadPerm() {
 });
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   function listenTLSNonExistentCertKeyFiles() {
     const options = {
       hostname: "localhost",
@@ -85,7 +85,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { net: true } }, function listenTLSNoReadPerm() {
+unitTest({ permissions: { net: true } }, function listenTLSNoReadPerm() {
   assertThrows(() => {
     Deno.listenTls({
       hostname: "localhost",
@@ -98,7 +98,7 @@ unitTest({ perms: { net: true } }, function listenTLSNoReadPerm() {
 
 unitTest(
   {
-    perms: { read: true, write: true, net: true },
+    permissions: { read: true, write: true, net: true },
   },
   function listenTLSEmptyKeyFile() {
     const options = {
@@ -124,7 +124,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true, net: true } },
+  { permissions: { read: true, write: true, net: true } },
   function listenTLSEmptyCertFile() {
     const options = {
       hostname: "localhost",
@@ -149,7 +149,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function dialAndListenTLS() {
     const resolvable = deferred();
     const hostname = "localhost";
@@ -301,7 +301,7 @@ async function receiveThenSend(
 }
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsServerStreamHalfCloseSendOneByte() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -312,7 +312,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsClientStreamHalfCloseSendOneByte() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -323,7 +323,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsServerStreamHalfCloseSendOneChunk() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -334,7 +334,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsClientStreamHalfCloseSendOneChunk() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -345,7 +345,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsServerStreamHalfCloseSendManyBytes() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -356,7 +356,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsClientStreamHalfCloseSendManyBytes() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -367,7 +367,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsServerStreamHalfCloseSendManyChunks() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -378,7 +378,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsClientStreamHalfCloseSendManyChunks() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -428,7 +428,7 @@ async function receiveAlotSendNothing(conn: Deno.Conn) {
 }
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsServerStreamCancelRead() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -439,7 +439,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsClientStreamCancelRead() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -485,7 +485,7 @@ async function sendReceiveEmptyBuf(conn: Deno.Conn) {
 }
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsStreamSendReceiveEmptyBuf() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -511,7 +511,7 @@ async function closeWriteAndClose(conn: Deno.Conn) {
 }
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsServerStreamImmediateClose() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -522,7 +522,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsClientStreamImmediateClose() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -533,7 +533,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsClientAndServerStreamImmediateClose() {
     const [serverConn, clientConn] = await tlsPair();
     await Promise.all([
@@ -776,7 +776,7 @@ async function tlsWithTcpFailureTestImpl(
 }
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsHandshakeWithTcpCorruptionImmediately() {
     await tlsWithTcpFailureTestImpl("handshake", 0, "corruption", false);
     await tlsWithTcpFailureTestImpl("handshake", 0, "corruption", true);
@@ -784,7 +784,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsHandshakeWithTcpShutdownImmediately() {
     await tlsWithTcpFailureTestImpl("handshake", 0, "shutdown", false);
     await tlsWithTcpFailureTestImpl("handshake", 0, "shutdown", true);
@@ -792,7 +792,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsHandshakeWithTcpCorruptionAfter70Bytes() {
     await tlsWithTcpFailureTestImpl("handshake", 76, "corruption", false);
     await tlsWithTcpFailureTestImpl("handshake", 78, "corruption", true);
@@ -800,7 +800,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsHandshakeWithTcpShutdownAfter70bytes() {
     await tlsWithTcpFailureTestImpl("handshake", 77, "shutdown", false);
     await tlsWithTcpFailureTestImpl("handshake", 79, "shutdown", true);
@@ -808,7 +808,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsHandshakeWithTcpCorruptionAfter200Bytes() {
     await tlsWithTcpFailureTestImpl("handshake", 200, "corruption", false);
     await tlsWithTcpFailureTestImpl("handshake", 202, "corruption", true);
@@ -816,7 +816,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsHandshakeWithTcpShutdownAfter200bytes() {
     await tlsWithTcpFailureTestImpl("handshake", 201, "shutdown", false);
     await tlsWithTcpFailureTestImpl("handshake", 203, "shutdown", true);
@@ -824,7 +824,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsTrafficWithTcpCorruption() {
     await tlsWithTcpFailureTestImpl("traffic", Infinity, "corruption", false);
     await tlsWithTcpFailureTestImpl("traffic", Infinity, "corruption", true);
@@ -832,7 +832,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function tlsTrafficWithTcpShutdown() {
     await tlsWithTcpFailureTestImpl("traffic", Infinity, "shutdown", false);
     await tlsWithTcpFailureTestImpl("traffic", Infinity, "shutdown", true);
@@ -913,7 +913,7 @@ async function curl(url: string): Promise<string> {
 }
 
 unitTest(
-  { perms: { read: true, net: true, run: true } },
+  { permissions: { read: true, net: true, run: true } },
   async function curlFakeHttpsServer() {
     const port = getPort();
     const listener = createHttpsListener(port);
@@ -937,7 +937,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function startTls() {
     const hostname = "smtp.gmail.com";
     const port = 587;
@@ -988,7 +988,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function connectTLSBadClientCertPrivateKey(): Promise<void> {
     await assertRejects(async () => {
       await Deno.connectTls({
@@ -1004,7 +1004,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function connectTLSBadPrivateKey(): Promise<void> {
     await assertRejects(async () => {
       await Deno.connectTls({
@@ -1020,7 +1020,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function connectTLSNotPrivateKey(): Promise<void> {
     await assertRejects(async () => {
       await Deno.connectTls({
@@ -1036,7 +1036,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, net: true } },
+  { permissions: { read: true, net: true } },
   async function connectWithClientCert() {
     // The test_server running on port 4552 responds with 'PASS' if client
     // authentication was successful. Try it by running test_server and

--- a/cli/tests/unit/truncate_test.ts
+++ b/cli/tests/unit/truncate_test.ts
@@ -7,7 +7,7 @@ import {
 } from "./test_util.ts";
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function ftruncateSyncSuccess() {
     const filename = Deno.makeTempDirSync() + "/test_ftruncateSync.txt";
     const file = Deno.openSync(filename, {
@@ -29,7 +29,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function ftruncateSuccess() {
     const filename = Deno.makeTempDirSync() + "/test_ftruncate.txt";
     const file = await Deno.open(filename, {
@@ -51,7 +51,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function truncateSyncSuccess() {
     const filename = Deno.makeTempDirSync() + "/test_truncateSync.txt";
     Deno.writeFileSync(filename, new Uint8Array(5));
@@ -66,7 +66,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function truncateSuccess() {
     const filename = Deno.makeTempDirSync() + "/test_truncate.txt";
     await Deno.writeFile(filename, new Uint8Array(5));
@@ -80,13 +80,13 @@ unitTest(
   },
 );
 
-unitTest({ perms: { write: false } }, function truncateSyncPerm() {
+unitTest({ permissions: { write: false } }, function truncateSyncPerm() {
   assertThrows(() => {
     Deno.truncateSync("/test_truncateSyncPermission.txt");
   }, Deno.errors.PermissionDenied);
 });
 
-unitTest({ perms: { write: false } }, async function truncatePerm() {
+unitTest({ permissions: { write: false } }, async function truncatePerm() {
   await assertRejects(async () => {
     await Deno.truncate("/test_truncatePermission.txt");
   }, Deno.errors.PermissionDenied);

--- a/cli/tests/unit/tty_test.ts
+++ b/cli/tests/unit/tty_test.ts
@@ -3,7 +3,7 @@ import { assert, assertThrows, unitTest } from "./test_util.ts";
 
 // Note tests for Deno.setRaw is in integration tests.
 
-unitTest({ perms: { read: true } }, function consoleSizeFile() {
+unitTest({ permissions: { read: true } }, function consoleSizeFile() {
   const file = Deno.openSync("cli/tests/testdata/hello.txt");
   assertThrows(() => {
     Deno.consoleSize(file.rid);
@@ -18,7 +18,7 @@ unitTest(function consoleSizeError() {
   }, Deno.errors.BadResource);
 });
 
-unitTest({ perms: { read: true } }, function isatty() {
+unitTest({ permissions: { read: true } }, function isatty() {
   // CI not under TTY, so cannot test stdin/stdout/stderr.
   const f = Deno.openSync("cli/tests/testdata/hello.txt");
   assert(!Deno.isatty(f.rid));

--- a/cli/tests/unit/utime_test.ts
+++ b/cli/tests/unit/utime_test.ts
@@ -8,7 +8,7 @@ import {
 } from "./test_util.ts";
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function futimeSyncSuccess() {
     const testDir = await Deno.makeTempDir();
     const filename = testDir + "/file.txt";
@@ -30,7 +30,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function futimeSyncSuccess() {
     const testDir = Deno.makeTempDirSync();
     const filename = testDir + "/file.txt";
@@ -52,7 +52,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function utimeSyncFileSuccess() {
     const testDir = Deno.makeTempDirSync();
     const filename = testDir + "/file.txt";
@@ -71,7 +71,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function utimeSyncUrlSuccess() {
     const testDir = Deno.makeTempDirSync();
     const filename = testDir + "/file.txt";
@@ -90,7 +90,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function utimeSyncDirectorySuccess() {
     const testDir = Deno.makeTempDirSync();
 
@@ -105,7 +105,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function utimeSyncDateSuccess() {
     const testDir = Deno.makeTempDirSync();
 
@@ -120,7 +120,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function utimeSyncFileDateSuccess() {
     const testDir = Deno.makeTempDirSync();
     const filename = testDir + "/file.txt";
@@ -138,7 +138,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function utimeSyncLargeNumberSuccess() {
     const testDir = Deno.makeTempDirSync();
 
@@ -155,7 +155,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function utimeSyncNotFound() {
     const atime = 1000;
     const mtime = 50000;
@@ -167,7 +167,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: false } },
+  { permissions: { read: true, write: false } },
   function utimeSyncPerm() {
     const atime = 1000;
     const mtime = 50000;
@@ -179,7 +179,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function utimeFileSuccess() {
     const testDir = Deno.makeTempDirSync();
     const filename = testDir + "/file.txt";
@@ -198,7 +198,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function utimeUrlSuccess() {
     const testDir = Deno.makeTempDirSync();
     const filename = testDir + "/file.txt";
@@ -217,7 +217,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function utimeDirectorySuccess() {
     const testDir = Deno.makeTempDirSync();
 
@@ -232,7 +232,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function utimeDateSuccess() {
     const testDir = Deno.makeTempDirSync();
 
@@ -247,7 +247,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function utimeFileDateSuccess() {
     const testDir = Deno.makeTempDirSync();
     const filename = testDir + "/file.txt";
@@ -266,7 +266,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function utimeNotFound() {
     const atime = 1000;
     const mtime = 50000;
@@ -278,7 +278,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: false } },
+  { permissions: { read: true, write: false } },
   async function utimeSyncPerm() {
     const atime = 1000;
     const mtime = 50000;

--- a/cli/tests/unit/wasm_test.ts
+++ b/cli/tests/unit/wasm_test.ts
@@ -77,7 +77,7 @@ unitTest(async function wasmInstantiateStreaming() {
 });
 
 unitTest(
-  { perms: { net: true } },
+  { permissions: { net: true } },
   async function wasmStreamingNonTrivial() {
     // deno-dom's WASM file is a real-world non-trivial case that gave us
     // trouble when implementing this.

--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -384,7 +384,7 @@ const pkcs8TestVectors = [
   "cli/tests/testdata/webcrypto/id_rsassaPss.pem",
 ];
 
-unitTest({ perms: { read: true } }, async function importRsaPkcs8() {
+unitTest({ permissions: { read: true } }, async function importRsaPkcs8() {
   const pemHeader = "-----BEGIN PRIVATE KEY-----";
   const pemFooter = "-----END PRIVATE KEY-----";
   for (const keyFile of pkcs8TestVectors) {

--- a/cli/tests/unit/webgpu_test.ts
+++ b/cli/tests/unit/webgpu_test.ts
@@ -10,7 +10,7 @@ try {
 // Skip this test on linux CI, because the vulkan emulator is not good enough
 // yet, and skip on macOS because these do not have virtual GPUs.
 unitTest({
-  perms: { read: true, env: true },
+  permissions: { read: true, env: true },
   ignore: (Deno.build.os === "linux" || Deno.build.os === "darwin") && isCI,
 }, async function webgpuComputePass() {
   const adapter = await navigator.gpu.requestAdapter();
@@ -101,7 +101,7 @@ unitTest({
 // Skip this test on linux CI, because the vulkan emulator is not good enough
 // yet, and skip on macOS because these do not have virtual GPUs.
 unitTest({
-  perms: { read: true, env: true },
+  permissions: { read: true, env: true },
   ignore: (Deno.build.os === "linux" || Deno.build.os === "darwin") && isCI,
 }, async function webgpuHelloTriangle() {
   const adapter = await navigator.gpu.requestAdapter();

--- a/cli/tests/unit/worker_types.ts
+++ b/cli/tests/unit/worker_types.ts
@@ -2,7 +2,7 @@
 import { assert, unitTest } from "./test_util.ts";
 
 unitTest(
-  { perms: { read: true } },
+  { permissions: { read: true } },
   function utimeSyncFileSuccess() {
     const w = new Worker(
       new URL("../workers/worker_types.ts", import.meta.url).href,

--- a/cli/tests/unit/write_file_test.ts
+++ b/cli/tests/unit/write_file_test.ts
@@ -7,7 +7,7 @@ import {
 } from "./test_util.ts";
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function writeFileSyncSuccess() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -21,7 +21,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function writeFileSyncUrl() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -39,7 +39,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { write: true } }, function writeFileSyncFail() {
+unitTest({ permissions: { write: true } }, function writeFileSyncFail() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
   const filename = "/baddir/test.txt";
@@ -49,7 +49,7 @@ unitTest({ perms: { write: true } }, function writeFileSyncFail() {
   }, Deno.errors.NotFound);
 });
 
-unitTest({ perms: { write: false } }, function writeFileSyncPerm() {
+unitTest({ permissions: { write: false } }, function writeFileSyncPerm() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
   const filename = "/baddir/test.txt";
@@ -60,7 +60,7 @@ unitTest({ perms: { write: false } }, function writeFileSyncPerm() {
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function writeFileSyncUpdateMode() {
     if (Deno.build.os !== "windows") {
       const enc = new TextEncoder();
@@ -75,7 +75,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function writeFileSyncCreate() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -96,7 +96,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function writeFileSyncAppend() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -121,7 +121,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeFileSuccess() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -135,7 +135,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeFileUrl() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -154,7 +154,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeFileNotFound() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -167,7 +167,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: false } },
+  { permissions: { read: true, write: false } },
   async function writeFilePerm() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -180,7 +180,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeFileUpdateMode() {
     if (Deno.build.os !== "windows") {
       const enc = new TextEncoder();
@@ -195,7 +195,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeFileCreate() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -216,7 +216,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeFileAppend() {
     const enc = new TextEncoder();
     const data = enc.encode("Hello");
@@ -241,7 +241,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeFileAbortSignal(): Promise<void> {
     const ac = new AbortController();
     const enc = new TextEncoder();
@@ -259,7 +259,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeFileAbortSignalPreAborted(): Promise<void> {
     const ac = new AbortController();
     ac.abort();

--- a/cli/tests/unit/write_text_file_test.ts
+++ b/cli/tests/unit/write_text_file_test.ts
@@ -7,7 +7,7 @@ import {
 } from "./test_util.ts";
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function writeTextFileSyncSuccess() {
     const filename = Deno.makeTempDirSync() + "/test.txt";
     Deno.writeTextFileSync(filename, "Hello");
@@ -17,7 +17,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function writeTextFileSyncByUrl() {
     const tempDir = Deno.makeTempDirSync();
     const fileUrl = new URL(
@@ -31,7 +31,7 @@ unitTest(
   },
 );
 
-unitTest({ perms: { write: true } }, function writeTextFileSyncFail() {
+unitTest({ permissions: { write: true } }, function writeTextFileSyncFail() {
   const filename = "/baddir/test.txt";
   // The following should fail because /baddir doesn't exist (hopefully).
   assertThrows(() => {
@@ -39,7 +39,7 @@ unitTest({ perms: { write: true } }, function writeTextFileSyncFail() {
   }, Deno.errors.NotFound);
 });
 
-unitTest({ perms: { write: false } }, function writeTextFileSyncPerm() {
+unitTest({ permissions: { write: false } }, function writeTextFileSyncPerm() {
   const filename = "/baddir/test.txt";
   // The following should fail due to no write permission
   assertThrows(() => {
@@ -48,7 +48,7 @@ unitTest({ perms: { write: false } }, function writeTextFileSyncPerm() {
 });
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function writeTextFileSyncUpdateMode() {
     if (Deno.build.os !== "windows") {
       const data = "Hello";
@@ -62,7 +62,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function writeTextFileSyncCreate() {
     const data = "Hello";
     const filename = Deno.makeTempDirSync() + "/test.txt";
@@ -84,7 +84,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   function writeTextFileSyncAppend() {
     const data = "Hello";
     const filename = Deno.makeTempDirSync() + "/test.txt";
@@ -101,7 +101,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeTextFileSuccess() {
     const filename = Deno.makeTempDirSync() + "/test.txt";
     await Deno.writeTextFile(filename, "Hello");
@@ -111,7 +111,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeTextFileByUrl() {
     const tempDir = Deno.makeTempDirSync();
     const fileUrl = new URL(
@@ -126,7 +126,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeTextFileNotFound() {
     const filename = "/baddir/test.txt";
     // The following should fail because /baddir doesn't exist (hopefully).
@@ -137,7 +137,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { write: false } },
+  { permissions: { write: false } },
   async function writeTextFilePerm() {
     const filename = "/baddir/test.txt";
     // The following should fail due to no write permission
@@ -148,7 +148,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeTextFileUpdateMode() {
     if (Deno.build.os !== "windows") {
       const data = "Hello";
@@ -162,7 +162,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeTextFileCreate() {
     const data = "Hello";
     const filename = Deno.makeTempDirSync() + "/test.txt";
@@ -184,7 +184,7 @@ unitTest(
 );
 
 unitTest(
-  { perms: { read: true, write: true } },
+  { permissions: { read: true, write: true } },
   async function writeTextFileAppend() {
     const data = "Hello";
     const filename = Deno.makeTempDirSync() + "/test.txt";


### PR DESCRIPTION
Aligns UnitTestPermissions type with the Deno.TestDefinition.permissions.

Came up in #12170 where I had to use Deno.test directly instead of unitTest to permission sets as intended.