### PR TITLE
bench(cli): add deno_http_native_headers.js

### DIFF
--- a/cli/bench/deno_http_native_headers.js
+++ b/cli/bench/deno_http_native_headers.js
@@ -1,0 +1,22 @@
+const addr = Deno.args[0] || "127.0.0.1:4500";
+const [hostname, port] = addr.split(":");
+const listener = Deno.listen({ hostname, port: Number(port) });
+console.log("Server listening on", addr);
+
+for await (const conn of listener) {
+  (async () => {
+    const requests = Deno.serveHttp(conn);
+    for await (const { respondWith } of requests) {
+      respondWith(
+        new Response("Hello World", {
+          status: 200,
+          headers: {
+            server: "deno",
+            "content-type": "text/plain",
+          },
+        }),
+      )
+        .catch((e) => console.log(e));
+    }
+  })();
+}


### PR DESCRIPTION
The use of headers reduces throughput by 30%, we want to reduce this gap since most real world apps will provide custom headers. So I added this benchmark so we can track that delta and measure improvements shipped over the next few days

### Throughput Datapoints

- `deno@1.14.0`:
  - `deno_http_native.js`: 107k rps
  - `deno_http_native_headers.js`: 74k rps
- `deno@1.14.2`:
  - `deno_http_native.js`: 117k rps
  - `deno_http_native_headers.js`: 82k rps

---

  ## Notes
  
  In addition to adding headers we also don't pre-encode the body, which likely better reflects typical use.