### PR TITLE
Revert "fix(cli): don't add colors for non-tty outputs (#13031)"

### DIFF
--- a/runtime/colors.rs
+++ b/runtime/colors.rs
@@ -9,14 +9,11 @@ use termcolor::{Ansi, ColorSpec, WriteColor};
 use termcolor::{BufferWriter, ColorChoice};
 
 lazy_static::lazy_static! {
-// checks if the output is piped to a tty
-  static ref IS_TTY: bool = atty::is(atty::Stream::Stdout);
   static ref NO_COLOR: bool = std::env::var_os("NO_COLOR").is_some();
 }
 
-// if the output is piped to a tty, use color
 pub fn use_color() -> bool {
-  !(*NO_COLOR) && *IS_TTY
+  !(*NO_COLOR)
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
This reverts commit 38f163022373c9adb050f17140f7d29bb403abe2.

Ref #13049