### PR TITLE
docs(release): proposal for publishing crates on CI

### DIFF
--- a/tools/cut_a_release.md
+++ b/tools/cut_a_release.md
@@ -64,85 +64,54 @@ previous release and start cherry-picking newer commits from the `main`.
 Once all relevant commits are cherry-picked, push the branch to the upstream and
 verify on GitHub that everything looks correct.
 
-1. Checkout a branch for releasing crate dependencies (e.g. `deps_#.#.#`).
+1. Checkout a branch for releasing Deno (e.g. `release_#.#.#`).
 
-2. Run `./tools/release/01_bump_dependency_crate_versions.ts` to increase the
-   minor versions of all crates in the `bench_util`, `core`, `ext`, and
-   `runtime` directories.
+2. Run `./tools/release/bump_versions.ts` to increase the versions of all
+   crates. If you are doing a patch release, answer `y` to the _Increment
+   patch?_ prompt.
 
-3. Commit these changes with a commit message like
-   `chore: bump crate version for #.#.#` and create a PR for this change. **If
-   you are cutting a patch release**: make sure to target `v1.XX` branch instead
-   of `main` in your PR.
+3. The above command has updated `Releases.md`. Review its changes. **If you are
+   cutting a minor release**: make sure that there are no duplicate entries in
+   previous releases; most often commits with `fix` prefix would have been
+   included in patch releases.
 
-4. Make sure CI pipeline passes (DO NOT merge yet).
+4. Update link in `cli/compat/mod.rs` with the released version of `deno_std`
+   and do a search through the tests to find std urls that need to be updated.
 
-5. Run `./tools/release/02_publish_dependency_crates.ts` to publish these bumped
-   crates to `crates.io`
+5. Commit these changes with a commit message like `#.#.#` and create a PR for
+   this change. **If you are cutting a patch release**: make sure to target
+   `v1.XX` branch instead of `main` in your PR.
 
-   **Make sure that `cargo` is logged on with a user that has permissions to
-   publish those crates.**
+6. Make sure CI pipeline passes and merge the PR.
 
-   If there are any problems when you publish, that require you to change the
-   code, then after applying the fixes they should be committed and pushed to
-   the PR.
+7. Wait for CI pipeline on the created tag branch to pass.
 
-6. Once all crates are published merge the PR.
+   The CI pipeline will publish to crates.io and create a release draft on
+   GitHub (https://github.com/denoland/deno/releases).
 
-7. Update your main branch and checkout another branch (e.g. `release_#.#.#`).
+8. Upload Apple M1 build (`deno-aarch64-apple-darwin.zip`) to the release draft
+   and to https://console.cloud.google.com/storage/browser/dl.deno.land
 
-8. Run `./tools/release/03_bump_cli_version.ts` to bump the CLI version.
+   ```
+   cargo build --release
+   cd target/release
+   zip -r deno-aarch64-apple-darwin.zip deno
+   ```
 
-9. If you are doing a patch release, answer `y` to the _Increment patch?_
-   prompt.
+9. Publish the release on Github
 
-10. Use the output of the above command to update `Releases.md`. **If you are
-    cutting a minor release**: make sure that there are no duplicate entries in
-    previous releases; most often commits with `fix` prefix would have been
-    included in patch releases.
-
-11. Update link in `cli/compat/mod.rs` with the released version of `deno_std`
-    and do a search through the tests to find std urls that need to be updated.
-
-12. Create a PR for these changes. **If you are cutting a patch release**: make
-    sure to target `v1.XX` branch instead of `main` in your PR.
-
-13. Make sure CI pipeline passes.
-
-14. Publish `cli` crate to `crates.io`: `cd cli && cargo publish`
-
-15. Merge the PR.
-
-16. Create a tag with the version number (with `v` prefix).
-
-17. Wait for CI pipeline on the created tag branch to pass.
-
-    The CI pipeline will create a release draft on GitHub
-    (https://github.com/denoland/deno/releases).
-
-18. Upload Apple M1 build (`deno-aarch64-apple-darwin.zip`) to the release draft
-    and to https://console.cloud.google.com/storage/browser/dl.deno.land
-
-    ```
-    cargo build --release
-    cd target/release
-    zip -r deno-aarch64-apple-darwin.zip deno
-    ```
-
-19. Publish the release on Github
-
-20. Update the Deno version on the website by updating
+10. Update the Deno version on the website by updating
     https://github.com/denoland/dotland/blob/main/versions.json.
 
-21. Push a new tag to [`manual`](https://github.com/denoland/manual). The tag
+11. Push a new tag to [`manual`](https://github.com/denoland/manual). The tag
     must match the CLI tag; you don't need to create dedicated commit for that
     purpose, it's enough to tag the latest commit in that repo.
 
-22. For minor releases: make sure https://github.com/mdn/browser-compat-data has
+12. For minor releases: make sure https://github.com/mdn/browser-compat-data has
     been updated to reflect Web API changes in this release. Usually done ahead
     of time by @lucacasonato.
 
-23. **If you are cutting a patch release**: open a PR that forwards all commits
+13. **If you are cutting a patch release**: open a PR that forwards all commits
     created in the release process to the `main` branch.
 
 ## Updating `doc.deno.land`


### PR DESCRIPTION
Don't merge. This is a proposal for publishing all the crates on the CI when doing a release which would lower the number of steps required in the release process from 23 to 13.