### PR TITLE
fix(cli) use color to the outputs for CI workflow

### DIFF
--- a/runtime/colors.rs
+++ b/runtime/colors.rs
@@ -12,11 +12,13 @@ lazy_static::lazy_static! {
 // checks if the output is piped to a tty
   static ref IS_TTY: bool = atty::is(atty::Stream::Stdout);
   static ref NO_COLOR: bool = std::env::var_os("NO_COLOR").is_some();
+// checks if the run is part of CI workflow to determine if we should use colors to the output
+  static ref IS_CI_WORKFLOW: bool = std::env::var_os("CI").is_some();
 }
 
-// if the output is piped to a tty, use color
+// if the output is piped to a tty or CI workfkow from Github Action, use color
 pub fn use_color() -> bool {
-  !(*NO_COLOR) && *IS_TTY
+  !(*NO_COLOR) && (*IS_TTY || *IS_CI_WORKFLOW)
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
followup on #13031 
fixes #13050
Output colors for CI workflows has been removed and this PR tries to address by adding them back

The idea is to use Github Action's default environment variable `CI` to determine to use output colour for non-tty