### PR TITLE
feat(ext/net): Support listening for UDP Broadcast packets

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -851,6 +851,15 @@ declare namespace Deno {
     [Symbol.asyncIterator](): AsyncIterableIterator<[Uint8Array, Addr]>;
   }
 
+  export interface UdpConn extends DatagramConn {
+    readonly broadcast: boolean;
+    /**
+     * 
+     * @param flag True to set the SO_BROADCAST flag
+     */
+    setBroadcast(flag: boolean);
+  }
+
   export interface UnixListenOptions {
     /** A Path to the Unix Socket. */
     path: string;
@@ -883,18 +892,12 @@ declare namespace Deno {
    *   port: 80,
    *   transport: "udp"
    * });
-   * const listener3 = Deno.listenDatagram({
-   *   hostname: "0.0.0.0",
-   *   port: 50000,
-   *   transport: "udp",
-   *   broadcast: true
-   * });
    * ```
    *
    * Requires `allow-net` permission. */
   export function listenDatagram(
-    options: ListenOptions & { transport: "udp"; broadcast?: boolean; },
-  ): DatagramConn;
+    options: ListenOptions & { transport: "udp"; },
+  ): UdpConn;
 
   /** **UNSTABLE**: new API, yet to be vetted
    *

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -862,9 +862,9 @@ declare namespace Deno {
     /** **UNSTABLE**: new API, yet to be vetted.
      * Sets the value of the SO_BROADCAST option for this socket.
      * When enabled, this socket is allowed to send packets to a broadcast address.
-     * @param flag True to set the SO_BROADCAST flag on the socket, false to unset the flag.
+     * @param enable True to set the SO_BROADCAST flag on the socket, false to unset the flag.
      */
-    setBroadcast(flag: boolean): void;
+    setBroadcast(enable: boolean): void;
   }
 
   export interface UnixListenOptions {

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -855,11 +855,11 @@ declare namespace Deno {
    *
    * A transport listener for UDP messages. */
   export interface UdpConn extends DatagramConn {
-    /**
+    /** **UNSTABLE**: new API, yet to be vetted.
      * Gets the value of the SO_BROADCAST option for this socket.
      */
     readonly broadcast: boolean;
-    /**
+    /** **UNSTABLE**: new API, yet to be vetted.
      * Sets the value of the SO_BROADCAST option for this socket.
      * When enabled, this socket is allowed to send packets to a broadcast address.
      * @param flag True to set the SO_BROADCAST flag on the socket, false to unset the flag.

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -883,11 +883,17 @@ declare namespace Deno {
    *   port: 80,
    *   transport: "udp"
    * });
+   * const listener3 = Deno.listenDatagram({
+   *   hostname: "0.0.0.0",
+   *   port: 50000,
+   *   transport: "udp",
+   *   broadcast: true
+   * });
    * ```
    *
    * Requires `allow-net` permission. */
   export function listenDatagram(
-    options: ListenOptions & { transport: "udp" },
+    options: ListenOptions & { transport: "udp"; broadcast?: boolean; },
   ): DatagramConn;
 
   /** **UNSTABLE**: new API, yet to be vetted

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -903,7 +903,7 @@ declare namespace Deno {
    *
    * Requires `allow-net` permission. */
   export function listenDatagram(
-    options: ListenOptions & { transport: "udp"; },
+    options: ListenOptions & { transport: "udp" },
   ): UdpConn;
 
   /** **UNSTABLE**: new API, yet to be vetted

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -851,13 +851,20 @@ declare namespace Deno {
     [Symbol.asyncIterator](): AsyncIterableIterator<[Uint8Array, Addr]>;
   }
 
+  /** **UNSTABLE**: new API, yet to be vetted.
+   *
+   * A transport listener for UDP messages. */
   export interface UdpConn extends DatagramConn {
+    /**
+     * Gets the value of the SO_BROADCAST option for this socket.
+     */
     readonly broadcast: boolean;
     /**
-     * 
-     * @param flag True to set the SO_BROADCAST flag
+     * Sets the value of the SO_BROADCAST option for this socket.
+     * When enabled, this socket is allowed to send packets to a broadcast address.
+     * @param flag True to set the SO_BROADCAST flag on the socket, false to unset the flag.
      */
-    setBroadcast(flag: boolean);
+    setBroadcast(flag: boolean): void;
   }
 
   export interface UnixListenOptions {

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -339,14 +339,15 @@ unitTest(
     assert(alice.broadcast);
 
     const bob = Deno.listenDatagram({ port: 4501, transport: "udp" });
+    bob.setBroadcast(true);
     assert(bob.addr.transport === "udp");
     assertEquals(bob.addr.port, 4501);
     assertEquals(bob.addr.hostname, "127.0.0.1");
 
-    const broadcastBob = { ...bob, hostname: "127.0.0.255"};
+    const broadcastAddr = { ...bob.addr, hostname: "127.0.0.255"};
 
     const sent = new Uint8Array([1, 2, 3]);
-    const byteLength = await alice.send(sent, broadcastBob.addr);
+    const byteLength = await alice.send(sent, broadcastAddr);
 
     assertEquals(byteLength, 3);
 

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -275,11 +275,14 @@ unitTest(
   { permissions: { net: true } },
   async function netUdpSendReceive() {
     const alice = Deno.listenDatagram({ port: 3500, transport: "udp" });
+    console.log(`bcast status ${alice.broadcast}`);
+    assert(!alice.broadcast)
     assert(alice.addr.transport === "udp");
     assertEquals(alice.addr.port, 3500);
     assertEquals(alice.addr.hostname, "127.0.0.1");
 
     const bob = Deno.listenDatagram({ port: 4501, transport: "udp" });
+    assert(!alice.broadcast)
     assert(bob.addr.transport === "udp");
     assertEquals(bob.addr.port, 4501);
     assertEquals(bob.addr.hostname, "127.0.0.1");
@@ -328,12 +331,14 @@ unitTest(
 unitTest(
   { permissions: { net: true } },
   async function netUdpSendReceiveBroadcast() {
-    const alice = Deno.listenDatagram({ port: 3500, transport: "udp", broadcast: true });
-    assert(alice.addr.transport === "udp");
-    assertEquals(alice.addr.port, 3500);
-    assertEquals(alice.addr.hostname, "127.0.0.1");
+    const alice = Deno.listenDatagram({ port: 3500, transport: "udp" });
+    assert(!alice.broadcast);
+    alice.setBroadcast(false);
+    assert(!alice.broadcast);
+    alice.setBroadcast(true);
+    assert(alice.broadcast);
 
-    const bob = Deno.listenDatagram({ port: 4501, transport: "udp", broadcast: true });
+    const bob = Deno.listenDatagram({ port: 4501, transport: "udp" });
     assert(bob.addr.transport === "udp");
     assertEquals(bob.addr.port, 4501);
     assertEquals(bob.addr.hostname, "127.0.0.1");

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -330,7 +330,13 @@ unitTest(
 unitTest(
   { permissions: { net: true } },
   async function netUdpSendReceiveBroadcast() {
-    const alice = Deno.listenDatagram({ port: 3500, transport: "udp" });
+    // Must bind sender to an address that can send to the broadcast address on MacOS.
+    // Macos will give us error 49 when sending the broadcast packet if we omit hostname here.
+    const alice = Deno.listenDatagram({
+      port: 3500,
+      transport: "udp",
+      hostname: "0.0.0.0",
+    });
     assert(!alice.broadcast);
 
     const bob = Deno.listenDatagram({

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -275,7 +275,6 @@ unitTest(
   { permissions: { net: true } },
   async function netUdpSendReceive() {
     const alice = Deno.listenDatagram({ port: 3500, transport: "udp" });
-    console.log(`bcast status ${alice.broadcast}`);
     assert(!alice.broadcast)
     assert(alice.addr.transport === "udp");
     assertEquals(alice.addr.port, 3500);
@@ -338,13 +337,13 @@ unitTest(
     alice.setBroadcast(true);
     assert(alice.broadcast);
 
-    const bob = Deno.listenDatagram({ port: 4501, transport: "udp" });
+    const bob = Deno.listenDatagram({ port: 4501, transport: "udp", hostname: '0.0.0.0'});
     bob.setBroadcast(true);
     assert(bob.addr.transport === "udp");
     assertEquals(bob.addr.port, 4501);
-    assertEquals(bob.addr.hostname, "127.0.0.1");
+    assertEquals(bob.addr.hostname, "0.0.0.0");
 
-    const broadcastAddr = { ...bob.addr, hostname: "127.0.0.255"};
+    const broadcastAddr = { ...bob.addr, hostname: "255.255.255.255"};
 
     const sent = new Uint8Array([1, 2, 3]);
     const byteLength = await alice.send(sent, broadcastAddr);

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -348,10 +348,11 @@ unitTest(
 
     let acceptErrCount = 0;
     const checkErr = (e: Error) => {
-      if (e.message === "Permission denied (os error 13)") {
+      if (e instanceof Deno.errors.PermissionDenied) {
+        // Broadcasting without SO_BROADCAST set should result in a permissions error.
         acceptErrCount++;
       } else {
-        throw new Error("Unexpected error message");
+        throw new Error("Unexpected error message: " + e.message)
       }
     };
     // Sending to the broadcast addr without broadcast flag should result in error.

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -352,7 +352,7 @@ unitTest(
         // Broadcasting without SO_BROADCAST set should result in a permissions error.
         acceptErrCount++;
       } else {
-        throw new Error("Unexpected error message: " + e.message)
+        throw new Error("Unexpected error message: " + e.message);
       }
     };
     // Sending to the broadcast addr without broadcast flag should result in error.

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -275,13 +275,13 @@ unitTest(
   { permissions: { net: true } },
   async function netUdpSendReceive() {
     const alice = Deno.listenDatagram({ port: 3500, transport: "udp" });
-    assert(!alice.broadcast)
+    assert(!alice.broadcast);
     assert(alice.addr.transport === "udp");
     assertEquals(alice.addr.port, 3500);
     assertEquals(alice.addr.hostname, "127.0.0.1");
 
     const bob = Deno.listenDatagram({ port: 4501, transport: "udp" });
-    assert(!alice.broadcast)
+    assert(!alice.broadcast);
     assert(bob.addr.transport === "udp");
     assertEquals(bob.addr.port, 4501);
     assertEquals(bob.addr.hostname, "127.0.0.1");
@@ -333,12 +333,16 @@ unitTest(
     const alice = Deno.listenDatagram({ port: 3500, transport: "udp" });
     assert(!alice.broadcast);
 
-    const bob = Deno.listenDatagram({ port: 4501, transport: "udp", hostname: '0.0.0.0'});
+    const bob = Deno.listenDatagram({
+      port: 4501,
+      transport: "udp",
+      hostname: "0.0.0.0",
+    });
     assert(bob.addr.transport === "udp");
     assertEquals(bob.addr.port, 4501);
-    assertEquals(bob.addr.hostname, '0.0.0.0');
+    assertEquals(bob.addr.hostname, "0.0.0.0");
 
-    const broadcastAddr = { ...bob.addr, hostname: "255.255.255.255"};
+    const broadcastAddr = { ...bob.addr, hostname: "255.255.255.255" };
 
     const sent = new Uint8Array([1, 2, 3]);
 
@@ -356,7 +360,6 @@ unitTest(
     alice.setBroadcast(true);
     assert(alice.broadcast);
     const byteLength = await alice.send(sent, broadcastAddr);
-
 
     assertEquals(byteLength, 3);
     const [recvd, remote] = await bob.receive();

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -210,7 +210,7 @@
 
   class UdpDatagram extends Datagram {
     setBroadcast(flag) {
-      return opSetBroadcast({ rid: this.rid, flag });
+      opSetBroadcast({ rid: this.rid, flag });
     }
     get broadcast() {
       return opGetBroadcast({ rid: this.rid });

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -54,6 +54,14 @@
     return core.opAsync("op_dgram_send", args, zeroCopy);
   }
 
+  function opGetBroadcast(args) {
+    return core.opAsync("op_udp_getbroadcast", args);
+  }
+
+  function opSetBroadcast(args) {
+    return core.opAsync("op_udp_setbroadcast", args);
+  }
+
   function resolveDns(query, recordType, options) {
     return core.opAsync("op_dns_resolve", { query, recordType, options });
   }
@@ -200,6 +208,15 @@
     }
   }
 
+  class UdpDatagram extends Datagram {
+    setBroadcast(flag) {
+      return opSetBroadcast({ rid: this.rid, flag });
+    }
+    get broadcast() {
+      return opGetBroadcast({ rid: this.rid });
+    }
+  }
+
   function listen({ hostname, ...options }) {
     const res = opListen({
       transport: "tcp",
@@ -235,6 +252,7 @@
     Listener,
     shutdown,
     Datagram,
+    UdpDatagram,
     resolveDns,
   };
 })(this);

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -55,11 +55,11 @@
   }
 
   function opGetBroadcast(args) {
-    return core.opSync("op_udp_getbroadcast", args);
+    return core.opSync("op_udp_get_broadcast", args);
   }
 
   function opSetBroadcast(args) {
-    return core.opSync("op_udp_setbroadcast", args);
+    return core.opSync("op_udp_set_broadcast", args);
   }
 
   function resolveDns(query, recordType, options) {

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -55,11 +55,11 @@
   }
 
   function opGetBroadcast(args) {
-    return core.opAsync("op_udp_getbroadcast", args);
+    return core.opSync("op_udp_getbroadcast", args);
   }
 
   function opSetBroadcast(args) {
-    return core.opAsync("op_udp_setbroadcast", args);
+    return core.opSync("op_udp_setbroadcast", args);
   }
 
   function resolveDns(query, recordType, options) {

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -209,8 +209,8 @@
   }
 
   class UdpDatagram extends Datagram {
-    setBroadcast(flag) {
-      opSetBroadcast({ rid: this.rid, flag });
+    setBroadcast(enable) {
+      opSetBroadcast({ rid: this.rid, enable });
     }
     get broadcast() {
       return opGetBroadcast({ rid: this.rid });

--- a/ext/net/04_net_unstable.js
+++ b/ext/net/04_net_unstable.js
@@ -23,6 +23,7 @@
       res = net.opListen({
         transport: "udp",
         hostname: "127.0.0.1",
+        broadcast: false,
         ...options,
       });
     }

--- a/ext/net/04_net_unstable.js
+++ b/ext/net/04_net_unstable.js
@@ -16,19 +16,18 @@
   function listenDatagram(
     options,
   ) {
-    let res;
     if (options.transport === "unixpacket") {
-      res = net.opListen(options);
+      const res = net.opListen(options);
+      return new net.Datagram(res.rid, res.localAddr);
     } else {
-      res = net.opListen({
+      const res = net.opListen({
         transport: "udp",
         hostname: "127.0.0.1",
         broadcast: false,
         ...options,
       });
+      return new net.UdpDatagram(res.rid, res.localAddr);
     }
-
-    return new net.Datagram(res.rid, res.localAddr);
   }
 
   async function connect(

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -541,7 +541,7 @@ where
 #[derive(Deserialize)]
 struct SetBroadcastArgs {
   rid: ResourceId,
-  flag: bool,
+  enable: bool,
 }
 
 fn op_udp_set_broadcast(
@@ -556,7 +556,7 @@ fn op_udp_set_broadcast(
   let socket = RcRef::map(&resource, |r| &r.socket)
     .try_borrow()
     .ok_or_else(|| custom_error("Busy", "Socket is in currently in use"))?;
-  socket.set_broadcast(args.flag)?;
+  socket.set_broadcast(args.enable)?;
   Ok(())
 }
 

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -53,8 +53,8 @@ pub fn init<P: NetPermissions + 'static>() -> Vec<OpPair> {
     ("op_net_listen", op_sync(op_net_listen::<P>)),
     ("op_dgram_recv", op_async(op_dgram_recv)),
     ("op_dgram_send", op_async(op_dgram_send::<P>)),
-    ("op_udp_setbroadcast", op_sync(op_udp_setbroadcast)),
-    ("op_udp_getbroadcast", op_sync(op_udp_getbroadcast)),
+    ("op_udp_set_broadcast", op_sync(op_udp_set_broadcast)),
+    ("op_udp_get_broadcast", op_sync(op_udp_get_broadcast)),
     ("op_dns_resolve", op_async(op_dns_resolve::<P>)),
   ]
 }
@@ -544,7 +544,7 @@ struct SetBroadcastArgs {
   flag: bool,
 }
 
-fn op_udp_setbroadcast(
+fn op_udp_set_broadcast(
   state: &mut OpState,
   args: SetBroadcastArgs,
   _: (),
@@ -565,7 +565,7 @@ struct GetBroadcastArgs {
   rid: ResourceId,
 }
 
-fn op_udp_getbroadcast(
+fn op_udp_get_broadcast(
   state: &mut OpState,
   args: GetBroadcastArgs,
   _: (),

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -578,7 +578,6 @@ fn op_udp_getbroadcast(
     .try_borrow()
     .ok_or_else(|| custom_error("Busy", "Socket is in currently in use"))?;
   let broadcast_flag = socket.broadcast()?;
-  println!("Broadcast flag is {}", broadcast_flag);
   Ok(broadcast_flag)
 }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
Supports setting/getting the broadcast flag on UDP sockets.

This exposes two new API calls on Datagram sockets, implemented as an extension of the existing `DatagramConn` interface:

```typescript
  /** **UNSTABLE**: new API, yet to be vetted.
   *
   * A transport listener for UDP messages. */
  export interface UdpConn extends DatagramConn {
    /** **UNSTABLE**: new API, yet to be vetted.
     * Gets the value of the SO_BROADCAST option for this socket.
     */
    readonly broadcast: boolean;
    /** **UNSTABLE**: new API, yet to be vetted.
     * Sets the value of the SO_BROADCAST option for this socket.
     * When enabled, this socket is allowed to send packets to a broadcast address.
     * @param flag True to set the SO_BROADCAST flag on the socket, false to unset the flag.
     */
    setBroadcast(flag: boolean): void;
  }
  ```
The overload of `listenDatagram()` for `{transport: 'udp'}` now returns this new type.

Fixes #10470

- [x] Unit testing:
  - [x] Sockets are `!broadcast` by default
  - [x] Sockets without broadcast flag error when sending to the broadcast address (`255.255.255.255`)
  - [x] Sockets with broadcast flag set can send successfully to the broadcast address
- [x] Manual testing
  - [x] Deno UdpConn can send messages to `255.255.255.255` and they are received by another computer on the same LAN.
  - [x] Deno UDP listeners can receive packets sent as broadcast from other computers on the same LAN
     -  (this is not new behavior, does not require broadcast flag on listener)


Considerations:
 - [ ] Is this API shape appropriate?
   - This API mimics [Tokio's UdpSocket](https://docs.rs/tokio/0.1.18/tokio/net/struct.UdpSocket.html) API for managing socket flags
   - Could also use ES6 getters/setters instead of an explicit `setBroadcast()` function.
   - Flags could be managed as a separate object instead of top-level on the socket object. 
     - e.g. `mySocket.flags.broadcast = true`
   - Underlying socket systems ([windows](https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options), [unix](https://notes.shichao.io/unp/ch7/#ipv6-socket-options)) support a variety of socket options depending on the type of socket. This could add a lot of properties to the top level of a socket object.
   - Another option is to generically add `setSocketOption(option_name, option_value)` but this would still potentially need to be overloaded per-socket-type for accurate typing.
- [ ] Is the synchronous code for retrieving the socket resource in Rust appropriate?
  - I'm not as clear on the synchronicity of `setSockOpt()` on underlying platforms, but it seems like it would be valid to mutate socket options at any time.
  - [setSockOpt(3)](https://linux.die.net/man/3/setsockopt) does not list any failure cases for "Socket Busy", though some options cannot be set after a socket is connected.
  - Will the code here fail to set a socket option while the socket is sending or receiving? This would feel like an artificial limitation. (maybe I should test this) 