### PR TITLE
fix(ext/crypto): use EcKeyImportParams dictionary

### DIFF
--- a/ext/crypto/01_webidl.js
+++ b/ext/crypto/01_webidl.js
@@ -153,18 +153,6 @@
   webidl.converters.EcKeyGenParams = webidl
     .createDictionaryConverter("EcKeyGenParams", dictEcKeyGenParams);
 
-  const dictEcImportParams = [
-    ...new SafeArrayIterator(dictAlgorithm),
-    {
-      key: "namedCurve",
-      converter: webidl.converters.NamedCurve,
-      required: true,
-    },
-  ];
-
-  webidl.converters.EcImportParams = webidl
-    .createDictionaryConverter("EcImportParams", dictEcImportParams);
-
   const dictAesKeyGenParams = [
     ...new SafeArrayIterator(dictAlgorithm),
     {

--- a/ext/crypto/lib.deno_crypto.d.ts
+++ b/ext/crypto/lib.deno_crypto.d.ts
@@ -82,7 +82,7 @@ interface EcKeyGenParams extends Algorithm {
   namedCurve: NamedCurve;
 }
 
-interface EcImportParams extends Algorithm {
+interface EcKeyImportParams extends Algorithm {
   namedCurve: NamedCurve;
 }
 
@@ -210,7 +210,7 @@ interface SubtleCrypto {
       | AlgorithmIdentifier
       | HmacImportParams
       | RsaHashedImportParams
-      | EcImportParams,
+      | EcKeyImportParams,
     extractable: boolean,
     keyUsages: KeyUsage[],
   ): Promise<CryptoKey>;
@@ -221,7 +221,7 @@ interface SubtleCrypto {
       | AlgorithmIdentifier
       | HmacImportParams
       | RsaHashedImportParams
-      | EcImportParams,
+      | EcKeyImportParams,
     extractable: boolean,
     keyUsages: KeyUsage[],
   ): Promise<CryptoKey>;
@@ -309,7 +309,7 @@ interface SubtleCrypto {
       | AlgorithmIdentifier
       | HmacImportParams
       | RsaHashedImportParams
-      | EcImportParams,
+      | EcKeyImportParams,
     extractable: boolean,
     keyUsages: KeyUsage[],
   ): Promise<CryptoKey>;


### PR DESCRIPTION
as per https://w3c.github.io/webcrypto/#webidl-410131068

currently, universal code referencing the `EcKeyImportParams` interface doesn't work

```
Uncaught TypeError: TS2304 [ERROR]: Cannot find name 'EcKeyImportParams'
```