### PR TITLE
revert: store header keys lower case internally

### DIFF
--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -114,7 +114,13 @@
 
     // 7.
     const list = headers[_headerList];
-    name = byteLowerCase(name);
+    const lowercaseName = byteLowerCase(name);
+    for (let i = 0; i < list.length; i++) {
+      if (byteLowerCase(list[i][0]) === lowercaseName) {
+        name = list[i][0];
+        break;
+      }
+    }
     ArrayPrototypePush(list, [name, value]);
   }
 
@@ -126,7 +132,10 @@
   function getHeader(list, name) {
     const lowercaseName = byteLowerCase(name);
     const entries = ArrayPrototypeMap(
-      ArrayPrototypeFilter(list, (entry) => entry[0] === lowercaseName),
+      ArrayPrototypeFilter(
+        list,
+        (entry) => byteLowerCase(entry[0]) === lowercaseName,
+      ),
       (entry) => entry[1],
     );
     if (entries.length === 0) {
@@ -196,7 +205,7 @@
       const headers = {};
       const cookies = [];
       for (const entry of list) {
-        const name = entry[0];
+        const name = byteLowerCase(entry[0]);
         const value = entry[1];
         if (value === null) throw new TypeError("Unreachable");
         // The following if statement is not spec compliant.
@@ -287,9 +296,9 @@
       }
 
       const list = this[_headerList];
-      name = byteLowerCase(name);
+      const lowercaseName = byteLowerCase(name);
       for (let i = 0; i < list.length; i++) {
-        if (list[i][0] === name) {
+        if (byteLowerCase(list[i][0]) === lowercaseName) {
           ArrayPrototypeSplice(list, i, 1);
           i--;
         }
@@ -331,9 +340,9 @@
       }
 
       const list = this[_headerList];
-      name = byteLowerCase(name);
+      const lowercaseName = byteLowerCase(name);
       for (let i = 0; i < list.length; i++) {
-        if (list[i][0] === name) {
+        if (byteLowerCase(list[i][0]) === lowercaseName) {
           return true;
         }
       }
@@ -372,10 +381,10 @@
       }
 
       const list = this[_headerList];
-      name = byteLowerCase(name);
+      const lowercaseName = byteLowerCase(name);
       let added = false;
       for (let i = 0; i < list.length; i++) {
-        if (list[i][0] === name) {
+        if (byteLowerCase(list[i][0]) === lowercaseName) {
           if (!added) {
             list[i][1] = value;
             added = true;

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -173,8 +173,10 @@
       let charset = null;
       let essence = null;
       let mimeType = null;
-      const headerList = headerListFromHeaders(this[_headers]);
-      const values = getDecodeSplitHeader(headerList, "content-type");
+      const values = getDecodeSplitHeader(
+        headerListFromHeaders(this[_headers]),
+        "Content-Type",
+      );
       if (values === null) return null;
       for (const value of values) {
         const temporaryMimeType = mimesniff.parseMimeType(value);

--- a/ext/fetch/23_response.js
+++ b/ext/fetch/23_response.js
@@ -157,8 +157,10 @@
       let charset = null;
       let essence = null;
       let mimeType = null;
-      const headerList = headerListFromHeaders(this[_headers]);
-      const values = getDecodeSplitHeader(headerList, "content-type");
+      const values = getDecodeSplitHeader(
+        headerListFromHeaders(this[_headers]),
+        "Content-Type",
+      );
       if (values === null) return null;
       for (const value of values) {
         const temporaryMimeType = mimesniff.parseMimeType(value);
@@ -230,7 +232,7 @@
       }
       const inner = newInnerResponse(status);
       inner.type = "default";
-      ArrayPrototypePush(inner.headerList, ["location", parsedURL.href]);
+      ArrayPrototypePush(inner.headerList, ["Location", parsedURL.href]);
       const response = webidl.createBranded(Response);
       response[_response] = inner;
       response[_headers] = headersFromHeaderList(

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -14,6 +14,7 @@
 ((window) => {
   const core = window.Deno.core;
   const webidl = window.__bootstrap.webidl;
+  const { byteLowerCase } = window.__bootstrap.infra;
   const { errorReadableStream } = window.__bootstrap.streams;
   const { InnerBody, extractBody } = window.__bootstrap.fetchBody;
   const {
@@ -331,7 +332,7 @@
   function httpRedirectFetch(request, response, terminator) {
     const locationHeaders = ArrayPrototypeFilter(
       response.headerList,
-      (entry) => entry[0] === "location",
+      (entry) => byteLowerCase(entry[0]) === "location",
     );
     if (locationHeaders.length === 0) {
       return response;
@@ -372,7 +373,7 @@
         if (
           ArrayPrototypeIncludes(
             REQUEST_BODY_HEADER_NAMES,
-            request.headerList[i][0],
+            byteLowerCase(request.headerList[i][0]),
           )
         ) {
           ArrayPrototypeSplice(request.headerList, i, 1);
@@ -418,8 +419,8 @@
       }
       requestObject.signal[abortSignal.add](onabort);
 
-      if (!requestObject.headers.has("accept")) {
-        ArrayPrototypePush(request.headerList, ["accept", "*/*"]);
+      if (!requestObject.headers.has("Accept")) {
+        ArrayPrototypePush(request.headerList, ["Accept", "*/*"]);
       }
 
       // 12.


### PR DESCRIPTION
This reverts commit 49ec3d10ad90851f4d28274a3f0fe96c642204ac.

This might introduce a slight performance degredation, but correctness is more important here. We can optimize this structure down the line by storing headers in a more optimized format internally (like Chromium does).

Fixes #12829