### PR TITLE
refactor(lsp): store the `LspUrlMap`'s state behind a mutex

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -341,7 +341,7 @@ fn is_preferred(
 /// for an LSP CodeAction.
 pub(crate) async fn ts_changes_to_edit(
   changes: &[tsc::FileTextChanges],
-  language_server: &mut language_server::Inner,
+  language_server: &language_server::Inner,
 ) -> Result<Option<lsp::WorkspaceEdit>, AnyError> {
   let mut text_document_edits = Vec::new();
   for change in changes {
@@ -607,7 +607,7 @@ impl CodeActionCollection {
     specifier: &ModuleSpecifier,
     action: &tsc::CodeFixAction,
     diagnostic: &lsp::Diagnostic,
-    language_server: &mut language_server::Inner,
+    language_server: &language_server::Inner,
   ) -> Result<(), AnyError> {
     if action.commands.is_some() {
       // In theory, tsc can return actions that require "commands" to be applied

--- a/cli/lsp/code_lens.rs
+++ b/cli/lsp/code_lens.rs
@@ -239,7 +239,7 @@ impl Visit for DenoTestCollector {
 async fn resolve_implementation_code_lens(
   code_lens: lsp::CodeLens,
   data: CodeLensData,
-  language_server: &mut language_server::Inner,
+  language_server: &language_server::Inner,
 ) -> Result<lsp::CodeLens, AnyError> {
   let asset_or_doc =
     language_server.get_cached_asset_or_document(&data.specifier)?;
@@ -308,7 +308,7 @@ async fn resolve_implementation_code_lens(
 async fn resolve_references_code_lens(
   code_lens: lsp::CodeLens,
   data: CodeLensData,
-  language_server: &mut language_server::Inner,
+  language_server: &language_server::Inner,
 ) -> Result<lsp::CodeLens, AnyError> {
   let asset_or_document =
     language_server.get_cached_asset_or_document(&data.specifier)?;
@@ -378,7 +378,7 @@ async fn resolve_references_code_lens(
 
 pub(crate) async fn resolve_code_lens(
   code_lens: lsp::CodeLens,
-  language_server: &mut language_server::Inner,
+  language_server: &language_server::Inner,
 ) -> Result<lsp::CodeLens, AnyError> {
   let data: CodeLensData =
     serde_json::from_value(code_lens.data.clone().unwrap())?;

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -398,6 +398,8 @@ impl Inner {
       maybe_lint_config: self.maybe_lint_config.clone(),
       maybe_fmt_config: self.maybe_fmt_config.clone(),
       module_registries: self.module_registries.clone(),
+      // it's ok to get an Arc to the url map because the url_map is a cache
+      // that does not change once the mapping for a specifier is set
       url_map: self.url_map.clone(),
     }))
   }
@@ -1147,7 +1149,7 @@ impl Inner {
   }
 
   async fn code_action(
-    &mut self,
+    &self,
     params: CodeActionParams,
   ) -> LspResult<Option<CodeActionResponse>> {
     let specifier = self.url_map.normalize_url(&params.text_document.uri);
@@ -1321,7 +1323,7 @@ impl Inner {
   }
 
   async fn code_action_resolve(
-    &mut self,
+    &self,
     params: CodeAction,
   ) -> LspResult<CodeAction> {
     if params.kind.is_none() || params.data.is_none() {
@@ -1460,7 +1462,7 @@ impl Inner {
   }
 
   async fn code_lens_resolve(
-    &mut self,
+    &self,
     code_lens: CodeLens,
   ) -> LspResult<CodeLens> {
     let mark = self.performance.mark("code_lens_resolve", Some(&code_lens));
@@ -1481,7 +1483,7 @@ impl Inner {
   }
 
   async fn document_highlight(
-    &mut self,
+    &self,
     params: DocumentHighlightParams,
   ) -> LspResult<Option<Vec<DocumentHighlight>>> {
     let specifier = self
@@ -1526,7 +1528,7 @@ impl Inner {
   }
 
   async fn references(
-    &mut self,
+    &self,
     params: ReferenceParams,
   ) -> LspResult<Option<Vec<Location>>> {
     let specifier = self
@@ -1581,7 +1583,7 @@ impl Inner {
   }
 
   async fn goto_definition(
-    &mut self,
+    &self,
     params: GotoDefinitionParams,
   ) -> LspResult<Option<GotoDefinitionResponse>> {
     let specifier = self
@@ -1620,7 +1622,7 @@ impl Inner {
   }
 
   async fn goto_type_definition(
-    &mut self,
+    &self,
     params: GotoTypeDefinitionParams,
   ) -> LspResult<Option<GotoTypeDefinitionResponse>> {
     let specifier = self
@@ -1668,7 +1670,7 @@ impl Inner {
   }
 
   async fn completion(
-    &mut self,
+    &self,
     params: CompletionParams,
   ) -> LspResult<Option<CompletionResponse>> {
     let specifier = self
@@ -1746,7 +1748,7 @@ impl Inner {
   }
 
   async fn completion_resolve(
-    &mut self,
+    &self,
     params: CompletionItem,
   ) -> LspResult<CompletionItem> {
     let mark = self.performance.mark("completion_resolve", Some(&params));
@@ -1793,7 +1795,7 @@ impl Inner {
   }
 
   async fn goto_implementation(
-    &mut self,
+    &self,
     params: GotoImplementationParams,
   ) -> LspResult<Option<GotoImplementationResponse>> {
     let specifier = self
@@ -1841,7 +1843,7 @@ impl Inner {
   }
 
   async fn folding_range(
-    &mut self,
+    &self,
     params: FoldingRangeParams,
   ) -> LspResult<Option<Vec<FoldingRange>>> {
     let specifier = self.url_map.normalize_url(&params.text_document.uri);
@@ -1885,7 +1887,7 @@ impl Inner {
   }
 
   async fn incoming_calls(
-    &mut self,
+    &self,
     params: CallHierarchyIncomingCallsParams,
   ) -> LspResult<Option<Vec<CallHierarchyIncomingCall>>> {
     let specifier = self.url_map.normalize_url(&params.item.uri);
@@ -1934,7 +1936,7 @@ impl Inner {
   }
 
   async fn outgoing_calls(
-    &mut self,
+    &self,
     params: CallHierarchyOutgoingCallsParams,
   ) -> LspResult<Option<Vec<CallHierarchyOutgoingCall>>> {
     let specifier = self.url_map.normalize_url(&params.item.uri);
@@ -1984,7 +1986,7 @@ impl Inner {
   }
 
   async fn prepare_call_hierarchy(
-    &mut self,
+    &self,
     params: CallHierarchyPrepareParams,
   ) -> LspResult<Option<Vec<CallHierarchyItem>>> {
     let specifier = self
@@ -2058,7 +2060,7 @@ impl Inner {
   }
 
   async fn rename(
-    &mut self,
+    &self,
     params: RenameParams,
   ) -> LspResult<Option<WorkspaceEdit>> {
     let specifier = self

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -714,7 +714,7 @@ impl DocumentSpan {
   pub(crate) async fn to_link(
     &self,
     line_index: Arc<LineIndex>,
-    language_server: &mut language_server::Inner,
+    language_server: &language_server::Inner,
   ) -> Option<lsp::LocationLink> {
     let target_specifier = normalize_specifier(&self.file_name).ok()?;
     let target_asset_or_doc = language_server
@@ -991,7 +991,7 @@ impl ImplementationLocation {
   pub(crate) fn to_location(
     &self,
     line_index: Arc<LineIndex>,
-    language_server: &mut language_server::Inner,
+    language_server: &language_server::Inner,
   ) -> lsp::Location {
     let specifier = normalize_specifier(&self.document_span.file_name)
       .unwrap_or_else(|_| ModuleSpecifier::parse("deno://invalid").unwrap());
@@ -1008,7 +1008,7 @@ impl ImplementationLocation {
   pub(crate) async fn to_link(
     &self,
     line_index: Arc<LineIndex>,
-    language_server: &mut language_server::Inner,
+    language_server: &language_server::Inner,
   ) -> Option<lsp::LocationLink> {
     self
       .document_span
@@ -1035,7 +1035,7 @@ impl RenameLocations {
   pub(crate) async fn into_workspace_edit(
     self,
     new_name: &str,
-    language_server: &mut language_server::Inner,
+    language_server: &language_server::Inner,
   ) -> Result<lsp::WorkspaceEdit, AnyError> {
     let mut text_document_edit_map: HashMap<Url, lsp::TextDocumentEdit> =
       HashMap::new();
@@ -1126,7 +1126,7 @@ impl DefinitionInfoAndBoundSpan {
   pub(crate) async fn to_definition(
     &self,
     line_index: Arc<LineIndex>,
-    language_server: &mut language_server::Inner,
+    language_server: &language_server::Inner,
   ) -> Option<lsp::GotoDefinitionResponse> {
     if let Some(definitions) = &self.definitions {
       let mut location_links = Vec::<lsp::LocationLink>::new();
@@ -1528,7 +1528,7 @@ impl ReferenceEntry {
   pub(crate) fn to_location(
     &self,
     line_index: Arc<LineIndex>,
-    language_server: &mut language_server::Inner,
+    language_server: &language_server::Inner,
   ) -> lsp::Location {
     let specifier = normalize_specifier(&self.document_span.file_name)
       .unwrap_or_else(|_| INVALID_SPECIFIER.clone());
@@ -1560,7 +1560,7 @@ pub struct CallHierarchyItem {
 impl CallHierarchyItem {
   pub(crate) async fn try_resolve_call_hierarchy_item(
     &self,
-    language_server: &mut language_server::Inner,
+    language_server: &language_server::Inner,
     maybe_root_path: Option<&Path>,
   ) -> Option<lsp::CallHierarchyItem> {
     let target_specifier = normalize_specifier(&self.file).ok()?;
@@ -1579,7 +1579,7 @@ impl CallHierarchyItem {
   pub(crate) fn to_call_hierarchy_item(
     &self,
     line_index: Arc<LineIndex>,
-    language_server: &mut language_server::Inner,
+    language_server: &language_server::Inner,
     maybe_root_path: Option<&Path>,
   ) -> lsp::CallHierarchyItem {
     let target_specifier = normalize_specifier(&self.file)
@@ -1661,7 +1661,7 @@ pub struct CallHierarchyIncomingCall {
 impl CallHierarchyIncomingCall {
   pub(crate) async fn try_resolve_call_hierarchy_incoming_call(
     &self,
-    language_server: &mut language_server::Inner,
+    language_server: &language_server::Inner,
     maybe_root_path: Option<&Path>,
   ) -> Option<lsp::CallHierarchyIncomingCall> {
     let target_specifier = normalize_specifier(&self.from.file).ok()?;
@@ -1696,7 +1696,7 @@ impl CallHierarchyOutgoingCall {
   pub(crate) async fn try_resolve_call_hierarchy_outgoing_call(
     &self,
     line_index: Arc<LineIndex>,
-    language_server: &mut language_server::Inner,
+    language_server: &language_server::Inner,
     maybe_root_path: Option<&Path>,
   ) -> Option<lsp::CallHierarchyOutgoingCall> {
     let target_specifier = normalize_specifier(&self.to.file).ok()?;


### PR DESCRIPTION
Similar to #13414, this PR stores the state of `LspUrlMap` behind a mutex in order to make more language server messages not require mutability (and run concurrently in the future).

I believe this is ok to do because the `LspUrlMap` is a cache whose value doesn't change once set and providing a value to `normalize_specifier` will always have the same output. That said, `normalize_url` might be different based on whether `normalize_specifier` has been called yet or not. I think for how `LspUrlMap` is used this shouldn't matter?

Again, slowly moving towards #11307.