### PR TITLE
feat(core): Add ability to "ref" and "unref" pending ops

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -134,12 +134,7 @@
 
   function opAsync(opName, arg1 = null, arg2 = null) {
     const promiseId = nextPromiseId++;
-    const maybeError = opcallAsync(
-      opsCache[opName],
-      promiseId,
-      arg1,
-      arg2,
-    );
+    const maybeError = opcallAsync(opsCache[opName], promiseId, arg1, arg2);
     // Handle sync error (e.g: error parsing args)
     if (maybeError) return unwrapOpResult(maybeError);
     const p = PromisePrototypeThen(setPromise(promiseId), unwrapOpResult);

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -141,7 +141,10 @@
     );
     // Handle sync error (e.g: error parsing args)
     if (maybeError) return unwrapOpResult(maybeError);
-    return PromisePrototypeThen(setPromise(promiseId), unwrapOpResult);
+    const p = PromisePrototypeThen(setPromise(promiseId), unwrapOpResult);
+    // Save the id on the promise so it can be latered ref'ed or unref'ed
+    p.id = promiseId;
+    return p;
   }
 
   function opSync(opName, arg1 = null, arg2 = null) {

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -44,6 +44,8 @@
   const RING_SIZE = 4 * 1024;
   const NO_PROMISE = null; // Alias to null is faster than plain nulls
   const promiseRing = ArrayPrototypeFill(new Array(RING_SIZE), NO_PROMISE);
+  // TODO(bartlomieju): it future use `v8::Private` so it's not visible
+  // to users. Currently missing bindings.
   const promiseIdSymbol = SymbolFor("Deno.core.internalPromiseId");
 
   function setPromise(promiseId) {
@@ -138,7 +140,7 @@
     // Handle sync error (e.g: error parsing args)
     if (maybeError) return unwrapOpResult(maybeError);
     const p = PromisePrototypeThen(setPromise(promiseId), unwrapOpResult);
-    // Save the id on the promise so it can be latered ref'ed or unref'ed
+    // Save the id on the promise so it can later be ref'ed or unref'ed
     p[promiseIdSymbol] = promiseId;
     return p;
   }

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -130,9 +130,15 @@
     return res;
   }
 
-  function opAsync(opName, arg1 = null, arg2 = null) {
+  function opAsync(opName, arg1 = null, arg2 = null, unref = false) {
     const promiseId = nextPromiseId++;
-    const maybeError = opcallAsync(opsCache[opName], promiseId, arg1, arg2);
+    const maybeError = opcallAsync(
+      opsCache[opName],
+      promiseId,
+      arg1,
+      arg2,
+      unref,
+    );
     // Handle sync error (e.g: error parsing args)
     if (maybeError) return unwrapOpResult(maybeError);
     return PromisePrototypeThen(setPromise(promiseId), unwrapOpResult);

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -375,7 +375,6 @@ fn opcall_sync<'s>(
     b,
     op_id,
     promise_id: 0,
-    unref: false,
   };
   let op = OpTable::route_op(op_id, state.op_state.clone(), payload);
   match op {
@@ -440,7 +439,6 @@ fn opcall_async<'s>(
     b,
     op_id,
     promise_id,
-    unref,
   };
   let op = OpTable::route_op(op_id, state.op_state.clone(), payload);
   match op {

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -439,7 +439,6 @@ fn opcall_async<'s>(
   // Deserializable args (may be structured args or ZeroCopyBuf)
   let a = args.get(2);
   let b = args.get(3);
-  let unref = args.get(4).is_true();
 
   let payload = OpPayload {
     scope,
@@ -460,10 +459,6 @@ fn opcall_async<'s>(
     Op::Async(fut) => {
       state.op_state.borrow().tracker.track_async(op_id);
       state.pending_ops.push(fut);
-      if unref {
-        // FIXME(bartlomieju): this should track using `track_unref`?
-        state.unrefed_ops.insert(promise_id);
-      }
       state.have_unpolled_ops = true;
     }
     Op::NotFound => {

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -454,13 +454,8 @@ fn opcall_async<'s>(
       state.pending_ops.push(fut);
       if unref {
         // FIXME(bartlomieju): this should track using `track_unref`?
-        state.unref_ops.insert(promise_id);
+        state.unrefed_ops.insert(promise_id);
       }
-      state.have_unpolled_ops = true;
-    }
-    Op::AsyncUnref(fut) => {
-      state.op_state.borrow().tracker.track_unref(op_id);
-      state.pending_unref_ops.push(fut);
       state.have_unpolled_ops = true;
     }
     Op::NotFound => {

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -21,6 +21,18 @@ declare namespace Deno {
       b?: any,
     ): Promise<any>;
 
+    /** Mark following promises as "ref", ie. event loop won't exit
+     * until they are resolved. All async ops are "ref" by default. */
+    function refOps(
+      ...promiseIds: number[]
+    ): void;
+
+    /** Mark following promises as "unref", ie. event loop will exit
+     * if there are only "unref" promises left. */
+    function unrefOps(
+      ...promiseIds: number[]
+    ): void;
+
     /**
      * Retrieve a list of all registered ops, in the form of a map that maps op
      * name to internal numerical op id.

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -21,17 +21,13 @@ declare namespace Deno {
       b?: any,
     ): Promise<any>;
 
-    /** Mark following promises as "ref", ie. event loop won't exit
-     * until they are resolved. All async ops are "ref" by default. */
-    function refOps(
-      ...promiseIds: number[]
-    ): void;
+    /** Mark following promise as "ref", ie. event loop won't exit
+     * until all "ref" promises are resolved. All async ops are "ref" by default. */
+    function refOp(promiseId: number): void;
 
-    /** Mark following promises as "unref", ie. event loop will exit
+    /** Mark following promise as "unref", ie. event loop will exit
      * if there are only "unref" promises left. */
-    function unrefOps(
-      ...promiseIds: number[]
-    ): void;
+    function unrefOps(promiseId: number): void;
 
     /**
      * Retrieve a list of all registered ops, in the form of a map that maps op

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -83,7 +83,6 @@ pub use crate::ops_builtin::op_close;
 pub use crate::ops_builtin::op_print;
 pub use crate::ops_builtin::op_resources;
 pub use crate::ops_json::op_async;
-pub use crate::ops_json::op_async_unref;
 pub use crate::ops_json::op_sync;
 pub use crate::ops_json::void_op_async;
 pub use crate::ops_json::void_op_sync;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -111,9 +111,6 @@ impl<'a, 'b, 'c> OpPayload<'a, 'b, 'c> {
 pub enum Op {
   Sync(OpResult),
   Async(OpAsyncFuture),
-  /// AsyncUnref is the variation of Async, which doesn't block the program
-  /// exiting.
-  AsyncUnref(OpAsyncFuture),
   NotFound,
 }
 

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -91,6 +91,7 @@ pub struct OpPayload<'a, 'b, 'c> {
   pub(crate) b: v8::Local<'c, v8::Value>,
   pub(crate) op_id: OpId,
   pub(crate) promise_id: PromiseId,
+  pub(crate) unref: bool,
 }
 
 impl<'a, 'b, 'c> OpPayload<'a, 'b, 'c> {

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -80,7 +80,7 @@ where
   }
 }
 
-pub type PromiseId = u64;
+pub type PromiseId = i32;
 pub type OpAsyncFuture = OpCall<(PromiseId, OpId, OpResult)>;
 pub type OpFn = dyn Fn(Rc<RefCell<OpState>>, OpPayload) -> Op + 'static;
 pub type OpId = usize;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -91,7 +91,6 @@ pub struct OpPayload<'a, 'b, 'c> {
   pub(crate) b: v8::Local<'c, v8::Value>,
   pub(crate) op_id: OpId,
   pub(crate) promise_id: PromiseId,
-  pub(crate) unref: bool,
 }
 
 impl<'a, 'b, 'c> OpPayload<'a, 'b, 'c> {

--- a/core/ops_json.rs
+++ b/core/ops_json.rs
@@ -67,7 +67,6 @@ where
 /// Creates an op that passes data asynchronously using JSON.
 ///
 /// When this op is dispatched, the runtime doesn't exit while processing it.
-/// Use op_async_unref instead if you want to make the runtime exit while processing it.
 ///
 /// The provided function `op_fn` has the following parameters:
 /// * `Rc<RefCell<OpState>`: the op state, can be used to read/write resources in the runtime from an op.
@@ -115,38 +114,6 @@ where
     let fut = op_fn(state.clone(), a, b)
       .map(move |result| (pid, op_id, serialize_op_result(result, state)));
     Op::Async(OpCall::eager(fut))
-  })
-}
-
-/// Creates an op that passes data asynchronously using JSON.
-///
-/// When this op is dispatched, the runtime still can exit while processing it.
-///
-/// The other usages are the same as `op_async`.
-pub fn op_async_unref<F, A, B, R, RV>(op_fn: F) -> Box<OpFn>
-where
-  F: Fn(Rc<RefCell<OpState>>, A, B) -> R + 'static,
-  A: DeserializeOwned,
-  B: DeserializeOwned,
-  R: Future<Output = Result<RV, Error>> + 'static,
-  RV: Serialize + 'static,
-{
-  Box::new(move |state, payload| -> Op {
-    let op_id = payload.op_id;
-    let pid = payload.promise_id;
-    // Deserialize args, sync error on failure
-    let args = match payload.deserialize() {
-      Ok(args) => args,
-      Err(err) => {
-        return Op::Sync(serialize_op_result(Err::<(), Error>(err), state))
-      }
-    };
-    let (a, b) = args;
-
-    use crate::futures::FutureExt;
-    let fut = op_fn(state.clone(), a, b)
-      .map(move |result| (pid, op_id, serialize_op_result(result, state)));
-    Op::AsyncUnref(OpCall::eager(fut))
   })
 }
 

--- a/core/ops_metrics.rs
+++ b/core/ops_metrics.rs
@@ -85,12 +85,14 @@ impl OpsTracker {
     metrics.ops_completed_async += 1;
   }
 
+  #[allow(unused)]
   pub fn track_unref(&self, id: OpId) {
     let metrics = &mut self.metrics_mut(id);
     metrics.ops_dispatched += 1;
     metrics.ops_dispatched_async_unref += 1;
   }
 
+  #[allow(unused)]
   pub fn track_unref_completed(&self, id: OpId) {
     let metrics = &mut self.metrics_mut(id);
     metrics.ops_completed += 1;

--- a/core/ops_metrics.rs
+++ b/core/ops_metrics.rs
@@ -11,10 +11,12 @@ pub struct OpMetrics {
   pub ops_dispatched: u64,
   pub ops_dispatched_sync: u64,
   pub ops_dispatched_async: u64,
+  // TODO(bartlomieju): this field is never updated
   pub ops_dispatched_async_unref: u64,
   pub ops_completed: u64,
   pub ops_completed_sync: u64,
   pub ops_completed_async: u64,
+  // TODO(bartlomieju): this field is never updated
   pub ops_completed_async_unref: u64,
   pub bytes_sent_control: u64,
   pub bytes_sent_data: u64,
@@ -83,19 +85,5 @@ impl OpsTracker {
     let metrics = &mut self.metrics_mut(id);
     metrics.ops_completed += 1;
     metrics.ops_completed_async += 1;
-  }
-
-  #[allow(unused)]
-  pub fn track_unref(&self, id: OpId) {
-    let metrics = &mut self.metrics_mut(id);
-    metrics.ops_dispatched += 1;
-    metrics.ops_dispatched_async_unref += 1;
-  }
-
-  #[allow(unused)]
-  pub fn track_unref_completed(&self, id: OpId) {
-    let metrics = &mut self.metrics_mut(id);
-    metrics.ops_completed += 1;
-    metrics.ops_completed_async_unref += 1;
   }
 }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -136,23 +136,6 @@ pub type SharedArrayBufferStore =
 
 pub type CompiledWasmModuleStore = CrossIsolateStore<v8::CompiledWasmModule>;
 
-struct AsyncOpIterator<'a, 'b, 'c> {
-  ops: &'b mut FuturesUnordered<PendingOpFuture>,
-  cx: &'a mut Context<'c>,
-}
-
-impl Iterator for AsyncOpIterator<'_, '_, '_> {
-  type Item = (PromiseId, OpId, OpResult);
-
-  #[inline]
-  fn next(&mut self) -> Option<Self::Item> {
-    match self.ops.poll_next_unpin(self.cx) {
-      Poll::Ready(Some(item)) => Some(item),
-      _ => None,
-    }
-  }
-}
-
 /// Internal state for JsRuntime which is stored in one of v8::Isolate's
 /// embedder slots.
 pub(crate) struct JsRuntimeState {
@@ -1530,21 +1513,17 @@ impl JsRuntime {
       state.have_unpolled_ops = false;
 
       let op_state = state.op_state.clone();
-      let ops = AsyncOpIterator {
-        ops: &mut state.pending_ops,
-        cx,
-      };
-      let mut remove_from_unref = vec![];
-      for (promise_id, op_id, resp) in ops {
-        op_state.borrow().tracker.track_async_completed(op_id);
-        remove_from_unref.push(promise_id);
-        args.push(v8::Integer::new(scope, promise_id as i32).into());
-        args.push(resp.to_v8(scope).unwrap());
-      }
-      // FIXME(bartlomieju): this should be done in the loop before,
-      // but that makes borrow checker unhappy, think how to refactor it
-      for promise_id in remove_from_unref {
-        state.unrefed_ops.remove(&promise_id);
+
+      loop {
+        if let Poll::Ready(Some(item)) = state.pending_ops.poll_next_unpin(cx) {
+          let (promise_id, op_id, resp) = item;
+          op_state.borrow().tracker.track_async_completed(op_id);
+          state.unrefed_ops.remove(&promise_id);
+          args.push(v8::Integer::new(scope, promise_id as i32).into());
+          args.push(resp.to_v8(scope).unwrap());
+        } else {
+          break;
+        }
       }
     }
 

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -29,6 +29,7 @@ use futures::task::AtomicWaker;
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::ffi::c_void;
 use std::mem::forget;
 use std::option::Option;
@@ -172,6 +173,7 @@ pub(crate) struct JsRuntimeState {
   pub(crate) js_error_create_fn: Rc<JsErrorCreateFn>,
   pub(crate) pending_ops: FuturesUnordered<PendingOpFuture>,
   pub(crate) pending_unref_ops: FuturesUnordered<PendingOpFuture>,
+  pub(crate) unref_ops: HashSet<u64>,
   pub(crate) have_unpolled_ops: bool,
   pub(crate) op_state: Rc<RefCell<OpState>>,
   pub(crate) shared_array_buffer_store: Option<SharedArrayBufferStore>,
@@ -372,6 +374,7 @@ impl JsRuntime {
       js_error_create_fn,
       pending_ops: FuturesUnordered::new(),
       pending_unref_ops: FuturesUnordered::new(),
+      unref_ops: HashSet::new(),
       shared_array_buffer_store: options.shared_array_buffer_store,
       compiled_wasm_module_store: options.compiled_wasm_module_store,
       op_state: op_state.clone(),
@@ -801,7 +804,7 @@ impl JsRuntime {
     let mut state = state_rc.borrow_mut();
     let module_map = module_map_rc.borrow();
 
-    let has_pending_ops = !state.pending_ops.is_empty();
+    let has_pending_ops = state.pending_ops.len() > state.unref_ops.len();
     let has_pending_dyn_imports = module_map.has_pending_dynamic_imports();
     let has_pending_dyn_module_evaluation =
       !state.pending_dyn_mod_evaluate.is_empty();
@@ -1535,6 +1538,8 @@ impl JsRuntime {
       };
       for (promise_id, op_id, resp) in ops {
         op_state.borrow().tracker.track_async_completed(op_id);
+        // FIXME(bartlomieju):
+        // state.unref_ops.remove(&promise_id);
         args.push(v8::Integer::new(scope, promise_id as i32).into());
         args.push(resp.to_v8(scope).unwrap());
       }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1757,8 +1757,10 @@ pub mod tests {
       .execute_script(
         "filename.js",
         r#"
-        Deno.core.unrefOps(
-          p1[Symbol.for("Deno.core.internalPromiseId")], 
+        Deno.core.unrefOp(
+          p1[Symbol.for("Deno.core.internalPromiseId")]
+        );
+        Deno.core.unrefOp(
           p2[Symbol.for("Deno.core.internalPromiseId")]
         );
         "#,
@@ -1775,8 +1777,10 @@ pub mod tests {
       .execute_script(
         "filename.js",
         r#"
-        Deno.core.refOps(
-          p1[Symbol.for("Deno.core.internalPromiseId")], 
+        Deno.core.refOp(
+          p1[Symbol.for("Deno.core.internalPromiseId")]
+        );
+        Deno.core.refOp(
           p2[Symbol.for("Deno.core.internalPromiseId")]
         );
         "#,

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1514,16 +1514,13 @@ impl JsRuntime {
 
       let op_state = state.op_state.clone();
 
-      loop {
-        if let Poll::Ready(Some(item)) = state.pending_ops.poll_next_unpin(cx) {
-          let (promise_id, op_id, resp) = item;
-          op_state.borrow().tracker.track_async_completed(op_id);
-          state.unrefed_ops.remove(&promise_id);
-          args.push(v8::Integer::new(scope, promise_id as i32).into());
-          args.push(resp.to_v8(scope).unwrap());
-        } else {
-          break;
-        }
+      while let Poll::Ready(Some(item)) = state.pending_ops.poll_next_unpin(cx)
+      {
+        let (promise_id, op_id, resp) = item;
+        op_state.borrow().tracker.track_async_completed(op_id);
+        state.unrefed_ops.remove(&promise_id);
+        args.push(v8::Integer::new(scope, promise_id as i32).into());
+        args.push(resp.to_v8(scope).unwrap());
       }
     }
 

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1719,6 +1719,22 @@ pub mod tests {
   }
 
   #[test]
+  fn test_op_async_promise_id() {
+    let (mut runtime, _dispatch_count) = setup(Mode::Async);
+    runtime
+      .execute_script(
+        "filename.js",
+        r#"
+        const p = Deno.core.opAsync("op_test", 42);
+        if (p.id == undefined) {
+          throw new Error("missing id on returned promise");
+        }
+        "#,
+      )
+      .unwrap();
+  }
+
+  #[test]
   fn test_dispatch_no_zero_copy_buf() {
     let (mut runtime, dispatch_count) = setup(Mode::AsyncZeroCopy(false));
     runtime

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1726,7 +1726,7 @@ pub mod tests {
         "filename.js",
         r#"
         const p = Deno.core.opAsync("op_test", 42);
-        if (p.id == undefined) {
+        if (p[Symbol.for("Deno.core.internalPromiseId")] == undefined) {
           throw new Error("missing id on returned promise");
         }
         "#,
@@ -1757,7 +1757,10 @@ pub mod tests {
       .execute_script(
         "filename.js",
         r#"
-        Deno.core.unrefOps(p1.id, p2.id);
+        Deno.core.unrefOps(
+          p1[Symbol.for("Deno.core.internalPromiseId")], 
+          p2[Symbol.for("Deno.core.internalPromiseId")]
+        );
         "#,
       )
       .unwrap();
@@ -1772,7 +1775,10 @@ pub mod tests {
       .execute_script(
         "filename.js",
         r#"
-        Deno.core.refOps(p1.id, p2.id);
+        Deno.core.refOps(
+          p1[Symbol.for("Deno.core.internalPromiseId")], 
+          p2[Symbol.for("Deno.core.internalPromiseId")]
+        );
         "#,
       )
       .unwrap();

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1741,6 +1741,7 @@ pub mod tests {
       .execute_script(
         "filename.js",
         r#"
+        var promiseIdSymbol = Symbol.for("Deno.core.internalPromiseId");
         var p1 = Deno.core.opAsync("op_test", 42);
         var p2 = Deno.core.opAsync("op_test", 42);
         "#,
@@ -1757,12 +1758,8 @@ pub mod tests {
       .execute_script(
         "filename.js",
         r#"
-        Deno.core.unrefOp(
-          p1[Symbol.for("Deno.core.internalPromiseId")]
-        );
-        Deno.core.unrefOp(
-          p2[Symbol.for("Deno.core.internalPromiseId")]
-        );
+        Deno.core.unrefOp(p1[promiseIdSymbol]);
+        Deno.core.unrefOp(p2[promiseIdSymbol]);
         "#,
       )
       .unwrap();
@@ -1777,12 +1774,8 @@ pub mod tests {
       .execute_script(
         "filename.js",
         r#"
-        Deno.core.refOp(
-          p1[Symbol.for("Deno.core.internalPromiseId")]
-        );
-        Deno.core.refOp(
-          p2[Symbol.for("Deno.core.internalPromiseId")]
-        );
+        Deno.core.refOp(p1[promiseIdSymbol]);
+        Deno.core.refOp(p2[promiseIdSymbol]);
         "#,
       )
       .unwrap();

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -5,6 +5,7 @@
   const core = window.Deno.core;
   const {
     Set,
+    SymbolFor,
     TypeError,
   } = window.__bootstrap.primordials;
 
@@ -13,9 +14,9 @@
   }
 
   function pollSignal(rid) {
-    // This is an "unrefed" op, ie. won't block event loop
-    // from exiting.
-    return core.opAsync("op_signal_poll", rid, null, true);
+    const promise = core.opAsync("op_signal_poll", rid);
+    core.unrefOps(promise[SymbolFor("Deno.core.internalPromiseId")]);
+    return promise;
   }
 
   function unbindSignal(rid) {

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -13,7 +13,9 @@
   }
 
   function pollSignal(rid) {
-    return core.opAsync("op_signal_poll", rid);
+    // This is an "unrefed" op, ie. won't block event loop
+    // from exiting.
+    return core.opAsync("op_signal_poll", rid, null, true);
   }
 
   function unbindSignal(rid) {

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -15,7 +15,7 @@
 
   function pollSignal(rid) {
     const promise = core.opAsync("op_signal_poll", rid);
-    core.unrefOps(promise[SymbolFor("Deno.core.internalPromiseId")]);
+    core.unrefOp(promise[SymbolFor("Deno.core.internalPromiseId")]);
     return promise;
   }
 

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -4,7 +4,7 @@ use deno_core::error::generic_error;
 #[cfg(not(target_os = "windows"))]
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
-use deno_core::op_async_unref;
+use deno_core::op_async;
 use deno_core::op_sync;
 use deno_core::Extension;
 use deno_core::OpState;
@@ -33,7 +33,7 @@ pub fn init() -> Extension {
     .ops(vec![
       ("op_signal_bind", op_sync(op_signal_bind)),
       ("op_signal_unbind", op_sync(op_signal_unbind)),
-      ("op_signal_poll", op_async_unref(op_signal_poll)),
+      ("op_signal_poll", op_async(op_signal_poll)),
     ])
     .build()
 }


### PR DESCRIPTION
This commit adds an ability to "ref" or "unref" pending ops.

Up to this point Deno had a notion of "async ops" and "unref async ops";
the former keep event loop alive, while the latter do not block event loop
from finishing. It was not possible to change between op types after 
dispatching, one had to decide which type to use before dispatch.

Instead of storing ops in two separate "FuturesUnordered" collections,
now ops are stored in a single collection, with supplemental "HashSet"
storing ids of promises that were "unrefed".

Two APIs were added to "Deno.core":
- "Deno.core.refOp(promiseId)" which allows to mark promise id 
to be "refed" and keep event loop alive (the default behavior)
- "Deno.core.unrefOp(promiseId)" which allows to mark promise 
id as "unrefed" which won't block event loop from exiting

Closes https://github.com/denoland/deno/issues/12745

TODO:
- [x] metrics for unrefed ops (I think that unrefing ops should decrement `ops_dispatched_async` and increment `ops_dispatched_async_unref`, though it seems overly complicated)
- [x] cleanup handling of finished ops (remove `AsyncOpIterator`?)
- [x] add `id` field to promises returned from `Deno.core.opcallAsync`
- [x] add `Deno.core.ref(...promiseIds)` and `Deno.core.unref(...promiseIds)`