### PR TITLE
chore(ext/web): remove `ReadableStream.getIterator`

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -4212,15 +4212,6 @@
     }
 
     /**
-     * @deprecated TODO(@kitsonk): Remove in Deno 1.8
-     * @param {ReadableStreamIteratorOptions=} options
-     * @returns {AsyncIterableIterator<R>}
-     */
-    getIterator(options = {}) {
-      return this[SymbolAsyncIterator](options);
-    }
-
-    /**
      * @param {ReadableStreamGetReaderOptions=} options
      * @returns {ReadableStreamDefaultReader<R> | ReadableStreamBYOBReader}
      */

--- a/ext/web/lib.deno_web.d.ts
+++ b/ext/web/lib.deno_web.d.ts
@@ -563,12 +563,6 @@ declare var ByteLengthQueuingStrategy: {
 interface ReadableStream<R = any> {
   readonly locked: boolean;
   cancel(reason?: any): Promise<void>;
-  /**
-   * @deprecated This is no longer part of the Streams standard and the async
-   *             iterable should be obtained by just using the stream as an
-   *             async iterator.
-   */
-  getIterator(options?: { preventCancel?: boolean }): AsyncIterableIterator<R>;
   getReader(): ReadableStreamDefaultReader<R>;
   pipeThrough<T>(
     { writable, readable }: {


### PR DESCRIPTION
Has a TODO for all the way back to 1.8. Also, std doesnt use getIterator anywhere anymore, so it should be safe to remove