### PR TITLE
chore(lint): await_holding_refcell_ref

### DIFF
--- a/tools/lint.js
+++ b/tools/lint.js
@@ -109,7 +109,14 @@ async function clippy() {
   }
 
   const p = Deno.run({
-    cmd: [...cmd, "--", "-D", "clippy::all"],
+    cmd: [
+      ...cmd,
+      "--",
+      "-D",
+      "clippy::all",
+      "-D",
+      "clippy::await_holding_refcell_ref",
+    ],
   });
   const { success } = await p.status();
   if (!success) {


### PR DESCRIPTION
Enable lint check to catch borrows across awaits leading to double borrow errors like https://github.com/denoland/deno/issues/12453