### PR TITLE
fix: expose Deno.TcpConn, add tests

### DIFF
--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -218,6 +218,7 @@ Deno.test({ permissions: { net: true } }, async function netTcpDialListen() {
 
   const conn = await Deno.connect({ hostname: "127.0.0.1", port: 3500 });
   assert(conn.remoteAddr.transport === "tcp");
+  assert(conn instanceof Deno.TcpConn);
   assertEquals(conn.remoteAddr.hostname, "127.0.0.1");
   assertEquals(conn.remoteAddr.port, 3500);
   assert(conn.localAddr != null);

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -311,19 +311,17 @@
   }
 
   async function connect(options) {
-    let res;
-
     if (options.transport === "unix") {
-      res = await opConnect(options);
+      const res = await opConnect(options);
+      return new Conn(res.rid, res.remoteAddr, res.localAddr);
     } else {
-      res = await opConnect({
+      const res = await opConnect({
         transport: "tcp",
         hostname: "127.0.0.1",
         ...options,
       });
+      return new TcpConn(res.rid, res.remoteAddr, res.localAddr);
     }
-
-    return new TcpConn(res.rid, res.remoteAddr, res.localAddr);
   }
 
   window.__bootstrap.net = {

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -87,6 +87,7 @@
     seek: __bootstrap.files.seek,
     seekSync: __bootstrap.files.seekSync,
     connect: __bootstrap.net.connect,
+    TcpConn: __bootstrap.net.TcpConn,
     listen: __bootstrap.net.listen,
     connectTls: __bootstrap.tls.connectTls,
     listenTls: __bootstrap.tls.listenTls,


### PR DESCRIPTION
Follow up to https://github.com/denoland/deno/pull/13714

Exposes `Deno.TcpConn`, checks in tests that instance of is returned
from `Deno.listen()` and `Deno.connect()` 