### PR TITLE
Feat(cli) add color flag to deno

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: ci
 
 on: [push, pull_request]
 
+env:
+  DENO_TERM_COLOR: always
+
 jobs:
   build:
     name: ${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}
@@ -237,6 +240,7 @@ jobs:
             export LD=ld.lld-13       # Use the lld linker.
 
             # Miscellaneous flags.
+            export DENO_TERM_COLOR=always
             export CARGO_TERM_COLOR=always
             export CI=true
           ___

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -12,6 +12,7 @@ use deno_core::url::Url;
 use deno_runtime::permissions::PermissionsOptions;
 use log::debug;
 use log::Level;
+use std::env;
 use std::net::SocketAddr;
 use std::num::NonZeroU32;
 use std::num::NonZeroU8;
@@ -206,6 +207,22 @@ impl Default for CheckFlag {
   }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum ColorFlag {
+  // use color for output piped to tty and refrain from using color for non-tty
+  // The default value.
+  Auto,
+  // Force color output for both tty and non-tty.
+  Always,
+  // Force no color output.
+  Never,
+}
+
+impl Default for ColorFlag {
+  fn default() -> Self {
+    Self::Auto
+  }
+}
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Flags {
   /// Vector of CLI arguments - these are user script arguments, all Deno
@@ -228,6 +245,7 @@ pub struct Flags {
   pub cache_path: Option<PathBuf>,
   pub cached_only: bool,
   pub check: CheckFlag,
+  pub color: ColorFlag,
   pub config_path: Option<String>,
   pub coverage_dir: Option<String>,
   pub enable_testing_features: bool,
@@ -384,6 +402,10 @@ static ENV_VARIABLES_HELP: &str = r#"ENVIRONMENT VARIABLES:
     DENO_INSTALL_ROOT    Set deno install's output directory
                          (defaults to $HOME/.deno/bin)
     DENO_WEBGPU_TRACE    Directory to use for wgpu traces
+    DENO_TERM_COLOR      Enable/disable color for outputs from deno
+                         should be one of [always, never, auto]
+                         setting NO_COLOR will override this
+                         (defaults to auto)
     HTTP_PROXY           Proxy address for HTTP requests
                          (module downloads, fetch)
     HTTPS_PROXY          Proxy address for HTTPS requests
@@ -421,6 +443,18 @@ pub fn flags_from_vec(args: Vec<String>) -> clap::Result<Flags> {
   })?;
 
   let mut flags = Flags::default();
+
+  if matches.is_present("color") {
+    let preferece = matches.value_of("color").unwrap().to_string();
+    flags.color = match preferece.as_str() {
+      "auto" => ColorFlag::Auto,
+      "always" => ColorFlag::Always,
+      "never" => ColorFlag::Never,
+      _ => unreachable!(),
+    };
+    // DENO_COLOR env var is created to let runtime/color.rs know about the color flag
+    env::set_var("DENO_TERM_COLOR", preferece);
+  }
 
   if matches.is_present("unstable") {
     flags.unstable = true;
@@ -519,6 +553,7 @@ If the flag is set, restrict these messages to errors.",
         )
         .global(true),
     )
+    .arg(color_arg())
     .subcommand(bundle_subcommand())
     .subcommand(cache_subcommand())
     .subcommand(compile_subcommand())
@@ -1479,6 +1514,28 @@ fn permission_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         .long("prompt")
         .help("Fallback to prompt if required permission wasn't passed"),
     )
+}
+
+fn color_arg<'a, 'b>() -> Arg<'a, 'b> {
+  Arg::with_name("color")
+    .long("color")
+    .value_name("WHEN")
+    .help("Sets the color mode for the output")
+    .long_help(
+      "Sets the color mode for the output 
+Can also be set through the environment variable `DENO_TERM_COLOR`
+Accepted values:
+  auto - intelligently sets color mode, This is default
+  always - always use color
+  never - never use color
+Important: Setting `NO_COLOR` environment variable will override this flag.
+      ",
+    )
+    .takes_value(true)
+    .possible_values(&["auto", "always", "never"])
+    .env("DENO_TERM_COLOR")
+    .default_value("auto")
+    .global(true)
 }
 
 fn runtime_args<'a, 'b>(

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -240,5 +240,6 @@ pub fn compile_to_runtime_flags(
     v8_flags: flags.v8_flags,
     version: false,
     watch: false,
+    color: flags.color,
   })
 }

--- a/runtime/colors.rs
+++ b/runtime/colors.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+use std::ffi::OsString;
 use std::fmt;
 use std::io::Write;
 use termcolor::Color::{Ansi256, Black, Blue, Cyan, Green, Red, White, Yellow};
@@ -14,9 +15,9 @@ lazy_static::lazy_static! {
 }
 
 pub fn use_color() -> bool {
-  let color_flag =
-    std::env::var("DENO_TERM_COLOR").unwrap_or_else(|_| "auto".to_string());
-  let preferece = match color_flag.as_str() {
+  let color_flag = std::env::var_os("DENO_TERM_COLOR")
+    .unwrap_or_else(|| OsString::from("auto"));
+  let preferece = match color_flag.into_string().unwrap().as_str() {
     "always" => true,
     "never" => false,
     "auto" => *IS_TTY,

--- a/runtime/colors.rs
+++ b/runtime/colors.rs
@@ -9,11 +9,20 @@ use termcolor::{Ansi, ColorSpec, WriteColor};
 use termcolor::{BufferWriter, ColorChoice};
 
 lazy_static::lazy_static! {
+  static ref IS_TTY: bool = atty::is(atty::Stream::Stdout);
   static ref NO_COLOR: bool = std::env::var_os("NO_COLOR").is_some();
 }
 
 pub fn use_color() -> bool {
-  !(*NO_COLOR)
+  let color_flag =
+    std::env::var("DENO_TERM_COLOR").unwrap_or_else(|_| "auto".to_string());
+  let preferece = match color_flag.as_str() {
+    "always" => true,
+    "never" => false,
+    "auto" => *IS_TTY,
+    _ => unreachable!(),
+  };
+  preferece && !*NO_COLOR
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
this PR adds `--colour` global flag to Deno which can also be set using `DENO_TERM_COLOR` environment variable

Just like `cargo --color` we accept the following 3 arguments 
- auto - the default, this option can identify tty and uses colour only to them
- always - use color even to non-tty
- never - never use colour even in tty

`--color` flag will be overridden if `NO_COLOR` environment var is set

follow up on #13049 

P.S: tests and docs are yet to be added if the approach taken is said okay