### PR TITLE
feat(web): Implement `DOMException`'s `stack` property.

### DIFF
--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -96,11 +96,16 @@
       });
       this.#code = nameToCodeMapping[this.#name] ?? 0;
 
-      // `DOMException` does not have `.stack`, so `Error.prepareStackTrace()`
-      // is not called on it, meaning our structured stack trace hack doesn't
-      // apply. This patches it in.
-      const error = new Error();
-      error.stack;
+      const error = new Error(`DOMException: ${this.#message}`);
+      Object.defineProperty(this, "stack", {
+        value: error.stack,
+        writable: true,
+        configurable: true,
+      });
+
+      // `DOMException` isn't a native error, so `Error.prepareStackTrace()` is
+      // not called when accessing `.stack`, meaning our structured stack trace
+      // hack doesn't apply. This patches it in.
       ObjectDefineProperty(this, "__callSiteEvals", {
         value: ArrayPrototypeSlice(error.__callSiteEvals, 1),
         configurable: true,

--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -97,7 +97,7 @@
       this.#code = nameToCodeMapping[this.#name] ?? 0;
 
       const error = new Error(`DOMException: ${this.#message}`);
-      Object.defineProperty(this, "stack", {
+      ObjectDefineProperty(this, "stack", {
         value: error.stack,
         writable: true,
         configurable: true,

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -13603,9 +13603,7 @@
         "DOMException-constants.any.html": true,
         "DOMException-constructor-and-prototype.any.html": true,
         "DOMException-constructor-behavior.any.html": true,
-        "DOMException-custom-bindings.any.html": [
-          "If the implementation has a stack property on normal errors, it also does on DOMExceptions"
-        ]
+        "DOMException-custom-bindings.any.html": true
       },
       "class-string-interface.any.html": true,
       "class-string-iterator-prototype-object.any.html": true,


### PR DESCRIPTION
[As per WebIDL](https://heycam.github.io/webidl/#es-DOMException-specialness), if `Error` objects have a `stack` property, so should `DOMException` instances.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
