### PR TITLE
perf(fetch): optimize newInnerRequest blob url check

### DIFF
--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -67,11 +67,12 @@
    * @param {string} url
    * @param {[string, string][]} headerList
    * @param {typeof __window.bootstrap.fetchBody.InnerBody} body
+   * @param {boolean} maybeBlob
    * @returns
    */
-  function newInnerRequest(method, url, headerList = [], body = null) {
+  function newInnerRequest(method, url, headerList, body, maybeBlob) {
     let blobUrlEntry = null;
-    if (url.startsWith("blob:")) {
+    if (maybeBlob && url.startsWith("blob:")) {
       blobUrlEntry = blobFromObjectUrl(url);
     }
     return {
@@ -236,7 +237,7 @@
       // 5.
       if (typeof input === "string") {
         const parsedURL = new URL(input, baseURL);
-        request = newInnerRequest("GET", parsedURL.href, [], null);
+        request = newInnerRequest("GET", parsedURL.href, [], null, true);
       } else { // 6.
         if (!(input instanceof Request)) throw new TypeError("Unreachable");
         request = input[_request];

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -103,6 +103,7 @@
         url,
         headersList,
         body !== null ? new InnerBody(body) : null,
+        false,
       );
       const signal = abortSignal.newSignal();
       const request = fromInnerRequest(innerRequest, signal, "immutable");


### PR DESCRIPTION
Avoid "blob:" prefix check on requests built in the http module since those can never be blob objects

Reduces cost of `newInnerRequest()` from 20ms to 0.1ms in my profiled run on ~2.5M reqs

Follow up to #12241 

## Notes

- Also removed default args on `newInnerRequest` since they weren't helpful given we only have 2 call sites that supply all args (and it's not user facing) 