### PR TITLE
chore: speed up compat tests

### DIFF
--- a/cli/tests/integration/compat_tests.rs
+++ b/cli/tests/integration/compat_tests.rs
@@ -1,40 +1,58 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 use crate::itest;
+use deno_core::url::Url;
 use test_util as util;
 
+/// Tests in this file should use `std_file_url` to override `DENO_NODE_COMPAT_URL`
+/// env variable. This speeds up tests significantly as they no longer
+/// download contents of `deno_std` from `https://deno.land` in each test.
+
+/// Return a file URL pointing to "std" submodule
+/// in "test_util" directory. It must have a trailing slash.
+fn std_file_url() -> String {
+  let u = Url::from_directory_path(util::std_path()).unwrap();
+  u.to_string()
+}
+
 itest!(globals {
-  args: "run --compat --unstable --allow-read --allow-env compat/globals.ts",
+  args: "run --compat --no-check --unstable --allow-read --allow-env compat/globals.ts",
   output: "compat/globals.out",
+  envs: vec![("DENO_NODE_COMPAT_URL".to_string(), std_file_url())],
 });
 
 itest!(fs_promises {
-  args: "run --compat --unstable -A compat/fs_promises.mjs",
+  args: "run --compat --no-check --unstable -A compat/fs_promises.mjs",
   output: "compat/fs_promises.out",
+  envs: vec![("DENO_NODE_COMPAT_URL".to_string(), std_file_url())],
 });
 
 itest!(node_prefix_fs_promises {
-  args: "run --compat --unstable -A compat/node_fs_promises.mjs",
+  args: "run --compat --no-check --unstable -A compat/node_fs_promises.mjs",
   output: "compat/fs_promises.out",
+  envs: vec![("DENO_NODE_COMPAT_URL".to_string(), std_file_url())],
 });
 
 itest!(compat_with_import_map_and_https_imports {
-  args: "run --quiet --compat --unstable -A --import-map=compat/import_map.json compat/import_map_https_imports.mjs",
+  args: "run --quiet --no-check --compat --unstable -A --import-map=compat/import_map.json compat/import_map_https_imports.mjs",
   output: "compat/import_map_https_imports.out",
+  envs: vec![("DENO_NODE_COMPAT_URL".to_string(), std_file_url())],
 });
 
 itest!(compat_dyn_import_rejects_with_node_compatible_error {
-  args: "run --quiet --compat --unstable -A compat/dyn_import_reject.js",
+  args:
+    "run --quiet --no-check --compat --unstable -A compat/dyn_import_reject.js",
   output: "compat/dyn_import_reject.out",
+  envs: vec![("DENO_NODE_COMPAT_URL".to_string(), std_file_url())],
 });
 
 #[test]
 fn globals_in_repl() {
   let (out, _err) = util::run_and_collect_output_with_args(
     true,
-    vec!["repl", "--compat", "--unstable", "--quiet"],
+    vec!["repl", "--compat", "--unstable", "--no-check", "--quiet"],
     Some(vec!["global == window"]),
-    None,
+    Some(vec![("DENO_NODE_COMPAT_URL".to_string(), std_file_url())]),
     false,
   );
   assert!(out.contains("true"));
@@ -44,7 +62,7 @@ fn globals_in_repl() {
 fn node_compat_url() {
   let (out, err) = util::run_and_collect_output_with_args(
     false,
-    vec!["repl", "--compat", "--unstable", "--quiet"],
+    vec!["repl", "--compat", "--unstable", "--no-check", "--quiet"],
     None,
     Some(vec![(
       "DENO_NODE_COMPAT_URL".to_string(),

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -105,6 +105,10 @@ pub fn third_party_path() -> PathBuf {
   root_path().join("third_party")
 }
 
+pub fn std_path() -> PathBuf {
+  root_path().join("test_util").join("std")
+}
+
 pub fn target_dir() -> PathBuf {
   let current_exe = std::env::current_exe().unwrap();
   let target_dir = current_exe.parent().unwrap().parent().unwrap();
@@ -1655,6 +1659,7 @@ pub struct CheckOutputIntegrationTest {
   pub output_str: Option<&'static str>,
   pub exit_code: i32,
   pub http_server: bool,
+  pub envs: Vec<(String, String)>,
 }
 
 impl CheckOutputIntegrationTest {
@@ -1675,6 +1680,7 @@ impl CheckOutputIntegrationTest {
     println!("deno_exe args {}", self.args);
     println!("deno_exe testdata path {:?}", &testdata_dir);
     command.args(args);
+    command.envs(self.envs.clone());
     command.current_dir(&testdata_dir);
     command.stdin(Stdio::piped());
     let writer_clone = writer.try_clone().unwrap();


### PR DESCRIPTION
This commit speeds up compat tests by using local copy of "deno_std"
instead of downloading it from https://deno.land for each test.
Additionally type checking is skipped.

Depends on https://github.com/denoland/deno/pull/12883