### PR TITLE
bench: core.encode/decode

### DIFF
--- a/bench_util/Cargo.toml
+++ b/bench_util/Cargo.toml
@@ -20,3 +20,7 @@ tokio = { version = "1.10.1", features = ["full"] }
 [[bench]]
 name = "op_baseline"
 harness = false
+
+[[bench]]
+name = "utf8"
+harness = false

--- a/bench_util/benches/utf8.rs
+++ b/bench_util/benches/utf8.rs
@@ -1,0 +1,49 @@
+use deno_bench_util::bench_js_sync;
+use deno_bench_util::bench_or_profile;
+use deno_bench_util::bencher::{benchmark_group, Bencher};
+
+use deno_core::Extension;
+
+fn setup() -> Vec<Extension> {
+  vec![Extension::builder()
+    .js(vec![(
+      "setup.js",
+      Box::new(|| {
+        Ok(
+          r#"
+      const hello = "hello world\n";
+      const hello1k = hello.repeat(1e3);
+      const helloEncoded = Deno.core.encode(hello);
+      const hello1kEncoded = Deno.core.encode(hello1k);
+      "#
+          .into(),
+        )
+      }),
+    )])
+    .build()]
+}
+
+fn bench_utf8_encode_single(b: &mut Bencher) {
+  bench_js_sync(b, r#"Deno.core.encode(hello);"#, setup);
+}
+
+fn bench_utf8_encode_1k(b: &mut Bencher) {
+  bench_js_sync(b, r#"Deno.core.encode(hello1k);"#, setup);
+}
+
+fn bench_utf8_decode_single(b: &mut Bencher) {
+  bench_js_sync(b, r#"Deno.core.decode(helloEncoded);"#, setup);
+}
+
+fn bench_utf8_decode_1k(b: &mut Bencher) {
+  bench_js_sync(b, r#"Deno.core.decode(hello1kEncoded);"#, setup);
+}
+
+benchmark_group!(
+  benches,
+  bench_utf8_encode_single,
+  bench_utf8_encode_1k,
+  bench_utf8_decode_single,
+  bench_utf8_decode_1k
+);
+bench_or_profile!(benches);

--- a/bench_util/benches/utf8.rs
+++ b/bench_util/benches/utf8.rs
@@ -1,7 +1,8 @@
-use deno_bench_util::bench_js_sync;
+use deno_bench_util::bench_js_sync_with;
 use deno_bench_util::bench_or_profile;
-use deno_bench_util::bencher::{benchmark_group, Bencher};
-
+use deno_bench_util::bencher::benchmark_group;
+use deno_bench_util::bencher::Bencher;
+use deno_bench_util::BenchOptions;
 use deno_core::Extension;
 
 fn setup() -> Vec<Extension> {
@@ -13,8 +14,10 @@ fn setup() -> Vec<Extension> {
           r#"
       const hello = "hello world\n";
       const hello1k = hello.repeat(1e3);
+      const hello1m = hello.repeat(1e6);
       const helloEncoded = Deno.core.encode(hello);
       const hello1kEncoded = Deno.core.encode(hello1k);
+      const hello1mEncoded = Deno.core.encode(hello1m);
       "#
           .into(),
         )
@@ -23,27 +26,87 @@ fn setup() -> Vec<Extension> {
     .build()]
 }
 
-fn bench_utf8_encode_single(b: &mut Bencher) {
-  bench_js_sync(b, r#"Deno.core.encode(hello);"#, setup);
+fn bench_utf8_encode_12_b(b: &mut Bencher) {
+  bench_js_sync_with(
+    b,
+    r#"Deno.core.encode(hello);"#,
+    setup,
+    BenchOptions {
+      benching_inner: 1,
+      ..Default::default()
+    },
+  );
 }
 
-fn bench_utf8_encode_1k(b: &mut Bencher) {
-  bench_js_sync(b, r#"Deno.core.encode(hello1k);"#, setup);
+fn bench_utf8_encode_12_kb(b: &mut Bencher) {
+  bench_js_sync_with(
+    b,
+    r#"Deno.core.encode(hello1k);"#,
+    setup,
+    BenchOptions {
+      benching_inner: 1,
+      ..Default::default()
+    },
+  );
 }
 
-fn bench_utf8_decode_single(b: &mut Bencher) {
-  bench_js_sync(b, r#"Deno.core.decode(helloEncoded);"#, setup);
+fn bench_utf8_encode_12_mb(b: &mut Bencher) {
+  bench_js_sync_with(
+    b,
+    r#"Deno.core.encode(hello1m);"#,
+    setup,
+    BenchOptions {
+      benching_inner: 1,
+      profiling_inner: 10,
+      profiling_outer: 10,
+    },
+  );
 }
 
-fn bench_utf8_decode_1k(b: &mut Bencher) {
-  bench_js_sync(b, r#"Deno.core.decode(hello1kEncoded);"#, setup);
+fn bench_utf8_decode_12_b(b: &mut Bencher) {
+  bench_js_sync_with(
+    b,
+    r#"Deno.core.decode(helloEncoded);"#,
+    setup,
+    BenchOptions {
+      benching_inner: 1,
+      ..Default::default()
+    },
+  );
+}
+
+fn bench_utf8_decode_12_kb(b: &mut Bencher) {
+  bench_js_sync_with(
+    b,
+    r#"Deno.core.decode(hello1kEncoded);"#,
+    setup,
+    BenchOptions {
+      benching_inner: 1,
+      ..Default::default()
+    },
+  );
+}
+
+fn bench_utf8_decode_12_mb(b: &mut Bencher) {
+  bench_js_sync_with(
+    b,
+    r#"Deno.core.decode(hello1mEncoded);"#,
+    setup,
+    BenchOptions {
+      benching_inner: 1,
+      profiling_inner: 10,
+      profiling_outer: 10,
+    },
+  );
 }
 
 benchmark_group!(
   benches,
-  bench_utf8_encode_single,
-  bench_utf8_encode_1k,
-  bench_utf8_decode_single,
-  bench_utf8_decode_1k
+  bench_utf8_encode_12_b,
+  bench_utf8_encode_12_kb,
+  bench_utf8_encode_12_mb,
+  bench_utf8_decode_12_b,
+  bench_utf8_decode_12_kb,
+  bench_utf8_decode_12_mb,
 );
 bench_or_profile!(benches);

--- a/bench_util/src/js_runtime.rs
+++ b/bench_util/src/js_runtime.rs
@@ -18,10 +18,11 @@ fn loop_code(iters: u64, src: &str) -> String {
   format!(r#"for(let i=0; i < {}; i++) {{ {} }}"#, iters, src,)
 }
 
+#[derive(Copy, Clone)]
 pub struct BenchOptions {
-  benching_inner: u64,
-  profiling_inner: u64,
-  profiling_outer: u64,
+  pub benching_inner: u64,
+  pub profiling_inner: u64,
+  pub profiling_outer: u64,
 }
 
 impl Default for BenchOptions {

--- a/bench_util/src/js_runtime.rs
+++ b/bench_util/src/js_runtime.rs
@@ -18,16 +18,45 @@ fn loop_code(iters: u64, src: &str) -> String {
   format!(r#"for(let i=0; i < {}; i++) {{ {} }}"#, iters, src,)
 }
 
+pub struct BenchOptions {
+  benching_inner: u64,
+  profiling_inner: u64,
+  profiling_outer: u64,
+}
+
+impl Default for BenchOptions {
+  fn default() -> Self {
+    Self {
+      benching_inner: 1_000,
+      profiling_inner: 1_000,
+      profiling_outer: 10_000,
+    }
+  }
+}
+
 pub fn bench_js_sync(
   b: &mut Bencher,
   src: &str,
   setup: impl FnOnce() -> Vec<Extension>,
 ) {
+  bench_js_sync_with(b, src, setup, Default::default())
+}
+
+pub fn bench_js_sync_with(
+  b: &mut Bencher,
+  src: &str,
+  setup: impl FnOnce() -> Vec<Extension>,
+  opts: BenchOptions,
+) {
   let mut runtime = create_js_runtime(setup);
   let scope = &mut runtime.handle_scope();
 
   // Increase JS iterations if profiling for nicer flamegraphs
-  let inner_iters = 1000 * if is_profiling() { 10000 } else { 1 };
+  let inner_iters = if is_profiling() {
+    opts.profiling_inner * opts.profiling_outer
+  } else {
+    opts.benching_inner
+  };
   // Looped code
   let looped_src = loop_code(inner_iters, src);
 
@@ -49,6 +78,15 @@ pub fn bench_js_async(
   src: &str,
   setup: impl FnOnce() -> Vec<Extension>,
 ) {
+  bench_js_async_with(b, src, setup, Default::default())
+}
+
+pub fn bench_js_async_with(
+  b: &mut Bencher,
+  src: &str,
+  setup: impl FnOnce() -> Vec<Extension>,
+  opts: BenchOptions,
+) {
   let mut runtime = create_js_runtime(setup);
   let tokio_runtime = tokio::runtime::Builder::new_current_thread()
     .enable_all()
@@ -56,11 +94,16 @@ pub fn bench_js_async(
     .unwrap();
 
   // Looped code
-  let looped = loop_code(1000, src);
+  let inner_iters = if is_profiling() {
+    opts.profiling_inner
+  } else {
+    opts.benching_inner
+  };
+  let looped = loop_code(inner_iters, src);
   let src = looped.as_ref();
 
   if is_profiling() {
-    for _ in 0..10000 {
+    for _ in 0..opts.profiling_outer {
       tokio_runtime.block_on(inner_async(src, &mut runtime));
     }
   } else {


### PR DESCRIPTION
Benches for #13749

M1 baseline:
```
test bench_utf8_decode_12_b  ... bench:         204 ns/iter (+/- 13)
test bench_utf8_decode_12_kb ... bench:       3,189 ns/iter (+/- 1,049)
test bench_utf8_decode_12_mb ... bench:   1,430,887 ns/iter (+/- 29,186)
test bench_utf8_encode_12_b  ... bench:         433 ns/iter (+/- 13)
test bench_utf8_encode_12_kb ... bench:       5,786 ns/iter (+/- 693)
test bench_utf8_encode_12_mb ... bench:   4,946,268 ns/iter (+/- 118,515)
```