### PR TITLE
chore: release script should automatically figure out CLI crate dependencies

### DIFF
--- a/tools/release/01_bump_crate_versions.ts
+++ b/tools/release/01_bump_crate_versions.ts
@@ -12,7 +12,7 @@ const originalCliVersion = cliCrate.version;
 await cliCrate.promptAndIncrement();
 
 // increment the dependency crate versions
-for (const crate of workspace.getDependencyCrates()) {
+for (const crate of workspace.getCliDependencyCrates()) {
   await crate.increment("minor");
 }
 

--- a/tools/release/02_publish_crates.ts
+++ b/tools/release/02_publish_crates.ts
@@ -6,7 +6,9 @@ import { getCratesPublishOrder } from "./deps.ts";
 const workspace = await DenoWorkspace.load();
 const cliCrate = workspace.getCliCrate();
 
-const dependencyCrates = getCratesPublishOrder(workspace.getDependencyCrates());
+const dependencyCrates = getCratesPublishOrder(
+  workspace.getCliDependencyCrates(),
+);
 
 try {
   for (const [i, crate] of dependencyCrates.entries()) {

--- a/tools/release/deno_workspace.ts
+++ b/tools/release/deno_workspace.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import { Crate, getCratesPublishOrder, path, Repo } from "./deps.ts";
+import { path, Repo } from "./deps.ts";
 
 export class DenoWorkspace {
   #repo: Repo;

--- a/tools/release/deno_workspace.ts
+++ b/tools/release/deno_workspace.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import { path, Repo } from "./deps.ts";
+import { Crate, getCratesPublishOrder, path, Repo } from "./deps.ts";
 
 export class DenoWorkspace {
   #repo: Repo;
@@ -28,40 +28,15 @@ export class DenoWorkspace {
     return this.#repo.crates;
   }
 
-  /** Gets the dependency crates used for the first part of the release process. */
-  getDependencyCrates() {
-    return [
-      this.getBenchUtilCrate(),
-      this.getSerdeV8Crate(),
-      this.getCoreCrate(),
-      ...this.getExtCrates(),
-      this.getRuntimeCrate(),
-    ];
-  }
-
-  getSerdeV8Crate() {
-    return this.getCrate("serde_v8");
+  /** Gets the CLI dependency crates that should be published. */
+  getCliDependencyCrates() {
+    return this.getCliCrate()
+      .descendantDependenciesInRepo()
+      .filter((c) => c.name !== "test_util");
   }
 
   getCliCrate() {
     return this.getCrate("deno");
-  }
-
-  getCoreCrate() {
-    return this.getCrate("deno_core");
-  }
-
-  getRuntimeCrate() {
-    return this.getCrate("deno_runtime");
-  }
-
-  getBenchUtilCrate() {
-    return this.getCrate("deno_bench_util");
-  }
-
-  getExtCrates() {
-    const extPath = path.join(this.#repo.folderPath, "ext");
-    return this.crates.filter((c) => c.manifestPath.startsWith(extPath));
   }
 
   getCrate(name: string) {

--- a/tools/release/deps.ts
+++ b/tools/release/deps.ts
@@ -1,3 +1,3 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-export * from "https://raw.githubusercontent.com/denoland/automation/0.4.0/mod.ts";
+export * from "https://raw.githubusercontent.com/denoland/automation/0.5.0/mod.ts";


### PR DESCRIPTION
Fixes the issue we saw with the last release.

This is the output now:

```
Setting deno to 1.20.1...      
Set version to 1.20.1
Setting deno_core to 0.124.0...
Setting serde_v8 to 0.35.0...
Setting deno_ops to 0.2.0... 
Setting deno_bench_util to 0.36.0...
Setting deno_runtime to 0.50.0...   
Setting deno_webstorage to 0.37.0...
Setting deno_web to 0.73.0...
Setting deno_webidl to 0.42.0...
Setting deno_url to 0.42.0...
Setting deno_websocket to 0.47.0...
Setting deno_tls to 0.29.0...
Setting deno_webgpu to 0.43.0...
Setting deno_net to 0.34.0...
Setting deno_http to 0.36.0...
Setting deno_ffi to 0.29.0...
Setting deno_fetch to 0.65.0...
Setting deno_crypto to 0.56.0...
Setting deno_console to 0.42.0...
Setting deno_broadcast_channel to 0.36.0...
```

Previously (deno_ops missing):

```
Setting deno to 1.20.1...
Set version to 1.20.1
Setting deno_bench_util to 0.36.0...
Setting serde_v8 to 0.35.0...
Setting deno_core to 0.124.0...
Setting deno_broadcast_channel to 0.36.0...
Setting deno_console to 0.42.0...
Setting deno_crypto to 0.56.0...
Setting deno_web to 0.73.0...
Setting deno_url to 0.42.0...
Setting deno_webidl to 0.42.0...
Setting deno_fetch to 0.65.0...
Setting deno_tls to 0.29.0...
Setting deno_ffi to 0.29.0...
Setting deno_http to 0.36.0...
Setting deno_websocket to 0.47.0...
Setting deno_net to 0.34.0...
Setting deno_webgpu to 0.43.0...
Setting deno_webstorage to 0.37.0...
Setting deno_runtime to 0.50.0...
```