### PR TITLE
Use Global::inner instead of Global::get

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -632,7 +632,7 @@ fn set_wasm_streaming_callback(
     let undefined = v8::undefined(scope);
     let rid = serde_v8::to_v8(scope, streaming_rid).unwrap();
     cb_handle
-      .get(scope)
+      .inner(scope)
       .call(scope, undefined.into(), &[arg, rid]);
   });
 }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -515,7 +515,7 @@ impl JsRuntime {
     let scope = &mut self.handle_scope();
     let state_rc = JsRuntime::state(scope);
     let js_sync_cb_handle = state_rc.borrow().js_sync_cb.clone().unwrap();
-    let js_sync_cb = js_sync_cb_handle.get(scope);
+    let js_sync_cb = js_sync_cb_handle.inner(scope);
     let this = v8::undefined(scope).into();
     js_sync_cb.call(scope, this, &[]);
   }
@@ -982,7 +982,7 @@ impl JsRuntime {
 
     let status = {
       let scope = &mut self.handle_scope();
-      let module = module_handle.get(scope);
+      let module = module_handle.inner(scope);
       module.get_status()
     };
 
@@ -1129,7 +1129,7 @@ impl JsRuntime {
       .dynamic_import_map
       .remove(&id)
       .expect("Invalid dynamic import id");
-    let resolver = resolver_handle.get(scope);
+    let resolver = resolver_handle.inner(scope);
 
     let exception = err
       .downcast_ref::<ErrWithV8Handle>()
@@ -1158,7 +1158,7 @@ impl JsRuntime {
       .dynamic_import_map
       .remove(&id)
       .expect("Invalid dynamic import id");
-    let resolver = resolver_handle.get(scope);
+    let resolver = resolver_handle.inner(scope);
 
     let module = {
       module_map_rc
@@ -1315,7 +1315,7 @@ impl JsRuntime {
     let module_evaluation = maybe_module_evaluation.unwrap();
     let scope = &mut self.handle_scope();
 
-    let promise = module_evaluation.promise.get(scope);
+    let promise = module_evaluation.promise.inner(scope);
     let promise_state = promise.state();
 
     match promise_state {
@@ -1351,8 +1351,8 @@ impl JsRuntime {
         let scope = &mut self.handle_scope();
 
         let module_id = pending_dyn_evaluate.module_id;
-        let promise = pending_dyn_evaluate.promise.get(scope);
-        let _module = pending_dyn_evaluate.module.get(scope);
+        let promise = pending_dyn_evaluate.promise.inner(scope);
+        let _module = pending_dyn_evaluate.module.inner(scope);
         let promise_state = promise.state();
 
         match promise_state {
@@ -1558,7 +1558,7 @@ impl JsRuntime {
     }
 
     let tc_scope = &mut v8::TryCatch::new(scope);
-    let js_recv_cb = js_recv_cb_handle.get(tc_scope);
+    let js_recv_cb = js_recv_cb_handle.inner(tc_scope);
     let this = v8::undefined(tc_scope).into();
     js_recv_cb.call(tc_scope, this, args.as_slice());
 
@@ -1576,7 +1576,7 @@ impl JsRuntime {
       };
 
     let scope = &mut self.handle_scope();
-    let js_macrotask_cb = js_macrotask_cb_handle.get(scope);
+    let js_macrotask_cb = js_macrotask_cb_handle.inner(scope);
 
     // Repeatedly invoke macrotask callback until it returns true (done),
     // such that ready microtasks would be automatically run before
@@ -1741,13 +1741,13 @@ pub mod tests {
     let value_global = runtime.execute_script("a.js", "a = 1 + 2").unwrap();
     {
       let scope = &mut runtime.handle_scope();
-      let value = value_global.get(scope);
+      let value = value_global.inner(scope);
       assert_eq!(value.integer_value(scope).unwrap(), 3);
     }
     let value_global = runtime.execute_script("b.js", "b = 'foobar'").unwrap();
     {
       let scope = &mut runtime.handle_scope();
-      let value = value_global.get(scope);
+      let value = value_global.inner(scope);
       assert!(value.is_string());
       assert_eq!(
         value.to_string(scope).unwrap().to_rust_string_lossy(scope),
@@ -1765,7 +1765,7 @@ pub mod tests {
     let result_global = runtime.resolve_value(value_global).await.unwrap();
     {
       let scope = &mut runtime.handle_scope();
-      let value = result_global.get(scope);
+      let value = result_global.inner(scope);
       assert_eq!(value.integer_value(scope).unwrap(), 3);
     }
 
@@ -1778,7 +1778,7 @@ pub mod tests {
     let result_global = runtime.resolve_value(value_global).await.unwrap();
     {
       let scope = &mut runtime.handle_scope();
-      let value = result_global.get(scope);
+      let value = result_global.inner(scope);
       assert_eq!(value.integer_value(scope).unwrap(), 4);
     }
 


### PR DESCRIPTION
This should be done in sync with a rusty_v8 update, but it hasn't been tagged yet.
