### PR TITLE
perf(encoding): Avoid copying the input data in `TextDecoder`

### DIFF
--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -114,7 +114,14 @@
         } else {
           input = new Uint8Array(input);
         }
-        return core.opSync("op_encoding_decode", new Uint8Array(input), {
+        if (input.buffer instanceof SharedArrayBuffer) {
+          // We clone the data into a non-shared ArrayBuffer so we can pass it
+          // to Rust.
+          // `input` is now a Uint8Array, and calling the TypedArray constructor
+          // with a TypedArray argument copies the data.
+          input = new Uint8Array(input);
+        }
+        return core.opSync("op_encoding_decode", input, {
           rid: this.#rid,
           stream: options.stream,
         });


### PR DESCRIPTION
The implementation of `TextDecoder` had a bug where it was copying the input data in every case. This change removes that copy in non-`SharedArrayBuffer` cases.

Since passing a shared buffer source to Rust would fail, this copy of the input data was making `TextDecoder` work in cases where the input is shared. In order to avoid a breaking change, the copy is retained in those cases.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
