### PR TITLE
fix(runtime): don't crash when window is deleted

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2479,3 +2479,8 @@ itest!(import_assertions_type_check {
   output: "import_assertions/type_check.out",
   exit_code: 1,
 });
+
+itest!(delete_window {
+  args: "run delete_window.js",
+  output_str: Some("true\n"),
+});

--- a/cli/tests/testdata/delete_window.js
+++ b/cli/tests/testdata/delete_window.js
@@ -1,0 +1,1 @@
+console.log(delete globalThis.window);

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -970,7 +970,11 @@
       webidl.requiredArguments(arguments.length, 1, {
         prefix: "Failed to execute 'dispatchEvent' on 'EventTarget'",
       });
-      const self = this ?? globalThis;
+      // If `this` is not present, then fallback to global scope. We don't use
+      // `globalThis` directly here, because it could be deleted by user.
+      // Instead use saved reference to global scope when the script was
+      // executed.
+      const self = this ?? window;
 
       const { listeners } = self[eventTargetData];
       if (!(event.type in listeners)) {

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -315,7 +315,10 @@ impl MainWorker {
   ) -> Result<(), AnyError> {
     self.execute_script(
       script_name,
-      "globalThis.dispatchEvent(new Event('load'))",
+      // NOTE(@bartlomieju): not using `globalThis` here, because user might delete
+      // it. Instead we're using global `dispatchEvent` function which will
+      // used a saved reference to global scope.
+      "dispatchEvent(new Event('load'))",
     )
   }
 
@@ -328,7 +331,10 @@ impl MainWorker {
   ) -> Result<(), AnyError> {
     self.execute_script(
       script_name,
-      "globalThis.dispatchEvent(new Event('unload'))",
+      // NOTE(@bartlomieju): not using `globalThis` here, because user might delete
+      // it. Instead we're using global `dispatchEvent` function which will
+      // used a saved reference to global scope.
+      "dispatchEvent(new Event('unload'))",
     )
   }
 }

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -313,7 +313,10 @@ impl MainWorker {
     &mut self,
     script_name: &str,
   ) -> Result<(), AnyError> {
-    self.execute_script(script_name, "window.dispatchEvent(new Event('load'))")
+    self.execute_script(
+      script_name,
+      "globalThis.dispatchEvent(new Event('load'))",
+    )
   }
 
   /// Dispatches "unload" event to the JavaScript runtime.
@@ -323,8 +326,10 @@ impl MainWorker {
     &mut self,
     script_name: &str,
   ) -> Result<(), AnyError> {
-    self
-      .execute_script(script_name, "window.dispatchEvent(new Event('unload'))")
+    self.execute_script(
+      script_name,
+      "globalThis.dispatchEvent(new Event('unload'))",
+    )
   }
 }
 


### PR DESCRIPTION
This commit fixes an error when user deletes "window" global JS
variable. Instead of relying on "window" or "globalThis" to dispatch
"load" and "unload" events, we are default to global scope of the
worker.

Fixes https://github.com/denoland/deno/issues/13358