### PR TITLE
chore(docs): remove unstable requirement for `deno test --coverage` in help text

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1260,7 +1260,7 @@ fn test_subcommand<'a, 'b>() -> App<'a, 'b> {
         .value_name("DIR")
         .conflicts_with("inspect")
         .conflicts_with("inspect-brk")
-        .help("UNSTABLE: Collect coverage profile data into DIR"),
+        .help("Collect coverage profile data into DIR"),
     )
     .arg(
       Arg::with_name("jobs")


### PR DESCRIPTION
This PR updates the output of `deno test --help`, which is saying `--coverage` is unstable even though`--unstable` doesn't have to be provided anymore.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
