### PR TITLE
chore: add custom panic message

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1466,7 +1466,7 @@ fn setup_panic_hook() {
     );
     eprintln!("Version: {}", version::deno());
     eprintln!("Args: {:?}", std::env::args().collect::<Vec<_>>());
-    eprintln!("");
+    eprintln!();
     orig_hook(panic_info);
     std::process::exit(1);
   }));

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1458,7 +1458,7 @@ fn setup_panic_hook() {
     eprintln!("If you can reliably reproduce this panic, include the");
     eprintln!("reproduction steps and re-run with the RUST_BACKTRACE=1 env");
     eprintln!("var set and include the backtrace in your report.");
-    eprintln!("");
+    eprintln!();
     eprintln!(
       "Platform: {} {}",
       std::env::consts::OS,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1444,11 +1444,29 @@ fn get_subcommand(
   }
 }
 
-fn setup_exit_process_panic_hook() {
-  // tokio does not exit the process when a task panics, so we
-  // define a custom panic hook to implement this behaviour
+fn setup_panic_hook() {
+  // This function does two things inside of the panic hook:
+  // - Tokio does not exit the process when a task panics, so we define a custom
+  //   panic hook to implement this behaviour.
+  // - We print a message to stderr to indicate that this is a bug in Deno, and
+  //   should be reported to us.
   let orig_hook = std::panic::take_hook();
   std::panic::set_hook(Box::new(move |panic_info| {
+    eprintln!("\n============================================================");
+    eprintln!("Deno has panicked. This is a bug in Deno. Please report this");
+    eprintln!("at https://github.com/denoland/deno/issues/new.");
+    eprintln!("If you can reliably reproduce this panic, include the");
+    eprintln!("reproduction steps and re-run with the RUST_BACKTRACE=1 env");
+    eprintln!("var set and include the backtrace in your report.");
+    eprintln!("");
+    eprintln!(
+      "Platform: {} {}",
+      std::env::consts::OS,
+      std::env::consts::ARCH
+    );
+    eprintln!("Version: {}", version::deno());
+    eprintln!("Args: {:?}", std::env::args().collect::<Vec<_>>());
+    eprintln!("");
     orig_hook(panic_info);
     std::process::exit(1);
   }));
@@ -1465,7 +1483,7 @@ fn unwrap_or_exit<T>(result: Result<T, AnyError>) -> T {
 }
 
 pub fn main() {
-  setup_exit_process_panic_hook();
+  setup_panic_hook();
 
   unix_util::raise_fd_limit();
   windows_util::ensure_stdio_open();


### PR DESCRIPTION
Closes #9263

Looks like this:

```
/m/s/P/g/d/deno ❯❯❯ ./target/debug/deno run --quiet --reload --allow-net --unstable workers/permissions_dynamic_remote.ts

============================================================
Deno has panicked. This is a bug in Deno. Please report this
at https://github.com/denoland/deno/issues/new.
If you can reliably reproduce this panic, include the
reproduction steps and re-run with the RUST_BACKTRACE=1 env
var set and include the backtrace in your report.

Platform: linux x86_64
Version: 1.16.4
Args: ["./target/debug/deno", "run", "--quiet", "--reload", "--allow-net", "--unstable", "workers/permissions_dynamic_remote.ts"]

thread 'main' panicked at 'foo!', cli/main.rs:1493:3
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
