### PR TITLE
docs: update `writeSync` docs to refer to `writeAllSync` in deno.land/std instead of `Deno.writeAllSync`

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -870,7 +870,7 @@ declare namespace Deno {
    *
    * Returns the number of bytes written.  This function is one of the lowest
    * level APIs and most users should not work with this directly, but rather use
-   * Deno.writeAllSync() instead.
+   * `writeAllSync()` from https://deno.land/std/streams/conversion.ts instead.
    *
    * **It is not guaranteed that the full buffer will be written in a single
    * call.**


### PR DESCRIPTION
`Deno.writeAllSync` is deprecated and its docs say to use `writeAllSync` from std.