### PR TITLE
fix: worker environment permissions should accept an array

### DIFF
--- a/cli/tests/testdata/workers/env_read_check_worker.js
+++ b/cli/tests/testdata/workers/env_read_check_worker.js
@@ -1,6 +1,6 @@
-onmessage = async ({ names }) => {
+onmessage = async ({ data }) => {
   const permissions = [];
-  for (const name of names) {
+  for (const name of data.names) {
     const { state } = await Deno.permissions.query({
       name: "env",
       variable: name,

--- a/cli/tests/testdata/workers/env_read_check_worker.js
+++ b/cli/tests/testdata/workers/env_read_check_worker.js
@@ -1,0 +1,14 @@
+onmessage = async ({ names }) => {
+  const permissions = [];
+  for (const name of names) {
+    const { state } = await Deno.permissions.query({
+      name: "env",
+      variable: name,
+    });
+    permissions.push(state === "granted");
+  }
+
+  postMessage({
+    permissions,
+  });
+};

--- a/cli/tests/testdata/workers/test.ts
+++ b/cli/tests/testdata/workers/test.ts
@@ -627,7 +627,6 @@ Deno.test("Worker initialization throws on worker permissions greater than paren
 Deno.test("Worker has correct env permissions", async function () {
   const promise = deferred<boolean[]>();
 
-  /** This worker has read permissions but doesn't grant them to its children */
   const worker = new Worker(
     new URL("./env_read_check_worker.js", import.meta.url).href,
     {

--- a/cli/tests/testdata/workers/test.ts
+++ b/cli/tests/testdata/workers/test.ts
@@ -624,6 +624,42 @@ Deno.test("Worker initialization throws on worker permissions greater than paren
   );
 });
 
+Deno.test("Worker has correct env permissions", async function () {
+  const promise = deferred<boolean[]>();
+
+  /** This worker has read permissions but doesn't grant them to its children */
+  const worker = new Worker(
+    new URL("./env_read_check_worker.js", import.meta.url).href,
+    {
+      type: "module",
+      deno: {
+        namespace: true,
+        permissions: {
+          env: ["test", "OTHER"],
+        },
+      },
+    },
+  );
+
+  worker.onmessage = ({ data }) => {
+    promise.resolve(data.permissions);
+  };
+
+  worker.postMessage({
+    names: ["test", "TEST", "asdf", "OTHER"],
+  });
+
+  const permissions = await promise;
+  worker.terminate();
+
+  if (Deno.build.os === "windows") {
+    // windows ignores case
+    assertEquals(permissions, [true, true, false, true]);
+  } else {
+    assertEquals(permissions, [true, false, false, true]);
+  }
+});
+
 Deno.test("Worker with disabled permissions", async function () {
   const promise = deferred();
 

--- a/cli/tests/testdata/workers/test.ts
+++ b/cli/tests/testdata/workers/test.ts
@@ -624,48 +624,6 @@ Deno.test("Worker initialization throws on worker permissions greater than paren
   );
 });
 
-Deno.test({
-  name: "Worker uses only env var names specified when using an array",
-  only: true,
-  permissions: {
-    env: true,
-  },
-  fn: async function () {
-    const promise = deferred<boolean[]>();
-
-    const worker = new Worker(
-      new URL("./env_read_check_worker.js", import.meta.url).href,
-      {
-        type: "module",
-        deno: {
-          namespace: true,
-          permissions: {
-            env: ["test", "OTHER"],
-          },
-        },
-      },
-    );
-
-    worker.onmessage = ({ data }) => {
-      promise.resolve(data.permissions);
-    };
-
-    worker.postMessage({
-      names: ["test", "TEST", "asdf", "OTHER"],
-    });
-
-    const permissions = await promise;
-    worker.terminate();
-
-    if (Deno.build.os === "windows") {
-      // windows ignores case
-      assertEquals(permissions, [true, true, false, true]);
-    } else {
-      assertEquals(permissions, [true, false, false, true]);
-    }
-  },
-});
-
 Deno.test("Worker with disabled permissions", async function () {
   const promise = deferred();
 

--- a/cli/tests/unit/worker_permissions_test.ts
+++ b/cli/tests/unit/worker_permissions_test.ts
@@ -1,0 +1,43 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { assertEquals, deferred, unitTest } from "./test_util.ts";
+
+unitTest(
+  { permissions: { env: true, read: true } },
+  async function workerEnvArrayPermissions() {
+    const promise = deferred<boolean[]>();
+
+    const worker = new Worker(
+      new URL(
+        "../testdata/workers/env_read_check_worker.js",
+        import.meta.url,
+      ).href,
+      {
+        type: "module",
+        deno: {
+          namespace: true,
+          permissions: {
+            env: ["test", "OTHER"],
+          },
+        },
+      },
+    );
+
+    worker.onmessage = ({ data }) => {
+      promise.resolve(data.permissions);
+    };
+
+    worker.postMessage({
+      names: ["test", "TEST", "asdf", "OTHER"],
+    });
+
+    const permissions = await promise;
+    worker.terminate();
+
+    if (Deno.build.os === "windows") {
+      // windows ignores case
+      assertEquals(permissions, [true, true, false, true]);
+    } else {
+      assertEquals(permissions, [true, false, false, true]);
+    }
+  },
+);

--- a/cli/tests/unit/worker_types.ts
+++ b/cli/tests/unit/worker_types.ts
@@ -5,7 +5,7 @@ unitTest(
   { permissions: { read: true } },
   function utimeSyncFileSuccess() {
     const w = new Worker(
-      new URL("../workers/worker_types.ts", import.meta.url).href,
+      new URL("../testdata/workers/worker_types.ts", import.meta.url).href,
       { type: "module" },
     );
     assert(w);

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -128,7 +128,7 @@
     write = "inherit",
   }) {
     return {
-      env: parseUnitPermission(env, "env"),
+      env: parseArrayPermission(env, "env"),
       hrtime: parseUnitPermission(hrtime, "hrtime"),
       net: parseArrayPermission(net, "net"),
       ffi: parseUnitPermission(ffi, "ffi"),

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -58,6 +58,7 @@
   }
 
   /**
+   * @param {"inherit" | boolean} value
    * @param {string} permission
    * @return {boolean}
    */

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -223,7 +223,10 @@ fn merge_env_permission(
 ) -> Result<UnaryPermission<EnvDescriptor>, AnyError> {
   if let Some(worker) = worker {
     if (worker.global_state < main.global_state)
-      || !worker.granted_list.iter().all(|x| main.check(&x.0).is_ok())
+      || !worker
+        .granted_list
+        .iter()
+        .all(|x| main.check(x.as_ref()).is_ok())
     {
       return Err(custom_error(
         "PermissionDenied",
@@ -451,7 +454,7 @@ where
     granted_list: value
       .paths
       .into_iter()
-      .map(|env| EnvDescriptor(env.to_uppercase()))
+      .map(EnvDescriptor::new)
       .collect(),
     ..Default::default()
   }))

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -451,11 +451,7 @@ where
 
   Ok(Some(UnaryPermission::<EnvDescriptor> {
     global_state: value.global_state,
-    granted_list: value
-      .paths
-      .into_iter()
-      .map(EnvDescriptor::new)
-      .collect(),
+    granted_list: value.paths.into_iter().map(EnvDescriptor::new).collect(),
     ..Default::default()
   }))
 }

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -162,7 +162,7 @@ impl UnitPermission {
 /// A normalized environment variable name. On Windows this will
 /// be uppercase and on other platforms it will stay as-is.
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
-pub struct EnvVarName {
+struct EnvVarName {
   inner: String,
 }
 

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -160,26 +160,23 @@ impl UnitPermission {
   }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct UnaryPermission<T: Eq + Hash> {
-  #[serde(skip)]
   pub name: &'static str,
-  #[serde(skip)]
   pub description: &'static str,
   pub global_state: PermissionState,
   pub granted_list: HashSet<T>,
   pub denied_list: HashSet<T>,
-  #[serde(skip)]
   pub prompt: bool,
 }
 
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Default, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct ReadDescriptor(pub PathBuf);
 
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Default, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct WriteDescriptor(pub PathBuf);
 
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Default, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct NetDescriptor(pub String, pub Option<u16>);
 
 impl NetDescriptor {
@@ -204,7 +201,7 @@ impl fmt::Display for NetDescriptor {
   }
 }
 
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Default, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct EnvDescriptor {
   env: String,
 }
@@ -233,10 +230,10 @@ impl Display for EnvDescriptor {
   }
 }
 
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Default, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct RunDescriptor(pub String);
 
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Default, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct FfiDescriptor(pub String);
 
 impl UnaryPermission<ReadDescriptor> {

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -650,9 +650,12 @@ impl UnaryPermission<EnvDescriptor> {
 
   pub fn revoke(&mut self, env: Option<&str>) -> PermissionState {
     if let Some(env) = env {
-      #[cfg(windows)]
-      let env = env.to_uppercase();
-      self.granted_list.remove(&EnvDescriptor(env.to_string()));
+      let env = if cfg!(windows) {
+        env.to_uppercase()
+      } else {
+        env.to_string()
+      };
+      self.granted_list.remove(&EnvDescriptor(env));
     } else {
       self.granted_list.clear();
     }


### PR DESCRIPTION
Fixes a Windows only clippy lint, but also aligns the worker environment permissions with accepting an array.