### PR TITLE
fix(http): don't expose body on GET/HEAD requests

### DIFF
--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -95,7 +95,12 @@
       let body = null;
       if (typeof requestRid === "number") {
         SetPrototypeAdd(this.managedResources, requestRid);
-        body = createRequestBodyStream(this, requestRid);
+        // There might be a body, but we don't expose it for GET/HEAD requests.
+        // It will be closed automatically once the request has been handled and
+        // the response has been sent.
+        if (method !== "GET" && method !== "HEAD") {
+          body = createRequestBodyStream(this, requestRid);
+        }
       }
 
       const innerRequest = newInnerRequest(

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -30,6 +30,7 @@ use hyper::http;
 use hyper::server::conn::Http;
 use hyper::service::Service as HyperService;
 use hyper::Body;
+use hyper::Method;
 use hyper::Request;
 use hyper::Response;
 use serde::Deserialize;
@@ -244,13 +245,17 @@ fn prepare_next_request(
   let url = req_url(&req, scheme, addr)?;
 
   let is_websocket = is_websocket_request(&req);
-  let has_body = if let Some(exact_size) = req.size_hint().exact() {
+  let maybe_has_body = if let Some(exact_size) = req.size_hint().exact() {
     exact_size > 0
   } else {
     true
   };
+  let can_method_have_body =
+    !matches!(*req.method(), Method::GET | Method::HEAD);
+  let should_expose_body =
+    is_websocket || (maybe_has_body && can_method_have_body);
 
-  let maybe_request_rid = if is_websocket || has_body {
+  let maybe_request_rid = if should_expose_body {
     let request_rid = state.resource_table.add(RequestResource {
       conn_rid,
       inner: AsyncRefCell::new(RequestOrStreamReader::Request(Some(req))),


### PR DESCRIPTION
GET/HEAD requests can't have bodies according to `fetch` spec. This
commit changes the HTTP server to hide request bodies for requests with
GET or HEAD methods.

Fixes #11927