### PR TITLE
feat(compiler): support data url

### DIFF
--- a/cli/tests/testdata/compiler_api_test.ts
+++ b/cli/tests/testdata/compiler_api_test.ts
@@ -46,6 +46,21 @@ Deno.test({
 });
 
 Deno.test({
+  name: "Deno.emit() - data url",
+  async fn() {
+    const data =
+      "data:application/javascript;base64,Y29uc29sZS5sb2coImhlbGxvIHdvcmxkIik7";
+    const { diagnostics, files, ignoredOptions, stats } = await Deno.emit(data);
+    assertEquals(diagnostics.length, 0);
+    assert(!ignoredOptions);
+    assertEquals(stats.length, 0);
+    const keys = Object.keys(files);
+    assertEquals(keys.length, 1);
+    assertEquals(keys[0], data);
+  },
+});
+
+Deno.test({
   name: "Deno.emit() - compiler options effects emit",
   async fn() {
     const { diagnostics, files, ignoredOptions, stats } = await Deno.emit(

--- a/cli/tests/testdata/compiler_api_test.ts
+++ b/cli/tests/testdata/compiler_api_test.ts
@@ -57,6 +57,7 @@ Deno.test({
     const keys = Object.keys(files);
     assertEquals(keys.length, 1);
     assertEquals(keys[0], data);
+    assertStringIncludes(files[keys[0]], 'console.log("hello world");');
   },
 });
 

--- a/runtime/js/40_compiler_api.js
+++ b/runtime/js/40_compiler_api.js
@@ -54,7 +54,7 @@
   function checkRelative(specifier) {
     return StringPrototypeMatch(
         specifier,
-        /^([\.\/\\]|https?:\/{2}|file:\/{2})/,
+        /^([\.\/\\]|https?:\/{2}|file:\/{2}|data:)/,
       )
       ? specifier
       : `./${specifier}`;


### PR DESCRIPTION
Noticed that `deno bundle` does seems to support data url:
```ts
PS> deno bundle "data:application/javascript;base64,Y29uc29sZS5sb2coImhlbGxvIHdvcmxkIik7"
Bundle data:application/javascript;base64,Y29uc29sZS5sb2coImhlbGxvIHdvcmxkIik7
// deno-fmt-ignore-file
// deno-lint-ignore-file
// This code was bundled using `deno bundle` and it's not recommended to edit it manually

console.log("hello world");
```

However when using it programmatically with `Deno.emit`, there is a `checkRelative` function which only support http(s)/file protocols, not the data one. It gets converted into a relative path instead of being passed as it.

Should close https://github.com/denoland/deno/issues/11141
