### PR TITLE
fix(cli/proc_state): Short-circuit in prepare_module_load()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2d76b6b75a6fbfda0f529e310fc3cab960f4219403280b430ce93dcf8cf9a2"
+checksum = "075b0c1b454eaf90cea9c6efc72ff946aa6c855c85a4209cb717c01424b37e5e"
 dependencies = [
  "cfg-if 1.0.0",
  "deno_ast",
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d84ddee0cf83bf295721be792b6769b92214983bda29d52c2b05a89d1e968f"
+checksum = "9ee63197c67746c40911cb3082ca13a29cc5adae1ff1b706397b44f7155d7c57"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,8 +41,8 @@ winres = "0.1.11"
 [dependencies]
 deno_ast = { version = "0.5.0", features = ["bundler", "codegen", "dep_graph", "module_specifier", "proposal", "react", "sourcemap", "transforms", "typescript", "view", "visit"] }
 deno_core = { version = "0.107.0", path = "../core" }
-deno_doc = "0.20.0"
-deno_graph = "0.11.1"
+deno_doc = "0.21.0"
+deno_graph = "0.12.0"
 deno_lint = { version = "0.19.0", features = ["docs"] }
 deno_runtime = { version = "0.33.0", path = "../runtime" }
 deno_tls = { version = "0.12.0", path = "../ext/tls" }

--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -17,7 +17,6 @@ use crate::version;
 
 use deno_ast::swc;
 use deno_core::error::anyhow;
-use deno_core::error::custom_error;
 use deno_core::error::AnyError;
 use deno_core::error::Context;
 use deno_core::serde::Deserialize;
@@ -26,7 +25,6 @@ use deno_core::serde::Serialize;
 use deno_core::serde::Serializer;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
-use deno_core::ModuleSource;
 use deno_core::ModuleSpecifier;
 use deno_graph::MediaType;
 use deno_graph::ModuleGraph;
@@ -43,7 +41,7 @@ use std::time::Instant;
 /// Represents the "default" type library that should be used when type
 /// checking the code in the module graph.  Note that a user provided config
 /// of `"lib"` would override this value.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub(crate) enum TypeLib {
   DenoWindow,
   DenoWorker,
@@ -75,8 +73,6 @@ impl Serialize for TypeLib {
     Serialize::serialize(&value, serializer)
   }
 }
-
-type Modules = HashMap<ModuleSpecifier, Result<ModuleSource, AnyError>>;
 
 /// A structure representing stats from an emit operation for a graph.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -790,74 +786,9 @@ pub(crate) fn to_file_map(
   files
 }
 
-/// Convert a module graph to a map of module sources, which are used by
-/// `deno_core` to load modules into V8.
-pub(crate) fn to_module_sources(
-  graph: &ModuleGraph,
-  cache: &dyn Cacher,
-) -> Modules {
-  graph
-    .specifiers()
-    .into_iter()
-    .map(|(requested_specifier, r)| match r {
-      Err(err) => (requested_specifier, Err(err.into())),
-      Ok((found_specifier, media_type)) => {
-        // First we check to see if there is an emitted file in the cache.
-        if let Some(code) = cache.get(CacheType::Emit, &found_specifier) {
-          (
-            requested_specifier.clone(),
-            Ok(ModuleSource {
-              code,
-              module_url_found: found_specifier.to_string(),
-              module_url_specified: requested_specifier.to_string(),
-            }),
-          )
-        // Then if the file is JavaScript (or unknown) and wasn't emitted, we
-        // will load the original source code in the module.
-        } else if matches!(
-          media_type,
-          MediaType::JavaScript
-            | MediaType::Unknown
-            | MediaType::Cjs
-            | MediaType::Mjs
-        ) {
-          if let Some(module) = graph.get(&found_specifier) {
-            (
-              requested_specifier.clone(),
-              Ok(ModuleSource {
-                code: module.source.as_str().to_string(),
-                module_url_found: module.specifier.to_string(),
-                module_url_specified: requested_specifier.to_string(),
-              }),
-            )
-          } else {
-            unreachable!(
-              "unexpected module missing from graph: {}",
-              found_specifier
-            )
-          }
-        // Otherwise we will add a not found error.
-        } else {
-          (
-            requested_specifier.clone(),
-            Err(custom_error(
-              "NotFound",
-              format!(
-                "Emitted code for \"{}\" not found.",
-                requested_specifier
-              ),
-            )),
-          )
-        }
-      }
-    })
-    .collect()
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::cache::MemoryCacher;
 
   #[test]
   fn test_is_emittable() {
@@ -872,82 +803,5 @@ mod tests {
     assert!(is_emittable(&MediaType::JavaScript, true));
     assert!(is_emittable(&MediaType::Jsx, false));
     assert!(!is_emittable(&MediaType::Json, false));
-  }
-
-  async fn setup<S: AsRef<str>>(
-    root: S,
-    sources: Vec<(S, S)>,
-  ) -> (ModuleGraph, MemoryCacher) {
-    let roots = vec![ModuleSpecifier::parse(root.as_ref()).unwrap()];
-    let sources = sources
-      .into_iter()
-      .map(|(s, c)| (s.as_ref().to_string(), Arc::new(c.as_ref().to_string())))
-      .collect();
-    let mut cache = MemoryCacher::new(sources);
-    let graph = deno_graph::create_graph(
-      roots, false, None, &mut cache, None, None, None,
-    )
-    .await;
-    (graph, cache)
-  }
-
-  #[tokio::test]
-  async fn test_to_module_sources_emitted() {
-    let (graph, mut cache) = setup(
-      "https://example.com/a.ts",
-      vec![("https://example.com/a.ts", r#"console.log("hello deno");"#)],
-    )
-    .await;
-    let (ts_config, _) = get_ts_config(ConfigType::Emit, None, None).unwrap();
-    emit(
-      &graph,
-      &mut cache,
-      EmitOptions {
-        ts_config,
-        reload_exclusions: HashSet::default(),
-        reload: false,
-      },
-    )
-    .unwrap();
-    let modules = to_module_sources(&graph, &cache);
-    assert_eq!(modules.len(), 1);
-    let root = ModuleSpecifier::parse("https://example.com/a.ts").unwrap();
-    let maybe_result = modules.get(&root);
-    assert!(maybe_result.is_some());
-    let result = maybe_result.unwrap();
-    assert!(result.is_ok());
-    let module_source = result.as_ref().unwrap();
-    assert!(module_source
-      .code
-      .starts_with(r#"console.log("hello deno");"#));
-  }
-
-  #[tokio::test]
-  async fn test_to_module_sources_not_emitted() {
-    let (graph, mut cache) = setup(
-      "https://example.com/a.js",
-      vec![("https://example.com/a.js", r#"console.log("hello deno");"#)],
-    )
-    .await;
-    let (ts_config, _) = get_ts_config(ConfigType::Emit, None, None).unwrap();
-    emit(
-      &graph,
-      &mut cache,
-      EmitOptions {
-        ts_config,
-        reload_exclusions: HashSet::default(),
-        reload: false,
-      },
-    )
-    .unwrap();
-    let modules = to_module_sources(&graph, &cache);
-    assert_eq!(modules.len(), 1);
-    let root = ModuleSpecifier::parse("https://example.com/a.js").unwrap();
-    let maybe_result = modules.get(&root);
-    assert!(maybe_result.is_some());
-    let result = maybe_result.unwrap();
-    assert!(result.is_ok());
-    let module_source = result.as_ref().unwrap();
-    assert_eq!(module_source.code, r#"console.log("hello deno");"#);
   }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -582,11 +582,9 @@ async fn cache_command(
       lib.clone(),
       Permissions::allow_all(),
       Permissions::allow_all(),
+      false,
     )
     .await?;
-    if let Some(graph_error) = ps.take_graph_error() {
-      return Err(graph_error.into());
-    }
   }
 
   Ok(())

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -116,6 +116,7 @@ impl ModuleLoader for CliModuleLoader {
         lib,
         root_permissions,
         dynamic_permissions,
+        false,
       )
       .await
     }

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2271,3 +2271,37 @@ fn issue12453() {
     .unwrap();
   assert!(status.success());
 }
+
+/// Regression test for https://github.com/denoland/deno/issues/12740.
+#[test]
+fn issue12740() {
+  let mod_dir = TempDir::new().expect("tempdir fail");
+  let mod1_path = mod_dir.path().join("mod1.ts");
+  let mod2_path = mod_dir.path().join("mod2.ts");
+  let mut deno_cmd = util::deno_cmd();
+  std::fs::write(&mod1_path, "").unwrap();
+  let status = deno_cmd
+    .current_dir(util::testdata_path())
+    .arg("run")
+    .arg(&mod1_path)
+    .stderr(std::process::Stdio::null())
+    .stdout(std::process::Stdio::null())
+    .spawn()
+    .unwrap()
+    .wait()
+    .unwrap();
+  assert!(status.success());
+  std::fs::write(&mod1_path, "export { foo } from \"./mod2.ts\";").unwrap();
+  std::fs::write(&mod2_path, "(").unwrap();
+  let status = deno_cmd
+    .current_dir(util::testdata_path())
+    .arg("run")
+    .arg(&mod1_path)
+    .stderr(std::process::Stdio::null())
+    .stdout(std::process::Stdio::null())
+    .spawn()
+    .unwrap()
+    .wait()
+    .unwrap();
+  assert!(!status.success());
+}

--- a/cli/tests/testdata/095_cache_with_bare_import.ts.out
+++ b/cli/tests/testdata/095_cache_with_bare_import.ts.out
@@ -1,1 +1,2 @@
 [WILDCARD]error: Relative import path "foo" not prefixed with / or ./ or ../ from "file:///[WILDCARD]/095_cache_with_bare_import.ts"
+    at file:///[WILDCARD]/095_cache_with_bare_import.ts:[WILDCARD]

--- a/cli/tests/testdata/disallow_http_from_https_js.out
+++ b/cli/tests/testdata/disallow_http_from_https_js.out
@@ -1,4 +1,3 @@
 error: Modules imported via https are not allowed to import http modules.
   Importing: http://localhost:4545/001_hello.js
     at https://localhost:5545/disallow_http_from_https.js:2:8
-

--- a/cli/tests/testdata/disallow_http_from_https_ts.out
+++ b/cli/tests/testdata/disallow_http_from_https_ts.out
@@ -1,4 +1,3 @@
 error: Modules imported via https are not allowed to import http modules.
   Importing: http://localhost:4545/001_hello.js
     at https://localhost:5545/disallow_http_from_https.ts:2:8
-

--- a/cli/tests/testdata/error_011_bad_module_specifier.ts.out
+++ b/cli/tests/testdata/error_011_bad_module_specifier.ts.out
@@ -1,3 +1,2 @@
 [WILDCARD]error: Relative import path "bad-module.ts" not prefixed with / or ./ or ../ from "[WILDCARD]/error_011_bad_module_specifier.ts"
     at [WILDCARD]/error_011_bad_module_specifier.ts:1:28
-

--- a/cli/tests/testdata/error_014_catch_dynamic_import_error.js.out
+++ b/cli/tests/testdata/error_014_catch_dynamic_import_error.js.out
@@ -6,7 +6,6 @@ TypeError: Relative import path "does not exist" not prefixed with / or ./ or ..
 Caught indirect direct dynamic import error.
 TypeError: Relative import path "does not exist either" not prefixed with / or ./ or ../ from "[WILDCARD]/subdir/indirect_import_error.js"
     at [WILDCARD]/subdir/indirect_import_error.js:1:15
-
     at async [WILDCARD]/error_014_catch_dynamic_import_error.js:10:5
 Caught error thrown by dynamically imported module.
 Error: An error

--- a/cli/tests/testdata/error_015_dynamic_import_permissions.out
+++ b/cli/tests/testdata/error_015_dynamic_import_permissions.out
@@ -1,5 +1,4 @@
 error: Uncaught (in promise) TypeError: Requires net access to "localhost:4545", run again with the --allow-net flag
-    at file://[WILDCARD]/error_015_dynamic_import_permissions.js:2:16
   await import("http://localhost:4545/subdir/mod4.js");
   ^
     at async file://[WILDCARD]/error_015_dynamic_import_permissions.js:2:3

--- a/cli/tests/testdata/error_016_dynamic_import_permissions2.out
+++ b/cli/tests/testdata/error_016_dynamic_import_permissions2.out
@@ -2,7 +2,6 @@
 error: Uncaught (in promise) TypeError: Remote modules are not allowed to import local modules. Consider using a dynamic import instead.
   Importing: file:///c:/etc/passwd
     at http://localhost:4545/subdir/evil_remote_import.js:3:15
-
   await import("http://localhost:4545/subdir/evil_remote_import.js");
   ^
     at async file://[WILDCARD]/error_016_dynamic_import_permissions2.js:4:3

--- a/cli/tests/testdata/error_local_static_import_from_remote.js.out
+++ b/cli/tests/testdata/error_local_static_import_from_remote.js.out
@@ -2,4 +2,3 @@
 error: Remote modules are not allowed to import local modules. Consider using a dynamic import instead.
   Importing: file:///some/dir/file.js
     at http://localhost:4545/error_local_static_import_from_remote.js:1:8
-

--- a/cli/tests/testdata/error_local_static_import_from_remote.ts.out
+++ b/cli/tests/testdata/error_local_static_import_from_remote.ts.out
@@ -2,4 +2,3 @@
 error: Remote modules are not allowed to import local modules. Consider using a dynamic import instead.
   Importing: file:///some/dir/file.ts
     at http://localhost:4545/error_local_static_import_from_remote.ts:1:8
-

--- a/cli/tests/testdata/error_missing_module_named_import.ts.out
+++ b/cli/tests/testdata/error_missing_module_named_import.ts.out
@@ -1,2 +1,3 @@
 [WILDCARD]
 error: Cannot load module "file://[WILDCARD]/does_not_exist.js".
+    at file:///[WILDCARD]/error_missing_module_named_import.ts:[WILDCARD]

--- a/cli/tests/testdata/import_blob_url_import_relative.ts.out
+++ b/cli/tests/testdata/import_blob_url_import_relative.ts.out
@@ -1,6 +1,5 @@
 error: Uncaught (in promise) TypeError: invalid URL: relative URL with a cannot-be-a-base base
     at blob:null/[WILDCARD]:1:19
-
 const a = await import(url);
           ^
     at async file://[WILDCARD]/import_blob_url_import_relative.ts:6:11

--- a/cli/tests/testdata/import_data_url_import_relative.ts.out
+++ b/cli/tests/testdata/import_data_url_import_relative.ts.out
@@ -1,3 +1,2 @@
 error: invalid URL: relative URL with a cannot-be-a-base base
     at data:application/javascript;base64,ZXhwb3J0IHsgYSB9IGZyb20gIi4vYS50cyI7Cg==:1:19
-

--- a/cli/tests/testdata/localhost_unsafe_ssl.ts.out
+++ b/cli/tests/testdata/localhost_unsafe_ssl.ts.out
@@ -1,2 +1,3 @@
 DANGER: TLS certificate validation is disabled for: deno.land
 error: error sending request for url (https://localhost:5545/subdir/mod2.ts): error trying to connect: invalid certificate: UnknownIssuer
+    at file:///[WILDCARD]/cafile_url_imports.ts:[WILDCARD]

--- a/cli/tests/testdata/ts_type_only_import.ts.out
+++ b/cli/tests/testdata/ts_type_only_import.ts.out
@@ -1,4 +1,1 @@
 Check file://[WILDCARD]/ts_type_only_import.ts
-warning: Cannot load module "file://[WILDCARD]/ts_type_only_import.d.ts".
-    at file://[WILDCARD]/ts_type_only_import.ts:1:15
-  If the source module contains only types, use `import type` and `export type` to import it instead.

--- a/cli/tests/testdata/workers/permissions_dynamic_remote.ts.out
+++ b/cli/tests/testdata/workers/permissions_dynamic_remote.ts.out
@@ -1,5 +1,4 @@
 error: Uncaught (in worker "") (in promise) TypeError: Requires net access to "example.com", run again with the --allow-net flag
-    at http://localhost:4545/workers/dynamic_remote.ts:2:14
 await import("https://example.com/some/file.ts");
 ^
     at async http://localhost:4545/workers/dynamic_remote.ts:2:1

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -693,6 +693,7 @@ pub async fn cover_files(
       emit::TypeLib::UnstableDenoWindow,
       Permissions::allow_all(),
       Permissions::allow_all(),
+      false,
     )
     .await?;
 

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -712,6 +712,7 @@ async fn check_specifiers(
       lib.clone(),
       Permissions::allow_all(),
       permissions.clone(),
+      false,
     )
     .await?;
   }
@@ -733,6 +734,7 @@ async fn check_specifiers(
     lib,
     Permissions::allow_all(),
     permissions,
+    true,
   )
   .await?;
 


### PR DESCRIPTION
Additionally improve `ProcState::prepare_module_load()` to detect all errors it is supposed to, so no error handling needs to be done in `ProcState::load()` for supposedly prepared modules.

Fixes #12519.
Fixes #12740.