### PR TITLE
fix(runtime/js): "Invalid URL" exception

### DIFF
--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -665,7 +665,10 @@ delete Object.prototype.__proto__;
       cpuCount,
     } = runtimeOptions;
 
-    location.setLocationHref(locationHref);
+    if (locationHref != null) {
+      location.setLocationHref(locationHref);
+    }
+
     numCpus = cpuCount;
     registerErrors();
 


### PR DESCRIPTION
In runtime/js/99_main.js -> [bootstrapWorkerRuntime](https://github.com/denoland/deno/blob/fdf890a68d3d54d40c766fd78faeccb20bd2e2c6/runtime/js/99_main.js#L614) function: 

As location is optional in bootstrap options, setLocationHref should only be called if location is not `null` (as it is in the [bootstrapMainRuntime](https://github.com/denoland/deno/blob/fdf890a68d3d54d40c766fd78faeccb20bd2e2c6/runtime/js/99_main.js#L577) function).
Otherwise there is a "Invalid URL" exception thrown while bootsraping a worker.
