### PR TITLE
feat(ext/http): add support for unix domain sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,7 @@ dependencies = [
  "deno_core",
  "deno_websocket",
  "hyper",
+ "percent-encoding",
  "ring",
  "serde",
  "tokio",

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -1156,10 +1156,10 @@ Deno.test(
       for await (const conn of listener) {
         const httpConn = Deno.serveHttp(conn);
         for await (const { request, respondWith } of httpConn) {
-          assertEquals(
-            new URL(request.url).pathname,
-            "/path/name",
-          );
+          const url = new URL(request.url);
+          assertEquals(url.protocol, "http+unix:");
+          assertEquals(decodeURIComponent(url.host), filePath);
+          assertEquals(url.pathname, "/path/name");
           await respondWith(new Response("", { headers: {} }));
           httpConn.close();
         }

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -1142,6 +1142,49 @@ Deno.test(
   },
 );
 
+// https://github.com/denoland/deno/pull/13628
+Deno.test(
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
+  async function httpServerOnUnixSocket() {
+    const filePath = Deno.makeTempFileSync();
+
+    const promise = (async () => {
+      const listener = Deno.listen({ path: filePath, transport: "unix" });
+      for await (const conn of listener) {
+        const httpConn = Deno.serveHttp(conn);
+        for await (const { request, respondWith } of httpConn) {
+          assertEquals(
+            new URL(request.url).pathname,
+            "/path/name",
+          );
+          await respondWith(new Response("", { headers: {} }));
+          httpConn.close();
+        }
+        break;
+      }
+    })();
+
+    // fetch() does not supports unix domain sockets yet https://github.com/denoland/deno/issues/8821
+    const conn = await Deno.connect({ path: filePath, transport: "unix" });
+    const encoder = new TextEncoder();
+    // The Host header must be present and empty if it is not a Internet host name (RFC2616, Section 14.23)
+    const body = `GET /path/name HTTP/1.1\r\nHost:\r\n\r\n`;
+    const writeResult = await conn.write(encoder.encode(body));
+    assertEquals(body.length, writeResult);
+
+    const resp = new Uint8Array(200);
+    const readResult = await conn.read(resp);
+    assertEquals(readResult, 115);
+
+    conn.close();
+
+    await promise;
+  },
+);
+
 function chunkedBodyReader(h: Headers, r: BufReader): Deno.Reader {
   // Based on https://tools.ietf.org/html/rfc2616#section-19.4.6
   const tp = new TextProtoReader(r);

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -19,6 +19,7 @@ bytes = "1"
 deno_core = { version = "0.118.0", path = "../../core" }
 deno_websocket = { version = "0.41.0", path = "../websocket" }
 hyper = { version = "0.14.9", features = ["server", "stream", "http1", "http2", "runtime"] }
+percent-encoding = "2.1.0"
 ring = "0.16.20"
 serde = { version = "1.0.129", features = ["derive"] }
 tokio = { version = "1.10.1", features = ["full"] }

--- a/runtime/ops/http.rs
+++ b/runtime/ops/http.rs
@@ -8,6 +8,7 @@ use deno_core::OpState;
 use deno_core::ResourceId;
 use deno_http::http_create_conn_resource;
 use deno_net::io::TcpStreamResource;
+use deno_net::io::UnixStreamResource;
 use deno_net::ops_tls::TlsStreamResource;
 
 pub fn init() -> Extension {
@@ -43,6 +44,19 @@ fn op_http_start(
     let tls_stream = read_half.reunite(write_half);
     let addr = tls_stream.get_ref().0.local_addr()?;
     return http_create_conn_resource(state, tls_stream, addr, "https");
+  }
+
+  #[cfg(unix)]
+  if let Ok(resource_rc) = state
+    .resource_table
+    .take::<UnixStreamResource>(tcp_stream_rid)
+  {
+    let resource = Rc::try_unwrap(resource_rc)
+      .expect("Only a single use of this resource should happen");
+    let (read_half, write_half) = resource.into_inner();
+    let unix_stream = read_half.reunite(write_half)?;
+    let addr = unix_stream.local_addr()?;
+    return http_create_conn_resource(state, unix_stream, addr, "http+unix");
   }
 
   Err(bad_resource_id())

--- a/runtime/ops/http.rs
+++ b/runtime/ops/http.rs
@@ -51,6 +51,8 @@ fn op_http_start(
     .resource_table
     .take::<UnixStreamResource>(tcp_stream_rid)
   {
+    super::check_unstable(state, "Deno.serveHttp");
+
     let resource = Rc::try_unwrap(resource_rc)
       .expect("Only a single use of this resource should happen");
     let (read_half, write_half) = resource.into_inner();


### PR DESCRIPTION
This adds support for unix domain sockets in ext/http (#13626). The primary change is replace `std::net::SocketAddr` with a custom enum so we can store the address of a unix domain socket. I have to make this type `pub` in order to refer to it in runtime/ops/http.rs .