### PR TITLE
Remove flush after write

### DIFF
--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -318,7 +318,6 @@ impl StdFileResource {
         .borrow_mut()
         .await;
       let nwritten = fs_file.0.as_mut().unwrap().write(buf).await?;
-      fs_file.0.as_mut().unwrap().flush().await?;
       Ok(nwritten)
     } else {
       Err(resource_unavailable())


### PR DESCRIPTION
This flush should not be needed; there was a fixme comment here but it is gone.
This was just introduced to keep CI happy, passes locally but CI doesn't flush.

Just checking if that is still the case with all the Tokyo bumps we've done.