### PR TITLE
chore: update regex to 1.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,7 @@ deno_web = { version = "0.70.0", path = "../ext/web" }
 deno_webgpu = { version = "0.40.0", path = "../ext/webgpu" }
 deno_websocket = { version = "0.44.0", path = "../ext/websocket" }
 deno_webstorage = { version = "0.34.0", path = "../ext/webstorage" }
-regex = "=1.5.4"
+regex = "=1.5.5"
 serde = { version = "=1.0.133", features = ["derive"] }
 zstd = '=0.9.2'
 
@@ -80,7 +80,7 @@ once_cell = "=1.9.0"
 percent-encoding = "=2.1.0"
 pin-project = "=1.0.8"
 rand = { version = "=0.8.4", features = ["small_rng"] }
-regex = "=1.5.4"
+regex = "=1.5.5"
 ring = "=0.16.20"
 rustyline = { version = "=9.1.2", default-features = false }
 rustyline-derive = "=0.6.0"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -74,7 +74,7 @@ lzzzz = '=0.8.0'
 netif = "0.1.3"
 notify = "=5.0.0-pre.12"
 once_cell = "=1.9.0"
-regex = "1.5.4"
+regex = "1.5.5"
 ring = "0.16.20"
 serde = { version = "1.0.129", features = ["derive"] }
 signal-hook-registry = "1.4.0"

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -20,7 +20,7 @@ futures = "0.3.21"
 hyper = { version = "0.14.12", features = ["server", "http1", "http2", "runtime"] }
 lazy_static = "1.4.0"
 os_pipe = "0.9.2"
-regex = "1.5.4"
+regex = "1.5.5"
 rustls-pemfile = "0.2.1"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.65"


### PR DESCRIPTION
https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html