### PR TITLE
reland #12908: fix(test): Improve reliability of `deno test`'s op sanitizer with timers

### DIFF
--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -151,6 +151,16 @@ itest!(ops_sanitizer_unstable {
   output: "test/ops_sanitizer_unstable.out",
 });
 
+itest!(ops_sanitizer_timeout_failure {
+  args: "test test/ops_sanitizer_timeout_failure.ts",
+  output: "test/ops_sanitizer_timeout_failure.out",
+});
+
+itest!(ops_sanitizer_nexttick {
+  args: "test test/ops_sanitizer_nexttick.ts",
+  output: "test/ops_sanitizer_nexttick.out",
+});
+
 itest!(exit_sanitizer {
   args: "test test/exit_sanitizer.ts",
   output: "test/exit_sanitizer.out",

--- a/cli/tests/testdata/test/ops_sanitizer_nexttick.out
+++ b/cli/tests/testdata/test/ops_sanitizer_nexttick.out
@@ -1,0 +1,7 @@
+Check [WILDCARD]/testdata/test/ops_sanitizer_nexttick.ts
+running 2 tests from [WILDCARD]/testdata/test/ops_sanitizer_nexttick.ts
+test test 1 ... ok ([WILDCARD])
+test test 2 ... ok ([WILDCARD])
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+

--- a/cli/tests/testdata/test/ops_sanitizer_nexttick.ts
+++ b/cli/tests/testdata/test/ops_sanitizer_nexttick.ts
@@ -1,0 +1,11 @@
+import { nextTick } from "../../../../test_util/std/node/_next_tick.ts";
+
+// https://github.com/denoland/deno_std/issues/1651
+
+Deno.test("test 1", async () => {
+  await new Promise<void>((resolve) => nextTick(resolve));
+});
+
+Deno.test("test 2", async () => {
+  await new Promise<void>((resolve) => nextTick(resolve));
+});

--- a/cli/tests/testdata/test/ops_sanitizer_timeout_failure.out
+++ b/cli/tests/testdata/test/ops_sanitizer_timeout_failure.out
@@ -1,0 +1,6 @@
+Check [WILDCARD]/testdata/test/ops_sanitizer_timeout_failure.ts
+running 1 test from [WILDCARD]/testdata/test/ops_sanitizer_timeout_failure.ts
+test wait ... ok ([WILDCARD])
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+

--- a/cli/tests/testdata/test/ops_sanitizer_timeout_failure.ts
+++ b/cli/tests/testdata/test/ops_sanitizer_timeout_failure.ts
@@ -1,0 +1,22 @@
+let intervalHandle: number;
+let firstIntervalPromise: Promise<void>;
+
+addEventListener("load", () => {
+  firstIntervalPromise = new Promise((resolve) => {
+    let firstIntervalCalled = false;
+    intervalHandle = setInterval(() => {
+      if (!firstIntervalCalled) {
+        resolve();
+        firstIntervalCalled = true;
+      }
+    }, 5);
+  });
+});
+
+addEventListener("unload", () => {
+  clearInterval(intervalHandle);
+});
+
+Deno.test("wait", async function () {
+  await firstIntervalPromise;
+});


### PR DESCRIPTION
This relands #12908 –which was reverted by #12929– now that #12933 has landed. It also adds @kt3k's tests from https://github.com/denoland/deno/pull/12908#issuecomment-981462813