### PR TITLE
[v1.16] fix(core): throw on invalid callConsole args (#12973)

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -633,10 +633,12 @@ fn call_console(
   args: v8::FunctionCallbackArguments,
   _rv: v8::ReturnValue,
 ) {
-  assert!(args.length() >= 2);
-
-  assert!(args.get(0).is_function());
-  assert!(args.get(1).is_function());
+  if args.length() < 2
+    || !args.get(0).is_function()
+    || !args.get(1).is_function()
+  {
+    return throw_type_error(scope, "Invalid arguments");
+  }
 
   let mut call_args = vec![];
   for i in 2..args.length() {


### PR DESCRIPTION
Instead of panicking via asserts, since JS-callable code (even Deno.core ...) should not cause process crashes/panics

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
