### PR TITLE
fix(lsp): tag deprecated diagnostics properly

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -285,9 +285,10 @@ fn ts_json_to_diagnostics(
           ),
           tags: match d.code {
             // These are codes that indicate the variable is unused.
-            2695 | 6133 | 6138 | 6192 | 6196 | 6198 | 6199 | 7027 | 7028 => {
-              Some(vec![lsp::DiagnosticTag::Unnecessary])
-            }
+            2695 | 6133 | 6138 | 6192 | 6196 | 6198 | 6199 | 6205 | 7027
+            | 7028 => Some(vec![lsp::DiagnosticTag::Unnecessary]),
+            // These are codes that indicated the variable is deprecated.
+            2789 | 6385 | 6387 => Some(vec![lsp::DiagnosticTag::Deprecated]),
             _ => None,
           },
           data: None,

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -3015,6 +3015,64 @@ fn lsp_diagnostics_warn() {
 }
 
 #[test]
+fn lsp_diagnostics_deprecated() {
+  let mut client = init("initialize_params.json");
+  let diagnostics = did_open(
+    &mut client,
+    json!({
+      "textDocument": {
+        "uri": "file:///a/file.ts",
+        "languageId": "typescript",
+        "version": 1,
+        "text": "/** @deprecated */\nexport const a = \"a\";\n\na;\n",
+      },
+    }),
+  );
+  assert_eq!(
+    json!(diagnostics),
+    json!([
+      {
+        "uri": "file:///a/file.ts",
+        "diagnostics": [],
+        "version": 1
+      },
+      {
+        "uri": "file:///a/file.ts",
+        "diagnostics": [],
+        "version": 1
+      },
+      {
+        "uri": "file:///a/file.ts",
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 3,
+                "character": 0
+              },
+              "end": {
+                "line": 3,
+                "character": 1
+              }
+            },
+            "severity": 4,
+            "code": 6385,
+            "source": "deno-ts",
+            "message": "'a' is deprecated.",
+            "relatedInformation": [],
+            "tags": [
+              2
+            ]
+          }
+        ],
+        "version": 1
+      }
+    ])
+  );
+  shutdown(&mut client);
+}
+
+#[test]
 fn lsp_diagnostics_deno_types() {
   let mut client = init("initialize_params.json");
   client


### PR DESCRIPTION
We weren't tagging deprecated diagnostics as deprecated, meaning they would not appear properly in the editor.