### PR TITLE
chore: update rusqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,9 +2319,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.22.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+checksum = "cb644c388dfaefa18035c12614156d285364769e818893da0dda9030c80ad2ba"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3427,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.25.4"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4b1eaf239b47034fb450ee9cdedd7d0226571689d8823030c4b6c2cb407152"
+checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/ext/webstorage/Cargo.toml
+++ b/ext/webstorage/Cargo.toml
@@ -16,5 +16,5 @@ path = "lib.rs"
 [dependencies]
 deno_core = { version = "0.125.0", path = "../../core" }
 deno_web = { version = "0.74.0", path = "../web" }
-rusqlite = { version = "0.25.3", features = ["unlock_notify", "bundled"] }
+rusqlite = { version = "0.27.0", features = ["unlock_notify", "bundled"] }
 serde = { version = "1.0.129", features = ["derive"] }


### PR DESCRIPTION
This allows users of deno to use a more recent version.
