### PR TITLE
feat(runtime): Make internal modules optional for workers in deno_runtime

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,6 +12,7 @@ description = "Provides the deno runtime library"
 [features]
 # "fake" feature that allows to generate docs on docs.rs
 docsrs = []
+default=[ "deno_webgpu", "deno_ffi" ]
 
 [lib]
 name = "deno_runtime"
@@ -27,14 +28,14 @@ deno_console = { version = "0.23.0", path = "../ext/console" }
 deno_core = { version = "0.105.0", path = "../core" }
 deno_crypto = { version = "0.37.0", path = "../ext/crypto" }
 deno_fetch = { version = "0.46.0", path = "../ext/fetch" }
-deno_ffi = { version = "0.10.0", path = "../ext/ffi" }
+deno_ffi = { version = "0.10.0", path = "../ext/ffi", optional = true }
 deno_http = { version = "0.15.0", path = "../ext/http" }
 deno_net = { version = "0.15.0", path = "../ext/net" }
 deno_timers = { version = "0.21.0", path = "../ext/timers" }
 deno_tls = { version = "0.10.0", path = "../ext/tls" }
 deno_url = { version = "0.23.0", path = "../ext/url" }
 deno_web = { version = "0.54.0", path = "../ext/web" }
-deno_webgpu = { version = "0.24.0", path = "../ext/webgpu" }
+deno_webgpu = { version = "0.24.0", path = "../ext/webgpu", optional = true }
 deno_webidl = { version = "0.23.0", path = "../ext/webidl" }
 deno_websocket = { version = "0.28.0", path = "../ext/websocket" }
 deno_webstorage = { version = "0.18.0", path = "../ext/webstorage" }
@@ -49,14 +50,14 @@ deno_console = { version = "0.23.0", path = "../ext/console" }
 deno_core = { version = "0.105.0", path = "../core" }
 deno_crypto = { version = "0.37.0", path = "../ext/crypto" }
 deno_fetch = { version = "0.46.0", path = "../ext/fetch" }
-deno_ffi = { version = "0.10.0", path = "../ext/ffi" }
+deno_ffi = { version = "0.10.0", path = "../ext/ffi", optional = true }
 deno_http = { version = "0.15.0", path = "../ext/http" }
 deno_net = { version = "0.15.0", path = "../ext/net" }
 deno_timers = { version = "0.21.0", path = "../ext/timers" }
 deno_tls = { version = "0.10.0", path = "../ext/tls" }
 deno_url = { version = "0.23.0", path = "../ext/url" }
 deno_web = { version = "0.54.0", path = "../ext/web" }
-deno_webgpu = { version = "0.24.0", path = "../ext/webgpu" }
+deno_webgpu = { version = "0.24.0", path = "../ext/webgpu", optional = true }
 deno_webidl = { version = "0.23.0", path = "../ext/webidl" }
 deno_websocket = { version = "0.28.0", path = "../ext/websocket" }
 deno_webstorage = { version = "0.18.0", path = "../ext/webstorage" }

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -82,6 +82,7 @@ mod not_docs {
     }
   }
 
+  #[cfg(feature = "deno_ffi")]
   impl deno_ffi::FfiPermissions for Permissions {
     fn check(
       &mut self,
@@ -133,12 +134,14 @@ mod not_docs {
       deno_websocket::init::<Permissions>("".to_owned(), None, None),
       deno_webstorage::init(None),
       deno_crypto::init(None),
+      #[cfg(feature = "deno_webgpu")]
       deno_webgpu::init(false),
       deno_timers::init::<Permissions>(),
       deno_broadcast_channel::init(
         deno_broadcast_channel::InMemoryBroadcastChannel::default(),
         false, // No --unstable.
       ),
+      #[cfg(feature = "deno_ffi")]
       deno_ffi::init::<Permissions>(false),
       deno_net::init::<Permissions>(
         None, false, // No --unstable.

--- a/runtime/errors.rs
+++ b/runtime/errors.rs
@@ -154,7 +154,10 @@ pub fn get_nix_error_class(error: &nix::Error) -> &'static str {
 
 pub fn get_error_class_name(e: &AnyError) -> Option<&'static str> {
   deno_core::error::get_custom_error_class(e)
-    .or_else(|| deno_webgpu::error::get_error_class_name(e))
+    .or_else(|| {
+      #[cfg(feature = "deno_webgpu")]
+      deno_webgpu::error::get_error_class_name(e)
+    })
     .or_else(|| deno_web::get_error_class_name(e))
     .or_else(|| deno_webstorage::get_not_supported_error_class_name(e))
     .or_else(|| deno_websocket::get_network_error_class_name(e))

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -4,6 +4,7 @@ pub use deno_broadcast_channel;
 pub use deno_console;
 pub use deno_crypto;
 pub use deno_fetch;
+#[cfg(feature = "deno_ffi")]
 pub use deno_ffi;
 pub use deno_http;
 pub use deno_net;
@@ -11,6 +12,7 @@ pub use deno_timers;
 pub use deno_tls;
 pub use deno_url;
 pub use deno_web;
+#[cfg(feature = "deno_webgpu")]
 pub use deno_webgpu;
 pub use deno_webidl;
 pub use deno_websocket;

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -1313,6 +1313,7 @@ impl deno_websocket::WebSocketPermissions for Permissions {
   }
 }
 
+#[cfg(feature = "deno_ffi")]
 impl deno_ffi::FfiPermissions for Permissions {
   fn check(&mut self, path: &Path) -> Result<(), AnyError> {
     self.ffi.check(path)

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -334,9 +334,11 @@ impl WebWorker {
       ),
       deno_broadcast_channel::init(options.broadcast_channel.clone(), unstable),
       deno_crypto::init(options.seed),
+      #[cfg(feature = "deno_webgpu")]
       deno_webgpu::init(unstable),
       deno_timers::init::<Permissions>(),
       // ffi
+      #[cfg(feature = "deno_ffi")]
       deno_ffi::init::<Permissions>(unstable),
       // Permissions ext (worker specific state)
       perm_ext,

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -118,9 +118,11 @@ impl MainWorker {
       deno_webstorage::init(options.origin_storage_dir.clone()),
       deno_crypto::init(options.seed),
       deno_broadcast_channel::init(options.broadcast_channel.clone(), unstable),
+      #[cfg(feature = "deno_webgpu")]
       deno_webgpu::init(unstable),
       deno_timers::init::<Permissions>(),
       // ffi
+      #[cfg(feature = "deno_ffi")]
       deno_ffi::init::<Permissions>(unstable),
       // Runtime ops
       ops::runtime::init(main_module.clone()),


### PR DESCRIPTION
As described in #12641, I've started working on a PR to make some of the dependencies optional. 
The default still uses those optional modules, so nothing changes for deno.
Currently this breaks the build without features because 90_deno_ns.js and 99_main.js try and use the types provided by those modules. I've yet to find a good way to apply the features with the js files.
I guess a better way would be to move the js that needs those modules into separate files inside the modules and load them on module init.