### PR TITLE
perf(fetch/headers): optimize appendHeader

### DIFF
--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -37,7 +37,6 @@
     SymbolFor,
     SymbolIterator,
     StringPrototypeReplaceAll,
-    StringPrototypeIncludes,
     TypeError,
   } = window.__bootstrap.primordials;
 
@@ -94,6 +93,10 @@
     }
   }
 
+  // Regex matching illegal chars in a header value
+  // deno-lint-ignore no-control-regex
+  const ILLEGAL_VALUE_CHARS = /[\x00\x0A\x0D]/;
+  
   /**
    * https://fetch.spec.whatwg.org/#concept-headers-append
    * @param {Headers} headers
@@ -108,11 +111,7 @@
     if (!RegExpPrototypeTest(HTTP_TOKEN_CODE_POINT_RE, name)) {
       throw new TypeError("Header name is not valid.");
     }
-    if (
-      StringPrototypeIncludes(value, "\x00") ||
-      StringPrototypeIncludes(value, "\x0A") ||
-      StringPrototypeIncludes(value, "\x0D")
-    ) {
+    if (RegExpPrototypeTest(ILLEGAL_VALUE_CHARS, value)) {
       throw new TypeError("Header value is not valid.");
     }
 
@@ -372,11 +371,7 @@
       if (!RegExpPrototypeTest(HTTP_TOKEN_CODE_POINT_RE, name)) {
         throw new TypeError("Header name is not valid.");
       }
-      if (
-        StringPrototypeIncludes(value, "\x00") ||
-        StringPrototypeIncludes(value, "\x0A") ||
-        StringPrototypeIncludes(value, "\x0D")
-      ) {
+      if (RegExpPrototypeTest(ILLEGAL_VALUE_CHARS, value)) {
         throw new TypeError("Header value is not valid.");
       }
 

--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -96,7 +96,7 @@
   // Regex matching illegal chars in a header value
   // deno-lint-ignore no-control-regex
   const ILLEGAL_VALUE_CHARS = /[\x00\x0A\x0D]/;
-  
+
   /**
    * https://fetch.spec.whatwg.org/#concept-headers-append
    * @param {Headers} headers


### PR DESCRIPTION
Use a single regex to check for `\0`, `\n`, `\r` instead of 3 `String.includes(...)` calls