### PR TITLE
bench(http): avoid obj destructuring for parity with std

### DIFF
--- a/cli/bench/deno_http_native.js
+++ b/cli/bench/deno_http_native.js
@@ -11,8 +11,8 @@ const body = encoder.encode("Hello World");
 for await (const conn of listener) {
   (async () => {
     const requests = Deno.serveHttp(conn);
-    for await (const { respondWith } of requests) {
-      respondWith(new Response(body))
+    for await (const event of requests) {
+      event.respondWith(new Response(body))
         .catch((e) => console.log(e));
     }
   })();


### PR DESCRIPTION
Might close gap in benchmark graph between std & native