### PR TITLE
feat(core): implement Deno.core.isProxy()

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -64,6 +64,9 @@ lazy_static::lazy_static! {
         function: get_proxy_details.map_fn_to()
       },
       v8::ExternalReference {
+        function: is_proxy.map_fn_to()
+      },
+      v8::ExternalReference {
         function: memory_usage.map_fn_to(),
       },
       v8::ExternalReference {
@@ -146,6 +149,7 @@ pub fn initialize_context<'s>(
   set_func(scope, core_val, "deserialize", deserialize);
   set_func(scope, core_val, "getPromiseDetails", get_promise_details);
   set_func(scope, core_val, "getProxyDetails", get_proxy_details);
+  set_func(scope, core_val, "isProxy", is_proxy);
   set_func(scope, core_val, "memoryUsage", memory_usage);
   set_func(scope, core_val, "callConsole", call_console);
   set_func(scope, core_val, "createHostObject", create_host_object);
@@ -1117,6 +1121,14 @@ fn get_proxy_details(
   let handler = proxy.get_handler(scope);
   let p: (serde_v8::Value, serde_v8::Value) = (target.into(), handler.into());
   rv.set(to_v8(scope, p).unwrap());
+}
+
+fn is_proxy(
+  scope: &mut v8::HandleScope,
+  args: v8::FunctionCallbackArguments,
+  mut rv: v8::ReturnValue,
+) {
+  rv.set(v8::Boolean::new(scope, args.get(0).is_proxy()).into())
 }
 
 fn throw_type_error(scope: &mut v8::HandleScope, message: impl AsRef<str>) {

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2289,8 +2289,7 @@ assertEquals(1, notify_return_value);
       })()
     "#,
       )
-      .unwrap()
-      .into();
+      .unwrap();
     let mut scope = runtime.handle_scope();
     let all_true = v8::Local::<v8::Value>::new(&mut scope, &all_true);
     assert!(all_true.is_true());

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2273,4 +2273,26 @@ assertEquals(1, notify_return_value);
     let mut runtime = JsRuntime::new(options);
     runtime.execute_script("<none>", "").unwrap();
   }
+
+  #[test]
+  fn test_is_proxy() {
+    let mut runtime = JsRuntime::new(RuntimeOptions::default());
+    let all_true: v8::Global<v8::Value> = runtime
+      .execute_script(
+        "is_proxy.js",
+        r#"
+      (function () {
+        const { isProxy } = Deno.core;
+        const o = { a: 1, b: 2};
+        const p = new Proxy(o, {});
+        return isProxy(p) && !isProxy(o) && !isProxy(42);
+      })()
+    "#,
+      )
+      .unwrap()
+      .into();
+    let mut scope = runtime.handle_scope();
+    let all_true = v8::Local::<v8::Value>::new(&mut scope, &all_true);
+    assert!(all_true.is_true());
+  }
 }


### PR DESCRIPTION
Another binding ... but it's required for https://github.com/denoland/deno/pull/12286 and could be useful elsewhere

`core.getProxyDetails(...)` isn't fast enough for fast-path checks:
```
No fast path:
resp_w_bh:               n = 1000000, dt = 1.295s, r = 772201/s, t = 1294ns/op
Fast path with getProxyDetails check:
resp_w_bh:               n = 1000000, dt = 1.321s, r = 757002/s, t = 1321ns/op
Fast path with isProxy check:
resp_w_bh:               n = 1000000, dt = 1.146s, r = 872600/s, t = 1146ns/op
Forced fast path:
resp_w_bh:               n = 1000000, dt = 1.112s, r = 899281/s, t = 1112ns/op
```