### PR TITLE
feat(ext/net): Enable sending UDP messages to the broadcast address

### DIFF
--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -433,6 +433,8 @@ fn listen_udp(
 ) -> Result<(u32, SocketAddr), AnyError> {
   let std_socket = std::net::UdpSocket::bind(&addr)?;
   std_socket.set_nonblocking(true)?;
+  // Enable messages to be sent to the broadcast address (255.255.255.255) by default
+  std_socket.set_broadcast(true)?;
   let socket = UdpSocket::from_std(std_socket)?;
   let local_addr = socket.local_addr()?;
   let socket_resource = UdpSocketResource {


### PR DESCRIPTION
Alternative proposal to #12817 

Fixes #10470 

Enable UDP sockets to send messages to the broadcast address (`255.255.255.255`).

See relevant discussion on linked PR #12817 for considerations.