### PR TITLE
cleanup(core): drop op_void_async's state arg

### DIFF
--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -59,7 +59,7 @@ pub fn op_void_sync() -> Result<(), Error> {
 }
 
 #[op]
-pub async fn op_void_async(_state: Rc<RefCell<OpState>>) -> Result<(), Error> {
+pub async fn op_void_async() -> Result<(), Error> {
   Ok(())
 }
 


### PR DESCRIPTION
Since OpState-like args are optional since: https://github.com/denoland/deno/pull/13954