### PR TITLE
feat(ext/net): Add recvBufferSize options to ListenDatagram

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1006,10 +1006,19 @@ declare namespace Deno {
    *   transport: "udp"
    * });
    * ```
+   * Listen with a specific buffer size, if not provided it defaults to 1024.
+   *
+   * ```ts
+   * const listener = Deno.listenDatagram({
+   *   port: 80,
+   *   transport: "udp"
+   * }, 2048);
+   * ```
    *
    * Requires `allow-net` permission. */
   export function listenDatagram(
     options: ListenOptions & { transport: "udp" },
+    receivBuffSize?: number,
   ): DatagramConn;
 
   /** **UNSTABLE**: new API, yet to be vetted
@@ -1026,6 +1035,7 @@ declare namespace Deno {
    * Requires `allow-read` and `allow-write` permission. */
   export function listenDatagram(
     options: UnixListenOptions & { transport: "unixpacket" },
+    receivBuffSize?: number,
   ): DatagramConn;
 
   export interface UnixConnectOptions {

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -457,6 +457,74 @@ Deno.test(
 );
 
 Deno.test(
+  { permissions: { net: true } },
+  async function netUdpReceiveBuffSize() {
+    const buffsize = 8;
+    const alice = Deno.listenDatagram({ port: 3500, transport: "udp" });
+    const bob = Deno.listenDatagram({ port: 4501, transport: "udp" }, buffsize);
+
+    const sent = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    await alice.send(sent, bob.addr);
+    const [recvd, ] = await bob.receive();
+    assertEquals(recvd.length, 8);
+    assertEquals(sent, recvd);
+    alice.close();
+    bob.close();
+  },
+);
+
+Deno.test(
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
+  async function netUnixPacketReceiveBuffSize() {
+    const buffsize = 8;
+    const filePath = await Deno.makeTempFile();
+    const alice = Deno.listenDatagram({
+      path: filePath,
+      transport: "unixpacket",
+    });
+    const bob = Deno.listenDatagram({
+      path: filePath,
+      transport: "unixpacket",
+    }, buffsize);
+
+    const sent = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    await alice.send(sent, bob.addr);
+    const [recvd, ] = await bob.receive();
+    assertEquals(recvd.length, 8);
+    assertEquals(sent, recvd);
+    alice.close();
+    bob.close();
+  },
+);
+
+Deno.test(
+  { permissions: { net: true } },
+  async function netUdpReceiveWithSetBuffSize() {
+    const buffsize = 3;
+    const alice = Deno.listenDatagram({ port: 3500, transport: "udp" }, buffsize * 2);
+    const bob = Deno.listenDatagram({ port: 4501, transport: "udp" }, buffsize);
+
+    const alicebuff = new Uint8Array([1, 2, 3, 4]);
+    const bobbuff = new Uint8Array([1, 2, 3, 4, 5, 6, 7]);
+
+    await alice.send(alicebuff, bob.addr);
+    const [recvd, ] = await bob.receive();
+    assertEquals(recvd.length, buffsize);
+    assertEquals(new Uint8Array([1, 2, 3]), recvd);
+    
+    await bob.send(bobbuff, alice.addr);
+    const [recvd2, ] = await alice.receive();
+    assertEquals(recvd2.length, buffsize * 2);
+    assertEquals(new Uint8Array([1, 2, 3, 4, 5, 6]), recvd2);
+    alice.close();
+    bob.close();
+  },
+);
+
+Deno.test(
   {
     ignore: Deno.build.os === "windows",
     permissions: { read: true, write: true },

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -465,7 +465,7 @@ Deno.test(
 
     const sent = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
     await alice.send(sent, bob.addr);
-    const [recvd, ] = await bob.receive();
+    const [recvd] = await bob.receive();
     assertEquals(recvd.length, 8);
     assertEquals(sent, recvd);
     alice.close();
@@ -492,7 +492,7 @@ Deno.test(
 
     const sent = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
     await alice.send(sent, bob.addr);
-    const [recvd, ] = await bob.receive();
+    const [recvd] = await bob.receive();
     assertEquals(recvd.length, 8);
     assertEquals(sent, recvd);
     alice.close();
@@ -504,19 +504,22 @@ Deno.test(
   { permissions: { net: true } },
   async function netUdpReceiveWithSetBuffSize() {
     const buffsize = 3;
-    const alice = Deno.listenDatagram({ port: 3500, transport: "udp" }, buffsize * 2);
+    const alice = Deno.listenDatagram(
+      { port: 3500, transport: "udp" },
+      buffsize * 2,
+    );
     const bob = Deno.listenDatagram({ port: 4501, transport: "udp" }, buffsize);
 
     const alicebuff = new Uint8Array([1, 2, 3, 4]);
     const bobbuff = new Uint8Array([1, 2, 3, 4, 5, 6, 7]);
 
     await alice.send(alicebuff, bob.addr);
-    const [recvd, ] = await bob.receive();
+    const [recvd] = await bob.receive();
     assertEquals(recvd.length, buffsize);
     assertEquals(new Uint8Array([1, 2, 3]), recvd);
-    
+
     await bob.send(bobbuff, alice.addr);
-    const [recvd2, ] = await alice.receive();
+    const [recvd2] = await alice.receive();
     assertEquals(recvd2.length, buffsize * 2);
     assertEquals(new Uint8Array([1, 2, 3, 4, 5, 6]), recvd2);
     alice.close();

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -253,10 +253,10 @@
     #rid = 0;
     #addr = null;
 
-    constructor(rid, addr, bufSize = 1024) {
+    constructor(rid, addr, recvBufferSize = 1024) {
       this.#rid = rid;
       this.#addr = addr;
-      this.bufSize = bufSize;
+      this.bufSize = recvBufferSize;
     }
 
     get rid() {

--- a/ext/net/04_net_unstable.js
+++ b/ext/net/04_net_unstable.js
@@ -15,6 +15,7 @@
 
   function listenDatagram(
     options,
+    recvBufferSize = 1024,
   ) {
     let res;
     if (options.transport === "unixpacket") {
@@ -27,7 +28,7 @@
       });
     }
 
-    return new net.Datagram(res.rid, res.localAddr);
+    return new net.Datagram(res.rid, res.localAddr, recvBufferSize);
   }
 
   async function connect(


### PR DESCRIPTION
Following an this issue #12822 and some need for a DTLS module, i've added recvBufferSize option to the ListenDatagram function, by default it is set to 1024 (like it was before)

#13625 this pr is a follow up of this issue.

*this is my first PR, I don't know if i did everything properly or if I missed something*