### PR TITLE
chore(cli): fix typo in `tools/test.rs`

### DIFF
--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -272,8 +272,8 @@ fn human_elapsed(elapsed: u128) -> String {
 
   let seconds = elapsed / 1_000;
   let minutes = seconds / 60;
-  let seconds_reminder = seconds % 60;
-  format!("({}m{}s)", minutes, seconds_reminder)
+  let seconds_remainder = seconds % 60;
+  format!("({}m{}s)", minutes, seconds_remainder)
 }
 
 impl TestReporter for PrettyTestReporter {


### PR DESCRIPTION
Just catched this in #12610, nice to have this formatting

Are milliseconds intentionally not shown when the test takes longer than a second (eg: `1s43ms`)? 