### PR TITLE
refactor(ext/web): Don't rely on NaN comparisons in `TextEncoderStream`

### DIFF
--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -292,6 +292,9 @@
         transform: (chunk, controller) => {
           try {
             chunk = webidl.converters.DOMString(chunk);
+            if (chunk === "") {
+              return PromiseResolve();
+            }
             if (this.#pendingHighSurrogate !== null) {
               chunk = this.#pendingHighSurrogate + chunk;
             }


### PR DESCRIPTION
In the `transform` function to `TextEncoderStream`'s internal `TransformStream`, if `chunk` is the empty string and `this.#pendingHighSurrogate` is null, then `lastCodeUnit` will be NaN. As it turns out, this does not cause a bug because the comparison to check for lone surrogates turns out to be false for NaN, but to rely on it makes the code brittle.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
