### PR TITLE
cleanup(core): use Extensions to register ops

### DIFF
--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -118,11 +118,17 @@ impl From<tokio::net::TcpStream> for TcpStream {
 }
 
 fn create_js_runtime() -> JsRuntime {
-  let mut runtime = JsRuntime::new(Default::default());
-  runtime.register_op("listen", deno_core::op_sync(op_listen));
-  runtime.register_op("accept", deno_core::op_async(op_accept));
-  runtime.sync_ops_cache();
-  runtime
+  let ext = deno_core::Extension::builder()
+    .ops(vec![
+      ("listen", deno_core::op_sync(op_listen)),
+      ("accept", deno_core::op_async(op_accept)),
+    ])
+    .build();
+
+  JsRuntime::new(deno_core::RuntimeOptions {
+    extensions: vec![ext],
+    ..Default::default()
+  })
 }
 
 fn op_listen(state: &mut OpState, _: (), _: ()) -> Result<ResourceId, Error> {

--- a/core/ops_json.rs
+++ b/core/ops_json.rs
@@ -123,8 +123,6 @@ mod tests {
 
   #[tokio::test]
   async fn op_async_stack_trace() {
-    let mut runtime = crate::JsRuntime::new(Default::default());
-
     async fn op_throw(
       _state: Rc<RefCell<OpState>>,
       msg: Option<String>,
@@ -134,8 +132,15 @@ mod tests {
       Err(crate::error::generic_error("foo"))
     }
 
-    runtime.register_op("op_throw", op_async(op_throw));
-    runtime.sync_ops_cache();
+    let ext = crate::Extension::builder()
+      .ops(vec![("op_throw", op_async(op_throw))])
+      .build();
+
+    let mut runtime = crate::JsRuntime::new(crate::RuntimeOptions {
+      extensions: vec![ext],
+      ..Default::default()
+    });
+
     runtime
       .execute_script(
         "<init>",

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1651,6 +1651,7 @@ pub mod tests {
     futures::executor::block_on(lazy(move |cx| f(cx)));
   }
 
+  #[derive(Copy, Clone)]
   enum Mode {
     Async,
     AsyncZeroCopy(bool),
@@ -1661,7 +1662,7 @@ pub mod tests {
     dispatch_count: Arc<AtomicUsize>,
   }
 
-  fn dispatch(rc_op_state: Rc<RefCell<OpState>>, payload: OpPayload) -> Op {
+  fn op_test(rc_op_state: Rc<RefCell<OpState>>, payload: OpPayload) -> Op {
     let rc_op_state2 = rc_op_state.clone();
     let op_state_ = rc_op_state2.borrow();
     let test_state = op_state_.borrow::<TestState>();
@@ -1687,15 +1688,21 @@ pub mod tests {
 
   fn setup(mode: Mode) -> (JsRuntime, Arc<AtomicUsize>) {
     let dispatch_count = Arc::new(AtomicUsize::new(0));
-    let mut runtime = JsRuntime::new(Default::default());
-    let op_state = runtime.op_state();
-    op_state.borrow_mut().put(TestState {
-      mode,
-      dispatch_count: dispatch_count.clone(),
+    let dispatch_count2 = dispatch_count.clone();
+    let ext = Extension::builder()
+      .ops(vec![("op_test", Box::new(op_test))])
+      .state(move |state| {
+        state.put(TestState {
+          mode,
+          dispatch_count: dispatch_count2.clone(),
+        });
+        Ok(())
+      })
+      .build();
+    let mut runtime = JsRuntime::new(RuntimeOptions {
+      extensions: vec![ext],
+      ..Default::default()
     });
-
-    runtime.register_op("op_test", dispatch);
-    runtime.sync_ops_cache();
 
     runtime
       .execute_script(
@@ -2029,12 +2036,14 @@ pub mod tests {
     }
 
     run_in_task(|cx| {
+      let ext = Extension::builder()
+        .ops(vec![("op_err", op_sync(op_err))])
+        .build();
       let mut runtime = JsRuntime::new(RuntimeOptions {
+        extensions: vec![ext],
         get_error_class_fn: Some(&get_error_class_name),
         ..Default::default()
       });
-      runtime.register_op("op_err", op_sync(op_err));
-      runtime.sync_ops_cache();
       runtime
         .execute_script(
           "error_builder_test.js",


### PR DESCRIPTION
In examples and tests.

It's slightly more verbose but I think we should encourage the declarative approach in all examples/code and ultimately deprecate the imperative APIs