### PR TITLE
fix(cli/emit): Don't cache .tsbuildinfo unless emitting

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -724,6 +724,7 @@ async fn create_graph_and_maybe_check(
         emit_with_diagnostics: false,
         maybe_config_specifier,
         ts_config,
+        reload: ps.flags.reload,
       },
     )?;
     debug!("{}", check_result.stats);

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -252,6 +252,7 @@ async fn op_emit(
           emit_with_diagnostics: true,
           maybe_config_specifier: None,
           ts_config,
+          reload: true,
         },
       )?;
       (emit_result.diagnostics, emit_result.stats)
@@ -271,6 +272,7 @@ async fn op_emit(
           emit_with_diagnostics: true,
           maybe_config_specifier: None,
           ts_config: ts_config.clone(),
+          reload: true,
         },
       )?;
       (emit_result.diagnostics, emit_result.stats)

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -481,6 +481,7 @@ impl ProcState {
           emit_with_diagnostics: false,
           maybe_config_specifier,
           ts_config,
+          reload: self.flags.reload,
         };
         for root in &graph.roots {
           let root_str = root.to_string();


### PR DESCRIPTION
Fixes #12755.
Fixes #12807.
Fixes #12832.