### PR TITLE
feat(ext/net): support cert, key options in listenTls

### DIFF
--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -15,6 +15,9 @@ import { TextProtoReader } from "../../../test_util/std/textproto/mod.ts";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+const cert = await Deno.readTextFile("cli/tests/testdata/tls/localhost.crt");
+const key = await Deno.readTextFile("cli/tests/testdata/tls/localhost.key");
+const caCerts = [await Deno.readTextFile("cli/tests/testdata/tls/RootCA.pem")];
 
 async function sleep(msec: number) {
   await new Promise((res, _rej) => setTimeout(res, msec));
@@ -184,11 +187,60 @@ Deno.test(
       },
     );
 
-    const conn = await Deno.connectTls({
-      hostname,
-      port,
-      caCerts: [Deno.readTextFileSync("cli/tests/testdata/tls/RootCA.pem")],
-    });
+    const conn = await Deno.connectTls({ hostname, port, caCerts });
+    assert(conn.rid > 0);
+    const w = new BufWriter(conn);
+    const r = new BufReader(conn);
+    const body = `GET / HTTP/1.1\r\nHost: ${hostname}:${port}\r\n\r\n`;
+    const writeResult = await w.write(encoder.encode(body));
+    assertEquals(body.length, writeResult);
+    await w.flush();
+    const tpr = new TextProtoReader(r);
+    const statusLine = await tpr.readLine();
+    assert(statusLine !== null, `line must be read: ${String(statusLine)}`);
+    const m = statusLine.match(/^(.+?) (.+?) (.+?)$/);
+    assert(m !== null, "must be matched");
+    const [_, proto, status, ok] = m;
+    assertEquals(proto, "HTTP/1.1");
+    assertEquals(status, "200");
+    assertEquals(ok, "OK");
+    const headers = await tpr.readMIMEHeader();
+    assert(headers !== null);
+    const contentLength = parseInt(headers.get("content-length")!);
+    const bodyBuf = new Uint8Array(contentLength);
+    await r.readFull(bodyBuf);
+    assertEquals(decoder.decode(bodyBuf), "Hello World\n");
+    conn.close();
+    listener.close();
+    await resolvable;
+  },
+);
+Deno.test(
+  { permissions: { read: false, net: true } },
+  async function listenTlsWithCertAndKey() {
+    const resolvable = deferred();
+    const hostname = "localhost";
+    const port = 3500;
+
+    const listener = Deno.listenTls({ hostname, port, cert, key });
+
+    const response = encoder.encode(
+      "HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\nHello World\n",
+    );
+
+    listener.accept().then(
+      async (conn) => {
+        assert(conn.remoteAddr != null);
+        assert(conn.localAddr != null);
+        await conn.write(response);
+        setTimeout(() => {
+          conn.close();
+          resolvable.resolve();
+        }, 0);
+      },
+    );
+
+    const conn = await Deno.connectTls({ hostname, port, caCerts });
     assert(conn.rid > 0);
     const w = new BufWriter(conn);
     const r = new BufReader(conn);

--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -65,7 +65,9 @@
 
   function listenTls({
     port,
+    cert,
     certFile,
+    key,
     keyFile,
     hostname = "0.0.0.0",
     transport = "tcp",
@@ -73,7 +75,9 @@
   }) {
     const res = opListenTls({
       port,
+      cert,
       certFile,
+      key,
       keyFile,
       hostname,
       transport,

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -93,11 +93,21 @@ declare namespace Deno {
   ): Listener;
 
   export interface ListenTlsOptions extends ListenOptions {
+    /** Server private key in PEM format */
+    key?: string;
+    /** Cert chain in PEM format */
+    cert?: string;
     /** Path to a file containing a PEM formatted CA certificate. Requires
-     * `--allow-read`. */
-    certFile: string;
-    /** Server public key file. Requires `--allow-read`.*/
-    keyFile: string;
+     * `--allow-read`.
+     *
+     * @deprecated This option is deprecated and will be removed in Deno 2.0.
+     */
+    certFile?: string;
+    /** Server private key file. Requires `--allow-read`.
+     *
+     * @deprecated This option is deprecated and will be removed in Deno 2.0.
+     */
+    keyFile?: string;
 
     transport?: "tcp";
   }


### PR DESCRIPTION
This PR adds `cert: string` and `key: string` options to `Deno.listenTls` and deprecates `certFile` and `keyFile` options.

You can specify the cert and private key from any source now. The read permission is checked only when `certFile` or `keyFile` is specified

closes #12639