### PR TITLE
fix(bench): don't await synchronous bench cases

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -119,24 +119,29 @@ function benchOpVoidAsync() {
   );
 }
 
+function benchNop() {
+  return benchSync("nop", 1e6, () => {});
+}
+
 async function main() {
-  // v8 builtin that's close to the upper bound non-NOPs
-  benchDateNow();
-  // Void ops measure op-overhead
-  benchOpVoidSync();
-  await benchOpVoidAsync();
-  // A very lightweight op, that should be highly optimizable
-  benchPerfNow();
-  // A common "language feature", that should be fast
-  // also a decent representation of a non-trivial JSON-op
-  benchUrlParse();
-  benchLargeBlobText();
-  benchB64RtLong();
-  benchB64RtShort();
-  // IO ops
-  benchReadZero();
-  benchWriteNull();
-  await benchRead128k();
-  benchRequestNew();
+  // // v8 builtin that's close to the upper bound non-NOPs
+  // benchDateNow();
+  // // Void ops measure op-overhead
+  // benchOpVoidSync();
+  // await benchOpVoidAsync();
+  // // A very lightweight op, that should be highly optimizable
+  // benchPerfNow();
+  // // A common "language feature", that should be fast
+  // // also a decent representation of a non-trivial JSON-op
+  // benchUrlParse();
+  // benchLargeBlobText();
+  // benchB64RtLong();
+  // benchB64RtShort();
+  // // IO ops
+  // benchReadZero();
+  // benchWriteNull();
+  // await benchRead128k();
+  // benchRequestNew();
+  benchNop();
 }
 await main();

--- a/nop_bench.js
+++ b/nop_bench.js
@@ -1,0 +1,2 @@
+Deno.bench("nop", { warmup: 1e6, n: 1e6 }, () => {
+});

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -803,7 +803,7 @@
     }
   }
 
-  function runSyncBench(step) {
+  function runSyncBench(bench, step) {
     const warmupIterations = bench.warmupIterations;
     step.warmup = true;
 
@@ -821,7 +821,7 @@
     return "ok";
   }
 
-  async function runAsyncBench(step) {
+  async function runAsyncBench(bench, step) {
     const warmupIterations = bench.warmupIterations;
     step.warmup = true;
 
@@ -856,11 +856,11 @@
       // function to run it. One might be tempted to just always await
       // `bench.fn`, but that adds a lot of overhead to synchronous
       // benches.
-      if (result instanceof Promise) {
+      if (typeof result.then !== "undefined") {
         await result;
-        return await runAsyncBench(step);
+        return await runAsyncBench(bench, step);
       } else {
-        return runSyncBench(step);
+        return runSyncBench(bench, step);
       }
     } catch (error) {
       return {


### PR DESCRIPTION
This commit changes how benchmarks are run, to not await sync
cases, as it introduces noticable penalty per each iteration.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
