### PR TITLE
feat: ALPN support in `Deno.connectTls()`

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -935,6 +935,22 @@ declare namespace Deno {
     certChain?: string;
     /** PEM formatted (RSA or PKCS8) private key of client certificate. */
     privateKey?: string;
+    /** **UNSTABLE**: new API, yet to be vetted.
+     *
+     * Application-Layer Protocol Negotiation (ALPN) protocols supported by
+     * the client. If not specified, no ALPN extension will be included in the
+     * TLS handshake.
+     */
+    alpnProtocols?: string[];
+  }
+
+  export interface TlsConn extends Conn {
+    /** **UNSTABLE**: new API, yet to be vetted.
+     *
+     * Returns the ALPN protocol selected during negotiation with the server.
+     * If no ALPN protocol selected, returns `null`.
+     */
+    getAgreedAlpnProtocol(): Promise<string | null>;
   }
 
   /** **UNSTABLE** New API, yet to be vetted.

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -944,13 +944,20 @@ declare namespace Deno {
     alpnProtocols?: string[];
   }
 
-  export interface TlsConn extends Conn {
+  export interface TlsHandshakeInfo {
     /** **UNSTABLE**: new API, yet to be vetted.
      *
-     * Returns the ALPN protocol selected during negotiation with the server.
+     * Contains the ALPN protocol selected during negotiation with the server.
      * If no ALPN protocol selected, returns `null`.
      */
-    getAgreedAlpnProtocol(): Promise<string | null>;
+    alpnProtocol: string | null;
+  }
+
+  export interface TlsConn extends Conn {
+    /** Runs the client or server handshake protocol to completion if that has
+     * not happened yet. Calling this method is optional; the TLS handshake
+     * will be completed automatically as soon as data is sent or received. */
+    handshake(): Promise<TlsHandshakeInfo>;
   }
 
   /** **UNSTABLE** New API, yet to be vetted.
@@ -971,6 +978,16 @@ declare namespace Deno {
   export function connectTls(options: ConnectTlsOptions): Promise<TlsConn>;
 
   export interface ListenTlsOptions {
+    /** **UNSTABLE**: new API, yet to be vetted.
+     *
+     * Application-Layer Protocol Negotiation (ALPN) protocols to announce to
+     * the client. If not specified, no ALPN extension will be included in the
+     * TLS handshake.
+     */
+    alpnProtocols?: string[];
+  }
+
+  export interface StartTlsOptions {
     /** **UNSTABLE**: new API, yet to be vetted.
      *
      * Application-Layer Protocol Negotiation (ALPN) protocols to announce to

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -364,7 +364,7 @@ Deno.test(
   },
 );
 
-unitTest(
+Deno.test(
   { permissions: { read: true, net: true } },
   async function tlsServerAlpnListenStartTls() {
     const [serverConn, clientConn] = await tlsAlpn(true);
@@ -380,7 +380,7 @@ unitTest(
   },
 );
 
-unitTest(
+Deno.test(
   { permissions: { read: true, net: true } },
   async function tlsServerStreamHalfCloseSendOneByte() {
     const [serverConn, clientConn] = await tlsPair();

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -244,6 +244,49 @@ async function tlsPair(): Promise<[Deno.Conn, Deno.Conn]> {
   return endpoints;
 }
 
+async function tlsAlpn(
+  useStartTls: boolean,
+): Promise<[Deno.TlsConn, Deno.TlsConn]> {
+  const port = getPort();
+  const listener = Deno.listenTls({
+    hostname: "localhost",
+    port,
+    certFile: "cli/tests/testdata/tls/localhost.crt",
+    keyFile: "cli/tests/testdata/tls/localhost.key",
+    alpnProtocols: ["deno", "rocks"],
+  });
+
+  const acceptPromise = listener.accept();
+
+  const caCerts = [Deno.readTextFileSync("cli/tests/testdata/tls/RootCA.pem")];
+  const clientAlpnProtocols = ["rocks", "rises"];
+  let endpoints: [Deno.TlsConn, Deno.TlsConn];
+
+  if (!useStartTls) {
+    const connectPromise = Deno.connectTls({
+      hostname: "localhost",
+      port,
+      caCerts,
+      alpnProtocols: clientAlpnProtocols,
+    });
+    endpoints = await Promise.all([acceptPromise, connectPromise]);
+  } else {
+    const client = await Deno.connect({
+      hostname: "localhost",
+      port,
+    });
+    const connectPromise = Deno.startTls(client, {
+      hostname: "localhost",
+      caCerts,
+      alpnProtocols: clientAlpnProtocols,
+    });
+    endpoints = await Promise.all([acceptPromise, connectPromise]);
+  }
+
+  listener.close();
+  return endpoints;
+}
+
 async function sendThenCloseWriteThenReceive(
   conn: Deno.Conn,
   chunkCount: number,
@@ -306,6 +349,38 @@ async function receiveThenSend(
 }
 
 Deno.test(
+  { permissions: { read: true, net: true } },
+  async function tlsServerAlpnListenConnect() {
+    const [serverConn, clientConn] = await tlsAlpn(false);
+    const [serverHS, clientHS] = await Promise.all([
+      serverConn.handshake(),
+      clientConn.handshake(),
+    ]);
+    assertStrictEquals(serverHS.alpnProtocol, "rocks");
+    assertStrictEquals(clientHS.alpnProtocol, "rocks");
+
+    serverConn.close();
+    clientConn.close();
+  },
+);
+
+unitTest(
+  { permissions: { read: true, net: true } },
+  async function tlsServerAlpnListenStartTls() {
+    const [serverConn, clientConn] = await tlsAlpn(true);
+    const [serverHS, clientHS] = await Promise.all([
+      serverConn.handshake(),
+      clientConn.handshake(),
+    ]);
+    assertStrictEquals(serverHS.alpnProtocol, "rocks");
+    assertStrictEquals(clientHS.alpnProtocol, "rocks");
+
+    serverConn.close();
+    clientConn.close();
+  },
+);
+
+unitTest(
   { permissions: { read: true, net: true } },
   async function tlsServerStreamHalfCloseSendOneByte() {
     const [serverConn, clientConn] = await tlsPair();

--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -27,15 +27,7 @@
     return core.opAsync("op_tls_handshake", rid);
   }
 
-  function opTlsGetAlpnProtocol(rid) {
-    return core.opAsync("op_tls_get_alpn_protocol", rid);
-  }
-
   class TlsConn extends Conn {
-    getAgreedAlpnProtocol() {
-      return opTlsGetAlpnProtocol(this.rid);
-    }
-
     handshake() {
       return opTlsHandshake(this.rid);
     }
@@ -49,7 +41,7 @@
     caCerts = [],
     certChain = undefined,
     privateKey = undefined,
-    alpnProtocols,
+    alpnProtocols = undefined,
   }) {
     const res = await opConnectTls({
       port,
@@ -77,7 +69,7 @@
     keyFile,
     hostname = "0.0.0.0",
     transport = "tcp",
-    alpnProtocols,
+    alpnProtocols = undefined,
   }) {
     const res = opListenTls({
       port,
@@ -92,13 +84,19 @@
 
   async function startTls(
     conn,
-    { hostname = "127.0.0.1", certFile = undefined, caCerts = [] } = {},
+    {
+      hostname = "127.0.0.1",
+      certFile = undefined,
+      caCerts = [],
+      alpnProtocols = undefined,
+    } = {},
   ) {
     const res = await opStartTls({
       rid: conn.rid,
       hostname,
       certFile,
       caCerts,
+      alpnProtocols,
     });
     return new TlsConn(res.rid, res.remoteAddr, res.localAddr);
   }

--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -27,7 +27,15 @@
     return core.opAsync("op_tls_handshake", rid);
   }
 
+  function opTlsGetAlpnProtocol(rid) {
+    return core.opAsync("op_tls_get_alpn_protocol", rid);
+  }
+
   class TlsConn extends Conn {
+    getAgreedAlpnProtocol() {
+      return opTlsGetAlpnProtocol(this.rid);
+    }
+
     handshake() {
       return opTlsHandshake(this.rid);
     }
@@ -41,6 +49,7 @@
     caCerts = [],
     certChain = undefined,
     privateKey = undefined,
+    alpnProtocols,
   }) {
     const res = await opConnectTls({
       port,
@@ -50,6 +59,7 @@
       caCerts,
       certChain,
       privateKey,
+      alpnProtocols,
     });
     return new TlsConn(res.rid, res.remoteAddr, res.localAddr);
   }

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -52,11 +52,14 @@ declare namespace Deno {
     closeWrite(): Promise<void>;
   }
 
+  // deno-lint-ignore no-empty-interface
+  export interface TlsHandshakeInfo {}
+
   export interface TlsConn extends Conn {
     /** Runs the client or server handshake protocol to completion if that has
      * not happened yet. Calling this method is optional; the TLS handshake
      * will be completed automatically as soon as data is sent or received. */
-    handshake(): Promise<void>;
+    handshake(): Promise<TlsHandshakeInfo>;
   }
 
   export interface ListenOptions {

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -85,7 +85,7 @@ pub struct OpPacket {
   pub remote_addr: OpAddr,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TlsHandshakeInfo {
   pub alpn_protocol: Option<ByteString>,

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -12,6 +12,7 @@ use deno_core::error::AnyError;
 use deno_core::op_async;
 use deno_core::op_sync;
 use deno_core::AsyncRefCell;
+use deno_core::ByteString;
 use deno_core::CancelHandle;
 use deno_core::CancelTryFuture;
 use deno_core::OpPair;
@@ -82,6 +83,12 @@ pub enum OpAddr {
 pub struct OpPacket {
   pub size: usize,
   pub remote_addr: OpAddr,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TlsHandshakeInfo {
+  pub alpn_protocol: Option<ByteString>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
* Make `connectTls()` accept `alpnProtocols` option
  (string[]), just like `listenTls()`.

* Add `alpnProtocol` to `TlsConn#handshake` return
  value to query the protocol agreed with the peer via ALPN.

The `alpnProtocols` is added as an unstable API (mirroring
how it's supported in `listenTls()`).

We need this change for making a Deno client for EdgeDB. EdgeDB
requires TLS by default and uses ALPN to upgrade connections to
its binary protocol. Without these APIs we can't support Deno,
something we really want to have.

Fixes: https://github.com/denoland/deno/issues/11479