### PR TITLE
feat(cli, runtime): compress snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,9 @@ name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -744,6 +747,7 @@ dependencies = [
  "walkdir",
  "winapi 0.3.9",
  "winres",
+ "zstd",
 ]
 
 [[package]]
@@ -979,6 +983,7 @@ dependencies = [
  "hyper",
  "libc",
  "log",
+ "lzzzz",
  "netif",
  "nix",
  "notify",
@@ -1986,6 +1991,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,6 +2224,15 @@ dependencies = [
  "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.65",
+]
+
+[[package]]
+name = "lzzzz"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d891cedd3b1659c206a60ff8afd15bccd7c2754b157f8a164861989e042b88"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -5078,4 +5101,33 @@ dependencies = [
  "quote 1.0.10",
  "syn 1.0.65",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.9.2+zstd.1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2390ea1bf6c038c39674f22d95f0564725fc06034a47129179810b2fc58caa54"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "4.1.3+zstd.1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e99d81b99fb3c2c2c794e3fe56c305c63d5173a16a46b5850b07c935ffc7db79"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.6.2+zstd.1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2daf2f248d9ea44454bfcb2516534e8b8ad2fc91bf818a1885495fc42bc8ac9f"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,12 @@ opt-level = 3
 opt-level = 3
 [profile.bench.package.tokio]
 opt-level = 3
+[profile.bench.package.zstd]
+opt-level = 3
+[profile.bench.package.lzzzz]
+opt-level = 3
+[profile.bench.package.zstd-sys]
+opt-level = 3
 
 # NB: the `bench` and `release` profiles must remain EXACTLY the same.
 [profile.release.package.rand]
@@ -129,4 +135,10 @@ opt-level = 3
 [profile.release.package.hyper]
 opt-level = 3
 [profile.release.package.tokio]
+opt-level = 3
+[profile.release.package.zstd]
+opt-level = 3
+[profile.release.package.lzzzz]
+opt-level = 3
+[profile.release.package.zstd-sys]
 opt-level = 3

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,6 +33,7 @@ deno_websocket = { version = "0.36.0", path = "../ext/websocket" }
 deno_webstorage = { version = "0.26.0", path = "../ext/webstorage" }
 regex = "=1.5.4"
 serde = { version = "=1.0.133", features = ["derive"] }
+zstd = '=0.9.2'
 
 [target.'cfg(windows)'.build-dependencies]
 winapi = "=0.3.9"
@@ -85,6 +86,7 @@ text_lines = "=0.4.1"
 tokio = { version = "=1.14", features = ["full"] }
 uuid = { version = "=0.8.2", features = ["v4", "serde"] }
 walkdir = "=2.3.2"
+zstd = '=0.9.2'
 
 [target.'cfg(windows)'.dependencies]
 fwdansi = "=1.1.0"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -39,6 +39,8 @@ deno_webidl = { version = "0.31.0", path = "../ext/webidl" }
 deno_websocket = { version = "0.36.0", path = "../ext/websocket" }
 deno_webstorage = { version = "0.26.0", path = "../ext/webstorage" }
 
+lzzzz = '=0.8.0'
+
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1.11"
 winapi = "0.3.9"
@@ -70,6 +72,7 @@ http = "0.2.4"
 hyper = { version = "0.14.12", features = ["server", "stream", "http1", "http2", "runtime"] }
 libc = "0.2.106"
 log = "0.4.14"
+lzzzz = '=0.8.0'
 netif = "0.1.0"
 notify = "=5.0.0-pre.12"
 once_cell = "=1.9.0"

--- a/runtime/js.rs
+++ b/runtime/js.rs
@@ -15,6 +15,8 @@ pub static CLI_SNAPSHOT: Lazy<Box<[u8]>> = Lazy::new(
         as usize;
     let mut vec = Vec::with_capacity(size);
 
+    // SAFETY: vec is allocated with exact snapshot size (+ alignment)
+    // SAFETY: non zeroed bytes are overwritten with decompressed snapshot
     unsafe {
       vec.set_len(size);
     }

--- a/runtime/js.rs
+++ b/runtime/js.rs
@@ -1,14 +1,33 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 use deno_core::Snapshot;
 use log::debug;
+use once_cell::sync::Lazy;
 
-pub static CLI_SNAPSHOT: &[u8] =
-  include_bytes!(concat!(env!("OUT_DIR"), "/CLI_SNAPSHOT.bin"));
+pub static CLI_SNAPSHOT: Lazy<Box<[u8]>> = Lazy::new(
+  #[cold]
+  #[inline(never)]
+  || {
+    static COMPRESSED_CLI_SNAPSHOT: &[u8] =
+      include_bytes!(concat!(env!("OUT_DIR"), "/CLI_SNAPSHOT.bin"));
+
+    let size =
+      u32::from_le_bytes(COMPRESSED_CLI_SNAPSHOT[0..4].try_into().unwrap())
+        as usize;
+    let mut vec = Vec::with_capacity(size);
+
+    unsafe {
+      vec.set_len(size);
+    }
+
+    lzzzz::lz4::decompress(&COMPRESSED_CLI_SNAPSHOT[4..], &mut vec).unwrap();
+
+    vec.into_boxed_slice()
+  },
+);
 
 pub fn deno_isolate_init() -> Snapshot {
   debug!("Deno isolate init with snapshots.");
-  let data = CLI_SNAPSHOT;
-  Snapshot::Static(data)
+  Snapshot::Static(&*CLI_SNAPSHOT)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
depends on  denoland/rusty_v8@1cedb0eb21a05eecd67869440005b6ac77dde503 reversal
replaces v8 zlib compression with lz4 and zstd for better speed and compression ratio

| build | size |
|:---| --- |
| deno-new | 79mb |
| deno-uncompressed | 103mb |
| deno-v8-compressed | 80mb |

| `deno run` with cache (cli snapshot) | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `deno-new run -A b.ts` | 30.4 ± 0.5 | 29.6 | 32.3 | 1.03 ± 0.02 |
| `deno-uncompressed run -A b.ts` | 29.6 ± 0.4 | 28.9 | 31.5 | 1.00 |
| `deno-v8-compressed run -A b.ts` | 44.6 ± 0.5 | 43.8 | 46.6 | 1.51 ± 0.03 |

| `deno cache` with no cache (tsc snapshot) | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `deno-new cache -r b.ts` | 266.5 ± 1.6 | 264.1 | 269.0 | 1.05 ± 0.01 |
| `deno-uncompressed cache -r b.ts` | 253.8 ± 1.1 | 252.2 | 255.7 | 1.00 |
| `deno-v8-compressed cache -r b.ts` | 273.8 ± 1.4 | 271.7 | 276.2 | 1.08 ± 0.01 |

| `deno run` with no cache (cli + tsc snapshot) | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `deno-new run -r -A b.ts` | 540.8 ± 16.3 | 530.2 | 580.8 | 1.04 ± 0.03 |
| `deno-uncompressed run -r -A b.ts` | 519.2 ± 1.9 | 517.5 | 522.6 | 1.00 |
| `deno-v8-compressed run -r -A b.ts` | 577.4 ± 2.0 | 574.7 | 580.9 | 1.11 ± 0.01 |

<details>
  <summary>test source</summary>

```ts

// b.ts
export function foo<T>(bar: T) {
  return bar;
}

console.log(foo(1));

let i = 5;
while (i--) {
  const w = new Worker(new URL(`a.ts`, import.meta.url), { type: 'module' });

  w.terminate();
}
```

```ts

// a.ts
let a = 1;

export function foo<T>(bar: T) {
  return bar;
}
```
</details>