### PR TITLE
cleanup(ext/fetch): consistent op names

### DIFF
--- a/ext/fetch/22_http_client.js
+++ b/ext/fetch/22_http_client.js
@@ -20,7 +20,7 @@
    */
   function createHttpClient(options) {
     options.caCerts ??= [];
-    return new HttpClient(core.opSync("op_create_http_client", options));
+    return new HttpClient(core.opSync("op_fetch_custom_client", options));
   }
 
   class HttpClient {

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -77,7 +77,10 @@ pub fn init<P: FetchPermissions + 'static>(
       ("op_fetch_send", op_async(op_fetch_send)),
       ("op_fetch_request_write", op_async(op_fetch_request_write)),
       ("op_fetch_response_read", op_async(op_fetch_response_read)),
-      ("op_create_http_client", op_sync(op_create_http_client::<P>)),
+      (
+        "op_fetch_custom_client",
+        op_sync(op_fetch_custom_client::<P>),
+      ),
     ])
     .state(move |state| {
       state.put::<reqwest::Client>({
@@ -455,7 +458,7 @@ pub struct CreateHttpClientOptions {
   private_key: Option<String>,
 }
 
-pub fn op_create_http_client<FP>(
+pub fn op_fetch_custom_client<FP>(
   state: &mut OpState,
   args: CreateHttpClientOptions,
   _: (),


### PR DESCRIPTION
Rename `op_create_http_client` to `op_fetch_custom_client` to follow prefix/namespaced convention