### PR TITLE
fix(compat): Changes an instance of `collect::<Vec<_>>().join("")` to `collect::<String>()`

### DIFF
--- a/cli/compat/esm_resolver.rs
+++ b/cli/compat/esm_resolver.rs
@@ -98,7 +98,7 @@ fn node_resolve(
 
     if protocol == "node" {
       let split_specifier = url.as_str().split(':');
-      let specifier = split_specifier.skip(1).collect::<Vec<_>>().join("");
+      let specifier = split_specifier.skip(1).collect::<String>();
       if let Some(resolved) =
         crate::compat::try_resolve_builtin_module(&specifier)
       {


### PR DESCRIPTION
Hey,
I've noticed that `esm_resolver.rs` uses `.collect::<Vec<_>>().join("");` over `.collect::<String>();`, the latter being shorter, clearer and more performant:

```rs
    criterion.bench_function("1", |bencher| {
        bencher.iter(|| {
            let url = "https://google.com".to_owned();
            let split_specifier = url.as_str().split(':');
            split_specifier.skip(1).collect::<String>();
        })
    });

    criterion.bench_function("2", |bencher| {
        bencher.iter(|| {
            let url = "https://google.com".to_owned();
            let split_specifier = url.as_str().split(':');
            split_specifier.skip(1).collect::<Vec<_>>().join("");
        })
    });
```

```
1                       time:   [61.874 ns 61.959 ns 62.071 ns]                   
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe
slope  [61.874 ns 62.071 ns] R^2            [0.9864790 0.9862826]
mean   [61.979 ns 62.326 ns] std. dev.      [424.74 ps 1.3139 ns]
median [61.842 ns 61.906 ns] med. abs. dev. [131.58 ps 218.49 ps]

2                       time:   [93.029 ns 93.209 ns 93.443 ns]                   
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
slope  [93.029 ns 93.443 ns] R^2            [0.9892041 0.9888479]
mean   [93.153 ns 93.528 ns] std. dev.      [626.57 ps 1.2486 ns]
median [92.996 ns 93.290 ns] med. abs. dev. [362.85 ps 716.21 ps]
```

I'm currently working on a [clippy PR](https://github.com/rust-lang/rust-clippy/pull/8573) to lint this issue but thought to create a manual PR for Deno

Thanks for your consideration!