### PR TITLE
fix(repl): avoid panic when assigned to globalThis

### DIFF
--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -135,6 +135,17 @@ fn pty_ignore_symbols() {
 }
 
 #[test]
+fn pty_assign_global_this() {
+  util::with_pty(&["repl"], |mut console| {
+    console.write_line("globalThis = 42;");
+    console.write_line("close();");
+
+    let output = console.read_all_output();
+    assert!(!output.contains("panicked"));
+  });
+}
+
+#[test]
 fn console_log() {
   let (out, err) = util::run_and_collect_output(
     true,

--- a/cli/tools/repl.rs
+++ b/cli/tools/repl.rs
@@ -485,7 +485,7 @@ impl ReplSession {
 
   pub async fn is_closing(&mut self) -> Result<bool, AnyError> {
     let closed = self
-      .evaluate_expression("(globalThis.closed)")
+      .evaluate_expression("(this.closed)")
       .await?
       .get("result")
       .unwrap()


### PR DESCRIPTION
This PR fixes the crash of repl described in #9916

Repl internally uses `globalThis` for getting `closed` variable. This PR uses `this` (in global scope) instead of `globalThis` to reference the global variable.

closes #9916