### PR TITLE
fix(ext/crypto): duplicate RsaHashedImportParams types

### DIFF
--- a/ext/crypto/lib.deno_crypto.d.ts
+++ b/ext/crypto/lib.deno_crypto.d.ts
@@ -116,10 +116,6 @@ interface HmacImportParams extends Algorithm {
   length?: number;
 }
 
-interface RsaHashedImportParams extends Algorithm {
-  hash: HashAlgorithmIdentifier;
-}
-
 interface EcKeyAlgorithm extends KeyAlgorithm {
   namedCurve: NamedCurve;
 }


### PR DESCRIPTION
Can be observed here: https://doc.deno.land/deno/stable/~/RsaHashedImportParams
It did not break `importKey` and wasn't detected by our tests because the right definition was inferred as [HmacImportParams](https://doc.deno.land/deno/stable/~/HmacImportParams) 

(i wish lint could complaint about overriding fields in duplicate definitions)