### PR TITLE
fix(lib.deno_fetch.d.ts): Extend deprecated fetch() overload

### DIFF
--- a/ext/fetch/lib.deno_fetch.d.ts
+++ b/ext/fetch/lib.deno_fetch.d.ts
@@ -445,6 +445,6 @@ declare function fetch(
  * `Response` to that `Request`, whether it is successful or not.
  */
 declare function fetch(
-  input: URL,
+  input: URL | Request | string,
   init?: RequestInit,
 ): Promise<Response>;


### PR DESCRIPTION
#14113 broke https://deno.land/x/download@v1.0.1/download.ts. The overload accepting `URL` should be all-inclusive or it won't accept an argument of type `string | URL`.

cc @kt3k 