### PR TITLE
chore(tests): remove pty_complete_imports test for deleting the cwd

### DIFF
--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -146,18 +146,6 @@ fn pty_complete_imports() {
     let output = console.read_all_output();
     assert!(output.contains("Hello World"));
   });
-
-  // ensure nothing too bad happens when deleting the cwd
-  util::with_pty(&["repl"], |mut console| {
-    console.write_line("Deno.mkdirSync('./temp-repl-lsp-dir');");
-    console.write_line("Deno.chdir('./temp-repl-lsp-dir');");
-    console.write_line("Deno.removeSync('../temp-repl-lsp-dir');");
-    console.write_line("import '../001_hello\t'");
-    console.write_line("close();");
-
-    let output = console.read_all_output();
-    assert!(output.contains("Hello World"));
-  });
 }
 
 #[test]


### PR DESCRIPTION
Closes #13158. Right now, [`resolve_path`](https://github.com/denoland/deno/blob/aca41a472a07932dd973cbefcf8a94920646ee58/core/module_specifier.rs#L141) in deno_core panics when the cwd doesn't exist and it seems like a big change to fix that (maybe not even worth it) so removing this test for now.