### PR TITLE
fix: `deno install` with `--allow-all` should output shim with `--allow-all` instead of each permission

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -214,6 +214,7 @@ pub struct Flags {
   pub argv: Vec<String>,
   pub subcommand: DenoSubcommand,
 
+  pub allow_all: bool,
   pub allow_env: Option<Vec<String>>,
   pub allow_hrtime: bool,
   pub allow_net: Option<Vec<String>>,
@@ -268,6 +269,11 @@ impl Flags {
   /// to the ones used to create `self`.
   pub fn to_permission_args(&self) -> Vec<String> {
     let mut args = vec![];
+
+    if self.allow_all {
+      args.push("--allow-all".to_string());
+      return args;
+    }
 
     match &self.allow_read {
       Some(read_allowlist) if read_allowlist.is_empty() => {
@@ -2252,6 +2258,7 @@ fn permission_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     flags.allow_hrtime = true;
   }
   if matches.is_present("allow-all") {
+    flags.allow_all = true;
     flags.allow_read = Some(vec![]);
     flags.allow_env = Some(vec![]);
     flags.allow_net = Some(vec![]);
@@ -2647,6 +2654,7 @@ mod tests {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "gist.ts".to_string(),
         }),
+        allow_all: true,
         allow_net: Some(vec![]),
         allow_env: Some(vec![]),
         allow_run: Some(vec![]),

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -730,6 +730,43 @@ mod tests {
   }
 
   #[test]
+  fn install_allow_all() {
+    let temp_dir = TempDir::new().expect("tempdir fail");
+    let bin_dir = temp_dir.path().join("bin");
+    std::fs::create_dir(&bin_dir).unwrap();
+
+    install(
+      Flags {
+        allow_all: true,
+        ..Flags::default()
+      },
+      InstallFlags {
+        module_url: "http://localhost:4545/echo_server.ts".to_string(),
+        args: vec![],
+        name: Some("echo_test".to_string()),
+        root: Some(temp_dir.path().to_path_buf()),
+        force: false,
+      },
+    )
+    .unwrap();
+
+    let mut file_path = bin_dir.join("echo_test");
+    if cfg!(windows) {
+      file_path = file_path.with_extension("cmd");
+    }
+
+    let content = fs::read_to_string(file_path).unwrap();
+    if cfg!(windows) {
+      assert!(content.contains(
+        r#""run" "--allow-all" "http://localhost:4545/echo_server.ts""#
+      ));
+    } else {
+      assert!(content
+        .contains(r#"run --allow-all 'http://localhost:4545/echo_server.ts'"#));
+    }
+  }
+
+  #[test]
   fn install_local_module() {
     let temp_dir = TempDir::new().expect("tempdir fail");
     let bin_dir = temp_dir.path().join("bin");

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -204,6 +204,7 @@ pub fn compile_to_runtime_flags(
     subcommand: DenoSubcommand::Run(RunFlags {
       script: "placeholder".to_string(),
     }),
+    allow_all: flags.allow_all,
     allow_env: flags.allow_env,
     allow_hrtime: flags.allow_hrtime,
     allow_net: flags.allow_net,


### PR DESCRIPTION
This changes doing `deno install` with `-A`/`--allow-all` to output a shim with `--allow-all` only instead of listing every permission flag.

We do not need to be concerned about potential future permission flags because `--allow-all` has a permission for `--allow-run` which allows for anything to occur already.

Closes #11819