### PR TITLE
chore: remove all `pub(crate)`s from the cli crate

### DIFF
--- a/cli/bench/http.rs
+++ b/cli/bench/http.rs
@@ -12,7 +12,7 @@ pub use test_util::{parse_wrk_output, WrkOutput as HttpBenchmarkResult};
 
 const DURATION: &str = "20s";
 
-pub(crate) fn benchmark(
+pub fn benchmark(
   target_path: &Path,
 ) -> Result<HashMap<String, HttpBenchmarkResult>> {
   let deno_exe = test_util::deno_exe_path();

--- a/cli/bench/lsp.rs
+++ b/cli/bench/lsp.rs
@@ -333,9 +333,7 @@ fn bench_startup_shutdown(deno_exe: &Path) -> Result<Duration, AnyError> {
 }
 
 /// Generate benchmarks for the LSP server.
-pub(crate) fn benchmarks(
-  deno_exe: &Path,
-) -> Result<HashMap<String, u64>, AnyError> {
+pub fn benchmarks(deno_exe: &Path) -> Result<HashMap<String, u64>, AnyError> {
   println!("-> Start benchmarking lsp");
   let mut exec_times = HashMap::new();
 

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -504,4 +504,4 @@ fn main() -> Result<()> {
   Ok(())
 }
 
-pub(crate) type Result<T> = std::result::Result<T, AnyError>;
+pub type Result<T> = std::result::Result<T, AnyError>;

--- a/cli/cache.rs
+++ b/cli/cache.rs
@@ -24,7 +24,7 @@ pub struct EmitMetadata {
   pub version_hash: String,
 }
 
-pub(crate) enum CacheType {
+pub enum CacheType {
   Declaration,
   Emit,
   SourceMap,
@@ -34,7 +34,7 @@ pub(crate) enum CacheType {
 
 /// A trait which provides a concise implementation to getting and setting
 /// values in a cache.
-pub(crate) trait Cacher {
+pub trait Cacher {
   /// Get a value from the cache.
   fn get(
     &self,
@@ -53,7 +53,7 @@ pub(crate) trait Cacher {
 /// Combines the cacher trait along with the deno_graph Loader trait to provide
 /// a single interface to be able to load and cache modules when building a
 /// graph.
-pub(crate) trait CacherLoader: Cacher + Loader {
+pub trait CacherLoader: Cacher + Loader {
   fn as_cacher(&self) -> &dyn Cacher;
   fn as_mut_loader(&mut self) -> &mut dyn Loader;
   fn as_mut_cacher(&mut self) -> &mut dyn Cacher;
@@ -61,7 +61,7 @@ pub(crate) trait CacherLoader: Cacher + Loader {
 
 /// A "wrapper" for the FileFetcher and DiskCache for the Deno CLI that provides
 /// a concise interface to the DENO_DIR when building module graphs.
-pub(crate) struct FetchCacher {
+pub struct FetchCacher {
   disk_cache: DiskCache,
   dynamic_permissions: Permissions,
   file_fetcher: Arc<FileFetcher>,
@@ -252,7 +252,7 @@ impl CacherLoader for FetchCacher {
 /// An in memory cache that is used by the runtime `Deno.emit()` API to provide
 /// the same behavior as the disk cache when sources are provided.
 #[derive(Debug)]
-pub(crate) struct MemoryCacher {
+pub struct MemoryCacher {
   sources: HashMap<String, Arc<String>>,
   declarations: HashMap<ModuleSpecifier, String>,
   emits: HashMap<ModuleSpecifier, String>,

--- a/cli/compat/errors.rs
+++ b/cli/compat/errors.rs
@@ -5,7 +5,7 @@ use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::url::Url;
 
-pub(crate) fn err_invalid_module_specifier(
+pub fn err_invalid_module_specifier(
   request: &str,
   reason: &str,
   maybe_base: Option<String>,
@@ -22,7 +22,7 @@ pub(crate) fn err_invalid_module_specifier(
   type_error(msg)
 }
 
-pub(crate) fn err_invalid_package_config(
+pub fn err_invalid_package_config(
   path: &str,
   maybe_base: Option<String>,
   maybe_message: Option<String>,
@@ -43,22 +43,18 @@ pub(crate) fn err_invalid_package_config(
   generic_error(msg)
 }
 
-pub(crate) fn err_module_not_found(
-  path: &str,
-  base: &str,
-  typ: &str,
-) -> AnyError {
+pub fn err_module_not_found(path: &str, base: &str, typ: &str) -> AnyError {
   generic_error(format!(
     "[ERR_MODULE_NOT_FOUND] Cannot find {} \"{}\" imported from \"{}\"",
     typ, path, base
   ))
 }
 
-pub(crate) fn err_unsupported_dir_import(path: &str, base: &str) -> AnyError {
+pub fn err_unsupported_dir_import(path: &str, base: &str) -> AnyError {
   generic_error(format!("[ERR_UNSUPPORTED_DIR_IMPORT] Directory import '{}' is not supported resolving ES modules imported from {}", path, base))
 }
 
-pub(crate) fn err_unsupported_esm_url_scheme(url: &Url) -> AnyError {
+pub fn err_unsupported_esm_url_scheme(url: &Url) -> AnyError {
   let mut msg =
     "[ERR_UNSUPPORTED_ESM_URL_SCHEME] Only file and data URLS are supported by the default ESM loader"
       .to_string();
@@ -74,7 +70,7 @@ pub(crate) fn err_unsupported_esm_url_scheme(url: &Url) -> AnyError {
   generic_error(msg)
 }
 
-pub(crate) fn err_invalid_package_target(
+pub fn err_invalid_package_target(
   pkg_path: String,
   key: String,
   target: String,
@@ -102,7 +98,7 @@ pub(crate) fn err_invalid_package_target(
   generic_error(msg)
 }
 
-pub(crate) fn err_package_path_not_exported(
+pub fn err_package_path_not_exported(
   pkg_path: String,
   subpath: String,
   maybe_base: Option<String>,
@@ -125,7 +121,7 @@ pub(crate) fn err_package_path_not_exported(
   generic_error(msg)
 }
 
-pub(crate) fn err_package_import_not_defined(
+pub fn err_package_import_not_defined(
   specifier: &str,
   package_path: Option<String>,
   base: &str,

--- a/cli/compat/esm_resolver.rs
+++ b/cli/compat/esm_resolver.rs
@@ -15,7 +15,7 @@ use regex::Regex;
 use std::path::PathBuf;
 
 #[derive(Debug, Default)]
-pub(crate) struct NodeEsmResolver {
+pub struct NodeEsmResolver {
   maybe_import_map_resolver: Option<ImportMapResolver>,
 }
 

--- a/cli/compat/mod.rs
+++ b/cli/compat/mod.rs
@@ -14,7 +14,7 @@ use once_cell::sync::Lazy;
 use std::sync::Arc;
 
 pub use esm_resolver::check_if_should_use_esm_loader;
-pub(crate) use esm_resolver::NodeEsmResolver;
+pub use esm_resolver::NodeEsmResolver;
 
 // TODO(bartlomieju): this needs to be bumped manually for
 // each release, a better mechanism is preferable, but it's a quick and dirty
@@ -77,20 +77,20 @@ static NODE_COMPAT_URL: Lazy<String> = Lazy::new(|| {
 static GLOBAL_URL_STR: Lazy<String> =
   Lazy::new(|| format!("{}node/global.ts", NODE_COMPAT_URL.as_str()));
 
-pub(crate) static GLOBAL_URL: Lazy<Url> =
+pub static GLOBAL_URL: Lazy<Url> =
   Lazy::new(|| Url::parse(&GLOBAL_URL_STR).unwrap());
 
 static MODULE_URL_STR: Lazy<String> =
   Lazy::new(|| format!("{}node/module.ts", NODE_COMPAT_URL.as_str()));
 
-pub(crate) static MODULE_URL: Lazy<Url> =
+pub static MODULE_URL: Lazy<Url> =
   Lazy::new(|| Url::parse(&MODULE_URL_STR).unwrap());
 
 static COMPAT_IMPORT_URL: Lazy<Url> =
   Lazy::new(|| Url::parse("flags:compat").unwrap());
 
 /// Provide imports into a module graph when the compat flag is true.
-pub(crate) fn get_node_imports() -> Vec<(Url, Vec<String>)> {
+pub fn get_node_imports() -> Vec<(Url, Vec<String>)> {
   vec![(COMPAT_IMPORT_URL.clone(), vec![GLOBAL_URL_STR.clone()])]
 }
 
@@ -104,7 +104,7 @@ fn try_resolve_builtin_module(specifier: &str) -> Option<Url> {
   }
 }
 
-pub(crate) fn load_cjs_module(
+pub fn load_cjs_module(
   js_runtime: &mut JsRuntime,
   module: &str,
   main: bool,
@@ -123,7 +123,7 @@ pub(crate) fn load_cjs_module(
   Ok(())
 }
 
-pub(crate) fn add_global_require(
+pub fn add_global_require(
   js_runtime: &mut JsRuntime,
   main_module: &str,
 ) -> Result<(), AnyError> {

--- a/cli/config_file.rs
+++ b/cli/config_file.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
 
-pub(crate) type MaybeImportsResult =
+pub type MaybeImportsResult =
   Result<Option<Vec<(ModuleSpecifier, Vec<String>)>>, AnyError>;
 
 /// The transpile options that are significant out of a user provided tsconfig

--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -70,7 +70,7 @@ const IGNORE_DIRECTIVES: &[&str] = &[
 /// checking the code in the module graph.  Note that a user provided config
 /// of `"lib"` would override this value.
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
-pub(crate) enum TypeLib {
+pub enum TypeLib {
   DenoWindow,
   DenoWorker,
   UnstableDenoWindow,
@@ -104,7 +104,7 @@ impl Serialize for TypeLib {
 
 /// A structure representing stats from an emit operation for a graph.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub(crate) struct Stats(pub Vec<(String, u32)>);
+pub struct Stats(pub Vec<(String, u32)>);
 
 impl<'de> Deserialize<'de> for Stats {
   fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
@@ -137,7 +137,7 @@ impl fmt::Display for Stats {
 }
 
 /// An enum that represents the base tsc configuration to return.
-pub(crate) enum ConfigType {
+pub enum ConfigType {
   /// Return a configuration for bundling, using swc to emit the bundle. This is
   /// independent of type checking.
   Bundle,
@@ -153,7 +153,7 @@ pub(crate) enum ConfigType {
 /// For a given configuration type and optionally a configuration file, return a
 /// tuple of the resulting `TsConfig` struct and optionally any user
 /// configuration options that were ignored.
-pub(crate) fn get_ts_config(
+pub fn get_ts_config(
   config_type: ConfigType,
   maybe_config_file: Option<&ConfigFile>,
   maybe_user_config: Option<&HashMap<String, Value>>,
@@ -315,7 +315,7 @@ fn get_version(source_bytes: &[u8], config_bytes: &[u8]) -> String {
 }
 
 /// Determine if a given module kind and media type is emittable or not.
-pub(crate) fn is_emittable(
+pub fn is_emittable(
   kind: &ModuleKind,
   media_type: &MediaType,
   include_js: bool,
@@ -336,7 +336,7 @@ pub(crate) fn is_emittable(
 
 /// Options for performing a check of a module graph. Note that the decision to
 /// emit or not is determined by the `ts_config` settings.
-pub(crate) struct CheckOptions {
+pub struct CheckOptions {
   /// The check flag from the option which can effect the filtering of
   /// diagnostics in the emit result.
   pub check: flags::CheckFlag,
@@ -361,7 +361,7 @@ pub(crate) struct CheckOptions {
 /// The result of a check or emit of a module graph. Note that the actual
 /// emitted sources are stored in the cache and are not returned in the result.
 #[derive(Debug, Default)]
-pub(crate) struct CheckEmitResult {
+pub struct CheckEmitResult {
   pub diagnostics: Diagnostics,
   pub stats: Stats,
 }
@@ -373,7 +373,7 @@ pub(crate) struct CheckEmitResult {
 ///
 /// It is expected that it is determined if a check and/or emit is validated
 /// before the function is called.
-pub(crate) fn check_and_maybe_emit(
+pub fn check_and_maybe_emit(
   roots: &[(ModuleSpecifier, ModuleKind)],
   graph_data: Arc<RwLock<GraphData>>,
   cache: &mut dyn Cacher,
@@ -512,7 +512,7 @@ pub(crate) fn check_and_maybe_emit(
   })
 }
 
-pub(crate) enum BundleType {
+pub enum BundleType {
   /// Return the emitted contents of the program as a single "flattened" ES
   /// module.
   Module,
@@ -531,7 +531,7 @@ impl From<BundleType> for swc::bundler::ModuleType {
   }
 }
 
-pub(crate) struct BundleOptions {
+pub struct BundleOptions {
   pub bundle_type: BundleType,
   pub ts_config: TsConfig,
   pub emit_ignore_directives: bool,
@@ -686,7 +686,7 @@ impl swc::bundler::Resolve for BundleResolver<'_> {
 /// optionally its source map. Unlike emitting with `check_and_maybe_emit` and
 /// `emit`, which store the emitted modules in the cache, this function simply
 /// returns the output.
-pub(crate) fn bundle(
+pub fn bundle(
   graph: &ModuleGraph,
   options: BundleOptions,
 ) -> Result<(String, Option<String>), AnyError> {
@@ -779,7 +779,7 @@ pub(crate) fn bundle(
   })
 }
 
-pub(crate) struct EmitOptions {
+pub struct EmitOptions {
   pub ts_config: TsConfig,
   pub reload: bool,
   pub reload_exclusions: HashSet<ModuleSpecifier>,
@@ -788,7 +788,7 @@ pub(crate) struct EmitOptions {
 /// Given a module graph, emit any appropriate modules and cache them.
 // TODO(nayeemrmn): This would ideally take `GraphData` like
 // `check_and_maybe_emit()`, but the AST isn't stored in that. Cleanup.
-pub(crate) fn emit(
+pub fn emit(
   graph: &ModuleGraph,
   cache: &mut dyn Cacher,
   options: EmitOptions,
@@ -899,7 +899,7 @@ fn valid_emit(
 /// An adapter struct to make a deno_graph::ModuleGraphError display as expected
 /// in the Deno CLI.
 #[derive(Debug)]
-pub(crate) struct GraphError(pub ModuleGraphError);
+pub struct GraphError(pub ModuleGraphError);
 
 impl std::error::Error for GraphError {}
 
@@ -930,7 +930,7 @@ impl fmt::Display for GraphError {
 
 /// Convert a module graph to a map of "files", which are used by the runtime
 /// emit to be passed back to the caller.
-pub(crate) fn to_file_map(
+pub fn to_file_map(
   graph: &ModuleGraph,
   cache: &dyn Cacher,
 ) -> HashMap<String, String> {

--- a/cli/errors.rs
+++ b/cli/errors.rs
@@ -29,9 +29,7 @@ fn get_graph_error_class(err: &GraphError) -> &'static str {
   get_module_graph_error_class(&err.0)
 }
 
-pub(crate) fn get_module_graph_error_class(
-  err: &ModuleGraphError,
-) -> &'static str {
+pub fn get_module_graph_error_class(err: &ModuleGraphError) -> &'static str {
   match err {
     ModuleGraphError::LoadingErr(_, err) => get_error_class_name(err.as_ref()),
     ModuleGraphError::InvalidSource(_, _)
@@ -55,7 +53,7 @@ fn get_resolution_error_class(err: &ResolutionError) -> &'static str {
   }
 }
 
-pub(crate) fn get_error_class_name(e: &AnyError) -> &'static str {
+pub fn get_error_class_name(e: &AnyError) -> &'static str {
   deno_runtime::errors::get_error_class_name(e)
     .or_else(|| {
       e.downcast_ref::<ImportMapError>()

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -169,7 +169,7 @@ fn fetch_local(specifier: &ModuleSpecifier) -> Result<File, AnyError> {
 
 /// Create and populate a root cert store based on the passed options and
 /// environment.
-pub(crate) fn get_root_cert_store(
+pub fn get_root_cert_store(
   maybe_root_path: Option<PathBuf>,
   maybe_ca_stores: Option<Vec<String>>,
   maybe_ca_file: Option<String>,
@@ -314,7 +314,7 @@ pub struct FileFetcher {
   allow_remote: bool,
   cache: FileCache,
   cache_setting: CacheSetting,
-  pub(crate) http_cache: HttpCache,
+  pub http_cache: HttpCache,
   http_client: reqwest::Client,
   blob_store: BlobStore,
   download_log_level: log::Level,
@@ -392,7 +392,7 @@ impl FileFetcher {
   /// Fetch cached remote file.
   ///
   /// This is a recursive operation if source file has redirections.
-  pub(crate) fn fetch_cached(
+  pub fn fetch_cached(
     &self,
     specifier: &ModuleSpecifier,
     redirect_limit: i64,

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -19,7 +19,7 @@ use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::sync::Arc;
 
-pub(crate) fn contains_specifier(
+pub fn contains_specifier(
   v: &[(ModuleSpecifier, ModuleKind)],
   specifier: &ModuleSpecifier,
 ) -> bool {
@@ -28,7 +28,7 @@ pub(crate) fn contains_specifier(
 
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
-pub(crate) enum ModuleEntry {
+pub enum ModuleEntry {
   Module {
     code: Arc<String>,
     dependencies: BTreeMap<String, Dependency>,
@@ -47,7 +47,7 @@ pub(crate) enum ModuleEntry {
 
 /// Composes data from potentially many `ModuleGraph`s.
 #[derive(Debug, Default)]
-pub(crate) struct GraphData {
+pub struct GraphData {
   modules: HashMap<ModuleSpecifier, ModuleEntry>,
   /// Map of first known referrer locations for each module. Used to enhance
   /// error messages.
@@ -58,7 +58,7 @@ pub(crate) struct GraphData {
 
 impl GraphData {
   /// Store data from `graph` into `self`.
-  pub(crate) fn add_graph(&mut self, graph: &ModuleGraph, reload: bool) {
+  pub fn add_graph(&mut self, graph: &ModuleGraph, reload: bool) {
     for (specifier, result) in graph.specifiers() {
       if !reload && self.modules.contains_key(&specifier) {
         continue;
@@ -139,13 +139,13 @@ impl GraphData {
     }
   }
 
-  pub(crate) fn entries(&self) -> HashMap<&ModuleSpecifier, &ModuleEntry> {
+  pub fn entries(&self) -> HashMap<&ModuleSpecifier, &ModuleEntry> {
     self.modules.iter().collect()
   }
 
   /// Walk dependencies from `roots` and return every encountered specifier.
   /// Return `None` if any modules are not known.
-  pub(crate) fn walk<'a>(
+  pub fn walk<'a>(
     &'a self,
     roots: &[(ModuleSpecifier, ModuleKind)],
     follow_dynamic: bool,
@@ -235,7 +235,7 @@ impl GraphData {
 
   /// Clone part of `self`, containing only modules which are dependencies of
   /// `roots`. Returns `None` if any roots are not known.
-  pub(crate) fn graph_segment(
+  pub fn graph_segment(
     &self,
     roots: &[(ModuleSpecifier, ModuleKind)],
   ) -> Option<Self> {
@@ -263,7 +263,7 @@ impl GraphData {
   /// so. Returns `Some(Err(_))` if there is a known module graph or resolution
   /// error statically reachable from `roots`. Returns `None` if any modules are
   /// not known.
-  pub(crate) fn check(
+  pub fn check(
     &self,
     roots: &[(ModuleSpecifier, ModuleKind)],
     follow_type_only: bool,
@@ -360,7 +360,7 @@ impl GraphData {
 
   /// Mark `roots` and all of their dependencies as type checked under `lib`.
   /// Assumes that all of those modules are known.
-  pub(crate) fn set_type_checked(
+  pub fn set_type_checked(
     &mut self,
     roots: &[(ModuleSpecifier, ModuleKind)],
     lib: &TypeLib,
@@ -380,7 +380,7 @@ impl GraphData {
   }
 
   /// Check if `roots` are all marked as type checked under `lib`.
-  pub(crate) fn is_type_checked(
+  pub fn is_type_checked(
     &self,
     roots: &[(ModuleSpecifier, ModuleKind)],
     lib: &TypeLib,
@@ -398,7 +398,7 @@ impl GraphData {
 
   /// If `specifier` is known and a redirect, return the found specifier.
   /// Otherwise return `specifier`.
-  pub(crate) fn follow_redirect(
+  pub fn follow_redirect(
     &self,
     specifier: &ModuleSpecifier,
   ) -> ModuleSpecifier {
@@ -408,7 +408,7 @@ impl GraphData {
     }
   }
 
-  pub(crate) fn get<'a>(
+  pub fn get<'a>(
     &'a self,
     specifier: &ModuleSpecifier,
   ) -> Option<&'a ModuleEntry> {
@@ -418,7 +418,7 @@ impl GraphData {
   // TODO(bartlomieju): after saving translated source
   // it's never removed, potentially leading to excessive
   // memory consumption
-  pub(crate) fn add_cjs_esm_translation(
+  pub fn add_cjs_esm_translation(
     &mut self,
     specifier: &ModuleSpecifier,
     source: String,
@@ -429,7 +429,7 @@ impl GraphData {
     assert!(prev.is_none());
   }
 
-  pub(crate) fn get_cjs_esm_translation<'a>(
+  pub fn get_cjs_esm_translation<'a>(
     &'a self,
     specifier: &ModuleSpecifier,
   ) -> Option<&'a String> {
@@ -446,7 +446,7 @@ impl From<&ModuleGraph> for GraphData {
 }
 
 /// Like `graph.valid()`, but enhanced with referrer info.
-pub(crate) fn graph_valid(
+pub fn graph_valid(
   graph: &ModuleGraph,
   follow_type_only: bool,
   check_js: bool,
@@ -457,7 +457,7 @@ pub(crate) fn graph_valid(
 }
 
 /// Calls `graph.lock()` and exits on errors.
-pub(crate) fn graph_lock_or_exit(graph: &ModuleGraph) {
+pub fn graph_lock_or_exit(graph: &ModuleGraph) {
   if let Err(err) = graph.lock() {
     log::error!("{} {}", colors::red("error:"), err);
     std::process::exit(10);

--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -134,7 +134,7 @@ impl HttpCache {
     })
   }
 
-  pub(crate) fn get_cache_filename(&self, url: &Url) -> Option<PathBuf> {
+  pub fn get_cache_filename(&self, url: &Url) -> Option<PathBuf> {
     Some(self.location.join(url_to_filename(url)?))
   }
 

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -57,7 +57,7 @@ pub type HeadersMap = HashMap<String, String>;
 /// This is heavily influenced by
 /// https://github.com/kornelski/rusty-http-cache-semantics which is BSD
 /// 2-Clause Licensed and copyright Kornel Lesiński
-pub(crate) struct CacheSemantics {
+pub struct CacheSemantics {
   cache_control: CacheControl,
   cached: SystemTime,
   headers: HashMap<String, String>,

--- a/cli/lockfile.rs
+++ b/cli/lockfile.rs
@@ -91,7 +91,7 @@ impl Lockfile {
 }
 
 #[derive(Debug)]
-pub(crate) struct Locker(Option<Arc<Mutex<Lockfile>>>);
+pub struct Locker(Option<Arc<Mutex<Lockfile>>>);
 
 impl deno_graph::source::Locker for Locker {
   fn check_or_insert(
@@ -117,7 +117,7 @@ impl deno_graph::source::Locker for Locker {
   }
 }
 
-pub(crate) fn as_maybe_locker(
+pub fn as_maybe_locker(
   lockfile: Option<Arc<Mutex<Lockfile>>>,
 ) -> Option<Rc<RefCell<Box<dyn deno_graph::source::Locker>>>> {
   lockfile.as_ref().map(|lf| {

--- a/cli/logger.rs
+++ b/cli/logger.rs
@@ -30,7 +30,7 @@ impl log::Log for CliLogger {
   }
 }
 
-pub(crate) fn init(maybe_level: Option<log::Level>) {
+pub fn init(maybe_level: Option<log::Level>) {
   let log_level = maybe_level.unwrap_or(log::Level::Info);
   let logger = env_logger::Builder::from_env(
     env_logger::Env::default()

--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -173,7 +173,7 @@ fn check_specifier(
 
 /// For a set of tsc changes, can them for any that contain something that looks
 /// like an import and rewrite the import specifier to include the extension
-pub(crate) fn fix_ts_import_changes(
+pub fn fix_ts_import_changes(
   referrer: &ModuleSpecifier,
   changes: &[tsc::FileTextChanges],
   documents: &Documents,
@@ -323,7 +323,7 @@ fn is_preferred(
 
 /// Convert changes returned from a TypeScript quick fix action into edits
 /// for an LSP CodeAction.
-pub(crate) async fn ts_changes_to_edit(
+pub async fn ts_changes_to_edit(
   changes: &[tsc::FileTextChanges],
   language_server: &language_server::Inner,
 ) -> Result<Option<lsp::WorkspaceEdit>, AnyError> {
@@ -366,7 +366,7 @@ pub struct CodeActionCollection {
 }
 
 impl CodeActionCollection {
-  pub(crate) fn add_deno_fix_action(
+  pub fn add_deno_fix_action(
     &mut self,
     specifier: &ModuleSpecifier,
     diagnostic: &lsp::Diagnostic,
@@ -376,7 +376,7 @@ impl CodeActionCollection {
     Ok(())
   }
 
-  pub(crate) fn add_deno_lint_ignore_action(
+  pub fn add_deno_lint_ignore_action(
     &mut self,
     specifier: &ModuleSpecifier,
     diagnostic: &lsp::Diagnostic,
@@ -539,7 +539,7 @@ impl CodeActionCollection {
   }
 
   /// Add a TypeScript code fix action to the code actions collection.
-  pub(crate) async fn add_ts_fix_action(
+  pub async fn add_ts_fix_action(
     &mut self,
     specifier: &ModuleSpecifier,
     action: &tsc::CodeFixAction,

--- a/cli/lsp/cache.rs
+++ b/cli/lsp/cache.rs
@@ -35,7 +35,7 @@ type Request = (
 /// A "server" that handles requests from the language server to cache modules
 /// in its own thread.
 #[derive(Debug)]
-pub(crate) struct CacheServer(mpsc::UnboundedSender<Request>);
+pub struct CacheServer(mpsc::UnboundedSender<Request>);
 
 impl CacheServer {
   pub async fn new(
@@ -121,7 +121,7 @@ impl CacheServer {
 }
 
 /// Calculate a version for for a given path.
-pub(crate) fn calculate_fs_version(path: &Path) -> Option<String> {
+pub fn calculate_fs_version(path: &Path) -> Option<String> {
   let metadata = fs::metadata(path).ok()?;
   if let Ok(modified) = metadata.modified() {
     if let Ok(n) = modified.duration_since(SystemTime::UNIX_EPOCH) {
@@ -146,7 +146,7 @@ fn parse_metadata(
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub(crate) enum MetadataKey {
+pub enum MetadataKey {
   /// Represent the `x-deno-warning` header associated with the document
   Warning,
 }
@@ -158,7 +158,7 @@ struct Metadata {
 }
 
 #[derive(Debug, Default, Clone)]
-pub(crate) struct CacheMetadata {
+pub struct CacheMetadata {
   cache: http_cache::HttpCache,
   metadata: Arc<Mutex<HashMap<ModuleSpecifier, Metadata>>>,
 }

--- a/cli/lsp/code_lens.rs
+++ b/cli/lsp/code_lens.rs
@@ -377,7 +377,7 @@ async fn resolve_references_code_lens(
   }
 }
 
-pub(crate) async fn resolve_code_lens(
+pub async fn resolve_code_lens(
   code_lens: lsp::CodeLens,
   language_server: &language_server::Inner,
 ) -> Result<lsp::CodeLens, AnyError> {
@@ -393,7 +393,7 @@ pub(crate) async fn resolve_code_lens(
   }
 }
 
-pub(crate) async fn collect(
+pub async fn collect(
   specifier: &ModuleSpecifier,
   parsed_source: Option<ParsedSource>,
   config: &Config,

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -124,7 +124,7 @@ fn to_narrow_lsp_range(
 /// Given a specifier, a position, and a snapshot, optionally return a
 /// completion response, which will be valid import completions for the specific
 /// context.
-pub(crate) async fn get_import_completions(
+pub async fn get_import_completions(
   specifier: &ModuleSpecifier,
   position: &lsp::Position,
   config: &ConfigSnapshot,

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -36,7 +36,7 @@ use tokio::sync::Mutex;
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-pub(crate) type SnapshotForDiagnostics =
+pub type SnapshotForDiagnostics =
   (Arc<StateSnapshot>, Arc<ConfigSnapshot>, Option<LintConfig>);
 pub type DiagnosticRecord =
   (ModuleSpecifier, Option<i32>, Vec<lsp::Diagnostic>);
@@ -137,7 +137,7 @@ impl TsDiagnosticsStore {
 }
 
 #[derive(Debug)]
-pub(crate) struct DiagnosticsServer {
+pub struct DiagnosticsServer {
   channel: Option<mpsc::UnboundedSender<SnapshotForDiagnostics>>,
   ts_diagnostics: TsDiagnosticsStore,
   client: Client,
@@ -160,7 +160,7 @@ impl DiagnosticsServer {
     }
   }
 
-  pub(crate) fn get_ts_diagnostics(
+  pub fn get_ts_diagnostics(
     &self,
     specifier: &ModuleSpecifier,
     document_version: Option<i32>,
@@ -168,16 +168,16 @@ impl DiagnosticsServer {
     self.ts_diagnostics.get(specifier, document_version)
   }
 
-  pub(crate) fn invalidate(&self, specifiers: &[ModuleSpecifier]) {
+  pub fn invalidate(&self, specifiers: &[ModuleSpecifier]) {
     self.ts_diagnostics.invalidate(specifiers);
   }
 
-  pub(crate) fn invalidate_all(&self) {
+  pub fn invalidate_all(&self) {
     self.ts_diagnostics.invalidate_all();
   }
 
   #[allow(unused_must_use)]
-  pub(crate) fn start(&mut self) {
+  pub fn start(&mut self) {
     let (tx, mut rx) = mpsc::unbounded_channel::<SnapshotForDiagnostics>();
     self.channel = Some(tx);
     let client = self.client.clone();
@@ -320,7 +320,7 @@ impl DiagnosticsServer {
     });
   }
 
-  pub(crate) fn update(
+  pub fn update(
     &self,
     message: SnapshotForDiagnostics,
   ) -> Result<(), AnyError> {
@@ -573,7 +573,7 @@ struct DiagnosticDataRedirect {
 }
 
 /// An enum which represents diagnostic errors which originate from Deno itself.
-pub(crate) enum DenoDiagnostic {
+pub enum DenoDiagnostic {
   /// A `x-deno-warn` is associated with the specifier and should be displayed
   /// as a warning to the user.
   DenoWarn(String),
@@ -627,7 +627,7 @@ impl DenoDiagnostic {
 
   /// A "static" method which for a diagnostic that originated from the
   /// structure returns a code action which can resolve the diagnostic.
-  pub(crate) fn get_code_action(
+  pub fn get_code_action(
     specifier: &ModuleSpecifier,
     diagnostic: &lsp::Diagnostic,
   ) -> Result<lsp::CodeAction, AnyError> {
@@ -713,7 +713,7 @@ impl DenoDiagnostic {
 
   /// Given a reference to the code from an LSP diagnostic, determine if the
   /// diagnostic is fixable or not
-  pub(crate) fn is_fixable(code: &Option<lsp::NumberOrString>) -> bool {
+  pub fn is_fixable(code: &Option<lsp::NumberOrString>) -> bool {
     if let Some(lsp::NumberOrString::String(code)) = code {
       matches!(
         code.as_str(),
@@ -726,10 +726,7 @@ impl DenoDiagnostic {
 
   /// Convert to an lsp Diagnostic when the range the diagnostic applies to is
   /// provided.
-  pub(crate) fn to_lsp_diagnostic(
-    &self,
-    range: &lsp::Range,
-  ) -> lsp::Diagnostic {
+  pub fn to_lsp_diagnostic(&self, range: &lsp::Range) -> lsp::Diagnostic {
     let (severity, message, data) = match self {
       Self::DenoWarn(message) => (lsp::DiagnosticSeverity::WARNING, message.to_string(), None),
       Self::InvalidAssertType(assert_type) => (lsp::DiagnosticSeverity::ERROR, format!("The module is a JSON module and expected an assertion type of \"json\". Instead got \"{}\".", assert_type), None),

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -96,7 +96,7 @@ impl deno_graph::SourceParser for SourceParser {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum LanguageId {
+pub enum LanguageId {
   JavaScript,
   Jsx,
   TypeScript,
@@ -527,7 +527,7 @@ impl Document {
   }
 }
 
-pub(crate) fn to_hover_text(result: &Resolved) -> String {
+pub fn to_hover_text(result: &Resolved) -> String {
   match result {
     Resolved::Ok { specifier, .. } => match specifier.scheme() {
       "data" => "_(a data url)_".to_string(),
@@ -544,7 +544,7 @@ pub(crate) fn to_hover_text(result: &Resolved) -> String {
   }
 }
 
-pub(crate) fn to_lsp_range(range: &deno_graph::Range) -> lsp::Range {
+pub fn to_lsp_range(range: &deno_graph::Range) -> lsp::Range {
   lsp::Range {
     start: lsp::Position {
       line: range.start.line as u32,
@@ -697,7 +697,7 @@ fn get_document_path(
 }
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct Documents {
+pub struct Documents {
   /// The DENO_DIR that the documents looks for non-file based modules.
   cache: HttpCache,
   /// A flag that indicates that stated data is potentially invalid and needs to

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -72,7 +72,7 @@ pub struct LanguageServer(Arc<tokio::sync::Mutex<Inner>>);
 
 /// Snapshot of the state used by TSC.
 #[derive(Debug, Default)]
-pub(crate) struct StateSnapshot {
+pub struct StateSnapshot {
   pub assets: AssetsSnapshot,
   pub cache_metadata: cache::CacheMetadata,
   pub documents: Documents,
@@ -80,7 +80,7 @@ pub(crate) struct StateSnapshot {
 }
 
 #[derive(Debug)]
-pub(crate) struct Inner {
+pub struct Inner {
   /// Cached versions of "fixed" assets that can either be inlined in Rust or
   /// are part of the TypeScript snapshot and have to be fetched out.
   assets: Assets,
@@ -88,13 +88,13 @@ pub(crate) struct Inner {
   /// which is used by the language server
   cache_metadata: cache::CacheMetadata,
   /// The LSP client that this LSP server is connected to.
-  pub(crate) client: Client,
+  pub client: Client,
   /// Configuration information.
-  pub(crate) config: Config,
+  pub config: Config,
   diagnostics_server: diagnostics::DiagnosticsServer,
   /// The collection of documents that the server is currently handling, either
   /// on disk or "open" within the client.
-  pub(crate) documents: Documents,
+  pub documents: Documents,
   /// Handles module registries, which allow discovery of modules
   module_registries: ModuleRegistry,
   /// The path to the module registries cache
@@ -108,11 +108,11 @@ pub(crate) struct Inner {
   /// options.
   maybe_config_file: Option<ConfigFile>,
   /// An optional configuration for linter which has been taken from specified config file.
-  pub(crate) maybe_lint_config: Option<LintConfig>,
+  pub maybe_lint_config: Option<LintConfig>,
   /// An optional configuration for formatter which has been taken from specified config file.
   maybe_fmt_config: Option<FmtConfig>,
   /// An optional import map which is used to resolve modules.
-  pub(crate) maybe_import_map: Option<Arc<ImportMap>>,
+  pub maybe_import_map: Option<Arc<ImportMap>>,
   /// The URL for the import map which is used to determine relative imports.
   maybe_import_map_uri: Option<Url>,
   /// A collection of measurements which instrument that performance of the LSP.
@@ -120,9 +120,9 @@ pub(crate) struct Inner {
   /// A memoized version of fixable diagnostic codes retrieved from TypeScript.
   ts_fixable_diagnostics: Vec<String>,
   /// An abstraction that handles interactions with TypeScript.
-  pub(crate) ts_server: Arc<TsServer>,
+  pub ts_server: Arc<TsServer>,
   /// A map of specifiers and URLs used to translate over the LSP.
-  pub(crate) url_map: urls::LspUrlMap,
+  pub url_map: urls::LspUrlMap,
 }
 
 impl LanguageServer {
@@ -180,7 +180,7 @@ impl Inner {
 
   /// Searches assets and open documents which might be performed asynchronously,
   /// hydrating in memory caches for subsequent requests.
-  pub(crate) async fn get_asset_or_document(
+  pub async fn get_asset_or_document(
     &self,
     specifier: &ModuleSpecifier,
   ) -> LspResult<AssetOrDocument> {
@@ -200,7 +200,7 @@ impl Inner {
 
   /// Searches assets and open documents which might be performed asynchronously,
   /// hydrating in memory caches for subsequent requests.
-  pub(crate) async fn get_maybe_asset_or_document(
+  pub async fn get_maybe_asset_or_document(
     &self,
     specifier: &ModuleSpecifier,
   ) -> LspResult<Option<AssetOrDocument>> {
@@ -223,7 +223,7 @@ impl Inner {
 
   /// Only searches already cached assets and documents. If
   /// the asset or document cannot be found an error is returned.
-  pub(crate) fn get_cached_asset_or_document(
+  pub fn get_cached_asset_or_document(
     &self,
     specifier: &ModuleSpecifier,
   ) -> LspResult<AssetOrDocument> {
@@ -242,7 +242,7 @@ impl Inner {
 
   /// Only searches already cached assets and documents. If
   /// the asset or document cannot be found, `None` is returned.
-  pub(crate) fn get_maybe_cached_asset_or_document(
+  pub fn get_maybe_cached_asset_or_document(
     &self,
     specifier: &ModuleSpecifier,
   ) -> Option<AssetOrDocument> {
@@ -257,7 +257,7 @@ impl Inner {
     }
   }
 
-  pub(crate) async fn get_navigation_tree(
+  pub async fn get_navigation_tree(
     &mut self,
     specifier: &ModuleSpecifier,
   ) -> Result<Arc<tsc::NavigationTree>, AnyError> {
@@ -384,7 +384,7 @@ impl Inner {
     Ok(())
   }
 
-  pub(crate) fn snapshot(&self) -> Arc<StateSnapshot> {
+  pub fn snapshot(&self) -> Arc<StateSnapshot> {
     Arc::new(StateSnapshot {
       assets: self.assets.snapshot(),
       cache_metadata: self.cache_metadata.clone(),

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -16,7 +16,7 @@ mod completions;
 mod config;
 mod diagnostics;
 mod documents;
-pub(crate) mod language_server;
+pub mod language_server;
 mod logging;
 mod lsp_custom;
 mod parent_process_checker;

--- a/cli/lsp/registries.rs
+++ b/cli/lsp/registries.rs
@@ -341,7 +341,7 @@ fn validate_config(config: &RegistryConfigurationJson) -> Result<(), AnyError> {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub(crate) struct RegistryConfigurationVariable {
+pub struct RegistryConfigurationVariable {
   /// The name of the variable.
   key: String,
   /// An optional URL/API endpoint that can provide optional documentation for a
@@ -353,7 +353,7 @@ pub(crate) struct RegistryConfigurationVariable {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub(crate) struct RegistryConfiguration {
+pub struct RegistryConfiguration {
   /// A Express-like path which describes how URLs are composed for a registry.
   schema: String,
   /// The variables denoted in the `schema` should have a variable entry.
@@ -407,7 +407,7 @@ enum VariableItems {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct ModuleRegistryOptions {
+pub struct ModuleRegistryOptions {
   pub maybe_root_path: Option<PathBuf>,
   pub maybe_ca_stores: Option<Vec<String>>,
   pub maybe_ca_file: Option<String>,
@@ -418,7 +418,7 @@ pub(crate) struct ModuleRegistryOptions {
 /// registries and can provide completion information for URLs that match
 /// one of the enabled registries.
 #[derive(Debug, Clone)]
-pub(crate) struct ModuleRegistry {
+pub struct ModuleRegistry {
   origins: HashMap<String, Vec<RegistryConfiguration>>,
   file_fetcher: FileFetcher,
 }
@@ -506,10 +506,7 @@ impl ModuleRegistry {
   }
 
   /// Check to see if the given origin has a registry configuration.
-  pub(crate) async fn check_origin(
-    &self,
-    origin: &str,
-  ) -> Result<(), AnyError> {
+  pub async fn check_origin(&self, origin: &str) -> Result<(), AnyError> {
     let origin_url = Url::parse(origin)?;
     let specifier = origin_url.join(CONFIG_PATH)?;
     self.fetch_config(&specifier).await?;
@@ -592,10 +589,7 @@ impl ModuleRegistry {
     Ok(())
   }
 
-  pub(crate) async fn get_hover(
-    &self,
-    dependency: &Dependency,
-  ) -> Option<String> {
+  pub async fn get_hover(&self, dependency: &Dependency) -> Option<String> {
     let maybe_code = dependency.get_code();
     let maybe_type = dependency.get_type();
     let specifier = match (maybe_code, maybe_type) {
@@ -647,7 +641,7 @@ impl ModuleRegistry {
 
   /// For a string specifier from the client, provide a set of completions, if
   /// any, for the specifier.
-  pub(crate) async fn get_completions(
+  pub async fn get_completions(
     &self,
     current_specifier: &str,
     offset: usize,
@@ -938,7 +932,7 @@ impl ModuleRegistry {
     self.get_origin_completions(current_specifier, range)
   }
 
-  pub(crate) async fn get_documentation(
+  pub async fn get_documentation(
     &self,
     url: &str,
   ) -> Option<lsp::Documentation> {

--- a/cli/lsp/semantic_tokens.rs
+++ b/cli/lsp/semantic_tokens.rs
@@ -12,8 +12,8 @@ use lspower::lsp::SemanticTokens;
 use lspower::lsp::SemanticTokensLegend;
 use std::ops::{Index, IndexMut};
 
-pub(crate) const MODIFIER_MASK: u32 = 255;
-pub(crate) const TYPE_OFFSET: u32 = 8;
+pub const MODIFIER_MASK: u32 = 255;
+pub const TYPE_OFFSET: u32 = 8;
 
 enum TokenType {
   Class = 0,

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -124,7 +124,7 @@ impl TsServer {
     Self(tx)
   }
 
-  pub(crate) async fn request<R>(
+  pub async fn request<R>(
     &self,
     snapshot: Arc<StateSnapshot>,
     req: RequestMethod,
@@ -137,7 +137,7 @@ impl TsServer {
       .await
   }
 
-  pub(crate) async fn request_with_cancellation<R>(
+  pub async fn request_with_cancellation<R>(
     &self,
     snapshot: Arc<StateSnapshot>,
     req: RequestMethod,
@@ -282,7 +282,7 @@ impl Assets {
     self.assets.lock().get(k).cloned()
   }
 
-  pub(crate) async fn get(
+  pub async fn get(
     &self,
     specifier: &ModuleSpecifier,
     // todo(dsherret): this shouldn't be a parameter, but instead retrieved via
@@ -774,7 +774,7 @@ fn display_parts_to_string(
 }
 
 impl QuickInfo {
-  pub(crate) fn to_hover(
+  pub fn to_hover(
     &self,
     line_index: Arc<LineIndex>,
     language_server: &language_server::Inner,
@@ -829,7 +829,7 @@ pub struct DocumentSpan {
 }
 
 impl DocumentSpan {
-  pub(crate) async fn to_link(
+  pub async fn to_link(
     &self,
     line_index: Arc<LineIndex>,
     language_server: &language_server::Inner,
@@ -927,7 +927,7 @@ pub struct NavigateToItem {
 }
 
 impl NavigateToItem {
-  pub(crate) async fn to_symbol_information(
+  pub async fn to_symbol_information(
     &self,
     language_server: &mut language_server::Inner,
   ) -> Option<lsp::SymbolInformation> {
@@ -1131,7 +1131,7 @@ pub struct ImplementationLocation {
 }
 
 impl ImplementationLocation {
-  pub(crate) fn to_location(
+  pub fn to_location(
     &self,
     line_index: Arc<LineIndex>,
     language_server: &language_server::Inner,
@@ -1148,7 +1148,7 @@ impl ImplementationLocation {
     }
   }
 
-  pub(crate) async fn to_link(
+  pub async fn to_link(
     &self,
     line_index: Arc<LineIndex>,
     language_server: &language_server::Inner,
@@ -1175,7 +1175,7 @@ pub struct RenameLocations {
 }
 
 impl RenameLocations {
-  pub(crate) async fn into_workspace_edit(
+  pub async fn into_workspace_edit(
     self,
     new_name: &str,
     language_server: &language_server::Inner,
@@ -1265,7 +1265,7 @@ pub struct DefinitionInfoAndBoundSpan {
 }
 
 impl DefinitionInfoAndBoundSpan {
-  pub(crate) async fn to_definition(
+  pub async fn to_definition(
     &self,
     line_index: Arc<LineIndex>,
     language_server: &language_server::Inner,
@@ -1345,7 +1345,7 @@ pub struct FileTextChanges {
 }
 
 impl FileTextChanges {
-  pub(crate) async fn to_text_document_edit(
+  pub async fn to_text_document_edit(
     &self,
     language_server: &language_server::Inner,
   ) -> Result<lsp::TextDocumentEdit, AnyError> {
@@ -1366,7 +1366,7 @@ impl FileTextChanges {
     })
   }
 
-  pub(crate) async fn to_text_document_change_ops(
+  pub async fn to_text_document_change_ops(
     &self,
     language_server: &language_server::Inner,
   ) -> Result<Vec<lsp::DocumentChangeOperation>, AnyError> {
@@ -1603,7 +1603,7 @@ pub struct RefactorEditInfo {
 }
 
 impl RefactorEditInfo {
-  pub(crate) async fn to_workspace_edit(
+  pub async fn to_workspace_edit(
     &self,
     language_server: &language_server::Inner,
   ) -> Result<Option<lsp::WorkspaceEdit>, AnyError> {
@@ -1668,7 +1668,7 @@ pub struct ReferenceEntry {
 }
 
 impl ReferenceEntry {
-  pub(crate) fn to_location(
+  pub fn to_location(
     &self,
     line_index: Arc<LineIndex>,
     url_map: &LspUrlMap,
@@ -1700,7 +1700,7 @@ pub struct CallHierarchyItem {
 }
 
 impl CallHierarchyItem {
-  pub(crate) async fn try_resolve_call_hierarchy_item(
+  pub async fn try_resolve_call_hierarchy_item(
     &self,
     language_server: &language_server::Inner,
     maybe_root_path: Option<&Path>,
@@ -1718,7 +1718,7 @@ impl CallHierarchyItem {
     ))
   }
 
-  pub(crate) fn to_call_hierarchy_item(
+  pub fn to_call_hierarchy_item(
     &self,
     line_index: Arc<LineIndex>,
     language_server: &language_server::Inner,
@@ -1801,7 +1801,7 @@ pub struct CallHierarchyIncomingCall {
 }
 
 impl CallHierarchyIncomingCall {
-  pub(crate) async fn try_resolve_call_hierarchy_incoming_call(
+  pub async fn try_resolve_call_hierarchy_incoming_call(
     &self,
     language_server: &language_server::Inner,
     maybe_root_path: Option<&Path>,
@@ -1835,7 +1835,7 @@ pub struct CallHierarchyOutgoingCall {
 }
 
 impl CallHierarchyOutgoingCall {
-  pub(crate) async fn try_resolve_call_hierarchy_outgoing_call(
+  pub async fn try_resolve_call_hierarchy_outgoing_call(
     &self,
     line_index: Arc<LineIndex>,
     language_server: &language_server::Inner,
@@ -1876,7 +1876,7 @@ pub struct CompletionEntryDetails {
 }
 
 impl CompletionEntryDetails {
-  pub(crate) fn as_completion_item(
+  pub fn as_completion_item(
     &self,
     original_item: &lsp::CompletionItem,
     language_server: &language_server::Inner,
@@ -2285,7 +2285,7 @@ pub struct SignatureHelpItems {
 }
 
 impl SignatureHelpItems {
-  pub(crate) fn into_signature_help(
+  pub fn into_signature_help(
     self,
     language_server: &language_server::Inner,
   ) -> lsp::SignatureHelp {
@@ -2314,7 +2314,7 @@ pub struct SignatureHelpItem {
 }
 
 impl SignatureHelpItem {
-  pub(crate) fn into_signature_information(
+  pub fn into_signature_information(
     self,
     language_server: &language_server::Inner,
   ) -> lsp::SignatureInformation {
@@ -2362,7 +2362,7 @@ pub struct SignatureHelpParameter {
 }
 
 impl SignatureHelpParameter {
-  pub(crate) fn into_parameter_information(
+  pub fn into_parameter_information(
     self,
     language_server: &language_server::Inner,
   ) -> lsp::ParameterInformation {
@@ -3252,7 +3252,7 @@ impl RequestMethod {
 }
 
 /// Send a request into a runtime and return the JSON value of the response.
-pub(crate) fn request(
+pub fn request(
   runtime: &mut JsRuntime,
   state_snapshot: Arc<StateSnapshot>,
   method: RequestMethod,

--- a/cli/lsp/urls.rs
+++ b/cli/lsp/urls.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 /// Used in situations where a default URL needs to be used where otherwise a
 /// panic is undesired.
-pub(crate) static INVALID_SPECIFIER: Lazy<ModuleSpecifier> =
+pub static INVALID_SPECIFIER: Lazy<ModuleSpecifier> =
   Lazy::new(|| ModuleSpecifier::parse("deno://invalid").unwrap());
 
 /// Matches the `encodeURIComponent()` encoding from JavaScript, which matches

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -15,7 +15,7 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::str;
 
-pub(crate) struct CliModuleLoader {
+pub struct CliModuleLoader {
   pub lib: TypeLib,
   /// The initial set of permissions used to resolve the static imports in the
   /// worker. They are decoupled from the worker (dynamic) permissions since

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -251,7 +251,7 @@ impl ProcState {
   /// module before attempting to `load()` it from a `JsRuntime`. It will
   /// populate `self.graph_data` in memory with the necessary source code, write
   /// emits where necessary or report any module graph / type checking errors.
-  pub(crate) async fn prepare_module_load(
+  pub async fn prepare_module_load(
     &self,
     roots: Vec<ModuleSpecifier>,
     is_dynamic: bool,
@@ -486,7 +486,7 @@ impl ProcState {
     Ok(())
   }
 
-  pub(crate) fn resolve(
+  pub fn resolve(
     &self,
     specifier: &str,
     referrer: &str,

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 /// This is done to avoid having `import_map` be a direct dependency of
 /// `deno_graph`.
 #[derive(Debug, Clone)]
-pub(crate) struct ImportMapResolver(Arc<ImportMap>);
+pub struct ImportMapResolver(Arc<ImportMap>);
 
 impl ImportMapResolver {
   pub fn new(import_map: Arc<ImportMap>) -> Self {
@@ -37,7 +37,7 @@ impl Resolver for ImportMapResolver {
 }
 
 #[derive(Debug, Default, Clone)]
-pub(crate) struct JsxResolver {
+pub struct JsxResolver {
   jsx_import_source_module: String,
   maybe_import_map_resolver: Option<ImportMapResolver>,
 }

--- a/cli/tools/coverage/merge.rs
+++ b/cli/tools/coverage/merge.rs
@@ -190,17 +190,14 @@ impl<'a> StartEventQueue<'a> {
     }
   }
 
-  pub(crate) fn set_pending_offset(&mut self, offset: usize) {
+  pub fn set_pending_offset(&mut self, offset: usize) {
     self.pending = Some(StartEvent {
       offset,
       trees: Vec::new(),
     });
   }
 
-  pub(crate) fn push_pending_tree(
-    &mut self,
-    tree: (usize, &'a mut RangeTree<'a>),
-  ) {
+  pub fn push_pending_tree(&mut self, tree: (usize, &'a mut RangeTree<'a>)) {
     self.pending = self.pending.take().map(|mut start_event| {
       start_event.trees.push(tree);
       start_event

--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -500,7 +500,7 @@ fn sort_diagnostics(diagnostics: &mut Vec<LintDiagnostic>) {
   });
 }
 
-pub(crate) fn get_configured_rules(
+pub fn get_configured_rules(
   maybe_lint_config: Option<&LintConfig>,
   maybe_rules_tags: Option<Vec<String>>,
   maybe_rules_include: Option<Vec<String>>,

--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -80,7 +80,7 @@ macro_rules! inc {
 }
 
 /// Contains static assets that are not preloaded in the compiler snapshot.
-pub(crate) static STATIC_ASSETS: Lazy<HashMap<&'static str, &'static str>> =
+pub static STATIC_ASSETS: Lazy<HashMap<&'static str, &'static str>> =
   Lazy::new(|| {
     (&[
       (
@@ -238,7 +238,7 @@ pub struct Request {
   pub config: TsConfig,
   /// Indicates to the tsc runtime if debug logging should occur.
   pub debug: bool,
-  pub(crate) graph_data: Arc<RwLock<GraphData>>,
+  pub graph_data: Arc<RwLock<GraphData>>,
   pub hash_data: Vec<Vec<u8>>,
   pub maybe_config_specifier: Option<ModuleSpecifier>,
   pub maybe_tsbuildinfo: Option<String>,
@@ -248,7 +248,7 @@ pub struct Request {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) struct Response {
+pub struct Response {
   /// Any diagnostics that have been returned from the checker.
   pub diagnostics: Diagnostics,
   /// Any files that were emitted during the check.
@@ -627,7 +627,7 @@ fn op_respond(state: &mut OpState, args: Value) -> Result<Value, AnyError> {
 /// Execute a request on the supplied snapshot, returning a response which
 /// contains information, like any emitted files, diagnostics, statistics and
 /// optionally an updated TypeScript build info.
-pub(crate) fn exec(request: Request) -> Result<Response, AnyError> {
+pub fn exec(request: Request) -> Result<Response, AnyError> {
   // tsc cannot handle root specifiers that don't have one of the "acceptable"
   // extensions.  Therefore, we have to check the root modules against their
   // extensions and remap any that are unacceptable to tsc and add them to the
@@ -730,7 +730,7 @@ mod tests {
   use std::fs;
 
   #[derive(Debug, Default)]
-  pub(crate) struct MockLoader {
+  pub struct MockLoader {
     pub fixtures: PathBuf,
   }
 


### PR DESCRIPTION
`pub(crate)` is viral and not necessary for the binary because it's not being used as a library.