### PR TITLE
fix(cli): do not cache emit when diagnostics present

### DIFF
--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -389,7 +389,7 @@ impl ProcState {
           .map(|cf| ModuleSpecifier::from_file_path(&cf.path).unwrap());
         let options = emit::CheckOptions {
           debug: self.flags.log_level == Some(log::Level::Debug),
-          emit_with_diagnostics: true,
+          emit_with_diagnostics: false,
           maybe_config_specifier,
           ts_config,
         };

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1396,6 +1396,38 @@ fn rust_log() {
   assert!(!output.stderr.is_empty());
 }
 
+#[test]
+fn dont_cache_on_check_fail() {
+  let deno_dir = util::new_deno_dir();
+
+  let mut deno_cmd = util::deno_cmd_with_deno_dir(deno_dir.path());
+  let output = deno_cmd
+    .current_dir(util::testdata_path())
+    .arg("run")
+    .arg("--reload")
+    .arg("error_003_typescript.ts")
+    .stderr(std::process::Stdio::piped())
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+  assert!(!output.status.success());
+  assert!(!output.stderr.is_empty());
+
+  let mut deno_cmd = util::deno_cmd_with_deno_dir(deno_dir.path());
+  let output = deno_cmd
+    .current_dir(util::testdata_path())
+    .arg("run")
+    .arg("error_003_typescript.ts")
+    .stderr(std::process::Stdio::piped())
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+  assert!(!output.status.success());
+  assert!(!output.stderr.is_empty());
+}
+
 mod permissions {
   use test_util as util;
 

--- a/cli/tests/testdata/error_missing_module_named_import.ts.out
+++ b/cli/tests/testdata/error_missing_module_named_import.ts.out
@@ -1,3 +1,2 @@
 [WILDCARD]
 error: Cannot load module "file://[WILDCARD]/does_not_exist.js".
-    at file://[WILDCARD]/error_missing_module_named_import.ts:1:19

--- a/cli/tests/testdata/localhost_unsafe_ssl.ts.out
+++ b/cli/tests/testdata/localhost_unsafe_ssl.ts.out
@@ -1,3 +1,2 @@
 DANGER: TLS certificate validation is disabled for: deno.land
 error: error sending request for url (https://localhost:5545/subdir/mod2.ts): error trying to connect: invalid certificate: UnknownIssuer
-    at file://[WILDCARD]/cafile_url_imports.ts:1:28


### PR DESCRIPTION
Fixes #12471 

The side effect of this is that in certain diagnostic situations we get less information, because the source file isn't there.  I think they are more edge cases though, and I can't really figure out a way to have the correct caching behaviour and be able to provide the line reference in every scenario.