### PR TITLE
fix(http): panic when responding to a closed conn

### DIFF
--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -959,7 +959,9 @@ unitTest(
 
       try {
         http.close();
-      } catch {}
+      } catch {
+        "nop";
+      }
 
       listener.close();
     }

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -936,3 +936,46 @@ unitTest(
     await promise;
   },
 );
+
+// https://github.com/denoland/deno/pull/12216
+unitTest(
+  { permissions: { net: true } },
+  async function droppedConnSenderNoPanic() {
+    async function server(listener: Deno.Listener) {
+      const conn = await listener.accept();
+      const http = Deno.serveHttp(conn);
+
+      for (;;) {
+        const req = await http.nextRequest();
+        if (req == null) break;
+
+        nextloop()
+          .then(() => {
+            http.close();
+            return req.respondWith(new Response("boom"));
+          })
+          .catch(() => {});
+      }
+
+      try {
+        http.close();
+      } catch {}
+
+      listener.close();
+    }
+
+    async function client() {
+      await fetch("http://127.0.0.1:8000/");
+    }
+
+    function nextloop() {
+      return new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    async function main() {
+      const listener = Deno.listen({ port: 8000 });
+      await Promise.all([server(listener), client()]);
+    }
+    await main();
+  },
+);

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -965,7 +965,8 @@ unitTest(
     }
 
     async function client() {
-      await fetch("http://127.0.0.1:8000/");
+      const resp = await fetch("http://127.0.0.1:8000/");
+      await resp.body?.cancel();
     }
 
     function nextloop() {

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -106,7 +106,7 @@ impl HyperService<Request<Body>> for Service {
 
     async move {
       resp_rx.await.or_else(|_|
-        // Fallback dummy response in case sender was dropped after conn being closed
+        // Fallback dummy response in case sender was dropped due to closed conn
         Response::builder()
           .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
           .body(vec![].into()))


### PR DESCRIPTION
Our oneshot receiver in `HyperService::call` would unwrap and panic, the `.await` on the oneshot receiver errors when the sender is dropped.

The sender is dropped in `op_http_response` because:
1. We take `ResponseSenderResource` (which owns the sender)
2. Then we hit an early exit in `op_http_response` due to the conn being closed
3. Then the taken sender gets dropped in this early exit before any response is sent over the channel

Fallbacking to returning a dummy response to hyper seems to be a fine quickfix