### PR TITLE
refactor: remove dead code from lsp

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -14,7 +14,6 @@ use deno_core::anyhow::anyhow;
 use deno_core::error::custom_error;
 use deno_core::error::AnyError;
 use deno_core::serde::Deserialize;
-use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::ModuleSpecifier;
 use lspower::lsp;
@@ -60,18 +59,6 @@ static PREFERRED_FIXES: Lazy<HashMap<&'static str, (u32, bool)>> =
 
 static IMPORT_SPECIFIER_RE: Lazy<Regex> =
   Lazy::new(|| Regex::new(r#"\sfrom\s+["']([^"']*)["']"#).unwrap());
-
-static DENO_TYPES_RE: Lazy<Regex> = Lazy::new(|| {
-  Regex::new(r#"(?i)^\s*@deno-types\s*=\s*(?:["']([^"']+)["']|(\S+))"#).unwrap()
-});
-
-static TRIPLE_SLASH_REFERENCE_RE: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"(?i)^/\s*<reference\s.*?/>").unwrap());
-
-static PATH_REFERENCE_RE: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r#"(?i)\spath\s*=\s*["']([^"']*)["']"#).unwrap());
-static TYPES_REFERENCE_RE: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r#"(?i)\stypes\s*=\s*["']([^"']*)["']"#).unwrap());
 
 const SUPPORTED_EXTENSIONS: &[&str] = &[".ts", ".tsx", ".js", ".jsx", ".mjs"];
 

--- a/cli/lsp/client.rs
+++ b/cli/lsp/client.rs
@@ -7,7 +7,6 @@ use deno_core::anyhow::bail;
 use deno_core::error::AnyError;
 use deno_core::futures::future;
 use deno_core::serde_json;
-use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use lspower::lsp;
 use lspower::lsp::ConfigurationItem;

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -3,7 +3,6 @@
 use super::client::Client;
 use super::config::ConfigSnapshot;
 use super::documents::Documents;
-use super::language_server;
 use super::lsp_custom;
 use super::registries::ModuleRegistry;
 use super::tsc;
@@ -11,7 +10,6 @@ use super::tsc;
 use crate::fs_util::is_supported_ext;
 use crate::fs_util::specifier_to_file_path;
 
-use deno_ast::swc::common::BytePos;
 use deno_ast::LineAndColumnIndex;
 use deno_ast::SourceTextInfo;
 use deno_core::normalize_path;
@@ -105,7 +103,7 @@ fn to_narrow_lsp_range(
   });
   let text_bytes = text_info.text_str().as_bytes();
   let has_trailing_quote =
-    matches!(text_bytes[end_byte_index.0 as usize - 1], (b'"' | b'\''));
+    matches!(text_bytes[end_byte_index.0 as usize - 1], b'"' | b'\'');
   lsp::Range {
     start: lsp::Position {
       line: range.start.line as u32,

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -1,25 +1,16 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::anyhow::anyhow;
 use deno_core::error::AnyError;
-use deno_core::parking_lot::RwLock;
 use deno_core::serde::Deserialize;
 use deno_core::serde::Serialize;
 use deno_core::serde_json;
 use deno_core::serde_json::Value;
-use deno_core::url::Url;
 use deno_core::ModuleSpecifier;
-use deno_runtime::tokio_util::create_basic_runtime;
-use log::error;
 use lsp::WorkspaceFolder;
 use lspower::lsp;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::thread;
-use tokio::sync::mpsc;
-
-use super::client::Client;
 
 pub const SETTINGS_SECTION: &str = "deno";
 
@@ -219,11 +210,6 @@ impl ConfigSnapshot {
       self.settings.workspace.enable
     }
   }
-}
-
-enum ConfigRequest {
-  All,
-  Specifier(ModuleSpecifier, ModuleSpecifier),
 }
 
 #[derive(Debug, Clone)]

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -29,15 +29,11 @@ use deno_runtime::tokio_util::create_basic_runtime;
 use log::error;
 use lspower::lsp;
 use std::collections::HashMap;
-use std::collections::HashSet;
-use std::mem;
 use std::sync::Arc;
 use std::thread;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
-use tokio::time::sleep;
 use tokio::time::Duration;
-use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 pub(crate) type SnapshotForDiagnostics =
@@ -80,7 +76,7 @@ impl DiagnosticsPublisher {
       // in case they're not keep track of that
       let diagnostics_by_version =
         all_diagnostics.entry(specifier.clone()).or_default();
-      let mut version_diagnostics =
+      let version_diagnostics =
         diagnostics_by_version.entry(version).or_default();
       version_diagnostics.extend(diagnostics);
 
@@ -180,6 +176,7 @@ impl DiagnosticsServer {
     self.ts_diagnostics.invalidate_all();
   }
 
+  #[allow(unused_must_use)]
   pub(crate) fn start(&mut self) {
     let (tx, mut rx) = mpsc::unbounded_channel::<SnapshotForDiagnostics>();
     self.channel = Some(tx);
@@ -574,7 +571,6 @@ struct DiagnosticDataSpecifier {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct DiagnosticDataRedirect {
-  pub specifier: ModuleSpecifier,
   pub redirect: ModuleSpecifier,
 }
 
@@ -1033,7 +1029,6 @@ let c: number = "a";
 
   #[tokio::test]
   async fn test_cancelled_ts_diagnostics_request() {
-    let specifier = ModuleSpecifier::parse("file:///a.ts").unwrap();
     let (snapshot, _) = setup(&[(
       "file:///a.ts",
       r#"export let a: string = 5;"#,

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -23,7 +23,6 @@ use deno_core::error::AnyError;
 use deno_core::parking_lot::Mutex;
 use deno_core::url;
 use deno_core::ModuleSpecifier;
-use deno_graph::source::ResolveResponse;
 use deno_graph::Module;
 use deno_graph::Resolved;
 use lspower::lsp;
@@ -37,7 +36,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::SystemTime;
 
 static JS_HEADERS: Lazy<HashMap<String, String>> = Lazy::new(|| {
   ([(
@@ -547,32 +545,6 @@ pub(crate) fn to_lsp_range(range: &deno_graph::Range) -> lsp::Range {
       line: range.end.line as u32,
       character: range.end.character as u32,
     },
-  }
-}
-
-fn to_deno_graph_range(
-  specifier: &ModuleSpecifier,
-  maybe_range: Option<&lsp::Range>,
-) -> deno_graph::Range {
-  let specifier = specifier.clone();
-  if let Some(range) = maybe_range {
-    deno_graph::Range {
-      specifier,
-      start: deno_graph::Position {
-        line: range.start.line as usize,
-        character: range.start.character as usize,
-      },
-      end: deno_graph::Position {
-        line: range.end.line as usize,
-        character: range.end.character as usize,
-      },
-    }
-  } else {
-    deno_graph::Range {
-      specifier,
-      start: deno_graph::Position::zeroed(),
-      end: deno_graph::Position::zeroed(),
-    }
   }
 }
 

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -8,10 +8,8 @@ use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::ModuleSpecifier;
-use deno_graph::Resolved;
 use import_map::ImportMap;
 use log::error;
-use log::info;
 use log::warn;
 use lspower::jsonrpc::Error as LspError;
 use lspower::jsonrpc::Result as LspResult;
@@ -20,7 +18,6 @@ use lspower::lsp::*;
 use serde_json::from_value;
 use std::env;
 use std::path::PathBuf;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::fs;
 
@@ -34,7 +31,6 @@ use super::client::Client;
 use super::code_lens;
 use super::completions;
 use super::config::Config;
-use super::config::ConfigSnapshot;
 use super::config::SETTINGS_SECTION;
 use super::diagnostics;
 use super::diagnostics::DiagnosticsServer;
@@ -53,7 +49,6 @@ use super::registries::ModuleRegistry;
 use super::registries::ModuleRegistryOptions;
 use super::text;
 use super::tsc;
-use super::tsc::AssetDocument;
 use super::tsc::Assets;
 use super::tsc::AssetsSnapshot;
 use super::tsc::TsServer;
@@ -65,7 +60,6 @@ use crate::config_file::TsConfig;
 use crate::deno_dir;
 use crate::file_fetcher::get_source_from_data_url;
 use crate::fs_util;
-use crate::logger;
 use crate::proc_state::import_map_from_text;
 use crate::tools::fmt::format_file;
 use crate::tools::fmt::format_parsed_source;
@@ -2484,7 +2478,7 @@ impl lspower::LanguageServer for LanguageServer {
       tokio::spawn(async move {
         if let Ok(configs) = client
           .specifier_configurations(
-            specifiers.iter().map(|(s)| s.client_uri.clone()).collect(),
+            specifiers.iter().map(|s| s.client_uri.clone()).collect(),
           )
           .await
         {

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -1,8 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-// FIXME(bartlomieju): remove this attribute
-#![allow(unused)]
-
 use deno_core::error::AnyError;
 use lspower::LspService;
 use lspower::Server;

--- a/cli/lsp/performance.rs
+++ b/cli/lsp/performance.rs
@@ -8,7 +8,6 @@ use std::cmp;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::fmt;
-use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 

--- a/cli/lsp/registries.rs
+++ b/cli/lsp/registries.rs
@@ -18,9 +18,7 @@ use crate::file_fetcher::FileFetcher;
 use crate::http_cache::HttpCache;
 
 use deno_core::anyhow::anyhow;
-use deno_core::anyhow::Context;
 use deno_core::error::AnyError;
-use deno_core::resolve_url;
 use deno_core::serde::Deserialize;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
@@ -640,7 +638,6 @@ impl ModuleRegistry {
             value,
             ..
           }) => Some(value),
-          _ => None,
         };
       }
     }
@@ -867,7 +864,7 @@ impl ModuleRegistry {
                               (items, None, false)
                             }
                           };
-                          if (incomplete) {
+                          if incomplete {
                             is_incomplete = true;
                           }
                           for (idx, item) in items.into_iter().enumerate() {

--- a/cli/lsp/repl.rs
+++ b/cli/lsp/repl.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 use std::collections::HashMap;
-use std::future::Future;
 
 use deno_ast::swc::common::BytePos;
 use deno_ast::swc::common::Span;
@@ -33,8 +32,6 @@ use lspower::lsp::TextDocumentPositionParams;
 use lspower::lsp::VersionedTextDocumentIdentifier;
 use lspower::lsp::WorkDoneProgressParams;
 use lspower::LanguageServer;
-
-use crate::logger;
 
 use super::client::Client;
 use super::config::CompletionSettings;

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -268,10 +268,6 @@ impl Assets {
     AssetsSnapshot(self.assets.clone())
   }
 
-  pub fn contains_key(&self, k: &ModuleSpecifier) -> bool {
-    self.assets.lock().contains_key(k)
-  }
-
   pub fn get_cached(
     &self,
     k: &ModuleSpecifier,
@@ -669,11 +665,15 @@ pub struct JsDocTagInfo {
   text: Option<Vec<SymbolDisplayPart>>,
 }
 
+// Note: the tsc protocol contains fields that are part of the protocol but
+// not currently used.  They are commented out in the structures so it is clear
+// that they exist.
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QuickInfo {
-  kind: ScriptElementKind,
-  kind_modifiers: String,
+  // kind: ScriptElementKind,
+  // kind_modifiers: String,
   text_span: TextSpan,
   display_parts: Option<Vec<SymbolDisplayPart>>,
   documentation: Option<Vec<SymbolDisplayPart>>,
@@ -815,7 +815,7 @@ pub struct DocumentSpan {
   text_span: TextSpan,
   pub file_name: String,
   original_text_span: Option<TextSpan>,
-  original_file_name: Option<String>,
+  // original_file_name: Option<String>,
   context_span: Option<TextSpan>,
   original_context_span: Option<TextSpan>,
 }
@@ -915,12 +915,12 @@ pub struct NavigateToItem {
   name: String,
   kind: ScriptElementKind,
   kind_modifiers: String,
-  match_kind: MatchKind,
-  is_case_sensitive: bool,
+  // match_kind: MatchKind,
+  // is_case_sensitive: bool,
   file_name: String,
   text_span: TextSpan,
   container_name: Option<String>,
-  container_kind: ScriptElementKind,
+  // container_kind: ScriptElementKind,
 }
 
 impl NavigateToItem {
@@ -1123,8 +1123,8 @@ pub struct ImplementationLocation {
   #[serde(flatten)]
   pub document_span: DocumentSpan,
   // ImplementationLocation props
-  kind: ScriptElementKind,
-  display_parts: Vec<SymbolDisplayPart>,
+  // kind: ScriptElementKind,
+  // display_parts: Vec<SymbolDisplayPart>,
 }
 
 impl ImplementationLocation {
@@ -1163,8 +1163,8 @@ pub struct RenameLocation {
   #[serde(flatten)]
   document_span: DocumentSpan,
   // RenameLocation props
-  prefix_text: Option<String>,
-  suffix_text: Option<String>,
+  // prefix_text: Option<String>,
+  // suffix_text: Option<String>,
 }
 
 pub struct RenameLocations {
@@ -1236,21 +1236,20 @@ pub enum HighlightSpanKind {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HighlightSpan {
-  file_name: Option<String>,
-  is_in_string: Option<bool>,
+  // file_name: Option<String>,
+  // is_in_string: Option<bool>,
   text_span: TextSpan,
-  context_span: Option<TextSpan>,
+  // context_span: Option<TextSpan>,
   kind: HighlightSpanKind,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DefinitionInfo {
-  kind: ScriptElementKind,
-  name: String,
-  container_kind: Option<ScriptElementKind>,
-  container_name: Option<String>,
-
+  // kind: ScriptElementKind,
+  // name: String,
+  // container_kind: Option<ScriptElementKind>,
+  // container_name: Option<String>,
   #[serde(flatten)]
   pub document_span: DocumentSpan,
 }
@@ -1259,7 +1258,7 @@ pub struct DefinitionInfo {
 #[serde(rename_all = "camelCase")]
 pub struct DefinitionInfoAndBoundSpan {
   pub definitions: Option<Vec<DefinitionInfo>>,
-  text_span: TextSpan,
+  // text_span: TextSpan,
 }
 
 impl DefinitionInfoAndBoundSpan {
@@ -1289,7 +1288,7 @@ impl DefinitionInfoAndBoundSpan {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentHighlights {
-  file_name: String,
+  // file_name: String,
   highlight_spans: Vec<HighlightSpan>,
 }
 
@@ -1538,9 +1537,9 @@ impl RefactorActionInfo {
 #[serde(rename_all = "camelCase")]
 pub struct ApplicableRefactorInfo {
   name: String,
-  description: String,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  inlineable: Option<bool>,
+  // description: String,
+  // #[serde(skip_serializing_if = "Option::is_none")]
+  // inlineable: Option<bool>,
   actions: Vec<RefactorActionInfo>,
 }
 
@@ -1620,10 +1619,10 @@ impl RefactorEditInfo {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeAction {
-  description: String,
-  changes: Vec<FileTextChanges>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  commands: Option<Vec<Value>>,
+  // description: String,
+// changes: Vec<FileTextChanges>,
+// #[serde(skip_serializing_if = "Option::is_none")]
+// commands: Option<Vec<Value>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -1657,9 +1656,9 @@ pub struct CombinedCodeActions {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReferenceEntry {
-  is_write_access: bool,
+  // is_write_access: bool,
   pub is_definition: bool,
-  is_in_string: Option<bool>,
+  // is_in_string: Option<bool>,
   #[serde(flatten)]
   pub document_span: DocumentSpan,
 }
@@ -1862,14 +1861,14 @@ impl CallHierarchyOutgoingCall {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionEntryDetails {
-  name: String,
-  kind: ScriptElementKind,
-  kind_modifiers: String,
+  // name: String,
+  // kind: ScriptElementKind,
+  // kind_modifiers: String,
   display_parts: Vec<SymbolDisplayPart>,
   documentation: Option<Vec<SymbolDisplayPart>>,
   tags: Option<Vec<JsDocTagInfo>>,
-  code_actions: Option<Vec<CodeAction>>,
-  source: Option<Vec<SymbolDisplayPart>>,
+  // code_actions: Option<Vec<CodeAction>>,
+  // source: Option<Vec<SymbolDisplayPart>>,
 }
 
 impl CompletionEntryDetails {
@@ -2202,9 +2201,9 @@ pub enum OutliningSpanKind {
 #[serde(rename_all = "camelCase")]
 pub struct OutliningSpan {
   text_span: TextSpan,
-  hint_span: TextSpan,
-  banner_text: String,
-  auto_collapse: bool,
+  // hint_span: TextSpan,
+  // banner_text: String,
+  // auto_collapse: bool,
   kind: OutliningSpanKind,
 }
 
@@ -2275,10 +2274,10 @@ impl OutliningSpan {
 #[serde(rename_all = "camelCase")]
 pub struct SignatureHelpItems {
   items: Vec<SignatureHelpItem>,
-  applicable_span: TextSpan,
+  // applicable_span: TextSpan,
   selected_item_index: u32,
   argument_index: u32,
-  argument_count: u32,
+  // argument_count: u32,
 }
 
 impl SignatureHelpItems {
@@ -2301,13 +2300,13 @@ impl SignatureHelpItems {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SignatureHelpItem {
-  is_variadic: bool,
+  // is_variadic: bool,
   prefix_display_parts: Vec<SymbolDisplayPart>,
   suffix_display_parts: Vec<SymbolDisplayPart>,
-  separator_display_parts: Vec<SymbolDisplayPart>,
+  // separator_display_parts: Vec<SymbolDisplayPart>,
   parameters: Vec<SignatureHelpParameter>,
   documentation: Vec<SymbolDisplayPart>,
-  tags: Vec<JsDocTagInfo>,
+  // tags: Vec<JsDocTagInfo>,
 }
 
 impl SignatureHelpItem {
@@ -2352,10 +2351,10 @@ impl SignatureHelpItem {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SignatureHelpParameter {
-  name: String,
+  // name: String,
   documentation: Vec<SymbolDisplayPart>,
   display_parts: Vec<SymbolDisplayPart>,
-  is_optional: bool,
+  // is_optional: bool,
 }
 
 impl SignatureHelpParameter {
@@ -2404,7 +2403,7 @@ impl SelectionRange {
 
 #[derive(Debug, Clone, Deserialize)]
 struct Response {
-  id: usize,
+  // id: usize,
   data: Value,
 }
 
@@ -2544,7 +2543,7 @@ fn op_exists(state: &mut State, args: SpecifierArgs) -> Result<bool, AnyError> {
     // sometimes tsc tries to query invalid specifiers, especially when
     // something else isn't quite right, so instead of bubbling up the error
     // back to tsc, we simply swallow it and say the file doesn't exist
-    Err(err) => return Ok(false),
+    Err(_) => return Ok(false),
   };
   let result = state.state_snapshot.documents.exists(&specifier);
   Ok(result)


### PR DESCRIPTION
In #12968 `#[allow(unused)]` was added, but never removed.  Since then there is a significant amount of dead code and other things that have creeped into the whole of the lsp.  This PR cleans all that up.