### PR TITLE
feat(ops): #[op(unstable)]

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -16,6 +16,7 @@ pub struct OpDecl {
   pub v8_fn_ptr: OpFnRef,
   pub enabled: bool,
   pub is_async: bool, // TODO(@AaronO): enum sync/async/fast ?
+  pub is_unstable: bool,
 }
 
 impl OpDecl {

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -45,8 +45,16 @@ impl syn::parse::Parse for MacroArgs {
       syn::punctuated::Punctuated::<Ident, syn::Token![,]>::parse_terminated(
         input,
       )?;
-    let is_unstable = vars.iter().any(|v| v == "unstable");
-    Ok(Self { is_unstable })
+    let vars: Vec<_> = vars.iter().map(Ident::to_string).collect();
+    let vars: Vec<_> = vars.iter().map(String::as_str).collect();
+    match vars[..] {
+      ["unstable"] => Ok(Self { is_unstable: true }),
+      [] => Ok(Self { is_unstable: false }),
+      _ => Err(syn::Error::new(
+        input.span(),
+        "Ops expect #[op] or #[op(unstable)]",
+      )),
+    }
   }
 }
 


### PR DESCRIPTION
`#[op(unstable)]` tags `OpDecl::is_unstable` as `true`, thus allowing op-middleware to then disable said ops

This should make unstable checks less error prone (forgotten or overlooked during review/impl), less verbose and moderately faster (check happens at runtime init vs each call)