### PR TITLE
perf(core): use raw v8 get/set data

### DIFF
--- a/core/modules.rs
+++ b/core/modules.rs
@@ -7,6 +7,7 @@ use crate::module_specifier::ModuleSpecifier;
 use crate::resolve_import;
 use crate::resolve_url;
 use crate::runtime::exception_to_err_result;
+use crate::JsRuntime;
 use crate::OpState;
 use anyhow::Error;
 use futures::future::FutureExt;
@@ -126,10 +127,7 @@ fn json_module_evaluation_steps<'a>(
 ) -> Option<v8::Local<'a, v8::Value>> {
   let scope = &mut unsafe { v8::CallbackScope::new(context) };
   let tc_scope = &mut v8::TryCatch::new(scope);
-  let module_map = tc_scope
-    .get_slot::<Rc<RefCell<ModuleMap>>>()
-    .unwrap()
-    .clone();
+  let module_map = JsRuntime::module_map(tc_scope);
 
   let handle = v8::Global::<v8::Module>::new(tc_scope, module);
   let value_handle = module_map


### PR DESCRIPTION
Instead of rusty_v8's Annex to reduce lookup overhead

```
Before:
test bench_is_proxy   ... bench:      20,051 ns/iter (+/- 860)
test bench_op_async   ... bench:     391,111 ns/iter (+/- 5,354)
test bench_op_nop     ... bench:      52,359 ns/iter (+/- 1,942)
test bench_op_pi_json ... bench:      54,409 ns/iter (+/- 1,326)

After:
test bench_is_proxy   ... bench:      20,292 ns/iter (+/- 480)
test bench_op_async   ... bench:     385,609 ns/iter (+/- 5,775)
test bench_op_nop     ... bench:      46,042 ns/iter (+/- 1,785)
test bench_op_pi_json ... bench:      49,903 ns/iter (+/- 668)
```

Blocked on https://github.com/denoland/rusty_v8/pull/911