### PR TITLE
chore(ops): include argument position in serde_v8 errors

### DIFF
--- a/cli/tests/testdata/workers/test.ts
+++ b/cli/tests/testdata/workers/test.ts
@@ -593,7 +593,7 @@ Deno.test("Worker with invalid permission arg", function () {
         deno: { permissions: { env: "foo" } },
       }),
     TypeError,
-    'Error parsing args: (deno.permissions.env) invalid value: string "foo", expected "inherit" or boolean or string[]',
+    'Error parsing args at position 1: (deno.permissions.env) invalid value: string "foo", expected "inherit" or boolean or string[]',
   );
 });
 

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -237,7 +237,7 @@ fn codegen_arg(
     let #ident = match #core::serde_v8::from_v8(scope, #ident) {
       Ok(v) => v,
       Err(err) => {
-        let msg = format!("Error parsing args: {}", #core::anyhow::Error::from(err));
+        let msg = format!("Error parsing args at position {}: {}", #idx, #core::anyhow::Error::from(err));
         return #core::_ops::throw_type_error(scope, msg);
       }
     };


### PR DESCRIPTION
```
> Deno.core.opSync("op_base64_atob", 1)
Uncaught TypeError: Error parsing args at position 1: serde_v8 error: ExpectedString
    at Object.opSync (deno:core/01_core.js:174:38)
    at <anonymous>:2:11
```