### PR TITLE
fix(lsp): respect DENO_CERT and other options related to TLS certs

### DIFF
--- a/cli/lsp/cache.rs
+++ b/cli/lsp/cache.rs
@@ -33,6 +33,9 @@ impl CacheServer {
     maybe_cache_path: Option<PathBuf>,
     maybe_import_map: Option<Arc<ImportMap>>,
     maybe_config_file: Option<ConfigFile>,
+    maybe_ca_stores: Option<Vec<String>>,
+    maybe_ca_file: Option<String>,
+    unsafely_ignore_certificate_errors: Option<Vec<String>>,
   ) -> Self {
     let (tx, mut rx) = mpsc::unbounded_channel::<Request>();
     let _join_handle = thread::spawn(move || {
@@ -40,6 +43,9 @@ impl CacheServer {
       runtime.block_on(async {
         let ps = ProcState::build(Flags {
           cache_path: maybe_cache_path,
+          ca_stores: maybe_ca_stores,
+          ca_file: maybe_ca_file,
+          unsafely_ignore_certificate_errors,
           ..Default::default()
         })
         .await

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -154,6 +154,10 @@ pub struct WorkspaceSettings {
   /// cache/DENO_DIR for the language server.
   pub cache: Option<String>,
 
+  /// Override the default stores used to validate certificates. This overrides
+  /// the environment variable `DENO_TLS_CA_STORE` if present.
+  pub certificate_stores: Option<Vec<String>>,
+
   /// An option that points to a path string of the config file to apply to
   /// code within the workspace.
   pub config: Option<String>,
@@ -178,6 +182,15 @@ pub struct WorkspaceSettings {
   /// APIs for the workspace.
   #[serde(default)]
   pub suggest: CompletionSettings,
+
+  /// An option which sets the cert file to use when attempting to fetch remote
+  /// resources. This overrides `DENO_CERT` if present.
+  pub tls_certificate: Option<String>,
+
+  /// An option, if set, will unsafely ignore certificate errors when fetching
+  /// remote resources.
+  #[serde(default)]
+  pub unsafely_ignore_certificate_errors: Option<Vec<String>>,
 
   #[serde(default)]
   pub unstable: bool,
@@ -485,6 +498,7 @@ mod tests {
       WorkspaceSettings {
         enable: false,
         cache: None,
+        certificate_stores: None,
         config: None,
         import_map: None,
         code_lens: CodeLensSettings {
@@ -505,6 +519,8 @@ mod tests {
             hosts: HashMap::new(),
           }
         },
+        tls_certificate: None,
+        unsafely_ignore_certificate_errors: None,
         unstable: false,
       }
     );

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -444,8 +444,7 @@ impl Inner {
         workspace_settings.certificate_stores.clone(),
         workspace_settings.tls_certificate.clone(),
         workspace_settings
-          .unsafely_ignore_certificate_errors
-          .clone(),
+          .unsafely_ignore_certificate_errors,
       )?;
       self.module_registries_location = module_registries_location;
       self.documents.set_location(dir.root.join(CACHE_PATH));

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -443,8 +443,7 @@ impl Inner {
         maybe_root_path,
         workspace_settings.certificate_stores.clone(),
         workspace_settings.tls_certificate.clone(),
-        workspace_settings
-          .unsafely_ignore_certificate_errors,
+        workspace_settings.unsafely_ignore_certificate_errors,
       )?;
       self.module_registries_location = module_registries_location;
       self.documents.set_location(dir.root.join(CACHE_PATH));

--- a/cli/lsp/registries.rs
+++ b/cli/lsp/registries.rs
@@ -12,6 +12,7 @@ use super::path_to_regex::StringOrVec;
 use super::path_to_regex::Token;
 
 use crate::deno_dir;
+use crate::file_fetcher::get_root_cert_store;
 use crate::file_fetcher::CacheSetting;
 use crate::file_fetcher::FileFetcher;
 use crate::http_cache::HttpCache;
@@ -37,6 +38,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashMap;
 use std::path::Path;
+use std::path::PathBuf;
 
 const CONFIG_PATH: &str = "/.well-known/deno-import-intellisense.json";
 const COMPONENT: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
@@ -422,29 +424,38 @@ impl Default for ModuleRegistry {
     // custom root.
     let dir = deno_dir::DenoDir::new(None).unwrap();
     let location = dir.root.join("registries");
-    Self::new(&location)
+    Self::new(&location, None, None, None, None).unwrap()
   }
 }
 
 impl ModuleRegistry {
-  pub fn new(location: &Path) -> Self {
+  pub fn new(
+    location: &Path,
+    maybe_root_path: Option<PathBuf>,
+    maybe_ca_stores: Option<Vec<String>>,
+    maybe_ca_file: Option<String>,
+    unsafely_ignore_certificate_errors: Option<Vec<String>>,
+  ) -> Result<Self, AnyError> {
     let http_cache = HttpCache::new(location);
+    let root_cert_store = Some(get_root_cert_store(
+      maybe_root_path,
+      maybe_ca_stores,
+      maybe_ca_file,
+    )?);
     let mut file_fetcher = FileFetcher::new(
       http_cache,
       CacheSetting::RespectHeaders,
       true,
-      None,
+      root_cert_store,
       BlobStore::default(),
-      None,
-    )
-    .context("Error creating file fetcher in module registry.")
-    .unwrap();
+      unsafely_ignore_certificate_errors,
+    )?;
     file_fetcher.set_download_log_level(super::logging::lsp_log_level());
 
-    Self {
+    Ok(Self {
       origins: HashMap::new(),
       file_fetcher,
-    }
+    })
   }
 
   fn complete_literal(
@@ -1200,7 +1211,8 @@ mod tests {
     let _g = test_util::http_server();
     let temp_dir = TempDir::new().expect("could not create tmp");
     let location = temp_dir.path().join("registries");
-    let mut module_registry = ModuleRegistry::new(&location);
+    let mut module_registry =
+      ModuleRegistry::new(&location, None, None, None, None).unwrap();
     module_registry
       .enable("http://localhost:4545/")
       .await
@@ -1260,7 +1272,8 @@ mod tests {
     let _g = test_util::http_server();
     let temp_dir = TempDir::new().expect("could not create tmp");
     let location = temp_dir.path().join("registries");
-    let mut module_registry = ModuleRegistry::new(&location);
+    let mut module_registry =
+      ModuleRegistry::new(&location, None, None, None, None).unwrap();
     module_registry
       .enable("http://localhost:4545/")
       .await
@@ -1482,7 +1495,8 @@ mod tests {
     let _g = test_util::http_server();
     let temp_dir = TempDir::new().expect("could not create tmp");
     let location = temp_dir.path().join("registries");
-    let mut module_registry = ModuleRegistry::new(&location);
+    let mut module_registry =
+      ModuleRegistry::new(&location, None, None, None, None).unwrap();
     module_registry
       .enable_custom("http://localhost:4545/lsp/registries/deno-import-intellisense-key-first.json")
       .await
@@ -1551,7 +1565,8 @@ mod tests {
     let _g = test_util::http_server();
     let temp_dir = TempDir::new().expect("could not create tmp");
     let location = temp_dir.path().join("registries");
-    let mut module_registry = ModuleRegistry::new(&location);
+    let mut module_registry =
+      ModuleRegistry::new(&location, None, None, None, None).unwrap();
     module_registry
       .enable_custom("http://localhost:4545/lsp/registries/deno-import-intellisense-complex.json")
       .await
@@ -1601,7 +1616,8 @@ mod tests {
     let _g = test_util::http_server();
     let temp_dir = TempDir::new().expect("could not create tmp");
     let location = temp_dir.path().join("registries");
-    let module_registry = ModuleRegistry::new(&location);
+    let module_registry =
+      ModuleRegistry::new(&location, None, None, None, None).unwrap();
     let result = module_registry.check_origin("http://localhost:4545").await;
     assert!(result.is_ok());
   }
@@ -1611,7 +1627,8 @@ mod tests {
     let _g = test_util::http_server();
     let temp_dir = TempDir::new().expect("could not create tmp");
     let location = temp_dir.path().join("registries");
-    let module_registry = ModuleRegistry::new(&location);
+    let module_registry =
+      ModuleRegistry::new(&location, None, None, None, None).unwrap();
     let result = module_registry.check_origin("https://deno.com").await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();

--- a/cli/lsp/repl.rs
+++ b/cli/lsp/repl.rs
@@ -277,11 +277,14 @@ pub fn get_repl_workspace_settings() -> WorkspaceSettings {
   WorkspaceSettings {
     enable: true,
     config: None,
+    certificate_stores: None,
     cache: None,
     import_map: None,
     code_lens: Default::default(),
     internal_debug: false,
     lint: false,
+    tls_certificate: None,
+    unsafely_ignore_certificate_errors: None,
     unstable: false,
     suggest: CompletionSettings {
       complete_function_calls: false,

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -8,6 +8,7 @@ use crate::config_file::ConfigFile;
 use crate::config_file::MaybeImportsResult;
 use crate::deno_dir;
 use crate::emit;
+use crate::file_fetcher::get_root_cert_store;
 use crate::file_fetcher::CacheSetting;
 use crate::file_fetcher::FileFetcher;
 use crate::flags;
@@ -42,11 +43,7 @@ use deno_graph::source::LoadFuture;
 use deno_graph::source::Loader;
 use deno_graph::MediaType;
 use deno_runtime::deno_broadcast_channel::InMemoryBroadcastChannel;
-use deno_runtime::deno_tls::rustls;
 use deno_runtime::deno_tls::rustls::RootCertStore;
-use deno_runtime::deno_tls::rustls_native_certs::load_native_certs;
-use deno_runtime::deno_tls::rustls_pemfile;
-use deno_runtime::deno_tls::webpki_roots;
 use deno_runtime::deno_web::BlobStore;
 use deno_runtime::inspector_server::InspectorServer;
 use deno_runtime::permissions::Permissions;
@@ -54,8 +51,6 @@ use import_map::ImportMap;
 use log::warn;
 use std::collections::HashSet;
 use std::env;
-use std::fs::File;
-use std::io::BufReader;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -101,67 +96,11 @@ impl ProcState {
     let deps_cache_location = dir.root.join("deps");
     let http_cache = http_cache::HttpCache::new(&deps_cache_location);
 
-    let mut root_cert_store = RootCertStore::empty();
-    let ca_stores: Vec<String> = flags
-      .ca_stores
-      .clone()
-      .or_else(|| {
-        let env_ca_store = env::var("DENO_TLS_CA_STORE").ok()?;
-        Some(
-          env_ca_store
-            .split(',')
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect(),
-        )
-      })
-      .unwrap_or_else(|| vec!["mozilla".to_string()]);
-
-    for store in ca_stores.iter() {
-      match store.as_str() {
-        "mozilla" => {
-          root_cert_store.add_server_trust_anchors(
-            webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
-              rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-              )
-            }),
-          );
-        }
-        "system" => {
-          let roots =
-            load_native_certs().expect("could not load platform certs");
-          for root in roots {
-            root_cert_store
-              .add(&rustls::Certificate(root.0))
-              .expect("Failed to add platform cert to root cert store");
-          }
-        }
-        _ => {
-          return Err(anyhow!("Unknown certificate store \"{}\" specified (allowed: \"system,mozilla\")", store));
-        }
-      }
-    }
-
-    let ca_file = flags.ca_file.clone().or_else(|| env::var("DENO_CERT").ok());
-    if let Some(ca_file) = ca_file {
-      let certfile = File::open(&ca_file)?;
-      let mut reader = BufReader::new(certfile);
-
-      match rustls_pemfile::certs(&mut reader) {
-        Ok(certs) => {
-          root_cert_store.add_parsable_certificates(&certs);
-        }
-        Err(e) => {
-          return Err(anyhow!(
-            "Unable to add pem file to certificate store: {}",
-            e
-          ));
-        }
-      }
-    }
+    let root_cert_store = get_root_cert_store(
+      None,
+      flags.ca_stores.clone(),
+      flags.ca_file.clone(),
+    )?;
 
     if let Some(insecure_allowlist) =
       flags.unsafely_ignore_certificate_errors.as_ref()

--- a/cli/tests/testdata/lsp/did_open_params_tls_cert.json
+++ b/cli/tests/testdata/lsp/did_open_params_tls_cert.json
@@ -1,0 +1,8 @@
+{
+  "textDocument": {
+    "uri": "file:///a/file.ts",
+    "languageId": "typescript",
+    "version": 1,
+    "text": "import * as a from \"https://localhost:5545/xTypeScriptTypes.js\";\n// @deno-types=\"https://localhost:5545/type_definitions/foo.d.ts\"\nimport * as b from \"https://localhost:5545/type_definitions/foo.js\";\nimport * as c from \"https://localhost:5545/subdir/type_reference.js\";\nimport * as d from \"https://localhost:5545/subdir/mod1.ts\";\nimport * as e from \"data:application/typescript;base64,ZXhwb3J0IGNvbnN0IGEgPSAiYSI7CgpleHBvcnQgZW51bSBBIHsKICBBLAogIEIsCiAgQywKfQo=\";\nimport * as f from \"./file_01.ts\";\nimport * as g from \"http://localhost:4545/x/a/mod.ts\";\n\nconsole.log(a, b, c, d, e, f, g);\n"
+  }
+}

--- a/cli/tests/testdata/lsp/initialize_params_tls_cert.json
+++ b/cli/tests/testdata/lsp/initialize_params_tls_cert.json
@@ -23,10 +23,13 @@
       "names": true,
       "paths": true,
       "imports": {
-        "hosts": {}
+        "hosts": {
+          "https://localhost:5545": true,
+          "http://localhost:4545": true
+        }
       }
     },
-    "tlsCertificate": null,
+    "tlsCertificate": "tls/RootCA.pem",
     "unsafelyIgnoreCertificateErrors": null,
     "unstable": false
   },


### PR DESCRIPTION
Fixes #13437

The LSP now respects `DENO_CERT` and `DENO_TLS_CA_STORE` for registry suggestions and caching remote modules.

This also adds the options to the configuration of the LSP:

- `tlsCertificate` - this mirrors the `--cert` option (and overrides the `DENO_CERT` environment variable)
- `certificateStores` - this overrides the `DENO_TLS_CA_STORE` enviornment variable.
- `unsafelyIgnoreCertificateErrors` - this mirrors the `--unsafely-ignore-certificate-errors` command line option.

It extracts the creation logic for `RootCertStore` which is used by the file fetcher to the file fetcher which is now shared between `ProcState` and the lsp.