### PR TITLE
chore: Add "noImplicitOverride" to config-file.v1.json

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -99,6 +99,12 @@
           "default": true,
           "markdownDescription": "Enable error reporting for expressions and declarations with an implied `any` type..\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitAny"
         },
+        "noImplicitOverride": {
+          "description": "Ensure overriding members in derived classes are marked with an override modifier.",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Ensure overriding members in derived classes are marked with an override modifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitOverride"
+        },
         "noImplicitReturns": {
           "description": "Enable error reporting for codepaths that do not explicitly return in a function.",
           "type": "boolean",


### PR DESCRIPTION
This PR adds the definition for the `"noImplicitOverride"` compiler option to the `deno.json` config file schema so it can be auto-completed in VS Code.

The definition was taken from http://json.schemastore.org/tsconfig, as mentioned in the original issue #11885. Related issue about possibly enabling `"noImplicitOverride"` by default: #11836.