### PR TITLE
perf(lsp): cancellable TS diagnostics

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -255,7 +255,7 @@ delete Object.prototype.__proto__;
    * @implements {ts.CancellationToken}
    */
   class ThrottledCancellationToken {
-    #lastCheckTimeMs = Date.now();
+    #lastCheckTimeMs = 0;
 
     isCancellationRequested() {
       const timeMs = Date.now();

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -698,6 +698,10 @@ delete Object.prototype.__proto__;
           /** @type {Record<string, any[]>} */
           const diagnosticMap = {};
           for (const specifier of request.specifiers) {
+            if (core.opSync("op_is_cancelled", {})) {
+              break;
+            }
+
             diagnosticMap[specifier] = fromTypeScriptDiagnostic([
               ...languageService.getSemanticDiagnostics(specifier),
               ...languageService.getSuggestionDiagnostics(specifier),

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -242,6 +242,39 @@ delete Object.prototype.__proto__;
     }
   }
 
+  /** Error thrown on cancellation. */
+  class OperationCanceledError extends Error {
+  }
+
+  /**
+   * Inspired by ThrottledCancellationToken in ts server.
+   *
+   * We don't want to continually call back into Rust and so
+   * we throttle cancellation checks to only occur once
+   * in a while.
+   * @implements {ts.CancellationToken}
+   */
+  class ThrottledCancellationToken {
+    #lastCheckTimeMs = Date.now();
+
+    isCancellationRequested() {
+      const timeMs = Date.now();
+      // TypeScript uses 20ms
+      if ((timeMs - this.#lastCheckTimeMs) < 20) {
+        return false;
+      }
+
+      this.#lastCheckTimeMs = timeMs;
+      return core.opSync("op_is_cancelled", {});
+    }
+
+    throwIfCancellationRequested() {
+      if (this.isCancellationRequested()) {
+        throw new OperationCanceledError();
+      }
+    }
+  }
+
   /** @type {ts.CompilerOptions} */
   let compilationSettings = {};
 
@@ -261,6 +294,10 @@ delete Object.prototype.__proto__;
     readFile(specifier) {
       debug(`host.readFile("${specifier}")`);
       return core.opSync("op_load", { specifier }).data;
+    },
+    getCancellationToken() {
+      // createLanguageService will call this immediately and cache it
+      return new ThrottledCancellationToken();
     },
     getSourceFile(
       specifier,
@@ -698,10 +735,6 @@ delete Object.prototype.__proto__;
           /** @type {Record<string, any[]>} */
           const diagnosticMap = {};
           for (const specifier of request.specifiers) {
-            if (core.opSync("op_is_cancelled", {})) {
-              break;
-            }
-
             diagnosticMap[specifier] = fromTypeScriptDiagnostic([
               ...languageService.getSemanticDiagnostics(specifier),
               ...languageService.getSuggestionDiagnostics(specifier),
@@ -710,10 +743,12 @@ delete Object.prototype.__proto__;
           }
           return respond(id, diagnosticMap);
         } catch (e) {
-          if ("stack" in e) {
-            error(e.stack);
-          } else {
-            error(e);
+          if (!(e instanceof OperationCanceledError)) {
+            if ("stack" in e) {
+              error(e.stack);
+            } else {
+              error(e);
+            }
           }
           return respond(id, {});
         }


### PR DESCRIPTION
Adds the ability to cancel generating TypeScript diagnostics while they're being generated. I'm not sure how to test this to see what kind of improvement this may bring, but I assume it will be helpful.