### PR TITLE
fix(ext/web): set location undefined when `--location` is not specified

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -233,7 +233,6 @@ itest!(_070_location {
 itest!(_071_location_unset {
   args: "run 071_location_unset.ts",
   output: "071_location_unset.ts.out",
-  exit_code: 1,
 });
 
 itest!(_072_location_relative_fetch {

--- a/cli/tests/testdata/071_location_unset.ts.out
+++ b/cli/tests/testdata/071_location_unset.ts.out
@@ -1,4 +1,4 @@
 [WILDCARD][Function: Location]
 Location {}
-error: Uncaught ReferenceError: Access to "location", run again with --location <href>.
+Warning: accessing undefined 'location' global, run again with --location <href>.
 [WILDCARD]

--- a/cli/tests/testdata/071_location_unset.ts.out
+++ b/cli/tests/testdata/071_location_unset.ts.out
@@ -1,4 +1,4 @@
 [WILDCARD][Function: Location]
 Location {}
-Warning: accessing undefined 'location' global, run again with --location <href>.
+undefined
 [WILDCARD]

--- a/ext/web/12_location.js
+++ b/ext/web/12_location.js
@@ -9,7 +9,6 @@
   const {
     Error,
     ObjectDefineProperties,
-    ReferenceError,
     Symbol,
     SymbolFor,
     SymbolToStringTag,

--- a/ext/web/12_location.js
+++ b/ext/web/12_location.js
@@ -356,8 +356,8 @@
     },
   });
 
-  let location = null;
-  let workerLocation = null;
+  let location = undefined;
+  let workerLocation = undefined;
 
   function setLocationHref(href) {
     location = new Location(href, locationConstructorKey);
@@ -378,8 +378,9 @@
     locationDescriptor: {
       get() {
         if (location == null) {
-          throw new ReferenceError(
-            `Access to "location", run again with --location <href>.`,
+          console.warn(
+            "Warning: accessing undefined 'location' global, " +
+              "run again with --location <href>.",
           );
         }
         return location;

--- a/ext/web/12_location.js
+++ b/ext/web/12_location.js
@@ -376,12 +376,6 @@
     },
     locationDescriptor: {
       get() {
-        if (location == null) {
-          console.warn(
-            "Warning: accessing undefined 'location' global, " +
-              "run again with --location <href>.",
-          );
-        }
         return location;
       },
       set() {


### PR DESCRIPTION
Currently `globalThis.location` throws an error when `--location` is not specified. This behavior is inconvenient if a script does the feature detection like `typeof window.location` ([type-detect](https://npm.im/type-detect) is an example of such a script)

This PR changes it to return `undefined` for `window.location` when `--location` is not specified.

closes #12969
previous version: #10828