### PR TITLE
fix: don't crash when $HOME is a relative path

### DIFF
--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -25,10 +25,10 @@ impl DenoDir {
       // We use the OS cache dir because all files deno writes are cache files
       // Once that changes we need to start using different roots if DENO_DIR
       // is not set, and keep a single one if it is.
-      cache_dir.join("deno")
+      cache_dir.canonicalize()?.join("deno")
     } else if let Some(home_dir) = dirs::home_dir() {
       // fallback path
-      home_dir.join(".deno")
+      home_dir.canonicalize()?.join(".deno")
     } else {
       panic!("Could not set the Deno root directory")
     };

--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -16,22 +16,23 @@ pub struct DenoDir {
 impl DenoDir {
   pub fn new(maybe_custom_root: Option<PathBuf>) -> std::io::Result<Self> {
     let root: PathBuf = if let Some(root) = maybe_custom_root {
-      if root.is_absolute() {
-        root
-      } else {
-        std::env::current_dir()?.join(root)
-      }
+      root
     } else if let Some(cache_dir) = dirs::cache_dir() {
       // We use the OS cache dir because all files deno writes are cache files
       // Once that changes we need to start using different roots if DENO_DIR
       // is not set, and keep a single one if it is.
-      cache_dir.canonicalize()?.join("deno")
+      cache_dir.join("deno")
     } else if let Some(home_dir) = dirs::home_dir() {
       // fallback path
-      home_dir.canonicalize()?.join(".deno")
+      home_dir.join(".deno")
     } else {
       panic!("Could not set the Deno root directory")
     };
+    if root.is_absolute() {
+      root
+    } else {
+      std::env::current_dir()?.join(root)
+    }
     assert!(root.is_absolute());
     let gen_path = root.join("gen");
 

--- a/cli/deno_dir.rs
+++ b/cli/deno_dir.rs
@@ -28,11 +28,11 @@ impl DenoDir {
     } else {
       panic!("Could not set the Deno root directory")
     };
-    if root.is_absolute() {
+    let root = if root.is_absolute() {
       root
     } else {
       std::env::current_dir()?.join(root)
-    }
+    };
     assert!(root.is_absolute());
     let gen_path = root.join("gen");
 

--- a/cli/tests/integration/cache_tests.rs
+++ b/cli/tests/integration/cache_tests.rs
@@ -1,8 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 use crate::itest;
-use tempfile::TempDir;
-use test_util as util;
 
 itest!(_036_import_map_fetch {
   args:
@@ -56,6 +54,9 @@ itest!(ignore_require {
 #[cfg(target_os = "linux")]
 #[test]
 fn relative_home_dir() {
+  use tempfile::TempDir;
+  use test_util as util;
+
   let deno_dir = TempDir::new_in(util::testdata_path()).unwrap();
   let path = deno_dir.path().strip_prefix(util::testdata_path()).unwrap();
 


### PR DESCRIPTION
Canonicalize the cache/home dir before use in DenoDir.

Fixes #13561
