### PR TITLE
chore: update dprint internally to 0.24.1

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -45,10 +45,10 @@
     "tools/wpt/manifest.json"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.61.0.wasm",
-    "https://plugins.dprint.dev/json-0.14.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.12.1.wasm",
-    "https://plugins.dprint.dev/toml-0.5.3.wasm",
-    "https://plugins.dprint.dev/exec-0.1.1.exe-plugin@42d3e30a14370b1a33dcc82c78528bd08979f2d4275014087d53472d3e229c62"
+    "https://plugins.dprint.dev/typescript-0.65.1.wasm",
+    "https://plugins.dprint.dev/json-0.14.1.wasm",
+    "https://plugins.dprint.dev/markdown-0.12.2.wasm",
+    "https://plugins.dprint.dev/toml-0.5.4.wasm",
+    "https://plugins.dprint.dev/exec-0.2.1.exe-plugin@0a89a91810a212d9413e26d8946d41fbab3e2b5400362d764a1523839c4d78ea"
   ]
 }


### PR DESCRIPTION
I changed the interface between the dprint CLI and process plugins in a breaking way, so this will cause Rust files to be formatted automatically in my editor again with the dprint vscode extension and the latest dprint installed.