### PR TITLE
perf(webidl): optimize createDictionaryConverter()

### DIFF
--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -41,6 +41,7 @@
     NumberMAX_SAFE_INTEGER,
     // deno-lint-ignore camelcase
     NumberMIN_SAFE_INTEGER,
+    ObjectAssign,
     ObjectCreate,
     ObjectDefineProperties,
     ObjectDefineProperty,
@@ -726,7 +727,7 @@
       }
       const esDict = V;
 
-      const idlDict = { ...defaultValues };
+      const idlDict = ObjectAssign({}, defaultValues);
 
       // NOTE: fast path Null and Undefined.
       if ((V === undefined || V === null) && !hasRequiredKey) {


### PR DESCRIPTION
On a benchmark constructing `Response`s with headers this shaves off 25%:
```
Before:
resp_w_h:            	n = 1000000, dt = 2.284s, r = 437828/s, t = 2283ns/op
After:
resp_w_h:            	n = 1000000, dt = 1.725s, r = 579710/s, t = 1725ns/op
```