### PR TITLE
fix(lsp): lint diagnostics respect config file

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -314,6 +314,7 @@ async fn generate_lint_diagnostics(
 ) -> Result<DiagnosticVec, AnyError> {
   let documents = snapshot.documents.clone();
   let workspace_settings = snapshot.config.settings.workspace.clone();
+  let maybe_config_file = snapshot.maybe_config_file.clone();
   tokio::task::spawn(async move {
     let mut diagnostics_vec = Vec::new();
     if workspace_settings.lint {
@@ -333,7 +334,10 @@ async fn generate_lint_diagnostics(
             .flatten();
           let diagnostics = match module {
             Some(Ok(module)) => {
-              if let Ok(references) = analysis::get_lint_references(module) {
+              if let Ok(references) = analysis::get_lint_references(
+                module,
+                maybe_config_file.as_ref(),
+              ) {
                 references
                   .into_iter()
                   .map(|r| r.to_diagnostic())

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -73,6 +73,7 @@ pub struct StateSnapshot {
   pub assets: Assets,
   pub config: ConfigSnapshot,
   pub documents: DocumentCache,
+  pub maybe_config_file: Option<ConfigFile>,
   pub maybe_config_uri: Option<ModuleSpecifier>,
   pub module_registries: registries::ModuleRegistry,
   pub performance: Performance,
@@ -413,6 +414,7 @@ impl Inner {
         LspError::internal_error()
       })?,
       documents: self.documents.clone(),
+      maybe_config_file: self.maybe_config_file.clone(),
       maybe_config_uri: self.maybe_config_uri.clone(),
       module_registries: self.module_registries.clone(),
       performance: self.performance.clone(),

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -3561,3 +3561,39 @@ console.log(snake_case);
   );
   shutdown(&mut client);
 }
+
+#[test]
+fn lsp_lint_with_config() {
+  let temp_dir = TempDir::new().expect("could not create temp dir");
+  let mut params: lsp::InitializeParams =
+    serde_json::from_value(load_fixture("initialize_params.json")).unwrap();
+  let deno_lint_jsonc =
+    serde_json::to_vec_pretty(&load_fixture("deno.lint.jsonc")).unwrap();
+  fs::write(temp_dir.path().join("deno.lint.jsonc"), deno_lint_jsonc).unwrap();
+
+  params.root_uri = Some(Url::from_file_path(temp_dir.path()).unwrap());
+  if let Some(Value::Object(mut map)) = params.initialization_options {
+    map.insert("config".to_string(), json!("./deno.lint.jsonc"));
+    params.initialization_options = Some(Value::Object(map));
+  }
+
+  let deno_exe = deno_exe_path();
+  let mut client = LspClient::new(&deno_exe).unwrap();
+  client
+    .write_request::<_, _, Value>("initialize", params)
+    .unwrap();
+
+  let diagnostics = did_open(&mut client, load_fixture("did_open_lint.json"));
+  let diagnostics = diagnostics
+    .into_iter()
+    .flat_map(|x| x.diagnostics)
+    .collect::<Vec<_>>();
+  assert_eq!(diagnostics.len(), 3);
+  for diagnostic in diagnostics {
+    assert_eq!(
+      diagnostic.code,
+      Some(lsp::NumberOrString::String("ban-untagged-todo".to_string()))
+    );
+  }
+  shutdown(&mut client);
+}

--- a/cli/tests/testdata/lsp/deno.lint.jsonc
+++ b/cli/tests/testdata/lsp/deno.lint.jsonc
@@ -1,0 +1,8 @@
+{
+  "lint": {
+    "rules": {
+      "exclude": ["camelcase"],
+      "include": ["ban-untagged-todo"]
+    }
+  }
+}

--- a/cli/tests/testdata/lsp/did_open_lint.json
+++ b/cli/tests/testdata/lsp/did_open_lint.json
@@ -1,0 +1,8 @@
+{
+  "textDocument": {
+    "uri": "file:///a/file.ts",
+    "languageId": "typescript",
+    "version": 1,
+    "text": "// TODO: fixme\nexport async function non_camel_case() {\nconsole.log(\"finished!\")\n}"
+  }
+}

--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -434,7 +434,7 @@ fn sort_diagnostics(diagnostics: &mut Vec<LintDiagnostic>) {
   });
 }
 
-fn get_configured_rules(
+pub fn get_configured_rules(
   maybe_lint_config: Option<&LintConfig>,
   rules_tags: Vec<String>,
   rules_include: Vec<String>,


### PR DESCRIPTION
This commit fixes problem with LSP where diagnostics coming
from "deno lint" don't respect configuration file.

LSP was changed to store "Option<ConfigFile>" on "Inner" and 
"StateSnapshot".

Fixes #12238