### PR TITLE
refactor(event): Deduplicate `defineEventHandler`

### DIFF
--- a/ext/broadcast_channel/01_broadcast_channel.js
+++ b/ext/broadcast_channel/01_broadcast_channel.js
@@ -7,7 +7,7 @@
 ((window) => {
   const core = window.Deno.core;
   const webidl = window.__bootstrap.webidl;
-  const { setTarget } = window.__bootstrap.event;
+  const { defineEventHandler, setTarget } = window.__bootstrap.event;
   const { DOMException } = window.__bootstrap.domException;
   const {
     ArrayPrototypeIndexOf,
@@ -15,54 +15,7 @@
     ArrayPrototypePush,
     Symbol,
     Uint8Array,
-    ObjectDefineProperty,
-    Map,
-    MapPrototypeSet,
-    MapPrototypeGet,
-    FunctionPrototypeCall,
   } = window.__bootstrap.primordials;
-
-  const handlerSymbol = Symbol("eventHandlers");
-  function makeWrappedHandler(handler) {
-    function wrappedHandler(...args) {
-      if (typeof wrappedHandler.handler !== "function") {
-        return;
-      }
-      return FunctionPrototypeCall(wrappedHandler.handler, this, ...args);
-    }
-    wrappedHandler.handler = handler;
-    return wrappedHandler;
-  }
-  // TODO(lucacasonato) reuse when we can reuse code between web crates
-  function defineEventHandler(emitter, name) {
-    // HTML specification section 8.1.5.1
-    ObjectDefineProperty(emitter, `on${name}`, {
-      get() {
-        // TODO(bnoordhuis) The "BroadcastChannel should have an onmessage
-        // event" WPT test expects that .onmessage !== undefined. Returning
-        // null makes it pass but is perhaps not exactly in the spirit.
-        if (!this[handlerSymbol]) {
-          return null;
-        }
-        return MapPrototypeGet(this[handlerSymbol], name)?.handler ?? null;
-      },
-      set(value) {
-        if (!this[handlerSymbol]) {
-          this[handlerSymbol] = new Map();
-        }
-        let handlerWrapper = MapPrototypeGet(this[handlerSymbol], name);
-        if (handlerWrapper) {
-          handlerWrapper.handler = value;
-        } else {
-          handlerWrapper = makeWrappedHandler(value);
-          this.addEventListener(name, handlerWrapper);
-        }
-        MapPrototypeSet(this[handlerSymbol], name, handlerWrapper);
-      },
-      configurable: true,
-      enumerable: true,
-    });
-  }
 
   const _name = Symbol("[[name]]");
   const _closed = Symbol("[[closed]]");

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -9,6 +9,7 @@
   const webidl = window.__bootstrap.webidl;
   const { HTTP_TOKEN_CODE_POINT_RE } = window.__bootstrap.infra;
   const { DOMException } = window.__bootstrap.domException;
+  const { defineEventHandler } = window.__bootstrap.event;
   const { Blob } = globalThis.__bootstrap.file;
   const {
     ArrayBuffer,
@@ -16,16 +17,11 @@
     ArrayPrototypeJoin,
     DataView,
     ErrorPrototypeToString,
-    ObjectDefineProperty,
-    Map,
-    MapPrototypeGet,
-    MapPrototypeSet,
     Set,
     Symbol,
     String,
     StringPrototypeToLowerCase,
     StringPrototypeEndsWith,
-    FunctionPrototypeCall,
     RegExpPrototypeTest,
     ObjectDefineProperties,
     ArrayPrototypeMap,
@@ -64,45 +60,6 @@
   const OPEN = 1;
   const CLOSING = 2;
   const CLOSED = 3;
-
-  const handlerSymbol = Symbol("eventHandlers");
-  function makeWrappedHandler(handler) {
-    function wrappedHandler(...args) {
-      if (typeof wrappedHandler.handler !== "function") {
-        return;
-      }
-      return FunctionPrototypeCall(wrappedHandler.handler, this, ...args);
-    }
-    wrappedHandler.handler = handler;
-    return wrappedHandler;
-  }
-  // TODO(lucacasonato) reuse when we can reuse code between web crates
-  function defineEventHandler(emitter, name) {
-    // HTML specification section 8.1.5.1
-    ObjectDefineProperty(emitter, `on${name}`, {
-      get() {
-        if (!this[handlerSymbol]) {
-          return null;
-        }
-        return MapPrototypeGet(this[handlerSymbol], name)?.handler;
-      },
-      set(value) {
-        if (!this[handlerSymbol]) {
-          this[handlerSymbol] = new Map();
-        }
-        let handlerWrapper = MapPrototypeGet(this[handlerSymbol], name);
-        if (handlerWrapper) {
-          handlerWrapper.handler = value;
-        } else {
-          handlerWrapper = makeWrappedHandler(value);
-          this.addEventListener(name, handlerWrapper);
-        }
-        MapPrototypeSet(this[handlerSymbol], name, handlerWrapper);
-      },
-      configurable: true,
-      enumerable: true,
-    });
-  }
 
   const _readyState = Symbol("[[readyState]]");
   const _url = Symbol("[[url]]");

--- a/runtime/js/01_web_util.js
+++ b/runtime/js/01_web_util.js
@@ -2,15 +2,7 @@
 "use strict";
 
 ((window) => {
-  const {
-    FunctionPrototypeCall,
-    Map,
-    MapPrototypeGet,
-    MapPrototypeSet,
-    ObjectDefineProperty,
-    TypeError,
-    Symbol,
-  } = window.__bootstrap.primordials;
+  const { TypeError, Symbol } = window.__bootstrap.primordials;
   const illegalConstructorKey = Symbol("illegalConstructorKey");
 
   function requiredArguments(
@@ -26,75 +18,8 @@
     }
   }
 
-  const handlerSymbol = Symbol("eventHandlers");
-  function makeWrappedHandler(handler, isSpecialErrorEventHandler) {
-    function wrappedHandler(...args) {
-      if (typeof wrappedHandler.handler !== "function") {
-        return;
-      }
-      if (isSpecialErrorEventHandler) {
-        const evt = args[0];
-        if (evt instanceof ErrorEvent && evt.type === "error") {
-          const ret = FunctionPrototypeCall(
-            wrappedHandler.handler,
-            this,
-            evt.message,
-            evt.filename,
-            evt.lineno,
-            evt.colno,
-            evt.error,
-          );
-          if (ret === true) {
-            evt.preventDefault();
-          }
-          return;
-        }
-      }
-
-      return FunctionPrototypeCall(wrappedHandler.handler, this, ...args);
-    }
-    wrappedHandler.handler = handler;
-    return wrappedHandler;
-  }
-  function defineEventHandler(
-    emitter,
-    name,
-    defaultValue = undefined,
-    isSpecialErrorEventHandler = false,
-  ) {
-    // HTML specification section 8.1.5.1
-    ObjectDefineProperty(emitter, `on${name}`, {
-      get() {
-        if (!this[handlerSymbol]) {
-          return defaultValue;
-        }
-
-        return MapPrototypeGet(this[handlerSymbol], name)?.handler ??
-          defaultValue;
-      },
-      set(value) {
-        if (!this[handlerSymbol]) {
-          this[handlerSymbol] = new Map();
-        }
-        let handlerWrapper = MapPrototypeGet(this[handlerSymbol], name);
-        if (handlerWrapper) {
-          handlerWrapper.handler = value;
-        } else {
-          handlerWrapper = makeWrappedHandler(
-            value,
-            isSpecialErrorEventHandler,
-          );
-          this.addEventListener(name, handlerWrapper);
-        }
-        MapPrototypeSet(this[handlerSymbol], name, handlerWrapper);
-      },
-      configurable: true,
-      enumerable: true,
-    });
-  }
   window.__bootstrap.webUtil = {
     illegalConstructorKey,
     requiredArguments,
-    defineEventHandler,
   };
 })(this);

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -16,7 +16,7 @@
   const { URL } = window.__bootstrap.url;
   const { getLocationHref } = window.__bootstrap.location;
   const { log, pathFromURL } = window.__bootstrap.util;
-  const { defineEventHandler } = window.__bootstrap.webUtil;
+  const { defineEventHandler } = window.__bootstrap.event;
   const { deserializeJsMessageData, serializeJsMessageData } =
     window.__bootstrap.messagePort;
 

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -59,7 +59,7 @@ delete Object.prototype.__proto__;
   const errors = window.__bootstrap.errors.errors;
   const webidl = window.__bootstrap.webidl;
   const domException = window.__bootstrap.domException;
-  const { defineEventHandler } = window.__bootstrap.webUtil;
+  const { defineEventHandler } = window.__bootstrap.event;
   const { deserializeJsMessageData, serializeJsMessageData } =
     window.__bootstrap.messagePort;
 
@@ -479,10 +479,6 @@ delete Object.prototype.__proto__;
       enumerable: true,
       get: () => navigator,
     },
-    // TODO(bartlomieju): from MDN docs (https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope)
-    // it seems those two properties should be available to workers as well
-    onload: util.writable(null),
-    onunload: util.writable(null),
     close: util.writable(windowClose),
     closed: util.getterOnly(() => windowIsClosing),
     alert: util.writable(prompt.alert),
@@ -514,8 +510,6 @@ delete Object.prototype.__proto__;
       get: () => workerNavigator,
     },
     self: util.readOnly(globalThis),
-    onmessage: util.writable(null),
-    onerror: util.writable(null),
     // TODO(bartlomieju): should be readonly?
     close: util.nonEnumerable(workerClose),
     postMessage: util.writable(postMessage),
@@ -548,8 +542,8 @@ delete Object.prototype.__proto__;
 
     eventTarget.setEventTargetData(globalThis);
 
-    defineEventHandler(window, "load", null);
-    defineEventHandler(window, "unload", null);
+    defineEventHandler(window, "load");
+    defineEventHandler(window, "unload");
 
     const isUnloadDispatched = SymbolFor("isUnloadDispatched");
     // Stores the flag for checking whether unload is dispatched or not.
@@ -646,8 +640,8 @@ delete Object.prototype.__proto__;
 
     eventTarget.setEventTargetData(globalThis);
 
-    defineEventHandler(self, "message", null);
-    defineEventHandler(self, "error", null, true);
+    defineEventHandler(self, "message");
+    defineEventHandler(self, "error", undefined, true);
 
     runtimeStart(
       runtimeOptions,

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -14979,9 +14979,9 @@
     "constructor.any.html": true,
     "constructor.any.html?wpt_flags=h2": true,
     "constructor.any.html?wss": true,
-    "eventhandlers.any.html": false,
-    "eventhandlers.any.html?wpt_flags=h2": false,
-    "eventhandlers.any.html?wss": false,
+    "eventhandlers.any.html": true,
+    "eventhandlers.any.html?wpt_flags=h2": true,
+    "eventhandlers.any.html?wss": true,
     "referrer.any.html": true,
     "Close-delayed.any.html": false,
     "Close-delayed.any.html?wpt_flags=h2": false,
@@ -15058,10 +15058,7 @@
     "interfaces": {
       "DedicatedWorkerGlobalScope": {
         "EventTarget.worker.html": true,
-        "onmessage.worker.html": [
-          "Setting onmessage to 1",
-          "Setting onmessage to 1 (again)"
-        ],
+        "onmessage.worker.html": true,
         "postMessage": {
           "return-value.worker.html": true
         }


### PR DESCRIPTION
There exist four different functions named `defineEventHandler` across the extensions and runtime code, that define an event handler attribute in an object, for an event name. The four implementations are mostly similar, having been copied off each other back when it was not easy to share code across extensions, and have evolved differences over time.

This change deduplicates them into a single `defineEventHandler` function in the `web` extension, so it is accessible from any other extension.

This deduplicated version also makes the following changes:

- Rather than having a parameter to give the event handler attribute a default value, it sets its default value to `null`. This matches the spec, which doesn't allow any other default value.
- The deduplicated version supports the `isSpecialErrorEventHandler` attribute from the `webUtil` version, which allows opting into the special behavior of `error` events in global scopes, where the event handler will be called with five arguments descriptive of the error, rather than with an error event.
- The deduplicated version supports `event`'s `init` attribute, which is an optional function which will be called when the event handler property is first set. This is needed to implement `MessagePort`'s `onmessage` property, which enables the port message queue when set.
- Setting the property to anything other than an object or function will be treated as if setting it to null, as required by Web IDL's `[LegacyTreatNonObjectAsNull]` extended attribute. This is observable when getting the property.
- It used to be that setting the property would add an event listener, even if it was set to `null`. Now the event listener is only added the first time that the property is set to an object or function.
- `mainRuntimeGlobalProperties` and `workerRuntimeGlobalProperties` used to include event handler properties, even though they would be replaced when calling `defineEventHandler` later in the bootstrap function. This change removes them from the global properties objects.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
