### PR TITLE
fix(test): wait for inspector session in side modules

### DIFF
--- a/cli/tests/testdata/inspector_test.js
+++ b/cli/tests/testdata/inspector_test.js
@@ -1,0 +1,3 @@
+Deno.test("basic test", () => {
+  console.log("test has finished running");
+});

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -229,6 +229,7 @@ impl MainWorker {
     module_specifier: &ModuleSpecifier,
   ) -> Result<(), AnyError> {
     let id = self.preload_module(module_specifier, false).await?;
+    self.wait_for_inspector_session();
     self.evaluate_module(id).await
   }
 


### PR DESCRIPTION
Fixes #12584

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
This the first time I've ever worked with rust so apologies if this a terrible PR.
All tests passed locally except for `test_respect_cache_revalidates` which was already failing without this change.

One thing I was a bit worried about was that this change would cause multiple breaks every time a new module is loaded. But I couldn't find any case where this happens.

Also, should a new test case for this specific issue be added? I couldn't find any existing tests checking for the inspector like this, so I'm not sure I'm capable of writing such a test case.