### PR TITLE
fix(lsp): properly generate data URLs for completion items

### DIFF
--- a/cli/tests/testdata/lsp/registries/deno-import-intellisense.json
+++ b/cli/tests/testdata/lsp/registries/deno-import-intellisense.json
@@ -11,6 +11,7 @@
         },
         {
           "key": "version",
+          "documentation": "/lsp/registries/doc_${module}_${{version}}.json",
           "url": "/lsp/registries/${module}_versions.json"
         },
         {


### PR DESCRIPTION
Discovered an issue with registry completions when generating the documentation URLs where matched variables needed to be interpolated.