### PR TITLE
chore: place `@deprecated` tag after documentation block

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -654,9 +654,6 @@ declare namespace Deno {
   }
 
   /**
-   * @deprecated Use `copy` from https://deno.land/std/streams/conversion.ts
-   * instead. `Deno.copy` will be removed in Deno 2.0.
-   *
    * Copies from `src` to `dst` until either EOF (`null`) is read from `src` or
    * an error occurs. It resolves to the number of bytes copied or rejects with
    * the first error encountered while copying.
@@ -667,6 +664,9 @@ declare namespace Deno {
    * const destination = await Deno.create("my_file_2.txt");
    * const bytesCopied2 = await Deno.copy(source, destination);
    * ```
+   *
+   * @deprecated Use `copy` from https://deno.land/std/streams/conversion.ts
+   * instead. `Deno.copy` will be removed in Deno 2.0.
    *
    * @param src The source to copy from
    * @param dst The destination to copy to
@@ -681,10 +681,6 @@ declare namespace Deno {
   ): Promise<number>;
 
   /**
-   * @deprecated Use `iterateReader` from
-   * https://deno.land/std/streams/conversion.ts instead. `Deno.iter` will be
-   * removed in Deno 2.0.
-   *
    * Turns a Reader, `r`, into an async iterator.
    *
    * ```ts
@@ -713,6 +709,10 @@ declare namespace Deno {
    * a view on that buffer on each iteration. It is therefore caller's
    * responsibility to copy contents of the buffer if needed; otherwise the
    * next iteration will overwrite contents of previously returned chunk.
+   *
+   * @deprecated Use `iterateReader` from
+   * https://deno.land/std/streams/conversion.ts instead. `Deno.iter` will be
+   * removed in Deno 2.0.
    */
   export function iter(
     r: Reader,
@@ -722,10 +722,6 @@ declare namespace Deno {
   ): AsyncIterableIterator<Uint8Array>;
 
   /**
-   * @deprecated Use `iterateReaderSync` from
-   * https://deno.land/std/streams/conversion.ts instead. `Deno.iterSync` will
-   * be removed in Deno 2.0.
-   *
    * Turns a ReaderSync, `r`, into an iterator.
    *
    * ```ts
@@ -754,6 +750,10 @@ declare namespace Deno {
    * a view on that buffer on each iteration. It is therefore caller's
    * responsibility to copy contents of the buffer if needed; otherwise the
    * next iteration will overwrite contents of previously returned chunk.
+   *
+   * @deprecated Use `iterateReaderSync` from
+   * https://deno.land/std/streams/conversion.ts instead. `Deno.iterSync` will
+   * be removed in Deno 2.0.
    */
   export function iterSync(
     r: ReaderSync,
@@ -1210,9 +1210,6 @@ declare namespace Deno {
   }
 
   /**
-   * @deprecated Use `readAll` from https://deno.land/std/streams/conversion.ts
-   * instead. `Deno.readAll` will be removed in Deno 2.0.
-   *
    * Read Reader `r` until EOF (`null`) and resolve to the content as
    * Uint8Array`.
    *
@@ -1231,14 +1228,13 @@ declare namespace Deno {
    * const reader = new Deno.Buffer(myData.buffer as ArrayBuffer);
    * const bufferContent = await Deno.readAll(reader);
    * ```
+   *
+   * @deprecated Use `readAll` from https://deno.land/std/streams/conversion.ts
+   * instead. `Deno.readAll` will be removed in Deno 2.0.
    */
   export function readAll(r: Reader): Promise<Uint8Array>;
 
   /**
-   * @deprecated Use `readAllSync` from
-   * https://deno.land/std/streams/conversion.ts instead. `Deno.readAllSync`
-   * will be removed in Deno 2.0.
-   *
    * Synchronously reads Reader `r` until EOF (`null`) and returns the content
    * as `Uint8Array`.
    *
@@ -1257,13 +1253,14 @@ declare namespace Deno {
    * const reader = new Deno.Buffer(myData.buffer as ArrayBuffer);
    * const bufferContent = Deno.readAllSync(reader);
    * ```
+   *
+   * @deprecated Use `readAllSync` from
+   * https://deno.land/std/streams/conversion.ts instead. `Deno.readAllSync`
+   * will be removed in Deno 2.0.
    */
   export function readAllSync(r: ReaderSync): Uint8Array;
 
   /**
-   * @deprecated Use `writeAll` from https://deno.land/std/streams/conversion.ts
-   * instead. `Deno.writeAll` will be removed in Deno 2.0.
-   *
    * Write all the content of the array buffer (`arr`) to the writer (`w`).
    *
    * ```ts
@@ -1287,14 +1284,13 @@ declare namespace Deno {
    * await Deno.writeAll(writer, contentBytes);
    * console.log(writer.bytes().length);  // 11
    * ```
+   *
+   * @deprecated Use `writeAll` from https://deno.land/std/streams/conversion.ts
+   * instead. `Deno.writeAll` will be removed in Deno 2.0.
    */
   export function writeAll(w: Writer, arr: Uint8Array): Promise<void>;
 
   /**
-   * @deprecated Use `writeAllSync` from
-   * https://deno.land/std/streams/conversion.ts instead. `Deno.writeAllSync`
-   * will be removed in Deno 2.0.
-   *
    * Synchronously write all the content of the array buffer (`arr`) to the
    * writer (`w`).
    *
@@ -1319,6 +1315,10 @@ declare namespace Deno {
    * Deno.writeAllSync(writer, contentBytes);
    * console.log(writer.bytes().length);  // 11
    * ```
+   *
+   * @deprecated Use `writeAllSync` from
+   * https://deno.land/std/streams/conversion.ts instead. `Deno.writeAllSync`
+   * will be removed in Deno 2.0.
    */
   export function writeAllSync(w: WriterSync, arr: Uint8Array): void;
 
@@ -2126,9 +2126,10 @@ declare namespace Deno {
     readonly rid: number;
     /** Stops watching the file system and closes the watcher resource. */
     close(): void;
-    /** @deprecated
+    /**
      * Stops watching the file system and closes the watcher resource.
-     * Will be removed at 2.0.
+     *
+     * @deprecated Will be removed at 2.0.
      */
     return?(value?: any): Promise<IteratorResult<FsEvent>>;
     [Symbol.asyncIterator](): AsyncIterableIterator<FsEvent>;
@@ -2564,11 +2565,12 @@ declare namespace Deno {
   export const args: string[];
 
   /**
-   * @deprecated A symbol which can be used as a key for a custom method which will be
+   * A symbol which can be used as a key for a custom method which will be
    * called when `Deno.inspect()` is called, or when the object is logged to
    * the console.
    *
-   * This symbol is deprecated since 1.9. Use `Symbol.for("Deno.customInspect")` instead.
+   * @deprecated This symbol is deprecated since 1.9. Use
+   * `Symbol.for("Deno.customInspect")` instead.
    */
   export const customInspect: unique symbol;
 

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -139,10 +139,10 @@ declare namespace Deno {
      * If not specified, defaults to `127.0.0.1`. */
     hostname?: string;
     /**
+     * Server certificate file.
+     *
      * @deprecated This option is deprecated and will be removed in a future
      * release.
-     *
-     * Server certificate file.
      */
     certFile?: string;
     /** A list of root certificates that will be used in addition to the


### PR DESCRIPTION
The way JSDoc tags work, once a tag is encountered, the text associated with the tag is everything up to the next tag, so all tags should come _after_ the documentation block associated with the entity.  This is consistent with how the likes of vscode and other parse tags, including now `deno_doc`.

This will fix issues where the documentation block is not appearing for certain entries in `doc.deno.land` because only the doc block is being displayed in a listing (along with just the `deprecated` tag).