### PR TITLE
perf(ext/web): optimize atob/btoa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: 4-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
+          key: 5-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
 
       # In main branch, always creates fresh cache
       - name: Cache build output (main)
@@ -279,7 +279,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: |
-            4-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}
+            5-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}
 
       # Restore cache from the latest 'main' branch build.
       - name: Cache build output (PR)
@@ -295,7 +295,7 @@ jobs:
             !./target/*/*.tar.gz
           key: never_saved
           restore-keys: |
-            4-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-
+            5-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-
 
       # Don't save cache after building PRs or branches other than 'main'.
       - name: Skip save cache (PR)

--- a/ext/web/05_base64.js
+++ b/ext/web/05_base64.js
@@ -12,6 +12,7 @@
   const core = Deno.core;
   const webidl = window.__bootstrap.webidl;
   const { DOMException } = window.__bootstrap.domException;
+  const { TypeError } = window.__bootstrap.primordials;
 
   /**
    * @param {string} data

--- a/ext/web/05_base64.js
+++ b/ext/web/05_base64.js
@@ -25,7 +25,17 @@
       prefix,
       context: "Argument 1",
     });
-    return core.opSync("op_base64_atob", data);
+    try {
+      return core.opSync("op_base64_atob", data);
+    } catch (e) {
+      if (e instanceof TypeError) {
+        throw new DOMException(
+          "Failed to decode base64: invalid character",
+          "InvalidCharacterError",
+        );
+      }
+      throw e;
+    }
   }
 
   /**

--- a/ext/web/05_base64.js
+++ b/ext/web/05_base64.js
@@ -11,6 +11,7 @@
 ((window) => {
   const core = Deno.core;
   const webidl = window.__bootstrap.webidl;
+  const { DOMException } = window.__bootstrap.domException;
 
   /**
    * @param {string} data
@@ -37,7 +38,17 @@
       prefix,
       context: "Argument 1",
     });
-    return core.opSync("op_base64_btoa", data);
+    try {
+      return core.opSync("op_base64_btoa", data);
+    } catch (e) {
+      if (e instanceof TypeError) {
+        throw new DOMException(
+          "The string to be encoded contains characters outside of the Latin1 range.",
+          "InvalidCharacterError",
+        );
+      }
+      throw e;
+    }
   }
 
   window.__bootstrap.base64 = {

--- a/ext/web/05_base64.js
+++ b/ext/web/05_base64.js
@@ -9,21 +9,8 @@
 "use strict";
 
 ((window) => {
+  const core = Deno.core;
   const webidl = window.__bootstrap.webidl;
-  const {
-    forgivingBase64Encode,
-    forgivingBase64Decode,
-  } = window.__bootstrap.infra;
-  const { DOMException } = window.__bootstrap.domException;
-  const {
-    ArrayPrototypeMap,
-    StringPrototypeCharCodeAt,
-    ArrayPrototypeJoin,
-    SafeArrayIterator,
-    StringFromCharCode,
-    TypedArrayFrom,
-    Uint8Array,
-  } = window.__bootstrap.primordials;
 
   /**
    * @param {string} data
@@ -36,13 +23,7 @@
       prefix,
       context: "Argument 1",
     });
-
-    const uint8Array = forgivingBase64Decode(data);
-    const result = ArrayPrototypeMap(
-      [...new SafeArrayIterator(uint8Array)],
-      (byte) => StringFromCharCode(byte),
-    );
-    return ArrayPrototypeJoin(result, "");
+    return core.opSync("op_base64_atob", data);
   }
 
   /**
@@ -56,20 +37,7 @@
       prefix,
       context: "Argument 1",
     });
-    const byteArray = ArrayPrototypeMap(
-      [...new SafeArrayIterator(data)],
-      (char) => {
-        const charCode = StringPrototypeCharCodeAt(char, 0);
-        if (charCode > 0xff) {
-          throw new DOMException(
-            "The string to be encoded contains characters outside of the Latin1 range.",
-            "InvalidCharacterError",
-          );
-        }
-        return charCode;
-      },
-    );
-    return forgivingBase64Encode(TypedArrayFrom(Uint8Array, byteArray));
+    return core.opSync("op_base64_btoa", data);
   }
 
   window.__bootstrap.base64 = {

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -170,7 +170,10 @@ fn b64_decode(input: String, padding: bool) -> Result<Vec<u8>, AnyError> {
 
   // If padding is expected, fail if not 4-byte aligned
   // TODO(@AaronO): cleanup
-  if padding && input.len() % 4 != 0 && (input.ends_with(b"==") || input.ends_with(b"=")) {
+  if padding
+    && input.len() % 4 != 0
+    && (input.ends_with(b"==") || input.ends_with(b"="))
+  {
     return Err(
       DomExceptionInvalidCharacterError::new("Failed to decode base64.").into(),
     );


### PR DESCRIPTION
Follow up to https://github.com/denoland/deno/pull/13839, optimizing `base64_roundtrip` ~20x (~125ms => ~6.5ms)

Before:
```
base64_roundtrip:    	n = 100, dt = 12.493s, r = 8/s, t = 124930000ns/op
```
After:
```
base64_roundtrip:    	n = 100, dt = 0.649s, r = 154/s, t = 6490000ns/op
```