### PR TITLE
feat(ext/crypto): support md5 in subtle.digest()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ dependencies = [
  "deno_web",
  "elliptic-curve",
  "lazy_static",
+ "md5",
  "num-traits",
  "p256",
  "p384",
@@ -2177,6 +2178,12 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -1,5 +1,62 @@
 import { assert, assertEquals, assertRejects } from "./test_util.ts";
 
+unitTest(async function testDigest() {
+  const subtle = window.crypto.subtle;
+  assert(subtle);
+
+  {
+    const result = await subtle.digest({ name: "MD5" }, new Uint8Array([42]));
+    const actual = [...new Uint8Array(result)];
+    const expected = [
+      0x33,
+      0x89,
+      0xda,
+      0xe3,
+      0x61,
+      0xaf,
+      0x79,
+      0xb0,
+      0x4c,
+      0x9c,
+      0x8e,
+      0x70,
+      0x57,
+      0xf6,
+      0x0c,
+      0xc6,
+    ];
+    assertEquals(actual, expected);
+  }
+
+  {
+    const result = await subtle.digest({ name: "SHA-1" }, new Uint8Array([42]));
+    const actual = [...new Uint8Array(result)];
+    const expected = [
+      0xdf,
+      0x58,
+      0x24,
+      0x8c,
+      0x41,
+      0x4f,
+      0x34,
+      0x2c,
+      0x81,
+      0xe0,
+      0x56,
+      0xb4,
+      0x0b,
+      0xee,
+      0x12,
+      0xd1,
+      0x7a,
+      0x08,
+      0xbf,
+      0x61,
+    ];
+    assertEquals(actual, expected);
+  }
+});
+
 // https://github.com/denoland/deno/issues/11664
 Deno.test(async function testImportArrayBufferKey() {
   const subtle = window.crypto.subtle;

--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals, assertRejects } from "./test_util.ts";
 
-unitTest(async function testDigest() {
+Deno.test(async function testDigest() {
   const subtle = window.crypto.subtle;
   assert(subtle);
 

--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -185,6 +185,10 @@
     // 4.
     let algName = initialAlg.name;
 
+    if (op === "digest" && "MD5" === StringPrototypeToUpperCase(algName)) {
+      return { name: "MD5" };
+    }
+
     // 5.
     let desiredType = undefined;
     for (const key in registeredAlgorithms) {
@@ -429,11 +433,16 @@
 
       algorithm = normalizeAlgorithm(algorithm, "digest");
 
-      const result = await core.opAsync(
-        "op_crypto_subtle_digest",
-        algorithm.name,
-        data,
-      );
+      let result;
+      if (algorithm.name === "MD5") {
+        result = await core.opAsync("op_crypto_subtle_digest_md5", null, data);
+      } else {
+        result = await core.opAsync(
+          "op_crypto_subtle_digest",
+          algorithm.name,
+          data,
+        );
+      }
 
       return result.buffer;
     }

--- a/ext/crypto/Cargo.toml
+++ b/ext/crypto/Cargo.toml
@@ -20,6 +20,7 @@ deno_core = { version = "0.109.0", path = "../../core" }
 deno_web = { version = "0.58.0", path = "../web" }
 elliptic-curve = "0.10.6"
 lazy_static = "1.4.0"
+md5 = "0.7.0"
 num-traits = "0.2.14"
 p256 = { version = "0.9.0", features = ["ecdh"] }
 p384 = "0.8.0"

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -117,6 +117,10 @@ pub fn init(maybe_seed: Option<u64>) -> Extension {
       ("op_crypto_encrypt_key", op_async(op_crypto_encrypt_key)),
       ("op_crypto_decrypt_key", op_async(op_crypto_decrypt_key)),
       ("op_crypto_subtle_digest", op_async(op_crypto_subtle_digest)),
+      (
+        "op_crypto_subtle_digest_md5",
+        op_async(op_crypto_subtle_digest_md5),
+      ),
       ("op_crypto_random_uuid", op_sync(op_crypto_random_uuid)),
     ])
     .state(move |state| {
@@ -1677,6 +1681,18 @@ pub async fn op_crypto_subtle_digest(
       .into()
   })
   .await?;
+
+  Ok(output)
+}
+
+pub async fn op_crypto_subtle_digest_md5(
+  _state: Rc<RefCell<OpState>>,
+  _: (),
+  data: ZeroCopyBuf,
+) -> Result<ZeroCopyBuf, AnyError> {
+  let output =
+    tokio::task::spawn_blocking(move || md5::compute(&data).to_vec().into())
+      .await?;
 
   Ok(output)
 }


### PR DESCRIPTION
Non-spec, but compatible with CF Workers.

Fixes #12715.