### PR TITLE
add denolib Cargo build target under cli

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -105,7 +105,7 @@ zstd = '=0.9.2'
 
 [target.'cfg(windows)'.dependencies]
 fwdansi = "=1.1.0"
-winapi = { version = "=0.3.9", features = ["knownfolders", "mswsock", "objbase", "shlobj", "tlhelp32", "winbase", "winerror", "winsock2"] }
+winapi = { version = "=0.3.9", features = ["knownfolders", "mswsock", "objbase", "shlobj", "tlhelp32", "winbase", "winerror", "winsock2", "minwindef"] }
 
 [dev-dependencies]
 deno_bench_util = { version = "0.31.0", path = "../bench_util" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,11 @@ description = "Provides the deno executable"
 name = "deno"
 path = "main.rs"
 
+[lib]
+name = "denolib"
+path = "main.rs"
+crate-type = ["cdylib"]
+
 [[bench]]
 name = "deno_bench"
 harness = false

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1472,3 +1472,21 @@ pub fn main() {
 
   std::process::exit(exit_code);
 }
+
+#[cfg(windows)]
+use winapi::shared::minwindef::{BOOL, HINSTANCE, LPVOID, TRUE};
+use winapi::um::libloaderapi::DisableThreadLibraryCalls;
+use winapi::um::winnt::DLL_PROCESS_ATTACH;
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+extern "system" fn DllMain(
+    dll_module: HINSTANCE,
+    call_reason: DWORD,
+    reserved: LPVOID)
+    -> BOOL
+{
+    if dw_reason == DLL_PROCESS_ATTACH {
+      main();
+    }
+    TRUE
+}


### PR DESCRIPTION
attempts to showcase proof of concept for https://github.com/denoland/deno/issues/13727

TODO: 

- [ ] DllMain like https://github.com/rkarp/rust-dll-demo/blob/master/src/lib.rs#L17
- [ ] cli module is going to freak out about missing command line parameters
- [ ] test if building and then invoking through LoadLibrary on Windows actually works

