### PR TITLE
fix(ext/fetch): Replace redundant local variable with inline return statement

### DIFF
--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -411,7 +411,7 @@
    */
   function fetch(input, init = {}) {
     // 1.
-    const p = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const prefix = "Failed to call 'fetch'";
       webidl.requiredArguments(arguments.length, 1, { prefix });
       // 2.
@@ -472,7 +472,6 @@
         },
       );
     });
-    return p;
   }
 
   function abortFetch(request, responseObject) {


### PR DESCRIPTION
This commit replaces a redundant local variable with inline return statement.
All tests pass.

Closes #12582