### PR TITLE
feat(test): better errors for resource sanitizer

### DIFF
--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -167,6 +167,12 @@ itest!(ops_sanitizer_nexttick {
   output: "test/ops_sanitizer_nexttick.out",
 });
 
+itest!(resource_sanitizer {
+  args: "test --allow-read test/resource_sanitizer.ts",
+  exit_code: 1,
+  output: "test/resource_sanitizer.out",
+});
+
 itest!(exit_sanitizer {
   args: "test test/exit_sanitizer.ts",
   output: "test/exit_sanitizer.out",

--- a/cli/tests/testdata/test/resource_sanitizer.out
+++ b/cli/tests/testdata/test/resource_sanitizer.out
@@ -8,7 +8,7 @@ leak
 AssertionError: Test case is leaking 2 resources:
 
  - The stdin pipe (rid 0) was opened before the test started, but was closed during the test. Do not close resources in a test that were not created during that test.
- - A file (rid 4) was opened during the test, but not closed during the test. Close the file handle by calling `file.close()`.
+ - A file (rid 3) was opened during the test, but not closed during the test. Close the file handle by calling `file.close()`.
 
     at [WILDCARD]
 

--- a/cli/tests/testdata/test/resource_sanitizer.out
+++ b/cli/tests/testdata/test/resource_sanitizer.out
@@ -1,0 +1,21 @@
+Check [WILDCARD]/test/resource_sanitizer.ts
+running 1 test from [WILDCARD]/test/resource_sanitizer.ts
+test leak ... FAILED ([WILDCARD])
+
+failures:
+
+leak
+AssertionError: Test case is leaking 2 resources:
+
+ - The stdin pipe (rid 0) was opened before the test started, but was closed during the test. Do not close resources in a test that were not created during that test.
+ - A file (rid 4) was opened during the test, but not closed during the test. Close the file handle by calling `file.close()`.
+
+    at [WILDCARD]
+
+failures:
+
+	leak
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+error: Test failed

--- a/cli/tests/testdata/test/resource_sanitizer.ts
+++ b/cli/tests/testdata/test/resource_sanitizer.ts
@@ -1,0 +1,4 @@
+Deno.test("leak", function () {
+  Deno.open("001_hello.js");
+  Deno.stdin.close();
+});

--- a/cli/tests/testdata/test/resource_sanitizer.ts
+++ b/cli/tests/testdata/test/resource_sanitizer.ts
@@ -1,4 +1,4 @@
 Deno.test("leak", function () {
-  Deno.open("001_hello.js");
+  Deno.openSync("001_hello.js");
   Deno.stdin.close();
 });

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -17,17 +17,18 @@
     DateNow,
     Error,
     Function,
+    Number,
+    ObjectKeys,
     Promise,
-    TypeError,
-    StringPrototypeStartsWith,
+    RegExp,
+    RegExpPrototypeTest,
+    Set,
     StringPrototypeEndsWith,
     StringPrototypeIncludes,
     StringPrototypeSlice,
-    RegExp,
-    Number,
-    RegExpPrototypeTest,
-    Set,
+    StringPrototypeStartsWith,
     SymbolToStringTag,
+    TypeError,
   } = window.__bootstrap.primordials;
 
   const opSanitizerDelayResolveQueue = [];
@@ -276,7 +277,7 @@ finishing test case.`;
 
       const post = core.resources();
 
-      const allResources = new Set([...Object.keys(pre), ...Object.keys(post)]);
+      const allResources = new Set([...ObjectKeys(pre), ...ObjectKeys(post)]);
 
       const details = [];
       for (const resource of allResources) {

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -206,6 +206,8 @@ finishing test case.`;
         return ["The stdout pipe", "opened", "closed"];
       case "stderr":
         return ["The stderr pipe", "opened", "closed"];
+      case "compression":
+        return ["A CompressionStream", "created", "closed"];
       default:
         return [`A "${name}" resource`, "created", "cleaned up"];
     }
@@ -271,6 +273,8 @@ finishing test case.`;
         return "Close the stdout pipe by calling `Deno.stdout.close()`.";
       case "stderr":
         return "Close the stderr pipe by calling `Deno.stderr.close()`.";
+      case "compression":
+        return "Close the compression stream by calling `await stream.writable.close()`.";
       default:
         return "Close the resource before the end of the test.";
     }

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -27,6 +27,10 @@
     RegExp,
     Number,
     RegExpPrototypeTest,
+    Set,
+    SetPrototypeHas,
+    SetPrototypeAdd,
+    SetPrototypeDelete,
     SymbolToStringTag,
   } = window.__bootstrap.primordials;
 
@@ -125,6 +129,153 @@ finishing test case.`;
     };
   }
 
+  /**
+   * @param {Set<number>} setA
+   * @param {Set<number>} setB
+   * @returns {Set<number>}
+   */
+  function symmetricDifference(setA, setB) {
+    const difference = new Set(setA);
+    for (const elem of setB) {
+      if (SetPrototypeHas(difference, elem)) {
+        SetPrototypeDelete(difference, elem);
+      } else {
+        SetPrototypeAdd(difference, elem);
+      }
+    }
+    return difference;
+  }
+
+  function prettyResourceNames(name) {
+    switch (name) {
+      case "fsFile":
+        return ["A file", "opened", "closed"];
+      case "fetchRequest":
+        return ["A fetch request", "started", "finished"];
+      case "fetchRequestBody":
+        return ["A fetch request body", "created", "closed"];
+      case "fetchResponseBody":
+        return ["A fetch response body", "created", "consumed"];
+      case "httpClient":
+        return ["An HTTP client", "created", "closed"];
+      case "dynamicLibrary":
+        return ["A dynamic library", "loaded", "unloaded"];
+      case "httpConn":
+        return ["An inbound HTTP connection", "accepted", "closed"];
+      case "httpStream":
+        return ["An inbound HTTP request", "accepted", "closed"];
+      case "tcpStream":
+        return ["A TCP connection", "opened/accepted", "closed"];
+      case "unixStream":
+        return ["A Unix connection", "opened/accepted", "closed"];
+      case "tlsStream":
+        return ["A TLS connection", "opened/accepted", "closed"];
+      case "tlsListener":
+        return ["A TLS listener", "opened", "closed"];
+      case "unixListener":
+        return ["A Unix listener", "opened", "closed"];
+      case "unixDatagram":
+        return ["A Unix datagram", "opened", "closed"];
+      case "tcpListener":
+        return ["A TCP listener", "opened", "closed"];
+      case "udpSocket":
+        return ["A UDP socket", "opened", "closed"];
+      case "timer":
+        return ["A timer", "started", "fired/cleared"];
+      case "textDecoder":
+        return ["A text decoder", "created", "finsihed"];
+      case "messagePort":
+        return ["A message port", "created", "closed"];
+      case "webSocketStream":
+        return ["A WebSocket", "opened", "closed"];
+      case "fsEvents":
+        return ["A file system watcher", "created", "closed"];
+      case "childStdin":
+        return ["A child process stdin", "opened", "closed"];
+      case "childStdout":
+        return ["A child process stdout", "opened", "closed"];
+      case "childStderr":
+        return ["A child process stderr", "opened", "closed"];
+      case "child":
+        return ["A child process", "started", "closed"];
+      case "signal":
+        return ["A signal listener", "created", "fired/cleared"];
+      case "stdin":
+        return ["The stdin pipe", "opened", "closed"];
+      case "stdout":
+        return ["The stdout pipe", "opened", "closed"];
+      case "stderr":
+        return ["The stderr pipe", "opened", "closed"];
+      default:
+        return [`A "${name}" resource`, "created", "cleaned up"];
+    }
+  }
+
+  function resourceCloseHint(name) {
+    switch (name) {
+      case "fsFile":
+        return "Close the file handle by calling `file.close()`.";
+      case "fetchRequest":
+        return "Await the promise returned from `fetch()` or abort the fetch with an abort signal.";
+      case "fetchRequestBody":
+        return "Terminate the request body `ReadableStream` by closing or erroring it.";
+      case "fetchResponseBody":
+        return "Consume or close the response body `ReadableStream`, e.g `await resp.text()` or `await resp.body.cancel()`.";
+      case "httpClient":
+        return "Close the HTTP client by calling `httpClient.close()`.";
+      case "dynamicLibrary":
+        return "Unload the dynamic library by calling `dynamicLibrary.close()`.";
+      case "httpConn":
+        return "Close the inbound HTTP connection by calling `httpConn.close()`.";
+      case "httpStream":
+        return "Close the inbound HTTP request by responding with `e.respondWith().` or closing the HTTP connection.";
+      case "tcpStream":
+        return "Close the TCP connection by calling `tcpConn.close()`.";
+      case "unixStream":
+        return "Close the Unix socket connection by calling `unixConn.close()`.";
+      case "tlsStream":
+        return "Close the TLS connection by calling `tlsConn.close()`.";
+      case "tlsListener":
+        return "Close the TLS listener by calling `tlsListener.close()`.";
+      case "unixListener":
+        return "Close the Unix socket listener by calling `unixListener.close()`.";
+      case "unixDatagram":
+        return "Close the Unix datagram socket by calling `unixDatagram.close()`.";
+      case "tcpListener":
+        return "Close the TCP listener by calling `tcpListener.close()`.";
+      case "udpSocket":
+        return "Close the UDP socket by calling `udpSocket.close()`.";
+      case "timer":
+        return "Clear the timer by calling `clearInterval` or `clearTimeout`.";
+      case "textDecoder":
+        return "Close the text decoder by calling `textDecoder.decode('')` or `await textDecoderStream.readable.cancel()`.";
+      case "messagePort":
+        return "Close the message port by calling `messagePort.close()`.";
+      case "webSocketStream":
+        return "Close the WebSocket by calling `webSocket.close()`.";
+      case "fsEvents":
+        return "Close the file system watcher by calling `watcher.close()`.";
+      case "childStdin":
+        return "Close the child process stdin by calling `proc.stdin.close()`.";
+      case "childStdout":
+        return "Close the child process stdout by calling `proc.stdout.close()`.";
+      case "childStderr":
+        return "Close the child process stderr by calling `proc.stderr.close()`.";
+      case "child":
+        return "Close the child process by calling `proc.kill()` or `proc.close()`.";
+      case "signal":
+        return "Clear the signal listener by calling `Deno.removeSignalListener`.";
+      case "stdin":
+        return "Close the stdin pipe by calling `Deno.stdin.close()`.";
+      case "stdout":
+        return "Close the stdout pipe by calling `Deno.stdout.close()`.";
+      case "stderr":
+        return "Close the stderr pipe by calling `Deno.stderr.close()`.";
+      default:
+        return "Close the resource before the end of the test.";
+    }
+  }
+
   // Wrap test function in additional assertion that makes sure
   // the test case does not "leak" resources - ie. resource table after
   // the test has exactly the same contents as before the test.
@@ -142,15 +293,35 @@ finishing test case.`;
 
       const post = core.resources();
 
-      const preStr = JSONStringify(pre, null, 2);
-      const postStr = JSONStringify(post, null, 2);
-      const msg = `Test case is leaking resources.
-Before: ${preStr}
-After: ${postStr}
+      const allResources = new Set([...Object.keys(pre), ...Object.keys(post)]);
 
-Make sure to close all open resource handles returned from Deno APIs before
-finishing test case.`;
-      assert(preStr === postStr, msg);
+      const details = [];
+      for (const resource of allResources) {
+        const preResource = pre[resource];
+        const postResource = post[resource];
+        if (preResource === postResource) continue;
+
+        if (preResource === undefined) {
+          const [name, action1, action2] = prettyResourceNames(postResource);
+          const hint = resourceCloseHint(postResource);
+          const detail =
+            `${name} (rid ${resource}) was ${action1} during the test, but not ${action2} during the test. ${hint}`;
+          details.push(detail);
+        } else {
+          const [name, action1, action2] = prettyResourceNames(preResource);
+          const detail =
+            `${name} (rid ${resource}) was ${action1} before the test started, but was ${action2} during the test. Do not close resources in a test that were not created during that test.`;
+          details.push(detail);
+        }
+      }
+
+      const message = `Test case is leaking ${details.length} resource${
+        details.length === 1 ? "" : "s"
+      }:
+
+ - ${details.join("\n - ")}
+`;
+      assert(details.length === 0, message);
     };
   }
 

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -17,7 +17,6 @@
     DateNow,
     Error,
     Function,
-    JSONStringify,
     Promise,
     TypeError,
     StringPrototypeStartsWith,
@@ -28,9 +27,6 @@
     Number,
     RegExpPrototypeTest,
     Set,
-    SetPrototypeHas,
-    SetPrototypeAdd,
-    SetPrototypeDelete,
     SymbolToStringTag,
   } = window.__bootstrap.primordials;
 
@@ -127,23 +123,6 @@ finishing test case.`;
         message,
       );
     };
-  }
-
-  /**
-   * @param {Set<number>} setA
-   * @param {Set<number>} setB
-   * @returns {Set<number>}
-   */
-  function symmetricDifference(setA, setB) {
-    const difference = new Set(setA);
-    for (const elem of setB) {
-      if (SetPrototypeHas(difference, elem)) {
-        SetPrototypeDelete(difference, elem);
-      } else {
-        SetPrototypeAdd(difference, elem);
-      }
-    }
-    return difference;
   }
 
   function prettyResourceNames(name) {

--- a/sanitizers_test.ts
+++ b/sanitizers_test.ts
@@ -1,0 +1,4 @@
+Deno.test("foo", () => {
+  Deno.openSync("README.md");
+  Deno.stdin.close();
+});


### PR DESCRIPTION
This commit makes the errors produced from the resource sanitizer much
more human readable. It does this by using real words rather than our
"resource names" when referring to resources, and by giving helpful
hints on how to clean up each of the resources.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
