### PR TITLE
fix(ext/net): make unix and tcp identical on close

### DIFF
--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -147,7 +147,8 @@ Deno.test(
     listener.close();
     await assertRejects(
       () => p,
-      Deno.errors.Interrupted,
+      Deno.errors.BadResource,
+      "Listener has been closed",
     );
   },
 );
@@ -185,7 +186,7 @@ Deno.test(
     const listener = Deno.listen({ transport: "unix", path: filePath });
     let acceptErrCount = 0;
     const checkErr = (e: Error) => {
-      if (e instanceof Deno.errors.Interrupted) { // "operation canceled"
+      if (e.message === "Listener has been closed") {
         assertEquals(acceptErrCount, 1);
       } else if (e instanceof Deno.errors.Busy) { // "Listener already in use"
         acceptErrCount++;

--- a/ext/net/ops_unix.rs
+++ b/ext/net/ops_unix.rs
@@ -91,8 +91,11 @@ pub(crate) async fn accept_unix(
     .try_borrow_mut()
     .ok_or_else(|| custom_error("Busy", "Listener already in use"))?;
   let cancel = RcRef::map(resource, |r| &r.cancel);
-  let (unix_stream, _socket_addr) =
-    listener.accept().try_or_cancel(cancel).await?;
+  let (unix_stream, _socket_addr) = listener
+    .accept()
+    .try_or_cancel(cancel)
+    .await
+    .map_err(crate::ops::accept_err)?;
 
   let local_addr = unix_stream.local_addr()?;
   let remote_addr = unix_stream.peer_addr()?;


### PR DESCRIPTION
std/http/server knows how to handle "Listener has been closed"
exceptions but not "operation canceled" errors.

Make "unix" listen sockets throw the same exception as "tcp" listen
sockets when the socket is closed and has a pending accept operation.

There is still a discrepancy when multiple accept requests are posted
but that's probably a less visible issue and something for another day.

Fixes #13033