### PR TITLE
fix(runtime): require full read and write permissions in order to create symlinks

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2347,7 +2347,7 @@ declare namespace Deno {
    * Deno.symlinkSync("old/name", "new/name");
    * ```
    *
-   * Requires `allow-write` permission. */
+   * Requires full `allow-read` and `allow-write` permissions. */
   export function symlinkSync(
     oldpath: string | URL,
     newpath: string | URL,
@@ -2364,7 +2364,7 @@ declare namespace Deno {
    * await Deno.symlink("old/name", "new/name");
    * ```
    *
-   * Requires `allow-write` permission. */
+   * Requires full `allow-read` and `allow-write` permissions. */
   export function symlink(
     oldpath: string | URL,
     newpath: string | URL,

--- a/cli/tests/unit/symlink_test.ts
+++ b/cli/tests/unit/symlink_test.ts
@@ -108,3 +108,31 @@ unitTest(
     );
   },
 );
+
+unitTest(
+  { permissions: { read: true, write: ["."] } },
+  async function symlinkNoFullWritePermissions() {
+    await assertRejects(
+      () => Deno.symlink("old", "new"),
+      Deno.errors.PermissionDenied,
+    );
+    assertThrows(
+      () => Deno.symlinkSync("old", "new"),
+      Deno.errors.PermissionDenied,
+    );
+  },
+);
+
+unitTest(
+  { permissions: { read: ["."], write: true } },
+  async function symlinkNoFullReadPermissions() {
+    await assertRejects(
+      () => Deno.symlink("old", "new"),
+      Deno.errors.PermissionDenied,
+    );
+    assertThrows(
+      () => Deno.symlinkSync("old", "new"),
+      Deno.errors.PermissionDenied,
+    );
+  },
+);

--- a/runtime/ops/fs.rs
+++ b/runtime/ops/fs.rs
@@ -1370,7 +1370,8 @@ fn op_symlink_sync(
   let oldpath = PathBuf::from(&args.oldpath);
   let newpath = PathBuf::from(&args.newpath);
 
-  state.borrow_mut::<Permissions>().write.check(&newpath)?;
+  state.borrow_mut::<Permissions>().write.check_all()?;
+  state.borrow_mut::<Permissions>().read.check_all()?;
 
   debug!(
     "op_symlink_sync {} {}",
@@ -1432,7 +1433,8 @@ async fn op_symlink_async(
 
   {
     let mut state = state.borrow_mut();
-    state.borrow_mut::<Permissions>().write.check(&newpath)?;
+    state.borrow_mut::<Permissions>().write.check_all()?;
+    state.borrow_mut::<Permissions>().read.check_all()?;
   }
 
   tokio::task::spawn_blocking(move || {


### PR DESCRIPTION
This change requires full write and read permissions in order to create a symlink. The reason is to prevent multiple scenarios where someone could create a symlink to escape the directories they have restricted permissions to. For example:

1. Creating a symlink target in a directory outside the sandbox then reading from or writing to that folder.
2. Creating a valid relative symlink like `../../etc` and then moving an ancestor directory so the descendant symlink now points outside the sandbox.

This does not prevent an application causing trouble with existing relative symlinks (ex. `../../etc`) in a directory with write permissions where the write permissions are limited to certain folders.

Closes #12152