### PR TITLE
refactor(core): validate promise id in refOp

### DIFF
--- a/cli/tests/unit/opcall_test.ts
+++ b/cli/tests/unit/opcall_test.ts
@@ -20,13 +20,6 @@ Deno.test(async function sendAsyncStackTrace() {
   }
 });
 
-declare global {
-  namespace Deno {
-    // deno-lint-ignore no-explicit-any, no-var
-    var core: any;
-  }
-}
-
 Deno.test(async function opsAsyncBadResource() {
   try {
     const nonExistingRid = 9999;

--- a/cli/tests/unit/opcall_test.ts
+++ b/cli/tests/unit/opcall_test.ts
@@ -20,6 +20,13 @@ Deno.test(async function sendAsyncStackTrace() {
   }
 });
 
+declare global {
+  namespace Deno {
+    // deno-lint-ignore no-explicit-any, no-var
+    var core: any;
+  }
+}
+
 Deno.test(async function opsAsyncBadResource() {
   try {
     const nonExistingRid = 9999;

--- a/cli/tests/unit/ref_unref_test.ts
+++ b/cli/tests/unit/ref_unref_test.ts
@@ -1,0 +1,27 @@
+import { assertThrows } from "./test_util.ts";
+
+Deno.test("ref/unref throws when called with invalid promise ids", () => {
+  assertThrows(
+    () => {
+      Deno.core.refOp(-1);
+    },
+    Error,
+    "Async op of the given promise id doesn't exist",
+  );
+  assertThrows(
+    () => {
+      Deno.core.unrefOp(-1);
+    },
+    Error,
+    "Async op of the given promise id doesn't exist",
+  );
+});
+
+Deno.test("ref/unref doesn't throw when called with valid promise ids", () => {
+  const cancelId = Deno.core.opSync("op_timer_handle");
+  const op = Deno.core.opAsync("op_sleep", 100, cancelId);
+  op.catch(() => {/* ignore error */});
+  Deno.core.unrefOp(op[Symbol.for("Deno.core.internalPromiseId")]);
+  Deno.core.refOp(op[Symbol.for("Deno.core.internalPromiseId")]);
+  Deno.core.tryClose(cancelId);
+});

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -28,9 +28,20 @@ export function pathToAbsoluteFileUrl(path: string): URL {
   return new URL(`file://${Deno.build.os === "windows" ? "/" : ""}${path}`);
 }
 
-declare global {
-  namespace Deno {
-    // deno-lint-ignore no-explicit-any, no-var
-    var core: any;
-  }
+const decoder = new TextDecoder();
+
+export async function execCode(code: string) {
+  const p = Deno.run({
+    cmd: [
+      Deno.execPath(),
+      "eval",
+      "--unstable",
+      "--no-check",
+      code,
+    ],
+    stdout: "piped",
+  });
+  const [status, output] = await Promise.all([p.status(), p.output()]);
+  p.close();
+  return [status.code, decoder.decode(output)];
 }

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -27,3 +27,10 @@ export function pathToAbsoluteFileUrl(path: string): URL {
 
   return new URL(`file://${Deno.build.os === "windows" ? "/" : ""}${path}`);
 }
+
+declare global {
+  namespace Deno {
+    // deno-lint-ignore no-explicit-any, no-var
+    var core: any;
+  }
+}

--- a/cli/tests/unit/timers_test.ts
+++ b/cli/tests/unit/timers_test.ts
@@ -6,10 +6,9 @@ import {
   Deferred,
   deferred,
   delay,
+  execCode,
   unreachable,
 } from "./test_util.ts";
-
-const decoder = new TextDecoder();
 
 Deno.test(async function functionParameterBindingSuccess() {
   const promise = deferred();
@@ -577,21 +576,6 @@ Deno.test(
     await p;
   },
 );
-
-async function execCode(code: string) {
-  const p = Deno.run({
-    cmd: [
-      Deno.execPath(),
-      "eval",
-      "--unstable",
-      code,
-    ],
-    stdout: "piped",
-  });
-  const [status, output] = await Promise.all([p.status(), p.output()]);
-  p.close();
-  return [status.code, decoder.decode(output)];
-}
 
 Deno.test({
   name: "unrefTimer",

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -184,21 +184,15 @@
   }
 
   function refOp(promiseId) {
-    // TODO(kt3k): Move this check to rust side.
     if (!hasPromise(promiseId)) {
-      throw new Error(
-        `Async op of the given promise id doesn't exist: id=${promiseId}`,
-      );
+      return;
     }
     refOp_(promiseId);
   }
 
   function unrefOp(promiseId) {
-    // TODO(kt3k): Move this check to rust side.
     if (!hasPromise(promiseId)) {
-      throw new Error(
-        `Async op of the given promise id doesn't exist: id=${promiseId}`,
-      );
+      return;
     }
     unrefOp_(promiseId);
   }

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -29,7 +29,7 @@
   } = window.__bootstrap.primordials;
 
   // Available on start due to bindings.
-  const { opcallSync, opcallAsync } = window.Deno.core;
+  const { opcallSync, opcallAsync, refOp_, unrefOp_ } = window.Deno.core;
 
   let opsCache = {};
   const errorMap = {};
@@ -97,6 +97,17 @@
     promise.resolve = resolve;
     promise.reject = reject;
     return promise;
+  }
+
+  function hasPromise(promiseId) {
+    // Check if out of ring bounds, fallback to map
+    const outOfBounds = promiseId < nextPromiseId - RING_SIZE;
+    if (outOfBounds) {
+      return MapPrototypeHas(promiseMap, promiseId);
+    }
+    // Otherwise check it in ring
+    const idx = promiseId % RING_SIZE;
+    return promiseRing[idx] != NO_PROMISE;
   }
 
   function ops() {
@@ -170,6 +181,26 @@
 
   function opSync(opName, arg1 = null, arg2 = null) {
     return unwrapOpResult(opcallSync(opsCache[opName], arg1, arg2));
+  }
+
+  function refOp(promiseId) {
+    // TODO(kt3k): Move this check to rust side.
+    if (!hasPromise(promiseId)) {
+      throw new Error(
+        `Async op of the given promise id doesn't exist: id=${promiseId}`,
+      );
+    }
+    refOp_(promiseId);
+  }
+
+  function unrefOp(promiseId) {
+    // TODO(kt3k): Move this check to rust side.
+    if (!hasPromise(promiseId)) {
+      throw new Error(
+        `Async op of the given promise id doesn't exist: id=${promiseId}`,
+      );
+    }
+    unrefOp_(promiseId);
   }
 
   function resources() {
@@ -252,6 +283,8 @@
     enableOpCallTracing,
     isOpCallTracingEnabled,
     opCallTraces,
+    refOp,
+    unrefOp,
   });
 
   ObjectAssign(globalThis.__bootstrap, { core });

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -173,8 +173,8 @@ pub fn initialize_context<'s>(
   // Bind functions to Deno.core.*
   set_func(scope, core_val, "opcallSync", opcall_sync);
   set_func(scope, core_val, "opcallAsync", opcall_async);
-  set_func(scope, core_val, "refOp", ref_op);
-  set_func(scope, core_val, "unrefOp", unref_op);
+  set_func(scope, core_val, "refOp_", ref_op);
+  set_func(scope, core_val, "unrefOp_", unref_op);
   set_func(
     scope,
     core_val,


### PR DESCRIPTION
This PR adds the wrappers of the existing `core.refOp` and `core.unrefOp`, and checks if the given promise ids are valid.

Currently we don't check whether the promise id is valid or not. If a wrong promise id is given to `core.unrefOp`, that id remains in pending_ops vector, and causes the exit condition incorrect (Deno program can exit with valid ops still remaining).

---
This implements the idea by @andreubotella in the comment https://github.com/denoland/deno/pull/12889#discussion_r756966729