### PR TITLE
chore(ci): pin setup-gcloud to `v0` instead of `master`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
           startsWith(github.ref, 'refs/tags/'))
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: denoland
           service_account_key: ${{ secrets.GCP_SA_KEY }}
@@ -135,7 +135,7 @@ jobs:
           github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
           startsWith(github.ref, 'refs/tags/'))
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         env:
           CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
         with:
@@ -618,7 +618,7 @@ jobs:
     if: github.repository == 'denoland/deno' && github.ref == 'refs/heads/main'
     steps:
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: denoland
           service_account_key: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
```
google-github-actions/setup-gcloud is pinned at "master". We strongly advise against pinning to "@master" as it may be unstable. Please update your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'

Alternatively, you can pin to any git tag or git SHA in the repository.
```

https://github.com/google-github-actions/setup-gcloud#-notices