### PR TITLE
fix(ci): maybe workaround windows' STATUS_ACCESS_VIOLATION

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1956,10 +1956,10 @@ pub mod tests {
         ..Default::default()
       });
       runtime.execute_script("a.js", "a = 1 + 2").unwrap();
-      runtime.snapshot()
+      Vec::from(&*runtime.snapshot()).into_boxed_slice()
     };
 
-    let snapshot = Snapshot::JustCreated(snapshot);
+    let snapshot = Snapshot::Boxed(snapshot);
     let mut runtime2 = JsRuntime::new(RuntimeOptions {
       startup_snapshot: Some(snapshot),
       ..Default::default()


### PR DESCRIPTION
Windows CI can be flaky, often failing on `runtime::tests::will_snapshot` with a `STATUS_ACCESS_VIOLATION`.

This might be related to accessing `v8::StartupData` after dropping its isolate (hinting at a deeper issue in v8/rusty_v8)

So this PR experiments with boxing (copying) the snapshot before the isolate is dropped