### PR TITLE
fix(task): handle `PATHEXT` with trailing semi-colon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7cfd6605b7291387e54a732e5b5fa8c1fb0d6757dbf4309740ad79c1e1e215"
+checksum = "a207191380d076a31b0bde505cd89ffa0a7336be0a9e17017afa8cf91d35499b"
 dependencies = [
  "anyhow",
  "futures",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,7 @@ deno_doc = "0.33.0"
 deno_graph = "0.25.0"
 deno_lint = { version = "0.28.0", features = ["docs"] }
 deno_runtime = { version = "0.52.0", path = "../runtime" }
-deno_task_shell = "0.2.0"
+deno_task_shell = "0.2.1"
 
 atty = "=0.2.14"
 base64 = "=0.13.0"


### PR DESCRIPTION
ref: https://github.com/denoland/deno_task_shell/pull/28