### PR TITLE
refactor(repl): move rustyline sync channel communication into struct

### DIFF
--- a/cli/tools/repl/channel.rs
+++ b/cli/tools/repl/channel.rs
@@ -2,6 +2,7 @@
 
 use deno_core::anyhow::anyhow;
 use deno_core::error::AnyError;
+use deno_core::serde_json::Value;
 use std::cell::RefCell;
 use tokio::sync::mpsc::channel;
 use tokio::sync::mpsc::unbounded_channel;
@@ -13,51 +14,58 @@ use tokio::sync::mpsc::UnboundedSender;
 /// Rustyline uses synchronous methods in its interfaces, but we need to call
 /// async methods. To get around this, we communicate with async code by using
 /// a channel and blocking on the result.
-pub fn rustyline_channel<TMessage, TResponse>() -> (
-  SyncMessageSender<TMessage, TResponse>,
-  SyncMessageHandler<TMessage, TResponse>,
-) {
+pub fn rustyline_channel(
+) -> (RustylineSyncMessageSender, RustylineSyncMessageHandler) {
   let (message_tx, message_rx) = channel(1);
   let (response_tx, response_rx) = unbounded_channel();
 
   (
-    SyncMessageSender {
+    RustylineSyncMessageSender {
       message_tx,
       response_rx: RefCell::new(response_rx),
     },
-    SyncMessageHandler {
+    RustylineSyncMessageHandler {
       response_tx,
       message_rx,
     },
   )
 }
 
-pub struct SyncMessageSender<TSend, TReceive> {
-  message_tx: Sender<TSend>,
-  response_rx: RefCell<UnboundedReceiver<TReceive>>,
+pub type RustylineSyncMessage = (String, Option<Value>);
+pub type RustylineSyncResponse = Result<Value, AnyError>;
+
+pub struct RustylineSyncMessageSender {
+  message_tx: Sender<RustylineSyncMessage>,
+  response_rx: RefCell<UnboundedReceiver<RustylineSyncResponse>>,
 }
 
-impl<TSend, TReceive> SyncMessageSender<TSend, TReceive> {
-  pub fn send(&self, message: TSend) -> Result<TReceive, AnyError> {
-    if let Err(err) = self.message_tx.blocking_send(message) {
+impl RustylineSyncMessageSender {
+  pub fn post_message(
+    &self,
+    method: &str,
+    params: Option<Value>,
+  ) -> Result<Value, AnyError> {
+    if let Err(err) =
+      self.message_tx.blocking_send((method.to_string(), params))
+    {
       Err(anyhow!("{}", err))
     } else {
-      Ok(self.response_rx.borrow_mut().blocking_recv().unwrap())
+      self.response_rx.borrow_mut().blocking_recv().unwrap()
     }
   }
 }
 
-pub struct SyncMessageHandler<TReceive, TResponse> {
-  message_rx: Receiver<TReceive>,
-  response_tx: UnboundedSender<TResponse>,
+pub struct RustylineSyncMessageHandler {
+  message_rx: Receiver<RustylineSyncMessage>,
+  response_tx: UnboundedSender<RustylineSyncResponse>,
 }
 
-impl<TReceive, TResponse> SyncMessageHandler<TReceive, TResponse> {
-  pub async fn recv(&mut self) -> Option<TReceive> {
+impl RustylineSyncMessageHandler {
+  pub async fn recv(&mut self) -> Option<RustylineSyncMessage> {
     self.message_rx.recv().await
   }
 
-  pub fn send(&self, response: TResponse) -> Result<(), AnyError> {
+  pub fn send(&self, response: RustylineSyncResponse) -> Result<(), AnyError> {
     self
       .response_tx
       .send(response)

--- a/cli/tools/repl/channel.rs
+++ b/cli/tools/repl/channel.rs
@@ -1,0 +1,66 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+use deno_core::anyhow::anyhow;
+use deno_core::error::AnyError;
+use std::cell::RefCell;
+use tokio::sync::mpsc::channel;
+use tokio::sync::mpsc::unbounded_channel;
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::UnboundedSender;
+
+/// Rustyline uses synchronous methods in its interfaces, but we need to call
+/// async methods. To get around this, we communicate with async code by using
+/// a channel and blocking on the result.
+pub fn rustyline_channel<TMessage, TResponse>() -> (
+  SyncMessageSender<TMessage, TResponse>,
+  SyncMessageHandler<TMessage, TResponse>,
+) {
+  let (message_tx, message_rx) = channel(1);
+  let (response_tx, response_rx) = unbounded_channel();
+
+  (
+    SyncMessageSender {
+      message_tx,
+      response_rx: RefCell::new(response_rx),
+    },
+    SyncMessageHandler {
+      response_tx,
+      message_rx,
+    },
+  )
+}
+
+pub struct SyncMessageSender<TSend, TReceive> {
+  message_tx: Sender<TSend>,
+  response_rx: RefCell<UnboundedReceiver<TReceive>>,
+}
+
+impl<TSend, TReceive> SyncMessageSender<TSend, TReceive> {
+  pub fn send(&self, message: TSend) -> Result<TReceive, AnyError> {
+    if let Err(err) = self.message_tx.blocking_send(message) {
+      Err(anyhow!("{}", err))
+    } else {
+      Ok(self.response_rx.borrow_mut().blocking_recv().unwrap())
+    }
+  }
+}
+
+pub struct SyncMessageHandler<TReceive, TResponse> {
+  message_rx: Receiver<TReceive>,
+  response_tx: UnboundedSender<TResponse>,
+}
+
+impl<TReceive, TResponse> SyncMessageHandler<TReceive, TResponse> {
+  pub async fn recv(&mut self) -> Option<TReceive> {
+    self.message_rx.recv().await
+  }
+
+  pub fn send(&self, response: TResponse) -> Result<(), AnyError> {
+    self
+      .response_tx
+      .send(response)
+      .map_err(|err| anyhow!("{}", err))
+  }
+}


### PR DESCRIPTION
I extracted this out of the repl import specifier autocompletion PR I'm working on.

Basically, for that PR I'm going to have to also get messages from the LSP for autocompletion and it would get out of hand quickly to not extract this out.