### PR TITLE
BREAKING(cli/eval): remove --ts flag

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -3006,8 +3006,12 @@ mod tests {
 
   #[test]
   fn eval_typescript() {
-    let r =
-      flags_from_vec(svec!["deno", "eval", "-T", "'console.log(\"hello\")'"]);
+    let r = flags_from_vec(svec![
+      "deno",
+      "eval",
+      "--ext=ts",
+      "'console.log(\"hello\")'"
+    ]);
     assert_eq!(
       r.unwrap(),
       Flags {

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -766,16 +766,6 @@ To evaluate as TypeScript:
 This command has implicit access to all permissions (--allow-all).",
     )
     .arg(
-      // TODO(@satyarohith): remove this argument in 2.0.
-      Arg::with_name("ts")
-        .long("ts")
-        .short("T")
-        .help("Treat eval input as TypeScript")
-        .takes_value(false)
-        .multiple(false)
-        .hidden(true),
-    )
-    .arg(
       Arg::with_name("ext")
         .long("ext")
         .help("Set standard input (stdin) content type")
@@ -1767,15 +1757,9 @@ fn eval_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   flags.allow_write = Some(vec![]);
   flags.allow_ffi = Some(vec![]);
   flags.allow_hrtime = true;
-  // TODO(@satyarohith): remove this flag in 2.0.
-  let as_typescript = matches.is_present("ts");
-  let ext = if as_typescript {
-    "ts".to_string()
-  } else {
-    matches.value_of("ext").unwrap().to_string()
-  };
 
   let print = matches.is_present("print");
+  let ext = matches.value_of("ext").unwrap().to_string();
   let mut code: Vec<String> = matches
     .values_of("code_arg")
     .unwrap()


### PR DESCRIPTION
Use `deno eval --ext` instead.

Should be merged after the merge window for 2.0 opens (27 October).