### PR TITLE
chore: Upgrade Tokio to 1.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4294,11 +4294,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.14.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+checksum = "95e99d373042c30406d317cfc5bfad7b5d604bdd31dab72cf8739abebaa64aee"
 dependencies = [
- "autocfg 1.0.1",
  "bytes",
  "libc",
  "memchr",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -90,7 +90,7 @@ sourcemap = "=6.0.1"
 tempfile = "=3.2.0"
 text-size = "=1.1.0"
 text_lines = "=0.4.1"
-tokio = { version = "=1.14", features = ["full"] }
+tokio = { version = "=1.16", features = ["full"] }
 tokio-util = "=0.6.9"
 typed-arena = "2.0.1"
 uuid = { version = "=0.8.2", features = ["v4", "serde"] }


### PR DESCRIPTION
Tokio 1.16.0 has been released. https://github.com/tokio-rs/tokio/releases/tag/tokio-1.16.0

The release includes improvements to the multi-threaded scheduler that
can increase throughput by up to 20% in some cases.

See more detail: https://github.com/tokio-rs/tokio/pull/4383