### PR TITLE
Revert "feat: prompt by default"

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -254,7 +254,7 @@ pub struct Flags {
   /// If true, a list of Node built-in modules will be injected into
   /// the import map.
   pub compat: bool,
-  pub no_prompt: bool,
+  pub prompt: bool,
   pub reload: bool,
   pub repl: bool,
   pub seed: Option<u64>,
@@ -403,7 +403,7 @@ impl Flags {
       allow_read: self.allow_read.clone(),
       allow_run: self.allow_run.clone(),
       allow_write: self.allow_write.clone(),
-      prompt: !self.no_prompt,
+      prompt: self.prompt,
     }
   }
 }
@@ -1558,13 +1558,10 @@ fn permission_args(app: App) -> App {
         .long("allow-all")
         .help("Allow all permissions"),
     )
-    .arg(Arg::new("prompt").long("prompt").help(
-      "deprecated: Fallback to prompt if required permission wasn't passed",
-    ))
     .arg(
-      Arg::new("no-prompt")
-        .long("no-prompt")
-        .help("Always throw if required permission wasn't passed"),
+      Arg::new("prompt")
+        .long("prompt")
+        .help("Fallback to prompt if required permission wasn't passed"),
     )
 }
 
@@ -2378,8 +2375,8 @@ fn permission_args_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     flags.allow_ffi = Some(vec![]);
     flags.allow_hrtime = true;
   }
-  if matches.is_present("no-prompt") {
-    flags.no_prompt = true;
+  if matches.is_present("prompt") {
+    flags.prompt = true;
   }
 }
 fn unsafely_ignore_certificate_errors_parse(

--- a/cli/tests/integration/mod.rs
+++ b/cli/tests/integration/mod.rs
@@ -1142,7 +1142,6 @@ fn js_unit_tests() {
     .arg("test")
     .arg("--unstable")
     .arg("--location=http://js-unit-tests/foo/bar")
-    .arg("--no-prompt")
     .arg("-A")
     .arg(util::tests_path().join("unit"))
     .spawn()

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -328,8 +328,8 @@ fn resolve_shim_data(
     executable_args.push("--cached-only".to_string());
   }
 
-  if flags.no_prompt {
-    executable_args.push("--no-prompt".to_string());
+  if flags.prompt {
+    executable_args.push("--prompt".to_string());
   }
 
   if !flags.v8_flags.is_empty() {
@@ -714,7 +714,7 @@ mod tests {
   fn install_prompt() {
     let shim_data = resolve_shim_data(
       &Flags {
-        no_prompt: true,
+        prompt: true,
         ..Flags::default()
       },
       &InstallFlags {
@@ -729,7 +729,7 @@ mod tests {
 
     assert_eq!(
       shim_data.args,
-      vec!["run", "--no-prompt", "http://localhost:4545/echo_server.ts",]
+      vec!["run", "--prompt", "http://localhost:4545/echo_server.ts",]
     );
   }
 

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -246,7 +246,7 @@ pub fn compile_to_runtime_flags(
       .unsafely_ignore_certificate_errors
       .clone(),
     no_remote: false,
-    no_prompt: flags.no_prompt,
+    prompt: flags.prompt,
     reload: false,
     repl: false,
     seed: flags.seed,


### PR DESCRIPTION
Reverts denoland/deno#13650

Calling `performance.now()` on a permissionless isolate causes a prompt to appear rather than to return a non-granular time like before. This needs to be fixed before re-landing.