### PR TITLE
docs: add description + code example to `structuredClone`, `CompressionStream`, `DecompressionStream`

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2910,11 +2910,13 @@ declare namespace Deno {
    * If `pid` is negative, the signal will be sent to the process group
    * identified by `pid`.
    *
-   *      const p = Deno.run({
-   *        cmd: ["sleep", "10000"]
-   *      });
+   * ```ts
+   * const p = Deno.run({
+   *   cmd: ["sleep", "10000"]
+   * });
    *
-   *      Deno.kill(p.pid, "SIGINT");
+   * Deno.kill(p.pid, "SIGINT");
+   * ```
    *
    * Requires `allow-run` permission. */
   export function kill(pid: number, signo: Signal): void;

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2135,22 +2135,24 @@ declare namespace Deno {
    * in the development of Deno. 'Ops', also called 'bindings', are the go-between
    * between Deno JavaScript and Deno Rust.
    *
-   *      > console.table(Deno.metrics())
-   *      ┌─────────────────────────┬────────┐
-   *      │         (index)         │ Values │
-   *      ├─────────────────────────┼────────┤
-   *      │      opsDispatched      │   3    │
-   *      │    opsDispatchedSync    │   2    │
-   *      │   opsDispatchedAsync    │   1    │
-   *      │ opsDispatchedAsyncUnref │   0    │
-   *      │      opsCompleted       │   3    │
-   *      │    opsCompletedSync     │   2    │
-   *      │    opsCompletedAsync    │   1    │
-   *      │ opsCompletedAsyncUnref  │   0    │
-   *      │    bytesSentControl     │   73   │
-   *      │      bytesSentData      │   0    │
-   *      │      bytesReceived      │  375   │
-   *      └─────────────────────────┴────────┘
+   * ```
+   * > console.table(Deno.metrics())
+   * ┌─────────────────────────┬────────┐
+   * │         (index)         │ Values │
+   * ├─────────────────────────┼────────┤
+   * │      opsDispatched      │   3    │
+   * │    opsDispatchedSync    │   2    │
+   * │   opsDispatchedAsync    │   1    │
+   * │ opsDispatchedAsyncUnref │   0    │
+   * │      opsCompleted       │   3    │
+   * │    opsCompletedSync     │   2    │
+   * │    opsCompletedAsync    │   1    │
+   * │ opsCompletedAsyncUnref  │   0    │
+   * │    bytesSentControl     │   73   │
+   * │      bytesSentData      │   0    │
+   * │      bytesReceived      │  375   │
+   * └─────────────────────────┴────────┘
+   * ```
    */
   export function metrics(): Metrics;
 
@@ -2910,13 +2912,16 @@ declare namespace Deno {
    * If `pid` is negative, the signal will be sent to the process group
    * identified by `pid`.
    *
-   *      const p = Deno.run({
-   *        cmd: ["sleep", "10000"]
-   *      });
+   * ```ts
+   * const p = Deno.run({
+   *    cmd: ["sleep", "10000"]
+   * });
    *
-   *      Deno.kill(p.pid, "SIGINT");
+   * Deno.kill(p.pid, "SIGINT");
+   * ```
    *
-   * Requires `allow-run` permission. */
+   * Requires `allow-run` permission.
+   */
   export function kill(pid: number, signo: Signal): void;
 
   /** The type of the resource record.

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2135,24 +2135,22 @@ declare namespace Deno {
    * in the development of Deno. 'Ops', also called 'bindings', are the go-between
    * between Deno JavaScript and Deno Rust.
    *
-   * ```
-   * > console.table(Deno.metrics())
-   * ┌─────────────────────────┬────────┐
-   * │         (index)         │ Values │
-   * ├─────────────────────────┼────────┤
-   * │      opsDispatched      │   3    │
-   * │    opsDispatchedSync    │   2    │
-   * │   opsDispatchedAsync    │   1    │
-   * │ opsDispatchedAsyncUnref │   0    │
-   * │      opsCompleted       │   3    │
-   * │    opsCompletedSync     │   2    │
-   * │    opsCompletedAsync    │   1    │
-   * │ opsCompletedAsyncUnref  │   0    │
-   * │    bytesSentControl     │   73   │
-   * │      bytesSentData      │   0    │
-   * │      bytesReceived      │  375   │
-   * └─────────────────────────┴────────┘
-   * ```
+   *      > console.table(Deno.metrics())
+   *      ┌─────────────────────────┬────────┐
+   *      │         (index)         │ Values │
+   *      ├─────────────────────────┼────────┤
+   *      │      opsDispatched      │   3    │
+   *      │    opsDispatchedSync    │   2    │
+   *      │   opsDispatchedAsync    │   1    │
+   *      │ opsDispatchedAsyncUnref │   0    │
+   *      │      opsCompleted       │   3    │
+   *      │    opsCompletedSync     │   2    │
+   *      │    opsCompletedAsync    │   1    │
+   *      │ opsCompletedAsyncUnref  │   0    │
+   *      │    bytesSentControl     │   73   │
+   *      │      bytesSentData      │   0    │
+   *      │      bytesReceived      │  375   │
+   *      └─────────────────────────┴────────┘
    */
   export function metrics(): Metrics;
 
@@ -2912,16 +2910,13 @@ declare namespace Deno {
    * If `pid` is negative, the signal will be sent to the process group
    * identified by `pid`.
    *
-   * ```ts
-   * const p = Deno.run({
-   *    cmd: ["sleep", "10000"]
-   * });
+   *      const p = Deno.run({
+   *        cmd: ["sleep", "10000"]
+   *      });
    *
-   * Deno.kill(p.pid, "SIGINT");
-   * ```
+   *      Deno.kill(p.pid, "SIGINT");
    *
-   * Requires `allow-run` permission.
-   */
+   * Requires `allow-run` permission. */
   export function kill(pid: number, signo: Signal): void;
 
   /** The type of the resource record.

--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -71,9 +71,11 @@ declare function prompt(message?: string, defaultValue?: string): string | null;
 /** Registers an event listener in the global scope, which will be called
  * synchronously whenever the event `type` is dispatched.
  *
- *     addEventListener('unload', () => { console.log('All finished!'); });
- *     ...
- *     dispatchEvent(new Event('unload'));
+ * ```ts
+ * addEventListener('unload', () => { console.log('All finished!'); });
+ * ...
+ * dispatchEvent(new Event('unload'));
+ * ```
  */
 declare function addEventListener(
   type: string,
@@ -83,9 +85,11 @@ declare function addEventListener(
 
 /** Remove a previously registered event listener from the global scope
  *
- *     const lstnr = () => { console.log('hello'); };
- *     addEventListener('load', lstnr);
- *     removeEventListener('load', lstnr);
+ * ```ts
+ * const lstnr = () => { console.log('hello'); };
+ * addEventListener('load', lstnr);
+ * removeEventListener('load', lstnr);
+ * ```
  */
 declare function removeEventListener(
   type: string,

--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -86,9 +86,9 @@ declare function addEventListener(
 /** Remove a previously registered event listener from the global scope
  *
  * ```ts
- * const lstnr = () => { console.log('hello'); };
- * addEventListener('load', lstnr);
- * removeEventListener('load', lstnr);
+ * const listener = () => { console.log('hello'); };
+ * addEventListener('load', listener);
+ * removeEventListener('load', listener);
  * ```
  */
 declare function removeEventListener(

--- a/ext/web/lib.deno_web.d.ts
+++ b/ext/web/lib.deno_web.d.ts
@@ -841,8 +841,8 @@ declare function structuredClone(
  * @example
  * ```ts
  * await Deno.stdin.readable
- * .pipeThrough(new CompressionStream("gzip"))
- * .pipeTo(Deno.stdout.writable);
+ *   .pipeThrough(new CompressionStream("gzip"))
+ *   .pipeTo(Deno.stdout.writable);
  * ```
  */
 declare class CompressionStream {
@@ -866,8 +866,8 @@ declare class CompressionStream {
  * const output = await Deno.create("./file.txt");
  *
  * await input.readable
- * .pipeThrough(new DecompressionStream("gzip"))
- * .pipeTo(output.writable);
+ *   .pipeThrough(new DecompressionStream("gzip"))
+ *   .pipeTo(output.writable);
  * ```
  */
 declare class DecompressionStream {

--- a/ext/web/lib.deno_web.d.ts
+++ b/ext/web/lib.deno_web.d.ts
@@ -846,7 +846,7 @@ declare function structuredClone(
  * ```
  */
 declare class CompressionStream {
-    /**
+  /**
    * Creates a new `CompressionStream` object which compresses a stream of data.
    *
    * Throws a `TypeError` if the format passed to the constructor is not supported.
@@ -871,7 +871,7 @@ declare class CompressionStream {
  * ```
  */
 declare class DecompressionStream {
-    /**
+  /**
    * Creates a new `DecompressionStream` object which decompresses a stream of data.
    *
    * Throws a `TypeError` if the format passed to the constructor is not supported.

--- a/ext/web/lib.deno_web.d.ts
+++ b/ext/web/lib.deno_web.d.ts
@@ -812,10 +812,13 @@ declare class MessagePort extends EventTarget {
 /**
  * Creates a deep copy of a given value using the structured clone algorithm.
  *
- * Unlike a shallow copy, a deep copy does not hold the same references as the source object, meaning its properties can be changed without affecting the source.
- * For more details, see [MDN](https://developer.mozilla.org/en-US/docs/Glossary/Deep_copy).
+ * Unlike a shallow copy, a deep copy does not hold the same references as the
+ * source object, meaning its properties can be changed without affecting the
+ * source. For more details, see
+ * [MDN](https://developer.mozilla.org/en-US/docs/Glossary/Deep_copy).
  *
- * Throws a `DataCloneError` if any part of the input value is not serializable.
+ * Throws a `DataCloneError` if any part of the input value is not
+ * serializable.
  *
  * @example
  * ```ts
@@ -826,7 +829,8 @@ declare class MessagePort extends EventTarget {
  * console.log(deepCopy.x, object.x); // 1 0
  *
  * const shallowCopy = object;
- * shallowCopy.x = 1; // shallowCopy.x is pointing to the same location in memory as object.x
+ * shallowCopy.x = 1;
+ * // shallowCopy.x is pointing to the same location in memory as object.x
  * console.log(shallowCopy.x, object.x); // 1 1
  * ```
  */
@@ -847,9 +851,11 @@ declare function structuredClone(
  */
 declare class CompressionStream {
   /**
-   * Creates a new `CompressionStream` object which compresses a stream of data.
+   * Creates a new `CompressionStream` object which compresses a stream of
+   * data.
    *
-   * Throws a `TypeError` if the format passed to the constructor is not supported.
+   * Throws a `TypeError` if the format passed to the constructor is not
+   * supported.
    */
   constructor(format: string);
 
@@ -872,9 +878,11 @@ declare class CompressionStream {
  */
 declare class DecompressionStream {
   /**
-   * Creates a new `DecompressionStream` object which decompresses a stream of data.
+   * Creates a new `DecompressionStream` object which decompresses a stream of
+   * data.
    *
-   * Throws a `TypeError` if the format passed to the constructor is not supported.
+   * Throws a `TypeError` if the format passed to the constructor is not
+   * supported.
    */
   constructor(format: string);
 

--- a/ext/web/lib.deno_web.d.ts
+++ b/ext/web/lib.deno_web.d.ts
@@ -167,13 +167,17 @@ declare class ProgressEvent<T extends EventTarget = EventTarget> extends Event {
 
 /** Decodes a string of data which has been encoded using base-64 encoding.
  *
- *     console.log(atob("aGVsbG8gd29ybGQ=")); // outputs 'hello world'
+ * ```
+ * console.log(atob("aGVsbG8gd29ybGQ=")); // outputs 'hello world'
+ * ```
  */
 declare function atob(s: string): string;
 
 /** Creates a base-64 ASCII encoded string from the input string.
  *
- *     console.log(btoa("hello world"));  // outputs "aGVsbG8gd29ybGQ="
+ * ```
+ * console.log(btoa("hello world"));  // outputs "aGVsbG8gd29ybGQ="
+ * ```
  */
 declare function btoa(s: string): string;
 
@@ -805,19 +809,73 @@ declare class MessagePort extends EventTarget {
   ): void;
 }
 
+/**
+ * Creates a deep copy of a given value using the structured clone algorithm.
+ *
+ * Unlike a shallow copy, a deep copy does not hold the same references as the source object, meaning its properties can be changed without affecting the source.
+ * For more details, see [MDN](https://developer.mozilla.org/en-US/docs/Glossary/Deep_copy).
+ *
+ * Throws a `DataCloneError` if any part of the input value is not serializable.
+ *
+ * @example
+ * ```ts
+ * const object = { x: 0, y: 1 };
+ *
+ * const deepCopy = structuredClone(object);
+ * deepCopy.x = 1;
+ * console.log(deepCopy.x, object.x); // 1 0
+ *
+ * const shallowCopy = object;
+ * shallowCopy.x = 1; // shallowCopy.x is pointing to the same location in memory as object.x
+ * console.log(shallowCopy.x, object.x); // 1 1
+ * ```
+ */
 declare function structuredClone(
   value: any,
   options?: StructuredSerializeOptions,
 ): any;
 
+/**
+ * An API for compressing a stream of data.
+ *
+ * @example
+ * ```ts
+ * await Deno.stdin.readable
+ * .pipeThrough(new CompressionStream("gzip"))
+ * .pipeTo(Deno.stdout.writable);
+ * ```
+ */
 declare class CompressionStream {
+    /**
+   * Creates a new `CompressionStream` object which compresses a stream of data.
+   *
+   * Throws a `TypeError` if the format passed to the constructor is not supported.
+   */
   constructor(format: string);
 
   readonly readable: ReadableStream<Uint8Array>;
   readonly writable: WritableStream<Uint8Array>;
 }
 
+/**
+ * An API for decompressing a stream of data.
+ *
+ * @example
+ * ```ts
+ * const input = await Deno.open("./file.txt.gz");
+ * const output = await Deno.create("./file.txt");
+ *
+ * await input.readable
+ * .pipeThrough(new DecompressionStream("gzip"))
+ * .pipeTo(output.writable);
+ * ```
+ */
 declare class DecompressionStream {
+    /**
+   * Creates a new `DecompressionStream` object which decompresses a stream of data.
+   *
+   * Throws a `TypeError` if the format passed to the constructor is not supported.
+   */
   constructor(format: string);
 
   readonly readable: ReadableStream<Uint8Array>;

--- a/ext/websocket/lib.deno_websocket.d.ts
+++ b/ext/websocket/lib.deno_websocket.d.ts
@@ -37,7 +37,7 @@ interface WebSocketEventMap {
 /**
  * Provides the API for creating and managing a WebSocket connection to a server, as well as for sending and receiving data on the connection.
  *
- * If you are looking to create a WebSocket server, please take a look at Deno.upgradeWebSocket().
+ * If you are looking to create a WebSocket server, please take a look at `Deno.upgradeWebSocket()`.
  */
 declare class WebSocket extends EventTarget {
   constructor(url: string, protocols?: string | string[]);


### PR DESCRIPTION
Also this updates some more jsdoc that is not rendering well on hover in VS Code.

The compression examples are from the 1.19 release notes, thought it would be nice to add them in

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
