### PR TITLE
refactor(lsp): Documents - combine duplicate exists methods

### DIFF
--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -146,7 +146,7 @@ pub(crate) async fn get_import_completions(
     };
     let maybe_list = module_registries
       .get_completions(&text, offset, &range, |specifier| {
-        documents.contains_specifier(specifier)
+        documents.exists(specifier)
       })
       .await;
     let list = maybe_list.unwrap_or_else(|| lsp::CompletionList {

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2379,10 +2379,7 @@ fn op_exists(state: &mut State, args: SpecifierArgs) -> Result<bool, AnyError> {
   // challenges, opening a single document in the editor causes some 3k worth
   // of op_exists requests... :omg:
   let specifier = state.normalize_specifier(args.specifier)?;
-  let result = state
-    .state_snapshot
-    .documents
-    .contains_specifier(&specifier);
+  let result = state.state_snapshot.documents.exists(&specifier);
   Ok(result)
 }
 

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2379,7 +2379,10 @@ fn op_exists(state: &mut State, args: SpecifierArgs) -> Result<bool, AnyError> {
   // challenges, opening a single document in the editor causes some 3k worth
   // of op_exists requests... :omg:
   let specifier = state.normalize_specifier(args.specifier)?;
-  let result = state.state_snapshot.documents.exists(&specifier);
+  let result = state
+    .state_snapshot
+    .documents
+    .contains_specifier(&specifier);
   Ok(result)
 }
 


### PR DESCRIPTION
`Document.exists` was added in #13473, but we already have a method for doing this. This changes combines the two methods and uses the new functionality.