### PR TITLE
refactor(core): InspectorSession implements Stream

### DIFF
--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -563,7 +563,8 @@ impl InspectorSession {
   pub fn break_on_next_statement(&mut self) {
     let reason = v8::inspector::StringView::from(&b"debugCommand"[..]);
     let detail = v8::inspector::StringView::empty();
-
+    // TODO(bartlomieju): use raw `*mut V8InspectorSession` pointer, as this
+    // reference may become aliased.
     (*self.v8_session).schedule_pause_on_next_statement(reason, detail);
   }
 }


### PR DESCRIPTION
This commit rewrites "InspectorSession" to no longer implement "Future"
trait but instead implement "Stream" trait. "Stream" trait is implemented 
by yielding a raw pointer to the "v8::inspector::V8InspectorSession" and 
received message. In effect received messages are no longer dispatched 
from within the future, but are explicitly dispatched by the caller.

This change should allow us to dispatch a message to the session when
another message is being dispatched, ie. 
"V8InspectorSesssion::dispatch_protocol_message" is already on the 
call stack. This situation can happen during an execution pause, especially
in situation from #13234