### PR TITLE
FFI - Infer Argument and Return types for Foreign Functions

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -121,58 +121,69 @@ declare namespace Deno {
     | "pointer";
 
   /** A foreign function as defined by its parameter and result types */
-  export interface ForeignFunction<Parameter extends readonly NativeType[], Result extends NativeType, NonBlocking extends boolean> {
-    parameters: Parameter
-    result: Result
+  export interface ForeignFunction<
+    Parameter extends readonly NativeType[],
+    Result extends NativeType,
+    NonBlocking extends boolean,
+  > {
+    parameters: Parameter;
+    result: Result;
     /** When true, function calls will run on a dedicated blocking thread and will return a Promise resolving to the `result`. */
-    nonblocking?: NonBlocking
+    nonblocking?: NonBlocking;
   }
 
   /** A foreign function interface descriptor */
   export interface ForeignFunctionInterface {
-    [name: string]: ForeignFunction<readonly NativeType[], NativeType, boolean>
+    [name: string]: ForeignFunction<readonly NativeType[], NativeType, boolean>;
   }
 
   /** Infers the associative TypeScript type for the given NativeType */
-  type StaticNativeType<T extends NativeType> =
-    T extends "void" ? void :
-    T extends "u8" ? number :
-    T extends "i8" ? number :
-    T extends "u16" ? number :
-    T extends "i16" ? number :
-    T extends "u32" ? number :
-    T extends "i32" ? number :
-    T extends "u64" ? number :
-    T extends "i64" ? number :
-    T extends "usize" ? number :
-    T extends "isize" ? number :
-    T extends "f32" ? number :
-    T extends "f64" ? number :
-    T extends "pointer" ? Deno.UnsafePointer :
-    never
+  type StaticNativeType<T extends NativeType> = T extends "void" ? void
+    : T extends "u8" ? number
+    : T extends "i8" ? number
+    : T extends "u16" ? number
+    : T extends "i16" ? number
+    : T extends "u32" ? number
+    : T extends "i32" ? number
+    : T extends "u64" ? number
+    : T extends "i64" ? number
+    : T extends "usize" ? number
+    : T extends "isize" ? number
+    : T extends "f32" ? number
+    : T extends "f64" ? number
+    : T extends "pointer" ? Deno.UnsafePointer
+    : never;
 
   /** Infers a foreign function parameter list. */
-  type StaticForeignFunctionParameters<T extends readonly NativeType[]> =
-    [...{
+  type StaticForeignFunctionParameters<T extends readonly NativeType[]> = [
+    ...{
       [K in keyof T]: T[K] extends NativeType
-      ? StaticNativeType<T[K]> extends infer R
-      // Pointer arguments can be passed either as UnsafePointer or TypedArray
-      ? R extends Deno.UnsafePointer ? Deno.TypedArray | R
-      : R : unknown
-      : unknown
-    }]
+        ? StaticNativeType<T[K]> extends infer R ? // Pointer arguments can be passed either as UnsafePointer or TypedArray
+        R extends Deno.UnsafePointer ? Deno.TypedArray | R
+        : R
+        : unknown
+        : unknown;
+    },
+  ];
 
   /** Infers a foreign function return type */
-  type StaticForeignFunctionResult<T extends NativeType> = StaticNativeType<T>
+  type StaticForeignFunctionResult<T extends NativeType> = StaticNativeType<T>;
 
   /** Infers a foreign function */
-  type StaticForeignFunction<T extends ForeignFunction<readonly NativeType[], NativeType, boolean>> =
-    T['nonblocking'] extends true
-    ? (...args: [...StaticForeignFunctionParameters<T["parameters"]>]) => Promise<StaticForeignFunctionResult<T["result"]>>
-    : (...args: [...StaticForeignFunctionParameters<T["parameters"]>]) => StaticForeignFunctionResult<T["result"]>
+  type StaticForeignFunction<
+    T extends ForeignFunction<readonly NativeType[], NativeType, boolean>,
+  > = T["nonblocking"] extends true
+    ? (
+      ...args: [...StaticForeignFunctionParameters<T["parameters"]>]
+    ) => Promise<StaticForeignFunctionResult<T["result"]>>
+    : (
+      ...args: [...StaticForeignFunctionParameters<T["parameters"]>]
+    ) => StaticForeignFunctionResult<T["result"]>;
 
   /** Infers a foreign function interface */
-  type StaticForeignFunctionInterface<T extends ForeignFunctionInterface> = { [K in keyof T]: StaticForeignFunction<T[K]> }
+  type StaticForeignFunctionInterface<T extends ForeignFunctionInterface> = {
+    [K in keyof T]: StaticForeignFunction<T[K]>;
+  };
 
   type TypedArray =
     | Int8Array
@@ -249,9 +260,9 @@ declare namespace Deno {
 
   /** A dynamic library resource */
   export type DynamicLibrary<S extends ForeignFunctionInterface> = {
-     symbols: StaticForeignFunctionInterface<S>
-     close(): void
-  }
+    symbols: StaticForeignFunctionInterface<S>;
+    close(): void;
+  };
 
   /** **UNSTABLE**: Unsafe and new API, beware!
    *
@@ -426,15 +437,15 @@ declare namespace Deno {
     /** Specify the module format for the emitted code. Defaults to
      * `"esnext"`. */
     module?:
-    | "none"
-    | "commonjs"
-    | "amd"
-    | "system"
-    | "umd"
-    | "es6"
-    | "es2015"
-    | "es2020"
-    | "esnext";
+      | "none"
+      | "commonjs"
+      | "amd"
+      | "system"
+      | "umd"
+      | "es6"
+      | "es2015"
+      | "es2020"
+      | "esnext";
     /** Do not generate custom helper functions like `__extends` in compiled
      * output. Defaults to `false`. */
     noEmitHelpers?: boolean;
@@ -520,16 +531,16 @@ declare namespace Deno {
     suppressImplicitAnyIndexErrors?: boolean;
     /** Specify ECMAScript target version. Defaults to `esnext`. */
     target?:
-    | "es3"
-    | "es5"
-    | "es6"
-    | "es2015"
-    | "es2016"
-    | "es2017"
-    | "es2018"
-    | "es2019"
-    | "es2020"
-    | "esnext";
+      | "es3"
+      | "es5"
+      | "es6"
+      | "es2015"
+      | "es2016"
+      | "es2017"
+      | "es2018"
+      | "es2019"
+      | "es2020"
+      | "esnext";
     /** List of names of type definitions to include when type checking.
      * Defaults to `undefined`.
      *
@@ -791,7 +802,7 @@ declare namespace Deno {
       gid?: number;
       uid?: number;
     },
-    >(opt: T): Process<T>;
+  >(opt: T): Process<T>;
 
   /**  **UNSTABLE**: New API, yet to be vetted.  Additional consideration is still
    * necessary around the permissions required.

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -122,11 +122,11 @@ declare namespace Deno {
 
   /** A foreign function as defined by its parameter and result types */
   export interface ForeignFunction<
-    Parameter extends readonly NativeType[],
+    Parameters extends readonly NativeType[],
     Result extends NativeType,
     NonBlocking extends boolean,
   > {
-    parameters: Parameter;
+    parameters: Parameters;
     result: Result;
     /** When true, function calls will run on a dedicated blocking thread and will return a Promise resolving to the `result`. */
     nonblocking?: NonBlocking;

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -172,10 +172,9 @@ declare namespace Deno {
   /** Infers a foreign function */
   type StaticForeignFunction<
     T extends ForeignFunction<readonly NativeType[], NativeType, boolean>,
-  > = T["nonblocking"] extends true
-    ? (
-      ...args: [...StaticForeignFunctionParameters<T["parameters"]>]
-    ) => Promise<StaticForeignFunctionResult<T["result"]>>
+  > = T["nonblocking"] extends true ? (
+    ...args: [...StaticForeignFunctionParameters<T["parameters"]>]
+  ) => Promise<StaticForeignFunctionResult<T["result"]>>
     : (
       ...args: [...StaticForeignFunctionParameters<T["parameters"]>]
     ) => StaticForeignFunctionResult<T["result"]>;
@@ -259,10 +258,11 @@ declare namespace Deno {
   }
 
   /** A dynamic library resource */
-  export type DynamicLibrary<S extends ForeignFunctionInterface> = {
+  export interface DynamicLibrary<S extends ForeignFunctionInterface> {
+    /** All of the registered symbols along with functions for calling them */
     symbols: StaticForeignFunctionInterface<S>;
     close(): void;
-  };
+  }
 
   /** **UNSTABLE**: Unsafe and new API, beware!
    *

--- a/cli/tests/unit/ffi_test.ts
+++ b/cli/tests/unit/ffi_test.ts
@@ -22,4 +22,32 @@ Deno.test({ permissions: { ffi: true } }, function dlopenInvalidArguments() {
     // @ts-expect-error: require 2 arguments
     Deno.dlopen(filename);
   }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(filename, {
+      method: { parameters: [
+        "usize", "isize", 
+        "u8", "u16", "u32", "u64", 
+        "i8", "i16", "i32", "i64", 
+        "void", "pointer"
+      ], result: "void" }
+    } as const);
+    remote.symbols.method(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, void 0, new Uint8Array(1));
+    remote.symbols.method(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, void 0, {} as Deno.UnsafePointer);
+    // @ts-expect-error: invalid arguments
+    remote.symbols.method("0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0");
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(filename, {
+      method: { parameters: [], result: "f32" }
+    } as const);
+    // @ts-expect-error Return type number | f32 is not assignable to type string
+    const _: string = remote.symbols.method();
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(filename, {
+      method: { parameters: [], result: "f32", nonblocking: true }
+    } as const);
+    // @ts-expect-error Return type Promise<number> | f32 is not assignable to type string
+    remote.symbols.method().then((_: string) => {});
+  }, TypeError);
 });

--- a/cli/tests/unit/ffi_test.ts
+++ b/cli/tests/unit/ffi_test.ts
@@ -22,32 +22,225 @@ Deno.test({ permissions: { ffi: true } }, function dlopenInvalidArguments() {
     // @ts-expect-error: require 2 arguments
     Deno.dlopen(filename);
   }, TypeError);
+
+  // ---------------------------------
+  // Infer: Parameter Types
+  // ---------------------------------
   assertThrows(() => {
-    const remote = Deno.dlopen(filename, {
-      method: { parameters: [
-        "usize", "isize", 
-        "u8", "u16", "u32", "u64", 
-        "i8", "i16", "i32", "i64", 
-        "void", "pointer"
-      ], result: "void" }
-    } as const);
-    remote.symbols.method(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, void 0, new Uint8Array(1));
-    remote.symbols.method(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, void 0, {} as Deno.UnsafePointer);
-    // @ts-expect-error: invalid arguments
-    remote.symbols.method("0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0");
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["usize", "usize"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(0);
+    remote.symbols.method(0, 0);
   }, TypeError);
   assertThrows(() => {
-    const remote = Deno.dlopen(filename, {
-      method: { parameters: [], result: "f32" }
-    } as const);
-    // @ts-expect-error Return type number | f32 is not assignable to type string
-    const _: string = remote.symbols.method();
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["void"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(void 0);
   }, TypeError);
   assertThrows(() => {
-    const remote = Deno.dlopen(filename, {
-      method: { parameters: [], result: "f32", nonblocking: true }
-    } as const);
-    // @ts-expect-error Return type Promise<number> | f32 is not assignable to type string
-    remote.symbols.method().then((_: string) => {});
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["usize"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["isize"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["u8"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["u16"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["u32"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["u64"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["i8"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["i16"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["i32"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["i64"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["f32"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["f64"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(0);
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: ["pointer"], result: "void" },
+      } as const,
+    );
+    // @ts-expect-error: Invalid argument
+    remote.symbols.method(null);
+    remote.symbols.method(new Uint16Array(1));
+    remote.symbols.method({} as Deno.UnsafePointer);
+  }, TypeError);
+  // ---------------------------------
+  // Infer: Return Type
+  // ---------------------------------
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: [], result: "usize" },
+      } as const,
+    );
+    const result = remote.symbols.method();
+    // @ts-expect-error: Invalid argument
+    const _0: string = result;
+    const _1: number = result;
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: [], result: "usize", nonblocking: true },
+      } as const,
+    );
+    const result = remote.symbols.method();
+    // @ts-expect-error: Invalid argument
+    result.then((_0: string) => {});
+    result.then((_1: number) => {});
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: [], result: "pointer" },
+      } as const,
+    );
+    const result = remote.symbols.method();
+    // @ts-expect-error: Invalid argument
+    const _0: Deno.TypedArray = result;
+    const _1: Deno.UnsafePointer = result;
+  }, TypeError);
+  assertThrows(() => {
+    const remote = Deno.dlopen(
+      filename,
+      {
+        method: { parameters: [], result: "pointer", nonblocking: true },
+      } as const,
+    );
+    const result = remote.symbols.method();
+    // @ts-expect-error: Invalid argument
+    result.then((_0: Deno.TypedArray) => {});
+    result.then((_1: Deno.UnsafePointer) => {});
   }, TypeError);
 });


### PR DESCRIPTION
This PR enhances the `lib.deno.unstable.d.ts` definitions for the Deno FFI API by inferring parameter and return types from the FFI descriptor passed on `Deno.dlopen(...)`. The inferred parameters can be observed on the `DynamicLibrary.symbols` object, as follows.

```typescript
const remote = Deno.dlopen('native.dll', {
   add: [ parameters: ["f32", "f32"], result: 'f32' }
} as const) // note: 'as const' is required

const result = remote.symbols.add(1, 3)
//                            ^
//                            |
//                            +-- inferred as: (args_0: number, args_1: number) => number
```
This PR also encodes the rules for `pointer` argument passing, enabling both `Deno.UnsafePointer` and `Deno.TypedArray` to be passed as function arguments. This rule only applies to parameter passing and NOT return types. Additionally, return types are inferred as either `T` or `Promise<T>` derived from the `nonblocking` property on function descriptors. An example of these rules is given below.

```typescript
const remote = Deno.dlopen('lib.dll', {
    // (args_0: number, args_1: Deno.TypedArray | Deno.UnsafePointer) => Deno.UnsafePointer
    sync: { parameters: ['u8', 'pointer'], result: 'pointer' },
    // (args_0: number, args_1: number) => Promise<number>
    async: { parameters: ['f32', 'f32'], result: 'f32', nonblocking: true }
} as const)


// Support both Deno.UnsafePointer & TypedArray on arguments, Return type
// is always Deno.UnsafePointer when specifying `pointer`

const result_0 = remote.symbols.sync(1, new Uint8Array(32))

const result_1 = remote.symbols.sync(1, {} as Deno.UnsafePointer)

const result_2 = await remote.symbols.async(1, 2)
```
I have created an example that implements these enhancements on the TypeScript playground which can be located [here](https://www.typescriptlang.org/play?#code/PTAEFpK6dv4YxBYAUCUBRAHgQwLYAOANgKZoZJXU21poDGA9gHYDOALqAE6n5MdSoALygAIqRZMAdABNiTQpIAUAcmIBLAEZzixVQBpQAbzShzoNgE8WDAFwnQhXNwKlB3Ng4DaqgK4AHIagqoRMGiweqgC6RrxsfsQcDqHhkaTcqqAAvgZmFrjWtg7GTi5uHl6gvgBmAMwATMGq9U2xPKQJSSmtwVIsWgoMANYRAOYOHNx+Qtlo2aCFoMzsHACU9KgUYADKfoRh3FxaAgAW4pIyAKrsuDWkAAppHqAAZKAAKlZKsqAAgtxXFZQKxFtwxn58JIOGwjAAldx+bgsUAcb7kdBgDRsRbEADuuCsOIkUmkNzYd0ezwyoDxp0kliUDA0NSs41AAAMwhEPBzNitOB0uhwAPoABhEHX4gmk1nwJ2IbFlNgYygAjEYWKQ8aArjyAgCgcpGmsNltUAKuPFEqK1ZLeNLSMr5UxFcrbOqjMYFksSddbvcnjyMmbGKxBdakiKGpLcASNFa+AInXKFUrCirPaAGqHzdsILRC0XC-m-aAAGLlgCSDi+SjY+eLTeb8E2slIDGILiELDcbGcDCEZdK+XMpGwhy4we4NVwg91Aap08cItXDj8LGGUjxKIWo9A48nqPRn3RskNhMl+4soAAPrr9RerNeLPe9ZE1QA2J8v8xvnmND+qA3je-6RAEADCXZEKQ56AoSv53qAVbgUBIGvshH7fvBz7AehSEoRwgE4Yh97lgouBEQ0aH4WRFEcJ+AAsNFjhOTBHKANQbgwHAaKC8iKJIAA8HwHtgggsLIOLluxpAaGMLCERks6DgAfMozgcKcDicNw4xGMknxrA4OwcJRGgMDJvDyYp6QznOpAiapN7zJs+6bIe7FcGiSigAAcuZABupB1kIwj7veABEgXhLIkURaAkWBPFeF-olGgBCloGJX4X5ZRhkUaHlCVJY0+VpYVZUlX4THlUhhW1dVbAaAAXqQdVRdirXtSVrQdYlNSNal9XcnZkUANxuag04qUIVlyQp5bcbxrBCQ85RQi844SVJHS4LIrDEMCAW8cFoXeO0CLCmJO04idGhneiRh+awABCQyjCwYw3ZIu0nK6pC4CwzmmMNziuJtGRVOtEPuBk+6RoZV02vu-SDEwIzjAA-A4L0sO9GOfWMrnmp5HEzQ5FayTZSn2fOoM3t4vZQjpUzjNEDjzTZS22CtLBCbw+2HcdQUheiF3PaLoVGP9ZBA6pJONi2ystqWlwVtWDgofcvC2EIoUNpiBYqybJak2xHE+UIpnmQw92PUoIk-ZJd1S09oAIhwSIsKFzt-UwAPyyI+6idtv04tFsWRaAWOgDFGi-HYId+xHyUx6ALCQloNJJ8NofieH6WZenmfyjnydhy7OV5SXWfl3nKfpTXsel9n3CgLnN757dOVlbXZft53Fjd4XlUNNHLd14PFcF1XSW1f3bcdzPPcNYxE8Z1Py8N5Xu1Jc1bUb639dd43hUH+1i8n8PZ99Vf0877Pe+Dev9-b6fu8R6NHgb8onve77T+qJphCFjn6Mki4gx2Q7hcUk5JKRQJePecBoU4JAjWO-CwWpgrcA8hbbyJ4ba8QYDDCoUMnZAMFgdFgR1-JuyUBdZy4VhreGkGw0o3gADSoAIigGGKQKwTAaifA5p8Lh0RG72zFr5WORCLJSNCiJcRRhZyKlIM5dcm5ty7miPkPBR4ragDkQwZGSQKFP1dqdaR6jJTGIUeiESBkQEK3NgYwhZliFc0WstPi-MR5Vy8SwHmPFfEC0BtQ2h9iGHtCiaQGWAc5bAyYSHXwaMPrjBiI3KYMxQCIVjsoNh0gXBjCqKwthxjSGQ08EoyK4MyGeEitEVS0QMHCGcg8bgTB8DYkcsY0xHAamI0aapFx+EYEFLYcU0phSKkbThtUj43halzMqMMlpIhnJ9M6DaQZ2ykjDP0V5Y8vljGBNprNcxPczl2Vmkwkw+5UyuiqBw7hvD+GCOER8URpzqbeN5qExZnCmk5H3J2JgbBSDKGMnHWKitzRAA). This may be useful for communicating additional type narrowing if necessary.

Submitting for community review
