### PR TITLE
fix: inspector prompts

### DIFF
--- a/cli/tests/integration/inspector_tests.rs
+++ b/cli/tests/integration/inspector_tests.rs
@@ -97,6 +97,8 @@ async fn inspector_break_on_first_line() {
 
   use TestStep::*;
   let test_steps = vec![
+    StdErr("Visit chrome://inspect to connect to the debugger."),
+    StdErr("Deno is waiting for debugger to connect."),
     WsSend(r#"{"id":1,"method":"Runtime.enable"}"#),
     WsSend(r#"{"id":2,"method":"Debugger.enable"}"#),
     WsRecv(
@@ -119,10 +121,10 @@ async fn inspector_break_on_first_line() {
 
   for step in test_steps {
     match step {
+      StdErr(s) => assert_eq!(&stderr_lines.next().unwrap(), s),
       StdOut(s) => assert_eq!(&stdout_lines.next().unwrap(), s),
       WsRecv(s) => assert!(socket_rx.next().await.unwrap().starts_with(s)),
       WsSend(s) => socket_tx.send(s.into()).await.unwrap(),
-      _ => unreachable!(),
     }
   }
 
@@ -276,6 +278,8 @@ async fn inspector_does_not_hang() {
 
   use TestStep::*;
   let test_steps = vec![
+    StdErr("Visit chrome://inspect to connect to the debugger."),
+    StdErr("Deno is waiting for debugger to connect."),
     WsSend(r#"{"id":1,"method":"Runtime.enable"}"#),
     WsSend(r#"{"id":2,"method":"Debugger.enable"}"#),
     WsRecv(
@@ -293,6 +297,7 @@ async fn inspector_does_not_hang() {
 
   for step in test_steps {
     match step {
+      StdErr(s) => assert_eq!(&stderr_lines.next().unwrap(), s),
       WsRecv(s) => assert!(socket_rx.next().await.unwrap().starts_with(s)),
       WsSend(s) => socket_tx.send(s.into()).await.unwrap(),
       _ => unreachable!(),
@@ -397,6 +402,7 @@ async fn inspector_runtime_evaluate_does_not_crash() {
 
   use TestStep::*;
   let test_steps = vec![
+    StdErr("Visit chrome://inspect to connect to the debugger."),
     WsSend(r#"{"id":1,"method":"Runtime.enable"}"#),
     WsSend(r#"{"id":2,"method":"Debugger.enable"}"#),
     WsRecv(
@@ -555,6 +561,8 @@ async fn inspector_break_on_first_line_in_test() {
 
   use TestStep::*;
   let test_steps = vec![
+    StdErr("Visit chrome://inspect to connect to the debugger."),
+    StdErr("Deno is waiting for debugger to connect."),
     WsSend(r#"{"id":1,"method":"Runtime.enable"}"#),
     WsSend(r#"{"id":2,"method":"Debugger.enable"}"#),
     WsRecv(
@@ -583,9 +591,9 @@ async fn inspector_break_on_first_line_in_test() {
         "Doesn't contain {}",
         s
       ),
+      StdErr(s) => assert_eq!(&stderr_lines.next().unwrap(), s),
       WsRecv(s) => assert!(socket_rx.next().await.unwrap().starts_with(s)),
       WsSend(s) => socket_tx.send(s.into()).await.unwrap(),
-      _ => unreachable!(),
     }
   }
 

--- a/runtime/inspector_server.rs
+++ b/runtime/inspector_server.rs
@@ -345,7 +345,7 @@ async fn pump_websocket_messages(
     .map_err(|_| ());
 
   let inbound_pump = async move {
-    let result = websocket_rx
+    let _result = websocket_rx
       .map_ok(|msg| msg.into_data())
       .map_err(AnyError::from)
       .map_ok(|msg| {
@@ -354,10 +354,9 @@ async fn pump_websocket_messages(
       .try_collect::<()>()
       .await;
 
-    match result {
-      Ok(_) => eprintln!("Debugger session ended"),
-      Err(err) => eprintln!("Debugger session ended: {}.", err),
-    };
+    // Users don't care if there was an error coming from debugger,
+    // just about the fact that debugger did disconnect.
+    eprintln!("Debugger session ended");
 
     Ok(())
   };

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -442,7 +442,11 @@ impl WebWorker {
     });
 
     if let Some(server) = options.maybe_inspector_server.clone() {
-      server.register_inspector(main_module.to_string(), &mut js_runtime);
+      server.register_inspector(
+        main_module.to_string(),
+        &mut js_runtime,
+        false,
+      );
     }
 
     let (internal_handle, external_handle) = {

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -161,7 +161,11 @@ impl MainWorker {
     });
 
     if let Some(server) = options.maybe_inspector_server.clone() {
-      server.register_inspector(main_module.to_string(), &mut js_runtime);
+      server.register_inspector(
+        main_module.to_string(),
+        &mut js_runtime,
+        options.should_break_on_first_statement,
+      );
     }
 
     Self {


### PR DESCRIPTION
This commit fixes prompts printed to the terminal when
running with "--inspect" or "--inspect-brk" flags.

When debugger disconnects error is no longer printed as
users don't care about the reason debugger did disconnect.

A message suggesting to go to "chrome://inspect" is printed 
if debugger is active.

Additionally and information that process is waiting for
debugger to connect is printed if running with "--inspect-brk"
flag.

Closes https://github.com/denoland/deno/issues/13110
Closes https://github.com/denoland/deno/issues/13124