### PR TITLE
fix: support "other" event type in FSWatcher

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2007,9 +2007,9 @@ declare namespace Deno {
    */
   export function resources(): ResourceMap;
 
-  /** 
+  /**
    * Additional information for FsEvent objects with the "other" kind.
-   * 
+   *
    * - "rescan": rescan notices indicate either a lapse in the events or a
    *    change in the filesystem such that events received so far can no longer
    *    be relied on to represent the state of the filesystem now. An

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2007,9 +2007,23 @@ declare namespace Deno {
    */
   export function resources(): ResourceMap;
 
+  /** 
+   * Additional information for FsEvent objects with the "other" kind.
+   * 
+   * - "rescan": rescan notices indicate either a lapse in the events or a
+   *    change in the filesystem such that events received so far can no longer
+   *    be relied on to represent the state of the filesystem now. An
+   *    application that simply reacts to file changes may not care about this.
+   *    An application that keeps an in-memory representation of the filesystem
+   *    will need to care, and will need to refresh that representation directly
+   *    from the filesystem.
+   */
+  export type FsEventFlag = "rescan";
+
   export interface FsEvent {
-    kind: "any" | "access" | "create" | "modify" | "remove";
+    kind: "any" | "access" | "create" | "modify" | "remove" | "other";
     paths: string[];
+    flag?: FsEventFlag;
   }
 
   /**

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -65,8 +65,9 @@ impl Resource for FsEventsResource {
 /// the complexity.
 #[derive(Serialize, Debug)]
 struct FsEvent {
-  kind: String,
+  kind: &'static str,
   paths: Vec<PathBuf>,
+  flag: Option<&'static str>,
 }
 
 impl From<NotifyEvent> for FsEvent {
@@ -77,12 +78,16 @@ impl From<NotifyEvent> for FsEvent {
       EventKind::Create(_) => "create",
       EventKind::Modify(_) => "modify",
       EventKind::Remove(_) => "remove",
-      EventKind::Other => todo!(), // What's this for? Leaving it out for now.
-    }
-    .to_string();
+      EventKind::Other => "other",
+    };
+    let flag = match e.flag() {
+      Some(notify::event::Flag::Rescan) => Some("rescan"),
+      None => None,
+    };
     FsEvent {
       kind,
       paths: e.paths,
+      flag,
     }
   }
 }

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -80,10 +80,9 @@ impl From<NotifyEvent> for FsEvent {
       EventKind::Remove(_) => "remove",
       EventKind::Other => "other",
     };
-    let flag = match e.flag() {
-      Some(notify::event::Flag::Rescan) => Some("rescan"),
-      None => None,
-    };
+    let flag = e.flag().map(|f| match f {
+      notify::event::Flag::Rescan => "rescan",
+    });
     FsEvent {
       kind,
       paths: e.paths,


### PR DESCRIPTION
This commit adds support for "other" events in `FSWatcher`. Flags on
events are now exposed via the `flag` property  on `FsEvent`.

There are no tests for this change, as the only known cause for this `"other"`
event being emitted, is watching an SMB share on macOS. Not something we can
really test for in CI.

Closes #12097