### PR TITLE
refactor(fetch/response): inline defaultInnerResponse

### DIFF
--- a/ext/fetch/23_response.js
+++ b/ext/fetch/23_response.js
@@ -101,37 +101,33 @@
       type: response.type,
       body,
       headerList,
-      url() {
-        if (this.urlList.length == 0) return null;
-        return this.urlList[this.urlList.length - 1];
-      },
       urlList,
       status: response.status,
       statusMessage: response.statusMessage,
       aborted: response.aborted,
+      url() {
+        if (this.urlList.length == 0) return null;
+        return this.urlList[this.urlList.length - 1];
+      },
     };
   }
-
-  const defaultInnerResponse = {
-    type: "default",
-    body: null,
-    aborted: false,
-    url() {
-      if (this.urlList.length == 0) return null;
-      return this.urlList[this.urlList.length - 1];
-    },
-  };
 
   /**
    * @returns {InnerResponse}
    */
   function newInnerResponse(status = 200, statusMessage = "") {
     return {
+      type: "default",
+      body: null,
       headerList: [],
       urlList: [],
       status,
       statusMessage,
-      ...defaultInnerResponse,
+      aborted: false,
+      url() {
+        if (this.urlList.length == 0) return null;
+        return this.urlList[this.urlList.length - 1];
+      },
     };
   }
 


### PR DESCRIPTION
Not useful to have the defaults externally defined when they're only used in `newInnerResponse()`. Also match order in `newInnerResponse()` and `cloneInnerResponse`