### PR TITLE
chore(workers): Test that closing a worker closes any child workers

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1194,6 +1194,11 @@ itest!(worker_drop_handle_race {
   exit_code: 1,
 });
 
+itest!(worker_close_nested {
+  args: "run --quiet --reload --allow-read worker_close_nested.js",
+  output: "worker_close_nested.js.out",
+});
+
 itest!(worker_message_before_close {
   args: "run --quiet --reload --allow-read worker_message_before_close.js",
   output: "worker_message_before_close.js.out",

--- a/cli/tests/testdata/worker_close_nested.js
+++ b/cli/tests/testdata/worker_close_nested.js
@@ -1,5 +1,8 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+// Test that closing a worker which has living child workers will automatically
+// close the children.
+
 console.log("Starting the main thread");
 
 const worker = new Worker(

--- a/cli/tests/testdata/worker_close_nested.js
+++ b/cli/tests/testdata/worker_close_nested.js
@@ -1,0 +1,17 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+console.log("Starting the main thread");
+
+const worker = new Worker(
+  new URL("./workers/close_nested_parent.js", import.meta.url),
+  { type: "module" },
+);
+
+setTimeout(() => {
+  console.log("About to close");
+  worker.postMessage({});
+
+  // Keep the process running for another two seconds, to make sure there's no
+  // output from the child worker.
+  setTimeout(() => {}, 2000);
+}, 1000);

--- a/cli/tests/testdata/worker_close_nested.js.out
+++ b/cli/tests/testdata/worker_close_nested.js.out
@@ -1,0 +1,5 @@
+Starting the main thread
+Starting the parent worker
+Starting the child worker
+About to close
+Closing

--- a/cli/tests/testdata/workers/close_nested_child.js
+++ b/cli/tests/testdata/workers/close_nested_child.js
@@ -1,0 +1,7 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+console.log("Starting the child worker");
+
+setTimeout(() => {
+  console.log("The child worker survived the death of the parent!!!");
+}, 2000);

--- a/cli/tests/testdata/workers/close_nested_parent.js
+++ b/cli/tests/testdata/workers/close_nested_parent.js
@@ -1,0 +1,13 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+console.log("Starting the parent worker");
+
+new Worker(
+  new URL("./close_nested_child.js", import.meta.url),
+  { type: "module" },
+);
+
+self.addEventListener("message", () => {
+  console.log("Closing");
+  self.close();
+});


### PR DESCRIPTION
Before #12156, closing a worker which had children would cause a panic (https://github.com/denoland/deno/issues/11342#issuecomment-918327693). After that PR, closing a worker will also close any child workers.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
