### PR TITLE
feat(deno_fetch): get_client option

### DIFF
--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -63,6 +63,7 @@ pub struct Options {
   pub root_cert_store: Option<RootCertStore>,
   pub proxy: Option<Proxy>,
   pub request_builder_hook: Option<fn(RequestBuilder) -> RequestBuilder>,
+  /// Called on every request. Defaults to process-wide shared client.
   pub get_client: Option<fn(&mut OpState) -> Client>,
   pub unsafely_ignore_certificate_errors: Option<Vec<String>>,
   pub client_cert_chain_and_key: Option<(String, String)>,
@@ -120,7 +121,7 @@ where
 }
 
 /// Assign to Options::get_client for a fetch that creates a new client for every request.
-pub fn get_new_client(state: &mut OpState) -> Client {
+pub fn new_client(state: &mut OpState) -> Client {
   let options = state.borrow::<Options>();
   create_http_client(
     options.user_agent.clone(),
@@ -133,20 +134,12 @@ pub fn get_new_client(state: &mut OpState) -> Client {
   .unwrap()
 }
 
+/// Default behavior when Options::get_client is None.
 fn get_shared_client(state: &mut OpState) -> Client {
   if let Some(client) = state.try_borrow::<Client>() {
     client.clone()
   } else {
-    let options = state.borrow::<Options>();
-    let client = create_http_client(
-      options.user_agent.clone(),
-      options.root_cert_store.clone(),
-      vec![],
-      options.proxy.clone(),
-      options.unsafely_ignore_certificate_errors.clone(),
-      options.client_cert_chain_and_key.clone(),
-    )
-    .unwrap();
+    let client = new_client(state);
     state.put::<Client>(client.clone());
     client
   }
@@ -234,8 +227,7 @@ where
     r.client.clone()
   } else {
     let options = state.borrow::<Options>();
-    let client = options.get_client.unwrap()(state);
-    client
+    options.get_client.unwrap()(state)
   };
 
   let method = Method::from_bytes(&args.method)?;


### PR DESCRIPTION
Allows embedders better control over outbound fetch requests - potentially allowing them to create a new client per request.