### PR TITLE
bench(cli): add deno_http_std.js

### DIFF
--- a/cli/bench/deno_http_std.js
+++ b/cli/bench/deno_http_std.js
@@ -1,0 +1,3 @@
+import { listenAndServe } from "https://deno.land/std/http/server.ts";
+console.log("http://localhost:4500/");
+listenAndServe(":4500", (req) => new Response("Hello World\n"));

--- a/cli/bench/deno_http_std.js
+++ b/cli/bench/deno_http_std.js
@@ -1,3 +1,3 @@
 import { listenAndServe } from "https://deno.land/std/http/server.ts";
 console.log("http://localhost:4500/");
-listenAndServe(":4500", (req) => new Response("Hello World\n"));
+listenAndServe(":4500", (_req) => new Response("Hello World\n"));


### PR DESCRIPTION
It has a few noteworthy differences with `deno_http_native.js`:
- It goes through the std/http wrappers
- Body isn't a pre-encoded buffer, it's a string
- It sets headers (`content-type: text/plain;charset=UTF-8`)

Overall it's currently about ~25% slower than `deno_http_native.js`