### PR TITLE
fix(testing): do not throw on error.errors.map

### DIFF
--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -9,6 +9,7 @@
   const { serializePermissions } = window.__bootstrap.permissions;
   const { assert } = window.__bootstrap.util;
   const {
+    AggregateError,
     ArrayPrototypeFilter,
     ArrayPrototypePush,
     ArrayPrototypeSome,
@@ -297,7 +298,7 @@ finishing test case.`;
   }
 
   function formatError(error) {
-    if (error.errors) {
+    if (error instanceof AggregateError) {
       const message = error
         .errors
         .map((error) =>


### PR DESCRIPTION
In tests, the function to format errors would assume that any property `errors` on error would contain an array, which is not necessarily the case.

I am currently porting a library to Deno and I was just bit by this.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
