### PR TITLE
tests: remove 'fmt_check_tests_dir' test

### DIFF
--- a/cli/tests/integration/fmt_tests.rs
+++ b/cli/tests/integration/fmt_tests.rs
@@ -128,12 +128,6 @@ fn fmt_ignore_unexplicit_files() {
   );
 }
 
-itest!(fmt_check_tests_dir {
-  args: "fmt --check ./ --ignore=.test_coverage,fmt/fmt_with_config/,test/markdown_windows.md",
-  output: "fmt/expected_fmt_check_tests_dir.out",
-  exit_code: 1,
-});
-
 itest!(fmt_quiet_check_fmt_dir {
   args: "fmt --check --quiet fmt/regular/",
   output_str: Some(""),

--- a/cli/tests/testdata/fmt/expected_fmt_check_tests_dir.out
+++ b/cli/tests/testdata/fmt/expected_fmt_check_tests_dir.out
@@ -1,2 +1,0 @@
-[WILDCARD]
-error: Found 6 not formatted files in [WILDCARD] files


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/12758

This test is not really valuable after we reorganized tests into `cli/tests/testdata` directories, adding new files that might be badly formatted on purpose requires to update the test case.