### PR TITLE
fix(cli):  refrain from adding colours to the non-tty outputs

### DIFF
--- a/runtime/colors.rs
+++ b/runtime/colors.rs
@@ -9,11 +9,14 @@ use termcolor::{Ansi, ColorSpec, WriteColor};
 use termcolor::{BufferWriter, ColorChoice};
 
 lazy_static::lazy_static! {
+// checks if the output is piped to a tty
+  static ref IS_TTY: bool = atty::is(atty::Stream::Stdout);
   static ref NO_COLOR: bool = std::env::var_os("NO_COLOR").is_some();
 }
 
+// if the output is piped to a tty, use color
 pub fn use_color() -> bool {
-  !(*NO_COLOR)
+  !(*NO_COLOR) && *IS_TTY
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
fixes #12224 

#### Before:
<img width="550px" height="250px" alt="Before" src="https://user-images.githubusercontent.com/45007338/145447261-d44817dd-704c-400b-8a4f-2f44d5d7d13c.png">

#### After
<img width="550px" height="250px" alt="after" src="https://user-images.githubusercontent.com/45007338/145447631-49863919-3711-4946-8d68-b5b5d94d27f6.png">
