### PR TITLE
feat(core): JsRuntime::replace_op

### DIFF
--- a/core/ops.rs
+++ b/core/ops.rs
@@ -201,7 +201,16 @@ impl OpTable {
     F: Fn(Rc<RefCell<OpState>>, OpPayload) -> Op + 'static,
   {
     let (op_id, prev) = self.0.insert_full(name.to_owned(), Rc::new(op_fn));
-    assert!(prev.is_none());
+    assert!(prev.is_none(), "Op '{}' was already registered", name);
+    op_id
+  }
+
+  pub fn replace_op<F>(&mut self, name: &str, op_fn: F) -> OpId
+  where
+    F: Fn(Rc<RefCell<OpState>>, OpPayload) -> Op + 'static,
+  {
+    let (op_id, prev) = self.0.insert_full(name.to_owned(), Rc::new(op_fn));
+    assert!(prev.is_some(), "Op '{}' wasn't already registered", name);
     op_id
   }
 

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -210,7 +210,7 @@ impl OpTable {
     F: Fn(Rc<RefCell<OpState>>, OpPayload) -> Op + 'static,
   {
     let (op_id, prev) = self.0.insert_full(name.to_owned(), Rc::new(op_fn));
-    assert!(prev.is_some(), "Op '{}' wasn't already registered", name);
+    assert!(prev.is_some(), "Op '{}' was not yet registered", name);
     op_id
   }
 

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -640,7 +640,7 @@ impl JsRuntime {
   /// Replaces an already existing op.
   ///
   /// In most situations this method is not required. However, in some
-  /// cases one might want to overwrite alreadt registered op to perform
+  /// cases one might want to overwrite already registered op to perform
   /// different action; eg. for "op_exit" instead of exiting the process,
   /// one might want to throw an error if that op is called during testing.
   pub fn replace_op<F>(&mut self, name: &str, op_fn: F) -> OpId


### PR DESCRIPTION
Adds a new API to "JsRuntime" that allows to replace (or overwrite) an existing op
with a new handler.

This is kind of "very unsafe, but I know what I'm doing, please leave me alone" API,
but has actual use cases in:
- #12938 - to replace "op_exit" with a handler that terminates execution, to prevent
calling "Deno.exit()" API in test code
- #13122 - to replace "op_print" with a handler that forwards all "console.*" messages
over a socket to a notebook frontend
