### PR TITLE
fix(info): print output with unescaped backslashes on windows

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -328,6 +328,8 @@ fn print_cache_info(
       origin_dir.join(&checksum::gen(&[location.to_string().as_bytes()]));
   }
 
+  let local_storage_dir = origin_dir.join("local_storage");
+
   if json {
     let mut output = json!({
       "denoDir": deno_dir,
@@ -339,33 +341,33 @@ fn print_cache_info(
 
     if location.is_some() {
       output["localStorage"] =
-        serde_json::to_value(origin_dir.join("local_storage"))?;
+        serde_json::to_value(local_storage_dir)?;
     }
 
     write_json_to_stdout(&output)
   } else {
-    println!("{} {:?}", colors::bold("DENO_DIR location:"), deno_dir);
+    println!("{} {}", colors::bold("DENO_DIR location:"), deno_dir.display());
     println!(
-      "{} {:?}",
+      "{} {}",
       colors::bold("Remote modules cache:"),
-      modules_cache
+      modules_cache.display()
     );
     println!(
-      "{} {:?}",
+      "{} {}",
       colors::bold("Emitted modules cache:"),
-      typescript_cache
+      typescript_cache.display()
     );
     println!(
-      "{} {:?}",
+      "{} {}",
       colors::bold("Language server registries cache:"),
-      registry_cache,
+      registry_cache.display(),
     );
-    println!("{} {:?}", colors::bold("Origin storage:"), origin_dir);
+    println!("{} {}", colors::bold("Origin storage:"), origin_dir.display());
     if location.is_some() {
       println!(
-        "{} {:?}",
+        "{} {}",
         colors::bold("Local Storage:"),
-        origin_dir.join("local_storage"),
+        local_storage_dir.display(),
       );
     }
     Ok(())

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -340,13 +340,16 @@ fn print_cache_info(
     });
 
     if location.is_some() {
-      output["localStorage"] =
-        serde_json::to_value(local_storage_dir)?;
+      output["localStorage"] = serde_json::to_value(local_storage_dir)?;
     }
 
     write_json_to_stdout(&output)
   } else {
-    println!("{} {}", colors::bold("DENO_DIR location:"), deno_dir.display());
+    println!(
+      "{} {}",
+      colors::bold("DENO_DIR location:"),
+      deno_dir.display()
+    );
     println!(
       "{} {}",
       colors::bold("Remote modules cache:"),
@@ -362,7 +365,11 @@ fn print_cache_info(
       colors::bold("Language server registries cache:"),
       registry_cache.display(),
     );
-    println!("{} {}", colors::bold("Origin storage:"), origin_dir.display());
+    println!(
+      "{} {}",
+      colors::bold("Origin storage:"),
+      origin_dir.display()
+    );
     if location.is_some() {
       println!(
         "{} {}",

--- a/cli/tests/testdata/041_info_flag.out
+++ b/cli/tests/testdata/041_info_flag.out
@@ -1,5 +1,5 @@
-DENO_DIR location: "[WILDCARD]"
-Remote modules cache: "[WILDCARD]deps"
-Emitted modules cache: "[WILDCARD]gen"
-Language server registries cache: "[WILDCARD]registries"
-Origin storage: "[WILDCARD]location_data"
+DENO_DIR location: [WILDCARD]
+Remote modules cache: [WILDCARD]deps
+Emitted modules cache: [WILDCARD]gen
+Language server registries cache: [WILDCARD]registries
+Origin storage: [WILDCARD]location_data

--- a/cli/tests/testdata/041_info_flag_location.out
+++ b/cli/tests/testdata/041_info_flag_location.out
@@ -1,6 +1,6 @@
-DENO_DIR location: "[WILDCARD]"
-Remote modules cache: "[WILDCARD]deps"
-Emitted modules cache: "[WILDCARD]gen"
-Language server registries cache: "[WILDCARD]registries"
-Origin storage: "[WILDCARD]location_data[WILDCARD]"
-Local Storage: "[WILDCARD]location_data[WILDCARD]local_storage"
+DENO_DIR location: [WILDCARD]
+Remote modules cache: [WILDCARD]deps
+Emitted modules cache: [WILDCARD]gen
+Language server registries cache: [WILDCARD]registries
+Origin storage: [WILDCARD]location_data[WILDCARD]
+Local Storage: [WILDCARD]location_data[WILDCARD]local_storage


### PR DESCRIPTION
Should fix #13076 so stuff this like:

```
DENO_DIR location: "C:\\Users\\GJZwiers\\AppData\\Local\\deno"
```

becomes:

```
DENO_DIR location: C:\Users\GJZwiers\AppData\Local\deno
```

But I'm not sure how to write a test, because it's using `[WILDCARD]`

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
