### PR TITLE
fix(lsp): watch .jsonc files

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -762,7 +762,7 @@ impl Inner {
       let watch_registration_options =
         DidChangeWatchedFilesRegistrationOptions {
           watchers: vec![FileSystemWatcher {
-            glob_pattern: "**/*.json".to_string(),
+            glob_pattern: "**/*.jsonc?".to_string(),
             kind: Some(WatchKind::Change),
           }],
         };


### PR DESCRIPTION
We are currently not watching `.jsonc` files in the editor, which means some changes to `deno.jsonc` won't be automatically tracked.