### PR TITLE
chore: bump nix to 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags_serde_shim"
@@ -2447,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
@@ -3305,9 +3305,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "9.0.0"
+version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790487c3881a63489ae77126f57048b42d62d3b2bafbf37453ea19eedb6340d6"
+checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -3328,9 +3328,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline-derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688599bdab9f42105d0ae1494335a9ffafdeb7d36325e6b10fd4abc5829d6284"
+checksum = "bb35a55ab810b5c0fe31606fe9b47d1354e4dc519bec0a102655f78ea2b38057"
 dependencies = [
  "quote 1.0.14",
  "syn 1.0.85",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -82,8 +82,8 @@ pin-project = "=1.0.8"
 rand = { version = "=0.8.4", features = ["small_rng"] }
 regex = "=1.5.4"
 ring = "=0.16.20"
-rustyline = { version = "=9.0.0", default-features = false }
-rustyline-derive = "=0.5.0"
+rustyline = { version = "=9.1.2", default-features = false }
+rustyline-derive = "=0.6.0"
 semver-parser = "=0.10.2"
 serde = { version = "=1.0.133", features = ["derive"] }
 shell-escape = "=0.1.5"
@@ -112,7 +112,7 @@ trust-dns-client = "=0.20.3"
 trust-dns-server = "=0.20.3"
 
 [target.'cfg(unix)'.dev-dependencies]
-nix = "=0.22.1"
+nix = "=0.23.0"
 
 [package.metadata.winres]
 # This section defines the metadata that appears in the deno.exe PE header.

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -88,7 +88,7 @@ fwdansi = "1.1.0"
 winapi = { version = "0.3.9", features = ["commapi", "knownfolders", "mswsock", "objbase", "shlobj", "tlhelp32", "winbase", "winerror", "winsock2"] }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.22.1"
+nix = "=0.23.0"
 
 [dev-dependencies]
 # Used in benchmark


### PR DESCRIPTION
As advised by `cargo audit`

```
$ cargo audit
Crate:         nix
Version:       0.22.1
Title:         Out-of-bounds write in nix::unistd::getgrouplist
Date:          2021-09-27
ID:            RUSTSEC-2021-0119
URL:           https://rustsec.org/advisories/RUSTSEC-2021-0119
Solution:      Upgrade to ^0.20.2 OR ^0.21.2 OR ^0.22.2 OR >=0.23.0
Dependency tree:
nix 0.22.1
├── rustyline 9.0.0
│   └── deno 1.19.0
├── deno_runtime 0.45.0
│   └── deno 1.19.0
└── deno 1.19.0
```

I think we should also add a `actions-rs/audit-check` job in the CI workflow