### PR TITLE
chore(ci): update dependency for upload_wptfyi

### DIFF
--- a/tools/upload_wptfyi.js
+++ b/tools/upload_wptfyi.js
@@ -2,7 +2,7 @@
 // passed, will automatically add a status check to the commit with a link to
 // the wpt.fyi page.
 
-import { gzip } from "https://deno.land/x/compress@v0.3.8/gzip/mod.ts";
+import { gzip } from "https://deno.land/x/compress@v0.4.1/gzip/mod.ts";
 
 const user = Deno.env.get("WPT_FYI_USER");
 const password = Deno.env.get("WPT_FYI_PW");


### PR DESCRIPTION
The upload script doesn't pass type checking, as it used a version of compress that used a version of `std` that was not type safe when handling caught errors.

This updates the dependency to a version that uses a `std` version compatible with more stricter type checking.