### PR TITLE
fix(cli/dts/webgpu): make GPUBlendComponent properties optional

### DIFF
--- a/cli/dts/lib.deno_webgpu.d.ts
+++ b/cli/dts/lib.deno_webgpu.d.ts
@@ -596,9 +596,9 @@ declare class GPUColorWrite {
 }
 
 declare interface GPUBlendComponent {
-  operation: GPUBlendOperation;
-  srcFactor: GPUBlendFactor;
-  dstFactor: GPUBlendFactor;
+  operation?: GPUBlendOperation;
+  srcFactor?: GPUBlendFactor;
+  dstFactor?: GPUBlendFactor;
 }
 
 declare type GPUBlendFactor =


### PR DESCRIPTION
https://github.com/denoland/deno/blob/bd5d445da98435d03e2f6a6f6d5478ff623bd714/ext/webgpu/webgpu.idl#L628-L632