### PR TITLE
fix(lsp): retain module dependencies when parse is invalid

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -492,19 +492,17 @@ async fn generate_deps_diagnostics(
         .get_version(document.specifier(), &DiagnosticSource::Deno);
       if version != current_version {
         let mut diagnostics = Vec::new();
-        if let Some(dependencies) = document.dependencies() {
-          for (_, dependency) in dependencies {
-            diagnose_dependency(
-              &mut diagnostics,
-              &documents,
-              &dependency.maybe_code,
-            );
-            diagnose_dependency(
-              &mut diagnostics,
-              &documents,
-              &dependency.maybe_type,
-            );
-          }
+        for (_, dependency) in document.dependencies() {
+          diagnose_dependency(
+            &mut diagnostics,
+            &documents,
+            &dependency.maybe_code,
+          );
+          diagnose_dependency(
+            &mut diagnostics,
+            &documents,
+            &dependency.maybe_type,
+          );
         }
         diagnostics_vec.push((
           document.specifier().clone(),

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -987,17 +987,16 @@ impl Inner {
     let asset_or_document = self.get_cached_asset_or_document(&specifier)?;
     let line_index = asset_or_document.line_index();
 
-    let req = tsc::RequestMethod::GetNavigationTree(specifier);
-    let navigation_tree: tsc::NavigationTree = self
-      .ts_server
-      .request(self.snapshot()?, req)
-      .await
-      .map_err(|err| {
-        error!("Failed to request to tsserver {}", err);
-        LspError::invalid_request()
+    let navigation_tree =
+      self.get_navigation_tree(&specifier).await.map_err(|err| {
+        error!(
+          "Error getting document symbols for \"{}\": {}",
+          specifier, err
+        );
+        LspError::internal_error()
       })?;
 
-    let response = if let Some(child_items) = navigation_tree.child_items {
+    let response = if let Some(child_items) = &navigation_tree.child_items {
       let mut document_symbols = Vec::<DocumentSymbol>::new();
       for item in child_items {
         item
@@ -1543,7 +1542,7 @@ impl Inner {
     let asset_or_doc = self.get_cached_asset_or_document(&specifier)?;
     let line_index = asset_or_doc.line_index();
     let req = tsc::RequestMethod::GetReferences((
-      specifier,
+      specifier.clone(),
       line_index.offset_tsc(params.text_document_position.position)?,
     ));
     let maybe_references: Option<Vec<tsc::ReferenceEntry>> = self
@@ -1563,9 +1562,14 @@ impl Inner {
         }
         let reference_specifier =
           resolve_url(&reference.document_span.file_name).unwrap();
-        let asset_or_doc =
-          self.get_asset_or_document(&reference_specifier).await?;
-        results.push(reference.to_location(asset_or_doc.line_index(), self));
+        let reference_line_index = if reference_specifier == specifier {
+          line_index.clone()
+        } else {
+          let asset_or_doc =
+            self.get_asset_or_document(&reference_specifier).await?;
+          asset_or_doc.line_index()
+        };
+        results.push(reference.to_location(reference_line_index, self));
       }
 
       self.performance.measure(mark);
@@ -2157,7 +2161,7 @@ impl Inner {
         LspError::invalid_request()
       })?;
 
-    let semantic_tokens: SemanticTokens =
+    let semantic_tokens =
       semantic_classification.to_semantic_tokens(line_index);
     let response = if !semantic_tokens.data.is_empty() {
       Some(SemanticTokensResult::Tokens(semantic_tokens))
@@ -2200,7 +2204,7 @@ impl Inner {
         LspError::invalid_request()
       })?;
 
-    let semantic_tokens: SemanticTokens =
+    let semantic_tokens =
       semantic_classification.to_semantic_tokens(line_index);
     let response = if !semantic_tokens.data.is_empty() {
       Some(SemanticTokensRangeResult::Tokens(semantic_tokens))

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -2162,7 +2162,7 @@ impl Inner {
       })?;
 
     let semantic_tokens =
-      semantic_classification.to_semantic_tokens(line_index);
+      semantic_classification.to_semantic_tokens(line_index)?;
     let response = if !semantic_tokens.data.is_empty() {
       Some(SemanticTokensResult::Tokens(semantic_tokens))
     } else {
@@ -2205,7 +2205,7 @@ impl Inner {
       })?;
 
     let semantic_tokens =
-      semantic_classification.to_semantic_tokens(line_index);
+      semantic_classification.to_semantic_tokens(line_index)?;
     let response = if !semantic_tokens.data.is_empty() {
       Some(SemanticTokensRangeResult::Tokens(semantic_tokens))
     } else {

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1141,14 +1141,23 @@ impl Classifications {
       let start_pos = line_index.position_tsc(offset.into());
       let end_pos = line_index.position_tsc(TextSize::from(offset + length));
 
-      // start_pos.line == end_pos.line is always true as there are no multiline tokens
-      builder.push(
-        start_pos.line,
-        start_pos.character,
-        end_pos.character - start_pos.character,
-        token_type,
-        token_modifiers,
-      );
+      if start_pos.line == end_pos.line
+        && start_pos.character <= end_pos.character
+      {
+        builder.push(
+          start_pos.line,
+          start_pos.character,
+          end_pos.character - start_pos.character,
+          token_type,
+          token_modifiers,
+        );
+      } else {
+        log::error!(
+          "unexpected positions\nstart_pos: {:?}\nend_pos: {:?}",
+          start_pos,
+          end_pos
+        );
+      }
     }
     builder.build(None)
   }

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -38,6 +38,8 @@ use deno_core::OpFn;
 use deno_core::RuntimeOptions;
 use deno_runtime::tokio_util::create_basic_runtime;
 use log::warn;
+use lspower::jsonrpc::Error as LspError;
+use lspower::jsonrpc::Result as LspResult;
 use lspower::lsp;
 use regex::Captures;
 use regex::Regex;
@@ -1122,7 +1124,7 @@ impl Classifications {
   pub fn to_semantic_tokens(
     &self,
     line_index: Arc<LineIndex>,
-  ) -> lsp::SemanticTokens {
+  ) -> LspResult<lsp::SemanticTokens> {
     let token_count = self.spans.len() / 3;
     let mut builder = SemanticTokensBuilder::new();
     for i in 0..token_count {
@@ -1157,9 +1159,10 @@ impl Classifications {
           start_pos,
           end_pos
         );
+        return Err(LspError::internal_error());
       }
     }
-    builder.build(None)
+    Ok(builder.build(None))
   }
 
   fn get_token_type_from_classification(ts_classification: u32) -> u32 {

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -1066,10 +1066,10 @@ fn lsp_hover_dependency() {
   );
 }
 
-// Regression test for #12753
+// This tests for a regression covered by denoland/deno#12753 where the lsp was
+// unable to resolve dependencies when there was an invalid syntax in the module
 #[test]
-#[ignore]
-fn lsp_hover_keep_type_info_after_invalid_syntax_change() {
+fn lsp_hover_deps_preserved_when_invalid_parse() {
   let mut client = init("initialize_params.json");
   did_open(
     &mut client,


### PR DESCRIPTION
Fixes #12753
