### PR TITLE
chore(lsp): log more for "unexpected positions" lsp error

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -159,12 +159,19 @@ impl IndexValid {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum AssetOrDocument {
+pub enum AssetOrDocument {
   Document(Document),
   Asset(AssetDocument),
 }
 
 impl AssetOrDocument {
+  pub fn specifier(&self) -> &ModuleSpecifier {
+    match self {
+      AssetOrDocument::Asset(asset) => asset.specifier(),
+      AssetOrDocument::Document(doc) => doc.specifier(),
+    }
+  }
+
   pub fn document(&self) -> Option<&Document> {
     match self {
       AssetOrDocument::Asset(_) => None,
@@ -211,6 +218,10 @@ impl AssetOrDocument {
   pub fn document_lsp_version(&self) -> Option<i32> {
     self.document().and_then(|d| d.maybe_lsp_version())
   }
+
+  pub fn is_open(&self) -> bool {
+    self.document().map(|d| d.is_open()).unwrap_or(false)
+  }
 }
 
 #[derive(Debug, Clone)]
@@ -229,7 +240,7 @@ struct DocumentInner {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct Document(Arc<DocumentInner>);
+pub struct Document(Arc<DocumentInner>);
 
 impl Document {
   fn new(

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -2197,7 +2197,7 @@ impl Inner {
       })?;
 
     let semantic_tokens =
-      semantic_classification.to_semantic_tokens(line_index)?;
+      semantic_classification.to_semantic_tokens(&asset_or_doc, line_index)?;
     let response = if !semantic_tokens.data.is_empty() {
       Some(SemanticTokensResult::Tokens(semantic_tokens))
     } else {
@@ -2240,7 +2240,7 @@ impl Inner {
       })?;
 
     let semantic_tokens =
-      semantic_classification.to_semantic_tokens(line_index)?;
+      semantic_classification.to_semantic_tokens(&asset_or_doc, line_index)?;
     let response = if !semantic_tokens.data.is_empty() {
       Some(SemanticTokensRangeResult::Tokens(semantic_tokens))
     } else {


### PR DESCRIPTION
This logs more for #13657.

We're pretty sure that the issue is a closed document's `line_index` is getting out of date. Fixing it would require a bit of an overhaul (I believe it would require keeping filesystem files in memory for the duration of a request if requested), so just want to be sure this is indeed the case.

### **Merge on review**