### PR TITLE
perf(http): avoid Set.has() when closing connection resource

### DIFF
--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -241,11 +241,15 @@
           ObjectPrototypeIsPrototypeOf(Uint8ArrayPrototype, respBody)
         );
 
+        const deferred = request[_deferred];
+        const ws = resp[_ws];
+        
         try {
           await core.opAsync(
             "op_http_write_headers",
             [streamRid, innerResp.status ?? 200, innerResp.headerList],
             isStreamingResponseBody ? null : respBody,
+            ws && deferred && isStreamingResponseBody,
           );
         } catch (error) {
           const connError = httpConn[connErrorSymbol];
@@ -303,7 +307,6 @@
           }
         }
 
-        const deferred = request[_deferred];
         if (deferred) {
           const res = await core.opAsync("op_http_upgrade", streamRid);
           let conn;
@@ -319,7 +322,6 @@
 
           deferred.resolve([conn, res.readBuf]);
         }
-        const ws = resp[_ws];
         if (ws) {
           const wsRid = await core.opAsync(
             "op_http_upgrade_websocket",

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -181,7 +181,6 @@
     localAddr,
   ) {
     return async function respondWith(resp) {
-      let closeQuick = false;
       try {
         resp = await resp;
         if (!(ObjectPrototypeIsPrototypeOf(ResponsePrototype, resp))) {

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -237,7 +237,6 @@
           ObjectPrototypeIsPrototypeOf(Uint8ArrayPrototype, respBody)
         );
 
-
         try {
           await core.opAsync(
             "op_http_write_headers",
@@ -355,10 +354,9 @@
           }
         }
       } finally {
-         const deleted = SetPrototypeDelete(httpConn.managedResources, streamRid);
-         if(deleted) {
-           core.close(streamRid)
-         }
+        if (SetPrototypeDelete(httpConn.managedResources, streamRid)) {
+          core.close(streamRid);
+        }
       }
     };
   }

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -316,8 +316,7 @@
 
           deferred.resolve([conn, res.readBuf]);
         }
-
-        const ws = request[_ws];
+        const ws = resp[_ws];
         if (ws) {
           const wsRid = await core.opAsync(
             "op_http_upgrade_websocket",

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -42,7 +42,6 @@
     Set,
     SetPrototypeAdd,
     SetPrototypeDelete,
-    SetPrototypeHas,
     SetPrototypeValues,
     StringPrototypeIncludes,
     StringPrototypeToLowerCase,

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -500,6 +500,7 @@ async fn op_http_write_headers(
   state: Rc<RefCell<OpState>>,
   args: RespondArgs,
   data: Option<StringOrBuffer>,
+  close: bool,
 ) -> Result<(), AnyError> {
   let RespondArgs(rid, status, headers) = args;
   let stream = state

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -500,7 +500,6 @@ async fn op_http_write_headers(
   state: Rc<RefCell<OpState>>,
   args: RespondArgs,
   data: Option<StringOrBuffer>,
-  close: bool,
 ) -> Result<(), AnyError> {
   let RespondArgs(rid, status, headers) = args;
   let stream = state


### PR DESCRIPTION
`main`:

```
# hey -n 1000000
Total:	12.3944 secs
Slowest:	0.0216 secs
Fastest:	0.0000 secs
Average:	0.0006 secs
Requests/sec:	80681.7978

Total data:	11000000 bytes
Size/request:	11 bytes
```

This PR:
```
# hey -n 1000000
Summary:
Total:	11.8821 secs
Slowest:	0.0116 secs
Fastest:	0.0000 secs
Average:	0.0006 secs
Requests/sec:	84160.5187

Total data:	11000000 bytes
Size/request:	11 bytes
```

JS benchmark: [here](https://perf.link/#eyJpZCI6Inh1Y3V3NW4waGN4IiwidGl0bGUiOiIiLCJiZWZvcmUiOiIvLyBMYXJnZSBudW1iZXIgb2Ygcmlkcy5cbmNvbnN0IHJpZHMgPSBuZXcgU2V0KFsxLDIsMyw0LDUsNiw3LDgsOSwxMCwxMSwxMiwxMywxNCwxNSwxNiwxNywxOCwxOSwyMCwyMSwyMiwyMywyNCwyNSwxLDIsMyw0LDUsNiw3LDgsOSwxMCwxMSwxMiwxMywxNCwxNSwxNiwxNywxOCwxOSwyMCwyMSwyMiwyMywyNCwyNSwxLDIsMyw0LDUsNiw3LDgsOSwxMCwxMSwxMiwxMywxNCwxNSwxNiwxNywxOCwxOSwyMCwyMSwyMiwyMywyNCwyNSwxLDIsMyw0LDUsNiw3LDgsOSwxMCwxMSwxMiwxMywxNCwxNSwxNiwxNywxOCwxOSwyMCwyMSwyMiwyMywyNCwyNSwxLDIsMyw0LDUsNiw3LDgsOSwxMCwxMSwxMiwxMywxNCwxNSwxNiwxNywxOCwxOSwyMCwyMSwyMiwyMywyNCwyNSwxLDIsMyw0LDUsNiw3LDgsOSwxMCwxMSwxMiwxMywxNCwxNSwxNiwxNywxOCwxOSwyMCwyMSwyMiwyMywyNCwyNSwxLDIsMyw0LDUsNiw3LDgsOSwxMCwxMSwxMiwxMywxNCwxNSwxNiwxNywxOCwxOSwyMCwyMSwyMiwyMywyNCwyNSwxLDIsMyw0LDUsNiw3LDgsOSwxMCwxMSwxMiwxMywxNCwxNSwxNiwxNywxOCwxOSwyMCwyMSwyMiwyMywyNCwyNSwxLDIsMyw0LDUsNiw3LDgsOSwxMCwxMSwxMiwxMywxNCwxNSwxNiwxNywxOCwxOSwyMCwyMSwyMiwyMywyNCwyNSwxLDIsMyw0LDUsNiw3LDgsOSwxMCwxMSwxMiwxMywxNCwxNSwxNiwxNywxOCwxOSwyMCwyMSwyMiwyMywyNCwyNSwxLDIsMyw0LDUsNiw3LDgsOSwxMCwxMSwxMiwxMywxNCwxNSwxNiwxNywxOCwxOSwyMCwyMSwyMiwyMywyNCwyNV0pOyIsInRlc3RzIjpbeyJuYW1lIjoiVGVzdCBDYXNlIiwiY29kZSI6ImlmKHJpZHMuaGFzKDEpKSByaWRzLmRlbGV0ZSgxKTtcbmlmKHJpZHMuaGFzKDExMikpIHJpZHMuZGVsZXRlKDExMik7IiwicnVucyI6WzY4ODAwMCwyMDQ3MDAwLDExMDAwMCwyNjk4MDAwLDIyMTgwMDAsOTUzMDAwLDI4NzIwMDAsNTg0NjAwMCw0NTcwMDAwLDU4NTkwMDAsMzY3MTAwMCwyNzI1MDAwLDcxNDIwMDAsMTcxMDAwMCwxMDc3MDAwLDQwNjgwMDAsNzQzMTAwMCw1NjQwMDAsNjgzMDAwLDU1NzYwMDAsNjU2OTAwMCwyNzkwMDAsMjIwNTAwMCw0MTc4MDAwLDU1MjQwMDAsMjAwMDAsMTY3MzAwMCwyMDAwMCw0ODQxMDAwLDEwNDEwMDAsMTQyODAwMCw0OTkwMDAsNDEwMzAwMCw2NTE4MDAwLDIwNzAwMCwxOTcwMDAwLDU3OTAwMCwyMDcwMDAwLDc0MzEwMDAsMTk0NjAwMCw3NDMxMDAwLDE4NTIwMDAsMTM2MDAwMCwxMTYxMDAwLDIzMDEwMDAsNTA5NjAwMCw2OTc3MDAwLDc5NDAwMCwyMjE1MDAwLDE2MDgwMDAsNjkzMjAwMCwxNzk1MDAwLDM1MDAwLDk2NDAwMCwyMDAzMDAwLDczMjIwMDAsODI3MDAwLDIwMTgwMDAsNjI3OTAwMCw2NTQ4MDAwLDE0NjcwMDAsMjU3OTAwMCw0OTAwMCwzMTI0MDAwLDUxMTAwMCwxOTExMDAwLDExMTUwMDAsNzQzMTAwMCw4ODkwMDAsMjI4MjAwMCwzNTUwMDAsMjA5NjAwMCw1NDYzMDAwLDQ5MDAwLDg3MjAwMCw4MzIwMDAsNDA2MDAwLDU3OTAwMCwxMjUxMDAwLDEyNzcwMDAsMjI4MDAwMCw3NDMxMDAwLDE2MzMwMDAsMTQ4OTAwMCw3NTAwMDAsNDUwNzAwMCw3NDMxMDAwLDkzNjAwMCw4OTAwMDAsNDIwMTAwMCwxNDA3MDAwLDc0MzEwMDAsNjQ2MDAwLDU1NzYwMDAsMTM4MDAwLDE3MzEwMDAsMTc1NTAwMCw4NzgwMDAsNjYzNTAwMCw3ODUwMDBdLCJvcHMiOjI3NDE5NTB9LHsibmFtZSI6IiIsImNvZGUiOiJyaWRzLmRlbGV0ZSgxKTtcbnJpZHMuZGVsZXRlKDExMik7IiwicnVucyI6WzIwOTAwMCw0ODcwMDAsMzc3NTAwMCwyNzE3MDAwLDg0NDAwMCw0OTk2MDAwLDE1NjgwMDAsNjExMzAwMCwzNzA2MDAwLDQyNzQwMDAsMzIxMTAwMCwxODMyMDAwLDY2MDkwMDAsNzA4MDAwLDU4MTIwMDAsMzczNzAwMCw3MjUwMDAwLDIzMDAwLDcwODcwMDAsNTgzMzAwMCw1NTU1MDAwLDczNzcwMDAsNjUxMDAwLDQyMTMwMDAsNTYyMjAwMCw3NjM1MDAwLDE2MDAwLDY4OTIwMDAsMzg1ODAwMCw2NTEwMDAsMTAxOTAwMCw3ODUwMDAwLDQxODcwMDAsNjEyNDAwMCw3ODUyMDAwLDYxNjAwMCw3NTQ3MDAwLDEyNzUwMDAsNjU0NjAwMCwxMzc0MDAwLDc4NTIwMDAsODg0MDAwLDIwODAwMCw3MTE1MDAwLDkwNDAwMCwzNTExMDAwLDY0OTYwMDAsNjk0ODAwMCwxNjExMDAwLDcyODgwMDAsNzg1MjAwMCwyNTAwMCw2NTE1MDAwLDcxNjAwMDAsMTA1MzAwMCw2NzQwMDAwLDc4NTIwMDAsNTE2MDAwLDYxMDgwMDAsNTIxMjAwMCw3ODUyMDAwLDEzMzcwMDAsMzcxMzAwMCwyMzIxMDAwLDY5NjUwMDAsMTA3OTAwMCw3Njg3MDAwLDc4MDUwMDAsNzYzMTAwMCwzMzQwMDAsNzI3ODAwMCwyNjM1MDAwLDQzOTcwMDAsNjA3MTAwMCwxODMwMDAsNzYyNTAwMCwzODQwMDAsNjQ3NjAwMCw0ODAwMCw1OTIwMDAsMTQyMjAwMCw3NTc0MDAwLDc3NzIwMDAsMzM4MDAwLDczMDcwMDAsMzc0NDAwMCw2Njk4MDAwLDE1NjAwMCw3MTY0MDAwLDM1NjgwMDAsNjg4MDAwLDY0OTEwMDAsNzg1MjAwMCw1MzQzMDAwLDcxMjAwMDAsOTI4MDAwLDc4NTIwMDAsMjE3NzAwMCw2Njg1MDAwLDczMzMwMDBdLCJvcHMiOjQzMDEyNjB9XSwidXBkYXRlZCI6IjIwMjItMDMtMjNUMDU6MDQ6MDYuMjgxWiJ9)