### PR TITLE
perf(fetch): fast path Uint8Array in extractBody()

### DIFF
--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -331,7 +331,7 @@
       if (object.type.length !== 0) {
         contentType = object.type;
       }
-    } else if(object instanceof Uint8Array) {
+    } else if (object instanceof Uint8Array) {
       // Fast(er) path for common case of Uint8Array
       const copy = TypedArrayPrototypeSlice(object, 0, object.byteLength);
       source = copy;


### PR DESCRIPTION
Reduces overhead of `new Response(pre_encoded_body)` by ~10% (~345ns/op -> ~315ns/op)