### PR TITLE
fix(config-file): config-file.v1.json schema should allow colons in the task name

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -315,7 +315,7 @@
       "description": "Configuration for deno task",
       "type": "object",
       "patternProperties": {
-        "^[A-Za-z][A-Za-z0-9_\\-]*$": {
+        "^[A-Za-z][A-Za-z0-9_\\-:]*$": {
           "type": "string",
           "description": "Command to execute for this task name."
         }


### PR DESCRIPTION
We accidentally missed this when adding support for having colons.