### PR TITLE
perf(webidl/ByteString): 3x faster ASCII check

### DIFF
--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -375,10 +375,10 @@
   };
 
   // deno-lint-ignore no-control-regex
-  const IS_BYTESTRING = /^[\x00-\xFF]*$/;
+  const IS_BYTE_STRING = /^[\x00-\xFF]*$/;
   converters.ByteString = (V, opts) => {
     const x = converters.DOMString(V, opts);
-    if (!RegExpPrototypeTest(IS_BYTESTRING, x)) {
+    if (!RegExpPrototypeTest(IS_BYTE_STRING, x)) {
       throw makeException(TypeError, "is not a valid ByteString", opts);
     }
     return x;

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -375,10 +375,10 @@
   };
 
   // deno-lint-ignore no-control-regex
-  const IS_ASCII = /^[\x00-\xFF]*$/;
+  const IS_BYTESTRING = /^[\x00-\xFF]*$/;
   converters.ByteString = (V, opts) => {
     const x = converters.DOMString(V, opts);
-    if (!RegExpPrototypeTest(IS_ASCII, x)) {
+    if (!RegExpPrototypeTest(IS_BYTESTRING, x)) {
       throw makeException(TypeError, "is not a valid ByteString", opts);
     }
     return x;

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -378,7 +378,7 @@
   const IS_ASCII = /^[\x00-\xFF]*$/;
   converters.ByteString = (V, opts) => {
     const x = converters.DOMString(V, opts);
-    if (!IS_ASCII.test(x)) {
+    if (!RegExpPrototypeTest(IS_ASCII, x)) {
       throw makeException(TypeError, "is not a valid ByteString", opts);
     }
     return x;

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -62,7 +62,6 @@
     String,
     StringFromCodePoint,
     StringPrototypeCharCodeAt,
-    StringPrototypeCodePointAt,
     Symbol,
     SymbolIterator,
     SymbolToStringTag,
@@ -375,15 +374,13 @@
     return String(V);
   };
 
+  // deno-lint-ignore no-control-regex
+  const IS_ASCII = /^[\x00-\xFF]*$/;
   converters.ByteString = (V, opts) => {
     const x = converters.DOMString(V, opts);
-    let c;
-    for (let i = 0; (c = StringPrototypeCodePointAt(x, i)) !== undefined; ++i) {
-      if (c > 255) {
-        throw makeException(TypeError, "is not a valid ByteString", opts);
-      }
+    if (!IS_ASCII.test(x)) {
+      throw makeException(TypeError, "is not a valid ByteString", opts);
     }
-
     return x;
   };
 


### PR DESCRIPTION
This replaces a looped `.codePointAt(i)` ASCII check with a regex, which is ~3x faster. This ascii check is the dominant cost in the webidl `ByteString` converter which is used for headers etc... in http hot path

## Benchmarks

Bench script: https://gist.github.com/AaronO/676dee49b4fdd4d6e0ad0efbff45b75c

```
❯ deno run https://gist.githubusercontent.com/AaronO/676dee49b4fdd4d6e0ad0efbff45b75c/raw/f6a9c14da88c68ac947dcd369a4b4939da15bbaa/deno_webidl_bstring_bench.js
ascii:               	n = 1000000, dt = 0.038s, r = 26315789/s, t = 37ns/op
ascii_inline:        	n = 1000000, dt = 0.049s, r = 20408163/s, t = 49ns/op
codepoint_loop:      	n = 1000000, dt = 0.124s, r = 8064516/s, t = 124ns/op
ascii:               	n = 1000000, dt = 0.048s, r = 20833333/s, t = 48ns/op
ascii_inline:        	n = 1000000, dt = 0.044s, r = 22727273/s, t = 44ns/op
codepoint_loop:      	n = 1000000, dt = 0.123s, r = 8130081/s, t = 123ns/op
```

**Note:** duplicated benches were used to ensure we're fairly comparing optimized versions of these functions