### PR TITLE
fix(ext/crypto) base-64 for JWK

### DIFF
--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -1327,11 +1327,10 @@ Deno.test(async function testBase64Forgiving() {
     true,
     ["sign", "verify"],
   );
-  
-  assertEquals(key instanceof CryptoKey);
+
+  assert(key instanceof CryptoKey);
   assertEquals(key.type, "secret");
-  assertEquals(key.algorithm.length, 16);
-  
+
   const exportedKey = await crypto.subtle.exportKey("jwk", key);
   assertEquals(exportedKey.k, "xxw");
 });

--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -1310,3 +1310,21 @@ Deno.test(async function testImportEcSpkiPkcs8() {
     assertEquals(new Uint8Array(expPrivateKeySPKI), spki);*/
   }
 });
+
+Deno.test(async function testBase64Forgiving() {
+  const keyData = `{
+    "kty": "oct",
+    "k": "xxx",
+    "alg": "HS512",
+    "key_ops": ["sign", "verify"],
+    "ext": true
+  }`;
+
+  const _key = await crypto.subtle.importKey(
+    "jwk",
+    JSON.parse(keyData),
+    { name: "HMAC", hash: "SHA-512" },
+    true,
+    ["sign", "verify"],
+  );
+});

--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -1320,11 +1320,18 @@ Deno.test(async function testBase64Forgiving() {
     "ext": true
   }`;
 
-  const _key = await crypto.subtle.importKey(
+  const key = await crypto.subtle.importKey(
     "jwk",
     JSON.parse(keyData),
     { name: "HMAC", hash: "SHA-512" },
     true,
     ["sign", "verify"],
   );
+  
+  assertEquals(key instanceof CryptoKey);
+  assertEquals(key.type, "secret");
+  assertEquals(key.algorithm.length, 16);
+  
+  const exportedKey = await crypto.subtle.exportKey("jwk", key);
+  assertEquals(exportedKey.k, "xxw");
 });

--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -1330,6 +1330,7 @@ Deno.test(async function testBase64Forgiving() {
 
   assert(key instanceof CryptoKey);
   assertEquals(key.type, "secret");
+  assertEquals((key.algorithm as HmacKeyAlgorithm).length, 16);
 
   const exportedKey = await crypto.subtle.exportKey("jwk", key);
   assertEquals(exportedKey.k, "xxw");

--- a/ext/crypto/import_key.rs
+++ b/ext/crypto/import_key.rs
@@ -105,9 +105,12 @@ pub fn op_crypto_import_key(
   }
 }
 
+const URL_SAFE_FORGIVING: base64::Config =
+  base64::URL_SAFE_NO_PAD.decode_allow_trailing_bits(true);
+
 macro_rules! jwt_b64_int_or_err {
   ($name:ident, $b64:expr, $err:expr) => {
-    let bytes = base64::decode_config($b64, base64::URL_SAFE)
+    let bytes = base64::decode_config($b64, URL_SAFE_FORGIVING)
       .map_err(|_| data_error($err))?;
     let $name = UIntBytes::new(&bytes).map_err(|_| data_error($err))?;
   };
@@ -1001,7 +1004,7 @@ fn import_key_ec(
 fn import_key_aes(key_data: KeyData) -> Result<ImportKeyResult, AnyError> {
   Ok(match key_data {
     KeyData::JwkSecret { k } => {
-      let data = base64::decode_config(k, base64::URL_SAFE)
+      let data = base64::decode_config(k, URL_SAFE_FORGIVING)
         .map_err(|_| data_error("invalid key data"))?;
       ImportKeyResult::Hmac {
         raw_data: RawKeyData::Secret(data.into()),
@@ -1014,7 +1017,7 @@ fn import_key_aes(key_data: KeyData) -> Result<ImportKeyResult, AnyError> {
 fn import_key_hmac(key_data: KeyData) -> Result<ImportKeyResult, AnyError> {
   Ok(match key_data {
     KeyData::JwkSecret { k } => {
-      let data = base64::decode_config(k, base64::URL_SAFE)
+      let data = base64::decode_config(k, URL_SAFE_FORGIVING)
         .map_err(|_| data_error("invalid key data"))?;
       ImportKeyResult::Hmac {
         raw_data: RawKeyData::Secret(data.into()),


### PR DESCRIPTION
Ref: #13222

Base-64-url values in JWK are encoded without padding, and have a non-canonical representation since the last character may include 2 or 4 unused "overflow" bits. Encoding should be canonical but decoders may be tolerant, as per `btoa` - [forgiving-base64-decode](https://infra.spec.whatwg.org/#forgiving-base64-decode). 

Chrome and Node implementations of webcrypto `importKey` are tolerant and ignore the overflow bits. 

Previous Deno implementation in js used `btoa` so was tolerant, see [here](https://github.com/denoland/deno/pull/13047/files#diff-863c907dfc6c1c6e507b662a7fc0ead3446473facaf183b7ca1a6908b50ab444L194)

PR implements "forgiving" in JWK decode passing suitable `config` to `base64::decode_config`. Includes test-case.

Rationale: Specifications are somewhat unclear on this, [RFC4648 - 3.5.  Canonical Encoding](https://datatracker.ietf.org/doc/html/rfc4648#section-3.5) states that "decoders MAY choose to reject an encoding if the pad bits have not been set to zero", but JWS/JWK does not mandate or clarify this .. [JSON Web Signature (JWS)](https://datatracker.ietf.org/doc/html/rfc7515#page-54) where example code (C#) just adds missing padding `=` before conversion. 
