### PR TITLE
ci: use 'ubuntu-20.04' runner image rather than 'ubuntu-latest'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,11 +163,11 @@ jobs:
       - name: Set up Linux sysroot with Ubuntu 18.04 and LLVM
         if: matrix.use_sysroot
         run: |
-          # Avoid running man-db triggers, which sometimes takes several minutes
-          # to complete.
-          sudo apt-get remove -y --purge man-db
-          sudo apt-get update
-          sudo apt-get install debootstrap
+          # Avoid running man-db and mime-support triggers, which sometimes
+          # takes several minutes to complete.
+          sudo apt remove --purge -y man-db mime-support
+          sudo apt update
+          sudo apt install --no-install-recommends debootstrap
 
           # `file` and `make` are needed to build libffi-sys.
           # `curl` is needed to build rusty_v8.
@@ -190,8 +190,8 @@ jobs:
           curl https://apt.llvm.org/llvm-snapshot.gpg.key |
             gpg --dearmor                                 |
             sudo dd of=/sysroot/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
-          sudo chroot /sysroot apt update -y
-          sudo chroot /sysroot apt install --no-install-recommends -y \
+          sudo chroot /sysroot apt update
+          sudo chroot /sysroot apt install --no-install-recommends \
                                            clang-13 lld-13
 
           # Redirect ld invocations to ld.lld-13 inside the chroot environment.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,9 +163,9 @@ jobs:
       - name: Set up Linux sysroot with Ubuntu 18.04 and LLVM
         if: matrix.use_sysroot
         run: |
-          # Avoid running man-db and mime-support triggers, which sometimes
-          # takes several minutes to complete.
-          sudo apt remove --purge -y man-db mime-support
+          # Avoid running man-db triggers, which sometimes takes several minutes
+          # to complete.
+          sudo apt remove --purge -y man-db
           sudo apt update
           sudo apt install --no-install-recommends debootstrap
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,9 +165,9 @@ jobs:
         run: |
           # Avoid running man-db triggers, which sometimes takes several minutes
           # to complete.
-          sudo apt remove --purge -y man-db
-          sudo apt update
-          sudo apt install --no-install-recommends debootstrap
+          sudo apt-get remove --purge -y man-db
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends debootstrap
 
           # `file` and `make` are needed to build libffi-sys.
           # `curl` is needed to build rusty_v8.
@@ -190,9 +190,9 @@ jobs:
           curl https://apt.llvm.org/llvm-snapshot.gpg.key |
             gpg --dearmor                                 |
             sudo dd of=/sysroot/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
-          sudo chroot /sysroot apt update
-          sudo chroot /sysroot apt install --no-install-recommends \
-                                           clang-13 lld-13
+          sudo chroot /sysroot apt-get update
+          sudo chroot /sysroot apt-get install --no-install-recommends \
+                                               clang-13 lld-13
 
           # Redirect ld invocations to ld.lld-13 inside the chroot environment.
           # Setting the 'LD' environment variable doesn't always work.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,18 @@ jobs:
           - os: windows-2019
             job: test
             profile: release
-          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-20.04-xl' || 'ubuntu-20.04' }}
             job: test
             profile: release
             use_sysroot: true
-          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-20.04-xl' || 'ubuntu-20.04' }}
             job: bench
             profile: release
             use_sysroot: true
-          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-20.04-xl' || 'ubuntu-20.04' }}
             job: test
             profile: debug
-          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-20.04-xl' || 'ubuntu-20.04' }}
             job: lint
             profile: debug
 
@@ -621,7 +621,7 @@ jobs:
   publish-canary:
     name: publish canary
     runs-on: ubuntu-20.04
-    needs: ['build']
+    needs: ["build"]
     if: github.repository == 'denoland/deno' &&
         (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
           # to complete.
           sudo apt-get remove --purge -y man-db
           sudo apt-get update
-          sudo apt-get install --no-install-recommends debootstrap
+          sudo apt-get install debootstrap
 
           # `file` and `make` are needed to build libffi-sys.
           # `curl` is needed to build rusty_v8.
@@ -191,7 +191,7 @@ jobs:
             gpg --dearmor                                 |
             sudo dd of=/sysroot/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
           sudo chroot /sysroot apt-get update
-          sudo chroot /sysroot apt-get install --no-install-recommends \
+          sudo chroot /sysroot apt-get install --no-install-recommends -y \
                                                clang-13 lld-13
 
           # Redirect ld invocations to ld.lld-13 inside the chroot environment.


### PR DESCRIPTION
The existing ubuntu-latest-xl runner image (based on Ubuntu 18.04 XL) is
deprecated and will retire soon. Migrate to ubuntu-20.04-xl instead.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
