### PR TITLE
chore: replace `.expect("...")` calls with `.unwrap()` in integration test code

### DIFF
--- a/cli/tests/integration/bundle_tests.rs
+++ b/cli/tests/integration/bundle_tests.rs
@@ -9,7 +9,7 @@ fn bundle_exports() {
   // First we have to generate a bundle of some module that has exports.
   let mod1 = util::testdata_path().join("subdir/mod1.ts");
   assert!(mod1.is_file());
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let bundle = t.path().join("mod1.bundle.js");
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -17,8 +17,8 @@ fn bundle_exports() {
     .arg(mod1)
     .arg(&bundle)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
   assert!(bundle.is_file());
 
@@ -30,14 +30,14 @@ fn bundle_exports() {
       import { printHello3 } from \"./mod1.bundle.js\";
       printHello3(); ",
   )
-  .expect("error writing file");
+  .unwrap();
 
   let output = util::deno_cmd()
     .current_dir(util::testdata_path())
     .arg("run")
     .arg(&test)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   // check the output of the test.ts program.
   assert!(std::str::from_utf8(&output.stdout)
     .unwrap()
@@ -51,7 +51,7 @@ fn bundle_exports_no_check() {
   // First we have to generate a bundle of some module that has exports.
   let mod1 = util::testdata_path().join("subdir/mod1.ts");
   assert!(mod1.is_file());
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let bundle = t.path().join("mod1.bundle.js");
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -60,8 +60,8 @@ fn bundle_exports_no_check() {
     .arg(mod1)
     .arg(&bundle)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
   assert!(bundle.is_file());
 
@@ -73,14 +73,14 @@ fn bundle_exports_no_check() {
       import { printHello3 } from \"./mod1.bundle.js\";
       printHello3(); ",
   )
-  .expect("error writing file");
+  .unwrap();
 
   let output = util::deno_cmd()
     .current_dir(util::testdata_path())
     .arg("run")
     .arg(&test)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   // check the output of the test.ts program.
   assert!(std::str::from_utf8(&output.stdout)
     .unwrap()
@@ -94,7 +94,7 @@ fn bundle_circular() {
   // First we have to generate a bundle of some module that has exports.
   let circular1 = util::testdata_path().join("subdir/circular1.ts");
   assert!(circular1.is_file());
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let bundle = t.path().join("circular1.bundle.js");
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -102,8 +102,8 @@ fn bundle_circular() {
     .arg(circular1)
     .arg(&bundle)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
   assert!(bundle.is_file());
 
@@ -112,7 +112,7 @@ fn bundle_circular() {
     .arg("run")
     .arg(&bundle)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   // check the output of the the bundle program.
   assert!(std::str::from_utf8(&output.stdout)
     .unwrap()
@@ -126,7 +126,7 @@ fn bundle_single_module() {
   // First we have to generate a bundle of some module that has exports.
   let single_module = util::testdata_path().join("subdir/single_module.ts");
   assert!(single_module.is_file());
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let bundle = t.path().join("single_module.bundle.js");
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -134,8 +134,8 @@ fn bundle_single_module() {
     .arg(single_module)
     .arg(&bundle)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
   assert!(bundle.is_file());
 
@@ -144,7 +144,7 @@ fn bundle_single_module() {
     .arg("run")
     .arg(&bundle)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   // check the output of the the bundle program.
   assert!(std::str::from_utf8(&output.stdout)
     .unwrap()
@@ -158,7 +158,7 @@ fn bundle_tla() {
   // First we have to generate a bundle of some module that has exports.
   let tla_import = util::testdata_path().join("subdir/tla.ts");
   assert!(tla_import.is_file());
-  let t = tempfile::TempDir::new().expect("tempdir fail");
+  let t = tempfile::TempDir::new().unwrap();
   let bundle = t.path().join("tla.bundle.js");
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -166,8 +166,8 @@ fn bundle_tla() {
     .arg(tla_import)
     .arg(&bundle)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
   assert!(bundle.is_file());
 
@@ -179,14 +179,14 @@ fn bundle_tla() {
       import { foo } from \"./tla.bundle.js\";
       console.log(foo); ",
   )
-  .expect("error writing file");
+  .unwrap();
 
   let output = util::deno_cmd()
     .current_dir(util::testdata_path())
     .arg("run")
     .arg(&test)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   // check the output of the test.ts program.
   assert!(std::str::from_utf8(&output.stdout)
     .unwrap()
@@ -200,7 +200,7 @@ fn bundle_js() {
   // First we have to generate a bundle of some module that has exports.
   let mod6 = util::testdata_path().join("subdir/mod6.js");
   assert!(mod6.is_file());
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let bundle = t.path().join("mod6.bundle.js");
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -208,8 +208,8 @@ fn bundle_js() {
     .arg(mod6)
     .arg(&bundle)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
   assert!(bundle.is_file());
 
@@ -218,7 +218,7 @@ fn bundle_js() {
     .arg("run")
     .arg(&bundle)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   // check that nothing went to stderr
   assert_eq!(output.stderr, b"");
 }
@@ -228,7 +228,7 @@ fn bundle_dynamic_import() {
   let _g = util::http_server();
   let dynamic_import = util::testdata_path().join("bundle_dynamic_import.ts");
   assert!(dynamic_import.is_file());
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let bundle = t.path().join("bundle_dynamic_import.bundle.js");
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -236,8 +236,8 @@ fn bundle_dynamic_import() {
     .arg(dynamic_import)
     .arg(&bundle)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
   assert!(bundle.is_file());
 
@@ -248,7 +248,7 @@ fn bundle_dynamic_import() {
     .arg("--quiet")
     .arg(&bundle)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   // check the output of the test.ts program.
   assert!(std::str::from_utf8(&output.stdout)
     .unwrap()
@@ -262,7 +262,7 @@ fn bundle_import_map() {
   let import = util::testdata_path().join("bundle_im.ts");
   let import_map_path = util::testdata_path().join("bundle_im.json");
   assert!(import.is_file());
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let bundle = t.path().join("import_map.bundle.js");
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -272,8 +272,8 @@ fn bundle_import_map() {
     .arg(import)
     .arg(&bundle)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
   assert!(bundle.is_file());
 
@@ -285,14 +285,14 @@ fn bundle_import_map() {
       import { printHello3 } from \"./import_map.bundle.js\";
       printHello3(); ",
   )
-  .expect("error writing file");
+  .unwrap();
 
   let output = util::deno_cmd()
     .current_dir(util::testdata_path())
     .arg("run")
     .arg(&test)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   // check the output of the test.ts program.
   assert!(std::str::from_utf8(&output.stdout)
     .unwrap()
@@ -306,7 +306,7 @@ fn bundle_import_map_no_check() {
   let import = util::testdata_path().join("bundle_im.ts");
   let import_map_path = util::testdata_path().join("bundle_im.json");
   assert!(import.is_file());
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let bundle = t.path().join("import_map.bundle.js");
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -317,8 +317,8 @@ fn bundle_import_map_no_check() {
     .arg(import)
     .arg(&bundle)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
   assert!(bundle.is_file());
 
@@ -330,14 +330,14 @@ fn bundle_import_map_no_check() {
       import { printHello3 } from \"./import_map.bundle.js\";
       printHello3(); ",
   )
-  .expect("error writing file");
+  .unwrap();
 
   let output = util::deno_cmd()
     .current_dir(util::testdata_path())
     .arg("run")
     .arg(&test)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   // check the output of the test.ts program.
   assert!(std::str::from_utf8(&output.stdout)
     .unwrap()
@@ -351,7 +351,7 @@ fn bundle_json_module() {
   // First we have to generate a bundle of some module that has exports.
   let mod7 = util::testdata_path().join("subdir/mod7.js");
   assert!(mod7.is_file());
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let bundle = t.path().join("mod7.bundle.js");
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -359,8 +359,8 @@ fn bundle_json_module() {
     .arg(mod7)
     .arg(&bundle)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
   assert!(bundle.is_file());
 
@@ -369,7 +369,7 @@ fn bundle_json_module() {
     .arg("run")
     .arg(&bundle)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   // check that nothing went to stderr
   assert_eq!(output.stderr, b"");
   // ensure the output looks right
@@ -383,7 +383,7 @@ fn bundle_json_module_escape_sub() {
   // First we have to generate a bundle of some module that has exports.
   let mod8 = util::testdata_path().join("subdir/mod8.js");
   assert!(mod8.is_file());
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let bundle = t.path().join("mod8.bundle.js");
   let mut deno = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -391,8 +391,8 @@ fn bundle_json_module_escape_sub() {
     .arg(mod8)
     .arg(&bundle)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
   assert!(bundle.is_file());
 
@@ -401,7 +401,7 @@ fn bundle_json_module_escape_sub() {
     .arg("run")
     .arg(&bundle)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   // check that nothing went to stderr
   assert_eq!(output.stderr, b"");
   // make sure the output looks right and the escapes were effective

--- a/cli/tests/integration/coverage_tests.rs
+++ b/cli/tests/integration/coverage_tests.rs
@@ -20,8 +20,8 @@ fn final_blankline() {
 }
 
 fn run_coverage_text(test_name: &str, extension: &str) {
-  let deno_dir = TempDir::new().expect("tempdir fail");
-  let tempdir = TempDir::new().expect("tempdir fail");
+  let deno_dir = TempDir::new().unwrap();
+  let tempdir = TempDir::new().unwrap();
   let tempdir = tempdir.path().join("cov");
 
   let status = util::deno_cmd_with_deno_dir(deno_dir.path())
@@ -34,7 +34,7 @@ fn run_coverage_text(test_name: &str, extension: &str) {
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::inherit())
     .status()
-    .expect("failed to spawn test runner");
+    .unwrap();
 
   assert!(status.success());
 
@@ -46,7 +46,7 @@ fn run_coverage_text(test_name: &str, extension: &str) {
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped())
     .output()
-    .expect("failed to spawn coverage reporter");
+    .unwrap();
 
   // Verify there's no "Check" being printed
   assert!(output.stderr.is_empty());
@@ -78,7 +78,7 @@ fn run_coverage_text(test_name: &str, extension: &str) {
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::inherit())
     .output()
-    .expect("failed to spawn coverage reporter");
+    .unwrap();
 
   let actual =
     util::strip_ansi_codes(std::str::from_utf8(&output.stdout).unwrap())
@@ -100,8 +100,8 @@ fn run_coverage_text(test_name: &str, extension: &str) {
 
 #[test]
 fn multifile_coverage() {
-  let deno_dir = TempDir::new().expect("tempdir fail");
-  let tempdir = TempDir::new().expect("tempdir fail");
+  let deno_dir = TempDir::new().unwrap();
+  let tempdir = TempDir::new().unwrap();
   let tempdir = tempdir.path().join("cov");
 
   let status = util::deno_cmd_with_deno_dir(deno_dir.path())
@@ -114,7 +114,7 @@ fn multifile_coverage() {
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::inherit())
     .status()
-    .expect("failed to spawn test runner");
+    .unwrap();
 
   assert!(status.success());
 
@@ -126,7 +126,7 @@ fn multifile_coverage() {
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped())
     .output()
-    .expect("failed to spawn coverage reporter");
+    .unwrap();
 
   // Verify there's no "Check" being printed
   assert!(output.stderr.is_empty());
@@ -158,7 +158,7 @@ fn multifile_coverage() {
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::inherit())
     .output()
-    .expect("failed to spawn coverage reporter");
+    .unwrap();
 
   let actual =
     util::strip_ansi_codes(std::str::from_utf8(&output.stdout).unwrap())

--- a/cli/tests/integration/fmt_tests.rs
+++ b/cli/tests/integration/fmt_tests.rs
@@ -6,30 +6,27 @@ use test_util as util;
 
 #[test]
 fn fmt_test() {
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let fixed_js = util::testdata_path().join("badly_formatted_fixed.js");
   let badly_formatted_original_js =
     util::testdata_path().join("badly_formatted.mjs");
   let badly_formatted_js = t.path().join("badly_formatted.js");
   let badly_formatted_js_str = badly_formatted_js.to_str().unwrap();
-  std::fs::copy(&badly_formatted_original_js, &badly_formatted_js)
-    .expect("Failed to copy file");
+  std::fs::copy(&badly_formatted_original_js, &badly_formatted_js).unwrap();
 
   let fixed_md = util::testdata_path().join("badly_formatted_fixed.md");
   let badly_formatted_original_md =
     util::testdata_path().join("badly_formatted.md");
   let badly_formatted_md = t.path().join("badly_formatted.md");
   let badly_formatted_md_str = badly_formatted_md.to_str().unwrap();
-  std::fs::copy(&badly_formatted_original_md, &badly_formatted_md)
-    .expect("Failed to copy file");
+  std::fs::copy(&badly_formatted_original_md, &badly_formatted_md).unwrap();
 
   let fixed_json = util::testdata_path().join("badly_formatted_fixed.json");
   let badly_formatted_original_json =
     util::testdata_path().join("badly_formatted.json");
   let badly_formatted_json = t.path().join("badly_formatted.json");
   let badly_formatted_json_str = badly_formatted_json.to_str().unwrap();
-  std::fs::copy(&badly_formatted_original_json, &badly_formatted_json)
-    .expect("Failed to copy file");
+  std::fs::copy(&badly_formatted_original_json, &badly_formatted_json).unwrap();
   // First, check formatting by ignoring the badly formatted file.
   let status = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -43,9 +40,9 @@ fn fmt_test() {
     .arg(badly_formatted_md_str)
     .arg(badly_formatted_json_str)
     .spawn()
-    .expect("Failed to spawn script")
+    .unwrap()
     .wait()
-    .expect("Failed to wait for child process");
+    .unwrap();
   // No target files found
   assert!(!status.success());
 
@@ -58,9 +55,9 @@ fn fmt_test() {
     .arg(badly_formatted_md_str)
     .arg(badly_formatted_json_str)
     .spawn()
-    .expect("Failed to spawn script")
+    .unwrap()
     .wait()
-    .expect("Failed to wait for child process");
+    .unwrap();
   assert!(!status.success());
 
   // Format the source file.
@@ -71,9 +68,9 @@ fn fmt_test() {
     .arg(badly_formatted_md_str)
     .arg(badly_formatted_json_str)
     .spawn()
-    .expect("Failed to spawn script")
+    .unwrap()
     .wait()
-    .expect("Failed to wait for child process");
+    .unwrap();
   assert!(status.success());
   let expected_js = std::fs::read_to_string(fixed_js).unwrap();
   let expected_md = std::fs::read_to_string(fixed_md).unwrap();

--- a/cli/tests/integration/info_tests.rs
+++ b/cli/tests/integration/info_tests.rs
@@ -8,7 +8,7 @@ use test_util as util;
 fn info_with_compiled_source() {
   let _g = util::http_server();
   let module_path = "http://127.0.0.1:4545/048_media_types_jsx.ts";
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
 
   let mut deno = util::deno_cmd()
     .env("DENO_DIR", t.path())
@@ -16,8 +16,8 @@ fn info_with_compiled_source() {
     .arg("cache")
     .arg(&module_path)
     .spawn()
-    .expect("failed to spawn script");
-  let status = deno.wait().expect("failed to wait for the child process");
+    .unwrap();
+  let status = deno.wait().unwrap();
   assert!(status.success());
 
   let output = util::deno_cmd()
@@ -27,7 +27,7 @@ fn info_with_compiled_source() {
     .arg("info")
     .arg(&module_path)
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
 
   let str_output = std::str::from_utf8(&output.stdout).unwrap().trim();
   eprintln!("{}", str_output);

--- a/cli/tests/integration/inspector_tests.rs
+++ b/cli/tests/integration/inspector_tests.rs
@@ -156,9 +156,8 @@ async fn inspector_connect() {
 
   // We use tokio_tungstenite as a websocket client because warp (which is
   // a dependency of Deno) uses it.
-  let (_socket, response) = tokio_tungstenite::connect_async(ws_url)
-    .await
-    .expect("Can't connect");
+  let (_socket, response) =
+    tokio_tungstenite::connect_async(ws_url).await.unwrap();
   assert_eq!("101 Switching Protocols", response.status().to_string());
   child.kill().unwrap();
   child.wait().unwrap();
@@ -181,9 +180,8 @@ async fn inspector_break_on_first_line() {
     std::io::BufReader::new(stderr).lines().map(|r| r.unwrap());
   let ws_url = extract_ws_url_from_stderr(&mut stderr_lines);
 
-  let (socket, response) = tokio_tungstenite::connect_async(ws_url)
-    .await
-    .expect("Can't connect");
+  let (socket, response) =
+    tokio_tungstenite::connect_async(ws_url).await.unwrap();
   assert_eq!(response.status(), 101); // Switching protocols.
 
   let (mut socket_tx, socket_rx) = socket.split();
@@ -273,9 +271,7 @@ async fn inspector_pause() {
 
   // We use tokio_tungstenite as a websocket client because warp (which is
   // a dependency of Deno) uses it.
-  let (mut socket, _) = tokio_tungstenite::connect_async(ws_url)
-    .await
-    .expect("Can't connect");
+  let (mut socket, _) = tokio_tungstenite::connect_async(ws_url).await.unwrap();
 
   /// Returns the next websocket message as a string ignoring
   /// Debugger.scriptParsed messages.
@@ -383,9 +379,8 @@ async fn inspector_does_not_hang() {
     std::io::BufReader::new(stderr).lines().map(|r| r.unwrap());
   let ws_url = extract_ws_url_from_stderr(&mut stderr_lines);
 
-  let (socket, response) = tokio_tungstenite::connect_async(ws_url)
-    .await
-    .expect("Can't connect");
+  let (socket, response) =
+    tokio_tungstenite::connect_async(ws_url).await.unwrap();
   assert_eq!(response.status(), 101); // Switching protocols.
 
   let (mut socket_tx, socket_rx) = socket.split();
@@ -524,9 +519,8 @@ async fn inspector_runtime_evaluate_does_not_crash() {
     .filter(|s| s.as_str() != "Debugger session started.");
   let ws_url = extract_ws_url_from_stderr(&mut stderr_lines);
 
-  let (socket, response) = tokio_tungstenite::connect_async(ws_url)
-    .await
-    .expect("Can't connect");
+  let (socket, response) =
+    tokio_tungstenite::connect_async(ws_url).await.unwrap();
   assert_eq!(response.status(), 101); // Switching protocols.
 
   let (mut socket_tx, socket_rx) = socket.split();
@@ -707,9 +701,8 @@ async fn inspector_break_on_first_line_in_test() {
     std::io::BufReader::new(stderr).lines().map(|r| r.unwrap());
   let ws_url = extract_ws_url_from_stderr(&mut stderr_lines);
 
-  let (socket, response) = tokio_tungstenite::connect_async(ws_url)
-    .await
-    .expect("Can't connect");
+  let (socket, response) =
+    tokio_tungstenite::connect_async(ws_url).await.unwrap();
   assert_eq!(response.status(), 101); // Switching protocols.
 
   let (mut socket_tx, socket_rx) = socket.split();
@@ -802,9 +795,8 @@ async fn inspector_with_ts_files() {
     std::io::BufReader::new(stderr).lines().map(|r| r.unwrap());
   let ws_url = extract_ws_url_from_stderr(&mut stderr_lines);
 
-  let (socket, response) = tokio_tungstenite::connect_async(ws_url)
-    .await
-    .expect("Can't connect");
+  let (socket, response) =
+    tokio_tungstenite::connect_async(ws_url).await.unwrap();
   assert_eq!(response.status(), 101); // Switching protocols.
 
   let (mut socket_tx, socket_rx) = socket.split();
@@ -928,9 +920,8 @@ async fn inspector_memory() {
     std::io::BufReader::new(stderr).lines().map(|r| r.unwrap());
   let ws_url = extract_ws_url_from_stderr(&mut stderr_lines);
 
-  let (socket, response) = tokio_tungstenite::connect_async(ws_url)
-    .await
-    .expect("Can't connect");
+  let (socket, response) =
+    tokio_tungstenite::connect_async(ws_url).await.unwrap();
   assert_eq!(response.status(), 101); // Switching protocols.
 
   let (mut socket_tx, socket_rx) = socket.split();
@@ -1043,9 +1034,8 @@ async fn inspector_profile() {
     std::io::BufReader::new(stderr).lines().map(|r| r.unwrap());
   let ws_url = extract_ws_url_from_stderr(&mut stderr_lines);
 
-  let (socket, response) = tokio_tungstenite::connect_async(ws_url)
-    .await
-    .expect("Can't connect");
+  let (socket, response) =
+    tokio_tungstenite::connect_async(ws_url).await.unwrap();
   assert_eq!(response.status(), 101); // Switching protocols.
 
   let (mut socket_tx, socket_rx) = socket.split();

--- a/cli/tests/integration/install_tests.rs
+++ b/cli/tests/integration/install_tests.rs
@@ -87,7 +87,7 @@ fn install_custom_dir_env_var() {
 
 #[test]
 fn installer_test_local_module_run() {
-  let temp_dir = TempDir::new().expect("tempdir fail");
+  let temp_dir = TempDir::new().unwrap();
   let bin_dir = temp_dir.path().join("bin");
   std::fs::create_dir(&bin_dir).unwrap();
   let status = util::deno_cmd()
@@ -116,7 +116,7 @@ fn installer_test_local_module_run() {
     .arg("foo")
     .env("PATH", util::target_dir())
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   let stdout_str = std::str::from_utf8(&output.stdout).unwrap().trim();
   assert!(stdout_str.ends_with("hello, foo"));
 }
@@ -124,7 +124,7 @@ fn installer_test_local_module_run() {
 #[test]
 fn installer_test_remote_module_run() {
   let _g = util::http_server();
-  let temp_dir = TempDir::new().expect("tempdir fail");
+  let temp_dir = TempDir::new().unwrap();
   let bin_dir = temp_dir.path().join("bin");
   std::fs::create_dir(&bin_dir).unwrap();
   let status = util::deno_cmd()
@@ -151,7 +151,7 @@ fn installer_test_remote_module_run() {
     .arg("foo")
     .env("PATH", util::target_dir())
     .output()
-    .expect("failed to spawn script");
+    .unwrap();
   assert!(std::str::from_utf8(&output.stdout)
     .unwrap()
     .trim()

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -233,7 +233,7 @@ fn lsp_startup_shutdown() {
 
 #[test]
 fn lsp_init_tsconfig() {
-  let temp_dir = TempDir::new().expect("could not create temp dir");
+  let temp_dir = TempDir::new().unwrap();
   let mut params: lsp::InitializeParams =
     serde_json::from_value(load_fixture("initialize_params.json")).unwrap();
   let tsconfig =
@@ -276,7 +276,7 @@ fn lsp_init_tsconfig() {
 fn lsp_tsconfig_types() {
   let mut params: lsp::InitializeParams =
     serde_json::from_value(load_fixture("initialize_params.json")).unwrap();
-  let temp_dir = TempDir::new().expect("could not create temp dir");
+  let temp_dir = TempDir::new().unwrap();
   let tsconfig =
     serde_json::to_vec_pretty(&load_fixture("types.tsconfig.json")).unwrap();
   fs::write(temp_dir.path().join("types.tsconfig.json"), tsconfig).unwrap();
@@ -343,7 +343,7 @@ fn lsp_tsconfig_bad_config_path() {
 fn lsp_triple_slash_types() {
   let mut params: lsp::InitializeParams =
     serde_json::from_value(load_fixture("initialize_params.json")).unwrap();
-  let temp_dir = TempDir::new().expect("could not create temp dir");
+  let temp_dir = TempDir::new().unwrap();
   let a_dts = load_fixture_str("a.d.ts");
   fs::write(temp_dir.path().join("a.d.ts"), a_dts).unwrap();
 
@@ -377,7 +377,7 @@ fn lsp_triple_slash_types() {
 
 #[test]
 fn lsp_import_map() {
-  let temp_dir = TempDir::new().expect("could not create temp dir");
+  let temp_dir = TempDir::new().unwrap();
   let mut params: lsp::InitializeParams =
     serde_json::from_value(load_fixture("initialize_params.json")).unwrap();
   let import_map =
@@ -488,7 +488,7 @@ fn lsp_import_map_data_url() {
 
 #[test]
 fn lsp_import_map_config_file() {
-  let temp_dir = TempDir::new().expect("could not create temp dir");
+  let temp_dir = TempDir::new().unwrap();
   let mut params: lsp::InitializeParams =
     serde_json::from_value(load_fixture("initialize_params.json")).unwrap();
 
@@ -659,7 +659,7 @@ fn lsp_import_assertions() {
 
 #[test]
 fn lsp_import_map_import_completions() {
-  let temp_dir = TempDir::new().expect("could not create temp dir");
+  let temp_dir = TempDir::new().unwrap();
   let mut params: lsp::InitializeParams =
     serde_json::from_value(load_fixture("initialize_params.json")).unwrap();
   let import_map =
@@ -1413,21 +1413,16 @@ fn lsp_hover_change_mbc() {
 
 #[test]
 fn lsp_hover_closed_document() {
-  let temp_dir = TempDir::new()
-    .expect("could not create temp dir")
-    .into_path();
+  let temp_dir = TempDir::new().unwrap().into_path();
   let a_path = temp_dir.join("a.ts");
-  fs::write(a_path, r#"export const a = "a";"#).expect("could not write file");
+  fs::write(a_path, r#"export const a = "a";"#).unwrap();
   let b_path = temp_dir.join("b.ts");
-  fs::write(&b_path, r#"export * from "./a.ts";"#)
-    .expect("could not write file");
-  let b_specifier =
-    Url::from_file_path(b_path).expect("could not convert path");
+  fs::write(&b_path, r#"export * from "./a.ts";"#).unwrap();
+  let b_specifier = Url::from_file_path(b_path).unwrap();
   let c_path = temp_dir.join("c.ts");
   fs::write(&c_path, "import { a } from \"./b.ts\";\nconsole.log(a);\n")
-    .expect("could not write file");
-  let c_specifier =
-    Url::from_file_path(c_path).expect("could not convert path");
+    .unwrap();
+  let c_specifier = Url::from_file_path(c_path).unwrap();
 
   let mut client = init("initialize_params.json");
   client
@@ -3772,7 +3767,7 @@ fn lsp_auto_discover_registry() {
 #[test]
 fn lsp_cache_location() {
   let _g = http_server();
-  let temp_dir = TempDir::new().expect("could not create temp dir");
+  let temp_dir = TempDir::new().unwrap();
   let mut params: lsp::InitializeParams =
     serde_json::from_value(load_fixture("initialize_params_registry.json"))
       .unwrap();
@@ -4568,7 +4563,7 @@ fn lsp_format_markdown() {
 
 #[test]
 fn lsp_format_with_config() {
-  let temp_dir = TempDir::new().expect("could not create temp dir");
+  let temp_dir = TempDir::new().unwrap();
   let mut params: lsp::InitializeParams =
     serde_json::from_value(load_fixture("initialize_params.json")).unwrap();
   let deno_fmt_jsonc =
@@ -5047,7 +5042,7 @@ console.log(snake_case);
 
 #[test]
 fn lsp_lint_with_config() {
-  let temp_dir = TempDir::new().expect("could not create temp dir");
+  let temp_dir = TempDir::new().unwrap();
   let mut params: lsp::InitializeParams =
     serde_json::from_value(load_fixture("initialize_params.json")).unwrap();
   let deno_lint_jsonc =

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -466,22 +466,21 @@ itest!(_082_prepare_stack_trace_throw {
 #[test]
 fn _083_legacy_external_source_map() {
   let _g = util::http_server();
-  let deno_dir = TempDir::new().expect("tempdir fail");
+  let deno_dir = TempDir::new().unwrap();
   let module_url =
     url::Url::parse("http://localhost:4545/083_legacy_external_source_map.ts")
       .unwrap();
   // Write a faulty old external source map.
   let faulty_map_path = deno_dir.path().join("gen/http/localhost_PORT4545/9576bd5febd0587c5c4d88d57cb3ac8ebf2600c529142abe3baa9a751d20c334.js.map");
-  std::fs::create_dir_all(faulty_map_path.parent().unwrap())
-    .expect("Failed to create faulty source map dir.");
-  std::fs::write(faulty_map_path, "{\"version\":3,\"file\":\"\",\"sourceRoot\":\"\",\"sources\":[\"http://localhost:4545/083_legacy_external_source_map.ts\"],\"names\":[],\"mappings\":\";AAAA,MAAM,IAAI,KAAK,CAAC,KAAK,CAAC,CAAC\"}").expect("Failed to write faulty source map.");
+  std::fs::create_dir_all(faulty_map_path.parent().unwrap()).unwrap();
+  std::fs::write(faulty_map_path, "{\"version\":3,\"file\":\"\",\"sourceRoot\":\"\",\"sources\":[\"http://localhost:4545/083_legacy_external_source_map.ts\"],\"names\":[],\"mappings\":\";AAAA,MAAM,IAAI,KAAK,CAAC,KAAK,CAAC,CAAC\"}").unwrap();
   let output = Command::new(util::deno_exe_path())
     .env("DENO_DIR", deno_dir.path())
     .current_dir(util::testdata_path())
     .arg("run")
     .arg(module_url.to_string())
     .output()
-    .expect("Failed to spawn script");
+    .unwrap();
   // Before https://github.com/denoland/deno/issues/6965 was fixed, the faulty
   // old external source map would cause a panic while formatting the error
   // and the exit code would be 101. The external source map should be ignored
@@ -2386,7 +2385,7 @@ fn issue12453() {
 /// Regression test for https://github.com/denoland/deno/issues/12740.
 #[test]
 fn issue12740() {
-  let mod_dir = TempDir::new().expect("tempdir fail");
+  let mod_dir = TempDir::new().unwrap();
   let mod1_path = mod_dir.path().join("mod1.ts");
   let mod2_path = mod_dir.path().join("mod2.ts");
   let mut deno_cmd = util::deno_cmd();
@@ -2420,7 +2419,7 @@ fn issue12740() {
 /// Regression test for https://github.com/denoland/deno/issues/12807.
 #[test]
 fn issue12807() {
-  let mod_dir = TempDir::new().expect("tempdir fail");
+  let mod_dir = TempDir::new().unwrap();
   let mod1_path = mod_dir.path().join("mod1.ts");
   let mod2_path = mod_dir.path().join("mod2.ts");
   let mut deno_cmd = util::deno_cmd();

--- a/cli/tests/integration/watcher_tests.rs
+++ b/cli/tests/integration/watcher_tests.rs
@@ -88,7 +88,7 @@ fn child_lines(
 
 #[test]
 fn lint_watch_test() {
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let badly_linted_original =
     util::testdata_path().join("lint/watch/badly_linted.js");
   let badly_linted_output =
@@ -103,8 +103,7 @@ fn lint_watch_test() {
     util::testdata_path().join("lint/watch/badly_linted_fixed2.js.out");
   let badly_linted = t.path().join("badly_linted.js");
 
-  std::fs::copy(&badly_linted_original, &badly_linted)
-    .expect("Failed to copy file");
+  std::fs::copy(&badly_linted_original, &badly_linted).unwrap();
 
   let mut child = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -115,7 +114,7 @@ fn lint_watch_test() {
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped())
     .spawn()
-    .expect("Failed to spawn script");
+    .unwrap();
   let (_stdout_lines, mut stderr_lines) = child_lines(&mut child);
   let next_line = stderr_lines.next().unwrap();
   assert_contains!(&next_line, CLEAR_SCREEN);
@@ -125,8 +124,7 @@ fn lint_watch_test() {
   assert_eq!(output, expected);
 
   // Change content of the file again to be badly-linted1
-  std::fs::copy(&badly_linted_fixed1, &badly_linted)
-    .expect("Failed to copy file");
+  std::fs::copy(&badly_linted_fixed1, &badly_linted).unwrap();
   std::thread::sleep(std::time::Duration::from_secs(1));
 
   output = read_all_lints(&mut stderr_lines);
@@ -134,8 +132,7 @@ fn lint_watch_test() {
   assert_eq!(output, expected);
 
   // Change content of the file again to be badly-linted1
-  std::fs::copy(&badly_linted_fixed2, &badly_linted)
-    .expect("Failed to copy file");
+  std::fs::copy(&badly_linted_fixed2, &badly_linted).unwrap();
 
   output = read_all_lints(&mut stderr_lines);
   let expected = std::fs::read_to_string(badly_linted_fixed2_output).unwrap();
@@ -150,7 +147,7 @@ fn lint_watch_test() {
 
 #[test]
 fn lint_watch_without_args_test() {
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let badly_linted_original =
     util::testdata_path().join("lint/watch/badly_linted.js");
   let badly_linted_output =
@@ -165,8 +162,7 @@ fn lint_watch_without_args_test() {
     util::testdata_path().join("lint/watch/badly_linted_fixed2.js.out");
   let badly_linted = t.path().join("badly_linted.js");
 
-  std::fs::copy(&badly_linted_original, &badly_linted)
-    .expect("Failed to copy file");
+  std::fs::copy(&badly_linted_original, &badly_linted).unwrap();
 
   let mut child = util::deno_cmd()
     .current_dir(t.path())
@@ -176,7 +172,7 @@ fn lint_watch_without_args_test() {
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped())
     .spawn()
-    .expect("Failed to spawn script");
+    .unwrap();
   let (_stdout_lines, mut stderr_lines) = child_lines(&mut child);
 
   let next_line = stderr_lines.next().unwrap();
@@ -187,16 +183,14 @@ fn lint_watch_without_args_test() {
   assert_eq!(output, expected);
 
   // Change content of the file again to be badly-linted1
-  std::fs::copy(&badly_linted_fixed1, &badly_linted)
-    .expect("Failed to copy file");
+  std::fs::copy(&badly_linted_fixed1, &badly_linted).unwrap();
 
   output = read_all_lints(&mut stderr_lines);
   let expected = std::fs::read_to_string(badly_linted_fixed1_output).unwrap();
   assert_eq!(output, expected);
 
   // Change content of the file again to be badly-linted1
-  std::fs::copy(&badly_linted_fixed2, &badly_linted)
-    .expect("Failed to copy file");
+  std::fs::copy(&badly_linted_fixed2, &badly_linted).unwrap();
   std::thread::sleep(std::time::Duration::from_secs(1));
 
   output = read_all_lints(&mut stderr_lines);
@@ -212,7 +206,7 @@ fn lint_watch_without_args_test() {
 
 #[test]
 fn lint_all_files_on_each_change_test() {
-  let t = TempDir::new().expect("tempdir fail");
+  let t = TempDir::new().unwrap();
   let badly_linted_fixed0 =
     util::testdata_path().join("lint/watch/badly_linted.js");
   let badly_linted_fixed1 =
@@ -222,10 +216,8 @@ fn lint_all_files_on_each_change_test() {
 
   let badly_linted_1 = t.path().join("badly_linted_1.js");
   let badly_linted_2 = t.path().join("badly_linted_2.js");
-  std::fs::copy(&badly_linted_fixed0, &badly_linted_1)
-    .expect("Failed to copy file");
-  std::fs::copy(&badly_linted_fixed1, &badly_linted_2)
-    .expect("Failed to copy file");
+  std::fs::copy(&badly_linted_fixed0, &badly_linted_1).unwrap();
+  std::fs::copy(&badly_linted_fixed1, &badly_linted_2).unwrap();
 
   let mut child = util::deno_cmd()
     .current_dir(util::testdata_path())
@@ -236,13 +228,12 @@ fn lint_all_files_on_each_change_test() {
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped())
     .spawn()
-    .expect("Failed to spawn script");
+    .unwrap();
   let (_stdout_lines, mut stderr_lines) = child_lines(&mut child);
 
   assert_contains!(read_line("Checked", &mut stderr_lines), "Checked 2 files");
 
-  std::fs::copy(&badly_linted_fixed2, &badly_linted_2)
-    .expect("Failed to copy file");
+  std::fs::copy(&badly_linted_fixed2, &badly_linted_2).unwrap();
 
   assert_contains!(read_line("Checked", &mut stderr_lines), "Checked 2 files");
 


### PR DESCRIPTION
Didn't bother with other test blocks yet.