### PR TITLE
fix(cli): fix `deno install --prompt`

### DIFF
--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -290,6 +290,10 @@ pub fn install(
     executable_args.push("--cached-only".to_string());
   }
 
+  if flags.prompt {
+    executable_args.push("--prompt".to_string());
+  }
+
   if !flags.v8_flags.is_empty() {
     executable_args.push(format!("--v8-flags={}", flags.v8_flags.join(",")));
   }


### PR DESCRIPTION
I noticed that `deno install --prompt` was not working. I have fixed it.

before
```
$ deno --version
deno 1.17.2 (release, x86_64-unknown-linux-gnu)
v8 9.7.106.15
typescript 4.5.2

$ deno help install |grep prompt
        --prompt                                            Fallback to prompt if required permission wasn't passed

$ deno install --prompt -f --allow-read https://deno.land/std@0.106.0/http/file_server.ts

$ ~/.deno/bin/file_server
HTTP server listening on http://0.0.0.0:4507/
error: Uncaught (in promise) PermissionDenied: Requires net access to "0.0.0.0:4507", run again with the --allow-net flag
  const listener = Deno.listen(addr);
                        ^
    at Object.opSync (deno:core/01_core.js:149:12)
    at opListen (deno:ext/net/01_net.js:38:17)
    at Object.listen (deno:ext/net/01_net.js:204:17)
    at serve (https://deno.land/std@0.106.0/http/server.ts:304:25)
    at listenAndServe (https://deno.land/std@0.106.0/http/server.ts:324:18)
    at main (https://deno.land/std@0.106.0/http/file_server.ts:680:5)
    at https://deno.land/std@0.106.0/http/file_server.ts:686:3

$ cat ~/.deno/bin/file_server
#!/bin/sh
# generated by deno install
exec deno run --allow-read 'https://deno.land/std@0.106.0/http/file_server.ts' "$@"
```

after
```
$ ./deno install --prompt -f --allow-read https://deno.land/std@0.106.0/http/file_server.ts

$ ~/.deno/bin/file_server
⚠️  ️Deno requests net access to "0.0.0.0:4507". Allow? [y/n (y = yes allow, n = no deny)] y
HTTP server listening on http://0.0.0.0:4507/
[2022-01-12 10:04:31] "GET / HTTP/1.0" 200
^C

$ cat ~/.deno/bin/file_server
#!/bin/sh
# generated by deno install
exec deno run --allow-read --prompt 'https://deno.land/std@0.106.0/http/file_server.ts' "$@"
```

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
