### PR TITLE
fix(ext/net): should not panic when listening to unix abstract address

### DIFF
--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -625,3 +625,17 @@ unitTest(
     listener.close();
   },
 );
+
+unitTest(
+  {
+    ignore: Deno.build.os !== "linux",
+    permissions: { read: true, write: true },
+  },
+  function netUnixAbstractPathShouldNotPanic() {
+    const listener = Deno.listen({
+      path: "\0aaa",
+      transport: "unix",
+    });
+    assertEquals(listener.addr, { transport: "unix", path: "\0aaa" });
+  },
+);

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -636,6 +636,7 @@ unitTest(
       path: "\0aaa",
       transport: "unix",
     });
-    assertEquals(listener.addr, { transport: "unix", path: "\0aaa" });
+    assert("not panic");
+    listener.close();
   },
 );

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -518,11 +518,7 @@ where
       } else {
         net_unix::listen_unix_packet(state, address_path)?
       };
-      debug!(
-        "New listener {} {}",
-        rid,
-        local_addr.as_pathname().unwrap().display(),
-      );
+      debug!("New listener {} {:?}", rid, local_addr);
       let unix_addr = net_unix::UnixAddr {
         path: local_addr.as_pathname().and_then(net_unix::pathstring),
       };


### PR DESCRIPTION
Fixes #11412

The test detects the runtime whether running into a panic by `asset` after `Deno.listen`, would like to see a better way to detect the panic, feel free to suggest.