### PR TITLE
fix: Don't panic when a worker is closed in the reactions to a wasm operation.

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1204,6 +1204,11 @@ itest!(worker_message_before_close {
   output: "worker_message_before_close.js.out",
 });
 
+itest!(worker_close_in_wasm_reactions {
+  args: "run --quiet --reload --allow-read worker_close_in_wasm_reactions.js",
+  output: "worker_close_in_wasm_reactions.js.out",
+});
+
 #[test]
 fn no_validate_asm() {
   let output = util::deno_cmd()

--- a/cli/tests/testdata/worker_close_in_wasm_reactions.js
+++ b/cli/tests/testdata/worker_close_in_wasm_reactions.js
@@ -1,0 +1,10 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+// https://github.com/denoland/deno/issues/12263
+// Test for a panic that happens when a worker is closed in the reactions of a
+// WASM async operation.
+
+new Worker(
+  new URL("./workers/close_in_wasm_reactions.js", import.meta.url),
+  { type: "module" },
+);

--- a/cli/tests/testdata/worker_close_in_wasm_reactions.js.out
+++ b/cli/tests/testdata/worker_close_in_wasm_reactions.js.out
@@ -1,0 +1,1 @@
+Error: CompileError: WebAssembly.compile(): expected string length @+10

--- a/cli/tests/testdata/workers/close_in_wasm_reactions.js
+++ b/cli/tests/testdata/workers/close_in_wasm_reactions.js
@@ -1,0 +1,21 @@
+// https://github.com/denoland/deno/issues/12263
+// Test for a panic that happens when a worker is closed in the reactions of a
+// WASM async operation.
+
+// The minimum valid wasm module, plus two additional zero bytes.
+const buffer = new Uint8Array([
+  0x00,
+  0x61,
+  0x73,
+  0x6D,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+]);
+WebAssembly.compile(buffer).catch((err) => {
+  console.log("Error:", err);
+  self.close();
+});

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1572,6 +1572,10 @@ impl JsRuntime {
         return exception_to_err_result(tc_scope, exception, false);
       }
 
+      if tc_scope.has_terminated() || tc_scope.is_execution_terminating() {
+        break;
+      }
+
       let is_done = is_done.unwrap();
       if is_done.is_true() {
         break;


### PR DESCRIPTION
Part of #12263.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
