### PR TITLE
fix(ext/ffi): Use `c_char` instead of `i8` in `op_ffi_cstr_read` for compatibility with aarch64

### DIFF
--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -23,6 +23,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::ffi::CStr;
+use std::os::raw::c_char;
 use std::path::Path;
 use std::path::PathBuf;
 use std::ptr;
@@ -608,7 +609,7 @@ where
   let permissions = state.borrow_mut::<FP>();
   permissions.check(None)?;
 
-  let ptr = u64::from(ptr) as *const i8;
+  let ptr = u64::from(ptr) as *const c_char;
   Ok(unsafe { CStr::from_ptr(ptr) }.to_str()?.to_string())
 }
 


### PR DESCRIPTION
👋

This patch fixes a build error I get when [compiling for aarch64 in Linux](https://github.com/LukeChannings/deno-arm64/runs/4552696134?check_suite_focus=true):

```
Compiling deno_ffi v0.16.0 (/deno/ext/ffi)
error[E0308]: mismatched types
   --> ext/ffi/lib.rs:612:30
    |
612 |   Ok(unsafe { CStr::from_ptr(ptr) }.to_str()?.to_string())
    |                              ^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `deno_ffi` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```

This is caused by `CStr::from_ptr` returning an `i8` on aarch64, instead of a `u8`.
Using `std::os::raw::c_char` will handle the underlying type differences (I think).

I've compiled with this patch [here](https://github.com/LukeChannings/deno-arm64) and it compiles correctly for aarch64.