### PR TITLE
Move base64 encoding/decoding to Rust side

### DIFF
--- a/ext/web/00_infra.js
+++ b/ext/web/00_infra.js
@@ -233,7 +233,7 @@
   }
 
   /**
-   * @param {Uint8Array} data
+   * @param {string} data
    * @returns {string}
    */
   function forgivingBase64Encode(data) {
@@ -242,7 +242,7 @@
 
   /**
    * @param {string} data
-   * @returns {Uint8Array}
+   * @returns {string}
    */
   function forgivingBase64Decode(data) {
     return core.opSync("op_base64_decode", data);

--- a/ext/web/05_base64.js
+++ b/ext/web/05_base64.js
@@ -37,12 +37,7 @@
       context: "Argument 1",
     });
 
-    const uint8Array = forgivingBase64Decode(data);
-    const result = ArrayPrototypeMap(
-      [...new SafeArrayIterator(uint8Array)],
-      (byte) => StringFromCharCode(byte),
-    );
-    return ArrayPrototypeJoin(result, "");
+    return forgivingBase64Decode(data);
   }
 
   /**
@@ -56,20 +51,7 @@
       prefix,
       context: "Argument 1",
     });
-    const byteArray = ArrayPrototypeMap(
-      [...new SafeArrayIterator(data)],
-      (char) => {
-        const charCode = StringPrototypeCharCodeAt(char, 0);
-        if (charCode > 0xff) {
-          throw new DOMException(
-            "The string to be encoded contains characters outside of the Latin1 range.",
-            "InvalidCharacterError",
-          );
-        }
-        return charCode;
-      },
-    );
-    return forgivingBase64Encode(TypedArrayFrom(Uint8Array, byteArray));
+    return forgivingBase64Encode(data);
   }
 
   window.__bootstrap.base64 = {

--- a/ext/web/internal.d.ts
+++ b/ext/web/internal.d.ts
@@ -43,8 +43,8 @@ declare namespace globalThis {
         result: string;
         position: number;
       };
-      forgivingBase64Encode(data: Uint8Array): string;
-      forgivingBase64Decode(data: string): Uint8Array;
+      forgivingBase64Encode(data: string): string;
+      forgivingBase64Decode(data: string): string;
     };
 
     declare var domException: {


### PR DESCRIPTION
Attempt to at least somewhat fix #13838.

### Before:
```
base64_roundtrip:       n = 10, dt = 4.157s, r = 2/s, t = 415700000ns/op
```

## After:
```
base64_roundtrip:       n = 10, dt = 1.936s, r = 5/s, t = 193600000ns/op
```
