### PR TITLE
chore(test_util): use pretty_assertions when not pattern matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,9 +2926,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty_assertions"
-version = "0.7.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+checksum = "57c038cb5319b9c704bf9c227c261d275bfec0ad438118a2787ce47944fb228b"
 dependencies = [
  "ansi_term",
  "ctor",
@@ -4346,6 +4346,7 @@ dependencies = [
  "hyper",
  "lazy_static",
  "os_pipe",
+ "pretty_assertions",
  "pty",
  "regex",
  "rustls-pemfile 0.2.1",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -98,7 +98,7 @@ winapi = { version = "=0.3.9", features = ["knownfolders", "mswsock", "objbase",
 deno_bench_util = { version = "0.34.0", path = "../bench_util" }
 flaky_test = "=0.1.0"
 os_pipe = "=1.0.1"
-pretty_assertions = "=0.7.2"
+pretty_assertions = "=1.2.0"
 test_util = { path = "../test_util" }
 trust-dns-client = "=0.20.3"
 trust-dns-server = "=0.20.3"

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3.21"
 hyper = { version = "0.14.12", features = ["server", "http1", "http2", "runtime"] }
 lazy_static = "1.4.0"
 os_pipe = "1.0.1"
+pretty_assertions = "=1.2.0"
 regex = "1.5.5"
 rustls-pemfile = "0.2.1"
 serde = { version = "1.0.126", features = ["derive"] }

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -15,6 +15,7 @@ use hyper::Response;
 use hyper::StatusCode;
 use lazy_static::lazy_static;
 use os_pipe::pipe;
+use pretty_assertions::assert_eq;
 use regex::Regex;
 use rustls::Certificate;
 use rustls::PrivateKey;
@@ -1801,7 +1802,9 @@ impl CheckOutputIntegrationTest {
       std::fs::read_to_string(output_path).expect("cannot read output")
     };
 
-    if !wildcard_match(&expected, &actual) {
+    if !expected.contains("[WILDCARD]") {
+      assert_eq!(actual, expected)
+    } else if !wildcard_match(&expected, &actual) {
       println!("OUTPUT\n{}\nOUTPUT", actual);
       println!("EXPECTED\n{}\nEXPECTED", expected);
       panic!("pattern match failed");
@@ -2090,6 +2093,7 @@ pub fn parse_max_mem(output: &str) -> Option<u64> {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use pretty_assertions::assert_eq;
 
   #[test]
   fn parse_wrk_output_1() {


### PR DESCRIPTION
If the assertion string doesn't contain "[WILDCARD]" then it uses `pretty_assertions::assert_eq` for better output.