### PR TITLE
perf(http): avoid checking promise every request

### DIFF
--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -39,7 +39,6 @@
     ArrayPrototypeSome,
     Error,
     ObjectPrototypeIsPrototypeOf,
-    PromisePrototype,
     Set,
     SetPrototypeAdd,
     SetPrototypeDelete,

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -181,15 +181,10 @@
     remoteAddr,
     localAddr,
   ) {
-    const isPromise = true;
     return async function respondWith(resp) {
       try {
-        if (isPromise || ObjectPrototypeIsPrototypeOf(PromisePrototype, resp)) {
-          resp = await resp;
-        }
-
+        resp = await resp;
         if (!(ObjectPrototypeIsPrototypeOf(ResponsePrototype, resp))) {
-          if (!isPromise) resp = await resp;
           throw new TypeError(
             "First argument to respondWith must be a Response or a promise resolving to a Response.",
           );

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -181,13 +181,15 @@
     remoteAddr,
     localAddr,
   ) {
+    const isPromise = true;
     return async function respondWith(resp) {
       try {
-        if (ObjectPrototypeIsPrototypeOf(PromisePrototype, resp)) {
+        if (isPromise || ObjectPrototypeIsPrototypeOf(PromisePrototype, resp)) {
           resp = await resp;
         }
 
         if (!(ObjectPrototypeIsPrototypeOf(ResponsePrototype, resp))) {
+          if (!isPromise) resp = await resp;
           throw new TypeError(
             "First argument to respondWith must be a Response or a promise resolving to a Response.",
           );


### PR DESCRIPTION
`main`:
```
# hey -n 1000000
Total:	12.3348 secs
Slowest:	0.0204 secs
Fastest:	0.0000 secs
Average:	0.0006 secs
Requests/sec:	81071.3752
Total data:	11000000 bytes
Size/request:	11 bytes

# wrk -c20 -t10s
Running 10s test @ http://127.0.0.1:4500
  2 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   174.66us  304.76us  16.45ms   99.61%
    Req/Sec    57.23k     3.04k   59.21k    92.08%
  1150126 requests in 10.10s, 120.65MB read
Requests/sec: 113858.76
Transfer/sec:     11.94MB
```

This PR:
```
# hey -n 1000000
Total:	12.1141 secs
Slowest:	0.0198 secs
Fastest:	0.0000 secs
Average:	0.0006 secs
Requests/sec:	83548.1332
Total data:	11000000 bytes
Size/request:	11 bytes

# wrk -c20 -t10s
Running 10s test @ http://127.0.0.1:4500
  2 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   161.29us   33.76us   2.85ms   80.34%
    Req/Sec    58.20k     2.00k   59.43k    99.01%
  1169650 requests in 10.10s, 122.70MB read
Requests/sec: 115802.44
Transfer/sec:     12.15MB
```