### PR TITLE
chore: update netif to 0.1.1

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -73,7 +73,7 @@ hyper = { version = "0.14.12", features = ["server", "stream", "http1", "http2",
 libc = "0.2.106"
 log = "0.4.14"
 lzzzz = '=0.8.0'
-netif = "0.1.0"
+netif = "0.1.1"
 notify = "=5.0.0-pre.12"
 once_cell = "=1.9.0"
 regex = "1.5.4"

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -97,7 +97,7 @@ pub fn signal_str_to_int(s: &str) -> Result<libc::c_int, AnyError> {
   }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub fn signal_str_to_int(s: &str) -> Result<libc::c_int, AnyError> {
   match s {
     "SIGHUP" => Ok(1),


### PR DESCRIPTION
Unblocks building the runtime for aarch64-linux-android:
```shell
RUSTFLAGS="-C linker=/home/divy/gh/rusty_v8/third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch
64-linux-android21-clang++" cargo build --target aarch64-linux-android
```
