### PR TITLE
experiment: derivative Default on worker options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
  "deno_webidl",
  "deno_websocket",
  "deno_webstorage",
+ "derivative",
  "dlopen",
  "encoding_rs",
  "filetime",
@@ -991,6 +992,17 @@ checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
 dependencies = [
  "const-oid",
  "crypto-bigint",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.65",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -62,6 +62,7 @@ deno_websocket = { version = "0.23.0", path = "../ext/websocket" }
 deno_webstorage = { version = "0.13.0", path = "../ext/webstorage" }
 
 atty = "0.2.14"
+derivative = "2.2.0"
 dlopen = "0.1.8"
 encoding_rs = "0.8.28"
 filetime = "0.2.15"

--- a/runtime/examples/hello_runtime.rs
+++ b/runtime/examples/hello_runtime.rs
@@ -2,8 +2,6 @@
 
 use deno_core::error::AnyError;
 use deno_core::FsModuleLoader;
-use deno_runtime::deno_broadcast_channel::InMemoryBroadcastChannel;
-use deno_runtime::deno_web::BlobStore;
 use deno_runtime::permissions::Permissions;
 use deno_runtime::worker::MainWorker;
 use deno_runtime::worker::WorkerOptions;
@@ -23,30 +21,11 @@ async fn main() -> Result<(), AnyError> {
   });
 
   let options = WorkerOptions {
-    apply_source_maps: false,
-    args: vec![],
-    debug_flag: false,
-    unstable: false,
-    enable_testing_features: false,
-    unsafely_ignore_certificate_errors: None,
-    root_cert_store: None,
-    user_agent: "hello_runtime".to_string(),
-    seed: None,
-    js_error_create_fn: None,
-    create_web_worker_cb,
-    maybe_inspector_server: None,
-    should_break_on_first_statement: false,
     module_loader,
-    runtime_version: "x".to_string(),
-    ts_version: "x".to_string(),
     no_color: false,
     get_error_class_fn: Some(&get_error_class_name),
-    location: None,
-    origin_storage_dir: None,
-    blob_store: BlobStore::default(),
-    broadcast_channel: InMemoryBroadcastChannel::default(),
-    shared_array_buffer_store: None,
-    cpu_count: 1,
+    create_web_worker_cb,
+    ..Default::default()
   };
 
   let js_path =

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -32,6 +32,7 @@ use deno_tls::rustls::RootCertStore;
 use deno_web::create_entangled_message_port;
 use deno_web::BlobStore;
 use deno_web::MessagePort;
+use derivative::Derivative;
 use log::debug;
 use std::cell::RefCell;
 use std::env;
@@ -43,11 +44,20 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+  Derivative, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum WebWorkerType {
   Classic,
+  #[derivative(Default)]
   Module,
+}
+
+impl Default for WebWorkerType {
+  fn default() -> Self {
+    Self::Module
+  }
 }
 
 #[derive(
@@ -258,6 +268,8 @@ pub struct WebWorker {
   pub main_module: ModuleSpecifier,
 }
 
+#[derive(Derivative)]
+#[derivative(Default)]
 pub struct WebWorkerOptions {
   /// Sets `Deno.args` in JS runtime.
   pub args: Vec<String>,
@@ -268,7 +280,9 @@ pub struct WebWorkerOptions {
   pub root_cert_store: Option<RootCertStore>,
   pub user_agent: String,
   pub seed: Option<u64>,
+  #[derivative(Default(value = "Rc::new(deno_core::NoopModuleLoader{})"))]
   pub module_loader: Rc<dyn ModuleLoader>,
+  #[derivative(Default(value = "Arc::new(|_| unimplemented!())"))]
   pub create_web_worker_cb: Arc<ops::worker_host::CreateWebWorkerCb>,
   pub js_error_create_fn: Option<Rc<JsErrorCreateFn>>,
   pub use_deno_namespace: bool,

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -44,13 +44,10 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 
-#[derive(
-  Derivative, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize,
-)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WebWorkerType {
   Classic,
-  #[derivative(Default)]
   Module,
 }
 

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -24,6 +24,7 @@ use deno_core::RuntimeOptions;
 use deno_core::SharedArrayBufferStore;
 use deno_tls::rustls::RootCertStore;
 use deno_web::BlobStore;
+use derivative::Derivative;
 use log::debug;
 use std::env;
 use std::pin::Pin;
@@ -44,6 +45,8 @@ pub struct MainWorker {
   should_break_on_first_statement: bool,
 }
 
+#[derive(Derivative)]
+#[derivative(Default)]
 pub struct WorkerOptions {
   pub apply_source_maps: bool,
   /// Sets `Deno.args` in JS runtime.
@@ -53,20 +56,26 @@ pub struct WorkerOptions {
   pub enable_testing_features: bool,
   pub unsafely_ignore_certificate_errors: Option<Vec<String>>,
   pub root_cert_store: Option<RootCertStore>,
+  #[derivative(Default(value = r#""Deno/0.0.0".to_string()"#))]
   pub user_agent: String,
   pub seed: Option<u64>,
+  #[derivative(Default(value = "Rc::new(deno_core::NoopModuleLoader{})"))]
   pub module_loader: Rc<dyn ModuleLoader>,
   // Callback that will be invoked when creating new instance
   // of WebWorker
+  #[derivative(Default(value = "Arc::new(|_| unimplemented!())"))]
   pub create_web_worker_cb: Arc<ops::worker_host::CreateWebWorkerCb>,
   pub js_error_create_fn: Option<Rc<JsErrorCreateFn>>,
   pub maybe_inspector_server: Option<Arc<InspectorServer>>,
   pub should_break_on_first_statement: bool,
   /// Sets `Deno.version.deno` in JS runtime.
+  #[derivative(Default(value = r#""0.0.0".to_string()"#))]
   pub runtime_version: String,
   /// Sets `Deno.version.typescript` in JS runtime.
+  #[derivative(Default(value = r#""0.0.0".to_string()"#))]
   pub ts_version: String,
   /// Sets `Deno.noColor` in JS runtime.
+  #[derivative(Default(value = "true"))]
   pub no_color: bool,
   pub get_error_class_fn: Option<GetErrorClassFn>,
   pub location: Option<Url>,
@@ -74,6 +83,7 @@ pub struct WorkerOptions {
   pub blob_store: BlobStore,
   pub broadcast_channel: InMemoryBroadcastChannel,
   pub shared_array_buffer_store: Option<SharedArrayBufferStore>,
+  #[derivative(Default(value = "1"))]
   pub cpu_count: usize,
 }
 
@@ -323,30 +333,8 @@ mod tests {
     let permissions = Permissions::default();
 
     let options = WorkerOptions {
-      apply_source_maps: false,
-      user_agent: "x".to_string(),
-      args: vec![],
-      debug_flag: false,
-      unstable: false,
-      enable_testing_features: false,
-      unsafely_ignore_certificate_errors: None,
-      root_cert_store: None,
-      seed: None,
-      js_error_create_fn: None,
-      create_web_worker_cb: Arc::new(|_| unreachable!()),
-      maybe_inspector_server: None,
-      should_break_on_first_statement: false,
       module_loader: Rc::new(deno_core::FsModuleLoader),
-      runtime_version: "x".to_string(),
-      ts_version: "x".to_string(),
-      no_color: true,
-      get_error_class_fn: None,
-      location: None,
-      origin_storage_dir: None,
-      blob_store: BlobStore::default(),
-      broadcast_channel: InMemoryBroadcastChannel::default(),
-      shared_array_buffer_store: None,
-      cpu_count: 1,
+      ..Default::default()
     };
 
     MainWorker::from_options(main_module, permissions, &options)


### PR DESCRIPTION
Allowing for less verbose (and lower maintenance) worker construction in tests and embedders (as we move to facilitating embedding `deno_runtime` for projects like Deno Desktop)