### PR TITLE
docs(ext/fetch): fix copy-paste errors in Request docs

### DIFF
--- a/ext/fetch/lib.deno_fetch.d.ts
+++ b/ext/fetch/lib.deno_fetch.d.ts
@@ -341,26 +341,26 @@ declare class Request implements Body {
   /** A simple getter used to expose a `ReadableStream` of the body contents. */
   readonly body: ReadableStream<Uint8Array> | null;
   /** Stores a `Boolean` that declares whether the body has been used in a
-   * response yet.
+   * request yet.
    */
   readonly bodyUsed: boolean;
-  /** Takes a `Response` stream and reads it to completion. It returns a promise
+  /** Takes a `Request` stream and reads it to completion. It returns a promise
    * that resolves with an `ArrayBuffer`.
    */
   arrayBuffer(): Promise<ArrayBuffer>;
-  /** Takes a `Response` stream and reads it to completion. It returns a promise
+  /** Takes a `Request` stream and reads it to completion. It returns a promise
    * that resolves with a `Blob`.
    */
   blob(): Promise<Blob>;
-  /** Takes a `Response` stream and reads it to completion. It returns a promise
+  /** Takes a `Request` stream and reads it to completion. It returns a promise
    * that resolves with a `FormData` object.
    */
   formData(): Promise<FormData>;
-  /** Takes a `Response` stream and reads it to completion. It returns a promise
+  /** Takes a `Request` stream and reads it to completion. It returns a promise
    * that resolves with the result of parsing the body text as JSON.
    */
   json(): Promise<any>;
-  /** Takes a `Response` stream and reads it to completion. It returns a promise
+  /** Takes a `Request` stream and reads it to completion. It returns a promise
    * that resolves with a `USVString` (text).
    */
   text(): Promise<string>;


### PR DESCRIPTION
The document of some methods in the `Request` object refers to `Response`, which I believe are copy-paste error (there are same methods in the `Response` object with identical doc string)