### PR TITLE
refactor(runtime): Worker bootstrap options

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -145,8 +145,12 @@ fn create_web_worker_callback(ps: ProcState) -> Arc<CreateWebWorkerCb> {
       shared_array_buffer_store: Some(ps.shared_array_buffer_store.clone()),
       compiled_wasm_module_store: Some(ps.compiled_wasm_module_store.clone()),
     };
+    let bootstrap_options = options.bootstrap.clone();
 
-    let (mut worker, external_handle) = WebWorker::bootstrap_from_options(
+    // TODO(@AaronO): switch to bootstrap_from_options() once ops below are an extension
+    // since it uses sync_ops_cache() which currently depends on the Deno namespace
+    // which can be nuked when bootstrapping workers (use_deno_namespace: false)
+    let (mut worker, external_handle) = WebWorker::from_options(
       args.name,
       args.permissions,
       args.main_module,
@@ -171,6 +175,7 @@ fn create_web_worker_callback(ps: ProcState) -> Arc<CreateWebWorkerCb> {
       }
       js_runtime.sync_ops_cache();
     }
+    worker.bootstrap(&bootstrap_options);
 
     (worker, external_handle)
   })

--- a/runtime/examples/hello_runtime.rs
+++ b/runtime/examples/hello_runtime.rs
@@ -7,6 +7,7 @@ use deno_runtime::deno_web::BlobStore;
 use deno_runtime::permissions::Permissions;
 use deno_runtime::worker::MainWorker;
 use deno_runtime::worker::WorkerOptions;
+use deno_runtime::BootstrapOptions;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -23,11 +24,18 @@ async fn main() -> Result<(), AnyError> {
   });
 
   let options = WorkerOptions {
-    apply_source_maps: false,
-    args: vec![],
-    debug_flag: false,
-    unstable: false,
-    enable_testing_features: false,
+    bootstrap: BootstrapOptions {
+      apply_source_maps: false,
+      args: vec![],
+      cpu_count: 1,
+      debug_flag: false,
+      enable_testing_features: false,
+      location: None,
+      no_color: false,
+      runtime_version: "x".to_string(),
+      ts_version: "x".to_string(),
+      unstable: false,
+    },
     unsafely_ignore_certificate_errors: None,
     root_cert_store: None,
     user_agent: "hello_runtime".to_string(),
@@ -37,17 +45,12 @@ async fn main() -> Result<(), AnyError> {
     maybe_inspector_server: None,
     should_break_on_first_statement: false,
     module_loader,
-    runtime_version: "x".to_string(),
-    ts_version: "x".to_string(),
-    no_color: false,
     get_error_class_fn: Some(&get_error_class_name),
-    location: None,
     origin_storage_dir: None,
     blob_store: BlobStore::default(),
     broadcast_channel: InMemoryBroadcastChannel::default(),
     shared_array_buffer_store: None,
     compiled_wasm_module_store: None,
-    cpu_count: 1,
   };
 
   let js_path =
@@ -55,9 +58,11 @@ async fn main() -> Result<(), AnyError> {
   let main_module = deno_core::resolve_path(&js_path.to_string_lossy())?;
   let permissions = Permissions::allow_all();
 
-  let mut worker =
-    MainWorker::from_options(main_module.clone(), permissions, &options);
-  worker.bootstrap(&options);
+  let mut worker = MainWorker::bootstrap_from_options(
+    main_module.clone(),
+    permissions,
+    options,
+  );
   worker.execute_main_module(&main_module).await?;
   worker.run_event_loop(false).await?;
   Ok(())

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -27,3 +27,6 @@ pub mod permissions;
 pub mod tokio_util;
 pub mod web_worker;
 pub mod worker;
+
+mod worker_bootstrap;
+pub use worker_bootstrap::BootstrapOptions;

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -1,0 +1,48 @@
+use crate::ops::runtime::ppid;
+use deno_core::serde_json;
+use deno_core::serde_json::json;
+use deno_core::ModuleSpecifier;
+
+/// Common bootstrap options for MainWorker & WebWorker
+#[derive(Clone)]
+pub struct BootstrapOptions {
+  /// Sets `Deno.args` in JS runtime.
+  pub args: Vec<String>,
+  pub apply_source_maps: bool,
+  pub cpu_count: usize,
+  pub debug_flag: bool,
+  pub enable_testing_features: bool,
+  pub location: Option<ModuleSpecifier>,
+  /// Sets `Deno.noColor` in JS runtime.
+  pub no_color: bool,
+  /// Sets `Deno.version.deno` in JS runtime.
+  pub runtime_version: String,
+  /// Sets `Deno.version.typescript` in JS runtime.
+  pub ts_version: String,
+  pub unstable: bool,
+}
+
+impl BootstrapOptions {
+  pub fn as_json(&self) -> String {
+    let payload = json!({
+      // Shared bootstrap args
+      "args": self.args,
+      "applySourceMaps": self.apply_source_maps,
+      "cpuCount": self.cpu_count,
+      "debugFlag": self.debug_flag,
+      "denoVersion": self.runtime_version,
+      "location": self.location,
+      "noColor": self.no_color,
+      "tsVersion": self.ts_version,
+      "unstableFlag": self.unstable,
+      // Web worker only
+      "enableTestingFeaturesFlag": self.enable_testing_features,
+      // Env values
+      "pid": std::process::id(),
+      "ppid": ppid(),
+      "target": env!("TARGET"),
+      "v8Version": deno_core::v8_version(),
+    });
+    serde_json::to_string_pretty(&payload).unwrap()
+  }
+}


### PR DESCRIPTION
## Notes

- Factors out shared portions of WorkerOptions & WebWorkerOptions to BootstrapOptions
- Adds ::bootstrap_from_options() methods
- Passes options by value instead of by ref so that we can mutate them and drain a vec of extensions passed
- I suppose the main reason we passed them by ref is that we had to repass them to .bootstrap()
- Conceptually, BootstrapOptions holds "higher-level" nice-to-have options compared to the rest of WorkerOptions that are closer tied to internal rust-side mechanics