### PR TITLE
fix(fetch): set content-length for empty POST/PUT

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -1416,3 +1416,60 @@ unitTest(
     assertEquals(await res.text(), fixture);
   },
 );
+
+unitTest(
+  { permissions: { net: true } },
+  async function fetchContentLengthPost() {
+    const response = await fetch("http://localhost:4545/content_length", {
+      method: "POST",
+    });
+    const length = await response.text();
+    assertEquals(length, 'Some("0")');
+  },
+);
+
+unitTest(
+  { permissions: { net: true } },
+  async function fetchContentLengthPut() {
+    const response = await fetch("http://localhost:4545/content_length", {
+      method: "PUT",
+    });
+    const length = await response.text();
+    assertEquals(length, 'Some("0")');
+  },
+);
+
+unitTest(
+  { permissions: { net: true } },
+  async function fetchContentLengthPatch() {
+    const response = await fetch("http://localhost:4545/content_length", {
+      method: "PATCH",
+    });
+    const length = await response.text();
+    assertEquals(length, "None");
+  },
+);
+
+unitTest(
+  { permissions: { net: true } },
+  async function fetchContentLengthPostWithStringBody() {
+    const response = await fetch("http://localhost:4545/content_length", {
+      method: "POST",
+      body: "Hey!",
+    });
+    const length = await response.text();
+    assertEquals(length, 'Some("4")');
+  },
+);
+
+unitTest(
+  { permissions: { net: true } },
+  async function fetchContentLengthPostWithBufferBody() {
+    const response = await fetch("http://localhost:4545/content_length", {
+      method: "POST",
+      body: new TextEncoder().encode("Hey!"),
+    });
+    const length = await response.text();
+    assertEquals(length, 'Some("4")');
+  },
+);

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -640,6 +640,7 @@ unitTest(
     const actual = new TextDecoder().decode((await bufPromise).bytes());
     const expected = [
       "POST /blah HTTP/1.1\r\n",
+      "content-length: 0\r\n",
       "hello: World\r\n",
       "foo: Bar\r\n",
       "accept: */*\r\n",

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -246,7 +246,7 @@ where
       let permissions = state.borrow_mut::<FP>();
       permissions.check_net_url(&url)?;
 
-      let mut request = client.request(method, url);
+      let mut request = client.request(method.clone(), url);
 
       let request_body_rid = if args.has_body {
         match data {
@@ -278,6 +278,11 @@ where
           }
         }
       } else {
+        // POST and PUT requests should always have a 0 length content-length,
+        // if there is no body. https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+        if matches!(method, Method::POST | Method::PUT) {
+          request = request.header(CONTENT_LENGTH, HeaderValue::from(0));
+        }
         None
       };
 

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -851,6 +851,10 @@ async fn main_server(
       let version = format!("{:?}", req.version());
       Ok(Response::new(version.into()))
     }
+    (_, "/content_length") => {
+      let content_length = format!("{:?}", req.headers().get("content-length"));
+      Ok(Response::new(content_length.into()))
+    }
     (_, "/jsx/jsx-runtime") | (_, "/jsx/jsx-dev-runtime") => {
       let mut res = Response::new(Body::from(
         r#"export function jsx(


### PR DESCRIPTION
This commit changes `fetch` to set `content-length: 0` on POST and PUT
requests with no body.

The relevant fetch spec text:
![image](https://user-images.githubusercontent.com/7829205/140904310-caf46835-f79e-4d1b-932f-5b9b8c884358.png)


Fixes #12597
Fixes #11920

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
