### PR TITLE
ci: skip debug WPT during PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,13 +456,10 @@ jobs:
         if: |
           startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&
           matrix.profile == 'debug' &&
-          github.event_name != 'pull_request'
+          github.ref == 'refs/heads/main'
         env:
           DENO_BIN: ./target/debug/deno
         run: |
-          echo GITHUB_EVENT_NAME 
-          echo ${{github.event_name}}
-          echo GITHUB_EVENT_NAME_END
           "$DENO_BIN" run --allow-env --allow-net --allow-read --allow-run \
                           --allow-write --unstable                         \
                           ./tools/wpt.ts setup


### PR DESCRIPTION
Running Debug WPT takes about 35 minutes. It will be still checked in
the release build and on main branch, but too slow to run for PRs.
See for example:
https://github.com/denoland/deno/pull/12438/checks?check_run_id=3889127272

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
