### PR TITLE
fix: support verbatim UNC prefixed paths on Windows

### DIFF
--- a/cli/fs_util.rs
+++ b/cli/fs_util.rs
@@ -83,10 +83,10 @@ fn strip_unc_prefix(path: PathBuf) -> PathBuf {
   match components.next() {
     Some(Component::Prefix(prefix)) => {
       match prefix.kind() {
-        // \\?\share_name\path
-        Prefix::Verbatim(share_name) => {
+        // \\?\device
+        Prefix::Verbatim(device) => {
           let mut path = PathBuf::new();
-          path.push(format!(r"\\{}\", share_name.to_string_lossy()));
+          path.push(format!(r"\\{}\", device.to_string_lossy()));
           path.extend(components.filter(|c| !matches!(c, Component::RootDir)));
           path
         }
@@ -97,7 +97,7 @@ fn strip_unc_prefix(path: PathBuf) -> PathBuf {
           path.extend(components);
           path
         }
-        // \\?\UNC\share_name\path
+        // \\?\UNC\hostname\share_name\path
         Prefix::VerbatimUNC(hostname, share_name) => {
           let mut path = PathBuf::new();
           path.push(format!(


### PR DESCRIPTION
The current code is stripping all UNC paths on Windows. We can't do this because not all UNC paths can safely be stripped.

For example, in #12398 it would take a path like `\\?\UNC\wsl$\Ubuntu\home\david\deno.json` and convert it to `UNC\wsl$\Ubuntu\home\david\deno.json`, which is not a valid path on Windows.

To solve this, the [dunce](https://crates.io/crates/dunce) crate has some special logic for handling when to strip unc paths, so I recommend we use it.

Closes #12398.