### PR TITLE
refactor(flags): rename CheckFlag to TypecheckMode

### DIFF
--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -339,7 +339,7 @@ pub fn is_emittable(
 pub struct CheckOptions {
   /// The check flag from the option which can effect the filtering of
   /// diagnostics in the emit result.
-  pub check: flags::CheckFlag,
+  pub typecheck_mode: flags::TypecheckMode,
   /// Set the debug flag on the TypeScript type checker.
   pub debug: bool,
   /// If true, any files emitted will be cached, even if there are diagnostics
@@ -430,7 +430,7 @@ pub fn check_and_maybe_emit(
     root_names,
   })?;
 
-  let diagnostics = if options.check == flags::CheckFlag::Local {
+  let diagnostics = if options.typecheck_mode == flags::TypecheckMode::Local {
     response.diagnostics.filter(|d| {
       if let Some(file_name) = &d.file_name {
         !file_name.starts_with("http")

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -215,7 +215,7 @@ impl Default for DenoSubcommand {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum CheckFlag {
+pub enum TypecheckMode {
   /// Type check all modules. The default value.
   All,
   /// Skip type checking of all modules. Represents `--no-check` on the command
@@ -226,7 +226,7 @@ pub enum CheckFlag {
   Local,
 }
 
-impl Default for CheckFlag {
+impl Default for TypecheckMode {
   fn default() -> Self {
     Self::All
   }
@@ -254,7 +254,7 @@ pub struct Flags {
   /// the language server is configured with an explicit cache option.
   pub cache_path: Option<PathBuf>,
   pub cached_only: bool,
-  pub check: CheckFlag,
+  pub typecheck_mode: TypecheckMode,
   pub config_path: Option<String>,
   pub coverage_dir: Option<String>,
   pub enable_testing_features: bool,
@@ -2712,14 +2712,14 @@ fn compat_arg_parse(flags: &mut Flags, matches: &ArgMatches) {
 fn no_check_arg_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   if let Some(cache_type) = matches.value_of("no-check") {
     match cache_type {
-      "remote" => flags.check = CheckFlag::Local,
+      "remote" => flags.typecheck_mode = TypecheckMode::Local,
       _ => debug!(
         "invalid value for 'no-check' of '{}' using default",
         cache_type
       ),
     }
   } else if matches.is_present("no-check") {
-    flags.check = CheckFlag::None;
+    flags.typecheck_mode = TypecheckMode::None;
   }
 }
 
@@ -3657,7 +3657,7 @@ mod tests {
         import_map_path: Some("import_map.json".to_string()),
         no_remote: true,
         config_path: Some("tsconfig.json".to_string()),
-        check: CheckFlag::None,
+        typecheck_mode: TypecheckMode::None,
         reload: true,
         lock: Some(PathBuf::from("lock.json")),
         lock_write: true,
@@ -3742,7 +3742,7 @@ mod tests {
         import_map_path: Some("import_map.json".to_string()),
         no_remote: true,
         config_path: Some("tsconfig.json".to_string()),
-        check: CheckFlag::None,
+        typecheck_mode: TypecheckMode::None,
         reload: true,
         lock: Some(PathBuf::from("lock.json")),
         lock_write: true,
@@ -4010,7 +4010,7 @@ mod tests {
           source_file: "script.ts".to_string(),
           out_file: None,
         }),
-        check: CheckFlag::None,
+        typecheck_mode: TypecheckMode::None,
         ..Flags::default()
       }
     );
@@ -4232,7 +4232,7 @@ mod tests {
         import_map_path: Some("import_map.json".to_string()),
         no_remote: true,
         config_path: Some("tsconfig.json".to_string()),
-        check: CheckFlag::None,
+        typecheck_mode: TypecheckMode::None,
         reload: true,
         lock: Some(PathBuf::from("lock.json")),
         lock_write: true,
@@ -4383,7 +4383,7 @@ mod tests {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
         }),
-        check: CheckFlag::None,
+        typecheck_mode: TypecheckMode::None,
         ..Flags::default()
       }
     );
@@ -4399,7 +4399,7 @@ mod tests {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
         }),
-        check: CheckFlag::Local,
+        typecheck_mode: TypecheckMode::Local,
         ..Flags::default()
       }
     );
@@ -5071,7 +5071,7 @@ mod tests {
         import_map_path: Some("import_map.json".to_string()),
         no_remote: true,
         config_path: Some("tsconfig.json".to_string()),
-        check: CheckFlag::None,
+        typecheck_mode: TypecheckMode::None,
         reload: true,
         lock: Some(PathBuf::from("lock.json")),
         lock_write: true,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -43,7 +43,6 @@ use crate::file_watcher::ResolutionResult;
 use crate::flags::BenchFlags;
 use crate::flags::BundleFlags;
 use crate::flags::CacheFlags;
-use crate::flags::CheckFlag;
 use crate::flags::CompileFlags;
 use crate::flags::CompletionsFlags;
 use crate::flags::CoverageFlags;
@@ -59,6 +58,7 @@ use crate::flags::ReplFlags;
 use crate::flags::RunFlags;
 use crate::flags::TaskFlags;
 use crate::flags::TestFlags;
+use crate::flags::TypecheckMode;
 use crate::flags::UninstallFlags;
 use crate::flags::UpgradeFlags;
 use crate::flags::VendorFlags;
@@ -693,10 +693,14 @@ async fn create_graph_and_maybe_check(
     .as_ref()
     .map(|cf| cf.get_check_js())
     .unwrap_or(false);
-  graph_valid(&graph, ps.flags.check != CheckFlag::None, check_js)?;
+  graph_valid(
+    &graph,
+    ps.flags.typecheck_mode != TypecheckMode::None,
+    check_js,
+  )?;
   graph_lock_or_exit(&graph);
 
-  if ps.flags.check != CheckFlag::None {
+  if ps.flags.typecheck_mode != TypecheckMode::None {
     let lib = if ps.flags.unstable {
       emit::TypeLib::UnstableDenoWindow
     } else {
@@ -720,7 +724,7 @@ async fn create_graph_and_maybe_check(
       Arc::new(RwLock::new(graph.as_ref().into())),
       &mut cache,
       emit::CheckOptions {
-        check: ps.flags.check.clone(),
+        typecheck_mode: ps.flags.typecheck_mode.clone(),
         debug,
         emit_with_diagnostics: false,
         maybe_config_specifier,
@@ -751,7 +755,7 @@ fn bundle_module_graph(
     ps.maybe_config_file.as_ref(),
     None,
   )?;
-  if flags.check == CheckFlag::None {
+  if flags.typecheck_mode == TypecheckMode::None {
     if let Some(ignored_options) = maybe_ignored_options {
       eprintln!("{}", ignored_options);
     }
@@ -1020,7 +1024,11 @@ async fn run_with_watch(flags: Flags, script: String) -> Result<i32, AnyError> {
         .as_ref()
         .map(|cf| cf.get_check_js())
         .unwrap_or(false);
-      graph_valid(&graph, ps.flags.check != flags::CheckFlag::None, check_js)?;
+      graph_valid(
+        &graph,
+        ps.flags.typecheck_mode != flags::TypecheckMode::None,
+        check_js,
+      )?;
 
       // Find all local files in graph
       let mut paths_to_watch: Vec<PathBuf> = graph

--- a/cli/ops/runtime_compiler.rs
+++ b/cli/ops/runtime_compiler.rs
@@ -245,7 +245,7 @@ async fn op_emit(
       Arc::new(RwLock::new(graph.as_ref().into())),
       cache.as_mut_cacher(),
       emit::CheckOptions {
-        check: flags::CheckFlag::All,
+        typecheck_mode: flags::TypecheckMode::All,
         debug,
         emit_with_diagnostics: true,
         maybe_config_specifier: None,
@@ -268,7 +268,7 @@ async fn op_emit(
         Arc::new(RwLock::new(graph.as_ref().into())),
         cache.as_mut_cacher(),
         emit::CheckOptions {
-          check: flags::CheckFlag::All,
+          typecheck_mode: flags::TypecheckMode::All,
           debug,
           emit_with_diagnostics: true,
           maybe_config_specifier: None,

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -304,12 +304,12 @@ impl ProcState {
     };
     if !reload_on_watch {
       let graph_data = self.graph_data.read();
-      if self.flags.check == flags::CheckFlag::None
+      if self.flags.typecheck_mode == flags::TypecheckMode::None
         || graph_data.is_type_checked(&roots, &lib)
       {
         if let Some(result) = graph_data.check(
           &roots,
-          self.flags.check != flags::CheckFlag::None,
+          self.flags.typecheck_mode != flags::TypecheckMode::None,
           false,
         ) {
           return result;
@@ -417,11 +417,16 @@ impl ProcState {
         .map(|cf| cf.get_check_js())
         .unwrap_or(false);
       graph_data
-        .check(&roots, self.flags.check != flags::CheckFlag::None, check_js)
+        .check(
+          &roots,
+          self.flags.typecheck_mode != flags::TypecheckMode::None,
+          check_js,
+        )
         .unwrap()?;
     }
 
-    let config_type = if self.flags.check == flags::CheckFlag::None {
+    let config_type = if self.flags.typecheck_mode == flags::TypecheckMode::None
+    {
       emit::ConfigType::Emit
     } else {
       emit::ConfigType::Check {
@@ -437,7 +442,7 @@ impl ProcState {
       log::warn!("{}", ignored_options);
     }
 
-    if self.flags.check == flags::CheckFlag::None {
+    if self.flags.typecheck_mode == flags::TypecheckMode::None {
       let options = emit::EmitOptions {
         ts_config,
         reload: self.flags.reload,
@@ -451,7 +456,7 @@ impl ProcState {
         .as_ref()
         .map(|cf| cf.specifier.clone());
       let options = emit::CheckOptions {
-        check: self.flags.check.clone(),
+        typecheck_mode: self.flags.typecheck_mode.clone(),
         debug: self.flags.log_level == Some(log::Level::Debug),
         emit_with_diagnostics: false,
         maybe_config_specifier,
@@ -472,7 +477,7 @@ impl ProcState {
       log::debug!("{}", emit_result.stats);
     }
 
-    if self.flags.check != flags::CheckFlag::None {
+    if self.flags.typecheck_mode != flags::TypecheckMode::None {
       let mut graph_data = self.graph_data.write();
       graph_data.set_type_checked(&roots, &lib);
     }

--- a/cli/tools/bench.rs
+++ b/cli/tools/bench.rs
@@ -10,8 +10,8 @@ use crate::emit;
 use crate::file_watcher;
 use crate::file_watcher::ResolutionResult;
 use crate::flags::BenchFlags;
-use crate::flags::CheckFlag;
 use crate::flags::Flags;
+use crate::flags::TypecheckMode;
 use crate::fs_util::collect_specifiers;
 use crate::fs_util::is_supported_bench_path;
 use crate::graph_util::contains_specifier;
@@ -517,7 +517,7 @@ pub async fn run_benchmarks_with_watch(
   let include = bench_flags.include.unwrap_or_else(|| vec![".".to_string()]);
   let ignore = bench_flags.ignore.clone();
   let paths_to_watch: Vec<_> = include.iter().map(PathBuf::from).collect();
-  let no_check = ps.flags.check == CheckFlag::None;
+  let no_check = ps.flags.typecheck_mode == TypecheckMode::None;
 
   let resolver = |changed: Option<Vec<PathBuf>>| {
     let mut cache = cache::FetchCacher::new(

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -1,8 +1,8 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-use crate::flags::CheckFlag;
 use crate::flags::Flags;
 use crate::flags::InstallFlags;
+use crate::flags::TypecheckMode;
 use crate::fs_util::canonicalize_path;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
@@ -306,10 +306,12 @@ fn resolve_shim_data(
 
   // we should avoid a default branch here to ensure we continue to cover any
   // changes to this flag.
-  match flags.check {
-    CheckFlag::All => (),
-    CheckFlag::None => executable_args.push("--no-check".to_string()),
-    CheckFlag::Local => executable_args.push("--no-check=remote".to_string()),
+  match flags.typecheck_mode {
+    TypecheckMode::All => (),
+    TypecheckMode::None => executable_args.push("--no-check".to_string()),
+    TypecheckMode::Local => {
+      executable_args.push("--no-check=remote".to_string())
+    }
   }
 
   if flags.unstable {
@@ -584,7 +586,7 @@ mod tests {
       &Flags {
         allow_net: Some(vec![]),
         allow_read: Some(vec![]),
-        check: CheckFlag::None,
+        typecheck_mode: TypecheckMode::None,
         log_level: Some(Level::Error),
         ..Flags::default()
       },

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -1,10 +1,10 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 use crate::deno_dir::DenoDir;
-use crate::flags::CheckFlag;
 use crate::flags::DenoSubcommand;
 use crate::flags::Flags;
 use crate::flags::RunFlags;
+use crate::flags::TypecheckMode;
 use crate::standalone::Metadata;
 use crate::standalone::MAGIC_TRAILER;
 use crate::ProcState;
@@ -286,7 +286,7 @@ pub fn compile_to_runtime_flags(
     lock_write: false,
     lock: None,
     log_level: flags.log_level,
-    check: CheckFlag::All,
+    typecheck_mode: TypecheckMode::All,
     compat: flags.compat,
     unsafely_ignore_certificate_errors: flags
       .unsafely_ignore_certificate_errors

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -10,9 +10,9 @@ use crate::emit;
 use crate::file_fetcher::File;
 use crate::file_watcher;
 use crate::file_watcher::ResolutionResult;
-use crate::flags::CheckFlag;
 use crate::flags::Flags;
 use crate::flags::TestFlags;
+use crate::flags::TypecheckMode;
 use crate::fs_util::collect_specifiers;
 use crate::fs_util::is_supported_test_ext;
 use crate::fs_util::is_supported_test_path;
@@ -1075,7 +1075,7 @@ pub async fn run_tests_with_watch(
   let include = test_flags.include.unwrap_or_else(|| vec![".".to_string()]);
   let ignore = test_flags.ignore.clone();
   let paths_to_watch: Vec<_> = include.iter().map(PathBuf::from).collect();
-  let no_check = ps.flags.check == CheckFlag::None;
+  let no_check = ps.flags.typecheck_mode == TypecheckMode::None;
 
   let resolver = |changed: Option<Vec<PathBuf>>| {
     let mut cache = cache::FetchCacher::new(


### PR DESCRIPTION
Working on https://github.com/denoland/deno/pull/14072 it became confusing to have `CheckFlag` and `CheckFlags`. I believe `TypecheckMode` is a better name than `CheckFlag`. 

Also renamed `Flags.check` to `Flags.typecheck_mode` and `CheckOptions.check` to `CheckOptions.typecheck_mode`.