### PR TITLE
feat(ext/ffi): support `null` in buffer argument

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -122,23 +122,23 @@ declare namespace Deno {
   /** A foreign function as defined by its parameter and result types */
   export interface ForeignFunction {
     /**
-     * Foreign Function parameter types also support `buffer` type which is 
-     * essentially a pointer to a JS `Uint8Array`. It can even be mutated 
+     * Foreign Function parameter types also support `buffer` type which is
+     * essentially a pointer to a JS `Uint8Array`. It can even be mutated
      * from native code.
-     * 
+     *
      * For example, take the following Rust code,
-     * 
+     *
      * ```rs
      * #[no_mangle]
      * pub unsafe extern "C" fn print_buffer(buffer: *const u8, size: usize) {
      *   println!("{:?}", std::slice::from_raw_parts(buffer, size));
      * }
      * ```
-     * 
+     *
      * Compile using `rustc --crate-type cdylib filename.rs`
-     * 
+     *
      * From Deno, you'd use the dynamic library like,
-     * 
+     *
      * ```ts
      * const lib = Deno.dlopen("./path/to/lib", {
      *   print_buffer: {
@@ -146,16 +146,16 @@ declare namespace Deno {
      *     result: "void",
      *   },
      * });
-     * 
+     *
      * const buffer = new Uint8Array([1, 2, 3]);
      * lib.symbols.print_buffer(buffer, buffer.byteLength);
      * // [1, 2, 3]
      * ```
-     * 
+     *
      * The `buffer` argument type supports passing `null` value which
      * becomes the null pointer (0) in FFI, accessing that pointer memory
      * may cause segmentation faults in some cases.
-     * 
+     *
      * In this case, Rust's `slice::from_raw_parts` handles null pointers safely,
      * and returns empty slice.
      */

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -122,8 +122,9 @@ declare namespace Deno {
   /** A foreign function as defined by its parameter and result types */
   export interface ForeignFunction {
     /**
-     * Foreign Function paramter types also support `buffer` type which is essentially
-     * a pointer to a JS `Uint8Array`. It can even be mutated from native code.
+     * Foreign Function parameter types also support `buffer` type which is 
+     * essentially a pointer to a JS `Uint8Array`. It can even be mutated 
+     * from native code.
      * 
      * For example, take the following Rust code,
      * 

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -407,9 +407,13 @@ fn ffi_call(args: FfiCallArgs, symbol: &Symbol) -> Result<Value, AnyError> {
     .zip(args.parameters.into_iter())
     .map(|(&native_type, value)| {
       if let NativeType::Buffer = native_type {
-        let idx: usize = value_as_uint(value);
-        let ptr = buffers[idx].as_ptr();
-        NativeValue::buffer(ptr)
+        if value.is_null() {
+          NativeValue::buffer(std::ptr::null())
+        } else {
+          let idx: usize = value_as_uint(value);
+          let ptr = buffers[idx].as_ptr();
+          NativeValue::buffer(ptr)
+        }
       } else {
         NativeValue::new(native_type, value)
       }

--- a/test_ffi/src/lib.rs
+++ b/test_ffi/src/lib.rs
@@ -90,7 +90,6 @@ pub extern "C" fn nonblocking_buffer(ptr: *const u8, len: usize) {
   assert_eq!(buf, vec![1, 2, 3, 4, 5, 6, 7, 8]);
 }
 
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn is_nullptr(ptr: *const u8) -> bool {
   ptr.is_null()

--- a/test_ffi/src/lib.rs
+++ b/test_ffi/src/lib.rs
@@ -93,5 +93,5 @@ pub extern "C" fn nonblocking_buffer(ptr: *const u8, len: usize) {
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn is_nullptr(ptr: *const u8) -> bool {
-  ptr == std::ptr::null()
+  ptr.is_null()
 }

--- a/test_ffi/src/lib.rs
+++ b/test_ffi/src/lib.rs
@@ -89,3 +89,9 @@ pub extern "C" fn nonblocking_buffer(ptr: *const u8, len: usize) {
   let buf = unsafe { std::slice::from_raw_parts(ptr, len) };
   assert_eq!(buf, vec![1, 2, 3, 4, 5, 6, 7, 8]);
 }
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn is_nullptr(ptr: *const u8) -> bool {
+  ptr == std::ptr::null()
+}

--- a/test_ffi/tests/integration_tests.rs
+++ b/test_ffi/tests/integration_tests.rs
@@ -49,6 +49,8 @@ fn basic() {
     579\n\
     579.9119873046875\n\
     579.912\n\
+    false\n\
+    true\n\
     Before\n\
     true\n\
     After\n\

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -42,7 +42,7 @@ const dylib = Deno.dlopen(libPath, {
   },
   "is_nullptr": {
     parameters: ["buffer"],
-    result: "bool",
+    result: "u8",
   },
 });
 
@@ -100,8 +100,8 @@ dylib.symbols.nonblocking_buffer(buffer3, buffer3.length).then(() => {
 });
 await promise;
 
-console.log(dylib.symbols.is_nullptr(new Uint8Array()));
-console.log(dylib.symbols.is_nullptr(null));
+console.log(dylib.symbols.is_nullptr(new Uint8Array()) === 1);
+console.log(dylib.symbols.is_nullptr(null) === 1);
 
 const start = performance.now();
 dylib.symbols.sleep_blocking(100).then(() => {

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -40,6 +40,10 @@ const dylib = Deno.dlopen(libPath, {
     result: "void",
     nonblocking: true,
   },
+  "is_nullptr": {
+    parameters: ["buffer"],
+    result: "void",
+  },
 });
 
 dylib.symbols.print_something();
@@ -95,6 +99,9 @@ dylib.symbols.nonblocking_buffer(buffer3, buffer3.length).then(() => {
   promise.resolve();
 });
 await promise;
+
+console.log(dylib.symbols.is_nullptr(new Uint8Array()));
+console.log(dylib.symbols.is_nullptr(null));
 
 const start = performance.now();
 dylib.symbols.sleep_blocking(100).then(() => {

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -42,7 +42,7 @@ const dylib = Deno.dlopen(libPath, {
   },
   "is_nullptr": {
     parameters: ["buffer"],
-    result: "void",
+    result: "bool",
   },
 });
 


### PR DESCRIPTION
- [x] Adds support for `null` in buffer argument. Corresponds to `nullptr` in FFI.
- [x] Adds relevant test case.

Fixes #12809 