### PR TITLE
feat(fetch): Support abort reasons in fetch

### DIFF
--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -27,7 +27,6 @@
     abortedNetworkError,
   } = window.__bootstrap.fetch;
   const abortSignal = window.__bootstrap.abortSignal;
-  const { DOMException } = window.__bootstrap.domException;
   const {
     ArrayPrototypePush,
     ArrayPrototypeSplice,

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -88,10 +88,7 @@
   function createResponseBodyStream(responseBodyRid, terminator) {
     function onAbort() {
       if (readable) {
-        errorReadableStream(
-          readable,
-          new DOMException("Ongoing fetch was aborted.", "AbortError"),
-        );
+        errorReadableStream(readable, terminator.reason);
       }
       core.tryClose(responseBodyRid);
     }
@@ -121,9 +118,7 @@
         } catch (err) {
           RESOURCE_REGISTRY.unregister(readable);
           if (terminator.aborted) {
-            controller.error(
-              new DOMException("Ongoing fetch was aborted.", "AbortError"),
-            );
+            controller.error(terminator.reason);
           } else {
             // There was an error while reading a chunk of the body, so we
             // error.
@@ -155,9 +150,7 @@
       }
 
       const body = new InnerBody(req.blobUrlEntry.stream());
-      terminator[abortSignal.add](() =>
-        body.error(new DOMException("Ongoing fetch was aborted.", "AbortError"))
-      );
+      terminator[abortSignal.add](() => body.error(terminator.reason));
 
       return {
         headerList: [
@@ -328,6 +321,7 @@
   /**
    * @param {InnerRequest} request
    * @param {InnerResponse} response
+   * @param {AbortSignal} terminator
    * @returns {Promise<InnerResponse>}
    */
   function httpRedirectFetch(request, response, terminator) {
@@ -405,7 +399,7 @@
       const request = toInnerRequest(requestObject);
       // 4.
       if (requestObject.signal.aborted) {
-        reject(abortFetch(request, null));
+        reject(abortFetch(request, null, requestObject.signal.reason));
         return;
       }
 
@@ -416,7 +410,9 @@
       // 10.
       function onabort() {
         locallyAborted = true;
-        reject(abortFetch(request, responseObject));
+        reject(
+          abortFetch(request, responseObject, requestObject.signal.reason),
+        );
       }
       requestObject.signal[abortSignal.add](onabort);
 
@@ -433,7 +429,13 @@
             if (locallyAborted) return;
             // 12.2.
             if (response.aborted) {
-              reject(request, responseObject);
+              reject(
+                abortFetch(
+                  request,
+                  responseObject,
+                  requestObject.signal.reason,
+                ),
+              );
               requestObject.signal[abortSignal.remove](onabort);
               return;
             }
@@ -459,8 +461,7 @@
     });
   }
 
-  function abortFetch(request, responseObject) {
-    const error = new DOMException("Ongoing fetch was aborted.", "AbortError");
+  function abortFetch(request, responseObject, error) {
     if (request.body !== null) {
       if (WeakMapPrototypeHas(requestBodyReaders, request)) {
         WeakMapPrototypeGet(requestBodyReaders, request).cancel(error);


### PR DESCRIPTION
The spec PR for this (whatwg/fetch#1343) hasn't been finalized yet because some questions regarding service worker integration are not settled yet, but since that is not relevant to Deno and everything else seems settled, and it seems best to not wait for another Deno version to support abort reasons in the fetch API.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
