### PR TITLE
chore: cancel deprecation of FsWatcher.return

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2209,9 +2209,11 @@ declare namespace Deno {
     /** Stops watching the file system and closes the watcher resource. */
     close(): void;
     /**
-     * Stops watching the file system and closes the watcher resource.
+     * This method is automatically called when you break from the for-await
+     * loop on the watcher, and that stops watching the file system.
      *
-     * @deprecated Will be removed at 2.0.
+     * This method shouldn't be called explicitly from the user's code. You
+     * should use `.close()` method instead for stopping the watcher.
      */
     return?(value?: any): Promise<IteratorResult<FsEvent>>;
     [Symbol.asyncIterator](): AsyncIterableIterator<FsEvent>;

--- a/cli/tests/unit/fs_events_test.ts
+++ b/cli/tests/unit/fs_events_test.ts
@@ -69,8 +69,6 @@ Deno.test(
   },
 );
 
-// TODO(kt3k): This test is for the backward compatibility of `.return` method.
-// This should be removed at 2.0
 Deno.test(
   { permissions: { read: true, write: true } },
   async function watchFsReturn() {

--- a/runtime/js/40_fs_events.js
+++ b/runtime/js/40_fs_events.js
@@ -40,8 +40,6 @@
       }
     }
 
-    // TODO(kt3k): This is deprecated. Will be removed in v2.0.
-    // See https://github.com/denoland/deno/issues/10577 for details
     return(value) {
       core.close(this.rid);
       return PromiseResolve({ value, done: true });


### PR DESCRIPTION
This PR cancels the deprecation of `FsWatcher.prototype.return` method as suggested in #14086

closes #14086
