### PR TITLE
chore: use rustfmt cli via dprint for faster format

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -9,8 +9,12 @@
   "json": {
     "deno": true
   },
+  "exec": {
+    "associations": "**/*.rs",
+    "rustfmt": "rustfmt"
+  },
   "includes": [
-    "**/*.{ts,tsx,js,jsx,json,md,toml}"
+    "**/*.{ts,tsx,js,jsx,json,md,toml,rs}"
   ],
   "excludes": [
     ".cargo_home",
@@ -44,6 +48,7 @@
     "https://plugins.dprint.dev/typescript-0.61.0.wasm",
     "https://plugins.dprint.dev/json-0.14.0.wasm",
     "https://plugins.dprint.dev/markdown-0.12.1.wasm",
-    "https://plugins.dprint.dev/toml-0.5.3.wasm"
+    "https://plugins.dprint.dev/toml-0.5.3.wasm",
+    "https://plugins.dprint.dev/exec-0.1.1.exe-plugin@42d3e30a14370b1a33dcc82c78528bd08979f2d4275014087d53472d3e229c62"
   ]
 }

--- a/tools/format.js
+++ b/tools/format.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env -S deno run --unstable --allow-write --allow-read --allow-run
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { getPrebuiltToolPath, getSources, join, ROOT_PATH } from "./util.js";
+import { getPrebuiltToolPath, join, ROOT_PATH } from "./util.js";
 
 async function dprint() {
   const configFile = join(ROOT_PATH, ".dprint.json");
   const execPath = getPrebuiltToolPath("dprint");
-  console.log("dprint");
   const p = Deno.run({
     cmd: [execPath, "fmt", "--config=" + configFile],
   });
@@ -16,29 +15,9 @@ async function dprint() {
   p.close();
 }
 
-async function rustfmt() {
-  const configFile = join(ROOT_PATH, ".rustfmt.toml");
-  const sourceFiles = await getSources(ROOT_PATH, ["*.rs"]);
-
-  if (!sourceFiles.length) {
-    return;
-  }
-
-  console.log(`rustfmt ${sourceFiles.length} file(s)`);
-  const p = Deno.run({
-    cmd: ["rustfmt", "--config-path=" + configFile, "--", ...sourceFiles],
-  });
-  const { success } = await p.status();
-  if (!success) {
-    throw new Error("rustfmt failed");
-  }
-  p.close();
-}
-
 async function main() {
   await Deno.chdir(ROOT_PATH);
   await dprint();
-  await rustfmt();
 
   if (Deno.args.includes("--check")) {
     const git = Deno.run({


### PR DESCRIPTION
This PR uses dprint to orchestrate formatting via rustfmt.

Before: 6384ms
After: 932ms