### PR TITLE
1.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "deno"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "atty",
  "base64 0.13.0",

--- a/Releases.md
+++ b/Releases.md
@@ -6,6 +6,11 @@ https://github.com/denoland/deno/releases
 We also have one-line install commands at:
 https://github.com/denoland/deno_install
 
+### 1.15.1 / 2021.10.13
+
+- fix: `--no-check` not properly handling code nested in TS expressions (#12416)
+- fix: bundler panic when encountering export specifier with an alias (#12418)
+
 ### 1.15.0 / 2021.10.12
 
 - feat: add --compat flag to provide built-in Node modules (#12293)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno"
-version = "1.15.0"
+version = "1.15.1"
 authors = ["the Deno authors"]
 default-run = "deno"
 edition = "2018"


### PR DESCRIPTION
We should do a new release because of these two critical bugs present in 1.15.0 that have now been resolved (see Releases.md in this PR for more details).