### PR TITLE
fix(core): variadic opSync/opAsync

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -152,9 +152,9 @@
     return res;
   }
 
-  function opAsync(opName, arg1 = null, arg2 = null) {
+  function opAsync(opName, ...args) {
     const promiseId = nextPromiseId++;
-    const maybeError = ops[opName](opIds[opName], promiseId, arg1, arg2);
+    const maybeError = ops[opName](opIds[opName], promiseId, ...args);
     // Handle sync error (e.g: error parsing args)
     if (maybeError) return unwrapOpResult(maybeError);
     let p = PromisePrototypeThen(setPromise(promiseId), unwrapOpResult);
@@ -173,8 +173,8 @@
     return p;
   }
 
-  function opSync(opName, arg1, arg2) {
-    return unwrapOpResult(ops[opName](opIds[opName], arg1, arg2));
+  function opSync(opName, ...args) {
+    return unwrapOpResult(ops[opName](opIds[opName], ...args));
   }
 
   function refOp(promiseId) {

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2874,4 +2874,28 @@ assertEquals(1, notify_return_value);
       )
       .is_err());
   }
+
+  #[test]
+  fn test_op_high_arity() {
+    #[op]
+    fn op_add_4(
+      x1: i64,
+      x2: i64,
+      x3: i64,
+      x4: i64,
+    ) -> Result<i64, anyhow::Error> {
+      Ok(x1 + x2 + x3 + x4)
+    }
+
+    let ext = Extension::builder().ops(vec![op_add_4::decl()]).build();
+    let mut runtime = JsRuntime::new(RuntimeOptions {
+      extensions: vec![ext],
+      ..Default::default()
+    });
+    let r = runtime
+      .execute_script("test.js", "Deno.core.opSync('op_add_4', 1, 2, 3, 4)")
+      .unwrap();
+    let scope = &mut runtime.handle_scope();
+    assert_eq!(r.open(scope).integer_value(scope), Some(10));
+  }
 }


### PR DESCRIPTION
To allow opcalls with more than 2 generic-args JS-side