### PR TITLE
chore: uploading WPT shouldn't make CI fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,7 @@ jobs:
                                              --wptreport=wptreport.json
 
       - name: Upload wpt results to dl.deno.land
+        continue-on-error: true
         if: |
           runner.os == 'Linux' &&
           matrix.job == 'test' &&
@@ -481,6 +482,7 @@ jobs:
           gsutil -h "Cache-Control: no-cache" cp wpt-latest.txt gs://dl.deno.land/wpt-latest.txt
 
       - name: Upload wpt results to wpt.fyi
+        continue-on-error: true
         if: |
           runner.os == 'Linux' &&
           matrix.job == 'test' &&


### PR DESCRIPTION
We had two successive main branch failures related to this.
- https://github.com/denoland/deno/runs/5566541876?check_suite_focus=true
- https://github.com/denoland/deno/runs/5566531944?check_suite_focus=true