### PR TITLE
feat: stabilize URLPattern API

### DIFF
--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -395,6 +395,7 @@ delete Object.prototype.__proto__;
     TextEncoderStream: util.nonEnumerable(encoding.TextEncoderStream),
     TransformStream: util.nonEnumerable(streams.TransformStream),
     URL: util.nonEnumerable(url.URL),
+    URLPattern: util.nonEnumerable(urlPattern.URLPattern),
     URLSearchParams: util.nonEnumerable(url.URLSearchParams),
     WebSocket: util.nonEnumerable(webSocket.WebSocket),
     MessageChannel: util.nonEnumerable(messagePort.MessageChannel),
@@ -435,7 +436,6 @@ delete Object.prototype.__proto__;
 
   const unstableWindowOrWorkerGlobalScope = {
     BroadcastChannel: util.nonEnumerable(broadcastChannel.BroadcastChannel),
-    URLPattern: util.nonEnumerable(urlPattern.URLPattern),
     WebSocketStream: util.nonEnumerable(webSocket.WebSocketStream),
 
     GPU: util.nonEnumerable(webgpu.GPU),


### PR DESCRIPTION
This stabilizes the URLPattern API introduced in Deno 1.14.

## Checklist for shipping Web APIs

- [x] Ships in at least 1 other browser engine
  - Yes: Chrome 95, which is currently in beta. I got confirmation from @wanderview that it is proceeding to stable as planned.
- [x] Has a specification
  - Yes: wicg.github.io/urlpattern
- [x] Has test coverage
  - Yes: https://github.com/web-platform-tests/wpt/tree/master/urlpattern

Also has extensive docs on MDN now: https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API.