### PR TITLE
docs(readme): Update readme to include MacPorts install

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ iwr https://deno.land/install.ps1 -useb | iex
 ```sh
 brew install deno
 ```
+[Macports](https://ports.macports.org/port/deno/summary) (Mac):
+
+```sh
+sudo port install deno
+```
 
 [Chocolatey](https://chocolatey.org/packages/deno) (Windows):
 


### PR DESCRIPTION
This PR changes readme.md to include a option using MacPorts. Deno_install includes MacPorts, and since scoop and chocolatey are included, MacPorts should be included too. 
