### PR TITLE
feat(serde_v8): deserialize ArrayBuffers

### DIFF
--- a/serde_v8/src/error.rs
+++ b/serde_v8/src/error.rs
@@ -16,6 +16,7 @@ pub enum Error {
   ExpectedMap,
   ExpectedEnum,
   ExpectedObject,
+  ExpectedBuffer,
 
   ExpectedUtf8,
 

--- a/serde_v8/src/payload.rs
+++ b/serde_v8/src/payload.rs
@@ -11,6 +11,7 @@ pub enum ValueType {
   Number,
   String,
   Array,
+  ArrayBuffer,
   ArrayBufferView,
   Object,
 }
@@ -25,6 +26,8 @@ impl ValueType {
       return Self::String;
     } else if v.is_array() {
       return Self::Array;
+    } else if v.is_array_buffer() {
+      return Self::ArrayBuffer;
     } else if v.is_array_buffer_view() {
       return Self::ArrayBufferView;
     } else if v.is_object() {

--- a/serde_v8/tests/de.rs
+++ b/serde_v8/tests/de.rs
@@ -2,6 +2,7 @@
 use serde::Deserialize;
 
 use serde_v8::utils::{js_exec, v8_do};
+use serde_v8::Buffer;
 use serde_v8::Error;
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -188,6 +189,29 @@ fn de_string_or_buffer() {
     |scope, v| {
       let sob: serde_v8::StringOrBuffer = serde_v8::from_v8(scope, v).unwrap();
       assert_eq!(sob.as_slice(), &[0x68, 0x65, 0x6C, 0x6C, 0x6F]);
+    },
+  );
+}
+
+#[test]
+fn de_buffers() {
+  // ArrayBufferView
+  dedo("new Uint8Array([97])", |scope, v| {
+    let buf: Buffer = serde_v8::from_v8(scope, v).unwrap();
+    assert_eq!(&*buf, &[97]);
+  });
+
+  // ArrayBuffer
+  dedo("(new Uint8Array([97])).buffer", |scope, v| {
+    let buf: Buffer = serde_v8::from_v8(scope, v).unwrap();
+    assert_eq!(&*buf, &[97]);
+  });
+
+  dedo(
+    "(Uint8Array.from([0x68, 0x65, 0x6C, 0x6C, 0x6F]))",
+    |scope, v| {
+      let buf: Buffer = serde_v8::from_v8(scope, v).unwrap();
+      assert_eq!(&*buf, &[0x68, 0x65, 0x6C, 0x6C, 0x6F]);
     },
   );
 }


### PR DESCRIPTION
Previously we would only deserialize `ArrayBufferView`s as zero-copy bufs

This avoids rewrapping `ArrayBuffer`s in `ArrayBufferView`s when implementing APIs that take [BufferSource](https://webidl.spec.whatwg.org/#BufferSource) args passed through the op-layer