### PR TITLE
bench(deno_common): track op_void_sync and op_void_async

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -18,6 +18,17 @@ async function benchAsync(name, n, innerLoop) {
   console.log(benchStats(name, n, t1, t2));
 }
 
+// Parallel version benchAsync
+async function benchAsyncP(name, n, p, innerLoop) {
+  const range = new Array(p).fill(null);
+  const t1 = Date.now();
+  for (let i = 0; i < n / p; i++) {
+    await Promise.all(range.map(() => innerLoop()));
+  }
+  const t2 = Date.now();
+  console.log(benchStats(name, n, t1, t2));
+}
+
 function benchStats(name, n, t1, t2) {
   const dt = (t2 - t1) / 1e3;
   const r = n / dt;
@@ -75,9 +86,25 @@ function benchRequestNew() {
   return benchSync("request_new", 5e5, () => new Request("https://deno.land"));
 }
 
+function benchOpVoidSync() {
+  return benchSync("op_void_sync", 1e7, () => Deno.core.opSync("op_void_sync"));
+}
+
+function benchOpVoidAsync() {
+  return benchAsyncP(
+    "op_void_async",
+    1e6,
+    1e3,
+    () => Deno.core.opAsync("op_void_async"),
+  );
+}
+
 async function main() {
   // v8 builtin that's close to the upper bound non-NOPs
   benchDateNow();
+  // Void ops measure op-overhead
+  benchOpVoidSync();
+  await benchOpVoidAsync();
   // A very lightweight op, that should be highly optimizable
   benchPerfNow();
   // A common "language feature", that should be fast

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -3,6 +3,8 @@ use crate::error::AnyError;
 use crate::include_js_files;
 use crate::op_sync;
 use crate::resources::ResourceId;
+use crate::void_op_async;
+use crate::void_op_sync;
 use crate::Extension;
 use crate::OpState;
 use crate::Resource;
@@ -30,6 +32,8 @@ pub(crate) fn init_builtins() -> Extension {
         "op_wasm_streaming_set_url",
         op_sync(op_wasm_streaming_set_url),
       ),
+      ("op_void_sync", void_op_sync()),
+      ("op_void_async", void_op_async()),
     ])
     .build()
 }


### PR DESCRIPTION
Useful to track overhead of opcalls from CLI (with metrics etc...) and measure impact of https://github.com/denoland/deno/pull/12386

Before (main):
```
date_now:            	n = 500000, dt = 0.032s, r = 15625000/s, t = 64ns/op
op_void_sync:        	n = 10000000, dt = 0.980s, r = 10204082/s, t = 98ns/op
op_void_async:       	n = 1000000, dt = 0.369s, r = 2710027/s, t = 369ns/op
perf_now:            	n = 500000, dt = 0.087s, r = 5747126/s, t = 174ns/op
url_parse:           	n = 50000, dt = 0.086s, r = 581395/s, t = 1719ns/op
```

After (https://github.com/denoland/deno/pull/12386):
```
date_now:            	n = 500000, dt = 0.031s, r = 16129032/s, t = 62ns/op
op_void_sync:        	n = 10000000, dt = 0.715s, r = 13986014/s, t = 71ns/op
op_void_async:       	n = 1000000, dt = 0.283s, r = 3533569/s, t = 283ns/op
perf_now:            	n = 500000, dt = 0.076s, r = 6578947/s, t = 151ns/op
url_parse:           	n = 50000, dt = 0.083s, r = 602410/s, t = 1660ns/op
```