### PR TITLE
perf(webidl): optimize createRecordConverter()

### DIFF
--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -48,6 +48,7 @@
     ObjectGetOwnPropertyDescriptor,
     ObjectGetOwnPropertyDescriptors,
     ObjectGetPrototypeOf,
+    ObjectPrototypeHasOwnProperty,
     ObjectIs,
     PromisePrototypeThen,
     PromiseReject,
@@ -844,16 +845,15 @@
           opts,
         );
       }
-      const keys = ReflectOwnKeys(V);
       const result = {};
-      for (const key of keys) {
-        const desc = ObjectGetOwnPropertyDescriptor(V, key);
-        if (desc !== undefined && desc.enumerable === true) {
-          const typedKey = keyConverter(key, opts);
-          const value = V[key];
-          const typedValue = valueConverter(value, opts);
-          result[typedKey] = typedValue;
+      for (const key in V) {
+        if (!ObjectPrototypeHasOwnProperty(V, key)) {
+          continue;
         }
+        const typedKey = keyConverter(key, opts);
+        const value = V[key];
+        const typedValue = valueConverter(value, opts);
+        result[typedKey] = typedValue;
       }
       return result;
     };

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -847,9 +847,8 @@
         );
       }
       const result = {};
-      const isProxy = core.isProxy(V);
       // Fast path for common case (not a Proxy)
-      if (!isProxy) {
+      if (!core.isProxy(V)) {
         for (const key in V) {
           if (!ObjectPrototypeHasOwnProperty(V, key)) {
             continue;

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -848,23 +848,23 @@
       }
       const result = {};
       const isProxy = core.isProxy(V);
-      if (isProxy) {
-        const keys = ReflectOwnKeys(V);
-        for (const key of keys) {
-          const desc = ObjectGetOwnPropertyDescriptor(V, key);
-          if (desc !== undefined && desc.enumerable === true) {
-            const typedKey = keyConverter(key, opts);
-            const value = V[key];
-            const typedValue = valueConverter(value, opts);
-            result[typedKey] = typedValue;
-          }
-        }
-      } else {
-        // Fast path for common case (not a Proxy)
+      // Fast path for common case (not a Proxy)
+      if (!isProxy) {
         for (const key in V) {
           if (!ObjectPrototypeHasOwnProperty(V, key)) {
             continue;
           }
+          const typedKey = keyConverter(key, opts);
+          const value = V[key];
+          const typedValue = valueConverter(value, opts);
+          result[typedKey] = typedValue;
+        }
+      }
+      // Slow path if Proxy (e.g: in WPT tests)
+      const keys = ReflectOwnKeys(V);
+      for (const key of keys) {
+        const desc = ObjectGetOwnPropertyDescriptor(V, key);
+        if (desc !== undefined && desc.enumerable === true) {
           const typedKey = keyConverter(key, opts);
           const value = V[key];
           const typedValue = valueConverter(value, opts);


### PR DESCRIPTION
Cuts self-time by ~6x, 172ns/iter => 22ns/iter benched on 1M Response builds / HeadersInit calls

This should be functionally identical to the old code since:
1. `for...in` loops on objects iterate over all enumberable string keys of an object (including inherited)
2. Then we filter out inherited keys with `.hasOwnProperty(...)`

**Note:** WebIDL / WPT is coupled to a subpar implementation so our hands are tied, unless an isProxy fast path check isn't too expensive

## Benchmarks

```
No fast path:
resp_w_bh:           	n = 1000000, dt = 1.295s, r = 772201/s, t = 1294ns/op
Fast path with isProxy check:
resp_w_bh:           	n = 1000000, dt = 1.146s, r = 872600/s, t = 1146ns/op
Forced fast path:
resp_w_bh:           	n = 1000000, dt = 1.112s, r = 899281/s, t = 1112ns/op
```

Pending on https://github.com/denoland/deno/pull/12288