### PR TITLE
fix(doc): Make private types which show up in the rustdocs public

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -88,6 +88,7 @@ pub use crate::resources::Resource;
 pub use crate::resources::ResourceId;
 pub use crate::resources::ResourceTable;
 pub use crate::runtime::CompiledWasmModuleStore;
+pub use crate::runtime::CrossIsolateStore;
 pub use crate::runtime::GetErrorClassFn;
 pub use crate::runtime::JsErrorCreateFn;
 pub use crate::runtime::JsRuntime;
@@ -96,6 +97,7 @@ pub use crate::runtime::SharedArrayBufferStore;
 pub use crate::runtime::Snapshot;
 // pub use crate::runtime_modules::include_js_files!;
 pub use crate::extensions::Extension;
+pub use crate::extensions::ExtensionBuilder;
 pub use crate::extensions::OpMiddlewareFn;
 pub use crate::extensions::OpPair;
 

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -3,6 +3,7 @@
 mod in_memory_broadcast_channel;
 
 pub use in_memory_broadcast_channel::InMemoryBroadcastChannel;
+pub use in_memory_broadcast_channel::InMemoryBroadcastChannelResource;
 
 use async_trait::async_trait;
 use deno_core::error::AnyError;


### PR DESCRIPTION
`CrossIsolateStore`, `ExtensionBuilder` and `InMemoryChannelResource` are private types which are referred to by other public APIs, and so they show up in the rustdoc, but not as links. This is especially confusing for `ExtensionBuilder`, since there is nothing in the docs that explains how to build an extension.

Exposing these three types doesn't add any new capabilities: `ExtensionBuilder` can be created from `Extension::builder()`, `SharedArrayBufferStore` and `CompiledWasmModuleStore` already enable doing anything that `CrossIsolateStore` can do, and `InMemoryChannelResource` isn't constructable.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
