### PR TITLE
perf(webidl/DOMString): don't wrap string primitives

### DIFF
--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -359,11 +359,11 @@
   };
 
   converters.DOMString = function (V, opts = {}) {
-    if (opts.treatNullAsEmptyString && V === null) {
+    if (typeof V === "string") {
+      return V;
+    } else if (V === null && opts.treatNullAsEmptyString) {
       return "";
-    }
-
-    if (typeof V === "symbol") {
+    } else if (typeof V === "symbol") {
       throw makeException(
         TypeError,
         "is a symbol, which cannot be converted to a string",


### PR DESCRIPTION
Avoids needlessly creating String objects, can reduce GC-pressure.

On a micro-bench, avoiding this unwrap (via typeof if or switch) is ~4x faster:
```
DOMString_main:      	n = 10000000, dt = 0.235s, r = 42553191/s, t = 23ns/op
DOMString_typeof:    	n = 10000000, dt = 0.055s, r = 181818182/s, t = 5ns/op
DOMString_typeof2:   	n = 10000000, dt = 0.056s, r = 178571429/s, t = 5ns/op
DOMString_switch:    	n = 10000000, dt = 0.055s, r = 181818182/s, t = 5ns/op
```

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
