### PR TITLE
perf(core): use opcall() directly

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -97,11 +97,6 @@
     }
   }
 
-  function dispatch(opName, promiseId, control, zeroCopy) {
-    const opId = typeof opName === "string" ? opsCache[opName] : opName;
-    return opcall(opId, promiseId, control, zeroCopy);
-  }
-
   function registerErrorClass(className, errorClass) {
     registerErrorBuilder(className, (msg) => new errorClass(msg));
   }
@@ -130,14 +125,14 @@
 
   function opAsync(opName, arg1 = null, arg2 = null) {
     const promiseId = nextPromiseId++;
-    const maybeError = dispatch(opName, promiseId, arg1, arg2);
+    const maybeError = opcall(opsCache[opName], promiseId, arg1, arg2);
     // Handle sync error (e.g: error parsing args)
     if (maybeError) return unwrapOpResult(maybeError);
     return PromisePrototypeThen(setPromise(promiseId), unwrapOpResult);
   }
 
   function opSync(opName, arg1 = null, arg2 = null) {
-    return unwrapOpResult(dispatch(opName, null, arg1, arg2));
+    return unwrapOpResult(opcall(opsCache[opName], null, arg1, arg2));
   }
 
   function resources() {

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1848,7 +1848,7 @@ pub mod tests {
           r#"
           let thrown;
           try {
-            Deno.core.opSync(100);
+            Deno.core.opcall(100, null, null, null);
           } catch (e) {
             thrown = e;
           }


### PR DESCRIPTION
Instead of the wrapper dispatch() func, also now forbids passing opIds to opSync()/opAsync() callers must always pass names.

This is admittedly a micro-optimization, it shaves off ~10ns/iter for async ops and ~4ns/iter for sync ops (though on the scale of sync ops that's ~7%), it's half micro-optimization and half cleanup:

```
Before:
bench async:     393,383 ns/iter (+/- 6,025)
bench nop:      50,881 ns/iter (+/- 1,073)
bench sync:      57,920 ns/iter (+/- 669)

After:
bench async:     380,437 ns/iter (+/- 8,691)
bench nop:      46,860 ns/iter (+/- 1,470)
bench sync:      54,840 ns/iter (+/- 1,499)
```