### PR TITLE
perf(web): optimize byteLowerCase()

### DIFF
--- a/ext/web/00_infra.js
+++ b/ext/web/00_infra.js
@@ -158,8 +158,8 @@
    */
   function byteLowerCase(s) {
     // NOTE: correct since all callers convert to ByteString first
-    // TODO: maybe prefer a ByteString_Lower webidl converter
-    return s.toLowerCase();
+    // TODO(@AaronO): maybe prefer a ByteString_Lower webidl converter
+    return StringPrototypeToLowerCase(s);
   }
 
   /**

--- a/ext/web/00_infra.js
+++ b/ext/web/00_infra.js
@@ -157,13 +157,9 @@
    * @returns {string}
    */
   function byteLowerCase(s) {
-    return StringPrototypeReplace(
-      String(s),
-      /[A-Z]/g,
-      function byteUpperCaseReplace(c) {
-        return StringPrototypeToLowerCase(c);
-      },
-    );
+    // NOTE: correct since all callers convert to ByteString first
+    // TODO: maybe prefer a ByteString_Lower webidl converter
+    return s.toLowerCase();
   }
 
   /**


### PR DESCRIPTION
To use `String.prototype.toLowerCase()`, this is safe since all callers convert the values to webidl ByteString so we know these inputs are already ASCII

We don't convert it in `getHeader()` but that shouldn't be an issue since those lookups will miss

Shaves off ~20% of total time spent constructing Responses with headers, ~1700ns/iter => ~1400ns/iter