### PR TITLE
feat(lsp): add bare specifier and extensionless code actions

### DIFF
--- a/cli/lsp/README.md
+++ b/cli/lsp/README.md
@@ -77,9 +77,21 @@ language server will assume the workspace setting applies to all resources.
 There are several commands that might be issued by the language server to the
 client, which the client is expected to implement:
 
+- `deno.addToImportMap` - This is sent as a command to complete code actions
+  where the language server has identified a bare import specifier it cannot
+  map. It will be sent with an argument of the bare specifier that should be
+  added to an import map in order to "resolve" the bare specifier diagnostic.
+  Clients should do the following when the command is activated:
+  - Determine if an import map is configured and exists for the workspace.
+  - Determine if the bare specifier looks like a Node.js built-in or is a npm
+    package.
+  - Provide an interface to select a CDN for an npm package.
+  - Potentially provide an interface to determine how the Node.js built-in will
+    be "polyfilled".
+  - Add the supplied bare specifier to the import map.
 - `deno.cache` - This is sent as a resolution code action when there is an
   un-cached module specifier that is being imported into a module. It will be
-  sent with and argument that contains the resolved specifier as a string to be
+  sent with an argument that contains the resolved specifier as a string to be
   cached.
 - `deno.showReferences` - This is sent as the command on some code lenses to
   show locations of references. The arguments contain the specifier that is the

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1211,13 +1211,8 @@ impl Inner {
             }
             _ => false,
           },
-          "deno-lint" => matches!(&d.code, Some(_)),
-          "deno" => match &d.code {
-            Some(NumberOrString::String(code)) => {
-              code == "no-cache" || code == "no-cache-data"
-            }
-            _ => false,
-          },
+          "deno-lint" => d.code.is_some(),
+          "deno" => d.data.is_some(),
           _ => false,
         },
         None => false,
@@ -1274,7 +1269,7 @@ impl Inner {
             }
           }
           Some("deno") => code_actions
-            .add_deno_fix_action(diagnostic)
+            .add_deno_fix_action(&specifier, diagnostic)
             .map_err(|err| {
               error!("{}", err);
               LspError::internal_error()

--- a/cli/tests/testdata/lsp/code_action_response_cache.json
+++ b/cli/tests/testdata/lsp/code_action_response_cache.json
@@ -1,6 +1,6 @@
 [
   {
-    "title": "Cache \"https://deno.land/x/a/mod.ts\" and its dependencies.",
+    "title": "Cache \"https://deno.land/x/a/mod.ts\" and its dependencies",
     "kind": "quickfix",
     "diagnostics": [
       {


### PR DESCRIPTION
This PR helps solves two "challenges" with using Deno on code bases that users are migrating from Node.js:

- Deno does not support extensionless imports, while non-ESM Node.js code is extensionless.
- Deno does not include Node.js built-in modules.

This PR makes the following changes:

- When a bare specifier is not found that looks like a npm package or Node.js builtin, the diagnostics now suggest that this can be resolved by using an import map.
- A code action is available for the diagnostic which resolves to a command in the editor to add the bare specifier to an import map. (This then requires the client to facilitate adding it, which I will be raising a PR in `vscode_deno` to do this.
- When a local file import is not resolved, the lsp will check the local FS to see if an extensioned import exists on the file system or if the local import is a directory, if a `index.<extension>` exists, and provide back a diagnostic that suggests that maybe they meant to import module that exists.
- A code action is available for the diagnostic which will add the extension or the index file to the specifier to resolve the diagnostic.

Here is what it looks like in action in an editor (again, the implementation of the add to import map is forthcoming in the `vscode_deno`):

https://user-images.githubusercontent.com/1282577/134433249-7e62db87-cbe9-4659-a63f-643c2d19f683.mp4



