### PR TITLE
perf(fetch): optimize fillHeaders() key iteration

### DIFF
--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -29,7 +29,7 @@
     ArrayPrototypeJoin,
     ArrayPrototypeSplice,
     ArrayPrototypeFilter,
-    ObjectKeys,
+    ObjectPrototypeHasOwnProperty,
     ObjectEntries,
     RegExpPrototypeTest,
     Symbol,
@@ -76,7 +76,10 @@
         appendHeader(headers, header[0], header[1]);
       }
     } else {
-      for (const key of ObjectKeys(object)) {
+      for (const key in object) {
+        if (!ObjectPrototypeHasOwnProperty(object, key)) {
+          continue;
+        }
         appendHeader(headers, key, object[key]);
       }
     }


### PR DESCRIPTION
Reduces self-time by ~70x (~70ms => ~1ms on 1M iters)

for...in filtered by hasOwnProperty yields the same set of keys as Object.keys()