### PR TITLE
feat(ext/timers): add refTimer, unrefTimer API

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1022,6 +1022,18 @@ declare namespace Deno {
    * Release an advisory file-system lock for the provided file.
    */
   export function funlockSync(rid: number): void;
+
+  /** **UNSTABLE**: new API, yet to be vetted.
+   *
+   * Make the timer of the given id blocking the event loop from finishing
+   */
+  export function refTimer(id: number): void;
+
+  /** **UNSTABLE**: new API, yet to be vetted.
+   *
+   * Make the timer of the given id not blocking the event loop from finishing
+   */
+  export function unrefTimer(id: number): void;
 }
 
 declare function fetch(

--- a/cli/tests/unit/timers_test.ts
+++ b/cli/tests/unit/timers_test.ts
@@ -552,32 +552,21 @@ Deno.test({
 });
 
 Deno.test({
-  name: "unrefTimer - unref interval 1",
+  name: "unrefTimer - unref interval",
   permissions: { run: true },
   fn: async () => {
     const [statusCode, output] = await execCode(`
-      const timer1 = setInterval(() => console.log("1"), 49);
-      const timer2 = setTimeout(() => console.log("2"), 300);
-      Deno.unrefTimer(timer1);
+      let i = 0;
+      const timer1 = setInterval(() => {
+        console.log("1");
+        i++;
+        if (i === 5) {
+          Deno.unrefTimer(timer1);
+        }
+      }, 10);
     `);
     assertEquals(statusCode, 0);
-    assertEquals(output, "1\n1\n1\n1\n1\n1\n2\n");
-  },
-});
-
-Deno.test({
-  name: "unrefTimer - unref interval 2",
-  permissions: { run: true },
-  fn: async () => {
-    const [statusCode, output] = await execCode(`
-      const timer1 = setInterval(() => console.log("1"), 49);
-      const timer2 = setTimeout(() => {
-        Deno.unrefTimer(timer1);
-      }, 300);
-      Deno.unrefTimer(timer2);
-    `);
-    assertEquals(statusCode, 0);
-    assertEquals(output, "1\n1\n1\n1\n1\n1\n");
+    assertEquals(output, "1\n1\n1\n1\n1\n");
   },
 });
 

--- a/cli/tests/unit/timers_test.ts
+++ b/cli/tests/unit/timers_test.ts
@@ -525,9 +525,9 @@ Deno.test({
   permissions: { run: true },
   fn: async () => {
     const [statusCode, output] = await execCode(`
-      const timer1 = setTimeout(() => console.log("1"), 10);
-      const timer2 = setTimeout(() => console.log("2"), 20);
-      const timer3 = setTimeout(() => console.log("3"), 30);
+      const timer1 = setTimeout(() => console.log("1"), 100);
+      const timer2 = setTimeout(() => console.log("2"), 200);
+      const timer3 = setTimeout(() => console.log("3"), 300);
       Deno.unrefTimer(timer3);
     `);
     assertEquals(statusCode, 0);
@@ -540,9 +540,9 @@ Deno.test({
   permissions: { run: true },
   fn: async () => {
     const [statusCode, output] = await execCode(`
-      const timer1 = setTimeout(() => console.log("1"), 10);
-      const timer2 = setTimeout(() => console.log("2"), 20);
-      const timer3 = setTimeout(() => console.log("3"), 30);
+      const timer1 = setTimeout(() => console.log("1"), 100);
+      const timer2 = setTimeout(() => console.log("2"), 200);
+      const timer3 = setTimeout(() => console.log("3"), 300);
       Deno.unrefTimer(timer1);
       Deno.unrefTimer(timer2);
     `);

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -139,5 +139,7 @@
     flockSync: __bootstrap.fs.flockSync,
     funlock: __bootstrap.fs.funlock,
     funlockSync: __bootstrap.fs.funlockSync,
+    refTimer: __bootstrap.timers.refTimer,
+    unrefTimer: __bootstrap.timers.unrefTimer,
   };
 })(this);


### PR DESCRIPTION
This implements Deno.refTimer / Deno.unrefTimer APIs in the unstable namespace.

These APIs change the ref/unref state of op_global_timer promises.

This also unblock us to implement https://github.com/denoland/deno_std/issues/1622 in std/node, (Node.js Timeout object has .ref() and .unref() methods. We need this change in CLI first to implement them in std/node)

closes #6141