### PR TITLE
chore(CODEOWNERS): add @AaronO on core/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ cli/dts/        @kitsonk
 cli/lsp/        @dsherret @kitsonk
 cli/schemas/    @kitsonk
 cli/tsc/        @kitsonk
-core/           @bartlomieju
+core/           @AaronO @bartlomieju
 docs/           @ry
 ext/            @bartlomieju @crowlKats @lucacasonato @littledivy
 ext/tls/        @piscisaureus


### PR DESCRIPTION
Adding myself as a "code owner" / "default reviewer" to `core/` since I'm familiar with the op-layer and other parts of core.