### PR TITLE
example(core): add example for FS module loading

### DIFF
--- a/core/examples/fs_module_loader.rs
+++ b/core/examples/fs_module_loader.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 fn main() -> Result<(), Error> {
   let args: Vec<String> = std::env::args().collect();
   if args.len() < 2 {
-    println!("Usage: target/examples/debug/fs_module_loading <path_to_module>");
+    println!("Usage: target/examples/debug/fs_module_loader <path_to_module>");
     std::process::exit(1);
   }
   let main_url = args[1].clone();
@@ -28,20 +28,9 @@ fn main() -> Result<(), Error> {
 
   let future = async move {
     let mod_id = js_runtime.load_main_module(&main_module, None).await?;
-
-    let mut receiver = js_runtime.mod_evaluate(mod_id);
-    tokio::select! {
-      maybe_result = &mut receiver => {
-        maybe_result.expect("Module evaluation result not provided.")
-      }
-
-      event_loop_result = js_runtime.run_event_loop(false) => {
-        event_loop_result?;
-        let maybe_result = receiver.await;
-        maybe_result.expect("Module evaluation result not provided.")
-      }
-    }
+    let _ = js_runtime.mod_evaluate(mod_id);
+    js_runtime.run_event_loop(false).await?;
+    Ok(())
   };
-  runtime.block_on(future)?;
-  Ok(())
+  runtime.block_on(future)
 }

--- a/core/examples/fs_module_loader.rs
+++ b/core/examples/fs_module_loader.rs
@@ -1,0 +1,47 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+use deno_core::anyhow::Error;
+use deno_core::FsModuleLoader;
+use deno_core::JsRuntime;
+use deno_core::RuntimeOptions;
+use std::rc::Rc;
+
+fn main() -> Result<(), Error> {
+  let args: Vec<String> = std::env::args().collect();
+  if args.len() < 2 {
+    println!("Usage: target/examples/debug/fs_module_loading <path_to_module>");
+    std::process::exit(1);
+  }
+  let main_url = args[1].clone();
+  println!("Run {}", main_url);
+
+  let mut js_runtime = JsRuntime::new(RuntimeOptions {
+    module_loader: Some(Rc::new(FsModuleLoader)),
+    ..Default::default()
+  });
+
+  let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()?;
+
+  let main_module = deno_core::resolve_path(&main_url)?;
+
+  let future = async move {
+    let mod_id = js_runtime.load_main_module(&main_module, None).await?;
+
+    let mut receiver = js_runtime.mod_evaluate(mod_id);
+    tokio::select! {
+      maybe_result = &mut receiver => {
+        maybe_result.expect("Module evaluation result not provided.")
+      }
+
+      event_loop_result = js_runtime.run_event_loop(false) => {
+        event_loop_result?;
+        let maybe_result = receiver.await;
+        maybe_result.expect("Module evaluation result not provided.")
+      }
+    }
+  };
+  runtime.block_on(future)?;
+  Ok(())
+}


### PR DESCRIPTION
Just adding a simple example of module loading, I'm using it
to test import assertions/JSON modules integration.