### PR TITLE
chore: various op cleanup

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -67,10 +67,6 @@ pub fn resource_unavailable() -> AnyError {
   )
 }
 
-pub fn null_opbuf() -> AnyError {
-  type_error("expected non-null op buffer arg")
-}
-
 /// A simple error type that lets the creator specify both the error message and
 /// the error class name. This type is private; externally it only ever appears
 /// wrapped in an `AnyError`. To retrieve the error class name from a wrapped

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
-use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
 use deno_core::AsyncRefCell;
 use deno_core::CancelHandle;
@@ -121,7 +120,7 @@ fn create_js_runtime() -> JsRuntime {
 
 fn op_listen(
   state: &mut OpState,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<ResourceId, AnyError> {
   log::debug!("listen");
@@ -158,9 +157,8 @@ async fn op_accept(
 async fn op_read(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  buf: Option<ZeroCopyBuf>,
+  mut buf: ZeroCopyBuf,
 ) -> Result<usize, AnyError> {
-  let mut buf = buf.ok_or_else(null_opbuf)?;
   log::debug!("read rid={}", rid);
 
   let stream = state.borrow().resource_table.get::<TcpStream>(rid)?;
@@ -171,9 +169,8 @@ async fn op_read(
 async fn op_write(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  buf: Option<ZeroCopyBuf>,
+  buf: ZeroCopyBuf,
 ) -> Result<usize, AnyError> {
-  let buf = buf.ok_or_else(null_opbuf)?;
   log::debug!("write rid={}", rid);
 
   let stream = state.borrow().resource_table.get::<TcpStream>(rid)?;

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -34,7 +34,7 @@ pub(crate) fn init_builtins() -> Extension {
 /// and string representation as value.
 pub fn op_resources(
   state: &mut OpState,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<Vec<(ResourceId, String)>, AnyError> {
   let serialized_resources = state

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1919,11 +1919,7 @@ pub mod tests {
 
   #[test]
   fn test_error_builder() {
-    fn op_err(
-      _: &mut OpState,
-      _: (),
-      _: Option<ZeroCopyBuf>,
-    ) -> Result<(), AnyError> {
+    fn op_err(_: &mut OpState, _: (), _: ()) -> Result<(), AnyError> {
       Err(custom_error("DOMExceptionOperationError", "abc"))
     }
 

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -45,8 +45,8 @@ struct Unstable(bool); // --unstable
 
 pub fn op_broadcast_subscribe<BC: BroadcastChannel + 'static>(
   state: &mut OpState,
-  _args: (),
-  _buf: (),
+  _: (),
+  _: (),
 ) -> Result<ResourceId, AnyError> {
   let unstable = state.borrow::<Unstable>().0;
 
@@ -85,7 +85,7 @@ pub async fn op_broadcast_send<BC: BroadcastChannel + 'static>(
 pub async fn op_broadcast_recv<BC: BroadcastChannel + 'static>(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  _buf: (),
+  _: (),
 ) -> Result<Option<Message>, AnyError> {
   let resource = state.borrow().resource_table.get::<BC::Resource>(rid)?;
   let bc = state.borrow().borrow::<BC>().clone();

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -2,7 +2,6 @@
 
 use deno_core::error::custom_error;
 use deno_core::error::not_supported;
-use deno_core::error::null_opbuf;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::include_js_files;
@@ -296,9 +295,8 @@ pub struct SignArg {
 pub async fn op_crypto_sign_key(
   _state: Rc<RefCell<OpState>>,
   args: SignArg,
-  zero_copy: Option<ZeroCopyBuf>,
+  zero_copy: ZeroCopyBuf,
 ) -> Result<ZeroCopyBuf, AnyError> {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let data = &*zero_copy;
   let algorithm = args.algorithm;
 
@@ -451,9 +449,8 @@ pub struct VerifyArg {
 pub async fn op_crypto_verify_key(
   _state: Rc<RefCell<OpState>>,
   args: VerifyArg,
-  zero_copy: Option<ZeroCopyBuf>,
+  zero_copy: ZeroCopyBuf,
 ) -> Result<bool, AnyError> {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let data = &*zero_copy;
   let algorithm = args.algorithm;
 
@@ -599,7 +596,7 @@ pub struct ExportKeyArg {
 pub async fn op_crypto_export_key(
   _state: Rc<RefCell<OpState>>,
   args: ExportKeyArg,
-  _zero_copy: Option<ZeroCopyBuf>,
+  _: (),
 ) -> Result<ZeroCopyBuf, AnyError> {
   let algorithm = args.algorithm;
   match algorithm {
@@ -731,9 +728,8 @@ pub struct DeriveKeyArg {
 pub async fn op_crypto_derive_bits(
   _state: Rc<RefCell<OpState>>,
   args: DeriveKeyArg,
-  zero_copy: Option<ZeroCopyBuf>,
+  zero_copy: ZeroCopyBuf,
 ) -> Result<ZeroCopyBuf, AnyError> {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let salt = &*zero_copy;
   let algorithm = args.algorithm;
   match algorithm {
@@ -798,9 +794,8 @@ pub struct EncryptArg {
 pub async fn op_crypto_encrypt_key(
   _state: Rc<RefCell<OpState>>,
   args: EncryptArg,
-  zero_copy: Option<ZeroCopyBuf>,
+  zero_copy: ZeroCopyBuf,
 ) -> Result<ZeroCopyBuf, AnyError> {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let data = &*zero_copy;
   let algorithm = args.algorithm;
 
@@ -1035,9 +1030,8 @@ pub struct ImportKeyResult {
 pub async fn op_crypto_import_key(
   _state: Rc<RefCell<OpState>>,
   args: ImportKeyArg,
-  zero_copy: Option<ZeroCopyBuf>,
+  zero_copy: ZeroCopyBuf,
 ) -> Result<ImportKeyResult, AnyError> {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let data = &*zero_copy;
   let algorithm = args.algorithm;
 
@@ -1359,9 +1353,8 @@ pub struct DecryptArg {
 pub async fn op_crypto_decrypt_key(
   _state: Rc<RefCell<OpState>>,
   args: DecryptArg,
-  zero_copy: Option<ZeroCopyBuf>,
+  zero_copy: ZeroCopyBuf,
 ) -> Result<ZeroCopyBuf, AnyError> {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let data = &*zero_copy;
   let algorithm = args.algorithm;
 
@@ -1431,11 +1424,10 @@ pub fn op_crypto_random_uuid(
 pub async fn op_crypto_subtle_digest(
   _state: Rc<RefCell<OpState>>,
   algorithm: CryptoHash,
-  data: Option<ZeroCopyBuf>,
+  data: ZeroCopyBuf,
 ) -> Result<ZeroCopyBuf, AnyError> {
-  let input = data.ok_or_else(null_opbuf)?;
   let output = tokio::task::spawn_blocking(move || {
-    digest::digest(algorithm.into(), &input)
+    digest::digest(algorithm.into(), &data)
       .as_ref()
       .to_vec()
       .into()

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use data_url::DataUrl;
-use deno_core::error::null_opbuf;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::futures::Future;
@@ -354,10 +353,9 @@ pub async fn op_fetch_send(
 pub async fn op_fetch_request_write(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  data: Option<ZeroCopyBuf>,
+  data: ZeroCopyBuf,
 ) -> Result<(), AnyError> {
-  let data = data.ok_or_else(null_opbuf)?;
-  let buf = Vec::from(&*data);
+  let buf = data.to_vec();
 
   let resource = state
     .borrow()
@@ -375,10 +373,8 @@ pub async fn op_fetch_request_write(
 pub async fn op_fetch_response_read(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  data: Option<ZeroCopyBuf>,
+  data: ZeroCopyBuf,
 ) -> Result<usize, AnyError> {
-  let data = data.ok_or_else(null_opbuf)?;
-
   let resource = state
     .borrow()
     .resource_table

--- a/ext/net/io.rs
+++ b/ext/net/io.rs
@@ -2,7 +2,6 @@
 
 use crate::ops_tls as tls;
 use deno_core::error::not_supported;
-use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
 use deno_core::op_async;
 use deno_core::AsyncMutFuture;
@@ -166,16 +165,15 @@ impl Resource for UnixStreamResource {
 async fn op_read_async(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  buf: Option<ZeroCopyBuf>,
+  mut buf: ZeroCopyBuf,
 ) -> Result<u32, AnyError> {
-  let buf = &mut buf.ok_or_else(null_opbuf)?;
   let resource = state.borrow().resource_table.get_any(rid)?;
   let nread = if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {
-    s.read(buf).await?
+    s.read(&mut buf).await?
   } else if let Some(s) = resource.downcast_rc::<TlsStreamResource>() {
-    s.read(buf).await?
+    s.read(&mut buf).await?
   } else if let Some(s) = resource.downcast_rc::<UnixStreamResource>() {
-    s.read(buf).await?
+    s.read(&mut buf).await?
   } else {
     return Err(not_supported());
   };
@@ -185,16 +183,15 @@ async fn op_read_async(
 async fn op_write_async(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
-  buf: Option<ZeroCopyBuf>,
+  buf: ZeroCopyBuf,
 ) -> Result<u32, AnyError> {
-  let buf = &buf.ok_or_else(null_opbuf)?;
   let resource = state.borrow().resource_table.get_any(rid)?;
   let nwritten = if let Some(s) = resource.downcast_rc::<TcpStreamResource>() {
-    s.write(buf).await?
+    s.write(&buf).await?
   } else if let Some(s) = resource.downcast_rc::<TlsStreamResource>() {
-    s.write(buf).await?
+    s.write(&buf).await?
   } else if let Some(s) = resource.downcast_rc::<UnixStreamResource>() {
-    s.write(buf).await?
+    s.write(&buf).await?
   } else {
     return Err(not_supported());
   };

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -7,7 +7,6 @@ use crate::NetPermissions;
 use deno_core::error::bad_resource;
 use deno_core::error::custom_error;
 use deno_core::error::generic_error;
-use deno_core::error::null_opbuf;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::op_async;
@@ -167,9 +166,8 @@ pub(crate) struct ReceiveArgs {
 async fn receive_udp(
   state: Rc<RefCell<OpState>>,
   args: ReceiveArgs,
-  zero_copy: Option<ZeroCopyBuf>,
+  zero_copy: ZeroCopyBuf,
 ) -> Result<OpPacket, AnyError> {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let mut zero_copy = zero_copy.clone();
 
   let rid = args.rid;
@@ -197,7 +195,7 @@ async fn receive_udp(
 async fn op_datagram_receive(
   state: Rc<RefCell<OpState>>,
   args: ReceiveArgs,
-  zero_copy: Option<ZeroCopyBuf>,
+  zero_copy: ZeroCopyBuf,
 ) -> Result<OpPacket, AnyError> {
   match args.transport.as_str() {
     "udp" => receive_udp(state, args, zero_copy).await,
@@ -218,12 +216,11 @@ struct SendArgs {
 async fn op_datagram_send<NP>(
   state: Rc<RefCell<OpState>>,
   args: SendArgs,
-  zero_copy: Option<ZeroCopyBuf>,
+  zero_copy: ZeroCopyBuf,
 ) -> Result<usize, AnyError>
 where
   NP: NetPermissions + 'static,
 {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let zero_copy = zero_copy.clone();
 
   match args {

--- a/ext/net/ops_unix.rs
+++ b/ext/net/ops_unix.rs
@@ -8,7 +8,6 @@ use crate::ops::OpPacket;
 use crate::ops::ReceiveArgs;
 use deno_core::error::bad_resource;
 use deno_core::error::custom_error;
-use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
 use deno_core::AsyncRefCell;
 use deno_core::CancelHandle;
@@ -114,10 +113,8 @@ pub(crate) async fn accept_unix(
 pub(crate) async fn receive_unix_packet(
   state: Rc<RefCell<OpState>>,
   args: ReceiveArgs,
-  buf: Option<ZeroCopyBuf>,
+  mut buf: ZeroCopyBuf,
 ) -> Result<OpPacket, AnyError> {
-  let mut buf = buf.ok_or_else(null_opbuf)?;
-
   let rid = args.rid;
 
   let resource = state

--- a/ext/timers/lib.rs
+++ b/ext/timers/lib.rs
@@ -102,7 +102,7 @@ impl GlobalTimer {
 
 pub fn op_global_timer_stop(
   state: &mut OpState,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<(), AnyError> {
   let global_timer = state.borrow_mut::<GlobalTimer>();
@@ -136,7 +136,7 @@ pub fn op_global_timer_start(
 
 pub async fn op_global_timer(
   state: Rc<RefCell<OpState>>,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<(), AnyError> {
   let maybe_timer_fut = {

--- a/ext/webgpu/buffer.rs
+++ b/ext/webgpu/buffer.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::null_opbuf;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::futures::channel::oneshot;
@@ -171,9 +170,8 @@ pub struct BufferGetMappedRangeArgs {
 pub fn op_webgpu_buffer_get_mapped_range(
   state: &mut OpState,
   args: BufferGetMappedRangeArgs,
-  zero_copy: Option<ZeroCopyBuf>,
+  mut zero_copy: ZeroCopyBuf,
 ) -> Result<WebGpuResult, AnyError> {
-  let mut zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let instance = state.borrow::<super::Instance>();
   let buffer_resource =
     state.resource_table.get::<WebGpuBuffer>(args.buffer_rid)?;

--- a/ext/webgpu/queue.rs
+++ b/ext/webgpu/queue.rs
@@ -2,7 +2,6 @@
 
 use std::num::NonZeroU32;
 
-use deno_core::error::null_opbuf;
 use deno_core::error::AnyError;
 use deno_core::OpState;
 use deno_core::ResourceId;
@@ -77,9 +76,8 @@ pub struct QueueWriteBufferArgs {
 pub fn op_webgpu_write_buffer(
   state: &mut OpState,
   args: QueueWriteBufferArgs,
-  zero_copy: Option<ZeroCopyBuf>,
+  zero_copy: ZeroCopyBuf,
 ) -> Result<WebGpuResult, AnyError> {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let instance = state.borrow::<super::Instance>();
   let buffer_resource = state
     .resource_table
@@ -116,9 +114,8 @@ pub struct QueueWriteTextureArgs {
 pub fn op_webgpu_write_texture(
   state: &mut OpState,
   args: QueueWriteTextureArgs,
-  zero_copy: Option<ZeroCopyBuf>,
+  zero_copy: ZeroCopyBuf,
 ) -> Result<WebGpuResult, AnyError> {
-  let zero_copy = zero_copy.ok_or_else(null_opbuf)?;
   let instance = state.borrow::<super::Instance>();
   let texture_resource = state
     .resource_table

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -324,10 +324,10 @@
       const sendTypedArray = (ta) => {
         this[_bufferedAmount] += ta.byteLength;
         PromisePrototypeThen(
-          core.opAsync("op_ws_send", {
-            rid: this[_rid],
+          core.opAsync("op_ws_send", this[_rid], {
             kind: "binary",
-          }, ta),
+            value: ta,
+          }),
           () => {
             this[_bufferedAmount] -= ta.byteLength;
           },
@@ -348,10 +348,9 @@
         const d = core.encode(string);
         this[_bufferedAmount] += d.byteLength;
         PromisePrototypeThen(
-          core.opAsync("op_ws_send", {
-            rid: this[_rid],
+          core.opAsync("op_ws_send", this[_rid], {
             kind: "text",
-            text: string,
+            value: string,
           }),
           () => {
             this[_bufferedAmount] -= d.byteLength;
@@ -456,8 +455,7 @@
             break;
           }
           case "ping": {
-            core.opAsync("op_ws_send", {
-              rid: this[_rid],
+            core.opAsync("op_ws_send", this[_rid], {
               kind: "pong",
             });
             break;

--- a/ext/websocket/02_websocketstream.js
+++ b/ext/websocket/02_websocketstream.js
@@ -190,15 +190,14 @@
               const writable = new WritableStream({
                 write: async (chunk) => {
                   if (typeof chunk === "string") {
-                    await core.opAsync("op_ws_send", {
-                      rid: this[_rid],
+                    await core.opAsync("op_ws_send", this[_rid], {
                       kind: "text",
-                      text: chunk,
+                      value: chunk,
                     });
                   } else if (chunk instanceof Uint8Array) {
-                    await core.opAsync("op_ws_send", {
-                      rid: this[_rid],
+                    await core.opAsync("op_ws_send", this[_rid], {
                       kind: "binary",
+                      value: chunk,
                     }, chunk);
                   } else {
                     throw new TypeError(
@@ -257,8 +256,7 @@
                       break;
                     }
                     case "ping": {
-                      await core.opAsync("op_ws_send", {
-                        rid: this[_rid],
+                      await core.opAsync("op_ws_send", this[_rid], {
                         kind: "pong",
                       });
                       break;

--- a/runtime/js/30_os.js
+++ b/runtime/js/30_os.js
@@ -49,7 +49,7 @@
   }
 
   function setEnv(key, value) {
-    core.opSync("op_set_env", { key, value });
+    core.opSync("op_set_env", key, value);
   }
 
   function getEnv(key) {

--- a/runtime/metrics.rs
+++ b/runtime/metrics.rs
@@ -27,7 +27,7 @@ struct MetricsReturn {
 
 fn op_metrics(
   state: &mut OpState,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<MetricsReturn, AnyError> {
   let m = state.borrow::<RuntimeMetrics>();

--- a/runtime/ops/fs.rs
+++ b/runtime/ops/fs.rs
@@ -1769,7 +1769,7 @@ async fn op_utime_async(
   .unwrap()
 }
 
-fn op_cwd(state: &mut OpState, _args: (), _: ()) -> Result<String, AnyError> {
+fn op_cwd(state: &mut OpState, _: (), _: ()) -> Result<String, AnyError> {
   let path = current_dir()?;
   state
     .borrow_mut::<Permissions>()

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -7,7 +7,6 @@ use deno_core::op_sync;
 use deno_core::url::Url;
 use deno_core::Extension;
 use deno_core::OpState;
-use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::env;
@@ -29,11 +28,7 @@ pub fn init() -> Extension {
     .build()
 }
 
-fn op_exec_path(
-  state: &mut OpState,
-  _args: (),
-  _: (),
-) -> Result<String, AnyError> {
+fn op_exec_path(state: &mut OpState, _: (), _: ()) -> Result<String, AnyError> {
   let current_exe = env::current_exe().unwrap();
   state
     .borrow_mut::<Permissions>()
@@ -47,31 +42,24 @@ fn op_exec_path(
   into_string(path.into_os_string())
 }
 
-#[derive(Deserialize)]
-pub struct SetEnv {
-  key: String,
-  value: String,
-}
-
 fn op_set_env(
   state: &mut OpState,
-  args: SetEnv,
-  _: (),
+  key: String,
+  value: String,
 ) -> Result<(), AnyError> {
-  state.borrow_mut::<Permissions>().env.check(&args.key)?;
-  let invalid_key =
-    args.key.is_empty() || args.key.contains(&['=', '\0'] as &[char]);
-  let invalid_value = args.value.contains('\0');
+  state.borrow_mut::<Permissions>().env.check(&key)?;
+  let invalid_key = key.is_empty() || key.contains(&['=', '\0'] as &[char]);
+  let invalid_value = value.contains('\0');
   if invalid_key || invalid_value {
     return Err(type_error("Key or value contains invalid characters."));
   }
-  env::set_var(args.key, args.value);
+  env::set_var(key, value);
   Ok(())
 }
 
 fn op_env(
   state: &mut OpState,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<HashMap<String, String>, AnyError> {
   state.borrow_mut::<Permissions>().env.check_all()?;
@@ -113,7 +101,7 @@ fn op_exit(_state: &mut OpState, code: i32, _: ()) -> Result<(), AnyError> {
 
 fn op_loadavg(
   state: &mut OpState,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<(f64, f64, f64), AnyError> {
   super::check_unstable(state, "Deno.loadavg");
@@ -124,11 +112,7 @@ fn op_loadavg(
   }
 }
 
-fn op_hostname(
-  state: &mut OpState,
-  _args: (),
-  _: (),
-) -> Result<String, AnyError> {
+fn op_hostname(state: &mut OpState, _: (), _: ()) -> Result<String, AnyError> {
   super::check_unstable(state, "Deno.hostname");
   state.borrow_mut::<Permissions>().env.check_all()?;
   let hostname = sys_info::hostname().unwrap_or_else(|_| "".to_string());
@@ -137,7 +121,7 @@ fn op_hostname(
 
 fn op_os_release(
   state: &mut OpState,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<String, AnyError> {
   super::check_unstable(state, "Deno.osRelease");
@@ -161,7 +145,7 @@ struct MemInfo {
 
 fn op_system_memory_info(
   state: &mut OpState,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<Option<MemInfo>, AnyError> {
   super::check_unstable(state, "Deno.systemMemoryInfo");

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -20,7 +20,7 @@ pub fn init(main_module: ModuleSpecifier) -> Extension {
 
 fn op_main_module(
   state: &mut OpState,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<String, AnyError> {
   let main = state.borrow::<ModuleSpecifier>().to_string();

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -224,7 +224,7 @@ pub fn op_signal_unbind(
 #[cfg(not(unix))]
 pub fn op_signal_bind(
   _state: &mut OpState,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<(), AnyError> {
   Err(generic_error("not implemented"))
@@ -233,7 +233,7 @@ pub fn op_signal_bind(
 #[cfg(not(unix))]
 fn op_signal_unbind(
   _state: &mut OpState,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<(), AnyError> {
   Err(generic_error("not implemented"))
@@ -242,7 +242,7 @@ fn op_signal_unbind(
 #[cfg(not(unix))]
 async fn op_signal_poll(
   _state: Rc<RefCell<OpState>>,
-  _args: (),
+  _: (),
   _: (),
 ) -> Result<(), AnyError> {
   Err(generic_error("not implemented"))


### PR DESCRIPTION
Primarily just gets rid of the `Option<ZeroCopyBuf>` and the `ok_or_else` for it which is the first thing in ops which stems from the first iteration of ZeroCopyBuf support, but doesn't make much sense anymore now.

For the webgpu related changes i will open up a PR at wgpu as well