### PR TITLE
chore: improve error messages in CompressionStream

### DIFF
--- a/ext/web/14_compression.js
+++ b/ext/web/14_compression.js
@@ -35,7 +35,10 @@
 
       this.#transform = new TransformStream({
         transform(chunk, controller) {
-          // TODO(lucacasonato): convert chunk to BufferSource
+          chunk = webidl.converters.BufferSource(chunk, {
+            prefix,
+            context: "chunk",
+          });
           const output = core.opSync(
             "op_compression_write",
             rid,
@@ -81,7 +84,10 @@
 
       this.#transform = new TransformStream({
         transform(chunk, controller) {
-          // TODO(lucacasonato): convert chunk to BufferSource
+          chunk = webidl.converters.BufferSource(chunk, {
+            prefix,
+            context: "chunk",
+          });
           const output = core.opSync(
             "op_compression_write",
             rid,


### PR DESCRIPTION
This commit makes the error messages that one sees when passing
something other than a BufferSource to a (De)CompressionStream. The
WPT tests already pass, because they just check for error type
(TypeError), and not error message. A TypeError was already thrown for
invalid values via serde_v8.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
