### PR TITLE
refactor(ext/crypto): symmetric jwk decode in rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ name = "deno_crypto"
 version = "0.42.0"
 dependencies = [
  "aes",
+ "base64 0.13.0",
  "block-modes",
  "deno_core",
  "deno_web",

--- a/ext/crypto/Cargo.toml
+++ b/ext/crypto/Cargo.toml
@@ -15,6 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 aes = "0.7.5"
+base64 = "0.13.0"
 block-modes = "0.8.1"
 deno_core = { version = "0.110.0", path = "../../core" }
 deno_web = { version = "0.59.0", path = "../web" }


### PR DESCRIPTION
This commit moves JWK secret importing for HMAC and AES to Rust.
