### PR TITLE
fix(web): Format `DOMException`'s `stack` property

### DIFF
--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -96,7 +96,8 @@
       });
       this.#code = nameToCodeMapping[this.#name] ?? 0;
 
-      const error = new Error(`DOMException: ${this.#message}`);
+      const error = new Error(this.#message);
+      error.name = "DOMException";
       ObjectDefineProperty(this, "stack", {
         value: error.stack,
         writable: true,


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Related: https://github.com/denoland/deno/pull/12294

I removed the `"Error: "` string from the `DOMException`'s `stack` property.

before:

<img width="814" src="https://user-images.githubusercontent.com/2622837/136092298-82c566eb-fad7-497e-b67e-dee73a585c11.png">

after:

<img width="767" src="https://user-images.githubusercontent.com/2622837/136092315-561edabd-dcce-4805-bf73-776ca213d207.png">
