### PR TITLE
refactor(core): move PromiseRing to rust

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -9,19 +9,12 @@
     SyntaxError,
     TypeError,
     URIError,
-    Map,
-    Array,
-    ArrayPrototypeFill,
     ArrayPrototypeMap,
     ErrorCaptureStackTrace,
-    Promise,
     ObjectEntries,
     ObjectFreeze,
     ObjectFromEntries,
-    MapPrototypeGet,
-    MapPrototypeDelete,
-    MapPrototypeSet,
-    PromisePrototypeThen,
+    PromisePrototypeCatch,
     ObjectAssign,
   } = window.__bootstrap.primordials;
 
@@ -38,50 +31,6 @@
   registerErrorClass("TypeError", TypeError);
   registerErrorClass("URIError", URIError);
 
-  let nextPromiseId = 1;
-  const promiseMap = new Map();
-  const RING_SIZE = 4 * 1024;
-  const NO_PROMISE = null; // Alias to null is faster than plain nulls
-  const promiseRing = ArrayPrototypeFill(new Array(RING_SIZE), NO_PROMISE);
-
-  function setPromise(promiseId) {
-    const idx = promiseId % RING_SIZE;
-    // Move old promise from ring to map
-    const oldPromise = promiseRing[idx];
-    if (oldPromise !== NO_PROMISE) {
-      const oldPromiseId = promiseId - RING_SIZE;
-      MapPrototypeSet(promiseMap, oldPromiseId, oldPromise);
-    }
-    // Set new promise
-    return promiseRing[idx] = newPromise();
-  }
-
-  function getPromise(promiseId) {
-    // Check if out of ring bounds, fallback to map
-    const outOfBounds = promiseId < nextPromiseId - RING_SIZE;
-    if (outOfBounds) {
-      const promise = MapPrototypeGet(promiseMap, promiseId);
-      MapPrototypeDelete(promiseMap, promiseId);
-      return promise;
-    }
-    // Otherwise take from ring
-    const idx = promiseId % RING_SIZE;
-    const promise = promiseRing[idx];
-    promiseRing[idx] = NO_PROMISE;
-    return promise;
-  }
-
-  function newPromise() {
-    let resolve, reject;
-    const promise = new Promise((resolve_, reject_) => {
-      resolve = resolve_;
-      reject = reject_;
-    });
-    promise.resolve = resolve;
-    promise.reject = reject;
-    return promise;
-  }
-
   function ops() {
     return opsCache;
   }
@@ -89,15 +38,6 @@
   function syncOpsCache() {
     // op id 0 is a special value to retrieve the map of registered ops.
     opsCache = ObjectFreeze(ObjectFromEntries(opcallSync(0)));
-  }
-
-  function opresolve() {
-    for (let i = 0; i < arguments.length; i += 2) {
-      const promiseId = arguments[i];
-      const res = arguments[i + 1];
-      const promise = getPromise(promiseId);
-      promise.resolve(res);
-    }
   }
 
   function registerErrorClass(className, errorClass) {
@@ -127,11 +67,11 @@
   }
 
   function opAsync(opName, arg1 = null, arg2 = null) {
-    const promiseId = nextPromiseId++;
-    const maybeError = opcallAsync(opsCache[opName], promiseId, arg1, arg2);
+    const promiseOrErr = opcallAsync(opsCache[opName], arg1, arg2);
     // Handle sync error (e.g: error parsing args)
-    if (maybeError) return unwrapOpResult(maybeError);
-    return PromisePrototypeThen(setPromise(promiseId), unwrapOpResult);
+    const promise = unwrapOpResult(promiseOrErr);
+    // TODO(@AaronO): remove by moving rejection rust-side
+    return PromisePrototypeCatch(promise, unwrapOpResult);
   }
 
   function opSync(opName, arg1 = null, arg2 = null) {
@@ -192,7 +132,6 @@
     metrics,
     registerErrorBuilder,
     registerErrorClass,
-    opresolve,
     syncOpsCache,
     BadResource,
     Interrupted,

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -9,7 +9,6 @@ use crate::OpId;
 use crate::OpPayload;
 use crate::OpResult;
 use crate::OpTable;
-use crate::PromiseId;
 use crate::ZeroCopyBuf;
 use log::debug;
 use rusty_v8 as v8;
@@ -372,7 +371,6 @@ fn opcall_async<'s>(
   mut rv: v8::ReturnValue,
 ) {
   let state_rc = JsRuntime::state(scope);
-  let mut state = state_rc.borrow_mut();
 
   let op_id = match v8::Local::<v8::Integer>::try_from(args.get(0))
     .map(|l| l.value() as OpId)
@@ -385,24 +383,13 @@ fn opcall_async<'s>(
     }
   };
 
-  // PromiseId
-  let arg1 = args.get(1);
-  let promise_id = v8::Local::<v8::Integer>::try_from(arg1)
-    .map(|l| l.value() as PromiseId)
-    .map_err(AnyError::from);
-  // Fail if promise id invalid (not an int)
-  let promise_id: PromiseId = match promise_id {
-    Ok(promise_id) => promise_id,
-    Err(err) => {
-      throw_type_error(scope, format!("invalid promise id: {}", err));
-      return;
-    }
-  };
-
   // Deserializable args (may be structured args or ZeroCopyBuf)
-  let a = args.get(2);
-  let b = args.get(3);
+  let a = args.get(1);
+  let b = args.get(2);
 
+  let op_state = state_rc.borrow().op_state.clone();
+  let mut state = state_rc.borrow_mut();
+  let promise_id = state.promise_ring.as_ref().unwrap().head();
   let payload = OpPayload {
     scope,
     a,
@@ -410,7 +397,7 @@ fn opcall_async<'s>(
     op_id,
     promise_id,
   };
-  let op = OpTable::route_op(op_id, state.op_state.clone(), payload);
+  let op = OpTable::route_op(op_id, op_state, payload);
   match op {
     Op::Sync(result) => match result {
       OpResult::Ok(_) => throw_type_error(
@@ -423,11 +410,21 @@ fn opcall_async<'s>(
       state.op_state.borrow_mut().tracker.track_async(op_id);
       state.pending_ops.push(fut);
       state.have_unpolled_ops = true;
+      let resolver = v8::PromiseResolver::new(scope).unwrap();
+      let promise = resolver.get_promise(scope);
+      rv.set(promise.into());
+      let resolver = v8::Global::new(scope, resolver);
+      state.promise_ring.as_mut().unwrap().put(resolver);
     }
     Op::AsyncUnref(fut) => {
       state.op_state.borrow_mut().tracker.track_unref(op_id);
       state.pending_unref_ops.push(fut);
       state.have_unpolled_ops = true;
+      let resolver = v8::PromiseResolver::new(scope).unwrap();
+      let promise = resolver.get_promise(scope);
+      rv.set(promise.into());
+      let resolver = v8::Global::new(scope, resolver);
+      state.promise_ring.as_mut().unwrap().put(resolver);
     }
     Op::NotFound => {
       throw_type_error(scope, format!("Unknown op id: {}", op_id));

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -14,6 +14,7 @@ mod ops;
 mod ops_builtin;
 mod ops_json;
 mod ops_metrics;
+mod promise_ring;
 mod resources;
 mod runtime;
 

--- a/core/promise_ring.rs
+++ b/core/promise_ring.rs
@@ -18,12 +18,9 @@ pub struct PromiseRing {
 
 impl PromiseRing {
   pub(crate) fn new() -> Self {
-    // let mut ring = Vec::with_capacity(RING_SIZE);
-    // ring.fill(None);
     Self {
       len: 0,
       cursor: 0,
-      // ring,
       ring: vec![None; RING_SIZE],
       map: BTreeMap::new(),
     }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -394,6 +394,8 @@ impl JsRuntime {
     js_runtime.init_cbs();
     // Sync ops cache
     js_runtime.sync_ops_cache();
+    // Run microtasks explicitly
+    js_runtime.v8_isolate().set_microtasks_policy(v8::MicrotasksPolicy::Explicit);
 
     js_runtime
   }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -395,7 +395,9 @@ impl JsRuntime {
     // Sync ops cache
     js_runtime.sync_ops_cache();
     // Run microtasks explicitly
-    js_runtime.v8_isolate().set_microtasks_policy(v8::MicrotasksPolicy::Explicit);
+    js_runtime
+      .v8_isolate()
+      .set_microtasks_policy(v8::MicrotasksPolicy::Explicit);
 
     js_runtime
   }


### PR DESCRIPTION
This is actually moderately slower than the current implementation, but will be about 25% faster (~400ns => ~300ns) once we move error throwing to rust (replacing `unwrapOpResult` JS side) since we can avoid an extra `.then`/`.catch` whilst improving stack traces in theory ...