### PR TITLE
fix(webidl): Don't throw when converting a detached buffer source

### DIFF
--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -105,14 +105,19 @@
       }
 
       try {
-        if (ArrayBufferIsView(input)) {
-          input = new Uint8Array(
-            input.buffer,
-            input.byteOffset,
-            input.byteLength,
-          );
-        } else {
-          input = new Uint8Array(input);
+        try {
+          if (ArrayBufferIsView(input)) {
+            input = new Uint8Array(
+              input.buffer,
+              input.byteOffset,
+              input.byteLength,
+            );
+          } else {
+            input = new Uint8Array(input);
+          }
+        } catch {
+          // If the buffer is detached, just create a new empty Uint8Array.
+          input = new Uint8Array();
         }
         if (input.buffer instanceof SharedArrayBuffer) {
           // We clone the data into a non-shared ArrayBuffer so we can pass it

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -441,15 +441,6 @@
     return V instanceof SharedArrayBuffer;
   }
 
-  function isArrayBufferDetached(V) {
-    try {
-      new Uint8Array(V);
-      return false;
-    } catch {
-      return true;
-    }
-  }
-
   converters.ArrayBuffer = (V, opts = {}) => {
     if (!isNonSharedArrayBuffer(V)) {
       if (opts.allowShared && !isSharedArrayBuffer(V)) {
@@ -460,9 +451,6 @@
         );
       }
       throw makeException(TypeError, "is not an ArrayBuffer", opts);
-    }
-    if (isArrayBufferDetached(V)) {
-      throw makeException(TypeError, "is a detached ArrayBuffer", opts);
     }
 
     return V;
@@ -477,13 +465,6 @@
       throw makeException(
         TypeError,
         "is backed by a SharedArrayBuffer, which is not allowed",
-        opts,
-      );
-    }
-    if (isArrayBufferDetached(V.buffer)) {
-      throw makeException(
-        TypeError,
-        "is backed by a detached ArrayBuffer",
         opts,
       );
     }
@@ -529,13 +510,6 @@
             opts,
           );
         }
-        if (isArrayBufferDetached(V.buffer)) {
-          throw makeException(
-            TypeError,
-            "is a view on a detached ArrayBuffer",
-            opts,
-          );
-        }
 
         return V;
       };
@@ -561,13 +535,6 @@
       );
     }
 
-    if (isArrayBufferDetached(V.buffer)) {
-      throw makeException(
-        TypeError,
-        "is a view on a detached ArrayBuffer",
-        opts,
-      );
-    }
     return V;
   };
 
@@ -581,13 +548,6 @@
         );
       }
 
-      if (isArrayBufferDetached(V.buffer)) {
-        throw makeException(
-          TypeError,
-          "is a view on a detached ArrayBuffer",
-          opts,
-        );
-      }
       return V;
     }
 
@@ -608,9 +568,6 @@
         "is not an ArrayBuffer, SharedArrayBuffer, or a view on one",
         opts,
       );
-    }
-    if (isArrayBufferDetached(V)) {
-      throw makeException(TypeError, "is a detached ArrayBuffer", opts);
     }
 
     return V;

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -5908,7 +5908,6 @@
     "api-surrogates-utf8.any.html": true,
     "api-surrogates-utf8.any.worker.html": true,
     "encodeInto.any.html": [
-      "encodeInto() and a detached output buffer",
       "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler 0",
       "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 4, filler 0",
       "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler 128",
@@ -5953,7 +5952,6 @@
       "encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 4, filler random"
     ],
     "encodeInto.any.worker.html": [
-      "encodeInto() and a detached output buffer",
       "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler 0",
       "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 4, filler 0",
       "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler 128",
@@ -6028,14 +6026,8 @@
       "decode-non-utf8.any.worker.html": true,
       "decode-split-character.any.html": true,
       "decode-split-character.any.worker.html": true,
-      "decode-utf8.any.html": [
-        "decoding a transferred Uint8Array chunk should give no output",
-        "decoding a transferred ArrayBuffer chunk should give no output"
-      ],
-      "decode-utf8.any.worker.html": [
-        "decoding a transferred Uint8Array chunk should give no output",
-        "decoding a transferred ArrayBuffer chunk should give no output"
-      ],
+      "decode-utf8.any.html": true,
+      "decode-utf8.any.worker.html": true,
       "encode-bad-chunks.any.html": true,
       "encode-bad-chunks.any.worker.html": true,
       "encode-utf8.any.html": true,


### PR DESCRIPTION
The Web IDL conversion to `BufferSource` and similar types shouldn't check whether the buffer is detached.

In the case of `TextDecoder`, our implementation would still throw after the Web IDL conversions because we're creating a new `Uint8Array` from the buffer source's buffer, which throws if it's detached. This change also fixes this bug.

Fixes #12534.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
