### PR TITLE
feat(test): Add more overloads for "Deno.test"

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -409,7 +409,7 @@ declare namespace Deno {
    *   assertEquals("hello", "hello");
    * });
    *
-   * Deno.test({ permissions: { read: false } }, function myOtherTestName(): Promise<void> {
+   * Deno.test({ permissions: { read: false } }, async function myOtherTestName(): Promise<void> {
    *   const decoder = new TextDecoder("utf-8");
    *   const data = await Deno.readFile("hello_world.txt");
    *   assertEquals(decoder.decode(data), "Hello world");

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -371,7 +371,7 @@ declare namespace Deno {
    */
   export function test(
     name: string,
-    options: Omit<TestDefinition, "fn" | "name">,
+    options: Omit<TestDefinition, "fn">,
     fn: (t: TestContext) => void | Promise<void>,
   ): void;
 
@@ -394,7 +394,7 @@ declare namespace Deno {
    * ```
    */
   export function test(
-    options: Omit<TestDefinition, "fn">,
+    options: Omit<TestDefinition, "fn" | "name">,
     fn: (t: TestContext) => void | Promise<void>,
   ): void;
 

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -371,7 +371,7 @@ declare namespace Deno {
    */
   export function test(
     name: string,
-    options: Omit<TestDefinition, "fn">,
+    options: Omit<TestDefinition, "fn" | "name">,
     fn: (t: TestContext) => void | Promise<void>,
   ): void;
 
@@ -394,10 +394,32 @@ declare namespace Deno {
    * ```
    */
   export function test(
-    options: Omit<TestDefinition, "fn" | "name">,
+    options: Omit<TestDefinition, "fn">,
     fn: (t: TestContext) => void | Promise<void>,
   ): void;
 
+  /** Register a test which will be run when `deno test` is used on the command
+   * line and the containing module looks like a test module.
+   * `fn` can be async if required. Declared function must have a name.
+   *
+   * ```ts
+   * import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
+   *
+   * Deno.test({ permissions: { read: true } }, function myTestName(): void {
+   *   assertEquals("hello", "hello");
+   * });
+   *
+   * Deno.test({ permissions: { read: false } }, function myOtherTestName(): Promise<void> {
+   *   const decoder = new TextDecoder("utf-8");
+   *   const data = await Deno.readFile("hello_world.txt");
+   *   assertEquals(decoder.decode(data), "Hello world");
+   * });
+   * ```
+   */
+   export function test(
+    options: Omit<TestDefinition, "fn" | "name">,
+    fn: (t: TestContext) => void | Promise<void>,
+  ): void;
   /** Exit the Deno process with optional exit code. If no exit code is supplied
    * then Deno will exit with return code of 0.
    *

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -315,11 +315,11 @@ declare namespace Deno {
    * ```ts
    * import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
    *
-   * Deno.test("My test description", ():void => {
+   * Deno.test("My test description", (): void => {
    *   assertEquals("hello", "hello");
    * });
    *
-   * Deno.test("My async test description", async ():Promise<void> => {
+   * Deno.test("My async test description", async (): Promise<void> => {
    *   const decoder = new TextDecoder("utf-8");
    *   const data = await Deno.readFile("hello_world.txt");
    *   assertEquals(decoder.decode(data), "Hello world");
@@ -328,6 +328,73 @@ declare namespace Deno {
    */
   export function test(
     name: string,
+    fn: (t: TestContext) => void | Promise<void>,
+  ): void;
+
+  /** Register a test which will be run when `deno test` is used on the command
+   * line and the containing module looks like a test module.
+   * `fn` can be async if required. Declared function must have a name.
+   *
+   * ```ts
+   * import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
+   *
+   * Deno.test(function myTestName(): void {
+   *   assertEquals("hello", "hello");
+   * });
+   *
+   * Deno.test(async function myOtherTestName(): Promise<void> => {
+   *   const decoder = new TextDecoder("utf-8");
+   *   const data = await Deno.readFile("hello_world.txt");
+   *   assertEquals(decoder.decode(data), "Hello world");
+   * });
+   * ```
+   */
+  export function test(fn: (t: TestContext) => void | Promise<void>): void;
+
+  /** Register a test which will be run when `deno test` is used on the command
+   * line and the containing module looks like a test module.
+   * `fn` can be async if required.
+   *
+   * ```ts
+   * import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
+   *
+   * Deno.test("My test description", { permissions: { read: true } }, (): void => {
+   *   assertEquals("hello", "hello");
+   * });
+   *
+   * Deno.test("My async test description", { permissions: { read: false } }, async (): Promise<void> => {
+   *   const decoder = new TextDecoder("utf-8");
+   *   const data = await Deno.readFile("hello_world.txt");
+   *   assertEquals(decoder.decode(data), "Hello world");
+   * });
+   * ```
+   */
+  export function test(
+    name: string,
+    options: Omit<TestDefinition, "fn" | "name">,
+    fn: (t: TestContext) => void | Promise<void>,
+  ): void;
+
+  /** Register a test which will be run when `deno test` is used on the command
+   * line and the containing module looks like a test module.
+   * `fn` can be async if required.
+   *
+   * ```ts
+   * import {assert, fail, assertEquals} from "https://deno.land/std/testing/asserts.ts";
+   *
+   * Deno.test({ name: "My test description", permissions: { read: true } }, (): void => {
+   *   assertEquals("hello", "hello");
+   * });
+   *
+   * Deno.test({ name: "My async test description", permissions: { read: false } }, async (): Promise<void> => {
+   *   const decoder = new TextDecoder("utf-8");
+   *   const data = await Deno.readFile("hello_world.txt");
+   *   assertEquals(decoder.decode(data), "Hello world");
+   * });
+   * ```
+   */
+  export function test(
+    options: Omit<TestDefinition, "fn">,
     fn: (t: TestContext) => void | Promise<void>,
   ): void;
 

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -342,7 +342,7 @@ declare namespace Deno {
    *   assertEquals("hello", "hello");
    * });
    *
-   * Deno.test(async function myOtherTestName(): Promise<void> => {
+   * Deno.test(async function myOtherTestName(): Promise<void> {
    *   const decoder = new TextDecoder("utf-8");
    *   const data = await Deno.readFile("hello_world.txt");
    *   assertEquals(decoder.decode(data), "Hello world");

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -416,7 +416,7 @@ declare namespace Deno {
    * });
    * ```
    */
-   export function test(
+  export function test(
     options: Omit<TestDefinition, "fn" | "name">,
     fn: (t: TestContext) => void | Promise<void>,
   ): void;

--- a/cli/tests/integration/mod.rs
+++ b/cli/tests/integration/mod.rs
@@ -1016,29 +1016,29 @@ async fn test_resolve_dns() {
 
 #[test]
 fn typecheck_declarations_ns() {
-  let status = util::deno_cmd()
+  let output = util::deno_cmd()
     .arg("test")
     .arg("--doc")
     .arg(util::root_path().join("cli/dts/lib.deno.ns.d.ts"))
-    .spawn()
-    .unwrap()
-    .wait()
+    .output()
     .unwrap();
-  assert!(status.success());
+  println!("stdout: {}", output.stdout);
+  println!("stderr: {}", output.stderr);
+  assert!(output.status.success());
 }
 
 #[test]
 fn typecheck_declarations_unstable() {
-  let status = util::deno_cmd()
+  let output = util::deno_cmd()
     .arg("test")
     .arg("--doc")
     .arg("--unstable")
     .arg(util::root_path().join("cli/dts/lib.deno.unstable.d.ts"))
-    .spawn()
-    .unwrap()
-    .wait()
+    .output()
     .unwrap();
-  assert!(status.success());
+  println!("stdout: {}", output.stdout);
+  println!("stderr: {}", output.stderr);
+  assert!(output.status.success());
 }
 
 #[test]

--- a/cli/tests/integration/mod.rs
+++ b/cli/tests/integration/mod.rs
@@ -1022,8 +1022,8 @@ fn typecheck_declarations_ns() {
     .arg(util::root_path().join("cli/dts/lib.deno.ns.d.ts"))
     .output()
     .unwrap();
-  println!("stdout: {}", output.stdout);
-  println!("stderr: {}", output.stderr);
+  println!("stdout: {}", String::from_utf8(output.stdout).unwrap());
+  println!("stderr: {}", String::from_utf8(output.stderr).unwrap());
   assert!(output.status.success());
 }
 
@@ -1036,8 +1036,8 @@ fn typecheck_declarations_unstable() {
     .arg(util::root_path().join("cli/dts/lib.deno.unstable.d.ts"))
     .output()
     .unwrap();
-  println!("stdout: {}", output.stdout);
-  println!("stderr: {}", output.stderr);
+  println!("stdout: {}", String::from_utf8(output.stdout).unwrap());
+  println!("stderr: {}", String::from_utf8(output.stderr).unwrap());
   assert!(output.status.success());
 }
 

--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -19,6 +19,12 @@ fn no_color() {
   assert!(out.contains("test result: FAILED. 1 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out"));
 }
 
+itest!(overloads {
+  args: "test test/overloads.ts",
+  exit_code: 0,
+  output: "test/overloads.out",
+});
+
 itest!(meta {
   args: "test test/meta.ts",
   exit_code: 0,

--- a/cli/tests/testdata/test/overloads.out
+++ b/cli/tests/testdata/test/overloads.out
@@ -1,0 +1,10 @@
+Check [WILDCARD]/test/overloads.ts
+running 5 tests from [WILDCARD]/test/overloads.ts
+test test0 ... ok ([WILDCARD])
+test test1 ... ok ([WILDCARD])
+test test2 ... ok ([WILDCARD])
+test test3 ... ok ([WILDCARD])
+test test4 ... ok ([WILDCARD])
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+

--- a/cli/tests/testdata/test/overloads.out
+++ b/cli/tests/testdata/test/overloads.out
@@ -7,5 +7,5 @@ test test3 ... ok ([WILDCARD])
 test test4 ... ok ([WILDCARD])
 test test5 ... ignored ([WILDCARD])
 
-test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+test result: ok. 5 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out ([WILDCARD])
 

--- a/cli/tests/testdata/test/overloads.out
+++ b/cli/tests/testdata/test/overloads.out
@@ -1,10 +1,11 @@
 Check [WILDCARD]/test/overloads.ts
-running 5 tests from [WILDCARD]/test/overloads.ts
+running 6 tests from [WILDCARD]/test/overloads.ts
 test test0 ... ok ([WILDCARD])
 test test1 ... ok ([WILDCARD])
 test test2 ... ok ([WILDCARD])
 test test3 ... ok ([WILDCARD])
 test test4 ... ok ([WILDCARD])
+test test5 ... ignored ([WILDCARD])
 
-test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 

--- a/cli/tests/testdata/test/overloads.ts
+++ b/cli/tests/testdata/test/overloads.ts
@@ -1,0 +1,5 @@
+Deno.test("test0", () => {});
+Deno.test(function test1() {});
+Deno.test({ name: "test2", fn: () => {} });
+Deno.test("test3", { permissions: {} }, () => {});
+Deno.test({ name: "test4" }, () => {});

--- a/cli/tests/testdata/test/overloads.ts
+++ b/cli/tests/testdata/test/overloads.ts
@@ -1,5 +1,6 @@
 Deno.test("test0", () => {});
 Deno.test(function test1() {});
 Deno.test({ name: "test2", fn: () => {} });
-Deno.test("test3", { permissions: {} }, () => {});
+Deno.test("test3", { permissions: "none" }, () => {});
 Deno.test({ name: "test4" }, () => {});
+Deno.test({ ignore: true }, function test5 () {});

--- a/cli/tests/testdata/test/overloads.ts
+++ b/cli/tests/testdata/test/overloads.ts
@@ -3,4 +3,4 @@ Deno.test(function test1() {});
 Deno.test({ name: "test2", fn: () => {} });
 Deno.test("test3", { permissions: "none" }, () => {});
 Deno.test({ name: "test4" }, () => {});
-Deno.test({ ignore: true }, function test5 () {});
+Deno.test({ ignore: true }, function test5() {});

--- a/cli/tests/unit/testing_test.ts
+++ b/cli/tests/unit/testing_test.ts
@@ -51,7 +51,7 @@ unitTest(function testFnOverloading() {
       Deno.test({});
     },
     TypeError,
-    "Missing test function",
+    "Expected 'fn' field in the first argument to be a test function.",
   );
   assertThrows(
     () => {
@@ -59,7 +59,7 @@ unitTest(function testFnOverloading() {
       Deno.test({ fn: "boo!" });
     },
     TypeError,
-    "'fn' must be a function",
+    "Expected 'fn' field in the first argument to be a test function.",
   );
 });
 

--- a/cli/tests/unit/testing_test.ts
+++ b/cli/tests/unit/testing_test.ts
@@ -1,10 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertRejects, assertThrows, unitTest } from "./test_util.ts";
 
-unitTest(function testFnOverloading() {
-  // just verifying that you can use this test definition syntax
-  Deno.test("test fn overloading", () => {});
-
+unitTest(function testWrongOverloads() {
   assertThrows(
     () => {
       // @ts-ignore Testing invalid overloads

--- a/cli/tests/unit/testing_test.ts
+++ b/cli/tests/unit/testing_test.ts
@@ -4,6 +4,63 @@ import { assertRejects, assertThrows, unitTest } from "./test_util.ts";
 unitTest(function testFnOverloading() {
   // just verifying that you can use this test definition syntax
   Deno.test("test fn overloading", () => {});
+
+  assertThrows(
+    () => {
+      // @ts-ignore Testing invalid overloads
+      Deno.test("some name", { fn: () => {} }, () => {});
+    },
+    TypeError,
+    "Unexpected 'fn' field in options, test function is already provided as the third argument.",
+  );
+  assertThrows(
+    () => {
+      // @ts-ignore Testing invalid overloads
+      Deno.test("some name", { name: "some name2" }, () => {});
+    },
+    TypeError,
+    "Unexpected 'name' field in options, test name is already provided as the first argument.",
+  );
+  assertThrows(
+    () => {
+      // @ts-ignore Testing invalid overloads
+      Deno.test(() => {});
+    },
+    TypeError,
+    "The test function must have a name",
+  );
+  assertThrows(
+    () => {
+      // @ts-ignore Testing invalid overloads
+      Deno.test(function foo() {}, {});
+    },
+    TypeError,
+    "Unexpected second argument to Deno.test()",
+  );
+  assertThrows(
+    () => {
+      // @ts-ignore Testing invalid overloads
+      Deno.test({ fn: () => {} }, function foo() {});
+    },
+    TypeError,
+    "Unexpected 'fn' field in options, test function is already provided as the second argument.",
+  );
+  assertThrows(
+    () => {
+      // @ts-ignore Testing invalid overloads
+      Deno.test({});
+    },
+    TypeError,
+    "Missing test function",
+  );
+  assertThrows(
+    () => {
+      // @ts-ignore Testing invalid overloads
+      Deno.test({ fn: "boo!" });
+    },
+    TypeError,
+    "'fn' must be a function",
+  );
 });
 
 unitTest(function nameOfTestCaseCantBeEmpty() {

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -284,7 +284,7 @@ finishing test case.`;
         }
         if (optionsOrFn.name != undefined) {
           throw new TypeError(
-            "Unexpected 'fn' field in options, test name is already provided as the first argument.",
+            "Unexpected 'name' field in options, test name is already provided as the first argument.",
           );
         }
         testDef = {

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -321,8 +321,12 @@ finishing test case.`;
         }
         name = nameOrFnOrOptions.name ?? fn.name;
       } else {
-        if (!nameOrFnOrOptions.fn || typeof nameOrFnOrOptions.fn !== "function") {
-          throw new TypeError("Expected 'fn' field in the first argument to be a test function.");
+        if (
+          !nameOrFnOrOptions.fn || typeof nameOrFnOrOptions.fn !== "function"
+        ) {
+          throw new TypeError(
+            "Expected 'fn' field in the first argument to be a test function.",
+          );
         }
         fn = nameOrFnOrOptions.fn;
         name = nameOrFnOrOptions.name ?? fn.name;

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -321,11 +321,8 @@ finishing test case.`;
         }
         name = nameOrFnOrOptions.name ?? fn.name;
       } else {
-        if (!nameOrFnOrOptions.fn) {
-          throw new TypeError("Missing test function");
-        }
-        if (typeof nameOrFnOrOptions.fn !== "function") {
-          throw new TypeError("'fn' must be a function");
+        if (!nameOrFnOrOptions.fn || typeof nameOrFnOrOptions.fn !== "function") {
+          throw new TypeError("Expected 'fn' field in the first argument to be a test function.");
         }
         fn = nameOrFnOrOptions.fn;
         name = nameOrFnOrOptions.name ?? fn.name;

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -309,11 +309,13 @@ finishing test case.`;
       };
     } else {
       let fn;
+      let name;
       if (typeof optionsOrFn === "function") {
         fn = optionsOrFn;
         if (nameOrFnOrOptions.fn != undefined) {
           throw new TypeError("Missing test function");
         }
+        // TODO: name;
       } else {
         if (!nameOrFnOrOptions.fn) {
           throw new TypeError("Missing test function");
@@ -322,6 +324,7 @@ finishing test case.`;
           throw new TypeError("'fn' must be a function");
         }
         fn = nameOrFnOrOptions.fn;
+        // TODO: name;
       }
       if (!nameOrFnOrOptions.name) {
         throw new TypeError("The test name can't be empty");

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -277,12 +277,15 @@ finishing test case.`;
         if (!maybeFn || typeof maybeFn !== "function") {
           throw new TypeError("Missing test function");
         }
-        // TODO(bartlomieju):
         if (optionsOrFn.fn != undefined) {
-          throw new TypeError("Missing test function");
+          throw new TypeError(
+            "Unexpected 'fn' field in options, test function is already provided as the third argument.",
+          );
         }
         if (optionsOrFn.name != undefined) {
-          throw new TypeError("Missing test function");
+          throw new TypeError(
+            "Unexpected 'fn' field in options, test name is already provided as the first argument.",
+          );
         }
         testDef = {
           ...defaults,
@@ -295,12 +298,11 @@ finishing test case.`;
       if (!nameOrFnOrOptions.name) {
         throw new TypeError("The test function must have a name");
       }
-      // TODO(bartlomieju):
       if (optionsOrFn != undefined) {
-        throw new TypeError("Missing test function");
+        throw new TypeError("Unexpected second argument to Deno.test()");
       }
       if (maybeFn != undefined) {
-        throw new TypeError("Missing test function");
+        throw new TypeError("Unexpected third argument to Deno.test()");
       }
       testDef = {
         ...defaults,
@@ -313,9 +315,11 @@ finishing test case.`;
       if (typeof optionsOrFn === "function") {
         fn = optionsOrFn;
         if (nameOrFnOrOptions.fn != undefined) {
-          throw new TypeError("Missing test function");
+          throw new TypeError(
+            "Unexpected 'fn' field in options, test function is already provided as the second argument.",
+          );
         }
-        // TODO: name;
+        name = nameOrFnOrOptions.name ?? fn.name;
       } else {
         if (!nameOrFnOrOptions.fn) {
           throw new TypeError("Missing test function");
@@ -324,12 +328,12 @@ finishing test case.`;
           throw new TypeError("'fn' must be a function");
         }
         fn = nameOrFnOrOptions.fn;
-        // TODO: name;
+        name = nameOrFnOrOptions.name ?? fn.name;
       }
-      if (!nameOrFnOrOptions.name) {
+      if (!name) {
         throw new TypeError("The test name can't be empty");
       }
-      testDef = { ...defaults, ...nameOrFnOrOptions, fn };
+      testDef = { ...defaults, ...nameOrFnOrOptions, fn, name };
     }
 
     testDef.fn = wrapTestFnWithSanitizers(testDef.fn, testDef);


### PR DESCRIPTION
This commit adds 4 more overloads to "Deno.test()" API.

```
// Deno.test(function testName() { });
export function test(fn: (t: TestContext) => void | Promise<void>): void;

// Deno.test("test name", { only: true }, function() { });
export function test(
  name: string,
  options: Omit<TestDefinition, "name">,
  fn: (t: TestContext) => void | Promise<void>,
): void;

// Deno.test({ name: "test name" }, function() { });
export function test(
  options: Omit<TestDefinition, "fn">,
  fn: (t: TestContext) => void | Promise<void>,
): void;

// Deno.test({ only: true }, function testName() { });
export function test(
  options: Omit<TestDefinition, "fn" | "name">,
  fn: (t: TestContext) => void | Promise<void>,
): void;
```

Closes https://github.com/denoland/deno/issues/12744