### PR TITLE
feat(lsp) add code lens for debugging tests

### DIFF
--- a/cli/lsp/code_lens.rs
+++ b/cli/lsp/code_lens.rs
@@ -597,6 +597,33 @@ mod tests {
             arguments: Some(vec![
               json!("https://deno.land/x/mod.ts"),
               json!("test a"),
+              json!({
+                "inspect": false,
+              }),
+            ])
+          }),
+          data: None,
+        },
+        lsp::CodeLens {
+          range: lsp::Range {
+            start: lsp::Position {
+              line: 1,
+              character: 11
+            },
+            end: lsp::Position {
+              line: 1,
+              character: 15
+            }
+          },
+          command: Some(lsp::Command {
+            title: "Debug".to_string(),
+            command: "deno.test".to_string(),
+            arguments: Some(vec![
+              json!("https://deno.land/x/mod.ts"),
+              json!("test a"),
+              json!({
+                "inspect": true,
+              }),
             ])
           }),
           data: None,
@@ -618,6 +645,33 @@ mod tests {
             arguments: Some(vec![
               json!("https://deno.land/x/mod.ts"),
               json!("test b"),
+              json!({
+                "inspect": false,
+              }),
+            ])
+          }),
+          data: None,
+        },
+        lsp::CodeLens {
+          range: lsp::Range {
+            start: lsp::Position {
+              line: 6,
+              character: 11
+            },
+            end: lsp::Position {
+              line: 6,
+              character: 15
+            }
+          },
+          command: Some(lsp::Command {
+            title: "Debug".to_string(),
+            command: "deno.test".to_string(),
+            arguments: Some(vec![
+              json!("https://deno.land/x/mod.ts"),
+              json!("test b"),
+              json!({
+                "inspect": true,
+              }),
             ])
           }),
           data: None,

--- a/cli/tests/testdata/lsp/code_lens_response_test.json
+++ b/cli/tests/testdata/lsp/code_lens_response_test.json
@@ -15,7 +15,33 @@
       "command": "deno.test",
       "arguments": [
         "file:///a/file.ts",
-        "test a"
+        "test a",
+        {
+          "inspect": false
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 4,
+        "character": 5
+      },
+      "end": {
+        "line": 4,
+        "character": 9
+      }
+    },
+    "command": {
+      "title": "Debug",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test a",
+        {
+          "inspect": true
+        }
       ]
     }
   },
@@ -35,7 +61,33 @@
       "command": "deno.test",
       "arguments": [
         "file:///a/file.ts",
-        "test b"
+        "test b",
+        {
+          "inspect": false
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 5,
+        "character": 5
+      },
+      "end": {
+        "line": 5,
+        "character": 9
+      }
+    },
+    "command": {
+      "title": "Debug",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test b",
+        {
+          "inspect": true
+        }
       ]
     }
   },
@@ -55,7 +107,33 @@
       "command": "deno.test",
       "arguments": [
         "file:///a/file.ts",
-        "test c"
+        "test c",
+        {
+          "inspect": false
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 9,
+        "character": 0
+      },
+      "end": {
+        "line": 9,
+        "character": 4
+      }
+    },
+    "command": {
+      "title": "Debug",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test c",
+        {
+          "inspect": true
+        }
       ]
     }
   },
@@ -75,7 +153,33 @@
       "command": "deno.test",
       "arguments": [
         "file:///a/file.ts",
-        "test d"
+        "test d",
+        {
+          "inspect": false
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 13,
+        "character": 0
+      },
+      "end": {
+        "line": 13,
+        "character": 4
+      }
+    },
+    "command": {
+      "title": "Debug",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test d",
+        {
+          "inspect": true
+        }
       ]
     }
   },
@@ -95,7 +199,33 @@
       "command": "deno.test",
       "arguments": [
         "file:///a/file.ts",
-        "test e"
+        "test e",
+        {
+          "inspect": false
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 14,
+        "character": 0
+      },
+      "end": {
+        "line": 14,
+        "character": 5
+      }
+    },
+    "command": {
+      "title": "Debug",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test e",
+        {
+          "inspect": true
+        }
       ]
     }
   },
@@ -115,7 +245,33 @@
       "command": "deno.test",
       "arguments": [
         "file:///a/file.ts",
-        "test f"
+        "test f",
+        {
+          "inspect": false
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 18,
+        "character": 0
+      },
+      "end": {
+        "line": 18,
+        "character": 5
+      }
+    },
+    "command": {
+      "title": "Debug",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test f",
+        {
+          "inspect": true
+        }
       ]
     }
   },
@@ -135,7 +291,33 @@
       "command": "deno.test",
       "arguments": [
         "file:///a/file.ts",
-        "test g"
+        "test g",
+        {
+          "inspect": false
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 19,
+        "character": 0
+      },
+      "end": {
+        "line": 19,
+        "character": 5
+      }
+    },
+    "command": {
+      "title": "Debug",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test g",
+        {
+          "inspect": true
+        }
       ]
     }
   },
@@ -155,7 +337,33 @@
       "command": "deno.test",
       "arguments": [
         "file:///a/file.ts",
-        "test h"
+        "test h",
+        {
+          "inspect": false
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 23,
+        "character": 0
+      },
+      "end": {
+        "line": 23,
+        "character": 5
+      }
+    },
+    "command": {
+      "title": "Debug",
+      "command": "deno.test",
+      "arguments": [
+        "file:///a/file.ts",
+        "test h",
+        {
+          "inspect": true
+        }
       ]
     }
   }


### PR DESCRIPTION
Fixes: #13130

Existing clients still need to add support for the `{inspect: true}` option.
I'm not sure what the current state is of the stability of lsp. I noticed a document saying lsp was still experimental and not feature complete, but this got removed when the document was moved to https://deno.land/manual@v1.17.0/language_server/overview last week.

Either way this shouldn't break any existing IDE plugins in a significant way. The debug button will simply run the test rather than debug it.