### PR TITLE
feat(net): added reuseAddress and reusePort in Sockets API

### DIFF
--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -809,21 +809,29 @@ Deno.test(
 );
 
 Deno.test({ permissions: { net: true } }, async function netReusePort() {
-  const listener1 = Deno.listen({ hostname: "127.0.0.1", port: 3500, reusePort: true});
+  const listener1 = Deno.listen({
+    hostname: "127.0.0.1",
+    port: 3500,
+    reusePort: true,
+  });
   listener1.accept().then(
     async (conn) => {
       await conn.write(new Uint8Array([1, 2, 3]));
       conn.close();
     },
   );
-  const listener2 = Deno.listen({ hostname: "127.0.0.1", port: 3500, reusePort: true});
+  const listener2 = Deno.listen({
+    hostname: "127.0.0.1",
+    port: 3500,
+    reusePort: true,
+  });
   listener2.accept().then(
     async (conn) => {
       await conn.write(new Uint8Array([1, 2, 3]));
       conn.close();
     },
   );
-  
+
   const conn1 = await Deno.connect({ hostname: "127.0.0.1", port: 3500 });
   const buf = new Uint8Array(1024);
   const readResult1 = await conn1.read(buf);
@@ -837,7 +845,7 @@ Deno.test({ permissions: { net: true } }, async function netReusePort() {
   const readResult2 = await conn1.read(buf);
   assertEquals(readResult2, null);
   conn1.close();
-  
+
   const conn2 = await Deno.connect({ hostname: "127.0.0.1", port: 3500 });
   const readResult3 = await conn2.read(buf);
   assertEquals(3, readResult3);
@@ -850,7 +858,7 @@ Deno.test({ permissions: { net: true } }, async function netReusePort() {
   const readResult4 = await conn2.read(buf);
   assertEquals(readResult4, null);
   conn2.close();
-  
+
   listener1.close();
   listener2.close();
 });

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -811,7 +811,7 @@ Deno.test(
 Deno.test({ permissions: { net: true } }, async function netReusePort() {
   const listener1 = Deno.listen({
     hostname: "127.0.0.1",
-    port: 3500,
+    port: 5000,
     reusePort: true,
   });
   listener1.accept().then(
@@ -822,7 +822,7 @@ Deno.test({ permissions: { net: true } }, async function netReusePort() {
   );
   const listener2 = Deno.listen({
     hostname: "127.0.0.1",
-    port: 3500,
+    port: 5000,
     reusePort: true,
   });
   listener2.accept().then(
@@ -832,7 +832,7 @@ Deno.test({ permissions: { net: true } }, async function netReusePort() {
     },
   );
 
-  const conn1 = await Deno.connect({ hostname: "127.0.0.1", port: 3500 });
+  const conn1 = await Deno.connect({ hostname: "127.0.0.1", port: 5000 });
   const buf = new Uint8Array(1024);
   const readResult1 = await conn1.read(buf);
   assertEquals(3, readResult1);
@@ -846,7 +846,7 @@ Deno.test({ permissions: { net: true } }, async function netReusePort() {
   assertEquals(readResult2, null);
   conn1.close();
 
-  const conn2 = await Deno.connect({ hostname: "127.0.0.1", port: 3500 });
+  const conn2 = await Deno.connect({ hostname: "127.0.0.1", port: 5000 });
   const readResult3 = await conn2.read(buf);
   assertEquals(3, readResult3);
   assertEquals(1, buf[0]);

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -807,3 +807,50 @@ Deno.test(
     assertEquals(res, "hello world!");
   },
 );
+
+Deno.test({ permissions: { net: true } }, async function netReusePort() {
+  const listener1 = Deno.listen({ hostname: "127.0.0.1", port: 3500, reusePort: true});
+  listener1.accept().then(
+    async (conn) => {
+      await conn.write(new Uint8Array([1, 2, 3]));
+      conn.close();
+    },
+  );
+  const listener2 = Deno.listen({ hostname: "127.0.0.1", port: 3500, reusePort: true});
+  listener2.accept().then(
+    async (conn) => {
+      await conn.write(new Uint8Array([1, 2, 3]));
+      conn.close();
+    },
+  );
+  
+  const conn1 = await Deno.connect({ hostname: "127.0.0.1", port: 3500 });
+  const buf = new Uint8Array(1024);
+  const readResult1 = await conn1.read(buf);
+  assertEquals(3, readResult1);
+  assertEquals(1, buf[0]);
+  assertEquals(2, buf[1]);
+  assertEquals(3, buf[2]);
+
+  assert(readResult1 !== null);
+
+  const readResult2 = await conn1.read(buf);
+  assertEquals(readResult2, null);
+  conn1.close();
+  
+  const conn2 = await Deno.connect({ hostname: "127.0.0.1", port: 3500 });
+  const readResult3 = await conn2.read(buf);
+  assertEquals(3, readResult3);
+  assertEquals(1, buf[0]);
+  assertEquals(2, buf[1]);
+  assertEquals(3, buf[2]);
+
+  assert(readResult3 !== null);
+
+  const readResult4 = await conn2.read(buf);
+  assertEquals(readResult4, null);
+  conn2.close();
+  
+  listener1.close();
+  listener2.close();
+});

--- a/ext/net/Cargo.toml
+++ b/ext/net/Cargo.toml
@@ -18,7 +18,7 @@ deno_core = { version = "0.120.0", path = "../../core" }
 deno_tls = { version = "0.25.0", path = "../tls" }
 log = "0.4.14"
 serde = { version = "1.0.129", features = ["derive"] }
-socket2 = "0.4.2"
+socket2 = { version = "0.4.2", features = ["all"] }
 tokio = { version = "1.10.1", features = ["full"] }
 trust-dns-proto = "0.20.3"
 trust-dns-resolver = { version = "0.20.3", features = ["tokio-runtime", "serde-config"] }

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -76,6 +76,12 @@ declare namespace Deno {
      * You should show the message like `server running on localhost:8080` instead of
      * `server running on 0.0.0.0:8080` if your program supports Windows. */
     hostname?: string;
+    reuseAddress?: boolean;
+    /** SO_REUSEADDR option for socket.
+     * If not specified, defaults to false. */
+    reusePort?: boolean;
+    /** SO_REUSEPORT option for socket.
+     * If not specified, defaults to false. */
   }
 
   /** Listen announces on the local transport address.
@@ -110,6 +116,11 @@ declare namespace Deno {
     keyFile?: string;
 
     transport?: "tcp";
+    /** SO_REUSEADDR option for socket.
+     * If not specified, defaults to false. */
+    reusePort?: boolean;
+    /** SO_REUSEPORT option for socket.
+     * If not specified, defaults to false. */
   }
 
   /** Listen announces on the local transport address over TLS (transport layer

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -444,6 +444,8 @@ fn listen_tcp(
   let socket = Socket::new(domain, Type::STREAM, None)?;
   if reuse_address.is_some() {
     socket.set_reuse_address(reuse_address.unwrap())?;
+  } else {
+    socket.set_reuse_address(true)?;
   }
   if reuse_port.is_some() {
     socket.set_reuse_port(reuse_port.unwrap())?;

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -932,6 +932,8 @@ mod tests {
     let ip_args = IpListenArgs {
       hostname: String::from(server_addr[0]),
       port: server_addr[1].parse().unwrap(),
+      reuse_address: None,
+      reuse_port: None,
     };
     let connect_args = ConnectArgs {
       transport: String::from("tcp"),

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -436,7 +436,11 @@ fn listen_tcp(
   reuse_address: Option<bool>,
   reuse_port: Option<bool>,
 ) -> Result<(u32, SocketAddr), AnyError> {
-  let domain = if addr.is_ipv4() { Domain::IPV4 } else { Domain::IPV6 };
+  let domain = if addr.is_ipv4() {
+    Domain::IPV4
+  } else {
+    Domain::IPV6
+  };
   let socket = Socket::new(domain, Type::STREAM, None)?;
   if reuse_address.is_some() {
     socket.set_reuse_address(reuse_address.unwrap())?;
@@ -448,7 +452,7 @@ fn listen_tcp(
   socket.bind(&socket_addr)?;
   socket.listen(128)?;
   socket.set_nonblocking(true)?;
-  let std_listener : std::net::TcpListener = socket.into();
+  let std_listener: std::net::TcpListener = socket.into();
   let listener = TcpListener::from_std(std_listener)?;
   let local_addr = listener.local_addr()?;
   let listener_resource = TcpListenerResource {

--- a/ext/net/ops_tls.rs
+++ b/ext/net/ops_tls.rs
@@ -1090,6 +1090,8 @@ where
   let socket = Socket::new(domain, Type::STREAM, None)?;
   if reuse_address.is_some() {
     socket.set_reuse_address(reuse_address.unwrap())?;
+  } else {
+    socket.set_reuse_address(true)?;
   }
   if reuse_port.is_some() {
     socket.set_reuse_port(reuse_port.unwrap())?;

--- a/ext/net/ops_tls.rs
+++ b/ext/net/ops_tls.rs
@@ -1034,7 +1034,7 @@ where
   let cert = args.cert.as_deref();
   let key = args.key.as_deref();
   let reuse_address = args.reuse_address;
-  let reuse_port = args.reuse_port; 
+  let reuse_port = args.reuse_port;
 
   {
     let permissions = state.borrow_mut::<NP>();
@@ -1082,7 +1082,11 @@ where
   let bind_addr = resolve_addr_sync(hostname, port)?
     .next()
     .ok_or_else(|| generic_error("No resolved address found"))?;
-  let domain = if bind_addr.is_ipv4() { Domain::IPV4 } else { Domain::IPV6 };
+  let domain = if bind_addr.is_ipv4() {
+    Domain::IPV4
+  } else {
+    Domain::IPV6
+  };
   let socket = Socket::new(domain, Type::STREAM, None)?;
   if reuse_address.is_some() {
     socket.set_reuse_address(reuse_address.unwrap())?;
@@ -1094,7 +1098,7 @@ where
   socket.bind(&socket_addr)?;
   socket.listen(128)?;
   socket.set_nonblocking(true)?;
-  let std_listener : std::net::TcpListener = socket.into();
+  let std_listener: std::net::TcpListener = socket.into();
   let tcp_listener = TcpListener::from_std(std_listener)?;
   let local_addr = tcp_listener.local_addr()?;
 


### PR DESCRIPTION
Support for **SO_REUSEADDR** socket option is requested in #1195, to avoid using different ports during tests. In order to achieve the wanted feature, it now possible to use the **SO_REUSEPORT** socket option in addition.

The implemented changes are:
1. 2 additional optional arguments for `Deno.listen` and `Deno.listenTls`, namely `reuseAddr` and `reusePort`  (one for each supported option)
2. changed the `socket2` entry to support the **SO_REUSEPORT** option
3. proposed a test to verify that the `reusePort` option works as intended

In this moment, the option is checked and set only for `op_net_listen` and `op_tls_listen`. In particular, for `op_net_listen`, changes are applied only to the `listen_tcp` method.

After testing `reuseAddr`, it has been noted that the `tokio::net::lookup_host` function use to solve the provided _hostname_, sometimes resolves the address `0.0.0.0` to `127.0.0.1`, leading to unwanted effects when the following code is used:

```
const listener1 = Deno.listen({ hostname: "127.0.0.1", port: 3500, reuseAddress: true});
const listener2 = Deno.listen({ hostname: "0.0.0.0", port: 3500, reuseAddress: true});
```
One possible solution could be using the dedicated [dns-lookup](https://docs.rs/dns-lookup/latest/dns_lookup/) package