### PR TITLE
fix(test): Improve reliability of `deno test`'s op sanitizer with timers

### DIFF
--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -151,6 +151,11 @@ itest!(ops_sanitizer_unstable {
   output: "test/ops_sanitizer_unstable.out",
 });
 
+itest!(ops_sanitizer_timeout_failure {
+  args: "test test/ops_sanitizer_timeout_failure.ts",
+  output: "test/ops_sanitizer_timeout_failure.out",
+});
+
 itest!(exit_sanitizer {
   args: "test test/exit_sanitizer.ts",
   output: "test/exit_sanitizer.out",

--- a/cli/tests/testdata/test/ops_sanitizer_timeout_failure.out
+++ b/cli/tests/testdata/test/ops_sanitizer_timeout_failure.out
@@ -1,0 +1,6 @@
+Check [WILDCARD]/testdata/test/ops_sanitizer_timeout_failure.ts
+running 1 test from [WILDCARD]/testdata/test/ops_sanitizer_timeout_failure.ts
+test wait ... ok ([WILDCARD])
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+

--- a/cli/tests/testdata/test/ops_sanitizer_timeout_failure.ts
+++ b/cli/tests/testdata/test/ops_sanitizer_timeout_failure.ts
@@ -1,0 +1,22 @@
+let intervalHandle: number;
+let firstIntervalPromise: Promise<void>;
+
+addEventListener("load", () => {
+  firstIntervalPromise = new Promise((resolve) => {
+    let firstIntervalCalled = false;
+    intervalHandle = setInterval(() => {
+      if (!firstIntervalCalled) {
+        resolve();
+        firstIntervalCalled = true;
+      }
+    }, 5);
+  });
+});
+
+addEventListener("unload", () => {
+  clearInterval(intervalHandle);
+});
+
+Deno.test("wait", async function () {
+  await firstIntervalPromise;
+});


### PR DESCRIPTION
Although not easy to replicate in the wild, the `deno test` op sanitizer can fail when there are intervals that started before a test runs, since the op sanitizer can end up running in the time between the timer op for an interval's run resolves and the op for the next run starts.

This change fixes that by adding a new macrotask callback that will run after the timer macrotask queue has drained. This ensures that there is a timer op if there are any timers which are unresolved by the time the op sanitizer runs.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
