### PR TITLE
feat(ext/net): add op_network_interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,7 @@ dependencies = [
  "hyper",
  "libc",
  "log",
+ "netif",
  "nix",
  "notify",
  "once_cell",
@@ -2256,6 +2257,16 @@ dependencies = [
  "serde",
  "spirv",
  "thiserror",
+]
+
+[[package]]
+name = "netif"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9e642845c332c335e3125759b10145a972c1f413cb48cd6d7b96e81821f281"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -70,6 +70,7 @@ http = "0.2.4"
 hyper = { version = "0.14.12", features = ["server", "stream", "http1", "http2", "runtime"] }
 libc = "0.2.106"
 log = "0.4.14"
+netif = "0.1.0"
 notify = "=5.0.0-pre.12"
 once_cell = "=1.9.0"
 regex = "1.5.4"


### PR DESCRIPTION
Add an op to list the network interfaces on the system.

Prep work for #8137 and `os.networkInterfaces()` Node compat in std.

Refs denoland/deno_std#1436.

<hr>

Opening this as a WIP because I'd like feedback on what permissions to check for.