### PR TITLE
feat(compat): add support for node: prefixed built-ins

### DIFF
--- a/cli/compat.rs
+++ b/cli/compat.rs
@@ -53,7 +53,12 @@ pub fn get_mapped_node_builtins() -> HashMap<String, String> {
   for module in SUPPORTED_MODULES {
     // TODO(bartlomieju): this is unversioned, and should be fixed to use latest stable?
     let module_url = format!("https://deno.land/std/node/{}.ts", module);
-    mappings.insert(module.to_string(), module_url);
+    mappings.insert(module.to_string(), module_url.clone());
+
+    // Support for `node:<module_name>`
+    // https://nodejs.org/api/esm.html#esm_node_imports
+    let node_prefixed = format!("node:{}", module);
+    mappings.insert(node_prefixed, module_url);
   }
 
   mappings

--- a/cli/tests/integration/compat_tests.rs
+++ b/cli/tests/integration/compat_tests.rs
@@ -7,6 +7,11 @@ itest!(fs_promises {
   output: "compat/fs_promises.out",
 });
 
+itest!(node_prefix_fs_promises {
+  args: "run --compat --unstable -A compat/node_fs_promises.js",
+  output: "compat/fs_promises.out",
+});
+
 itest!(existing_import_map {
   args: "run --compat --import-map compat/existing_import_map.json compat/fs_promises.js",
   output: "compat/existing_import_map.out",

--- a/cli/tests/testdata/compat/node_fs_promises.js
+++ b/cli/tests/testdata/compat/node_fs_promises.js
@@ -1,0 +1,3 @@
+import fs from "node:fs/promises";
+const data = await fs.readFile("compat/test.txt", "utf-8");
+console.log(data);


### PR DESCRIPTION
Adds support for "node:" prefix for Node built-ins in "--compat" mode.

As per https://nodejs.org/api/esm.html#esm_node_imports