### PR TITLE
bench(op_baseline): measure Deno.core.isProxy()

### DIFF
--- a/bench_util/benches/op_baseline.rs
+++ b/bench_util/benches/op_baseline.rs
@@ -47,5 +47,15 @@ fn bench_op_async(b: &mut Bencher) {
   bench_js_async(b, r#"Deno.core.opAsync("pi_async", null);"#, setup);
 }
 
-benchmark_group!(benches, bench_op_pi_json, bench_op_nop, bench_op_async);
+fn bench_is_proxy(b: &mut Bencher) {
+  bench_js_sync(b, r#"Deno.core.isProxy(42);"#, setup);
+}
+
+benchmark_group!(
+  benches,
+  bench_op_pi_json,
+  bench_op_nop,
+  bench_op_async,
+  bench_is_proxy
+);
 bench_or_profile!(benches);


### PR DESCRIPTION
`Deno.core.isProxy()` isn't an op but it establishes a good reference point for the overhead of calling into rust (aka binding overhead, of which opcall overhead is a superset)

We're currently at ~20ns/call on M1, <10% of that is actually spent in `v8::Value::IsProxy()` and `v8::Boolean::New()`

So there's room for improvement in `rusty_v8` that would benefit bindings & opcalls, but not trivial