### PR TITLE
chore: cancel old in-progress CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: ci
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}


### PR DESCRIPTION
CI will run only on the latest commit in a PR. Saves energy 🌲 

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

Idea from https://github.com/nodejs/node/pull/42017