### PR TITLE
feat(core): intercept unhandled promise rejections

### DIFF
--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -124,8 +124,11 @@ declare namespace Deno {
       cb: PromiseRejectCallback,
     ): undefined | PromiseRejectCallback;
 
-    export type PromiseRejectCallback =
-      (type: number, promise: Promise, reason: any) => void;
+    export type PromiseRejectCallback = (
+      type: number,
+      promise: Promise,
+      reason: any,
+    ) => void;
 
     /**
      * Set a callback that will be called when an exception isn't caught

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -115,5 +115,28 @@ declare namespace Deno {
     function setMacrotaskCallback(
       cb: () => bool,
     ): void;
+
+    /**
+     * Set a callback that will be called when a promise without a .catch
+     * handler is rejected. Returns the old handler or undefined.
+     */
+    function setPromiseRejectCallback(
+      cb: PromiseRejectCallback,
+    ): undefined | PromiseRejectCallback;
+
+    export type PromiseRejectCallback =
+      (type: number, promise: Promise, reason: any) => void;
+
+    /**
+     * Set a callback that will be called when an exception isn't caught
+     * by any try/catch handlers. Currently only invoked when the callback
+     * to setPromiseRejectCallback() throws an exception but that is expected
+     * to change in the future. Returns the old handler or undefined.
+     */
+    function setUncaughtExceptionCallback(
+      cb: UncaughtExceptionCallback,
+    ): undefined | UncaughtExceptionCallback;
+
+    export type UncaughtExceptionCallback = (err: any) => void;
   }
 }


### PR DESCRIPTION
Provide a programmatic means of intercepting rejected promises without a
.catch() handler. Needed for Node compat mode.

Also do a first pass at uncaughtException support because they're
closely intertwined in Node. It's like that Frank Sinatra song:
you can't have one without the other.

Stepping stone for #7013.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
