### PR TITLE
cleanup(cli): use op Extensions

### DIFF
--- a/cli/ops/errors.rs
+++ b/cli/ops/errors.rs
@@ -6,18 +6,24 @@ use crate::proc_state::ProcState;
 use crate::source_maps::get_orig_position;
 use crate::source_maps::CachedMaps;
 use deno_core::error::AnyError;
+use deno_core::op_sync;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
+use deno_core::Extension;
 use deno_core::OpState;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_sync(rt, "op_apply_source_map", op_apply_source_map);
-  super::reg_sync(rt, "op_format_diagnostic", op_format_diagnostic);
-  super::reg_sync(rt, "op_format_file_name", op_format_file_name);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![
+      ("op_apply_source_map", op_sync(op_apply_source_map)),
+      ("op_format_diagnostic", op_sync(op_format_diagnostic)),
+      ("op_format_file_name", op_sync(op_format_file_name)),
+    ])
+    .build()
 }
 
 #[derive(Deserialize)]

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -1,7 +1,29 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-pub mod errors;
-pub mod runtime_compiler;
+use crate::proc_state::ProcState;
+use deno_core::Extension;
+
+mod errors;
+mod runtime_compiler;
 pub mod testing;
 
-pub use deno_runtime::ops::{reg_async, reg_sync};
+pub fn cli_exts(ps: ProcState, enable_compiler: bool) -> Vec<Extension> {
+  if enable_compiler {
+    vec![
+      init_proc_state(ps),
+      errors::init(),
+      runtime_compiler::init(),
+    ]
+  } else {
+    vec![init_proc_state(ps), errors::init()]
+  }
+}
+
+fn init_proc_state(ps: ProcState) -> Extension {
+  Extension::builder()
+    .state(move |state| {
+      state.put(ps.clone());
+      Ok(())
+    })
+    .build()
+}

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -15,10 +15,12 @@ use deno_core::anyhow::Context;
 use deno_core::error::custom_error;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
+use deno_core::op_async;
 use deno_core::parking_lot::RwLock;
 use deno_core::resolve_url_or_path;
 use deno_core::serde_json;
 use deno_core::serde_json::Value;
+use deno_core::Extension;
 use deno_core::ModuleSpecifier;
 use deno_core::OpState;
 use deno_graph;
@@ -32,8 +34,10 @@ use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::Arc;
 
-pub fn init(rt: &mut deno_core::JsRuntime) {
-  super::reg_async(rt, "op_emit", op_emit);
+pub fn init() -> Extension {
+  Extension::builder()
+    .ops(vec![("op_emit", op_async(op_emit))])
+    .build()
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -23,7 +23,6 @@ use deno_core::serde_json::Value;
 use deno_core::Extension;
 use deno_core::ModuleSpecifier;
 use deno_core::OpState;
-use deno_graph;
 use deno_runtime::permissions::Permissions;
 use import_map::ImportMap;
 use serde::Deserialize;

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -1,7 +1,8 @@
 use crate::tools::test::TestEvent;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
-use deno_core::JsRuntime;
+use deno_core::op_sync;
+use deno_core::Extension;
 use deno_core::ModuleSpecifier;
 use deno_core::OpState;
 use deno_runtime::permissions::create_child_permissions;
@@ -10,15 +11,25 @@ use deno_runtime::permissions::Permissions;
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
-pub fn init(rt: &mut JsRuntime) {
-  super::reg_sync(rt, "op_pledge_test_permissions", op_pledge_test_permissions);
-  super::reg_sync(
-    rt,
-    "op_restore_test_permissions",
-    op_restore_test_permissions,
-  );
-  super::reg_sync(rt, "op_get_test_origin", op_get_test_origin);
-  super::reg_sync(rt, "op_dispatch_test_event", op_dispatch_test_event);
+pub fn init(sender: Sender<TestEvent>) -> Extension {
+  Extension::builder()
+    .ops(vec![
+      (
+        "op_pledge_test_permissions",
+        op_sync(op_pledge_test_permissions),
+      ),
+      (
+        "op_restore_test_permissions",
+        op_sync(op_restore_test_permissions),
+      ),
+      ("op_get_test_origin", op_sync(op_get_test_origin)),
+      ("op_dispatch_test_event", op_sync(op_dispatch_test_event)),
+    ])
+    .state(move |state| {
+      state.put(sender.clone());
+      Ok(())
+    })
+    .build()
 }
 
 #[derive(Clone)]

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -249,7 +249,7 @@ pub async fn run(
       ts_version: version::TYPESCRIPT.to_string(),
       unstable: metadata.unstable,
     },
-    extensions: vec![],
+    extensions: ops::cli_exts(ps.clone(), true),
     user_agent: version::get_user_agent(),
     unsafely_ignore_certificate_errors: metadata
       .unsafely_ignore_certificate_errors,
@@ -272,17 +272,6 @@ pub async fn run(
     permissions,
     options,
   );
-  // TODO(@AaronO): move to a JsRuntime Extension passed into options
-  {
-    let js_runtime = &mut worker.js_runtime;
-    js_runtime
-      .op_state()
-      .borrow_mut()
-      .put::<ProcState>(ps.clone());
-    ops::errors::init(js_runtime);
-    ops::runtime_compiler::init(js_runtime);
-    js_runtime.sync_ops_cache();
-  }
   worker.execute_main_module(&main_module).await?;
   worker.dispatch_load_event(&located_script_name!())?;
   worker.run_event_loop(true).await?;

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -33,7 +33,6 @@ use deno_core::futures::stream;
 use deno_core::futures::FutureExt;
 use deno_core::futures::StreamExt;
 use deno_core::serde_json::json;
-use deno_core::JsRuntime;
 use deno_core::ModuleSpecifier;
 use deno_graph::Module;
 use deno_runtime::permissions::Permissions;
@@ -453,17 +452,12 @@ async fn test_specifier(
   shuffle: Option<u64>,
   channel: Sender<TestEvent>,
 ) -> Result<(), AnyError> {
-  let init_ops = |js_runtime: &mut JsRuntime| {
-    ops::testing::init(js_runtime);
-
-    js_runtime
-      .op_state()
-      .borrow_mut()
-      .put::<Sender<TestEvent>>(channel.clone());
-  };
-
-  let mut worker =
-    create_main_worker(&ps, specifier.clone(), permissions, Some(&init_ops));
+  let mut worker = create_main_worker(
+    &ps,
+    specifier.clone(),
+    permissions,
+    vec![ops::testing::init(channel.clone())],
+  );
 
   let mut maybe_coverage_collector = if let Some(ref coverage_dir) =
     ps.coverage_dir

--- a/runtime/ops/mod.rs
+++ b/runtime/ops/mod.rs
@@ -14,40 +14,9 @@ mod utils;
 pub mod web_worker;
 pub mod worker_host;
 
-use deno_core::error::AnyError;
-use deno_core::op_async;
-use deno_core::op_sync;
-use deno_core::serde::de::DeserializeOwned;
-use deno_core::serde::Serialize;
-use deno_core::JsRuntime;
 use deno_core::OpState;
 use std::cell::RefCell;
-use std::future::Future;
 use std::rc::Rc;
-
-pub fn reg_async<F, A, B, R, RV>(
-  rt: &mut JsRuntime,
-  name: &'static str,
-  op_fn: F,
-) where
-  F: Fn(Rc<RefCell<OpState>>, A, B) -> R + 'static,
-  A: DeserializeOwned,
-  B: DeserializeOwned,
-  R: Future<Output = Result<RV, AnyError>> + 'static,
-  RV: Serialize + 'static,
-{
-  rt.register_op(name, op_async(op_fn));
-}
-
-pub fn reg_sync<F, A, B, R>(rt: &mut JsRuntime, name: &'static str, op_fn: F)
-where
-  F: Fn(&mut OpState, A, B) -> Result<R, AnyError> + 'static,
-  A: DeserializeOwned,
-  B: DeserializeOwned,
-  R: Serialize + 'static,
-{
-  rt.register_op(name, op_sync(op_fn));
-}
 
 /// `UnstableChecker` is a struct so it can be placed inside `GothamState`;
 /// using type alias for a bool could work, but there's a high chance


### PR DESCRIPTION
Enabling op-middleware for overrides in lieu of imperative .replace_op() etc...

Impacts #13219,  #12938, #13122