### PR TITLE
chore(test): fix flaky tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,12 +1068,13 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad23aacc3db4f37eb88fb9c874a85a4abe5eab14a98fc070ee8df9e204f243e6"
+checksum = "5a528d67d2c9efba7316669eee5889e0dc150297799d3824d35f187596bec94b"
 dependencies = [
  "anyhow",
  "futures",
+ "os_pipe",
  "pretty_assertions 1.1.0",
  "tokio",
 ]
@@ -2643,9 +2644,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "os_pipe"
-version = "0.9.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
+checksum = "2c92f2b54f081d635c77e7120862d48db8e91f7f21cef23ab1b4fe9971c59f55"
 dependencies = [
  "libc",
  "winapi 0.3.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,7 @@ dependencies = [
  "os_pipe",
  "percent-encoding",
  "pin-project",
- "pretty_assertions 0.7.2",
+ "pretty_assertions",
  "rand 0.8.4",
  "regex",
  "ring",
@@ -1068,14 +1068,13 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a528d67d2c9efba7316669eee5889e0dc150297799d3824d35f187596bec94b"
+checksum = "fafb65c387677c45078adb3bb70503128cadd0ee94772167be4f7da8549434dc"
 dependencies = [
  "anyhow",
  "futures",
  "os_pipe",
- "pretty_assertions 1.1.0",
  "tokio",
 ]
 
@@ -2903,18 +2902,6 @@ name = "pretty_assertions"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
-dependencies = [
- "ansi_term",
- "ctor",
- "diff",
- "output_vt100",
-]
-
-[[package]]
-name = "pretty_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d5b548b725018ab5496482b45cb8bef21e9fed1858a6d674e3a8a0f0bb5d50"
 dependencies = [
  "ansi_term",
  "ctor",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,7 @@ deno_doc = "0.32.0"
 deno_graph = "0.24.0"
 deno_lint = { version = "0.26.0", features = ["docs"] }
 deno_runtime = { version = "0.48.0", path = "../runtime" }
-deno_task_shell = "0.1.7"
+deno_task_shell = "0.1.8"
 
 atty = "=0.2.14"
 base64 = "=0.13.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,7 @@ deno_doc = "0.32.0"
 deno_graph = "0.24.0"
 deno_lint = { version = "0.26.0", features = ["docs"] }
 deno_runtime = { version = "0.48.0", path = "../runtime" }
-deno_task_shell = "0.1.6"
+deno_task_shell = "0.1.7"
 
 atty = "=0.2.14"
 base64 = "=0.13.0"
@@ -106,7 +106,7 @@ winapi = { version = "=0.3.9", features = ["knownfolders", "mswsock", "objbase",
 [dev-dependencies]
 deno_bench_util = { version = "0.34.0", path = "../bench_util" }
 flaky_test = "=0.1.0"
-os_pipe = "=0.9.2"
+os_pipe = "=1.0.1"
 pretty_assertions = "=0.7.2"
 test_util = { path = "../test_util" }
 trust-dns-client = "=0.20.3"

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -19,7 +19,7 @@ base64 = "0.13.0"
 futures = "0.3.21"
 hyper = { version = "0.14.12", features = ["server", "http1", "http2", "runtime"] }
 lazy_static = "1.4.0"
-os_pipe = "0.9.2"
+os_pipe = "1.0.1"
 regex = "1.5.5"
 rustls-pemfile = "0.2.1"
 serde = { version = "1.0.126", features = ["derive"] }


### PR DESCRIPTION
The tasks were flaky. Now it's been rewritten to use os pipes so when it writes to stdout it will write directly to that pipe instead of through a series of tokio channels.