### PR TITLE
fix(cli): disable config discovery for remote script

### DIFF
--- a/cli/config_file.rs
+++ b/cli/config_file.rs
@@ -164,17 +164,18 @@ const CONFIG_FILE_NAMES: [&str; 2] = ["deno.json", "deno.jsonc"];
 pub fn discover(flags: &crate::Flags) -> Result<Option<ConfigFile>, AnyError> {
   if let Some(config_path) = flags.config_path.as_ref() {
     Ok(Some(ConfigFile::read(config_path)?))
-  } else {
+  } else if let Some(config_path_args) = flags.config_path_args() {
     let mut checked = HashSet::new();
-    for f in flags.config_path_args() {
+    for f in config_path_args {
       if let Some(cf) = discover_from(&f, &mut checked)? {
         return Ok(Some(cf));
       }
     }
-
     // From CWD walk up to root looking for deno.json or deno.jsonc
     let cwd = std::env::current_dir()?;
     discover_from(&cwd, &mut checked)
+  } else {
+    Ok(None)
   }
 }
 

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -373,6 +373,9 @@ impl Flags {
   }
 
   /// Extract path arguments for config search paths.
+  /// If it returns Some(vec), the config should be discovered
+  /// from the current dir after trying to discover from each entry in vec.
+  /// If it returns None, the config file shouldn't be discovered at all.
   pub fn config_path_args(&self) -> Option<Vec<PathBuf>> {
     use DenoSubcommand::*;
     if let Fmt(FmtFlags { files, .. }) = &self.subcommand {
@@ -388,8 +391,8 @@ impl Flags {
             Some(vec![])
           }
         } else {
-          // When the entrypoint doesn't have file: scheme,
-          // then doesn't discover config file
+          // When the entrypoint doesn't have file: scheme (it's the remote
+          // script), then we don't auto discover config file.
           None
         }
       } else {

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2500,3 +2500,14 @@ itest!(colors_without_global_this {
   args: "run colors_without_globalThis.js",
   output_str: Some("true\n"),
 });
+
+itest!(config_auto_discovered_for_local_script {
+  args: "run --quiet run/with_config/frontend_work.ts",
+  output_str: Some("ok\n"),
+});
+
+itest!(config_not_auto_discovered_for_remote_script {
+  args: "run --quiet http://127.0.0.1:4545/run/with_config/server_side_work.ts",
+  output_str: Some("ok\n"),
+  http_server: true,
+});

--- a/cli/tests/testdata/run/with_config/deno.jsonc
+++ b/cli/tests/testdata/run/with_config/deno.jsonc
@@ -1,0 +1,6 @@
+{
+  // type settings for frontend dev
+  "compilerOptions": {
+    "lib": ["esnext", "dom"]
+  }
+}

--- a/cli/tests/testdata/run/with_config/frontend_work.ts
+++ b/cli/tests/testdata/run/with_config/frontend_work.ts
@@ -1,0 +1,4 @@
+function _main() {
+  console.log(document);
+}
+console.log("ok");

--- a/cli/tests/testdata/run/with_config/server_side_work.ts
+++ b/cli/tests/testdata/run/with_config/server_side_work.ts
@@ -1,0 +1,2 @@
+const _ = Deno.build.os;
+console.log("ok");


### PR DESCRIPTION
This implements the idea proposed in #13744.

This PR disables the config auto-discovery when executing remote scripts (`deno run <remote_script>`)

closes #13744