### PR TITLE
chore: upgrade dprint-core to 0.54.1

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -45,9 +45,9 @@
     "tools/wpt/manifest.json"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.65.1.wasm",
-    "https://plugins.dprint.dev/json-0.14.1.wasm",
-    "https://plugins.dprint.dev/markdown-0.12.2.wasm",
+    "https://plugins.dprint.dev/typescript-0.66.0.wasm",
+    "https://plugins.dprint.dev/json-0.15.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.13.0.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",
     "https://plugins.dprint.dev/exec-0.2.1.exe-plugin@0a89a91810a212d9413e26d8946d41fbab3e2b5400362d764a1523839c4d78ea"
   ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayvec"
@@ -1264,21 +1264,22 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.50.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a596556533e5739e71dfe105c8b4496c3eccaf5aa96d14b19db2fdf4157085a"
+checksum = "4ac67835685dd407cfb415eec8a114bafa6ab6de9bad29ba93d29f874f40bc1a"
 dependencies = [
  "anyhow",
  "bumpalo",
+ "indexmap",
  "rustc-hash",
  "serde",
 ]
 
 [[package]]
 name = "dprint-plugin-json"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7673b479d64372e60e344722789ed9c61ea1023e9a8a13c7da8e7d63b0f7dc"
+checksum = "1a83f35e23681206c2a69a65946e66e5bb692543c6e0377c32208452a8995fe2"
 dependencies = [
  "anyhow",
  "dprint-core",
@@ -1289,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-markdown"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a8c4e905bf5c95dbcc6eab7d81a1d884f7fbd0e7f2fd99af0154692fabc8a8"
+checksum = "254ee918c51c21fa6ca20fe9556f3177b0b5be141df64952c6e353d17dbb5923"
 dependencies = [
  "anyhow",
  "dprint-core",
@@ -1302,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.65.1"
+version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e482c9fe4929ec672d2bdaf0b6dcfee88684ec23858f0c54f225b565f08882ac"
+checksum = "e464d85d3db3ba0c53b1bf207f13d32aba614ff5c032497f240938738568bc20"
 dependencies = [
  "anyhow",
  "deno_ast",
@@ -3641,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -3659,9 +3660,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,7 +37,7 @@ deno_webgpu = { version = "0.45.0", path = "../ext/webgpu" }
 deno_websocket = { version = "0.49.0", path = "../ext/websocket" }
 deno_webstorage = { version = "0.39.0", path = "../ext/webstorage" }
 regex = "=1.5.5"
-serde = { version = "=1.0.133", features = ["derive"] }
+serde = { version = "=1.0.136", features = ["derive"] }
 zstd = '=0.9.2'
 
 [target.'cfg(windows)'.build-dependencies]
@@ -62,9 +62,9 @@ clap_complete = "=3.1.1"
 clap_complete_fig = "=3.1.4"
 data-url = "=0.1.1"
 dissimilar = "=1.0.2"
-dprint-plugin-json = "=0.14.1"
-dprint-plugin-markdown = "=0.12.2"
-dprint-plugin-typescript = "=0.65.1"
+dprint-plugin-json = "=0.15.0"
+dprint-plugin-markdown = "=0.13.0"
+dprint-plugin-typescript = "=0.66.0"
 encoding_rs = "=0.8.29"
 env_logger = "=0.8.4"
 eszip = "=0.18.0"
@@ -87,7 +87,7 @@ ring = "=0.16.20"
 rustyline = { version = "=9.1.2", default-features = false }
 rustyline-derive = "=0.6.0"
 semver-parser = "=0.10.2"
-serde = { version = "=1.0.133", features = ["derive"] }
+serde = { version = "=1.0.136", features = ["derive"] }
 shell-escape = "=0.1.5"
 sourcemap = "=6.0.1"
 tempfile = "=3.2.0"

--- a/cli/lockfile.rs
+++ b/cli/lockfile.rs
@@ -45,7 +45,10 @@ impl Lockfile {
     let j = json!(&self.map);
     let s = serde_json::to_string_pretty(&j).unwrap();
 
-    let format_s = format_json(&s, &Default::default()).unwrap_or(s);
+    let format_s = format_json(&s, &Default::default())
+      .ok()
+      .flatten()
+      .unwrap_or(s);
     let mut f = std::fs::OpenOptions::new()
       .write(true)
       .create(true)

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1063,11 +1063,13 @@ impl Inner {
       };
 
       match format_result {
-        Ok(new_text) => Some(text::get_edits(
-          document.content().as_str(),
-          &new_text,
-          document.line_index().as_ref(),
-        )),
+        Ok(new_text) => new_text.map(|new_text| {
+          text::get_edits(
+            document.content().as_str(),
+            &new_text,
+            document.line_index().as_ref(),
+          )
+        }),
         Err(err) => {
           // TODO(lucacasonato): handle error properly
           warn!("Format error: {}", err);

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -126,8 +126,10 @@ impl CoverageCollector {
 
       let mut out = BufWriter::new(File::create(filepath)?);
       let coverage = serde_json::to_string(&script_coverage)?;
-      let formated_coverage =
-        format_json(&coverage, &Default::default()).unwrap_or(coverage);
+      let formated_coverage = format_json(&coverage, &Default::default())
+        .ok()
+        .flatten()
+        .unwrap_or(coverage);
 
       out.write_all(formated_coverage.as_bytes())?;
       out.flush()?;

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -369,9 +369,7 @@ async fn get_tls_config(
           ),
         )
         .with_single_cert(certs, PrivateKey(key))
-        .map_err(|e| {
-          anyhow!("Error setting cert: {:?}", e);
-        })
+        .map_err(|e| anyhow!("Error setting cert: {:?}", e))
         .unwrap();
 
       match http_versions {


### PR DESCRIPTION
Upgrades to the new API. This actually has some perf improvements and a bug fix that won't matter to most people.