### PR TITLE
fix(cli): fix slow test, unbreak ci

### DIFF
--- a/cli/tests/testdata/blob_gc_finalization.js
+++ b/cli/tests/testdata/blob_gc_finalization.js
@@ -1,6 +1,6 @@
-// This test creates 1024 blobs of 128 MB each. This will only work if the blobs
+// This test creates 128 blobs of 128 MB each. This will only work if the blobs
 // and their backing data is GCed as expected.
-for (let i = 0; i < 1024; i++) {
+for (let i = 0; i < 128; i++) {
   // Create a 128MB byte array, and then a blob from it.
   const buf = new Uint8Array(128 * 1024 * 1024);
   new Blob([buf]);


### PR DESCRIPTION
Reduce the number of iterations from 1,024 to 128.

On my big bruiser of a desktop machine it already takes up close to a
minute to complete when nothing else is running so no way it's going to
finish in the allotted time on the CI.

The fact that the test used to pass may be indicative of a performance
regression somewhere but it's not clear to me when or where that would
have been introduced.

Fixes #12887.