### PR TITLE
feat(wasm): Support `WebAssembly.instantiateStreaming` for file fetches

### DIFF
--- a/cli/tests/unit/wasm_test.ts
+++ b/cli/tests/unit/wasm_test.ts
@@ -77,6 +77,20 @@ Deno.test(async function wasmInstantiateStreaming() {
 });
 
 Deno.test(
+  { permissions: { read: true } },
+  async function wasmFileStreaming() {
+    const url = new URL("../testdata/unreachable.wasm", import.meta.url);
+    assert(url.href.startsWith("file://"));
+
+    const { module } = await WebAssembly.instantiateStreaming(fetch(url));
+    assertEquals(WebAssembly.Module.exports(module), [{
+      name: "unreachable",
+      kind: "function",
+    }]);
+  },
+);
+
+Deno.test(
   { permissions: { net: true } },
   async function wasmStreamingNonTrivial() {
     // deno-dom's WASM file is a real-world non-trivial case that gave us

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -37,6 +37,7 @@
     PromisePrototypeThen,
     PromisePrototypeCatch,
     String,
+    StringPrototypeStartsWith,
     StringPrototypeToLowerCase,
     TypedArrayPrototypeSubarray,
     TypeError,
@@ -498,12 +499,16 @@
         // The spec is ambiguous here, see
         // https://github.com/WebAssembly/spec/issues/1138. The WPT tests
         // expect the raw value of the Content-Type attribute lowercased.
-        const contentType = res.headers.get("Content-Type");
-        if (
-          typeof contentType !== "string" ||
-          StringPrototypeToLowerCase(contentType) !== "application/wasm"
-        ) {
-          throw new TypeError("Invalid WebAssembly content type.");
+        // We ignore this for file:// because file fetches don't have a
+        // Content-Type.
+        if (!StringPrototypeStartsWith(res.url, "file://")) {
+          const contentType = res.headers.get("Content-Type");
+          if (
+            typeof contentType !== "string" ||
+            StringPrototypeToLowerCase(contentType) !== "application/wasm"
+          ) {
+            throw new TypeError("Invalid WebAssembly content type.");
+          }
         }
 
         // 2.5.


### PR DESCRIPTION
Fetching of local files, added in #12545, returns a response with no headers, including the `Content-Type` header. This currently makes it not work with the WebAssembly streaming APIs, which require the response to have a content type of `application/wasm`.

Since the only way to obtain a `Response` object with a non-empty `url` field is via `fetch()`, this change changes the content type requirement to only apply to responses whose url has the `file:` scheme.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
