### PR TITLE
chore(ci): ubuntu-latest-xl => ubuntu-20.04-xl

### DIFF
--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         deno-version: [v1.x, canary]
-        os: [ubuntu-latest-xl]
+        os: [ubuntu-20.04-xl]
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
Since ubuntu-latest-xl is based on Ubuntu 18 (so indeed not "latest") and will be deprecated by GitHub on January 24th, 2022