### PR TITLE
fix(ext/console): print circular ref indicator in cyan

### DIFF
--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -1189,7 +1189,7 @@
     if (circular !== undefined) {
       const index = MapPrototypeGet(circular, value);
       if (index !== undefined) {
-        refIndex = `<ref *${index}> `;
+        refIndex = cyan(`<ref *${index}> `);
       }
     }
 


### PR DESCRIPTION
This must have slipped in the previous PR