### PR TITLE
build: hardcode WPT_FYI_USER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,7 +517,7 @@ jobs:
           github.repository == 'denoland/deno' &&
           github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
         env:
-          WPT_FYI_USER: ${{ secrets.WPT_FYI_USER }}
+          WPT_FYI_USER: deno
           WPT_FYI_PW: ${{ secrets.WPT_FYI_PW }}
           GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
         run: |

--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload wpt results to wpt.fyi
         env:
-          WPT_FYI_USER: ${{ secrets.WPT_FYI_USER }}
+          WPT_FYI_USER: deno
           WPT_FYI_PW: ${{ secrets.WPT_FYI_PW }}
         run: |
           deno run -A ./tools/upload_wptfyi.js wptreport.json --from-raw-file


### PR DESCRIPTION
GHA keeps redacting all occurrences of the word "deno" out of logs
because this is our wpt.fyi username. This is rather annoying (suprise suprise),
so I am just hardcoding the username in the CI script now.
