### PR TITLE
feat(unstable): add Deno.networkInterfaces

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -103,6 +103,36 @@ declare namespace Deno {
     swapFree: number;
   }
 
+  /** The information of the network interface */
+  export interface NetworkInterfaceInfo {
+    /** The network interface name */
+    name: string;
+    /** The IP protocol version */
+    family: "IPv4" | "IPv6";
+    /** The IP address */
+    address: string;
+    /** The netmask */
+    netmask: string;
+    /** The IPv6 scope id or null */
+    scopeid: number | null;
+    /** The CIDR range */
+    cidr: string;
+    /** The MAC address */
+    mac: string;
+  }
+
+  /** **Unstable** new API. yet to be vetted.
+   *
+   * Returns an array of the network interface informations.
+   *
+   * ```ts
+   * console.log(Deno.networkInterfaces());
+   * ```
+   *
+   * Requires `allow-env` permission.
+   */
+  export function networkInterfaces(): NetworkInterfaceInfo[];
+
   /** All possible types for interfacing with foreign functions */
   export type NativeType =
     | "void"

--- a/cli/tests/unit/network_interfaces_test.ts
+++ b/cli/tests/unit/network_interfaces_test.ts
@@ -1,0 +1,25 @@
+import { assert } from "./test_util.ts";
+
+Deno.test(
+  { name: "Deno.networkInterfaces", permissions: { env: true } },
+  () => {
+    const networkInterfaces = Deno.networkInterfaces();
+    assert(Array.isArray(networkInterfaces));
+    assert(networkInterfaces.length > 0);
+    for (
+      const { name, family, address, netmask, scopeid, cidr, mac }
+        of networkInterfaces
+    ) {
+      assert(typeof name === "string");
+      assert(family === "IPv4" || family === "IPv6");
+      assert(typeof address === "string");
+      assert(typeof netmask === "string");
+      assert(
+        (family === "IPv6" && typeof scopeid === "number") ||
+          (family === "IPv4" && scopeid === null),
+      );
+      assert(typeof cidr === "string");
+      assert(typeof mac === "string");
+    }
+  },
+);

--- a/runtime/js/30_os.js
+++ b/runtime/js/30_os.js
@@ -24,6 +24,10 @@
     return core.opSync("op_system_memory_info");
   }
 
+  function networkInterfaces() {
+    return core.opSync("op_network_interfaces");
+  }
+
   // This is an internal only method used by the test harness to override the
   // behavior of exit when the exit sanitizer is enabled.
   let exitHandler = null;
@@ -89,5 +93,6 @@
     systemMemoryInfo,
     hostname,
     loadavg,
+    networkInterfaces,
   };
 })(this);

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -121,6 +121,7 @@
     hostname: __bootstrap.os.hostname,
     osRelease: __bootstrap.os.osRelease,
     systemMemoryInfo: __bootstrap.os.systemMemoryInfo,
+    networkInterfaces: __bootstrap.os.networkInterfaces,
     applySourceMap: __bootstrap.errorStack.opApplySourceMap,
     formatDiagnostics: __bootstrap.errorStack.opFormatDiagnostics,
     sleepSync: __bootstrap.timers.sleepSync,


### PR DESCRIPTION
This PR adds an unstable new API `Deno.networkInterfaces` which returns an array of network interface informations.

closes #8137 