### PR TITLE
perf: micro-optimize core.encode 

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -866,9 +866,9 @@ fn encode(
   let text_str = text.to_rust_string_lossy(scope);
   let bytes: Box<[u8]> = text_str.into_bytes().into_boxed_slice();
   let len = bytes.len();
-  let bs =
+  let backing_store =
     v8::ArrayBuffer::new_backing_store_from_boxed_slice(bytes).make_shared();
-  let buffer = v8::ArrayBuffer::with_backing_store(scope, &bs);
+  let buffer = v8::ArrayBuffer::with_backing_store(scope, &backing_store);
   let u8array = v8::Uint8Array::new(scope, buffer, 0, len).unwrap();
   rv.set(u8array.into())
 }

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -864,9 +864,12 @@ fn encode(
     }
   };
   let text_str = text.to_rust_string_lossy(scope);
-  let zbuf: ZeroCopyBuf = text_str.into_bytes().into();
-
-  rv.set(to_v8(scope, zbuf).unwrap())
+  let bytes: Box<[u8]> = text_str.into_bytes().into_boxed_slice();
+  let len = bytes.len();
+  let bs = v8::ArrayBuffer::new_backing_store_from_boxed_slice(bytes).make_shared();
+  let buffer = v8::ArrayBuffer::with_backing_store(scope, &bs);
+  let u8array = v8::Uint8Array::new(scope, buffer, 0, len).unwrap();
+  rv.set(u8array.into())
 }
 
 fn decode(

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -866,7 +866,8 @@ fn encode(
   let text_str = text.to_rust_string_lossy(scope);
   let bytes: Box<[u8]> = text_str.into_bytes().into_boxed_slice();
   let len = bytes.len();
-  let bs = v8::ArrayBuffer::new_backing_store_from_boxed_slice(bytes).make_shared();
+  let bs =
+    v8::ArrayBuffer::new_backing_store_from_boxed_slice(bytes).make_shared();
   let buffer = v8::ArrayBuffer::with_backing_store(scope, &bs);
   let u8array = v8::Uint8Array::new(scope, buffer, 0, len).unwrap();
   rv.set(u8array.into())

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -188,7 +188,7 @@ macro_rules! include_js_files {
         Box::new(|| {
           let c = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
           let path = c.join($file);
-          // println!("cargo:rerun-if-changed={}", path.display());
+          println!("cargo:rerun-if-changed={}", path.display());
           let src = std::fs::read_to_string(path)?;
           Ok(src)
         }),

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -188,7 +188,7 @@ macro_rules! include_js_files {
         Box::new(|| {
           let c = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
           let path = c.join($file);
-          println!("cargo:rerun-if-changed={}", path.display());
+          // println!("cargo:rerun-if-changed={}", path.display());
           let src = std::fs::read_to_string(path)?;
           Ok(src)
         }),


### PR DESCRIPTION
`main`:
```
test bench_utf8_decode_12_b  ... bench:         187 ns/iter (+/- 12)
test bench_utf8_decode_12_kb ... bench:       4,589 ns/iter (+/- 676)
test bench_utf8_decode_12_mb ... bench:   1,502,699 ns/iter (+/- 28,120)
test bench_utf8_encode_12_b  ... bench:         450 ns/iter (+/- 42)
test bench_utf8_encode_12_kb ... bench:       5,586 ns/iter (+/- 295)
test bench_utf8_encode_12_mb ... bench:   4,767,425 ns/iter (+/- 9,069)
```

This PR:
```
test bench_utf8_decode_12_b  ... bench:         176 ns/iter (+/- 3)
test bench_utf8_decode_12_kb ... bench:       3,268 ns/iter (+/- 80)
test bench_utf8_decode_12_mb ... bench:   1,441,622 ns/iter (+/- 19,107)
test bench_utf8_encode_12_b  ... bench:         354 ns/iter (+/- 15)
test bench_utf8_encode_12_kb ... bench:       5,401 ns/iter (+/- 109)
test bench_utf8_encode_12_mb ... bench:   4,760,358 ns/iter (+/- 26,787)
```