### PR TITLE
perf(webidl): fix typo from #12286

### DIFF
--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -858,6 +858,7 @@
           const typedValue = valueConverter(value, opts);
           result[typedKey] = typedValue;
         }
+        return result;
       }
       // Slow path if Proxy (e.g: in WPT tests)
       const keys = ReflectOwnKeys(V);


### PR DESCRIPTION
In a tweak commit of #12286 I accidentally eliminated the else branch ... running the slow & the fast path providing a worst of both worlds path