### PR TITLE
feat(ext/cache): partial service-worker cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_cache"
+version = "0.0.0"
+dependencies = [
+ "deno_core",
+]
+
+[[package]]
 name = "deno_console"
 version = "0.27.0"
 dependencies = [
@@ -897,6 +904,7 @@ version = "0.35.0"
 dependencies = [
  "atty",
  "deno_broadcast_channel",
+ "deno_cache",
  "deno_console",
  "deno_core",
  "deno_crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "test_ffi",
   "test_util",
   "ext/broadcast_channel",
+  "ext/cache",
   "ext/console",
   "ext/crypto",
   "ext/fetch",

--- a/ext/cache/01_swcache.js
+++ b/ext/cache/01_swcache.js
@@ -1,0 +1,142 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+// @ts-check
+/// <reference path="../../core/internal.d.ts" />
+/// <reference path="../fetch/lib.deno_fetch.d.ts" />
+
+"use strict";
+
+((window) => {
+  const {
+    ArrayPrototypeJoin,
+    Map,
+    MapPrototypeDelete,
+    MapPrototypeGet,
+    MapPrototypeSet,
+    ObjectFromEntries,
+    PromiseResolve,
+  } = window.__bootstrap.primordials;
+  const { Request, Response } = window.__bootstrap.fetch;
+
+  class Caches {
+    constructor(engine) {
+      this.engine = engine;
+    }
+
+    get default() {
+      return new Cache(this.engine, "default");
+    }
+
+    async open(cacheNs) {
+      await this.engine.open(cacheNs);
+      return new Cache(this.engine, cacheNs);
+    }
+  }
+
+  class Cache {
+    constructor(engine, cacheNs) {
+      this.engine = engine;
+      this.cacheNs = cacheNs;
+    }
+
+    match(reqOrUrl, _cacheOptions) {
+      const key = toKey(reqOrUrl);
+      return this.engine.get(this.cacheNs, key);
+    }
+
+    put(reqOrUrl, resp) {
+      const key = toKey(reqOrUrl);
+      return this.engine.set(this.cacheNs, key, resp);
+    }
+
+    delete(reqOrUrl) {
+      const key = toKey(reqOrUrl);
+      return this.engine.del(this.cacheNs, key);
+    }
+
+    /// Other methods are intentionally unsupported, for now
+  }
+
+  function toKey(reqOrUrl) {
+    return reqToKey(asReq(reqOrUrl));
+  }
+
+  function asReq(reqOrUrl) {
+    return reqOrUrl instanceof Request ? reqOrUrl : new Request(reqOrUrl);
+  }
+
+  function reqToKey(req) {
+    return ArrayPrototypeJoin([req.url, req.method], ":");
+  }
+
+  // A no-op cache engine, cache-disabled
+  class VoidEngine {
+    open(_cacheNs) {
+      return PromiseResolve();
+    }
+    set(_cacheNs, _key, _resp) {
+      return PromiseResolve();
+    }
+    get(_cacheNs, _key) {
+      return PromiseResolve();
+    }
+    del(_cacheNs, _key) {
+      return PromiseResolve(false);
+    }
+  }
+
+  // Incredibly naive cache-engine, in-memory and unbounded
+  class NaiveEngine {
+    constructor() {
+      this.kvs = new Map();
+    }
+
+    open(_cacheNs) {
+      return PromiseResolve();
+    }
+
+    async set(cacheNs, key, resp) {
+      MapPrototypeSet(
+        this.kvs,
+        this.key(cacheNs, key),
+        await this.persisted(resp),
+      );
+    }
+
+    get(cacheNs, key) {
+      const resp = MapPrototypeGet(this.kvs, this.key(cacheNs, key));
+      return PromiseResolve(resp ? this.fromPersisted(resp) : undefined);
+    }
+
+    del(cacheNs, key) {
+      return PromiseResolve(
+        MapPrototypeDelete(this.kvs, this.key(cacheNs, key)),
+      );
+    }
+
+    key(cacheNs, key) {
+      return `${cacheNs}:${key}`;
+    }
+
+    fromPersisted(pResp) {
+      const { body, ...init } = pResp;
+      return new Response(body, init);
+    }
+
+    async persisted(resp) {
+      return {
+        body: await resp.arrayBuffer(),
+        headers: ObjectFromEntries(resp.headers.entries()),
+        status: resp.status,
+        statusText: resp.statusText,
+      };
+    }
+  }
+
+  window.__bootstrap.cache = {
+    Cache,
+    Caches,
+    NaiveEngine,
+    VoidEngine,
+  };
+})(globalThis);

--- a/ext/cache/Cargo.toml
+++ b/ext/cache/Cargo.toml
@@ -1,0 +1,17 @@
+# Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+[package]
+name = "deno_cache"
+version = "0.0.0"
+authors = ["the Deno authors"]
+edition = "2021"
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/denoland/deno"
+description = "Implementation of SW Cache API for Deno"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+deno_core = { version = "0.109.0", path = "../../core" }

--- a/ext/cache/README.md
+++ b/ext/cache/README.md
@@ -1,0 +1,5 @@
+# deno_cache
+
+This crate implements a subset (match/put/delete) of the SW Cache API.
+
+Spec: https://w3c.github.io/ServiceWorker/#cache-match

--- a/ext/cache/internal.d.ts
+++ b/ext/cache/internal.d.ts
@@ -1,0 +1,17 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/// <reference no-default-lib="true" />
+/// <reference lib="esnext" />
+
+declare namespace globalThis {
+  declare namespace __bootstrap {
+    declare namespace cache {
+      declare interface CacheEngine {
+        open(cacheNs: string): Promise<void>;
+        get(cacheNs: string, key: string): Promise<Response>;
+        set(cacheNs: string, key: string, resp: Response): Promise<void>;
+        del(cacheNs: string, key: string): Promise<boolean>;
+      }
+    }
+  }
+}

--- a/ext/cache/lib.deno_cache.d.ts
+++ b/ext/cache/lib.deno_cache.d.ts
@@ -1,0 +1,6 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/// <reference no-default-lib="true" />
+/// <reference lib="esnext" />
+
+// TODO(@AaronO): add types

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -1,0 +1,18 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+use deno_core::include_js_files;
+use deno_core::Extension;
+use std::path::PathBuf;
+
+pub fn init() -> Extension {
+  Extension::builder()
+    .js(include_js_files!(
+      prefix "deno:ext/cache",
+      "01_swcache.js",
+    ))
+    .build()
+}
+
+pub fn get_declaration() -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("lib.deno_console.d.ts")
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -23,6 +23,7 @@ path = "examples/hello_runtime.rs"
 
 [build-dependencies]
 deno_broadcast_channel = { version = "0.21.0", path = "../ext/broadcast_channel" }
+deno_cache = { version = "0.0.0", path = "../ext/cache" }
 deno_console = { version = "0.27.0", path = "../ext/console" }
 deno_core = { version = "0.109.0", path = "../core" }
 deno_crypto = { version = "0.41.0", path = "../ext/crypto" }
@@ -45,6 +46,7 @@ winapi = "0.3.9"
 
 [dependencies]
 deno_broadcast_channel = { version = "0.21.0", path = "../ext/broadcast_channel" }
+deno_cache = { version = "0.0.0", path = "../ext/cache" }
 deno_console = { version = "0.27.0", path = "../ext/console" }
 deno_core = { version = "0.109.0", path = "../core" }
 deno_crypto = { version = "0.41.0", path = "../ext/crypto" }

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -122,6 +122,7 @@ mod not_docs {
       deno_tls::init(),
       deno_web::init(deno_web::BlobStore::default(), Default::default()),
       deno_fetch::init::<Permissions>(Default::default()),
+      deno_cache::init(),
       deno_websocket::init::<Permissions>("".to_owned(), None, None),
       deno_webstorage::init(None),
       deno_crypto::init(None),

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -62,6 +62,7 @@ delete Object.prototype.__proto__;
   const { defineEventHandler } = window.__bootstrap.event;
   const { deserializeJsMessageData, serializeJsMessageData } =
     window.__bootstrap.messagePort;
+  const cache = window.__bootstrap.cache;
 
   let windowIsClosing = false;
 
@@ -438,6 +439,9 @@ delete Object.prototype.__proto__;
     setInterval: util.writable(timers.setInterval),
     setTimeout: util.writable(timers.setTimeout),
     structuredClone: util.writable(messagePort.structuredClone),
+    caches: util.nonEnumerable(
+      new cache.Caches(new cache.NaiveEngine()),
+    ),
   };
 
   const unstableWindowOrWorkerGlobalScope = {

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -110,6 +110,7 @@ impl MainWorker {
         file_fetch_handler: Box::new(deno_fetch::FsFetchHandler),
         ..Default::default()
       }),
+      deno_cache::init(),
       deno_websocket::init::<Permissions>(
         options.user_agent.clone(),
         options.root_cert_store.clone(),

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -8537,5 +8537,14 @@
       "Pattern: [] Inputs: [{}]",
       "Pattern: [] Inputs: []"
     ]
+  },
+  "service-workers": {
+    "idlharness.https.any.html": false,
+    "idlharness.https.any.worker.html": false,
+    "service-worker": {
+      "fetch-request-xhr-sync-error.https.window.html": false,
+      "ready.https.window.html": false,
+      "xhr-content-length.https.window.html": false
+    }
   }
 }


### PR DESCRIPTION
First pass at implementing partial(match/put/delete) SW Cache support

Ships with a naive in-memory CacheEngine which should be swapped out for an LRU or another store can be customized by embedders

It is not batteries-included, cache-control matching etc... is left as an exercise to the engine providers ...