### PR TITLE
chore(lsp): align ScriptElementKind to current versions of TypeScript/vscode

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -410,6 +410,12 @@ pub enum ScriptElementKind {
   JsxAttribute,
   #[serde(rename = "string")]
   String,
+  #[serde(rename = "link")]
+  Link,
+  #[serde(rename = "link name")]
+  LinkName,
+  #[serde(rename = "link test")]
+  LinkText,
 }
 
 impl Default for ScriptElementKind {
@@ -418,6 +424,7 @@ impl Default for ScriptElementKind {
   }
 }
 
+/// This mirrors the method `convertKind` in `completions.ts` in vscode
 impl From<ScriptElementKind> for lsp::CompletionItemKind {
   fn from(kind: ScriptElementKind) -> Self {
     match kind {
@@ -468,29 +475,33 @@ impl From<ScriptElementKind> for lsp::CompletionItemKind {
   }
 }
 
+/// This mirrors `fromProtocolScriptElementKind` in vscode
 impl From<ScriptElementKind> for lsp::SymbolKind {
   fn from(kind: ScriptElementKind) -> Self {
     match kind {
-      ScriptElementKind::ModuleElement => lsp::SymbolKind::Module,
-      ScriptElementKind::ClassElement => lsp::SymbolKind::Class,
-      ScriptElementKind::EnumElement => lsp::SymbolKind::Enum,
-      ScriptElementKind::InterfaceElement => lsp::SymbolKind::Interface,
-      ScriptElementKind::MemberFunctionElement => lsp::SymbolKind::Method,
-      ScriptElementKind::MemberVariableElement => lsp::SymbolKind::Property,
-      ScriptElementKind::MemberGetAccessorElement => lsp::SymbolKind::Property,
-      ScriptElementKind::MemberSetAccessorElement => lsp::SymbolKind::Property,
-      ScriptElementKind::VariableElement => lsp::SymbolKind::Variable,
-      ScriptElementKind::ConstElement => lsp::SymbolKind::Variable,
-      ScriptElementKind::LocalVariableElement => lsp::SymbolKind::Variable,
-      ScriptElementKind::FunctionElement => lsp::SymbolKind::Function,
-      ScriptElementKind::LocalFunctionElement => lsp::SymbolKind::Function,
-      ScriptElementKind::ConstructSignatureElement => {
-        lsp::SymbolKind::Constructor
-      }
-      ScriptElementKind::ConstructorImplementationElement => {
-        lsp::SymbolKind::Constructor
-      }
-      _ => lsp::SymbolKind::Variable,
+      ScriptElementKind::ModuleElement => Self::Module,
+      ScriptElementKind::ClassElement => Self::Class,
+      ScriptElementKind::EnumElement => Self::Enum,
+      ScriptElementKind::EnumMemberElement => Self::EnumMember,
+      ScriptElementKind::InterfaceElement => Self::Interface,
+      ScriptElementKind::IndexSignatureElement => Self::Method,
+      ScriptElementKind::CallSignatureElement => Self::Method,
+      ScriptElementKind::MemberFunctionElement => Self::Method,
+      ScriptElementKind::MemberVariableElement => Self::Property,
+      ScriptElementKind::MemberGetAccessorElement => Self::Property,
+      ScriptElementKind::MemberSetAccessorElement => Self::Property,
+      ScriptElementKind::VariableElement => Self::Variable,
+      ScriptElementKind::LetElement => Self::Variable,
+      ScriptElementKind::ConstElement => Self::Variable,
+      ScriptElementKind::LocalVariableElement => Self::Variable,
+      ScriptElementKind::Alias => Self::Variable,
+      ScriptElementKind::FunctionElement => Self::Function,
+      ScriptElementKind::LocalFunctionElement => Self::Function,
+      ScriptElementKind::ConstructSignatureElement => Self::Constructor,
+      ScriptElementKind::ConstructorImplementationElement => Self::Constructor,
+      ScriptElementKind::TypeParameterElement => Self::TypeParameter,
+      ScriptElementKind::String => Self::String,
+      _ => Self::Variable,
     }
   }
 }

--- a/cli/tests/testdata/lsp/document_symbol_response.json
+++ b/cli/tests/testdata/lsp/document_symbol_response.json
@@ -320,7 +320,7 @@
     "children": [
       {
         "name": "value1",
-        "kind": 13,
+        "kind": 22,
         "range": {
           "start": {
             "line": 15,
@@ -344,7 +344,7 @@
       },
       {
         "name": "value2",
-        "kind": 13,
+        "kind": 22,
         "range": {
           "start": {
             "line": 15,


### PR DESCRIPTION
There has been a bit of "drift" in what TypeScript supports and what vscode does with information included in the navigation tree.