### PR TITLE
feat(test): Allow timeout option for catching asynchronous long-running tests

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -157,6 +157,14 @@ declare namespace Deno {
     /** If at least one test has `only` set to true, only run tests that have
      * `only` set to true and fail the test suite. */
     only?: boolean;
+    /** Determines after how many millisseconds when the test should timeout.
+     *
+     * Please notice that Deno will not timeout tests during blocking synchronous
+     * operations.
+     *
+     * Defaults to 5000.
+     */
+    timeout?: number | null;
     /** Check that the number of async completed ops after the test is the same
      * as number of dispatched ops. Defaults to true. */
     sanitizeOps?: boolean;
@@ -362,6 +370,7 @@ declare namespace Deno {
   export function test(
     name: string,
     fn: (t: TestContext) => void | Promise<void>,
+    timeout?: number | null,
   ): void;
 
   /** Register a test which will be run when `deno test` is used on the command
@@ -382,7 +391,10 @@ declare namespace Deno {
    * });
    * ```
    */
-  export function test(fn: (t: TestContext) => void | Promise<void>): void;
+  export function test(
+    fn: (t: TestContext) => void | Promise<void>,
+    timeout?: number | null,
+  ): void;
 
   /** Register a test which will be run when `deno test` is used on the command
    * line and the containing module looks like a test module.

--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -227,6 +227,18 @@ itest!(aggregate_error {
   output: "test/aggregate_error.out",
 });
 
+itest!(async_timeout {
+  args: "test test/async_timeout.ts",
+  exit_code: 1,
+  output: "test/async_timeout.out",
+});
+
+itest!(async_timeout_not_leaking_without_sanitizer {
+  args: "test test/async_timeout_not_leaking_without_sanitizer.ts",
+  exit_code: 0,
+  output: "test/async_timeout_not_leaking_without_sanitizer.out",
+});
+
 itest!(steps_passing_steps {
   args: "test test/steps/passing_steps.ts",
   exit_code: 0,

--- a/cli/tests/testdata/test/async_timeout.out
+++ b/cli/tests/testdata/test/async_timeout.out
@@ -1,0 +1,21 @@
+Check [WILDCARD]/testdata/test/async_timeout.ts
+running 3 tests from [WILDCARD]/testdata/test/async_timeout.ts
+test test 1 ... ok ([WILDCARD])
+test test 2 ... FAILED ([WILDCARD])
+test test 3 ... ok ([WILDCARD])
+
+failures:
+
+test 2
+Error: Test took longer than the 5000ms timeout.
+    at deno:runtime/js/40_testing.js:1030:18
+    at Object.action (deno:ext/timers/01_timers.js:162:11)
+    at handleTimerMacrotask (deno:ext/timers/01_timers.js:79:12)
+
+failures:
+
+	test 2
+
+test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+error: Test failed

--- a/cli/tests/testdata/test/async_timeout.ts
+++ b/cli/tests/testdata/test/async_timeout.ts
@@ -1,0 +1,7 @@
+Deno.test("test 1", () => {});
+
+Deno.test("test 2", async () => {
+  await new Promise(() => {});
+});
+
+Deno.test("test 3", () => {});

--- a/cli/tests/testdata/test/async_timeout_not_leaking_without_sanitizer.out
+++ b/cli/tests/testdata/test/async_timeout_not_leaking_without_sanitizer.out
@@ -1,0 +1,7 @@
+Check [WILDCARD]/testdata/test/async_timeout_not_leaking_without_sanitizer.ts
+running 2 tests from [WILDCARD]/testdata/test/async_timeout_not_leaking_without_sanitizer.ts
+test will not rely on sanitizeOps to sanitize the test's timeout ... ok ([WILDCARD])
+test will pass because the previous test can still clear its own timeout without sanitizeOps ... ok ([WILDCARD])
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+

--- a/cli/tests/testdata/test/async_timeout_not_leaking_without_sanitizer.ts
+++ b/cli/tests/testdata/test/async_timeout_not_leaking_without_sanitizer.ts
@@ -1,0 +1,11 @@
+Deno.test({
+  name: "will not rely on sanitizeOps to sanitize the test's timeout",
+  fn: async () => {},
+  sanitizeOps: false,
+});
+
+Deno.test({
+  name:
+    "will pass because the previous test can still clear its own timeout without sanitizeOps",
+  fn: async () => {},
+});

--- a/cli/tests/unit/metrics_test.ts
+++ b/cli/tests/unit/metrics_test.ts
@@ -54,7 +54,7 @@ Deno.test(
 );
 
 Deno.test(
-  { permissions: { write: true } },
+  { permissions: { write: true }, timeout: null },
   async function metricsUpdatedIfNoResponseAsync() {
     const filename = Deno.makeTempDirSync() + "/test.txt";
 

--- a/cli/tests/unit/read_file_test.ts
+++ b/cli/tests/unit/read_file_test.ts
@@ -154,7 +154,7 @@ Deno.test(
 );
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  { permissions: { read: true, write: true }, timeout: null },
   async function readFileExtendedDuringRead() {
     // Write 128MB file
     const filename = Deno.makeTempDirSync() + "/test.txt";

--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -742,7 +742,7 @@ Deno.test(async function testECDH() {
   assertEquals(derivedKey.byteLength, 256 / 8);
 });
 
-Deno.test(async function testWrapKey() {
+Deno.test({ timeout: null }, async function testWrapKey() {
   // Test wrapKey
   const key = await crypto.subtle.generateKey(
     {

--- a/runtime/js/06_util.js
+++ b/runtime/js/06_util.js
@@ -146,6 +146,10 @@
     };
   }
 
+  function isAsyncFunction(fn) {
+    return fn.constructor.name === "AsyncFunction";
+  }
+
   window.__bootstrap.util = {
     log,
     setLogDebug,
@@ -157,5 +161,6 @@
     nonEnumerable,
     readOnly,
     getterOnly,
+    isAsyncFunction,
   };
 })(this);


### PR DESCRIPTION
# Summary

This PR closes #11133 by allowing users to specify a `timeout` for their tests.

One can specify a timeout in the following ways:

```ts
// Usual form: name, function, and timeout
Deno.test("Usual test form", () => {
  const x = 1 + 2;
  assertEquals(x, 3);
}, 5000);

// Compact form: named function, and timeout.
Deno.test(function helloWorld3() {
  const x = 1 + 2;
  assertEquals(x, 3);
}, 5000);

// Longer form: using an options object.
Deno.test({
  name: "hello world #2",
  timeout: 5000,
  fn: () => {
    const x = 1 + 2;
    assertEquals(x, 3);
  },
});
```

The timeout is always optional and defaults to `5000` ms.

⚠️ Please notice that this PR only addresses asynchronous timeouts, [as we discussed on Discord](https://github.com/denoland/deno/issues/11133#issuecomment-1008327698).

**We'll address timing-out synchronous tests in a separate PR as that require further changes, as described below**.


# Implementation details

> ☝️  Given this PR only addresses timing-out tests during asynchronous operations, most of the changes here are done on the JS side of things.

When a `timeout` option exists (and when dealing with an `AsyncFunction`), we'll wrap the testing function into a function that starts a timer using `setTimeout` and runs the test function. If that timer is due to execute before the testing function finishes, it'll throw an error.

Regardless of whether the test succeeds, once it's done, we'll clear the timer we've set up.

## How does this code behave with the sanitizers?

The `op` sanitizer will already wait for the cleared timer to resolve, as shown in the piece of code below. Therefore, we will not have a hanging `op` after the test finishes.

```ts
// Defer until next event loop turn - that way timeouts and intervals
// cleared can actually be removed from resource table, otherwise
// false positives may occur (https://github.com/denoland/deno/issues/4591)
await opSanitizerDelay();
``` 

We would, however, have problems if we have tests which do not have `sanitizeOps` turned on, because in that case we would not allow for the event loop to clear and the next test would start with a leaking op from the previous test (if the previous test was async).

Take the test file below as an example. In that file, without calling `sanitizeOps` after clearing the timeout timer, the second test would fail. It would fail because `sanitizeOps` wouldn't have been called, and thus the timer kicked by the test wouldn't be allowed to complete. Therefore, the timeout timer would "leak" to the next test.

```ts
// Without calling `sanitizeOps` after clearing the timeout timer, the second test fails

Deno.test({
  name: "would cause the timeout timer to leak",
  fn: async () => {},
  sanitizeOps: false,
});

Deno.test({
  name:
    "I would fail because the previous test didn't wait for ops to complete",
  fn: async () => {},
});
```

That's why I also had to call `opSanitizerDelay` after clearing the timeout. That call prevents the timer from leaking into the next test and causing it to fail in case it needs to sanitize ops. By the way, that behaviour is already checked by the `steps_passing_steps` test.

I also added an extra test to cover this case.


# Changes to existing tests

There were tests in which we were checking for a particular number of operations to match. In those tests, the operations would _not_ match if there wasn't a `timeout` explicitly defined for the test. Therefore, I had to make sure to pass `null` to those tests so that these test callbacks were not wrapped into the timeout function.


# Upcoming work

As previously mentioned, there are a few items I want to tackle once I get this PR merged in:

1. I would like to be able to timeout individual synchronous tests.
    For that, however, we'd have to do some significant refactoring in order to allow for the runner to execute each test in a separate thread. Without that, we would have to timeout entire files and thus not run any tests after the one which is performing blocking operations.
    An alternative suggestion was to simply alert users when a single test has taken more than the specified time to run and accept that no further tests would run.
    We could also simply rerun the same test file and skipped the test which was blocking the last time, but I think that could be confusing and would not lead to clean code/flow.
2. [I've seen we currently do not track `unrefed` ops](https://github.com/denoland/deno/blob/592b1fb911765802fd5d6cb774995f2617dec59c/core/ops_metrics.rs#L14-L20). Tracking those `ops` could yield benefits to this timeout flow because it allows us to `unref` the timer we're starting and then we can use that information in our sanitizer calculations.

Those two items are not necessary for now though. I just wanted to keep track of them somewhere.