### PR TITLE
fix(runtime): Replace instanceof with ObjectPrototypeIsPrototypeOf in Runtime

### DIFF
--- a/runtime/js/06_util.js
+++ b/runtime/js/06_util.js
@@ -93,7 +93,7 @@
   }
 
   function pathFromURL(pathOrUrl) {
-    if (pathOrUrl instanceof URL) {
+    if (ObjectPrototypeIsPrototypeOf(URL, pathOrUrl)) {
       if (pathOrUrl.protocol != "file:") {
         throw new TypeError("Must be a file URL.");
       }

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -199,7 +199,7 @@
         const event = new MessageEvent("message", {
           cancelable: false,
           data: message,
-          ports: transferables.filter((t) => t instanceof MessagePort),
+          ports: transferables.filter((t) => ObjectPrototypeIsPrototypeOf(MessagePort, t)),
         });
         this.dispatchEvent(event);
       }

--- a/runtime/js/30_fs.js
+++ b/runtime/js/30_fs.js
@@ -277,7 +277,7 @@
   }
 
   function toUnixTimeFromEpoch(value) {
-    if (value instanceof Date) {
+    if (ObjectPrototypeIsPrototypeOf(Date, value)) {
       const time = value.valueOf();
       const seconds = MathTrunc(time / 1e3);
       const nanoseconds = MathTrunc(time - (seconds * 1e3)) * 1e6;

--- a/runtime/js/40_fs_events.js
+++ b/runtime/js/40_fs_events.js
@@ -28,9 +28,9 @@
           ? { value, done: false }
           : { value: undefined, done: true };
       } catch (error) {
-        if (error instanceof errors.BadResource) {
+        if (ObjectPrototypeIsPrototypeOf(errors.BadResource, error)) {
           return { value: undefined, done: true };
-        } else if (error instanceof errors.Interrupted) {
+        } else if (ObjectPrototypeIsPrototypeOf(errors.Interrupted, error)) {
           return { value: undefined, done: true };
         }
         throw error;

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -375,7 +375,7 @@ finishing test case.`;
   }
 
   function formatError(error) {
-    if (error instanceof AggregateError) {
+    if (ObjectPrototypeIsPrototypeOf(AggregateError, error)) {
       const message = error
         .errors
         .map((error) =>
@@ -829,7 +829,7 @@ finishing test case.`;
         /** @returns {TestStepDefinition} */
         function getDefinition() {
           if (typeof nameOrTestDefinition === "string") {
-            if (!(fn instanceof Function)) {
+            if (!(ObjectPrototypeIsPrototypeOf(Function, fn))) {
               throw new TypeError("Expected function for second argument.");
             }
             return {

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -141,7 +141,7 @@ delete Object.prototype.__proto__;
       const msgEvent = new MessageEvent("message", {
         cancelable: false,
         data: message,
-        ports: transferables.filter((t) => t instanceof MessagePort),
+        ports: transferables.filter((t) => ObjectPrototypeIsPrototypeOf(MessagePort, t)),
       });
 
       try {


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

- Replace `instanceof` in runtime code with `ObjectPrototypeIsPrototypeOf`

Fixes #13255 
