### PR TITLE
feat(task): add unstable warning to `deno task`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafb65c387677c45078adb3bb70503128cadd0ee94772167be4f7da8549434dc"
+checksum = "b4b477c481d76502130fc5a212900fbe9da9520ad65c54c7e6a7cb129df082fb"
 dependencies = [
  "anyhow",
  "futures",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,7 +41,7 @@ deno_doc = "0.32.0"
 deno_graph = "0.24.0"
 deno_lint = { version = "0.26.0", features = ["docs"] }
 deno_runtime = { version = "0.48.0", path = "../runtime" }
-deno_task_shell = "0.1.8"
+deno_task_shell = "0.1.9"
 
 atty = "=0.2.14"
 base64 = "=0.13.0"

--- a/cli/tests/integration/task_tests.rs
+++ b/cli/tests/integration/task_tests.rs
@@ -25,7 +25,7 @@ itest!(task_boolean_logic {
   envs: vec![("NO_COLOR".to_string(), "1".to_string())],
 });
 
-itest!(task_exit_code_1 {
+itest!(task_exit_code_5 {
   args: "task --config task/deno.json exit_code_5",
   output: "task/task_exit_code_5.out",
   envs: vec![("NO_COLOR".to_string(), "1".to_string())],

--- a/cli/tests/testdata/task/task_exit_code_5.out
+++ b/cli/tests/testdata/task/task_exit_code_5.out
@@ -1,2 +1,3 @@
-Task exit_code_5 echo $(echo 10 ; exit 2) && exit 5 
+Warning deno task is unstable and may drastically change in the future
+Task exit_code_5 echo $(echo 10 ; exit 2) && exit 5
 10

--- a/cli/tests/testdata/task/task_non_existent.out
+++ b/cli/tests/testdata/task/task_non_existent.out
@@ -1,3 +1,4 @@
+Warning deno task is unstable and may drastically change in the future
 Task not found: non_existent
 Available tasks:
 - boolean_logic

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -52,6 +52,10 @@ pub async fn execute_script(
   flags: Flags,
   task_flags: TaskFlags,
 ) -> Result<i32, AnyError> {
+  log::warn!(
+    "{} deno task is unstable and may drastically change in the future",
+    crate::colors::yellow("Warning"),
+  );
   let flags = Arc::new(flags);
   let ps = ProcState::build(flags.clone()).await?;
   let tasks_config = get_tasks_config(ps.maybe_config_file.as_ref())?;
@@ -81,13 +85,14 @@ pub async fn execute_script(
       .collect::<Vec<_>>()
       .join(" ");
     let script = format!("{} {}", script, additional_args);
+    let script = script.trim();
     log::info!(
       "{} {} {}",
       colors::green("Task"),
       colors::cyan(&task_name),
-      script
+      script,
     );
-    let seq_list = deno_task_shell::parser::parse(&script)
+    let seq_list = deno_task_shell::parser::parse(script)
       .with_context(|| format!("Error parsing script '{}'.", task_name))?;
     let env_vars = std::env::vars().collect::<HashMap<String, String>>();
     let exit_code = deno_task_shell::execute(seq_list, env_vars, cwd).await;


### PR DESCRIPTION
Moving `deno task` to unstable. This will allow us to validate the approach before stabilizing it.