### PR TITLE
chore(core): Remove a note that is no longer relevant.

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -650,8 +650,6 @@ impl JsRuntime {
 
     let state = Self::state(self.v8_isolate());
 
-    // Note: create_blob() method must not be called from within a HandleScope.
-    // TODO(piscisaureus): The rusty_v8 type system should enforce this.
     state.borrow_mut().global_context.take();
 
     self.inspector.take();


### PR DESCRIPTION
This note about how `v8::SnapshotCreator::create_blob` must not be called from a `HandleScope` stopped being relevant in #6801, and was now attached to code that had nothing to do with `HandleScope`s.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
