### PR TITLE
perf(webidl): optimize isArrayBufferDetached()

### DIFF
--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -440,12 +440,7 @@
   }
 
   function isArrayBufferDetached(V) {
-    try {
-      new Uint8Array(V);
-      return false;
-    } catch {
-      return true;
-    }
+    return V.byteLength === 0;
   }
 
   converters.ArrayBuffer = (V, opts = {}) => {


### PR DESCRIPTION
Per MDN (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/byteLength#description):
> The `byteLength` property ... returns 0 if this `ArrayBuffer` has been detached.