### PR TITLE
fix(lsp): display signature docs as markdown

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1953,11 +1953,15 @@ impl SignatureHelpItem {
       .collect::<Vec<String>>()
       .join(", ");
     let suffix_text = display_parts_to_string(&self.suffix_display_parts);
+    let documentation = display_parts_to_string(&self.documentation);
     lsp::SignatureInformation {
       label: format!("{}{}{}", prefix_text, params_text, suffix_text),
-      documentation: Some(lsp::Documentation::String(display_parts_to_string(
-        &self.documentation,
-      ))),
+      documentation: Some(lsp::Documentation::MarkupContent(
+        lsp::MarkupContent {
+          kind: lsp::MarkupKind::Markdown,
+          value: documentation,
+        },
+      )),
       parameters: Some(
         self
           .parameters
@@ -1981,13 +1985,17 @@ pub struct SignatureHelpParameter {
 
 impl SignatureHelpParameter {
   pub fn into_parameter_information(self) -> lsp::ParameterInformation {
+    let documentation = display_parts_to_string(&self.documentation);
     lsp::ParameterInformation {
       label: lsp::ParameterLabel::Simple(display_parts_to_string(
         &self.display_parts,
       )),
-      documentation: Some(lsp::Documentation::String(display_parts_to_string(
-        &self.documentation,
-      ))),
+      documentation: Some(lsp::Documentation::MarkupContent(
+        lsp::MarkupContent {
+          kind: lsp::MarkupKind::Markdown,
+          value: documentation,
+        },
+      )),
     }
   }
 }

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -1931,15 +1931,24 @@ fn lsp_signature_help() {
       "signatures": [
         {
           "label": "add(a: number, b: number): number",
-          "documentation": "Adds two numbers.",
+          "documentation": {
+            "kind": "markdown",
+            "value": "Adds two numbers."
+          },
           "parameters": [
             {
               "label": "a: number",
-              "documentation": "This is a first number."
+              "documentation": {
+                "kind": "markdown",
+                "value": "This is a first number."
+              }
             },
             {
               "label": "b: number",
-              "documentation": "This is a second number."
+              "documentation": {
+                "kind": "markdown",
+                "value": "This is a second number."
+              }
             }
           ]
         }
@@ -1995,15 +2004,24 @@ fn lsp_signature_help() {
       "signatures": [
         {
           "label": "add(a: number, b: number): number",
-          "documentation": "Adds two numbers.",
+          "documentation": {
+            "kind": "markdown",
+            "value": "Adds two numbers."
+          },
           "parameters": [
             {
               "label": "a: number",
-              "documentation": "This is a first number."
+              "documentation": {
+                "kind": "markdown",
+                "value": "This is a first number."
+              }
             },
             {
               "label": "b: number",
-              "documentation": "This is a second number."
+              "documentation": {
+                "kind": "markdown",
+                "value": "This is a second number."
+              }
             }
           ]
         }


### PR DESCRIPTION
These were previously displayed as plain text. Now they are displayed as
`MarkupContent` with type `Markdown`.

Fixes #12620.