### PR TITLE
fix(coverage): don't type check

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -328,7 +328,7 @@ impl FileFetcher {
   /// Fetch cached remote file.
   ///
   /// This is a recursive operation if source file has redirections.
-  fn fetch_cached(
+  pub(crate) fn fetch_cached(
     &self,
     specifier: &ModuleSpecifier,
     redirect_limit: i64,

--- a/cli/tests/integration/coverage_tests.rs
+++ b/cli/tests/integration/coverage_tests.rs
@@ -41,13 +41,15 @@ fn run_coverage_text(test_name: &str, extension: &str) {
   let output = util::deno_cmd_with_deno_dir(deno_dir.path())
     .current_dir(util::testdata_path())
     .arg("coverage")
-    .arg("--quiet")
     .arg("--unstable")
     .arg(format!("{}/", tempdir.to_str().unwrap()))
     .stdout(std::process::Stdio::piped())
-    .stderr(std::process::Stdio::inherit())
+    .stderr(std::process::Stdio::piped())
     .output()
     .expect("failed to spawn coverage reporter");
+
+  // Verify there's no "Check" being printed
+  assert!(output.stderr.is_empty());
 
   let actual =
     util::strip_ansi_codes(std::str::from_utf8(&output.stdout).unwrap())

--- a/cli/tests/integration/coverage_tests.rs
+++ b/cli/tests/integration/coverage_tests.rs
@@ -20,9 +20,11 @@ fn final_blankline() {
 }
 
 fn run_coverage_text(test_name: &str, extension: &str) {
+  let deno_dir = TempDir::new().expect("tempdir fail");
   let tempdir = TempDir::new().expect("tempdir fail");
   let tempdir = tempdir.path().join("cov");
-  let status = util::deno_cmd()
+
+  let status = util::deno_cmd_with_deno_dir(deno_dir.path())
     .current_dir(util::testdata_path())
     .arg("test")
     .arg("--quiet")
@@ -36,7 +38,7 @@ fn run_coverage_text(test_name: &str, extension: &str) {
 
   assert!(status.success());
 
-  let output = util::deno_cmd()
+  let output = util::deno_cmd_with_deno_dir(deno_dir.path())
     .current_dir(util::testdata_path())
     .arg("coverage")
     .arg("--quiet")
@@ -64,7 +66,7 @@ fn run_coverage_text(test_name: &str, extension: &str) {
 
   assert!(output.status.success());
 
-  let output = util::deno_cmd()
+  let output = util::deno_cmd_with_deno_dir(deno_dir.path())
     .current_dir(util::testdata_path())
     .arg("coverage")
     .arg("--quiet")

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 use crate::colors;
-use crate::emit;
 use crate::flags::CoverageFlags;
 use crate::flags::Flags;
 use crate::fs_util::collect_files;
@@ -11,11 +10,12 @@ use crate::tools::fmt::format_json;
 
 use deno_ast::MediaType;
 use deno_ast::ModuleSpecifier;
+use deno_core::anyhow::anyhow;
+use deno_core::anyhow::Context;
 use deno_core::error::AnyError;
 use deno_core::serde_json;
 use deno_core::url::Url;
 use deno_core::LocalInspectorSession;
-use deno_runtime::permissions::Permissions;
 use regex::Regex;
 use serde::Deserialize;
 use serde::Serialize;
@@ -643,40 +643,65 @@ pub async fn cover_files(
   for script_coverage in script_coverages {
     let module_specifier =
       deno_core::resolve_url_or_path(&script_coverage.url)?;
-    ps.prepare_module_load(
-      vec![module_specifier.clone()],
-      false,
-      emit::TypeLib::UnstableDenoWindow,
-      Permissions::allow_all(),
-      Permissions::allow_all(),
-      false,
-    )
-    .await?;
 
-    let module_source = ps.load(module_specifier.clone(), None, false)?;
-    let script_source = &module_source.code;
+    let maybe_file = if module_specifier.scheme() == "file" {
+      ps.file_fetcher.get_source(&module_specifier)
+    } else {
+      ps.file_fetcher
+        .fetch_cached(&module_specifier, 10)
+        .with_context(|| {
+          format!("Failed to fetch \"{}\" from cache.", module_specifier)
+        })?
+    };
+    let file = if let Some(f) = maybe_file {
+      f
+    } else {
+      return Err(
+        anyhow!("Failed to fetch \"{}\" from cache. 
+          Before generating coverage report run `deno test --coverage` to generate coverage data.", 
+          module_specifier
+        )
+      );
+    };
 
+    // Check if file was transpiled
+    let transpiled_source = match file.media_type {
+      MediaType::JavaScript
+      | MediaType::Unknown
+      | MediaType::Cjs
+      | MediaType::Mjs
+      | MediaType::Json => file.source.as_ref().clone(),
+      MediaType::Dts => "".to_string(),
+      _ => {
+        let emit_path = ps
+          .dir
+          .gen_cache
+          .get_cache_filename_with_extension(&file.specifier, "js")
+          .unwrap_or_else(|| {
+            unreachable!("Unable to get cache filename: {}", &file.specifier)
+          });
+        match ps.dir.gen_cache.get(&emit_path) {
+          Ok(b) => String::from_utf8(b).unwrap(),
+          Err(_) => {
+            return Err(anyhow!(
+              "Missing transpiled source code for: \"{}\"",
+              file.specifier
+            ))
+          }
+        }
+      }
+    };
+
+    let original_source = &file.source;
     let maybe_source_map = ps.get_source_map(&script_coverage.url);
-    let maybe_cached_source = ps
-      .file_fetcher
-      .get_source(&module_specifier)
-      .map(|f| f.source);
 
     let coverage_report = generate_coverage_report(
       &script_coverage,
-      script_source,
+      &transpiled_source,
       &maybe_source_map,
     );
 
-    let file_text = if let Some(original_source) =
-      maybe_source_map.and(maybe_cached_source.as_ref())
-    {
-      original_source.as_str()
-    } else {
-      script_source
-    };
-
-    reporter.report(&coverage_report, file_text);
+    reporter.report(&coverage_report, original_source);
   }
 
   reporter.done();

--- a/cli/tools/coverage.rs
+++ b/cli/tools/coverage.rs
@@ -658,7 +658,7 @@ pub async fn cover_files(
     } else {
       return Err(
         anyhow!("Failed to fetch \"{}\" from cache. 
-          Before generating coverage report run `deno test --coverage` to generate coverage data.", 
+          Before generating coverage report, run `deno test --coverage` to ensure consistent state.", 
           module_specifier
         )
       );
@@ -684,8 +684,9 @@ pub async fn cover_files(
           Ok(b) => String::from_utf8(b).unwrap(),
           Err(_) => {
             return Err(anyhow!(
-              "Missing transpiled source code for: \"{}\"",
-              file.specifier
+              "Missing transpiled source code for: \"{}\".
+              Before generating coverage report, run `deno test --coverage` to ensure consistent state.",
+              file.specifier,
             ))
           }
         }


### PR DESCRIPTION
This commit changes "deno coverage" command not to type check.

Instead of relying on infrastructure for module loading in "deno run";
the code now directly reaches into cache for original and transpiled
sources. In case sources are not available the error is returned to the
user, suggesting to first run "deno test --coverage" command.

Fixes https://github.com/denoland/deno/issues/13161
Fixes https://github.com/denoland/deno/issues/13326