### PR TITLE
perf(ext/fetch): Use the WebIDL conversion to DOMString rather than USVString for Response constructor

### DIFF
--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -112,6 +112,11 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
     None,
   ),
   (
+    "response_string",
+    &["run", "cli/tests/testdata/response_string_perf.js"],
+    None,
+  ),
+  (
     "check",
     &[
       "cache",

--- a/cli/tests/testdata/response_string_perf.js
+++ b/cli/tests/testdata/response_string_perf.js
@@ -1,0 +1,34 @@
+const mixed = "@Ā๐😀";
+
+function generateRandom(bytes) {
+  let result = "";
+  let i = 0;
+  while (i < bytes) {
+    const toAdd = Math.floor(Math.random() * Math.min(4, bytes - i));
+    switch (toAdd) {
+      case 0:
+        result += mixed[0];
+        i++;
+        break;
+      case 1:
+        result += mixed[1];
+        i++;
+        break;
+      case 2:
+        result += mixed[2];
+        i++;
+        break;
+      case 3:
+        result += mixed[3];
+        result += mixed[4];
+        i += 2;
+        break;
+    }
+  }
+  return result;
+}
+
+const randomData = generateRandom(1024);
+for (let i = 0; i < 10_000; i++) {
+  new Response(randomData);
+}

--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -393,7 +393,7 @@
         return webidl.converters["ArrayBufferView"](V, opts);
       }
     }
-    return webidl.converters["USVString"](V, opts);
+    return webidl.converters["DOMString"](V, opts);
   };
   webidl.converters["BodyInit?"] = webidl.createNullableConverter(
     webidl.converters["BodyInit"],

--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -372,7 +372,7 @@
     return { body, contentType };
   }
 
-  webidl.converters["BodyInit"] = (V, opts) => {
+  webidl.converters["BodyInit_DOMString"] = (V, opts) => {
     // Union for (ReadableStream or Blob or ArrayBufferView or ArrayBuffer or FormData or URLSearchParams or USVString)
     if (V instanceof ReadableStream) {
       // TODO(lucacasonato): ReadableStream is not branded
@@ -393,10 +393,13 @@
         return webidl.converters["ArrayBufferView"](V, opts);
       }
     }
+    // BodyInit conversion is passed to extractBody(), which calls core.encode().
+    // core.encode() will UTF-8 encode strings with replacement, being equivalent to the USV normalization.
+    // Therefore we can convert to DOMString instead of USVString and avoid a costly redundant conversion.
     return webidl.converters["DOMString"](V, opts);
   };
-  webidl.converters["BodyInit?"] = webidl.createNullableConverter(
-    webidl.converters["BodyInit"],
+  webidl.converters["BodyInit_DOMString?"] = webidl.createNullableConverter(
+    webidl.converters["BodyInit_DOMString"],
   );
 
   window.__bootstrap.fetchBody = { mixinBody, InnerBody, extractBody };

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -450,7 +450,7 @@
       {
         key: "body",
         converter: webidl.createNullableConverter(
-          webidl.converters["BodyInit"],
+          webidl.converters["BodyInit_DOMString"],
         ),
       },
       { key: "redirect", converter: webidl.converters["RequestRedirect"] },

--- a/ext/fetch/23_response.js
+++ b/ext/fetch/23_response.js
@@ -254,7 +254,7 @@
      */
     constructor(body = null, init = {}) {
       const prefix = "Failed to construct 'Response'";
-      body = webidl.converters["BodyInit?"](body, {
+      body = webidl.converters["BodyInit_DOMString?"](body, {
         prefix,
         context: "Argument 1",
       });


### PR DESCRIPTION
Fixes performance issue https://github.com/denoland/deno/issues/12090

* Replaces conversion to `USVString` by `DOMString` at the `BodyInit` WebIDL conversion.
* Adds benchmark `response_string` which produced the following results before and after the change:

  * using `USVString`:
  ```
  Benchmark #13: /home/luismalheiro/projects/deno_pr/target/release/deno run cli/tests/testdata/response_string_perf.js 
    Time (mean ± σ):     432.9 ms ±  26.8 ms    [User: 308.8 ms, System: 192.8 ms]
    Range (min … max):   409.5 ms … 485.4 ms    10 runs
  ```
  * using `DOMString`:
  ```
  Benchmark #13: /home/luismalheiro/projects/deno_pr/target/release/deno run cli/tests/testdata/response_string_perf.js 
    Time (mean ± σ):     175.8 ms ±  17.6 ms    [User: 168.6 ms, System: 73.9 ms]
    Range (min … max):   147.3 ms … 211.6 ms    18 runs
  ```
  Notice that the difference will increase non-linearly for larger strings.

This pull request replaces https://github.com/denoland/deno/pull/12093