### PR TITLE
fix: add typings for AbortSignal.reason

### DIFF
--- a/cli/tests/unit/abort_controller_test.ts
+++ b/cli/tests/unit/abort_controller_test.ts
@@ -54,3 +54,9 @@ unitTest(function controllerHasProperToString() {
   const actual = Object.prototype.toString.call(new AbortController());
   assertEquals(actual, "[object AbortController]");
 });
+
+unitTest(function abortReason() {
+  const signal = AbortSignal.abort("hey!");
+  assertEquals(signal.aborted, true);
+  assertEquals(signal.reason, "hey!");
+});

--- a/ext/web/lib.deno_web.d.ts
+++ b/ext/web/lib.deno_web.d.ts
@@ -271,7 +271,7 @@ interface AbortSignal extends EventTarget {
   /** Returns true if this AbortSignal's AbortController has signaled to abort,
    * and false otherwise. */
   readonly aborted: boolean;
-  readonly reason?: any;
+  readonly reason?: unknown;
   onabort: ((this: AbortSignal, ev: Event) => any) | null;
   addEventListener<K extends keyof AbortSignalEventMap>(
     type: K,

--- a/ext/web/lib.deno_web.d.ts
+++ b/ext/web/lib.deno_web.d.ts
@@ -258,7 +258,7 @@ declare class AbortController {
   readonly signal: AbortSignal;
   /** Invoking this method will set this object's AbortSignal's aborted flag and
    * signal to any observers that the associated activity is to be aborted. */
-  abort(): void;
+  abort(reason?: any): void;
 }
 
 interface AbortSignalEventMap {
@@ -271,6 +271,7 @@ interface AbortSignal extends EventTarget {
   /** Returns true if this AbortSignal's AbortController has signaled to abort,
    * and false otherwise. */
   readonly aborted: boolean;
+  readonly reason?: any;
   onabort: ((this: AbortSignal, ev: Event) => any) | null;
   addEventListener<K extends keyof AbortSignalEventMap>(
     type: K,
@@ -297,6 +298,7 @@ interface AbortSignal extends EventTarget {
 declare var AbortSignal: {
   prototype: AbortSignal;
   new (): AbortSignal;
+  abort(reason?: any): AbortSignal;
 };
 
 interface FileReaderEventMap {


### PR DESCRIPTION
Adds missing types.
