### PR TITLE
fix: deprecate URL as the first arg of fetch

### DIFF
--- a/ext/fetch/lib.deno_fetch.d.ts
+++ b/ext/fetch/lib.deno_fetch.d.ts
@@ -435,6 +435,16 @@ declare class Response implements Body {
  * ```
  */
 declare function fetch(
-  input: Request | URL | string,
+  input: Request | string,
+  init?: RequestInit,
+): Promise<Response>;
+// TODO(kt3k): Remove the following overloaded declaration for 2.0.
+/** @deprecated URL is deprecated as the first argument. Use string or Request object instead.
+ *
+ * Fetch a resource from the network. It returns a `Promise` that resolves to the
+ * `Response` to that `Request`, whether it is successful or not.
+ */
+declare function fetch(
+  input: URL,
   init?: RequestInit,
 ): Promise<Response>;


### PR DESCRIPTION
Deno's fetch and lib.dom's fetch have slightly different declarations. (Deno's fetch accept URL as the first arg, but lib.dom's fetch doesn't)

We should align Deno's declaration to lib.dom's (spec defines first arg as `typedef (Request or USVString) RequestInfo` [ref](https://fetch.spec.whatwg.org/#requestinfo)) to reduce the confusion.

This PR tries to deprecate Deno-only signature of fetch function.

With this change, fetch with URL call gets strikethrough style in vscode like the below
<img width="473" alt="スクリーンショット 2022-03-25 18 54 20" src="https://user-images.githubusercontent.com/613956/160098440-5fb2b87f-9459-49e4-bde1-4c752560c2fb.png">

