### PR TITLE
fix(cli/fmt_errors): don't panic on source line formatting errors

### DIFF
--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -177,12 +177,23 @@ fn format_maybe_source_line(
   if source_line.is_empty() || source_line.len() > SOURCE_ABBREV_THRESHOLD {
     return "".to_string();
   }
+  if source_line.contains("Couldn't format source line: ") {
+    return format!("\n{}", source_line);
+  }
 
   assert!(start_column.is_some());
   assert!(end_column.is_some());
   let mut s = String::new();
   let start_column = start_column.unwrap();
   let end_column = end_column.unwrap();
+
+  if start_column as usize >= source_line.len() {
+    return format!(
+      "\n{} Couldn't format source line: Column {} is out of bounds (source may have changed at runtime)",
+      crate::colors::yellow("Warning"), start_column + 1,
+    );
+  }
+
   // TypeScript uses `~` always, but V8 would utilise `^` always, even when
   // doing ranges, so here, if we only have one marker (very common with V8
   // errors) we will use `^` instead.

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -622,8 +622,14 @@ impl SourceMapGetter for ProcState {
         // Do NOT use .lines(): it skips the terminating empty line.
         // (due to internally using .split_terminator() instead of .split())
         let lines: Vec<&str> = out.source.split('\n').collect();
-        assert!(lines.len() > line_number);
-        lines[line_number].to_string()
+        if line_number >= lines.len() {
+          format!(
+            "{} Couldn't format source line: Line {} is out of bounds (source may have changed at runtime)",
+            crate::colors::yellow("Warning"), line_number + 1,
+          )
+        } else {
+          lines[line_number].to_string()
+        }
       })
     } else {
       None

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1916,3 +1916,9 @@ itest!(long_data_url_formatting {
   output: "long_data_url_formatting.ts.out",
   exit_code: 1,
 });
+
+itest!(eval_context_throw_with_conflicting_source {
+  args: "run eval_context_throw_with_conflicting_source.ts",
+  output: "eval_context_throw_with_conflicting_source.ts.out",
+  exit_code: 1,
+});

--- a/cli/tests/testdata/eval_context_conflicting_source.ts
+++ b/cli/tests/testdata/eval_context_conflicting_source.ts
@@ -1,0 +1,1 @@
+throw new Error("foo");

--- a/cli/tests/testdata/eval_context_throw_with_conflicting_source.ts
+++ b/cli/tests/testdata/eval_context_throw_with_conflicting_source.ts
@@ -1,0 +1,6 @@
+// deno-lint-ignore no-explicit-any
+const [, errorInfo] = (Deno as any).core.evalContext(
+  '/* aaaaaaaaaaaaaaaaa */ throw new Error("foo")',
+  new URL("eval_context_conflicting_source.ts", import.meta.url).href,
+);
+throw errorInfo.thrown;

--- a/cli/tests/testdata/eval_context_throw_with_conflicting_source.ts.out
+++ b/cli/tests/testdata/eval_context_throw_with_conflicting_source.ts.out
@@ -1,0 +1,4 @@
+[WILDCARD]error: Uncaught Error: foo
+Warning Couldn't format source line: Column 31 is out of bounds (source may have changed at runtime)
+    at file:///[WILDCARD]/eval_context_conflicting_source.ts:1:31
+    at file:///[WILDCARD]/eval_context_throw_with_conflicting_source.ts:[WILDCARD]


### PR DESCRIPTION
Fixes #10886. Returns empty values in case of errors, source lines are non-essential anyway. These errors can happen e.g. when source files change at runtime. A warning is also printed to help us track when it happens in unexpected cases besides this.