### PR TITLE
perf(web): use DOMString for BlobParts

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -56,6 +56,13 @@ function benchUrlParse() {
   });
 }
 
+function benchLargeBlobText() {
+  const input = "long-string".repeat(999_999);
+  benchSync("blob_text_large", 3, () => {
+    new Blob([input]).text();
+  });
+}
+
 function benchDateNow() {
   benchSync("date_now", 5e5, () => {
     Date.now();
@@ -123,6 +130,7 @@ async function main() {
   // A common "language feature", that should be fast
   // also a decent representation of a non-trivial JSON-op
   benchUrlParse();
+  benchLargeBlobText();
   benchB64RtLong();
   benchB64RtShort();
   // IO ops

--- a/ext/web/09_file.js
+++ b/ext/web/09_file.js
@@ -394,7 +394,10 @@
         return webidl.converters["ArrayBufferView"](V, opts);
       }
     }
-    return webidl.converters["USVString"](V, opts);
+    // BlobPart is passed to processBlobParts after conversion, which calls core.encode()
+    // on the string.
+    // core.encode() is equivalent to USVString normalization.
+    return webidl.converters["DOMString"](V, opts);
   };
   webidl.converters["sequence<BlobPart>"] = webidl.createSequenceConverter(
     webidl.converters["BlobPart"],


### PR DESCRIPTION
70% faster than Node (24ms)
50% faster than Bun (14ms)

(above numbers taken from https://twitter.com/jarredsumner/status/1503888103227867136)

Before:
```
blob_text_large:     	n = 3, dt = 2.123s, r = 1/s, t = 707666666ns/op
```

After:
```
blob_text_large:     	n = 3, dt = 0.021s, r = 143/s, t = 7000000ns/op
```

Closes #13973 