### PR TITLE
docs: fix markdown error in sleepSync jsdoc

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -953,7 +953,7 @@ declare namespace Deno {
     mtime: number | Date,
   ): Promise<void>;
 
-  /** *UNSTABLE**: new API, yet to be vetted.
+  /** **UNSTABLE**: new API, yet to be vetted.
    *
    * SleepSync puts the main thread to sleep synchronously for a given amount of
    * time in milliseconds.


### PR DESCRIPTION
sleepSync jsdoc has an error in markdown syntax. This affects the rendered doc in doc.deno.land https://doc.deno.land/deno/unstable/~/Deno.sleepSync